### PR TITLE
Maintains that weird entire-tcomms-setup-in-one-machine thing

### DIFF
--- a/code/game/machinery/telecomms/machines/allinone.dm
+++ b/code/game/machinery/telecomms/machines/allinone.dm
@@ -12,7 +12,7 @@
 	use_power = NO_POWER_USE
 	idle_power_usage = 0
 	machinetype = 6
-	var/intercept = 0 // if nonzero, broadcasts all messages to syndicate channel
+	var/intercept = FALSE // if TRUE, broadcasts all (non-syndie) messages to syndicate channel
 
 /obj/machinery/telecomms/allinone/receive_signal(datum/signal/signal)
 
@@ -33,12 +33,21 @@
 			sleep(signal.data["slow"]) // simulate the network lag if necessary
 
 		/* ###### Broadcast a message using signal.data ###### */
-		if(signal.frequency == GLOB.SYND_FREQ) // if syndicate broadcast, just
+		Broadcast_Message(signal.data["mob"],
+						  signal.data["vmask"],
+						  signal.data["radio"], signal.data["message"],
+						  signal.data["name"], signal.data["job"],
+						  signal.data["realname"],, signal.data["compression"], list(0, z), signal.frequency, signal.data["spans"],
+						  signal.data["verb_say"], signal.data["verb_ask"], signal.data["verb_exclaim"], signal.data["verb_yell"],
+						  signal.data["language"])
+		
+		/* ###### Copy all non-syndie communications to the Syndicate Frequency ###### */
+		if(intercept && signal.frequency != GLOB.SYND_FREQ)
 			Broadcast_Message(signal.data["mob"],
 							  signal.data["vmask"],
 							  signal.data["radio"], signal.data["message"],
 							  signal.data["name"], signal.data["job"],
-							  signal.data["realname"],, signal.data["compression"], list(0, z), signal.frequency, signal.data["spans"],
+							  signal.data["realname"],, signal.data["compression"], list(0, z), GLOB.SYND_FREQ, signal.data["spans"],
 							  signal.data["verb_say"], signal.data["verb_ask"], signal.data["verb_exclaim"], signal.data["verb_yell"],
 							  signal.data["language"])
 

--- a/code/game/objects/items/devices/radio/radio.dm
+++ b/code/game/objects/items/devices/radio/radio.dm
@@ -426,7 +426,10 @@
 	signal.frequency = freqnum // Quick frequency set
 	for(var/obj/machinery/telecomms/receiver/R in GLOB.telecomms_list)
 		R.receive_signal(signal)
-
+		
+	// Allinone can act as receivers. (Unless of course whoever coded this last time forgot to put it in somewhere!)
+	for(var/obj/machinery/telecomms/allinone/R in GLOB.telecomms_list)
+		R.receive_signal(signal)
 
 	spawn(20) // wait a little...
 


### PR DESCRIPTION
That's only used on away missions...

It had a var for intercepting signals and duplicating them to the syndicate channel, but it never used it, and only sent things if they were already syndicate communication... wat.
