### PR TITLE
Fixes jump boots sleeper bug, adds return value to /atom/movable/throw_at

### DIFF
--- a/code/game/atoms_movable.dm
+++ b/code/game/atoms_movable.dm
@@ -317,7 +317,8 @@
 		step(src, AM.dir)
 	..()
 
-/atom/movable/proc/throw_at(atom/target, range, speed, mob/thrower, spin=TRUE, diagonals_first = FALSE, var/datum/callback/callback)
+/atom/movable/proc/throw_at(atom/target, range, speed, mob/thrower, spin=TRUE, diagonals_first = FALSE, var/datum/callback/callback) //If this returns FALSE then callback will not be called.
+	. = FALSE
 	if (!target || (flags_1 & NODROP_1) || speed <= 0)
 		return
 
@@ -346,7 +347,9 @@
 			//then lets add it to speed
 			speed += user_momentum
 			if (speed <= 0)
-				return //no throw speed, the user was moving too fast.
+				return//no throw speed, the user was moving too fast.
+
+	. = TRUE // No failure conditions past this point.
 
 	var/datum/thrownthing/TT = new()
 	TT.thrownthing = src

--- a/code/modules/clothing/shoes/miscellaneous.dm
+++ b/code/modules/clothing/shoes/miscellaneous.dm
@@ -195,24 +195,24 @@
 	var/jumping = FALSE //are we mid-jump?
 
 /obj/item/clothing/shoes/bhop/ui_action_click(mob/user, action)
-	if(!isliving(usr))
+	if(!isliving(user))
 		return
 
 	if(jumping)
 		return
 
 	if(recharging_time > world.time)
-		to_chat(usr, "<span class='warning'>The boot's internal propulsion needs to recharge still!</span>")
+		to_chat(user, "<span class='warning'>The boot's internal propulsion needs to recharge still!</span>")
 		return
 
-	var/atom/target = get_edge_target_turf(usr, usr.dir) //gets the user's direction
+	var/atom/target = get_edge_target_turf(user, user.dir) //gets the user's direction
 
-	if (usr.throw_at(target, jumpdistance, jumpspeed, spin = TRUE, diagonals_first = TRUE, callback = CALLBACK(src, .proc/hop_end)))
+	if (user.throw_at(target, jumpdistance, jumpspeed, spin = FALSE, diagonals_first = TRUE, callback = CALLBACK(src, .proc/hop_end)))
 		jumping = TRUE
 		playsound(src, 'sound/effects/stealthoff.ogg', 50, 1, 1)
-		usr.visible_message("<span class='warning'>[usr] dashes forward into the air!</span>")
+		user.visible_message("<span class='warning'>[usr] dashes forward into the air!</span>")
 	else
-		to_chat(usr, "<span class='warning'>Something prevents you from dashing forward!</span>")
+		to_chat(user, "<span class='warning'>Something prevents you from dashing forward!</span>")
 
 /obj/item/clothing/shoes/bhop/proc/hop_end()
 	jumping = FALSE

--- a/code/modules/clothing/shoes/miscellaneous.dm
+++ b/code/modules/clothing/shoes/miscellaneous.dm
@@ -207,10 +207,12 @@
 
 	var/atom/target = get_edge_target_turf(usr, usr.dir) //gets the user's direction
 
-	jumping = TRUE
-	playsound(src.loc, 'sound/effects/stealthoff.ogg', 50, 1, 1)
-	usr.visible_message("<span class='warning'>[usr] dashes forward into the air!</span>")
-	usr.throw_at(target, jumpdistance, jumpspeed, spin=0, diagonals_first = 1, callback = CALLBACK(src, .proc/hop_end))
+	if (usr.throw_at(target, jumpdistance, jumpspeed, spin=0, diagonals_first = 1, callback = CALLBACK(src, .proc/hop_end)))
+		jumping = TRUE
+		playsound(src.loc, 'sound/effects/stealthoff.ogg', 50, 1, 1)
+		usr.visible_message("<span class='warning'>[usr] dashes forward into the air!</span>")
+	else
+		to_chat(usr, "<span class='warning'>Something prevents you from dashing forward!</span>")
 
 /obj/item/clothing/shoes/bhop/proc/hop_end()
 	jumping = FALSE

--- a/code/modules/clothing/shoes/miscellaneous.dm
+++ b/code/modules/clothing/shoes/miscellaneous.dm
@@ -207,9 +207,9 @@
 
 	var/atom/target = get_edge_target_turf(usr, usr.dir) //gets the user's direction
 
-	if (usr.throw_at(target, jumpdistance, jumpspeed, spin=0, diagonals_first = 1, callback = CALLBACK(src, .proc/hop_end)))
+	if (usr.throw_at(target, jumpdistance, jumpspeed, spin = TRUE, diagonals_first = TRUE, callback = CALLBACK(src, .proc/hop_end)))
 		jumping = TRUE
-		playsound(src.loc, 'sound/effects/stealthoff.ogg', 50, 1, 1)
+		playsound(src, 'sound/effects/stealthoff.ogg', 50, 1, 1)
 		usr.visible_message("<span class='warning'>[usr] dashes forward into the air!</span>")
 	else
 		to_chat(usr, "<span class='warning'>Something prevents you from dashing forward!</span>")


### PR DESCRIPTION
Fixes #30963

Also, modifies /atom/movable/throw_at to return FALSE on an early failure condition (= callback will not be called) or TRUE otherwise (= callback will be called.)

Handling the return value will allow stuff that relies on a throw_at callback to continue functioning.

[Changelogs]: 
:cl: Naksu
fix: Fixed jump boots breaking if used when you can't jump, such as when inside a sleeper.
/:cl:

[why]: 
Bugfix
