### PR TITLE
Cleans up and fixes old landmarks

### DIFF
--- a/code/datums/mind.dm
+++ b/code/datums/mind.dm
@@ -1109,7 +1109,7 @@
 					message_admins("[key_name_admin(usr)] has nuke op'ed [current].")
 					log_admin("[key_name(usr)] has nuke op'ed [current].")
 			if("lair")
-				current.forceMove(get_turf(locate("landmark*Syndicate-Spawn")))
+				current.forceMove(pick(GLOB.nukeop_start))
 			if("dressup")
 				var/mob/living/carbon/human/H = current
 				qdel(H.belt)

--- a/code/modules/admin/verbs/randomverbs.dm
+++ b/code/modules/admin/verbs/randomverbs.dm
@@ -381,13 +381,10 @@ Traitors and the like can also be revived with the previous role mostly intact.
 
 	switch(new_character.mind.special_role)
 		if("Wizard")
-			new_character.loc = pick(GLOB.wizardstart)
-			//SSticker.mode.learn_basic_spells(new_character)
+			new_character.forceMove(pick(GLOB.wizardstart))
 			SSticker.mode.equip_wizard(new_character)
 		if("Syndicate")
-			var/obj/effect/landmark/synd_spawn = locate("landmark*Syndicate-Spawn")
-			if(synd_spawn)
-				new_character.loc = get_turf(synd_spawn)
+			new_character.forceMove(pick(GLOB.nukeop_start))
 			call(/datum/game_mode/proc/equip_syndicate)(new_character)
 		if("Space Ninja")
 			var/list/ninja_spawn = list()
@@ -396,8 +393,7 @@ Traitors and the like can also be revived with the previous role mostly intact.
 			var/datum/antagonist/ninja/ninjadatum = new_character.mind.has_antag_datum(ANTAG_DATUM_NINJA)
 			ninjadatum.equip_space_ninja()
 			if(ninja_spawn.len)
-				var/obj/effect/landmark/ninja_spawn_here = pick(ninja_spawn)
-				new_character.loc = ninja_spawn_here.loc
+				new_character.forceMove(pick(ninja_spawn))
 
 		else//They may also be a cyborg or AI.
 			switch(new_character.mind.assigned_role)

--- a/code/modules/mob/dead/new_player/new_player.dm
+++ b/code/modules/mob/dead/new_player/new_player.dm
@@ -273,7 +273,7 @@
 
 	observer.started_as_observer = TRUE
 	close_spawn_windows()
-	var/obj/O = locate("landmark*Observer-Start")
+	var/obj/effect/landmark/observer_start/O = locate(/obj/effect/landmark/observer_start) in GLOB.landmarks_list
 	to_chat(src, "<span class='notice'>Now teleporting.</span>")
 	if (O)
 		observer.loc = O.loc

--- a/code/modules/shuttle/manipulator.dm
+++ b/code/modules/shuttle/manipulator.dm
@@ -242,7 +242,7 @@
 /obj/machinery/shuttle_manipulator/proc/load_template(
 	datum/map_template/shuttle/S)
 	// load shuttle template, centred at shuttle import landmark,
-	var/turf/landmark_turf = get_turf(locate("landmark*Shuttle Import"))
+	var/turf/landmark_turf = get_turf(locate(/obj/effect/landmark/shuttle_import) in GLOB.landmarks_list)
 	S.load(landmark_turf, centered = TRUE)
 
 	var/affected = S.get_affected_turfs(landmark_turf, centered=TRUE)


### PR DESCRIPTION
A couple things were referencing tags to find landmarks instead of looking for the actual landmark type.

This lead to things referencing nonexistant landmarks in some cases such as respawning and teleporting syndies to their base.