### PR TITLE
Fixes initialize hints for a fair number of mobs and items

### DIFF
--- a/code/game/machinery/camera/presets.dm
+++ b/code/game/machinery/camera/presets.dm
@@ -24,7 +24,7 @@
 	name = "motion-sensitive security camera"
 
 /obj/machinery/camera/motion/Initialize()
-	..()
+	. = ..()
 	upgradeMotion()
 
 // ALL UPGRADES

--- a/code/game/machinery/computer/atmos_alert.dm
+++ b/code/game/machinery/computer/atmos_alert.dm
@@ -12,7 +12,7 @@
 	light_color = LIGHT_COLOR_CYAN
 
 /obj/machinery/computer/atmos_alert/Initialize()
-	..()
+	. = ..()
 	set_frequency(receive_frequency)
 
 /obj/machinery/computer/atmos_alert/Destroy()

--- a/code/game/machinery/computer/atmos_control.dm
+++ b/code/game/machinery/computer/atmos_control.dm
@@ -46,7 +46,7 @@
 	radio_connection = SSradio.add_object(src, frequency, GLOB.RADIO_ATMOSIA)
 
 /obj/machinery/air_sensor/Initialize()
-	..()
+	. = ..()
 	SSair.atmos_machinery += src
 	set_frequency(frequency)
 

--- a/code/game/objects/items/cigs_lighters.dm
+++ b/code/game/objects/items/cigs_lighters.dm
@@ -121,7 +121,7 @@ CIGARETTE PACKETS ARE IN FANCY.DM
 	return (TOXLOSS|OXYLOSS)
 
 /obj/item/clothing/mask/cigarette/Initialize()
-	..()
+	. = ..()
 	create_reagents(chem_volume)
 	reagents.set_reacting(FALSE) // so it doesn't react until you light it
 	if(list_reagents)
@@ -378,7 +378,7 @@ CIGARETTE PACKETS ARE IN FANCY.DM
 	var/packeditem = 0
 
 /obj/item/clothing/mask/cigarette/pipe/Initialize()
-	..()
+	. = ..()
 	name = "empty [initial(name)]"
 
 /obj/item/clothing/mask/cigarette/pipe/Destroy()

--- a/code/game/objects/items/devices/PDA/cart.dm
+++ b/code/game/objects/items/devices/PDA/cart.dm
@@ -134,7 +134,7 @@
 	access = CART_REAGENT_SCANNER | CART_ATMOS
 
 /obj/item/cartridge/signal/Initialize()
-	..()
+	. = ..()
 	radio = new /obj/item/radio/integrated/signal(src)
 
 
@@ -183,7 +183,7 @@
 	bot_access_flags = FLOOR_BOT | CLEAN_BOT | MED_BOT
 
 /obj/item/cartridge/rd/Initialize()
-	..()
+	. = ..()
 	radio = new /obj/item/radio/integrated/signal(src)
 
 /obj/item/cartridge/captain

--- a/code/game/objects/items/devices/PDA/radio.dm
+++ b/code/game/objects/items/devices/PDA/radio.dm
@@ -30,7 +30,7 @@
 	return ..()
 
 /obj/item/radio/integrated/signal/Initialize()
-	..()
+	. = ..()
 	if (src.frequency < 1200 || src.frequency > 1600)
 		src.frequency = sanitize_frequency(src.frequency)
 

--- a/code/game/objects/items/devices/flashlight.dm
+++ b/code/game/objects/items/devices/flashlight.dm
@@ -16,7 +16,7 @@
 	var/flashlight_power = 1 //strength of the light when on
 
 /obj/item/device/flashlight/Initialize()
-	..()
+	. = ..()
 	update_brightness()
 
 /obj/item/device/flashlight/proc/update_brightness(mob/user = null)
@@ -409,7 +409,7 @@
 /obj/item/device/flashlight/glowstick/Initialize()
 	fuel = rand(1600, 2000)
 	light_color = color
-	..()
+	. = ..()
 
 /obj/item/device/flashlight/glowstick/Destroy()
 	STOP_PROCESSING(SSobj, src)

--- a/code/game/objects/items/devices/gps.dm
+++ b/code/game/objects/items/devices/gps.dm
@@ -17,7 +17,7 @@ GLOBAL_LIST_EMPTY(GPS_list)
 
 
 /obj/item/device/gps/Initialize()
-	..()
+	. = ..()
 	GLOB.GPS_list += src
 	name = "global positioning system ([gpstag])"
 	add_overlay("working")

--- a/code/game/objects/items/devices/radio/radio.dm
+++ b/code/game/objects/items/devices/radio/radio.dm
@@ -555,7 +555,7 @@
 	flags_2 = NO_EMP_WIRES_2
 
 /obj/item/device/radio/borg/Initialize(mapload)
-	..()
+	. = ..()
 
 /obj/item/device/radio/borg/syndicate
 	syndie = 1

--- a/code/game/objects/items/devices/taperecorder.dm
+++ b/code/game/objects/items/devices/taperecorder.dm
@@ -21,7 +21,7 @@
 
 
 /obj/item/device/taperecorder/Initialize(mapload)
-	..()
+	. = ..()
 	if(starting_tape_type)
 		mytape = new starting_tape_type(src)
 	update_icon()

--- a/code/game/objects/structures/aliens.dm
+++ b/code/game/objects/structures/aliens.dm
@@ -127,7 +127,7 @@
 /obj/structure/alien/weeds/Initialize()
 	pixel_x = -4
 	pixel_y = -4 //so the sprites line up right in the map editor
-	..()
+	. = ..()
 
 	if(!blacklisted_turfs)
 		blacklisted_turfs = typecacheof(list(
@@ -178,7 +178,7 @@
 
 /obj/structure/alien/weeds/node/Initialize()
 	icon = 'icons/obj/smooth_structures/alien/weednode.dmi'
-	..()
+	. = ..()
 	set_light(lon_range)
 	var/obj/structure/alien/weeds/W = locate(/obj/structure/alien/weeds) in loc
 	if(W && W != src)
@@ -223,7 +223,7 @@
 	var/obj/item/clothing/mask/facehugger/child
 
 /obj/structure/alien/egg/Initialize(mapload)
-	..()
+	. = ..()
 	update_icon()
 	if(status == GROWING || status == GROWN)
 		child = new(src)

--- a/code/game/objects/structures/beds_chairs/chair.dm
+++ b/code/game/objects/structures/beds_chairs/chair.dm
@@ -15,7 +15,7 @@
 	layer = OBJ_LAYER
 
 /obj/structure/chair/Initialize()
-	..()
+	. = ..()
 	if(!anchored)	//why would you put these on the shuttle?
 		addtimer(CALLBACK(src, .proc/RemoveFromLatejoin), 0)
 

--- a/code/game/objects/structures/safe.dm
+++ b/code/game/objects/structures/safe.dm
@@ -33,7 +33,7 @@ FLOOR SAFES
 
 
 /obj/structure/safe/Initialize(mapload)
-	..()
+	. = ..()
 
 	if(!mapload)
 		return
@@ -192,7 +192,7 @@ FLOOR SAFES
 
 
 /obj/structure/safe/floor/Initialize(mapload)
-	..()
+	. = ..()
 	if(mapload)
 		var/turf/T = loc
 		hide(T.intact)

--- a/code/modules/mob/living/silicon/pai/pai.dm
+++ b/code/modules/mob/living/silicon/pai/pai.dm
@@ -104,7 +104,7 @@
 		pda.owner = text("[]", src)
 		pda.name = pda.owner + " (" + pda.ownjob + ")"
 
-	..()
+	. = ..()
 
 	var/datum/action/innate/pai/shell/AS = new /datum/action/innate/pai/shell
 	var/datum/action/innate/pai/chassis/AC = new /datum/action/innate/pai/chassis

--- a/code/modules/mob/living/simple_animal/bot/ed209bot.dm
+++ b/code/modules/mob/living/simple_animal/bot/ed209bot.dm
@@ -43,7 +43,7 @@
 
 
 /mob/living/simple_animal/bot/ed209/Initialize(mapload,created_name,created_lasercolor)
-	..()
+	. = ..()
 	if(created_name)
 		name = created_name
 	if(created_lasercolor)

--- a/code/modules/mob/living/simple_animal/bot/floorbot.dm
+++ b/code/modules/mob/living/simple_animal/bot/floorbot.dm
@@ -39,7 +39,7 @@
 	#define TILE_EMAG		7
 
 /mob/living/simple_animal/bot/floorbot/Initialize()
-	..()
+	. = ..()
 	update_icon()
 	var/datum/job/engineer/J = new/datum/job/engineer
 	access_card.access += J.get_access()

--- a/code/modules/mob/living/simple_animal/bot/mulebot.dm
+++ b/code/modules/mob/living/simple_animal/bot/mulebot.dm
@@ -47,7 +47,7 @@
 	var/bloodiness = 0
 
 /mob/living/simple_animal/bot/mulebot/Initialize()
-	..()
+	. = ..()
 	wires = new /datum/wires/mulebot(src)
 	var/datum/job/cargo_tech/J = new/datum/job/cargo_tech
 	access_card.access = J.get_access()

--- a/code/modules/mob/living/simple_animal/friendly/cat.dm
+++ b/code/modules/mob/living/simple_animal/friendly/cat.dm
@@ -31,7 +31,7 @@
 	gold_core_spawnable = 2
 
 /mob/living/simple_animal/pet/cat/Initialize()
-	..()
+	. = ..()
 	verbs += /mob/living/proc/lay_down
 
 /mob/living/simple_animal/pet/cat/update_canmove()
@@ -91,7 +91,7 @@
 		icon_living = "original"
 		icon_dead = "original_dead"
 	Read_Memory()
-	..()
+	. = ..()
 
 /mob/living/simple_animal/pet/cat/Runtime/Life()
 	if(!cats_deployed && SSticker.current_state >= GAME_STATE_SETTING_UP)

--- a/code/modules/mob/living/simple_animal/friendly/drone/extra_drone_types.dm
+++ b/code/modules/mob/living/simple_animal/friendly/drone/extra_drone_types.dm
@@ -33,7 +33,7 @@
 	flavortext = null
 
 /mob/living/simple_animal/drone/syndrone/Initialize()
-	..()
+	. = ..()
 	internal_storage.hidden_uplink.telecrystals = 10
 
 /mob/living/simple_animal/drone/syndrone/Login()
@@ -46,7 +46,7 @@
 	default_storage = /obj/item/device/radio/uplink/nuclear
 
 /mob/living/simple_animal/drone/syndrone/badass/Initialize()
-	..()
+	. = ..()
 	internal_storage.hidden_uplink.telecrystals = 30
 	var/obj/item/implant/weapons_auth/W = new/obj/item/implant/weapons_auth(src)
 	W.implant(src)
@@ -55,7 +55,7 @@
 	default_hatmask = /obj/item/clothing/head/chameleon/drone
 
 /mob/living/simple_animal/drone/snowflake/Initialize()
-	..()
+	. = ..()
 	desc += " This drone appears to have a complex holoprojector built on its 'head'."
 
 /obj/item/drone_shell/syndrone

--- a/code/modules/mob/living/simple_animal/friendly/mouse.dm
+++ b/code/modules/mob/living/simple_animal/friendly/mouse.dm
@@ -26,7 +26,7 @@
 	var/chew_probability = 1
 
 /mob/living/simple_animal/mouse/Initialize()
-	..()
+	. = ..()
 	if(!body_color)
 		body_color = pick( list("brown","gray","white") )
 	icon_state = "mouse_[body_color]"

--- a/code/modules/mob/living/simple_animal/friendly/pet.dm
+++ b/code/modules/mob/living/simple_animal/friendly/pet.dm
@@ -30,7 +30,7 @@
 		..()
 
 /mob/living/simple_animal/pet/Initialize()
-	..()
+	. = ..()
 	if(pcollar)
 		pcollar = new(src)
 		regenerate_icons()

--- a/code/modules/mob/living/simple_animal/guardian/guardian.dm
+++ b/code/modules/mob/living/simple_animal/guardian/guardian.dm
@@ -54,7 +54,7 @@ GLOBAL_LIST_EMPTY(parasites) //all currently existing/living guardians
 	GLOB.parasites += src
 	setthemename(theme)
 
-	..()
+	. = ..()
 
 /mob/living/simple_animal/hostile/guardian/med_hud_set_health()
 	if(summoner)
@@ -655,7 +655,7 @@ GLOBAL_LIST_EMPTY(parasites) //all currently existing/living guardians
 	name = "holoparasite injector kit"
 
 /obj/item/storage/box/syndie_kit/guardian/Initialize()
-	..()
+	. = ..()
 	new /obj/item/guardiancreator/tech/choose/traitor(src)
 	new /obj/item/paper/guides/antag/guardian(src)
 	return

--- a/code/modules/mob/living/simple_animal/hostile/bosses/boss.dm
+++ b/code/modules/mob/living/simple_animal/hostile/bosses/boss.dm
@@ -12,7 +12,7 @@
 
 
 /mob/living/simple_animal/hostile/boss/Initialize()
-	..()
+	. = ..()
 
 	atb = new()
 	atb.point_regen_delay = point_regen_delay

--- a/code/modules/mob/living/simple_animal/parrot.dm
+++ b/code/modules/mob/living/simple_animal/parrot.dm
@@ -895,7 +895,7 @@
 	else
 		speak += pick("...alive?", "This isn't parrot heaven!", "I live, I die, I live again!", "The void fades!")
 
-	..()
+	. = ..()
 
 /mob/living/simple_animal/parrot/Poly/Life()
 	if(!stat && SSticker.current_state == GAME_STATE_FINISHED && !memory_saved)


### PR DESCRIPTION
Hopefully fixes the following:
Fixes #29686
Fixes #29679

Fixes "broken" `. = ..()` chains in the following Initialize()s that don't set a return value themselves: 

/mob/living/simple_animal/pet <- Actually fixes Ian, also fixes puppies
/mob/living/simple_animal/parrot/Poly
/mob/living/simple_animal/bot/floorbot
/mob/living/simple_animal/hostile/boss <- fixes paper wizard
/obj/machinery/camera/motion
/obj/machinery/air_sensor
/obj/item/clothing/mask/cigarette
/obj/item/clothing/mask/cigarette/pipe
/obj/item/cartridge/signal
/obj/item/cartridge/rd
/obj/item/radio/integrated/signal
/obj/item/device/radio/borg
/obj/item/device/flashlight
/obj/item/device/flashlight/glowstick
/obj/item/device/gps
/obj/item/device/taperecorder
/obj/structure/safe
/obj/structure/safe/floor
/obj/structure/chair
/obj/structure/alien/weeds
/obj/structure/alien/weeds/node
/obj/structure/alien/egg

[why]: 
Removes a fair amount of initialize errors
