### PR TITLE
Protects proc/priority_announce from people with null clients/prefs in the playerlist.

### DIFF
--- a/code/__HELPERS/priority_announce.dm
+++ b/code/__HELPERS/priority_announce.dm
@@ -28,7 +28,7 @@
 	for(var/mob/M in GLOB.player_list)
 		if(!isnewplayer(M) && M.can_hear())
 			to_chat(M, announcement)
-			if(M.client.prefs.toggles & SOUND_ANNOUNCEMENTS)
+			if(M.client && M.client.prefs && M.client.prefs.toggles & SOUND_ANNOUNCEMENTS)
 				SEND_SOUND(M, s)
 
 /proc/print_command_report(text = "", title = null, announce=TRUE)


### PR DESCRIPTION
tfw warops gets declared and only 2 people heard it before it runtimed and 20 minutes in everyone goes WTF HE WAS RIGHT

Really though.