### PR TITLE
moved the goddamn locker in toxins maint

### DIFF
--- a/_maps/map_files/BoxStation/BoxStation.dmm
+++ b/_maps/map_files/BoxStation/BoxStation.dmm
@@ -115146,7 +115146,7 @@ aaa
 aaa
 aaa
 bky
-btq
+btp
 brH
 bvQ
 bxt
@@ -115660,7 +115660,7 @@ aaa
 aaa
 aaa
 bZi
-btp
+btq
 brI
 bvR
 cNS


### PR DESCRIPTION
:cl: Qbopper
tweak: Moved a locker blocking an airlock in Toxins maintenance.
/:cl:

this FUCKING locker has been pissing me off for months

it's in the tile between the shelf and airlock despite a perfectly fine tile being RIGHT THERE

so I moved it

![fug](https://i.imgur.com/ugAeyUV.png)