### PR TITLE
Fixes chemfridges not displaying items with dots in their name properly

### DIFF
--- a/code/modules/food_and_drinks/kitchen_machinery/smartfridge.dm
+++ b/code/modules/food_and_drinks/kitchen_machinery/smartfridge.dm
@@ -158,10 +158,11 @@
 	for (var/I in src)
 		var/atom/movable/O = I
 		if (!QDELETED(O))
-			if (listofitems[O.name])
-				listofitems[O.name]["amount"]++
+			var/md5name = md5(O.name)				// This needs to happen because of a bug in a TGUI component, https://github.com/ractivejs/ractive/issues/744
+			if (listofitems[md5name])				// which is fixed in a version we cannot use due to ie8 incompatibility
+				listofitems[md5name]["amount"]++	// The good news is, #30519 made smartfridge UIs non-auto-updating
 			else
-				listofitems[O.name] = list("name" = O.name, "type" = O.type, "amount" = 1)
+				listofitems[md5name] = list("name" = O.name, "type" = O.type, "amount" = 1)
 	sortList(listofitems)
 
 	.["contents"] = listofitems


### PR DESCRIPTION
Fixes #30808 

The issue is actually not really in the byond code, but TGUI or rather ractive is unable to cope with dots in array keys. I thought about running the names through a replacer function but that would confuse things like 1.1u and 11u, and then it turned out byond doesn't even have a built-in function for that.

[Changelogs]: 
[]:


:cl: Naksu
fix: Fixed chemfridges being unable to display items with dots in their name
/:cl:

[why]: 
Bugfix.
