### PR TITLE
Fixes sheet-crafted stuff being created in nullspace

### DIFF
--- a/code/game/objects/items/stacks/stack.dm
+++ b/code/game/objects/items/stacks/stack.dm
@@ -149,7 +149,7 @@
 			if(!building_checks(R, multiplier))
 				return
 
-		var/obj/O = new R.result_type()
+		var/obj/O = new R.result_type(usr.drop_location())	// DO NOT BUILD STUFF IN NULLSPACE AND THEN MOVE THEM OVER, YOU WILL BREAK THINGS
 		O.setDir(usr.dir)
 		use(R.req_amount * multiplier)
 
@@ -170,8 +170,7 @@
 
 		if (isitem(O))
 			usr.put_in_hands(O)
-		else
-			O.forceMove(usr.drop_location())
+
 		O.add_fingerprint(usr)
 
 		//BubbleWrap - so newly formed boxes are empty


### PR DESCRIPTION
If we're going to have sheet-crafting machinery, we can't initialize them in nullspace as nullspace is not powered()

[Changelogs]: 

:cl: Naksu
fix: Drying racks actually work after being constructed
/:cl:

[why]: 
Being able to dry their weed makes players and the server host happy
