### PR TITLE
Fixes the wiki button

### DIFF
--- a/interface/interface.dm
+++ b/interface/interface.dm
@@ -1,7 +1,7 @@
 //Please use mob or src (not usr) in these procs. This way they can be called in the same fashion as procs.
-/client/verb/wiki(query as text | null)
+/client/verb/wiki(query as text)
 	set name = "wiki"
-	set desc = "Type what you want to know about.  This will open the wiki on your web browser. Type nothing to go to the main page."
+	set desc = "Type what you want to know about.  This will open the wiki in your web browser. Type nothing to go to the main page."
 	set hidden = 1
 	if(config.wikiurl)
 		if(query)


### PR DESCRIPTION
This PR fixes the wiki button, which previously did nothing when pressed.

I also fixed a typo.

:cl: NewSta
fix: Fixes the wiki button
spellcheck: Fixes a typo in the wiki button description
/:cl: