### PR TITLE
Fixes observer statpanel blob roundtype mismatch runtime

### DIFF
--- a/code/modules/mob/dead/observer/observer.dm
+++ b/code/modules/mob/dead/observer/observer.dm
@@ -306,11 +306,10 @@ This is the proc mobs get to turn into a ghost. Forked from ghostize due to comp
 
 /mob/dead/observer/Stat()
 	..()
-	if(statpanel("Status"))
-		if(SSticker.HasRoundStarted())
-			var/datum/game_mode/blob/B = SSticker.mode
-			if(B.message_sent)
-				stat(null, "Blobs to Blob Win: [GLOB.blobs_legit.len]/[B.blobwincount]")
+	if(statpanel("Status") && SSticker.HasRoundStarted() && istype(SSticker.mode, /datum/game_mode/blob))
+		var/datum/game_mode/blob/B = SSticker.mode
+		if(B.message_sent)
+			stat(null, "Blobs to Blob Win: [GLOB.blobs_legit.len]/[B.blobwincount]")
 
 /mob/dead/observer/verb/reenter_corpse()
 	set category = "Ghost"


### PR DESCRIPTION
the thing that displays blob tiles to win runtimes if it's not blob.