### PR TITLE
Remove ash drake hide from lesser ash drakes butcher loot

### DIFF
--- a/code/modules/mob/living/simple_animal/hostile/megafauna/dragon.dm
+++ b/code/modules/mob/living/simple_animal/hostile/megafauna/dragon.dm
@@ -384,6 +384,7 @@ Difficulty: Medium
 	melee_damage_lower = 30
 	damage_coeff = list(BRUTE = 1, BURN = 1, TOX = 1, CLONE = 1, STAMINA = 0, OXY = 1)
 	loot = list()
+	butcher_results = list(/obj/item/ore/diamond = 5, /obj/item/stack/sheet/sinew = 5, /obj/item/stack/sheet/bone = 30)
 
 /mob/living/simple_animal/hostile/megafauna/dragon/lesser/grant_achievement(medaltype,scoretype)
 	return


### PR DESCRIPTION
:cl: Arianya
balance: Lesser ash drakes no longer drop ash drake hide when butchered. 
/:cl:

Lesser ash drakes are much easier to kill then their greater brethren, hence the lack of special drops. It was highlighted that there are some possible exploits in relation to change wands/magicarp/etc and braindead mobs. This just aims for consistency with their existing loot list and avoid any questionable exploits, as edge case as they might be.

They still drop sinew and diamonds and bone, just no drake hide.
