### PR TITLE
Slime people can eat anything again

### DIFF
--- a/code/modules/mob/living/carbon/human/species_types/jellypeople.dm
+++ b/code/modules/mob/living/carbon/human/species_types/jellypeople.dm
@@ -9,8 +9,7 @@
 	exotic_blood = "slimejelly"
 	damage_overlay_type = ""
 	var/datum/action/innate/regenerate_limbs/regenerate_limbs
-	toxic_food = MEAT | DAIRY
-	liked_food = TOXIC
+	liked_food = MEAT
 
 /datum/species/jelly/on_species_loss(mob/living/carbon/C)
 	if(regenerate_limbs)


### PR DESCRIPTION
:cl: Kor
balance: Slime people can consume meat and dairy again.
/:cl:

Why: Their main gimmick is eating as much food as possible, this doesn't work when the most common foodtypes kill them instead. Also normal slimes are carnivorous so it doesn't make sense for them to hate meat.

Closes https://github.com/tgstation/tgstation/issues/29744