### PR TITLE
Fixes station name in cargo stock displays

### DIFF
--- a/code/modules/stock_market/computer.dm
+++ b/code/modules/stock_market/computer.dm
@@ -13,7 +13,7 @@
 
 /obj/machinery/computer/stockexchange/Initialize()
 	. = ..()
-	logged_in = "[station_name()] Cargo Department"
+	logged_in = "SS13 Cargo Department"
 
 /obj/machinery/computer/stockexchange/proc/balance()
 	if (!logged_in)
@@ -63,7 +63,7 @@ a.updated {
 </style>"}
 	var/dat = "<html><head><title>[station_name()] Stock Exchange</title>[css]</head><body>"
 
-	dat += "<span class='user'>Welcome, <b>[logged_in]</b></span><br><span class='balance'><b>Credits:</b> [balance()] </span><br>"
+	dat += "<span class='user'>Welcome, <b>[station_name()] Cargo Department</b></span><br><span class='balance'><b>Credits:</b> [balance()] </span><br>"
 	for (var/datum/stock/S in GLOB.stockExchange.last_read)
 		var/list/LR = GLOB.stockExchange.last_read[S]
 		if (!(logged_in in LR))


### PR DESCRIPTION
Fixes #31154

Stock exchange computers fetch the station name once during initialize, and then use it as a key for... stuff. See commit name.

[Changelogs]: 

:cl: Naksu
fix: Updates to station name are now reflected on Cargo's stock exchange computers.
/:cl: