### PR TITLE
Fixes lighting object initialization on new zlevels.

### DIFF
--- a/code/controllers/subsystem/lighting.dm
+++ b/code/controllers/subsystem/lighting.dm
@@ -88,3 +88,11 @@ SUBSYSTEM_DEF(lighting)
 /datum/controller/subsystem/lighting/Recover()
 	initialized = SSlighting.initialized
 	..()
+
+
+/datum/controller/subsystem/lighting/proc/initialize_lighting_objects(list/turfs)
+	for(var/turf/T in turfs)
+		if(!IS_DYNAMIC_LIGHTING(T))
+			continue
+		new/atom/movable/lighting_object(T)
+		CHECK_TICK

--- a/code/modules/mapping/map_template.dm
+++ b/code/modules/mapping/map_template.dm
@@ -53,6 +53,7 @@
 	smooth_zlevel(world.maxz)
 	repopulate_sorted_areas()
 
+	SSlighting.initialize_lighting_objects(block(locate(bounds[MAP_MINX], bounds[MAP_MINY], bounds[MAP_MINZ]),locate(bounds[MAP_MAXX], bounds[MAP_MAXY], bounds[MAP_MAXZ])))
 	//initialize things that are normally initialized after map load
 	initTemplateBounds(bounds)
 	log_game("Z-level [name] loaded at at [x],[y],[world.maxz]")


### PR DESCRIPTION
At some point the area change one was removed so these wouldn't intialize properly.