### PR TITLE
Fixed changeling augmented eyesight ability

### DIFF
--- a/code/game/gamemodes/changeling/powers/augmented_eyesight.dm
+++ b/code/game/gamemodes/changeling/powers/augmented_eyesight.dm
@@ -7,23 +7,22 @@
 	helptext = "Grants us thermal vision or flash protection. We will become a lot more vulnerable to flash-based devices while thermal vision is active."
 	chemical_cost = 0
 	dna_cost = 2 //Would be 1 without thermal vision
-	active = 0 //Whether or not vision is enhanced
 
 /obj/effect/proc_holder/changeling/augmented_eyesight/sting_action(mob/living/carbon/human/user)
 	if(!istype(user))
 		return
 	var/obj/item/organ/eyes/E = user.getorganslot("eye_sight")
 	if(E)
-		if(active)
+		if(!active)
 			E.sight_flags |= SEE_MOBS
 			E.flash_protect = -1
 			to_chat(user, "We adjust our eyes to sense prey through walls.")
-			active = 1
+			active = TRUE //Defined in code/modules/spells/spell.dm
 		else
 			E.sight_flags -= SEE_MOBS
 			E.flash_protect = 2
 			to_chat(user, "We adjust our eyes to protect them from bright lights.")
-			active = 0
+			active = FALSE
 		user.update_sight()
 	else
 		to_chat(user, "We can't adjust our eyes if we don't have any!")

--- a/code/game/gamemodes/changeling/powers/augmented_eyesight.dm
+++ b/code/game/gamemodes/changeling/powers/augmented_eyesight.dm
@@ -14,14 +14,16 @@
 		return
 	var/obj/item/organ/eyes/E = user.getorganslot("eye_sight")
 	if(E)
-		if(E.flash_protect)
+		if(active)
 			E.sight_flags |= SEE_MOBS
 			E.flash_protect = -1
 			to_chat(user, "We adjust our eyes to sense prey through walls.")
+			active = 1
 		else
 			E.sight_flags -= SEE_MOBS
 			E.flash_protect = 2
 			to_chat(user, "We adjust our eyes to protect them from bright lights.")
+			active = 0
 		user.update_sight()
 	else
 		to_chat(user, "We can't adjust our eyes if we don't have any!")

--- a/code/game/gamemodes/changeling/powers/augmented_eyesight.dm
+++ b/code/game/gamemodes/changeling/powers/augmented_eyesight.dm
@@ -1,4 +1,4 @@
-//Augmented Eyesight: Gives you thermal and night vision - bye bye, flashlights. Also, high DNA cost because of how powerful it is.
+//Augmented Eyesight: Gives you x-ray vision or protection from flashes. Also, high DNA cost because of how powerful it is.
 //Possible todo: make a custom message for directing a penlight/flashlight at the eyes - not sure what would display though.
 
 /obj/effect/proc_holder/changeling/augmented_eyesight
@@ -7,6 +7,15 @@
 	helptext = "Grants us thermal vision or flash protection. We will become a lot more vulnerable to flash-based devices while thermal vision is active."
 	chemical_cost = 0
 	dna_cost = 2 //Would be 1 without thermal vision
+	active = FALSE
+
+/obj/effect/proc_holder/changeling/augmented_eyesight/on_purchase(mob/user) //The ability starts inactive, so we should be protected from flashes.
+	var/obj/item/organ/eyes/E = user.getorganslot("eye_sight")
+	if (E)
+		E.flash_protect = 2 //Adjust the user's eyes' flash protection
+		to_chat(user, "We adjust our eyes to protect them from bright lights.")
+	else
+		to_chat(user, "We can't adjust our eyes if we don't have any!")
 
 /obj/effect/proc_holder/changeling/augmented_eyesight/sting_action(mob/living/carbon/human/user)
 	if(!istype(user))
@@ -14,13 +23,13 @@
 	var/obj/item/organ/eyes/E = user.getorganslot("eye_sight")
 	if(E)
 		if(!active)
-			E.sight_flags |= SEE_MOBS
-			E.flash_protect = -1
+			E.sight_flags |= SEE_MOBS | SEE_OBJS | SEE_TURFS //Add sight flags to the user's eyes
+			E.flash_protect = -1 //Adjust the user's eyes' flash protection
 			to_chat(user, "We adjust our eyes to sense prey through walls.")
 			active = TRUE //Defined in code/modules/spells/spell.dm
 		else
-			E.sight_flags -= SEE_MOBS
-			E.flash_protect = 2
+			E.sight_flags ^= SEE_MOBS | SEE_OBJS | SEE_TURFS //Remove sight flags from the user's eyes
+			E.flash_protect = 2 //Adjust the user's eyes' flash protection
 			to_chat(user, "We adjust our eyes to protect them from bright lights.")
 			active = FALSE
 		user.update_sight()
@@ -32,7 +41,11 @@
 	return 1
 
 
-/obj/effect/proc_holder/changeling/augmented_eyesight/on_refund(mob/user)
+/obj/effect/proc_holder/changeling/augmented_eyesight/on_refund(mob/user) //Get rid of x-ray vision and flash protection when the user refunds this ability
 	var/obj/item/organ/eyes/E = user.getorganslot("eye_sight")
 	if(E)
-		E.sight_flags -= SEE_MOBS
+		if (active)
+			E.sight_flags ^= SEE_MOBS | SEE_OBJS | SEE_TURFS
+		else
+			E.flash_protect = 0
+		user.update_sight()


### PR DESCRIPTION
:cl: VexingRaven
fix: Changeling Augmented Eyesight ability now grants flash protection when toggled off
fix: Changeling Augmented Eyesight ability can now be toggled properly
fix: Changeling Augmented Eyesight ability is properly removed when readapting
/:cl:

Fixes #24086.

Note that I decided not to remove the x-ray part since it's been like this for so long it seems more like a balance change than a bugfix if I change that now. For whatever reason, it was underflowing the sight variable before, causing it to set sight to something like 65531 or something and granting x-ray vision. I'm unsure why, but my changes made it no longer underflow so I had to set the proper flags to make it x-ray again.

I'm willing to make it actually work as thermals though if maintainers think that would be better. (since that's what the ability was intended to be).

Also if anyone could help out, I'm not sure that I am using the right operator to unset the bitflags. I couldn't get it working any other way, but using XOR doesn't feel right for this case.