### PR TITLE
Fixes potted plants putting you above wall objects

### DIFF
--- a/code/game/objects/structures/flora.dm
+++ b/code/game/objects/structures/flora.dm
@@ -267,6 +267,7 @@
 	var/image/I = image(icon = 'icons/obj/flora/plants.dmi' , icon_state = src.icon_state, loc = user)
 	I.override = 1
 	add_alt_appearance(/datum/atom_hud/alternate_appearance/basic/everyone, "sneaking_mission", I)
+	I.layer = ABOVE_MOB_LAYER
 	..()
 
 /obj/item/twohanded/required/kirbyplants/dropped(mob/living/user)


### PR DESCRIPTION
Fixes #28887 

🆑 ShizCalev
fix: Holding a potted plant will no longer put you above objects on walls.
/🆑