### PR TITLE
Fixes abductor scientists being unable to use tools

### DIFF
--- a/code/datums/antagonists/datum_abductor.dm
+++ b/code/datums/antagonists/datum_abductor.dm
@@ -58,3 +58,9 @@
 			break
 
 	SSticker.mode.update_abductor_icons_added(owner)
+
+/datum/antagonist/abductor/scientist/finalize_abductor()
+	..()
+	var/mob/living/carbon/human/H = owner.current
+	var/datum/species/abductor/A = H.dna.species
+	A.scientist = TRUE


### PR DESCRIPTION
:cl: Kor
fix: Abductor scientists are once again able to use their tools.
/:cl:

I feel like I broke some code standard here but I'm not sure which one yet