### PR TITLE
Adds a var to minds that makes them immune to conversion

### DIFF
--- a/code/datums/mind.dm
+++ b/code/datums/mind.dm
@@ -63,6 +63,7 @@
 
 	var/mob/living/enslaved_to //If this mind's master is another mob (i.e. adamantine golems)
 	var/datum/language_holder/language_holder
+	var/unconvertable = FALSE
 
 /datum/mind/New(var/key)
 	src.key = key

--- a/code/game/gamemodes/clock_cult/clock_cult.dm
+++ b/code/game/gamemodes/clock_cult/clock_cult.dm
@@ -56,6 +56,8 @@ Credit where due:
 			return FALSE
 		if(M.mind.enslaved_to && !is_servant_of_ratvar(M.mind.enslaved_to))
 			return FALSE
+		if(M.mind.unconvertable)
+			return FALSE
 	else
 		return FALSE
 	if(iscultist(M) || isconstruct(M) || M.isloyal() || ispAI(M))

--- a/code/game/gamemodes/cult/cult.dm
+++ b/code/game/gamemodes/cult/cult.dm
@@ -21,6 +21,8 @@
 			return FALSE
 		if(M.mind.enslaved_to && !iscultist(M.mind.enslaved_to))
 			return FALSE
+		if(M.mind.unconvertable)
+			return FALSE
 	else
 		return FALSE
 	if(M.isloyal() || issilicon(M) || isbot(M) || isdrone(M) || is_servant_of_ratvar(M))

--- a/code/game/gamemodes/revolution/revolution.dm
+++ b/code/game/gamemodes/revolution/revolution.dm
@@ -259,12 +259,14 @@
 
 /datum/game_mode/proc/add_revolutionary(datum/mind/rev_mind)
 	if(rev_mind.assigned_role in GLOB.command_positions)
-		return 0
+		return FALSE
 	var/mob/living/carbon/human/H = rev_mind.current//Check to see if the potential rev is implanted
 	if(H.isloyal())
-		return 0
+		return FALSE
 	if((rev_mind in revolutionaries) || (rev_mind in head_revolutionaries))
-		return 0
+		return FALSE
+	if(rev_mind.unconvertable)
+		return FALSE
 	revolutionaries += rev_mind
 	if(iscarbon(rev_mind.current))
 		var/mob/living/carbon/carbon_mob = rev_mind.current
@@ -277,7 +279,7 @@
 	update_rev_icons_added(rev_mind)
 	if(jobban_isbanned(rev_mind.current, ROLE_REV))
 		INVOKE_ASYNC(src, .proc/replace_jobbaned_player, rev_mind.current, ROLE_REV, ROLE_REV)
-	return 1
+	return TRUE
 //////////////////////////////////////////////////////////////////////////////
 //Deals with players being converted from the revolution (Not a rev anymore)//  // Modified to handle borged MMIs.  Accepts another var if the target is being borged at the time  -- Polymorph.
 //////////////////////////////////////////////////////////////////////////////

--- a/code/game/objects/items/implants/implant_loyality.dm
+++ b/code/game/objects/items/implants/implant_loyality.dm
@@ -19,12 +19,12 @@
 
 /obj/item/implant/mindshield/implant(mob/living/target, mob/user, silent = 0)
 	if(..())
-		if((target.mind in (SSticker.mode.head_revolutionaries)))
+		if((target.mind in (SSticker.mode.head_revolutionaries)) || target.mind.unconvertable)
 			if(!silent)
 				target.visible_message("<span class='warning'>[target] seems to resist the implant!</span>", "<span class='warning'>You feel something interfering with your mental conditioning, but you resist it!</span>")
 			removed(target, 1)
 			qdel(src)
-			return 0
+			return FALSE
 		if(target.mind in SSticker.mode.revolutionaries)
 			SSticker.mode.remove_revolutionary(target.mind, FALSE, user)
 		if(!silent)
@@ -32,8 +32,8 @@
 				to_chat(target, "<span class='warning'>You feel something interfering with your mental conditioning, but you resist it!</span>")
 			else
 				to_chat(target, "<span class='notice'>You feel a sense of peace and security. You are now protected from brainwashing.</span>")
-		return 1
-	return 0
+		return TRUE
+	return FALSE
 
 /obj/item/implant/mindshield/removed(mob/target, silent = 0, special = 0)
 	if(..())


### PR DESCRIPTION
I'd like to start experimenting with having a more regular chance for a roundstart side antag, but roundstart side antags won't be any fun if they immediately join security or a conversion antag and one of those teams just gets super powers.

They'll still be able to work together obviously, they just won't have the iron clad protection of the HUD/rules preventing double crosses.