### PR TITLE
Fixes survival_pods being a valid_territory for gangs sprays & dominations/blob takeovers/cult summons/ect

### DIFF
--- a/code/game/gamemodes/gang/gang_items.dm
+++ b/code/game/gamemodes/gang/gang_items.dm
@@ -431,7 +431,7 @@
 /datum/gang_item/equipment/dominator/purchase(mob/living/carbon/user, datum/gang/gang, obj/item/device/gangtool/gangtool)
 	var/area/usrarea = get_area(user.loc)
 	var/usrturf = get_turf(user.loc)
-	if(initial(usrarea.name) == "Space" || isspaceturf(usrturf) || usr.z != ZLEVEL_STATION)
+	if(initial(usrarea.name) == "Space" || isspaceturf(usrturf) || usr.z != ZLEVEL_STATION || !usrarea.valid_territory)
 		to_chat(user, "<span class='warning'>You can only use this on the station!</span>")
 		return FALSE
 

--- a/code/modules/mining/equipment/survival_pod.dm
+++ b/code/modules/mining/equipment/survival_pod.dm
@@ -5,6 +5,7 @@
 	dynamic_lighting = DYNAMIC_LIGHTING_FORCED
 	requires_power = FALSE
 	has_gravity = TRUE
+	valid_territory = FALSE
 
 //Survival Capsule
 /obj/item/survivalcapsule


### PR DESCRIPTION
fixes #30178