### PR TITLE
GetAllContents performance increase

### DIFF
--- a/code/__HELPERS/unsorted.dm
+++ b/code/__HELPERS/unsorted.dm
@@ -503,6 +503,14 @@ Turf and target are separate in case you want to teleport some distance from a t
 	return y
 
 /atom/proc/GetAllContents(list/ignore_typecache)
+	if(prob(50))
+		return OldGetAllContents(ignore_typecache)
+	return NewGetAllContents(ignore_typecache)
+	
+/atom/proc/OldGetAllContents(a)
+	return _OldGetAllContents(a)
+
+/atom/proc/_OldGetAllContents(list/ignore_typecache)
 	var/list/processing_list = list(src)
 	var/list/assembled = list()
 	if(ignore_typecache)		//If there's a typecache, use it.
@@ -524,6 +532,17 @@ Turf and target are separate in case you want to teleport some distance from a t
 			assembled |= A
 
 	return assembled
+
+/atom/proc/NewGetAllContents(a)
+	return _NewGetAllContents(a)
+ 
+/atom/proc/_NewGetAllContents(list/ignore_typecache=list(),list/output=list())
+	. = output
+	if(!ignore_typecache[src])
+		output += src 
+	for(var/i in 1 to contents.len) 
+		var/atom/thing = contents[i] 
+		thing._NewGetAllContents(ignore_typecache,output) 
 
 //Step-towards method of determining whether one atom can see another. Similar to viewers()
 /proc/can_see(atom/source, atom/target, length=5) // I couldnt be arsed to do actual raycasting :I This is horribly inaccurate.

--- a/code/__HELPERS/unsorted.dm
+++ b/code/__HELPERS/unsorted.dm
@@ -502,47 +502,12 @@ Turf and target are separate in case you want to teleport some distance from a t
 	var/y=arcsin(x/sqrt(1+x*x))
 	return y
 
-/atom/proc/GetAllContents(list/ignore_typecache)
-	if(prob(50))
-		return OldGetAllContents(ignore_typecache)
-	return NewGetAllContents(ignore_typecache)
-	
-/atom/proc/OldGetAllContents(a)
-	return _OldGetAllContents(a)
-
-/atom/proc/_OldGetAllContents(list/ignore_typecache)
-	var/list/processing_list = list(src)
-	var/list/assembled = list()
-	if(ignore_typecache)		//If there's a typecache, use it.
-		while(processing_list.len)
-			var/atom/A = processing_list[1]
-			processing_list -= A
-			if(ignore_typecache[A.type])
-				continue
-			processing_list |= (A.contents - assembled)
-			assembled |= A
-
-	else		//If there's none, only make this check once for performance.
-		while(processing_list.len)
-			var/atom/A = processing_list[1]
-			processing_list -= A
-
-			processing_list |= (A.contents - assembled)
-
-			assembled |= A
-
-	return assembled
-
-/atom/proc/NewGetAllContents(a)
-	return _NewGetAllContents(a)
- 
-/atom/proc/_NewGetAllContents(list/ignore_typecache=list(),list/output=list())
+/atom/proc/GetAllContents(list/output=list())
 	. = output
-	if(!ignore_typecache[src])
-		output += src 
+	output += src 
 	for(var/i in 1 to contents.len) 
 		var/atom/thing = contents[i] 
-		thing._NewGetAllContents(ignore_typecache,output) 
+		thing.GetAllContents(output) 
 
 //Step-towards method of determining whether one atom can see another. Similar to viewers()
 /proc/can_see(atom/source, atom/target, length=5) // I couldnt be arsed to do actual raycasting :I This is horribly inaccurate.

--- a/code/game/turfs/turf.dm
+++ b/code/game/turfs/turf.dm
@@ -444,7 +444,7 @@
 /turf/proc/empty(turf_type=/turf/open/space, baseturf_type, list/ignore_typecache, forceop = FALSE)
 	// Remove all atoms except observers, landmarks, docking ports
 	var/static/list/ignored_atoms = typecacheof(list(/mob/dead, /obj/effect/landmark, /obj/docking_port, /atom/movable/lighting_object))
-	var/list/allowed_contents = typecache_filter_list_reverse(GetAllContents(ignore_typecache), ignored_atoms)
+	var/list/allowed_contents = typecache_filter_list_reverse(GetAllContents(), ignored_atoms | ignore_typecache)
 	allowed_contents -= src
 	for(var/i in 1 to allowed_contents.len)
 		var/thing = allowed_contents[i]


### PR DESCRIPTION
It seems a self referential method works better than the list method, even with the proc call costs.

![profiling](https://puu.sh/xJfTZ/853a8821f7.png)

(In case you dont remember, the order from left to right is: `Self CPU` `Total CPU` `Real Time` `Calls`)

The new GetAllContents had to be wrapped because it calls itself, thus both had to be wrapped to maintain parity in profiling.