### PR TITLE
Adds Abandoned Airlocks

### DIFF
--- a/_maps/map_files/BoxStation/BoxStation.dmm
+++ b/_maps/map_files/BoxStation/BoxStation.dmm
@@ -6125,8 +6125,7 @@
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
 "ank" = (
-/obj/machinery/door/airlock/maintenance{
-	abandoned = 1;
+/obj/machinery/door/airlock/maintenance/abandoned{
 	req_access_txt = "12"
 	},
 /turf/open/floor/plating,
@@ -6900,8 +6899,7 @@
 /area/security/detectives_office)
 "ape" = (
 /obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/engineering{
-	abandoned = 1;
+/obj/machinery/door/airlock/engineering/abandoned{
 	name = "Vacant Office B";
 	req_access_txt = "32"
 	},
@@ -7057,8 +7055,7 @@
 /turf/open/floor/plating,
 /area/maintenance/fore/secondary)
 "apx" = (
-/obj/machinery/door/airlock/atmos{
-	abandoned = 1;
+/obj/machinery/door/airlock/atmos/abandoned{
 	name = "Atmospherics Maintenance";
 	req_access_txt = "12;24"
 	},
@@ -8275,8 +8272,7 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
 "asy" = (
-/obj/machinery/door/airlock/maintenance{
-	abandoned = 1;
+/obj/machinery/door/airlock/maintenance/abandoned{
 	name = "Firefighting equipment";
 	req_access_txt = "12"
 	},
@@ -8650,8 +8646,7 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
 "atB" = (
-/obj/machinery/door/airlock/maintenance{
-	abandoned = 1;
+/obj/machinery/door/airlock/maintenance/abandoned{
 	req_access_txt = "12"
 	},
 /turf/open/floor/plating,
@@ -9086,8 +9081,7 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
 "auG" = (
-/obj/machinery/door/airlock/maintenance{
-	abandoned = 1;
+/obj/machinery/door/airlock/maintenance/abandoned{
 	req_access_txt = "12"
 	},
 /obj/structure/cable{
@@ -9277,8 +9271,7 @@
 /turf/open/floor/plating,
 /area/maintenance/fore)
 "avf" = (
-/obj/machinery/door/airlock/maintenance{
-	abandoned = 1;
+/obj/machinery/door/airlock/maintenance/abandoned{
 	name = "Chemical Storage";
 	req_access_txt = "12"
 	},
@@ -10060,8 +10053,7 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/machinery/door/airlock/engineering{
-	abandoned = 1;
+/obj/machinery/door/airlock/engineering/abandoned{
 	name = "Electrical Maintenance";
 	req_access_txt = "11"
 	},
@@ -10237,8 +10229,7 @@
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
 "axj" = (
-/obj/machinery/door/airlock/maintenance{
-	abandoned = 1;
+/obj/machinery/door/airlock/maintenance/abandoned{
 	name = "Firefighting equipment";
 	req_access_txt = "12"
 	},
@@ -21404,8 +21395,7 @@
 /turf/open/floor/carpet,
 /area/chapel/main)
 "aXX" = (
-/obj/machinery/door/airlock/engineering{
-	abandoned = 1;
+/obj/machinery/door/airlock/engineering/abandoned{
 	name = "Vacant Office A";
 	req_access_txt = "32"
 	},
@@ -29916,8 +29906,7 @@
 	},
 /area/science/explab)
 "brE" = (
-/obj/machinery/door/airlock/maintenance{
-	abandoned = 1;
+/obj/machinery/door/airlock/maintenance/abandoned{
 	req_access_txt = "0";
 	req_one_access_txt = "8;12"
 	},
@@ -36569,8 +36558,7 @@
 /turf/open/floor/plasteel,
 /area/quartermaster/miningdock)
 "bGo" = (
-/obj/machinery/door/airlock/maintenance{
-	abandoned = 1;
+/obj/machinery/door/airlock/maintenance/abandoned{
 	name = "Firefighting equipment";
 	req_access_txt = "12"
 	},
@@ -38907,8 +38895,7 @@
 /turf/open/floor/plating,
 /area/maintenance/aft)
 "bKU" = (
-/obj/machinery/door/airlock/engineering{
-	abandoned = 1;
+/obj/machinery/door/airlock/engineering/abandoned{
 	name = "Construction Area";
 	req_access_txt = "32"
 	},
@@ -42596,8 +42583,7 @@
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
 "bTw" = (
-/obj/machinery/door/airlock/maintenance{
-	abandoned = 1;
+/obj/machinery/door/airlock/maintenance/abandoned{
 	req_access_txt = "12"
 	},
 /obj/machinery/atmospherics/pipe/simple/general/hidden{
@@ -44822,8 +44808,7 @@
 /turf/open/floor/plasteel/floorgrime,
 /area/maintenance/port/aft)
 "bYy" = (
-/obj/machinery/door/airlock/maintenance{
-	abandoned = 1;
+/obj/machinery/door/airlock/maintenance/abandoned{
 	name = "Incinerator Access";
 	req_access_txt = "12"
 	},
@@ -46174,8 +46159,7 @@
 /turf/open/floor/plasteel,
 /area/engine/break_room)
 "cbv" = (
-/obj/machinery/door/airlock/maintenance{
-	abandoned = 1;
+/obj/machinery/door/airlock/maintenance/abandoned{
 	name = "Research Delivery access";
 	req_access_txt = "12"
 	},
@@ -46320,8 +46304,7 @@
 /turf/open/floor/plating,
 /area/maintenance/aft)
 "cbO" = (
-/obj/machinery/door/airlock/atmos{
-	abandoned = 1;
+/obj/machinery/door/airlock/atmos/abandoned{
 	name = "Atmospherics Maintenance";
 	req_access_txt = "12;24"
 	},
@@ -46494,8 +46477,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/machinery/door/airlock/maintenance{
-	abandoned = 1;
+/obj/machinery/door/airlock/maintenance/abandoned{
 	name = "Construction Area Maintenance";
 	req_access_txt = "32"
 	},
@@ -47868,8 +47850,7 @@
 /turf/open/floor/circuit/killroom,
 /area/science/xenobiology)
 "cfs" = (
-/obj/machinery/door/airlock/maintenance{
-	abandoned = 1;
+/obj/machinery/door/airlock/maintenance/abandoned{
 	name = "Air Supply Maintenance";
 	req_access_txt = "12"
 	},
@@ -47894,8 +47875,7 @@
 /turf/closed/wall/r_wall,
 /area/science/misc_lab)
 "cfv" = (
-/obj/machinery/door/airlock/maintenance{
-	abandoned = 1;
+/obj/machinery/door/airlock/maintenance/abandoned{
 	name = "Firefighting equipment";
 	req_access_txt = "12"
 	},
@@ -50100,8 +50080,7 @@
 /turf/open/floor/plating,
 /area/maintenance/aft)
 "ckm" = (
-/obj/machinery/door/airlock/maintenance{
-	abandoned = 1;
+/obj/machinery/door/airlock/maintenance/abandoned{
 	name = "Biohazard Disposals";
 	req_access_txt = "12"
 	},
@@ -52775,8 +52754,7 @@
 /turf/open/space,
 /area/maintenance/disposal/incinerator)
 "cpR" = (
-/obj/machinery/door/airlock{
-	abandoned = 1;
+/obj/machinery/door/airlock/abandoned{
 	name = "Observatory Access"
 	},
 /turf/open/floor/plating,
@@ -56639,8 +56617,7 @@
 /turf/open/floor/plating,
 /area/maintenance/solars/port/aft)
 "cyL" = (
-/obj/machinery/door/airlock/maintenance{
-	abandoned = 1;
+/obj/machinery/door/airlock/maintenance/abandoned{
 	req_access_txt = "12"
 	},
 /obj/structure/cable{
@@ -62629,8 +62606,7 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard)
 "cNV" = (
-/obj/machinery/door/airlock/maintenance{
-	abandoned = 1;
+/obj/machinery/door/airlock/maintenance/abandoned{
 	req_access_txt = "0";
 	req_one_access_txt = "8;12"
 	},
@@ -63955,29 +63931,25 @@
 	},
 /area/construction/mining/aux_base)
 "cTF" = (
-/obj/machinery/door/airlock/maintenance{
-	abandoned = 1;
+/obj/machinery/door/airlock/maintenance/abandoned{
 	req_access_txt = "12"
 	},
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
 "cTG" = (
-/obj/machinery/door/airlock/maintenance{
-	abandoned = 1;
+/obj/machinery/door/airlock/maintenance/abandoned{
 	req_access_txt = "12"
 	},
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
 "cTH" = (
-/obj/machinery/door/airlock/maintenance{
-	abandoned = 1;
+/obj/machinery/door/airlock/maintenance/abandoned{
 	req_access_txt = "12"
 	},
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
 "cTI" = (
-/obj/machinery/door/airlock/maintenance{
-	abandoned = 1;
+/obj/machinery/door/airlock/maintenance/abandoned{
 	req_access_txt = "12"
 	},
 /turf/open/floor/plating,

--- a/_maps/map_files/BoxStation/BoxStation.dmm
+++ b/_maps/map_files/BoxStation/BoxStation.dmm
@@ -6126,6 +6126,7 @@
 /area/maintenance/port/fore)
 "ank" = (
 /obj/machinery/door/airlock/maintenance{
+	abandoned = 1;
 	req_access_txt = "12"
 	},
 /turf/open/floor/plating,
@@ -6900,6 +6901,7 @@
 "ape" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/engineering{
+	abandoned = 1;
 	name = "Vacant Office B";
 	req_access_txt = "32"
 	},
@@ -7056,6 +7058,7 @@
 /area/maintenance/fore/secondary)
 "apx" = (
 /obj/machinery/door/airlock/atmos{
+	abandoned = 1;
 	name = "Atmospherics Maintenance";
 	req_access_txt = "12;24"
 	},
@@ -8273,6 +8276,7 @@
 /area/maintenance/starboard/fore)
 "asy" = (
 /obj/machinery/door/airlock/maintenance{
+	abandoned = 1;
 	name = "Firefighting equipment";
 	req_access_txt = "12"
 	},
@@ -8647,6 +8651,7 @@
 /area/maintenance/starboard/fore)
 "atB" = (
 /obj/machinery/door/airlock/maintenance{
+	abandoned = 1;
 	req_access_txt = "12"
 	},
 /turf/open/floor/plating,
@@ -9082,6 +9087,7 @@
 /area/maintenance/starboard/fore)
 "auG" = (
 /obj/machinery/door/airlock/maintenance{
+	abandoned = 1;
 	req_access_txt = "12"
 	},
 /obj/structure/cable{
@@ -9272,6 +9278,7 @@
 /area/maintenance/fore)
 "avf" = (
 /obj/machinery/door/airlock/maintenance{
+	abandoned = 1;
 	name = "Chemical Storage";
 	req_access_txt = "12"
 	},
@@ -10054,6 +10061,7 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/door/airlock/engineering{
+	abandoned = 1;
 	name = "Electrical Maintenance";
 	req_access_txt = "11"
 	},
@@ -10230,6 +10238,7 @@
 /area/maintenance/port/fore)
 "axj" = (
 /obj/machinery/door/airlock/maintenance{
+	abandoned = 1;
 	name = "Firefighting equipment";
 	req_access_txt = "12"
 	},
@@ -21396,6 +21405,7 @@
 /area/chapel/main)
 "aXX" = (
 /obj/machinery/door/airlock/engineering{
+	abandoned = 1;
 	name = "Vacant Office A";
 	req_access_txt = "32"
 	},
@@ -29907,6 +29917,7 @@
 /area/science/explab)
 "brE" = (
 /obj/machinery/door/airlock/maintenance{
+	abandoned = 1;
 	req_access_txt = "0";
 	req_one_access_txt = "8;12"
 	},
@@ -36559,6 +36570,7 @@
 /area/quartermaster/miningdock)
 "bGo" = (
 /obj/machinery/door/airlock/maintenance{
+	abandoned = 1;
 	name = "Firefighting equipment";
 	req_access_txt = "12"
 	},
@@ -38896,6 +38908,7 @@
 /area/maintenance/aft)
 "bKU" = (
 /obj/machinery/door/airlock/engineering{
+	abandoned = 1;
 	name = "Construction Area";
 	req_access_txt = "32"
 	},
@@ -42584,6 +42597,7 @@
 /area/maintenance/port/aft)
 "bTw" = (
 /obj/machinery/door/airlock/maintenance{
+	abandoned = 1;
 	req_access_txt = "12"
 	},
 /obj/machinery/atmospherics/pipe/simple/general/hidden{
@@ -44809,6 +44823,7 @@
 /area/maintenance/port/aft)
 "bYy" = (
 /obj/machinery/door/airlock/maintenance{
+	abandoned = 1;
 	name = "Incinerator Access";
 	req_access_txt = "12"
 	},
@@ -46160,6 +46175,7 @@
 /area/engine/break_room)
 "cbv" = (
 /obj/machinery/door/airlock/maintenance{
+	abandoned = 1;
 	name = "Research Delivery access";
 	req_access_txt = "12"
 	},
@@ -46305,6 +46321,7 @@
 /area/maintenance/aft)
 "cbO" = (
 /obj/machinery/door/airlock/atmos{
+	abandoned = 1;
 	name = "Atmospherics Maintenance";
 	req_access_txt = "12;24"
 	},
@@ -46478,6 +46495,7 @@
 	dir = 4
 	},
 /obj/machinery/door/airlock/maintenance{
+	abandoned = 1;
 	name = "Construction Area Maintenance";
 	req_access_txt = "32"
 	},
@@ -47851,6 +47869,7 @@
 /area/science/xenobiology)
 "cfs" = (
 /obj/machinery/door/airlock/maintenance{
+	abandoned = 1;
 	name = "Air Supply Maintenance";
 	req_access_txt = "12"
 	},
@@ -47876,6 +47895,7 @@
 /area/science/misc_lab)
 "cfv" = (
 /obj/machinery/door/airlock/maintenance{
+	abandoned = 1;
 	name = "Firefighting equipment";
 	req_access_txt = "12"
 	},
@@ -50081,6 +50101,7 @@
 /area/maintenance/aft)
 "ckm" = (
 /obj/machinery/door/airlock/maintenance{
+	abandoned = 1;
 	name = "Biohazard Disposals";
 	req_access_txt = "12"
 	},
@@ -52755,6 +52776,7 @@
 /area/maintenance/disposal/incinerator)
 "cpR" = (
 /obj/machinery/door/airlock{
+	abandoned = 1;
 	name = "Observatory Access"
 	},
 /turf/open/floor/plating,
@@ -56618,6 +56640,7 @@
 /area/maintenance/solars/port/aft)
 "cyL" = (
 /obj/machinery/door/airlock/maintenance{
+	abandoned = 1;
 	req_access_txt = "12"
 	},
 /obj/structure/cable{
@@ -62607,6 +62630,7 @@
 /area/maintenance/starboard)
 "cNV" = (
 /obj/machinery/door/airlock/maintenance{
+	abandoned = 1;
 	req_access_txt = "0";
 	req_one_access_txt = "8;12"
 	},
@@ -63930,6 +63954,34 @@
 	dir = 4
 	},
 /area/construction/mining/aux_base)
+"cTF" = (
+/obj/machinery/door/airlock/maintenance{
+	abandoned = 1;
+	req_access_txt = "12"
+	},
+/turf/open/floor/plating,
+/area/maintenance/port/aft)
+"cTG" = (
+/obj/machinery/door/airlock/maintenance{
+	abandoned = 1;
+	req_access_txt = "12"
+	},
+/turf/open/floor/plating,
+/area/maintenance/port/aft)
+"cTH" = (
+/obj/machinery/door/airlock/maintenance{
+	abandoned = 1;
+	req_access_txt = "12"
+	},
+/turf/open/floor/plating,
+/area/maintenance/port/aft)
+"cTI" = (
+/obj/machinery/door/airlock/maintenance{
+	abandoned = 1;
+	req_access_txt = "12"
+	},
+/turf/open/floor/plating,
+/area/maintenance/starboard/aft)
 
 (1,1,1) = {"
 aaa
@@ -83888,7 +83940,7 @@ bHE
 bYu
 bZk
 bCq
-bTz
+cTG
 bCq
 bCq
 bCq
@@ -85184,7 +85236,7 @@ bCq
 bCq
 bCq
 bCq
-bTz
+cTH
 bCq
 bLv
 bLv
@@ -86193,7 +86245,7 @@ bLv
 bPZ
 bHE
 bHE
-bTz
+cTF
 bHE
 bLv
 aoV
@@ -109860,7 +109912,7 @@ cmq
 ciI
 cnJ
 cri
-bYr
+cTI
 cmn
 cBT
 cBU

--- a/_maps/map_files/Deltastation/DeltaStation2.dmm
+++ b/_maps/map_files/Deltastation/DeltaStation2.dmm
@@ -2598,8 +2598,7 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/machinery/door/airlock/maintenance_hatch{
-	abandoned = 1;
+/obj/machinery/door/airlock/maintenance_hatch/abandoned{
 	name = "Maintenance Hatch";
 	req_access_txt = "12"
 	},
@@ -3389,8 +3388,7 @@
 /turf/closed/wall,
 /area/security/vacantoffice)
 "ahx" = (
-/obj/machinery/door/airlock{
-	abandoned = 1;
+/obj/machinery/door/airlock/abandoned{
 	name = "Auxiliary Office";
 	req_access_txt = "32"
 	},
@@ -4919,8 +4917,7 @@
 /turf/open/floor/wood,
 /area/security/vacantoffice)
 "alk" = (
-/obj/machinery/door/airlock/maintenance_hatch{
-	abandoned = 1;
+/obj/machinery/door/airlock/maintenance_hatch/abandoned{
 	name = "Office Maintenance";
 	req_access_txt = "32"
 	},
@@ -7666,8 +7663,7 @@
 /area/maintenance/starboard/fore)
 "aqK" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/door/airlock/maintenance_hatch{
-	abandoned = 1;
+/obj/machinery/door/airlock/maintenance_hatch/abandoned{
 	name = "Maintenance Hatch";
 	req_access_txt = "12"
 	},
@@ -8012,8 +8008,7 @@
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
 "arq" = (
-/obj/machinery/door/airlock/maintenance_hatch{
-	abandoned = 1;
+/obj/machinery/door/airlock/maintenance_hatch/abandoned{
 	name = "Maintenance Hatch";
 	req_access_txt = "12"
 	},
@@ -8028,8 +8023,7 @@
 /turf/open/floor/plasteel,
 /area/maintenance/port/fore)
 "arr" = (
-/obj/machinery/door/airlock/maintenance_hatch{
-	abandoned = 1;
+/obj/machinery/door/airlock/maintenance_hatch/abandoned{
 	name = "Maintenance Hatch";
 	req_access_txt = "12"
 	},
@@ -9194,8 +9188,7 @@
 /turf/open/floor/wood,
 /area/maintenance/port/fore)
 "atE" = (
-/obj/machinery/door/airlock/maintenance_hatch{
-	abandoned = 1;
+/obj/machinery/door/airlock/maintenance_hatch/abandoned{
 	name = "Maintenance Hatch";
 	req_access_txt = "12"
 	},
@@ -57982,8 +57975,7 @@
 /turf/open/floor/plasteel,
 /area/maintenance/port)
 "chF" = (
-/obj/machinery/door/airlock/maintenance_hatch{
-	abandoned = 1;
+/obj/machinery/door/airlock/maintenance_hatch/abandoned{
 	name = "Maintenance Hatch";
 	req_access_txt = "12"
 	},
@@ -61499,8 +61491,7 @@
 	icon_state = "2-8"
 	},
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/door/airlock/glass_security{
-	abandoned = 1;
+/obj/machinery/door/airlock/glass_security/abandoned{
 	name = "Storage Closet";
 	req_access_txt = "63"
 	},
@@ -67183,8 +67174,7 @@
 /turf/open/floor/plasteel,
 /area/maintenance/port)
 "czB" = (
-/obj/machinery/door/airlock/maintenance_hatch{
-	abandoned = 1;
+/obj/machinery/door/airlock/maintenance_hatch/abandoned{
 	name = "Maintenance Hatch";
 	req_access_txt = "12"
 	},
@@ -70794,8 +70784,7 @@
 "cFS" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/door/airlock/maintenance_hatch{
-	abandoned = 1;
+/obj/machinery/door/airlock/maintenance_hatch/abandoned{
 	name = "Maintenance Hatch";
 	req_access_txt = "12"
 	},
@@ -72970,8 +72959,7 @@
 /area/maintenance/starboard/aft)
 "cKH" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/door/airlock/maintenance_hatch{
-	abandoned = 1;
+/obj/machinery/door/airlock/maintenance_hatch/abandoned{
 	name = "Maintenance Hatch";
 	req_access_txt = "12"
 	},
@@ -80844,8 +80832,7 @@
 /area/maintenance/starboard/aft)
 "daD" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/door/airlock/maintenance_hatch{
-	abandoned = 1;
+/obj/machinery/door/airlock/maintenance_hatch/abandoned{
 	name = "Maintenance Hatch";
 	req_access_txt = "12"
 	},
@@ -80910,8 +80897,7 @@
 /area/medical/abandoned)
 "daJ" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/door/airlock/maintenance_hatch{
-	abandoned = 1;
+/obj/machinery/door/airlock/maintenance_hatch/abandoned{
 	name = "Maintenance Hatch";
 	req_access_txt = "12"
 	},
@@ -83167,8 +83153,7 @@
 /area/maintenance/starboard/aft)
 "dfA" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/door/airlock/maintenance_hatch{
-	abandoned = 1;
+/obj/machinery/door/airlock/maintenance_hatch/abandoned{
 	name = "Maintenance Hatch";
 	req_access_txt = "12"
 	},
@@ -87507,8 +87492,7 @@
 /area/maintenance/starboard/aft)
 "doy" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/door/airlock/maintenance_hatch{
-	abandoned = 1;
+/obj/machinery/door/airlock/maintenance_hatch/abandoned{
 	name = "Maintenance Hatch";
 	req_access_txt = "12"
 	},
@@ -87563,8 +87547,7 @@
 /area/hallway/secondary/construction)
 "doE" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/door/airlock/maintenance_hatch{
-	abandoned = 1;
+/obj/machinery/door/airlock/maintenance_hatch/abandoned{
 	name = "Maintenance Hatch";
 	req_access_txt = "12"
 	},
@@ -90697,8 +90680,7 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
 "duA" = (
-/obj/machinery/door/airlock/maintenance_hatch{
-	abandoned = 1;
+/obj/machinery/door/airlock/maintenance_hatch/abandoned{
 	name = "Maintenance Hatch";
 	req_access_txt = "12"
 	},
@@ -92690,8 +92672,7 @@
 /turf/closed/wall,
 /area/security/detectives_office/private_investigators_office)
 "dyt" = (
-/obj/machinery/door/airlock/maintenance_hatch{
-	abandoned = 1;
+/obj/machinery/door/airlock/maintenance_hatch/abandoned{
 	name = "Maintenance Hatch";
 	req_access_txt = "12"
 	},
@@ -95239,8 +95220,7 @@
 /area/maintenance/starboard/aft)
 "dDr" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/door/airlock/maintenance_hatch{
-	abandoned = 1;
+/obj/machinery/door/airlock/maintenance_hatch/abandoned{
 	name = "Maintenance Hatch";
 	req_access_txt = "12"
 	},
@@ -112369,8 +112349,7 @@
 /turf/open/floor/plasteel,
 /area/engine/gravity_generator)
 "eqf" = (
-/obj/machinery/door/airlock/maintenance_hatch{
-	abandoned = 1;
+/obj/machinery/door/airlock/maintenance_hatch/abandoned{
 	name = "Maintenance Hatch";
 	req_access_txt = "12"
 	},

--- a/_maps/map_files/Deltastation/DeltaStation2.dmm
+++ b/_maps/map_files/Deltastation/DeltaStation2.dmm
@@ -2599,6 +2599,7 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/door/airlock/maintenance_hatch{
+	abandoned = 1;
 	name = "Maintenance Hatch";
 	req_access_txt = "12"
 	},
@@ -3389,6 +3390,7 @@
 /area/security/vacantoffice)
 "ahx" = (
 /obj/machinery/door/airlock{
+	abandoned = 1;
 	name = "Auxiliary Office";
 	req_access_txt = "32"
 	},
@@ -4918,6 +4920,7 @@
 /area/security/vacantoffice)
 "alk" = (
 /obj/machinery/door/airlock/maintenance_hatch{
+	abandoned = 1;
 	name = "Office Maintenance";
 	req_access_txt = "32"
 	},
@@ -7664,6 +7667,7 @@
 "aqK" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/door/airlock/maintenance_hatch{
+	abandoned = 1;
 	name = "Maintenance Hatch";
 	req_access_txt = "12"
 	},
@@ -8009,6 +8013,7 @@
 /area/maintenance/port/fore)
 "arq" = (
 /obj/machinery/door/airlock/maintenance_hatch{
+	abandoned = 1;
 	name = "Maintenance Hatch";
 	req_access_txt = "12"
 	},
@@ -8024,6 +8029,7 @@
 /area/maintenance/port/fore)
 "arr" = (
 /obj/machinery/door/airlock/maintenance_hatch{
+	abandoned = 1;
 	name = "Maintenance Hatch";
 	req_access_txt = "12"
 	},
@@ -9189,6 +9195,7 @@
 /area/maintenance/port/fore)
 "atE" = (
 /obj/machinery/door/airlock/maintenance_hatch{
+	abandoned = 1;
 	name = "Maintenance Hatch";
 	req_access_txt = "12"
 	},
@@ -57976,6 +57983,7 @@
 /area/maintenance/port)
 "chF" = (
 /obj/machinery/door/airlock/maintenance_hatch{
+	abandoned = 1;
 	name = "Maintenance Hatch";
 	req_access_txt = "12"
 	},
@@ -61492,6 +61500,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/door/airlock/glass_security{
+	abandoned = 1;
 	name = "Storage Closet";
 	req_access_txt = "63"
 	},
@@ -67175,6 +67184,7 @@
 /area/maintenance/port)
 "czB" = (
 /obj/machinery/door/airlock/maintenance_hatch{
+	abandoned = 1;
 	name = "Maintenance Hatch";
 	req_access_txt = "12"
 	},
@@ -70785,6 +70795,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/door/airlock/maintenance_hatch{
+	abandoned = 1;
 	name = "Maintenance Hatch";
 	req_access_txt = "12"
 	},
@@ -72960,6 +72971,7 @@
 "cKH" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/door/airlock/maintenance_hatch{
+	abandoned = 1;
 	name = "Maintenance Hatch";
 	req_access_txt = "12"
 	},
@@ -80833,6 +80845,7 @@
 "daD" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/door/airlock/maintenance_hatch{
+	abandoned = 1;
 	name = "Maintenance Hatch";
 	req_access_txt = "12"
 	},
@@ -80898,6 +80911,7 @@
 "daJ" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/door/airlock/maintenance_hatch{
+	abandoned = 1;
 	name = "Maintenance Hatch";
 	req_access_txt = "12"
 	},
@@ -83154,6 +83168,7 @@
 "dfA" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/door/airlock/maintenance_hatch{
+	abandoned = 1;
 	name = "Maintenance Hatch";
 	req_access_txt = "12"
 	},
@@ -87493,6 +87508,7 @@
 "doy" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/door/airlock/maintenance_hatch{
+	abandoned = 1;
 	name = "Maintenance Hatch";
 	req_access_txt = "12"
 	},
@@ -87548,6 +87564,7 @@
 "doE" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/door/airlock/maintenance_hatch{
+	abandoned = 1;
 	name = "Maintenance Hatch";
 	req_access_txt = "12"
 	},
@@ -90681,6 +90698,7 @@
 /area/maintenance/starboard/aft)
 "duA" = (
 /obj/machinery/door/airlock/maintenance_hatch{
+	abandoned = 1;
 	name = "Maintenance Hatch";
 	req_access_txt = "12"
 	},
@@ -92673,6 +92691,7 @@
 /area/security/detectives_office/private_investigators_office)
 "dyt" = (
 /obj/machinery/door/airlock/maintenance_hatch{
+	abandoned = 1;
 	name = "Maintenance Hatch";
 	req_access_txt = "12"
 	},
@@ -95221,6 +95240,7 @@
 "dDr" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/door/airlock/maintenance_hatch{
+	abandoned = 1;
 	name = "Maintenance Hatch";
 	req_access_txt = "12"
 	},
@@ -112350,6 +112370,7 @@
 /area/engine/gravity_generator)
 "eqf" = (
 /obj/machinery/door/airlock/maintenance_hatch{
+	abandoned = 1;
 	name = "Maintenance Hatch";
 	req_access_txt = "12"
 	},

--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -5999,8 +5999,7 @@
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
 "alF" = (
-/obj/machinery/door/airlock/maintenance{
-	abandoned = 1;
+/obj/machinery/door/airlock/maintenance/abandoned{
 	name = "Secure Storage Room";
 	req_access_txt = "65"
 	},
@@ -7030,8 +7029,7 @@
 /area/maintenance/fore)
 "anE" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/machinery/door/airlock/maintenance{
-	abandoned = 1;
+/obj/machinery/door/airlock/maintenance/abandoned{
 	name = "Storage Room";
 	req_access_txt = "12"
 	},
@@ -8014,8 +8012,7 @@
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
 "apv" = (
-/obj/machinery/door/airlock/maintenance{
-	abandoned = 1;
+/obj/machinery/door/airlock/maintenance/abandoned{
 	name = "Storage Room";
 	req_access_txt = "12"
 	},
@@ -9401,8 +9398,7 @@
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
 "asl" = (
-/obj/machinery/door/airlock/maintenance{
-	abandoned = 1;
+/obj/machinery/door/airlock/maintenance/abandoned{
 	name = "Storage Room";
 	req_access_txt = "12"
 	},
@@ -9846,8 +9842,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
-/obj/machinery/door/airlock/maintenance{
-	abandoned = 1;
+/obj/machinery/door/airlock/maintenance/abandoned{
 	name = "Storage Room";
 	req_access_txt = "12"
 	},
@@ -10623,8 +10618,7 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
 "aut" = (
-/obj/machinery/door/airlock/maintenance{
-	abandoned = 1;
+/obj/machinery/door/airlock/maintenance/abandoned{
 	name = "Storage Room";
 	req_access_txt = "12"
 	},
@@ -11950,8 +11944,7 @@
 /turf/open/floor/wood,
 /area/crew_quarters/dorms)
 "awI" = (
-/obj/machinery/door/airlock/maintenance{
-	abandoned = 1;
+/obj/machinery/door/airlock/maintenance/abandoned{
 	name = "Storage Room";
 	req_access_txt = "12"
 	},
@@ -26787,8 +26780,7 @@
 /area/storage/tools)
 "aZv" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/machinery/door/airlock/maintenance{
-	abandoned = 1;
+/obj/machinery/door/airlock/maintenance/abandoned{
 	name = "Storage Room";
 	req_access_txt = "12"
 	},
@@ -40980,8 +40972,7 @@
 /area/security/vacantoffice)
 "bzz" = (
 /obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/centcom{
-	abandoned = 1;
+/obj/machinery/door/airlock/centcom/abandoned{
 	name = "Vacant Office";
 	opacity = 1;
 	req_access_txt = "32"
@@ -49136,8 +49127,7 @@
 /turf/open/floor/plating,
 /area/maintenance/port)
 "bPI" = (
-/obj/machinery/door/airlock/maintenance{
-	abandoned = 1;
+/obj/machinery/door/airlock/maintenance/abandoned{
 	name = "Vacant Office Maintenance";
 	req_access_txt = "32";
 	req_one_access_txt = "0"
@@ -49796,8 +49786,7 @@
 /turf/open/floor/plating,
 /area/maintenance/port)
 "bRf" = (
-/obj/machinery/door/airlock/maintenance{
-	abandoned = 1;
+/obj/machinery/door/airlock/maintenance/abandoned{
 	name = "Storage Room";
 	req_access_txt = "12"
 	},
@@ -51080,8 +51069,7 @@
 /area/engine/engineering)
 "bTr" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/machinery/door/airlock/maintenance{
-	abandoned = 1;
+/obj/machinery/door/airlock/maintenance/abandoned{
 	name = "Storage Room";
 	req_access_txt = "12"
 	},
@@ -54280,7 +54268,6 @@
 /area/maintenance/disposal/incinerator)
 "bZD" = (
 /obj/machinery/door/airlock/maintenance{
-	abandoned = 0;
 	name = "Incinerator Access";
 	req_access_txt = "12"
 	},
@@ -54375,8 +54362,7 @@
 /turf/open/floor/plating/airless,
 /area/maintenance/solars/port/aft)
 "bZO" = (
-/obj/machinery/door/airlock/maintenance{
-	abandoned = 1;
+/obj/machinery/door/airlock/maintenance/abandoned{
 	name = "Storage Room";
 	req_access_txt = "12"
 	},
@@ -56204,8 +56190,7 @@
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
 "cde" = (
-/obj/machinery/door/airlock/maintenance{
-	abandoned = 1;
+/obj/machinery/door/airlock/maintenance/abandoned{
 	name = "Storage Room";
 	req_access_txt = "12"
 	},
@@ -57365,8 +57350,7 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard)
 "cfl" = (
-/obj/machinery/door/airlock/maintenance{
-	abandoned = 1;
+/obj/machinery/door/airlock/maintenance/abandoned{
 	name = "Storage Room";
 	req_access_txt = "12"
 	},
@@ -60678,8 +60662,7 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
 "clX" = (
-/obj/machinery/door/airlock/maintenance{
-	abandoned = 1;
+/obj/machinery/door/airlock/maintenance/abandoned{
 	locked = 0;
 	name = "Storage Room";
 	req_access_txt = "0";
@@ -65603,8 +65586,7 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
 "cuZ" = (
-/obj/machinery/door/airlock/maintenance{
-	abandoned = 1;
+/obj/machinery/door/airlock/maintenance/abandoned{
 	name = "Storage Room";
 	req_access_txt = "0";
 	req_one_access_txt = "12;47"
@@ -66686,8 +66668,7 @@
 /turf/open/floor/plasteel,
 /area/science/storage)
 "cwZ" = (
-/obj/machinery/door/airlock/maintenance{
-	abandoned = 1;
+/obj/machinery/door/airlock/maintenance/abandoned{
 	name = "airlock access";
 	req_access_txt = "0";
 	req_one_access_txt = "12;47"
@@ -71969,8 +71950,7 @@
 	},
 /area/medical/medbay/aft)
 "cGP" = (
-/obj/machinery/door/airlock{
-	abandoned = 1;
+/obj/machinery/door/airlock/abandoned{
 	name = "Medical Surplus Storeroom";
 	req_access_txt = "5"
 	},
@@ -73454,8 +73434,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
-/obj/machinery/door/airlock/maintenance{
-	abandoned = 1;
+/obj/machinery/door/airlock/maintenance/abandoned{
 	name = "Medical Surplus Storeroom";
 	req_access_txt = "12";
 	req_one_access_txt = "0"
@@ -74129,8 +74108,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
-/obj/machinery/door/airlock/maintenance{
-	abandoned = 1;
+/obj/machinery/door/airlock/maintenance/abandoned{
 	locked = 0;
 	name = "Storage Room";
 	req_access_txt = "0";
@@ -90826,8 +90804,7 @@
 	},
 /area/construction/mining/aux_base)
 "dDL" = (
-/obj/machinery/door/airlock/maintenance{
-	abandoned = 1;
+/obj/machinery/door/airlock/maintenance/abandoned{
 	name = "Storage Room";
 	req_access_txt = "12"
 	},
@@ -90835,8 +90812,7 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
 "dDM" = (
-/obj/machinery/door/airlock/maintenance{
-	abandoned = 1;
+/obj/machinery/door/airlock/maintenance/abandoned{
 	name = "Storage Room";
 	req_access_txt = "12"
 	},

--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -6000,6 +6000,7 @@
 /area/maintenance/port/fore)
 "alF" = (
 /obj/machinery/door/airlock/maintenance{
+	abandoned = 1;
 	name = "Secure Storage Room";
 	req_access_txt = "65"
 	},
@@ -7030,6 +7031,7 @@
 "anE" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/machinery/door/airlock/maintenance{
+	abandoned = 1;
 	name = "Storage Room";
 	req_access_txt = "12"
 	},
@@ -8013,6 +8015,7 @@
 /area/maintenance/port/fore)
 "apv" = (
 /obj/machinery/door/airlock/maintenance{
+	abandoned = 1;
 	name = "Storage Room";
 	req_access_txt = "12"
 	},
@@ -9399,6 +9402,7 @@
 /area/maintenance/port/fore)
 "asl" = (
 /obj/machinery/door/airlock/maintenance{
+	abandoned = 1;
 	name = "Storage Room";
 	req_access_txt = "12"
 	},
@@ -9843,6 +9847,7 @@
 	dir = 4
 	},
 /obj/machinery/door/airlock/maintenance{
+	abandoned = 1;
 	name = "Storage Room";
 	req_access_txt = "12"
 	},
@@ -10619,6 +10624,7 @@
 /area/maintenance/starboard/fore)
 "aut" = (
 /obj/machinery/door/airlock/maintenance{
+	abandoned = 1;
 	name = "Storage Room";
 	req_access_txt = "12"
 	},
@@ -11945,6 +11951,7 @@
 /area/crew_quarters/dorms)
 "awI" = (
 /obj/machinery/door/airlock/maintenance{
+	abandoned = 1;
 	name = "Storage Room";
 	req_access_txt = "12"
 	},
@@ -26781,6 +26788,7 @@
 "aZv" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/machinery/door/airlock/maintenance{
+	abandoned = 1;
 	name = "Storage Room";
 	req_access_txt = "12"
 	},
@@ -40973,6 +40981,7 @@
 "bzz" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/centcom{
+	abandoned = 1;
 	name = "Vacant Office";
 	opacity = 1;
 	req_access_txt = "32"
@@ -49128,6 +49137,7 @@
 /area/maintenance/port)
 "bPI" = (
 /obj/machinery/door/airlock/maintenance{
+	abandoned = 1;
 	name = "Vacant Office Maintenance";
 	req_access_txt = "32";
 	req_one_access_txt = "0"
@@ -49787,6 +49797,7 @@
 /area/maintenance/port)
 "bRf" = (
 /obj/machinery/door/airlock/maintenance{
+	abandoned = 1;
 	name = "Storage Room";
 	req_access_txt = "12"
 	},
@@ -51070,6 +51081,7 @@
 "bTr" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/machinery/door/airlock/maintenance{
+	abandoned = 1;
 	name = "Storage Room";
 	req_access_txt = "12"
 	},
@@ -54268,6 +54280,7 @@
 /area/maintenance/disposal/incinerator)
 "bZD" = (
 /obj/machinery/door/airlock/maintenance{
+	abandoned = 0;
 	name = "Incinerator Access";
 	req_access_txt = "12"
 	},
@@ -54363,6 +54376,7 @@
 /area/maintenance/solars/port/aft)
 "bZO" = (
 /obj/machinery/door/airlock/maintenance{
+	abandoned = 1;
 	name = "Storage Room";
 	req_access_txt = "12"
 	},
@@ -56191,6 +56205,7 @@
 /area/maintenance/port/aft)
 "cde" = (
 /obj/machinery/door/airlock/maintenance{
+	abandoned = 1;
 	name = "Storage Room";
 	req_access_txt = "12"
 	},
@@ -57351,6 +57366,7 @@
 /area/maintenance/starboard)
 "cfl" = (
 /obj/machinery/door/airlock/maintenance{
+	abandoned = 1;
 	name = "Storage Room";
 	req_access_txt = "12"
 	},
@@ -60663,6 +60679,7 @@
 /area/maintenance/starboard/aft)
 "clX" = (
 /obj/machinery/door/airlock/maintenance{
+	abandoned = 1;
 	locked = 0;
 	name = "Storage Room";
 	req_access_txt = "0";
@@ -65587,6 +65604,7 @@
 /area/maintenance/starboard/aft)
 "cuZ" = (
 /obj/machinery/door/airlock/maintenance{
+	abandoned = 1;
 	name = "Storage Room";
 	req_access_txt = "0";
 	req_one_access_txt = "12;47"
@@ -66669,6 +66687,7 @@
 /area/science/storage)
 "cwZ" = (
 /obj/machinery/door/airlock/maintenance{
+	abandoned = 1;
 	name = "airlock access";
 	req_access_txt = "0";
 	req_one_access_txt = "12;47"
@@ -71951,6 +71970,7 @@
 /area/medical/medbay/aft)
 "cGP" = (
 /obj/machinery/door/airlock{
+	abandoned = 1;
 	name = "Medical Surplus Storeroom";
 	req_access_txt = "5"
 	},
@@ -73435,6 +73455,7 @@
 	dir = 4
 	},
 /obj/machinery/door/airlock/maintenance{
+	abandoned = 1;
 	name = "Medical Surplus Storeroom";
 	req_access_txt = "12";
 	req_one_access_txt = "0"
@@ -74109,6 +74130,7 @@
 	dir = 4
 	},
 /obj/machinery/door/airlock/maintenance{
+	abandoned = 1;
 	locked = 0;
 	name = "Storage Room";
 	req_access_txt = "0";
@@ -90803,6 +90825,24 @@
 	dir = 1
 	},
 /area/construction/mining/aux_base)
+"dDL" = (
+/obj/machinery/door/airlock/maintenance{
+	abandoned = 1;
+	name = "Storage Room";
+	req_access_txt = "12"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/turf/open/floor/plating,
+/area/maintenance/starboard/fore)
+"dDM" = (
+/obj/machinery/door/airlock/maintenance{
+	abandoned = 1;
+	name = "Storage Room";
+	req_access_txt = "12"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/turf/open/floor/plating,
+/area/maintenance/starboard/fore)
 
 (1,1,1) = {"
 aaa
@@ -100196,7 +100236,7 @@ aVs
 aVs
 aVs
 cVF
-cVW
+cVF
 cWn
 cVF
 cVF
@@ -129958,7 +129998,7 @@ arI
 atd
 bai
 ate
-dpP
+dDM
 axP
 dnS
 axY
@@ -131755,7 +131795,7 @@ ape
 dnS
 arL
 ate
-dpP
+dDL
 avt
 awJ
 axS

--- a/_maps/map_files/PubbyStation/PubbyStation.dmm
+++ b/_maps/map_files/PubbyStation/PubbyStation.dmm
@@ -4967,8 +4967,7 @@
 /turf/open/floor/plating,
 /area/maintenance/department/crew_quarters/dorms)
 "ali" = (
-/obj/machinery/door/airlock{
-	abandoned = 1;
+/obj/machinery/door/airlock/abandoned{
 	id_tag = "mainthideout";
 	name = "Hideout"
 	},
@@ -5669,8 +5668,7 @@
 	},
 /area/maintenance/department/crew_quarters/dorms)
 "amH" = (
-/obj/machinery/door/airlock/atmos{
-	abandoned = 1;
+/obj/machinery/door/airlock/atmos/abandoned{
 	name = "Atmospherics Maintenance";
 	req_access_txt = "12;24"
 	},
@@ -5934,8 +5932,7 @@
 /turf/open/space/basic,
 /area/space)
 "anm" = (
-/obj/machinery/door/airlock/maintenance{
-	abandoned = 1;
+/obj/machinery/door/airlock/maintenance/abandoned{
 	name = "Pete's Speakeasy";
 	req_access_txt = "12"
 	},
@@ -15124,8 +15121,7 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "aHn" = (
-/obj/machinery/door/airlock{
-	abandoned = 1;
+/obj/machinery/door/airlock/abandoned{
 	name = "Starboard Emergency Storage";
 	req_access_txt = "0"
 	},
@@ -38014,8 +38010,7 @@
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
 "bEm" = (
-/obj/machinery/door/airlock/atmos{
-	abandoned = 1;
+/obj/machinery/door/airlock/atmos/abandoned{
 	name = "Atmospherics Maintenance";
 	req_access_txt = "12;24"
 	},
@@ -44665,8 +44660,7 @@
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
 "bTf" = (
-/obj/machinery/door/airlock/atmos{
-	abandoned = 1;
+/obj/machinery/door/airlock/atmos/abandoned{
 	name = "Atmospherics Maintenance";
 	req_access_txt = "12;24"
 	},

--- a/_maps/map_files/PubbyStation/PubbyStation.dmm
+++ b/_maps/map_files/PubbyStation/PubbyStation.dmm
@@ -4968,6 +4968,7 @@
 /area/maintenance/department/crew_quarters/dorms)
 "ali" = (
 /obj/machinery/door/airlock{
+	abandoned = 1;
 	id_tag = "mainthideout";
 	name = "Hideout"
 	},
@@ -5669,6 +5670,7 @@
 /area/maintenance/department/crew_quarters/dorms)
 "amH" = (
 /obj/machinery/door/airlock/atmos{
+	abandoned = 1;
 	name = "Atmospherics Maintenance";
 	req_access_txt = "12;24"
 	},
@@ -5933,6 +5935,7 @@
 /area/space)
 "anm" = (
 /obj/machinery/door/airlock/maintenance{
+	abandoned = 1;
 	name = "Pete's Speakeasy";
 	req_access_txt = "12"
 	},
@@ -15122,6 +15125,7 @@
 /area/hallway/primary/central)
 "aHn" = (
 /obj/machinery/door/airlock{
+	abandoned = 1;
 	name = "Starboard Emergency Storage";
 	req_access_txt = "0"
 	},
@@ -38011,6 +38015,7 @@
 /area/maintenance/department/engine)
 "bEm" = (
 /obj/machinery/door/airlock/atmos{
+	abandoned = 1;
 	name = "Atmospherics Maintenance";
 	req_access_txt = "12;24"
 	},
@@ -44661,6 +44666,7 @@
 /area/maintenance/department/engine)
 "bTf" = (
 /obj/machinery/door/airlock/atmos{
+	abandoned = 1;
 	name = "Atmospherics Maintenance";
 	req_access_txt = "12;24"
 	},
@@ -72392,13 +72398,13 @@ aaa
 aaa
 aaa
 aFS
-cBO
-cBP
+cBN
+cBN
 aKs
 aFS
 aFS
-cBT
-cBU
+cBN
+cBN
 aFS
 aKs
 aFS
@@ -72652,7 +72658,7 @@ aFS
 aIs
 aJx
 aJx
-cBR
+cBN
 aMI
 aNZ
 aNZ
@@ -73166,7 +73172,7 @@ aFS
 aIu
 aJy
 aKt
-cBS
+cBN
 aIx
 aOa
 aOa
@@ -73936,14 +73942,14 @@ aGQ
 aHw
 aIw
 aIw
-cBQ
+cBN
 aIx
 aIx
 aOc
 aPj
 aOc
 aIx
-cBV
+cBN
 aMI
 aMI
 aMI

--- a/code/game/machinery/doors/airlock.dm
+++ b/code/game/machinery/doors/airlock.dm
@@ -121,7 +121,7 @@
 	if(abandoned)
 		var/outcome = rand(1,100)
 		switch(outcome)
-			if(1 to 6)
+			if(1 to 9)
 				var/turf/here = get_turf(src)
 				for(var/turf/closed/T in range(2, src))
 					here.changeTurf(T.type)
@@ -130,15 +130,15 @@
 				here.changeTurf(/turf/closed/wall)
 				qdel(src)
 				return INITIALIZE_HINT_QDEL
-			if(7 to 9)
+			if(9 to 11)
 				lights = FALSE
 				bolt()
-			if(10 to 13)
+			if(12 to 15)
 				bolt()
-			if(14 to 20)
+			if(16 to 23)
 				welded = TRUE
 				update_icon()
-			if(21 to 25)
+			if(24 to 30)
 				panel_open = TRUE
 				update_icon()
 	prepare_huds()

--- a/code/game/machinery/doors/airlock.dm
+++ b/code/game/machinery/doors/airlock.dm
@@ -73,6 +73,7 @@
 	var/obj/item/device/doorCharge/charge = null //If applied, causes an explosion upon opening the door
 	var/obj/item/note //Any papers pinned to the airlock
 	var/detonated = 0
+	var/abandoned = FALSE
 	var/doorOpen = 'sound/machines/airlock.ogg'
 	var/doorClose = 'sound/machines/airlockclose.ogg'
 	var/doorDeni = 'sound/machines/deniedbeep.ogg' // i'm thinkin' Deni's
@@ -117,6 +118,25 @@
 		max_integrity = normal_integrity
 	if(damage_deflection == AIRLOCK_DAMAGE_DEFLECTION_N && security_level > AIRLOCK_SECURITY_METAL)
 		damage_deflection = AIRLOCK_DAMAGE_DEFLECTION_R
+	if(abandoned)
+		var/outcome = rand(100)
+		switch(outcome)
+			if(1 to 5)
+				for(var/turf/T in range(2, src)
+					new T.type(loc)
+					qdel(src)
+			if(6 to 10)
+				lights = FALSE
+				bolt()
+			if(11 to 15)
+				bolt()
+			if(16 to 20)
+				welded = TRUE
+				set_airlock_overlays(AIRLOCK_CLOSED)
+				update_icon()
+			if(21 to 25)
+				panel_open = TRUE
+				update_icon()		
 	prepare_huds()
 	var/datum/atom_hud/data/diagnostic/diag_hud = GLOB.huds[DATA_HUD_DIAGNOSTIC]
 	diag_hud.add_to_hud(src)

--- a/code/game/machinery/doors/airlock.dm
+++ b/code/game/machinery/doors/airlock.dm
@@ -124,10 +124,10 @@
 			if(1 to 9)
 				var/turf/here = get_turf(src)
 				for(var/turf/closed/T in range(2, src))
-					here.changeTurf(T.type)
+					here.ChangeTurf(T.type)
 					qdel(src)
 					return INITIALIZE_HINT_QDEL
-				here.changeTurf(/turf/closed/wall)
+				here.ChangeTurf(/turf/closed/wall)
 				qdel(src)
 				return INITIALIZE_HINT_QDEL
 			if(9 to 11)

--- a/code/game/machinery/doors/airlock.dm
+++ b/code/game/machinery/doors/airlock.dm
@@ -119,24 +119,27 @@
 	if(damage_deflection == AIRLOCK_DAMAGE_DEFLECTION_N && security_level > AIRLOCK_SECURITY_METAL)
 		damage_deflection = AIRLOCK_DAMAGE_DEFLECTION_R
 	if(abandoned)
-		var/outcome = rand(100)
+		var/outcome = rand(0,100)
 		switch(outcome)
-			if(1 to 5)
-				for(var/turf/T in range(2, src)
+			if(1 to 6)
+				for(var/turf/closed/T in range(2, src))
 					new T.type(loc)
 					qdel(src)
-			if(6 to 10)
+					return
+				new /turf/closed/wall(loc)
+				qdel(src)
+				return
+			if(7 to 9)
 				lights = FALSE
 				bolt()
-			if(11 to 15)
+			if(10 to 13)
 				bolt()
-			if(16 to 20)
+			if(14 to 20)
 				welded = TRUE
-				set_airlock_overlays(AIRLOCK_CLOSED)
 				update_icon()
 			if(21 to 25)
 				panel_open = TRUE
-				update_icon()		
+				update_icon()
 	prepare_huds()
 	var/datum/atom_hud/data/diagnostic/diag_hud = GLOB.huds[DATA_HUD_DIAGNOSTIC]
 	diag_hud.add_to_hud(src)

--- a/code/game/machinery/doors/airlock.dm
+++ b/code/game/machinery/doors/airlock.dm
@@ -122,13 +122,14 @@
 		var/outcome = rand(1,100)
 		switch(outcome)
 			if(1 to 6)
+				var/turf/here = get_turf(src)
 				for(var/turf/closed/T in range(2, src))
-					new T.type(loc)
+					here.changeTurf(T.type)
 					qdel(src)
-					return
-				new /turf/closed/wall(loc)
+					return INITIALIZE_HINT_QDEL
+				here.changeTurf(/turf/closed/wall)
 				qdel(src)
-				return
+				return INITIALIZE_HINT_QDEL
 			if(7 to 9)
 				lights = FALSE
 				bolt()

--- a/code/game/machinery/doors/airlock.dm
+++ b/code/game/machinery/doors/airlock.dm
@@ -119,7 +119,7 @@
 	if(damage_deflection == AIRLOCK_DAMAGE_DEFLECTION_N && security_level > AIRLOCK_SECURITY_METAL)
 		damage_deflection = AIRLOCK_DAMAGE_DEFLECTION_R
 	if(abandoned)
-		var/outcome = rand(0,100)
+		var/outcome = rand(1,100)
 		switch(outcome)
 			if(1 to 6)
 				for(var/turf/closed/T in range(2, src))

--- a/code/game/machinery/doors/airlock.dm
+++ b/code/game/machinery/doors/airlock.dm
@@ -125,10 +125,8 @@
 				var/turf/here = get_turf(src)
 				for(var/turf/closed/T in range(2, src))
 					here.ChangeTurf(T.type)
-					qdel(src)
 					return INITIALIZE_HINT_QDEL
 				here.ChangeTurf(/turf/closed/wall)
-				qdel(src)
 				return INITIALIZE_HINT_QDEL
 			if(9 to 11)
 				lights = FALSE

--- a/code/game/machinery/doors/airlock.dm
+++ b/code/game/machinery/doors/airlock.dm
@@ -130,15 +130,13 @@
 				return INITIALIZE_HINT_QDEL
 			if(9 to 11)
 				lights = FALSE
-				bolt()
+				locked = TRUE
 			if(12 to 15)
-				bolt()
+				locked = TRUE
 			if(16 to 23)
 				welded = TRUE
-				update_icon()
 			if(24 to 30)
 				panel_open = TRUE
-				update_icon()
 	prepare_huds()
 	var/datum/atom_hud/data/diagnostic/diag_hud = GLOB.huds[DATA_HUD_DIAGNOSTIC]
 	diag_hud.add_to_hud(src)

--- a/code/game/machinery/doors/airlock_types.dm
+++ b/code/game/machinery/doors/airlock_types.dm
@@ -1,6 +1,9 @@
 /*
 	Station Airlocks Regular
 */
+/obj/machinery/door/airlock/abandoned
+	abandoned = TRUE
+
 /obj/machinery/door/airlock/command
 	icon = 'icons/obj/doors/airlocks/station/command.dmi'
 	assemblytype = /obj/structure/door_assembly/door_assembly_com
@@ -14,6 +17,9 @@
 /obj/machinery/door/airlock/engineering
 	icon = 'icons/obj/doors/airlocks/station/engineering.dmi'
 	assemblytype = /obj/structure/door_assembly/door_assembly_eng
+	
+/obj/machinery/door/airlock/engineering/abandoned
+	abandoned = TRUE
 
 /obj/machinery/door/airlock/medical
 	icon = 'icons/obj/doors/airlocks/station/medical.dmi'
@@ -24,6 +30,9 @@
 	icon = 'icons/obj/doors/airlocks/station/maintenance.dmi'
 	assemblytype = /obj/structure/door_assembly/door_assembly_mai
 	normal_integrity = 250
+
+/obj/machinery/door/airlock/maintenance/abandoned
+	abandoned = TRUE
 
 /obj/machinery/door/airlock/maintenance/external
 	name = "external airlock access"
@@ -40,6 +49,9 @@
 	name = "atmospherics airlock"
 	icon = 'icons/obj/doors/airlocks/station/atmos.dmi'
 	assemblytype = /obj/structure/door_assembly/door_assembly_atmo
+
+/obj/machinery/door/airlock/atmos/abandoned
+	abandoned = TRUE
 
 /obj/machinery/door/airlock/research
 	icon = 'icons/obj/doors/airlocks/station/research.dmi'
@@ -82,6 +94,9 @@
 	assemblytype = /obj/structure/door_assembly/door_assembly_sec/glass
 	glass = TRUE
 	normal_integrity = 400
+
+/obj/machinery/door/airlock/glass_security/abandoned
+	abandoned = TRUE
 
 /obj/machinery/door/airlock/glass_medical
 	icon = 'icons/obj/doors/airlocks/station/medical.dmi'
@@ -279,6 +294,9 @@
 	security_level = 6
 	explosion_block = 2
 
+/obj/machinery/door/airlock/centcom/abandoned
+	abandoned = TRUE
+
 //////////////////////////////////
 /*
 	Vault Airlocks
@@ -315,6 +333,9 @@
 	note_overlay_file = 'icons/obj/doors/airlocks/hatch/overlays.dmi'
 	opacity = 1
 	assemblytype = /obj/structure/door_assembly/door_assembly_mhatch
+
+/obj/machinery/door/airlock/maintenance_hatch/abandoned
+	abandoned = TRUE
 
 //////////////////////////////////
 /*

--- a/html/changelogs/AutoChangeLog-pr-30056.yml
+++ b/html/changelogs/AutoChangeLog-pr-30056.yml
@@ -1,4 +1,0 @@
-author: "More Robust Than You"
-delete-after: True
-changes: 
-  - rscdel: "Finally fucking removed gangs"

--- a/html/changelogs/AutoChangeLog-pr-30056.yml
+++ b/html/changelogs/AutoChangeLog-pr-30056.yml
@@ -1,0 +1,4 @@
+author: "More Robust Than You"
+delete-after: True
+changes: 
+  - rscdel: "Finally fucking removed gangs"


### PR DESCRIPTION
:cl: Robustin
add: Due to budget cuts, airlocks that control access to non-functional maint rooms and other abandoned areas now have a chance to spawn welded, bolted, screwdrivered, or flat out replaced by a wall at roundstart.
/:cl:

This PR adds the "abandoned" var to airlocks. Abandoned airlocks have a roughly 20% chance of appearing in a non-functional state. I went ahead and made this var TRUE on select doors on Box/Meta/Delta/Pubby. The criteria was basically:

A) Room doesn't naturally possess a unique or functional purpose
B) The room is in maint or is otherwise designated "surplus/abandoned/vacant"

So I left turbine/disposals untouched along with any doors that simply break maint into segments, most of the other maint rooms were given this var though. 

Overall I really like this idea because currently false walls are pretty much your only hope for doing anything naughty in maint without getting caught. Regular old door hacking or welding actually increases the chance of snooping since the first assistant to stroll by knows someone went out of their way to keep people out. I think this will help make maint a more cryptic/mysterious place where it's not so easy to spot when something is out of place. 
