### PR TITLE
Tank gauge rounding fix

### DIFF
--- a/code/game/objects/items/tanks/tanks.dm
+++ b/code/game/objects/items/tanks/tanks.dm
@@ -74,7 +74,7 @@
 		if (icon == src) to_chat(user, "<span class='notice'>If you want any more information you'll need to get closer.</span>")
 		return
 
-	to_chat(user, "<span class='notice'>The pressure gauge reads [src.air_contents.return_pressure()] kPa.</span>")
+	to_chat(user, "<span class='notice'>The pressure gauge reads [round(src.air_contents.return_pressure(),0.01)] kPa.</span>")
 
 	var/celsius_temperature = src.air_contents.temperature-T0C
 	var/descriptive


### PR DESCRIPTION
Makes the number round to the nearest hundredth, instead of possibly displaying massive numbers in scientific notation instead.

Fixes second issue mentioned in #30748