### PR TITLE
Fixes servertools branch revision # location

### DIFF
--- a/code/datums/helper_datums/getrev.dm
+++ b/code/datums/helper_datums/getrev.dm
@@ -13,7 +13,7 @@
 		date = unix2date(text2num(logs[5]))
 		commit = logs[2]
 		log_world("[date]")
-	logs = world.file2list(".git/logs/refs/remotes/origin/master")
+	logs = world.file2list(".git/logs/refs/remotes/origin/ServerToolsAPIv31")
 	if(logs)
 		originmastercommit = splittext(logs[logs.len - 1], " ")[2]
 


### PR DESCRIPTION
Wrong location was causing it to show "Revision Unknown" w/ Show Server Revision ingame.