### PR TITLE
Fixes action buttons after cloning

### DIFF
--- a/code/game/machinery/cloning.dm
+++ b/code/game/machinery/cloning.dm
@@ -370,6 +370,7 @@
 	for(var/fl in unattached_flesh)
 		qdel(fl)
 	unattached_flesh.Cut()
+	mob_occupant.update_action_buttons() 
 
 	occupant = null
 


### PR DESCRIPTION
:cl:
fix: Action buttons are now updated after cloning, this should fix angel wings and any other inherent power that should be persistent after death; like action buttons for mutations if we ever go that way.
/:cl:

fixes: #30817 