### PR TITLE
Removes the ability of non-interacting admin ghosts to steal and carry objects, pick pockets etc.

### DIFF
--- a/code/modules/mob/dead/observer/observer.dm
+++ b/code/modules/mob/dead/observer/observer.dm
@@ -710,9 +710,7 @@ This is the proc mobs get to turn into a ghost. Forked from ghostize due to comp
 	update_icon()
 
 /mob/dead/observer/canUseTopic(atom/movable/AM,be_close = FALSE)
-	if(IsAdminGhost(usr))
-		return 1
-	return
+	return IsAdminGhost(usr)
 
 /mob/dead/observer/is_literate()
 	return 1

--- a/code/modules/mob/dead/observer/observer.dm
+++ b/code/modules/mob/dead/observer/observer.dm
@@ -710,7 +710,7 @@ This is the proc mobs get to turn into a ghost. Forked from ghostize due to comp
 	update_icon()
 
 /mob/dead/observer/canUseTopic(atom/movable/AM,be_close = FALSE)
-	if(check_rights(R_ADMIN, 0))
+	if(IsAdminGhost(usr))
 		return 1
 	return
 


### PR DESCRIPTION
Fixes #19114

Admin ghosts were able to take stuff out of machines and carry them in their hands, set weapons to kill, pick peoples' pockets and otherwise interact with the world in destructive ways.

[Changelogs]: 

:cl: Naksu
fix: Admin ghosts can no longer unintentionally make a mess of things.
/:cl:

[why]:
bugfix
