### PR TITLE
Fixes suppressing weapons in your bag / pocket

### DIFF
--- a/code/modules/projectiles/gun.dm
+++ b/code/modules/projectiles/gun.dm
@@ -21,7 +21,7 @@
 	attack_verb = list("struck", "hit", "bashed")
 
 	var/fire_sound = "gunshot"
-	var/suppressed = FALSE					//whether or not a message is displayed when fired
+	var/suppressed = null					//whether or not a message is displayed when fired
 	var/can_suppress = FALSE
 	var/can_unsuppress = TRUE
 	var/recoil = 0						//boom boom shake the room

--- a/code/modules/projectiles/gun.dm
+++ b/code/modules/projectiles/gun.dm
@@ -21,9 +21,9 @@
 	attack_verb = list("struck", "hit", "bashed")
 
 	var/fire_sound = "gunshot"
-	var/suppressed = 0					//whether or not a message is displayed when fired
-	var/can_suppress = 0
-	var/can_unsuppress = 1
+	var/suppressed = FALSE					//whether or not a message is displayed when fired
+	var/can_suppress = FALSE
+	var/can_unsuppress = TRUE
 	var/recoil = 0						//boom boom shake the room
 	var/clumsy_check = 1
 	var/obj/item/ammo_casing/chambered = null

--- a/code/modules/projectiles/guns/ballistic.dm
+++ b/code/modules/projectiles/guns/ballistic.dm
@@ -70,7 +70,10 @@
 			to_chat(user, "<span class='notice'>There's already a magazine in \the [src].</span>")
 	if(istype(A, /obj/item/suppressor))
 		var/obj/item/suppressor/S = A
-		if(can_suppress)
+		if(!user.is_holding(src))
+			to_chat(user, "<span class='notice'>You need be holding [src] to do that!</span>")
+			return
+		else if(can_suppress)
 			if(!suppressed)
 				if(!user.transferItemToLoc(A, src))
 					return
@@ -79,7 +82,7 @@
 				S.oldsound = fire_sound
 				S.initial_w_class = w_class
 				fire_sound = 'sound/weapons/gunshot_silenced.ogg'
-				w_class = WEIGHT_CLASS_NORMAL //so pistols do not fit in pockets when suppressed
+				w_class += A.w_class //so pistols do not fit in pockets when suppressed
 				update_icon()
 				return
 			else
@@ -195,7 +198,7 @@
 	desc = "A universal syndicate small-arms suppressor for maximum espionage."
 	icon = 'icons/obj/guns/projectile.dmi'
 	icon_state = "suppressor"
-	w_class = WEIGHT_CLASS_SMALL
+	w_class = WEIGHT_CLASS_TINY
 	var/oldsound = null
 	var/initial_w_class = null
 

--- a/code/modules/projectiles/guns/ballistic.dm
+++ b/code/modules/projectiles/guns/ballistic.dm
@@ -100,7 +100,7 @@
 			user.put_in_hands(suppressed)
 			fire_sound = S.oldsound
 			w_class -= S.w_class
-			suppressed = FALSE
+			suppressed = null
 			update_icon()
 			return
 	..()

--- a/code/modules/projectiles/guns/ballistic.dm
+++ b/code/modules/projectiles/guns/ballistic.dm
@@ -71,7 +71,7 @@
 	if(istype(A, /obj/item/suppressor))
 		var/obj/item/suppressor/S = A
 		if(!user.is_holding(src))
-			to_chat(user, "<span class='notice'>You need be holding [src] to do that!</span>")
+			to_chat(user, "<span class='notice'>You need be holding [src] to fit [S] to it!</span>")
 			return
 		else if(can_suppress)
 			if(!suppressed)

--- a/code/modules/projectiles/guns/ballistic.dm
+++ b/code/modules/projectiles/guns/ballistic.dm
@@ -80,7 +80,6 @@
 				to_chat(user, "<span class='notice'>You screw [S] onto [src].</span>")
 				suppressed = A
 				S.oldsound = fire_sound
-				S.initial_w_class = w_class
 				fire_sound = 'sound/weapons/gunshot_silenced.ogg'
 				w_class += A.w_class //so pistols do not fit in pockets when suppressed
 				update_icon()
@@ -103,7 +102,7 @@
 			to_chat(user, "<span class='notice'>You unscrew [suppressed] from [src].</span>")
 			user.put_in_hands(suppressed)
 			fire_sound = S.oldsound
-			w_class = S.initial_w_class
+			w_class -= S.w_class
 			suppressed = FALSE
 			update_icon()
 			return
@@ -200,7 +199,6 @@
 	icon_state = "suppressor"
 	w_class = WEIGHT_CLASS_TINY
 	var/oldsound = null
-	var/initial_w_class = null
 
 
 /obj/item/suppressor/specialoffer

--- a/code/modules/projectiles/guns/ballistic.dm
+++ b/code/modules/projectiles/guns/ballistic.dm
@@ -70,25 +70,22 @@
 			to_chat(user, "<span class='notice'>There's already a magazine in \the [src].</span>")
 	if(istype(A, /obj/item/suppressor))
 		var/obj/item/suppressor/S = A
+		if(!can_suppress)
+			to_chat(user, "<span class='warning'>You can't seem to figure out how to fit [S] on [src]!</span>")
+			return
 		if(!user.is_holding(src))
 			to_chat(user, "<span class='notice'>You need be holding [src] to fit [S] to it!</span>")
 			return
-		else if(can_suppress)
-			if(!suppressed)
-				if(!user.transferItemToLoc(A, src))
-					return
-				to_chat(user, "<span class='notice'>You screw [S] onto [src].</span>")
-				suppressed = A
-				S.oldsound = fire_sound
-				fire_sound = 'sound/weapons/gunshot_silenced.ogg'
-				w_class += A.w_class //so pistols do not fit in pockets when suppressed
-				update_icon()
-				return
-			else
-				to_chat(user, "<span class='warning'>[src] already has a suppressor!</span>")
-				return
-		else
-			to_chat(user, "<span class='warning'>You can't seem to figure out how to fit [S] on [src]!</span>")
+		if(suppressed)
+			to_chat(user, "<span class='warning'>[src] already has a suppressor!</span>")
+			return
+		if(user.transferItemToLoc(A, src))
+			to_chat(user, "<span class='notice'>You screw [S] onto [src].</span>")
+			suppressed = A
+			S.oldsound = fire_sound
+			fire_sound = 'sound/weapons/gunshot_silenced.ogg'
+			w_class += A.w_class //so pistols do not fit in pockets when suppressed
+			update_icon()
 			return
 	return 0
 

--- a/code/modules/projectiles/guns/ballistic.dm
+++ b/code/modules/projectiles/guns/ballistic.dm
@@ -4,10 +4,10 @@
 	icon_state = "pistol"
 	origin_tech = "combat=2;materials=2"
 	w_class = WEIGHT_CLASS_NORMAL
-	var/spawnwithmagazine = 1
+	var/spawnwithmagazine = TRUE
 	var/mag_type = /obj/item/ammo_box/magazine/m10mm //Removes the need for max_ammo and caliber info
 	var/obj/item/ammo_box/magazine/magazine
-	var/casing_ejector = 1 //whether the gun ejects the chambered casing
+	var/casing_ejector = TRUE //whether the gun ejects the chambered casing
 
 /obj/item/gun/ballistic/Initialize()
 	. = ..()
@@ -104,7 +104,7 @@
 			user.put_in_hands(suppressed)
 			fire_sound = S.oldsound
 			w_class = S.initial_w_class
-			suppressed = 0
+			suppressed = FALSE
 			update_icon()
 			return
 	..()

--- a/code/modules/projectiles/guns/ballistic/automatic.dm
+++ b/code/modules/projectiles/guns/ballistic/automatic.dm
@@ -3,7 +3,7 @@
 	w_class = WEIGHT_CLASS_NORMAL
 	var/alarmed = 0
 	var/select = 1
-	can_suppress = 1
+	can_suppress = TRUE
 	burst_size = 3
 	fire_delay = 2
 	actions_types = list(/datum/action/item_action/toggle_firemode)
@@ -119,7 +119,7 @@
 	item_state = "arg"
 	mag_type = /obj/item/ammo_box/magazine/wt550m9
 	fire_delay = 2
-	can_suppress = 0
+	can_suppress = FALSE
 	burst_size = 0
 	actions_types = list()
 
@@ -143,7 +143,7 @@
 	origin_tech = "combat=5;materials=2;syndicate=6"
 	mag_type = /obj/item/ammo_box/magazine/m556
 	fire_sound = 'sound/weapons/gunshot_smg.ogg'
-	can_suppress = 0
+	can_suppress = FALSE
 	var/obj/item/gun/ballistic/revolver/grenadelauncher/underbarrel
 	burst_size = 3
 	fire_delay = 2
@@ -217,7 +217,7 @@
 	origin_tech = "combat=5;materials=1;syndicate=3"
 	mag_type = /obj/item/ammo_box/magazine/tommygunm45
 	fire_sound = 'sound/weapons/gunshot_smg.ogg'
-	can_suppress = 0
+	can_suppress = FALSE
 	burst_size = 4
 	fire_delay = 1
 
@@ -230,7 +230,7 @@
 	origin_tech = "combat=6;engineering=4"
 	mag_type = /obj/item/ammo_box/magazine/m556
 	fire_sound = 'sound/weapons/gunshot_smg.ogg'
-	can_suppress = 0
+	can_suppress = FALSE
 	burst_size = 3
 	fire_delay = 1
 
@@ -246,7 +246,7 @@
 	origin_tech = "combat=6;materials=4;syndicate=6"
 	mag_type = /obj/item/ammo_box/magazine/m12g
 	fire_sound = 'sound/weapons/gunshot.ogg'
-	can_suppress = 0
+	can_suppress = FALSE
 	burst_size = 1
 	fire_delay = 0
 	pin = /obj/item/device/firing_pin/implant/pindicate
@@ -286,7 +286,7 @@
 	weapon_weight = WEAPON_HEAVY
 	fire_sound = 'sound/weapons/gunshot_smg.ogg'
 	var/cover_open = FALSE
-	can_suppress = 0
+	can_suppress = FALSE
 	burst_size = 3
 	fire_delay = 1
 	pin = /obj/item/device/firing_pin/implant/pindicate
@@ -362,8 +362,8 @@
 	fire_delay = 40
 	burst_size = 1
 	origin_tech = "combat=7"
-	can_unsuppress = 1
-	can_suppress = 1
+	can_unsuppress = TRUE
+	can_suppress = TRUE
 	w_class = WEIGHT_CLASS_NORMAL
 	zoomable = TRUE
 	zoom_amt = 7 //Long range, enough to see in front of you, but no tiles behind you.
@@ -396,8 +396,8 @@
 	mag_type = /obj/item/ammo_box/magazine/m10mm/rifle
 	fire_delay = 30
 	burst_size = 1
-	can_unsuppress = 1
-	can_suppress = 1
+	can_unsuppress = TRUE
+	can_suppress = TRUE
 	w_class = WEIGHT_CLASS_HUGE
 	slot_flags = SLOT_BACK
 	actions_types = list()
@@ -418,11 +418,11 @@
 	item_state = "arg"
 	mag_type = /obj/item/ammo_box/magazine/recharge
 	fire_delay = 2
-	can_suppress = 0
+	can_suppress = FALSE
 	burst_size = 0
 	actions_types = list()
 	fire_sound = 'sound/weapons/laser.ogg'
-	casing_ejector = 0
+	casing_ejector = FALSE
 
 /obj/item/gun/ballistic/automatic/laser/update_icon()
 	..()

--- a/code/modules/projectiles/guns/ballistic/laser_gatling.dm
+++ b/code/modules/projectiles/guns/ballistic/laser_gatling.dm
@@ -109,7 +109,7 @@
 	weapon_weight = WEAPON_HEAVY
 	fire_sound = 'sound/weapons/laser.ogg'
 	mag_type = /obj/item/ammo_box/magazine/internal/minigun
-	casing_ejector = 0
+	casing_ejector = FALSE
 	flags_2 = SLOWS_WHILE_IN_HAND_2
 	var/obj/item/minigunpack/ammo_pack
 

--- a/code/modules/projectiles/guns/ballistic/launchers.dm
+++ b/code/modules/projectiles/guns/ballistic/launchers.dm
@@ -40,7 +40,7 @@
 	burst_size = 1
 	fire_delay = 0
 	actions_types = list()
-	casing_ejector = 0
+	casing_ejector = FALSE
 
 /obj/item/gun/ballistic/automatic/gyropistol/update_icon()
 	..()
@@ -54,14 +54,14 @@
 	w_class = WEIGHT_CLASS_BULKY
 	origin_tech = "combat=4;engineering=4"
 	force = 10
-	can_suppress = 0
+	can_suppress = FALSE
 	mag_type = /obj/item/ammo_box/magazine/internal/speargun
 	fire_sound = 'sound/weapons/grenadelaunch.ogg'
 	burst_size = 1
 	fire_delay = 0
 	select = 0
 	actions_types = list()
-	casing_ejector = 0
+	casing_ejector = FALSE
 
 /obj/item/gun/ballistic/automatic/speargun/update_icon()
 	return
@@ -84,12 +84,12 @@
 	mag_type = /obj/item/ammo_box/magazine/internal/rocketlauncher
 	fire_sound = 'sound/weapons/rocketlaunch.ogg'
 	w_class = WEIGHT_CLASS_BULKY
-	can_suppress = 0
+	can_suppress = FALSE
 	burst_size = 1
 	fire_delay = 0
 	select = 0
 	actions_types = list()
-	casing_ejector = 0
+	casing_ejector = FALSE
 	weapon_weight = WEAPON_HEAVY
 
 /obj/item/gun/ballistic/automatic/atlauncher/attack_self()

--- a/code/modules/projectiles/guns/ballistic/pistol.dm
+++ b/code/modules/projectiles/guns/ballistic/pistol.dm
@@ -5,7 +5,7 @@
 	w_class = WEIGHT_CLASS_SMALL
 	origin_tech = "combat=3;materials=2;syndicate=4"
 	mag_type = /obj/item/ammo_box/magazine/m10mm
-	can_suppress = 1
+	can_suppress = TRUE
 	burst_size = 1
 	fire_delay = 0
 	actions_types = list()
@@ -21,7 +21,7 @@
 	icon_state = "m1911"
 	w_class = WEIGHT_CLASS_NORMAL
 	mag_type = /obj/item/ammo_box/magazine/m45
-	can_suppress = 0
+	can_suppress = FALSE
 
 /obj/item/gun/ballistic/automatic/pistol/deagle
 	name = "desert eagle"
@@ -29,7 +29,7 @@
 	icon_state = "deagle"
 	force = 14
 	mag_type = /obj/item/ammo_box/magazine/m50
-	can_suppress = 0
+	can_suppress = FALSE
 
 /obj/item/gun/ballistic/automatic/pistol/deagle/update_icon()
 	..()
@@ -57,7 +57,7 @@
 	w_class = WEIGHT_CLASS_SMALL
 	origin_tech = "combat=3;materials=2;syndicate=3"
 	mag_type = /obj/item/ammo_box/magazine/pistolm9mm
-	can_suppress = 0
+	can_suppress = FALSE
 	burst_size = 3
 	fire_delay = 2
 	actions_types = list(/datum/action/item_action/toggle_firemode)

--- a/code/modules/projectiles/guns/ballistic/revolver.dm
+++ b/code/modules/projectiles/guns/ballistic/revolver.dm
@@ -4,7 +4,7 @@
 	icon_state = "revolver"
 	mag_type = /obj/item/ammo_box/magazine/internal/cylinder
 	origin_tech = "combat=3;materials=2"
-	casing_ejector = 0
+	casing_ejector = FALSE
 
 /obj/item/gun/ballistic/revolver/Initialize()
 	. = ..()
@@ -159,7 +159,7 @@
 	desc = "An old model of revolver that originated in Russia. Able to be suppressed. Uses 7.62x38mmR ammo."
 	icon_state = "nagant"
 	origin_tech = "combat=3"
-	can_suppress = 1
+	can_suppress = TRUE
 	mag_type = /obj/item/ammo_box/magazine/internal/cylinder/rev762
 
 

--- a/code/modules/projectiles/guns/ballistic/shotgun.dm
+++ b/code/modules/projectiles/guns/ballistic/shotgun.dm
@@ -9,7 +9,7 @@
 	slot_flags = SLOT_BACK
 	origin_tech = "combat=4;materials=2"
 	mag_type = /obj/item/ammo_box/magazine/internal/shot
-	casing_ejector = 0
+	casing_ejector = FALSE
 	var/recentpump = 0 // to prevent spammage
 	weapon_weight = WEAPON_MEDIUM
 

--- a/code/modules/projectiles/guns/ballistic/toy.dm
+++ b/code/modules/projectiles/guns/ballistic/toy.dm
@@ -12,7 +12,7 @@
 	can_suppress = TRUE
 	clumsy_check = 0
 	needs_permit = 0
-	casing_ejector = 0
+	casing_ejector = FALSE
 
 /obj/item/gun/ballistic/automatic/toy/unrestricted
 	pin = /obj/item/device/firing_pin
@@ -55,7 +55,7 @@
 	mag_type = /obj/item/ammo_box/magazine/internal/shot/toy
 	clumsy_check = 0
 	needs_permit = 0
-	casing_ejector = 0
+	casing_ejector = FALSE
 	can_suppress = FALSE
 
 /obj/item/gun/ballistic/shotgun/toy/process_chamber(empty_chamber = 0)
@@ -84,7 +84,7 @@
 	can_suppress = TRUE
 	needs_permit = 0
 	mag_type = /obj/item/ammo_box/magazine/toy/smgm45/riot
-	casing_ejector = 0
+	casing_ejector = FALSE
 
 /obj/item/gun/ballistic/automatic/c20r/toy/unrestricted //Use this for actual toys
 	pin = /obj/item/device/firing_pin
@@ -100,7 +100,7 @@
 	can_suppress = FALSE
 	needs_permit = 0
 	mag_type = /obj/item/ammo_box/magazine/toy/m762/riot
-	casing_ejector = 0
+	casing_ejector = FALSE
 
 /obj/item/gun/ballistic/automatic/l6_saw/toy/unrestricted //Use this for actual toys
 	pin = /obj/item/device/firing_pin

--- a/code/modules/projectiles/guns/energy/special.dm
+++ b/code/modules/projectiles/guns/energy/special.dm
@@ -115,7 +115,7 @@
 	w_class = WEIGHT_CLASS_NORMAL
 	materials = list(MAT_METAL=4000)
 	origin_tech = "combat=4;magnets=4;syndicate=2"
-	suppressed = FALSE
+	suppressed = null
 	ammo_type = list(/obj/item/ammo_casing/energy/bolt/large)
 	pin = null
 

--- a/code/modules/projectiles/guns/energy/special.dm
+++ b/code/modules/projectiles/guns/energy/special.dm
@@ -90,7 +90,7 @@
 	w_class = WEIGHT_CLASS_SMALL
 	materials = list(MAT_METAL=2000)
 	origin_tech = "combat=4;magnets=4;syndicate=5"
-	suppressed = 1
+	suppressed = TRUE
 	ammo_type = list(/obj/item/ammo_casing/energy/bolt)
 	weapon_weight = WEAPON_LIGHT
 	unique_rename = 0
@@ -115,7 +115,7 @@
 	w_class = WEIGHT_CLASS_NORMAL
 	materials = list(MAT_METAL=4000)
 	origin_tech = "combat=4;magnets=4;syndicate=2"
-	suppressed = 0
+	suppressed = FALSE
 	ammo_type = list(/obj/item/ammo_casing/energy/bolt/large)
 	pin = null
 

--- a/code/modules/projectiles/guns/syringe_gun.dm
+++ b/code/modules/projectiles/guns/syringe_gun.dm
@@ -76,8 +76,8 @@
 	w_class = WEIGHT_CLASS_SMALL
 	origin_tech = "combat=2;syndicate=2;biotech=3"
 	force = 2 //Also very weak because it's smaller
-	suppressed = 1 //Softer fire sound
-	can_unsuppress = 0 //Permanently silenced
+	suppressed = TRUE //Softer fire sound
+	can_unsuppress = FALSE //Permanently silenced
 	
 /obj/item/gun/syringe/dna
 	name = "modified syringe gun"

--- a/code/modules/projectiles/projectile.dm
+++ b/code/modules/projectiles/projectile.dm
@@ -13,7 +13,7 @@
 	resistance_flags = LAVA_PROOF | FIRE_PROOF | UNACIDABLE | ACID_PROOF
 	var/def_zone = ""	//Aiming at
 	var/mob/firer = null//Who shot it
-	var/suppressed = 0	//Attack message
+	var/suppressed = FALSE	//Attack message
 	var/yo = null
 	var/xo = null
 	var/current = null


### PR DESCRIPTION
🆑 ShizCalev
fix: You now have to be holding a weapon to affix a suppressor to it.
balance: Attaching a suppressor to a weapon will now make it slightly larger, as is logical.
/🆑

Fixes #30886

You now have to be holding a weapon to attach a suppressor to it. This check was already being performed while removing it, so it was likely just missed initially.

Also fixes heavier weapons like the surplus rifle dropping w_class from WEIGHT_CLASS_HUGE to WEIGHT_CLASS_NORMAL when attaching a suppressor to it. 

Likewise, attaching a suppressor to a larger weapon such as a sniper rifle or a C20r will mean that it will no longer fit in your bag until the suppressor is removed due to the larger mass of it.

Changed the w_class of the suppressor to TINY to retain it's old behavior.

