### PR TITLE
Stops AIs from giving the borg a free secondary light

### DIFF
--- a/code/game/machinery/camera/camera.dm
+++ b/code/game/machinery/camera/camera.dm
@@ -39,7 +39,7 @@
 	// Upgrades bitflag
 	var/upgrades = 0
 
-	var/internal_light = FALSE //Whether it can light up when an AI views it
+	var/internal_light = TRUE //Whether it can light up when an AI views it
 
 /obj/machinery/camera/Initialize(mapload)
 	. = ..()

--- a/code/game/machinery/camera/camera.dm
+++ b/code/game/machinery/camera/camera.dm
@@ -39,6 +39,8 @@
 	// Upgrades bitflag
 	var/upgrades = 0
 
+	var/internal_light = FALSE //Whether it can light up when an AI views it
+
 /obj/machinery/camera/Initialize(mapload)
 	. = ..()
 	assembly = new(src)

--- a/code/modules/mob/living/silicon/ai/ai.dm
+++ b/code/modules/mob/living/silicon/ai/ai.dm
@@ -740,7 +740,7 @@
 	var/list/obj/machinery/camera/visible = list()
 	for (var/datum/camerachunk/CC in eyeobj.visibleCameraChunks)
 		for (var/obj/machinery/camera/C in CC.cameras)
-			if (!C.can_use() || get_dist(C, eyeobj) > 7)
+			if (!C.can_use() || get_dist(C, eyeobj) > 7 || iscyborg(C.loc))
 				continue
 			visible |= C
 

--- a/code/modules/mob/living/silicon/ai/ai.dm
+++ b/code/modules/mob/living/silicon/ai/ai.dm
@@ -740,7 +740,7 @@
 	var/list/obj/machinery/camera/visible = list()
 	for (var/datum/camerachunk/CC in eyeobj.visibleCameraChunks)
 		for (var/obj/machinery/camera/C in CC.cameras)
-			if (!C.can_use() || get_dist(C, eyeobj) > 7 || C.internal_light)
+			if (!C.can_use() || get_dist(C, eyeobj) > 7 || !C.internal_light)
 				continue
 			visible |= C
 

--- a/code/modules/mob/living/silicon/ai/ai.dm
+++ b/code/modules/mob/living/silicon/ai/ai.dm
@@ -740,7 +740,7 @@
 	var/list/obj/machinery/camera/visible = list()
 	for (var/datum/camerachunk/CC in eyeobj.visibleCameraChunks)
 		for (var/obj/machinery/camera/C in CC.cameras)
-			if (!C.can_use() || get_dist(C, eyeobj) > 7 || iscyborg(C.loc))
+			if (!C.can_use() || get_dist(C, eyeobj) > 7 || C.internal_light)
 				continue
 			visible |= C
 

--- a/code/modules/mob/living/silicon/robot/robot.dm
+++ b/code/modules/mob/living/silicon/robot/robot.dm
@@ -129,6 +129,7 @@
 		builtInCamera = new (src)
 		builtInCamera.c_tag = real_name
 		builtInCamera.network = list("SS13")
+		builtInCamera.internal_light = FALSE
 		if(wires.is_cut(WIRE_CAMERA))
 			builtInCamera.status = 0
 	module = new /obj/item/robot_module(src)


### PR DESCRIPTION
Tricky silicons were using the untouchable camera light on borgs to run down nightmares 