### PR TITLE
Revheads are now stealthier/harder to metagame

### DIFF
--- a/code/game/gamemodes/revolution/revolution.dm
+++ b/code/game/gamemodes/revolution/revolution.dm
@@ -154,8 +154,7 @@
 
 
 	var/obj/item/device/assembly/flash/T = new(mob)
-	var/obj/item/toy/crayon/spraycan/R = new(mob)
-	var/obj/item/clothing/glasses/hud/security/chameleon/C = new(mob)
+	var/obj/item/clothing/glasses/hud/security/chameleon/rev/C = new(mob)
 
 	var/list/slots = list (
 		"backpack" = slot_in_backpack,

--- a/code/game/gamemodes/revolution/revolution.dm
+++ b/code/game/gamemodes/revolution/revolution.dm
@@ -162,7 +162,7 @@
 		"right pocket" = slot_r_store
 	)
 	var/where = mob.equip_in_one_of_slots(T, slots)
-	S.Insert(mob, special = 0, drop_if_replaced = FALSE)
+	S.Insert(mob, special = FALSE, drop_if_replaced = FALSE)
 	to_chat(mob, "Your eyes have been implanted with a cybernetic security HUD which will help you keep track of who is mindshield-implanted, and therefore unable to be recruited.")
 
 	if (!where)

--- a/code/game/gamemodes/revolution/revolution.dm
+++ b/code/game/gamemodes/revolution/revolution.dm
@@ -154,7 +154,7 @@
 
 
 	var/obj/item/device/assembly/flash/T = new(mob)
-	var/obj/item/clothing/glasses/hud/security/chameleon/rev/C = new(mob)
+	var/obj/item/organ/cyberimp/eyes/hud/security/S = new(mob)
 
 	var/list/slots = list (
 		"backpack" = slot_in_backpack,
@@ -162,13 +162,8 @@
 		"right pocket" = slot_r_store
 	)
 	var/where = mob.equip_in_one_of_slots(T, slots)
-	var/where2 = mob.equip_in_one_of_slots(C, slots)
-	mob.equip_in_one_of_slots(R,slots)
-
-	if (!where2)
-		to_chat(mob, "The Syndicate were unfortunately unable to get you a chameleon security HUD.")
-	else
-		to_chat(mob, "The chameleon security HUD in your [where2] will help you keep track of who is mindshield-implanted, and unable to be recruited.")
+	S.Insert(mob, special = 0, drop_if_replaced = FALSE)
+	to_chat(mob, "Your eyes have been implanted with a cybernetic security HUD which will help you keep track of who is mindshield-implanted, and therefore unable to be recruited.")
 
 	if (!where)
 		to_chat(mob, "The Syndicate were unfortunately unable to get you a flash.")


### PR DESCRIPTION
:cl: Robustin
tweak: Revheads no longer spawn with chameleon glasses or a spraycan, instead they will start with a cybernetic security HUD implanted into their eyes. 
/:cl:

Instantly confirming revheads based on their eyewear and spraycan possession is silly. I have personally been metagamed as an assistant for wearing sunglasses and I will admit that if I'm hunting for revheads I will absolutely prioritize anyone wearing eyewear and I will often check that eyewear before deciding to implant them.

According to stats heads win more than revs so this seems like an uncontroversial change - so naturally I'm expecting a huge shitshow in the comments. 
