### PR TITLE
Overloaded leg actuators now consume at least 100 power per step

### DIFF
--- a/code/game/mecha/mecha.dm
+++ b/code/game/mecha/mecha.dm
@@ -30,6 +30,7 @@
 	var/dir_in = 2//What direction will the mech face when entered/powered on? Defaults to South.
 	var/step_energy_drain = 10
 	var/melee_energy_drain = 15
+	var/overload_step_energy_drain_min = 100
 	max_integrity = 300 //max_integrity is base health
 	var/deflect_chance = 10 //chance to deflect the incoming projectiles, hits, or lesser the effect of ex_act.
 	armor = list(melee = 20, bullet = 10, laser = 0, energy = 0, bomb = 0, bio = 0, rad = 0, fire = 100, acid = 100)

--- a/code/game/mecha/mecha_actions.dm
+++ b/code/game/mecha/mecha_actions.dm
@@ -203,7 +203,7 @@
 		chassis.leg_overload_mode = 1
 		chassis.bumpsmash = 1
 		chassis.step_in = min(1, round(chassis.step_in/2))
-		chassis.step_energy_drain = chassis.step_energy_drain*chassis.leg_overload_coeff
+		chassis.step_energy_drain = max(100,chassis.step_energy_drain*chassis.leg_overload_coeff)
 		chassis.occupant_message("<span class='danger'>You enable leg actuators overload.</span>")
 	else
 		chassis.leg_overload_mode = 0

--- a/code/game/mecha/mecha_actions.dm
+++ b/code/game/mecha/mecha_actions.dm
@@ -203,7 +203,7 @@
 		chassis.leg_overload_mode = 1
 		chassis.bumpsmash = 1
 		chassis.step_in = min(1, round(chassis.step_in/2))
-		chassis.step_energy_drain = max(100,chassis.step_energy_drain*chassis.leg_overload_coeff)
+		chassis.step_energy_drain = max(chassis.overload_step_energy_drain_min,chassis.step_energy_drain*chassis.leg_overload_coeff)
 		chassis.occupant_message("<span class='danger'>You enable leg actuators overload.</span>")
 	else
 		chassis.leg_overload_mode = 0


### PR DESCRIPTION
:cl: Y0SH1_M4S73R
balance: Gygax overdrive consumes at least 100 power per step
/:cl: 

Fixes #31385 

With a tier 3 scanning module, overdrive consumes 500 power per step. This makes a tier 4 scanning module 5 times more efficient than a Tier 3 module, but not allowing for infinite overloading as described in #31385. Admins can tweak the minimum power drain on the fly by editing the "overload_step_power_drain_min" var in the mech object.

