### PR TITLE
Fix Hearty Punch healing to include softcrit

### DIFF
--- a/code/modules/reagents/chemistry/reagents/alcohol_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/alcohol_reagents.dm
@@ -1072,7 +1072,7 @@ All effects don't start immediately, but rather get worse over time; the rate is
 	glass_desc = "Aromatic beverage served piping hot. According to folk tales it can almost wake the dead."
 
 /datum/reagent/consumable/ethanol/hearty_punch/on_mob_life(mob/living/M)
-	if(M.stat == UNCONSCIOUS && M.health <= 0)
+	if(M.health <= 0)
 		M.adjustBruteLoss(-7, 0)
 		M.adjustFireLoss(-7, 0)
 		M.adjustToxLoss(-7, 0)


### PR DESCRIPTION
:cl: VexingRaven
fix: Hearty Punch once again pulls people out of crit.
/:cl:

With softcrit implemented, people are only unconscious in hard crit, so Hearty Punch no longer brings you out of crit, only into soft crit. This PR fixes that by removing the consciousness check. If you're below 0 HP you're always crit, so checking consciousness seems unnecessary.
