### PR TITLE
Zombie claws do +1 damage

### DIFF
--- a/code/modules/zombie/items.dm
+++ b/code/modules/zombie/items.dm
@@ -11,7 +11,7 @@
 	var/icon_left = "bloodhand_left"
 	var/icon_right = "bloodhand_right"
 	hitsound = 'sound/hallucinations/growl1.ogg'
-	force = 21
+	force = 21 // Just enough to break airlocks with melee attacks
 	damtype = "brute"
 
 	var/removing_airlock = FALSE

--- a/code/modules/zombie/items.dm
+++ b/code/modules/zombie/items.dm
@@ -11,7 +11,7 @@
 	var/icon_left = "bloodhand_left"
 	var/icon_right = "bloodhand_right"
 	hitsound = 'sound/hallucinations/growl1.ogg'
-	force = 20
+	force = 21
 	damtype = "brute"
 
 	var/removing_airlock = FALSE

--- a/html/changelogs/AutoChangeLog-pr-30056.yml
+++ b/html/changelogs/AutoChangeLog-pr-30056.yml
@@ -1,4 +1,0 @@
-author: "More Robust Than You"
-delete-after: True
-changes: 
-  - rscdel: "Finally fucking removed gangs"

--- a/html/changelogs/AutoChangeLog-pr-30056.yml
+++ b/html/changelogs/AutoChangeLog-pr-30056.yml
@@ -1,0 +1,4 @@
+author: "More Robust Than You"
+delete-after: True
+changes: 
+  - rscdel: "Finally fucking removed gangs"


### PR DESCRIPTION
The door deflection threshold was apparently raised to 21 from 20.

Zombie claws do 20.

The one thing I absolutely never wanted was for zombies to go back to the (sprint speed, instant conversion) days where they could be stopped by one of the most common objects on the station, an airlock.

So now they do 21. 