### PR TITLE
Adds shovels to the golem ship

### DIFF
--- a/_maps/RandomRuins/LavaRuins/lavaland_surface_golem_ship.dmm
+++ b/_maps/RandomRuins/LavaRuins/lavaland_surface_golem_ship.dmm
@@ -7,6 +7,9 @@
 /area/ruin/powered/golem_ship)
 "c" = (
 /obj/structure/closet/crate,
+/obj/item/shovel,
+/obj/item/shovel,
+/obj/item/shovel,
 /obj/item/pickaxe,
 /obj/item/pickaxe,
 /obj/item/pickaxe,
@@ -19,6 +22,8 @@
 /area/ruin/powered/golem_ship)
 "d" = (
 /obj/structure/closet/crate,
+/obj/item/shovel,
+/obj/item/shovel,
 /obj/item/pickaxe,
 /obj/item/pickaxe,
 /obj/item/storage/bag/ore,


### PR DESCRIPTION
Was intended to treat #30616, however it seems that the root of it is a separate issue.

This just adds some shovels to the crates where the pickaxes are for the golems. They can make them in their autolathe as well if they run out, so why not just give them a few to start off anyway?