### PR TITLE
Adds 5s delay to current immediate ahelp verb returns

### DIFF
--- a/code/modules/admin/verbs/adminhelp.dm
+++ b/code/modules/admin/verbs/adminhelp.dm
@@ -327,8 +327,7 @@ GLOBAL_DATUM_INIT(ahelp_tickets, /datum/admin_help_tickets, new)
 	state = AHELP_RESOLVED
 	GLOB.ahelp_tickets.ListInsert(src)
 
-	if(initiator)
-		initiator.giveadminhelpverb()
+	addtimer(CALLBACK(initiator, /client/proc/giveadminhelpverb), 50)
 
 	AddInteraction("<font color='green'>Resolved by [key_name].</font>")
 	if(!silent)


### PR DESCRIPTION
To prevent accidental instant reahelps when the ticket is resolved