### PR TITLE
Mappers can now set up quantum pads to auto-link

### DIFF
--- a/code/game/machinery/quantum_pad.dm
+++ b/code/game/machinery/quantum_pad.dm
@@ -24,7 +24,7 @@
 /obj/machinery/quantumpad/Initialize()
 	. = ..()
 	if(map_pad_id)
-		mapped_quantum_pads += src
+		mapped_quantum_pads[map_pad_id] = src
 
 /obj/machinery/quantumpad/RefreshParts()
 	var/E = 0

--- a/code/game/machinery/quantum_pad.dm
+++ b/code/game/machinery/quantum_pad.dm
@@ -25,6 +25,10 @@
 	. = ..()
 	if(map_pad_id)
 		mapped_quantum_pads[map_pad_id] = src
+		
+/obj/machinery/quantumpad/Destroy()
+	mapped_quantum_pads -= map_pad_id
+	return ..()
 
 /obj/machinery/quantumpad/RefreshParts()
 	var/E = 0

--- a/code/game/machinery/quantum_pad.dm
+++ b/code/game/machinery/quantum_pad.dm
@@ -15,6 +15,16 @@
 	var/teleporting = 0 //if it's in the process of teleporting
 	var/power_efficiency = 1
 	var/obj/machinery/quantumpad/linked_pad
+	
+	//mapping
+	var/static/list/mapped_quantum_pads = list()
+	var/map_pad_id = "" as text //what's my name
+	var/map_pad_link_id = "" as text //who's my friend
+	
+/obj/machinery/quantumpad/Initialize()
+	. = ..()
+	if(map_pad_id)
+		mapped_quantum_pads += src
 
 /obj/machinery/quantumpad/RefreshParts()
 	var/E = 0
@@ -60,8 +70,9 @@
 		return
 
 	if(!linked_pad || QDELETED(linked_pad))
-		to_chat(user, "<span class='warning'>There is no linked pad!</span>")
-		return
+		if(!map_pad_link_id || !initMappedLink())
+			to_chat(user, "<span class='warning'>There is no linked pad!</span>")
+			return
 
 	if(world.time < last_teleport + teleport_cooldown)
 		to_chat(user, "<span class='warning'>[src] is recharging power. Please wait [round((last_teleport + teleport_cooldown - world.time) / 10)] seconds.</span>")
@@ -80,7 +91,6 @@
 		return
 	src.add_fingerprint(user)
 	doteleport(user)
-	return
 
 /obj/machinery/quantumpad/proc/sparks()
 	var/datum/effect_system/spark_spread/s = new /datum/effect_system/spark_spread
@@ -88,6 +98,8 @@
 	s.start()
 
 /obj/machinery/quantumpad/attack_ghost(mob/dead/observer/ghost)
+	if(!linked_pad && map_pad_link_id)
+		initMappedLink()
 	if(linked_pad)
 		ghost.forceMove(get_turf(linked_pad))
 
@@ -136,6 +148,12 @@
 						continue
 				do_teleport(ROI, get_turf(linked_pad))
 
+/obj/machinery/quantumpad/proc/initMappedLink()
+	. = FALSE
+	var/obj/machinery/quantumpad/link = mapped_quantum_pads[map_pad_link_id]
+	if(link)
+		linked_pad = link
+		. = TRUE
 
 /obj/item/paper/guides/quantumpad
 	name = "Quantum Pad For Dummies"


### PR DESCRIPTION
They auto-link just like buttons do, upon first use (in this case, either by person or ghost)
Just like buttons this "first-use-activation" is hidden from the player so you have no idea it wasn't already linked! haha! you know NOTHING!

