### PR TITLE
Refactor quick create antag panel code, fixed AFK revs not properly ending the round.

### DIFF
--- a/code/__HELPERS/game.dm
+++ b/code/__HELPERS/game.dm
@@ -332,15 +332,13 @@
 
 /proc/considered_alive(datum/mind/M, enforce_human = TRUE)
 	if(M && M.current)
-		switch(enforce_human)
-			if(TRUE)
-				var/mob/living/carbon/human/H
-				if(ishuman(M.current))
-					H = M.current
-				return M.current.stat != DEAD && !issilicon(M.current) && !isbrain(M.current) && (!H || H.dna.species.id != "memezombies")
-			if(FALSE)
-				if(isliving(M.current))
-					return M.current.stat != DEAD
+		if(enforce_human)
+			var/mob/living/carbon/human/H
+			if(ishuman(M.current))
+				H = M.current
+			return M.current.stat != DEAD && !issilicon(M.current) && !isbrain(M.current) && (!H || H.dna.species.id != "memezombies")
+		else if(isliving(M.current))
+			return M.current.stat != DEAD
 	return FALSE
 
 /proc/considered_afk(datum/mind/M)

--- a/code/__HELPERS/game.dm
+++ b/code/__HELPERS/game.dm
@@ -330,15 +330,20 @@
 		afk_bracket += 600 // Add a minute to the bracket, for every attempt
 	return candidates
 
-/datum/proc/considered_alive(datum/mind/M)
+/proc/considered_alive(datum/mind/M, enforce_human = TRUE)
 	if(M && M.current)
-		var/mob/living/carbon/human/H
-		if(ishuman(M.current))
-			H = M.current
-		return M.current.stat != DEAD && !issilicon(M.current) && !isbrain(M.current) && (!H || H.dna.species.id != "memezombies")
+		switch(enforce_human)
+			if(TRUE)
+				var/mob/living/carbon/human/H
+				if(ishuman(M.current))
+					H = M.current
+				return M.current.stat != DEAD && !issilicon(M.current) && !isbrain(M.current) && (!H || H.dna.species.id != "memezombies")
+			if(FALSE)
+				if(isliving(M.current))
+					return M.current.stat != DEAD
 	return FALSE
 
-/datum/proc/considered_afk(datum/mind/M)
+/proc/considered_afk(datum/mind/M)
 	return !M || !M.current || !M.current.client || M.current.client.is_afk()
 
 /proc/ScreenText(obj/O, maptext="", screen_loc="CENTER-7,CENTER-7", maptext_height=480, maptext_width=480)

--- a/code/__HELPERS/game.dm
+++ b/code/__HELPERS/game.dm
@@ -330,6 +330,17 @@
 		afk_bracket += 600 // Add a minute to the bracket, for every attempt
 	return candidates
 
+/datum/proc/considered_alive(datum/mind/M)
+	if(M && M.current)
+		var/mob/living/carbon/human/H
+		if(ishuman(M.current))
+			H = M.current
+		return M.current.stat != DEAD && !issilicon(M.current) && !isbrain(M.current) && (!H || H.dna.species.id != "memezombies")
+	return FALSE
+
+/datum/proc/considered_afk(datum/mind/M)
+	return !M || !M.current || !M.current.client || M.current.client.is_afk()
+
 /proc/ScreenText(obj/O, maptext="", screen_loc="CENTER-7,CENTER-7", maptext_height=480, maptext_width=480)
 	if(!isobj(O))
 		O = new /obj/screen/text()

--- a/code/game/gamemodes/objective.dm
+++ b/code/game/gamemodes/objective.dm
@@ -17,14 +17,6 @@
 	if(owner)
 		. += owner
 
-/datum/objective/proc/considered_alive(var/datum/mind/M)
-	if(M && M.current)
-		var/mob/living/carbon/human/H
-		if(ishuman(M.current))
-			H = M.current
-		return M.current.stat != DEAD && !issilicon(M.current) && !isbrain(M.current) && (!H || H.dna.species.id != "memezombies")
-	return FALSE
-
 /datum/objective/proc/considered_escaped(datum/mind/M)
 	if(!considered_alive(M))
 		return FALSE
@@ -36,9 +28,6 @@
 	if(!location || istype(location, /turf/open/floor/plasteel/shuttle/red) || istype(location, /turf/open/floor/mineral/plastitanium/brig)) // Fails if they are in the shuttle brig
 		return FALSE
 	return location.onCentCom() || location.onSyndieBase()
-
-/datum/objective/proc/considered_afk(datum/mind/M)
-	return !M || !M.current || !M.current.client || M.current.client.is_afk()
 
 /datum/objective/proc/check_completion()
 	return completed

--- a/code/game/gamemodes/objective.dm
+++ b/code/game/gamemodes/objective.dm
@@ -337,13 +337,14 @@
 			return FALSE
 	return TRUE
 
-//Like survive, but works for silicons and zombies and such.
-/datum/objective/survive/exist/considered_alive(var/datum/mind/M)
-	if(M && M.current)
-		if(isliving(M.current))
-			var/mob/living/L = M.current
-			return L.stat != DEAD
-	return FALSE
+/datum/objective/survive/exist //Like survive, but works for silicons and zombies and such.
+
+/datum/objective/survive/exist/check_completion()
+	var/list/datum/mind/owners = get_owners()
+	for(var/datum/mind/M in owners)
+		if(!considered_alive(M, FALSE))
+			return FALSE
+	return TRUE
 
 /datum/objective/martyr
 	explanation_text = "Die a glorious death."

--- a/code/game/gamemodes/revolution/revolution.dm
+++ b/code/game/gamemodes/revolution/revolution.dm
@@ -329,7 +329,7 @@
 /datum/game_mode/revolution/proc/check_heads_victory()
 	for(var/datum/mind/rev_mind in head_revolutionaries)
 		var/turf/T = get_turf(rev_mind.current)
-		if((rev_mind) && (rev_mind.current) && (rev_mind.current.stat != DEAD) && T && (T.z in GLOB.station_z_levels))
+		if(!considered_afk(rev_mind) && considered_alive(rev_mind) && (T.z in GLOB.station_z_levels))
 			if(ishuman(rev_mind.current))
 				return 0
 	return 1

--- a/code/modules/admin/verbs/one_click_antag.dm
+++ b/code/modules/admin/verbs/one_click_antag.dm
@@ -29,6 +29,8 @@
 	popup.open()
 
 /datum/admins/proc/isReadytoRumble(mob/living/carbon/human/applicant, targetrole, onstation = TRUE, conscious = TRUE)
+	if(applicant.mind.special_role)
+		return FALSE
 	if(!(targetrole in applicant.client.prefs.be_special))
 		return FALSE
 	if(onstation)
@@ -38,8 +40,6 @@
 	if(conscious && applicant.stat) //incase you don't care about a certain antag being unconcious when made, ie if they have selfhealing abilities.
 		return FALSE
 	if(!considered_alive(applicant.mind) || considered_afk(applicant.mind)) //makes sure the player isn't a zombie, brain, or just afk all together
-		return FALSE
-	if(applicant.mind.special_role)
 		return FALSE
 	return (!jobban_isbanned(applicant, targetrole) && !jobban_isbanned(applicant, "Syndicate"))
 

--- a/code/modules/admin/verbs/one_click_antag.dm
+++ b/code/modules/admin/verbs/one_click_antag.dm
@@ -28,6 +28,22 @@
 	popup.set_content(dat)
 	popup.open()
 
+/datum/admins/proc/isReadytoRumble(mob/living/carbon/human/applicant, targetrole, onstation = TRUE, conscious = TRUE)
+	if(!(targetrole in applicant.client.prefs.be_special))
+		return FALSE
+	if(onstation)
+		var/turf/T = get_turf(applicant)
+		if(!(T.z in GLOB.station_z_levels))
+			return FALSE
+	if((!conscious && applicant.stat != DEAD) || (conscious && applicant.stat)) //incase you don't care about a certain antag being unconcious when made, ie if they have selfhealing abilities.
+		return FALSE
+	if(!considered_alive(applicant.mind) && considered_afk(applicant.mind)) //makes sure the player isn't a zombie, brain, or just afk all together
+		return FALSE
+	if(applicant.mind.special_role)
+		return FALSE
+	return (!jobban_isbanned(applicant, targetrole) && !jobban_isbanned(applicant, "Syndicate"))
+
+
 /datum/admins/proc/makeTraitors()
 	var/datum/game_mode/traitor/temp = new
 
@@ -41,14 +57,10 @@
 	var/mob/living/carbon/human/H = null
 
 	for(var/mob/living/carbon/human/applicant in GLOB.player_list)
-		if(ROLE_TRAITOR in applicant.client.prefs.be_special)
-			if(!applicant.stat)
-				if(applicant.mind)
-					if (!applicant.mind.special_role)
-						if(!jobban_isbanned(applicant, ROLE_TRAITOR) && !jobban_isbanned(applicant, "Syndicate"))
-							if(temp.age_check(applicant.client))
-								if(!(applicant.job in temp.restricted_jobs))
-									candidates += applicant
+		if(isReadytoRumble(applicant, ROLE_TRAITOR, FALSE))
+			if(temp.age_check(applicant.client))
+				if(!(applicant.job in temp.restricted_jobs))
+					candidates += applicant
 
 	if(candidates.len)
 		var/numTraitors = min(candidates.len, 3)
@@ -77,13 +89,10 @@
 	var/mob/living/carbon/human/H = null
 
 	for(var/mob/living/carbon/human/applicant in GLOB.player_list)
-		if(ROLE_CHANGELING in applicant.client.prefs.be_special)
-			var/turf/T = get_turf(applicant)
-			if(applicant.stat == CONSCIOUS && applicant.mind && !applicant.mind.special_role && (T.z in GLOB.station_z_levels))
-				if(!jobban_isbanned(applicant, ROLE_CHANGELING) && !jobban_isbanned(applicant, "Syndicate"))
-					if(temp.age_check(applicant.client))
-						if(!(applicant.job in temp.restricted_jobs))
-							candidates += applicant
+		if(isReadytoRumble(applicant, ROLE_CHANGELING))
+			if(temp.age_check(applicant.client))
+				if(!(applicant.job in temp.restricted_jobs))
+					candidates += applicant
 
 	if(candidates.len)
 		var/numChanglings = min(candidates.len, 3)
@@ -110,13 +119,10 @@
 	var/mob/living/carbon/human/H = null
 
 	for(var/mob/living/carbon/human/applicant in GLOB.player_list)
-		if(ROLE_REV in applicant.client.prefs.be_special)
-			var/turf/T = get_turf(applicant)
-			if(applicant.stat == CONSCIOUS && applicant.mind && !applicant.mind.special_role && (T.z in GLOB.station_z_levels))
-				if(!jobban_isbanned(applicant, ROLE_REV) && !jobban_isbanned(applicant, "Syndicate"))
-					if(temp.age_check(applicant.client))
-						if(!(applicant.job in temp.restricted_jobs))
-							candidates += applicant
+		if(isReadytoRumble(applicant, ROLE_REV))
+			if(temp.age_check(applicant.client))
+				if(!(applicant.job in temp.restricted_jobs))
+					candidates += applicant
 
 	if(candidates.len)
 		var/numRevs = min(candidates.len, 3)
@@ -152,13 +158,10 @@
 	var/mob/living/carbon/human/H = null
 
 	for(var/mob/living/carbon/human/applicant in GLOB.player_list)
-		if(ROLE_CULTIST in applicant.client.prefs.be_special)
-			var/turf/T = get_turf(applicant)
-			if(applicant.stat == CONSCIOUS && applicant.mind && !applicant.mind.special_role && (T.z in GLOB.station_z_levels))
-				if(!jobban_isbanned(applicant, ROLE_CULTIST) && !jobban_isbanned(applicant, "Syndicate"))
-					if(temp.age_check(applicant.client))
-						if(!(applicant.job in temp.restricted_jobs))
-							candidates += applicant
+		if(isReadytoRumble(applicant, ROLE_CULTIST))
+			if(temp.age_check(applicant.client))
+				if(!(applicant.job in temp.restricted_jobs))
+					candidates += applicant
 
 	if(candidates.len)
 		var/numCultists = min(candidates.len, 4)
@@ -185,13 +188,10 @@
 	var/mob/living/carbon/human/H = null
 
 	for(var/mob/living/carbon/human/applicant in GLOB.player_list)
-		if(ROLE_SERVANT_OF_RATVAR in applicant.client.prefs.be_special)
-			var/turf/T = get_turf(applicant)
-			if(applicant.stat == CONSCIOUS && applicant.mind && !applicant.mind.special_role && (T.z in GLOB.station_z_levels))
-				if(!jobban_isbanned(applicant, ROLE_SERVANT_OF_RATVAR) && !jobban_isbanned(applicant, "Syndicate"))
-					if(temp.age_check(applicant.client))
-						if(!(applicant.job in temp.restricted_jobs))
-							candidates += applicant
+		if(isReadytoRumble(applicant, ROLE_SERVANT_OF_RATVAR))
+			if(temp.age_check(applicant.client))
+				if(!(applicant.job in temp.restricted_jobs))
+					candidates += applicant
 
 	if(candidates.len)
 		var/numCultists = min(candidates.len, 4)

--- a/code/modules/admin/verbs/one_click_antag.dm
+++ b/code/modules/admin/verbs/one_click_antag.dm
@@ -37,7 +37,7 @@
 			return FALSE
 	if((!conscious && applicant.stat != DEAD) || (conscious && applicant.stat)) //incase you don't care about a certain antag being unconcious when made, ie if they have selfhealing abilities.
 		return FALSE
-	if(!considered_alive(applicant.mind) && considered_afk(applicant.mind)) //makes sure the player isn't a zombie, brain, or just afk all together
+	if(!considered_alive(applicant.mind) || considered_afk(applicant.mind)) //makes sure the player isn't a zombie, brain, or just afk all together
 		return FALSE
 	if(applicant.mind.special_role)
 		return FALSE

--- a/code/modules/admin/verbs/one_click_antag.dm
+++ b/code/modules/admin/verbs/one_click_antag.dm
@@ -35,7 +35,7 @@
 		var/turf/T = get_turf(applicant)
 		if(!(T.z in GLOB.station_z_levels))
 			return FALSE
-	if((!conscious && applicant.stat != DEAD) || (conscious && applicant.stat)) //incase you don't care about a certain antag being unconcious when made, ie if they have selfhealing abilities.
+	if(conscious && applicant.stat) //incase you don't care about a certain antag being unconcious when made, ie if they have selfhealing abilities.
 		return FALSE
 	if(!considered_alive(applicant.mind) || considered_afk(applicant.mind)) //makes sure the player isn't a zombie, brain, or just afk all together
 		return FALSE


### PR DESCRIPTION
Fixes #29322

Also cleans up quick antag creation code a bit. 
Players who are AFK or zombies will no longer be made new antags through the panel.