### PR TITLE
Config option to automatically call the shuttle for high casualties

### DIFF
--- a/code/controllers/configuration/entries/game_options.dm
+++ b/code/controllers/configuration/entries/game_options.dm
@@ -264,3 +264,8 @@ CONFIG_DEF(number/bombcap)
 		GLOB.MAX_EX_LIGHT_RANGE = value
 		GLOB.MAX_EX_FLASH_RANGE = value
 		GLOB.MAX_EX_FLAME_RANGE = value
+
+CONFIG_DEF(number/emergency_shuttle_autocall_threshold)
+	min_val = 0
+	max_val = 1
+	integer = FALSE

--- a/config/game_options.txt
+++ b/config/game_options.txt
@@ -493,3 +493,5 @@ ARRIVALS_SHUTTLE_DOCK_WINDOW 55
 
 MICE_ROUNDSTART 10
 
+## If the percentage of players alive (doesn't count conversions) drops below this threshold the emergency shuttle will be forcefully called (provided it can be)
+#EMERGENCY_SHUTTLE_AUTOCALL_THRESHOLD 0.2


### PR DESCRIPTION
Adapted from https://github.com/HippieStation/HippieStation/pull/3723. May be useful one day

:cl: Cyberboss
config: The shuttle may now be configured to be automatically called if the amount of living crew drops below a certain percentage
/:cl: