### PR TITLE
Held items drop when falling over for not having legs

### DIFF
--- a/code/game/turfs/turf.dm
+++ b/code/game/turfs/turf.dm
@@ -510,7 +510,7 @@
 		return
 	if(has_gravity(src))
 		playsound(src, "bodyfall", 50, 1)
-
+	faller.drop_all_held_items()
 
 /turf/proc/add_decal(decal,group)
 	LAZYINITLIST(decals)


### PR DESCRIPTION
Held items now drop when falling over for not having legs. Fixes two issues, other one is a duplicate.
The situation described works as intended, but is there any other edge cases which should be checked?

Fixes #20220
Fixes #20415