### PR TITLE
Makes APC cell_type actually pick a cell

### DIFF
--- a/_maps/RandomRuins/SpaceRuins/bigderelict1.dmm
+++ b/_maps/RandomRuins/SpaceRuins/bigderelict1.dmm
@@ -67,7 +67,7 @@
 /area/ruin/space/has_grav/derelictoutpost/cargobay)
 "ao" = (
 /obj/machinery/power/apc{
-	cell_type = 0;
+	start_charge = 0;
 	dir = 4;
 	name = "Cargo Bay APC";
 	pixel_x = 24
@@ -754,7 +754,7 @@
 /area/ruin/space/has_grav/derelictoutpost/powerstorage)
 "ca" = (
 /obj/machinery/power/apc{
-	cell_type = 0;
+	start_charge = 0;
 	dir = 4;
 	name = "Power Storage APC";
 	pixel_x = 23;
@@ -850,7 +850,7 @@
 /area/ruin/space/has_grav/derelictoutpost)
 "ck" = (
 /obj/machinery/power/apc{
-	cell_type = 0;
+	start_charge = 0;
 	dir = 2;
 	name = "Tradepost APC";
 	pixel_y = -24
@@ -2011,7 +2011,7 @@
 /area/ruin/space/has_grav/derelictoutpost/cargostorage)
 "el" = (
 /obj/machinery/power/apc{
-	cell_type = 0;
+	start_charge = 0;
 	dir = 4;
 	name = "Cargo Storage APC";
 	pixel_x = 24

--- a/_maps/RandomRuins/SpaceRuins/deepstorage.dmm
+++ b/_maps/RandomRuins/SpaceRuins/deepstorage.dmm
@@ -1096,8 +1096,7 @@
 	d2 = 8;
 	icon_state = "0-8"
 	},
-/obj/machinery/power/apc{
-	cell_type = /obj/item/stock_parts/cell/upgraded/plus;
+/obj/machinery/power/apc/highcap/five_k{
 	dir = 4;
 	name = "Hydroponics APC";
 	pixel_x = 24
@@ -1466,8 +1465,7 @@
 /area/ruin/space/has_grav/deepstorage)
 "cQ" = (
 /obj/structure/cable/yellow,
-/obj/machinery/power/apc{
-	cell_type = /obj/item/stock_parts/cell/upgraded/plus;
+/obj/machinery/power/apc/highcap/five_k{
 	dir = 4;
 	name = "Storage APC";
 	pixel_x = 24
@@ -2260,8 +2258,7 @@
 	d2 = 8;
 	icon_state = "0-8"
 	},
-/obj/machinery/power/apc{
-	cell_type = /obj/item/stock_parts/cell/upgraded/plus;
+/obj/machinery/power/apc/highcap/five_k{
 	dir = 4;
 	name = "Armory APC";
 	pixel_x = 24
@@ -3085,8 +3082,7 @@
 "fE" = (
 /obj/machinery/atmospherics/pipe/simple/supplymain/hidden,
 /obj/structure/cable/yellow,
-/obj/machinery/power/apc{
-	cell_type = /obj/item/stock_parts/cell/upgraded/plus;
+/obj/machinery/power/apc/highcap/five_k{
 	dir = 4;
 	name = "Dormory APC";
 	pixel_x = 24

--- a/_maps/RandomRuins/SpaceRuins/deepstorage.dmm
+++ b/_maps/RandomRuins/SpaceRuins/deepstorage.dmm
@@ -1097,7 +1097,7 @@
 	icon_state = "0-8"
 	},
 /obj/machinery/power/apc{
-	cell_type = 5000;
+	cell_type = /obj/item/stock_parts/cell/upgraded/plus;
 	dir = 4;
 	name = "Hydroponics APC";
 	pixel_x = 24
@@ -1467,7 +1467,7 @@
 "cQ" = (
 /obj/structure/cable/yellow,
 /obj/machinery/power/apc{
-	cell_type = 5000;
+	cell_type = /obj/item/stock_parts/cell/upgraded/plus;
 	dir = 4;
 	name = "Storage APC";
 	pixel_x = 24
@@ -2261,7 +2261,7 @@
 	icon_state = "0-8"
 	},
 /obj/machinery/power/apc{
-	cell_type = 5000;
+	cell_type = /obj/item/stock_parts/cell/upgraded/plus;
 	dir = 4;
 	name = "Armory APC";
 	pixel_x = 24
@@ -3086,7 +3086,7 @@
 /obj/machinery/atmospherics/pipe/simple/supplymain/hidden,
 /obj/structure/cable/yellow,
 /obj/machinery/power/apc{
-	cell_type = 5000;
+	cell_type = /obj/item/stock_parts/cell/upgraded/plus;
 	dir = 4;
 	name = "Dormory APC";
 	pixel_x = 24

--- a/_maps/RandomRuins/SpaceRuins/gasthelizards.dmm
+++ b/_maps/RandomRuins/SpaceRuins/gasthelizards.dmm
@@ -174,7 +174,6 @@
 	dir = 1
 	},
 /obj/machinery/power/apc{
-	cell_type = 2500;
 	dir = 1;
 	name = "Worn-out APC";
 	pixel_x = 1;

--- a/_maps/RandomRuins/SpaceRuins/oldAIsat.dmm
+++ b/_maps/RandomRuins/SpaceRuins/oldAIsat.dmm
@@ -44,7 +44,6 @@
 /area/tcommsat/chamber)
 "ak" = (
 /obj/machinery/power/apc{
-	cell_type = 2500;
 	dir = 1;
 	name = "Worn-out APC";
 	pixel_x = 1;

--- a/_maps/RandomRuins/SpaceRuins/onehalf.dmm
+++ b/_maps/RandomRuins/SpaceRuins/onehalf.dmm
@@ -350,7 +350,6 @@
 	icon_state = "0-8"
 	},
 /obj/machinery/power/apc{
-	cell_type = 2500;
 	dir = 1;
 	name = "Mining Drone Bay APC";
 	pixel_y = 24
@@ -848,7 +847,6 @@
 	d2 = 4
 	},
 /obj/machinery/power/apc{
-	cell_type = 2500;
 	dir = 1;
 	name = "Bridge APC";
 	pixel_y = 24

--- a/_maps/RandomRuins/SpaceRuins/spacehotel.dmm
+++ b/_maps/RandomRuins/SpaceRuins/spacehotel.dmm
@@ -655,8 +655,7 @@
 	name = "Hotel Guest Room 3"
 	})
 "bN" = (
-/obj/machinery/power/apc{
-	cell_type = /obj/item/stock_parts/cell/upgraded/plus;
+/obj/machinery/power/apc/highcap/five_k{
 	dir = 2;
 	name = "Guest Room APC";
 	pixel_y = -24
@@ -719,8 +718,7 @@
 	name = "Hotel Guest Room 4"
 	})
 "bT" = (
-/obj/machinery/power/apc{
-	cell_type = /obj/item/stock_parts/cell/upgraded/plus;
+/obj/machinery/power/apc/highcap/five_k{
 	dir = 2;
 	name = "Guest Room APC";
 	pixel_y = -24
@@ -783,8 +781,7 @@
 	name = "Hotel Guest Room 5"
 	})
 "bZ" = (
-/obj/machinery/power/apc{
-	cell_type = /obj/item/stock_parts/cell/upgraded/plus;
+/obj/machinery/power/apc/highcap/five_k{
 	dir = 2;
 	name = "Guest Room APC";
 	pixel_y = -24
@@ -847,8 +844,7 @@
 	name = "Hotel Guest Room 6"
 	})
 "cf" = (
-/obj/machinery/power/apc{
-	cell_type = /obj/item/stock_parts/cell/upgraded/plus;
+/obj/machinery/power/apc/highcap/five_k{
 	dir = 2;
 	name = "Guest Room APC";
 	pixel_y = -24
@@ -1379,8 +1375,7 @@
 	name = "Hotel Guest Room 2"
 	})
 "dn" = (
-/obj/machinery/power/apc{
-	cell_type = /obj/item/stock_parts/cell/upgraded/plus;
+/obj/machinery/power/apc/highcap/five_k{
 	dir = 1;
 	name = "Guest Room APC";
 	pixel_y = 25
@@ -1461,8 +1456,7 @@
 	name = "Hotel Guest Room 1"
 	})
 "dv" = (
-/obj/machinery/power/apc{
-	cell_type = /obj/item/stock_parts/cell/upgraded/plus;
+/obj/machinery/power/apc/highcap/five_k{
 	dir = 1;
 	name = "Guest Room APC";
 	pixel_y = 25
@@ -1874,8 +1868,7 @@
 /turf/open/floor/plasteel/white,
 /area/ruin/space/has_grav/hotel/workroom)
 "eA" = (
-/obj/machinery/power/apc{
-	cell_type = /obj/item/stock_parts/cell/upgraded/plus;
+/obj/machinery/power/apc/highcap/five_k{
 	dir = 2;
 	name = "Laundry APC";
 	pixel_y = -24
@@ -2080,8 +2073,7 @@
 /turf/open/floor/plating,
 /area/ruin/space/has_grav/hotel)
 "fh" = (
-/obj/machinery/power/apc{
-	cell_type = /obj/item/stock_parts/cell/upgraded/plus;
+/obj/machinery/power/apc/highcap/five_k{
 	dir = 2;
 	name = "Kitchen APC";
 	pixel_y = -24
@@ -2874,8 +2866,7 @@
 /turf/open/floor/plasteel/cafeteria,
 /area/ruin/space/has_grav/hotel/bar)
 "hA" = (
-/obj/machinery/power/apc{
-	cell_type = /obj/item/stock_parts/cell/upgraded/plus;
+/obj/machinery/power/apc/highcap/five_k{
 	dir = 2;
 	name = "Staff Room APC";
 	pixel_y = -24
@@ -3261,8 +3252,7 @@
 	},
 /area/ruin/space/has_grav/hotel/power)
 "iw" = (
-/obj/machinery/power/apc{
-	cell_type = /obj/item/stock_parts/cell/upgraded/plus;
+/obj/machinery/power/apc/highcap/five_k{
 	dir = 1;
 	name = "Power Storage APC";
 	pixel_y = 25
@@ -3427,8 +3417,7 @@
 	},
 /area/ruin/space/has_grav/hotel/power)
 "iU" = (
-/obj/machinery/power/apc{
-	cell_type = /obj/item/stock_parts/cell/upgraded/plus;
+/obj/machinery/power/apc/highcap/five_k{
 	dir = 2;
 	name = "Security APC";
 	pixel_y = -24
@@ -3500,8 +3489,7 @@
 /turf/open/floor/plating,
 /area/ruin/space/has_grav/hotel/pool)
 "iZ" = (
-/obj/machinery/power/apc{
-	cell_type = /obj/item/stock_parts/cell/upgraded/plus;
+/obj/machinery/power/apc/highcap/five_k{
 	dir = 2;
 	name = "Pool APC";
 	pixel_y = -24
@@ -3559,8 +3547,7 @@
 /obj/machinery/light{
 	dir = 8
 	},
-/obj/machinery/power/apc{
-	cell_type = /obj/item/stock_parts/cell/upgraded/plus;
+/obj/machinery/power/apc/highcap/five_k{
 	dir = 2;
 	name = "Dock APC";
 	pixel_y = -24
@@ -4824,8 +4811,7 @@
 /turf/open/floor/plasteel/neutral,
 /area/ruin/space/has_grav/hotel/custodial)
 "mJ" = (
-/obj/machinery/power/apc{
-	cell_type = /obj/item/stock_parts/cell/upgraded/plus;
+/obj/machinery/power/apc/highcap/five_k{
 	dir = 2;
 	name = "Custodial APC";
 	pixel_y = -24

--- a/_maps/RandomRuins/SpaceRuins/spacehotel.dmm
+++ b/_maps/RandomRuins/SpaceRuins/spacehotel.dmm
@@ -656,7 +656,7 @@
 	})
 "bN" = (
 /obj/machinery/power/apc{
-	cell_type = 5000;
+	cell_type = /obj/item/stock_parts/cell/upgraded/plus;
 	dir = 2;
 	name = "Guest Room APC";
 	pixel_y = -24
@@ -720,7 +720,7 @@
 	})
 "bT" = (
 /obj/machinery/power/apc{
-	cell_type = 5000;
+	cell_type = /obj/item/stock_parts/cell/upgraded/plus;
 	dir = 2;
 	name = "Guest Room APC";
 	pixel_y = -24
@@ -784,7 +784,7 @@
 	})
 "bZ" = (
 /obj/machinery/power/apc{
-	cell_type = 5000;
+	cell_type = /obj/item/stock_parts/cell/upgraded/plus;
 	dir = 2;
 	name = "Guest Room APC";
 	pixel_y = -24
@@ -848,7 +848,7 @@
 	})
 "cf" = (
 /obj/machinery/power/apc{
-	cell_type = 5000;
+	cell_type = /obj/item/stock_parts/cell/upgraded/plus;
 	dir = 2;
 	name = "Guest Room APC";
 	pixel_y = -24
@@ -1380,7 +1380,7 @@
 	})
 "dn" = (
 /obj/machinery/power/apc{
-	cell_type = 5000;
+	cell_type = /obj/item/stock_parts/cell/upgraded/plus;
 	dir = 1;
 	name = "Guest Room APC";
 	pixel_y = 25
@@ -1462,7 +1462,7 @@
 	})
 "dv" = (
 /obj/machinery/power/apc{
-	cell_type = 5000;
+	cell_type = /obj/item/stock_parts/cell/upgraded/plus;
 	dir = 1;
 	name = "Guest Room APC";
 	pixel_y = 25
@@ -1875,7 +1875,7 @@
 /area/ruin/space/has_grav/hotel/workroom)
 "eA" = (
 /obj/machinery/power/apc{
-	cell_type = 5000;
+	cell_type = /obj/item/stock_parts/cell/upgraded/plus;
 	dir = 2;
 	name = "Laundry APC";
 	pixel_y = -24
@@ -2081,7 +2081,7 @@
 /area/ruin/space/has_grav/hotel)
 "fh" = (
 /obj/machinery/power/apc{
-	cell_type = 5000;
+	cell_type = /obj/item/stock_parts/cell/upgraded/plus;
 	dir = 2;
 	name = "Kitchen APC";
 	pixel_y = -24
@@ -2875,7 +2875,7 @@
 /area/ruin/space/has_grav/hotel/bar)
 "hA" = (
 /obj/machinery/power/apc{
-	cell_type = 5000;
+	cell_type = /obj/item/stock_parts/cell/upgraded/plus;
 	dir = 2;
 	name = "Staff Room APC";
 	pixel_y = -24
@@ -3262,7 +3262,7 @@
 /area/ruin/space/has_grav/hotel/power)
 "iw" = (
 /obj/machinery/power/apc{
-	cell_type = 5000;
+	cell_type = /obj/item/stock_parts/cell/upgraded/plus;
 	dir = 1;
 	name = "Power Storage APC";
 	pixel_y = 25
@@ -3428,7 +3428,7 @@
 /area/ruin/space/has_grav/hotel/power)
 "iU" = (
 /obj/machinery/power/apc{
-	cell_type = 5000;
+	cell_type = /obj/item/stock_parts/cell/upgraded/plus;
 	dir = 2;
 	name = "Security APC";
 	pixel_y = -24
@@ -3501,7 +3501,7 @@
 /area/ruin/space/has_grav/hotel/pool)
 "iZ" = (
 /obj/machinery/power/apc{
-	cell_type = 5000;
+	cell_type = /obj/item/stock_parts/cell/upgraded/plus;
 	dir = 2;
 	name = "Pool APC";
 	pixel_y = -24
@@ -3560,7 +3560,7 @@
 	dir = 8
 	},
 /obj/machinery/power/apc{
-	cell_type = 5000;
+	cell_type = /obj/item/stock_parts/cell/upgraded/plus;
 	dir = 2;
 	name = "Dock APC";
 	pixel_y = -24
@@ -4825,7 +4825,7 @@
 /area/ruin/space/has_grav/hotel/custodial)
 "mJ" = (
 /obj/machinery/power/apc{
-	cell_type = 5000;
+	cell_type = /obj/item/stock_parts/cell/upgraded/plus;
 	dir = 2;
 	name = "Custodial APC";
 	pixel_y = -24

--- a/_maps/RandomZLevels/moonoutpost19.dmm
+++ b/_maps/RandomZLevels/moonoutpost19.dmm
@@ -1974,7 +1974,7 @@
 "cK" = (
 /obj/structure/cable,
 /obj/machinery/power/apc{
-	cell_type = 15000;
+	cell_type = /obj/item/stock_parts/cell/high/plus;
 	dir = 2;
 	locked = 1;
 	name = "Worn-out APC";
@@ -4918,7 +4918,7 @@
 "gG" = (
 /obj/structure/cable,
 /obj/machinery/power/apc{
-	cell_type = 15000;
+	cell_type = /obj/item/stock_parts/cell/high/plus;
 	dir = 4;
 	locked = 0;
 	name = "Worn-out APC";
@@ -6982,7 +6982,7 @@
 	d2 = 2
 	},
 /obj/machinery/power/apc{
-	cell_type = 15000;
+	cell_type = /obj/item/stock_parts/cell/high/plus;
 	dir = 1;
 	locked = 0;
 	name = "Worn-out APC";

--- a/_maps/RandomZLevels/moonoutpost19.dmm
+++ b/_maps/RandomZLevels/moonoutpost19.dmm
@@ -1973,8 +1973,7 @@
 	})
 "cK" = (
 /obj/structure/cable,
-/obj/machinery/power/apc{
-	cell_type = /obj/item/stock_parts/cell/high/plus;
+/obj/machinery/power/apc/highcap/fifteen_k{
 	dir = 2;
 	locked = 1;
 	name = "Worn-out APC";
@@ -4917,8 +4916,7 @@
 	})
 "gG" = (
 /obj/structure/cable,
-/obj/machinery/power/apc{
-	cell_type = /obj/item/stock_parts/cell/high/plus;
+/obj/machinery/power/apc/highcap/fifteen_k{
 	dir = 4;
 	locked = 0;
 	name = "Worn-out APC";
@@ -6981,8 +6979,7 @@
 	icon_state = "0-2";
 	d2 = 2
 	},
-/obj/machinery/power/apc{
-	cell_type = /obj/item/stock_parts/cell/high/plus;
+/obj/machinery/power/apc/highcap/fifteen_k{
 	dir = 1;
 	locked = 0;
 	name = "Worn-out APC";

--- a/_maps/RandomZLevels/research.dmm
+++ b/_maps/RandomZLevels/research.dmm
@@ -373,7 +373,7 @@
 	},
 /obj/machinery/power/apc{
 	auto_name = 1;
-	cell_type = 9000;
+	cell_type = /obj/item/stock_parts/cell/high;
 	dir = 4;
 	name = "Engineering APC";
 	pixel_x = 27;
@@ -661,7 +661,7 @@
 /area/awaymission/research/interior/gateway)
 "cb" = (
 /obj/machinery/power/apc{
-	cell_type = 12000;
+	cell_type = /obj/item/stock_parts/cell/high/plus;
 	dir = 4;
 	name = "Gateway APC";
 	pixel_x = 24
@@ -989,7 +989,7 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/power/apc{
-	cell_type = 5000;
+	cell_type = /obj/item/stock_parts/cell/upgraded/plus;
 	dir = 4;
 	name = "Genetics APC";
 	pixel_x = 24
@@ -1719,7 +1719,7 @@
 /area/awaymission/research/interior)
 "fa" = (
 /obj/machinery/power/apc{
-	cell_type = 5000;
+	cell_type = /obj/item/stock_parts/cell/upgraded/plus;
 	dir = 4;
 	name = "Cryostatis APC";
 	pixel_x = 24
@@ -1890,7 +1890,7 @@
 /area/awaymission/research/interior/secure)
 "fy" = (
 /obj/machinery/power/apc{
-	cell_type = 12000;
+	cell_type = /obj/item/stock_parts/cell/high/plus;
 	dir = 4;
 	name = "Vault APC";
 	pixel_x = 24
@@ -3058,7 +3058,7 @@
 /area/awaymission/research/interior/maint)
 "iw" = (
 /obj/machinery/power/apc{
-	cell_type = 5000;
+	cell_type = /obj/item/stock_parts/cell/upgraded/plus;
 	dir = 4;
 	name = "Genetics APC";
 	pixel_x = 24
@@ -3656,7 +3656,7 @@
 /area/awaymission/research/interior/medbay)
 "kp" = (
 /obj/machinery/power/apc{
-	cell_type = 5000;
+	cell_type = /obj/item/stock_parts/cell/upgraded/plus;
 	dir = 4;
 	name = "Dorms APC";
 	pixel_x = 24

--- a/_maps/RandomZLevels/research.dmm
+++ b/_maps/RandomZLevels/research.dmm
@@ -371,9 +371,8 @@
 	icon_state = "0-2";
 	d2 = 2
 	},
-/obj/machinery/power/apc{
+/obj/machinery/power/apc/highcap/ten_k{
 	auto_name = 1;
-	cell_type = /obj/item/stock_parts/cell/high;
 	dir = 4;
 	name = "Engineering APC";
 	pixel_x = 27;
@@ -660,8 +659,7 @@
 /turf/open/floor/plasteel/black,
 /area/awaymission/research/interior/gateway)
 "cb" = (
-/obj/machinery/power/apc{
-	cell_type = /obj/item/stock_parts/cell/high/plus;
+/obj/machinery/power/apc/highcap/fifteen_k{
 	dir = 4;
 	name = "Gateway APC";
 	pixel_x = 24
@@ -988,8 +986,7 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/machinery/power/apc{
-	cell_type = /obj/item/stock_parts/cell/upgraded/plus;
+/obj/machinery/power/apc/highcap/five_k{
 	dir = 4;
 	name = "Genetics APC";
 	pixel_x = 24
@@ -1718,8 +1715,7 @@
 /turf/open/floor/plasteel/whitepurple,
 /area/awaymission/research/interior)
 "fa" = (
-/obj/machinery/power/apc{
-	cell_type = /obj/item/stock_parts/cell/upgraded/plus;
+/obj/machinery/power/apc/highcap/five_k{
 	dir = 4;
 	name = "Cryostatis APC";
 	pixel_x = 24
@@ -1889,8 +1885,7 @@
 /turf/open/floor/plasteel/black,
 /area/awaymission/research/interior/secure)
 "fy" = (
-/obj/machinery/power/apc{
-	cell_type = /obj/item/stock_parts/cell/high/plus;
+/obj/machinery/power/apc/highcap/fifteen_k{
 	dir = 4;
 	name = "Vault APC";
 	pixel_x = 24
@@ -3057,8 +3052,7 @@
 /turf/open/floor/plating,
 /area/awaymission/research/interior/maint)
 "iw" = (
-/obj/machinery/power/apc{
-	cell_type = /obj/item/stock_parts/cell/upgraded/plus;
+/obj/machinery/power/apc/highcap/five_k{
 	dir = 4;
 	name = "Genetics APC";
 	pixel_x = 24
@@ -3655,8 +3649,7 @@
 	},
 /area/awaymission/research/interior/medbay)
 "kp" = (
-/obj/machinery/power/apc{
-	cell_type = /obj/item/stock_parts/cell/upgraded/plus;
+/obj/machinery/power/apc/highcap/five_k{
 	dir = 4;
 	name = "Dorms APC";
 	pixel_x = 24

--- a/_maps/RandomZLevels/undergroundoutpost45.dmm
+++ b/_maps/RandomZLevels/undergroundoutpost45.dmm
@@ -3159,8 +3159,7 @@
 	dir = 1;
 	network = list("UO45")
 	},
-/obj/machinery/power/apc{
-	cell_type = /obj/item/stock_parts/cell/high/plus;
+/obj/machinery/power/apc/highcap/fifteen_k{
 	dir = 2;
 	locked = 0;
 	name = "Hydroponics APC";
@@ -6240,8 +6239,7 @@
 	icon_state = "0-4";
 	d2 = 4
 	},
-/obj/machinery/power/apc{
-	cell_type = /obj/item/stock_parts/cell/high/plus;
+/obj/machinery/power/apc/highcap/fifteen_k{
 	dir = 1;
 	locked = 0;
 	name = "UO45 Bar APC";
@@ -7619,8 +7617,7 @@
 	d2 = 8;
 	icon_state = "0-8"
 	},
-/obj/machinery/power/apc{
-	cell_type = /obj/item/stock_parts/cell/high/plus;
+/obj/machinery/power/apc/highcap/fifteen_k{
 	dir = 2;
 	locked = 0;
 	name = "UO45 Research Division APC";
@@ -8313,8 +8310,7 @@
 	})
 "mE" = (
 /obj/structure/cable,
-/obj/machinery/power/apc{
-	cell_type = /obj/item/stock_parts/cell/high/plus;
+/obj/machinery/power/apc/highcap/fifteen_k{
 	dir = 2;
 	locked = 0;
 	name = "UO45 Gateway APC";
@@ -11932,8 +11928,7 @@
 	icon_state = "0-4";
 	d2 = 4
 	},
-/obj/machinery/power/apc{
-	cell_type = /obj/item/stock_parts/cell/high/plus;
+/obj/machinery/power/apc/highcap/fifteen_k{
 	dir = 8;
 	locked = 1;
 	name = "UO45 Engineering APC";
@@ -12695,8 +12690,7 @@
 	})
 "sj" = (
 /obj/structure/cable,
-/obj/machinery/power/apc{
-	cell_type = /obj/item/stock_parts/cell/high/plus;
+/obj/machinery/power/apc/highcap/fifteen_k{
 	dir = 2;
 	locked = 0;
 	name = "UO45 Mining APC";

--- a/_maps/RandomZLevels/undergroundoutpost45.dmm
+++ b/_maps/RandomZLevels/undergroundoutpost45.dmm
@@ -3160,7 +3160,7 @@
 	network = list("UO45")
 	},
 /obj/machinery/power/apc{
-	cell_type = 15000;
+	cell_type = /obj/item/stock_parts/cell/high/plus;
 	dir = 2;
 	locked = 0;
 	name = "Hydroponics APC";
@@ -6241,7 +6241,7 @@
 	d2 = 4
 	},
 /obj/machinery/power/apc{
-	cell_type = 15000;
+	cell_type = /obj/item/stock_parts/cell/high/plus;
 	dir = 1;
 	locked = 0;
 	name = "UO45 Bar APC";
@@ -7620,7 +7620,7 @@
 	icon_state = "0-8"
 	},
 /obj/machinery/power/apc{
-	cell_type = 15000;
+	cell_type = /obj/item/stock_parts/cell/high/plus;
 	dir = 2;
 	locked = 0;
 	name = "UO45 Research Division APC";
@@ -8314,7 +8314,7 @@
 "mE" = (
 /obj/structure/cable,
 /obj/machinery/power/apc{
-	cell_type = 15000;
+	cell_type = /obj/item/stock_parts/cell/high/plus;
 	dir = 2;
 	locked = 0;
 	name = "UO45 Gateway APC";
@@ -11933,7 +11933,7 @@
 	d2 = 4
 	},
 /obj/machinery/power/apc{
-	cell_type = 15000;
+	cell_type = /obj/item/stock_parts/cell/high/plus;
 	dir = 8;
 	locked = 1;
 	name = "UO45 Engineering APC";
@@ -12696,7 +12696,7 @@
 "sj" = (
 /obj/structure/cable,
 /obj/machinery/power/apc{
-	cell_type = 15000;
+	cell_type = /obj/item/stock_parts/cell/high/plus;
 	dir = 2;
 	locked = 0;
 	name = "UO45 Mining APC";

--- a/_maps/map_files/BoxStation/BoxStation.dmm
+++ b/_maps/map_files/BoxStation/BoxStation.dmm
@@ -851,8 +851,7 @@
 /turf/open/floor/plasteel,
 /area/ai_monitored/security/armory)
 "acm" = (
-/obj/machinery/power/apc{
-	cell_type = /obj/item/stock_parts/cell/upgraded/plus;
+/obj/machinery/power/apc/highcap/five_k{
 	dir = 4;
 	areastring = "/area/ai_monitored/security/armory";
 	name = "Armory APC";
@@ -20943,8 +20942,7 @@
 	},
 /area/bridge)
 "aWW" = (
-/obj/machinery/power/apc{
-	cell_type = /obj/item/stock_parts/cell/upgraded/plus;
+/obj/machinery/power/apc/highcap/five_k{
 	dir = 2;
 	name = "Bridge APC";
 	areastring = "/area/bridge";
@@ -23801,8 +23799,7 @@
 /turf/open/floor/plasteel/black,
 /area/ai_monitored/turret_protected/ai_upload)
 "bed" = (
-/obj/machinery/power/apc{
-	cell_type = /obj/item/stock_parts/cell/upgraded/plus;
+/obj/machinery/power/apc/highcap/five_k{
 	dir = 2;
 	name = "Upload APC";
 	areastring = "/area/ai_monitored/turret_protected/ai_upload";
@@ -42340,8 +42337,7 @@
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
 "bSX" = (
-/obj/machinery/power/apc{
-	cell_type = /obj/item/stock_parts/cell/upgraded/plus;
+/obj/machinery/power/apc/highcap/five_k{
 	dir = 1;
 	name = "Virology APC";
 	areastring = "/area/medical/virology";
@@ -43923,8 +43919,7 @@
 /obj/machinery/light{
 	dir = 1
 	},
-/obj/machinery/power/apc{
-	cell_type = /obj/item/stock_parts/cell/upgraded/plus;
+/obj/machinery/power/apc/highcap/five_k{
 	dir = 1;
 	name = "Telecomms Server APC";
 	areastring = "/area/tcommsat/server";
@@ -46080,8 +46075,7 @@
 /obj/structure/closet/secure_closet/engineering_chief{
 	req_access_txt = "0"
 	},
-/obj/machinery/power/apc{
-	cell_type = /obj/item/stock_parts/cell/upgraded/plus;
+/obj/machinery/power/apc/highcap/five_k{
 	dir = 4;
 	name = "CE Office APC";
 	areastring = "/area/crew_quarters/heads/chief";
@@ -49117,8 +49111,7 @@
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "cib" = (
-/obj/machinery/power/apc{
-	cell_type = /obj/item/stock_parts/cell/high/plus;
+/obj/machinery/power/apc/highcap/fifteen_k{
 	dir = 1;
 	name = "Engineering APC";
 	areastring = "/area/engine/engineering";
@@ -49155,8 +49148,7 @@
 	dir = 1
 	},
 /obj/structure/reagent_dispensers/watertank,
-/obj/machinery/power/apc{
-	cell_type = /obj/item/stock_parts/cell/high/plus;
+/obj/machinery/power/apc/highcap/fifteen_k{
 	dir = 1;
 	name = "Engineering APC";
 	areastring = "/area/engine/engineering";
@@ -55810,8 +55802,7 @@
 	d2 = 8;
 	icon_state = "0-8"
 	},
-/obj/machinery/power/apc{
-	cell_type = /obj/item/stock_parts/cell/upgraded/plus;
+/obj/machinery/power/apc/highcap/five_k{
 	dir = 2;
 	name = "AI Chamber APC";
 	areastring = "/area/ai_monitored/turret_protected/ai";

--- a/_maps/map_files/BoxStation/BoxStation.dmm
+++ b/_maps/map_files/BoxStation/BoxStation.dmm
@@ -852,7 +852,7 @@
 /area/ai_monitored/security/armory)
 "acm" = (
 /obj/machinery/power/apc{
-	cell_type = 5000;
+	cell_type = /obj/item/stock_parts/cell/upgraded/plus;
 	dir = 4;
 	areastring = "/area/ai_monitored/security/armory";
 	name = "Armory APC";
@@ -20944,7 +20944,7 @@
 /area/bridge)
 "aWW" = (
 /obj/machinery/power/apc{
-	cell_type = 5000;
+	cell_type = /obj/item/stock_parts/cell/upgraded/plus;
 	dir = 2;
 	name = "Bridge APC";
 	areastring = "/area/bridge";
@@ -22745,7 +22745,6 @@
 /area/quartermaster/storage)
 "bbu" = (
 /obj/machinery/power/apc{
-	cell_type = 2500;
 	dir = 1;
 	name = "Captain's Office APC";
 	areastring = "/area/crew_quarters/heads/captain";
@@ -23803,7 +23802,7 @@
 /area/ai_monitored/turret_protected/ai_upload)
 "bed" = (
 /obj/machinery/power/apc{
-	cell_type = 5000;
+	cell_type = /obj/item/stock_parts/cell/upgraded/plus;
 	dir = 2;
 	name = "Upload APC";
 	areastring = "/area/ai_monitored/turret_protected/ai_upload";
@@ -42342,7 +42341,7 @@
 /area/medical/virology)
 "bSX" = (
 /obj/machinery/power/apc{
-	cell_type = 5000;
+	cell_type = /obj/item/stock_parts/cell/upgraded/plus;
 	dir = 1;
 	name = "Virology APC";
 	areastring = "/area/medical/virology";
@@ -43925,7 +43924,7 @@
 	dir = 1
 	},
 /obj/machinery/power/apc{
-	cell_type = 5000;
+	cell_type = /obj/item/stock_parts/cell/upgraded/plus;
 	dir = 1;
 	name = "Telecomms Server APC";
 	areastring = "/area/tcommsat/server";
@@ -46082,7 +46081,7 @@
 	req_access_txt = "0"
 	},
 /obj/machinery/power/apc{
-	cell_type = 5000;
+	cell_type = /obj/item/stock_parts/cell/upgraded/plus;
 	dir = 4;
 	name = "CE Office APC";
 	areastring = "/area/crew_quarters/heads/chief";
@@ -49119,7 +49118,7 @@
 /area/engine/engineering)
 "cib" = (
 /obj/machinery/power/apc{
-	cell_type = 15000;
+	cell_type = /obj/item/stock_parts/cell/high/plus;
 	dir = 1;
 	name = "Engineering APC";
 	areastring = "/area/engine/engineering";
@@ -49157,7 +49156,7 @@
 	},
 /obj/structure/reagent_dispensers/watertank,
 /obj/machinery/power/apc{
-	cell_type = 15000;
+	cell_type = /obj/item/stock_parts/cell/high/plus;
 	dir = 1;
 	name = "Engineering APC";
 	areastring = "/area/engine/engineering";
@@ -55812,7 +55811,7 @@
 	icon_state = "0-8"
 	},
 /obj/machinery/power/apc{
-	cell_type = 5000;
+	cell_type = /obj/item/stock_parts/cell/upgraded/plus;
 	dir = 2;
 	name = "AI Chamber APC";
 	areastring = "/area/ai_monitored/turret_protected/ai";
@@ -62503,7 +62502,6 @@
 /area/quartermaster/sorting)
 "cNL" = (
 /obj/machinery/power/apc{
-	cell_type = 2500;
 	dir = 1;
 	name = "Central Maintenance APC";
 	areastring = "/area/maintenance/central";

--- a/_maps/map_files/Deltastation/DeltaStation2.dmm
+++ b/_maps/map_files/Deltastation/DeltaStation2.dmm
@@ -863,8 +863,7 @@
 /area/maintenance/solars/starboard/fore)
 "abM" = (
 /obj/structure/cable/white,
-/obj/machinery/power/apc{
-	cell_type = /obj/item/stock_parts/cell/high;
+/obj/machinery/power/apc/highcap/ten_k{
 	dir = 2;
 	name = "Starboard Bow Solar APC";
 	areastring = "/area/maintenance/solars/starboard/fore";
@@ -15589,8 +15588,7 @@
 /area/maintenance/solars/port/fore)
 "aGh" = (
 /obj/structure/cable/white,
-/obj/machinery/power/apc{
-	cell_type = /obj/item/stock_parts/cell/high;
+/obj/machinery/power/apc/highcap/ten_k{
 	dir = 2;
 	name = "Port Bow Solar APC";
 	areastring = "/area/maintenance/solars/port/fore";
@@ -24570,8 +24568,7 @@
 /area/security/prison)
 "aXv" = (
 /obj/structure/cable/white,
-/obj/machinery/power/apc{
-	cell_type = /obj/item/stock_parts/cell/upgraded/plus;
+/obj/machinery/power/apc/highcap/five_k{
 	dir = 2;
 	name = "Prison Wing APC";
 	areastring = "/area/security/prison";
@@ -27406,8 +27403,7 @@
 	},
 /area/engine/atmos)
 "bdr" = (
-/obj/machinery/power/apc{
-	cell_type = /obj/item/stock_parts/cell/upgraded/plus;
+/obj/machinery/power/apc/highcap/five_k{
 	dir = 1;
 	name = "Atmospherics APC";
 	areastring = "/area/engine/atmos";
@@ -37815,8 +37811,7 @@
 /turf/open/floor/plasteel,
 /area/engine/gravity_generator)
 "bwL" = (
-/obj/machinery/power/apc{
-	cell_type = /obj/item/stock_parts/cell/upgraded/plus;
+/obj/machinery/power/apc/highcap/five_k{
 	dir = 1;
 	name = "Gravity Generator APC";
 	areastring = "/area/engine/gravity_generator";
@@ -38945,8 +38940,7 @@
 /obj/machinery/light{
 	dir = 1
 	},
-/obj/machinery/power/apc{
-	cell_type = /obj/item/stock_parts/cell/upgraded/plus;
+/obj/machinery/power/apc/highcap/five_k{
 	dir = 1;
 	name = "Engineering Foyer APC";
 	areastring = "/area/engine/break_room";
@@ -43406,8 +43400,7 @@
 	d2 = 2;
 	icon_state = "0-2"
 	},
-/obj/machinery/power/apc{
-	cell_type = /obj/item/stock_parts/cell/high;
+/obj/machinery/power/apc/highcap/ten_k{
 	dir = 1;
 	name = "Council Chambers APC";
 	areastring = "/area/bridge/meeting_room/council";
@@ -43982,8 +43975,7 @@
 /turf/closed/wall,
 /area/engine/transit_tube)
 "bHy" = (
-/obj/machinery/power/apc{
-	cell_type = /obj/item/stock_parts/cell/upgraded/plus;
+/obj/machinery/power/apc/highcap/five_k{
 	dir = 1;
 	name = "Transit Tube Access APC";
 	areastring = "/area/engine/transit_tube";
@@ -44496,8 +44488,7 @@
 /turf/open/floor/plasteel/grimy,
 /area/tcommsat/computer)
 "bIq" = (
-/obj/machinery/power/apc{
-	cell_type = /obj/item/stock_parts/cell/high;
+/obj/machinery/power/apc/highcap/ten_k{
 	dir = 1;
 	name = "Telecomms Monitoring APC";
 	areastring = "/area/tcommsat/computer";
@@ -44659,8 +44650,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/disposal/bin,
 /obj/structure/disposalpipe/trunk,
-/obj/machinery/power/apc{
-	cell_type = /obj/item/stock_parts/cell/upgraded/plus;
+/obj/machinery/power/apc/highcap/five_k{
 	dir = 1;
 	name = "Auxiliary Tool Storage APC";
 	areastring = "/area/storage/tools";
@@ -46594,8 +46584,7 @@
 /turf/open/floor/wood,
 /area/crew_quarters/heads/captain)
 "bMI" = (
-/obj/machinery/power/apc{
-	cell_type = /obj/item/stock_parts/cell/high;
+/obj/machinery/power/apc/highcap/ten_k{
 	dir = 2;
 	name = "Captain's Office APC";
 	areastring = "/area/crew_quarters/heads/captain";
@@ -54595,8 +54584,7 @@
 	d2 = 8;
 	icon_state = "0-8"
 	},
-/obj/machinery/power/apc{
-	cell_type = /obj/item/stock_parts/cell/high;
+/obj/machinery/power/apc/highcap/ten_k{
 	dir = 1;
 	name = "Brig APC";
 	areastring = "/area/security/brig";
@@ -55181,8 +55169,7 @@
 /obj/structure/window/reinforced{
 	dir = 8
 	},
-/obj/machinery/power/apc{
-	cell_type = /obj/item/stock_parts/cell/high;
+/obj/machinery/power/apc/highcap/ten_k{
 	dir = 2;
 	name = "Captain's Quarters APC";
 	areastring = "/area/crew_quarters/heads/captain/private";
@@ -58237,8 +58224,7 @@
 "cig" = (
 /obj/structure/table,
 /obj/item/hand_tele,
-/obj/machinery/power/apc{
-	cell_type = /obj/item/stock_parts/cell/high;
+/obj/machinery/power/apc/highcap/ten_k{
 	dir = 1;
 	name = "Teleporter APC";
 	areastring = "/area/teleporter";
@@ -63428,8 +63414,7 @@
 	d2 = 2;
 	icon_state = "0-2"
 	},
-/obj/machinery/power/apc{
-	cell_type = /obj/item/stock_parts/cell/high;
+/obj/machinery/power/apc/highcap/ten_k{
 	dir = 1;
 	name = "Gateway APC";
 	areastring = "/area/gateway";
@@ -84197,8 +84182,7 @@
 	d2 = 8;
 	icon_state = "0-8"
 	},
-/obj/machinery/power/apc{
-	cell_type = /obj/item/stock_parts/cell/high;
+/obj/machinery/power/apc/highcap/ten_k{
 	dir = 1;
 	name = "Mech Bay APC";
 	areastring = "/area/science/robotics/mechbay";
@@ -84331,8 +84315,7 @@
 	d2 = 2;
 	icon_state = "0-2"
 	},
-/obj/machinery/power/apc{
-	cell_type = /obj/item/stock_parts/cell/upgraded/plus;
+/obj/machinery/power/apc/highcap/five_k{
 	dir = 1;
 	name = "Cloning Lab APC";
 	areastring = "/area/medical/genetics/cloning";
@@ -92088,8 +92071,7 @@
 /area/maintenance/starboard/aft)
 "dxk" = (
 /obj/structure/cable/white,
-/obj/machinery/power/apc{
-	cell_type = /obj/item/stock_parts/cell/high;
+/obj/machinery/power/apc/highcap/ten_k{
 	dir = 2;
 	name = "Starboard Quarter Solar APC";
 	areastring = "/area/maintenance/solars/starboard/aft";
@@ -104595,8 +104577,7 @@
 /area/maintenance/solars/port/aft)
 "dWj" = (
 /obj/structure/cable/white,
-/obj/machinery/power/apc{
-	cell_type = /obj/item/stock_parts/cell/high;
+/obj/machinery/power/apc/highcap/ten_k{
 	dir = 2;
 	name = "Port Quarter Solar APC";
 	areastring = "/area/maintenance/solars/port/aft";
@@ -108844,8 +108825,7 @@
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit/departure_lounge)
 "egC" = (
-/obj/machinery/power/apc{
-	cell_type = /obj/item/stock_parts/cell/upgraded/plus;
+/obj/machinery/power/apc/highcap/five_k{
 	dir = 1;
 	name = "Departure Lounge APC";
 	areastring = "/area/hallway/secondary/exit/departure_lounge";

--- a/_maps/map_files/Deltastation/DeltaStation2.dmm
+++ b/_maps/map_files/Deltastation/DeltaStation2.dmm
@@ -864,7 +864,7 @@
 "abM" = (
 /obj/structure/cable/white,
 /obj/machinery/power/apc{
-	cell_type = 10000;
+	cell_type = /obj/item/stock_parts/cell/high;
 	dir = 2;
 	name = "Starboard Bow Solar APC";
 	areastring = "/area/maintenance/solars/starboard/fore";
@@ -15590,7 +15590,7 @@
 "aGh" = (
 /obj/structure/cable/white,
 /obj/machinery/power/apc{
-	cell_type = 10000;
+	cell_type = /obj/item/stock_parts/cell/high;
 	dir = 2;
 	name = "Port Bow Solar APC";
 	areastring = "/area/maintenance/solars/port/fore";
@@ -24571,7 +24571,7 @@
 "aXv" = (
 /obj/structure/cable/white,
 /obj/machinery/power/apc{
-	cell_type = 5000;
+	cell_type = /obj/item/stock_parts/cell/upgraded/plus;
 	dir = 2;
 	name = "Prison Wing APC";
 	areastring = "/area/security/prison";
@@ -27407,7 +27407,7 @@
 /area/engine/atmos)
 "bdr" = (
 /obj/machinery/power/apc{
-	cell_type = 5000;
+	cell_type = /obj/item/stock_parts/cell/upgraded/plus;
 	dir = 1;
 	name = "Atmospherics APC";
 	areastring = "/area/engine/atmos";
@@ -37816,7 +37816,7 @@
 /area/engine/gravity_generator)
 "bwL" = (
 /obj/machinery/power/apc{
-	cell_type = 5000;
+	cell_type = /obj/item/stock_parts/cell/upgraded/plus;
 	dir = 1;
 	name = "Gravity Generator APC";
 	areastring = "/area/engine/gravity_generator";
@@ -38946,7 +38946,7 @@
 	dir = 1
 	},
 /obj/machinery/power/apc{
-	cell_type = 5000;
+	cell_type = /obj/item/stock_parts/cell/upgraded/plus;
 	dir = 1;
 	name = "Engineering Foyer APC";
 	areastring = "/area/engine/break_room";
@@ -43407,7 +43407,7 @@
 	icon_state = "0-2"
 	},
 /obj/machinery/power/apc{
-	cell_type = 10000;
+	cell_type = /obj/item/stock_parts/cell/high;
 	dir = 1;
 	name = "Council Chambers APC";
 	areastring = "/area/bridge/meeting_room/council";
@@ -43983,7 +43983,7 @@
 /area/engine/transit_tube)
 "bHy" = (
 /obj/machinery/power/apc{
-	cell_type = 5000;
+	cell_type = /obj/item/stock_parts/cell/upgraded/plus;
 	dir = 1;
 	name = "Transit Tube Access APC";
 	areastring = "/area/engine/transit_tube";
@@ -44497,7 +44497,7 @@
 /area/tcommsat/computer)
 "bIq" = (
 /obj/machinery/power/apc{
-	cell_type = 10000;
+	cell_type = /obj/item/stock_parts/cell/high;
 	dir = 1;
 	name = "Telecomms Monitoring APC";
 	areastring = "/area/tcommsat/computer";
@@ -44660,7 +44660,7 @@
 /obj/machinery/disposal/bin,
 /obj/structure/disposalpipe/trunk,
 /obj/machinery/power/apc{
-	cell_type = 5000;
+	cell_type = /obj/item/stock_parts/cell/upgraded/plus;
 	dir = 1;
 	name = "Auxiliary Tool Storage APC";
 	areastring = "/area/storage/tools";
@@ -46595,7 +46595,7 @@
 /area/crew_quarters/heads/captain)
 "bMI" = (
 /obj/machinery/power/apc{
-	cell_type = 10000;
+	cell_type = /obj/item/stock_parts/cell/high;
 	dir = 2;
 	name = "Captain's Office APC";
 	areastring = "/area/crew_quarters/heads/captain";
@@ -54596,7 +54596,7 @@
 	icon_state = "0-8"
 	},
 /obj/machinery/power/apc{
-	cell_type = 10000;
+	cell_type = /obj/item/stock_parts/cell/high;
 	dir = 1;
 	name = "Brig APC";
 	areastring = "/area/security/brig";
@@ -55182,7 +55182,7 @@
 	dir = 8
 	},
 /obj/machinery/power/apc{
-	cell_type = 10000;
+	cell_type = /obj/item/stock_parts/cell/high;
 	dir = 2;
 	name = "Captain's Quarters APC";
 	areastring = "/area/crew_quarters/heads/captain/private";
@@ -58238,7 +58238,7 @@
 /obj/structure/table,
 /obj/item/hand_tele,
 /obj/machinery/power/apc{
-	cell_type = 10000;
+	cell_type = /obj/item/stock_parts/cell/high;
 	dir = 1;
 	name = "Teleporter APC";
 	areastring = "/area/teleporter";
@@ -63429,7 +63429,7 @@
 	icon_state = "0-2"
 	},
 /obj/machinery/power/apc{
-	cell_type = 10000;
+	cell_type = /obj/item/stock_parts/cell/high;
 	dir = 1;
 	name = "Gateway APC";
 	areastring = "/area/gateway";
@@ -84198,7 +84198,7 @@
 	icon_state = "0-8"
 	},
 /obj/machinery/power/apc{
-	cell_type = 10000;
+	cell_type = /obj/item/stock_parts/cell/high;
 	dir = 1;
 	name = "Mech Bay APC";
 	areastring = "/area/science/robotics/mechbay";
@@ -84332,7 +84332,7 @@
 	icon_state = "0-2"
 	},
 /obj/machinery/power/apc{
-	cell_type = 5000;
+	cell_type = /obj/item/stock_parts/cell/upgraded/plus;
 	dir = 1;
 	name = "Cloning Lab APC";
 	areastring = "/area/medical/genetics/cloning";
@@ -92089,7 +92089,7 @@
 "dxk" = (
 /obj/structure/cable/white,
 /obj/machinery/power/apc{
-	cell_type = 10000;
+	cell_type = /obj/item/stock_parts/cell/high;
 	dir = 2;
 	name = "Starboard Quarter Solar APC";
 	areastring = "/area/maintenance/solars/starboard/aft";
@@ -104596,7 +104596,7 @@
 "dWj" = (
 /obj/structure/cable/white,
 /obj/machinery/power/apc{
-	cell_type = 10000;
+	cell_type = /obj/item/stock_parts/cell/high;
 	dir = 2;
 	name = "Port Quarter Solar APC";
 	areastring = "/area/maintenance/solars/port/aft";
@@ -108845,7 +108845,7 @@
 /area/hallway/secondary/exit/departure_lounge)
 "egC" = (
 /obj/machinery/power/apc{
-	cell_type = 5000;
+	cell_type = /obj/item/stock_parts/cell/upgraded/plus;
 	dir = 1;
 	name = "Departure Lounge APC";
 	areastring = "/area/hallway/secondary/exit/departure_lounge";

--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -2553,8 +2553,7 @@
 	},
 /area/security/prison)
 "aeX" = (
-/obj/machinery/power/apc{
-	cell_type = /obj/item/stock_parts/cell/upgraded/plus;
+/obj/machinery/power/apc/highcap/five_k{
 	dir = 1;
 	name = "Prison Wing APC";
 	areastring = "/area/security/prison";
@@ -3933,8 +3932,7 @@
 	},
 /area/ai_monitored/security/armory)
 "ahF" = (
-/obj/machinery/power/apc{
-	cell_type = /obj/item/stock_parts/cell/upgraded/plus;
+/obj/machinery/power/apc/highcap/five_k{
 	dir = 2;
 	name = "Armory APC";
 	areastring = "/area/ai_monitored/security/armory";
@@ -6332,8 +6330,7 @@
 	d2 = 4;
 	icon_state = "1-4"
 	},
-/obj/machinery/power/apc{
-	cell_type = /obj/item/stock_parts/cell/upgraded/plus;
+/obj/machinery/power/apc/highcap/five_k{
 	dir = 8;
 	name = "Brig Control APC";
 	areastring = "/area/security/warden";
@@ -6998,8 +6995,7 @@
 /turf/open/floor/plasteel,
 /area/security/main)
 "anC" = (
-/obj/machinery/power/apc{
-	cell_type = /obj/item/stock_parts/cell/upgraded/plus;
+/obj/machinery/power/apc/highcap/five_k{
 	dir = 4;
 	name = "Security Office APC";
 	areastring = "/area/security/main";
@@ -12215,8 +12211,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
-/obj/machinery/power/apc{
-	cell_type = /obj/item/stock_parts/cell/high;
+/obj/machinery/power/apc/highcap/ten_k{
 	dir = 2;
 	name = "Brig APC";
 	areastring = "/area/security/brig";
@@ -17035,8 +17030,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
-/obj/machinery/power/apc{
-	cell_type = /obj/item/stock_parts/cell/upgraded/plus;
+/obj/machinery/power/apc/highcap/five_k{
 	dir = 2;
 	name = "Fore Primary Hallway APC";
 	areastring = "/area/hallway/primary/fore";
@@ -21221,8 +21215,7 @@
 	},
 /area/hydroponics/garden)
 "aOO" = (
-/obj/machinery/power/apc{
-	cell_type = /obj/item/stock_parts/cell/high;
+/obj/machinery/power/apc/highcap/ten_k{
 	dir = 8;
 	name = "Engine Room APC";
 	areastring = "/area/engine/engineering";
@@ -22131,8 +22124,7 @@
 /turf/open/floor/plasteel/black,
 /area/ai_monitored/turret_protected/ai_upload)
 "aQA" = (
-/obj/machinery/power/apc{
-	cell_type = /obj/item/stock_parts/cell/upgraded/plus;
+/obj/machinery/power/apc/highcap/five_k{
 	dir = 2;
 	name = "Upload APC";
 	areastring = "/area/ai_monitored/turret_protected/ai_upload";
@@ -34908,8 +34900,7 @@
 /turf/open/floor/wood,
 /area/crew_quarters/heads/hop)
 "bop" = (
-/obj/machinery/power/apc{
-	cell_type = /obj/item/stock_parts/cell/high;
+/obj/machinery/power/apc/highcap/ten_k{
 	dir = 8;
 	name = "Bridge APC";
 	areastring = "/area/bridge";
@@ -37012,9 +37003,8 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
-/obj/machinery/power/apc{
+/obj/machinery/power/apc/highcap/five_k{
 	aidisabled = 0;
-	cell_type = /obj/item/stock_parts/cell/upgraded/plus;
 	dir = 2;
 	name = "MiniSat Foyer APC";
 	areastring = "/area/ai_monitored/turret_protected/aisat/foyer";
@@ -39563,8 +39553,7 @@
 /turf/open/floor/plasteel/bar,
 /area/crew_quarters/bar)
 "bwR" = (
-/obj/machinery/power/apc{
-	cell_type = /obj/item/stock_parts/cell/upgraded/plus;
+/obj/machinery/power/apc/highcap/five_k{
 	dir = 1;
 	name = "Bar APC";
 	areastring = "/area/crew_quarters/bar";
@@ -40100,8 +40089,7 @@
 /area/crew_quarters/toilet/auxiliary)
 "bxS" = (
 /obj/item/cigbutt,
-/obj/machinery/power/apc{
-	cell_type = /obj/item/stock_parts/cell/upgraded/plus;
+/obj/machinery/power/apc/highcap/five_k{
 	dir = 2;
 	name = "Port Maintenance APC";
 	areastring = "/area/maintenance/port";
@@ -40663,8 +40651,7 @@
 	},
 /area/engine/atmos)
 "byX" = (
-/obj/machinery/power/apc{
-	cell_type = /obj/item/stock_parts/cell/high;
+/obj/machinery/power/apc/highcap/ten_k{
 	dir = 1;
 	name = "Atmospherics APC";
 	areastring = "/area/engine/atmos";
@@ -40902,8 +40889,7 @@
 /turf/open/floor/plasteel/grimy,
 /area/tcommsat/computer)
 "bzt" = (
-/obj/machinery/power/apc{
-	cell_type = /obj/item/stock_parts/cell/upgraded/plus;
+/obj/machinery/power/apc/highcap/five_k{
 	dir = 4;
 	name = "Telecomms Control Room APC";
 	areastring = "/area/tcommsat/computer";
@@ -42531,8 +42517,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 9
 	},
-/obj/machinery/power/apc{
-	cell_type = /obj/item/stock_parts/cell/upgraded/plus;
+/obj/machinery/power/apc/highcap/five_k{
 	dir = 2;
 	name = "Auxiliary Restrooms APC";
 	areastring = "/area/crew_quarters/toilet/auxiliary";
@@ -42787,8 +42772,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
-/obj/machinery/power/apc{
-	cell_type = /obj/item/stock_parts/cell/high;
+/obj/machinery/power/apc/highcap/ten_k{
 	dir = 1;
 	name = "Command Hallway APC";
 	areastring = "/area/hallway/secondary/command";
@@ -45453,8 +45437,7 @@
 	},
 /obj/item/storage/toolbox/emergency,
 /obj/item/device/flashlight,
-/obj/machinery/power/apc{
-	cell_type = /obj/item/stock_parts/cell/upgraded/plus;
+/obj/machinery/power/apc/highcap/five_k{
 	dir = 4;
 	name = "Gateway APC";
 	areastring = "/area/gateway";
@@ -47408,8 +47391,7 @@
 /turf/open/floor/plasteel/black/telecomms/mainframe,
 /area/tcommsat/server)
 "bMs" = (
-/obj/machinery/power/apc{
-	cell_type = /obj/item/stock_parts/cell/upgraded/plus;
+/obj/machinery/power/apc/highcap/five_k{
 	dir = 4;
 	name = "Telecomms Server Room APC";
 	areastring = "/area/tcommsat/server";
@@ -48624,8 +48606,7 @@
 /turf/open/floor/wood,
 /area/bridge/showroom/corporate)
 "bOF" = (
-/obj/machinery/power/apc{
-	cell_type = /obj/item/stock_parts/cell/upgraded/plus;
+/obj/machinery/power/apc/highcap/five_k{
 	dir = 4;
 	name = "Nanotrasen Corporate Showroom APC";
 	areastring = "/area/bridge/showroom/corporate";
@@ -51366,8 +51347,7 @@
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 1
 	},
-/obj/machinery/power/apc{
-	cell_type = /obj/item/stock_parts/cell/high;
+/obj/machinery/power/apc/highcap/ten_k{
 	dir = 1;
 	name = "Central Primary Hallway APC";
 	areastring = "/area/hallway/primary/central";
@@ -59112,8 +59092,7 @@
 /turf/open/floor/plasteel/white,
 /area/science/research)
 "ciJ" = (
-/obj/machinery/power/apc{
-	cell_type = /obj/item/stock_parts/cell/high;
+/obj/machinery/power/apc/highcap/ten_k{
 	dir = 1;
 	name = "Research Division APC";
 	areastring = "/area/science/research";
@@ -63755,8 +63734,7 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
 "crH" = (
-/obj/machinery/power/apc{
-	cell_type = /obj/item/stock_parts/cell/upgraded/plus;
+/obj/machinery/power/apc/highcap/five_k{
 	dir = 4;
 	name = "Aft Hallway APC";
 	areastring = "/area/hallway/primary/aft";
@@ -64647,8 +64625,7 @@
 /area/science/storage)
 "cti" = (
 /obj/machinery/portable_atmospherics/canister/oxygen,
-/obj/machinery/power/apc{
-	cell_type = /obj/item/stock_parts/cell/upgraded/plus;
+/obj/machinery/power/apc/highcap/five_k{
 	dir = 1;
 	name = "Toxins Storage APC";
 	areastring = "/area/science/storage";
@@ -70038,8 +70015,7 @@
 	pixel_y = 2
 	},
 /obj/item/storage/box/syringes,
-/obj/machinery/power/apc{
-	cell_type = /obj/item/stock_parts/cell/upgraded/plus;
+/obj/machinery/power/apc/highcap/five_k{
 	dir = 1;
 	name = "Virology APC";
 	areastring = "/area/medical/virology";
@@ -73946,8 +73922,7 @@
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit/departure_lounge)
 "cKy" = (
-/obj/machinery/power/apc{
-	cell_type = /obj/item/stock_parts/cell/upgraded/plus;
+/obj/machinery/power/apc/highcap/five_k{
 	dir = 1;
 	name = "Departure Lounge APC";
 	areastring = "/area/hallway/secondary/exit/departure_lounge";
@@ -74936,8 +74911,7 @@
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit/departure_lounge)
 "cMk" = (
-/obj/machinery/power/apc{
-	cell_type = /obj/item/stock_parts/cell/upgraded/plus;
+/obj/machinery/power/apc/highcap/five_k{
 	dir = 2;
 	name = "Aft Maintenance APC";
 	areastring = "/area/maintenance/aft";
@@ -82756,8 +82730,7 @@
 	pixel_y = 3
 	},
 /obj/item/reagent_containers/dropper,
-/obj/machinery/power/apc{
-	cell_type = /obj/item/stock_parts/cell/high;
+/obj/machinery/power/apc/highcap/ten_k{
 	dir = 1;
 	name = "Xenobiology APC";
 	areastring = "/area/science/xenobiology";
@@ -89539,8 +89512,7 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
 "dAd" = (
-/obj/machinery/power/apc{
-	cell_type = /obj/item/stock_parts/cell/upgraded/plus;
+/obj/machinery/power/apc/highcap/five_k{
 	dir = 2;
 	name = "Starboard Quarter Maintenance APC";
 	areastring = "/area/maintenance/starboard/aft";

--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -1461,7 +1461,6 @@
 /area/security/execution/education)
 "acZ" = (
 /obj/machinery/power/apc{
-	cell_type = 2500;
 	dir = 1;
 	name = "Prisoner Education Chamber APC";
 	areastring = "/area/security/execution/education";
@@ -2555,7 +2554,7 @@
 /area/security/prison)
 "aeX" = (
 /obj/machinery/power/apc{
-	cell_type = 5000;
+	cell_type = /obj/item/stock_parts/cell/upgraded/plus;
 	dir = 1;
 	name = "Prison Wing APC";
 	areastring = "/area/security/prison";
@@ -3935,7 +3934,7 @@
 /area/ai_monitored/security/armory)
 "ahF" = (
 /obj/machinery/power/apc{
-	cell_type = 5000;
+	cell_type = /obj/item/stock_parts/cell/upgraded/plus;
 	dir = 2;
 	name = "Armory APC";
 	areastring = "/area/ai_monitored/security/armory";
@@ -6334,7 +6333,7 @@
 	icon_state = "1-4"
 	},
 /obj/machinery/power/apc{
-	cell_type = 5000;
+	cell_type = /obj/item/stock_parts/cell/upgraded/plus;
 	dir = 8;
 	name = "Brig Control APC";
 	areastring = "/area/security/warden";
@@ -6499,7 +6498,6 @@
 	req_access_txt = "1"
 	},
 /obj/machinery/power/apc{
-	cell_type = 2500;
 	dir = 4;
 	name = "Shooting Range APC";
 	areastring = "/area/security/range";
@@ -7001,7 +6999,7 @@
 /area/security/main)
 "anC" = (
 /obj/machinery/power/apc{
-	cell_type = 5000;
+	cell_type = /obj/item/stock_parts/cell/upgraded/plus;
 	dir = 4;
 	name = "Security Office APC";
 	areastring = "/area/security/main";
@@ -12218,7 +12216,7 @@
 	dir = 4
 	},
 /obj/machinery/power/apc{
-	cell_type = 10000;
+	cell_type = /obj/item/stock_parts/cell/high;
 	dir = 2;
 	name = "Brig APC";
 	areastring = "/area/security/brig";
@@ -17038,7 +17036,7 @@
 	dir = 4
 	},
 /obj/machinery/power/apc{
-	cell_type = 5000;
+	cell_type = /obj/item/stock_parts/cell/upgraded/plus;
 	dir = 2;
 	name = "Fore Primary Hallway APC";
 	areastring = "/area/hallway/primary/fore";
@@ -21224,7 +21222,7 @@
 /area/hydroponics/garden)
 "aOO" = (
 /obj/machinery/power/apc{
-	cell_type = 10000;
+	cell_type = /obj/item/stock_parts/cell/high;
 	dir = 8;
 	name = "Engine Room APC";
 	areastring = "/area/engine/engineering";
@@ -22134,7 +22132,7 @@
 /area/ai_monitored/turret_protected/ai_upload)
 "aQA" = (
 /obj/machinery/power/apc{
-	cell_type = 5000;
+	cell_type = /obj/item/stock_parts/cell/upgraded/plus;
 	dir = 2;
 	name = "Upload APC";
 	areastring = "/area/ai_monitored/turret_protected/ai_upload";
@@ -24313,7 +24311,6 @@
 /area/security/courtroom)
 "aUG" = (
 /obj/machinery/power/apc{
-	cell_type = 2500;
 	dir = 2;
 	name = "Courtroom APC";
 	areastring = "/area/security/courtroom";
@@ -30962,7 +30959,6 @@
 "bhf" = (
 /obj/effect/landmark/blobstart,
 /obj/machinery/power/apc{
-	cell_type = 2500;
 	dir = 4;
 	name = "Central Maintenance APC";
 	areastring = "/area/maintenance/central";
@@ -32675,7 +32671,6 @@
 	},
 /obj/item/hand_labeler,
 /obj/machinery/power/apc{
-	cell_type = 2500;
 	dir = 4;
 	name = "Delivery Office APC";
 	areastring = "/area/quartermaster/sorting";
@@ -34503,7 +34498,6 @@
 "bnE" = (
 /obj/machinery/power/apc{
 	aidisabled = 0;
-	cell_type = 2500;
 	dir = 4;
 	name = "MiniSat Antechamber APC";
 	areastring = "/area/ai_monitored/turret_protected/aisat_interior";
@@ -34915,7 +34909,7 @@
 /area/crew_quarters/heads/hop)
 "bop" = (
 /obj/machinery/power/apc{
-	cell_type = 10000;
+	cell_type = /obj/item/stock_parts/cell/high;
 	dir = 8;
 	name = "Bridge APC";
 	areastring = "/area/bridge";
@@ -36423,7 +36417,6 @@
 "brd" = (
 /obj/structure/table,
 /obj/machinery/power/apc{
-	cell_type = 2500;
 	dir = 8;
 	name = "Art Storage APC";
 	areastring = "/area/storage/art";
@@ -37021,7 +37014,7 @@
 	},
 /obj/machinery/power/apc{
 	aidisabled = 0;
-	cell_type = 5000;
+	cell_type = /obj/item/stock_parts/cell/upgraded/plus;
 	dir = 2;
 	name = "MiniSat Foyer APC";
 	areastring = "/area/ai_monitored/turret_protected/aisat/foyer";
@@ -39571,7 +39564,7 @@
 /area/crew_quarters/bar)
 "bwR" = (
 /obj/machinery/power/apc{
-	cell_type = 5000;
+	cell_type = /obj/item/stock_parts/cell/upgraded/plus;
 	dir = 1;
 	name = "Bar APC";
 	areastring = "/area/crew_quarters/bar";
@@ -40108,7 +40101,7 @@
 "bxS" = (
 /obj/item/cigbutt,
 /obj/machinery/power/apc{
-	cell_type = 5000;
+	cell_type = /obj/item/stock_parts/cell/upgraded/plus;
 	dir = 2;
 	name = "Port Maintenance APC";
 	areastring = "/area/maintenance/port";
@@ -40671,7 +40664,7 @@
 /area/engine/atmos)
 "byX" = (
 /obj/machinery/power/apc{
-	cell_type = 10000;
+	cell_type = /obj/item/stock_parts/cell/high;
 	dir = 1;
 	name = "Atmospherics APC";
 	areastring = "/area/engine/atmos";
@@ -40910,7 +40903,7 @@
 /area/tcommsat/computer)
 "bzt" = (
 /obj/machinery/power/apc{
-	cell_type = 5000;
+	cell_type = /obj/item/stock_parts/cell/upgraded/plus;
 	dir = 4;
 	name = "Telecomms Control Room APC";
 	areastring = "/area/tcommsat/computer";
@@ -42539,7 +42532,7 @@
 	dir = 9
 	},
 /obj/machinery/power/apc{
-	cell_type = 5000;
+	cell_type = /obj/item/stock_parts/cell/upgraded/plus;
 	dir = 2;
 	name = "Auxiliary Restrooms APC";
 	areastring = "/area/crew_quarters/toilet/auxiliary";
@@ -42795,7 +42788,7 @@
 	dir = 4
 	},
 /obj/machinery/power/apc{
-	cell_type = 10000;
+	cell_type = /obj/item/stock_parts/cell/high;
 	dir = 1;
 	name = "Command Hallway APC";
 	areastring = "/area/hallway/secondary/command";
@@ -45461,7 +45454,7 @@
 /obj/item/storage/toolbox/emergency,
 /obj/item/device/flashlight,
 /obj/machinery/power/apc{
-	cell_type = 5000;
+	cell_type = /obj/item/stock_parts/cell/upgraded/plus;
 	dir = 4;
 	name = "Gateway APC";
 	areastring = "/area/gateway";
@@ -47416,7 +47409,7 @@
 /area/tcommsat/server)
 "bMs" = (
 /obj/machinery/power/apc{
-	cell_type = 5000;
+	cell_type = /obj/item/stock_parts/cell/upgraded/plus;
 	dir = 4;
 	name = "Telecomms Server Room APC";
 	areastring = "/area/tcommsat/server";
@@ -48632,7 +48625,7 @@
 /area/bridge/showroom/corporate)
 "bOF" = (
 /obj/machinery/power/apc{
-	cell_type = 5000;
+	cell_type = /obj/item/stock_parts/cell/upgraded/plus;
 	dir = 4;
 	name = "Nanotrasen Corporate Showroom APC";
 	areastring = "/area/bridge/showroom/corporate";
@@ -50924,7 +50917,6 @@
 /area/maintenance/starboard)
 "bTc" = (
 /obj/machinery/power/apc{
-	cell_type = 2500;
 	dir = 1;
 	name = "Starboard Maintenance APC";
 	areastring = "/area/maintenance/starboard";
@@ -51375,7 +51367,7 @@
 	dir = 1
 	},
 /obj/machinery/power/apc{
-	cell_type = 10000;
+	cell_type = /obj/item/stock_parts/cell/high;
 	dir = 1;
 	name = "Central Primary Hallway APC";
 	areastring = "/area/hallway/primary/central";
@@ -59121,7 +59113,7 @@
 /area/science/research)
 "ciJ" = (
 /obj/machinery/power/apc{
-	cell_type = 10000;
+	cell_type = /obj/item/stock_parts/cell/high;
 	dir = 1;
 	name = "Research Division APC";
 	areastring = "/area/science/research";
@@ -63764,7 +63756,7 @@
 /area/hallway/primary/aft)
 "crH" = (
 /obj/machinery/power/apc{
-	cell_type = 5000;
+	cell_type = /obj/item/stock_parts/cell/upgraded/plus;
 	dir = 4;
 	name = "Aft Hallway APC";
 	areastring = "/area/hallway/primary/aft";
@@ -64656,7 +64648,7 @@
 "cti" = (
 /obj/machinery/portable_atmospherics/canister/oxygen,
 /obj/machinery/power/apc{
-	cell_type = 5000;
+	cell_type = /obj/item/stock_parts/cell/upgraded/plus;
 	dir = 1;
 	name = "Toxins Storage APC";
 	areastring = "/area/science/storage";
@@ -70047,7 +70039,7 @@
 	},
 /obj/item/storage/box/syringes,
 /obj/machinery/power/apc{
-	cell_type = 5000;
+	cell_type = /obj/item/stock_parts/cell/upgraded/plus;
 	dir = 1;
 	name = "Virology APC";
 	areastring = "/area/medical/virology";
@@ -73955,7 +73947,7 @@
 /area/hallway/secondary/exit/departure_lounge)
 "cKy" = (
 /obj/machinery/power/apc{
-	cell_type = 5000;
+	cell_type = /obj/item/stock_parts/cell/upgraded/plus;
 	dir = 1;
 	name = "Departure Lounge APC";
 	areastring = "/area/hallway/secondary/exit/departure_lounge";
@@ -74945,7 +74937,7 @@
 /area/hallway/secondary/exit/departure_lounge)
 "cMk" = (
 /obj/machinery/power/apc{
-	cell_type = 5000;
+	cell_type = /obj/item/stock_parts/cell/upgraded/plus;
 	dir = 2;
 	name = "Aft Maintenance APC";
 	areastring = "/area/maintenance/aft";
@@ -82765,7 +82757,7 @@
 	},
 /obj/item/reagent_containers/dropper,
 /obj/machinery/power/apc{
-	cell_type = 10000;
+	cell_type = /obj/item/stock_parts/cell/high;
 	dir = 1;
 	name = "Xenobiology APC";
 	areastring = "/area/science/xenobiology";
@@ -87024,7 +87016,6 @@
 	icon_state = "0-8"
 	},
 /obj/machinery/power/apc{
-	cell_type = 2500;
 	dir = 4;
 	name = "Port Bow Maintenance APC";
 	areastring = "/area/maintenance/port/fore";
@@ -89549,7 +89540,7 @@
 /area/maintenance/starboard/aft)
 "dAd" = (
 /obj/machinery/power/apc{
-	cell_type = 5000;
+	cell_type = /obj/item/stock_parts/cell/upgraded/plus;
 	dir = 2;
 	name = "Starboard Quarter Maintenance APC";
 	areastring = "/area/maintenance/starboard/aft";

--- a/_maps/map_files/OmegaStation/OmegaStation.dmm
+++ b/_maps/map_files/OmegaStation/OmegaStation.dmm
@@ -2783,8 +2783,7 @@
 	d2 = 2;
 	icon_state = "0-2"
 	},
-/obj/machinery/power/apc{
-	cell_type = /obj/item/stock_parts/cell/upgraded/plus;
+/obj/machinery/power/apc/highcap/five_k{
 	dir = 1;
 	name = "Head of Personnel Quarter's APC";
 	areastring = "/area/crew_quarters/heads/hop";
@@ -2968,8 +2967,7 @@
 /turf/open/floor/wood,
 /area/security/detectives_office)
 "afh" = (
-/obj/machinery/power/apc{
-	cell_type = /obj/item/stock_parts/cell/upgraded/plus;
+/obj/machinery/power/apc/highcap/five_k{
 	dir = 1;
 	name = "Detective's Office APC";
 	areastring = "/area/security/detectives_office";
@@ -15182,8 +15180,7 @@
 	d2 = 2;
 	icon_state = "0-2"
 	},
-/obj/machinery/power/apc{
-	cell_type = /obj/item/stock_parts/cell/upgraded/plus;
+/obj/machinery/power/apc/highcap/five_k{
 	dir = 1;
 	name = "Central Starboard Maintenance APC";
 	areastring = "/area/maintenance/starboard/central";
@@ -16893,8 +16890,7 @@
 	d2 = 2;
 	icon_state = "0-2"
 	},
-/obj/machinery/power/apc{
-	cell_type = /obj/item/stock_parts/cell/upgraded/plus;
+/obj/machinery/power/apc/highcap/five_k{
 	dir = 1;
 	name = "Theatre Backstage APC";
 	areastring = "/area/crew_quarters/theatre";
@@ -19560,8 +19556,7 @@
 	d2 = 2;
 	icon_state = "0-2"
 	},
-/obj/machinery/power/apc{
-	cell_type = /obj/item/stock_parts/cell/upgraded/plus;
+/obj/machinery/power/apc/highcap/five_k{
 	dir = 1;
 	name = "Central Port Maintenance APC";
 	areastring = "/area/maintenance/port/central";
@@ -21269,8 +21264,7 @@
 /turf/open/floor/plasteel,
 /area/engine/gravity_generator)
 "aJl" = (
-/obj/machinery/power/apc{
-	cell_type = /obj/item/stock_parts/cell/upgraded/plus;
+/obj/machinery/power/apc/highcap/five_k{
 	dir = 1;
 	name = "Gravity Generator APC";
 	areastring = "/area/engine/gravity_generator";
@@ -21563,8 +21557,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/item/storage/bag/trash,
 /obj/item/key/janitor,
-/obj/machinery/power/apc{
-	cell_type = /obj/item/stock_parts/cell/upgraded/plus;
+/obj/machinery/power/apc/highcap/five_k{
 	dir = 1;
 	name = "Custodial Closet APC";
 	areastring = "/area/janitor";
@@ -26410,8 +26403,7 @@
 /obj/machinery/light{
 	dir = 1
 	},
-/obj/machinery/power/apc{
-	cell_type = /obj/item/stock_parts/cell/upgraded/plus;
+/obj/machinery/power/apc/highcap/five_k{
 	dir = 1;
 	name = "Chemistry Lab APC";
 	areastring = "/area/medical/chemistry";
@@ -30345,8 +30337,7 @@
 	locked = 0;
 	pixel_x = -23
 	},
-/obj/machinery/power/apc{
-	cell_type = /obj/item/stock_parts/cell/high;
+/obj/machinery/power/apc/highcap/ten_k{
 	dir = 1;
 	name = "Mech Bay APC";
 	areastring = "/area/science/robotics/mechbay";
@@ -33800,8 +33791,7 @@
 /obj/structure/chair/wood/normal{
 	dir = 8
 	},
-/obj/machinery/power/apc{
-	cell_type = /obj/item/stock_parts/cell/upgraded/plus;
+/obj/machinery/power/apc/highcap/five_k{
 	dir = 1;
 	name = "Chapel APC";
 	areastring = "/area/chapel/main";
@@ -34639,8 +34629,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
-/obj/machinery/power/apc{
-	cell_type = /obj/item/stock_parts/cell/upgraded/plus;
+/obj/machinery/power/apc/highcap/five_k{
 	dir = 1;
 	name = "Arrivals APC";
 	areastring = "/area/hallway/secondary/entry";

--- a/_maps/map_files/OmegaStation/OmegaStation.dmm
+++ b/_maps/map_files/OmegaStation/OmegaStation.dmm
@@ -2784,7 +2784,7 @@
 	icon_state = "0-2"
 	},
 /obj/machinery/power/apc{
-	cell_type = 5000;
+	cell_type = /obj/item/stock_parts/cell/upgraded/plus;
 	dir = 1;
 	name = "Head of Personnel Quarter's APC";
 	areastring = "/area/crew_quarters/heads/hop";
@@ -2969,7 +2969,7 @@
 /area/security/detectives_office)
 "afh" = (
 /obj/machinery/power/apc{
-	cell_type = 5000;
+	cell_type = /obj/item/stock_parts/cell/upgraded/plus;
 	dir = 1;
 	name = "Detective's Office APC";
 	areastring = "/area/security/detectives_office";
@@ -15183,7 +15183,7 @@
 	icon_state = "0-2"
 	},
 /obj/machinery/power/apc{
-	cell_type = 5000;
+	cell_type = /obj/item/stock_parts/cell/upgraded/plus;
 	dir = 1;
 	name = "Central Starboard Maintenance APC";
 	areastring = "/area/maintenance/starboard/central";
@@ -16894,7 +16894,7 @@
 	icon_state = "0-2"
 	},
 /obj/machinery/power/apc{
-	cell_type = 5000;
+	cell_type = /obj/item/stock_parts/cell/upgraded/plus;
 	dir = 1;
 	name = "Theatre Backstage APC";
 	areastring = "/area/crew_quarters/theatre";
@@ -19561,7 +19561,7 @@
 	icon_state = "0-2"
 	},
 /obj/machinery/power/apc{
-	cell_type = 5000;
+	cell_type = /obj/item/stock_parts/cell/upgraded/plus;
 	dir = 1;
 	name = "Central Port Maintenance APC";
 	areastring = "/area/maintenance/port/central";
@@ -21270,7 +21270,7 @@
 /area/engine/gravity_generator)
 "aJl" = (
 /obj/machinery/power/apc{
-	cell_type = 5000;
+	cell_type = /obj/item/stock_parts/cell/upgraded/plus;
 	dir = 1;
 	name = "Gravity Generator APC";
 	areastring = "/area/engine/gravity_generator";
@@ -21564,7 +21564,7 @@
 /obj/item/storage/bag/trash,
 /obj/item/key/janitor,
 /obj/machinery/power/apc{
-	cell_type = 5000;
+	cell_type = /obj/item/stock_parts/cell/upgraded/plus;
 	dir = 1;
 	name = "Custodial Closet APC";
 	areastring = "/area/janitor";
@@ -26411,7 +26411,7 @@
 	dir = 1
 	},
 /obj/machinery/power/apc{
-	cell_type = 5000;
+	cell_type = /obj/item/stock_parts/cell/upgraded/plus;
 	dir = 1;
 	name = "Chemistry Lab APC";
 	areastring = "/area/medical/chemistry";
@@ -30346,7 +30346,7 @@
 	pixel_x = -23
 	},
 /obj/machinery/power/apc{
-	cell_type = 10000;
+	cell_type = /obj/item/stock_parts/cell/high;
 	dir = 1;
 	name = "Mech Bay APC";
 	areastring = "/area/science/robotics/mechbay";
@@ -33801,7 +33801,7 @@
 	dir = 8
 	},
 /obj/machinery/power/apc{
-	cell_type = 5000;
+	cell_type = /obj/item/stock_parts/cell/upgraded/plus;
 	dir = 1;
 	name = "Chapel APC";
 	areastring = "/area/chapel/main";
@@ -34640,7 +34640,7 @@
 	dir = 4
 	},
 /obj/machinery/power/apc{
-	cell_type = 5000;
+	cell_type = /obj/item/stock_parts/cell/upgraded/plus;
 	dir = 1;
 	name = "Arrivals APC";
 	areastring = "/area/hallway/secondary/entry";

--- a/_maps/map_files/PubbyStation/PubbyStation.dmm
+++ b/_maps/map_files/PubbyStation/PubbyStation.dmm
@@ -3325,8 +3325,7 @@
 	},
 /area/security/prison)
 "ahJ" = (
-/obj/machinery/power/apc{
-	cell_type = /obj/item/stock_parts/cell/upgraded/plus;
+/obj/machinery/power/apc/highcap/five_k{
 	dir = 1;
 	name = "Prison Wing APC";
 	pixel_x = 1;
@@ -3804,8 +3803,7 @@
 /obj/item/storage/box/firingpins,
 /obj/item/storage/box/firingpins,
 /obj/item/key/security,
-/obj/machinery/power/apc{
-	cell_type = /obj/item/stock_parts/cell/upgraded/plus;
+/obj/machinery/power/apc/highcap/five_k{
 	dir = 4;
 	name = "Armory APC";
 	pixel_x = 24
@@ -5369,8 +5367,7 @@
 	d2 = 8;
 	icon_state = "0-8"
 	},
-/obj/machinery/power/apc{
-	cell_type = /obj/item/stock_parts/cell/high;
+/obj/machinery/power/apc/highcap/ten_k{
 	dir = 4;
 	name = "Brig APC";
 	pixel_x = 24
@@ -11494,8 +11491,7 @@
 /area/bridge)
 "azo" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/machinery/power/apc{
-	cell_type = /obj/item/stock_parts/cell/high;
+/obj/machinery/power/apc/highcap/ten_k{
 	dir = 4;
 	name = "Bridge APC";
 	areastring = "/area/bridge";
@@ -12400,8 +12396,7 @@
 	},
 /area/ai_monitored/turret_protected/ai_upload)
 "aBx" = (
-/obj/machinery/power/apc{
-	cell_type = /obj/item/stock_parts/cell/upgraded/plus;
+/obj/machinery/power/apc/highcap/five_k{
 	dir = 1;
 	name = "Upload APC";
 	areastring = "/area/ai_monitored/turret_protected/ai_upload";
@@ -12507,8 +12502,7 @@
 /turf/open/floor/wood,
 /area/crew_quarters/heads/hop)
 "aBH" = (
-/obj/machinery/power/apc{
-	cell_type = /obj/item/stock_parts/cell/upgraded/plus;
+/obj/machinery/power/apc/highcap/five_k{
 	dir = 8;
 	name = "Central Hall APC";
 	pixel_x = -25
@@ -17678,8 +17672,7 @@
 	},
 /area/hallway/secondary/exit/departure_lounge)
 "aMO" = (
-/obj/machinery/power/apc{
-	cell_type = /obj/item/stock_parts/cell/upgraded/plus;
+/obj/machinery/power/apc/highcap/five_k{
 	dir = 1;
 	name = "Departure Lounge APC";
 	areastring = "/area/hallway/secondary/exit/departure_lounge";
@@ -17840,8 +17833,7 @@
 /area/crew_quarters/toilet/auxiliary)
 "aNe" = (
 /obj/structure/cable,
-/obj/machinery/power/apc{
-	cell_type = /obj/item/stock_parts/cell/upgraded/plus;
+/obj/machinery/power/apc/highcap/five_k{
 	dir = 2;
 	name = "Auxiliary Restrooms APC";
 	pixel_y = -24
@@ -33659,8 +33651,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
-/obj/machinery/power/apc{
-	cell_type = /obj/item/stock_parts/cell/high;
+/obj/machinery/power/apc/highcap/ten_k{
 	dir = 1;
 	name = "Research Lobby APC";
 	pixel_y = 25
@@ -33767,8 +33758,7 @@
 /turf/closed/wall,
 /area/science/research)
 "bvL" = (
-/obj/machinery/power/apc{
-	cell_type = /obj/item/stock_parts/cell/high;
+/obj/machinery/power/apc/highcap/ten_k{
 	dir = 1;
 	name = "Research Division APC";
 	pixel_y = 25
@@ -34018,8 +34008,7 @@
 	icon_state = "0-4";
 	d2 = 4
 	},
-/obj/machinery/power/apc{
-	cell_type = /obj/item/stock_parts/cell/upgraded/plus;
+/obj/machinery/power/apc/highcap/five_k{
 	dir = 8;
 	name = "Xenobiology APC";
 	pixel_x = -25
@@ -39329,8 +39318,7 @@
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
 "bGU" = (
-/obj/machinery/power/apc{
-	cell_type = /obj/item/stock_parts/cell/upgraded/plus;
+/obj/machinery/power/apc/highcap/five_k{
 	dir = 1;
 	name = "Virology APC";
 	pixel_y = 24
@@ -46637,8 +46625,7 @@
 	amount = 50
 	},
 /obj/item/stack/cable_coil,
-/obj/machinery/power/apc{
-	cell_type = /obj/item/stock_parts/cell/high;
+/obj/machinery/power/apc/highcap/ten_k{
 	dir = 8;
 	name = "Engine Room APC";
 	areastring = "/area/engine/engine_smes";
@@ -47188,8 +47175,7 @@
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
 "bYG" = (
-/obj/machinery/power/apc{
-	cell_type = /obj/item/stock_parts/cell/upgraded/plus;
+/obj/machinery/power/apc/highcap/five_k{
 	dir = 8;
 	name = "Engineering Maintenance APC";
 	pixel_x = -25;
@@ -47586,8 +47572,7 @@
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "bZc" = (
-/obj/machinery/power/apc{
-	cell_type = /obj/item/stock_parts/cell/high/plus;
+/obj/machinery/power/apc/highcap/fifteen_k{
 	dir = 4;
 	name = "Engineering APC";
 	pixel_x = 28
@@ -53308,8 +53293,7 @@
 /turf/open/floor/circuit/telecomms/mainframe,
 /area/tcommsat/server)
 "cmI" = (
-/obj/machinery/power/apc{
-	cell_type = /obj/item/stock_parts/cell/upgraded/plus;
+/obj/machinery/power/apc/highcap/five_k{
 	dir = 1;
 	layer = 4;
 	name = "Telecomms Server APC";

--- a/_maps/map_files/PubbyStation/PubbyStation.dmm
+++ b/_maps/map_files/PubbyStation/PubbyStation.dmm
@@ -3326,7 +3326,7 @@
 /area/security/prison)
 "ahJ" = (
 /obj/machinery/power/apc{
-	cell_type = 5000;
+	cell_type = /obj/item/stock_parts/cell/upgraded/plus;
 	dir = 1;
 	name = "Prison Wing APC";
 	pixel_x = 1;
@@ -3805,7 +3805,7 @@
 /obj/item/storage/box/firingpins,
 /obj/item/key/security,
 /obj/machinery/power/apc{
-	cell_type = 5000;
+	cell_type = /obj/item/stock_parts/cell/upgraded/plus;
 	dir = 4;
 	name = "Armory APC";
 	pixel_x = 24
@@ -5370,7 +5370,7 @@
 	icon_state = "0-8"
 	},
 /obj/machinery/power/apc{
-	cell_type = 10000;
+	cell_type = /obj/item/stock_parts/cell/high;
 	dir = 4;
 	name = "Brig APC";
 	pixel_x = 24
@@ -10810,7 +10810,6 @@
 /area/crew_quarters/heads/captain)
 "axS" = (
 /obj/machinery/power/apc{
-	cell_type = 2500;
 	dir = 1;
 	name = "Captain's Office APC";
 	pixel_y = 24
@@ -11496,7 +11495,7 @@
 "azo" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/machinery/power/apc{
-	cell_type = 10000;
+	cell_type = /obj/item/stock_parts/cell/high;
 	dir = 4;
 	name = "Bridge APC";
 	areastring = "/area/bridge";
@@ -12402,7 +12401,7 @@
 /area/ai_monitored/turret_protected/ai_upload)
 "aBx" = (
 /obj/machinery/power/apc{
-	cell_type = 5000;
+	cell_type = /obj/item/stock_parts/cell/upgraded/plus;
 	dir = 1;
 	name = "Upload APC";
 	areastring = "/area/ai_monitored/turret_protected/ai_upload";
@@ -12509,7 +12508,7 @@
 /area/crew_quarters/heads/hop)
 "aBH" = (
 /obj/machinery/power/apc{
-	cell_type = 5000;
+	cell_type = /obj/item/stock_parts/cell/upgraded/plus;
 	dir = 8;
 	name = "Central Hall APC";
 	pixel_x = -25
@@ -17680,7 +17679,7 @@
 /area/hallway/secondary/exit/departure_lounge)
 "aMO" = (
 /obj/machinery/power/apc{
-	cell_type = 5000;
+	cell_type = /obj/item/stock_parts/cell/upgraded/plus;
 	dir = 1;
 	name = "Departure Lounge APC";
 	areastring = "/area/hallway/secondary/exit/departure_lounge";
@@ -17842,7 +17841,7 @@
 "aNe" = (
 /obj/structure/cable,
 /obj/machinery/power/apc{
-	cell_type = 5000;
+	cell_type = /obj/item/stock_parts/cell/upgraded/plus;
 	dir = 2;
 	name = "Auxiliary Restrooms APC";
 	pixel_y = -24
@@ -20209,7 +20208,6 @@
 /area/quartermaster/storage)
 "aSl" = (
 /obj/machinery/power/apc{
-	cell_type = 2500;
 	dir = 4;
 	name = "Cargo Maintenance APC";
 	pixel_x = 24
@@ -33662,7 +33660,7 @@
 	dir = 4
 	},
 /obj/machinery/power/apc{
-	cell_type = 10000;
+	cell_type = /obj/item/stock_parts/cell/high;
 	dir = 1;
 	name = "Research Lobby APC";
 	pixel_y = 25
@@ -33770,7 +33768,7 @@
 /area/science/research)
 "bvL" = (
 /obj/machinery/power/apc{
-	cell_type = 10000;
+	cell_type = /obj/item/stock_parts/cell/high;
 	dir = 1;
 	name = "Research Division APC";
 	pixel_y = 25
@@ -34021,7 +34019,7 @@
 	d2 = 4
 	},
 /obj/machinery/power/apc{
-	cell_type = 5000;
+	cell_type = /obj/item/stock_parts/cell/upgraded/plus;
 	dir = 8;
 	name = "Xenobiology APC";
 	pixel_x = -25
@@ -39332,7 +39330,7 @@
 /area/medical/virology)
 "bGU" = (
 /obj/machinery/power/apc{
-	cell_type = 5000;
+	cell_type = /obj/item/stock_parts/cell/upgraded/plus;
 	dir = 1;
 	name = "Virology APC";
 	pixel_y = 24
@@ -46640,7 +46638,7 @@
 	},
 /obj/item/stack/cable_coil,
 /obj/machinery/power/apc{
-	cell_type = 10000;
+	cell_type = /obj/item/stock_parts/cell/high;
 	dir = 8;
 	name = "Engine Room APC";
 	areastring = "/area/engine/engine_smes";
@@ -47191,7 +47189,7 @@
 /area/maintenance/department/engine)
 "bYG" = (
 /obj/machinery/power/apc{
-	cell_type = 5000;
+	cell_type = /obj/item/stock_parts/cell/upgraded/plus;
 	dir = 8;
 	name = "Engineering Maintenance APC";
 	pixel_x = -25;
@@ -47589,7 +47587,7 @@
 /area/engine/engineering)
 "bZc" = (
 /obj/machinery/power/apc{
-	cell_type = 15000;
+	cell_type = /obj/item/stock_parts/cell/high/plus;
 	dir = 4;
 	name = "Engineering APC";
 	pixel_x = 28
@@ -53311,7 +53309,7 @@
 /area/tcommsat/server)
 "cmI" = (
 /obj/machinery/power/apc{
-	cell_type = 5000;
+	cell_type = /obj/item/stock_parts/cell/upgraded/plus;
 	dir = 1;
 	layer = 4;
 	name = "Telecomms Server APC";

--- a/code/modules/power/apc.dm
+++ b/code/modules/power/apc.dm
@@ -55,7 +55,7 @@
 	var/areastring = null
 	var/obj/item/stock_parts/cell/cell
 	var/start_charge = 90				// initial cell charge %
-	var/cell_type = 2500				// 0=no cell, 1=regular, 2=high-cap (x5) <- old, now it's just 0=no cell, otherwise dictate cellcapacity by changing this value. 1 used to be 1000, 2 was 2500
+	var/cell_type = /obj/item/stock_parts/cell/upgraded		//Enter the path of the cell you want to use. cell determines charge rates, max capacity, ect. These can also be changed with other APC vars, but isn't recommended to minimize the risk of accidental usage of dirty editted APCs
 	var/opened = 0 //0=closed, 1=opened, 2=cover removed
 	var/shorted = 0
 	var/lighting = 3
@@ -177,8 +177,7 @@
 	has_electronics = 2 //installed and secured
 	// is starting with a power cell installed, create it and set its charge level
 	if(cell_type)
-		src.cell = new/obj/item/stock_parts/cell(src)
-		cell.maxcharge = cell_type	// cell_type is maximum charge (old default was 1000 or 2500 (values one and two respectively)
+		cell = new cell_type
 		cell.charge = start_charge * cell.maxcharge / 100 		// (convert percentage to actual value)
 
 	var/area/A = src.loc.loc

--- a/code/modules/power/apc.dm
+++ b/code/modules/power/apc.dm
@@ -55,7 +55,7 @@
 	var/areastring = null
 	var/obj/item/stock_parts/cell/cell
 	var/start_charge = 90				// initial cell charge %
-	var/cell_type = /obj/item/stock_parts/cell/upgraded		//Enter the path of the cell you want to use. cell determines charge rates, max capacity, ect. These can also be changed with other APC vars, but isn't recommended to minimize the risk of accidental usage of dirty editted APCs
+	var/cell_type = /obj/item/stock_parts/cell/upgraded		//Base cell has 2500 capacity. Enter the path of a different cell you want to use. cell determines charge rates, max capacity, ect. These can also be changed with other APC vars, but isn't recommended to minimize the risk of accidental usage of dirty editted APCs
 	var/opened = 0 //0=closed, 1=opened, 2=cover removed
 	var/shorted = 0
 	var/lighting = 3
@@ -91,6 +91,15 @@
 	var/update_state = -1
 	var/update_overlay = -1
 	var/icon_update_needed = FALSE
+
+/obj/machinery/power/apc/highcap/five_k
+	cell_type = /obj/item/stock_parts/cell/upgraded/plus
+
+/obj/machinery/power/apc/highcap/ten_k
+	cell_type = /obj/item/stock_parts/cell/high
+
+/obj/machinery/power/apc/highcap/fifteen_k
+	cell_type = /obj/item/stock_parts/cell/high/plus
 
 /obj/machinery/power/apc/get_cell()
 	return cell

--- a/code/modules/power/cell.dm
+++ b/code/modules/power/cell.dm
@@ -176,6 +176,20 @@
 	..()
 	charge = 0
 
+/obj/item/stock_parts/cell/upgraded
+	name = "high-capacity power cell"
+	desc = "A power cell with a slightly higher capacity than normal!"
+	maxcharge = 2500
+	materials = list(MAT_GLASS=50)
+	rating = 2
+	chargerate = 1000
+
+/obj/item/stock_parts/cell/upgraded/plus
+	name = "upgraded power cell+"
+	desc = "A power cell with an even higher capacity than the base model!"
+	maxcharge = 5000
+	rating = 2
+
 /obj/item/stock_parts/cell/secborg
 	name = "security borg rechargeable D battery"
 	origin_tech = null

--- a/code/modules/power/cell.dm
+++ b/code/modules/power/cell.dm
@@ -188,7 +188,6 @@
 	name = "upgraded power cell+"
 	desc = "A power cell with an even higher capacity than the base model!"
 	maxcharge = 5000
-	rating = 2
 
 /obj/item/stock_parts/cell/secborg
 	name = "security borg rechargeable D battery"


### PR DESCRIPTION
Closes #30326

Setting a APC's cell_type just sets the max_charge var for the standard cell inside, resulting in a ton of var-editted increased capacity standard cells being spread out around the station.

This makes it so those cells are actually the proper types instead of just being a mass of varedited ones.

regex;
`/obj/machinery/power/apc{\r\n	cell_type = 10000;`
to 
`/obj/machinery/power/apc/highcap/ten_k{`

.

`/obj/machinery/power/apc{\r\n	cell_type = 15000;`
to 
`/obj/machinery/power/apc/highcap/fifteen_k{`

.


`/obj/machinery/power/apc{\r\n	cell_type = 5000;`
to 
`/obj/machinery/power/apc/highcap/five_k{`

.

`/obj/machinery/power/apc{\r\n	cell_type = 2500;`
to 
`/obj/machinery/power/apc{`
dirty edit.

.


`cell_type = 0`
to
`start_charge = 0`
^ _(this was bad since it means that those cells would NEVER hold a charge and shouldn't have been done in the first place.)_

Then just clean up any leftover `cell_type =` (there should only be a few if any)