### PR TITLE
Adds ore box and shuttle console to aux bases on all maps ATTEMPT DEUX

### DIFF
--- a/_maps/map_files/BoxStation/BoxStation.dmm
+++ b/_maps/map_files/BoxStation/BoxStation.dmm
@@ -13354,6 +13354,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 10
 	},
+/obj/structure/ore_box,
 /turf/open/floor/plating,
 /area/shuttle/auxillary_base)
 "aEq" = (
@@ -63962,6 +63963,12 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/central/secondary)
+"cTE" = (
+/obj/machinery/computer/shuttle/mining,
+/turf/open/floor/plasteel/yellow/side{
+	dir = 4
+	},
+/area/construction/mining/aux_base)
 
 (1,1,1) = {"
 aaa
@@ -75366,8 +75373,8 @@ aaa
 apJ
 apJ
 apJ
-apJ
 ajZ
+asF
 atp
 asF
 asF
@@ -75622,9 +75629,9 @@ aaa
 aaa
 aaa
 aaf
-aaf
 apJ
 asH
+atI
 atI
 arE
 ayq
@@ -75879,9 +75886,9 @@ aaa
 aaa
 aaa
 aaa
-aaa
 asF
 asI
+auQ
 auQ
 auQ
 auQ
@@ -76136,9 +76143,9 @@ aaa
 aaa
 aaa
 aaa
-aaa
 apJ
 asJ
+cTE
 avQ
 axc
 aCT
@@ -76393,7 +76400,7 @@ aaa
 aaa
 aaa
 aaa
-aaa
+apJ
 apJ
 apJ
 apJ

--- a/_maps/map_files/Cerestation/cerestation.dmm
+++ b/_maps/map_files/Cerestation/cerestation.dmm
@@ -59321,6 +59321,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 10
 	},
+/obj/structure/ore_box,
 /turf/open/floor/plating{
 	baseturf = /turf/open/floor/plating/asteroid/airless
 	},
@@ -60169,7 +60170,6 @@
 	c_tag = "Aux Base Construction";
 	dir = 6
 	},
-/obj/machinery/computer/camera_advanced/base_construction,
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
@@ -60188,6 +60188,7 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
+/obj/machinery/computer/camera_advanced/base_construction,
 /turf/open/floor/plasteel{
 	baseturf = /turf/open/floor/plating/asteroid/airless
 	},
@@ -95762,6 +95763,20 @@
 	baseturf = /turf/open/floor/plating/asteroid/airless
 	},
 /area/medical/virology)
+"dCX" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/computer/shuttle/mining,
+/turf/open/floor/plasteel{
+	baseturf = /turf/open/floor/plating/asteroid/airless
+	},
+/area/construction/mining/aux_base)
 
 (1,1,1) = {"
 aaa
@@ -114973,7 +114988,7 @@ ceA
 ceA
 ciA
 cjg
-cjX
+dCX
 ckF
 clj
 cdI

--- a/_maps/map_files/Deltastation/DeltaStation2.dmm
+++ b/_maps/map_files/Deltastation/DeltaStation2.dmm
@@ -1244,12 +1244,19 @@
 	},
 /area/construction/mining/aux_base)
 "acy" = (
+/obj/structure/table/reinforced,
+/obj/item/stack/packageWrap,
+/obj/item/stack/cable_coil/white{
+	pixel_x = 3;
+	pixel_y = 3
+	},
+/obj/item/stack/cable_coil/white,
+/obj/item/weapon/stock_parts/cell/high,
 /obj/effect/decal/cleanable/dirt,
 /obj/item/device/radio/intercom{
 	name = "Station Intercom";
 	pixel_y = 26
 	},
-/obj/item/weapon/twohanded/required/kirbyplants/random,
 /turf/open/floor/plasteel/yellow/side{
 	dir = 5
 	},
@@ -113524,6 +113531,26 @@
 	dir = 4
 	},
 /area/construction/mining/aux_base)
+"esw" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 9
+	},
+/obj/machinery/portable_atmospherics/canister/air,
+/turf/open/floor/plating,
+/area/shuttle/auxillary_base)
+"esx" = (
+/obj/machinery/computer/shuttle/mining,
+/turf/open/floor/plasteel/yellow/side{
+	dir = 4
+	},
+/area/construction/mining/aux_base)
+"esy" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 10
+	},
+/obj/structure/ore_box,
+/turf/open/floor/plating,
+/area/shuttle/auxillary_base)
 
 (1,1,1) = {"
 aaa
@@ -155980,11 +156007,11 @@ epT
 acf
 aaG
 acy
-acO
 adf
 adl
+esx
 abK
-adS
+abK
 aeg
 aep
 aeC
@@ -156493,7 +156520,7 @@ abM
 abf
 aaf
 aaG
-acz
+esw
 acP
 acP
 acP
@@ -156501,7 +156528,7 @@ edj
 acP
 acP
 acP
-aeq
+esy
 aaG
 afc
 afr

--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -15276,6 +15276,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 9
 	},
+/obj/structure/ore_box,
 /turf/open/floor/plating,
 /area/shuttle/auxillary_base)
 "aDb" = (
@@ -22695,10 +22696,10 @@
 /turf/open/floor/mineral/titanium/blue,
 /area/shuttle/pod_1)
 "aRD" = (
-/obj/structure/closet/toolcloset,
 /obj/machinery/light{
 	dir = 8
 	},
+/obj/machinery/computer/camera_advanced/base_construction,
 /turf/open/floor/plasteel/yellow/side{
 	dir = 9
 	},
@@ -22709,10 +22710,20 @@
 	},
 /area/construction/mining/aux_base)
 "aRF" = (
+/obj/structure/table,
+/obj/item/stack/sheet/metal{
+	amount = 50
+	},
+/obj/item/stack/sheet/metal{
+	amount = 50
+	},
+/obj/item/stack/sheet/glass{
+	amount = 50
+	},
+/obj/item/weapon/pipe_dispenser,
 /obj/machinery/light{
 	dir = 4
 	},
-/obj/machinery/computer/camera_advanced/base_construction,
 /turf/open/floor/plasteel/yellow/side{
 	dir = 5
 	},
@@ -23234,7 +23245,7 @@
 /turf/open/floor/plating,
 /area/hallway/secondary/entry)
 "aSJ" = (
-/obj/structure/closet/toolcloset,
+/obj/machinery/computer/shuttle/mining,
 /turf/open/floor/plasteel/yellow/side{
 	dir = 10
 	},
@@ -23243,20 +23254,6 @@
 /turf/open/floor/plasteel/yellow/side,
 /area/construction/mining/aux_base)
 "aSL" = (
-/obj/structure/rack{
-	dir = 4
-	},
-/obj/item/weapon/electronics/airlock,
-/obj/item/weapon/electronics/airlock,
-/obj/item/weapon/electronics/airlock,
-/obj/item/weapon/electronics/airlock,
-/obj/item/stack/cable_coil,
-/obj/item/stack/cable_coil,
-/obj/item/wallframe/camera,
-/obj/item/wallframe/camera,
-/obj/item/wallframe/camera,
-/obj/item/wallframe/camera,
-/obj/item/device/assault_pod/mining,
 /obj/structure/cable/yellow{
 	d2 = 8;
 	icon_state = "0-8"
@@ -23270,17 +23267,6 @@
 /turf/open/floor/plasteel/yellow/side,
 /area/construction/mining/aux_base)
 "aSM" = (
-/obj/structure/table,
-/obj/item/stack/sheet/metal{
-	amount = 50
-	},
-/obj/item/stack/sheet/metal{
-	amount = 50
-	},
-/obj/item/stack/sheet/glass{
-	amount = 50
-	},
-/obj/item/weapon/pipe_dispenser,
 /obj/machinery/airalarm{
 	dir = 1;
 	pixel_y = -22
@@ -81221,7 +81207,7 @@
 /turf/open/floor/mineral/titanium,
 /area/shuttle/abandoned)
 "cYE" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on,
+/obj/structure/closet/toolcloset,
 /turf/open/floor/plasteel/yellow/side{
 	dir = 1
 	},
@@ -81271,7 +81257,6 @@
 /turf/open/floor/mineral/titanium/blue,
 /area/shuttle/escape)
 "cYK" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/structure/cable/yellow{
 	icon_state = "4-8";
 	d1 = 4;
@@ -81284,7 +81269,7 @@
 	network = list("AuxBase");
 	pixel_y = -28
 	},
-/obj/structure/reagent_dispensers/fueltank,
+/obj/machinery/atmospherics/components/unary/vent_pump/on,
 /turf/open/floor/plasteel/yellow/side,
 /area/construction/mining/aux_base)
 "cYL" = (
@@ -90843,6 +90828,31 @@
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/plasteel/white,
 /area/science/xenobiology)
+"dDJ" = (
+/obj/structure/reagent_dispensers/fueltank,
+/turf/open/floor/plasteel/yellow/side{
+	dir = 1
+	},
+/area/construction/mining/aux_base)
+"dDK" = (
+/obj/structure/rack{
+	dir = 4
+	},
+/obj/item/weapon/electronics/airlock,
+/obj/item/weapon/electronics/airlock,
+/obj/item/weapon/electronics/airlock,
+/obj/item/weapon/electronics/airlock,
+/obj/item/stack/cable_coil,
+/obj/item/stack/cable_coil,
+/obj/item/wallframe/camera,
+/obj/item/wallframe/camera,
+/obj/item/wallframe/camera,
+/obj/item/wallframe/camera,
+/obj/item/device/assault_pod/mining,
+/turf/open/floor/plasteel/yellow/side{
+	dir = 1
+	},
+/area/construction/mining/aux_base)
 
 (1,1,1) = {"
 aaa
@@ -103287,7 +103297,7 @@ cVL
 cVL
 cWJ
 cWK
-aRE
+dDJ
 aSL
 aDb
 cZq
@@ -103544,7 +103554,7 @@ cVL
 cVL
 cWJ
 cWK
-aRE
+dDK
 aSM
 aDb
 cZq

--- a/_maps/map_files/PubbyStation/PubbyStation.dmm
+++ b/_maps/map_files/PubbyStation/PubbyStation.dmm
@@ -47009,7 +47009,7 @@
 	pixel_x = 0;
 	pixel_y = -28
 	},
-/obj/structure/chair/stool,
+/obj/machinery/computer/shuttle/mining,
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
 "bXV" = (
@@ -58278,6 +58278,10 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/security/brig)
+"cBj" = (
+/obj/structure/ore_box,
+/turf/open/floor/plating,
+/area/maintenance/department/engine)
 
 (1,1,1) = {"
 aaa
@@ -82599,7 +82603,7 @@ bUa
 bva
 bVv
 bSw
-bDi
+bPC
 bXU
 bva
 bZt
@@ -84142,7 +84146,7 @@ bva
 bva
 bva
 bDi
-bDi
+cBj
 bva
 bZv
 cad


### PR DESCRIPTION
Let's try that again.

And this time the shuttle console is outside the aux base, so people can actually call it from the station.

:cl: WJohnston
add: Adds an ore box and shuttle console to aux bases on all stations.
/:cl:
