### PR TITLE
Gives them syndie boys some new toys #freezeisover

### DIFF
--- a/code/game/objects/items/weapons/implants/implantchair.dm
+++ b/code/game/objects/items/weapons/implants/implantchair.dm
@@ -187,3 +187,38 @@
 	log_game("[key_name_admin(user)] brainwashed [key_name_admin(C)] with objective '[objective]'.")
 	return 1
 
+/obj/machinery/implantchair/augment
+	name = "Augmentation Pod"
+	desc = "A disturbing piece of mad science, developed by Cyber-Hive GmbH. A subject placed inside will have their limbs replaced by experimental combat augmentations and their id, ego and superego entirely subsumed into an uncaring, unfeeling automaton. Luckily for you, the thing that moves in their place is a terrifying engine of destruction."
+	special = TRUE
+	special_name = "Augment"
+	auto_replenish = FALSE
+	max_implants = 1
+	ready_implants = 1
+
+/obj/machinery/implantchair/augment/implant_action(mob/living/carbon/human/H,mob/user)
+	if(!istype(H) || !H.mind)
+		playsound(get_turf(src), 'sound/machines/buzz-two.ogg', 50, 1)
+		return 0
+	var/mob/living/carbon/human/human = H
+	if(human.dna && human.dna.species.id == "human")
+		if(H.abiotic(1))//gotta get naked to have surgery done
+			visible_message("<span_class='warning'>The machine buzzes. It will only operate on a naked human.</span>")
+			playsound(get_turf(src), 'sound/machines/buzz-two.ogg', 50, 1)
+			return 0
+		else
+			visible_message("<span class='warning'>A horrible screech and a bright flash of light eminate from the [src]. In the aftermath, cold fog flows from the chamber, pooling from the floor.</span>")
+			playsound(get_turf(src), 'sound/effects/screech.ogg', 50, 1)
+			to_chat(H, "<span class='heavy_alloy'>Your body is twisted in terrible trauma as robotic arms amputate appendages and restore them with resplendent replacements. You feel a sharp pain in your head and your mind shatters as you lose your concept of self. The agony leaves you as soon as it came and you feel much lighter without your humanity weighing you down.</span>")
+			to_chat(H, "<span class='heavy_alloy'>You feel leather and cloth wrap around your body, armor fit for your new form.</span>")
+			H.equipOutfit(/datum/outfit/syndicate_agent)//Gives them a space suit + gloves + headset + boots. no helmet though.
+			human.set_species(/datum/species/corporate)
+			return 1
+	else if(human.dna && human.dna.species.id == "corporate")//if war ops manage to buy 2 somehow this is so they dont waste 2 augmentations on 1 guy
+		visible_message("<span class='warning'>The machine buzzes. It won't augment a person twice.</span>")
+		playsound(get_turf(src), 'sound/machines/buzz-two.ogg', 50, 1)
+		return 0
+	else//nobody even likes the furry races
+		visible_message("<span class='warning'>The machine buzzes. It wasn't designed to operate on inferior species.</span>")
+		playsound(get_turf(src), 'sound/machines/buzz-two.ogg', 50, 1)
+		return 0

--- a/code/modules/clothing/outfits/standard.dm
+++ b/code/modules/clothing/outfits/standard.dm
@@ -392,6 +392,16 @@
 	mask = /obj/item/clothing/mask/breath
 	suit_store = /obj/item/weapon/tank/internals/oxygen
 
+/datum/outfit/syndicate_agent
+	name = "Syndicate Agent"
+	uniform = /obj/item/clothing/under/syndicate
+	suit = /obj/item/clothing/suit/space/officer
+	shoes = /obj/item/clothing/shoes/combat/swat
+	gloves = /obj/item/clothing/gloves/combat
+	ears = /obj/item/device/radio/headset/syndicate/alt
+
+
+
 
 
 

--- a/code/modules/clothing/spacesuits/miscellaneous.dm
+++ b/code/modules/clothing/spacesuits/miscellaneous.dm
@@ -67,19 +67,19 @@ Contains:
 /obj/item/clothing/suit/space/officer
 	name = "officer's jacket"
 	desc = "An armored, space-proof jacket used in special operations."
-	icon_state = "detective"
-	item_state = "det_suit"
+	icon_state = "hos"
+	item_state = "greatcoat"
 	blood_overlay_type = "coat"
 	slowdown = 0
 	flags_inv = 0
 	w_class = WEIGHT_CLASS_NORMAL
 	allowed = list(/obj/item/weapon/gun, /obj/item/ammo_box, /obj/item/ammo_casing, /obj/item/weapon/melee/baton, /obj/item/weapon/restraints/handcuffs, /obj/item/weapon/tank/internals)
-	armor = list(melee = 80, bullet = 80, laser = 50, energy = 50, bomb = 100, bio = 100, rad = 100, fire = 100, acid = 100)
+	armor = list(melee = 30, bullet = 40, laser = 10, energy = 10, bomb = 0, bio = 100, rad = 100, fire = 100, acid = 100)
 	strip_delay = 130
 	max_heat_protection_temperature = FIRE_IMMUNITY_HELM_MAX_TEMP_PROTECT
 	resistance_flags = FIRE_PROOF | ACID_PROOF
 
-	//NASA Voidsuit
+	//NASA Voidsuita
 /obj/item/clothing/head/helmet/space/nasavoid
 	name = "NASA Void Helmet"
 	desc = "An old, NASA Centcom branch designed, dark red space suit helmet."

--- a/code/modules/uplink/uplink_item.dm
+++ b/code/modules/uplink/uplink_item.dm
@@ -589,6 +589,20 @@ GLOBAL_LIST_EMPTY(uplink_items) // Global list so we only initialize this once.
 	item = /obj/mecha/combat/gygax/dark/loaded
 	cost = 80
 
+/datum/uplink_item/support/augmenter
+	name = "Experimental Augmentation"
+	desc = "An advanced medical chamber similar to a sleeper, this device is equipped with the tools and supplies \
+			to turn a single subject into a highly sophisticated combat cyborg. Enhancements include a sub-dermal \
+			armor plating that provides exceptional protection from direct energy fire (as well as raging infernos), \
+			while also providing excellent protection from kinetic impacts as well. Leg and arm implants \
+			provide exceptional strength and running speed from cutting edge servos. Limbs are secured to subdermal \
+			armor and are virtually impossible to dismember. Additionally, top secret alloys have been included in \
+			the subdermal armor that result in notable radioimmunity as well as protection from viral pathogens. \
+			Nanotrasen never stood a chance."
+	item = /obj/machinery/implantchair/augment
+	cant_discount = TRUE
+	cost = 90
+
 /datum/uplink_item/support/mauler
 	name = "Mauler Exosuit"
 	desc = "A massive and incredibly deadly military-grade exosuit. Features long-range targeting, thrust vectoring, \

--- a/config/admins.txt
+++ b/config/admins.txt
@@ -7,7 +7,7 @@
 # NOTE: if the rank-name cannot be found in admin_ranks.txt, they will not be adminned! ~Carn #
 # NOTE: syntax was changed to allow hyphenation of ranknames, since spaces are stripped.      #
 ###############################################################################################
-Optimumtact = Host
+kilkun = Host
 NewSta = Game Master
 Expletives = Game Master
 kingofkosmos = Game Master

--- a/config/admins.txt
+++ b/config/admins.txt
@@ -7,7 +7,7 @@
 # NOTE: if the rank-name cannot be found in admin_ranks.txt, they will not be adminned! ~Carn #
 # NOTE: syntax was changed to allow hyphenation of ranknames, since spaces are stripped.      #
 ###############################################################################################
-kilkun = Host
+Optimumtact = Host
 NewSta = Game Master
 Expletives = Game Master
 kingofkosmos = Game Master


### PR DESCRIPTION
:cl:
experiment: Reports are coming in of Syndicate strike teams deploying experimental super soldiers. Crew are advised to be on alert.
/:cl:

This PR finally puts the corporate species datum into use. Basically, for 90TC (to be tweaked), Ops can buy a modified implanting chamber that will turn one of them into a combat cyborg. Cyborg as in the traditional idea, not the in-game established cyborg race. They also get a swanky space-proof greatcoat, since the whole thing is a reference to Bullfrog's Syndicate agents of the 1993 cult classic, Syndicate.

Also it puts the officer's jacket into use. Previously it was used for a long-deprecated equipment datum. I simply debuffed it's armor values and made it use the greatcoat sprite.

Now that the feature freeze is over, can we finally go over this?