### PR TITLE
Adds "you" to some combat-related self-messages

### DIFF
--- a/code/_onclick/item_attack.dm
+++ b/code/_onclick/item_attack.dm
@@ -111,9 +111,10 @@
 	if(hit_area)
 		message_hit_area = " in the [hit_area]"
 	var/attack_message = "[src] has been [message_verb][message_hit_area] with [I]."
+	var/attack_message2 = "You've been [message_verb][message_hit_area] with [I]."
 	if(user in viewers(src, null))
-		attack_message = "[user] has [message_verb] [src][message_hit_area] with [I]!"
+		attack_message = "[user] [message_verb] [src][message_hit_area] with [I]!"
+		attack_message2 = "[user] [message_verb] you[message_hit_area] with [I]!"
 	visible_message("<span class='danger'>[attack_message]</span>", \
-		"<span class='userdanger'>[attack_message]</span>", null, COMBAT_MESSAGE_RANGE)
+		"<span class='userdanger'>[attack_message2]</span>", null, COMBAT_MESSAGE_RANGE)
 	return 1
-

--- a/code/_onclick/other_mobs.dm
+++ b/code/_onclick/other_mobs.dm
@@ -96,16 +96,16 @@
 		var/armor = ML.run_armor_check(affecting, "melee")
 		if(prob(75))
 			ML.apply_damage(rand(1,3), BRUTE, affecting, armor)
-			ML.visible_message("<span class='danger'>[name] bit [ML]!</span>", \
-							"<span class='userdanger'>[name] bit you!</span>")
+			ML.visible_message("<span class='danger'>[src] bit [ML]!</span>", \
+							"<span class='userdanger'>[src] bit you!</span>")
 			if(armor >= 2)
 				return
 			for(var/thing in viruses)
 				var/datum/disease/D = thing
 				ML.ForceContractDisease(D)
 		else
-			ML.visible_message("<span class='danger'>[src] has attempted to bite [ML]!</span>", \
-							"<span class='danger'>[src] has attempted to bite you!</span>")
+			ML.visible_message("<span class='danger'>[src] attempted to bite [ML]!</span>", \
+							"<span class='danger'>[src] attempted to bite you!</span>")
 
 /*
 	Aliens

--- a/code/_onclick/other_mobs.dm
+++ b/code/_onclick/other_mobs.dm
@@ -96,15 +96,16 @@
 		var/armor = ML.run_armor_check(affecting, "melee")
 		if(prob(75))
 			ML.apply_damage(rand(1,3), BRUTE, affecting, armor)
-			ML.visible_message("<span class='danger'>[name] bites [ML]!</span>", \
-							"<span class='userdanger'>[name] bites [ML]!</span>")
+			ML.visible_message("<span class='danger'>[name] bit [ML]!</span>", \
+							"<span class='userdanger'>[name] bit you!</span>")
 			if(armor >= 2)
 				return
 			for(var/thing in viruses)
 				var/datum/disease/D = thing
 				ML.ForceContractDisease(D)
 		else
-			ML.visible_message("<span class='danger'>[src] has attempted to bite [ML]!</span>")
+			ML.visible_message("<span class='danger'>[src] has attempted to bite [ML]!</span>", \
+							"<span class='danger'>[src] has attempted to bite you!</span>")
 
 /*
 	Aliens

--- a/code/datums/martial.dm
+++ b/code/datums/martial.dm
@@ -50,8 +50,8 @@
 
 	if(!damage)
 		playsound(D.loc, A.dna.species.miss_sound, 25, 1, -1)
-		D.visible_message("<span class='warning'>[A] has attempted to [atk_verb] [D]!</span>", \
-			"<span class='userdanger'>[A] has attempted to [atk_verb] [D]!</span>", null, COMBAT_MESSAGE_RANGE)
+		D.visible_message("<span class='warning'>[A] attempted to [atk_verb] [D]!</span>", \
+			"<span class='userdanger'>[A] attempted to [atk_verb] you!</span>", null, COMBAT_MESSAGE_RANGE)
 		add_logs(A, D, "attempted to [atk_verb]")
 		return 0
 
@@ -59,16 +59,16 @@
 	var/armor_block = D.run_armor_check(affecting, "melee")
 
 	playsound(D.loc, A.dna.species.attack_sound, 25, 1, -1)
-	D.visible_message("<span class='danger'>[A] has [atk_verb]ed [D]!</span>", \
-			"<span class='userdanger'>[A] has [atk_verb]ed [D]!</span>", null, COMBAT_MESSAGE_RANGE)
+	D.visible_message("<span class='danger'>[A] [atk_verb]ed [D]!</span>", \
+			"<span class='userdanger'>[A] [atk_verb]ed you!</span>", null, COMBAT_MESSAGE_RANGE)
 
 	D.apply_damage(damage, BRUTE, affecting, armor_block)
 
 	add_logs(A, D, "punched")
 
 	if((D.stat != DEAD) && damage >= A.dna.species.punchstunthreshold)
-		D.visible_message("<span class='danger'>[A] has knocked [D] down!!</span>", \
-								"<span class='userdanger'>[A] has knocked [D] down!</span>")
+		D.visible_message("<span class='danger'>[A] knocked [D] down!!</span>", \
+								"<span class='userdanger'>[A] knocked you down!</span>")
 		D.apply_effect(40, KNOCKDOWN, armor_block)
 		D.forcesay(GLOB.hit_appends)
 	else if(D.lying)

--- a/code/datums/martial/boxing.dm
+++ b/code/datums/martial/boxing.dm
@@ -18,8 +18,8 @@
 	var/damage = rand(5, 8) + A.dna.species.punchdamagelow
 	if(!damage)
 		playsound(D.loc, A.dna.species.miss_sound, 25, 1, -1)
-		D.visible_message("<span class='warning'>[A] has attempted to [atk_verb] [D]!</span>", \
-			"<span class='userdanger'>[A] has attempted to [atk_verb] [D]!</span>", null, COMBAT_MESSAGE_RANGE)
+		D.visible_message("<span class='warning'>[A] attempted to [atk_verb] [D]!</span>", \
+			"<span class='userdanger'>[A] attempted to [atk_verb] you!</span>", null, COMBAT_MESSAGE_RANGE)
 		add_logs(A, D, "attempted to hit", atk_verb)
 		return 0
 
@@ -29,16 +29,16 @@
 
 	playsound(D.loc, A.dna.species.attack_sound, 25, 1, -1)
 
-	D.visible_message("<span class='danger'>[A] has [atk_verb]ed [D]!</span>", \
-			"<span class='userdanger'>[A] has [atk_verb]ed [D]!</span>", null, COMBAT_MESSAGE_RANGE)
+	D.visible_message("<span class='danger'>[A] [atk_verb]ed [D]!</span>", \
+			"<span class='userdanger'>[A] [atk_verb]ed you!</span>", null, COMBAT_MESSAGE_RANGE)
 
 	D.apply_damage(damage, STAMINA, affecting, armor_block)
 	add_logs(A, D, "punched (boxing) ")
 	if(D.getStaminaLoss() > 50)
 		var/knockout_prob = D.getStaminaLoss() + rand(-15,15)
 		if((D.stat != DEAD) && prob(knockout_prob))
-			D.visible_message("<span class='danger'>[A] has knocked [D] out with a haymaker!</span>", \
-								"<span class='userdanger'>[A] has knocked [D] out with a haymaker!</span>")
+			D.visible_message("<span class='danger'>[A] knocked [D] out with a haymaker!</span>", \
+								"<span class='userdanger'>[A] knocked you out with a haymaker!</span>")
 			D.apply_effect(200,KNOCKDOWN,armor_block)
 			D.SetSleeping(100)
 			D.forcesay(GLOB.hit_appends)

--- a/code/datums/martial/cqc.dm
+++ b/code/datums/martial/cqc.dm
@@ -151,7 +151,7 @@
 			D.apply_damage(5, BRUTE)
 	else
 		D.visible_message("<span class='danger'>[A] attempted to disarm [D]!</span>", \
-							"<span class='userdanger'>[A] attempted to disarm [D]!</span>")
+							"<span class='userdanger'>[A] attempted to disarm you!</span>")
 		playsound(D, 'sound/weapons/punchmiss.ogg', 25, 1, -1)
 	add_logs(A, D, "disarmed with CQC", "[I ? " grabbing \the [I]" : ""]")
 	if(restraining && A.pulling == D)

--- a/code/datums/martial/krav_maga.dm
+++ b/code/datums/martial/krav_maga.dm
@@ -152,12 +152,12 @@
 		if(I)
 			if(D.drop_item())
 				A.put_in_hands(I)
-		D.visible_message("<span class='danger'>[A] has disarmed [D]!</span>", \
-							"<span class='userdanger'>[A] has disarmed [D]!</span>")
+		D.visible_message("<span class='danger'>[A] disarmed [D]!</span>", \
+							"<span class='userdanger'>[A] disarmed you!</span>")
 		playsound(D, 'sound/weapons/thudswoosh.ogg', 50, 1, -1)
 	else
 		D.visible_message("<span class='danger'>[A] attempted to disarm [D]!</span>", \
-							"<span class='userdanger'>[A] attempted to disarm [D]!</span>")
+							"<span class='userdanger'>[A] attempted to disarm you!</span>")
 		playsound(D, 'sound/weapons/punchmiss.ogg', 25, 1, -1)
 	add_logs(A, D, "disarmed with krav maga", "[I ? " removing \the [I]" : ""]")
 	return 1

--- a/code/datums/martial/plasma_fist.dm
+++ b/code/datums/martial/plasma_fist.dm
@@ -43,8 +43,8 @@
 	return
 
 /datum/martial_art/plasma_fist/proc/Throwback(mob/living/carbon/human/A, mob/living/carbon/human/D)
-	D.visible_message("<span class='danger'>[A] has hit [D] with Plasma Punch!</span>", \
-								"<span class='userdanger'>[A] has hit [D] with Plasma Punch!</span>")
+	D.visible_message("<span class='danger'>[A] hit [D] with Plasma Punch!</span>", \
+								"<span class='userdanger'>[A] hit you with Plasma Punch!</span>")
 	playsound(D.loc, 'sound/weapons/punch1.ogg', 50, 1, -1)
 	var/atom/throw_target = get_edge_target_turf(D, get_dir(D, get_step_away(D, A)))
 	D.throw_at(throw_target, 200, 4,A)
@@ -56,8 +56,8 @@
 	A.do_attack_animation(D, ATTACK_EFFECT_PUNCH)
 	playsound(D.loc, 'sound/weapons/punch1.ogg', 50, 1, -1)
 	A.say("PLASMA FIST!")
-	D.visible_message("<span class='danger'>[A] has hit [D] with THE PLASMA FIST TECHNIQUE!</span>", \
-								"<span class='userdanger'>[A] has hit [D] with THE PLASMA FIST TECHNIQUE!</span>")
+	D.visible_message("<span class='danger'>[A] hit [D] with THE PLASMA FIST TECHNIQUE!</span>", \
+								"<span class='userdanger'>[A] hit you with THE PLASMA FIST TECHNIQUE!</span>")
 	D.gib()
 	add_logs(A, D, "gibbed (Plasma Fist)")
 	return

--- a/code/datums/martial/wrestling.dm
+++ b/code/datums/martial/wrestling.dm
@@ -432,8 +432,8 @@
 	if(A.pulling == D)
 		return 1
 	A.start_pulling(D)
-	D.visible_message("<span class='danger'>[A] gets [D] in a cinch!</span>", \
-								"<span class='userdanger'>[A] gets [D] in a cinch!</span>")
+	D.visible_message("<span class='danger'>[A] got [D] in a cinch!</span>", \
+								"<span class='userdanger'>[A] got you in a cinch!</span>")
 	D.Stun(rand(60,100))
 	add_logs(A, D, "cinched")
 	return 1

--- a/code/game/objects/items/defib.dm
+++ b/code/game/objects/items/defib.dm
@@ -399,8 +399,8 @@
 	if(!req_defib && !combat)
 		return
 	busy = TRUE
-	M.visible_message("<span class='danger'>[user] has touched [M] with [src]!</span>", \
-			"<span class='userdanger'>[user] has touched [M] with [src]!</span>")
+	M.visible_message("<span class='danger'>[user] touched [M] with [src]!</span>", \
+			"<span class='userdanger'>[user] touched you with [src]!</span>")
 	M.adjustStaminaLoss(50)
 	M.Knockdown(100)
 	M.updatehealth() //forces health update before next life tick

--- a/code/game/objects/items/dna_injector.dm
+++ b/code/game/objects/items/dna_injector.dm
@@ -69,11 +69,12 @@
 	add_logs(user, target, "attempted to inject", src)
 
 	if(target != user)
-		target.visible_message("<span class='danger'>[user] is trying to inject [target] with [src]!</span>", "<span class='userdanger'>[user] is trying to inject [target] with [src]!</span>")
+		target.visible_message("<span class='danger'>[user] tries to inject [target] with [src]...</span>", \
+						"<span class='userdanger'>[user] tries to inject you with [src]...</span>")
 		if(!do_mob(user, target) || used)
 			return
-		target.visible_message("<span class='danger'>[user] injects [target] with the syringe with [src]!", \
-						"<span class='userdanger'>[user] injects [target] with the syringe with [src]!")
+		target.visible_message("<span class='danger'>[user] injected [target] with the syringe with [src]!", \
+						"<span class='userdanger'>[user] injected you with the syringe with [src]!")
 
 	else
 		to_chat(user, "<span class='notice'>You inject yourself with [src].</span>")

--- a/code/modules/flufftext/Hallucination.dm
+++ b/code/modules/flufftext/Hallucination.dm
@@ -662,7 +662,7 @@ GLOBAL_LIST_INIT(hallucinations_major, list(
 			if(prob(15))
 				if(weapon_name)
 					my_target.playsound_local(my_target, weap.hitsound, weap.get_clamped_volume(), 1)
-					my_target.show_message("<span class='danger'>[src.name] has attacked [my_target] with [weapon_name]!</span>", 1)
+					my_target.show_message("<span class='danger'>[src.name] attacked you with [weapon_name]!</span>", 1)
 					my_target.staminaloss += 30
 					if(prob(20))
 						my_target.blur_eyes(3)
@@ -671,7 +671,7 @@ GLOBAL_LIST_INIT(hallucinations_major, list(
 							fake_blood(my_target)
 				else
 					my_target.playsound_local(my_target, pick('sound/weapons/punch1.ogg','sound/weapons/punch2.ogg','sound/weapons/punch3.ogg','sound/weapons/punch4.ogg'), 25, 1)
-					my_target.show_message("<span class='userdanger'>[src.name] has punched [my_target]!</span>", 1)
+					my_target.show_message("<span class='userdanger'>[src.name] punched you!</span>", 1)
 					my_target.staminaloss += 30
 					if(prob(33))
 						if(!locate(/obj/effect/overlay) in my_target.loc)
@@ -1148,4 +1148,3 @@ GLOBAL_LIST_INIT(hallucinations_major, list(
 	H.original = target
 	H.fire()
 	qdel(src)
-

--- a/code/modules/flufftext/Hallucination.dm
+++ b/code/modules/flufftext/Hallucination.dm
@@ -662,7 +662,7 @@ GLOBAL_LIST_INIT(hallucinations_major, list(
 			if(prob(15))
 				if(weapon_name)
 					my_target.playsound_local(my_target, weap.hitsound, weap.get_clamped_volume(), 1)
-					my_target.show_message("<span class='danger'>[src.name] attacked you with [weapon_name]!</span>", 1)
+					my_target.show_message("<span class='danger'>[src] attacked you with [weapon_name]!</span>", 1)
 					my_target.staminaloss += 30
 					if(prob(20))
 						my_target.blur_eyes(3)
@@ -671,7 +671,7 @@ GLOBAL_LIST_INIT(hallucinations_major, list(
 							fake_blood(my_target)
 				else
 					my_target.playsound_local(my_target, pick('sound/weapons/punch1.ogg','sound/weapons/punch2.ogg','sound/weapons/punch3.ogg','sound/weapons/punch4.ogg'), 25, 1)
-					my_target.show_message("<span class='userdanger'>[src.name] punched you!</span>", 1)
+					my_target.show_message("<span class='userdanger'>[src] punched you!</span>", 1)
 					my_target.staminaloss += 30
 					if(prob(33))
 						if(!locate(/obj/effect/overlay) in my_target.loc)

--- a/code/modules/food_and_drinks/drinks/drinks.dm
+++ b/code/modules/food_and_drinks/drinks/drinks.dm
@@ -35,12 +35,14 @@
 		to_chat(M, "<span class='notice'>You swallow a gulp of [src].</span>")
 
 	else
-		M.visible_message("<span class='danger'>[user] attempts to feed the contents of [src] to [M].</span>", "<span class='userdanger'>[user] attempts to feed the contents of [src] to [M].</span>")
+		M.visible_message("<span class='danger'>[user] attempts to feed the contents of [src] to [M]...</span>", \
+						"<span class='userdanger'>[user] attempts to feed the contents of [src] to you...</span>")
 		if(!do_mob(user, M))
 			return
 		if(!reagents || !reagents.total_volume)
 			return // The drink might be empty after the delay, such as by spam-feeding
-		M.visible_message("<span class='danger'>[user] feeds the contents of [src] to [M].</span>", "<span class='userdanger'>[user] feeds the contents of [src] to [M].</span>")
+		M.visible_message("<span class='danger'>[user] fed the contents of [src] to [M]!</span>", \
+						"<span class='userdanger'>[user] fed the contents of [src] to you!</span>")
 		add_logs(user, M, "fed", reagentlist(src))
 
 	var/fraction = min(gulp_size/reagents.total_volume, 1)

--- a/code/modules/food_and_drinks/drinks/drinks/bottle.dm
+++ b/code/modules/food_and_drinks/drinks/drinks/bottle.dm
@@ -106,11 +106,11 @@
 
 	//Display an attack message.
 	if(target != user)
-		target.visible_message("<span class='danger'>[user] hit [target][head_attack_message] with a bottle of [src.name]!</span>", \
-				"<span class='userdanger'>[user] hit you[head_attack_message] with a bottle of [src.name]!</span>")
+		target.visible_message("<span class='danger'>[user] hit [target][head_attack_message] with a bottle of [src]!</span>", \
+				"<span class='userdanger'>[user] hit you[head_attack_message] with a bottle of [src]!</span>")
 	else
-		user.visible_message("<span class='danger'>[target] hit [target.p_them()]self with a bottle of [src.name][head_attack_message]!</span>", \
-				"<span class='userdanger'>You hit yourself with a bottle of [src.name][head_attack_message]!</span>")
+		user.visible_message("<span class='danger'>[target] hit [target.p_them()]self with a bottle of [src][head_attack_message]!</span>", \
+				"<span class='userdanger'>You hit yourself with a bottle of [src][head_attack_message]!</span>")
 
 	//Attack logs
 	add_logs(user, target, "attacked", src)

--- a/code/modules/food_and_drinks/drinks/drinks/bottle.dm
+++ b/code/modules/food_and_drinks/drinks/drinks/bottle.dm
@@ -106,11 +106,11 @@
 
 	//Display an attack message.
 	if(target != user)
-		target.visible_message("<span class='danger'>[user] has hit [target][head_attack_message] with a bottle of [src.name]!</span>", \
-				"<span class='userdanger'>[user] has hit [target][head_attack_message] with a bottle of [src.name]!</span>")
+		target.visible_message("<span class='danger'>[user] hit [target][head_attack_message] with a bottle of [src.name]!</span>", \
+				"<span class='userdanger'>[user] hit you[head_attack_message] with a bottle of [src.name]!</span>")
 	else
-		user.visible_message("<span class='danger'>[target] hits [target.p_them()]self with a bottle of [src.name][head_attack_message]!</span>", \
-				"<span class='userdanger'>[target] hits [target.p_them()]self with a bottle of [src.name][head_attack_message]!</span>")
+		user.visible_message("<span class='danger'>[target] hit [target.p_them()]self with a bottle of [src.name][head_attack_message]!</span>", \
+				"<span class='userdanger'>You hit yourself with a bottle of [src.name][head_attack_message]!</span>")
 
 	//Attack logs
 	add_logs(user, target, "attacked", src)

--- a/code/modules/mob/living/carbon/alien/alien_defense.dm
+++ b/code/modules/mob/living/carbon/alien/alien_defense.dm
@@ -35,8 +35,8 @@ In all, this is a lot like the monkey code. /N
 			if(health > 0)
 				M.do_attack_animation(src, ATTACK_EFFECT_BITE)
 				playsound(loc, 'sound/weapons/bite.ogg', 50, 1, -1)
-				visible_message("<span class='danger'>[M.name] bit [src]!</span>", \
-						"<span class='userdanger'>[M.name] bit you!</span>", null, COMBAT_MESSAGE_RANGE)
+				visible_message("<span class='danger'>[M] bit [src]!</span>", \
+						"<span class='userdanger'>[M] bit you!</span>", null, COMBAT_MESSAGE_RANGE)
 				adjustBruteLoss(1)
 				add_logs(M, src, "attacked")
 				updatehealth()

--- a/code/modules/mob/living/carbon/alien/alien_defense.dm
+++ b/code/modules/mob/living/carbon/alien/alien_defense.dm
@@ -35,8 +35,8 @@ In all, this is a lot like the monkey code. /N
 			if(health > 0)
 				M.do_attack_animation(src, ATTACK_EFFECT_BITE)
 				playsound(loc, 'sound/weapons/bite.ogg', 50, 1, -1)
-				visible_message("<span class='danger'>[M.name] bites [src]!</span>", \
-						"<span class='userdanger'>[M.name] bites [src]!</span>", null, COMBAT_MESSAGE_RANGE)
+				visible_message("<span class='danger'>[M.name] bit [src]!</span>", \
+						"<span class='userdanger'>[M.name] bit you!</span>", null, COMBAT_MESSAGE_RANGE)
 				adjustBruteLoss(1)
 				add_logs(M, src, "attacked")
 				updatehealth()

--- a/code/modules/mob/living/carbon/alien/humanoid/humanoid_defense.dm
+++ b/code/modules/mob/living/carbon/alien/humanoid/humanoid_defense.dm
@@ -16,8 +16,8 @@
 			step_away(src,user,15)
 			hitverb = "slammed"
 		playsound(loc, "punch", 25, 1, -1)
-		visible_message("<span class='danger'>[user] has [hitverb] [src]!</span>", \
-		"<span class='userdanger'>[user] has [hitverb] [src]!</span>", null, COMBAT_MESSAGE_RANGE)
+		visible_message("<span class='danger'>[user] [hitverb] [src]!</span>", \
+		"<span class='userdanger'>[user] [hitverb] you!</span>", null, COMBAT_MESSAGE_RANGE)
 		return 1
 
 /mob/living/carbon/alien/humanoid/attack_hand(mob/living/carbon/human/M)
@@ -27,19 +27,19 @@
 				var/damage = rand(1, 9)
 				if (prob(90))
 					playsound(loc, "punch", 25, 1, -1)
-					visible_message("<span class='danger'>[M] has punched [src]!</span>", \
-							"<span class='userdanger'>[M] has punched [src]!</span>", null, COMBAT_MESSAGE_RANGE)
+					visible_message("<span class='danger'>[M] punched [src]!</span>", \
+							"<span class='userdanger'>[M] punched you!</span>", null, COMBAT_MESSAGE_RANGE)
 					if ((stat != DEAD) && (damage > 9 || prob(5)))//Regular humans have a very small chance of knocking an alien down.
 						Unconscious(40)
-						visible_message("<span class='danger'>[M] has knocked [src] down!</span>", \
-								"<span class='userdanger'>[M] has knocked [src] down!</span>")
+						visible_message("<span class='danger'>[M] knocked [src] down!</span>", \
+								"<span class='userdanger'>[M] knocked you down!</span>")
 					var/obj/item/bodypart/affecting = get_bodypart(ran_zone(M.zone_selected))
 					apply_damage(damage, BRUTE, affecting)
 					add_logs(M, src, "attacked")
 				else
 					playsound(loc, 'sound/weapons/punchmiss.ogg', 25, 1, -1)
-					visible_message("<span class='userdanger'>[M] has attempted to punch [src]!</span>", \
-						"<span class='userdanger'>[M] has attempted to punch [src]!</span>", null, COMBAT_MESSAGE_RANGE)
+					visible_message("<span class='userdanger'>[M] attempted to punch [src]!</span>", \
+						"<span class='userdanger'>[M] attempted to punch you!</span>", null, COMBAT_MESSAGE_RANGE)
 
 			if ("disarm")
 				if (!lying)
@@ -47,18 +47,18 @@
 						Unconscious(40)
 						playsound(loc, 'sound/weapons/thudswoosh.ogg', 50, 1, -1)
 						add_logs(M, src, "pushed")
-						visible_message("<span class='danger'>[M] has pushed down [src]!</span>", \
-							"<span class='userdanger'>[M] has pushed down [src]!</span>")
+						visible_message("<span class='danger'>[M] pushed [src] down!</span>", \
+							"<span class='userdanger'>[M] pushed you down!</span>")
 					else
 						if (prob(50))
 							drop_item()
 							playsound(loc, 'sound/weapons/thudswoosh.ogg', 50, 1, -1)
-							visible_message("<span class='danger'>[M] has disarmed [src]!</span>", \
-							"<span class='userdanger'>[M] has disarmed [src]!</span>", null, COMBAT_MESSAGE_RANGE)
+							visible_message("<span class='danger'>[M] disarmed [src]!</span>", \
+							"<span class='userdanger'>[M] disarmed you!</span>", null, COMBAT_MESSAGE_RANGE)
 						else
 							playsound(loc, 'sound/weapons/punchmiss.ogg', 25, 1, -1)
-							visible_message("<span class='userdanger'>[M] has attempted to disarm [src]!</span>",\
-								"<span class='userdanger'>[M] has attempted to disarm [src]!</span>", null, COMBAT_MESSAGE_RANGE)
+							visible_message("<span class='userdanger'>[M] attempted to disarm [src]!</span>",\
+								"<span class='userdanger'>[M] attempted to disarm you!</span>", null, COMBAT_MESSAGE_RANGE)
 
 
 

--- a/code/modules/mob/living/carbon/alien/larva/larva_defense.dm
+++ b/code/modules/mob/living/carbon/alien/larva/larva_defense.dm
@@ -6,8 +6,8 @@
 		if (prob(90))
 			playsound(loc, "punch", 25, 1, -1)
 			add_logs(M, src, "attacked")
-			visible_message("<span class='danger'>[M] has kicked [src]!</span>", \
-					"<span class='userdanger'>[M] has kicked [src]!</span>", null, COMBAT_MESSAGE_RANGE)
+			visible_message("<span class='danger'>[M] kicked [src]!</span>", \
+					"<span class='userdanger'>[M] kicked you!</span>", null, COMBAT_MESSAGE_RANGE)
 			if ((stat != DEAD) && (damage > 4.9))
 				Unconscious(rand(100,200))
 
@@ -15,8 +15,8 @@
 			apply_damage(damage, BRUTE, affecting)
 		else
 			playsound(loc, 'sound/weapons/punchmiss.ogg', 25, 1, -1)
-			visible_message("<span class='danger'>[M] has attempted to kick [src]!</span>", \
-					"<span class='userdanger'>[M] has attempted to kick [src]!</span>", null, COMBAT_MESSAGE_RANGE)
+			visible_message("<span class='danger'>[M] attempted to kick [src]!</span>", \
+					"<span class='userdanger'>[M] attempted to kick you!</span>", null, COMBAT_MESSAGE_RANGE)
 
 /mob/living/carbon/alien/larva/attack_hulk(mob/living/carbon/human/user, does_attack_animation = 0)
 	if(user.a_intent == INTENT_HARM)

--- a/code/modules/mob/living/carbon/carbon_defense.dm
+++ b/code/modules/mob/living/carbon/carbon_defense.dm
@@ -160,8 +160,8 @@
 				if(M.powerlevel < 0)
 					M.powerlevel = 0
 
-				visible_message("<span class='danger'>The [M.name] has shocked [src]!</span>", \
-				"<span class='userdanger'>The [M.name] has shocked [src]!</span>")
+				visible_message("<span class='danger'>The [M.name] shocked [src]!</span>", \
+				"<span class='userdanger'>The [M.name] shocked you!</span>")
 
 				do_sparks(5, TRUE, src)
 				var/power = M.powerlevel + rand(0,3)

--- a/code/modules/mob/living/carbon/carbon_defense.dm
+++ b/code/modules/mob/living/carbon/carbon_defense.dm
@@ -160,8 +160,8 @@
 				if(M.powerlevel < 0)
 					M.powerlevel = 0
 
-				visible_message("<span class='danger'>The [M.name] shocked [src]!</span>", \
-				"<span class='userdanger'>The [M.name] shocked you!</span>")
+				visible_message("<span class='danger'>The [M] shocked [src]!</span>", \
+				"<span class='userdanger'>The [M] shocked you!</span>")
 
 				do_sparks(5, TRUE, src)
 				var/power = M.powerlevel + rand(0,3)

--- a/code/modules/mob/living/carbon/human/human_defense.dm
+++ b/code/modules/mob/living/carbon/human/human_defense.dm
@@ -177,9 +177,8 @@
 			return
 		..(user, 1)
 		playsound(loc, user.dna.species.attack_sound, 25, 1, -1)
-		var/message = "[user] has [hulk_verb]ed [src]!"
-		visible_message("<span class='danger'>[message]</span>", \
-								"<span class='userdanger'>[message]</span>")
+		visible_message("<span class='danger'>[user] [hulk_verb]ed [src]!</span>", \
+								"<span class='userdanger'>[user] [hulk_verb]ed you!</span>")
 		adjustBruteLoss(15)
 		damage_clothes(15, BRUTE, "melee")
 		return 1
@@ -208,13 +207,13 @@
 		if(get_active_held_item() && drop_item())
 			playsound(loc, 'sound/weapons/slash.ogg', 25, 1, -1)
 			visible_message("<span class='danger'>[M] disarmed [src]!</span>", \
-					"<span class='userdanger'>[M] disarmed [src]!</span>")
+					"<span class='userdanger'>[M] disarmed you!</span>")
 		else if(!M.client || prob(5)) // only natural monkeys get to stun reliably, (they only do it occasionaly)
 			playsound(loc, 'sound/weapons/pierce.ogg', 25, 1, -1)
 			Knockdown(100)
 			add_logs(M, src, "tackled")
-			visible_message("<span class='danger'>[M] has tackled down [src]!</span>", \
-				"<span class='userdanger'>[M] has tackled down [src]!</span>")
+			visible_message("<span class='danger'>[M] tackled [src] down!</span>", \
+				"<span class='userdanger'>[M] tackled you down!</span>")
 
 	if(M.limb_destroyer)
 		dismembering_strike(M, affecting.body_zone)
@@ -241,8 +240,8 @@
 			var/damage = prob(90) ? 20 : 0
 			if(!damage)
 				playsound(loc, 'sound/weapons/slashmiss.ogg', 50, 1, -1)
-				visible_message("<span class='danger'>[M] has lunged at [src]!</span>", \
-					"<span class='userdanger'>[M] has lunged at [src]!</span>")
+				visible_message("<span class='danger'>[M] lunged at [src]!</span>", \
+					"<span class='userdanger'>[M] lunged at you!</span>")
 				return 0
 			var/obj/item/bodypart/affecting = get_bodypart(ran_zone(M.zone_selected))
 			if(!affecting)
@@ -250,8 +249,8 @@
 			var/armor_block = run_armor_check(affecting, "melee","","",10)
 
 			playsound(loc, 'sound/weapons/slice.ogg', 25, 1, -1)
-			visible_message("<span class='danger'>[M] has slashed at [src]!</span>", \
-				"<span class='userdanger'>[M] has slashed at [src]!</span>")
+			visible_message("<span class='danger'>[M] slashed at [src]!</span>", \
+				"<span class='userdanger'>[M] slashed at you!</span>")
 			add_logs(M, src, "attacked")
 			if(!dismembering_strike(M, M.zone_selected)) //Dismemberment successful
 				return 1
@@ -262,13 +261,13 @@
 			if(get_active_held_item() && drop_item())
 				playsound(loc, 'sound/weapons/slash.ogg', 25, 1, -1)
 				visible_message("<span class='danger'>[M] disarmed [src]!</span>", \
-						"<span class='userdanger'>[M] disarmed [src]!</span>")
+						"<span class='userdanger'>[M] disarmed you!</span>")
 			else
 				playsound(loc, 'sound/weapons/pierce.ogg', 25, 1, -1)
 				Knockdown(100)
 				add_logs(M, src, "tackled")
-				visible_message("<span class='danger'>[M] has tackled down [src]!</span>", \
-					"<span class='userdanger'>[M] has tackled down [src]!</span>")
+				visible_message("<span class='danger'>[M] tackled [src] down!</span>", \
+					"<span class='userdanger'>[M] tackled you down!</span>")
 
 
 /mob/living/carbon/human/attack_larva(mob/living/carbon/alien/larva/L)
@@ -353,8 +352,8 @@
 				update_damage_overlays()
 			updatehealth()
 
-		visible_message("<span class='danger'>[M.name] has hit [src]!</span>", \
-								"<span class='userdanger'>[M.name] has hit [src]!</span>", null, COMBAT_MESSAGE_RANGE)
+		visible_message("<span class='danger'>[M.name] hit [src]!</span>", \
+								"<span class='userdanger'>[M.name] hit you!</span>", null, COMBAT_MESSAGE_RANGE)
 		add_logs(M.occupant, src, "attacked", M, "(INTENT: [uppertext(M.occupant.a_intent)]) (DAMTYPE: [uppertext(M.damtype)])")
 
 	else

--- a/code/modules/mob/living/carbon/human/human_defense.dm
+++ b/code/modules/mob/living/carbon/human/human_defense.dm
@@ -352,8 +352,8 @@
 				update_damage_overlays()
 			updatehealth()
 
-		visible_message("<span class='danger'>[M.name] hit [src]!</span>", \
-								"<span class='userdanger'>[M.name] hit you!</span>", null, COMBAT_MESSAGE_RANGE)
+		visible_message("<span class='danger'>[M] hit [src]!</span>", \
+								"<span class='userdanger'>[M] hit you!</span>", null, COMBAT_MESSAGE_RANGE)
 		add_logs(M.occupant, src, "attacked", M, "(INTENT: [uppertext(M.occupant.a_intent)]) (DAMTYPE: [uppertext(M.damtype)])")
 
 	else

--- a/code/modules/mob/living/carbon/human/species.dm
+++ b/code/modules/mob/living/carbon/human/species.dm
@@ -1105,8 +1105,8 @@
 
 		if(!damage || !affecting)
 			playsound(target.loc, user.dna.species.miss_sound, 25, 1, -1)
-			target.visible_message("<span class='danger'>[user] has attempted to [atk_verb] [target]!</span>",\
-			"<span class='userdanger'>[user] has attempted to [atk_verb] [target]!</span>", null, COMBAT_MESSAGE_RANGE)
+			target.visible_message("<span class='danger'>[user] attempted to [atk_verb] [target]!</span>",\
+			"<span class='userdanger'>[user] attempted to [atk_verb] you!</span>", null, COMBAT_MESSAGE_RANGE)
 			return 0
 
 
@@ -1114,16 +1114,16 @@
 
 		playsound(target.loc, user.dna.species.attack_sound, 25, 1, -1)
 
-		target.visible_message("<span class='danger'>[user] has [atk_verb]ed [target]!</span>", \
-					"<span class='userdanger'>[user] has [atk_verb]ed [target]!</span>", null, COMBAT_MESSAGE_RANGE)
+		target.visible_message("<span class='danger'>[user] [atk_verb]ed [target]!</span>", \
+					"<span class='userdanger'>[user] [atk_verb]ed you!</span>", null, COMBAT_MESSAGE_RANGE)
 
 		if(user.limb_destroyer)
 			target.dismembering_strike(user, affecting.body_zone)
 		target.apply_damage(damage, BRUTE, affecting, armor_block)
 		add_logs(user, target, "punched")
 		if((target.stat != DEAD) && damage >= user.dna.species.punchstunthreshold)
-			target.visible_message("<span class='danger'>[user] has knocked  [target] down!</span>", \
-							"<span class='userdanger'>[user] has knocked [target] down!</span>")
+			target.visible_message("<span class='danger'>[user] knocked  [target] down!</span>", \
+							"<span class='userdanger'>[user] knocked you down!</span>")
 			target.apply_effect(80, KNOCKDOWN, armor_block)
 			target.forcesay(GLOB.hit_appends)
 		else if(target.lying)
@@ -1146,8 +1146,8 @@
 		var/randn = rand(1, 100)
 		if(randn <= 25)
 			playsound(target, 'sound/weapons/thudswoosh.ogg', 50, 1, -1)
-			target.visible_message("<span class='danger'>[user] has pushed [target]!</span>",
-				"<span class='userdanger'>[user] has pushed [target]!</span>", null, COMBAT_MESSAGE_RANGE)
+			target.visible_message("<span class='danger'>[user] pushed [target]!</span>",
+				"<span class='userdanger'>[user] pushed you!</span>", null, COMBAT_MESSAGE_RANGE)
 			target.apply_effect(40, KNOCKDOWN, target.run_armor_check(affecting, "melee", "Your armor prevents your fall!", "Your armor softens your fall!"))
 			target.forcesay(GLOB.hit_appends)
 			add_logs(user, target, "disarmed", " pushing them to the ground")
@@ -1161,8 +1161,8 @@
 			else
 				I = target.get_active_held_item()
 				if(target.drop_item())
-					target.visible_message("<span class='danger'>[user] has disarmed [target]!</span>", \
-						"<span class='userdanger'>[user] has disarmed [target]!</span>", null, COMBAT_MESSAGE_RANGE)
+					target.visible_message("<span class='danger'>[user] disarmed [target]!</span>", \
+						"<span class='userdanger'>[user] disarmed you!</span>", null, COMBAT_MESSAGE_RANGE)
 				else
 					I = null
 			playsound(target, 'sound/weapons/thudswoosh.ogg', 50, 1, -1)
@@ -1172,7 +1172,7 @@
 
 		playsound(target, 'sound/weapons/punchmiss.ogg', 25, 1, -1)
 		target.visible_message("<span class='danger'>[user] attempted to disarm [target]!</span>", \
-						"<span class='userdanger'>[user] attemped to disarm [target]!</span>", null, COMBAT_MESSAGE_RANGE)
+						"<span class='userdanger'>[user] attemped to disarm you!</span>", null, COMBAT_MESSAGE_RANGE)
 
 
 
@@ -1258,8 +1258,8 @@
 			if("head")
 				if(H.stat == CONSCIOUS && armor_block < 50)
 					if(prob(I.force))
-						H.visible_message("<span class='danger'>[H] has been knocked senseless!</span>", \
-										"<span class='userdanger'>[H] has been knocked senseless!</span>")
+						H.visible_message("<span class='danger'>[H] is knocked senseless!</span>", \
+										"<span class='userdanger'>You're knocked senseless!</span>")
 						H.confused = max(H.confused, 20)
 						H.adjust_blurriness(10)
 
@@ -1280,8 +1280,8 @@
 			if("chest")
 				if(H.stat == CONSCIOUS && armor_block < 50)
 					if(prob(I.force))
-						H.visible_message("<span class='danger'>[H] has been knocked down!</span>", \
-									"<span class='userdanger'>[H] has been knocked down!</span>")
+						H.visible_message("<span class='danger'>[H] is knocked down!</span>", \
+									"<span class='userdanger'>You're knocked down!</span>")
 						H.apply_effect(60, KNOCKDOWN, armor_block)
 
 				if(bloody)

--- a/code/modules/mob/living/carbon/monkey/monkey_defense.dm
+++ b/code/modules/mob/living/carbon/monkey/monkey_defense.dm
@@ -43,7 +43,7 @@
 		if("harm")
 			M.do_attack_animation(src, ATTACK_EFFECT_PUNCH)
 			if (prob(75))
-				visible_message("<span class='danger'>[M] punched [name]!</span>", \
+				visible_message("<span class='danger'>[M] punched [src]!</span>", \
 						"<span class='userdanger'>[M] punched you!</span>", null, COMBAT_MESSAGE_RANGE)
 
 				playsound(loc, "punch", 25, 1, -1)
@@ -52,7 +52,7 @@
 					damage = rand(10, 15)
 					if(AmountUnconscious() < 100 && health > 0)
 						Unconscious(rand(200, 300))
-						visible_message("<span class='danger'>[M] knocked [name] out!</span>", \
+						visible_message("<span class='danger'>[M] knocked [src] out!</span>", \
 									"<span class='userdanger'>[M] knocked you out!</span>", null, 5)
 				var/obj/item/bodypart/affecting = get_bodypart(ran_zone(M.zone_selected))
 				if(!affecting)
@@ -63,7 +63,7 @@
 
 			else
 				playsound(loc, 'sound/weapons/punchmiss.ogg', 25, 1, -1)
-				visible_message("<span class='danger'>[M] attempted to punch [name]!</span>", \
+				visible_message("<span class='danger'>[M] attempted to punch [src]!</span>", \
 					"<span class='userdanger'>[M] attempted to punch you!</span>", null, COMBAT_MESSAGE_RANGE)
 		if("disarm")
 			if(!IsUnconscious())
@@ -90,10 +90,10 @@
 					damage = rand(20, 40)
 					if(AmountUnconscious() < 300)
 						Unconscious(rand(200, 300))
-					visible_message("<span class='danger'>[M] wounded [name]!</span>", \
+					visible_message("<span class='danger'>[M] wounded [src]!</span>", \
 							"<span class='userdanger'>[M] wounded you!</span>", null, COMBAT_MESSAGE_RANGE)
 				else
-					visible_message("<span class='danger'>[M] slashed [name]!</span>", \
+					visible_message("<span class='danger'>[M] slashed [src]!</span>", \
 							"<span class='userdanger'>[M] slashed you!</span>", null, COMBAT_MESSAGE_RANGE)
 
 				var/obj/item/bodypart/affecting = get_bodypart(ran_zone(M.zone_selected))
@@ -107,7 +107,7 @@
 
 			else
 				playsound(loc, 'sound/weapons/slashmiss.ogg', 25, 1, -1)
-				visible_message("<span class='danger'>[M] attempted to lunge at [name]!</span>", \
+				visible_message("<span class='danger'>[M] attempted to lunge at [src]!</span>", \
 						"<span class='userdanger'>[M] attempted to lunge at you!</span>", null, COMBAT_MESSAGE_RANGE)
 
 		if (M.a_intent == INTENT_DISARM)
@@ -115,12 +115,12 @@
 			playsound(loc, 'sound/weapons/pierce.ogg', 25, 1, -1)
 			if(prob(95))
 				Knockdown(20)
-				visible_message("<span class='danger'>[M] tackled [name] down!</span>", \
+				visible_message("<span class='danger'>[M] tackled [src] down!</span>", \
 						"<span class='userdanger'>[M] tackled you down!</span>", null, COMBAT_MESSAGE_RANGE)
 			else
 				I = get_active_held_item()
 				if(drop_item())
-					visible_message("<span class='danger'>[M] disarmed [name]!</span>", \
+					visible_message("<span class='danger'>[M] disarmed [src]!</span>", \
 							"<span class='userdanger'>[M] disarmed you!</span>", null, COMBAT_MESSAGE_RANGE)
 				else
 					I = null//did not manage to actually disarm the item, gross but no time to refactor

--- a/code/modules/mob/living/carbon/monkey/monkey_defense.dm
+++ b/code/modules/mob/living/carbon/monkey/monkey_defense.dm
@@ -43,8 +43,8 @@
 		if("harm")
 			M.do_attack_animation(src, ATTACK_EFFECT_PUNCH)
 			if (prob(75))
-				visible_message("<span class='danger'>[M] has punched [name]!</span>", \
-						"<span class='userdanger'>[M] has punched [name]!</span>", null, COMBAT_MESSAGE_RANGE)
+				visible_message("<span class='danger'>[M] punched [name]!</span>", \
+						"<span class='userdanger'>[M] punched you!</span>", null, COMBAT_MESSAGE_RANGE)
 
 				playsound(loc, "punch", 25, 1, -1)
 				var/damage = rand(5, 10)
@@ -52,8 +52,8 @@
 					damage = rand(10, 15)
 					if(AmountUnconscious() < 100 && health > 0)
 						Unconscious(rand(200, 300))
-						visible_message("<span class='danger'>[M] has knocked out [name]!</span>", \
-									"<span class='userdanger'>[M] has knocked out [name]!</span>", null, 5)
+						visible_message("<span class='danger'>[M] knocked [name] out!</span>", \
+									"<span class='userdanger'>[M] knocked you out!</span>", null, 5)
 				var/obj/item/bodypart/affecting = get_bodypart(ran_zone(M.zone_selected))
 				if(!affecting)
 					affecting = get_bodypart("chest")
@@ -63,8 +63,8 @@
 
 			else
 				playsound(loc, 'sound/weapons/punchmiss.ogg', 25, 1, -1)
-				visible_message("<span class='danger'>[M] has attempted to punch [name]!</span>", \
-					"<span class='userdanger'>[M] has attempted to punch [name]!</span>", null, COMBAT_MESSAGE_RANGE)
+				visible_message("<span class='danger'>[M] attempted to punch [name]!</span>", \
+					"<span class='userdanger'>[M] attempted to punch you!</span>", null, COMBAT_MESSAGE_RANGE)
 		if("disarm")
 			if(!IsUnconscious())
 				M.do_attack_animation(src, ATTACK_EFFECT_DISARM)
@@ -72,13 +72,13 @@
 					Knockdown(40)
 					playsound(loc, 'sound/weapons/thudswoosh.ogg', 50, 1, -1)
 					add_logs(M, src, "pushed")
-					visible_message("<span class='danger'>[M] has pushed down [src]!</span>", \
-						"<span class='userdanger'>[M] has pushed down [src]!</span>", null, COMBAT_MESSAGE_RANGE)
+					visible_message("<span class='danger'>[M] pushed [src] down!</span>", \
+						"<span class='userdanger'>[M] pushed you down!</span>", null, COMBAT_MESSAGE_RANGE)
 				else
 					if(drop_item())
 						playsound(loc, 'sound/weapons/thudswoosh.ogg', 50, 1, -1)
-						visible_message("<span class='danger'>[M] has disarmed [src]!</span>", \
-							"<span class='userdanger'>[M] has disarmed [src]!</span>", null, COMBAT_MESSAGE_RANGE)
+						visible_message("<span class='danger'>[M] disarmed [src]!</span>", \
+							"<span class='userdanger'>[M] disarmed you!</span>", null, COMBAT_MESSAGE_RANGE)
 
 /mob/living/carbon/monkey/attack_alien(mob/living/carbon/alien/humanoid/M)
 	if(..()) //if harm or disarm intent.
@@ -90,11 +90,11 @@
 					damage = rand(20, 40)
 					if(AmountUnconscious() < 300)
 						Unconscious(rand(200, 300))
-					visible_message("<span class='danger'>[M] has wounded [name]!</span>", \
-							"<span class='userdanger'>[M] has wounded [name]!</span>", null, COMBAT_MESSAGE_RANGE)
+					visible_message("<span class='danger'>[M] wounded [name]!</span>", \
+							"<span class='userdanger'>[M] wounded you!</span>", null, COMBAT_MESSAGE_RANGE)
 				else
-					visible_message("<span class='danger'>[M] has slashed [name]!</span>", \
-							"<span class='userdanger'>[M] has slashed [name]!</span>", null, COMBAT_MESSAGE_RANGE)
+					visible_message("<span class='danger'>[M] slashed [name]!</span>", \
+							"<span class='userdanger'>[M] slashed you!</span>", null, COMBAT_MESSAGE_RANGE)
 
 				var/obj/item/bodypart/affecting = get_bodypart(ran_zone(M.zone_selected))
 				add_logs(M, src, "attacked")
@@ -107,21 +107,21 @@
 
 			else
 				playsound(loc, 'sound/weapons/slashmiss.ogg', 25, 1, -1)
-				visible_message("<span class='danger'>[M] has attempted to lunge at [name]!</span>", \
-						"<span class='userdanger'>[M] has attempted to lunge at [name]!</span>", null, COMBAT_MESSAGE_RANGE)
+				visible_message("<span class='danger'>[M] attempted to lunge at [name]!</span>", \
+						"<span class='userdanger'>[M] attempted to lunge at you!</span>", null, COMBAT_MESSAGE_RANGE)
 
 		if (M.a_intent == INTENT_DISARM)
 			var/obj/item/I = null
 			playsound(loc, 'sound/weapons/pierce.ogg', 25, 1, -1)
 			if(prob(95))
 				Knockdown(20)
-				visible_message("<span class='danger'>[M] has tackled down [name]!</span>", \
-						"<span class='userdanger'>[M] has tackled down [name]!</span>", null, COMBAT_MESSAGE_RANGE)
+				visible_message("<span class='danger'>[M] tackled [name] down!</span>", \
+						"<span class='userdanger'>[M] tackled you down!</span>", null, COMBAT_MESSAGE_RANGE)
 			else
 				I = get_active_held_item()
 				if(drop_item())
-					visible_message("<span class='danger'>[M] has disarmed [name]!</span>", \
-							"<span class='userdanger'>[M] has disarmed [name]!</span>", null, COMBAT_MESSAGE_RANGE)
+					visible_message("<span class='danger'>[M] disarmed [name]!</span>", \
+							"<span class='userdanger'>[M] disarmed you!</span>", null, COMBAT_MESSAGE_RANGE)
 				else
 					I = null//did not manage to actually disarm the item, gross but no time to refactor
 

--- a/code/modules/mob/living/living_defense.dm
+++ b/code/modules/mob/living/living_defense.dm
@@ -82,8 +82,8 @@
 		if(!I.throwforce)// Otherwise, if the item's throwforce is 0...
 			playsound(loc, 'sound/weapons/throwtap.ogg', 1, volume, -1)//...play throwtap.ogg.
 		if(!blocked)
-			visible_message("<span class='danger'>[src] has been hit by [I].</span>", \
-							"<span class='userdanger'>[src] has been hit by [I].</span>")
+			visible_message("<span class='danger'>[src] is hit by [I]!</span>", \
+							"<span class='userdanger'>You're hit by [I]!</span>")
 			var/armor = run_armor_check(zone, "melee", "Your armor has protected your [parse_zone(zone)].", "Your armor has softened hit to your [parse_zone(zone)].",I.armour_penetration)
 			apply_damage(I.throwforce, dtype, zone, armor)
 			if(I.thrownby)
@@ -113,8 +113,8 @@
 			else
 				return
 		updatehealth()
-		visible_message("<span class='danger'>[M.name] has hit [src]!</span>", \
-						"<span class='userdanger'>[M.name] has hit [src]!</span>", null, COMBAT_MESSAGE_RANGE)
+		visible_message("<span class='danger'>[M.name] hit [src]!</span>", \
+						"<span class='userdanger'>[M.name] hit you!</span>", null, COMBAT_MESSAGE_RANGE)
 		add_logs(M.occupant, src, "attacked", M, "(INTENT: [uppertext(M.occupant.a_intent)]) (DAMTYPE: [uppertext(M.damtype)])")
 	else
 		step_away(src,M)
@@ -157,14 +157,14 @@
 		switch(user.grab_state)
 			if(GRAB_AGGRESSIVE)
 				add_logs(user, src, "grabbed", addition="aggressive grab")
-				visible_message("<span class='danger'>[user] has grabbed [src] aggressively!</span>", \
-								"<span class='userdanger'>[user] has grabbed [src] aggressively!</span>")
+				visible_message("<span class='danger'>[user] grabbed [src] aggressively!</span>", \
+								"<span class='userdanger'>[user] grabbed you aggressively!</span>")
 				drop_all_held_items()
 				stop_pulling()
 			if(GRAB_NECK)
 				add_logs(user, src, "grabbed", addition="neck grab")
-				visible_message("<span class='danger'>[user] has grabbed [src] by the neck!</span>",\
-								"<span class='userdanger'>[user] has grabbed you by the neck!</span>")
+				visible_message("<span class='danger'>[user] grabbed [src] by the neck!</span>",\
+								"<span class='userdanger'>[user] grabbed you by the neck!</span>")
 				update_canmove() //we fall down
 				if(!buckled && !density)
 					Move(user.loc)
@@ -191,8 +191,8 @@
 	if (stat != DEAD)
 		add_logs(M, src, "attacked")
 		M.do_attack_animation(src)
-		visible_message("<span class='danger'>The [M.name] glomps [src]!</span>", \
-				"<span class='userdanger'>The [M.name] glomps [src]!</span>", null, COMBAT_MESSAGE_RANGE)
+		visible_message("<span class='danger'>The [M.name] glomped [src]!</span>", \
+				"<span class='userdanger'>The [M.name] glomped you!</span>", null, COMBAT_MESSAGE_RANGE)
 		return 1
 
 /mob/living/attack_animal(mob/living/simple_animal/M)
@@ -205,7 +205,7 @@
 			playsound(loc, M.attack_sound, 50, 1, 1)
 		M.do_attack_animation(src)
 		visible_message("<span class='danger'>\The [M] [M.attacktext] [src]!</span>", \
-						"<span class='userdanger'>\The [M] [M.attacktext] [src]!</span>", null, COMBAT_MESSAGE_RANGE)
+						"<span class='userdanger'>\The [M] [M.attacktext] you!</span>", null, COMBAT_MESSAGE_RANGE)
 		add_logs(M, src, "attacked")
 		return 1
 
@@ -223,12 +223,12 @@
 		if (prob(75))
 			add_logs(M, src, "attacked")
 			playsound(loc, 'sound/weapons/bite.ogg', 50, 1, -1)
-			visible_message("<span class='danger'>[M.name] bites [src]!</span>", \
-					"<span class='userdanger'>[M.name] bites [src]!</span>", null, COMBAT_MESSAGE_RANGE)
+			visible_message("<span class='danger'>[M.name] bit [src]!</span>", \
+					"<span class='userdanger'>[M.name] bit you!</span>", null, COMBAT_MESSAGE_RANGE)
 			return 1
 		else
-			visible_message("<span class='danger'>[M.name] has attempted to bite [src]!</span>", \
-				"<span class='userdanger'>[M.name] has attempted to bite [src]!</span>", null, COMBAT_MESSAGE_RANGE)
+			visible_message("<span class='danger'>[M.name] attempted to bite [src]!</span>", \
+				"<span class='userdanger'>[M.name] attempted to bite you!</span>", null, COMBAT_MESSAGE_RANGE)
 	return 0
 
 /mob/living/attack_larva(mob/living/carbon/alien/larva/L)
@@ -241,19 +241,19 @@
 			L.do_attack_animation(src)
 			if(prob(90))
 				add_logs(L, src, "attacked")
-				visible_message("<span class='danger'>[L.name] bites [src]!</span>", \
-					"<span class='userdanger'>[L.name] bites [src]!</span>", null, COMBAT_MESSAGE_RANGE)
+				visible_message("<span class='danger'>[L.name] bit [src]!</span>", \
+					"<span class='userdanger'>[L.name] bit you!</span>", null, COMBAT_MESSAGE_RANGE)
 				playsound(loc, 'sound/weapons/bite.ogg', 50, 1, -1)
 				return 1
 			else
-				visible_message("<span class='danger'>[L.name] has attempted to bite [src]!</span>", \
-					"<span class='userdanger'>[L.name] has attempted to bite [src]!</span>", null, COMBAT_MESSAGE_RANGE)
+				visible_message("<span class='danger'>[L.name] attempted to bite [src]!</span>", \
+					"<span class='userdanger'>[L.name] attempted to bite you!</span>", null, COMBAT_MESSAGE_RANGE)
 	return 0
 
 /mob/living/attack_alien(mob/living/carbon/alien/humanoid/M)
 	switch(M.a_intent)
 		if ("help")
-			visible_message("<span class='notice'>[M] caresses [src] with its scythe like arm.</span>")
+			visible_message("<span class='notice'>[M] caresses [src] with its scythe-like arm.</span>")
 			return 0
 
 		if ("grab")

--- a/code/modules/mob/living/living_defense.dm
+++ b/code/modules/mob/living/living_defense.dm
@@ -191,8 +191,8 @@
 	if (stat != DEAD)
 		add_logs(M, src, "attacked")
 		M.do_attack_animation(src)
-		visible_message("<span class='danger'>The [M.name] glomped [src]!</span>", \
-				"<span class='userdanger'>The [M.name] glomped you!</span>", null, COMBAT_MESSAGE_RANGE)
+		visible_message("<span class='danger'>The [M] glomped [src]!</span>", \
+				"<span class='userdanger'>The [M] glomped you!</span>", null, COMBAT_MESSAGE_RANGE)
 		return 1
 
 /mob/living/attack_animal(mob/living/simple_animal/M)
@@ -223,12 +223,12 @@
 		if (prob(75))
 			add_logs(M, src, "attacked")
 			playsound(loc, 'sound/weapons/bite.ogg', 50, 1, -1)
-			visible_message("<span class='danger'>[M.name] bit [src]!</span>", \
-					"<span class='userdanger'>[M.name] bit you!</span>", null, COMBAT_MESSAGE_RANGE)
+			visible_message("<span class='danger'>[M] bit [src]!</span>", \
+					"<span class='userdanger'>[M] bit you!</span>", null, COMBAT_MESSAGE_RANGE)
 			return 1
 		else
-			visible_message("<span class='danger'>[M.name] attempted to bite [src]!</span>", \
-				"<span class='userdanger'>[M.name] attempted to bite you!</span>", null, COMBAT_MESSAGE_RANGE)
+			visible_message("<span class='danger'>[M] attempted to bite [src]!</span>", \
+				"<span class='userdanger'>[M] attempted to bite you!</span>", null, COMBAT_MESSAGE_RANGE)
 	return 0
 
 /mob/living/attack_larva(mob/living/carbon/alien/larva/L)
@@ -241,13 +241,13 @@
 			L.do_attack_animation(src)
 			if(prob(90))
 				add_logs(L, src, "attacked")
-				visible_message("<span class='danger'>[L.name] bit [src]!</span>", \
-					"<span class='userdanger'>[L.name] bit you!</span>", null, COMBAT_MESSAGE_RANGE)
+				visible_message("<span class='danger'>[L] bit [src]!</span>", \
+					"<span class='userdanger'>[L] bit you!</span>", null, COMBAT_MESSAGE_RANGE)
 				playsound(loc, 'sound/weapons/bite.ogg', 50, 1, -1)
 				return 1
 			else
-				visible_message("<span class='danger'>[L.name] attempted to bite [src]!</span>", \
-					"<span class='userdanger'>[L.name] attempted to bite you!</span>", null, COMBAT_MESSAGE_RANGE)
+				visible_message("<span class='danger'>[L] attempted to bite [src]!</span>", \
+					"<span class='userdanger'>[L] attempted to bite you!</span>", null, COMBAT_MESSAGE_RANGE)
 	return 0
 
 /mob/living/attack_alien(mob/living/carbon/alien/humanoid/M)

--- a/code/modules/mob/living/living_defense.dm
+++ b/code/modules/mob/living/living_defense.dm
@@ -113,8 +113,8 @@
 			else
 				return
 		updatehealth()
-		visible_message("<span class='danger'>[M.name] hit [src]!</span>", \
-						"<span class='userdanger'>[M.name] hit you!</span>", null, COMBAT_MESSAGE_RANGE)
+		visible_message("<span class='danger'>[M] hit [src]!</span>", \
+						"<span class='userdanger'>[M] hit you!</span>", null, COMBAT_MESSAGE_RANGE)
 		add_logs(M.occupant, src, "attacked", M, "(INTENT: [uppertext(M.occupant.a_intent)]) (DAMTYPE: [uppertext(M.damtype)])")
 	else
 		step_away(src,M)

--- a/code/modules/mob/living/silicon/robot/robot_defense.dm
+++ b/code/modules/mob/living/silicon/robot/robot_defense.dm
@@ -20,14 +20,14 @@
 			if(I)
 				uneq_active()
 				visible_message("<span class='danger'>[M] disarmed [src]!</span>", \
-					"<span class='userdanger'>[M] has disabled [src]'s active module!</span>", null, COMBAT_MESSAGE_RANGE)
+					"<span class='userdanger'>[M] disabled your active module!</span>", null, COMBAT_MESSAGE_RANGE)
 				add_logs(M, src, "disarmed", "[I ? " removing \the [I]" : ""]")
 			else
 				Stun(40)
 				step(src,get_dir(M,src))
 				add_logs(M, src, "pushed")
-				visible_message("<span class='danger'>[M] has forced back [src]!</span>", \
-					"<span class='userdanger'>[M] has forced back [src]!</span>", null, COMBAT_MESSAGE_RANGE)
+				visible_message("<span class='danger'>[M] forced [src] back!</span>", \
+					"<span class='userdanger'>[M] forced you back!</span>", null, COMBAT_MESSAGE_RANGE)
 			playsound(loc, 'sound/weapons/pierce.ogg', 50, 1, -1)
 	else
 		..()

--- a/code/modules/mob/living/silicon/silicon_defense.dm
+++ b/code/modules/mob/living/silicon/silicon_defense.dm
@@ -11,8 +11,8 @@
 		if (prob(90))
 			add_logs(M, src, "attacked")
 			playsound(loc, 'sound/weapons/slash.ogg', 25, 1, -1)
-			visible_message("<span class='danger'>[M] has slashed at [src]!</span>", \
-							"<span class='userdanger'>[M] has slashed at [src]!</span>")
+			visible_message("<span class='danger'>[M] slashed at [src]!</span>", \
+							"<span class='userdanger'>[M] slashed at you!</span>")
 			if(prob(8))
 				flash_act(affect_silicon = 1)
 			add_logs(M, src, "attacked")
@@ -21,7 +21,7 @@
 		else
 			playsound(loc, 'sound/weapons/slashmiss.ogg', 25, 1, -1)
 			visible_message("<span class='danger'>[M] took a swipe at [src]!</span>", \
-							"<span class='userdanger'>[M] took a swipe at [src]!</span>")
+							"<span class='userdanger'>[M] took a swipe at you!</span>")
 
 /mob/living/silicon/attack_animal(mob/living/simple_animal/M)
 	. = ..()
@@ -58,8 +58,8 @@
 		..(user, 1)
 		adjustBruteLoss(rand(10, 15))
 		playsound(loc, "punch", 25, 1, -1)
-		visible_message("<span class='danger'>[user] has punched [src]!</span>", \
-				"<span class='userdanger'>[user] has punched [src]!</span>")
+		visible_message("<span class='danger'>[user] punched [src]!</span>", \
+				"<span class='userdanger'>[user] punched you!</span>")
 		return 1
 	return 0
 

--- a/code/modules/mob/living/simple_animal/animal_defense.dm
+++ b/code/modules/mob/living/simple_animal/animal_defense.dm
@@ -15,7 +15,7 @@
 		if("harm", "disarm")
 			M.do_attack_animation(src, ATTACK_EFFECT_PUNCH)
 			visible_message("<span class='danger'>[M] [response_harm] [src]!</span>",\
-			"<span class='userdanger'>[M] [response_harm] [src]!</span>", null, COMBAT_MESSAGE_RANGE)
+			"<span class='userdanger'>[M] [response_harm] you!</span>", null, COMBAT_MESSAGE_RANGE)
 			playsound(loc, attacked_sound, 25, 1, -1)
 			attack_threshold_check(harm_intent_damage)
 			add_logs(M, src, "attacked")
@@ -26,8 +26,8 @@
 	if(user.a_intent == INTENT_HARM)
 		..(user, 1)
 		playsound(loc, "punch", 25, 1, -1)
-		visible_message("<span class='danger'>[user] has punched [src]!</span>", \
-			"<span class='userdanger'>[user] has punched [src]!</span>", null, COMBAT_MESSAGE_RANGE)
+		visible_message("<span class='danger'>[user] punched [src]!</span>", \
+			"<span class='userdanger'>[user] punched you!</span>", null, COMBAT_MESSAGE_RANGE)
 		adjustBruteLoss(15)
 		return 1
 
@@ -48,12 +48,12 @@
 		if(M.a_intent == INTENT_DISARM)
 			playsound(loc, 'sound/weapons/pierce.ogg', 25, 1, -1)
 			visible_message("<span class='danger'>[M] [response_disarm] [name]!</span>", \
-					"<span class='userdanger'>[M] [response_disarm] [name]!</span>", null, COMBAT_MESSAGE_RANGE)
+					"<span class='userdanger'>[M] [response_disarm] you!</span>", null, COMBAT_MESSAGE_RANGE)
 			add_logs(M, src, "disarmed")
 		else
 			var/damage = rand(15, 30)
-			visible_message("<span class='danger'>[M] has slashed at [src]!</span>", \
-					"<span class='userdanger'>[M] has slashed at [src]!</span>", null, COMBAT_MESSAGE_RANGE)
+			visible_message("<span class='danger'>[M] slashed at [src]!</span>", \
+					"<span class='userdanger'>[M] slashed at you!</span>", null, COMBAT_MESSAGE_RANGE)
 			playsound(loc, 'sound/weapons/slice.ogg', 25, 1, -1)
 			attack_threshold_check(damage)
 			add_logs(M, src, "attacked")

--- a/code/modules/mob/living/simple_animal/animal_defense.dm
+++ b/code/modules/mob/living/simple_animal/animal_defense.dm
@@ -47,7 +47,7 @@
 	if(..()) //if harm or disarm intent.
 		if(M.a_intent == INTENT_DISARM)
 			playsound(loc, 'sound/weapons/pierce.ogg', 25, 1, -1)
-			visible_message("<span class='danger'>[M] [response_disarm] [name]!</span>", \
+			visible_message("<span class='danger'>[M] [response_disarm] [src]!</span>", \
 					"<span class='userdanger'>[M] [response_disarm] you!</span>", null, COMBAT_MESSAGE_RANGE)
 			add_logs(M, src, "disarmed")
 		else


### PR DESCRIPTION
Utilizes the self_messages in visible_messages by adding a “you” to them.

*Before (player as John Fiddles):*
**"Jane Doodles punched John Fiddles!"**

*After (same situation):*
**"Jane Doodles punched you!"**

The goal here is that you should be able to see with just a glance that you're in danger, rather than having to look for your specific name in a sea of names in the chat during an avalanche of text. Also imho makes the game feel more polished. Thanks to Remie for all the help with this!

This is a simplified sequel to my old PR #9281. To do (in next PR):
* Utilize all other self_messages, not just combat-related.
* Change all visible_messages to a consistent time tense ("slammed" instead of "slams" etc.).
* Also perhaps change the order of the attacker/victim to always be consistent ("You're punched by Attacker!" instead of "Attacker punched you!"), or what do you guys think?


:cl:
spellcheck: Made some combat-messages appear in 2nd person e.g. "Someone punched you!".
/:cl: