### PR TITLE
Fixes evidence bags showing ghost contents after their contents get deleted

### DIFF
--- a/code/modules/detectivework/evidence.dm
+++ b/code/modules/detectivework/evidence.dm
@@ -17,6 +17,12 @@
 	if(evidencebagEquip(I, user))
 		return 1
 
+/obj/item/evidencebag/handle_atom_del(atom/A)
+	cut_overlays()
+	w_class = WEIGHT_CLASS_TINY
+	icon_state = "evidenceobj"
+	desc = "An empty evidence bag."
+
 /obj/item/evidencebag/proc/evidencebagEquip(obj/item/I, mob/user)
 	if(!istype(I) || I.anchored == 1)
 		return

--- a/code/modules/detectivework/evidence.dm
+++ b/code/modules/detectivework/evidence.dm
@@ -19,9 +19,9 @@
 
 /obj/item/evidencebag/handle_atom_del(atom/A)
 	cut_overlays()
-	w_class = WEIGHT_CLASS_TINY
-	icon_state = "evidenceobj"
-	desc = "An empty evidence bag."
+	w_class = initial(w_class)
+	icon_state = initial(icon_state)
+	desc = initial(desc)
 
 /obj/item/evidencebag/proc/evidencebagEquip(obj/item/I, mob/user)
 	if(!istype(I) || I.anchored == 1)


### PR DESCRIPTION
Fixes #9544

On a related note, I cannot reproduce #20795 but it might've been caused by this bug leaving a ghost in the evidence bag that was used to bag the item.

[Changelogs]: 
[]: 


:cl: Naksu
fix: Evidence bags will no longer show ghosts of items such as primed flashbangs after the flashbang inside explodes
/:cl:

[why]: 
bugfix
