### PR TITLE
Fixes MMI to AI law transfer

### DIFF
--- a/code/game/gamemodes/clock_cult/clock_items/soul_vessel.dm
+++ b/code/game/gamemodes/clock_cult/clock_items/soul_vessel.dm
@@ -23,6 +23,7 @@
 	autoping = FALSE
 	resistance_flags = FIRE_PROOF | ACID_PROOF
 	force_replace_ai_name = TRUE
+	overrides_aicore_laws = TRUE
 
 /obj/item/device/mmi/posibrain/soul_vessel/Initialize()
 	. = ..()

--- a/code/game/objects/structures/ai_core.dm
+++ b/code/game/objects/structures/ai_core.dm
@@ -174,7 +174,14 @@
 						SSticker.mode.remove_antag_for_borging(brain.brainmob.mind)
 						if(!istype(brain.laws, /datum/ai_laws/ratvar))
 							remove_servant_of_ratvar(brain.brainmob, TRUE)
-						var/mob/living/silicon/ai/A = new /mob/living/silicon/ai(loc, brain.laws, brain.brainmob)
+
+						var/mob/living/silicon/ai/A = null
+
+						if (brain.overrides_aicore_laws)
+							A = new /mob/living/silicon/ai(loc, brain.laws, brain.brainmob)
+						else
+							A = new /mob/living/silicon/ai(loc, laws, brain.brainmob)
+
 						if(brain.force_replace_ai_name)
 							A.fully_replace_character_name(A.name, brain.replacement_ai_name())
 						SSblackbox.inc("cyborg_ais_created",1)

--- a/code/game/objects/structures/ai_core.dm
+++ b/code/game/objects/structures/ai_core.dm
@@ -45,14 +45,13 @@
 		switch(state)
 			if(EMPTY_CORE)
 				if(istype(P, /obj/item/circuitboard/aicore))
-					if(!user.drop_item())
+					if(!user.transferItemToLoc(P, src))
 						return
 					playsound(loc, 'sound/items/deconstruct.ogg', 50, 1)
 					to_chat(user, "<span class='notice'>You place the circuit board inside the frame.</span>")
 					update_icon()
 					state = CIRCUIT_CORE
 					circuit = P
-					P.forceMove(src)
 					return
 			if(CIRCUIT_CORE)
 				if(istype(P, /obj/item/screwdriver))
@@ -143,10 +142,9 @@
 						to_chat(user, "<span class='warning'>This [M.name] is mindless!</span>")
 						return
 
-					if(!user.drop_item())
+					if(!user.transferItemToLoc(M,src))
 						return
 
-					M.forceMove(src)
 					brain = M
 					to_chat(user, "<span class='notice'>You add [M.name] to the frame.</span>")
 					update_icon()
@@ -176,7 +174,7 @@
 						SSticker.mode.remove_antag_for_borging(brain.brainmob.mind)
 						if(!istype(brain.laws, /datum/ai_laws/ratvar))
 							remove_servant_of_ratvar(brain.brainmob, TRUE)
-						var/mob/living/silicon/ai/A = new /mob/living/silicon/ai(loc, laws, brain.brainmob)
+						var/mob/living/silicon/ai/A = new /mob/living/silicon/ai(loc, brain.laws, brain.brainmob)
 						if(brain.force_replace_ai_name)
 							A.fully_replace_character_name(A.name, brain.replacement_ai_name())
 						SSblackbox.inc("cyborg_ais_created",1)

--- a/code/modules/mob/living/brain/MMI.dm
+++ b/code/modules/mob/living/brain/MMI.dm
@@ -13,6 +13,7 @@
 	var/obj/item/organ/brain/brain = null //The actual brain
 	var/datum/ai_laws/laws = new()
 	var/force_replace_ai_name = FALSE
+	var/overrides_aicore_laws = FALSE // Whether the laws on the MMI, if any, override possible pre-existing laws loaded on the AI core.
 
 /obj/item/device/mmi/update_icon()
 	if(brain)
@@ -203,6 +204,7 @@
 	name = "Syndicate Man-Machine Interface"
 	desc = "Syndicate's own brand of MMI. It enforces laws designed to help Syndicate agents achieve their goals upon cyborgs and AIs created with it."
 	origin_tech = "biotech=4;programming=4;syndicate=2"
+	overrides_aicore_laws = TRUE
 
 /obj/item/device/mmi/syndie/Initialize()
 	. = ..()

--- a/code/modules/mob/living/brain/MMI.dm
+++ b/code/modules/mob/living/brain/MMI.dm
@@ -204,7 +204,7 @@
 	desc = "Syndicate's own brand of MMI. It enforces laws designed to help Syndicate agents achieve their goals upon cyborgs and AIs created with it."
 	origin_tech = "biotech=4;programming=4;syndicate=2"
 
-/obj/item/device/mmi/syndie/New()
-	..()
+/obj/item/device/mmi/syndie/Initialize()
+	. = ..()
 	laws = new /datum/ai_laws/syndicate_override()
 	radio.on = 0


### PR DESCRIPTION
Fixes #31004

Newly-built AIs were always initialized with the laws of the AI core itself, which default to Asimov, instead of the laws of the MMI. Also contains very minor (tested) touchups to nearby code. 

[Changelogs]:

:cl: Naksu
fix: Syndicate MMIs will now properly transfer their laws to newly-constructed AIs
/:cl:

[why]: 
Bugfix
