### PR TITLE
Editing machinery's rating has a cancel button and a rights check

### DIFF
--- a/code/modules/admin/verbs/machine_upgrade.dm
+++ b/code/modules/admin/verbs/machine_upgrade.dm
@@ -1,7 +1,9 @@
 /proc/machine_upgrade(obj/machinery/M in world)
 	set name = "Tweak Component Ratings"
 	set category = "Debug"
-	var/new_rating = input("Enter new rating:","Num") as num
+	if(!check_rights(R_DEBUG, TRUE))
+		return
+	var/new_rating = input("Enter new rating:","Num") as null|num
 	if(new_rating && M.component_parts)
 		for(var/obj/item/stock_parts/P in M.component_parts)
 			P.rating = new_rating


### PR DESCRIPTION
Not being able to cancel this when you click on accident is annoying.