### PR TITLE
You can no longer say any message containing a tilde

### DIFF
--- a/code/game/say.dm
+++ b/code/game/say.dm
@@ -23,6 +23,9 @@ GLOBAL_LIST_INIT(freqtospan, list(
 		return
 	if(message == "" || !message)
 		return
+	if(findtext(message, "~"))
+		to_chat(src, "<span class='userdanger'>We do not allow the use of tilde on this server</span>")
+		return
 	var/list/spans = get_spans()
 	if(!language)
 		language = get_default_language()


### PR DESCRIPTION
:cl: oranges
del: You can no longer speak the ~ character in game
/:cl:

This character is used only be people who are low roleplay and do not fit with our server culture.

It's also not a pronounceable character.

I can extend this on request to a configurable list of blacklisted characters or words.
