### PR TITLE
readds toggle_hear_radio admin verb

### DIFF
--- a/code/modules/admin/admin_verbs.dm
+++ b/code/modules/admin/admin_verbs.dm
@@ -12,6 +12,7 @@ GLOBAL_LIST_INIT(admin_verbs_default, world.AVerbsDefault())
 	/client/proc/dsay,					/*talk in deadchat using our ckey/fakekey*/
 	/client/proc/investigate_show,		/*various admintools for investigation. Such as a singulo grief-log*/
 	/client/proc/secrets,
+	/client/proc/toggle_hear_radio,		/*allows admins to hide all radio output*/
 	/client/proc/reload_admins,
 	/client/proc/reestablish_db_connection, /*reattempt a connection to the database*/
 	/client/proc/cmd_admin_pm_context,	/*right-click adminPM interface*/


### PR DESCRIPTION
This is a admin version of the ghost preference that hides radio chatter even when human, even from near by radios/intercoms.

Its an old verb, it was removed accidentally in my datum top menu rewrite, and it needs to come back because a admin got their shit stuck in disabled and couldn't re-enable it.

Fixes #29978