### PR TITLE
Removes replica pods from the seed vendor

### DIFF
--- a/code/game/machinery/vending.dm
+++ b/code/game/machinery/vending.dm
@@ -947,7 +947,7 @@ IF YOU MODIFY THE PRODUCTS LIST OF A MACHINE, MAKE SURE TO UPDATE ITS RESUPPLY C
 						/obj/item/seeds/chili = 3, /obj/item/seeds/cocoapod = 3, /obj/item/seeds/coffee = 3, /obj/item/seeds/corn = 3,
 						/obj/item/seeds/eggplant = 3, /obj/item/seeds/grape = 3, /obj/item/seeds/grass = 3, /obj/item/seeds/lemon = 3,
 						/obj/item/seeds/lime = 3, /obj/item/seeds/onion = 3, /obj/item/seeds/orange = 3, /obj/item/seeds/potato = 3, /obj/item/seeds/poppy = 3,
-						/obj/item/seeds/pumpkin = 3, /obj/item/seeds/replicapod = 3, /obj/item/seeds/wheat/rice = 3, /obj/item/seeds/soya = 3, /obj/item/seeds/sunflower = 3,
+						/obj/item/seeds/pumpkin = 3, /obj/item/seeds/wheat/rice = 3, /obj/item/seeds/soya = 3, /obj/item/seeds/sunflower = 3,
 						/obj/item/seeds/tea = 3, /obj/item/seeds/tobacco = 3, /obj/item/seeds/tomato = 3,
 						/obj/item/seeds/tower = 3, /obj/item/seeds/watermelon = 3, /obj/item/seeds/wheat = 3, /obj/item/seeds/whitebeet = 3)
 	contraband = list(/obj/item/seeds/amanita = 2, /obj/item/seeds/glowshroom = 2, /obj/item/seeds/liberty = 2, /obj/item/seeds/nettle = 2,


### PR DESCRIPTION
:cl: Wrathful Moonman
del: Replica pods have been removed from the seed vendor, if you want them, get busy mutating or order a crate at cargo!
/:cl:

This is a firm and fair nerf to podpeople and station botany that punishes a easy revive, circumnavigating around the penalties of cloning to be inserted into a generally preferable non-human body. Due to the fiddly nature of replica pods it may take some stat mutation engineering in order to receive double the amount of seeds with a high harvest in order to actively spread your plant without mutating more cabbages.

- I respect that replica pods can still arrive via cargo and i don't much care about it since you get what you pay for in my eyes, but from the vendor at roundstart and such behaviors as killing yourself immediately to become a pod-person grows (_no pun intended_) to become unacceptable.