### PR TITLE
Allows atmos techs to download the SM monitor

### DIFF
--- a/code/modules/modular_computers/file_system/programs/sm_monitor.dm
+++ b/code/modules/modular_computers/file_system/programs/sm_monitor.dm
@@ -5,7 +5,7 @@
 	program_icon_state = "smmon_0"
 	extended_desc = "This program connects to specially calibrated supermatter sensors to provide information on the status of supermatter-based engines."
 	requires_ntnet = TRUE
-	transfer_access = ACCESS_ENGINE
+	transfer_access = ACCESS_CONSTRUCTION
 	network_destination = "supermatter monitoring system"
 	size = 5
 	tgui_id = "ntos_supermatter_monitor"


### PR DESCRIPTION
Closes #30232

Atmosia sends gas to the engine, ergo it would make since that they can monitor what current gases are inside the engine so they can adjust the output coming from their deparment.

They also have direct access to the SM on certain maps (ie Delta)