### PR TITLE
Makes Ocular Wardens effective again

### DIFF
--- a/code/game/gamemodes/clock_cult/clock_structures/ocular_warden.dm
+++ b/code/game/gamemodes/clock_cult/clock_structures/ocular_warden.dm
@@ -141,6 +141,9 @@
 	. = 1
 	if(target)
 		for(var/turf/T in getline(src, target))
+			if(T.density)
+				. -= 0.1
+				continue
 			for(var/obj/structure/O in T)
 				if(O != src && O.density)
 					. -= 0.1

--- a/code/game/gamemodes/clock_cult/clock_structures/ocular_warden.dm
+++ b/code/game/gamemodes/clock_cult/clock_structures/ocular_warden.dm
@@ -11,7 +11,7 @@
 	break_message = "<span class='warning'>The warden's eye gives a glare of utter hate before falling dark!</span>"
 	debris = list(/obj/item/clockwork/component/belligerent_eye/blind_eye = 1)
 	resistance_flags = LAVA_PROOF | FIRE_PROOF | ACID_PROOF
-	var/damage_per_tick = 2.5
+	var/damage_per_tick = 3
 	var/sight_range = 3
 	var/atom/movable/target
 	var/list/idle_messages = list(" sulkily glares around.", " lazily drifts from side to side.", " looks around for something to burn.", " slowly turns in circles.")
@@ -142,7 +142,8 @@
 	if(target)
 		for(var/turf/T in getline(src, target))
 			for(var/obj/structure/O in T)
-				if(O.density)
-					. -= 0.15
+				if(O != src && O.density)
+					. -= 0.1
+					break
 		. -= (get_dist(src, target) * 0.05)
 		. = max(., 0.1) //The lowest damage a warden can do is 10% of its normal amount (0.25 by default)


### PR DESCRIPTION
:cl: Joan
balance: Ocular Warden base damage per second changed from 12.5 to 15.
bugfix: Ocular Wardens no longer count themselves when checking for dense objects, which decreased their overall damage by 15%.
balance: Ocular Wardens now only reduce their damage by 10% per dense object, and only do so once per turf. However, dense turfs now reduce their damage with the same 10% penalty.
/:cl:

This changes their damage per second on a target at maximum range with one dense object in the way from **8.75** (**6.875** due to the bug) to **11.25**.