### PR TITLE
Knockout now regens stamina, increases stamina stun

### DIFF
--- a/code/datums/status_effects/debuffs.dm
+++ b/code/datums/status_effects/debuffs.dm
@@ -31,7 +31,7 @@
 
 /datum/status_effect/incapacitating/knockdown/tick()
 	if(owner.staminaloss)
-		owner.adjustStaminaLoss(-0.5)
+		owner.adjustStaminaLoss(-0.5) //reduce stamina loss by 0.5 per tick, 10 per 2 seconds
 
 //UNCONSCIOUS
 /datum/status_effect/incapacitating/unconscious
@@ -40,7 +40,7 @@
 
 /datum/status_effect/incapacitating/unconscious/tick()
 	if(owner.staminaloss)
-		owner.adjustStaminaLoss(-0.5)
+		owner.adjustStaminaLoss(-0.5) //reduce stamina loss by 0.5 per tick, 10 per 2 seconds
 
 //SLEEPING
 /datum/status_effect/incapacitating/sleeping
@@ -65,7 +65,7 @@
 
 /datum/status_effect/incapacitating/sleeping/tick()
 	if(owner.staminaloss)
-		owner.adjustStaminaLoss(-0.5)
+		owner.adjustStaminaLoss(-0.5) //reduce stamina loss by 0.5 per tick, 10 per 2 seconds
 	if(human_owner && human_owner.drunkenness)
 		human_owner.drunkenness *= 0.997 //reduce drunkenness by 0.3% per tick, 6% per 2 seconds
 	if(prob(20))

--- a/code/datums/status_effects/debuffs.dm
+++ b/code/datums/status_effects/debuffs.dm
@@ -29,10 +29,18 @@
 /datum/status_effect/incapacitating/knockdown
 	id = "knockdown"
 
+/datum/status_effect/incapacitating/knockdown/tick()
+	if(owner.staminaloss)
+		owner.adjustStaminaLoss(-0.5)
+
 //UNCONSCIOUS
 /datum/status_effect/incapacitating/unconscious
 	id = "unconscious"
 	needs_update_stat = TRUE
+
+/datum/status_effect/incapacitating/unconscious/tick()
+	if(owner.staminaloss)
+		owner.adjustStaminaLoss(-0.5)
 
 //SLEEPING
 /datum/status_effect/incapacitating/sleeping
@@ -57,7 +65,7 @@
 
 /datum/status_effect/incapacitating/sleeping/tick()
 	if(owner.staminaloss)
-		owner.adjustStaminaLoss(-0.35) //reduce stamina loss by 0.35 per tick, 7 per 2 seconds
+		owner.adjustStaminaLoss(-0.5) //reduce stamina loss by 0.35 per tick, 7 per 2 seconds
 	if(human_owner && human_owner.drunkenness)
 		human_owner.drunkenness *= 0.997 //reduce drunkenness by 0.3% per tick, 6% per 2 seconds
 	if(prob(20))

--- a/code/datums/status_effects/debuffs.dm
+++ b/code/datums/status_effects/debuffs.dm
@@ -65,7 +65,7 @@
 
 /datum/status_effect/incapacitating/sleeping/tick()
 	if(owner.staminaloss)
-		owner.adjustStaminaLoss(-0.5) //reduce stamina loss by 0.35 per tick, 7 per 2 seconds
+		owner.adjustStaminaLoss(-0.5)
 	if(human_owner && human_owner.drunkenness)
 		human_owner.drunkenness *= 0.997 //reduce drunkenness by 0.3% per tick, 6% per 2 seconds
 	if(prob(20))

--- a/code/modules/mob/living/carbon/life.dm
+++ b/code/modules/mob/living/carbon/life.dm
@@ -314,7 +314,10 @@
 /mob/living/carbon/handle_status_effects()
 	..()
 	if(staminaloss)
-		adjustStaminaLoss(-3)
+		if(IsKnockdown() || IsUnconscious())
+			adjustStaminaLoss(-8)
+		else
+			adjustStaminaLoss(-3)
 
 	var/restingpwr = 1 + 4 * resting
 

--- a/code/modules/mob/living/carbon/life.dm
+++ b/code/modules/mob/living/carbon/life.dm
@@ -314,10 +314,7 @@
 /mob/living/carbon/handle_status_effects()
 	..()
 	if(staminaloss)
-		if(IsKnockdown() || IsUnconscious())
-			adjustStaminaLoss(-8)
-		else
-			adjustStaminaLoss(-3)
+		adjustStaminaLoss(-3)
 
 	var/restingpwr = 1 + 4 * resting
 

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -804,7 +804,7 @@
 		var/total_health = (health - staminaloss)
 		if(total_health <= HEALTH_THRESHOLD_CRIT && !stat)
 			to_chat(src, "<span class='notice'>You're too exhausted to keep going...</span>")
-			Knockdown(160)
+			Knockdown(140)
 			setStaminaLoss(health - 2)
 	update_health_hud()
 

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -804,7 +804,7 @@
 		var/total_health = (health - staminaloss)
 		if(total_health <= HEALTH_THRESHOLD_CRIT && !stat)
 			to_chat(src, "<span class='notice'>You're too exhausted to keep going...</span>")
-			Knockdown(100)
+			Knockdown(160)
 			setStaminaLoss(health - 2)
 	update_health_hud()
 


### PR DESCRIPTION
One of the most annoying things about our stamina system is that even after you get up you still have shitloads of stamina damage and move at a snails pace. This PR makes it so you regenerate 5 extra stamina damage per second while being knocked down or unconscious. 

Because having 100 stamina should mean you have lost a fight the stun from getting 100 is increased to 8 seconds. If the knockdown lasts the full 8 seconds then you get up with only 32 stamina damage left (83 before this change)

 I think this makes stamina a much more workable damage system.



:cl:
balance: Being knocked out now regenerates your stamina, the stun from having too much stamina damage is increased.
/:cl:

