### PR TITLE
Revert: Adds DropLocation(). To generally be preferred to get_turf() (#29814)

### DIFF
--- a/code/game/area/areas.dm
+++ b/code/game/area/areas.dm
@@ -477,9 +477,3 @@ GLOBAL_LIST_EMPTY(teleportlocs)
 	valid_territory = FALSE
 	blob_allowed = FALSE
 	addSorted()
-
-/area/AllowDrop()
-	CRASH("Bad op: area/AllowDrop() called")
-
-/area/drop_location()
-	CRASH("Bad op: area/drop_location() called")

--- a/code/game/atoms.dm
+++ b/code/game/atoms.dm
@@ -211,8 +211,8 @@
 		return TRUE
 	return container_type & DRAWABLE_1
 
-/atom/proc/AllowDrop()
-	return FALSE
+/atom/proc/allow_drop()
+	return 1
 
 /atom/proc/CheckExit()
 	return 1
@@ -613,12 +613,6 @@ GLOBAL_LIST_EMPTY(blood_splatter_icons)
 	.["Add reagent"] = "?_src_=vars;addreagent=\ref[src]"
 	.["Trigger EM pulse"] = "?_src_=vars;emp=\ref[src]"
 	.["Trigger explosion"] = "?_src_=vars;explode=\ref[src]"
-
-/atom/proc/drop_location()
-	var/atom/L = loc
-	if(!L)
-		return null
-	return L.AllowDrop() ? L : get_turf(L)
 
 /atom/Entered(atom/movable/AM, atom/oldLoc)
 	SendSignal(COMSIG_ATOM_ENTERED, AM, oldLoc)

--- a/code/game/machinery/_machinery.dm
+++ b/code/game/machinery/_machinery.dm
@@ -473,6 +473,9 @@ Class Procs:
 /obj/machinery/proc/on_deconstruction()
 	return
 
+/obj/machinery/allow_drop()
+	return 0
+
 // Hook for html_interface module to prevent updates to clients who don't have this as their active machine.
 /obj/machinery/proc/hiIsValidClient(datum/html_interface_client/hclient, datum/html_interface/hi)
 	if (hclient.client.mob && (hclient.client.mob.stat == 0 || IsAdminGhost(hclient.client.mob)))

--- a/code/game/mecha/equipment/tools/medical_tools.dm
+++ b/code/game/mecha/equipment/tools/medical_tools.dm
@@ -42,6 +42,9 @@
 	var/inject_amount = 10
 	salvageable = 0
 
+/obj/item/mecha_parts/mecha_equipment/medical/sleeper/allow_drop()
+	return 0
+
 /obj/item/mecha_parts/mecha_equipment/medical/sleeper/Destroy()
 	for(var/atom/movable/AM in src)
 		AM.forceMove(get_turf(src))

--- a/code/game/mecha/mecha.dm
+++ b/code/game/mecha/mecha.dm
@@ -1047,6 +1047,9 @@ GLOBAL_VAR_INIT(year_integer, text2num(year)) // = 2013???
 		return 1
 	return 0
 
+/obj/mecha/allow_drop()
+	return 0
+
 /obj/mecha/update_remote_sight(mob/living/user)
 	if(occupant_sight_flags)
 		if(user == occupant)

--- a/code/game/objects/items/storage/storage.dm
+++ b/code/game/objects/items/storage/storage.dm
@@ -416,8 +416,6 @@
 
 	handle_item_insertion(W, 0 , user)
 
-/obj/item/storage/AllowDrop()
-	return TRUE
 
 /obj/item/storage/attack_hand(mob/user)
 	if(user.s_active == src && loc == user) //if you're already looking inside the storage item

--- a/code/game/objects/structures/crates_lockers/closets.dm
+++ b/code/game/objects/structures/crates_lockers/closets.dm
@@ -110,12 +110,7 @@
 	return 1
 
 /obj/structure/closet/proc/dump_contents()
-	var/atom/L = loc
-	if(!L)
-		for(var/I in src)
-			qdel(I)
-		return
-	var/turf/T = L.drop_location()
+	var/turf/T = get_turf(src)
 	for(var/atom/movable/AM in src)
 		AM.forceMove(T)
 		if(throwing) // you keep some momentum when getting out of a thrown closet
@@ -124,10 +119,7 @@
 		throwing.finalize(FALSE)
 
 /obj/structure/closet/proc/take_contents()
-	var/atom/L = loc
-	if(!L)
-		return
-	var/turf/T = L.drop_location()
+	var/turf/T = get_turf(src)
 	for(var/atom/movable/AM in T)
 		if(AM != src && insert(AM) == -1) // limit reached
 			break
@@ -456,6 +448,3 @@
 /obj/structure/closet/singularity_act()
 	dump_contents()
 	..()
-
-/obj/structure/closet/AllowDrop()
-	return TRUE

--- a/code/game/turfs/turf.dm
+++ b/code/game/turfs/turf.dm
@@ -535,6 +535,3 @@
 		else
 			return I
 	return I
-
-/turf/AllowDrop()
-	return TRUE

--- a/code/modules/mob/inventory.dm
+++ b/code/modules/mob/inventory.dm
@@ -234,11 +234,15 @@
 
 
 /mob/proc/drop_all_held_items()
+	if(!loc || !loc.allow_drop())
+		return
 	for(var/obj/item/I in held_items)
 		dropItemToGround(I)
 
 //Drops the item in our active hand.
 /mob/proc/drop_item()
+	if(!loc || !loc.allow_drop())
+		return
 	var/obj/item/held = get_active_held_item()
 	return dropItemToGround(held)
 
@@ -268,7 +272,7 @@
 //for when you want the item to end up on the ground
 //will force move the item to the ground and call the turf's Entered
 /mob/proc/dropItemToGround(obj/item/I, force = FALSE)
-	return doUnEquip(I, force, drop_location(), FALSE)
+	return doUnEquip(I, force, loc, FALSE)
 
 //for when the item will be immediately placed in a loc other than the ground
 /mob/proc/transferItemToLoc(obj/item/I, newloc = null, force = FALSE)

--- a/code/modules/modular_computers/hardware/printer.dm
+++ b/code/modules/modular_computers/hardware/printer.dm
@@ -24,7 +24,7 @@
 	if(!check_functionality())
 		return FALSE
 
-	var/obj/item/paper/P = new/obj/item/paper(holder.drop_location())
+	var/obj/item/paper/P = new/obj/item/paper(get_turf(holder))
 
 	// Damaged printer causes the resulting paper to be somewhat harder to read.
 	if(damage > damage_malfunction)

--- a/code/modules/recycling/disposal-structures.dm
+++ b/code/modules/recycling/disposal-structures.dm
@@ -121,8 +121,8 @@
 	T.assume_air(gas)
 	T.air_update_turf()
 
-/obj/structure/disposalholder/AllowDrop()
-	return TRUE
+/obj/structure/disposalholder/allow_drop()
+	return 1
 
 /obj/structure/disposalholder/ex_act(severity, target)
 	return


### PR DESCRIPTION
(reverts #29814) (reverted from commit 728aefbd70e6370f23454e05fb9e2b50cb4370ae)


It breaks the contents of lockers, chests, ect; nothing spawns inside of them when they're opened. Was this even tested? :((((