### PR TITLE
Transit tube pods no longer constantly suck in air

### DIFF
--- a/code/game/objects/structures/transit_tubes/station.dm
+++ b/code/game/objects/structures/transit_tubes/station.dm
@@ -147,6 +147,7 @@
 		sleep(OPEN_DURATION + 2)
 		pod_moving = 0
 		if(!QDELETED(pod))
+			pod.air_contents.archive()
 			pod.air_contents.share(loc.return_air(), 1) //mix the pod's gas mixture with the tile it's on
 
 /obj/structure/transit_tube/station/init_tube_dirs()

--- a/code/game/objects/structures/transit_tubes/station.dm
+++ b/code/game/objects/structures/transit_tubes/station.dm
@@ -147,7 +147,7 @@
 		sleep(OPEN_DURATION + 2)
 		pod_moving = 0
 		if(!QDELETED(pod))
-			pod.air_contents.share(loc.return_air()) //mix the pod's gas mixture with the tile it's on
+			pod.air_contents.share(loc.return_air(), 1) //mix the pod's gas mixture with the tile it's on
 
 /obj/structure/transit_tube/station/init_tube_dirs()
 	switch(dir)

--- a/code/game/objects/structures/transit_tubes/transit_tube_pod.dm
+++ b/code/game/objects/structures/transit_tubes/transit_tube_pod.dm
@@ -12,7 +12,7 @@
 /obj/structure/transit_tube_pod/New(loc)
 	..()
 	air_contents.assert_gases("o2", "n2")
-	air_contents.gases["o2"][MOLES] = MOLES_O2STANDARD * 2
+	air_contents.gases["o2"][MOLES] = MOLES_O2STANDARD
 	air_contents.gases["n2"][MOLES] = MOLES_N2STANDARD
 	air_contents.temperature = T20C
 

--- a/code/modules/atmospherics/gasmixtures/gas_mixture.dm
+++ b/code/modules/atmospherics/gasmixtures/gas_mixture.dm
@@ -293,6 +293,9 @@ GLOBAL_LIST_INIT(gaslist_cache, init_gaslist_cache())
 	if(!sharer)
 		return 0
 
+	archive()
+	sharer.archive()
+
 	var/list/cached_gases = gases
 	var/list/sharer_gases = sharer.gases
 

--- a/code/modules/atmospherics/gasmixtures/gas_mixture.dm
+++ b/code/modules/atmospherics/gasmixtures/gas_mixture.dm
@@ -293,9 +293,6 @@ GLOBAL_LIST_INIT(gaslist_cache, init_gaslist_cache())
 	if(!sharer)
 		return 0
 
-	archive()
-	sharer.archive()
-
 	var/list/cached_gases = gases
 	var/list/sharer_gases = sharer.gases
 


### PR DESCRIPTION
Fixes #23556
gas_mixture.share() will now archive the gas_mixtures so it works on gas_mixtures that are not otherwise archived, such as the ones used for transit pods.
Also, transit pods now start with normal gas levels and share gas at the proper speed.