### PR TITLE
Removes portable chem dispenser from xenobio

### DIFF
--- a/_maps/map_files/BoxStation/BoxStation.dmm
+++ b/_maps/map_files/BoxStation/BoxStation.dmm
@@ -40932,7 +40932,6 @@
 /area/science/xenobiology)
 "bPE" = (
 /obj/structure/table/reinforced,
-/obj/item/clothing/gloves/color/latex,
 /obj/item/device/slime_scanner,
 /obj/effect/turf_decal/stripes/line{
 	dir = 9
@@ -40961,7 +40960,6 @@
 /turf/open/floor/plasteel,
 /area/science/xenobiology)
 "bPH" = (
-/obj/machinery/chem_dispenser/constructable,
 /obj/machinery/requests_console{
 	department = "Science";
 	departmentType = 2;
@@ -40972,6 +40970,9 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
+/obj/structure/table/reinforced,
+/obj/item/clothing/gloves/color/latex,
+/obj/item/clothing/glasses/science,
 /turf/open/floor/plasteel,
 /area/science/xenobiology)
 "bPI" = (

--- a/_maps/map_files/Deltastation/DeltaStation2.dmm
+++ b/_maps/map_files/Deltastation/DeltaStation2.dmm
@@ -74818,8 +74818,8 @@
 /turf/open/floor/plasteel,
 /area/science/xenobiology)
 "cOM" = (
-/obj/machinery/chem_dispenser/constructable,
 /obj/effect/turf_decal/delivery,
+/obj/machinery/chem_master,
 /turf/open/floor/plasteel,
 /area/science/xenobiology)
 "cON" = (
@@ -145166,7 +145166,7 @@ ecI
 cJK
 cLq
 cNa
-cOL
+cYG
 cQH
 cRX
 cTK

--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -82390,13 +82390,6 @@
 /area/science/xenobiology)
 "dce" = (
 /obj/structure/table/glass,
-/obj/item/storage/box/beakers{
-	pixel_x = 2;
-	pixel_y = 7
-	},
-/obj/item/storage/box/syringes{
-	pixel_y = 5
-	},
 /obj/item/storage/box/monkeycubes{
 	pixel_x = 2;
 	pixel_y = -2
@@ -82753,8 +82746,15 @@
 	},
 /area/science/xenobiology)
 "dcL" = (
-/obj/machinery/chem_dispenser/constructable,
 /obj/machinery/light,
+/obj/structure/table/glass,
+/obj/item/storage/box/beakers{
+	pixel_x = 2;
+	pixel_y = 7
+	},
+/obj/item/storage/box/syringes{
+	pixel_y = 5
+	},
 /turf/open/floor/plasteel/whitepurple/side,
 /area/science/xenobiology)
 "dcM" = (


### PR DESCRIPTION
This PR removes the chem dispensers from xenobio in all maps.
We're supposed to encourage inter-departmental reliance, and cooperation + interaction with other people. Not just give everything to science so they can do everything on there own.

Adding these was powercreep at its finest.



Added some random tables and stuff in their place. Left the chemmasters as those make sense.