### PR TITLE
Temporarily removes BYOS kit from comms console

### DIFF
--- a/config/unbuyableshuttles.txt
+++ b/config/unbuyableshuttles.txt
@@ -13,7 +13,7 @@
 
 ##Others
 #_maps/shuttles/emergency_asteroid.dmm
-#_maps/shuttles/emergency_airless.dmm
+_maps/shuttles/emergency_airless.dmm
 #_maps/shuttles/emergency_arena.dmm
 #_maps/shuttles/emergency_bar.dmm
 #_maps/shuttles/emergency_clown.dmm


### PR DESCRIPTION
:cl: nervere
tweak: Removed the "build your own shuttle" option from the communications console until it is fixed.
/:cl:

[why]: The build your own shuttle, while not necessarily a bad shuttle, is currently broken. If the shuttle is called and a build your own shuttle has been purchased, the ETA on the shuttle will count down until it hits about 0:03, in which it will tick down to zero, then go back to 0:03. This is done indefinitely. It's best for the server if the shuttle is temporarily removed from communications consoles until this issue is fixed, as it can delay a round indefinitely until admin intervention occurs.
