### PR TITLE
Nerfs soap slips

### DIFF
--- a/code/game/objects/items/clown_items.dm
+++ b/code/game/objects/items/clown_items.dm
@@ -25,7 +25,7 @@
 
 /obj/item/soap/Initialize()
 	. = ..()
-	AddComponent(/datum/component/slippery, 80)
+	AddComponent(/datum/component/slippery, 30)
 
 /obj/item/soap/nanotrasen
 	desc = "A Nanotrasen brand bar of soap. Smells of plasma."

--- a/code/game/objects/items/clown_items.dm
+++ b/code/game/objects/items/clown_items.dm
@@ -25,8 +25,11 @@
 
 /obj/item/soap/Initialize()
 	. = ..()
-	AddComponent(/datum/component/slippery, 30)
+	AddComponent(/datum/component/slippery, 40)
 
+/obj/item/soap/syndie/Initialize()
+	. = ..()
+	AddComponent(/datum/component/slippery, 80)
 /obj/item/soap/nanotrasen
 	desc = "A Nanotrasen brand bar of soap. Smells of plasma."
 	icon_state = "soapnt"


### PR DESCRIPTION
:cl: Evsey9
balance: Because of NanoTrasen receiving complaints on soap being too slippery and causing too many workplace accidents, they have decided to change the cleaning agent to a less slippery one.
/:cl:
Nerfs soap slips down to 4 seconds, which is still enough to apply cuffs. Syndicate soap stays at 8 seconds, since it's the syndicate!
Why: A soap being able to slip you for 8 seconds ( enough to apply cuffs without any effort which is basically GG you're dead ) is dumb and overpowered IMO, since its an easy stun that can be gotten very easily ( the bathrooms for example ). 