### PR TITLE
Nerfs shotgun darts

### DIFF
--- a/code/modules/projectiles/ammunition/ammo_casings.dm
+++ b/code/modules/projectiles/ammunition/ammo_casings.dm
@@ -288,7 +288,7 @@
 	..()
 	container_type |= OPENCONTAINER_1
 	create_reagents(30)
-	reagents.set_reacting(FALSE)
+	reagents.set_reacting(TRUE)
 
 /obj/item/ammo_casing/shotgun/dart/attackby()
 	return


### PR DESCRIPTION
ITS TIME TO STOP THE POWERCREEP WE CALL NO REACT SHOTGUN DARTS

[why]: # (Please add a short description [two lines down] of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.)

>cyro syringe requires quite some research with some materials to make
>shotgun darts are no react and 30 units