### PR TITLE
Fix transit tube atmos (again)

### DIFF
--- a/code/game/objects/structures/transit_tubes/station.dm
+++ b/code/game/objects/structures/transit_tubes/station.dm
@@ -147,8 +147,11 @@
 		sleep(OPEN_DURATION + 2)
 		pod_moving = 0
 		if(!QDELETED(pod))
+			var/datum/gas_mixture/floor_mixture = loc.return_air()
+			floor_mixture.archive()
 			pod.air_contents.archive()
-			pod.air_contents.share(loc.return_air(), 1) //mix the pod's gas mixture with the tile it's on
+			pod.air_contents.share(floor_mixture, 1) //mix the pod's gas mixture with the tile it's on
+			air_update_turf()
 
 /obj/structure/transit_tube/station/init_tube_dirs()
 	switch(dir)

--- a/code/game/objects/structures/transit_tubes/transit_tube_pod.dm
+++ b/code/game/objects/structures/transit_tubes/transit_tube_pod.dm
@@ -11,7 +11,7 @@
 
 /obj/structure/transit_tube_pod/New(loc)
 	..()
-	air_contents.assert_gases("o2", "n2")
+	air_contents.add_gases("o2", "n2")
 	air_contents.gases["o2"][MOLES] = MOLES_O2STANDARD
 	air_contents.gases["n2"][MOLES] = MOLES_N2STANDARD
 	air_contents.temperature = T20C

--- a/code/game/objects/structures/transit_tubes/transit_tube_pod.dm
+++ b/code/game/objects/structures/transit_tubes/transit_tube_pod.dm
@@ -9,8 +9,8 @@
 	var/datum/gas_mixture/air_contents = new()
 
 
-/obj/structure/transit_tube_pod/New(loc)
-	..()
+/obj/structure/transit_tube_pod/Initialize()
+	. = ..()
 	air_contents.add_gases("o2", "n2")
 	air_contents.gases["o2"][MOLES] = MOLES_O2STANDARD
 	air_contents.gases["n2"][MOLES] = MOLES_N2STANDARD


### PR DESCRIPTION
#30116 had the right idea but it did not fix the problem. Calling `archive` on the turf's gas mixture was the best fix I've found.

I'm not sure how safe it is to call `archive` like this. If there's concern, I guess it would be possible to clone the turf's gas archive and then copy it back after `share` returns. I'm not sure if that would be better or worse.

I've also added `air_update_turf` so that the released gas gets mixed into the surrounding atmosphere correctly. Otherwise the gas changes remain invisible until something else makes the turf active.