### PR TITLE
Server tools versioning and fix to displayed testmerges

### DIFF
--- a/code/__DEFINES/server_tools.dm
+++ b/code/__DEFINES/server_tools.dm
@@ -9,7 +9,9 @@
 
 //keep these in sync with TGS3
 #define SERVICE_WORLD_PARAM "server_service"
-#define SERVICE_PR_TEST_JSON "..\\..\\prtestjob.json"
+#define SERVICE_VERSION_PARAM "server_service_version"
+#define SERVICE_PR_TEST_JSON "prtestjob.json"
+#define SERVICE_PR_TEST_JSON_OLD "..\\..\\[SERVICE_PR_TEST_JSON]"
 
 #define SERVICE_CMD_HARD_REBOOT "hard_reboot"
 #define SERVICE_CMD_GRACEFUL_SHUTDOWN "graceful_shutdown"

--- a/code/datums/helper_datums/getrev.dm
+++ b/code/datums/helper_datums/getrev.dm
@@ -12,7 +12,8 @@
 			file_name = SERVICE_PR_TEST_JSON_OLD
 		else
 			file_name = SERVICE_PR_TEST_JSON
-		testmerge = json_decode(file2text(SERVICE_PR_TEST_JSON))
+		if(fexists(file_name))
+			testmerge = json_decode(file2text(file_name))
 #ifdef SERVERTOOLS
 	else if(!world.RunningService() && fexists("../prtestjob.lk"))	//tgs2 support
 		var/list/tmp = world.file2list("..\\prtestjob.lk")

--- a/code/datums/helper_datums/getrev.dm
+++ b/code/datums/helper_datums/getrev.dm
@@ -6,7 +6,12 @@
 	var/date
 
 /datum/getrev/New()
-	if(world.RunningService() && fexists(SERVICE_PR_TEST_JSON))
+	if(world.RunningService())
+		var/file_name
+		if(ServiceVersion())	//will return null for versions < 3.0.91.0
+			file_name = SERVICE_PR_TEST_JSON_OLD
+		else
+			file_name = SERVICE_PR_TEST_JSON
 		testmerge = json_decode(file2text(SERVICE_PR_TEST_JSON))
 #ifdef SERVERTOOLS
 	else if(!world.RunningService() && fexists("../prtestjob.lk"))	//tgs2 support

--- a/code/modules/server_tools/server_tools.dm
+++ b/code/modules/server_tools/server_tools.dm
@@ -4,6 +4,10 @@ GLOBAL_PROTECT(reboot_mode)
 /world/proc/RunningService()
 	return params[SERVICE_WORLD_PARAM]
 
+/proc/ServiceVersion()
+	if(world.RunningService())
+		return world.params[SERVICE_VERSION_PARAM]
+
 /world/proc/ExportService(command)
 	return RunningService() && shell("python code/modules/server_tools/nudge.py \"[command]\"") == 0
 


### PR DESCRIPTION
Sister PRs:

https://github.com/tgstation/tgstation-server/pull/146
https://github.com/tgstation/tgstation-server/pull/144

Prevents an issue where if the scratch repository's PRs aren't in sync with the servers the testmerge display will be incorrect