### PR TITLE
Prioritizes the PDA pen as a traitor uplink location when the pen is selected

### DIFF
--- a/code/datums/mind.dm
+++ b/code/datums/mind.dm
@@ -265,7 +265,12 @@
 	var/list/all_contents = traitor_mob.GetAllContents()
 	var/obj/item/device/pda/PDA = locate() in all_contents
 	var/obj/item/device/radio/R = locate() in all_contents
-	var/obj/item/pen/P = locate() in all_contents //including your PDA-pen!
+	var/obj/item/pen/P
+
+	if (PDA) // Prioritize PDA pen, otherwise the pocket protector pens will be chosen, which causes numerous ahelps about missing uplink
+		P = locate() in PDA.contents
+	if (!P) // If we couldn't find a pen in the PDA, or we didn't even have a PDA, do it the old way
+		P = locate() in all_contents
 
 	var/obj/item/uplink_loc
 

--- a/code/datums/mind.dm
+++ b/code/datums/mind.dm
@@ -268,7 +268,7 @@
 	var/obj/item/pen/P
 
 	if (PDA) // Prioritize PDA pen, otherwise the pocket protector pens will be chosen, which causes numerous ahelps about missing uplink
-		P = locate() in PDA.contents
+		P = locate() in PDA
 	if (!P) // If we couldn't find a pen in the PDA, or we didn't even have a PDA, do it the old way
 		P = locate() in all_contents
 


### PR DESCRIPTION
Fixes #31402 i think

> < Naksu> Daturix: could you confirm that the traitor panel says Uplink: . when the pocket protector thing happens
< Naksu> or is that a separate bug
< Daturix> Naksu yup


[Changelogs]:

:cl: Naksu
fix: Traitor pen uplinks now preferentially spawn in the PDA pen, and not in a pocket protector full of pens that no-one checks.
/:cl:

[why]:
Requested by Daturix on coderbus, also seems legit
