### PR TITLE
Ladders cant be moved by the singularity

### DIFF
--- a/code/game/objects/structures/ladders.dm
+++ b/code/game/objects/structures/ladders.dm
@@ -124,3 +124,4 @@
 
 /obj/structure/ladder/singularity_pull()
 	visible_message("<span class='danger'>[src] is torn to pieces by the gravitational pull!</span>")
+	qdel(src)

--- a/code/game/objects/structures/ladders.dm
+++ b/code/game/objects/structures/ladders.dm
@@ -123,4 +123,4 @@
 
 
 /obj/structure/ladder/singularity_pull()
-	return
+	visible_message("<span class='danger'>[src] is torn to pieces by the gravitational pull!</span>")

--- a/code/game/objects/structures/ladders.dm
+++ b/code/game/objects/structures/ladders.dm
@@ -118,6 +118,9 @@
 	else
 		return QDEL_HINT_LETMELIVE
 
+/obj/structure/ladder/unbreakable/singularity_pull()
+	return
+
 /obj/structure/ladder/auto_connect //They will connect to ladders with the same X and Y without needing to share an ID
 	auto_connect = TRUE
 

--- a/code/game/objects/structures/ladders.dm
+++ b/code/game/objects/structures/ladders.dm
@@ -120,3 +120,7 @@
 
 /obj/structure/ladder/auto_connect //They will connect to ladders with the same X and Y without needing to share an ID
 	auto_connect = TRUE
+
+
+/obj/structure/ladder/singularity_pull()
+	return


### PR DESCRIPTION
It'd be weird to have the top part of a ladder moved five tiles and then still lead to the ladder underneath its old location. Just destroys it instead.