### PR TITLE
Makes the sleepy pen single use

### DIFF
--- a/code/modules/paperwork/pen.dm
+++ b/code/modules/paperwork/pen.dm
@@ -168,7 +168,7 @@
  */
 /obj/item/pen/sleepy
 	origin_tech = "engineering=4;syndicate=2"
-	container_type = OPENCONTAINER_1
+	container_type = NONE
 
 
 /obj/item/pen/sleepy/attack(mob/living/M, mob/user)


### PR DESCRIPTION
🆑 ShizCalev
balance: The sleepy pen is now a single use item which CANNOT be refilled.
/🆑

Fixes #30838 
Closes #30842 
Closes #30865