### PR TITLE
Fixes pet persistence

### DIFF
--- a/code/controllers/subsystem/persistence.dm
+++ b/code/controllers/subsystem/persistence.dm
@@ -42,8 +42,7 @@ SUBSYSTEM_DEF(persistence)
 		var/json_file = file("data/npc_saves/SecretSatchels[SSmapping.config.map_name].json")
 		if(!fexists(json_file))
 			return
-		var/list/json = list()
-		json = json_decode(file2text(json_file))
+		var/list/json = json_decode(file2text(json_file))
 		old_secret_satchels = json["data"]
 		if(old_secret_satchels.len)
 			if(old_secret_satchels.len >= 20) //guards against low drop pools assuring that one player cannot reliably find his own gear.
@@ -85,8 +84,7 @@ SUBSYSTEM_DEF(persistence)
 		var/json_file = file("data/npc_saves/ChiselMessages[SSmapping.config.map_name].json")
 		if(!fexists(json_file))
 			return
-		var/list/json
-		json = json_decode(file2text(json_file))
+		var/list/json = json_decode(file2text(json_file))
 
 		if(!json)
 			return
@@ -130,8 +128,7 @@ SUBSYSTEM_DEF(persistence)
 		var/json_file = file("data/npc_saves/TrophyItems.json")
 		if(!fexists(json_file))
 			return
-		var/list/json = list()
-		json = json_decode(file2text(json_file))
+		var/list/json = json_decode(file2text(json_file))
 		if(!json)
 			return
 		saved_trophies = json["data"]
@@ -141,8 +138,7 @@ SUBSYSTEM_DEF(persistence)
 	var/json_file = file("data/RecentModes.json")
 	if(!fexists(json_file))
 		return
-	var/list/json = list()
-	json = json_decode(file2text(json_file))
+	var/list/json = json_decode(file2text(json_file))
 	if(!json)
 		return
 	saved_modes = json["data"]

--- a/code/modules/awaymissions/super_secret_room.dm
+++ b/code/modules/awaymissions/super_secret_room.dm
@@ -9,13 +9,13 @@
 	var/times_spoken_to = 0
 	var/list/shenanigans = list()
 
-/obj/structure/speaking_tile/New()
+/obj/structure/speaking_tile/Initialize()
+	. = ..()
 	var/json_file = file("data/npc_saves/Poly.json")
 	if(!fexists(json_file))
 		return
 	var/list/json = json_decode(file2text(json_file))
 	shenanigans = json["phrases"]
-	..()
 
 /obj/structure/speaking_tile/interact(mob/user)
 	if(!isliving(user) || speaking)

--- a/code/modules/awaymissions/super_secret_room.dm
+++ b/code/modules/awaymissions/super_secret_room.dm
@@ -10,8 +10,11 @@
 	var/list/shenanigans = list()
 
 /obj/structure/speaking_tile/New()
-	var/savefile/S = new /savefile("data/npc_saves/Poly.sav")
-	S["phrases"] 			>> shenanigans
+	var/json_file = file("data/npc_saves/Poly.json")
+	if(!fexists(json_file))
+		return
+	var/list/json = json_decode(file2text(json_file))
+	shenanigans = json["phrases"]
 	..()
 
 /obj/structure/speaking_tile/interact(mob/user)

--- a/code/modules/mob/living/carbon/human/interactive.dm
+++ b/code/modules/mob/living/carbon/human/interactive.dm
@@ -95,8 +95,7 @@
 		var/json_file = file("data/npc_saves/snpc.json")
 		if(!fexists(json_file))
 			return
-		var/list/json = list()
-		json = json_decode(file2text(json_file))
+		var/list/json = json_decode(file2text(json_file))
 		knownStrings = json["knownStrings"]
 	if(isnull(knownStrings))
 		knownStrings = list()

--- a/code/modules/mob/living/carbon/monkey/punpun.dm
+++ b/code/modules/mob/living/carbon/monkey/punpun.dm
@@ -5,7 +5,7 @@
 	var/ancestor_chain = 1
 	var/relic_hat	//Note: these two are paths
 	var/relic_mask
-	var/memory_saved = 0
+	var/memory_saved = FALSE
 	var/list/pet_monkey_names = list("Pun Pun", "Bubbles", "Mojo", "George", "Darwin", "Aldo", "Caeser", "Kanzi", "Kong", "Terk", "Grodd", "Mala", "Bojangles", "Coco", "Able", "Baker", "Scatter", "Norbit", "Travis")
 	var/list/rare_pet_monkey_names = list("Professor Bobo", "Deempisi's Revenge", "Furious George", "King Louie", "Dr. Zaius", "Jimmy Rustles", "Dinner", "Lanky")
 
@@ -32,13 +32,14 @@
 		equip_to_slot_or_del(new relic_mask, slot_wear_mask)
 
 /mob/living/carbon/monkey/punpun/Life()
-	if(SSticker.current_state == GAME_STATE_FINISHED && !memory_saved)
-		Write_Memory(0)
+	if(!stat && SSticker.current_state == GAME_STATE_FINISHED && !memory_saved)
+		Write_Memory(FALSE, FALSE)
+		memory_saved = TRUE
 	..()
 
 /mob/living/carbon/monkey/punpun/death(gibbed)
-	if(!memory_saved || gibbed)
-		Write_Memory(1,gibbed)
+	if(!memory_saved)
+		Write_Memory(TRUE, gibbed)
 	..()
 
 /mob/living/carbon/monkey/punpun/proc/Read_Memory()
@@ -53,8 +54,7 @@
 		var/json_file = file("data/npc_saves/Punpun.json")
 		if(!fexists(json_file))
 			return
-		var/list/json = list()
-		json = json_decode(file2text(json_file))
+		var/list/json = json_decode(file2text(json_file))
 		ancestor_name = json["ancestor_name"]
 		ancestor_chain = json["ancestor_chain"]
 		relic_hat = json["relic_hat"]
@@ -68,14 +68,10 @@
 		file_data["ancestor_chain"] = null
 		file_data["relic_hat"] = null
 		file_data["relic_mask"] = null
-	if(dead)
-		file_data["ancestor_name"] = ancestor_name
-		file_data["ancestor_chain"] = ancestor_chain + 1
-	file_data["relic_hat"] = head ? head.type : null
-	file_data["relic_mask"] = wear_mask ? wear_mask.type : null
-	if(!ancestor_name)
-		file_data["ancestor_name"] = name
+	else
+		file_data["ancestor_name"] = ancestor_name ? ancestor_name : name
+		file_data["ancestor_chain"] = dead ? ancestor_chain + 1 : ancestor_chain
+		file_data["relic_hat"] = head ? head.type : null
+		file_data["relic_mask"] = wear_mask ? wear_mask.type : null
 	fdel(json_file)
 	WRITE_FILE(json_file, json_encode(file_data))
-	if(!dead)
-		memory_saved = 1

--- a/code/modules/mob/living/simple_animal/friendly/cat.dm
+++ b/code/modules/mob/living/simple_animal/friendly/cat.dm
@@ -83,7 +83,7 @@
 	var/list/family = list()//var restored from savefile, has count of each child type
 	var/list/children = list()//Actual mob instances of children
 	var/cats_deployed = 0
-	var/memory_saved = 0
+	var/memory_saved = FALSE
 
 /mob/living/simple_animal/pet/cat/Runtime/Initialize()
 	if(prob(5))
@@ -98,6 +98,7 @@
 		Deploy_The_Cats()
 	if(!stat && SSticker.current_state == GAME_STATE_FINISHED && !memory_saved)
 		Write_Memory()
+		memory_saved = TRUE
 	..()
 
 /mob/living/simple_animal/pet/cat/Runtime/make_babies()
@@ -108,7 +109,7 @@
 
 /mob/living/simple_animal/pet/cat/Runtime/death()
 	if(!memory_saved)
-		Write_Memory(1)
+		Write_Memory(TRUE)
 	..()
 
 /mob/living/simple_animal/pet/cat/Runtime/proc/Read_Memory()
@@ -120,14 +121,14 @@
 		var/json_file = file("data/npc_saves/Runtime.json")
 		if(!fexists(json_file))
 			return
-		var/list/json = list()
-		json = json_decode(file2text(json_file))
+		var/list/json = json_decode(file2text(json_file))
 		family = json["family"]
 	if(isnull(family))
 		family = list()
 
 /mob/living/simple_animal/pet/cat/Runtime/proc/Write_Memory(dead)
 	var/json_file = file("data/npc_saves/Runtime.json")
+	var/list/file_data = list()
 	family = list()
 	if(!dead)
 		for(var/mob/living/simple_animal/pet/cat/kitten/C in children)
@@ -137,9 +138,9 @@
 				family[C.type] += 1
 			else
 				family[C.type] = 1
+	file_data["family"] = family
 	fdel(json_file)
-	WRITE_FILE(json_file, json_encode(family))
-	memory_saved = 1
+	WRITE_FILE(json_file, json_encode(file_data))
 
 /mob/living/simple_animal/pet/cat/Runtime/proc/Deploy_The_Cats()
 	cats_deployed = 1

--- a/code/modules/mob/living/simple_animal/friendly/dog.dm
+++ b/code/modules/mob/living/simple_animal/friendly/dog.dm
@@ -290,7 +290,7 @@
 	gold_core_spawnable = 0
 	var/age = 0
 	var/record_age = 1
-	var/memory_saved = 0
+	var/memory_saved = FALSE
 	var/saved_head //path
 
 /mob/living/simple_animal/pet/dog/corgi/Ian/Initialize()
@@ -306,7 +306,7 @@
 			P.real_name = "Ian"
 			P.gender = MALE
 			P.desc = "It's the HoP's beloved corgi puppy."
-			Write_Memory(0)
+			Write_Memory(FALSE)
 			qdel(src)
 	else if(age == record_age)
 		icon_state = "old_corgi"
@@ -316,13 +316,14 @@
 		turns_per_move = 20
 
 /mob/living/simple_animal/pet/dog/corgi/Ian/Life()
-	if(SSticker.current_state == GAME_STATE_FINISHED && !memory_saved)
-		Write_Memory(0)
+	if(!stat && SSticker.current_state == GAME_STATE_FINISHED && !memory_saved)
+		Write_Memory(FALSE)
+		memory_saved = TRUE
 	..()
 
 /mob/living/simple_animal/pet/dog/corgi/Ian/death()
 	if(!memory_saved)
-		Write_Memory(1)
+		Write_Memory(TRUE)
 	..()
 
 /mob/living/simple_animal/pet/dog/corgi/Ian/proc/Read_Memory()
@@ -336,8 +337,7 @@
 		var/json_file = file("data/npc_saves/Ian.json")
 		if(!fexists(json_file))
 			return
-		var/list/json = list()
-		json = json_decode(file2text(json_file))
+		var/list/json = json_decode(file2text(json_file))
 		age = json["age"]
 		record_age = json["record_age"]
 		saved_head = json["saved_head"]
@@ -355,14 +355,18 @@
 		file_data["age"] = age + 1
 		if((age + 1) > record_age)
 			file_data["record_age"] = record_age + 1
+		else
+			file_data["record_age"] = record_age
 		if(inventory_head)
 			file_data["saved_head"] = inventory_head.type
+		else
+			file_data["saved_head"] = null
 	else
 		file_data["age"] = 0
+		file_data["record_age"] = record_age
 		file_data["saved_head"] = null
 	fdel(json_file)
 	WRITE_FILE(json_file, json_encode(file_data))
-	memory_saved = 1
 
 /mob/living/simple_animal/pet/dog/corgi/Ian/Life()
 	..()

--- a/code/modules/mob/living/simple_animal/hostile/megafauna/colossus.dm
+++ b/code/modules/mob/living/simple_animal/hostile/megafauna/colossus.dm
@@ -276,6 +276,7 @@ Difficulty: Very Hard
 	..()
 	if(!memory_saved && SSticker.current_state == GAME_STATE_FINISHED)
 		WriteMemory()
+		memory_saved = TRUE
 
 /obj/machinery/smartfridge/black_box/proc/WriteMemory()
 	var/json_file = file("data/npc_saves/Blackbox.json")
@@ -287,7 +288,6 @@ Difficulty: Very Hard
 	file_data["data"] = stored_items
 	fdel(json_file)
 	WRITE_FILE(json_file, json_encode(file_data))
-	memory_saved = TRUE
 
 /obj/machinery/smartfridge/black_box/proc/ReadMemory()
 	if(fexists("data/npc_saves/Blackbox.sav")) //legacy compatability to convert old format to new
@@ -298,8 +298,7 @@ Difficulty: Very Hard
 		var/json_file = file("data/npc_saves/Blackbox.json")
 		if(!fexists(json_file))
 			return
-		var/list/json = list()
-		json = json_decode(file2text(json_file))
+		var/list/json = json_decode(file2text(json_file))
 		stored_items = json["data"]
 	if(isnull(stored_items))
 		stored_items = list()


### PR DESCRIPTION
:cl:
fix: Pet persistence works again
/:cl:

- Stops the super secret room from creating an empty Poly.sav file and preventing the Poly.json file from loading.
- memory_saved is set to true only at the end of the round in case the pet is revived during the round.
- All variables are now written to the file in all cases (since the file is deleted beforehand).
- Runtime's family saves properly.
- Gibbing PunPun after round end doesn't update the savefile (gib() doesn't call death() on already dead mobs anyway)
- Poly's longest_survival actually increases now