### PR TITLE
Morphs now have to restore to their original form before taking another

### DIFF
--- a/code/game/gamemodes/miniantags/morph/morph.dm
+++ b/code/game/gamemodes/miniantags/morph/morph.dm
@@ -93,6 +93,9 @@
 		..()
 
 /mob/living/simple_animal/hostile/morph/proc/assume(atom/movable/target)
+	if(morphed)
+		to_chat(src, "<span class='warning'>You must restore to your original form first!</span>")
+		return
 	morphed = 1
 	form = target
 
@@ -117,6 +120,7 @@
 
 /mob/living/simple_animal/hostile/morph/proc/restore()
 	if(!morphed)
+		to_chat(src, "<span class='warning'>You're already in your normal form!</span>")
 		return
 	morphed = 0
 	form = null

--- a/code/game/gamemodes/miniantags/morph/morph.dm
+++ b/code/game/gamemodes/miniantags/morph/morph.dm
@@ -32,7 +32,7 @@
 	attack_sound = 'sound/effects/blobattack.ogg'
 	butcher_results = list(/obj/item/reagent_containers/food/snacks/meat/slab = 2)
 
-	var/morphed = 0
+	var/morphed = FALSE
 	var/atom/movable/form = null
 	var/morph_time = 0
 	var/static/list/blacklist_typecache = typecacheof(list(
@@ -96,7 +96,7 @@
 	if(morphed)
 		to_chat(src, "<span class='warning'>You must restore to your original form first!</span>")
 		return
-	morphed = 1
+	morphed = TRUE
 	form = target
 
 	visible_message("<span class='warning'>[src] suddenly twists and changes shape, becoming a copy of [target]!</span>", \
@@ -122,7 +122,7 @@
 	if(!morphed)
 		to_chat(src, "<span class='warning'>You're already in your normal form!</span>")
 		return
-	morphed = 0
+	morphed = FALSE
 	form = null
 	alpha = initial(alpha)
 	color = initial(color)


### PR DESCRIPTION
Closes #30066

🆑 ShizCalev
balance: Morphlings now have to restore to their original form before taking a new one.
fix: Morphlings will no longer have combined object appearances
/🆑

This change forces them to be visible in their natural form for 5 seconds in between transformations.