### PR TITLE
Fix pipenets

### DIFF
--- a/code/modules/atmospherics/machinery/datum_pipeline.dm
+++ b/code/modules/atmospherics/machinery/datum_pipeline.dm
@@ -5,7 +5,7 @@
 	var/list/obj/machinery/atmospherics/pipe/members
 	var/list/obj/machinery/atmospherics/components/other_atmosmch
 
-	var/update = 1
+	var/update = TRUE
 
 /datum/pipeline/New()
 	other_airs = list()
@@ -25,7 +25,7 @@
 
 /datum/pipeline/process()
 	if(update)
-		update = 0
+		update = FALSE
 		reconcile_air()
 	update = air.react()
 
@@ -114,6 +114,7 @@
 	other_airs.Add(E.other_airs)
 	E.members.Cut()
 	E.other_atmosmch.Cut()
+	update = TRUE
 	qdel(E)
 
 /obj/machinery/atmospherics/proc/addMember(obj/machinery/atmospherics/A)
@@ -195,7 +196,7 @@
 				(partial_heat_capacity*target.heat_capacity/(partial_heat_capacity+target.heat_capacity))
 
 			air.temperature -= heat/total_heat_capacity
-	update = 1
+	update = TRUE
 
 /datum/pipeline/proc/return_air()
 	. = other_airs + air


### PR DESCRIPTION
Wew this took a long time to figure out. Basically, `/datum/pipeline/proc/merge` was ignoring the `update` flag of the pipeline it was merging from, causing the merged pipe to not update properly and get stuck in a weird non-updating state.

This was very easy to trigger. All you had to do was add a pipe onto an existing pipenet and watch as everything broke. 

Fixes #28990
Also probably the solution to #30737 and #30305 but I'm not 100% sure

:cl: Pubby
fix: Atmos pipenets are less glitchy
/:cl: