### PR TITLE
Gives the detective a mass spectrometer

### DIFF
--- a/code/game/objects/structures/crates_lockers/closets/secure/security.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/security.dm
@@ -185,6 +185,7 @@
 	new /obj/item/clothing/suit/armor/vest/det_suit(src)
 	new /obj/item/storage/belt/holster/full(src)
 	new /obj/item/pinpointer/crew(src)
+	new /obj/item/device/mass_spectrometer(src)
 
 /obj/structure/closet/secure_closet/injection
 	name = "lethal injections"


### PR DESCRIPTION



:cl: as334
add: Added a mass spectrometer to the detective's closet

/:cl:

The detectives job is based off of their access to information, and since detective is currently fairly limited in what information they can gather, this is a tool to help them with investigations and crime solving.

It's main use would be detecting poisons or other chemicals from corpses or other blood samples to determine cause or circumstances of death.