### PR TITLE
Increases emag price from 6tc to 10tc

### DIFF
--- a/code/modules/uplink/uplink_item.dm
+++ b/code/modules/uplink/uplink_item.dm
@@ -890,7 +890,7 @@ GLOBAL_LIST_EMPTY(uplink_items) // Global list so we only initialize this once.
 	desc = "The cryptographic sequencer, electromagnetic card, or emag, is a small card that unlocks hidden functions \
 			in electronic devices, subverts intended functions, and easily breaks security mechanisms."
 	item = /obj/item/card/emag
-	cost = 12
+	cost = 10
 	exclude_modes = list(/datum/game_mode/gang)
 
 /datum/uplink_item/device_tools/toolbox

--- a/code/modules/uplink/uplink_item.dm
+++ b/code/modules/uplink/uplink_item.dm
@@ -890,7 +890,7 @@ GLOBAL_LIST_EMPTY(uplink_items) // Global list so we only initialize this once.
 	desc = "The cryptographic sequencer, electromagnetic card, or emag, is a small card that unlocks hidden functions \
 			in electronic devices, subverts intended functions, and easily breaks security mechanisms."
 	item = /obj/item/card/emag
-	cost = 6
+	cost = 12
 	exclude_modes = list(/datum/game_mode/gang)
 
 /datum/uplink_item/device_tools/toolbox


### PR DESCRIPTION
emags have gotten way better and just one of the most bought uplink items in the game, i think it's time to increase its price to a more reasonable one. no this is not an i ded because emags are too cheap and you know that

:cl: Frozenguy5
balance: The emag/Cryptographic Sequencer's price has now increased from 6TC to 10TC
/:cl:

was originally 12tc