### PR TITLE
Fixes viruses not calling Start on their symptoms when spreading

### DIFF
--- a/code/datums/diseases/_MobProcs.dm
+++ b/code/datums/diseases/_MobProcs.dm
@@ -43,7 +43,7 @@
 		SSdisease.active_diseases += DD //Add it to the active diseases list, now that it's actually in a mob and being processed.
 
 		//Copy properties over. This is so edited diseases persist.
-		var/list/skipped = list("affected_mob","holder","carrier","stage","type","parent_type","vars","transformed","symptoms")
+		var/list/skipped = list("affected_mob","holder","carrier","stage","type","parent_type","vars","transformed","symptoms","processing")
 		for(var/V in DD.vars)
 			if(V in skipped)
 				continue


### PR DESCRIPTION
:cl: XDTM
fix: Fixed a bug where Viral Aggressive Metabolism caused viruses to be cured instantly.
fix: Fixed a bug where viruses' symptoms would all instantly activate on infection.
/:cl:

Fixes #31169
