### PR TITLE
Makes shuttle movement a bit smoother and faster

### DIFF
--- a/code/modules/shuttle/on_move.dm
+++ b/code/modules/shuttle/on_move.dm
@@ -317,10 +317,6 @@ All ShuttleMove procs go here
 			shake_force *= 0.25
 		shake_camera(src, shake_force, 1)
 
-/mob/living/beforeShuttleMove(turf/newT, rotation, move_mode)
-	. = ..()
-	Stun(1) //Just making sure people aren't moving around between beforeShuttleMove ticks
-
 /mob/living/afterShuttleMove(list/movement_force, shuttle_dir, shuttle_preferred_direction, move_dir)
 	. = ..()
 	if(movement_force && !buckled)
@@ -378,7 +374,6 @@ All ShuttleMove procs go here
 
 /obj/docking_port/stationary/public_mining_dock/onShuttleMove(turf/newT, turf/oldT, rotation, list/movement_force, move_dir, old_dock)
 	id = "mining_public" //It will not move with the base, but will become enabled as a docking point.
-	return
 
 /obj/effect/abstract/proximity_checker/onShuttleMove(turf/newT, turf/oldT, rotation, list/movement_force, move_dir, old_dock)
 	//timer so it only happens once

--- a/code/modules/shuttle/on_move.dm
+++ b/code/modules/shuttle/on_move.dm
@@ -203,7 +203,7 @@ All ShuttleMove procs go here
 	if(pipe_vision_img)
 		pipe_vision_img.loc = loc
 
-/obj/machinery/computer/auxillary_base/onShuttleMove(turf/newT, turf/oldT, rotation, list/movement_force, move_dir, old_dock)
+/obj/machinery/computer/auxillary_base/afterShuttleMove(list/movement_force, shuttle_dir, shuttle_preferred_direction, move_dir)
 	. = ..()
 	if(z == ZLEVEL_MINING) //Avoids double logging and landing on other Z-levels due to badminnery
 		SSblackbox.add_details("colonies_dropped", "[x]|[y]|[z]") //Number of times a base has been dropped!
@@ -297,24 +297,29 @@ All ShuttleMove procs go here
 
 /************************************Item move procs************************************/
 
-/obj/item/storage/pod/onShuttleMove(turf/newT, turf/oldT, rotation, list/movement_force, move_dir, old_dock)
+/obj/item/storage/pod/afterShuttleMove(turf/newT, turf/oldT, rotation, list/movement_force, move_dir, old_dock)
+	. = ..()
 	unlocked = TRUE
 	// If the pod was launched, the storage will always open.
-	return ..()
 
 /************************************Mob move procs************************************/
 
 /mob/onShuttleMove(turf/newT, turf/oldT, rotation, list/movement_force, move_dir, old_dock)
 	if(!move_on_shuttle)
-		return 0
-	. = ..()
-	if(!.)
 		return
-	if(client)
+	. = ..()
+
+/mob/afterShuttleMove(list/movement_force, shuttle_dir, shuttle_preferred_direction, move_dir)
+	. = ..()
+	if(client && movement_force)
+		var/shake_force = max(movement_force["THROW"], movement_force["KNOCKDOWN"])
 		if(buckled)
-			shake_camera(src, 2, 1) // turn it down a bit come on
-		else
-			shake_camera(src, 7, 1)
+			shake_force *= 0.25
+		shake_camera(src, shake_force, 1)
+
+/mob/living/beforeShuttleMove(turf/newT, rotation, move_mode)
+	. = ..()
+	Stun(1) //Just making sure people aren't moving around between beforeShuttleMove ticks
 
 /mob/living/afterShuttleMove(list/movement_force, shuttle_dir, shuttle_preferred_direction, move_dir)
 	. = ..()
@@ -373,7 +378,7 @@ All ShuttleMove procs go here
 
 /obj/docking_port/stationary/public_mining_dock/onShuttleMove(turf/newT, turf/oldT, rotation, list/movement_force, move_dir, old_dock)
 	id = "mining_public" //It will not move with the base, but will become enabled as a docking point.
-	return 0
+	return
 
 /obj/effect/abstract/proximity_checker/onShuttleMove(turf/newT, turf/oldT, rotation, list/movement_force, move_dir, old_dock)
 	//timer so it only happens once

--- a/code/modules/shuttle/shuttle.dm
+++ b/code/modules/shuttle/shuttle.dm
@@ -553,6 +553,8 @@
 	var/list/moved_atoms = list() //Everything not a turf that gets moved in the shuttle
 	var/list/areas_to_move = list() //unique assoc list of areas on turfs being moved
 
+	CHECK_TICK
+
 	/****************************************All beforeShuttleMove procs*****************************************/
 	var/index = 0
 	for(var/place in old_turfs)
@@ -578,6 +580,7 @@
 			areas_to_move[old_area] = TRUE
 
 		old_turfs[place] = move_mode
+		CHECK_TICK
 
 	/*******************************************All onShuttleMove procs******************************************/
 
@@ -608,16 +611,19 @@
 		var/turf/oldT = thing
 		var/turf/newT = new_turfs[index]
 		newT.afterShuttleMove(oldT)																			//turfs
+		CHECK_TICK
 
 	for(var/i in 1 to moved_atoms.len)
 		var/atom/movable/moved_object = moved_atoms[i]
 		moved_object.afterShuttleMove(movement_force, dir, preferred_direction, movement_direction)			//atoms
+		CHECK_TICK
 
 	underlying_old_area.afterShuttleMove()
 
 	for(var/thing in areas_to_move)
 		var/area/internal_area = thing
 		internal_area.afterShuttleMove()																	//areas
+		CHECK_TICK
 
 	// Parallax handling
 	var/new_parallax_dir = FALSE
@@ -626,6 +632,7 @@
 	for(var/i in shuttle_areas)
 		var/area/place = i
 		place.parallax_movedir = new_parallax_dir
+		CHECK_TICK
 
 	check_poddoors()
 	new_dock.last_dock_time = world.time


### PR DESCRIPTION
You can't CHECK_TICK any of the onShuttleMove() because moving half the shuttle then waiting a tick would be bad idea. However beforeShuttleMove() and afterShuttleMove() usualy do functions which don't have an exact tick requirement like onShuttleMove does. 

This attempts to safely add CHECK_TICK to the primary loops of dock() in order to reduce lag.

This also reduces the screen shake a little bit and connects it to movement_force