### PR TITLE
Fix: Prevents PANDEMIC Neutering Lockout

### DIFF
--- a/code/datums/diseases/advance/advance.dm
+++ b/code/datums/diseases/advance/advance.dm
@@ -291,9 +291,10 @@
 	if(!id)
 		var/list/L = list()
 		for(var/datum/symptom/S in symptoms)
-			L += S.id
 			if(S.neutered)
-				L += "N"
+				L += "[S.id]N"
+			else
+				L += S.id
 		L = sortList(L) // Sort the list so it doesn't matter which order the symptoms are in.
 		var/result = jointext(L, ":")
 		id = result


### PR DESCRIPTION
:cl: Robustin
fix: Neutering a disease symptom now produces a unique ID that will ensure the PANDEMIC machine copies it properly. 
/:cl:

This took forever to figure out. PANDEMIC copies diseases based on their archived ID. Neutering a symptom added a "N" to the ID but only at the end. So a disease with symptoms 1,2,3,4,5 where 1-3-5 were neutered would give you an id of 1:2:3:4:5:N:N:N. 

Unfortunately that meant if you cooked up a disease with the same symptoms but 2-4-5 were neutered, it would produce an identical ID. When PANDEMIC would copy the disease it would "find" the 1-3-5 version and copy that instead. Adding N directly to the symptom's name ensures there are no false duplicate ID's. 