### PR TITLE
Fixes APC pixel shift being off

### DIFF
--- a/code/modules/power/apc.dm
+++ b/code/modules/power/apc.dm
@@ -120,8 +120,15 @@
 	if(auto_name)
 		name = "\improper [get_area(src)] APC"
 
-	pixel_x = (src.tdir & 3)? 0 : (src.tdir == 4 ? 26 : -27)
-	pixel_y = (src.tdir & 3)? (src.tdir == 1 ? 25 : -25) : 0
+	switch(tdir)
+		if(NORTH)
+			pixel_y = 23
+		if(SOUTH)
+			pixel_y = -25
+		if(EAST)
+			pixel_x = 24
+		if(WEST)
+			pixel_x = -25
 	if (building)
 		area = get_area(src)
 		opened = 1

--- a/code/modules/power/apc.dm
+++ b/code/modules/power/apc.dm
@@ -124,7 +124,7 @@
 		if(NORTH)
 			pixel_y = 23
 		if(SOUTH)
-			pixel_y = -25
+			pixel_y = -23
 		if(EAST)
 			pixel_x = 24
 		if(WEST)


### PR DESCRIPTION
I *just did this* god
![](http://puu.sh/xjHUw/49bb9b066e.png)
there's like a two pixel gap there between the APC and the terminal right now, what the heck.