### PR TITLE
Tweak to abandoned airlocks

### DIFF
--- a/code/game/machinery/doors/airlock.dm
+++ b/code/game/machinery/doors/airlock.dm
@@ -127,7 +127,6 @@
 					here.ChangeTurf(T.type)
 					return INITIALIZE_HINT_QDEL
 				here.ChangeTurf(/turf/closed/wall)
-				return INITIALIZE_HINT_QDEL
 			if(9 to 11)
 				lights = FALSE
 				locked = TRUE


### PR DESCRIPTION
:cl: Robustin
tweak: Abandoned Airlocks will no longer be deleted when their turf is changed to a wall. 
/:cl:

So I've really enjoyed my abandoned airlocks, it definitely makes maint more mysterious.

However, it occurred to me that if someone was going to wall off an airlock, they wouldn't deconstruct the door too. This made is obvious when a door was being walled off by the "abandoned" effect instead of by a player, defeating the purpose of the effect. 
