### PR TITLE
Buckled mobs rotation fix

### DIFF
--- a/code/modules/shuttle/shuttle_rotate.dm
+++ b/code/modules/shuttle/shuttle_rotate.dm
@@ -32,7 +32,8 @@ All shuttleRotate procs go here
 
 //override to avoid rotating pixel_xy on mobs
 /mob/shuttleRotate(rotation)
-	setDir(angle2dir(rotation+dir2angle(dir)))
+	if(!buckled)
+		setDir(angle2dir(rotation+dir2angle(dir)))
 
 /************************************Structure rotate procs************************************/
 


### PR DESCRIPTION
:cl: ninjanomnom
fix: Buckled mobs when on a rotating shuttle should now rotate correctly
/:cl: