### PR TITLE
Changes playtime verb name

### DIFF
--- a/code/modules/admin/verbs/randomverbs.dm
+++ b/code/modules/admin/verbs/randomverbs.dm
@@ -1214,7 +1214,7 @@ GLOBAL_LIST_EMPTY(custom_outfits) //Admin created outfits
 
 /client/proc/cmd_admin_check_player_exp()	//Allows admins to determine who the newer players are.
 	set category = "Admin"
-	set name = "Check Player Playtime"
+	set name = "Player Playtime"
 	if(!check_rights(R_ADMIN))
 		return
 


### PR DESCRIPTION
This will make Player Panel the first option for autocomplete when you type Play as an admin

Player Panel is a far more commonly used/useful verb and its throwing me off having this pop up after five years or whatever of being able to type play+ enter to open the player panel