### PR TITLE
Mice spawn now chooses correct z-level

### DIFF
--- a/code/controllers/subsystem/squeak.dm
+++ b/code/controllers/subsystem/squeak.dm
@@ -32,8 +32,9 @@ SUBSYSTEM_DEF(squeak)
 
 /datum/controller/subsystem/squeak/proc/find_exposed_wires()
 	exposed_wires.Cut()
-
-	var/list/all_turfs = block(locate(1,1,1), locate(world.maxx,world.maxy,1))
+	var/list/all_turfs
+	for (var/z in GLOB.station_z_levels)
+		all_turfs += block(locate(1,1,z), locate(world.maxx,world.maxy,z))
 	for(var/turf/open/floor/plating/T in all_turfs)
 		if(is_blocked_turf(T))
 			continue


### PR DESCRIPTION
:cl:
fix: Mice spawning finds the station z level properly
/:cl:

[why]: # It was broke
