### PR TITLE
Fix dangling #elseif in list helpers

### DIFF
--- a/code/__HELPERS/_lists.dm
+++ b/code/__HELPERS/_lists.dm
@@ -474,7 +474,7 @@
 #error Remie said that lummox was adding a way to get a lists
 #error contents via list.values, if that is true remove this
 #error otherwise, update the version and bug lummox
-#elseif
+#endif
 //Flattens a keyed list into a list of it's contents
 /proc/flatten_list(list/key_list)
 	if(!islist(key_list))


### PR DESCRIPTION
Minor cleanup, so the entire codebase isn't in a big conditionless `#elseif` on `DM_VERSION`.