### PR TITLE
Fix monastery shuttle + Pods

### DIFF
--- a/_maps/map_files/PubbyStation/PubbyStation.dmm
+++ b/_maps/map_files/PubbyStation/PubbyStation.dmm
@@ -43456,7 +43456,7 @@
 	dir = 2;
 	network = list("SS13")
 	},
-/obj/item/circuitboard/computer/shuttle/monastery_shuttle,
+/obj/item/circuitboard/computer/monastery_shuttle,
 /turf/open/floor/plasteel/darkgreen,
 /area/storage/tech)
 "bQx" = (

--- a/code/game/machinery/computer/monastery_shuttle.dm
+++ b/code/game/machinery/computer/monastery_shuttle.dm
@@ -1,7 +1,7 @@
 /obj/machinery/computer/shuttle/monastery_shuttle
 	name = "monastery shuttle console"
 	desc = "Used to control the monastery shuttle."
-	circuit = /obj/item/circuitboard/computer/shuttle/monastery_shuttle
+	circuit = /obj/item/circuitboard/computer/monastery_shuttle
 	shuttleId = "pod1"
 	possible_destinations = "monastery_shuttle_asteroid;monastery_shuttle_station"
 	no_destination_swap = TRUE

--- a/code/game/objects/items/circuitboards/computer_circuitboards.dm
+++ b/code/game/objects/items/circuitboards/computer_circuitboards.dm
@@ -257,22 +257,6 @@
 	build_path = /obj/machinery/computer/telecomms/server
 	origin_tech = "programming=3;magnets=3;bluespace=2"
 
-/obj/item/circuitboard/computer/shuttle
-	name = "Shuttle (Computer Board)"
-	build_path = /obj/machinery/computer/shuttle
-	var/shuttleId
-	var/possible_destinations = ""
-
-/obj/item/circuitboard/computer/shuttle/attackby(obj/item/I, mob/user, params)
-	if(istype(I, /obj/item/device/multitool))
-		var/chosen_id = round(input(usr, "Choose an ID number (-1 for reset):", "Input an Integer", null) as num|null)
-		if(chosen_id >= 0)
-			shuttleId = chosen_id
-		else
-			shuttleId = initial(shuttleId)
-	else
-		return ..()
-
 /obj/item/circuitboard/computer/labor_shuttle
 	name = "Labor Shuttle (Computer Board)"
 	build_path = /obj/machinery/computer/shuttle/labor
@@ -339,7 +323,7 @@
 	build_path = /obj/machinery/computer/apc_control
 	origin_tech = "programming=3;engineering=3;powerstorage=2"
 
-/obj/item/circuitboard/computer/shuttle/monastery_shuttle
+/obj/item/circuitboard/computer/monastery_shuttle
 	name = "Monastery Shuttle (Computer Board)"
 	build_path = /obj/machinery/computer/shuttle/monastery_shuttle
 

--- a/code/modules/shuttle/computer.dm
+++ b/code/modules/shuttle/computer.dm
@@ -9,10 +9,6 @@
 	var/admin_controlled
 	var/no_destination_swap = 0
 
-/obj/machinery/computer/shuttle/Initialize()
-	..()
-	return INITIALIZE_HINT_LATELOAD
-
 /obj/machinery/computer/shuttle/attack_hand(mob/user)
 	if(..(user))
 		return

--- a/code/modules/shuttle/computer.dm
+++ b/code/modules/shuttle/computer.dm
@@ -4,7 +4,6 @@
 	icon_keyboard = "tech_key"
 	light_color = LIGHT_COLOR_CYAN
 	req_access = list( )
-	circuit = /obj/item/circuitboard/computer/shuttle
 	var/shuttleId
 	var/possible_destinations = ""
 	var/admin_controlled
@@ -13,12 +12,6 @@
 /obj/machinery/computer/shuttle/Initialize()
 	..()
 	return INITIALIZE_HINT_LATELOAD
-
-/obj/machinery/computer/shuttle/LateInitialize()
-	if(istype(circuit, /obj/item/circuitboard/computer/shuttle))
-		var/obj/item/circuitboard/computer/shuttle/C = circuit
-		possible_destinations = C.possible_destinations
-		shuttleId = C.shuttleId
 
 /obj/machinery/computer/shuttle/attack_hand(mob/user)
 	if(..(user))


### PR DESCRIPTION
`/obj/item/circuitboard/computer/shuttle` was old code that used integers for shuttleIds rather than strings, but it did not work properly and never appeared in-game. The monastery shuttle's board was mistakenly a subtype of this path, causing it to inherit the bugged behavior.

The fix was to remove `/obj/item/circuitboard/computer/shuttle` and repath the monastery shuttle circuit board to be like the other shuttles.

Escape pods were also fixed with by change, as they used `/obj/item/circuitboard/computer/shuttle` too.

Closes #29881 
Closes #30390

:cl: Pubby
fix: Escape pods and PubbyStation's monastery shuttle are back in commission
/:cl:
