### PR TITLE
Note fading and persistent messages

### DIFF
--- a/SQL/database_changelog.txt
+++ b/SQL/database_changelog.txt
@@ -1,13 +1,27 @@
 Any time you make a change to the schema files, remember to increment the database schema version. Generally increment the minor number, major should be reserved for significant changes to the schema. Both values go up to 255.
 
-The latest database version is 3.3; The query to update the schema revision table is:
+The latest database version is 3.4; The query to update the schema revision table is:
 
-INSERT INTO `schema_revision` (`major`, `minor`) VALUES (3, 3);
+INSERT INTO `schema_revision` (`major`, `minor`) VALUES (3, 4);
 or
-INSERT INTO `SS13_schema_revision` (`major`, `minor`) VALUES (3, 3);
+INSERT INTO `SS13_schema_revision` (`major`, `minor`) VALUES (3, 4);
+
+In any query remember to add a prefix to the table names if you use one.
 
 ----------------------------------------------------
-In any query remember to add a prefix to the table names if you use one.
+
+28 August 2017, by MrStonedOne
+Modified table 'messages', adding a deleted column and editing all indexes to include it
+
+ALTER TABLE `messages`
+ADD COLUMN `deleted` tinyint(1) unsigned NOT NULL DEFAULT '0' AFTER `edits`,
+DROP INDEX `idx_msg_ckey_time`,
+DROP INDEX `idx_msg_type_ckeys_time`,
+DROP INDEX `idx_msg_type_ckey_time_odr`,
+ADD INDEX `idx_msg_ckey_time` (`targetckey`,`timestamp`, `deleted`),
+ADD INDEX `idx_msg_type_ckeys_time` (`type`,`targetckey`,`adminckey`,`timestamp`, `deleted`),
+ADD INDEX `idx_msg_type_ckey_time_odr` (`type`,`targetckey`,`timestamp`, `deleted`);
+
 ----------------------------------------------------
 
 25 August 2017, by Jordie0608

--- a/SQL/tgstation_schema.sql
+++ b/SQL/tgstation_schema.sql
@@ -254,10 +254,11 @@ CREATE TABLE `messages` (
   `secret` tinyint(1) unsigned NOT NULL,
   `lasteditor` varchar(32) DEFAULT NULL,
   `edits` text,
+  `deleted` tinyint(1) unsigned NOT NULL DEFAULT '0',
   PRIMARY KEY (`id`),
-  KEY `idx_msg_ckey_time` (`targetckey`,`timestamp`),
-  KEY `idx_msg_type_ckeys_time` (`type`,`targetckey`,`adminckey`,`timestamp`),
-  KEY `idx_msg_type_ckey_time_odr` (`type`,`targetckey`,`timestamp`)
+  KEY `idx_msg_ckey_time` (`targetckey`,`timestamp`, `deleted`),
+  KEY `idx_msg_type_ckeys_time` (`type`,`targetckey`,`adminckey`,`timestamp`, `deleted`),
+  KEY `idx_msg_type_ckey_time_odr` (`type`,`targetckey`,`timestamp`, `deleted`)
 ) ENGINE=InnoDB DEFAULT CHARSET=latin1;
 /*!40101 SET character_set_client = @saved_cs_client */;
 

--- a/SQL/tgstation_schema_prefixed.sql
+++ b/SQL/tgstation_schema_prefixed.sql
@@ -31,7 +31,7 @@ CREATE TABLE `SS13_admin` (
 -- Table structure for table `SS13_admin_log`
 --
 
-DROP TABLE IF EXISTS `SS13_dmin_log`;
+DROP TABLE IF EXISTS `SS13_admin_log`;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
 /*!40101 SET character_set_client = utf8 */;
 CREATE TABLE `SS13_admin_log` (
@@ -254,10 +254,11 @@ CREATE TABLE `SS13_messages` (
   `secret` tinyint(1) unsigned NOT NULL,
   `lasteditor` varchar(32) DEFAULT NULL,
   `edits` text,
+  `deleted` tinyint(1) unsigned NOT NULL DEFAULT '0',
   PRIMARY KEY (`id`),
-  KEY `idx_msg_ckey_time` (`targetckey`,`timestamp`),
-  KEY `idx_msg_type_ckeys_time` (`type`,`targetckey`,`adminckey`,`timestamp`),
-  KEY `idx_msg_type_ckey_time_odr` (`type`,`targetckey`,`timestamp`)
+  KEY `idx_msg_ckey_time` (`targetckey`,`timestamp`, `deleted`),
+  KEY `idx_msg_type_ckeys_time` (`type`,`targetckey`,`adminckey`,`timestamp`, `deleted`),
+  KEY `idx_msg_type_ckey_time_odr` (`type`,`targetckey`,`timestamp`, `deleted`)
 ) ENGINE=InnoDB DEFAULT CHARSET=latin1;
 /*!40101 SET character_set_client = @saved_cs_client */;
 

--- a/code/_compile_options.dm
+++ b/code/_compile_options.dm
@@ -72,4 +72,4 @@
 //Update this whenever the db schema changes
 //make sure you add an update to the schema_version stable in the db changelog
 #define DB_MAJOR_VERSION 3
-#define DB_MINOR_VERSION 3
+#define DB_MINOR_VERSION 4

--- a/code/controllers/configuration.dm
+++ b/code/controllers/configuration.dm
@@ -102,6 +102,8 @@
 	var/use_age_restriction_for_jobs = 0 //Do jobs use account age restrictions? --requires database
 	var/use_account_age_for_jobs = 0	//Uses the time they made the account for the job restriction stuff. New player joining alerts should be unaffected.
 	var/see_own_notes = 0 //Can players see their own admin notes (read-only)? Config option in config.txt
+	var/note_fresh_days
+	var/note_stale_days
 
 	var/use_exp_tracking = FALSE
 	var/use_exp_restrictions_heads = FALSE
@@ -473,6 +475,10 @@
 					showircname = 1
 				if("see_own_notes")
 					see_own_notes = 1
+				if("note_fresh_days")
+					note_fresh_days = text2num(value)
+				if("note_stale_days")
+					note_stale_days = text2num(value)
 				if("soft_popcap")
 					soft_popcap = text2num(value)
 				if("hard_popcap")

--- a/code/modules/admin/sql_message_system.dm
+++ b/code/modules/admin/sql_message_system.dm
@@ -56,7 +56,7 @@
 		if(browse)
 			browse_messages("[type]")
 		else
-			browse_messages(target_ckey = target_ckey)
+			browse_messages(target_ckey = target_ckey, agegate = TRUE)
 
 /proc/delete_message(message_id, logged = 1, browse)
 	if(!SSdbcore.Connect())
@@ -68,14 +68,14 @@
 	var/type
 	var/target_ckey
 	var/text
-	var/datum/DBQuery/query_find_del_message = SSdbcore.NewQuery("SELECT type, targetckey, adminckey, text FROM [format_table_name("messages")] WHERE id = [message_id]")
+	var/datum/DBQuery/query_find_del_message = SSdbcore.NewQuery("SELECT type, targetckey, adminckey, text FROM [format_table_name("messages")] WHERE id = [message_id] AND deleted = 0")
 	if(!query_find_del_message.warn_execute())
 		return
 	if(query_find_del_message.NextRow())
 		type = query_find_del_message.item[1]
 		target_ckey = query_find_del_message.item[2]
 		text = query_find_del_message.item[4]
-	var/datum/DBQuery/query_del_message = SSdbcore.NewQuery("DELETE FROM [format_table_name("messages")] WHERE id = [message_id]")
+	var/datum/DBQuery/query_del_message = SSdbcore.NewQuery("UPDATE [format_table_name("messages")] SET deleted = 1 WHERE id = [message_id]")
 	if(!query_del_message.warn_execute())
 		return
 	if(logged)
@@ -84,7 +84,7 @@
 		if(browse)
 			browse_messages("[type]")
 		else
-			browse_messages(target_ckey = target_ckey)
+			browse_messages(target_ckey = target_ckey, agegate = TRUE)
 
 /proc/edit_message(message_id, browse)
 	if(!SSdbcore.Connect())
@@ -93,7 +93,7 @@
 	message_id = text2num(message_id)
 	if(!message_id)
 		return
-	var/datum/DBQuery/query_find_edit_message = SSdbcore.NewQuery("SELECT type, targetckey, adminckey, text FROM [format_table_name("messages")] WHERE id = [message_id]")
+	var/datum/DBQuery/query_find_edit_message = SSdbcore.NewQuery("SELECT type, targetckey, adminckey, text FROM [format_table_name("messages")] WHERE id = [message_id] AND deleted = 0")
 	if(!query_find_edit_message.warn_execute())
 		return
 	if(query_find_edit_message.NextRow())
@@ -107,7 +107,7 @@
 			return
 		new_text = sanitizeSQL(new_text)
 		var/edit_text = sanitizeSQL("Edited by [editor_ckey] on [SQLtime()] from<br>[old_text]<br>to<br>[new_text]<hr>")
-		var/datum/DBQuery/query_edit_message = SSdbcore.NewQuery("UPDATE [format_table_name("messages")] SET text = '[new_text]', lasteditor = '[editor_ckey]', edits = CONCAT(IFNULL(edits,''),'[edit_text]') WHERE id = [message_id]")
+		var/datum/DBQuery/query_edit_message = SSdbcore.NewQuery("UPDATE [format_table_name("messages")] SET text = '[new_text]', lasteditor = '[editor_ckey]', edits = CONCAT(IFNULL(edits,''),'[edit_text]') WHERE id = [message_id] AND deleted = 0")
 		if(!query_edit_message.warn_execute())
 			return
 		log_admin_private("[key_name(usr)] has edited a [type] [(type == "note" || type == "message" || type == "watchlist entry") ? " for [target_ckey]" : ""] made by [admin_ckey] from [old_text] to [new_text]")
@@ -115,7 +115,7 @@
 		if(browse)
 			browse_messages("[type]")
 		else
-			browse_messages(target_ckey = target_ckey)
+			browse_messages(target_ckey = target_ckey, agegate = TRUE)
 
 /proc/toggle_message_secrecy(message_id)
 	if(!SSdbcore.Connect())
@@ -124,7 +124,7 @@
 	message_id = text2num(message_id)
 	if(!message_id)
 		return
-	var/datum/DBQuery/query_find_message_secret = SSdbcore.NewQuery("SELECT type, targetckey, adminckey, secret FROM [format_table_name("messages")] WHERE id = [message_id]")
+	var/datum/DBQuery/query_find_message_secret = SSdbcore.NewQuery("SELECT type, targetckey, adminckey, secret FROM [format_table_name("messages")] WHERE id = [message_id] AND deleted = 0")
 	if(!query_find_message_secret.warn_execute())
 		return
 	if(query_find_message_secret.NextRow())
@@ -139,9 +139,9 @@
 			return
 		log_admin_private("[key_name(usr)] has toggled [target_ckey]'s [type] made by [admin_ckey] to [secret ? "not secret" : "secret"]")
 		message_admins("[key_name_admin(usr)] has toggled [target_ckey]'s [type] made by [admin_ckey] to [secret ? "not secret" : "secret"]")
-		browse_messages(target_ckey = target_ckey)
+		browse_messages(target_ckey = target_ckey, agegate = TRUE)
 
-/proc/browse_messages(type, target_ckey, index, linkless = 0, filter)
+/proc/browse_messages(type, target_ckey, index, linkless = FALSE, filter, agegate = FALSE)
 	if(!SSdbcore.Connect())
 		to_chat(usr, "<span class='danger'>Failed to establish database connection.</span>")
 		return
@@ -169,7 +169,7 @@
 			else
 				output += "|<a href='?_src_=holder;showwatchfilter=1'>\[Filter offline clients\]</a></center>"
 		output += ruler
-		var/datum/DBQuery/query_get_type_messages = SSdbcore.NewQuery("SELECT id, targetckey, adminckey, text, timestamp, server, lasteditor FROM [format_table_name("messages")] WHERE type = '[type]'")
+		var/datum/DBQuery/query_get_type_messages = SSdbcore.NewQuery("SELECT id, targetckey, adminckey, text, timestamp, server, lasteditor FROM [format_table_name("messages")] WHERE type = '[type]' AND deleted = 0")
 		if(!query_get_type_messages.warn_execute())
 			return
 		while(query_get_type_messages.NextRow())
@@ -193,7 +193,7 @@
 			output += "<br>[text]<hr style='background:#000000; border:0; height:1px'>"
 	if(target_ckey)
 		target_ckey = sanitizeSQL(target_ckey)
-		var/datum/DBQuery/query_get_messages = SSdbcore.NewQuery("SELECT type, secret, id, adminckey, text, timestamp, server, lasteditor FROM [format_table_name("messages")] WHERE type <> 'memo' AND targetckey = '[target_ckey]' ORDER BY timestamp DESC")
+		var/datum/DBQuery/query_get_messages = SSdbcore.NewQuery("SELECT type, secret, id, adminckey, text, timestamp, server, lasteditor, DATEDIFF(NOW(), timestamp) AS `age` FROM [format_table_name("messages")] WHERE type <> 'memo' AND targetckey = '[target_ckey]' AND deleted = 0 ORDER BY timestamp DESC")
 		if(!query_get_messages.warn_execute())
 			return
 		var/messagedata
@@ -212,8 +212,17 @@
 			var/timestamp = query_get_messages.item[6]
 			var/server = query_get_messages.item[7]
 			var/editor_ckey = query_get_messages.item[8]
+			var/age = text2num(query_get_messages.item[9])
+			var/alphatext = ""
+			if (agegate && type == "note" && isnum(config.note_stale_days) && isnum(config.note_fresh_days) && config.note_stale_days > config.note_fresh_days)
+				var/alpha = Clamp(100 - (age - config.note_fresh_days) * (85 / (config.note_stale_days - config.note_fresh_days)), 15, 100)
+				if (alpha < 100)
+					alphatext = "filter: alpha(opacity=[alpha]); opacity: [alpha/100];"
+					if (alpha <= 15)
+						alphatext += " display:none;"
+
 			var/data
-			data += "<b>[timestamp] | [server] | [admin_ckey]</b>"
+			data += "<p style='margin:0px;[alphatext]'> <b>[timestamp] | [server] | [admin_ckey]</b>"
 			if(!linkless)
 				data += " <a href='?_src_=holder;deletemessage=[id]'>\[Delete\]</a>"
 				if(type == "note")
@@ -226,7 +235,7 @@
 					data += " <a href='?_src_=holder;editmessage=[id]'>\[Edit\]</a>"
 				if(editor_ckey)
 					data += " <font size='2'>Last edit by [editor_ckey] <a href='?_src_=holder;messageedits=[id]'>(Click here to see edit log)</a></font>"
-			data += "<br>[text]<hr style='background:#000000; border:0; height:1px'>"
+			data += "<br>[text]</p><hr style='background:#000000; border:0; height:1px; [alphatext]'>"
 			switch(type)
 				if("message")
 					messagedata += data
@@ -254,6 +263,11 @@
 		if(notedata)
 			output += "<h4>Notes</h4>"
 			output += notedata
+			if(!linkless)
+				if (agegate)
+					output += " <center><a href='?_src_=holder;showmessageckey=[target_ckey];showall=1'>\[Show All\]</center>"
+				else
+					output += " <center><a href='?_src_=holder;showmessageckey=[target_ckey]'>\[Hide Old\]</center>"
 	if(index)
 		var/index_ckey
 		var/search
@@ -268,7 +282,7 @@
 				search = "^\[^\[:alpha:\]\]"
 			else
 				search = "^[index]"
-		var/datum/DBQuery/query_list_messages = SSdbcore.NewQuery("SELECT DISTINCT targetckey FROM [format_table_name("messages")] WHERE type <> 'memo' AND targetckey REGEXP '[search]' ORDER BY targetckey")
+		var/datum/DBQuery/query_list_messages = SSdbcore.NewQuery("SELECT DISTINCT targetckey FROM [format_table_name("messages")] WHERE type <> 'memo' AND targetckey REGEXP '[search]' AND deleted = 0 ORDER BY targetckey")
 		if(!query_list_messages.warn_execute())
 			return
 		while(query_list_messages.NextRow())
@@ -277,7 +291,7 @@
 	else if(!type && !target_ckey && !index)
 		output += "<center></a> <a href='?_src_=holder;addmessageempty=1'>\[Add message\]</a><a href='?_src_=holder;addwatchempty=1'>\[Add watchlist entry\]</a><a href='?_src_=holder;addnoteempty=1'>\[Add note\]</a></center>"
 		output += ruler
-	usr << browse(output, "window=browse_messages;size=900x500")
+	usr << browse({"<!DOCTYPE html><html><head><meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1" /></head><body>[output]</body></html>"}, "window=browse_messages;size=900x500")
 
 proc/get_message_output(type, target_ckey)
 	if(!SSdbcore.Connect())
@@ -288,7 +302,7 @@ proc/get_message_output(type, target_ckey)
 	var/output
 	if(target_ckey)
 		target_ckey = sanitizeSQL(target_ckey)
-	var/query = "SELECT id, adminckey, text, timestamp, lasteditor FROM [format_table_name("messages")] WHERE type = '[type]'"
+	var/query = "SELECT id, adminckey, text, timestamp, lasteditor FROM [format_table_name("messages")] WHERE type = '[type]' AND deleted = 0"
 	if(type == "message" || type == "watchlist entry")
 		query += " AND targetckey = '[target_ckey]'"
 	var/datum/DBQuery/query_get_message_output = SSdbcore.NewQuery(query)

--- a/code/modules/admin/sql_message_system.dm
+++ b/code/modules/admin/sql_message_system.dm
@@ -199,7 +199,7 @@
 		var/messagedata
 		var/watchdata
 		var/notedata
-		var/skipped = FALSE
+		var/skipped = 0
 		while(query_get_messages.NextRow())
 			type = query_get_messages.item[1]
 			if(type == "memo")
@@ -220,7 +220,8 @@
 				if (alpha < 100)
 					if (alpha <= 15)
 						if (skipped)
-							break
+							skipped++
+							continue
 						alpha = 10
 						skipped = TRUE
 					alphatext = "filter: alpha(opacity=[alpha]); opacity: [alpha/100];"
@@ -270,7 +271,7 @@
 			if(!linkless)
 				if (agegate)
 					if (skipped) //the first skipped message is still shown so that we can put this link over it.
-						output += " <center><a href='?_src_=holder;showmessageckey=[target_ckey];showall=1' style='position: relative; top: -3em;'>\[Show All\]</center>"
+						output += " <center><a href='?_src_=holder;showmessageckey=[target_ckey];showall=1' style='position: relative; top: -3em;'>\[Show [skipped] hidden messages\]</center>"
 					else
 						output += " <center><a href='?_src_=holder;showmessageckey=[target_ckey];showall=1'>\[Show All\]</center>"
 

--- a/code/modules/admin/sql_message_system.dm
+++ b/code/modules/admin/sql_message_system.dm
@@ -199,6 +199,7 @@
 		var/messagedata
 		var/watchdata
 		var/notedata
+		var/skipped = FALSE
 		while(query_get_messages.NextRow())
 			type = query_get_messages.item[1]
 			if(type == "memo")
@@ -217,9 +218,12 @@
 			if (agegate && type == "note" && isnum(config.note_stale_days) && isnum(config.note_fresh_days) && config.note_stale_days > config.note_fresh_days)
 				var/alpha = Clamp(100 - (age - config.note_fresh_days) * (85 / (config.note_stale_days - config.note_fresh_days)), 15, 100)
 				if (alpha < 100)
-					alphatext = "filter: alpha(opacity=[alpha]); opacity: [alpha/100];"
 					if (alpha <= 15)
-						alphatext += " display:none;"
+						if (skipped)
+							break
+						alpha = 10
+						skipped = TRUE
+					alphatext = "filter: alpha(opacity=[alpha]); opacity: [alpha/100];"
 
 			var/data
 			data += "<p style='margin:0px;[alphatext]'> <b>[timestamp] | [server] | [admin_ckey]</b>"
@@ -265,7 +269,11 @@
 			output += notedata
 			if(!linkless)
 				if (agegate)
-					output += " <center><a href='?_src_=holder;showmessageckey=[target_ckey];showall=1'>\[Show All\]</center>"
+					if (skipped) //the first skipped message is still shown so that we can put this link over it.
+						output += " <center><a href='?_src_=holder;showmessageckey=[target_ckey];showall=1' style='position: relative; top: -3em;'>\[Show All\]</center>"
+					else
+						output += " <center><a href='?_src_=holder;showmessageckey=[target_ckey];showall=1'>\[Show All\]</center>"
+
 				else
 					output += " <center><a href='?_src_=holder;showmessageckey=[target_ckey]'>\[Hide Old\]</center>"
 	if(index)

--- a/code/modules/admin/topic.dm
+++ b/code/modules/admin/topic.dm
@@ -1101,7 +1101,10 @@
 
 	else if(href_list["showmessageckey"])
 		var/target = href_list["showmessageckey"]
-		browse_messages(target_ckey = target)
+		var/agegate = TRUE
+		if (href_list["showall"])
+			agegate = FALSE
+		browse_messages(target_ckey = target, agegate = agegate)
 
 	else if(href_list["showmessageckeylinkless"])
 		var/target = href_list["showmessageckeylinkless"]

--- a/code/modules/client/client_procs.dm
+++ b/code/modules/client/client_procs.dm
@@ -565,13 +565,13 @@ GLOBAL_LIST(external_rsc_urls)
 	var/const/adminckey = "CID-Error"
 	var/sql_ckey = sanitizeSQL(ckey)
 	//check to see if we noted them in the last day.
-	var/datum/DBQuery/query_get_notes = SSdbcore.NewQuery("SELECT id FROM [format_table_name("messages")] WHERE type = 'note' AND targetckey = '[sql_ckey]' AND adminckey = '[adminckey]' AND timestamp + INTERVAL 1 DAY < NOW()")
+	var/datum/DBQuery/query_get_notes = SSdbcore.NewQuery("SELECT id FROM [format_table_name("messages")] WHERE type = 'note' AND targetckey = '[sql_ckey]' AND adminckey = '[adminckey]' AND timestamp + INTERVAL 1 DAY < NOW() AND deleted = 0")
 	if(!query_get_notes.Execute())
 		return
 	if(query_get_notes.NextRow())
 		return
 	//regardless of above, make sure their last note is not from us, as no point in repeating the same note over and over.
-	query_get_notes = SSdbcore.NewQuery("SELECT adminckey FROM [format_table_name("messages")] WHERE targetckey = '[sql_ckey]' ORDER BY timestamp DESC LIMIT 1")
+	query_get_notes = SSdbcore.NewQuery("SELECT adminckey FROM [format_table_name("messages")] WHERE targetckey = '[sql_ckey]' AND deleted = 0 ORDER BY timestamp DESC LIMIT 1")
 	if(!query_get_notes.Execute())
 		return
 	if(query_get_notes.NextRow())

--- a/code/modules/client/verbs/ooc.dm
+++ b/code/modules/client/verbs/ooc.dm
@@ -234,7 +234,7 @@ GLOBAL_VAR_INIT(normal_ooc_colour, OOC_COLOR)
 		to_chat(usr, "<span class='notice'>Sorry, that function is not enabled on this server.</span>")
 		return
 
-	browse_messages(null, usr.ckey, null, 1)
+	browse_messages(null, usr.ckey, null, TRUE)
 
 /client/proc/ignore_key(client)
 	var/client/C = client

--- a/config/config.txt
+++ b/config/config.txt
@@ -225,6 +225,12 @@ TICKLAG 0.5
 ## Uncomment this to let players see their own notes (they can still be set by admins only)
 #SEE_OWN_NOTES
 
+### Comment these two out to prevent notes fading out over time for admins.
+## Notes older then this will start fading out.
+NOTE_FRESH_DAYS 91.31055
+## Notes older then this will be completely faded out.
+NOTE_STALE_DAYS 365.2422
+
 ##Note: all population caps can be used with each other if desired.
 
 ## Uncomment for 'soft' population caps, players will be warned while joining if the living crew exceeds the listed number.


### PR DESCRIPTION
Player Notes can now fade out over time so admins don't accidentally ban players for 4 year old notes (admins may still reveal these older notes)

Deleted messages now remain in the database and are instead just hidden from view.

Two things relating to messages I've been meaning to do for ever.
:cl:
add: Player notes can now be configured to fade out over time to allow admins to quickly see how recent notes are. Server Operators, check the config for more info
/:cl:

30 to 90 day fade out preview:

![1](https://user-images.githubusercontent.com/7069733/29907449-3b2fed56-8dd0-11e7-9c11-9bf2e67e0645.PNG)
![2](https://user-images.githubusercontent.com/7069733/29907448-3b2f11ce-8dd0-11e7-8ff9-5ab77d7875a5.PNG)


Defaults to disabled on existing servers, defaults to a fade out between 3 months to a year on new servers (What I plan on using for /tg/)