### PR TITLE
Fixes cigarettes runtiming when preferences generation attempts to light them before initialization is done.

### DIFF
--- a/code/game/objects/items/cigs_lighters.dm
+++ b/code/game/objects/items/cigs_lighters.dm
@@ -155,7 +155,11 @@ CIGARETTE PACKETS ARE IN FANCY.DM
 
 
 /obj/item/clothing/mask/cigarette/proc/light(flavor_text = null)
-	if(lit || !initialized)
+	if(lit)
+		return
+	if(!initialized)
+		icon_state = icon_on
+		item_state = icon_on
 		return
 
 	lit = TRUE

--- a/code/game/objects/items/cigs_lighters.dm
+++ b/code/game/objects/items/cigs_lighters.dm
@@ -155,7 +155,7 @@ CIGARETTE PACKETS ARE IN FANCY.DM
 
 
 /obj/item/clothing/mask/cigarette/proc/light(flavor_text = null)
-	if(lit || QDELETED(src))	//Incase outfit datum tries to light us after the dummy we're on is recycled for other purposes.
+	if(lit || !initialized)
 		return
 
 	lit = TRUE

--- a/code/game/objects/items/cigs_lighters.dm
+++ b/code/game/objects/items/cigs_lighters.dm
@@ -155,7 +155,7 @@ CIGARETTE PACKETS ARE IN FANCY.DM
 
 
 /obj/item/clothing/mask/cigarette/proc/light(flavor_text = null)
-	if(lit)
+	if(lit || QDELETED(src))	//Incase outfit datum tries to light us after the dummy we're on is recycled for other purposes.
 		return
 
 	lit = TRUE


### PR DESCRIPTION

![image](https://user-images.githubusercontent.com/2003111/31315409-fa3be3ca-abcc-11e7-95a5-68378f9523dc.png)
