### PR TITLE
Fixes shaking people up while buckled into a bed/resin nest

### DIFF
--- a/code/modules/mob/living/carbon/carbon_defense.dm
+++ b/code/modules/mob/living/carbon/carbon_defense.dm
@@ -247,6 +247,9 @@
 		return
 
 	if(health >= 0 && !(status_flags & FAKEDEATH))
+		if(buckled && lying)
+			to_chat(M, "<span class='warning'>You need to unbuckle [src] first to do that!")
+			return
 
 		if(lying)
 			M.visible_message("<span class='notice'>[M] shakes [src] trying to get [p_them()] up!</span>", \

--- a/code/modules/mob/living/carbon/carbon_defense.dm
+++ b/code/modules/mob/living/carbon/carbon_defense.dm
@@ -247,11 +247,11 @@
 		return
 
 	if(health >= 0 && !(status_flags & FAKEDEATH))
-		if(buckled && lying)
-			to_chat(M, "<span class='warning'>You need to unbuckle [src] first to do that!")
-			return
 
 		if(lying)
+			if(buckled)
+				to_chat(M, "<span class='warning'>You need to unbuckle [src] first to do that!")
+				return
 			M.visible_message("<span class='notice'>[M] shakes [src] trying to get [p_them()] up!</span>", \
 							"<span class='notice'>You shake [src] trying to get [p_them()] up!</span>")
 		else


### PR DESCRIPTION
🆑 ShizCalev
fix: You now have to unbuckle a player PRIOR to shaking them up off a bed or resin nest.
/🆑

Fixes #28744

People buckled into beds/while lying down could be shaken up without first unbuckling them.

This makes it so that you have to unbuckle them prior to making them stand up via shaking.