### PR TITLE
The agent card now has 15 throw force

### DIFF
--- a/code/game/objects/items/weapons/cards_ids.dm
+++ b/code/game/objects/items/weapons/cards_ids.dm
@@ -158,6 +158,7 @@ update_label("John Doe", "Clowny")
 	access = list(ACCESS_MAINT_TUNNELS, ACCESS_SYNDICATE)
 	origin_tech = "syndicate=1"
 	var/anyone = FALSE //Can anyone forge the ID or just syndicate?
+	throwforce = 15 //emergency weapon
 
 /obj/item/weapon/card/id/syndicate/Initialize()
 	..()


### PR DESCRIPTION
The syndicate has added a razor tipped edge to the agent card, as a
weapon of last resort


:cl: oranges
tweak: The syndicate has added a razor edge to the agent card for last resort situations
/:cl:

Why:
rule of cool, it would be cool to see someone whip out their agent card and finish someone off with it

gives the agent card a little more versatility, and makes it a stronger pick
