### PR TITLE
Fixes monkeys being able to open PDA's UI.

### DIFF
--- a/code/game/objects/items/devices/PDA/PDA.dm
+++ b/code/game/objects/items/devices/PDA/PDA.dm
@@ -112,6 +112,10 @@ GLOBAL_LIST_EMPTY(PDAs)
 	return
 
 /obj/item/device/pda/attack_self(mob/user)
+	if(!user.IsAdvancedToolUser())
+		to_chat(user, "<span class='warning'>You don't have the dexterity to do this!</span>")
+		return
+
 	var/datum/asset/assets = get_asset_datum(/datum/asset/simple/pda)
 	assets.send(user)
 


### PR DESCRIPTION
Monkey's were able to open PDA's normally by attack_self (if they clicked something on the PDA screen it would close and claim that they didn't have the dexterity to use it) but not by clicking&dragging on self.

This makes it so that they don't have the dexterity to open it up at all.

Fixes #30536 