### PR TITLE
 Travis improvements for tools and trusty environment bump

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,5 @@
 language: generic
 sudo: false
-dist: precise
-
 env:
     global:
     - BYOND_MAJOR="511"
@@ -23,12 +21,15 @@ cache:
 
 addons:
   apt:
+    sources:
+      - sourceline: 'ppa:ondrej/php'
     packages:
       - libc6-i386
       - libgcc1:i386
       - libstdc++6:i386
       - python
       - python-pip
+      - php5.6
 
 install:
   - tools/travis/install_build_tools.sh

--- a/tools/travis/before_build_byond.sh
+++ b/tools/travis/before_build_byond.sh
@@ -5,6 +5,10 @@ set -e
 if [ "$BUILD_TOOLS" = true ]; then
   exit 0
 fi;
+echo "Combining maps for building"
+if [ "$DM_MAPFILE" = "loadallmaps" ]; then
+    python tools/travis/template_dm_generator.py
+fi;
 
 if [ -d "$HOME/BYOND-${BYOND_MAJOR}.${BYOND_MINOR}/byond/bin" ];
 then

--- a/tools/travis/before_build_tools.sh
+++ b/tools/travis/before_build_tools.sh
@@ -5,6 +5,3 @@ if [ "$BUILD_TOOLS" = true ]; then
     cd tgui && source ~/.nvm/nvm.sh && npm install && cd ..
 fi;
 
-if [ "$DM_MAPFILE" = "loadallmaps" ]; then
-    python tools/travis/template_dm_generator.py
-fi;

--- a/tools/travis/build_tools.sh
+++ b/tools/travis/build_tools.sh
@@ -7,5 +7,6 @@ if [ "$BUILD_TOOLS" = true ];
 then
     md5sum -c - <<< "49bc6b1b9ed56c83cceb6674bd97cb34 *html/changelogs/example.yml";
     cd tgui && source ~/.nvm/nvm.sh && gulp && cd ..;
+    php5.6 -l tools/WebhookProcessor/github_webhook_processor.php;
     python tools/ss13_genchangelog.py html/changelog.html html/changelogs;
 fi;


### PR DESCRIPTION
We now run a php linter on the webhook

We now combine and build all maps in the right build script

Because only the byond build will use the maps this shouldn't
run in the tools script file, this is only working because of
the order the build scripts are run in the travis yml