### PR TITLE
Blackbox stat for internet midis

### DIFF
--- a/code/modules/admin/verbs/playsound.dm
+++ b/code/modules/admin/verbs/playsound.dm
@@ -92,6 +92,7 @@
 						pitch = pick(0.5, 0.7, 0.8, 0.85, 0.9, 0.95, 1.1, 1.2, 1.4, 1.6, 2.0, 2.5)
 						to_chat(src, "You feel the Honkmother messing with your song...")
 
+					SSblackbox.add_details("played_url", web_sound_input)
 					log_admin("[key_name(src)] played web sound: [web_sound_input]")
 					message_admins("[key_name(src)] played web sound: [web_sound_input]")
 			else


### PR DESCRIPTION
New blackbox stat when playing internet midis, which stores the url played. This only happens when the url is valid and successfully plays.

nfreader/newSS13tools#63