### PR TITLE
Makes the shuttle code a little bit more robust by removing a snowflake loop

### DIFF
--- a/code/__DEFINES/shuttles.dm
+++ b/code/__DEFINES/shuttles.dm
@@ -59,3 +59,8 @@
 #define DOCKING_BLOCKED 2
 #define DOCKING_IMMOBILIZED 4
 #define DOCKING_AREA_EMPTY 8
+
+//Docking turf movements
+#define MOVE_TURF 1
+#define MOVE_AREA 2
+#define MOVE_CONTENTS 4

--- a/code/modules/shuttle/on_move.dm
+++ b/code/modules/shuttle/on_move.dm
@@ -75,9 +75,9 @@ All ShuttleMove procs go here
 /////////////////////////////////////////////////////////////////////////////////////
 
 // Called on every atom in shuttle turf contents before anything has been moved
-// Return true if it should be moved regardless of turf being moved
-/atom/movable/proc/beforeShuttleMove(turf/newT, rotation)
-	return FALSE
+// returns the new move_mode (based on the old)
+/atom/movable/proc/beforeShuttleMove(turf/newT, rotation, move_mode)
+	return move_mode
 
 // Called on atoms to move the atom to the new location
 /atom/movable/proc/onShuttleMove(turf/newT, turf/oldT, rotation, list/movement_force, move_dir, old_dock)
@@ -122,7 +122,7 @@ All ShuttleMove procs go here
 
 	var/area/old_dest_area = newT.loc
 	parallax_movedir = old_dest_area.parallax_movedir
-	
+
 	old_dest_area.contents -= newT
 	contents += newT
 	newT.change_area(old_dest_area, src)
@@ -165,9 +165,11 @@ All ShuttleMove procs go here
 	SSair.add_to_active(src, TRUE)
 	SSair.add_to_active(oldT, TRUE)
 
+/************************************Area move procs************************************/
+
 /************************************Machinery move procs************************************/
 
-/obj/machinery/door/airlock/beforeShuttleMove(turf/newT, rotation)
+/obj/machinery/door/airlock/beforeShuttleMove(turf/newT, rotation, move_mode)
 	. = ..()
 	shuttledocked = 0
 	for(var/obj/machinery/door/airlock/A in range(1, src))
@@ -181,11 +183,11 @@ All ShuttleMove procs go here
 	for(var/obj/machinery/door/airlock/A in range(1, src))
 		A.shuttledocked = 1
 
-/obj/machinery/camera/beforeShuttleMove(turf/newT, rotation)
+/obj/machinery/camera/beforeShuttleMove(turf/newT, rotation, move_mode)
 	. = ..()
 	GLOB.cameranet.removeCamera(src)
 	GLOB.cameranet.updateChunk()
-	return TRUE
+	. |= MOVE_CONTENTS
 
 /obj/machinery/camera/afterShuttleMove(list/movement_force, shuttle_dir, shuttle_preferred_direction, move_dir)
 	. = ..()
@@ -212,7 +214,7 @@ All ShuttleMove procs go here
 	if(z == ZLEVEL_MINING) //Avoids double logging and landing on other Z-levels due to badminnery
 		SSblackbox.add_details("colonies_dropped", "[x]|[y]|[z]") //Number of times a base has been dropped!
 
-/obj/machinery/gravity_generator/main/beforeShuttleMove(turf/newT, rotation)
+/obj/machinery/gravity_generator/main/beforeShuttleMove(turf/newT, rotation, move_mode)
 	. = ..()
 	on = FALSE
 	update_list()
@@ -223,9 +225,9 @@ All ShuttleMove procs go here
 		on = TRUE
 	update_list()
 
-/obj/machinery/thruster/beforeShuttleMove(turf/newT, rotation)
+/obj/machinery/thruster/beforeShuttleMove(turf/newT, rotation, move_mode)
 	. = ..()
-	. = TRUE
+	. |= MOVE_CONTENTS
 
 //Properly updates pipes on shuttle movement
 /obj/machinery/atmospherics/shuttleRotate(rotation)
@@ -276,7 +278,7 @@ All ShuttleMove procs go here
 	var/turf/T = loc
 	hide(T.intact)
 
-/obj/machinery/navbeacon/beforeShuttleMove(turf/newT, rotation)
+/obj/machinery/navbeacon/beforeShuttleMove(turf/newT, rotation, move_mode)
 	. = ..()
 	GLOB.navbeacons["[z]"] -= src
 	GLOB.deliverybeacons -= src
@@ -338,13 +340,13 @@ All ShuttleMove procs go here
 
 /************************************Structure move procs************************************/
 
-/obj/structure/grille/beforeShuttleMove(turf/newT, rotation)
+/obj/structure/grille/beforeShuttleMove(turf/newT, rotation, move_mode)
 	. = ..()
-	. = TRUE
+	. |= MOVE_CONTENTS
 
-/obj/structure/lattice/beforeShuttleMove(turf/newT, rotation)
+/obj/structure/lattice/beforeShuttleMove(turf/newT, rotation, move_mode)
 	. = ..()
-	. = TRUE
+	. |= MOVE_CONTENTS
 
 /obj/structure/disposalpipe/afterShuttleMove(list/movement_force, shuttle_dir, shuttle_preferred_direction, move_dir)
 	. = ..()
@@ -355,6 +357,11 @@ All ShuttleMove procs go here
 	var/turf/T = loc
 	if(level==1)
 		hide(T.intact)
+		
+/obj/structure/shuttle/beforeShuttleMove(turf/newT, rotation, move_mode)
+	. = ..()
+	. |= MOVE_CONTENTS
+
 
 /************************************Misc move procs************************************/
 


### PR DESCRIPTION
:cl: ninjanomnom
fix: Fixed a problem with shuttles being unrepairable under certain circumstances.
/:cl:

Tweaked the shuttleMove procs to get rid of the snowflake loops dealing with only moving contents of a turf. Should be better now but I probably missed something so testmerge this first.