### PR TITLE
Chem dispenser upgrade boards

### DIFF
--- a/code/modules/reagents/chemistry/machinery/chem_dispenser.dm
+++ b/code/modules/reagents/chemistry/machinery/chem_dispenser.dm
@@ -212,7 +212,7 @@
 				return
 			if(!user.transferItemToLoc(A, src))
 				return
-			to_chat(user, "<span class='notice'>You insert [A], disabling the [src]'s safeties.</span>")
+			to_chat(user, "<span class='notice'>You insert [A], disabling [src]'s safeties.</span>")
 			dispensable_reagents |= emagged_reagents //add the emagged reagents to the dispensable ones
 			emagged = TRUE
 			return

--- a/code/modules/reagents/chemistry/machinery/chem_dispenser.dm
+++ b/code/modules/reagents/chemistry/machinery/chem_dispenser.dm
@@ -53,7 +53,7 @@
 		"mine_salve",
 		"toxin"
 	)
-	var/list/addin_reagents = list(
+	var/static/list/addin_reagents = list(
 		"oil",
 		"ash",
 		"acetone",
@@ -208,24 +208,22 @@
 		var/obj/item/device/chem_dispenser_auth_board/A = I
 		if (A.isAuthorized())
 			if(emagged)
-				to_chat(user, "<span class='warning'>\The machine has no functional safeties to disable.</span>")
+				to_chat(user, "<span class='warning'>[src] has no functional safeties to disable.</span>")
 				return
-			if(!user.drop_item())
+			if(!user.transferItemToLoc(A, src))
 				return
-			A.loc = src
-			to_chat(user, "<span class='notice'>You insert the dangerous reagents authorization board, disabling the [src]'s safeties.</span>")
+			to_chat(user, "<span class='notice'>You insert [A], disabling the [src]'s safeties.</span>")
 			dispensable_reagents |= emagged_reagents //add the emagged reagents to the dispensable ones
 			emagged = TRUE
 			return
 		else
-			to_chat(user, "<span class='warning'>\The board has to be authorized for use by the Head of Security.</span>")
+			to_chat(user, "<span class='warning'>[A] has to be authorized for use by the Head of Security or the Captain.</span>")
 			return ..()
 	else if (istype(I, /obj/item/device/chem_dispenser_addin_board))
 		if (!upgraded)
-			if(!user.drop_item())
+			if(!user.transferItemToLoc(I, src))
 				return
-			I.loc = src
-			to_chat(user, "<span class='notice'>You insert the supplementary recipes add-in board to the [src].</span>")
+			to_chat(user, "<span class='notice'>You insert [I] to [src].</span>")
 			dispensable_reagents |= addin_reagents
 			upgraded = TRUE
 			return

--- a/code/modules/reagents/chemistry/machinery/chem_dispenser.dm
+++ b/code/modules/reagents/chemistry/machinery/chem_dispenser.dm
@@ -228,7 +228,8 @@
 			upgraded = TRUE
 			return
 		else
-			return ..()
+			to_chat(user, "<span class='notice'>[src] has already been upgraded with [I].</span>")
+			return
 	else if(user.a_intent != INTENT_HARM && !istype(I, /obj/item/card/emag))
 		to_chat(user, "<span class='warning'>You can't load \the [I] into the machine!</span>")
 		return ..()

--- a/code/modules/reagents/chemistry/machinery/chem_dispenser_upgrades.dm
+++ b/code/modules/reagents/chemistry/machinery/chem_dispenser_upgrades.dm
@@ -14,7 +14,7 @@
 
 /obj/item/device/chem_dispenser_auth_board/attackby(obj/item/I, mob/user, params)
 	if (istype(I, /obj/item/card/id) && check_access(I))
-		to_chat(user, "You authorize the use of this board.")
+		to_chat(user, "You authorize the use of [src].")
 		authorized = TRUE
 		return
 

--- a/code/modules/reagents/chemistry/machinery/chem_dispenser_upgrades.dm
+++ b/code/modules/reagents/chemistry/machinery/chem_dispenser_upgrades.dm
@@ -13,6 +13,9 @@
 	var/authorized = FALSE
 
 /obj/item/device/chem_dispenser_auth_board/attackby(obj/item/I, mob/user, params)
+	if (authorized)
+		to_chat(user, "[src] is already authorized.")
+		return
 	if (istype(I, /obj/item/card/id) && check_access(I))
 		to_chat(user, "You authorize the use of [src].")
 		authorized = TRUE

--- a/code/modules/reagents/chemistry/machinery/chem_dispenser_upgrades.dm
+++ b/code/modules/reagents/chemistry/machinery/chem_dispenser_upgrades.dm
@@ -1,0 +1,30 @@
+/obj/item/device/chem_dispenser_addin_board
+	name = "chem dispenser add-in board"
+	desc = "An add-in board containing supplementary recipes for the chem dispenser."
+	icon_state = "door_electronics"
+	icon = 'icons/obj/module.dmi'
+
+/obj/item/device/chem_dispenser_auth_board
+	name = "chem dispenser dangerous recipes authorization board"
+	desc = "An authorization board that disengages the safeties on a chem dispenser, allowing it to dispense toxic materials."
+	icon_state = "door_electronics"
+	icon = 'icons/obj/module.dmi'
+	req_access = list(ACCESS_HOS, ACCESS_CAPTAIN)
+	var/authorized = FALSE
+
+/obj/item/device/chem_dispenser_auth_board/attackby(obj/item/I, mob/user, params)
+	if (istype(I, /obj/item/card/id) && check_access(I))
+		to_chat(user, "You authorize the use of this board.")
+		authorized = TRUE
+		return
+
+	return ..()
+
+
+/obj/item/device/chem_dispenser_auth_board/examine(user)
+	..()
+	if (authorized)
+		to_chat(user, "The use of this board has been authorized by station management.")
+
+/obj/item/device/chem_dispenser_auth_board/proc/isAuthorized()
+	return authorized

--- a/code/modules/research/designs/comp_board_designs.dm
+++ b/code/modules/research/designs/comp_board_designs.dm
@@ -275,3 +275,25 @@
 	req_tech = list("programming" = 4, "engineering" = 4, "powerstorage" = 5)
 	build_path = /obj/item/circuitboard/computer/apc_control
 	category = list("Computer Boards")
+
+/datum/design/chem_dispenser_addin_board
+	name = "Dispenser Design (Supplemental Chem Recipes)"
+	desc = "Allows for the construction of circuit boards used to provide supplemental recipes to non-portable chem dispensers."
+	id = "chem_dispenser_addin_board"
+	req_tech = list("materials" = 4, "programming" = 4, "engineering" = 4)
+	build_path = /obj/item/device/chem_dispenser_addin_board
+	build_type = IMPRINTER
+	materials = list(MAT_GLASS = 1000, MAT_GOLD = 500, MAT_DIAMOND = 500)
+	reagents_list = list("sacid" = 20)
+	category = list("Computer Boards")
+
+/datum/design/chem_dispenser_auth_board
+	name = "Dispenser Design (Toxic Chem Authorization)"
+	desc = "Allows for the construction of circuit boards used to unlock the safety features of a chem dispenser."
+	id = "chem_dispenser_auth_board"
+	req_tech = list("syndicate" = 1, "materials" = 4, "programming" = 4, "engineering" = 4)
+	build_path = /obj/item/device/chem_dispenser_auth_board
+	build_type = IMPRINTER
+	materials = list(MAT_GLASS = 1000, MAT_GOLD = 500)
+	reagents_list = list("sacid" = 20)
+	category = list("Computer Boards")

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -1959,6 +1959,7 @@
 #include "code\modules\reagents\chemistry\reagents.dm"
 #include "code\modules\reagents\chemistry\recipes.dm"
 #include "code\modules\reagents\chemistry\machinery\chem_dispenser.dm"
+#include "code\modules\reagents\chemistry\machinery\chem_dispenser_upgrades.dm"
 #include "code\modules\reagents\chemistry\machinery\chem_heater.dm"
 #include "code\modules\reagents\chemistry\machinery\chem_master.dm"
 #include "code\modules\reagents\chemistry\machinery\pandemic.dm"


### PR DESCRIPTION
Adds two new items, "chem dispenser add-in board" and "chem dispenser dangerous recipes authorization board."

The first one requires materials, data and engineering 4 to fab from the circuit imprinter, costing 1000 glass, 500 diamond and 500 gold. It effectively replicates the femto-manipulator upgrade of a constructable chem dispenser, allowing chemistry to receive a quality-of-life upgrade to their machinery that doesn't involve spacing the machines they start with and replacing them with portable ones.

The second one requires illegal tech 1 along with materials, data and engineering 4. It's effectively a single-use, chem-dispenser-only emag that requires hos or cap to bless its use. I've on purpose exluded the RD from this list. 

There are balance considerations for either, and the numbers may have to be tweaked even if the feature is approved.

[Changelogs]: 
[]: 


:cl: Naksu
add: Adds two new consumable upgrade boards for the (non-portable) chem dispenser. The first one adds the recipes a portable dispenser gains from the femto-manipulator upgrade, the other one requires authorization by the HoS or Captain and essentially emags the dispenser. These boards can be made from the circuit imprinter.
/:cl:

[why]: 
Auth board: emagged reagents have civilian uses, particularly toxin, and are not otherwise obtainable in
useful quantities.
Supplementary recipes board: the chem dispensers chemistry spawns with are non-upgradeable "due to reasons", yet allowing them to dispense "tier 4" reagents is a relatively big quality-of-life upgrade for the chemist. 