### PR TITLE
Neurotoxin now only applies its stun up front

### DIFF
--- a/code/modules/reagents/chemistry/reagents/alcohol_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/alcohol_reagents.dm
@@ -1161,9 +1161,10 @@ All effects don't start immediately, but rather get worse over time; the rate is
 	glass_name = "Neurotoxin"
 	glass_desc = "A drink that is guaranteed to knock you silly."
 
-/datum/reagent/consumable/ethanol/neurotoxin/reaction_mob(mob/living/M, method=TOUCH, reac_volume)
-	M.Knockdown(reac_volume*2, 1, 0)
-	..()
+/datum/reagent/consumable/ethanol/neurotoxin/on_mob_add(mob/M)
+	iscarbon(M)
+		M.Knockdown(reac_volume*2, 1, 0)
+		..()
 
 /datum/reagent/consumable/ethanol/neurotoxin/on_mob_life(mob/living/carbon/M)
 	M.dizziness +=6

--- a/code/modules/reagents/chemistry/reagents/alcohol_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/alcohol_reagents.dm
@@ -1162,7 +1162,7 @@ All effects don't start immediately, but rather get worse over time; the rate is
 	glass_desc = "A drink that is guaranteed to knock you silly."
 
 /datum/reagent/consumable/ethanol/neurotoxin/reaction_mob(mob/living/M, method=TOUCH, reac_volume)
-	M.Knockdown(reac_volume, 1, 0)
+	M.Knockdown(reac_volume*2, 1, 0)
 	..()
 
 /datum/reagent/consumable/ethanol/neurotoxin/on_mob_life(mob/living/carbon/M)

--- a/code/modules/reagents/chemistry/reagents/alcohol_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/alcohol_reagents.dm
@@ -1161,8 +1161,11 @@ All effects don't start immediately, but rather get worse over time; the rate is
 	glass_name = "Neurotoxin"
 	glass_desc = "A drink that is guaranteed to knock you silly."
 
+/datum/reagent/consumable/ethanol/neurotoxin/reaction_mob(mob/living/M, method=TOUCH, reac_volume)
+	M.Knockdown(reac_volume, 1, 0)
+	..()
+
 /datum/reagent/consumable/ethanol/neurotoxin/on_mob_life(mob/living/carbon/M)
-	M.Knockdown(60, 1, 0)
 	M.dizziness +=6
 	switch(current_cycle)
 		if(15 to 45)


### PR DESCRIPTION
:cl:
balance: Neurotoxin now only applies its stun up front, amount of stun based on volume.
/:cl:

Neurotoxin is so fucking busted it basically mandates #30865 and #30840 as well as this. Your fucked for as long as you have it in your system and it processes very slowly. This makes it less meme without taking what makes it special. numbers very open to change