### PR TITLE
Fixes blackbox artifact exploits

### DIFF
--- a/code/modules/mob/living/simple_animal/hostile/megafauna/colossus.dm
+++ b/code/modules/mob/living/simple_animal/hostile/megafauna/colossus.dm
@@ -250,7 +250,7 @@ Difficulty: Very Hard
 	use_power = NO_POWER_USE
 	var/memory_saved = FALSE
 	var/list/stored_items = list()
-	var/static/list/blacklist = typecacheof(list(/obj/item/spellbook))
+	var/list/blacklist = list()
 
 /obj/machinery/smartfridge/black_box/update_icon()
 	return
@@ -258,7 +258,8 @@ Difficulty: Very Hard
 /obj/machinery/smartfridge/black_box/accept_check(obj/item/O)
 	if(!istype(O))
 		return FALSE
-	if(is_type_in_typecache(O, blacklist))
+	if(O in blacklist)
+		visible_message("<span class='boldwarning'>[src] ripples as it rejects [O]. The device will not accept items that have been removed from it.</span>")
 		return FALSE
 	return TRUE
 
@@ -309,7 +310,8 @@ Difficulty: Very Hard
 //in it's own proc to avoid issues with items that nolonger exist in the code base.
 //try catch doesn't always prevent byond runtimes from halting a proc,
 /obj/machinery/smartfridge/black_box/proc/create_item(item_type)
-	new item_type(src)
+	var/obj/O = new item_type(src)
+	blacklist |= O
 
 /obj/machinery/smartfridge/black_box/Destroy(force = FALSE)
 	if(force)

--- a/code/modules/mob/living/simple_animal/hostile/megafauna/colossus.dm
+++ b/code/modules/mob/living/simple_animal/hostile/megafauna/colossus.dm
@@ -258,7 +258,7 @@ Difficulty: Very Hard
 /obj/machinery/smartfridge/black_box/accept_check(obj/item/O)
 	if(!istype(O))
 		return FALSE
-	if(O in blacklist)
+	if(blacklist[O])
 		visible_message("<span class='boldwarning'>[src] ripples as it rejects [O]. The device will not accept items that have been removed from it.</span>")
 		return FALSE
 	return TRUE
@@ -311,7 +311,7 @@ Difficulty: Very Hard
 //try catch doesn't always prevent byond runtimes from halting a proc,
 /obj/machinery/smartfridge/black_box/proc/create_item(item_type)
 	var/obj/O = new item_type(src)
-	blacklist |= O
+	blacklist[O] = TRUE
 
 /obj/machinery/smartfridge/black_box/Destroy(force = FALSE)
 	if(force)


### PR DESCRIPTION
You can't put an item back into the box after taking it out.

This prevents people from stashing uplinks/wizard books etc to withdraw them, use them, and then put them back in for another round.

This still isn't accessible to players again though
