### PR TITLE
Gives admins the ability to show a read only vv window to a player

### DIFF
--- a/code/datums/datumvars.dm
+++ b/code/datums/datumvars.dm
@@ -128,7 +128,7 @@
 			"Remove Nulls" = "?_src_=vars;listnulls=[refid]",
 			"Remove Dupes" = "?_src_=vars;listdupes=[refid]",
 			"Set len" = "?_src_=vars;listlen=[refid]",
-			"Shuffle" = "?_src_=vars;listshuffle=[refid]"
+			"Shuffle" = "?_src_=vars;listshuffle=[refid]",
 			"Show To Player" = "?_src_=vars;expose=[refid]"
 			)
 	else

--- a/code/datums/datumvars.dm
+++ b/code/datums/datumvars.dm
@@ -559,6 +559,8 @@
 		var/prompt = alert("Do you want to grant [C] access to view this VV window? (they will not be able to edit or change anything nor open nested vv windows unless they themselves are an admin)", "Confirm", "Yes", "No")
 		if (prompt != "Yes")
 			return
+		message_admins("[key_name_admin(usr)] Showed [key_name_admin(C)] a <a href='?_src_=vars;datumrefresh=\ref[thing]'>VV window</a>")
+		log_admin("Admin [key_name(usr)] Showed [key_name(C)] a VV window of a [thing]")
 		to_chat(C, "[usr.client.holder.fakekey ? "an Administrator" : "[usr.client.ckey]"] has granted you access to view a View Variables window")
 		C.debug_variables(thing)
 		

--- a/code/datums/datumvars.dm
+++ b/code/datums/datumvars.dm
@@ -28,7 +28,7 @@
 	.["Call Proc"] = "?_src_=vars;proc_call=\ref[src]"
 	.["Mark Object"] = "?_src_=vars;mark_object=\ref[src]"
 	.["Delete"] = "?_src_=vars;delete=\ref[src]"
-	.["Show To Player"] = "?_src_=vars;expose=\ref[src]"
+	.["Show VV To Player"] = "?_src_=vars;expose=\ref[src]"
 
 
 /datum/proc/on_reagent_change()
@@ -129,7 +129,7 @@
 			"Remove Dupes" = "?_src_=vars;listdupes=[refid]",
 			"Set len" = "?_src_=vars;listlen=[refid]",
 			"Shuffle" = "?_src_=vars;listshuffle=[refid]",
-			"Show To Player" = "?_src_=vars;expose=[refid]"
+			"Show VV To Player" = "?_src_=vars;expose=[refid]"
 			)
 	else
 		dropdownoptions = D.vv_get_dropdown()

--- a/code/datums/datumvars.dm
+++ b/code/datums/datumvars.dm
@@ -547,7 +547,7 @@
 			return
 		M.regenerate_icons()
 	else if(href_list["expose"])
-		if(!check_rights(R_ADMIN, 0))
+		if(!check_rights(R_ADMIN, FALSE))
 			return
 		var/thing = locate(href_list["expose"])
 		if (!thing)

--- a/code/datums/datumvars.dm
+++ b/code/datums/datumvars.dm
@@ -553,7 +553,7 @@
 		var/value = vv_get_value(VV_CLIENT)
 		if (value["class"] != VV_CLIENT)
 			return
-		var/cient/C = value["value"]
+		var/client/C = value["value"]
 		if (!C)
 			return
 		var/prompt = alert("Do you want to grant [C] access to view this VV window? (they will not be able to edit or change anything nor open nested vv windows unless they themselves are an admin)", "Confirm", "Yes", "No")

--- a/code/datums/datumvars.dm
+++ b/code/datums/datumvars.dm
@@ -549,7 +549,9 @@
 	else if(href_list["expose"])
 		if(!check_rights(R_ADMIN, 0))
 			return
-		var/thing = href_list["expose"]
+		var/thing = locate(href_list["expose"])
+		if (!thing)
+			return
 		var/value = vv_get_value(VV_CLIENT)
 		if (value["class"] != VV_CLIENT)
 			return
@@ -557,13 +559,13 @@
 		if (!C)
 			return
 		var/prompt = alert("Do you want to grant [C] access to view this VV window? (they will not be able to edit or change anything nor open nested vv windows unless they themselves are an admin)", "Confirm", "Yes", "No")
-		if (prompt != "Yes")
+		if (prompt != "Yes" || !usr.client)
 			return
 		message_admins("[key_name_admin(usr)] Showed [key_name_admin(C)] a <a href='?_src_=vars;datumrefresh=\ref[thing]'>VV window</a>")
 		log_admin("Admin [key_name(usr)] Showed [key_name(C)] a VV window of a [thing]")
-		to_chat(C, "[usr.client.holder.fakekey ? "an Administrator" : "[usr.client.ckey]"] has granted you access to view a View Variables window")
+		to_chat(C, "[usr.client.holder.fakekey ? "an Administrator" : "[usr.client.key]"] has granted you access to view a View Variables window")
 		C.debug_variables(thing)
-		
+
 
 //Needs +VAREDIT past this point
 


### PR DESCRIPTION
For funsies and for helping coders

Can also be used to show a vv window to another admin.

Requires +ADMIN

:cl:
add: Admins may now show the variables interface to players to help contributors debug their new additions 
/:cl:
