### PR TITLE
Fix CentCom issues

### DIFF
--- a/_maps/map_files/generic/CentCom.dmm
+++ b/_maps/map_files/generic/CentCom.dmm
@@ -1,4 +1,4 @@
-//MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE 
+//MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
 "aa" = (
 /turf/open/space/basic,
 /area/space)
@@ -58,10 +58,7 @@
 /obj/item/stack/medical/ointment{
 	heal_burn = 10
 	},
-/turf/open/floor/holofloor{
-	icon_state = "asteroid_warn_side";
-	dir = 8
-	},
+/turf/open/floor/holofloor/asteroid,
 /area/holodeck/rec_center/bunker)
 "am" = (
 /obj/structure/table/wood{
@@ -160,10 +157,7 @@
 "aA" = (
 /obj/structure/table,
 /obj/machinery/recharger,
-/turf/open/floor/holofloor{
-	icon_state = "asteroidfloor";
-	dir = 8
-	},
+/turf/open/floor/holofloor/asteroid,
 /area/holodeck/rec_center/bunker)
 "aB" = (
 /obj/structure/table/wood,
@@ -213,10 +207,7 @@
 "aJ" = (
 /obj/structure/table,
 /obj/item/gun/energy/laser,
-/turf/open/floor/holofloor{
-	icon_state = "asteroidfloor";
-	dir = 8
-	},
+/turf/open/floor/holofloor/asteroid,
 /area/holodeck/rec_center/bunker)
 "aK" = (
 /obj/structure/chair/wood/normal{
@@ -360,10 +351,7 @@
 /obj/item/stack/medical/bruise_pack{
 	heal_brute = 10
 	},
-/turf/open/floor/holofloor{
-	icon_state = "asteroid_warn_side";
-	dir = 8
-	},
+/turf/open/floor/holofloor/asteroid,
 /area/holodeck/rec_center/bunker)
 "bf" = (
 /obj/structure/table/wood,
@@ -428,7 +416,6 @@
 /obj/item/surgicaldrill,
 /turf/open/floor/holofloor{
 	icon_state = "white";
-	dir = 9
 	},
 /area/holodeck/rec_center/medical)
 "br" = (
@@ -436,7 +423,6 @@
 /obj/item/hemostat,
 /turf/open/floor/holofloor{
 	icon_state = "white";
-	dir = 1
 	},
 /area/holodeck/rec_center/medical)
 "bs" = (
@@ -447,7 +433,6 @@
 /obj/item/circular_saw,
 /turf/open/floor/holofloor{
 	icon_state = "white";
-	dir = 1
 	},
 /area/holodeck/rec_center/medical)
 "bt" = (
@@ -455,7 +440,6 @@
 /obj/item/retractor,
 /turf/open/floor/holofloor{
 	icon_state = "white";
-	dir = 1
 	},
 /area/holodeck/rec_center/medical)
 "bu" = (
@@ -464,7 +448,6 @@
 /obj/item/cautery,
 /turf/open/floor/holofloor{
 	icon_state = "white";
-	dir = 5
 	},
 /area/holodeck/rec_center/medical)
 "bv" = (
@@ -492,33 +475,21 @@
 /turf/open/floor/holofloor/beach,
 /area/holodeck/rec_center/beach)
 "bz" = (
-/turf/open/floor/holofloor/basalt,
 /obj/structure/table,
 /obj/machinery/readybutton,
-/turf/open/floor/holofloor{
-	icon_state = "warningline";
-	dir = 2
-	},
+/turf/open/floor/holofloor/basalt,
 /area/holodeck/rec_center/thunderdome)
 "bA" = (
-/turf/open/floor/holofloor/basalt,
 /obj/structure/table,
 /obj/item/clothing/head/helmet/thunderdome,
 /obj/item/clothing/suit/armor/tdome/red,
 /obj/item/clothing/under/color/red,
 /obj/item/holo/esword/red,
-/turf/open/floor/holofloor{
-	icon_state = "warningline";
-	dir = 2
-	},
+/turf/open/floor/holofloor/basalt,
 /area/holodeck/rec_center/thunderdome)
 "bB" = (
-/turf/open/floor/holofloor/basalt,
 /obj/structure/table,
-/turf/open/floor/holofloor{
-	icon_state = "warningline";
-	dir = 2
-	},
+/turf/open/floor/holofloor/basalt,
 /area/holodeck/rec_center/thunderdome)
 "bC" = (
 /obj/machinery/readybutton,
@@ -558,7 +529,6 @@
 /obj/item/razor,
 /turf/open/floor/holofloor{
 	icon_state = "white";
-	dir = 8
 	},
 /area/holodeck/rec_center/medical)
 "bJ" = (
@@ -569,7 +539,6 @@
 "bK" = (
 /turf/open/floor/holofloor{
 	icon_state = "white";
-	dir = 4
 	},
 /area/holodeck/rec_center/medical)
 "bL" = (
@@ -636,19 +605,18 @@
 "bX" = (
 /turf/open/floor/holofloor{
 	icon_state = "white";
-	dir = 10
 	},
 /area/holodeck/rec_center/medical)
 "bZ" = (
 /obj/structure/table/optable,
 /turf/open/floor/holofloor{
-	icon_state = "white"
+	icon_state = "white";
 	},
 /area/holodeck/rec_center/medical)
 "ca" = (
 /obj/machinery/computer/operating,
 /turf/open/floor/holofloor{
-	icon_state = "white"
+	icon_state = "white";
 	},
 /area/holodeck/rec_center/medical)
 "cb" = (
@@ -658,7 +626,6 @@
 /obj/item/clothing/mask/surgical,
 /turf/open/floor/holofloor{
 	icon_state = "white";
-	dir = 6
 	},
 /area/holodeck/rec_center/medical)
 "cc" = (
@@ -701,7 +668,7 @@
 	dir = 1
 	},
 /turf/open/floor/holofloor{
-	icon_state = "white"
+	icon_state = "white";
 	},
 /area/holodeck/rec_center/medical)
 "cj" = (
@@ -714,13 +681,11 @@
 /obj/machinery/reagentgrinder,
 /turf/open/floor/holofloor{
 	icon_state = "white";
-	dir = 9
 	},
 /area/holodeck/rec_center/medical)
 "cl" = (
 /turf/open/floor/holofloor{
 	icon_state = "white";
-	dir = 5
 	},
 /area/holodeck/rec_center/medical)
 "cm" = (
@@ -731,13 +696,13 @@
 	},
 /obj/item/storage/box/beakers,
 /turf/open/floor/holofloor{
-	icon_state = "white"
+	icon_state = "white";
 	},
 /area/holodeck/rec_center/medical)
 "cn" = (
 /obj/machinery/washing_machine,
 /turf/open/floor/holofloor{
-	icon_state = "white"
+	icon_state = "white";
 	},
 /area/holodeck/rec_center/medical)
 "co" = (
@@ -812,26 +777,24 @@
 /obj/machinery/chem_master,
 /turf/open/floor/holofloor{
 	icon_state = "white";
-	dir = 10
 	},
 /area/holodeck/rec_center/medical)
 "cz" = (
 /turf/open/floor/holofloor{
 	icon_state = "white";
-	dir = 6
 	},
 /area/holodeck/rec_center/medical)
 "cA" = (
 /obj/structure/table/glass,
 /obj/item/device/healthanalyzer,
 /turf/open/floor/holofloor{
-	icon_state = "white"
+	icon_state = "white";
 	},
 /area/holodeck/rec_center/medical)
 "cB" = (
 /obj/structure/closet/wardrobe/white,
 /turf/open/floor/holofloor{
-	icon_state = "white"
+	icon_state = "white";
 	},
 /area/holodeck/rec_center/medical)
 "cC" = (
@@ -948,7 +911,6 @@
 	},
 /turf/open/floor/holofloor{
 	icon_state = "white";
-	dir = 9
 	},
 /area/holodeck/rec_center/medical)
 "cW" = (
@@ -962,7 +924,6 @@
 	},
 /turf/open/floor/holofloor{
 	icon_state = "white";
-	dir = 5
 	},
 /area/holodeck/rec_center/medical)
 "cX" = (
@@ -971,7 +932,7 @@
 	},
 /obj/machinery/computer/pandemic,
 /turf/open/floor/holofloor{
-	icon_state = "white"
+	icon_state = "white";
 	},
 /area/holodeck/rec_center/medical)
 "cY" = (
@@ -1004,7 +965,6 @@
 "de" = (
 /turf/open/floor/holofloor{
 	icon_state = "white";
-	dir = 8
 	},
 /area/holodeck/rec_center/medical)
 "df" = (
@@ -1017,13 +977,11 @@
 /obj/machinery/door/window/westleft,
 /turf/open/floor/holofloor{
 	icon_state = "white";
-	dir = 1
 	},
 /area/holodeck/rec_center/medical)
 "dh" = (
 /turf/open/floor/holofloor{
 	icon_state = "white";
-	dir = 1
 	},
 /area/holodeck/rec_center/medical)
 "di" = (
@@ -1037,7 +995,6 @@
 	},
 /turf/open/floor/holofloor{
 	icon_state = "white";
-	dir = 10
 	},
 /area/holodeck/rec_center/medical)
 "dk" = (
@@ -1050,7 +1007,7 @@
 	density = 0
 	},
 /turf/open/floor/holofloor{
-	icon_state = "white"
+	icon_state = "white";
 	},
 /area/holodeck/rec_center/medical)
 "dl" = (
@@ -1061,7 +1018,7 @@
 	dir = 1
 	},
 /turf/open/floor/holofloor{
-	icon_state = "white"
+	icon_state = "white";
 	},
 /area/holodeck/rec_center/medical)
 "dm" = (
@@ -1069,7 +1026,7 @@
 	density = 0
 	},
 /turf/open/floor/holofloor{
-	icon_state = "white"
+	icon_state = "white";
 	},
 /area/holodeck/rec_center/medical)
 "dn" = (
@@ -1078,7 +1035,6 @@
 	},
 /turf/open/floor/holofloor{
 	icon_state = "white";
-	dir = 6
 	},
 /area/holodeck/rec_center/medical)
 "do" = (
@@ -1115,16 +1071,12 @@
 	},
 /area/holodeck/rec_center/thunderdome)
 "dt" = (
-/turf/open/floor/holofloor/basalt,
 /obj/structure/table,
 /obj/item/clothing/head/helmet/thunderdome,
 /obj/item/clothing/suit/armor/tdome/green,
 /obj/item/clothing/under/color/green,
 /obj/item/holo/esword/green,
-/turf/open/floor/holofloor{
-	icon_state = "warningline";
-	dir = 1
-	},
+/turf/open/floor/holofloor/basalt,
 /area/holodeck/rec_center/thunderdome)
 "du" = (
 /turf/open/floor/holofloor/basalt,
@@ -1158,11 +1110,7 @@
 /turf/open/floor/holofloor/plating,
 /area/holodeck/rec_center/refuel)
 "dz" = (
-/turf/open/floor/holofloor/grass,
-/turf/open/floor/holofloor{
-	icon_state = "warningline";
-	dir = 2
-	},
+/turf/open/floor/holofloor/plating,
 /area/holodeck/rec_center/spacechess)
 "dA" = (
 /obj/item/banner/blue,
@@ -1248,21 +1196,15 @@
 	},
 /area/holodeck/rec_center/chapelcourt)
 "dM" = (
-/obj/machinery/conveyor/holodeck{
-	dir = 5;
-	id = "holocoaster";
-	movedir = null;
-	verted = -1
-	},
-/turf/open/floor/holofloor/asteroid,
-/area/holodeck/rec_center/rollercoaster)
+/turf/open/floor/holofloor,
+/area/holodeck/rec_center/school)
 "dN" = (
 /obj/machinery/conveyor/holodeck{
 	dir = 8;
 	id = "holocoaster"
 	},
 /turf/open/floor/holofloor/asteroid,
-/area/holodeck/rec_center/rollercoaster)
+/area/holodeck/rec_center/school)
 "dO" = (
 /obj/machinery/conveyor/holodeck{
 	dir = 6;
@@ -1271,7 +1213,7 @@
 	verted = -1
 	},
 /turf/open/floor/holofloor/asteroid,
-/area/holodeck/rec_center/rollercoaster)
+/area/holodeck/rec_center/school)
 "dP" = (
 /turf/open/floor/holofloor{
 	dir = 8;
@@ -1287,7 +1229,6 @@
 	},
 /turf/open/floor/holofloor{
 	icon_state = "white";
-	dir = 9
 	},
 /area/holodeck/rec_center/firingrange)
 "dR" = (
@@ -1296,7 +1237,6 @@
 	},
 /turf/open/floor/holofloor{
 	icon_state = "white";
-	dir = 1
 	},
 /area/holodeck/rec_center/firingrange)
 "dS" = (
@@ -1308,7 +1248,6 @@
 	},
 /turf/open/floor/holofloor{
 	icon_state = "white";
-	dir = 5
 	},
 /area/holodeck/rec_center/firingrange)
 "dT" = (
@@ -1502,10 +1441,13 @@
 	id = "holocoaster"
 	},
 /turf/open/floor/holofloor/asteroid,
-/area/holodeck/rec_center/rollercoaster)
+/area/holodeck/rec_center/school)
 "em" = (
-/turf/open/floor/holofloor/asteroid,
-/area/holodeck/rec_center/rollercoaster)
+/obj/structure/table/wood,
+/obj/item/folder,
+/obj/item/melee/classic_baton/telescopic,
+/turf/open/floor/holofloor,
+/area/holodeck/rec_center/school)
 "en" = (
 /obj/machinery/conveyor/holodeck{
 	dir = 1;
@@ -1513,7 +1455,7 @@
 	layer = 2.5
 	},
 /turf/open/floor/holofloor/asteroid,
-/area/holodeck/rec_center/rollercoaster)
+/area/holodeck/rec_center/school)
 "eo" = (
 /obj/structure/window/reinforced{
 	dir = 8
@@ -1638,7 +1580,7 @@
 "eF" = (
 /obj/item/shovel,
 /turf/open/floor/holofloor/asteroid,
-/area/holodeck/rec_center/rollercoaster)
+/area/holodeck/rec_center/school)
 "eG" = (
 /obj/structure/window/reinforced{
 	dir = 8
@@ -1808,14 +1750,14 @@
 	name = "coaster car"
 	},
 /turf/open/floor/holofloor/asteroid,
-/area/holodeck/rec_center/rollercoaster)
+/area/holodeck/rec_center/school)
 "fg" = (
-/obj/machinery/conveyor_switch/oneway{
-	convdir = -1;
-	id = "holocoaster"
-	},
-/turf/open/floor/holofloor/asteroid,
-/area/holodeck/rec_center/rollercoaster)
+/obj/structure/table,
+/obj/item/paper,
+/obj/item/pen,
+/obj/item/clothing/under/schoolgirl/orange,
+/turf/open/floor/holofloor,
+/area/holodeck/rec_center/school)
 "fh" = (
 /obj/structure/window/reinforced,
 /turf/open/floor/holofloor/plating,
@@ -1896,13 +1838,13 @@
 /turf/open/floor/holofloor/plating,
 /area/holodeck/rec_center/kobayashi)
 "fr" = (
-/obj/structure/closet/crate/miningcar{
-	can_buckle = 1;
-	desc = "Great for mining!";
-	name = "minecart"
-	},
-/turf/open/floor/holofloor/asteroid,
-/area/holodeck/rec_center/rollercoaster)
+/obj/structure/table,
+/obj/item/paper,
+/obj/item/pen,
+/obj/item/clothing/under/schoolgirl,
+/obj/item/toy/katana,
+/turf/open/floor/holofloor,
+/area/holodeck/rec_center/school)
 "fs" = (
 /obj/structure/table/reinforced,
 /obj/machinery/recharger,
@@ -2038,14 +1980,14 @@
 	verted = -1
 	},
 /turf/open/floor/holofloor/asteroid,
-/area/holodeck/rec_center/rollercoaster)
+/area/holodeck/rec_center/school)
 "fI" = (
 /obj/machinery/conveyor/holodeck{
 	dir = 4;
 	id = "holocoaster"
 	},
 /turf/open/floor/holofloor/asteroid,
-/area/holodeck/rec_center/rollercoaster)
+/area/holodeck/rec_center/school)
 "fJ" = (
 /obj/machinery/conveyor/holodeck{
 	dir = 10;
@@ -2053,7 +1995,7 @@
 	verted = -1
 	},
 /turf/open/floor/holofloor/asteroid,
-/area/holodeck/rec_center/rollercoaster)
+/area/holodeck/rec_center/school)
 "fK" = (
 /obj/item/target,
 /obj/item/target/clown,
@@ -3081,7 +3023,7 @@
 "je" = (
 /obj/machinery/conveyor{
 	dir = 1;
-	id = "QMLoad2";
+	id = "XCCQMLoad2";
 	movedir = 2
 	},
 /obj/effect/turf_decal/stripes/line{
@@ -3092,7 +3034,7 @@
 "jf" = (
 /obj/machinery/conveyor_switch/oneway{
 	convdir = 1;
-	id = "QMLoad2";
+	id = "XCCQMLoad2";
 	pixel_x = 6
 	},
 /turf/open/floor/plasteel/brown{
@@ -3149,13 +3091,13 @@
 /obj/machinery/door/poddoor{
 	density = 1;
 	icon_state = "closed";
-	id = "QMLoaddoor2";
+	id = "XCCQMLoaddoor2";
 	name = "Supply Dock Loading Door";
 	opacity = 1
 	},
 /obj/machinery/conveyor{
 	dir = 4;
-	id = "QMLoad2";
+	id = "XCCQMLoad2";
 	movedir = 8
 	},
 /obj/effect/turf_decal/stripes/end{
@@ -3167,7 +3109,7 @@
 /obj/structure/plasticflaps,
 /obj/machinery/conveyor{
 	dir = 4;
-	id = "QMLoad2";
+	id = "XCCQMLoad2";
 	movedir = 8
 	},
 /obj/effect/turf_decal/stripes/line{
@@ -3179,13 +3121,13 @@
 /obj/machinery/door/poddoor{
 	density = 1;
 	icon_state = "closed";
-	id = "QMLoaddoor2";
+	id = "XCCQMLoaddoor2";
 	name = "Supply Dock Loading Door";
 	opacity = 1
 	},
 /obj/machinery/conveyor{
 	dir = 4;
-	id = "QMLoad2";
+	id = "XCCQMLoad2";
 	movedir = 8
 	},
 /obj/effect/turf_decal/stripes/line{
@@ -3196,7 +3138,7 @@
 "jo" = (
 /obj/machinery/conveyor{
 	dir = 1;
-	id = "QMLoad2";
+	id = "XCCQMLoad2";
 	movedir = 2
 	},
 /obj/effect/turf_decal/stripes/end,
@@ -3266,7 +3208,7 @@
 /area/centcom/control)
 "jz" = (
 /obj/machinery/button/door{
-	id = "QMLoaddoor";
+	id = "XCCQMLoaddoor";
 	layer = 4;
 	name = "Loading Doors";
 	pixel_x = -27;
@@ -3274,7 +3216,7 @@
 	},
 /obj/machinery/button/door{
 	dir = 2;
-	id = "QMLoaddoor2";
+	id = "XCCQMLoaddoor2";
 	layer = 4;
 	name = "Loading Doors";
 	pixel_x = -27;
@@ -3353,13 +3295,13 @@
 /obj/machinery/door/poddoor{
 	density = 1;
 	icon_state = "closed";
-	id = "QMLoaddoor";
+	id = "XCCQMLoaddoor";
 	name = "Supply Dock Loading Door";
 	opacity = 1
 	},
 /obj/machinery/conveyor{
 	dir = 8;
-	id = "QMLoad"
+	id = "XCCQMLoad"
 	},
 /obj/effect/turf_decal/stripes/end{
 	dir = 8
@@ -3370,7 +3312,7 @@
 /obj/structure/plasticflaps,
 /obj/machinery/conveyor{
 	dir = 8;
-	id = "QMLoad"
+	id = "XCCQMLoad"
 	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 2
@@ -3381,13 +3323,13 @@
 /obj/machinery/door/poddoor{
 	density = 1;
 	icon_state = "closed";
-	id = "QMLoaddoor";
+	id = "XCCQMLoaddoor";
 	name = "Supply Dock Loading Door";
 	opacity = 1
 	},
 /obj/machinery/conveyor{
 	dir = 8;
-	id = "QMLoad"
+	id = "XCCQMLoad"
 	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 2
@@ -3397,7 +3339,7 @@
 "jM" = (
 /obj/machinery/conveyor{
 	dir = 8;
-	id = "QMLoad"
+	id = "XCCQMLoad"
 	},
 /obj/effect/turf_decal/stripes/end{
 	dir = 1
@@ -3418,7 +3360,7 @@
 "jP" = (
 /obj/machinery/conveyor{
 	dir = 1;
-	id = "QMLoad";
+	id = "XCCQMLoad";
 	movedir = 2
 	},
 /obj/effect/turf_decal/stripes/line{
@@ -3429,7 +3371,7 @@
 "jQ" = (
 /obj/machinery/conveyor_switch/oneway{
 	convdir = 1;
-	id = "QMLoad";
+	id = "XCCQMLoad";
 	pixel_x = 6
 	},
 /turf/open/floor/plasteel/brown{
@@ -13647,6 +13589,80 @@
 	},
 /turf/open/floor/plating/asteroid/snow/airless,
 /area/syndicate_mothership)
+"QH" = (
+/obj/structure/table/wood,
+/obj/item/toy/crayon/white,
+/turf/open/floor/holofloor,
+/area/holodeck/rec_center/school)
+"QI" = (
+/obj/structure/table/wood,
+/obj/item/reagent_containers/food/snacks/grown/apple,
+/turf/open/floor/holofloor,
+/area/holodeck/rec_center/school)
+"QJ" = (
+/obj/structure/table,
+/obj/item/paper,
+/obj/item/pen,
+/obj/item/clothing/under/schoolgirl,
+/turf/open/floor/holofloor,
+/area/holodeck/rec_center/school)
+"QK" = (
+/obj/structure/table,
+/obj/item/paper,
+/obj/item/pen,
+/obj/item/clothing/under/schoolgirl/green,
+/turf/open/floor/holofloor,
+/area/holodeck/rec_center/school)
+"QL" = (
+/obj/structure/chair{
+	dir = 1
+	},
+/turf/open/floor/holofloor,
+/area/holodeck/rec_center/school)
+"QM" = (
+/obj/structure/chair{
+	dir = 1
+	},
+/turf/open/floor/holofloor,
+/area/holodeck/rec_center/school)
+"QN" = (
+/obj/structure/table,
+/obj/item/paper,
+/obj/item/pen,
+/obj/item/clothing/under/schoolgirl/red,
+/turf/open/floor/holofloor,
+/area/holodeck/rec_center/school)
+"QO" = (
+/obj/structure/chair{
+	dir = 1
+	},
+/turf/open/floor/holofloor,
+/area/holodeck/rec_center/school)
+"QP" = (
+/obj/structure/chair{
+	dir = 1
+	},
+/turf/open/floor/holofloor,
+/area/holodeck/rec_center/school)
+"QQ" = (
+/obj/structure/table,
+/obj/item/paper,
+/obj/item/pen,
+/obj/item/clothing/under/schoolgirl/green,
+/turf/open/floor/holofloor,
+/area/holodeck/rec_center/school)
+"QR" = (
+/obj/structure/chair{
+	dir = 1
+	},
+/turf/open/floor/holofloor,
+/area/holodeck/rec_center/school)
+"QS" = (
+/obj/structure/chair{
+	dir = 1
+	},
+/turf/open/floor/holofloor,
+/area/holodeck/rec_center/school)
 
 (1,1,1) = {"
 aa
@@ -40574,7 +40590,7 @@ AR
 Ay
 Ay
 Ay
-CN
+CL
 CV
 CV
 zV
@@ -69964,7 +69980,7 @@ eK
 eL
 fi
 fv
-fC
+dz
 fN
 aa
 aa
@@ -70221,7 +70237,7 @@ eL
 eK
 fj
 fw
-fC
+dz
 fN
 aa
 aa
@@ -70478,7 +70494,7 @@ eK
 eL
 fi
 fx
-fC
+dz
 fN
 aa
 aa
@@ -70704,16 +70720,16 @@ aa
 "}
 (223,1,1) = {"
 ac
-ak
-az
-az
-ak
-az
-az
-ak
-az
-az
-ak
+aj
+aj
+aj
+aj
+aj
+aj
+aj
+aj
+aj
+aj
 bl
 bp
 bH
@@ -70735,7 +70751,7 @@ eL
 eK
 fj
 fy
-fC
+dz
 fN
 ab
 ab
@@ -70964,10 +70980,10 @@ ac
 al
 aA
 aJ
-ak
+aj
 aJ
 aJ
-ak
+aj
 aJ
 aA
 be
@@ -70992,7 +71008,7 @@ eK
 eL
 fi
 fv
-fC
+dz
 fN
 ab
 fR
@@ -71488,13 +71504,13 @@ aR
 bl
 bq
 bI
-bX
-bJ
+cl
+cl
 ck
 cy
-bJ
+cl
 cV
-de
+cl
 dj
 ac
 dA
@@ -71744,14 +71760,14 @@ bc
 bf
 bl
 br
-bJ
-bJ
-bJ
 cl
-cz
-bJ
+cl
+cl
+cl
+cl
+cl
 cW
-df
+cl
 dk
 ac
 dB
@@ -72001,12 +72017,12 @@ bb
 bg
 bl
 bs
-bJ
+cl
 bZ
 ci
 cm
 cA
-bJ
+cl
 cX
 dg
 dl
@@ -72258,14 +72274,14 @@ bb
 bg
 bl
 bt
-bJ
+cl
 ca
 ci
-bJ
-bJ
-bJ
-bJ
-dh
+cl
+cl
+cl
+cl
+cl
 dm
 ac
 dD
@@ -72515,13 +72531,13 @@ bd
 bh
 bl
 bu
-bK
+cl
 cb
 ci
 cn
 cB
-bJ
-bJ
+cl
+cl
 cl
 dn
 ac
@@ -76121,18 +76137,18 @@ cG
 bQ
 bQ
 bQ
-ds
+bB
 bl
 dM
-el
-el
-el
-el
-ff
-ff
-ff
-ff
-fH
+dM
+dM
+dM
+dM
+dM
+dM
+dM
+dM
+dM
 fN
 Ij
 Il
@@ -76380,16 +76396,16 @@ bQ
 bQ
 dt
 bl
-dN
+dM
 em
-eF
-em
-em
+dM
+QJ
+QL
 fg
-em
-em
-em
-fI
+QO
+QQ
+QR
+dM
 fN
 fQ
 fQ
@@ -76637,16 +76653,16 @@ bQ
 bQ
 dt
 bl
-dN
-em
-em
-em
-em
-em
-em
-em
-em
-fI
+dM
+QH
+dM
+dM
+dM
+dM
+dM
+dM
+dM
+dM
 fN
 fP
 fV
@@ -76894,16 +76910,16 @@ bQ
 bQ
 dt
 bl
-dN
-em
-em
-em
-em
-em
-em
+dM
+QI
+dM
+QK
+QM
+QN
+QP
 fr
-em
-fI
+QS
+dM
 fN
 ab
 fT
@@ -77149,18 +77165,18 @@ cG
 bQ
 bQ
 bQ
-du
+bz
 bl
-dO
-en
-en
-en
-en
-en
-en
-en
-en
-fJ
+dM
+dM
+dM
+dM
+dM
+dM
+dM
+dM
+dM
+dM
 fN
 ab
 ab

--- a/code/game/area/areas/holodeck.dm
+++ b/code/game/area/areas/holodeck.dm
@@ -84,8 +84,8 @@
 /area/holodeck/rec_center/firingrange
 	name = "Holodeck - Firing Range"
 
-/area/holodeck/rec_center/rollercoaster
-	name = "Holodeck - Roller Coaster"
+/area/holodeck/rec_center/school
+	name = "Holodeck - Anime School"
 
 /area/holodeck/rec_center/chapelcourt
 	name = "Holodeck - Chapel Courtroom"


### PR DESCRIPTION
Fixes #30408

Fixes the holodeck turfs that were missing icons.

Replaces the rollercoaster holodeck with an anime classroom holodeck because it has been a glitchy mess since day 1.