### PR TITLE
ssgarbage now runs every 2 seconds.

### DIFF
--- a/code/controllers/subsystem/garbage.dm
+++ b/code/controllers/subsystem/garbage.dm
@@ -1,7 +1,7 @@
 SUBSYSTEM_DEF(garbage)
 	name = "Garbage"
 	priority = 15
-	wait = 5
+	wait = 20
 	flags = SS_POST_FIRE_TIMING|SS_BACKGROUND|SS_NO_INIT
 	runlevels = RUNLEVELS_DEFAULT | RUNLEVEL_LOBBY
 


### PR DESCRIPTION
This was moved down to 5ds back when subsystems had to complete their entire workload each fire in the old mc system.

The idea was that less would have gotten in the queue to be hard deleted in 5ds compared to 20ds, and a tiny amount of lag more often would be more preferred to alot of lag less often.

That is no longer the case now.

:cl:
tweak: Garbage collection happens less often now to reduce the lag caused by hard deletions.
/:cl:
