### PR TITLE
Silver slime extracts create proper fried foods

### DIFF
--- a/code/modules/food_and_drinks/food/snacks_bread.dm
+++ b/code/modules/food_and_drinks/food/snacks_bread.dm
@@ -185,6 +185,37 @@
 	icon_state = ""
 	bitesize = 2
 
+/obj/item/reagent_containers/food/snacks/deepfryholder/proc/fry(obj/item/frying, datum/reagents/reagents, cook_time = 30)
+	if(istype(frying, /obj/item/reagent_containers/))
+		var/obj/item/reagent_containers/food = frying
+		food.reagents.trans_to(src, food.reagents.total_volume)
+	icon = frying.icon
+	overlays = frying.overlays
+	icon_state = frying.icon_state
+	desc = frying.desc
+	w_class = frying.w_class
+	reagents.trans_to(src, 2*(cook_time/15))
+	switch(cook_time)
+		if(0 to 15)
+			add_atom_colour(rgb(166,103,54), FIXED_COLOUR_PRIORITY)
+			name = "lightly-fried [frying.name]"
+		if(16 to 49)
+			add_atom_colour(rgb(103,63,24), FIXED_COLOUR_PRIORITY)
+			name = "fried [frying.name]"
+		if(50 to 59)
+			add_atom_colour(rgb(63,23,4), FIXED_COLOUR_PRIORITY)
+			name = "deep-fried [frying.name]"
+		if(60 to INFINITY)
+			add_atom_colour(rgb(33,19,9), FIXED_COLOUR_PRIORITY)
+			name = "the physical manifestation of the very concept of fried foods"
+			desc = "A heavily fried...something.  Who can tell anymore?"
+	filling_color = color
+	foodtype |= FRIED
+	if(istype(frying, /obj/item/reagent_containers/food/snacks/))
+		qdel(frying)
+	else
+		frying.forceMove(src)
+
 /obj/item/reagent_containers/food/snacks/butteredtoast
 	name = "buttered toast"
 	desc = "Butter lightly spread over a piece of toast."

--- a/code/modules/food_and_drinks/kitchen_machinery/deep_fryer.dm
+++ b/code/modules/food_and_drinks/kitchen_machinery/deep_fryer.dm
@@ -82,36 +82,7 @@ insert ascii eagle on american flag background here
 		if(frying.loc == src)
 			to_chat(user, "<span class='notice'>You eject [frying] from [src].</span>")
 			var/obj/item/reagent_containers/food/snacks/deepfryholder/S = new(get_turf(src))
-			if(istype(frying, /obj/item/reagent_containers/))
-				var/obj/item/reagent_containers/food = frying
-				food.reagents.trans_to(S, food.reagents.total_volume)
-			S.icon = frying.icon
-			S.overlays = frying.overlays
-			S.icon_state = frying.icon_state
-			S.desc = frying.desc
-			S.w_class = frying.w_class
-			reagents.trans_to(S, 2*(cook_time/15))
-			switch(cook_time)
-				if(0 to 15)
-					S.add_atom_colour(rgb(166,103,54), FIXED_COLOUR_PRIORITY)
-					S.name = "lightly-fried [frying.name]"
-				if(16 to 49)
-					S.add_atom_colour(rgb(103,63,24), FIXED_COLOUR_PRIORITY)
-					S.name = "fried [frying.name]"
-				if(50 to 59)
-					S.add_atom_colour(rgb(63,23,4), FIXED_COLOUR_PRIORITY)
-					S.name = "deep-fried [frying.name]"
-				if(60 to INFINITY)
-					S.add_atom_colour(rgb(33,19,9), FIXED_COLOUR_PRIORITY)
-					S.name = "the physical manifestation of the very concept of fried foods"
-					S.desc = "A heavily fried...something.  Who can tell anymore?"
-			S.filling_color = S.color
-			S.foodtype |= FRIED
-			if(istype(frying, /obj/item/reagent_containers/food/snacks/))
-				qdel(frying)
-			else
-				frying.forceMove(S)
-
+			S.fry(frying, reagents, cook_time)
 			icon_state = "fryer_off"
 			user.put_in_hands(S)
 			frying = null

--- a/code/modules/reagents/chemistry/recipes/slime_extracts.dm
+++ b/code/modules/reagents/chemistry/recipes/slime_extracts.dm
@@ -151,6 +151,12 @@
 	for(var/i in 1 to 4 + rand(1,2))
 		var/chosen = pick(borks)
 		var/obj/B = new chosen(T)
+		if(prob(5))//Fry it!
+			var/obj/item/reagent_containers/food/snacks/deepfryholder/D = new(T)
+			var/datum/reagents/reagents = new(25)
+			reagents.add_reagent("nutriment", 25)
+			D.fry(B, reagents)
+			B = D
 		if(prob(50))
 			for(var/j in 1 to rand(1, 3))
 				step(B, pick(NORTH,SOUTH,EAST,WEST))
@@ -173,6 +179,7 @@
 		/obj/item/reagent_containers/food/snacks/soup,
 		/obj/item/reagent_containers/food/snacks/grown,
 		/obj/item/reagent_containers/food/snacks/grown/mushroom,
+		/obj/item/reagent_containers/food/snacks/deepfryholder
 		)
 	blocked |= typesof(/obj/item/reagent_containers/food/snacks/customizable)
 


### PR DESCRIPTION
Silver slime extracts will no longer create empty fried food holders. Instead they have a 5% chance of frying the food.
Moved the actual frying code to the fried food holder to avoid code copy/paste.