### PR TITLE
Raises airlock deflection by a single point

### DIFF
--- a/code/game/machinery/doors/airlock.dm
+++ b/code/game/machinery/doors/airlock.dm
@@ -34,7 +34,7 @@
 
 #define AIRLOCK_INTEGRITY_N			 300 // Normal airlock integrity
 #define AIRLOCK_INTEGRITY_MULTIPLIER 1.5 // How much reinforced doors health increases
-#define AIRLOCK_DAMAGE_DEFLECTION_N  20  // Normal airlock damage deflection
+#define AIRLOCK_DAMAGE_DEFLECTION_N  21  // Normal airlock damage deflection
 #define AIRLOCK_DAMAGE_DEFLECTION_R  30  // Reinforced airlock damage deflection
 
 #define NOT_ELECTRIFIED 0


### PR DESCRIPTION
:cl: 
balance: Raised airlock deflection by one point
/:cl:

[why]: Kor told me to make this PR again myself. 

My reasoning is that destroying an airlock is not something that should be accomplished without cost or uncommon equipment. Being able to ghetto all-access with throwing spears seems dumb and makes perma joke considering you have everything in there to make a spear and break out without any preparation or outside help on your behalf. 
I've seen some people break through the perma door in under 4 minutes with nothing but a throwing spear and something has got to change