### PR TITLE
Wizard can't cast shout or whisper spells when he is unable to speak

### DIFF
--- a/code/modules/spells/spell.dm
+++ b/code/modules/spells/spell.dm
@@ -161,7 +161,7 @@ GLOBAL_LIST_INIT(spells, typesof(/obj/effect/proc_holder/spell)) //needed for th
 
 		var/mob/living/carbon/human/H = user
 
-		if((invocation_type == "whisper" || invocation_type == "shout") && H.is_muzzled())
+		if((invocation_type == "whisper" || invocation_type == "shout") && !H.can_speak_vocal())
 			to_chat(user, "<span class='notice'>You can't get the words out!</span>")
 			return 0
 

--- a/code/modules/spells/spell_types/godhand.dm
+++ b/code/modules/spells/spell_types/godhand.dm
@@ -49,6 +49,9 @@
 /obj/item/melee/touch_attack/disintegrate/afterattack(atom/target, mob/living/carbon/user, proximity)
 	if(!proximity || target == user || !ismob(target) || !iscarbon(user) || user.lying || user.handcuffed) //exploding after touching yourself would be bad
 		return
+	if(!user.can_speak_vocal())
+		to_chat(user, "<span class='notice'>You can't get the words out!</span>")
+		return
 	var/mob/M = target
 	do_sparks(4, FALSE, M.loc)
 	M.gib()
@@ -67,6 +70,9 @@
 		return
 	if(user.lying || user.handcuffed)
 		to_chat(user, "<span class='warning'>You can't reach out!</span>")
+		return
+	if(!user.can_speak_vocal())
+		to_chat(user, "<span class='notice'>You can't get the words out!</span>")
 		return
 	var/mob/living/M = target
 	M.Stun(40)


### PR DESCRIPTION
[Changelogs]:

:cl: 
tweak: Wizard cannot cast spoken or whispered spells while mute
/:cl:

[why]: # Before, only the muzzle stopped the wizard from casting spells with spoken components, now anything that stops speaking, like chemicals or surgery, will stop those spells
