### PR TITLE
Gives ghosts direction is their meaningless existence

### DIFF
--- a/code/modules/shuttle/shuttle_rotate.dm
+++ b/code/modules/shuttle/shuttle_rotate.dm
@@ -1,5 +1,7 @@
 /*
 All shuttleRotate procs go here
+
+If ever any of these procs are useful for non-shuttles, rename it to proc/rotate and move it to be a generic atom proc
 */
 
 /************************************Base proc************************************/
@@ -33,6 +35,10 @@ All shuttleRotate procs go here
 //override to avoid rotating pixel_xy on mobs
 /mob/shuttleRotate(rotation)
 	setDir(angle2dir(rotation+dir2angle(dir)))
+
+/mob/dead/observer/shuttleRotate(rotation)
+	. = ..()
+	update_icon()
 
 /************************************Structure rotate procs************************************/
 


### PR DESCRIPTION
:cl: ninjanomnom
fix: Shuttles no longer rotate ghosts of players who prefer directionless sprites
/:cl:

fixes #19997