### PR TITLE
Fixes humans having no examine feedback for soft crit

### DIFF
--- a/code/modules/mob/living/carbon/human/examine.dm
+++ b/code/modules/mob/living/carbon/human/examine.dm
@@ -271,9 +271,11 @@
 	if(!appears_dead)
 		if(stat == UNCONSCIOUS)
 			msg += "[t_He] [t_is]n't responding to anything around [t_him] and seems to be asleep.\n"
-		else if(getBrainLoss() >= 60)
-			msg += "[t_He] [t_has] a stupid expression on [t_his] face.\n"
-
+		else
+			if(getBrainLoss() >= 60)
+				msg += "[t_He] [t_has] a stupid expression on [t_his] face.\n"
+			if(InCritical())
+				msg += "[t_He] is barely concious and seems to be in a great deal of pain.\n"
 		if(getorgan(/obj/item/organ/brain))
 			if(istype(src, /mob/living/carbon/human/interactive))
 				var/mob/living/carbon/human/interactive/auto = src

--- a/code/modules/mob/living/carbon/human/examine.dm
+++ b/code/modules/mob/living/carbon/human/examine.dm
@@ -275,7 +275,7 @@
 			if(getBrainLoss() >= 60)
 				msg += "[t_He] [t_has] a stupid expression on [t_his] face.\n"
 			if(InCritical())
-				msg += "[t_He] is barely concious and seems to be in a great deal of pain.\n"
+				msg += "[t_He] is barely concious.\n"
 		if(getorgan(/obj/item/organ/brain))
 			if(istype(src, /mob/living/carbon/human/interactive))
 				var/mob/living/carbon/human/interactive/auto = src


### PR DESCRIPTION
:cl: Kor
fix: You can now tell when someone is in soft crit by examining them.
/:cl:

Turns out there was a check/feedback message for carbons, but humans basically inherit zero from the carbon checks.

If anyone has a better idea for an examine message let me know, I wanted to do "laboured breathing" but realized we have a bunch of species without lungs.