### PR TITLE
Tweaks syndicate infiltrator and box/meta whiteships.

### DIFF
--- a/_maps/map_files/BoxStation/BoxStation.dmm
+++ b/_maps/map_files/BoxStation/BoxStation.dmm
@@ -1,4 +1,4 @@
-//MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE 
+//MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
 "aaa" = (
 /turf/open/space/basic,
 /area/space)
@@ -54691,12 +54691,14 @@
 "cyd" = (
 /obj/machinery/door/airlock/titanium,
 /obj/docking_port/mobile{
+	callTime = 250;
 	dheight = 0;
 	dir = 2;
 	dwidth = 11;
 	height = 22;
 	id = "whiteship";
 	launch_status = 0;
+	movement_force = list("KNOCKDOWN" = 0, "THROW" = 0);
 	name = "NT Medical Ship";
 	port_direction = 8;
 	preferred_direction = 4;
@@ -58902,14 +58904,27 @@
 /area/science/xenobiology)
 "Qlj" = (
 /obj/docking_port/stationary{
- 	dheight = 9;
- 	dir = 2;
- 	dwidth = 5;
- 	height = 24;
+	 dheight = 9;
+	dir = 2;
+	dwidth = 5;
+	height = 24;
 	id = "syndicate_nw";
 	name = "northwest of station";
 	turf_type = /turf/open/space
-},
+	},
+/turf/open/space/basic,
+/area/space)
+"Qlk" = (
+/obj/docking_port/stationary{
+	dheight = 9;
+	dir = 2;
+	dwidth = 5;
+	height = 24;
+	id = "syndicate_nw";
+	name = "northwest of station";
+	turf_type = /turf/open/space;
+	width = 18
+	},
 /turf/open/space/basic,
 /area/space)
 
@@ -72577,7 +72592,7 @@ aaa
 aaa
 aaa
 aaa
-aaa
+Qlk
 aaa
 aaa
 aaa
@@ -73082,7 +73097,7 @@ aaa
 aaa
 aaa
 aaa
-Qlj
+aaa
 aaa
 aaa
 aaa

--- a/_maps/map_files/BoxStation/BoxStation.dmm
+++ b/_maps/map_files/BoxStation/BoxStation.dmm
@@ -58904,7 +58904,7 @@
 /area/science/xenobiology)
 "Qlj" = (
 /obj/docking_port/stationary{
-	 dheight = 9;
+	dheight = 9;
 	dir = 2;
 	dwidth = 5;
 	height = 24;

--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -1,4 +1,4 @@
-//MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE 
+//MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
 "aaa" = (
 /turf/open/space/basic,
 /area/space)
@@ -54639,12 +54639,14 @@
 /area/engine/atmos)
 "cbm" = (
 /obj/docking_port/mobile{
+	callTime = 250;
 	dheight = 0;
 	dir = 2;
 	dwidth = 11;
 	height = 15;
 	id = "whiteship";
 	launch_status = 0;
+	movement_force = list("KNOCKDOWN" = 0, "THROW" = 0);
 	name = "NT Recovery White-Ship";
 	port_direction = 8;
 	preferred_direction = 4;
@@ -95770,7 +95772,7 @@ aaa
 aaa
 aaa
 aaa
-EDa
+aaa
 aaa
 aaa
 aaa
@@ -96575,7 +96577,7 @@ aaa
 aaa
 aaa
 aaa
-aaa
+EDa
 aaa
 aaa
 aaa

--- a/_maps/map_files/generic/CentCom.dmm
+++ b/_maps/map_files/generic/CentCom.dmm
@@ -1,4 +1,4 @@
-//MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE 
+//MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
 "aa" = (
 /turf/open/space/basic,
 /area/space)
@@ -14091,11 +14091,10 @@
 	},
 /area/shuttle/syndicate/eva)
 "Tl" = (
+/obj/structure/grille,
 /obj/structure/window/plastitanium,
-/turf/open/floor/plasteel/vault{
-	dir = 5
-	},
-/area/shuttle/syndicate/eva)
+/turf/open/floor/plating,
+/area/shuttle/syndicate/medical)
 "Tm" = (
 /obj/machinery/status_display,
 /turf/closed/wall/mineral/plastitanium,
@@ -14494,6 +14493,16 @@
 	dir = 6
 	},
 /turf/closed/wall/mineral/plastitanium,
+/area/shuttle/syndicate/medical)
+"ZZ" = (
+/obj/structure/grille,
+/obj/structure/window/plastitanium,
+/turf/open/floor/plating,
+/area/shuttle/syndicate/medical)
+"OVERFLOW" = (
+/obj/structure/grille,
+/obj/structure/window/plastitanium,
+/turf/open/floor/plating,
 /area/shuttle/syndicate/medical)
 
 (1,1,1) = {"
@@ -28551,10 +28560,10 @@ Ou
 NJ
 Tl
 ZS
-QP
-QP
+Tl
+Tl
 pk
-Nc
+Tl
 XJ
 XJ
 Nk
@@ -28804,7 +28813,7 @@ XN
 Ru
 XN
 XN
-Ur
+ZZ
 Pt
 Pt
 Pt
@@ -28813,7 +28822,7 @@ RF
 NV
 RD
 TT
-XL
+Ur
 de
 Jn
 hq
@@ -29318,7 +29327,7 @@ Om
 TW
 Om
 Om
-Ur
+OVERFLOW
 Pt
 Pt
 Pt
@@ -29327,7 +29336,7 @@ WW
 NV
 RD
 TT
-XL
+Ur
 de
 Mz
 hq
@@ -29577,12 +29586,12 @@ Nk
 Wk
 Wk
 Qo
-Mk
+Tl
 Se
-Wd
-Wd
+Tl
+Tl
 ZM
-ZE
+Tl
 Jz
 Jz
 Nk

--- a/_maps/map_files/generic/CentCom.dmm
+++ b/_maps/map_files/generic/CentCom.dmm
@@ -13628,10 +13628,9 @@
 /turf/closed/wall/mineral/titanium/nodiagonal,
 /area/centcom/evac)
 "Mk" = (
+/obj/structure/grille,
 /obj/structure/window/plastitanium,
-/turf/open/floor/plasteel/vault{
-	dir = 5
-	},
+/turf/open/floor/plating,
 /area/shuttle/syndicate/airlock)
 "Mz" = (
 /obj/structure/shuttle/engine/propulsion/right,
@@ -13794,6 +13793,7 @@
 	},
 /area/shuttle/syndicate/eva)
 "Pd" = (
+/obj/structure/grille,
 /obj/structure/window/plastitanium,
 /obj/machinery/door/poddoor/shutters{
 	id = "syndieshutters";
@@ -13889,10 +13889,9 @@
 /turf/open/floor/holofloor,
 /area/holodeck/rec_center/school)
 "QP" = (
+/obj/structure/grille,
 /obj/structure/window/plastitanium,
-/turf/open/floor/plasteel/vault{
-	dir = 5
-	},
+/turf/open/floor/plating,
 /area/shuttle/syndicate/medical)
 "QT" = (
 /obj/effect/turf_decal/stripes/corner,
@@ -14091,10 +14090,9 @@
 	},
 /area/shuttle/syndicate/eva)
 "Tl" = (
+/obj/structure/grille,
 /obj/structure/window/plastitanium,
-/turf/open/floor/plasteel/vault{
-	dir = 5
-	},
+/turf/open/floor/plating,
 /area/shuttle/syndicate/eva)
 "Tm" = (
 /obj/machinery/status_display,
@@ -14250,10 +14248,9 @@
 /turf/open/floor/plasteel/vault,
 /area/shuttle/syndicate/medical)
 "Wd" = (
+/obj/structure/grille,
 /obj/structure/window/plastitanium,
-/turf/open/floor/plasteel/vault{
-	dir = 5
-	},
+/turf/open/floor/plating,
 /area/shuttle/syndicate/armory)
 "We" = (
 /obj/item/screwdriver{
@@ -14495,6 +14492,16 @@
 	},
 /turf/closed/wall/mineral/plastitanium,
 /area/shuttle/syndicate/medical)
+"ZZ" = (
+/obj/structure/grille,
+/obj/structure/window/plastitanium,
+/turf/open/floor/plating,
+/area/shuttle/syndicate/hallway)
+"OVERFLOW" = (
+/obj/structure/grille,
+/obj/structure/window/plastitanium,
+/turf/open/floor/plating,
+/area/shuttle/syndicate/hallway)
 
 (1,1,1) = {"
 aa
@@ -28554,7 +28561,7 @@ ZS
 QP
 QP
 pk
-Nc
+QP
 XJ
 XJ
 Nk
@@ -28804,7 +28811,7 @@ XN
 Ru
 XN
 XN
-Ur
+ZZ
 Pt
 Pt
 Pt
@@ -28813,7 +28820,7 @@ RF
 NV
 RD
 TT
-XL
+Ur
 de
 Jn
 hq
@@ -29318,7 +29325,7 @@ Om
 TW
 Om
 Om
-Ur
+OVERFLOW
 Pt
 Pt
 Pt
@@ -29327,7 +29334,7 @@ WW
 NV
 RD
 TT
-XL
+Ur
 de
 Mz
 hq
@@ -29582,7 +29589,7 @@ Se
 Wd
 Wd
 ZM
-ZE
+Wd
 Jz
 Jz
 Nk

--- a/_maps/map_files/generic/CentCom.dmm
+++ b/_maps/map_files/generic/CentCom.dmm
@@ -14091,10 +14091,11 @@
 	},
 /area/shuttle/syndicate/eva)
 "Tl" = (
-/obj/structure/grille,
 /obj/structure/window/plastitanium,
-/turf/open/floor/plating,
-/area/shuttle/syndicate/medical)
+/turf/open/floor/plasteel/vault{
+	dir = 5
+	},
+/area/shuttle/syndicate/eva)
 "Tm" = (
 /obj/machinery/status_display,
 /turf/closed/wall/mineral/plastitanium,
@@ -14493,16 +14494,6 @@
 	dir = 6
 	},
 /turf/closed/wall/mineral/plastitanium,
-/area/shuttle/syndicate/medical)
-"ZZ" = (
-/obj/structure/grille,
-/obj/structure/window/plastitanium,
-/turf/open/floor/plating,
-/area/shuttle/syndicate/medical)
-"OVERFLOW" = (
-/obj/structure/grille,
-/obj/structure/window/plastitanium,
-/turf/open/floor/plating,
 /area/shuttle/syndicate/medical)
 
 (1,1,1) = {"
@@ -28560,10 +28551,10 @@ Ou
 NJ
 Tl
 ZS
-Tl
-Tl
+QP
+QP
 pk
-Tl
+Nc
 XJ
 XJ
 Nk
@@ -28813,7 +28804,7 @@ XN
 Ru
 XN
 XN
-ZZ
+Ur
 Pt
 Pt
 Pt
@@ -28822,7 +28813,7 @@ RF
 NV
 RD
 TT
-Ur
+XL
 de
 Jn
 hq
@@ -29327,7 +29318,7 @@ Om
 TW
 Om
 Om
-OVERFLOW
+Ur
 Pt
 Pt
 Pt
@@ -29336,7 +29327,7 @@ WW
 NV
 RD
 TT
-Ur
+XL
 de
 Mz
 hq
@@ -29586,12 +29577,12 @@ Nk
 Wk
 Wk
 Qo
-Tl
+Mk
 Se
-Tl
-Tl
+Wd
+Wd
 ZM
-Tl
+ZE
 Jz
 Jz
 Nk

--- a/_maps/map_files/generic/CentCom.dmm
+++ b/_maps/map_files/generic/CentCom.dmm
@@ -13628,9 +13628,10 @@
 /turf/closed/wall/mineral/titanium/nodiagonal,
 /area/centcom/evac)
 "Mk" = (
-/obj/structure/grille,
 /obj/structure/window/plastitanium,
-/turf/open/floor/plating,
+/turf/open/floor/plasteel/vault{
+	dir = 5
+	},
 /area/shuttle/syndicate/airlock)
 "Mz" = (
 /obj/structure/shuttle/engine/propulsion/right,
@@ -13793,7 +13794,6 @@
 	},
 /area/shuttle/syndicate/eva)
 "Pd" = (
-/obj/structure/grille,
 /obj/structure/window/plastitanium,
 /obj/machinery/door/poddoor/shutters{
 	id = "syndieshutters";
@@ -13889,9 +13889,10 @@
 /turf/open/floor/holofloor,
 /area/holodeck/rec_center/school)
 "QP" = (
-/obj/structure/grille,
 /obj/structure/window/plastitanium,
-/turf/open/floor/plating,
+/turf/open/floor/plasteel/vault{
+	dir = 5
+	},
 /area/shuttle/syndicate/medical)
 "QT" = (
 /obj/effect/turf_decal/stripes/corner,
@@ -14090,9 +14091,10 @@
 	},
 /area/shuttle/syndicate/eva)
 "Tl" = (
-/obj/structure/grille,
 /obj/structure/window/plastitanium,
-/turf/open/floor/plating,
+/turf/open/floor/plasteel/vault{
+	dir = 5
+	},
 /area/shuttle/syndicate/eva)
 "Tm" = (
 /obj/machinery/status_display,
@@ -14248,9 +14250,10 @@
 /turf/open/floor/plasteel/vault,
 /area/shuttle/syndicate/medical)
 "Wd" = (
-/obj/structure/grille,
 /obj/structure/window/plastitanium,
-/turf/open/floor/plating,
+/turf/open/floor/plasteel/vault{
+	dir = 5
+	},
 /area/shuttle/syndicate/armory)
 "We" = (
 /obj/item/screwdriver{
@@ -14492,16 +14495,6 @@
 	},
 /turf/closed/wall/mineral/plastitanium,
 /area/shuttle/syndicate/medical)
-"ZZ" = (
-/obj/structure/grille,
-/obj/structure/window/plastitanium,
-/turf/open/floor/plating,
-/area/shuttle/syndicate/hallway)
-"OVERFLOW" = (
-/obj/structure/grille,
-/obj/structure/window/plastitanium,
-/turf/open/floor/plating,
-/area/shuttle/syndicate/hallway)
 
 (1,1,1) = {"
 aa
@@ -28561,7 +28554,7 @@ ZS
 QP
 QP
 pk
-QP
+Nc
 XJ
 XJ
 Nk
@@ -28811,7 +28804,7 @@ XN
 Ru
 XN
 XN
-ZZ
+Ur
 Pt
 Pt
 Pt
@@ -28820,7 +28813,7 @@ RF
 NV
 RD
 TT
-Ur
+XL
 de
 Jn
 hq
@@ -29325,7 +29318,7 @@ Om
 TW
 Om
 Om
-OVERFLOW
+Ur
 Pt
 Pt
 Pt
@@ -29334,7 +29327,7 @@ WW
 NV
 RD
 TT
-Ur
+XL
 de
 Mz
 hq
@@ -29589,7 +29582,7 @@ Se
 Wd
 Wd
 ZM
-Wd
+ZE
 Jz
 Jz
 Nk

--- a/_maps/map_files/generic/CentCom.dmm
+++ b/_maps/map_files/generic/CentCom.dmm
@@ -13628,10 +13628,9 @@
 /turf/closed/wall/mineral/titanium/nodiagonal,
 /area/centcom/evac)
 "Mk" = (
+/obj/structure/grille,
 /obj/structure/window/plastitanium,
-/turf/open/floor/plasteel/vault{
-	dir = 5
-	},
+/turf/open/floor/plating,
 /area/shuttle/syndicate/airlock)
 "Mz" = (
 /obj/structure/shuttle/engine/propulsion/right,
@@ -13799,6 +13798,7 @@
 	id = "syndieshutters";
 	name = "blast shutters"
 	},
+/obj/structure/grille,
 /turf/open/floor/plating,
 /area/shuttle/syndicate/bridge)
 "Pm" = (
@@ -13889,10 +13889,9 @@
 /turf/open/floor/holofloor,
 /area/holodeck/rec_center/school)
 "QP" = (
+/obj/structure/grille,
 /obj/structure/window/plastitanium,
-/turf/open/floor/plasteel/vault{
-	dir = 5
-	},
+/turf/open/floor/plating,
 /area/shuttle/syndicate/medical)
 "QT" = (
 /obj/effect/turf_decal/stripes/corner,
@@ -14091,10 +14090,9 @@
 	},
 /area/shuttle/syndicate/eva)
 "Tl" = (
+/obj/structure/grille,
 /obj/structure/window/plastitanium,
-/turf/open/floor/plasteel/vault{
-	dir = 5
-	},
+/turf/open/floor/plating,
 /area/shuttle/syndicate/eva)
 "Tm" = (
 /obj/machinery/status_display,
@@ -14250,10 +14248,9 @@
 /turf/open/floor/plasteel/vault,
 /area/shuttle/syndicate/medical)
 "Wd" = (
+/obj/structure/grille,
 /obj/structure/window/plastitanium,
-/turf/open/floor/plasteel/vault{
-	dir = 5
-	},
+/turf/open/floor/plating,
 /area/shuttle/syndicate/armory)
 "We" = (
 /obj/item/screwdriver{
@@ -14495,6 +14492,16 @@
 	},
 /turf/closed/wall/mineral/plastitanium,
 /area/shuttle/syndicate/medical)
+"ZZ" = (
+/obj/structure/grille,
+/obj/structure/window/plastitanium,
+/turf/open/floor/plating,
+/area/shuttle/syndicate/hallway)
+"OVERFLOW" = (
+/obj/structure/grille,
+/obj/structure/window/plastitanium,
+/turf/open/floor/plating,
+/area/shuttle/syndicate/hallway)
 
 (1,1,1) = {"
 aa
@@ -28554,7 +28561,7 @@ ZS
 QP
 QP
 pk
-Nc
+QP
 XJ
 XJ
 Nk
@@ -28804,7 +28811,7 @@ XN
 Ru
 XN
 XN
-Ur
+ZZ
 Pt
 Pt
 Pt
@@ -28813,7 +28820,7 @@ RF
 NV
 RD
 TT
-XL
+Ur
 de
 Jn
 hq
@@ -29318,7 +29325,7 @@ Om
 TW
 Om
 Om
-Ur
+OVERFLOW
 Pt
 Pt
 Pt
@@ -29327,7 +29334,7 @@ WW
 NV
 RD
 TT
-XL
+Ur
 de
 Mz
 hq
@@ -29582,7 +29589,7 @@ Se
 Wd
 Wd
 ZM
-ZE
+Wd
 Jz
 Jz
 Nk

--- a/_maps/shuttles/whiteship_box.dmm
+++ b/_maps/shuttles/whiteship_box.dmm
@@ -11,17 +11,28 @@
 "ad" = (
 /obj/machinery/door/airlock/titanium,
 /obj/docking_port/mobile{
+	callTime = 250;
 	dheight = 0;
 	dir = 2;
 	dwidth = 11;
 	height = 22;
 	id = "whiteship";
 	launch_status = 0;
+	movement_force = list("KNOCKDOWN" = 0, "THROW" = 0);
 	name = "NT Medical Ship";
 	port_direction = 8;
 	preferred_direction = 4;
 	roundstart_move = "whiteship_away";
-	timid = 1;
+	timid = null;
+	width = 35
+	},
+/obj/docking_port/stationary{
+	dir = 2;
+	dwidth = 11;
+	height = 22;
+	id = "whiteship_home";
+	name = "SS13 Arrival Docking";
+	turf_type = /turf/open/space;
 	width = 35
 	},
 /turf/open/floor/mineral/titanium,

--- a/_maps/shuttles/whiteship_box.dmm
+++ b/_maps/shuttles/whiteship_box.dmm
@@ -26,15 +26,6 @@
 	timid = null;
 	width = 35
 	},
-/obj/docking_port/stationary{
-	dir = 2;
-	dwidth = 11;
-	height = 22;
-	id = "whiteship_home";
-	name = "SS13 Arrival Docking";
-	turf_type = /turf/open/space;
-	width = 35
-	},
 /turf/open/floor/mineral/titanium,
 /area/shuttle/abandoned)
 "ae" = (

--- a/_maps/shuttles/whiteship_meta.dmm
+++ b/_maps/shuttles/whiteship_meta.dmm
@@ -20,12 +20,14 @@
 /area/shuttle/abandoned)
 "ag" = (
 /obj/docking_port/mobile{
+	callTime = 250;
 	dheight = 0;
 	dir = 2;
 	dwidth = 11;
 	height = 15;
 	id = "whiteship";
 	launch_status = 0;
+	movement_force = list("KNOCKDOWN" = 0, "THROW" = 0);
 	name = "NT Recovery White-Ship";
 	port_direction = 8;
 	preferred_direction = 4;
@@ -38,6 +40,14 @@
 /obj/effect/decal/cleanable/dirt{
 	desc = "A thin layer of dust coating the floor.";
 	name = "dust"
+	},
+/obj/docking_port/stationary{
+	dir = 2;
+	dwidth = 11;
+	height = 15;
+	id = "whiteship_home";
+	name = "SS13: Auxiliary Dock, Station-Port";
+	width = 27
 	},
 /turf/open/floor/mineral/titanium/blue,
 /area/shuttle/abandoned)

--- a/_maps/shuttles/whiteship_meta.dmm
+++ b/_maps/shuttles/whiteship_meta.dmm
@@ -41,14 +41,6 @@
 	desc = "A thin layer of dust coating the floor.";
 	name = "dust"
 	},
-/obj/docking_port/stationary{
-	dir = 2;
-	dwidth = 11;
-	height = 15;
-	id = "whiteship_home";
-	name = "SS13: Auxiliary Dock, Station-Port";
-	width = 27
-	},
 /turf/open/floor/mineral/titanium/blue,
 /area/shuttle/abandoned)
 "ah" = (


### PR DESCRIPTION
Box and metastation whiteships now no longer have any knockdown when you travel, but also spend 250 ticks in hyperspace instead of 10. This, coupled with not needing to be in a chair to avoid the annoying milisecond long knockdown, incentivizes people to walk around their ship and maybe fix it up or do something in it or bring some friends to go talk to when you're out adventuring all over the place.

The syndie infiltrator had its windows slightly changed to look prettier, and the northwest docking port of boxstation now works again. (The port had no width value put in).
![](https://i.imgur.com/QXyF9H0.png)

:cl: WJohnston
tweak: Due to age, the abandoned ship's engines are now considerably slower when bringing it place to place. This does however mean that the ship now has a more gradual takeoff, with no sudden jolt to knock you off your feet.
/:cl: