### PR TITLE
Revert "Revert "Automatic unbuckle by player moving""

### DIFF
--- a/code/game/objects/structures/beds_chairs/bed.dm
+++ b/code/game/objects/structures/beds_chairs/bed.dm
@@ -37,6 +37,9 @@
 	else
 		return ..()
 
+/obj/structure/bed/relaymove(mob/living/user)
+	user.resist_buckle()
+
 /*
  * Roller beds
  */

--- a/code/game/objects/structures/beds_chairs/chair.dm
+++ b/code/game/objects/structures/beds_chairs/chair.dm
@@ -112,6 +112,9 @@
 	else
 		rotate()
 
+/obj/structure/chair/relaymove(mob/living/user)
+	user.resist_buckle()
+
 // Chair types
 /obj/structure/chair/wood
 	icon_state = "wooden_chair"


### PR DESCRIPTION
Buckle tatics are bullshit and also the only reason this revert happened.

This is open for discussion, so no speed merge pls.

Reverts #30281.