### PR TITLE
Make scrubber code use temporary vars consistently

### DIFF
--- a/code/modules/atmospherics/machinery/components/unary_devices/vent_scrubber.dm
+++ b/code/modules/atmospherics/machinery/components/unary_devices/vent_scrubber.dm
@@ -198,37 +198,37 @@
 			if(scrub_Toxins && removed_gases["plasma"])
 				filtered_out.assert_gas("plasma")
 				filtered_gases["plasma"][MOLES] = removed_gases["plasma"][MOLES]
-				removed.gases["plasma"][MOLES] = 0
+				removed_gases["plasma"][MOLES] = 0
 
 			if(scrub_CO2 && removed_gases["co2"])
 				filtered_out.assert_gas("co2")
-				filtered_out.gases["co2"][MOLES] = removed_gases["co2"][MOLES]
-				removed.gases["co2"][MOLES] = 0
+				filtered_gases["co2"][MOLES] = removed_gases["co2"][MOLES]
+				removed_gases["co2"][MOLES] = 0
 
 			if(removed_gases["agent_b"])
 				filtered_out.assert_gas("agent_b")
-				filtered_out.gases["agent_b"][MOLES] = removed_gases["agent_b"][MOLES]
-				removed.gases["agent_b"][MOLES] = 0
+				filtered_gases["agent_b"][MOLES] = removed_gases["agent_b"][MOLES]
+				removed_gases["agent_b"][MOLES] = 0
 
 			if(scrub_N2O && removed_gases["n2o"])
 				filtered_out.assert_gas("n2o")
-				filtered_out.gases["n2o"][MOLES] = removed_gases["n2o"][MOLES]
-				removed.gases["n2o"][MOLES] = 0
+				filtered_gases["n2o"][MOLES] = removed_gases["n2o"][MOLES]
+				removed_gases["n2o"][MOLES] = 0
 
 			if(scrub_BZ && removed_gases["bz"])
 				filtered_out.assert_gas("bz")
-				filtered_out.gases["bz"][MOLES] = removed_gases["bz"][MOLES]
-				removed.gases["bz"][MOLES] = 0
+				filtered_gases["bz"][MOLES] = removed_gases["bz"][MOLES]
+				removed_gases["bz"][MOLES] = 0
 
 			if(scrub_Freon && removed_gases["freon"])
 				filtered_out.assert_gas("freon")
-				filtered_out.gases["freon"][MOLES] = removed_gases["freon"][MOLES]
-				removed.gases["freon"][MOLES] = 0
+				filtered_gases["freon"][MOLES] = removed_gases["freon"][MOLES]
+				removed_gases["freon"][MOLES] = 0
 
 			if(scrub_WaterVapor && removed_gases["water_vapor"])
 				filtered_out.assert_gas("water_vapor")
-				filtered_out.gases["water_vapor"][MOLES] = removed_gases["water_vapor"][MOLES]
-				removed.gases["water_vapor"][MOLES] = 0
+				filtered_gases["water_vapor"][MOLES] = removed_gases["water_vapor"][MOLES]
+				removed_gases["water_vapor"][MOLES] = 0
 
 			removed.garbage_collect()
 

--- a/code/modules/atmospherics/machinery/components/unary_devices/vent_scrubber.dm
+++ b/code/modules/atmospherics/machinery/components/unary_devices/vent_scrubber.dm
@@ -196,37 +196,37 @@
 			filtered_out.temperature = removed.temperature
 
 			if(scrub_Toxins && removed_gases["plasma"])
-				filtered_out.assert_gas("plasma")
+				filtered_out.add_gas("plasma")
 				filtered_gases["plasma"][MOLES] = removed_gases["plasma"][MOLES]
 				removed_gases["plasma"][MOLES] = 0
 
 			if(scrub_CO2 && removed_gases["co2"])
-				filtered_out.assert_gas("co2")
+				filtered_out.add_gas("co2")
 				filtered_gases["co2"][MOLES] = removed_gases["co2"][MOLES]
 				removed_gases["co2"][MOLES] = 0
 
 			if(removed_gases["agent_b"])
-				filtered_out.assert_gas("agent_b")
+				filtered_out.add_gas("agent_b")
 				filtered_gases["agent_b"][MOLES] = removed_gases["agent_b"][MOLES]
 				removed_gases["agent_b"][MOLES] = 0
 
 			if(scrub_N2O && removed_gases["n2o"])
-				filtered_out.assert_gas("n2o")
+				filtered_out.add_gas("n2o")
 				filtered_gases["n2o"][MOLES] = removed_gases["n2o"][MOLES]
 				removed_gases["n2o"][MOLES] = 0
 
 			if(scrub_BZ && removed_gases["bz"])
-				filtered_out.assert_gas("bz")
+				filtered_out.add_gas("bz")
 				filtered_gases["bz"][MOLES] = removed_gases["bz"][MOLES]
 				removed_gases["bz"][MOLES] = 0
 
 			if(scrub_Freon && removed_gases["freon"])
-				filtered_out.assert_gas("freon")
+				filtered_out.add_gas("freon")
 				filtered_gases["freon"][MOLES] = removed_gases["freon"][MOLES]
 				removed_gases["freon"][MOLES] = 0
 
 			if(scrub_WaterVapor && removed_gases["water_vapor"])
-				filtered_out.assert_gas("water_vapor")
+				filtered_out.add_gas("water_vapor")
 				filtered_gases["water_vapor"][MOLES] = removed_gases["water_vapor"][MOLES]
 				removed_gases["water_vapor"][MOLES] = 0
 


### PR DESCRIPTION
There was inconsistent usage of temporary vars in scrubber code. Some of the code was using the temporary vars, some of the code was not. This changes the code to be consistent and only use temporary vars.

Originally I had made a PR with the alternative solution of just removing the temporary vars, but then I found this comment elsewhere in the code:

	var/list/removed_gases = removed.gases //accessing datum vars is slower than proc vars

So use of these is 100% deliberate and intended.