### PR TITLE
Singularities dig up asteroid turf

### DIFF
--- a/code/game/turfs/simulated/floor/plating/asteroid.dm
+++ b/code/game/turfs/simulated/floor/plating/asteroid.dm
@@ -104,7 +104,18 @@
 	return
 
 /turf/open/floor/plating/asteroid/singularity_pull(S, current_size)
-	return
+	if(dug)
+		return
+	switch(current_size)
+		if(STAGE_THREE)
+			if(prob(30))
+				gets_dug()
+		if(STAGE_FOUR)
+			if(prob(50))
+				gets_dug()
+		else if(current_size >= STAGE_FIVE)
+			if(prob(70))
+				gets_dug()
 
 
 /turf/open/floor/plating/asteroid/basalt

--- a/code/game/turfs/simulated/floor/plating/asteroid.dm
+++ b/code/game/turfs/simulated/floor/plating/asteroid.dm
@@ -108,13 +108,13 @@
 		return
 	switch(current_size)
 		if(STAGE_THREE)
-			if(prob(30))
+			if(!prob(30))
 				gets_dug()
 		if(STAGE_FOUR)
 			if(prob(50))
 				gets_dug()
-		else if(current_size >= STAGE_FIVE)
-			if(prob(70))
+		else 
+			if(current_size >= STAGE_FIVE && prob(70))
 				gets_dug()
 
 


### PR DESCRIPTION
Broken off of #29859 so that it is a bit more focused on what it acomplishes.

This change makes it so that singularities in proximity of asteroid turfs will dig/pull up the sand/dirt/whatever on them.

🆑 ShizCalev
tweak: The singularity will now dig up asteroids when in proximity of them. Please watch for flying debris.
/🆑