### PR TITLE
num2text the Instances number

### DIFF
--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -579,7 +579,7 @@
 			var/turf/T = get_turf(client.eye)
 			stat("Location:", COORD(T))
 			stat("CPU:", "[world.cpu]")
-			stat("Instances:", "[world.contents.len]")
+			stat("Instances:", "[num2text(world.contents.len, 10)]")
 			GLOB.stat_entry()
 			config.stat_entry()
 			stat(null)


### PR DESCRIPTION
This way it doesn't go to enotation.

Also, would somebody kindly explain why this is so regularly getting to a million?



