### PR TITLE
Hit a teleport beacon with a DRAGnet to set the teleport destination

### DIFF
--- a/code/game/objects/items/devices/radio/beacon.dm
+++ b/code/game/objects/items/devices/radio/beacon.dm
@@ -41,3 +41,9 @@
 /obj/item/device/radio/beacon/bacon/proc/digest_delay()
 	spawn(600)
 		qdel(src)*/ //Bacon beacons are no more rip in peace
+
+/obj/item/device/radio/beacon/attackby(obj/item/W, mob/user)
+	..()
+	if(istype(W, /obj/item/gun/energy/e_gun/dragnet))
+		var/obj/item/gun/energy/e_gun/dragnet/D = W
+		D.set_target(src, user)

--- a/code/game/objects/items/devices/radio/beacon.dm
+++ b/code/game/objects/items/devices/radio/beacon.dm
@@ -43,7 +43,7 @@
 		qdel(src)*/ //Bacon beacons are no more rip in peace
 
 /obj/item/device/radio/beacon/attackby(obj/item/W, mob/user)
-	..()
 	if(istype(W, /obj/item/gun/energy/e_gun/dragnet))
 		var/obj/item/gun/energy/e_gun/dragnet/D = W
 		D.set_target(src, user)
+	return ..()

--- a/code/modules/projectiles/ammunition/energy.dm
+++ b/code/modules/projectiles/ammunition/energy.dm
@@ -185,8 +185,9 @@
 	variance = 40
 	var/obj/item/gun/energy/e_gun/dragnet/drag
 
-/obj/item/ammo_casing/energy/net/New(var/obj/item/gun/energy/e_gun/dragnet/D)
-	drag = D
+/obj/item/ammo_casing/energy/net/Initialize(var/obj/item/gun/energy/e_gun/dragnet)
+	. = ..()
+	drag = loc
 
 /obj/item/ammo_casing/energy/trap
 	projectile_type = /obj/item/projectile/energy/trap

--- a/code/modules/projectiles/ammunition/energy.dm
+++ b/code/modules/projectiles/ammunition/energy.dm
@@ -183,6 +183,10 @@
 	select_name = "netting"
 	pellets = 6
 	variance = 40
+	var/obj/item/gun/energy/e_gun/dragnet/drag
+
+/obj/item/ammo_casing/energy/net/New(var/obj/item/gun/energy/e_gun/dragnet/D)
+	drag = D
 
 /obj/item/ammo_casing/energy/trap
 	projectile_type = /obj/item/projectile/energy/trap

--- a/code/modules/projectiles/ammunition/energy.dm
+++ b/code/modules/projectiles/ammunition/energy.dm
@@ -185,7 +185,7 @@
 	variance = 40
 	var/obj/item/gun/energy/e_gun/dragnet/drag
 
-/obj/item/ammo_casing/energy/net/Initialize(var/obj/item/gun/energy/e_gun/dragnet)
+/obj/item/ammo_casing/energy/net/Initialize()
 	. = ..()
 	drag = loc
 

--- a/code/modules/projectiles/ammunition/energy.dm
+++ b/code/modules/projectiles/ammunition/energy.dm
@@ -186,8 +186,11 @@
 	var/obj/item/gun/energy/e_gun/dragnet/drag
 
 /obj/item/ammo_casing/energy/net/Initialize()
-	. = ..()
+	.=..()
 	drag = loc
+	if(!istype(drag))
+    	. = INITIALIZE_HINT_QDEL
+    	CRASH("Energy net created outside of dragnet")
 
 /obj/item/ammo_casing/energy/trap
 	projectile_type = /obj/item/projectile/energy/trap

--- a/code/modules/projectiles/ammunition/energy.dm
+++ b/code/modules/projectiles/ammunition/energy.dm
@@ -189,8 +189,8 @@
 	.=..()
 	drag = loc
 	if(!istype(drag))
-    	. = INITIALIZE_HINT_QDEL
-    	CRASH("Energy net created outside of dragnet")
+		. = INITIALIZE_HINT_QDEL
+		CRASH("Energy net created outside of dragnet")
 
 /obj/item/ammo_casing/energy/trap
 	projectile_type = /obj/item/projectile/energy/trap

--- a/code/modules/projectiles/guns/energy/energy_gun.dm
+++ b/code/modules/projectiles/guns/energy/energy_gun.dm
@@ -74,16 +74,18 @@
 	ammo_x_offset = 1
 	var/obj/item/device/radio/beacon/guntarget
 
-/obj/item/gun/energy/e_gun/dragnet/proc/set_target(target, user)
+/obj/item/gun/energy/e_gun/dragnet/proc/set_target(target, user)//called on beacon's attackby()
 	guntarget = target
 	to_chat(user, "<span class='notice'>[src] has locked onto [guntarget].</span>")
+	//qdel(chambered)
+	//recharge_newshot()
 
 /obj/item/gun/energy/e_gun/dragnet/examine(mob/user)
 	..()
 	if(guntarget)
 		to_chat(user, "<span class='notice'>[src] has locked onto [guntarget].</span>")//improve this
 
-/obj/item/gun/energy/e_gun/dragnet/process_fire()
+/*/obj/item/gun/energy/e_gun/dragnet/process_fire()
 	if(guntarget)//the code should work without this If, but It's against my principles to remove it
 		if(istype(chambered, /obj/item/ammo_casing/energy/net) && chambered.BB)
 			var/obj/item/ammo_casing/energy/net/C = chambered
@@ -92,7 +94,7 @@
 				var/obj/item/projectile/energy/net/B = C.BB
 				B.projtarget = guntarget
 				to_chat(world, "process fire: [B.projtarget]")//debug
-	..()
+	..()*/
 
 /obj/item/gun/energy/e_gun/dragnet/snare
 	name = "Energy Snare Launcher"

--- a/code/modules/projectiles/guns/energy/energy_gun.dm
+++ b/code/modules/projectiles/guns/energy/energy_gun.dm
@@ -63,7 +63,7 @@
 
 /obj/item/gun/energy/e_gun/dragnet
 	name = "\improper DRAGnet"
-	desc = "The \"Dynamic Rapid-Apprehension of the Guilty\" net is a revolution in law enforcement technology."
+	desc = "The \"Dynamic Rapid-Apprehension of the Guilty\" net is a revolution in law enforcement technology. Hit a teleport beacon with it to set the bluespace net teleport destination."
 	icon_state = "dragnet"
 	item_state = "dragnet"
 	lefthand_file = 'icons/mob/inhands/weapons/guns_lefthand.dmi'
@@ -72,6 +72,25 @@
 	ammo_type = list(/obj/item/ammo_casing/energy/net, /obj/item/ammo_casing/energy/trap)
 	can_flashlight = 0
 	ammo_x_offset = 1
+	var/teletarget
+
+/obj/item/gun/energy/e_gun/dragnet/proc/set_target(target, user)
+	teletarget = target
+	to_chat(user, "<span class='notice'>[src] has locked onto [target].</span>")
+
+/obj/item/gun/energy/e_gun/dragnet/examine(mob/user)
+	..()
+	if(teletarget)
+		to_chat(user, "<span class='notice'>[src] has locked onto [teletarget].</span>")
+
+/obj/item/gun/energy/e_gun/dragnet/process_fire()
+	..()
+	if(istype(chambered, /obj/item/ammo_casing/energy/net) && chambered.BB)
+		var/obj/item/ammo_casing/energy/net/C = chambered
+
+		if(istype(C.BB, /obj/item/projectile/energy/net))
+			var/obj/item/projectile/energy/net/B = C.BB
+			B.teletarget = teletarget
 
 /obj/item/gun/energy/e_gun/dragnet/snare
 	name = "Energy Snare Launcher"

--- a/code/modules/projectiles/guns/energy/energy_gun.dm
+++ b/code/modules/projectiles/guns/energy/energy_gun.dm
@@ -77,7 +77,11 @@
 /obj/item/gun/energy/e_gun/dragnet/proc/set_target(target, user)//called on beacon's attackby()
 	guntarget = target
 	to_chat(user, "<span class='notice'>[src] has locked onto [guntarget].</span>")
-	chambered.BB.set_projtarget()
+
+	var/obj/item/ammo_casing/energy/net/C = chambered
+	var/obj/item/projectile/energy/net/B = C.BB
+	if(istype(C) && istype(B))
+		C.B.set_projtarget()
 
 /obj/item/gun/energy/e_gun/dragnet/examine(mob/user)
 	..()

--- a/code/modules/projectiles/guns/energy/energy_gun.dm
+++ b/code/modules/projectiles/guns/energy/energy_gun.dm
@@ -91,7 +91,7 @@
 			if(istype(C.BB, /obj/item/projectile/energy/net))
 				var/obj/item/projectile/energy/net/B = C.BB
 				B.projtarget = guntarget
-				to_chat(world, "process fire: [B.teletarget]")//debug
+				to_chat(world, "process fire: [B.projtarget]")//debug
 	..()
 
 /obj/item/gun/energy/e_gun/dragnet/snare

--- a/code/modules/projectiles/guns/energy/energy_gun.dm
+++ b/code/modules/projectiles/guns/energy/energy_gun.dm
@@ -78,8 +78,9 @@
 	guntarget = target
 	to_chat(user, "<span class='notice'>[src] has locked onto [guntarget].</span>")
 
-	if(chambered && chambered.BB)
-		chambered.BB.set_projtarget()
+	var/obj/item/projectile/energy/net/MEME = chambered.BB
+
+	MEME.set_projtarget()
 
 /obj/item/gun/energy/e_gun/dragnet/examine(mob/user)
 	..()

--- a/code/modules/projectiles/guns/energy/energy_gun.dm
+++ b/code/modules/projectiles/guns/energy/energy_gun.dm
@@ -72,26 +72,27 @@
 	ammo_type = list(/obj/item/ammo_casing/energy/net, /obj/item/ammo_casing/energy/trap)
 	can_flashlight = 0
 	ammo_x_offset = 1
-	var/obj/item/device/radio/beacon/teletarget
+	var/obj/item/device/radio/beacon/guntarget
 
 /obj/item/gun/energy/e_gun/dragnet/proc/set_target(target, user)
-	src.teletarget = target
-	to_chat(user, "<span class='notice'>[src] has locked onto [target].</span>")
+	guntarget = target
+	to_chat(user, "<span class='notice'>[src] has locked onto [guntarget].</span>")
 
 /obj/item/gun/energy/e_gun/dragnet/examine(mob/user)
 	..()
-	if(src.teletarget)
-		to_chat(user, "<span class='notice'>[src] has locked onto [teletarget].</span>")
+	if(guntarget)
+		to_chat(user, "<span class='notice'>[src] has locked onto [guntarget].</span>")//improve this
 
 /obj/item/gun/energy/e_gun/dragnet/process_fire()
-	..()
-	if(istype(chambered, /obj/item/ammo_casing/energy/net) && chambered.BB)
-		var/obj/item/ammo_casing/energy/net/C = chambered
+	if(guntarget)//the code should work without this If, but It's against my principles to remove it
+		if(istype(chambered, /obj/item/ammo_casing/energy/net) && chambered.BB)
+			var/obj/item/ammo_casing/energy/net/C = chambered
 
-		if(istype(C.BB, /obj/item/projectile/energy/net))
-			var/obj/item/projectile/energy/net/B = C.BB
-			B.teletarget = src.teletarget
-			to_chat(world, "process fire: [B.teletarget]")
+			if(istype(C.BB, /obj/item/projectile/energy/net))
+				var/obj/item/projectile/energy/net/B = C.BB
+				B.teletarget = guntarget
+				to_chat(world, "process fire: [B.teletarget]")//debug
+	..()
 
 /obj/item/gun/energy/e_gun/dragnet/snare
 	name = "Energy Snare Launcher"

--- a/code/modules/projectiles/guns/energy/energy_gun.dm
+++ b/code/modules/projectiles/guns/energy/energy_gun.dm
@@ -91,6 +91,7 @@
 		if(istype(C.BB, /obj/item/projectile/energy/net))
 			var/obj/item/projectile/energy/net/B = C.BB
 			B.teletarget = teletarget
+			to_chat(world, "process fire: [B.teletarget]")
 
 /obj/item/gun/energy/e_gun/dragnet/snare
 	name = "Energy Snare Launcher"

--- a/code/modules/projectiles/guns/energy/energy_gun.dm
+++ b/code/modules/projectiles/guns/energy/energy_gun.dm
@@ -90,7 +90,7 @@
 
 			if(istype(C.BB, /obj/item/projectile/energy/net))
 				var/obj/item/projectile/energy/net/B = C.BB
-				B.teletarget = guntarget
+				B.projtarget = guntarget
 				to_chat(world, "process fire: [B.teletarget]")//debug
 	..()
 

--- a/code/modules/projectiles/guns/energy/energy_gun.dm
+++ b/code/modules/projectiles/guns/energy/energy_gun.dm
@@ -78,10 +78,8 @@
 	guntarget = target
 	to_chat(user, "<span class='notice'>[src] has locked onto [guntarget].</span>")
 
-	var/obj/item/ammo_casing/energy/net/C = chambered
-	var/obj/item/projectile/energy/net/B = C.BB
-	if(istype(C) && istype(B))
-		C.B.set_projtarget()
+	if(chambered && chambered.BB)
+		chambered.BB.set_projtarget()
 
 /obj/item/gun/energy/e_gun/dragnet/examine(mob/user)
 	..()

--- a/code/modules/projectiles/guns/energy/energy_gun.dm
+++ b/code/modules/projectiles/guns/energy/energy_gun.dm
@@ -85,7 +85,7 @@
 /obj/item/gun/energy/e_gun/dragnet/examine(mob/user)
 	..()
 	if(guntarget)
-		to_chat(user, "<span class='notice'>[src] has locked onto [guntarget].</span>")//improve this
+		to_chat(user, "<span class='notice'>[src] has locked onto [guntarget].</span>")
 
 /obj/item/gun/energy/e_gun/dragnet/snare
 	name = "Energy Snare Launcher"

--- a/code/modules/projectiles/guns/energy/energy_gun.dm
+++ b/code/modules/projectiles/guns/energy/energy_gun.dm
@@ -72,15 +72,15 @@
 	ammo_type = list(/obj/item/ammo_casing/energy/net, /obj/item/ammo_casing/energy/trap)
 	can_flashlight = 0
 	ammo_x_offset = 1
-	var/teletarget
+	var/obj/item/device/radio/beacon/teletarget
 
 /obj/item/gun/energy/e_gun/dragnet/proc/set_target(target, user)
-	teletarget = target
+	src.teletarget = target
 	to_chat(user, "<span class='notice'>[src] has locked onto [target].</span>")
 
 /obj/item/gun/energy/e_gun/dragnet/examine(mob/user)
 	..()
-	if(teletarget)
+	if(src.teletarget)
 		to_chat(user, "<span class='notice'>[src] has locked onto [teletarget].</span>")
 
 /obj/item/gun/energy/e_gun/dragnet/process_fire()
@@ -90,7 +90,7 @@
 
 		if(istype(C.BB, /obj/item/projectile/energy/net))
 			var/obj/item/projectile/energy/net/B = C.BB
-			B.teletarget = teletarget
+			B.teletarget = src.teletarget
 			to_chat(world, "process fire: [B.teletarget]")
 
 /obj/item/gun/energy/e_gun/dragnet/snare

--- a/code/modules/projectiles/guns/energy/energy_gun.dm
+++ b/code/modules/projectiles/guns/energy/energy_gun.dm
@@ -77,24 +77,12 @@
 /obj/item/gun/energy/e_gun/dragnet/proc/set_target(target, user)//called on beacon's attackby()
 	guntarget = target
 	to_chat(user, "<span class='notice'>[src] has locked onto [guntarget].</span>")
-	//qdel(chambered)
-	//recharge_newshot()
+	chambered.BB.set_projtarget()
 
 /obj/item/gun/energy/e_gun/dragnet/examine(mob/user)
 	..()
 	if(guntarget)
 		to_chat(user, "<span class='notice'>[src] has locked onto [guntarget].</span>")//improve this
-
-/*/obj/item/gun/energy/e_gun/dragnet/process_fire()
-	if(guntarget)//the code should work without this If, but It's against my principles to remove it
-		if(istype(chambered, /obj/item/ammo_casing/energy/net) && chambered.BB)
-			var/obj/item/ammo_casing/energy/net/C = chambered
-
-			if(istype(C.BB, /obj/item/projectile/energy/net))
-				var/obj/item/projectile/energy/net/B = C.BB
-				B.projtarget = guntarget
-				to_chat(world, "process fire: [B.projtarget]")//debug
-	..()*/
 
 /obj/item/gun/energy/e_gun/dragnet/snare
 	name = "Energy Snare Launcher"

--- a/code/modules/projectiles/projectile/energy.dm
+++ b/code/modules/projectiles/projectile/energy.dm
@@ -80,9 +80,9 @@
 /obj/effect/nettingportal/Initialize()
 	. = ..()
 
-	addtimer(CALLBACK(src, .proc/pop, teletarget), 30)
+	addtimer(CALLBACK(src, .proc/pop), 30)
 
-/obj/effect/nettingportal/proc/pop(teletarget)
+/obj/effect/nettingportal/proc/pop()
 	to_chat(world, "pop: [teletarget]")//debug
 	if(teletarget)
 		var/TT = get_turf(teletarget)

--- a/code/modules/projectiles/projectile/energy.dm
+++ b/code/modules/projectiles/projectile/energy.dm
@@ -42,7 +42,7 @@
 	damage_type = STAMINA
 	hitsound = 'sound/weapons/taserhit.ogg'
 	range = 10
-	var/teletarget
+	var/obj/item/device/radio/beacon/teletarget
 
 /obj/item/projectile/energy/net/Initialize()
 	. = ..()
@@ -53,7 +53,7 @@
 		var/turf/Tloc = get_turf(target)
 		if(!locate(/obj/effect/nettingportal) in Tloc)
 			var/obj/effect/nettingportal/portal = new /obj/effect/nettingportal(Tloc)
-			portal.teletarget = teletarget
+			portal.teletarget = src.teletarget
 			to_chat(world, "on hit:[portal.teletarget]")
 	..()
 

--- a/code/modules/projectiles/projectile/energy.dm
+++ b/code/modules/projectiles/projectile/energy.dm
@@ -47,12 +47,16 @@
 /obj/item/projectile/energy/net/Initialize()
 	. = ..()
 	SpinAnimation()
+	var/obj/item/ammo_casing/energy/net/N = loc
+	if(istype(N))
+		projtarget = N.drag.guntarget
 
 /obj/item/projectile/energy/net/on_hit(atom/target, blocked = FALSE)
 	if(isliving(target))
 		var/turf/Tloc = get_turf(target)
 		if(!locate(/obj/effect/nettingportal) in Tloc)
-			new /obj/effect/nettingportal(loc = Tloc, target = projtarget)
+			var/obj/effect/nettingportal/NP = new /obj/effect/nettingportal(Tloc)
+			NP.teletarget = projtarget
 	..()
 
 /obj/item/projectile/energy/net/on_range()
@@ -68,10 +72,9 @@
 	anchored = TRUE
 	var/obj/item/device/radio/beacon/teletarget
 
-/obj/effect/nettingportal/Initialize(target)
+/obj/effect/nettingportal/Initialize()//might need to make loc an arg and set loc in init
 	. = ..()
 
-	teletarget = target
 	addtimer(CALLBACK(src, .proc/pop, teletarget), 30)
 
 /obj/effect/nettingportal/proc/pop(teletarget)

--- a/code/modules/projectiles/projectile/energy.dm
+++ b/code/modules/projectiles/projectile/energy.dm
@@ -62,6 +62,7 @@
 
 /obj/item/projectile/energy/net/on_range()
 	do_sparks(1, TRUE, src)
+	to_chat(world, "on_range() triggered")//pls dont lag me lmao
 	..()
 
 /obj/effect/nettingportal

--- a/code/modules/projectiles/projectile/energy.dm
+++ b/code/modules/projectiles/projectile/energy.dm
@@ -53,7 +53,6 @@
 	var/obj/item/ammo_casing/energy/net/N = loc
 	if(istype(N))
 		projtarget = N.drag.guntarget
-		to_chat(world, "proj target: [projtarget]")//debug
 
 /obj/item/projectile/energy/net/on_hit(atom/target, blocked = FALSE)
 	if(isliving(target))
@@ -65,7 +64,6 @@
 
 /obj/item/projectile/energy/net/on_range()
 	do_sparks(1, TRUE, src)
-	to_chat(world, "on_range() triggered")//pls dont lag me lmao
 	..()
 
 /obj/effect/nettingportal
@@ -83,11 +81,10 @@
 	addtimer(CALLBACK(src, .proc/pop), 30)
 
 /obj/effect/nettingportal/proc/pop()
-	to_chat(world, "pop: [teletarget]")//debug
 	if(teletarget)
 		var/TT = get_turf(teletarget)
 		for(var/mob/living/L in get_turf(src))
-			do_teleport(L, TT, 2)//teleport what's in the tile to the beacon
+			do_teleport(L, TT, 1)//teleport what's in the tile to the beacon
 	else
 		for(var/mob/living/L in get_turf(src))
 			do_teleport(L, L, 15) //Otherwise it just warps you off somewhere.

--- a/code/modules/projectiles/projectile/energy.dm
+++ b/code/modules/projectiles/projectile/energy.dm
@@ -82,8 +82,9 @@
 /obj/effect/nettingportal/proc/pop(teletarget)
 	to_chat(world, "pop: [teletarget]")//debug
 	if(teletarget)
+		var/TT = get_turf(teletarget)
 		for(var/mob/living/L in get_turf(src))
-			do_teleport(L, get_turf(teletarget), 2)//teleport what's in the tile to the beacon
+			do_teleport(L, TT, 2)//teleport what's in the tile to the beacon
 	else
 		for(var/mob/living/L in get_turf(src))
 			do_teleport(L, L, 15) //Otherwise it just warps you off somewhere.

--- a/code/modules/projectiles/projectile/energy.dm
+++ b/code/modules/projectiles/projectile/energy.dm
@@ -54,6 +54,7 @@
 		if(!locate(/obj/effect/nettingportal) in Tloc)
 			var/obj/effect/nettingportal/portal = new /obj/effect/nettingportal(Tloc)
 			portal.teletarget = teletarget
+			to_chat(world, "on hit:[portal.teletarget]")
 	..()
 
 /obj/item/projectile/energy/net/on_range()
@@ -67,13 +68,14 @@
 	icon_state = "dragnetfield"
 	light_range = 3
 	anchored = TRUE
-	var/teletarget
+	var/obj/item/device/radio/beacon/teletarget
 
 /obj/effect/nettingportal/Initialize()
 	. = ..()
 	addtimer(CALLBACK(src, .proc/pop, teletarget), 30)
 
 /obj/effect/nettingportal/proc/pop(teletarget)
+	to_chat(world, "pop: [teletarget]")
 	if(teletarget)
 		for(var/mob/living/L in get_turf(src))
 			do_teleport(L, teletarget, 2)//teleport what's in the tile to the beacon

--- a/code/modules/projectiles/projectile/energy.dm
+++ b/code/modules/projectiles/projectile/energy.dm
@@ -59,7 +59,7 @@
 		var/turf/Tloc = get_turf(target)
 		if(!locate(/obj/effect/nettingportal) in Tloc)
 			var/obj/effect/nettingportal/NP = new /obj/effect/nettingportal(Tloc)
-			NP.teletarget = projtarget //if this doesnt work try doing it by passing src as an arg to the nettingportal and doing it all in init
+			NP.teletarget = projtarget
 	..()
 
 /obj/item/projectile/energy/net/on_range()

--- a/code/modules/projectiles/projectile/energy.dm
+++ b/code/modules/projectiles/projectile/energy.dm
@@ -52,7 +52,7 @@
 	if(isliving(target))
 		var/turf/Tloc = get_turf(target)
 		if(!locate(/obj/effect/nettingportal) in Tloc)
-			new /obj/effect/nettingportal(Tloc, target = projtarget)
+			new /obj/effect/nettingportal(loc = Tloc, target = projtarget)
 	..()
 
 /obj/item/projectile/energy/net/on_range()

--- a/code/modules/projectiles/projectile/energy.dm
+++ b/code/modules/projectiles/projectile/energy.dm
@@ -42,6 +42,7 @@
 	damage_type = STAMINA
 	hitsound = 'sound/weapons/taserhit.ogg'
 	range = 10
+	var/teletarget
 
 /obj/item/projectile/energy/net/Initialize()
 	. = ..()
@@ -51,7 +52,8 @@
 	if(isliving(target))
 		var/turf/Tloc = get_turf(target)
 		if(!locate(/obj/effect/nettingportal) in Tloc)
-			new /obj/effect/nettingportal(Tloc)
+			var/obj/effect/nettingportal/portal = new /obj/effect/nettingportal(Tloc)
+			portal.teletarget = teletarget
 	..()
 
 /obj/item/projectile/energy/net/on_range()
@@ -65,15 +67,10 @@
 	icon_state = "dragnetfield"
 	light_range = 3
 	anchored = TRUE
+	var/teletarget
 
 /obj/effect/nettingportal/Initialize()
 	. = ..()
-	var/obj/item/device/radio/beacon/teletarget = null
-	for(var/obj/machinery/computer/teleporter/com in GLOB.machines)
-		if(com.target)
-			if(com.power_station && com.power_station.teleporter_hub && com.power_station.engaged)
-				teletarget = com.target
-
 	addtimer(CALLBACK(src, .proc/pop, teletarget), 30)
 
 /obj/effect/nettingportal/proc/pop(teletarget)

--- a/code/modules/projectiles/projectile/energy.dm
+++ b/code/modules/projectiles/projectile/energy.dm
@@ -50,6 +50,7 @@
 	var/obj/item/ammo_casing/energy/net/N = loc
 	if(istype(N))
 		projtarget = N.drag.guntarget
+		to_chat(world, "proj init: [projtarget]")//debug
 
 /obj/item/projectile/energy/net/on_hit(atom/target, blocked = FALSE)
 	if(isliving(target))

--- a/code/modules/projectiles/projectile/energy.dm
+++ b/code/modules/projectiles/projectile/energy.dm
@@ -53,8 +53,8 @@
 		var/turf/Tloc = get_turf(target)
 		if(!locate(/obj/effect/nettingportal) in Tloc)
 			var/obj/effect/nettingportal/portal = new /obj/effect/nettingportal(Tloc)
-			portal.teletarget = src.teletarget
-			to_chat(world, "on hit:[portal.teletarget]")
+			portal.teletarget = teletarget
+			to_chat(world, "on hit:[portal.teletarget]")//debug
 	..()
 
 /obj/item/projectile/energy/net/on_range()
@@ -75,7 +75,7 @@
 	addtimer(CALLBACK(src, .proc/pop, teletarget), 30)
 
 /obj/effect/nettingportal/proc/pop(teletarget)
-	to_chat(world, "pop: [teletarget]")
+	to_chat(world, "pop: [teletarget]")//debug
 	if(teletarget)
 		for(var/mob/living/L in get_turf(src))
 			do_teleport(L, teletarget, 2)//teleport what's in the tile to the beacon

--- a/code/modules/projectiles/projectile/energy.dm
+++ b/code/modules/projectiles/projectile/energy.dm
@@ -47,17 +47,20 @@
 /obj/item/projectile/energy/net/Initialize()
 	. = ..()
 	SpinAnimation()
+	set_projtarget()
+
+/obj/item/projectile/energy/net/proc/set_projtarget()
 	var/obj/item/ammo_casing/energy/net/N = loc
 	if(istype(N))
 		projtarget = N.drag.guntarget
-		to_chat(world, "proj init: [projtarget]")//debug
+		to_chat(world, "proj target: [projtarget]")//debug
 
 /obj/item/projectile/energy/net/on_hit(atom/target, blocked = FALSE)
 	if(isliving(target))
 		var/turf/Tloc = get_turf(target)
 		if(!locate(/obj/effect/nettingportal) in Tloc)
 			var/obj/effect/nettingportal/NP = new /obj/effect/nettingportal(Tloc)
-			NP.teletarget = projtarget
+			NP.teletarget = projtarget //if this doesnt work try doing it by passing src as an arg to the nettingportal and doing it all in init
 	..()
 
 /obj/item/projectile/energy/net/on_range()
@@ -74,7 +77,7 @@
 	anchored = TRUE
 	var/obj/item/device/radio/beacon/teletarget
 
-/obj/effect/nettingportal/Initialize()//might need to make loc an arg and set loc in init
+/obj/effect/nettingportal/Initialize()
 	. = ..()
 
 	addtimer(CALLBACK(src, .proc/pop, teletarget), 30)

--- a/code/modules/projectiles/projectile/energy.dm
+++ b/code/modules/projectiles/projectile/energy.dm
@@ -42,7 +42,7 @@
 	damage_type = STAMINA
 	hitsound = 'sound/weapons/taserhit.ogg'
 	range = 10
-	var/obj/item/device/radio/beacon/teletarget
+	var/obj/item/device/radio/beacon/projtarget
 
 /obj/item/projectile/energy/net/Initialize()
 	. = ..()
@@ -52,9 +52,7 @@
 	if(isliving(target))
 		var/turf/Tloc = get_turf(target)
 		if(!locate(/obj/effect/nettingportal) in Tloc)
-			var/obj/effect/nettingportal/portal = new /obj/effect/nettingportal(Tloc)
-			portal.teletarget = teletarget
-			to_chat(world, "on hit:[portal.teletarget]")//debug
+			new /obj/effect/nettingportal(Tloc, target = projtarget)
 	..()
 
 /obj/item/projectile/energy/net/on_range()
@@ -70,15 +68,17 @@
 	anchored = TRUE
 	var/obj/item/device/radio/beacon/teletarget
 
-/obj/effect/nettingportal/Initialize()
+/obj/effect/nettingportal/Initialize(target)
 	. = ..()
+
+	teletarget = target
 	addtimer(CALLBACK(src, .proc/pop, teletarget), 30)
 
 /obj/effect/nettingportal/proc/pop(teletarget)
 	to_chat(world, "pop: [teletarget]")//debug
 	if(teletarget)
 		for(var/mob/living/L in get_turf(src))
-			do_teleport(L, teletarget, 2)//teleport what's in the tile to the beacon
+			do_teleport(L, get_turf(teletarget), 2)//teleport what's in the tile to the beacon
 	else
 		for(var/mob/living/L in get_turf(src))
 			do_teleport(L, L, 15) //Otherwise it just warps you off somewhere.

--- a/code/modules/projectiles/projectile/energy.dm
+++ b/code/modules/projectiles/projectile/energy.dm
@@ -58,7 +58,7 @@
 	if(isliving(target))
 		var/turf/Tloc = get_turf(target)
 		if(!locate(/obj/effect/nettingportal) in Tloc)
-			var/obj/effect/nettingportal/NP = new /obj/effect/nettingportal(Tloc)
+			var/obj/effect/nettingportal/NP = new (Tloc)
 			NP.teletarget = projtarget
 	..()
 


### PR DESCRIPTION
:cl: Tacolizard
tweak: DRAGnets no longer use teleport stations to determine their teleport destination. Instead, hit a teleport beacon with the DRAGnet.
tweak: DRAGnets now teleport to within 1 tile of a beacon, instead of 2. This allows you to use standard brig cells as teleportation cells so long as the beacon is placed in the center of the room.
experiment: Reminder: teleport beacons can be purchased in cargo and built in Science with pretty low Bluespace levels.
/:cl:

I haven't coded anything since the beginning of summer, so I apologize for shitcode. I'm mainly doing this to get back into coding here.
