### PR TITLE
Hosts can lock config options from admins

### DIFF
--- a/code/controllers/configuration/configuration.dm
+++ b/code/controllers/configuration/configuration.dm
@@ -74,10 +74,9 @@ GLOBAL_PROTECT(config_dir)
 		if(copytext(L, 1, 2) == "#")
 			continue
 
-		var/lockthis = FALSE
-		if(copytext(L, 1, 2) == "@")
+		var/lockthis = copytext(L, 1, 2) == "@"
+		if(lockthis)
 			L = copytext(L, 2)
-			lockthis = TRUE
 
 		var/pos = findtext(L, " ")
 		var/entry = null

--- a/code/controllers/configuration/configuration.dm
+++ b/code/controllers/configuration/configuration.dm
@@ -74,6 +74,11 @@ GLOBAL_PROTECT(config_dir)
 		if(copytext(L, 1, 2) == "#")
 			continue
 
+		var/lockthis = FALSE
+		if(copytext(L, 1, 2) == "@")
+			L = copytext(L, 2)
+			lockthis = TRUE
+
 		var/pos = findtext(L, " ")
 		var/entry = null
 		var/value = null
@@ -95,6 +100,9 @@ GLOBAL_PROTECT(config_dir)
 		if(filename != E.resident_file)
 			log_config("Found [entry] in [filename] when it should have been in [E.resident_file]! Ignoring.")
 			continue
+
+		if(lockthis)
+			E.protection |= CONFIG_ENTRY_LOCKED
 
 		var/validated = E.ValidateAndSet(value)
 		if(!validated)

--- a/config/config.txt
+++ b/config/config.txt
@@ -1,3 +1,11 @@
+# You can use the @ character at the beginning of a config option to lock it from being edited in-game
+# Example usage:
+# @SERVERNAME tgstation
+# Which sets the SERVERNAME, and disallows admins from being able to change it using View Variables.
+# @LOG_TWITTER 0
+# Which explicitly disables LOG_TWITTER, as well as locking it.
+# There are various options which are hard-locked for security reasons.
+
 ## Server name: This appears at the top of the screen in-game and in the BYOND hub. Uncomment and replace 'tgstation' with the name of your choice.
 # SERVERNAME tgstation
 


### PR DESCRIPTION
:cl: JJRcop
config: Hosts can now lock config options with the @ prefix. This prevents admins from editing the option in-game.
/:cl:

Figured if we had some hard coded ones why not let downstreams easily lock whichever ones themselves without editing the code.