### PR TITLE
Log file for PDA messages

### DIFF
--- a/code/__HELPERS/_logging.dm
+++ b/code/__HELPERS/_logging.dm
@@ -85,7 +85,7 @@
 
 /proc/log_pda(text)
 	if (config.log_pda)
-		WRITE_FILE(GLOB.world_game_log, "\[[time_stamp()]]PDA: [text]")
+		WRITE_FILE(GLOB.world_pda_log, "\[[time_stamp()]]PDA: [text]")
 
 /proc/log_comment(text)
 	if (config.log_pda)

--- a/code/_globalvars/logging.dm
+++ b/code/_globalvars/logging.dm
@@ -16,6 +16,8 @@ GLOBAL_VAR(config_error_log)
 GLOBAL_PROTECT(config_error_log)
 GLOBAL_VAR(sql_error_log)
 GLOBAL_PROTECT(sql_error_log)
+GLOBAL_VAR(world_pda_log)
+GLOBAL_PROTECT(world_pda_log)
 
 GLOBAL_LIST_EMPTY(bombers)
 GLOBAL_PROTECT(bombers)

--- a/code/game/world.dm
+++ b/code/game/world.dm
@@ -6,7 +6,7 @@ GLOBAL_PROTECT(security_mode)
 
 	SetupExternalRSC()
 
-	GLOB.config_error_log = GLOB.sql_error_log = GLOB.world_href_log = GLOB.world_runtime_log = GLOB.world_attack_log = GLOB.world_game_log = file("data/logs/config_error.log") //temporary file used to record errors with loading config, moved to log directory once logging is set bl
+	GLOB.config_error_log = GLOB.world_pda_log = GLOB.sql_error_log = GLOB.world_href_log = GLOB.world_runtime_log = GLOB.world_attack_log = GLOB.world_game_log = file("data/logs/config_error.log") //temporary file used to record errors with loading config, moved to log directory once logging is set bl
 
 	CheckSecurityMode()
 
@@ -88,10 +88,12 @@ GLOBAL_PROTECT(security_mode)
 	GLOB.world_runtime_log = file("[GLOB.log_directory]/runtime.log")
 	GLOB.world_qdel_log = file("[GLOB.log_directory]/qdel.log")
 	GLOB.world_href_log = file("[GLOB.log_directory]/hrefs.html")
+	GLOB.world_pda_log = file("[GLOB.log_directory]/pda.log")
 	GLOB.sql_error_log = file("[GLOB.log_directory]/sql.log")
 	WRITE_FILE(GLOB.world_game_log, "\n\nStarting up round ID [GLOB.round_id]. [time_stamp()]\n---------------------")
 	WRITE_FILE(GLOB.world_attack_log, "\n\nStarting up round ID [GLOB.round_id]. [time_stamp()]\n---------------------")
 	WRITE_FILE(GLOB.world_runtime_log, "\n\nStarting up round ID [GLOB.round_id]. [time_stamp()]\n---------------------")
+	WRITE_FILE(GLOB.world_pda_log, "\n\nStarting up round ID [GLOB.round_id]. [time_stamp()]\n---------------------")
 	GLOB.changelog_hash = md5('html/changelog.html')					//used for telling if the changelog has changed recently
 	if(fexists(GLOB.config_error_log))
 		fcopy(GLOB.config_error_log, "[GLOB.log_directory]/config_error.log")
@@ -106,7 +108,7 @@ GLOBAL_PROTECT(security_mode)
 		GLOB.security_mode = SECURITY_ULTRASAFE
 		warning("/tg/station 13 is not supported in ultrasafe security mode. Everything will break!")
 		return
-	
+
 	//try to shell
 	if(shell("echo \"The world is running in trusted mode\"") != null)
 		GLOB.security_mode = SECURITY_TRUSTED


### PR DESCRIPTION
Separate log for PDA messages per request from #30606

If you're wondering where the actual logging is: PDAs call `log_talk()` with `LOGPDA` argument, which calls `log_pda()`