### PR TITLE
Make add_details faster and fix the lag. (maybe)

### DIFF
--- a/code/controllers/subsystem/blackbox.dm
+++ b/code/controllers/subsystem/blackbox.dm
@@ -227,7 +227,7 @@ SUBSYSTEM_DEF(blackbox)
 /datum/feedback_variable
 	var/variable
 	var/value
-	var/details
+	var/list/details
 
 /datum/feedback_variable/New(param_variable, param_value = 0)
 	variable = param_variable
@@ -266,16 +266,16 @@ SUBSYSTEM_DEF(blackbox)
 	return variable
 
 /datum/feedback_variable/proc/set_details(deets)
-	details = "\"[deets]\""
+	details = list("\"[deets]\"")
 
 /datum/feedback_variable/proc/add_details(deets)
 	if (!details)
 		set_details(deets)
 	else
-		details += " | \"[deets]\""
+		details += "\"[deets]\""
 
 /datum/feedback_variable/proc/get_details()
-	return details
+	return details.Join(" | ")
 
 /datum/feedback_variable/proc/get_parsed()
-	return list(variable,value,details)
+	return list(variable,value,details.Join(" | "))


### PR DESCRIPTION
Storing all of these intermediary strings in the string table might be unbalancing it (especially since there would be a high number of partially matching strings.

Waiting until later to concat the string will prevent this.

add_details was getting to be more expensive then atmos, this is very like why (but I can't be sure)
