### PR TITLE
Cleaned up dirty turf varedits

### DIFF
--- a/_maps/RandomRuins/SpaceRuins/oldstation.dmm
+++ b/_maps/RandomRuins/SpaceRuins/oldstation.dmm
@@ -2904,7 +2904,6 @@
 	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel/yellow/corner{
-	icon_state = "yellowcorner";
 	dir = 8
 	},
 /area/ruin/space/has_grav/ancientstation/engi)
@@ -2947,7 +2946,6 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/yellow/corner{
-	icon_state = "yellowcorner";
 	dir = 8
 	},
 /area/ruin/space/has_grav/ancientstation)
@@ -3301,7 +3299,6 @@
 "if" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/yellow/corner{
-	icon_state = "yellowcorner";
 	dir = 8
 	},
 /area/ruin/space/has_grav/ancientstation/engi)

--- a/_maps/RandomRuins/SpaceRuins/shuttlerelic.dmm
+++ b/_maps/RandomRuins/SpaceRuins/shuttlerelic.dmm
@@ -5,7 +5,6 @@
 "b" = (
 /turf/template_noop,
 /turf/closed/indestructible/oldshuttle/corner{
-	icon_state = "corner";
 	dir = 8
 	},
 /area/ruin/powered)
@@ -14,38 +13,24 @@
 /area/ruin/powered)
 "d" = (
 /obj/machinery/door/airlock/glass,
-/turf/open/floor/oldshuttle{
-	baseturf = /turf/open/space;
-	initial_gas_mix = "o2=22;n2=82;TEMP=293.15"
-	},
+/turf/open/floor/oldshuttle,
 /area/ruin/powered)
 "e" = (
 /turf/template_noop,
 /turf/closed/indestructible/oldshuttle/corner,
 /area/ruin/powered)
 "f" = (
-/turf/open/floor/oldshuttle{
-	baseturf = /turf/open/space;
-	initial_gas_mix = "o2=22;n2=82;TEMP=293.15"
-	},
+/turf/open/floor/oldshuttle,
 /turf/closed/indestructible/oldshuttle/corner{
-	icon_state = "corner";
 	dir = 1
 	},
 /area/ruin/powered)
 "g" = (
-/turf/open/floor/oldshuttle{
-	baseturf = /turf/open/space;
-	initial_gas_mix = "o2=22;n2=82;TEMP=293.15"
-	},
+/turf/open/floor/oldshuttle,
 /area/ruin/powered)
 "h" = (
-/turf/open/floor/oldshuttle{
-	baseturf = /turf/open/space;
-	initial_gas_mix = "o2=22;n2=82;TEMP=293.15"
-	},
+/turf/open/floor/oldshuttle,
 /turf/closed/indestructible/oldshuttle/corner{
-	icon_state = "corner";
 	dir = 4
 	},
 /area/ruin/powered)
@@ -54,10 +39,7 @@
 	icon_state = "oldcloset";
 	name = "strange closet"
 	},
-/turf/open/floor/oldshuttle{
-	baseturf = /turf/open/space;
-	initial_gas_mix = "o2=22;n2=82;TEMP=293.15"
-	},
+/turf/open/floor/oldshuttle,
 /area/ruin/powered)
 "j" = (
 /obj/structure/shuttle/engine/propulsion/burst{
@@ -67,10 +49,7 @@
 /area/ruin/powered)
 "k" = (
 /mob/living/simple_animal/hostile/retaliate/spaceman,
-/turf/open/floor/oldshuttle{
-	baseturf = /turf/open/space;
-	initial_gas_mix = "o2=22;n2=82;TEMP=293.15"
-	},
+/turf/open/floor/oldshuttle,
 /area/ruin/powered)
 "l" = (
 /turf/closed/indestructible/oldshuttle{
@@ -82,10 +61,7 @@
 	icon_state = "chairold";
 	dir = 1
 	},
-/turf/open/floor/oldshuttle{
-	baseturf = /turf/open/space;
-	initial_gas_mix = "o2=22;n2=82;TEMP=293.15"
-	},
+/turf/open/floor/oldshuttle,
 /area/ruin/powered)
 "n" = (
 /obj/structure/chair/old{
@@ -97,10 +73,7 @@
 	force = 20;
 	name = "heavy crowbar"
 	},
-/turf/open/floor/oldshuttle{
-	baseturf = /turf/open/space;
-	initial_gas_mix = "o2=22;n2=82;TEMP=293.15"
-	},
+/turf/open/floor/oldshuttle,
 /area/ruin/powered)
 "o" = (
 /obj/structure/chair/old{
@@ -108,55 +81,37 @@
 	dir = 1
 	},
 /mob/living/simple_animal/hostile/retaliate/spaceman,
-/turf/open/floor/oldshuttle{
-	baseturf = /turf/open/space;
-	initial_gas_mix = "o2=22;n2=82;TEMP=293.15"
-	},
+/turf/open/floor/oldshuttle,
 /area/ruin/powered)
 "p" = (
-/turf/open/floor/oldshuttle{
-	baseturf = /turf/open/space;
-	initial_gas_mix = "o2=22;n2=82;TEMP=293.15"
-	},
+/turf/open/floor/oldshuttle,
 /turf/closed/indestructible/oldshuttle/corner{
-	icon_state = "corner";
 	dir = 8
 	},
 /area/ruin/powered)
 "q" = (
-/turf/open/floor/oldshuttle{
-	baseturf = /turf/open/space;
-	initial_gas_mix = "o2=22;n2=82;TEMP=293.15"
-	},
+/turf/open/floor/oldshuttle,
 /turf/closed/indestructible/oldshuttle/corner,
 /area/ruin/powered)
 "r" = (
 /turf/template_noop,
 /turf/closed/indestructible/oldshuttle/corner{
-	icon_state = "corner";
 	dir = 1
 	},
 /area/ruin/powered)
 "s" = (
 /turf/template_noop,
 /turf/closed/indestructible/oldshuttle/corner{
-	icon_state = "corner";
 	dir = 4
 	},
 /area/ruin/powered)
 "t" = (
 /obj/machinery/power/generator,
-/turf/open/floor/oldshuttle{
-	baseturf = /turf/open/space;
-	initial_gas_mix = "o2=22;n2=82;TEMP=293.15"
-	},
+/turf/open/floor/oldshuttle,
 /area/ruin/powered)
 "u" = (
 /obj/machinery/power/smes,
-/turf/open/floor/oldshuttle{
-	baseturf = /turf/open/space;
-	initial_gas_mix = "o2=22;n2=82;TEMP=293.15"
-	},
+/turf/open/floor/oldshuttle,
 /area/ruin/powered)
 "v" = (
 /obj/structure/shuttle/engine/propulsion/burst/left,

--- a/_maps/RandomRuins/SpaceRuins/spacehotel.dmm
+++ b/_maps/RandomRuins/SpaceRuins/spacehotel.dmm
@@ -3212,7 +3212,6 @@
 "is" = (
 /obj/structure/reagent_dispensers/fueltank,
 /turf/open/floor/plasteel/yellow/side{
-	icon_state = "yellow";
 	dir = 9
 	},
 /area/ruin/space/has_grav/hotel/power)
@@ -3229,7 +3228,6 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plasteel/yellow/side{
-	icon_state = "yellow";
 	dir = 1
 	},
 /area/ruin/space/has_grav/hotel/power)
@@ -3246,7 +3244,6 @@
 	pixel_y = 32
 	},
 /turf/open/floor/plasteel/yellow/side{
-	icon_state = "yellow";
 	dir = 1
 	},
 /area/ruin/space/has_grav/hotel/power)
@@ -3260,7 +3257,6 @@
 	pixel_y = 24
 	},
 /turf/open/floor/plasteel/yellow/side{
-	icon_state = "yellow";
 	dir = 1
 	},
 /area/ruin/space/has_grav/hotel/power)
@@ -3276,7 +3272,6 @@
 	icon_state = "0-8"
 	},
 /turf/open/floor/plasteel/yellow/side{
-	icon_state = "yellow";
 	dir = 1
 	},
 /area/ruin/space/has_grav/hotel/power)
@@ -3285,7 +3280,6 @@
 /obj/item/stack/sheet/metal/fifty,
 /obj/item/stack/sheet/metal/fifty,
 /turf/open/floor/plasteel/yellow/side{
-	icon_state = "yellow";
 	dir = 5
 	},
 /area/ruin/space/has_grav/hotel/power)
@@ -3352,7 +3346,6 @@
 	dir = 8
 	},
 /turf/open/floor/plasteel/yellow/side{
-	icon_state = "yellow";
 	dir = 8
 	},
 /area/ruin/space/has_grav/hotel/power)
@@ -3379,7 +3372,6 @@
 /obj/item/stack/sheet/glass/fifty,
 /obj/item/stack/sheet/glass/fifty,
 /turf/open/floor/plasteel/yellow/side{
-	icon_state = "yellow";
 	dir = 4
 	},
 /area/ruin/space/has_grav/hotel/power)
@@ -3417,7 +3409,6 @@
 /obj/item/storage/toolbox/mechanical,
 /obj/item/clothing/head/welding,
 /turf/open/floor/plasteel/yellow/side{
-	icon_state = "yellow";
 	dir = 8
 	},
 /area/ruin/space/has_grav/hotel/power)
@@ -3432,7 +3423,6 @@
 	amount = 60
 	},
 /turf/open/floor/plasteel/yellow/side{
-	icon_state = "yellow";
 	dir = 4
 	},
 /area/ruin/space/has_grav/hotel/power)
@@ -3601,7 +3591,6 @@
 /obj/item/stock_parts/cell/high,
 /obj/item/stock_parts/cell/high,
 /turf/open/floor/plasteel/yellow/side{
-	icon_state = "yellow";
 	dir = 8
 	},
 /area/ruin/space/has_grav/hotel/power)
@@ -3634,7 +3623,6 @@
 	amount = 50
 	},
 /turf/open/floor/plasteel/yellow/side{
-	icon_state = "yellow";
 	dir = 4
 	},
 /area/ruin/space/has_grav/hotel/power)
@@ -3736,7 +3724,6 @@
 	icon_state = "2-4"
 	},
 /turf/open/floor/plasteel/yellow/side{
-	icon_state = "yellow";
 	dir = 8
 	},
 /area/ruin/space/has_grav/hotel/power)
@@ -3762,7 +3749,6 @@
 /area/ruin/space/has_grav/hotel/power)
 "jE" = (
 /turf/open/floor/plasteel/yellow/corner{
-	icon_state = "yellowcorner";
 	dir = 4
 	},
 /area/ruin/space/has_grav/hotel/power)
@@ -3771,7 +3757,6 @@
 	pixel_x = 30
 	},
 /turf/open/floor/plasteel/yellow/side{
-	icon_state = "yellow";
 	dir = 5
 	},
 /area/ruin/space/has_grav/hotel/power)
@@ -3780,21 +3765,18 @@
 /area/ruin/space/has_grav/hotel/security)
 "jH" = (
 /turf/open/floor/plasteel/red/side{
-	icon_state = "red";
 	dir = 9
 	},
 /area/ruin/space/has_grav/hotel/security)
 "jI" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plasteel/red/side{
-	icon_state = "red";
 	dir = 1
 	},
 /area/ruin/space/has_grav/hotel/security)
 "jJ" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plasteel/red/side{
-	icon_state = "red";
 	dir = 1
 	},
 /area/ruin/space/has_grav/hotel/security)
@@ -3803,7 +3785,6 @@
 	pixel_y = 24
 	},
 /turf/open/floor/plasteel/red/side{
-	icon_state = "red";
 	dir = 1
 	},
 /area/ruin/space/has_grav/hotel/security)
@@ -3812,7 +3793,6 @@
 	pixel_y = 30
 	},
 /turf/open/floor/plasteel/red/side{
-	icon_state = "red";
 	dir = 5
 	},
 /area/ruin/space/has_grav/hotel/security)
@@ -3900,7 +3880,6 @@
 	dir = 8
 	},
 /turf/open/floor/plasteel/yellow/side{
-	icon_state = "yellow";
 	dir = 8
 	},
 /area/ruin/space/has_grav/hotel/power)
@@ -3942,7 +3921,6 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel/yellow/side{
-	icon_state = "yellow";
 	dir = 4
 	},
 /area/ruin/space/has_grav/hotel/power)
@@ -3951,7 +3929,6 @@
 	dir = 8
 	},
 /turf/open/floor/plasteel/red/side{
-	icon_state = "red";
 	dir = 8
 	},
 /area/ruin/space/has_grav/hotel/security)
@@ -3969,7 +3946,6 @@
 /area/ruin/space/has_grav/hotel/security)
 "kl" = (
 /turf/open/floor/plasteel/red/side{
-	icon_state = "red";
 	dir = 4
 	},
 /area/ruin/space/has_grav/hotel/security)
@@ -3997,7 +3973,6 @@
 	icon_state = "1-4"
 	},
 /turf/open/floor/plasteel/yellow/side{
-	icon_state = "yellow";
 	dir = 10
 	},
 /area/ruin/space/has_grav/hotel/power)
@@ -4065,13 +4040,11 @@
 	icon_state = "2-8"
 	},
 /turf/open/floor/plasteel/yellow/side{
-	icon_state = "yellow";
 	dir = 6
 	},
 /area/ruin/space/has_grav/hotel/power)
 "kx" = (
 /turf/open/floor/plasteel/red/side{
-	icon_state = "red";
 	dir = 8
 	},
 /area/ruin/space/has_grav/hotel/security)
@@ -4155,7 +4128,6 @@
 /obj/structure/table,
 /obj/item/book/manual/wiki/security_space_law,
 /turf/open/floor/plasteel/red/side{
-	icon_state = "red";
 	dir = 8
 	},
 /area/ruin/space/has_grav/hotel/security)
@@ -4176,7 +4148,6 @@
 	dir = 8
 	},
 /turf/open/floor/plasteel/red/side{
-	icon_state = "red";
 	dir = 4
 	},
 /area/ruin/space/has_grav/hotel/security)
@@ -4273,7 +4244,6 @@
 	pixel_x = -32
 	},
 /turf/open/floor/plasteel/red/side{
-	icon_state = "red";
 	dir = 8
 	},
 /area/ruin/space/has_grav/hotel/security)
@@ -4374,7 +4344,6 @@
 /obj/item/restraints/handcuffs,
 /obj/item/restraints/handcuffs,
 /turf/open/floor/plasteel/red/side{
-	icon_state = "red";
 	dir = 8
 	},
 /area/ruin/space/has_grav/hotel/security)
@@ -4401,7 +4370,6 @@
 /area/ruin/unpowered/no_grav)
 "lw" = (
 /turf/open/floor/plasteel/red/side{
-	icon_state = "red";
 	dir = 10
 	},
 /area/ruin/space/has_grav/hotel/security)
@@ -4418,7 +4386,6 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel/red/side{
-	icon_state = "red";
 	dir = 4
 	},
 /area/ruin/space/has_grav/hotel/security)
@@ -4570,7 +4537,6 @@
 /area/ruin/space/has_grav/hotel/security)
 "lU" = (
 /turf/open/floor/plasteel/red/side{
-	icon_state = "red";
 	dir = 6
 	},
 /area/ruin/space/has_grav/hotel/security)

--- a/_maps/map_files/BoxStation/BoxStation.dmm
+++ b/_maps/map_files/BoxStation/BoxStation.dmm
@@ -25741,7 +25741,6 @@
 	},
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel/whitered/corner{
-	icon_state = "whiteredcorner";
 	dir = 1
 	},
 /area/science/robotics/lab)
@@ -33501,17 +33500,11 @@
 	pressure_checks = 0;
 	name = "server vent"
 	},
-/turf/open/floor/circuit{
-	name = "Server Base";
-	initial_gas_mix = "n2=500;TEMP=80"
-	},
+/turf/open/floor/circuit/telecomms/server,
 /area/science/server)
 "bzu" = (
 /obj/machinery/r_n_d/server/robotics,
-/turf/open/floor/circuit{
-	name = "Server Base";
-	initial_gas_mix = "n2=500;TEMP=80"
-	},
+/turf/open/floor/circuit/telecomms/server,
 /area/science/server)
 "bzv" = (
 /obj/machinery/atmospherics/pipe/simple{
@@ -34002,10 +33995,7 @@
 /area/maintenance/port/aft)
 "bAy" = (
 /obj/effect/landmark/blobstart,
-/turf/open/floor/plasteel/black{
-	name = "Server Walkway";
-	initial_gas_mix = "n2=500;TEMP=80"
-	},
+/turf/open/floor/plasteel/black/telecomms/server/walkway,
 /area/science/server)
 "bAz" = (
 /obj/machinery/airalarm/server{
@@ -34015,10 +34005,7 @@
 /obj/machinery/light/small{
 	dir = 8
 	},
-/turf/open/floor/plasteel/black{
-	name = "Server Walkway";
-	initial_gas_mix = "n2=500;TEMP=80"
-	},
+/turf/open/floor/plasteel/black/telecomms/server/walkway,
 /area/science/server)
 "bAA" = (
 /obj/machinery/atmospherics/pipe/manifold{
@@ -34662,17 +34649,11 @@
 	external_pressure_bound = 120;
 	name = "server vent"
 	},
-/turf/open/floor/circuit{
-	name = "Server Base";
-	initial_gas_mix = "n2=500;TEMP=80"
-	},
+/turf/open/floor/circuit/telecomms/server,
 /area/science/server)
 "bBT" = (
 /obj/machinery/r_n_d/server/core,
-/turf/open/floor/circuit{
-	name = "Server Base";
-	initial_gas_mix = "n2=500;TEMP=80"
-	},
+/turf/open/floor/circuit/telecomms/server,
 /area/science/server)
 "bBU" = (
 /obj/machinery/atmospherics/pipe/simple{
@@ -47868,10 +47849,7 @@
 	dir = 4;
 	network = list("SS13","RD")
 	},
-/turf/open/floor/circuit{
-	name = "Killroom Floor";
-	initial_gas_mix = "n2=500;TEMP=80"
-	},
+/turf/open/floor/circuit/killroom,
 /area/science/xenobiology)
 "cfs" = (
 /obj/machinery/door/airlock/maintenance{
@@ -48225,10 +48203,7 @@
 /turf/open/floor/plating,
 /area/maintenance/aft)
 "cgi" = (
-/turf/open/floor/circuit{
-	name = "Killroom Floor";
-	initial_gas_mix = "n2=500;TEMP=80"
-	},
+/turf/open/floor/circuit/killroom,
 /area/science/xenobiology)
 "cgj" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -48249,10 +48224,7 @@
 	external_pressure_bound = 120;
 	name = "killroom vent"
 	},
-/turf/open/floor/circuit{
-	name = "Killroom Floor";
-	initial_gas_mix = "n2=500;TEMP=80"
-	},
+/turf/open/floor/circuit/killroom,
 /area/science/xenobiology)
 "cgm" = (
 /obj/structure/cable{
@@ -48744,10 +48716,7 @@
 /obj/machinery/atmospherics/pipe/simple/general/visible{
 	dir = 5
 	},
-/turf/open/floor/circuit{
-	name = "Killroom Floor";
-	initial_gas_mix = "n2=500;TEMP=80"
-	},
+/turf/open/floor/circuit/killroom,
 /area/science/xenobiology)
 "chp" = (
 /obj/structure/disposalpipe/segment{
@@ -48762,10 +48731,7 @@
 /obj/machinery/atmospherics/pipe/simple/general/visible{
 	dir = 4
 	},
-/turf/open/floor/circuit{
-	name = "Killroom Floor";
-	initial_gas_mix = "n2=500;TEMP=80"
-	},
+/turf/open/floor/circuit/killroom,
 /area/science/xenobiology)
 "chr" = (
 /obj/machinery/door/firedoor,
@@ -48781,10 +48747,7 @@
 "chs" = (
 /obj/machinery/light,
 /obj/machinery/atmospherics/pipe/manifold/general/visible,
-/turf/open/floor/circuit{
-	name = "Killroom Floor";
-	initial_gas_mix = "n2=500;TEMP=80"
-	},
+/turf/open/floor/circuit/killroom,
 /area/science/xenobiology)
 "cht" = (
 /obj/structure/disposalpipe/segment,

--- a/_maps/map_files/Cerestation/cerestation.dmm
+++ b/_maps/map_files/Cerestation/cerestation.dmm
@@ -1535,7 +1535,6 @@
 	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel/red/side{
-	icon_state = "red";
 	dir = 1
 	},
 /area/security/prison)
@@ -1557,7 +1556,6 @@
 	icon_state = "2-4"
 	},
 /turf/open/floor/plasteel/red/side{
-	icon_state = "red";
 	dir = 1
 	},
 /area/security/prison)
@@ -1574,7 +1572,6 @@
 	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel/red/side{
-	icon_state = "red";
 	dir = 1
 	},
 /area/security/prison)
@@ -1594,7 +1591,6 @@
 	icon_state = "1-8"
 	},
 /turf/open/floor/plasteel/red/side{
-	icon_state = "red";
 	dir = 5
 	},
 /area/security/prison)
@@ -1791,7 +1787,6 @@
 	dir = 9
 	},
 /turf/open/floor/plasteel/red/side{
-	icon_state = "red";
 	dir = 4
 	},
 /area/security/prison)
@@ -1905,7 +1900,6 @@
 	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel/red/side{
-	icon_state = "red";
 	dir = 8
 	},
 /area/security/prison)
@@ -1919,7 +1913,6 @@
 	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel/red/side{
-	icon_state = "red";
 	dir = 4
 	},
 /area/security/prison)
@@ -2042,7 +2035,6 @@
 	dir = 8
 	},
 /turf/open/floor/plasteel/red/side{
-	icon_state = "red";
 	dir = 8
 	},
 /area/security/prison)
@@ -2074,7 +2066,6 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel/red/side{
-	icon_state = "red";
 	dir = 4
 	},
 /area/security/prison)
@@ -2213,7 +2204,6 @@
 	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel/red/side{
-	icon_state = "red";
 	dir = 8
 	},
 /area/security/prison)
@@ -2253,7 +2243,6 @@
 "ajm" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plasteel/red/side{
-	icon_state = "red";
 	dir = 8
 	},
 /area/security/prison)
@@ -2458,7 +2447,6 @@
 /area/maintenance/asteroid/fore/com_west)
 "aka" = (
 /turf/open/floor/plasteel/red/side{
-	icon_state = "red";
 	dir = 8
 	},
 /area/security/prison)
@@ -2497,7 +2485,6 @@
 "ake" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plasteel/red/side{
-	icon_state = "red";
 	dir = 4
 	},
 /area/security/prison)
@@ -2733,7 +2720,6 @@
 	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel/red/side{
-	icon_state = "red";
 	dir = 8
 	},
 /area/security/prison)
@@ -2857,7 +2843,6 @@
 	pixel_x = -32
 	},
 /turf/open/floor/plasteel/red/side{
-	icon_state = "red";
 	dir = 8
 	},
 /area/security/prison)
@@ -3014,7 +2999,6 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel/red/side{
-	icon_state = "red";
 	dir = 1
 	},
 /area/security/processing)
@@ -3029,7 +3013,6 @@
 	pixel_y = 20
 	},
 /turf/open/floor/plasteel/red/side{
-	icon_state = "red";
 	dir = 1
 	},
 /area/security/prison)
@@ -3044,7 +3027,6 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel/red/side{
-	icon_state = "red";
 	dir = 1
 	},
 /area/security/prison)
@@ -3128,7 +3110,6 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel/red/side{
-	icon_state = "red";
 	dir = 1
 	},
 /area/security/prison)
@@ -3429,7 +3410,6 @@
 	dir = 8
 	},
 /turf/open/floor/plasteel/red/side{
-	icon_state = "red";
 	dir = 8
 	},
 /area/security/prison)
@@ -3731,7 +3711,6 @@
 	pixel_x = -32
 	},
 /turf/open/floor/plasteel/red/side{
-	icon_state = "red";
 	dir = 8
 	},
 /area/security/prison)
@@ -3757,7 +3736,6 @@
 	pixel_x = 32
 	},
 /turf/open/floor/plasteel/red/side{
-	icon_state = "red";
 	dir = 4
 	},
 /area/security/prison)
@@ -4370,7 +4348,6 @@
 /area/security/prison)
 "apC" = (
 /turf/open/floor/plasteel/red/side{
-	icon_state = "red";
 	dir = 4
 	},
 /area/security/prison)
@@ -4903,7 +4880,6 @@
 	dir = 8
 	},
 /turf/open/floor/plasteel/red/side{
-	icon_state = "red";
 	dir = 8
 	},
 /area/security/prison)
@@ -4917,7 +4893,6 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel/red/side{
-	icon_state = "red";
 	dir = 4
 	},
 /area/security/prison)
@@ -4993,7 +4968,6 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel/neutral/side{
-	icon_state = "neutral";
 	dir = 6
 	},
 /area/crew_quarters/dorms/female)
@@ -5002,7 +4976,6 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel/neutral/side{
-	icon_state = "neutral";
 	dir = 6
 	},
 /area/crew_quarters/dorms/female)
@@ -5011,7 +4984,6 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel/neutral/side{
-	icon_state = "neutral";
 	dir = 10
 	},
 /area/crew_quarters/dorms/female)
@@ -5025,7 +4997,6 @@
 	pixel_y = 20
 	},
 /turf/open/floor/plasteel/neutral/side{
-	icon_state = "neutral";
 	dir = 10
 	},
 /area/crew_quarters/dorms/female)
@@ -5038,7 +5009,6 @@
 	dir = 8
 	},
 /turf/open/floor/plasteel/neutral/side{
-	icon_state = "neutral";
 	dir = 10
 	},
 /area/crew_quarters/dorms/female)
@@ -5226,7 +5196,6 @@
 	name = "Female Sleeping Quarters"
 	},
 /turf/open/floor/plasteel/neutral/side{
-	icon_state = "neutral";
 	dir = 4
 	},
 /area/crew_quarters/dorms/female)
@@ -5601,7 +5570,6 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel/neutral/side{
-	icon_state = "neutral";
 	dir = 5
 	},
 /area/crew_quarters/dorms/female)
@@ -5610,19 +5578,16 @@
 	dir = 8
 	},
 /turf/open/floor/plasteel/neutral/side{
-	icon_state = "neutral";
 	dir = 5
 	},
 /area/crew_quarters/dorms/female)
 "atH" = (
 /turf/open/floor/plasteel/neutral/side{
-	icon_state = "neutral";
 	dir = 5
 	},
 /area/crew_quarters/dorms/female)
 "atI" = (
 /turf/open/floor/plasteel/neutral/side{
-	icon_state = "neutral";
 	dir = 9
 	},
 /area/crew_quarters/dorms/female)
@@ -5820,7 +5785,6 @@
 	network = list("SS13","Security")
 	},
 /turf/open/floor/plasteel/red/side{
-	icon_state = "red";
 	dir = 1
 	},
 /area/security/main)
@@ -5831,7 +5795,6 @@
 	pixel_y = 32
 	},
 /turf/open/floor/plasteel/red/side{
-	icon_state = "red";
 	dir = 1
 	},
 /area/security/main)
@@ -5842,7 +5805,6 @@
 	dir = 1
 	},
 /turf/open/floor/plasteel/red/side{
-	icon_state = "red";
 	dir = 5
 	},
 /area/security/main)
@@ -5991,7 +5953,6 @@
 	dir = 10
 	},
 /turf/open/floor/plasteel/darkblue/side{
-	icon_state = "darkblue";
 	dir = 1
 	},
 /area/bridge)
@@ -6004,7 +5965,6 @@
 	},
 /obj/item/storage/fancy/donut_box,
 /turf/open/floor/plasteel/darkblue/side{
-	icon_state = "darkblue";
 	dir = 1
 	},
 /area/bridge)
@@ -6014,7 +5974,6 @@
 	pixel_y = 32
 	},
 /turf/open/floor/plasteel/darkblue/side{
-	icon_state = "darkblue";
 	dir = 1
 	},
 /area/bridge)
@@ -6096,7 +6055,6 @@
 	c_tag = "Bridge Main 1"
 	},
 /turf/open/floor/plasteel/darkblue/side{
-	icon_state = "darkblue";
 	dir = 1
 	},
 /area/bridge)
@@ -6105,7 +6063,6 @@
 	pixel_y = 32
 	},
 /turf/open/floor/plasteel/darkblue/side{
-	icon_state = "darkblue";
 	dir = 1
 	},
 /area/bridge)
@@ -6114,7 +6071,6 @@
 	dir = 6
 	},
 /turf/open/floor/plasteel/darkblue/side{
-	icon_state = "darkblue";
 	dir = 1
 	},
 /area/bridge)
@@ -6340,7 +6296,6 @@
 	icon_state = "0-2"
 	},
 /turf/open/floor/plasteel/red/side{
-	icon_state = "red";
 	dir = 4
 	},
 /area/security/main)
@@ -6622,7 +6577,6 @@
 	pixel_x = -32
 	},
 /turf/open/floor/plasteel/red/side{
-	icon_state = "red";
 	dir = 9
 	},
 /area/security/main)
@@ -6665,7 +6619,6 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel/red/side{
-	icon_state = "red";
 	dir = 5
 	},
 /area/security/main)
@@ -6681,7 +6634,6 @@
 	name = "evidence closet"
 	},
 /turf/open/floor/plasteel/red/side{
-	icon_state = "red";
 	dir = 9
 	},
 /area/security/brig)
@@ -6722,7 +6674,6 @@
 	dir = 8
 	},
 /turf/open/floor/plasteel/red/side{
-	icon_state = "red";
 	dir = 8
 	},
 /area/security/brig)
@@ -6730,7 +6681,6 @@
 /obj/structure/table,
 /obj/machinery/computer/med_data/laptop,
 /turf/open/floor/plasteel/whiteblue/side{
-	icon_state = "whiteblue";
 	dir = 1
 	},
 /area/security/brig)
@@ -6739,7 +6689,6 @@
 	dir = 1
 	},
 /turf/open/floor/plasteel/whiteblue/side{
-	icon_state = "whiteblue";
 	dir = 1
 	},
 /area/security/brig)
@@ -6931,7 +6880,6 @@
 	pixel_x = -32
 	},
 /turf/open/floor/plasteel/red/side{
-	icon_state = "red";
 	dir = 8
 	},
 /area/security/main)
@@ -6966,7 +6914,6 @@
 	name = "evidence closet"
 	},
 /turf/open/floor/plasteel/red/side{
-	icon_state = "red";
 	dir = 8
 	},
 /area/security/brig)
@@ -7484,7 +7431,6 @@
 /obj/structure/table,
 /obj/machinery/recharger,
 /turf/open/floor/plasteel/red/side{
-	icon_state = "red";
 	dir = 4
 	},
 /area/security/main)
@@ -7506,7 +7452,6 @@
 	name = "evidence closet"
 	},
 /turf/open/floor/plasteel/red/side{
-	icon_state = "red";
 	dir = 4
 	},
 /area/security/brig)
@@ -7726,7 +7671,6 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel/darkblue/side{
-	icon_state = "darkblue";
 	dir = 1
 	},
 /area/bridge)
@@ -7737,7 +7681,6 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel/darkblue/side{
-	icon_state = "darkblue";
 	dir = 1
 	},
 /area/bridge)
@@ -7747,14 +7690,12 @@
 	},
 /obj/machinery/holopad,
 /turf/open/floor/plasteel/darkblue/side{
-	icon_state = "darkblue";
 	dir = 1
 	},
 /area/bridge)
 "azP" = (
 /obj/machinery/atmospherics/pipe/manifold4w/scrubbers/hidden,
 /turf/open/floor/plasteel/darkblue/side{
-	icon_state = "darkblue";
 	dir = 1
 	},
 /area/bridge)
@@ -7993,7 +7934,6 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel/red/side{
-	icon_state = "red";
 	dir = 6
 	},
 /area/security/main)
@@ -8002,7 +7942,6 @@
 	name = "evidence closet"
 	},
 /turf/open/floor/plasteel/red/side{
-	icon_state = "red";
 	dir = 10
 	},
 /area/security/brig)
@@ -8047,7 +7986,6 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel/red/side{
-	icon_state = "red";
 	dir = 4
 	},
 /area/security/brig)
@@ -8176,7 +8114,6 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel/neutral/side{
-	icon_state = "neutral";
 	dir = 6
 	},
 /area/crew_quarters/dorms/male)
@@ -8185,7 +8122,6 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel/neutral/side{
-	icon_state = "neutral";
 	dir = 6
 	},
 /area/crew_quarters/dorms/male)
@@ -8194,7 +8130,6 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel/neutral/side{
-	icon_state = "neutral";
 	dir = 10
 	},
 /area/crew_quarters/dorms/male)
@@ -8208,7 +8143,6 @@
 	pixel_y = 20
 	},
 /turf/open/floor/plasteel/neutral/side{
-	icon_state = "neutral";
 	dir = 10
 	},
 /area/crew_quarters/dorms/male)
@@ -8221,7 +8155,6 @@
 	dir = 8
 	},
 /turf/open/floor/plasteel/neutral/side{
-	icon_state = "neutral";
 	dir = 10
 	},
 /area/crew_quarters/dorms/male)
@@ -8353,7 +8286,6 @@
 	network = list("SS13","Security")
 	},
 /turf/open/floor/plasteel/red/side{
-	icon_state = "red";
 	dir = 4
 	},
 /area/security/main)
@@ -8419,7 +8351,6 @@
 	name = "Male Sleeping Quarters"
 	},
 /turf/open/floor/plasteel/neutral/side{
-	icon_state = "neutral";
 	dir = 4
 	},
 /area/crew_quarters/dorms/male)
@@ -8740,7 +8671,6 @@
 	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel/red/side{
-	icon_state = "red";
 	dir = 4
 	},
 /area/security/main)
@@ -8769,7 +8699,6 @@
 	network = list("SS13","Security")
 	},
 /turf/open/floor/plasteel/red/side{
-	icon_state = "red";
 	dir = 1
 	},
 /area/security/brig)
@@ -8778,7 +8707,6 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel/red/side{
-	icon_state = "red";
 	dir = 1
 	},
 /area/security/brig)
@@ -8790,7 +8718,6 @@
 	dir = 1
 	},
 /turf/open/floor/plasteel/red/side{
-	icon_state = "red";
 	dir = 1
 	},
 /area/security/brig)
@@ -8805,7 +8732,6 @@
 	pixel_y = 20
 	},
 /turf/open/floor/plasteel/red/side{
-	icon_state = "red";
 	dir = 1
 	},
 /area/security/brig)
@@ -8817,7 +8743,6 @@
 	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel/red/side{
-	icon_state = "red";
 	dir = 1
 	},
 /area/security/brig)
@@ -8826,7 +8751,6 @@
 	dir = 1
 	},
 /turf/open/floor/plasteel/red/side{
-	icon_state = "red";
 	dir = 1
 	},
 /area/security/brig)
@@ -8846,7 +8770,6 @@
 	pixel_y = 32
 	},
 /turf/open/floor/plasteel/red/side{
-	icon_state = "red";
 	dir = 1
 	},
 /area/security/brig)
@@ -8858,7 +8781,6 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel/red/side{
-	icon_state = "red";
 	dir = 1
 	},
 /area/security/brig)
@@ -8870,7 +8792,6 @@
 	pixel_y = 32
 	},
 /turf/open/floor/plasteel/red/side{
-	icon_state = "red";
 	dir = 1
 	},
 /area/security/brig)
@@ -8879,7 +8800,6 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel/red/side{
-	icon_state = "red";
 	dir = 1
 	},
 /area/security/brig)
@@ -9015,7 +8935,6 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel/neutral/side{
-	icon_state = "neutral";
 	dir = 5
 	},
 /area/crew_quarters/dorms/male)
@@ -9024,19 +8943,16 @@
 	dir = 8
 	},
 /turf/open/floor/plasteel/neutral/side{
-	icon_state = "neutral";
 	dir = 5
 	},
 /area/crew_quarters/dorms/male)
 "aDo" = (
 /turf/open/floor/plasteel/neutral/side{
-	icon_state = "neutral";
 	dir = 5
 	},
 /area/crew_quarters/dorms/male)
 "aDp" = (
 /turf/open/floor/plasteel/neutral/side{
-	icon_state = "neutral";
 	dir = 9
 	},
 /area/crew_quarters/dorms/male)
@@ -9223,7 +9139,6 @@
 	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel/red/side{
-	icon_state = "red";
 	dir = 4
 	},
 /area/security/main)
@@ -9266,14 +9181,12 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel/red/side{
-	icon_state = "red";
 	dir = 1
 	},
 /area/security/courtroom)
 "aEi" = (
 /obj/structure/table/wood,
 /turf/open/floor/plasteel/red/side{
-	icon_state = "red";
 	dir = 5
 	},
 /area/security/courtroom)
@@ -9303,7 +9216,6 @@
 	dir = 8
 	},
 /turf/open/floor/plasteel/blue/side{
-	icon_state = "blue";
 	dir = 1
 	},
 /area/security/courtroom)
@@ -9450,7 +9362,6 @@
 /area/bridge)
 "aED" = (
 /turf/open/floor/plasteel/darkblue/side{
-	icon_state = "darkblue";
 	dir = 1
 	},
 /area/bridge)
@@ -9462,7 +9373,6 @@
 	pixel_y = 23
 	},
 /turf/open/floor/plasteel/darkblue/side{
-	icon_state = "darkblue";
 	dir = 1
 	},
 /area/bridge)
@@ -9471,7 +9381,6 @@
 /obj/item/stack/packageWrap,
 /obj/item/device/destTagger,
 /turf/open/floor/plasteel/darkblue/side{
-	icon_state = "darkblue";
 	dir = 1
 	},
 /area/bridge)
@@ -9479,7 +9388,6 @@
 /obj/structure/table,
 /obj/machinery/cell_charger,
 /turf/open/floor/plasteel/darkblue/side{
-	icon_state = "darkblue";
 	dir = 1
 	},
 /area/bridge)
@@ -9487,7 +9395,6 @@
 /obj/structure/table,
 /obj/machinery/recharger,
 /turf/open/floor/plasteel/darkblue/side{
-	icon_state = "darkblue";
 	dir = 1
 	},
 /area/bridge)
@@ -9549,7 +9456,6 @@
 	pixel_y = 20
 	},
 /turf/open/floor/plasteel/darkblue/side{
-	icon_state = "darkblue";
 	dir = 1
 	},
 /area/bridge)
@@ -9563,7 +9469,6 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel/darkblue/side{
-	icon_state = "darkblue";
 	dir = 1
 	},
 /area/bridge)
@@ -9576,7 +9481,6 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel/darkblue/side{
-	icon_state = "darkblue";
 	dir = 1
 	},
 /area/bridge)
@@ -9589,7 +9493,6 @@
 	dir = 8
 	},
 /turf/open/floor/plasteel/darkblue/side{
-	icon_state = "darkblue";
 	dir = 1
 	},
 /area/bridge)
@@ -9723,7 +9626,6 @@
 	icon_state = "1-4"
 	},
 /turf/open/floor/plasteel/red/side{
-	icon_state = "red";
 	dir = 4
 	},
 /area/security/main)
@@ -9768,7 +9670,6 @@
 	icon_state = "1-4"
 	},
 /turf/open/floor/plasteel/red/side{
-	icon_state = "red";
 	dir = 10
 	},
 /area/security/brig)
@@ -10487,7 +10388,6 @@
 	pixel_x = 32
 	},
 /turf/open/floor/plasteel/red/side{
-	icon_state = "red";
 	dir = 4
 	},
 /area/security/main)
@@ -10515,7 +10415,6 @@
 	icon_state = "pipe-c"
 	},
 /turf/open/floor/plasteel/red/side{
-	icon_state = "red";
 	dir = 8
 	},
 /area/security/brig)
@@ -10548,7 +10447,6 @@
 	dir = 8
 	},
 /turf/open/floor/plasteel/red/side{
-	icon_state = "red";
 	dir = 4
 	},
 /area/security/brig)
@@ -10583,7 +10481,6 @@
 "aGU" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plasteel/red/side{
-	icon_state = "red";
 	dir = 8
 	},
 /area/security/courtroom)
@@ -10594,7 +10491,6 @@
 /obj/structure/table/wood,
 /obj/item/folder/blue,
 /turf/open/floor/plasteel/blue/side{
-	icon_state = "blue";
 	dir = 9
 	},
 /area/security/courtroom)
@@ -10756,7 +10652,6 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel/red/side{
-	icon_state = "red";
 	dir = 9
 	},
 /area/security/checkpoint/supply)
@@ -10769,7 +10664,6 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel/red/side{
-	icon_state = "red";
 	dir = 1
 	},
 /area/security/checkpoint/supply)
@@ -10778,7 +10672,6 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel/red/side{
-	icon_state = "red";
 	dir = 1
 	},
 /area/security/checkpoint/supply)
@@ -10790,7 +10683,6 @@
 	pixel_x = 32
 	},
 /turf/open/floor/plasteel/red/side{
-	icon_state = "red";
 	dir = 5
 	},
 /area/security/checkpoint/supply)
@@ -10850,7 +10742,6 @@
 	dir = 1
 	},
 /turf/open/floor/plasteel/red/side{
-	icon_state = "red";
 	dir = 6
 	},
 /area/security/brig)
@@ -10862,7 +10753,6 @@
 	network = list("SS13","Security")
 	},
 /turf/open/floor/plasteel/red/side{
-	icon_state = "red";
 	dir = 1
 	},
 /area/security/brig)
@@ -10877,7 +10767,6 @@
 "aHN" = (
 /obj/structure/chair,
 /turf/open/floor/plasteel/red/side{
-	icon_state = "red";
 	dir = 5
 	},
 /area/security/brig)
@@ -10902,7 +10791,6 @@
 	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel/red/side{
-	icon_state = "red";
 	dir = 1
 	},
 /area/security/brig)
@@ -10934,7 +10822,6 @@
 "aHW" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plasteel/blue/side{
-	icon_state = "blue";
 	dir = 4
 	},
 /area/security/courtroom)
@@ -10983,7 +10870,6 @@
 	pixel_y = 32
 	},
 /turf/open/floor/plasteel/neutral/side{
-	icon_state = "neutral";
 	dir = 4
 	},
 /area/crew_quarters/locker)
@@ -11176,7 +11062,6 @@
 /area/security/checkpoint/supply)
 "aIB" = (
 /turf/open/floor/plasteel/red/side{
-	icon_state = "red";
 	dir = 8
 	},
 /area/security/checkpoint/supply)
@@ -11189,7 +11074,6 @@
 	pixel_x = 24
 	},
 /turf/open/floor/plasteel/red/side{
-	icon_state = "red";
 	dir = 4
 	},
 /area/security/checkpoint/supply)
@@ -11224,7 +11108,6 @@
 /obj/effect/landmark/secequipment,
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel/red/side{
-	icon_state = "red";
 	dir = 6
 	},
 /area/security/main)
@@ -11386,7 +11269,6 @@
 /area/crew_quarters/locker)
 "aJf" = (
 /turf/open/floor/plasteel/neutral/side{
-	icon_state = "neutral";
 	dir = 4
 	},
 /area/crew_quarters/locker)
@@ -11583,7 +11465,6 @@
 	},
 /obj/structure/closet/secure_closet/security/cargo,
 /turf/open/floor/plasteel/red/side{
-	icon_state = "red";
 	dir = 10
 	},
 /area/security/checkpoint/supply)
@@ -11625,7 +11506,6 @@
 	network = list("SS13","QM")
 	},
 /turf/open/floor/plasteel/red/side{
-	icon_state = "red";
 	dir = 6
 	},
 /area/security/checkpoint/supply)
@@ -11772,7 +11652,6 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel/neutral/side{
-	icon_state = "neutral";
 	dir = 4
 	},
 /area/crew_quarters/locker)
@@ -12442,7 +12321,6 @@
 	icon_state = "plant-22"
 	},
 /turf/open/floor/plasteel/neutral/side{
-	icon_state = "neutral";
 	dir = 4
 	},
 /area/crew_quarters/locker)
@@ -12827,13 +12705,11 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel/blue/side{
-	icon_state = "blue";
 	dir = 9
 	},
 /area/crew_quarters/heads/hop)
 "aMZ" = (
 /turf/open/floor/plasteel/blue/side{
-	icon_state = "blue";
 	dir = 1
 	},
 /area/crew_quarters/heads/hop)
@@ -12846,7 +12722,6 @@
 	pixel_x = 24
 	},
 /turf/open/floor/plasteel/blue/side{
-	icon_state = "blue";
 	dir = 5
 	},
 /area/crew_quarters/heads/hop)
@@ -13249,7 +13124,6 @@
 	layer = 2.6
 	},
 /turf/open/floor/plasteel/blue/corner{
-	icon_state = "bluecorner";
 	dir = 1
 	},
 /area/crew_quarters/heads/hop)
@@ -13268,7 +13142,6 @@
 	layer = 2.6
 	},
 /turf/open/floor/plasteel/blue/corner{
-	icon_state = "bluecorner";
 	dir = 4
 	},
 /area/crew_quarters/heads/hop)
@@ -13878,7 +13751,6 @@
 	dir = 6
 	},
 /turf/open/floor/plasteel/blue/corner{
-	icon_state = "bluecorner";
 	dir = 4
 	},
 /area/hallway/primary/fore)
@@ -13895,7 +13767,6 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel/blue/corner{
-	icon_state = "bluecorner";
 	dir = 4
 	},
 /area/hallway/primary/fore)
@@ -13913,7 +13784,6 @@
 	icon_state = "pipe-c"
 	},
 /turf/open/floor/plasteel/blue/corner{
-	icon_state = "bluecorner";
 	dir = 4
 	},
 /area/hallway/primary/fore)
@@ -13933,7 +13803,6 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plasteel/blue/corner{
-	icon_state = "bluecorner";
 	dir = 4
 	},
 /area/hallway/primary/fore)
@@ -13945,7 +13814,6 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden,
 /turf/open/floor/plasteel/blue/corner{
-	icon_state = "bluecorner";
 	dir = 4
 	},
 /area/hallway/primary/fore)
@@ -13964,7 +13832,6 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel/blue/corner{
-	icon_state = "bluecorner";
 	dir = 4
 	},
 /area/hallway/primary/fore)
@@ -13978,7 +13845,6 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel/blue/corner{
-	icon_state = "bluecorner";
 	dir = 4
 	},
 /area/hallway/primary/fore)
@@ -19755,7 +19621,6 @@
 /area/crew_quarters/rehab_dome)
 "bcz" = (
 /turf/open/floor/plasteel/neutral/side{
-	icon_state = "neutral";
 	dir = 10
 	},
 /area/crew_quarters/rehab_dome)
@@ -20074,7 +19939,6 @@
 /area/crew_quarters/rehab_dome)
 "bdq" = (
 /turf/open/floor/plasteel/neutral/side{
-	icon_state = "neutral";
 	dir = 5
 	},
 /area/crew_quarters/rehab_dome)
@@ -20087,7 +19951,6 @@
 	},
 /obj/machinery/door/firedoor,
 /turf/open/floor/plasteel/neutral/side{
-	icon_state = "neutral";
 	dir = 10
 	},
 /area/crew_quarters/rehab_dome)
@@ -20427,7 +20290,6 @@
 /obj/structure/disposalpipe/segment,
 /obj/machinery/door/firedoor,
 /turf/open/floor/plasteel/neutral/side{
-	icon_state = "neutral";
 	dir = 5
 	},
 /area/crew_quarters/rehab_dome)
@@ -20440,7 +20302,6 @@
 /area/crew_quarters/rehab_dome)
 "beg" = (
 /turf/open/floor/plasteel/neutral/side{
-	icon_state = "neutral";
 	dir = 10
 	},
 /area/hallway/primary/central)
@@ -20754,7 +20615,6 @@
 /area/crew_quarters/rehab_dome)
 "beV" = (
 /turf/open/floor/plasteel/neutral/side{
-	icon_state = "neutral";
 	dir = 5
 	},
 /area/hallway/primary/central)
@@ -20884,7 +20744,6 @@
 "bfh" = (
 /obj/machinery/holopad,
 /turf/open/floor/plasteel/blue/side{
-	icon_state = "blue";
 	dir = 9
 	},
 /area/ai_monitored/storage/eva)
@@ -20896,14 +20755,12 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plasteel/blue/side{
-	icon_state = "blue";
 	dir = 1
 	},
 /area/ai_monitored/storage/eva)
 "bfj" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plasteel/blue/side{
-	icon_state = "blue";
 	dir = 1
 	},
 /area/ai_monitored/storage/eva)
@@ -20914,14 +20771,12 @@
 	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel/blue/side{
-	icon_state = "blue";
 	dir = 1
 	},
 /area/ai_monitored/storage/eva)
 "bfl" = (
 /obj/structure/tank_dispenser/oxygen,
 /turf/open/floor/plasteel/blue/side{
-	icon_state = "blue";
 	dir = 5
 	},
 /area/ai_monitored/storage/eva)
@@ -21331,7 +21186,6 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plasteel/blue/side{
-	icon_state = "blue";
 	dir = 4
 	},
 /area/hallway/primary/central)
@@ -21361,7 +21215,6 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel/blue/side{
-	icon_state = "blue";
 	dir = 8
 	},
 /area/ai_monitored/storage/eva)
@@ -21420,7 +21273,6 @@
 	pixel_y = 2
 	},
 /turf/open/floor/plasteel/blue/side{
-	icon_state = "blue";
 	dir = 4
 	},
 /area/ai_monitored/storage/eva)
@@ -21893,7 +21745,6 @@
 	dir = 8
 	},
 /turf/open/floor/plasteel/blue/corner{
-	icon_state = "bluecorner";
 	dir = 4
 	},
 /area/hallway/primary/central)
@@ -21902,7 +21753,6 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel/blue/side{
-	icon_state = "blue";
 	dir = 8
 	},
 /area/ai_monitored/storage/eva)
@@ -21932,7 +21782,6 @@
 	pixel_x = 24
 	},
 /turf/open/floor/plasteel/blue/side{
-	icon_state = "blue";
 	dir = 4
 	},
 /area/ai_monitored/storage/eva)
@@ -22211,7 +22060,6 @@
 	},
 /obj/item/stack/sheet/metal/fifty,
 /turf/open/floor/plasteel/blue/side{
-	icon_state = "blue";
 	dir = 10
 	},
 /area/ai_monitored/storage/eva)
@@ -22237,7 +22085,6 @@
 /obj/structure/table,
 /obj/item/storage/toolbox/mechanical,
 /turf/open/floor/plasteel/blue/side{
-	icon_state = "blue";
 	dir = 6
 	},
 /area/ai_monitored/storage/eva)
@@ -24781,7 +24628,6 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel/whitegreen/side{
-	icon_state = "whitegreen";
 	dir = 4
 	},
 /area/medical/virology)
@@ -25233,14 +25079,12 @@
 "bog" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plasteel/whiteblue/side{
-	icon_state = "whiteblue";
 	dir = 1
 	},
 /area/medical/medbay/central)
 "boh" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plasteel/whiteblue/side{
-	icon_state = "whiteblue";
 	dir = 1
 	},
 /area/medical/medbay/central)
@@ -25256,13 +25100,11 @@
 	icon_state = "0-2"
 	},
 /turf/open/floor/plasteel/whiteblue/side{
-	icon_state = "whiteblue";
 	dir = 1
 	},
 /area/medical/patients_rooms)
 "boj" = (
 /turf/open/floor/plasteel/whiteblue/side{
-	icon_state = "whiteblue";
 	dir = 1
 	},
 /area/medical/medbay/central)
@@ -25862,7 +25704,6 @@
 	dir = 8
 	},
 /turf/open/floor/plasteel/red/side{
-	icon_state = "red";
 	dir = 1
 	},
 /area/security/checkpoint/medical)
@@ -25876,7 +25717,6 @@
 	pixel_y = 32
 	},
 /turf/open/floor/plasteel/red/side{
-	icon_state = "red";
 	dir = 1
 	},
 /area/security/checkpoint/medical)
@@ -25893,7 +25733,6 @@
 	pixel_y = 32
 	},
 /turf/open/floor/plasteel/red/side{
-	icon_state = "red";
 	dir = 1
 	},
 /area/security/checkpoint/medical)
@@ -25903,7 +25742,6 @@
 	},
 /obj/structure/closet/secure_closet/security/med,
 /turf/open/floor/plasteel/red/side{
-	icon_state = "red";
 	dir = 5
 	},
 /area/security/checkpoint/medical)
@@ -25938,7 +25776,6 @@
 	},
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel/whiteblue/side{
-	icon_state = "whiteblue";
 	dir = 1
 	},
 /area/medical/medbay/central)
@@ -26062,7 +25899,6 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel/whiteblue/side{
-	icon_state = "whiteblue";
 	dir = 1
 	},
 /area/medical/medbay/central)
@@ -26094,7 +25930,6 @@
 "bpN" = (
 /obj/machinery/vending/medical,
 /turf/open/floor/plasteel/whiteblue/side{
-	icon_state = "whiteblue";
 	dir = 1
 	},
 /area/medical/medbay/central)
@@ -26510,7 +26345,6 @@
 	icon_state = "2-4"
 	},
 /turf/open/floor/plasteel/red/side{
-	icon_state = "red";
 	dir = 8
 	},
 /area/security/checkpoint/medical)
@@ -26552,7 +26386,6 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel/red/side{
-	icon_state = "red";
 	dir = 4
 	},
 /area/security/checkpoint/medical)
@@ -26591,7 +26424,6 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel/whiteblue/side{
-	icon_state = "whiteblue";
 	dir = 8
 	},
 /area/medical/medbay/central)
@@ -26712,7 +26544,6 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel/whitegreen/side{
-	icon_state = "whitegreen";
 	dir = 4
 	},
 /area/medical/medbay/central)
@@ -26723,7 +26554,6 @@
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on,
 /turf/open/floor/plasteel/whitegreen/side{
-	icon_state = "whitegreen";
 	dir = 9
 	},
 /area/medical/virology)
@@ -26758,7 +26588,6 @@
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on,
 /turf/open/floor/plasteel/whitegreen/side{
-	icon_state = "whitegreen";
 	dir = 5
 	},
 /area/medical/virology)
@@ -26770,7 +26599,6 @@
 /obj/item/storage/box/gloves,
 /obj/structure/table/glass,
 /turf/open/floor/plasteel/whitegreen/side{
-	icon_state = "whitegreen";
 	dir = 5
 	},
 /area/medical/virology)
@@ -26956,7 +26784,6 @@
 	},
 /obj/machinery/door/airlock/glass,
 /turf/open/floor/plasteel/green/corner{
-	icon_state = "greencorner";
 	dir = 8
 	},
 /area/hallway/primary/port)
@@ -26993,7 +26820,6 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel/green/corner{
-	icon_state = "greencorner";
 	dir = 8
 	},
 /area/hallway/primary/port)
@@ -27002,7 +26828,6 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel/green/corner{
-	icon_state = "greencorner";
 	dir = 8
 	},
 /area/hallway/primary/port)
@@ -27015,7 +26840,6 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel/green/corner{
-	icon_state = "greencorner";
 	dir = 8
 	},
 /area/hallway/primary/port)
@@ -27458,7 +27282,6 @@
 	},
 /obj/structure/cable/orange,
 /turf/open/floor/plasteel/red/side{
-	icon_state = "red";
 	dir = 8
 	},
 /area/security/checkpoint/medical)
@@ -27486,7 +27309,6 @@
 	},
 /obj/item/twohanded/required/kirbyplants/random,
 /turf/open/floor/plasteel/red/side{
-	icon_state = "red";
 	dir = 6
 	},
 /area/security/checkpoint/medical)
@@ -27512,7 +27334,6 @@
 	},
 /obj/item/clothing/mask/breath,
 /turf/open/floor/plasteel/whiteblue/side{
-	icon_state = "whiteblue";
 	dir = 8
 	},
 /area/medical/medbay/central)
@@ -27590,7 +27411,6 @@
 	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel/whitegreen/side{
-	icon_state = "whitegreen";
 	dir = 4
 	},
 /area/medical/medbay/central)
@@ -27629,7 +27449,6 @@
 	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel/whitegreen/side{
-	icon_state = "whitegreen";
 	dir = 4
 	},
 /area/medical/virology)
@@ -27643,7 +27462,6 @@
 	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel/whitegreen/side{
-	icon_state = "whitegreen";
 	dir = 8
 	},
 /area/medical/virology)
@@ -27782,7 +27600,6 @@
 /area/hydroponics)
 "bte" = (
 /turf/open/floor/plasteel/green/corner{
-	icon_state = "greencorner";
 	dir = 8
 	},
 /area/hydroponics)
@@ -28149,7 +27966,6 @@
 	pixel_x = -28
 	},
 /turf/open/floor/plasteel/red/side{
-	icon_state = "red";
 	dir = 10
 	},
 /area/security/checkpoint/medical)
@@ -28235,7 +28051,6 @@
 	},
 /obj/item/twohanded/required/kirbyplants/random,
 /turf/open/floor/plasteel/whitegreen/side{
-	icon_state = "whitegreen";
 	dir = 4
 	},
 /area/medical/medbay/central)
@@ -28253,7 +28068,6 @@
 	network = list("SS13","CMO")
 	},
 /turf/open/floor/plasteel/whitegreen/side{
-	icon_state = "whitegreen";
 	dir = 8
 	},
 /area/medical/virology)
@@ -28273,7 +28087,6 @@
 	dir = 5
 	},
 /turf/open/floor/plasteel/whitegreen/side{
-	icon_state = "whitegreen";
 	dir = 6
 	},
 /area/medical/virology)
@@ -28300,7 +28113,6 @@
 	icon_state = "plant-25"
 	},
 /turf/open/floor/plasteel/whitegreen/side{
-	icon_state = "whitegreen";
 	dir = 8
 	},
 /area/medical/virology)
@@ -28607,7 +28419,6 @@
 /area/hallway/primary/central)
 "buR" = (
 /turf/open/floor/plasteel/yellow/corner{
-	icon_state = "yellowcorner";
 	dir = 8
 	},
 /area/hallway/primary/central)
@@ -28751,7 +28562,6 @@
 	pixel_x = 24
 	},
 /turf/open/floor/plasteel/yellow/corner{
-	icon_state = "yellowcorner";
 	dir = 8
 	},
 /area/hallway/primary/central)
@@ -29004,14 +28814,12 @@
 /obj/structure/chair,
 /obj/effect/landmark/start/assistant,
 /turf/open/floor/plasteel/whiteblue/side{
-	icon_state = "whiteblue";
 	dir = 1
 	},
 /area/medical/medbay/central)
 "bvC" = (
 /obj/structure/reagent_dispensers/water_cooler,
 /turf/open/floor/plasteel/whiteblue/corner{
-	icon_state = "whitebluecorner";
 	dir = 4
 	},
 /area/medical/medbay/central)
@@ -29185,7 +28993,6 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel/green/corner{
-	icon_state = "greencorner";
 	dir = 8
 	},
 /area/hydroponics)
@@ -29198,7 +29005,6 @@
 /area/hydroponics)
 "bwa" = (
 /turf/open/floor/plasteel/darkgreen/side{
-	icon_state = "darkgreen";
 	dir = 8
 	},
 /area/hydroponics)
@@ -29863,7 +29669,6 @@
 	dir = 9
 	},
 /turf/open/floor/plasteel/yellow/corner{
-	icon_state = "yellowcorner";
 	dir = 4
 	},
 /area/engine/break_room)
@@ -29875,7 +29680,6 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plasteel/yellow/side{
-	icon_state = "yellow";
 	dir = 1
 	},
 /area/engine/break_room)
@@ -29884,7 +29688,6 @@
 	icon_state = "plant-22"
 	},
 /turf/open/floor/plasteel/yellow/corner{
-	icon_state = "yellowcorner";
 	dir = 1
 	},
 /area/engine/break_room)
@@ -29983,7 +29786,6 @@
 	},
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel/yellow/corner{
-	icon_state = "yellowcorner";
 	dir = 4
 	},
 /area/engine/break_room)
@@ -29996,7 +29798,6 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel/yellow/side{
-	icon_state = "yellow";
 	dir = 1
 	},
 /area/engine/break_room)
@@ -30012,7 +29813,6 @@
 	icon_state = "2-8"
 	},
 /turf/open/floor/plasteel/yellow/corner{
-	icon_state = "yellowcorner";
 	dir = 1
 	},
 /area/engine/break_room)
@@ -30408,7 +30208,6 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel/yellow/corner{
-	icon_state = "yellowcorner";
 	dir = 8
 	},
 /area/engine/break_room)
@@ -30475,7 +30274,6 @@
 	dir = 8
 	},
 /turf/open/floor/plasteel/white/side{
-	icon_state = "whitehall";
 	dir = 4
 	},
 /area/medical/medbay/central)
@@ -30748,7 +30546,6 @@
 	pixel_x = 29
 	},
 /turf/open/floor/plasteel/yellow/side{
-	icon_state = "yellow";
 	dir = 4
 	},
 /area/engine/break_room)
@@ -30802,7 +30599,6 @@
 	pixel_x = -28
 	},
 /turf/open/floor/plasteel/yellow/side{
-	icon_state = "yellow";
 	dir = 8
 	},
 /area/engine/break_room)
@@ -30842,7 +30638,6 @@
 	pixel_y = 32
 	},
 /turf/open/floor/plasteel/red/side{
-	icon_state = "red";
 	dir = 9
 	},
 /area/security/checkpoint/engineering)
@@ -30854,7 +30649,6 @@
 	pixel_y = 20
 	},
 /turf/open/floor/plasteel/red/side{
-	icon_state = "red";
 	dir = 1
 	},
 /area/security/checkpoint/engineering)
@@ -30874,7 +30668,6 @@
 	pixel_y = 32
 	},
 /turf/open/floor/plasteel/red/side{
-	icon_state = "red";
 	dir = 5
 	},
 /area/security/checkpoint/engineering)
@@ -30930,7 +30723,6 @@
 	dir = 8
 	},
 /turf/open/floor/plasteel/white/side{
-	icon_state = "whitehall";
 	dir = 4
 	},
 /area/medical/medbay/central)
@@ -30988,7 +30780,6 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel/whiteblue/side{
-	icon_state = "whiteblue";
 	dir = 1
 	},
 /area/medical/medbay/central)
@@ -31142,7 +30933,6 @@
 	dir = 8
 	},
 /turf/open/floor/plasteel/darkgreen/side{
-	icon_state = "darkgreen";
 	dir = 8
 	},
 /area/hydroponics)
@@ -31308,7 +31098,6 @@
 /obj/structure/table,
 /obj/machinery/microwave,
 /turf/open/floor/plasteel/yellow/side{
-	icon_state = "yellow";
 	dir = 4
 	},
 /area/engine/break_room)
@@ -31503,7 +31292,6 @@
 	},
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel/yellow/side{
-	icon_state = "yellow";
 	dir = 8
 	},
 /area/engine/break_room)
@@ -31538,7 +31326,6 @@
 	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel/red/side{
-	icon_state = "red";
 	dir = 4
 	},
 /area/engine/break_room)
@@ -31573,7 +31360,6 @@
 	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel/red/side{
-	icon_state = "red";
 	dir = 8
 	},
 /area/security/checkpoint/engineering)
@@ -31593,7 +31379,6 @@
 	icon_state = "1-8"
 	},
 /turf/open/floor/plasteel/red/side{
-	icon_state = "red";
 	dir = 4
 	},
 /area/security/checkpoint/engineering)
@@ -31654,7 +31439,6 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel/whiteblue/side{
-	icon_state = "whiteblue";
 	dir = 4
 	},
 /area/medical/medbay/central)
@@ -31746,7 +31530,6 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel/whitepurple/side{
-	icon_state = "whitepurple";
 	dir = 4
 	},
 /area/medical/medbay/central)
@@ -31918,7 +31701,6 @@
 /obj/structure/table,
 /obj/item/storage/box/cups,
 /turf/open/floor/plasteel/yellow/side{
-	icon_state = "yellow";
 	dir = 4
 	},
 /area/engine/break_room)
@@ -32056,7 +31838,6 @@
 	network = list("SS13","CE")
 	},
 /turf/open/floor/plasteel/yellow/side{
-	icon_state = "yellow";
 	dir = 8
 	},
 /area/engine/break_room)
@@ -32080,7 +31861,6 @@
 /area/engine/break_room)
 "bBZ" = (
 /turf/open/floor/plasteel/red/side{
-	icon_state = "red";
 	dir = 4
 	},
 /area/engine/break_room)
@@ -32099,7 +31879,6 @@
 	},
 /obj/effect/landmark/start/depsec/engineering,
 /turf/open/floor/plasteel/red/side{
-	icon_state = "red";
 	dir = 8
 	},
 /area/security/checkpoint/engineering)
@@ -32119,7 +31898,6 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel/red/side{
-	icon_state = "red";
 	dir = 4
 	},
 /area/security/checkpoint/engineering)
@@ -32328,7 +32106,6 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel/darkgreen/side{
-	icon_state = "darkgreen";
 	dir = 8
 	},
 /area/hydroponics)
@@ -32393,7 +32170,6 @@
 "bCL" = (
 /obj/structure/reagent_dispensers/water_cooler,
 /turf/open/floor/plasteel/yellow/side{
-	icon_state = "yellow";
 	dir = 4
 	},
 /area/engine/break_room)
@@ -32488,7 +32264,6 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel/yellow/side{
-	icon_state = "yellow";
 	dir = 8
 	},
 /area/engine/break_room)
@@ -32497,7 +32272,6 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel/red/side{
-	icon_state = "red";
 	dir = 4
 	},
 /area/engine/break_room)
@@ -32521,7 +32295,6 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel/red/side{
-	icon_state = "red";
 	dir = 8
 	},
 /area/security/checkpoint/engineering)
@@ -32540,7 +32313,6 @@
 	},
 /obj/structure/table,
 /turf/open/floor/plasteel/red/side{
-	icon_state = "red";
 	dir = 4
 	},
 /area/security/checkpoint/engineering)
@@ -32569,7 +32341,6 @@
 	},
 /obj/effect/landmark/start/chemist,
 /turf/open/floor/plasteel/whiteyellow/side{
-	icon_state = "whiteyellow";
 	dir = 1
 	},
 /area/medical/chemistry)
@@ -32582,13 +32353,11 @@
 /obj/item/reagent_containers/glass/beaker/large,
 /obj/item/reagent_containers/dropper,
 /turf/open/floor/plasteel/whiteyellow/side{
-	icon_state = "whiteyellow";
 	dir = 1
 	},
 /area/medical/chemistry)
 "bDl" = (
 /turf/open/floor/plasteel/whiteyellow/side{
-	icon_state = "whiteyellow";
 	dir = 1
 	},
 /area/medical/chemistry)
@@ -32599,7 +32368,6 @@
 	icon_state = "pipe-c"
 	},
 /turf/open/floor/plasteel/whiteblue/corner{
-	icon_state = "whitebluecorner";
 	dir = 8
 	},
 /area/medical/medbay/central)
@@ -32868,7 +32636,6 @@
 	pixel_x = 24
 	},
 /turf/open/floor/plasteel/yellow/side{
-	icon_state = "yellow";
 	dir = 4
 	},
 /area/engine/break_room)
@@ -32966,7 +32733,6 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel/yellow/corner{
-	icon_state = "yellowcorner";
 	dir = 1
 	},
 /area/engine/break_room)
@@ -33017,7 +32783,6 @@
 	pixel_y = -24
 	},
 /turf/open/floor/plasteel/red/side{
-	icon_state = "red";
 	dir = 10
 	},
 /area/security/checkpoint/engineering)
@@ -33040,7 +32805,6 @@
 	icon_state = "plant-21"
 	},
 /turf/open/floor/plasteel/red/side{
-	icon_state = "red";
 	dir = 6
 	},
 /area/security/checkpoint/engineering)
@@ -33060,13 +32824,11 @@
 "bEs" = (
 /obj/machinery/chem_master,
 /turf/open/floor/plasteel/whiteyellow/corner{
-	icon_state = "whiteyellowcorner";
 	dir = 1
 	},
 /area/medical/chemistry)
 "bEt" = (
 /turf/open/floor/plasteel/whiteyellow/corner{
-	icon_state = "whiteyellowcorner";
 	dir = 1
 	},
 /area/medical/chemistry)
@@ -33079,7 +32841,6 @@
 /obj/item/reagent_containers/glass/beaker/large,
 /obj/item/reagent_containers/dropper,
 /turf/open/floor/plasteel/whiteyellow/corner{
-	icon_state = "whiteyellowcorner";
 	dir = 1
 	},
 /area/medical/chemistry)
@@ -33104,7 +32865,6 @@
 	icon_state = "pipe-c"
 	},
 /turf/open/floor/plasteel/whiteblue/side{
-	icon_state = "whiteblue";
 	dir = 8
 	},
 /area/medical/medbay/central)
@@ -33162,7 +32922,6 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel/whitepurple/side{
-	icon_state = "whitepurple";
 	dir = 9
 	},
 /area/medical/genetics)
@@ -33181,8 +32940,7 @@
 	pixel_y = 23
 	},
 /turf/open/floor/plasteel/whitepurple/side{
-	dir = 5;
-	initial_gas_mix = "o2=22;n2=82;TEMP=293.15"
+	dir = 5
 	},
 /area/medical/genetics)
 "bEG" = (
@@ -33376,7 +33134,6 @@
 "bFe" = (
 /obj/structure/tank_dispenser,
 /turf/open/floor/plasteel/yellow/side{
-	icon_state = "yellow";
 	dir = 4
 	},
 /area/engine/atmos)
@@ -33391,7 +33148,6 @@
 "bFg" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden,
 /turf/open/floor/plasteel/yellow/side{
-	icon_state = "yellow";
 	dir = 8
 	},
 /area/engine/break_room)
@@ -33418,7 +33174,6 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel/yellow/side{
-	icon_state = "yellow";
 	dir = 4
 	},
 /area/engine/break_room)
@@ -33579,7 +33334,6 @@
 	},
 /obj/structure/closet/secure_closet/engineering_electrical,
 /turf/open/floor/plasteel/yellow/side{
-	icon_state = "yellow";
 	dir = 4
 	},
 /area/engine/engineering)
@@ -33601,7 +33355,6 @@
 	icon_state = "pipe-c"
 	},
 /turf/open/floor/plasteel/yellow/corner{
-	icon_state = "yellowcorner";
 	dir = 8
 	},
 /area/engine/break_room)
@@ -33619,7 +33372,6 @@
 "bFC" = (
 /obj/machinery/vending/cola,
 /turf/open/floor/plasteel/yellow/side{
-	icon_state = "yellow";
 	dir = 4
 	},
 /area/engine/break_room)
@@ -33664,7 +33416,6 @@
 	pixel_x = -32
 	},
 /turf/open/floor/plasteel/whiteyellow/side{
-	icon_state = "whiteyellow";
 	dir = 8
 	},
 /area/medical/chemistry)
@@ -33715,7 +33466,6 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel/whiteyellow/side{
-	icon_state = "whiteyellow";
 	dir = 4
 	},
 /area/medical/chemistry)
@@ -33742,7 +33492,6 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel/whiteblue/side{
-	icon_state = "whiteblue";
 	dir = 8
 	},
 /area/medical/medbay/central)
@@ -33790,7 +33539,6 @@
 /obj/machinery/computer/scan_consolenew,
 /obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel/whitepurple/side{
-	icon_state = "whitepurple";
 	dir = 4
 	},
 /area/medical/genetics)
@@ -33916,7 +33664,6 @@
 	name = "Forbidden Knowledge"
 	},
 /turf/open/floor/plasteel/chapel{
-	icon_state = "chapel";
 	dir = 1
 	},
 /area/library)
@@ -33939,7 +33686,6 @@
 /obj/item/stack/packageWrap,
 /obj/item/device/destTagger,
 /turf/open/floor/plasteel/chapel{
-	icon_state = "chapel";
 	dir = 4
 	},
 /area/library)
@@ -34084,7 +33830,6 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel/yellow/side{
-	icon_state = "yellow";
 	dir = 4
 	},
 /area/engine/atmos)
@@ -34109,7 +33854,6 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel/yellow/side{
-	icon_state = "yellow";
 	dir = 8
 	},
 /area/engine/break_room)
@@ -34159,7 +33903,6 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel/yellow/side{
-	icon_state = "yellow";
 	dir = 4
 	},
 /area/engine/break_room)
@@ -34195,7 +33938,6 @@
 	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel/yellow/side{
-	icon_state = "yellow";
 	dir = 8
 	},
 /area/engine/engineering)
@@ -34357,7 +34099,6 @@
 	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel/yellow/side{
-	icon_state = "yellow";
 	dir = 4
 	},
 /area/engine/engineering)
@@ -34397,7 +34138,6 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel/yellow/side{
-	icon_state = "yellow";
 	dir = 8
 	},
 /area/engine/break_room)
@@ -34441,7 +34181,6 @@
 	dir = 10
 	},
 /turf/open/floor/plasteel/yellow/side{
-	icon_state = "yellow";
 	dir = 4
 	},
 /area/engine/break_room)
@@ -34459,7 +34198,6 @@
 	name = "Na2CO3"
 	},
 /turf/open/floor/plasteel/whiteyellow/side{
-	icon_state = "whiteyellow";
 	dir = 8
 	},
 /area/medical/chemistry)
@@ -34467,7 +34205,6 @@
 /obj/structure/disposalpipe/segment,
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/plasteel/whiteyellow/side{
-	icon_state = "whiteyellow";
 	dir = 1
 	},
 /area/medical/chemistry)
@@ -34476,7 +34213,6 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel/whiteyellow/side{
-	icon_state = "whiteyellow";
 	dir = 1
 	},
 /area/medical/chemistry)
@@ -34485,7 +34221,6 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel/whiteyellow/side{
-	icon_state = "whiteyellow";
 	dir = 4
 	},
 /area/medical/chemistry)
@@ -34503,7 +34238,6 @@
 	},
 /obj/item/twohanded/required/kirbyplants/random,
 /turf/open/floor/plasteel/whiteblue/side{
-	icon_state = "whiteblue";
 	dir = 10
 	},
 /area/medical/medbay/central)
@@ -34515,7 +34249,6 @@
 "bHt" = (
 /obj/item/twohanded/required/kirbyplants/random,
 /turf/open/floor/plasteel/whiteblue/side{
-	icon_state = "whiteblue";
 	dir = 6
 	},
 /area/medical/medbay/central)
@@ -34618,7 +34351,6 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel/whitepurple/side{
-	icon_state = "whitepurple";
 	dir = 1
 	},
 /area/medical/genetics)
@@ -34652,7 +34384,6 @@
 /obj/machinery/dna_scannernew,
 /obj/effect/turf_decal/delivery,
 /turf/open/floor/plasteel/whitepurple/side{
-	icon_state = "whitepurple";
 	dir = 4
 	},
 /area/medical/genetics)
@@ -34890,7 +34621,6 @@
 /obj/machinery/atmospherics/components/unary/portables_connector/visible,
 /obj/machinery/portable_atmospherics/scrubber,
 /turf/open/floor/plasteel/yellow/side{
-	icon_state = "yellow";
 	dir = 10
 	},
 /area/engine/break_room)
@@ -34917,13 +34647,11 @@
 	dir = 1
 	},
 /turf/open/floor/plasteel/yellow/side{
-	icon_state = "yellow";
 	dir = 6
 	},
 /area/engine/break_room)
 "bIt" = (
 /turf/open/floor/plasteel/yellow/side{
-	icon_state = "yellow";
 	dir = 8
 	},
 /area/engine/engineering)
@@ -34985,7 +34713,6 @@
 /area/engine/engineering)
 "bIC" = (
 /turf/open/floor/plasteel/yellow/side{
-	icon_state = "yellow";
 	dir = 4
 	},
 /area/engine/engineering)
@@ -34995,7 +34722,6 @@
 	dir = 1
 	},
 /turf/open/floor/plasteel/yellow/side{
-	icon_state = "yellow";
 	dir = 10
 	},
 /area/engine/break_room)
@@ -35022,7 +34748,6 @@
 /obj/item/stack/packageWrap,
 /obj/item/device/destTagger,
 /turf/open/floor/plasteel/yellow/side{
-	icon_state = "yellow";
 	dir = 6
 	},
 /area/engine/break_room)
@@ -35062,7 +34787,6 @@
 	pixel_x = -24
 	},
 /turf/open/floor/plasteel/whiteyellow/corner{
-	icon_state = "whiteyellowcorner";
 	dir = 8
 	},
 /area/medical/chemistry)
@@ -35074,7 +34798,6 @@
 /obj/item/stack/packageWrap,
 /obj/machinery/light,
 /turf/open/floor/plasteel/whiteyellow/corner{
-	icon_state = "whiteyellowcorner";
 	dir = 8
 	},
 /area/medical/chemistry)
@@ -35084,7 +34807,6 @@
 /obj/item/stack/cable_coil/random,
 /obj/item/book/manual/wiki/chemistry,
 /turf/open/floor/plasteel/whiteyellow/corner{
-	icon_state = "whiteyellowcorner";
 	dir = 8
 	},
 /area/medical/chemistry)
@@ -35099,7 +34821,6 @@
 	network = list("SS13","CMO")
 	},
 /turf/open/floor/plasteel/whiteyellow/corner{
-	icon_state = "whiteyellowcorner";
 	dir = 8
 	},
 /area/medical/chemistry)
@@ -35213,7 +34934,6 @@
 /area/medical/genetics)
 "bJe" = (
 /turf/open/floor/plasteel/whitepurple/side{
-	icon_state = "whitepurple";
 	dir = 4
 	},
 /area/medical/genetics)
@@ -35275,7 +34995,6 @@
 "bJs" = (
 /obj/machinery/light/small,
 /turf/open/floor/plasteel/chapel{
-	icon_state = "chapel";
 	dir = 8
 	},
 /area/library)
@@ -35420,7 +35139,6 @@
 	},
 /obj/machinery/vending/tool,
 /turf/open/floor/plasteel/yellow/side{
-	icon_state = "yellow";
 	dir = 8
 	},
 /area/engine/engineering)
@@ -35501,7 +35219,6 @@
 	network = list("SS13","CE")
 	},
 /turf/open/floor/plasteel/yellow/side{
-	icon_state = "yellow";
 	dir = 4
 	},
 /area/engine/engineering)
@@ -35538,7 +35255,6 @@
 	},
 /obj/structure/closet/secure_closet/medical3,
 /turf/open/floor/plasteel/whiteblue/corner{
-	icon_state = "whitebluecorner";
 	dir = 8
 	},
 /area/medical/medbay/zone2)
@@ -35549,7 +35265,6 @@
 	},
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel/whiteblue/corner{
-	icon_state = "whitebluecorner";
 	dir = 8
 	},
 /area/medical/medbay/zone2)
@@ -35558,7 +35273,6 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel/whiteblue/corner{
-	icon_state = "whitebluecorner";
 	dir = 8
 	},
 /area/medical/medbay/zone2)
@@ -35567,7 +35281,6 @@
 	dir = 8
 	},
 /turf/open/floor/plasteel/whiteblue/corner{
-	icon_state = "whitebluecorner";
 	dir = 8
 	},
 /area/medical/medbay/zone2)
@@ -36025,7 +35738,6 @@
 	pixel_y = 2
 	},
 /turf/open/floor/plasteel/whitepurple/side{
-	icon_state = "whitepurple";
 	dir = 10
 	},
 /area/medical/genetics)
@@ -36067,7 +35779,6 @@
 /obj/machinery/dna_scannernew,
 /obj/effect/turf_decal/delivery,
 /turf/open/floor/plasteel/whitepurple/side{
-	icon_state = "whitepurple";
 	dir = 6
 	},
 /area/medical/genetics)
@@ -36302,7 +36013,6 @@
 "bLW" = (
 /obj/machinery/vending/engivend,
 /turf/open/floor/plasteel/yellow/side{
-	icon_state = "yellow";
 	dir = 10
 	},
 /area/engine/engineering)
@@ -36410,7 +36120,6 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel/yellow/side{
-	icon_state = "yellow";
 	dir = 10
 	},
 /area/engine/engineering)
@@ -36487,7 +36196,6 @@
 "bMk" = (
 /obj/structure/closet/firecloset/full,
 /turf/open/floor/plasteel/yellow/side{
-	icon_state = "yellow";
 	dir = 6
 	},
 /area/engine/engineering)
@@ -36768,7 +36476,6 @@
 	},
 /obj/structure/table/glass,
 /turf/open/floor/plasteel/whiteblue/side{
-	icon_state = "whiteblue";
 	dir = 10
 	},
 /area/medical/medbay/zone2)
@@ -37001,7 +36708,6 @@
 "bNp" = (
 /obj/machinery/atmospherics/pipe/simple/yellow/visible,
 /turf/open/floor/plasteel/yellow/side{
-	icon_state = "yellow";
 	dir = 8
 	},
 /area/engine/atmos)
@@ -37386,7 +37092,6 @@
 /obj/machinery/atmospherics/pipe/simple/yellow/visible,
 /obj/machinery/meter,
 /turf/open/floor/plasteel/yellow/side{
-	icon_state = "yellow";
 	dir = 8
 	},
 /area/engine/atmos)
@@ -37406,7 +37111,6 @@
 "bOo" = (
 /obj/machinery/atmospherics/pipe/simple/general/visible,
 /turf/open/floor/plasteel/yellow/side{
-	icon_state = "yellow";
 	dir = 8
 	},
 /area/engine/atmos)
@@ -37499,7 +37203,6 @@
 	icon_state = "pipe-c"
 	},
 /turf/open/floor/plasteel/yellow/side{
-	icon_state = "yellow";
 	dir = 9
 	},
 /area/engine/engine_smes)
@@ -37524,7 +37227,6 @@
 	icon_state = "2-8"
 	},
 /turf/open/floor/plasteel/yellow/side{
-	icon_state = "yellow";
 	dir = 1
 	},
 /area/engine/engine_smes)
@@ -37538,7 +37240,6 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel/yellow/side{
-	icon_state = "yellow";
 	dir = 1
 	},
 /area/engine/engine_smes)
@@ -37553,7 +37254,6 @@
 	dir = 8
 	},
 /turf/open/floor/plasteel/yellow/side{
-	icon_state = "yellow";
 	dir = 1
 	},
 /area/engine/engine_smes)
@@ -37565,7 +37265,6 @@
 	},
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel/yellow/side{
-	icon_state = "yellow";
 	dir = 1
 	},
 /area/engine/engine_smes)
@@ -37577,7 +37276,6 @@
 	},
 /obj/structure/table,
 /turf/open/floor/plasteel/yellow/side{
-	icon_state = "yellow";
 	dir = 1
 	},
 /area/engine/engine_smes)
@@ -37594,7 +37292,6 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plasteel/yellow/side{
-	icon_state = "yellow";
 	dir = 1
 	},
 /area/engine/engine_smes)
@@ -37981,7 +37678,6 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/yellow/visible,
 /turf/open/floor/plasteel/yellow/side{
-	icon_state = "yellow";
 	dir = 8
 	},
 /area/engine/atmos)
@@ -38078,7 +37774,6 @@
 /obj/structure/table,
 /obj/item/book/manual/engineering_particle_accelerator,
 /turf/open/floor/plasteel/yellow/side{
-	icon_state = "yellow";
 	dir = 8
 	},
 /area/engine/engine_smes)
@@ -38460,7 +38155,6 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plasteel/yellow/side{
-	icon_state = "yellow";
 	dir = 8
 	},
 /area/engine/atmos)
@@ -38539,7 +38233,6 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel/yellow/side{
-	icon_state = "yellow";
 	dir = 8
 	},
 /area/engine/engine_smes)
@@ -38866,7 +38559,6 @@
 	},
 /obj/machinery/meter,
 /turf/open/floor/plasteel/yellow/side{
-	icon_state = "yellow";
 	dir = 4
 	},
 /area/engine/atmos)
@@ -38882,7 +38574,6 @@
 /obj/machinery/portable_atmospherics/canister,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plasteel/yellow/side{
-	icon_state = "yellow";
 	dir = 8
 	},
 /area/engine/atmos)
@@ -38929,7 +38620,6 @@
 	icon_state = "2-4"
 	},
 /turf/open/floor/plasteel/yellow/side{
-	icon_state = "yellow";
 	dir = 10
 	},
 /area/engine/engine_smes)
@@ -38989,14 +38679,12 @@
 	pixel_y = -29
 	},
 /turf/open/floor/plasteel/yellow/side{
-	icon_state = "yellow";
 	dir = 6
 	},
 /area/engine/engine_smes)
 "bRK" = (
 /obj/machinery/suit_storage_unit/engine,
 /turf/open/floor/plasteel/yellow/side{
-	icon_state = "yellow";
 	dir = 10
 	},
 /area/engine/engine_smes)
@@ -39007,7 +38695,6 @@
 "bRM" = (
 /obj/machinery/suit_storage_unit/engine,
 /turf/open/floor/plasteel/yellow/side{
-	icon_state = "yellow";
 	dir = 6
 	},
 /area/engine/engine_smes)
@@ -39207,7 +38894,6 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel/yellow/side{
-	icon_state = "yellow";
 	dir = 4
 	},
 /area/engine/atmos)
@@ -39456,7 +39142,6 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel/yellow/side{
-	icon_state = "yellow";
 	dir = 8
 	},
 /area/engine/atmos)
@@ -39484,7 +39169,6 @@
 	dir = 10
 	},
 /turf/open/floor/plasteel/yellow/side{
-	icon_state = "yellow";
 	dir = 4
 	},
 /area/engine/atmos)
@@ -39497,7 +39181,6 @@
 "bTd" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plasteel/yellow/side{
-	icon_state = "yellow";
 	dir = 8
 	},
 /area/engine/atmos)
@@ -39655,7 +39338,6 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel/yellow/side{
-	icon_state = "yellow";
 	dir = 8
 	},
 /area/engine/atmos)
@@ -39672,7 +39354,6 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel/yellow/side{
-	icon_state = "yellow";
 	dir = 4
 	},
 /area/engine/atmos)
@@ -39692,7 +39373,6 @@
 	on = 0
 	},
 /turf/open/floor/plasteel/yellow/side{
-	icon_state = "yellow";
 	dir = 8
 	},
 /area/engine/atmos)
@@ -39982,7 +39662,6 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel/yellow/side{
-	icon_state = "yellow";
 	dir = 6
 	},
 /area/engine/atmos)
@@ -39991,7 +39670,6 @@
 	dir = 6
 	},
 /turf/open/floor/plasteel/yellow/side{
-	icon_state = "yellow";
 	dir = 8
 	},
 /area/engine/atmos)
@@ -40155,7 +39833,6 @@
 	dir = 8
 	},
 /turf/open/floor/plasteel/yellow/side{
-	icon_state = "yellow";
 	dir = 10
 	},
 /area/engine/atmos)
@@ -40454,7 +40131,6 @@
 	on = 1
 	},
 /turf/open/floor/plasteel/yellow/side{
-	icon_state = "yellow";
 	dir = 8
 	},
 /area/engine/atmos)
@@ -40535,7 +40211,6 @@
 	dir = 5
 	},
 /turf/open/floor/plasteel/chapel{
-	icon_state = "chapel";
 	dir = 1
 	},
 /area/chapel/main)
@@ -40544,19 +40219,16 @@
 	dir = 1
 	},
 /turf/open/floor/plasteel/chapel{
-	icon_state = "chapel";
 	dir = 4
 	},
 /area/chapel/main)
 "bVM" = (
 /turf/open/floor/plasteel/chapel{
-	icon_state = "chapel";
 	dir = 1
 	},
 /area/chapel/main)
 "bVN" = (
 /turf/open/floor/plasteel/chapel{
-	icon_state = "chapel";
 	dir = 4
 	},
 /area/chapel/main)
@@ -40581,7 +40253,6 @@
 	dir = 1
 	},
 /turf/open/floor/plasteel/chapel{
-	icon_state = "chapel";
 	dir = 1
 	},
 /area/chapel/main)
@@ -40651,7 +40322,6 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel/yellow/side{
-	icon_state = "yellow";
 	dir = 10
 	},
 /area/engine/atmos)
@@ -40717,7 +40387,6 @@
 /area/chapel/main)
 "bWl" = (
 /turf/open/floor/plasteel/chapel{
-	icon_state = "chapel";
 	dir = 8
 	},
 /area/chapel/main)
@@ -41319,7 +40988,6 @@
 	icon_state = "pipe-c"
 	},
 /turf/open/floor/plasteel/chapel{
-	icon_state = "chapel";
 	dir = 1
 	},
 /area/chapel/main)
@@ -41328,7 +40996,6 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel/chapel{
-	icon_state = "chapel";
 	dir = 4
 	},
 /area/chapel/main)
@@ -41343,7 +41010,6 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel/chapel{
-	icon_state = "chapel";
 	dir = 1
 	},
 /area/chapel/main)
@@ -41508,7 +41174,6 @@
 	dir = 1
 	},
 /turf/open/floor/plasteel/chapel{
-	icon_state = "chapel";
 	dir = 8
 	},
 /area/chapel/main)
@@ -41523,7 +41188,6 @@
 "bYz" = (
 /obj/machinery/light,
 /turf/open/floor/plasteel/chapel{
-	icon_state = "chapel";
 	dir = 8
 	},
 /area/chapel/main)
@@ -43718,14 +43382,12 @@
 "cen" = (
 /obj/structure/chair,
 /turf/open/floor/plasteel/red/side{
-	icon_state = "red";
 	dir = 9
 	},
 /area/hallway/secondary/exit)
 "ceo" = (
 /obj/structure/chair,
 /turf/open/floor/plasteel/red/side{
-	icon_state = "red";
 	dir = 1
 	},
 /area/hallway/secondary/exit)
@@ -43735,7 +43397,6 @@
 	dir = 1
 	},
 /turf/open/floor/plasteel/red/side{
-	icon_state = "red";
 	dir = 1
 	},
 /area/hallway/secondary/exit)
@@ -43746,7 +43407,6 @@
 	dir = 6
 	},
 /turf/open/floor/plasteel/red/side{
-	icon_state = "red";
 	dir = 1
 	},
 /area/hallway/secondary/exit)
@@ -43758,14 +43418,12 @@
 	pixel_y = 20
 	},
 /turf/open/floor/plasteel/red/side{
-	icon_state = "red";
 	dir = 1
 	},
 /area/hallway/secondary/exit)
 "ces" = (
 /obj/structure/chair,
 /turf/open/floor/plasteel/red/side{
-	icon_state = "red";
 	dir = 5
 	},
 /area/hallway/secondary/exit)
@@ -43956,7 +43614,6 @@
 /area/maintenance/asteroid/aft/arrivals)
 "ceM" = (
 /turf/open/floor/plasteel/red/side{
-	icon_state = "red";
 	dir = 8
 	},
 /area/hallway/secondary/exit)
@@ -43981,7 +43638,6 @@
 /area/hallway/secondary/exit)
 "ceR" = (
 /turf/open/floor/plasteel/red/side{
-	icon_state = "red";
 	dir = 4
 	},
 /area/hallway/secondary/exit)
@@ -44290,7 +43946,6 @@
 /area/maintenance/asteroid/aft/arrivals)
 "cfN" = (
 /turf/open/floor/plasteel/red/side{
-	icon_state = "red";
 	dir = 10
 	},
 /area/hallway/secondary/exit)
@@ -44323,7 +43978,6 @@
 /area/hallway/secondary/exit)
 "cfT" = (
 /turf/open/floor/plasteel/red/side{
-	icon_state = "red";
 	dir = 6
 	},
 /area/hallway/secondary/exit)
@@ -44834,20 +44488,17 @@
 	pixel_x = -23
 	},
 /turf/open/floor/plasteel/escape{
-	icon_state = "escape";
 	dir = 9
 	},
 /area/hallway/secondary/exit)
 "chg" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plasteel/escape{
-	icon_state = "escape";
 	dir = 1
 	},
 /area/hallway/secondary/exit)
 "chh" = (
 /turf/open/floor/plasteel/escape/corner{
-	icon_state = "escapecorner";
 	dir = 1
 	},
 /area/hallway/secondary/exit)
@@ -45077,7 +44728,6 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel/escape{
-	icon_state = "escape";
 	dir = 8
 	},
 /area/hallway/secondary/exit)
@@ -45089,7 +44739,6 @@
 /area/hallway/secondary/exit)
 "chL" = (
 /turf/open/floor/plasteel/neutral/side{
-	icon_state = "neutral";
 	dir = 1
 	},
 /area/shuttle/escape)
@@ -45333,7 +44982,6 @@
 	dir = 8
 	},
 /turf/open/floor/plasteel/escape{
-	icon_state = "escape";
 	dir = 8
 	},
 /area/hallway/secondary/exit)
@@ -45973,7 +45621,6 @@
 	pixel_x = -28
 	},
 /turf/open/floor/plasteel/escape{
-	icon_state = "escape";
 	dir = 8
 	},
 /area/hallway/secondary/exit)
@@ -46680,7 +46327,6 @@
 "clc" = (
 /obj/structure/reagent_dispensers/fueltank,
 /turf/open/floor/plasteel/brown{
-	icon_state = "brown";
 	dir = 10
 	},
 /area/construction/mining/aux_base)
@@ -46738,7 +46384,6 @@
 /obj/item/device/assault_pod/mining,
 /obj/item/storage/box/lights/mixed,
 /turf/open/floor/plasteel/brown{
-	icon_state = "brown";
 	dir = 6
 	},
 /area/construction/mining/aux_base)
@@ -47129,13 +46774,11 @@
 "cmo" = (
 /obj/structure/closet/secure_closet/security,
 /turf/open/floor/plasteel/red/side{
-	icon_state = "red";
 	dir = 9
 	},
 /area/security/checkpoint/checkpoint2)
 "cmp" = (
 /turf/open/floor/plasteel/red/side{
-	icon_state = "red";
 	dir = 1
 	},
 /area/security/checkpoint/checkpoint2)
@@ -47145,7 +46788,6 @@
 	dir = 1
 	},
 /turf/open/floor/plasteel/red/side{
-	icon_state = "red";
 	dir = 1
 	},
 /area/security/checkpoint/checkpoint2)
@@ -47161,7 +46803,6 @@
 	pixel_y = 20
 	},
 /turf/open/floor/plasteel/red/side{
-	icon_state = "red";
 	dir = 1
 	},
 /area/security/checkpoint/checkpoint2)
@@ -47171,7 +46812,6 @@
 	pixel_y = 32
 	},
 /turf/open/floor/plasteel/red/side{
-	icon_state = "red";
 	dir = 1
 	},
 /area/security/checkpoint/checkpoint2)
@@ -47183,7 +46823,6 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel/red/side{
-	icon_state = "red";
 	dir = 1
 	},
 /area/security/checkpoint/checkpoint2)
@@ -47195,7 +46834,6 @@
 	pixel_y = 23
 	},
 /turf/open/floor/plasteel/red/side{
-	icon_state = "red";
 	dir = 5
 	},
 /area/security/checkpoint/checkpoint2)
@@ -47854,7 +47492,6 @@
 	dir = 1
 	},
 /turf/open/floor/plasteel/blue/corner{
-	icon_state = "bluecorner";
 	dir = 4
 	},
 /area/hallway/secondary/entry)
@@ -47873,7 +47510,6 @@
 	pixel_y = 32
 	},
 /turf/open/floor/plasteel/blue/corner{
-	icon_state = "bluecorner";
 	dir = 4
 	},
 /area/hallway/secondary/entry)
@@ -47887,7 +47523,6 @@
 	pixel_y = 20
 	},
 /turf/open/floor/plasteel/blue/corner{
-	icon_state = "bluecorner";
 	dir = 4
 	},
 /area/hallway/secondary/entry)
@@ -47899,7 +47534,6 @@
 	pixel_y = 23
 	},
 /turf/open/floor/plasteel/blue/corner{
-	icon_state = "bluecorner";
 	dir = 4
 	},
 /area/hallway/secondary/entry)
@@ -47911,7 +47545,6 @@
 	pixel_y = 32
 	},
 /turf/open/floor/plasteel/blue/corner{
-	icon_state = "bluecorner";
 	dir = 4
 	},
 /area/hallway/secondary/entry)
@@ -47926,7 +47559,6 @@
 /area/teleporter)
 "cnB" = (
 /turf/open/floor/plasteel/red/side{
-	icon_state = "red";
 	dir = 8
 	},
 /area/security/checkpoint/checkpoint2)
@@ -47940,7 +47572,6 @@
 	pixel_x = 28
 	},
 /turf/open/floor/plasteel/red/side{
-	icon_state = "red";
 	dir = 4
 	},
 /area/security/checkpoint/checkpoint2)
@@ -47995,7 +47626,6 @@
 	dir = 8
 	},
 /turf/open/floor/plasteel/escape{
-	icon_state = "escape";
 	dir = 8
 	},
 /area/hallway/secondary/exit)
@@ -48097,7 +47727,6 @@
 "cod" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plasteel/blue/corner{
-	icon_state = "bluecorner";
 	dir = 4
 	},
 /area/hallway/secondary/entry)
@@ -48121,7 +47750,6 @@
 	icon_state = "plant-21"
 	},
 /turf/open/floor/plasteel/red/side{
-	icon_state = "red";
 	dir = 10
 	},
 /area/security/checkpoint/checkpoint2)
@@ -48164,7 +47792,6 @@
 /obj/structure/table,
 /obj/machinery/recharger,
 /turf/open/floor/plasteel/red/side{
-	icon_state = "red";
 	dir = 6
 	},
 /area/security/checkpoint/checkpoint2)
@@ -48255,7 +47882,6 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel/purple/corner{
-	icon_state = "purplecorner";
 	dir = 8
 	},
 /area/hallway/primary/aft)
@@ -48271,7 +47897,6 @@
 	},
 /obj/machinery/door/firedoor,
 /turf/open/floor/plasteel/purple/corner{
-	icon_state = "purplecorner";
 	dir = 8
 	},
 /area/hallway/primary/aft)
@@ -48281,7 +47906,6 @@
 	},
 /obj/machinery/light,
 /turf/open/floor/plasteel/purple/corner{
-	icon_state = "purplecorner";
 	dir = 8
 	},
 /area/hallway/primary/aft)
@@ -48294,7 +47918,6 @@
 	pixel_y = -24
 	},
 /turf/open/floor/plasteel/purple/corner{
-	icon_state = "purplecorner";
 	dir = 8
 	},
 /area/hallway/primary/aft)
@@ -48307,7 +47930,6 @@
 	},
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel/purple/corner{
-	icon_state = "purplecorner";
 	dir = 8
 	},
 /area/hallway/primary/aft)
@@ -48327,7 +47949,6 @@
 "coG" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden,
 /turf/open/floor/plasteel/purple/corner{
-	icon_state = "purplecorner";
 	dir = 8
 	},
 /area/hallway/primary/aft)
@@ -48348,7 +47969,6 @@
 	pixel_y = -32
 	},
 /turf/open/floor/plasteel/purple/corner{
-	icon_state = "purplecorner";
 	dir = 8
 	},
 /area/hallway/primary/aft)
@@ -48666,7 +48286,6 @@
 	pixel_y = 32
 	},
 /turf/open/floor/plasteel/escape/corner{
-	icon_state = "escapecorner";
 	dir = 1
 	},
 /area/hallway/secondary/exit)
@@ -48853,7 +48472,6 @@
 	pixel_y = 32
 	},
 /turf/open/floor/plasteel/arrival/corner{
-	icon_state = "arrivalcorner";
 	dir = 1
 	},
 /area/hallway/secondary/entry)
@@ -48862,7 +48480,6 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel/arrival/corner{
-	icon_state = "arrivalcorner";
 	dir = 1
 	},
 /area/hallway/secondary/entry)
@@ -48875,7 +48492,6 @@
 	dir = 6
 	},
 /turf/open/floor/plasteel/arrival/corner{
-	icon_state = "arrivalcorner";
 	dir = 1
 	},
 /area/hallway/secondary/entry)
@@ -48885,14 +48501,12 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plasteel/arrival/corner{
-	icon_state = "arrivalcorner";
 	dir = 1
 	},
 /area/hallway/secondary/entry)
 "cpL" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden,
 /turf/open/floor/plasteel/arrival/corner{
-	icon_state = "arrivalcorner";
 	dir = 1
 	},
 /area/hallway/secondary/entry)
@@ -48904,14 +48518,12 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel/arrival/corner{
-	icon_state = "arrivalcorner";
 	dir = 1
 	},
 /area/hallway/secondary/entry)
 "cpN" = (
 /obj/machinery/atmospherics/pipe/manifold4w/supply/hidden,
 /turf/open/floor/plasteel/arrival/corner{
-	icon_state = "arrivalcorner";
 	dir = 1
 	},
 /area/hallway/secondary/entry)
@@ -48920,7 +48532,6 @@
 	dir = 1
 	},
 /turf/open/floor/plasteel/arrival/corner{
-	icon_state = "arrivalcorner";
 	dir = 1
 	},
 /area/hallway/secondary/entry)
@@ -48938,7 +48549,6 @@
 	pixel_y = 20
 	},
 /turf/open/floor/plasteel/arrival/corner{
-	icon_state = "arrivalcorner";
 	dir = 1
 	},
 /area/hallway/secondary/entry)
@@ -48954,7 +48564,6 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel/blue/corner{
-	icon_state = "bluecorner";
 	dir = 1
 	},
 /area/hallway/secondary/entry)
@@ -48985,7 +48594,6 @@
 	pixel_y = 40
 	},
 /turf/open/floor/plasteel/blue/corner{
-	icon_state = "bluecorner";
 	dir = 1
 	},
 /area/hallway/secondary/entry)
@@ -49190,7 +48798,6 @@
 	sensor_tag = "tox_airlock_sensor"
 	},
 /turf/open/floor/plasteel/whitepurple/side{
-	icon_state = "whitepurple";
 	dir = 8
 	},
 /area/science/mixing)
@@ -49206,7 +48813,6 @@
 	dir = 8
 	},
 /turf/open/floor/plasteel/whitepurple/side{
-	icon_state = "whitepurple";
 	dir = 4
 	},
 /area/science/mixing)
@@ -49339,7 +48945,6 @@
 	network = list("SS13","RD")
 	},
 /turf/open/floor/plasteel/whitepurple/side{
-	icon_state = "whitepurple";
 	dir = 1
 	},
 /area/science/lab)
@@ -49354,7 +48959,6 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel/whitepurple/side{
-	icon_state = "whitepurple";
 	dir = 1
 	},
 /area/science/lab)
@@ -49363,7 +48967,6 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel/whitepurple/side{
-	icon_state = "whitepurple";
 	dir = 1
 	},
 /area/science/lab)
@@ -49372,13 +48975,11 @@
 	dir = 10
 	},
 /turf/open/floor/plasteel/whitepurple/side{
-	icon_state = "whitepurple";
 	dir = 1
 	},
 /area/science/lab)
 "cqI" = (
 /turf/open/floor/plasteel/whitepurple/side{
-	icon_state = "whitepurple";
 	dir = 1
 	},
 /area/science/lab)
@@ -49387,7 +48988,6 @@
 	dir = 1
 	},
 /turf/open/floor/plasteel/whitepurple/side{
-	icon_state = "whitepurple";
 	dir = 1
 	},
 /area/science/lab)
@@ -49400,7 +49000,6 @@
 	pixel_y = 23
 	},
 /turf/open/floor/plasteel/whitepurple/side{
-	icon_state = "whitepurple";
 	dir = 1
 	},
 /area/science/lab)
@@ -49660,7 +49259,6 @@
 /area/science/mixing)
 "crl" = (
 /turf/open/floor/plasteel/whitepurple/side{
-	icon_state = "whitepurple";
 	dir = 8
 	},
 /area/science/mixing)
@@ -49675,7 +49273,6 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel/whitepurple/side{
-	icon_state = "whitepurple";
 	dir = 4
 	},
 /area/science/mixing)
@@ -50102,7 +49699,6 @@
 	pixel_y = -5
 	},
 /turf/open/floor/plasteel/whitepurple/side{
-	icon_state = "whitepurple";
 	dir = 8
 	},
 /area/science/mixing)
@@ -50352,7 +49948,6 @@
 	pixel_x = 28
 	},
 /turf/open/floor/plasteel/whitepurple/side{
-	icon_state = "whitepurple";
 	dir = 4
 	},
 /area/science/mixing)
@@ -50521,7 +50116,6 @@
 /area/maintenance/asteroid/aft/science)
 "cte" = (
 /turf/open/floor/plasteel/darkpurple/side{
-	icon_state = "darkpurple";
 	dir = 1
 	},
 /area/science/xenobiology)
@@ -50530,7 +50124,6 @@
 	dir = 1
 	},
 /turf/open/floor/plasteel/darkpurple/side{
-	icon_state = "darkpurple";
 	dir = 1
 	},
 /area/science/xenobiology)
@@ -50540,7 +50133,6 @@
 	dir = 8
 	},
 /turf/open/floor/plasteel/darkpurple/side{
-	icon_state = "darkpurple";
 	dir = 1
 	},
 /area/science/xenobiology)
@@ -50588,7 +50180,6 @@
 	},
 /obj/machinery/portable_atmospherics/canister,
 /turf/open/floor/plasteel/whitepurple/side{
-	icon_state = "whitepurple";
 	dir = 9
 	},
 /area/science/mixing)
@@ -50597,13 +50188,11 @@
 	dir = 10
 	},
 /turf/open/floor/plasteel/whitepurple/side{
-	icon_state = "whitepurple";
 	dir = 1
 	},
 /area/science/mixing)
 "cto" = (
 /turf/open/floor/plasteel/whitepurple/side{
-	icon_state = "whitepurple";
 	dir = 1
 	},
 /area/science/mixing)
@@ -50633,7 +50222,6 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel/whitepurple/side{
-	icon_state = "whitepurple";
 	dir = 4
 	},
 /area/science/mixing)
@@ -50680,7 +50268,6 @@
 /obj/effect/turf_decal/stripes/corner,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plasteel/purple/corner{
-	icon_state = "purplecorner";
 	dir = 8
 	},
 /area/science/robotics/lab)
@@ -50743,7 +50330,6 @@
 "ctG" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plasteel/whitepurple/side{
-	icon_state = "whitepurple";
 	dir = 1
 	},
 /area/science/research)
@@ -50865,7 +50451,6 @@
 	pixel_x = -22
 	},
 /turf/open/floor/plasteel/whitepurple/side{
-	icon_state = "whitepurple";
 	dir = 8
 	},
 /area/science/mixing)
@@ -50883,7 +50468,6 @@
 	},
 /obj/structure/closet/bombcloset,
 /turf/open/floor/plasteel/whitepurple/side{
-	icon_state = "whitepurple";
 	dir = 4
 	},
 /area/science/mixing)
@@ -51002,7 +50586,6 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel/whitepurple/side{
-	icon_state = "whitepurple";
 	dir = 1
 	},
 /area/science/mixing)
@@ -51012,7 +50595,6 @@
 	dir = 1
 	},
 /turf/open/floor/plasteel/whitepurple/side{
-	icon_state = "whitepurple";
 	dir = 5
 	},
 /area/science/mixing)
@@ -51032,7 +50614,6 @@
 	dir = 1
 	},
 /turf/open/floor/plasteel/whitepurple/side{
-	icon_state = "whitepurple";
 	dir = 9
 	},
 /area/science/research)
@@ -51053,7 +50634,6 @@
 	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel/whitepurple/side{
-	icon_state = "whitepurple";
 	dir = 1
 	},
 /area/science/research)
@@ -51062,7 +50642,6 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel/whitepurple/side{
-	icon_state = "whitepurple";
 	dir = 1
 	},
 /area/science/research)
@@ -51072,7 +50651,6 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plasteel/whitepurple/side{
-	icon_state = "whitepurple";
 	dir = 1
 	},
 /area/science/research)
@@ -51081,7 +50659,6 @@
 	dir = 1
 	},
 /turf/open/floor/plasteel/whitepurple/side{
-	icon_state = "whitepurple";
 	dir = 1
 	},
 /area/science/research)
@@ -51093,7 +50670,6 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden,
 /turf/open/floor/plasteel/whitepurple/side{
-	icon_state = "whitepurple";
 	dir = 1
 	},
 /area/science/research)
@@ -51469,7 +51045,6 @@
 	dir = 8
 	},
 /turf/open/floor/plasteel/whitepurple/side{
-	icon_state = "whitepurple";
 	dir = 8
 	},
 /area/science/mixing)
@@ -51535,7 +51110,6 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plasteel/whitepurple/side{
-	icon_state = "whitepurple";
 	dir = 4
 	},
 /area/science/mixing)
@@ -51570,7 +51144,6 @@
 	dir = 1
 	},
 /turf/open/floor/plasteel/whitepurple/side{
-	icon_state = "whitepurple";
 	dir = 8
 	},
 /area/science/research)
@@ -51783,7 +51356,6 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel/whitepurple/side{
-	icon_state = "whitepurple";
 	dir = 4
 	},
 /area/science/research)
@@ -51860,7 +51432,6 @@
 	req_access_txt = "55"
 	},
 /turf/open/floor/plasteel/whitepurple/side{
-	icon_state = "whitepurple";
 	dir = 1
 	},
 /area/science/xenobiology)
@@ -52087,7 +51658,6 @@
 	dir = 8
 	},
 /turf/open/floor/plasteel/whitepurple/side{
-	icon_state = "whitepurple";
 	dir = 10
 	},
 /area/science/mixing)
@@ -52141,7 +51711,6 @@
 /obj/machinery/portable_atmospherics/scrubber,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plasteel/whitepurple/side{
-	icon_state = "whitepurple";
 	dir = 4
 	},
 /area/science/mixing)
@@ -52153,7 +51722,6 @@
 "cwq" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plasteel/whitepurple/side{
-	icon_state = "whitepurple";
 	dir = 8
 	},
 /area/science/research)
@@ -52349,7 +51917,6 @@
 /area/science/xenobiology)
 "cwR" = (
 /turf/open/floor/plasteel/whitepurple/side{
-	icon_state = "whitepurple";
 	dir = 4
 	},
 /area/science/xenobiology)
@@ -52828,7 +52395,6 @@
 /obj/structure/bed/roller,
 /obj/effect/turf_decal/delivery,
 /turf/open/floor/plasteel/whitepurple/side{
-	icon_state = "whitepurple";
 	dir = 8
 	},
 /area/science/research)
@@ -52838,7 +52404,6 @@
 	pixel_x = 24
 	},
 /turf/open/floor/plasteel/whitepurple/side{
-	icon_state = "whitepurple";
 	dir = 4
 	},
 /area/science/research)
@@ -52879,7 +52444,6 @@
 /obj/structure/table,
 /obj/item/paper_bin,
 /turf/open/floor/plasteel/red/side{
-	icon_state = "red";
 	dir = 9
 	},
 /area/security/checkpoint/science)
@@ -52892,20 +52456,17 @@
 	network = list("RD")
 	},
 /turf/open/floor/plasteel/red/side{
-	icon_state = "red";
 	dir = 1
 	},
 /area/security/checkpoint/science)
 "cye" = (
 /obj/structure/table,
 /turf/open/floor/plasteel/red/side{
-	icon_state = "red";
 	dir = 1
 	},
 /area/security/checkpoint/science)
 "cyf" = (
 /turf/open/floor/plasteel/red/side{
-	icon_state = "red";
 	dir = 1
 	},
 /area/security/checkpoint/science)
@@ -52924,7 +52485,6 @@
 	random_basetype = /obj/structure/sign/poster/official
 	},
 /turf/open/floor/plasteel/red/side{
-	icon_state = "red";
 	dir = 5
 	},
 /area/security/checkpoint/science)
@@ -53184,7 +52744,6 @@
 	},
 /obj/item/clothing/neck/stethoscope,
 /turf/open/floor/plasteel/whitepurple/side{
-	icon_state = "whitepurple";
 	dir = 10
 	},
 /area/science/research)
@@ -53199,7 +52758,6 @@
 "cyN" = (
 /obj/machinery/iv_drip,
 /turf/open/floor/plasteel/whitepurple/side{
-	icon_state = "whitepurple";
 	dir = 6
 	},
 /area/science/research)
@@ -53217,7 +52775,6 @@
 	},
 /obj/machinery/recharger,
 /turf/open/floor/plasteel/red/side{
-	icon_state = "red";
 	dir = 8
 	},
 /area/security/checkpoint/science)
@@ -53243,7 +52800,6 @@
 	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel/red/side{
-	icon_state = "red";
 	dir = 4
 	},
 /area/security/checkpoint/science)
@@ -53526,7 +53082,6 @@
 	pixel_y = -28
 	},
 /turf/open/floor/plasteel/red/side{
-	icon_state = "red";
 	dir = 10
 	},
 /area/security/checkpoint/science)
@@ -53571,7 +53126,6 @@
 	icon_state = "1-8"
 	},
 /turf/open/floor/plasteel/red/side{
-	icon_state = "red";
 	dir = 6
 	},
 /area/security/checkpoint/science)
@@ -53894,15 +53448,11 @@
 "cAh" = (
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel/darkpurple/side{
-	icon_state = "darkpurple";
 	dir = 1
 	},
 /area/science/xenobiology)
 "cAi" = (
-/turf/open/floor/circuit{
-	initial_gas_mix = "n2=500;TEMP=80";
-	name = "Killroom Floor"
-	},
+/turf/open/floor/circuit/killroom,
 /area/science/xenobiology)
 "cAj" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -54070,29 +53620,20 @@
 	dir = 1;
 	network = list("SS13","RD")
 	},
-/turf/open/floor/circuit{
-	initial_gas_mix = "n2=500;TEMP=80";
-	name = "Killroom Floor"
-	},
+/turf/open/floor/circuit/killroom,
 /area/science/xenobiology)
 "cAz" = (
 /obj/machinery/light/small,
 /obj/machinery/atmospherics/pipe/manifold/general/visible{
 	dir = 1
 	},
-/turf/open/floor/circuit{
-	initial_gas_mix = "n2=500;TEMP=80";
-	name = "Killroom Floor"
-	},
+/turf/open/floor/circuit/killroom,
 /area/science/xenobiology)
 "cAA" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 8
 	},
-/turf/open/floor/circuit{
-	initial_gas_mix = "n2=500;TEMP=80";
-	name = "Killroom Floor"
-	},
+/turf/open/floor/circuit/killroom,
 /area/science/xenobiology)
 "cAB" = (
 /obj/structure/disposalpipe/segment,
@@ -55447,7 +54988,6 @@
 	dir = 1
 	},
 /turf/open/floor/plasteel/darkred/side{
-	icon_state = "darkred";
 	dir = 8
 	},
 /area/security/armory)
@@ -55472,7 +55012,6 @@
 /area/security/armory)
 "cEy" = (
 /turf/open/floor/plasteel/darkred/side{
-	icon_state = "darkred";
 	dir = 8
 	},
 /area/security/armory)
@@ -55910,7 +55449,6 @@
 	pixel_x = -28
 	},
 /turf/open/floor/plasteel/escape{
-	icon_state = "escape";
 	dir = 8
 	},
 /area/hallway/secondary/exit)
@@ -56068,7 +55606,6 @@
 	dir = 1
 	},
 /turf/open/floor/plasteel/red/side{
-	icon_state = "red";
 	dir = 1
 	},
 /area/security/brig)
@@ -56194,7 +55731,6 @@
 "cGD" = (
 /obj/effect/landmark/start/medical_doctor,
 /turf/open/floor/plasteel/whiteblue/corner{
-	icon_state = "whitebluecorner";
 	dir = 8
 	},
 /area/medical/medbay/zone2)
@@ -56264,7 +55800,6 @@
 	},
 /obj/effect/landmark/start/assistant,
 /turf/open/floor/plasteel/escape{
-	icon_state = "escape";
 	dir = 8
 	},
 /area/hallway/secondary/exit)
@@ -56319,7 +55854,6 @@
 	},
 /obj/machinery/door/airlock/glass,
 /turf/open/floor/plasteel/purple/corner{
-	icon_state = "purplecorner";
 	dir = 8
 	},
 /area/hallway/primary/aft)
@@ -56412,13 +55946,11 @@
 "cHf" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plasteel/red/side{
-	icon_state = "red";
 	dir = 10
 	},
 /area/security/brig)
 "cHg" = (
 /turf/open/floor/plasteel/red/side{
-	icon_state = "red";
 	dir = 6
 	},
 /area/security/brig)
@@ -56426,7 +55958,6 @@
 /obj/structure/table,
 /obj/item/storage/fancy/donut_box,
 /turf/open/floor/plasteel/red/side{
-	icon_state = "red";
 	dir = 10
 	},
 /area/security/brig)
@@ -56515,13 +56046,11 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel/red/side{
-	icon_state = "red";
 	dir = 1
 	},
 /area/security/brig)
 "cHu" = (
 /turf/open/floor/plasteel/red/side{
-	icon_state = "red";
 	dir = 1
 	},
 /area/security/brig)
@@ -56532,7 +56061,6 @@
 	network = list("SS13","Security")
 	},
 /turf/open/floor/plasteel/red/side{
-	icon_state = "red";
 	dir = 1
 	},
 /area/security/brig)
@@ -57035,7 +56563,6 @@
 	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel/red/side{
-	icon_state = "red";
 	dir = 4
 	},
 /area/security/checkpoint/medical)
@@ -57044,7 +56571,6 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel/green/corner{
-	icon_state = "greencorner";
 	dir = 8
 	},
 /area/hydroponics)
@@ -57389,7 +56915,6 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel/blue/corner{
-	icon_state = "bluecorner";
 	dir = 4
 	},
 /area/hallway/secondary/entry)
@@ -57622,7 +57147,6 @@
 	dir = 8
 	},
 /turf/open/floor/plasteel/whitepurple/side{
-	icon_state = "whitepurple";
 	dir = 10
 	},
 /area/science/mixing)
@@ -58181,7 +57705,6 @@
 "cLS" = (
 /obj/structure/closet/firecloset/full,
 /turf/open/floor/plasteel/brown{
-	icon_state = "brown";
 	dir = 10
 	},
 /area/quartermaster/qm)
@@ -58208,7 +57731,6 @@
 	icon_state = "plant-21"
 	},
 /turf/open/floor/plasteel/brown{
-	icon_state = "brown";
 	dir = 6
 	},
 /area/quartermaster/qm)
@@ -58273,7 +57795,6 @@
 	pixel_y = 32
 	},
 /turf/open/floor/plasteel/blue/side{
-	icon_state = "blue";
 	dir = 1
 	},
 /area/crew_quarters/heads/hop)
@@ -58781,7 +58302,6 @@
 /area/crew_quarters/theatre)
 "cNh" = (
 /turf/open/floor/plasteel/stairs{
-	icon_state = "stairs";
 	dir = 8
 	},
 /area/crew_quarters/theatre)
@@ -59623,7 +59143,6 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel/whiteblue/side{
-	icon_state = "whiteblue";
 	dir = 1
 	},
 /area/medical/medbay/central)
@@ -59979,7 +59498,6 @@
 	dir = 10
 	},
 /turf/open/floor/plasteel/yellow/corner{
-	icon_state = "yellowcorner";
 	dir = 8
 	},
 /area/engine/engineering)
@@ -61350,7 +60868,6 @@
 	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel/red/side{
-	icon_state = "red";
 	dir = 1
 	},
 /area/security/prison)
@@ -62081,7 +61598,6 @@
 	dir = 1
 	},
 /turf/open/floor/plasteel/red/side{
-	icon_state = "red";
 	dir = 1
 	},
 /area/security/prison)
@@ -62095,7 +61611,6 @@
 	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel/red/side{
-	icon_state = "red";
 	dir = 8
 	},
 /area/security/prison)
@@ -62125,7 +61640,6 @@
 	specialfunctions = 1
 	},
 /turf/open/floor/plasteel/red/side{
-	icon_state = "red";
 	dir = 4
 	},
 /area/security/prison)
@@ -62157,7 +61671,6 @@
 	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel/red/side{
-	icon_state = "red";
 	dir = 8
 	},
 /area/security/prison)
@@ -62167,7 +61680,6 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel/red/side{
-	icon_state = "red";
 	dir = 4
 	},
 /area/security/prison)
@@ -62180,7 +61692,6 @@
 	dir = 8
 	},
 /turf/open/floor/plasteel/red/side{
-	icon_state = "red";
 	dir = 4
 	},
 /area/security/prison)
@@ -62204,7 +61715,6 @@
 	specialfunctions = 1
 	},
 /turf/open/floor/plasteel/red/side{
-	icon_state = "red";
 	dir = 4
 	},
 /area/security/prison)
@@ -62250,7 +61760,6 @@
 	specialfunctions = 1
 	},
 /turf/open/floor/plasteel/red/side{
-	icon_state = "red";
 	dir = 4
 	},
 /area/security/prison)
@@ -63931,7 +63440,6 @@
 /area/shuttle/escape)
 "cZI" = (
 /turf/open/floor/plasteel/darkyellow/side{
-	icon_state = "darkyellow";
 	dir = 1
 	},
 /area/shuttle/escape)
@@ -63986,7 +63494,6 @@
 /area/shuttle/escape)
 "cZQ" = (
 /turf/open/floor/plasteel/darkred/side{
-	icon_state = "darkred";
 	dir = 1
 	},
 /area/shuttle/escape)
@@ -64081,7 +63588,6 @@
 	pixel_y = -29
 	},
 /turf/open/floor/plasteel/darkred/side{
-	icon_state = "darkred";
 	dir = 1
 	},
 /area/shuttle/escape)
@@ -64147,13 +63653,11 @@
 /area/shuttle/escape)
 "dai" = (
 /turf/open/floor/plasteel/neutral/side{
-	icon_state = "neutral";
 	dir = 8
 	},
 /area/shuttle/escape)
 "daj" = (
 /turf/open/floor/plasteel/neutral/side{
-	icon_state = "neutral";
 	dir = 4
 	},
 /area/shuttle/escape)
@@ -64278,7 +63782,6 @@
 	pixel_x = -28
 	},
 /turf/open/floor/plasteel/brown{
-	icon_state = "brown";
 	dir = 8
 	},
 /area/shuttle/escape)
@@ -64300,7 +63803,6 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel/brown{
-	icon_state = "brown";
 	dir = 4
 	},
 /area/shuttle/escape)
@@ -64322,7 +63824,6 @@
 /area/shuttle/escape)
 "daD" = (
 /turf/open/floor/plasteel/brown{
-	icon_state = "brown";
 	dir = 8
 	},
 /area/shuttle/escape)
@@ -64334,7 +63835,6 @@
 /obj/effect/turf_decal/delivery,
 /obj/structure/closet/crate,
 /turf/open/floor/plasteel/brown{
-	icon_state = "brown";
 	dir = 4
 	},
 /area/shuttle/escape)
@@ -64376,7 +63876,6 @@
 /area/shuttle/escape)
 "daM" = (
 /turf/open/floor/plasteel/brown{
-	icon_state = "brown";
 	dir = 10
 	},
 /area/shuttle/escape)
@@ -64391,7 +63890,6 @@
 /obj/effect/turf_decal/delivery,
 /obj/structure/closet,
 /turf/open/floor/plasteel/brown{
-	icon_state = "brown";
 	dir = 6
 	},
 /area/shuttle/escape)
@@ -64462,7 +63960,6 @@
 "daZ" = (
 /obj/machinery/light,
 /turf/open/floor/plasteel/neutral/side{
-	icon_state = "neutral";
 	dir = 1
 	},
 /area/shuttle/escape)
@@ -64501,13 +63998,11 @@
 	name = "Speedy* Recovery"
 	},
 /turf/open/floor/plasteel/whiteblue/side{
-	icon_state = "whiteblue";
 	dir = 9
 	},
 /area/shuttle/escape)
 "dbf" = (
 /turf/open/floor/plasteel/whiteblue/side{
-	icon_state = "whiteblue";
 	dir = 1
 	},
 /area/shuttle/escape)
@@ -64515,21 +64010,18 @@
 /obj/machinery/atmospherics/components/unary/portables_connector/visible,
 /obj/machinery/portable_atmospherics/canister/oxygen,
 /turf/open/floor/plasteel/whiteblue/side{
-	icon_state = "whiteblue";
 	dir = 1
 	},
 /area/shuttle/escape)
 "dbh" = (
 /obj/machinery/atmospherics/components/unary/cryo_cell,
 /turf/open/floor/plasteel/whiteblue/side{
-	icon_state = "whiteblue";
 	dir = 1
 	},
 /area/shuttle/escape)
 "dbi" = (
 /obj/machinery/atmospherics/components/unary/thermomachine/freezer,
 /turf/open/floor/plasteel/whiteblue/side{
-	icon_state = "whiteblue";
 	dir = 1
 	},
 /area/shuttle/escape)
@@ -64538,7 +64030,6 @@
 /obj/item/reagent_containers/glass/beaker/cryoxadone,
 /obj/item/wrench,
 /turf/open/floor/plasteel/whiteblue/side{
-	icon_state = "whiteblue";
 	dir = 5
 	},
 /area/shuttle/escape)
@@ -64548,7 +64039,6 @@
 /area/shuttle/escape)
 "dbl" = (
 /turf/open/floor/plasteel/whiteblue/side{
-	icon_state = "whiteblue";
 	dir = 8
 	},
 /area/shuttle/escape)
@@ -64573,7 +64063,6 @@
 /area/shuttle/escape)
 "dbq" = (
 /turf/open/floor/plasteel/whiteblue/corner{
-	icon_state = "whitebluecorner";
 	dir = 4
 	},
 /area/shuttle/escape)
@@ -64585,13 +64074,11 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel/whiteblue/side{
-	icon_state = "whiteblue";
 	dir = 5
 	},
 /area/shuttle/escape)
 "dbs" = (
 /turf/open/floor/plasteel/whiteblue/side{
-	icon_state = "whiteblue";
 	dir = 10
 	},
 /area/shuttle/escape)
@@ -64600,7 +64087,6 @@
 /area/shuttle/escape)
 "dbu" = (
 /turf/open/floor/plasteel/whiteblue/corner{
-	icon_state = "whitebluecorner";
 	dir = 8
 	},
 /area/shuttle/escape)
@@ -64611,7 +64097,6 @@
 	pixel_y = 3
 	},
 /turf/open/floor/plasteel/whiteblue/side{
-	icon_state = "whiteblue";
 	dir = 4
 	},
 /area/shuttle/escape)
@@ -64644,7 +64129,6 @@
 	dir = 8
 	},
 /turf/open/floor/plasteel/whiteblue/side{
-	icon_state = "whiteblue";
 	dir = 4
 	},
 /area/shuttle/escape)
@@ -64694,7 +64178,6 @@
 /obj/item/storage/firstaid/fire,
 /obj/item/crowbar,
 /turf/open/floor/plasteel/whiteblue/side{
-	icon_state = "whiteblue";
 	dir = 4
 	},
 /area/shuttle/escape)
@@ -64724,7 +64207,6 @@
 /obj/item/storage/firstaid/toxin,
 /obj/item/defibrillator/loaded,
 /turf/open/floor/plasteel/whiteblue/side{
-	icon_state = "whiteblue";
 	dir = 10
 	},
 /area/shuttle/escape)
@@ -64746,7 +64228,6 @@
 	dir = 8
 	},
 /turf/open/floor/plasteel/whiteblue/side{
-	icon_state = "whiteblue";
 	dir = 6
 	},
 /area/shuttle/escape)
@@ -64755,7 +64236,6 @@
 	pixel_y = -30
 	},
 /turf/open/floor/plasteel/neutral/side{
-	icon_state = "neutral";
 	dir = 1
 	},
 /area/shuttle/escape)
@@ -64787,13 +64267,11 @@
 "dbQ" = (
 /obj/structure/closet/secure_closet/engineering_personal,
 /turf/open/floor/plasteel/yellow/side{
-	icon_state = "yellow";
 	dir = 9
 	},
 /area/shuttle/escape)
 "dbR" = (
 /turf/open/floor/plasteel/yellow/side{
-	icon_state = "yellow";
 	dir = 1
 	},
 /area/shuttle/escape)
@@ -64803,13 +64281,11 @@
 	},
 /obj/machinery/computer/monitor,
 /turf/open/floor/plasteel/yellow/side{
-	icon_state = "yellow";
 	dir = 1
 	},
 /area/shuttle/escape)
 "dbT" = (
 /turf/open/floor/plasteel/yellow/side{
-	icon_state = "yellow";
 	dir = 5
 	},
 /area/shuttle/escape)
@@ -64833,19 +64309,16 @@
 "dbW" = (
 /obj/structure/closet/secure_closet/engineering_personal,
 /turf/open/floor/plasteel/yellow/side{
-	icon_state = "yellow";
 	dir = 10
 	},
 /area/shuttle/escape)
 "dbX" = (
 /turf/open/floor/plasteel/yellow/corner{
-	icon_state = "yellowcorner";
 	dir = 8
 	},
 /area/shuttle/escape)
 "dbY" = (
 /turf/open/floor/plasteel/yellow/corner{
-	icon_state = "yellowcorner";
 	dir = 4
 	},
 /area/shuttle/escape)
@@ -64853,7 +64326,6 @@
 /obj/structure/table,
 /obj/item/storage/box/metalfoam,
 /turf/open/floor/plasteel/yellow/side{
-	icon_state = "yellow";
 	dir = 1
 	},
 /area/shuttle/escape)
@@ -64861,7 +64333,6 @@
 /obj/structure/table,
 /obj/item/stack/sheet/metal/fifty,
 /turf/open/floor/plasteel/yellow/side{
-	icon_state = "yellow";
 	dir = 1
 	},
 /area/shuttle/escape)
@@ -64869,7 +64340,6 @@
 /obj/structure/table,
 /obj/item/stack/sheet/glass/fifty,
 /turf/open/floor/plasteel/yellow/side{
-	icon_state = "yellow";
 	dir = 5
 	},
 /area/shuttle/escape)
@@ -64889,7 +64359,6 @@
 "dce" = (
 /obj/structure/reagent_dispensers/watertank/high,
 /turf/open/floor/plasteel/yellow/side{
-	icon_state = "yellow";
 	dir = 10
 	},
 /area/shuttle/escape)
@@ -64898,7 +64367,6 @@
 	pixel_x = 32
 	},
 /turf/open/floor/plasteel/yellow/side{
-	icon_state = "yellow";
 	dir = 4
 	},
 /area/shuttle/escape)
@@ -64906,7 +64374,6 @@
 /obj/structure/table,
 /obj/item/storage/toolbox/mechanical,
 /turf/open/floor/plasteel/yellow/side{
-	icon_state = "yellow";
 	dir = 10
 	},
 /area/shuttle/escape)
@@ -64943,7 +64410,6 @@
 	pixel_y = -30
 	},
 /turf/open/floor/plasteel/yellow/side{
-	icon_state = "yellow";
 	dir = 6
 	},
 /area/shuttle/escape)
@@ -65120,7 +64586,6 @@
 	dir = 1
 	},
 /turf/open/floor/plasteel/darkgreen/side{
-	icon_state = "darkgreen";
 	dir = 8
 	},
 /area/hydroponics)
@@ -65479,7 +64944,6 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible,
 /turf/open/floor/plasteel/yellow/side{
-	icon_state = "yellow";
 	dir = 10
 	},
 /area/engine/atmos)
@@ -65591,7 +65055,6 @@
 "ddW" = (
 /obj/machinery/atmospherics/pipe/simple/general/visible,
 /turf/open/floor/plasteel/yellow/side{
-	icon_state = "yellow";
 	dir = 4
 	},
 /area/engine/atmos)
@@ -65599,7 +65062,6 @@
 /obj/machinery/pipedispenser,
 /obj/machinery/light,
 /turf/open/floor/plasteel/yellow/corner{
-	icon_state = "yellowcorner";
 	dir = 8
 	},
 /area/engine/atmos)
@@ -65635,7 +65097,6 @@
 	network = list("SS13","CE")
 	},
 /turf/open/floor/plasteel/yellow/side{
-	icon_state = "yellow";
 	dir = 4
 	},
 /area/engine/atmos)
@@ -65654,7 +65115,6 @@
 	},
 /obj/machinery/meter,
 /turf/open/floor/plasteel/yellow/side{
-	icon_state = "yellow";
 	dir = 8
 	},
 /area/engine/atmos)
@@ -65699,7 +65159,6 @@
 	target_pressure = 101
 	},
 /turf/open/floor/plasteel/yellow/side{
-	icon_state = "yellow";
 	dir = 4
 	},
 /area/engine/atmos)
@@ -65721,7 +65180,6 @@
 /obj/effect/landmark/start/atmospheric_technician,
 /obj/machinery/atmospherics/pipe/simple/general/visible,
 /turf/open/floor/plasteel/yellow/side{
-	icon_state = "yellow";
 	dir = 8
 	},
 /area/engine/atmos)
@@ -65737,7 +65195,6 @@
 "den" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden,
 /turf/open/floor/plasteel/yellow/side{
-	icon_state = "yellow";
 	dir = 8
 	},
 /area/engine/atmos)
@@ -65782,7 +65239,6 @@
 	},
 /obj/machinery/meter,
 /turf/open/floor/plasteel/yellow/side{
-	icon_state = "yellow";
 	dir = 4
 	},
 /area/engine/atmos)
@@ -65996,7 +65452,6 @@
 	dir = 6
 	},
 /turf/open/floor/plasteel/darkred/side{
-	icon_state = "darkred";
 	dir = 9
 	},
 /area/security/armory)
@@ -66085,7 +65540,6 @@
 	pixel_x = 28
 	},
 /turf/open/floor/plasteel/red/side{
-	icon_state = "red";
 	dir = 4
 	},
 /area/security/main)
@@ -67497,7 +66951,6 @@
 "dkv" = (
 /obj/structure/closet/secure_closet/engineering_electrical,
 /turf/open/floor/plasteel/yellow/side{
-	icon_state = "yellow";
 	dir = 4
 	},
 /area/engine/engineering)
@@ -67518,7 +66971,6 @@
 	dir = 10
 	},
 /turf/open/floor/plasteel/whitepurple/side{
-	icon_state = "whitepurple";
 	dir = 8
 	},
 /area/science/mixing)
@@ -67688,7 +67140,6 @@
 	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel/red/side{
-	icon_state = "red";
 	dir = 9
 	},
 /area/security/prison)
@@ -67697,7 +67148,6 @@
 	name = "Perma Storage"
 	},
 /turf/open/floor/plasteel/red/side{
-	icon_state = "red";
 	dir = 1
 	},
 /area/security/prison)
@@ -67712,7 +67162,6 @@
 	pixel_y = 20
 	},
 /turf/open/floor/plasteel/red/side{
-	icon_state = "red";
 	dir = 1
 	},
 /area/security/prison)
@@ -67721,7 +67170,6 @@
 	dir = 5
 	},
 /turf/open/floor/plasteel/red/side{
-	icon_state = "red";
 	dir = 1
 	},
 /area/security/prison)
@@ -67729,7 +67177,6 @@
 /obj/machinery/atmospherics/pipe/manifold4w/general/hidden,
 /obj/machinery/meter,
 /turf/open/floor/plasteel/red/side{
-	icon_state = "red";
 	dir = 1
 	},
 /area/security/prison)
@@ -67739,7 +67186,6 @@
 	},
 /obj/item/wrench,
 /turf/open/floor/plasteel/red/side{
-	icon_state = "red";
 	dir = 5
 	},
 /area/security/prison)
@@ -67795,7 +67241,6 @@
 	icon_state = "1-4"
 	},
 /turf/open/floor/plasteel/red/side{
-	icon_state = "red";
 	dir = 8
 	},
 /area/security/prison)
@@ -67819,7 +67264,6 @@
 	name = "Mix To Perma"
 	},
 /turf/open/floor/plasteel/red/side{
-	icon_state = "red";
 	dir = 4
 	},
 /area/security/prison)
@@ -67883,7 +67327,6 @@
 	network = list("SS13","Security")
 	},
 /turf/open/floor/plasteel/red/side{
-	icon_state = "red";
 	dir = 10
 	},
 /area/security/prison)
@@ -67914,7 +67357,6 @@
 	dir = 10
 	},
 /turf/open/floor/plasteel/red/side{
-	icon_state = "red";
 	dir = 4
 	},
 /area/security/prison)
@@ -68032,7 +67474,6 @@
 	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel/red/side{
-	icon_state = "red";
 	dir = 8
 	},
 /area/security/prison)
@@ -68042,7 +67483,6 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel/red/side{
-	icon_state = "red";
 	dir = 4
 	},
 /area/security/prison)
@@ -68145,7 +67585,6 @@
 	icon_state = "1-4"
 	},
 /turf/open/floor/plasteel/red/side{
-	icon_state = "red";
 	dir = 9
 	},
 /area/security/prison)
@@ -68180,7 +67619,6 @@
 	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel/red/side{
-	icon_state = "red";
 	dir = 8
 	},
 /area/security/prison)
@@ -68496,7 +67934,6 @@
 	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel/red/side{
-	icon_state = "red";
 	dir = 4
 	},
 /area/security/prison)
@@ -68728,7 +68165,6 @@
 	pixel_x = 32
 	},
 /turf/open/floor/plasteel/red/side{
-	icon_state = "red";
 	dir = 4
 	},
 /area/security/prison)
@@ -68751,7 +68187,6 @@
 	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel/red/side{
-	icon_state = "red";
 	dir = 8
 	},
 /area/security/prison)
@@ -68775,7 +68210,6 @@
 	specialfunctions = 1
 	},
 /turf/open/floor/plasteel/red/side{
-	icon_state = "red";
 	dir = 4
 	},
 /area/security/prison)
@@ -68859,7 +68293,6 @@
 	pixel_y = 32
 	},
 /turf/open/floor/plasteel/red/side{
-	icon_state = "red";
 	dir = 1
 	},
 /area/security/prison)
@@ -68882,7 +68315,6 @@
 	pixel_x = 32
 	},
 /turf/open/floor/plasteel/red/side{
-	icon_state = "red";
 	dir = 4
 	},
 /area/security/prison)
@@ -69038,7 +68470,6 @@
 	pixel_y = 20
 	},
 /turf/open/floor/plasteel/darkred/side{
-	icon_state = "darkred";
 	dir = 1
 	},
 /area/security/armory)
@@ -69051,7 +68482,6 @@
 	network = list("SS13","Security")
 	},
 /turf/open/floor/plasteel/darkred/side{
-	icon_state = "darkred";
 	dir = 1
 	},
 /area/security/armory)
@@ -69066,7 +68496,6 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel/darkred/side{
-	icon_state = "darkred";
 	dir = 1
 	},
 /area/security/armory)
@@ -69078,7 +68507,6 @@
 	dir = 9
 	},
 /turf/open/floor/plasteel/darkred/side{
-	icon_state = "darkred";
 	dir = 1
 	},
 /area/security/armory)
@@ -69088,7 +68516,6 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plasteel/darkred/side{
-	icon_state = "darkred";
 	dir = 5
 	},
 /area/security/armory)
@@ -69140,7 +68567,6 @@
 	specialfunctions = 1
 	},
 /turf/open/floor/plasteel/red/side{
-	icon_state = "red";
 	dir = 4
 	},
 /area/security/prison)
@@ -69229,7 +68655,6 @@
 /obj/item/storage/box/trackimp,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plasteel/darkred/side{
-	icon_state = "darkred";
 	dir = 4
 	},
 /area/security/armory)
@@ -69352,7 +68777,6 @@
 /obj/item/key/security,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plasteel/darkred/side{
-	icon_state = "darkred";
 	dir = 4
 	},
 /area/security/armory)
@@ -69452,7 +68876,6 @@
 /obj/structure/closet/secure_closet/lethalshots,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plasteel/darkred/side{
-	icon_state = "darkred";
 	dir = 4
 	},
 /area/security/armory)
@@ -69512,7 +68935,6 @@
 /obj/structure/table,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plasteel/darkred/side{
-	icon_state = "darkred";
 	dir = 4
 	},
 /area/security/armory)
@@ -69550,7 +68972,6 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plasteel/red/side{
-	icon_state = "red";
 	dir = 8
 	},
 /area/security/prison)
@@ -69562,7 +68983,6 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel/red/side{
-	icon_state = "red";
 	dir = 4
 	},
 /area/security/prison)
@@ -69614,7 +69034,6 @@
 /obj/item/reagent_containers/glass/bottle/morphine,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plasteel/darkred/side{
-	icon_state = "darkred";
 	dir = 4
 	},
 /area/security/armory)
@@ -69654,7 +69073,6 @@
 "drY" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden,
 /turf/open/floor/plasteel/red/side{
-	icon_state = "red";
 	dir = 4
 	},
 /area/security/prison)
@@ -69706,13 +69124,11 @@
 /obj/structure/closet/secure_closet/security/sec,
 /obj/item/device/radio,
 /turf/open/floor/plasteel/red/side{
-	icon_state = "red";
 	dir = 9
 	},
 /area/security/main)
 "dsn" = (
 /turf/open/floor/plasteel/red/side{
-	icon_state = "red";
 	dir = 1
 	},
 /area/security/main)
@@ -69726,13 +69142,11 @@
 	pixel_y = 20
 	},
 /turf/open/floor/plasteel/red/side{
-	icon_state = "red";
 	dir = 1
 	},
 /area/security/main)
 "dsp" = (
 /turf/open/floor/plasteel/darkred/side{
-	icon_state = "darkred";
 	dir = 10
 	},
 /area/security/armory)
@@ -69757,7 +69171,6 @@
 	dir = 9
 	},
 /turf/open/floor/plasteel/darkred/side{
-	icon_state = "darkred";
 	dir = 6
 	},
 /area/security/armory)
@@ -69771,7 +69184,6 @@
 	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel/red/side{
-	icon_state = "red";
 	dir = 10
 	},
 /area/security/prison)
@@ -69815,7 +69227,6 @@
 	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel/red/side{
-	icon_state = "red";
 	dir = 6
 	},
 /area/security/prison)
@@ -69824,7 +69235,6 @@
 	dir = 5
 	},
 /turf/open/floor/plasteel/red/side{
-	icon_state = "red";
 	dir = 10
 	},
 /area/security/prison)
@@ -69847,7 +69257,6 @@
 	specialfunctions = 1
 	},
 /turf/open/floor/plasteel/red/side{
-	icon_state = "red";
 	dir = 6
 	},
 /area/security/prison)
@@ -69935,7 +69344,6 @@
 /area/security/main)
 "dsO" = (
 /turf/open/floor/plasteel/red/side{
-	icon_state = "red";
 	dir = 8
 	},
 /area/security/main)
@@ -69995,7 +69403,6 @@
 	network = list("SS13","Security")
 	},
 /turf/open/floor/plasteel/red/side{
-	icon_state = "red";
 	dir = 5
 	},
 /area/security/brig)
@@ -70044,7 +69451,6 @@
 /obj/structure/table,
 /obj/item/clothing/neck/stethoscope,
 /turf/open/floor/plasteel/whiteblue/side{
-	icon_state = "whiteblue";
 	dir = 1
 	},
 /area/security/brig)
@@ -70057,7 +69463,6 @@
 	network = list("SS13","Security")
 	},
 /turf/open/floor/plasteel/whiteblue/side{
-	icon_state = "whiteblue";
 	dir = 1
 	},
 /area/security/brig)
@@ -70186,7 +69591,6 @@
 /area/security/main)
 "dtK" = (
 /turf/open/floor/plasteel/red/side{
-	icon_state = "red";
 	dir = 4
 	},
 /area/security/brig)
@@ -70196,7 +69600,6 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel/red/side{
-	icon_state = "red";
 	dir = 8
 	},
 /area/security/brig)
@@ -70205,7 +69608,6 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel/red/side{
-	icon_state = "red";
 	dir = 4
 	},
 /area/security/brig)
@@ -70339,7 +69741,6 @@
 	icon_state = "2-8"
 	},
 /turf/open/floor/plasteel/red/side{
-	icon_state = "red";
 	dir = 8
 	},
 /area/security/main)
@@ -70381,14 +69782,12 @@
 	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel/red/side{
-	icon_state = "red";
 	dir = 8
 	},
 /area/security/brig)
 "dun" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plasteel/red/side{
-	icon_state = "red";
 	dir = 4
 	},
 /area/security/brig)
@@ -70450,7 +69849,6 @@
 	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel/red/side{
-	icon_state = "red";
 	dir = 8
 	},
 /area/security/main)
@@ -70465,7 +69863,6 @@
 	name = "evidence closet"
 	},
 /turf/open/floor/plasteel/red/side{
-	icon_state = "red";
 	dir = 6
 	},
 /area/security/brig)
@@ -70601,7 +69998,6 @@
 	icon_state = "2-8"
 	},
 /turf/open/floor/plasteel/red/side{
-	icon_state = "red";
 	dir = 8
 	},
 /area/security/main)
@@ -70771,7 +70167,6 @@
 	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel/red/side{
-	icon_state = "red";
 	dir = 8
 	},
 /area/security/main)
@@ -70804,7 +70199,6 @@
 	icon_state = "0-2"
 	},
 /turf/open/floor/plasteel/red/side{
-	icon_state = "red";
 	dir = 9
 	},
 /area/security/brig)
@@ -70818,14 +70212,12 @@
 	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel/red/side{
-	icon_state = "red";
 	dir = 1
 	},
 /area/security/brig)
 "dvI" = (
 /obj/machinery/atmospherics/pipe/manifold4w/supply/hidden,
 /turf/open/floor/plasteel/red/side{
-	icon_state = "red";
 	dir = 1
 	},
 /area/security/brig)
@@ -70835,7 +70227,6 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plasteel/red/side{
-	icon_state = "red";
 	dir = 1
 	},
 /area/security/brig)
@@ -70849,7 +70240,6 @@
 	network = list("SS13","Security")
 	},
 /turf/open/floor/plasteel/red/side{
-	icon_state = "red";
 	dir = 1
 	},
 /area/security/brig)
@@ -70956,7 +70346,6 @@
 	icon_state = "1-4"
 	},
 /turf/open/floor/plasteel/red/side{
-	icon_state = "red";
 	dir = 8
 	},
 /area/security/main)
@@ -71019,7 +70408,6 @@
 	pixel_x = -32
 	},
 /turf/open/floor/plasteel/red/side{
-	icon_state = "red";
 	dir = 10
 	},
 /area/security/main)
@@ -71112,7 +70500,6 @@
 "dwC" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on,
 /turf/open/floor/plasteel/blue/side{
-	icon_state = "blue";
 	dir = 4
 	},
 /area/security/courtroom)
@@ -71197,7 +70584,6 @@
 "dwV" = (
 /obj/structure/chair,
 /turf/open/floor/plasteel/red/side{
-	icon_state = "red";
 	dir = 1
 	},
 /area/security/brig)
@@ -71214,7 +70600,6 @@
 /obj/structure/table/wood,
 /obj/item/folder/red,
 /turf/open/floor/plasteel/red/side{
-	icon_state = "red";
 	dir = 6
 	},
 /area/security/courtroom)
@@ -71222,7 +70607,6 @@
 /obj/structure/table/wood,
 /obj/item/book/manual/wiki/security_space_law,
 /turf/open/floor/plasteel/blue/side{
-	icon_state = "blue";
 	dir = 10
 	},
 /area/security/courtroom)
@@ -71265,7 +70649,6 @@
 "dxg" = (
 /obj/effect/landmark/secequipment,
 /turf/open/floor/plasteel/red/side{
-	icon_state = "red";
 	dir = 10
 	},
 /area/security/main)
@@ -71347,7 +70730,6 @@
 	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel/red/side{
-	icon_state = "red";
 	dir = 10
 	},
 /area/security/brig)
@@ -71369,7 +70751,6 @@
 	icon_state = "2-8"
 	},
 /turf/open/floor/plasteel/red/side{
-	icon_state = "red";
 	dir = 1
 	},
 /area/security/brig)
@@ -71380,7 +70761,6 @@
 	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel/red/side{
-	icon_state = "red";
 	dir = 6
 	},
 /area/security/brig)
@@ -71499,7 +70879,6 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel/red/side{
-	icon_state = "red";
 	dir = 4
 	},
 /area/security/brig)
@@ -71629,7 +71008,6 @@
 	pixel_y = 20
 	},
 /turf/open/floor/plasteel/red/side{
-	icon_state = "red";
 	dir = 1
 	},
 /area/security/brig)
@@ -71638,7 +71016,6 @@
 	pixel_y = 32
 	},
 /turf/open/floor/plasteel/red/side{
-	icon_state = "red";
 	dir = 1
 	},
 /area/security/brig)
@@ -72163,7 +71540,6 @@
 	dir = 8
 	},
 /turf/open/floor/plasteel/whiteblue/side{
-	icon_state = "whiteblue";
 	dir = 8
 	},
 /area/medical/surgery)
@@ -72174,7 +71550,6 @@
 	},
 /obj/item/circular_saw,
 /turf/open/floor/plasteel/whiteblue/side{
-	icon_state = "whiteblue";
 	dir = 4
 	},
 /area/medical/surgery)
@@ -72262,7 +71637,6 @@
 /area/medical/virology)
 "dzM" = (
 /turf/open/floor/plasteel/whitegreen/side{
-	icon_state = "whitegreen";
 	dir = 4
 	},
 /area/medical/virology)
@@ -72407,7 +71781,6 @@
 	pixel_y = 7
 	},
 /turf/open/floor/plasteel/whitegreen/side{
-	icon_state = "whitegreen";
 	dir = 9
 	},
 /area/medical/virology)
@@ -72623,7 +71996,6 @@
 	},
 /obj/item/twohanded/required/kirbyplants/random,
 /turf/open/floor/plasteel/whiteblue/side{
-	icon_state = "whiteblue";
 	dir = 6
 	},
 /area/medical/medbay/central)
@@ -72765,7 +72137,6 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel/whiteyellow/corner{
-	icon_state = "whiteyellowcorner";
 	dir = 8
 	},
 /area/medical/chemistry)
@@ -72777,7 +72148,6 @@
 "dBM" = (
 /obj/machinery/holopad,
 /turf/open/floor/plasteel/whiteyellow/side{
-	icon_state = "whiteyellow";
 	dir = 1
 	},
 /area/medical/chemistry)
@@ -72786,13 +72156,11 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel/whiteyellow/side{
-	icon_state = "whiteyellow";
 	dir = 1
 	},
 /area/medical/chemistry)
 "dBO" = (
 /turf/open/floor/plasteel/whiteblue/side{
-	icon_state = "whiteblue";
 	dir = 8
 	},
 /area/medical/medbay/zone2)
@@ -72823,7 +72191,6 @@
 	req_access_txt = "29"
 	},
 /turf/open/floor/plasteel/purple/corner{
-	icon_state = "purplecorner";
 	dir = 8
 	},
 /area/hallway/primary/aft)
@@ -73014,7 +72381,6 @@
 "dCr" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden,
 /turf/open/floor/plasteel/whitepurple/side{
-	icon_state = "whitepurple";
 	dir = 1
 	},
 /area/science/research)
@@ -73183,7 +72549,6 @@
 	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel/whitegreen/side{
-	icon_state = "whitegreen";
 	dir = 8
 	},
 /area/medical/virology)
@@ -73505,7 +72870,6 @@
 	},
 /obj/effect/baseturf_helper/asteroid,
 /turf/open/floor/plasteel/darkblue/side{
-	icon_state = "darkblue";
 	dir = 1
 	},
 /area/bridge)
@@ -76754,7 +76118,6 @@
 	},
 /obj/effect/baseturf_helper/asteroid,
 /turf/open/floor/plasteel/whiteyellow/corner{
-	icon_state = "whiteyellowcorner";
 	dir = 1
 	},
 /area/medical/chemistry)

--- a/_maps/map_files/Deltastation/DeltaStation2.dmm
+++ b/_maps/map_files/Deltastation/DeltaStation2.dmm
@@ -512,15 +512,12 @@
 "abi" = (
 /obj/item/twohanded/required/kirbyplants/random,
 /turf/open/floor/plasteel/yellow/side{
-	dir = 9;
-	initial_gas_mix = "o2=22;n2=82;TEMP=293.15"
+	dir = 9
 	},
 /area/construction/mining/aux_base)
 "abj" = (
 /turf/open/floor/plasteel/yellow/side{
-	dir = 1;
-	icon_state = "yellow";
-	initial_gas_mix = "o2=22;n2=82;TEMP=293.15"
+	dir = 1
 	},
 /area/construction/mining/aux_base)
 "abk" = (
@@ -1226,8 +1223,7 @@
 	},
 /obj/item/twohanded/required/kirbyplants/random,
 /turf/open/floor/plasteel/yellow/side{
-	dir = 9;
-	initial_gas_mix = "o2=22;n2=82;TEMP=293.15"
+	dir = 9
 	},
 /area/construction/mining/aux_base)
 "acx" = (
@@ -1238,9 +1234,7 @@
 	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel/yellow/side{
-	dir = 1;
-	icon_state = "yellow";
-	initial_gas_mix = "o2=22;n2=82;TEMP=293.15"
+	dir = 1
 	},
 /area/construction/mining/aux_base)
 "acy" = (
@@ -2002,7 +1996,6 @@
 "aem" = (
 /obj/structure/closet/wardrobe/yellow,
 /turf/open/floor/plasteel/blue/corner{
-	icon_state = "bluecorner";
 	dir = 8
 	},
 /area/shuttle/arrival)
@@ -2125,8 +2118,7 @@
 	dir = 5
 	},
 /turf/open/floor/plasteel/yellow/side{
-	dir = 10;
-	initial_gas_mix = "o2=22;n2=82;TEMP=293.15"
+	dir = 10
 	},
 /area/construction/mining/aux_base)
 "aeB" = (
@@ -2285,7 +2277,6 @@
 	dir = 1
 	},
 /turf/open/floor/plasteel/blue/side{
-	icon_state = "blue";
 	dir = 4
 	},
 /area/shuttle/arrival)
@@ -2402,8 +2393,7 @@
 	icon_state = "2-8"
 	},
 /turf/open/floor/plasteel/neutral/side{
-	dir = 5;
-	initial_gas_mix = "o2=22;n2=82;TEMP=293.15"
+	dir = 5
 	},
 /area/maintenance/starboard/fore)
 "afc" = (
@@ -2855,7 +2845,6 @@
 "agi" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/arrival{
-	icon_state = "arrival";
 	dir = 9
 	},
 /area/hallway/secondary/entry)
@@ -3019,7 +3008,6 @@
 /area/hallway/secondary/entry)
 "agy" = (
 /turf/open/floor/plasteel/arrival{
-	icon_state = "arrival";
 	dir = 5
 	},
 /area/hallway/secondary/entry)
@@ -3112,7 +3100,6 @@
 /area/hallway/secondary/entry)
 "agK" = (
 /turf/open/floor/plasteel/arrival{
-	icon_state = "arrival";
 	dir = 10
 	},
 /area/hallway/secondary/entry)
@@ -3192,7 +3179,6 @@
 	dir = 1
 	},
 /turf/open/floor/plasteel/arrival/corner{
-	icon_state = "arrivalcorner";
 	dir = 8
 	},
 /area/hallway/secondary/entry)
@@ -3261,7 +3247,6 @@
 /area/hallway/secondary/entry)
 "ahd" = (
 /turf/open/floor/plasteel/arrival{
-	icon_state = "arrival";
 	dir = 6
 	},
 /area/hallway/secondary/entry)
@@ -3459,7 +3444,6 @@
 "ahD" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plasteel/arrival{
-	icon_state = "arrival";
 	dir = 8
 	},
 /area/hallway/secondary/entry)
@@ -3501,7 +3485,6 @@
 "ahK" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plasteel/arrival{
-	icon_state = "arrival";
 	dir = 4
 	},
 /area/hallway/secondary/entry)
@@ -3628,7 +3611,6 @@
 /obj/effect/decal/cleanable/blood/old,
 /obj/effect/decal/remains/human,
 /turf/open/floor/plasteel/white/side{
-	icon_state = "whitehall";
 	dir = 8
 	},
 /area/maintenance/starboard/fore)
@@ -3757,7 +3739,6 @@
 	},
 /obj/item/twohanded/required/kirbyplants/random,
 /turf/open/floor/plasteel/blue/side{
-	icon_state = "blue";
 	dir = 5
 	},
 /area/security/checkpoint/customs)
@@ -4204,7 +4185,6 @@
 	},
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/plasteel/blue/side{
-	icon_state = "blue";
 	dir = 4
 	},
 /area/security/checkpoint/customs)
@@ -4231,7 +4211,6 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel/blue/corner{
-	icon_state = "bluecorner";
 	dir = 8
 	},
 /area/hallway/secondary/entry)
@@ -4613,7 +4592,6 @@
 /obj/item/stack/packageWrap,
 /obj/item/hand_labeler,
 /turf/open/floor/plasteel/blue/side{
-	icon_state = "blue";
 	dir = 4
 	},
 /area/security/checkpoint/customs)
@@ -4628,7 +4606,6 @@
 "akr" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plasteel/blue/corner{
-	icon_state = "bluecorner";
 	dir = 8
 	},
 /area/hallway/secondary/entry)
@@ -5020,7 +4997,6 @@
 /obj/item/folder/blue,
 /obj/item/pen,
 /turf/open/floor/plasteel/blue/side{
-	icon_state = "blue";
 	dir = 4
 	},
 /area/security/checkpoint/customs)
@@ -5419,7 +5395,6 @@
 /obj/item/paper_bin,
 /obj/item/pen,
 /turf/open/floor/plasteel/blue/side{
-	icon_state = "blue";
 	dir = 4
 	},
 /area/security/checkpoint/customs)
@@ -5908,8 +5883,7 @@
 "ann" = (
 /obj/structure/reagent_dispensers/fueltank,
 /turf/open/floor/plasteel/neutral/side{
-	dir = 6;
-	initial_gas_mix = "o2=22;n2=82;TEMP=293.15"
+	dir = 6
 	},
 /area/maintenance/port/fore)
 "ano" = (
@@ -6007,7 +5981,6 @@
 	pixel_x = 32
 	},
 /turf/open/floor/plasteel/blue/side{
-	icon_state = "blue";
 	dir = 6
 	},
 /area/security/checkpoint/customs)
@@ -6175,7 +6148,6 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/components/unary/vent_pump/on,
 /turf/open/floor/plasteel/brown{
-	icon_state = "brown";
 	dir = 8
 	},
 /area/maintenance/disposal)
@@ -6472,7 +6444,6 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plasteel/brown{
-	icon_state = "brown";
 	dir = 8
 	},
 /area/maintenance/disposal)
@@ -6538,7 +6509,6 @@
 /obj/structure/disposalpipe/segment,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/brown{
-	icon_state = "brown";
 	dir = 4
 	},
 /area/maintenance/disposal)
@@ -7020,7 +6990,6 @@
 /obj/structure/disposalpipe/segment,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/brown{
-	icon_state = "brown";
 	dir = 4
 	},
 /area/maintenance/disposal)
@@ -7162,7 +7131,6 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel/caution{
-	icon_state = "caution";
 	dir = 8
 	},
 /area/engine/atmospherics_engine)
@@ -7959,7 +7927,6 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel/caution{
-	icon_state = "caution";
 	dir = 8
 	},
 /area/engine/atmospherics_engine)
@@ -8493,7 +8460,6 @@
 	icon_state = "0-8"
 	},
 /turf/open/floor/plasteel/brown{
-	icon_state = "brown";
 	dir = 6
 	},
 /area/maintenance/disposal)
@@ -8595,7 +8561,6 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel/caution{
-	icon_state = "caution";
 	dir = 8
 	},
 /area/engine/atmospherics_engine)
@@ -8699,7 +8664,6 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plasteel/redblue/redside{
-	icon_state = "redblue";
 	dir = 8
 	},
 /area/maintenance/port/fore)
@@ -9183,7 +9147,6 @@
 	dir = 1
 	},
 /turf/open/floor/plasteel/redblue/redside{
-	icon_state = "redblue";
 	dir = 8
 	},
 /area/maintenance/port/fore)
@@ -9308,7 +9271,6 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel/whitepurple/side{
-	icon_state = "whitepurple";
 	dir = 1
 	},
 /area/janitor)
@@ -9319,7 +9281,6 @@
 	dir = 8
 	},
 /turf/open/floor/plasteel/whitegreen/side{
-	icon_state = "whitegreen";
 	dir = 5
 	},
 /area/janitor)
@@ -9458,7 +9419,6 @@
 	dir = 1
 	},
 /turf/open/floor/plasteel/brown{
-	icon_state = "brown";
 	dir = 1
 	},
 /area/quartermaster/warehouse)
@@ -9475,7 +9435,6 @@
 "aue" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/brown{
-	icon_state = "brown";
 	dir = 1
 	},
 /area/quartermaster/warehouse)
@@ -9512,7 +9471,6 @@
 	dir = 1
 	},
 /turf/open/floor/plasteel/brown{
-	icon_state = "brown";
 	dir = 1
 	},
 /area/quartermaster/storage)
@@ -9525,7 +9483,6 @@
 "aul" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/brown{
-	icon_state = "brown";
 	dir = 1
 	},
 /area/quartermaster/storage)
@@ -9533,7 +9490,6 @@
 /obj/structure/table/reinforced,
 /obj/item/paper_bin,
 /turf/open/floor/plasteel/brown{
-	icon_state = "brown";
 	dir = 1
 	},
 /area/quartermaster/storage)
@@ -9545,7 +9501,6 @@
 	pixel_y = 26
 	},
 /turf/open/floor/plasteel/brown{
-	icon_state = "brown";
 	dir = 1
 	},
 /area/quartermaster/storage)
@@ -9553,7 +9508,6 @@
 /obj/structure/table/reinforced,
 /obj/machinery/computer/stockexchange,
 /turf/open/floor/plasteel/brown{
-	icon_state = "brown";
 	dir = 1
 	},
 /area/quartermaster/storage)
@@ -9564,13 +9518,11 @@
 	},
 /obj/structure/filingcabinet/chestdrawer,
 /turf/open/floor/plasteel/brown{
-	icon_state = "brown";
 	dir = 1
 	},
 /area/quartermaster/storage)
 "auq" = (
 /turf/open/floor/plasteel/brown{
-	icon_state = "brown";
 	dir = 1
 	},
 /area/quartermaster/storage)
@@ -9797,7 +9749,6 @@
 /area/maintenance/port/fore)
 "auS" = (
 /turf/open/floor/plasteel/redblue/redside{
-	icon_state = "redblue";
 	dir = 8
 	},
 /area/maintenance/port/fore)
@@ -10085,7 +10036,6 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel/brown{
-	icon_state = "brown";
 	dir = 4
 	},
 /area/quartermaster/warehouse)
@@ -10186,7 +10136,6 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/loadingarea{
-	baseturf = /turf/open/space;
 	dir = 8
 	},
 /area/quartermaster/storage)
@@ -10347,7 +10296,6 @@
 /obj/machinery/light/small,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/redblue/redside{
-	icon_state = "redblue";
 	dir = 8
 	},
 /area/maintenance/port/fore)
@@ -10495,7 +10443,6 @@
 	pixel_x = -23
 	},
 /turf/open/floor/plasteel/brown{
-	icon_state = "brown";
 	dir = 8
 	},
 /area/quartermaster/warehouse)
@@ -10552,7 +10499,6 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel/brown{
-	icon_state = "brown";
 	dir = 4
 	},
 /area/quartermaster/warehouse)
@@ -10641,7 +10587,6 @@
 /area/quartermaster/storage)
 "awJ" = (
 /turf/open/floor/plasteel/loadingarea{
-	baseturf = /turf/open/space;
 	dir = 8
 	},
 /area/quartermaster/storage)
@@ -10993,7 +10938,6 @@
 /area/quartermaster/warehouse)
 "axu" = (
 /turf/open/floor/plasteel/brown{
-	icon_state = "brown";
 	dir = 4
 	},
 /area/quartermaster/warehouse)
@@ -11047,7 +10991,6 @@
 	id = "cargounload"
 	},
 /turf/open/floor/plasteel/brown{
-	icon_state = "brown";
 	dir = 4
 	},
 /area/quartermaster/storage)
@@ -11705,7 +11648,6 @@
 "ayT" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/brown{
-	icon_state = "brown";
 	dir = 4
 	},
 /area/quartermaster/storage)
@@ -11865,7 +11807,6 @@
 	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel/escape{
-	icon_state = "escape";
 	dir = 4
 	},
 /area/engine/atmospherics_engine)
@@ -12105,7 +12046,6 @@
 	sortType = 1
 	},
 /turf/open/floor/plasteel/brown{
-	icon_state = "brown";
 	dir = 8
 	},
 /area/quartermaster/warehouse)
@@ -12212,7 +12152,6 @@
 	pixel_x = 26
 	},
 /turf/open/floor/plasteel/brown{
-	icon_state = "brown";
 	dir = 4
 	},
 /area/quartermaster/warehouse)
@@ -12582,7 +12521,6 @@
 "aAI" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/brown{
-	icon_state = "brown";
 	dir = 6
 	},
 /area/quartermaster/warehouse)
@@ -12644,7 +12582,6 @@
 /area/quartermaster/storage)
 "aAQ" = (
 /turf/open/floor/plasteel/brown{
-	icon_state = "brown";
 	dir = 4
 	},
 /area/quartermaster/storage)
@@ -14685,7 +14622,6 @@
 "aEq" = (
 /obj/machinery/computer/secure_data,
 /turf/open/floor/plasteel/red/side{
-	icon_state = "red";
 	dir = 6
 	},
 /area/security/checkpoint/supply)
@@ -14700,7 +14636,6 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel/red/side{
-	icon_state = "red";
 	dir = 4
 	},
 /area/security/checkpoint/supply)
@@ -14770,7 +14705,6 @@
 	id = "cargoload"
 	},
 /turf/open/floor/plasteel/brown{
-	icon_state = "brown";
 	dir = 4
 	},
 /area/quartermaster/storage)
@@ -15006,7 +14940,6 @@
 "aET" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/vault{
-	icon_state = "vault";
 	dir = 8
 	},
 /area/maintenance/disposal/incinerator)
@@ -15531,7 +15464,6 @@
 	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel/red/side{
-	icon_state = "red";
 	dir = 4
 	},
 /area/security/checkpoint/supply)
@@ -16109,7 +16041,6 @@
 	},
 /obj/effect/landmark/start/cargo_technician,
 /turf/open/floor/plasteel/brown{
-	icon_state = "brown";
 	dir = 9
 	},
 /area/quartermaster/sorting)
@@ -16118,7 +16049,6 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel/brown{
-	icon_state = "brown";
 	dir = 1
 	},
 /area/quartermaster/sorting)
@@ -16129,7 +16059,6 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plasteel/brown{
-	icon_state = "brown";
 	dir = 1
 	},
 /area/quartermaster/sorting)
@@ -16143,7 +16072,6 @@
 	dir = 1
 	},
 /turf/open/floor/plasteel/brown{
-	icon_state = "brown";
 	dir = 5
 	},
 /area/quartermaster/sorting)
@@ -16190,7 +16118,6 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel/red/side{
-	icon_state = "red";
 	dir = 4
 	},
 /area/security/checkpoint/supply)
@@ -16666,7 +16593,6 @@
 "aIi" = (
 /obj/item/twohanded/required/kirbyplants/random,
 /turf/open/floor/plasteel/brown{
-	icon_state = "brown";
 	dir = 8
 	},
 /area/quartermaster/sorting)
@@ -16686,7 +16612,6 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plasteel/brown{
-	icon_state = "brown";
 	dir = 4
 	},
 /area/quartermaster/sorting)
@@ -16722,7 +16647,6 @@
 	pixel_x = -26
 	},
 /turf/open/floor/plasteel/red/side{
-	icon_state = "red";
 	dir = 10
 	},
 /area/security/checkpoint/supply)
@@ -16757,7 +16681,6 @@
 	name = "security camera"
 	},
 /turf/open/floor/plasteel/red/side{
-	icon_state = "red";
 	dir = 6
 	},
 /area/security/checkpoint/supply)
@@ -17059,7 +16982,6 @@
 /obj/machinery/atmospherics/pipe/manifold/general/visible,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/caution{
-	icon_state = "caution";
 	dir = 10
 	},
 /area/maintenance/disposal/incinerator)
@@ -17343,7 +17265,6 @@
 	dir = 8
 	},
 /turf/open/floor/plasteel/brown{
-	icon_state = "brown";
 	dir = 8
 	},
 /area/quartermaster/sorting)
@@ -17431,7 +17352,6 @@
 "aJN" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/loadingarea{
-	icon_state = "loadingarea";
 	dir = 1
 	},
 /area/quartermaster/storage)
@@ -17690,7 +17610,6 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel/vault{
-	icon_state = "vault";
 	dir = 8
 	},
 /area/maintenance/disposal/incinerator)
@@ -18018,7 +17937,6 @@
 	pixel_y = 3
 	},
 /turf/open/floor/plasteel/brown{
-	icon_state = "brown";
 	dir = 8
 	},
 /area/quartermaster/sorting)
@@ -18061,7 +17979,6 @@
 	dir = 8
 	},
 /turf/open/floor/plasteel/brown{
-	icon_state = "brown";
 	dir = 4
 	},
 /area/quartermaster/sorting)
@@ -18371,7 +18288,6 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/caution{
-	icon_state = "caution";
 	dir = 10
 	},
 /area/maintenance/disposal/incinerator)
@@ -18902,7 +18818,6 @@
 	pixel_x = -32
 	},
 /turf/open/floor/plasteel/brown{
-	icon_state = "brown";
 	dir = 10
 	},
 /area/quartermaster/sorting)
@@ -18930,7 +18845,6 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plasteel/brown{
-	icon_state = "brown";
 	dir = 6
 	},
 /area/quartermaster/sorting)
@@ -18945,7 +18859,6 @@
 "aMW" = (
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/plasteel/red/side{
-	icon_state = "red";
 	dir = 10
 	},
 /area/security/checkpoint/supply)
@@ -18972,7 +18885,6 @@
 	dir = 8
 	},
 /turf/open/floor/plasteel/red/side{
-	icon_state = "red";
 	dir = 6
 	},
 /area/security/checkpoint/supply)
@@ -18992,21 +18904,18 @@
 "aNa" = (
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel/brown{
-	icon_state = "brown";
 	dir = 9
 	},
 /area/quartermaster/storage)
 "aNb" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plasteel/brown{
-	icon_state = "brown";
 	dir = 1
 	},
 /area/quartermaster/storage)
 "aNc" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plasteel/brown{
-	icon_state = "brown";
 	dir = 1
 	},
 /area/quartermaster/storage)
@@ -19018,7 +18927,6 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/brown{
-	icon_state = "brown";
 	dir = 5
 	},
 /area/quartermaster/storage)
@@ -19537,7 +19445,6 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel/redblue/redside{
-	icon_state = "redblue";
 	dir = 1
 	},
 /area/crew_quarters/theatre)
@@ -19573,7 +19480,6 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel/redblue/redside{
-	icon_state = "redblue";
 	dir = 1
 	},
 /area/crew_quarters/theatre)
@@ -19590,7 +19496,6 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel/redblue/redside{
-	icon_state = "redblue";
 	dir = 1
 	},
 /area/crew_quarters/theatre)
@@ -19875,7 +19780,6 @@
 	name = "cargo camera"
 	},
 /turf/open/floor/plasteel/brown{
-	icon_state = "brown";
 	dir = 8
 	},
 /area/quartermaster/storage)
@@ -19915,14 +19819,12 @@
 	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel/brown{
-	icon_state = "brown";
 	dir = 4
 	},
 /area/quartermaster/storage)
 "aOI" = (
 /obj/structure/filingcabinet/chestdrawer,
 /turf/open/floor/plasteel/brown{
-	icon_state = "brown";
 	dir = 9
 	},
 /area/quartermaster/qm)
@@ -19931,7 +19833,6 @@
 /obj/item/clipboard,
 /obj/item/toy/figure/qm,
 /turf/open/floor/plasteel/brown{
-	icon_state = "brown";
 	dir = 1
 	},
 /area/quartermaster/qm)
@@ -19939,7 +19840,6 @@
 /obj/machinery/disposal/bin,
 /obj/structure/disposalpipe/trunk,
 /turf/open/floor/plasteel/brown{
-	icon_state = "brown";
 	dir = 1
 	},
 /area/quartermaster/qm)
@@ -19956,20 +19856,17 @@
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on,
 /turf/open/floor/plasteel/brown{
-	icon_state = "brown";
 	dir = 1
 	},
 /area/quartermaster/qm)
 "aOM" = (
 /turf/open/floor/plasteel/brown{
-	icon_state = "brown";
 	dir = 1
 	},
 /area/quartermaster/qm)
 "aON" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/brown{
-	icon_state = "brown";
 	dir = 1
 	},
 /area/quartermaster/qm)
@@ -19991,7 +19888,6 @@
 	pixel_x = 28
 	},
 /turf/open/floor/plasteel/brown{
-	icon_state = "brown";
 	dir = 5
 	},
 /area/quartermaster/qm)
@@ -20004,7 +19900,6 @@
 	},
 /obj/item/bedsheet/qm,
 /turf/open/floor/plasteel/brown{
-	icon_state = "brown";
 	dir = 1
 	},
 /area/quartermaster/qm)
@@ -20012,7 +19907,6 @@
 /obj/structure/table/reinforced,
 /obj/item/device/flashlight/lamp,
 /turf/open/floor/plasteel/brown{
-	icon_state = "brown";
 	dir = 5
 	},
 /area/quartermaster/qm)
@@ -20136,7 +20030,6 @@
 	pixel_y = 5
 	},
 /turf/open/floor/plasteel/darkred/side{
-	icon_state = "darkred";
 	dir = 9
 	},
 /area/security/execution/education)
@@ -20311,7 +20204,6 @@
 /obj/item/stack/packageWrap,
 /obj/item/hand_labeler,
 /turf/open/floor/plasteel/caution{
-	icon_state = "caution";
 	dir = 10
 	},
 /area/engine/atmos)
@@ -20748,7 +20640,6 @@
 	pixel_x = -32
 	},
 /turf/open/floor/plasteel/brown{
-	icon_state = "brown";
 	dir = 9
 	},
 /area/quartermaster/office)
@@ -20761,7 +20652,6 @@
 	dir = 6
 	},
 /turf/open/floor/plasteel/brown{
-	icon_state = "brown";
 	dir = 1
 	},
 /area/quartermaster/office)
@@ -20776,7 +20666,6 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel/brown{
-	icon_state = "brown";
 	dir = 1
 	},
 /area/quartermaster/office)
@@ -20785,7 +20674,6 @@
 	dir = 9
 	},
 /turf/open/floor/plasteel/brown{
-	icon_state = "brown";
 	dir = 1
 	},
 /area/quartermaster/office)
@@ -20795,7 +20683,6 @@
 	pixel_y = 32
 	},
 /turf/open/floor/plasteel/brown{
-	icon_state = "brown";
 	dir = 1
 	},
 /area/quartermaster/office)
@@ -20814,7 +20701,6 @@
 	name = "cargo camera"
 	},
 /turf/open/floor/plasteel/brown{
-	icon_state = "brown";
 	dir = 1
 	},
 /area/quartermaster/office)
@@ -20832,13 +20718,11 @@
 	icon_state = "0-2"
 	},
 /turf/open/floor/plasteel/brown{
-	icon_state = "brown";
 	dir = 1
 	},
 /area/quartermaster/office)
 "aQk" = (
 /turf/open/floor/plasteel/brown{
-	icon_state = "brown";
 	dir = 1
 	},
 /area/quartermaster/office)
@@ -20849,7 +20733,6 @@
 	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel/brown{
-	icon_state = "brown";
 	dir = 1
 	},
 /area/quartermaster/office)
@@ -20862,7 +20745,6 @@
 	pixel_x = 26
 	},
 /turf/open/floor/plasteel/brown{
-	icon_state = "brown";
 	dir = 5
 	},
 /area/quartermaster/office)
@@ -20883,7 +20765,6 @@
 	icon_state = "pipe-c"
 	},
 /turf/open/floor/plasteel/brown{
-	icon_state = "brown";
 	dir = 8
 	},
 /area/quartermaster/storage)
@@ -20946,7 +20827,6 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel/brown{
-	icon_state = "brown";
 	dir = 4
 	},
 /area/quartermaster/storage)
@@ -20968,7 +20848,6 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel/brown{
-	icon_state = "brown";
 	dir = 8
 	},
 /area/quartermaster/qm)
@@ -21023,7 +20902,6 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel/brown{
-	icon_state = "brown";
 	dir = 4
 	},
 /area/quartermaster/qm)
@@ -21039,7 +20917,6 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel/brown{
-	icon_state = "brown";
 	dir = 8
 	},
 /area/quartermaster/qm)
@@ -21065,7 +20942,6 @@
 	name = "cargo camera"
 	},
 /turf/open/floor/plasteel/brown{
-	icon_state = "brown";
 	dir = 4
 	},
 /area/quartermaster/qm)
@@ -21601,7 +21477,6 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel/brown{
-	icon_state = "brown";
 	dir = 8
 	},
 /area/quartermaster/office)
@@ -21711,7 +21586,6 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel/brown{
-	icon_state = "brown";
 	dir = 4
 	},
 /area/quartermaster/office)
@@ -21760,7 +21634,6 @@
 	icon_state = "pipe-c"
 	},
 /turf/open/floor/plasteel/brown{
-	icon_state = "brown";
 	dir = 8
 	},
 /area/quartermaster/storage)
@@ -21884,7 +21757,6 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel/brown{
-	icon_state = "brown";
 	dir = 4
 	},
 /area/quartermaster/storage)
@@ -21914,7 +21786,6 @@
 	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel/brown{
-	icon_state = "brown";
 	dir = 8
 	},
 /area/quartermaster/qm)
@@ -21985,7 +21856,6 @@
 	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel/brown{
-	icon_state = "brown";
 	dir = 4
 	},
 /area/quartermaster/qm)
@@ -22036,7 +21906,6 @@
 	pixel_x = 32
 	},
 /turf/open/floor/plasteel/brown{
-	icon_state = "brown";
 	dir = 4
 	},
 /area/quartermaster/qm)
@@ -22146,7 +22015,6 @@
 	pixel_x = -26
 	},
 /turf/open/floor/plasteel/darkred/side{
-	icon_state = "darkred";
 	dir = 10
 	},
 /area/security/execution/education)
@@ -22193,7 +22061,6 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel/darkred/side{
-	icon_state = "darkred";
 	dir = 6
 	},
 /area/security/execution/education)
@@ -22626,7 +22493,6 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel/brown{
-	icon_state = "brown";
 	dir = 4
 	},
 /area/quartermaster/office)
@@ -22653,7 +22519,6 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel/brown{
-	icon_state = "brown";
 	dir = 8
 	},
 /area/quartermaster/storage)
@@ -22683,7 +22548,6 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plasteel/brown{
-	icon_state = "brown";
 	dir = 4
 	},
 /area/quartermaster/storage)
@@ -22699,7 +22563,6 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel/brown{
-	icon_state = "brown";
 	dir = 8
 	},
 /area/quartermaster/qm)
@@ -22762,7 +22625,6 @@
 	pixel_x = 23
 	},
 /turf/open/floor/plasteel/brown{
-	icon_state = "brown";
 	dir = 4
 	},
 /area/quartermaster/qm)
@@ -23029,7 +22891,6 @@
 	},
 /obj/structure/disposalpipe/trunk,
 /turf/open/floor/plasteel/caution{
-	icon_state = "caution";
 	dir = 8
 	},
 /area/engine/atmos)
@@ -23378,7 +23239,6 @@
 "aUW" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/brown{
-	icon_state = "brown";
 	dir = 8
 	},
 /area/quartermaster/office)
@@ -23424,7 +23284,6 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel/brown{
-	icon_state = "brown";
 	dir = 4
 	},
 /area/quartermaster/office)
@@ -23442,7 +23301,6 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel/brown{
-	icon_state = "brown";
 	dir = 10
 	},
 /area/quartermaster/storage)
@@ -23521,7 +23379,6 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel/purple/side{
-	icon_state = "purple";
 	dir = 6
 	},
 /area/quartermaster/storage)
@@ -23540,7 +23397,6 @@
 	pixel_y = -32
 	},
 /turf/open/floor/plasteel/brown{
-	icon_state = "brown";
 	dir = 10
 	},
 /area/quartermaster/qm)
@@ -23591,7 +23447,6 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel/brown{
-	icon_state = "brown";
 	dir = 6
 	},
 /area/quartermaster/qm)
@@ -24155,7 +24010,6 @@
 	},
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel/caution{
-	icon_state = "caution";
 	dir = 8
 	},
 /area/engine/atmos)
@@ -24431,7 +24285,6 @@
 	pixel_x = -23
 	},
 /turf/open/floor/plasteel/brown{
-	icon_state = "brown";
 	dir = 10
 	},
 /area/quartermaster/office)
@@ -24491,7 +24344,6 @@
 	pixel_x = 28
 	},
 /turf/open/floor/plasteel/brown{
-	icon_state = "brown";
 	dir = 6
 	},
 /area/quartermaster/office)
@@ -24955,7 +24807,6 @@
 	icon_state = "pipe-c"
 	},
 /turf/open/floor/plasteel/caution{
-	icon_state = "caution";
 	dir = 8
 	},
 /area/engine/atmos)
@@ -25130,7 +24981,6 @@
 	dir = 8
 	},
 /turf/open/floor/plasteel/loadingarea{
-	icon_state = "loadingarea";
 	dir = 1
 	},
 /area/hallway/secondary/service)
@@ -25324,7 +25174,6 @@
 	pixel_x = -26
 	},
 /turf/open/floor/plasteel/brown{
-	icon_state = "brown";
 	dir = 9
 	},
 /area/quartermaster/miningoffice)
@@ -25332,14 +25181,12 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plasteel/purple/side{
-	icon_state = "purple";
 	dir = 1
 	},
 /area/quartermaster/miningoffice)
 "aYG" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plasteel/brown{
-	icon_state = "brown";
 	dir = 1
 	},
 /area/quartermaster/miningoffice)
@@ -25347,7 +25194,6 @@
 /obj/structure/table/reinforced,
 /obj/item/storage/belt/utility,
 /turf/open/floor/plasteel/purple/side{
-	icon_state = "purple";
 	dir = 1
 	},
 /area/quartermaster/miningoffice)
@@ -25355,7 +25201,6 @@
 /obj/structure/table/reinforced,
 /obj/machinery/computer/stockexchange,
 /turf/open/floor/plasteel/brown{
-	icon_state = "brown";
 	dir = 5
 	},
 /area/quartermaster/miningoffice)
@@ -25640,7 +25485,6 @@
 	on = 0
 	},
 /turf/open/floor/plasteel/purple/side{
-	icon_state = "purple";
 	dir = 9
 	},
 /area/engine/atmos)
@@ -25682,7 +25526,6 @@
 "aZs" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on,
 /turf/open/floor/plasteel/caution{
-	icon_state = "caution";
 	dir = 8
 	},
 /area/engine/atmos)
@@ -25764,7 +25607,6 @@
 	icon_state = "pipe-c"
 	},
 /turf/open/floor/plasteel/greenblue/side{
-	icon_state = "greenblue";
 	dir = 1
 	},
 /area/hydroponics)
@@ -25781,7 +25623,6 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel/greenblue/side{
-	icon_state = "greenblue";
 	dir = 1
 	},
 /area/hydroponics)
@@ -25800,7 +25641,6 @@
 	icon_state = "pipe-c"
 	},
 /turf/open/floor/plasteel/greenblue/side{
-	icon_state = "greenblue";
 	dir = 1
 	},
 /area/hydroponics)
@@ -25814,7 +25654,6 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel/greenblue/side{
-	icon_state = "greenblue";
 	dir = 1
 	},
 /area/hydroponics)
@@ -25833,7 +25672,6 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel/greenblue/side{
-	icon_state = "greenblue";
 	dir = 1
 	},
 /area/hydroponics)
@@ -25847,7 +25685,6 @@
 	dir = 1
 	},
 /turf/open/floor/plasteel/greenblue/side{
-	icon_state = "greenblue";
 	dir = 1
 	},
 /area/hydroponics)
@@ -26060,7 +25897,6 @@
 	pixel_x = -26
 	},
 /turf/open/floor/plasteel/brown{
-	icon_state = "brown";
 	dir = 9
 	},
 /area/hallway/primary/fore)
@@ -26071,7 +25907,6 @@
 	icon_state = "plant-21"
 	},
 /turf/open/floor/plasteel/brown{
-	icon_state = "brown";
 	dir = 1
 	},
 /area/hallway/primary/fore)
@@ -26079,13 +25914,11 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plasteel/brown{
-	icon_state = "brown";
 	dir = 1
 	},
 /area/hallway/primary/fore)
 "bad" = (
 /turf/open/floor/plasteel/brown{
-	icon_state = "brown";
 	dir = 1
 	},
 /area/hallway/primary/fore)
@@ -26118,7 +25951,6 @@
 "bai" = (
 /obj/machinery/computer/cargo/request,
 /turf/open/floor/plasteel/purple/side{
-	icon_state = "purple";
 	dir = 8
 	},
 /area/quartermaster/miningoffice)
@@ -26144,14 +25976,12 @@
 "bam" = (
 /obj/structure/filingcabinet/filingcabinet,
 /turf/open/floor/plasteel/purple/side{
-	icon_state = "purple";
 	dir = 4
 	},
 /area/quartermaster/miningoffice)
 "ban" = (
 /obj/item/twohanded/required/kirbyplants/random,
 /turf/open/floor/plasteel/brown{
-	icon_state = "brown";
 	dir = 8
 	},
 /area/quartermaster/miningoffice)
@@ -26163,40 +25993,34 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plasteel/brown{
-	icon_state = "brown";
 	dir = 1
 	},
 /area/quartermaster/miningoffice)
 "bap" = (
 /turf/open/floor/plasteel/loadingarea{
-	icon_state = "loadingarea";
 	dir = 1
 	},
 /area/quartermaster/miningoffice)
 "baq" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/loadingarea{
-	icon_state = "loadingarea";
 	dir = 1
 	},
 /area/quartermaster/miningoffice)
 "bar" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/brown{
-	icon_state = "brown";
 	dir = 1
 	},
 /area/quartermaster/miningoffice)
 "bas" = (
 /turf/open/floor/plasteel/purple/side{
-	icon_state = "purple";
 	dir = 1
 	},
 /area/quartermaster/miningoffice)
 "bat" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/brown{
-	icon_state = "brown";
 	dir = 5
 	},
 /area/quartermaster/miningoffice)
@@ -26368,7 +26192,6 @@
 /obj/machinery/atmospherics/pipe/simple/green/visible,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/purple/side{
-	icon_state = "purple";
 	dir = 8
 	},
 /area/engine/atmos)
@@ -26400,7 +26223,6 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plasteel/caution{
-	icon_state = "caution";
 	dir = 8
 	},
 /area/engine/atmos)
@@ -26681,7 +26503,6 @@
 	},
 /obj/effect/landmark/start/assistant,
 /turf/open/floor/plasteel/brown{
-	icon_state = "brown";
 	dir = 8
 	},
 /area/hallway/primary/fore)
@@ -26719,7 +26540,6 @@
 	dir = 8
 	},
 /turf/open/floor/plasteel/brown{
-	icon_state = "brown";
 	dir = 8
 	},
 /area/quartermaster/miningoffice)
@@ -26737,7 +26557,6 @@
 "bbG" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/brown{
-	icon_state = "brown";
 	dir = 4
 	},
 /area/quartermaster/miningoffice)
@@ -26758,7 +26577,6 @@
 /area/quartermaster/miningoffice)
 "bbI" = (
 /turf/open/floor/plasteel/purple/side{
-	icon_state = "purple";
 	dir = 8
 	},
 /area/quartermaster/miningoffice)
@@ -26808,7 +26626,6 @@
 /area/quartermaster/miningoffice)
 "bbP" = (
 /turf/open/floor/plasteel/purple/side{
-	icon_state = "purple";
 	dir = 4
 	},
 /area/quartermaster/miningoffice)
@@ -27267,7 +27084,6 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel/brown{
-	icon_state = "brown";
 	dir = 8
 	},
 /area/hallway/primary/fore)
@@ -27310,7 +27126,6 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel/loadingarea{
-	icon_state = "loadingarea";
 	dir = 1
 	},
 /area/hallway/primary/fore)
@@ -27327,7 +27142,6 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel/purple/side{
-	icon_state = "purple";
 	dir = 8
 	},
 /area/quartermaster/miningoffice)
@@ -27359,7 +27173,6 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel/purple/side{
-	icon_state = "purple";
 	dir = 4
 	},
 /area/quartermaster/miningoffice)
@@ -27369,7 +27182,6 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel/brown{
-	icon_state = "brown";
 	dir = 8
 	},
 /area/quartermaster/miningoffice)
@@ -27810,7 +27622,6 @@
 	dir = 1
 	},
 /turf/open/floor/plasteel/greenblue/side{
-	icon_state = "greenblue";
 	dir = 8
 	},
 /area/hallway/secondary/service)
@@ -27822,7 +27633,6 @@
 	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel/green/side{
-	icon_state = "green";
 	dir = 1
 	},
 /area/hallway/secondary/service)
@@ -27956,7 +27766,6 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel/brown{
-	icon_state = "brown";
 	dir = 8
 	},
 /area/hallway/primary/fore)
@@ -28022,7 +27831,6 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel/brown{
-	icon_state = "brown";
 	dir = 8
 	},
 /area/quartermaster/miningoffice)
@@ -28057,7 +27865,6 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel/brown{
-	icon_state = "brown";
 	dir = 4
 	},
 /area/quartermaster/miningoffice)
@@ -28093,7 +27900,6 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel/purple/side{
-	icon_state = "purple";
 	dir = 8
 	},
 /area/quartermaster/miningoffice)
@@ -28145,7 +27951,6 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/item/device/flashlight/lamp,
 /turf/open/floor/plasteel/purple/side{
-	icon_state = "purple";
 	dir = 4
 	},
 /area/quartermaster/miningoffice)
@@ -28717,7 +28522,6 @@
 /area/hydroponics)
 "bfA" = (
 /turf/open/floor/plasteel/greenblue/side{
-	icon_state = "greenblue";
 	dir = 9
 	},
 /area/hydroponics)
@@ -28728,7 +28532,6 @@
 	icon_state = "pipe-c"
 	},
 /turf/open/floor/plasteel/greenblue/side{
-	icon_state = "greenblue";
 	dir = 1
 	},
 /area/hydroponics)
@@ -28741,7 +28544,6 @@
 	icon_state = "pipe-c"
 	},
 /turf/open/floor/plasteel/greenblue/side{
-	icon_state = "greenblue";
 	dir = 1
 	},
 /area/hydroponics)
@@ -28750,7 +28552,6 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel/greenblue/side{
-	icon_state = "greenblue";
 	dir = 1
 	},
 /area/hydroponics)
@@ -28759,7 +28560,6 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel/greenblue/side{
-	icon_state = "greenblue";
 	dir = 5
 	},
 /area/hydroponics)
@@ -28792,7 +28592,6 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel/greenblue/side{
-	icon_state = "greenblue";
 	dir = 8
 	},
 /area/hallway/secondary/service)
@@ -28958,7 +28757,6 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel/brown{
-	icon_state = "brown";
 	dir = 8
 	},
 /area/hallway/primary/fore)
@@ -28978,7 +28776,6 @@
 	icon_state = "plant-21"
 	},
 /turf/open/floor/plasteel/brown{
-	icon_state = "brown";
 	dir = 4
 	},
 /area/hallway/primary/fore)
@@ -28986,7 +28783,6 @@
 /obj/structure/table/reinforced,
 /obj/item/storage/toolbox/mechanical,
 /turf/open/floor/plasteel/purple/side{
-	icon_state = "purple";
 	dir = 8
 	},
 /area/quartermaster/miningoffice)
@@ -29012,7 +28808,6 @@
 /obj/machinery/photocopier,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/purple/side{
-	icon_state = "purple";
 	dir = 4
 	},
 /area/quartermaster/miningoffice)
@@ -29020,7 +28815,6 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/item/twohanded/required/kirbyplants/random,
 /turf/open/floor/plasteel/brown{
-	icon_state = "brown";
 	dir = 8
 	},
 /area/quartermaster/miningoffice)
@@ -29100,7 +28894,6 @@
 /obj/item/folder/yellow,
 /obj/item/device/gps/mining,
 /turf/open/floor/plasteel/brown{
-	icon_state = "brown";
 	dir = 6
 	},
 /area/quartermaster/miningoffice)
@@ -29665,7 +29458,6 @@
 /area/hydroponics)
 "bho" = (
 /turf/open/floor/plasteel/greenblue/side{
-	icon_state = "greenblue";
 	dir = 8
 	},
 /area/hydroponics)
@@ -29703,7 +29495,6 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel/greenblue/side{
-	icon_state = "greenblue";
 	dir = 4
 	},
 /area/hydroponics)
@@ -29735,7 +29526,6 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel/greenblue/side{
-	icon_state = "greenblue";
 	dir = 8
 	},
 /area/hallway/secondary/service)
@@ -29922,7 +29712,6 @@
 /obj/item/stack/packageWrap,
 /obj/item/hand_labeler,
 /turf/open/floor/plasteel/brown{
-	icon_state = "brown";
 	dir = 10
 	},
 /area/hallway/primary/fore)
@@ -29971,7 +29760,6 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel/brown{
-	icon_state = "brown";
 	dir = 6
 	},
 /area/hallway/primary/fore)
@@ -29987,7 +29775,6 @@
 	pixel_y = -24
 	},
 /turf/open/floor/plasteel/brown{
-	icon_state = "brown";
 	dir = 10
 	},
 /area/quartermaster/miningoffice)
@@ -30011,7 +29798,6 @@
 	icon_state = "1-4"
 	},
 /turf/open/floor/plasteel/loadingarea{
-	baseturf = /turf/open/space;
 	dir = 8
 	},
 /area/quartermaster/miningoffice)
@@ -30035,7 +29821,6 @@
 	name = "cargo camera"
 	},
 /turf/open/floor/plasteel/brown{
-	icon_state = "brown";
 	dir = 6
 	},
 /area/quartermaster/miningoffice)
@@ -30476,7 +30261,6 @@
 	dir = 6
 	},
 /turf/open/floor/plasteel/caution{
-	icon_state = "caution";
 	dir = 9
 	},
 /area/engine/atmos)
@@ -30500,7 +30284,6 @@
 	dir = 1
 	},
 /turf/open/floor/plasteel/caution{
-	icon_state = "caution";
 	dir = 5
 	},
 /area/engine/atmos)
@@ -30649,7 +30432,6 @@
 /area/hydroponics)
 "bjv" = (
 /turf/open/floor/plasteel/greenblue/side{
-	icon_state = "greenblue";
 	dir = 4
 	},
 /area/hydroponics)
@@ -31493,7 +31275,6 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plasteel/purple/corner{
-	icon_state = "purplecorner";
 	dir = 4
 	},
 /area/hallway/primary/central)
@@ -31566,7 +31347,6 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel/brown{
-	icon_state = "brown";
 	dir = 8
 	},
 /area/maintenance/starboard/fore)
@@ -34838,7 +34618,6 @@
 	dir = 8
 	},
 /turf/open/floor/plasteel/arrival{
-	icon_state = "arrival";
 	dir = 9
 	},
 /area/engine/atmos)
@@ -35084,7 +34863,6 @@
 	},
 /obj/machinery/portable_atmospherics/scrubber,
 /turf/open/floor/plasteel/escape{
-	icon_state = "escape";
 	dir = 4
 	},
 /area/hallway/primary/port)
@@ -35126,13 +34904,11 @@
 /area/storage/tech)
 "brD" = (
 /turf/open/floor/plasteel/greenblue/side{
-	icon_state = "greenblue";
 	dir = 10
 	},
 /area/hydroponics)
 "brE" = (
 /turf/open/floor/plasteel/greenblue/side{
-	icon_state = "greenblue";
 	dir = 6
 	},
 /area/hydroponics)
@@ -35487,7 +35263,6 @@
 	on = 1
 	},
 /turf/open/floor/plasteel/arrival{
-	icon_state = "arrival";
 	dir = 10
 	},
 /area/engine/atmos)
@@ -36465,7 +36240,6 @@
 "bug" = (
 /obj/machinery/computer/crew,
 /turf/open/floor/plasteel/darkblue/side{
-	icon_state = "darkblue";
 	dir = 1
 	},
 /area/bridge)
@@ -36477,7 +36251,6 @@
 	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel/darkblue/side{
-	icon_state = "darkblue";
 	dir = 1
 	},
 /area/bridge)
@@ -36529,21 +36302,18 @@
 	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel/darkyellow/side{
-	icon_state = "darkyellow";
 	dir = 1
 	},
 /area/bridge)
 "buo" = (
 /obj/machinery/computer/atmos_alert,
 /turf/open/floor/plasteel/darkyellow/side{
-	icon_state = "darkyellow";
 	dir = 1
 	},
 /area/bridge)
 "bup" = (
 /obj/machinery/computer/monitor,
 /turf/open/floor/plasteel/darkyellow/corner{
-	icon_state = "darkyellowcorners";
 	dir = 4
 	},
 /area/bridge)
@@ -37516,7 +37286,6 @@
 /obj/item/device/assembly/timer,
 /obj/item/device/assembly/signaler,
 /turf/open/floor/plasteel/darkyellow/corner{
-	icon_state = "darkyellowcorners";
 	dir = 4
 	},
 /area/bridge)
@@ -38465,7 +38234,6 @@
 	icon_state = "plant-22"
 	},
 /turf/open/floor/plasteel/darkblue/side{
-	icon_state = "darkblue";
 	dir = 1
 	},
 /area/bridge)
@@ -38481,21 +38249,18 @@
 "bxz" = (
 /obj/item/twohanded/required/kirbyplants/random,
 /turf/open/floor/plasteel/darkblue/side{
-	icon_state = "darkblue";
 	dir = 1
 	},
 /area/bridge)
 "bxA" = (
 /obj/machinery/vending/cola/random,
 /turf/open/floor/plasteel/darkblue/side{
-	icon_state = "darkblue";
 	dir = 1
 	},
 /area/bridge)
 "bxB" = (
 /obj/machinery/vending/snack/random,
 /turf/open/floor/plasteel/darkblue/side{
-	icon_state = "darkblue";
 	dir = 1
 	},
 /area/bridge)
@@ -38505,7 +38270,6 @@
 "bxD" = (
 /obj/machinery/computer/security/mining,
 /turf/open/floor/plasteel/darkpurple/side{
-	icon_state = "darkpurple";
 	dir = 1
 	},
 /area/bridge)
@@ -38517,7 +38281,6 @@
 	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel/darkyellow/side{
-	icon_state = "darkyellow";
 	dir = 1
 	},
 /area/bridge)
@@ -38598,35 +38361,30 @@
 	},
 /obj/machinery/modular_computer/console/preset/command,
 /turf/open/floor/plasteel/darkpurple/side{
-	icon_state = "darkpurple";
 	dir = 1
 	},
 /area/bridge)
 "bxN" = (
 /obj/machinery/modular_computer/console/preset/engineering,
 /turf/open/floor/plasteel/darkpurple/side{
-	icon_state = "darkpurple";
 	dir = 1
 	},
 /area/bridge)
 "bxO" = (
 /obj/machinery/vending/coffee,
 /turf/open/floor/plasteel/darkblue/side{
-	icon_state = "darkblue";
 	dir = 1
 	},
 /area/bridge)
 "bxP" = (
 /obj/machinery/vending/cigarette,
 /turf/open/floor/plasteel/darkblue/side{
-	icon_state = "darkblue";
 	dir = 1
 	},
 /area/bridge)
 "bxQ" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plasteel/blue/corner{
-	icon_state = "bluecorner";
 	dir = 8
 	},
 /area/hallway/primary/central)
@@ -39249,7 +39007,6 @@
 /obj/structure/table/reinforced,
 /obj/item/device/flashlight/lamp,
 /turf/open/floor/plasteel/caution{
-	icon_state = "caution";
 	dir = 10
 	},
 /area/engine/atmos)
@@ -39958,7 +39715,6 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel/blue/corner{
-	icon_state = "bluecorner";
 	dir = 8
 	},
 /area/hallway/primary/central)
@@ -40925,7 +40681,6 @@
 /obj/item/twohanded/required/kirbyplants/random,
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden,
 /turf/open/floor/plasteel/darkblue/side{
-	icon_state = "darkblue";
 	dir = 1
 	},
 /area/bridge)
@@ -40985,7 +40740,6 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel/darkblue/side{
-	icon_state = "darkblue";
 	dir = 1
 	},
 /area/bridge)
@@ -41034,7 +40788,6 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plasteel/blue/corner{
-	icon_state = "bluecorner";
 	dir = 8
 	},
 /area/hallway/primary/central)
@@ -41453,9 +41206,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel/yellow/side{
-	dir = 1;
-	icon_state = "yellow";
-	initial_gas_mix = "o2=22;n2=82;TEMP=293.15"
+	dir = 1
 	},
 /area/engine/break_room)
 "bCn" = (
@@ -41772,7 +41523,6 @@
 /obj/item/device/aicard,
 /obj/item/storage/secure/briefcase,
 /turf/open/floor/plasteel/vault{
-	icon_state = "vault";
 	dir = 8
 	},
 /area/bridge)
@@ -41830,7 +41580,6 @@
 /obj/item/storage/toolbox/emergency,
 /obj/item/wrench,
 /turf/open/floor/plasteel/vault{
-	icon_state = "vault";
 	dir = 8
 	},
 /area/bridge)
@@ -42688,7 +42437,6 @@
 /obj/structure/table/reinforced,
 /obj/machinery/recharger,
 /turf/open/floor/plasteel/vault{
-	icon_state = "vault";
 	dir = 8
 	},
 /area/bridge)
@@ -42696,7 +42444,6 @@
 /obj/structure/table/reinforced,
 /obj/machinery/cell_charger,
 /turf/open/floor/plasteel/vault{
-	icon_state = "vault";
 	dir = 8
 	},
 /area/bridge)
@@ -42799,7 +42546,6 @@
 /obj/structure/table/reinforced,
 /obj/item/paper_bin,
 /turf/open/floor/plasteel/vault{
-	icon_state = "vault";
 	dir = 8
 	},
 /area/bridge)
@@ -42902,8 +42648,7 @@
 	icon_state = "2-8"
 	},
 /turf/open/floor/plasteel/neutral/side{
-	dir = 5;
-	initial_gas_mix = "o2=22;n2=82;TEMP=293.15"
+	dir = 5
 	},
 /area/maintenance/starboard)
 "bEX" = (
@@ -45454,7 +45199,6 @@
 	dir = 1
 	},
 /turf/open/floor/plasteel/neutral/side{
-	icon_state = "neutral";
 	dir = 4
 	},
 /area/crew_quarters/heads/chief)
@@ -46398,7 +46142,6 @@
 /area/crew_quarters/heads/chief)
 "bLE" = (
 /turf/open/floor/plasteel/neutral/side{
-	icon_state = "neutral";
 	dir = 4
 	},
 /area/crew_quarters/heads/chief)
@@ -50126,7 +49869,6 @@
 /obj/item/book/manual/wiki/security_space_law,
 /obj/item/device/radio,
 /turf/open/floor/plasteel/red/side{
-	icon_state = "red";
 	dir = 4
 	},
 /area/security/checkpoint/engineering)
@@ -51509,7 +51251,6 @@
 	name = "Queue Shutters"
 	},
 /turf/open/floor/plasteel/loadingarea{
-	baseturf = /turf/open/space;
 	dir = 8
 	},
 /area/hallway/primary/central)
@@ -56077,9 +55818,7 @@
 /area/engine/engineering)
 "ccW" = (
 /turf/open/floor/plasteel/yellow/side{
-	dir = 1;
-	icon_state = "yellow";
-	initial_gas_mix = "o2=22;n2=82;TEMP=293.15"
+	dir = 1
 	},
 /area/engine/engineering)
 "ccX" = (
@@ -56117,8 +55856,7 @@
 /area/engine/engineering)
 "cdb" = (
 /turf/open/floor/plasteel/yellow/side{
-	dir = 9;
-	initial_gas_mix = "o2=22;n2=82;TEMP=293.15"
+	dir = 9
 	},
 /area/engine/engineering)
 "cdc" = (
@@ -60873,7 +60611,6 @@
 /obj/machinery/atmospherics/components/unary/portables_connector/visible,
 /obj/machinery/portable_atmospherics/scrubber,
 /turf/open/floor/plasteel/escape{
-	icon_state = "escape";
 	dir = 1
 	},
 /area/crew_quarters/locker)
@@ -62256,7 +61993,6 @@
 	icon_state = "plant-21"
 	},
 /turf/open/floor/plasteel/blue/corner{
-	icon_state = "bluecorner";
 	dir = 1
 	},
 /area/hallway/secondary/command)
@@ -62269,7 +62005,6 @@
 /obj/structure/chair/comfy/black,
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden,
 /turf/open/floor/plasteel/blue/corner{
-	icon_state = "bluecorner";
 	dir = 1
 	},
 /area/hallway/secondary/command)
@@ -62294,7 +62029,6 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel/blue/corner{
-	icon_state = "bluecorner";
 	dir = 1
 	},
 /area/hallway/secondary/command)
@@ -62310,7 +62044,6 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel/blue/corner{
-	icon_state = "bluecorner";
 	dir = 1
 	},
 /area/hallway/secondary/command)
@@ -62326,7 +62059,6 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel/blue/corner{
-	icon_state = "bluecorner";
 	dir = 1
 	},
 /area/hallway/secondary/command)
@@ -62944,7 +62676,6 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel/blue/corner{
-	icon_state = "bluecorner";
 	dir = 1
 	},
 /area/hallway/secondary/command)
@@ -64975,18 +64706,14 @@
 /area/engine/storage)
 "cuQ" = (
 /turf/open/floor/plasteel/yellow/side{
-	dir = 1;
-	icon_state = "yellow";
-	initial_gas_mix = "o2=22;n2=82;TEMP=293.15"
+	dir = 1
 	},
 /area/engine/storage)
 "cuR" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on,
 /turf/open/floor/plasteel/yellow/side{
-	dir = 1;
-	icon_state = "yellow";
-	initial_gas_mix = "o2=22;n2=82;TEMP=293.15"
+	dir = 1
 	},
 /area/engine/storage)
 "cuS" = (
@@ -69838,7 +69565,6 @@
 /obj/item/reagent_containers/blood/random,
 /obj/item/roller,
 /turf/open/floor/plasteel/blue/corner{
-	icon_state = "bluecorner";
 	dir = 1
 	},
 /area/maintenance/starboard/aft)
@@ -69863,7 +69589,6 @@
 	name = "dormitories camera"
 	},
 /turf/open/floor/plasteel/arrival{
-	icon_state = "arrival";
 	dir = 8
 	},
 /area/crew_quarters/dorms)
@@ -71119,7 +70844,6 @@
 	dir = 8
 	},
 /turf/open/floor/plasteel/arrival{
-	icon_state = "arrival";
 	dir = 8
 	},
 /area/crew_quarters/dorms)
@@ -71702,7 +71426,6 @@
 "cHn" = (
 /obj/machinery/washing_machine,
 /turf/open/floor/plasteel/arrival{
-	icon_state = "arrival";
 	dir = 8
 	},
 /area/crew_quarters/dorms)
@@ -72101,11 +71824,7 @@
 	name = "xenobiology camera";
 	network = list("SS13","xeno","RD")
 	},
-/turf/open/floor/plasteel/vault{
-	dir = 5;
-	initial_gas_mix = "n2=500;TEMP=80";
-	temperature = 80
-	},
+/turf/open/floor/plasteel/vault/killroom,
 /area/science/xenobiology)
 "cIc" = (
 /obj/structure/closet/crate{
@@ -72357,7 +72076,6 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel/blue/corner{
-	icon_state = "bluecorner";
 	dir = 8
 	},
 /area/maintenance/starboard/aft)
@@ -72797,16 +72515,10 @@
 	name = "killroom vent";
 	pressure_checks = 0
 	},
-/turf/open/floor/circuit{
-	name = "Killroom Floor";
-	initial_gas_mix = "n2=500;TEMP=80"
-	},
+/turf/open/floor/circuit/killroom,
 /area/science/xenobiology)
 "cJJ" = (
-/turf/open/floor/circuit{
-	initial_gas_mix = "n2=500;TEMP=80";
-	name = "Mainframe Base"
-	},
+/turf/open/floor/circuit/telecomms/mainframe,
 /area/science/xenobiology)
 "cJK" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/siphon/on{
@@ -72814,10 +72526,7 @@
 	external_pressure_bound = 120;
 	name = "server vent"
 	},
-/turf/open/floor/circuit{
-	name = "Killroom Floor";
-	initial_gas_mix = "n2=500;TEMP=80"
-	},
+/turf/open/floor/circuit/killroom,
 /area/science/xenobiology)
 "cJL" = (
 /turf/closed/wall/r_wall,
@@ -72886,7 +72595,6 @@
 	dir = 1
 	},
 /turf/open/floor/plasteel/whitepurple/side{
-	icon_state = "whitepurple";
 	dir = 1
 	},
 /area/science/research)
@@ -73110,7 +72818,6 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel/whiteblue/side{
-	icon_state = "whiteblue";
 	dir = 1
 	},
 /area/medical/storage)
@@ -73124,7 +72831,6 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel/whiteblue/side{
-	icon_state = "whiteblue";
 	dir = 1
 	},
 /area/medical/storage)
@@ -73601,31 +73307,19 @@
 /obj/machinery/atmospherics/pipe/manifold/general/hidden{
 	dir = 8
 	},
-/turf/open/floor/plasteel/vault{
-	dir = 5;
-	initial_gas_mix = "n2=500;TEMP=80";
-	temperature = 80
-	},
+/turf/open/floor/plasteel/vault/killroom,
 /area/science/xenobiology)
 "cLp" = (
 /obj/machinery/atmospherics/pipe/simple/general/hidden{
 	dir = 4
 	},
-/turf/open/floor/plasteel/vault{
-	dir = 5;
-	initial_gas_mix = "n2=500;TEMP=80";
-	temperature = 80
-	},
+/turf/open/floor/plasteel/vault/killroom,
 /area/science/xenobiology)
 "cLq" = (
 /obj/machinery/atmospherics/pipe/simple/general/hidden{
 	dir = 9
 	},
-/turf/open/floor/plasteel/vault{
-	dir = 5;
-	initial_gas_mix = "n2=500;TEMP=80";
-	temperature = 80
-	},
+/turf/open/floor/plasteel/vault/killroom,
 /area/science/xenobiology)
 "cLr" = (
 /obj/structure/closet/wardrobe/science_white,
@@ -73649,7 +73343,6 @@
 	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel/whitepurple/side{
-	icon_state = "whitepurple";
 	dir = 1
 	},
 /area/science/research)
@@ -74136,7 +73829,6 @@
 /area/maintenance/port)
 "cMI" = (
 /turf/open/floor/plasteel/vault{
-	icon_state = "vault";
 	dir = 5
 	},
 /area/science/xenobiology)
@@ -74145,7 +73837,6 @@
 	dir = 1
 	},
 /turf/open/floor/plasteel/vault{
-	icon_state = "vault";
 	dir = 5
 	},
 /area/science/xenobiology)
@@ -75613,7 +75304,6 @@
 "cPy" = (
 /obj/machinery/computer/secure_data,
 /turf/open/floor/plasteel/red/side{
-	icon_state = "red";
 	dir = 6
 	},
 /area/security/checkpoint/medical)
@@ -75628,7 +75318,6 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel/red/side{
-	icon_state = "red";
 	dir = 4
 	},
 /area/security/checkpoint/medical)
@@ -76219,7 +75908,6 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel/whitepurple/side{
-	icon_state = "whitepurple";
 	dir = 1
 	},
 /area/science/xenobiology)
@@ -76228,7 +75916,6 @@
 	dir = 8
 	},
 /turf/open/floor/plasteel/whitepurple/side{
-	icon_state = "whitepurple";
 	dir = 1
 	},
 /area/science/xenobiology)
@@ -76717,7 +76404,6 @@
 	network = list("SS13","xeno","RD")
 	},
 /turf/open/floor/plasteel/vault{
-	icon_state = "vault";
 	dir = 5
 	},
 /area/science/xenobiology)
@@ -76990,7 +76676,6 @@
 	pixel_y = -7
 	},
 /turf/open/floor/plasteel/red/side{
-	icon_state = "red";
 	dir = 10
 	},
 /area/security/checkpoint/science/research)
@@ -77243,7 +76928,6 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel/red/side{
-	icon_state = "red";
 	dir = 4
 	},
 /area/security/checkpoint/medical)
@@ -78019,7 +77703,6 @@
 	name = "security camera"
 	},
 /turf/open/floor/plasteel/red/side{
-	icon_state = "red";
 	dir = 10
 	},
 /area/security/checkpoint/medical)
@@ -78049,7 +77732,6 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel/red/side{
-	icon_state = "red";
 	dir = 6
 	},
 /area/security/checkpoint/medical)
@@ -78094,7 +77776,6 @@
 /area/medical/medbay/central)
 "cUu" = (
 /turf/open/floor/plasteel/whiteblue/side{
-	icon_state = "whiteblue";
 	dir = 1
 	},
 /area/medical/medbay/central)
@@ -78402,7 +78083,6 @@
 /obj/item/storage/crayons,
 /obj/item/storage/crayons,
 /turf/open/floor/plasteel/escape{
-	icon_state = "escape";
 	dir = 4
 	},
 /area/crew_quarters/fitness/recreation)
@@ -78754,7 +78434,6 @@
 /area/science/lab)
 "cVE" = (
 /turf/open/floor/plasteel/whitepurple/side{
-	icon_state = "whitepurple";
 	dir = 1
 	},
 /area/science/lab)
@@ -78792,7 +78471,6 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel/purple/corner{
-	icon_state = "purplecorner";
 	dir = 8
 	},
 /area/hallway/primary/aft)
@@ -78831,7 +78509,6 @@
 	pixel_y = 32
 	},
 /turf/open/floor/plasteel/whiteyellow/corner{
-	icon_state = "whiteyellowcorner";
 	dir = 1
 	},
 /area/medical/chemistry)
@@ -78840,7 +78517,6 @@
 /obj/item/clipboard,
 /obj/item/toy/figure/chemist,
 /turf/open/floor/plasteel/whiteyellow/corner{
-	icon_state = "whiteyellowcorner";
 	dir = 1
 	},
 /area/medical/chemistry)
@@ -79127,7 +78803,6 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel/escape{
-	icon_state = "escape";
 	dir = 4
 	},
 /area/crew_quarters/fitness/recreation)
@@ -79152,7 +78827,6 @@
 	dir = 6
 	},
 /turf/open/floor/plasteel/purple/side{
-	icon_state = "purple";
 	dir = 4
 	},
 /area/maintenance/port)
@@ -79312,7 +78986,6 @@
 "cWO" = (
 /obj/machinery/light,
 /turf/open/floor/plasteel/vault{
-	icon_state = "vault";
 	dir = 5
 	},
 /area/science/xenobiology)
@@ -79583,7 +79256,6 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel/red/side{
-	icon_state = "red";
 	dir = 10
 	},
 /area/security/checkpoint/science/research)
@@ -80078,7 +79750,6 @@
 	pixel_y = -32
 	},
 /turf/open/floor/plasteel/escape{
-	icon_state = "escape";
 	dir = 4
 	},
 /area/crew_quarters/fitness/recreation)
@@ -80382,8 +80053,7 @@
 "cYU" = (
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/plasteel/whitepurple/side{
-	dir = 5;
-	initial_gas_mix = "o2=22;n2=82;TEMP=293.15"
+	dir = 5
 	},
 /area/science/lab)
 "cYV" = (
@@ -80428,13 +80098,11 @@
 /obj/item/grenade/chem_grenade,
 /obj/item/screwdriver,
 /turf/open/floor/plasteel/whiteyellow/corner{
-	icon_state = "whiteyellowcorner";
 	dir = 8
 	},
 /area/medical/chemistry)
 "cZa" = (
 /turf/open/floor/plasteel/whiteyellow/corner{
-	icon_state = "whiteyellowcorner";
 	dir = 8
 	},
 /area/medical/chemistry)
@@ -80502,7 +80170,6 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel/red/side{
-	icon_state = "red";
 	dir = 10
 	},
 /area/security/checkpoint/medical)
@@ -80526,7 +80193,6 @@
 	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel/red/side{
-	icon_state = "red";
 	dir = 6
 	},
 /area/security/checkpoint/medical)
@@ -80964,7 +80630,6 @@
 	req_access_txt = "33"
 	},
 /turf/open/floor/plasteel/whiteyellow/corner{
-	icon_state = "whiteyellowcorner";
 	dir = 8
 	},
 /area/medical/chemistry)
@@ -81556,7 +81221,6 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel/whitepurple/side{
-	icon_state = "whitepurple";
 	dir = 1
 	},
 /area/science/research)
@@ -81592,7 +81256,6 @@
 	dir = 1
 	},
 /turf/open/floor/plasteel/whitepurple/side{
-	icon_state = "whitepurple";
 	dir = 1
 	},
 /area/science/research)
@@ -81663,8 +81326,7 @@
 	pixel_y = 6
 	},
 /turf/open/floor/plasteel/whitepurple/side{
-	dir = 6;
-	initial_gas_mix = "o2=22;n2=82;TEMP=293.15"
+	dir = 6
 	},
 /area/science/lab)
 "dbD" = (
@@ -81791,7 +81453,6 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel/whiteyellow/corner{
-	icon_state = "whiteyellowcorner";
 	dir = 1
 	},
 /area/medical/medbay/central)
@@ -83159,7 +82820,6 @@
 	dir = 8
 	},
 /turf/open/floor/plasteel/whiteyellow/corner{
-	icon_state = "whiteyellowcorner";
 	dir = 8
 	},
 /area/medical/chemistry)
@@ -83239,7 +82899,6 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel/whiteyellow/corner{
-	icon_state = "whiteyellowcorner";
 	dir = 8
 	},
 /area/medical/medbay/central)
@@ -83744,7 +83403,6 @@
 	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel/whitepurple/side{
-	icon_state = "whitepurple";
 	dir = 1
 	},
 /area/science/explab)
@@ -84566,14 +84224,12 @@
 /obj/item/wrench,
 /obj/item/roller,
 /turf/open/floor/plasteel/blue/corner{
-	icon_state = "bluecorner";
 	dir = 1
 	},
 /area/maintenance/department/medical)
 "dhN" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/blue/corner{
-	icon_state = "bluecorner";
 	dir = 1
 	},
 /area/maintenance/department/medical)
@@ -86337,7 +85993,6 @@
 	dir = 6
 	},
 /turf/open/floor/plasteel/whitepurple/side{
-	icon_state = "whitepurple";
 	dir = 1
 	},
 /area/crew_quarters/heads/hor)
@@ -87075,7 +86730,6 @@
 /obj/structure/bed/roller,
 /obj/machinery/iv_drip,
 /turf/open/floor/plasteel/blue/corner{
-	icon_state = "bluecorner";
 	dir = 8
 	},
 /area/maintenance/department/medical)
@@ -87442,7 +87096,6 @@
 /area/science/mixing)
 "dnK" = (
 /turf/open/floor/plasteel/whitepurple/side{
-	icon_state = "whitepurple";
 	dir = 1
 	},
 /area/science/mixing)
@@ -88420,7 +88073,6 @@
 	pixel_y = 26
 	},
 /turf/open/floor/plasteel/whitepurple/side{
-	icon_state = "whitepurple";
 	dir = 8
 	},
 /area/medical/genetics)
@@ -88926,7 +88578,6 @@
 	network = list("SS13","RD")
 	},
 /turf/open/floor/plasteel/escape{
-	icon_state = "escape";
 	dir = 8
 	},
 /area/science/mixing)
@@ -89325,7 +88976,6 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel/whitepurple/side{
-	icon_state = "whitepurple";
 	dir = 1
 	},
 /area/medical/genetics)
@@ -89822,7 +89472,6 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel/escape{
-	icon_state = "escape";
 	dir = 8
 	},
 /area/science/mixing)
@@ -90136,7 +89785,6 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel/whitepurple/side{
-	icon_state = "whitepurple";
 	dir = 8
 	},
 /area/medical/genetics)
@@ -90621,7 +90269,6 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel/arrival{
-	icon_state = "arrival";
 	dir = 8
 	},
 /area/science/mixing)
@@ -90816,7 +90463,6 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel/purple/corner{
-	icon_state = "purplecorner";
 	dir = 8
 	},
 /area/hallway/primary/aft)
@@ -91497,7 +91143,6 @@
 	pixel_y = -22
 	},
 /turf/open/floor/plasteel/whitepurple/side{
-	icon_state = "whitepurple";
 	dir = 8
 	},
 /area/medical/genetics)
@@ -97403,7 +97048,6 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plasteel/whitegreen/side{
-	icon_state = "whitegreen";
 	dir = 4
 	},
 /area/medical/medbay/central)
@@ -97935,7 +97579,6 @@
 "dHT" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plasteel/whitegreen/side{
-	icon_state = "whitegreen";
 	dir = 4
 	},
 /area/medical/medbay/central)
@@ -98279,13 +97922,11 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel/escape{
-	icon_state = "escape";
 	dir = 1
 	},
 /area/hallway/primary/aft)
 "dIC" = (
 /turf/open/floor/plasteel/escape{
-	icon_state = "escape";
 	dir = 1
 	},
 /area/hallway/primary/aft)
@@ -98293,7 +97934,6 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel/escape{
-	icon_state = "escape";
 	dir = 1
 	},
 /area/hallway/primary/aft)
@@ -100904,13 +100544,11 @@
 	dir = 8
 	},
 /turf/open/floor/plasteel/whiteblue/side{
-	icon_state = "whiteblue";
 	dir = 1
 	},
 /area/shuttle/escape)
 "dNY" = (
 /turf/open/floor/plasteel/whiteblue/side{
-	icon_state = "whiteblue";
 	dir = 1
 	},
 /area/shuttle/escape)
@@ -101630,7 +101268,6 @@
 	name = "emergency shower"
 	},
 /turf/open/floor/plasteel/whiteblue/side{
-	baseturf = /turf/open/space;
 	dir = 4
 	},
 /area/shuttle/escape)
@@ -101742,7 +101379,6 @@
 	name = "virology camera"
 	},
 /turf/open/floor/plasteel/whitegreen/side{
-	icon_state = "whitegreen";
 	dir = 4
 	},
 /area/medical/virology)
@@ -101750,7 +101386,6 @@
 /obj/effect/decal/cleanable/dirt,
 /mob/living/carbon/monkey,
 /turf/open/floor/plasteel/whitegreen/side{
-	icon_state = "whitegreen";
 	dir = 9
 	},
 /area/medical/virology)
@@ -101782,7 +101417,6 @@
 "dPS" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/whitegreen/side{
-	icon_state = "whitegreen";
 	dir = 5
 	},
 /area/medical/virology)
@@ -102433,7 +102067,6 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel/whitegreen/side{
-	icon_state = "whitegreen";
 	dir = 4
 	},
 /area/medical/virology)
@@ -103444,7 +103077,6 @@
 /obj/item/pen/red,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plasteel/whitegreen/side{
-	icon_state = "whitegreen";
 	dir = 4
 	},
 /area/medical/virology)
@@ -104216,7 +103848,6 @@
 /obj/item/bedsheet/medical,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plasteel/whitegreen/side{
-	icon_state = "whitegreen";
 	dir = 9
 	},
 /area/medical/virology)
@@ -104230,7 +103861,6 @@
 	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel/whitegreen/side{
-	icon_state = "whitegreen";
 	dir = 5
 	},
 /area/medical/virology)
@@ -104248,7 +103878,6 @@
 	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel/whitegreen/side{
-	icon_state = "whitegreen";
 	dir = 9
 	},
 /area/medical/virology)
@@ -104257,7 +103886,6 @@
 /obj/item/bedsheet/medical,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plasteel/whitegreen/side{
-	icon_state = "whitegreen";
 	dir = 5
 	},
 /area/medical/virology)
@@ -104520,7 +104148,6 @@
 	dir = 1
 	},
 /turf/open/floor/plasteel/whitegreen/side{
-	icon_state = "whitegreen";
 	dir = 10
 	},
 /area/medical/virology)
@@ -104536,7 +104163,6 @@
 	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel/whitegreen/side{
-	icon_state = "whitegreen";
 	dir = 6
 	},
 /area/medical/virology)
@@ -104555,7 +104181,6 @@
 	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel/whitegreen/side{
-	icon_state = "whitegreen";
 	dir = 10
 	},
 /area/medical/virology)
@@ -104565,7 +104190,6 @@
 	dir = 1
 	},
 /turf/open/floor/plasteel/whitegreen/side{
-	icon_state = "whitegreen";
 	dir = 6
 	},
 /area/medical/virology)
@@ -107184,13 +106808,11 @@
 	icon_state = "plant-21"
 	},
 /turf/open/floor/plasteel/vault{
-	icon_state = "vault";
 	dir = 5
 	},
 /area/shuttle/escape)
 "eav" = (
 /turf/open/floor/plasteel/vault{
-	icon_state = "vault";
 	dir = 5
 	},
 /area/shuttle/escape)
@@ -107204,7 +106826,6 @@
 "eax" = (
 /obj/machinery/computer/security,
 /turf/open/floor/plasteel/darkred/side{
-	icon_state = "darkred";
 	dir = 9
 	},
 /area/shuttle/escape)
@@ -107213,7 +106834,6 @@
 	dir = 8
 	},
 /turf/open/floor/plasteel/vault{
-	icon_state = "vault";
 	dir = 5
 	},
 /area/shuttle/escape)
@@ -107224,7 +106844,6 @@
 	pixel_y = 58
 	},
 /turf/open/floor/plasteel/vault{
-	icon_state = "vault";
 	dir = 5
 	},
 /area/shuttle/escape)
@@ -107233,14 +106852,12 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel/vault{
-	icon_state = "vault";
 	dir = 5
 	},
 /area/shuttle/escape)
 "eaB" = (
 /obj/machinery/computer/station_alert,
 /turf/open/floor/plasteel/darkyellow/side{
-	icon_state = "darkyellow";
 	dir = 5
 	},
 /area/shuttle/escape)
@@ -107252,7 +106869,6 @@
 "eaD" = (
 /obj/machinery/computer/secure_data,
 /turf/open/floor/plasteel/darkred/side{
-	icon_state = "darkred";
 	dir = 10
 	},
 /area/shuttle/escape)
@@ -107286,7 +106902,6 @@
 "eaJ" = (
 /obj/machinery/computer/atmos_alert,
 /turf/open/floor/plasteel/darkyellow/side{
-	icon_state = "darkyellow";
 	dir = 6
 	},
 /area/shuttle/escape)
@@ -107843,11 +107458,7 @@
 /turf/open/floor/plating,
 /area/tcommsat/server)
 "ecI" = (
-/turf/open/floor/plasteel/vault{
-	dir = 5;
-	initial_gas_mix = "n2=500;TEMP=80";
-	temperature = 80
-	},
+/turf/open/floor/plasteel/vault/killroom,
 /area/science/xenobiology)
 "ecQ" = (
 /obj/effect/decal/cleanable/dirt,
@@ -107986,7 +107597,6 @@
 "edh" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/brown{
-	icon_state = "brown";
 	dir = 1
 	},
 /area/maintenance/starboard/fore)

--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -42429,10 +42429,7 @@
 /turf/open/floor/engine/vacuum,
 /area/engine/atmos)
 "bCC" = (
-/turf/open/floor/engine{
-	name = "vacuum floor";
-	initial_gas_mix = "o2=0.01;n2=0.01"
-	},
+/turf/open/floor/engine/vacuum,
 /area/engine/atmos)
 "bCD" = (
 /turf/closed/wall/r_wall,
@@ -60082,19 +60079,13 @@
 /obj/machinery/atmospherics/components/unary/outlet_injector/on{
 	dir = 1
 	},
-/turf/open/floor/engine{
-	name = "vacuum floor";
-	initial_gas_mix = "o2=0.01;n2=0.01"
-	},
+/turf/open/floor/engine/vacuum,
 /area/engine/atmos)
 "ckL" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 1
 	},
-/turf/open/floor/engine{
-	name = "vacuum floor";
-	initial_gas_mix = "o2=0.01;n2=0.01"
-	},
+/turf/open/floor/engine/vacuum,
 /area/engine/atmos)
 "ckM" = (
 /obj/structure/girder,
@@ -60741,10 +60732,7 @@
 /obj/item/stack/rods{
 	amount = 25
 	},
-/turf/open/floor/engine{
-	name = "vacuum floor";
-	initial_gas_mix = "o2=0.01;n2=0.01"
-	},
+/turf/open/floor/engine/vacuum,
 /area/engine/atmos)
 "cmf" = (
 /turf/open/floor/plating/airless,
@@ -72730,10 +72718,7 @@
 /area/science/server)
 "cIe" = (
 /obj/machinery/r_n_d/server/robotics,
-/turf/open/floor/circuit{
-	name = "Server Base";
-	initial_gas_mix = "n2=500;TEMP=80"
-	},
+/turf/open/floor/circuit/telecomms/server,
 /area/science/server)
 "cIf" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
@@ -72741,10 +72726,7 @@
 	name = "server vent";
 	pressure_checks = 0
 	},
-/turf/open/floor/circuit{
-	name = "Server Base";
-	initial_gas_mix = "n2=500;TEMP=80"
-	},
+/turf/open/floor/circuit/telecomms/server,
 /area/science/server)
 "cIg" = (
 /turf/closed/wall/r_wall,
@@ -73201,10 +73183,7 @@
 /obj/machinery/atmospherics/pipe/simple{
 	dir = 4
 	},
-/turf/open/floor/plasteel/black{
-	name = "Server Walkway";
-	initial_gas_mix = "n2=500;TEMP=80"
-	},
+/turf/open/floor/plasteel/black/telecomms/server/walkway,
 /area/science/server)
 "cIZ" = (
 /obj/effect/landmark/blobstart,
@@ -73218,10 +73197,7 @@
 	dir = 8;
 	pixel_x = 22
 	},
-/turf/open/floor/plasteel/black{
-	name = "Server Walkway";
-	initial_gas_mix = "n2=500;TEMP=80"
-	},
+/turf/open/floor/plasteel/black/telecomms/server/walkway,
 /area/science/server)
 "cJa" = (
 /obj/structure/cable/yellow{
@@ -73706,10 +73682,7 @@
 /area/science/server)
 "cJV" = (
 /obj/machinery/r_n_d/server/core,
-/turf/open/floor/circuit{
-	name = "Server Base";
-	initial_gas_mix = "n2=500;TEMP=80"
-	},
+/turf/open/floor/circuit/telecomms/server,
 /area/science/server)
 "cJW" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/siphon/on{
@@ -73717,10 +73690,7 @@
 	external_pressure_bound = 120;
 	name = "server vent"
 	},
-/turf/open/floor/circuit{
-	name = "Server Base";
-	initial_gas_mix = "n2=500;TEMP=80"
-	},
+/turf/open/floor/circuit/telecomms/server,
 /area/science/server)
 "cJX" = (
 /obj/structure/cable/yellow{
@@ -81645,10 +81615,7 @@
 /turf/open/floor/mineral/titanium/blue,
 /area/shuttle/escape)
 "cZv" = (
-/turf/open/floor/circuit{
-	name = "Killroom Floor";
-	initial_gas_mix = "n2=500;TEMP=80"
-	},
+/turf/open/floor/circuit/killroom,
 /area/science/xenobiology)
 "cZw" = (
 /obj/structure/table,
@@ -82244,17 +82211,11 @@
 	name = "server vent";
 	pressure_checks = 0
 	},
-/turf/open/floor/circuit{
-	name = "Killroom Floor";
-	initial_gas_mix = "n2=500;TEMP=80"
-	},
+/turf/open/floor/circuit/killroom,
 /area/science/xenobiology)
 "daS" = (
 /obj/structure/disposalpipe/segment,
-/turf/open/floor/circuit{
-	name = "Killroom Floor";
-	initial_gas_mix = "n2=500;TEMP=80"
-	},
+/turf/open/floor/circuit/killroom,
 /area/science/xenobiology)
 "daT" = (
 /turf/open/space,
@@ -82429,10 +82390,7 @@
 "dbv" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/light/small,
-/turf/open/floor/circuit{
-	name = "Killroom Floor";
-	initial_gas_mix = "n2=500;TEMP=80"
-	},
+/turf/open/floor/circuit/killroom,
 /area/science/xenobiology)
 "dbw" = (
 /obj/machinery/camera{
@@ -82441,10 +82399,7 @@
 	network = list("SS13","RD","Xeno");
 	start_active = 1
 	},
-/turf/open/floor/circuit{
-	name = "Killroom Floor";
-	initial_gas_mix = "n2=500;TEMP=80"
-	},
+/turf/open/floor/circuit/killroom,
 /area/science/xenobiology)
 "dbx" = (
 /obj/structure/table/optable,
@@ -83696,10 +83651,7 @@
 	external_pressure_bound = 120;
 	name = "server vent"
 	},
-/turf/open/floor/circuit{
-	name = "Killroom Floor";
-	initial_gas_mix = "n2=500;TEMP=80"
-	},
+/turf/open/floor/circuit/killroom,
 /area/science/xenobiology)
 "ddC" = (
 /obj/structure/disposalpipe/trunk{

--- a/_maps/map_files/OmegaStation/OmegaStation.dmm
+++ b/_maps/map_files/OmegaStation/OmegaStation.dmm
@@ -142,7 +142,6 @@
 "aaq" = (
 /obj/machinery/computer/med_data,
 /turf/open/floor/plasteel/darkblue/side{
-	icon_state = "darkblue";
 	dir = 1
 	},
 /area/bridge)
@@ -152,7 +151,6 @@
 	pixel_y = 32
 	},
 /turf/open/floor/plasteel/darkblue/side{
-	icon_state = "darkblue";
 	dir = 1
 	},
 /area/bridge)
@@ -200,14 +198,12 @@
 	pixel_y = 32
 	},
 /turf/open/floor/plasteel/darkyellow/side{
-	icon_state = "darkyellow";
 	dir = 1
 	},
 /area/bridge)
 "aaw" = (
 /obj/machinery/computer/security/mining,
 /turf/open/floor/plasteel/darkpurple/side{
-	icon_state = "darkpurple";
 	dir = 1
 	},
 /area/bridge)
@@ -242,7 +238,6 @@
 	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel/darkred/side{
-	icon_state = "darkred";
 	dir = 9
 	},
 /area/bridge)
@@ -360,7 +355,6 @@
 	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel/darkyellow/side{
-	icon_state = "darkyellow";
 	dir = 1
 	},
 /area/bridge)
@@ -374,7 +368,6 @@
 	pixel_y = 32
 	},
 /turf/open/floor/plasteel/darkyellow/side{
-	icon_state = "darkyellow";
 	dir = 1
 	},
 /area/bridge)
@@ -384,7 +377,6 @@
 	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel/darkyellow/side{
-	icon_state = "darkyellow";
 	dir = 5
 	},
 /area/bridge)
@@ -2853,7 +2845,6 @@
 "aeU" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/brown{
-	icon_state = "brown";
 	dir = 4
 	},
 /area/quartermaster/storage)
@@ -3300,7 +3291,6 @@
 	pixel_x = -22
 	},
 /turf/open/floor/plasteel/brown{
-	icon_state = "brown";
 	dir = 8
 	},
 /area/quartermaster/storage)
@@ -3326,7 +3316,6 @@
 	id = "cargounload"
 	},
 /turf/open/floor/plasteel/brown{
-	icon_state = "brown";
 	dir = 4
 	},
 /area/quartermaster/storage)
@@ -3787,7 +3776,6 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/brown{
-	icon_state = "brown";
 	dir = 8
 	},
 /area/quartermaster/storage)
@@ -3822,7 +3810,6 @@
 	dir = 10
 	},
 /turf/open/floor/plasteel/brown{
-	icon_state = "brown";
 	dir = 4
 	},
 /area/quartermaster/storage)
@@ -5111,7 +5098,6 @@
 	name = "Queue Shutters"
 	},
 /turf/open/floor/plasteel/loadingarea{
-	icon_state = "loadingarea";
 	dir = 1
 	},
 /area/hallway/primary/central{
@@ -5162,14 +5148,12 @@
 	pixel_x = -22
 	},
 /turf/open/floor/plasteel/brown{
-	icon_state = "brown";
 	dir = 9
 	},
 /area/quartermaster/storage)
 "aiJ" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/brown{
-	icon_state = "brown";
 	dir = 1
 	},
 /area/quartermaster/storage)
@@ -5178,7 +5162,6 @@
 	icon_state = "plant-22"
 	},
 /turf/open/floor/plasteel/brown{
-	icon_state = "brown";
 	dir = 1
 	},
 /area/quartermaster/storage)
@@ -5191,7 +5174,6 @@
 	dir = 1
 	},
 /turf/open/floor/plasteel/brown{
-	icon_state = "brown";
 	dir = 5
 	},
 /area/quartermaster/storage)
@@ -5214,7 +5196,6 @@
 /obj/item/pen/red,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plasteel/brown{
-	icon_state = "brown";
 	dir = 1
 	},
 /area/quartermaster/storage)
@@ -5225,7 +5206,6 @@
 	},
 /obj/item/paper_bin,
 /turf/open/floor/plasteel/brown{
-	icon_state = "brown";
 	dir = 5
 	},
 /area/quartermaster/storage)
@@ -5546,7 +5526,6 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plasteel/blue/corner{
-	icon_state = "bluecorner";
 	dir = 1
 	},
 /area/hallway/primary/central{
@@ -5555,7 +5534,6 @@
 "ajp" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden,
 /turf/open/floor/plasteel/blue/corner{
-	icon_state = "bluecorner";
 	dir = 1
 	},
 /area/hallway/primary/central{
@@ -5808,7 +5786,6 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel/brown{
-	icon_state = "brown";
 	dir = 4
 	},
 /area/quartermaster/storage)
@@ -5841,7 +5818,6 @@
 	pixel_x = 32
 	},
 /turf/open/floor/plasteel/brown{
-	icon_state = "brown";
 	dir = 4
 	},
 /area/quartermaster/storage)
@@ -6708,7 +6684,6 @@
 "akL" = (
 /obj/structure/closet/wardrobe/cargotech,
 /turf/open/floor/plasteel/brown{
-	icon_state = "brown";
 	dir = 8
 	},
 /area/quartermaster/storage)
@@ -6721,21 +6696,18 @@
 "akN" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plasteel/brown{
-	icon_state = "brown";
 	dir = 1
 	},
 /area/quartermaster/storage)
 "akO" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plasteel/brown{
-	icon_state = "brown";
 	dir = 1
 	},
 /area/quartermaster/storage)
 "akP" = (
 /obj/machinery/photocopier,
 /turf/open/floor/plasteel/brown{
-	icon_state = "brown";
 	dir = 5
 	},
 /area/quartermaster/storage)
@@ -7167,7 +7139,6 @@
 	network = list("SS13")
 	},
 /turf/open/floor/plasteel/brown{
-	icon_state = "brown";
 	dir = 8
 	},
 /area/quartermaster/storage)
@@ -7212,7 +7183,6 @@
 	icon_state = "0-8"
 	},
 /turf/open/floor/plasteel/brown{
-	icon_state = "brown";
 	dir = 4
 	},
 /area/quartermaster/storage)
@@ -7735,7 +7705,6 @@
 /obj/machinery/computer/stockexchange,
 /obj/structure/table/reinforced,
 /turf/open/floor/plasteel/brown{
-	icon_state = "brown";
 	dir = 10
 	},
 /area/quartermaster/storage)
@@ -7787,7 +7756,6 @@
 /obj/item/stack/cable_coil/white,
 /obj/item/hand_labeler,
 /turf/open/floor/plasteel/brown{
-	icon_state = "brown";
 	dir = 6
 	},
 /area/quartermaster/storage)
@@ -8726,7 +8694,6 @@
 	dir = 2
 	},
 /turf/open/floor/plasteel/brown{
-	icon_state = "brown";
 	dir = 1
 	},
 /area/hallway/primary/central{
@@ -8793,7 +8760,6 @@
 	dir = 8
 	},
 /turf/open/floor/plasteel/purple/side{
-	icon_state = "purple";
 	dir = 9
 	},
 /area/quartermaster/miningdock)
@@ -8806,7 +8772,6 @@
 	},
 /obj/effect/landmark/start/shaft_miner,
 /turf/open/floor/plasteel/brown{
-	icon_state = "brown";
 	dir = 5
 	},
 /area/quartermaster/miningdock)
@@ -9465,7 +9430,6 @@
 	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel/brown{
-	icon_state = "brown";
 	dir = 8
 	},
 /area/quartermaster/miningdock)
@@ -9477,7 +9441,6 @@
 	icon_state = "1-8"
 	},
 /turf/open/floor/plasteel/purple/side{
-	icon_state = "purple";
 	dir = 4
 	},
 /area/quartermaster/miningdock)
@@ -10222,14 +10185,12 @@
 	dir = 1
 	},
 /turf/open/floor/plasteel/purple/side{
-	icon_state = "purple";
 	dir = 8
 	},
 /area/quartermaster/miningdock)
 "aqs" = (
 /obj/machinery/computer/shuttle/mining,
 /turf/open/floor/plasteel/brown{
-	icon_state = "brown";
 	dir = 4
 	},
 /area/quartermaster/miningdock)
@@ -10362,7 +10323,6 @@
 	dir = 6
 	},
 /turf/open/floor/plasteel/vault{
-	icon_state = "vault";
 	dir = 8
 	},
 /area/security/brig)
@@ -10384,7 +10344,6 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel/vault{
-	icon_state = "vault";
 	dir = 8
 	},
 /area/security/brig)
@@ -10698,7 +10657,6 @@
 /obj/item/folder/yellow,
 /obj/item/toy/figure/miner,
 /turf/open/floor/plasteel/brown{
-	icon_state = "brown";
 	dir = 10
 	},
 /area/quartermaster/miningdock)
@@ -10711,7 +10669,6 @@
 	pixel_y = -32
 	},
 /turf/open/floor/plasteel/purple/side{
-	icon_state = "purple";
 	dir = 6
 	},
 /area/quartermaster/miningdock)
@@ -10915,7 +10872,6 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/green/side{
-	icon_state = "green";
 	dir = 1
 	},
 /area/engine/atmos)
@@ -12309,7 +12265,6 @@
 	pixel_x = 32
 	},
 /turf/open/floor/plasteel/caution/corner{
-	icon_state = "cautioncorner";
 	dir = 1
 	},
 /area/hallway/primary/central{
@@ -15940,7 +15895,6 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/arrival{
-	icon_state = "arrival";
 	dir = 9
 	},
 /area/engine/atmos)
@@ -16599,7 +16553,6 @@
 	dir = 8
 	},
 /turf/open/floor/plasteel/arrival{
-	icon_state = "arrival";
 	dir = 8
 	},
 /area/engine/atmos)
@@ -16710,7 +16663,6 @@
 /obj/structure/closet/crate/bin,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/caution{
-	icon_state = "caution";
 	dir = 10
 	},
 /area/engine/atmos)
@@ -17623,7 +17575,6 @@
 	icon_state = "1-4"
 	},
 /turf/open/floor/plasteel/escape{
-	icon_state = "escape";
 	dir = 1
 	},
 /area/hallway/secondary/exit{
@@ -17637,7 +17588,6 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plasteel/escape{
-	icon_state = "escape";
 	dir = 1
 	},
 /area/hallway/secondary/exit{
@@ -19031,7 +18981,6 @@
 	pixel_x = -32
 	},
 /turf/open/floor/plasteel/arrival{
-	icon_state = "arrival";
 	dir = 8
 	},
 /area/hallway/primary/central{
@@ -19472,7 +19421,6 @@
 	pixel_x = -24
 	},
 /turf/open/floor/plasteel/arrival{
-	icon_state = "arrival";
 	dir = 8
 	},
 /area/hallway/primary/central{
@@ -21675,20 +21623,17 @@
 /area/hydroponics)
 "aJO" = (
 /turf/open/floor/plasteel/greenblue/side{
-	icon_state = "greenblue";
 	dir = 9
 	},
 /area/hydroponics)
 "aJP" = (
 /turf/open/floor/plasteel/greenblue/side{
-	icon_state = "greenblue";
 	dir = 1
 	},
 /area/hydroponics)
 "aJQ" = (
 /obj/effect/landmark/start/botanist,
 /turf/open/floor/plasteel/greenblue/side{
-	icon_state = "greenblue";
 	dir = 1
 	},
 /area/hydroponics)
@@ -21703,7 +21648,6 @@
 	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel/greenblue/side{
-	icon_state = "greenblue";
 	dir = 1
 	},
 /area/hydroponics)
@@ -21712,7 +21656,6 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel/greenblue/side{
-	icon_state = "greenblue";
 	dir = 5
 	},
 /area/hydroponics)
@@ -22341,7 +22284,6 @@
 	icon_state = "1-8"
 	},
 /turf/open/floor/plasteel/purple/side{
-	icon_state = "purple";
 	dir = 5
 	},
 /area/janitor)
@@ -22384,7 +22326,6 @@
 "aKW" = (
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/plasteel/greenblue/side{
-	icon_state = "greenblue";
 	dir = 8
 	},
 /area/hydroponics)
@@ -22440,7 +22381,6 @@
 "aLb" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plasteel/greenblue/side{
-	icon_state = "greenblue";
 	dir = 4
 	},
 /area/hydroponics)
@@ -22565,7 +22505,6 @@
 	})
 "aLt" = (
 /turf/open/floor/plasteel/brown{
-	icon_state = "brown";
 	dir = 5
 	},
 /area/hallway/secondary/exit{
@@ -22988,7 +22927,6 @@
 /area/hydroponics)
 "aMl" = (
 /turf/open/floor/plasteel/greenblue/side{
-	icon_state = "greenblue";
 	dir = 10
 	},
 /area/hydroponics)
@@ -23037,7 +22975,6 @@
 "aMq" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plasteel/greenblue/side{
-	icon_state = "greenblue";
 	dir = 6
 	},
 /area/hydroponics)
@@ -23146,7 +23083,6 @@
 	layer = 4.1
 	},
 /turf/open/floor/plasteel/brown{
-	icon_state = "brown";
 	dir = 8
 	},
 /area/hallway/secondary/exit{
@@ -23171,7 +23107,6 @@
 "aMC" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/brown{
-	icon_state = "brown";
 	dir = 4
 	},
 /area/hallway/secondary/exit{
@@ -23821,7 +23756,6 @@
 	pixel_x = -23
 	},
 /turf/open/floor/plasteel/brown{
-	icon_state = "brown";
 	dir = 8
 	},
 /area/hallway/secondary/exit{
@@ -24180,7 +24114,6 @@
 	layer = 4.1
 	},
 /turf/open/floor/plasteel/redyellow/side{
-	icon_state = "redyellow";
 	dir = 9
 	},
 /area/hallway/primary/central)
@@ -24192,20 +24125,17 @@
 	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel/redyellow/side{
-	icon_state = "redyellow";
 	dir = 1
 	},
 /area/hallway/primary/central)
 "aOo" = (
 /turf/open/floor/plasteel/redyellow/side{
-	icon_state = "redyellow";
 	dir = 1
 	},
 /area/hallway/primary/central)
 "aOp" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plasteel/redyellow/side{
-	icon_state = "redyellow";
 	dir = 1
 	},
 /area/hallway/primary/central)
@@ -24214,7 +24144,6 @@
 	icon_state = "plant-22"
 	},
 /turf/open/floor/plasteel/redyellow/side{
-	icon_state = "redyellow";
 	dir = 5
 	},
 /area/hallway/primary/central)
@@ -24628,7 +24557,6 @@
 	network = list("SS13","Prison")
 	},
 /turf/open/floor/plasteel/green/corner{
-	icon_state = "greencorner";
 	dir = 1
 	},
 /area/hallway/primary/central{
@@ -24656,7 +24584,6 @@
 	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel/purple/corner{
-	icon_state = "purplecorner";
 	dir = 1
 	},
 /area/hallway/primary/central{
@@ -24683,7 +24610,6 @@
 	icon_state = "0-8"
 	},
 /turf/open/floor/plasteel/green/corner{
-	icon_state = "greencorner";
 	dir = 1
 	},
 /area/hallway/primary/central{
@@ -24739,7 +24665,6 @@
 	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel/green/corner{
-	icon_state = "greencorner";
 	dir = 1
 	},
 /area/hallway/primary/central{
@@ -24755,7 +24680,6 @@
 	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel/blue/corner{
-	icon_state = "bluecorner";
 	dir = 1
 	},
 /area/hallway/primary/central{
@@ -24775,7 +24699,6 @@
 	network = list("SS13","Prison")
 	},
 /turf/open/floor/plasteel/green/corner{
-	icon_state = "greencorner";
 	dir = 1
 	},
 /area/hallway/primary/central{
@@ -24804,7 +24727,6 @@
 	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel/blue/corner{
-	icon_state = "bluecorner";
 	dir = 1
 	},
 /area/hallway/primary/central)
@@ -24819,7 +24741,6 @@
 	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel/green/corner{
-	icon_state = "greencorner";
 	dir = 1
 	},
 /area/hallway/primary/central)
@@ -24833,7 +24754,6 @@
 	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel/blue/corner{
-	icon_state = "bluecorner";
 	dir = 1
 	},
 /area/hallway/primary/central)
@@ -24850,7 +24770,6 @@
 	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel/green/corner{
-	icon_state = "greencorner";
 	dir = 1
 	},
 /area/hallway/primary/central)
@@ -27089,7 +27008,6 @@
 "aTw" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plasteel/blue/corner{
-	icon_state = "bluecorner";
 	dir = 1
 	},
 /area/hallway/primary/central)
@@ -27138,7 +27056,6 @@
 "aTE" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plasteel/purple/corner{
-	icon_state = "purplecorner";
 	dir = 4
 	},
 /area/hallway/primary/central)
@@ -27554,7 +27471,6 @@
 	icon_state = "1-4"
 	},
 /turf/open/floor/plasteel/whiteyellow/corner{
-	icon_state = "whiteyellowcorner";
 	dir = 8
 	},
 /area/medical/chemistry)
@@ -27948,13 +27864,11 @@
 "aVk" = (
 /obj/effect/landmark/start/chemist,
 /turf/open/floor/plasteel/whiteyellow/corner{
-	icon_state = "whiteyellowcorner";
 	dir = 8
 	},
 /area/medical/chemistry)
 "aVl" = (
 /turf/open/floor/plasteel/whiteyellow/corner{
-	icon_state = "whiteyellowcorner";
 	dir = 8
 	},
 /area/medical/chemistry)
@@ -29391,7 +29305,6 @@
 	dir = 8
 	},
 /turf/open/floor/plasteel/blue/corner{
-	icon_state = "bluecorner";
 	dir = 1
 	},
 /area/hallway/primary/central)
@@ -30813,7 +30726,6 @@
 "baG" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plasteel/blue/corner{
-	icon_state = "bluecorner";
 	dir = 8
 	},
 /area/hallway/primary/central)
@@ -31267,7 +31179,6 @@
 	dir = 8
 	},
 /turf/open/floor/plasteel/blue/corner{
-	icon_state = "bluecorner";
 	dir = 8
 	},
 /area/hallway/primary/central)
@@ -33270,7 +33181,6 @@
 	pixel_x = -23
 	},
 /turf/open/floor/plasteel/blue/corner{
-	icon_state = "bluecorner";
 	dir = 8
 	},
 /area/hallway/primary/central)
@@ -33662,7 +33572,6 @@
 	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel/blue/corner{
-	icon_state = "bluecorner";
 	dir = 8
 	},
 /area/hallway/primary/central)
@@ -34478,8 +34387,7 @@
 	icon_state = "1-4"
 	},
 /turf/open/floor/plasteel/whitepurple/side{
-	dir = 5;
-	initial_gas_mix = "o2=22;n2=82;TEMP=293.15"
+	dir = 5
 	},
 /area/science/xenobiology)
 "bhe" = (
@@ -34508,7 +34416,6 @@
 /area/science/xenobiology)
 "bhf" = (
 /turf/open/floor/plasteel/vault{
-	icon_state = "vault";
 	dir = 8
 	},
 /area/science/xenobiology)
@@ -35695,15 +35602,13 @@
 /area/science/xenobiology)
 "bjs" = (
 /turf/open/floor/plasteel/whitepurple/side{
-	icon_state = "whitepurple";
 	dir = 1
 	},
 /area/science/xenobiology)
 "bjt" = (
 /obj/effect/landmark/start/scientist,
 /turf/open/floor/plasteel/whitepurple/side{
-	dir = 5;
-	initial_gas_mix = "o2=22;n2=82;TEMP=293.15"
+	dir = 5
 	},
 /area/science/xenobiology)
 "bju" = (
@@ -35804,8 +35709,7 @@
 /area/science/xenobiology)
 "bjG" = (
 /turf/open/floor/plasteel/whitepurple/side{
-	dir = 6;
-	initial_gas_mix = "o2=22;n2=82;TEMP=293.15"
+	dir = 6
 	},
 /area/science/xenobiology)
 "bjH" = (
@@ -36430,7 +36334,6 @@
 	dir = 1
 	},
 /turf/open/floor/plasteel/blue/corner{
-	icon_state = "bluecorner";
 	dir = 8
 	},
 /area/shuttle/arrival)
@@ -36511,7 +36414,6 @@
 	dir = 1
 	},
 /turf/open/floor/plasteel/blue/side{
-	icon_state = "blue";
 	dir = 4
 	},
 /area/shuttle/arrival)
@@ -38517,7 +38419,6 @@
 	icon_state = "2-4"
 	},
 /turf/open/floor/plasteel/escape{
-	icon_state = "escape";
 	dir = 1
 	},
 /area/hallway/secondary/exit{
@@ -38941,7 +38842,6 @@
 	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel/brown{
-	icon_state = "brown";
 	dir = 9
 	},
 /area/hallway/secondary/exit{
@@ -38957,7 +38857,6 @@
 	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel/brown{
-	icon_state = "brown";
 	dir = 1
 	},
 /area/hallway/secondary/exit{
@@ -38985,7 +38884,6 @@
 	icon_state = "1-8"
 	},
 /turf/open/floor/plasteel/brown{
-	icon_state = "brown";
 	dir = 1
 	},
 /area/hallway/secondary/exit{

--- a/_maps/map_files/PubbyStation/PubbyStation.dmm
+++ b/_maps/map_files/PubbyStation/PubbyStation.dmm
@@ -7461,9 +7461,7 @@
 "aqB" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on,
 /turf/open/floor/plasteel/darkred/side{
-	icon_state = "darkred";
-	dir = 1;
-	baseturf = /turf/open/floor/plating/asteroid/airless
+	dir = 1
 	},
 /area/security/brig)
 "aqC" = (
@@ -7474,9 +7472,7 @@
 	pixel_y = 32
 	},
 /turf/open/floor/plasteel/darkred/side{
-	icon_state = "darkred";
-	dir = 1;
-	baseturf = /turf/open/floor/plating/asteroid/airless
+	dir = 1
 	},
 /area/security/brig)
 "aqE" = (
@@ -9468,7 +9464,6 @@
 	pixel_x = -22
 	},
 /turf/open/floor/plasteel/darkpurple/side{
-	icon_state = "darkpurple";
 	dir = 1
 	},
 /area/bridge)
@@ -9479,7 +9474,6 @@
 	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel/darkpurple/side{
-	icon_state = "darkpurple";
 	dir = 1
 	},
 /area/bridge)
@@ -13450,7 +13444,6 @@
 	pixel_x = 28
 	},
 /turf/open/floor/plasteel/neutral/side{
-	icon_state = "neutral";
 	dir = 4
 	},
 /area/storage/primary)
@@ -13943,7 +13936,6 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel/neutral/side{
-	icon_state = "neutral";
 	dir = 4
 	},
 /area/storage/primary)
@@ -14370,7 +14362,6 @@
 /obj/item/stack/packageWrap,
 /obj/item/stack/packageWrap,
 /turf/open/floor/plasteel/neutral/side{
-	icon_state = "neutral";
 	dir = 4
 	},
 /area/storage/primary)
@@ -14705,8 +14696,7 @@
 "aGj" = (
 /obj/machinery/disposal/bin,
 /turf/open/floor/plasteel/neutral/side{
-	dir = 6;
-	initial_gas_mix = "o2=22;n2=82;TEMP=293.15"
+	dir = 6
 	},
 /area/storage/primary)
 "aGk" = (
@@ -22944,7 +22934,6 @@
 /area/hydroponics)
 "aXV" = (
 /turf/open/floor/plasteel/neutral/side{
-	icon_state = "neutral";
 	dir = 5
 	},
 /area/hydroponics)
@@ -23030,9 +23019,7 @@
 	pixel_y = 10
 	},
 /turf/open/floor/plasteel/darkred/side{
-	icon_state = "darkred";
-	dir = 1;
-	baseturf = /turf/open/floor/plating/asteroid/airless
+	dir = 1
 	},
 /area/crew_quarters/bar)
 "aYf" = (
@@ -23040,17 +23027,13 @@
 /obj/item/book/manual/barman_recipes,
 /obj/item/reagent_containers/glass/rag,
 /turf/open/floor/plasteel/darkred/side{
-	icon_state = "darkred";
-	dir = 1;
-	baseturf = /turf/open/floor/plating/asteroid/airless
+	dir = 1
 	},
 /area/crew_quarters/bar)
 "aYg" = (
 /obj/structure/table/reinforced,
 /turf/open/floor/plasteel/darkred/side{
-	icon_state = "darkred";
-	dir = 1;
-	baseturf = /turf/open/floor/plating/asteroid/airless
+	dir = 1
 	},
 /area/crew_quarters/bar)
 "aYh" = (
@@ -23058,9 +23041,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/item/device/instrument/guitar,
 /turf/open/floor/plasteel/darkred/side{
-	icon_state = "darkred";
-	dir = 1;
-	baseturf = /turf/open/floor/plating/asteroid/airless
+	dir = 1
 	},
 /area/crew_quarters/bar)
 "aYi" = (
@@ -23072,9 +23053,7 @@
 	pixel_y = 10
 	},
 /turf/open/floor/plasteel/darkred/side{
-	icon_state = "darkred";
-	dir = 1;
-	baseturf = /turf/open/floor/plating/asteroid/airless
+	dir = 1
 	},
 /area/crew_quarters/bar)
 "aYj" = (
@@ -29046,10 +29025,7 @@
 	pixel_x = 0;
 	pixel_y = 32
 	},
-/turf/open/floor/circuit{
-	name = "Server Base";
-	initial_gas_mix = "n2=500;TEMP=80"
-	},
+/turf/open/floor/circuit/telecomms/server,
 /area/science/server)
 "blN" = (
 /obj/machinery/light{
@@ -29060,10 +29036,7 @@
 	pixel_x = 0;
 	pixel_y = 32
 	},
-/turf/open/floor/plasteel/black{
-	name = "Server Walkway";
-	initial_gas_mix = "n2=500;TEMP=80"
-	},
+/turf/open/floor/plasteel/black/telecomms/server/walkway,
 /area/science/server)
 "blO" = (
 /obj/machinery/r_n_d/server/robotics,
@@ -29071,10 +29044,7 @@
 	pixel_x = 0;
 	pixel_y = 32
 	},
-/turf/open/floor/circuit{
-	name = "Server Base";
-	initial_gas_mix = "n2=500;TEMP=80"
-	},
+/turf/open/floor/circuit/telecomms/server,
 /area/science/server)
 "blP" = (
 /obj/effect/landmark/event_spawn,
@@ -29420,7 +29390,6 @@
 "bmA" = (
 /obj/machinery/door/firedoor,
 /turf/open/floor/plasteel/blue/side{
-	icon_state = "blue";
 	dir = 8
 	},
 /area/medical/medbay/central)
@@ -29562,19 +29531,13 @@
 	external_pressure_bound = 120;
 	name = "server vent"
 	},
-/turf/open/floor/circuit{
-	name = "Server Base";
-	initial_gas_mix = "n2=500;TEMP=80"
-	},
+/turf/open/floor/circuit/telecomms/server,
 /area/science/server)
 "bmT" = (
 /obj/machinery/atmospherics/pipe/manifold/general/visible{
 	dir = 1
 	},
-/turf/open/floor/plasteel/black{
-	name = "Server Walkway";
-	initial_gas_mix = "n2=500;TEMP=80"
-	},
+/turf/open/floor/plasteel/black/telecomms/server/walkway,
 /area/science/server)
 "bmU" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
@@ -29583,10 +29546,7 @@
 	name = "server vent";
 	pressure_checks = 0
 	},
-/turf/open/floor/circuit{
-	name = "Server Base";
-	initial_gas_mix = "n2=500;TEMP=80"
-	},
+/turf/open/floor/circuit/telecomms/server,
 /area/science/server)
 "bmV" = (
 /obj/machinery/atmospherics/components/unary/outlet_injector{
@@ -30915,7 +30875,6 @@
 	pixel_y = 0
 	},
 /turf/open/floor/plasteel/yellow/corner{
-	icon_state = "yellowcorner";
 	dir = 4
 	},
 /area/hallway/primary/aft)
@@ -31635,7 +31594,6 @@
 "bro" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plasteel/yellow/corner{
-	icon_state = "yellowcorner";
 	dir = 4
 	},
 /area/hallway/primary/aft)
@@ -32626,7 +32584,6 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel/darkpurple/side{
-	icon_state = "darkpurple";
 	dir = 1
 	},
 /area/science/xenobiology)
@@ -32635,7 +32592,6 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel/darkgreen/side{
-	icon_state = "darkgreen";
 	dir = 1
 	},
 /area/science/xenobiology)
@@ -32649,7 +32605,6 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel/darkgreen/side{
-	icon_state = "darkgreen";
 	dir = 1
 	},
 /area/science/xenobiology)
@@ -32661,7 +32616,6 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel/darkpurple/side{
-	icon_state = "darkpurple";
 	dir = 1
 	},
 /area/science/xenobiology)
@@ -32670,7 +32624,6 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel/darkpurple/side{
-	icon_state = "darkpurple";
 	dir = 1
 	},
 /area/science/xenobiology)
@@ -32684,7 +32637,6 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel/darkpurple/side{
-	icon_state = "darkpurple";
 	dir = 1
 	},
 /area/science/xenobiology)
@@ -32702,7 +32654,6 @@
 	pixel_y = 28
 	},
 /turf/open/floor/plasteel/darkpurple/side{
-	icon_state = "darkpurple";
 	dir = 1
 	},
 /area/science/xenobiology)
@@ -32716,7 +32667,6 @@
 	dir = 10
 	},
 /turf/open/floor/plasteel/darkpurple/side{
-	icon_state = "darkpurple";
 	dir = 1
 	},
 /area/science/xenobiology)
@@ -33857,7 +33807,6 @@
 	dir = 1
 	},
 /turf/open/floor/plasteel/darkpurple/side{
-	icon_state = "darkpurple";
 	dir = 1
 	},
 /area/science/research)
@@ -33901,7 +33850,6 @@
 	pixel_y = 30
 	},
 /turf/open/floor/plasteel/darkpurple/side{
-	icon_state = "darkpurple";
 	dir = 1
 	},
 /area/science/research)
@@ -33910,7 +33858,6 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel/darkpurple/side{
-	icon_state = "darkpurple";
 	dir = 1
 	},
 /area/science/research)
@@ -33919,13 +33866,11 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel/darkpurple/side{
-	icon_state = "darkpurple";
 	dir = 1
 	},
 /area/science/research)
 "bvS" = (
 /turf/open/floor/plasteel/darkpurple/side{
-	icon_state = "darkpurple";
 	dir = 1
 	},
 /area/science/research)
@@ -33939,7 +33884,6 @@
 	dir = 1
 	},
 /turf/open/floor/plasteel/darkpurple/side{
-	icon_state = "darkpurple";
 	dir = 1
 	},
 /area/science/research)
@@ -33949,7 +33893,6 @@
 	layer = 4.1
 	},
 /turf/open/floor/plasteel/darkpurple/side{
-	icon_state = "darkpurple";
 	dir = 1
 	},
 /area/science/research)
@@ -36766,7 +36709,6 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plasteel/darkpurple/side{
-	icon_state = "darkpurple";
 	dir = 1
 	},
 /area/crew_quarters/heads/hor)
@@ -36776,7 +36718,6 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel/darkpurple/side{
-	icon_state = "darkpurple";
 	dir = 1
 	},
 /area/crew_quarters/heads/hor)
@@ -36787,7 +36728,6 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel/darkpurple/side{
-	icon_state = "darkpurple";
 	dir = 1
 	},
 /area/crew_quarters/heads/hor)
@@ -39395,7 +39335,6 @@
 	pixel_y = 24
 	},
 /turf/open/floor/plasteel/whitegreen/side{
-	icon_state = "whitegreen";
 	dir = 9
 	},
 /area/medical/virology)
@@ -39421,7 +39360,6 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/cyan/hidden,
 /turf/open/floor/plasteel/whitegreen/side{
-	icon_state = "whitegreen";
 	dir = 5
 	},
 /area/medical/virology)
@@ -39865,7 +39803,6 @@
 "bHU" = (
 /obj/machinery/vending/medical,
 /turf/open/floor/plasteel/whitegreen/side{
-	icon_state = "whitegreen";
 	dir = 9
 	},
 /area/medical/virology)
@@ -41010,7 +40947,6 @@
 "bKu" = (
 /obj/machinery/smartfridge/chemistry/virology/preloaded,
 /turf/open/floor/plasteel/whitegreen/side{
-	icon_state = "whitegreen";
 	dir = 4
 	},
 /area/medical/virology)
@@ -41548,7 +41484,6 @@
 	layer = 3
 	},
 /turf/open/floor/plasteel/whitegreen/side{
-	icon_state = "whitegreen";
 	dir = 4
 	},
 /area/medical/virology)
@@ -42016,7 +41951,6 @@
 	},
 /obj/item/reagent_containers/spray/cleaner,
 /turf/open/floor/plasteel/whitegreen/side{
-	icon_state = "whitegreen";
 	dir = 6
 	},
 /area/medical/virology)
@@ -42583,7 +42517,6 @@
 	},
 /obj/machinery/portable_atmospherics/pump,
 /turf/open/floor/plasteel/arrival{
-	icon_state = "arrival";
 	dir = 9
 	},
 /area/hallway/primary/aft)
@@ -53786,23 +53719,17 @@
 /area/shuttle/pod_1)
 "coa" = (
 /turf/open/floor/plasteel/darkred/side{
-	icon_state = "darkred";
-	dir = 1;
-	baseturf = /turf/open/floor/plating/asteroid/airless
+	dir = 1
 	},
 /area/security/brig)
 "cob" = (
 /turf/open/floor/plasteel/darkred/side{
-	icon_state = "darkred";
-	dir = 1;
-	baseturf = /turf/open/floor/plating/asteroid/airless
+	dir = 1
 	},
 /area/security/brig)
 "coc" = (
 /turf/open/floor/plasteel/darkred/side{
-	icon_state = "darkred";
-	dir = 1;
-	baseturf = /turf/open/floor/plating/asteroid/airless
+	dir = 1
 	},
 /area/security/brig)
 "cod" = (
@@ -54228,9 +54155,7 @@
 "cpf" = (
 /obj/structure/table/reinforced,
 /turf/open/floor/plasteel/darkred/side{
-	icon_state = "darkred";
-	dir = 1;
-	baseturf = /turf/open/floor/plating/asteroid/airless
+	dir = 1
 	},
 /area/crew_quarters/bar)
 "cpg" = (
@@ -58084,7 +58009,6 @@
 /area/library)
 "cAB" = (
 /turf/open/floor/plasteel/darkpurple/side{
-	icon_state = "darkpurple";
 	dir = 1
 	},
 /area/library)
@@ -58107,7 +58031,6 @@
 /area/library)
 "cAE" = (
 /turf/open/floor/plasteel/darkpurple/side{
-	icon_state = "darkpurple";
 	dir = 1
 	},
 /area/library)

--- a/_maps/map_files/debug/runtimestation.dmm
+++ b/_maps/map_files/debug/runtimestation.dmm
@@ -712,7 +712,6 @@
 	},
 /obj/structure/closet/firecloset/full,
 /turf/open/floor/plasteel/arrival{
-	icon_state = "arrival";
 	dir = 9
 	},
 /area/hallway/secondary/entry)

--- a/_maps/map_files/generic/CentCom.dmm
+++ b/_maps/map_files/generic/CentCom.dmm
@@ -2998,7 +2998,6 @@
 /area/centcom/supply)
 "iT" = (
 /turf/open/floor/plasteel/brown{
-	icon_state = "brown";
 	dir = 1
 	},
 /area/centcom/supply)
@@ -3008,7 +3007,6 @@
 	pixel_x = 24
 	},
 /turf/open/floor/plasteel/brown{
-	icon_state = "brown";
 	dir = 5
 	},
 /area/centcom/supply)
@@ -3808,7 +3806,6 @@
 /area/centcom/supply)
 "kL" = (
 /turf/open/floor/plasteel/brown{
-	icon_state = "brown";
 	dir = 6
 	},
 /area/centcom/supply)
@@ -4105,7 +4102,6 @@
 /area/centcom/supply)
 "lv" = (
 /turf/open/floor/plasteel/brown{
-	icon_state = "brown";
 	dir = 9
 	},
 /area/centcom/supply)
@@ -4115,7 +4111,6 @@
 	pixel_x = 24
 	},
 /turf/open/floor/plasteel/brown{
-	icon_state = "brown";
 	dir = 5
 	},
 /area/centcom/supply)
@@ -4230,7 +4225,6 @@
 	dir = 8
 	},
 /turf/open/floor/plasteel/brown{
-	icon_state = "brown";
 	dir = 9
 	},
 /area/centcom/supply)
@@ -4239,7 +4233,6 @@
 	dir = 1
 	},
 /turf/open/floor/plasteel/brown{
-	icon_state = "brown";
 	dir = 1
 	},
 /area/centcom/supply)
@@ -4249,7 +4242,6 @@
 	pixel_x = 32
 	},
 /turf/open/floor/plasteel/brown{
-	icon_state = "brown";
 	dir = 5
 	},
 /area/centcom/supply)
@@ -4439,7 +4431,6 @@
 /area/centcom/supply)
 "mm" = (
 /turf/open/floor/plasteel/brown{
-	icon_state = "brown";
 	dir = 10
 	},
 /area/centcom/supply)
@@ -4622,7 +4613,6 @@
 	pixel_y = -26
 	},
 /turf/open/floor/plasteel/brown{
-	icon_state = "brown";
 	dir = 6
 	},
 /area/centcom/supply)
@@ -5077,7 +5067,6 @@
 /area/centcom/supply)
 "nQ" = (
 /turf/open/floor/plasteel/brown{
-	icon_state = "brown";
 	dir = 5
 	},
 /area/centcom/supply)
@@ -6437,7 +6426,6 @@
 /area/centcom/ferry)
 "qO" = (
 /turf/open/floor/plasteel/darkred/side{
-	icon_state = "darkred";
 	dir = 1
 	},
 /area/centcom/control)
@@ -7332,7 +7320,6 @@
 /area/centcom/evac)
 "sY" = (
 /turf/open/floor/plasteel/blue/corner{
-	icon_state = "bluecorner";
 	dir = 8
 	},
 /area/centcom/evac)
@@ -7632,7 +7619,6 @@
 /area/centcom/evac)
 "tJ" = (
 /turf/open/floor/plasteel/blue/side{
-	icon_state = "blue";
 	dir = 5
 	},
 /area/centcom/evac)
@@ -7641,13 +7627,11 @@
 /area/centcom/evac)
 "tL" = (
 /turf/open/floor/plasteel/blue/side{
-	icon_state = "blue";
 	dir = 4
 	},
 /area/centcom/evac)
 "tM" = (
 /turf/open/floor/plasteel/blue/side{
-	icon_state = "blue";
 	dir = 8
 	},
 /area/centcom/evac)
@@ -7838,7 +7822,6 @@
 /area/centcom/evac)
 "uo" = (
 /turf/open/floor/plasteel/blue/side{
-	icon_state = "blue";
 	dir = 6
 	},
 /area/centcom/evac)
@@ -8036,7 +8019,6 @@
 /area/centcom/evac)
 "uQ" = (
 /turf/open/floor/plasteel/neutral/side{
-	icon_state = "neutral";
 	dir = 5
 	},
 /area/centcom/evac)
@@ -8168,13 +8150,11 @@
 /area/centcom/control)
 "vm" = (
 /turf/open/floor/plasteel/blue/side{
-	icon_state = "blue";
 	dir = 9
 	},
 /area/centcom/evac)
 "vn" = (
 /turf/open/floor/plasteel/blue/side{
-	icon_state = "blue";
 	dir = 10
 	},
 /area/centcom/evac)
@@ -8520,13 +8500,11 @@
 /area/centcom/control)
 "wd" = (
 /turf/open/floor/plasteel/blue/corner{
-	icon_state = "bluecorner";
 	dir = 1
 	},
 /area/centcom/evac)
 "we" = (
 /turf/open/floor/plasteel/blue/side{
-	icon_state = "blue";
 	dir = 1
 	},
 /area/centcom/evac)
@@ -10360,7 +10338,6 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel/whitegreen/side{
-	icon_state = "whitegreen";
 	dir = 9
 	},
 /area/tdome/tdomeobserve)
@@ -10377,7 +10354,6 @@
 	dir = 8
 	},
 /turf/open/floor/plasteel/whitegreen/side{
-	icon_state = "whitegreen";
 	dir = 5
 	},
 /area/tdome/tdomeobserve)
@@ -10403,7 +10379,6 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel/whitered/corner{
-	icon_state = "whiteredcorner";
 	dir = 1
 	},
 /area/tdome/tdomeobserve)
@@ -10416,7 +10391,6 @@
 	dir = 8
 	},
 /turf/open/floor/plasteel/whitered/corner{
-	icon_state = "whiteredcorner";
 	dir = 4
 	},
 /area/tdome/tdomeobserve)
@@ -10947,7 +10921,6 @@
 	dir = 1
 	},
 /turf/open/floor/plasteel/whitegreen/side{
-	icon_state = "whitegreen";
 	dir = 4
 	},
 /area/tdome/tdomeobserve)
@@ -10977,7 +10950,6 @@
 	pixel_x = -28
 	},
 /turf/open/floor/plasteel/whitered/corner{
-	icon_state = "whiteredcorner";
 	dir = 1
 	},
 /area/tdome/tdomeobserve)
@@ -11157,7 +11129,6 @@
 	pixel_x = -28
 	},
 /turf/open/floor/plasteel/whitered/corner{
-	icon_state = "whiteredcorner";
 	dir = 8
 	},
 /area/tdome/tdomeobserve)
@@ -11302,7 +11273,6 @@
 	pixel_x = 28
 	},
 /turf/open/floor/plasteel/whitegreen/side{
-	icon_state = "whitegreen";
 	dir = 4
 	},
 /area/tdome/tdomeobserve)
@@ -11632,7 +11602,6 @@
 	name = "Thunderdome Blast Door"
 	},
 /turf/open/floor/plasteel/loadingarea{
-	baseturf = /turf/open/space;
 	dir = 8
 	},
 /area/tdome/arena)
@@ -11663,7 +11632,6 @@
 	name = "General Supply"
 	},
 /turf/open/floor/plasteel/loadingarea{
-	baseturf = /turf/open/space;
 	dir = 8
 	},
 /area/tdome/arena)
@@ -11811,7 +11779,6 @@
 /area/tdome/arena)
 "Ey" = (
 /turf/open/floor/plasteel/loadingarea{
-	baseturf = /turf/open/space;
 	dir = 8
 	},
 /area/tdome/arena)
@@ -12044,7 +12011,6 @@
 /area/tdome/tdomeadmin)
 "Ff" = (
 /turf/open/floor/plasteel/darkgreen/side{
-	icon_state = "darkgreen";
 	dir = 1
 	},
 /area/tdome/tdomeadmin)
@@ -12968,7 +12934,6 @@
 /area/tdome/arena_source)
 "IS" = (
 /turf/open/floor/plasteel/loadingarea{
-	baseturf = /turf/open/space;
 	dir = 8
 	},
 /area/tdome/arena_source)
@@ -13116,7 +13081,6 @@
 	dir = 1
 	},
 /turf/open/floor/plasteel/brown{
-	icon_state = "brown";
 	dir = 1
 	},
 /area/centcom/supply)

--- a/_maps/shuttles/emergency_cere.dmm
+++ b/_maps/shuttles/emergency_cere.dmm
@@ -155,7 +155,6 @@
 /area/shuttle/escape)
 "aE" = (
 /turf/open/floor/plasteel/darkyellow/side{
-	icon_state = "darkyellow";
 	dir = 1
 	},
 /area/shuttle/escape)
@@ -180,7 +179,6 @@
 /area/shuttle/escape)
 "aJ" = (
 /turf/open/floor/plasteel/darkred/side{
-	icon_state = "darkred";
 	dir = 1
 	},
 /area/shuttle/escape)
@@ -225,7 +223,6 @@
 	pixel_y = -29
 	},
 /turf/open/floor/plasteel/darkred/side{
-	icon_state = "darkred";
 	dir = 1
 	},
 /area/shuttle/escape)
@@ -302,13 +299,11 @@
 /area/shuttle/escape)
 "aZ" = (
 /turf/open/floor/plasteel/neutral/side{
-	icon_state = "neutral";
 	dir = 8
 	},
 /area/shuttle/escape)
 "ba" = (
 /turf/open/floor/plasteel/neutral/side{
-	icon_state = "neutral";
 	dir = 4
 	},
 /area/shuttle/escape)
@@ -443,7 +438,6 @@
 	pixel_x = -28
 	},
 /turf/open/floor/plasteel/brown{
-	icon_state = "brown";
 	dir = 8
 	},
 /area/shuttle/escape)
@@ -465,7 +459,6 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel/brown{
-	icon_state = "brown";
 	dir = 4
 	},
 /area/shuttle/escape)
@@ -524,7 +517,6 @@
 /area/shuttle/escape)
 "bB" = (
 /turf/open/floor/plasteel/brown{
-	icon_state = "brown";
 	dir = 8
 	},
 /area/shuttle/escape)
@@ -536,7 +528,6 @@
 /obj/effect/turf_decal/delivery,
 /obj/structure/closet/crate,
 /turf/open/floor/plasteel/brown{
-	icon_state = "brown";
 	dir = 4
 	},
 /area/shuttle/escape)
@@ -602,7 +593,6 @@
 /area/shuttle/escape)
 "bM" = (
 /turf/open/floor/plasteel/brown{
-	icon_state = "brown";
 	dir = 10
 	},
 /area/shuttle/escape)
@@ -617,7 +607,6 @@
 /obj/effect/turf_decal/delivery,
 /obj/structure/closet,
 /turf/open/floor/plasteel/brown{
-	icon_state = "brown";
 	dir = 6
 	},
 /area/shuttle/escape)
@@ -629,7 +618,6 @@
 /area/shuttle/escape)
 "bR" = (
 /turf/open/floor/plasteel/neutral/side{
-	icon_state = "neutral";
 	dir = 1
 	},
 /area/shuttle/escape)
@@ -707,7 +695,6 @@
 "cc" = (
 /obj/machinery/light,
 /turf/open/floor/plasteel/neutral/side{
-	icon_state = "neutral";
 	dir = 1
 	},
 /area/shuttle/escape)
@@ -746,13 +733,11 @@
 	name = "Speedy* Recovery"
 	},
 /turf/open/floor/plasteel/whiteblue/side{
-	icon_state = "whiteblue";
 	dir = 9
 	},
 /area/shuttle/escape)
 "ci" = (
 /turf/open/floor/plasteel/whiteblue/side{
-	icon_state = "whiteblue";
 	dir = 1
 	},
 /area/shuttle/escape)
@@ -760,21 +745,18 @@
 /obj/machinery/atmospherics/components/unary/portables_connector/visible,
 /obj/machinery/portable_atmospherics/canister/oxygen,
 /turf/open/floor/plasteel/whiteblue/side{
-	icon_state = "whiteblue";
 	dir = 1
 	},
 /area/shuttle/escape)
 "ck" = (
 /obj/machinery/atmospherics/components/unary/cryo_cell,
 /turf/open/floor/plasteel/whiteblue/side{
-	icon_state = "whiteblue";
 	dir = 1
 	},
 /area/shuttle/escape)
 "cl" = (
 /obj/machinery/atmospherics/components/unary/thermomachine/freezer,
 /turf/open/floor/plasteel/whiteblue/side{
-	icon_state = "whiteblue";
 	dir = 1
 	},
 /area/shuttle/escape)
@@ -783,7 +765,6 @@
 /obj/item/reagent_containers/glass/beaker/cryoxadone,
 /obj/item/wrench,
 /turf/open/floor/plasteel/whiteblue/side{
-	icon_state = "whiteblue";
 	dir = 5
 	},
 /area/shuttle/escape)
@@ -793,7 +774,6 @@
 /area/shuttle/escape)
 "co" = (
 /turf/open/floor/plasteel/whiteblue/side{
-	icon_state = "whiteblue";
 	dir = 8
 	},
 /area/shuttle/escape)
@@ -820,7 +800,6 @@
 /area/shuttle/escape)
 "ct" = (
 /turf/open/floor/plasteel/whiteblue/corner{
-	icon_state = "whitebluecorner";
 	dir = 4
 	},
 /area/shuttle/escape)
@@ -832,13 +811,11 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel/whiteblue/side{
-	icon_state = "whiteblue";
 	dir = 5
 	},
 /area/shuttle/escape)
 "cv" = (
 /turf/open/floor/plasteel/whiteblue/side{
-	icon_state = "whiteblue";
 	dir = 10
 	},
 /area/shuttle/escape)
@@ -847,7 +824,6 @@
 /area/shuttle/escape)
 "cx" = (
 /turf/open/floor/plasteel/whiteblue/corner{
-	icon_state = "whitebluecorner";
 	dir = 8
 	},
 /area/shuttle/escape)
@@ -858,7 +834,6 @@
 	pixel_y = 3
 	},
 /turf/open/floor/plasteel/whiteblue/side{
-	icon_state = "whiteblue";
 	dir = 4
 	},
 /area/shuttle/escape)
@@ -891,7 +866,6 @@
 	dir = 8
 	},
 /turf/open/floor/plasteel/whiteblue/side{
-	icon_state = "whiteblue";
 	dir = 4
 	},
 /area/shuttle/escape)
@@ -941,7 +915,6 @@
 /obj/item/storage/firstaid/fire,
 /obj/item/crowbar,
 /turf/open/floor/plasteel/whiteblue/side{
-	icon_state = "whiteblue";
 	dir = 4
 	},
 /area/shuttle/escape)
@@ -970,7 +943,6 @@
 /obj/item/storage/firstaid/o2,
 /obj/item/storage/firstaid/toxin,
 /turf/open/floor/plasteel/whiteblue/side{
-	icon_state = "whiteblue";
 	dir = 10
 	},
 /area/shuttle/escape)
@@ -992,7 +964,6 @@
 	dir = 8
 	},
 /turf/open/floor/plasteel/whiteblue/side{
-	icon_state = "whiteblue";
 	dir = 6
 	},
 /area/shuttle/escape)
@@ -1001,7 +972,6 @@
 	pixel_y = -30
 	},
 /turf/open/floor/plasteel/neutral/side{
-	icon_state = "neutral";
 	dir = 1
 	},
 /area/shuttle/escape)
@@ -1033,13 +1003,11 @@
 "cT" = (
 /obj/structure/closet/secure_closet/engineering_personal,
 /turf/open/floor/plasteel/yellow/side{
-	icon_state = "yellow";
 	dir = 9
 	},
 /area/shuttle/escape)
 "cU" = (
 /turf/open/floor/plasteel/yellow/side{
-	icon_state = "yellow";
 	dir = 1
 	},
 /area/shuttle/escape)
@@ -1049,13 +1017,11 @@
 	},
 /obj/machinery/computer/monitor,
 /turf/open/floor/plasteel/yellow/side{
-	icon_state = "yellow";
 	dir = 1
 	},
 /area/shuttle/escape)
 "cW" = (
 /turf/open/floor/plasteel/yellow/side{
-	icon_state = "yellow";
 	dir = 5
 	},
 /area/shuttle/escape)
@@ -1079,19 +1045,16 @@
 "cZ" = (
 /obj/structure/closet/secure_closet/engineering_personal,
 /turf/open/floor/plasteel/yellow/side{
-	icon_state = "yellow";
 	dir = 10
 	},
 /area/shuttle/escape)
 "da" = (
 /turf/open/floor/plasteel/yellow/corner{
-	icon_state = "yellowcorner";
 	dir = 8
 	},
 /area/shuttle/escape)
 "db" = (
 /turf/open/floor/plasteel/yellow/corner{
-	icon_state = "yellowcorner";
 	dir = 4
 	},
 /area/shuttle/escape)
@@ -1099,7 +1062,6 @@
 /obj/structure/table,
 /obj/item/storage/box/metalfoam,
 /turf/open/floor/plasteel/yellow/side{
-	icon_state = "yellow";
 	dir = 1
 	},
 /area/shuttle/escape)
@@ -1107,7 +1069,6 @@
 /obj/structure/table,
 /obj/item/stack/sheet/metal/fifty,
 /turf/open/floor/plasteel/yellow/side{
-	icon_state = "yellow";
 	dir = 1
 	},
 /area/shuttle/escape)
@@ -1115,7 +1076,6 @@
 /obj/structure/table,
 /obj/item/stack/sheet/glass/fifty,
 /turf/open/floor/plasteel/yellow/side{
-	icon_state = "yellow";
 	dir = 5
 	},
 /area/shuttle/escape)
@@ -1135,7 +1095,6 @@
 "dh" = (
 /obj/structure/reagent_dispensers/watertank/high,
 /turf/open/floor/plasteel/yellow/side{
-	icon_state = "yellow";
 	dir = 10
 	},
 /area/shuttle/escape)
@@ -1144,7 +1103,6 @@
 	pixel_x = 32
 	},
 /turf/open/floor/plasteel/yellow/side{
-	icon_state = "yellow";
 	dir = 4
 	},
 /area/shuttle/escape)
@@ -1152,7 +1110,6 @@
 /obj/structure/table,
 /obj/item/storage/toolbox/mechanical,
 /turf/open/floor/plasteel/yellow/side{
-	icon_state = "yellow";
 	dir = 10
 	},
 /area/shuttle/escape)
@@ -1189,7 +1146,6 @@
 	pixel_y = -30
 	},
 /turf/open/floor/plasteel/yellow/side{
-	icon_state = "yellow";
 	dir = 6
 	},
 /area/shuttle/escape)

--- a/_maps/shuttles/emergency_delta.dmm
+++ b/_maps/shuttles/emergency_delta.dmm
@@ -274,13 +274,11 @@
 	dir = 8
 	},
 /turf/open/floor/plasteel/whiteblue/side{
-	icon_state = "whiteblue";
 	dir = 1
 	},
 /area/shuttle/escape)
 "aA" = (
 /turf/open/floor/plasteel/whiteblue/side{
-	icon_state = "whiteblue";
 	dir = 1
 	},
 /area/shuttle/escape)
@@ -893,13 +891,11 @@
 	dir = 1
 	},
 /turf/open/floor/plasteel/vault{
-	icon_state = "vault";
 	dir = 5
 	},
 /area/shuttle/escape)
 "cc" = (
 /turf/open/floor/plasteel/vault{
-	icon_state = "vault";
 	dir = 5
 	},
 /area/shuttle/escape)
@@ -913,7 +909,6 @@
 "ce" = (
 /obj/machinery/computer/security,
 /turf/open/floor/plasteel/darkred/side{
-	icon_state = "darkred";
 	dir = 9
 	},
 /area/shuttle/escape)
@@ -922,7 +917,6 @@
 	dir = 8
 	},
 /turf/open/floor/plasteel/vault{
-	icon_state = "vault";
 	dir = 5
 	},
 /area/shuttle/escape)
@@ -933,7 +927,6 @@
 	pixel_y = 58
 	},
 /turf/open/floor/plasteel/vault{
-	icon_state = "vault";
 	dir = 5
 	},
 /area/shuttle/escape)
@@ -942,21 +935,18 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel/vault{
-	icon_state = "vault";
 	dir = 5
 	},
 /area/shuttle/escape)
 "ci" = (
 /obj/machinery/computer/station_alert,
 /turf/open/floor/plasteel/darkyellow/side{
-	icon_state = "darkyellow";
 	dir = 5
 	},
 /area/shuttle/escape)
 "cj" = (
 /obj/machinery/computer/secure_data,
 /turf/open/floor/plasteel/darkred/side{
-	icon_state = "darkred";
 	dir = 10
 	},
 /area/shuttle/escape)
@@ -990,7 +980,6 @@
 "cp" = (
 /obj/machinery/computer/atmos_alert,
 /turf/open/floor/plasteel/darkyellow/side{
-	icon_state = "darkyellow";
 	dir = 6
 	},
 /area/shuttle/escape)

--- a/_maps/shuttles/emergency_raven.dmm
+++ b/_maps/shuttles/emergency_raven.dmm
@@ -413,7 +413,6 @@
 	dir = 1
 	},
 /turf/open/floor/plasteel/darkyellow/side{
-	icon_state = "darkyellow";
 	dir = 5
 	},
 /area/shuttle/escape)
@@ -475,7 +474,6 @@
 "bk" = (
 /obj/machinery/suit_storage_unit/standard_unit,
 /turf/open/floor/plasteel/darkyellow/side{
-	icon_state = "darkyellow";
 	dir = 6
 	},
 /area/shuttle/escape)
@@ -556,7 +554,6 @@
 /area/shuttle/escape)
 "br" = (
 /turf/open/floor/plasteel/darkgreen/side{
-	icon_state = "darkgreen";
 	dir = 1
 	},
 /area/shuttle/escape)
@@ -679,7 +676,6 @@
 "bL" = (
 /obj/machinery/door/airlock/hatch,
 /turf/open/floor/plasteel/darkgreen/side{
-	icon_state = "darkgreen";
 	dir = 1
 	},
 /area/shuttle/escape)
@@ -863,7 +859,6 @@
 "cb" = (
 /obj/structure/chair,
 /turf/open/floor/plasteel/darkgreen/side{
-	icon_state = "darkgreen";
 	dir = 1
 	},
 /area/shuttle/escape)
@@ -1483,7 +1478,6 @@
 	dir = 1
 	},
 /turf/open/floor/plasteel/darkgreen/side{
-	icon_state = "darkgreen";
 	dir = 1
 	},
 /area/shuttle/escape)
@@ -1500,7 +1494,6 @@
 	dir = 1
 	},
 /turf/open/floor/plasteel/darkgreen/side{
-	icon_state = "darkgreen";
 	dir = 1
 	},
 /area/shuttle/escape)
@@ -1526,7 +1519,6 @@
 	dir = 1
 	},
 /turf/open/floor/plasteel/darkgreen/side{
-	icon_state = "darkgreen";
 	dir = 1
 	},
 /area/shuttle/escape)
@@ -1535,7 +1527,6 @@
 	dir = 1
 	},
 /turf/open/floor/plasteel/darkgreen/side{
-	icon_state = "darkgreen";
 	dir = 1
 	},
 /area/shuttle/escape)
@@ -1544,7 +1535,6 @@
 	dir = 1
 	},
 /turf/open/floor/plasteel/darkgreen/side{
-	icon_state = "darkgreen";
 	dir = 1
 	},
 /area/shuttle/escape)

--- a/_maps/templates/medium_shuttle4.dmm
+++ b/_maps/templates/medium_shuttle4.dmm
@@ -5,7 +5,6 @@
 "b" = (
 /turf/open/space,
 /turf/closed/indestructible/oldshuttle/corner{
-	icon_state = "corner";
 	dir = 8
 	},
 /area/ruin/powered)
@@ -14,38 +13,24 @@
 /area/ruin/powered)
 "d" = (
 /obj/machinery/door/airlock/glass,
-/turf/open/floor/oldshuttle{
-	baseturf = /turf/open/space;
-	initial_gas_mix = "o2=22;n2=82;TEMP=293.15"
-	},
+/turf/open/floor/oldshuttle,
 /area/ruin/powered)
 "e" = (
 /turf/open/space,
 /turf/closed/indestructible/oldshuttle/corner,
 /area/ruin/powered)
 "f" = (
-/turf/open/floor/oldshuttle{
-	baseturf = /turf/open/space;
-	initial_gas_mix = "o2=22;n2=82;TEMP=293.15"
-	},
+/turf/open/floor/oldshuttle,
 /turf/closed/indestructible/oldshuttle/corner{
-	icon_state = "corner";
 	dir = 1
 	},
 /area/ruin/powered)
 "g" = (
-/turf/open/floor/oldshuttle{
-	baseturf = /turf/open/space;
-	initial_gas_mix = "o2=22;n2=82;TEMP=293.15"
-	},
+/turf/open/floor/oldshuttle,
 /area/ruin/powered)
 "h" = (
-/turf/open/floor/oldshuttle{
-	baseturf = /turf/open/space;
-	initial_gas_mix = "o2=22;n2=82;TEMP=293.15"
-	},
+/turf/open/floor/oldshuttle,
 /turf/closed/indestructible/oldshuttle/corner{
-	icon_state = "corner";
 	dir = 4
 	},
 /area/ruin/powered)
@@ -53,10 +38,7 @@
 /obj/structure/closet{
 	icon_state = "oldcloset"
 	},
-/turf/open/floor/oldshuttle{
-	baseturf = /turf/open/space;
-	initial_gas_mix = "o2=22;n2=82;TEMP=293.15"
-	},
+/turf/open/floor/oldshuttle,
 /area/ruin/powered)
 "j" = (
 /obj/structure/shuttle/engine/propulsion/burst{
@@ -74,39 +56,27 @@
 	icon_state = "chairold";
 	dir = 1
 	},
-/turf/open/floor/oldshuttle{
-	baseturf = /turf/open/space;
-	initial_gas_mix = "o2=22;n2=82;TEMP=293.15"
-	},
+/turf/open/floor/oldshuttle,
 /area/ruin/powered)
 "m" = (
-/turf/open/floor/oldshuttle{
-	baseturf = /turf/open/space;
-	initial_gas_mix = "o2=22;n2=82;TEMP=293.15"
-	},
+/turf/open/floor/oldshuttle,
 /turf/closed/indestructible/oldshuttle/corner{
-	icon_state = "corner";
 	dir = 8
 	},
 /area/ruin/powered)
 "n" = (
-/turf/open/floor/oldshuttle{
-	baseturf = /turf/open/space;
-	initial_gas_mix = "o2=22;n2=82;TEMP=293.15"
-	},
+/turf/open/floor/oldshuttle,
 /turf/closed/indestructible/oldshuttle/corner,
 /area/ruin/powered)
 "o" = (
 /turf/open/space,
 /turf/closed/indestructible/oldshuttle/corner{
-	icon_state = "corner";
 	dir = 1
 	},
 /area/ruin/powered)
 "p" = (
 /turf/open/space,
 /turf/closed/indestructible/oldshuttle/corner{
-	icon_state = "corner";
 	dir = 4
 	},
 /area/ruin/powered)
@@ -116,17 +86,11 @@
 /area/ruin/powered)
 "r" = (
 /obj/machinery/power/generator,
-/turf/open/floor/oldshuttle{
-	baseturf = /turf/open/space;
-	initial_gas_mix = "o2=22;n2=82;TEMP=293.15"
-	},
+/turf/open/floor/oldshuttle,
 /area/ruin/powered)
 "s" = (
 /obj/machinery/power/smes,
-/turf/open/floor/oldshuttle{
-	baseturf = /turf/open/space;
-	initial_gas_mix = "o2=22;n2=82;TEMP=293.15"
-	},
+/turf/open/floor/oldshuttle,
 /area/ruin/powered)
 "t" = (
 /obj/structure/shuttle/engine/propulsion/burst/left,

--- a/code/game/turfs/simulated/floor/misc_floor.dm
+++ b/code/game/turfs/simulated/floor/misc_floor.dm
@@ -46,11 +46,18 @@
 /turf/open/floor/circuit/airless
 	initial_gas_mix = "TEMP=2.7"
 
+/turf/open/floor/circuit/killroom
+	name = "Killroom Floor"
+	initial_gas_mix = "n2=500;TEMP=80"
+
 /turf/open/floor/circuit/telecomms
 	initial_gas_mix = "n2=100;TEMP=80"
 
 /turf/open/floor/circuit/telecomms/mainframe
 	name = "Mainframe Base"
+
+/turf/open/floor/circuit/telecomms/server
+	name = "Server Base"
 
 /turf/open/floor/circuit/green
 	icon_state = "gcircuit"

--- a/code/game/turfs/simulated/floor/plasteel_floor.dm
+++ b/code/game/turfs/simulated/floor/plasteel_floor.dm
@@ -21,6 +21,10 @@
 	initial_gas_mix = "n2=100;TEMP=80"
 /turf/open/floor/plasteel/black/telecomms/mainframe
 	name = "Mainframe Floor"
+/turf/open/floor/plasteel/black/telecomms/server
+	name = "Server Base"
+/turf/open/floor/plasteel/black/telecomms/server/walkway
+	name = "Server Walkway"
 /turf/open/floor/plasteel/airless/black
 	icon_state = "dark"
 /turf/open/floor/plasteel/black/side
@@ -355,6 +359,8 @@
 	initial_gas_mix = "n2=100;TEMP=80"
 /turf/open/floor/plasteel/vault/telecomms/mainframe
 	name = "Mainframe Floor"
+/turf/open/floor/plasteel/vault/killroom
+	name = "Killroom Floor"
 
 /turf/open/floor/plasteel/cult
 	icon_state = "cult"


### PR DESCRIPTION
Cleaned up a number of dirty/erroneous varedits on turfs.

Helps reduce the number of duplicate instances in the editor (as well as accidental placing of varedited AIRLESS TURF in courtrooms and half the places that people want black vault floors at, which caused #29942.) 