### PR TITLE
Small refactor to movement

### DIFF
--- a/code/game/atoms_movable.dm
+++ b/code/game/atoms_movable.dm
@@ -225,6 +225,17 @@
 		A.CollidedWith(src)
 
 /atom/movable/proc/forceMove(atom/destination)
+	. = FALSE
+	if(destination)
+		. = doMove(destination)
+	else
+		CRASH("No valid destination passed into forceMove")
+
+/atom/movable/proc/moveToNullspace()
+	return doMove(null)
+
+/atom/movable/proc/doMove(atom/destination)
+	. = FALSE
 	if(destination)
 		if(pulledby)
 			pulledby.stop_pulling()
@@ -251,8 +262,17 @@
 				AM.Crossed(src, oldloc)
 
 		Moved(oldloc, 0)
-		return 1
-	return 0
+		. = TRUE
+
+	//If no destination, move the atom into nullspace (don't do this unless you know what you're doing)
+	else
+		. = TRUE
+		var/atom/oldloc = loc
+		var/area/old_area = get_area(oldloc)
+		oldloc.Exited(src, null)
+		if(old_area)
+			old_area.Exited(src, null)
+		loc = null
 
 /mob/living/forceMove(atom/destination)
 	stop_pulling()
@@ -261,9 +281,10 @@
 	if(has_buckled_mobs())
 		unbuckle_all_mobs(force=1)
 	. = ..()
-	if(client)
-		reset_perspective(destination)
-	update_canmove() //if the mob was asleep inside a container and then got forceMoved out we need to make them fall.
+	if(.)
+		if(client)
+			reset_perspective(destination)
+		update_canmove() //if the mob was asleep inside a container and then got forceMoved out we need to make them fall.
 
 /mob/living/brain/forceMove(atom/destination)
 	if(container)

--- a/code/modules/mob/living/silicon/silicon_movement.dm
+++ b/code/modules/mob/living/silicon/silicon_movement.dm
@@ -4,7 +4,9 @@
 
 /mob/living/silicon/forceMove(atom/destination)
 	. = ..()
-	update_camera_location(destination)
+	//Only bother updating the camera if we actually managed to move
+	if(.)
+		update_camera_location(destination)
 
 /mob/living/silicon/proc/do_camera_update(oldLoc)
 	if(!QDELETED(builtInCamera) && oldLoc != get_turf(src))


### PR DESCRIPTION
You can now move an object into nullspace, which will call exited on
it's parent and parent area but will not call any entered.

Note that you cannot pass null into forceMove it will crash, instead use
the new proc that will call the underlying logic with a null destination

Some of the force move procs have been refactored to check that their
parent move succeeded before doing updates

replaces #31070 