### PR TITLE
Enables Dead OOC at round-end

### DIFF
--- a/code/controllers/subsystem/ticker.dm
+++ b/code/controllers/subsystem/ticker.dm
@@ -135,6 +135,7 @@ SUBSYSTEM_DEF(ticker)
 			if(!mode.explosion_in_progress && mode.check_finished(force_ending) || force_ending)
 				current_state = GAME_STATE_FINISHED
 				toggle_ooc(1) // Turn it on
+				GLOB.dooc_allowed = TRUE // Previous line already announces OOC availability, also DOOC has no convenience procs anyways
 				declare_completion(force_ending)
 				Master.SetRunLevel(RUNLEVEL_POSTGAME)
 

--- a/code/controllers/subsystem/ticker.dm
+++ b/code/controllers/subsystem/ticker.dm
@@ -134,8 +134,8 @@ SUBSYSTEM_DEF(ticker)
 
 			if(!mode.explosion_in_progress && mode.check_finished(force_ending) || force_ending)
 				current_state = GAME_STATE_FINISHED
-				toggle_ooc(1) // Turn it on
-				GLOB.dooc_allowed = TRUE // Previous line already announces OOC availability, also DOOC has no convenience procs anyways
+				toggle_ooc(TRUE) // Turn it on
+				toggle_dooc(TRUE)
 				declare_completion(force_ending)
 				Master.SetRunLevel(RUNLEVEL_POSTGAME)
 
@@ -201,7 +201,7 @@ SUBSYSTEM_DEF(ticker)
 		mode.announce()
 
 	if(!config.ooc_during_round)
-		toggle_ooc(0) // Turn it off
+		toggle_ooc(FALSE) // Turn it off
 
 	CHECK_TICK
 	GLOB.start_landmarks_list = shuffle(GLOB.start_landmarks_list) //Shuffle the order of spawn points so they dont always predictably spawn bottom-up and right-to-left

--- a/code/modules/admin/admin.dm
+++ b/code/modules/admin/admin.dm
@@ -513,7 +513,7 @@
 	set category = "Server"
 	set desc="Toggle dis bitch"
 	set name="Toggle Dead OOC"
-	GLOB.dooc_allowed = !( GLOB.dooc_allowed )
+	toggle_dooc()
 
 	log_admin("[key_name(usr)] toggled OOC.")
 	message_admins("[key_name_admin(usr)] toggled Dead OOC.")

--- a/code/modules/client/verbs/ooc.dm
+++ b/code/modules/client/verbs/ooc.dm
@@ -80,6 +80,15 @@
 		GLOB.ooc_allowed = !GLOB.ooc_allowed
 	to_chat(world, "<B>The OOC channel has been globally [GLOB.ooc_allowed ? "enabled" : "disabled"].</B>")
 
+/proc/toggle_dooc(toggle = null)
+	if(toggle != null)
+		if(toggle != GLOB.dooc_allowed)
+			GLOB.dooc_allowed = toggle
+		else
+			return
+	else
+		GLOB.dooc_allowed = !GLOB.dooc_allowed
+
 GLOBAL_VAR_INIT(normal_ooc_colour, OOC_COLOR)
 
 /client/proc/set_ooc(newColor as color)


### PR DESCRIPTION
Fixes #29321

[Changelogs]:
[]: 


:cl: Naksu
fix: OOC for dead people is now (re-)enabled at round-end
/:cl:

[why]: 
Consistency with global OOC, which is also enabled at round-end
