### PR TITLE
Makes mixing meth dangerous again

### DIFF
--- a/code/modules/food_and_drinks/recipes/food_mixtures.dm
+++ b/code/modules/food_and_drinks/recipes/food_mixtures.dm
@@ -13,7 +13,7 @@
 	id = "tofu"
 	required_reagents = list("soymilk" = 10)
 	required_catalysts = list("enzyme" = 5)
-	mob_react=1
+	mob_react = FALSE
 
 /datum/chemical_reaction/tofu/on_reaction(datum/reagents/holder, created_volume)
 	var/location = get_turf(holder.my_atom)
@@ -37,7 +37,7 @@
 	name = "Chocolate Bar"
 	id = "chocolate_bar"
 	required_reagents = list("chocolate_milk" = 4, "sugar" = 2)
-	mob_react = 1
+	mob_react = FALSE
 
 /datum/chemical_reaction/chocolate_bar2/on_reaction(datum/reagents/holder, created_volume)
 	var/location = get_turf(holder.my_atom)
@@ -91,7 +91,7 @@
 	name = "synthmeat"
 	id = "synthmeat"
 	required_reagents = list("blood" = 5, "cryoxadone" = 1)
-	mob_react = 1
+	mob_react = FALSE
 
 /datum/chemical_reaction/synthmeat/on_reaction(datum/reagents/holder, created_volume)
 	var/location = get_turf(holder.my_atom)

--- a/code/modules/reagents/chemistry/holder.dm
+++ b/code/modules/reagents/chemistry/holder.dm
@@ -370,9 +370,8 @@
 					else
 						if(cached_my_atom.type == C.required_container)
 							matching_container = 1
-					if (isliving(cached_my_atom)) //Makes it so certain chemical reactions don't occur in mobs
-						if (C.mob_react)
-							return
+					if (isliving(cached_my_atom) && !C.mob_react) //Makes it so certain chemical reactions don't occur in mobs
+						return
 					if(!C.required_other)
 						matching_other = 1
 

--- a/code/modules/reagents/chemistry/recipes.dm
+++ b/code/modules/reagents/chemistry/recipes.dm
@@ -10,7 +10,7 @@
 	var/required_other = 0 // an integer required for the reaction to happen
 
 	var/secondary = 0 // set to nonzero if secondary reaction
-	var/mob_react = 0 //Determines if a chemical reaction can occur inside a mob
+	var/mob_react = TRUE //Determines if a chemical reaction can occur inside a mob
 
 	var/required_temp = 0
 	var/is_cold_recipe = 0 // Set to 1 if you want the recipe to only react when it's BELOW the required temp.

--- a/code/modules/reagents/chemistry/recipes/others.dm
+++ b/code/modules/reagents/chemistry/recipes/others.dm
@@ -51,7 +51,7 @@
 	name = "Solid Plasma"
 	id = "solidplasma"
 	required_reagents = list("iron" = 5, "frostoil" = 5, "plasma" = 20)
-	mob_react = 1
+	mob_react = FALSE
 
 /datum/chemical_reaction/plasmasolidification/on_reaction(datum/reagents/holder, created_volume)
 	var/location = get_turf(holder.my_atom)
@@ -62,7 +62,7 @@
 	name = "Solid Gold"
 	id = "solidgold"
 	required_reagents = list("frostoil" = 5, "gold" = 20, "iron" = 1)
-	mob_react = 1
+	mob_react = FALSE
 
 /datum/chemical_reaction/goldsolidification/on_reaction(datum/reagents/holder, created_volume)
 	var/location = get_turf(holder.my_atom)
@@ -80,7 +80,7 @@
 	id = "soapification"
 	required_reagents = list("liquidgibs" = 10, "lye"  = 10) // requires two scooped gib tiles
 	required_temp = 374
-	mob_react = 1
+	mob_react = FALSE
 
 /datum/chemical_reaction/soapification/on_reaction(datum/reagents/holder, created_volume)
 	var/location = get_turf(holder.my_atom)
@@ -92,7 +92,7 @@
 	id = "candlefication"
 	required_reagents = list("liquidgibs" = 5, "oxygen"  = 5) //
 	required_temp = 374
-	mob_react = 1
+	mob_react = FALSE
 
 /datum/chemical_reaction/candlefication/on_reaction(datum/reagents/holder, created_volume)
 	var/location = get_turf(holder.my_atom)
@@ -103,7 +103,7 @@
 	name = "Meatification"
 	id = "meatification"
 	required_reagents = list("liquidgibs" = 10, "nutriment" = 10, "carbon" = 10)
-	mob_react = 1
+	mob_react = FALSE
 
 /datum/chemical_reaction/meatification/on_reaction(datum/reagents/holder, created_volume)
 	var/location = get_turf(holder.my_atom)
@@ -436,7 +436,7 @@
 	name = "Foam"
 	id = "foam"
 	required_reagents = list("fluorosurfactant" = 1, "water" = 1)
-	mob_react = 1
+	mob_react = FALSE
 
 /datum/chemical_reaction/foam/on_reaction(datum/reagents/holder, created_volume)
 	var/location = get_turf(holder.my_atom)
@@ -453,7 +453,7 @@
 	name = "Metal Foam"
 	id = "metalfoam"
 	required_reagents = list("aluminium" = 3, "foaming_agent" = 1, "facid" = 1)
-	mob_react = 1
+	mob_react = FALSE
 
 /datum/chemical_reaction/metalfoam/on_reaction(datum/reagents/holder, created_volume)
 	var/location = get_turf(holder.my_atom)
@@ -470,7 +470,7 @@
 	name = "Iron Foam"
 	id = "ironlfoam"
 	required_reagents = list("iron" = 3, "foaming_agent" = 1, "facid" = 1)
-	mob_react = 1
+	mob_react = FALSE
 
 /datum/chemical_reaction/ironfoam/on_reaction(datum/reagents/holder, created_volume)
 	var/location = get_turf(holder.my_atom)

--- a/code/modules/reagents/chemistry/recipes/pyrotechnics.dm
+++ b/code/modules/reagents/chemistry/recipes/pyrotechnics.dm
@@ -144,7 +144,7 @@
 	required_reagents = list("methamphetamine" = 1)
 	strengthdiv = 6
 	modifier = 1
-	mob_react = TRUE //Yes, setting it true makes it NOT react in mobs.
+	mob_react = FALSE
 
 /datum/chemical_reaction/reagent_explosion/methsplosion/on_reaction(datum/reagents/holder, created_volume)
 	var/turf/T = get_turf(holder.my_atom)
@@ -270,7 +270,7 @@
 	required_reagents = list("smoke_powder" = 1)
 	required_temp = 374
 	secondary = 1
-	mob_react = 1
+	mob_react = FALSE
 
 /datum/chemical_reaction/smoke_powder_smoke/on_reaction(datum/reagents/holder, created_volume)
 	var/location = get_turf(holder.my_atom)

--- a/code/modules/reagents/chemistry/recipes/pyrotechnics.dm
+++ b/code/modules/reagents/chemistry/recipes/pyrotechnics.dm
@@ -140,10 +140,11 @@
 	name = "Meth explosion"
 	id = "methboom1"
 	results = list("methboom1" = 1)
-	required_temp = 420 //high enough to not blow up in the meth syringes
+	required_temp = 380 //slightly above the meth mix time.
 	required_reagents = list("methamphetamine" = 1)
 	strengthdiv = 6
 	modifier = 1
+	mob_react = TRUE //Yes, setting it true makes it NOT react in mobs.
 
 /datum/chemical_reaction/reagent_explosion/methsplosion/on_reaction(datum/reagents/holder, created_volume)
 	var/turf/T = get_turf(holder.my_atom)
@@ -154,7 +155,7 @@
 
 /datum/chemical_reaction/reagent_explosion/methsplosion/methboom2
 	required_reagents = list("diethylamine" = 1, "iodine" = 1, "phosphorus" = 1, "hydrogen" = 1) //diethylamine is often left over from mixing the ephedrine.
-	required_temp = 420 
+	required_temp = 300 //room temperature, chilling it even a little will prevent the explosion 
 	results = list("methboom1" = 4) // this is ugly. Sorry goof.
 
 /datum/chemical_reaction/sorium


### PR DESCRIPTION
[Changelogs]: Reverts #29912 while fixing the same problem it solves in a better way.

[why]: Mixing meth is supposed to be dangerous and potentially explosive if done wrong.  Though methsplosion syringes did need to be removed, there was no need to make meth less explosive, we just needed to make the explosions not happen inside of mobs.
