### PR TITLE
Fixes Teslas always doing the same movement pattern

### DIFF
--- a/code/modules/power/tesla/energy_ball.dm
+++ b/code/modules/power/tesla/energy_ball.dm
@@ -57,7 +57,7 @@
 		pixel_x = 0
 		pixel_y = 0
 
-		setDir(tesla_zap(src, 7, TESLA_DEFAULT_POWER, TRUE))
+		tesla_zap(src, 7, TESLA_DEFAULT_POWER, TRUE))
 
 		pixel_x = -32
 		pixel_y = -32
@@ -75,9 +75,9 @@
 
 /obj/singularity/energy_ball/proc/move_the_basket_ball(var/move_amount)
 	//we face the last thing we zapped, so this lets us favor that direction a bit
-	var/first_move = dir
+	var/move_bias = pick(GLOB.alldirs)
 	for(var/i in 0 to move_amount)
-		var/move_dir = pick(GLOB.alldirs + first_move) //give the first move direction a bit of favoring.
+		var/move_dir = pick(GLOB.alldirs + move_bias) //ensures large-ball teslas don't just sit around 
 		if(target && prob(60))
 			move_dir = get_dir(src,target)
 		var/turf/T = get_step(src, move_dir)

--- a/code/modules/power/tesla/energy_ball.dm
+++ b/code/modules/power/tesla/energy_ball.dm
@@ -57,7 +57,7 @@
 		pixel_x = 0
 		pixel_y = 0
 
-		tesla_zap(src, 7, TESLA_DEFAULT_POWER, TRUE))
+		tesla_zap(src, 7, TESLA_DEFAULT_POWER, TRUE)
 
 		pixel_x = -32
 		pixel_y = -32


### PR DESCRIPTION
Tesla movement is now independent of the last thing it zapped. It was never going to work since large-ball teslas (the only kind that exists now) would create a high likelihood that the Tesla would follow a fixed path based on the map. This meant that the tesla would always annihilate escape on Box but ended up ping ponging on AI sat until it flings another Z-level on meta.

:cl: Robustin
tweak: Tesla movement is now completely random.
/:cl:
