### PR TITLE
Fixes it so patches do not work on robotic limbs.

### DIFF
--- a/code/modules/reagents/reagent_containers/patch.dm
+++ b/code/modules/reagents/reagent_containers/patch.dm
@@ -13,6 +13,14 @@
 /obj/item/reagent_containers/pill/patch/afterattack(obj/target, mob/user , proximity)
 	return // thanks inheritance again
 
+/obj/item/reagent_containers/pill/patch/attack(mob/living/L, mob/user)
+	if(ishuman(L))
+		var/obj/item/bodypart/affecting = L.get_bodypart(check_zone(user.zone_selected))
+		if(affecting.status != BODYPART_ORGANIC)
+			to_chat(user, "<span class='notice'>Medicine won't work on a robotic limb!</span>")
+			return
+	..()
+
 /obj/item/reagent_containers/pill/patch/canconsume(mob/eater, mob/user)
 	if(!iscarbon(eater))
 		return 0


### PR DESCRIPTION
Patches can now no longer be used on robotic limbs. Tested this with both the stock brute and burn patches, and they did not work on the robotic limbs. When I healed other, normal, damaged limbs with them, they healed the organic limbs, but still left the robotic ones alone.

I would appreciate it if a maintainer could also test this to doubly make sure it works properly.

Fixes #11854

Half of the credit also goes to @bgobandit for their previous, unfortunately closed, bugfix PR.