### PR TITLE
Fixes alium leap exploit

### DIFF
--- a/code/modules/mob/living/carbon/alien/humanoid/caste/hunter.dm
+++ b/code/modules/mob/living/carbon/alien/humanoid/caste/hunter.dm
@@ -38,11 +38,11 @@
 #define MAX_ALIEN_LEAP_DIST 7
 
 /mob/living/carbon/alien/humanoid/hunter/proc/leap_at(atom/A)
-	if(pounce_cooldown > world.time)
-		to_chat(src, "<span class='alertalien'>You are too fatigued to pounce right now!</span>")
+	if(!canmove || leaping)
 		return
 
-	if(leaping || stat || buckled || lying)
+	if(pounce_cooldown > world.time)
+		to_chat(src, "<span class='alertalien'>You are too fatigued to pounce right now!</span>")
 		return
 
 	if(!has_gravity() || !A.has_gravity())
@@ -66,6 +66,7 @@
 	if(!leaping)
 		return ..()
 
+	pounce_cooldown = world.time + pounce_cooldown_time
 	if(A)
 		if(isliving(A))
 			var/mob/living/L = A
@@ -83,7 +84,6 @@
 				Knockdown(40, 1, 1)
 
 			toggle_leap(0)
-			pounce_cooldown = world.time + pounce_cooldown_time
 		else if(A.density && !A.CanPass(src))
 			visible_message("<span class ='danger'>[src] smashes into [A]!</span>", "<span class ='alertalien'>[src] smashes into [A]!</span>")
 			Knockdown(40, 1, 1)


### PR DESCRIPTION
Fixes https://i.imgur.com/be4Wpvk.mp4

Aliums were able to leap infinitely unless they hit a player, even if they hit something else that stunned them (ie smashed face first into a wall.)

Once they hit a player, there was a sleep before setting the cooldown, allowing an alien player with an autoclicker to leap up to 5 more times, stunning another player for 10 seconds with each additional leap before the cooldown was set.

This makes it so that the cooldown is always set after leaping.

Also reordered the cooldown message so that it checks if you're able to move /before/ yelling at you that it's still on cooldown.