### PR TITLE
Alters the pressure plate crafting recipe

### DIFF
--- a/code/modules/crafting/recipes.dm
+++ b/code/modules/crafting/recipes.dm
@@ -555,7 +555,10 @@
 	name = "Pressure Plate"
 	result = /obj/item/device/pressure_plate
 	time = 5
-	reqs = list(/obj/item/stack/sheet/plasteel = 1, /obj/item/stack/tile/plasteel = 1, /obj/item/stack/cable_coil = 2)
+	reqs = list(/obj/item/stack/sheet/metal = 1,
+				  /obj/item/stack/tile/plasteel = 1,
+				  /obj/item/stack/cable_coil = 2,
+				  /obj/item/device/assembly/igniter = 1)
 	category = CAT_MISC
 
 


### PR DESCRIPTION
[Changelogs]: Pressure plates no longer require plasteel in their recipes. Instead, they now require a signaller and a sheet of normal metal

:cl: 
balance: Altered pressure plate crafting recipe
/:cl:

[why]: A lot of people don't even realise this recipe even exists, let alone consider it worthwhile to construct due to plasteel not being a common material (or requires a lengthy a deconstruction of a wall in a secure area). Pressure plates themselves will continue to function as before. 
