### PR TITLE
Soil plot fixes

### DIFF
--- a/code/modules/hydroponics/hydroponics.dm
+++ b/code/modules/hydroponics/hydroponics.dm
@@ -917,7 +917,8 @@
 	icon_state = "soil"
 	density = FALSE
 	use_power = NO_POWER_USE
-	unwrenchable = 0
+	flags_1 = NODECONSTRUCT_1
+	unwrenchable = FALSE
 
 /obj/machinery/hydroponics/soil/update_icon_hoses()
 	return // Has no hoses

--- a/code/modules/hydroponics/hydroponics.dm
+++ b/code/modules/hydroponics/hydroponics.dm
@@ -915,6 +915,7 @@
 	name = "soil"
 	icon = 'icons/obj/hydroponics/equipment.dmi'
 	icon_state = "soil"
+	circuit = null
 	density = FALSE
 	use_power = NO_POWER_USE
 	flags_1 = NODECONSTRUCT_1


### PR DESCRIPTION
Make soil plots NODECONSTRUCT so that they don't leave behind machine frames.

Removes their circuit board so that they don't spawn with components.

Closes #30380