### PR TITLE
Experimental fix for #29663

### DIFF
--- a/code/modules/mob/living/simple_animal/simple_animal.dm
+++ b/code/modules/mob/living/simple_animal/simple_animal.dm
@@ -96,13 +96,6 @@
 	if(!loc)
 		stack_trace("Simple animal being instantiated in nullspace")
 
-
-/mob/living/simple_animal/Login()
-	if(src && src.client)
-		src.client.screen = list()
-		client.screen += client.void
-	..()
-
 /mob/living/simple_animal/updatehealth()
 	..()
 	health = Clamp(health, 0, maxHealth)


### PR DESCRIPTION
:cl: RandomMarine
fix: Simple mobs should no longer experience severe hud/lighting glitches when reconnecting.
/:cl:

⚠️**EXPERIMENTAL FIX ZONE I DON'T REALLY KNOW WHAT THE FUCK I'M DOING**⚠️
Somebody that knows how screens and hud objects and shit works should input on this.

**BEFORE THIS CHANGE:**

\>control a simple_animal
\>close client/lose connection
\>reconnect
\>#29663 happens
\> `Runtime in simple_animal.dm,103: wrong type of value for list
  proc name: Login (/mob/living/simple_animal/Login)
  usr: The cow (randommarine) (/mob/living/simple_animal/cow)
  usr.loc: The floor (111,141,2) (/turf/open/floor/plasteel)
  src: the cow (/mob/living/simple_animal/cow)
  src.loc: the floor (111,141,2) (/turf/open/floor/plasteel)
  call stack:
  the cow (/mob/living/simple_animal/cow): Login()
  RandomMarine (/client): New(null)`
\>check client vars
![shitsbroke](https://user-images.githubusercontent.com/6583225/31160138-13eda8c8-a883-11e7-81b9-913da8355142.png)

**AFTER THIS CHANGE:**

\>control a simple_animal
\>close client/lose connection
\>reconnect
\>everything seems fine, no runtime.
\>check client vars
![shitsnotfucked](https://user-images.githubusercontent.com/6583225/31160224-bea1565c-a883-11e7-8df5-f7a89c559dc8.png)
