### PR TITLE
Spetsnaz Pyro Bundle Rebalance

### DIFF
--- a/code/modules/projectiles/guns/ballistic/pistol.dm
+++ b/code/modules/projectiles/guns/ballistic/pistol.dm
@@ -54,7 +54,7 @@
 	name = "stechkin APS pistol"
 	desc = "The original russian version of a widely used Syndicate sidearm. Uses 9mm ammo."
 	icon_state = "aps"
-	w_class = WEIGHT_CLASS_NORMAL
+	w_class = WEIGHT_CLASS_SMALL
 	origin_tech = "combat=3;materials=2;syndicate=3"
 	mag_type = /obj/item/ammo_box/magazine/pistolm9mm
 	can_suppress = 0

--- a/code/modules/uplink/uplink_item.dm
+++ b/code/modules/uplink/uplink_item.dm
@@ -403,7 +403,7 @@ GLOBAL_LIST_EMPTY(uplink_items) // Global list so we only initialize this once.
 	item = /obj/item/ammo_box/magazine/m10mm/hp
 	cost = 3
 
-/datum/uplink_item/ammo/pistolhp
+/datum/uplink_item/ammo/pistolaps
 	name = "9mm Handgun Magazine"
 	desc = "An additional 15-round 9mm magazine, compatible with the Stetchkin APS pistol, found in the Spetsnaz Pyro bundle."
 	item = /obj/item/ammo_box/magazine/pistolm9mm

--- a/code/modules/uplink/uplink_item.dm
+++ b/code/modules/uplink/uplink_item.dm
@@ -403,6 +403,12 @@ GLOBAL_LIST_EMPTY(uplink_items) // Global list so we only initialize this once.
 	item = /obj/item/ammo_box/magazine/m10mm/hp
 	cost = 3
 
+/datum/uplink_item/ammo/pistolhp
+	name = "9mm Handgun Magazine"
+	desc = "An additional 15-round 9mm magazine, compatible with the Stetchkin APS pistol, found in the Spetsnaz Pyro bundle."
+	item = /obj/item/ammo_box/magazine/pistolm9mm
+	cost = 2
+
 /datum/uplink_item/ammo/bolt_action
 	name = "Surplus Rifle Clip"
 	desc = "A stripper clip used to quickly load bolt action rifles. Contains 5 rounds."


### PR DESCRIPTION
I made the stetchkin APS pistol smaller so it can fit on the ops belt. I also made 9mm mags purchasable for 2 TCs each, seemed like a fair price since they do the same as a stetchkin and you get roughly twice as many bullets.

:cl: BeeSting12
balance: The stetchkin APS pistol is smaller.
add: The 9mm pistol magazines can be purchased from nuke op uplinks at two telecrystals each. 
/:cl:

Why: Gun size seemed unintended, if it was intended then thats dumb. I just think it would be nice for the mags to be purchasable. 
