### PR TITLE
Made antimatter engine's power display more user friendly.

### DIFF
--- a/code/modules/power/antimatter/control.dm
+++ b/code/modules/power/antimatter/control.dm
@@ -306,7 +306,10 @@
 	dat += "Cores: [linked_cores.len]<BR><BR>"
 	dat += "-Current Efficiency: [reported_core_efficiency]<BR>"
 	dat += "-Average Stability: [stored_core_stability] <A href='?src=\ref[src];refreshstability=1'>(update)</A><BR>"
-	dat += "Last Produced: [stored_power]<BR>"
+	if(stored_power < 1000000) //less than a MW
+		dat += "Last Produced: [round((stored_power * 0.001),0.01)] kW<BR>"
+	else
+		dat += "Last Produced: [round((stored_power * 0.000001),0.01)] MW<BR>"
 
 	dat += "Fuel: "
 	if(!fueljar)


### PR DESCRIPTION
Will no longer output scientific notation and will provide the user with a more friendly "Last Produced: 5 MW" or "Last Produced: 50 kW"

part of #30213's goals.