### PR TITLE
"Help, help, I'm being opressed" - the Oppressor upgrade module

### DIFF
--- a/code/game/objects/items/robot/robot_upgrades.dm
+++ b/code/game/objects/items/robot/robot_upgrades.dm
@@ -413,6 +413,6 @@
 	if(..())
 		return 0
 
-	R.module.transform_to(/obj/item/weapon/robot_module/security/traitorsec)
+	R.module.transform_to(/obj/item/robot_module/security/traitorsec)
 	R.emag_act(user)
 	return 1

--- a/code/game/objects/items/robot/robot_upgrades.dm
+++ b/code/game/objects/items/robot/robot_upgrades.dm
@@ -403,7 +403,7 @@
 	return TRUE
 
 /obj/item/borg/upgrade/traitorsec
-	name = "Bloodhound upgrade module"
+	name = "Opressor upgrade module"
 	desc = "Ilegal upgrade board that unlocks the banned security module."
 	icon_state = "cyborg_upgrade3"
 	origin_tech = "data=4;combat=4;syndicate=3"

--- a/code/game/objects/items/robot/robot_upgrades.dm
+++ b/code/game/objects/items/robot/robot_upgrades.dm
@@ -403,7 +403,7 @@
 	return TRUE
 
 /obj/item/borg/upgrade/traitorsec
-	name = "Opressor upgrade module"
+	name = "Oppressor upgrade module"
 	desc = "Ilegal upgrade board that unlocks the banned security module."
 	icon_state = "cyborg_upgrade3"
 	origin_tech = "data=4;combat=4;syndicate=3"

--- a/code/game/objects/items/robot/robot_upgrades.dm
+++ b/code/game/objects/items/robot/robot_upgrades.dm
@@ -410,7 +410,7 @@
 
 /obj/item/borg/upgrade/traitorsec/action(mob/living/silicon/robot/R,mob/living/user)
 	if(..())
-		return
+		return FALSE
 
 	R.module.transform_to(/obj/item/robot_module/security/traitorsec)
 	R.emag_act(user)

--- a/code/game/objects/items/robot/robot_upgrades.dm
+++ b/code/game/objects/items/robot/robot_upgrades.dm
@@ -410,7 +410,7 @@
 
 /obj/item/borg/upgrade/traitorsec/action(mob/living/silicon/robot/R,mob/living/user)
 	if(..())
-		return FALSE
+		return
 
 	R.module.transform_to(/obj/item/robot_module/security/traitorsec)
 	R.emag_act(user)

--- a/code/game/objects/items/robot/robot_upgrades.dm
+++ b/code/game/objects/items/robot/robot_upgrades.dm
@@ -406,7 +406,6 @@
 	name = "Bloodhound upgrade module"
 	desc = "Ilegal upgrade board that unlocks the banned security module."
 	icon_state = "cyborg_upgrade3"
-	require_module = 1
 	origin_tech = "data=4;combat=4;syndicate=3"
 
 /obj/item/borg/upgrade/traitorsec/action(mob/living/silicon/robot/R,mob/living/user)

--- a/code/game/objects/items/robot/robot_upgrades.dm
+++ b/code/game/objects/items/robot/robot_upgrades.dm
@@ -410,8 +410,8 @@
 
 /obj/item/borg/upgrade/traitorsec/action(mob/living/silicon/robot/R,mob/living/user)
 	if(..())
-		return 0
+		return FALSE
 
 	R.module.transform_to(/obj/item/robot_module/security/traitorsec)
 	R.emag_act(user)
-	return 1
+	return TRUE

--- a/code/game/objects/items/robot/robot_upgrades.dm
+++ b/code/game/objects/items/robot/robot_upgrades.dm
@@ -404,7 +404,7 @@
 
 /obj/item/borg/upgrade/traitorsec
 	name = "Oppressor upgrade module"
-	desc = "Ilegal upgrade board that unlocks the banned security module."
+	desc = "Illegal upgrade board that unlocks the banned security module."
 	icon_state = "cyborg_upgrade3"
 	origin_tech = "data=4;combat=4;syndicate=3"
 

--- a/code/game/objects/items/robot/robot_upgrades.dm
+++ b/code/game/objects/items/robot/robot_upgrades.dm
@@ -15,7 +15,7 @@
 	// if module is reset
 	var/one_use = FALSE
 
-/obj/item/borg/upgrade/proc/action(mob/living/silicon/robot/R)
+/obj/item/borg/upgrade/proc/action(mob/living/silicon/robot/R,mob/living/user)
 	if(R.stat == DEAD)
 		to_chat(usr, "<span class='notice'>[src] will not function on a deceased cyborg.</span>")
 		return 1
@@ -54,7 +54,7 @@
 	icon_state = "cyborg_upgrade1"
 	one_use = TRUE
 
-/obj/item/borg/upgrade/restart/action(mob/living/silicon/robot/R)
+/obj/item/borg/upgrade/restart/action(mob/living/silicon/robot/R,mob/living/user)
 	if(R.health < 0)
 		to_chat(usr, "<span class='warning'>You have to repair the cyborg before using this module!</span>")
 		return 0
@@ -74,7 +74,7 @@
 	require_module = 1
 	origin_tech = "engineering=4;materials=5;programming=4"
 
-/obj/item/borg/upgrade/vtec/action(mob/living/silicon/robot/R)
+/obj/item/borg/upgrade/vtec/action(mob/living/silicon/robot/R,mob/living/user)
 	if(..())
 		return
 	if(R.speed < 0)
@@ -94,7 +94,7 @@
 	module_type = /obj/item/robot_module/security
 	origin_tech = "engineering=4;powerstorage=4;combat=4"
 
-/obj/item/borg/upgrade/disablercooler/action(mob/living/silicon/robot/R)
+/obj/item/borg/upgrade/disablercooler/action(mob/living/silicon/robot/R,mob/living/user)
 	if(..())
 		return
 
@@ -117,7 +117,7 @@
 	icon_state = "cyborg_upgrade3"
 	origin_tech = "engineering=4;powerstorage=4"
 
-/obj/item/borg/upgrade/thrusters/action(mob/living/silicon/robot/R)
+/obj/item/borg/upgrade/thrusters/action(mob/living/silicon/robot/R,mob/living/user)
 	if(..())
 		return
 
@@ -136,7 +136,7 @@
 	module_type = /obj/item/robot_module/miner
 	origin_tech = "engineering=4;materials=5"
 
-/obj/item/borg/upgrade/ddrill/action(mob/living/silicon/robot/R)
+/obj/item/borg/upgrade/ddrill/action(mob/living/silicon/robot/R,mob/living/user)
 	if(..())
 		return
 
@@ -158,7 +158,7 @@
 	module_type = /obj/item/robot_module/miner
 	origin_tech = "engineering=4;materials=4;bluespace=4"
 
-/obj/item/borg/upgrade/soh/action(mob/living/silicon/robot/R)
+/obj/item/borg/upgrade/soh/action(mob/living/silicon/robot/R,mob/living/user)
 	if(..())
 		return
 
@@ -177,7 +177,7 @@
 	require_module = 1
 	origin_tech = "combat=4;syndicate=1"
 
-/obj/item/borg/upgrade/syndicate/action(mob/living/silicon/robot/R)
+/obj/item/borg/upgrade/syndicate/action(mob/living/silicon/robot/R,mob/living/user)
 	if(..())
 		return
 
@@ -197,7 +197,7 @@
 	module_type = /obj/item/robot_module/miner
 	origin_tech = "engineering=4;materials=4;plasmatech=4"
 
-/obj/item/borg/upgrade/lavaproof/action(mob/living/silicon/robot/R)
+/obj/item/borg/upgrade/lavaproof/action(mob/living/silicon/robot/R,mob/living/user)
 	if(..())
 		return
 	R.weather_immunities += "lava"
@@ -216,7 +216,7 @@
 	var/mob/living/silicon/robot/cyborg
 	var/datum/action/toggle_action
 
-/obj/item/borg/upgrade/selfrepair/action(mob/living/silicon/robot/R)
+/obj/item/borg/upgrade/selfrepair/action(mob/living/silicon/robot/R,mob/living/user)
 	if(..())
 		return
 
@@ -317,7 +317,7 @@
 	origin_tech = null
 	var/list/additional_reagents = list()
 
-/obj/item/borg/upgrade/hypospray/action(mob/living/silicon/robot/R)
+/obj/item/borg/upgrade/hypospray/action(mob/living/silicon/robot/R,mob/living/user)
 	if(..())
 		return
 	for(var/obj/item/reagent_containers/borghypo/H in R.module)
@@ -350,7 +350,7 @@
 	origin_tech = "materials=5;engineering=7;combat=3"
 	icon_state = "cyborg_upgrade3"
 
-/obj/item/borg/upgrade/piercing_hypospray/action(mob/living/silicon/robot/R)
+/obj/item/borg/upgrade/piercing_hypospray/action(mob/living/silicon/robot/R,mob/living/user)
 	if(..())
 		return
 
@@ -373,7 +373,7 @@
 	module_type = /obj/item/robot_module/medical
 	origin_tech = "programming=4;engineering=6;materials=5;powerstorage=5;biotech=5"
 
-/obj/item/borg/upgrade/defib/action(mob/living/silicon/robot/R)
+/obj/item/borg/upgrade/defib/action(mob/living/silicon/robot/R,mob/living/user)
 	if(..())
 		return
 
@@ -401,3 +401,18 @@
 
 	R.make_shell(src)
 	return TRUE
+
+/obj/item/borg/upgrade/traitorsec
+	name = "Bloodhound upgrade module"
+	desc = "Ilegal upgrade board that unlocks the banned security module."
+	icon_state = "cyborg_upgrade3"
+	require_module = 1
+	origin_tech = "data=4;combat=4;syndicate=3"
+
+/obj/item/borg/upgrade/traitorsec/action(mob/living/silicon/robot/R,mob/living/user)
+	if(..())
+		return 0
+
+	R.module.transform_to(/obj/item/weapon/robot_module/security/traitorsec)
+	R.emag_act(user)
+	return 1

--- a/code/game/objects/items/storage/uplink_kits.dm
+++ b/code/game/objects/items/storage/uplink_kits.dm
@@ -306,7 +306,5 @@
 	new /obj/item/spellbook/oneuse/mimery_blockade(src)
 	new /obj/item/spellbook/oneuse/mimery_guns(src)
 
-/obj/item/storage/box/syndie_kit/traitorsec_boards/New()
-	..()
-	contents = list()
+/obj/item/storage/box/syndie_kit/traitorsec_boards/PopulateContents()
 	new /obj/item/borg/upgrade/traitorsec(src)

--- a/code/game/objects/items/storage/uplink_kits.dm
+++ b/code/game/objects/items/storage/uplink_kits.dm
@@ -305,3 +305,8 @@
 /obj/item/storage/box/syndie_kit/mimery/PopulateContents()
 	new /obj/item/spellbook/oneuse/mimery_blockade(src)
 	new /obj/item/spellbook/oneuse/mimery_guns(src)
+
++/obj/item/weapon/storage/box/syndie_kit/traitorsec_boards/New()
+	..()
+	contents = list()
+	new /obj/item/borg/upgrade/traitorsec(src)

--- a/code/game/objects/items/storage/uplink_kits.dm
+++ b/code/game/objects/items/storage/uplink_kits.dm
@@ -306,7 +306,7 @@
 	new /obj/item/spellbook/oneuse/mimery_blockade(src)
 	new /obj/item/spellbook/oneuse/mimery_guns(src)
 
-+/obj/item/storage/box/syndie_kit/traitorsec_boards/New()
+/obj/item/storage/box/syndie_kit/traitorsec_boards/New()
 	..()
 	contents = list()
 	new /obj/item/borg/upgrade/traitorsec(src)

--- a/code/game/objects/items/storage/uplink_kits.dm
+++ b/code/game/objects/items/storage/uplink_kits.dm
@@ -306,7 +306,7 @@
 	new /obj/item/spellbook/oneuse/mimery_blockade(src)
 	new /obj/item/spellbook/oneuse/mimery_guns(src)
 
-+/obj/item/weapon/storage/box/syndie_kit/traitorsec_boards/New()
++/obj/item/storage/box/syndie_kit/traitorsec_boards/New()
 	..()
 	contents = list()
 	new /obj/item/borg/upgrade/traitorsec(src)

--- a/code/modules/mob/living/silicon/robot/robot.dm
+++ b/code/modules/mob/living/silicon/robot/robot.dm
@@ -516,7 +516,7 @@
 		else
 			if(!user.drop_item())
 				return
-			if(U.action(src))
+			if(U.action(src,user))
 				to_chat(user, "<span class='notice'>You apply the upgrade to [src].</span>")
 				if(U.one_use)
 					qdel(U)

--- a/code/modules/mob/living/silicon/robot/robot_modules.dm
+++ b/code/modules/mob/living/silicon/robot/robot_modules.dm
@@ -340,6 +340,15 @@
 	can_be_pushed = FALSE
 	hat_offset = 3
 
+/obj/item/weapon/robot_module/security/traitorsec
+	name = "Bloodhound"
+	cyborg_base_icon = "synd_sec"
+	moduleselect_icon = "malf"
+	feedback_key = "cyborg_traitorsec"
+	can_be_pushed = FALSE
+	hat_offset = 3
+
+ 
 /obj/item/robot_module/security/do_transform_animation()
 	..()
 	to_chat(loc, "<span class='userdanger'>While you have picked the security module, you still have to follow your laws, NOT Space Law. \

--- a/code/modules/mob/living/silicon/robot/robot_modules.dm
+++ b/code/modules/mob/living/silicon/robot/robot_modules.dm
@@ -341,7 +341,7 @@
 	hat_offset = 3
 
 /obj/item/robot_module/security/traitorsec
-	name = "Bloodhound"
+	name = "Opressor"
 	cyborg_base_icon = "synd_sec"
 	moduleselect_icon = "malf"
 	feedback_key = "cyborg_traitorsec"

--- a/code/modules/mob/living/silicon/robot/robot_modules.dm
+++ b/code/modules/mob/living/silicon/robot/robot_modules.dm
@@ -341,7 +341,7 @@
 	hat_offset = 3
 
 /obj/item/robot_module/security/traitorsec
-	name = "Opressor"
+	name = "Oppressor"
 	cyborg_base_icon = "synd_sec"
 	moduleselect_icon = "malf"
 	feedback_key = "cyborg_traitorsec"

--- a/code/modules/mob/living/silicon/robot/robot_modules.dm
+++ b/code/modules/mob/living/silicon/robot/robot_modules.dm
@@ -340,7 +340,7 @@
 	can_be_pushed = FALSE
 	hat_offset = 3
 
-/obj/item/weapon/robot_module/security/traitorsec
+/obj/item/robot_module/security/traitorsec
 	name = "Bloodhound"
 	cyborg_base_icon = "synd_sec"
 	moduleselect_icon = "malf"

--- a/code/modules/uplink/uplink_item.dm
+++ b/code/modules/uplink/uplink_item.dm
@@ -1315,11 +1315,11 @@ GLOBAL_LIST_EMPTY(uplink_items) // Global list so we only initialize this once.
 
 /datum/uplink_item/role_restricted/traitorsec
 	name = "Bloodhound upgrade modules"
- 	desc = "A box containing an cyborg upgrade module that instantly hacks a cyborg and unlocks the outlawed securiy module (in a inconspicuous black-and-red paintjob)"
- 	item = /obj/item/storage/box/syndie_kit/traitorsec_boards
- 	cost = 16
- 	restricted_roles = list("Roboticist", "Research Director")
- 	surplus = 5
+	desc = "A box containing an cyborg upgrade module that instantly hacks a cyborg and unlocks the outlawed securiy module (in a inconspicuous black-and-red paintjob)"
+	item = /obj/item/storage/box/syndie_kit/traitorsec_boards
+	cost = 16
+	restricted_roles = list("Roboticist", "Research Director")
+	surplus = 5
 	
 // Pointless
 /datum/uplink_item/badass

--- a/code/modules/uplink/uplink_item.dm
+++ b/code/modules/uplink/uplink_item.dm
@@ -1314,12 +1314,11 @@ GLOBAL_LIST_EMPTY(uplink_items) // Global list so we only initialize this once.
 	restricted_roles = list("Shaft Miner")
 
 /datum/uplink_item/role_restricted/traitorsec
-	name = "Opressor Upgrade Module"
+	name = "Oppressor Upgrade Module"
 	desc = "A box containing an cyborg upgrade module that instantly hacks a cyborg and unlocks the outlawed securiy module (in a inconspicuous black-and-red paintjob)"
 	item = /obj/item/storage/box/syndie_kit/traitorsec_boards
 	cost = 16
 	restricted_roles = list("Roboticist", "Research Director")
-	surplus = 5
 	
 // Pointless
 /datum/uplink_item/badass

--- a/code/modules/uplink/uplink_item.dm
+++ b/code/modules/uplink/uplink_item.dm
@@ -1325,10 +1325,10 @@ GLOBAL_LIST_EMPTY(uplink_items) // Global list so we only initialize this once.
 	cost = 16
 	player_minimum = 20
 	restricted_roles = list("Roboticist", "Research Director")
-	
+
 /datum/uplink_item/role_restricted/traitorsec/SpecialRequirements()
 	return config.forbid_secborg
-			
+
 // Pointless
 /datum/uplink_item/badass
 	category = "(Pointless) Badassery"

--- a/code/modules/uplink/uplink_item.dm
+++ b/code/modules/uplink/uplink_item.dm
@@ -36,7 +36,7 @@ GLOBAL_LIST_EMPTY(uplink_items) // Global list so we only initialize this once.
 				continue
 			if(I.SpecialRequirements())
 				continue
-			
+
 			if(!filtered_uplink_items[category])
 				filtered_uplink_items[category] = list()
 			filtered_uplink_items[category][item] = I

--- a/code/modules/uplink/uplink_item.dm
+++ b/code/modules/uplink/uplink_item.dm
@@ -1314,7 +1314,7 @@ GLOBAL_LIST_EMPTY(uplink_items) // Global list so we only initialize this once.
 	restricted_roles = list("Shaft Miner")
 
 /datum/uplink_item/role_restricted/traitorsec
-	name = "Bloodhound upgrade modules"
+	name = "Opressor Upgrade Module"
 	desc = "A box containing an cyborg upgrade module that instantly hacks a cyborg and unlocks the outlawed securiy module (in a inconspicuous black-and-red paintjob)"
 	item = /obj/item/storage/box/syndie_kit/traitorsec_boards
 	cost = 16

--- a/code/modules/uplink/uplink_item.dm
+++ b/code/modules/uplink/uplink_item.dm
@@ -1326,7 +1326,7 @@ GLOBAL_LIST_EMPTY(uplink_items) // Global list so we only initialize this once.
 	player_minimum = 20
 	restricted_roles = list("Roboticist", "Research Director")
 	
-/datum/uplink_item/role_restricted/traitorsec/SpecialRequirement()
+/datum/uplink_item/role_restricted/traitorsec/SpecialRequirements()
 	return !config.forbid_secborg
 			
 // Pointless

--- a/code/modules/uplink/uplink_item.dm
+++ b/code/modules/uplink/uplink_item.dm
@@ -1327,7 +1327,7 @@ GLOBAL_LIST_EMPTY(uplink_items) // Global list so we only initialize this once.
 	restricted_roles = list("Roboticist", "Research Director")
 	
 /datum/uplink_item/role_restricted/traitorsec/SpecialRequirements()
-	return !config.forbid_secborg
+	return config.forbid_secborg
 			
 // Pointless
 /datum/uplink_item/badass

--- a/code/modules/uplink/uplink_item.dm
+++ b/code/modules/uplink/uplink_item.dm
@@ -34,7 +34,7 @@ GLOBAL_LIST_EMPTY(uplink_items) // Global list so we only initialize this once.
 					continue
 			if(I.player_minimum && I.player_minimum > GLOB.joined_player_list.len)
 				continue
-			if(uplink_item.SpecialRequirements())
+			if(I.uplink_item.SpecialRequirements())
 				continue
 			
 			if(!filtered_uplink_items[category])
@@ -133,7 +133,7 @@ GLOBAL_LIST_EMPTY(uplink_items) // Global list so we only initialize this once.
 		GLOB.uplink_items -= src	//Take us out instead of leaving a null!
 	return ..()
 
-datum/uplink_item/proc/SpecialRequirements()
+/datum/uplink_item/proc/SpecialRequirements()
 	return TRUE
  
 //Discounts (dynamically filled above)
@@ -1323,10 +1323,11 @@ datum/uplink_item/proc/SpecialRequirements()
 	desc = "A box containing an cyborg upgrade module that instantly hacks a cyborg and unlocks the outlawed security module (in a inconspicuous black-and-red paintjob)"
 	item = /obj/item/storage/box/syndie_kit/traitorsec_boards
 	cost = 16
+	player_minimum = 20
 	restricted_roles = list("Roboticist", "Research Director")
 	
-	/datum/uplink_item/role_restricted/traitorsec/SpecialRequirement()
-		return !config.forbid_secborg
+/datum/uplink_item/role_restricted/traitorsec/SpecialRequirement()
+	return !config.forbid_secborg
 			
 // Pointless
 /datum/uplink_item/badass

--- a/code/modules/uplink/uplink_item.dm
+++ b/code/modules/uplink/uplink_item.dm
@@ -1313,6 +1313,14 @@ GLOBAL_LIST_EMPTY(uplink_items) // Global list so we only initialize this once.
 	limited_stock = 2 //you can't use more than two!
 	restricted_roles = list("Shaft Miner")
 
+/datum/uplink_item/role_restricted/traitorsec
+	name = "Bloodhound upgrade modules"
+ 	desc = "A box containing an cyborg upgrade module that instantly hacks a cyborg and unlocks the outlawed securiy module (in a inconspicuous black-and-red paintjob)"
+ 	item = /obj/item/storage/box/syndie_kit/traitorsec_boards
+ 	cost = 16
+ 	restricted_roles = list("Roboticist", "Research Director")
+ 	surplus = 5
+	
 // Pointless
 /datum/uplink_item/badass
 	category = "(Pointless) Badassery"

--- a/code/modules/uplink/uplink_item.dm
+++ b/code/modules/uplink/uplink_item.dm
@@ -1315,7 +1315,7 @@ GLOBAL_LIST_EMPTY(uplink_items) // Global list so we only initialize this once.
 
 /datum/uplink_item/role_restricted/traitorsec
 	name = "Oppressor Upgrade Module"
-	desc = "A box containing an cyborg upgrade module that instantly hacks a cyborg and unlocks the outlawed securiy module (in a inconspicuous black-and-red paintjob)"
+	desc = "A box containing an cyborg upgrade module that instantly hacks a cyborg and unlocks the outlawed security module (in a inconspicuous black-and-red paintjob)"
 	item = /obj/item/storage/box/syndie_kit/traitorsec_boards
 	cost = 16
 	restricted_roles = list("Roboticist", "Research Director")

--- a/code/modules/uplink/uplink_item.dm
+++ b/code/modules/uplink/uplink_item.dm
@@ -34,7 +34,7 @@ GLOBAL_LIST_EMPTY(uplink_items) // Global list so we only initialize this once.
 					continue
 			if(I.player_minimum && I.player_minimum > GLOB.joined_player_list.len)
 				continue
-			if(I.uplink_item.SpecialRequirements())
+			if(I.SpecialRequirements())
 				continue
 			
 			if(!filtered_uplink_items[category])

--- a/code/modules/uplink/uplink_item.dm
+++ b/code/modules/uplink/uplink_item.dm
@@ -34,7 +34,9 @@ GLOBAL_LIST_EMPTY(uplink_items) // Global list so we only initialize this once.
 					continue
 			if(I.player_minimum && I.player_minimum > GLOB.joined_player_list.len)
 				continue
-
+			if(uplink_item.SpecialRequirements())
+				continue
+			
 			if(!filtered_uplink_items[category])
 				filtered_uplink_items[category] = list()
 			filtered_uplink_items[category][item] = I
@@ -131,6 +133,9 @@ GLOBAL_LIST_EMPTY(uplink_items) // Global list so we only initialize this once.
 		GLOB.uplink_items -= src	//Take us out instead of leaving a null!
 	return ..()
 
+datum/uplink_item/proc/SpecialRequirements()
+	return TRUE
+ 
 //Discounts (dynamically filled above)
 /datum/uplink_item/discounts
 	category = "Discounted Gear"
@@ -1320,6 +1325,9 @@ GLOBAL_LIST_EMPTY(uplink_items) // Global list so we only initialize this once.
 	cost = 16
 	restricted_roles = list("Roboticist", "Research Director")
 	
+	/datum/uplink_item/role_restricted/traitorsec/SpecialRequirement()
+		return !config.forbid_secborg
+			
 // Pointless
 /datum/uplink_item/badass
 	category = "(Pointless) Badassery"


### PR DESCRIPTION
:cl: 
add: Added a roboticist-specific traitor item - the Oppressor upgrade module.
/:cl:

Adds an expensive traitor item that allows a roboticist to create a single security cyborg bound to do his evil bidding. The security cyborg comes in an obvious syndicate paintjob.

This PR was previously vetoed by PKPenguin, because he hates silicons and secborgs specifically. Now that his term is over, I'm posting an updated version.