### PR TITLE
Internals set to 0 pressure will properly prevent breathing environment air

### DIFF
--- a/code/modules/mob/living/carbon/life.dm
+++ b/code/modules/mob/living/carbon/life.dm
@@ -72,7 +72,7 @@
 		//Breathe from internal
 		breath = get_breath_from_internal(BREATH_VOLUME)
 
-		if(!breath)
+		if(isnull(breath)) //in case of 0 pressure internals
 
 			if(isobj(loc)) //Breathe from loc as object
 				var/obj/loc_as_obj = loc
@@ -221,7 +221,9 @@
 			update_internals_hud_icon(0)
 		else
 			update_internals_hud_icon(1)
-			return internal.remove_air_volume(volume_needed)
+			. = internal.remove_air_volume(volume_needed)
+			if(!.)
+				return FALSE //to differentiate between no internals and active, but empty internals
 
 /mob/living/carbon/proc/handle_blood()
 	return


### PR DESCRIPTION
Fixes #12770

:cl: XDTM
fix: Internals now properly work if set to 0 pressure, and will prevent breathing gas from the external atmosphere.
/:cl:
