### PR TITLE
Fixes 9mm ammo appearing in traitortot surplus crates

### DIFF
--- a/code/modules/uplink/uplink_item.dm
+++ b/code/modules/uplink/uplink_item.dm
@@ -404,6 +404,7 @@ GLOBAL_LIST_EMPTY(uplink_items) // Global list so we only initialize this once.
 	desc = "An additional 15-round 9mm magazine, compatible with the Stetchkin APS pistol, found in the Spetsnaz Pyro bundle."
 	item = /obj/item/ammo_box/magazine/pistolm9mm
 	cost = 2
+	include_modes = list(/datum/game_mode/nuclear)
 
 /datum/uplink_item/ammo/bolt_action
 	name = "Surplus Rifle Clip"


### PR DESCRIPTION
Nuke ops had a bluespace network error and their supplies got send to station agents instead!

:cl: improvedname
fix: 9mm doesn't longer appear in traitor surplus crates
/:cl:

[why]: # (Please add a short description [two lines down] of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.)

Closes #31433