### PR TITLE
Stops airlocks from getting harddeleted, also fixes an unrelated runtime

### DIFF
--- a/code/game/machinery/doors/airlock.dm
+++ b/code/game/machinery/doors/airlock.dm
@@ -235,6 +235,8 @@
 		for(var/obj/machinery/doorButtons/D in GLOB.machines)
 			D.removeMe(src)
 	qdel(note)
+	var/datum/atom_hud/data/diagnostic/diag_hud = GLOB.huds[DATA_HUD_DIAGNOSTIC]
+	diag_hud.remove_from_hud(src)
 	return ..()
 
 /obj/machinery/door/airlock/handle_atom_del(atom/A)

--- a/code/game/machinery/doors/door.dm
+++ b/code/game/machinery/doors/door.dm
@@ -179,7 +179,7 @@
 
 /obj/machinery/door/take_damage(damage_amount, damage_type = BRUTE, damage_flag = 0, sound_effect = 1, attack_dir)
 	. = ..()
-	if(. && obj_integrity > 0 && !QDELETED(src))
+	if(. && obj_integrity > 0)
 		if(damage_amount >= 10 && prob(30))
 			spark_system.start()
 

--- a/code/game/machinery/doors/door.dm
+++ b/code/game/machinery/doors/door.dm
@@ -179,7 +179,7 @@
 
 /obj/machinery/door/take_damage(damage_amount, damage_type = BRUTE, damage_flag = 0, sound_effect = 1, attack_dir)
 	. = ..()
-	if(. && obj_integrity > 0)
+	if(. && obj_integrity > 0 && !QDELETED(src))
 		if(damage_amount >= 10 && prob(30))
 			spark_system.start()
 

--- a/code/game/objects/obj_defense.dm
+++ b/code/game/objects/obj_defense.dm
@@ -52,10 +52,12 @@
 		return
 	..() //contents explosion
 	if(target == src)
+		obj_integrity = 0
 		qdel(src)
 		return
 	switch(severity)
 		if(1)
+			obj_integrity = 0
 			qdel(src)
 		if(2)
 			take_damage(rand(100, 250), BRUTE, "bomb", 0)


### PR DESCRIPTION
Doors would very often not get qdel'd properly, this *seems* to fix it but since reproducing the bug was never quite certain, I'm not absolutely sure I got it. I did destroy all the doors on the station without triggering a harddel on a door after this fix, where previously it would happen.

Also, destroying doors with a sniper rifle or anything that flat out destroys them good would runtime in doors.dm #L184.


[Changelogs]: 

:cl: Naksu
fix: Fixes to door/airlock deletion routines.
/:cl:

[why]: 
bugfix
