### PR TITLE
Makes gutlunches hungry for gibs again

### DIFF
--- a/code/modules/mob/living/simple_animal/hostile/mining_mobs/gutlunch.dm
+++ b/code/modules/mob/living/simple_animal/hostile/mining_mobs/gutlunch.dm
@@ -62,6 +62,10 @@
 
 		return TRUE
 
+	if(isobj(the_target))
+		if(attack_all_objects || is_type_in_typecache(the_target, wanted_objects))
+			return TRUE
+
 	return FALSE
 
 /mob/living/simple_animal/hostile/asteroid/gutlunch/Destroy()

--- a/code/modules/mob/living/simple_animal/hostile/mining_mobs/gutlunch.dm
+++ b/code/modules/mob/living/simple_animal/hostile/mining_mobs/gutlunch.dm
@@ -62,9 +62,8 @@
 
 		return TRUE
 
-	if(isobj(the_target))
-		if(attack_all_objects || is_type_in_typecache(the_target, wanted_objects))
-			return TRUE
+	if(isobj(the_target) && is_type_in_typecache(the_target, wanted_objects))
+		return TRUE
 
 	return FALSE
 


### PR DESCRIPTION
In my zealousness in #31141 I mistakenly removed the ability of gutlunches to find and eat gibs. As gib-eating directly affects their milk production, this is a bit worse than just some missing fluff.

[Changelogs]: 

:cl: Naksu
fix: Gutlunches will now once again look for gibs to eat.
/:cl:

[why]:
Bugfix
