### PR TITLE
Move shuttleRotate into the shuttle module

### DIFF
--- a/code/game/turfs/simulated/minerals.dm
+++ b/code/game/turfs/simulated/minerals.dm
@@ -38,10 +38,6 @@
 				if(istype(T, /turf/closed/mineral/random))
 					Spread(T)
 
-/turf/closed/mineral/shuttleRotate(rotation)
-	setDir(angle2dir(rotation+dir2angle(dir)))
-	queue_smooth(src)
-
 /turf/closed/mineral/get_smooth_underlay_icon(mutable_appearance/underlay_appearance, turf/asking_turf, adjacency_dir)
 	if(turf_type)
 		underlay_appearance.icon = initial(turf_type.icon)

--- a/code/modules/awaymissions/gateway.dm
+++ b/code/modules/awaymissions/gateway.dm
@@ -60,10 +60,6 @@ GLOBAL_DATUM(the_gateway, /obj/machinery/gateway/centerstation)
 		return
 	icon_state = "off"
 
-//prevents shuttles attempting to rotate this since it messes up sprites
-/obj/machinery/gateway/shuttleRotate()
-	return
-
 /obj/machinery/gateway/attack_hand(mob/user)
 	if(!detect())
 		return

--- a/code/modules/mining/equipment/survival_pod.dm
+++ b/code/modules/mining/equipment/survival_pod.dm
@@ -104,10 +104,6 @@
 	direction = expected_dir
 	..()
 
-/obj/machinery/door/airlock/survival_pod/shuttleRotate(rotation)
-	expected_dir = angle2dir(rotation+dir2angle(dir))
-	..()
-
 /obj/machinery/door/airlock/survival_pod/vertical
 	dir = EAST
 	expected_dir = EAST
@@ -125,10 +121,6 @@
 
 /obj/structure/door_assembly/door_assembly_pod/setDir(direction)
 	direction = expected_dir
-	..()
-
-/obj/structure/door_assembly/door_assembly_pod/shuttleRotate(rotation)
-	expected_dir = angle2dir(rotation+dir2angle(dir))
 	..()
 
 /obj/structure/door_assembly/door_assembly_pod/vertical

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -735,10 +735,6 @@
 			mob_spell_list -= S
 			qdel(S)
 
-//override to avoid rotating pixel_xy on mobs
-/mob/shuttleRotate(rotation)
-	setDir(angle2dir(rotation+dir2angle(dir)))
-
 //You can buckle on mobs if you're next to them since most are dense
 /mob/buckle_mob(mob/living/M, force = FALSE, check_loc = TRUE)
 	if(M.buckled)

--- a/code/modules/power/cable.dm
+++ b/code/modules/power/cable.dm
@@ -437,21 +437,6 @@ By design, d1 is the smallest direction and d2 is the highest
 			if(!P.connect_to_network()) //can't find a node cable on a the turf to connect to
 				P.disconnect_from_network() //remove from current network
 
-/obj/structure/cable/shuttleRotate(rotation)
-	//..() is not called because wires are not supposed to have a non-default direction
-	//Rotate connections
-	if(d1)
-		d1 = angle2dir(rotation+dir2angle(d1))
-	if(d2)
-		d2 = angle2dir(rotation+dir2angle(d2))
-
-	//d1 should be less than d2 for cable icons to work
-	if(d1 > d2)
-		var/temp = d1
-		d1 = d2
-		d2 = temp
-	update_icon()
-
 
 ///////////////////////////////////////////////
 // The cable coil object, used for laying cable

--- a/code/modules/power/gravitygenerator.dm
+++ b/code/modules/power/gravitygenerator.dm
@@ -48,10 +48,6 @@ GLOBAL_LIST_EMPTY(gravity_generators) // We will keep track of this by adding ne
 	..()
 	icon_state = "[get_status()]_[sprite_number]"
 
-//prevents shuttles attempting to rotate this since it messes up sprites
-/obj/machinery/gravity_generator/shuttleRotate()
-	return
-
 /obj/machinery/gravity_generator/proc/get_status()
 	return "off"
 

--- a/code/modules/recycling/disposal-structures.dm
+++ b/code/modules/recycling/disposal-structures.dm
@@ -339,16 +339,6 @@
 	if(current_size >= STAGE_FIVE)
 		deconstruct()
 
-//Fixes dpdir on shuttle rotation
-/obj/structure/disposalpipe/shuttleRotate(rotation)
-	..()
-	var/new_dpdir = 0
-	for(var/D in GLOB.cardinals)
-		if(dpdir & D)
-			new_dpdir = new_dpdir | angle2dir(rotation+dir2angle(D))
-	dpdir = new_dpdir
-
-
 // *** TEST verb
 //client/verb/dispstop()
 //	for(var/obj/structure/disposalholder/H in world)

--- a/code/modules/shuttle/on_move.dm
+++ b/code/modules/shuttle/on_move.dm
@@ -83,7 +83,7 @@ All ShuttleMove procs go here
 			return
 
 	if(rotation)
-		shuttleRotate(rotation)
+		shuttleRotate(rotation) //see shuttle_rotate.dm
 	loc = newT
 	if(length(client_mobs_in_contents))
 		update_parallax_contents()
@@ -125,26 +125,6 @@ All ShuttleMove procs go here
 // Called on areas after everything has been moved
 /area/proc/afterShuttleMove()
 	return TRUE
-
-/************************************Shuttle Rotation************************************/
-
-/atom/proc/shuttleRotate(rotation)
-	//rotate our direction
-	setDir(angle2dir(rotation+dir2angle(dir)))
-
-	//resmooth if need be.
-	if(smooth)
-		queue_smooth(src)
-
-	//rotate the pixel offsets too.
-	if (pixel_x || pixel_y)
-		if (rotation < 0)
-			rotation += 360
-		for (var/turntimes=rotation/90;turntimes>0;turntimes--)
-			var/oldPX = pixel_x
-			var/oldPY = pixel_y
-			pixel_x = oldPY
-			pixel_y = (oldPX*(-1))
 
 /************************************Turf move procs************************************/
 
@@ -222,21 +202,6 @@ All ShuttleMove procs go here
 /obj/machinery/thruster/beforeShuttleMove(turf/newT, rotation, move_mode)
 	. = ..()
 	. |= MOVE_CONTENTS
-
-//Properly updates pipes on shuttle movement
-/obj/machinery/atmospherics/shuttleRotate(rotation)
-	var/list/real_node_connect = getNodeConnects()
-	for(DEVICE_TYPE_LOOP)
-		real_node_connect[I] = angle2dir(rotation+dir2angle(real_node_connect[I]))
-
-	. = ..()
-	SetInitDirections()
-	var/list/supposed_node_connect = getNodeConnects()
-	var/list/nodes_copy = nodes.Copy()
-
-	for(DEVICE_TYPE_LOOP)
-		var/new_pos = supposed_node_connect.Find(real_node_connect[I])
-		nodes[new_pos] = nodes_copy[I]
 
 /obj/machinery/atmospherics/afterShuttleMove(list/movement_force, shuttle_dir, shuttle_preferred_direction, move_dir)
 	. = ..()

--- a/code/modules/shuttle/shuttle_rotate.dm
+++ b/code/modules/shuttle/shuttle_rotate.dm
@@ -1,0 +1,100 @@
+/*
+All shuttleRotate procs go here
+*/
+
+/************************************Base proc************************************/
+
+/atom/proc/shuttleRotate(rotation)
+	//rotate our direction
+	setDir(angle2dir(rotation+dir2angle(dir)))
+
+	//resmooth if need be.
+	if(smooth)
+		queue_smooth(src)
+
+	//rotate the pixel offsets too.
+	if (pixel_x || pixel_y)
+		if (rotation < 0)
+			rotation += 360
+		for (var/turntimes=rotation/90;turntimes>0;turntimes--)
+			var/oldPX = pixel_x
+			var/oldPY = pixel_y
+			pixel_x = oldPY
+			pixel_y = (oldPX*(-1))
+
+/************************************Turf rotate procs************************************/
+
+/turf/closed/mineral/shuttleRotate(rotation)
+	setDir(angle2dir(rotation+dir2angle(dir)))
+	queue_smooth(src)
+
+/************************************Mob rotate procs************************************/
+
+//override to avoid rotating pixel_xy on mobs
+/mob/shuttleRotate(rotation)
+	setDir(angle2dir(rotation+dir2angle(dir)))
+
+/************************************Structure rotate procs************************************/
+
+/obj/structure/door_assembly/door_assembly_pod/shuttleRotate(rotation)
+	. = ..()
+	expected_dir = angle2dir(rotation+dir2angle(dir))
+
+/obj/structure/cable/shuttleRotate(rotation)
+	//..() is not called because wires are not supposed to have a non-default direction
+	//Rotate connections
+	if(d1)
+		d1 = angle2dir(rotation+dir2angle(d1))
+	if(d2)
+		d2 = angle2dir(rotation+dir2angle(d2))
+
+	//d1 should be less than d2 for cable icons to work
+	if(d1 > d2)
+		var/temp = d1
+		d1 = d2
+		d2 = temp
+	update_icon()
+
+//Fixes dpdir on shuttle rotation
+/obj/structure/disposalpipe/shuttleRotate(rotation)
+	. = ..()
+	var/new_dpdir = 0
+	for(var/D in GLOB.cardinals)
+		if(dpdir & D)
+			new_dpdir = new_dpdir | angle2dir(rotation+dir2angle(D))
+	dpdir = new_dpdir
+
+/obj/structure/table/wood/bar/shuttleRotate(rotation)
+	. = ..()
+	boot_dir = angle2dir(rotation + dir2angle(boot_dir))
+
+/obj/structure/alien/weeds/shuttleRotate(rotation)
+	return
+
+/************************************Machine rotate procs************************************/
+
+/obj/machinery/atmospherics/shuttleRotate(rotation)
+	var/list/real_node_connect = getNodeConnects()
+	for(DEVICE_TYPE_LOOP)
+		real_node_connect[I] = angle2dir(rotation+dir2angle(real_node_connect[I]))
+
+	. = ..()
+	SetInitDirections()
+	var/list/supposed_node_connect = getNodeConnects()
+	var/list/nodes_copy = nodes.Copy()
+
+	for(DEVICE_TYPE_LOOP)
+		var/new_pos = supposed_node_connect.Find(real_node_connect[I])
+		nodes[new_pos] = nodes_copy[I]
+
+//prevents shuttles attempting to rotate this since it messes up sprites
+/obj/machinery/gateway/shuttleRotate()
+	return
+
+/obj/machinery/door/airlock/survival_pod/shuttleRotate(rotation)
+	expected_dir = angle2dir(rotation+dir2angle(dir))
+	return ..()
+
+//prevents shuttles attempting to rotate this since it messes up sprites
+/obj/machinery/gravity_generator/shuttleRotate()
+	return

--- a/code/modules/shuttle/special.dm
+++ b/code/modules/shuttle/special.dm
@@ -195,10 +195,6 @@
 	else
 		. = ..()
 
-/obj/structure/table/wood/bar/shuttleRotate(rotation)
-	. = ..()
-	boot_dir = angle2dir(rotation + dir2angle(boot_dir))
-
 /obj/structure/table/wood/bar/proc/is_barstaff(mob/living/user)
 	. = FALSE
 	if(ishuman(user))

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -2081,6 +2081,7 @@
 #include "code\modules\shuttle\on_move.dm"
 #include "code\modules\shuttle\ripple.dm"
 #include "code\modules\shuttle\shuttle.dm"
+#include "code\modules\shuttle\shuttle_rotate.dm"
 #include "code\modules\shuttle\special.dm"
 #include "code\modules\shuttle\supply.dm"
 #include "code\modules\shuttle\syndicate.dm"


### PR DESCRIPTION
shuttleRotate doesn't seem to have any special code for shuttles, it seems to act like a generic rotate proc. In my opinion it'd be best if it was renamed and moved into the appropriate place for that. In theory this proc is useful elsewhere but as of right now it isn't used except in shuttles.

So is it better to concentrate it all like this and the shuttle_move procs, or make it a more generic name and move it closer to the other atom proc definitions. Either way is fine by me and I just want whatever method is most maintainable.

Also, this fixes #18519 with 2 lines