### PR TITLE
Map fixes

### DIFF
--- a/_maps/map_files/BoxStation/BoxStation.dmm
+++ b/_maps/map_files/BoxStation/BoxStation.dmm
@@ -13334,6 +13334,7 @@
 	id = "chapelgun";
 	name = "Chapel Launcher Door"
 	},
+/obj/structure/fans/tiny,
 /turf/open/floor/plating,
 /area/chapel/main)
 "aEo" = (
@@ -27902,6 +27903,7 @@
 	id = "trash";
 	name = "disposal bay door"
 	},
+/obj/structure/fans/tiny,
 /turf/open/floor/plating,
 /area/maintenance/disposal)
 "bnw" = (
@@ -39042,6 +39044,7 @@
 	id = "toxinsdriver";
 	name = "toxins launcher bay door"
 	},
+/obj/structure/fans/tiny,
 /turf/open/floor/plating,
 /area/science/mixing)
 "bLm" = (
@@ -83826,7 +83829,7 @@ bHE
 bYu
 bZk
 bCq
-cTG
+cTF
 bCq
 bCq
 bCq
@@ -85122,7 +85125,7 @@ bCq
 bCq
 bCq
 bCq
-cTH
+cTF
 bCq
 bLv
 bLv

--- a/_maps/map_files/Deltastation/DeltaStation2.dmm
+++ b/_maps/map_files/Deltastation/DeltaStation2.dmm
@@ -46733,7 +46733,6 @@
 /turf/open/floor/carpet,
 /area/security/detectives_office)
 "bMX" = (
-/obj/machinery/computer/security/wooden_tv,
 /obj/structure/table/wood,
 /obj/machinery/button/door{
 	id = "detectivewindows";
@@ -46747,15 +46746,16 @@
 	pixel_y = -26
 	},
 /obj/structure/disposalpipe/segment,
+/obj/item/device/flashlight/lamp,
+/obj/item/reagent_containers/food/drinks/flask/det,
 /turf/open/floor/carpet,
 /area/security/detectives_office)
 "bMY" = (
 /obj/structure/table/wood,
-/obj/item/device/flashlight/lamp,
 /obj/item/storage/secure/safe{
 	pixel_x = 32
 	},
-/obj/item/reagent_containers/food/drinks/flask/det,
+/obj/machinery/computer/security/wooden_tv,
 /turf/open/floor/carpet,
 /area/security/detectives_office)
 "bMZ" = (

--- a/_maps/map_files/Deltastation/DeltaStation2.dmm
+++ b/_maps/map_files/Deltastation/DeltaStation2.dmm
@@ -30323,8 +30323,8 @@
 /obj/item/stack/sheet/metal{
 	amount = 50
 	},
-/obj/item/grenade/chem_grenade/metalfoam,
-/obj/item/grenade/chem_grenade/metalfoam,
+/obj/item/grenade/chem_grenade/smart_metal_foam,
+/obj/item/grenade/chem_grenade/smart_metal_foam,
 /obj/machinery/newscaster{
 	pixel_y = -32
 	},
@@ -67257,7 +67257,7 @@
 	pixel_x = -26
 	},
 /obj/structure/table/reinforced,
-/obj/item/grenade/chem_grenade/metalfoam,
+/obj/item/grenade/chem_grenade/smart_metal_foam,
 /turf/open/floor/plasteel/vault{
 	dir = 8
 	},
@@ -108371,8 +108371,8 @@
 	amount = 50
 	},
 /obj/item/crowbar,
-/obj/item/grenade/chem_grenade/metalfoam,
-/obj/item/grenade/chem_grenade/metalfoam,
+/obj/item/grenade/chem_grenade/smart_metal_foam,
+/obj/item/grenade/chem_grenade/smart_metal_foam,
 /obj/effect/turf_decal/bot,
 /obj/structure/sign/poster/official/report_crimes{
 	pixel_y = 32
@@ -136697,7 +136697,7 @@ aae
 aae
 aae
 aaf
-dYc
+aBW
 aae
 aae
 aaa
@@ -136948,7 +136948,7 @@ aaa
 aaa
 aae
 aaf
-dYc
+aBW
 aae
 aae
 aaa
@@ -137474,7 +137474,7 @@ dZB
 eab
 ear
 aaa
-dYc
+aBW
 aaa
 aaa
 aaa
@@ -139530,7 +139530,7 @@ dZB
 eaf
 ear
 aaa
-dYc
+aBW
 aae
 aae
 aae
@@ -140544,7 +140544,7 @@ dVy
 dUl
 aaf
 aaf
-dYc
+aBW
 aaa
 dZB
 eag
@@ -140558,7 +140558,7 @@ dZB
 eag
 ear
 aaa
-dYc
+aBW
 aaa
 aaa
 aaa
@@ -141061,14 +141061,14 @@ aaf
 aae
 aae
 aae
-dYc
+aBW
 aae
 aaa
 aaa
 aaf
 aaa
 aaa
-dYc
+aBW
 aae
 aae
 aaf
@@ -141325,7 +141325,7 @@ aae
 aaf
 aae
 aae
-dYc
+aBW
 aaa
 aaa
 aaa

--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -4182,6 +4182,7 @@
 	id = "trash";
 	name = "disposal bay door"
 	},
+/obj/structure/fans/tiny,
 /turf/open/floor/plating,
 /area/maintenance/disposal)
 "aig" = (
@@ -17389,8 +17390,8 @@
 	amount = 50
 	},
 /obj/item/crowbar,
-/obj/item/grenade/chem_grenade/metalfoam,
-/obj/item/grenade/chem_grenade/metalfoam,
+/obj/item/grenade/chem_grenade/smart_metal_foam,
+/obj/item/grenade/chem_grenade/smart_metal_foam,
 /obj/effect/turf_decal/bot{
 	dir = 1
 	},
@@ -23436,6 +23437,7 @@
 /turf/open/floor/plating,
 /area/storage/primary)
 "aTi" = (
+/obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/highsecurity{
 	locked = 0;
 	name = "AI Upload";
@@ -24856,6 +24858,7 @@
 /turf/closed/wall/r_wall,
 /area/ai_monitored/turret_protected/ai_upload_foyer)
 "aVY" = (
+/obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/highsecurity{
 	name = "Secure Network Access";
 	req_access_txt = "19"
@@ -36260,6 +36263,7 @@
 	d2 = 4;
 	icon_state = "0-4"
 	},
+/obj/item/paper_bin,
 /obj/item/stack/cable_coil/random,
 /obj/item/stack/cable_coil/random,
 /obj/item/stack/cable_coil/random,
@@ -36280,6 +36284,7 @@
 /area/storage/art)
 "brf" = (
 /obj/structure/table,
+/obj/item/paper_bin/construction,
 /obj/item/airlock_painter,
 /obj/machinery/airalarm{
 	dir = 8;
@@ -41266,8 +41271,8 @@
 /obj/item/stack/sheet/metal{
 	amount = 50
 	},
-/obj/item/grenade/chem_grenade/metalfoam,
-/obj/item/grenade/chem_grenade/metalfoam,
+/obj/item/grenade/chem_grenade/smart_metal_foam,
+/obj/item/grenade/chem_grenade/smart_metal_foam,
 /turf/open/floor/plasteel/caution{
 	dir = 8
 	},
@@ -69603,6 +69608,7 @@
 	id = "toxinsdriver";
 	name = "Toxins Launcher Bay Door"
 	},
+/obj/structure/fans/tiny,
 /turf/open/floor/plating,
 /area/science/mixing)
 "cDu" = (
@@ -77240,6 +77246,7 @@
 	id = "chapelgun";
 	name = "Chapel Launcher Door"
 	},
+/obj/structure/fans/tiny,
 /turf/open/floor/plating,
 /area/chapel/main)
 "cRQ" = (
@@ -128535,7 +128542,7 @@ aaa
 aaa
 aaf
 aaa
-aaX
+blx
 adl
 aQf
 adl

--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -13542,10 +13542,6 @@
 /turf/open/floor/carpet,
 /area/security/detectives_office)
 "azU" = (
-/obj/machinery/computer/security/wooden_tv{
-	pixel_x = 3;
-	pixel_y = 2
-	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 10
 	},
@@ -13556,6 +13552,11 @@
 	network = list("Prison");
 	pixel_y = 30
 	},
+/obj/item/device/flashlight/lamp/green{
+	pixel_x = 1;
+	pixel_y = 5
+	},
+/obj/item/restraints/handcuffs,
 /turf/open/floor/carpet,
 /area/security/detectives_office)
 "azV" = (
@@ -13563,16 +13564,15 @@
 /obj/item/storage/secure/safe{
 	pixel_x = 32
 	},
-/obj/item/device/flashlight/lamp/green{
-	pixel_x = 1;
-	pixel_y = 5
-	},
-/obj/item/restraints/handcuffs,
 /obj/machinery/button/door{
 	id = "detective_shutters";
 	name = "detective's office shutters control";
 	pixel_y = 26;
 	req_access_txt = "4"
+	},
+/obj/machinery/computer/security/wooden_tv{
+	pixel_x = 3;
+	pixel_y = 2
 	},
 /turf/open/floor/carpet,
 /area/security/detectives_office)

--- a/_maps/map_files/OmegaStation/OmegaStation.dmm
+++ b/_maps/map_files/OmegaStation/OmegaStation.dmm
@@ -13900,8 +13900,8 @@
 /obj/item/stack/sheet/metal{
 	amount = 50
 	},
-/obj/item/grenade/chem_grenade/metalfoam,
-/obj/item/grenade/chem_grenade/metalfoam,
+/obj/item/grenade/chem_grenade/smart_metal_foam,
+/obj/item/grenade/chem_grenade/smart_metal_foam,
 /obj/machinery/newscaster{
 	pixel_y = 32
 	},
@@ -20539,8 +20539,8 @@
 	amount = 50
 	},
 /obj/item/crowbar,
-/obj/item/grenade/chem_grenade/metalfoam,
-/obj/item/grenade/chem_grenade/metalfoam,
+/obj/item/grenade/chem_grenade/smart_metal_foam,
+/obj/item/grenade/chem_grenade/smart_metal_foam,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
@@ -35681,6 +35681,7 @@
 	id = "chapelmassdoor";
 	name = "Chapel Launcher Door"
 	},
+/obj/structure/fans/tiny,
 /turf/open/floor/plating,
 /area/chapel/main)
 "blJ" = (

--- a/_maps/map_files/PubbyStation/PubbyStation.dmm
+++ b/_maps/map_files/PubbyStation/PubbyStation.dmm
@@ -13789,8 +13789,7 @@
 	pixel_x = -1;
 	pixel_y = 9
 	},
-/obj/item/reagent_containers/food/drinks/drinkingglass/shotglass{
-	},
+/obj/item/reagent_containers/food/drinks/drinkingglass/shotglass,
 /obj/item/reagent_containers/food/drinks/drinkingglass/shotglass{
 	pixel_x = 7;
 	pixel_y = 2
@@ -16903,6 +16902,7 @@
 	id = "trash";
 	name = "disposal bay door"
 	},
+/obj/structure/fans/tiny,
 /turf/open/floor/plating,
 /area/maintenance/disposal)
 "aLo" = (
@@ -41644,6 +41644,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
+/obj/structure/fans/tiny,
 /turf/open/floor/plating,
 /area/science/mineral_storeroom)
 "bMr" = (
@@ -45768,7 +45769,7 @@
 /area/storage/tech)
 "bVL" = (
 /obj/structure/table,
-/obj/item/storage/box/metalfoam{
+/obj/item/storage/box/smart_metal_foam{
 	pixel_x = 4;
 	pixel_y = 7
 	},
@@ -103836,8 +103837,8 @@ aaa
 aaa
 aaa
 aLn
-aLn
 aNT
+aQo
 aPg
 aQl
 aRu


### PR DESCRIPTION
Fixes #30978 
Fixes #31002 on Meta & Delta

Made all engineering / atmos foam grenades the smart foam variant. The ones on the shuttles and such are still normal foam. 

Also fixes missing fans in the chapel, disposals, and toxins massdriver rooms on all the other maps (some had them, some didn't. Just made them all consistent.)