### PR TITLE
Cleans up non-timid shuttle templates & some dirty vars

### DIFF
--- a/_maps/map_files/BoxStation/BoxStation.dmm
+++ b/_maps/map_files/BoxStation/BoxStation.dmm
@@ -2282,7 +2282,6 @@
 	},
 /obj/docking_port/mobile/emergency{
 	name = "Box emergency shuttle";
-	timid = 0
 	},
 /obj/docking_port/stationary{
 	dir = 4;

--- a/_maps/map_files/OmegaStation/OmegaStation.dmm
+++ b/_maps/map_files/OmegaStation/OmegaStation.dmm
@@ -16885,7 +16885,6 @@
 	dwidth = 5;
 	height = 11;
 	name = "Omega emergency shuttle";
-	timid = 0;
 	width = 19
 	},
 /obj/docking_port/stationary{

--- a/_maps/shuttles/emergency_box.dmm
+++ b/_maps/shuttles/emergency_box.dmm
@@ -224,7 +224,7 @@
 	},
 /obj/docking_port/mobile/emergency{
 	name = "Box emergency shuttle";
-	timid = 0
+	timid = 1
 	},
 /turf/open/floor/plating,
 /area/shuttle/escape)

--- a/_maps/shuttles/whiteship_box.dmm
+++ b/_maps/shuttles/whiteship_box.dmm
@@ -21,7 +21,7 @@
 	port_direction = 8;
 	preferred_direction = 4;
 	roundstart_move = "whiteship_away";
-	timid = null;
+	timid = 1;
 	width = 35
 	},
 /turf/open/floor/mineral/titanium,


### PR DESCRIPTION
Non-timid templates get unloaded immediately. Looks like the shuttles were just copypasta'd without that actually being set properly.

Also cleaned up timid = 0 on two shuttles, since that's the default state for the var anyway.