### PR TITLE
makes /turf/Enter() faster, and also makes CollidedWith async

### DIFF
--- a/code/game/atoms.dm
+++ b/code/game/atoms.dm
@@ -189,6 +189,7 @@
 
 
 /atom/proc/CollidedWith(atom/movable/AM)
+	set waitfor = FALSE
 	return
 
 // Convenience proc to see if a container is open for chemistry handling

--- a/code/game/turfs/turf.dm
+++ b/code/game/turfs/turf.dm
@@ -121,8 +121,6 @@
 	return FALSE
 
 /turf/Enter(atom/movable/mover as mob|obj, atom/forget as mob|obj|turf|area)
-	if (!mover)
-		return TRUE
 	// First, make sure it can leave its square
 	if(isturf(mover.loc))
 		// Nothing but border objects stop you from leaving a tile, only one loop is needed
@@ -131,32 +129,28 @@
 				mover.Collide(obstacle)
 				return FALSE
 
-	var/list/large_dense = list()
-
-	//Next, check objects to block entry that are on the border
-	for(var/atom/movable/border_obstacle in src)
-		if(border_obstacle.flags_1 & ON_BORDER_1)
-			if(!border_obstacle.CanPass(mover, mover.loc, 1) && (forget != border_obstacle))
-				mover.Collide(border_obstacle)
-				return FALSE
-		else
-			large_dense += border_obstacle
-
 	//Then, check the turf itself
 	if (!src.CanPass(mover, src))
 		mover.Collide(src)
 		return FALSE
 
-	//Finally, check objects/mobs to block entry that are not on the border
-	var/atom/movable/tompost_bump
+
+	var/atom/movable/topmost_bump
 	var/top_layer = FALSE
-	for(var/atom/movable/obstacle in large_dense)
+
+	//Next, check objects to block entry that are on the border
+	for(var/atom/movable/obstacle in src)
 		if(!obstacle.CanPass(mover, mover.loc, 1) && (forget != obstacle))
-			if(obstacle.layer > top_layer)
-				tompost_bump = obstacle
-				top_layer = obstacle.layer
-	if(tompost_bump)
-		mover.Collide(tompost_bump)
+			if(obstacle.flags_1 & ON_BORDER_1)
+				mover.Collide(obstacle)
+				return FALSE
+			else
+				if(obstacle.layer > top_layer)
+					topmost_bump = obstacle
+					top_layer = obstacle.layer
+
+	if(topmost_bump)
+		mover.Collide(topmost_bump)
 		return FALSE
 
 	return TRUE //Nothing found to block so return success!


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/20017308/31059588-672b8edc-a70d-11e7-8d7a-29a2afe716b7.png)

This is the "NewNewEnter" one. ~~While testing this, I've had trouble getting good numbers from the real time tab in the profiler. There seems to be a lot of variance, sometimes my new procs are below the old one as they should, sometimes the NewEnter proc has double the real time cost of the others for reasons unknown, there's barely any change in it at all.~~

^ Disregard all this, it was fucking windoors sleeping

Small(er) beans, maybe, but this does get its share of cycles on higher-pop rounds.

Things I did:
1. Same as last time, did some popularity contest on the various return return paths and based on that:
2. Moved the "incoming" turf check before incoming border objects, as hitting solid turfs is far far far more likelier than hitting windoors or windows which seem to be the only border objects that matter.
3. Removed the (!mover) check as i could not get it to fire even once, there's probably not much cost to it but why keep dead code around?
4. Combined the loop that checks for border objects and creates a list of nonpassable objects on the "incoming" turf with the next one that goes over the list and picks the one on the topmost layer

Bonus: Also made CollidedWith async so that windoor sleeps etc don't mess up real time profiling of movement procs