### PR TITLE
Removes RPD from hacked autolathes

### DIFF
--- a/code/modules/research/designs/autolathe_designs.dm
+++ b/code/modules/research/designs/autolathe_designs.dm
@@ -592,14 +592,6 @@
 	build_path = /obj/item/construction/rcd
 	category = list("hacked", "Construction")
 
-/datum/design/rpd
-	name = "Rapid Pipe Dispenser (RPD)"
-	id = "rpd"
-	build_type = AUTOLATHE
-	materials = list(MAT_METAL = 75000, MAT_GLASS = 37500)
-	build_path = /obj/item/pipe_dispenser
-	category = list("hacked", "Construction")
-
 /datum/design/electropack
 	name = "Electropack"
 	id = "electropack"


### PR DESCRIPTION
Removes rpds from hacked autolathes

:cl: Improvedname
tweak: Hacked autolathes no longer dispense RPDs
/:cl:

[why]: # (Please add a short description [two lines down] of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.)

Because these things were added to give atmos techs an easier time replacing pipes then carrying the whole solid dispenser.

The only pros of it being in the autolathe were the following 

Pros:

Assistants had a easier time building improvised shotguns without sabotaging station parts or getting to the atmos dispenser

Atmos techs having a easier time repairing times and placing them

Cons:

There isn't a intercourse anymore with assistants wrenching pipes to make improvised weaponry giving less work to atmos tech

Atmos tech is still useless why arent we removing them yet and make it just engineers
