### PR TITLE
Slight on_move.dm rewrite

### DIFF
--- a/code/modules/shuttle/on_move.dm
+++ b/code/modules/shuttle/on_move.dm
@@ -1,19 +1,3 @@
-//These defines are to make it easier to change the args available without having to copy paste it in everywhere
-//You need to also change the same procs in shuttle.dm
-//These are undefined at the end of the file
-#define TURF_FROM fromShuttleMove(turf/newT, turf_type, baseturf_type)
-#define TURF_TO toShuttleMove(turf/oldT, shuttle_dir)
-#define TURF_ON onShuttleMove(turf/newT, turf_type, baseturf_type, rotation, list/movement_force, move_dir)
-#define TURF_AFTER afterShuttleMove(turf/oldT)
-
-#define ATOM_BEFORE beforeShuttleMove(turf/newT, rotation)
-#define ATOM_ON onShuttleMove(turf/newT, turf/oldT, rotation, list/movement_force, move_dir, old_dock)
-#define ATOM_AFTER afterShuttleMove(list/movement_force, shuttle_dir, shuttle_preferred_direction, move_dir)
-
-#define AREA_BEFORE beforeShuttleMove()
-#define AREA_ON onShuttleMove(turf/oldT, turf/newT, area/underlying_old_area)
-#define AREA_AFTER afterShuttleMove()
-
 /*
 All ShuttleMove procs go here
 */
@@ -21,14 +5,14 @@ All ShuttleMove procs go here
 /************************************Base procs************************************/
 
 // Called on every turf in the shuttle region, return false if it doesn't want to move
-/turf/proc/TURF_FROM
+/turf/proc/fromShuttleMove(turf/newT, turf_type, baseturf_type)
 	if(type == turf_type && baseturf == baseturf_type)
 		return FALSE
 	return TRUE
 
 // Called from the new turf before anything has been moved
 // Only gets called if fromShuttleMove returns true first
-/turf/proc/TURF_TO
+/turf/proc/toShuttleMove(turf/oldT, shuttle_dir)
 	for(var/i in contents)
 		var/atom/movable/thing = i
 		if(ismob(thing))
@@ -57,7 +41,7 @@ All ShuttleMove procs go here
 	return TRUE
 
 // Called on the old turf to move the turf data
-/turf/proc/TURF_ON
+/turf/proc/onShuttleMove(turf/newT, turf_type, baseturf_type, rotation, list/movement_force, move_dir)
 	if(newT == src) // In case of in place shuttle rotation shenanigans.
 		return
 
@@ -76,7 +60,7 @@ All ShuttleMove procs go here
 	return TRUE
 
 // Called on the new turf after everything has been moved
-/turf/proc/TURF_AFTER
+/turf/proc/afterShuttleMove(turf/oldT)
 	if(SSlighting.initialized && FALSE)
 		var/atom/movable/lighting_object/old_obj = lighting_object
 		var/atom/movable/lighting_object/new_obj = oldT.lighting_object
@@ -90,11 +74,11 @@ All ShuttleMove procs go here
 
 // Called on every atom in shuttle turf contents before anything has been moved
 // Return true if it should be moved regardless of turf being moved
-/atom/movable/proc/ATOM_BEFORE
+/atom/movable/proc/beforeShuttleMove(turf/newT, rotation)
 	return FALSE
 
 // Called on atoms to move the atom to the new location
-/atom/movable/proc/ATOM_ON
+/atom/movable/proc/onShuttleMove(turf/newT, turf/oldT, rotation, list/movement_force, move_dir, old_dock)
 	if(newT == oldT) // In case of in place shuttle rotation shenanigans.
 		return
 
@@ -110,7 +94,7 @@ All ShuttleMove procs go here
 	return TRUE
 
 // Called on atoms after everything has been moved
-/atom/movable/proc/ATOM_AFTER
+/atom/movable/proc/afterShuttleMove(list/movement_force, shuttle_dir, shuttle_preferred_direction, move_dir)
 	if(light)
 		update_light()
 	return TRUE
@@ -118,11 +102,11 @@ All ShuttleMove procs go here
 /////////////////////////////////////////////////////////////////////////////////////
 
 // Called on areas before anything has been moved
-/area/proc/AREA_BEFORE
+/area/proc/beforeShuttleMove()
 	return TRUE
 
 // Called on areas to move their turf between areas
-/area/proc/AREA_ON
+/area/proc/onShuttleMove(turf/oldT, turf/newT, area/underlying_old_area)
 	if(newT == oldT) // In case of in place shuttle rotation shenanigans.
 		return
 
@@ -140,7 +124,7 @@ All ShuttleMove procs go here
 	return TRUE
 
 // Called on areas after everything has been moved
-/area/proc/AREA_AFTER
+/area/proc/afterShuttleMove()
 	return TRUE
 
 /************************************Shuttle Rotation************************************/
@@ -165,7 +149,7 @@ All ShuttleMove procs go here
 
 /************************************Turf move procs************************************/
 
-/turf/open/TURF_AFTER //Recalculates SSair stuff for turfs on both sides
+/turf/open/afterShuttleMove(turf/oldT) //Recalculates SSair stuff for turfs on both sides
 	. = ..()
 	SSair.remove_from_active(src)
 	SSair.remove_from_active(oldT)
@@ -178,7 +162,7 @@ All ShuttleMove procs go here
 
 /************************************Machinery move procs************************************/
 
-/obj/machinery/door/airlock/ATOM_BEFORE
+/obj/machinery/door/airlock/beforeShuttleMove(turf/newT, rotation)
 	. = ..()
 	shuttledocked = 0
 	for(var/obj/machinery/door/airlock/A in range(1, src))
@@ -186,55 +170,55 @@ All ShuttleMove procs go here
 		A.air_tight = TRUE
 		INVOKE_ASYNC(A, /obj/machinery/door/.proc/close)
 
-/obj/machinery/door/airlock/ATOM_AFTER
+/obj/machinery/door/airlock/afterShuttleMove(list/movement_force, shuttle_dir, shuttle_preferred_direction, move_dir)
 	. = ..()
 	shuttledocked =  1
 	for(var/obj/machinery/door/airlock/A in range(1, src))
 		A.shuttledocked = 1
 
-/obj/machinery/camera/ATOM_BEFORE
+/obj/machinery/camera/beforeShuttleMove(turf/newT, rotation)
 	. = ..()
 	GLOB.cameranet.removeCamera(src)
 	GLOB.cameranet.updateChunk()
 	return TRUE
 
-/obj/machinery/camera/ATOM_AFTER
+/obj/machinery/camera/afterShuttleMove(list/movement_force, shuttle_dir, shuttle_preferred_direction, move_dir)
 	. = ..()
 	if(can_use())
 		GLOB.cameranet.addCamera(src)
 	var/datum/camerachunk/chunk = GLOB.cameranet.getCameraChunk(x, y, z)
 	chunk.hasChanged(TRUE)
 
-/obj/machinery/telecomms/ATOM_AFTER
+/obj/machinery/telecomms/afterShuttleMove(list/movement_force, shuttle_dir, shuttle_preferred_direction, move_dir)
 	. = ..()
 	listening_level = z // Update listening Z, just in case you have telecomm relay on a shuttle
 
-/obj/machinery/mech_bay_recharge_port/ATOM_AFTER
+/obj/machinery/mech_bay_recharge_port/afterShuttleMove(list/movement_force, shuttle_dir, shuttle_preferred_direction, move_dir)
 	. = ..()
 	recharging_turf = get_step(loc, dir)
 
-/obj/machinery/atmospherics/ATOM_AFTER
+/obj/machinery/atmospherics/afterShuttleMove(list/movement_force, shuttle_dir, shuttle_preferred_direction, move_dir)
 	. = ..()
 	if(pipe_vision_img)
 		pipe_vision_img.loc = loc
 
-/obj/machinery/computer/auxillary_base/ATOM_ON
+/obj/machinery/computer/auxillary_base/onShuttleMove(turf/newT, turf/oldT, rotation, list/movement_force, move_dir, old_dock)
 	. = ..()
 	if(z == ZLEVEL_MINING) //Avoids double logging and landing on other Z-levels due to badminnery
 		SSblackbox.add_details("colonies_dropped", "[x]|[y]|[z]") //Number of times a base has been dropped!
 
-/obj/machinery/gravity_generator/main/ATOM_BEFORE
+/obj/machinery/gravity_generator/main/beforeShuttleMove(turf/newT, rotation)
 	. = ..()
 	on = FALSE
 	update_list()
 
-/obj/machinery/gravity_generator/main/ATOM_AFTER
+/obj/machinery/gravity_generator/main/afterShuttleMove(list/movement_force, shuttle_dir, shuttle_preferred_direction, move_dir)
 	. = ..()
 	if(charge_count != 0 && charging_state != POWER_UP)
 		on = TRUE
 	update_list()
 
-/obj/machinery/thruster/ATOM_BEFORE
+/obj/machinery/thruster/beforeShuttleMove(turf/newT, rotation)
 	. = ..()
 	. = TRUE
 
@@ -253,7 +237,7 @@ All ShuttleMove procs go here
 		var/new_pos = supposed_node_connect.Find(real_node_connect[I])
 		nodes[new_pos] = nodes_copy[I]
 
-/obj/machinery/atmospherics/ATOM_AFTER
+/obj/machinery/atmospherics/afterShuttleMove(list/movement_force, shuttle_dir, shuttle_preferred_direction, move_dir)
 	. = ..()
 	var/missing_nodes = FALSE
 	for(DEVICE_TYPE_LOOP)
@@ -282,17 +266,17 @@ All ShuttleMove procs go here
 		// atmosinit() calls update_icon(), so we don't need to call it
 		update_icon()
 
-/obj/machinery/atmospherics/pipe/ATOM_AFTER
+/obj/machinery/atmospherics/pipe/afterShuttleMove(list/movement_force, shuttle_dir, shuttle_preferred_direction, move_dir)
 	. = ..()
 	var/turf/T = loc
 	hide(T.intact)
 
-/obj/machinery/navbeacon/ATOM_BEFORE
+/obj/machinery/navbeacon/beforeShuttleMove(turf/newT, rotation)
 	. = ..()
 	GLOB.navbeacons["[z]"] -= src
 	GLOB.deliverybeacons -= src
 
-/obj/machinery/navbeacon/ATOM_AFTER
+/obj/machinery/navbeacon/afterShuttleMove(list/movement_force, shuttle_dir, shuttle_preferred_direction, move_dir)
 	. = ..()
 	var/turf/T = loc
 	hide(T.intact)
@@ -304,7 +288,7 @@ All ShuttleMove procs go here
 		GLOB.deliverybeacons += src
 		GLOB.deliverybeacontags += location
 
-/obj/machinery/power/terminal/ATOM_AFTER
+/obj/machinery/power/terminal/afterShuttleMove(list/movement_force, shuttle_dir, shuttle_preferred_direction, move_dir)
 	. = ..()
 	var/turf/T = src.loc
 	if(level==1)
@@ -312,14 +296,14 @@ All ShuttleMove procs go here
 
 /************************************Item move procs************************************/
 
-/obj/item/storage/pod/ATOM_ON
+/obj/item/storage/pod/onShuttleMove(turf/newT, turf/oldT, rotation, list/movement_force, move_dir, old_dock)
 	unlocked = TRUE
 	// If the pod was launched, the storage will always open.
 	return ..()
 
 /************************************Mob move procs************************************/
 
-/mob/ATOM_ON
+/mob/onShuttleMove(turf/newT, turf/oldT, rotation, list/movement_force, move_dir, old_dock)
 	if(!move_on_shuttle)
 		return 0
 	. = ..()
@@ -331,7 +315,7 @@ All ShuttleMove procs go here
 		else
 			shake_camera(src, 7, 1)
 
-/mob/living/ATOM_AFTER
+/mob/living/afterShuttleMove(list/movement_force, shuttle_dir, shuttle_preferred_direction, move_dir)
 	. = ..()
 	if(movement_force && !buckled)
 		if(movement_force["THROW"])
@@ -343,25 +327,25 @@ All ShuttleMove procs go here
 		if(movement_force["KNOCKDOWN"])
 			Knockdown(movement_force["KNOCKDOWN"])
 
-/mob/living/simple_animal/hostile/megafauna/ATOM_ON
+/mob/living/simple_animal/hostile/megafauna/onShuttleMove(turf/newT, turf/oldT, rotation, list/movement_force, move_dir, old_dock)
 	. = ..()
 	message_admins("Megafauna [src] [ADMIN_FLW(src)] moved via shuttle from [ADMIN_COORDJMP(oldT)] to [ADMIN_COORDJMP(loc)]")
 
 /************************************Structure move procs************************************/
 
-/obj/structure/grille/ATOM_BEFORE
+/obj/structure/grille/beforeShuttleMove(turf/newT, rotation)
 	. = ..()
 	. = TRUE
 
-/obj/structure/lattice/ATOM_BEFORE
+/obj/structure/lattice/beforeShuttleMove(turf/newT, rotation)
 	. = ..()
 	. = TRUE
 
-/obj/structure/disposalpipe/ATOM_AFTER
+/obj/structure/disposalpipe/afterShuttleMove(list/movement_force, shuttle_dir, shuttle_preferred_direction, move_dir)
 	. = ..()
 	update()
 
-/obj/structure/cable/ATOM_AFTER
+/obj/structure/cable/afterShuttleMove(list/movement_force, shuttle_dir, shuttle_preferred_direction, move_dir)
 	. = ..()
 	var/turf/T = loc
 	if(level==1)
@@ -369,22 +353,22 @@ All ShuttleMove procs go here
 
 /************************************Misc move procs************************************/
 
-/atom/movable/lighting_object/ATOM_ON
+/atom/movable/lighting_object/onShuttleMove(turf/newT, turf/oldT, rotation, list/movement_force, move_dir, old_dock)
 	return FALSE
 
-/atom/movable/light/ATOM_ON
+/atom/movable/light/onShuttleMove(turf/newT, turf/oldT, rotation, list/movement_force, move_dir, old_dock)
 	return FALSE
 
-/obj/docking_port/stationary/ATOM_ON
+/obj/docking_port/stationary/onShuttleMove(turf/newT, turf/oldT, rotation, list/movement_force, move_dir, old_dock)
 	if(old_dock == src) //Don't move the dock we're leaving
 		return FALSE
 
 	. = ..()
 
-/obj/docking_port/stationary/public_mining_dock/ATOM_ON
+/obj/docking_port/stationary/public_mining_dock/onShuttleMove(turf/newT, turf/oldT, rotation, list/movement_force, move_dir, old_dock)
 	id = "mining_public" //It will not move with the base, but will become enabled as a docking point.
 	return 0
 
-/obj/effect/abstract/proximity_checker/ATOM_ON
+/obj/effect/abstract/proximity_checker/onShuttleMove(turf/newT, turf/oldT, rotation, list/movement_force, move_dir, old_dock)
 	//timer so it only happens once
 	addtimer(CALLBACK(monitor, /datum/proximity_monitor/proc/SetRange, monitor.current_range, TRUE), 0, TIMER_UNIQUE)

--- a/code/modules/shuttle/shuttle.dm
+++ b/code/modules/shuttle/shuttle.dm
@@ -535,7 +535,7 @@
 			continue
 		for(var/thing in oldT) //Needs to be this kind of loop in case, because of shuttle rotation shenanigans, the destination turf is the same as the source turf
 			var/atom/movable/moving_atom = thing
-			moving_atom.onShuttleMove(newT, oldT, rotation, movement_force, movement_direction)				//atoms
+			moving_atom.onShuttleMove(newT, oldT, rotation, movement_force, movement_direction, old_dock)	//atoms
 			moved_atoms += moving_atom
 		oldT.onShuttleMove(newT, turf_type, baseturf_type, rotation, movement_force, movement_direction) 	//turfs
 		var/area/shuttle_area = oldT.loc


### PR DESCRIPTION
Checks if the stationary dock being moved is the same as the old_dock, no more locates.

Adds in all args to all uses of ShuttleMove

Cleans up a couple other procs in the file.