### PR TITLE
Greatly speeds up bees 

### DIFF
--- a/code/modules/mob/living/simple_animal/hostile/bees.dm
+++ b/code/modules/mob/living/simple_animal/hostile/bees.dm
@@ -200,7 +200,7 @@
 				continue
 			BB.bees |= src
 			beehome = BB
-			return // End loop after the first compatible find.
+			break // End loop after the first compatible find.
 
 /mob/living/simple_animal/hostile/poison/bees/toxin/Initialize()
 	. = ..()

--- a/code/modules/mob/living/simple_animal/hostile/bees.dm
+++ b/code/modules/mob/living/simple_animal/hostile/bees.dm
@@ -105,22 +105,22 @@
 /mob/living/simple_animal/hostile/poison/bees/CanAttack(atom/the_target)
 	. = ..()
 	if(!.)
-		return 0
+		return FALSE
 	if(isliving(the_target))
 		var/mob/living/H = the_target
 		return !H.bee_friendly()
 
 
 /mob/living/simple_animal/hostile/poison/bees/Found(atom/A)
+	if(isliving(A))
+		var/mob/living/H = A
+		return !H.bee_friendly()
 	if(istype(A, /obj/machinery/hydroponics))
 		var/obj/machinery/hydroponics/Hydro = A
 		if(Hydro.myseed && !Hydro.dead && !Hydro.recent_bee_visit)
 			wanted_objects |= typecacheof(/obj/machinery/hydroponics) //so we only hunt them while they're alive/seeded/not visisted
-			return 1
-	if(isliving(A))
-		var/mob/living/H = A
-		return !H.bee_friendly()
-	return 0
+			return TRUE
+	return FALSE
 
 
 /mob/living/simple_animal/hostile/poison/bees/AttackingTarget()
@@ -187,7 +187,7 @@
 		if(loc == beehome)
 			idle = min(100, ++idle)
 			if(idle >= BEE_IDLE_ROAMING && prob(BEE_PROB_GOROAM))
-				forceMove(get_turf(beehome))
+				forceMove(beehome.drop_location())
 		else
 			idle = max(0, --idle)
 			if(idle <= BEE_IDLE_GOHOME && prob(BEE_PROB_GOHOME))
@@ -200,6 +200,7 @@
 				continue
 			BB.bees |= src
 			beehome = BB
+			return // End loop after the first compatible find.
 
 /mob/living/simple_animal/hostile/poison/bees/toxin/Initialize()
 	. = ..()
@@ -215,7 +216,7 @@
 
  //the Queen doesn't leave the box on her own, and she CERTAINLY doesn't pollinate by herself
 /mob/living/simple_animal/hostile/poison/bees/queen/Found(atom/A)
-	return 0
+	return FALSE
 
 
 //leave pollination for the peasent bees
@@ -234,10 +235,10 @@
 
 /mob/living/simple_animal/hostile/poison/bees/proc/reagent_incompatible(mob/living/simple_animal/hostile/poison/bees/B)
 	if(!B)
-		return 0
+		return FALSE
 	if(B.beegent && beegent && B.beegent.id != beegent.id || B.beegent && !beegent || !B.beegent && beegent)
-		return 1
-	return 0
+		return TRUE
+	return FALSE
 
 
 /obj/item/queen_bee
@@ -255,7 +256,7 @@
 		if(S.reagents.has_reagent("royal_bee_jelly")) //checked twice, because I really don't want royal bee jelly to be duped
 			if(S.reagents.has_reagent("royal_bee_jelly",5))
 				S.reagents.remove_reagent("royal_bee_jelly", 5)
-				var/obj/item/queen_bee/qb = new(get_turf(user))
+				var/obj/item/queen_bee/qb = new(user.drop_location())
 				qb.queen = new(qb)
 				if(queen && queen.beegent)
 					qb.queen.assign_reagent(queen.beegent) //Bees use the global singleton instances of reagents, so we don't need to worry about one bee being deleted and her copies losing their reagents.

--- a/code/modules/mob/living/simple_animal/hostile/hostile.dm
+++ b/code/modules/mob/living/simple_animal/hostile/hostile.dm
@@ -112,7 +112,11 @@
 			if(can_see(targets_from, HM, vision_range))
 				. += HM
 	else
-		. = oview(vision_range, targets_from)
+		. = list() // The following code is only very slightly slower than just returning oview(vision_range, targets_from), but it saves us much more work down the line, particularly when bees are involved
+		for (var/obj/A in oview(vision_range, targets_from))
+			. += A
+		for (var/mob/A in oview(vision_range, targets_from))
+			. += A
 
 /mob/living/simple_animal/hostile/proc/FindTarget(var/list/possible_targets, var/HasTargetsList = 0)//Step 2, filter down possible targets to things we actually care about
 	. = list()


### PR DESCRIPTION
In testing, bee-related procs are no longer in top 20 most called with the changes in this PR. This is kind of a hard thing to provide total perf numbers for. ListTargets() is maybe 5% slower in self/total (somehow slightly faster in real?), but it doesn't return turfs and lighting objects for other procs to choke on. 

[Changelogs]: 

:cl: Naksu
fix: Bees now come with reduced amounts of free lag
/:cl:

