### PR TITLE
Secure containers give more hints, no RNG, for hacking

### DIFF
--- a/code/game/objects/items/storage/secure.dm
+++ b/code/game/objects/items/storage/secure.dm
@@ -37,7 +37,7 @@
 				src.open =! src.open
 				user.show_message("<span class='notice'>You [open ? "open" : "close"] the service panel.</span>", 1)
 			return
-		if (istype(W, /obj/item/wirecutters) || istype(W, /obj/item/card/emag)
+		if (istype(W, /obj/item/wirecutters) || istype(W, /obj/item/card/emag))
 			user.show_message("<span class='danger'>The [src] is protected from this sort of tampering, perhaps a <b>multitool</b> could pulse the wires controlling internal memory instead?</span>", 1)
 		if ((istype(W, /obj/item/device/multitool)) && (!src.l_hacking))
 			if(src.open == 1)

--- a/code/game/objects/items/storage/secure.dm
+++ b/code/game/objects/items/storage/secure.dm
@@ -28,7 +28,7 @@
 
 /obj/item/storage/secure/examine(mob/user)
 	..()
-	to_chat(user, text("The service panel is [src.open ? "open" : "closed"]."))
+	to_chat(user, text("The service panel is current <b>[src.open ? "unscrewed" : "screwed shut"]</b>."))
 
 /obj/item/storage/secure/attackby(obj/item/W, mob/user, params)
 	if(locked)
@@ -37,20 +37,15 @@
 				src.open =! src.open
 				user.show_message("<span class='notice'>You [open ? "open" : "close"] the service panel.</span>", 1)
 			return
+		if (istype(W, /obj/item/wirecutters))
+			user.show_message("<span class='notice'>These wires are too strong for wirecutters, perhaps a <b>multitool</b> could pulse them instead...</span>", 1)
 		if ((istype(W, /obj/item/device/multitool)) && (src.open == 1)&& (!src.l_hacking))
 			user.show_message("<span class='danger'>Now attempting to reset internal memory, please hold.</span>", 1)
 			src.l_hacking = 1
-			if (do_after(usr, 100*W.toolspeed, target = src))
-				if (prob(33))
-					src.l_setshort = 1
-					src.l_set = 0
-					user.show_message("<span class='danger'>Internal memory reset.  Please give it a few seconds to reinitialize.</span>", 1)
-					sleep(80)
-					src.l_setshort = 0
-					src.l_hacking = 0
-				else
-					user.show_message("<span class='danger'>Unable to reset internal memory.</span>", 1)
-					src.l_hacking = 0
+			if (do_after(usr, 400*W.toolspeed, target = src))
+				user.show_message("<span class='danger'>Internal memory reset - lock has been disengaged.</span>", 1)
+				src.l_set = 0
+				src.l_hacking = 0
 			else
 				src.l_hacking = 0
 			return

--- a/code/game/objects/items/storage/secure.dm
+++ b/code/game/objects/items/storage/secure.dm
@@ -38,7 +38,7 @@
 				to_chat(user, "<span class='notice'>You [open ? "open" : "close"] the service panel.</span>")
 			return
 		if (istype(W, /obj/item/wirecutters) || istype(W, /obj/item/card/emag))
-			to_chat(user, "<span class='danger'>[src] is protected from this sort of tampering, perhaps a <b>multitool</b> could pulse the wires controlling internal memory instead?</span>")
+			to_chat(user, "<span class='danger'>[src] is protected from this sort of tampering, yet it appears the internal memory wires can still be <b>pulsed</b>.</span>")
 		if ((istype(W, /obj/item/device/multitool)) && (!l_hacking))
 			if(src.open == 1)
 				to_chat(user, "<span class='danger'>Now attempting to reset internal memory, please hold.</span>")

--- a/code/game/objects/items/storage/secure.dm
+++ b/code/game/objects/items/storage/secure.dm
@@ -38,7 +38,7 @@
 				to_chat(user, "<span class='notice'>You [open ? "open" : "close"] the service panel.</span>")
 			return
 		if (istype(W, /obj/item/wirecutters) || istype(W, /obj/item/card/emag))
-			to_chat(user, "<span class='danger'>The [src] is protected from this sort of tampering, perhaps a <b>multitool</b> could pulse the wires controlling internal memory instead?</span>")
+			to_chat(user, "<span class='danger'>[src] is protected from this sort of tampering, perhaps a <b>multitool</b> could pulse the wires controlling internal memory instead?</span>")
 		if ((istype(W, /obj/item/device/multitool)) && (!l_hacking))
 			if(src.open == 1)
 				to_chat(user, "<span class='danger'>Now attempting to reset internal memory, please hold.</span>")

--- a/code/game/objects/items/storage/secure.dm
+++ b/code/game/objects/items/storage/secure.dm
@@ -37,17 +37,20 @@
 				src.open =! src.open
 				user.show_message("<span class='notice'>You [open ? "open" : "close"] the service panel.</span>", 1)
 			return
-		if (istype(W, /obj/item/wirecutters))
-			user.show_message("<span class='notice'>These wires are too strong for wirecutters, perhaps a <b>multitool</b> could pulse them instead...</span>", 1)
-		if ((istype(W, /obj/item/device/multitool)) && (src.open == 1)&& (!src.l_hacking))
-			user.show_message("<span class='danger'>Now attempting to reset internal memory, please hold.</span>", 1)
-			src.l_hacking = 1
-			if (do_after(usr, 400*W.toolspeed, target = src))
-				user.show_message("<span class='danger'>Internal memory reset - lock has been disengaged.</span>", 1)
-				src.l_set = 0
-				src.l_hacking = 0
+		if (istype(W, /obj/item/wirecutters) || istype(W, /obj/item/card/emag)
+			user.show_message("<span class='danger'>The [src] is protected from this sort of tampering, perhaps a <b>multitool</b> could pulse the wires controlling internal memory instead?</span>", 1)
+		if ((istype(W, /obj/item/device/multitool)) && (!src.l_hacking))
+			if(src.open == 1)
+				user.show_message("<span class='danger'>Now attempting to reset internal memory, please hold.</span>", 1)
+				src.l_hacking = 1
+				if (do_after(usr, 400*W.toolspeed, target = src))
+					user.show_message("<span class='danger'>Internal memory reset - lock has been disengaged.</span>", 1)
+					src.l_set = 0
+					src.l_hacking = 0
+				else
+					src.l_hacking = 0
 			else
-				src.l_hacking = 0
+				user.show_message("<span class='notice'>You must <b>unscrew</b> the service panel before you can pulse the wiring.</span>", 1)
 			return
 		//At this point you have exhausted all the special things to do when locked
 		// ... but it's still locked.

--- a/code/game/objects/items/storage/secure.dm
+++ b/code/game/objects/items/storage/secure.dm
@@ -28,29 +28,29 @@
 
 /obj/item/storage/secure/examine(mob/user)
 	..()
-	to_chat(user, text("The service panel is currently <b>[src.open ? "unscrewed" : "screwed shut"]</b>."))
+	to_chat(user, text("The service panel is currently <b>[open ? "unscrewed" : "screwed shut"]</b>."))
 
 /obj/item/storage/secure/attackby(obj/item/W, mob/user, params)
 	if(locked)
 		if (istype(W, /obj/item/screwdriver))
 			if (do_after(user, 20*W.toolspeed, target = src))
-				src.open =! src.open
-				user.show_message("<span class='notice'>You [open ? "open" : "close"] the service panel.</span>", 1)
+				open =! open
+				to_chat(user, "<span class='notice'>You [open ? "open" : "close"] the service panel.</span>")
 			return
 		if (istype(W, /obj/item/wirecutters) || istype(W, /obj/item/card/emag))
-			user.show_message("<span class='danger'>The [src] is protected from this sort of tampering, perhaps a <b>multitool</b> could pulse the wires controlling internal memory instead?</span>", 1)
-		if ((istype(W, /obj/item/device/multitool)) && (!src.l_hacking))
+			to_chat(user, "<span class='danger'>The [src] is protected from this sort of tampering, perhaps a <b>multitool</b> could pulse the wires controlling internal memory instead?</span>")
+		if ((istype(W, /obj/item/device/multitool)) && (!l_hacking))
 			if(src.open == 1)
-				user.show_message("<span class='danger'>Now attempting to reset internal memory, please hold.</span>", 1)
+				to_chat(user, "<span class='danger'>Now attempting to reset internal memory, please hold.</span>")
 				src.l_hacking = 1
 				if (do_after(usr, 400*W.toolspeed, target = src))
-					user.show_message("<span class='danger'>Internal memory reset - lock has been disengaged.</span>", 1)
+					to_chat(user, "<span class='danger'>Internal memory reset - lock has been disengaged.</span>")
 					src.l_set = 0
 					src.l_hacking = 0
 				else
 					src.l_hacking = 0
 			else
-				user.show_message("<span class='notice'>You must <b>unscrew</b> the service panel before you can pulse the wiring.</span>", 1)
+				to_chat(user, "<span class='notice'>You must <b>unscrew</b> the service panel before you can pulse the wiring.</span>")
 			return
 		//At this point you have exhausted all the special things to do when locked
 		// ... but it's still locked.

--- a/code/game/objects/items/storage/secure.dm
+++ b/code/game/objects/items/storage/secure.dm
@@ -28,7 +28,7 @@
 
 /obj/item/storage/secure/examine(mob/user)
 	..()
-	to_chat(user, text("The service panel is current <b>[src.open ? "unscrewed" : "screwed shut"]</b>."))
+	to_chat(user, text("The service panel is currently <b>[src.open ? "unscrewed" : "screwed shut"]</b>."))
 
 /obj/item/storage/secure/attackby(obj/item/W, mob/user, params)
 	if(locked)

--- a/code/game/objects/items/storage/secure.dm
+++ b/code/game/objects/items/storage/secure.dm
@@ -33,7 +33,7 @@
 /obj/item/storage/secure/attackby(obj/item/W, mob/user, params)
 	if(locked)
 		if (istype(W, /obj/item/screwdriver))
-			if (do_after(user, 20*W.toolspeed, target = src))
+			if (do_after(user, 20*W.toolspeed, target = user))
 				open =! open
 				to_chat(user, "<span class='notice'>You [open ? "open" : "close"] the service panel.</span>")
 			return
@@ -43,7 +43,7 @@
 			if(src.open == 1)
 				to_chat(user, "<span class='danger'>Now attempting to reset internal memory, please hold.</span>")
 				src.l_hacking = 1
-				if (do_after(usr, 400*W.toolspeed, target = src))
+				if (do_after(usr, 400*W.toolspeed, target = user))
 					to_chat(user, "<span class='danger'>Internal memory reset - lock has been disengaged.</span>")
 					src.l_set = 0
 					src.l_hacking = 0

--- a/html/changelogs/AutoChangeLog-pr-30056.yml
+++ b/html/changelogs/AutoChangeLog-pr-30056.yml
@@ -1,4 +1,0 @@
-author: "More Robust Than You"
-delete-after: True
-changes: 
-  - rscdel: "Finally fucking removed gangs"

--- a/html/changelogs/AutoChangeLog-pr-30056.yml
+++ b/html/changelogs/AutoChangeLog-pr-30056.yml
@@ -1,0 +1,4 @@
+author: "More Robust Than You"
+delete-after: True
+changes: 
+  - rscdel: "Finally fucking removed gangs"


### PR DESCRIPTION
:cl: Robustin
tweak: Hacking a secure container with a multitool now takes longer, but no longer has a chance to fail. 
/:cl:

Since making the case emaggable turned into a bikeshed debate I've turned to this less controversial option for my own health and sanity. The case now offers multiple hints on how to hack it, and the hack time is now 4x as long to account for removing the 75% chance of failure - and to keep in-line with the container's purpose as something that shouldn't be easily cracked. 
