### PR TITLE
Enables meteors to qdel normally, saving actual seconds of time spent harddeleting them otherwise

### DIFF
--- a/code/controllers/subsystem/augury.dm
+++ b/code/controllers/subsystem/augury.dm
@@ -14,6 +14,9 @@ SUBSYSTEM_DEF(augury)
 /datum/controller/subsystem/augury/proc/register_doom(atom/A, severity)
 	doombringers[A] = severity
 
+/datum/controller/subsystem/augury/proc/unregister_doom(atom/A)
+	doombringers -= A
+
 /datum/controller/subsystem/augury/fire()
 	var/biggest_doom = null
 	var/biggest_threat = null

--- a/code/game/gamemodes/meteor/meteors.dm
+++ b/code/game/gamemodes/meteor/meteors.dm
@@ -119,6 +119,7 @@ GLOBAL_LIST_INIT(meteorsC, list(/obj/effect/meteor/dust)) //for space dust event
 
 /obj/effect/meteor/Destroy()
 	GLOB.meteor_list -= src
+	SSaugury.unregister_doom(src)
 	walk(src,0) //this cancels the walk_towards() proc
 	. = ..()
 


### PR DESCRIPTION
SSaugury was holding a reference to them that was not cleaned up in destroy(). The subsystem cleans up its' list but but by the time the cleanup routine runs, the meteors have already been hard-deleted. 

At least that's my guess, I've limited experience with deletion stuff. In any case, meteors no longer harddel with these changes. 

[Changelogs]: 

:cl: Naksu
code: Removed meteor-related free lag.
/:cl:

[why]: 
Performance!
