### PR TITLE
Removes kudzu manufacturing

### DIFF
--- a/code/modules/hydroponics/hydroponics.dm
+++ b/code/modules/hydroponics/hydroponics.dm
@@ -406,7 +406,7 @@
 		if(myseed)
 			qdel(myseed)
 			myseed = null
-		var/newWeed = pick(/obj/item/seeds/liberty, /obj/item/seeds/angel, /obj/item/seeds/nettle/death, /obj/item/seeds/kudzu)
+		var/newWeed = pick(/obj/item/seeds/liberty, /obj/item/seeds/angel, /obj/item/seeds/nettle/death)
 		myseed = new newWeed
 		dead = 0
 		hardmutate()


### PR DESCRIPTION
:cl: Thunder12345
del: Weeds can no longer be mutated into kudzu plants
/:cl:

Traitor botanists can reliably turn the station into kudzu hell within 15 minutes of round start. I don't think I need to elaborate on why this gets boring quickly.