### PR TITLE
Kept the wrong dock on box

### DIFF
--- a/_maps/map_files/BoxStation/BoxStation.dmm
+++ b/_maps/map_files/BoxStation/BoxStation.dmm
@@ -58911,17 +58911,14 @@
 /turf/open/floor/plasteel/white,
 /area/science/xenobiology)
 "Qlj" = (
-/obj/docking_port/mobile{
-	dheight = 9;
-	dir = 2;
-	dwidth = 5;
-	height = 24;
-	id = "syndicate";
-	name = "syndicate infiltrator";
-	port_direction = 1;
-	roundstart_move = "syndicate_away";
-	width = 18
-	},
+/obj/docking_port/stationary{
+ 	dheight = 9;
+ 	dir = 2;
+ 	dwidth = 5;
+ 	height = 24;
+	id = "syndicate_nw";
+	name = "northwest of station";
+	turf_type = /turf/open/space;
 /turf/open/space/basic,
 /area/space)
 

--- a/_maps/map_files/BoxStation/BoxStation.dmm
+++ b/_maps/map_files/BoxStation/BoxStation.dmm
@@ -58918,7 +58918,8 @@
  	height = 24;
 	id = "syndicate_nw";
 	name = "northwest of station";
-	turf_type = /turf/open/space;
+	turf_type = /turf/open/space
+},
 /turf/open/space/basic,
 /area/space)
 


### PR DESCRIPTION
Fixed a conflict incorrectly in #31410 and kept the mobile dock instead of the stationary dock. This fixes that.
