### PR TITLE
Shadow Walk/New Shadowling movement spell

### DIFF
--- a/code/modules/spells/spell_types/shadow_walk.dm
+++ b/code/modules/spells/spell_types/shadow_walk.dm
@@ -1,0 +1,91 @@
+/obj/effect/proc_holder/spell/targeted/shadowwalk
+	name = "Shadow Walk"
+	desc = "Grants unlimited movement in darkness."
+	charge_max = 0
+	clothes_req = 0
+	phase_allowed = 1
+	selection_type = "range"
+	range = -1
+	include_user = 1
+	cooldown_min = 0
+	overlay = null
+	action_icon = 'icons/mob/actions/actions_minor_antag.dmi'
+	action_icon_state = "bloodcrawl"
+	action_background_icon_state = "bg_demon"
+
+/obj/effect/proc_holder/spell/targeted/shadowwalk/cast(list/targets,mob/user = usr)
+	var/L = user.loc
+	if(istype(user.loc, /obj/effect/dummy/shadow))
+		var/obj/effect/dummy/shadow/S = L
+		S.end_jaunt(FALSE)
+		return
+	else
+		var/turf/T = get_turf(src)
+		var/light_amount = T.get_lumcount()
+		if(light_amount < 0.2)
+			playsound(get_turf(user), 'sound/magic/ethereal_enter.ogg', 50, 1, -1)
+			visible_message("<span class='boldwarning'>[user] melts into the shadows!</span>")
+			var/obj/effect/dummy/shadow/S2 = new(get_turf(user.loc))
+			user.forceMove(S2)
+			S2.jaunter = user
+		else
+			to_chat(user, "<span class='warning'>It isn't dark enough here!</span>")
+
+/obj/effect/dummy/shadow
+	name = "darkness"
+	icon = 'icons/effects/effects.dmi'
+	icon_state = "nothing"
+	var/canmove = 1
+	var/mob/living/jaunter
+	density = FALSE
+	anchored = TRUE
+	invisibility = 60
+	resistance_flags = LAVA_PROOF | FIRE_PROOF | UNACIDABLE | ACID_PROOF
+
+/obj/effect/dummy/shadow/relaymove(mob/user, direction)
+	forceMove(get_step(src,direction))
+	check_light_level()
+
+/obj/effect/dummy/shadow/proc/check_light_level()
+	var/turf/T = get_turf(src)
+	var/light_amount = T.get_lumcount()
+	if(light_amount > 0.2) // jaunt ends
+		end_jaunt(TRUE)
+	else if (light_amount < 0.2 && jaunter) //heal in the dark
+		jaunter.heal_overall_damage(1,1)
+
+/obj/effect/dummy/shadow/proc/end_jaunt(forced = FALSE)
+	if(jaunter)
+		if(forced)
+			visible_message("<span class='boldwarning'>[jaunter] is revealed by the light!</span>")
+		else
+			visible_message("<span class='boldwarning'>[jaunter] emerges from the darkness!</span>")
+		jaunter.forceMove(get_turf(src))
+		playsound(get_turf(jaunter), 'sound/magic/ethereal_exit.ogg', 50, 1, -1)
+		jaunter = null
+	qdel(src)
+
+/obj/effect/dummy/shadow/Initialize(mapload)
+	. = ..()
+	START_PROCESSING(SSobj, src)
+
+/obj/effect/dummy/shadow/Destroy()
+	STOP_PROCESSING(SSobj, src)
+	. = ..()
+
+/obj/effect/dummy/shadow/process()
+	if(!jaunter)
+		qdel(src)
+	if(jaunter.loc != src)
+		qdel(src)
+	check_light_level()
+
+/obj/effect/dummy/shadow/ex_act()
+	return
+
+/obj/effect/dummy/shadow/bullet_act()
+	return
+
+/obj/effect/dummy/shadow/singularity_act()
+	return
+

--- a/code/modules/spells/spell_types/shadow_walk.dm
+++ b/code/modules/spells/spell_types/shadow_walk.dm
@@ -10,8 +10,8 @@
 	cooldown_min = 0
 	overlay = null
 	action_icon = 'icons/mob/actions/actions_minor_antag.dmi'
-	action_icon_state = "bloodcrawl"
-	action_background_icon_state = "bg_demon"
+	action_icon_state = "ninja_cloak"
+	action_background_icon_state = "bg_alien"
 
 /obj/effect/proc_holder/spell/targeted/shadowwalk/cast(list/targets,mob/user = usr)
 	var/L = user.loc
@@ -20,7 +20,7 @@
 		S.end_jaunt(FALSE)
 		return
 	else
-		var/turf/T = get_turf(src)
+		var/turf/T = get_turf(user)
 		var/light_amount = T.get_lumcount()
 		if(light_amount < 0.2)
 			playsound(get_turf(user), 'sound/magic/ethereal_enter.ogg', 50, 1, -1)
@@ -43,7 +43,11 @@
 	resistance_flags = LAVA_PROOF | FIRE_PROOF | UNACIDABLE | ACID_PROOF
 
 /obj/effect/dummy/shadow/relaymove(mob/user, direction)
-	forceMove(get_step(src,direction))
+	var/turf/newLoc = get_step(src,direction)
+	if(isspaceturf(newLoc))
+		to_chat(user, "<span class='warning'>It really would not be wise to go into space.</span>")
+		return
+	forceMove(newLoc)
 	check_light_level()
 
 /obj/effect/dummy/shadow/proc/check_light_level()

--- a/code/modules/spells/spell_types/shadow_walk.dm
+++ b/code/modules/spells/spell_types/shadow_walk.dm
@@ -55,7 +55,7 @@
 	var/light_amount = T.get_lumcount()
 	if(light_amount > 0.2) // jaunt ends
 		end_jaunt(TRUE)
-	else if (light_amount < 0.2 && jaunter) //heal in the dark
+	else if (light_amount < 0.2 && (!QDELETED(jaunter))) //heal in the dark
 		jaunter.heal_overall_damage(1,1)
 
 /obj/effect/dummy/shadow/proc/end_jaunt(forced = FALSE)

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -2086,6 +2086,7 @@
 #include "code\modules\spells\spell_types\rightandwrong.dm"
 #include "code\modules\spells\spell_types\rod_form.dm"
 #include "code\modules\spells\spell_types\santa.dm"
+#include "code\modules\spells\spell_types\shadow_walk.dm"
 #include "code\modules\spells\spell_types\shapeshift.dm"
 #include "code\modules\spells\spell_types\spacetime_distortion.dm"
 #include "code\modules\spells\spell_types\summonitem.dm"


### PR DESCRIPTION
:cl: Kor
add: Added Shadow Walk, a new form of jaunt that lasts for an unlimited amount of time, but ends if you enter a well lit tile. It is planned for use in a Shadowling rework, but feel free to hassle admins to test it out in the mean time.
/:cl:

Can only be used in the dark/will end if you leave the dark.

It also heals you while you're in the darkness.

Shadowlings for side antag 2017. This will make expanding areas of light/dark actually relevant
