### PR TITLE
Shoes With Storage Now Do What Their Desc. Says They Do

### DIFF
--- a/code/game/objects/items/storage/internal.dm
+++ b/code/game/objects/items/storage/internal.dm
@@ -42,26 +42,15 @@
 	priority = FALSE
 
 /obj/item/storage/internal/pocket/shoes
-	can_hold = list(
-		/obj/item/kitchen/knife, /obj/item/switchblade, /obj/item/pen,
-		/obj/item/scalpel, /obj/item/reagent_containers/syringe, /obj/item/dnainjector,
-		/obj/item/reagent_containers/hypospray/medipen, /obj/item/reagent_containers/dropper,
-		/obj/item/implanter, /obj/item/screwdriver, /obj/item/weldingtool/mini,
-		/obj/item/device/firing_pin
-		)
-	//can hold both regular pens and energy daggers. made for your every-day tactical curators/murderers.
+	max_w_class = WEIGHT_CLASS_SMALL
 	priority = FALSE
 	quickdraw = TRUE
 	silent = TRUE
 
 
 /obj/item/storage/internal/pocket/shoes/clown
-	can_hold = list(
-		/obj/item/kitchen/knife, /obj/item/switchblade, /obj/item/pen,
-		/obj/item/scalpel, /obj/item/reagent_containers/syringe, /obj/item/dnainjector,
-		/obj/item/reagent_containers/hypospray/medipen, /obj/item/reagent_containers/dropper,
-		/obj/item/implanter, /obj/item/screwdriver, /obj/item/weldingtool/mini,
-		/obj/item/device/firing_pin, /obj/item/bikehorn)
+	max_w_class = WEIGHT_CLASS_SMALL
+
 
 /obj/item/storage/internal/pocket/small/detective
 	priority = TRUE // so the detectives would discover pockets in their hats


### PR DESCRIPTION
[Changelogs]: Shoes with storage now hold items small or smaller like they say they do.

:cl: Kerbin Fiber
tweak: Shoes like Jackboots now hold small or smaller items just like it says in their description
/:cl:

[why]: Many people have complained that their description says small and smaller, and yet it only holds a handful of items, also opens up new opportunities.
