### PR TITLE
Alt clicking on doors sends the AI a request link to open it

### DIFF
--- a/code/game/machinery/doors/airlock.dm
+++ b/code/game/machinery/doors/airlock.dm
@@ -1625,7 +1625,7 @@
 	for(var/mob/living/silicon/ai/AI in GLOB.living_mob_list)
 		if(!AI.client)
 			continue
-		to_chat(AI, "<span class='info'>[user.name] is requesting you to open [src]<a href='?src=\ref[AI];remotedoor=\ref[src]'>(Open)</a></span>)
+		to_chat(AI, "<span class='info'>[user.name] is requesting you to open [src]<a href='?src=\ref[AI];remotedoor=\ref[src]'>(Open)</a></span>")
 	request_cooldown = world.time + 100
 	to_chat(user, "<span class='info'>Request sent.</span>")
 

--- a/code/game/machinery/doors/airlock.dm
+++ b/code/game/machinery/doors/airlock.dm
@@ -1607,27 +1607,27 @@
 
 /obj/machinery/door/airlock/AltClick(mob/living/user)
 	if(!istype(user))
-		user << "<span class='info'>Nice try, ghosts.</span>"
+		to_chat(user, "<span class='info'>Nice try, ghosts.</span>")
 		return
 
 	if (!user.canUseTopic(src))
-		user << "<span class='info'>You can't do this right now!</span>"
+		to_chat(user, "<span class='info'>You can't do this right now!</span>")
 		return
 
 	if(stat & (NOPOWER|BROKEN) || emagged)
-		user << "<span class='info'>The door isn't working!</span>"
+		to_chat(user, "<span class='info'>The door isn't working!</span>")
 		return
 
 	if(request_cooldown > world.time)
-		user << "<span class='info'>The airlocks spam filter is blocking your request. Please wait at least 10 seconds between requests.</span>"
+		to_chat(user, "<span class='info'>The airlocks spam filter is blocking your request. Please wait at least 10 seconds between requests.</span>")
 		return
 
 	for(var/mob/living/silicon/ai/AI in GLOB.living_mob_list)
 		if(!AI.client)
 			continue
-		AI << "<span class='info'>[user.name] is requesting you to open [src]<a href='?src=\ref[AI];remotedoor=\ref[src]'>(Open)</a></span>"
+		to_chat(AI, "<span class='info'>[user.name] is requesting you to open [src]<a href='?src=\ref[AI];remotedoor=\ref[src]'>(Open)</a></span>)
 	request_cooldown = world.time + 100
-	user << "<span class='info'>Request sent.</span>"
+	to_chat(user, "<span class='info'>Request sent.</span>")
 
 #undef AIRLOCK_CLOSED
 #undef AIRLOCK_CLOSING

--- a/code/modules/mob/living/silicon/ai/ai.dm
+++ b/code/modules/mob/living/silicon/ai/ai.dm
@@ -396,9 +396,9 @@
 		if(stat == CONSCIOUS)
 			if(A && near_camera(A))
 				A.AIShiftClick(src)
-				src << "<span class='notice'>[A] opened.</span>"
+				to_chat(src, "<span class='notice'>[A] opened.</span>")
 			else
-				src << "<span class='notice'>Unable to locate airlock. It may be out of camera range.</span>"
+				to_chat(src, "<span class='notice'>Unable to locate airlock. It may be out of camera range.</span>")
 
 	if(href_list["track"])
 		var/string = href_list["track"]

--- a/code/modules/mob/living/silicon/ai/ai.dm
+++ b/code/modules/mob/living/silicon/ai/ai.dm
@@ -390,6 +390,16 @@
 				H.attack_ai(src) //may as well recycle
 			else
 				to_chat(src, "<span class='notice'>Unable to locate the holopad.</span>")
+
+	if(href_list["remotedoor"])
+		var/obj/machinery/door/airlock/A = locate(href_list["remotedoor"])
+		if(stat == CONSCIOUS)
+			if(A && near_camera(A))
+				A.AIShiftClick(src)
+				src << "<span class='notice'>[A] opened.</span>"
+			else
+				src << "<span class='notice'>Unable to locate airlock. It may be out of camera range.</span>"
+
 	if(href_list["track"])
 		var/string = href_list["track"]
 		trackable_mobs()


### PR DESCRIPTION
:cl: Kor
rscadd: Alt+clicking on an airlock will now send a request to the AI to open it. The door must be on camera for this to work.
/:cl:

Alt+click on a door will send the AI a notice with the doors name, and the name (not real name, so disguises will work here) of the person requesting the door. Clicking the link will open the door.

There is a 10 second cooldown on each door to stop request spam.

The door must be near cameras, or the AI can not open it.

Reasoning: Opening doors is annoying busy work, it tends to generate a bunch of complaints when an AI is swamped (its not listening to me!), etc, and it'd be nice if you could let the clown into EVA and the scientist into tech storage without taking your eyes away from the murder.