### PR TITLE
Fixes component cleanup

### DIFF
--- a/code/datums/datum.dm
+++ b/code/datums/datum.dm
@@ -22,10 +22,16 @@
 			continue
 		qdel(timer)
 	var/list/dc = datum_components
-	for(var/I in dc)
-		var/datum/component/C = I
-		C._RemoveNoSignal()
-		qdel(C)
 	if(dc)
+		var/all_components = dc[/datum/component]
+		if(islist(all_components))
+			for(var/I in all_components)
+				var/datum/component/C = I
+				C._RemoveNoSignal()
+				qdel(C)
+		else
+			var/datum/component/C = all_components
+			C._RemoveNoSignal()
+			qdel(C)
 		dc.Cut()
 	return QDEL_HINT_QUEUE


### PR DESCRIPTION
Forgot to do this in #29523.

In case you guys didn't read that PR, datum_components is a list keyed by type. The values are either a) A component, if there's only one. B) A list of components

The value of the /datum/component key will always contain all components.

Fixes #30147
Closes #30149