### PR TITLE
Fixes a bunch of computers

### DIFF
--- a/code/game/machinery/computer/_computer.dm
+++ b/code/game/machinery/computer/_computer.dm
@@ -19,6 +19,10 @@
 /obj/machinery/computer/Initialize(mapload, obj/item/circuitboard/C)
 	. = ..()
 	power_change()
+	if(C)
+		qdel(circuit)
+		circuit = C
+		C.loc = src
 
 /obj/machinery/computer/Destroy()
 	QDEL_NULL(circuit)

--- a/code/game/machinery/computer/_computer.dm
+++ b/code/game/machinery/computer/_computer.dm
@@ -19,10 +19,10 @@
 /obj/machinery/computer/Initialize(mapload, obj/item/circuitboard/C)
 	. = ..()
 	power_change()
-	if(C)
+	if(!QDELETED(C))
 		qdel(circuit)
 		circuit = C
-		C.loc = src
+		C.forceMove(src)
 
 /obj/machinery/computer/Destroy()
 	QDEL_NULL(circuit)


### PR DESCRIPTION
:cl: Kor
fix: It is possible to multitool the cargo computer circuitboard for contraband again
/:cl:

Constructed computers will once again use the circuit they were built with which fixes cargo contraband as well as ID computers, the syndicate challenge lock, and the cooldown on spamming captain messages

Fixes #30615