### PR TITLE
Makes action buttons call the correct procs

### DIFF
--- a/code/_onclick/hud/alert.dm
+++ b/code/_onclick/hud/alert.dm
@@ -244,7 +244,11 @@ or shoot a gun to move around via Newton's 3rd Law of Motion."
 /obj/screen/alert/fire/Click()
 	if(isliving(usr))
 		var/mob/living/L = usr
-		return L.resist()
+		if(!can_do_alert_action(L))
+			return
+		L.changeNext_move(CLICK_CD_RESIST)
+		if(L.canmove)
+			return L.resist_fire() //I just want to start a flame in your hearrrrrrtttttt.
 
 
 //ALIENS
@@ -646,7 +650,23 @@ so as to remain in compliance with the most up-to-date laws."
 /obj/screen/alert/restrained/Click()
 	if(isliving(usr))
 		var/mob/living/L = usr
-		return L.resist()
+		if(!can_do_alert_action(L))
+			return
+		L.changeNext_move(CLICK_CD_RESIST)
+		if((L.canmove) && (L.last_special <= world.time))
+			return L.resist_restraints()
+
+/obj/screen/alert/restrained/buckled/Click()
+	if(isliving(usr))
+		var/mob/living/L = usr
+		if(!can_do_alert_action(L))
+			return
+		L.changeNext_move(CLICK_CD_RESIST)
+		if(L.last_special <= world.time)
+			return L.resist_buckle()
+
+/obj/screen/alert/proc/can_do_alert_action(mob/living/L)
+	return (!((L.next_move > world.time) || L.incapacitated(ignore_restraints = TRUE)))
 
 // PRIVATE = only edit, use, or override these if you're editing the system as a whole
 

--- a/code/_onclick/hud/alert.dm
+++ b/code/_onclick/hud/alert.dm
@@ -242,13 +242,12 @@ or shoot a gun to move around via Newton's 3rd Law of Motion."
 	icon_state = "fire"
 
 /obj/screen/alert/fire/Click()
-	if(isliving(usr))
-		var/mob/living/L = usr
-		if(!can_do_alert_action(L))
-			return
-		L.changeNext_move(CLICK_CD_RESIST)
-		if(L.canmove)
-			return L.resist_fire() //I just want to start a flame in your hearrrrrrtttttt.
+	var/mob/living/L = usr
+	if(!L.can_resist())
+		return
+	L.changeNext_move(CLICK_CD_RESIST)
+	if(L.canmove)
+		return L.resist_fire() //I just want to start a flame in your hearrrrrrtttttt.
 
 
 //ALIENS
@@ -648,25 +647,20 @@ so as to remain in compliance with the most up-to-date laws."
 	desc = "You're legcuffed, which slows you down considerably. Click the alert to free yourself."
 
 /obj/screen/alert/restrained/Click()
-	if(isliving(usr))
-		var/mob/living/L = usr
-		if(!can_do_alert_action(L))
-			return
-		L.changeNext_move(CLICK_CD_RESIST)
-		if((L.canmove) && (L.last_special <= world.time))
-			return L.resist_restraints()
+	var/mob/living/L = usr
+	if(!L.can_resist())
+		return
+	L.changeNext_move(CLICK_CD_RESIST)
+	if((L.canmove) && (L.last_special <= world.time))
+		return L.resist_restraints()
 
 /obj/screen/alert/restrained/buckled/Click()
-	if(isliving(usr))
-		var/mob/living/L = usr
-		if(!can_do_alert_action(L))
-			return
-		L.changeNext_move(CLICK_CD_RESIST)
-		if(L.last_special <= world.time)
-			return L.resist_buckle()
-
-/obj/screen/alert/proc/can_do_alert_action(mob/living/L)
-	return (!((L.next_move > world.time) || L.incapacitated(ignore_restraints = TRUE)))
+	var/mob/living/L = usr
+	if(!L.can_resist())
+		return
+	L.changeNext_move(CLICK_CD_RESIST)
+	if(L.last_special <= world.time)
+		return L.resist_buckle()
 
 // PRIVATE = only edit, use, or override these if you're editing the system as a whole
 

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -545,7 +545,7 @@
 		..(pressure_difference, direction, pressure_resistance_prob_delta)
 
 /mob/living/proc/can_resist()
-	return !(!isliving(src) || (next_move > world.time) || incapacitated(ignore_restraints = TRUE))
+	return !((next_move > world.time) || incapacitated(ignore_restraints = TRUE))
 
 /mob/living/verb/resist()
 	set name = "Resist"

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -544,11 +544,14 @@
 	if(!force_moving)
 		..(pressure_difference, direction, pressure_resistance_prob_delta)
 
+/mob/living/proc/can_resist()
+	return !(!isliving(src) || (next_move > world.time) || incapacitated(ignore_restraints = TRUE))
+
 /mob/living/verb/resist()
 	set name = "Resist"
 	set category = "IC"
 
-	if(!isliving(src) || next_move > world.time || incapacitated(ignore_restraints = TRUE)) //make sure /obj/screen/alert/proc/can_do_alert_action() is updated if changed.
+	if(!can_resist())
 		return
 	changeNext_move(CLICK_CD_RESIST)
 

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -548,7 +548,7 @@
 	set name = "Resist"
 	set category = "IC"
 
-	if(!isliving(src) || next_move > world.time || incapacitated(ignore_restraints = 1))
+	if(!isliving(src) || next_move > world.time || incapacitated(ignore_restraints = TRUE)) //make sure /obj/screen/alert/proc/can_do_alert_action() is updated if changed.
 		return
 	changeNext_move(CLICK_CD_RESIST)
 


### PR DESCRIPTION
Fixes #30916

They were previously just calling resist, which lead to some priority issues if you intended to stay on fire, but just wanted to unhandcuff yourself.

Now clicking on an action button will now try to perform that specific action instead (if you're able to perform it.)