### PR TITLE
Fixes banning panel href errors, adds href helper functions

### DIFF
--- a/code/modules/admin/DB_ban/functions.dm
+++ b/code/modules/admin/DB_ban/functions.dm
@@ -358,6 +358,7 @@
 
 	output += "<form method='GET' action='?src=\ref[src]'><b>Add custom ban:</b> (ONLY use this if you can't ban through any other method)"
 	output += "<input type='hidden' name='src' value='\ref[src]'>"
+	output += HrefTokenFormField()
 	output += "<table width='100%'><tr>"
 	output += "<td><b>Ban type:</b><select name='dbbanaddtype'>"
 	output += "<option value=''>--</option>"
@@ -391,6 +392,7 @@
 
 	output += "<form method='GET' action='?src=\ref[src]'><b>Search:</b> "
 	output += "<input type='hidden' name='src' value='\ref[src]'>"
+	output += HrefTokenFormField()
 	output += "<b>Ckey:</b> <input type='text' name='dbsearchckey' value='[playerckey]'>"
 	output += "<b>Admin ckey:</b> <input type='text' name='dbsearchadmin' value='[adminckey]'>"
 	output += "<input type='submit' value='search'>"

--- a/code/modules/admin/holder2.dm
+++ b/code/modules/admin/holder2.dm
@@ -40,7 +40,7 @@ GLOBAL_PROTECT(href_token)
 	for(var/I in 1 to 32)
 		. += "[rand(10)]"
 
-/proc/HrefToken(forceGlobal = FALSE)
+/proc/RawHrefToken(forceGlobal = FALSE)
 	var/tok = GLOB.href_token
 	if(!forceGlobal && usr)
 		var/client/C = usr.client
@@ -49,7 +49,13 @@ GLOBAL_PROTECT(href_token)
 		var/datum/admins/holder = C.holder
 		if(holder)
 			tok = holder.href_token
-	return "admin_token=[tok]"
+	return tok
+
+/proc/HrefToken(forceGlobal = FALSE)
+	return "admin_token=[RawHrefToken(forceGlobal)]"
+
+/proc/HrefTokenFormField(forceGlobal = FALSE)
+	return "<input type='hidden' name='admin_token' value='[RawHrefToken(forceGlobal)]'>"
 
 /datum/admins/proc/associate(client/C)
 	if(IsAdminAdvancedProcCall())


### PR DESCRIPTION
Fixes #30874

Also fixes an unreported identical issue with the "Add custom ban" form on the banning panel.

Adds new helpers HrefTokenFormField() and RawHrefToken() with identical arguments as HrefToken(), refactors HrefToken() to use RawHrefToken()

[why]: 
bugfix