### PR TITLE
Removes Tesla Revolver from RnD weapon designs

### DIFF
--- a/code/modules/research/designs/weapon_designs.dm
+++ b/code/modules/research/designs/weapon_designs.dm
@@ -22,16 +22,6 @@
 	build_path = /obj/item/device/firing_pin/implant/mindshield
 	category = list("Firing Pins")
 
-/datum/design/stunrevolver
-	name = "Tesla Revolver"
-	desc = "A high-tech revolver that fires internal, reusable shock cartridges in a revolving cylinder. The cartridges can be recharged using conventional rechargers."
-	id = "stunrevolver"
-	req_tech = list("combat" = 4, "materials" = 4, "powerstorage" = 5)
-	build_type = PROTOLATHE
-	materials = list(MAT_METAL = 10000, MAT_GLASS = 10000, MAT_SILVER = 10000)
-	build_path = /obj/item/gun/energy/tesla_revolver
-	category = list("Weapons")
-
 /datum/design/nuclear_gun
 	name = "Advanced Energy Gun"
 	desc = "An energy gun with an experimental miniaturized reactor."


### PR DESCRIPTION
i'm actually making @kevinz000 angry and i have no idea why i did this pr anyway even though he explained why i shouldn't

teslavolver is like one of the worst rnd designs plus i've seen nobody use it. if you can provide enough justification to not remove this weapon, then speak you science powergamers. 


_also i hate rnd_

:cl: Frozenguy5
del: Tesla Revolver has been removed from RnD weapon designs.
/:cl: