### PR TITLE
Fixes stealth nerf to detectives gun

### DIFF
--- a/code/modules/projectiles/projectile/bullets.dm
+++ b/code/modules/projectiles/projectile/bullets.dm
@@ -67,7 +67,7 @@
 	name = ".38 bullet"
 	damage = 15
 	knockdown = 30
-	stamina = 50
+	stamina = 60
 
 // 10mm (Stechkin)
 

--- a/code/modules/projectiles/projectile/bullets.dm
+++ b/code/modules/projectiles/projectile/bullets.dm
@@ -66,8 +66,8 @@
 /obj/item/projectile/bullet/c38
 	name = ".38 bullet"
 	damage = 15
-	knockdown = 30
-	stamina = 60
+	knockdown = 60
+	stamina = 50
 
 // 10mm (Stechkin)
 


### PR DESCRIPTION

:cl:
balance: The detectives gun has been restored from a system change that nerfed knockdown in general. We need to have a serious discussion about anti revolver hate in this community.
/:cl:

This was getting arrestes killed when it looked like they were adrenalined up from cuffing. 0/10 for conveying whats happening guys. They still go down in one shot so all this changes is that now they don't take 15 extra real damage when you shoot them a second time. You could run up and baton them anyway if you actually knew what had changed.
