### PR TITLE
Ninja adrenaline boost removes stamina damage

### DIFF
--- a/code/modules/ninja/suit/n_suit_verbs/ninja_adrenaline.dm
+++ b/code/modules/ninja/suit/n_suit_verbs/ninja_adrenaline.dm
@@ -7,6 +7,7 @@
 		H.SetUnconscious(0)
 		H.SetStun(0)
 		H.SetKnockdown(0)
+		H.adjustStaminaLoss(-75)
 		H.stuttering = 0
 		H.say(pick("A CORNERED FOX IS MORE DANGEROUS THAN A JACKAL!","HURT ME MOOORRREEE!","IMPRESSIVE!"))
 		a_boost--


### PR DESCRIPTION
:cl:
add: Ninja adrenaline boost removes stamina damage
/:cl:

[why]: Disablers are no longer the ultimate anti-ninja weapon. Consistency with other adrenals.
