### PR TITLE
Fixes Cult 2H Sword Soulshards

### DIFF
--- a/code/game/gamemodes/cult/cult_items.dm
+++ b/code/game/gamemodes/cult/cult_items.dm
@@ -98,7 +98,6 @@
 	var/datum/action/innate/cult/spin2win/linked_action
 	var/spinning = FALSE
 	var/spin_cooldown = 250
-	var/list/shards = list()
 	var/dash_toggled = TRUE
 
 /obj/item/twohanded/required/cult_bastard/Initialize()
@@ -174,11 +173,14 @@
 		if(H.stat != CONSCIOUS)
 			var/obj/item/device/soulstone/SS = new /obj/item/device/soulstone(src)
 			SS.attack(H, user)
-			shards += SS
-		return
+			if(!LAZYLEN(SS.contents))
+				qdel(SS)
 	if(istype(target, /obj/structure/constructshell) && contents.len)
 		var/obj/item/device/soulstone/SS = contents[1]
-		if(istype(SS) && SS.transfer_soul("CONSTRUCT",target,user))
+		if(istype(SS))
+			SS.transfer_soul("CONSTRUCT",target,user)
+
+
 			qdel(SS)
 
 /datum/action/innate/dash/cult

--- a/code/game/gamemodes/cult/cult_items.dm
+++ b/code/game/gamemodes/cult/cult_items.dm
@@ -179,8 +179,6 @@
 		var/obj/item/device/soulstone/SS = contents[1]
 		if(istype(SS))
 			SS.transfer_soul("CONSTRUCT",target,user)
-
-
 			qdel(SS)
 
 /datum/action/innate/dash/cult

--- a/code/game/gamemodes/wizard/soulstone.dm
+++ b/code/game/gamemodes/wizard/soulstone.dm
@@ -60,7 +60,6 @@
 		to_chat(user, "<span class='cultlarge'>\"Come now, do not capture your bretheren's soul.\"</span>")
 		return
 	add_logs(user, M, "captured [M.name]'s soul", src)
-
 	transfer_soul("VICTIM", M, user)
 
 ///////////////////Options for using captured souls///////////////////////////////////////

--- a/code/game/objects/items/storage/book.dm
+++ b/code/game/objects/items/storage/book.dm
@@ -162,7 +162,7 @@ GLOBAL_LIST_INIT(bibleitemstates, list("bible", "koran", "scrapbook", "bible",  
 		playsound(src,'sound/hallucinations/veryfar_noise.ogg',40,1)
 		if(do_after(user, 40, target = sword))
 			playsound(src,'sound/effects/pray_chaplain.ogg',60,1)
-			for(var/obj/item/device/soulstone/SS in sword.shards)
+			for(var/obj/item/device/soulstone/SS in sword.contents)
 				SS.usability = TRUE
 				for(var/mob/living/simple_animal/shade/EX in SS)
 					SSticker.mode.remove_cultist(EX.mind, 1, 0)


### PR DESCRIPTION
So certain conditions would create empty soul shards that would prevent the creation of constructs, its fixed. 

:cl: Robustin
fix: The Cult's bastard sword should now properly store souls and create constructs. 
/:cl:
