### PR TITLE
Fixed small error causing signalers to fail to attach to each other in an assembly

### DIFF
--- a/code/modules/assembly/signaler.dm
+++ b/code/modules/assembly/signaler.dm
@@ -104,8 +104,7 @@ Code:
 			code = signaler2.code
 			frequency = signaler2.frequency
 			to_chat(user, "You transfer the frequency and code of \the [signaler2.name] to \the [name]")
-	else
-		..()
+	..()
 
 /obj/item/device/assembly/signaler/proc/signal()
 	if(!radio_connection) return


### PR DESCRIPTION
There was a small error in 7821fb80321ef2ee544d97f173c676999ecc759b which resulted in players being unable to create signaler-signaler assemblies. Corrected.
