### PR TITLE
Removes blob cuddling

### DIFF
--- a/code/game/gamemodes/blob/theblob.dm
+++ b/code/game/gamemodes/blob/theblob.dm
@@ -19,16 +19,6 @@
 	var/atmosblock = 0 //if the blob blocks atmos and heat spread
 	var/mob/camera/blob/overmind
 
-/obj/structure/blob/attack_hand(mob/M)
-	. = ..()
-	M.changeNext_move(CLICK_CD_MELEE)
-	var/a = pick("gently stroke", "nuzzle", "affectionatly pet", "cuddle")
-	M.visible_message("<span class='notice'>[M] [a]s [src]!</span>", "<span class='notice'>You [a] [src]!</span>")
-	to_chat(overmind, "<span class='notice'>[M] [a]s you!</span>")
-	playsound(src, 'sound/effects/blobattack.ogg', 50, 1) //SQUISH SQUISH
-	
-
-
 /obj/structure/blob/Initialize()
 	var/area/Ablob = get_area(loc)
 	if(Ablob.blob_allowed) //Is this area allowed for winning as blob?


### PR DESCRIPTION
Reverts #29820 and #29159
This code:
1. Serves no mechanical purpose.
2. Encourages being "friendly" to the blob (jesus christ)
3. Spams the blob overmind's chat, when he needs to be paying attention to his Juggernauts reporting what they see/hear, and the other overminds.
4. Why are we adding this kind of shit? It's just needless pandering to the "uguu" crowd, who already have shitloads of snowflake crap for them specifically. They can do without cluttering up blob code.