### PR TITLE
Fixes species being referenced instead of copied when cloning

### DIFF
--- a/code/datums/dna.dm
+++ b/code/datums/dna.dm
@@ -230,7 +230,8 @@
 		dna.features = newfeatures
 
 	if(mrace)
-		set_species(mrace, icon_update=0)
+		var/datum/species/newrace = new mrace
+		set_species(newrace, icon_update=0)
 
 	if(newreal_name)
 		real_name = newreal_name

--- a/code/datums/dna.dm
+++ b/code/datums/dna.dm
@@ -230,7 +230,7 @@
 		dna.features = newfeatures
 
 	if(mrace)
-		var/datum/species/newrace = new mrace
+		var/datum/species/newrace = new mrace.type
 		set_species(newrace, icon_update=0)
 
 	if(newreal_name)

--- a/code/datums/dna.dm
+++ b/code/datums/dna.dm
@@ -231,6 +231,7 @@
 
 	if(mrace)
 		var/datum/species/newrace = new mrace.type
+		newrace.copy_properties_from(mrace)
 		set_species(newrace, icon_update=0)
 
 	if(newreal_name)

--- a/code/modules/mob/living/carbon/human/species.dm
+++ b/code/modules/mob/living/carbon/human/species.dm
@@ -106,6 +106,9 @@
 
 	return randname
 
+//Called when cloning, copies some vars that should be kept
+/datum/species/proc/copy_properties_from(datum/species/old_species)
+	return
 
 //Please override this locally if you want to define when what species qualifies for what rank if human authority is enforced.
 /datum/species/proc/qualifies_for_rank(rank, list/features)

--- a/code/modules/mob/living/carbon/human/species_types/abductors.dm
+++ b/code/modules/mob/living/carbon/human/species_types/abductors.dm
@@ -8,6 +8,6 @@
 	var/scientist = 0 // vars to not pollute spieces list with castes
 	var/team = 1
 
-/datum/species/abductor/copy_properties_from(datum/species/old_species)
+/datum/species/abductor/copy_properties_from(datum/species/abductor/old_species)
 	scientist = old_species.scientist
 	team = old_species.team

--- a/code/modules/mob/living/carbon/human/species_types/abductors.dm
+++ b/code/modules/mob/living/carbon/human/species_types/abductors.dm
@@ -7,3 +7,7 @@
 	mutanttongue = /obj/item/organ/tongue/abductor
 	var/scientist = 0 // vars to not pollute spieces list with castes
 	var/team = 1
+
+/datum/species/abductor/copy_properties_from(datum/species/old_species)
+	scientist = old_species.scientist
+	team = old_species.team

--- a/code/modules/mob/living/carbon/human/species_types/angel.dm
+++ b/code/modules/mob/living/carbon/human/species_types/angel.dm
@@ -18,10 +18,9 @@
 	if(H.dna && H.dna.species &&((H.dna.features["wings"] != "Angel") && ("wings" in H.dna.species.mutant_bodyparts)))
 		H.dna.features["wings"] = "Angel"
 		H.update_body()
-	if(ishuman(H)&& !fly)
+	if(ishuman(H) && !fly)
 		fly = new
 		fly.Grant(H)
-
 
 /datum/species/angel/on_species_loss(mob/living/carbon/human/H)
 	if(fly)

--- a/code/modules/mob/living/carbon/human/species_types/jellypeople.dm
+++ b/code/modules/mob/living/carbon/human/species_types/jellypeople.dm
@@ -59,6 +59,7 @@
 	name = "Regenerate Limbs"
 	check_flags = AB_CHECK_CONSCIOUS
 	button_icon_state = "slimeheal"
+	icon_icon = 'icons/mob/actions/actions_slime.dmi'
 	background_icon_state = "bg_alien"
 
 /datum/action/innate/regenerate_limbs/IsAvailable()
@@ -153,6 +154,7 @@
 	name = "Split Body"
 	check_flags = AB_CHECK_CONSCIOUS
 	button_icon_state = "slimesplit"
+	icon_icon = 'icons/mob/actions/actions_slime.dmi'
 	background_icon_state = "bg_alien"
 
 /datum/action/innate/split_body/IsAvailable()
@@ -219,6 +221,7 @@
 	name = "Swap Body"
 	check_flags = AB_CHECK_CONSCIOUS
 	button_icon_state = "slimeswap"
+	icon_icon = 'icons/mob/actions/actions_slime.dmi'
 	background_icon_state = "bg_alien"
 
 /datum/action/innate/swap_body/Activate()

--- a/code/modules/mob/living/carbon/human/species_types/jellypeople.dm
+++ b/code/modules/mob/living/carbon/human/species_types/jellypeople.dm
@@ -141,7 +141,7 @@
 	C.faction |= "slime"
 
 //If you're cloned you get your body pool back
-/datum/species/jelly/slime/copy_properties_from(datum/species/old_species)
+/datum/species/jelly/slime/copy_properties_from(datum/species/jelly/slime/old_species)
 	bodies = old_species.bodies
 
 /datum/species/jelly/slime/spec_life(mob/living/carbon/human/H)

--- a/code/modules/mob/living/carbon/human/species_types/jellypeople.dm
+++ b/code/modules/mob/living/carbon/human/species_types/jellypeople.dm
@@ -140,6 +140,10 @@
 
 	C.faction |= "slime"
 
+//If you're cloned you get your body pool back
+/datum/species/jelly/slime/copy_properties_from(datum/species/old_species)
+	bodies = old_species.bodies
+
 /datum/species/jelly/slime/spec_life(mob/living/carbon/human/H)
 	if(H.blood_volume >= BLOOD_VOLUME_SLIME_SPLIT)
 		if(prob(5))


### PR DESCRIPTION
Fixes #30817 
Probably hasn't happened yet, but technically the old and new bodies share ability cooldowns and species vars. This fixes that.

Slimepeople still keep their body pool and abductors keep their team status after cloning.

Also fixes broken slime icons.