### PR TITLE
Fixes Poly lying about his age

### DIFF
--- a/code/modules/mob/living/simple_animal/parrot.dm
+++ b/code/modules/mob/living/simple_animal/parrot.dm
@@ -899,9 +899,6 @@
 
 /mob/living/simple_animal/parrot/Poly/Life()
 	if(!stat && SSticker.current_state == GAME_STATE_FINISHED && !memory_saved)
-		rounds_survived = max(++rounds_survived,1)
-		if(rounds_survived > longest_survival)
-			longest_survival = rounds_survived
 		Write_Memory(FALSE)
 		memory_saved = TRUE
 	..()


### PR DESCRIPTION
Recently Poly was transitioned to increment his stats in Write_Memory, but the old incrementer was still around, which lead poly to +2 his age every round.