### PR TITLE
Fixes anti-drop exploit

### DIFF
--- a/code/modules/surgery/organs/augments_internal.dm
+++ b/code/modules/surgery/organs/augments_internal.dm
@@ -87,6 +87,7 @@
 /obj/item/organ/cyberimp/brain/anti_drop/proc/release_items()
 	for(var/obj/item/I in stored_items)
 		I.flags_1 &= ~NODROP_1
+	stored_items = list()
 
 
 /obj/item/organ/cyberimp/brain/anti_drop/Remove(var/mob/living/carbon/M, special = 0)


### PR DESCRIPTION
stored items not being cleared lets you set an infinite amoutn of items to nodrop until you get emped.