### PR TITLE
Removes corgis as a facehugger target

### DIFF
--- a/code/modules/mob/living/carbon/alien/special/facehugger.dm
+++ b/code/modules/mob/living/carbon/alien/special/facehugger.dm
@@ -119,13 +119,11 @@
 		Leap(hit_atom)
 
 /obj/item/clothing/mask/facehugger/proc/valid_to_attach(mob/living/M)
-	// valid targets: corgis, carbons except aliens and devils
+	// valid targets: carbons except aliens and devils
 	// facehugger state early exit checks
 	if(stat != CONSCIOUS)
 		return FALSE
 	if(attached)
-		return FALSE
-	if(!iscorgi(M) && !iscarbon(M))
 		return FALSE
 	if(iscarbon(M))
 		// disallowed carbons
@@ -140,9 +138,8 @@
 			return FALSE
 		// carbon, has head, not alien or devil, has no hivenode or embryo: valid
 		return TRUE
-	else if(iscorgi(M))
-		// corgi: valid
-		return TRUE
+
+	return FALSE
 
 /obj/item/clothing/mask/facehugger/proc/Leap(mob/living/M)
 	if(!valid_to_attach(M))
@@ -183,11 +180,6 @@
 	//ensure we detach once we no longer need to be attached
 	addtimer(CALLBACK(src, .proc/detach), MAX_IMPREGNATION_TIME)
 
-	if (iscorgi(M))
-		var/mob/living/simple_animal/pet/dog/corgi/C = M
-		loc = C
-		C.facehugger = src
-		C.regenerate_icons()
 
 	if(!sterile)
 		M.take_bodypart_damage(strength,0) //done here so that humans in helmets take damage
@@ -221,10 +213,6 @@
 		if((!LC || LC.status != BODYPART_ROBOTIC) && !target.getorgan(/obj/item/organ/body_egg/alien_embryo))
 			new /obj/item/organ/body_egg/alien_embryo(target)
 
-		if(iscorgi(target))
-			var/mob/living/simple_animal/pet/dog/corgi/C = target
-			src.loc = get_turf(C)
-			C.facehugger = null
 	else
 		target.visible_message("<span class='danger'>[src] violates [target]'s face!</span>", \
 								"<span class='userdanger'>[src] violates [target]'s face!</span>")
@@ -263,7 +251,7 @@
 	if(M.getorgan(/obj/item/organ/alien/hivenode))
 		return 0
 
-	if(iscorgi(M) || ismonkey(M))
+	if(ismonkey(M))
 		return 1
 
 	var/mob/living/carbon/C = M

--- a/code/modules/mob/living/simple_animal/friendly/dog.dm
+++ b/code/modules/mob/living/simple_animal/friendly/dog.dm
@@ -28,7 +28,6 @@
 	var/shaved = 0
 	var/obj/item/inventory_head
 	var/obj/item/inventory_back
-	var/facehugger
 	var/nofur = 0 		//Corgis that have risen past the material plane of existence.
 	gold_core_spawnable = 2
 
@@ -462,13 +461,6 @@
 			back_icon = DF.get_overlay()
 		add_overlay(back_icon)
 
-	if(facehugger)
-		var/mutable_appearance/facehugger_overlay = mutable_appearance('icons/mob/mask.dmi')
-		if(istype(src, /mob/living/simple_animal/pet/dog/corgi/puppy))
-			facehugger_overlay.icon_state = "facehugger_corgipuppy"
-		else
-			facehugger_overlay.icon_state = "facehugger_corgi"
-		add_overlay(facehugger_overlay)
 	if(pcollar)
 		add_overlay(collar)
 		add_overlay(pettag)


### PR DESCRIPTION
Fixes #18518
Also fixes unsubmitted issue where facebuggers attach to the wrong side of the corgi.

This might have balance considerations so maintainers can duke it out. 

[Changelogs]: 
[]: 

:cl: Naksu
del: Corgis can no longer be targeted by facehuggers
/:cl:

[why]: 
Exists for a meme and has multiple unresolved bugs, also makes the code that has TODOs from 6 years ago even worse by introducing corgi-specific segments to handle them (corgis are not carbon)