### PR TITLE
[S]Removes ability to meta roundtype from centcom report.

### DIFF
--- a/code/game/gamemodes/game_mode.dm
+++ b/code/game/gamemodes/game_mode.dm
@@ -280,12 +280,35 @@
 	var/intercepttext = "<b><i>Central Command Status Summary</i></b><hr>"
 	intercepttext += "<b>Central Command has intercepted and partially decoded a Syndicate transmission with vital information regarding their movements. The following report outlines the most \
 	likely threats to appear in your sector.</b>"
-	var/list/possible_modes = list()
-	possible_modes.Add("blob", "changeling", "clock_cult", "cult", "extended", "gang", "malf", "nuclear", "revolution", "traitor", "wizard")
-	possible_modes -= name //remove the current gamemode to prevent it from being randomly deleted, it will be readded later
+	var/list/mode_weights = list(
+	"wizard" = 10,
+	"traitor" = 20,
+	"Internal Affairs" = 10,
+	"revolution" = 10,
+	"nuclear emergency" = 10,
+	"monkey" = 1,
+	"abduction" = 1,
+	"meteor" = 1,
+	"gang war" = 5,
+	"secret extended" = 5,
+	"devil" = 1,
+	"Devil Agents" = 1,
+	"cult" = 10,
+	"clockwork cult" = 10,
+	"changeling" = 10
+	)
+	
+	
+	//"extended" and "blob" both have their own custom send_intercept, so it makes no sense to put them as a possibility here, else their existance could be meta'ed to simply reduce the size of the list.
+	
+	
+	mode_weights[name] = 0//remove the current gamemode to prevent it from being randomly deleted, it will be readded later
 
-	for(var/i in 1 to 6) //Remove a few modes to leave four
-		possible_modes -= pick(possible_modes)
+	var/list/possible_modes = list()
+	for(var/i in 1 to rand(3,5)) //Only pick a few modes,
+		var/selected_mode = pickweight(mode_weights)
+		mode_weights[selected_mode] = 0
+		possible_modes += selected_mode
 
 	possible_modes |= name //Re-add the actual gamemode - the intercept will thus always have the correct mode in its list
 	possible_modes = shuffle(possible_modes) //Meta prevention

--- a/code/game/gamemodes/game_mode.dm
+++ b/code/game/gamemodes/game_mode.dm
@@ -297,10 +297,11 @@
 	"clockwork cult" = 10,
 	"changeling" = 10,
 	"traitor+changeling" = 10
+	"blob" = 5
 	)
 	
 	
-	//"extended" and "blob" both have their own custom send_intercept, so it makes no sense to put them as a possibility here, else their existance could be meta'ed to simply reduce the size of the list.
+	//"extended" has it's own custom send_intercept, so it makes no sense to put them as a possibility here, else their existance could be meta'ed to simply reduce the size of the list.
 	
 	
 	mode_weights[name] = 0//remove the current gamemode to prevent it from being randomly deleted, it will be readded later

--- a/code/game/gamemodes/game_mode.dm
+++ b/code/game/gamemodes/game_mode.dm
@@ -295,7 +295,8 @@
 	"Devil Agents" = 1,
 	"cult" = 10,
 	"clockwork cult" = 10,
-	"changeling" = 10
+	"changeling" = 10,
+	"traitor+changeling" = 10
 	)
 	
 	

--- a/code/game/gamemodes/intercept_report.dm
+++ b/code/game/gamemodes/intercept_report.dm
@@ -6,6 +6,11 @@
 /datum/intercept_text/proc/build(mode_type)
 	text = "<hr>"
 	switch(mode_type)
+		if("blob")
+			text += "A CMP scientist by the name of [pick("Griff", "Pasteur", "Chamberland", "Buist", "Rivers", "Stanley")] boasted about his corporation's \"finest creation\" - a macrobiological \
+			virus capable of self-reproduction and hellbent on consuming whatever it touches. He went on to query Cybersun for permission to utilize the virus in biochemical warfare, to which \
+			CMP subsequently gained. Be vigilant for any large organisms rapidly spreading across the station, as they are classified as a level 5 biohazard and critically dangerous. Note that \
+			this organism seems to be weak to extreme heat; concentrated fire (such as welding tools and lasers) will be effective against it."
 		if("changeling")
 			text += "The Gorlex Marauders have announced the successful raid and destruction of Central Command containment ship #S-[rand(1111, 9999)]. This ship housed only a single prisoner - \
 			codenamed \"Thing\", and it was highly adaptive and extremely dangerous. We have reason to believe that the Thing has allied with the Syndicate, and you should note that likelihood \
@@ -64,7 +69,7 @@
 			text += "Nearby spaceships report crewmembers having been [pick("kidnapped", "abducted", "captured")] and [pick("tortured", "experimented on", "probed", "implanted")] by mysterious \
 			grey humanoids, before being sent back.  Be advised that the kidnapped crewmembers behave strangely upon return to duties."
 		if("traitor+changeling")
-			text += "The Syndicate union has started some experimental research regarding humanoid shapeshifting.  There are rumors that this technology will be field tested on a Nanotrasen station \
+			text += "The Syndicate has started some experimental research regarding humanoid shapeshifting.  There are rumors that this technology will be field tested on a Nanotrasen station \
 			for infiltration purposes.  Be advised that support personel may also be deployed to defend these shapeshifters. Trust nobody - suspect everybody. Do not announce this to the crew, \
 			as paranoia may spread and inhibit workplace efficiency."
 		else

--- a/code/game/gamemodes/intercept_report.dm
+++ b/code/game/gamemodes/intercept_report.dm
@@ -6,17 +6,12 @@
 /datum/intercept_text/proc/build(mode_type)
 	text = "<hr>"
 	switch(mode_type)
-		if("blob")
-			text += "A CMP scientist by the name of [pick("Griff", "Pasteur", "Chamberland", "Buist", "Rivers", "Stanley")] boasted about his corporation's \"finest creation\" - a macrobiological \
-			virus capable of self-reproduction and hellbent on consuming whatever it touches. He went on to query Cybersun for permission to utilize the virus in biochemical warfare, to which \
-			CMP subsequently gained. Be vigilant for any large organisms rapidly spreading across the station, as they are classified as a level 5 biohazard and critically dangerous. Note that \
-			this organism seems to be weak to extreme heat; concentrated fire (such as welding tools and lasers) will be effective against it."
 		if("changeling")
 			text += "The Gorlex Marauders have announced the successful raid and destruction of Central Command containment ship #S-[rand(1111, 9999)]. This ship housed only a single prisoner - \
 			codenamed \"Thing\", and it was highly adaptive and extremely dangerous. We have reason to believe that the Thing has allied with the Syndicate, and you should note that likelihood \
 			of the Thing being sent to a station in this sector is highly likely. It may be in the guise of any crew member. Trust nobody - suspect everybody. Do not announce this to the crew, \
 			as paranoia may spread and inhibit workplace efficiency."
-		if("clock_cult")
+		if("clockwork cult")
 			text += "We have lost contact with multiple stations in your sector. They have gone dark and do not respond to all transmissions, although they appear intact and the crew's life \
 			signs remain uninterrupted. Those that have managed to send a transmission or have had some of their crew escape tell tales of a machine cult creating sapient automatons and seeking \
 			to brainwash the crew to summon their god, Ratvar. If evidence of this cult is dicovered aboard your station, extreme caution and extreme vigilance must be taken going forward, and \
@@ -28,18 +23,14 @@
 			the cult of Nar-Sie. If evidence of this cult is discovered aboard your station, extreme caution and extreme vigilance must be taken going forward, and all resources should be \
 			devoted to stopping this cult. Note that holy water seems to weaken and eventually return the minds of cultists that ingest it, and mindshield implants will prevent conversion \
 			altogether."
-		if("extended")
+		if("secret extended")
 			text += "The transmission mostly failed to mention your sector. It is possible that there is nothing in the Syndicate that could threaten your station during this shift."
-		if("gang")
+		if("gang war")
 			text += "Cybersun Industries representatives claimed that they, in joint research with the Tiger Cooperative, have made a major breakthrough in brainwashing technology, and have \
 			made the nanobots that apply the \"conversion\" very small and capable of fitting into usually innocent objects - namely, pens. While they refused to outsource this technology for \
 			months to come due to its flaws, they reported some as missing but passed it off to carelessness. At Central Command, we don't like mysteries, and we have reason to believe that this \
 			technology was stolen for anti-Nanotrasen use. Be on the lookout for territory claims and unusually violent crew behavior, applying mindshield implants as necessary."
-		if("malf")
-			text += "A large ionospheric anomaly recently passed through your sector. Although physically undetectable, ionospherics tend to have an extreme effect on telecommunications equipment \
-			as well as artificial intelligence units. Closely observe the behavior of artificial intelligence, and treat any machine malfunctions as purposeful. If necessary, termination of the \
-			artificial intelligence is advised; assuming that it activates the station's self-destruct, your pinpointer has been configured to constantly track it, wherever it may be."
-		if("nuclear")
+		if("nuclear emergency")
 			text += "One of Central Command's trading routes was recently disrupted by a raid carried out by the Gorlex Marauders. They seemed to only be after one ship - a highly-sensitive \
 			transport containing a nuclear fission explosive, although it is useless without the proper code and authorization disk. While the code was likely found in minutes, the only disk that \
 			can activate this explosive is on your station. Ensure that it is protected at all times, and remain alert for possible intruders."
@@ -54,4 +45,24 @@
 			text += "A dangerous Wizards' Federation individual by the name of [pick(GLOB.wizard_first)] [pick(GLOB.wizard_second)] has recently escaped confinement from an unlisted prison facility. This \
 			man is a dangerous mutant with the ability to alter himself and the world around him by what he and his leaders believe to be magic. If this man attempts an attack on your station, \
 			his execution is highly encouraged, as is the preservation of his body for later study."
+		if("Internal Affairs")
+			text += "Nanotrasen denies any accusations of placing internal affairs agents onboard your station to eliminate inconvenient employees.  Any further accusations against Centcom for such \
+			actions will be met with a conversation with an official internal affairs agent."
+		if("monkey")
+			text += "Reports of an ancient [pick("retrovirus", "flesh eating bacteria", "disease", "magical curse blamed on viruses", "bananna blight")] outbreak that turn humans into monkies has been \
+			reported in your quadrant.  Any such infections may be treated with bananna juice.  If an outbreak occurs, ensure the station is quarantined to prevent a largescale outbreak at Centcom."
+		if("meteor")
+			text += "[pick("Asteroids have", "Meteors have", "Large rocks have", "Stellar minerals have", "Space hail has", "Debris has")] been detected near your station, and a collision is possible, though unlikely.  Be prepared \
+			for largescale impacts and destruction.  Please note that the debris will prevent the escape shuttle from arriving quickly."
+		if("devil")
+			text += "Infernal creatures have been seen nearby offering great boons in exchange for souls.  This is considered theft against Nanotrasen, as all employment contracts contain a lien on the \
+			employee's soul.  If anyone sells their soul in error, contact an attorney to overrule the sale.  Be warned that if the devil purchases enough souls, a gateway to hell may open."
+		if("Devil Agents")
+			text += "Multiple soul merchants have been spotted in the quadrant, and appear to be competing over who can purchase the most souls.  Be advised that they are likely to manufacture \
+			emergencies to encourage employees to sell their souls. If anyone sells their soul in error, contact an attorney to overrule the sale."
+		if("abduction")
+			text += "Nearby spaceships report crewmembers having been kidnapped and tortured by mysterious grey humanoids, before being sent back.  Be advised that the kidnapped crewmembers behave \
+			strangely upon return to duties."
+		else
+			EXCEPTION("An intercept report tried to generate a report for an invalid gamemode, \"[mode_type]\"")
 	return text

--- a/code/game/gamemodes/intercept_report.dm
+++ b/code/game/gamemodes/intercept_report.dm
@@ -65,7 +65,7 @@
 			strangely upon return to duties."
 		if("traitor+changeling")
 			text += "The Syndicate union has started some experimental research regarding humanoid shapeshifting.  There are rumors that this technology will be field tested on a Nanotrasen station \
-			for infiltration purposes.  Be advised that support personell may also be deployed to defend these shapeshifters. Trust nobody - suspect everybody. Do not announce this to the crew, \
+			for infiltration purposes.  Be advised that support personel may also be deployed to defend these shapeshifters. Trust nobody - suspect everybody. Do not announce this to the crew, \
 			as paranoia may spread and inhibit workplace efficiency."
 		else
 			EXCEPTION("An intercept report tried to generate a report for an invalid gamemode, \"[mode_type]\"")

--- a/code/game/gamemodes/intercept_report.dm
+++ b/code/game/gamemodes/intercept_report.dm
@@ -52,8 +52,8 @@
 			text += "Reports of an ancient [pick("retrovirus", "flesh eating bacteria", "disease", "magical curse blamed on viruses", "bananna blight")] outbreak that turn humans into monkies has been \
 			reported in your quadrant.  Any such infections may be treated with bananna juice.  If an outbreak occurs, ensure the station is quarantined to prevent a largescale outbreak at Centcom."
 		if("meteor")
-			text += "[pick("Asteroids have", "Meteors have", "Large rocks have", "Stellar minerals have", "Space hail has", "Debris has")] been detected near your station, and a collision is possible, though unlikely.  Be prepared \
-			for largescale impacts and destruction.  Please note that the debris will prevent the escape shuttle from arriving quickly."
+			text += "[pick("Asteroids have", "Meteors have", "Large rocks have", "Stellar minerals have", "Space hail has", "Debris has")] been detected near your station, and a collision is possible, \
+			though unlikely.  Be prepared for largescale impacts and destruction.  Please note that the debris will prevent the escape shuttle from arriving quickly."
 		if("devil")
 			text += "Infernal creatures have been seen nearby offering great boons in exchange for souls.  This is considered theft against Nanotrasen, as all employment contracts contain a lien on the \
 			employee's soul.  If anyone sells their soul in error, contact an attorney to overrule the sale.  Be warned that if the devil purchases enough souls, a gateway to hell may open."
@@ -61,8 +61,8 @@
 			text += "Multiple soul merchants have been spotted in the quadrant, and appear to be competing over who can purchase the most souls.  Be advised that they are likely to manufacture \
 			emergencies to encourage employees to sell their souls. If anyone sells their soul in error, contact an attorney to overrule the sale."
 		if("abduction")
-			text += "Nearby spaceships report crewmembers having been kidnapped and tortured by mysterious grey humanoids, before being sent back.  Be advised that the kidnapped crewmembers behave \
-			strangely upon return to duties."
+			text += "Nearby spaceships report crewmembers having been [pick("kidnapped", "abducted", "captured")] and [pick("tortured", "experimented on", "probed", "implanted")] by mysterious \
+			grey humanoids, before being sent back.  Be advised that the kidnapped crewmembers behave strangely upon return to duties."
 		if("traitor+changeling")
 			text += "The Syndicate union has started some experimental research regarding humanoid shapeshifting.  There are rumors that this technology will be field tested on a Nanotrasen station \
 			for infiltration purposes.  Be advised that support personel may also be deployed to defend these shapeshifters. Trust nobody - suspect everybody. Do not announce this to the crew, \

--- a/code/game/gamemodes/intercept_report.dm
+++ b/code/game/gamemodes/intercept_report.dm
@@ -63,6 +63,10 @@
 		if("abduction")
 			text += "Nearby spaceships report crewmembers having been kidnapped and tortured by mysterious grey humanoids, before being sent back.  Be advised that the kidnapped crewmembers behave \
 			strangely upon return to duties."
+		if("traitor+changeling")
+			text += "The Syndicate union has started some experimental research regarding humanoid shapeshifting.  There are rumors that this technology will be field tested on a Nanotrasen station \
+			for infiltration purposes.  Be advised that support personell may also be deployed to defend these shapeshifters. Trust nobody - suspect everybody. Do not announce this to the crew, \
+			as paranoia may spread and inhibit workplace efficiency."
 		else
 			EXCEPTION("An intercept report tried to generate a report for an invalid gamemode, \"[mode_type]\"")
 	return text


### PR DESCRIPTION
So, I did some code diving, and it turns out that by COUNTING the number of horizontal lines on a report, you can partially meta the gamemode.  If there are EIGHT, then it is definitely one of the following: changeling, traitor, bloodcult, revolution, or wizard, if there are SEVEN, then it is NOT any of those modes.  If it is EIGHT, then two of the lines will be adjacent.

Combine that with the contents of the report, and there's a good chance you can nail the gamemode with 100% accuracy.

I have taken this opportunity to add additional gamemodes to the report.  I am not a terribly creative writer for these, so if someone has recommendations for better text, let me know and I'll put it in.

I have also added a LOW possibility for adminfuckery round types to appear on the list.

:cl: lordpidey
fix: Centcom threat reports can now report more types of roundtypes.
/:cl:

