### PR TITLE
Fixes SM shard extraction

### DIFF
--- a/code/game/objects/items/theft_tools.dm
+++ b/code/game/objects/items/theft_tools.dm
@@ -106,7 +106,7 @@
 	<ul>\
 	<li>Approach an active supermatter crystal with proper protective gear. DO NOT MAKE PHYSICAL CONTACT.</li>\
 	<li>Use a supermatter scalpel (provided) to slice off a sliver of the crystal.</li>\
-	<li>Use supermatter extraction tongs (also provided) to safely remove the sliver.</li>\
+	<li>Use supermatter extraction tongs (also provided) to safely pick up the sliver you sliced off.</li>\
 	<li>Physical contact of any object with the sliver will dust the object, as well as yourself.</li>\
 	<li>Use the tongs to place the sliver into the provided container, which will take some time to seal</li>\
 	<li>Get the hell out before the crystal delaminates.</li>\

--- a/code/game/objects/items/theft_tools.dm
+++ b/code/game/objects/items/theft_tools.dm
@@ -104,11 +104,11 @@
 /obj/item/paper/guides/antag/supermatter_sliver
 	info = "How to safely extract a supermatter sliver:<br>\
 	<ul>\
-	<li>Approach an active supermatter crystal with proper protective gear. DO NOT MAKE PHYSICAL CONTACT.</li>\
+	<li>Approach an active supermatter crystal with radiation shielded personal protective equipment. DO NOT MAKE PHYSICAL CONTACT.</li>\
 	<li>Use a supermatter scalpel (provided) to slice off a sliver of the crystal.</li>\
 	<li>Use supermatter extraction tongs (also provided) to safely pick up the sliver you sliced off.</li>\
 	<li>Physical contact of any object with the sliver will dust the object, as well as yourself.</li>\
-	<li>Use the tongs to place the sliver into the provided container, which will take some time to seal</li>\
+	<li>Use the tongs to place the sliver into the provided container, which will take some time to seal.</li>\
 	<li>Get the hell out before the crystal delaminates.</li>\
 	<li>???</li>\
 	</ul>"

--- a/code/modules/power/supermatter/supermatter.dm
+++ b/code/modules/power/supermatter/supermatter.dm
@@ -537,7 +537,7 @@ GLOBAL_DATUM(main_supermatter_engine, /obj/machinery/power/supermatter_shard)
 		to_chat(user, "<span class='notice'>You carefully begin to scrape \the [src] with \the [W]...</span>")
 		if(do_after(user, 60 * W.toolspeed, TRUE, src))
 			to_chat(user, "<span class='notice'>You extract a sliver from \the [src]. \The [src] begins to react violently!</span>")
-			new /obj/item/nuke_core/supermatter_sliver(user.loc)
+			new /obj/item/nuke_core/supermatter_sliver(drop_location())
 			matter_power += 200
 	else if(user.dropItemToGround(W))
 		user.visible_message("<span class='danger'>As [user] touches \the [src] with \a [W], silence fills the room...</span>",\


### PR DESCRIPTION
Fixes #31107

Tweaked the wording of the manual slightly. Also, the shard will now spawn ontop of the crystal as opposed to underneath the player who sliced it off.