### PR TITLE
Fixes MMI buckled-warning

### DIFF
--- a/code/modules/mob/living/brain/MMI.dm
+++ b/code/modules/mob/living/brain/MMI.dm
@@ -200,7 +200,7 @@
 			to_chat(user, "<span class='notice'>The MMI indicates the brain is active.</span>")
 
 /obj/item/device/mmi/relaymove()
-	return
+	return //so that the MMI won't get a warning about not being able to move if it tries to move
 
 /obj/item/device/mmi/syndie
 	name = "Syndicate Man-Machine Interface"

--- a/code/modules/mob/living/brain/MMI.dm
+++ b/code/modules/mob/living/brain/MMI.dm
@@ -199,6 +199,8 @@
 		else
 			to_chat(user, "<span class='notice'>The MMI indicates the brain is active.</span>")
 
+/obj/item/device/mmi/relaymove()
+	return
 
 /obj/item/device/mmi/syndie
 	name = "Syndicate Man-Machine Interface"


### PR DESCRIPTION
Makes the MMI not have a warning about being buckled when trying to move.

Fixes #30991 