### PR TITLE
Fixes explosives in bags not exploding

### DIFF
--- a/code/datums/explosion.dm
+++ b/code/datums/explosion.dm
@@ -179,10 +179,12 @@ GLOBAL_LIST_EMPTY(explosions)
 
 		if(T == epicenter) // Ensures explosives detonating from bags trigger other explosives in that bag
 			var/list/items = list() 
-			for(var/atom/A in T.contents)
+			for(var/I in T)
+				var/atom/A = I
 				items += A.GetAllContents()
-			for(var/atom/I in items)
-				I.ex_act(dist)
+			for(var/O in items)
+				var/atom/A = O
+				A.ex_act(dist)
 
 		if(flame_dist && prob(40) && !isspaceturf(T) && !T.density)
 			new /obj/effect/hotspot(T) //Mostly for ambience!

--- a/code/datums/explosion.dm
+++ b/code/datums/explosion.dm
@@ -177,6 +177,13 @@ GLOBAL_LIST_EMPTY(explosions)
 
 		//------- EX_ACT AND TURF FIRES -------
 
+		if(T == epicenter)
+			var/list/items
+			for(var/atom/A in T.contents)
+				items += A.GetAllContents()
+			for(var/atom/I in items)
+				I.ex_act(dist)
+
 		if(flame_dist && prob(40) && !isspaceturf(T) && !T.density)
 			new /obj/effect/hotspot(T) //Mostly for ambience!
 

--- a/code/datums/explosion.dm
+++ b/code/datums/explosion.dm
@@ -177,8 +177,8 @@ GLOBAL_LIST_EMPTY(explosions)
 
 		//------- EX_ACT AND TURF FIRES -------
 
-		if(T == epicenter)
-			var/list/items
+		if(T == epicenter) // Ensures explosives detonating from bags trigger other explosives in that bag
+			var/list/items = list() 
 			for(var/atom/A in T.contents)
 				items += A.GetAllContents()
 			for(var/atom/I in items)

--- a/code/modules/mob/living/carbon/human/human_defense.dm
+++ b/code/modules/mob/living/carbon/human/human_defense.dm
@@ -372,7 +372,7 @@
 			else
 				for(var/I in contents)
 					var/atom/A = I
-					A.ex_act(EXPLODE_DEVASTATE)
+					A.ex_act(severity)
 				gib()
 				return
 

--- a/code/modules/mob/living/carbon/human/human_defense.dm
+++ b/code/modules/mob/living/carbon/human/human_defense.dm
@@ -370,6 +370,9 @@
 				throw_at(throw_target, 200, 4)
 				damage_clothes(400 - bomb_armor, BRUTE, "bomb")
 			else
+				for(var/I in contents)
+					var/atom/A = I
+					A.ex_act(EXPLODE_DEVASTATE)
 				gib()
 				return
 

--- a/code/modules/mob/living/death.dm
+++ b/code/modules/mob/living/death.dm
@@ -1,10 +1,7 @@
-/mob/living/gib(no_brain, no_organs, no_bodyparts, explosion = false)
+/mob/living/gib(no_brain, no_organs, no_bodyparts)
 	var/prev_lying = lying
 	if(stat != DEAD)
 		death(1)
-	if(explosion)
-		for(var/atom/A in contents)
-			A.ex_act(EXPLODE_DEVASTATE)
 
 	if(!prev_lying)
 		gib_animation()

--- a/code/modules/mob/living/death.dm
+++ b/code/modules/mob/living/death.dm
@@ -2,6 +2,8 @@
 	var/prev_lying = lying
 	if(stat != DEAD)
 		death(1)
+	for(var/atom/A in contents)
+		A.ex_act(EXPLODE_DEVASTATE)
 
 	if(!prev_lying)
 		gib_animation()
@@ -10,7 +12,6 @@
 
 	if(!no_bodyparts)
 		spread_bodyparts(no_brain, no_organs)
-
 	spawn_gibs(no_bodyparts)
 	qdel(src)
 

--- a/code/modules/mob/living/death.dm
+++ b/code/modules/mob/living/death.dm
@@ -10,7 +10,9 @@
 
 	if(!no_bodyparts)
 		spread_bodyparts(no_brain, no_organs)
+		
 	spawn_gibs(no_bodyparts)
+	
 	qdel(src)
 
 /mob/living/proc/gib_animation()

--- a/code/modules/mob/living/death.dm
+++ b/code/modules/mob/living/death.dm
@@ -10,6 +10,7 @@
 
 	if(!no_bodyparts)
 		spread_bodyparts(no_brain, no_organs)
+	
 	spawn_gibs(no_bodyparts)
 	qdel(src)
 

--- a/code/modules/mob/living/death.dm
+++ b/code/modules/mob/living/death.dm
@@ -10,9 +10,7 @@
 
 	if(!no_bodyparts)
 		spread_bodyparts(no_brain, no_organs)
-		
 	spawn_gibs(no_bodyparts)
-	
 	qdel(src)
 
 /mob/living/proc/gib_animation()

--- a/code/modules/mob/living/death.dm
+++ b/code/modules/mob/living/death.dm
@@ -1,9 +1,10 @@
-/mob/living/gib(no_brain, no_organs, no_bodyparts)
+/mob/living/gib(no_brain, no_organs, no_bodyparts, explosion = false)
 	var/prev_lying = lying
 	if(stat != DEAD)
 		death(1)
-	for(var/atom/A in contents)
-		A.ex_act(EXPLODE_DEVASTATE)
+	if(explosion)
+		for(var/atom/A in contents)
+			A.ex_act(EXPLODE_DEVASTATE)
 
 	if(!prev_lying)
 		gib_animation()

--- a/code/modules/mob/living/death.dm
+++ b/code/modules/mob/living/death.dm
@@ -10,7 +10,7 @@
 
 	if(!no_bodyparts)
 		spread_bodyparts(no_brain, no_organs)
-	
+
 	spawn_gibs(no_bodyparts)
 	qdel(src)
 


### PR DESCRIPTION
This was a 2-part issue that created a loophole where explosives wouldn't explode when exploded on. The most striking example is placing c4 on another explosive (i.e. syndie bomb core) only to have the c4 detonate and the bomb core remains unharmed - but if you pull the same stunt outside of a bomb, the core will detonate as intended. 

The 2nd part of the issue was that getting gibbed by an explosive would prevent your contents from exploding. That is fixed as well. 

:cl: Robustin
fix: Chain reactions between explosives will now properly trigger explosives located in an individual's bag.
/:cl:

The hackiest part of this PR is the fact that the chain-reaction is limited to the epicenter. It was a little much if it just worked for ANY explosion, so it made sense to limit this effect to the epicenter. 
