### PR TITLE
Alternative To Removing Kudzu Manufacturing (#30080)

### DIFF
--- a/code/modules/events/spacevine.dm
+++ b/code/modules/events/spacevine.dm
@@ -99,7 +99,6 @@
 	var/turf/T = get_turf(holder)
 	if(istype(T, /turf/open/floor/vines))
 		T.ChangeTurf(T.baseturf)
-		b
 
 /datum/spacevine_mutation/light
 	name = "light"

--- a/code/modules/events/spacevine.dm
+++ b/code/modules/events/spacevine.dm
@@ -88,9 +88,6 @@
 /datum/spacevine_mutation/space_covering/process_mutation(obj/structure/spacevine/holder)
 	var/turf/T = get_turf(holder)
 	if(is_type_in_typecache(T, coverable_turfs))
-		for(var/obj/machinery/door/airlock in T.contents)
-			if(airlock.density)
-				return
 		var/currtype = T.type
 		T.ChangeTurf(/turf/open/floor/vines)
 		T.baseturf = currtype

--- a/code/modules/events/spacevine.dm
+++ b/code/modules/events/spacevine.dm
@@ -99,11 +99,7 @@
 	var/turf/T = get_turf(holder)
 	if(istype(T, /turf/open/floor/vines))
 		T.ChangeTurf(T.baseturf)
-
-/datum/spacevine_mutation/bluespace
-	name = "bluespace"
-	hue = "#3333ff"
-	quality = MINOR_NEGATIVE
+		b
 
 /datum/spacevine_mutation/light
 	name = "light"

--- a/code/modules/events/spacevine.dm
+++ b/code/modules/events/spacevine.dm
@@ -69,34 +69,6 @@
 	return
 
 
-/datum/spacevine_mutation/space_covering
-	name = "space protective"
-	hue = "#aa77aa"
-	quality = POSITIVE
-
-/datum/spacevine_mutation/space_covering
-	var/static/list/coverable_turfs
-
-/datum/spacevine_mutation/space_covering/New()
-	. = ..()
-	if(!coverable_turfs)
-		coverable_turfs = typecacheof(list(/turf/open/space)) - /turf/open/space/transit
-
-/datum/spacevine_mutation/space_covering/on_grow(obj/structure/spacevine/holder)
-	process_mutation(holder)
-
-/datum/spacevine_mutation/space_covering/process_mutation(obj/structure/spacevine/holder)
-	var/turf/T = get_turf(holder)
-	if(is_type_in_typecache(T, coverable_turfs))
-		var/currtype = T.type
-		T.ChangeTurf(/turf/open/floor/vines)
-		T.baseturf = currtype
-
-/datum/spacevine_mutation/space_covering/on_death(obj/structure/spacevine/holder)
-	var/turf/T = get_turf(holder)
-	if(istype(T, /turf/open/floor/vines))
-		T.ChangeTurf(T.baseturf)
-
 /datum/spacevine_mutation/light
 	name = "light"
 	hue = "#ffff00"

--- a/code/modules/events/spacevine.dm
+++ b/code/modules/events/spacevine.dm
@@ -88,6 +88,9 @@
 /datum/spacevine_mutation/space_covering/process_mutation(obj/structure/spacevine/holder)
 	var/turf/T = get_turf(holder)
 	if(is_type_in_typecache(T, coverable_turfs))
+		for(var/obj/machinery/door/airlock in T.contents)
+			if(airlock.density)
+				return
 		var/currtype = T.type
 		T.ChangeTurf(/turf/open/floor/vines)
 		T.baseturf = currtype
@@ -101,10 +104,6 @@
 	name = "bluespace"
 	hue = "#3333ff"
 	quality = MINOR_NEGATIVE
-
-/datum/spacevine_mutation/bluespace/on_spread(obj/structure/spacevine/holder, turf/target)
-	if(holder.energy > 1 && !locate(/obj/structure/spacevine) in target)
-		holder.master.spawn_spacevine_piece(target, holder)
 
 /datum/spacevine_mutation/light
 	name = "light"

--- a/code/modules/hydroponics/grown/kudzu.dm
+++ b/code/modules/hydroponics/grown/kudzu.dm
@@ -43,7 +43,7 @@
 
 /obj/item/seeds/kudzu/attack_self(mob/user)
 	user.visible_message("<span class='danger'>[user] begins throwing seeds on the ground...</span>")
-	if(do_after(user, 50, needhand = 1, target = user, progress = 1))
+	if(do_after(user, 50, needhand = TRUE, target = user.drop_location(), progress = TRUE))
 		plant(user)
 		to_chat(user, "<span class='notice'>You plant the kudzu. You monster.</span>")
 

--- a/code/modules/hydroponics/grown/kudzu.dm
+++ b/code/modules/hydroponics/grown/kudzu.dm
@@ -42,8 +42,10 @@
 	qdel(src)
 
 /obj/item/seeds/kudzu/attack_self(mob/user)
-	plant(user)
-	to_chat(user, "<span class='notice'>You plant the kudzu. You monster.</span>")
+	user.visible_message("<span class='danger'>[user] begins throwing seeds on the ground...</span>")
+	if(do_after(user, 50, needhand = 1, target = user, progress = 1))
+		plant(user)
+		to_chat(user, "<span class='notice'>You plant the kudzu. You monster.</span>")
 
 /obj/item/seeds/kudzu/get_analyzer_text()
 	var/text = ..()


### PR DESCRIPTION
:cl: Cobby
balance: Planting kudzu now has a short delay with a visible message to users around you. Hit-N-Run planting is no longer possible.
del: kudzu bluespace mutation and spacewalk mutation are removed.
/:cl:

closes #30080

This nerf strikes at 2 major problems, Hit-N-Run planting and kudzu going through walls/space, while still making it a station destroyer if done properly and with more effort than left clicking seeds while inhand.

If this is still unmanageable I'll lower the spread by 25% but I think this will be fine tbh.

Oh I did test this but my ~~github~~ local branch is out of date due to not using this computer in forever and so I had to transfer it from desktop to online via web editor. pls no bully gunhog