### PR TITLE
fixes delete hotkey triggering messages when the user isn't even a living mob

### DIFF
--- a/code/modules/mob/mob_movement.dm
+++ b/code/modules/mob/mob_movement.dm
@@ -62,6 +62,8 @@
 /client/verb/delete_key_pressed()
 	set hidden = 1
 
+	if(!isliving(usr))
+		return
 	if(!usr.pulling)
 		to_chat(usr, "<span class='notice'>You are not pulling anything.</span>")
 		return


### PR DESCRIPTION
AFAIK only living mobs can pull, right?
fixes #31159 
