### PR TITLE
Fixes admin volume not updating datum var

### DIFF
--- a/code/modules/goonchat/browserassets/js/browserOutput.js
+++ b/code/modules/goonchat/browserassets/js/browserOutput.js
@@ -428,6 +428,7 @@ function ehjaxCallback(data) {
 			} else {
 				handleClientData(data.clientData.ckey, data.clientData.ip, data.clientData.compid);
 			}
+			sendVolumeUpdate();
 		} else if (data.firebug) {
 			if (data.trigger) {
 				internalOutput('<span class="internal boldnshit">Loading firebug console, triggered by '+data.trigger+'...</span>', 'internal');


### PR DESCRIPTION
Fixes an issue when joining a round with a browseroutput control already loaded from a previous round, the server-side datum var for the music volume wouldn't be updated unless you moved the slider again.