### PR TITLE
Automatic unbuckle by player moving

### DIFF
--- a/code/game/objects/structures/beds_chairs/bed.dm
+++ b/code/game/objects/structures/beds_chairs/bed.dm
@@ -37,6 +37,9 @@
 	else
 		return ..()
 
+/obj/structure/bed/relaymove(mob/living/user)
+	user.resist_buckle()
+
 /*
  * Roller beds
  */

--- a/code/game/objects/structures/beds_chairs/chair.dm
+++ b/code/game/objects/structures/beds_chairs/chair.dm
@@ -112,6 +112,9 @@
 	else
 		rotate()
 
+/obj/structure/chair/relaymove(mob/living/user)
+	user.resist_buckle()
+
 // Chair types
 /obj/structure/chair/wood
 	icon_state = "wooden_chair"


### PR DESCRIPTION
:cl:
add: You can now unbuckle out a chair/bed by moving.
/:cl:

Some first time players were getting stuck in the arrivals shuttle because they didn't realize they were buckled to a chair. This fixes the issue, it feels intuitive imo and practically does the same thing as clicking on the resist-button while buckled on a chair/bed. Thanks to Jordie for the help!

Should this also be expanded to closets, suit storage unit, gibber etc. where ever the player is stuck and needs to press the resist-button in order to escape?