### PR TITLE
Revert "flashbangs no longer damage blob tiles"

### DIFF
--- a/code/game/objects/items/grenades/flashbang.dm
+++ b/code/game/objects/items/grenades/flashbang.dm
@@ -13,6 +13,11 @@
 		return
 	for(var/mob/living/M in get_hearers_in_view(7, flashbang_turf))
 		bang(get_turf(M), M)
+
+	for(var/obj/structure/blob/B in get_hear(8,flashbang_turf))     		//Blob damage here
+		var/distance = get_dist(B, get_turf(src))
+		var/damage = round(100/(distance*distance)+1)
+		B.take_damage(damage, BURN, "energy")
 	qdel(src)
 
 /obj/item/grenade/flashbang/proc/bang(turf/T , mob/living/M)


### PR DESCRIPTION
Reverts tgstation/tgstation#30862
**Why:**
flashbangs are the only way to fight large portions of blob at a time without using methods that completely fuck up the area for everyone for long periods of time

the change is bad and dumb and should never have been merged