### PR TITLE
Corrects runtime in observer.dm

### DIFF
--- a/code/modules/mob/dead/observer/observer.dm
+++ b/code/modules/mob/dead/observer/observer.dm
@@ -308,9 +308,10 @@ This is the proc mobs get to turn into a ghost. Forked from ghostize due to comp
 	..()
 	if(statpanel("Status"))
 		if(SSticker.HasRoundStarted())
-			var/datum/game_mode/blob/B = SSticker.mode
-			if(B.message_sent)
-				stat(null, "Blobs to Blob Win: [GLOB.blobs_legit.len]/[B.blobwincount]")
+			if(istype(SSticker.mode, /datum/game_mode/blob))
+				var/datum/game_mode/blob/B = SSticker.mode
+				if(B.message_sent)
+					stat(null, "Blobs to Blob Win: [GLOB.blobs_legit.len]/[B.blobwincount]")
 
 /mob/dead/observer/verb/reenter_corpse()
 	set category = "Ghost"


### PR DESCRIPTION
#30056 removed a type check resulting in CONSTANT FUCKING RUNTIME SPAM.

this reverts the mistake.