### PR TITLE
Adds navigation consoles to boxstation and metastation white ships.

### DIFF
--- a/_maps/map_files/BoxStation/BoxStation.dmm
+++ b/_maps/map_files/BoxStation/BoxStation.dmm
@@ -2281,7 +2281,7 @@
 	name = "Emergency Shuttle Airlock"
 	},
 /obj/docking_port/mobile/emergency{
-	name = "Box emergency shuttle";
+	name = "Box emergency shuttle"
 	},
 /obj/docking_port/stationary{
 	dir = 4;
@@ -64022,6 +64022,10 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plating,
 /area/maintenance/department/medical/morgue)
+"cTW" = (
+/obj/machinery/computer/camera_advanced/shuttle_docker/whiteship,
+/turf/open/floor/mineral/titanium,
+/area/shuttle/abandoned)
 
 (1,1,1) = {"
 aaa
@@ -75982,7 +75986,7 @@ aaa
 cyc
 cyy
 cyc
-czy
+cTW
 cyO
 cyi
 cyi
@@ -105020,7 +105024,7 @@ bfS
 biE
 bkf
 bfS
-cTP
+cTO
 bmZ
 bpL
 bre
@@ -105277,7 +105281,7 @@ bfS
 biD
 bke
 bfS
-cTQ
+cTO
 bmZ
 bpK
 brd
@@ -105534,7 +105538,7 @@ bfS
 bfS
 bfS
 bfS
-cTR
+cTO
 bmZ
 bon
 bon
@@ -105790,13 +105794,13 @@ cTJ
 cHD
 bgo
 cTK
-cTN
+cTK
 blq
 cTS
-cTT
+cTK
 bpQ
-cTU
-cTV
+cTK
+cTJ
 btm
 buy
 bvz

--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -79816,7 +79816,6 @@
 /area/shuttle/abandoned)
 "cWT" = (
 /obj/structure/table,
-/obj/item/device/camera,
 /obj/effect/decal/cleanable/dirt{
 	desc = "A thin layer of dust coating the floor.";
 	name = "dust"
@@ -79824,6 +79823,8 @@
 /obj/structure/light_construct{
 	dir = 1
 	},
+/obj/item/folder/blue,
+/obj/item/pen,
 /turf/open/floor/mineral/titanium,
 /area/shuttle/abandoned)
 "cWU" = (
@@ -79832,6 +79833,8 @@
 	desc = "A thin layer of dust coating the floor.";
 	name = "dust"
 	},
+/obj/structure/table,
+/obj/item/device/camera,
 /turf/open/floor/mineral/titanium,
 /area/shuttle/abandoned)
 "cWV" = (
@@ -80229,13 +80232,12 @@
 /turf/open/floor/mineral/titanium/blue,
 /area/shuttle/abandoned)
 "cXH" = (
-/obj/structure/table,
 /obj/effect/decal/cleanable/dirt{
 	desc = "A thin layer of dust coating the floor.";
 	name = "dust"
 	},
-/obj/item/device/megaphone,
 /obj/structure/light_construct,
+/obj/machinery/computer/camera_advanced/shuttle_docker/whiteship,
 /turf/open/floor/mineral/titanium,
 /area/shuttle/abandoned)
 "cXI" = (
@@ -90386,6 +90388,38 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
+"dDN" = (
+/obj/effect/decal/cleanable/dirt{
+	desc = "A thin layer of dust coating the floor.";
+	name = "dust"
+	},
+/obj/effect/decal/cleanable/dirt{
+	desc = "A thin layer of dust coating the floor.";
+	name = "dust"
+	},
+/obj/structure/chair/office/light{
+	dir = 1
+	},
+/turf/open/floor/mineral/titanium/blue,
+/area/shuttle/abandoned)
+"dDO" = (
+/obj/effect/decal/cleanable/blood/old,
+/obj/effect/decal/cleanable/dirt{
+	desc = "A thin layer of dust coating the floor.";
+	name = "dust"
+	},
+/obj/structure/chair/office/light,
+/turf/open/floor/mineral/titanium/blue,
+/area/shuttle/abandoned)
+"dDP" = (
+/obj/effect/decal/cleanable/dirt{
+	desc = "A thin layer of dust coating the floor.";
+	name = "dust"
+	},
+/obj/structure/table,
+/obj/item/device/megaphone,
+/turf/open/floor/mineral/titanium,
+/area/shuttle/abandoned)
 
 (1,1,1) = {"
 aaa
@@ -101583,10 +101617,10 @@ cWt
 cWE
 cVF
 cWU
-cXe
-cWo
-cXB
 cXa
+cWo
+cXa
+dDP
 cVF
 cJI
 cYp
@@ -101840,9 +101874,9 @@ cVG
 cVF
 cVF
 cWT
-cVY
+dDN
 cWo
-cWR
+dDO
 cXH
 cVF
 cVF

--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -80237,7 +80237,10 @@
 	name = "dust"
 	},
 /obj/structure/light_construct,
-/obj/machinery/computer/camera_advanced/shuttle_docker/whiteship,
+/obj/machinery/computer/camera_advanced/shuttle_docker/whiteship{
+	x_offset = -3;
+	y_offset = -7
+	},
 /turf/open/floor/mineral/titanium,
 /area/shuttle/abandoned)
 "cXI" = (

--- a/_maps/shuttles/whiteship_box.dmm
+++ b/_maps/shuttles/whiteship_box.dmm
@@ -373,6 +373,10 @@
 	},
 /turf/open/floor/plating,
 /area/shuttle/abandoned)
+"bu" = (
+/obj/machinery/computer/camera_advanced/shuttle_docker/whiteship,
+/turf/open/floor/mineral/titanium,
+/area/shuttle/abandoned)
 
 (1,1,1) = {"
 aa
@@ -1148,7 +1152,7 @@ aa
 aC
 ax
 aC
-bb
+bu
 aJ
 aj
 aj

--- a/_maps/shuttles/whiteship_meta.dmm
+++ b/_maps/shuttles/whiteship_meta.dmm
@@ -722,11 +722,12 @@
 	desc = "A thin layer of dust coating the floor.";
 	name = "dust"
 	},
+/obj/structure/table,
+/obj/item/device/camera,
 /turf/open/floor/mineral/titanium,
 /area/shuttle/abandoned)
 "bs" = (
 /obj/structure/table,
-/obj/item/device/camera,
 /obj/effect/decal/cleanable/dirt{
 	desc = "A thin layer of dust coating the floor.";
 	name = "dust"
@@ -734,6 +735,8 @@
 /obj/structure/light_construct{
 	dir = 1
 	},
+/obj/item/folder/blue,
+/obj/item/pen,
 /turf/open/floor/mineral/titanium,
 /area/shuttle/abandoned)
 "bt" = (
@@ -1162,13 +1165,15 @@
 /turf/open/floor/mineral/titanium,
 /area/shuttle/abandoned)
 "cg" = (
-/obj/structure/table,
 /obj/effect/decal/cleanable/dirt{
 	desc = "A thin layer of dust coating the floor.";
 	name = "dust"
 	},
-/obj/item/device/megaphone,
 /obj/structure/light_construct,
+/obj/machinery/computer/camera_advanced/shuttle_docker/whiteship{
+	x_offset = -3;
+	y_offset = -7
+	},
 /turf/open/floor/mineral/titanium,
 /area/shuttle/abandoned)
 "ch" = (
@@ -1765,6 +1770,38 @@
 	},
 /turf/open/floor/mineral/titanium,
 /area/shuttle/abandoned)
+"dk" = (
+/obj/effect/decal/cleanable/dirt{
+	desc = "A thin layer of dust coating the floor.";
+	name = "dust"
+	},
+/obj/effect/decal/cleanable/dirt{
+	desc = "A thin layer of dust coating the floor.";
+	name = "dust"
+	},
+/obj/structure/chair/office/light{
+	dir = 1
+	},
+/turf/open/floor/mineral/titanium/blue,
+/area/shuttle/abandoned)
+"dl" = (
+/obj/effect/decal/cleanable/blood/old,
+/obj/effect/decal/cleanable/dirt{
+	desc = "A thin layer of dust coating the floor.";
+	name = "dust"
+	},
+/obj/structure/chair/office/light,
+/turf/open/floor/mineral/titanium/blue,
+/area/shuttle/abandoned)
+"dm" = (
+/obj/effect/decal/cleanable/dirt{
+	desc = "A thin layer of dust coating the floor.";
+	name = "dust"
+	},
+/obj/structure/table,
+/obj/item/device/megaphone,
+/turf/open/floor/mineral/titanium,
+/area/shuttle/abandoned)
 
 (1,1,1) = {"
 aa
@@ -2130,10 +2167,10 @@ aR
 bc
 ac
 br
-bC
-aL
-bZ
 bx
+aL
+bx
+dm
 ac
 cA
 cN
@@ -2147,9 +2184,9 @@ ae
 ac
 ac
 bs
-ax
+dk
 aL
-bp
+dl
 cg
 ac
 ac

--- a/code/modules/shuttle/white_ship.dm
+++ b/code/modules/shuttle/white_ship.dm
@@ -3,4 +3,17 @@
 	desc = "Used to control the White Ship."
 	circuit = /obj/item/circuitboard/computer/white_ship
 	shuttleId = "whiteship"
-	possible_destinations = "whiteship_away;whiteship_home;whiteship_z4;whiteship_lavaland"
+	possible_destinations = "whiteship_away;whiteship_home;whiteship_z4;whiteship_lavaland;whiteship_custom"
+
+/obj/machinery/computer/camera_advanced/shuttle_docker/whiteship
+	name = "White Ship Navigation Computer"
+	desc = "Used to designate a precise transit location for the White Ship."
+	shuttleId = "whiteship"
+	station_lock_override = TRUE
+	shuttlePortId = "whiteship_custom"
+	shuttlePortName = "Custom Location"
+	jumpto_ports = list("whiteship_away" = 1, "whiteship_home" = 1, "whiteship_z4" = 1)
+	view_range = 20
+	x_offset = -6
+	y_offset = -10
+


### PR DESCRIPTION
This lets them have custom locations created and placed for them, wherever you want on the station, the derelict, and where the white ship spawns (it's possible for the white ship and derelict to spawn on the same z level so sometimes your options will be reduced, sadly).

I refrained from giving it a view of lavaland because you wouldn't be able to actually customize your landing location there and it would just give you huge amount of meson vision sight which isn't great.

Also didn't do this for delta, omega, or pubby because the first two don't even have a white ship, while the last one's white ship is this tardis lookin' circular pod with no real room for a navigation console.

:cl: WJohnston
add: Boxstation and Metastation's white ships now have navigation computers, letting you move them around in the station, deep space, and derelict z levels.
/:cl:

Thank you, coiax. These things are really, really cool! I'm sure players will greatly enjoy messing with these.
