### PR TITLE
Fixes ingredients-box sprite.

### DIFF
--- a/code/game/objects/items/storage/boxes.dm
+++ b/code/game/objects/items/storage/boxes.dm
@@ -732,7 +732,6 @@
 /obj/item/storage/box/ingredients //This box is for the randomely chosen version the chef spawns with, it shouldn't actually exist.
 	name = "ingredients box"
 	illustration = "donk_kit"
-	icon_state = null
 
 /obj/item/storage/box/ingredients/Initialize()
 	..()


### PR DESCRIPTION
Makes the ingredients-box visible again.

PS. How do I make that newline-crap not appear?
Fixes #30237 