### PR TITLE
AFK players count as dead for the assassinate objective

### DIFF
--- a/code/game/gamemodes/objective.dm
+++ b/code/game/gamemodes/objective.dm
@@ -121,7 +121,7 @@
 	return target
 
 /datum/objective/assassinate/check_completion()
-	return !target || !considered_alive(target)
+	return !target || !considered_alive(target) || considered_afk(target)
 
 /datum/objective/assassinate/update_explanation_text()
 	..()

--- a/code/game/gamemodes/objective.dm
+++ b/code/game/gamemodes/objective.dm
@@ -121,7 +121,7 @@
 	return target
 
 /datum/objective/assassinate/check_completion()
-	return !target || !considered_alive(target) || considered_afk(target)
+	return !considered_alive(target) || considered_afk(target)
 
 /datum/objective/assassinate/update_explanation_text()
 	..()


### PR DESCRIPTION
:cl: Y0SH1_M4S73R
fix: AFK players count as dead for the assassinate objective.
/:cl:

Is it i ded if I didn't actually die?
