### PR TITLE
Monkeys are now more likely to become Gorillas

### DIFF
--- a/code/modules/mob/living/carbon/monkey/life.dm
+++ b/code/modules/mob/living/carbon/monkey/life.dm
@@ -29,7 +29,7 @@
 				emote("collapse")
 			Knockdown(200)
 			to_chat(src, "<span class='danger'>You feel weak.</span>")
-		if(radiation > 30 && prob((radiation - 30) * (radiation - 30) * 0.00002))
+		if(radiation > 30 && prob((radiation - 30) * (radiation - 30) * 0.0002))
 			gorillize()
 			return
 		switch(radiation)

--- a/html/changelogs/AutoChangeLog-pr-30056.yml
+++ b/html/changelogs/AutoChangeLog-pr-30056.yml
@@ -1,4 +1,0 @@
-author: "More Robust Than You"
-delete-after: True
-changes: 
-  - rscdel: "Finally fucking removed gangs"

--- a/html/changelogs/AutoChangeLog-pr-30056.yml
+++ b/html/changelogs/AutoChangeLog-pr-30056.yml
@@ -1,0 +1,4 @@
+author: "More Robust Than You"
+delete-after: True
+changes: 
+  - rscdel: "Finally fucking removed gangs"


### PR DESCRIPTION
So I found out today we have gorillas in our code, made from irradiated monkeys, nice!

**I checked the percentage - at max radiation a monkey had a 10% chance to become a gorilla every tick.**

Wow

Then I saw it got nerfed. **Currently at max radiation a monkey has a .01% chance to become a gorilla. Meaning it would take about 30 minutes of max rads for a monkey to transform.** 

Wow

Now I've used advanced mathematics to decide that the decimal place between those two is closer to ideal. **Now its a .1% chance meaning it will take about 3 minutes of max rads.** Max rads are not easy to maintain since it decays fairly quickly and "caps" at 100 and it will be dead before transforming (on average) unless you're also healing them.

Leaving them in their current state - they might as well not exist. 