### PR TITLE
Stops dead monkeys from moving

### DIFF
--- a/code/modules/mob/living/carbon/monkey/death.dm
+++ b/code/modules/mob/living/carbon/monkey/death.dm
@@ -3,3 +3,7 @@
 
 /mob/living/carbon/monkey/dust_animation()
 	new /obj/effect/temp_visual/dust_animation(loc, "dust-m")
+
+/mob/living/carbon/monkey/death(gibbed)
+	walk(src,0) // Stops dead monkeys from fleeing their attacker or climbing out from inside His Grace
+	. = ..()


### PR DESCRIPTION
Fixes #29425

Hopefully. The bug is kind of hard to reproduce reliably. Basically dead monkeys were sometimes capable of continuing to flee their attackers, even after eaten by His Grace. I haven't been able to reproduce the bug after this fix was applied, and Remie says the same patch was used to fix syndie mecha pilots.

[Changelogs]: 
[]:

:cl: Naksu
fix: Prevents dead monkeys from fleeing their attackers or escaping His Grace only to be eaten again
/:cl:

[why]: 
bugfix
