### PR TITLE
Removes the shotgun nerf

### DIFF
--- a/code/modules/projectiles/projectile/bullets.dm
+++ b/code/modules/projectiles/projectile/bullets.dm
@@ -8,12 +8,6 @@
 	hitsound_wall = "ricochet"
 	impact_effect_type = /obj/effect/temp_visual/impact_effect
 
-/obj/item/projectile/bullet/pellet/Range()
-	..()
-	damage += -0.75
-	if(damage < 0)
-		qdel(src)
-
 /obj/item/projectile/bullet/incendiary
 	damage = 20
 	var/fire_stacks = 4


### PR DESCRIPTION
Reverts #24633

Shotguns are completely useless with the nerf, rubber shots just vanishing after 4 tiles, taking 3 buckshots to even crit a guy in a lab coat (at like point blank range i might add). This is a shitty nerf that makes a very interesting weapon into just a pile of trash, so fuck this nerf.
