### PR TITLE
Cleanup operative landmarks

### DIFF
--- a/_maps/map_files/BoxStation/BoxStation.dmm
+++ b/_maps/map_files/BoxStation/BoxStation.dmm
@@ -7441,14 +7441,6 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/crew_quarters/fitness)
-"aqt" = (
-/obj/effect/landmark/syndicate_breach_area,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating,
-/area/crew_quarters/fitness)
 "aqu" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 10

--- a/_maps/map_files/BoxStation/BoxStation.dmm
+++ b/_maps/map_files/BoxStation/BoxStation.dmm
@@ -14777,7 +14777,6 @@
 /turf/open/floor/plating,
 /area/chapel/main)
 "aHr" = (
-/obj/effect/landmark/marauder_entry,
 /turf/open/space,
 /area/space)
 "aHs" = (
@@ -100719,7 +100718,7 @@ aaa
 aaa
 aaa
 aaa
-aqt
+aqs
 aro
 aro
 aro

--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -178,7 +178,6 @@
 /turf/open/floor/plasteel/airless/solarpanel,
 /area/solar/port/fore)
 "aav" = (
-/obj/effect/landmark/marauder_entry,
 /turf/open/space,
 /area/space)
 "aaw" = (
@@ -129060,7 +129059,7 @@ aaa
 aaa
 bii
 aaa
-aeD
+aeC
 afD
 afD
 afD

--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -2224,14 +2224,6 @@
 	},
 /turf/open/floor/plating,
 /area/crew_quarters/fitness/recreation)
-"aeD" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/effect/landmark/syndicate_breach_area,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/crew_quarters/fitness/recreation)
 "aeE" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{

--- a/_maps/map_files/generic/CentCom.dmm
+++ b/_maps/map_files/generic/CentCom.dmm
@@ -5751,6 +5751,10 @@
 /obj/structure/mirror{
 	pixel_x = 28
 	},
+/obj/structure/sink{
+	dir = 4;
+	pixel_x = 11
+	},
 /turf/open/floor/plasteel/freezer{
 	dir = 2
 	},
@@ -6101,7 +6105,7 @@
 /area/syndicate_mothership/control)
 "qp" = (
 /obj/structure/chair/stool,
-/obj/effect/landmark/syndicate_spawn,
+/obj/effect/landmark/start/nukeop,
 /turf/open/floor/plasteel/bar{
 	dir = 2
 	},
@@ -6506,6 +6510,7 @@
 /area/syndicate_mothership/control)
 "rj" = (
 /obj/structure/closet/cardboard,
+/obj/effect/turf_decal/stripes/corner,
 /turf/open/floor/plating/airless,
 /area/syndicate_mothership/control)
 "rk" = (
@@ -7623,7 +7628,7 @@
 /turf/open/floor/wood,
 /area/syndicate_mothership/control)
 "tT" = (
-/obj/effect/landmark/syndicate_spawn,
+/obj/effect/landmark/start/nukeop_leader,
 /turf/open/floor/wood,
 /area/syndicate_mothership/control)
 "tU" = (
@@ -8025,6 +8030,9 @@
 /area/syndicate_mothership/control)
 "vb" = (
 /obj/structure/closet/cardboard/metal,
+/obj/effect/turf_decal/stripes/corner{
+	dir = 8
+	},
 /turf/open/floor/plating/airless,
 /area/syndicate_mothership/control)
 "vc" = (
@@ -9731,7 +9739,6 @@
 /area/wizard_station)
 "zj" = (
 /obj/structure/table/wood,
-/obj/effect/landmark/teleport_scroll,
 /obj/item/dice/d20,
 /obj/item/dice,
 /turf/open/floor/carpet,
@@ -13652,6 +13659,44 @@
 	},
 /turf/open/floor/holofloor,
 /area/holodeck/rec_center/school)
+"QT" = (
+/obj/effect/turf_decal/stripes/corner,
+/turf/open/floor/plating/airless,
+/area/syndicate_mothership/control)
+"QU" = (
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/plating/airless,
+/area/syndicate_mothership/control)
+"QV" = (
+/obj/effect/turf_decal/stripes/corner{
+	dir = 1
+	},
+/turf/open/floor/plating/airless,
+/area/syndicate_mothership/control)
+"QW" = (
+/obj/effect/turf_decal/stripes/corner{
+	dir = 1
+	},
+/turf/open/floor/plating/airless,
+/area/syndicate_mothership/control)
+"QX" = (
+/obj/effect/turf_decal/stripes/corner{
+	dir = 4
+	},
+/turf/open/floor/plating/airless,
+/area/syndicate_mothership/control)
+"QY" = (
+/obj/effect/turf_decal/stripes/corner{
+	dir = 8
+	},
+/turf/open/floor/plating/airless,
+/area/syndicate_mothership/control)
+"QZ" = (
+/obj/effect/turf_decal/stripes/corner{
+	dir = 4
+	},
+/turf/open/floor/plating/airless,
+/area/syndicate_mothership/control)
 
 (1,1,1) = {"
 aa
@@ -34895,7 +34940,7 @@ lG
 hm
 aa
 kl
-qs
+QT
 rk
 rl
 rm
@@ -34903,7 +34948,7 @@ tl
 rm
 ux
 vc
-qs
+QY
 kl
 aa
 aa
@@ -36180,7 +36225,7 @@ hq
 hm
 aa
 kl
-qt
+QU
 ro
 rm
 sd
@@ -36437,7 +36482,7 @@ hq
 hm
 aa
 kl
-qs
+QV
 rp
 ro
 rm
@@ -36445,7 +36490,7 @@ tl
 rm
 uy
 ve
-qs
+QZ
 kl
 aa
 aa
@@ -36695,13 +36740,13 @@ hm
 aa
 kl
 qs
-qs
+QW
 se
 se
 se
 se
 se
-qs
+QX
 qs
 kl
 aa
@@ -76391,9 +76436,9 @@ dM
 QJ
 QL
 fg
-QO
-QQ
-QR
+QL
+QK
+QL
 dM
 fN
 fQ
@@ -76903,11 +76948,11 @@ dM
 QI
 dM
 QK
-QM
+QL
 QN
-QP
+QL
 fr
-QS
+QL
 dM
 fN
 ab

--- a/code/_globalvars/lists/mapping.dm
+++ b/code/_globalvars/lists/mapping.dm
@@ -33,6 +33,8 @@ GLOBAL_LIST_EMPTY(department_security_spawns)	//list of all department security 
 GLOBAL_LIST_EMPTY(generic_event_spawns)			//list of all spawns for events
 
 GLOBAL_LIST_EMPTY(wizardstart)
+GLOBAL_LIST_EMPTY(nukeop_start)
+GLOBAL_LIST_EMPTY(nukeop_leader_start)
 GLOBAL_LIST_EMPTY(newplayer_start)
 GLOBAL_LIST_EMPTY(prisonwarp)	//prisoners go to these
 GLOBAL_LIST_EMPTY(holdingfacility)	//captured people go here

--- a/code/game/gamemodes/nuclear/nuclear.dm
+++ b/code/game/gamemodes/nuclear/nuclear.dm
@@ -22,27 +22,17 @@
 	var/nukes_left = 1 // Call 3714-PRAY right now and order more nukes! Limited offer!
 	var/nuke_off_station = 0 //Used for tracking if the syndies actually haul the nuke to the station
 	var/syndies_didnt_escape = 0 //Used for tracking if the syndies got the shuttle off of the z-level
+	var/list/pre_nukeops = list()
 
 /datum/game_mode/nuclear/pre_setup()
-	var/n_players = num_players()
-	var/n_agents = min(round(n_players / 10, 1), agents_possible)
-
-	if(antag_candidates.len < n_agents) //In the case of having less candidates than the selected number of agents
-		n_agents = antag_candidates.len
-
-	while(n_agents > 0)
-		var/datum/mind/new_syndicate = pick(antag_candidates)
-		syndicates += new_syndicate
-		antag_candidates -= new_syndicate //So it doesn't pick the same guy each time.
-		n_agents--
-
-	for(var/datum/mind/synd_mind in syndicates)
-		synd_mind.assigned_role = "Syndicate"
-		synd_mind.special_role = "Syndicate"//So they actually have a special role/N
-		log_game("[synd_mind.key] (ckey) has been selected as a nuclear operative")
-
-	return 1
-
+	var/n_agents = min(round(num_players() / 10), antag_candidates.len, agents_possible)
+	for(var/i = 0, i < n_agents, ++i)
+		var/datum/mind/new_op = pick_n_take(antag_candidates)
+		pre_nukeops += new_op
+		new_op.assigned_role = "Nuclear Operative"
+		new_op.special_role = "Nuclear Operative"
+		log_game("[new_op.key] (ckey) has been selected as a nuclear operative")
+	return TRUE
 
 ////////////////////////////////////////////////////////////////////////////////////////
 ////////////////////////////////////////////////////////////////////////////////////////
@@ -60,47 +50,35 @@
 ////////////////////////////////////////////////////////////////////////////////////////
 
 /datum/game_mode/nuclear/post_setup()
-
-	var/list/turf/synd_spawn = list()
-
-	for(var/obj/effect/landmark/A in GLOB.landmarks_list)
-		if(A.name == "Syndicate-Spawn")
-			synd_spawn += get_turf(A)
-			continue
-
 	var/nuke_code = random_nukecode()
-	var/leader_selected = 0
 	var/agent_number = 1
-	var/spawnpos = 1
+	var/datum/mind/leader = pick(pre_nukeops)
+	syndicates += pre_nukeops
+	for(var/i = 1 to pre_nukeops.len)
+		var/datum/mind/op = pre_nukeops[i]
 
-	for(var/datum/mind/synd_mind in syndicates)
-		if(spawnpos > synd_spawn.len)
-			spawnpos = 2
-		synd_mind.current.loc = synd_spawn[spawnpos]
-
-		forge_syndicate_objectives(synd_mind)
-		greet_syndicate(synd_mind)
-		equip_syndicate(synd_mind.current)
+		forge_syndicate_objectives(op)
+		greet_syndicate(op)
+		equip_syndicate(op.current)
 
 		if(nuke_code)
-			synd_mind.store_memory("<B>Syndicate Nuclear Bomb Code</B>: [nuke_code]", 0, 0)
-			to_chat(synd_mind.current, "The nuclear authorization code is: <B>[nuke_code]</B>")
+			op.store_memory("<B>Syndicate Nuclear Bomb Code</B>: [nuke_code]", 0, 0)
+			to_chat(op.current, "The nuclear authorization code is: <B>[nuke_code]</B>")
 
-		if(!leader_selected)
-			prepare_syndicate_leader(synd_mind, nuke_code)
-			leader_selected = 1
+		if(op == leader)
+			op.current.forceMove(pick(GLOB.nukeop_leader_start))
+			prepare_syndicate_leader(op, nuke_code)
 		else
-			synd_mind.current.real_name = "[syndicate_name()] Operative #[agent_number]"
-			agent_number++
-		spawnpos++
-		update_synd_icons_added(synd_mind)
-		synd_mind.current.playsound_local(get_turf(synd_mind.current), 'sound/ambience/antag/ops.ogg',100,0)
-	var/obj/machinery/nuclearbomb/nuke = locate("syndienuke") in GLOB.nuke_list
+			op.current.forceMove(GLOB.nukeop_start[((i - 1) % GLOB.nukeop_start.len) + 1])
+			op.current.real_name = "[syndicate_name()] Operative #[agent_number++]"
 
+		update_synd_icons_added(op)
+		op.current.playsound_local(get_turf(op.current), 'sound/ambience/antag/ops.ogg',100,0)
+
+	var/obj/machinery/nuclearbomb/nuke = locate("syndienuke") in GLOB.nuke_list
 	if(nuke)
 		nuke.r_code = nuke_code
 	return ..()
-
 
 /datum/game_mode/proc/prepare_syndicate_leader(datum/mind/synd_mind, nuke_code)
 	var/leader_title = pick("Czar", "Boss", "Commander", "Chief", "Kingpin", "Director", "Overlord")

--- a/code/game/objects/effects/landmarks.dm
+++ b/code/game/objects/effects/landmarks.dm
@@ -157,9 +157,25 @@
 /obj/effect/landmark/start/wizard
 	name = "wizard"
 
-/obj/effect/landmark/start/wizard/Initialize(mapload)
+/obj/effect/landmark/start/wizard/Initialize()
 	..()
 	GLOB.wizardstart += loc
+	return INITIALIZE_HINT_QDEL
+
+/obj/effect/landmark/start/nukeop
+	name = "nukeop"
+
+/obj/effect/landmark/start/nukeop/Initialize()
+	..()
+	GLOB.nukeop_start += loc
+	return INITIALIZE_HINT_QDEL
+
+/obj/effect/landmark/start/nukeop_leader
+	name = "nukeop leader"
+
+/obj/effect/landmark/start/nukeop_leader/Initialize()
+	..()
+	GLOB.nukeop_leader_start += loc
 	return INITIALIZE_HINT_QDEL
 
 /obj/effect/landmark/start/new_player
@@ -204,23 +220,6 @@
 // triple ais.
 /obj/effect/landmark/tripai
 	name = "tripai"
-
-// marauder entry (XXX WTF IS MAURADER ENTRY???)
-
-/obj/effect/landmark/marauder_entry
-	name = "Marauder Entry"
-
-// syndicate breach area (XXX I DON'T KNOW WHAT THIS IS EITHER)
-
-/obj/effect/landmark/syndicate_breach_area
-	name = "Syndicate Breach Area"
-
-// teleport scroll landmark, XXX DOES THIS DO ANYTHING?
-/obj/effect/landmark/teleport_scroll
-	name = "Teleport-Scroll"
-
-/obj/effect/landmark/syndicate_spawn
-	name = "Syndicate-Spawn"
 
 // xenos.
 /obj/effect/landmark/xeno_spawn


### PR DESCRIPTION
Removes some old unused landmarks and makes the used ones slightly less hardcoded.

Does a tiny bit of refactoring in nuclear.dm in anticipation of further cleanup.

Also added a sink to the nukeop bathroom cause it didn't have one.