### PR TITLE
Moves assert_gas() into a define it should always have been, speeding up atmos slightly

### DIFF
--- a/code/__DEFINES/atmospherics.dm
+++ b/code/__DEFINES/atmospherics.dm
@@ -176,3 +176,11 @@
 #define LAVALAND_DEFAULT_ATMOS "o2=14;n2=23;TEMP=300"
 
 #define THERMAL_ENERGY(gas) (gas.temperature * gas.heat_capacity())
+
+//ASSERT_GAS(gas_mixture,gas_id) - used to guarantee that the gas list for this id exists in gas_mixture.
+//Must be used before adding to a gas. May be used before reading from a gas.
+#define ASSERT_GAS(gas_mixture,gas_id) if (!gas_mixture.gases[gas_id]) { GASLIST(gas_id, gas_mixture.gases[gas_id]) };
+
+#define GASLIST(id, out_list)\
+	var/list/tmp_gaslist = GLOB.gaslist_cache[id];\
+	out_list = tmp_gaslist.Copy();

--- a/code/__DEFINES/atmospherics.dm
+++ b/code/__DEFINES/atmospherics.dm
@@ -177,10 +177,10 @@
 
 #define THERMAL_ENERGY(gas) (gas.temperature * gas.heat_capacity())
 
-//ASSERT_GAS(gas_mixture,gas_id) - used to guarantee that the gas list for this id exists in gas_mixture.
-//Must be used before adding to a gas. May be used before reading from a gas.
-#define ASSERT_GAS(gas_mixture,gas_id) if (!gas_mixture.gases[gas_id]) { GASLIST(gas_id, gas_mixture.gases[gas_id]) };
-
 #define GASLIST(id, out_list)\
 	var/list/tmp_gaslist = GLOB.gaslist_cache[id];\
 	out_list = tmp_gaslist.Copy();
+
+//ASSERT_GAS(gas_mixture,gas_id) - used to guarantee that the gas list for this id exists in gas_mixture.
+//Must be used before adding to a gas. May be used before reading from a gas.
+#define ASSERT_GAS(gas_mixture,gas_id) if (!gas_mixture.gases[gas_id]) { GASLIST(gas_id, gas_mixture.gases[gas_id]) };

--- a/code/__DEFINES/atmospherics.dm
+++ b/code/__DEFINES/atmospherics.dm
@@ -177,10 +177,10 @@
 
 #define THERMAL_ENERGY(gas) (gas.temperature * gas.heat_capacity())
 
-#define GASLIST(id, out_list)\
-	var/list/tmp_gaslist = GLOB.gaslist_cache[id];\
-	out_list = tmp_gaslist.Copy();
+#define ADD_GAS(gas_id, out_list)\
+	var/list/tmp_gaslist = GLOB.gaslist_cache[gas_id];\
+	out_list[gas_id] = tmp_gaslist.Copy();
 
-//ASSERT_GAS(gas_mixture,gas_id) - used to guarantee that the gas list for this id exists in gas_mixture.
+//ASSERT_GAS(gas_id, gas_mixture) - used to guarantee that the gas list for this id exists in gas_mixture.gases.
 //Must be used before adding to a gas. May be used before reading from a gas.
-#define ASSERT_GAS(gas_mixture,gas_id) if (!gas_mixture.gases[gas_id]) { GASLIST(gas_id, gas_mixture.gases[gas_id]) };
+#define ASSERT_GAS(gas_id, gas_mixture) if (!gas_mixture.gases[gas_id]) { ADD_GAS(gas_id, gas_mixture.gases) };

--- a/code/game/mecha/equipment/tools/other_tools.dm
+++ b/code/game/mecha/equipment/tools/other_tools.dm
@@ -430,7 +430,7 @@
 	if(!istype(T))
 		return
 	var/datum/gas_mixture/GM = new
-	GM.assert_gas("plasma")
+	ASSERT_GAS(GM,"plasma")
 	if(prob(10))
 		GM.gases["plasma"][MOLES] += 100
 		GM.temperature = 1500+T0C //should be enough to start a fire

--- a/code/game/mecha/equipment/tools/other_tools.dm
+++ b/code/game/mecha/equipment/tools/other_tools.dm
@@ -430,7 +430,7 @@
 	if(!istype(T))
 		return
 	var/datum/gas_mixture/GM = new
-	ASSERT_GAS(GM,"plasma")
+	ASSERT_GAS("plasma", GM)
 	if(prob(10))
 		GM.gases["plasma"][MOLES] += 100
 		GM.temperature = 1500+T0C //should be enough to start a fire

--- a/code/game/objects/effects/effect_system/effects_smoke.dm
+++ b/code/game/objects/effects/effect_system/effects_smoke.dm
@@ -169,7 +169,7 @@
 				qdel(H)
 				var/list/G_gases = G.gases
 				if(G_gases["plasma"])
-					G.assert_gas("n2")
+					ASSERT_GAS(G,"n2")
 					G_gases["n2"][MOLES] += (G_gases["plasma"][MOLES])
 					G_gases["plasma"][MOLES] = 0
 					G.garbage_collect()

--- a/code/game/objects/effects/effect_system/effects_smoke.dm
+++ b/code/game/objects/effects/effect_system/effects_smoke.dm
@@ -169,7 +169,7 @@
 				qdel(H)
 				var/list/G_gases = G.gases
 				if(G_gases["plasma"])
-					ASSERT_GAS(G,"n2")
+					ASSERT_GAS("n2", G)
 					G_gases["n2"][MOLES] += (G_gases["plasma"][MOLES])
 					G_gases["plasma"][MOLES] = 0
 					G.garbage_collect()

--- a/code/game/objects/items/tanks/jetpack.dm
+++ b/code/game/objects/items/tanks/jetpack.dm
@@ -17,7 +17,7 @@
 /obj/item/tank/jetpack/New()
 	..()
 	if(gas_type)
-		ASSERT_GAS(air_contents,gas_type)
+		ASSERT_GAS(gas_type,air_contents)
 		air_contents.gases[gas_type][MOLES] = (6 * ONE_ATMOSPHERE) * volume / (R_IDEAL_GAS_EQUATION * T20C)
 
 	ion_trail = new

--- a/code/game/objects/items/tanks/jetpack.dm
+++ b/code/game/objects/items/tanks/jetpack.dm
@@ -17,7 +17,7 @@
 /obj/item/tank/jetpack/New()
 	..()
 	if(gas_type)
-		air_contents.assert_gas(gas_type)
+		ASSERT_GAS(air_contents,gas_type)
 		air_contents.gases[gas_type][MOLES] = (6 * ONE_ATMOSPHERE) * volume / (R_IDEAL_GAS_EQUATION * T20C)
 
 	ion_trail = new
@@ -193,7 +193,7 @@
 
 //Return a jetpack that the mob can use
 //Back worn jetpacks, hardsuit internal packs, and so on.
-//Used in Process_Spacemove() and wherever you want to check for/get a jetpack	
+//Used in Process_Spacemove() and wherever you want to check for/get a jetpack
 
 /mob/proc/get_jetpack()
 	return

--- a/code/game/objects/items/tanks/tank_types.dm
+++ b/code/game/objects/items/tanks/tank_types.dm
@@ -21,7 +21,7 @@
 
 /obj/item/tank/internals/oxygen/New()
 	..()
-	air_contents.assert_gas("o2")
+	ASSERT_GAS(air_contents, "o2")
 	air_contents.gases["o2"][MOLES] = (6*ONE_ATMOSPHERE)*volume/(R_IDEAL_GAS_EQUATION*T20C)
 	return
 
@@ -87,7 +87,7 @@
 
 /obj/item/tank/internals/plasma/New()
 	..()
-	air_contents.assert_gas("plasma")
+	ASSERT_GAS(air_contents,"plasma")
 	air_contents.gases["plasma"][MOLES] = (3*ONE_ATMOSPHERE)*volume/(R_IDEAL_GAS_EQUATION*T20C)
 	return
 
@@ -106,7 +106,7 @@
 
 /obj/item/tank/internals/plasma/full/New()
 	..()
-	air_contents.assert_gas("plasma")
+	ASSERT_GAS(air_contents,"plasma")
 	air_contents.gases["plasma"][MOLES] = (10*ONE_ATMOSPHERE)*volume/(R_IDEAL_GAS_EQUATION*T20C)
 	return
 
@@ -125,13 +125,12 @@
 
 /obj/item/tank/internals/plasmaman/New()
 	..()
-	air_contents.assert_gas("plasma")
+	ASSERT_GAS(air_contents,"plasma")
 	air_contents.gases["plasma"][MOLES] = (3*ONE_ATMOSPHERE)*volume/(R_IDEAL_GAS_EQUATION*T20C)
 	return
 
 /obj/item/tank/internals/plasmaman/full/New()
-	..()
-	air_contents.assert_gas("plasma")
+	..() // Plasma asserted in parent
 	air_contents.gases["plasma"][MOLES] = (10*ONE_ATMOSPHERE)*volume/(R_IDEAL_GAS_EQUATION*T20C)
 	return
 
@@ -145,8 +144,7 @@
 	w_class = WEIGHT_CLASS_SMALL //thanks i forgot this
 
 /obj/item/tank/internals/plasmaman/belt/full/New()
-	..()
-	air_contents.assert_gas("plasma")
+	..() // Plasma asserted in parent
 	air_contents.gases["plasma"][MOLES] = (10*ONE_ATMOSPHERE)*volume/(R_IDEAL_GAS_EQUATION*T20C)
 	return
 
@@ -169,7 +167,7 @@
 
 /obj/item/tank/internals/emergency_oxygen/New()
 	..()
-	air_contents.assert_gas("o2")
+	ASSERT_GAS(air_contents,"o2")
 	air_contents.gases["o2"][MOLES] = (3*ONE_ATMOSPHERE)*volume/(R_IDEAL_GAS_EQUATION*T20C)
 	return
 

--- a/code/game/objects/items/tanks/tank_types.dm
+++ b/code/game/objects/items/tanks/tank_types.dm
@@ -21,7 +21,7 @@
 
 /obj/item/tank/internals/oxygen/New()
 	..()
-	ASSERT_GAS(air_contents, "o2")
+	ASSERT_GAS("o2", air_contents)
 	air_contents.gases["o2"][MOLES] = (6*ONE_ATMOSPHERE)*volume/(R_IDEAL_GAS_EQUATION*T20C)
 	return
 
@@ -87,7 +87,7 @@
 
 /obj/item/tank/internals/plasma/New()
 	..()
-	ASSERT_GAS(air_contents,"plasma")
+	ASSERT_GAS("plasma", air_contents)
 	air_contents.gases["plasma"][MOLES] = (3*ONE_ATMOSPHERE)*volume/(R_IDEAL_GAS_EQUATION*T20C)
 	return
 
@@ -105,8 +105,7 @@
 		return ..()
 
 /obj/item/tank/internals/plasma/full/New()
-	..()
-	ASSERT_GAS(air_contents,"plasma")
+	..() // Plasma asserted in parent
 	air_contents.gases["plasma"][MOLES] = (10*ONE_ATMOSPHERE)*volume/(R_IDEAL_GAS_EQUATION*T20C)
 	return
 
@@ -125,7 +124,7 @@
 
 /obj/item/tank/internals/plasmaman/New()
 	..()
-	ASSERT_GAS(air_contents,"plasma")
+	ASSERT_GAS("plasma", air_contents)
 	air_contents.gases["plasma"][MOLES] = (3*ONE_ATMOSPHERE)*volume/(R_IDEAL_GAS_EQUATION*T20C)
 	return
 
@@ -167,7 +166,7 @@
 
 /obj/item/tank/internals/emergency_oxygen/New()
 	..()
-	ASSERT_GAS(air_contents,"o2")
+	ASSERT_GAS("o2", air_contents)
 	air_contents.gases["o2"][MOLES] = (3*ONE_ATMOSPHERE)*volume/(R_IDEAL_GAS_EQUATION*T20C)
 	return
 

--- a/code/game/turfs/turf.dm
+++ b/code/game/turfs/turf.dm
@@ -290,7 +290,7 @@
 			continue
 		var/list/S_gases = S.air.gases
 		for(var/id in S_gases)
-			ASSERT_GAS(total, id)
+			ASSERT_GAS(id, total)
 			total_gases[id][MOLES] += S_gases[id][MOLES]
 		total.temperature += S.air.temperature
 

--- a/code/game/turfs/turf.dm
+++ b/code/game/turfs/turf.dm
@@ -290,7 +290,7 @@
 			continue
 		var/list/S_gases = S.air.gases
 		for(var/id in S_gases)
-			total.assert_gas(id)
+			ASSERT_GAS(total, id)
 			total_gases[id][MOLES] += S_gases[id][MOLES]
 		total.temperature += S.air.temperature
 

--- a/code/modules/admin/verbs/debug.dm
+++ b/code/modules/admin/verbs/debug.dm
@@ -716,7 +716,7 @@ GLOBAL_PROTECT(LastAdminCalledProc)
 		if(Rad.anchored)
 			if(!Rad.loaded_tank)
 				var/obj/item/tank/internals/plasma/Plasma = new/obj/item/tank/internals/plasma(Rad)
-				ASSERT_GAS(Plasma.air_contents, "plasma")
+				ASSERT_GAS("plasma", Plasma.air_contents)
 				Plasma.air_contents.gases["plasma"][MOLES] = 70
 				Rad.drainratio = 0
 				Rad.loaded_tank = Plasma

--- a/code/modules/admin/verbs/debug.dm
+++ b/code/modules/admin/verbs/debug.dm
@@ -716,7 +716,7 @@ GLOBAL_PROTECT(LastAdminCalledProc)
 		if(Rad.anchored)
 			if(!Rad.loaded_tank)
 				var/obj/item/tank/internals/plasma/Plasma = new/obj/item/tank/internals/plasma(Rad)
-				Plasma.air_contents.assert_gas("plasma")
+				ASSERT_GAS(Plasma.air_contents, "plasma")
 				Plasma.air_contents.gases["plasma"][MOLES] = 70
 				Rad.drainratio = 0
 				Rad.loaded_tank = Plasma

--- a/code/modules/atmospherics/gasmixtures/gas_mixture.dm
+++ b/code/modules/atmospherics/gasmixtures/gas_mixture.dm
@@ -21,10 +21,6 @@ GLOBAL_LIST_INIT(gaslist_cache, init_gaslist_cache())
 		cached_gas[ARCHIVE] = 0
 		cached_gas[GAS_META] = GLOB.meta_gas_info[id]
 
-#define GASLIST(id, out_list)\
-	var/list/tmp_gaslist = GLOB.gaslist_cache[id];\
-	out_list = tmp_gaslist.Copy();
-
 /datum/gas_mixture
 	var/list/gases
 	var/temperature //kelvins
@@ -43,18 +39,10 @@ GLOBAL_LIST_INIT(gaslist_cache, init_gaslist_cache())
 
 //listmos procs
 
-	//assert_gas(gas_id) - used to guarantee that the gas list for this id exists.
-	//Must be used before adding to a gas. May be used before reading from a gas.
-/datum/gas_mixture/proc/assert_gas(gas_id)
-	var/cached_gases = gases
-	if(cached_gases[gas_id])
-		return
-	GASLIST(gas_id, cached_gases[gas_id])
-
-	//assert_gases(args) - shorthand for calling assert_gas() once for each gas type.
+	//assert_gases(args) - shorthand for calling ASSERT_GAS() once for each gas type.
 /datum/gas_mixture/proc/assert_gases()
 	for(var/id in args)
-		assert_gas(id)
+		ASSERT_GAS(src,id)
 
 	//add_gas(gas_id) - similar to assert_gas(), but does not check for an existing
 		//gas list for this id. This can clobber existing gases.
@@ -80,9 +68,9 @@ GLOBAL_LIST_INIT(gaslist_cache, init_gaslist_cache())
 			cached_gases -= id
 
 	//PV = nRT
+
 /datum/gas_mixture/proc/heat_capacity() //joules per kelvin
 	var/list/cached_gases = gases
-	. = 0
 	for(var/id in cached_gases)
 		var/gas_data = cached_gases[id]
 		. += gas_data[MOLES] * gas_data[GAS_META][META_GAS_SPECIFIC_HEAT]
@@ -195,7 +183,7 @@ GLOBAL_LIST_INIT(gaslist_cache, init_gaslist_cache())
 	var/list/giver_gases = giver.gases
 	//gas transfer
 	for(var/giver_id in giver_gases)
-		assert_gas(giver_id)
+		ASSERT_GAS(src, giver_id)
 		cached_gases[giver_id][MOLES] += giver_gases[giver_id][MOLES]
 
 	return 1
@@ -250,13 +238,14 @@ GLOBAL_LIST_INIT(gaslist_cache, init_gaslist_cache())
 
 	return copy
 
+
 /datum/gas_mixture/copy_from(datum/gas_mixture/sample)
 	var/list/cached_gases = gases //accessing datum vars is slower than proc vars
 	var/list/sample_gases = sample.gases
 
 	temperature = sample.temperature
 	for(var/id in sample_gases)
-		assert_gas(id)
+		ASSERT_GAS(src,id)
 		cached_gases[id][MOLES] = sample_gases[id][MOLES]
 
 	//remove all gases not in the sample

--- a/code/modules/atmospherics/gasmixtures/gas_mixture.dm
+++ b/code/modules/atmospherics/gasmixtures/gas_mixture.dm
@@ -71,6 +71,7 @@ GLOBAL_LIST_INIT(gaslist_cache, init_gaslist_cache())
 
 /datum/gas_mixture/proc/heat_capacity() //joules per kelvin
 	var/list/cached_gases = gases
+	. = 0
 	for(var/id in cached_gases)
 		var/gas_data = cached_gases[id]
 		. += gas_data[MOLES] * gas_data[GAS_META][META_GAS_SPECIFIC_HEAT]

--- a/code/modules/atmospherics/gasmixtures/immutable_mixtures.dm
+++ b/code/modules/atmospherics/gasmixtures/immutable_mixtures.dm
@@ -69,7 +69,7 @@
 
 /datum/gas_mixture/immutable/cloner/garbage_collect()
 	..()
-	add_gas("n2")
+	ADD_GAS("n2", gases)
 	gases["n2"][MOLES] = MOLES_O2STANDARD + MOLES_N2STANDARD
 
 /datum/gas_mixture/immutable/cloner/heat_capacity()

--- a/code/modules/atmospherics/gasmixtures/reactions.dm
+++ b/code/modules/atmospherics/gasmixtures/reactions.dm
@@ -57,7 +57,7 @@
 	cached_gases["co2"][MOLES] -= reaction_rate
 	cached_gases["agent_b"][MOLES] -= reaction_rate*0.05
 
-	air.assert_gas("o2") //only need to assert oxygen, as this reaction doesn't occur without the other gases existing
+	ASSERT_GAS(air, "o2") //only need to assert oxygen, as this reaction doesn't occur without the other gases existing
 	cached_gases["o2"][MOLES] += reaction_rate
 
 	air.temperature -= (reaction_rate*20000)/air.heat_capacity()
@@ -126,7 +126,7 @@
 		if(burned_fuel)
 			energy_released += FIRE_CARBON_ENERGY_RELEASED * burned_fuel
 
-			air.assert_gas("co2")
+			ASSERT_GAS(air, "co2")
 			cached_gases["co2"][MOLES] += burned_fuel
 
 			cached_results[id] += burned_fuel
@@ -142,14 +142,14 @@
 		else
 			temperature_scale = (temperature-PLASMA_MINIMUM_BURN_TEMPERATURE)/(PLASMA_UPPER_TEMPERATURE-PLASMA_MINIMUM_BURN_TEMPERATURE)
 		if(temperature_scale > 0)
-			air.assert_gas("o2")
+			ASSERT_GAS(air, "o2")
 			oxygen_burn_rate = OXYGEN_BURN_RATE_BASE - temperature_scale
 			if(cached_gases["o2"][MOLES] > cached_gases["plasma"][MOLES]*PLASMA_OXYGEN_FULLBURN)
 				plasma_burn_rate = (cached_gases["plasma"][MOLES]*temperature_scale)/PLASMA_BURN_RATE_DELTA
 			else
 				plasma_burn_rate = (temperature_scale*(cached_gases["o2"][MOLES]/PLASMA_OXYGEN_FULLBURN))/PLASMA_BURN_RATE_DELTA
 			if(plasma_burn_rate > MINIMUM_HEAT_CAPACITY)
-				air.assert_gas("co2")
+				ASSERT_GAS(air, "co2")
 				cached_gases["plasma"][MOLES] = QUANTIZE(cached_gases["plasma"][MOLES] - plasma_burn_rate)
 				cached_gases["o2"][MOLES] = QUANTIZE(cached_gases["o2"][MOLES] - (plasma_burn_rate * oxygen_burn_rate))
 				cached_gases["co2"][MOLES] += plasma_burn_rate

--- a/code/modules/atmospherics/gasmixtures/reactions.dm
+++ b/code/modules/atmospherics/gasmixtures/reactions.dm
@@ -57,7 +57,7 @@
 	cached_gases["co2"][MOLES] -= reaction_rate
 	cached_gases["agent_b"][MOLES] -= reaction_rate*0.05
 
-	ASSERT_GAS(air, "o2") //only need to assert oxygen, as this reaction doesn't occur without the other gases existing
+	ASSERT_GAS("o2", air) //only need to assert oxygen, as this reaction doesn't occur without the other gases existing
 	cached_gases["o2"][MOLES] += reaction_rate
 
 	air.temperature -= (reaction_rate*20000)/air.heat_capacity()
@@ -126,7 +126,7 @@
 		if(burned_fuel)
 			energy_released += FIRE_CARBON_ENERGY_RELEASED * burned_fuel
 
-			ASSERT_GAS(air, "co2")
+			ASSERT_GAS("co2", air)
 			cached_gases["co2"][MOLES] += burned_fuel
 
 			cached_results[id] += burned_fuel
@@ -142,14 +142,14 @@
 		else
 			temperature_scale = (temperature-PLASMA_MINIMUM_BURN_TEMPERATURE)/(PLASMA_UPPER_TEMPERATURE-PLASMA_MINIMUM_BURN_TEMPERATURE)
 		if(temperature_scale > 0)
-			ASSERT_GAS(air, "o2")
+			ASSERT_GAS("o2", air)
 			oxygen_burn_rate = OXYGEN_BURN_RATE_BASE - temperature_scale
 			if(cached_gases["o2"][MOLES] > cached_gases["plasma"][MOLES]*PLASMA_OXYGEN_FULLBURN)
 				plasma_burn_rate = (cached_gases["plasma"][MOLES]*temperature_scale)/PLASMA_BURN_RATE_DELTA
 			else
 				plasma_burn_rate = (temperature_scale*(cached_gases["o2"][MOLES]/PLASMA_OXYGEN_FULLBURN))/PLASMA_BURN_RATE_DELTA
 			if(plasma_burn_rate > MINIMUM_HEAT_CAPACITY)
-				ASSERT_GAS(air, "co2")
+				ASSERT_GAS("co2", air)
 				cached_gases["plasma"][MOLES] = QUANTIZE(cached_gases["plasma"][MOLES] - plasma_burn_rate)
 				cached_gases["o2"][MOLES] = QUANTIZE(cached_gases["o2"][MOLES] - (plasma_burn_rate * oxygen_burn_rate))
 				cached_gases["co2"][MOLES] += plasma_burn_rate

--- a/code/modules/atmospherics/machinery/components/trinary_devices/filter.dm
+++ b/code/modules/atmospherics/machinery/components/trinary_devices/filter.dm
@@ -96,7 +96,7 @@
 			var/datum/gas_mixture/filtered_out = new
 
 			filtered_out.temperature = removed.temperature
-			filtered_out.assert_gas(filter_type)
+			ASSERT_GAS(filtered_out, filter_type)
 			filtered_out.gases[filter_type][MOLES] = removed.gases[filter_type][MOLES]
 
 			removed.gases[filter_type][MOLES] = 0
@@ -166,4 +166,3 @@
 	if(. && on && is_operational())
 		to_chat(user, "<span class='warning'>You cannot unwrench [src], turn it off first!</span>")
 		return FALSE
-

--- a/code/modules/atmospherics/machinery/components/trinary_devices/filter.dm
+++ b/code/modules/atmospherics/machinery/components/trinary_devices/filter.dm
@@ -96,7 +96,7 @@
 			var/datum/gas_mixture/filtered_out = new
 
 			filtered_out.temperature = removed.temperature
-			ASSERT_GAS(filtered_out, filter_type)
+			ASSERT_GAS(filter_type, filtered_out)
 			filtered_out.gases[filter_type][MOLES] = removed.gases[filter_type][MOLES]
 
 			removed.gases[filter_type][MOLES] = 0

--- a/code/modules/atmospherics/machinery/components/unary_devices/oxygen_generator.dm
+++ b/code/modules/atmospherics/machinery/components/unary_devices/oxygen_generator.dm
@@ -47,7 +47,7 @@
 		var/added_oxygen = oxygen_content - total_moles
 
 		air_contents.temperature = (current_heat_capacity*air_contents.temperature + 20*added_oxygen*T0C)/(current_heat_capacity+20*added_oxygen)
-		air_contents.assert_gas("o2")
+		ASSERT_GAS(air_contents, "o2")
 		air_contents.gases["o2"][MOLES] += added_oxygen
 
 		update_parents()

--- a/code/modules/atmospherics/machinery/components/unary_devices/oxygen_generator.dm
+++ b/code/modules/atmospherics/machinery/components/unary_devices/oxygen_generator.dm
@@ -47,7 +47,7 @@
 		var/added_oxygen = oxygen_content - total_moles
 
 		air_contents.temperature = (current_heat_capacity*air_contents.temperature + 20*added_oxygen*T0C)/(current_heat_capacity+20*added_oxygen)
-		ASSERT_GAS(air_contents, "o2")
+		ASSERT_GAS("o2", air_contents)
 		air_contents.gases["o2"][MOLES] += added_oxygen
 
 		update_parents()

--- a/code/modules/atmospherics/machinery/components/unary_devices/tank.dm
+++ b/code/modules/atmospherics/machinery/components/unary_devices/tank.dm
@@ -16,7 +16,7 @@
 	air_contents.volume = volume
 	air_contents.temperature = T20C
 	if(gas_type)
-		ASSERT_GAS(air_contents, gas_type)
+		ASSERT_GAS(gas_type, air_contents)
 		air_contents.gases[gas_type][MOLES] = AIR_CONTENTS
 		name = "[name] ([air_contents.gases[gas_type][GAS_META][META_GAS_NAME]])"
 

--- a/code/modules/atmospherics/machinery/components/unary_devices/tank.dm
+++ b/code/modules/atmospherics/machinery/components/unary_devices/tank.dm
@@ -16,7 +16,7 @@
 	air_contents.volume = volume
 	air_contents.temperature = T20C
 	if(gas_type)
-		air_contents.assert_gas(gas_type)
+		ASSERT_GAS(air_contents, gas_type)
 		air_contents.gases[gas_type][MOLES] = AIR_CONTENTS
 		name = "[name] ([air_contents.gases[gas_type][GAS_META][META_GAS_NAME]])"
 

--- a/code/modules/atmospherics/machinery/components/unary_devices/vent_scrubber.dm
+++ b/code/modules/atmospherics/machinery/components/unary_devices/vent_scrubber.dm
@@ -196,37 +196,37 @@
 			filtered_out.temperature = removed.temperature
 
 			if(scrub_Toxins && removed_gases["plasma"])
-				filtered_out.add_gas("plasma")
+				ADD_GAS("plasma", filtered_out.gases)
 				filtered_gases["plasma"][MOLES] = removed_gases["plasma"][MOLES]
 				removed_gases["plasma"][MOLES] = 0
 
 			if(scrub_CO2 && removed_gases["co2"])
-				filtered_out.add_gas("co2")
+				ADD_GAS("co2", filtered_out.gases)
 				filtered_gases["co2"][MOLES] = removed_gases["co2"][MOLES]
 				removed_gases["co2"][MOLES] = 0
 
 			if(removed_gases["agent_b"])
-				filtered_out.add_gas("agent_b")
+				ADD_GAS("agent_b", filtered_out.gases)
 				filtered_gases["agent_b"][MOLES] = removed_gases["agent_b"][MOLES]
 				removed_gases["agent_b"][MOLES] = 0
 
 			if(scrub_N2O && removed_gases["n2o"])
-				filtered_out.add_gas("n2o")
+				ADD_GAS("n2o", filtered_out.gases)
 				filtered_gases["n2o"][MOLES] = removed_gases["n2o"][MOLES]
 				removed_gases["n2o"][MOLES] = 0
 
 			if(scrub_BZ && removed_gases["bz"])
-				filtered_out.add_gas("bz")
+				ADD_GAS("bz", filtered_out.gases)
 				filtered_gases["bz"][MOLES] = removed_gases["bz"][MOLES]
 				removed_gases["bz"][MOLES] = 0
 
 			if(scrub_Freon && removed_gases["freon"])
-				filtered_out.add_gas("freon")
+				ADD_GAS("freon", filtered_out.gases)
 				filtered_gases["freon"][MOLES] = removed_gases["freon"][MOLES]
 				removed_gases["freon"][MOLES] = 0
 
 			if(scrub_WaterVapor && removed_gases["water_vapor"])
-				filtered_out.add_gas("water_vapor")
+				ADD_GAS("water_vapor", filtered_out.gases)
 				filtered_gases["water_vapor"][MOLES] = removed_gases["water_vapor"][MOLES]
 				removed_gases["water_vapor"][MOLES] = 0
 

--- a/code/modules/atmospherics/machinery/other/miner.dm
+++ b/code/modules/atmospherics/machinery/other/miner.dm
@@ -132,7 +132,7 @@
 	if(!isopenturf(O))
 		return FALSE
 	var/datum/gas_mixture/merger = new
-	merger.assert_gas(spawn_id)
+	ASSERT_GAS(merger, spawn_id)
 	merger.gases[spawn_id][MOLES] = (spawn_mol)
 	merger.temperature = spawn_temp
 	O.assume_air(merger)

--- a/code/modules/atmospherics/machinery/other/miner.dm
+++ b/code/modules/atmospherics/machinery/other/miner.dm
@@ -132,7 +132,7 @@
 	if(!isopenturf(O))
 		return FALSE
 	var/datum/gas_mixture/merger = new
-	ASSERT_GAS(merger, spawn_id)
+	ASSERT_GAS(spawn_id, merger)
 	merger.gases[spawn_id][MOLES] = (spawn_mol)
 	merger.temperature = spawn_temp
 	O.assume_air(merger)

--- a/code/modules/atmospherics/machinery/portable/canister.dm
+++ b/code/modules/atmospherics/machinery/portable/canister.dm
@@ -174,7 +174,7 @@
 
 /obj/machinery/portable_atmospherics/canister/proc/create_gas()
 	if(gas_type)
-		air_contents.add_gas(gas_type)
+		ADD_GAS(gas_type, air_contents.gases)
 		if(starter_temp)
 			air_contents.temperature = starter_temp
 		air_contents.gases[gas_type][MOLES] = (maximum_pressure * filled) * air_contents.volume / (R_IDEAL_GAS_EQUATION * air_contents.temperature)

--- a/code/modules/atmospherics/machinery/portable/scrubber.dm
+++ b/code/modules/atmospherics/machinery/portable/scrubber.dm
@@ -45,7 +45,7 @@
 
 	filtered.temperature = filtering.temperature
 	for(var/gas in filtering.gases & scrubbing)
-		filtered.add_gas(gas)
+		ADD_GAS(gas, filtered.gases)
 		filtered.gases[gas][MOLES] = filtering.gases[gas][MOLES] // Shuffle the "bad" gasses to the filtered mixture.
 		filtering.gases[gas][MOLES] = 0
 	filtering.garbage_collect() // Now that the gasses are set to 0, clean up the mixture.


### PR DESCRIPTION
Cherrypicking some "safe" stuff from my more comprehensive perf patch, which might not see the light of day due to game design changes it would impose

This speeds up /datum/gas_mixture/merge by 27.4% and /datum/gas_mixture/copy_from by 18.6% through deep byond voodoo, as measured in total time per call. The speedups in these gas mixture procs operations will trickle down to a lot of places, such as LINDA procs.

e: Changes in latest commit:
* Renamed GASLIST into ADD_GAS
* Reordered ASSERT_GAS arguments around
* Replaced all instances of add_gas with the define
* Threw out the useless add_gas proc
* Removed one instance of manual duplication of ASSERT_GAS with the real deal

This was because the only thing add_gas did was run the GASLIST macro.

|Proc Name|Self CPU|Total CPU|Real Time|Calls|
|-----------|---------|----------|----------|----|
|/datum/gas_mixture/proc/oldmerge|0.687|0.880|0.848|259635|
|/datum/gas_mixture/proc/newmerge|0.568|0.639|0.675|259718|
|/datum/gas_mixture/proc/oldcopy_from|0.569|0.672|0.710|241830|
|/datum/gas_mixture/proc/newcopy_from|0.539|0.546|0.572|241635|

[Changelogs]: 

:cl: Naksu
fix: Tweaks to atmos performance
/:cl:

[why]: 
More speed = more better
