### PR TITLE
Soft crit slowdown for all carbons

### DIFF
--- a/code/__DEFINES/combat.dm
+++ b/code/__DEFINES/combat.dm
@@ -69,7 +69,6 @@
 #define GRAB_KILL					3
 
 //slowdown when in softcrit
-#define SOFTCRIT_MIN_SLOWDOWN 8
 #define SOFTCRIT_ADD_SLOWDOWN 6
 
 //Attack types for checking shields/hit reactions

--- a/code/modules/mob/living/carbon/carbon_movement.dm
+++ b/code/modules/mob/living/carbon/carbon_movement.dm
@@ -17,6 +17,9 @@
 		if(legcuffed)
 			. += legcuffed.slowdown
 
+	if(stat == SOFT_CRIT)
+		. = max(SOFTCRIT_MIN_SLOWDOWN, . + SOFTCRIT_ADD_SLOWDOWN) //regardless of how fast you are, you move at a maximum of SOFTCRIT_MIN_SLOWDOWN while in softcrit
+
 /mob/living/carbon/slip(knockdown_amount, obj/O, lube)
 	if(movement_type & FLYING)
 		return 0

--- a/code/modules/mob/living/carbon/carbon_movement.dm
+++ b/code/modules/mob/living/carbon/carbon_movement.dm
@@ -18,7 +18,7 @@
 			. += legcuffed.slowdown
 
 	if(stat == SOFT_CRIT)
-		. = max(SOFTCRIT_MIN_SLOWDOWN, . + SOFTCRIT_ADD_SLOWDOWN) //regardless of how fast you are, you move at a maximum of SOFTCRIT_MIN_SLOWDOWN while in softcrit
+		. += SOFTCRIT_ADD_SLOWDOWN
 
 /mob/living/carbon/slip(knockdown_amount, obj/O, lube)
 	if(movement_type & FLYING)

--- a/code/modules/mob/living/carbon/human/species.dm
+++ b/code/modules/mob/living/carbon/human/species.dm
@@ -1036,8 +1036,6 @@
 			. += (1.5 - flight)
 		if(H.bodytemperature < BODYTEMP_COLD_DAMAGE_LIMIT)
 			. += (BODYTEMP_COLD_DAMAGE_LIMIT - H.bodytemperature) / COLD_SLOWDOWN_FACTOR
-	if(H.stat == SOFT_CRIT)
-		. = max(SOFTCRIT_MIN_SLOWDOWN, . + SOFTCRIT_ADD_SLOWDOWN) //regardless of how fast you are, you move at a maximum of SOFTCRIT_MIN_SLOWDOWN while in softcrit
 	return .
 
 //////////////////


### PR DESCRIPTION
Fixes #30546

Removes the soft crit cap because it does not work with the current code. If someone wants to figure it out to re-add it that'd be cool but lightning speed crit people are a bigger issue right now