### PR TITLE
Strip propriety macros from tooltips

### DIFF
--- a/code/modules/tooltip/tooltip.dm
+++ b/code/modules/tooltip/tooltip.dm
@@ -65,6 +65,10 @@ Notes:
 	else if (!title && content)
 		content = "<p>[content]</p>"
 
+	// Strip macros from item names
+	title = replacetext(title, "\proper", "")
+	title = replacetext(title, "\improper", "")
+
 	//Make our dumb param object
 	params = {"{ "cursor": "[params]", "screenLoc": "[thing.screen_loc]" }"}
 


### PR DESCRIPTION
Fixes this:
![image](https://user-images.githubusercontent.com/222630/31003676-cb775138-a4a5-11e7-9985-3b405d74cdd2.png)

Implementation based on goonchat and tgui which do the same replacement.