### PR TITLE
High pop reduced MC processing mode.

### DIFF
--- a/code/__DEFINES/configuration.dm
+++ b/code/__DEFINES/configuration.dm
@@ -2,6 +2,7 @@
 #define CONFIG_DEF(X) /datum/config_entry/##X { resident_file = CURRENT_RESIDENT_FILE }; /datum/config_entry/##X
 #define CONFIG_GET(X) global.config.Get(/datum/config_entry/##X)
 #define CONFIG_SET(X, Y) global.config.Set(/datum/config_entry/##X, ##Y)
+#define CONFIG_TWEAK(X) /datum/config_entry/##X
 
 #define CONFIG_MAPS_FILE "maps.txt"
 

--- a/code/controllers/configuration/entries/config.dm
+++ b/code/controllers/configuration/entries/config.dm
@@ -349,3 +349,26 @@ CONFIG_DEF(number/error_msg_delay)	// How long to wait between messaging admins 
 CONFIG_DEF(flag/irc_announce_new_game)
 
 CONFIG_DEF(flag/debug_admin_hrefs)
+
+
+CONFIG_DEF(number/mc_tick_rate/base_mc_tick_rate)
+	integer = FALSE
+	value = 1
+
+CONFIG_DEF(number/mc_tick_rate/high_pop_mc_tick_rate)
+	integer = FALSE
+	value = 1.1
+
+CONFIG_DEF(number/mc_tick_rate/high_pop_mc_mode_amount)
+	value = 65
+
+CONFIG_DEF(number/mc_tick_rate/disable_high_pop_mc_mode_amount)
+	value = 60
+
+CONFIG_TWEAK(number/mc_tick_rate)
+	abstract_type = /datum/config_entry/number/mc_tick_rate
+
+CONFIG_TWEAK(number/mc_tick_rate/ValidateAndSet(str_val))
+	. = ..()
+	if (. && Master)
+		Master.UpdateTickRate()

--- a/code/controllers/configuration/entries/config.dm
+++ b/code/controllers/configuration/entries/config.dm
@@ -370,5 +370,5 @@ CONFIG_TWEAK(number/mc_tick_rate)
 
 CONFIG_TWEAK(number/mc_tick_rate/ValidateAndSet(str_val))
 	. = ..()
-	if (. && Master)
+	if (.)
 		Master.UpdateTickRate()

--- a/code/controllers/master.dm
+++ b/code/controllers/master.dm
@@ -573,3 +573,13 @@ GLOBAL_REAL(Master, /datum/controller/master) = new
 	for(var/S in subsystems)
 		var/datum/controller/subsystem/SS = S
 		SS.StopLoadingMap()
+
+
+/datum/controller/master/proc/UpdateTickRate()
+	if (!processing)
+		return
+	var/client_count = length(GLOB.clients)
+	if (client_count < CONFIG_GET(number/mc_tick_rate/disable_high_pop_mc_mode_amount))
+		processing = CONFIG_GET(number/mc_tick_rate/base_mc_tick_rate)
+	else if (client_count > CONFIG_GET(number/mc_tick_rate/high_pop_mc_mode_amount))
+		processing = CONFIG_GET(number/mc_tick_rate/high_pop_mc_tick_rate)

--- a/code/modules/client/client_procs.dm
+++ b/code/modules/client/client_procs.dm
@@ -350,6 +350,8 @@ GLOBAL_LIST(external_rsc_urls)
 		if (menuitem)
 			menuitem.Load_checked(src)
 
+	Master.UpdateTickRate()
+
 //////////////
 //DISCONNECT//
 //////////////
@@ -386,6 +388,7 @@ GLOBAL_LIST(external_rsc_urls)
 	if(movingmob != null)
 		movingmob.client_mobs_in_contents -= mob
 		UNSETEMPTY(movingmob.client_mobs_in_contents)
+	Master.UpdateTickRate()
 	return ..()
 
 /client/Destroy()

--- a/config/config.txt
+++ b/config/config.txt
@@ -236,7 +236,7 @@ TICK_LIMIT_MC_INIT 500
 ##	This also controls the client network update rate, as well as the default client fps
 TICKLAG 0.5
 
-##Can also be set as per-second value, the follow value is identical to the above.
+##Can also be set as per-second value, the following value is identical to the above.
 #FPS 20
 
 ## Comment this out to disable automuting

--- a/config/config.txt
+++ b/config/config.txt
@@ -232,8 +232,12 @@ ALLOW_HOLIDAYS
 ##This is currently a testing optimized setting. A good value for production would be 98.
 TICK_LIMIT_MC_INIT 500
 
-##Defines the ticklag for the world.  0.9 is the normal one, 0.5 is smoother.
+##Defines the ticklag for the world. Ticklag is the amount of time between game ticks (aka byond ticks) (in 1/10ths of a second).
+##	This also controls the client network update rate, as well as the default client fps
 TICKLAG 0.5
+
+##Can also be set as per-second value, the follow value is identical to the above.
+#FPS 20
 
 ## Comment this out to disable automuting
 #AUTOMUTE_ON
@@ -361,3 +365,23 @@ MINUTE_TOPIC_LIMIT 100
 
 ## Allow admin hrefs that don't use the new token system, will eventually be removed
 DEBUG_ADMIN_HREFS
+
+###Master Controller High Pop Mode###
+
+##The Master Controller(MC) is the primary system controlling timed tasks and events in SS13 (lobby timer, game checks, lighting updates, atmos, etc)
+##Default base MC tick rate (1 = process every "byond tick" (see: tick_lag/fps config settings), 2 = process every 2 byond ticks, etc)
+##	Setting this to 0 will prevent the Master Controller from ticking
+BASE_MC_TICK_RATE 1
+
+##High population MC tick rate 
+##	Byond rounds timer values UP, but the tick rate is modified with heuristics during lag spites so setting this to something like 2
+##	will make it run every 2 byond ticks, but will also double the effect of anti-lag heuristics. You can instead set it to something like
+##	1.1 to make it run every 2 byond ticks, but only increase the effect of anti-lag heuristics by 10%. or 1.5 for 50%.
+##	(As an aside, you could in theory also reduce the effect of anti-lag heuristics in the base tick rate by setting it to something like 0.5)
+HIGH_POP_MC_TICK_RATE 1.1
+
+##Engage high pop mode if player count raises above this (Player in this context means any connected user. Lobby, ghost or in-game all count)
+HIGH_POP_MC_MODE_AMOUNT 65
+
+##Disengage high pop mode if player count drops below this
+DISABLE_HIGH_POP_MC_MODE_AMOUNT 60


### PR DESCRIPTION
The logic behind this is that at higher populations, byond ends up needing to do more at the end of the tick to update clients, that the mc and traditional sleep timers end up fighting for a very small amount of time left.
Increasing the MC's sleep time means its wakes up sooner in the tick. So it has more time to do things, even if they don't happen as often, and leaving every other tick free allows for sleeping CHECK_TICK task to wake up without finding the MC left them very little time to do things.

Admins have been regularly manually doing this by varediting the processing variable to 2, that i figured we should automate it.

for /tg/, i plan on raising the player count a bit, but they make decent defaults for the avg server.

:cl:
tweak: The MC will now reduce tick rate during high populations to keep it from fighting with byond for processing time.
config: Added config options to control MC tick rate
admin: Admins can no longer manually control the mc's tick rate by editing the MC's processing value, instead you will have to edit the config datum's values for high/low pop tick rates.
/:cl: