### PR TITLE
Gives Deltastation's and Metastation's armory one more riot shotty

### DIFF
--- a/_maps/map_files/Deltastation/DeltaStation2.dmm
+++ b/_maps/map_files/Deltastation/DeltaStation2.dmm
@@ -46873,6 +46873,7 @@
 /obj/item/gun/ballistic/shotgun/riot,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/effect/turf_decal/bot,
+/obj/item/gun/ballistic/shotgun/riot,
 /turf/open/floor/plasteel,
 /area/ai_monitored/security/armory)
 "bNh" = (

--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -3614,6 +3614,7 @@
 	pixel_y = 3
 	},
 /obj/item/gun/ballistic/shotgun/riot,
+/obj/item/gun/ballistic/shotgun/riot,
 /turf/open/floor/plasteel/vault{
 	dir = 1
 	},
@@ -100159,7 +100160,7 @@ aVs
 aVs
 aVs
 cVF
-cVW
+cVF
 cWn
 cVF
 cVF


### PR DESCRIPTION
Makes it consistent with boxstation, which has three. Both maps are meant for pops higher than box anyways so it makes sense. 

:cl: BeeSting12
balance: Deltastation's and Metastation's armory now starts with three riot shotguns!
/:cl:

