### PR TITLE
Gang mode rebalance

### DIFF
--- a/code/game/gamemodes/gang/gang_datum.dm
+++ b/code/game/gamemodes/gang/gang_datum.dm
@@ -57,7 +57,6 @@
 		/datum/gang_item/equipment/emp,
 		/datum/gang_item/equipment/c4,
 		/datum/gang_item/equipment/frag,
-		/datum/gang_item/equipment/stimpack,
 		/datum/gang_item/equipment/implant_breaker,
 		/datum/gang_item/equipment/wetwork_boots,
 		/datum/gang_item/equipment/pen,
@@ -94,7 +93,6 @@
 		/datum/gang_item/equipment/emp,
 		/datum/gang_item/equipment/c4,
 		/datum/gang_item/equipment/frag,
-		/datum/gang_item/equipment/stimpack,
 		/datum/gang_item/equipment/implant_breaker,
 		/datum/gang_item/equipment/wetwork_boots,
 	)

--- a/code/game/gamemodes/gang/gang_items.dm
+++ b/code/game/gamemodes/gang/gang_items.dm
@@ -325,12 +325,6 @@
 	cost = 10
 	item_path = /obj/item/weapon/grenade/syndieminibomb/concussion/frag
 
-/datum/gang_item/equipment/stimpack
-	name = "Black Market Stimulants"
-	id = "stimpack"
-	cost = 12
-	item_path = /obj/item/weapon/reagent_containers/syringe/stimulants
-
 /datum/gang_item/equipment/implant_breaker
 	name = "Implant Breaker"
 	id = "implant_breaker"

--- a/code/game/gamemodes/gang/gang_items.dm
+++ b/code/game/gamemodes/gang/gang_items.dm
@@ -213,7 +213,7 @@
 /datum/gang_item/weapon/surplus
 	name = "Surplus Rifle"
 	id = "surplus"
-	cost = 8
+	cost = 5
 	item_path = /obj/item/weapon/gun/ballistic/automatic/surplus
 
 /datum/gang_item/weapon/ammo/surplus_ammo
@@ -230,7 +230,7 @@
 
 /datum/gang_item/weapon/ammo/improvised_ammo
 	name = "Box of Improvised Buckshots"
-	id = "improved"
+	id = "improvised_ammo"
 	cost = 5
 	item_path = /obj/item/weapon/storage/box/improvisedshot
 

--- a/code/game/gamemodes/gang/gang_items.dm
+++ b/code/game/gamemodes/gang/gang_items.dm
@@ -225,14 +225,14 @@
 /datum/gang_item/weapon/improvised
 	name = "Sawn-Off Improvised Shotgun"
 	id = "sawn"
-	cost = 6
+	cost = 10
 	item_path = /obj/item/weapon/gun/ballistic/revolver/doublebarrel/improvised/sawn
 
 /datum/gang_item/weapon/ammo/improvised_ammo
-	name = "Box of Buckshot"
-	id = "buckshot"
+	name = "Box of Improvised Buckshots"
+	id = "improved"
 	cost = 5
-	item_path = /obj/item/weapon/storage/box/lethalshot
+	item_path = /obj/item/weapon/storage/box/improvisedshot
 
 /datum/gang_item/weapon/pistol
 	name = "10mm Pistol"

--- a/code/game/gamemodes/gang/gang_items.dm
+++ b/code/game/gamemodes/gang/gang_items.dm
@@ -310,7 +310,7 @@
 /datum/gang_item/equipment/emp
 	name = "EMP Grenade"
 	id = "EMP"
-	cost = 5
+	cost = 20
 	item_path = /obj/item/weapon/grenade/empgrenade
 
 /datum/gang_item/equipment/c4
@@ -322,7 +322,7 @@
 /datum/gang_item/equipment/frag
 	name = "Fragmentation Grenade"
 	id = "frag nade"
-	cost = 18
+	cost = 10
 	item_path = /obj/item/weapon/grenade/syndieminibomb/concussion/frag
 
 /datum/gang_item/equipment/stimpack

--- a/code/game/objects/items/weapons/storage/boxes.dm
+++ b/code/game/objects/items/weapons/storage/boxes.dm
@@ -648,7 +648,7 @@
 	
 /obj/item/weapon/storage/box/improvisedhsot/PopulateContents()
 	for(var/i in 1 to 6)
-		new /obj/item/ammo_casing/shotgun/improvised
+		new /obj/item/ammo_casing/shotgun/improvised(src)
 
 /obj/item/weapon/storage/box/actionfigure
 	name = "box of action figures"

--- a/code/game/objects/items/weapons/storage/boxes.dm
+++ b/code/game/objects/items/weapons/storage/boxes.dm
@@ -635,10 +635,20 @@
 	desc = "A box full of beanbag shells."
 	icon_state = "rubbershot_box"
 	illustration = null
-
+	
 /obj/item/weapon/storage/box/beanbag/PopulateContents()
 	for(var/i in 1 to 6)
 		new /obj/item/ammo_casing/shotgun/beanbag(src)
+	
+/obj/item/weapon/storage/box/improvisedshot
+	name = "box of improvised shots"
+	desc = "A box full of improvised shells"
+	icon_state = "lethalshot_box"
+	illustration = null
+	
+/obj/item/weapon/storage/box/improvisedhsot/PopuateContents()
+	for(var/i in 1 to 6)
+		new /obj/item/ammo_casing/shotgun/improvised
 
 /obj/item/weapon/storage/box/actionfigure
 	name = "box of action figures"

--- a/code/game/objects/items/weapons/storage/boxes.dm
+++ b/code/game/objects/items/weapons/storage/boxes.dm
@@ -642,7 +642,7 @@
 	
 /obj/item/weapon/storage/box/improvisedshot
 	name = "box of improvised shots"
-	desc = "A box full of improvised shells"
+	desc = "A box full of low tier shots"
 	icon_state = "lethalshot_box"
 	illustration = null
 	

--- a/code/game/objects/items/weapons/storage/boxes.dm
+++ b/code/game/objects/items/weapons/storage/boxes.dm
@@ -646,7 +646,7 @@
 	icon_state = "lethalshot_box"
 	illustration = null
 	
-/obj/item/weapon/storage/box/improvisedhsot/PopuateContents()
+/obj/item/weapon/storage/box/improvisedhsot/PopulateContents()
 	for(var/i in 1 to 6)
 		new /obj/item/ammo_casing/shotgun/improvised
 

--- a/code/game/objects/structures/manned_turret.dm
+++ b/code/game/objects/structures/manned_turret.dm
@@ -12,7 +12,7 @@
 	layer = ABOVE_MOB_LAYER
 	var/view_range = 10
 	var/cooldown = 0
-	var/projectile_type = /obj/item/projectile/bullet/Sweakbullet
+	var/projectile_type = /obj/item/projectile/bullet/weakbullet4
 	var/rate_of_fire = 1
 	var/number_of_shots = 40
 	var/cooldown_duration = 90

--- a/code/game/objects/structures/manned_turret.dm
+++ b/code/game/objects/structures/manned_turret.dm
@@ -12,7 +12,7 @@
 	layer = ABOVE_MOB_LAYER
 	var/view_range = 10
 	var/cooldown = 0
-	var/projectile_type = /obj/item/projectile/bullet/weakbullet3
+	var/projectile_type = /obj/item/projectile/bullet/Sweakbullet
 	var/rate_of_fire = 1
 	var/number_of_shots = 40
 	var/cooldown_duration = 90

--- a/code/modules/projectiles/projectile/bullets.dm
+++ b/code/modules/projectiles/projectile/bullets.dm
@@ -16,6 +16,9 @@
 	damage = 15
 	knockdown = 30
 	stamina = 50
+	
+/obj/item/projectile/bullet/Sweakbullet
+	damage = 10
 
 /obj/item/projectile/bullet/weakbullet3
 	damage = 20

--- a/code/modules/projectiles/projectile/bullets.dm
+++ b/code/modules/projectiles/projectile/bullets.dm
@@ -16,12 +16,12 @@
 	damage = 15
 	knockdown = 30
 	stamina = 50
-	
-/obj/item/projectile/bullet/Sweakbullet
-	damage = 10
 
 /obj/item/projectile/bullet/weakbullet3
 	damage = 20
+	
+/obj/item/projectile/bullet/weakbullet4
+	damage = 10
 
 /obj/item/projectile/bullet/toxinbullet
 	damage = 15


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/14280283/29250437-bdc9f568-8042-11e7-9f99-6d6bfbbfc968.png)

Stimulants are removed, to give a security a better time handling gangs.
Manned machine turrets has been nerfed by 10 damage resulting in 10 brute each shot((they release 40 shots a stream)
Box of buckshots have been removed and replaced with improvised shots ((ghetto rubber shots))
Emps price are increased as 3 can easily take out a dominator
Frag grenades are lowered by 8 


:cl: Improvedname
balance: Balances a few things around gangmode
/:cl:

[why]: # (Please add a short description [on the next line] of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding:) better then what oldman had,
