### PR TITLE
Repairs and Intensifies Secret Satchels

### DIFF
--- a/code/controllers/subsystem/persistence.dm
+++ b/code/controllers/subsystem/persistence.dm
@@ -22,47 +22,54 @@ SUBSYSTEM_DEF(persistence)
 /datum/controller/subsystem/persistence/proc/LoadSatchels()
 	var/placed_satchel = 0
 	var/path
-	var/obj/item/storage/backpack/satchel/flat/F = new()
-	if(fexists("data/npc_saves/SecretSatchels.sav")) //legacy compatability to convert old format to new
+	if(fexists("data/npc_saves/SecretSatchels.sav")) //legacy conversion. Will only ever run once.
 		var/savefile/secret_satchels = new /savefile("data/npc_saves/SecretSatchels.sav")
-		var/sav_text
-		secret_satchels[SSmapping.config.map_name] >> sav_text
-		fdel("data/npc_saves/SecretSatchels.sav")
-		if(sav_text)
-			old_secret_satchels = splittext(sav_text,"#")
-			if(old_secret_satchels.len >= 20)
-				var/satchel_string = pick_n_take(old_secret_satchels)
+		for(var/map in secret_satchels)
+			var/json_file = file("data/npc_saves/SecretSatchels[map].json")
+			var/list/legacy_secret_satchels = splittext(secret_satchels[map],"#")
+			var/list/satchels = list()
+			for(var/i=1,i<=legacy_secret_satchels.len,i++)
+				var/satchel_string = legacy_secret_satchels[i]
 				var/list/chosen_satchel = splittext(satchel_string,"|")
 				if(chosen_satchel.len == 3)
-					F.x = text2num(chosen_satchel[1])
-					F.y = text2num(chosen_satchel[2])
-					F.z = ZLEVEL_STATION_PRIMARY
-					path = text2path(chosen_satchel[3])
-	else
-		var/json_file = file("data/npc_saves/SecretSatchels[SSmapping.config.map_name].json")
-		if(!fexists(json_file))
-			return
-		var/list/json = json_decode(file2text(json_file))
-		old_secret_satchels = json["data"]
-		if(old_secret_satchels.len)
-			if(old_secret_satchels.len >= 20) //guards against low drop pools assuring that one player cannot reliably find his own gear.
-				var/pos = rand(1, old_secret_satchels.len)
-				old_secret_satchels.Cut(pos, pos+1)
-				F.x = old_secret_satchels[pos]["x"]
-				F.y = old_secret_satchels[pos]["y"]
-				F.z = ZLEVEL_STATION_PRIMARY
-				path = text2path(old_secret_satchels[pos]["saved_obj"])
-	if(!ispath(path))
-		return
-	if(isfloorturf(F.loc) && !istype(F.loc, /turf/open/floor/plating/))
-		F.hide(1)
-	new path(F)
-	placed_satchel++
-	var/list/free_satchels = list()
+					var/list/data = list()
+					data["x"] = text2num(chosen_satchel[1])
+					data["y"] = text2num(chosen_satchel[2])
+					data["saved_obj"] = chosen_satchel[3]
+					satchels += list(data)
+			var/list/file_data = list()
+			file_data["data"] = satchels
+			WRITE_FILE(json_file, json_encode(file_data))
+		fdel("data/npc_saves/SecretSatchels.sav")
+
+	var/json_file = file("data/npc_saves/SecretSatchels[SSmapping.config.map_name].json")
+	var/list/json = list()
+	if(fexists(json_file))
+		json = json_decode(file2text(json_file))
+
+	old_secret_satchels = json["data"]
+	var/obj/item/storage/backpack/satchel/flat/F
+	if(old_secret_satchels && old_secret_satchels.len >= 10) //guards against low drop pools assuring that one player cannot reliably find his own gear.
+		var/pos = rand(1, old_secret_satchels.len)
+		F = new()
+		old_secret_satchels.Cut(pos, pos+1 % old_secret_satchels.len)
+		F.x = old_secret_satchels[pos]["x"]
+		F.y = old_secret_satchels[pos]["y"]
+		F.z = ZLEVEL_STATION_PRIMARY
+		path = text2path(old_secret_satchels[pos]["saved_obj"])
+
+	if(F)
+		if(isfloorturf(F.loc) && !istype(F.loc, /turf/open/floor/plating/))
+			F.hide(1)
+		if(ispath(path))
+			new path(F)
+		placed_satchel++
+	var/free_satchels = 0
 	for(var/turf/T in shuffle(block(locate(TRANSITIONEDGE,TRANSITIONEDGE,ZLEVEL_STATION_PRIMARY), locate(world.maxx-TRANSITIONEDGE,world.maxy-TRANSITIONEDGE,ZLEVEL_STATION_PRIMARY)))) //Nontrivially expensive but it's roundstart only
 		if(isfloorturf(T) && !istype(T, /turf/open/floor/plating/))
-			free_satchels += new /obj/item/storage/backpack/satchel/flat/secret(T)
-			if(!isemptylist(free_satchels) && ((free_satchels.len + placed_satchel) >= (50 - old_secret_satchels.len) * 0.1)) //up to six tiles, more than enough to kill anything that moves
+			new /obj/item/storage/backpack/satchel/flat/secret(T)
+			free_satchels++
+			if((free_satchels + placed_satchel) == 10) //ten tiles, more than enough to kill anything that moves
 				break
 
 /datum/controller/subsystem/persistence/proc/LoadPoly()
@@ -176,8 +183,8 @@ SUBSYSTEM_DEF(persistence)
 	CollectRoundtype()
 
 /datum/controller/subsystem/persistence/proc/CollectSecretSatchels()
-	var/list/satchels = list()
 	satchel_blacklist = typecacheof(list(/obj/item/stack/tile/plasteel, /obj/item/crowbar))
+	var/list/satchels_to_add = list()
 	for(var/A in new_secret_satchels)
 		var/obj/item/storage/backpack/satchel/flat/F = A
 		if(QDELETED(F) || F.z != ZLEVEL_STATION_PRIMARY || F.invisibility != INVISIBILITY_MAXIMUM)
@@ -196,11 +203,12 @@ SUBSYSTEM_DEF(persistence)
 		data["x"] = F.x
 		data["y"] = F.y
 		data["saved_obj"] = pick(savable_obj)
-		satchels += list(data)
+		satchels_to_add += list(data)
+
 	var/json_file = file("data/npc_saves/SecretSatchels[SSmapping.config.map_name].json")
 	var/list/file_data = list()
-	file_data["data"] = satchels
 	fdel(json_file)
+	file_data["data"] = old_secret_satchels + satchels_to_add
 	WRITE_FILE(json_file, json_encode(file_data))
 
 /datum/controller/subsystem/persistence/proc/CollectChiselMessages()


### PR DESCRIPTION
A few days back secret satchels were changed to use JSON files, but the legacy conversion method did not work, and unrelated errors meant that new satchels did not spawn. That's all fixed now.

Since no one likely noticed they were missing I've also taken the opportunity to intensify the mechanics a bit. Instead of up to 6 satchels spawning, 10 will now (but only one might hold an item). At the same time the pool size required for items to drop has been moved from 20 to 10.

:cl:
bugfix: The rarely utilized secret satchel item persistence system has been fixed and made more lenient. 
add: In case you forgot how it works: if you find or buy secret satchels, put an item in them, and then bury them under tiles on the station you or someone else can find them again in a future round with the item still there! Free satchels can often be found hiding around the station, so get to burying!
/:cl: