### PR TITLE
Emags remove access restrictions from buttons again.

### DIFF
--- a/code/game/machinery/buttons.dm
+++ b/code/game/machinery/buttons.dm
@@ -105,8 +105,8 @@
 /obj/machinery/button/emag_act(mob/user)
 	if(emagged)
 		return
-	req_access = null
-	req_one_access = null
+	req_access = list()
+	req_one_access = list()
 	playsound(src, "sparks", 100, 1)
 	emagged = TRUE
 

--- a/code/game/mecha/mech_fabricator.dm
+++ b/code/game/mecha/mech_fabricator.dm
@@ -78,7 +78,7 @@
 	if(emagged)
 		return
 	emagged = TRUE
-	req_access = null
+	req_access = list()
 	say("DB error \[Code 0x00F1\]")
 	sleep(10)
 	say("Attempting auto-repair...")

--- a/code/modules/shuttle/computer.dm
+++ b/code/modules/shuttle/computer.dm
@@ -78,7 +78,7 @@
 /obj/machinery/computer/shuttle/emag_act(mob/user)
 	if(emagged)
 		return
-	req_access = null
+	req_access = list()
 	emagged = TRUE
 	to_chat(user, "<span class='notice'>You fried the consoles ID checking system.</span>")
 


### PR DESCRIPTION
Emagging a button, mech fabricator, or shuttle console should again remove access restrictions.
Bug caused by #29238, setting req_access to null causes it to be regenerated from req_access_txt.