### PR TITLE
Fixes runtime with lavaland_equipment_pressure_check if air isn't initialized on a turf or whatever

### DIFF
--- a/code/__HELPERS/game.dm
+++ b/code/__HELPERS/game.dm
@@ -570,9 +570,12 @@
 	return hex2num(copytext(hexa, 6, 8))
 
 /proc/lavaland_equipment_pressure_check(turf/T)
+	. = FALSE
 	if(!istype(T))
 		return
 	var/datum/gas_mixture/environment = T.return_air()
+	if(!istype(environment))
+		return
 	var/pressure = environment.return_pressure()
 	if(pressure <= LAVALAND_EQUIPMENT_EFFECT_PRESSURE)
-		return TRUE
+		. = TRUE


### PR DESCRIPTION
`
[08:11:16] Runtime in game.dm, line 576: Cannot execute null.return pressure().
proc name: lavaland equipment pressure check (/proc/lavaland_equipment_pressure_check)
src: null
call stack:
lavaland equipment pressure check(the plating (41,32,5) (/turf/open/floor/plating))
the plasma blast (/obj/item/projectile/plasma): Initialize(1)
Atoms (/datum/controller/subsystem/atoms): InitAtom(the plasma blast (/obj/item/projectile/plasma), /list (/list))
the plasma blast (/obj/item/projectile/plasma): New(1)
the plasma blast (/obj/item/projectile/plasma): New(the energy weapon lens (/obj/item/ammo_casing/energy/plasma))
the energy weapon lens (/obj/item/ammo_casing/energy/plasma): New(the plasma cutter (/obj/item/gun/energy/plasmacutter))
the plasma cutter (/obj/item/gun/energy/plasmacutter): update ammo types()
the plasma cutter (/obj/item/gun/energy/plasmacutter): Initialize(1)
Atoms (/datum/controller/subsystem/atoms): InitAtom(the plasma cutter (/obj/item/gun/energy/plasmacutter), /list (/list))
Atoms (/datum/controller/subsystem/atoms): InitializeAtoms(null)
Atoms (/datum/controller/subsystem/atoms): Initialize(294741)
Master (/datum/controller/master): Initialize(10, 0)
`