### PR TITLE
Fixes paper writing

### DIFF
--- a/code/__HELPERS/text.dm
+++ b/code/__HELPERS/text.dm
@@ -444,7 +444,7 @@ GLOBAL_LIST_INIT(binary, list("0","1"))
 		t = replacetext(t, "((", "<font size=\"1\">")
 		t = replacetext(t, "))", "</font>")
 		t = replacetext(t, regex("^-{3,}$", "gm"), "<hr>")
-		t = replacetext(t, regex("^\\(-{3,})$", "gm"), "$1")
+		t = replacetext(t, regex("^\\(-{3,}\\)$", "gm"), "$1")
 
 		// Parse lists
 

--- a/code/__HELPERS/text.dm
+++ b/code/__HELPERS/text.dm
@@ -443,8 +443,8 @@ GLOBAL_LIST_INIT(binary, list("0","1"))
 	if(!limited)
 		t = replacetext(t, "((", "<font size=\"1\">")
 		t = replacetext(t, "))", "</font>")
-		t = replacetext(t, regex("^-{3,}$", "gm"), "<hr>")
-		t = replacetext(t, regex("^\\(-{3,}\\)$", "gm"), "$1")
+		t = replacetext(t, regex("(-){3,}", "gm"), "<hr>")
+		t = replacetext(t, regex("^\\((-){3,}\\)$", "gm"), "$1")
 
 		// Parse lists
 


### PR DESCRIPTION
Fixes #31195 

remind me to turn every regex to raws in 512 

Also turns out byond doesn't handle `a{x,}` needs to be `(a){x,}`