### PR TITLE
New DCS signals

### DIFF
--- a/code/__DEFINES/components.dm
+++ b/code/__DEFINES/components.dm
@@ -11,12 +11,34 @@
 // All signals. Format:
 // When the signal is called: (signal arguments)
 
+// /datum signals
 #define COMSIG_COMPONENT_ADDED "component_added"				//when a component is added to a datum: (datum/component)
 #define COMSIG_COMPONENT_REMOVING "component_removing"			//before a component is removed from a datum because of RemoveComponent: (datum/component)
 #define COMSIG_PARENT_QDELETED "parent_qdeleted"				//before a datum's Destroy() is called: ()
-#define COMSIG_PARENT_ATTACKBY "atom_attackby"			        //from the base of atom/attackby: (obj/item, mob/living, params)
-#define COMSIG_PARENT_EXAMINE "atom_examine"                    //from the base of atom/examine: (mob)
+
+// /atom signals
+#define COMSIG_PARENT_ATTACKBY "atom_attackby"			        //from base of atom/attackby(): (obj/item, mob/living, params)
+#define COMSIG_ATOM_HULK_ATTACK "hulk_attack"					//from base of atom/attack_hulk(): (mob/living/carbon/human)
+#define COMSIG_PARENT_EXAMINE "atom_examine"                    //from base of atom/examine(): (mob)
 #define COMSIG_ATOM_ENTERED "atom_entered"                      //from base of atom/Entered(): (atom/movable, atom)
 #define COMSIG_ATOM_EX_ACT "atom_ex_act"						//from base of atom/ex_act(): (severity, target)
+#define COMSIG_ATOM_EMP_ACT "atom_emp_act"						//from base of atom/emp_act(): (severity)
+#define COMSIG_ATOM_FIRE_ACT "atom_fire_act"					//from base of atom/fire_act(): (exposed_temperature, exposed_volume)
+#define COMSIG_ATOM_BULLET_ACT "atom_bullet_act"				//from base of atom/bullet_act(): (obj/item/projectile, def_zone)
+#define COMSIG_ATOM_BLOB_ACT "atom_blob_act"					//from base of atom/blob_act(): (obj/structure/blob)
+#define COMSIG_ATOM_ACID_ACT "atom_acid_act"					//from base of atom/acid_act(): (acidpwr, acid_volume)
+#define COMSIG_ATOM_EMAG_ACT "atom_emag_act"					//from base of atom/emag_act(): ()
+#define COMSIG_ATOM_NARSIE_ACT "atom_narsie_act"				//from base of atom/narsie_act(): ()
+#define COMSIG_ATOM_RATVAR_ACT "atom_ratvar_act"				//from base of atom/ratvar_act(): ()
+#define COMSIG_ATOM_RCD_ACT "atom_rcd_act"						//from base of atom/rcd_act(): (mob, obj/item/construction/rcd, passed_mode)
 #define COMSIG_ATOM_SING_PULL "atom_sing_pull"					//from base of atom/singularity_pull(): (S, current_size)
+
+// /atom/movable signals
+#define COMSIG_MOVABLE_MOVED "movable_moved"					//from base of atom/movable/Moved(): (atom, dir)
 #define COMSIG_MOVABLE_CROSSED "movable_crossed"                //from base of atom/movable/Crossed(): (atom/movable)
+#define COMSIG_MOVABLE_COLLIDE "movable_collide"				//from base of atom/movable/Collide(): (atom)
+#define COMSIG_MOVABLE_IMPACT "movable_impact"					//from base of atom/movable/throw_impact(): (atom, throwingdatum)
+
+// /obj/machinery signals
+#define COMSIG_MACHINE_PROCESS "machine_process"				//from machinery subsystem fire(): ()
+#define COMSIG_MACHINE_PROCESS_ATMOS "machine_process_atmos"	//from air subsystem process_atmos_machinery(): () 

--- a/code/controllers/subsystem/air.dm
+++ b/code/controllers/subsystem/air.dm
@@ -164,6 +164,7 @@ SUBSYSTEM_DEF(air)
 		currentrun.len--
 		if(!M || (M.process_atmos(seconds) == PROCESS_KILL))
 			atmos_machinery.Remove(M)
+		M.SendSignal(COMSIG_MACHINE_PROCESS_ATMOS)
 		if(MC_TICK_CHECK)
 			return
 

--- a/code/controllers/subsystem/machines.dm
+++ b/code/controllers/subsystem/machines.dm
@@ -40,6 +40,7 @@ SUBSYSTEM_DEF(machines)
 		var/obj/machinery/thing = currentrun[currentrun.len]
 		currentrun.len--
 		if(!QDELETED(thing) && thing.process(seconds) != PROCESS_KILL)
+			thing.SendSignal(COMSIG_MACHINE_PROCESS)
 			if(thing.use_power)
 				thing.auto_use_power() //add back the power state
 		else

--- a/code/game/atoms.dm
+++ b/code/game/atoms.dm
@@ -150,6 +150,7 @@
 	return 0
 
 /atom/proc/attack_hulk(mob/living/carbon/human/user, does_attack_animation = 0)
+	SendSignal(COMSIG_ATOM_HULK_ATTACK, user)
 	if(does_attack_animation)
 		user.changeNext_move(CLICK_CD_MELEE)
 		add_logs(user, src, "punched", "hulk powers")
@@ -222,10 +223,12 @@
 	return
 
 /atom/proc/emp_act(severity)
+	SendSignal(COMSIG_ATOM_EMP_ACT, severity)
 	if(istype(wires) && !(flags_2 & NO_EMP_WIRES_2))
 		wires.emp_pulse()
 
 /atom/proc/bullet_act(obj/item/projectile/P, def_zone)
+	SendSignal(COMSIG_ATOM_BULLET_ACT, P, def_zone)
 	. = P.on_hit(src, 0, def_zone)
 
 /atom/proc/in_contents_of(container)//can take class or object instance as argument
@@ -308,9 +311,11 @@
 	SendSignal(COMSIG_ATOM_EX_ACT, severity, target)
 
 /atom/proc/blob_act(obj/structure/blob/B)
+	SendSignal(COMSIG_ATOM_BLOB_ACT, B)
 	return
 
 /atom/proc/fire_act(exposed_temperature, exposed_volume)
+	SendSignal(COMSIG_ATOM_FIRE_ACT, exposed_temperature, exposed_volume)
 	return
 
 /atom/proc/hitby(atom/movable/AM, skipcatch, hitpush, blocked)
@@ -474,21 +479,26 @@ GLOBAL_LIST_EMPTY(blood_splatter_icons)
 	SendSignal(COMSIG_ATOM_SING_PULL, S, current_size)
 
 /atom/proc/acid_act(acidpwr, acid_volume)
+	SendSignal(COMSIG_ATOM_ACID_ACT, acidpwr, acid_volume)
 	return
 
 /atom/proc/emag_act()
+	SendSignal(COMSIG_ATOM_EMAG_ACT)
 	return
 
 /atom/proc/narsie_act()
+	SendSignal(COMSIG_ATOM_NARSIE_ACT)
 	return
 
 /atom/proc/ratvar_act()
+	SendSignal(COMSIG_ATOM_RATVAR_ACT)
 	return
 
 /atom/proc/rcd_vals(mob/user, obj/item/construction/rcd/the_rcd)
 	return FALSE
 
 /atom/proc/rcd_act(mob/user, obj/item/construction/rcd/the_rcd, passed_mode)
+	SendSignal(COMSIG_ATOM_RCD_ACT)
 	return FALSE
 
 /atom/proc/storage_contents_dump_act(obj/item/storage/src_object, mob/user)

--- a/code/game/atoms.dm
+++ b/code/game/atoms.dm
@@ -498,7 +498,7 @@ GLOBAL_LIST_EMPTY(blood_splatter_icons)
 	return FALSE
 
 /atom/proc/rcd_act(mob/user, obj/item/construction/rcd/the_rcd, passed_mode)
-	SendSignal(COMSIG_ATOM_RCD_ACT)
+	SendSignal(COMSIG_ATOM_RCD_ACT, user, the_rcd, passed_mode)
 	return FALSE
 
 /atom/proc/storage_contents_dump_act(obj/item/storage/src_object, mob/user)

--- a/code/game/atoms_movable.dm
+++ b/code/game/atoms_movable.dm
@@ -116,6 +116,7 @@
 
 //Called after a successful Move(). By this point, we've already moved
 /atom/movable/proc/Moved(atom/OldLoc, Dir)
+	SendSignal(COMSIG_MOVABLE_MOVED, OldLoc, Dir)
 	if (!inertia_moving)
 		inertia_next_move = world.time + inertia_move_delay
 		newtonian_move(Dir)
@@ -214,6 +215,7 @@
 //to differentiate it, naturally everyone forgot about this immediately and so some things
 //would bump twice, so now it's called Collide
 /atom/movable/proc/Collide(atom/A)
+	SendSignal(COMSIG_MOVABLE_COLLIDE, A)
 	if(A)
 		if(throwing)
 			throwing.hit_atom(A)
@@ -307,6 +309,7 @@
 
 /atom/movable/proc/throw_impact(atom/hit_atom, throwingdatum)
 	set waitfor = 0
+	SendSignal(COMSIG_MOVABLE_IMPACT, hit_atom, throwingdatum)
 	return hit_atom.hitby(src)
 
 /atom/movable/hitby(atom/movable/AM, skipcatch, hitpush = TRUE, blocked)


### PR DESCRIPTION
This pr is to hopefully figure out exactly where signals should go and get a lot of them out of the way preemptively. Feel free to suggest where we would use more.

The machine process signals in particular are what I need for a future pr but their implementation currently is questionable. We have a few options there:

1. Put it in the parent machine/process() proc and change all existing machinery to call it.
2. Make datum components able to be registered in the subsystem processing queue.
3. (The current) Call it only on machines already being processed in the subsystems.

The first and third both have the disadvantage that if a machine is normally not processing the datum components won't either. However the second choice is snowflake and adds a new codeblock in the affected subsystems. 

The options are in roughly descending order of difficulty/scope of the change.