### PR TITLE
Fix cargo shuttle not docking correctly

### DIFF
--- a/code/modules/shuttle/supply.dm
+++ b/code/modules/shuttle/supply.dm
@@ -67,7 +67,8 @@ GLOBAL_LIST_INIT(blacklisted_cargo_types, typecacheof(list(
 /obj/docking_port/mobile/supply/dock()
 	if(getDockedId() == "supply_away") // Buy when we leave home.
 		buy()
-	if(..()) // Fly/enter transit.
+	. = ..() // Fly/enter transit.
+	if(. != DOCKING_SUCCESS)
 		return
 	if(getDockedId() == "supply_away") // Sell when we get home
 		sell()


### PR DESCRIPTION
#30356 made returning null in `dock` not okay

The other dock overloads probably need fixing too.

@AnturK