### PR TITLE
Minor touchups to chemistry/bar/virology machinery

### DIFF
--- a/code/modules/reagents/chemistry/machinery/chem_dispenser.dm
+++ b/code/modules/reagents/chemistry/machinery/chem_dispenser.dm
@@ -75,9 +75,9 @@
 
 /obj/machinery/chem_dispenser/emag_act(mob/user)
 	if(emagged)
-		to_chat(user, "<span class='warning'>\The [src] has no functional safeties to emag.</span>")
+		to_chat(user, "<span class='warning'>[src] has no functional safeties to emag.</span>")
 		return
-	to_chat(user, "<span class='notice'>You short out \the [src]'s safeties.</span>")
+	to_chat(user, "<span class='notice'>You short out [src]'s safeties.</span>")
 	dispensable_reagents |= emagged_reagents//add the emagged reagents to the dispensable ones
 	emagged = TRUE
 
@@ -182,21 +182,20 @@
 		var/obj/item/reagent_containers/B = I
 		. = 1 //no afterattack
 		if(beaker)
-			to_chat(user, "<span class='warning'>A container is already loaded into the machine!</span>")
+			to_chat(user, "<span class='warning'>A container is already loaded into [src]!</span>")
 			return
 
-		if(!user.drop_item()) // Can't let go?
+		if(!user.transferItemToLoc(B, src))
 			return
 
 		beaker = B
-		beaker.loc = src
-		to_chat(user, "<span class='notice'>You add \the [B] to the machine.</span>")
+		to_chat(user, "<span class='notice'>You add [B] to [src].</span>")
 
 		beaker_overlay = beaker_overlay ||  mutable_appearance(icon, "disp_beaker")
 		beaker_overlay.pixel_x = rand(-10, 5)//randomize beaker overlay position.
 		add_overlay(beaker_overlay)
 	else if(user.a_intent != INTENT_HARM && !istype(I, /obj/item/card/emag))
-		to_chat(user, "<span class='warning'>You can't load \the [I] into the machine!</span>")
+		to_chat(user, "<span class='warning'>You can't load [I] into [src]!</span>")
 		return ..()
 	else
 		return ..()
@@ -230,7 +229,7 @@
 	recharge_delay = 30
 	dispensable_reagents = list()
 	circuit = /obj/item/circuitboard/machine/chem_dispenser
-	var/list/dispensable_reagent_tiers = list(
+	var/static/list/dispensable_reagent_tiers = list(
 		list(
 			"hydrogen",
 			"oxygen",

--- a/code/modules/reagents/chemistry/machinery/chem_heater.dm
+++ b/code/modules/reagents/chemistry/machinery/chem_heater.dm
@@ -45,14 +45,13 @@
 	if(istype(I, /obj/item/reagent_containers) && (I.container_type & OPENCONTAINER_1))
 		. = 1 //no afterattack
 		if(beaker)
-			to_chat(user, "<span class='warning'>A beaker is already loaded into the machine!</span>")
+			to_chat(user, "<span class='warning'>A container is already loaded into [src]!</span>")
 			return
 
-		if(!user.drop_item())
+		if(!user.transferItemToLoc(I, src))
 			return
 		beaker = I
-		I.loc = src
-		to_chat(user, "<span class='notice'>You add the beaker to the machine.</span>")
+		to_chat(user, "<span class='notice'>You add [I] to [src].</span>")
 		icon_state = "mixer1b"
 		return
 	return ..()

--- a/code/modules/reagents/chemistry/machinery/chem_master.dm
+++ b/code/modules/reagents/chemistry/machinery/chem_master.dm
@@ -85,27 +85,25 @@
 			to_chat(user, "<span class='warning'>You can't use the [src.name] while its panel is opened!</span>")
 			return
 		if(beaker)
-			to_chat(user, "<span class='warning'>A container is already loaded in the machine!</span>")
+			to_chat(user, "<span class='warning'>A container is already loaded into [src]!</span>")
 			return
-		if(!user.drop_item())
+		if(!user.transferItemToLoc(I, src))
 			return
 
 		beaker = I
-		beaker.loc = src
-		to_chat(user, "<span class='notice'>You add the beaker to the machine.</span>")
+		to_chat(user, "<span class='notice'>You add [I] to [src].</span>")
 		src.updateUsrDialog()
 		icon_state = "mixer1"
 
 	else if(!condi && istype(I, /obj/item/storage/pill_bottle))
 		if(bottle)
-			to_chat(user, "<span class='warning'>A pill bottle is already loaded into the machine!</span>")
+			to_chat(user, "<span class='warning'>A pill bottle is already loaded into [src]!</span>")
 			return
-		if(!user.drop_item())
+		if(!user.transferItemToLoc(I, src))
 			return
 
 		bottle = I
-		bottle.loc = src
-		to_chat(user, "<span class='notice'>You add the pill bottle into the dispenser slot.</span>")
+		to_chat(user, "<span class='notice'>You add [I] into the dispenser slot.</span>")
 		src.updateUsrDialog()
 	else
 		return ..()

--- a/code/modules/reagents/chemistry/machinery/pandemic.dm
+++ b/code/modules/reagents/chemistry/machinery/pandemic.dm
@@ -221,14 +221,13 @@
 		if(stat & (NOPOWER|BROKEN))
 			return
 		if(beaker)
-			to_chat(user, "<span class='warning'>A beaker is already loaded into the machine!</span>")
+			to_chat(user, "<span class='warning'>A container is already loaded into [src]!</span>")
 			return
-		if(!user.drop_item())
+		if(!user.transferItemToLoc(I, src))
 			return
 
 		beaker = I
-		beaker.forceMove(src)
-		to_chat(user, "<span class='notice'>You add the beaker to the machine.</span>")
+		to_chat(user, "<span class='notice'>You insert [I] into [src].</span>")
 		update_icon()
 	else
 		return ..()

--- a/code/modules/reagents/chemistry/machinery/reagentgrinder.dm
+++ b/code/modules/reagents/chemistry/machinery/reagentgrinder.dm
@@ -118,21 +118,20 @@
 
 		if (istype(I, /obj/item/reagent_containers) && (I.container_type & OPENCONTAINER_1) )
 				if (!beaker)
-						if(!user.drop_item())
+						if(!user.transferItemToLoc(I, src))
 								return 1
 						beaker =  I
-						beaker.loc = src
 						update_icon()
 						src.updateUsrDialog()
 				else
-						to_chat(user, "<span class='warning'>There's already a container inside.</span>")
+						to_chat(user, "<span class='warning'>There's already a container inside [src].</span>")
 				return 1 //no afterattack
 
 		if(is_type_in_list(I, dried_items))
 				if(istype(I, /obj/item/reagent_containers/food/snacks/grown))
 						var/obj/item/reagent_containers/food/snacks/grown/G = I
 						if(!G.dry)
-								to_chat(user, "<span class='warning'>You must dry that first!</span>")
+								to_chat(user, "<span class='warning'>You must dry [G] first!</span>")
 								return 1
 
 		if(holdingitems && holdingitems.len >= limit)
@@ -146,11 +145,11 @@
 						B.remove_from_storage(G, src)
 						holdingitems += G
 						if(holdingitems && holdingitems.len >= limit) //Sanity checking so the blender doesn't overfill
-								to_chat(user, "<span class='notice'>You fill the All-In-One grinder to the brim.</span>")
+								to_chat(user, "<span class='notice'>You fill [src] to the brim.</span>")
 								break
 
 				if(!I.contents.len)
-						to_chat(user, "<span class='notice'>You empty the plant bag into the All-In-One grinder.</span>")
+						to_chat(user, "<span class='notice'>You empty [I] into [src].</span>")
 
 				src.updateUsrDialog()
 				return 1
@@ -162,8 +161,7 @@
 						to_chat(user, "<span class='warning'>Cannot refine into a reagent!</span>")
 						return 1
 
-		if(user.drop_item())
-				I.loc = src
+		if(user.transferItemToLoc(I, src))
 				holdingitems += I
 				src.updateUsrDialog()
 				return 0


### PR DESCRIPTION
* replace drop_item() patterns with transferItemToLoc()
* grammar consistency fixes
* replace "that", "the machine", "the beaker" etc. with the name of the actual object in question in chat messages
* replace the portable chem dispenser reagent tier list with a static one, it's immutable between instances and only used to fill dispensable_reagents, saving literally bytes of memory.

[Changelogs]: # (Please make a changelog if you're adding, removing or changing content that'll affect players. This includes, but is not limited to, new features, sprites, sounds; balance changes; map edits and important fixes)
[]: # (See here for how to easily make a changelog: https://github.com/tgstation/tgstation/wiki/Changelogs. An example changelog has been provided below. Please edit or remove)


:cl: Naksu
spellcheck: fixed inconsistent grammar between machines that derive from /obj/machinery/chem_dispenser
spellcheck: touched up some chat messages to include references to objects instead of "that" or "the machine" etc., also removed references to beakers being loaded in machines that can accept any container
/:cl:

[why]: # (Please add a short description [on the next line] of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding:) 
This commit brings code/modules/reagents/chemistry/machinery in-line with what's expected of new code. This is fairly minor stuff but came as a freebie with my work on a minor feature that touches this code.