### PR TITLE
Fixes Wood Being Invisible.

### DIFF
--- a/code/game/objects/items/stacks/sheets/sheet_types.dm
+++ b/code/game/objects/items/stacks/sheets/sheet_types.dm
@@ -159,7 +159,7 @@ GLOBAL_LIST_INIT(wood_recipes, list ( \
 	desc = "One can only guess that this is a bunch of wood."
 	singular_name = "wood plank"
 	icon_state = "sheet-wood"
-	icon = 'icons/obj/items_and_weapons.dmi'
+	icon = 'icons/obj/stack_objects.dmi'
 	origin_tech = "materials=1;biotech=1"
 	sheettype = "wood"
 	armor = list(melee = 0, bullet = 0, laser = 0, energy = 0, bomb = 0, bio = 0, rad = 0, fire = 50, acid = 0)

--- a/code/game/objects/items/storage/internal.dm
+++ b/code/game/objects/items/storage/internal.dm
@@ -42,14 +42,7 @@
 	priority = FALSE
 
 /obj/item/storage/internal/pocket/shoes
-	can_hold = list(
-		/obj/item/kitchen/knife, /obj/item/switchblade, /obj/item/pen,
-		/obj/item/scalpel, /obj/item/reagent_containers/syringe, /obj/item/dnainjector,
-		/obj/item/reagent_containers/hypospray/medipen, /obj/item/reagent_containers/dropper,
-		/obj/item/implanter, /obj/item/screwdriver, /obj/item/weldingtool/mini,
-		/obj/item/device/firing_pin
-		)
-	//can hold both regular pens and energy daggers. made for your every-day tactical curators/murderers.
+	max_w_class = WEIGHT_CLASS_SMALL
 	priority = FALSE
 	quickdraw = TRUE
 	silent = TRUE

--- a/code/game/objects/items/storage/internal.dm
+++ b/code/game/objects/items/storage/internal.dm
@@ -42,7 +42,14 @@
 	priority = FALSE
 
 /obj/item/storage/internal/pocket/shoes
-	max_w_class = WEIGHT_CLASS_SMALL
+	can_hold = list(
+		/obj/item/kitchen/knife, /obj/item/switchblade, /obj/item/pen,
+		/obj/item/scalpel, /obj/item/reagent_containers/syringe, /obj/item/dnainjector,
+		/obj/item/reagent_containers/hypospray/medipen, /obj/item/reagent_containers/dropper,
+		/obj/item/implanter, /obj/item/screwdriver, /obj/item/weldingtool/mini,
+		/obj/item/device/firing_pin
+		)
+	//can hold both regular pens and energy daggers. made for your every-day tactical curators/murderers.
 	priority = FALSE
 	quickdraw = TRUE
 	silent = TRUE


### PR DESCRIPTION
:cl:
fix: Wood is no longer invisible
/:cl:

[why]: # Wood was invisible since someone somehow fucked up the Icon for wood. No clue how that happened.

See: #31361 and #31360