### PR TITLE
Fixes the issue of potted plants not having their overlays when picked up/equipped.

### DIFF
--- a/code/game/objects/structures/flora.dm
+++ b/code/game/objects/structures/flora.dm
@@ -265,6 +265,7 @@
 
 /obj/item/twohanded/required/kirbyplants/equipped(mob/living/user)
 	var/image/I = image(icon = 'icons/obj/flora/plants.dmi' , icon_state = src.icon_state, loc = user)
+	I.copy_overlays(src)
 	I.override = 1
 	add_alt_appearance(/datum/atom_hud/alternate_appearance/basic/everyone, "sneaking_mission", I)
 	I.layer = ABOVE_MOB_LAYER


### PR DESCRIPTION
Basically what it says in the title. If a potted plant was bloody and it was picked up, it would suddenly be clean when it shows your alt appearance. This fixes that. A bloody potted plant when picked up will now give the correct bloody potted plant overlay to the alt appearance.

Fixes #30678 