### PR TITLE
Decreases hacked ai module cost 

### DIFF
--- a/code/modules/uplink/uplink_item.dm
+++ b/code/modules/uplink/uplink_item.dm
@@ -970,7 +970,7 @@ GLOBAL_LIST_EMPTY(uplink_items) // Global list so we only initialize this once.
 	desc = "When used with an upload console, this module allows you to upload priority laws to an artificial intelligence. \
 			Be careful with wording, as artificial intelligences may look for loopholes to exploit."
 	item = /obj/item/aiModule/syndicate
-	cost = 14
+	cost = 9
 
 /datum/uplink_item/device_tools/briefcase_launchpad
 	name = "Briefcase Launchpad"


### PR DESCRIPTION
The cost of the hacked ai module was determined when:

There were still secborgs
camera's were hard to disable
The ai couldn't be a traitor as well and fuck you over
RCD's weren't everywhere
There weren't a bazillion tools to fight fires
Uploads weren't in impenetrable ai satellite fortresses
There were no door remotes
There were no instant access tools like jaws of life
And there weren't a multitude of other small powercreeps that reduced the influence of the AI.

The cost of the hacked AI module stayed the same. Now nobody bothers subverting the AI any more, so it is time to reduce the hacked ai module cost to reflect the new reality we are in.


:cl: 
balance: Hacked AI module cost is reduced to 9TC
/:cl:


