### PR TITLE
Makes the pda font a prefernce

### DIFF
--- a/code/__DEFINES/misc.dm
+++ b/code/__DEFINES/misc.dm
@@ -283,6 +283,12 @@ GLOBAL_LIST_INIT(ghost_accs_options, list(GHOST_ACCS_NONE, GHOST_ACCS_DIR, GHOST
 
 GLOBAL_LIST_INIT(ghost_others_options, list(GHOST_OTHERS_SIMPLE, GHOST_OTHERS_DEFAULT_SPRITE, GHOST_OTHERS_THEIR_SETTING)) //Same as ghost_accs_options.
 
+//pda fonts
+#define MONO		"Monospaced"
+#define VT			"VT323"
+#define ORBITRON	"Orbitron"
+#define SHARE		"Share Tech Mono"
+
 //Color Defines
 #define OOC_COLOR  "#002eb8"
 

--- a/code/game/objects/items/devices/PDA/PDA.dm
+++ b/code/game/objects/items/devices/PDA/PDA.dm
@@ -30,10 +30,14 @@ GLOBAL_LIST_EMPTY(PDAs)
 	var/font_mode = "font-family:monospace;" //The currently selected font.
 	var/background_color = "#808000" //The currently selected background color.
 	
-	#define FONT_MONO 0
-	#define FONT_SHARE 1
-	#define FONT_ORBITRON 2
-	#define FONT_VT 3
+	#define FONT_MONO "font-family:monospace;"
+	#define FONT_SHARE "font-family:\"Share Tech Mono\", monospace;letter-spacing:0px;"
+	#define FONT_ORBITRON "font-family:\"Orbitron\", monospace;letter-spacing:0px; font-size:15px"
+	#define FONT_VT "font-family:\"VT323\", monospace;letter-spacing:1px;"
+	#define MODE_MONO 0
+	#define MODE_SHARE 1
+	#define MODE_ORBITRON 2
+	#define MODE_VT 3
 
 	//Secondary variables
 	var/scanmode = 0 //1 is medical scanner, 2 is forensics, 3 is reagent scanner.
@@ -54,7 +58,7 @@ GLOBAL_LIST_EMPTY(PDAs)
 	var/detonatable = TRUE // Can the PDA be blown up?
 	var/hidden = 0 // Is the PDA hidden from the PDA list?
 	var/emped = 0
-	var/equiped = 0 //is this the first time it has been equiped?
+	var/equipped = FALSE  //used here to determine if this is the first time its been picked up
 
 	var/obj/item/card/id/id = null //Making it possible to slot an ID card into the PDA so it can function as both.
 	var/ownjob = null //related to above
@@ -93,21 +97,21 @@ GLOBAL_LIST_EMPTY(PDAs)
 		if(user.client)
 			switch(user.client.prefs.pda_style)
 				if(MONO)
-					font_index = 0
-					font_mode = "font-family:monospace;"
+					font_index = MODE_MONO
+					font_mode = FONT_MONO
 				if(SHARE)
-					font_index = 1
-					font_mode = "font-family:\"Share Tech Mono\", monospace;letter-spacing:0px;"
+					font_index = MODE_SHARE
+					font_mode = FONT_SHARE
 				if(ORBITRON)
-					font_index = 2
-					font_mode = "font-family:\"Orbitron\", monospace;letter-spacing:0px; font-size:15px"
+					font_index = MODE_ORBITRON
+					font_mode = FONT_ORBITRON
 				if(VT)
-					font_index = 3
-					font_mode = "font-family:\"VT323\", monospace;letter-spacing:1px;"
+					font_index = MODE_VT
+					font_mode = FONT_VT
 				else
-					font_index = 0
-					font_mode = "font-family:monospace;"
-		equiped = 1
+					font_index = MODE_MONO
+					font_mode = FONT_MONO
+		equipped = TRUE
 
 /obj/item/device/pda/proc/update_label()
 	name = "PDA-[owner] ([ownjob])" //Name generalisation
@@ -361,14 +365,14 @@ GLOBAL_LIST_EMPTY(PDAs)
 				font_index = (font_index + 1) % 4
 
 				switch(font_index)
-					if (FONT_VT)
-						font_mode = "font-family:\"VT323\", monospace;letter-spacing:1px;"
-					if (FONT_SHARE)
-						font_mode = "font-family:\"Share Tech Mono\", monospace;letter-spacing:0px;"
-					if (FONT_ORBITRON)
-						font_mode = "font-family:\"Orbitron\", monospace;letter-spacing:0px; font-size:15px"
-					if (FONT_MONO)
-						font_mode = "font-family:monospace;"
+					if (MODE_MONO)
+						font_mode = FONT_MONO
+					if (MODE_SHARE)
+						font_mode = FONT_SHARE
+					if (MODE_ORBITRON)
+						font_mode = FONT_ORBITRON
+					if (MODE_VT)
+						font_mode = FONT_VT
 			if ("Change_Color")
 				var/new_color = input("Please enter a color name or hex value (Default is \'#808000\').")as color
 				background_color = new_color

--- a/code/game/objects/items/devices/PDA/PDA.dm
+++ b/code/game/objects/items/devices/PDA/PDA.dm
@@ -93,7 +93,7 @@ GLOBAL_LIST_EMPTY(PDAs)
 	update_icon()
 
 /obj/item/device/pda/equipped(mob/user, slot)
-	if(!equiped)
+	if(!equipped)
 		if(user.client)
 			switch(user.client.prefs.pda_style)
 				if(MONO)

--- a/code/game/objects/items/devices/PDA/PDA.dm
+++ b/code/game/objects/items/devices/PDA/PDA.dm
@@ -107,6 +107,7 @@ GLOBAL_LIST_EMPTY(PDAs)
 				else
 					font_index = 0
 					font_mode = "font-family:monospace;"
+		equiped = 1
 
 /obj/item/device/pda/proc/update_label()
 	name = "PDA-[owner] ([ownjob])" //Name generalisation

--- a/code/game/objects/items/devices/PDA/PDA.dm
+++ b/code/game/objects/items/devices/PDA/PDA.dm
@@ -27,13 +27,13 @@ GLOBAL_LIST_EMPTY(PDAs)
 	var/mode = 0 //Controls what menu the PDA will display. 0 is hub; the rest are either built in or based on cartridge.
 	var/icon_alert = "pda-r" //Icon to be overlayed for message alerts. Taken from the pda icon file.
 	var/font_index = 0 //This int tells DM which font is currently selected and lets DM know when the last font has been selected so that it can cycle back to the first font when "toggle font" is pressed again.
-	var/font_mode = "font-family:\"VT323\", monospace;letter-spacing:1px;" //The currently selected font.
+	font_mode = "font-family:monospace;" //The currently selected font.
 	var/background_color = "#808000" //The currently selected background color.
 	
-	#define FONT_VT 0
+	#define FONT_MONO 0
 	#define FONT_SHARE 1
 	#define FONT_ORBITRON 2
-	#define FONT_MONO 3
+	#define FONT_VT 3
 
 	//Secondary variables
 	var/scanmode = 0 //1 is medical scanner, 2 is forensics, 3 is reagent scanner.

--- a/code/game/objects/items/devices/PDA/PDA.dm
+++ b/code/game/objects/items/devices/PDA/PDA.dm
@@ -27,7 +27,7 @@ GLOBAL_LIST_EMPTY(PDAs)
 	var/mode = 0 //Controls what menu the PDA will display. 0 is hub; the rest are either built in or based on cartridge.
 	var/icon_alert = "pda-r" //Icon to be overlayed for message alerts. Taken from the pda icon file.
 	var/font_index = 0 //This int tells DM which font is currently selected and lets DM know when the last font has been selected so that it can cycle back to the first font when "toggle font" is pressed again.
-	font_mode = "font-family:monospace;" //The currently selected font.
+	var/font_mode = "font-family:monospace;" //The currently selected font.
 	var/background_color = "#808000" //The currently selected background color.
 	
 	#define FONT_MONO 0

--- a/code/game/objects/items/devices/PDA/PDA.dm
+++ b/code/game/objects/items/devices/PDA/PDA.dm
@@ -54,6 +54,7 @@ GLOBAL_LIST_EMPTY(PDAs)
 	var/detonatable = TRUE // Can the PDA be blown up?
 	var/hidden = 0 // Is the PDA hidden from the PDA list?
 	var/emped = 0
+	var/equiped = 0 //is this the first time it has been equiped?
 
 	var/obj/item/card/id/id = null //Making it possible to slot an ID card into the PDA so it can function as both.
 	var/ownjob = null //related to above
@@ -86,6 +87,26 @@ GLOBAL_LIST_EMPTY(PDAs)
 	else
 		inserted_item =	new /obj/item/pen(src)
 	update_icon()
+
+/obj/item/device/pda/equipped(mob/user, slot)
+	if(!equiped)
+		if(user.client)
+			switch(user.client.prefs.pda_style)
+				if(MONO)
+					font_index = 0
+					font_mode = "font-family:monospace;"
+				if(SHARE)
+					font_index = 1
+					font_mode = "font-family:\"Share Tech Mono\", monospace;letter-spacing:0px;"
+				if(ORBITRON)
+					font_index = 2
+					font_mode = "font-family:\"Orbitron\", monospace;letter-spacing:0px; font-size:15px"
+				if(VT)
+					font_index = 3
+					font_mode = "font-family:\"VT323\", monospace;letter-spacing:1px;"
+				else
+					font_index = 0
+					font_mode = "font-family:monospace;"
 
 /obj/item/device/pda/proc/update_label()
 	name = "PDA-[owner] ([ownjob])" //Name generalisation

--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -46,7 +46,8 @@ GLOBAL_LIST_EMPTY(preferences_datums)
 	var/inquisitive_ghost = 1
 	var/allow_midround_antag = 1
 	var/preferred_map = null
-
+	var/pda_font = MONO
+	
 	var/uses_glasses_colour = 0
 
 	//character preferences
@@ -369,6 +370,7 @@ GLOBAL_LIST_EMPTY(preferences_datums)
 			dat += "<b>Keybindings:</b> <a href='?_src_=prefs;preference=hotkeys'>[(hotkeys) ? "Hotkeys" : "Default"]</a><br>"
 			dat += "<b>Action Buttons:</b> <a href='?_src_=prefs;preference=action_buttons'>[(buttons_locked) ? "Locked In Place" : "Unlocked"]</a><br>"
 			dat += "<b>tgui Style:</b> <a href='?_src_=prefs;preference=tgui_fancy'>[(tgui_fancy) ? "Fancy" : "No Frills"]</a><br>"
+			dat += "<b>PDA Style:</b> <a href='?_src_=prefs;task=input;preference=PDA'>[pda_style]</a><br>"
 			dat += "<b>tgui Monitors:</b> <a href='?_src_=prefs;preference=tgui_lock'>[(tgui_lock) ? "Primary" : "All"]</a><br>"
 			dat += "<b>Window Flashing:</b> <a href='?_src_=prefs;preference=winflash'>[(windowflashing) ? "Yes" : "No"]</a><br>"
 			dat += "<b>Play admin midis:</b> <a href='?_src_=prefs;preference=hear_midis'>[(toggles & SOUND_MIDI) ? "Yes" : "No"]</a><br>"
@@ -1144,6 +1146,10 @@ GLOBAL_LIST_EMPTY(preferences_datums)
 					var/pickedui = input(user, "Choose your UI style.", "Character Preference")  as null|anything in list("Midnight", "Plasmafire", "Retro", "Slimecore", "Operative", "Clockwork")
 					if(pickedui)
 						UI_style = pickedui
+				if("PDA")
+					var/pickedPDA = input(user, "Choose your PDA style.", "Character Preference")  as null|anything in list("MONO", "SHARE", "ORBITRON", "VT")
+					if(pickedPDA)
+						pda_style = pickedPDA
 
 		else
 			switch(href_list["preference"])

--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -46,7 +46,7 @@ GLOBAL_LIST_EMPTY(preferences_datums)
 	var/inquisitive_ghost = 1
 	var/allow_midround_antag = 1
 	var/preferred_map = null
-	var/pda_font = MONO
+	var/pda_style = MONO
 	
 	var/uses_glasses_colour = 0
 

--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -1147,7 +1147,7 @@ GLOBAL_LIST_EMPTY(preferences_datums)
 					if(pickedui)
 						UI_style = pickedui
 				if("PDA")
-					var/pickedPDA = input(user, "Choose your PDA style.", "Character Preference")  as null|anything in list("MONO", "SHARE", "ORBITRON", "VT")
+					var/pickedPDA = input(user, "Choose your PDA style.", "Character Preference")  as null|anything in list(MONO, SHARE, ORBITRON, VT)
 					if(pickedPDA)
 						pda_style = pickedPDA
 

--- a/code/modules/client/preferences_savefile.dm
+++ b/code/modules/client/preferences_savefile.dm
@@ -2,7 +2,7 @@
 #define SAVEFILE_VERSION_MIN	15
 
 //This is the current version, anything below this will attempt to update (if it's not obsolete)
-#define SAVEFILE_VERSION_MAX	18
+#define SAVEFILE_VERSION_MAX	19
 /*
 SAVEFILE UPDATING/VERSIONING - 'Simplified', or rather, more coder-friendly ~Carn
 	This proc checks if the current directory of the savefile S needs updating
@@ -107,7 +107,8 @@ SAVEFILE UPDATING/VERSIONING - 'Simplified', or rather, more coder-friendly ~Car
 			joblessrole = BEASSISTANT
 	if(current_version < 17)
 		features["legs"] = "Normal Legs"
-
+	if(current_version < 19)
+		pda_style = "mono"
 
 
 /datum/preferences/proc/load_path(ckey,filename="preferences.sav")
@@ -158,6 +159,7 @@ SAVEFILE UPDATING/VERSIONING - 'Simplified', or rather, more coder-friendly ~Car
 	S["menuoptions"]		>> menuoptions
 	S["enable_tips"]		>> enable_tips
 	S["tip_delay"]			>> tip_delay
+	S["pda_style"]			>> pda_style
 
 	//try to fix any outdated data if necessary
 	if(needs_update >= 0)
@@ -182,7 +184,7 @@ SAVEFILE UPDATING/VERSIONING - 'Simplified', or rather, more coder-friendly ~Car
 	ghost_others	= sanitize_inlist(ghost_others, GLOB.ghost_others_options, GHOST_OTHERS_DEFAULT_OPTION)
 	menuoptions		= SANITIZE_LIST(menuoptions)
 	be_special		= SANITIZE_LIST(be_special)
-
+	pda_style		= sanitize_inlist(MONO, VT, SHARE, ORBITRON)
 
 	return 1
 
@@ -222,6 +224,7 @@ SAVEFILE UPDATING/VERSIONING - 'Simplified', or rather, more coder-friendly ~Car
 	WRITE_FILE(S["menuoptions"], menuoptions)
 	WRITE_FILE(S["enable_tips"], enable_tips)
 	WRITE_FILE(S["tip_delay"], tip_delay)
+	WRITE_FILE(S["pda_style"], pda_style)
 
 	return 1
 


### PR DESCRIPTION
Its now a preference applied only on a pda's first equip.
:cl:
tweak: The PDA default font has been switched from "eye bleed" to old-style monospace. Check your preference.
/:cl:

Muh eyes.

![pda](https://user-images.githubusercontent.com/11540177/31057332-1b0902f4-a6af-11e7-9a35-da29688e9cef.PNG)

VT323 (old new default)
![image](https://user-images.githubusercontent.com/11540177/31058539-764bf4e6-a6c3-11e7-9adc-5abe4d65c37b.png)

Share Tech Mono
![image](https://user-images.githubusercontent.com/11540177/31058542-814d6190-a6c3-11e7-8b07-111c379dabb6.png)

Orbitron
![image](https://user-images.githubusercontent.com/11540177/31058553-946f7150-a6c3-11e7-905a-055031f4a2c6.png)

Monospaced (new new default)
![image](https://user-images.githubusercontent.com/11540177/31058558-9d2e6850-a6c3-11e7-8bf3-c422320a77e4.png)
