### PR TITLE
[Delta] Adds missing warning lines under firedoors in xeno

### DIFF
--- a/_maps/map_files/Deltastation/DeltaStation2.dmm
+++ b/_maps/map_files/Deltastation/DeltaStation2.dmm
@@ -141055,9 +141055,9 @@ cHW
 cHW
 cHW
 cOy
-cQx
-cRP
-cTA
+epl
+epm
+epn
 cOy
 cHW
 cHS
@@ -155988,7 +155988,7 @@ esD
 dAw
 dBO
 dDd
-esF
+esB
 dFd
 dGE
 dHP
@@ -156239,13 +156239,13 @@ drs
 dsS
 drs
 dvx
-esA
+esz
 dyb
 dzf
 dAx
 dBP
 dDe
-esG
+esB
 dFe
 dGF
 dHP
@@ -157016,7 +157016,7 @@ dzi
 dAA
 dBS
 esE
-esH
+esB
 dEY
 dGA
 dHP


### PR DESCRIPTION
The warning lines were missing on one side of the series of firelocks on the West side of Xenobio.