### PR TITLE
Quick pAI software buying tweak

### DIFF
--- a/code/modules/mob/living/silicon/pai/software.dm
+++ b/code/modules/mob/living/silicon/pai/software.dm
@@ -130,8 +130,8 @@
 				if(available_software.Find(target))
 					var/cost = src.available_software[target]
 					if(ram >= cost)
-						ram -= cost
 						software.Add(target)
+						ram -= cost
 					else
 						temp = "Insufficient RAM available."
 				else

--- a/code/modules/mob/living/silicon/pai/software.dm
+++ b/code/modules/mob/living/silicon/pai/software.dm
@@ -127,7 +127,7 @@
 		if("buy")
 			if(subscreen == 1)
 				var/target = href_list["buy"]
-				if(available_software.Find(target))
+				if(available_software.Find(target) && !software.Find(target))
 					var/cost = src.available_software[target]
 					if(ram >= cost)
 						software.Add(target)
@@ -248,6 +248,7 @@
 				medHUD = !medHUD
 				if(medHUD)
 					add_med_hud()
+					
 				else
 					var/datum/atom_hud/med = GLOB.huds[med_hud]
 					med.remove_hud_from(src)


### PR DESCRIPTION
:cl:
Tweak: Swapped the action of purchasing a pAI software and subtracting the RAM from available pool.
/:cl:

[why]: in an attempt to fix the "buy twice" bug upstream [as described in Hippie Station
](https://github.com/HippieStation/HippieStation/issues/2252) I made a [pull req](https://github.com/HippieStation/HippieStation/pull/3092) in Hippie Station but was told to try it here.