### PR TITLE
Adds secborgs to the Staff of Change's possible transformations.

### DIFF
--- a/code/modules/mob/living/silicon/robot/robot.dm
+++ b/code/modules/mob/living/silicon/robot/robot.dm
@@ -781,6 +781,13 @@
 		cell = null
 	qdel(src)
 
+/mob/living/silicon/robot/security
+	var/set_module = /obj/item/robot_module/security
+
+/mob/living/silicon/robot/security/Initialize()
+	. = ..()
+	module.transform_to(set_module)
+
 /mob/living/silicon/robot/syndicate
 	icon_state = "syndie_bloodhound"
 	faction = list("syndicate")

--- a/code/modules/projectiles/projectile/magic.dm
+++ b/code/modules/projectiles/projectile/magic.dm
@@ -133,11 +133,15 @@
 			new_mob = new /mob/living/carbon/monkey(M.loc)
 		if("robot")
 			var/robot = pick("cyborg","syndiborg","drone")
+			var/path
 			switch(robot)
 				if("cyborg")
-					new_mob = new /mob/living/silicon/robot(M.loc)
+					if(prob(70))
+						path = /mob/living/silicon/robot
+					else
+						path = /mob/living/silicon/robot/security
+					new_mob = new path(M.loc)
 				if("syndiborg")
-					var/path
 					if(prob(50))
 						path = /mob/living/silicon/robot/syndicate
 					else

--- a/code/modules/projectiles/projectile/magic.dm
+++ b/code/modules/projectiles/projectile/magic.dm
@@ -139,7 +139,7 @@
 					if(prob(70))
 						path = /mob/living/silicon/robot
 					else
-						if(config.forbid_secborg)
+						if(config.forbid_secborg) // This is correct. It is intended for servers where secborg is disabled. If secborg is enabled, then it defaults to a default borg since they can manually select secborgs.
 							path = /mob/living/silicon/robot/security
 						else
 							path = /mob/living/silicon/robot

--- a/code/modules/projectiles/projectile/magic.dm
+++ b/code/modules/projectiles/projectile/magic.dm
@@ -139,7 +139,10 @@
 					if(prob(70))
 						path = /mob/living/silicon/robot
 					else
-						path = /mob/living/silicon/robot/security
+						if(config.forbid_secborg)
+							path = /mob/living/silicon/robot/security
+						else
+							path = /mob/living/silicon/robot
 					new_mob = new path(M.loc)
 				if("syndiborg")
 					if(prob(50))


### PR DESCRIPTION
This PR simply adds secborgs to the possible transformations which the Change projectile(mostly used by the Staff of Change...and I think Magicarp?) can transform people into. So it has a 70% chance of it being the default module-less borg, and 30% chance to be a secborg when it comes to normal borgs. Originally had it at 10% chance for a secborg, but I literally didn't see it once during an hour of testing.

:cl: Firecage
Add: NanoTrasen Bureau of Intelligence Notification: We have recently received reports that the Wizard Federation has made improvements on their polymorph spells, specifically those used by the famed Staff of Change. We have detected Security Cyborgs roaming on the stations they targeted during testing.
/:cl: