### PR TITLE
Adds a tip to examine for L6 SAW machinegun

### DIFF
--- a/code/modules/projectiles/guns/ballistic/automatic.dm
+++ b/code/modules/projectiles/guns/ballistic/automatic.dm
@@ -298,7 +298,7 @@
 /obj/item/gun/ballistic/automatic/l6_saw/examine(mob/user)
 	..()
 	if(cover_open && magazine)
-		to_chat(user, "<span class='notice'>It seems like you can use an <b>empty hand</b> to remove the magazine.</span>")
+		to_chat(user, "<span class='notice'>It seems like you could use an <b>empty hand</b> to remove the magazine.</span>")
 
 
 /obj/item/gun/ballistic/automatic/l6_saw/attack_self(mob/user)

--- a/code/modules/projectiles/guns/ballistic/automatic.dm
+++ b/code/modules/projectiles/guns/ballistic/automatic.dm
@@ -295,6 +295,12 @@
 	pin = /obj/item/device/firing_pin
 
 
+/obj/item/gun/ballistic/automatic/l6_saw/examine(mob/user)
+	..()
+	if(cover_open && magazine)
+		to_chat(user, "<span class='notice'>It seems like you can use an <b>empty hand</b> to remove the magazine.</span>")
+
+
 /obj/item/gun/ballistic/automatic/l6_saw/attack_self(mob/user)
 	cover_open = !cover_open
 	to_chat(user, "<span class='notice'>You [cover_open ? "open" : "close"] [src]'s cover.</span>")


### PR DESCRIPTION
Since other guns pull the magazine out on attack_self, but the L6 SAW does not, I feel this tip should be included.