### PR TITLE
Makes cameras work on shuttles

### DIFF
--- a/code/modules/mob/living/silicon/ai/freelook/chunk.dm
+++ b/code/modules/mob/living/silicon/ai/freelook/chunk.dm
@@ -14,7 +14,6 @@
 	var/list/seenby = list()
 	var/visible = FALSE
 	var/changed = 0
-	var/updating = 0
 	var/x = 0
 	var/y = 0
 	var/z = 0
@@ -28,7 +27,7 @@
 	eye.visibleCameraChunks += src
 	visible++
 	seenby += eye
-	if(changed && !updating)
+	if(changed)
 		update()
 
 // Remove an AI eye from the chunk, then update if changed.
@@ -54,11 +53,7 @@
 
 /datum/camerachunk/proc/hasChanged(update_now = 0)
 	if(visible || update_now)
-		if(!updating)
-			updating = 1
-			spawn(UPDATE_BUFFER) // Batch large changes, such as many doors opening or closing at once
-				update()
-				updating = 0
+		addtimer(CALLBACK(src, .proc/update), UPDATE_BUFFER, TIMER_UNIQUE)
 	else
 		changed = 1
 

--- a/code/modules/shuttle/on_move.dm
+++ b/code/modules/shuttle/on_move.dm
@@ -160,15 +160,11 @@ All ShuttleMove procs go here
 /obj/machinery/camera/beforeShuttleMove(turf/newT, rotation, move_mode)
 	. = ..()
 	GLOB.cameranet.removeCamera(src)
-	GLOB.cameranet.updateChunk()
 	. |= MOVE_CONTENTS
 
 /obj/machinery/camera/afterShuttleMove(list/movement_force, shuttle_dir, shuttle_preferred_direction, move_dir)
 	. = ..()
-	if(can_use())
-		GLOB.cameranet.addCamera(src)
-	var/datum/camerachunk/chunk = GLOB.cameranet.getCameraChunk(x, y, z)
-	chunk.hasChanged(TRUE)
+	GLOB.cameranet.addCamera(src)
 
 /obj/machinery/telecomms/afterShuttleMove(list/movement_force, shuttle_dir, shuttle_preferred_direction, move_dir)
 	. = ..()


### PR DESCRIPTION
:cl: ninjanomnom
fix: 2 Years later and cameras work on shuttles now, probably.
/:cl:

This also removes a spawn in camera code and replaces it with a unique timer.

(Really I was just cleaning code up and these lines started actually working from when I last attempted to fix this)

fixes #12170
fixes #18277