### PR TITLE
Sleepypen refills are now capped at 15 volume

### DIFF
--- a/code/modules/paperwork/pen.dm
+++ b/code/modules/paperwork/pen.dm
@@ -186,6 +186,7 @@
 	reagents.add_reagent("chloralhydrate2", 20)
 	reagents.add_reagent("mutetoxin", 15)
 	reagents.add_reagent("tirizene", 10)
+	reagents.max_volume = 15 // Refills won't be as potent
 	..()
 
 /*

--- a/code/modules/paperwork/pen.dm
+++ b/code/modules/paperwork/pen.dm
@@ -186,7 +186,7 @@
 	reagents.add_reagent("chloralhydrate2", 20)
 	reagents.add_reagent("mutetoxin", 15)
 	reagents.add_reagent("tirizene", 10)
-	reagents.max_volume = 15 // Refills won't be as potent
+	reagents.maximum_volume = 15 // Refills won't be as potent
 	..()
 
 /*

--- a/html/changelogs/AutoChangeLog-pr-30056.yml
+++ b/html/changelogs/AutoChangeLog-pr-30056.yml
@@ -1,4 +1,0 @@
-author: "More Robust Than You"
-delete-after: True
-changes: 
-  - rscdel: "Finally fucking removed gangs"

--- a/html/changelogs/AutoChangeLog-pr-30056.yml
+++ b/html/changelogs/AutoChangeLog-pr-30056.yml
@@ -1,0 +1,4 @@
+author: "More Robust Than You"
+delete-after: True
+changes: 
+  - rscdel: "Finally fucking removed gangs"


### PR DESCRIPTION
:cl: Robustin
balance: Sleepypens can now only be refilled with 15 units of chemicals, down from 45. 
/:cl:

Long overdue change. Saw another PR trying to remove the refill function outright, so I'm going to pull the rare dick move of opening a competing PR to #30840 so that we can produce a more reasonable solution. 

Closes #30840 