### PR TITLE
Round weighting now reduces the chances of repeating a recently played mode

### DIFF
--- a/code/controllers/configuration.dm
+++ b/code/controllers/configuration.dm
@@ -692,15 +692,16 @@
 						WRITE_FILE(GLOB.config_error_log, "Incorrect probability configuration definition: [prob_name]  [prob_value].")
 				if("adjust")
 					var/adj_pos = findtext(value, " ")
-					var/adj_name = null
+					to_chat(world, "value: [value]")
 					var/adj_value = null
 
 					if(adj_pos)
-						adj_name = text2num(copytext(value, 1, adj_pos))
-						adj_value = text2num(copytext(value, adj_pos + 1))
-						adjust[adj_name] = adj_value
+						adj_value = text2num(copytext(value, 1, adj_pos))
+						adjust += adj_value
+						to_chat(world, "slot weight =[adj_value].")
 					else
-						WRITE_FILE(GLOB.config_error_log, "Incorrect round weight adjustment configuration definition: [adj_name] [adj_value].")
+						to_chat(world, "FUCK")
+						WRITE_FILE(GLOB.config_error_log, "Incorrect round weight adjustment configuration definition.")
 				if("protect_roles_from_antagonist")
 					protect_roles_from_antagonist	= 1
 				if("protect_assistant_from_antagonist")
@@ -953,8 +954,9 @@
 			var/recent_round = SSpersistence.saved_modes.Find(M.config_tag)
 			var/adjustment
 			while(recent_round)
+				to_chat(world, "Finding weight for mode [M.config_tag] at slot [recent_round], result is: [adjust[recent_round]].")
 				adjustment += adjust[recent_round]
-				recent_round = SSpersistence.saved_modes.Find(recent_round+1,M.config_tag)
+				recent_round = SSpersistence.saved_modes.Find(M.config_tag,recent_round+1,0)
 			final_weight *= ((100-adjustment)/100)
 			runnable_modes[M] = final_weight
 			to_chat(world, "tag=[M.config_tag], prob inital=[probabilities[M.config_tag]], prob_final = [final_weight].")

--- a/code/controllers/configuration.dm
+++ b/code/controllers/configuration.dm
@@ -691,17 +691,10 @@
 					else
 						WRITE_FILE(GLOB.config_error_log, "Incorrect probability configuration definition: [prob_name]  [prob_value].")
 				if("adjust")
-					var/adj_pos = findtext(value, " ")
-					to_chat(world, "value: [value]")
-					var/adj_value = null
-
-					if(adj_pos)
-						adj_value = text2num(copytext(value, 1, adj_pos))
-						adjust += adj_value
-						to_chat(world, "slot weight =[adj_value].")
+					if(value)
+						adjust += text2num(value)
 					else
-						to_chat(world, "FUCK")
-						WRITE_FILE(GLOB.config_error_log, "Incorrect round weight adjustment configuration definition.")
+						WRITE_FILE(GLOB.config_error_log, "Incorrect round weight adjustment configuration definition for [value].")
 				if("protect_roles_from_antagonist")
 					protect_roles_from_antagonist	= 1
 				if("protect_assistant_from_antagonist")
@@ -954,12 +947,10 @@
 			var/recent_round = SSpersistence.saved_modes.Find(M.config_tag)
 			var/adjustment
 			while(recent_round)
-				to_chat(world, "Finding weight for mode [M.config_tag] at slot [recent_round], result is: [adjust[recent_round]].")
 				adjustment += adjust[recent_round]
 				recent_round = SSpersistence.saved_modes.Find(M.config_tag,recent_round+1,0)
 			final_weight *= ((100-adjustment)/100)
 			runnable_modes[M] = final_weight
-			to_chat(world, "tag=[M.config_tag], prob inital=[probabilities[M.config_tag]], prob_final = [final_weight].")
 	return runnable_modes
 
 /datum/configuration/proc/get_runnable_midround_modes(crew)

--- a/code/controllers/configuration.dm
+++ b/code/controllers/configuration.dm
@@ -938,8 +938,12 @@
 		if(max_pop[M.config_tag])
 			M.maximum_players = max_pop[M.config_tag]
 		if(M.can_start())
-			runnable_modes[M] = probabilities[M.config_tag]
-			//to_chat(world, "DEBUG: runnable_mode\[[runnable_modes.len]\] = [M.config_tag]")
+			var/adjusted_weight = probabilities[M.config_tag]
+			var/textmode = "[M]"
+			if(SSpersistence.saved_modes.Find(textmode))
+				adjusted_weight *= (sqrt(SSpersistence.saved_modes.Find(textmode)) * 0.5)
+			runnable_modes[M] = adjusted_weight
+			//to_chat(world, "DEBUG: runnable_mode\[[M]\] = [adjusted_weight], adjusted from [probabilities[M.config_tag]]")
 	return runnable_modes
 
 /datum/configuration/proc/get_runnable_midround_modes(crew)

--- a/code/controllers/configuration.dm
+++ b/code/controllers/configuration.dm
@@ -943,7 +943,6 @@
 			if(SSpersistence.saved_modes.Find(textmode))
 				adjusted_weight *= (sqrt(SSpersistence.saved_modes.Find(textmode)) * 0.5)
 			runnable_modes[M] = adjusted_weight
-			//to_chat(world, "DEBUG: runnable_mode\[[M]\] = [adjusted_weight], adjusted from [probabilities[M.config_tag]]")
 	return runnable_modes
 
 /datum/configuration/proc/get_runnable_midround_modes(crew)

--- a/code/controllers/subsystem/persistence.dm
+++ b/code/controllers/subsystem/persistence.dm
@@ -241,7 +241,7 @@ SUBSYSTEM_DEF(persistence)
 /datum/controller/subsystem/persistence/proc/CollectRoundtype()
 	saved_modes[3] = saved_modes[2]
 	saved_modes[2] = saved_modes[1]
-	saved_modes[1] = SSticker.mode
+	saved_modes[1] = SSticker.mode.config_tag
 	var/json_file = file("data/RecentModes.json")
 	var/list/file_data = list()
 	file_data["data"] = saved_modes

--- a/code/controllers/subsystem/persistence.dm
+++ b/code/controllers/subsystem/persistence.dm
@@ -138,23 +138,14 @@ SUBSYSTEM_DEF(persistence)
 	SetUpTrophies(saved_trophies.Copy())
 
 /datum/controller/subsystem/persistence/proc/LoadRecentModes()
-	if(fexists("data/RecentModes.sav")) //legacy compatability to convert old format to new
-		var/savefile/S = new /savefile("data/RecentModes.sav")
-		var/saved_json
-		S >> saved_json
-		if(!saved_json)
-			return
-		saved_modes = json_decode(saved_json)
-		fdel(S)
-	else
-		var/json_file = file("data/RecentModes.json")
-		if(!fexists(json_file))
-			return
-		var/list/json = list()
-		json = json_decode(file2text(json_file))
-		if(!json)
-			return
-		saved_modes = json["data"]
+	var/json_file = file("data/RecentModes.json")
+	if(!fexists(json_file))
+		return
+	var/list/json = list()
+	json = json_decode(file2text(json_file))
+	if(!json)
+		return
+	saved_modes = json["data"]
 
 
 /datum/controller/subsystem/persistence/proc/SetUpTrophies(list/trophy_items)

--- a/config/game_options.txt
+++ b/config/game_options.txt
@@ -97,12 +97,11 @@ PROBABILITY DEVIL_AGENTS 0
 ## You probably want to keep sandbox off by default for secret and random.
 PROBABILITY SANDBOX 0
 
-## Percent weight adjustments for three of the most recent modes where 1 is the most recent mode.
+## Percent weight changes for three of the most recent modes where the top figure is the most recent.
 
-ADJUST 0 0
-ADJUST 1 45
-ADJUST 2 30
-ADJUST 3 10
+ADJUST 45
+ADJUST 30
+ADJUST 10
 
 
 ## Toggles for continuous modes.

--- a/config/game_options.txt
+++ b/config/game_options.txt
@@ -97,6 +97,13 @@ PROBABILITY DEVIL_AGENTS 0
 ## You probably want to keep sandbox off by default for secret and random.
 PROBABILITY SANDBOX 0
 
+## Percent weight adjustments for three of the most recent modes where 1 is the most recent mode.
+
+ADJUST 0 0
+ADJUST 1 45
+ADJUST 2 30
+ADJUST 3 10
+
 
 ## Toggles for continuous modes.
 ## Modes that aren't continuous will end the instant all antagonists are dead.

--- a/config/game_options.txt
+++ b/config/game_options.txt
@@ -97,7 +97,7 @@ PROBABILITY DEVIL_AGENTS 0
 ## You probably want to keep sandbox off by default for secret and random.
 PROBABILITY SANDBOX 0
 
-## Percent weight changes for three of the most recent modes where the top figure is the most recent.
+## Percent weight reductions for three of the most recent modes where the top figure is the most recent.
 
 ADJUST 45
 ADJUST 30

--- a/html/changelogs/AutoChangeLog-pr-30056.yml
+++ b/html/changelogs/AutoChangeLog-pr-30056.yml
@@ -1,4 +1,0 @@
-author: "More Robust Than You"
-delete-after: True
-changes: 
-  - rscdel: "Finally fucking removed gangs"

--- a/html/changelogs/AutoChangeLog-pr-30056.yml
+++ b/html/changelogs/AutoChangeLog-pr-30056.yml
@@ -1,0 +1,4 @@
+author: "More Robust Than You"
+delete-after: True
+changes: 
+  - rscdel: "Finally fucking removed gangs"


### PR DESCRIPTION
Oh my god I've been dreaming of this for ages, wasn't as hard as I thought it would be.

I enjoy a good Warops round, but after two - hearing a third declaration is enough to make anyone walk out an airlock. Same thing goes for almost any mode, its downright common sense that repeating modes isn't healthy for gameplay - god knows how many times our server pop plummits in off-hours because we get back to back to back rev rounds... but nobody wants an outright exclusion that would let people metagame the roundtype.

So the gist is this, the game now tracks the last 3 roundtypes. When calculating weights, if a mode was played in the last 3 rounds it will be adjusted as follows:

Last round: 45% weight reduction
2nd to last round: 30% weight reduction
3rd to last round:  10% weight reduction

I'm open to adjusting the numbers, they're just preliminary, the percentages are now additive if a mode appears more than once in the list.  