### PR TITLE
Adds a hecksuit to the bartender.

### DIFF
--- a/code/modules/jobs/job_types/cargo_service.dm
+++ b/code/modules/jobs/job_types/cargo_service.dm
@@ -162,7 +162,7 @@ Bartender
 	belt = /obj/item/device/pda/bar
 	ears = /obj/item/device/radio/headset/headset_srv
 	uniform = /obj/item/clothing/under/rank/bartender
-	suit = /obj/item/clothing/suit/armor/vest
+	suit = /obj/item/clothing/suit/space/hostile_environment
 	backpack_contents = list(/obj/item/storage/box/beanbag=1)
 	shoes = /obj/item/clothing/shoes/laceup
 


### PR DESCRIPTION
I believe this provides a much-needed buff to the weakest job on the station, the Bartender. The Bartender is already immensely restricted to his bar area, forced to serve drinks so he doesn't get in trouble with the HoP. With his brand new suit, he has a much better chance at surviving at almost everything.
@KorPhaeron even suggested this change and I agree with everything he said about the bartender being a really bad hero.

Take some time to consider this, Maintainers. It's actually a really needed change and this is coming from a veteran player!