### PR TITLE
Resolving tickets now informs the player.

### DIFF
--- a/code/modules/admin/verbs/adminhelp.dm
+++ b/code/modules/admin/verbs/adminhelp.dm
@@ -338,8 +338,7 @@ GLOBAL_DATUM_INIT(ahelp_tickets, /datum/admin_help_tickets, new)
 	if(!silent)
 		SSblackbox.inc("ahelp_resolve")
 		var/msg = "Ticket [TicketHref("#[id]")] resolved by [key_name]"
-		var/imsg = "<span class='adminhelp'>Your ticket has been resolved by an admin. The Adminhelp verb will be returned to you shortly.</span>"
-		to_chat(initiator, imsg)
+		to_chat(initiator, "<span class='adminhelp'>Your ticket has been resolved by an admin. The Adminhelp verb will be returned to you shortly.</span>")
 		message_admins(msg)
 		log_admin_private(msg)
 

--- a/code/modules/admin/verbs/adminhelp.dm
+++ b/code/modules/admin/verbs/adminhelp.dm
@@ -338,6 +338,8 @@ GLOBAL_DATUM_INIT(ahelp_tickets, /datum/admin_help_tickets, new)
 	if(!silent)
 		SSblackbox.inc("ahelp_resolve")
 		var/msg = "Ticket [TicketHref("#[id]")] resolved by [key_name]"
+		var/imsg = "<span class='adminhelp'>Your ticket has been resolved by an admin. The Adminhelp verb will be returned to you shortly.</span>"
+		to_chat(initiator, imsg)
 		message_admins(msg)
 		log_admin_private(msg)
 


### PR DESCRIPTION
:cl: Cobby
admin: Players will now be notified automatically when an admin resolves their ahelp.
/:cl:

Why: Informing players their ticket was at least ~~handled in some way~~ looked at is always good!

This only works when the other admins also get a notification the ticket has been resolved. Dunno if that matters or not.