### PR TITLE
Various webhook processor fixes

### DIFF
--- a/tools/WebhookProcessor/github_webhook_processor.php
+++ b/tools/WebhookProcessor/github_webhook_processor.php
@@ -96,9 +96,14 @@ switch (strtolower($_SERVER['HTTP_X_GITHUB_EVENT'])) {
 		handle_pr($payload);
 		break;
 	case 'pull_request_review':
-		$lower_state = strtolower($payload['review']['state']);
-		if(($lower_state == 'approved' || $lower_state == 'changes_requested') && is_maintainer($payload, $payload['review']['user']['login']))
-			remove_ready_for_review($payload);
+		if($payload['action'] == 'submitted'){
+			$lower_state = strtolower($payload['review']['state']);
+			if(($lower_state == 'approved' || $lower_state == 'changes_requested') && is_maintainer($payload, $payload['review']['user']['login'])){
+				$lower_association = strtolower($payload['review']['author_association']);
+				if($lower_association == 'member' || $lower_association == 'contributor' || $lower_association == 'owner')
+					remove_ready_for_review($payload);
+			}
+		}
 		break;
 	default:
 		header('HTTP/1.0 404 Not Found');
@@ -153,7 +158,11 @@ function validate_user($payload) {
 
 function get_labels($payload){
 	$url = $payload['pull_request']['issue_url'] . '/labels';
-	return json_decode(apisend($url), true);
+	$existing_labels = json_decode(apisend($url), true);
+	$existing = array();
+	foreach($existing_labels as $label)
+		$existing[] = $label['name'];
+	return $existing;
 }
 
 //rip bs-12
@@ -207,11 +216,8 @@ function tag_pr($payload, $opened) {
 
 	$url = $payload['pull_request']['issue_url'] . '/labels';
 
-	$existing_labels = get_labels($payload);
+	$existing = get_labels($payload);
 
-	$existing = array();
-	foreach($existing_labels as $label)
-		$existing[] = $label['name'];
 	$tags = array_merge($tags, $existing);
 	$tags = array_unique($tags);
 	$tags = array_diff($tags, $remove);
@@ -260,16 +266,14 @@ function check_ready_for_review($payload, $labels = null){
 	$dismissed_an_approved_review = false;
 
 	foreach($reviews as $R){
-		if(isset($R['author_association'])){
-			$lower_association = strtolower($R['author_association']);
-			if($lower_association == 'member' || $lower_association == 'contributor' || $lower_association == 'owner'){
-				$lower_state = strtolower($R['state']);
-				if($lower_state == 'changes_requested')
-					$reviews_ids_with_changes_requested[] = $R['id'];
-				else if ($lower_state == 'approved'){
-					dismiss_review($payload, $R['id']);
-					$dismissed_an_approved_review = true;
-				}
+		$lower_association = strtolower($R['author_association']);
+		if($lower_association == 'member' || $lower_association == 'contributor' || $lower_association == 'owner'){
+			$lower_state = strtolower($R['state']);
+			if($lower_state == 'changes_requested')
+				$reviews_ids_with_changes_requested[] = $R['id'];
+			else if ($lower_state == 'approved'){
+				dismiss_review($payload, $R['id']);
+				$dismissed_an_approved_review = true;
 			}
 		}
 	}
@@ -316,7 +320,7 @@ function handle_pr($payload) {
 			if(get_pr_code_friendliness($payload) < 0){
 				$balances = pr_balances();
 				$author = $payload['pull_request']['user']['login'];
-				if(isset($balances[$author]) && $balances[$author] < 0)
+				if(isset($balances[$author]) && $balances[$author] < 0 && !is_maintainer($payload, $author))
 					create_comment($payload, 'You currently have a negative Fix/Feature pull request delta of ' . $balances[$author] . '. Maintainers may close this PR at will. Fixing issues or improving the codebase will improve this score.');
 			}
 			break;
@@ -433,7 +437,7 @@ function is_maintainer($payload, $author){
 	global $maintainer_team_id;
 	$repo_is_org = $payload['pull_request']['base']['repo']['owner']['type'] == 'Organization';
 	if($maintainer_team_id == null || !$repo_is_org) {
-		$collaburl = $payload['pull_request']['base']['repo']['collaborators_url'] . '/' . $author . '/permissions';
+		$collaburl = str_replace('{/collaborator}', '/' . $author, $payload['pull_request']['base']['repo']['collaborators_url']) . '/permission';
 		$perms = json_decode(apisend($collaburl), true);
 		$permlevel = $perms['permission'];
 		return $permlevel == 'admin' || $permlevel == 'write';
@@ -441,7 +445,7 @@ function is_maintainer($payload, $author){
 	else {
 		$check_url = 'https://api.github.com/teams/' . $maintainer_team_id . '/memberships/' . $author;
 		$result = json_decode(apisend($check_url), true);
-		return isset($result['state']);	//this field won't be here if they aren't a member
+		return isset($result['state']) && $result['state'] == 'active';
 	}
 }
 
@@ -452,17 +456,17 @@ function update_pr_balance($payload) {
 	if(!$trackPRBalance)
 		return;
 	$author = $payload['pull_request']['user']['login'];
-	if(is_maintainer($payload, $author))	//immune
-		return;
 	$balances = pr_balances();
 	if(!isset($balances[$author]))
 		$balances[$author] = $startingPRBalance;
 	$friendliness = get_pr_code_friendliness($payload, $balances[$author]);
 	$balances[$author] += $friendliness;
-	if($balances[$author] < 0 && $friendliness < 0)
-		create_comment($payload, 'Your Fix/Feature pull request delta is currently below zero (' . $balances[$author] . '). Maintainers may close future Feature/Tweak/Balance PRs. Fixing issues or helping to improve the codebase will raise this score.');
-	else if($balances[$author] >= 0 && ($balances[$author] - $friendliness) < 0)
-		create_comment($payload, 'Your Fix/Feature pull request delta is now above zero (' . $balances[$author] . '). Feel free to make Feature/Tweak/Balance PRs.');
+	if(!is_maintainer($payload, $author)){	//immune
+		if($balances[$author] < 0 && $friendliness < 0)
+			create_comment($payload, 'Your Fix/Feature pull request delta is currently below zero (' . $balances[$author] . '). Maintainers may close future Feature/Tweak/Balance PRs. Fixing issues or helping to improve the codebase will raise this score.');
+		else if($balances[$author] >= 0 && ($balances[$author] - $friendliness) < 0)
+			create_comment($payload, 'Your Fix/Feature pull request delta is now above zero (' . $balances[$author] . '). Feel free to make Feature/Tweak/Balance PRs.');
+	}
 	$balances_file = fopen(pr_balance_json_path(), 'w');
 	fwrite($balances_file, json_encode($balances));
 	fclose($balances_file);

--- a/tools/WebhookProcessor/secret.php
+++ b/tools/WebhookProcessor/secret.php
@@ -8,6 +8,7 @@
 $hookSecret = '08ajh0qj93209qj90jfq932j32r';
 
 //Api key for pushing changelogs.
+//This requires the public_repo (or repo for private repositories) and read:org permissions
 $apiKey = '209ab8d879c0f987d06a09b9d879c0f987d06a09b9d8787d0a089c';
 
 //Used to prevent potential RCEs


### PR DESCRIPTION
- Fixed is_maintainer() for repo scope
- Fixed the pull_request_review events running on actions other than submitted
- Fixed get_labels()
- PR balances will be recorded for maintainers but not acted upon