### PR TITLE
Makes a couple of atmos procs a tiny bit faster, removes /datum/gas_mixture/thermal_energy()

### DIFF
--- a/code/__DEFINES/atmospherics.dm
+++ b/code/__DEFINES/atmospherics.dm
@@ -174,3 +174,5 @@
 
 #define LAVALAND_EQUIPMENT_EFFECT_PRESSURE 50 //what pressure you have to be under to increase the effect of equipment meant for lavaland
 #define LAVALAND_DEFAULT_ATMOS "o2=14;n2=23;TEMP=300"
+
+#define THERMAL_ENERGY(gas) (gas.temperature * gas.heat_capacity())

--- a/code/modules/atmospherics/gasmixtures/gas_mixture.dm
+++ b/code/modules/atmospherics/gasmixtures/gas_mixture.dm
@@ -119,9 +119,6 @@ GLOBAL_LIST_INIT(gaslist_cache, init_gaslist_cache())
 /datum/gas_mixture/proc/return_volume() //liters
 	return max(0, volume)
 
-// This was a proc once, turns out calling a proc is much more expensive than multiplication
-#define THERMAL_ENERGY(gas) (gas.temperature * gas.heat_capacity())
-
 /datum/gas_mixture/proc/archive()
 	//Update archived versions of variables
 	//Returns: 1 in all cases

--- a/code/modules/atmospherics/gasmixtures/gas_mixture.dm
+++ b/code/modules/atmospherics/gasmixtures/gas_mixture.dm
@@ -119,8 +119,8 @@ GLOBAL_LIST_INIT(gaslist_cache, init_gaslist_cache())
 /datum/gas_mixture/proc/return_volume() //liters
 	return max(0, volume)
 
-/datum/gas_mixture/proc/thermal_energy() //joules
-	return temperature * heat_capacity()
+// This was a proc once, turns out calling a proc is much more expensive than multiplication
+#define THERMAL_ENERGY(gas) (gas.temperature * gas.heat_capacity())
 
 /datum/gas_mixture/proc/archive()
 	//Update archived versions of variables
@@ -424,7 +424,7 @@ GLOBAL_LIST_INIT(gaslist_cache, init_gaslist_cache())
 
 	var/list/cached_gases = gases
 	var/temp = temperature
-	var/ener = thermal_energy()
+	var/ener = THERMAL_ENERGY(src)
 
 	reaction_loop:
 		for(var/r in SSair.gas_reactions)

--- a/code/modules/atmospherics/gasmixtures/reactions.dm
+++ b/code/modules/atmospherics/gasmixtures/reactions.dm
@@ -199,13 +199,13 @@
 
 	var/old_heat_capacity = air.heat_capacity()
 	var/carbon_efficency = min(cached_gases["plasma"][MOLES]/cached_gases["co2"][MOLES],MAX_CARBON_EFFICENCY)
-	var/reaction_energy = air.thermal_energy()
+	var/reaction_energy = THERMAL_ENERGY(air)
 	var/moles_impurities = air.total_moles()-(cached_gases["plasma"][MOLES]+cached_gases["co2"][MOLES])
 
 	var/plasma_fused = (PLASMA_FUSED_COEFFICENT*carbon_efficency)*(temperature/PLASMA_BINDING_ENERGY)
 	var/carbon_catalyzed = (CARBON_CATALYST_COEFFICENT*carbon_efficency)*(temperature/PLASMA_BINDING_ENERGY)
 	var/oxygen_added = carbon_catalyzed
-	var/nitrogen_added = (plasma_fused-oxygen_added)-(air.thermal_energy()/PLASMA_BINDING_ENERGY)
+	var/nitrogen_added = (plasma_fused-oxygen_added)-(THERMAL_ENERGY(air)/PLASMA_BINDING_ENERGY)
 
 	reaction_energy = max(reaction_energy+((carbon_efficency*cached_gases["plasma"][MOLES])/((moles_impurities/carbon_efficency)+2)*10)+((plasma_fused/(moles_impurities/carbon_efficency))*PLASMA_BINDING_ENERGY),0)
 

--- a/code/modules/atmospherics/machinery/datum_pipeline.dm
+++ b/code/modules/atmospherics/machinery/datum_pipeline.dm
@@ -232,7 +232,7 @@
 
 		total_gas_mixture.merge(G)
 
-		total_thermal_energy += G.thermal_energy()
+		total_thermal_energy += THERMAL_ENERGY(G)
 		total_heat_capacity += G.heat_capacity()
 
 	total_gas_mixture.temperature = total_heat_capacity ? total_thermal_energy/total_heat_capacity : 0


### PR DESCRIPTION
This is fairly small beans, but every little bit helps I guess.

Measured by total time (the one that actually matters in this case):

/datum/gas_mixture/thermal_energy() is infinitely faster, due to no longer existing.
/datum/gas_mixture/react() is 5.6% faster, due to no longer calling thermal_energy()
/datum/pipeline/proc/reconcile_air() is 6.24% faster, for the same reason


Measured by self time (the one that actually doesn't matter in this case)
/datum/gas_mixture/thermal_energy() still does not exist
/datum/gas_mixture/react() is 0.48% slower, due to taking on extra work that used to happen in thermal_energy()
/datum/pipeline/proc/reconcile_air() is 1.5% slower, for the same reason


[Changelogs]: 

:cl: Naksu
tweak: Made atmos tiny bit faster
/:cl:

[why]: 
![image](https://user-images.githubusercontent.com/20017308/31202167-3f62a69c-a96a-11e7-9ff6-da06d791de78.png)

