### PR TITLE
Fixes wormholes

### DIFF
--- a/code/game/objects/effects/portals.dm
+++ b/code/game/objects/effects/portals.dm
@@ -43,7 +43,7 @@
 		teleport(user)
 
 /obj/effect/portal/Crossed(atom/movable/AM, oldloc)
-	if(get_turf(oldloc) == get_turf(linked))
+	if(oldloc && get_turf(oldloc) == get_turf(linked))
 		return ..()
 	if(!teleport(AM))
 		return ..()

--- a/code/modules/events/wormholes.dm
+++ b/code/modules/events/wormholes.dm
@@ -48,12 +48,6 @@
 	icon_state = "anom"
 	mech_sized = TRUE
 
-/obj/effect/portal/wormhole/attack_hand(mob/user)
-	teleport(user)
-
-/obj/effect/portal/wormhole/attackby(obj/item/I, mob/user, params)
-	teleport(user)
-
 /obj/effect/portal/wormhole/teleport(atom/movable/M)
 	if(istype(M, /obj/effect))	//sparks don't teleport
 		return

--- a/code/modules/mining/equipment/wormhole_jaunter.dm
+++ b/code/modules/mining/equipment/wormhole_jaunter.dm
@@ -17,7 +17,7 @@
 /obj/item/device/wormhole_jaunter/attack_self(mob/user)
 	user.visible_message("<span class='notice'>[user.name] activates the [src.name]!</span>")
 	SSblackbox.add_details("jaunter", "User") // user activated
-	activate(user)
+	activate(user, TRUE)
 
 /obj/item/device/wormhole_jaunter/proc/turf_check(mob/user)
 	var/turf/device_turf = get_turf(user)
@@ -46,7 +46,7 @@
 
 	return destinations
 
-/obj/item/device/wormhole_jaunter/proc/activate(mob/user)
+/obj/item/device/wormhole_jaunter/proc/activate(mob/user, adjacent)
 	if(!turf_check(user))
 		return
 
@@ -56,7 +56,8 @@
 		return
 	var/chosen_beacon = pick(L)
 	var/obj/effect/portal/wormhole/jaunt_tunnel/J = new (get_turf(src), src, 100, null, FALSE, get_turf(chosen_beacon))
-	try_move_adjacent(J)
+	if(adjacent)
+		try_move_adjacent(J)
 	playsound(src,'sound/effects/sparks4.ogg',50,1)
 	qdel(src)
 
@@ -78,7 +79,7 @@
 	if(user.get_item_by_slot(slot_belt) == src)
 		to_chat(user, "Your [src] activates, saving you from the chasm!</span>")
 		SSblackbox.add_details("jaunter","Chasm") // chasm automatic activation
-		activate(user)
+		activate(user, FALSE)
 	else
 		to_chat(user, "The [src] is not attached to your belt, preventing it from saving you from the chasm. RIP.</span>")
 


### PR DESCRIPTION
:cl:
fix: Wormholes teleport things that walk into them again
fix: Jaunters on your belt will save you from chasms again
/:cl:

crossed() checks if oldloc is null (which it always is unless called from forceMove()) 
Fixes #30236

Jaunters will create the wormhole on the same turf as the user if activated by a chasm
Fixes #30879

Removed two procs that do the same thing as the parent procs