### PR TITLE
Tweaks syndie infiltrator and box/meta whiteships: Diet conflicts flavor!

### DIFF
--- a/_maps/map_files/BoxStation/BoxStation.dmm
+++ b/_maps/map_files/BoxStation/BoxStation.dmm
@@ -1,4 +1,4 @@
-//MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE 
+//MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
 "aaa" = (
 /turf/open/space/basic,
 /area/space)
@@ -54691,12 +54691,14 @@
 "cyd" = (
 /obj/machinery/door/airlock/titanium,
 /obj/docking_port/mobile{
+	callTime = 250;
 	dheight = 0;
 	dir = 2;
 	dwidth = 11;
 	height = 22;
 	id = "whiteship";
 	launch_status = 0;
+	movement_force = list("KNOCKDOWN" = 0, "THROW" = 0);
 	name = "NT Medical Ship";
 	port_direction = 8;
 	preferred_direction = 4;
@@ -58902,14 +58904,27 @@
 /area/science/xenobiology)
 "Qlj" = (
 /obj/docking_port/stationary{
- 	dheight = 9;
- 	dir = 2;
- 	dwidth = 5;
- 	height = 24;
+	dheight = 9;
+	dir = 2;
+	dwidth = 5;
+	height = 24;
 	id = "syndicate_nw";
 	name = "northwest of station";
 	turf_type = /turf/open/space
-},
+	},
+/turf/open/space/basic,
+/area/space)
+"Qlk" = (
+/obj/docking_port/stationary{
+	dheight = 9;
+	dir = 2;
+	dwidth = 5;
+	height = 24;
+	id = "syndicate_nw";
+	name = "northwest of station";
+	turf_type = /turf/open/space;
+	width = 18
+	},
 /turf/open/space/basic,
 /area/space)
 
@@ -73082,7 +73097,6 @@ aaa
 aaa
 aaa
 aaa
-Qlj
 aaa
 aaa
 aaa
@@ -73093,6 +73107,7 @@ aaa
 aaa
 aaa
 aaa
+Qlk
 aaa
 aaa
 aaa

--- a/_maps/map_files/Deltastation/DeltaStation2.dmm
+++ b/_maps/map_files/Deltastation/DeltaStation2.dmm
@@ -1,4 +1,4 @@
-//MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE 
+//MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
 "aaa" = (
 /turf/open/space/basic,
 /area/space)
@@ -121753,7 +121753,7 @@ aaa
 aaa
 aaa
 aaa
-YGI
+aaa
 aaa
 aaa
 aaa
@@ -125889,7 +125889,7 @@ aaa
 aaa
 aaa
 aaa
-aaa
+YGI
 aaa
 aaa
 aaa

--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -1,4 +1,4 @@
-//MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE 
+//MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
 "aaa" = (
 /turf/open/space/basic,
 /area/space)
@@ -54639,12 +54639,14 @@
 /area/engine/atmos)
 "cbm" = (
 /obj/docking_port/mobile{
+	callTime = 250;
 	dheight = 0;
 	dir = 2;
 	dwidth = 11;
 	height = 15;
 	id = "whiteship";
 	launch_status = 0;
+	movement_force = list("KNOCKDOWN" = 0, "THROW" = 0);
 	name = "NT Recovery White-Ship";
 	port_direction = 8;
 	preferred_direction = 4;
@@ -95770,7 +95772,7 @@ aaa
 aaa
 aaa
 aaa
-EDa
+aaa
 aaa
 aaa
 aaa
@@ -96070,7 +96072,7 @@ aaa
 aaa
 aaa
 aaa
-aaa
+EDa
 aaa
 aaa
 aaa

--- a/_maps/map_files/PubbyStation/PubbyStation.dmm
+++ b/_maps/map_files/PubbyStation/PubbyStation.dmm
@@ -1,4 +1,4 @@
-//MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE 
+//MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
 "aaa" = (
 /turf/open/space/basic,
 /area/space)
@@ -62889,7 +62889,7 @@ aaa
 aaa
 aaa
 aaa
-aaa
+YXG
 aaa
 aaa
 aaa
@@ -63892,7 +63892,7 @@ aaa
 aaa
 aaa
 aaa
-YXG
+aaa
 aaa
 aaa
 aaa
@@ -110462,7 +110462,7 @@ aaa
 aaa
 aaa
 aaa
-aaa
+ajA
 aaa
 aaa
 aaa
@@ -110971,7 +110971,7 @@ aaa
 aaa
 aaa
 aaa
-ajA
+aaa
 aaa
 aaa
 aaa

--- a/_maps/map_files/generic/CentCom.dmm
+++ b/_maps/map_files/generic/CentCom.dmm
@@ -13628,9 +13628,10 @@
 /turf/closed/wall/mineral/titanium/nodiagonal,
 /area/centcom/evac)
 "Mk" = (
-/obj/structure/grille,
 /obj/structure/window/plastitanium,
-/turf/open/floor/plating,
+/turf/open/floor/plasteel/vault{
+	dir = 5
+	},
 /area/shuttle/syndicate/airlock)
 "Mz" = (
 /obj/structure/shuttle/engine/propulsion/right,
@@ -13798,7 +13799,6 @@
 	id = "syndieshutters";
 	name = "blast shutters"
 	},
-/obj/structure/grille,
 /turf/open/floor/plating,
 /area/shuttle/syndicate/bridge)
 "Pm" = (
@@ -13889,9 +13889,10 @@
 /turf/open/floor/holofloor,
 /area/holodeck/rec_center/school)
 "QP" = (
-/obj/structure/grille,
 /obj/structure/window/plastitanium,
-/turf/open/floor/plating,
+/turf/open/floor/plasteel/vault{
+	dir = 5
+	},
 /area/shuttle/syndicate/medical)
 "QT" = (
 /obj/effect/turf_decal/stripes/corner,
@@ -14090,9 +14091,10 @@
 	},
 /area/shuttle/syndicate/eva)
 "Tl" = (
-/obj/structure/grille,
 /obj/structure/window/plastitanium,
-/turf/open/floor/plating,
+/turf/open/floor/plasteel/vault{
+	dir = 5
+	},
 /area/shuttle/syndicate/eva)
 "Tm" = (
 /obj/machinery/status_display,
@@ -14248,9 +14250,10 @@
 /turf/open/floor/plasteel/vault,
 /area/shuttle/syndicate/medical)
 "Wd" = (
-/obj/structure/grille,
 /obj/structure/window/plastitanium,
-/turf/open/floor/plating,
+/turf/open/floor/plasteel/vault{
+	dir = 5
+	},
 /area/shuttle/syndicate/armory)
 "We" = (
 /obj/item/screwdriver{
@@ -14492,16 +14495,6 @@
 	},
 /turf/closed/wall/mineral/plastitanium,
 /area/shuttle/syndicate/medical)
-"ZZ" = (
-/obj/structure/grille,
-/obj/structure/window/plastitanium,
-/turf/open/floor/plating,
-/area/shuttle/syndicate/hallway)
-"OVERFLOW" = (
-/obj/structure/grille,
-/obj/structure/window/plastitanium,
-/turf/open/floor/plating,
-/area/shuttle/syndicate/hallway)
 
 (1,1,1) = {"
 aa
@@ -28561,7 +28554,7 @@ ZS
 QP
 QP
 pk
-QP
+Nc
 XJ
 XJ
 Nk
@@ -28811,7 +28804,7 @@ XN
 Ru
 XN
 XN
-ZZ
+Ur
 Pt
 Pt
 Pt
@@ -28820,7 +28813,7 @@ RF
 NV
 RD
 TT
-Ur
+XL
 de
 Jn
 hq
@@ -29325,7 +29318,7 @@ Om
 TW
 Om
 Om
-OVERFLOW
+Ur
 Pt
 Pt
 Pt
@@ -29334,7 +29327,7 @@ WW
 NV
 RD
 TT
-Ur
+XL
 de
 Mz
 hq
@@ -29589,7 +29582,7 @@ Se
 Wd
 Wd
 ZM
-Wd
+ZE
 Jz
 Jz
 Nk

--- a/_maps/map_files/generic/CentCom.dmm
+++ b/_maps/map_files/generic/CentCom.dmm
@@ -13629,8 +13629,9 @@
 /area/centcom/evac)
 "Mk" = (
 /obj/structure/window/plastitanium,
-/obj/structure/grille,
-/turf/open/floor/plating,
+/turf/open/floor/plasteel/vault{
+	dir = 5
+	},
 /area/shuttle/syndicate/airlock)
 "Mz" = (
 /obj/structure/shuttle/engine/propulsion/right,
@@ -13798,7 +13799,6 @@
 	id = "syndieshutters";
 	name = "blast shutters"
 	},
-/obj/structure/grille,
 /turf/open/floor/plating,
 /area/shuttle/syndicate/bridge)
 "Pm" = (
@@ -13890,8 +13890,9 @@
 /area/holodeck/rec_center/school)
 "QP" = (
 /obj/structure/window/plastitanium,
-/obj/structure/grille,
-/turf/open/floor/plating,
+/turf/open/floor/plasteel/vault{
+	dir = 5
+	},
 /area/shuttle/syndicate/medical)
 "QT" = (
 /obj/effect/turf_decal/stripes/corner,
@@ -14091,8 +14092,9 @@
 /area/shuttle/syndicate/eva)
 "Tl" = (
 /obj/structure/window/plastitanium,
-/obj/structure/grille,
-/turf/open/floor/plating,
+/turf/open/floor/plasteel/vault{
+	dir = 5
+	},
 /area/shuttle/syndicate/eva)
 "Tm" = (
 /obj/machinery/status_display,
@@ -14249,8 +14251,9 @@
 /area/shuttle/syndicate/medical)
 "Wd" = (
 /obj/structure/window/plastitanium,
-/obj/structure/grille,
-/turf/open/floor/plating,
+/turf/open/floor/plasteel/vault{
+	dir = 5
+	},
 /area/shuttle/syndicate/armory)
 "We" = (
 /obj/item/screwdriver{
@@ -14492,16 +14495,6 @@
 	},
 /turf/closed/wall/mineral/plastitanium,
 /area/shuttle/syndicate/medical)
-"ZZ" = (
-/obj/structure/window/plastitanium,
-/obj/structure/grille,
-/turf/open/floor/plating,
-/area/shuttle/syndicate/hallway)
-"OVERFLOW" = (
-/obj/structure/window/plastitanium,
-/obj/structure/grille,
-/turf/open/floor/plating,
-/area/shuttle/syndicate/hallway)
 
 (1,1,1) = {"
 aa
@@ -28561,7 +28554,7 @@ ZS
 QP
 QP
 pk
-QP
+Nc
 XJ
 XJ
 Nk
@@ -28811,7 +28804,7 @@ XN
 Ru
 XN
 XN
-ZZ
+Ur
 Pt
 Pt
 Pt
@@ -28820,7 +28813,7 @@ RF
 NV
 RD
 TT
-Ur
+XL
 de
 Jn
 hq
@@ -29325,7 +29318,7 @@ Om
 TW
 Om
 Om
-OVERFLOW
+Ur
 Pt
 Pt
 Pt
@@ -29334,7 +29327,7 @@ WW
 NV
 RD
 TT
-Ur
+XL
 de
 Mz
 hq
@@ -29589,7 +29582,7 @@ Se
 Wd
 Wd
 ZM
-Wd
+ZE
 Jz
 Jz
 Nk

--- a/_maps/map_files/generic/CentCom.dmm
+++ b/_maps/map_files/generic/CentCom.dmm
@@ -47,14 +47,14 @@
 "aj" = (
 /turf/open/floor/holofloor/asteroid,
 /area/holodeck/rec_center/bunker)
-"al" = (
+"ak" = (
 /obj/structure/table,
 /obj/item/stack/medical/ointment{
 	heal_burn = 10
 	},
 /turf/open/floor/holofloor/asteroid,
 /area/holodeck/rec_center/bunker)
-"am" = (
+"al" = (
 /obj/structure/table/wood{
 	layer = 3.3
 	},
@@ -67,20 +67,20 @@
 	dir = 9
 	},
 /area/holodeck/rec_center/lounge)
-"an" = (
+"am" = (
 /obj/structure/closet/crate/bin,
 /turf/open/floor/holofloor{
 	icon_state = "wood";
 	dir = 9
 	},
 /area/holodeck/rec_center/lounge)
-"ao" = (
+"an" = (
 /turf/open/floor/holofloor{
 	icon_state = "wood";
 	dir = 9
 	},
 /area/holodeck/rec_center/lounge)
-"ap" = (
+"ao" = (
 /obj/structure/table/wood,
 /obj/item/device/flashlight/lamp/green{
 	layer = 3.3
@@ -90,44 +90,44 @@
 	dir = 9
 	},
 /area/holodeck/rec_center/lounge)
-"aq" = (
+"ap" = (
 /turf/open/floor/holofloor/plating,
 /area/holodeck/rec_center/wildlife)
-"ar" = (
+"aq" = (
 /turf/open/floor/holofloor/plating,
 /area/holodeck/rec_center/offline)
-"as" = (
+"ar" = (
 /turf/open/floor/holofloor/plating/burnmix,
 /area/holodeck/rec_center/burn)
-"at" = (
+"as" = (
 /turf/open/floor/holofloor{
 	dir = 9;
 	icon_state = "red"
 	},
 /area/holodeck/rec_center/court)
-"au" = (
+"at" = (
 /turf/open/floor/holofloor{
 	dir = 1;
 	icon_state = "red"
 	},
 /area/holodeck/rec_center/court)
-"av" = (
+"au" = (
 /turf/open/floor/holofloor{
 	dir = 5;
 	icon_state = "red"
 	},
 /area/holodeck/rec_center/court)
-"aw" = (
+"av" = (
 /obj/structure/window/reinforced{
 	dir = 8
 	},
 /turf/closed/indestructible/riveted,
 /area/space)
-"ax" = (
+"aw" = (
 /obj/structure/flora/bush,
 /turf/open/floor/holofloor/snow,
 /area/holodeck/rec_center/winterwonderland)
-"ay" = (
+"ax" = (
 /obj/effect/holodeck_effect/mobspawner/penguin,
 /obj/effect/holodeck_effect/mobspawner/penguin,
 /obj/item/toy/snowball{
@@ -141,12 +141,12 @@
 	},
 /turf/open/floor/holofloor/snow,
 /area/holodeck/rec_center/winterwonderland)
-"aA" = (
+"ay" = (
 /obj/structure/table,
 /obj/machinery/recharger,
 /turf/open/floor/holofloor/asteroid,
 /area/holodeck/rec_center/bunker)
-"aB" = (
+"az" = (
 /obj/structure/table/wood,
 /obj/item/storage/box/matches{
 	pixel_x = -4;
@@ -157,46 +157,46 @@
 	dir = 9
 	},
 /area/holodeck/rec_center/lounge)
-"aC" = (
+"aA" = (
 /obj/structure/chair/wood/normal,
 /turf/open/floor/holofloor{
 	icon_state = "wood";
 	dir = 9
 	},
 /area/holodeck/rec_center/lounge)
-"aD" = (
+"aB" = (
 /obj/effect/holodeck_effect/mobspawner,
 /turf/open/floor/holofloor/plating,
 /area/holodeck/rec_center/wildlife)
-"aE" = (
+"aC" = (
 /obj/effect/holodeck_effect/sparks,
 /turf/open/floor/holofloor/plating/burnmix,
 /area/holodeck/rec_center/burn)
-"aF" = (
+"aD" = (
 /turf/open/floor/holofloor{
 	dir = 8;
 	icon_state = "red"
 	},
 /area/holodeck/rec_center/court)
-"aG" = (
+"aE" = (
 /turf/open/floor/holofloor,
 /area/holodeck/rec_center/court)
-"aH" = (
+"aF" = (
 /turf/open/floor/holofloor{
 	dir = 4;
 	icon_state = "red"
 	},
 /area/holodeck/rec_center/court)
-"aI" = (
+"aG" = (
 /obj/structure/flora/grass/brown,
 /turf/open/floor/holofloor/snow,
 /area/holodeck/rec_center/winterwonderland)
-"aJ" = (
+"aH" = (
 /obj/structure/table,
 /obj/item/gun/energy/laser,
 /turf/open/floor/holofloor/asteroid,
 /area/holodeck/rec_center/bunker)
-"aK" = (
+"aI" = (
 /obj/structure/chair/wood/normal{
 	dir = 4
 	},
@@ -205,7 +205,7 @@
 	dir = 9
 	},
 /area/holodeck/rec_center/lounge)
-"aL" = (
+"aJ" = (
 /obj/structure/table/wood/poker,
 /obj/item/clothing/mask/cigarette/pipe,
 /turf/open/floor/holofloor{
@@ -213,7 +213,7 @@
 	dir = 9
 	},
 /area/holodeck/rec_center/lounge)
-"aM" = (
+"aK" = (
 /obj/structure/table/wood/poker,
 /obj/structure/table/wood/poker,
 /obj/effect/holodeck_effect/cards,
@@ -222,7 +222,7 @@
 	dir = 9
 	},
 /area/holodeck/rec_center/lounge)
-"aN" = (
+"aL" = (
 /obj/structure/chair/wood/normal{
 	dir = 8
 	},
@@ -231,13 +231,13 @@
 	dir = 9
 	},
 /area/holodeck/rec_center/lounge)
-"aO" = (
+"aM" = (
 /obj/structure/statue/snow/snowman{
 	anchored = 1
 	},
 /turf/open/floor/holofloor/snow,
 /area/holodeck/rec_center/winterwonderland)
-"aP" = (
+"aN" = (
 /obj/structure/chair/wood/normal{
 	dir = 1
 	},
@@ -246,11 +246,11 @@
 	dir = 9
 	},
 /area/holodeck/rec_center/lounge)
-"aQ" = (
+"aO" = (
 /obj/structure/chair/wood/wings,
 /turf/open/floor/holofloor/snow,
 /area/holodeck/rec_center/winterwonderland)
-"aR" = (
+"aP" = (
 /obj/structure/window/reinforced/tinted{
 	dir = 4
 	},
@@ -259,23 +259,23 @@
 	dir = 9
 	},
 /area/holodeck/rec_center/lounge)
-"aS" = (
+"aQ" = (
 /obj/structure/window/reinforced,
 /turf/open/floor/holofloor{
 	icon_state = "wood";
 	dir = 9
 	},
 /area/holodeck/rec_center/lounge)
-"aT" = (
+"aR" = (
 /obj/effect/holodeck_effect/mobspawner/penguin_baby,
 /obj/structure/flora/tree/pine,
 /turf/open/floor/holofloor/snow,
 /area/holodeck/rec_center/winterwonderland)
-"aU" = (
+"aS" = (
 /obj/structure/chair/wood,
 /turf/open/floor/holofloor/snow,
 /area/holodeck/rec_center/winterwonderland)
-"aV" = (
+"aT" = (
 /obj/structure/table/wood,
 /obj/item/twohanded/required/kirbyplants{
 	icon_state = "plant-05";
@@ -286,132 +286,132 @@
 	dir = 9
 	},
 /area/holodeck/rec_center/lounge)
-"aW" = (
+"aU" = (
 /turf/open/floor/holofloor{
 	dir = 9;
 	icon_state = "stairs-l"
 	},
 /area/holodeck/rec_center/lounge)
-"aX" = (
+"aV" = (
 /turf/open/floor/holofloor{
 	dir = 9;
 	icon_state = "stairs-r"
 	},
 /area/holodeck/rec_center/lounge)
-"aY" = (
+"aW" = (
 /turf/open/floor/holofloor{
 	dir = 8;
 	icon_state = "green"
 	},
 /area/holodeck/rec_center/court)
-"aZ" = (
+"aX" = (
 /turf/open/floor/holofloor{
 	dir = 4;
 	icon_state = "green"
 	},
 /area/holodeck/rec_center/court)
-"ba" = (
+"aY" = (
 /obj/structure/table/wood,
 /obj/item/device/flashlight/lamp/green{
 	pixel_y = 4
 	},
 /turf/open/floor/holofloor/carpet,
 /area/holodeck/rec_center/lounge)
-"bb" = (
+"aZ" = (
 /turf/open/floor/holofloor/carpet,
 /area/holodeck/rec_center/lounge)
-"bc" = (
+"ba" = (
 /obj/structure/chair/comfy/brown{
 	dir = 4
 	},
 /turf/open/floor/holofloor/carpet,
 /area/holodeck/rec_center/lounge)
-"bd" = (
+"bb" = (
 /obj/structure/chair/comfy/brown{
 	dir = 8
 	},
 /turf/open/floor/holofloor/carpet,
 /area/holodeck/rec_center/lounge)
-"be" = (
+"bc" = (
 /obj/structure/table,
 /obj/item/stack/medical/bruise_pack{
 	heal_brute = 10
 	},
 /turf/open/floor/holofloor/asteroid,
 /area/holodeck/rec_center/bunker)
-"bf" = (
+"bd" = (
 /obj/structure/table/wood,
 /obj/item/device/instrument/violin,
 /turf/open/floor/holofloor/carpet,
 /area/holodeck/rec_center/lounge)
-"bg" = (
+"be" = (
 /obj/structure/chair/comfy/brown{
 	buildstackamount = 0;
 	dir = 1
 	},
 /turf/open/floor/holofloor/carpet,
 /area/holodeck/rec_center/lounge)
-"bh" = (
+"bf" = (
 /obj/structure/table/wood,
 /obj/item/book/manual/barman_recipes,
 /obj/item/clothing/mask/cigarette/pipe,
 /turf/open/floor/holofloor/carpet,
 /area/holodeck/rec_center/lounge)
-"bi" = (
+"bg" = (
 /turf/open/floor/holofloor{
 	dir = 10;
 	icon_state = "green"
 	},
 /area/holodeck/rec_center/court)
-"bj" = (
+"bh" = (
 /turf/open/floor/holofloor{
 	dir = 2;
 	icon_state = "green"
 	},
 /area/holodeck/rec_center/court)
-"bk" = (
+"bi" = (
 /turf/open/floor/holofloor{
 	dir = 6;
 	icon_state = "green"
 	},
 /area/holodeck/rec_center/court)
-"bl" = (
+"bj" = (
 /obj/structure/window/reinforced{
 	dir = 1
 	},
 /obj/structure/window/reinforced,
 /turf/closed/indestructible/riveted,
 /area/space)
-"bm" = (
+"bk" = (
 /obj/effect/holodeck_effect/mobspawner/bee,
 /turf/open/floor/holofloor/asteroid,
 /area/holodeck/rec_center/anthophila)
-"bn" = (
+"bl" = (
 /turf/open/floor/holofloor/grass,
 /area/holodeck/rec_center/pet_lounge)
-"bo" = (
+"bm" = (
 /obj/structure/flora/ausbushes/sunnybush,
 /turf/open/floor/holofloor/grass,
 /area/holodeck/rec_center/pet_lounge)
-"bp" = (
+"bn" = (
 /obj/structure/flora/ausbushes/genericbush,
 /turf/open/floor/holofloor/grass,
 /area/holodeck/rec_center/pet_lounge)
-"bq" = (
+"bo" = (
 /obj/structure/table/glass,
 /obj/item/surgicaldrill,
 /turf/open/floor/holofloor{
 	icon_state = "white"
 	},
 /area/holodeck/rec_center/medical)
-"br" = (
+"bp" = (
 /obj/structure/table/glass,
 /obj/item/hemostat,
 /turf/open/floor/holofloor{
 	icon_state = "white"
 	},
 /area/holodeck/rec_center/medical)
-"bs" = (
+"bq" = (
 /obj/structure/table/glass,
 /obj/item/scalpel{
 	pixel_y = 10
@@ -421,14 +421,14 @@
 	icon_state = "white"
 	},
 /area/holodeck/rec_center/medical)
-"bt" = (
+"br" = (
 /obj/structure/table/glass,
 /obj/item/retractor,
 /turf/open/floor/holofloor{
 	icon_state = "white"
 	},
 /area/holodeck/rec_center/medical)
-"bu" = (
+"bs" = (
 /obj/structure/table/glass,
 /obj/item/stack/medical/gauze,
 /obj/item/cautery,
@@ -436,13 +436,13 @@
 	icon_state = "white"
 	},
 /area/holodeck/rec_center/medical)
-"bv" = (
+"bt" = (
 /turf/open/floor/holofloor{
 	dir = 9;
 	icon_state = "red"
 	},
 /area/holodeck/rec_center/basketball)
-"bw" = (
+"bu" = (
 /obj/structure/holohoop{
 	layer = 3.9
 	},
@@ -451,21 +451,21 @@
 	icon_state = "red"
 	},
 /area/holodeck/rec_center/basketball)
-"bx" = (
+"bv" = (
 /turf/open/floor/holofloor{
 	dir = 5;
 	icon_state = "red"
 	},
 /area/holodeck/rec_center/basketball)
-"by" = (
+"bw" = (
 /turf/open/floor/holofloor/beach,
 /area/holodeck/rec_center/beach)
-"bz" = (
+"bx" = (
 /obj/structure/table,
 /obj/machinery/readybutton,
 /turf/open/floor/holofloor/basalt,
 /area/holodeck/rec_center/thunderdome)
-"bA" = (
+"by" = (
 /obj/structure/table,
 /obj/item/clothing/head/helmet/thunderdome,
 /obj/item/clothing/suit/armor/tdome/red,
@@ -473,43 +473,43 @@
 /obj/item/holo/esword/red,
 /turf/open/floor/holofloor/basalt,
 /area/holodeck/rec_center/thunderdome)
-"bB" = (
+"bz" = (
 /obj/structure/table,
 /turf/open/floor/holofloor/basalt,
 /area/holodeck/rec_center/thunderdome)
-"bC" = (
+"bA" = (
 /obj/machinery/readybutton,
 /turf/open/floor/holofloor{
 	dir = 9;
 	icon_state = "red"
 	},
 /area/holodeck/rec_center/dodgeball)
-"bD" = (
+"bB" = (
 /turf/open/floor/holofloor{
 	dir = 1;
 	icon_state = "red"
 	},
 /area/holodeck/rec_center/dodgeball)
-"bE" = (
+"bC" = (
 /turf/open/floor/holofloor{
 	dir = 5;
 	icon_state = "red"
 	},
 /area/holodeck/rec_center/dodgeball)
-"bF" = (
+"bD" = (
 /obj/effect/holodeck_effect/mobspawner/pet,
 /turf/open/floor/holofloor/grass,
 /area/holodeck/rec_center/pet_lounge)
-"bG" = (
+"bE" = (
 /obj/structure/flora/ausbushes/ppflowers,
 /turf/open/floor/holofloor/grass,
 /area/holodeck/rec_center/pet_lounge)
-"bH" = (
+"bF" = (
 /obj/effect/holodeck_effect/mobspawner/pet,
 /obj/structure/flora/ausbushes/brflowers,
 /turf/open/floor/holofloor/grass,
 /area/holodeck/rec_center/pet_lounge)
-"bI" = (
+"bG" = (
 /obj/structure/table/glass,
 /obj/item/surgical_drapes,
 /obj/item/razor,
@@ -517,58 +517,58 @@
 	icon_state = "white"
 	},
 /area/holodeck/rec_center/medical)
-"bJ" = (
+"bH" = (
 /turf/open/floor/holofloor{
 	icon_state = "white"
 	},
 /area/holodeck/rec_center/medical)
-"bL" = (
+"bI" = (
 /turf/open/floor/holofloor{
 	dir = 8;
 	icon_state = "red"
 	},
 /area/holodeck/rec_center/basketball)
-"bM" = (
+"bJ" = (
 /turf/open/floor/holofloor,
 /area/holodeck/rec_center/basketball)
-"bN" = (
+"bK" = (
 /turf/open/floor/holofloor{
 	dir = 4;
 	icon_state = "red"
 	},
 /area/holodeck/rec_center/basketball)
-"bO" = (
+"bL" = (
 /obj/effect/overlay/palmtree_r,
 /turf/open/floor/holofloor/beach,
 /area/holodeck/rec_center/beach)
-"bP" = (
+"bM" = (
 /obj/effect/overlay/palmtree_l,
 /obj/effect/overlay/coconut,
 /turf/open/floor/holofloor/beach,
 /area/holodeck/rec_center/beach)
-"bQ" = (
+"bN" = (
 /turf/open/floor/holofloor/basalt,
 /area/holodeck/rec_center/thunderdome)
-"bR" = (
+"bO" = (
 /turf/open/floor/holofloor{
 	dir = 8;
 	icon_state = "red"
 	},
 /area/holodeck/rec_center/dodgeball)
-"bS" = (
+"bP" = (
 /turf/open/floor/holofloor,
 /area/holodeck/rec_center/dodgeball)
-"bT" = (
+"bQ" = (
 /turf/open/floor/holofloor{
 	dir = 4;
 	icon_state = "red"
 	},
 /area/holodeck/rec_center/dodgeball)
-"bU" = (
+"bR" = (
 /obj/structure/flora/ausbushes/brflowers,
 /turf/open/floor/holofloor/grass,
 /area/holodeck/rec_center/pet_lounge)
-"bV" = (
+"bS" = (
 /obj/item/storage/bag/easterbasket{
 	name = "picnic basket";
 	pixel_y = 6
@@ -577,25 +577,25 @@
 	icon_state = "redbluefull"
 	},
 /area/holodeck/rec_center/pet_lounge)
-"bW" = (
+"bT" = (
 /obj/item/trash/plate,
 /turf/open/floor/holofloor{
 	icon_state = "redbluefull"
 	},
 /area/holodeck/rec_center/pet_lounge)
-"bZ" = (
+"bU" = (
 /obj/structure/table/optable,
 /turf/open/floor/holofloor{
 	icon_state = "white"
 	},
 /area/holodeck/rec_center/medical)
-"ca" = (
+"bV" = (
 /obj/machinery/computer/operating,
 /turf/open/floor/holofloor{
 	icon_state = "white"
 	},
 /area/holodeck/rec_center/medical)
-"cb" = (
+"bW" = (
 /obj/structure/table/glass,
 /obj/item/clothing/gloves/color/latex/nitrile,
 /obj/item/clothing/suit/apron/surgical,
@@ -604,33 +604,33 @@
 	icon_state = "white"
 	},
 /area/holodeck/rec_center/medical)
-"cc" = (
+"bX" = (
 /turf/open/floor/holofloor{
 	dir = 1;
 	icon_state = "red"
 	},
 /area/holodeck/rec_center/basketball)
-"cd" = (
+"bY" = (
 /obj/effect/holodeck_effect/mobspawner/monkey,
 /turf/open/floor/holofloor/beach,
 /area/holodeck/rec_center/beach)
-"ce" = (
+"bZ" = (
 /turf/open/floor/holofloor{
 	dir = 2;
 	icon_state = "red"
 	},
 /area/holodeck/rec_center/dodgeball)
-"cf" = (
+"ca" = (
 /obj/structure/flora/ausbushes/palebush,
 /turf/open/floor/holofloor/grass,
 /area/holodeck/rec_center/pet_lounge)
-"cg" = (
+"cb" = (
 /obj/effect/holodeck_effect/mobspawner/pet,
 /turf/open/floor/holofloor{
 	icon_state = "redbluefull"
 	},
 /area/holodeck/rec_center/pet_lounge)
-"ch" = (
+"cc" = (
 /obj/item/shovel/spade{
 	pixel_x = 2;
 	pixel_y = -2
@@ -639,7 +639,7 @@
 	icon_state = "redbluefull"
 	},
 /area/holodeck/rec_center/pet_lounge)
-"ci" = (
+"cd" = (
 /obj/structure/window{
 	dir = 1
 	},
@@ -647,19 +647,19 @@
 	icon_state = "white"
 	},
 /area/holodeck/rec_center/medical)
-"cj" = (
+"ce" = (
 /obj/effect/holodeck_effect/mobspawner/bee,
 /obj/item/clothing/head/beekeeper_head,
 /turf/open/floor/holofloor/asteroid,
 /area/holodeck/rec_center/anthophila)
-"ck" = (
+"cf" = (
 /obj/structure/table/glass,
 /obj/machinery/reagentgrinder,
 /turf/open/floor/holofloor{
 	icon_state = "white"
 	},
 /area/holodeck/rec_center/medical)
-"cm" = (
+"cg" = (
 /obj/structure/table/glass,
 /obj/item/storage/box/syringes{
 	pixel_x = 4;
@@ -670,40 +670,40 @@
 	icon_state = "white"
 	},
 /area/holodeck/rec_center/medical)
-"cn" = (
+"ch" = (
 /obj/machinery/washing_machine,
 /turf/open/floor/holofloor{
 	icon_state = "white"
 	},
 /area/holodeck/rec_center/medical)
-"co" = (
+"ci" = (
 /turf/open/floor/holofloor{
 	dir = 10;
 	icon_state = "red"
 	},
 /area/holodeck/rec_center/basketball)
-"cp" = (
+"cj" = (
 /turf/open/floor/holofloor{
 	dir = 2;
 	icon_state = "red"
 	},
 /area/holodeck/rec_center/basketball)
-"cq" = (
+"ck" = (
 /turf/open/floor/holofloor{
 	dir = 6;
 	icon_state = "red"
 	},
 /area/holodeck/rec_center/basketball)
-"cr" = (
+"cl" = (
 /obj/item/clothing/under/color/rainbow,
 /obj/item/clothing/glasses/sunglasses,
 /turf/open/floor/holofloor/beach,
 /area/holodeck/rec_center/beach)
-"cs" = (
+"cm" = (
 /obj/structure/window,
 /turf/open/floor/holofloor/basalt,
 /area/holodeck/rec_center/thunderdome)
-"ct" = (
+"cn" = (
 /obj/structure/window{
 	dir = 1
 	},
@@ -713,7 +713,7 @@
 	icon_state = "red"
 	},
 /area/holodeck/rec_center/dodgeball)
-"cu" = (
+"co" = (
 /obj/structure/window{
 	dir = 1
 	},
@@ -723,7 +723,7 @@
 	icon_state = "red"
 	},
 /area/holodeck/rec_center/dodgeball)
-"cv" = (
+"cp" = (
 /obj/structure/window{
 	dir = 1
 	},
@@ -733,65 +733,65 @@
 	icon_state = "red"
 	},
 /area/holodeck/rec_center/dodgeball)
-"cw" = (
+"cq" = (
 /obj/effect/holodeck_effect/mobspawner/bee,
 /obj/effect/decal/remains/human,
 /obj/item/clothing/suit/beekeeper_suit,
 /turf/open/floor/holofloor/asteroid,
 /area/holodeck/rec_center/anthophila)
-"cx" = (
+"cr" = (
 /obj/effect/holodeck_effect/mobspawner/bee,
 /obj/item/melee/flyswatter,
 /turf/open/floor/holofloor/asteroid,
 /area/holodeck/rec_center/anthophila)
-"cy" = (
+"cs" = (
 /obj/machinery/chem_master,
 /turf/open/floor/holofloor{
 	icon_state = "white"
 	},
 /area/holodeck/rec_center/medical)
-"cA" = (
+"ct" = (
 /obj/structure/table/glass,
 /obj/item/device/healthanalyzer,
 /turf/open/floor/holofloor{
 	icon_state = "white"
 	},
 /area/holodeck/rec_center/medical)
-"cB" = (
+"cu" = (
 /obj/structure/closet/wardrobe/white,
 /turf/open/floor/holofloor{
 	icon_state = "white"
 	},
 /area/holodeck/rec_center/medical)
-"cC" = (
+"cv" = (
 /turf/open/floor/holofloor{
 	dir = 9;
 	icon_state = "green"
 	},
 /area/holodeck/rec_center/basketball)
-"cD" = (
+"cw" = (
 /turf/open/floor/holofloor{
 	dir = 1;
 	icon_state = "green"
 	},
 /area/holodeck/rec_center/basketball)
-"cE" = (
+"cx" = (
 /turf/open/floor/holofloor{
 	dir = 5;
 	icon_state = "green"
 	},
 /area/holodeck/rec_center/basketball)
-"cF" = (
+"cy" = (
 /obj/item/toy/beach_ball,
 /turf/open/floor/holofloor/beach,
 /area/holodeck/rec_center/beach)
-"cG" = (
+"cz" = (
 /obj/structure/window{
 	dir = 1
 	},
 /turf/open/floor/holofloor/basalt,
 /area/holodeck/rec_center/thunderdome)
-"cH" = (
+"cA" = (
 /obj/structure/window,
 /obj/item/toy/beach_ball/holoball/dodgeball,
 /turf/open/floor/holofloor{
@@ -799,7 +799,7 @@
 	icon_state = "green"
 	},
 /area/holodeck/rec_center/dodgeball)
-"cI" = (
+"cB" = (
 /obj/structure/window,
 /obj/item/toy/beach_ball/holoball/dodgeball,
 /turf/open/floor/holofloor{
@@ -807,7 +807,7 @@
 	icon_state = "green"
 	},
 /area/holodeck/rec_center/dodgeball)
-"cJ" = (
+"cC" = (
 /obj/structure/window,
 /obj/item/toy/beach_ball/holoball/dodgeball,
 /turf/open/floor/holofloor{
@@ -815,61 +815,61 @@
 	icon_state = "green"
 	},
 /area/holodeck/rec_center/dodgeball)
-"cK" = (
+"cD" = (
 /obj/structure/sink/puddle,
 /turf/open/floor/holofloor/grass,
 /area/holodeck/rec_center/pet_lounge)
-"cL" = (
+"cE" = (
 /obj/item/reagent_containers/glass/bucket,
 /turf/open/floor/holofloor/grass,
 /area/holodeck/rec_center/pet_lounge)
-"cM" = (
+"cF" = (
 /turf/open/floor/holofloor{
 	dir = 8;
 	icon_state = "green"
 	},
 /area/holodeck/rec_center/basketball)
-"cN" = (
+"cG" = (
 /obj/item/toy/beach_ball/holoball,
 /turf/open/floor/holofloor,
 /area/holodeck/rec_center/basketball)
-"cO" = (
+"cH" = (
 /turf/open/floor/holofloor{
 	dir = 4;
 	icon_state = "green"
 	},
 /area/holodeck/rec_center/basketball)
-"cP" = (
+"cI" = (
 /turf/open/floor/holofloor{
 	dir = 8;
 	icon_state = "green"
 	},
 /area/holodeck/rec_center/dodgeball)
-"cQ" = (
+"cJ" = (
 /turf/open/floor/holofloor{
 	dir = 4;
 	icon_state = "green"
 	},
 /area/holodeck/rec_center/dodgeball)
-"cR" = (
+"cK" = (
 /obj/machinery/hydroponics/soil,
 /turf/open/floor/holofloor/grass,
 /area/holodeck/rec_center/pet_lounge)
-"cS" = (
+"cL" = (
 /obj/machinery/hydroponics/soil,
 /obj/item/cultivator,
 /turf/open/floor/holofloor/grass,
 /area/holodeck/rec_center/pet_lounge)
-"cT" = (
+"cM" = (
 /obj/machinery/hydroponics/soil,
 /obj/effect/holodeck_effect/mobspawner/pet,
 /turf/open/floor/holofloor/grass,
 /area/holodeck/rec_center/pet_lounge)
-"cU" = (
+"cN" = (
 /obj/structure/flora/ausbushes/grassybush,
 /turf/open/floor/holofloor/grass,
 /area/holodeck/rec_center/pet_lounge)
-"cV" = (
+"cO" = (
 /obj/structure/bed,
 /obj/item/bedsheet/medical,
 /obj/structure/window{
@@ -879,7 +879,7 @@
 	icon_state = "white"
 	},
 /area/holodeck/rec_center/medical)
-"cW" = (
+"cP" = (
 /obj/structure/window{
 	dir = 8
 	},
@@ -892,7 +892,7 @@
 	icon_state = "white"
 	},
 /area/holodeck/rec_center/medical)
-"cX" = (
+"cQ" = (
 /obj/structure/window{
 	dir = 8
 	},
@@ -901,51 +901,43 @@
 	icon_state = "white"
 	},
 /area/holodeck/rec_center/medical)
-"cY" = (
+"cR" = (
 /turf/open/floor/holofloor{
 	dir = 2;
 	icon_state = "green"
 	},
 /area/holodeck/rec_center/basketball)
-"cZ" = (
+"cS" = (
 /turf/open/floor/holofloor/beach/coast_t,
 /area/holodeck/rec_center/beach)
-"da" = (
+"cT" = (
 /obj/item/reagent_containers/glass/bucket,
 /turf/open/floor/holofloor/beach/coast_t,
 /area/holodeck/rec_center/beach)
-"db" = (
+"cU" = (
 /obj/item/shovel/spade,
 /turf/open/floor/holofloor/beach/coast_t,
 /area/holodeck/rec_center/beach)
-"dc" = (
+"cV" = (
 /turf/open/floor/holofloor{
 	dir = 1;
 	icon_state = "green"
 	},
 /area/holodeck/rec_center/dodgeball)
-"dd" = (
+"cW" = (
 /obj/structure/flora/ausbushes/pointybush,
 /turf/open/floor/holofloor/grass,
 /area/holodeck/rec_center/pet_lounge)
-"de" = (
-/obj/structure/shuttle/engine/heater,
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/obj/effect/turf_decal/stripes/line,
-/turf/open/floor/plating/airless,
-/area/shuttle/syndicate/hallway)
-"dg" = (
+"cX" = (
 /obj/machinery/door/window/westleft,
 /turf/open/floor/holofloor{
 	icon_state = "white"
 	},
 /area/holodeck/rec_center/medical)
-"di" = (
+"cY" = (
 /turf/open/floor/holofloor/beach/coast_b,
 /area/holodeck/rec_center/beach)
-"dj" = (
+"cZ" = (
 /obj/structure/bed,
 /obj/item/bedsheet/medical,
 /obj/machinery/iv_drip,
@@ -953,7 +945,7 @@
 	icon_state = "white"
 	},
 /area/holodeck/rec_center/medical)
-"dk" = (
+"da" = (
 /obj/structure/window{
 	dir = 8
 	},
@@ -964,7 +956,7 @@
 	icon_state = "white"
 	},
 /area/holodeck/rec_center/medical)
-"dl" = (
+"db" = (
 /obj/structure/window{
 	dir = 8
 	},
@@ -975,13 +967,13 @@
 	icon_state = "white"
 	},
 /area/holodeck/rec_center/medical)
-"dm" = (
+"dc" = (
 /obj/machinery/iv_drip,
 /turf/open/floor/holofloor{
 	icon_state = "white"
 	},
 /area/holodeck/rec_center/medical)
-"dn" = (
+"dd" = (
 /obj/machinery/sleeper{
 	dir = 1
 	},
@@ -989,13 +981,13 @@
 	icon_state = "white"
 	},
 /area/holodeck/rec_center/medical)
-"do" = (
+"de" = (
 /turf/open/floor/holofloor{
 	dir = 10;
 	icon_state = "green"
 	},
 /area/holodeck/rec_center/basketball)
-"dp" = (
+"df" = (
 /obj/structure/holohoop{
 	dir = 1;
 	layer = 4.1
@@ -1005,16 +997,16 @@
 	icon_state = "green"
 	},
 /area/holodeck/rec_center/basketball)
-"dq" = (
+"dg" = (
 /turf/open/floor/holofloor{
 	dir = 6;
 	icon_state = "green"
 	},
 /area/holodeck/rec_center/basketball)
-"dr" = (
+"dh" = (
 /turf/open/floor/holofloor/beach/water,
 /area/holodeck/rec_center/beach)
-"dt" = (
+"di" = (
 /obj/structure/table,
 /obj/item/clothing/head/helmet/thunderdome,
 /obj/item/clothing/suit/armor/tdome/green,
@@ -1022,68 +1014,68 @@
 /obj/item/holo/esword/green,
 /turf/open/floor/holofloor/basalt,
 /area/holodeck/rec_center/thunderdome)
-"dv" = (
+"dj" = (
 /turf/open/floor/holofloor{
 	dir = 10;
 	icon_state = "green"
 	},
 /area/holodeck/rec_center/dodgeball)
-"dw" = (
+"dk" = (
 /turf/open/floor/holofloor{
 	dir = 2;
 	icon_state = "green"
 	},
 /area/holodeck/rec_center/dodgeball)
-"dx" = (
+"dl" = (
 /obj/machinery/readybutton,
 /turf/open/floor/holofloor{
 	dir = 6;
 	icon_state = "green"
 	},
 /area/holodeck/rec_center/dodgeball)
-"dy" = (
+"dm" = (
 /turf/open/floor/holofloor/plating,
 /area/holodeck/rec_center/refuel)
-"dz" = (
+"dn" = (
 /turf/open/floor/holofloor/plating,
 /area/holodeck/rec_center/spacechess)
-"dA" = (
+"do" = (
 /obj/item/banner/blue,
 /turf/open/floor/holofloor/grass,
 /area/holodeck/rec_center/thunderdome1218)
-"dB" = (
+"dp" = (
 /obj/structure/table/wood/fancy,
 /obj/item/clothing/suit/armor/riot/knight/blue,
 /obj/item/clothing/head/helmet/knight/blue,
 /obj/item/claymore/weak,
 /turf/open/floor/holofloor/grass,
 /area/holodeck/rec_center/thunderdome1218)
-"dC" = (
+"dq" = (
 /obj/structure/table/wood/fancy,
 /obj/item/clothing/head/crown/fancy{
 	pixel_y = 6
 	},
 /turf/open/floor/holofloor/grass,
 /area/holodeck/rec_center/thunderdome1218)
-"dD" = (
+"dr" = (
 /obj/structure/table/wood/fancy,
 /obj/item/clothing/suit/armor/riot/knight/red,
 /obj/item/clothing/head/helmet/knight/red,
 /obj/item/claymore/weak,
 /turf/open/floor/holofloor/grass,
 /area/holodeck/rec_center/thunderdome1218)
-"dE" = (
+"ds" = (
 /obj/item/banner/red,
 /turf/open/floor/holofloor/grass,
 /area/holodeck/rec_center/thunderdome1218)
-"dF" = (
+"dt" = (
 /turf/open/floor/holofloor/hyperspace,
 /area/holodeck/rec_center/kobayashi)
-"dG" = (
+"du" = (
 /obj/structure/window/reinforced,
 /turf/open/floor/holofloor/hyperspace,
 /area/holodeck/rec_center/kobayashi)
-"dH" = (
+"dv" = (
 /obj/structure/closet{
 	density = 0;
 	opened = 1
@@ -1095,7 +1087,7 @@
 	icon_state = "dark"
 	},
 /area/holodeck/rec_center/chapelcourt)
-"dI" = (
+"dw" = (
 /obj/structure/table/wood/fancy,
 /obj/item/clothing/suit/nun,
 /obj/item/clothing/head/nun_hood,
@@ -1105,7 +1097,7 @@
 	icon_state = "dark"
 	},
 /area/holodeck/rec_center/chapelcourt)
-"dJ" = (
+"dx" = (
 /obj/structure/table/wood/fancy,
 /obj/item/storage/book/bible,
 /turf/open/floor/holofloor{
@@ -1113,7 +1105,7 @@
 	icon_state = "dark"
 	},
 /area/holodeck/rec_center/chapelcourt)
-"dK" = (
+"dy" = (
 /obj/structure/table/wood/fancy,
 /obj/item/book/manual/wiki/security_space_law,
 /turf/open/floor/holofloor{
@@ -1121,7 +1113,7 @@
 	icon_state = "dark"
 	},
 /area/holodeck/rec_center/chapelcourt)
-"dL" = (
+"dz" = (
 /obj/structure/closet{
 	name = "Evidence Closet"
 	},
@@ -1130,16 +1122,16 @@
 	icon_state = "dark"
 	},
 /area/holodeck/rec_center/chapelcourt)
-"dM" = (
+"dA" = (
 /turf/open/floor/holofloor,
 /area/holodeck/rec_center/school)
-"dP" = (
+"dB" = (
 /turf/open/floor/holofloor{
 	dir = 8;
 	icon_state = "green"
 	},
 /area/holodeck/rec_center/firingrange)
-"dQ" = (
+"dC" = (
 /obj/structure/window/reinforced{
 	dir = 1
 	},
@@ -1150,7 +1142,7 @@
 	icon_state = "white"
 	},
 /area/holodeck/rec_center/firingrange)
-"dR" = (
+"dD" = (
 /obj/structure/window/reinforced{
 	dir = 1
 	},
@@ -1158,7 +1150,7 @@
 	icon_state = "white"
 	},
 /area/holodeck/rec_center/firingrange)
-"dS" = (
+"dE" = (
 /obj/structure/window/reinforced{
 	dir = 1
 	},
@@ -1169,17 +1161,17 @@
 	icon_state = "white"
 	},
 /area/holodeck/rec_center/firingrange)
-"dT" = (
+"dF" = (
 /turf/open/floor/holofloor{
 	dir = 4;
 	icon_state = "green"
 	},
 /area/holodeck/rec_center/firingrange)
-"dU" = (
+"dG" = (
 /obj/structure/reagent_dispensers/fueltank,
 /turf/open/floor/holofloor/plating,
 /area/holodeck/rec_center/refuel)
-"dV" = (
+"dH" = (
 /obj/item/cardboard_cutout/adaptive{
 	color = "#9999BB";
 	icon_state = "cutout_viva";
@@ -1190,7 +1182,7 @@
 	icon_state = "dark"
 	},
 /area/holodeck/rec_center/spacechess)
-"dW" = (
+"dI" = (
 /obj/item/cardboard_cutout/adaptive{
 	color = "#9999BB";
 	icon_state = "cutout_mime";
@@ -1200,7 +1192,7 @@
 	icon_state = "white"
 	},
 /area/holodeck/rec_center/spacechess)
-"dX" = (
+"dJ" = (
 /obj/item/cardboard_cutout/adaptive{
 	color = "#9999BB";
 	icon_state = "cutout_clown";
@@ -1211,7 +1203,7 @@
 	icon_state = "dark"
 	},
 /area/holodeck/rec_center/spacechess)
-"dY" = (
+"dK" = (
 /obj/item/cardboard_cutout/adaptive{
 	color = "#9999BB";
 	icon_state = "cutout_ian";
@@ -1221,14 +1213,14 @@
 	icon_state = "white"
 	},
 /area/holodeck/rec_center/spacechess)
-"dZ" = (
+"dL" = (
 /turf/open/floor/holofloor/grass,
 /area/holodeck/rec_center/thunderdome1218)
-"ea" = (
+"dM" = (
 /obj/structure/chair/wood/wings,
 /turf/open/floor/holofloor/grass,
 /area/holodeck/rec_center/thunderdome1218)
-"eb" = (
+"dN" = (
 /obj/structure/window/reinforced,
 /obj/machinery/mass_driver{
 	dir = 1;
@@ -1245,7 +1237,7 @@
 	},
 /turf/open/floor/holofloor/hyperspace,
 /area/holodeck/rec_center/kobayashi)
-"ec" = (
+"dO" = (
 /obj/structure/window/reinforced{
 	dir = 8
 	},
@@ -1260,7 +1252,7 @@
 	},
 /turf/open/floor/holofloor/plating,
 /area/holodeck/rec_center/kobayashi)
-"ed" = (
+"dP" = (
 /obj/machinery/button/massdriver{
 	id = "trektorpedo1";
 	layer = 3.9;
@@ -1286,7 +1278,7 @@
 	},
 /turf/open/floor/holofloor/plating,
 /area/holodeck/rec_center/kobayashi)
-"ee" = (
+"dQ" = (
 /obj/structure/window/reinforced{
 	dir = 4
 	},
@@ -1301,7 +1293,7 @@
 	},
 /turf/open/floor/holofloor/plating,
 /area/holodeck/rec_center/kobayashi)
-"ef" = (
+"dR" = (
 /obj/structure/window/reinforced,
 /obj/machinery/mass_driver{
 	dir = 1;
@@ -1318,7 +1310,7 @@
 	},
 /turf/open/floor/holofloor/hyperspace,
 /area/holodeck/rec_center/kobayashi)
-"eg" = (
+"dS" = (
 /obj/structure/chair{
 	dir = 4
 	},
@@ -1327,26 +1319,26 @@
 	dir = 1
 	},
 /area/holodeck/rec_center/chapelcourt)
-"eh" = (
+"dT" = (
 /turf/open/floor/holofloor{
 	icon_state = "chapel";
 	dir = 4
 	},
 /area/holodeck/rec_center/chapelcourt)
-"ei" = (
+"dU" = (
 /obj/structure/chair,
 /turf/open/floor/holofloor{
 	dir = 8;
 	icon_state = "dark"
 	},
 /area/holodeck/rec_center/chapelcourt)
-"ej" = (
+"dV" = (
 /turf/open/floor/holofloor{
 	icon_state = "chapel";
 	dir = 1
 	},
 /area/holodeck/rec_center/chapelcourt)
-"ek" = (
+"dW" = (
 /obj/structure/chair{
 	dir = 8
 	},
@@ -1355,13 +1347,23 @@
 	dir = 4
 	},
 /area/holodeck/rec_center/chapelcourt)
-"em" = (
+"dX" = (
 /obj/structure/table/wood,
 /obj/item/folder,
 /obj/item/melee/classic_baton/telescopic,
 /turf/open/floor/holofloor,
 /area/holodeck/rec_center/school)
-"eo" = (
+"dY" = (
+/obj/structure/table/wood,
+/obj/item/toy/crayon/white,
+/turf/open/floor/holofloor,
+/area/holodeck/rec_center/school)
+"dZ" = (
+/obj/structure/table/wood,
+/obj/item/reagent_containers/food/snacks/grown/apple,
+/turf/open/floor/holofloor,
+/area/holodeck/rec_center/school)
+"ea" = (
 /obj/structure/window/reinforced{
 	dir = 8
 	},
@@ -1370,14 +1372,14 @@
 	dir = 8
 	},
 /area/holodeck/rec_center/firingrange)
-"ep" = (
+"eb" = (
 /obj/structure/target_stake,
 /obj/machinery/magnetic_module,
 /turf/open/floor/holofloor{
 	icon_state = "white"
 	},
 /area/holodeck/rec_center/firingrange)
-"eq" = (
+"ec" = (
 /obj/structure/window/reinforced{
 	dir = 4
 	},
@@ -1386,7 +1388,7 @@
 	dir = 4
 	},
 /area/holodeck/rec_center/firingrange)
-"er" = (
+"ed" = (
 /obj/item/cardboard_cutout/adaptive{
 	color = "#9999BB";
 	icon_state = "cutout_greytide";
@@ -1396,7 +1398,7 @@
 	icon_state = "white"
 	},
 /area/holodeck/rec_center/spacechess)
-"es" = (
+"ee" = (
 /obj/item/cardboard_cutout/adaptive{
 	color = "#9999BB";
 	icon_state = "cutout_greytide";
@@ -1407,43 +1409,43 @@
 	icon_state = "dark"
 	},
 /area/holodeck/rec_center/spacechess)
-"et" = (
+"ef" = (
 /obj/machinery/door/window/westleft{
 	dir = 2;
 	icon_state = "right"
 	},
 /turf/open/floor/holofloor/grass,
 /area/holodeck/rec_center/thunderdome1218)
-"eu" = (
+"eg" = (
 /obj/structure/window/reinforced,
 /turf/open/floor/holofloor/grass,
 /area/holodeck/rec_center/thunderdome1218)
-"ev" = (
+"eh" = (
 /obj/machinery/door/window/westleft{
 	dir = 2
 	},
 /turf/open/floor/holofloor/grass,
 /area/holodeck/rec_center/thunderdome1218)
-"ew" = (
+"ei" = (
 /obj/structure/table/glass,
 /obj/machinery/recharger,
 /turf/open/floor/holofloor/plating,
 /area/holodeck/rec_center/kobayashi)
-"ex" = (
+"ej" = (
 /turf/open/floor/holofloor/plating,
 /area/holodeck/rec_center/kobayashi)
-"ey" = (
+"ek" = (
 /obj/structure/chair/comfy{
 	dir = 1
 	},
 /turf/open/floor/holofloor/plating,
 /area/holodeck/rec_center/kobayashi)
-"ez" = (
+"el" = (
 /obj/structure/table/glass,
 /obj/item/gun/energy/e_gun/mini/practice_phaser,
 /turf/open/floor/holofloor/plating,
 /area/holodeck/rec_center/kobayashi)
-"eA" = (
+"em" = (
 /obj/structure/chair{
 	dir = 4
 	},
@@ -1452,13 +1454,13 @@
 	icon_state = "chapel"
 	},
 /area/holodeck/rec_center/chapelcourt)
-"eB" = (
+"en" = (
 /turf/open/floor/holofloor{
 	icon_state = "chapel";
 	dir = 2
 	},
 /area/holodeck/rec_center/chapelcourt)
-"eC" = (
+"eo" = (
 /obj/item/gavelblock,
 /obj/item/gavelhammer,
 /obj/structure/table/wood,
@@ -1467,13 +1469,13 @@
 	icon_state = "dark"
 	},
 /area/holodeck/rec_center/chapelcourt)
-"eD" = (
+"ep" = (
 /turf/open/floor/holofloor{
 	dir = 8;
 	icon_state = "chapel"
 	},
 /area/holodeck/rec_center/chapelcourt)
-"eE" = (
+"eq" = (
 /obj/structure/chair{
 	dir = 8
 	},
@@ -1482,7 +1484,7 @@
 	dir = 2
 	},
 /area/holodeck/rec_center/chapelcourt)
-"eG" = (
+"er" = (
 /obj/structure/window/reinforced{
 	dir = 8
 	},
@@ -1491,12 +1493,12 @@
 	dir = 10
 	},
 /area/holodeck/rec_center/firingrange)
-"eH" = (
+"es" = (
 /turf/open/floor/holofloor{
 	icon_state = "white"
 	},
 /area/holodeck/rec_center/firingrange)
-"eI" = (
+"et" = (
 /obj/structure/window/reinforced{
 	dir = 4
 	},
@@ -1505,28 +1507,28 @@
 	dir = 6
 	},
 /area/holodeck/rec_center/firingrange)
-"eJ" = (
+"eu" = (
 /obj/item/weldingtool,
 /turf/open/floor/holofloor/plating,
 /area/holodeck/rec_center/refuel)
-"eK" = (
+"ev" = (
 /turf/open/floor/holofloor{
 	dir = 8;
 	icon_state = "dark"
 	},
 /area/holodeck/rec_center/spacechess)
-"eL" = (
+"ew" = (
 /turf/open/floor/holofloor{
 	icon_state = "white"
 	},
 /area/holodeck/rec_center/spacechess)
-"eM" = (
+"ex" = (
 /turf/open/floor/holofloor{
 	icon_state = "stairs-old";
 	dir = 8
 	},
 /area/holodeck/rec_center/thunderdome1218)
-"eN" = (
+"ey" = (
 /obj/structure/table/wood,
 /obj/item/melee/chainofcommand{
 	name = "chain whip"
@@ -1534,25 +1536,39 @@
 /obj/item/twohanded/spear,
 /turf/open/floor/holofloor/asteroid,
 /area/holodeck/rec_center/thunderdome1218)
-"eO" = (
+"ez" = (
 /obj/structure/table/wood,
 /obj/item/scythe,
 /obj/item/twohanded/spear,
 /turf/open/floor/holofloor/asteroid,
 /area/holodeck/rec_center/thunderdome1218)
-"eP" = (
+"eA" = (
 /obj/structure/table/wood,
 /obj/item/tailclub,
 /obj/item/twohanded/spear,
 /turf/open/floor/holofloor/asteroid,
 /area/holodeck/rec_center/thunderdome1218)
-"eQ" = (
+"eB" = (
 /turf/open/floor/holofloor{
 	dir = 8;
 	icon_state = "dark"
 	},
 /area/holodeck/rec_center/chapelcourt)
-"eR" = (
+"eC" = (
+/obj/structure/table,
+/obj/item/paper,
+/obj/item/pen,
+/obj/item/clothing/under/schoolgirl,
+/turf/open/floor/holofloor,
+/area/holodeck/rec_center/school)
+"eD" = (
+/obj/structure/table,
+/obj/item/paper,
+/obj/item/pen,
+/obj/item/clothing/under/schoolgirl/green,
+/turf/open/floor/holofloor,
+/area/holodeck/rec_center/school)
+"eE" = (
 /obj/structure/window/reinforced{
 	dir = 8
 	},
@@ -1561,10 +1577,10 @@
 	icon_state = "red"
 	},
 /area/holodeck/rec_center/firingrange)
-"eS" = (
+"eF" = (
 /turf/open/floor/holofloor,
 /area/holodeck/rec_center/firingrange)
-"eT" = (
+"eG" = (
 /obj/structure/window/reinforced{
 	dir = 4
 	},
@@ -1573,30 +1589,30 @@
 	icon_state = "red"
 	},
 /area/holodeck/rec_center/firingrange)
-"eU" = (
+"eH" = (
 /turf/open/floor/holofloor/asteroid,
 /area/holodeck/rec_center/thunderdome1218)
-"eV" = (
+"eI" = (
 /obj/machinery/modular_computer/console/preset/civilian,
 /turf/open/floor/holofloor/plating,
 /area/holodeck/rec_center/kobayashi)
-"eW" = (
+"eJ" = (
 /obj/structure/chair/office/dark{
 	dir = 8
 	},
 /turf/open/floor/holofloor/plating,
 /area/holodeck/rec_center/kobayashi)
-"eX" = (
+"eK" = (
 /obj/structure/chair/office/dark{
 	dir = 4
 	},
 /turf/open/floor/holofloor/plating,
 /area/holodeck/rec_center/kobayashi)
-"eY" = (
+"eL" = (
 /obj/machinery/computer/station_alert,
 /turf/open/floor/holofloor/plating,
 /area/holodeck/rec_center/kobayashi)
-"eZ" = (
+"eM" = (
 /obj/structure/chair{
 	dir = 1
 	},
@@ -1605,7 +1621,7 @@
 	dir = 1
 	},
 /area/holodeck/rec_center/chapelcourt)
-"fa" = (
+"eN" = (
 /obj/structure/chair{
 	dir = 1
 	},
@@ -1614,17 +1630,23 @@
 	dir = 4
 	},
 /area/holodeck/rec_center/chapelcourt)
-"fb" = (
+"eO" = (
+/obj/structure/chair{
+	dir = 1
+	},
+/turf/open/floor/holofloor,
+/area/holodeck/rec_center/school)
+"eP" = (
 /obj/machinery/modular_computer/console/preset/civilian,
 /obj/structure/window/reinforced,
 /turf/open/floor/holofloor/plating,
 /area/holodeck/rec_center/kobayashi)
-"fc" = (
+"eQ" = (
 /obj/machinery/computer/atmos_alert,
 /obj/structure/window/reinforced,
 /turf/open/floor/holofloor/plating,
 /area/holodeck/rec_center/kobayashi)
-"fd" = (
+"eR" = (
 /obj/structure/chair{
 	dir = 1
 	},
@@ -1633,7 +1655,7 @@
 	icon_state = "chapel"
 	},
 /area/holodeck/rec_center/chapelcourt)
-"fe" = (
+"eS" = (
 /obj/structure/chair{
 	dir = 1
 	},
@@ -1642,18 +1664,25 @@
 	dir = 2
 	},
 /area/holodeck/rec_center/chapelcourt)
-"fg" = (
+"eT" = (
 /obj/structure/table,
 /obj/item/paper,
 /obj/item/pen,
 /obj/item/clothing/under/schoolgirl/orange,
 /turf/open/floor/holofloor,
 /area/holodeck/rec_center/school)
-"fh" = (
+"eU" = (
+/obj/structure/table,
+/obj/item/paper,
+/obj/item/pen,
+/obj/item/clothing/under/schoolgirl/red,
+/turf/open/floor/holofloor,
+/area/holodeck/rec_center/school)
+"eV" = (
 /obj/structure/window/reinforced,
 /turf/open/floor/holofloor/plating,
 /area/holodeck/rec_center/kobayashi)
-"fi" = (
+"eW" = (
 /obj/item/cardboard_cutout/adaptive{
 	icon_state = "cutout_greytide";
 	name = "White Pawn"
@@ -1663,7 +1692,7 @@
 	icon_state = "dark"
 	},
 /area/holodeck/rec_center/spacechess)
-"fj" = (
+"eX" = (
 /obj/item/cardboard_cutout/adaptive{
 	icon_state = "cutout_greytide";
 	name = "White Pawn"
@@ -1672,24 +1701,24 @@
 	icon_state = "white"
 	},
 /area/holodeck/rec_center/spacechess)
-"fk" = (
+"eY" = (
 /obj/structure/window/reinforced,
 /turf/open/floor/holofloor/asteroid,
 /area/holodeck/rec_center/thunderdome1218)
-"fl" = (
+"eZ" = (
 /obj/machinery/door/window/westleft{
 	dir = 2
 	},
 /turf/open/floor/holofloor/asteroid,
 /area/holodeck/rec_center/thunderdome1218)
-"fm" = (
+"fa" = (
 /obj/machinery/door/window/westleft{
 	dir = 2;
 	icon_state = "right"
 	},
 /turf/open/floor/holofloor/plating,
 /area/holodeck/rec_center/kobayashi)
-"fn" = (
+"fb" = (
 /obj/structure/table,
 /obj/item/folder,
 /obj/item/pen/blue,
@@ -1701,7 +1730,7 @@
 	dir = 1
 	},
 /area/holodeck/rec_center/kobayashi)
-"fo" = (
+"fc" = (
 /obj/structure/table,
 /obj/item/folder,
 /obj/item/pen,
@@ -1710,7 +1739,7 @@
 	dir = 1
 	},
 /area/holodeck/rec_center/kobayashi)
-"fp" = (
+"fd" = (
 /obj/structure/table,
 /obj/structure/window/reinforced{
 	dir = 4
@@ -1722,13 +1751,13 @@
 	dir = 1
 	},
 /area/holodeck/rec_center/kobayashi)
-"fq" = (
+"fe" = (
 /obj/machinery/door/window/westleft{
 	dir = 2
 	},
 /turf/open/floor/holofloor/plating,
 /area/holodeck/rec_center/kobayashi)
-"fr" = (
+"ff" = (
 /obj/structure/table,
 /obj/item/paper,
 /obj/item/pen,
@@ -1736,7 +1765,7 @@
 /obj/item/toy/katana,
 /turf/open/floor/holofloor,
 /area/holodeck/rec_center/school)
-"fs" = (
+"fg" = (
 /obj/structure/table/reinforced,
 /obj/machinery/recharger,
 /obj/structure/window/reinforced{
@@ -1750,11 +1779,11 @@
 	icon_state = "red"
 	},
 /area/holodeck/rec_center/firingrange)
-"ft" = (
+"fh" = (
 /obj/item/paper/guides/jobs/security/range,
 /turf/open/floor/holofloor,
 /area/holodeck/rec_center/firingrange)
-"fu" = (
+"fi" = (
 /obj/structure/table/reinforced,
 /obj/machinery/magnetic_controller{
 	autolink = 1
@@ -1770,7 +1799,7 @@
 	icon_state = "red"
 	},
 /area/holodeck/rec_center/firingrange)
-"fv" = (
+"fj" = (
 /obj/item/cardboard_cutout/adaptive{
 	icon_state = "cutout_viva";
 	name = "White Rook"
@@ -1779,7 +1808,7 @@
 	icon_state = "white"
 	},
 /area/holodeck/rec_center/spacechess)
-"fw" = (
+"fk" = (
 /obj/item/cardboard_cutout/adaptive{
 	icon_state = "cutout_mime";
 	name = "White Queen"
@@ -1789,7 +1818,7 @@
 	icon_state = "dark"
 	},
 /area/holodeck/rec_center/spacechess)
-"fx" = (
+"fl" = (
 /obj/item/cardboard_cutout/adaptive{
 	icon_state = "cutout_clown";
 	name = "White King"
@@ -1798,7 +1827,7 @@
 	icon_state = "white"
 	},
 /area/holodeck/rec_center/spacechess)
-"fy" = (
+"fm" = (
 /obj/item/cardboard_cutout/adaptive{
 	icon_state = "cutout_ian";
 	name = "White Knight"
@@ -1808,37 +1837,31 @@
 	icon_state = "dark"
 	},
 /area/holodeck/rec_center/spacechess)
-"fz" = (
+"fn" = (
 /turf/open/floor/holofloor{
 	icon_state = "neutral";
 	dir = 1
 	},
 /area/holodeck/rec_center/kobayashi)
-"fA" = (
+"fo" = (
 /obj/structure/chair{
 	dir = 1
 	},
 /turf/open/floor/holofloor,
 /area/holodeck/rec_center/kobayashi)
-"fB" = (
+"fp" = (
 /turf/open/floor/holofloor{
 	dir = 1;
 	icon_state = "green"
 	},
 /area/holodeck/rec_center/firingrange)
-"fC" = (
-/obj/structure/table/reinforced,
-/turf/open/floor/plasteel/vault{
-	dir = 8
-	},
-/area/shuttle/syndicate/bridge)
-"fD" = (
+"fq" = (
 /obj/structure/chair/wood/normal{
 	dir = 1
 	},
 /turf/open/floor/holofloor/grass,
 /area/holodeck/rec_center/thunderdome1218)
-"fE" = (
+"fr" = (
 /obj/structure/rack,
 /obj/item/clothing/under/trek/medsci,
 /obj/item/clothing/under/trek/medsci,
@@ -1848,13 +1871,13 @@
 	dir = 1
 	},
 /area/holodeck/rec_center/kobayashi)
-"fF" = (
+"fs" = (
 /turf/open/floor/holofloor{
 	icon_state = "neutral";
 	dir = 2
 	},
 /area/holodeck/rec_center/kobayashi)
-"fG" = (
+"ft" = (
 /obj/structure/rack,
 /obj/item/clothing/under/trek/engsec,
 /obj/item/clothing/under/trek/engsec,
@@ -1863,49 +1886,41 @@
 	dir = 1
 	},
 /area/holodeck/rec_center/kobayashi)
-"fH" = (
-/obj/structure/sink{
-	dir = 4;
-	pixel_x = 11
-	},
-/obj/structure/mirror{
-	pixel_x = 30
-	},
-/turf/open/floor/plasteel/vault{
-	dir = 5
-	},
-/area/shuttle/syndicate/medical)
-"fK" = (
+"fu" = (
 /obj/item/target,
 /obj/item/target/clown,
 /turf/open/floor/holofloor,
 /area/holodeck/rec_center/firingrange)
-"fL" = (
+"fv" = (
 /obj/item/target,
 /obj/item/target/syndicate,
 /turf/open/floor/holofloor,
 /area/holodeck/rec_center/firingrange)
-"fM" = (
+"fw" = (
 /obj/structure/rack,
 /obj/item/gun/energy/laser/practice,
 /obj/item/clothing/ears/earmuffs,
 /turf/open/floor/holofloor,
 /area/holodeck/rec_center/firingrange)
-"fN" = (
+"fx" = (
 /obj/structure/window/reinforced{
 	dir = 1
 	},
 /turf/closed/indestructible/riveted,
 /area/space)
-"fP" = (
+"fy" = (
 /obj/machinery/igniter,
 /obj/effect/turf_decal/delivery,
 /turf/open/floor/plasteel,
 /area/tdome/arena_source)
-"fQ" = (
+"fz" = (
 /turf/open/floor/plasteel,
 /area/tdome/arena_source)
-"fR" = (
+"fA" = (
+/obj/effect/turf_decal/bot,
+/turf/open/floor/plasteel,
+/area/tdome/arena_source)
+"fB" = (
 /obj/structure/rack,
 /obj/item/clothing/under/color/red,
 /obj/item/clothing/shoes/sneakers/brown,
@@ -1918,31 +1933,48 @@
 	},
 /turf/open/floor/plasteel,
 /area/tdome/arena_source)
-"fS" = (
+"fC" = (
 /obj/machinery/door/poddoor{
 	id = "thunderdomegen";
 	name = "General Supply"
 	},
 /turf/open/floor/plasteel/black,
 /area/tdome/arena_source)
-"fT" = (
+"fD" = (
 /obj/machinery/door/poddoor{
 	id = "thunderdome";
 	name = "Thunderdome Blast Door"
 	},
 /turf/open/floor/plasteel,
 /area/tdome/arena_source)
-"fU" = (
+"fE" = (
 /turf/open/floor/plasteel/red/side{
 	dir = 8
 	},
 /area/tdome/arena_source)
-"fV" = (
+"fF" = (
+/obj/effect/turf_decal/delivery,
+/turf/open/floor/plasteel,
+/area/tdome/arena_source)
+"fG" = (
+/turf/open/floor/plasteel/neutral/side{
+	dir = 4
+	},
+/area/tdome/arena_source)
+"fH" = (
+/turf/open/floor/plasteel/neutral,
+/area/tdome/arena_source)
+"fI" = (
+/turf/open/floor/plasteel/neutral/side{
+	dir = 8
+	},
+/area/tdome/arena_source)
+"fJ" = (
 /turf/open/floor/plasteel/green/side{
 	dir = 4
 	},
 /area/tdome/arena_source)
-"fW" = (
+"fK" = (
 /obj/structure/rack,
 /obj/item/clothing/under/color/green,
 /obj/item/clothing/shoes/sneakers/brown,
@@ -1955,24 +1987,60 @@
 	},
 /turf/open/floor/plasteel,
 /area/tdome/arena_source)
-"fX" = (
+"fL" = (
+/turf/open/floor/plasteel/red/corner{
+	dir = 1
+	},
+/area/tdome/arena_source)
+"fM" = (
+/turf/open/floor/plasteel/green/corner{
+	dir = 4
+	},
+/area/tdome/arena_source)
+"fN" = (
+/turf/open/floor/plasteel/loadingarea{
+	dir = 4
+	},
+/area/tdome/arena_source)
+"fO" = (
 /turf/open/floor/circuit/green,
 /area/tdome/arena_source)
-"fY" = (
+"fP" = (
 /obj/machinery/flasher{
 	id = "tdomeflash";
 	name = "Thunderdome Flash"
 	},
 /turf/open/floor/circuit/green,
 /area/tdome/arena_source)
-"fZ" = (
+"fQ" = (
+/turf/open/floor/plasteel/loadingarea{
+	dir = 8
+	},
+/area/tdome/arena_source)
+"fR" = (
+/obj/machinery/camera{
+	pixel_x = 10;
+	network = list("thunder");
+	c_tag = "Arena"
+	},
+/turf/open/floor/circuit/green,
+/area/tdome/arena_source)
+"fS" = (
+/turf/open/floor/plasteel/red/corner{
+	dir = 8
+	},
+/area/tdome/arena_source)
+"fT" = (
+/turf/open/floor/plasteel/green/corner,
+/area/tdome/arena_source)
+"fU" = (
 /obj/machinery/door/poddoor{
 	id = "thunderdomehea";
 	name = "Heavy Supply"
 	},
 /turf/open/floor/plasteel/black,
 /area/tdome/arena_source)
-"ga" = (
+"fV" = (
 /obj/structure/rack,
 /obj/item/clothing/under/color/red,
 /obj/item/clothing/shoes/sneakers/brown,
@@ -1984,7 +2052,7 @@
 	},
 /turf/open/floor/plasteel,
 /area/tdome/arena_source)
-"gb" = (
+"fW" = (
 /obj/structure/rack,
 /obj/item/clothing/under/color/green,
 /obj/item/clothing/shoes/sneakers/brown,
@@ -1996,131 +2064,131 @@
 	},
 /turf/open/floor/plasteel,
 /area/tdome/arena_source)
-"gc" = (
+"fX" = (
 /turf/closed/indestructible/riveted,
 /area/start)
-"gd" = (
+"fY" = (
 /obj/effect/landmark/start/new_player,
 /turf/open/floor/plating,
 /area/start)
-"ge" = (
+"fZ" = (
 /turf/closed/indestructible/riveted,
 /area/ctf)
-"gf" = (
+"ga" = (
 /turf/open/floor/plasteel/darkblue/side{
 	dir = 9
+	},
+/area/ctf)
+"gb" = (
+/turf/open/floor/plasteel/darkblue/side{
+	dir = 1
+	},
+/area/ctf)
+"gc" = (
+/turf/open/floor/plasteel/darkblue/side{
+	dir = 5
+	},
+/area/ctf)
+"gd" = (
+/turf/open/floor/plasteel/darkred/side{
+	dir = 9
+	},
+/area/ctf)
+"ge" = (
+/turf/open/floor/plasteel/darkred/side{
+	dir = 1
+	},
+/area/ctf)
+"gf" = (
+/turf/open/floor/plasteel/darkred/side{
+	dir = 5
 	},
 /area/ctf)
 "gg" = (
 /turf/open/floor/plasteel/darkblue/side{
-	dir = 1
+	dir = 8
 	},
 /area/ctf)
 "gh" = (
-/turf/open/floor/plasteel/darkblue/side{
-	dir = 5
-	},
+/turf/open/floor/plasteel/black,
 /area/ctf)
 "gi" = (
-/turf/open/floor/plasteel/darkred/side{
-	dir = 9
+/turf/open/floor/plasteel/darkblue/side{
+	dir = 4
 	},
 /area/ctf)
 "gj" = (
-/turf/open/floor/plasteel/darkred/side{
-	dir = 1
-	},
-/area/ctf)
-"gk" = (
-/turf/open/floor/plasteel/darkred/side{
-	dir = 5
-	},
-/area/ctf)
-"gl" = (
-/turf/open/floor/plasteel/darkblue/side{
-	dir = 8
-	},
-/area/ctf)
-"gm" = (
-/turf/open/floor/plasteel/black,
-/area/ctf)
-"gn" = (
-/turf/open/floor/plasteel/darkblue/side{
-	dir = 4
-	},
-/area/ctf)
-"go" = (
 /turf/open/floor/plasteel/blue,
 /area/ctf)
-"gp" = (
+"gk" = (
 /turf/open/floor/plasteel/darkblue,
 /area/ctf)
-"gq" = (
+"gl" = (
 /obj/structure/barricade/security/ctf,
 /turf/open/floor/circuit,
 /area/ctf)
-"gr" = (
+"gm" = (
 /obj/structure/table/reinforced,
 /turf/open/floor/plasteel/bluespace,
 /area/ctf)
-"gs" = (
+"gn" = (
 /obj/structure/barricade/security/ctf,
 /turf/open/floor/plasteel/bluespace,
 /area/ctf)
-"gt" = (
+"go" = (
 /turf/open/floor/plasteel/bluespace,
 /area/ctf)
-"gu" = (
+"gp" = (
 /turf/open/floor/plasteel/darkred/side{
 	dir = 8
 	},
 /area/ctf)
-"gv" = (
+"gq" = (
 /obj/structure/barricade/security/ctf,
 /turf/open/floor/circuit/red,
 /area/ctf)
-"gw" = (
+"gr" = (
 /turf/open/floor/plasteel/darkred/side{
 	dir = 4
 	},
 /area/ctf)
-"gx" = (
+"gs" = (
 /turf/open/floor/plasteel/red,
 /area/ctf)
-"gy" = (
+"gt" = (
 /obj/structure/kitchenspike,
 /turf/open/floor/plasteel/black,
 /area/ctf)
-"gz" = (
+"gu" = (
 /turf/closed/indestructible/splashscreen,
 /area/start)
-"gA" = (
+"gv" = (
 /turf/open/floor/plasteel/darkblue/side{
 	dir = 10
+	},
+/area/ctf)
+"gw" = (
+/turf/open/floor/plasteel/darkblue/side,
+/area/ctf)
+"gx" = (
+/turf/open/floor/plasteel/darkblue/side{
+	dir = 6
+	},
+/area/ctf)
+"gy" = (
+/turf/open/floor/plasteel/darkred/side{
+	dir = 10
+	},
+/area/ctf)
+"gz" = (
+/turf/open/floor/plasteel/darkred/side,
+/area/ctf)
+"gA" = (
+/turf/open/floor/plasteel/darkred/side{
+	dir = 6
 	},
 /area/ctf)
 "gB" = (
-/turf/open/floor/plasteel/darkblue/side,
-/area/ctf)
-"gC" = (
-/turf/open/floor/plasteel/darkblue/side{
-	dir = 6
-	},
-/area/ctf)
-"gD" = (
-/turf/open/floor/plasteel/darkred/side{
-	dir = 10
-	},
-/area/ctf)
-"gE" = (
-/turf/open/floor/plasteel/darkred/side,
-/area/ctf)
-"gF" = (
-/turf/open/floor/plasteel/darkred/side{
-	dir = 6
-	},
-/area/ctf)
-"gG" = (
 /obj/structure/window/reinforced/fulltile{
 	obj_integrity = 5000;
 	max_integrity = 5000;
@@ -2128,11 +2196,11 @@
 	},
 /turf/open/floor/plating,
 /area/ctf)
-"gH" = (
+"gC" = (
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plasteel/black,
 /area/ctf)
-"gI" = (
+"gD" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
@@ -2141,7 +2209,7 @@
 	},
 /turf/open/floor/plasteel/darkblue/corner,
 /area/ctf)
-"gJ" = (
+"gE" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
@@ -2149,19 +2217,19 @@
 	dir = 8
 	},
 /area/ctf)
-"gK" = (
+"gF" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
 /turf/open/floor/plasteel/black,
 /area/ctf)
-"gL" = (
+"gG" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
 /turf/open/floor/plasteel/darkblue/corner,
 /area/ctf)
-"gM" = (
+"gH" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
@@ -2170,13 +2238,41 @@
 	},
 /turf/open/floor/plasteel/black,
 /area/ctf)
-"gN" = (
+"gI" = (
 /obj/machinery/power/emitter/energycannon,
+/turf/open/floor/plating,
+/area/ctf)
+"gJ" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/turf/open/floor/plasteel/black,
+/area/ctf)
+"gK" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/turf/open/floor/plasteel/darkblue/corner{
+	dir = 4
+	},
+/area/ctf)
+"gL" = (
+/turf/open/floor/plasteel/darkblue/corner{
+	dir = 8
+	},
+/area/ctf)
+"gM" = (
+/turf/open/floor/plasteel/darkblue/corner{
+	dir = 4
+	},
+/area/ctf)
+"gN" = (
+/obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plating,
 /area/ctf)
 "gO" = (
 /obj/effect/turf_decal/stripes/line{
-	dir = 4
+	dir = 8
 	},
 /turf/open/floor/plasteel/black,
 /area/ctf)
@@ -2184,40 +2280,12 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
-/turf/open/floor/plasteel/darkblue/corner{
-	dir = 4
-	},
+/turf/open/floor/plating,
 /area/ctf)
 "gQ" = (
-/turf/open/floor/plasteel/darkblue/corner{
-	dir = 8
-	},
+/turf/open/floor/plating,
 /area/ctf)
 "gR" = (
-/turf/open/floor/plasteel/darkblue/corner{
-	dir = 4
-	},
-/area/ctf)
-"gS" = (
-/obj/effect/turf_decal/stripes/line,
-/turf/open/floor/plating,
-/area/ctf)
-"gT" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/turf/open/floor/plasteel/black,
-/area/ctf)
-"gU" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/turf/open/floor/plating,
-/area/ctf)
-"gV" = (
-/turf/open/floor/plating,
-/area/ctf)
-"gW" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
@@ -2225,27 +2293,27 @@
 	luminosity = 2
 	},
 /area/ctf)
-"gX" = (
+"gS" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
 /turf/open/floor/plasteel/darkblue/corner,
 /area/ctf)
-"gY" = (
+"gT" = (
 /turf/open/floor/plasteel/darkblue/corner{
 	dir = 1
 	},
 /area/ctf)
-"gZ" = (
+"gU" = (
 /turf/open/floor/plasteel/darkblue/corner,
 /area/ctf)
-"ha" = (
+"gV" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
 /turf/open/floor/plating,
 /area/ctf)
-"hb" = (
+"gW" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 10
 	},
@@ -2253,205 +2321,205 @@
 	dir = 4
 	},
 /area/ctf)
-"hc" = (
+"gX" = (
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plasteel/darkblue/corner{
 	dir = 1
 	},
 /area/ctf)
-"hd" = (
+"gY" = (
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plasteel/darkblue/corner{
 	dir = 4
 	},
 /area/ctf)
-"he" = (
+"gZ" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 6
 	},
 /turf/open/floor/plasteel/black,
 /area/ctf)
-"hf" = (
+"ha" = (
 /obj/machinery/power/emitter/energycannon{
 	dir = 1
 	},
 /turf/open/floor/plating,
 /area/ctf)
-"hg" = (
+"hb" = (
 /obj/structure/trap/ctf/blue,
 /turf/open/floor/plasteel/blue,
 /area/ctf)
-"hh" = (
+"hc" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 9
 	},
 /turf/open/floor/circuit,
 /area/ctf)
-"hi" = (
+"hd" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
+	},
+/turf/open/floor/circuit,
+/area/ctf)
+"he" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 5
+	},
+/turf/open/floor/circuit,
+/area/ctf)
+"hf" = (
+/turf/open/floor/plasteel/darkred,
+/area/ctf)
+"hg" = (
+/obj/structure/trap/ctf/red,
+/turf/open/floor/plasteel/darkred,
+/area/ctf)
+"hh" = (
+/turf/closed/indestructible/rock/snow,
+/area/syndicate_mothership)
+"hi" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
 	},
 /turf/open/floor/circuit,
 /area/ctf)
 "hj" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 5
-	},
 /turf/open/floor/circuit,
 /area/ctf)
 "hk" = (
-/turf/open/floor/plasteel/darkred,
-/area/ctf)
-"hl" = (
-/obj/structure/trap/ctf/red,
-/turf/open/floor/plasteel/darkred,
-/area/ctf)
-"hm" = (
-/turf/closed/indestructible/rock/snow,
-/area/syndicate_mothership)
-"hn" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/turf/open/floor/circuit,
-/area/ctf)
-"ho" = (
-/turf/open/floor/circuit,
-/area/ctf)
-"hp" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
 /turf/open/floor/circuit,
 /area/ctf)
-"hq" = (
+"hl" = (
 /turf/open/floor/plating/asteroid/snow/airless,
 /area/syndicate_mothership)
-"hr" = (
+"hm" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/effect/turf_decal/stripes/line{
 	dir = 10
 	},
 /turf/open/floor/circuit,
 /area/ctf)
-"hs" = (
+"hn" = (
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/circuit,
 /area/ctf)
-"ht" = (
+"ho" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 6
 	},
 /turf/open/floor/circuit,
 /area/ctf)
-"hu" = (
+"hp" = (
 /obj/structure/barricade/security/ctf,
 /turf/open/floor/circuit/green/off,
 /area/ctf)
-"hv" = (
+"hq" = (
 /obj/structure/trap/ctf/red,
 /turf/open/floor/plasteel/red,
 /area/ctf)
-"hw" = (
+"hr" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 9
 	},
 /turf/open/floor/plasteel/darkblue/side{
 	dir = 9
+	},
+/area/ctf)
+"hs" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel/darkblue/side{
+	dir = 1
+	},
+/area/ctf)
+"ht" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel/darkblue/side{
+	dir = 5
+	},
+/area/ctf)
+"hu" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/turf/open/floor/circuit/green/off,
+/area/ctf)
+"hv" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel/darkred/side{
+	dir = 9
+	},
+/area/ctf)
+"hw" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel/darkred/side{
+	dir = 1
 	},
 /area/ctf)
 "hx" = (
 /obj/effect/turf_decal/stripes/line{
-	dir = 1
+	dir = 5
 	},
-/turf/open/floor/plasteel/darkblue/side{
-	dir = 1
+/turf/open/floor/plasteel/darkred/side{
+	dir = 5
 	},
 /area/ctf)
 "hy" = (
 /obj/effect/turf_decal/stripes/line{
-	dir = 1
+	dir = 8
 	},
 /turf/open/floor/plasteel/darkblue/side{
-	dir = 5
+	dir = 8
 	},
 /area/ctf)
 "hz" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
 /turf/open/floor/circuit/green/off,
 /area/ctf)
 "hA" = (
 /obj/effect/turf_decal/stripes/line{
-	dir = 1
+	dir = 4
 	},
 /turf/open/floor/plasteel/darkred/side{
-	dir = 9
+	dir = 4
 	},
 /area/ctf)
 "hB" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/turf/open/floor/plasteel/darkred/side{
-	dir = 1
-	},
-/area/ctf)
-"hC" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 5
-	},
-/turf/open/floor/plasteel/darkred/side{
-	dir = 5
-	},
-/area/ctf)
-"hD" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/turf/open/floor/plasteel/darkblue/side{
-	dir = 8
-	},
-/area/ctf)
-"hE" = (
-/turf/open/floor/circuit/green/off,
-/area/ctf)
-"hF" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/turf/open/floor/plasteel/darkred/side{
-	dir = 4
-	},
-/area/ctf)
-"hG" = (
 /turf/open/floor/circuit/red,
 /area/ctf)
-"hH" = (
+"hC" = (
 /turf/open/floor/circuit/green/anim,
 /area/ctf)
-"hI" = (
+"hD" = (
 /obj/machinery/capture_the_flag/blue,
 /turf/open/floor/circuit/green/anim,
 /area/ctf)
-"hJ" = (
+"hE" = (
 /obj/item/twohanded/ctf/blue,
 /turf/open/floor/circuit/green/anim,
 /area/ctf)
-"hK" = (
+"hF" = (
 /obj/item/twohanded/ctf/red,
 /turf/open/floor/circuit/green/anim,
 /area/ctf)
-"hL" = (
+"hG" = (
 /obj/machinery/capture_the_flag/red,
 /turf/open/floor/circuit/green/anim,
 /area/ctf)
-"hM" = (
+"hH" = (
 /obj/effect/landmark/shuttle_import,
 /turf/open/space,
 /area/space)
-"hN" = (
+"hI" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 10
 	},
@@ -2459,31 +2527,31 @@
 	dir = 10
 	},
 /area/ctf)
-"hO" = (
+"hJ" = (
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plasteel/darkblue/side,
 /area/ctf)
-"hP" = (
+"hK" = (
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plasteel/darkblue/side{
 	dir = 6
 	},
 /area/ctf)
-"hQ" = (
+"hL" = (
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/circuit/green/off,
 /area/ctf)
-"hR" = (
+"hM" = (
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plasteel/darkred/side{
 	dir = 10
 	},
 /area/ctf)
-"hS" = (
+"hN" = (
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plasteel/darkred/side,
 /area/ctf)
-"hT" = (
+"hO" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 6
 	},
@@ -2491,21 +2559,49 @@
 	dir = 6
 	},
 /area/ctf)
-"hU" = (
+"hP" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 9
+	},
+/turf/open/floor/circuit/red,
+/area/ctf)
+"hQ" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/turf/open/floor/circuit/red,
+/area/ctf)
+"hR" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 5
+	},
+/turf/open/floor/circuit/red,
+/area/ctf)
+"hS" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/turf/open/floor/circuit/red,
+/area/ctf)
+"hT" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/turf/open/floor/circuit/red,
+/area/ctf)
+"hU" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 10
 	},
 /turf/open/floor/circuit/red,
 /area/ctf)
 "hV" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
+/obj/effect/turf_decal/stripes/line,
 /turf/open/floor/circuit/red,
 /area/ctf)
 "hW" = (
 /obj/effect/turf_decal/stripes/line{
-	dir = 5
+	dir = 6
 	},
 /turf/open/floor/circuit/red,
 /area/ctf)
@@ -2513,46 +2609,18 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
-/turf/open/floor/circuit/red,
-/area/ctf)
-"hY" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/turf/open/floor/circuit/red,
-/area/ctf)
-"hZ" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 10
-	},
-/turf/open/floor/circuit/red,
-/area/ctf)
-"ia" = (
-/obj/effect/turf_decal/stripes/line,
-/turf/open/floor/circuit/red,
-/area/ctf)
-"ib" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 6
-	},
-/turf/open/floor/circuit/red,
-/area/ctf)
-"ic" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
 /turf/open/floor/plasteel/black,
 /area/ctf)
-"id" = (
+"hY" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
 /turf/open/floor/plasteel/darkred/corner,
 /area/ctf)
-"ie" = (
+"hZ" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
@@ -2560,7 +2628,7 @@
 	dir = 8
 	},
 /area/ctf)
-"if" = (
+"ia" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 5
 	},
@@ -2568,59 +2636,59 @@
 	dir = 8
 	},
 /area/ctf)
-"ig" = (
+"ib" = (
 /turf/open/floor/plasteel/darkred/corner,
 /area/ctf)
+"ic" = (
+/turf/open/floor/plasteel/darkred/corner{
+	dir = 1
+	},
+/area/ctf)
+"id" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/turf/open/floor/plasteel/darkred/corner{
+	dir = 1
+	},
+/area/ctf)
+"ie" = (
+/turf/open/floor/plasteel/darkred/corner{
+	dir = 4
+	},
+/area/ctf)
+"if" = (
+/turf/open/floor/plasteel/darkred/corner{
+	dir = 8
+	},
+/area/ctf)
+"ig" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/turf/open/floor/plasteel/darkred/corner{
+	dir = 8
+	},
+/area/ctf)
 "ih" = (
-/turf/open/floor/plasteel/darkred/corner{
-	dir = 1
-	},
-/area/ctf)
-"ii" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/turf/open/floor/plasteel/darkred/corner{
-	dir = 1
-	},
-/area/ctf)
-"ij" = (
-/turf/open/floor/plasteel/darkred/corner{
-	dir = 4
-	},
-/area/ctf)
-"ik" = (
-/turf/open/floor/plasteel/darkred/corner{
-	dir = 8
-	},
-/area/ctf)
-"il" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/turf/open/floor/plasteel/darkred/corner{
-	dir = 8
-	},
-/area/ctf)
-"im" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 10
 	},
 /turf/open/floor/plasteel/black,
 /area/ctf)
-"in" = (
+"ii" = (
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plasteel/darkred/corner{
 	dir = 4
 	},
 /area/ctf)
-"io" = (
+"ij" = (
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plasteel/darkred/corner{
 	dir = 1
 	},
 /area/ctf)
-"ip" = (
+"ik" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 6
 	},
@@ -2628,44 +2696,44 @@
 	dir = 1
 	},
 /area/ctf)
-"iq" = (
+"il" = (
 /turf/closed/indestructible/riveted,
 /area/centcom/prison)
-"ir" = (
+"im" = (
 /obj/machinery/status_display,
 /turf/closed/indestructible/riveted,
 /area/centcom/control)
-"is" = (
+"in" = (
 /obj/structure/sign/nanotrasen,
 /turf/closed/indestructible/riveted,
 /area/centcom/control)
-"it" = (
+"io" = (
 /turf/closed/indestructible/riveted,
 /area/centcom/control)
-"iu" = (
+"ip" = (
 /obj/machinery/ai_status_display,
 /turf/closed/indestructible/riveted,
 /area/centcom/control)
-"iv" = (
+"iq" = (
 /obj/effect/landmark/prisonwarp,
 /turf/open/floor/plasteel/vault{
 	dir = 8
 	},
 /area/centcom/prison)
-"iw" = (
+"ir" = (
 /turf/closed/indestructible/fakeglass{
 	icon_state = "fakewindows2";
 	dir = 6
 	},
 /area/centcom/prison)
-"ix" = (
+"is" = (
 /obj/structure/table/reinforced,
 /obj/item/paper_bin,
 /obj/item/pen,
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plasteel,
 /area/centcom/control)
-"iy" = (
+"it" = (
 /obj/structure/table/reinforced,
 /obj/item/crowbar/red,
 /obj/item/tank/internals/emergency_oxygen/engi,
@@ -2673,11 +2741,11 @@
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plasteel,
 /area/centcom/control)
-"iz" = (
+"iu" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/centcom/control)
-"iA" = (
+"iv" = (
 /obj/structure/table/reinforced,
 /obj/item/device/radio{
 	pixel_x = 5;
@@ -2694,7 +2762,7 @@
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plasteel,
 /area/centcom/control)
-"iB" = (
+"iw" = (
 /obj/structure/table/reinforced,
 /obj/item/storage/lockbox/loyalty,
 /obj/machinery/light{
@@ -2703,7 +2771,7 @@
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plasteel,
 /area/centcom/control)
-"iC" = (
+"ix" = (
 /obj/item/storage/box/emps{
 	pixel_x = 3;
 	pixel_y = 3
@@ -2720,35 +2788,35 @@
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plasteel,
 /area/centcom/control)
-"iD" = (
+"iy" = (
 /obj/structure/table/reinforced,
 /obj/item/restraints/handcuffs/cable/zipties,
 /obj/item/device/assembly/flash/handheld,
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plasteel,
 /area/centcom/control)
-"iE" = (
+"iz" = (
 /obj/structure/table/reinforced,
 /obj/item/storage/fancy/donut_box,
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plasteel,
 /area/centcom/control)
-"iF" = (
+"iA" = (
 /turf/open/floor/plasteel/vault{
 	dir = 5
 	},
 /area/centcom/prison)
-"iG" = (
+"iB" = (
 /turf/closed/indestructible/fakedoor{
 	name = "CentCom Cell"
 	},
 /area/centcom/prison)
-"iH" = (
+"iC" = (
 /turf/open/floor/plasteel/vault{
 	dir = 8
 	},
 /area/centcom/control)
-"iI" = (
+"iD" = (
 /obj/structure/closet/secure_closet/security,
 /obj/item/storage/belt/security/full,
 /obj/item/gun/ballistic/automatic/wt550,
@@ -2759,7 +2827,7 @@
 	},
 /turf/open/floor/plasteel,
 /area/centcom/control)
-"iJ" = (
+"iE" = (
 /obj/structure/closet/secure_closet/security,
 /obj/item/storage/belt/security/full,
 /obj/item/gun/ballistic/automatic/wt550,
@@ -2770,56 +2838,82 @@
 	},
 /turf/open/floor/plasteel,
 /area/centcom/control)
-"iK" = (
+"iF" = (
 /turf/closed/indestructible/riveted,
 /area/centcom/supply)
-"iL" = (
+"iG" = (
 /turf/closed/indestructible/fakedoor{
 	name = "CentCom Warehouse"
 	},
 /area/centcom/supply)
-"iM" = (
+"iH" = (
 /obj/structure/sign/nanotrasen,
 /turf/closed/indestructible/riveted,
 /area/centcom/prison)
-"iN" = (
+"iI" = (
 /obj/structure/sign/securearea,
 /turf/closed/indestructible/riveted,
 /area/centcom/prison)
-"iO" = (
+"iJ" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 9
 	},
+/obj/machinery/light{
+	dir = 8
+	},
 /turf/open/floor/plasteel,
 /area/centcom/control)
-"iP" = (
+"iK" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 5
 	},
 /turf/open/floor/plasteel,
 /area/centcom/control)
-"iQ" = (
+"iL" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 9
+	},
+/turf/open/floor/plasteel,
+/area/centcom/control)
+"iM" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 5
+	},
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/centcom/control)
+"iN" = (
 /obj/machinery/status_display{
 	name = "cargo display";
 	supply_display = 1
 	},
 /turf/closed/indestructible/riveted,
 /area/centcom/supply)
-"iR" = (
+"iO" = (
 /obj/effect/turf_decal/delivery,
 /turf/open/floor/plasteel,
 /area/centcom/supply)
-"iS" = (
+"iP" = (
 /turf/open/floor/plasteel/loadingarea{
 	dir = 4
 	},
 /area/centcom/supply)
-"iT" = (
+"iQ" = (
+/obj/machinery/light{
+	dir = 1
+	},
 /turf/open/floor/plasteel/brown{
 	dir = 1
 	},
 /area/centcom/supply)
-"iU" = (
+"iR" = (
+/turf/open/floor/plasteel/brown{
+	dir = 1
+	},
+/area/centcom/supply)
+"iS" = (
 /obj/machinery/firealarm{
 	dir = 4;
 	pixel_x = 24
@@ -2828,19 +2922,19 @@
 	dir = 5
 	},
 /area/centcom/supply)
-"iV" = (
+"iT" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
 /area/centcom/control)
-"iW" = (
+"iU" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/centcom/control)
-"iX" = (
+"iV" = (
 /obj/structure/closet/secure_closet/security,
 /obj/item/storage/belt/security/full,
 /obj/item/gun/ballistic/automatic/wt550,
@@ -2851,7 +2945,7 @@
 	},
 /turf/open/floor/plasteel,
 /area/centcom/control)
-"iY" = (
+"iW" = (
 /obj/structure/closet/secure_closet/security,
 /obj/item/storage/belt/security/full,
 /obj/item/gun/ballistic/automatic/wt550,
@@ -2862,19 +2956,19 @@
 	},
 /turf/open/floor/plasteel,
 /area/centcom/control)
-"iZ" = (
+"iX" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/centcom/supply)
-"ja" = (
+"iY" = (
 /turf/open/floor/plasteel/neutral,
 /area/centcom/supply)
-"jb" = (
+"iZ" = (
 /turf/open/floor/plasteel/brown{
 	dir = 4
 	},
 /area/centcom/supply)
-"jc" = (
+"ja" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/centcom{
 	name = "CentCom";
@@ -2886,7 +2980,7 @@
 	},
 /turf/open/floor/plasteel,
 /area/centcom/control)
-"jd" = (
+"jb" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/sign/securearea{
 	desc = "A warning sign which reads 'EXTERNAL AIRLOCK'";
@@ -2896,7 +2990,7 @@
 	},
 /turf/open/floor/plating,
 /area/centcom/supply)
-"je" = (
+"jc" = (
 /obj/machinery/conveyor{
 	dir = 1;
 	id = "XCCQMLoad2";
@@ -2907,7 +3001,7 @@
 	},
 /turf/open/floor/plasteel,
 /area/centcom/supply)
-"jf" = (
+"jd" = (
 /obj/machinery/conveyor_switch/oneway{
 	convdir = 1;
 	id = "XCCQMLoad2";
@@ -2917,12 +3011,20 @@
 	dir = 8
 	},
 /area/centcom/supply)
-"jg" = (
+"je" = (
 /turf/open/floor/plasteel/yellowsiding{
 	dir = 1
 	},
 /area/centcom/supply)
-"jh" = (
+"jf" = (
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/open/floor/plasteel/brown{
+	dir = 4
+	},
+/area/centcom/supply)
+"jg" = (
 /obj/structure/reagent_dispensers/peppertank{
 	pixel_x = -32
 	},
@@ -2934,7 +3036,7 @@
 	},
 /turf/open/floor/plasteel,
 /area/centcom/control)
-"ji" = (
+"jh" = (
 /obj/structure/table/reinforced,
 /obj/machinery/recharger,
 /obj/effect/turf_decal/stripes/line{
@@ -2942,7 +3044,7 @@
 	},
 /turf/open/floor/plasteel,
 /area/centcom/control)
-"jj" = (
+"ji" = (
 /obj/machinery/vending/security,
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -2950,7 +3052,7 @@
 /obj/machinery/light,
 /turf/open/floor/plasteel,
 /area/centcom/control)
-"jk" = (
+"jj" = (
 /obj/structure/extinguisher_cabinet{
 	dir = 4;
 	pixel_x = 24
@@ -2963,7 +3065,7 @@
 	},
 /turf/open/floor/plasteel,
 /area/centcom/control)
-"jl" = (
+"jk" = (
 /obj/machinery/door/poddoor{
 	density = 1;
 	icon_state = "closed";
@@ -2981,7 +3083,7 @@
 	},
 /turf/open/floor/plasteel,
 /area/centcom/supply)
-"jm" = (
+"jl" = (
 /obj/structure/plasticflaps,
 /obj/machinery/conveyor{
 	dir = 4;
@@ -2993,7 +3095,7 @@
 	},
 /turf/open/floor/plasteel,
 /area/centcom/supply)
-"jn" = (
+"jm" = (
 /obj/machinery/door/poddoor{
 	density = 1;
 	icon_state = "closed";
@@ -3011,7 +3113,7 @@
 	},
 /turf/open/floor/plasteel,
 /area/centcom/supply)
-"jo" = (
+"jn" = (
 /obj/machinery/conveyor{
 	dir = 1;
 	id = "XCCQMLoad2";
@@ -3020,24 +3122,24 @@
 /obj/effect/turf_decal/stripes/end,
 /turf/open/floor/plasteel,
 /area/centcom/supply)
-"jp" = (
+"jo" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 5
 	},
 /turf/open/floor/plasteel,
 /area/centcom/supply)
-"jq" = (
+"jp" = (
 /obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel,
 /area/centcom/supply)
-"jr" = (
+"jq" = (
 /obj/item/stack/packageWrap,
 /obj/item/hand_labeler,
 /obj/structure/table,
 /obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel,
 /area/centcom/supply)
-"js" = (
+"jr" = (
 /obj/machinery/door/airlock/external{
 	name = "Supply Shuttle";
 	req_access_txt = "106"
@@ -3047,42 +3149,42 @@
 	},
 /turf/open/floor/plasteel,
 /area/centcom/supply)
-"jt" = (
+"js" = (
 /obj/structure/fans/tiny,
 /obj/effect/turf_decal/delivery,
 /turf/open/floor/plasteel,
 /area/centcom/supply)
-"ju" = (
+"jt" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/centcom/supply)
-"jv" = (
+"ju" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/filingcabinet/filingcabinet,
 /obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel,
 /area/centcom/supply)
-"jw" = (
+"jv" = (
 /obj/effect/turf_decal/stripes/corner{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
 /area/centcom/control)
-"jx" = (
+"jw" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
 /area/centcom/control)
-"jy" = (
+"jx" = (
 /obj/effect/turf_decal/stripes/corner{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/centcom/control)
-"jz" = (
+"jy" = (
 /obj/machinery/button/door{
 	id = "XCCQMLoaddoor";
 	layer = 4;
@@ -3102,7 +3204,7 @@
 /obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel,
 /area/centcom/supply)
-"jA" = (
+"jz" = (
 /obj/machinery/airalarm{
 	dir = 4;
 	pixel_x = -23
@@ -3115,12 +3217,12 @@
 	},
 /turf/open/floor/plasteel,
 /area/centcom/control)
-"jB" = (
+"jA" = (
 /turf/open/floor/plasteel/vault{
 	dir = 5
 	},
 /area/centcom/control)
-"jC" = (
+"jB" = (
 /obj/structure/noticeboard{
 	dir = 8;
 	pixel_x = 32
@@ -3133,7 +3235,7 @@
 	},
 /turf/open/floor/plasteel,
 /area/centcom/control)
-"jD" = (
+"jC" = (
 /obj/docking_port/stationary{
 	dir = 8;
 	dwidth = 5;
@@ -3144,30 +3246,30 @@
 	},
 /turf/open/space,
 /area/space)
-"jE" = (
+"jD" = (
 /turf/open/floor/plasteel/loadingarea{
 	dir = 8
 	},
 /area/centcom/supply)
-"jF" = (
+"jE" = (
 /obj/machinery/status_display,
 /turf/closed/indestructible/riveted,
 /area/centcom/supply)
-"jG" = (
+"jF" = (
 /obj/effect/turf_decal/stripes/corner,
 /turf/open/floor/plasteel,
 /area/centcom/control)
-"jH" = (
+"jG" = (
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plasteel,
 /area/centcom/control)
-"jI" = (
+"jH" = (
 /obj/effect/turf_decal/stripes/corner{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
 /area/centcom/control)
-"jJ" = (
+"jI" = (
 /obj/machinery/door/poddoor{
 	density = 1;
 	icon_state = "closed";
@@ -3184,7 +3286,7 @@
 	},
 /turf/open/floor/plasteel,
 /area/centcom/supply)
-"jK" = (
+"jJ" = (
 /obj/structure/plasticflaps,
 /obj/machinery/conveyor{
 	dir = 8;
@@ -3195,7 +3297,7 @@
 	},
 /turf/open/floor/plasteel,
 /area/centcom/supply)
-"jL" = (
+"jK" = (
 /obj/machinery/door/poddoor{
 	density = 1;
 	icon_state = "closed";
@@ -3212,7 +3314,7 @@
 	},
 /turf/open/floor/plasteel,
 /area/centcom/supply)
-"jM" = (
+"jL" = (
 /obj/machinery/conveyor{
 	dir = 8;
 	id = "XCCQMLoad"
@@ -3222,18 +3324,18 @@
 	},
 /turf/open/floor/plasteel,
 /area/centcom/supply)
-"jN" = (
+"jM" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 6
 	},
 /turf/open/floor/plasteel,
 /area/centcom/supply)
-"jO" = (
+"jN" = (
 /obj/structure/closet/wardrobe/cargotech,
 /obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel,
 /area/centcom/supply)
-"jP" = (
+"jO" = (
 /obj/machinery/conveyor{
 	dir = 1;
 	id = "XCCQMLoad";
@@ -3244,7 +3346,7 @@
 	},
 /turf/open/floor/plasteel,
 /area/centcom/supply)
-"jQ" = (
+"jP" = (
 /obj/machinery/conveyor_switch/oneway{
 	convdir = 1;
 	id = "XCCQMLoad";
@@ -3254,7 +3356,7 @@
 	dir = 8
 	},
 /area/centcom/supply)
-"jR" = (
+"jQ" = (
 /obj/structure/closet/secure_closet/quartermaster,
 /obj/machinery/airalarm{
 	dir = 8;
@@ -3263,7 +3365,7 @@
 /obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel,
 /area/centcom/supply)
-"jS" = (
+"jR" = (
 /obj/machinery/newscaster/security_unit{
 	pixel_x = -32
 	},
@@ -3275,12 +3377,12 @@
 	},
 /turf/open/floor/plasteel,
 /area/centcom/control)
-"jT" = (
+"jS" = (
 /obj/machinery/computer/prisoner,
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plasteel,
 /area/centcom/control)
-"jU" = (
+"jT" = (
 /obj/machinery/computer/security,
 /obj/effect/turf_decal/stripes/line,
 /obj/machinery/light{
@@ -3288,12 +3390,12 @@
 	},
 /turf/open/floor/plasteel,
 /area/centcom/control)
-"jV" = (
+"jU" = (
 /obj/machinery/computer/secure_data,
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plasteel,
 /area/centcom/control)
-"jW" = (
+"jV" = (
 /obj/machinery/firealarm{
 	dir = 4;
 	pixel_x = 24
@@ -3306,43 +3408,25 @@
 	},
 /turf/open/floor/plasteel,
 /area/centcom/control)
-"jX" = (
-/obj/docking_port/stationary{
-	area_type = /area/syndicate_mothership;
-	dir = 1;
-	dwidth = 25;
-	height = 50;
-	id = "emergency_syndicate";
-	name = "Syndicate Auxillary Shuttle Dock";
-	turf_type = /turf/open/floor/plating/asteroid/snow;
-	width = 50
-	},
-/turf/open/floor/plating/asteroid/snow/airless,
-/area/syndicate_mothership)
-"jY" = (
-/turf/open/floor/plasteel/brown{
-	dir = 8
-	},
-/area/centcom/supply)
-"jZ" = (
+"jW" = (
 /obj/structure/closet/secure_closet/contraband/heads,
 /turf/open/floor/plasteel/vault{
 	dir = 8
 	},
 /area/centcom/control)
-"ka" = (
+"jX" = (
 /obj/structure/closet/secure_closet/courtroom,
 /turf/open/floor/plasteel/vault{
 	dir = 8
 	},
 /area/centcom/control)
-"kb" = (
+"jY" = (
 /obj/structure/closet/lawcloset,
 /turf/open/floor/plasteel/vault{
 	dir = 8
 	},
 /area/centcom/control)
-"kc" = (
+"jZ" = (
 /obj/item/storage/box/handcuffs,
 /obj/item/crowbar/red,
 /obj/structure/table/wood,
@@ -3350,13 +3434,13 @@
 	dir = 8
 	},
 /area/centcom/control)
-"kd" = (
+"ka" = (
 /obj/structure/bookcase/random,
 /turf/open/floor/plasteel/vault{
 	dir = 8
 	},
 /area/centcom/control)
-"ke" = (
+"kb" = (
 /obj/structure/bookcase/random,
 /obj/machinery/light{
 	dir = 1
@@ -3365,7 +3449,7 @@
 	dir = 8
 	},
 /area/centcom/control)
-"kf" = (
+"kc" = (
 /obj/item/book/manual/wiki/security_space_law,
 /obj/item/device/taperecorder,
 /obj/structure/table/wood,
@@ -3373,7 +3457,7 @@
 	dir = 8
 	},
 /area/centcom/control)
-"kg" = (
+"kd" = (
 /obj/item/wrench,
 /obj/item/restraints/handcuffs,
 /obj/item/device/assembly/flash/handheld,
@@ -3382,7 +3466,7 @@
 	dir = 8
 	},
 /area/centcom/control)
-"kh" = (
+"ke" = (
 /obj/item/twohanded/required/kirbyplants{
 	icon_state = "plant-21"
 	},
@@ -3390,7 +3474,7 @@
 	dir = 8
 	},
 /area/centcom/control)
-"ki" = (
+"kf" = (
 /obj/structure/table/wood,
 /obj/item/phone{
 	desc = "Supposedly a direct line to Nanotrasen Central Command. It's not even plugged in.";
@@ -3410,7 +3494,7 @@
 	dir = 8
 	},
 /area/centcom/control)
-"kj" = (
+"kg" = (
 /obj/item/clipboard,
 /obj/item/folder/red,
 /obj/item/stamp/denied{
@@ -3423,7 +3507,7 @@
 	dir = 8
 	},
 /area/centcom/control)
-"kk" = (
+"kh" = (
 /obj/item/storage/briefcase{
 	pixel_x = -3;
 	pixel_y = 3
@@ -3434,35 +3518,25 @@
 	dir = 8
 	},
 /area/centcom/control)
-"kl" = (
-/turf/closed/indestructible/riveted,
-/area/syndicate_mothership/control)
-"km" = (
-/obj/machinery/door/poddoor/shuttledock{
-	checkdir = 1;
-	name = "syndicate blast door";
-	turftype = /turf/open/floor/plating/asteroid/snow
+"ki" = (
+/obj/docking_port/stationary{
+	area_type = /area/syndicate_mothership;
+	dir = 1;
+	dwidth = 25;
+	height = 50;
+	id = "emergency_syndicate";
+	name = "Syndicate Auxillary Shuttle Dock";
+	turf_type = /turf/open/floor/plating/asteroid/snow;
+	width = 50
 	},
-/turf/open/floor/plating,
-/area/syndicate_mothership/control)
-"kn" = (
-/turf/open/floor/plasteel/yellowsiding,
+/turf/open/floor/plating/asteroid/snow/airless,
+/area/syndicate_mothership)
+"kj" = (
+/turf/open/floor/plasteel/brown{
+	dir = 8
+	},
 /area/centcom/supply)
-"ko" = (
-/obj/structure/filingcabinet/medical,
-/obj/effect/turf_decal/stripes/line{
-	dir = 5
-	},
-/turf/open/floor/plasteel,
-/area/centcom/control)
-"kp" = (
-/obj/structure/filingcabinet/security,
-/obj/effect/turf_decal/stripes/line{
-	dir = 9
-	},
-/turf/open/floor/plasteel,
-/area/centcom/control)
-"kq" = (
+"kk" = (
 /obj/item/twohanded/required/kirbyplants{
 	icon_state = "plant-22"
 	},
@@ -3470,13 +3544,13 @@
 	dir = 8
 	},
 /area/centcom/control)
-"kr" = (
+"kl" = (
 /turf/open/floor/wood,
 /area/centcom/control)
-"ks" = (
+"km" = (
 /turf/open/floor/plasteel/grimy,
 /area/centcom/control)
-"kt" = (
+"kn" = (
 /obj/machinery/newscaster/security_unit{
 	pixel_x = 32
 	},
@@ -3484,30 +3558,67 @@
 	dir = 8
 	},
 /area/centcom/control)
+"ko" = (
+/turf/closed/indestructible/abductor{
+	icon_state = "alien20"
+	},
+/area/abductor_ship)
+"kp" = (
+/turf/closed/indestructible/abductor{
+	icon_state = "alien21"
+	},
+/area/abductor_ship)
+"kq" = (
+/turf/closed/indestructible/abductor{
+	icon_state = "alien22"
+	},
+/area/abductor_ship)
+"kr" = (
+/turf/closed/indestructible/abductor{
+	icon_state = "alien23"
+	},
+/area/abductor_ship)
+"ks" = (
+/turf/closed/indestructible/abductor{
+	icon_state = "alien24"
+	},
+/area/abductor_ship)
+"kt" = (
+/obj/effect/light_emitter{
+	set_cap = 1;
+	set_luminosity = 4
+	},
+/turf/open/floor/plating/asteroid/snow/airless,
+/area/syndicate_mothership)
 "ku" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
+/turf/closed/indestructible/riveted,
+/area/syndicate_mothership/control)
+"kv" = (
+/obj/machinery/door/poddoor/shuttledock{
+	checkdir = 1;
+	name = "syndicate blast door";
+	turftype = /turf/open/floor/plating/asteroid/snow
 	},
 /turf/open/floor/plating,
 /area/syndicate_mothership/control)
-"kv" = (
-/obj/structure/table/reinforced,
-/obj/item/storage/box/handcuffs,
-/obj/item/crowbar/red,
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/centcom/control)
 "kw" = (
-/obj/structure/table/reinforced,
-/obj/machinery/recharger,
+/turf/open/floor/plasteel/yellowsiding,
+/area/centcom/supply)
+"kx" = (
+/obj/structure/filingcabinet/medical,
 /obj/effect/turf_decal/stripes/line{
-	dir = 8
+	dir = 5
 	},
 /turf/open/floor/plasteel,
 /area/centcom/control)
-"kx" = (
+"ky" = (
+/obj/structure/filingcabinet/security,
+/obj/effect/turf_decal/stripes/line{
+	dir = 9
+	},
+/turf/open/floor/plasteel,
+/area/centcom/control)
+"kz" = (
 /obj/item/clipboard,
 /obj/item/folder/red,
 /obj/item/stamp/denied{
@@ -3518,11 +3629,11 @@
 /obj/structure/table/wood,
 /turf/open/floor/plasteel/grimy,
 /area/centcom/control)
-"ky" = (
+"kA" = (
 /obj/structure/chair/comfy/brown,
 /turf/open/floor/plasteel/grimy,
 /area/centcom/control)
-"kz" = (
+"kB" = (
 /obj/item/twohanded/required/kirbyplants{
 	icon_state = "plant-22"
 	},
@@ -3534,7 +3645,7 @@
 	dir = 8
 	},
 /area/centcom/control)
-"kA" = (
+"kC" = (
 /obj/structure/window/reinforced{
 	dir = 4
 	},
@@ -3543,7 +3654,7 @@
 	},
 /turf/open/floor/plasteel/grimy,
 /area/centcom/control)
-"kB" = (
+"kD" = (
 /obj/structure/window/reinforced{
 	dir = 1
 	},
@@ -3552,14 +3663,14 @@
 	},
 /turf/open/floor/plasteel/grimy,
 /area/centcom/control)
-"kC" = (
+"kE" = (
 /obj/structure/chair,
 /obj/structure/window/reinforced{
 	dir = 1
 	},
 /turf/open/floor/plasteel/grimy,
 /area/centcom/control)
-"kD" = (
+"kF" = (
 /obj/structure/table/wood,
 /obj/structure/window/reinforced{
 	dir = 8
@@ -3568,14 +3679,14 @@
 /obj/item/pen/fourcolor,
 /turf/open/floor/plasteel/grimy,
 /area/centcom/control)
-"kE" = (
+"kG" = (
 /obj/structure/chair/comfy/brown{
 	color = "#596479";
 	dir = 2
 	},
 /turf/open/floor/plasteel/grimy,
 /area/centcom/control)
-"kF" = (
+"kH" = (
 /obj/structure/table/wood,
 /obj/structure/window/reinforced{
 	dir = 4
@@ -3585,7 +3696,7 @@
 /obj/item/stamp/law,
 /turf/open/floor/plasteel/grimy,
 /area/centcom/control)
-"kG" = (
+"kI" = (
 /obj/structure/window/reinforced{
 	dir = 8
 	},
@@ -3594,7 +3705,7 @@
 	},
 /turf/open/floor/plasteel/grimy,
 /area/centcom/control)
-"kH" = (
+"kJ" = (
 /obj/item/twohanded/required/kirbyplants{
 	icon_state = "plant-22"
 	},
@@ -3606,74 +3717,107 @@
 	dir = 8
 	},
 /area/centcom/control)
-"kI" = (
+"kK" = (
+/turf/closed/indestructible/abductor{
+	icon_state = "alien16"
+	},
+/area/abductor_ship)
+"kL" = (
+/turf/closed/indestructible/abductor{
+	icon_state = "alien17"
+	},
+/area/abductor_ship)
+"kM" = (
+/obj/machinery/abductor/experiment{
+	team_number = 4
+	},
+/turf/open/floor/plating/abductor,
+/area/abductor_ship)
+"kN" = (
+/obj/machinery/abductor/console{
+	team_number = 4
+	},
+/turf/open/floor/plating/abductor,
+/area/abductor_ship)
+"kO" = (
+/obj/machinery/abductor/pad{
+	team_number = 4
+	},
+/turf/open/floor/plating/abductor,
+/area/abductor_ship)
+"kP" = (
+/turf/closed/indestructible/abductor{
+	icon_state = "alien18"
+	},
+/area/abductor_ship)
+"kQ" = (
+/turf/closed/indestructible/abductor{
+	icon_state = "alien19"
+	},
+/area/abductor_ship)
+"kR" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
 /turf/open/floor/plating,
 /area/syndicate_mothership/control)
-"kJ" = (
-/turf/open/floor/plasteel/brown,
-/area/centcom/supply)
-"kK" = (
-/obj/machinery/firealarm{
-	dir = 1;
-	pixel_y = -26
-	},
-/turf/open/floor/plasteel/brown,
-/area/centcom/supply)
-"kL" = (
-/turf/open/floor/plasteel/brown{
-	dir = 6
-	},
-/area/centcom/supply)
-"kM" = (
-/turf/closed/indestructible/fakedoor{
-	name = "CentCom"
-	},
-/area/centcom/control)
-"kN" = (
+"kS" = (
 /obj/effect/turf_decal/stripes/line{
-	dir = 10
+	dir = 8
+	},
+/obj/machinery/light{
+	dir = 8
 	},
 /turf/open/floor/plasteel,
 /area/centcom/control)
-"kO" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 6
-	},
-/turf/open/floor/plasteel,
-/area/centcom/control)
-"kP" = (
+"kT" = (
 /obj/structure/table/reinforced,
-/obj/item/wrench,
-/obj/item/restraints/handcuffs,
-/obj/item/device/assembly/flash/handheld,
+/obj/item/storage/box/handcuffs,
+/obj/item/crowbar/red,
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/centcom/control)
-"kQ" = (
+"kU" = (
 /obj/structure/table/reinforced,
-/obj/item/gun/ballistic/automatic/wt550,
-/obj/item/device/flashlight/seclite,
+/obj/machinery/recharger,
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
 /area/centcom/control)
-"kR" = (
+"kV" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/centcom/control)
+"kW" = (
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/open/floor/plasteel/vault{
+	dir = 8
+	},
+/area/centcom/control)
+"kX" = (
 /obj/structure/table/wood,
 /obj/item/paper_bin,
 /obj/item/pen/fourcolor,
 /turf/open/floor/plasteel/grimy,
 /area/centcom/control)
-"kS" = (
+"kY" = (
 /obj/structure/table/wood,
 /obj/item/clipboard,
 /obj/item/folder/blue,
 /obj/item/stamp/law,
 /turf/open/floor/plasteel/grimy,
 /area/centcom/control)
-"kT" = (
+"kZ" = (
 /obj/machinery/door/airlock/centcom{
 	name = "CentCom Security";
 	opacity = 1;
@@ -3684,7 +3828,7 @@
 	},
 /turf/open/floor/plasteel,
 /area/centcom/control)
-"kU" = (
+"la" = (
 /obj/machinery/door/window/brigdoor{
 	base_state = "rightsecure";
 	dir = 2;
@@ -3697,7 +3841,7 @@
 	},
 /turf/open/floor/plasteel/grimy,
 /area/centcom/control)
-"kV" = (
+"lb" = (
 /obj/structure/table/wood,
 /obj/machinery/door/window,
 /obj/item/device/radio/intercom{
@@ -3706,7 +3850,7 @@
 	},
 /turf/open/floor/plasteel/grimy,
 /area/centcom/control)
-"kW" = (
+"lc" = (
 /obj/structure/table/wood,
 /obj/structure/window/reinforced{
 	dir = 8
@@ -3716,7 +3860,7 @@
 /obj/structure/window/reinforced,
 /turf/open/floor/plasteel/grimy,
 /area/centcom/control)
-"kX" = (
+"ld" = (
 /obj/structure/table/wood,
 /obj/item/device/radio/intercom{
 	desc = "Talk smack through this.";
@@ -3731,7 +3875,7 @@
 	},
 /turf/open/floor/plasteel/grimy,
 /area/centcom/control)
-"kY" = (
+"le" = (
 /obj/structure/table/wood,
 /obj/structure/window/reinforced{
 	dir = 4
@@ -3740,7 +3884,7 @@
 /obj/structure/window/reinforced,
 /turf/open/floor/plasteel/grimy,
 /area/centcom/control)
-"kZ" = (
+"lf" = (
 /obj/machinery/door/window/brigdoor{
 	base_state = "rightsecure";
 	dir = 2;
@@ -3753,10 +3897,162 @@
 	},
 /turf/open/floor/plasteel/grimy,
 /area/centcom/control)
-"la" = (
+"lg" = (
+/turf/closed/indestructible/abductor{
+	icon_state = "alien14"
+	},
+/area/abductor_ship)
+"lh" = (
+/obj/machinery/computer/camera_advanced/abductor{
+	team_number = 4
+	},
+/turf/open/floor/plating/abductor,
+/area/abductor_ship)
+"li" = (
+/turf/open/floor/plating/abductor,
+/area/abductor_ship)
+"lj" = (
+/obj/structure/closet/abductor,
+/turf/open/floor/plating/abductor,
+/area/abductor_ship)
+"lk" = (
+/turf/closed/indestructible/abductor{
+	icon_state = "alien15"
+	},
+/area/abductor_ship)
+"ll" = (
+/turf/open/floor/plating,
+/area/syndicate_mothership/control)
+"lm" = (
+/obj/machinery/light,
+/turf/open/floor/plating,
+/area/syndicate_mothership/control)
+"ln" = (
+/obj/machinery/light,
+/turf/open/floor/plasteel/brown,
+/area/centcom/supply)
+"lo" = (
+/turf/open/floor/plasteel/brown,
+/area/centcom/supply)
+"lp" = (
+/obj/machinery/firealarm{
+	dir = 1;
+	pixel_y = -26
+	},
+/turf/open/floor/plasteel/brown,
+/area/centcom/supply)
+"lq" = (
+/turf/open/floor/plasteel/brown{
+	dir = 6
+	},
+/area/centcom/supply)
+"lr" = (
+/turf/closed/indestructible/fakedoor{
+	name = "CentCom"
+	},
+/area/centcom/control)
+"ls" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 10
+	},
+/turf/open/floor/plasteel,
+/area/centcom/control)
+"lt" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 6
+	},
+/turf/open/floor/plasteel,
+/area/centcom/control)
+"lu" = (
+/obj/structure/table/reinforced,
+/obj/item/wrench,
+/obj/item/restraints/handcuffs,
+/obj/item/device/assembly/flash/handheld,
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/centcom/control)
+"lv" = (
+/obj/structure/table/reinforced,
+/obj/item/gun/ballistic/automatic/wt550,
+/obj/item/device/flashlight/seclite,
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/centcom/control)
+"lw" = (
+/obj/structure/chair/comfy/brown{
+	buildstackamount = 0;
+	dir = 1
+	},
+/turf/open/floor/plasteel/grimy,
+/area/centcom/control)
+"lx" = (
+/obj/structure/extinguisher_cabinet{
+	pixel_x = -24
+	},
+/turf/open/floor/plasteel/vault,
+/area/centcom/control)
+"ly" = (
+/turf/open/floor/plasteel/vault,
+/area/centcom/control)
+"lz" = (
+/obj/structure/table/wood,
+/obj/item/storage/briefcase,
+/turf/open/floor/plasteel/vault{
+	dir = 8
+	},
+/area/centcom/control)
+"lA" = (
+/obj/structure/noticeboard{
+	dir = 8;
+	pixel_x = 32
+	},
+/turf/open/floor/plasteel/vault,
+/area/centcom/control)
+"lB" = (
+/turf/closed/indestructible/abductor{
+	icon_state = "alien12"
+	},
+/area/abductor_ship)
+"lC" = (
+/obj/item/retractor/alien,
+/obj/item/hemostat/alien,
+/obj/structure/table/abductor,
+/turf/open/floor/plating/abductor,
+/area/abductor_ship)
+"lD" = (
+/obj/effect/landmark/abductor/scientist{
+	team_number = 4
+	},
+/turf/open/floor/plating/abductor,
+/area/abductor_ship)
+"lE" = (
+/obj/structure/table/optable/abductor,
+/turf/open/floor/plating/abductor,
+/area/abductor_ship)
+"lF" = (
+/obj/effect/landmark/abductor/agent{
+	team_number = 4
+	},
+/turf/open/floor/plating/abductor,
+/area/abductor_ship)
+"lG" = (
+/obj/structure/table/abductor,
+/obj/item/storage/box/alienhandcuffs,
+/turf/open/floor/plating/abductor,
+/area/abductor_ship)
+"lH" = (
+/turf/closed/indestructible/abductor{
+	icon_state = "alien13"
+	},
+/area/abductor_ship)
+"lI" = (
 /turf/open/space/transit,
 /area/space)
-"lb" = (
+"lJ" = (
 /obj/machinery/door/airlock/centcom{
 	name = "Shuttle Control Office";
 	opacity = 1;
@@ -3767,7 +4063,7 @@
 	},
 /turf/open/floor/plasteel,
 /area/centcom/supply)
-"lc" = (
+"lK" = (
 /obj/machinery/door/airlock/centcom{
 	name = "CentCom Supply";
 	req_access_txt = "106"
@@ -3777,7 +4073,7 @@
 	},
 /turf/open/floor/plasteel,
 /area/centcom/supply)
-"ld" = (
+"lL" = (
 /obj/structure/flora/ausbushes/lavendergrass,
 /obj/structure/flora/ausbushes/sparsegrass,
 /obj/structure/flora/ausbushes/ywflowers,
@@ -3785,12 +4081,12 @@
 /obj/structure/flora/ausbushes/palebush,
 /turf/open/floor/plating/asteroid,
 /area/centcom/control)
-"le" = (
+"lM" = (
 /obj/machinery/door/poddoor/shutters,
 /obj/effect/turf_decal/delivery,
 /turf/open/floor/plasteel,
 /area/centcom/control)
-"lf" = (
+"lN" = (
 /obj/structure/flora/ausbushes/sparsegrass,
 /obj/structure/flora/ausbushes/grassybush,
 /obj/structure/flora/ausbushes/fernybush,
@@ -3800,7 +4096,7 @@
 	name = "sand"
 	},
 /area/centcom/control)
-"lg" = (
+"lO" = (
 /obj/structure/table/reinforced,
 /obj/item/clipboard,
 /obj/item/folder/red,
@@ -3810,7 +4106,7 @@
 	},
 /turf/open/floor/plasteel,
 /area/centcom/control)
-"lh" = (
+"lP" = (
 /obj/structure/table/reinforced,
 /obj/item/storage/box/handcuffs,
 /obj/item/crowbar/red,
@@ -3821,124 +4117,7 @@
 	},
 /turf/open/floor/plasteel,
 /area/centcom/control)
-"li" = (
-/obj/structure/chair/comfy/brown{
-	buildstackamount = 0;
-	dir = 1
-	},
-/turf/open/floor/plasteel/grimy,
-/area/centcom/control)
-"lj" = (
-/obj/structure/extinguisher_cabinet{
-	pixel_x = -24
-	},
-/turf/open/floor/plasteel/vault,
-/area/centcom/control)
-"lk" = (
-/turf/open/floor/plasteel/vault,
-/area/centcom/control)
-"ll" = (
-/obj/structure/table/wood,
-/obj/item/storage/briefcase,
-/turf/open/floor/plasteel/vault{
-	dir = 8
-	},
-/area/centcom/control)
-"lm" = (
-/obj/structure/noticeboard{
-	dir = 8;
-	pixel_x = 32
-	},
-/turf/open/floor/plasteel/vault,
-/area/centcom/control)
-"ln" = (
-/obj/structure/flora/grass/both,
-/turf/open/floor/plating/asteroid/snow/airless,
-/area/syndicate_mothership)
-"lo" = (
-/obj/structure/table/reinforced,
-/obj/machinery/computer/stockexchange,
-/turf/open/floor/plasteel/vault{
-	dir = 8
-	},
-/area/centcom/supply)
-"lp" = (
-/obj/machinery/computer/auxillary_base{
-	pixel_y = 32
-	},
-/obj/structure/table/reinforced,
-/obj/item/clipboard,
-/obj/item/folder/yellow,
-/obj/item/pen/red,
-/turf/open/floor/plasteel/vault{
-	dir = 8
-	},
-/area/centcom/supply)
-"lq" = (
-/obj/machinery/computer/shuttle/labor,
-/obj/effect/turf_decal/stripes/line{
-	dir = 10
-	},
-/turf/open/floor/plasteel,
-/area/centcom/supply)
-"lr" = (
-/obj/machinery/computer/shuttle/mining,
-/obj/effect/turf_decal/stripes/line{
-	dir = 6
-	},
-/turf/open/floor/plasteel,
-/area/centcom/supply)
-"ls" = (
-/obj/machinery/light{
-	dir = 1
-	},
-/obj/structure/table/reinforced,
-/obj/item/crowbar/red,
-/obj/item/wrench,
-/obj/item/clothing/mask/gas,
-/turf/open/floor/plasteel/vault{
-	dir = 8
-	},
-/area/centcom/supply)
-"lt" = (
-/turf/open/floor/plasteel/vault{
-	dir = 8
-	},
-/area/centcom/supply)
-"lu" = (
-/obj/machinery/airalarm{
-	dir = 8;
-	pixel_x = 24
-	},
-/obj/structure/filingcabinet/filingcabinet,
-/turf/open/floor/plasteel/vault{
-	dir = 8
-	},
-/area/centcom/supply)
-"lv" = (
-/turf/open/floor/plasteel/brown{
-	dir = 9
-	},
-/area/centcom/supply)
-"lw" = (
-/obj/machinery/airalarm{
-	dir = 8;
-	pixel_x = 24
-	},
-/turf/open/floor/plasteel/brown{
-	dir = 5
-	},
-/area/centcom/supply)
-"lx" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/structure/sign/directions/engineering{
-	desc = "A sign that shows there are doors here. There are doors everywhere!";
-	icon_state = "doors";
-	name = "WARNING: BLAST DOORS"
-	},
-/turf/open/floor/plating,
-/area/centcom/control)
-"ly" = (
+"lQ" = (
 /obj/item/twohanded/required/kirbyplants{
 	icon_state = "plant-21"
 	},
@@ -3950,17 +4129,17 @@
 	dir = 8
 	},
 /area/centcom/control)
-"lz" = (
+"lR" = (
 /turf/open/floor/plasteel/darkred/side{
 	dir = 8
 	},
 /area/centcom/control)
-"lA" = (
+"lS" = (
 /turf/open/floor/plasteel/vault{
 	dir = 9
 	},
 /area/centcom/control)
-"lB" = (
+"lT" = (
 /obj/machinery/door/airlock/centcom{
 	name = "CentCom Security";
 	opacity = 1;
@@ -3971,13 +4150,13 @@
 	},
 /turf/open/floor/plasteel,
 /area/centcom/control)
-"lC" = (
+"lU" = (
 /obj/structure/table/wood,
 /turf/open/floor/plasteel/vault{
 	dir = 8
 	},
 /area/centcom/control)
-"lD" = (
+"lV" = (
 /obj/structure/chair{
 	dir = 8
 	},
@@ -3988,27 +4167,220 @@
 	},
 /turf/open/floor/plasteel/grimy,
 /area/centcom/control)
-"lE" = (
+"lW" = (
 /obj/structure/chair{
 	dir = 8
 	},
 /turf/open/floor/plasteel/grimy,
 /area/centcom/control)
-"lF" = (
+"lX" = (
+/turf/closed/indestructible/abductor{
+	icon_state = "alien10"
+	},
+/area/abductor_ship)
+"lY" = (
+/obj/item/surgical_drapes,
+/obj/item/paper/guides/antag/abductor,
+/obj/item/scalpel/alien,
+/obj/structure/table/abductor,
+/obj/item/cautery/alien,
+/turf/open/floor/plating/abductor,
+/area/abductor_ship)
+"lZ" = (
+/turf/closed/indestructible/abductor{
+	icon_state = "alien11"
+	},
+/area/abductor_ship)
+"ma" = (
+/obj/structure/flora/grass/both,
+/obj/effect/light_emitter{
+	set_cap = 1;
+	set_luminosity = 4
+	},
+/turf/open/floor/plating/asteroid/snow/airless,
+/area/syndicate_mothership)
+"mb" = (
+/obj/structure/table/reinforced,
+/obj/machinery/computer/stockexchange,
+/turf/open/floor/plasteel/vault{
+	dir = 8
+	},
+/area/centcom/supply)
+"mc" = (
+/obj/machinery/computer/auxillary_base{
+	pixel_y = 32
+	},
+/obj/structure/table/reinforced,
+/obj/item/clipboard,
+/obj/item/folder/yellow,
+/obj/item/pen/red,
+/turf/open/floor/plasteel/vault{
+	dir = 8
+	},
+/area/centcom/supply)
+"md" = (
+/obj/machinery/computer/shuttle/labor,
+/obj/effect/turf_decal/stripes/line{
+	dir = 10
+	},
+/turf/open/floor/plasteel,
+/area/centcom/supply)
+"me" = (
+/obj/machinery/computer/shuttle/mining,
+/obj/effect/turf_decal/stripes/line{
+	dir = 6
+	},
+/turf/open/floor/plasteel,
+/area/centcom/supply)
+"mf" = (
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/structure/table/reinforced,
+/obj/item/crowbar/red,
+/obj/item/wrench,
+/obj/item/clothing/mask/gas,
+/turf/open/floor/plasteel/vault{
+	dir = 8
+	},
+/area/centcom/supply)
+"mg" = (
+/turf/open/floor/plasteel/vault{
+	dir = 8
+	},
+/area/centcom/supply)
+"mh" = (
+/obj/machinery/airalarm{
+	dir = 8;
+	pixel_x = 24
+	},
+/obj/structure/filingcabinet/filingcabinet,
+/turf/open/floor/plasteel/vault{
+	dir = 8
+	},
+/area/centcom/supply)
+"mi" = (
+/turf/open/floor/plasteel/brown{
+	dir = 9
+	},
+/area/centcom/supply)
+"mj" = (
+/obj/machinery/airalarm{
+	dir = 8;
+	pixel_x = 24
+	},
+/turf/open/floor/plasteel/brown{
+	dir = 5
+	},
+/area/centcom/supply)
+"mk" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/sign/directions/engineering{
+	desc = "A sign that shows there are doors here. There are doors everywhere!";
+	icon_state = "doors";
+	name = "WARNING: BLAST DOORS"
+	},
+/turf/open/floor/plating,
+/area/centcom/control)
+"ml" = (
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/open/floor/plasteel/darkred/side{
+	dir = 8
+	},
+/area/centcom/control)
+"mm" = (
+/obj/machinery/computer/secure_data,
+/turf/open/floor/plasteel/vault{
+	dir = 8
+	},
+/area/centcom/control)
+"mn" = (
+/obj/structure/table/wood,
+/obj/item/device/radio/intercom{
+	desc = "Talk smack through this.";
+	syndie = 1
+	},
+/turf/open/floor/plasteel/grimy,
+/area/centcom/control)
+"mo" = (
+/obj/structure/table/wood,
+/turf/open/floor/plasteel/grimy,
+/area/centcom/control)
+"mp" = (
+/obj/structure/table/wood,
+/obj/item/folder,
+/obj/item/pen/red,
+/turf/open/floor/plasteel/vault{
+	dir = 8
+	},
+/area/centcom/control)
+"mq" = (
+/obj/structure/chair{
+	dir = 8
+	},
+/obj/machinery/newscaster{
+	pixel_x = 32
+	},
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/open/floor/plasteel/grimy,
+/area/centcom/control)
+"mr" = (
+/turf/closed/indestructible/abductor{
+	icon_state = "alien6"
+	},
+/area/abductor_ship)
+"ms" = (
+/turf/closed/indestructible/abductor{
+	icon_state = "alien7"
+	},
+/area/abductor_ship)
+"mt" = (
+/obj/machinery/abductor/gland_dispenser,
+/turf/open/floor/plating/abductor,
+/area/abductor_ship)
+"mu" = (
+/obj/structure/table/abductor,
+/obj/item/surgicaldrill/alien,
+/obj/item/circular_saw/alien,
+/turf/open/floor/plating/abductor,
+/area/abductor_ship)
+"mv" = (
+/obj/structure/bed/abductor,
+/turf/open/floor/plating/abductor,
+/area/abductor_ship)
+"mw" = (
+/turf/closed/indestructible/abductor{
+	icon_state = "alien8"
+	},
+/area/abductor_ship)
+"mx" = (
+/turf/closed/indestructible/abductor{
+	icon_state = "alien9"
+	},
+/area/abductor_ship)
+"my" = (
 /obj/structure/flora/grass/brown,
 /turf/open/floor/plating/asteroid/snow/airless,
 /area/syndicate_mothership)
-"lG" = (
+"mz" = (
 /obj/structure/flora/tree/pine,
 /turf/open/floor/plating/asteroid/snow/airless,
 /area/syndicate_mothership)
-"lH" = (
+"mA" = (
+/obj/structure/flora/grass/both,
+/turf/open/floor/plating/asteroid/snow/airless,
+/area/syndicate_mothership)
+"mB" = (
 /turf/closed/indestructible/fakeglass{
 	icon_state = "fakewindows";
 	dir = 1
 	},
 /area/syndicate_mothership/control)
-"lI" = (
+"mC" = (
 /obj/item/disk/data,
 /obj/effect/light_emitter{
 	set_cap = 1;
@@ -4016,25 +4388,25 @@
 	},
 /turf/open/floor/plating/asteroid/snow/airless,
 /area/syndicate_mothership)
-"lJ" = (
+"mD" = (
 /turf/closed/indestructible/riveted,
 /area/centcom/ferry)
-"lK" = (
+"mE" = (
 /obj/machinery/computer/security/telescreen/entertainment,
 /turf/closed/indestructible/riveted,
 /area/centcom/ferry)
-"lL" = (
+"mF" = (
 /obj/machinery/ai_status_display,
 /turf/closed/indestructible/riveted,
 /area/centcom/supply)
-"lM" = (
+"mG" = (
 /obj/machinery/computer/cargo,
 /obj/effect/turf_decal/stripes/line{
 	dir = 5
 	},
 /turf/open/floor/plasteel,
 /area/centcom/supply)
-"lN" = (
+"mH" = (
 /obj/structure/chair/office/dark{
 	dir = 8
 	},
@@ -4042,7 +4414,7 @@
 	dir = 9
 	},
 /area/centcom/supply)
-"lO" = (
+"mI" = (
 /obj/structure/chair/office/dark{
 	dir = 1
 	},
@@ -4050,7 +4422,7 @@
 	dir = 1
 	},
 /area/centcom/supply)
-"lP" = (
+"mJ" = (
 /obj/structure/noticeboard{
 	dir = 8;
 	pixel_x = 32
@@ -4059,7 +4431,7 @@
 	dir = 5
 	},
 /area/centcom/supply)
-"lQ" = (
+"mK" = (
 /obj/structure/table,
 /obj/item/clipboard,
 /obj/item/stack/packageWrap,
@@ -4069,7 +4441,7 @@
 	dir = 9
 	},
 /area/centcom/control)
-"lR" = (
+"mL" = (
 /obj/item/twohanded/required/kirbyplants{
 	icon_state = "plant-22"
 	},
@@ -4077,7 +4449,7 @@
 	dir = 1
 	},
 /area/centcom/control)
-"lS" = (
+"mM" = (
 /obj/item/twohanded/required/kirbyplants{
 	icon_state = "plant-21";
 	pixel_x = -3;
@@ -4087,25 +4459,25 @@
 	dir = 1
 	},
 /area/centcom/control)
-"lT" = (
+"mN" = (
 /turf/open/floor/plasteel/green/side{
 	dir = 1
 	},
 /area/centcom/control)
-"lU" = (
+"mO" = (
 /obj/structure/chair,
 /turf/open/floor/plasteel/green/side{
 	dir = 1
 	},
 /area/centcom/control)
-"lV" = (
+"mP" = (
 /obj/item/storage/firstaid/regular,
 /obj/structure/table,
 /turf/open/floor/plasteel/green/side{
 	dir = 5
 	},
 /area/centcom/control)
-"lW" = (
+"mQ" = (
 /obj/structure/flora/ausbushes/lavendergrass,
 /obj/structure/flora/ausbushes/sparsegrass,
 /obj/structure/flora/ausbushes/fullgrass,
@@ -4113,14 +4485,14 @@
 /obj/structure/flora/ausbushes/genericbush,
 /turf/open/floor/grass,
 /area/centcom/control)
-"lX" = (
+"mR" = (
 /obj/machinery/door/firedoor,
 /obj/effect/turf_decal/stripes/line{
 	dir = 2
 	},
 /turf/open/floor/plasteel,
 /area/centcom/control)
-"lY" = (
+"mS" = (
 /obj/structure/table/reinforced,
 /obj/item/clipboard,
 /obj/item/folder/red,
@@ -4136,7 +4508,7 @@
 	},
 /turf/open/floor/plasteel,
 /area/centcom/control)
-"lZ" = (
+"mT" = (
 /obj/structure/table/reinforced,
 /obj/machinery/recharger,
 /obj/machinery/button/door{
@@ -4151,67 +4523,100 @@
 	},
 /turf/open/floor/plasteel,
 /area/centcom/control)
-"ma" = (
-/obj/machinery/light{
+"mU" = (
+/obj/item/book/manual/wiki/security_space_law,
+/obj/structure/table/wood,
+/turf/open/floor/plasteel/vault{
 	dir = 8
+	},
+/area/centcom/control)
+"mV" = (
+/obj/machinery/vending/cola,
+/turf/open/floor/plasteel/vault{
+	dir = 8
+	},
+/area/centcom/control)
+"mW" = (
+/obj/structure/reagent_dispensers/peppertank{
+	pixel_x = -32
 	},
 /turf/open/floor/plasteel/darkred/side{
 	dir = 8
 	},
 /area/centcom/control)
-"mb" = (
-/obj/machinery/computer/secure_data,
+"mX" = (
+/obj/structure/table/reinforced,
+/obj/item/restraints/handcuffs/cable/zipties,
+/obj/item/device/assembly/flash/handheld,
 /turf/open/floor/plasteel/vault{
 	dir = 8
 	},
 /area/centcom/control)
-"mc" = (
-/obj/structure/table/wood,
-/obj/item/device/radio/intercom{
-	desc = "Talk smack through this.";
-	syndie = 1
+"mY" = (
+/obj/structure/chair{
+	dir = 1
 	},
 /turf/open/floor/plasteel/grimy,
 /area/centcom/control)
-"md" = (
+"mZ" = (
 /obj/structure/table/wood,
-/turf/open/floor/plasteel/grimy,
-/area/centcom/control)
-"me" = (
-/obj/structure/table/wood,
-/obj/item/folder,
-/obj/item/pen/red,
+/obj/item/paper_bin,
+/obj/item/pen,
 /turf/open/floor/plasteel/vault{
 	dir = 8
 	},
 /area/centcom/control)
-"mf" = (
+"na" = (
 /obj/structure/chair{
 	dir = 8
 	},
 /obj/machinery/newscaster{
 	pixel_x = 32
 	},
-/obj/machinery/light{
-	dir = 4
-	},
 /turf/open/floor/plasteel/grimy,
 /area/centcom/control)
-"mg" = (
+"nb" = (
+/turf/closed/indestructible/abductor,
+/area/abductor_ship)
+"nc" = (
+/turf/closed/indestructible/abductor{
+	icon_state = "alien2"
+	},
+/area/abductor_ship)
+"nd" = (
+/turf/closed/indestructible/abductor{
+	icon_state = "alien3"
+	},
+/area/abductor_ship)
+"ne" = (
+/turf/closed/indestructible/abductor{
+	icon_state = "alien4"
+	},
+/area/abductor_ship)
+"nf" = (
+/turf/closed/indestructible/abductor{
+	icon_state = "alien5"
+	},
+/area/abductor_ship)
+"ng" = (
 /turf/closed/indestructible/fakeglass{
 	icon_state = "fakewindows2";
 	dir = 1
 	},
 /area/syndicate_mothership/control)
-"mh" = (
+"nh" = (
 /obj/item/toy/figure/syndie,
+/obj/effect/light_emitter{
+	set_cap = 1;
+	set_luminosity = 4
+	},
 /turf/open/floor/plating/asteroid/snow/airless,
 /area/syndicate_mothership)
-"mi" = (
+"ni" = (
 /obj/machinery/newscaster/security_unit,
 /turf/closed/indestructible/riveted,
 /area/centcom/ferry)
-"mj" = (
+"nj" = (
 /obj/structure/toilet{
 	dir = 4
 	},
@@ -4220,7 +4625,7 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/centcom/ferry)
-"mk" = (
+"nk" = (
 /obj/structure/window/reinforced{
 	dir = 8
 	},
@@ -4235,23 +4640,23 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on,
 /turf/open/floor/plasteel/white,
 /area/centcom/ferry)
-"ml" = (
+"nl" = (
 /obj/machinery/computer/security/mining,
 /obj/effect/turf_decal/stripes/line{
 	dir = 6
 	},
 /turf/open/floor/plasteel,
 /area/centcom/supply)
-"mm" = (
+"nm" = (
 /turf/open/floor/plasteel/brown{
 	dir = 10
 	},
 /area/centcom/supply)
-"mn" = (
+"nn" = (
 /obj/structure/chair/office/dark,
 /turf/open/floor/plasteel/brown,
 /area/centcom/supply)
-"mo" = (
+"no" = (
 /obj/structure/plasticflaps{
 	opacity = 1
 	},
@@ -4259,14 +4664,14 @@
 /obj/effect/turf_decal/delivery,
 /turf/open/floor/plasteel,
 /area/centcom/supply)
-"mp" = (
+"np" = (
 /obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel,
 /area/centcom/control)
-"mq" = (
+"nq" = (
 /turf/open/floor/plasteel/neutral,
 /area/centcom/control)
-"mr" = (
+"nr" = (
 /obj/structure/chair{
 	dir = 8
 	},
@@ -4277,76 +4682,70 @@
 	dir = 4
 	},
 /area/centcom/control)
-"ms" = (
-/obj/item/book/manual/wiki/security_space_law,
+"ns" = (
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/open/floor/plasteel/vault{
+	dir = 8
+	},
+/area/centcom/control)
+"nt" = (
+/obj/structure/table/wood,
+/obj/item/storage/photo_album,
+/obj/item/device/camera,
+/turf/open/floor/plasteel/vault{
+	dir = 8
+	},
+/area/centcom/control)
+"nu" = (
+/obj/item/paper/pamphlet/centcom/visitor_info,
+/obj/item/paper/pamphlet/centcom/visitor_info,
+/obj/item/paper/pamphlet/centcom/visitor_info,
 /obj/structure/table/wood,
 /turf/open/floor/plasteel/vault{
 	dir = 8
 	},
 /area/centcom/control)
-"mt" = (
-/obj/machinery/vending/cola,
-/turf/open/floor/plasteel/vault{
-	dir = 8
-	},
-/area/centcom/control)
-"mu" = (
-/obj/structure/reagent_dispensers/peppertank{
+"nv" = (
+/obj/machinery/newscaster/security_unit{
 	pixel_x = -32
 	},
 /turf/open/floor/plasteel/darkred/side{
 	dir = 8
 	},
 /area/centcom/control)
-"mv" = (
+"nw" = (
 /obj/structure/table/reinforced,
-/obj/item/restraints/handcuffs/cable/zipties,
-/obj/item/device/assembly/flash/handheld,
+/obj/machinery/recharger,
 /turf/open/floor/plasteel/vault{
 	dir = 8
 	},
 /area/centcom/control)
-"mw" = (
-/obj/structure/chair{
-	dir = 1
-	},
-/turf/open/floor/plasteel/grimy,
-/area/centcom/control)
-"mx" = (
-/obj/structure/table/wood,
-/obj/item/paper_bin,
-/obj/item/pen,
-/turf/open/floor/plasteel/vault{
-	dir = 8
-	},
-/area/centcom/control)
-"my" = (
-/obj/structure/chair{
-	dir = 8
-	},
-/obj/machinery/newscaster{
-	pixel_x = 32
-	},
-/turf/open/floor/plasteel/grimy,
-/area/centcom/control)
-"mz" = (
+"nx" = (
 /obj/structure/flora/bush,
 /turf/open/floor/plating/asteroid/snow/airless,
 /area/syndicate_mothership)
-"mA" = (
+"ny" = (
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/syndicate_mothership/control)
+"nz" = (
 /turf/closed/indestructible/fakeglass,
 /area/syndicate_mothership/control)
-"mB" = (
+"nA" = (
 /obj/structure/sign/nosmoking_2,
 /turf/closed/indestructible/riveted,
 /area/centcom/ferry)
-"mC" = (
+"nB" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 6
 	},
 /turf/open/floor/plasteel/white,
 /area/centcom/ferry)
-"mD" = (
+"nC" = (
 /obj/structure/sink{
 	dir = 4;
 	pixel_x = 11
@@ -4359,7 +4758,7 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/centcom/ferry)
-"mE" = (
+"nD" = (
 /obj/item/clipboard,
 /obj/item/stamp/denied{
 	pixel_x = 3;
@@ -4371,7 +4770,7 @@
 	dir = 8
 	},
 /area/centcom/supply)
-"mF" = (
+"nE" = (
 /obj/machinery/keycard_auth{
 	pixel_y = -24
 	},
@@ -4383,7 +4782,7 @@
 	dir = 8
 	},
 /area/centcom/supply)
-"mG" = (
+"nF" = (
 /obj/machinery/newscaster/security_unit{
 	pixel_y = -32
 	},
@@ -4393,21 +4792,21 @@
 	},
 /turf/open/floor/plasteel,
 /area/centcom/supply)
-"mH" = (
+"nG" = (
 /obj/machinery/computer/security/mining,
 /obj/effect/turf_decal/stripes/line{
 	dir = 5
 	},
 /turf/open/floor/plasteel,
 /area/centcom/supply)
-"mI" = (
+"nH" = (
 /obj/machinery/light,
 /obj/structure/filingcabinet/chestdrawer,
 /turf/open/floor/plasteel/vault{
 	dir = 8
 	},
 /area/centcom/supply)
-"mJ" = (
+"nI" = (
 /obj/machinery/firealarm{
 	dir = 1;
 	pixel_y = -24
@@ -4420,7 +4819,7 @@
 	dir = 4
 	},
 /area/centcom/supply)
-"mK" = (
+"nJ" = (
 /obj/machinery/firealarm{
 	dir = 1;
 	pixel_y = -26
@@ -4429,12 +4828,12 @@
 	dir = 6
 	},
 /area/centcom/supply)
-"mL" = (
+"nK" = (
 /turf/open/floor/plasteel/loadingarea{
 	dir = 1
 	},
 /area/centcom/control)
-"mM" = (
+"nL" = (
 /obj/structure/chair{
 	dir = 8
 	},
@@ -4442,7 +4841,7 @@
 	dir = 4
 	},
 /area/centcom/control)
-"mN" = (
+"nM" = (
 /obj/machinery/door/poddoor/shutters{
 	id = "XCCsecdepartment";
 	name = "XCC Security Checkpoint Shutters"
@@ -4450,103 +4849,25 @@
 /obj/effect/turf_decal/delivery,
 /turf/open/floor/plasteel,
 /area/centcom/control)
-"mO" = (
+"nN" = (
 /obj/structure/chair/office/dark,
 /turf/open/floor/plasteel/grimy,
 /area/centcom/control)
-"mP" = (
-/obj/structure/table/wood,
-/obj/item/storage/photo_album,
-/obj/item/device/camera,
-/turf/open/floor/plasteel/vault{
-	dir = 8
-	},
-/area/centcom/control)
-"mQ" = (
-/obj/item/paper/pamphlet/centcom/visitor_info,
-/obj/item/paper/pamphlet/centcom/visitor_info,
-/obj/item/paper/pamphlet/centcom/visitor_info,
-/obj/structure/table/wood,
-/turf/open/floor/plasteel/vault{
-	dir = 8
-	},
-/area/centcom/control)
-"mR" = (
-/obj/machinery/newscaster/security_unit{
-	pixel_x = -32
-	},
-/turf/open/floor/plasteel/darkred/side{
-	dir = 8
-	},
-/area/centcom/control)
-"mS" = (
-/obj/structure/table/reinforced,
-/obj/machinery/recharger,
-/turf/open/floor/plasteel/vault{
-	dir = 8
-	},
-/area/centcom/control)
-"mT" = (
-/obj/machinery/door/airlock/silver{
-	name = "Bathroom"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/turf/open/floor/plasteel/white,
-/area/centcom/ferry)
-"mU" = (
-/obj/machinery/ai_status_display,
-/turf/closed/indestructible/riveted,
-/area/centcom/ferry)
-"mV" = (
-/obj/machinery/status_display,
-/turf/closed/indestructible/riveted,
-/area/centcom/ferry)
-"mW" = (
-/obj/structure/chair{
+"nO" = (
+/obj/structure/chair/comfy/black{
 	dir = 4
 	},
-/turf/open/floor/plasteel/brown{
+/turf/open/floor/plasteel/vault{
 	dir = 8
 	},
 /area/centcom/control)
-"mX" = (
-/obj/machinery/vending/cola,
-/obj/effect/turf_decal/delivery,
-/turf/open/floor/plasteel,
-/area/centcom/control)
-"mY" = (
-/turf/open/floor/plasteel/red/side{
-	dir = 4
-	},
-/area/centcom/control)
-"mZ" = (
-/obj/machinery/computer/prisoner,
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/centcom/control)
-"na" = (
-/obj/machinery/computer/security,
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/centcom/control)
-"nb" = (
-/obj/machinery/computer/secure_data,
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/centcom/control)
-"nc" = (
+"nP" = (
 /obj/machinery/vending/snack,
 /turf/open/floor/plasteel/vault{
 	dir = 8
 	},
 /area/centcom/control)
-"nd" = (
+"nQ" = (
 /obj/machinery/door/window/brigdoor{
 	base_state = "rightsecure";
 	dir = 2;
@@ -4562,7 +4883,7 @@
 	dir = 8
 	},
 /area/centcom/control)
-"ne" = (
+"nR" = (
 /obj/machinery/door/window/brigdoor{
 	base_state = "rightsecure";
 	dir = 2;
@@ -4578,11 +4899,88 @@
 	dir = 8
 	},
 /area/centcom/control)
-"nf" = (
+"nS" = (
+/obj/machinery/door/airlock/silver{
+	name = "Bathroom"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/turf/open/floor/plasteel/white,
+/area/centcom/ferry)
+"nT" = (
+/obj/machinery/ai_status_display,
+/turf/closed/indestructible/riveted,
+/area/centcom/ferry)
+"nU" = (
+/obj/machinery/status_display,
+/turf/closed/indestructible/riveted,
+/area/centcom/ferry)
+"nV" = (
+/obj/structure/chair{
+	dir = 4
+	},
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/open/floor/plasteel/brown{
+	dir = 8
+	},
+/area/centcom/control)
+"nW" = (
+/obj/machinery/vending/cola,
+/obj/effect/turf_decal/delivery,
+/turf/open/floor/plasteel,
+/area/centcom/control)
+"nX" = (
+/turf/open/floor/plasteel/red/side{
+	dir = 4
+	},
+/area/centcom/control)
+"nY" = (
+/obj/machinery/computer/prisoner,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/centcom/control)
+"nZ" = (
+/obj/machinery/computer/security,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/centcom/control)
+"oa" = (
+/obj/machinery/computer/secure_data,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/centcom/control)
+"ob" = (
+/obj/structure/table/wood,
+/obj/item/paper_bin,
+/obj/item/pen/fourcolor,
+/turf/open/floor/plasteel/vault{
+	dir = 8
+	},
+/area/centcom/control)
+"oc" = (
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/open/floor/plasteel/vault,
+/area/centcom/control)
+"od" = (
+/obj/structure/chair{
+	dir = 1
+	},
+/turf/open/floor/plasteel/vault,
+/area/centcom/control)
+"oe" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/centcom/ferry)
-"ng" = (
+"of" = (
 /obj/structure/table/wood,
 /obj/item/device/taperecorder,
 /obj/item/storage/box/handcuffs,
@@ -4594,7 +4992,7 @@
 	dir = 8
 	},
 /area/centcom/ferry)
-"nh" = (
+"og" = (
 /obj/structure/table/wood,
 /obj/item/storage/photo_album,
 /obj/item/device/camera,
@@ -4605,7 +5003,7 @@
 	dir = 8
 	},
 /area/centcom/ferry)
-"ni" = (
+"oh" = (
 /obj/machinery/ai_status_display{
 	pixel_y = 32
 	},
@@ -4618,11 +5016,11 @@
 	dir = 6
 	},
 /area/centcom/ferry)
-"nj" = (
+"oi" = (
 /obj/structure/fireplace,
 /turf/open/floor/plasteel/vault,
 /area/centcom/ferry)
-"nk" = (
+"oj" = (
 /obj/machinery/status_display{
 	pixel_y = 32
 	},
@@ -4630,13 +5028,13 @@
 	dir = 10
 	},
 /area/centcom/ferry)
-"nl" = (
+"ok" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plasteel/vault{
 	dir = 8
 	},
 /area/centcom/ferry)
-"nm" = (
+"ol" = (
 /obj/structure/table/wood,
 /obj/item/device/flashlight/lamp,
 /obj/machinery/requests_console{
@@ -4648,16 +5046,16 @@
 	},
 /turf/open/floor/plasteel/grimy,
 /area/centcom/ferry)
-"nn" = (
+"om" = (
 /obj/machinery/computer/card/centcom,
 /obj/item/card/id/centcom,
 /turf/open/floor/plasteel/grimy,
 /area/centcom/ferry)
-"no" = (
+"on" = (
 /obj/machinery/computer/communications,
 /turf/open/floor/plasteel/grimy,
 /area/centcom/ferry)
-"np" = (
+"oo" = (
 /obj/structure/table/wood,
 /obj/item/paper_bin,
 /obj/item/pen/fourcolor,
@@ -4669,7 +5067,7 @@
 	},
 /turf/open/floor/plasteel/vault,
 /area/centcom/ferry)
-"nq" = (
+"op" = (
 /obj/structure/table/wood,
 /obj/item/clipboard,
 /obj/item/folder/blue,
@@ -4680,7 +5078,7 @@
 	},
 /turf/open/floor/plasteel/vault,
 /area/centcom/ferry)
-"nr" = (
+"oq" = (
 /obj/structure/table/wood,
 /obj/machinery/computer/security/wooden_tv,
 /obj/item/storage/secure/safe{
@@ -4689,14 +5087,14 @@
 	},
 /turf/open/floor/plasteel/vault,
 /area/centcom/ferry)
-"ns" = (
+"or" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/filingcabinet/chestdrawer,
 /turf/open/floor/plasteel/vault{
 	dir = 8
 	},
 /area/centcom/supply)
-"nt" = (
+"os" = (
 /obj/structure/table/reinforced,
 /obj/item/paper_bin,
 /obj/item/pen/red,
@@ -4705,7 +5103,7 @@
 	},
 /turf/open/floor/plasteel,
 /area/centcom/supply)
-"nu" = (
+"ot" = (
 /obj/structure/table/reinforced,
 /obj/item/stack/packageWrap,
 /obj/item/hand_labeler,
@@ -4715,21 +5113,21 @@
 	},
 /turf/open/floor/plasteel,
 /area/centcom/supply)
-"nv" = (
+"ou" = (
 /obj/machinery/photocopier,
 /obj/effect/turf_decal/stripes/line{
 	dir = 6
 	},
 /turf/open/floor/plasteel,
 /area/centcom/supply)
-"nw" = (
+"ov" = (
 /obj/machinery/computer/cargo,
 /obj/effect/turf_decal/stripes/line{
 	dir = 9
 	},
 /turf/open/floor/plasteel,
 /area/centcom/supply)
-"nx" = (
+"ow" = (
 /obj/structure/table,
 /obj/item/paper_bin,
 /obj/item/pen,
@@ -4737,7 +5135,7 @@
 	dir = 8
 	},
 /area/centcom/control)
-"ny" = (
+"ox" = (
 /obj/structure/table,
 /obj/item/paper/pamphlet/centcom/visitor_info,
 /obj/item/paper/pamphlet/centcom/visitor_info,
@@ -4745,7 +5143,7 @@
 /obj/effect/turf_decal/delivery,
 /turf/open/floor/plasteel,
 /area/centcom/control)
-"nz" = (
+"oy" = (
 /obj/item/twohanded/required/kirbyplants{
 	icon_state = "plant-21";
 	pixel_x = -3;
@@ -4755,27 +5153,19 @@
 	dir = 4
 	},
 /area/centcom/control)
-"nA" = (
+"oz" = (
 /obj/structure/table/wood,
 /obj/item/paper_bin,
 /obj/item/pen/fourcolor,
+/obj/machinery/airalarm{
+	dir = 8;
+	pixel_x = 24
+	},
 /turf/open/floor/plasteel/vault{
 	dir = 8
 	},
 /area/centcom/control)
-"nB" = (
-/obj/machinery/light{
-	dir = 1
-	},
-/turf/open/floor/plasteel/vault,
-/area/centcom/control)
-"nC" = (
-/obj/structure/chair{
-	dir = 1
-	},
-/turf/open/floor/plasteel/vault,
-/area/centcom/control)
-"nD" = (
+"oA" = (
 /obj/item/storage/briefcase{
 	pixel_x = -3;
 	pixel_y = 3
@@ -4786,10 +5176,10 @@
 	dir = 8
 	},
 /area/centcom/ferry)
-"nE" = (
+"oB" = (
 /turf/open/floor/wood,
 /area/centcom/ferry)
-"nF" = (
+"oC" = (
 /obj/structure/chair/comfy/brown{
 	color = "#c45c57";
 	dir = 4;
@@ -4797,22 +5187,22 @@
 	},
 /turf/open/floor/plasteel/grimy,
 /area/centcom/ferry)
-"nG" = (
+"oD" = (
 /obj/structure/table/wood,
 /obj/item/storage/fancy/donut_box,
 /turf/open/floor/plasteel/grimy,
 /area/centcom/ferry)
-"nH" = (
+"oE" = (
 /obj/structure/chair/comfy/black{
 	dir = 8
 	},
 /turf/open/floor/plasteel/grimy,
 /area/centcom/ferry)
-"nI" = (
+"oF" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/wood,
 /area/centcom/ferry)
-"nJ" = (
+"oG" = (
 /obj/structure/table/wood,
 /obj/item/clipboard,
 /obj/item/folder/red,
@@ -4823,7 +5213,7 @@
 /obj/item/stamp,
 /turf/open/floor/plasteel/grimy,
 /area/centcom/ferry)
-"nK" = (
+"oH" = (
 /obj/structure/chair/comfy/brown{
 	color = "#c45c57";
 	dir = 8;
@@ -4834,13 +5224,13 @@
 	},
 /turf/open/floor/plasteel/grimy,
 /area/centcom/ferry)
-"nL" = (
+"oI" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
 /turf/open/floor/plasteel/grimy,
 /area/centcom/ferry)
-"nM" = (
+"oJ" = (
 /obj/machinery/door/airlock/centcom{
 	name = "Administrative Office";
 	opacity = 1;
@@ -4853,7 +5243,7 @@
 	dir = 8
 	},
 /area/centcom/ferry)
-"nN" = (
+"oK" = (
 /obj/structure/chair/comfy/brown{
 	color = "#596479";
 	dir = 1
@@ -4863,13 +5253,13 @@
 	},
 /turf/open/floor/plasteel/grimy,
 /area/centcom/ferry)
-"nO" = (
+"oL" = (
 /obj/machinery/modular_computer/console/preset/command,
 /turf/open/floor/plasteel/vault{
 	dir = 8
 	},
 /area/centcom/ferry)
-"nP" = (
+"oM" = (
 /obj/structure/table/reinforced,
 /obj/machinery/computer/stockexchange,
 /obj/effect/turf_decal/stripes/line{
@@ -4877,36 +5267,79 @@
 	},
 /turf/open/floor/plasteel,
 /area/centcom/supply)
-"nQ" = (
+"oN" = (
 /turf/open/floor/plasteel/brown{
 	dir = 5
 	},
 /area/centcom/supply)
-"nR" = (
+"oO" = (
 /obj/machinery/computer/security/mining,
 /obj/effect/turf_decal/stripes/line{
 	dir = 10
 	},
 /turf/open/floor/plasteel,
 /area/centcom/supply)
-"nS" = (
+"oP" = (
+/obj/structure/chair{
+	dir = 4
+	},
+/turf/open/floor/plasteel/brown{
+	dir = 8
+	},
+/area/centcom/control)
+"oQ" = (
 /obj/machinery/vending/snack,
 /obj/effect/turf_decal/delivery,
 /turf/open/floor/plasteel,
 /area/centcom/control)
-"nT" = (
+"oR" = (
+/obj/item/storage/briefcase{
+	pixel_x = -3;
+	pixel_y = 3
+	},
+/obj/item/storage/secure/briefcase,
 /obj/structure/table/wood,
-/obj/item/paper_bin,
-/obj/item/pen/fourcolor,
-/obj/machinery/airalarm{
+/obj/structure/noticeboard{
 	dir = 8;
-	pixel_x = 24
+	pixel_x = 32
 	},
 /turf/open/floor/plasteel/vault{
 	dir = 8
 	},
 /area/centcom/control)
-"nU" = (
+"oS" = (
+/obj/machinery/porta_turret/syndicate{
+	dir = 9
+	},
+/turf/closed/wall/mineral/plastitanium,
+/area/shuttle/syndicate/bridge)
+"oT" = (
+/turf/closed/wall/mineral/plastitanium,
+/area/shuttle/syndicate/bridge)
+"oU" = (
+/obj/structure/window/plastitanium,
+/obj/machinery/door/poddoor/shutters{
+	id = "syndieshutters";
+	name = "blast shutters"
+	},
+/obj/structure/grille,
+/turf/open/floor/plating,
+/area/shuttle/syndicate/bridge)
+"oV" = (
+/obj/machinery/porta_turret/syndicate{
+	dir = 5
+	},
+/turf/closed/wall/mineral/plastitanium,
+/area/shuttle/syndicate/bridge)
+"oW" = (
+/obj/structure/flora/bush,
+/obj/effect/light_emitter{
+	set_cap = 1;
+	set_luminosity = 4
+	},
+/turf/open/floor/plating/asteroid/snow/airless,
+/area/syndicate_mothership)
+"oX" = (
 /obj/structure/bookcase/random,
 /obj/machinery/light{
 	dir = 8
@@ -4915,13 +5348,13 @@
 	dir = 5
 	},
 /area/centcom/ferry)
-"nV" = (
+"oY" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 4
 	},
 /turf/open/floor/wood,
 /area/centcom/ferry)
-"nW" = (
+"oZ" = (
 /obj/structure/chair/comfy/black{
 	dir = 4
 	},
@@ -4930,7 +5363,7 @@
 	},
 /turf/open/floor/plasteel/grimy,
 /area/centcom/ferry)
-"nX" = (
+"pa" = (
 /obj/structure/table/wood,
 /obj/item/phone{
 	desc = "Supposedly a direct line to Nanotrasen Central Command. It's not even plugged in.";
@@ -4951,7 +5384,7 @@
 	},
 /turf/open/floor/plasteel/grimy,
 /area/centcom/ferry)
-"nY" = (
+"pb" = (
 /obj/structure/chair/comfy/brown{
 	color = "#c45c57";
 	dir = 8;
@@ -4959,19 +5392,19 @@
 	},
 /turf/open/floor/plasteel/grimy,
 /area/centcom/ferry)
-"nZ" = (
+"pc" = (
 /obj/structure/table/wood,
 /obj/item/paper_bin,
 /obj/item/pen/fourcolor,
 /turf/open/floor/plasteel/grimy,
 /area/centcom/ferry)
-"oa" = (
+"pd" = (
 /obj/structure/table/wood,
 /obj/machinery/computer/security/wooden_tv,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plasteel/grimy,
 /area/centcom/ferry)
-"ob" = (
+"pe" = (
 /obj/machinery/light{
 	dir = 4
 	},
@@ -4980,16 +5413,16 @@
 	},
 /turf/open/floor/plasteel/grimy,
 /area/centcom/ferry)
-"oc" = (
+"pf" = (
 /obj/machinery/light_switch{
 	pixel_x = -24
 	},
 /turf/open/floor/plasteel/grimy,
 /area/centcom/ferry)
-"od" = (
+"pg" = (
 /turf/open/floor/plasteel/grimy,
 /area/centcom/ferry)
-"oe" = (
+"ph" = (
 /obj/item/twohanded/required/kirbyplants{
 	icon_state = "plant-21"
 	},
@@ -5003,7 +5436,7 @@
 	dir = 8
 	},
 /area/centcom/ferry)
-"of" = (
+"pi" = (
 /obj/structure/table/reinforced,
 /obj/item/folder/yellow,
 /obj/item/stamp/qm,
@@ -5012,7 +5445,7 @@
 	},
 /turf/open/floor/plasteel,
 /area/centcom/supply)
-"og" = (
+"pj" = (
 /obj/structure/chair/office/dark{
 	dir = 8
 	},
@@ -5020,7 +5453,7 @@
 	dir = 8
 	},
 /area/centcom/supply)
-"oh" = (
+"pk" = (
 /obj/structure/chair/office/dark{
 	dir = 4
 	},
@@ -5028,7 +5461,7 @@
 	dir = 8
 	},
 /area/centcom/supply)
-"oi" = (
+"pl" = (
 /obj/structure/table/reinforced,
 /obj/machinery/door/firedoor,
 /obj/machinery/door/window/brigdoor{
@@ -5044,36 +5477,153 @@
 /obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel,
 /area/centcom/supply)
-"oj" = (
+"pm" = (
+/obj/effect/turf_decal/stripes/line,
+/obj/machinery/light,
+/turf/open/floor/plasteel,
+/area/centcom/control)
+"pn" = (
+/obj/structure/table/wood,
+/obj/item/storage/fancy/donut_box,
+/turf/open/floor/plasteel/vault{
+	dir = 8
+	},
+/area/centcom/control)
+"po" = (
+/obj/structure/chair/comfy/brown{
+	dir = 1
+	},
+/turf/open/floor/plasteel/vault{
+	dir = 8
+	},
+/area/centcom/control)
+"pp" = (
 /obj/structure/chair/comfy/black{
+	dir = 1
+	},
+/obj/machinery/light,
+/obj/machinery/status_display{
+	pixel_y = -32
+	},
+/turf/open/floor/plasteel/vault{
+	dir = 8
+	},
+/area/centcom/control)
+"pq" = (
+/obj/structure/bookcase/random,
+/obj/machinery/airalarm{
+	dir = 1;
+	pixel_y = -22
+	},
+/turf/open/floor/plasteel/vault{
+	dir = 8
+	},
+/area/centcom/control)
+"pr" = (
+/obj/structure/bookcase/random,
+/obj/machinery/status_display{
+	pixel_y = -32
+	},
+/turf/open/floor/plasteel/vault{
+	dir = 8
+	},
+/area/centcom/control)
+"ps" = (
+/obj/structure/bookcase/random,
+/obj/structure/noticeboard{
+	dir = 1;
+	pixel_y = -32
+	},
+/turf/open/floor/plasteel/vault{
+	dir = 8
+	},
+/area/centcom/control)
+"pt" = (
+/obj/machinery/vending/coffee,
+/obj/machinery/newscaster{
+	pixel_y = -32
+	},
+/turf/open/floor/plasteel/vault{
+	dir = 1
+	},
+/area/centcom/control)
+"pu" = (
+/obj/structure/table/wood,
+/obj/item/storage/fancy/donut_box,
+/obj/machinery/light,
+/turf/open/floor/plasteel/vault{
+	dir = 8
+	},
+/area/centcom/control)
+"pv" = (
+/obj/machinery/vending/cigarette,
+/obj/machinery/newscaster{
+	pixel_y = -32
+	},
+/turf/open/floor/plasteel/vault{
 	dir = 4
 	},
-/turf/open/floor/plasteel/vault{
-	dir = 8
-	},
 /area/centcom/control)
-"ok" = (
-/obj/item/storage/briefcase{
-	pixel_x = -3;
-	pixel_y = 3
+"pw" = (
+/obj/item/twohanded/required/kirbyplants{
+	icon_state = "plant-22"
 	},
-/obj/item/storage/secure/briefcase,
-/obj/structure/table/wood,
-/obj/structure/noticeboard{
-	dir = 8;
-	pixel_x = 32
+/obj/structure/extinguisher_cabinet{
+	pixel_y = -32
 	},
 /turf/open/floor/plasteel/vault{
 	dir = 8
 	},
 /area/centcom/control)
-"ol" = (
+"px" = (
+/obj/machinery/computer/med_data/syndie,
+/turf/open/floor/plasteel/vault{
+	dir = 8
+	},
+/area/shuttle/syndicate/bridge)
+"py" = (
+/obj/machinery/computer/crew/syndie,
+/turf/open/floor/plasteel/vault{
+	dir = 8
+	},
+/area/shuttle/syndicate/bridge)
+"pz" = (
+/obj/machinery/computer/camera_advanced/shuttle_docker/syndicate,
+/turf/open/floor/plasteel/vault{
+	dir = 8
+	},
+/area/shuttle/syndicate/bridge)
+"pA" = (
+/obj/machinery/computer/shuttle/syndicate,
+/turf/open/floor/plasteel/vault{
+	dir = 8
+	},
+/area/shuttle/syndicate/bridge)
+"pB" = (
+/obj/structure/table/reinforced,
+/turf/open/floor/plasteel/vault{
+	dir = 8
+	},
+/area/shuttle/syndicate/bridge)
+"pC" = (
+/obj/machinery/computer/camera_advanced/syndie,
+/turf/open/floor/plasteel/vault{
+	dir = 8
+	},
+/area/shuttle/syndicate/bridge)
+"pD" = (
+/obj/machinery/computer/secure_data/syndie,
+/turf/open/floor/plasteel/vault{
+	dir = 8
+	},
+/area/shuttle/syndicate/bridge)
+"pE" = (
 /turf/closed/indestructible/fakeglass{
 	icon_state = "fakewindows2";
 	dir = 6
 	},
 /area/syndicate_mothership/control)
-"om" = (
+"pF" = (
 /obj/machinery/door/airlock/centcom{
 	name = "Auxillary Dock";
 	opacity = 1;
@@ -5081,34 +5631,42 @@
 	},
 /turf/open/floor/plating,
 /area/syndicate_mothership/control)
-"on" = (
+"pG" = (
+/obj/structure/flora/tree/pine,
+/obj/effect/light_emitter{
+	set_cap = 1;
+	set_luminosity = 4
+	},
+/turf/open/floor/plating/asteroid/snow/airless,
+/area/syndicate_mothership)
+"pH" = (
 /obj/structure/table/wood,
 /obj/machinery/recharger,
 /turf/open/floor/plasteel/vault{
 	dir = 8
 	},
 /area/centcom/ferry)
-"oo" = (
+"pI" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
 	dir = 8
 	},
 /turf/open/floor/wood,
 /area/centcom/ferry)
-"op" = (
+"pJ" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
 /turf/open/floor/wood,
 /area/centcom/ferry)
-"oq" = (
+"pK" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden,
 /turf/open/floor/wood,
 /area/centcom/ferry)
-"or" = (
+"pL" = (
 /obj/machinery/atmospherics/pipe/manifold4w/supply/hidden,
 /turf/open/floor/plasteel/grimy,
 /area/centcom/ferry)
-"os" = (
+"pM" = (
 /obj/machinery/firealarm{
 	dir = 4;
 	pixel_x = 24
@@ -5118,7 +5676,7 @@
 	},
 /turf/open/floor/plasteel/grimy,
 /area/centcom/ferry)
-"ot" = (
+"pN" = (
 /obj/structure/closet/secure_closet/personal/cabinet,
 /obj/item/clothing/under/rank/curator/treasure_hunter,
 /obj/item/clothing/under/skirt/black,
@@ -5142,7 +5700,7 @@
 	},
 /turf/open/floor/plasteel/grimy,
 /area/centcom/ferry)
-"ou" = (
+"pO" = (
 /obj/structure/destructible/cult/tome,
 /obj/item/book/codex_gigas,
 /obj/machinery/airalarm{
@@ -5153,7 +5711,7 @@
 	dir = 8
 	},
 /area/centcom/ferry)
-"ov" = (
+"pP" = (
 /obj/structure/table/reinforced,
 /obj/item/cartridge/quartermaster{
 	pixel_x = -6
@@ -5170,7 +5728,7 @@
 	},
 /turf/open/floor/plasteel,
 /area/centcom/supply)
-"ow" = (
+"pQ" = (
 /obj/structure/table/reinforced,
 /obj/machinery/door/firedoor,
 /obj/structure/window/reinforced{
@@ -5181,88 +5739,66 @@
 /obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel,
 /area/centcom/supply)
-"ox" = (
-/obj/structure/table/wood,
-/obj/item/storage/fancy/donut_box,
-/turf/open/floor/plasteel/vault{
-	dir = 8
-	},
-/area/centcom/control)
-"oy" = (
-/obj/structure/chair/comfy/brown{
-	dir = 1
-	},
-/turf/open/floor/plasteel/vault{
-	dir = 8
-	},
-/area/centcom/control)
-"oA" = (
-/obj/structure/bookcase/random,
-/obj/machinery/airalarm{
-	dir = 1;
-	pixel_y = -22
-	},
-/turf/open/floor/plasteel/vault{
-	dir = 8
-	},
-/area/centcom/control)
-"oB" = (
-/obj/structure/bookcase/random,
+"pR" = (
+/obj/structure/table/reinforced,
 /obj/machinery/status_display{
-	pixel_y = -32
+	pixel_x = -32
 	},
+/obj/item/clipboard,
+/obj/machinery/light{
+	dir = 8
+	},
+/obj/item/folder/red,
+/obj/item/toy/figure/syndie,
 /turf/open/floor/plasteel/vault{
 	dir = 8
 	},
-/area/centcom/control)
-"oC" = (
-/obj/structure/bookcase/random,
-/obj/structure/noticeboard{
+/area/shuttle/syndicate/bridge)
+"pS" = (
+/obj/structure/chair/office/dark{
+	dir = 8;
+	name = "tactical swivel chair"
+	},
+/turf/open/floor/plasteel/black,
+/area/shuttle/syndicate/bridge)
+"pT" = (
+/turf/open/floor/plasteel/black,
+/area/shuttle/syndicate/bridge)
+"pU" = (
+/obj/structure/chair/office/dark{
 	dir = 1;
-	pixel_y = -32
+	name = "tactical swivel chair"
 	},
-/turf/open/floor/plasteel/vault{
-	dir = 8
+/obj/machinery/button/door{
+	id = "syndieshutters";
+	name = "Cockpit View Control";
+	pixel_x = 32;
+	pixel_y = 32;
+	req_access_txt = "150"
 	},
-/area/centcom/control)
-"oD" = (
-/obj/machinery/vending/coffee,
-/obj/machinery/newscaster{
-	pixel_y = -32
+/turf/open/floor/plasteel/black,
+/area/shuttle/syndicate/bridge)
+"pV" = (
+/obj/structure/chair/office/dark{
+	dir = 4;
+	name = "tactical swivel chair"
 	},
-/turf/open/floor/plasteel/vault{
-	dir = 1
+/turf/open/floor/plasteel/black,
+/area/shuttle/syndicate/bridge)
+"pW" = (
+/obj/structure/table/reinforced,
+/obj/machinery/ai_status_display{
+	pixel_x = 32
 	},
-/area/centcom/control)
-"oE" = (
-/obj/structure/table/wood,
 /obj/item/storage/fancy/donut_box,
-/obj/machinery/light,
-/turf/open/floor/plasteel/vault{
-	dir = 8
-	},
-/area/centcom/control)
-"oF" = (
-/obj/machinery/vending/cigarette,
-/obj/machinery/newscaster{
-	pixel_y = -32
-	},
-/turf/open/floor/plasteel/vault{
+/obj/machinery/light{
 	dir = 4
 	},
-/area/centcom/control)
-"oG" = (
-/obj/item/twohanded/required/kirbyplants{
-	icon_state = "plant-22"
-	},
-/obj/structure/extinguisher_cabinet{
-	pixel_y = -32
-	},
 /turf/open/floor/plasteel/vault{
 	dir = 8
 	},
-/area/centcom/control)
-"oH" = (
+/area/shuttle/syndicate/bridge)
+"pX" = (
 /obj/item/storage/crayons,
 /obj/structure/table,
 /obj/item/storage/crayons,
@@ -5270,18 +5806,26 @@
 	dir = 2
 	},
 /area/syndicate_mothership/control)
-"oI" = (
+"pY" = (
 /obj/machinery/washing_machine,
 /turf/open/floor/plasteel/freezer{
 	dir = 2
 	},
 /area/syndicate_mothership/control)
-"oJ" = (
+"pZ" = (
 /turf/open/floor/plasteel/bar{
 	dir = 2
 	},
 /area/syndicate_mothership/control)
-"oK" = (
+"qa" = (
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/open/floor/plasteel/bar{
+	dir = 2
+	},
+/area/syndicate_mothership/control)
+"qb" = (
 /obj/structure/table/wood,
 /obj/item/folder/red,
 /obj/item/book/manual/wiki/security_space_law,
@@ -5295,7 +5839,7 @@
 	dir = 8
 	},
 /area/centcom/ferry)
-"oL" = (
+"qc" = (
 /obj/structure/table/wood,
 /obj/item/folder/red,
 /obj/item/lighter,
@@ -5307,13 +5851,13 @@
 	dir = 8
 	},
 /area/centcom/ferry)
-"oM" = (
+"qd" = (
 /obj/item/twohanded/required/kirbyplants{
 	icon_state = "plant-21"
 	},
 /turf/open/floor/wood,
 /area/centcom/ferry)
-"oN" = (
+"qe" = (
 /obj/item/twohanded/required/kirbyplants{
 	icon_state = "plant-22"
 	},
@@ -5322,12 +5866,12 @@
 	},
 /turf/open/floor/wood,
 /area/centcom/ferry)
-"oO" = (
+"qf" = (
 /obj/structure/closet/crate/bin,
 /obj/machinery/light,
 /turf/open/floor/wood,
 /area/centcom/ferry)
-"oP" = (
+"qg" = (
 /obj/structure/table/wood,
 /obj/item/clipboard,
 /obj/item/toy/figure/dsquad,
@@ -5335,11 +5879,11 @@
 	dir = 8
 	},
 /area/centcom/ferry)
-"oQ" = (
+"qh" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plasteel/vault,
 /area/centcom/ferry)
-"oR" = (
+"qi" = (
 /obj/structure/table/wood,
 /obj/item/storage/secure/briefcase{
 	pixel_x = 5;
@@ -5353,19 +5897,19 @@
 	dir = 8
 	},
 /area/centcom/ferry)
-"oS" = (
+"qj" = (
 /obj/structure/table/wood,
 /obj/item/device/flashlight/lamp,
 /turf/open/floor/plasteel/vault,
 /area/centcom/ferry)
-"oT" = (
+"qk" = (
 /obj/structure/bed,
 /obj/item/bedsheet/black,
 /turf/open/floor/plasteel/vault{
 	dir = 8
 	},
 /area/centcom/ferry)
-"oU" = (
+"ql" = (
 /obj/structure/dresser,
 /obj/structure/sign/goldenplaque/captain{
 	pixel_x = 32
@@ -5374,13 +5918,13 @@
 	dir = 8
 	},
 /area/centcom/ferry)
-"oV" = (
+"qm" = (
 /obj/structure/filingcabinet/filingcabinet,
 /turf/open/floor/plasteel/vault{
 	dir = 8
 	},
 /area/centcom/supply)
-"oW" = (
+"qn" = (
 /obj/structure/filingcabinet/filingcabinet,
 /obj/machinery/airalarm{
 	dir = 1;
@@ -5391,7 +5935,7 @@
 	},
 /turf/open/floor/plasteel,
 /area/centcom/supply)
-"oX" = (
+"qo" = (
 /obj/structure/table/reinforced,
 /obj/item/folder,
 /obj/item/stamp/denied{
@@ -5405,7 +5949,7 @@
 /obj/machinery/light,
 /turf/open/floor/plasteel,
 /area/centcom/supply)
-"oY" = (
+"qp" = (
 /obj/machinery/firealarm{
 	dir = 1;
 	pixel_y = -26
@@ -5414,7 +5958,7 @@
 	dir = 8
 	},
 /area/centcom/supply)
-"oZ" = (
+"qq" = (
 /obj/machinery/button/door{
 	id = "XCCsec3";
 	name = "XCC Shutter 3 Control";
@@ -5425,22 +5969,22 @@
 	dir = 8
 	},
 /area/centcom/supply)
-"pa" = (
+"qr" = (
 /obj/structure/closet/crate/bin,
 /turf/open/floor/plasteel/green/side{
 	dir = 10
 	},
 /area/centcom/control)
-"pb" = (
+"qs" = (
 /obj/structure/chair{
 	dir = 1
 	},
 /turf/open/floor/plasteel/green/side,
 /area/centcom/control)
-"pc" = (
+"qt" = (
 /turf/open/floor/plasteel/green/side,
 /area/centcom/control)
-"pd" = (
+"qu" = (
 /obj/structure/table,
 /obj/item/paper_bin,
 /obj/item/pen,
@@ -5448,7 +5992,7 @@
 	dir = 6
 	},
 /area/centcom/control)
-"pe" = (
+"qv" = (
 /obj/structure/flora/ausbushes/lavendergrass,
 /obj/structure/flora/ausbushes/fullgrass,
 /obj/structure/flora/ausbushes/ywflowers,
@@ -5456,7 +6000,7 @@
 /obj/structure/flora/ausbushes/palebush,
 /turf/open/floor/plating/asteroid,
 /area/centcom/control)
-"pf" = (
+"qw" = (
 /obj/structure/flora/ausbushes/sparsegrass,
 /obj/structure/flora/ausbushes/lavendergrass,
 /obj/structure/flora/ausbushes/fernybush,
@@ -5465,57 +6009,103 @@
 	icon_state = "asteroid5"
 	},
 /area/centcom/control)
-"pg" = (
+"qx" = (
+/turf/closed/indestructible/riveted,
+/area/centcom/evac)
+"qy" = (
+/obj/structure/flora/ausbushes/lavendergrass,
+/obj/structure/flora/ausbushes/sparsegrass,
+/obj/structure/flora/ausbushes/fullgrass,
+/obj/structure/flora/ausbushes/brflowers,
+/obj/structure/flora/ausbushes/genericbush,
+/turf/open/floor/grass,
+/area/centcom/evac)
+"qz" = (
+/obj/structure/flora/ausbushes/lavendergrass,
+/obj/structure/flora/ausbushes/sparsegrass,
+/obj/structure/flora/ausbushes/fullgrass,
+/obj/structure/flora/ausbushes/grassybush,
+/obj/structure/flora/ausbushes/ppflowers,
+/obj/structure/flora/ausbushes/pointybush,
+/turf/open/floor/grass,
+/area/centcom/evac)
+"qA" = (
+/obj/structure/flora/ausbushes/lavendergrass,
+/obj/structure/flora/ausbushes/sparsegrass,
+/obj/structure/flora/ausbushes/fullgrass,
+/obj/structure/flora/ausbushes/grassybush,
+/obj/structure/flora/ausbushes/ppflowers,
+/obj/structure/flora/ausbushes/pointybush,
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/open/floor/grass,
+/area/centcom/evac)
+"qB" = (
+/obj/structure/flora/ausbushes/ppflowers,
+/obj/structure/flora/ausbushes/lavendergrass,
+/turf/open/floor/grass,
+/area/centcom/evac)
+"qC" = (
+/obj/structure/flora/ausbushes/ywflowers,
+/obj/structure/flora/ausbushes/lavendergrass,
+/obj/structure/flora/ausbushes/brflowers,
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/open/floor/grass,
+/area/centcom/evac)
+"qD" = (
+/obj/structure/flora/ausbushes/brflowers,
+/obj/structure/flora/ausbushes/lavendergrass,
+/turf/open/floor/grass,
+/area/centcom/evac)
+"qE" = (
 /turf/closed/indestructible/riveted/uranium,
 /area/wizard_station)
-"ph" = (
+"qF" = (
 /turf/closed/indestructible/fakeglass{
 	color = "#008000";
 	dir = 8;
 	icon_state = "fakewindows"
 	},
 /area/wizard_station)
-"pi" = (
+"qG" = (
 /turf/closed/indestructible/fakeglass{
 	color = "#008000";
 	dir = 8;
 	icon_state = "fakewindows2"
 	},
 /area/wizard_station)
-"pj" = (
+"qH" = (
 /turf/closed/indestructible/fakeglass{
 	color = "#008000";
 	dir = 4;
 	icon_state = "fakewindows"
 	},
 /area/wizard_station)
-"pk" = (
-/obj/machinery/door/airlock/hatch{
-	req_access_txt = "150"
-	},
-/turf/open/floor/plasteel/vault{
-	dir = 8
-	},
-/area/shuttle/syndicate/medical)
-"pl" = (
+"qI" = (
+/turf/open/floor/plasteel/vault,
+/area/shuttle/syndicate/bridge)
+"qJ" = (
 /obj/machinery/computer/shuttle/syndicate/recall,
 /turf/open/floor/plasteel/bar{
 	dir = 2
 	},
 /area/syndicate_mothership/control)
-"pm" = (
+"qK" = (
 /obj/machinery/vending/coffee,
 /turf/open/floor/plasteel/bar{
 	dir = 2
 	},
 /area/syndicate_mothership/control)
-"pn" = (
+"qL" = (
 /obj/machinery/vending/cola,
 /turf/open/floor/plasteel/bar{
 	dir = 2
 	},
 /area/syndicate_mothership/control)
-"po" = (
+"qM" = (
 /obj/machinery/vending/cigarette{
 	products = list(/obj/item/storage/fancy/cigarettes/cigpack_syndicate = 7, /obj/item/storage/fancy/cigarettes/cigpack_uplift = 3, /obj/item/storage/fancy/cigarettes/cigpack_robust = 2, /obj/item/storage/fancy/cigarettes/cigpack_carp = 3, /obj/item/storage/fancy/cigarettes/cigpack_midori = 1, /obj/item/storage/box/matches = 10, /obj/item/lighter/greyscale = 4, /obj/item/storage/fancy/rollingpapers = 5)
 	},
@@ -5523,7 +6113,7 @@
 	dir = 2
 	},
 /area/syndicate_mothership/control)
-"pp" = (
+"qN" = (
 /obj/structure/urinal{
 	pixel_y = 28
 	},
@@ -5531,7 +6121,7 @@
 	dir = 2
 	},
 /area/syndicate_mothership/control)
-"pq" = (
+"qO" = (
 /obj/item/soap/syndie,
 /obj/structure/mopbucket,
 /obj/machinery/light/small{
@@ -5541,7 +6131,7 @@
 	dir = 2
 	},
 /area/syndicate_mothership/control)
-"pr" = (
+"qP" = (
 /obj/structure/mirror{
 	pixel_x = 28
 	},
@@ -5550,7 +6140,7 @@
 	dir = 2
 	},
 /area/syndicate_mothership/control)
-"ps" = (
+"qQ" = (
 /obj/machinery/door/airlock/centcom{
 	name = "Administrative Office";
 	opacity = 1;
@@ -5562,11 +6152,11 @@
 	},
 /turf/open/floor/plasteel,
 /area/centcom/ferry)
-"pt" = (
+"qR" = (
 /obj/structure/sign/nanotrasen,
 /turf/closed/indestructible/riveted,
 /area/centcom/ferry)
-"pu" = (
+"qS" = (
 /obj/machinery/door/airlock/centcom{
 	name = "CentCom Security";
 	opacity = 1;
@@ -5577,7 +6167,7 @@
 	},
 /turf/open/floor/plasteel,
 /area/centcom/supply)
-"pv" = (
+"qT" = (
 /obj/machinery/door/airlock/centcom{
 	name = "CentCom";
 	opacity = 1;
@@ -5588,23 +6178,61 @@
 	},
 /turf/open/floor/plasteel,
 /area/centcom/control)
-"pw" = (
+"qU" = (
 /obj/structure/flora/ausbushes/lavendergrass,
-/obj/structure/flora/ausbushes/sparsegrass,
 /obj/structure/flora/ausbushes/fullgrass,
+/obj/structure/flora/ausbushes/ywflowers,
 /obj/structure/flora/ausbushes/grassybush,
-/obj/structure/flora/ausbushes/ppflowers,
-/obj/structure/flora/ausbushes/pointybush,
+/obj/structure/flora/ausbushes/palebush,
+/turf/open/floor/plating/asteroid,
+/area/centcom/evac)
+"qV" = (
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
+/area/centcom/evac)
+"qW" = (
+/obj/structure/flora/ausbushes/lavendergrass,
+/obj/structure/flora/ausbushes/ywflowers,
 /turf/open/floor/grass,
-/area/centcom/control)
-"px" = (
+/area/centcom/evac)
+"qX" = (
+/obj/structure/fluff/arc,
+/turf/open/floor/grass,
+/area/centcom/evac)
+"qY" = (
+/obj/structure/flora/ausbushes/lavendergrass,
+/obj/structure/flora/ausbushes/brflowers,
+/turf/open/floor/grass,
+/area/centcom/evac)
+"qZ" = (
 /turf/open/floor/engine/cult,
 /area/wizard_station)
-"py" = (
+"ra" = (
 /obj/machinery/computer/shuttle,
 /turf/open/floor/engine/cult,
 /area/wizard_station)
-"pz" = (
+"rb" = (
+/obj/machinery/status_display,
+/turf/closed/wall/mineral/plastitanium,
+/area/shuttle/syndicate/bridge)
+"rc" = (
+/obj/machinery/door/airlock/hatch{
+	name = "Cockpit";
+	req_access_txt = "150"
+	},
+/turf/open/floor/plasteel/vault{
+	dir = 8
+	},
+/area/shuttle/syndicate/bridge)
+"rd" = (
+/obj/structure/flora/grass/brown,
+/obj/effect/light_emitter{
+	set_cap = 1;
+	set_luminosity = 4
+	},
+/turf/open/floor/plating/asteroid/snow/airless,
+/area/syndicate_mothership)
+"re" = (
 /obj/item/paper/fluff/stations/centcom/disk_memo,
 /obj/structure/noticeboard{
 	pixel_x = -32
@@ -5613,19 +6241,19 @@
 	dir = 2
 	},
 /area/syndicate_mothership/control)
-"pA" = (
+"rf" = (
 /obj/structure/chair/stool,
 /turf/open/floor/plasteel/bar{
 	dir = 2
 	},
 /area/syndicate_mothership/control)
-"pB" = (
+"rg" = (
 /mob/living/simple_animal/hostile/carp/cayenne,
 /turf/open/floor/plasteel/bar{
 	dir = 2
 	},
 /area/syndicate_mothership/control)
-"pC" = (
+"rh" = (
 /obj/machinery/door/airlock/centcom{
 	name = "Restroom";
 	opacity = 1;
@@ -5635,12 +6263,12 @@
 	dir = 2
 	},
 /area/syndicate_mothership/control)
-"pD" = (
+"ri" = (
 /turf/open/floor/plasteel/freezer{
 	dir = 2
 	},
 /area/syndicate_mothership/control)
-"pE" = (
+"rj" = (
 /obj/structure/mirror{
 	pixel_x = 28
 	},
@@ -5652,7 +6280,7 @@
 	dir = 2
 	},
 /area/syndicate_mothership/control)
-"pF" = (
+"rk" = (
 /obj/structure/table/reinforced,
 /obj/item/book/manual/wiki/security_space_law,
 /obj/item/device/taperecorder,
@@ -5660,7 +6288,7 @@
 	dir = 8
 	},
 /area/centcom/ferry)
-"pG" = (
+"rl" = (
 /obj/machinery/computer/auxillary_base{
 	pixel_y = 32
 	},
@@ -5671,21 +6299,21 @@
 	dir = 8
 	},
 /area/centcom/ferry)
-"pH" = (
+"rm" = (
 /obj/machinery/computer/shuttle/labor,
 /obj/effect/turf_decal/stripes/line{
 	dir = 10
 	},
 /turf/open/floor/plasteel,
 /area/centcom/ferry)
-"pI" = (
+"rn" = (
 /obj/machinery/computer/shuttle/mining,
 /obj/effect/turf_decal/stripes/line{
 	dir = 6
 	},
 /turf/open/floor/plasteel,
 /area/centcom/ferry)
-"pJ" = (
+"ro" = (
 /obj/machinery/light{
 	dir = 1
 	},
@@ -5697,13 +6325,13 @@
 	dir = 8
 	},
 /area/centcom/ferry)
-"pK" = (
+"rp" = (
 /obj/structure/filingcabinet/filingcabinet,
 /turf/open/floor/plasteel/vault{
 	dir = 8
 	},
 /area/centcom/ferry)
-"pL" = (
+"rq" = (
 /obj/machinery/airalarm{
 	dir = 8;
 	pixel_x = 24
@@ -5713,7 +6341,7 @@
 	dir = 8
 	},
 /area/centcom/ferry)
-"pM" = (
+"rr" = (
 /obj/structure/reagent_dispensers/fueltank,
 /obj/item/weldingtool/experimental,
 /obj/effect/decal/cleanable/oil,
@@ -5721,7 +6349,7 @@
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plasteel,
 /area/centcom/ferry)
-"pN" = (
+"rs" = (
 /obj/structure/table/reinforced,
 /obj/item/stack/sheet/metal{
 	amount = 50
@@ -5745,7 +6373,7 @@
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plasteel,
 /area/centcom/ferry)
-"pO" = (
+"rt" = (
 /obj/item/twohanded/required/kirbyplants{
 	icon_state = "plant-22"
 	},
@@ -5754,13 +6382,13 @@
 	},
 /turf/open/floor/plasteel/vault,
 /area/centcom/ferry)
-"pP" = (
+"ru" = (
 /obj/machinery/light_switch{
 	pixel_y = 24
 	},
 /turf/open/floor/wood,
 /area/centcom/ferry)
-"pQ" = (
+"rv" = (
 /obj/item/twohanded/required/kirbyplants{
 	icon_state = "plant-21"
 	},
@@ -5769,18 +6397,18 @@
 	},
 /turf/open/floor/wood,
 /area/centcom/ferry)
-"pR" = (
+"rw" = (
 /obj/item/device/flashlight/lamp,
 /obj/structure/table/reinforced,
 /turf/open/floor/plasteel/vault{
 	dir = 8
 	},
 /area/centcom/ferry)
-"pS" = (
+"rx" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plasteel/grimy,
 /area/centcom/ferry)
-"pT" = (
+"ry" = (
 /obj/machinery/computer/card/centcom,
 /obj/item/card/id/centcom,
 /obj/machinery/computer/security/telescreen{
@@ -5791,11 +6419,11 @@
 	},
 /turf/open/floor/plasteel/grimy,
 /area/centcom/ferry)
-"pU" = (
+"rz" = (
 /obj/structure/sign/securearea,
 /turf/closed/indestructible/riveted,
 /area/centcom/ferry)
-"pV" = (
+"rA" = (
 /obj/machinery/power/smes/magical,
 /obj/machinery/light{
 	dir = 1
@@ -5808,7 +6436,7 @@
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plasteel,
 /area/centcom/ferry)
-"pW" = (
+"rB" = (
 /obj/machinery/power/apc{
 	dir = 4;
 	name = "Commander's Office APC";
@@ -5846,7 +6474,7 @@
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plasteel,
 /area/centcom/ferry)
-"pX" = (
+"rC" = (
 /obj/structure/table/reinforced,
 /obj/item/clothing/suit/space/hardsuit/deathsquad{
 	pixel_y = 5
@@ -5857,7 +6485,7 @@
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plasteel,
 /area/centcom/ferry)
-"pY" = (
+"rD" = (
 /obj/structure/table/reinforced,
 /obj/item/storage/lockbox/loyalty,
 /obj/item/gun/ballistic/automatic/ar,
@@ -5867,7 +6495,7 @@
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plasteel,
 /area/centcom/ferry)
-"pZ" = (
+"rE" = (
 /obj/structure/table/reinforced,
 /obj/item/storage/box/handcuffs,
 /obj/item/crowbar/red,
@@ -5879,7 +6507,7 @@
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plasteel,
 /area/centcom/ferry)
-"qa" = (
+"rF" = (
 /obj/structure/flora/ausbushes/sparsegrass,
 /obj/structure/flora/ausbushes/grassybush,
 /obj/structure/flora/ausbushes/fernybush,
@@ -5889,13 +6517,25 @@
 	name = "sand"
 	},
 /area/centcom/supply)
-"qb" = (
+"rG" = (
 /obj/structure/fans/tiny,
 /turf/open/floor/plasteel/vault{
 	dir = 8
 	},
 /area/centcom/supply)
-"qc" = (
+"rH" = (
+/obj/structure/flora/ausbushes/sparsegrass,
+/obj/structure/flora/ausbushes/lavendergrass,
+/obj/structure/flora/ausbushes/fernybush,
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/open/floor/plasteel{
+	name = "plating";
+	icon_state = "asteroid5"
+	},
+/area/centcom/control)
+"rI" = (
 /obj/machinery/door/poddoor/shutters{
 	id = "XCCsec3";
 	name = "XCC Checkpoint 3 Shutters"
@@ -5903,7 +6543,27 @@
 /obj/effect/turf_decal/delivery,
 /turf/open/floor/plasteel,
 /area/centcom/control)
-"qd" = (
+"rJ" = (
+/obj/structure/flora/ausbushes/lavendergrass,
+/obj/structure/flora/ausbushes/sparsegrass,
+/obj/structure/flora/ausbushes/fullgrass,
+/obj/structure/flora/ausbushes/brflowers,
+/obj/structure/flora/ausbushes/genericbush,
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/open/floor/grass,
+/area/centcom/control)
+"rK" = (
+/obj/structure/flora/ausbushes/lavendergrass,
+/obj/structure/flora/ausbushes/sparsegrass,
+/obj/structure/flora/ausbushes/fullgrass,
+/obj/structure/flora/ausbushes/grassybush,
+/obj/structure/flora/ausbushes/ppflowers,
+/obj/structure/flora/ausbushes/pointybush,
+/turf/open/floor/grass,
+/area/centcom/control)
+"rL" = (
 /obj/item/twohanded/required/kirbyplants{
 	icon_state = "plant-21"
 	},
@@ -5914,19 +6574,19 @@
 	dir = 8
 	},
 /area/centcom/control)
-"qe" = (
+"rM" = (
 /obj/structure/filingcabinet/medical,
 /turf/open/floor/plasteel/vault{
 	dir = 8
 	},
 /area/centcom/control)
-"qf" = (
+"rN" = (
 /obj/structure/filingcabinet/security,
 /turf/open/floor/plasteel/vault{
 	dir = 8
 	},
 /area/centcom/control)
-"qg" = (
+"rO" = (
 /obj/structure/table/reinforced,
 /obj/item/paper_bin,
 /obj/item/pen,
@@ -5937,7 +6597,7 @@
 	dir = 8
 	},
 /area/centcom/control)
-"qh" = (
+"rP" = (
 /obj/structure/table/reinforced,
 /obj/item/wrench,
 /obj/item/restraints/handcuffs,
@@ -5946,7 +6606,7 @@
 	dir = 8
 	},
 /area/centcom/control)
-"qi" = (
+"rQ" = (
 /obj/structure/table/reinforced,
 /obj/item/storage/box/handcuffs,
 /obj/item/crowbar/red,
@@ -5954,7 +6614,7 @@
 	dir = 8
 	},
 /area/centcom/control)
-"qj" = (
+"rR" = (
 /obj/item/storage/box/ids{
 	pixel_x = 3;
 	pixel_y = 3
@@ -5971,45 +6631,116 @@
 	dir = 8
 	},
 /area/centcom/control)
-"qk" = (
-/turf/closed/indestructible/riveted,
-/area/centcom/evac)
-"ql" = (
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating,
-/area/centcom/evac)
-"qm" = (
+"rS" = (
 /obj/machinery/status_display,
 /turf/closed/indestructible/riveted,
 /area/centcom/evac)
-"qn" = (
+"rT" = (
+/obj/structure/flora/ausbushes/brflowers,
+/obj/structure/flora/ausbushes/lavendergrass,
+/obj/structure/window/reinforced,
+/turf/open/floor/grass,
+/area/centcom/evac)
+"rU" = (
+/obj/structure/flora/ausbushes/ppflowers,
+/obj/structure/flora/ausbushes/lavendergrass,
+/obj/structure/window/reinforced,
+/turf/open/floor/grass,
+/area/centcom/evac)
+"rV" = (
+/obj/structure/flora/ausbushes/ywflowers,
+/obj/structure/flora/ausbushes/lavendergrass,
+/obj/structure/window/reinforced,
+/turf/open/floor/grass,
+/area/centcom/evac)
+"rW" = (
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/open/floor/engine/cult,
+/area/wizard_station)
+"rX" = (
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/open/floor/engine/cult,
+/area/wizard_station)
+"rY" = (
+/obj/machinery/porta_turret/syndicate{
+	dir = 10
+	},
+/turf/closed/wall/mineral/plastitanium,
+/area/shuttle/syndicate/hallway)
+"rZ" = (
+/turf/closed/wall/mineral/plastitanium,
+/area/shuttle/syndicate/hallway)
+"sa" = (
+/obj/structure/table/reinforced,
+/obj/item/stack/cable_coil/white,
+/obj/item/stack/cable_coil/white,
+/obj/item/crowbar/red,
+/turf/open/floor/plasteel/vault{
+	dir = 5
+	},
+/area/shuttle/syndicate/hallway)
+"sb" = (
+/turf/open/floor/plasteel/vault{
+	dir = 5
+	},
+/area/shuttle/syndicate/hallway)
+"sc" = (
+/obj/structure/table/reinforced,
+/obj/item/storage/box/handcuffs{
+	pixel_x = 3;
+	pixel_y = 3
+	},
+/obj/item/storage/box/zipties,
+/turf/open/floor/plasteel/vault{
+	dir = 5
+	},
+/area/shuttle/syndicate/hallway)
+"sd" = (
+/obj/machinery/porta_turret/syndicate{
+	dir = 6
+	},
+/turf/closed/wall/mineral/plastitanium,
+/area/shuttle/syndicate/hallway)
+"se" = (
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/open/floor/plasteel/bar{
+	dir = 2
+	},
+/area/syndicate_mothership/control)
+"sf" = (
 /obj/structure/table/wood,
 /obj/item/device/paicard,
 /turf/open/floor/plasteel/bar{
 	dir = 2
 	},
 /area/syndicate_mothership/control)
-"qo" = (
+"sg" = (
 /obj/structure/table/wood,
 /obj/item/pizzabox,
 /turf/open/floor/plasteel/bar{
 	dir = 2
 	},
 /area/syndicate_mothership/control)
-"qp" = (
+"sh" = (
 /obj/structure/chair/stool,
 /obj/effect/landmark/start/nukeop,
 /turf/open/floor/plasteel/bar{
 	dir = 2
 	},
 /area/syndicate_mothership/control)
-"qq" = (
+"si" = (
 /obj/machinery/computer/telecrystals/uplinker,
 /turf/open/floor/plasteel/podhatch{
 	dir = 9
 	},
 /area/syndicate_mothership/control)
-"qr" = (
+"sj" = (
 /obj/structure/toilet{
 	dir = 8
 	},
@@ -6026,23 +6757,46 @@
 	dir = 2
 	},
 /area/syndicate_mothership/control)
-"qs" = (
+"sk" = (
 /turf/open/floor/plating/airless,
 /area/syndicate_mothership/control)
-"qt" = (
+"sl" = (
+/obj/effect/turf_decal/stripes/corner,
+/turf/open/floor/plating/airless,
+/area/syndicate_mothership/control)
+"sm" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 2
 	},
 /turf/open/floor/plating/airless,
 /area/syndicate_mothership/control)
-"qu" = (
+"sn" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 2
+	},
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/open/floor/plating/airless,
+/area/syndicate_mothership/control)
+"so" = (
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/plating/airless,
+/area/syndicate_mothership/control)
+"sp" = (
+/obj/effect/turf_decal/stripes/corner{
+	dir = 1
+	},
+/turf/open/floor/plating/airless,
+/area/syndicate_mothership/control)
+"sq" = (
 /obj/machinery/computer/shuttle/white_ship,
 /obj/effect/turf_decal/stripes/line{
 	dir = 5
 	},
 /turf/open/floor/plasteel,
 /area/centcom/ferry)
-"qv" = (
+"sr" = (
 /obj/structure/chair/office/dark{
 	dir = 8
 	},
@@ -6050,12 +6804,12 @@
 	dir = 9
 	},
 /area/centcom/ferry)
-"qw" = (
+"ss" = (
 /turf/open/floor/plasteel/green/corner{
 	dir = 1
 	},
 /area/centcom/ferry)
-"qx" = (
+"st" = (
 /obj/structure/chair/office/dark{
 	dir = 1
 	},
@@ -6063,12 +6817,12 @@
 	dir = 1
 	},
 /area/centcom/ferry)
-"qy" = (
+"su" = (
 /turf/open/floor/plasteel/green/corner{
 	dir = 4
 	},
 /area/centcom/ferry)
-"qz" = (
+"sv" = (
 /obj/structure/noticeboard{
 	dir = 8;
 	pixel_x = 32
@@ -6077,12 +6831,12 @@
 	dir = 5
 	},
 /area/centcom/ferry)
-"qA" = (
+"sw" = (
 /turf/open/floor/plasteel/vault{
 	dir = 8
 	},
 /area/centcom/ferry)
-"qB" = (
+"sx" = (
 /obj/structure/chair/comfy/black,
 /obj/machinery/computer/security/telescreen/entertainment{
 	pixel_x = -32
@@ -6095,12 +6849,12 @@
 	},
 /turf/open/floor/plasteel/grimy,
 /area/centcom/ferry)
-"qC" = (
+"sy" = (
 /obj/structure/chair/comfy/black,
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden,
 /turf/open/floor/plasteel/grimy,
 /area/centcom/ferry)
-"qD" = (
+"sz" = (
 /obj/structure/chair/office/dark{
 	dir = 4
 	},
@@ -6114,7 +6868,7 @@
 	},
 /turf/open/floor/wood,
 /area/centcom/ferry)
-"qE" = (
+"sA" = (
 /obj/item/clipboard,
 /obj/structure/table/reinforced,
 /obj/item/device/detective_scanner,
@@ -6130,7 +6884,7 @@
 	dir = 8
 	},
 /area/centcom/ferry)
-"qF" = (
+"sB" = (
 /obj/structure/chair/office/dark{
 	dir = 8
 	},
@@ -6142,7 +6896,7 @@
 	},
 /turf/open/floor/plasteel/grimy,
 /area/centcom/ferry)
-"qG" = (
+"sC" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
@@ -6153,7 +6907,7 @@
 	},
 /turf/open/floor/plasteel/grimy,
 /area/centcom/ferry)
-"qH" = (
+"sD" = (
 /obj/machinery/door/airlock/centcom{
 	name = "Administrative Storage";
 	req_access_txt = "106"
@@ -6171,7 +6925,7 @@
 	},
 /turf/open/floor/plasteel,
 /area/centcom/ferry)
-"qI" = (
+"sE" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/visible{
 	dir = 1
 	},
@@ -6190,7 +6944,7 @@
 	dir = 8
 	},
 /area/centcom/ferry)
-"qJ" = (
+"sF" = (
 /obj/machinery/power/terminal{
 	dir = 1
 	},
@@ -6213,7 +6967,7 @@
 	dir = 8
 	},
 /area/centcom/ferry)
-"qK" = (
+"sG" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/visible{
 	dir = 1
 	},
@@ -6237,7 +6991,7 @@
 	dir = 8
 	},
 /area/centcom/ferry)
-"qL" = (
+"sH" = (
 /obj/machinery/door/airlock/vault{
 	locked = 1;
 	name = "Vault Door";
@@ -6251,7 +7005,7 @@
 	},
 /turf/open/floor/plasteel,
 /area/centcom/ferry)
-"qM" = (
+"sI" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
@@ -6259,7 +7013,7 @@
 	dir = 8
 	},
 /area/centcom/ferry)
-"qN" = (
+"sJ" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 8
 	},
@@ -6267,18 +7021,12 @@
 	dir = 8
 	},
 /area/centcom/ferry)
-"qO" = (
+"sK" = (
 /turf/open/floor/plasteel/darkred/side{
 	dir = 1
 	},
 /area/centcom/control)
-"qP" = (
-/obj/structure/fans/tiny,
-/turf/open/floor/plasteel/vault{
-	dir = 8
-	},
-/area/centcom/control)
-"qQ" = (
+"sL" = (
 /obj/machinery/door/airlock/centcom{
 	name = "CentCom Security";
 	opacity = 1;
@@ -6289,26 +7037,25 @@
 	},
 /turf/open/floor/plasteel,
 /area/centcom/evac)
-"qR" = (
+"sM" = (
+/obj/structure/fans/tiny,
+/turf/open/floor/plasteel/vault{
+	dir = 8
+	},
+/area/centcom/evac)
+"sN" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 9
 	},
 /turf/open/floor/plasteel,
 /area/centcom/evac)
-"qS" = (
+"sO" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
 /area/centcom/evac)
-"qT" = (
-/obj/structure/chair,
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/centcom/evac)
-"qU" = (
+"sP" = (
 /obj/structure/table,
 /obj/item/paper_bin,
 /obj/item/pen,
@@ -6317,15 +7064,24 @@
 	},
 /turf/open/floor/plasteel,
 /area/centcom/evac)
-"qW" = (
-/obj/structure/rack,
-/obj/item/clothing/suit/space/syndicate/black/red,
-/obj/item/clothing/head/helmet/space/syndicate/black/red,
-/turf/open/floor/plasteel/vault{
-	dir = 8
+"sQ" = (
+/obj/structure/chair,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
 	},
-/area/shuttle/syndicate/airlock)
-"qX" = (
+/turf/open/floor/plasteel,
+/area/centcom/evac)
+"sR" = (
+/obj/structure/chair,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/centcom/evac)
+"sS" = (
 /obj/structure/table,
 /obj/item/toy/katana,
 /obj/item/toy/plush/carpplushie,
@@ -6334,18 +7090,25 @@
 	},
 /turf/open/floor/plasteel,
 /area/centcom/evac)
-"qZ" = (
+"sT" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 5
 	},
 /turf/open/floor/plasteel,
 /area/centcom/evac)
-"ra" = (
+"sU" = (
+/obj/effect/turf_decal/delivery,
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/centcom/evac)
+"sV" = (
 /obj/machinery/door/poddoor/shuttledock,
 /obj/effect/turf_decal/delivery,
 /turf/open/floor/plasteel,
 /area/centcom/evac)
-"rb" = (
+"sW" = (
 /obj/structure/showcase{
 	desc = "A strange machine supposedly from another world. The Wizard Federation has been meddling with it for years.";
 	icon = 'icons/obj/machines/telecomms.dmi';
@@ -6354,7 +7117,7 @@
 	},
 /turf/open/floor/engine/cult,
 /area/wizard_station)
-"rc" = (
+"sX" = (
 /obj/structure/showcase{
 	desc = "A historical figure of great importance to the wizard federation. He spent his long life learning magic, stealing artifacts, and harassing idiots with swords. May he rest forever, Rodney.";
 	icon = 'icons/mob/mob.dmi';
@@ -6363,32 +7126,53 @@
 	},
 /turf/open/floor/engine/cult,
 /area/wizard_station)
-"rd" = (
+"sY" = (
+/obj/structure/chair{
+	dir = 4;
+	name = "tactical chair"
+	},
+/turf/open/floor/plasteel/vault{
+	dir = 5
+	},
+/area/shuttle/syndicate/hallway)
+"sZ" = (
+/turf/open/floor/plasteel/black,
+/area/shuttle/syndicate/hallway)
+"ta" = (
+/obj/structure/chair{
+	dir = 8;
+	name = "tactical chair"
+	},
+/turf/open/floor/plasteel/vault{
+	dir = 5
+	},
+/area/shuttle/syndicate/hallway)
+"tb" = (
 /turf/closed/indestructible/fakeglass{
 	icon_state = "fakewindows";
 	dir = 9
 	},
 /area/syndicate_mothership/control)
-"re" = (
+"tc" = (
 /turf/closed/indestructible/fakeglass{
 	icon_state = "fakewindows2";
 	dir = 8
 	},
 /area/syndicate_mothership/control)
-"rf" = (
+"td" = (
 /turf/closed/indestructible/fakeglass{
 	icon_state = "fakewindows";
 	dir = 4
 	},
 /area/syndicate_mothership/control)
-"rg" = (
+"te" = (
 /obj/structure/table/wood,
 /obj/item/reagent_containers/food/snacks/pizzaslice/mushroom,
 /turf/open/floor/plasteel/bar{
 	dir = 2
 	},
 /area/syndicate_mothership/control)
-"rh" = (
+"tf" = (
 /obj/structure/table/wood,
 /obj/item/reagent_containers/food/drinks/beer{
 	pixel_x = 5;
@@ -6403,24 +7187,24 @@
 	dir = 2
 	},
 /area/syndicate_mothership/control)
-"ri" = (
+"tg" = (
 /obj/machinery/computer/telecrystals/uplinker,
 /turf/open/floor/plasteel/podhatch{
 	dir = 8
 	},
 /area/syndicate_mothership/control)
-"rj" = (
+"th" = (
 /obj/structure/closet/cardboard,
 /obj/effect/turf_decal/stripes/corner,
 /turf/open/floor/plating/airless,
 /area/syndicate_mothership/control)
-"rk" = (
+"ti" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 6
 	},
 /turf/open/floor/plating/airless,
 /area/syndicate_mothership/control)
-"rl" = (
+"tj" = (
 /turf/open/floor/plating/asteroid/snow/airless,
 /obj/machinery/porta_turret/syndicate/pod,
 /turf/closed/wall/mineral/plastitanium{
@@ -6428,10 +7212,10 @@
 	icon_state = "diagonalWall3"
 	},
 /area/shuttle/assault_pod)
-"rm" = (
+"tk" = (
 /turf/closed/wall/mineral/plastitanium,
 /area/shuttle/assault_pod)
-"rn" = (
+"tl" = (
 /obj/machinery/door/airlock/centcom{
 	name = "Assault Pod";
 	opacity = 1;
@@ -6439,7 +7223,7 @@
 	},
 /turf/open/floor/plating,
 /area/shuttle/assault_pod)
-"ro" = (
+"tm" = (
 /turf/open/floor/plating/asteroid/snow/airless,
 /obj/machinery/porta_turret/syndicate/pod,
 /turf/closed/wall/mineral/plastitanium{
@@ -6447,44 +7231,44 @@
 	icon_state = "diagonalWall3"
 	},
 /area/shuttle/assault_pod)
-"rp" = (
+"tn" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 10
 	},
 /turf/open/floor/plating/airless,
 /area/syndicate_mothership/control)
-"rq" = (
+"to" = (
 /obj/machinery/computer/shuttle/ferry,
 /obj/effect/turf_decal/stripes/line{
 	dir = 6
 	},
 /turf/open/floor/plasteel,
 /area/centcom/ferry)
-"rr" = (
+"tp" = (
 /turf/open/floor/plasteel/green/side{
 	dir = 10
 	},
 /area/centcom/ferry)
-"rs" = (
+"tq" = (
 /obj/structure/chair/office/dark,
 /turf/open/floor/plasteel/green/corner{
 	dir = 8
 	},
 /area/centcom/ferry)
-"rt" = (
+"tr" = (
 /turf/open/floor/plasteel/green/corner{
 	dir = 8
 	},
 /area/centcom/ferry)
-"ru" = (
+"ts" = (
 /turf/open/floor/plasteel/green/corner,
 /area/centcom/ferry)
-"rv" = (
+"tt" = (
 /turf/open/floor/plasteel/green/side{
 	dir = 6
 	},
 /area/centcom/ferry)
-"rw" = (
+"tu" = (
 /obj/machinery/door/airlock/centcom{
 	name = "CentCom Supply";
 	req_access_txt = "106"
@@ -6494,22 +7278,22 @@
 	},
 /turf/open/floor/plasteel,
 /area/centcom/ferry)
-"rx" = (
+"tv" = (
 /turf/open/floor/plasteel/vault{
 	dir = 9
 	},
 /area/centcom/ferry)
-"ry" = (
+"tw" = (
 /turf/open/floor/plasteel/vault{
 	dir = 5
 	},
 /area/centcom/ferry)
-"rz" = (
+"tx" = (
 /obj/structure/table/wood,
 /obj/item/storage/pill_bottle/dice,
 /turf/open/floor/plasteel/grimy,
 /area/centcom/ferry)
-"rA" = (
+"ty" = (
 /obj/structure/table/wood,
 /obj/item/toy/cards/deck/cas{
 	pixel_x = -5;
@@ -6521,7 +7305,7 @@
 	},
 /turf/open/floor/plasteel/grimy,
 /area/centcom/ferry)
-"rB" = (
+"tz" = (
 /obj/structure/chair/office/dark{
 	dir = 4
 	},
@@ -6532,7 +7316,7 @@
 	},
 /turf/open/floor/wood,
 /area/centcom/ferry)
-"rC" = (
+"tA" = (
 /obj/structure/table/reinforced,
 /obj/item/folder/red,
 /obj/item/restraints/handcuffs,
@@ -6541,7 +7325,7 @@
 	dir = 8
 	},
 /area/centcom/ferry)
-"rD" = (
+"tB" = (
 /obj/item/storage/fancy/donut_box,
 /obj/structure/table/reinforced,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -6549,7 +7333,7 @@
 	dir = 8
 	},
 /area/centcom/ferry)
-"rE" = (
+"tC" = (
 /obj/item/paper_bin,
 /obj/item/pen/fourcolor,
 /obj/structure/table/reinforced,
@@ -6563,7 +7347,7 @@
 	dir = 8
 	},
 /area/centcom/ferry)
-"rF" = (
+"tD" = (
 /obj/machinery/atmospherics/components/unary/portables_connector/visible{
 	dir = 1
 	},
@@ -6584,7 +7368,7 @@
 	},
 /turf/open/floor/plasteel,
 /area/centcom/ferry)
-"rG" = (
+"tE" = (
 /obj/machinery/computer/monitor,
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 1
@@ -6605,7 +7389,7 @@
 	},
 /turf/open/floor/plasteel,
 /area/centcom/ferry)
-"rH" = (
+"tF" = (
 /obj/machinery/atmospherics/components/unary/tank/air{
 	dir = 1
 	},
@@ -6624,7 +7408,7 @@
 	},
 /turf/open/floor/plasteel,
 /area/centcom/ferry)
-"rI" = (
+"tG" = (
 /obj/item/storage/box/handcuffs,
 /obj/item/ammo_box/a357,
 /obj/item/ammo_box/a357,
@@ -6639,7 +7423,7 @@
 	},
 /turf/open/floor/plasteel,
 /area/centcom/ferry)
-"rJ" = (
+"tH" = (
 /obj/item/gun/energy/pulse/carbine/loyalpin,
 /obj/item/device/flashlight/seclite,
 /obj/structure/table/reinforced,
@@ -6652,7 +7436,7 @@
 	},
 /turf/open/floor/plasteel,
 /area/centcom/ferry)
-"rK" = (
+"tI" = (
 /obj/item/storage/box/emps{
 	pixel_x = 3;
 	pixel_y = 3
@@ -6671,7 +7455,7 @@
 	},
 /turf/open/floor/plasteel,
 /area/centcom/ferry)
-"rL" = (
+"tJ" = (
 /obj/item/twohanded/required/kirbyplants{
 	icon_state = "plant-22"
 	},
@@ -6679,30 +7463,30 @@
 	dir = 1
 	},
 /area/centcom/control)
-"rM" = (
+"tK" = (
 /turf/open/floor/plasteel/green/corner{
 	dir = 1
 	},
 /area/centcom/control)
-"rN" = (
+"tL" = (
 /obj/machinery/door/firedoor,
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
 /area/centcom/control)
-"rO" = (
+"tM" = (
 /turf/open/floor/plasteel/neutral/side{
 	dir = 1;
 	heat_capacity = 1e+006
 	},
 /area/centcom/control)
-"rP" = (
+"tN" = (
 /turf/open/floor/plasteel/green/corner{
 	dir = 4
 	},
 /area/centcom/control)
-"rQ" = (
+"tO" = (
 /obj/item/twohanded/required/kirbyplants{
 	icon_state = "plant-21"
 	},
@@ -6710,11 +7494,11 @@
 	dir = 4
 	},
 /area/centcom/control)
-"rR" = (
+"tP" = (
 /obj/structure/sign/securearea,
 /turf/closed/indestructible/riveted,
 /area/centcom/control)
-"rS" = (
+"tQ" = (
 /obj/item/twohanded/required/kirbyplants{
 	icon_state = "plant-22"
 	},
@@ -6722,7 +7506,11 @@
 	dir = 5
 	},
 /area/centcom/control)
-"rT" = (
+"tR" = (
+/obj/machinery/ai_status_display,
+/turf/closed/indestructible/riveted,
+/area/centcom/evac)
+"tS" = (
 /obj/item/twohanded/required/kirbyplants{
 	icon_state = "plant-21"
 	},
@@ -6734,78 +7522,109 @@
 	},
 /turf/open/floor/plasteel,
 /area/centcom/evac)
-"rU" = (
+"tT" = (
 /turf/open/floor/plasteel/yellowsiding{
 	dir = 1
 	},
 /area/centcom/evac)
-"rV" = (
+"tU" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/centcom/evac)
-"rW" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/centcom{
-	name = "CentCom";
-	opacity = 1;
-	req_access_txt = "0"
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
+"tV" = (
+/obj/effect/turf_decal/delivery,
 /turf/open/floor/plasteel,
 /area/centcom/evac)
-"rX" = (
+"tW" = (
 /turf/closed/indestructible/fakeglass{
 	color = "#008000";
 	dir = 6;
 	icon_state = "fakewindows2"
 	},
 /area/wizard_station)
-"rY" = (
+"tX" = (
 /obj/machinery/door/airlock{
 	icon = 'icons/obj/doors/airlocks/station/uranium.dmi';
 	name = "Cockpit"
 	},
 /turf/open/floor/engine/cult,
 /area/wizard_station)
-"rZ" = (
+"tY" = (
+/obj/machinery/porta_turret/syndicate{
+	dir = 9
+	},
+/turf/closed/wall/mineral/plastitanium,
+/area/shuttle/syndicate/eva)
+"tZ" = (
+/turf/closed/wall/mineral/plastitanium,
+/area/shuttle/syndicate/eva)
+"ua" = (
+/obj/structure/chair{
+	dir = 4;
+	name = "tactical chair"
+	},
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/open/floor/plasteel/vault{
+	dir = 5
+	},
+/area/shuttle/syndicate/hallway)
+"ub" = (
+/obj/structure/chair{
+	dir = 8;
+	name = "tactical chair"
+	},
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/open/floor/plasteel/vault{
+	dir = 5
+	},
+/area/shuttle/syndicate/hallway)
+"uc" = (
+/obj/machinery/porta_turret/syndicate{
+	dir = 4
+	},
+/turf/closed/wall/mineral/plastitanium,
+/area/shuttle/syndicate/hallway)
+"ud" = (
 /obj/machinery/door/poddoor/shutters{
 	id = "nukeop_ready";
 	name = "shuttle dock"
 	},
 /turf/open/floor/plating,
 /area/syndicate_mothership/control)
-"sa" = (
+"ue" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
 /turf/open/floor/plating/airless,
 /area/syndicate_mothership/control)
-"sb" = (
+"uf" = (
 /obj/structure/chair{
 	dir = 4
 	},
 /turf/open/floor/mineral/plastitanium,
 /area/shuttle/assault_pod)
-"sc" = (
+"ug" = (
 /turf/open/floor/mineral/plastitanium,
 /area/shuttle/assault_pod)
-"sd" = (
+"uh" = (
 /obj/structure/chair{
 	dir = 8
 	},
 /turf/open/floor/mineral/plastitanium,
 /area/shuttle/assault_pod)
-"se" = (
+"ui" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
 /turf/open/floor/plating/airless,
 /area/syndicate_mothership/control)
-"sf" = (
+"uj" = (
 /obj/item/clipboard,
 /obj/item/folder/red,
 /obj/item/stamp/denied{
@@ -6818,7 +7637,7 @@
 	dir = 8
 	},
 /area/centcom/ferry)
-"sg" = (
+"uk" = (
 /obj/machinery/keycard_auth{
 	pixel_y = -24
 	},
@@ -6834,7 +7653,7 @@
 	dir = 8
 	},
 /area/centcom/ferry)
-"sh" = (
+"ul" = (
 /obj/machinery/computer/emergency_shuttle,
 /obj/machinery/newscaster/security_unit{
 	pixel_y = -32
@@ -6844,21 +7663,21 @@
 	},
 /turf/open/floor/plasteel,
 /area/centcom/ferry)
-"si" = (
+"um" = (
 /obj/machinery/computer/communications,
 /obj/effect/turf_decal/stripes/line{
 	dir = 5
 	},
 /turf/open/floor/plasteel,
 /area/centcom/ferry)
-"sj" = (
+"un" = (
 /obj/machinery/light,
 /obj/structure/filingcabinet/chestdrawer,
 /turf/open/floor/plasteel/vault{
 	dir = 8
 	},
 /area/centcom/ferry)
-"sk" = (
+"uo" = (
 /obj/machinery/firealarm{
 	dir = 1;
 	pixel_y = -24
@@ -6871,7 +7690,7 @@
 	dir = 4
 	},
 /area/centcom/ferry)
-"sl" = (
+"up" = (
 /obj/structure/chair/comfy/black{
 	dir = 1
 	},
@@ -6880,13 +7699,13 @@
 	},
 /turf/open/floor/plasteel/grimy,
 /area/centcom/ferry)
-"sm" = (
+"uq" = (
 /obj/structure/chair/comfy/black{
 	dir = 1
 	},
 /turf/open/floor/plasteel/grimy,
 /area/centcom/ferry)
-"sn" = (
+"ur" = (
 /obj/structure/cable/white{
 	d1 = 1;
 	d2 = 2;
@@ -6894,13 +7713,19 @@
 	},
 /turf/open/floor/wood,
 /area/centcom/ferry)
-"so" = (
+"us" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 1
 	},
 /turf/open/floor/wood,
 /area/centcom/ferry)
-"sp" = (
+"ut" = (
+/obj/structure/fans/tiny,
+/turf/open/floor/plasteel/vault{
+	dir = 8
+	},
+/area/centcom/control)
+"uu" = (
 /obj/machinery/firealarm{
 	dir = 1;
 	pixel_y = -24
@@ -6909,17 +7734,17 @@
 	dir = 9
 	},
 /area/centcom/control)
-"sq" = (
+"uv" = (
 /obj/machinery/computer/security,
 /turf/open/floor/plasteel/vault{
 	dir = 8
 	},
 /area/centcom/control)
-"sr" = (
+"uw" = (
 /obj/structure/chair/office/dark,
 /turf/open/floor/plasteel/darkred/side,
 /area/centcom/control)
-"ss" = (
+"ux" = (
 /obj/machinery/computer/card/centcom,
 /obj/machinery/button/door{
 	id = "XCCcustoms1";
@@ -6937,7 +7762,7 @@
 	},
 /turf/open/floor/plasteel/darkred/side,
 /area/centcom/control)
-"st" = (
+"uy" = (
 /obj/machinery/computer/security,
 /obj/machinery/airalarm{
 	dir = 8;
@@ -6947,7 +7772,16 @@
 	dir = 8
 	},
 /area/centcom/control)
-"su" = (
+"uz" = (
+/obj/structure/flora/ausbushes/lavendergrass,
+/obj/structure/flora/ausbushes/sparsegrass,
+/obj/structure/flora/ausbushes/ywflowers,
+/obj/structure/flora/ausbushes/grassybush,
+/obj/structure/flora/ausbushes/palebush,
+/obj/machinery/light,
+/turf/open/floor/plating/asteroid,
+/area/centcom/evac)
+"uA" = (
 /obj/structure/chair{
 	dir = 4
 	},
@@ -6956,23 +7790,14 @@
 	},
 /turf/open/floor/plasteel,
 /area/centcom/evac)
-"sv" = (
+"uB" = (
 /turf/open/floor/plasteel/neutral,
 /area/centcom/evac)
-"sw" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/structure/sign/directions/engineering{
-	desc = "A sign that shows there are doors here. There are doors everywhere!";
-	icon_state = "doors";
-	name = "WARNING: BLAST DOORS"
-	},
-/turf/open/floor/plating,
-/area/centcom/evac)
-"sx" = (
+"uC" = (
 /obj/machinery/computer/camera_advanced,
 /turf/open/floor/wood,
 /area/wizard_station)
-"sy" = (
+"uD" = (
 /obj/structure/table/wood/fancy,
 /obj/item/device/radio/intercom{
 	desc = "Talk smack through this.";
@@ -6980,26 +7805,43 @@
 	},
 /turf/open/floor/wood,
 /area/wizard_station)
-"sz" = (
+"uE" = (
 /turf/open/floor/carpet,
 /area/wizard_station)
-"sA" = (
+"uF" = (
 /obj/structure/chair/wood/wings,
 /turf/open/floor/carpet,
 /area/wizard_station)
-"sB" = (
+"uG" = (
+/obj/machinery/suit_storage_unit/syndicate,
+/turf/open/floor/plasteel/podhatch{
+	dir = 5
+	},
+/area/shuttle/syndicate/eva)
+"uH" = (
+/turf/open/floor/plasteel/vault{
+	dir = 5
+	},
+/area/shuttle/syndicate/eva)
+"uI" = (
+/obj/machinery/portable_atmospherics/canister/oxygen,
+/turf/open/floor/plasteel/vault{
+	dir = 8
+	},
+/area/shuttle/syndicate/eva)
+"uJ" = (
 /obj/machinery/door/airlock/external{
 	req_access_txt = "150"
 	},
 /turf/open/floor/plating,
 /area/syndicate_mothership/control)
-"sC" = (
+"uK" = (
 /turf/closed/indestructible/fakeglass{
 	icon_state = "fakewindows";
 	dir = 8
 	},
 /area/syndicate_mothership/control)
-"sD" = (
+"uL" = (
 /obj/machinery/button/door{
 	id = "nukeop_ready";
 	name = "mission launch control";
@@ -7010,20 +7852,20 @@
 	dir = 2
 	},
 /area/syndicate_mothership/control)
-"sE" = (
+"uM" = (
 /obj/machinery/computer/telecrystals/uplinker,
 /turf/open/floor/plasteel/podhatch{
 	dir = 10
 	},
 /area/syndicate_mothership/control)
-"sF" = (
+"uN" = (
 /obj/structure/chair{
 	dir = 1
 	},
 /obj/machinery/light,
 /turf/open/floor/mineral/plastitanium,
 /area/shuttle/assault_pod)
-"sG" = (
+"uO" = (
 /obj/machinery/door/airlock/centcom{
 	name = "Shuttle Control Office";
 	opacity = 1;
@@ -7034,7 +7876,7 @@
 	},
 /turf/open/floor/plasteel,
 /area/centcom/ferry)
-"sH" = (
+"uP" = (
 /obj/structure/table/reinforced,
 /obj/item/stack/packageWrap,
 /obj/item/crowbar/power,
@@ -7045,20 +7887,20 @@
 	},
 /turf/open/floor/plasteel,
 /area/centcom/ferry)
-"sI" = (
+"uQ" = (
 /obj/structure/reagent_dispensers/watertank,
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
 /area/centcom/ferry)
-"sJ" = (
+"uR" = (
 /obj/structure/bookcase/random,
 /turf/open/floor/plasteel/vault{
 	dir = 8
 	},
 /area/centcom/ferry)
-"sK" = (
+"uS" = (
 /obj/structure/table/wood,
 /obj/item/paper_bin,
 /obj/item/pen/fourcolor,
@@ -7070,7 +7912,7 @@
 	dir = 8
 	},
 /area/centcom/ferry)
-"sL" = (
+"uT" = (
 /obj/item/twohanded/required/kirbyplants{
 	icon_state = "plant-22"
 	},
@@ -7078,11 +7920,11 @@
 	dir = 6
 	},
 /area/centcom/ferry)
-"sM" = (
+"uU" = (
 /obj/structure/cable/white,
 /turf/open/floor/plasteel/vault,
 /area/centcom/ferry)
-"sN" = (
+"uV" = (
 /obj/item/twohanded/required/kirbyplants{
 	icon_state = "plant-21"
 	},
@@ -7090,7 +7932,7 @@
 	dir = 10
 	},
 /area/centcom/ferry)
-"sO" = (
+"uW" = (
 /obj/structure/closet/crate/bin,
 /obj/machinery/light_switch{
 	pixel_y = -24
@@ -7099,7 +7941,7 @@
 	dir = 8
 	},
 /area/centcom/ferry)
-"sP" = (
+"uX" = (
 /obj/structure/table/wood,
 /obj/item/dice/d20{
 	pixel_x = 3;
@@ -7119,7 +7961,7 @@
 	dir = 8
 	},
 /area/centcom/ferry)
-"sQ" = (
+"uY" = (
 /obj/structure/flora/ausbushes/lavendergrass,
 /obj/structure/flora/ausbushes/sparsegrass,
 /obj/structure/flora/ausbushes/fullgrass,
@@ -7128,7 +7970,7 @@
 /obj/structure/flora/ausbushes/leafybush,
 /turf/open/floor/grass,
 /area/centcom/ferry)
-"sR" = (
+"uZ" = (
 /obj/structure/flora/ausbushes/lavendergrass,
 /obj/structure/flora/ausbushes/sparsegrass,
 /obj/structure/flora/ausbushes/fullgrass,
@@ -7136,7 +7978,7 @@
 /obj/structure/flora/ausbushes/pointybush,
 /turf/open/floor/grass,
 /area/centcom/ferry)
-"sS" = (
+"va" = (
 /obj/structure/flora/ausbushes/lavendergrass,
 /obj/structure/flora/ausbushes/sparsegrass,
 /obj/structure/flora/ausbushes/fullgrass,
@@ -7144,7 +7986,7 @@
 /obj/structure/flora/ausbushes/genericbush,
 /turf/open/floor/grass,
 /area/centcom/ferry)
-"sT" = (
+"vb" = (
 /obj/structure/flora/ausbushes/lavendergrass,
 /obj/structure/flora/ausbushes/sparsegrass,
 /obj/structure/flora/ausbushes/fullgrass,
@@ -7153,11 +7995,11 @@
 /obj/structure/flora/ausbushes/pointybush,
 /turf/open/floor/grass,
 /area/centcom/ferry)
-"sU" = (
+"vc" = (
 /obj/machinery/newscaster,
 /turf/closed/indestructible/riveted,
 /area/centcom/control)
-"sV" = (
+"vd" = (
 /obj/structure/table/reinforced,
 /obj/machinery/door/firedoor,
 /obj/item/folder/red,
@@ -7173,21 +8015,21 @@
 /obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel,
 /area/centcom/control)
-"sW" = (
+"ve" = (
 /turf/open/floor/plasteel/blue/corner,
 /area/centcom/evac)
-"sX" = (
+"vf" = (
 /turf/open/floor/plasteel/blue/side,
 /area/centcom/evac)
-"sY" = (
+"vg" = (
 /turf/open/floor/plasteel/blue/corner{
 	dir = 8
 	},
 /area/centcom/evac)
-"sZ" = (
+"vh" = (
 /turf/open/floor/plasteel,
 /area/centcom/evac)
-"ta" = (
+"vi" = (
 /obj/docking_port/stationary{
 	dir = 4;
 	dwidth = 25;
@@ -7198,6458 +8040,51 @@
 	},
 /turf/open/space,
 /area/space)
-"tb" = (
+"vj" = (
 /turf/open/floor/wood,
 /area/wizard_station)
-"tc" = (
+"vk" = (
 /obj/structure/chair/wood/wings{
 	icon_state = "wooden_chair_wings";
 	dir = 1
 	},
 /turf/open/floor/wood,
 /area/wizard_station)
-"td" = (
+"vl" = (
 /obj/structure/chair/wood/wings{
 	icon_state = "wooden_chair_wings";
 	dir = 4
 	},
 /turf/open/floor/carpet,
 /area/wizard_station)
-"te" = (
+"vm" = (
 /obj/structure/table/wood/poker,
 /obj/item/toy/figure/wizard,
 /turf/open/floor/carpet,
 /area/wizard_station)
-"tf" = (
-/obj/structure/chair/wood/wings{
-	icon_state = "wooden_chair_wings";
-	dir = 8
-	},
-/turf/open/floor/carpet,
-/area/wizard_station)
-"tg" = (
-/turf/open/floor/plasteel/podhatch{
-	dir = 1
-	},
-/area/shuttle/syndicate/medical)
-"th" = (
-/obj/item/storage/box/drinkingglasses,
-/obj/item/reagent_containers/food/drinks/bottle/rum,
-/obj/structure/table/wood,
-/turf/open/floor/wood,
-/area/syndicate_mothership/control)
-"ti" = (
-/obj/structure/table/wood,
-/turf/open/floor/wood,
-/area/syndicate_mothership/control)
-"tj" = (
-/obj/structure/table/wood,
-/obj/item/device/syndicatedetonator{
-	desc = "This gaudy button can be used to instantly detonate syndicate bombs that have been activated on the station. It is also fun to press."
-	},
-/turf/open/floor/wood,
-/area/syndicate_mothership/control)
-"tk" = (
-/obj/structure/table/wood,
-/obj/item/toy/nuke,
-/turf/open/floor/wood,
-/area/syndicate_mothership/control)
-"tl" = (
-/obj/machinery/door/airlock/centcom{
-	aiControlDisabled = 1;
-	name = "Assault Pod";
-	opacity = 1;
-	req_access_txt = "150"
-	},
-/turf/open/floor/plating,
-/area/shuttle/assault_pod)
-"tm" = (
-/obj/machinery/computer/shuttle/syndicate/drop_pod,
-/turf/closed/wall/mineral/plastitanium,
-/area/shuttle/assault_pod)
-"tn" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/structure/sign/directions/engineering{
-	desc = "A sign that shows there are doors here. There are doors everywhere!";
-	icon_state = "doors";
-	name = "WARNING: EXTERNAL AIRLOCK"
-	},
-/turf/open/floor/plating,
-/area/centcom/ferry)
-"to" = (
-/obj/structure/closet/emcloset,
-/obj/item/tank/internals/emergency_oxygen/engi,
-/obj/item/tank/internals/emergency_oxygen/engi,
-/obj/item/tank/internals/emergency_oxygen/engi,
-/obj/item/clothing/mask/gas,
-/obj/item/clothing/mask/gas,
-/obj/item/clothing/mask/gas,
-/obj/effect/turf_decal/delivery,
-/turf/open/floor/plasteel,
-/area/centcom/ferry)
-"tp" = (
-/obj/machinery/light{
-	dir = 1
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 9
-	},
-/turf/open/floor/plasteel,
-/area/centcom/ferry)
-"tq" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/centcom/ferry)
-"tr" = (
-/obj/machinery/firealarm{
-	pixel_y = 24
-	},
-/obj/structure/chair{
-	dir = 8
-	},
-/obj/structure/extinguisher_cabinet{
-	pixel_x = 24
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 5
-	},
-/turf/open/floor/plasteel,
-/area/centcom/ferry)
-"ts" = (
-/obj/machinery/door/airlock/centcom{
-	name = "Administrative Office";
-	opacity = 1;
-	req_access_txt = "109"
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 2
-	},
-/turf/open/floor/plasteel,
-/area/centcom/ferry)
-"tt" = (
-/obj/machinery/door/poddoor/shutters{
-	id = "XCCsec1";
-	name = "XCC Checkpoint 1 Shutters"
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/centcom/control)
-"tu" = (
-/obj/machinery/light{
-	dir = 8
-	},
-/turf/open/floor/plasteel/green/corner{
-	dir = 1
-	},
-/area/centcom/control)
-"tv" = (
-/obj/machinery/pdapainter,
-/turf/open/floor/plasteel/vault{
-	dir = 8
-	},
-/area/centcom/control)
-"tw" = (
-/obj/machinery/photocopier,
-/obj/machinery/light{
-	dir = 1
-	},
-/obj/machinery/button/door{
-	id = "XCCFerry";
-	name = "Hanger Bay Shutters";
-	pixel_x = -8;
-	pixel_y = 24;
-	req_access_txt = "2"
-	},
-/obj/machinery/button/door{
-	id = "XCCsec3";
-	name = "CC Main Access Control";
-	pixel_x = 8;
-	pixel_y = 24
-	},
-/obj/machinery/button/door{
-	id = "XCCsec1";
-	name = "CC Shutter 1 Control";
-	pixel_x = 8;
-	pixel_y = 38
-	},
-/obj/machinery/button/door{
-	id = "XCCsec3";
-	name = "XCC Shutter 3 Control";
-	pixel_x = -8;
-	pixel_y = 38
-	},
-/turf/open/floor/plasteel/vault{
-	dir = 8
-	},
-/area/centcom/control)
-"tx" = (
-/obj/structure/table/reinforced,
-/obj/item/storage/fancy/donut_box,
-/turf/open/floor/plasteel/vault{
-	dir = 8
-	},
-/area/centcom/control)
-"ty" = (
-/obj/item/device/flashlight/lamp,
-/obj/structure/table/reinforced,
-/turf/open/floor/plasteel/vault{
-	dir = 8
-	},
-/area/centcom/control)
-"tz" = (
-/obj/structure/table/reinforced,
-/obj/item/paper_bin,
-/obj/item/pen,
-/turf/open/floor/plasteel/vault{
-	dir = 8
-	},
-/area/centcom/control)
-"tA" = (
-/obj/structure/filingcabinet/medical,
-/obj/machinery/light{
-	dir = 1
-	},
-/turf/open/floor/plasteel/vault{
-	dir = 8
-	},
-/area/centcom/control)
-"tB" = (
-/obj/machinery/light{
-	dir = 4
-	},
-/turf/open/floor/plasteel/green/corner{
-	dir = 4
-	},
-/area/centcom/control)
-"tC" = (
-/obj/machinery/door/poddoor/shutters{
-	id = "XCCcustoms2";
-	name = "XCC Customs 2 Shutters"
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/centcom/control)
-"tD" = (
-/obj/structure/table,
-/obj/item/paper/pamphlet/centcom/visitor_info,
-/obj/item/paper/pamphlet/centcom/visitor_info,
-/obj/item/paper/pamphlet/centcom/visitor_info,
-/obj/machinery/light{
-	dir = 8
-	},
-/turf/open/floor/plasteel/green/side{
-	dir = 9
-	},
-/area/centcom/control)
-"tE" = (
-/obj/structure/chair,
-/turf/open/floor/plasteel/red/side{
-	dir = 1
-	},
-/area/centcom/control)
-"tF" = (
-/obj/effect/turf_decal/delivery,
-/turf/open/floor/plasteel,
-/area/centcom/control)
-"tG" = (
-/obj/structure/table,
-/obj/item/paper_bin,
-/obj/item/pen,
-/obj/machinery/light{
-	dir = 4
-	},
-/turf/open/floor/plasteel/green/side{
-	dir = 5
-	},
-/area/centcom/control)
-"tH" = (
-/obj/machinery/door/poddoor/shutters{
-	id = "XCCcustoms1";
-	name = "XCC Customs 1 Shutters"
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/centcom/evac)
-"tI" = (
-/turf/open/floor/plasteel/neutral/side{
-	dir = 10
-	},
-/area/centcom/evac)
-"tJ" = (
-/turf/open/floor/plasteel/blue/side{
-	dir = 5
-	},
-/area/centcom/evac)
-"tK" = (
-/turf/open/floor/plasteel/blue,
-/area/centcom/evac)
-"tL" = (
-/turf/open/floor/plasteel/blue/side{
-	dir = 4
-	},
-/area/centcom/evac)
-"tM" = (
-/turf/open/floor/plasteel/blue/side{
-	dir = 8
-	},
-/area/centcom/evac)
-"tO" = (
-/obj/machinery/door/airlock{
-	icon = 'icons/obj/doors/airlocks/station/uranium.dmi';
-	name = "Observation Room"
-	},
-/turf/open/floor/engine/cult,
-/area/wizard_station)
-"tP" = (
-/obj/machinery/door/airlock{
-	icon = 'icons/obj/doors/airlocks/station/uranium.dmi';
-	name = "Game Room"
-	},
-/turf/open/floor/engine/cult,
-/area/wizard_station)
-"tQ" = (
-/obj/structure/chair/wood/wings{
-	icon_state = "wooden_chair_wings";
-	dir = 1
-	},
-/turf/open/floor/carpet,
-/area/wizard_station)
-"tR" = (
-/obj/structure/sign/securearea{
-	desc = "A warning sign which reads 'FOURTH WALL'.";
-	name = "\improper FOURTH WALL";
-	pixel_x = -32
-	},
-/turf/open/floor/plating/asteroid/snow/airless,
-/area/syndicate_mothership)
-"tS" = (
-/turf/open/floor/wood,
-/area/syndicate_mothership/control)
-"tT" = (
-/obj/effect/landmark/start/nukeop_leader,
-/turf/open/floor/wood,
-/area/syndicate_mothership/control)
-"tU" = (
-/obj/machinery/door/window{
-	base_state = "right";
-	dir = 4;
-	icon_state = "right";
-	name = "Uplink Management Control";
-	req_access_txt = "151"
-	},
-/turf/open/floor/wood,
-/area/syndicate_mothership/control)
-"tV" = (
-/obj/structure/chair,
-/obj/machinery/light{
-	dir = 1
-	},
-/turf/open/floor/mineral/plastitanium,
-/area/shuttle/assault_pod)
-"tW" = (
-/obj/structure/chair{
-	dir = 4
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/centcom/ferry)
-"tX" = (
-/turf/open/floor/plasteel/neutral,
-/area/centcom/ferry)
-"tY" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/centcom/ferry)
-"tZ" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/centcom{
-	name = "CentCom Security";
-	opacity = 1;
-	req_access_txt = "101"
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/centcom/ferry)
-"ua" = (
-/obj/machinery/door/poddoor/shutters{
-	id = "XCCFerry";
-	name = "XCC Ferry Hangar"
-	},
-/turf/open/floor/plasteel/loadingarea{
-	dir = 4
-	},
-/area/centcom/ferry)
-"ub" = (
-/obj/machinery/button/door{
-	id = "XCCFerry";
-	name = "Hanger Bay Shutters";
-	pixel_y = 24;
-	req_access_txt = "2"
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 5
-	},
-/turf/open/floor/plasteel,
-/area/centcom/ferry)
-"uc" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 10
-	},
-/turf/open/floor/plasteel,
-/area/centcom/ferry)
-"ud" = (
-/obj/effect/turf_decal/delivery,
-/turf/open/floor/plasteel,
-/area/centcom/ferry)
-"ue" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 6
-	},
-/turf/open/floor/plasteel,
-/area/centcom/ferry)
-"uf" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 9
-	},
-/turf/open/floor/plasteel,
-/area/centcom/ferry)
-"ug" = (
-/obj/machinery/door/airlock/centcom{
-	name = "CentCom Customs";
-	opacity = 1;
-	req_access_txt = "109"
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/centcom/control)
-"uh" = (
-/obj/structure/table/reinforced,
-/obj/item/folder/red{
-	pixel_x = -2;
-	pixel_y = -2
-	},
-/obj/item/folder/blue{
-	pixel_x = 2;
-	pixel_y = 2
-	},
-/obj/item/lighter,
-/turf/open/floor/plasteel/vault{
-	dir = 8
-	},
-/area/centcom/control)
-"ui" = (
-/obj/structure/chair/comfy/brown{
-	color = "#596479";
-	dir = 2
-	},
-/turf/open/floor/plasteel/vault,
-/area/centcom/control)
-"uj" = (
-/obj/structure/table/reinforced,
-/obj/machinery/computer/med_data/laptop,
-/turf/open/floor/plasteel/vault{
-	dir = 8
-	},
-/area/centcom/control)
-"uk" = (
-/turf/open/floor/plasteel/green/side{
-	dir = 8
-	},
-/area/centcom/control)
-"ul" = (
-/turf/open/floor/plasteel/loadingarea,
-/area/centcom/control)
-"um" = (
-/turf/open/floor/plasteel/green/side{
-	dir = 4
-	},
-/area/centcom/control)
-"un" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/centcom/evac)
-"uo" = (
-/turf/open/floor/plasteel/blue/side{
-	dir = 6
-	},
-/area/centcom/evac)
-"uq" = (
-/obj/structure/chair/wood/wings{
-	icon_state = "wooden_chair_wings";
-	dir = 8
-	},
-/turf/open/floor/wood,
-/area/wizard_station)
-"ur" = (
-/obj/structure/table/wood/fancy,
-/obj/item/device/camera/spooky,
-/turf/open/floor/carpet,
-/area/wizard_station)
-"us" = (
-/obj/structure/table/wood/poker,
-/obj/item/toy/cards/deck,
-/turf/open/floor/carpet,
-/area/wizard_station)
-"ut" = (
-/obj/machinery/computer/telecrystals/boss,
-/turf/open/floor/plasteel/podhatch{
-	dir = 5
-	},
-/area/syndicate_mothership/control)
-"uu" = (
-/obj/structure/sign/map/left{
-	pixel_y = -32
-	},
-/obj/structure/rack{
-	icon = 'icons/obj/stationobjs.dmi';
-	icon_state = "minibar_left";
-	name = "skeletal minibar"
-	},
-/obj/item/reagent_containers/food/drinks/bottle/vodka,
-/turf/open/floor/wood,
-/area/syndicate_mothership/control)
-"uv" = (
-/obj/structure/sign/map/right{
-	pixel_y = -32
-	},
-/obj/structure/rack{
-	icon = 'icons/obj/stationobjs.dmi';
-	icon_state = "minibar_right";
-	name = "skeletal minibar"
-	},
-/obj/item/reagent_containers/food/drinks/bottle/gin,
-/turf/open/floor/wood,
-/area/syndicate_mothership/control)
-"uw" = (
-/obj/machinery/door/airlock/centcom{
-	name = "Equipment Room";
-	opacity = 1;
-	req_access_txt = "150"
-	},
-/turf/open/floor/plasteel/bar{
-	dir = 2
-	},
-/area/syndicate_mothership/control)
-"ux" = (
-/turf/open/floor/plating/asteroid/snow/airless,
-/obj/machinery/porta_turret/syndicate/pod,
-/turf/closed/wall/mineral/plastitanium{
-	icon_state = "diagonalWall3"
-	},
-/area/shuttle/assault_pod)
-"uy" = (
-/turf/open/floor/plating/asteroid/snow/airless,
-/obj/machinery/porta_turret/syndicate/pod,
-/turf/closed/wall/mineral/plastitanium{
-	dir = 4;
-	icon_state = "diagonalWall3"
-	},
-/area/shuttle/assault_pod)
-"uz" = (
-/obj/docking_port/stationary{
-	dir = 8;
-	dwidth = 2;
-	height = 13;
-	id = "ferry_away";
-	name = "CentCom Ferry Dock";
-	width = 5
-	},
-/turf/open/space,
-/area/space)
-"uA" = (
-/obj/machinery/door/airlock/external{
-	name = "Ferry Airlock";
-	req_access_txt = "0"
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/centcom/ferry)
-"uB" = (
-/obj/structure/fans/tiny,
-/obj/effect/turf_decal/delivery,
-/turf/open/floor/plasteel,
-/area/centcom/ferry)
-"uC" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/centcom/ferry)
-"uD" = (
-/obj/effect/turf_decal/bot,
-/turf/open/floor/plasteel,
-/area/centcom/ferry)
-"uE" = (
-/obj/structure/chair{
-	dir = 8
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/centcom/ferry)
-"uF" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/structure/sign/directions/engineering{
-	desc = "A sign that shows there are doors here. There are doors everywhere!";
-	icon_state = "doors";
-	name = "WARNING: BLAST DOORS"
-	},
-/turf/open/floor/plating,
-/area/centcom/ferry)
-"uG" = (
-/obj/item/twohanded/required/kirbyplants{
-	icon_state = "plant-21"
-	},
-/obj/effect/turf_decal/delivery,
-/turf/open/floor/plasteel,
-/area/centcom/ferry)
-"uH" = (
-/turf/open/floor/plasteel/green/side{
-	dir = 8
-	},
-/area/centcom/ferry)
-"uI" = (
-/turf/open/floor/plasteel/green/side{
-	dir = 4
-	},
-/area/centcom/ferry)
-"uJ" = (
-/turf/open/floor/plasteel/neutral/side{
-	dir = 8;
-	heat_capacity = 1e+006
-	},
-/area/centcom/control)
-"uK" = (
-/obj/machinery/computer/med_data,
-/turf/open/floor/plasteel/vault{
-	dir = 8
-	},
-/area/centcom/control)
-"uL" = (
-/obj/machinery/computer/card/centcom,
-/turf/open/floor/plasteel/vault{
-	dir = 8
-	},
-/area/centcom/control)
-"uM" = (
-/turf/open/floor/plasteel/green/corner,
-/area/centcom/control)
-"uN" = (
-/obj/item/twohanded/required/kirbyplants{
-	icon_state = "plant-21"
-	},
-/turf/open/floor/plasteel/green/side{
-	dir = 8
-	},
-/area/centcom/control)
-"uO" = (
-/obj/item/twohanded/required/kirbyplants{
-	icon_state = "plant-21"
-	},
-/turf/open/floor/plasteel/green/side{
-	dir = 4
-	},
-/area/centcom/control)
-"uP" = (
-/obj/item/twohanded/required/kirbyplants{
-	icon_state = "plant-22"
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/centcom/evac)
-"uQ" = (
-/turf/open/floor/plasteel/neutral/side{
-	dir = 5
-	},
-/area/centcom/evac)
-"uR" = (
-/obj/item/statuebust{
-	pixel_y = 12
-	},
-/obj/structure/table/wood/fancy,
-/turf/open/floor/wood,
-/area/wizard_station)
-"uS" = (
-/obj/machinery/vending/magivend,
-/turf/open/floor/engine/cult,
-/area/wizard_station)
-"uT" = (
-/obj/machinery/vending/snack,
-/turf/open/floor/engine/cult,
-/area/wizard_station)
-"uU" = (
-/obj/structure/table/wood/fancy,
-/obj/item/storage/pill_bottle/dice{
-	icon_state = "magicdicebag"
-	},
-/turf/open/floor/carpet,
-/area/wizard_station)
-"uV" = (
-/obj/structure/table/wood/fancy,
-/obj/item/storage/photo_album,
-/obj/machinery/light,
-/turf/open/floor/carpet,
-/area/wizard_station)
-"uW" = (
-/turf/open/floor/plasteel/black,
-/area/syndicate_mothership/control)
-"uX" = (
-/obj/machinery/mech_bay_recharge_port,
-/turf/open/floor/plating,
-/area/syndicate_mothership/control)
-"uY" = (
-/obj/machinery/light{
-	dir = 1
-	},
-/turf/open/floor/mech_bay_recharge_floor,
-/area/syndicate_mothership/control)
-"uZ" = (
-/obj/machinery/computer/mech_bay_power_console,
-/turf/open/floor/plating,
-/area/syndicate_mothership/control)
-"va" = (
-/obj/machinery/vending/tool,
-/turf/open/floor/plasteel/black,
-/area/syndicate_mothership/control)
-"vb" = (
-/obj/structure/closet/cardboard/metal,
-/obj/effect/turf_decal/stripes/corner{
-	dir = 8
-	},
-/turf/open/floor/plating/airless,
-/area/syndicate_mothership/control)
-"vc" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 5
-	},
-/turf/open/floor/plating/airless,
-/area/syndicate_mothership/control)
-"vd" = (
-/obj/machinery/door/airlock/centcom{
-	aiControlDisabled = 1;
-	name = "Assault Pod";
-	opacity = 1;
-	req_access_txt = "150"
-	},
-/obj/docking_port/mobile/assault_pod{
-	dwidth = 3;
-	name = "steel rain";
-	port_direction = 4;
-	preferred_direction = 4
-	},
-/turf/open/floor/plating,
-/area/shuttle/assault_pod)
-"ve" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 9
-	},
-/turf/open/floor/plating/airless,
-/area/syndicate_mothership/control)
-"vf" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 5
-	},
-/turf/open/floor/plasteel,
-/area/centcom/ferry)
-"vg" = (
-/obj/machinery/button/door{
-	id = "XCCsec1";
-	name = "CC Shutter 1 Control";
-	pixel_y = -24
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 10
-	},
-/turf/open/floor/plasteel,
-/area/centcom/ferry)
-"vh" = (
-/turf/open/floor/plasteel/green/corner{
-	dir = 8
-	},
-/area/centcom/control)
-"vi" = (
-/obj/machinery/computer/crew,
-/turf/open/floor/plasteel/vault{
-	dir = 8
-	},
-/area/centcom/control)
-"vj" = (
-/obj/structure/chair/office/dark{
-	dir = 8
-	},
-/turf/open/floor/wood,
-/area/centcom/control)
-"vk" = (
-/obj/structure/chair/office/dark{
-	dir = 4
-	},
-/turf/open/floor/wood,
-/area/centcom/control)
-"vl" = (
-/obj/machinery/computer/communications,
-/turf/open/floor/plasteel/vault{
-	dir = 8
-	},
-/area/centcom/control)
-"vm" = (
-/turf/open/floor/plasteel/blue/side{
-	dir = 9
-	},
-/area/centcom/evac)
 "vn" = (
-/turf/open/floor/plasteel/blue/side{
-	dir = 10
-	},
-/area/centcom/evac)
-"vo" = (
-/obj/machinery/door/airlock{
-	icon = 'icons/obj/doors/airlocks/station/uranium.dmi';
-	name = "Study"
-	},
-/turf/open/floor/engine/cult,
-/area/wizard_station)
-"vp" = (
-/obj/machinery/door/airlock{
-	icon = 'icons/obj/doors/airlocks/station/uranium.dmi';
-	name = "Break Room"
-	},
-/turf/open/floor/engine/cult,
-/area/wizard_station)
-"vq" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/turf/open/floor/plating/airless,
-/area/syndicate_mothership/control)
-"vr" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/structure/sign/vacuum,
-/turf/open/floor/plating,
-/area/centcom/ferry)
-"vs" = (
-/obj/machinery/light,
-/obj/effect/turf_decal/stripes/line{
-	dir = 10
-	},
-/turf/open/floor/plasteel,
-/area/centcom/ferry)
-"vt" = (
-/obj/effect/turf_decal/stripes/line,
-/turf/open/floor/plasteel,
-/area/centcom/ferry)
-"vu" = (
-/obj/structure/chair{
-	dir = 8
-	},
-/obj/machinery/computer/security/telescreen/entertainment{
-	pixel_y = -28
-	},
-/obj/structure/sign/securearea{
-	pixel_x = 32
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 6
-	},
-/turf/open/floor/plasteel,
-/area/centcom/ferry)
-"vv" = (
-/obj/machinery/door/airlock/centcom{
-	name = "Briefing Room";
-	opacity = 1;
-	req_access_txt = "101"
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 2
-	},
-/turf/open/floor/plasteel,
-/area/centcom/ferry)
-"vw" = (
-/obj/machinery/light{
-	dir = 8
-	},
-/turf/open/floor/plasteel/green/corner{
-	dir = 8
-	},
-/area/centcom/control)
-"vx" = (
-/obj/item/storage/box/ids{
-	pixel_x = 3;
-	pixel_y = 3
-	},
-/obj/item/storage/box/silver_ids,
-/obj/structure/table/reinforced,
-/turf/open/floor/plasteel/vault{
-	dir = 8
-	},
-/area/centcom/control)
-"vy" = (
-/obj/structure/table/reinforced,
-/obj/item/clipboard,
-/obj/item/folder/white,
-/obj/item/pen/blue,
-/turf/open/floor/plasteel/vault{
-	dir = 8
-	},
-/area/centcom/control)
-"vz" = (
-/obj/machinery/computer/prisoner,
-/obj/machinery/light,
-/turf/open/floor/plasteel/vault{
-	dir = 8
-	},
-/area/centcom/control)
-"vA" = (
-/obj/machinery/computer/secure_data,
-/obj/machinery/light,
-/turf/open/floor/plasteel/vault{
-	dir = 8
-	},
-/area/centcom/control)
-"vB" = (
-/obj/structure/table/reinforced,
-/obj/item/clipboard,
-/obj/item/folder/red,
-/obj/item/pen/red,
-/turf/open/floor/plasteel/vault{
-	dir = 8
-	},
-/area/centcom/control)
-"vC" = (
-/obj/machinery/light{
-	dir = 4
-	},
-/turf/open/floor/plasteel/green/corner,
-/area/centcom/control)
-"vD" = (
-/obj/structure/chair{
-	dir = 1
-	},
-/turf/open/floor/plasteel/blue/side,
-/area/centcom/control)
-"vE" = (
-/obj/item/storage/firstaid/regular,
-/obj/structure/table,
-/turf/open/floor/plasteel/green/side{
-	dir = 6
-	},
-/area/centcom/control)
-"vF" = (
-/turf/open/floor/plasteel/blue/corner{
-	dir = 4
-	},
-/area/centcom/evac)
-"vG" = (
-/obj/structure/chair/wood/wings,
-/turf/open/floor/engine/cult,
-/area/wizard_station)
-"vH" = (
-/obj/structure/table/wood,
-/obj/item/stack/medical/bruise_pack,
-/obj/item/stack/medical/ointment,
-/turf/open/floor/engine/cult,
-/area/wizard_station)
-"vI" = (
-/obj/structure/table/wood,
-/obj/item/retractor,
-/obj/machinery/light{
-	dir = 1
-	},
-/turf/open/floor/engine/cult,
-/area/wizard_station)
-"vJ" = (
-/obj/structure/table/wood,
-/obj/item/clothing/suit/wizrobe/magusblue,
-/obj/item/clothing/head/wizard/magus,
-/obj/item/staff,
-/obj/structure/mirror/magic{
-	pixel_y = 28
-	},
-/obj/machinery/light{
-	dir = 1
-	},
-/turf/open/floor/engine/cult,
-/area/wizard_station)
-"vK" = (
-/obj/structure/table/wood,
-/obj/item/clothing/suit/wizrobe/magusred,
-/obj/item/clothing/head/wizard/magus,
-/obj/item/staff,
-/turf/open/floor/engine/cult,
-/area/wizard_station)
-"vL" = (
-/obj/item/reagent_containers/food/snacks/meat/slab/human/mutant/lizard,
-/turf/open/floor/grass,
-/area/wizard_station)
-"vM" = (
-/obj/effect/decal/cleanable/blood/splatter,
-/obj/effect/decal/cleanable/blood/gibs/body,
-/turf/open/floor/grass,
-/area/wizard_station)
-"vN" = (
-/obj/effect/decal/remains/xeno/larva,
-/turf/open/floor/grass,
-/area/wizard_station)
-"vO" = (
-/obj/effect/decal/cleanable/blood/splatter,
-/turf/open/floor/grass,
-/area/wizard_station)
-"vP" = (
-/obj/structure/chair/stool,
-/turf/open/floor/plasteel/black,
-/area/syndicate_mothership/control)
-"vQ" = (
-/obj/structure/table/wood,
-/obj/item/storage/fancy/donut_box,
-/turf/open/floor/plasteel/vault{
-	dir = 8
-	},
-/area/centcom/ferry)
-"vR" = (
-/obj/structure/table/wood,
-/obj/item/phone{
-	desc = "Supposedly a direct line to Nanotrasen Central Command. It's not even plugged in.";
-	pixel_x = -3;
-	pixel_y = 3
-	},
-/obj/item/clothing/mask/cigarette/cigar/cohiba{
-	pixel_x = 6
-	},
-/obj/item/clothing/mask/cigarette/cigar/havana{
-	pixel_x = 2
-	},
-/obj/item/clothing/mask/cigarette/cigar{
-	pixel_x = 4.5
-	},
-/obj/machinery/newscaster{
-	pixel_y = 32
-	},
-/turf/open/floor/plasteel/vault{
-	dir = 8
-	},
-/area/centcom/ferry)
-"vS" = (
-/obj/structure/bookcase/random,
-/obj/machinery/light{
-	dir = 1
-	},
-/turf/open/floor/plasteel/vault{
-	dir = 8
-	},
-/area/centcom/ferry)
-"vT" = (
-/obj/structure/table/wood,
-/obj/machinery/computer/med_data/laptop,
-/turf/open/floor/plasteel/vault{
-	dir = 8
-	},
-/area/centcom/ferry)
-"vU" = (
-/obj/item/twohanded/required/kirbyplants{
-	icon_state = "plant-21"
-	},
-/turf/open/floor/plasteel/vault{
-	dir = 8
-	},
-/area/centcom/ferry)
-"vV" = (
-/obj/item/twohanded/required/kirbyplants{
-	icon_state = "plant-22"
-	},
-/obj/machinery/light{
-	dir = 1
-	},
-/turf/open/floor/plasteel/vault{
-	dir = 8
-	},
-/area/centcom/ferry)
-"vW" = (
-/obj/structure/closet/secure_closet/ertEngi,
-/obj/structure/sign/directions/engineering{
-	pixel_y = 24
-	},
-/obj/effect/turf_decal/stripes/line,
-/turf/open/floor/plasteel,
-/area/centcom/ferry)
-"vX" = (
-/obj/structure/closet/secure_closet/ertEngi,
-/obj/machinery/airalarm{
-	pixel_y = 24
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 6
-	},
-/turf/open/floor/plasteel,
-/area/centcom/ferry)
-"vY" = (
-/obj/structure/table/reinforced,
-/obj/item/gun/ballistic/automatic/wt550,
-/obj/item/device/flashlight/seclite,
-/obj/structure/noticeboard{
-	pixel_y = 28
-	},
-/obj/effect/turf_decal/stripes/line,
-/turf/open/floor/plasteel,
-/area/centcom/ferry)
-"vZ" = (
-/obj/structure/table/reinforced,
-/obj/item/grenade/plastic/c4{
-	pixel_x = 6
-	},
-/obj/item/grenade/plastic/c4{
-	pixel_x = -4
-	},
-/obj/machinery/firealarm{
-	pixel_y = 24
-	},
-/obj/effect/turf_decal/stripes/line,
-/turf/open/floor/plasteel,
-/area/centcom/ferry)
-"wa" = (
-/obj/structure/rack,
-/obj/item/gun/energy/e_gun{
-	pixel_x = -3;
-	pixel_y = 3
-	},
-/obj/item/gun/energy/e_gun,
-/obj/structure/sign/nanotrasen{
-	pixel_y = 32
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 10
-	},
-/turf/open/floor/plasteel,
-/area/centcom/ferry)
-"wb" = (
-/obj/structure/closet/secure_closet/ertCom,
-/obj/structure/sign/directions/engineering{
-	desc = "A direction sign, pointing out which way the Command department is.";
-	dir = 2;
-	icon_state = "direction_bridge";
-	name = "command department";
-	pixel_y = 24
-	},
-/obj/effect/turf_decal/stripes/line,
-/turf/open/floor/plasteel,
-/area/centcom/ferry)
-"wc" = (
-/obj/machinery/door/airlock/glass_medical{
-	name = "Infirmary"
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 2
-	},
-/turf/open/floor/plasteel,
-/area/centcom/control)
-"wd" = (
-/turf/open/floor/plasteel/blue/corner{
-	dir = 1
-	},
-/area/centcom/evac)
-"we" = (
-/turf/open/floor/plasteel/blue/side{
-	dir = 1
-	},
-/area/centcom/evac)
-"wf" = (
-/turf/closed/indestructible/fakeglass{
-	color = "#008000";
-	dir = 1;
-	icon_state = "fakewindows"
-	},
-/area/wizard_station)
-"wg" = (
-/obj/structure/destructible/cult/tome,
-/turf/open/floor/engine/cult,
-/area/wizard_station)
-"wh" = (
-/obj/structure/closet/crate{
-	icon_state = "crateopen";
-	opened = 1
-	},
-/obj/item/clothing/suit/wizrobe/red,
-/obj/item/clothing/head/wizard/red,
-/obj/item/staff,
-/obj/item/clothing/shoes/sandal/magic,
-/turf/open/floor/engine/cult,
-/area/wizard_station)
-"wi" = (
-/turf/open/floor/grass,
-/area/wizard_station)
-"wj" = (
-/obj/item/reagent_containers/food/snacks/meat/slab/corgi,
-/turf/open/floor/grass,
-/area/wizard_station)
-"wk" = (
-/obj/structure/closet/syndicate/personal,
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/turf/open/floor/plasteel/black,
-/area/syndicate_mothership/control)
-"wl" = (
-/obj/structure/table,
-/obj/item/gun/energy/ionrifle{
-	pin = /obj/item/device/firing_pin
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/turf/open/floor/plasteel/black,
-/area/syndicate_mothership/control)
-"wm" = (
-/obj/structure/table/wood,
-/obj/item/storage/box/drinkingglasses,
-/obj/item/reagent_containers/food/drinks/bottle/whiskey{
-	pixel_y = 5
-	},
-/turf/open/floor/plasteel/vault{
-	dir = 8
-	},
-/area/centcom/ferry)
-"wn" = (
-/turf/open/floor/plasteel/black,
-/area/centcom/ferry)
-"wo" = (
-/obj/structure/chair/office/dark,
-/obj/effect/landmark/ert_spawn,
-/turf/open/floor/plasteel/black,
-/area/centcom/ferry)
-"wp" = (
-/obj/structure/chair/office/dark,
-/obj/effect/landmark/ert_spawn,
-/turf/open/floor/plasteel/vault{
-	dir = 5
-	},
-/area/centcom/ferry)
-"wq" = (
-/obj/machinery/light{
-	dir = 8
-	},
-/turf/open/floor/plasteel/vault{
-	dir = 8
-	},
-/area/centcom/ferry)
-"wr" = (
-/obj/machinery/light{
-	dir = 4
-	},
-/turf/open/floor/plasteel/vault{
-	dir = 8
-	},
-/area/centcom/ferry)
-"ws" = (
-/turf/open/floor/plasteel/red/corner{
-	dir = 8
-	},
-/area/centcom/control)
-"wt" = (
-/turf/open/floor/plasteel/blue/corner,
-/area/centcom/control)
-"wu" = (
-/obj/item/scalpel{
-	pixel_y = 12
-	},
-/obj/item/circular_saw,
-/obj/item/retractor{
-	pixel_x = 4
-	},
-/obj/item/hemostat{
-	pixel_x = -4
-	},
-/obj/item/clothing/gloves/color/latex,
-/obj/item/clothing/mask/surgical,
-/obj/structure/table/reinforced,
-/turf/open/floor/plasteel/cmo,
-/area/centcom/control)
-"wv" = (
-/obj/structure/bed/roller,
-/obj/machinery/iv_drip,
-/turf/open/floor/plasteel/cmo,
-/area/centcom/control)
-"ww" = (
-/turf/open/floor/plasteel/cmo,
-/area/centcom/control)
-"wx" = (
-/obj/machinery/computer/med_data,
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = 24
-	},
-/turf/open/floor/plasteel/cmo,
-/area/centcom/control)
-"wy" = (
-/turf/closed/indestructible/fakeglass{
-	color = "#008000";
-	dir = 1;
-	icon_state = "fakewindows2"
-	},
-/area/wizard_station)
-"wz" = (
-/obj/structure/bookcase/random/reference,
-/turf/open/floor/engine/cult,
-/area/wizard_station)
-"wA" = (
-/obj/structure/destructible/cult/talisman{
-	desc = "An altar dedicated to the Wizards' Federation"
-	},
-/obj/item/kitchen/knife/ritual,
-/turf/open/floor/engine/cult,
-/area/wizard_station)
-"wB" = (
-/obj/item/clothing/shoes/sandal/marisa,
-/obj/item/clothing/suit/wizrobe/marisa,
-/obj/item/clothing/head/wizard/marisa,
-/obj/item/staff/broom,
-/turf/open/floor/engine/cult,
-/area/wizard_station)
-"wC" = (
-/obj/effect/decal/cleanable/blood/splatter,
-/mob/living/simple_animal/hostile/creature{
-	name = "Experiment 35b"
-	},
-/turf/open/floor/grass,
-/area/wizard_station)
-"wD" = (
-/obj/machinery/photocopier,
-/turf/open/floor/plasteel/grimy,
-/area/centcom/ferry)
-"wE" = (
-/obj/structure/table/reinforced,
-/obj/item/folder/red{
-	pixel_x = -2;
-	pixel_y = -2
-	},
-/obj/item/folder/blue{
-	pixel_x = 2;
-	pixel_y = 2
-	},
-/obj/item/lighter,
-/turf/open/floor/plasteel/grimy,
-/area/centcom/ferry)
-"wF" = (
-/obj/structure/table/reinforced,
-/obj/item/storage/secure/briefcase,
-/turf/open/floor/plasteel/vault{
-	dir = 8
-	},
-/area/centcom/ferry)
-"wG" = (
-/obj/structure/table/reinforced,
-/obj/item/storage/firstaid/regular,
-/turf/open/floor/plasteel/vault{
-	dir = 8
-	},
-/area/centcom/ferry)
-"wH" = (
-/obj/structure/table/reinforced,
-/obj/item/clipboard,
-/obj/item/folder/white,
-/obj/item/pen/blue,
-/turf/open/floor/plasteel/vault{
-	dir = 8
-	},
-/area/centcom/ferry)
-"wI" = (
-/obj/structure/table/reinforced,
-/obj/item/paper_bin,
-/obj/item/pen,
-/turf/open/floor/plasteel/vault{
-	dir = 8
-	},
-/area/centcom/ferry)
-"wJ" = (
-/obj/structure/chair/office/dark{
-	dir = 8
-	},
-/obj/effect/landmark/ert_spawn,
-/turf/open/floor/plasteel/black,
-/area/centcom/ferry)
-"wK" = (
-/obj/machinery/door/poddoor/ert,
-/obj/effect/turf_decal/delivery,
-/turf/open/floor/plasteel,
-/area/centcom/ferry)
-"wM" = (
-/obj/structure/table/reinforced,
-/obj/item/restraints/handcuffs,
-/obj/item/device/radio,
-/obj/effect/turf_decal/stripes/line{
-	dir = 9
-	},
-/turf/open/floor/plasteel,
-/area/centcom/ferry)
-"wN" = (
-/obj/structure/table/reinforced,
-/obj/item/storage/firstaid/regular,
-/obj/effect/turf_decal/stripes/line{
-	dir = 5
-	},
-/turf/open/floor/plasteel,
-/area/centcom/ferry)
-"wO" = (
-/obj/structure/extinguisher_cabinet{
-	pixel_x = 26
-	},
-/turf/open/floor/plasteel/vault{
-	dir = 8
-	},
-/area/centcom/ferry)
-"wP" = (
-/obj/item/twohanded/required/kirbyplants{
-	icon_state = "plant-21"
-	},
-/turf/open/floor/plasteel/red/corner{
-	dir = 8
-	},
-/area/centcom/control)
-"wQ" = (
-/obj/machinery/light,
-/turf/open/floor/plasteel/green/corner{
-	dir = 8
-	},
-/area/centcom/control)
-"wR" = (
-/obj/machinery/light,
-/turf/open/floor/plasteel/green/corner,
-/area/centcom/control)
-"wS" = (
-/obj/item/twohanded/required/kirbyplants{
-	icon_state = "plant-22"
-	},
-/turf/open/floor/plasteel/blue/corner,
-/area/centcom/control)
-"wT" = (
-/obj/structure/table/optable,
-/obj/item/surgical_drapes,
-/turf/open/floor/plasteel/cmo,
-/area/centcom/control)
-"wU" = (
-/turf/open/floor/plasteel/blue,
-/area/centcom/control)
-"wV" = (
-/obj/machinery/computer/communications,
-/obj/structure/extinguisher_cabinet{
-	pixel_x = 24
-	},
-/turf/open/floor/plasteel/cmo,
-/area/centcom/control)
-"wW" = (
-/turf/open/floor/plasteel/yellowsiding,
-/area/centcom/evac)
-"wX" = (
-/turf/closed/indestructible/fakeglass{
-	color = "#008000"
-	},
-/area/wizard_station)
-"wY" = (
-/obj/effect/landmark/start/wizard,
-/turf/open/floor/engine/cult,
-/area/wizard_station)
-"wZ" = (
-/obj/effect/decal/remains/human,
-/obj/effect/decal/cleanable/blood/splatter,
-/turf/open/floor/grass,
-/area/wizard_station)
-"xa" = (
-/obj/item/reagent_containers/food/snacks/meat/slab/human/mutant/slime,
-/turf/open/floor/grass,
-/area/wizard_station)
-"xb" = (
-/obj/effect/decal/remains/xeno,
-/turf/open/floor/grass,
-/area/wizard_station)
-"xc" = (
-/obj/structure/chair/comfy/brown{
-	color = "#596479";
-	dir = 4
-	},
-/turf/open/floor/plasteel/grimy,
-/area/centcom/ferry)
-"xd" = (
-/obj/item/clipboard,
-/obj/item/folder/red,
-/obj/item/stamp/denied{
-	pixel_x = 3;
-	pixel_y = 3
-	},
-/obj/item/stamp,
-/obj/structure/table/reinforced,
-/turf/open/floor/plasteel/grimy,
-/area/centcom/ferry)
-"xe" = (
-/obj/structure/table/reinforced,
-/obj/item/device/flashlight/seclite,
-/turf/open/floor/plasteel/vault{
-	dir = 8
-	},
-/area/centcom/ferry)
-"xf" = (
-/obj/machinery/shuttle_manipulator,
-/turf/open/floor/circuit/green,
-/area/centcom/ferry)
-"xg" = (
-/turf/open/floor/circuit/green,
-/area/centcom/ferry)
-"xh" = (
-/obj/structure/table/reinforced,
-/obj/item/clipboard,
-/obj/item/folder/red,
-/obj/item/pen/red,
-/turf/open/floor/plasteel/vault{
-	dir = 8
-	},
-/area/centcom/ferry)
-"xi" = (
-/obj/structure/chair/office/dark{
-	dir = 8
-	},
-/obj/effect/landmark/ert_spawn,
-/turf/open/floor/plasteel/vault{
-	dir = 5
-	},
-/area/centcom/ferry)
-"xj" = (
-/obj/structure/table/reinforced,
-/obj/item/clipboard,
-/obj/item/folder/yellow,
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/centcom/ferry)
-"xk" = (
-/obj/structure/table/reinforced,
-/obj/item/storage/box/zipties,
-/obj/item/crowbar/red,
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/centcom/ferry)
-"xl" = (
-/obj/machinery/power/apc{
-	dir = 4;
-	name = "Briefing Area APC";
-	pixel_x = 26
-	},
-/turf/open/floor/plasteel/vault{
-	dir = 8
-	},
-/area/centcom/ferry)
-"xm" = (
-/obj/structure/sign/bluecross_2,
-/turf/closed/indestructible/riveted,
-/area/centcom/control)
-"xn" = (
-/obj/machinery/computer/operating,
-/turf/open/floor/plasteel/cmo,
-/area/centcom/control)
-"xo" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 10
-	},
-/turf/open/floor/plasteel,
-/area/centcom/evac)
-"xp" = (
-/obj/effect/turf_decal/stripes/line,
-/turf/open/floor/plasteel,
-/area/centcom/evac)
-"xq" = (
-/obj/structure/chair{
-	dir = 1
-	},
-/obj/effect/turf_decal/stripes/line,
-/turf/open/floor/plasteel,
-/area/centcom/evac)
-"xs" = (
-/obj/structure/table,
-/obj/item/toy/sword,
-/obj/item/gun/ballistic/shotgun/toy/crossbow,
-/obj/effect/turf_decal/stripes/line,
-/turf/open/floor/plasteel,
-/area/centcom/evac)
-"xt" = (
-/obj/item/twohanded/required/kirbyplants{
-	icon_state = "plant-21"
-	},
-/obj/effect/turf_decal/stripes/line,
-/turf/open/floor/plasteel,
-/area/centcom/evac)
-"xu" = (
 /obj/structure/chair/wood/wings{
 	icon_state = "wooden_chair_wings";
-	dir = 1
-	},
-/turf/open/floor/engine/cult,
-/area/wizard_station)
-"xv" = (
-/mob/living/simple_animal/bot/medbot/mysterious{
-	desc = "If you don't accidentally blow yourself up from time to time you're not really a wizard anyway.";
-	faction = list("neutral","silicon","creature");
-	name = "Nobody's Perfect"
-	},
-/turf/open/floor/engine/cult,
-/area/wizard_station)
-"xw" = (
-/obj/item/reagent_containers/food/snacks/meat/slab/xeno,
-/turf/open/floor/grass,
-/area/wizard_station)
-"xx" = (
-/obj/structure/table/wood,
-/obj/item/paper_bin,
-/obj/item/pen/fourcolor,
-/turf/open/floor/plasteel/vault{
 	dir = 8
 	},
-/area/centcom/ferry)
-"xy" = (
-/obj/machinery/computer/card/centcom,
-/turf/open/floor/plasteel/grimy,
-/area/centcom/ferry)
-"xz" = (
-/obj/structure/table/reinforced,
-/obj/item/book/manual/wiki/security_space_law,
-/obj/item/device/taperecorder,
-/turf/open/floor/plasteel/grimy,
-/area/centcom/ferry)
-"xA" = (
-/obj/structure/table/reinforced,
-/obj/item/storage/fancy/donut_box,
-/turf/open/floor/plasteel/vault{
-	dir = 8
-	},
-/area/centcom/ferry)
-"xB" = (
-/obj/structure/table/reinforced,
-/obj/item/crowbar/red,
-/obj/item/tank/internals/emergency_oxygen/engi,
-/obj/item/clothing/mask/gas,
-/turf/open/floor/plasteel/vault{
-	dir = 8
-	},
-/area/centcom/ferry)
-"xC" = (
-/obj/structure/table/reinforced,
-/obj/item/clipboard,
-/obj/item/folder/yellow,
-/obj/item/pen/blue,
-/turf/open/floor/plasteel/vault{
-	dir = 8
-	},
-/area/centcom/ferry)
-"xD" = (
-/obj/structure/table/reinforced,
-/obj/item/restraints/handcuffs/cable/zipties,
-/obj/item/device/assembly/flash/handheld,
-/turf/open/floor/plasteel/vault{
-	dir = 8
-	},
-/area/centcom/ferry)
-"xE" = (
-/obj/structure/table/reinforced,
-/obj/item/storage/lockbox/loyalty,
-/obj/effect/turf_decal/stripes/line{
-	dir = 10
-	},
-/turf/open/floor/plasteel,
-/area/centcom/ferry)
-"xF" = (
-/obj/structure/table/reinforced,
-/obj/item/storage/toolbox/mechanical,
-/obj/item/tank/internals/emergency_oxygen/engi,
-/obj/effect/turf_decal/stripes/line{
-	dir = 6
-	},
-/turf/open/floor/plasteel,
-/area/centcom/ferry)
-"xG" = (
-/obj/machinery/newscaster/security_unit{
-	pixel_x = 32
-	},
-/turf/open/floor/plasteel/vault{
-	dir = 8
-	},
-/area/centcom/ferry)
-"xH" = (
-/obj/machinery/door/poddoor/shutters{
-	id = "XCCsec3";
-	name = "CC Main Access Shutters"
-	},
-/obj/effect/turf_decal/delivery,
-/turf/open/floor/plasteel,
-/area/centcom/control)
-"xI" = (
-/obj/item/defibrillator/loaded,
-/obj/structure/table/reinforced,
-/turf/open/floor/plasteel/cmo,
-/area/centcom/control)
-"xJ" = (
-/obj/item/reagent_containers/glass/bottle/epinephrine{
-	pixel_x = 6
-	},
-/obj/item/reagent_containers/glass/bottle/charcoal{
-	pixel_x = -3
-	},
-/obj/item/reagent_containers/glass/bottle/epinephrine{
-	pixel_x = -3;
-	pixel_y = 8
-	},
-/obj/item/reagent_containers/glass/bottle/charcoal{
-	pixel_x = 6;
-	pixel_y = 8
-	},
-/obj/item/reagent_containers/syringe/epinephrine{
-	pixel_x = 3;
-	pixel_y = -2
-	},
-/obj/item/reagent_containers/syringe/epinephrine{
-	pixel_x = 4;
-	pixel_y = 1
-	},
-/obj/item/reagent_containers/syringe/epinephrine{
-	pixel_x = -2;
-	pixel_y = 5
-	},
-/obj/item/reagent_containers/syringe/epinephrine{
-	pixel_x = 2;
-	pixel_y = 8
-	},
-/obj/structure/table/reinforced,
-/turf/open/floor/plasteel/cmo,
-/area/centcom/control)
-"xK" = (
-/obj/machinery/sleeper{
-	dir = 4
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 9
-	},
-/turf/open/floor/plasteel,
-/area/centcom/control)
-"xL" = (
-/obj/machinery/light,
-/obj/structure/noticeboard{
-	dir = 1;
-	pixel_y = -32
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/centcom/control)
-"xM" = (
-/obj/machinery/sleeper{
-	dir = 8
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 5
-	},
-/turf/open/floor/plasteel,
-/area/centcom/control)
-"xN" = (
-/obj/item/storage/firstaid/fire,
-/obj/item/storage/firstaid/regular{
-	pixel_x = 2;
-	pixel_y = 3
-	},
-/obj/structure/table/reinforced,
-/turf/open/floor/plasteel/cmo,
-/area/centcom/control)
-"xO" = (
-/obj/item/storage/firstaid/toxin,
-/obj/item/storage/firstaid/o2{
-	pixel_x = 3;
-	pixel_y = 3
-	},
-/obj/structure/table/reinforced,
-/obj/machinery/airalarm{
-	dir = 8;
-	pixel_x = 24
-	},
-/turf/open/floor/plasteel/cmo,
-/area/centcom/control)
-"xP" = (
-/obj/structure/table/reinforced,
-/obj/machinery/door/firedoor,
-/obj/item/storage/fancy/donut_box,
-/obj/machinery/door/window/brigdoor{
-	base_state = "rightsecure";
-	dir = 1;
-	icon_state = "rightsecure";
-	name = "CentCom Customs";
-	req_access_txt = "109"
-	},
-/obj/effect/turf_decal/bot,
-/turf/open/floor/plasteel,
-/area/centcom/evac)
-"xQ" = (
-/obj/structure/table/reinforced,
-/obj/machinery/door/firedoor,
-/obj/item/folder/red,
-/obj/item/pen/red,
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/obj/effect/turf_decal/bot,
-/turf/open/floor/plasteel,
-/area/centcom/evac)
-"xR" = (
-/obj/structure/table/reinforced,
-/obj/machinery/door/firedoor,
-/obj/machinery/door/window/brigdoor{
-	base_state = "rightsecure";
-	dir = 1;
-	icon_state = "rightsecure";
-	name = "CentCom Customs";
-	req_access_txt = "109"
-	},
-/obj/effect/turf_decal/bot,
-/turf/open/floor/plasteel,
-/area/centcom/evac)
-"xS" = (
-/obj/machinery/door/airlock{
-	icon = 'icons/obj/doors/airlocks/station/uranium.dmi';
-	name = "Observation Deck"
-	},
-/turf/open/floor/engine/cult,
-/area/wizard_station)
-"xT" = (
-/obj/structure/table/wood,
-/obj/item/clipboard,
-/obj/item/device/radio/headset/headset_cent,
-/turf/open/floor/plasteel/vault{
-	dir = 8
-	},
-/area/centcom/ferry)
-"xU" = (
-/obj/structure/chair/office/dark{
-	dir = 1
-	},
-/obj/effect/landmark/ert_spawn,
-/turf/open/floor/plasteel/black,
-/area/centcom/ferry)
-"xV" = (
-/obj/structure/chair/office/dark{
-	dir = 1
-	},
-/obj/effect/landmark/ert_spawn,
-/turf/open/floor/plasteel/vault{
-	dir = 5
-	},
-/area/centcom/ferry)
-"xW" = (
-/obj/structure/flora/ausbushes/lavendergrass,
-/obj/structure/flora/ausbushes/sparsegrass,
-/obj/structure/flora/ausbushes/fullgrass,
-/obj/structure/flora/ausbushes/grassybush,
-/obj/structure/flora/ausbushes/ppflowers,
-/obj/structure/flora/ausbushes/pointybush,
-/turf/open/floor/grass,
-/area/centcom/evac)
-"xX" = (
-/obj/structure/flora/ausbushes/lavendergrass,
-/obj/structure/flora/ausbushes/sparsegrass,
-/obj/structure/flora/ausbushes/fullgrass,
-/obj/structure/flora/ausbushes/brflowers,
-/obj/structure/flora/ausbushes/genericbush,
-/turf/open/floor/grass,
-/area/centcom/evac)
-"xY" = (
-/obj/structure/table/reinforced,
-/obj/item/restraints/handcuffs/cable/zipties,
-/obj/item/device/assembly/flash/handheld,
-/turf/open/floor/plasteel/vault{
-	dir = 8
-	},
-/area/centcom/evac)
-"xZ" = (
-/turf/open/floor/plasteel/darkred/side{
-	dir = 1
-	},
-/area/centcom/evac)
-"ya" = (
-/obj/machinery/computer/secure_data,
-/obj/machinery/button/door{
-	id = "XCCcustoms1";
-	layer = 3;
-	name = "CC Emergency Docks Control";
-	pixel_x = 24;
-	pixel_y = 24
-	},
-/turf/open/floor/plasteel/vault{
-	dir = 8
-	},
-/area/centcom/evac)
-"yc" = (
-/obj/structure/statue/uranium/nuke,
-/turf/open/floor/plating/asteroid/snow/airless,
-/area/syndicate_mothership)
-"yd" = (
-/obj/structure/table/wood,
-/obj/item/folder/red,
-/obj/item/book/manual/wiki/security_space_law,
-/obj/item/restraints/handcuffs,
-/obj/item/device/assembly/flash/handheld,
-/turf/open/floor/plasteel/vault{
-	dir = 8
-	},
-/area/centcom/ferry)
-"ye" = (
-/obj/structure/table/wood,
-/obj/item/folder/red,
-/obj/item/lighter,
-/obj/machinery/newscaster{
-	pixel_y = -32
-	},
-/turf/open/floor/plasteel/vault{
-	dir = 8
-	},
-/area/centcom/ferry)
-"yf" = (
-/obj/structure/bookcase/random,
-/obj/machinery/light,
-/turf/open/floor/plasteel/vault{
-	dir = 8
-	},
-/area/centcom/ferry)
-"yg" = (
-/obj/structure/filingcabinet/medical,
-/turf/open/floor/plasteel/vault{
-	dir = 8
-	},
-/area/centcom/ferry)
-"yh" = (
-/obj/structure/filingcabinet/security,
-/turf/open/floor/plasteel/vault{
-	dir = 8
-	},
-/area/centcom/ferry)
-"yi" = (
-/obj/structure/closet/crate/bin,
-/turf/open/floor/plasteel/vault{
-	dir = 8
-	},
-/area/centcom/ferry)
-"yj" = (
-/obj/item/twohanded/required/kirbyplants{
-	icon_state = "plant-22"
-	},
-/obj/machinery/power/apc{
-	dir = 2;
-	name = "Briefing Room APC";
-	pixel_y = -26
-	},
-/turf/open/floor/plasteel/vault{
-	dir = 8
-	},
-/area/centcom/ferry)
-"yk" = (
-/obj/machinery/airalarm{
-	dir = 1;
-	pixel_y = -22
-	},
-/turf/open/floor/plasteel/vault{
-	dir = 8
-	},
-/area/centcom/ferry)
-"yl" = (
-/obj/item/twohanded/required/kirbyplants{
-	icon_state = "plant-22"
-	},
-/obj/machinery/light,
-/obj/structure/noticeboard{
-	dir = 1;
-	pixel_y = -32
-	},
-/turf/open/floor/plasteel/vault{
-	dir = 8
-	},
-/area/centcom/ferry)
-"ym" = (
-/obj/item/twohanded/required/kirbyplants{
-	icon_state = "plant-21"
-	},
-/obj/structure/extinguisher_cabinet{
-	pixel_y = -32
-	},
-/turf/open/floor/plasteel/vault{
-	dir = 8
-	},
-/area/centcom/ferry)
-"yn" = (
-/obj/item/device/radio{
-	pixel_x = 5;
-	pixel_y = 5
-	},
-/obj/item/device/radio{
-	pixel_x = -5;
-	pixel_y = 5
-	},
-/obj/item/device/radio,
-/obj/structure/table/wood,
-/turf/open/floor/plasteel/vault{
-	dir = 8
-	},
-/area/centcom/ferry)
-"yo" = (
-/obj/structure/closet/secure_closet/ertMed,
-/obj/structure/sign/directions/medical{
-	dir = 1;
-	pixel_y = -24
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/centcom/ferry)
-"yp" = (
-/obj/structure/closet/secure_closet/ertMed,
-/obj/machinery/vending/wallmed{
-	name = "Emergency NanoMed";
-	pixel_y = -32;
-	req_access_txt = "0";
-	use_power = 0
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 5
-	},
-/turf/open/floor/plasteel,
-/area/centcom/ferry)
-"yq" = (
-/obj/structure/table/reinforced,
-/obj/item/storage/box/emps,
-/obj/item/gun/energy/ionrifle,
-/obj/structure/sign/bluecross_2{
-	pixel_y = -32
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/centcom/ferry)
-"yr" = (
-/obj/structure/table/reinforced,
-/obj/item/storage/box/syringes,
-/obj/item/gun/syringe/rapidsyringe,
-/obj/structure/reagent_dispensers/peppertank{
-	pixel_y = -32
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/centcom/ferry)
-"ys" = (
-/obj/structure/closet/secure_closet/ertSec,
-/obj/effect/turf_decal/stripes/line{
-	dir = 9
-	},
-/turf/open/floor/plasteel,
-/area/centcom/ferry)
-"yt" = (
-/obj/structure/closet/secure_closet/ertSec,
-/obj/structure/sign/directions/security{
-	dir = 1;
-	pixel_y = -24
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/centcom/ferry)
-"yu" = (
-/obj/structure/table/reinforced,
-/obj/item/book/manual/wiki/security_space_law,
-/obj/item/device/taperecorder,
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = 24
-	},
-/turf/open/floor/plasteel/vault{
-	dir = 8
-	},
-/area/centcom/control)
-"yv" = (
-/obj/structure/table,
-/obj/item/paper_bin,
-/obj/item/pen,
-/obj/machinery/light{
-	dir = 1
-	},
-/turf/open/floor/plasteel/green/side{
-	dir = 9
-	},
-/area/centcom/control)
-"yw" = (
-/obj/structure/chair,
-/turf/open/floor/plasteel/green/corner{
-	dir = 1
-	},
-/area/centcom/control)
-"yx" = (
-/obj/structure/chair,
-/turf/open/floor/plasteel/green/corner{
-	dir = 4
-	},
-/area/centcom/control)
-"yy" = (
-/obj/structure/table,
-/obj/item/paper/pamphlet/centcom/visitor_info,
-/obj/item/paper/pamphlet/centcom/visitor_info,
-/obj/item/paper/pamphlet/centcom/visitor_info,
-/obj/machinery/light{
-	dir = 1
-	},
-/turf/open/floor/plasteel/green/side{
-	dir = 5
-	},
-/area/centcom/control)
-"yz" = (
-/obj/structure/filingcabinet/medical,
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = -24
-	},
-/turf/open/floor/plasteel/vault{
-	dir = 8
-	},
-/area/centcom/control)
-"yA" = (
-/obj/structure/table/reinforced,
-/obj/item/storage/firstaid/regular,
-/turf/open/floor/plasteel/vault{
-	dir = 8
-	},
-/area/centcom/control)
-"yB" = (
-/obj/structure/table/reinforced,
-/obj/machinery/recharger,
-/turf/open/floor/plasteel/vault{
-	dir = 8
-	},
-/area/centcom/evac)
-"yC" = (
-/turf/open/floor/plasteel/vault{
-	dir = 5
-	},
-/area/centcom/evac)
-"yD" = (
-/obj/machinery/computer/security,
-/obj/machinery/newscaster{
-	pixel_x = 32
-	},
-/turf/open/floor/plasteel/vault{
-	dir = 8
-	},
-/area/centcom/evac)
-"yE" = (
-/obj/structure/closet/secure_closet/security,
-/obj/item/storage/belt/security/full,
-/obj/item/gun/ballistic/automatic/wt550,
-/obj/item/clothing/head/helmet/swat/nanotrasen,
-/obj/item/crowbar/red,
-/obj/machinery/light{
-	dir = 8
-	},
-/turf/open/floor/plasteel/vault{
-	dir = 8
-	},
-/area/centcom/control)
-"yF" = (
-/obj/structure/chair{
-	dir = 4
-	},
-/turf/open/floor/plasteel/red/corner{
-	dir = 1
-	},
-/area/centcom/control)
-"yG" = (
-/obj/structure/chair{
-	dir = 8
-	},
-/turf/open/floor/plasteel/blue/corner{
-	dir = 4
-	},
-/area/centcom/control)
-"yH" = (
-/obj/structure/table/reinforced,
-/obj/item/reagent_containers/glass/bottle/charcoal{
-	pixel_x = 6
-	},
-/obj/item/reagent_containers/glass/bottle/epinephrine{
-	pixel_x = -4
-	},
-/obj/item/reagent_containers/hypospray/medipen,
-/turf/open/floor/plasteel/vault{
-	dir = 8
-	},
-/area/centcom/control)
-"yI" = (
-/obj/structure/table/reinforced,
-/obj/item/paper_bin,
-/obj/item/pen,
-/obj/machinery/light{
-	dir = 4
-	},
-/turf/open/floor/plasteel/vault{
-	dir = 8
-	},
-/area/centcom/control)
-"yJ" = (
-/obj/structure/closet/secure_closet/security,
-/obj/item/storage/belt/security/full,
-/obj/item/gun/ballistic/automatic/wt550,
-/obj/item/clothing/head/helmet/swat/nanotrasen,
-/obj/item/crowbar/red,
-/turf/open/floor/plasteel/vault{
-	dir = 8
-	},
-/area/centcom/evac)
-"yK" = (
-/obj/structure/table/reinforced,
-/obj/item/crowbar/red,
-/turf/open/floor/plasteel/vault{
-	dir = 8
-	},
-/area/centcom/evac)
-"yL" = (
-/obj/item/twohanded/required/kirbyplants{
-	icon_state = "plant-21"
-	},
-/obj/structure/extinguisher_cabinet{
-	pixel_x = -24
-	},
-/turf/open/floor/plasteel/vault{
-	dir = 8
-	},
-/area/centcom/evac)
-"yM" = (
-/obj/item/clipboard,
-/obj/item/folder/red,
-/obj/item/stamp/denied{
-	pixel_x = 3;
-	pixel_y = 3
-	},
-/obj/item/stamp,
-/obj/structure/table/reinforced,
-/turf/open/floor/plasteel/vault{
-	dir = 8
-	},
-/area/centcom/evac)
-"yN" = (
-/obj/machinery/door/airlock/external,
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/centcom/control)
-"yO" = (
-/turf/open/floor/plasteel/darkred/side{
-	dir = 4
-	},
-/area/centcom/control)
-"yP" = (
-/obj/structure/table/reinforced,
-/obj/machinery/door/firedoor,
-/obj/item/storage/fancy/donut_box,
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/effect/turf_decal/bot,
-/turf/open/floor/plasteel,
-/area/centcom/control)
-"yQ" = (
-/obj/structure/table/reinforced,
-/obj/machinery/door/firedoor,
-/obj/item/reagent_containers/food/drinks/britcup,
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/effect/turf_decal/bot,
-/turf/open/floor/plasteel,
-/area/centcom/control)
-"yR" = (
-/turf/open/floor/plasteel/darkblue/side{
-	dir = 8
-	},
-/area/centcom/control)
-"yS" = (
-/turf/open/floor/plasteel/vault{
-	dir = 8
-	},
-/area/centcom/evac)
-"yT" = (
-/turf/open/floor/plasteel/vault{
-	dir = 9
-	},
-/area/centcom/evac)
-"yU" = (
-/obj/structure/table/reinforced,
-/obj/item/paper_bin,
-/obj/item/pen,
-/obj/machinery/light,
-/turf/open/floor/plasteel/vault{
-	dir = 8
-	},
-/area/centcom/evac)
-"yV" = (
-/obj/structure/table/reinforced,
-/obj/item/book/manual/wiki/security_space_law,
-/obj/item/device/taperecorder,
-/turf/open/floor/plasteel/vault{
-	dir = 8
-	},
-/area/centcom/evac)
-"yW" = (
-/obj/item/storage/box/ids{
-	pixel_x = 3;
-	pixel_y = 3
-	},
-/obj/item/storage/box/silver_ids,
-/obj/structure/table/reinforced,
-/obj/structure/reagent_dispensers/peppertank{
-	pixel_x = 32
-	},
-/turf/open/floor/plasteel/vault{
-	dir = 8
-	},
-/area/centcom/evac)
-"yX" = (
-/obj/machinery/door/airlock{
-	icon = 'icons/obj/doors/airlocks/station/uranium.dmi';
-	name = "Storage"
-	},
-/turf/open/floor/engine/cult,
-/area/wizard_station)
-"yY" = (
-/obj/machinery/door/airlock{
-	icon = 'icons/obj/doors/airlocks/station/uranium.dmi';
-	name = "Personal Quarters"
-	},
-/turf/open/floor/engine/cult,
-/area/wizard_station)
-"yZ" = (
-/obj/machinery/door/airlock{
-	icon = 'icons/obj/doors/airlocks/station/uranium.dmi';
-	name = "Bathroom"
-	},
-/turf/open/floor/engine/cult,
-/area/wizard_station)
-"za" = (
-/obj/item/clipboard,
-/obj/item/folder/red,
-/obj/item/stamp/denied{
-	pixel_x = 3;
-	pixel_y = 3
-	},
-/obj/item/stamp,
-/obj/structure/table/reinforced,
-/obj/machinery/light{
-	dir = 8
-	},
-/turf/open/floor/plasteel/vault{
-	dir = 8
-	},
-/area/centcom/control)
-"zb" = (
-/obj/structure/chair/office/dark{
-	dir = 4
-	},
-/turf/open/floor/plasteel/darkred/side{
-	dir = 4
-	},
-/area/centcom/control)
-"zc" = (
-/obj/structure/table/reinforced,
-/obj/machinery/door/firedoor,
-/obj/item/folder/red,
-/obj/item/pen/red,
-/obj/machinery/door/window/brigdoor{
-	name = "CentCom Customs";
-	icon_state = "rightsecure";
-	dir = 4;
-	req_access_txt = "109";
-	base_state = "rightsecure"
-	},
-/obj/effect/turf_decal/bot,
-/turf/open/floor/plasteel,
-/area/centcom/control)
-"zd" = (
-/obj/structure/table/reinforced,
-/obj/machinery/door/firedoor,
-/obj/item/folder/white,
-/obj/item/pen/blue,
-/obj/machinery/door/window/brigdoor{
-	name = "CentCom Customs";
-	icon_state = "rightsecure";
-	dir = 8;
-	req_access_txt = "109";
-	base_state = "rightsecure"
-	},
-/obj/effect/turf_decal/bot,
-/turf/open/floor/plasteel,
-/area/centcom/control)
-"ze" = (
-/obj/structure/chair/office/dark{
-	dir = 8
-	},
-/turf/open/floor/plasteel/darkblue/side{
-	dir = 8
-	},
-/area/centcom/control)
-"zf" = (
-/obj/machinery/light{
-	dir = 4
-	},
-/turf/open/floor/plasteel/vault{
-	dir = 8
-	},
-/area/centcom/control)
-"zg" = (
-/obj/item/clothing/suit/wizrobe/black,
-/obj/item/clothing/head/wizard/black,
-/obj/effect/turf_decal/bot,
-/turf/open/floor/plasteel,
-/area/wizard_station)
-"zh" = (
-/obj/effect/turf_decal/bot,
-/turf/open/floor/plasteel,
-/area/wizard_station)
-"zi" = (
-/obj/item/cardboard_cutout,
-/obj/effect/turf_decal/bot,
-/turf/open/floor/plasteel,
-/area/wizard_station)
-"zj" = (
-/obj/structure/table/wood,
-/obj/item/dice/d20,
-/obj/item/dice,
 /turf/open/floor/carpet,
 /area/wizard_station)
-"zk" = (
-/obj/structure/punching_bag,
-/turf/open/floor/carpet,
-/area/wizard_station)
-"zl" = (
-/obj/structure/urinal{
-	pixel_y = 28
-	},
-/turf/open/floor/plasteel/white,
-/area/wizard_station)
-"zm" = (
-/turf/open/floor/plasteel/white,
-/area/wizard_station)
-"zn" = (
-/obj/structure/mirror/magic{
-	pixel_y = 28
-	},
-/obj/structure/sink{
-	pixel_y = 20
-	},
-/turf/open/floor/plasteel/white,
-/area/wizard_station)
-"zo" = (
-/obj/structure/table/reinforced,
-/obj/machinery/button/door{
-	id = "XCCsec3";
-	name = "CC Main Access Control"
-	},
-/obj/machinery/airalarm{
-	dir = 1;
-	pixel_y = -22
-	},
-/turf/open/floor/plasteel/vault{
-	dir = 8
-	},
-/area/centcom/control)
-"zp" = (
-/obj/machinery/computer/security,
-/obj/machinery/newscaster{
-	pixel_y = -32
-	},
-/turf/open/floor/plasteel/vault{
-	dir = 8
-	},
-/area/centcom/control)
-"zq" = (
-/obj/item/twohanded/required/kirbyplants{
-	icon_state = "plant-21"
-	},
-/turf/open/floor/plasteel/green/corner{
-	dir = 8
-	},
-/area/centcom/control)
-"zr" = (
-/obj/item/twohanded/required/kirbyplants{
-	icon_state = "plant-22"
-	},
-/turf/open/floor/plasteel/green/corner,
-/area/centcom/control)
-"zs" = (
-/obj/machinery/newscaster{
-	pixel_y = -32
-	},
-/obj/machinery/computer/med_data,
-/turf/open/floor/plasteel/vault{
-	dir = 8
-	},
-/area/centcom/control)
-"zt" = (
-/obj/structure/table/reinforced,
-/obj/item/clipboard,
-/obj/item/folder/white,
-/obj/item/pen/blue,
-/obj/machinery/airalarm{
-	dir = 1;
-	pixel_y = -22
-	},
-/turf/open/floor/plasteel/vault{
-	dir = 8
-	},
-/area/centcom/control)
-"zu" = (
-/obj/item/cautery/alien,
-/obj/effect/turf_decal/bot,
-/turf/open/floor/plasteel,
-/area/wizard_station)
-"zv" = (
-/obj/item/coin/antagtoken,
-/obj/effect/turf_decal/bot,
-/turf/open/floor/plasteel,
-/area/wizard_station)
-"zw" = (
-/obj/structure/bed,
-/obj/item/bedsheet/wiz,
-/turf/open/floor/carpet,
-/area/wizard_station)
-"zx" = (
-/obj/item/soap/homemade,
-/obj/machinery/light/small{
-	brightness = 3;
-	dir = 8
-	},
-/turf/open/floor/plasteel/white,
-/area/wizard_station)
-"zy" = (
-/obj/machinery/door/airlock/centcom{
-	name = "Thunderdome Booth";
-	opacity = 1;
-	req_access_txt = "0"
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 2
-	},
-/turf/open/floor/plasteel,
-/area/centcom/control)
-"zz" = (
-/obj/structure/closet/cardboard,
-/obj/item/banhammer,
-/obj/effect/turf_decal/stripes/line,
-/turf/open/floor/plasteel,
-/area/wizard_station)
-"zA" = (
-/obj/effect/turf_decal/stripes/line,
-/turf/open/floor/plasteel,
-/area/wizard_station)
-"zB" = (
-/obj/vehicle/scooter/skateboard{
-	icon_state = "skateboard";
-	dir = 4
-	},
-/obj/effect/turf_decal/stripes/line,
-/obj/machinery/light/small,
-/turf/open/floor/plasteel,
-/area/wizard_station)
-"zC" = (
-/obj/structure/dresser,
-/obj/item/storage/backpack/satchel,
-/turf/open/floor/carpet,
-/area/wizard_station)
-"zD" = (
-/obj/structure/table/wood,
-/obj/item/storage/bag/tray,
-/obj/item/reagent_containers/food/snacks/burger/spell,
-/turf/open/floor/carpet,
-/area/wizard_station)
-"zE" = (
-/obj/structure/bookcase/random/adult,
-/turf/open/floor/plasteel/white,
-/area/wizard_station)
-"zF" = (
-/obj/structure/toilet{
-	dir = 1
-	},
-/turf/open/floor/plasteel/white,
-/area/wizard_station)
-"zG" = (
-/obj/structure/table/wood/fancy,
-/obj/item/skub{
-	pixel_y = 16
-	},
-/turf/open/floor/plasteel/white,
-/area/wizard_station)
-"zH" = (
-/turf/closed/indestructible/riveted,
-/area/tdome/tdomeobserve)
-"zI" = (
-/obj/machinery/door/airlock/external,
-/obj/effect/turf_decal/stripes/line{
-	dir = 2
-	},
-/turf/open/floor/plasteel,
-/area/tdome/tdomeobserve)
-"zJ" = (
-/obj/machinery/vending/cola,
-/obj/effect/turf_decal/delivery,
-/turf/open/floor/plasteel,
-/area/tdome/tdomeobserve)
-"zK" = (
-/obj/machinery/vending/snack,
-/obj/effect/turf_decal/delivery,
-/turf/open/floor/plasteel,
-/area/tdome/tdomeobserve)
-"zL" = (
-/obj/item/clipboard,
-/obj/item/stamp/denied{
-	pixel_x = 3;
-	pixel_y = 3
-	},
-/obj/item/stamp,
-/obj/structure/table/reinforced,
-/turf/open/floor/plasteel/vault{
-	dir = 8
-	},
-/area/tdome/tdomeobserve)
-"zM" = (
-/obj/structure/table/reinforced,
-/obj/item/paper_bin,
-/obj/item/pen/red,
-/turf/open/floor/plasteel/vault{
-	dir = 8
-	},
-/area/tdome/tdomeobserve)
-"zN" = (
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating,
-/area/tdome/tdomeobserve)
-"zO" = (
-/obj/structure/table,
-/obj/item/paper_bin,
-/obj/item/pen,
-/turf/open/floor/plasteel/green/side{
-	dir = 9
-	},
-/area/tdome/tdomeobserve)
-"zP" = (
-/obj/structure/chair,
-/turf/open/floor/plasteel/green/corner{
-	dir = 1
-	},
-/area/tdome/tdomeobserve)
-"zQ" = (
-/obj/effect/turf_decal/bot,
-/turf/open/floor/plasteel,
-/area/tdome/tdomeobserve)
-"zR" = (
-/obj/structure/chair,
-/turf/open/floor/plasteel/green/corner{
-	dir = 4
-	},
-/area/tdome/tdomeobserve)
-"zS" = (
-/obj/structure/closet/crate/bin,
-/turf/open/floor/plasteel/green/side{
-	dir = 5
-	},
-/area/tdome/tdomeobserve)
-"zT" = (
-/obj/machinery/door/airlock/centcom{
-	name = "CentCom Security";
-	opacity = 1;
-	req_access_txt = "101"
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 2
-	},
-/turf/open/floor/plasteel,
-/area/tdome/tdomeobserve)
-"zU" = (
-/obj/machinery/door/airlock{
-	icon = 'icons/obj/doors/airlocks/station/uranium.dmi';
-	name = "Engine Room"
-	},
-/obj/structure/barricade/wooden,
-/turf/open/floor/engine/cult,
-/area/wizard_station)
-"zV" = (
-/turf/closed/indestructible/riveted,
-/area/centcom/holding)
-"zW" = (
-/obj/structure/closet/crate/bin,
-/turf/open/floor/plasteel/vault{
-	dir = 8
-	},
-/area/tdome/tdomeobserve)
-"zX" = (
-/obj/structure/fans/tiny,
-/turf/open/floor/plasteel/vault{
-	dir = 8
-	},
-/area/tdome/tdomeobserve)
-"zY" = (
-/obj/structure/flora/ausbushes/sparsegrass,
-/obj/structure/flora/ausbushes/lavendergrass,
-/obj/structure/flora/ausbushes/fernybush,
-/turf/open/floor/plasteel{
-	name = "plating";
-	icon_state = "asteroid5"
-	},
-/area/tdome/tdomeobserve)
-"zZ" = (
-/obj/structure/flora/ausbushes/sparsegrass,
-/obj/structure/flora/ausbushes/grassybush,
-/obj/structure/flora/ausbushes/fernybush,
-/turf/open/floor/plasteel{
-	dir = 6;
-	icon_state = "asteroid8";
-	name = "sand"
-	},
-/area/tdome/tdomeobserve)
-"Aa" = (
-/turf/open/floor/plasteel/red/corner,
-/area/tdome/tdomeobserve)
-"Ab" = (
-/turf/open/floor/plasteel/neutral/corner{
-	dir = 8;
-	heat_capacity = 1e+006
-	},
-/area/tdome/tdomeobserve)
-"Ac" = (
-/obj/machinery/status_display,
-/turf/closed/indestructible/riveted,
-/area/tdome/tdomeobserve)
-"Ad" = (
-/obj/machinery/light{
-	dir = 8
-	},
-/turf/open/floor/plasteel/red/side{
-	dir = 8
-	},
-/area/tdome/tdomeobserve)
-"Ae" = (
-/obj/structure/chair/office/light{
-	dir = 4
-	},
-/turf/open/floor/plasteel/neutral,
-/area/tdome/tdomeobserve)
-"Af" = (
-/obj/structure/table/reinforced,
-/obj/machinery/door/firedoor,
-/obj/item/paper/pamphlet/centcom/visitor_info,
-/obj/effect/turf_decal/bot,
-/turf/open/floor/plasteel,
-/area/tdome/tdomeobserve)
-"Ag" = (
-/turf/open/floor/plasteel/neutral,
-/area/tdome/tdomeobserve)
-"Ah" = (
-/obj/structure/chair/office/light{
-	dir = 8
-	},
-/turf/open/floor/plasteel/neutral,
-/area/tdome/tdomeobserve)
-"Ai" = (
-/obj/machinery/light{
-	dir = 4
-	},
-/turf/open/floor/plasteel/green/side{
-	dir = 4
-	},
-/area/tdome/tdomeobserve)
-"Aj" = (
-/turf/open/floor/plasteel/neutral/corner,
-/area/tdome/tdomeobserve)
-"Ak" = (
-/turf/open/floor/plasteel/green/corner{
-	dir = 8
-	},
-/area/tdome/tdomeobserve)
-"Al" = (
-/obj/structure/flora/ausbushes/lavendergrass,
-/obj/structure/flora/ausbushes/sparsegrass,
-/obj/structure/flora/ausbushes/ywflowers,
-/obj/structure/flora/ausbushes/grassybush,
-/obj/structure/flora/ausbushes/palebush,
-/turf/open/floor/plating/asteroid,
-/area/tdome/tdomeobserve)
-"Am" = (
-/obj/structure/flora/ausbushes/lavendergrass,
-/obj/structure/flora/ausbushes/fullgrass,
-/obj/structure/flora/ausbushes/ywflowers,
-/obj/structure/flora/ausbushes/grassybush,
-/obj/structure/flora/ausbushes/palebush,
-/turf/open/floor/plating/asteroid,
-/area/tdome/tdomeobserve)
-"An" = (
-/obj/structure/table/wood,
-/turf/open/floor/engine/cult,
-/area/wizard_station)
-"Ao" = (
-/obj/structure/table/wood,
-/obj/item/gun/magic/wand{
-	desc = "Used in emergencies to reignite magma engines.";
-	max_charges = 0;
-	name = "wand of emergency engine ignition"
-	},
-/turf/open/floor/engine/cult,
-/area/wizard_station)
-"Ap" = (
-/obj/structure/table/wood,
-/obj/item/bikehorn/golden{
-	pixel_x = -8;
-	pixel_y = 8
-	},
-/turf/open/floor/engine/cult,
-/area/wizard_station)
-"Aq" = (
-/obj/structure/table,
-/turf/open/floor/plasteel/freezer{
-	dir = 2
-	},
-/area/centcom/holding)
-"Ar" = (
-/turf/open/floor/plasteel/freezer{
-	dir = 2
-	},
-/area/centcom/holding)
-"As" = (
-/obj/structure/closet/secure_closet/bar{
-	req_access_txt = "25"
-	},
-/obj/machinery/light{
-	dir = 1
-	},
-/turf/open/floor/plasteel/freezer{
-	dir = 2
-	},
-/area/centcom/holding)
-"At" = (
-/obj/structure/reagent_dispensers/beerkeg,
-/turf/open/floor/plasteel/freezer{
-	dir = 2
-	},
-/area/centcom/holding)
-"Au" = (
-/obj/structure/table,
-/obj/item/storage/box/donkpockets{
-	pixel_x = 3;
-	pixel_y = 3
-	},
-/obj/item/storage/box/donkpockets{
-	pixel_x = 3;
-	pixel_y = 3
-	},
-/obj/item/storage/box/donkpockets{
-	pixel_x = 3;
-	pixel_y = 3
-	},
-/obj/item/storage/box/donkpockets{
-	pixel_x = 3;
-	pixel_y = 3
-	},
-/turf/open/floor/plasteel/freezer{
-	dir = 2
-	},
-/area/centcom/holding)
-"Av" = (
-/obj/structure/rack,
-/obj/item/device/camera,
-/turf/open/floor/plasteel/cafeteria,
-/area/centcom/holding)
-"Aw" = (
-/obj/structure/rack,
-/obj/item/toy/sword,
-/obj/machinery/light{
-	dir = 1
-	},
-/turf/open/floor/plasteel/cafeteria,
-/area/centcom/holding)
-"Ax" = (
-/obj/structure/rack,
-/obj/item/toy/gun,
-/turf/open/floor/plasteel/cafeteria,
-/area/centcom/holding)
-"Ay" = (
-/turf/open/floor/plasteel/cafeteria,
-/area/centcom/holding)
-"Az" = (
-/turf/open/floor/plating/beach/sand,
-/area/centcom/holding)
-"AA" = (
-/obj/effect/overlay/palmtree_r,
-/obj/effect/overlay/coconut,
-/turf/open/floor/plating/beach/sand,
-/area/centcom/holding)
-"AB" = (
-/obj/effect/overlay/palmtree_l,
-/turf/open/floor/plating/beach/sand,
-/area/centcom/holding)
-"AC" = (
-/obj/machinery/shower{
-	dir = 4
-	},
-/turf/open/floor/plasteel/whitered/side{
-	dir = 9
-	},
-/area/tdome/tdomeobserve)
-"AD" = (
-/obj/machinery/light{
-	dir = 1
-	},
-/turf/open/floor/plasteel/whitered/side{
-	dir = 1
-	},
-/area/tdome/tdomeobserve)
-"AE" = (
-/obj/machinery/shower{
-	dir = 8
-	},
-/turf/open/floor/plasteel/whitered/side{
-	dir = 5
-	},
-/area/tdome/tdomeobserve)
-"AF" = (
-/turf/open/floor/plasteel/neutral/side{
-	dir = 4
-	},
-/area/tdome/tdomeobserve)
-"AG" = (
-/turf/open/floor/plasteel/red/side{
-	dir = 8
-	},
-/area/tdome/tdomeobserve)
-"AH" = (
-/obj/machinery/door/window/brigdoor{
-	base_state = "rightsecure";
-	dir = 2;
-	icon_state = "rightsecure";
-	name = "Thunderdome Booth";
-	req_access_txt = "109"
-	},
-/obj/effect/turf_decal/bot,
-/turf/open/floor/plasteel,
-/area/tdome/tdomeobserve)
-"AI" = (
-/obj/item/twohanded/required/kirbyplants{
-	icon_state = "plant-22"
-	},
-/turf/open/floor/plasteel/green/corner{
-	dir = 8
-	},
-/area/tdome/tdomeobserve)
-"AJ" = (
-/turf/open/floor/plasteel/goonplaque{
-	desc = "This is a plaque commemorating the thunderdome and all those who have died at its pearly blast doors."
-	},
-/area/tdome/tdomeobserve)
-"AK" = (
-/obj/item/twohanded/required/kirbyplants{
-	icon_state = "plant-21"
-	},
-/turf/open/floor/plasteel/green/corner,
-/area/tdome/tdomeobserve)
-"AL" = (
-/turf/open/floor/plasteel/green/side{
-	dir = 4
-	},
-/area/tdome/tdomeobserve)
-"AM" = (
-/turf/open/floor/plasteel/neutral/side{
-	dir = 8
-	},
-/area/tdome/tdomeobserve)
-"AN" = (
-/obj/machinery/shower{
-	dir = 4
-	},
-/turf/open/floor/plasteel/whitegreen/side{
-	dir = 9
-	},
-/area/tdome/tdomeobserve)
-"AO" = (
-/obj/machinery/light{
-	dir = 1
-	},
-/turf/open/floor/plasteel/whitegreen/side{
-	dir = 1
-	},
-/area/tdome/tdomeobserve)
-"AP" = (
-/obj/machinery/shower{
-	dir = 8
-	},
-/turf/open/floor/plasteel/whitegreen/side{
-	dir = 5
-	},
-/area/tdome/tdomeobserve)
-"AQ" = (
-/obj/structure/table,
-/obj/item/clothing/head/that,
-/turf/open/floor/plasteel/freezer{
-	dir = 2
-	},
-/area/centcom/holding)
-"AR" = (
-/obj/structure/chair/stool{
-	pixel_y = 8
-	},
-/turf/open/floor/plasteel/cafeteria,
-/area/centcom/holding)
-"AS" = (
-/obj/item/device/camera,
-/turf/open/floor/plating/beach/sand,
-/area/centcom/holding)
-"AT" = (
-/obj/machinery/shower{
-	dir = 4
-	},
-/turf/open/floor/plasteel/whitered/corner{
-	dir = 1
-	},
-/area/tdome/tdomeobserve)
-"AU" = (
-/obj/item/soap/nanotrasen,
-/turf/open/floor/plasteel/white,
-/area/tdome/tdomeobserve)
-"AV" = (
-/obj/machinery/shower{
-	dir = 8
-	},
-/turf/open/floor/plasteel/whitered/corner{
-	dir = 4
-	},
-/area/tdome/tdomeobserve)
-"AW" = (
-/obj/item/twohanded/required/kirbyplants{
-	icon_state = "plant-21"
-	},
-/turf/open/floor/plasteel/red/corner,
-/area/tdome/tdomeobserve)
-"AX" = (
-/turf/open/floor/plasteel/neutral/side,
-/area/tdome/tdomeobserve)
-"AY" = (
-/turf/open/floor/plasteel/red/side,
-/area/tdome/tdomeobserve)
-"AZ" = (
-/turf/open/floor/plasteel/red/side{
-	dir = 6
-	},
-/area/tdome/tdomeobserve)
-"Ba" = (
-/obj/machinery/door/airlock/centcom{
-	name = "Thunderdome Backstage";
-	opacity = 1;
-	req_access_txt = "0"
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/tdome/tdomeobserve)
-"Bb" = (
-/turf/open/floor/plasteel/neutral/side{
-	dir = 1;
-	heat_capacity = 1e+006
-	},
-/area/tdome/tdomeobserve)
-"Bc" = (
-/turf/open/floor/plasteel/neutral/corner{
-	dir = 1
-	},
-/area/tdome/tdomeobserve)
-"Bd" = (
-/turf/open/floor/plasteel/neutral/corner{
-	dir = 4
-	},
-/area/tdome/tdomeobserve)
-"Be" = (
-/turf/open/floor/plasteel/green/side{
-	dir = 10
-	},
-/area/tdome/tdomeobserve)
-"Bf" = (
-/turf/open/floor/plasteel/green/side,
-/area/tdome/tdomeobserve)
-"Bg" = (
-/obj/item/twohanded/required/kirbyplants{
-	icon_state = "plant-21"
-	},
-/turf/open/floor/plasteel/green/corner{
-	dir = 8
-	},
-/area/tdome/tdomeobserve)
-"Bh" = (
-/obj/machinery/shower{
-	dir = 4
-	},
-/turf/open/floor/plasteel/whitegreen/corner{
-	dir = 1
-	},
-/area/tdome/tdomeobserve)
-"Bi" = (
-/obj/machinery/shower{
-	dir = 8
-	},
-/turf/open/floor/plasteel/whitegreen/corner{
-	dir = 4
-	},
-/area/tdome/tdomeobserve)
-"Bj" = (
-/obj/structure/destructible/cult/forge{
-	desc = "An engine used in powering the wizard's ship";
-	name = "magma engine"
-	},
-/turf/open/floor/engine/cult,
-/area/wizard_station)
-"Bk" = (
-/obj/structure/table,
-/obj/item/ammo_box/foambox,
-/turf/open/floor/plasteel/freezer{
-	dir = 2
-	},
-/area/centcom/holding)
-"Bl" = (
-/obj/structure/table,
-/obj/item/reagent_containers/food/drinks/shaker,
-/turf/open/floor/plasteel/freezer{
-	dir = 2
-	},
-/area/centcom/holding)
-"Bm" = (
-/obj/structure/table,
-/obj/item/lighter,
-/turf/open/floor/plasteel/freezer{
-	dir = 2
-	},
-/area/centcom/holding)
-"Bn" = (
-/obj/structure/table,
-/obj/item/reagent_containers/food/drinks/soda_cans/cola,
-/turf/open/floor/plasteel/freezer{
-	dir = 2
-	},
-/area/centcom/holding)
-"Bo" = (
-/obj/structure/table,
-/obj/item/dice/d20,
-/turf/open/floor/plasteel/freezer{
-	dir = 2
-	},
-/area/centcom/holding)
-"Bp" = (
-/obj/structure/chair/stool{
-	pixel_y = 8
-	},
-/obj/item/clothing/head/bandana{
-	pixel_y = -10
-	},
-/obj/item/clothing/glasses/sunglasses,
-/turf/open/floor/plating/beach/sand,
-/area/centcom/holding)
-"Bq" = (
-/obj/structure/chair/stool{
-	pixel_y = 8
-	},
-/turf/open/floor/plating/beach/sand,
-/area/centcom/holding)
-"Br" = (
-/obj/machinery/shower{
-	dir = 4
-	},
-/turf/open/floor/plasteel/white,
-/area/tdome/tdomeobserve)
-"Bs" = (
-/turf/open/floor/plasteel/white,
-/area/tdome/tdomeobserve)
-"Bt" = (
-/obj/machinery/shower{
-	dir = 8
-	},
-/turf/open/floor/plasteel/white,
-/area/tdome/tdomeobserve)
-"Bu" = (
-/turf/open/floor/plasteel/red/side{
-	dir = 1
-	},
-/area/tdome/tdomeobserve)
-"Bv" = (
-/obj/item/twohanded/required/kirbyplants{
-	icon_state = "plant-22"
-	},
-/turf/open/floor/plasteel/neutral/side{
-	dir = 1;
-	heat_capacity = 1e+006
-	},
-/area/tdome/tdomeobserve)
-"Bw" = (
-/obj/item/twohanded/required/kirbyplants{
-	icon_state = "plant-21"
-	},
-/turf/open/floor/plasteel/red/corner{
-	dir = 1
-	},
-/area/tdome/tdomeobserve)
-"Bx" = (
-/obj/item/twohanded/required/kirbyplants{
-	icon_state = "plant-21"
-	},
-/turf/open/floor/plasteel/red/side{
-	dir = 10
-	},
-/area/tdome/tdomeobserve)
-"By" = (
-/obj/item/twohanded/required/kirbyplants{
-	icon_state = "plant-22"
-	},
-/turf/open/floor/plasteel/red/side,
-/area/tdome/tdomeobserve)
-"Bz" = (
-/obj/machinery/light,
-/turf/open/floor/plasteel/redyellow/side,
-/area/tdome/tdomeobserve)
-"BA" = (
-/turf/open/floor/plasteel/redyellow/side,
-/area/tdome/tdomeobserve)
-"BB" = (
-/turf/open/floor/plasteel/loadingarea,
-/area/tdome/tdomeobserve)
-"BC" = (
-/obj/item/twohanded/required/kirbyplants{
-	icon_state = "plant-22"
-	},
-/turf/open/floor/plasteel/green/side,
-/area/tdome/tdomeobserve)
-"BD" = (
-/obj/item/twohanded/required/kirbyplants{
-	icon_state = "plant-21"
-	},
-/turf/open/floor/plasteel/green/side{
-	dir = 6
-	},
-/area/tdome/tdomeobserve)
-"BE" = (
-/obj/item/twohanded/required/kirbyplants{
-	icon_state = "plant-21"
-	},
-/turf/open/floor/plasteel/green/corner{
-	dir = 4
-	},
-/area/tdome/tdomeobserve)
-"BF" = (
-/turf/open/floor/plasteel/green/side{
-	dir = 1
-	},
-/area/tdome/tdomeobserve)
-"BG" = (
-/obj/structure/window/reinforced{
-	resistance_flags = 3;
-	color = "#008000";
-	dir = 1
-	},
-/turf/open/lava,
-/area/wizard_station)
-"BH" = (
-/obj/structure/rack,
-/obj/item/clothing/head/that,
-/obj/item/clothing/under/suit_jacket,
-/obj/item/clothing/accessory/waistcoat,
-/turf/open/floor/plasteel/cafeteria,
-/area/centcom/holding)
-"BI" = (
-/obj/item/toy/beach_ball,
-/turf/open/floor/plating/beach/sand,
-/area/centcom/holding)
-"BJ" = (
-/obj/machinery/door/airlock/silver{
-	name = "Shower"
-	},
-/turf/open/floor/plasteel/white,
-/area/tdome/tdomeobserve)
-"BK" = (
-/obj/machinery/door/firedoor,
-/obj/effect/turf_decal/stripes/line{
-	dir = 2
-	},
-/turf/open/floor/plasteel,
-/area/tdome/tdomeobserve)
-"BL" = (
-/obj/structure/sign/nosmoking_2,
-/turf/closed/indestructible/riveted,
-/area/tdome/tdomeobserve)
-"BM" = (
-/obj/machinery/door/airlock/centcom{
-	name = "Thunderdome";
-	opacity = 1;
-	req_access_txt = "101"
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 2
-	},
-/turf/open/floor/plasteel,
-/area/tdome/tdomeobserve)
-"BN" = (
-/obj/structure/sign/nanotrasen,
-/turf/closed/indestructible/riveted,
-/area/tdome/tdomeobserve)
-"BO" = (
-/obj/structure/shuttle/engine/heater{
-	resistance_flags = 3
-	},
-/obj/structure/window/reinforced{
-	resistance_flags = 3;
-	color = "#008000";
-	dir = 1
-	},
-/turf/open/lava/airless,
-/area/wizard_station)
-"BP" = (
-/obj/structure/rack,
-/obj/item/storage/crayons,
-/obj/item/gun/ballistic/automatic/toy/pistol,
-/turf/open/floor/plasteel/cafeteria,
-/area/centcom/holding)
-"BQ" = (
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/turf/open/floor/plasteel/cafeteria,
-/area/centcom/holding)
-"BR" = (
-/obj/structure/table,
-/obj/structure/bedsheetbin,
-/obj/machinery/light{
-	dir = 1
-	},
-/turf/open/floor/plasteel/whitered/side{
-	dir = 8
-	},
-/area/tdome/tdomeobserve)
-"BS" = (
-/obj/structure/closet/secure_closet/personal,
-/turf/open/floor/plasteel/vault{
-	dir = 8
-	},
-/area/tdome/tdomeobserve)
-"BT" = (
-/turf/open/floor/plasteel/red/corner{
-	dir = 8
-	},
-/area/tdome/tdomeobserve)
-"BU" = (
-/obj/structure/closet/secure_closet/freezer/meat,
-/obj/item/reagent_containers/food/snacks/meat/rawbacon,
-/obj/item/reagent_containers/food/snacks/meat/rawbacon,
-/obj/item/reagent_containers/food/snacks/meat/rawbacon,
-/obj/item/reagent_containers/food/snacks/meat/rawbacon,
-/obj/item/reagent_containers/food/snacks/meat/slab/killertomato,
-/obj/item/reagent_containers/food/snacks/meat/slab/killertomato,
-/obj/item/reagent_containers/food/snacks/meat/slab/killertomato,
-/obj/item/reagent_containers/food/snacks/meat/slab/killertomato,
-/obj/item/reagent_containers/food/snacks/meat/slab/human/mutant/lizard,
-/obj/item/reagent_containers/food/snacks/meat/slab/human/mutant/lizard,
-/obj/item/reagent_containers/food/snacks/meat/slab/human/mutant/lizard,
-/obj/item/reagent_containers/food/snacks/meat/slab/human/mutant/lizard,
-/obj/item/reagent_containers/food/snacks/sausage,
-/obj/item/reagent_containers/food/snacks/sausage,
-/obj/item/reagent_containers/food/snacks/meat/rawcutlet,
-/obj/item/reagent_containers/food/snacks/meat/rawcutlet,
-/obj/item/reagent_containers/food/snacks/meat/rawcutlet,
-/obj/item/reagent_containers/food/snacks/carpmeat,
-/obj/item/reagent_containers/food/snacks/carpmeat,
-/obj/item/reagent_containers/food/snacks/carpmeat,
-/obj/item/reagent_containers/food/snacks/carpmeat,
-/turf/open/floor/plasteel/vault{
-	dir = 8
-	},
-/area/tdome/tdomeobserve)
-"BV" = (
-/obj/structure/closet/secure_closet/freezer/fridge,
-/obj/item/reagent_containers/food/snacks/grown/potato,
-/obj/item/reagent_containers/food/snacks/grown/potato,
-/obj/item/reagent_containers/food/snacks/grown/whitebeet,
-/obj/item/reagent_containers/food/snacks/grown/whitebeet,
-/obj/item/reagent_containers/food/snacks/grown/tomato,
-/obj/item/reagent_containers/food/snacks/grown/tomato,
-/obj/item/reagent_containers/food/snacks/grown/rice,
-/obj/item/reagent_containers/food/snacks/grown/rice,
-/obj/item/reagent_containers/food/snacks/grown/icepepper,
-/obj/item/reagent_containers/food/snacks/grown/icepepper,
-/obj/item/reagent_containers/food/snacks/grown/citrus/lemon,
-/obj/item/reagent_containers/food/snacks/grown/citrus/lime,
-/obj/item/reagent_containers/food/snacks/grown/citrus/orange,
-/obj/item/reagent_containers/food/snacks/grown/cherries,
-/obj/item/reagent_containers/food/snacks/grown/apple,
-/obj/item/reagent_containers/food/snacks/grown/ambrosia/deus,
-/turf/open/floor/plasteel/vault{
-	dir = 8
-	},
-/area/tdome/tdomeobserve)
-"BW" = (
-/obj/machinery/processor,
-/obj/effect/turf_decal/stripes/end,
-/turf/open/floor/plasteel,
-/area/tdome/tdomeobserve)
-"BX" = (
-/obj/structure/closet/secure_closet/freezer/kitchen,
-/obj/item/reagent_containers/food/snacks/grown/banana,
-/obj/item/reagent_containers/food/snacks/grown/banana,
-/obj/item/reagent_containers/food/snacks/grown/wheat,
-/obj/item/reagent_containers/food/snacks/grown/wheat,
-/obj/item/reagent_containers/food/snacks/grown/vanillapod,
-/obj/item/reagent_containers/food/snacks/grown/vanillapod,
-/obj/item/reagent_containers/food/snacks/grown/sugarcane,
-/obj/item/reagent_containers/food/snacks/grown/sugarcane,
-/obj/item/reagent_containers/food/snacks/grown/oat,
-/obj/item/reagent_containers/food/snacks/grown/oat,
-/obj/item/reagent_containers/food/snacks/grown/grapes,
-/obj/item/reagent_containers/food/snacks/grown/grapes,
-/obj/item/reagent_containers/food/snacks/grown/corn,
-/obj/item/reagent_containers/food/snacks/grown/corn,
-/obj/item/reagent_containers/food/snacks/grown/chili,
-/obj/item/reagent_containers/food/snacks/grown/chili,
-/obj/item/reagent_containers/food/snacks/grown/carrot,
-/obj/item/reagent_containers/food/snacks/grown/apple,
-/obj/item/reagent_containers/food/snacks/grown/ambrosia/vulgaris,
-/turf/open/floor/plasteel/vault{
-	dir = 8
-	},
-/area/tdome/tdomeobserve)
-"BY" = (
-/obj/structure/closet/secure_closet/freezer/meat,
-/obj/item/reagent_containers/food/snacks/meat/slab/bear,
-/obj/item/reagent_containers/food/snacks/meat/slab/bear,
-/obj/item/reagent_containers/food/snacks/meat/slab/bear,
-/obj/item/reagent_containers/food/snacks/meat/slab/bear,
-/obj/item/reagent_containers/food/snacks/meat/slab/goliath,
-/obj/item/reagent_containers/food/snacks/meat/slab/goliath,
-/obj/item/reagent_containers/food/snacks/meat/slab/goliath,
-/obj/item/reagent_containers/food/snacks/meat/slab/goliath,
-/obj/item/reagent_containers/food/snacks/meat/slab/xeno,
-/obj/item/reagent_containers/food/snacks/meat/slab/xeno,
-/obj/item/reagent_containers/food/snacks/meat/slab/xeno,
-/obj/item/reagent_containers/food/snacks/meat/slab/xeno,
-/obj/item/reagent_containers/food/snacks/spaghetti,
-/obj/item/reagent_containers/food/snacks/spaghetti,
-/obj/item/reagent_containers/food/snacks/meat/rawcutlet,
-/obj/item/reagent_containers/food/snacks/meat/rawcutlet,
-/obj/item/reagent_containers/food/snacks/meat/rawcutlet,
-/turf/open/floor/plasteel/vault{
-	dir = 8
-	},
-/area/tdome/tdomeobserve)
-"BZ" = (
-/obj/structure/flora/ausbushes/lavendergrass,
-/obj/structure/flora/ausbushes/sparsegrass,
-/obj/structure/flora/ausbushes/fullgrass,
-/obj/structure/flora/ausbushes/grassybush,
-/obj/structure/flora/ausbushes/ppflowers,
-/obj/structure/flora/ausbushes/pointybush,
-/turf/open/floor/grass,
-/area/tdome/tdomeobserve)
-"Ca" = (
-/obj/structure/table/wood,
-/obj/structure/sign/goldenplaque{
-	pixel_y = 32
-	},
-/obj/item/clothing/accessory/lawyers_badge{
-	desc = "A badge of upmost glory.";
-	name = "thunderdome badge"
-	},
-/turf/open/floor/plasteel/grimy,
-/area/tdome/tdomeobserve)
-"Cb" = (
-/turf/open/floor/plasteel/vault{
-	dir = 8
-	},
-/area/tdome/tdomeobserve)
-"Cc" = (
-/turf/open/floor/plasteel/vault{
-	dir = 5
-	},
-/area/tdome/tdomeobserve)
-"Cd" = (
-/obj/structure/table/wood,
-/obj/structure/sign/goldenplaque{
-	pixel_y = 32
-	},
-/obj/item/clothing/accessory/medal/silver{
-	pixel_y = 5
-	},
-/turf/open/floor/plasteel/grimy,
-/area/tdome/tdomeobserve)
-"Ce" = (
-/obj/structure/flora/ausbushes/lavendergrass,
-/obj/structure/flora/ausbushes/sparsegrass,
-/obj/structure/flora/ausbushes/fullgrass,
-/obj/structure/flora/ausbushes/brflowers,
-/obj/structure/flora/ausbushes/genericbush,
-/turf/open/floor/grass,
-/area/tdome/tdomeobserve)
-"Cf" = (
-/obj/structure/table/wood,
-/obj/machinery/reagentgrinder{
-	desc = "Used to grind things up into raw materials and liquids.";
-	pixel_y = 5
-	},
-/turf/open/floor/plasteel/vault{
-	dir = 8
-	},
-/area/tdome/tdomeobserve)
-"Cg" = (
-/obj/structure/table/wood,
-/obj/item/storage/box/beanbag,
-/obj/item/gun/ballistic/revolver/doublebarrel,
-/turf/open/floor/plasteel/vault{
-	dir = 8
-	},
-/area/tdome/tdomeobserve)
-"Ch" = (
-/obj/structure/table/wood,
-/obj/structure/reagent_dispensers/beerkeg,
-/obj/machinery/newscaster{
-	pixel_y = 32
-	},
-/turf/open/floor/plasteel/vault{
-	dir = 8
-	},
-/area/tdome/tdomeobserve)
-"Ci" = (
-/obj/machinery/vending/cigarette,
-/turf/open/floor/plasteel/vault{
-	dir = 8
-	},
-/area/tdome/tdomeobserve)
-"Cj" = (
-/obj/structure/table/wood,
-/obj/item/storage/box/drinkingglasses,
-/obj/item/reagent_containers/food/drinks/bottle/whiskey{
-	pixel_y = 5
-	},
-/turf/open/floor/plasteel/vault{
-	dir = 8
-	},
-/area/tdome/tdomeobserve)
-"Ck" = (
-/turf/open/floor/plasteel/green/corner,
-/area/tdome/tdomeobserve)
-"Cl" = (
-/obj/structure/table,
-/obj/structure/bedsheetbin,
-/obj/machinery/light{
-	dir = 1
-	},
-/turf/open/floor/plasteel/whitegreen/side{
-	dir = 4
-	},
-/area/tdome/tdomeobserve)
-"Cm" = (
-/obj/structure/shuttle/engine/propulsion,
-/turf/open/space,
-/area/wizard_station)
-"Cn" = (
-/obj/structure/rack,
-/obj/item/storage/crayons,
-/obj/item/gun/ballistic/shotgun/toy/crossbow,
-/turf/open/floor/plasteel/cafeteria,
-/area/centcom/holding)
-"Co" = (
-/turf/open/floor/plating/beach/coastline_b,
-/area/centcom/holding)
-"Cp" = (
-/obj/item/clothing/head/collectable/paper,
-/turf/open/floor/plating/beach/coastline_b,
-/area/centcom/holding)
-"Cq" = (
-/obj/structure/sink{
-	dir = 8;
-	pixel_x = -12
-	},
-/obj/structure/mirror{
-	pixel_x = -28
-	},
-/turf/open/floor/plasteel/whitered/corner{
-	dir = 1
-	},
-/area/tdome/tdomeobserve)
-"Cr" = (
-/turf/open/floor/plasteel/red/side{
-	dir = 4
-	},
-/area/tdome/tdomeobserve)
-"Cs" = (
-/turf/open/floor/plasteel/red,
-/area/tdome/tdomeobserve)
-"Ct" = (
-/obj/structure/table/wood,
-/obj/item/reagent_containers/food/drinks/trophy/gold_cup,
-/turf/open/floor/plasteel/grimy,
-/area/tdome/tdomeobserve)
-"Cu" = (
-/turf/open/floor/plasteel/bar,
-/area/tdome/tdomeobserve)
-"Cv" = (
-/turf/open/floor/plasteel/green/side{
-	dir = 8
-	},
-/area/tdome/tdomeobserve)
-"Cw" = (
-/obj/structure/sink{
-	dir = 4;
-	pixel_x = 11
-	},
-/obj/structure/mirror{
-	pixel_x = 28
-	},
-/turf/open/floor/plasteel/whitegreen/corner{
-	dir = 4
-	},
-/area/tdome/tdomeobserve)
-"Cx" = (
-/obj/structure/rack,
-/obj/item/clothing/shoes/laceup,
-/obj/item/clothing/under/suit_jacket/female{
-	desc = "A black trouser suit for women. Very formal.";
-	name = "black suit";
-	pixel_x = 3;
-	pixel_y = 1
-	},
-/turf/open/floor/plasteel/cafeteria,
-/area/centcom/holding)
-"Cy" = (
-/obj/structure/table,
-/obj/item/gun/ballistic/automatic/toy/pistol,
-/turf/open/floor/plasteel/cafeteria,
-/area/centcom/holding)
-"Cz" = (
-/turf/open/floor/plating/beach/water,
-/area/centcom/holding)
-"CA" = (
-/obj/structure/sink{
-	dir = 8;
-	pixel_x = -12
-	},
-/obj/structure/mirror{
-	pixel_x = -28
-	},
-/turf/open/floor/plasteel/white,
-/area/tdome/tdomeobserve)
-"CB" = (
-/obj/structure/table/reinforced,
-/obj/item/reagent_containers/food/condiment/saltshaker{
-	pixel_x = -8;
-	pixel_y = 5
-	},
-/obj/item/reagent_containers/food/condiment/peppermill{
-	pixel_x = -8
-	},
-/obj/item/kitchen/knife,
-/obj/machinery/newscaster{
-	pixel_x = -32
-	},
-/turf/open/floor/plasteel/vault{
-	dir = 8
-	},
-/area/tdome/tdomeobserve)
-"CC" = (
-/obj/machinery/light,
-/turf/open/floor/plasteel/red,
-/area/tdome/tdomeobserve)
-"CD" = (
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = 24
-	},
-/turf/open/floor/plasteel/white,
-/area/tdome/tdomeobserve)
-"CE" = (
-/obj/structure/table/wood,
-/obj/structure/sign/atmosplaque/thunderdome{
-	pixel_y = -32
-	},
-/obj/item/clothing/accessory/medal/gold{
-	pixel_x = 3;
-	pixel_y = 5
-	},
-/obj/item/clothing/accessory/medal/gold,
-/turf/open/floor/plasteel/grimy,
-/area/tdome/tdomeobserve)
-"CF" = (
-/obj/machinery/light,
-/turf/open/floor/plasteel/vault{
-	dir = 8
-	},
-/area/tdome/tdomeobserve)
-"CG" = (
-/obj/structure/table/wood,
-/obj/structure/sign/atmosplaque/thunderdome{
-	pixel_y = -32
-	},
-/obj/item/clothing/accessory/medal{
-	pixel_y = 5
-	},
-/turf/open/floor/plasteel/grimy,
-/area/tdome/tdomeobserve)
-"CH" = (
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = -24
-	},
-/turf/open/floor/plasteel/bar,
-/area/tdome/tdomeobserve)
-"CI" = (
-/obj/machinery/light,
-/turf/open/floor/plasteel/bar,
-/area/tdome/tdomeobserve)
-"CJ" = (
-/obj/machinery/chem_master/condimaster{
-	name = "HoochMaster 2000"
-	},
-/obj/machinery/airalarm{
-	dir = 8;
-	pixel_x = 24
-	},
-/turf/open/floor/plasteel/vault{
-	dir = 8
-	},
-/area/tdome/tdomeobserve)
-"CK" = (
-/obj/structure/sink{
-	dir = 4;
-	pixel_x = 11
-	},
-/obj/structure/mirror{
-	pixel_x = 28
-	},
-/turf/open/floor/plasteel/white,
-/area/tdome/tdomeobserve)
-"CL" = (
-/obj/effect/spawner/structure/window/hollow/reinforced,
-/turf/open/floor/plasteel,
-/area/centcom/holding)
-"CM" = (
-/obj/effect/turf_decal/delivery,
-/turf/open/floor/plasteel,
-/area/centcom/holding)
-"CO" = (
-/obj/structure/sink{
-	dir = 8;
-	pixel_x = -12
-	},
-/obj/structure/mirror{
-	pixel_x = -28
-	},
-/turf/open/floor/plasteel/whitered/corner{
-	dir = 8
-	},
-/area/tdome/tdomeobserve)
-"CP" = (
-/obj/structure/table/reinforced,
-/obj/item/reagent_containers/food/snacks/mint,
-/obj/item/reagent_containers/food/condiment/enzyme{
-	pixel_y = 5
-	},
-/turf/open/floor/plasteel/vault{
-	dir = 8
-	},
-/area/tdome/tdomeobserve)
-"CQ" = (
-/obj/structure/sink{
-	dir = 4;
-	pixel_x = 11
-	},
-/turf/open/floor/plasteel/red,
-/area/tdome/tdomeobserve)
-"CR" = (
-/obj/structure/sink{
-	dir = 8;
-	pixel_x = -12
-	},
-/turf/open/floor/plasteel/bar,
-/area/tdome/tdomeobserve)
-"CS" = (
-/obj/structure/table/wood,
-/obj/machinery/chem_dispenser/drinks/beer,
-/turf/open/floor/plasteel/vault{
-	dir = 8
-	},
-/area/tdome/tdomeobserve)
-"CT" = (
-/obj/structure/sink{
-	dir = 4;
-	pixel_x = 11
-	},
-/obj/structure/mirror{
-	pixel_x = 28
-	},
-/turf/open/floor/plasteel/whitegreen/corner,
-/area/tdome/tdomeobserve)
-"CU" = (
-/obj/item/reagent_containers/food/snacks/egg/rainbow{
-	desc = "I bet you think you're pretty clever... well you are.";
-	name = "easter egg"
-	},
-/turf/open/space,
-/area/space)
-"CV" = (
-/obj/effect/landmark/holding_facility,
-/turf/open/floor/engine,
-/area/centcom/holding)
-"CW" = (
-/obj/structure/sink{
-	dir = 8;
-	pixel_x = -12
-	},
-/obj/structure/mirror{
-	pixel_x = -28
-	},
-/turf/open/floor/plasteel/whitered/side{
-	dir = 8
-	},
-/area/tdome/tdomeobserve)
-"CX" = (
-/obj/structure/table/reinforced,
-/obj/item/clothing/suit/apron/chef,
-/obj/item/kitchen/rollingpin,
-/turf/open/floor/plasteel/vault{
-	dir = 8
-	},
-/area/tdome/tdomeobserve)
-"CY" = (
-/obj/structure/table/reinforced,
-/obj/machinery/door/firedoor,
-/obj/item/reagent_containers/food/condiment/saltshaker{
-	pixel_x = -8;
-	pixel_y = 5
-	},
-/obj/item/reagent_containers/food/condiment/peppermill{
-	pixel_x = -8
-	},
-/obj/item/reagent_containers/food/drinks/britcup,
-/obj/effect/turf_decal/bot,
-/turf/open/floor/plasteel,
-/area/tdome/tdomeobserve)
-"CZ" = (
-/turf/open/floor/plasteel/vault,
-/area/tdome/tdomeobserve)
-"Da" = (
-/obj/structure/chair,
-/obj/effect/landmark/thunderdome/observe,
-/obj/structure/sign/barsign{
-	pixel_y = 32
-	},
-/turf/open/floor/plasteel/vault{
-	dir = 8
-	},
-/area/tdome/tdomeobserve)
-"Db" = (
-/obj/structure/chair,
-/obj/effect/landmark/thunderdome/observe,
-/turf/open/floor/plasteel/vault{
-	dir = 8
-	},
-/area/tdome/tdomeobserve)
-"Dc" = (
-/obj/machinery/computer/security/telescreen,
-/obj/structure/table/reinforced,
-/obj/machinery/light{
-	dir = 1
-	},
-/obj/machinery/ai_status_display{
-	pixel_y = 32
-	},
-/turf/open/floor/plasteel/vault{
-	dir = 8
-	},
-/area/tdome/tdomeobserve)
-"Dd" = (
-/obj/structure/table/reinforced,
-/obj/machinery/door/firedoor,
-/obj/effect/turf_decal/bot,
-/turf/open/floor/plasteel,
-/area/tdome/tdomeobserve)
-"De" = (
-/obj/structure/table/wood,
-/obj/machinery/chem_dispenser/drinks,
-/turf/open/floor/plasteel/vault{
-	dir = 8
-	},
-/area/tdome/tdomeobserve)
-"Df" = (
-/obj/structure/sink{
-	dir = 4;
-	pixel_x = 11
-	},
-/obj/structure/mirror{
-	pixel_x = 28
-	},
-/turf/open/floor/plasteel/whitegreen/side{
-	dir = 4
-	},
-/area/tdome/tdomeobserve)
-"Dg" = (
-/obj/machinery/door/airlock/centcom{
-	name = "Thunderdome Locker Room";
-	opacity = 1;
-	req_access_txt = "101"
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 2
-	},
-/turf/open/floor/plasteel,
-/area/tdome/tdomeobserve)
-"Dh" = (
-/obj/structure/table/reinforced,
-/obj/machinery/reagentgrinder{
-	desc = "Used to grind things up into raw materials and liquids.";
-	pixel_y = 5
-	},
-/obj/machinery/light{
-	dir = 8
-	},
-/turf/open/floor/plasteel/vault{
-	dir = 8
-	},
-/area/tdome/tdomeobserve)
-"Di" = (
-/obj/structure/table/reinforced,
-/obj/machinery/door/firedoor,
-/obj/item/storage/bag/tray,
-/obj/item/kitchen/fork,
-/obj/effect/turf_decal/bot,
-/turf/open/floor/plasteel,
-/area/tdome/tdomeobserve)
-"Dj" = (
-/turf/open/floor/plasteel/redyellow,
-/area/tdome/tdomeobserve)
-"Dk" = (
-/obj/machinery/vending/boozeomat,
-/obj/machinery/light{
-	dir = 4
-	},
-/turf/open/floor/plasteel/vault{
-	dir = 8
-	},
-/area/tdome/tdomeobserve)
-"Dl" = (
-/obj/item/twohanded/required/kirbyplants{
-	icon_state = "plant-21"
-	},
-/turf/open/floor/plasteel/neutral/corner,
-/area/tdome/tdomeobserve)
-"Dm" = (
-/turf/open/floor/plasteel/neutral/side{
-	dir = 6
-	},
-/area/tdome/tdomeobserve)
-"Dn" = (
-/obj/structure/rack,
-/obj/item/storage/box/donkpockets,
-/obj/item/storage/box/donkpockets,
-/obj/item/clothing/head/chefhat,
-/turf/open/floor/plasteel/vault,
-/area/tdome/tdomeobserve)
-"Do" = (
-/obj/structure/table/reinforced,
-/obj/machinery/door/firedoor,
-/obj/structure/noticeboard{
-	dir = 1;
-	pixel_y = -32
-	},
-/obj/effect/turf_decal/bot,
-/turf/open/floor/plasteel,
-/area/tdome/tdomeobserve)
-"Dp" = (
-/obj/machinery/computer/security/telescreen,
-/obj/structure/table/reinforced,
-/turf/open/floor/plasteel/vault{
-	dir = 8
-	},
-/area/tdome/tdomeobserve)
-"Dq" = (
-/obj/item/storage/fancy/cigarettes/cigars{
-	pixel_y = 6
-	},
-/obj/item/storage/fancy/cigarettes/cigars/cohiba{
-	pixel_y = 3
-	},
-/obj/item/storage/fancy/cigarettes/cigars/havana,
-/obj/structure/table/wood,
-/turf/open/floor/plasteel/vault{
-	dir = 8
-	},
-/area/tdome/tdomeobserve)
-"Dr" = (
-/turf/open/floor/plasteel/neutral/side{
-	dir = 10
-	},
-/area/tdome/tdomeobserve)
-"Ds" = (
-/obj/item/twohanded/required/kirbyplants{
-	icon_state = "plant-21"
-	},
-/turf/open/floor/plasteel/neutral/corner{
-	dir = 8;
-	heat_capacity = 1e+006
-	},
-/area/tdome/tdomeobserve)
-"Dt" = (
-/turf/open/floor/plasteel/red/corner{
-	dir = 4
-	},
-/area/tdome/tdomeobserve)
-"Du" = (
-/obj/structure/table/reinforced,
-/obj/machinery/microwave{
-	desc = "Cooks and boils stuff, somehow.";
-	pixel_x = -3;
-	pixel_y = 5
-	},
-/obj/machinery/airalarm{
-	dir = 1;
-	pixel_y = -22
-	},
-/turf/open/floor/plasteel/vault{
-	dir = 8
-	},
-/area/tdome/tdomeobserve)
-"Dv" = (
-/obj/structure/table/reinforced,
-/obj/machinery/microwave{
-	desc = "Cooks and boils stuff, somehow.";
-	pixel_x = -3;
-	pixel_y = 5
-	},
-/obj/structure/sign/barsign{
-	pixel_y = -32
-	},
-/turf/open/floor/plasteel/vault{
-	dir = 8
-	},
-/area/tdome/tdomeobserve)
-"Dw" = (
-/obj/machinery/icecream_vat,
-/turf/open/floor/plasteel/vault{
-	dir = 8
-	},
-/area/tdome/tdomeobserve)
-"Dx" = (
-/turf/closed/indestructible/fakeglass{
-	icon_state = "fakewindows";
-	dir = 8
-	},
-/area/tdome/tdomeobserve)
-"Dy" = (
-/turf/closed/indestructible/fakeglass{
-	icon_state = "fakewindows2";
-	dir = 8
-	},
-/area/tdome/tdomeobserve)
-"Dz" = (
-/turf/closed/indestructible/fakeglass{
-	icon_state = "fakewindows";
-	dir = 4
-	},
-/area/tdome/tdomeobserve)
-"DA" = (
-/obj/item/storage/box/matches{
-	pixel_x = -3;
-	pixel_y = 5
-	},
-/obj/structure/table/wood,
-/obj/structure/sign/barsign{
-	pixel_y = -32
-	},
-/turf/open/floor/plasteel/vault{
-	dir = 8
-	},
-/area/tdome/tdomeobserve)
-"DB" = (
-/obj/item/lighter{
-	pixel_x = 3;
-	pixel_y = 3
-	},
-/obj/item/lighter,
-/obj/structure/table/wood,
-/turf/open/floor/plasteel/vault{
-	dir = 8
-	},
-/area/tdome/tdomeobserve)
-"DC" = (
-/obj/structure/table/wood,
-/obj/item/book/manual/barman_recipes,
-/obj/item/reagent_containers/food/drinks/shaker,
-/obj/item/reagent_containers/glass/rag,
-/obj/machinery/newscaster{
-	pixel_y = -32
-	},
-/turf/open/floor/plasteel/vault{
-	dir = 8
-	},
-/area/tdome/tdomeobserve)
-"DD" = (
-/turf/open/floor/plasteel/green/corner{
-	dir = 1
-	},
-/area/tdome/tdomeobserve)
-"DG" = (
-/obj/machinery/igniter,
-/obj/effect/turf_decal/delivery,
-/turf/open/floor/plasteel,
-/area/tdome/arena)
-"DH" = (
-/turf/open/floor/plasteel,
-/area/tdome/arena)
-"DI" = (
-/obj/effect/turf_decal/bot,
-/turf/open/floor/plasteel,
-/area/tdome/arena)
-"DJ" = (
-/turf/closed/indestructible/riveted,
-/area/tdome/tdomeadmin)
-"DK" = (
-/obj/structure/flora/ausbushes/lavendergrass,
-/obj/structure/flora/ausbushes/fullgrass,
-/obj/structure/flora/ausbushes/ywflowers,
-/obj/structure/flora/ausbushes/grassybush,
-/obj/structure/flora/ausbushes/palebush,
-/turf/open/floor/plating/asteroid,
-/area/tdome/tdomeadmin)
-"DL" = (
-/obj/machinery/door/airlock/centcom{
-	name = "Thunderdome Administration";
-	opacity = 1;
-	req_access_txt = "102"
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 2
-	},
-/turf/open/floor/plasteel,
-/area/tdome/tdomeadmin)
-"DM" = (
-/obj/structure/rack,
-/obj/item/clothing/under/color/red,
-/obj/item/clothing/shoes/sneakers/brown,
-/obj/item/clothing/suit/armor/tdome/red,
-/obj/item/clothing/head/helmet/thunderdome,
-/obj/item/melee/baton/loaded,
-/obj/item/melee/transforming/energy/sword/saber/red,
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/tdome/arena)
-"DN" = (
-/obj/machinery/door/poddoor{
-	id = "thunderdomegen";
-	name = "General Supply"
-	},
-/turf/open/floor/plasteel/loadingarea{
-	dir = 4
-	},
-/area/tdome/arena)
-"DO" = (
-/obj/effect/landmark/thunderdome/two,
-/obj/effect/turf_decal/stripes/line{
-	dir = 9
-	},
-/turf/open/floor/plasteel,
-/area/tdome/arena)
-"DP" = (
-/obj/effect/landmark/thunderdome/two,
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/tdome/arena)
-"DQ" = (
-/obj/effect/landmark/thunderdome/two,
-/obj/effect/turf_decal/stripes/line{
-	dir = 5
-	},
-/turf/open/floor/plasteel,
-/area/tdome/arena)
-"DR" = (
-/obj/machinery/door/poddoor{
-	id = "thunderdome";
-	name = "Thunderdome Blast Door"
-	},
-/turf/open/floor/plasteel/loadingarea{
-	dir = 4
-	},
-/area/tdome/arena)
-"DS" = (
-/turf/open/floor/plasteel/red/side{
-	dir = 8
-	},
-/area/tdome/arena)
-"DT" = (
-/obj/effect/turf_decal/delivery,
-/turf/open/floor/plasteel,
-/area/tdome/arena)
-"DU" = (
-/turf/open/floor/plasteel/neutral/side{
-	dir = 4
-	},
-/area/tdome/arena)
-"DV" = (
-/turf/open/floor/plasteel/neutral,
-/area/tdome/arena)
-"DW" = (
-/turf/open/floor/plasteel/neutral/side{
-	dir = 8
-	},
-/area/tdome/arena)
-"DX" = (
-/turf/open/floor/plasteel/green/side{
-	dir = 4
-	},
-/area/tdome/arena)
-"DY" = (
-/obj/machinery/door/poddoor{
-	id = "thunderdome";
-	name = "Thunderdome Blast Door"
-	},
-/turf/open/floor/plasteel/loadingarea{
-	dir = 8
-	},
-/area/tdome/arena)
-"DZ" = (
-/obj/effect/landmark/thunderdome/one,
-/obj/effect/turf_decal/stripes/line{
-	dir = 9
-	},
-/turf/open/floor/plasteel,
-/area/tdome/arena)
-"Ea" = (
-/obj/effect/landmark/thunderdome/one,
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/tdome/arena)
-"Eb" = (
-/obj/effect/landmark/thunderdome/one,
-/obj/effect/turf_decal/stripes/line{
-	dir = 5
-	},
-/turf/open/floor/plasteel,
-/area/tdome/arena)
-"Ec" = (
-/obj/machinery/door/poddoor{
-	id = "thunderdomegen";
-	name = "General Supply"
-	},
-/turf/open/floor/plasteel/loadingarea{
-	dir = 8
-	},
-/area/tdome/arena)
-"Ed" = (
-/obj/structure/rack,
-/obj/item/clothing/under/color/green,
-/obj/item/clothing/shoes/sneakers/brown,
-/obj/item/clothing/suit/armor/tdome/green,
-/obj/item/clothing/head/helmet/thunderdome,
-/obj/item/melee/baton/loaded,
-/obj/item/melee/transforming/energy/sword/saber/green,
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/tdome/arena)
-"Ee" = (
-/obj/structure/flora/ausbushes/sparsegrass,
-/obj/structure/flora/ausbushes/grassybush,
-/obj/structure/flora/ausbushes/fernybush,
-/turf/open/floor/plasteel{
-	dir = 6;
-	icon_state = "asteroid8";
-	name = "sand"
-	},
-/area/tdome/tdomeadmin)
-"Ef" = (
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating,
-/area/tdome/tdomeadmin)
-"Eg" = (
-/obj/machinery/door/firedoor,
-/obj/effect/turf_decal/stripes/line{
-	dir = 2
-	},
-/turf/open/floor/plasteel,
-/area/tdome/tdomeadmin)
-"Eh" = (
-/obj/effect/landmark/thunderdome/two,
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/tdome/arena)
-"Ei" = (
-/obj/machinery/recharger{
-	pixel_y = 4
-	},
-/obj/effect/landmark/thunderdome/two,
-/obj/effect/turf_decal/delivery,
-/turf/open/floor/plasteel,
-/area/tdome/arena)
-"Ej" = (
-/obj/effect/landmark/thunderdome/two,
-/turf/open/floor/plasteel/neutral,
-/area/tdome/arena)
-"Ek" = (
-/obj/effect/landmark/thunderdome/two,
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/tdome/arena)
-"El" = (
-/turf/open/floor/plasteel/red/corner{
-	dir = 1
-	},
-/area/tdome/arena)
-"Em" = (
-/turf/open/floor/plasteel/green/corner{
-	dir = 4
-	},
-/area/tdome/arena)
-"En" = (
-/obj/effect/landmark/thunderdome/one,
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/tdome/arena)
-"Eo" = (
-/obj/machinery/recharger{
-	pixel_y = 4
-	},
-/obj/effect/landmark/thunderdome/one,
-/obj/effect/turf_decal/delivery,
-/turf/open/floor/plasteel,
-/area/tdome/arena)
-"Ep" = (
-/obj/effect/landmark/thunderdome/one,
-/turf/open/floor/plasteel/neutral,
-/area/tdome/arena)
-"Eq" = (
-/obj/effect/landmark/thunderdome/one,
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/tdome/arena)
-"Er" = (
-/obj/structure/flora/ausbushes/sparsegrass,
-/obj/structure/flora/ausbushes/lavendergrass,
-/obj/structure/flora/ausbushes/fernybush,
-/turf/open/floor/plasteel{
-	name = "plating";
-	icon_state = "asteroid5"
-	},
-/area/tdome/tdomeadmin)
-"Es" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 9
-	},
-/turf/open/floor/plasteel,
-/area/tdome/tdomeadmin)
-"Et" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 5
-	},
-/turf/open/floor/plasteel,
-/area/tdome/tdomeadmin)
-"Eu" = (
-/obj/machinery/camera{
-	pixel_x = 11;
-	pixel_y = -9;
-	network = list("thunder");
-	c_tag = "Red Team"
-	},
-/obj/effect/landmark/thunderdome/two,
-/turf/open/floor/plasteel/neutral,
-/area/tdome/arena)
-"Ev" = (
-/turf/open/floor/plasteel/loadingarea{
-	dir = 4
-	},
-/area/tdome/arena)
-"Ew" = (
-/turf/open/floor/circuit/green,
-/area/tdome/arena)
-"Ex" = (
-/obj/machinery/flasher{
-	id = "tdomeflash";
-	name = "Thunderdome Flash"
-	},
-/turf/open/floor/circuit/green,
-/area/tdome/arena)
-"Ey" = (
-/turf/open/floor/plasteel/loadingarea{
-	dir = 8
-	},
-/area/tdome/arena)
-"Ez" = (
-/obj/machinery/camera{
-	pixel_x = 12;
-	pixel_y = -10;
-	network = list("thunder");
-	c_tag = "Green Team"
-	},
-/obj/effect/landmark/thunderdome/one,
-/turf/open/floor/plasteel/neutral,
-/area/tdome/arena)
-"EA" = (
-/obj/structure/flora/ausbushes/lavendergrass,
-/obj/structure/flora/ausbushes/sparsegrass,
-/obj/structure/flora/ausbushes/ywflowers,
-/obj/structure/flora/ausbushes/grassybush,
-/obj/structure/flora/ausbushes/palebush,
-/turf/open/floor/plating/asteroid,
-/area/tdome/tdomeadmin)
-"EB" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 10
-	},
-/turf/open/floor/plasteel,
-/area/tdome/tdomeadmin)
-"EC" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 6
-	},
-/turf/open/floor/plasteel,
-/area/tdome/tdomeadmin)
-"ED" = (
-/obj/machinery/camera{
-	pixel_x = 10;
-	network = list("thunder");
-	c_tag = "Arena"
-	},
-/turf/open/floor/circuit/green,
-/area/tdome/arena)
-"EE" = (
-/turf/open/floor/plasteel/red/corner{
-	dir = 8
-	},
-/area/tdome/arena)
-"EF" = (
-/turf/open/floor/plasteel/green/corner,
-/area/tdome/arena)
-"EG" = (
-/obj/effect/landmark/thunderdome/two,
-/obj/effect/turf_decal/stripes/line{
-	dir = 10
-	},
-/turf/open/floor/plasteel,
-/area/tdome/arena)
-"EH" = (
-/obj/effect/landmark/thunderdome/two,
-/obj/effect/turf_decal/stripes/line,
-/turf/open/floor/plasteel,
-/area/tdome/arena)
-"EI" = (
-/obj/effect/landmark/thunderdome/two,
-/obj/effect/turf_decal/stripes/line{
-	dir = 6
-	},
-/turf/open/floor/plasteel,
-/area/tdome/arena)
-"EJ" = (
-/obj/effect/landmark/thunderdome/one,
-/obj/effect/turf_decal/stripes/line{
-	dir = 10
-	},
-/turf/open/floor/plasteel,
-/area/tdome/arena)
-"EK" = (
-/obj/effect/landmark/thunderdome/one,
-/obj/effect/turf_decal/stripes/line,
-/turf/open/floor/plasteel,
-/area/tdome/arena)
-"EL" = (
-/obj/effect/landmark/thunderdome/one,
-/obj/effect/turf_decal/stripes/line{
-	dir = 6
-	},
-/turf/open/floor/plasteel,
-/area/tdome/arena)
-"EM" = (
-/obj/machinery/door/poddoor{
-	id = "thunderdomehea";
-	name = "Heavy Supply"
-	},
-/turf/open/floor/plasteel/loadingarea{
-	dir = 1
-	},
-/area/tdome/arena)
-"EN" = (
-/obj/machinery/door/poddoor{
-	id = "thunderdomehea";
-	name = "Heavy Supply"
-	},
-/turf/open/floor/plasteel/loadingarea,
-/area/tdome/arena)
-"EO" = (
-/turf/open/floor/plasteel/vault{
-	dir = 5
-	},
-/area/tdome/tdomeadmin)
-"EP" = (
-/obj/structure/rack,
-/obj/item/clothing/under/color/red,
-/obj/item/clothing/shoes/sneakers/brown,
-/obj/item/clothing/suit/armor/vest,
-/obj/item/clothing/head/helmet/swat,
-/obj/item/gun/energy/laser,
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/tdome/arena)
-"EQ" = (
-/turf/closed/indestructible/fakeglass{
-	icon_state = "fakewindows";
-	dir = 8
-	},
-/area/tdome/tdomeadmin)
-"ER" = (
-/turf/closed/indestructible/fakeglass{
-	icon_state = "fakewindows2";
-	dir = 8
-	},
-/area/tdome/tdomeadmin)
-"ES" = (
-/turf/closed/indestructible/fakeglass{
-	icon_state = "fakewindows";
-	dir = 4
-	},
-/area/tdome/tdomeadmin)
-"ET" = (
-/obj/structure/rack,
-/obj/item/clothing/under/color/green,
-/obj/item/clothing/shoes/sneakers/brown,
-/obj/item/clothing/suit/armor/vest,
-/obj/item/clothing/head/helmet/swat,
-/obj/item/gun/energy/laser,
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/tdome/arena)
-"EU" = (
-/obj/item/device/radio{
-	pixel_x = 5;
-	pixel_y = 5
-	},
-/obj/item/device/radio{
-	pixel_x = -5;
-	pixel_y = 5
-	},
-/obj/item/device/radio,
-/obj/structure/table/wood,
-/turf/open/floor/plasteel/vault{
-	dir = 8
-	},
-/area/tdome/tdomeadmin)
-"EV" = (
-/obj/effect/landmark/thunderdome/admin,
-/obj/structure/chair/comfy/black{
-	dir = 1
-	},
-/turf/open/floor/plasteel/grimy,
-/area/tdome/tdomeadmin)
-"EW" = (
-/obj/machinery/computer/security/telescreen,
-/obj/structure/table/reinforced,
-/turf/open/floor/plasteel/vault{
-	dir = 8
-	},
-/area/tdome/tdomeadmin)
-"EX" = (
-/obj/structure/chair/comfy/brown{
-	color = "#66b266";
-	dir = 1
-	},
-/turf/open/floor/plasteel/darkgreen,
-/area/tdome/tdomeadmin)
-"EY" = (
-/obj/machinery/button/flasher{
-	id = "tdomeflash"
-	},
-/obj/structure/table/reinforced,
-/turf/open/floor/plasteel/vault{
-	dir = 8
-	},
-/area/tdome/tdomeadmin)
-"EZ" = (
-/turf/closed/wall/mineral/titanium,
-/area/shuttle/escape)
-"Fa" = (
-/obj/machinery/status_display,
-/turf/closed/wall/mineral/titanium,
-/area/shuttle/escape)
-"Fb" = (
-/obj/machinery/door/firedoor,
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/tdome/tdomeadmin)
-"Fc" = (
-/turf/open/floor/plasteel/vault{
-	dir = 8
-	},
-/area/tdome/tdomeadmin)
-"Fd" = (
-/obj/item/twohanded/required/kirbyplants{
-	icon_state = "plant-21"
-	},
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = -24
-	},
-/turf/open/floor/plasteel/vault{
-	dir = 8
-	},
-/area/tdome/tdomeadmin)
-"Fe" = (
-/turf/open/floor/plasteel/grimy,
-/area/tdome/tdomeadmin)
-"Ff" = (
-/turf/open/floor/plasteel/darkgreen/side{
-	dir = 1
-	},
-/area/tdome/tdomeadmin)
-"Fg" = (
-/obj/item/twohanded/required/kirbyplants{
-	icon_state = "plant-21"
-	},
-/turf/open/floor/plasteel/vault{
-	dir = 8
-	},
-/area/tdome/tdomeadmin)
-"Fh" = (
-/turf/open/floor/mineral/titanium,
-/area/shuttle/escape)
-"Fi" = (
-/turf/open/floor/mineral/plastitanium,
-/area/shuttle/escape)
-"Fj" = (
-/turf/closed/indestructible/fakedoor{
-	name = "Thunderdome Admin"
-	},
-/area/tdome/tdomeadmin)
-"Fk" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/centcom{
-	name = "Thunderdome Administration";
-	opacity = 1;
-	req_access_txt = "102"
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/tdome/tdomeadmin)
-"Fl" = (
-/turf/open/floor/plasteel/vault,
-/area/tdome/tdomeadmin)
-"Fm" = (
-/obj/machinery/door/airlock/external{
-	name = "Backup Emergency Escape Shuttle"
-	},
-/obj/effect/turf_decal/delivery,
-/turf/open/floor/plasteel,
-/area/tdome/tdomeadmin)
-"Fn" = (
-/obj/machinery/door/airlock/titanium,
-/obj/docking_port/stationary{
-	dir = 4;
-	dwidth = 2;
-	height = 8;
-	id = "backup_away";
-	name = "Backup Shuttle Dock";
-	width = 8
-	},
-/obj/docking_port/mobile/emergency/backup,
-/turf/open/floor/plating,
-/area/shuttle/escape)
-"Fo" = (
-/obj/structure/chair/office/light{
-	dir = 4
-	},
-/turf/open/floor/mineral/titanium,
-/area/shuttle/escape)
-"Fp" = (
-/obj/structure/table/wood,
-/obj/item/paper/fluff/stations/centcom/broken_evac,
-/turf/open/floor/mineral/titanium,
-/area/shuttle/escape)
-"Fq" = (
-/obj/structure/bookcase/random,
-/turf/open/floor/plasteel/vault{
-	dir = 8
-	},
-/area/tdome/tdomeadmin)
-"Fr" = (
-/obj/structure/table/wood,
-/obj/item/paper_bin,
-/obj/item/pen/fourcolor,
-/obj/machinery/light,
-/turf/open/floor/plasteel/vault{
-	dir = 8
-	},
-/area/tdome/tdomeadmin)
-"Fs" = (
-/obj/structure/table/wood,
-/obj/item/folder/red,
-/obj/item/book/manual/wiki/security_space_law,
-/obj/item/restraints/handcuffs,
-/obj/item/device/assembly/flash/handheld,
-/turf/open/floor/plasteel/vault{
-	dir = 8
-	},
-/area/tdome/tdomeadmin)
-"Ft" = (
-/obj/structure/table/wood,
-/obj/item/clipboard,
-/obj/item/device/radio/headset/headset_cent,
-/turf/open/floor/plasteel/vault{
-	dir = 8
-	},
-/area/tdome/tdomeadmin)
-"Fu" = (
-/obj/structure/table/wood,
-/obj/item/phone{
-	desc = "Supposedly a direct line to Nanotrasen Central Command. It's not even plugged in.";
-	pixel_x = -3;
-	pixel_y = 3
-	},
-/obj/item/clothing/mask/cigarette/cigar/cohiba{
-	pixel_x = 6
-	},
-/obj/item/clothing/mask/cigarette/cigar/havana{
-	pixel_x = 2
-	},
-/obj/item/clothing/mask/cigarette/cigar{
-	pixel_x = 4.5
-	},
-/obj/machinery/airalarm{
-	dir = 1;
-	pixel_y = -22
-	},
-/turf/open/floor/plasteel/vault{
-	dir = 8
-	},
-/area/tdome/tdomeadmin)
-"Fv" = (
-/obj/machinery/button/door{
-	id = "thunderdomehea";
-	name = "Heavy Supply Control";
-	req_access_txt = "102"
-	},
-/obj/structure/table/reinforced,
-/turf/open/floor/plasteel/vault{
-	dir = 8
-	},
-/area/tdome/tdomeadmin)
-"Fw" = (
-/obj/machinery/button/door{
-	id = "thunderdome";
-	name = "Main Blast Doors Control";
-	req_access_txt = "102"
-	},
-/obj/structure/table/reinforced,
-/obj/machinery/light,
-/turf/open/floor/plasteel/vault{
-	dir = 8
-	},
-/area/tdome/tdomeadmin)
-"Fx" = (
-/obj/machinery/button/door{
-	id = "thunderdomegen";
-	name = "General Supply Control";
-	req_access_txt = "102"
-	},
-/obj/structure/table/reinforced,
-/turf/open/floor/plasteel/vault{
-	dir = 8
-	},
-/area/tdome/tdomeadmin)
-"Fy" = (
-/obj/structure/table/wood,
-/obj/item/folder/red,
-/obj/item/lighter,
-/obj/machinery/newscaster{
-	pixel_y = -32
-	},
-/turf/open/floor/plasteel/vault{
-	dir = 8
-	},
-/area/tdome/tdomeadmin)
-"Fz" = (
-/obj/item/storage/briefcase{
-	pixel_x = -3;
-	pixel_y = 3
-	},
-/obj/item/storage/secure/briefcase,
-/obj/structure/table/wood,
-/turf/open/floor/plasteel/vault{
-	dir = 8
-	},
-/area/tdome/tdomeadmin)
-"FA" = (
-/obj/structure/table/wood,
-/obj/item/storage/fancy/donut_box,
-/turf/open/floor/plasteel/vault{
-	dir = 8
-	},
-/area/tdome/tdomeadmin)
-"FB" = (
-/obj/structure/table/wood,
-/obj/item/storage/box/drinkingglasses,
-/obj/item/reagent_containers/food/drinks/bottle/whiskey{
-	pixel_y = 5
-	},
-/obj/machinery/light,
-/turf/open/floor/plasteel/vault{
-	dir = 8
-	},
-/area/tdome/tdomeadmin)
-"FC" = (
-/obj/structure/table/wood,
-/obj/item/book/manual/random,
-/turf/open/floor/mineral/titanium,
-/area/shuttle/escape)
-"FD" = (
-/obj/structure/flora/ausbushes/lavendergrass,
-/obj/structure/flora/ausbushes/sparsegrass,
-/obj/structure/flora/ausbushes/fullgrass,
-/obj/structure/flora/ausbushes/brflowers,
-/obj/structure/flora/ausbushes/genericbush,
-/turf/open/floor/grass,
-/area/tdome/tdomeadmin)
-"FE" = (
-/obj/structure/flora/ausbushes/lavendergrass,
-/obj/structure/flora/ausbushes/sparsegrass,
-/obj/structure/flora/ausbushes/fullgrass,
-/obj/structure/flora/ausbushes/grassybush,
-/obj/structure/flora/ausbushes/ppflowers,
-/obj/structure/flora/ausbushes/pointybush,
-/turf/open/floor/grass,
-/area/tdome/tdomeadmin)
-"FF" = (
-/obj/machinery/status_display,
-/turf/closed/indestructible/riveted,
-/area/tdome/tdomeadmin)
-"FG" = (
-/obj/machinery/ai_status_display,
-/turf/closed/indestructible/riveted,
-/area/tdome/tdomeadmin)
-"FI" = (
-/obj/structure/shuttle/engine/propulsion/right{
-	dir = 1
-	},
-/turf/open/floor/plating/airless,
-/area/centcom/evac)
-"FJ" = (
-/obj/structure/shuttle/engine/propulsion{
-	dir = 1
-	},
-/turf/open/floor/plating/airless,
-/area/centcom/evac)
-"FK" = (
-/obj/structure/shuttle/engine/propulsion/left{
-	dir = 1
-	},
-/turf/open/floor/plating/airless,
-/area/centcom/evac)
-"FL" = (
-/obj/docking_port/stationary{
-	dir = 1;
-	dwidth = 1;
-	height = 4;
-	id = "pod4_away";
-	name = "recovery ship";
-	width = 3
-	},
-/turf/open/space,
-/area/space)
-"FM" = (
-/obj/docking_port/stationary{
-	dir = 1;
-	dwidth = 1;
-	height = 4;
-	id = "pod3_away";
-	name = "recovery ship";
-	width = 3
-	},
-/turf/open/space,
-/area/space)
-"FN" = (
-/turf/closed/wall/mineral/titanium,
-/area/centcom/evac)
-"FO" = (
-/obj/structure/window/reinforced,
-/obj/structure/shuttle/engine/heater{
-	dir = 1
-	},
-/turf/open/floor/plating/airless,
-/area/centcom/evac)
-"FP" = (
-/obj/machinery/door/airlock/titanium,
-/turf/open/floor/plating,
-/area/centcom/evac)
-"FQ" = (
-/obj/structure/window/shuttle,
-/obj/structure/grille,
-/turf/open/floor/plating,
-/area/centcom/evac)
-"FR" = (
-/turf/open/floor/plating,
-/area/centcom/evac)
-"FS" = (
-/turf/open/floor/plating,
-/turf/closed/wall/mineral/titanium/interior,
-/area/centcom/evac)
-"FT" = (
-/turf/open/floor/mineral/titanium/blue,
-/turf/closed/wall/mineral/titanium/interior,
-/area/centcom/evac)
-"FU" = (
-/obj/structure/closet/emcloset,
-/turf/open/floor/mineral/titanium/blue,
-/area/centcom/evac)
-"FV" = (
-/turf/open/floor/mineral/titanium/yellow,
-/area/centcom/evac)
-"FW" = (
-/obj/structure/table,
-/obj/item/storage/firstaid/toxin{
-	pixel_x = -2;
-	pixel_y = 4
-	},
-/obj/item/storage/firstaid/toxin,
-/turf/open/floor/mineral/titanium/blue,
-/area/centcom/evac)
-"FX" = (
-/obj/structure/table,
-/obj/item/storage/firstaid/fire,
-/obj/item/storage/firstaid/fire{
-	pixel_x = -2;
-	pixel_y = 4
-	},
-/turf/open/floor/mineral/titanium/blue,
-/area/centcom/evac)
-"FY" = (
-/obj/structure/table,
-/obj/item/storage/firstaid/regular{
-	pixel_x = 2
-	},
-/obj/item/storage/firstaid/regular{
-	pixel_x = -2;
-	pixel_y = 4
-	},
-/turf/open/floor/mineral/titanium/blue,
-/area/centcom/evac)
-"FZ" = (
-/turf/open/floor/mineral/titanium/blue,
-/area/centcom/evac)
-"Ga" = (
-/turf/closed/indestructible/abductor{
-	icon_state = "alien20"
-	},
-/area/abductor_ship)
-"Gb" = (
-/turf/closed/indestructible/abductor{
-	icon_state = "alien21"
-	},
-/area/abductor_ship)
-"Gc" = (
-/turf/closed/indestructible/abductor{
-	icon_state = "alien22"
-	},
-/area/abductor_ship)
-"Gd" = (
-/turf/closed/indestructible/abductor{
-	icon_state = "alien23"
-	},
-/area/abductor_ship)
-"Ge" = (
-/turf/closed/indestructible/abductor{
-	icon_state = "alien24"
-	},
-/area/abductor_ship)
-"Gf" = (
-/turf/closed/indestructible/abductor{
-	icon_state = "alien16"
-	},
-/area/abductor_ship)
-"Gg" = (
-/turf/closed/indestructible/abductor{
-	icon_state = "alien17"
-	},
-/area/abductor_ship)
-"Gh" = (
-/obj/machinery/abductor/experiment{
-	team_number = 1
-	},
-/turf/open/floor/plating/abductor,
-/area/abductor_ship)
-"Gi" = (
-/obj/machinery/abductor/console{
-	team_number = 1
-	},
-/turf/open/floor/plating/abductor,
-/area/abductor_ship)
-"Gj" = (
-/obj/machinery/abductor/pad{
-	team_number = 1
-	},
-/turf/open/floor/plating/abductor,
-/area/abductor_ship)
-"Gk" = (
-/turf/closed/indestructible/abductor{
-	icon_state = "alien18"
-	},
-/area/abductor_ship)
-"Gl" = (
-/turf/closed/indestructible/abductor{
-	icon_state = "alien19"
-	},
-/area/abductor_ship)
-"Gm" = (
-/obj/machinery/abductor/experiment{
-	team_number = 4
-	},
-/turf/open/floor/plating/abductor,
-/area/abductor_ship)
-"Gn" = (
-/obj/machinery/abductor/console{
-	team_number = 4
-	},
-/turf/open/floor/plating/abductor,
-/area/abductor_ship)
-"Go" = (
-/obj/machinery/abductor/pad{
-	team_number = 4
-	},
-/turf/open/floor/plating/abductor,
-/area/abductor_ship)
-"Gp" = (
-/obj/structure/table/reinforced,
-/obj/item/paper_bin,
-/turf/open/floor/mineral/plastitanium,
-/area/centcom/evac)
-"Gq" = (
-/obj/structure/table/reinforced,
-/obj/item/storage/fancy/donut_box,
-/turf/open/floor/mineral/plastitanium,
-/area/centcom/evac)
-"Gr" = (
-/obj/structure/table/reinforced,
-/obj/item/pen,
-/turf/open/floor/mineral/plastitanium,
-/area/centcom/evac)
-"Gs" = (
-/obj/structure/table/reinforced,
-/turf/open/floor/mineral/plastitanium,
-/area/centcom/evac)
-"Gt" = (
-/obj/machinery/sleeper{
-	dir = 8
-	},
-/turf/open/floor/mineral/titanium/blue,
-/area/centcom/evac)
-"Gu" = (
-/obj/structure/chair{
-	dir = 8
-	},
-/turf/open/floor/mineral/titanium/blue,
-/area/centcom/evac)
-"Gv" = (
-/turf/closed/indestructible/abductor{
-	icon_state = "alien14"
-	},
-/area/abductor_ship)
-"Gw" = (
-/obj/machinery/computer/camera_advanced/abductor{
-	team_number = 1
-	},
-/turf/open/floor/plating/abductor,
-/area/abductor_ship)
-"Gx" = (
-/turf/open/floor/plating/abductor,
-/area/abductor_ship)
-"Gy" = (
-/obj/structure/closet/abductor,
-/turf/open/floor/plating/abductor,
-/area/abductor_ship)
-"Gz" = (
-/turf/closed/indestructible/abductor{
-	icon_state = "alien15"
-	},
-/area/abductor_ship)
-"GA" = (
-/obj/machinery/computer/camera_advanced/abductor{
-	team_number = 4
-	},
-/turf/open/floor/plating/abductor,
-/area/abductor_ship)
-"GB" = (
-/obj/machinery/computer/secure_data,
-/turf/open/floor/mineral/plastitanium,
-/area/centcom/evac)
-"GC" = (
-/obj/structure/chair{
-	dir = 1
-	},
-/turf/open/floor/mineral/plastitanium,
-/area/centcom/evac)
-"GD" = (
-/obj/structure/chair{
-	dir = 4
-	},
-/turf/open/floor/mineral/plastitanium,
-/area/centcom/evac)
-"GE" = (
-/obj/structure/table/reinforced,
-/obj/item/clipboard,
-/obj/item/stamp,
-/turf/open/floor/mineral/plastitanium,
-/area/centcom/evac)
-"GF" = (
-/turf/closed/indestructible/abductor{
-	icon_state = "alien12"
-	},
-/area/abductor_ship)
-"GG" = (
-/obj/item/retractor/alien,
-/obj/item/hemostat/alien,
-/obj/structure/table/abductor,
-/turf/open/floor/plating/abductor,
-/area/abductor_ship)
-"GH" = (
-/obj/effect/landmark/abductor/scientist,
-/turf/open/floor/plating/abductor,
-/area/abductor_ship)
-"GI" = (
-/obj/structure/table/optable/abductor,
-/turf/open/floor/plating/abductor,
-/area/abductor_ship)
-"GJ" = (
-/obj/effect/landmark/abductor/agent,
-/turf/open/floor/plating/abductor,
-/area/abductor_ship)
-"GK" = (
-/obj/structure/table/abductor,
-/obj/item/storage/box/alienhandcuffs,
-/turf/open/floor/plating/abductor,
-/area/abductor_ship)
-"GL" = (
-/turf/closed/indestructible/abductor{
-	icon_state = "alien13"
-	},
-/area/abductor_ship)
-"GM" = (
-/obj/effect/landmark/abductor/scientist{
-	team_number = 4
-	},
-/turf/open/floor/plating/abductor,
-/area/abductor_ship)
-"GN" = (
-/obj/effect/landmark/abductor/agent{
-	team_number = 4
-	},
-/turf/open/floor/plating/abductor,
-/area/abductor_ship)
-"GO" = (
-/obj/structure/table,
-/obj/item/device/assembly/flash/handheld,
-/turf/open/floor/mineral/plastitanium,
-/area/centcom/evac)
-"GP" = (
-/turf/open/floor/mineral/plastitanium,
-/area/centcom/evac)
-"GQ" = (
-/obj/structure/chair{
-	dir = 4
-	},
-/turf/open/floor/mineral/titanium/blue,
-/area/centcom/evac)
-"GR" = (
-/turf/closed/indestructible/abductor{
-	icon_state = "alien10"
-	},
-/area/abductor_ship)
-"GS" = (
-/obj/item/surgical_drapes,
-/obj/item/paper/guides/antag/abductor,
-/obj/item/scalpel/alien,
-/obj/structure/table/abductor,
-/obj/item/cautery/alien,
-/turf/open/floor/plating/abductor,
-/area/abductor_ship)
-"GT" = (
-/turf/closed/indestructible/abductor{
-	icon_state = "alien11"
-	},
-/area/abductor_ship)
-"GU" = (
-/obj/structure/table,
-/obj/item/storage/box/handcuffs,
-/turf/open/floor/mineral/plastitanium,
-/area/centcom/evac)
-"GV" = (
-/obj/machinery/door/window/northright{
-	base_state = "right";
-	dir = 4;
-	icon_state = "right";
-	name = "Security Desk";
-	req_access_txt = "103"
-	},
-/turf/open/floor/mineral/plastitanium,
-/area/centcom/evac)
-"GW" = (
-/obj/docking_port/stationary{
-	dir = 4;
-	dwidth = 1;
-	height = 4;
-	id = "pod2_away";
-	name = "recovery ship";
-	width = 3
-	},
-/turf/open/space,
-/area/space)
-"GX" = (
-/turf/closed/indestructible/abductor{
-	icon_state = "alien6"
-	},
-/area/abductor_ship)
-"GY" = (
-/turf/closed/indestructible/abductor{
-	icon_state = "alien7"
-	},
-/area/abductor_ship)
-"GZ" = (
-/obj/machinery/abductor/gland_dispenser,
-/turf/open/floor/plating/abductor,
-/area/abductor_ship)
-"Ha" = (
-/obj/structure/table/abductor,
-/obj/item/surgicaldrill/alien,
-/obj/item/circular_saw/alien,
-/turf/open/floor/plating/abductor,
-/area/abductor_ship)
-"Hb" = (
-/obj/structure/bed/abductor,
-/turf/open/floor/plating/abductor,
-/area/abductor_ship)
-"Hc" = (
-/turf/closed/indestructible/abductor{
-	icon_state = "alien8"
-	},
-/area/abductor_ship)
-"Hd" = (
-/turf/closed/indestructible/abductor{
-	icon_state = "alien9"
-	},
-/area/abductor_ship)
-"He" = (
-/turf/closed/indestructible/abductor,
-/area/abductor_ship)
-"Hf" = (
-/turf/closed/indestructible/abductor{
-	icon_state = "alien2"
-	},
-/area/abductor_ship)
-"Hg" = (
-/turf/closed/indestructible/abductor{
-	icon_state = "alien3"
-	},
-/area/abductor_ship)
-"Hh" = (
-/turf/closed/indestructible/abductor{
-	icon_state = "alien4"
-	},
-/area/abductor_ship)
-"Hi" = (
-/turf/closed/indestructible/abductor{
-	icon_state = "alien5"
-	},
-/area/abductor_ship)
-"Hj" = (
-/obj/structure/bed,
-/turf/open/floor/mineral/titanium/blue,
-/area/centcom/evac)
-"Hk" = (
-/obj/effect/spawner/structure/window/shuttle,
-/turf/open/floor/plating,
-/area/centcom/evac)
-"Hl" = (
-/obj/machinery/door/airlock/titanium,
-/turf/open/floor/mineral/titanium/yellow,
-/area/centcom/evac)
-"Hm" = (
-/obj/docking_port/stationary{
-	dir = 4;
-	dwidth = 2;
-	height = 7;
-	id = "pod1_away";
-	name = "recovery ship";
-	width = 5
-	},
-/turf/open/space,
-/area/space)
-"Hn" = (
-/obj/machinery/abductor/experiment{
-	team_number = 2
-	},
-/turf/open/floor/plating/abductor,
-/area/abductor_ship)
-"Ho" = (
-/obj/machinery/abductor/console{
-	team_number = 2
-	},
-/turf/open/floor/plating/abductor,
-/area/abductor_ship)
-"Hp" = (
-/obj/machinery/abductor/pad{
-	team_number = 2
-	},
-/turf/open/floor/plating/abductor,
-/area/abductor_ship)
-"Hq" = (
-/obj/machinery/abductor/experiment{
-	team_number = 3
-	},
-/turf/open/floor/plating/abductor,
-/area/abductor_ship)
-"Hr" = (
-/obj/machinery/abductor/console{
-	team_number = 3
-	},
-/turf/open/floor/plating/abductor,
-/area/abductor_ship)
-"Hs" = (
-/obj/machinery/abductor/pad{
-	team_number = 3
-	},
-/turf/open/floor/plating/abductor,
-/area/abductor_ship)
-"Ht" = (
-/obj/machinery/computer/camera_advanced/abductor{
-	team_number = 2
-	},
-/turf/open/floor/plating/abductor,
-/area/abductor_ship)
-"Hu" = (
-/obj/machinery/computer/camera_advanced/abductor{
-	team_number = 3
-	},
-/turf/open/floor/plating/abductor,
-/area/abductor_ship)
-"Hv" = (
-/obj/structure/table,
-/obj/structure/bedsheetbin,
-/turf/open/floor/mineral/titanium/blue,
-/area/centcom/evac)
-"Hw" = (
-/obj/structure/table,
-/obj/item/hand_labeler,
-/obj/machinery/light,
-/turf/open/floor/mineral/titanium/blue,
-/area/centcom/evac)
-"Hx" = (
-/obj/structure/table,
-/obj/item/storage/box/donkpockets,
-/turf/open/floor/mineral/titanium/blue,
-/area/centcom/evac)
-"Hy" = (
-/obj/effect/landmark/abductor/scientist{
-	team_number = 2
-	},
-/turf/open/floor/plating/abductor,
-/area/abductor_ship)
-"Hz" = (
-/obj/effect/landmark/abductor/agent{
-	team_number = 2
-	},
-/turf/open/floor/plating/abductor,
-/area/abductor_ship)
-"HA" = (
-/obj/effect/landmark/abductor/scientist{
-	team_number = 3
-	},
-/turf/open/floor/plating/abductor,
-/area/abductor_ship)
-"HB" = (
-/obj/effect/landmark/abductor/agent{
-	team_number = 3
-	},
-/turf/open/floor/plating/abductor,
-/area/abductor_ship)
-"HC" = (
-/obj/machinery/door/airlock/titanium{
-	name = "Cockpit";
-	req_access_txt = "109"
-	},
-/turf/open/floor/mineral/titanium/yellow,
-/area/centcom/evac)
-"HD" = (
-/obj/structure/table,
-/obj/item/device/radio/off,
-/turf/open/floor/mineral/titanium/blue,
-/area/centcom/evac)
-"HE" = (
-/obj/structure/chair{
-	dir = 4;
-	name = "Prosecution"
-	},
-/turf/open/floor/mineral/titanium/blue,
-/area/centcom/evac)
-"HF" = (
-/obj/structure/filingcabinet,
-/turf/open/floor/mineral/titanium/blue,
-/area/centcom/evac)
-"HG" = (
-/obj/structure/chair,
-/turf/open/floor/mineral/titanium/blue,
-/area/centcom/evac)
-"HH" = (
-/obj/structure/table,
-/obj/item/storage/lockbox,
-/turf/open/floor/mineral/titanium/blue,
-/area/centcom/evac)
-"HI" = (
-/obj/structure/table,
-/turf/open/floor/mineral/titanium/blue,
-/area/centcom/evac)
-"HJ" = (
-/obj/machinery/computer/shuttle,
-/turf/open/floor/mineral/titanium/blue,
-/area/centcom/evac)
-"HK" = (
-/obj/structure/table,
-/obj/item/clipboard,
-/obj/item/pen,
-/turf/open/floor/mineral/titanium/blue,
-/area/centcom/evac)
-"HL" = (
-/obj/structure/table,
-/obj/item/paper_bin,
-/turf/open/floor/mineral/titanium/blue,
-/area/centcom/evac)
-"HM" = (
-/turf/closed/indestructible/riveted,
-/area/awaymission/errorroom)
-"HN" = (
-/turf/closed/mineral/ash_rock,
-/area/awaymission/errorroom)
-"HO" = (
-/obj/structure/speaking_tile,
-/turf/closed/mineral/ash_rock,
-/area/awaymission/errorroom)
-"HP" = (
-/obj/item/rupee,
-/turf/open/floor/plating/ashplanet/wateryrock{
-	initial_gas_mix = "o2=22;n2=82;TEMP=293.15";
-	planetary_atmos = 0
-	},
-/area/awaymission/errorroom)
-"HQ" = (
-/turf/open/floor/plating/ashplanet/wateryrock{
-	initial_gas_mix = "o2=22;n2=82;TEMP=293.15";
-	planetary_atmos = 0
-	},
-/area/awaymission/errorroom)
-"HR" = (
-/obj/effect/landmark/error,
-/turf/open/floor/plating/ashplanet/wateryrock{
-	initial_gas_mix = "o2=22;n2=82;TEMP=293.15";
-	planetary_atmos = 0
-	},
-/area/awaymission/errorroom)
-"HS" = (
-/obj/structure/signpost/salvation{
-	icon = 'icons/obj/structures.dmi';
-	icon_state = "ladder10";
-	invisibility = 100
-	},
-/turf/open/floor/plating/ashplanet/wateryrock{
-	initial_gas_mix = "o2=22;n2=82;TEMP=293.15";
-	planetary_atmos = 0
-	},
-/area/awaymission/errorroom)
-"HT" = (
-/obj/structure/lattice,
-/turf/open/space,
-/area/space)
-"HU" = (
-/obj/machinery/door/airlock/external,
-/turf/open/floor/plasteel/vault{
-	dir = 8
-	},
-/area/centcom/control)
-"HV" = (
-/obj/effect/turf_decal/delivery,
-/turf/open/floor/plasteel,
-/area/centcom/evac)
-"HW" = (
-/obj/structure/table/reinforced,
-/obj/item/stack/medical/gauze,
-/obj/item/stack/medical/bruise_pack,
-/obj/item/stack/medical/ointment,
-/turf/open/floor/plasteel/vault{
-	dir = 8
-	},
-/area/shuttle/syndicate/medical)
-"Ic" = (
-/obj/structure/shuttle/engine/heater,
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/obj/effect/turf_decal/stripes/line,
-/turf/open/floor/plating/airless,
-/area/shuttle/syndicate/medical)
-"Id" = (
-/obj/item/retractor,
-/obj/item/hemostat,
-/obj/structure/table/reinforced,
-/turf/open/floor/plasteel/vault{
-	dir = 8
-	},
-/area/shuttle/syndicate/medical)
-"Ih" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 6
-	},
-/turf/open/floor/plasteel,
-/area/centcom/evac)
-"Ij" = (
-/obj/effect/turf_decal/bot,
-/turf/open/floor/plasteel,
-/area/tdome/arena_source)
-"Il" = (
-/obj/effect/turf_decal/delivery,
-/turf/open/floor/plasteel,
-/area/tdome/arena_source)
-"Im" = (
-/turf/open/floor/plasteel/neutral/side{
-	dir = 4
-	},
-/area/tdome/arena_source)
-"In" = (
-/turf/open/floor/plasteel/neutral,
-/area/tdome/arena_source)
-"Is" = (
-/obj/machinery/computer/crew/syndie,
-/turf/open/floor/plasteel/vault{
-	dir = 8
-	},
-/area/shuttle/syndicate/bridge)
-"Iu" = (
-/turf/open/floor/plasteel/neutral/side{
-	dir = 8
-	},
-/area/tdome/arena_source)
-"Iw" = (
-/turf/open/floor/plasteel/red/corner{
-	dir = 1
-	},
-/area/tdome/arena_source)
-"ID" = (
-/turf/open/floor/plasteel/vault{
-	dir = 5
-	},
-/area/shuttle/syndicate/armory)
-"II" = (
-/turf/open/floor/plasteel/green/corner{
-	dir = 4
-	},
-/area/tdome/arena_source)
-"IJ" = (
-/turf/open/floor/plasteel/loadingarea{
-	dir = 4
-	},
-/area/tdome/arena_source)
-"IS" = (
-/turf/open/floor/plasteel/loadingarea{
-	dir = 8
-	},
-/area/tdome/arena_source)
-"IY" = (
-/obj/machinery/camera{
-	pixel_x = 10;
-	network = list("thunder");
-	c_tag = "Arena"
-	},
-/turf/open/floor/circuit/green,
-/area/tdome/arena_source)
-"IZ" = (
-/obj/structure/table/optable,
-/obj/item/surgical_drapes,
-/turf/open/floor/plasteel/vault{
-	dir = 8
-	},
-/area/shuttle/syndicate/medical)
-"Jb" = (
-/obj/structure/shuttle/engine/heater,
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/obj/effect/turf_decal/stripes/line,
-/turf/open/floor/plating/airless,
-/area/shuttle/syndicate/armory)
-"Je" = (
-/turf/open/floor/plasteel/red/corner{
-	dir = 8
-	},
-/area/tdome/arena_source)
-"Jg" = (
-/obj/machinery/sleeper/syndie{
-	dir = 4
-	},
-/turf/open/floor/plasteel/vault{
-	dir = 8
-	},
-/area/shuttle/syndicate/medical)
-"Jh" = (
-/obj/machinery/porta_turret/syndicate{
-	dir = 4
-	},
-/turf/closed/wall/mineral/plastitanium,
-/area/shuttle/syndicate/hallway)
-"Jk" = (
-/obj/structure/bed/roller,
-/obj/machinery/iv_drip,
-/turf/open/floor/plasteel/vault{
-	dir = 8
-	},
-/area/shuttle/syndicate/medical)
-"Jm" = (
-/obj/structure/table/reinforced,
-/obj/item/reagent_containers/glass/beaker/large,
-/obj/item/reagent_containers/glass/beaker,
-/obj/item/reagent_containers/dropper,
-/turf/open/floor/plasteel/vault{
-	dir = 8
-	},
-/area/shuttle/syndicate/medical)
-"Jn" = (
-/obj/structure/shuttle/engine/propulsion/left,
-/obj/effect/turf_decal/stripes/line,
-/turf/open/floor/plating/airless,
-/area/shuttle/syndicate/hallway)
-"Jq" = (
-/turf/open/floor/plasteel/green/corner,
-/area/tdome/arena_source)
-"Js" = (
-/turf/open/floor/plasteel/podhatch{
-	dir = 5
-	},
-/area/shuttle/syndicate/armory)
-"Jz" = (
-/turf/closed/wall/mineral/plastitanium,
-/area/shuttle/syndicate/armory)
-"JC" = (
+"vo" = (
 /obj/machinery/suit_storage_unit/syndicate,
 /turf/open/floor/plasteel/podhatch{
-	dir = 6
-	},
-/area/shuttle/syndicate/eva)
-"JE" = (
-/obj/machinery/light,
-/turf/open/floor/plating,
-/area/syndicate_mothership/control)
-"JG" = (
-/obj/machinery/light{
-	dir = 8
-	},
-/turf/open/floor/plating,
-/area/syndicate_mothership/control)
-"JH" = (
-/obj/machinery/light{
 	dir = 4
 	},
-/turf/open/floor/plasteel/bar{
-	dir = 2
-	},
-/area/syndicate_mothership/control)
-"JI" = (
-/obj/machinery/light{
+/area/shuttle/syndicate/eva)
+"vp" = (
+/obj/structure/tank_dispenser/oxygen,
+/turf/open/floor/plasteel/vault{
 	dir = 8
 	},
-/turf/open/floor/plasteel/bar{
-	dir = 2
-	},
-/area/syndicate_mothership/control)
-"JJ" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 2
-	},
-/obj/machinery/light{
-	dir = 1
-	},
-/turf/open/floor/plating/airless,
-/area/syndicate_mothership/control)
-"JK" = (
-/obj/machinery/status_display,
+/area/shuttle/syndicate/eva)
+"vq" = (
 /turf/closed/wall/mineral/plastitanium,
-/area/shuttle/syndicate/armory)
-"JL" = (
-/obj/machinery/light,
-/turf/open/floor/wood,
-/area/syndicate_mothership/control)
-"JM" = (
-/obj/machinery/light,
-/turf/open/floor/plasteel/bar{
-	dir = 2
-	},
-/area/syndicate_mothership/control)
-"JN" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/obj/machinery/light,
-/turf/open/floor/plating/airless,
-/area/syndicate_mothership/control)
-"JO" = (
-/obj/machinery/light/small{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/centcom/evac)
-"JP" = (
-/obj/machinery/light/small{
-	dir = 8
-	},
-/turf/open/floor/plating,
-/area/centcom/evac)
-"JQ" = (
-/obj/machinery/light{
-	dir = 8
-	},
-/turf/open/floor/mineral/titanium/blue,
-/area/centcom/evac)
-"JR" = (
-/obj/machinery/light{
-	dir = 4
-	},
-/turf/open/floor/mineral/titanium/blue,
-/area/centcom/evac)
-"JS" = (
-/obj/machinery/light{
-	dir = 8
-	},
-/turf/open/floor/mineral/titanium/yellow,
-/area/centcom/evac)
-"JT" = (
-/obj/structure/bed,
-/obj/machinery/light{
-	dir = 8
-	},
-/turf/open/floor/mineral/titanium/blue,
-/area/centcom/evac)
-"JU" = (
-/obj/structure/table,
-/obj/item/storage/box/donkpockets,
-/obj/machinery/light{
-	dir = 8
-	},
-/turf/open/floor/mineral/titanium/blue,
-/area/centcom/evac)
-"JV" = (
-/obj/structure/table,
-/obj/item/device/radio/off,
-/obj/machinery/light{
-	dir = 4
-	},
-/turf/open/floor/mineral/titanium/blue,
-/area/centcom/evac)
-"JW" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 9
-	},
-/obj/machinery/light{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/centcom/control)
-"JX" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 5
-	},
-/obj/machinery/light{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/centcom/control)
-"JY" = (
-/obj/machinery/light{
-	dir = 1
-	},
-/turf/open/floor/plasteel/brown{
-	dir = 1
-	},
-/area/centcom/supply)
-"JZ" = (
-/obj/machinery/light{
-	dir = 4
-	},
-/turf/open/floor/plasteel/brown{
-	dir = 4
-	},
-/area/centcom/supply)
-"Kb" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/obj/machinery/light{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/centcom/control)
-"Kc" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/obj/machinery/light{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/centcom/control)
-"Kd" = (
-/obj/machinery/light,
-/turf/open/floor/plasteel/brown,
-/area/centcom/supply)
-"Ke" = (
-/obj/machinery/light{
-	dir = 8
-	},
-/turf/open/floor/plasteel/vault{
-	dir = 8
-	},
-/area/centcom/control)
-"Kg" = (
-/obj/item/toy/figure/syndie,
-/obj/effect/light_emitter{
-	set_cap = 1;
-	set_luminosity = 4
-	},
-/turf/open/floor/plating/asteroid/snow/airless,
-/area/syndicate_mothership)
-"Ki" = (
-/turf/open/floor/plasteel/podhatch{
-	dir = 10
-	},
-/area/shuttle/syndicate/medical)
-"Kj" = (
-/obj/structure/flora/grass/both,
-/obj/effect/light_emitter{
-	set_cap = 1;
-	set_luminosity = 4
-	},
-/turf/open/floor/plating/asteroid/snow/airless,
-/area/syndicate_mothership)
-"Kk" = (
-/obj/structure/chair{
-	dir = 4
-	},
-/obj/machinery/light{
-	dir = 8
-	},
-/turf/open/floor/plasteel/brown{
-	dir = 8
-	},
-/area/centcom/control)
-"Kl" = (
-/obj/effect/light_emitter{
-	set_cap = 1;
-	set_luminosity = 4
-	},
-/turf/open/floor/plating/asteroid/snow/airless,
-/area/syndicate_mothership)
-"Km" = (
-/obj/effect/turf_decal/stripes/line,
-/obj/machinery/light,
-/turf/open/floor/plasteel,
-/area/centcom/control)
-"Ko" = (
-/obj/structure/flora/tree/pine,
-/obj/effect/light_emitter{
-	set_cap = 1;
-	set_luminosity = 4
-	},
-/turf/open/floor/plating/asteroid/snow/airless,
-/area/syndicate_mothership)
-"Kq" = (
-/obj/structure/flora/ausbushes/lavendergrass,
-/obj/structure/flora/ausbushes/sparsegrass,
-/obj/structure/flora/ausbushes/fullgrass,
-/obj/structure/flora/ausbushes/grassybush,
-/obj/structure/flora/ausbushes/ppflowers,
-/obj/structure/flora/ausbushes/pointybush,
-/obj/machinery/light{
-	dir = 1
-	},
-/turf/open/floor/grass,
-/area/centcom/evac)
-"Ks" = (
-/obj/structure/flora/ausbushes/lavendergrass,
-/obj/structure/flora/ausbushes/fullgrass,
-/obj/structure/flora/ausbushes/ywflowers,
-/obj/structure/flora/ausbushes/grassybush,
-/obj/structure/flora/ausbushes/palebush,
-/obj/machinery/light{
-	dir = 1
-	},
-/turf/open/floor/plating/asteroid,
-/area/centcom/evac)
-"Kt" = (
-/obj/structure/flora/ausbushes/sparsegrass,
-/obj/structure/flora/ausbushes/lavendergrass,
-/obj/structure/flora/ausbushes/fernybush,
-/obj/machinery/light{
-	dir = 4
-	},
-/turf/open/floor/plasteel{
-	name = "plating";
-	icon_state = "asteroid5"
-	},
-/area/centcom/control)
-"Ku" = (
-/obj/structure/flora/ausbushes/lavendergrass,
-/obj/structure/flora/ausbushes/sparsegrass,
-/obj/structure/flora/ausbushes/fullgrass,
-/obj/structure/flora/ausbushes/brflowers,
-/obj/structure/flora/ausbushes/genericbush,
-/obj/machinery/light{
-	dir = 8
-	},
-/turf/open/floor/grass,
-/area/centcom/control)
-"Kv" = (
-/obj/machinery/light{
-	dir = 8
-	},
-/turf/open/floor/engine/cult,
-/area/wizard_station)
-"Kw" = (
-/obj/machinery/light{
-	dir = 4
-	},
-/turf/open/floor/engine/cult,
-/area/wizard_station)
-"KA" = (
-/turf/open/floor/plasteel/vault,
-/area/shuttle/syndicate/armory)
-"KD" = (
-/obj/structure/chair,
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/obj/machinery/light{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/centcom/evac)
-"KE" = (
-/turf/open/floor/plasteel/podhatch{
-	dir = 9
-	},
-/area/shuttle/syndicate/medical)
-"KG" = (
-/obj/structure/flora/ausbushes/lavendergrass,
-/obj/structure/flora/ausbushes/sparsegrass,
-/obj/structure/flora/ausbushes/ywflowers,
-/obj/structure/flora/ausbushes/grassybush,
-/obj/structure/flora/ausbushes/palebush,
-/obj/machinery/light,
-/turf/open/floor/plating/asteroid,
-/area/centcom/evac)
-"KK" = (
-/obj/structure/chair{
-	dir = 4
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/obj/machinery/light{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/centcom/evac)
-"KL" = (
-/obj/machinery/light{
-	dir = 1
-	},
-/turf/open/floor/plasteel/green/corner{
-	dir = 4
-	},
-/area/centcom/ferry)
-"KM" = (
-/obj/machinery/light/small{
-	brightness = 3;
-	dir = 8
-	},
-/turf/open/floor/engine/cult,
-/area/wizard_station)
-"KN" = (
-/obj/machinery/light/small{
-	dir = 4
-	},
-/turf/open/floor/engine/cult,
-/area/wizard_station)
-"KO" = (
-/obj/machinery/light,
-/turf/open/floor/wood,
-/area/wizard_station)
-"KP" = (
-/obj/effect/turf_decal/delivery,
-/obj/machinery/light,
-/turf/open/floor/plasteel,
-/area/centcom/ferry)
-"KS" = (
-/obj/machinery/portable_atmospherics/canister/oxygen,
-/obj/machinery/light{
-	dir = 4
-	},
-/turf/open/floor/plasteel/vault{
-	dir = 8
-	},
-/area/shuttle/syndicate/eva)
-"KT" = (
-/obj/structure/chair{
-	dir = 1
-	},
-/obj/effect/turf_decal/stripes/line,
-/obj/machinery/light,
-/turf/open/floor/plasteel,
-/area/centcom/evac)
-"KW" = (
-/obj/machinery/light,
-/turf/open/floor/engine/cult,
-/area/wizard_station)
-"KZ" = (
-/obj/structure/flora/ausbushes/lavendergrass,
-/obj/structure/flora/ausbushes/sparsegrass,
-/obj/structure/flora/ausbushes/fullgrass,
-/obj/structure/flora/ausbushes/brflowers,
-/obj/structure/flora/ausbushes/genericbush,
-/obj/machinery/light,
-/turf/open/floor/grass,
-/area/centcom/evac)
-"La" = (
-/obj/machinery/light{
-	dir = 1
-	},
-/turf/open/floor/engine/cult,
-/area/wizard_station)
-"Lc" = (
-/obj/machinery/light{
-	dir = 4
-	},
-/turf/open/floor/plasteel/vault{
-	dir = 5
-	},
-/area/centcom/evac)
-"Ld" = (
-/obj/machinery/light{
-	dir = 1
-	},
-/turf/open/floor/plasteel/vault{
-	dir = 8
-	},
-/area/centcom/control)
-"Le" = (
-/obj/machinery/light,
-/turf/open/floor/plasteel/vault{
-	dir = 5
-	},
-/area/centcom/evac)
-"Lf" = (
-/obj/structure/chair/office/dark{
-	dir = 8;
-	name = "tactical swivel chair"
-	},
-/turf/open/floor/plasteel/black,
-/area/shuttle/syndicate/bridge)
-"Lg" = (
-/obj/machinery/light/small{
-	brightness = 3;
-	dir = 8
-	},
-/turf/open/floor/carpet,
-/area/wizard_station)
-"Lh" = (
-/obj/machinery/light/small{
-	dir = 4
-	},
-/turf/open/floor/carpet,
-/area/wizard_station)
-"Li" = (
-/obj/machinery/light/small{
-	dir = 4
-	},
-/turf/open/floor/plasteel/white,
-/area/wizard_station)
-"Lj" = (
-/obj/structure/closet/crate/bin,
-/obj/machinery/light{
-	dir = 4
-	},
-/turf/open/floor/plasteel/vault{
-	dir = 8
-	},
-/area/tdome/tdomeobserve)
-"Lk" = (
-/obj/machinery/light,
-/turf/open/floor/plasteel/neutral/side{
-	dir = 1;
-	heat_capacity = 1e+006
-	},
-/area/tdome/tdomeobserve)
-"Lm" = (
-/obj/machinery/light{
-	dir = 8
-	},
-/turf/open/floor/plasteel/red/side{
-	dir = 4
-	},
-/area/tdome/tdomeobserve)
-"Ln" = (
-/obj/machinery/light{
-	dir = 4
-	},
-/turf/open/floor/plasteel/green/side{
-	dir = 8
-	},
-/area/tdome/tdomeobserve)
-"Lo" = (
-/obj/structure/flora/ausbushes/lavendergrass,
-/obj/structure/flora/ausbushes/fullgrass,
-/obj/structure/flora/ausbushes/ywflowers,
-/obj/structure/flora/ausbushes/grassybush,
-/obj/structure/flora/ausbushes/palebush,
-/obj/machinery/light{
-	dir = 8
-	},
-/turf/open/floor/plating/asteroid,
-/area/tdome/tdomeadmin)
-"Lp" = (
-/obj/structure/flora/ausbushes/sparsegrass,
-/obj/structure/flora/ausbushes/grassybush,
-/obj/structure/flora/ausbushes/fernybush,
-/obj/machinery/light{
-	dir = 4
-	},
-/turf/open/floor/plasteel{
-	dir = 6;
-	icon_state = "asteroid8";
-	name = "sand"
-	},
-/area/tdome/tdomeadmin)
-"Ls" = (
-/obj/machinery/light{
-	dir = 4
-	},
-/turf/open/floor/plasteel/vault{
-	dir = 5
-	},
-/area/tdome/tdomeadmin)
-"Lt" = (
-/obj/machinery/light{
-	dir = 8
-	},
-/turf/open/floor/plasteel/vault{
-	dir = 5
-	},
-/area/tdome/tdomeadmin)
-"Lu" = (
-/obj/structure/flora/ausbushes/lavendergrass,
-/obj/structure/flora/ausbushes/sparsegrass,
-/obj/structure/flora/ausbushes/fullgrass,
-/obj/structure/flora/ausbushes/grassybush,
-/obj/structure/flora/ausbushes/ppflowers,
-/obj/structure/flora/ausbushes/pointybush,
-/obj/machinery/light,
-/turf/open/floor/grass,
-/area/tdome/tdomeadmin)
-"Lw" = (
-/obj/structure/flora/bush,
-/obj/effect/light_emitter{
-	set_cap = 1;
-	set_luminosity = 4
-	},
-/turf/open/floor/plating/asteroid/snow/airless,
-/area/syndicate_mothership)
-"Lx" = (
-/obj/structure/flora/grass/brown,
-/obj/effect/light_emitter{
-	set_cap = 1;
-	set_luminosity = 4
-	},
-/turf/open/floor/plating/asteroid/snow/airless,
-/area/syndicate_mothership)
-"Ly" = (
-/obj/item/device/assembly/signaler,
-/obj/item/device/assembly/signaler,
-/obj/item/device/assembly/prox_sensor{
-	pixel_x = -8;
-	pixel_y = 4
-	},
-/obj/item/device/assembly/prox_sensor{
-	pixel_x = -8;
-	pixel_y = 4
-	},
-/obj/structure/table/reinforced,
-/turf/open/floor/plasteel/vault{
-	dir = 8
-	},
-/area/shuttle/syndicate/armory)
-"Lz" = (
-/obj/machinery/light{
-	dir = 1
-	},
-/turf/open/floor/plating/beach/sand,
-/area/centcom/holding)
-"LA" = (
-/obj/machinery/light,
-/turf/open/floor/plasteel/cafeteria,
-/area/centcom/holding)
-"LB" = (
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/machinery/light,
-/turf/open/floor/plasteel/cafeteria,
-/area/centcom/holding)
-"LF" = (
-/obj/structure/fluff/arc,
-/turf/open/floor/grass,
-/area/centcom/evac)
-"LG" = (
-/obj/machinery/telecomms/allinone{
-	intercept = 1
-	},
-/turf/open/floor/circuit/red,
-/area/shuttle/syndicate/armory)
-"LH" = (
-/obj/structure/flora/ausbushes/ppflowers,
-/obj/structure/flora/ausbushes/lavendergrass,
-/obj/structure/window/reinforced,
-/turf/open/floor/grass,
-/area/centcom/evac)
-"LJ" = (
-/obj/structure/chair/comfy/black{
-	dir = 1
-	},
-/obj/machinery/light,
-/obj/machinery/status_display{
-	pixel_y = -32
-	},
-/turf/open/floor/plasteel/vault{
-	dir = 8
-	},
-/area/centcom/control)
-"LK" = (
-/obj/structure/flora/ausbushes/ppflowers,
-/obj/structure/flora/ausbushes/lavendergrass,
-/turf/open/floor/grass,
-/area/centcom/evac)
-"LL" = (
-/obj/structure/flora/ausbushes/ywflowers,
-/obj/structure/flora/ausbushes/lavendergrass,
-/obj/structure/flora/ausbushes/brflowers,
-/obj/machinery/light{
-	dir = 1
-	},
-/turf/open/floor/grass,
-/area/centcom/evac)
-"LM" = (
-/obj/structure/flora/ausbushes/brflowers,
-/obj/structure/flora/ausbushes/lavendergrass,
-/turf/open/floor/grass,
-/area/centcom/evac)
-"LN" = (
-/obj/structure/flora/ausbushes/lavendergrass,
-/obj/structure/flora/ausbushes/ywflowers,
-/turf/open/floor/grass,
-/area/centcom/evac)
-"LP" = (
-/obj/structure/flora/ausbushes/lavendergrass,
-/obj/structure/flora/ausbushes/brflowers,
-/turf/open/floor/grass,
-/area/centcom/evac)
-"LQ" = (
-/obj/structure/flora/ausbushes/brflowers,
-/obj/structure/flora/ausbushes/lavendergrass,
-/obj/structure/window/reinforced,
-/turf/open/floor/grass,
-/area/centcom/evac)
-"LR" = (
-/obj/structure/flora/ausbushes/ywflowers,
-/obj/structure/flora/ausbushes/lavendergrass,
-/obj/structure/window/reinforced,
-/turf/open/floor/grass,
-/area/centcom/evac)
-"LS" = (
-/obj/effect/turf_decal/delivery,
-/obj/machinery/light{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/centcom/evac)
-"LT" = (
-/obj/effect/turf_decal/stripes/line,
-/obj/structure/closet/crate/bin,
-/turf/open/floor/plasteel,
-/area/centcom/evac)
-"LU" = (
-/obj/effect/turf_decal/delivery,
-/obj/machinery/light,
-/turf/open/floor/plasteel,
-/area/centcom/evac)
-"LW" = (
-/obj/structure/table/reinforced,
-/obj/item/storage/box/handcuffs,
-/turf/open/floor/plasteel/vault{
-	dir = 8
-	},
-/area/centcom/evac)
-"LX" = (
-/obj/structure/flora/ausbushes/lavendergrass,
-/obj/structure/flora/ausbushes/fullgrass,
-/obj/structure/flora/ausbushes/ywflowers,
-/obj/structure/flora/ausbushes/grassybush,
-/obj/structure/flora/ausbushes/palebush,
-/turf/open/floor/plating/asteroid,
-/area/centcom/evac)
-"LY" = (
-/obj/structure/fans/tiny,
-/turf/open/floor/plasteel/vault{
-	dir = 8
-	},
-/area/centcom/evac)
-"LZ" = (
-/obj/machinery/ai_status_display,
-/turf/closed/indestructible/riveted,
-/area/centcom/evac)
-"Mb" = (
-/obj/machinery/door/airlock/centcom{
-	name = "CentCom Security";
-	opacity = 1;
-	req_access_txt = "101"
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 2
-	},
-/turf/open/floor/plasteel,
-/area/centcom/evac)
-"Mc" = (
-/turf/closed/indestructible/fakedoor{
-	name = "CentCom"
-	},
-/area/centcom/evac)
-"Md" = (
-/obj/machinery/computer/emergency_shuttle,
-/turf/open/floor/mineral/titanium,
-/area/shuttle/escape)
-"Me" = (
-/obj/machinery/light{
-	dir = 8
-	},
-/turf/open/floor/mineral/titanium,
-/area/shuttle/escape)
-"Mf" = (
-/obj/machinery/light{
-	dir = 4
-	},
-/turf/open/floor/mineral/titanium,
-/area/shuttle/escape)
-"Mg" = (
-/obj/item/cardboard_cutout{
-	desc = "They seem to be ignoring you... Typical.";
-	dir = 1;
-	icon_state = "cutout_ntsec";
-	name = "Private Security Officer"
-	},
-/turf/open/floor/plasteel/darkred/side{
-	dir = 1
-	},
-/area/centcom/evac)
-"Mh" = (
-/obj/item/cardboard_cutout{
-	desc = "They seem to be ignoring you... Typical.";
-	icon_state = "cutout_ntsec";
-	name = "Private Security Officer"
-	},
-/turf/open/floor/plasteel/vault{
-	dir = 5
-	},
-/area/centcom/evac)
-"Mi" = (
-/turf/closed/wall/mineral/titanium/nodiagonal,
-/area/centcom/evac)
-"Mk" = (
-/obj/structure/window/plastitanium,
-/turf/open/floor/plasteel/vault{
-	dir = 5
-	},
 /area/shuttle/syndicate/airlock)
-"Mz" = (
-/obj/structure/shuttle/engine/propulsion/right,
-/obj/effect/turf_decal/stripes/line,
-/turf/open/floor/plating/airless,
-/area/shuttle/syndicate/hallway)
-"MI" = (
-/obj/item/storage/toolbox/syndicate,
-/obj/item/crowbar/red,
-/obj/structure/table/reinforced,
-/obj/machinery/light{
-	dir = 8
-	},
-/turf/open/floor/plasteel/podhatch{
-	dir = 10
-	},
-/area/shuttle/syndicate/airlock)
-"MZ" = (
+"vr" = (
 /obj/docking_port/stationary{
 	area_type = /area/syndicate_mothership;
 	baseturf_type = /turf/open/floor/plating/asteroid/snow;
@@ -13688,318 +8123,7 @@
 	dir = 1
 	},
 /area/shuttle/syndicate/airlock)
-"Nc" = (
-/obj/structure/window/plastitanium,
-/turf/open/floor/plasteel/vault{
-	dir = 8
-	},
-/area/shuttle/syndicate/medical)
-"Nk" = (
-/turf/closed/wall/mineral/plastitanium,
-/area/shuttle/syndicate/hallway)
-"Ns" = (
-/obj/machinery/nuclearbomb/syndicate,
-/obj/machinery/door/window{
-	dir = 1;
-	name = "Theatre Stage";
-	req_access_txt = "0"
-	},
-/turf/open/floor/circuit/red,
-/area/shuttle/syndicate/hallway)
-"NH" = (
-/obj/structure/table/reinforced,
-/obj/machinery/status_display{
-	pixel_x = -32
-	},
-/obj/item/clipboard,
-/obj/machinery/light{
-	dir = 8
-	},
-/obj/item/folder/red,
-/obj/item/toy/figure/syndie,
-/turf/open/floor/plasteel/vault{
-	dir = 8
-	},
-/area/shuttle/syndicate/bridge)
-"NJ" = (
-/obj/machinery/door/airlock/external{
-	name = "E.V.A. Gear Storage";
-	req_access_txt = "150"
-	},
-/turf/open/floor/plasteel/vault{
-	dir = 8
-	},
-/area/shuttle/syndicate/eva)
-"NQ" = (
-/obj/machinery/door/window{
-	dir = 1;
-	name = "Technological Storage";
-	req_access_txt = "150"
-	},
-/turf/open/floor/plasteel/vault,
-/area/shuttle/syndicate/armory)
-"NV" = (
-/turf/open/floor/plasteel/podhatch{
-	dir = 1
-	},
-/area/shuttle/syndicate/hallway)
-"Om" = (
-/obj/structure/chair{
-	dir = 8;
-	name = "tactical chair"
-	},
-/turf/open/floor/plasteel/vault{
-	dir = 5
-	},
-/area/shuttle/syndicate/hallway)
-"Os" = (
-/obj/machinery/recharge_station,
-/turf/open/floor/circuit/red,
-/area/shuttle/syndicate/armory)
-"Ou" = (
-/turf/closed/wall/mineral/plastitanium,
-/area/shuttle/syndicate/eva)
-"Oz" = (
-/obj/structure/shuttle/engine/propulsion,
-/obj/effect/turf_decal/stripes/line,
-/turf/open/floor/plating/airless,
-/area/shuttle/syndicate/medical)
-"OQ" = (
-/obj/structure/closet/syndicate/personal,
-/turf/open/floor/plasteel/vault{
-	dir = 8
-	},
-/area/shuttle/syndicate/armory)
-"OS" = (
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/obj/structure/table/reinforced,
-/obj/item/device/aicard,
-/turf/open/floor/plasteel/vault,
-/area/shuttle/syndicate/armory)
-"OT" = (
-/obj/structure/table/reinforced,
-/obj/item/stack/cable_coil/white,
-/obj/item/stack/cable_coil/white,
-/obj/item/crowbar/red,
-/turf/open/floor/plasteel/vault{
-	dir = 5
-	},
-/area/shuttle/syndicate/hallway)
-"Pa" = (
-/obj/machinery/portable_atmospherics/canister/oxygen,
-/turf/open/floor/plasteel/vault{
-	dir = 8
-	},
-/area/shuttle/syndicate/eva)
-"Pd" = (
-/obj/structure/window/plastitanium,
-/obj/machinery/door/poddoor/shutters{
-	id = "syndieshutters";
-	name = "blast shutters"
-	},
-/turf/open/floor/plating,
-/area/shuttle/syndicate/bridge)
-"Pm" = (
-/obj/structure/shuttle/engine/propulsion/right,
-/obj/effect/turf_decal/stripes/line,
-/turf/open/floor/plating/airless,
-/area/shuttle/syndicate/armory)
-"Pt" = (
-/turf/open/floor/plasteel/vault{
-	dir = 5
-	},
-/area/shuttle/syndicate/hallway)
-"Pv" = (
-/obj/machinery/porta_turret/syndicate{
-	dir = 9
-	},
-/turf/closed/wall/mineral/plastitanium,
-/area/shuttle/syndicate/bridge)
-"Qm" = (
-/obj/machinery/light{
-	dir = 1
-	},
-/turf/open/floor/plasteel/vault{
-	dir = 8
-	},
-/area/shuttle/syndicate/medical)
-"Qo" = (
-/obj/machinery/door/airlock/external{
-	req_access_txt = "150"
-	},
-/turf/open/floor/mineral/plastitanium,
-/area/shuttle/syndicate/airlock)
-"Qr" = (
-/obj/machinery/suit_storage_unit/syndicate,
-/turf/open/floor/plasteel/podhatch{
-	dir = 5
-	},
-/area/shuttle/syndicate/eva)
-"Qt" = (
-/obj/machinery/door/window{
-	dir = 1;
-	name = "Surgery";
-	req_access_txt = "150"
-	},
-/turf/open/floor/plasteel/vault,
-/area/shuttle/syndicate/medical)
-"QB" = (
-/obj/structure/tank_dispenser/oxygen,
-/turf/open/floor/plasteel/vault{
-	dir = 8
-	},
-/area/shuttle/syndicate/eva)
-"QH" = (
-/obj/structure/table/wood,
-/obj/item/toy/crayon/white,
-/turf/open/floor/holofloor,
-/area/holodeck/rec_center/school)
-"QI" = (
-/obj/structure/table/wood,
-/obj/item/reagent_containers/food/snacks/grown/apple,
-/turf/open/floor/holofloor,
-/area/holodeck/rec_center/school)
-"QJ" = (
-/obj/structure/table,
-/obj/item/paper,
-/obj/item/pen,
-/obj/item/clothing/under/schoolgirl,
-/turf/open/floor/holofloor,
-/area/holodeck/rec_center/school)
-"QK" = (
-/obj/structure/table,
-/obj/item/paper,
-/obj/item/pen,
-/obj/item/clothing/under/schoolgirl/green,
-/turf/open/floor/holofloor,
-/area/holodeck/rec_center/school)
-"QL" = (
-/obj/structure/chair{
-	dir = 1
-	},
-/turf/open/floor/holofloor,
-/area/holodeck/rec_center/school)
-"QN" = (
-/obj/structure/table,
-/obj/item/paper,
-/obj/item/pen,
-/obj/item/clothing/under/schoolgirl/red,
-/turf/open/floor/holofloor,
-/area/holodeck/rec_center/school)
-"QP" = (
-/obj/structure/window/plastitanium,
-/turf/open/floor/plasteel/vault{
-	dir = 5
-	},
-/area/shuttle/syndicate/medical)
-"QT" = (
-/obj/effect/turf_decal/stripes/corner,
-/turf/open/floor/plating/airless,
-/area/syndicate_mothership/control)
-"QU" = (
-/obj/effect/turf_decal/stripes/line,
-/turf/open/floor/plating/airless,
-/area/syndicate_mothership/control)
-"QV" = (
-/obj/effect/turf_decal/stripes/corner{
-	dir = 1
-	},
-/turf/open/floor/plating/airless,
-/area/syndicate_mothership/control)
-"QX" = (
-/obj/effect/turf_decal/stripes/corner{
-	dir = 4
-	},
-/turf/open/floor/plating/airless,
-/area/syndicate_mothership/control)
-"QY" = (
-/obj/effect/turf_decal/stripes/corner{
-	dir = 8
-	},
-/turf/open/floor/plating/airless,
-/area/syndicate_mothership/control)
-"Rg" = (
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/item/storage/firstaid/regular{
-	pixel_x = 3;
-	pixel_y = 3
-	},
-/obj/item/storage/firstaid/brute,
-/obj/item/storage/firstaid/regular{
-	pixel_x = -3;
-	pixel_y = -3
-	},
-/obj/structure/table/reinforced,
-/turf/open/floor/plasteel/vault,
-/area/shuttle/syndicate/medical)
-"Rj" = (
-/turf/open/floor/plasteel/podhatch{
-	dir = 6
-	},
-/area/shuttle/syndicate/armory)
-"Ru" = (
-/obj/structure/chair{
-	dir = 4;
-	name = "tactical chair"
-	},
-/obj/machinery/light{
-	dir = 8
-	},
-/turf/open/floor/plasteel/vault{
-	dir = 5
-	},
-/area/shuttle/syndicate/hallway)
-"Rx" = (
-/obj/structure/shuttle/engine/propulsion/left,
-/obj/effect/turf_decal/stripes/line,
-/turf/open/floor/plating/airless,
-/area/shuttle/syndicate/medical)
-"RD" = (
-/turf/open/floor/plasteel/podhatch,
-/area/shuttle/syndicate/hallway)
-"RF" = (
-/obj/machinery/light{
-	dir = 8
-	},
-/turf/open/floor/plasteel/vault{
-	dir = 5
-	},
-/area/shuttle/syndicate/hallway)
-"RJ" = (
-/obj/item/grenade/syndieminibomb{
-	pixel_x = 4;
-	pixel_y = 2
-	},
-/obj/item/grenade/syndieminibomb{
-	pixel_x = -1
-	},
-/obj/structure/table/reinforced,
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/item/grenade/plastic/c4,
-/obj/item/grenade/plastic/c4,
-/obj/item/grenade/plastic/c4,
-/obj/item/grenade/plastic/c4,
-/obj/item/grenade/plastic/c4,
-/turf/open/floor/plasteel/vault{
-	dir = 8
-	},
-/area/shuttle/syndicate/armory)
-"RK" = (
-/obj/machinery/door/airlock/external{
-	name = "Ready Room";
-	req_access_txt = "150"
-	},
-/turf/open/floor/plasteel/vault{
-	dir = 8
-	},
-/area/shuttle/syndicate/hallway)
-"RR" = (
+"vs" = (
 /obj/structure/sign/securearea{
 	desc = "A warning sign which reads 'EXTERNAL AIRLOCK'";
 	icon_state = "space";
@@ -14008,186 +8132,854 @@
 	},
 /turf/closed/wall/mineral/plastitanium,
 /area/shuttle/syndicate/airlock)
-"RS" = (
-/turf/open/floor/plasteel/podhatch,
-/area/shuttle/syndicate/armory)
-"RT" = (
-/turf/open/floor/plasteel/vault{
-	dir = 8
-	},
-/area/shuttle/syndicate/medical)
-"Sb" = (
-/obj/structure/closet/syndicate/nuclear,
-/turf/open/floor/plasteel/vault{
-	dir = 8
-	},
-/area/shuttle/syndicate/armory)
-"Se" = (
-/turf/closed/wall/mineral/plastitanium/nodiagonal,
-/area/shuttle/syndicate/armory)
-"Sg" = (
+"vt" = (
 /obj/machinery/porta_turret/syndicate{
-	dir = 10
-	},
-/turf/closed/wall/mineral/plastitanium,
-/area/shuttle/syndicate/hallway)
-"So" = (
-/turf/open/floor/plasteel/black,
-/area/shuttle/syndicate/bridge)
-"Sr" = (
-/obj/structure/chair/office/dark{
-	dir = 1;
-	name = "tactical swivel chair"
-	},
-/obj/machinery/button/door{
-	id = "syndieshutters";
-	name = "Cockpit View Control";
-	pixel_x = 32;
-	pixel_y = 32;
-	req_access_txt = "150"
-	},
-/turf/open/floor/plasteel/black,
-/area/shuttle/syndicate/bridge)
-"Su" = (
-/obj/machinery/porta_turret/syndicate{
-	dir = 10
-	},
-/turf/closed/wall/mineral/plastitanium,
-/area/shuttle/syndicate/armory)
-"Sx" = (
-/turf/open/floor/plasteel/vault{
-	dir = 8
-	},
-/area/shuttle/syndicate/eva)
-"SA" = (
-/obj/machinery/computer/secure_data/syndie,
-/turf/open/floor/plasteel/vault{
-	dir = 8
-	},
-/area/shuttle/syndicate/bridge)
-"SC" = (
-/obj/machinery/porta_turret/syndicate{
-	dir = 9
-	},
-/turf/closed/wall/mineral/plastitanium,
-/area/shuttle/syndicate/medical)
-"SD" = (
-/obj/item/storage/firstaid/regular{
-	pixel_x = 3;
-	pixel_y = 3
-	},
-/obj/item/storage/firstaid/fire,
-/obj/item/storage/firstaid/regular{
-	pixel_x = -3;
-	pixel_y = -3
-	},
-/obj/structure/table/reinforced,
-/turf/open/floor/plasteel/vault,
-/area/shuttle/syndicate/medical)
-"Tg" = (
-/obj/machinery/suit_storage_unit/syndicate,
-/turf/open/floor/plasteel/podhatch{
-	dir = 4
-	},
-/area/shuttle/syndicate/eva)
-"Tl" = (
-/obj/structure/window/plastitanium,
-/turf/open/floor/plasteel/vault{
 	dir = 5
 	},
-/area/shuttle/syndicate/eva)
-"Tm" = (
-/obj/machinery/status_display,
 /turf/closed/wall/mineral/plastitanium,
-/area/shuttle/syndicate/bridge)
-"Tt" = (
-/obj/machinery/ai_status_display,
+/area/shuttle/syndicate/airlock)
+"vu" = (
+/obj/item/storage/box/drinkingglasses,
+/obj/item/reagent_containers/food/drinks/bottle/rum,
+/obj/structure/table/wood,
+/turf/open/floor/wood,
+/area/syndicate_mothership/control)
+"vv" = (
+/obj/structure/table/wood,
+/turf/open/floor/wood,
+/area/syndicate_mothership/control)
+"vw" = (
+/obj/structure/table/wood,
+/obj/item/device/syndicatedetonator{
+	desc = "This gaudy button can be used to instantly detonate syndicate bombs that have been activated on the station. It is also fun to press."
+	},
+/turf/open/floor/wood,
+/area/syndicate_mothership/control)
+"vx" = (
+/obj/structure/table/wood,
+/obj/item/toy/nuke,
+/turf/open/floor/wood,
+/area/syndicate_mothership/control)
+"vy" = (
+/obj/machinery/door/airlock/centcom{
+	aiControlDisabled = 1;
+	name = "Assault Pod";
+	opacity = 1;
+	req_access_txt = "150"
+	},
+/turf/open/floor/plating,
+/area/shuttle/assault_pod)
+"vz" = (
+/obj/machinery/computer/shuttle/syndicate/drop_pod,
 /turf/closed/wall/mineral/plastitanium,
-/area/shuttle/syndicate/medical)
-"TC" = (
-/obj/structure/window/reinforced{
+/area/shuttle/assault_pod)
+"vA" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/sign/directions/engineering{
+	desc = "A sign that shows there are doors here. There are doors everywhere!";
+	icon_state = "doors";
+	name = "WARNING: EXTERNAL AIRLOCK"
+	},
+/turf/open/floor/plating,
+/area/centcom/ferry)
+"vB" = (
+/obj/structure/closet/emcloset,
+/obj/item/tank/internals/emergency_oxygen/engi,
+/obj/item/tank/internals/emergency_oxygen/engi,
+/obj/item/tank/internals/emergency_oxygen/engi,
+/obj/item/clothing/mask/gas,
+/obj/item/clothing/mask/gas,
+/obj/item/clothing/mask/gas,
+/obj/effect/turf_decal/delivery,
+/turf/open/floor/plasteel,
+/area/centcom/ferry)
+"vC" = (
+/obj/machinery/light{
 	dir = 1
 	},
-/turf/open/floor/plasteel/vault,
-/area/shuttle/syndicate/armory)
-"TD" = (
-/obj/structure/chair/office/dark{
-	dir = 4;
-	name = "tactical swivel chair"
+/obj/effect/turf_decal/stripes/line{
+	dir = 9
 	},
-/turf/open/floor/plasteel/black,
-/area/shuttle/syndicate/bridge)
-"TO" = (
-/obj/structure/window/reinforced{
+/turf/open/floor/plasteel,
+/area/centcom/ferry)
+"vD" = (
+/obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
-/turf/open/floor/plasteel/vault,
-/area/shuttle/syndicate/medical)
-"TT" = (
-/turf/open/floor/plasteel/vault,
-/area/shuttle/syndicate/hallway)
-"TW" = (
+/turf/open/floor/plasteel,
+/area/centcom/ferry)
+"vE" = (
+/obj/machinery/firealarm{
+	pixel_y = 24
+	},
 /obj/structure/chair{
-	dir = 8;
-	name = "tactical chair"
+	dir = 8
 	},
+/obj/structure/extinguisher_cabinet{
+	pixel_x = 24
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 5
+	},
+/turf/open/floor/plasteel,
+/area/centcom/ferry)
+"vF" = (
+/obj/machinery/door/airlock/centcom{
+	name = "Administrative Office";
+	opacity = 1;
+	req_access_txt = "109"
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 2
+	},
+/turf/open/floor/plasteel,
+/area/centcom/ferry)
+"vG" = (
+/obj/machinery/door/poddoor/shutters{
+	id = "XCCsec1";
+	name = "XCC Checkpoint 1 Shutters"
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/centcom/control)
+"vH" = (
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/open/floor/plasteel/green/corner{
+	dir = 1
+	},
+/area/centcom/control)
+"vI" = (
+/obj/machinery/pdapainter,
+/turf/open/floor/plasteel/vault{
+	dir = 8
+	},
+/area/centcom/control)
+"vJ" = (
+/obj/machinery/photocopier,
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/machinery/button/door{
+	id = "XCCFerry";
+	name = "Hanger Bay Shutters";
+	pixel_x = -8;
+	pixel_y = 24;
+	req_access_txt = "2"
+	},
+/obj/machinery/button/door{
+	id = "XCCsec3";
+	name = "CC Main Access Control";
+	pixel_x = 8;
+	pixel_y = 24
+	},
+/obj/machinery/button/door{
+	id = "XCCsec1";
+	name = "CC Shutter 1 Control";
+	pixel_x = 8;
+	pixel_y = 38
+	},
+/obj/machinery/button/door{
+	id = "XCCsec3";
+	name = "XCC Shutter 3 Control";
+	pixel_x = -8;
+	pixel_y = 38
+	},
+/turf/open/floor/plasteel/vault{
+	dir = 8
+	},
+/area/centcom/control)
+"vK" = (
+/obj/structure/table/reinforced,
+/obj/item/storage/fancy/donut_box,
+/turf/open/floor/plasteel/vault{
+	dir = 8
+	},
+/area/centcom/control)
+"vL" = (
+/obj/item/device/flashlight/lamp,
+/obj/structure/table/reinforced,
+/turf/open/floor/plasteel/vault{
+	dir = 8
+	},
+/area/centcom/control)
+"vM" = (
+/obj/structure/table/reinforced,
+/obj/item/paper_bin,
+/obj/item/pen,
+/turf/open/floor/plasteel/vault{
+	dir = 8
+	},
+/area/centcom/control)
+"vN" = (
+/obj/structure/filingcabinet/medical,
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/open/floor/plasteel/vault{
+	dir = 8
+	},
+/area/centcom/control)
+"vO" = (
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/open/floor/plasteel/green/corner{
+	dir = 4
+	},
+/area/centcom/control)
+"vP" = (
+/obj/machinery/door/poddoor/shutters{
+	id = "XCCcustoms2";
+	name = "XCC Customs 2 Shutters"
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/centcom/control)
+"vQ" = (
+/obj/structure/table,
+/obj/item/paper/pamphlet/centcom/visitor_info,
+/obj/item/paper/pamphlet/centcom/visitor_info,
+/obj/item/paper/pamphlet/centcom/visitor_info,
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/open/floor/plasteel/green/side{
+	dir = 9
+	},
+/area/centcom/control)
+"vR" = (
+/obj/structure/chair,
+/turf/open/floor/plasteel/red/side{
+	dir = 1
+	},
+/area/centcom/control)
+"vS" = (
+/obj/effect/turf_decal/delivery,
+/turf/open/floor/plasteel,
+/area/centcom/control)
+"vT" = (
+/obj/structure/table,
+/obj/item/paper_bin,
+/obj/item/pen,
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/open/floor/plasteel/green/side{
+	dir = 5
+	},
+/area/centcom/control)
+"vU" = (
+/obj/machinery/door/poddoor/shutters{
+	id = "XCCcustoms1";
+	name = "XCC Customs 1 Shutters"
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/centcom/evac)
+"vV" = (
+/obj/structure/chair{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/centcom/evac)
+"vW" = (
+/turf/open/floor/plasteel/neutral/side{
+	dir = 10
+	},
+/area/centcom/evac)
+"vX" = (
+/turf/open/floor/plasteel/blue/side{
+	dir = 5
+	},
+/area/centcom/evac)
+"vY" = (
+/turf/open/floor/plasteel/blue,
+/area/centcom/evac)
+"vZ" = (
+/turf/open/floor/plasteel/blue/side{
+	dir = 4
+	},
+/area/centcom/evac)
+"wa" = (
+/turf/open/floor/plasteel/blue/side{
+	dir = 8
+	},
+/area/centcom/evac)
+"wb" = (
+/obj/machinery/door/airlock{
+	icon = 'icons/obj/doors/airlocks/station/uranium.dmi';
+	name = "Observation Room"
+	},
+/turf/open/floor/engine/cult,
+/area/wizard_station)
+"wc" = (
+/obj/machinery/door/airlock{
+	icon = 'icons/obj/doors/airlocks/station/uranium.dmi';
+	name = "Game Room"
+	},
+/turf/open/floor/engine/cult,
+/area/wizard_station)
+"wd" = (
+/obj/structure/chair/wood/wings{
+	icon_state = "wooden_chair_wings";
+	dir = 1
+	},
+/turf/open/floor/carpet,
+/area/wizard_station)
+"we" = (
+/obj/structure/sign/securearea{
+	desc = "A warning sign which reads 'FOURTH WALL'.";
+	name = "\improper FOURTH WALL";
+	pixel_x = -32
+	},
+/turf/open/floor/plating/asteroid/snow/airless,
+/area/syndicate_mothership)
+"wf" = (
+/obj/machinery/portable_atmospherics/canister/oxygen,
 /obj/machinery/light{
 	dir = 4
 	},
 /turf/open/floor/plasteel/vault{
-	dir = 5
-	},
-/area/shuttle/syndicate/hallway)
-"TY" = (
-/obj/machinery/computer/camera_advanced/shuttle_docker/syndicate,
-/turf/open/floor/plasteel/vault{
 	dir = 8
 	},
-/area/shuttle/syndicate/bridge)
-"Um" = (
-/obj/machinery/computer/camera_advanced/syndie,
-/turf/open/floor/plasteel/vault{
-	dir = 8
-	},
-/area/shuttle/syndicate/bridge)
-"Uq" = (
-/obj/machinery/porta_turret/syndicate{
-	dir = 6
-	},
-/turf/closed/wall/mineral/plastitanium,
-/area/shuttle/syndicate/hallway)
-"Ur" = (
-/obj/effect/spawner/structure/window/reinforced,
+/area/shuttle/syndicate/eva)
+"wg" = (
+/obj/structure/grille,
+/obj/structure/window/plastitanium,
 /turf/open/floor/plating,
 /area/shuttle/syndicate/hallway)
-"Us" = (
-/turf/closed/wall/mineral/plastitanium,
-/area/shuttle/syndicate/bridge)
-"Uv" = (
+"wh" = (
+/obj/machinery/door/airlock/external{
+	name = "Ready Room";
+	req_access_txt = "150"
+	},
+/turf/open/floor/plasteel/vault{
+	dir = 8
+	},
+/area/shuttle/syndicate/hallway)
+"wi" = (
+/obj/item/storage/toolbox/syndicate,
+/obj/item/crowbar/red,
+/obj/structure/table/reinforced,
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/open/floor/plasteel/podhatch{
+	dir = 10
+	},
+/area/shuttle/syndicate/airlock)
+"wj" = (
+/turf/open/floor/plasteel/podhatch,
+/area/shuttle/syndicate/airlock)
+"wk" = (
+/obj/structure/chair{
+	name = "tactical chair"
+	},
+/turf/open/floor/plasteel/podhatch{
+	dir = 6
+	},
+/area/shuttle/syndicate/airlock)
+"wl" = (
+/obj/machinery/light,
+/turf/open/floor/wood,
+/area/syndicate_mothership/control)
+"wm" = (
+/obj/effect/landmark/start/nukeop_leader,
+/turf/open/floor/wood,
+/area/syndicate_mothership/control)
+"wn" = (
+/turf/open/floor/wood,
+/area/syndicate_mothership/control)
+"wo" = (
+/obj/machinery/door/window{
+	base_state = "right";
+	dir = 4;
+	icon_state = "right";
+	name = "Uplink Management Control";
+	req_access_txt = "151"
+	},
+/turf/open/floor/wood,
+/area/syndicate_mothership/control)
+"wp" = (
+/obj/machinery/light,
+/turf/open/floor/plasteel/bar{
+	dir = 2
+	},
+/area/syndicate_mothership/control)
+"wq" = (
+/obj/structure/chair,
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/open/floor/mineral/plastitanium,
+/area/shuttle/assault_pod)
+"wr" = (
+/obj/structure/chair{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/centcom/ferry)
+"ws" = (
+/turf/open/floor/plasteel/neutral,
+/area/centcom/ferry)
+"wt" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/centcom/ferry)
+"wu" = (
+/obj/machinery/door/firedoor,
+/obj/machinery/door/airlock/centcom{
+	name = "CentCom Security";
+	opacity = 1;
+	req_access_txt = "101"
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/centcom/ferry)
+"wv" = (
+/obj/machinery/door/poddoor/shutters{
+	id = "XCCFerry";
+	name = "XCC Ferry Hangar"
+	},
+/turf/open/floor/plasteel/loadingarea{
+	dir = 4
+	},
+/area/centcom/ferry)
+"ww" = (
+/obj/machinery/button/door{
+	id = "XCCFerry";
+	name = "Hanger Bay Shutters";
+	pixel_y = 24;
+	req_access_txt = "2"
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 5
+	},
+/turf/open/floor/plasteel,
+/area/centcom/ferry)
+"wx" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 10
+	},
+/turf/open/floor/plasteel,
+/area/centcom/ferry)
+"wy" = (
+/obj/effect/turf_decal/delivery,
+/turf/open/floor/plasteel,
+/area/centcom/ferry)
+"wz" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 6
+	},
+/turf/open/floor/plasteel,
+/area/centcom/ferry)
+"wA" = (
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/open/floor/plasteel/green/corner{
+	dir = 4
+	},
+/area/centcom/ferry)
+"wB" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 9
+	},
+/turf/open/floor/plasteel,
+/area/centcom/ferry)
+"wC" = (
+/obj/machinery/door/airlock/centcom{
+	name = "CentCom Customs";
+	opacity = 1;
+	req_access_txt = "109"
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/centcom/control)
+"wD" = (
+/obj/structure/table/reinforced,
+/obj/item/folder/red{
+	pixel_x = -2;
+	pixel_y = -2
+	},
+/obj/item/folder/blue{
+	pixel_x = 2;
+	pixel_y = 2
+	},
+/obj/item/lighter,
+/turf/open/floor/plasteel/vault{
+	dir = 8
+	},
+/area/centcom/control)
+"wE" = (
+/obj/structure/chair/comfy/brown{
+	color = "#596479";
+	dir = 2
+	},
+/turf/open/floor/plasteel/vault,
+/area/centcom/control)
+"wF" = (
+/obj/structure/table/reinforced,
+/obj/machinery/computer/med_data/laptop,
+/turf/open/floor/plasteel/vault{
+	dir = 8
+	},
+/area/centcom/control)
+"wG" = (
+/turf/open/floor/plasteel/green/side{
+	dir = 8
+	},
+/area/centcom/control)
+"wH" = (
+/turf/open/floor/plasteel/loadingarea,
+/area/centcom/control)
+"wI" = (
+/turf/open/floor/plasteel/green/side{
+	dir = 4
+	},
+/area/centcom/control)
+"wJ" = (
+/obj/machinery/door/firedoor,
+/obj/machinery/door/airlock/centcom{
+	name = "CentCom";
+	opacity = 1;
+	req_access_txt = "0"
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/centcom/evac)
+"wK" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/centcom/evac)
+"wL" = (
+/turf/open/floor/plasteel/blue/side{
+	dir = 6
+	},
+/area/centcom/evac)
+"wM" = (
+/obj/structure/chair/wood/wings{
+	icon_state = "wooden_chair_wings";
+	dir = 8
+	},
+/turf/open/floor/wood,
+/area/wizard_station)
+"wN" = (
+/obj/machinery/light/small{
+	brightness = 3;
+	dir = 8
+	},
+/turf/open/floor/engine/cult,
+/area/wizard_station)
+"wO" = (
+/obj/machinery/light/small{
+	dir = 4
+	},
+/turf/open/floor/engine/cult,
+/area/wizard_station)
+"wP" = (
+/obj/structure/table/wood/fancy,
+/obj/item/device/camera/spooky,
+/turf/open/floor/carpet,
+/area/wizard_station)
+"wQ" = (
+/obj/structure/table/wood/poker,
+/obj/item/toy/cards/deck,
+/turf/open/floor/carpet,
+/area/wizard_station)
+"wR" = (
+/turf/open/floor/plasteel/vault{
+	dir = 8
+	},
+/area/shuttle/syndicate/eva)
+"wS" = (
+/obj/machinery/door/airlock/external{
+	name = "E.V.A. Gear Storage";
+	req_access_txt = "150"
+	},
+/turf/open/floor/plasteel/vault{
+	dir = 8
+	},
+/area/shuttle/syndicate/eva)
+"wT" = (
+/obj/machinery/door/airlock/external{
+	req_access_txt = "150"
+	},
+/turf/open/floor/mineral/plastitanium,
+/area/shuttle/syndicate/airlock)
+"wU" = (
+/turf/open/floor/plasteel/vault{
+	dir = 5
+	},
+/area/shuttle/syndicate/airlock)
+"wV" = (
+/obj/machinery/computer/telecrystals/boss,
+/turf/open/floor/plasteel/podhatch{
+	dir = 5
+	},
+/area/syndicate_mothership/control)
+"wW" = (
+/obj/structure/sign/map/left{
+	pixel_y = -32
+	},
+/obj/structure/rack{
+	icon = 'icons/obj/stationobjs.dmi';
+	icon_state = "minibar_left";
+	name = "skeletal minibar"
+	},
+/obj/item/reagent_containers/food/drinks/bottle/vodka,
+/turf/open/floor/wood,
+/area/syndicate_mothership/control)
+"wX" = (
+/obj/structure/sign/map/right{
+	pixel_y = -32
+	},
+/obj/structure/rack{
+	icon = 'icons/obj/stationobjs.dmi';
+	icon_state = "minibar_right";
+	name = "skeletal minibar"
+	},
+/obj/item/reagent_containers/food/drinks/bottle/gin,
+/turf/open/floor/wood,
+/area/syndicate_mothership/control)
+"wY" = (
+/obj/machinery/door/airlock/centcom{
+	name = "Equipment Room";
+	opacity = 1;
+	req_access_txt = "150"
+	},
+/turf/open/floor/plasteel/bar{
+	dir = 2
+	},
+/area/syndicate_mothership/control)
+"wZ" = (
+/turf/open/floor/plating/asteroid/snow/airless,
+/obj/machinery/porta_turret/syndicate/pod,
+/turf/closed/wall/mineral/plastitanium{
+	icon_state = "diagonalWall3"
+	},
+/area/shuttle/assault_pod)
+"xa" = (
+/turf/open/floor/plating/asteroid/snow/airless,
+/obj/machinery/porta_turret/syndicate/pod,
+/turf/closed/wall/mineral/plastitanium{
+	dir = 4;
+	icon_state = "diagonalWall3"
+	},
+/area/shuttle/assault_pod)
+"xb" = (
+/obj/docking_port/stationary{
+	dir = 8;
+	dwidth = 2;
+	height = 13;
+	id = "ferry_away";
+	name = "CentCom Ferry Dock";
+	width = 5
+	},
+/turf/open/space,
+/area/space)
+"xc" = (
+/obj/machinery/door/airlock/external{
+	name = "Ferry Airlock";
+	req_access_txt = "0"
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/centcom/ferry)
+"xd" = (
+/obj/structure/fans/tiny,
+/obj/effect/turf_decal/delivery,
+/turf/open/floor/plasteel,
+/area/centcom/ferry)
+"xe" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/centcom/ferry)
+"xf" = (
+/obj/effect/turf_decal/bot,
+/turf/open/floor/plasteel,
+/area/centcom/ferry)
+"xg" = (
+/obj/structure/chair{
+	dir = 8
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/centcom/ferry)
+"xh" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/sign/directions/engineering{
+	desc = "A sign that shows there are doors here. There are doors everywhere!";
+	icon_state = "doors";
+	name = "WARNING: BLAST DOORS"
+	},
+/turf/open/floor/plating,
+/area/centcom/ferry)
+"xi" = (
+/obj/item/twohanded/required/kirbyplants{
+	icon_state = "plant-21"
+	},
+/obj/effect/turf_decal/delivery,
+/turf/open/floor/plasteel,
+/area/centcom/ferry)
+"xj" = (
+/turf/open/floor/plasteel/green/side{
+	dir = 8
+	},
+/area/centcom/ferry)
+"xk" = (
+/turf/open/floor/plasteel/green/side{
+	dir = 4
+	},
+/area/centcom/ferry)
+"xl" = (
+/turf/open/floor/plasteel/neutral/side{
+	dir = 8;
+	heat_capacity = 1e+006
+	},
+/area/centcom/control)
+"xm" = (
+/obj/machinery/computer/med_data,
+/turf/open/floor/plasteel/vault{
+	dir = 8
+	},
+/area/centcom/control)
+"xn" = (
+/obj/machinery/computer/card/centcom,
+/turf/open/floor/plasteel/vault{
+	dir = 8
+	},
+/area/centcom/control)
+"xo" = (
+/turf/open/floor/plasteel/green/corner,
+/area/centcom/control)
+"xp" = (
+/obj/item/twohanded/required/kirbyplants{
+	icon_state = "plant-21"
+	},
+/turf/open/floor/plasteel/green/side{
+	dir = 8
+	},
+/area/centcom/control)
+"xq" = (
+/obj/item/twohanded/required/kirbyplants{
+	icon_state = "plant-21"
+	},
+/turf/open/floor/plasteel/green/side{
+	dir = 4
+	},
+/area/centcom/control)
+"xr" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/sign/directions/engineering{
+	desc = "A sign that shows there are doors here. There are doors everywhere!";
+	icon_state = "doors";
+	name = "WARNING: BLAST DOORS"
+	},
+/turf/open/floor/plating,
+/area/centcom/evac)
+"xs" = (
+/obj/item/twohanded/required/kirbyplants{
+	icon_state = "plant-22"
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/centcom/evac)
+"xt" = (
+/turf/open/floor/plasteel/neutral/side{
+	dir = 5
+	},
+/area/centcom/evac)
+"xu" = (
+/obj/machinery/light,
+/turf/open/floor/wood,
+/area/wizard_station)
+"xv" = (
+/obj/item/statuebust{
+	pixel_y = 12
+	},
+/obj/structure/table/wood/fancy,
+/turf/open/floor/wood,
+/area/wizard_station)
+"xw" = (
+/obj/machinery/vending/magivend,
+/turf/open/floor/engine/cult,
+/area/wizard_station)
+"xx" = (
+/obj/machinery/vending/snack,
+/turf/open/floor/engine/cult,
+/area/wizard_station)
+"xy" = (
+/obj/structure/table/wood/fancy,
+/obj/item/storage/pill_bottle/dice{
+	icon_state = "magicdicebag"
+	},
+/turf/open/floor/carpet,
+/area/wizard_station)
+"xz" = (
+/obj/structure/table/wood/fancy,
+/obj/item/storage/photo_album,
+/obj/machinery/light,
+/turf/open/floor/carpet,
+/area/wizard_station)
+"xA" = (
+/obj/machinery/suit_storage_unit/syndicate,
+/turf/open/floor/plasteel/podhatch{
+	dir = 6
+	},
+/area/shuttle/syndicate/eva)
+"xB" = (
 /obj/structure/reagent_dispensers/fueltank,
 /turf/open/floor/plasteel/vault{
 	dir = 8
 	},
 /area/shuttle/syndicate/eva)
-"Ux" = (
-/turf/open/floor/plasteel/black,
-/area/shuttle/syndicate/hallway)
-"UI" = (
-/obj/machinery/door/airlock/hatch{
-	name = "Cockpit";
-	req_access_txt = "150"
-	},
-/turf/open/floor/plasteel/vault{
-	dir = 8
-	},
-/area/shuttle/syndicate/bridge)
-"UK" = (
-/obj/machinery/porta_turret/syndicate{
-	dir = 5
-	},
-/turf/closed/wall/mineral/plastitanium,
-/area/shuttle/syndicate/armory)
-"UR" = (
+"xC" = (
+/obj/structure/grille,
+/obj/structure/window/plastitanium,
+/turf/open/floor/plating,
+/area/shuttle/syndicate/eva)
+"xD" = (
+/obj/structure/grille,
+/obj/structure/window/plastitanium,
+/turf/open/floor/plating,
+/area/shuttle/syndicate/airlock)
+"xE" = (
 /obj/structure/chair{
 	dir = 1;
 	name = "tactical chair"
@@ -14196,195 +8988,395 @@
 	dir = 8
 	},
 /area/shuttle/syndicate/airlock)
-"UW" = (
-/obj/structure/shuttle/engine/propulsion/left,
-/obj/effect/turf_decal/stripes/line,
-/turf/open/floor/plating/airless,
-/area/shuttle/syndicate/armory)
-"Ve" = (
-/turf/open/floor/plasteel/podhatch{
-	dir = 1
-	},
-/area/shuttle/syndicate/armory)
-"Vk" = (
-/obj/item/weldingtool/largetank{
-	pixel_y = 3
-	},
-/obj/item/device/multitool,
-/obj/structure/table/reinforced,
+"xF" = (
+/obj/structure/rack,
+/obj/item/clothing/suit/space/syndicate/black/red,
+/obj/item/clothing/head/helmet/space/syndicate/black/red,
 /turf/open/floor/plasteel/vault{
 	dir = 8
 	},
-/area/shuttle/syndicate/armory)
-"Vo" = (
-/obj/machinery/computer/med_data/syndie,
-/turf/open/floor/plasteel/vault{
-	dir = 8
-	},
-/area/shuttle/syndicate/bridge)
-"Vv" = (
-/obj/item/wrench,
-/obj/item/device/assembly/infra,
-/obj/structure/table/reinforced,
+/area/shuttle/syndicate/airlock)
+"xG" = (
+/turf/open/floor/plasteel/black,
+/area/syndicate_mothership/control)
+"xH" = (
+/obj/machinery/mech_bay_recharge_port,
+/turf/open/floor/plating,
+/area/syndicate_mothership/control)
+"xI" = (
 /obj/machinery/light{
 	dir = 1
 	},
-/turf/open/floor/plasteel/vault{
+/turf/open/floor/mech_bay_recharge_floor,
+/area/syndicate_mothership/control)
+"xJ" = (
+/obj/machinery/computer/mech_bay_power_console,
+/turf/open/floor/plating,
+/area/syndicate_mothership/control)
+"xK" = (
+/obj/machinery/vending/tool,
+/turf/open/floor/plasteel/black,
+/area/syndicate_mothership/control)
+"xL" = (
+/obj/structure/closet/cardboard/metal,
+/obj/effect/turf_decal/stripes/corner{
 	dir = 8
 	},
-/area/shuttle/syndicate/armory)
-"Vy" = (
-/obj/machinery/porta_turret/syndicate{
-	dir = 5
-	},
-/turf/closed/wall/mineral/plastitanium,
-/area/shuttle/syndicate/airlock)
-"VO" = (
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/obj/item/bodypart/r_arm/robot,
-/obj/item/bodypart/l_arm/robot,
-/obj/structure/table/reinforced,
-/obj/item/toy/plush/nukeplushie,
-/turf/open/floor/plasteel/vault,
-/area/shuttle/syndicate/medical)
-"Wd" = (
-/obj/structure/window/plastitanium,
-/turf/open/floor/plasteel/vault{
-	dir = 5
-	},
-/area/shuttle/syndicate/armory)
-"We" = (
-/obj/item/screwdriver{
-	pixel_y = 9
-	},
-/obj/item/device/assembly/voice{
-	pixel_y = 3
-	},
-/obj/structure/table/reinforced,
-/turf/open/floor/plasteel/vault{
-	dir = 8
-	},
-/area/shuttle/syndicate/armory)
-"Wj" = (
-/obj/item/device/sbeacondrop/bomb{
-	pixel_y = 5
-	},
-/obj/item/device/sbeacondrop/bomb,
-/obj/structure/table/reinforced,
-/turf/open/floor/plasteel/vault{
-	dir = 8
-	},
-/area/shuttle/syndicate/armory)
-"Wk" = (
-/turf/closed/wall/mineral/plastitanium,
-/area/shuttle/syndicate/airlock)
-"Wr" = (
-/turf/open/floor/plasteel/vault,
-/area/shuttle/syndicate/bridge)
-"Wz" = (
-/obj/structure/shuttle/engine/propulsion/right,
-/obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plating/airless,
-/area/shuttle/syndicate/medical)
-"WK" = (
-/obj/structure/shuttle/engine/propulsion,
-/obj/effect/turf_decal/stripes/line,
+/area/syndicate_mothership/control)
+"xM" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 5
+	},
 /turf/open/floor/plating/airless,
-/area/shuttle/syndicate/hallway)
-"WM" = (
-/turf/open/floor/plasteel/vault{
-	dir = 5
+/area/syndicate_mothership/control)
+"xN" = (
+/obj/machinery/door/airlock/centcom{
+	aiControlDisabled = 1;
+	name = "Assault Pod";
+	opacity = 1;
+	req_access_txt = "150"
 	},
-/area/shuttle/syndicate/medical)
-"WW" = (
-/obj/machinery/light{
+/obj/docking_port/mobile/assault_pod{
+	dwidth = 3;
+	name = "steel rain";
+	port_direction = 4;
+	preferred_direction = 4
+	},
+/turf/open/floor/plating,
+/area/shuttle/assault_pod)
+"xO" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 9
+	},
+/turf/open/floor/plating/airless,
+/area/syndicate_mothership/control)
+"xP" = (
+/obj/effect/turf_decal/stripes/corner{
 	dir = 4
 	},
-/turf/open/floor/plasteel/vault{
+/turf/open/floor/plating/airless,
+/area/syndicate_mothership/control)
+"xQ" = (
+/obj/effect/turf_decal/delivery,
+/obj/machinery/light,
+/turf/open/floor/plasteel,
+/area/centcom/ferry)
+"xR" = (
+/obj/effect/turf_decal/stripes/line{
 	dir = 5
 	},
-/area/shuttle/syndicate/hallway)
-"WX" = (
-/obj/structure/chair{
-	name = "tactical chair"
+/turf/open/floor/plasteel,
+/area/centcom/ferry)
+"xS" = (
+/obj/machinery/button/door{
+	id = "XCCsec1";
+	name = "CC Shutter 1 Control";
+	pixel_y = -24
 	},
-/turf/open/floor/plasteel/podhatch{
-	dir = 6
+/obj/effect/turf_decal/stripes/line{
+	dir = 10
 	},
-/area/shuttle/syndicate/airlock)
-"WY" = (
-/obj/machinery/light{
-	dir = 4
+/turf/open/floor/plasteel,
+/area/centcom/ferry)
+"xT" = (
+/turf/open/floor/plasteel/green/corner{
+	dir = 8
 	},
-/turf/open/floor/plasteel/vault{
-	dir = 5
-	},
-/area/shuttle/syndicate/armory)
-"XJ" = (
-/turf/closed/wall/mineral/plastitanium,
-/area/shuttle/syndicate/medical)
-"XL" = (
-/obj/structure/window/plastitanium,
+/area/centcom/control)
+"xU" = (
+/obj/machinery/computer/crew,
 /turf/open/floor/plasteel/vault{
 	dir = 8
 	},
-/area/shuttle/syndicate/hallway)
-"XN" = (
-/obj/structure/chair{
-	dir = 4;
-	name = "tactical chair"
+/area/centcom/control)
+"xV" = (
+/obj/structure/chair/office/dark{
+	dir = 8
 	},
-/turf/open/floor/plasteel/vault{
-	dir = 5
-	},
-/area/shuttle/syndicate/hallway)
-"XU" = (
-/turf/open/floor/plasteel/vault{
-	dir = 5
-	},
-/area/shuttle/syndicate/eva)
-"XW" = (
-/turf/open/floor/plasteel/podhatch,
-/area/shuttle/syndicate/airlock)
-"Yk" = (
-/obj/structure/table/reinforced,
-/obj/item/storage/box/handcuffs{
-	pixel_x = 3;
-	pixel_y = 3
-	},
-/obj/item/storage/box/zipties,
-/turf/open/floor/plasteel/vault{
-	dir = 5
-	},
-/area/shuttle/syndicate/hallway)
-"Yl" = (
-/obj/structure/table/reinforced,
-/obj/machinery/ai_status_display{
-	pixel_x = 32
-	},
-/obj/item/storage/fancy/donut_box,
-/obj/machinery/light{
+/turf/open/floor/wood,
+/area/centcom/control)
+"xW" = (
+/obj/structure/chair/office/dark{
 	dir = 4
 	},
+/turf/open/floor/wood,
+/area/centcom/control)
+"xX" = (
+/obj/machinery/computer/communications,
 /turf/open/floor/plasteel/vault{
 	dir = 8
 	},
-/area/shuttle/syndicate/bridge)
-"Ym" = (
+/area/centcom/control)
+"xY" = (
+/turf/open/floor/plasteel/blue/side{
+	dir = 9
+	},
+/area/centcom/evac)
+"xZ" = (
+/turf/open/floor/plasteel/blue/side{
+	dir = 10
+	},
+/area/centcom/evac)
+"ya" = (
+/obj/machinery/door/airlock{
+	icon = 'icons/obj/doors/airlocks/station/uranium.dmi';
+	name = "Study"
+	},
+/turf/open/floor/engine/cult,
+/area/wizard_station)
+"yb" = (
+/obj/machinery/door/airlock{
+	icon = 'icons/obj/doors/airlocks/station/uranium.dmi';
+	name = "Break Room"
+	},
+/turf/open/floor/engine/cult,
+/area/wizard_station)
+"yc" = (
 /obj/machinery/porta_turret/syndicate{
 	dir = 9
 	},
 /turf/closed/wall/mineral/plastitanium,
-/area/shuttle/syndicate/eva)
-"Yo" = (
-/obj/machinery/computer/shuttle/syndicate,
+/area/shuttle/syndicate/medical)
+"yd" = (
+/turf/closed/wall/mineral/plastitanium,
+/area/shuttle/syndicate/medical)
+"ye" = (
+/obj/machinery/ai_status_display,
+/turf/closed/wall/mineral/plastitanium,
+/area/shuttle/syndicate/medical)
+"yf" = (
+/turf/closed/wall/mineral/plastitanium/nodiagonal,
+/area/shuttle/syndicate/medical)
+"yg" = (
+/turf/closed/wall/mineral/plastitanium/nodiagonal,
+/area/shuttle/syndicate/armory)
+"yh" = (
+/turf/closed/wall/mineral/plastitanium,
+/area/shuttle/syndicate/armory)
+"yi" = (
+/obj/machinery/status_display,
+/turf/closed/wall/mineral/plastitanium,
+/area/shuttle/syndicate/armory)
+"yj" = (
+/obj/machinery/porta_turret/syndicate{
+	dir = 5
+	},
+/turf/closed/wall/mineral/plastitanium,
+/area/shuttle/syndicate/armory)
+"yk" = (
+/obj/effect/turf_decal/stripes/corner{
+	dir = 8
+	},
+/turf/open/floor/plating/airless,
+/area/syndicate_mothership/control)
+"yl" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/turf/open/floor/plating/airless,
+/area/syndicate_mothership/control)
+"ym" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/machinery/light,
+/turf/open/floor/plating/airless,
+/area/syndicate_mothership/control)
+"yn" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/sign/vacuum,
+/turf/open/floor/plating,
+/area/centcom/ferry)
+"yo" = (
+/obj/machinery/light,
+/obj/effect/turf_decal/stripes/line{
+	dir = 10
+	},
+/turf/open/floor/plasteel,
+/area/centcom/ferry)
+"yp" = (
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/plasteel,
+/area/centcom/ferry)
+"yq" = (
+/obj/structure/chair{
+	dir = 8
+	},
+/obj/machinery/computer/security/telescreen/entertainment{
+	pixel_y = -28
+	},
+/obj/structure/sign/securearea{
+	pixel_x = 32
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 6
+	},
+/turf/open/floor/plasteel,
+/area/centcom/ferry)
+"yr" = (
+/obj/machinery/door/airlock/centcom{
+	name = "Briefing Room";
+	opacity = 1;
+	req_access_txt = "101"
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 2
+	},
+/turf/open/floor/plasteel,
+/area/centcom/ferry)
+"ys" = (
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/open/floor/plasteel/green/corner{
+	dir = 8
+	},
+/area/centcom/control)
+"yt" = (
+/obj/item/storage/box/ids{
+	pixel_x = 3;
+	pixel_y = 3
+	},
+/obj/item/storage/box/silver_ids,
+/obj/structure/table/reinforced,
 /turf/open/floor/plasteel/vault{
 	dir = 8
 	},
-/area/shuttle/syndicate/bridge)
-"Yw" = (
+/area/centcom/control)
+"yu" = (
+/obj/structure/table/reinforced,
+/obj/item/clipboard,
+/obj/item/folder/white,
+/obj/item/pen/blue,
+/turf/open/floor/plasteel/vault{
+	dir = 8
+	},
+/area/centcom/control)
+"yv" = (
+/obj/machinery/computer/prisoner,
+/obj/machinery/light,
+/turf/open/floor/plasteel/vault{
+	dir = 8
+	},
+/area/centcom/control)
+"yw" = (
+/obj/machinery/computer/secure_data,
+/obj/machinery/light,
+/turf/open/floor/plasteel/vault{
+	dir = 8
+	},
+/area/centcom/control)
+"yx" = (
+/obj/structure/table/reinforced,
+/obj/item/clipboard,
+/obj/item/folder/red,
+/obj/item/pen/red,
+/turf/open/floor/plasteel/vault{
+	dir = 8
+	},
+/area/centcom/control)
+"yy" = (
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/open/floor/plasteel/green/corner,
+/area/centcom/control)
+"yz" = (
+/obj/structure/chair{
+	dir = 1
+	},
+/turf/open/floor/plasteel/blue/side,
+/area/centcom/control)
+"yA" = (
+/obj/item/storage/firstaid/regular,
+/obj/structure/table,
+/turf/open/floor/plasteel/green/side{
+	dir = 6
+	},
+/area/centcom/control)
+"yB" = (
+/turf/open/floor/plasteel/blue/corner{
+	dir = 4
+	},
+/area/centcom/evac)
+"yC" = (
+/obj/structure/chair/wood/wings,
+/turf/open/floor/engine/cult,
+/area/wizard_station)
+"yD" = (
+/obj/structure/table/wood,
+/obj/item/stack/medical/bruise_pack,
+/obj/item/stack/medical/ointment,
+/turf/open/floor/engine/cult,
+/area/wizard_station)
+"yE" = (
+/obj/structure/table/wood,
+/obj/item/retractor,
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/open/floor/engine/cult,
+/area/wizard_station)
+"yF" = (
+/obj/structure/table/wood,
+/obj/item/clothing/suit/wizrobe/magusblue,
+/obj/item/clothing/head/wizard/magus,
+/obj/item/staff,
+/obj/structure/mirror/magic{
+	pixel_y = 28
+	},
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/open/floor/engine/cult,
+/area/wizard_station)
+"yG" = (
+/obj/structure/table/wood,
+/obj/item/clothing/suit/wizrobe/magusred,
+/obj/item/clothing/head/wizard/magus,
+/obj/item/staff,
+/turf/open/floor/engine/cult,
+/area/wizard_station)
+"yH" = (
+/obj/item/reagent_containers/food/snacks/meat/slab/human/mutant/lizard,
+/turf/open/floor/grass,
+/area/wizard_station)
+"yI" = (
+/obj/effect/decal/cleanable/blood/splatter,
+/obj/effect/decal/cleanable/blood/gibs/body,
+/turf/open/floor/grass,
+/area/wizard_station)
+"yJ" = (
+/obj/effect/decal/remains/xeno/larva,
+/turf/open/floor/grass,
+/area/wizard_station)
+"yK" = (
+/obj/effect/decal/cleanable/blood/splatter,
+/turf/open/floor/grass,
+/area/wizard_station)
+"yL" = (
+/obj/machinery/sleeper/syndie{
+	dir = 4
+	},
+/turf/open/floor/plasteel/vault{
+	dir = 8
+	},
+/area/shuttle/syndicate/medical)
+"yM" = (
+/turf/open/floor/plasteel/vault{
+	dir = 8
+	},
+/area/shuttle/syndicate/medical)
+"yN" = (
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/open/floor/plasteel/vault{
+	dir = 8
+	},
+/area/shuttle/syndicate/medical)
+"yO" = (
 /obj/item/reagent_containers/glass/bottle/epinephrine{
 	pixel_x = 6
 	},
@@ -14420,29 +9412,26 @@
 	dir = 8
 	},
 /area/shuttle/syndicate/medical)
-"Yz" = (
-/obj/item/cautery,
-/obj/item/scalpel,
+"yP" = (
 /obj/structure/table/reinforced,
+/obj/item/stack/medical/gauze,
+/obj/item/stack/medical/bruise_pack,
+/obj/item/stack/medical/ointment,
 /turf/open/floor/plasteel/vault{
 	dir = 8
 	},
 /area/shuttle/syndicate/medical)
-"YF" = (
-/obj/structure/shuttle/engine/propulsion,
-/obj/effect/turf_decal/stripes/line,
-/turf/open/floor/plating/airless,
-/area/shuttle/syndicate/armory)
-"YS" = (
-/obj/machinery/porta_turret/syndicate{
-	dir = 5
-	},
-/turf/closed/wall/mineral/plastitanium,
-/area/shuttle/syndicate/bridge)
-"YX" = (
-/turf/open/floor/plasteel/podhatch,
+"yQ" = (
+/obj/structure/grille,
+/obj/structure/window/plastitanium,
+/turf/open/floor/plating,
 /area/shuttle/syndicate/medical)
-"YY" = (
+"yR" = (
+/obj/structure/grille,
+/obj/structure/window/plastitanium,
+/turf/open/floor/plating,
+/area/shuttle/syndicate/armory)
+"yS" = (
 /obj/item/stock_parts/cell/high{
 	pixel_x = -3;
 	pixel_y = 3
@@ -14453,10 +9442,1191 @@
 	dir = 8
 	},
 /area/shuttle/syndicate/armory)
-"Ze" = (
+"yT" = (
+/obj/item/screwdriver{
+	pixel_y = 9
+	},
+/obj/item/device/assembly/voice{
+	pixel_y = 3
+	},
+/obj/structure/table/reinforced,
+/turf/open/floor/plasteel/vault{
+	dir = 8
+	},
+/area/shuttle/syndicate/armory)
+"yU" = (
+/obj/item/wrench,
+/obj/item/device/assembly/infra,
+/obj/structure/table/reinforced,
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/open/floor/plasteel/vault{
+	dir = 8
+	},
+/area/shuttle/syndicate/armory)
+"yV" = (
+/obj/item/device/assembly/signaler,
+/obj/item/device/assembly/signaler,
+/obj/item/device/assembly/prox_sensor{
+	pixel_x = -8;
+	pixel_y = 4
+	},
+/obj/item/device/assembly/prox_sensor{
+	pixel_x = -8;
+	pixel_y = 4
+	},
+/obj/structure/table/reinforced,
+/turf/open/floor/plasteel/vault{
+	dir = 8
+	},
+/area/shuttle/syndicate/armory)
+"yW" = (
+/obj/item/weldingtool/largetank{
+	pixel_y = 3
+	},
+/obj/item/device/multitool,
+/obj/structure/table/reinforced,
+/turf/open/floor/plasteel/vault{
+	dir = 8
+	},
+/area/shuttle/syndicate/armory)
+"yX" = (
+/obj/structure/chair/stool,
+/turf/open/floor/plasteel/black,
+/area/syndicate_mothership/control)
+"yY" = (
+/obj/structure/table/wood,
+/obj/item/storage/fancy/donut_box,
+/turf/open/floor/plasteel/vault{
+	dir = 8
+	},
+/area/centcom/ferry)
+"yZ" = (
+/obj/structure/table/wood,
+/obj/item/phone{
+	desc = "Supposedly a direct line to Nanotrasen Central Command. It's not even plugged in.";
+	pixel_x = -3;
+	pixel_y = 3
+	},
+/obj/item/clothing/mask/cigarette/cigar/cohiba{
+	pixel_x = 6
+	},
+/obj/item/clothing/mask/cigarette/cigar/havana{
+	pixel_x = 2
+	},
+/obj/item/clothing/mask/cigarette/cigar{
+	pixel_x = 4.5
+	},
+/obj/machinery/newscaster{
+	pixel_y = 32
+	},
+/turf/open/floor/plasteel/vault{
+	dir = 8
+	},
+/area/centcom/ferry)
+"za" = (
+/obj/structure/bookcase/random,
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/open/floor/plasteel/vault{
+	dir = 8
+	},
+/area/centcom/ferry)
+"zb" = (
+/obj/structure/table/wood,
+/obj/machinery/computer/med_data/laptop,
+/turf/open/floor/plasteel/vault{
+	dir = 8
+	},
+/area/centcom/ferry)
+"zc" = (
+/obj/item/twohanded/required/kirbyplants{
+	icon_state = "plant-21"
+	},
+/turf/open/floor/plasteel/vault{
+	dir = 8
+	},
+/area/centcom/ferry)
+"zd" = (
+/obj/item/twohanded/required/kirbyplants{
+	icon_state = "plant-22"
+	},
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/open/floor/plasteel/vault{
+	dir = 8
+	},
+/area/centcom/ferry)
+"ze" = (
+/obj/structure/closet/secure_closet/ertEngi,
+/obj/structure/sign/directions/engineering{
+	pixel_y = 24
+	},
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/plasteel,
+/area/centcom/ferry)
+"zf" = (
+/obj/structure/closet/secure_closet/ertEngi,
+/obj/machinery/airalarm{
+	pixel_y = 24
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 6
+	},
+/turf/open/floor/plasteel,
+/area/centcom/ferry)
+"zg" = (
+/obj/structure/table/reinforced,
+/obj/item/gun/ballistic/automatic/wt550,
+/obj/item/device/flashlight/seclite,
+/obj/structure/noticeboard{
+	pixel_y = 28
+	},
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/plasteel,
+/area/centcom/ferry)
+"zh" = (
+/obj/structure/table/reinforced,
+/obj/item/grenade/plastic/c4{
+	pixel_x = 6
+	},
+/obj/item/grenade/plastic/c4{
+	pixel_x = -4
+	},
+/obj/machinery/firealarm{
+	pixel_y = 24
+	},
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/plasteel,
+/area/centcom/ferry)
+"zi" = (
+/obj/structure/rack,
+/obj/item/gun/energy/e_gun{
+	pixel_x = -3;
+	pixel_y = 3
+	},
+/obj/item/gun/energy/e_gun,
+/obj/structure/sign/nanotrasen{
+	pixel_y = 32
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 10
+	},
+/turf/open/floor/plasteel,
+/area/centcom/ferry)
+"zj" = (
+/obj/structure/closet/secure_closet/ertCom,
+/obj/structure/sign/directions/engineering{
+	desc = "A direction sign, pointing out which way the Command department is.";
+	dir = 2;
+	icon_state = "direction_bridge";
+	name = "command department";
+	pixel_y = 24
+	},
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/plasteel,
+/area/centcom/ferry)
+"zk" = (
+/obj/machinery/door/airlock/glass_medical{
+	name = "Infirmary"
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 2
+	},
+/turf/open/floor/plasteel,
+/area/centcom/control)
+"zl" = (
+/turf/open/floor/plasteel/blue/corner{
+	dir = 1
+	},
+/area/centcom/evac)
+"zm" = (
+/turf/open/floor/plasteel/blue/side{
+	dir = 1
+	},
+/area/centcom/evac)
+"zn" = (
+/turf/closed/indestructible/fakeglass{
+	color = "#008000";
+	dir = 1;
+	icon_state = "fakewindows"
+	},
+/area/wizard_station)
+"zo" = (
+/obj/structure/destructible/cult/tome,
+/turf/open/floor/engine/cult,
+/area/wizard_station)
+"zp" = (
+/obj/structure/closet/crate{
+	icon_state = "crateopen";
+	opened = 1
+	},
+/obj/item/clothing/suit/wizrobe/red,
+/obj/item/clothing/head/wizard/red,
+/obj/item/staff,
+/obj/item/clothing/shoes/sandal/magic,
+/turf/open/floor/engine/cult,
+/area/wizard_station)
+"zq" = (
+/turf/open/floor/grass,
+/area/wizard_station)
+"zr" = (
+/obj/item/reagent_containers/food/snacks/meat/slab/corgi,
+/turf/open/floor/grass,
+/area/wizard_station)
+"zs" = (
+/obj/structure/bed/roller,
+/obj/machinery/iv_drip,
+/turf/open/floor/plasteel/vault{
+	dir = 8
+	},
+/area/shuttle/syndicate/medical)
+"zt" = (
 /turf/open/floor/plasteel/vault,
 /area/shuttle/syndicate/medical)
-"Zi" = (
+"zu" = (
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/open/floor/plasteel/vault{
+	dir = 5
+	},
+/area/shuttle/syndicate/hallway)
+"zv" = (
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/open/floor/plasteel/vault{
+	dir = 5
+	},
+/area/shuttle/syndicate/hallway)
+"zw" = (
+/turf/open/floor/plasteel/vault,
+/area/shuttle/syndicate/armory)
+"zx" = (
+/obj/structure/closet/syndicate/personal,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel/black,
+/area/syndicate_mothership/control)
+"zy" = (
+/obj/structure/table,
+/obj/item/gun/energy/ionrifle{
+	pin = /obj/item/device/firing_pin
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel/black,
+/area/syndicate_mothership/control)
+"zz" = (
+/obj/structure/table/wood,
+/obj/item/storage/box/drinkingglasses,
+/obj/item/reagent_containers/food/drinks/bottle/whiskey{
+	pixel_y = 5
+	},
+/turf/open/floor/plasteel/vault{
+	dir = 8
+	},
+/area/centcom/ferry)
+"zA" = (
+/turf/open/floor/plasteel/black,
+/area/centcom/ferry)
+"zB" = (
+/obj/structure/chair/office/dark,
+/obj/effect/landmark/ert_spawn,
+/turf/open/floor/plasteel/black,
+/area/centcom/ferry)
+"zC" = (
+/obj/structure/chair/office/dark,
+/obj/effect/landmark/ert_spawn,
+/turf/open/floor/plasteel/vault{
+	dir = 5
+	},
+/area/centcom/ferry)
+"zD" = (
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/open/floor/plasteel/vault{
+	dir = 8
+	},
+/area/centcom/ferry)
+"zE" = (
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/open/floor/plasteel/vault{
+	dir = 8
+	},
+/area/centcom/ferry)
+"zF" = (
+/turf/open/floor/plasteel/red/corner{
+	dir = 8
+	},
+/area/centcom/control)
+"zG" = (
+/turf/open/floor/plasteel/blue/corner,
+/area/centcom/control)
+"zH" = (
+/obj/item/scalpel{
+	pixel_y = 12
+	},
+/obj/item/circular_saw,
+/obj/item/retractor{
+	pixel_x = 4
+	},
+/obj/item/hemostat{
+	pixel_x = -4
+	},
+/obj/item/clothing/gloves/color/latex,
+/obj/item/clothing/mask/surgical,
+/obj/structure/table/reinforced,
+/turf/open/floor/plasteel/cmo,
+/area/centcom/control)
+"zI" = (
+/obj/structure/bed/roller,
+/obj/machinery/iv_drip,
+/turf/open/floor/plasteel/cmo,
+/area/centcom/control)
+"zJ" = (
+/turf/open/floor/plasteel/cmo,
+/area/centcom/control)
+"zK" = (
+/obj/machinery/computer/med_data,
+/obj/machinery/firealarm{
+	dir = 4;
+	pixel_x = 24
+	},
+/turf/open/floor/plasteel/cmo,
+/area/centcom/control)
+"zL" = (
+/obj/structure/flora/ausbushes/lavendergrass,
+/obj/structure/flora/ausbushes/fullgrass,
+/obj/structure/flora/ausbushes/ywflowers,
+/obj/structure/flora/ausbushes/grassybush,
+/obj/structure/flora/ausbushes/palebush,
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/open/floor/plating/asteroid,
+/area/centcom/evac)
+"zM" = (
+/turf/closed/indestructible/fakeglass{
+	color = "#008000";
+	dir = 1;
+	icon_state = "fakewindows2"
+	},
+/area/wizard_station)
+"zN" = (
+/obj/structure/bookcase/random/reference,
+/turf/open/floor/engine/cult,
+/area/wizard_station)
+"zO" = (
+/obj/structure/destructible/cult/talisman{
+	desc = "An altar dedicated to the Wizards' Federation"
+	},
+/obj/item/kitchen/knife/ritual,
+/turf/open/floor/engine/cult,
+/area/wizard_station)
+"zP" = (
+/obj/item/clothing/shoes/sandal/marisa,
+/obj/item/clothing/suit/wizrobe/marisa,
+/obj/item/clothing/head/wizard/marisa,
+/obj/item/staff/broom,
+/turf/open/floor/engine/cult,
+/area/wizard_station)
+"zQ" = (
+/obj/effect/decal/cleanable/blood/splatter,
+/mob/living/simple_animal/hostile/creature{
+	name = "Experiment 35b"
+	},
+/turf/open/floor/grass,
+/area/wizard_station)
+"zR" = (
+/turf/open/floor/plasteel/vault{
+	dir = 5
+	},
+/area/shuttle/syndicate/medical)
+"zS" = (
+/turf/open/floor/plasteel/podhatch{
+	dir = 9
+	},
+/area/shuttle/syndicate/medical)
+"zT" = (
+/turf/open/floor/plasteel/podhatch{
+	dir = 1
+	},
+/area/shuttle/syndicate/medical)
+"zU" = (
+/obj/machinery/door/airlock/hatch{
+	req_access_txt = "150"
+	},
+/turf/open/floor/plasteel/vault{
+	dir = 8
+	},
+/area/shuttle/syndicate/medical)
+"zV" = (
+/turf/open/floor/plasteel/podhatch{
+	dir = 1
+	},
+/area/shuttle/syndicate/hallway)
+"zW" = (
+/obj/machinery/door/airlock/hatch{
+	req_access_txt = "150"
+	},
+/turf/open/floor/plasteel/vault{
+	dir = 8
+	},
+/area/shuttle/syndicate/armory)
+"zX" = (
+/turf/open/floor/plasteel/podhatch{
+	dir = 1
+	},
+/area/shuttle/syndicate/armory)
+"zY" = (
+/turf/open/floor/plasteel/podhatch{
+	dir = 5
+	},
+/area/shuttle/syndicate/armory)
+"zZ" = (
+/turf/open/floor/plasteel/vault{
+	dir = 5
+	},
+/area/shuttle/syndicate/armory)
+"Aa" = (
+/obj/structure/closet/syndicate/personal,
+/turf/open/floor/plasteel/vault{
+	dir = 8
+	},
+/area/shuttle/syndicate/armory)
+"Ab" = (
+/obj/machinery/photocopier,
+/turf/open/floor/plasteel/grimy,
+/area/centcom/ferry)
+"Ac" = (
+/obj/structure/table/reinforced,
+/obj/item/folder/red{
+	pixel_x = -2;
+	pixel_y = -2
+	},
+/obj/item/folder/blue{
+	pixel_x = 2;
+	pixel_y = 2
+	},
+/obj/item/lighter,
+/turf/open/floor/plasteel/grimy,
+/area/centcom/ferry)
+"Ad" = (
+/obj/structure/table/reinforced,
+/obj/item/storage/secure/briefcase,
+/turf/open/floor/plasteel/vault{
+	dir = 8
+	},
+/area/centcom/ferry)
+"Ae" = (
+/obj/structure/table/reinforced,
+/obj/item/storage/firstaid/regular,
+/turf/open/floor/plasteel/vault{
+	dir = 8
+	},
+/area/centcom/ferry)
+"Af" = (
+/obj/structure/table/reinforced,
+/obj/item/clipboard,
+/obj/item/folder/white,
+/obj/item/pen/blue,
+/turf/open/floor/plasteel/vault{
+	dir = 8
+	},
+/area/centcom/ferry)
+"Ag" = (
+/obj/structure/table/reinforced,
+/obj/item/paper_bin,
+/obj/item/pen,
+/turf/open/floor/plasteel/vault{
+	dir = 8
+	},
+/area/centcom/ferry)
+"Ah" = (
+/obj/structure/chair/office/dark{
+	dir = 8
+	},
+/obj/effect/landmark/ert_spawn,
+/turf/open/floor/plasteel/black,
+/area/centcom/ferry)
+"Ai" = (
+/obj/machinery/door/poddoor/ert,
+/obj/effect/turf_decal/delivery,
+/turf/open/floor/plasteel,
+/area/centcom/ferry)
+"Aj" = (
+/obj/structure/table/reinforced,
+/obj/item/restraints/handcuffs,
+/obj/item/device/radio,
+/obj/effect/turf_decal/stripes/line{
+	dir = 9
+	},
+/turf/open/floor/plasteel,
+/area/centcom/ferry)
+"Ak" = (
+/obj/structure/table/reinforced,
+/obj/item/storage/firstaid/regular,
+/obj/effect/turf_decal/stripes/line{
+	dir = 5
+	},
+/turf/open/floor/plasteel,
+/area/centcom/ferry)
+"Al" = (
+/obj/structure/extinguisher_cabinet{
+	pixel_x = 26
+	},
+/turf/open/floor/plasteel/vault{
+	dir = 8
+	},
+/area/centcom/ferry)
+"Am" = (
+/obj/item/twohanded/required/kirbyplants{
+	icon_state = "plant-21"
+	},
+/turf/open/floor/plasteel/red/corner{
+	dir = 8
+	},
+/area/centcom/control)
+"An" = (
+/obj/machinery/light,
+/turf/open/floor/plasteel/green/corner{
+	dir = 8
+	},
+/area/centcom/control)
+"Ao" = (
+/obj/machinery/light,
+/turf/open/floor/plasteel/green/corner,
+/area/centcom/control)
+"Ap" = (
+/obj/item/twohanded/required/kirbyplants{
+	icon_state = "plant-22"
+	},
+/turf/open/floor/plasteel/blue/corner,
+/area/centcom/control)
+"Aq" = (
+/obj/structure/table/optable,
+/obj/item/surgical_drapes,
+/turf/open/floor/plasteel/cmo,
+/area/centcom/control)
+"Ar" = (
+/turf/open/floor/plasteel/blue,
+/area/centcom/control)
+"As" = (
+/obj/machinery/computer/communications,
+/obj/structure/extinguisher_cabinet{
+	pixel_x = 24
+	},
+/turf/open/floor/plasteel/cmo,
+/area/centcom/control)
+"At" = (
+/turf/open/floor/plasteel/yellowsiding,
+/area/centcom/evac)
+"Au" = (
+/obj/machinery/abductor/experiment{
+	team_number = 3
+	},
+/turf/open/floor/plating/abductor,
+/area/abductor_ship)
+"Av" = (
+/obj/machinery/abductor/console{
+	team_number = 3
+	},
+/turf/open/floor/plating/abductor,
+/area/abductor_ship)
+"Aw" = (
+/obj/machinery/abductor/pad{
+	team_number = 3
+	},
+/turf/open/floor/plating/abductor,
+/area/abductor_ship)
+"Ax" = (
+/turf/closed/indestructible/fakeglass{
+	color = "#008000"
+	},
+/area/wizard_station)
+"Ay" = (
+/obj/effect/landmark/start/wizard,
+/turf/open/floor/engine/cult,
+/area/wizard_station)
+"Az" = (
+/obj/effect/decal/remains/human,
+/obj/effect/decal/cleanable/blood/splatter,
+/turf/open/floor/grass,
+/area/wizard_station)
+"AA" = (
+/obj/item/reagent_containers/food/snacks/meat/slab/human/mutant/slime,
+/turf/open/floor/grass,
+/area/wizard_station)
+"AB" = (
+/obj/effect/decal/remains/xeno,
+/turf/open/floor/grass,
+/area/wizard_station)
+"AC" = (
+/obj/structure/table/reinforced,
+/obj/item/reagent_containers/glass/beaker/large,
+/obj/item/reagent_containers/glass/beaker,
+/obj/item/reagent_containers/dropper,
+/turf/open/floor/plasteel/vault{
+	dir = 8
+	},
+/area/shuttle/syndicate/medical)
+"AD" = (
+/turf/open/floor/plasteel/podhatch{
+	dir = 10
+	},
+/area/shuttle/syndicate/medical)
+"AE" = (
+/turf/open/floor/plasteel/podhatch,
+/area/shuttle/syndicate/medical)
+"AF" = (
+/turf/open/floor/plasteel/podhatch,
+/area/shuttle/syndicate/hallway)
+"AG" = (
+/turf/open/floor/plasteel/podhatch,
+/area/shuttle/syndicate/armory)
+"AH" = (
+/turf/open/floor/plasteel/podhatch{
+	dir = 6
+	},
+/area/shuttle/syndicate/armory)
+"AI" = (
+/obj/structure/closet/syndicate/nuclear,
+/turf/open/floor/plasteel/vault{
+	dir = 8
+	},
+/area/shuttle/syndicate/armory)
+"AJ" = (
+/obj/structure/chair/comfy/brown{
+	color = "#596479";
+	dir = 4
+	},
+/turf/open/floor/plasteel/grimy,
+/area/centcom/ferry)
+"AK" = (
+/obj/item/clipboard,
+/obj/item/folder/red,
+/obj/item/stamp/denied{
+	pixel_x = 3;
+	pixel_y = 3
+	},
+/obj/item/stamp,
+/obj/structure/table/reinforced,
+/turf/open/floor/plasteel/grimy,
+/area/centcom/ferry)
+"AL" = (
+/obj/structure/table/reinforced,
+/obj/item/device/flashlight/seclite,
+/turf/open/floor/plasteel/vault{
+	dir = 8
+	},
+/area/centcom/ferry)
+"AM" = (
+/obj/machinery/shuttle_manipulator,
+/turf/open/floor/circuit/green,
+/area/centcom/ferry)
+"AN" = (
+/turf/open/floor/circuit/green,
+/area/centcom/ferry)
+"AO" = (
+/obj/structure/table/reinforced,
+/obj/item/clipboard,
+/obj/item/folder/red,
+/obj/item/pen/red,
+/turf/open/floor/plasteel/vault{
+	dir = 8
+	},
+/area/centcom/ferry)
+"AP" = (
+/obj/structure/chair/office/dark{
+	dir = 8
+	},
+/obj/effect/landmark/ert_spawn,
+/turf/open/floor/plasteel/vault{
+	dir = 5
+	},
+/area/centcom/ferry)
+"AQ" = (
+/obj/structure/table/reinforced,
+/obj/item/clipboard,
+/obj/item/folder/yellow,
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/centcom/ferry)
+"AR" = (
+/obj/structure/table/reinforced,
+/obj/item/storage/box/zipties,
+/obj/item/crowbar/red,
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/centcom/ferry)
+"AS" = (
+/obj/machinery/power/apc{
+	dir = 4;
+	name = "Briefing Area APC";
+	pixel_x = 26
+	},
+/turf/open/floor/plasteel/vault{
+	dir = 8
+	},
+/area/centcom/ferry)
+"AT" = (
+/obj/structure/sign/bluecross_2,
+/turf/closed/indestructible/riveted,
+/area/centcom/control)
+"AU" = (
+/obj/machinery/computer/operating,
+/turf/open/floor/plasteel/cmo,
+/area/centcom/control)
+"AV" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 10
+	},
+/turf/open/floor/plasteel,
+/area/centcom/evac)
+"AW" = (
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/plasteel,
+/area/centcom/evac)
+"AX" = (
+/obj/structure/table,
+/obj/item/toy/sword,
+/obj/item/gun/ballistic/shotgun/toy/crossbow,
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/plasteel,
+/area/centcom/evac)
+"AY" = (
+/obj/structure/chair{
+	dir = 1
+	},
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/plasteel,
+/area/centcom/evac)
+"AZ" = (
+/obj/structure/chair{
+	dir = 1
+	},
+/obj/effect/turf_decal/stripes/line,
+/obj/machinery/light,
+/turf/open/floor/plasteel,
+/area/centcom/evac)
+"Ba" = (
+/obj/item/twohanded/required/kirbyplants{
+	icon_state = "plant-21"
+	},
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/plasteel,
+/area/centcom/evac)
+"Bb" = (
+/obj/effect/turf_decal/stripes/line,
+/obj/structure/closet/crate/bin,
+/turf/open/floor/plasteel,
+/area/centcom/evac)
+"Bc" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 6
+	},
+/turf/open/floor/plasteel,
+/area/centcom/evac)
+"Bd" = (
+/obj/effect/turf_decal/delivery,
+/obj/machinery/light,
+/turf/open/floor/plasteel,
+/area/centcom/evac)
+"Be" = (
+/obj/machinery/computer/camera_advanced/abductor{
+	team_number = 3
+	},
+/turf/open/floor/plating/abductor,
+/area/abductor_ship)
+"Bf" = (
+/obj/structure/chair/wood/wings{
+	icon_state = "wooden_chair_wings";
+	dir = 1
+	},
+/turf/open/floor/engine/cult,
+/area/wizard_station)
+"Bg" = (
+/mob/living/simple_animal/bot/medbot/mysterious{
+	desc = "If you don't accidentally blow yourself up from time to time you're not really a wizard anyway.";
+	faction = list("neutral","silicon","creature");
+	name = "Nobody's Perfect"
+	},
+/turf/open/floor/engine/cult,
+/area/wizard_station)
+"Bh" = (
+/obj/machinery/light,
+/turf/open/floor/engine/cult,
+/area/wizard_station)
+"Bi" = (
+/obj/item/reagent_containers/food/snacks/meat/slab/xeno,
+/turf/open/floor/grass,
+/area/wizard_station)
+"Bj" = (
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/item/bodypart/r_arm/robot,
+/obj/item/bodypart/l_arm/robot,
+/obj/structure/table/reinforced,
+/obj/item/toy/plush/nukeplushie,
+/turf/open/floor/plasteel/vault,
+/area/shuttle/syndicate/medical)
+"Bk" = (
+/obj/machinery/door/window{
+	dir = 1;
+	name = "Surgery";
+	req_access_txt = "150"
+	},
+/turf/open/floor/plasteel/vault,
+/area/shuttle/syndicate/medical)
+"Bl" = (
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/turf/open/floor/plasteel/vault,
+/area/shuttle/syndicate/medical)
+"Bm" = (
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/item/storage/firstaid/regular{
+	pixel_x = 3;
+	pixel_y = 3
+	},
+/obj/item/storage/firstaid/brute,
+/obj/item/storage/firstaid/regular{
+	pixel_x = -3;
+	pixel_y = -3
+	},
+/obj/structure/table/reinforced,
+/turf/open/floor/plasteel/vault,
+/area/shuttle/syndicate/medical)
+"Bn" = (
+/obj/item/storage/firstaid/regular{
+	pixel_x = 3;
+	pixel_y = 3
+	},
+/obj/item/storage/firstaid/fire,
+/obj/item/storage/firstaid/regular{
+	pixel_x = -3;
+	pixel_y = -3
+	},
+/obj/structure/table/reinforced,
+/turf/open/floor/plasteel/vault,
+/area/shuttle/syndicate/medical)
+"Bo" = (
+/turf/open/floor/plasteel/vault,
+/area/shuttle/syndicate/hallway)
+"Bp" = (
+/obj/item/device/sbeacondrop/bomb{
+	pixel_y = 5
+	},
+/obj/item/device/sbeacondrop/bomb,
+/obj/structure/table/reinforced,
+/turf/open/floor/plasteel/vault{
+	dir = 8
+	},
+/area/shuttle/syndicate/armory)
+"Bq" = (
+/obj/item/grenade/syndieminibomb{
+	pixel_x = 4;
+	pixel_y = 2
+	},
+/obj/item/grenade/syndieminibomb{
+	pixel_x = -1
+	},
+/obj/structure/table/reinforced,
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/item/grenade/plastic/c4,
+/obj/item/grenade/plastic/c4,
+/obj/item/grenade/plastic/c4,
+/obj/item/grenade/plastic/c4,
+/obj/item/grenade/plastic/c4,
+/turf/open/floor/plasteel/vault{
+	dir = 8
+	},
+/area/shuttle/syndicate/armory)
+"Br" = (
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/turf/open/floor/plasteel/vault,
+/area/shuttle/syndicate/armory)
+"Bs" = (
+/obj/machinery/door/window{
+	dir = 1;
+	name = "Technological Storage";
+	req_access_txt = "150"
+	},
+/turf/open/floor/plasteel/vault,
+/area/shuttle/syndicate/armory)
+"Bt" = (
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/structure/table/reinforced,
+/obj/item/device/aicard,
+/turf/open/floor/plasteel/vault,
+/area/shuttle/syndicate/armory)
+"Bu" = (
+/obj/structure/table/wood,
+/obj/item/paper_bin,
+/obj/item/pen/fourcolor,
+/turf/open/floor/plasteel/vault{
+	dir = 8
+	},
+/area/centcom/ferry)
+"Bv" = (
+/obj/machinery/computer/card/centcom,
+/turf/open/floor/plasteel/grimy,
+/area/centcom/ferry)
+"Bw" = (
+/obj/structure/table/reinforced,
+/obj/item/book/manual/wiki/security_space_law,
+/obj/item/device/taperecorder,
+/turf/open/floor/plasteel/grimy,
+/area/centcom/ferry)
+"Bx" = (
+/obj/structure/table/reinforced,
+/obj/item/storage/fancy/donut_box,
+/turf/open/floor/plasteel/vault{
+	dir = 8
+	},
+/area/centcom/ferry)
+"By" = (
+/obj/structure/table/reinforced,
+/obj/item/crowbar/red,
+/obj/item/tank/internals/emergency_oxygen/engi,
+/obj/item/clothing/mask/gas,
+/turf/open/floor/plasteel/vault{
+	dir = 8
+	},
+/area/centcom/ferry)
+"Bz" = (
+/obj/structure/table/reinforced,
+/obj/item/clipboard,
+/obj/item/folder/yellow,
+/obj/item/pen/blue,
+/turf/open/floor/plasteel/vault{
+	dir = 8
+	},
+/area/centcom/ferry)
+"BA" = (
+/obj/structure/table/reinforced,
+/obj/item/restraints/handcuffs/cable/zipties,
+/obj/item/device/assembly/flash/handheld,
+/turf/open/floor/plasteel/vault{
+	dir = 8
+	},
+/area/centcom/ferry)
+"BB" = (
+/obj/structure/table/reinforced,
+/obj/item/storage/lockbox/loyalty,
+/obj/effect/turf_decal/stripes/line{
+	dir = 10
+	},
+/turf/open/floor/plasteel,
+/area/centcom/ferry)
+"BC" = (
+/obj/structure/table/reinforced,
+/obj/item/storage/toolbox/mechanical,
+/obj/item/tank/internals/emergency_oxygen/engi,
+/obj/effect/turf_decal/stripes/line{
+	dir = 6
+	},
+/turf/open/floor/plasteel,
+/area/centcom/ferry)
+"BD" = (
+/obj/machinery/newscaster/security_unit{
+	pixel_x = 32
+	},
+/turf/open/floor/plasteel/vault{
+	dir = 8
+	},
+/area/centcom/ferry)
+"BE" = (
+/obj/machinery/door/poddoor/shutters{
+	id = "XCCsec3";
+	name = "CC Main Access Shutters"
+	},
+/obj/effect/turf_decal/delivery,
+/turf/open/floor/plasteel,
+/area/centcom/control)
+"BF" = (
+/obj/item/defibrillator/loaded,
+/obj/structure/table/reinforced,
+/turf/open/floor/plasteel/cmo,
+/area/centcom/control)
+"BG" = (
+/obj/item/reagent_containers/glass/bottle/epinephrine{
+	pixel_x = 6
+	},
+/obj/item/reagent_containers/glass/bottle/charcoal{
+	pixel_x = -3
+	},
+/obj/item/reagent_containers/glass/bottle/epinephrine{
+	pixel_x = -3;
+	pixel_y = 8
+	},
+/obj/item/reagent_containers/glass/bottle/charcoal{
+	pixel_x = 6;
+	pixel_y = 8
+	},
+/obj/item/reagent_containers/syringe/epinephrine{
+	pixel_x = 3;
+	pixel_y = -2
+	},
+/obj/item/reagent_containers/syringe/epinephrine{
+	pixel_x = 4;
+	pixel_y = 1
+	},
+/obj/item/reagent_containers/syringe/epinephrine{
+	pixel_x = -2;
+	pixel_y = 5
+	},
+/obj/item/reagent_containers/syringe/epinephrine{
+	pixel_x = 2;
+	pixel_y = 8
+	},
+/obj/structure/table/reinforced,
+/turf/open/floor/plasteel/cmo,
+/area/centcom/control)
+"BH" = (
+/obj/machinery/sleeper{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 9
+	},
+/turf/open/floor/plasteel,
+/area/centcom/control)
+"BI" = (
+/obj/machinery/light,
+/obj/structure/noticeboard{
+	dir = 1;
+	pixel_y = -32
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/centcom/control)
+"BJ" = (
+/obj/machinery/sleeper{
+	dir = 8
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 5
+	},
+/turf/open/floor/plasteel,
+/area/centcom/control)
+"BK" = (
+/obj/item/storage/firstaid/fire,
+/obj/item/storage/firstaid/regular{
+	pixel_x = 2;
+	pixel_y = 3
+	},
+/obj/structure/table/reinforced,
+/turf/open/floor/plasteel/cmo,
+/area/centcom/control)
+"BL" = (
+/obj/item/storage/firstaid/toxin,
+/obj/item/storage/firstaid/o2{
+	pixel_x = 3;
+	pixel_y = 3
+	},
+/obj/structure/table/reinforced,
+/obj/machinery/airalarm{
+	dir = 8;
+	pixel_x = 24
+	},
+/turf/open/floor/plasteel/cmo,
+/area/centcom/control)
+"BM" = (
+/obj/machinery/door/airlock/centcom{
+	name = "CentCom Security";
+	opacity = 1;
+	req_access_txt = "101"
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 2
+	},
+/turf/open/floor/plasteel,
+/area/centcom/evac)
+"BN" = (
+/obj/structure/table/reinforced,
+/obj/machinery/door/firedoor,
+/obj/item/storage/fancy/donut_box,
+/obj/machinery/door/window/brigdoor{
+	base_state = "rightsecure";
+	dir = 1;
+	icon_state = "rightsecure";
+	name = "CentCom Customs";
+	req_access_txt = "109"
+	},
+/obj/effect/turf_decal/bot,
+/turf/open/floor/plasteel,
+/area/centcom/evac)
+"BO" = (
+/obj/structure/table/reinforced,
+/obj/machinery/door/firedoor,
+/obj/item/folder/red,
+/obj/item/pen/red,
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/effect/turf_decal/bot,
+/turf/open/floor/plasteel,
+/area/centcom/evac)
+"BP" = (
+/obj/structure/table/reinforced,
+/obj/machinery/door/firedoor,
+/obj/machinery/door/window/brigdoor{
+	base_state = "rightsecure";
+	dir = 1;
+	icon_state = "rightsecure";
+	name = "CentCom Customs";
+	req_access_txt = "109"
+	},
+/obj/effect/turf_decal/bot,
+/turf/open/floor/plasteel,
+/area/centcom/evac)
+"BQ" = (
+/obj/effect/landmark/abductor/scientist{
+	team_number = 3
+	},
+/turf/open/floor/plating/abductor,
+/area/abductor_ship)
+"BR" = (
+/obj/effect/landmark/abductor/agent{
+	team_number = 3
+	},
+/turf/open/floor/plating/abductor,
+/area/abductor_ship)
+"BS" = (
+/obj/machinery/door/airlock{
+	icon = 'icons/obj/doors/airlocks/station/uranium.dmi';
+	name = "Observation Deck"
+	},
+/turf/open/floor/engine/cult,
+/area/wizard_station)
+"BT" = (
 /obj/item/surgicaldrill,
 /obj/item/circular_saw,
 /obj/structure/table/reinforced,
@@ -14467,34 +10637,3848 @@
 	dir = 8
 	},
 /area/shuttle/syndicate/medical)
-"ZE" = (
-/obj/structure/window/plastitanium,
-/turf/open/floor/plasteel/vault{
-	dir = 8
+"BU" = (
+/obj/structure/sink{
+	dir = 4;
+	pixel_x = 11
 	},
-/area/shuttle/syndicate/armory)
-"ZL" = (
+/obj/structure/mirror{
+	pixel_x = 30
+	},
 /turf/open/floor/plasteel/vault{
 	dir = 5
 	},
-/area/shuttle/syndicate/airlock)
-"ZM" = (
-/obj/machinery/door/airlock/hatch{
-	req_access_txt = "150"
+/area/shuttle/syndicate/medical)
+"BV" = (
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
+/area/shuttle/syndicate/hallway)
+"BW" = (
+/obj/machinery/nuclearbomb/syndicate,
+/obj/machinery/door/window{
+	dir = 1;
+	name = "Theatre Stage";
+	req_access_txt = "0"
+	},
+/turf/open/floor/circuit/red,
+/area/shuttle/syndicate/hallway)
+"BX" = (
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/open/floor/plasteel/vault{
+	dir = 5
+	},
+/area/shuttle/syndicate/armory)
+"BY" = (
+/obj/item/toy/figure/syndie,
+/turf/open/floor/plating/asteroid/snow/airless,
+/area/syndicate_mothership)
+"BZ" = (
+/obj/structure/table/wood,
+/obj/item/clipboard,
+/obj/item/device/radio/headset/headset_cent,
+/turf/open/floor/plasteel/vault{
+	dir = 8
+	},
+/area/centcom/ferry)
+"Ca" = (
+/obj/structure/chair/office/dark{
+	dir = 1
+	},
+/obj/effect/landmark/ert_spawn,
+/turf/open/floor/plasteel/black,
+/area/centcom/ferry)
+"Cb" = (
+/obj/structure/chair/office/dark{
+	dir = 1
+	},
+/obj/effect/landmark/ert_spawn,
+/turf/open/floor/plasteel/vault{
+	dir = 5
+	},
+/area/centcom/ferry)
+"Cc" = (
+/turf/open/floor/plasteel/vault{
+	dir = 8
+	},
+/area/centcom/evac)
+"Cd" = (
+/obj/structure/flora/ausbushes/lavendergrass,
+/obj/structure/flora/ausbushes/sparsegrass,
+/obj/structure/flora/ausbushes/fullgrass,
+/obj/structure/flora/ausbushes/brflowers,
+/obj/structure/flora/ausbushes/genericbush,
+/obj/machinery/light,
+/turf/open/floor/grass,
+/area/centcom/evac)
+"Ce" = (
+/obj/structure/table/reinforced,
+/obj/item/restraints/handcuffs/cable/zipties,
+/obj/item/device/assembly/flash/handheld,
+/turf/open/floor/plasteel/vault{
+	dir = 8
+	},
+/area/centcom/evac)
+"Cf" = (
+/turf/open/floor/plasteel/darkred/side{
+	dir = 1
+	},
+/area/centcom/evac)
+"Cg" = (
+/obj/item/cardboard_cutout{
+	desc = "They seem to be ignoring you... Typical.";
+	dir = 1;
+	icon_state = "cutout_ntsec";
+	name = "Private Security Officer"
+	},
+/turf/open/floor/plasteel/darkred/side{
+	dir = 1
+	},
+/area/centcom/evac)
+"Ch" = (
+/obj/machinery/computer/secure_data,
+/obj/machinery/button/door{
+	id = "XCCcustoms1";
+	layer = 3;
+	name = "CC Emergency Docks Control";
+	pixel_x = 24;
+	pixel_y = 24
 	},
 /turf/open/floor/plasteel/vault{
 	dir = 8
 	},
-/area/shuttle/syndicate/armory)
-"ZS" = (
-/turf/closed/wall/mineral/plastitanium/nodiagonal,
+/area/centcom/evac)
+"Ci" = (
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/open/floor/engine/cult,
+/area/wizard_station)
+"Cj" = (
+/obj/item/cautery,
+/obj/item/scalpel,
+/obj/structure/table/reinforced,
+/turf/open/floor/plasteel/vault{
+	dir = 8
+	},
 /area/shuttle/syndicate/medical)
-"ZY" = (
+"Ck" = (
+/obj/structure/table/optable,
+/obj/item/surgical_drapes,
+/turf/open/floor/plasteel/vault{
+	dir = 8
+	},
+/area/shuttle/syndicate/medical)
+"Cl" = (
+/obj/item/retractor,
+/obj/item/hemostat,
+/obj/structure/table/reinforced,
+/turf/open/floor/plasteel/vault{
+	dir = 8
+	},
+/area/shuttle/syndicate/medical)
+"Cm" = (
+/obj/structure/shuttle/engine/heater,
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/plating/airless,
+/area/shuttle/syndicate/hallway)
+"Cn" = (
+/obj/machinery/recharge_station,
+/turf/open/floor/circuit/red,
+/area/shuttle/syndicate/armory)
+"Co" = (
+/obj/machinery/telecomms/allinone{
+	intercept = 1
+	},
+/turf/open/floor/circuit/red,
+/area/shuttle/syndicate/armory)
+"Cp" = (
+/obj/structure/statue/uranium/nuke,
+/turf/open/floor/plating/asteroid/snow/airless,
+/area/syndicate_mothership)
+"Cq" = (
+/obj/structure/table/wood,
+/obj/item/folder/red,
+/obj/item/book/manual/wiki/security_space_law,
+/obj/item/restraints/handcuffs,
+/obj/item/device/assembly/flash/handheld,
+/turf/open/floor/plasteel/vault{
+	dir = 8
+	},
+/area/centcom/ferry)
+"Cr" = (
+/obj/structure/table/wood,
+/obj/item/folder/red,
+/obj/item/lighter,
+/obj/machinery/newscaster{
+	pixel_y = -32
+	},
+/turf/open/floor/plasteel/vault{
+	dir = 8
+	},
+/area/centcom/ferry)
+"Cs" = (
+/obj/structure/bookcase/random,
+/obj/machinery/light,
+/turf/open/floor/plasteel/vault{
+	dir = 8
+	},
+/area/centcom/ferry)
+"Ct" = (
+/obj/structure/filingcabinet/medical,
+/turf/open/floor/plasteel/vault{
+	dir = 8
+	},
+/area/centcom/ferry)
+"Cu" = (
+/obj/structure/filingcabinet/security,
+/turf/open/floor/plasteel/vault{
+	dir = 8
+	},
+/area/centcom/ferry)
+"Cv" = (
+/obj/structure/closet/crate/bin,
+/turf/open/floor/plasteel/vault{
+	dir = 8
+	},
+/area/centcom/ferry)
+"Cw" = (
+/obj/item/twohanded/required/kirbyplants{
+	icon_state = "plant-22"
+	},
+/obj/machinery/power/apc{
+	dir = 2;
+	name = "Briefing Room APC";
+	pixel_y = -26
+	},
+/turf/open/floor/plasteel/vault{
+	dir = 8
+	},
+/area/centcom/ferry)
+"Cx" = (
+/obj/machinery/airalarm{
+	dir = 1;
+	pixel_y = -22
+	},
+/turf/open/floor/plasteel/vault{
+	dir = 8
+	},
+/area/centcom/ferry)
+"Cy" = (
+/obj/item/twohanded/required/kirbyplants{
+	icon_state = "plant-22"
+	},
+/obj/machinery/light,
+/obj/structure/noticeboard{
+	dir = 1;
+	pixel_y = -32
+	},
+/turf/open/floor/plasteel/vault{
+	dir = 8
+	},
+/area/centcom/ferry)
+"Cz" = (
+/obj/item/twohanded/required/kirbyplants{
+	icon_state = "plant-21"
+	},
+/obj/structure/extinguisher_cabinet{
+	pixel_y = -32
+	},
+/turf/open/floor/plasteel/vault{
+	dir = 8
+	},
+/area/centcom/ferry)
+"CA" = (
+/obj/item/device/radio{
+	pixel_x = 5;
+	pixel_y = 5
+	},
+/obj/item/device/radio{
+	pixel_x = -5;
+	pixel_y = 5
+	},
+/obj/item/device/radio,
+/obj/structure/table/wood,
+/turf/open/floor/plasteel/vault{
+	dir = 8
+	},
+/area/centcom/ferry)
+"CB" = (
+/obj/structure/closet/secure_closet/ertMed,
+/obj/structure/sign/directions/medical{
+	dir = 1;
+	pixel_y = -24
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/centcom/ferry)
+"CC" = (
+/obj/structure/closet/secure_closet/ertMed,
+/obj/machinery/vending/wallmed{
+	name = "Emergency NanoMed";
+	pixel_y = -32;
+	req_access_txt = "0";
+	use_power = 0
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 5
+	},
+/turf/open/floor/plasteel,
+/area/centcom/ferry)
+"CD" = (
+/obj/structure/table/reinforced,
+/obj/item/storage/box/emps,
+/obj/item/gun/energy/ionrifle,
+/obj/structure/sign/bluecross_2{
+	pixel_y = -32
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/centcom/ferry)
+"CE" = (
+/obj/structure/table/reinforced,
+/obj/item/storage/box/syringes,
+/obj/item/gun/syringe/rapidsyringe,
+/obj/structure/reagent_dispensers/peppertank{
+	pixel_y = -32
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/centcom/ferry)
+"CF" = (
+/obj/structure/closet/secure_closet/ertSec,
+/obj/effect/turf_decal/stripes/line{
+	dir = 9
+	},
+/turf/open/floor/plasteel,
+/area/centcom/ferry)
+"CG" = (
+/obj/structure/closet/secure_closet/ertSec,
+/obj/structure/sign/directions/security{
+	dir = 1;
+	pixel_y = -24
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/centcom/ferry)
+"CH" = (
+/obj/structure/table/reinforced,
+/obj/item/book/manual/wiki/security_space_law,
+/obj/item/device/taperecorder,
+/obj/machinery/firealarm{
+	dir = 4;
+	pixel_x = 24
+	},
+/turf/open/floor/plasteel/vault{
+	dir = 8
+	},
+/area/centcom/control)
+"CI" = (
+/obj/structure/table,
+/obj/item/paper_bin,
+/obj/item/pen,
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/open/floor/plasteel/green/side{
+	dir = 9
+	},
+/area/centcom/control)
+"CJ" = (
+/obj/structure/chair,
+/turf/open/floor/plasteel/green/corner{
+	dir = 1
+	},
+/area/centcom/control)
+"CK" = (
+/obj/structure/chair,
+/turf/open/floor/plasteel/green/corner{
+	dir = 4
+	},
+/area/centcom/control)
+"CL" = (
+/obj/structure/table,
+/obj/item/paper/pamphlet/centcom/visitor_info,
+/obj/item/paper/pamphlet/centcom/visitor_info,
+/obj/item/paper/pamphlet/centcom/visitor_info,
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/open/floor/plasteel/green/side{
+	dir = 5
+	},
+/area/centcom/control)
+"CM" = (
+/obj/structure/filingcabinet/medical,
+/obj/machinery/firealarm{
+	dir = 8;
+	pixel_x = -24
+	},
+/turf/open/floor/plasteel/vault{
+	dir = 8
+	},
+/area/centcom/control)
+"CN" = (
+/obj/structure/table/reinforced,
+/obj/item/storage/firstaid/regular,
+/turf/open/floor/plasteel/vault{
+	dir = 8
+	},
+/area/centcom/control)
+"CO" = (
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/open/floor/plasteel/vault{
+	dir = 5
+	},
+/area/centcom/evac)
+"CP" = (
+/obj/structure/table/reinforced,
+/obj/machinery/recharger,
+/turf/open/floor/plasteel/vault{
+	dir = 8
+	},
+/area/centcom/evac)
+"CQ" = (
+/turf/open/floor/plasteel/vault{
+	dir = 5
+	},
+/area/centcom/evac)
+"CR" = (
+/obj/machinery/computer/security,
+/obj/machinery/newscaster{
+	pixel_x = 32
+	},
+/turf/open/floor/plasteel/vault{
+	dir = 8
+	},
+/area/centcom/evac)
+"CS" = (
+/obj/structure/shuttle/engine/heater,
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/plating/airless,
+/area/shuttle/syndicate/medical)
+"CT" = (
+/obj/structure/shuttle/engine/propulsion/left,
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/plating/airless,
+/area/shuttle/syndicate/hallway)
+"CU" = (
+/obj/structure/shuttle/engine/propulsion,
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/plating/airless,
+/area/shuttle/syndicate/hallway)
+"CV" = (
+/obj/structure/shuttle/engine/propulsion/right,
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/plating/airless,
+/area/shuttle/syndicate/hallway)
+"CW" = (
+/obj/structure/shuttle/engine/heater,
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/plating/airless,
+/area/shuttle/syndicate/armory)
+"CX" = (
+/obj/structure/closet/secure_closet/security,
+/obj/item/storage/belt/security/full,
+/obj/item/gun/ballistic/automatic/wt550,
+/obj/item/clothing/head/helmet/swat/nanotrasen,
+/obj/item/crowbar/red,
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/open/floor/plasteel/vault{
+	dir = 8
+	},
+/area/centcom/control)
+"CY" = (
+/obj/structure/chair{
+	dir = 4
+	},
+/turf/open/floor/plasteel/red/corner{
+	dir = 1
+	},
+/area/centcom/control)
+"CZ" = (
+/obj/structure/chair{
+	dir = 8
+	},
+/turf/open/floor/plasteel/blue/corner{
+	dir = 4
+	},
+/area/centcom/control)
+"Da" = (
+/obj/structure/table/reinforced,
+/obj/item/reagent_containers/glass/bottle/charcoal{
+	pixel_x = 6
+	},
+/obj/item/reagent_containers/glass/bottle/epinephrine{
+	pixel_x = -4
+	},
+/obj/item/reagent_containers/hypospray/medipen,
+/turf/open/floor/plasteel/vault{
+	dir = 8
+	},
+/area/centcom/control)
+"Db" = (
+/obj/structure/table/reinforced,
+/obj/item/paper_bin,
+/obj/item/pen,
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/open/floor/plasteel/vault{
+	dir = 8
+	},
+/area/centcom/control)
+"Dc" = (
+/obj/structure/closet/secure_closet/security,
+/obj/item/storage/belt/security/full,
+/obj/item/gun/ballistic/automatic/wt550,
+/obj/item/clothing/head/helmet/swat/nanotrasen,
+/obj/item/crowbar/red,
+/turf/open/floor/plasteel/vault{
+	dir = 8
+	},
+/area/centcom/evac)
+"Dd" = (
+/obj/structure/table/reinforced,
+/obj/item/crowbar/red,
+/turf/open/floor/plasteel/vault{
+	dir = 8
+	},
+/area/centcom/evac)
+"De" = (
+/obj/structure/table/reinforced,
+/obj/item/storage/box/handcuffs,
+/turf/open/floor/plasteel/vault{
+	dir = 8
+	},
+/area/centcom/evac)
+"Df" = (
+/obj/item/twohanded/required/kirbyplants{
+	icon_state = "plant-21"
+	},
+/obj/structure/extinguisher_cabinet{
+	pixel_x = -24
+	},
+/turf/open/floor/plasteel/vault{
+	dir = 8
+	},
+/area/centcom/evac)
+"Dg" = (
+/obj/item/cardboard_cutout{
+	desc = "They seem to be ignoring you... Typical.";
+	icon_state = "cutout_ntsec";
+	name = "Private Security Officer"
+	},
+/turf/open/floor/plasteel/vault{
+	dir = 5
+	},
+/area/centcom/evac)
+"Dh" = (
+/obj/item/clipboard,
+/obj/item/folder/red,
+/obj/item/stamp/denied{
+	pixel_x = 3;
+	pixel_y = 3
+	},
+/obj/item/stamp,
+/obj/structure/table/reinforced,
+/turf/open/floor/plasteel/vault{
+	dir = 8
+	},
+/area/centcom/evac)
+"Di" = (
+/obj/structure/shuttle/engine/propulsion/left,
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/plating/airless,
+/area/shuttle/syndicate/medical)
+"Dj" = (
+/obj/structure/shuttle/engine/propulsion,
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/plating/airless,
+/area/shuttle/syndicate/medical)
+"Dk" = (
+/obj/structure/shuttle/engine/propulsion/right,
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/plating/airless,
+/area/shuttle/syndicate/medical)
+"Dl" = (
 /obj/machinery/porta_turret/syndicate{
 	dir = 6
 	},
 /turf/closed/wall/mineral/plastitanium,
 /area/shuttle/syndicate/medical)
+"Dm" = (
+/obj/machinery/porta_turret/syndicate{
+	dir = 10
+	},
+/turf/closed/wall/mineral/plastitanium,
+/area/shuttle/syndicate/armory)
+"Dn" = (
+/obj/structure/shuttle/engine/propulsion/left,
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/plating/airless,
+/area/shuttle/syndicate/armory)
+"Do" = (
+/obj/structure/shuttle/engine/propulsion,
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/plating/airless,
+/area/shuttle/syndicate/armory)
+"Dp" = (
+/obj/structure/shuttle/engine/propulsion/right,
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/plating/airless,
+/area/shuttle/syndicate/armory)
+"Dq" = (
+/obj/machinery/door/airlock/external,
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/centcom/control)
+"Dr" = (
+/obj/machinery/door/airlock/external,
+/turf/open/floor/plasteel/vault{
+	dir = 8
+	},
+/area/centcom/control)
+"Ds" = (
+/turf/open/floor/plasteel/darkred/side{
+	dir = 4
+	},
+/area/centcom/control)
+"Dt" = (
+/obj/structure/table/reinforced,
+/obj/machinery/door/firedoor,
+/obj/item/storage/fancy/donut_box,
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/effect/turf_decal/bot,
+/turf/open/floor/plasteel,
+/area/centcom/control)
+"Du" = (
+/obj/structure/table/reinforced,
+/obj/machinery/door/firedoor,
+/obj/item/reagent_containers/food/drinks/britcup,
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/effect/turf_decal/bot,
+/turf/open/floor/plasteel,
+/area/centcom/control)
+"Dv" = (
+/turf/open/floor/plasteel/darkblue/side{
+	dir = 8
+	},
+/area/centcom/control)
+"Dw" = (
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/open/floor/plasteel/vault{
+	dir = 8
+	},
+/area/centcom/control)
+"Dx" = (
+/obj/machinery/light,
+/turf/open/floor/plasteel/vault{
+	dir = 5
+	},
+/area/centcom/evac)
+"Dy" = (
+/turf/open/floor/plasteel/vault{
+	dir = 9
+	},
+/area/centcom/evac)
+"Dz" = (
+/obj/structure/table/reinforced,
+/obj/item/paper_bin,
+/obj/item/pen,
+/obj/machinery/light,
+/turf/open/floor/plasteel/vault{
+	dir = 8
+	},
+/area/centcom/evac)
+"DA" = (
+/obj/structure/table/reinforced,
+/obj/item/book/manual/wiki/security_space_law,
+/obj/item/device/taperecorder,
+/turf/open/floor/plasteel/vault{
+	dir = 8
+	},
+/area/centcom/evac)
+"DB" = (
+/obj/item/storage/box/ids{
+	pixel_x = 3;
+	pixel_y = 3
+	},
+/obj/item/storage/box/silver_ids,
+/obj/structure/table/reinforced,
+/obj/structure/reagent_dispensers/peppertank{
+	pixel_x = 32
+	},
+/turf/open/floor/plasteel/vault{
+	dir = 8
+	},
+/area/centcom/evac)
+"DC" = (
+/obj/machinery/door/airlock{
+	icon = 'icons/obj/doors/airlocks/station/uranium.dmi';
+	name = "Storage"
+	},
+/turf/open/floor/engine/cult,
+/area/wizard_station)
+"DD" = (
+/obj/machinery/door/airlock{
+	icon = 'icons/obj/doors/airlocks/station/uranium.dmi';
+	name = "Personal Quarters"
+	},
+/turf/open/floor/engine/cult,
+/area/wizard_station)
+"DE" = (
+/obj/machinery/door/airlock{
+	icon = 'icons/obj/doors/airlocks/station/uranium.dmi';
+	name = "Bathroom"
+	},
+/turf/open/floor/engine/cult,
+/area/wizard_station)
+"DF" = (
+/obj/item/clipboard,
+/obj/item/folder/red,
+/obj/item/stamp/denied{
+	pixel_x = 3;
+	pixel_y = 3
+	},
+/obj/item/stamp,
+/obj/structure/table/reinforced,
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/open/floor/plasteel/vault{
+	dir = 8
+	},
+/area/centcom/control)
+"DG" = (
+/obj/structure/chair/office/dark{
+	dir = 4
+	},
+/turf/open/floor/plasteel/darkred/side{
+	dir = 4
+	},
+/area/centcom/control)
+"DH" = (
+/obj/structure/table/reinforced,
+/obj/machinery/door/firedoor,
+/obj/item/folder/red,
+/obj/item/pen/red,
+/obj/machinery/door/window/brigdoor{
+	name = "CentCom Customs";
+	icon_state = "rightsecure";
+	dir = 4;
+	req_access_txt = "109";
+	base_state = "rightsecure"
+	},
+/obj/effect/turf_decal/bot,
+/turf/open/floor/plasteel,
+/area/centcom/control)
+"DI" = (
+/obj/structure/table/reinforced,
+/obj/machinery/door/firedoor,
+/obj/item/folder/white,
+/obj/item/pen/blue,
+/obj/machinery/door/window/brigdoor{
+	name = "CentCom Customs";
+	icon_state = "rightsecure";
+	dir = 8;
+	req_access_txt = "109";
+	base_state = "rightsecure"
+	},
+/obj/effect/turf_decal/bot,
+/turf/open/floor/plasteel,
+/area/centcom/control)
+"DJ" = (
+/obj/structure/chair/office/dark{
+	dir = 8
+	},
+/turf/open/floor/plasteel/darkblue/side{
+	dir = 8
+	},
+/area/centcom/control)
+"DK" = (
+/turf/closed/indestructible/fakedoor{
+	name = "CentCom"
+	},
+/area/centcom/evac)
+"DL" = (
+/obj/item/clothing/suit/wizrobe/black,
+/obj/item/clothing/head/wizard/black,
+/obj/effect/turf_decal/bot,
+/turf/open/floor/plasteel,
+/area/wizard_station)
+"DM" = (
+/obj/effect/turf_decal/bot,
+/turf/open/floor/plasteel,
+/area/wizard_station)
+"DN" = (
+/obj/item/cardboard_cutout,
+/obj/effect/turf_decal/bot,
+/turf/open/floor/plasteel,
+/area/wizard_station)
+"DO" = (
+/obj/structure/table/wood,
+/obj/item/dice/d20,
+/obj/item/dice,
+/turf/open/floor/carpet,
+/area/wizard_station)
+"DP" = (
+/obj/structure/punching_bag,
+/turf/open/floor/carpet,
+/area/wizard_station)
+"DQ" = (
+/obj/structure/urinal{
+	pixel_y = 28
+	},
+/turf/open/floor/plasteel/white,
+/area/wizard_station)
+"DR" = (
+/turf/open/floor/plasteel/white,
+/area/wizard_station)
+"DS" = (
+/obj/structure/mirror/magic{
+	pixel_y = 28
+	},
+/obj/structure/sink{
+	pixel_y = 20
+	},
+/turf/open/floor/plasteel/white,
+/area/wizard_station)
+"DT" = (
+/obj/structure/table/reinforced,
+/obj/machinery/button/door{
+	id = "XCCsec3";
+	name = "CC Main Access Control"
+	},
+/obj/machinery/airalarm{
+	dir = 1;
+	pixel_y = -22
+	},
+/turf/open/floor/plasteel/vault{
+	dir = 8
+	},
+/area/centcom/control)
+"DU" = (
+/obj/machinery/computer/security,
+/obj/machinery/newscaster{
+	pixel_y = -32
+	},
+/turf/open/floor/plasteel/vault{
+	dir = 8
+	},
+/area/centcom/control)
+"DV" = (
+/obj/item/twohanded/required/kirbyplants{
+	icon_state = "plant-21"
+	},
+/turf/open/floor/plasteel/green/corner{
+	dir = 8
+	},
+/area/centcom/control)
+"DW" = (
+/obj/item/twohanded/required/kirbyplants{
+	icon_state = "plant-22"
+	},
+/turf/open/floor/plasteel/green/corner,
+/area/centcom/control)
+"DX" = (
+/obj/machinery/newscaster{
+	pixel_y = -32
+	},
+/obj/machinery/computer/med_data,
+/turf/open/floor/plasteel/vault{
+	dir = 8
+	},
+/area/centcom/control)
+"DY" = (
+/obj/structure/table/reinforced,
+/obj/item/clipboard,
+/obj/item/folder/white,
+/obj/item/pen/blue,
+/obj/machinery/airalarm{
+	dir = 1;
+	pixel_y = -22
+	},
+/turf/open/floor/plasteel/vault{
+	dir = 8
+	},
+/area/centcom/control)
+"DZ" = (
+/obj/item/cautery/alien,
+/obj/effect/turf_decal/bot,
+/turf/open/floor/plasteel,
+/area/wizard_station)
+"Ea" = (
+/obj/item/coin/antagtoken,
+/obj/effect/turf_decal/bot,
+/turf/open/floor/plasteel,
+/area/wizard_station)
+"Eb" = (
+/obj/machinery/light/small{
+	brightness = 3;
+	dir = 8
+	},
+/turf/open/floor/carpet,
+/area/wizard_station)
+"Ec" = (
+/obj/structure/bed,
+/obj/item/bedsheet/wiz,
+/turf/open/floor/carpet,
+/area/wizard_station)
+"Ed" = (
+/obj/machinery/light/small{
+	dir = 4
+	},
+/turf/open/floor/carpet,
+/area/wizard_station)
+"Ee" = (
+/obj/item/soap/homemade,
+/obj/machinery/light/small{
+	brightness = 3;
+	dir = 8
+	},
+/turf/open/floor/plasteel/white,
+/area/wizard_station)
+"Ef" = (
+/obj/machinery/light/small{
+	dir = 4
+	},
+/turf/open/floor/plasteel/white,
+/area/wizard_station)
+"Eg" = (
+/obj/machinery/door/airlock/centcom{
+	name = "Thunderdome Booth";
+	opacity = 1;
+	req_access_txt = "0"
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 2
+	},
+/turf/open/floor/plasteel,
+/area/centcom/control)
+"Eh" = (
+/obj/structure/closet/cardboard,
+/obj/item/banhammer,
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/plasteel,
+/area/wizard_station)
+"Ei" = (
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/plasteel,
+/area/wizard_station)
+"Ej" = (
+/obj/vehicle/scooter/skateboard{
+	icon_state = "skateboard";
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/line,
+/obj/machinery/light/small,
+/turf/open/floor/plasteel,
+/area/wizard_station)
+"Ek" = (
+/obj/structure/dresser,
+/obj/item/storage/backpack/satchel,
+/turf/open/floor/carpet,
+/area/wizard_station)
+"El" = (
+/obj/structure/table/wood,
+/obj/item/storage/bag/tray,
+/obj/item/reagent_containers/food/snacks/burger/spell,
+/turf/open/floor/carpet,
+/area/wizard_station)
+"Em" = (
+/obj/structure/bookcase/random/adult,
+/turf/open/floor/plasteel/white,
+/area/wizard_station)
+"En" = (
+/obj/structure/toilet{
+	dir = 1
+	},
+/turf/open/floor/plasteel/white,
+/area/wizard_station)
+"Eo" = (
+/obj/structure/table/wood/fancy,
+/obj/item/skub{
+	pixel_y = 16
+	},
+/turf/open/floor/plasteel/white,
+/area/wizard_station)
+"Ep" = (
+/turf/closed/indestructible/riveted,
+/area/tdome/tdomeobserve)
+"Eq" = (
+/obj/machinery/door/airlock/external,
+/obj/effect/turf_decal/stripes/line{
+	dir = 2
+	},
+/turf/open/floor/plasteel,
+/area/tdome/tdomeobserve)
+"Er" = (
+/obj/machinery/vending/cola,
+/obj/effect/turf_decal/delivery,
+/turf/open/floor/plasteel,
+/area/tdome/tdomeobserve)
+"Es" = (
+/obj/machinery/vending/snack,
+/obj/effect/turf_decal/delivery,
+/turf/open/floor/plasteel,
+/area/tdome/tdomeobserve)
+"Et" = (
+/obj/item/clipboard,
+/obj/item/stamp/denied{
+	pixel_x = 3;
+	pixel_y = 3
+	},
+/obj/item/stamp,
+/obj/structure/table/reinforced,
+/turf/open/floor/plasteel/vault{
+	dir = 8
+	},
+/area/tdome/tdomeobserve)
+"Eu" = (
+/obj/structure/table/reinforced,
+/obj/item/paper_bin,
+/obj/item/pen/red,
+/turf/open/floor/plasteel/vault{
+	dir = 8
+	},
+/area/tdome/tdomeobserve)
+"Ev" = (
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
+/area/tdome/tdomeobserve)
+"Ew" = (
+/obj/structure/table,
+/obj/item/paper_bin,
+/obj/item/pen,
+/turf/open/floor/plasteel/green/side{
+	dir = 9
+	},
+/area/tdome/tdomeobserve)
+"Ex" = (
+/obj/structure/chair,
+/turf/open/floor/plasteel/green/corner{
+	dir = 1
+	},
+/area/tdome/tdomeobserve)
+"Ey" = (
+/obj/effect/turf_decal/bot,
+/turf/open/floor/plasteel,
+/area/tdome/tdomeobserve)
+"Ez" = (
+/obj/structure/chair,
+/turf/open/floor/plasteel/green/corner{
+	dir = 4
+	},
+/area/tdome/tdomeobserve)
+"EA" = (
+/obj/structure/closet/crate/bin,
+/turf/open/floor/plasteel/green/side{
+	dir = 5
+	},
+/area/tdome/tdomeobserve)
+"EB" = (
+/obj/machinery/door/airlock/centcom{
+	name = "CentCom Security";
+	opacity = 1;
+	req_access_txt = "101"
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 2
+	},
+/turf/open/floor/plasteel,
+/area/tdome/tdomeobserve)
+"EC" = (
+/obj/machinery/door/airlock{
+	icon = 'icons/obj/doors/airlocks/station/uranium.dmi';
+	name = "Engine Room"
+	},
+/obj/structure/barricade/wooden,
+/turf/open/floor/engine/cult,
+/area/wizard_station)
+"ED" = (
+/turf/closed/indestructible/riveted,
+/area/centcom/holding)
+"EE" = (
+/obj/structure/closet/crate/bin,
+/turf/open/floor/plasteel/vault{
+	dir = 8
+	},
+/area/tdome/tdomeobserve)
+"EF" = (
+/obj/structure/fans/tiny,
+/turf/open/floor/plasteel/vault{
+	dir = 8
+	},
+/area/tdome/tdomeobserve)
+"EG" = (
+/obj/structure/flora/ausbushes/sparsegrass,
+/obj/structure/flora/ausbushes/lavendergrass,
+/obj/structure/flora/ausbushes/fernybush,
+/turf/open/floor/plasteel{
+	name = "plating";
+	icon_state = "asteroid5"
+	},
+/area/tdome/tdomeobserve)
+"EH" = (
+/obj/structure/flora/ausbushes/sparsegrass,
+/obj/structure/flora/ausbushes/grassybush,
+/obj/structure/flora/ausbushes/fernybush,
+/turf/open/floor/plasteel{
+	dir = 6;
+	icon_state = "asteroid8";
+	name = "sand"
+	},
+/area/tdome/tdomeobserve)
+"EI" = (
+/turf/open/floor/plasteel/red/corner,
+/area/tdome/tdomeobserve)
+"EJ" = (
+/turf/open/floor/plasteel/neutral/corner{
+	dir = 8;
+	heat_capacity = 1e+006
+	},
+/area/tdome/tdomeobserve)
+"EK" = (
+/obj/machinery/status_display,
+/turf/closed/indestructible/riveted,
+/area/tdome/tdomeobserve)
+"EL" = (
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/open/floor/plasteel/red/side{
+	dir = 8
+	},
+/area/tdome/tdomeobserve)
+"EM" = (
+/obj/structure/chair/office/light{
+	dir = 4
+	},
+/turf/open/floor/plasteel/neutral,
+/area/tdome/tdomeobserve)
+"EN" = (
+/obj/structure/table/reinforced,
+/obj/machinery/door/firedoor,
+/obj/item/paper/pamphlet/centcom/visitor_info,
+/obj/effect/turf_decal/bot,
+/turf/open/floor/plasteel,
+/area/tdome/tdomeobserve)
+"EO" = (
+/turf/open/floor/plasteel/neutral,
+/area/tdome/tdomeobserve)
+"EP" = (
+/obj/structure/chair/office/light{
+	dir = 8
+	},
+/turf/open/floor/plasteel/neutral,
+/area/tdome/tdomeobserve)
+"EQ" = (
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/open/floor/plasteel/green/side{
+	dir = 4
+	},
+/area/tdome/tdomeobserve)
+"ER" = (
+/turf/open/floor/plasteel/neutral/corner,
+/area/tdome/tdomeobserve)
+"ES" = (
+/turf/open/floor/plasteel/green/corner{
+	dir = 8
+	},
+/area/tdome/tdomeobserve)
+"ET" = (
+/obj/structure/flora/ausbushes/lavendergrass,
+/obj/structure/flora/ausbushes/sparsegrass,
+/obj/structure/flora/ausbushes/ywflowers,
+/obj/structure/flora/ausbushes/grassybush,
+/obj/structure/flora/ausbushes/palebush,
+/turf/open/floor/plating/asteroid,
+/area/tdome/tdomeobserve)
+"EU" = (
+/obj/structure/flora/ausbushes/lavendergrass,
+/obj/structure/flora/ausbushes/fullgrass,
+/obj/structure/flora/ausbushes/ywflowers,
+/obj/structure/flora/ausbushes/grassybush,
+/obj/structure/flora/ausbushes/palebush,
+/turf/open/floor/plating/asteroid,
+/area/tdome/tdomeobserve)
+"EV" = (
+/obj/structure/closet/crate/bin,
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/open/floor/plasteel/vault{
+	dir = 8
+	},
+/area/tdome/tdomeobserve)
+"EW" = (
+/obj/structure/table/wood,
+/turf/open/floor/engine/cult,
+/area/wizard_station)
+"EX" = (
+/obj/structure/table/wood,
+/obj/item/gun/magic/wand{
+	desc = "Used in emergencies to reignite magma engines.";
+	max_charges = 0;
+	name = "wand of emergency engine ignition"
+	},
+/turf/open/floor/engine/cult,
+/area/wizard_station)
+"EY" = (
+/obj/structure/table/wood,
+/obj/item/bikehorn/golden{
+	pixel_x = -8;
+	pixel_y = 8
+	},
+/turf/open/floor/engine/cult,
+/area/wizard_station)
+"EZ" = (
+/obj/structure/table,
+/turf/open/floor/plasteel/freezer{
+	dir = 2
+	},
+/area/centcom/holding)
+"Fa" = (
+/turf/open/floor/plasteel/freezer{
+	dir = 2
+	},
+/area/centcom/holding)
+"Fb" = (
+/obj/structure/closet/secure_closet/bar{
+	req_access_txt = "25"
+	},
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/open/floor/plasteel/freezer{
+	dir = 2
+	},
+/area/centcom/holding)
+"Fc" = (
+/obj/structure/reagent_dispensers/beerkeg,
+/turf/open/floor/plasteel/freezer{
+	dir = 2
+	},
+/area/centcom/holding)
+"Fd" = (
+/obj/structure/table,
+/obj/item/storage/box/donkpockets{
+	pixel_x = 3;
+	pixel_y = 3
+	},
+/obj/item/storage/box/donkpockets{
+	pixel_x = 3;
+	pixel_y = 3
+	},
+/obj/item/storage/box/donkpockets{
+	pixel_x = 3;
+	pixel_y = 3
+	},
+/obj/item/storage/box/donkpockets{
+	pixel_x = 3;
+	pixel_y = 3
+	},
+/turf/open/floor/plasteel/freezer{
+	dir = 2
+	},
+/area/centcom/holding)
+"Fe" = (
+/obj/structure/rack,
+/obj/item/device/camera,
+/turf/open/floor/plasteel/cafeteria,
+/area/centcom/holding)
+"Ff" = (
+/obj/structure/rack,
+/obj/item/toy/sword,
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/open/floor/plasteel/cafeteria,
+/area/centcom/holding)
+"Fg" = (
+/obj/structure/rack,
+/obj/item/toy/gun,
+/turf/open/floor/plasteel/cafeteria,
+/area/centcom/holding)
+"Fh" = (
+/turf/open/floor/plasteel/cafeteria,
+/area/centcom/holding)
+"Fi" = (
+/turf/open/floor/plating/beach/sand,
+/area/centcom/holding)
+"Fj" = (
+/obj/effect/overlay/palmtree_r,
+/obj/effect/overlay/coconut,
+/turf/open/floor/plating/beach/sand,
+/area/centcom/holding)
+"Fk" = (
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/open/floor/plating/beach/sand,
+/area/centcom/holding)
+"Fl" = (
+/obj/effect/overlay/palmtree_l,
+/turf/open/floor/plating/beach/sand,
+/area/centcom/holding)
+"Fm" = (
+/obj/machinery/shower{
+	dir = 4
+	},
+/turf/open/floor/plasteel/whitered/side{
+	dir = 9
+	},
+/area/tdome/tdomeobserve)
+"Fn" = (
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/open/floor/plasteel/whitered/side{
+	dir = 1
+	},
+/area/tdome/tdomeobserve)
+"Fo" = (
+/obj/machinery/shower{
+	dir = 8
+	},
+/turf/open/floor/plasteel/whitered/side{
+	dir = 5
+	},
+/area/tdome/tdomeobserve)
+"Fp" = (
+/turf/open/floor/plasteel/neutral/side{
+	dir = 4
+	},
+/area/tdome/tdomeobserve)
+"Fq" = (
+/turf/open/floor/plasteel/red/side{
+	dir = 8
+	},
+/area/tdome/tdomeobserve)
+"Fr" = (
+/obj/machinery/door/window/brigdoor{
+	base_state = "rightsecure";
+	dir = 2;
+	icon_state = "rightsecure";
+	name = "Thunderdome Booth";
+	req_access_txt = "109"
+	},
+/obj/effect/turf_decal/bot,
+/turf/open/floor/plasteel,
+/area/tdome/tdomeobserve)
+"Fs" = (
+/obj/item/twohanded/required/kirbyplants{
+	icon_state = "plant-22"
+	},
+/turf/open/floor/plasteel/green/corner{
+	dir = 8
+	},
+/area/tdome/tdomeobserve)
+"Ft" = (
+/turf/open/floor/plasteel/goonplaque{
+	desc = "This is a plaque commemorating the thunderdome and all those who have died at its pearly blast doors."
+	},
+/area/tdome/tdomeobserve)
+"Fu" = (
+/obj/item/twohanded/required/kirbyplants{
+	icon_state = "plant-21"
+	},
+/turf/open/floor/plasteel/green/corner,
+/area/tdome/tdomeobserve)
+"Fv" = (
+/turf/open/floor/plasteel/green/side{
+	dir = 4
+	},
+/area/tdome/tdomeobserve)
+"Fw" = (
+/turf/open/floor/plasteel/neutral/side{
+	dir = 8
+	},
+/area/tdome/tdomeobserve)
+"Fx" = (
+/obj/machinery/shower{
+	dir = 4
+	},
+/turf/open/floor/plasteel/whitegreen/side{
+	dir = 9
+	},
+/area/tdome/tdomeobserve)
+"Fy" = (
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/open/floor/plasteel/whitegreen/side{
+	dir = 1
+	},
+/area/tdome/tdomeobserve)
+"Fz" = (
+/obj/machinery/shower{
+	dir = 8
+	},
+/turf/open/floor/plasteel/whitegreen/side{
+	dir = 5
+	},
+/area/tdome/tdomeobserve)
+"FA" = (
+/obj/structure/table,
+/obj/item/clothing/head/that,
+/turf/open/floor/plasteel/freezer{
+	dir = 2
+	},
+/area/centcom/holding)
+"FB" = (
+/obj/structure/chair/stool{
+	pixel_y = 8
+	},
+/turf/open/floor/plasteel/cafeteria,
+/area/centcom/holding)
+"FC" = (
+/obj/item/device/camera,
+/turf/open/floor/plating/beach/sand,
+/area/centcom/holding)
+"FD" = (
+/obj/machinery/shower{
+	dir = 4
+	},
+/turf/open/floor/plasteel/whitered/corner{
+	dir = 1
+	},
+/area/tdome/tdomeobserve)
+"FE" = (
+/obj/item/soap/nanotrasen,
+/turf/open/floor/plasteel/white,
+/area/tdome/tdomeobserve)
+"FF" = (
+/obj/machinery/shower{
+	dir = 8
+	},
+/turf/open/floor/plasteel/whitered/corner{
+	dir = 4
+	},
+/area/tdome/tdomeobserve)
+"FG" = (
+/obj/item/twohanded/required/kirbyplants{
+	icon_state = "plant-21"
+	},
+/turf/open/floor/plasteel/red/corner,
+/area/tdome/tdomeobserve)
+"FH" = (
+/turf/open/floor/plasteel/neutral/side,
+/area/tdome/tdomeobserve)
+"FI" = (
+/turf/open/floor/plasteel/red/side,
+/area/tdome/tdomeobserve)
+"FJ" = (
+/turf/open/floor/plasteel/red/side{
+	dir = 6
+	},
+/area/tdome/tdomeobserve)
+"FK" = (
+/obj/machinery/door/airlock/centcom{
+	name = "Thunderdome Backstage";
+	opacity = 1;
+	req_access_txt = "0"
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/tdome/tdomeobserve)
+"FL" = (
+/turf/open/floor/plasteel/neutral/side{
+	dir = 1;
+	heat_capacity = 1e+006
+	},
+/area/tdome/tdomeobserve)
+"FM" = (
+/turf/open/floor/plasteel/neutral/corner{
+	dir = 1
+	},
+/area/tdome/tdomeobserve)
+"FN" = (
+/turf/open/floor/plasteel/neutral/corner{
+	dir = 4
+	},
+/area/tdome/tdomeobserve)
+"FO" = (
+/turf/open/floor/plasteel/green/side{
+	dir = 10
+	},
+/area/tdome/tdomeobserve)
+"FP" = (
+/turf/open/floor/plasteel/green/side,
+/area/tdome/tdomeobserve)
+"FQ" = (
+/obj/item/twohanded/required/kirbyplants{
+	icon_state = "plant-21"
+	},
+/turf/open/floor/plasteel/green/corner{
+	dir = 8
+	},
+/area/tdome/tdomeobserve)
+"FR" = (
+/obj/machinery/shower{
+	dir = 4
+	},
+/turf/open/floor/plasteel/whitegreen/corner{
+	dir = 1
+	},
+/area/tdome/tdomeobserve)
+"FS" = (
+/obj/machinery/shower{
+	dir = 8
+	},
+/turf/open/floor/plasteel/whitegreen/corner{
+	dir = 4
+	},
+/area/tdome/tdomeobserve)
+"FT" = (
+/obj/structure/destructible/cult/forge{
+	desc = "An engine used in powering the wizard's ship";
+	name = "magma engine"
+	},
+/turf/open/floor/engine/cult,
+/area/wizard_station)
+"FU" = (
+/obj/structure/table,
+/obj/item/ammo_box/foambox,
+/turf/open/floor/plasteel/freezer{
+	dir = 2
+	},
+/area/centcom/holding)
+"FV" = (
+/obj/structure/table,
+/obj/item/reagent_containers/food/drinks/shaker,
+/turf/open/floor/plasteel/freezer{
+	dir = 2
+	},
+/area/centcom/holding)
+"FW" = (
+/obj/structure/table,
+/obj/item/lighter,
+/turf/open/floor/plasteel/freezer{
+	dir = 2
+	},
+/area/centcom/holding)
+"FX" = (
+/obj/structure/table,
+/obj/item/reagent_containers/food/drinks/soda_cans/cola,
+/turf/open/floor/plasteel/freezer{
+	dir = 2
+	},
+/area/centcom/holding)
+"FY" = (
+/obj/structure/table,
+/obj/item/dice/d20,
+/turf/open/floor/plasteel/freezer{
+	dir = 2
+	},
+/area/centcom/holding)
+"FZ" = (
+/obj/structure/chair/stool{
+	pixel_y = 8
+	},
+/obj/item/clothing/head/bandana{
+	pixel_y = -10
+	},
+/obj/item/clothing/glasses/sunglasses,
+/turf/open/floor/plating/beach/sand,
+/area/centcom/holding)
+"Ga" = (
+/obj/structure/chair/stool{
+	pixel_y = 8
+	},
+/turf/open/floor/plating/beach/sand,
+/area/centcom/holding)
+"Gb" = (
+/obj/machinery/shower{
+	dir = 4
+	},
+/turf/open/floor/plasteel/white,
+/area/tdome/tdomeobserve)
+"Gc" = (
+/turf/open/floor/plasteel/white,
+/area/tdome/tdomeobserve)
+"Gd" = (
+/obj/machinery/shower{
+	dir = 8
+	},
+/turf/open/floor/plasteel/white,
+/area/tdome/tdomeobserve)
+"Ge" = (
+/turf/open/floor/plasteel/red/side{
+	dir = 1
+	},
+/area/tdome/tdomeobserve)
+"Gf" = (
+/obj/machinery/light,
+/turf/open/floor/plasteel/neutral/side{
+	dir = 1;
+	heat_capacity = 1e+006
+	},
+/area/tdome/tdomeobserve)
+"Gg" = (
+/obj/item/twohanded/required/kirbyplants{
+	icon_state = "plant-22"
+	},
+/turf/open/floor/plasteel/neutral/side{
+	dir = 1;
+	heat_capacity = 1e+006
+	},
+/area/tdome/tdomeobserve)
+"Gh" = (
+/obj/item/twohanded/required/kirbyplants{
+	icon_state = "plant-21"
+	},
+/turf/open/floor/plasteel/red/corner{
+	dir = 1
+	},
+/area/tdome/tdomeobserve)
+"Gi" = (
+/obj/item/twohanded/required/kirbyplants{
+	icon_state = "plant-21"
+	},
+/turf/open/floor/plasteel/red/side{
+	dir = 10
+	},
+/area/tdome/tdomeobserve)
+"Gj" = (
+/obj/item/twohanded/required/kirbyplants{
+	icon_state = "plant-22"
+	},
+/turf/open/floor/plasteel/red/side,
+/area/tdome/tdomeobserve)
+"Gk" = (
+/obj/machinery/light,
+/turf/open/floor/plasteel/redyellow/side,
+/area/tdome/tdomeobserve)
+"Gl" = (
+/turf/open/floor/plasteel/redyellow/side,
+/area/tdome/tdomeobserve)
+"Gm" = (
+/turf/open/floor/plasteel/loadingarea,
+/area/tdome/tdomeobserve)
+"Gn" = (
+/obj/item/twohanded/required/kirbyplants{
+	icon_state = "plant-22"
+	},
+/turf/open/floor/plasteel/green/side,
+/area/tdome/tdomeobserve)
+"Go" = (
+/obj/item/twohanded/required/kirbyplants{
+	icon_state = "plant-21"
+	},
+/turf/open/floor/plasteel/green/side{
+	dir = 6
+	},
+/area/tdome/tdomeobserve)
+"Gp" = (
+/obj/item/twohanded/required/kirbyplants{
+	icon_state = "plant-21"
+	},
+/turf/open/floor/plasteel/green/corner{
+	dir = 4
+	},
+/area/tdome/tdomeobserve)
+"Gq" = (
+/turf/open/floor/plasteel/green/side{
+	dir = 1
+	},
+/area/tdome/tdomeobserve)
+"Gr" = (
+/obj/structure/window/reinforced{
+	resistance_flags = 3;
+	color = "#008000";
+	dir = 1
+	},
+/turf/open/lava,
+/area/wizard_station)
+"Gs" = (
+/obj/structure/rack,
+/obj/item/clothing/head/that,
+/obj/item/clothing/under/suit_jacket,
+/obj/item/clothing/accessory/waistcoat,
+/turf/open/floor/plasteel/cafeteria,
+/area/centcom/holding)
+"Gt" = (
+/obj/item/toy/beach_ball,
+/turf/open/floor/plating/beach/sand,
+/area/centcom/holding)
+"Gu" = (
+/obj/machinery/door/airlock/silver{
+	name = "Shower"
+	},
+/turf/open/floor/plasteel/white,
+/area/tdome/tdomeobserve)
+"Gv" = (
+/obj/machinery/door/firedoor,
+/obj/effect/turf_decal/stripes/line{
+	dir = 2
+	},
+/turf/open/floor/plasteel,
+/area/tdome/tdomeobserve)
+"Gw" = (
+/obj/structure/sign/nosmoking_2,
+/turf/closed/indestructible/riveted,
+/area/tdome/tdomeobserve)
+"Gx" = (
+/obj/machinery/door/airlock/centcom{
+	name = "Thunderdome";
+	opacity = 1;
+	req_access_txt = "101"
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 2
+	},
+/turf/open/floor/plasteel,
+/area/tdome/tdomeobserve)
+"Gy" = (
+/obj/structure/sign/nanotrasen,
+/turf/closed/indestructible/riveted,
+/area/tdome/tdomeobserve)
+"Gz" = (
+/obj/structure/shuttle/engine/heater{
+	resistance_flags = 3
+	},
+/obj/structure/window/reinforced{
+	resistance_flags = 3;
+	color = "#008000";
+	dir = 1
+	},
+/turf/open/lava/airless,
+/area/wizard_station)
+"GA" = (
+/obj/structure/rack,
+/obj/item/storage/crayons,
+/obj/item/gun/ballistic/automatic/toy/pistol,
+/turf/open/floor/plasteel/cafeteria,
+/area/centcom/holding)
+"GB" = (
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/turf/open/floor/plasteel/cafeteria,
+/area/centcom/holding)
+"GC" = (
+/obj/structure/table,
+/obj/structure/bedsheetbin,
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/open/floor/plasteel/whitered/side{
+	dir = 8
+	},
+/area/tdome/tdomeobserve)
+"GD" = (
+/obj/structure/closet/secure_closet/personal,
+/turf/open/floor/plasteel/vault{
+	dir = 8
+	},
+/area/tdome/tdomeobserve)
+"GE" = (
+/turf/open/floor/plasteel/red/corner{
+	dir = 8
+	},
+/area/tdome/tdomeobserve)
+"GF" = (
+/obj/structure/closet/secure_closet/freezer/meat,
+/obj/item/reagent_containers/food/snacks/meat/rawbacon,
+/obj/item/reagent_containers/food/snacks/meat/rawbacon,
+/obj/item/reagent_containers/food/snacks/meat/rawbacon,
+/obj/item/reagent_containers/food/snacks/meat/rawbacon,
+/obj/item/reagent_containers/food/snacks/meat/slab/killertomato,
+/obj/item/reagent_containers/food/snacks/meat/slab/killertomato,
+/obj/item/reagent_containers/food/snacks/meat/slab/killertomato,
+/obj/item/reagent_containers/food/snacks/meat/slab/killertomato,
+/obj/item/reagent_containers/food/snacks/meat/slab/human/mutant/lizard,
+/obj/item/reagent_containers/food/snacks/meat/slab/human/mutant/lizard,
+/obj/item/reagent_containers/food/snacks/meat/slab/human/mutant/lizard,
+/obj/item/reagent_containers/food/snacks/meat/slab/human/mutant/lizard,
+/obj/item/reagent_containers/food/snacks/sausage,
+/obj/item/reagent_containers/food/snacks/sausage,
+/obj/item/reagent_containers/food/snacks/meat/rawcutlet,
+/obj/item/reagent_containers/food/snacks/meat/rawcutlet,
+/obj/item/reagent_containers/food/snacks/meat/rawcutlet,
+/obj/item/reagent_containers/food/snacks/carpmeat,
+/obj/item/reagent_containers/food/snacks/carpmeat,
+/obj/item/reagent_containers/food/snacks/carpmeat,
+/obj/item/reagent_containers/food/snacks/carpmeat,
+/turf/open/floor/plasteel/vault{
+	dir = 8
+	},
+/area/tdome/tdomeobserve)
+"GG" = (
+/obj/structure/closet/secure_closet/freezer/fridge,
+/obj/item/reagent_containers/food/snacks/grown/potato,
+/obj/item/reagent_containers/food/snacks/grown/potato,
+/obj/item/reagent_containers/food/snacks/grown/whitebeet,
+/obj/item/reagent_containers/food/snacks/grown/whitebeet,
+/obj/item/reagent_containers/food/snacks/grown/tomato,
+/obj/item/reagent_containers/food/snacks/grown/tomato,
+/obj/item/reagent_containers/food/snacks/grown/rice,
+/obj/item/reagent_containers/food/snacks/grown/rice,
+/obj/item/reagent_containers/food/snacks/grown/icepepper,
+/obj/item/reagent_containers/food/snacks/grown/icepepper,
+/obj/item/reagent_containers/food/snacks/grown/citrus/lemon,
+/obj/item/reagent_containers/food/snacks/grown/citrus/lime,
+/obj/item/reagent_containers/food/snacks/grown/citrus/orange,
+/obj/item/reagent_containers/food/snacks/grown/cherries,
+/obj/item/reagent_containers/food/snacks/grown/apple,
+/obj/item/reagent_containers/food/snacks/grown/ambrosia/deus,
+/turf/open/floor/plasteel/vault{
+	dir = 8
+	},
+/area/tdome/tdomeobserve)
+"GH" = (
+/obj/machinery/processor,
+/obj/effect/turf_decal/stripes/end,
+/turf/open/floor/plasteel,
+/area/tdome/tdomeobserve)
+"GI" = (
+/obj/structure/closet/secure_closet/freezer/kitchen,
+/obj/item/reagent_containers/food/snacks/grown/banana,
+/obj/item/reagent_containers/food/snacks/grown/banana,
+/obj/item/reagent_containers/food/snacks/grown/wheat,
+/obj/item/reagent_containers/food/snacks/grown/wheat,
+/obj/item/reagent_containers/food/snacks/grown/vanillapod,
+/obj/item/reagent_containers/food/snacks/grown/vanillapod,
+/obj/item/reagent_containers/food/snacks/grown/sugarcane,
+/obj/item/reagent_containers/food/snacks/grown/sugarcane,
+/obj/item/reagent_containers/food/snacks/grown/oat,
+/obj/item/reagent_containers/food/snacks/grown/oat,
+/obj/item/reagent_containers/food/snacks/grown/grapes,
+/obj/item/reagent_containers/food/snacks/grown/grapes,
+/obj/item/reagent_containers/food/snacks/grown/corn,
+/obj/item/reagent_containers/food/snacks/grown/corn,
+/obj/item/reagent_containers/food/snacks/grown/chili,
+/obj/item/reagent_containers/food/snacks/grown/chili,
+/obj/item/reagent_containers/food/snacks/grown/carrot,
+/obj/item/reagent_containers/food/snacks/grown/apple,
+/obj/item/reagent_containers/food/snacks/grown/ambrosia/vulgaris,
+/turf/open/floor/plasteel/vault{
+	dir = 8
+	},
+/area/tdome/tdomeobserve)
+"GJ" = (
+/obj/structure/closet/secure_closet/freezer/meat,
+/obj/item/reagent_containers/food/snacks/meat/slab/bear,
+/obj/item/reagent_containers/food/snacks/meat/slab/bear,
+/obj/item/reagent_containers/food/snacks/meat/slab/bear,
+/obj/item/reagent_containers/food/snacks/meat/slab/bear,
+/obj/item/reagent_containers/food/snacks/meat/slab/goliath,
+/obj/item/reagent_containers/food/snacks/meat/slab/goliath,
+/obj/item/reagent_containers/food/snacks/meat/slab/goliath,
+/obj/item/reagent_containers/food/snacks/meat/slab/goliath,
+/obj/item/reagent_containers/food/snacks/meat/slab/xeno,
+/obj/item/reagent_containers/food/snacks/meat/slab/xeno,
+/obj/item/reagent_containers/food/snacks/meat/slab/xeno,
+/obj/item/reagent_containers/food/snacks/meat/slab/xeno,
+/obj/item/reagent_containers/food/snacks/spaghetti,
+/obj/item/reagent_containers/food/snacks/spaghetti,
+/obj/item/reagent_containers/food/snacks/meat/rawcutlet,
+/obj/item/reagent_containers/food/snacks/meat/rawcutlet,
+/obj/item/reagent_containers/food/snacks/meat/rawcutlet,
+/turf/open/floor/plasteel/vault{
+	dir = 8
+	},
+/area/tdome/tdomeobserve)
+"GK" = (
+/obj/structure/flora/ausbushes/lavendergrass,
+/obj/structure/flora/ausbushes/sparsegrass,
+/obj/structure/flora/ausbushes/fullgrass,
+/obj/structure/flora/ausbushes/grassybush,
+/obj/structure/flora/ausbushes/ppflowers,
+/obj/structure/flora/ausbushes/pointybush,
+/turf/open/floor/grass,
+/area/tdome/tdomeobserve)
+"GL" = (
+/obj/structure/table/wood,
+/obj/structure/sign/goldenplaque{
+	pixel_y = 32
+	},
+/obj/item/clothing/accessory/lawyers_badge{
+	desc = "A badge of upmost glory.";
+	name = "thunderdome badge"
+	},
+/turf/open/floor/plasteel/grimy,
+/area/tdome/tdomeobserve)
+"GM" = (
+/turf/open/floor/plasteel/vault{
+	dir = 8
+	},
+/area/tdome/tdomeobserve)
+"GN" = (
+/turf/open/floor/plasteel/vault{
+	dir = 5
+	},
+/area/tdome/tdomeobserve)
+"GO" = (
+/obj/structure/table/wood,
+/obj/structure/sign/goldenplaque{
+	pixel_y = 32
+	},
+/obj/item/clothing/accessory/medal/silver{
+	pixel_y = 5
+	},
+/turf/open/floor/plasteel/grimy,
+/area/tdome/tdomeobserve)
+"GP" = (
+/obj/structure/flora/ausbushes/lavendergrass,
+/obj/structure/flora/ausbushes/sparsegrass,
+/obj/structure/flora/ausbushes/fullgrass,
+/obj/structure/flora/ausbushes/brflowers,
+/obj/structure/flora/ausbushes/genericbush,
+/turf/open/floor/grass,
+/area/tdome/tdomeobserve)
+"GQ" = (
+/obj/structure/table/wood,
+/obj/machinery/reagentgrinder{
+	desc = "Used to grind things up into raw materials and liquids.";
+	pixel_y = 5
+	},
+/turf/open/floor/plasteel/vault{
+	dir = 8
+	},
+/area/tdome/tdomeobserve)
+"GR" = (
+/obj/structure/table/wood,
+/obj/item/storage/box/beanbag,
+/obj/item/gun/ballistic/revolver/doublebarrel,
+/turf/open/floor/plasteel/vault{
+	dir = 8
+	},
+/area/tdome/tdomeobserve)
+"GS" = (
+/obj/structure/table/wood,
+/obj/structure/reagent_dispensers/beerkeg,
+/obj/machinery/newscaster{
+	pixel_y = 32
+	},
+/turf/open/floor/plasteel/vault{
+	dir = 8
+	},
+/area/tdome/tdomeobserve)
+"GT" = (
+/obj/machinery/vending/cigarette,
+/turf/open/floor/plasteel/vault{
+	dir = 8
+	},
+/area/tdome/tdomeobserve)
+"GU" = (
+/obj/structure/table/wood,
+/obj/item/storage/box/drinkingglasses,
+/obj/item/reagent_containers/food/drinks/bottle/whiskey{
+	pixel_y = 5
+	},
+/turf/open/floor/plasteel/vault{
+	dir = 8
+	},
+/area/tdome/tdomeobserve)
+"GV" = (
+/turf/open/floor/plasteel/green/corner,
+/area/tdome/tdomeobserve)
+"GW" = (
+/obj/structure/table,
+/obj/structure/bedsheetbin,
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/open/floor/plasteel/whitegreen/side{
+	dir = 4
+	},
+/area/tdome/tdomeobserve)
+"GX" = (
+/obj/structure/shuttle/engine/propulsion,
+/turf/open/space,
+/area/wizard_station)
+"GY" = (
+/obj/structure/rack,
+/obj/item/storage/crayons,
+/obj/item/gun/ballistic/shotgun/toy/crossbow,
+/turf/open/floor/plasteel/cafeteria,
+/area/centcom/holding)
+"GZ" = (
+/turf/open/floor/plating/beach/coastline_b,
+/area/centcom/holding)
+"Ha" = (
+/obj/item/clothing/head/collectable/paper,
+/turf/open/floor/plating/beach/coastline_b,
+/area/centcom/holding)
+"Hb" = (
+/obj/structure/sink{
+	dir = 8;
+	pixel_x = -12
+	},
+/obj/structure/mirror{
+	pixel_x = -28
+	},
+/turf/open/floor/plasteel/whitered/corner{
+	dir = 1
+	},
+/area/tdome/tdomeobserve)
+"Hc" = (
+/turf/open/floor/plasteel/red/side{
+	dir = 4
+	},
+/area/tdome/tdomeobserve)
+"Hd" = (
+/turf/open/floor/plasteel/red,
+/area/tdome/tdomeobserve)
+"He" = (
+/obj/structure/table/wood,
+/obj/item/reagent_containers/food/drinks/trophy/gold_cup,
+/turf/open/floor/plasteel/grimy,
+/area/tdome/tdomeobserve)
+"Hf" = (
+/turf/open/floor/plasteel/bar,
+/area/tdome/tdomeobserve)
+"Hg" = (
+/turf/open/floor/plasteel/green/side{
+	dir = 8
+	},
+/area/tdome/tdomeobserve)
+"Hh" = (
+/obj/structure/sink{
+	dir = 4;
+	pixel_x = 11
+	},
+/obj/structure/mirror{
+	pixel_x = 28
+	},
+/turf/open/floor/plasteel/whitegreen/corner{
+	dir = 4
+	},
+/area/tdome/tdomeobserve)
+"Hi" = (
+/obj/structure/rack,
+/obj/item/clothing/shoes/laceup,
+/obj/item/clothing/under/suit_jacket/female{
+	desc = "A black trouser suit for women. Very formal.";
+	name = "black suit";
+	pixel_x = 3;
+	pixel_y = 1
+	},
+/turf/open/floor/plasteel/cafeteria,
+/area/centcom/holding)
+"Hj" = (
+/obj/machinery/light,
+/turf/open/floor/plasteel/cafeteria,
+/area/centcom/holding)
+"Hk" = (
+/obj/structure/table,
+/obj/item/gun/ballistic/automatic/toy/pistol,
+/turf/open/floor/plasteel/cafeteria,
+/area/centcom/holding)
+"Hl" = (
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/machinery/light,
+/turf/open/floor/plasteel/cafeteria,
+/area/centcom/holding)
+"Hm" = (
+/turf/open/floor/plating/beach/water,
+/area/centcom/holding)
+"Hn" = (
+/obj/structure/sink{
+	dir = 8;
+	pixel_x = -12
+	},
+/obj/structure/mirror{
+	pixel_x = -28
+	},
+/turf/open/floor/plasteel/white,
+/area/tdome/tdomeobserve)
+"Ho" = (
+/obj/structure/table/reinforced,
+/obj/item/reagent_containers/food/condiment/saltshaker{
+	pixel_x = -8;
+	pixel_y = 5
+	},
+/obj/item/reagent_containers/food/condiment/peppermill{
+	pixel_x = -8
+	},
+/obj/item/kitchen/knife,
+/obj/machinery/newscaster{
+	pixel_x = -32
+	},
+/turf/open/floor/plasteel/vault{
+	dir = 8
+	},
+/area/tdome/tdomeobserve)
+"Hp" = (
+/obj/machinery/light,
+/turf/open/floor/plasteel/red,
+/area/tdome/tdomeobserve)
+"Hq" = (
+/obj/machinery/firealarm{
+	dir = 4;
+	pixel_x = 24
+	},
+/turf/open/floor/plasteel/white,
+/area/tdome/tdomeobserve)
+"Hr" = (
+/obj/structure/table/wood,
+/obj/structure/sign/atmosplaque/thunderdome{
+	pixel_y = -32
+	},
+/obj/item/clothing/accessory/medal/gold{
+	pixel_x = 3;
+	pixel_y = 5
+	},
+/obj/item/clothing/accessory/medal/gold,
+/turf/open/floor/plasteel/grimy,
+/area/tdome/tdomeobserve)
+"Hs" = (
+/obj/machinery/light,
+/turf/open/floor/plasteel/vault{
+	dir = 8
+	},
+/area/tdome/tdomeobserve)
+"Ht" = (
+/obj/structure/table/wood,
+/obj/structure/sign/atmosplaque/thunderdome{
+	pixel_y = -32
+	},
+/obj/item/clothing/accessory/medal{
+	pixel_y = 5
+	},
+/turf/open/floor/plasteel/grimy,
+/area/tdome/tdomeobserve)
+"Hu" = (
+/obj/machinery/firealarm{
+	dir = 8;
+	pixel_x = -24
+	},
+/turf/open/floor/plasteel/bar,
+/area/tdome/tdomeobserve)
+"Hv" = (
+/obj/machinery/light,
+/turf/open/floor/plasteel/bar,
+/area/tdome/tdomeobserve)
+"Hw" = (
+/obj/machinery/chem_master/condimaster{
+	name = "HoochMaster 2000"
+	},
+/obj/machinery/airalarm{
+	dir = 8;
+	pixel_x = 24
+	},
+/turf/open/floor/plasteel/vault{
+	dir = 8
+	},
+/area/tdome/tdomeobserve)
+"Hx" = (
+/obj/structure/sink{
+	dir = 4;
+	pixel_x = 11
+	},
+/obj/structure/mirror{
+	pixel_x = 28
+	},
+/turf/open/floor/plasteel/white,
+/area/tdome/tdomeobserve)
+"Hy" = (
+/obj/effect/spawner/structure/window/hollow/reinforced,
+/turf/open/floor/plasteel,
+/area/centcom/holding)
+"Hz" = (
+/obj/effect/turf_decal/delivery,
+/turf/open/floor/plasteel,
+/area/centcom/holding)
+"HA" = (
+/obj/structure/sink{
+	dir = 8;
+	pixel_x = -12
+	},
+/obj/structure/mirror{
+	pixel_x = -28
+	},
+/turf/open/floor/plasteel/whitered/corner{
+	dir = 8
+	},
+/area/tdome/tdomeobserve)
+"HB" = (
+/obj/structure/table/reinforced,
+/obj/item/reagent_containers/food/snacks/mint,
+/obj/item/reagent_containers/food/condiment/enzyme{
+	pixel_y = 5
+	},
+/turf/open/floor/plasteel/vault{
+	dir = 8
+	},
+/area/tdome/tdomeobserve)
+"HC" = (
+/obj/structure/sink{
+	dir = 4;
+	pixel_x = 11
+	},
+/turf/open/floor/plasteel/red,
+/area/tdome/tdomeobserve)
+"HD" = (
+/obj/structure/sink{
+	dir = 8;
+	pixel_x = -12
+	},
+/turf/open/floor/plasteel/bar,
+/area/tdome/tdomeobserve)
+"HE" = (
+/obj/structure/table/wood,
+/obj/machinery/chem_dispenser/drinks/beer,
+/turf/open/floor/plasteel/vault{
+	dir = 8
+	},
+/area/tdome/tdomeobserve)
+"HF" = (
+/obj/structure/sink{
+	dir = 4;
+	pixel_x = 11
+	},
+/obj/structure/mirror{
+	pixel_x = 28
+	},
+/turf/open/floor/plasteel/whitegreen/corner,
+/area/tdome/tdomeobserve)
+"HG" = (
+/obj/item/reagent_containers/food/snacks/egg/rainbow{
+	desc = "I bet you think you're pretty clever... well you are.";
+	name = "easter egg"
+	},
+/turf/open/space,
+/area/space)
+"HH" = (
+/obj/effect/landmark/holding_facility,
+/turf/open/floor/engine,
+/area/centcom/holding)
+"HI" = (
+/obj/structure/sink{
+	dir = 8;
+	pixel_x = -12
+	},
+/obj/structure/mirror{
+	pixel_x = -28
+	},
+/turf/open/floor/plasteel/whitered/side{
+	dir = 8
+	},
+/area/tdome/tdomeobserve)
+"HJ" = (
+/obj/structure/table/reinforced,
+/obj/item/clothing/suit/apron/chef,
+/obj/item/kitchen/rollingpin,
+/turf/open/floor/plasteel/vault{
+	dir = 8
+	},
+/area/tdome/tdomeobserve)
+"HK" = (
+/obj/structure/table/reinforced,
+/obj/machinery/door/firedoor,
+/obj/item/reagent_containers/food/condiment/saltshaker{
+	pixel_x = -8;
+	pixel_y = 5
+	},
+/obj/item/reagent_containers/food/condiment/peppermill{
+	pixel_x = -8
+	},
+/obj/item/reagent_containers/food/drinks/britcup,
+/obj/effect/turf_decal/bot,
+/turf/open/floor/plasteel,
+/area/tdome/tdomeobserve)
+"HL" = (
+/turf/open/floor/plasteel/vault,
+/area/tdome/tdomeobserve)
+"HM" = (
+/obj/structure/chair,
+/obj/effect/landmark/thunderdome/observe,
+/obj/structure/sign/barsign{
+	pixel_y = 32
+	},
+/turf/open/floor/plasteel/vault{
+	dir = 8
+	},
+/area/tdome/tdomeobserve)
+"HN" = (
+/obj/structure/chair,
+/obj/effect/landmark/thunderdome/observe,
+/turf/open/floor/plasteel/vault{
+	dir = 8
+	},
+/area/tdome/tdomeobserve)
+"HO" = (
+/obj/machinery/computer/security/telescreen,
+/obj/structure/table/reinforced,
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/machinery/ai_status_display{
+	pixel_y = 32
+	},
+/turf/open/floor/plasteel/vault{
+	dir = 8
+	},
+/area/tdome/tdomeobserve)
+"HP" = (
+/obj/structure/table/reinforced,
+/obj/machinery/door/firedoor,
+/obj/effect/turf_decal/bot,
+/turf/open/floor/plasteel,
+/area/tdome/tdomeobserve)
+"HQ" = (
+/obj/structure/table/wood,
+/obj/machinery/chem_dispenser/drinks,
+/turf/open/floor/plasteel/vault{
+	dir = 8
+	},
+/area/tdome/tdomeobserve)
+"HR" = (
+/obj/structure/sink{
+	dir = 4;
+	pixel_x = 11
+	},
+/obj/structure/mirror{
+	pixel_x = 28
+	},
+/turf/open/floor/plasteel/whitegreen/side{
+	dir = 4
+	},
+/area/tdome/tdomeobserve)
+"HS" = (
+/obj/machinery/door/airlock/centcom{
+	name = "Thunderdome Locker Room";
+	opacity = 1;
+	req_access_txt = "101"
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 2
+	},
+/turf/open/floor/plasteel,
+/area/tdome/tdomeobserve)
+"HT" = (
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/open/floor/plasteel/red/side{
+	dir = 4
+	},
+/area/tdome/tdomeobserve)
+"HU" = (
+/obj/structure/table/reinforced,
+/obj/machinery/reagentgrinder{
+	desc = "Used to grind things up into raw materials and liquids.";
+	pixel_y = 5
+	},
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/open/floor/plasteel/vault{
+	dir = 8
+	},
+/area/tdome/tdomeobserve)
+"HV" = (
+/obj/structure/table/reinforced,
+/obj/machinery/door/firedoor,
+/obj/item/storage/bag/tray,
+/obj/item/kitchen/fork,
+/obj/effect/turf_decal/bot,
+/turf/open/floor/plasteel,
+/area/tdome/tdomeobserve)
+"HW" = (
+/turf/open/floor/plasteel/redyellow,
+/area/tdome/tdomeobserve)
+"HX" = (
+/obj/machinery/vending/boozeomat,
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/open/floor/plasteel/vault{
+	dir = 8
+	},
+/area/tdome/tdomeobserve)
+"HY" = (
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/open/floor/plasteel/green/side{
+	dir = 8
+	},
+/area/tdome/tdomeobserve)
+"HZ" = (
+/obj/item/twohanded/required/kirbyplants{
+	icon_state = "plant-21"
+	},
+/turf/open/floor/plasteel/neutral/corner,
+/area/tdome/tdomeobserve)
+"Ia" = (
+/turf/open/floor/plasteel/neutral/side{
+	dir = 6
+	},
+/area/tdome/tdomeobserve)
+"Ib" = (
+/obj/structure/rack,
+/obj/item/storage/box/donkpockets,
+/obj/item/storage/box/donkpockets,
+/obj/item/clothing/head/chefhat,
+/turf/open/floor/plasteel/vault,
+/area/tdome/tdomeobserve)
+"Ic" = (
+/obj/structure/table/reinforced,
+/obj/machinery/door/firedoor,
+/obj/structure/noticeboard{
+	dir = 1;
+	pixel_y = -32
+	},
+/obj/effect/turf_decal/bot,
+/turf/open/floor/plasteel,
+/area/tdome/tdomeobserve)
+"Id" = (
+/obj/machinery/computer/security/telescreen,
+/obj/structure/table/reinforced,
+/turf/open/floor/plasteel/vault{
+	dir = 8
+	},
+/area/tdome/tdomeobserve)
+"Ie" = (
+/obj/item/storage/fancy/cigarettes/cigars{
+	pixel_y = 6
+	},
+/obj/item/storage/fancy/cigarettes/cigars/cohiba{
+	pixel_y = 3
+	},
+/obj/item/storage/fancy/cigarettes/cigars/havana,
+/obj/structure/table/wood,
+/turf/open/floor/plasteel/vault{
+	dir = 8
+	},
+/area/tdome/tdomeobserve)
+"If" = (
+/turf/open/floor/plasteel/neutral/side{
+	dir = 10
+	},
+/area/tdome/tdomeobserve)
+"Ig" = (
+/obj/item/twohanded/required/kirbyplants{
+	icon_state = "plant-21"
+	},
+/turf/open/floor/plasteel/neutral/corner{
+	dir = 8;
+	heat_capacity = 1e+006
+	},
+/area/tdome/tdomeobserve)
+"Ih" = (
+/turf/open/floor/plasteel/red/corner{
+	dir = 4
+	},
+/area/tdome/tdomeobserve)
+"Ii" = (
+/obj/structure/table/reinforced,
+/obj/machinery/microwave{
+	desc = "Cooks and boils stuff, somehow.";
+	pixel_x = -3;
+	pixel_y = 5
+	},
+/obj/machinery/airalarm{
+	dir = 1;
+	pixel_y = -22
+	},
+/turf/open/floor/plasteel/vault{
+	dir = 8
+	},
+/area/tdome/tdomeobserve)
+"Ij" = (
+/obj/structure/table/reinforced,
+/obj/machinery/microwave{
+	desc = "Cooks and boils stuff, somehow.";
+	pixel_x = -3;
+	pixel_y = 5
+	},
+/obj/structure/sign/barsign{
+	pixel_y = -32
+	},
+/turf/open/floor/plasteel/vault{
+	dir = 8
+	},
+/area/tdome/tdomeobserve)
+"Ik" = (
+/obj/machinery/icecream_vat,
+/turf/open/floor/plasteel/vault{
+	dir = 8
+	},
+/area/tdome/tdomeobserve)
+"Il" = (
+/turf/closed/indestructible/fakeglass{
+	icon_state = "fakewindows";
+	dir = 8
+	},
+/area/tdome/tdomeobserve)
+"Im" = (
+/turf/closed/indestructible/fakeglass{
+	icon_state = "fakewindows2";
+	dir = 8
+	},
+/area/tdome/tdomeobserve)
+"In" = (
+/turf/closed/indestructible/fakeglass{
+	icon_state = "fakewindows";
+	dir = 4
+	},
+/area/tdome/tdomeobserve)
+"Io" = (
+/obj/item/storage/box/matches{
+	pixel_x = -3;
+	pixel_y = 5
+	},
+/obj/structure/table/wood,
+/obj/structure/sign/barsign{
+	pixel_y = -32
+	},
+/turf/open/floor/plasteel/vault{
+	dir = 8
+	},
+/area/tdome/tdomeobserve)
+"Ip" = (
+/obj/item/lighter{
+	pixel_x = 3;
+	pixel_y = 3
+	},
+/obj/item/lighter,
+/obj/structure/table/wood,
+/turf/open/floor/plasteel/vault{
+	dir = 8
+	},
+/area/tdome/tdomeobserve)
+"Iq" = (
+/obj/structure/table/wood,
+/obj/item/book/manual/barman_recipes,
+/obj/item/reagent_containers/food/drinks/shaker,
+/obj/item/reagent_containers/glass/rag,
+/obj/machinery/newscaster{
+	pixel_y = -32
+	},
+/turf/open/floor/plasteel/vault{
+	dir = 8
+	},
+/area/tdome/tdomeobserve)
+"Ir" = (
+/turf/open/floor/plasteel/green/corner{
+	dir = 1
+	},
+/area/tdome/tdomeobserve)
+"Is" = (
+/obj/machinery/igniter,
+/obj/effect/turf_decal/delivery,
+/turf/open/floor/plasteel,
+/area/tdome/arena)
+"It" = (
+/turf/open/floor/plasteel,
+/area/tdome/arena)
+"Iu" = (
+/obj/effect/turf_decal/bot,
+/turf/open/floor/plasteel,
+/area/tdome/arena)
+"Iv" = (
+/turf/closed/indestructible/riveted,
+/area/tdome/tdomeadmin)
+"Iw" = (
+/obj/structure/flora/ausbushes/lavendergrass,
+/obj/structure/flora/ausbushes/fullgrass,
+/obj/structure/flora/ausbushes/ywflowers,
+/obj/structure/flora/ausbushes/grassybush,
+/obj/structure/flora/ausbushes/palebush,
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/open/floor/plating/asteroid,
+/area/tdome/tdomeadmin)
+"Ix" = (
+/obj/machinery/door/airlock/centcom{
+	name = "Thunderdome Administration";
+	opacity = 1;
+	req_access_txt = "102"
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 2
+	},
+/turf/open/floor/plasteel,
+/area/tdome/tdomeadmin)
+"Iy" = (
+/obj/structure/rack,
+/obj/item/clothing/under/color/red,
+/obj/item/clothing/shoes/sneakers/brown,
+/obj/item/clothing/suit/armor/tdome/red,
+/obj/item/clothing/head/helmet/thunderdome,
+/obj/item/melee/baton/loaded,
+/obj/item/melee/transforming/energy/sword/saber/red,
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/tdome/arena)
+"Iz" = (
+/obj/machinery/door/poddoor{
+	id = "thunderdomegen";
+	name = "General Supply"
+	},
+/turf/open/floor/plasteel/loadingarea{
+	dir = 4
+	},
+/area/tdome/arena)
+"IA" = (
+/obj/effect/landmark/thunderdome/two,
+/obj/effect/turf_decal/stripes/line{
+	dir = 9
+	},
+/turf/open/floor/plasteel,
+/area/tdome/arena)
+"IB" = (
+/obj/effect/landmark/thunderdome/two,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/tdome/arena)
+"IC" = (
+/obj/effect/landmark/thunderdome/two,
+/obj/effect/turf_decal/stripes/line{
+	dir = 5
+	},
+/turf/open/floor/plasteel,
+/area/tdome/arena)
+"ID" = (
+/obj/machinery/door/poddoor{
+	id = "thunderdome";
+	name = "Thunderdome Blast Door"
+	},
+/turf/open/floor/plasteel/loadingarea{
+	dir = 4
+	},
+/area/tdome/arena)
+"IE" = (
+/turf/open/floor/plasteel/red/side{
+	dir = 8
+	},
+/area/tdome/arena)
+"IF" = (
+/obj/effect/turf_decal/delivery,
+/turf/open/floor/plasteel,
+/area/tdome/arena)
+"IG" = (
+/turf/open/floor/plasteel/neutral/side{
+	dir = 4
+	},
+/area/tdome/arena)
+"IH" = (
+/turf/open/floor/plasteel/neutral,
+/area/tdome/arena)
+"II" = (
+/turf/open/floor/plasteel/neutral/side{
+	dir = 8
+	},
+/area/tdome/arena)
+"IJ" = (
+/turf/open/floor/plasteel/green/side{
+	dir = 4
+	},
+/area/tdome/arena)
+"IK" = (
+/obj/machinery/door/poddoor{
+	id = "thunderdome";
+	name = "Thunderdome Blast Door"
+	},
+/turf/open/floor/plasteel/loadingarea{
+	dir = 8
+	},
+/area/tdome/arena)
+"IL" = (
+/obj/effect/landmark/thunderdome/one,
+/obj/effect/turf_decal/stripes/line{
+	dir = 9
+	},
+/turf/open/floor/plasteel,
+/area/tdome/arena)
+"IM" = (
+/obj/effect/landmark/thunderdome/one,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/tdome/arena)
+"IN" = (
+/obj/effect/landmark/thunderdome/one,
+/obj/effect/turf_decal/stripes/line{
+	dir = 5
+	},
+/turf/open/floor/plasteel,
+/area/tdome/arena)
+"IO" = (
+/obj/machinery/door/poddoor{
+	id = "thunderdomegen";
+	name = "General Supply"
+	},
+/turf/open/floor/plasteel/loadingarea{
+	dir = 8
+	},
+/area/tdome/arena)
+"IP" = (
+/obj/structure/rack,
+/obj/item/clothing/under/color/green,
+/obj/item/clothing/shoes/sneakers/brown,
+/obj/item/clothing/suit/armor/tdome/green,
+/obj/item/clothing/head/helmet/thunderdome,
+/obj/item/melee/baton/loaded,
+/obj/item/melee/transforming/energy/sword/saber/green,
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/tdome/arena)
+"IQ" = (
+/obj/structure/flora/ausbushes/sparsegrass,
+/obj/structure/flora/ausbushes/grassybush,
+/obj/structure/flora/ausbushes/fernybush,
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/open/floor/plasteel{
+	dir = 6;
+	icon_state = "asteroid8";
+	name = "sand"
+	},
+/area/tdome/tdomeadmin)
+"IR" = (
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
+/area/tdome/tdomeadmin)
+"IS" = (
+/obj/machinery/door/firedoor,
+/obj/effect/turf_decal/stripes/line{
+	dir = 2
+	},
+/turf/open/floor/plasteel,
+/area/tdome/tdomeadmin)
+"IT" = (
+/obj/effect/landmark/thunderdome/two,
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/tdome/arena)
+"IU" = (
+/obj/machinery/recharger{
+	pixel_y = 4
+	},
+/obj/effect/landmark/thunderdome/two,
+/obj/effect/turf_decal/delivery,
+/turf/open/floor/plasteel,
+/area/tdome/arena)
+"IV" = (
+/obj/effect/landmark/thunderdome/two,
+/turf/open/floor/plasteel/neutral,
+/area/tdome/arena)
+"IW" = (
+/obj/effect/landmark/thunderdome/two,
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/tdome/arena)
+"IX" = (
+/turf/open/floor/plasteel/red/corner{
+	dir = 1
+	},
+/area/tdome/arena)
+"IY" = (
+/turf/open/floor/plasteel/green/corner{
+	dir = 4
+	},
+/area/tdome/arena)
+"IZ" = (
+/obj/effect/landmark/thunderdome/one,
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/tdome/arena)
+"Ja" = (
+/obj/machinery/recharger{
+	pixel_y = 4
+	},
+/obj/effect/landmark/thunderdome/one,
+/obj/effect/turf_decal/delivery,
+/turf/open/floor/plasteel,
+/area/tdome/arena)
+"Jb" = (
+/obj/effect/landmark/thunderdome/one,
+/turf/open/floor/plasteel/neutral,
+/area/tdome/arena)
+"Jc" = (
+/obj/effect/landmark/thunderdome/one,
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/tdome/arena)
+"Jd" = (
+/obj/structure/flora/ausbushes/sparsegrass,
+/obj/structure/flora/ausbushes/lavendergrass,
+/obj/structure/flora/ausbushes/fernybush,
+/turf/open/floor/plasteel{
+	name = "plating";
+	icon_state = "asteroid5"
+	},
+/area/tdome/tdomeadmin)
+"Je" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 9
+	},
+/turf/open/floor/plasteel,
+/area/tdome/tdomeadmin)
+"Jf" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 5
+	},
+/turf/open/floor/plasteel,
+/area/tdome/tdomeadmin)
+"Jg" = (
+/obj/machinery/camera{
+	pixel_x = 11;
+	pixel_y = -9;
+	network = list("thunder");
+	c_tag = "Red Team"
+	},
+/obj/effect/landmark/thunderdome/two,
+/turf/open/floor/plasteel/neutral,
+/area/tdome/arena)
+"Jh" = (
+/turf/open/floor/plasteel/loadingarea{
+	dir = 4
+	},
+/area/tdome/arena)
+"Ji" = (
+/turf/open/floor/circuit/green,
+/area/tdome/arena)
+"Jj" = (
+/obj/machinery/flasher{
+	id = "tdomeflash";
+	name = "Thunderdome Flash"
+	},
+/turf/open/floor/circuit/green,
+/area/tdome/arena)
+"Jk" = (
+/turf/open/floor/plasteel/loadingarea{
+	dir = 8
+	},
+/area/tdome/arena)
+"Jl" = (
+/obj/machinery/camera{
+	pixel_x = 12;
+	pixel_y = -10;
+	network = list("thunder");
+	c_tag = "Green Team"
+	},
+/obj/effect/landmark/thunderdome/one,
+/turf/open/floor/plasteel/neutral,
+/area/tdome/arena)
+"Jm" = (
+/obj/structure/flora/ausbushes/lavendergrass,
+/obj/structure/flora/ausbushes/sparsegrass,
+/obj/structure/flora/ausbushes/ywflowers,
+/obj/structure/flora/ausbushes/grassybush,
+/obj/structure/flora/ausbushes/palebush,
+/turf/open/floor/plating/asteroid,
+/area/tdome/tdomeadmin)
+"Jn" = (
+/obj/structure/flora/ausbushes/sparsegrass,
+/obj/structure/flora/ausbushes/grassybush,
+/obj/structure/flora/ausbushes/fernybush,
+/turf/open/floor/plasteel{
+	dir = 6;
+	icon_state = "asteroid8";
+	name = "sand"
+	},
+/area/tdome/tdomeadmin)
+"Jo" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 10
+	},
+/turf/open/floor/plasteel,
+/area/tdome/tdomeadmin)
+"Jp" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 6
+	},
+/turf/open/floor/plasteel,
+/area/tdome/tdomeadmin)
+"Jq" = (
+/obj/machinery/camera{
+	pixel_x = 10;
+	network = list("thunder");
+	c_tag = "Arena"
+	},
+/turf/open/floor/circuit/green,
+/area/tdome/arena)
+"Jr" = (
+/obj/structure/flora/ausbushes/lavendergrass,
+/obj/structure/flora/ausbushes/fullgrass,
+/obj/structure/flora/ausbushes/ywflowers,
+/obj/structure/flora/ausbushes/grassybush,
+/obj/structure/flora/ausbushes/palebush,
+/turf/open/floor/plating/asteroid,
+/area/tdome/tdomeadmin)
+"Js" = (
+/turf/open/floor/plasteel/red/corner{
+	dir = 8
+	},
+/area/tdome/arena)
+"Jt" = (
+/turf/open/floor/plasteel/green/corner,
+/area/tdome/arena)
+"Ju" = (
+/obj/effect/landmark/thunderdome/two,
+/obj/effect/turf_decal/stripes/line{
+	dir = 10
+	},
+/turf/open/floor/plasteel,
+/area/tdome/arena)
+"Jv" = (
+/obj/effect/landmark/thunderdome/two,
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/plasteel,
+/area/tdome/arena)
+"Jw" = (
+/obj/effect/landmark/thunderdome/two,
+/obj/effect/turf_decal/stripes/line{
+	dir = 6
+	},
+/turf/open/floor/plasteel,
+/area/tdome/arena)
+"Jx" = (
+/obj/effect/landmark/thunderdome/one,
+/obj/effect/turf_decal/stripes/line{
+	dir = 10
+	},
+/turf/open/floor/plasteel,
+/area/tdome/arena)
+"Jy" = (
+/obj/effect/landmark/thunderdome/one,
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/plasteel,
+/area/tdome/arena)
+"Jz" = (
+/obj/effect/landmark/thunderdome/one,
+/obj/effect/turf_decal/stripes/line{
+	dir = 6
+	},
+/turf/open/floor/plasteel,
+/area/tdome/arena)
+"JA" = (
+/obj/machinery/abductor/experiment{
+	team_number = 1
+	},
+/turf/open/floor/plating/abductor,
+/area/abductor_ship)
+"JB" = (
+/obj/machinery/abductor/console{
+	team_number = 1
+	},
+/turf/open/floor/plating/abductor,
+/area/abductor_ship)
+"JC" = (
+/obj/machinery/abductor/pad{
+	team_number = 1
+	},
+/turf/open/floor/plating/abductor,
+/area/abductor_ship)
+"JD" = (
+/obj/machinery/door/poddoor{
+	id = "thunderdomehea";
+	name = "Heavy Supply"
+	},
+/turf/open/floor/plasteel/loadingarea{
+	dir = 1
+	},
+/area/tdome/arena)
+"JE" = (
+/obj/machinery/door/poddoor{
+	id = "thunderdomehea";
+	name = "Heavy Supply"
+	},
+/turf/open/floor/plasteel/loadingarea,
+/area/tdome/arena)
+"JF" = (
+/obj/machinery/computer/camera_advanced/abductor{
+	team_number = 1
+	},
+/turf/open/floor/plating/abductor,
+/area/abductor_ship)
+"JG" = (
+/turf/open/floor/plasteel/vault{
+	dir = 5
+	},
+/area/tdome/tdomeadmin)
+"JH" = (
+/obj/structure/rack,
+/obj/item/clothing/under/color/red,
+/obj/item/clothing/shoes/sneakers/brown,
+/obj/item/clothing/suit/armor/vest,
+/obj/item/clothing/head/helmet/swat,
+/obj/item/gun/energy/laser,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/tdome/arena)
+"JI" = (
+/turf/closed/indestructible/fakeglass{
+	icon_state = "fakewindows";
+	dir = 8
+	},
+/area/tdome/tdomeadmin)
+"JJ" = (
+/turf/closed/indestructible/fakeglass{
+	icon_state = "fakewindows2";
+	dir = 8
+	},
+/area/tdome/tdomeadmin)
+"JK" = (
+/turf/closed/indestructible/fakeglass{
+	icon_state = "fakewindows";
+	dir = 4
+	},
+/area/tdome/tdomeadmin)
+"JL" = (
+/obj/structure/rack,
+/obj/item/clothing/under/color/green,
+/obj/item/clothing/shoes/sneakers/brown,
+/obj/item/clothing/suit/armor/vest,
+/obj/item/clothing/head/helmet/swat,
+/obj/item/gun/energy/laser,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/tdome/arena)
+"JM" = (
+/obj/effect/landmark/abductor/scientist,
+/turf/open/floor/plating/abductor,
+/area/abductor_ship)
+"JN" = (
+/obj/effect/landmark/abductor/agent,
+/turf/open/floor/plating/abductor,
+/area/abductor_ship)
+"JO" = (
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/open/floor/plasteel/vault{
+	dir = 5
+	},
+/area/tdome/tdomeadmin)
+"JP" = (
+/obj/item/device/radio{
+	pixel_x = 5;
+	pixel_y = 5
+	},
+/obj/item/device/radio{
+	pixel_x = -5;
+	pixel_y = 5
+	},
+/obj/item/device/radio,
+/obj/structure/table/wood,
+/turf/open/floor/plasteel/vault{
+	dir = 8
+	},
+/area/tdome/tdomeadmin)
+"JQ" = (
+/obj/effect/landmark/thunderdome/admin,
+/obj/structure/chair/comfy/black{
+	dir = 1
+	},
+/turf/open/floor/plasteel/grimy,
+/area/tdome/tdomeadmin)
+"JR" = (
+/obj/machinery/computer/security/telescreen,
+/obj/structure/table/reinforced,
+/turf/open/floor/plasteel/vault{
+	dir = 8
+	},
+/area/tdome/tdomeadmin)
+"JS" = (
+/obj/structure/chair/comfy/brown{
+	color = "#66b266";
+	dir = 1
+	},
+/turf/open/floor/plasteel/darkgreen,
+/area/tdome/tdomeadmin)
+"JT" = (
+/obj/machinery/button/flasher{
+	id = "tdomeflash"
+	},
+/obj/structure/table/reinforced,
+/turf/open/floor/plasteel/vault{
+	dir = 8
+	},
+/area/tdome/tdomeadmin)
+"JU" = (
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/open/floor/plasteel/vault{
+	dir = 5
+	},
+/area/tdome/tdomeadmin)
+"JV" = (
+/turf/closed/wall/mineral/titanium,
+/area/shuttle/escape)
+"JW" = (
+/obj/machinery/status_display,
+/turf/closed/wall/mineral/titanium,
+/area/shuttle/escape)
+"JX" = (
+/obj/machinery/door/firedoor,
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/tdome/tdomeadmin)
+"JY" = (
+/turf/open/floor/plasteel/vault{
+	dir = 8
+	},
+/area/tdome/tdomeadmin)
+"JZ" = (
+/obj/item/twohanded/required/kirbyplants{
+	icon_state = "plant-21"
+	},
+/obj/machinery/firealarm{
+	dir = 8;
+	pixel_x = -24
+	},
+/turf/open/floor/plasteel/vault{
+	dir = 8
+	},
+/area/tdome/tdomeadmin)
+"Ka" = (
+/turf/open/floor/plasteel/grimy,
+/area/tdome/tdomeadmin)
+"Kb" = (
+/turf/open/floor/plasteel/darkgreen/side{
+	dir = 1
+	},
+/area/tdome/tdomeadmin)
+"Kc" = (
+/obj/item/twohanded/required/kirbyplants{
+	icon_state = "plant-21"
+	},
+/turf/open/floor/plasteel/vault{
+	dir = 8
+	},
+/area/tdome/tdomeadmin)
+"Kd" = (
+/turf/open/floor/mineral/titanium,
+/area/shuttle/escape)
+"Ke" = (
+/turf/open/floor/mineral/plastitanium,
+/area/shuttle/escape)
+"Kf" = (
+/obj/machinery/computer/emergency_shuttle,
+/turf/open/floor/mineral/titanium,
+/area/shuttle/escape)
+"Kg" = (
+/turf/closed/indestructible/fakedoor{
+	name = "Thunderdome Admin"
+	},
+/area/tdome/tdomeadmin)
+"Kh" = (
+/obj/machinery/door/firedoor,
+/obj/machinery/door/airlock/centcom{
+	name = "Thunderdome Administration";
+	opacity = 1;
+	req_access_txt = "102"
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/tdome/tdomeadmin)
+"Ki" = (
+/turf/open/floor/plasteel/vault,
+/area/tdome/tdomeadmin)
+"Kj" = (
+/obj/machinery/door/airlock/external{
+	name = "Backup Emergency Escape Shuttle"
+	},
+/obj/effect/turf_decal/delivery,
+/turf/open/floor/plasteel,
+/area/tdome/tdomeadmin)
+"Kk" = (
+/obj/machinery/door/airlock/titanium,
+/obj/docking_port/stationary{
+	dir = 4;
+	dwidth = 2;
+	height = 8;
+	id = "backup_away";
+	name = "Backup Shuttle Dock";
+	width = 8
+	},
+/obj/docking_port/mobile/emergency/backup,
+/turf/open/floor/plating,
+/area/shuttle/escape)
+"Kl" = (
+/obj/structure/chair/office/light{
+	dir = 4
+	},
+/turf/open/floor/mineral/titanium,
+/area/shuttle/escape)
+"Km" = (
+/obj/structure/table/wood,
+/obj/item/paper/fluff/stations/centcom/broken_evac,
+/turf/open/floor/mineral/titanium,
+/area/shuttle/escape)
+"Kn" = (
+/obj/structure/bookcase/random,
+/turf/open/floor/plasteel/vault{
+	dir = 8
+	},
+/area/tdome/tdomeadmin)
+"Ko" = (
+/obj/structure/table/wood,
+/obj/item/paper_bin,
+/obj/item/pen/fourcolor,
+/obj/machinery/light,
+/turf/open/floor/plasteel/vault{
+	dir = 8
+	},
+/area/tdome/tdomeadmin)
+"Kp" = (
+/obj/structure/table/wood,
+/obj/item/folder/red,
+/obj/item/book/manual/wiki/security_space_law,
+/obj/item/restraints/handcuffs,
+/obj/item/device/assembly/flash/handheld,
+/turf/open/floor/plasteel/vault{
+	dir = 8
+	},
+/area/tdome/tdomeadmin)
+"Kq" = (
+/obj/structure/table/wood,
+/obj/item/clipboard,
+/obj/item/device/radio/headset/headset_cent,
+/turf/open/floor/plasteel/vault{
+	dir = 8
+	},
+/area/tdome/tdomeadmin)
+"Kr" = (
+/obj/structure/table/wood,
+/obj/item/phone{
+	desc = "Supposedly a direct line to Nanotrasen Central Command. It's not even plugged in.";
+	pixel_x = -3;
+	pixel_y = 3
+	},
+/obj/item/clothing/mask/cigarette/cigar/cohiba{
+	pixel_x = 6
+	},
+/obj/item/clothing/mask/cigarette/cigar/havana{
+	pixel_x = 2
+	},
+/obj/item/clothing/mask/cigarette/cigar{
+	pixel_x = 4.5
+	},
+/obj/machinery/airalarm{
+	dir = 1;
+	pixel_y = -22
+	},
+/turf/open/floor/plasteel/vault{
+	dir = 8
+	},
+/area/tdome/tdomeadmin)
+"Ks" = (
+/obj/machinery/button/door{
+	id = "thunderdomehea";
+	name = "Heavy Supply Control";
+	req_access_txt = "102"
+	},
+/obj/structure/table/reinforced,
+/turf/open/floor/plasteel/vault{
+	dir = 8
+	},
+/area/tdome/tdomeadmin)
+"Kt" = (
+/obj/machinery/button/door{
+	id = "thunderdome";
+	name = "Main Blast Doors Control";
+	req_access_txt = "102"
+	},
+/obj/structure/table/reinforced,
+/obj/machinery/light,
+/turf/open/floor/plasteel/vault{
+	dir = 8
+	},
+/area/tdome/tdomeadmin)
+"Ku" = (
+/obj/machinery/button/door{
+	id = "thunderdomegen";
+	name = "General Supply Control";
+	req_access_txt = "102"
+	},
+/obj/structure/table/reinforced,
+/turf/open/floor/plasteel/vault{
+	dir = 8
+	},
+/area/tdome/tdomeadmin)
+"Kv" = (
+/obj/structure/table/wood,
+/obj/item/folder/red,
+/obj/item/lighter,
+/obj/machinery/newscaster{
+	pixel_y = -32
+	},
+/turf/open/floor/plasteel/vault{
+	dir = 8
+	},
+/area/tdome/tdomeadmin)
+"Kw" = (
+/obj/item/storage/briefcase{
+	pixel_x = -3;
+	pixel_y = 3
+	},
+/obj/item/storage/secure/briefcase,
+/obj/structure/table/wood,
+/turf/open/floor/plasteel/vault{
+	dir = 8
+	},
+/area/tdome/tdomeadmin)
+"Kx" = (
+/obj/structure/table/wood,
+/obj/item/storage/fancy/donut_box,
+/turf/open/floor/plasteel/vault{
+	dir = 8
+	},
+/area/tdome/tdomeadmin)
+"Ky" = (
+/obj/structure/table/wood,
+/obj/item/storage/box/drinkingglasses,
+/obj/item/reagent_containers/food/drinks/bottle/whiskey{
+	pixel_y = 5
+	},
+/obj/machinery/light,
+/turf/open/floor/plasteel/vault{
+	dir = 8
+	},
+/area/tdome/tdomeadmin)
+"Kz" = (
+/obj/structure/table/wood,
+/obj/item/book/manual/random,
+/turf/open/floor/mineral/titanium,
+/area/shuttle/escape)
+"KA" = (
+/obj/structure/flora/ausbushes/lavendergrass,
+/obj/structure/flora/ausbushes/sparsegrass,
+/obj/structure/flora/ausbushes/fullgrass,
+/obj/structure/flora/ausbushes/brflowers,
+/obj/structure/flora/ausbushes/genericbush,
+/turf/open/floor/grass,
+/area/tdome/tdomeadmin)
+"KB" = (
+/obj/structure/flora/ausbushes/lavendergrass,
+/obj/structure/flora/ausbushes/sparsegrass,
+/obj/structure/flora/ausbushes/fullgrass,
+/obj/structure/flora/ausbushes/grassybush,
+/obj/structure/flora/ausbushes/ppflowers,
+/obj/structure/flora/ausbushes/pointybush,
+/obj/machinery/light,
+/turf/open/floor/grass,
+/area/tdome/tdomeadmin)
+"KC" = (
+/obj/machinery/status_display,
+/turf/closed/indestructible/riveted,
+/area/tdome/tdomeadmin)
+"KD" = (
+/obj/machinery/ai_status_display,
+/turf/closed/indestructible/riveted,
+/area/tdome/tdomeadmin)
+"KE" = (
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/open/floor/mineral/titanium,
+/area/shuttle/escape)
+"KF" = (
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/open/floor/mineral/titanium,
+/area/shuttle/escape)
+"KG" = (
+/obj/structure/flora/ausbushes/lavendergrass,
+/obj/structure/flora/ausbushes/sparsegrass,
+/obj/structure/flora/ausbushes/fullgrass,
+/obj/structure/flora/ausbushes/grassybush,
+/obj/structure/flora/ausbushes/ppflowers,
+/obj/structure/flora/ausbushes/pointybush,
+/turf/open/floor/grass,
+/area/tdome/tdomeadmin)
+"KH" = (
+/turf/closed/wall/mineral/titanium,
+/area/centcom/evac)
+"KI" = (
+/obj/structure/shuttle/engine/propulsion/right{
+	dir = 1
+	},
+/turf/open/floor/plating/airless,
+/area/centcom/evac)
+"KJ" = (
+/obj/structure/shuttle/engine/propulsion{
+	dir = 1
+	},
+/turf/open/floor/plating/airless,
+/area/centcom/evac)
+"KK" = (
+/obj/structure/shuttle/engine/propulsion/left{
+	dir = 1
+	},
+/turf/open/floor/plating/airless,
+/area/centcom/evac)
+"KL" = (
+/obj/docking_port/stationary{
+	dir = 1;
+	dwidth = 1;
+	height = 4;
+	id = "pod4_away";
+	name = "recovery ship";
+	width = 3
+	},
+/turf/open/space,
+/area/space)
+"KM" = (
+/obj/docking_port/stationary{
+	dir = 1;
+	dwidth = 1;
+	height = 4;
+	id = "pod3_away";
+	name = "recovery ship";
+	width = 3
+	},
+/turf/open/space,
+/area/space)
+"KN" = (
+/obj/structure/window/reinforced,
+/obj/structure/shuttle/engine/heater{
+	dir = 1
+	},
+/turf/open/floor/plating/airless,
+/area/centcom/evac)
+"KO" = (
+/obj/machinery/door/airlock/titanium,
+/turf/open/floor/plating,
+/area/centcom/evac)
+"KP" = (
+/obj/structure/window/shuttle,
+/obj/structure/grille,
+/turf/open/floor/plating,
+/area/centcom/evac)
+"KQ" = (
+/turf/open/floor/plating,
+/area/centcom/evac)
+"KR" = (
+/obj/machinery/light/small{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/centcom/evac)
+"KS" = (
+/turf/open/floor/plating,
+/turf/closed/wall/mineral/titanium/interior,
+/area/centcom/evac)
+"KT" = (
+/turf/open/floor/mineral/titanium/blue,
+/turf/closed/wall/mineral/titanium/interior,
+/area/centcom/evac)
+"KU" = (
+/obj/structure/closet/emcloset,
+/turf/open/floor/mineral/titanium/blue,
+/area/centcom/evac)
+"KV" = (
+/turf/open/floor/mineral/titanium/yellow,
+/area/centcom/evac)
+"KW" = (
+/obj/structure/table,
+/obj/item/storage/firstaid/toxin{
+	pixel_x = -2;
+	pixel_y = 4
+	},
+/obj/item/storage/firstaid/toxin,
+/turf/open/floor/mineral/titanium/blue,
+/area/centcom/evac)
+"KX" = (
+/obj/structure/table,
+/obj/item/storage/firstaid/fire,
+/obj/item/storage/firstaid/fire{
+	pixel_x = -2;
+	pixel_y = 4
+	},
+/turf/open/floor/mineral/titanium/blue,
+/area/centcom/evac)
+"KY" = (
+/obj/structure/table,
+/obj/item/storage/firstaid/regular{
+	pixel_x = 2
+	},
+/obj/item/storage/firstaid/regular{
+	pixel_x = -2;
+	pixel_y = 4
+	},
+/turf/open/floor/mineral/titanium/blue,
+/area/centcom/evac)
+"KZ" = (
+/obj/machinery/light/small{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/centcom/evac)
+"La" = (
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/open/floor/mineral/titanium/blue,
+/area/centcom/evac)
+"Lb" = (
+/turf/open/floor/mineral/titanium/blue,
+/area/centcom/evac)
+"Lc" = (
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/open/floor/mineral/titanium/blue,
+/area/centcom/evac)
+"Ld" = (
+/obj/structure/table/reinforced,
+/obj/item/paper_bin,
+/turf/open/floor/mineral/plastitanium,
+/area/centcom/evac)
+"Le" = (
+/obj/structure/table/reinforced,
+/obj/item/storage/fancy/donut_box,
+/turf/open/floor/mineral/plastitanium,
+/area/centcom/evac)
+"Lf" = (
+/obj/structure/table/reinforced,
+/obj/item/pen,
+/turf/open/floor/mineral/plastitanium,
+/area/centcom/evac)
+"Lg" = (
+/obj/structure/table/reinforced,
+/turf/open/floor/mineral/plastitanium,
+/area/centcom/evac)
+"Lh" = (
+/obj/machinery/sleeper{
+	dir = 8
+	},
+/turf/open/floor/mineral/titanium/blue,
+/area/centcom/evac)
+"Li" = (
+/obj/structure/chair{
+	dir = 8
+	},
+/turf/open/floor/mineral/titanium/blue,
+/area/centcom/evac)
+"Lj" = (
+/obj/machinery/computer/secure_data,
+/turf/open/floor/mineral/plastitanium,
+/area/centcom/evac)
+"Lk" = (
+/obj/structure/chair{
+	dir = 1
+	},
+/turf/open/floor/mineral/plastitanium,
+/area/centcom/evac)
+"Ll" = (
+/obj/structure/chair{
+	dir = 4
+	},
+/turf/open/floor/mineral/plastitanium,
+/area/centcom/evac)
+"Lm" = (
+/obj/structure/table/reinforced,
+/obj/item/clipboard,
+/obj/item/stamp,
+/turf/open/floor/mineral/plastitanium,
+/area/centcom/evac)
+"Ln" = (
+/obj/structure/table,
+/obj/item/device/assembly/flash/handheld,
+/turf/open/floor/mineral/plastitanium,
+/area/centcom/evac)
+"Lo" = (
+/turf/open/floor/mineral/plastitanium,
+/area/centcom/evac)
+"Lp" = (
+/obj/structure/chair{
+	dir = 4
+	},
+/turf/open/floor/mineral/titanium/blue,
+/area/centcom/evac)
+"Lq" = (
+/obj/structure/table,
+/obj/item/storage/box/handcuffs,
+/turf/open/floor/mineral/plastitanium,
+/area/centcom/evac)
+"Lr" = (
+/obj/machinery/door/window/northright{
+	base_state = "right";
+	dir = 4;
+	icon_state = "right";
+	name = "Security Desk";
+	req_access_txt = "103"
+	},
+/turf/open/floor/mineral/plastitanium,
+/area/centcom/evac)
+"Ls" = (
+/obj/docking_port/stationary{
+	dir = 4;
+	dwidth = 1;
+	height = 4;
+	id = "pod2_away";
+	name = "recovery ship";
+	width = 3
+	},
+/turf/open/space,
+/area/space)
+"Lt" = (
+/turf/closed/wall/mineral/titanium/nodiagonal,
+/area/centcom/evac)
+"Lu" = (
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/open/floor/mineral/titanium/yellow,
+/area/centcom/evac)
+"Lv" = (
+/obj/structure/bed,
+/turf/open/floor/mineral/titanium/blue,
+/area/centcom/evac)
+"Lw" = (
+/obj/effect/spawner/structure/window/shuttle,
+/turf/open/floor/plating,
+/area/centcom/evac)
+"Lx" = (
+/obj/structure/bed,
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/open/floor/mineral/titanium/blue,
+/area/centcom/evac)
+"Ly" = (
+/obj/machinery/door/airlock/titanium,
+/turf/open/floor/mineral/titanium/yellow,
+/area/centcom/evac)
+"Lz" = (
+/obj/docking_port/stationary{
+	dir = 4;
+	dwidth = 2;
+	height = 7;
+	id = "pod1_away";
+	name = "recovery ship";
+	width = 5
+	},
+/turf/open/space,
+/area/space)
+"LA" = (
+/obj/structure/table,
+/obj/structure/bedsheetbin,
+/turf/open/floor/mineral/titanium/blue,
+/area/centcom/evac)
+"LB" = (
+/obj/structure/table,
+/obj/item/hand_labeler,
+/obj/machinery/light,
+/turf/open/floor/mineral/titanium/blue,
+/area/centcom/evac)
+"LC" = (
+/obj/structure/table,
+/obj/item/storage/box/donkpockets,
+/turf/open/floor/mineral/titanium/blue,
+/area/centcom/evac)
+"LD" = (
+/obj/machinery/door/airlock/titanium{
+	name = "Cockpit";
+	req_access_txt = "109"
+	},
+/turf/open/floor/mineral/titanium/yellow,
+/area/centcom/evac)
+"LE" = (
+/obj/structure/table,
+/obj/item/device/radio/off,
+/turf/open/floor/mineral/titanium/blue,
+/area/centcom/evac)
+"LF" = (
+/obj/structure/chair{
+	dir = 4;
+	name = "Prosecution"
+	},
+/turf/open/floor/mineral/titanium/blue,
+/area/centcom/evac)
+"LG" = (
+/obj/structure/filingcabinet,
+/turf/open/floor/mineral/titanium/blue,
+/area/centcom/evac)
+"LH" = (
+/obj/structure/table,
+/obj/item/storage/box/donkpockets,
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/open/floor/mineral/titanium/blue,
+/area/centcom/evac)
+"LI" = (
+/obj/structure/chair,
+/turf/open/floor/mineral/titanium/blue,
+/area/centcom/evac)
+"LJ" = (
+/obj/structure/table,
+/obj/item/device/radio/off,
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/open/floor/mineral/titanium/blue,
+/area/centcom/evac)
+"LK" = (
+/obj/machinery/abductor/experiment{
+	team_number = 2
+	},
+/turf/open/floor/plating/abductor,
+/area/abductor_ship)
+"LL" = (
+/obj/machinery/abductor/console{
+	team_number = 2
+	},
+/turf/open/floor/plating/abductor,
+/area/abductor_ship)
+"LM" = (
+/obj/machinery/abductor/pad{
+	team_number = 2
+	},
+/turf/open/floor/plating/abductor,
+/area/abductor_ship)
+"LN" = (
+/obj/structure/table,
+/obj/item/storage/lockbox,
+/turf/open/floor/mineral/titanium/blue,
+/area/centcom/evac)
+"LO" = (
+/obj/structure/table,
+/turf/open/floor/mineral/titanium/blue,
+/area/centcom/evac)
+"LP" = (
+/obj/machinery/computer/shuttle,
+/turf/open/floor/mineral/titanium/blue,
+/area/centcom/evac)
+"LQ" = (
+/obj/structure/table,
+/obj/item/clipboard,
+/obj/item/pen,
+/turf/open/floor/mineral/titanium/blue,
+/area/centcom/evac)
+"LR" = (
+/obj/structure/table,
+/obj/item/paper_bin,
+/turf/open/floor/mineral/titanium/blue,
+/area/centcom/evac)
+"LS" = (
+/obj/machinery/computer/camera_advanced/abductor{
+	team_number = 2
+	},
+/turf/open/floor/plating/abductor,
+/area/abductor_ship)
+"LT" = (
+/obj/effect/landmark/abductor/scientist{
+	team_number = 2
+	},
+/turf/open/floor/plating/abductor,
+/area/abductor_ship)
+"LU" = (
+/obj/effect/landmark/abductor/agent{
+	team_number = 2
+	},
+/turf/open/floor/plating/abductor,
+/area/abductor_ship)
+"LV" = (
+/turf/closed/indestructible/riveted,
+/area/awaymission/errorroom)
+"LW" = (
+/turf/closed/mineral/ash_rock,
+/area/awaymission/errorroom)
+"LX" = (
+/obj/structure/speaking_tile,
+/turf/closed/mineral/ash_rock,
+/area/awaymission/errorroom)
+"LY" = (
+/obj/item/rupee,
+/turf/open/floor/plating/ashplanet/wateryrock{
+	initial_gas_mix = "o2=22;n2=82;TEMP=293.15";
+	planetary_atmos = 0
+	},
+/area/awaymission/errorroom)
+"LZ" = (
+/turf/open/floor/plating/ashplanet/wateryrock{
+	initial_gas_mix = "o2=22;n2=82;TEMP=293.15";
+	planetary_atmos = 0
+	},
+/area/awaymission/errorroom)
+"Ma" = (
+/obj/effect/landmark/error,
+/turf/open/floor/plating/ashplanet/wateryrock{
+	initial_gas_mix = "o2=22;n2=82;TEMP=293.15";
+	planetary_atmos = 0
+	},
+/area/awaymission/errorroom)
+"Mb" = (
+/obj/structure/signpost/salvation{
+	icon = 'icons/obj/structures.dmi';
+	icon_state = "ladder10";
+	invisibility = 100
+	},
+/turf/open/floor/plating/ashplanet/wateryrock{
+	initial_gas_mix = "o2=22;n2=82;TEMP=293.15";
+	planetary_atmos = 0
+	},
+/area/awaymission/errorroom)
+"Mc" = (
+/obj/structure/lattice,
+/turf/open/space,
+/area/space)
 
 (1,1,1) = {"
 aa
@@ -14571,21 +14555,21 @@ aa
 aa
 aa
 aa
-gc
-gc
-gc
-gc
-gc
-gc
-gc
-gc
-gc
-gc
-gc
-gc
-gc
-gc
-gz
+fX
+fX
+fX
+fX
+fX
+fX
+fX
+fX
+fX
+fX
+fX
+fX
+fX
+fX
+gu
 aa
 aa
 aa
@@ -14828,21 +14812,21 @@ aa
 aa
 aa
 aa
-gc
-gc
-gc
-gc
-gc
-gc
-gc
-gc
-gc
-gc
-gc
-gc
-gc
-gc
-gc
+fX
+fX
+fX
+fX
+fX
+fX
+fX
+fX
+fX
+fX
+fX
+fX
+fX
+fX
+fX
 aa
 aa
 aa
@@ -14997,17 +14981,17 @@ aa
 aa
 aa
 aa
-HM
-HM
-HM
-HM
-HM
-HM
-HM
-HM
-HM
-HM
-HM
+LV
+LV
+LV
+LV
+LV
+LV
+LV
+LV
+LV
+LV
+LV
 aa
 "}
 (3,1,1) = {"
@@ -15085,21 +15069,21 @@ aa
 aa
 aa
 aa
-gc
-gc
-gc
-gc
-gc
-gc
-gc
-gc
-gc
-gc
-gc
-gc
-gc
-gc
-gc
+fX
+fX
+fX
+fX
+fX
+fX
+fX
+fX
+fX
+fX
+fX
+fX
+fX
+fX
+fX
 aa
 aa
 aa
@@ -15163,11 +15147,11 @@ aa
 aa
 aa
 aa
-Gf
-Gv
-GF
-GR
-GX
+kK
+lg
+lB
+lX
+mr
 aa
 aa
 aa
@@ -15190,11 +15174,11 @@ aa
 aa
 aa
 aa
-Gf
-Gv
-GF
-GR
-GX
+kK
+lg
+lB
+lX
+mr
 aa
 aa
 aa
@@ -15220,11 +15204,11 @@ aa
 aa
 aa
 aa
-Gf
-Gv
-GF
-GR
-GX
+kK
+lg
+lB
+lX
+mr
 aa
 aa
 aa
@@ -15247,24 +15231,24 @@ aa
 aa
 aa
 aa
-Gf
-Gv
-GF
-GR
-GX
+kK
+lg
+lB
+lX
+mr
 aa
 aa
-HM
-HN
-HN
-HN
-HN
-HN
-HN
-HN
-HN
-HN
-HM
+LV
+LW
+LW
+LW
+LW
+LW
+LW
+LW
+LW
+LW
+LV
 aa
 "}
 (4,1,1) = {"
@@ -15342,21 +15326,21 @@ aa
 aa
 aa
 aa
-gc
-gc
-gc
-gc
-gc
-gc
-gc
-gc
-gc
-gc
-gc
-gc
-gc
-gc
-gc
+fX
+fX
+fX
+fX
+fX
+fX
+fX
+fX
+fX
+fX
+fX
+fX
+fX
+fX
+fX
 aa
 aa
 aa
@@ -15419,13 +15403,13 @@ aa
 aa
 aa
 aa
-Ga
-Gg
-GA
-GG
-GS
-GY
-He
+ko
+kL
+lh
+lC
+lY
+ms
+nb
 aa
 aa
 aa
@@ -15446,13 +15430,13 @@ aa
 aa
 aa
 aa
-Ga
-Gg
-Hu
-GG
-GS
-GY
-He
+ko
+kL
+Be
+lC
+lY
+ms
+nb
 aa
 aa
 aa
@@ -15476,13 +15460,13 @@ aa
 aa
 aa
 aa
-Ga
-Gg
-Gw
-GG
-GS
-GY
-He
+ko
+kL
+JF
+lC
+lY
+ms
+nb
 aa
 aa
 aa
@@ -15503,25 +15487,25 @@ aa
 aa
 aa
 aa
-Ga
-Gg
-Ht
-GG
-GS
-GY
-He
+ko
+kL
+LS
+lC
+lY
+ms
+nb
 aa
-HM
-HN
-HP
-HP
-HP
-HQ
-HP
-HP
-HP
-HN
-HM
+LV
+LW
+LY
+LY
+LY
+LZ
+LY
+LY
+LY
+LW
+LV
 aa
 "}
 (5,1,1) = {"
@@ -15599,21 +15583,21 @@ aa
 aa
 aa
 aa
-gc
-gc
-gc
-gc
-gc
-gc
-gc
-gc
-gc
-gc
-gc
-gc
-gc
-gc
-gc
+fX
+fX
+fX
+fX
+fX
+fX
+fX
+fX
+fX
+fX
+fX
+fX
+fX
+fX
+fX
 aa
 aa
 aa
@@ -15676,13 +15660,13 @@ aa
 aa
 aa
 aa
-Gb
-Gm
-Gx
-GM
-Gx
-GZ
-Hf
+kp
+kM
+li
+lD
+li
+mt
+nc
 aa
 aa
 aa
@@ -15703,13 +15687,13 @@ aa
 aa
 aa
 aa
-Gb
-Hq
-Gx
-HA
-Gx
-GZ
-Hf
+kp
+Au
+li
+BQ
+li
+mt
+nc
 aa
 aa
 aa
@@ -15733,13 +15717,13 @@ aa
 aa
 aa
 aa
-Gb
-Gh
-Gx
-GH
-Gx
-GZ
-Hf
+kp
+JA
+li
+JM
+li
+mt
+nc
 aa
 aa
 aa
@@ -15760,25 +15744,25 @@ aa
 aa
 aa
 aa
-Gb
-Hn
-Gx
-Hy
-Gx
-GZ
-Hf
+kp
+LK
+li
+LT
+li
+mt
+nc
 aa
-HM
-HN
-HP
-HP
-HP
-HQ
-HP
-HP
-HP
-HN
-HM
+LV
+LW
+LY
+LY
+LY
+LZ
+LY
+LY
+LY
+LW
+LV
 aa
 "}
 (6,1,1) = {"
@@ -15856,21 +15840,21 @@ aa
 aa
 aa
 aa
-gc
-gc
-gc
-gc
-gc
-gc
-gc
-gc
-gc
-gc
-gc
-gc
-gc
-gc
-gc
+fX
+fX
+fX
+fX
+fX
+fX
+fX
+fX
+fX
+fX
+fX
+fX
+fX
+fX
+fX
 aa
 aa
 aa
@@ -15933,13 +15917,13 @@ aa
 aa
 aa
 aa
-Gc
-Gn
-Gx
-GI
-Gx
-Ha
-Hg
+kq
+kN
+li
+lE
+li
+mu
+nd
 aa
 aa
 aa
@@ -15960,13 +15944,13 @@ aa
 aa
 aa
 aa
-Gc
-Hr
-Gx
-GI
-Gx
-Ha
-Hg
+kq
+Av
+li
+lE
+li
+mu
+nd
 aa
 aa
 aa
@@ -15990,13 +15974,13 @@ aa
 aa
 aa
 aa
-Gc
-Gi
-Gx
-GI
-Gx
-Ha
-Hg
+kq
+JB
+li
+lE
+li
+mu
+nd
 aa
 aa
 aa
@@ -16017,25 +16001,25 @@ aa
 aa
 aa
 aa
-Gc
-Ho
-Gx
-GI
-Gx
-Ha
-Hg
+kq
+LL
+li
+lE
+li
+mu
+nd
 aa
-HM
-HN
-HP
-HP
-HP
-HQ
-HP
-HP
-HP
-HN
-HM
+LV
+LW
+LY
+LY
+LY
+LZ
+LY
+LY
+LY
+LW
+LV
 aa
 "}
 (7,1,1) = {"
@@ -16113,21 +16097,21 @@ aa
 aa
 aa
 aa
-gc
-gc
-gc
-gc
-gc
-gc
-gc
-gc
-gc
-gc
-gc
-gc
-gc
-gc
-gc
+fX
+fX
+fX
+fX
+fX
+fX
+fX
+fX
+fX
+fX
+fX
+fX
+fX
+fX
+fX
 aa
 aa
 aa
@@ -16190,13 +16174,13 @@ aa
 aa
 aa
 aa
-Gd
-Go
-Gx
-GN
-Gx
-Hb
-Hh
+kr
+kO
+li
+lF
+li
+mv
+ne
 aa
 aa
 aa
@@ -16217,13 +16201,13 @@ aa
 aa
 aa
 aa
-Gd
-Hs
-Gx
-HB
-Gx
-Hb
-Hh
+kr
+Aw
+li
+BR
+li
+mv
+ne
 aa
 aa
 aa
@@ -16247,13 +16231,13 @@ aa
 aa
 aa
 aa
-Gd
-Gj
-Gx
-GJ
-Gx
-Hb
-Hh
+kr
+JC
+li
+JN
+li
+mv
+ne
 aa
 aa
 aa
@@ -16274,25 +16258,25 @@ aa
 aa
 aa
 aa
-Gd
-Hp
-Gx
-Hz
-Gx
-Hb
-Hh
+kr
+LM
+li
+LU
+li
+mv
+ne
 aa
-HM
-HN
-HQ
-HQ
-HQ
-HQ
-HQ
-HQ
-HQ
-HN
-HM
+LV
+LW
+LZ
+LZ
+LZ
+LZ
+LZ
+LZ
+LZ
+LW
+LV
 aa
 "}
 (8,1,1) = {"
@@ -16370,21 +16354,21 @@ aa
 aa
 aa
 aa
-gc
-gc
-gc
-gc
-gc
-gc
-gc
-gd
-gc
-gc
-gc
-gc
-gc
-gc
-gc
+fX
+fX
+fX
+fX
+fX
+fX
+fX
+fY
+fX
+fX
+fX
+fX
+fX
+fX
+fX
 aa
 aa
 aa
@@ -16447,13 +16431,13 @@ aa
 aa
 aa
 aa
-Ge
-Gk
-Gy
-GK
-Gy
-Hc
-Hi
+ks
+kP
+lj
+lG
+lj
+mw
+nf
 aa
 aa
 aa
@@ -16474,13 +16458,13 @@ aa
 aa
 aa
 aa
-Ge
-Gk
-Gy
-GK
-Gy
-Hc
-Hi
+ks
+kP
+lj
+lG
+lj
+mw
+nf
 aa
 aa
 aa
@@ -16504,13 +16488,13 @@ aa
 aa
 aa
 aa
-Ge
-Gk
-Gy
-GK
-Gy
-Hc
-Hi
+ks
+kP
+lj
+lG
+lj
+mw
+nf
 aa
 aa
 aa
@@ -16531,25 +16515,25 @@ aa
 aa
 aa
 aa
-Ge
-Gk
-Gy
-GK
-Gy
-Hc
-Hi
+ks
+kP
+lj
+lG
+lj
+mw
+nf
 aa
-HM
-HN
-HP
-HP
-HP
-HQ
-HQ
-HQ
-HQ
-HN
-HM
+LV
+LW
+LY
+LY
+LY
+LZ
+LZ
+LZ
+LZ
+LW
+LV
 aa
 "}
 (9,1,1) = {"
@@ -16627,21 +16611,21 @@ aa
 aa
 aa
 aa
-gc
-gc
-gc
-gc
-gc
-gc
-gc
-gc
-gc
-gc
-gc
-gc
-gc
-gc
-gc
+fX
+fX
+fX
+fX
+fX
+fX
+fX
+fX
+fX
+fX
+fX
+fX
+fX
+fX
+fX
 aa
 aa
 aa
@@ -16705,11 +16689,11 @@ aa
 aa
 aa
 aa
-Gl
-Gz
-GL
-GT
-Hd
+kQ
+lk
+lH
+lZ
+mx
 aa
 aa
 aa
@@ -16732,11 +16716,11 @@ aa
 aa
 aa
 aa
-Gl
-Gz
-GL
-GT
-Hd
+kQ
+lk
+lH
+lZ
+mx
 aa
 aa
 aa
@@ -16762,11 +16746,11 @@ aa
 aa
 aa
 aa
-Gl
-Gz
-GL
-GT
-Hd
+kQ
+lk
+lH
+lZ
+mx
 aa
 aa
 aa
@@ -16789,24 +16773,24 @@ aa
 aa
 aa
 aa
-Gl
-Gz
-GL
-GT
-Hd
+kQ
+lk
+lH
+lZ
+mx
 aa
 aa
-HM
-HO
-HP
-HP
-HP
-HQ
-HQ
-HR
-HS
-HN
-HM
+LV
+LX
+LY
+LY
+LY
+LZ
+LZ
+Ma
+Mb
+LW
+LV
 aa
 "}
 (10,1,1) = {"
@@ -16884,21 +16868,21 @@ aa
 aa
 aa
 aa
-gc
-gc
-gc
-gc
-gc
-gc
-gc
-gc
-gc
-gc
-gc
-gc
-gc
-gc
-gc
+fX
+fX
+fX
+fX
+fX
+fX
+fX
+fX
+fX
+fX
+fX
+fX
+fX
+fX
+fX
 aa
 aa
 aa
@@ -17053,17 +17037,17 @@ aa
 aa
 aa
 aa
-HM
-HN
-HP
-HP
-HP
-HQ
-HQ
-HQ
-HQ
-HN
-HM
+LV
+LW
+LY
+LY
+LY
+LZ
+LZ
+LZ
+LZ
+LW
+LV
 aa
 "}
 (11,1,1) = {"
@@ -17141,21 +17125,21 @@ aa
 aa
 aa
 aa
-gc
-gc
-gc
-gc
-gc
-gc
-gc
-gc
-gc
-gc
-gc
-gc
-gc
-gc
-gc
+fX
+fX
+fX
+fX
+fX
+fX
+fX
+fX
+fX
+fX
+fX
+fX
+fX
+fX
+fX
 aa
 aa
 aa
@@ -17221,50 +17205,50 @@ aa
 aa
 aa
 aa
-la
-la
-la
-la
-la
-la
-la
-la
-la
-la
-la
-la
-la
-la
-la
-la
-la
-la
-la
-la
-la
-la
-la
-la
-la
-la
-la
-la
-la
-la
-la
-la
-la
-la
-la
-la
-la
-la
-la
-la
-la
-la
-la
-la
+lI
+lI
+lI
+lI
+lI
+lI
+lI
+lI
+lI
+lI
+lI
+lI
+lI
+lI
+lI
+lI
+lI
+lI
+lI
+lI
+lI
+lI
+lI
+lI
+lI
+lI
+lI
+lI
+lI
+lI
+lI
+lI
+lI
+lI
+lI
+lI
+lI
+lI
+lI
+lI
+lI
+lI
+lI
+lI
 aa
 aa
 aa
@@ -17310,17 +17294,17 @@ aa
 aa
 aa
 aa
-HM
-HN
-HQ
-HQ
-HQ
-HQ
-HQ
-HQ
-HQ
-HN
-HM
+LV
+LW
+LZ
+LZ
+LZ
+LZ
+LZ
+LZ
+LZ
+LW
+LV
 aa
 "}
 (12,1,1) = {"
@@ -17398,21 +17382,21 @@ aa
 aa
 aa
 aa
-gc
-gc
-gc
-gc
-gc
-gc
-gc
-gc
-gc
-gc
-gc
-gc
-gc
-gc
-gc
+fX
+fX
+fX
+fX
+fX
+fX
+fX
+fX
+fX
+fX
+fX
+fX
+fX
+fX
+fX
 aa
 aa
 aa
@@ -17478,50 +17462,50 @@ aa
 aa
 aa
 aa
-la
-la
-la
-la
-la
-la
-la
-la
-la
-la
-la
-la
-la
-la
-la
-la
-la
-la
-la
-la
-la
-la
-la
-la
-la
-la
-la
-la
-la
-la
-la
-la
-la
-la
-la
-la
-la
-la
-la
-la
-la
-la
-la
-la
+lI
+lI
+lI
+lI
+lI
+lI
+lI
+lI
+lI
+lI
+lI
+lI
+lI
+lI
+lI
+lI
+lI
+lI
+lI
+lI
+lI
+lI
+lI
+lI
+lI
+lI
+lI
+lI
+lI
+lI
+lI
+lI
+lI
+lI
+lI
+lI
+lI
+lI
+lI
+lI
+lI
+lI
+lI
+lI
 aa
 aa
 aa
@@ -17567,17 +17551,17 @@ aa
 aa
 aa
 aa
-HM
-HN
-HP
-HP
-HP
-HQ
-HP
-HP
-HP
-HN
-HM
+LV
+LW
+LY
+LY
+LY
+LZ
+LY
+LY
+LY
+LW
+LV
 aa
 "}
 (13,1,1) = {"
@@ -17655,21 +17639,21 @@ aa
 aa
 aa
 aa
-gc
-gc
-gc
-gc
-gc
-gc
-gc
-gc
-gc
-gc
-gc
-gc
-gc
-gc
-gc
+fX
+fX
+fX
+fX
+fX
+fX
+fX
+fX
+fX
+fX
+fX
+fX
+fX
+fX
+fX
 aa
 aa
 aa
@@ -17735,50 +17719,50 @@ aa
 aa
 aa
 aa
-la
-la
-la
-la
-la
-la
-la
-la
-la
-la
-la
-la
-la
-la
-la
-la
-la
-la
-la
-la
-la
-la
-la
-la
-la
-la
-la
-la
-la
-la
-la
-la
-la
-la
-la
-la
-la
-la
-la
-la
-la
-la
-la
-la
+lI
+lI
+lI
+lI
+lI
+lI
+lI
+lI
+lI
+lI
+lI
+lI
+lI
+lI
+lI
+lI
+lI
+lI
+lI
+lI
+lI
+lI
+lI
+lI
+lI
+lI
+lI
+lI
+lI
+lI
+lI
+lI
+lI
+lI
+lI
+lI
+lI
+lI
+lI
+lI
+lI
+lI
+lI
+lI
 aa
 aa
 aa
@@ -17824,17 +17808,17 @@ aa
 aa
 aa
 aa
-HM
-HN
-HP
-HP
-HP
-HQ
-HP
-HP
-HP
-HN
-HM
+LV
+LW
+LY
+LY
+LY
+LZ
+LY
+LY
+LY
+LW
+LV
 aa
 "}
 (14,1,1) = {"
@@ -17912,21 +17896,21 @@ aa
 aa
 aa
 aa
-gc
-gc
-gc
-gc
-gc
-gc
-gc
-gc
-gc
-gc
-gc
-gc
-gc
-gc
-gc
+fX
+fX
+fX
+fX
+fX
+fX
+fX
+fX
+fX
+fX
+fX
+fX
+fX
+fX
+fX
 aa
 aa
 aa
@@ -17992,50 +17976,50 @@ aa
 aa
 aa
 aa
-la
-la
-la
-la
-la
-la
-la
-la
-la
-la
-la
-la
-la
-la
-la
-la
-la
-la
-la
-la
-la
-la
-la
-la
-la
-la
-la
-la
-la
-la
-la
-la
-la
-la
-la
-la
-la
-la
-la
-la
-la
-la
-la
-la
+lI
+lI
+lI
+lI
+lI
+lI
+lI
+lI
+lI
+lI
+lI
+lI
+lI
+lI
+lI
+lI
+lI
+lI
+lI
+lI
+lI
+lI
+lI
+lI
+lI
+lI
+lI
+lI
+lI
+lI
+lI
+lI
+lI
+lI
+lI
+lI
+lI
+lI
+lI
+lI
+lI
+lI
+lI
+lI
 aa
 aa
 aa
@@ -18081,17 +18065,17 @@ aa
 aa
 aa
 aa
-HM
-HN
-HP
-HP
-HP
-HQ
-HP
-HP
-HP
-HN
-HM
+LV
+LW
+LY
+LY
+LY
+LZ
+LY
+LY
+LY
+LW
+LV
 aa
 "}
 (15,1,1) = {"
@@ -18169,21 +18153,21 @@ aa
 aa
 aa
 aa
-gc
-gc
-gc
-gc
-gc
-gc
-gc
-gc
-gc
-gc
-gc
-gc
-gc
-gc
-gc
+fX
+fX
+fX
+fX
+fX
+fX
+fX
+fX
+fX
+fX
+fX
+fX
+fX
+fX
+fX
 aa
 aa
 aa
@@ -18249,50 +18233,50 @@ aa
 aa
 aa
 aa
-la
-la
-la
-la
-la
-la
-la
-la
-la
-la
-la
-la
-la
-la
-la
-la
-la
-la
-la
-la
-la
-la
-la
-la
-la
-la
-la
-la
-la
-la
-la
-la
-la
-la
-la
-la
-la
-la
-la
-la
-la
-la
-la
-la
+lI
+lI
+lI
+lI
+lI
+lI
+lI
+lI
+lI
+lI
+lI
+lI
+lI
+lI
+lI
+lI
+lI
+lI
+lI
+lI
+lI
+lI
+lI
+lI
+lI
+lI
+lI
+lI
+lI
+lI
+lI
+lI
+lI
+lI
+lI
+lI
+lI
+lI
+lI
+lI
+lI
+lI
+lI
+lI
 aa
 aa
 aa
@@ -18338,17 +18322,17 @@ aa
 aa
 aa
 aa
-HM
-HN
-HN
-HN
-HN
-HN
-HN
-HN
-HN
-HN
-HM
+LV
+LW
+LW
+LW
+LW
+LW
+LW
+LW
+LW
+LW
+LV
 aa
 "}
 (16,1,1) = {"
@@ -18506,50 +18490,50 @@ aa
 aa
 aa
 aa
-la
-la
-la
-la
-la
-la
-la
-la
-la
-la
-la
-la
-la
-la
-la
-la
-la
-la
-la
-la
-la
-la
-la
-la
-la
-la
-la
-la
-la
-la
-la
-la
-la
-la
-la
-la
-la
-la
-la
-la
-la
-la
-la
-la
+lI
+lI
+lI
+lI
+lI
+lI
+lI
+lI
+lI
+lI
+lI
+lI
+lI
+lI
+lI
+lI
+lI
+lI
+lI
+lI
+lI
+lI
+lI
+lI
+lI
+lI
+lI
+lI
+lI
+lI
+lI
+lI
+lI
+lI
+lI
+lI
+lI
+lI
+lI
+lI
+lI
+lI
+lI
+lI
 aa
 aa
 aa
@@ -18595,17 +18579,17 @@ aa
 aa
 aa
 aa
-HM
-HM
-HM
-HM
-HM
-HM
-HM
-HM
-HM
-HM
-HM
+LV
+LV
+LV
+LV
+LV
+LV
+LV
+LV
+LV
+LV
+LV
 aa
 "}
 (17,1,1) = {"
@@ -18763,50 +18747,50 @@ aa
 aa
 aa
 aa
-la
-la
-la
-la
-la
-la
-la
-la
-la
-la
-la
-la
-la
-la
-la
-la
-la
-la
-la
-la
-la
-la
-la
-la
-la
-la
-la
-la
-la
-la
-la
-la
-la
-la
-la
-la
-la
-la
-la
-la
-la
-la
-la
-la
+lI
+lI
+lI
+lI
+lI
+lI
+lI
+lI
+lI
+lI
+lI
+lI
+lI
+lI
+lI
+lI
+lI
+lI
+lI
+lI
+lI
+lI
+lI
+lI
+lI
+lI
+lI
+lI
+lI
+lI
+lI
+lI
+lI
+lI
+lI
+lI
+lI
+lI
+lI
+lI
+lI
+lI
+lI
+lI
 aa
 aa
 aa
@@ -19020,50 +19004,50 @@ aa
 aa
 aa
 aa
-la
-la
-la
-la
-la
-la
-la
-la
-la
-la
-la
-la
-la
-la
-la
-la
-la
-la
-la
-la
-la
-pg
-pg
-wf
-wy
-wX
-pg
-pg
-la
-la
-la
-la
-la
-la
-la
-la
-la
-la
-la
-la
-la
-la
-la
-la
+lI
+lI
+lI
+lI
+lI
+lI
+lI
+lI
+lI
+lI
+lI
+lI
+lI
+lI
+lI
+lI
+lI
+lI
+lI
+lI
+lI
+qE
+qE
+zn
+zM
+Ax
+qE
+qE
+lI
+lI
+lI
+lI
+lI
+lI
+lI
+lI
+lI
+lI
+lI
+lI
+lI
+lI
+lI
+lI
 aa
 aa
 aa
@@ -19277,50 +19261,50 @@ aa
 aa
 aa
 aa
-la
-la
-la
-la
-la
-la
-la
-la
-la
-la
-la
-la
-la
-la
-la
-la
-la
-la
-pg
-pg
-pg
-pg
-vG
-wg
-wz
-wg
-xu
-pg
-wf
-wX
-pg
-la
-la
-la
-la
-la
-la
-la
-la
-la
-la
-la
-la
-la
+lI
+lI
+lI
+lI
+lI
+lI
+lI
+lI
+lI
+lI
+lI
+lI
+lI
+lI
+lI
+lI
+lI
+lI
+qE
+qE
+qE
+qE
+yC
+zo
+zN
+zo
+Bf
+qE
+zn
+Ax
+qE
+lI
+lI
+lI
+lI
+lI
+lI
+lI
+lI
+lI
+lI
+lI
+lI
+lI
 aa
 aa
 aa
@@ -19534,50 +19518,50 @@ aa
 aa
 aa
 aa
-la
-la
-la
-la
-la
-la
-la
-la
-la
-la
-la
-la
-la
-la
-la
-la
-la
-pg
-pg
-sx
-tb
-vo
-px
-px
-px
-px
-px
-xS
-px
-px
-pg
-pg
-la
-la
-la
-la
-la
-la
-la
-la
-la
-la
-la
-la
+lI
+lI
+lI
+lI
+lI
+lI
+lI
+lI
+lI
+lI
+lI
+lI
+lI
+lI
+lI
+lI
+lI
+qE
+qE
+uC
+vj
+ya
+qZ
+qZ
+qZ
+qZ
+qZ
+BS
+qZ
+qZ
+qE
+qE
+lI
+lI
+lI
+lI
+lI
+lI
+lI
+lI
+lI
+lI
+lI
+lI
 aa
 aa
 aa
@@ -19791,50 +19775,50 @@ aa
 aa
 aa
 aa
-la
-la
-la
-la
-la
-la
-la
-la
-la
-la
-la
-la
-la
-la
-la
-la
-pg
-pg
-sy
-uq
-tb
-pg
-px
-px
-px
-px
-px
-pg
-px
-sz
-px
-pg
-pg
-pg
-pg
-pg
-la
-la
-la
-la
-la
-la
-la
-la
+lI
+lI
+lI
+lI
+lI
+lI
+lI
+lI
+lI
+lI
+lI
+lI
+lI
+lI
+lI
+lI
+qE
+qE
+uD
+wM
+vj
+qE
+qZ
+qZ
+qZ
+qZ
+qZ
+qE
+qZ
+uE
+qZ
+qE
+qE
+qE
+qE
+qE
+lI
+lI
+lI
+lI
+lI
+lI
+lI
+lI
 aa
 aa
 aa
@@ -20048,50 +20032,50 @@ aa
 aa
 aa
 aa
-la
-la
-la
-la
-la
-la
-la
-la
-la
-la
-la
-la
-la
-la
-la
-pg
-pg
-tb
-tb
-tb
-tb
-pg
-vG
-wg
-px
-wg
-xu
-pg
-px
-px
-px
-pg
-zg
-zu
-zz
-pg
-pg
-rX
-pg
-la
-la
-la
-la
-la
+lI
+lI
+lI
+lI
+lI
+lI
+lI
+lI
+lI
+lI
+lI
+lI
+lI
+lI
+lI
+qE
+qE
+vj
+vj
+vj
+vj
+qE
+yC
+zo
+qZ
+zo
+Bf
+qE
+qZ
+qZ
+qZ
+qE
+DL
+DZ
+Eh
+qE
+qE
+tW
+qE
+lI
+lI
+lI
+lI
+lI
 aa
 aa
 aa
@@ -20305,50 +20289,50 @@ aa
 aa
 aa
 aa
-la
-la
-la
-la
-la
-la
-la
-la
-la
-la
-la
-la
-la
-la
-la
-pg
-sx
-tc
-tb
-tb
-KO
-pg
-pg
-wf
-wy
-wX
-pg
-pg
-La
-sz
-px
-yX
-zh
-zh
-zA
-zU
-px
-px
-pg
-la
-la
-la
-la
-la
+lI
+lI
+lI
+lI
+lI
+lI
+lI
+lI
+lI
+lI
+lI
+lI
+lI
+lI
+lI
+qE
+uC
+vk
+vj
+vj
+xu
+qE
+qE
+zn
+zM
+Ax
+qE
+qE
+Ci
+uE
+qZ
+DC
+DM
+DM
+Ei
+EC
+qZ
+qZ
+qE
+lI
+lI
+lI
+lI
+lI
 aa
 aa
 aa
@@ -20562,50 +20546,50 @@ aa
 aa
 aa
 aa
-la
-la
-la
-la
-la
-la
-la
-la
-la
-la
-la
-la
-pg
-pg
-pg
-pg
-sy
-tb
-tb
-tb
-uR
-pg
-vH
-px
-px
-px
+lI
+lI
+lI
+lI
+lI
+lI
+lI
+lI
+lI
+lI
+lI
+lI
+qE
+qE
+qE
+qE
+uD
+vj
+vj
+vj
 xv
-pg
-px
-px
-px
-pg
-zi
-zv
-zB
-pg
-pg
-zU
-pg
-pg
-pg
-la
-la
-la
+qE
+yD
+qZ
+qZ
+qZ
+Bg
+qE
+qZ
+qZ
+qZ
+qE
+DN
+Ea
+Ej
+qE
+qE
+EC
+qE
+qE
+qE
+lI
+lI
+lI
 aa
 aa
 aa
@@ -20819,50 +20803,50 @@ aa
 aa
 aa
 aa
-la
-la
-la
-la
-la
-la
-la
-la
-la
-la
-la
-pg
-pg
-Kv
-rb
-pg
-pg
-pg
-tO
-pg
-pg
-pg
-vI
-px
-px
-px
-KW
-pg
-px
-sz
-px
-pg
-pg
-pg
-pg
-pg
-px
-px
-Bj
-BG
-pg
-la
-la
-la
+lI
+lI
+lI
+lI
+lI
+lI
+lI
+lI
+lI
+lI
+lI
+qE
+qE
+rW
+sW
+qE
+qE
+qE
+wb
+qE
+qE
+qE
+yE
+qZ
+qZ
+qZ
+Bh
+qE
+qZ
+uE
+qZ
+qE
+qE
+qE
+qE
+qE
+qZ
+qZ
+FT
+Gr
+qE
+lI
+lI
+lI
 aa
 aa
 aa
@@ -21076,50 +21060,50 @@ aa
 aa
 aa
 aa
-la
-la
-la
-la
-la
-la
-la
-la
-la
-la
-la
-ph
-px
-px
-px
-rX
-px
-px
-px
-KM
-uS
-pg
-px
-px
-px
-px
-px
-rX
-px
-px
-px
-pg
-zj
-Lg
-zC
-pg
-An
-px
-px
-BG
-BO
-Cm
-la
-la
+lI
+lI
+lI
+lI
+lI
+lI
+lI
+lI
+lI
+lI
+lI
+qF
+qZ
+qZ
+qZ
+tW
+qZ
+qZ
+qZ
+wN
+xw
+qE
+qZ
+qZ
+qZ
+qZ
+qZ
+tW
+qZ
+qZ
+qZ
+qE
+DO
+Eb
+Ek
+qE
+EW
+qZ
+qZ
+Gr
+Gz
+GX
+lI
+lI
 aa
 aa
 aa
@@ -21333,51 +21317,51 @@ aa
 aa
 aa
 aa
-la
-la
-la
-la
-la
-la
-la
-la
-la
-la
-la
-pi
-py
-px
-px
-rY
-px
-px
-px
-px
-px
-vp
-px
-px
-wA
-wY
-px
-xS
-px
-sz
-px
-yY
-sz
-zw
-sz
-rX
-Ao
-px
-px
-BG
-BO
-Cm
-la
-la
-CU
+lI
+lI
+lI
+lI
+lI
+lI
+lI
+lI
+lI
+lI
+lI
+qG
+ra
+qZ
+qZ
+tX
+qZ
+qZ
+qZ
+qZ
+qZ
+yb
+qZ
+qZ
+zO
+Ay
+qZ
+BS
+qZ
+uE
+qZ
+DD
+uE
+Ec
+uE
+tW
+EX
+qZ
+qZ
+Gr
+Gz
+GX
+lI
+lI
+HG
 aa
 aa
 aa
@@ -21590,50 +21574,50 @@ aa
 aa
 aa
 aa
-la
-la
-la
-la
-la
-la
-la
-la
-la
-la
-la
-pj
-px
-px
-px
-rX
-px
-px
-px
-KN
-uT
-pg
-px
-px
-px
-px
-px
-rX
-px
-px
-px
-pg
-zk
-Lh
-zD
-pg
-An
-px
-px
-BG
-BO
-Cm
-la
-la
+lI
+lI
+lI
+lI
+lI
+lI
+lI
+lI
+lI
+lI
+lI
+qH
+qZ
+qZ
+qZ
+tW
+qZ
+qZ
+qZ
+wO
+xx
+qE
+qZ
+qZ
+qZ
+qZ
+qZ
+tW
+qZ
+qZ
+qZ
+qE
+DP
+Ed
+El
+qE
+EW
+qZ
+qZ
+Gr
+Gz
+GX
+lI
+lI
 aa
 aa
 aa
@@ -21847,50 +21831,50 @@ aa
 aa
 aa
 aa
-la
-la
-la
-la
-la
-la
-la
-la
-la
-la
-la
-pg
-pg
-Kw
-rc
-pg
-pg
-pg
-tP
-pg
-pg
-pg
-vJ
-px
-px
-px
-KW
-pg
-px
-sz
-px
-pg
-pg
-pg
-pg
-pg
-Ap
-px
-Bj
-BG
-pg
-la
-la
-la
+lI
+lI
+lI
+lI
+lI
+lI
+lI
+lI
+lI
+lI
+lI
+qE
+qE
+rX
+sX
+qE
+qE
+qE
+wc
+qE
+qE
+qE
+yF
+qZ
+qZ
+qZ
+Bh
+qE
+qZ
+uE
+qZ
+qE
+qE
+qE
+qE
+qE
+EY
+qZ
+FT
+Gr
+qE
+lI
+lI
+lI
 aa
 aa
 aa
@@ -22104,50 +22088,50 @@ aa
 aa
 aa
 aa
-la
-la
-la
-la
-la
-la
-la
-la
-la
-la
-la
-la
-pg
-pg
-pg
-pg
-sz
-td
-sz
-ur
-uU
-pg
-vK
-wh
-wB
-px
-px
-pg
-px
-px
-px
-pg
-zl
-zx
-zE
-pg
-pg
-rX
-pg
-pg
-pg
-la
-la
-la
+lI
+lI
+lI
+lI
+lI
+lI
+lI
+lI
+lI
+lI
+lI
+lI
+qE
+qE
+qE
+qE
+uE
+vl
+uE
+wP
+xy
+qE
+yG
+zp
+zP
+qZ
+qZ
+qE
+qZ
+qZ
+qZ
+qE
+DQ
+Ee
+Em
+qE
+qE
+tW
+qE
+qE
+qE
+lI
+lI
+lI
 aa
 aa
 aa
@@ -22361,50 +22345,50 @@ aa
 aa
 aa
 aa
-la
-la
-la
-la
-la
-la
-la
-la
-la
-la
-la
-la
-la
-la
-la
-pg
-sA
-te
-tQ
-sz
-uV
-pg
-pg
-wf
-wy
-wX
-pg
-pg
-La
-sz
-px
-yZ
-zm
-zm
-zF
-pg
-la
-la
-la
-la
-la
-la
-la
-la
+lI
+lI
+lI
+lI
+lI
+lI
+lI
+lI
+lI
+lI
+lI
+lI
+lI
+lI
+lI
+qE
+uF
+vm
+wd
+uE
+xz
+qE
+qE
+zn
+zM
+Ax
+qE
+qE
+Ci
+uE
+qZ
+DE
+DR
+DR
+En
+qE
+lI
+lI
+lI
+lI
+lI
+lI
+lI
+lI
 aa
 aa
 aa
@@ -22618,50 +22602,50 @@ aa
 aa
 aa
 aa
-la
-la
-la
-la
-la
-la
-la
-la
-la
-la
-la
-la
-la
-la
-la
-pg
-pg
-tf
-sz
-td
-sz
-ph
-vL
-vO
-wC
-wZ
-vO
-ph
-px
-px
-px
-pg
-zn
-Li
-zG
-pg
-la
-la
-la
-la
-la
-la
-la
-la
+lI
+lI
+lI
+lI
+lI
+lI
+lI
+lI
+lI
+lI
+lI
+lI
+lI
+lI
+lI
+qE
+qE
+vn
+uE
+vl
+uE
+qF
+yH
+yK
+zQ
+Az
+yK
+qF
+qZ
+qZ
+qZ
+qE
+DS
+Ef
+Eo
+qE
+lI
+lI
+lI
+lI
+lI
+lI
+lI
+lI
 aa
 aa
 aa
@@ -22875,50 +22859,50 @@ aa
 aa
 aa
 aa
-la
-la
-la
-la
-la
-la
-la
-la
-la
-la
-la
-la
-la
-la
-la
-la
-pg
-pg
-sA
-us
-tQ
-pi
-vM
-wi
-vM
-xa
-vM
-pi
-px
-sz
-px
-pg
-pg
-pg
-pg
-pg
-la
-la
-la
-la
-la
-la
-la
-la
+lI
+lI
+lI
+lI
+lI
+lI
+lI
+lI
+lI
+lI
+lI
+lI
+lI
+lI
+lI
+lI
+qE
+qE
+uF
+wQ
+wd
+qG
+yI
+zq
+yI
+AA
+yI
+qG
+qZ
+uE
+qZ
+qE
+qE
+qE
+qE
+qE
+lI
+lI
+lI
+lI
+lI
+lI
+lI
+lI
 aa
 aa
 aa
@@ -23132,50 +23116,50 @@ aa
 aa
 aa
 aa
-la
-la
-la
-la
-la
-la
-la
-la
-la
-la
-la
-la
-la
-la
-la
-la
-la
-pg
-pg
-tf
-sz
-pj
-vN
-wj
-vO
-wi
-vO
-pj
-px
-px
-pg
-pg
-la
-la
-la
-la
-la
-la
-la
-la
-la
-la
-la
-la
+lI
+lI
+lI
+lI
+lI
+lI
+lI
+lI
+lI
+lI
+lI
+lI
+lI
+lI
+lI
+lI
+lI
+qE
+qE
+vn
+uE
+qH
+yJ
+zr
+yK
+zq
+yK
+qH
+qZ
+qZ
+qE
+qE
+lI
+lI
+lI
+lI
+lI
+lI
+lI
+lI
+lI
+lI
+lI
+lI
 aa
 aa
 aa
@@ -23389,50 +23373,50 @@ aa
 aa
 aa
 aa
-la
-la
-la
-la
-la
-la
-la
-la
-la
-la
-la
-la
-la
-la
-la
-la
-la
-la
-pg
-pg
-pg
-pg
-vO
-wi
-vM
-xb
-xw
-pg
-wf
-wX
-pg
-la
-la
-la
-la
-la
-la
-la
-la
-la
-la
-la
-la
-la
+lI
+lI
+lI
+lI
+lI
+lI
+lI
+lI
+lI
+lI
+lI
+lI
+lI
+lI
+lI
+lI
+lI
+lI
+qE
+qE
+qE
+qE
+yK
+zq
+yI
+AB
+Bi
+qE
+zn
+Ax
+qE
+lI
+lI
+lI
+lI
+lI
+lI
+lI
+lI
+lI
+lI
+lI
+lI
+lI
 aa
 aa
 aa
@@ -23646,50 +23630,50 @@ aa
 aa
 aa
 aa
-la
-la
-la
-la
-la
-la
-la
-la
-la
-la
-la
-la
-la
-la
-la
-la
-la
-la
-la
-la
-la
-pg
-pg
-pg
-pg
-pg
-pg
-pg
-la
-la
-la
-la
-la
-la
-la
-la
-la
-la
-la
-la
-la
-la
-la
-la
+lI
+lI
+lI
+lI
+lI
+lI
+lI
+lI
+lI
+lI
+lI
+lI
+lI
+lI
+lI
+lI
+lI
+lI
+lI
+lI
+lI
+qE
+qE
+qE
+qE
+qE
+qE
+qE
+lI
+lI
+lI
+lI
+lI
+lI
+lI
+lI
+lI
+lI
+lI
+lI
+lI
+lI
+lI
+lI
 aa
 aa
 aa
@@ -23903,50 +23887,50 @@ aa
 aa
 aa
 aa
-la
-la
-la
-la
-la
-la
-la
-la
-la
-la
-la
-la
-la
-la
-la
-la
-la
-la
-la
-la
-la
-la
-la
-la
-la
-la
-la
-la
-la
-la
-la
-la
-la
-la
-la
-la
-la
-la
-la
-la
-la
-la
-la
-la
+lI
+lI
+lI
+lI
+lI
+lI
+lI
+lI
+lI
+lI
+lI
+lI
+lI
+lI
+lI
+lI
+lI
+lI
+lI
+lI
+lI
+lI
+lI
+lI
+lI
+lI
+lI
+lI
+lI
+lI
+lI
+lI
+lI
+lI
+lI
+lI
+lI
+lI
+lI
+lI
+lI
+lI
+lI
+lI
 aa
 aa
 aa
@@ -24160,50 +24144,50 @@ aa
 aa
 aa
 aa
-la
-la
-la
-la
-la
-la
-la
-la
-la
-la
-la
-la
-la
-la
-la
-la
-la
-la
-la
-la
-la
-la
-la
-la
-la
-la
-la
-la
-la
-la
-la
-la
-la
-la
-la
-la
-la
-la
-la
-la
-la
-la
-la
-la
+lI
+lI
+lI
+lI
+lI
+lI
+lI
+lI
+lI
+lI
+lI
+lI
+lI
+lI
+lI
+lI
+lI
+lI
+lI
+lI
+lI
+lI
+lI
+lI
+lI
+lI
+lI
+lI
+lI
+lI
+lI
+lI
+lI
+lI
+lI
+lI
+lI
+lI
+lI
+lI
+lI
+lI
+lI
+lI
 aa
 aa
 aa
@@ -24359,108 +24343,108 @@ aa
 aa
 aa
 aa
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
+hh
+hh
+hh
+hh
+hh
+hh
+hh
+hh
+hh
+hh
+hh
+hh
+hh
+hh
+hh
+hh
+hh
+hh
+hh
+hh
+hh
+hh
+hh
+hh
+hh
+hh
+hh
+hh
+hh
+hh
+hh
+hh
+hh
+hh
+hh
+hh
+hh
+hh
+hh
+hh
+hh
+hh
+hh
+hh
+hh
+hh
+hh
+hh
+hh
+hh
+hh
+hh
+hh
+hh
+hh
+hh
+hh
 aa
-la
-la
-la
-la
-la
-la
-la
-la
-la
-la
-la
-la
-la
-la
-la
-la
-la
-la
-la
-la
-la
-la
-la
-la
-la
-la
-la
-la
-la
-la
-la
-la
-la
-la
-la
-la
-la
-la
-la
-la
-la
-la
-la
-la
+lI
+lI
+lI
+lI
+lI
+lI
+lI
+lI
+lI
+lI
+lI
+lI
+lI
+lI
+lI
+lI
+lI
+lI
+lI
+lI
+lI
+lI
+lI
+lI
+lI
+lI
+lI
+lI
+lI
+lI
+lI
+lI
+lI
+lI
+lI
+lI
+lI
+lI
+lI
+lI
+lI
+lI
+lI
+lI
 aa
 aa
 aa
@@ -24616,108 +24600,108 @@ aa
 aa
 aa
 aa
-hm
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hm
+hh
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hh
 aa
-la
-la
-la
-la
-la
-la
-la
-la
-la
-la
-la
-la
-la
-la
-la
-la
-la
-la
-la
-la
-la
-la
-la
-la
-la
-la
-la
-la
-la
-la
-la
-la
-la
-la
-la
-la
-la
-la
-la
-la
-la
-la
-la
-la
+lI
+lI
+lI
+lI
+lI
+lI
+lI
+lI
+lI
+lI
+lI
+lI
+lI
+lI
+lI
+lI
+lI
+lI
+lI
+lI
+lI
+lI
+lI
+lI
+lI
+lI
+lI
+lI
+lI
+lI
+lI
+lI
+lI
+lI
+lI
+lI
+lI
+lI
+lI
+lI
+lI
+lI
+lI
+lI
 aa
 aa
 aa
@@ -24873,108 +24857,108 @@ aa
 aa
 aa
 aa
-hm
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hm
+hh
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hh
 aa
-la
-la
-la
-la
-la
-la
-la
-la
-la
-la
-la
-la
-la
-la
-la
-la
-la
-la
-la
-la
-la
-la
-la
-la
-la
-la
-la
-la
-la
-la
-la
-la
-la
-la
-la
-la
-la
-la
-la
-la
-la
-la
-la
-la
+lI
+lI
+lI
+lI
+lI
+lI
+lI
+lI
+lI
+lI
+lI
+lI
+lI
+lI
+lI
+lI
+lI
+lI
+lI
+lI
+lI
+lI
+lI
+lI
+lI
+lI
+lI
+lI
+lI
+lI
+lI
+lI
+lI
+lI
+lI
+lI
+lI
+lI
+lI
+lI
+lI
+lI
+lI
+lI
 aa
 aa
 aa
@@ -25130,108 +25114,108 @@ aa
 aa
 aa
 aa
-hm
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hm
+hh
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hh
 aa
-la
-la
-la
-la
-la
-la
-la
-la
-la
-la
-la
-la
-la
-la
-la
-la
-la
-la
-la
-la
-la
-la
-la
-la
-la
-la
-la
-la
-la
-la
-la
-la
-la
-la
-la
-la
-la
-la
-la
-la
-la
-la
-la
-la
+lI
+lI
+lI
+lI
+lI
+lI
+lI
+lI
+lI
+lI
+lI
+lI
+lI
+lI
+lI
+lI
+lI
+lI
+lI
+lI
+lI
+lI
+lI
+lI
+lI
+lI
+lI
+lI
+lI
+lI
+lI
+lI
+lI
+lI
+lI
+lI
+lI
+lI
+lI
+lI
+lI
+lI
+lI
+lI
 aa
 aa
 aa
@@ -25387,63 +25371,63 @@ aa
 aa
 aa
 aa
-hm
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hm
+hh
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hh
 aa
 aa
 aa
@@ -25644,63 +25628,63 @@ aa
 aa
 aa
 aa
-hm
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hm
+hh
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hh
 aa
 aa
 aa
@@ -25901,63 +25885,63 @@ aa
 aa
 aa
 aa
-hm
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hm
+hh
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hh
 aa
 aa
 aa
@@ -26158,63 +26142,63 @@ aa
 aa
 aa
 aa
-hm
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hm
+hh
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hh
 aa
 aa
 aa
@@ -26415,97 +26399,97 @@ aa
 aa
 aa
 aa
-hm
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
+hh
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hh
+hh
+hh
+hh
+hh
+hh
+hh
+hh
+hh
+hh
+hh
+hh
+hh
+hh
+hh
+hh
+hh
+hh
+hh
+hh
+hh
+hh
+hh
+hh
+hh
+hh
+hh
+hh
+hh
+hh
+hh
+hh
+hh
+hh
+hh
 aa
 aa
 aa
@@ -26672,97 +26656,97 @@ aa
 aa
 aa
 aa
-hm
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-tR
-hq
-Kl
-Kl
-Kl
-Kl
-Kl
-Kl
-Kl
-Kl
-Kl
-Kl
-Kl
-Kl
-hm
+hh
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+we
+hl
+kt
+kt
+kt
+kt
+kt
+kt
+kt
+kt
+kt
+kt
+kt
+kt
+hh
 aa
 aa
 aa
@@ -26929,97 +26913,97 @@ aa
 aa
 aa
 aa
-hm
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-Kl
-Kl
-Kl
-hq
-hq
-hq
-hq
-SC
-XJ
-XJ
-XJ
-XJ
-XJ
-XJ
-XJ
-XJ
-XJ
-Kl
-hm
+hh
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+kt
+kt
+kt
+hl
+hl
+hl
+hl
+yc
+yd
+yd
+yd
+yd
+yd
+yd
+yd
+yd
+yd
+kt
+hh
 aa
 aa
 aa
@@ -27186,97 +27170,97 @@ aa
 aa
 aa
 aa
-hm
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-Ym
-Ou
-Ou
-Ou
-Ou
-Ou
-XJ
-Jg
-Jk
-Jg
-Jm
-VO
-Zi
-Yz
-Ic
-Rx
-Kl
-hm
+hh
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+tY
+tZ
+tZ
+tZ
+tZ
+tZ
+yd
+yL
+zs
+yL
+AC
+Bj
+BT
+Cj
+CS
+Di
+kt
+hh
 aa
 aa
 aa
@@ -27443,97 +27427,97 @@ aa
 aa
 aa
 aa
-hm
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-Kl
-Ou
-Qr
-Tg
-Tg
-Tg
-JC
-XJ
-RT
-Ze
-WM
-WM
-Qt
-WM
-IZ
-Ic
-Oz
-Kl
-hm
+hh
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+kt
+tZ
+uG
+vo
+vo
+vo
+xA
+yd
+yM
+zt
+zR
+zR
+Bk
+zR
+Ck
+CS
+Dj
+kt
+hh
 aa
 aa
 aa
@@ -27700,97 +27684,97 @@ aa
 aa
 aa
 aa
-hm
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-lF
-hq
-hq
-Kl
-Kl
-hq
-hq
-hq
-hq
-hq
-hq
-Kl
-Ou
-XU
-XU
-XU
-XU
-XU
-Tt
-Qm
-Ze
-KE
-Ki
-TO
-fH
-Id
-Ic
-Wz
-Kl
-hm
+hh
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+my
+hl
+hl
+kt
+kt
+hl
+hl
+hl
+hl
+hl
+hl
+kt
+tZ
+uH
+uH
+uH
+uH
+uH
+ye
+yN
+zt
+zS
+AD
+Bl
+BU
+Cl
+CS
+Dk
+kt
+hh
 aa
 aa
 aa
@@ -27957,97 +27941,97 @@ aa
 aa
 aa
 aa
-hm
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-Kl
-hq
-Pv
-Us
-Us
-Us
-Us
-hq
-hq
-Ou
-XU
-XU
-XU
-XU
-XU
-XJ
-Yw
-Ze
-tg
-YX
-Rg
-ZS
-XJ
-XJ
-ZY
-Kl
-hm
+hh
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+kt
+hl
+oS
+oT
+oT
+oT
+oT
+hl
+hl
+tZ
+uH
+uH
+uH
+uH
+uH
+yd
+yO
+zt
+zT
+AE
+Bm
+yf
+yd
+yd
+Dl
+kt
+hh
 aa
 aa
 aa
@@ -28214,97 +28198,97 @@ aa
 aa
 aa
 aa
-hm
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-Kl
-hq
-Us
-Vo
-NH
-Wr
-Us
-Sg
-hq
-Ou
-Pa
-QB
-KS
-Sx
-Uv
-XJ
-HW
-Ze
-tg
-YX
-SD
-XJ
-hq
-hq
-Kl
-Kl
-hm
+hh
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+kt
+hl
+oT
+px
+pR
+qI
+oT
+rY
+hl
+tZ
+uI
+vp
+wf
+wR
+xB
+yd
+yP
+zt
+zT
+AE
+Bn
+yd
+hl
+hl
+kt
+kt
+hh
 aa
 aa
 aa
@@ -28471,97 +28455,97 @@ aa
 aa
 aa
 aa
-hm
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-mz
-hq
-Kl
-hq
-Pd
-Is
-Lf
-Wr
-Us
-Nk
-Nk
-Ou
-Ou
-Ou
-Ou
-NJ
-Tl
-ZS
-QP
-QP
-pk
-Nc
-XJ
-XJ
-Nk
-Nk
-hq
-hq
-hm
+hh
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+nx
+hl
+kt
+hl
+oU
+py
+pS
+qI
+oT
+rZ
+rZ
+tZ
+tZ
+tZ
+tZ
+wS
+xC
+yf
+yQ
+yQ
+zU
+yQ
+yd
+yd
+rZ
+rZ
+hl
+hl
+hh
 aa
 aa
 aa
@@ -28728,97 +28712,97 @@ aa
 aa
 aa
 aa
-hm
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-Kl
-hq
-Pd
-TY
-So
-Wr
-Tm
-OT
-XN
-Ru
-XN
-XN
-Ur
-Pt
-Pt
-Pt
-Pt
-RF
-NV
-RD
-TT
-XL
-de
-Jn
-hq
-hq
-hm
+hh
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+kt
+hl
+oU
+pz
+pT
+qI
+rb
+sa
+sY
+ua
+sY
+sY
+wg
+sb
+sb
+sb
+sb
+zu
+zV
+AF
+Bo
+BV
+Cm
+CT
+hl
+hl
+hh
 aa
 aa
 aa
@@ -28985,97 +28969,97 @@ aa
 aa
 aa
 aa
-hm
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-lF
-hq
-hq
-hq
-Kl
-hq
-Pd
-Yo
-Sr
-Wr
-UI
-Pt
-Ux
-Ux
-Ux
-Pt
-RK
-Pt
-Ux
-Ux
-Ux
-Ux
-NV
-RD
-TT
-Ns
-de
-WK
-hq
-hq
-hm
+hh
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+my
+hl
+hl
+hl
+kt
+hl
+oU
+pA
+pU
+qI
+rc
+sb
+sZ
+sZ
+sZ
+sb
+wh
+sb
+sZ
+sZ
+sZ
+sZ
+zV
+AF
+Bo
+BW
+Cm
+CU
+hl
+hl
+hh
 aa
 aa
 aa
@@ -29242,97 +29226,97 @@ aa
 aa
 aa
 aa
-hm
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-Kl
-hq
-Pd
-fC
-So
-Wr
-Us
-Yk
-Om
-TW
-Om
-Om
-Ur
-Pt
-Pt
-Pt
-Pt
-WW
-NV
-RD
-TT
-XL
-de
-Mz
-hq
-hq
-hm
+hh
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+kt
+hl
+oU
+pB
+pT
+qI
+oT
+sc
+ta
+ub
+ta
+ta
+wg
+sb
+sb
+sb
+sb
+zv
+zV
+AF
+Bo
+BV
+Cm
+CV
+hl
+hl
+hh
 aa
 aa
 aa
@@ -29499,97 +29483,97 @@ aa
 aa
 aa
 aa
-hm
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-Kl
-hq
-Pd
-Um
-TD
-Wr
-Us
-Nk
-Nk
-Jh
-Nk
-Wk
-Wk
-Qo
-Mk
-Se
-Wd
-Wd
-ZM
-ZE
-Jz
-Jz
-Nk
-Nk
-hq
-hq
-hm
+hh
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+kt
+hl
+oU
+pC
+pV
+qI
+oT
+rZ
+rZ
+uc
+rZ
+vq
+vq
+wT
+xD
+yg
+yR
+yR
+zW
+yR
+yh
+yh
+rZ
+rZ
+hl
+hl
+hh
 aa
 aa
 aa
@@ -29756,97 +29740,97 @@ aa
 aa
 aa
 aa
-hm
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-Kl
-hq
-Us
-SA
-Yl
-Wr
-Us
-Uq
-rd
-mg
-mA
-Wk
-MI
-ZL
-UR
-Jz
-YY
-KA
-Ve
-RS
-Wj
-Jz
-hq
-hq
-Kl
-Kl
-hm
+hh
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+kt
+hl
+oT
+pD
+pW
+qI
+oT
+sd
+tb
+ng
+nz
+vq
+wi
+wU
+xE
+yh
+yS
+zw
+zX
+AG
+Bp
+yh
+hl
+hl
+kt
+kt
+hh
 aa
 aa
 aa
@@ -30013,97 +29997,97 @@ aa
 aa
 aa
 aa
-hm
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-lG
-hq
-lF
-hq
-Kl
-hq
-YS
-Us
-Us
-Us
-Us
-hq
-re
-kI
-sB
-MZ
-XW
-ZL
-UR
-Jz
-We
-KA
-Ve
-RS
-RJ
-Se
-Jz
-Jz
-Su
-Kl
-hm
+hh
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+mz
+hl
+my
+hl
+kt
+hl
+oV
+oT
+oT
+oT
+oT
+hl
+tc
+ll
+uJ
+vr
+wj
+wU
+xE
+yh
+yT
+zw
+zX
+AG
+Bq
+yg
+yh
+yh
+Dm
+kt
+hh
 aa
 aa
 aa
@@ -30270,97 +30254,97 @@ aa
 aa
 aa
 aa
-hm
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-ln
-hq
-hq
-hq
-Kl
-Kl
-Kl
-Kl
-Kl
-Kl
-Kl
-Kl
-re
-kI
-sC
-RR
-WX
-ZL
-qW
-JK
-Vv
-KA
-Js
-Rj
-TC
-ID
-Os
-Jb
-UW
-Kl
-hm
+hh
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+mA
+hl
+hl
+hl
+kt
+kt
+kt
+kt
+kt
+kt
+kt
+kt
+tc
+ll
+uK
+vs
+wk
+wU
+xF
+yi
+yU
+zw
+zY
+AH
+Br
+zZ
+Cn
+CW
+Dn
+kt
+hh
 aa
 aa
 aa
@@ -30527,97 +30511,97 @@ aa
 aa
 aa
 aa
-hm
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-lF
-hq
-hq
-hq
-hq
-mz
-hq
-Kl
-re
-kI
-re
-Vy
-Wk
-Wk
-Wk
-Jz
-Ly
-KA
-ID
-ID
-NQ
-ID
-LG
-Jb
-YF
-Kl
-hm
+hh
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+my
+hl
+hl
+hl
+hl
+nx
+hl
+kt
+tc
+ll
+tc
+vt
+vq
+vq
+vq
+yh
+yV
+zw
+zZ
+zZ
+Bs
+zZ
+Co
+CW
+Do
+kt
+hh
 aa
 aa
 aa
@@ -30784,97 +30768,97 @@ aa
 aa
 aa
 aa
-hm
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-Kl
-Kl
-Kl
-Kl
-Kl
-hq
-lG
-ln
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-Kl
-re
-kI
-re
-hq
-hq
-hq
-Wk
-Jz
-Vk
-KA
-OQ
-Sb
-OS
-WY
-Os
-Jb
-Pm
-Kl
-hm
+hh
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+kt
+kt
+kt
+kt
+kt
+hl
+mz
+mA
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+kt
+tc
+ll
+tc
+hl
+hl
+hl
+vq
+yh
+yW
+zw
+Aa
+AI
+Bt
+BX
+Cn
+CW
+Dp
+kt
+hh
 aa
 aa
 aa
@@ -31041,97 +31025,97 @@ aa
 aa
 aa
 aa
-hm
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-kl
-kl
-kl
-kl
-Kl
-hq
-hq
-hq
-lG
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-Kl
-re
-kI
-re
-hq
-hq
-hq
-hq
-UK
-Jz
-Jz
-Jz
-Jz
-Jz
-Jz
-Jz
-Jz
-Jz
-Kl
-hm
+hh
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+ku
+ku
+ku
+ku
+kt
+hl
+hl
+hl
+mz
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+kt
+tc
+ll
+tc
+hl
+hl
+hl
+hl
+yj
+yh
+yh
+yh
+yh
+yh
+yh
+yh
+yh
+yh
+kt
+hh
 aa
 aa
 aa
@@ -31298,97 +31282,97 @@ aa
 aa
 aa
 aa
-hm
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-km
+hh
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+kv
+kR
+ll
 ku
-kI
-kl
-Kl
-hq
-hq
-hq
-hq
-hq
-ln
-hq
-Kl
-Kl
-Kl
-Lx
-Kl
-rf
-kI
-rf
-Kl
-Lx
-Kl
-Kl
-Kl
-Kl
-Kl
-Kl
-Kl
-Kl
-Kl
-Kl
-Kl
-Kl
-Kl
-hm
+kt
+hl
+hl
+hl
+hl
+hl
+mA
+hl
+kt
+kt
+kt
+rd
+kt
+td
+ll
+td
+kt
+rd
+kt
+kt
+kt
+kt
+kt
+kt
+kt
+kt
+kt
+kt
+kt
+kt
+kt
+hh
 aa
 aa
 aa
@@ -31555,97 +31539,97 @@ aa
 aa
 aa
 aa
-hm
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-km
+hh
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+kv
+kR
+ll
 ku
-kI
-kl
-Kl
-hq
-hq
-lG
-hq
-hq
-hq
-Kl
-Kl
-kl
-kl
-kl
-kl
-kl
-rZ
-kl
-kl
-kl
-kl
-Kl
-Kl
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hm
+kt
+hl
+hl
+mz
+hl
+hl
+hl
+kt
+kt
+ku
+ku
+ku
+ku
+ku
+ud
+ku
+ku
+ku
+ku
+kt
+kt
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hh
 aa
 aa
 aa
@@ -31812,97 +31796,97 @@ aa
 aa
 aa
 aa
-hm
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-km
+hh
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+kv
+kR
+ll
 ku
-kI
-kl
-Kl
-lG
-hq
-hq
-lF
-hq
-hq
-Lw
-kl
-kl
-pl
-pz
-JI
-oJ
-oJ
-sD
-th
-JL
-kl
-kl
-Kl
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hm
+kt
+mz
+hl
+hl
+my
+hl
+hl
+oW
+ku
+ku
+qJ
+re
+se
+pZ
+pZ
+uL
+vu
+wl
+ku
+ku
+kt
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hh
 aa
 aa
 aa
@@ -32069,97 +32053,97 @@ aa
 aa
 aa
 aa
-hm
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-jX
-km
+hh
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+ki
+kv
+kR
+lm
 ku
-JE
-kl
-Kl
-hq
-hq
-hq
-hq
-hq
-hq
-Kl
-kl
-oH
-oJ
-oJ
-pA
-pA
-oJ
-pA
-ti
-tT
-qq
-kl
-Kl
-lF
+kt
+hl
+hl
+hl
+hl
+hl
+hl
+kt
+ku
+pX
+pZ
+pZ
+rf
+rf
+pZ
+rf
+vv
+wm
+si
+ku
+kt
+my
+nx
+hl
 mz
-hq
-lG
-hq
-hq
-mh
-hq
-hq
-hq
-hm
+hl
+hl
+BY
+hl
+hl
+hl
+hh
 aa
 aa
 aa
@@ -32326,97 +32310,97 @@ aa
 aa
 aa
 aa
-hm
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-km
+hh
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+kv
+kR
+ll
 ku
-kI
-kl
-Kl
-Kl
-Kl
-Kl
-Kl
-Kl
-Kl
-Kl
-ol
-oI
-oJ
-pA
-qn
-rg
-oJ
-pA
-tj
-tS
-ut
-kl
-Kl
-hq
-lG
-hq
-hq
-hq
-mh
-yc
-mh
-hq
-hq
-hm
+kt
+kt
+kt
+kt
+kt
+kt
+kt
+kt
+pE
+pY
+pZ
+rf
+sf
+te
+pZ
+rf
+vw
+wn
+wV
+ku
+kt
+hl
+mz
+hl
+hl
+hl
+BY
+Cp
+BY
+hl
+hl
+hh
 aa
 aa
 aa
@@ -32583,97 +32567,97 @@ aa
 aa
 aa
 aa
-hm
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-km
+hh
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+kv
+kR
+ll
 ku
-kI
-kl
-kl
-kl
-kl
-kl
-kl
-kl
-kl
-kl
-kl
-oJ
-oJ
-pA
-qo
-rh
-oJ
-pA
-ti
-tS
-uu
-kl
-Lw
-hq
-lF
-lG
+ku
+ku
+ku
+ku
+ku
+ku
+ku
+ku
+ku
+pZ
+pZ
+rf
+sg
+tf
+pZ
+rf
+vv
+wn
+wW
+ku
+oW
+hl
+my
 mz
-hq
-hq
-mh
-hq
-hq
-hq
-hm
+nx
+hl
+hl
+BY
+hl
+hl
+hl
+hh
 aa
 aa
 aa
@@ -32840,97 +32824,97 @@ aa
 aa
 aa
 aa
-hm
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-km
+hh
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+kv
+kR
+ll
+ll
+ll
+ll
+ll
+ny
+ll
+ll
+ll
+ll
+pF
+qa
+pZ
+rg
+rf
+rf
+pZ
+pZ
+vx
+wo
+wX
 ku
-kI
-kI
-kI
-kI
-kI
-JG
-kI
-kI
-kI
-kI
-om
-JH
-oJ
-pB
-pA
-pA
-oJ
-oJ
-tk
-tU
-uv
-kl
-Kl
-Kj
-Lw
-Kl
-Kl
-hq
-hq
-hq
-hq
-hq
-hq
-hm
+kt
+ma
+oW
+kt
+kt
+hl
+hl
+hl
+hl
+hl
+hl
+hh
 aa
 aa
 aa
@@ -33097,97 +33081,97 @@ aa
 aa
 aa
 aa
-hm
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-km
+hh
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+kv
+kR
+ll
 ku
-kI
-kl
-kl
-lH
-mg
-mA
-kl
-kl
-kl
-kl
-kl
-kl
-pm
-oJ
-oJ
-oJ
-oJ
-oJ
-oJ
-oJ
-kl
-kl
-kl
-ol
-kl
-kl
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
+ku
+mB
+ng
+nz
+ku
+ku
+ku
+ku
+ku
+ku
+qK
+pZ
+pZ
+pZ
+pZ
+pZ
+pZ
+pZ
+ku
+ku
+ku
+pE
+ku
+ku
+hh
+hh
+hh
+hh
+hh
+hh
+hh
+hh
 aa
 aa
 aa
@@ -33354,89 +33338,89 @@ aa
 aa
 aa
 aa
-hm
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-km
+hh
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+kv
+kR
+ll
 ku
-kI
-kl
-Kl
-lI
-Kg
-Kj
-Kl
-Kj
-Kj
-Kl
-Kl
-kl
-pn
-oJ
-qp
-qp
-qp
-qp
-oJ
-oJ
-uw
-uW
-uW
-uW
-wk
-kl
+kt
+mC
+nh
+ma
+kt
+ma
+ma
+kt
+kt
+ku
+qL
+pZ
+sh
+sh
+sh
+sh
+pZ
+pZ
+wY
+xG
+xG
+xG
+zx
+ku
 aa
 aa
 aa
@@ -33611,89 +33595,89 @@ aa
 aa
 aa
 aa
-hm
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-km
+hh
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+kv
+kR
+lm
 ku
-JE
-kl
-Kl
-lG
-hq
-hq
-lG
-hq
-hq
-lG
-Kj
-kl
-po
-oJ
-qq
-ri
-ri
-sE
-oJ
-JM
-kl
-uW
-uW
-uW
-wk
-kl
+kt
+mz
+hl
+hl
+mz
+hl
+hl
+mz
+ma
+ku
+qM
+pZ
+si
+tg
+tg
+uM
+pZ
+wp
+ku
+xG
+xG
+xG
+zx
+ku
 aa
 aa
 aa
@@ -33868,89 +33852,89 @@ aa
 aa
 aa
 aa
-hm
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-km
+hh
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+kv
+kR
+ll
 ku
-kI
-kl
-Kl
-hq
-hq
-lG
-hq
-lG
-hq
-hq
-Ko
-kl
-kl
-pC
-kl
-kl
-kl
-sC
-sB
-sC
-kl
-uX
-uW
-uW
-wk
-kl
+kt
+hl
+hl
+mz
+hl
+mz
+hl
+hl
+pG
+ku
+ku
+rh
+ku
+ku
+ku
+uK
+uJ
+uK
+ku
+xH
+xG
+xG
+zx
+ku
 aa
 aa
 aa
@@ -34125,89 +34109,89 @@ aa
 aa
 aa
 aa
-hm
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-km
+hh
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+kv
+kR
+ll
 ku
-kI
-kl
-Kl
-hq
-lG
-hq
-ln
-hq
-hq
-lG
-Kl
-kl
-pp
-pD
-pD
-kl
-kl
-re
-kI
-re
-kl
-uY
-uW
-uW
-wk
-kl
+kt
+hl
+mz
+hl
+mA
+hl
+hl
+mz
+kt
+ku
+qN
+ri
+ri
+ku
+ku
+tc
+ll
+tc
+ku
+xI
+xG
+xG
+zx
+ku
 aa
 aa
 aa
@@ -34382,89 +34366,89 @@ aa
 aa
 aa
 aa
-hm
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-km
+hh
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+kv
+kR
+ll
 ku
-kI
-kl
-Kj
-hq
-hq
-hq
-lG
-hq
-hq
-lG
-Kj
-kl
-pq
-pD
-qr
-kl
-kl
-re
-kI
-re
-kl
-uZ
-uW
-uW
-wk
-kl
+ma
+hl
+hl
+hl
+mz
+hl
+hl
+mz
+ma
+ku
+qO
+ri
+sj
+ku
+ku
+tc
+ll
+tc
+ku
+xJ
+xG
+xG
+zx
+ku
 aa
 aa
 aa
@@ -34639,89 +34623,89 @@ aa
 aa
 aa
 aa
-hm
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-kl
-kl
-kl
-kl
-Kl
-hq
-lG
-ln
-hq
-hq
-ln
-hq
-Ko
-ol
-pr
+hh
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+ku
+ku
+ku
+ku
+kt
+hl
+mz
+mA
+hl
+hl
+mA
+hl
+pG
 pE
-kl
-kl
-kl
-re
-kI
-re
-kl
-va
-uW
-vP
-wl
-kl
+qP
+rj
+ku
+ku
+ku
+tc
+ll
+tc
+ku
+xK
+xG
+yX
+zy
+ku
 aa
 aa
 aa
@@ -34896,89 +34880,89 @@ aa
 aa
 aa
 aa
-hm
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-Kl
-Kl
-Kl
-Kl
-Kl
-hq
-hq
-hq
-ln
-lG
-hq
-ln
-Kl
-kl
-kl
-kl
-kl
-kl
-kl
-re
-kI
-re
-kl
-kl
-kl
-kl
-kl
-kl
+hh
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+kt
+kt
+kt
+kt
+kt
+hl
+hl
+hl
+mA
+mz
+hl
+mA
+kt
+ku
+ku
+ku
+ku
+ku
+ku
+tc
+ll
+tc
+ku
+ku
+ku
+ku
+ku
+ku
 aa
 aa
 aa
@@ -35153,87 +35137,87 @@ aa
 aa
 aa
 aa
-hm
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-lG
-hq
-hq
-hq
-lG
-Kj
-hm
+hh
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+mz
+hl
+hl
+hl
+mz
+ma
+hh
 aa
-kl
-qs
-qs
-qs
-re
-kI
-re
-qs
-qs
-qs
-kl
+ku
+sk
+sk
+sk
+tc
+ll
+tc
+sk
+sk
+sk
+ku
 aa
 aa
 aa
@@ -35410,87 +35394,87 @@ aa
 aa
 aa
 aa
-hm
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-lG
-hq
-ln
-hq
-hm
+hh
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+mz
+hl
+mA
+hl
+hh
 aa
-kl
-qs
-rj
-sa
-re
-sB
-re
-sa
-vb
-qs
-kl
+ku
+sk
+th
+ue
+tc
+uJ
+tc
+ue
+xL
+sk
+ku
 aa
 aa
 aa
@@ -35667,87 +35651,87 @@ aa
 aa
 aa
 aa
-hm
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-ln
-hq
-hq
-ln
-hq
-lG
-hm
+hh
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+mA
+hl
+hl
+mA
+hl
+mz
+hh
 aa
-kl
-QT
-rk
-rl
-rm
-tl
-rm
-ux
-vc
-QY
-kl
+ku
+sl
+ti
+tj
+tk
+vy
+tk
+wZ
+xM
+yk
+ku
 aa
 aa
 aa
@@ -35924,87 +35908,87 @@ aa
 aa
 aa
 aa
-hm
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-lG
-hq
-hq
-hq
-hm
+hh
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+mz
+hl
+hl
+hl
+hh
 aa
-kl
-qt
-rl
-rm
-sb
-sc
-sb
-rm
-ux
-vq
-kl
+ku
+sm
+tj
+tk
+uf
+ug
+uf
+tk
+wZ
+yl
+ku
 aa
 aa
 aa
@@ -36181,87 +36165,87 @@ aa
 aa
 aa
 aa
-hm
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hm
+hh
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hh
 aa
-kl
-JJ
-rm
-sb
-sc
-sd
-sc
-sb
-rm
-JN
-kl
+ku
+sn
+tk
+uf
+ug
+uh
+ug
+uf
+tk
+ym
+ku
 aa
 aa
 aa
@@ -36438,87 +36422,87 @@ aa
 aa
 aa
 aa
-hm
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hm
+hh
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hh
 aa
-kl
-qt
-rn
-sc
-sF
-tm
-tV
-sc
-vd
-vq
-kl
+ku
+sm
+tl
+ug
+uN
+vz
+wq
+ug
+xN
+yl
+ku
 aa
 aa
 aa
@@ -36695,87 +36679,87 @@ aa
 aa
 aa
 aa
-hm
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hm
+hh
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hh
 aa
-kl
-qt
-rm
-sd
-sc
-sb
-sc
-sd
-rm
-vq
-kl
+ku
+sm
+tk
+uh
+ug
+uf
+ug
+uh
+tk
+yl
+ku
 aa
 aa
 aa
@@ -36952,87 +36936,87 @@ aa
 aa
 aa
 aa
-hm
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hm
+hh
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hh
 aa
-kl
-QU
-ro
-rm
-sd
-sc
-sd
-rm
-uy
-vq
-kl
+ku
+so
+tm
+tk
+uh
+ug
+uh
+tk
+xa
+yl
+ku
 aa
 aa
 aa
@@ -37209,87 +37193,87 @@ aa
 aa
 aa
 aa
-hm
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hm
+hh
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hh
 aa
-kl
-QV
-rp
-ro
-rm
-tl
-rm
-uy
-ve
-QX
-kl
+ku
+sp
+tn
+tm
+tk
+vy
+tk
+xa
+xO
+xP
+ku
 aa
 aa
 aa
@@ -37466,87 +37450,87 @@ aa
 aa
 aa
 aa
-hm
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hm
+hh
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hh
 aa
-kl
-qs
-QV
-se
-se
-se
-se
-se
-QX
-qs
-kl
+ku
+sk
+sp
+ui
+ui
+ui
+ui
+ui
+xP
+sk
+ku
 aa
 aa
 aa
@@ -37723,87 +37707,87 @@ aa
 aa
 aa
 aa
-hm
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hm
+hh
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hh
 aa
-kl
-kl
-kl
-kl
-kl
-kl
-kl
-kl
-kl
-kl
-kl
+ku
+ku
+ku
+ku
+ku
+ku
+ku
+ku
+ku
+ku
+ku
 aa
 aa
 aa
@@ -37980,75 +37964,75 @@ aa
 aa
 aa
 aa
-hm
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hm
+hh
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hh
 aa
 aa
 aa
@@ -38237,75 +38221,75 @@ aa
 aa
 aa
 aa
-hm
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hm
+hh
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hh
 aa
 aa
 aa
@@ -38494,75 +38478,75 @@ aa
 aa
 aa
 aa
-hm
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hm
+hh
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hh
 aa
 aa
 aa
@@ -38751,75 +38735,75 @@ aa
 aa
 aa
 aa
-hm
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hq
-hm
+hh
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hh
 aa
 aa
 aa
@@ -39008,75 +38992,75 @@ aa
 aa
 aa
 aa
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
+hh
+hh
+hh
+hh
+hh
+hh
+hh
+hh
+hh
+hh
+hh
+hh
+hh
+hh
+hh
+hh
+hh
+hh
+hh
+hh
+hh
+hh
+hh
+hh
+hh
+hh
+hh
+hh
+hh
+hh
+hh
+hh
+hh
+hh
+hh
+hh
+hh
+hh
+hh
+hh
+hh
+hh
+hh
+hh
+hh
+hh
+hh
+hh
+hh
+hh
+hh
+hh
+hh
+hh
+hh
+hh
+hh
+hh
+hh
+hh
+hh
+hh
+hh
+hh
+hh
+hh
+hh
+hh
+hh
 aa
 aa
 aa
@@ -39387,11 +39371,11 @@ aa
 aa
 aa
 aa
-FN
-FN
-FN
-FN
-FN
+KH
+KH
+KH
+KH
+KH
 aa
 aa
 aa
@@ -39644,12 +39628,12 @@ aa
 aa
 aa
 aa
-FI
-FO
-FR
-FR
-FN
-FN
+KI
+KN
+KQ
+KQ
+KH
+KH
 aa
 aa
 aa
@@ -39901,12 +39885,12 @@ aa
 aa
 aa
 aa
-FJ
-FO
-JO
-FR
-FR
-FN
+KJ
+KN
+KR
+KQ
+KQ
+KH
 aa
 aa
 aa
@@ -40129,15 +40113,15 @@ aa
 aa
 aa
 aa
-zV
-zV
-zV
-zV
-zV
-zV
-zV
-zV
-zV
+ED
+ED
+ED
+ED
+ED
+ED
+ED
+ED
+ED
 aa
 aa
 aa
@@ -40158,22 +40142,22 @@ aa
 aa
 aa
 aa
-FK
-FO
-FS
-FN
-FP
-FN
-FN
-FN
-FN
-FN
-FN
-FN
-FN
-FN
-FN
-FN
+KK
+KN
+KS
+KH
+KO
+KH
+KH
+KH
+KH
+KH
+KH
+KH
+KH
+KH
+KH
+KH
 aa
 aa
 aa
@@ -40386,18 +40370,18 @@ aa
 aa
 aa
 aa
-zV
-Aq
-Aq
-Bk
-BH
-BP
-Cn
-Cx
-zV
-zV
-zV
-zV
+ED
+EZ
+EZ
+FU
+Gs
+GA
+GY
+Hi
+ED
+ED
+ED
+ED
 aa
 aa
 aa
@@ -40415,23 +40399,23 @@ aa
 aa
 aa
 aa
-FN
-FN
-FT
-JQ
-FZ
-Gp
-GB
-GO
-GU
-FN
-Hj
-Hj
-JT
-Hj
-Hj
-FN
-FN
+KH
+KH
+KT
+La
+Lb
+Ld
+Lj
+Ln
+Lq
+KH
+Lv
+Lv
+Lx
+Lv
+Lv
+KH
+KH
 aa
 aa
 aa
@@ -40643,18 +40627,18 @@ aa
 aa
 aa
 aa
-zV
-Ar
-Ar
-Ar
-Ay
-Ay
-Ay
-Ay
-CL
-CV
-CV
-zV
+ED
+Fa
+Fa
+Fa
+Fh
+Fh
+Fh
+Fh
+Hy
+HH
+HH
+ED
 aa
 aa
 aa
@@ -40673,25 +40657,25 @@ aa
 aa
 aa
 aa
-FN
-FU
-FZ
-FV
-Gq
-GC
-GP
-GP
-FN
-FV
-FV
-FV
-FV
-FV
-FN
-FN
-FN
-FN
-FN
+KH
+KU
+Lb
+KV
+Le
+Lk
+Lo
+Lo
+KH
+KV
+KV
+KV
+KV
+KV
+KH
+KH
+KH
+KH
+KH
 aa
 aa
 aa
@@ -40900,55 +40884,55 @@ aa
 aa
 aa
 aa
-zV
-As
-Ar
-Bl
-AR
-Ay
-Ay
-Ay
-CM
-CV
-CV
-zV
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-FL
-FP
+ED
+Fb
+Fa
 FV
-FV
-FV
-Gr
-GD
-GP
-GP
-FN
-Hj
-Hj
-FV
-Hj
-Hj
-FN
-HD
-JU
+FB
+Fh
+Fh
+Fh
+Hz
 HH
-Hk
+HH
+ED
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+KL
+KO
+KV
+KV
+KV
+Lf
+Ll
+Lo
+Lo
+KH
+Lv
+Lv
+KV
+Lv
+Lv
+KH
+LE
+LH
+LN
+Lw
 aa
 aa
 aa
@@ -41157,18 +41141,18 @@ aa
 aa
 aa
 aa
-zV
-At
-Ar
-Aq
-AR
-Ay
-Ay
-Ay
-CM
-CV
-CV
-zV
+ED
+Fc
+Fa
+EZ
+FB
+Fh
+Fh
+Fh
+Hz
+HH
+HH
+ED
 aa
 aa
 aa
@@ -41187,25 +41171,25 @@ aa
 aa
 aa
 aa
-FN
-FW
-FZ
-FV
-Gs
-GE
-Gs
-GV
-Mi
-FN
-FN
-Hl
-FN
-FN
-FN
-Gu
-FZ
-HI
-Hk
+KH
+KW
+Lb
+KV
+Lg
+Lm
+Lg
+Lr
+Lt
+KH
+KH
+Ly
+KH
+KH
+KH
+Li
+Lb
+LO
+Lw
 aa
 aa
 aa
@@ -41414,18 +41398,18 @@ aa
 aa
 aa
 aa
-zV
-At
-Ar
-Bm
-AR
-Ay
-Ay
-Ay
-CL
-CV
-CV
-zV
+ED
+Fc
+Fa
+FW
+FB
+Fh
+Fh
+Fh
+Hy
+HH
+HH
+ED
 aa
 aa
 aa
@@ -41444,25 +41428,25 @@ aa
 aa
 aa
 aa
-FQ
-FX
-FZ
-FV
-FV
-FV
-FV
-FV
-JS
-FV
-FV
-FV
-FV
-FV
-HC
-FV
-HG
-HJ
-Hk
+KP
+KX
+Lb
+KV
+KV
+KV
+KV
+KV
+Lu
+KV
+KV
+KV
+KV
+KV
+LD
+KV
+LI
+LP
+Lw
 aa
 aa
 aa
@@ -41671,55 +41655,55 @@ aa
 aa
 aa
 aa
-zV
-Ar
-Ar
-Bn
-AR
-Ay
-Ay
+ED
+Fa
+Fa
+FX
+FB
+Fh
+Fh
+Hj
+ED
+ED
+ED
+ED
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+KH
+KY
+Lb
+KV
+Lh
+Lb
+Li
+Li
+Lb
+Li
+Li
+KV
+Lb
 LA
-zV
-zV
-zV
-zV
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-FN
-FY
-FZ
-FV
-Gt
-FZ
-Gu
-Gu
-FZ
-Gu
-Gu
-FV
-FZ
-Hv
-FN
-HE
-FZ
-HK
-Hk
+KH
+LF
+Lb
+LQ
+Lw
 aa
 aa
 aa
@@ -41928,15 +41912,15 @@ aa
 aa
 aa
 aa
-zV
-Au
-AQ
-Bo
-AR
-Ay
-Ay
-Ay
-zV
+ED
+Fd
+FA
+FY
+FB
+Fh
+Fh
+Fh
+ED
 aa
 aa
 aa
@@ -41957,26 +41941,26 @@ aa
 aa
 aa
 aa
-FM
-FP
-FV
-FV
-FV
-FZ
-FZ
-GQ
-GQ
-FZ
-GQ
-GQ
-FV
-FZ
-Hw
-FN
-HF
-JV
-HL
-Hk
+KM
+KO
+KV
+KV
+KV
+Lb
+Lb
+Lp
+Lp
+Lb
+Lp
+Lp
+KV
+Lb
+LB
+KH
+LG
+LJ
+LR
+Lw
 aa
 aa
 aa
@@ -42185,15 +42169,15 @@ aa
 aa
 aa
 aa
-zV
-Av
-Ay
-Ay
-Ay
-Ay
-Ay
-Ay
-zV
+ED
+Fe
+Fh
+Fh
+Fh
+Fh
+Fh
+Fh
+ED
 aa
 aa
 aa
@@ -42215,25 +42199,25 @@ aa
 aa
 aa
 aa
-FN
-FU
-FZ
-FV
-FV
-FV
-FV
-FV
-FV
-FV
-FV
-FV
-FZ
-Hx
-FN
-FN
-FN
-FN
-FN
+KH
+KU
+Lb
+KV
+KV
+KV
+KV
+KV
+KV
+KV
+KV
+KV
+Lb
+LC
+KH
+KH
+KH
+KH
+KH
 aa
 aa
 aa
@@ -42442,15 +42426,15 @@ aa
 aa
 aa
 aa
-zV
-Aw
-Ay
-Ay
-Ay
-Ay
-Ay
-AR
-zV
+ED
+Ff
+Fh
+Fh
+Fh
+Fh
+Fh
+FB
+ED
 aa
 aa
 aa
@@ -42471,23 +42455,23 @@ aa
 aa
 aa
 aa
-FN
-FN
-FT
-JR
-FZ
-Gu
-Gu
-Gu
-FV
-Gu
-Gu
-Gu
-FV
-FZ
-FU
-FN
-FN
+KH
+KH
+KT
+Lc
+Lb
+Li
+Li
+Li
+KV
+Li
+Li
+Li
+KV
+Lb
+KU
+KH
+KH
 aa
 aa
 aa
@@ -42699,51 +42683,51 @@ aa
 aa
 aa
 aa
-zV
-Ax
-Ay
-Ay
-Ay
-Ay
-AR
-Cy
-zV
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-FI
-FO
-FS
-FN
-FP
-FN
-FN
-FN
-FP
-FN
+ED
+Fg
+Fh
+Fh
+Fh
+Fh
+FB
 Hk
-FN
-FP
-FN
-FN
-FN
+ED
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+KI
+KN
+KS
+KH
+KO
+KH
+KH
+KH
+KO
+KH
+Lw
+KH
+KO
+KH
+KH
+KH
 aa
 aa
 aa
@@ -42956,15 +42940,15 @@ aa
 aa
 aa
 aa
-zV
-Ay
-AR
-Ay
-Ay
-Ay
-Ay
-AR
-zV
+ED
+Fh
+FB
+Fh
+Fh
+Fh
+Fh
+FB
+ED
 aa
 aa
 aa
@@ -42985,19 +42969,19 @@ aa
 aa
 aa
 aa
-FJ
-FO
-JP
-FR
-FR
-FN
+KJ
+KN
+KZ
+KQ
+KQ
+KH
 aa
 aa
-GW
+Ls
 aa
 aa
 aa
-Hm
+Lz
 aa
 aa
 aa
@@ -43213,15 +43197,15 @@ aa
 aa
 aa
 aa
-zV
-Az
-Az
-Az
-Az
-BQ
-BQ
-LB
-zV
+ED
+Fi
+Fi
+Fi
+Fi
+GB
+GB
+Hl
+ED
 aa
 aa
 aa
@@ -43242,12 +43226,12 @@ aa
 aa
 aa
 aa
-FK
-FO
-FR
-FR
-FN
-FN
+KK
+KN
+KQ
+KQ
+KH
+KH
 aa
 aa
 aa
@@ -43470,15 +43454,15 @@ aa
 aa
 aa
 aa
-zV
-AA
-Az
-Az
-Az
-Az
-Co
-Cz
-zV
+ED
+Fj
+Fi
+Fi
+Fi
+Fi
+GZ
+Hm
+ED
 aa
 aa
 aa
@@ -43499,11 +43483,11 @@ aa
 aa
 aa
 aa
-FN
-FN
-FN
-FN
-FN
+KH
+KH
+KH
+KH
+KH
 aa
 aa
 aa
@@ -43727,15 +43711,15 @@ aa
 aa
 aa
 aa
-zV
-Az
-Az
-Bp
-Az
-Az
-Co
-Cz
-zV
+ED
+Fi
+Fi
+FZ
+Fi
+Fi
+GZ
+Hm
+ED
 aa
 aa
 aa
@@ -43984,15 +43968,15 @@ aa
 aa
 aa
 aa
-zV
-Lz
-AS
-Az
-BI
-Az
-Co
-Cz
-zV
+ED
+Fk
+FC
+Fi
+Gt
+Fi
+GZ
+Hm
+ED
 aa
 aa
 aa
@@ -44241,15 +44225,15 @@ aa
 aa
 aa
 aa
-zV
-Az
-Az
-Bq
-Az
-Az
-Cp
-Cz
-zV
+ED
+Fi
+Fi
+Ga
+Fi
+Fi
+Ha
+Hm
+ED
 aa
 aa
 aa
@@ -44498,15 +44482,15 @@ aa
 aa
 aa
 aa
-zV
-AB
-Az
-AA
-Az
-Az
-Co
-Cz
-zV
+ED
+Fl
+Fi
+Fj
+Fi
+Fi
+GZ
+Hm
+ED
 aa
 aa
 aa
@@ -44755,15 +44739,15 @@ aa
 aa
 aa
 aa
-zV
-zV
-zV
-zV
-zV
-zV
-zV
-zV
-zV
+ED
+ED
+ED
+ED
+ED
+ED
+ED
+ED
+ED
 aa
 aa
 aa
@@ -45444,7 +45428,7 @@ aa
 aa
 aa
 aa
-hM
+hH
 aa
 aa
 aa
@@ -48586,12 +48570,12 @@ aa
 aa
 aa
 aa
-nf
-nf
-mU
-mV
-nf
-nf
+oe
+oe
+nT
+nU
+oe
+oe
 aa
 aa
 aa
@@ -48843,15 +48827,15 @@ aa
 aa
 aa
 aa
-nf
-pF
-qu
-rq
-sf
-nf
+oe
+rk
+sq
+to
+uj
+oe
 aa
 aa
-uz
+xb
 aa
 aa
 aa
@@ -49100,18 +49084,18 @@ aa
 aa
 aa
 aa
-lJ
-pG
-qv
-rr
-sg
-lJ
+mD
+rl
+sr
+tp
+uk
+mD
 aa
-nf
-uA
-nf
+oe
+xc
+oe
 aa
-lJ
+mD
 aa
 aa
 aa
@@ -49357,18 +49341,18 @@ aa
 aa
 aa
 aa
-nf
-pH
-qw
-rs
-sh
-lJ
-tn
-nf
-uB
-nf
-vr
-lJ
+oe
+rm
+ss
+tq
+ul
+mD
+vA
+oe
+xd
+oe
+yn
+mD
 aa
 aa
 aa
@@ -49614,18 +49598,18 @@ aa
 aa
 aa
 aa
-nf
-pI
-qx
-rt
-si
-mU
-to
-nf
-uA
-nf
-to
-lJ
+oe
+rn
+st
+tr
+um
+nT
+vB
+oe
+xc
+oe
+vB
+mD
 aa
 aa
 aa
@@ -49871,18 +49855,18 @@ aa
 aa
 aa
 aa
-mV
-pJ
-qy
-ru
-sj
-mV
-tp
-tW
-uC
-tW
-vs
-mV
+nU
+ro
+su
+ts
+un
+nU
+vC
+wr
+xe
+wr
+yo
+nU
 aa
 aa
 aa
@@ -50128,18 +50112,18 @@ aa
 aa
 aa
 aa
-nf
-pK
-qy
-ru
-qA
-sG
-tq
-tX
-uD
-tX
-vt
-nf
+oe
+rp
+su
+ts
+sw
+uO
+vD
+ws
+xf
+ws
+yp
+oe
 aa
 aa
 aa
@@ -50385,18 +50369,18 @@ aa
 aa
 aa
 aa
-lJ
-pL
-qz
-rv
-sk
-lJ
-tr
-tY
-uE
-tY
-vu
-lJ
+mD
+rq
+sv
+tt
+uo
+mD
+vE
+wt
+xg
+wt
+yq
+mD
 aa
 aa
 aa
@@ -50642,25 +50626,25 @@ aa
 aa
 aa
 aa
-lJ
-lJ
-lJ
-rw
-lJ
-lJ
-lJ
-tZ
-uF
-tZ
-lJ
-lJ
-nf
-nf
-mV
-nf
-nf
-lJ
-lJ
+mD
+mD
+mD
+tu
+mD
+mD
+mD
+wu
+xh
+wu
+mD
+mD
+oe
+oe
+nU
+oe
+oe
+mD
+mD
 aa
 aa
 aa
@@ -50893,31 +50877,31 @@ aa
 aa
 aa
 aa
-lJ
-nf
-nf
-lJ
-nf
-nf
-lJ
-pM
-qA
-rx
-qA
-sH
-lJ
-ua
-ua
-ua
-lJ
-vQ
-wm
-nD
-vU
-xx
-xT
-yd
-lJ
+mD
+oe
+oe
+mD
+oe
+oe
+mD
+rr
+sw
+tv
+sw
+uP
+mD
+wv
+wv
+wv
+mD
+yY
+zz
+oA
+zc
+Bu
+BZ
+Cq
+mD
 aa
 aa
 aa
@@ -51150,31 +51134,31 @@ aa
 aa
 aa
 aa
-lJ
-ng
-nD
-nU
-on
-oK
-lJ
-pN
-qA
-ry
-qA
-sI
-lJ
-tZ
-uF
-tZ
-lJ
-vR
-od
-od
-od
-od
-od
-ye
-lJ
+mD
+of
+oA
+oX
+pH
+qb
+mD
+rs
+sw
+tw
+sw
+uQ
+mD
+wu
+xh
+wu
+mD
+yZ
+pg
+pg
+pg
+pg
+pg
+Cr
+mD
 aa
 aa
 aa
@@ -51407,31 +51391,31 @@ aa
 aa
 aa
 aa
-lJ
-nh
-nE
-nV
-nE
-oL
-lJ
-lJ
-lJ
-lJ
-lJ
-pt
-lJ
-ub
-uG
-ue
-pt
-vS
-od
-wD
-xc
-xy
-od
-yf
-pt
+mD
+og
+oB
+oY
+oB
+qc
+mD
+mD
+mD
+mD
+mD
+qR
+mD
+ww
+xi
+wz
+qR
+za
+pg
+Ab
+AJ
+Bv
+pg
+Cs
+qR
 aa
 aa
 aa
@@ -51664,31 +51648,31 @@ aa
 aa
 aa
 aa
-lJ
-ni
-nF
-nW
-nE
-oM
-mV
-pO
-qB
-rz
-sl
-sJ
-lJ
-qw
-uH
+mD
+oh
+oC
+oZ
+oB
+qd
+nU
 rt
-mV
-vT
-od
-wE
-xd
-xz
-od
-yg
-mU
+sx
+tx
+up
+uR
+mD
+ss
+xj
+tr
+nU
+zb
+pg
+Ac
+AK
+Bw
+pg
+Ct
+nT
 aa
 aa
 aa
@@ -51921,31 +51905,31 @@ aa
 aa
 aa
 aa
-lJ
-nj
-nG
-nX
-oo
-nI
-ps
-oQ
-qC
-rA
-sm
-sK
-lJ
-qw
-tX
-rt
-pU
-vU
-wn
-ry
-wn
-ry
-wn
-yh
-mV
+mD
+oi
+oD
+pa
+pI
+oF
+qQ
+qh
+sy
+ty
+uq
+uS
+mD
+ss
+ws
+tr
+rz
+zc
+zA
+tw
+zA
+tw
+zA
+Cu
+nU
 aa
 aa
 aa
@@ -52175,34 +52159,34 @@ aa
 aa
 aa
 aa
-lJ
-mi
-mB
-lJ
-nk
-nH
-nY
-op
-oN
-lJ
-pP
-op
-nE
-nE
-sL
-mU
-uc
-tX
-uf
-vv
-qA
-ry
-wF
-xe
-xA
-ry
-yi
-lJ
+mD
+ni
+nA
+mD
+oj
+oE
+pb
+pJ
+qe
+mD
+ru
+pJ
+oB
+oB
+uT
+nT
+wx
+ws
+wB
+yr
+sw
+tw
+Ad
+AL
+Bx
+tw
+Cv
+mD
 aa
 aa
 aa
@@ -52359,49 +52343,49 @@ aa
 aa
 aa
 aa
-ge
-ge
-ge
-ge
-ge
-ge
-ge
-ge
-ge
-ge
-ge
-ge
-ge
-ge
-ge
-ge
-ge
-ge
-ge
-ge
-ge
-ge
-ge
-ge
-ge
-ge
-ge
-ge
-ge
-ge
-ge
-ge
-ge
-ge
-ge
-ge
-ge
-ge
-ge
-ge
-ge
-ge
-ge
+fZ
+fZ
+fZ
+fZ
+fZ
+fZ
+fZ
+fZ
+fZ
+fZ
+fZ
+fZ
+fZ
+fZ
+fZ
+fZ
+fZ
+fZ
+fZ
+fZ
+fZ
+fZ
+fZ
+fZ
+fZ
+fZ
+fZ
+fZ
+fZ
+fZ
+fZ
+fZ
+fZ
+fZ
+fZ
+fZ
+fZ
+fZ
+fZ
+fZ
+fZ
+fZ
+fZ
 aa
 aa
 aa
@@ -52432,34 +52416,34 @@ aa
 aa
 aa
 aa
-lK
-mj
-mC
-mT
-nl
-nI
-nI
-oq
-oO
-mV
-pQ
-qD
-rB
-sn
-sM
-ts
-ud
-tX
-KP
-mU
-qA
-wo
-wG
-xf
-xB
-xU
-yj
-lJ
+mE
+nj
+nB
+nS
+ok
+oF
+oF
+pK
+qf
+nU
+rv
+sz
+tz
+ur
+uU
+vF
+wy
+ws
+xQ
+nT
+sw
+zB
+Ae
+AM
+By
+Ca
+Cw
+mD
 aa
 aa
 aa
@@ -52475,20 +52459,20 @@ aa
 aa
 aa
 aa
-zH
-zH
-zH
-zH
-DJ
-DJ
-DJ
-DJ
-DJ
-DJ
-DJ
-DJ
-DJ
-DJ
+Ep
+Ep
+Ep
+Ep
+Iv
+Iv
+Iv
+Iv
+Iv
+Iv
+Iv
+Iv
+Iv
+Iv
 aa
 aa
 aa
@@ -52616,49 +52600,49 @@ aa
 aa
 aa
 aa
-ge
-gf
-gl
-gl
-gl
-gl
-gl
-gl
-gl
-gl
-gl
-gA
-hg
-gp
-gp
-gp
-gp
-gp
-ge
-gp
-gp
-gp
-gp
-gp
-ge
-gp
-gp
-gp
-gp
-gp
-hg
-gf
-gl
-gl
-gl
-gl
-gl
-gl
-gl
-gl
-gl
-gA
-ge
+fZ
+ga
+gg
+gg
+gg
+gg
+gg
+gg
+gg
+gg
+gg
+gv
+hb
+gk
+gk
+gk
+gk
+gk
+fZ
+gk
+gk
+gk
+gk
+gk
+fZ
+gk
+gk
+gk
+gk
+gk
+hb
+ga
+gg
+gg
+gg
+gg
+gg
+gg
+gg
+gg
+gg
+gv
+fZ
 aa
 aa
 aa
@@ -52689,34 +52673,34 @@ aa
 aa
 aa
 aa
-lJ
-mk
 mD
-lJ
-nm
-nJ
-nZ
-nL
-oP
-lK
-pR
-qE
-rC
-nE
-sN
-pU
-ue
-tX
-vf
-vv
-qA
-wp
-wH
-xg
-xC
-xV
-yk
-lJ
+nk
+nC
+mD
+ol
+oG
+pc
+oI
+qg
+mE
+rw
+sA
+tA
+oB
+uV
+rz
+wz
+ws
+xR
+yr
+sw
+zC
+Af
+AN
+Bz
+Cb
+Cx
+mD
 aa
 aa
 aa
@@ -52732,20 +52716,20 @@ aa
 aa
 aa
 aa
-zH
-zY
-zZ
-zN
-Lo
-Ef
-Er
-Ee
-Ef
-Lo
-Ef
-Er
-Ee
-DJ
+Ep
+EG
+EH
+Ev
+Iw
+IR
+Jd
+Jn
+IR
+Iw
+IR
+Jd
+Jn
+Iv
 aa
 aa
 aa
@@ -52873,49 +52857,49 @@ aa
 aa
 aa
 aa
-ge
-gg
-gm
-gm
-gm
-gm
-gm
-gm
-gm
-gm
-gm
-gB
-ge
-gp
-gq
-gq
-gq
-gp
-go
-gp
-gp
-gp
-gp
-gp
-go
-gp
-gq
-gq
-gq
-gp
-ge
-gg
-gm
-gm
-gm
-gm
-gm
-gm
-gm
-gm
-gm
-gB
-ge
+fZ
+gb
+gh
+gh
+gh
+gh
+gh
+gh
+gh
+gh
+gh
+gw
+fZ
+gk
+gl
+gl
+gl
+gk
+gj
+gk
+gk
+gk
+gk
+gk
+gj
+gk
+gl
+gl
+gl
+gk
+fZ
+gb
+gh
+gh
+gh
+gh
+gh
+gh
+gh
+gh
+gh
+gw
+fZ
 aa
 aa
 aa
@@ -52946,63 +52930,63 @@ aa
 aa
 aa
 aa
-lJ
-lJ
-lJ
-mU
-nn
-nK
-oa
-or
-oQ
-ps
-pS
-qF
-rD
-so
-sO
-lJ
-qy
-tX
-ru
-pU
-vV
-wo
-wI
-xh
-xD
-xU
-yl
-lJ
+mD
+mD
+mD
+nT
+om
+oH
+pd
+pL
+qh
+qQ
+rx
+sB
+tB
+us
+uW
+mD
+su
+ws
+ts
+rz
+zd
+zB
+Ag
+AO
+BA
+Ca
+Cy
+mD
 aa
 aa
 aa
 aa
 aa
-zH
-zH
-zH
-zH
-zH
-zH
-zH
-zH
-zH
-zH
-zH
-zN
-zN
-zH
-DJ
-DJ
-Ef
-Ef
-DJ
-DJ
-DJ
-Ef
-Ef
-DJ
+Ep
+Ep
+Ep
+Ep
+Ep
+Ep
+Ep
+Ep
+Ep
+Ep
+Ep
+Ev
+Ev
+Ep
+Iv
+Iv
+IR
+IR
+Iv
+Iv
+Iv
+IR
+IR
+Iv
 aa
 aa
 aa
@@ -53130,49 +53114,49 @@ aa
 aa
 aa
 aa
-ge
-gg
-gm
-gy
-gm
-gy
-gm
-gy
-gm
-gy
-gm
-gB
-ge
-gp
-gq
-gp
-gp
-gp
-go
-gp
-gp
-hH
-gp
-gp
-go
-gp
-gp
-gp
-gq
-gp
-ge
-gg
-gm
-gy
-gm
-gy
-gm
-gy
-gm
-gy
-gm
-gB
-ge
+fZ
+gb
+gh
+gt
+gh
+gt
+gh
+gt
+gh
+gt
+gh
+gw
+fZ
+gk
+gl
+gk
+gk
+gk
+gj
+gk
+gk
+hC
+gk
+gk
+gj
+gk
+gk
+gk
+gl
+gk
+fZ
+gb
+gh
+gt
+gh
+gt
+gh
+gt
+gh
+gt
+gh
+gw
+fZ
 aa
 aa
 aa
@@ -53206,60 +53190,60 @@ aa
 aa
 aa
 aa
-mV
-no
-nL
-ob
-os
-oR
-lJ
-pT
-qG
-rE
-nE
-sP
-lJ
-qy
-tX
-ru
-lJ
-vU
+nU
+on
+oI
+pe
+pM
+qi
+mD
 ry
-wJ
-xi
-wJ
-ry
-ym
-lJ
+sC
+tC
+oB
+uX
+mD
+su
+ws
+ts
+mD
+zc
+tw
+Ah
+AP
+Ah
+tw
+Cz
+mD
 aa
 aa
 aa
 aa
 aa
-zH
-AC
-AT
-Br
-zH
-BR
-Cq
-CA
-CO
-CW
-zH
-Dl
-Dt
-BK
-DL
-Eg
-Es
-EB
-Eg
-DL
-Eg
-EO
-EO
-DJ
+Ep
+Fm
+FD
+Gb
+Ep
+GC
+Hb
+Hn
+HA
+HI
+Ep
+HZ
+Ih
+Gv
+Ix
+IS
+Je
+Jo
+IS
+Ix
+IS
+JG
+JG
+Iv
 aa
 aa
 aa
@@ -53387,49 +53371,49 @@ aa
 aa
 aa
 aa
-ge
-gg
-gm
-gy
-gm
-gy
-gm
-gy
-gm
-gy
-gm
-gB
-ge
-gp
-gq
-gp
-gp
-gp
-go
-gp
-hH
-hI
-hH
-gp
-go
-gp
-gp
-gp
-gq
-gp
-ge
-gg
-gm
-gy
-gm
-gy
-gm
-gy
-gm
-gy
-gm
-gB
-ge
+fZ
+gb
+gh
+gt
+gh
+gt
+gh
+gt
+gh
+gt
+gh
+gw
+fZ
+gk
+gl
+gk
+gk
+gk
+gj
+gk
+hC
+hD
+hC
+gk
+gj
+gk
+gk
+gk
+gl
+gk
+fZ
+gb
+gh
+gt
+gh
+gt
+gh
+gt
+gh
+gt
+gh
+gw
+fZ
 aa
 aa
 aa
@@ -53451,7 +53435,7 @@ aa
 aa
 aa
 aa
-jD
+jC
 aa
 aa
 aa
@@ -53463,62 +53447,62 @@ aa
 aa
 aa
 aa
-lJ
-lK
-nM
-lJ
-lJ
-lJ
-lJ
-pU
-qH
-lJ
-mV
-lJ
-lJ
-qy
-tX
-ru
-pt
-on
-wn
-ry
-wn
-ry
-wn
-yn
-lJ
+mD
+mE
+oJ
+mD
+mD
+mD
+mD
+rz
+sD
+mD
+nU
+mD
+mD
+su
+ws
+ts
+qR
+pH
+zA
+tw
+zA
+tw
+zA
+CA
+mD
 aa
 aa
 aa
 aa
 aa
-zH
-AD
-AU
-Bs
-BJ
-Bs
-Bs
-Bs
-Bs
-Bs
-Dg
-AY
-Bb
-BK
-DL
-Eg
-Et
-EC
-Eg
-DL
-Eg
-EO
-EO
-DJ
-Fj
-DJ
+Ep
+Fn
+FE
+Gc
+Gu
+Gc
+Gc
+Gc
+Gc
+Gc
+HS
+FI
+FL
+Gv
+Ix
+IS
+Jf
+Jp
+IS
+Ix
+IS
+JG
+JG
+Iv
+Kg
+Iv
 aa
 aa
 aa
@@ -53644,49 +53628,49 @@ aa
 aa
 aa
 aa
-ge
-gg
-gm
-gy
-gm
-gy
-gm
-gy
-gm
-gy
-gm
-gB
-ge
-gp
-gq
-gp
-gp
-gp
-go
-gp
-gp
-hH
-gp
-gp
-go
-gp
-gp
-gp
-gq
-gp
-ge
-gg
-gm
-gy
-gm
-gy
-gm
-gy
-gm
-gy
-gm
-gB
-ge
+fZ
+gb
+gh
+gt
+gh
+gt
+gh
+gt
+gh
+gt
+gh
+gw
+fZ
+gk
+gl
+gk
+gk
+gk
+gj
+gk
+gk
+hC
+gk
+gk
+gj
+gk
+gk
+gk
+gl
+gk
+fZ
+gb
+gh
+gt
+gh
+gt
+gh
+gt
+gh
+gt
+gh
+gw
+fZ
 aa
 aa
 aa
@@ -53704,78 +53688,78 @@ aa
 aa
 aa
 aa
-iZ
-jl
-js
-iZ
-js
-jJ
-iZ
+iX
+jk
+jr
+iX
+jr
+jI
+iX
 aa
 aa
 aa
 aa
-iZ
-iZ
-lL
-jF
-iK
-lJ
-np
-nL
-oc
-ot
-oS
-mV
-pM
-qI
-rF
-lJ
-sQ
-nf
-qy
-tX
-ru
-lJ
-mU
-pU
-wK
-wK
-wK
-pU
-mV
-lJ
+iX
+iX
+mF
+jE
+iF
+mD
+oo
+oI
+pf
+pN
+qj
+nU
+rr
+sE
+tD
+mD
+uY
+oe
+su
+ws
+ts
+mD
+nT
+rz
+Ai
+Ai
+Ai
+rz
+nU
+mD
 aa
 aa
 aa
 aa
 aa
-zH
-AE
-AV
-Bt
-zH
-BS
-BS
-BS
-BS
-BS
-zH
-AX
-Bu
-zH
-DJ
-DJ
-DJ
-DJ
-DJ
-DJ
-DJ
-EO
-EO
-EO
-EO
-DJ
+Ep
+Fo
+FF
+Gd
+Ep
+GD
+GD
+GD
+GD
+GD
+Ep
+FH
+Ge
+Ep
+Iv
+Iv
+Iv
+Iv
+Iv
+Iv
+Iv
+JG
+JG
+JG
+JG
+Iv
 aa
 aa
 aa
@@ -53901,49 +53885,49 @@ aa
 aa
 aa
 aa
-ge
-gg
-gm
-gm
-gm
-gm
-gm
-gm
-gm
-gm
-gm
-gB
-ge
-gp
-gq
-gq
-gq
-gp
-go
-gp
-gp
-gp
-gp
-gp
-go
-gp
-gq
-gq
-gq
-gp
-ge
-gg
-gm
-gm
-gm
-gm
-gm
-gm
-gm
-gm
-gm
-gB
-ge
+fZ
+gb
+gh
+gh
+gh
+gh
+gh
+gh
+gh
+gh
+gh
+gw
+fZ
+gk
+gl
+gl
+gl
+gk
+gj
+gk
+gk
+gk
+gk
+gk
+gj
+gk
+gl
+gl
+gl
+gk
+fZ
+gb
+gh
+gh
+gh
+gh
+gh
+gh
+gh
+gh
+gh
+gw
+fZ
 aa
 aa
 aa
@@ -53961,78 +53945,78 @@ aa
 aa
 aa
 aa
-jd
-jm
-jt
-iZ
-jt
-jK
-jd
+jb
+jl
+js
+iX
+js
+jJ
+jb
 aa
 aa
 aa
 aa
-iZ
-lo
-lM
-ml
-mE
-lJ
-nq
-nN
-od
-od
-oT
-pt
-pV
-qJ
-rG
-mV
-sR
-nf
-qy
-tX
-ru
-lJ
-vW
-wq
-qA
-qA
-qA
-wq
-yo
-lJ
+iX
+mb
+mG
+nl
+nD
+mD
+op
+oK
+pg
+pg
+qk
+qR
+rA
+sF
+tE
+nU
+uZ
+oe
+su
+ws
+ts
+mD
+ze
+zD
+sw
+sw
+sw
+zD
+CB
+mD
 aa
 aa
 aa
 aa
-zH
-zH
-zH
-zH
-zH
-zH
-zH
-zH
-zH
-zH
-zH
-zH
-AY
-Bb
-zH
-DM
-DM
-DM
-DM
-DM
-DM
-DJ
-EO
-Ls
-EO
-EO
-DJ
+Ep
+Ep
+Ep
+Ep
+Ep
+Ep
+Ep
+Ep
+Ep
+Ep
+Ep
+Ep
+FI
+FL
+Ep
+Iy
+Iy
+Iy
+Iy
+Iy
+Iy
+Iv
+JG
+JO
+JG
+JG
+Iv
 aa
 aa
 aa
@@ -54158,49 +54142,49 @@ aa
 aa
 aa
 aa
-ge
-gh
-gn
-gn
-gn
-gn
-gn
-gn
-gn
-gn
-gn
-gC
-hg
-gp
-gp
-gp
-gp
-gp
-ge
-gp
-gp
-gp
-gp
-gp
-ge
-gp
-gp
-gp
-gp
-gp
-hg
-gh
-gn
-gn
-gn
-gn
-gn
-gn
-gn
-gn
-gn
-gC
-ge
+fZ
+gc
+gi
+gi
+gi
+gi
+gi
+gi
+gi
+gi
+gi
+gx
+hb
+gk
+gk
+gk
+gk
+gk
+fZ
+gk
+gk
+gk
+gk
+gk
+fZ
+gk
+gk
+gk
+gk
+gk
+hb
+gc
+gi
+gi
+gi
+gi
+gi
+gi
+gi
+gi
+gi
+gx
+fZ
 aa
 aa
 aa
@@ -54215,81 +54199,81 @@ aa
 aa
 aa
 aa
-iK
-iQ
-iZ
-iZ
-jn
-js
-iZ
-js
-jL
-iZ
-iZ
-iZ
-iZ
-iQ
-iK
-lp
-lN
-mm
-mF
-lJ
-nr
-nO
+iF
+iN
+iX
+iX
+jm
+jr
+iX
+jr
+jK
+iX
+iX
+iX
+iX
+iN
+iF
+mc
+mH
+nm
+nE
+mD
+oq
+oL
+ph
+pO
+ql
+nT
+rB
+sG
+tF
+mD
+uY
 oe
-ou
-oU
-mU
-pW
-qK
-rH
-lJ
-sQ
-nf
-qy
-uD
-ru
-lJ
-vX
-qA
-ry
-ry
-ry
-qA
-yp
-lJ
+su
+xf
+ts
+mD
+zf
+sw
+tw
+tw
+tw
+sw
+CC
+mD
 aa
 aa
 aa
 aa
-zH
-zW
-zH
-AW
-Bd
-BK
-Aj
-Cr
-AF
-Cr
-AF
-Lm
-Dm
-Bu
-zH
-DN
-DN
-DN
-DN
-DN
-DN
-DJ
-DJ
-DJ
-Fb
-Fb
-DJ
+Ep
+EE
+Ep
+FG
+FN
+Gv
+ER
+Hc
+Fp
+Hc
+Fp
+HT
+Ia
+Ge
+Ep
+Iz
+Iz
+Iz
+Iz
+Iz
+Iz
+Iv
+Iv
+Iv
+JX
+JX
+Iv
 aa
 aa
 aa
@@ -54415,49 +54399,49 @@ aa
 aa
 aa
 aa
-ge
-ge
-go
-go
-go
-ge
-ge
-ge
-go
-go
-go
-ge
-ge
-ge
-hg
-hg
-hg
-ge
-ge
-ge
-ge
-ge
-ge
-ge
-ge
-ge
-hg
-hg
-hg
-ge
-ge
-ge
-go
-go
-go
-ge
-ge
-ge
-go
-go
-go
-ge
-ge
+fZ
+fZ
+gj
+gj
+gj
+fZ
+fZ
+fZ
+gj
+gj
+gj
+fZ
+fZ
+fZ
+hb
+hb
+hb
+fZ
+fZ
+fZ
+fZ
+fZ
+fZ
+fZ
+fZ
+fZ
+hb
+hb
+hb
+fZ
+fZ
+fZ
+gj
+gj
+gj
+fZ
+fZ
+fZ
+gj
+gj
+gj
+fZ
+fZ
 aa
 aa
 aa
@@ -54472,83 +54456,83 @@ aa
 aa
 aa
 aa
-iK
+iF
+iO
+iO
+jc
+jn
+iP
+jy
+jD
+jL
+jO
+jO
+jO
+iO
+iO
+iX
+md
 iR
-iR
-je
-jo
-iS
-jz
-jE
-jM
-jP
-jP
-jP
-iR
-iR
-iZ
-lq
-iT
-mn
-mG
-lJ
-mU
-mV
-lJ
-lJ
-lJ
-lJ
-lJ
-qL
-pU
-lJ
-nf
-pt
-KL
-tX
-ru
-lJ
-vY
-qA
-wM
-xj
-xE
-qA
-yq
-lJ
+nn
+nF
+mD
+nT
+nU
+mD
+mD
+mD
+mD
+mD
+sH
+rz
+mD
+oe
+qR
+wA
+ws
+ts
+mD
+zg
+sw
+Aj
+AQ
+BB
+sw
+CD
+mD
 aa
 aa
 aa
 aa
-zI
-zX
-zI
-AX
-Bu
-BK
-BT
-AM
-AG
-AM
-AG
-AM
-AG
-Bc
-zH
-DO
-Eh
-Eh
-Eh
-Eh
-EG
-EM
-EP
-DJ
-EO
-EO
-DJ
-DJ
-DJ
+Eq
+EF
+Eq
+FH
+Ge
+Gv
+GE
+Fw
+Fq
+Fw
+Fq
+Fw
+Fq
+FM
+Ep
+IA
+IT
+IT
+IT
+IT
+Ju
+JD
+JH
+Iv
+JG
+JG
+Iv
+Iv
+Iv
 aa
 aa
 aa
@@ -54672,49 +54656,49 @@ aa
 aa
 aa
 aa
-ge
-gf
-gl
-gl
-gl
-gA
-ge
-gf
-gl
-gl
-gl
-gA
-ge
-gf
-gl
-gl
-gl
-gA
-ge
-gp
-gp
-gp
-gp
-gp
-ge
-gf
-gl
-gl
-gl
-gA
-ge
-gf
-gl
-gl
-gl
-gA
-ge
-gf
-gl
-gl
-gl
-gA
-ge
+fZ
+ga
+gg
+gg
+gg
+gv
+fZ
+ga
+gg
+gg
+gg
+gv
+fZ
+ga
+gg
+gg
+gg
+gv
+fZ
+gk
+gk
+gk
+gk
+gk
+fZ
+ga
+gg
+gg
+gg
+gv
+fZ
+ga
+gg
+gg
+gg
+gv
+fZ
+ga
+gg
+gg
+gg
+gv
+fZ
 aa
 aa
 aa
@@ -54729,83 +54713,83 @@ aa
 aa
 aa
 aa
-iK
-iS
-iS
-jf
-jp
-ju
-ju
-ju
-jN
-jQ
-jY
-jY
-jE
-jE
-iZ
-lr
-lO
-kJ
-mH
-lL
-ns
-nP
-of
-ov
-oV
-mV
-pX
-qM
-rI
-lJ
-sS
-nf
-qy
-tX
-ru
-lJ
-vZ
-qA
-wN
-xk
-xF
-qA
-yr
-lJ
+iF
+iP
+iP
+jd
+jo
+jt
+jt
+jt
+jM
+jP
+kj
+kj
+jD
+jD
+iX
+me
+mI
+lo
+nG
+mF
+or
+oM
+pi
+pP
+qm
+nU
+rC
+sI
+tG
+mD
+va
+oe
+su
+ws
+ts
+mD
+zh
+sw
+Ak
+AR
+BC
+sw
+CE
+mD
 aa
 aa
 aa
 aa
-zH
-zN
-zH
-AY
-Lk
-zH
-zH
-Ba
-zH
-zH
-Ac
-BL
-Ac
-zH
-zH
-DP
-Ei
-Ej
-Ej
-Ei
-EH
-EM
-EP
-DJ
-EO
-EO
-Ef
-FD
-DJ
+Ep
+Ev
+Ep
+FI
+Gf
+Ep
+Ep
+FK
+Ep
+Ep
+EK
+Gw
+EK
+Ep
+Ep
+IB
+IU
+IV
+IV
+IU
+Jv
+JD
+JH
+Iv
+JG
+JG
+IR
+KA
+Iv
 aa
 aa
 aa
@@ -54929,49 +54913,49 @@ aa
 aa
 aa
 aa
-ge
-gg
-gp
-gp
-gp
-gB
-go
-gg
-gp
-gp
-gp
-gB
-go
-gg
-gp
-gq
-gp
-gB
-ge
-gp
-gm
-gm
-gm
-gp
-ge
-gg
-gm
-gq
-gm
-gB
-go
-gg
-gm
-gm
-gm
-gB
-go
-gg
-gm
-gm
-gm
-gB
-ge
+fZ
+gb
+gk
+gk
+gk
+gw
+gj
+gb
+gk
+gk
+gk
+gw
+gj
+gb
+gk
+gl
+gk
+gw
+fZ
+gk
+gh
+gh
+gh
+gk
+fZ
+gb
+gh
+gl
+gh
+gw
+gj
+gb
+gh
+gh
+gh
+gw
+gj
+gb
+gh
+gh
+gh
+gw
+fZ
 aa
 aa
 aa
@@ -54986,83 +54970,83 @@ aa
 aa
 aa
 aa
-iK
-JY
-ja
-ja
-ja
-ja
-ja
-ja
-ja
-ja
-ja
-ja
-ja
-Kd
+iF
 iQ
-ls
-iT
-kJ
-mI
-jF
-lt
-lv
-og
-mm
-oV
-pt
-pY
-qN
-rJ
-lJ
-sT
-nf
-qy
-uI
-ru
-lJ
-wa
-qA
-ry
-ry
-ry
-qA
-ys
-mU
+iY
+iY
+iY
+iY
+iY
+iY
+iY
+iY
+iY
+iY
+iY
+ln
+iN
+mf
+iR
+lo
+nH
+jE
+mg
+mi
+pj
+nm
+qm
+qR
+rD
+sJ
+tH
+mD
+vb
+oe
+su
+xk
+ts
+mD
+zi
+sw
+tw
+tw
+tw
+sw
+CF
+nT
 aa
 aa
 aa
 aa
-zH
-zY
-zN
-AX
-Bu
-zH
-BU
-Cb
-CB
-CP
-CX
-Dh
-Dn
-Du
-zH
-DP
-Ej
-Eu
-Ej
-Ej
-EH
-EM
-EP
-DJ
-EO
-EO
-Ef
-Lu
-DJ
+Ep
+EG
+Ev
+FH
+Ge
+Ep
+GF
+GM
+Ho
+HB
+HJ
+HU
+Ib
+Ii
+Ep
+IB
+IV
+Jg
+IV
+IV
+Jv
+JD
+JH
+Iv
+JG
+JG
+IR
+KB
+Iv
 aa
 aa
 aa
@@ -55186,49 +55170,49 @@ aa
 aa
 aa
 aa
-ge
-gg
-gq
-gq
-gq
-gB
-go
-gg
-gq
-gq
-gq
-gB
-go
-gg
-gq
-gq
-gq
-gB
-ge
-gp
-ge
-gq
-ge
-gp
-ge
-gg
-gq
-gq
-gq
-gB
-go
-gg
-gq
-gq
-gq
-gB
-go
-gg
-gq
-gq
-gq
-gB
-ge
+fZ
+gb
+gl
+gl
+gl
+gw
+gj
+gb
+gl
+gl
+gl
+gw
+gj
+gb
+gl
+gl
+gl
+gw
+fZ
+gk
+fZ
+gl
+fZ
+gk
+fZ
+gb
+gl
+gl
+gl
+gw
+gj
+gb
+gl
+gl
+gl
+gw
+gj
+gb
+gl
+gl
+gl
+gw
+fZ
 aa
 aa
 aa
@@ -55243,83 +55227,83 @@ aa
 aa
 aa
 aa
-iL
-iT
-ja
-jg
+iG
 iR
-ja
-iR
-ja
-iR
-ja
-iR
-kn
-ja
-kJ
-lb
-lt
-iT
-kJ
-lt
-lb
-lt
-iT
-ja
-kJ
-lt
-mU
-pZ
-qA
-rK
+iY
+je
+iO
+iY
+iO
+iY
+iO
+iY
+iO
+kw
+iY
+lo
 lJ
-sS
-nf
-uf
-uG
-vg
+mg
+iR
+lo
+mg
 lJ
-wb
-wr
-wO
-xl
-xG
-wr
-yt
-lJ
+mg
+iR
+iY
+lo
+mg
+nT
+rE
+sw
+tI
+mD
+va
+oe
+wB
+xi
+xS
+mD
+zj
+zE
+Al
+AS
+BD
+zE
+CG
+mD
 aa
 aa
 aa
 aa
-zH
-zZ
-zN
-AY
-Bb
-Ac
-BV
-Bs
-Cs
-Bs
-Cs
-Bs
-Cs
-Dv
-zH
-DP
-Ei
-Ej
-Ej
-Ei
+Ep
 EH
-EM
-EP
-DJ
-EO
-EO
-Ef
-FD
-DJ
+Ev
+FI
+FL
+EK
+GG
+Gc
+Hd
+Gc
+Hd
+Gc
+Hd
+Ij
+Ep
+IB
+IU
+IV
+IV
+IU
+Jv
+JD
+JH
+Iv
+JG
+JG
+IR
+KA
+Iv
 aa
 aa
 aa
@@ -55443,49 +55427,49 @@ aa
 aa
 aa
 aa
-ge
-gg
-gp
-gq
-gp
-gB
-go
-gg
-gp
-gq
-gp
-gB
-go
-gg
-gp
-gq
-gp
-gB
-ge
-gp
-gm
-gm
-gm
-gp
-ge
-gg
-gm
-gq
-gm
-gB
-go
-gg
-gm
-gq
-gm
-gB
-go
-gg
-gm
-gq
-gm
-gB
-ge
+fZ
+gb
+gk
+gl
+gk
+gw
+gj
+gb
+gk
+gl
+gk
+gw
+gj
+gb
+gk
+gl
+gk
+gw
+fZ
+gk
+gh
+gh
+gh
+gk
+fZ
+gb
+gh
+gl
+gh
+gw
+gj
+gb
+gh
+gl
+gh
+gw
+gj
+gb
+gh
+gl
+gh
+gw
+fZ
 aa
 aa
 aa
@@ -55500,83 +55484,83 @@ aa
 aa
 aa
 aa
-iL
-iT
-ja
-jg
-jq
-ja
-jq
-ja
-jq
-ja
-jq
-kn
-ja
-kJ
-iK
-lu
-lP
-kL
+iG
+iR
+iY
+je
+jp
+iY
+jp
+iY
+jp
+iY
+jp
+kw
+iY
+lo
+iF
+mh
 mJ
-iK
-nt
-iT
-ja
-kJ
-oW
-lJ
-lJ
-lJ
-lJ
-lJ
-lJ
-lJ
-tZ
-uF
-tZ
-lJ
-mU
-pU
-lJ
-lJ
-lJ
-pU
-mV
-lJ
-yN
-it
-it
-it
-zH
-zN
-zH
-AX
-Bu
-zH
-BW
-Cs
-Bs
-CQ
-Bs
-Cs
-Bs
-Dw
-zH
-DQ
-Ek
-Ek
-Ek
-Ek
-EI
-EM
-EP
-DJ
-Fc
-Fc
-DJ
-DJ
-DJ
+lq
+nI
+iF
+os
+iR
+iY
+lo
+qn
+mD
+mD
+mD
+mD
+mD
+mD
+mD
+wu
+xh
+wu
+mD
+nT
+rz
+mD
+mD
+mD
+rz
+nU
+mD
+Dq
+io
+io
+io
+Ep
+Ev
+Ep
+FH
+Ge
+Ep
+GH
+Hd
+Gc
+HC
+Gc
+Hd
+Gc
+Ik
+Ep
+IC
+IW
+IW
+IW
+IW
+Jw
+JD
+JH
+Iv
+JY
+JY
+Iv
+Iv
+Iv
 aa
 aa
 aa
@@ -55700,49 +55684,49 @@ aa
 aa
 aa
 aa
-ge
-gh
-gn
-gn
-gn
-gC
-ge
-gh
-gn
-gn
-gn
-gC
-ge
-gh
-gn
-gn
-gn
-gC
-ge
-gp
-gp
-gp
-gp
-gp
-ge
-gh
-gn
-gn
-gn
-gC
-ge
-gh
-gn
-gn
-gn
-gC
-ge
-gh
-gn
-gn
-gn
-gC
-ge
+fZ
+gc
+gi
+gi
+gi
+gx
+fZ
+gc
+gi
+gi
+gi
+gx
+fZ
+gc
+gi
+gi
+gi
+gx
+fZ
+gk
+gk
+gk
+gk
+gk
+fZ
+gc
+gi
+gi
+gi
+gx
+fZ
+gc
+gi
+gi
+gi
+gx
+fZ
+gc
+gi
+gi
+gi
+gx
+fZ
 aa
 aa
 aa
@@ -55757,82 +55741,82 @@ aa
 aa
 aa
 aa
-iK
-iT
-ja
-jg
-jq
-ja
-jq
-ja
-jq
-ja
-jq
-kn
-ja
-kJ
-jF
-iK
-iK
-lb
-iK
-iQ
-nu
-lO
-ja
-mn
-oX
-iQ
-iK
-iK
-pw
-lW
-it
-tt
-tt
-tt
-tt
-tt
-it
-pw
-lW
-it
-it
-it
-pf
-iz
-qP
-iz
-lf
-iz
-zJ
-Aa
-AF
-AZ
-Bv
-Ac
-BX
-Bs
-CC
-BN
-CY
-Di
-Do
-zH
-zH
-DR
-DR
-DR
-DR
-DR
-DR
-DJ
-DJ
-DJ
-DJ
-Fk
-DJ
-DJ
+iF
+iR
+iY
+je
+jp
+iY
+jp
+iY
+jp
+iY
+jp
+kw
+iY
+lo
+jE
+iF
+iF
+lJ
+iF
+iN
+ot
+mI
+iY
+nn
+qo
+iN
+iF
+iF
+rK
+mQ
+io
+vG
+vG
+vG
+vG
+vG
+io
+rK
+mQ
+io
+io
+io
+qw
+iu
+ut
+iu
+lN
+iu
+Er
+EI
+Fp
+FJ
+Gg
+EK
+GI
+Gc
+Hp
+Gy
+HK
+HV
+Ic
+Ep
+Ep
+ID
+ID
+ID
+ID
+ID
+ID
+Iv
+Iv
+Iv
+Iv
+Kh
+Iv
+Iv
 aa
 aa
 aa
@@ -55957,49 +55941,49 @@ aa
 aa
 aa
 aa
-ge
-ge
-go
-go
-go
-ge
-ge
-ge
-go
-go
-go
-ge
-ge
-ge
-ge
-ge
-ge
-ge
-ge
-ge
-gp
-gp
-gp
-ge
-ge
-ge
-ge
-ge
-ge
-ge
-ge
-ge
-go
-go
-go
-ge
-ge
-ge
-go
-go
-go
-ge
-ge
+fZ
+fZ
+gj
+gj
+gj
+fZ
+fZ
+fZ
+gj
+gj
+gj
+fZ
+fZ
+fZ
+fZ
+fZ
+fZ
+fZ
+fZ
+fZ
+gk
+gk
+gk
+fZ
+fZ
+fZ
+fZ
+fZ
+fZ
+fZ
+fZ
+fZ
+gj
+gj
+gj
+fZ
+fZ
+fZ
+gj
+gj
+gj
+fZ
+fZ
 aa
 aa
 aa
@@ -56014,82 +55998,82 @@ aa
 aa
 aa
 aa
-iL
-iT
-ja
-jg
-jq
-ja
-jq
-ja
-jq
-ja
-jq
-kn
-ja
-kK
-iK
-lv
-jY
-jY
-mm
-iK
-nv
-iT
-ja
-kJ
-nP
-iK
-qa
-iK
-iz
-iz
-it
-ir
-jc
-lx
-jc
-ir
-it
-iz
-iz
-it
-lW
-it
-iz
-ir
-HU
+iG
+iR
+iY
+je
+jp
+iY
+jp
+iY
+jp
+iY
+jp
+kw
+iY
+lp
+iF
+mi
+kj
+kj
+nm
+iF
+ou
+iR
+iY
+lo
+oM
+iF
+rF
+iF
 iu
-iz
-it
-zK
-Ab
-AG
-AM
-Bw
-zH
-BY
-Cs
-CD
-BM
-CZ
-Dj
-Dj
-Dx
-DG
-DS
-El
-Ev
-Ev
-EE
-DS
-DG
-EQ
-EU
-Fd
-Fc
+iu
+io
+im
+ja
+mk
+ja
+im
+io
+iu
+iu
+io
+mQ
+io
+iu
+im
+Dr
+ip
+iu
+io
+Es
+EJ
 Fq
-DJ
+Fw
+Gh
+Ep
+GJ
+Hd
+Hq
+Gx
+HL
+HW
+HW
+Il
+Is
+IE
+IX
+Jh
+Jh
+Js
+IE
+Is
+JI
+JP
+JZ
+JY
+Kn
+Iv
 aa
 aa
 aa
@@ -56214,49 +56198,49 @@ aa
 aa
 aa
 aa
-ge
-gf
-gl
-gl
-gl
-gA
-ge
-gf
-gl
-gl
-gl
-gA
-ge
-gp
-gp
-gp
-gp
-gp
-ge
-gp
-gp
-gp
-gp
-gp
-ge
-gp
-gp
-gp
-gp
-gp
-ge
-gf
-gl
-gl
-gl
-gA
-ge
-gf
-gl
-gl
-gl
-gA
-ge
+fZ
+ga
+gg
+gg
+gg
+gv
+fZ
+ga
+gg
+gg
+gg
+gv
+fZ
+gk
+gk
+gk
+gk
+gk
+fZ
+gk
+gk
+gk
+gk
+gk
+fZ
+gk
+gk
+gk
+gk
+gk
+fZ
+ga
+gg
+gg
+gg
+gv
+fZ
+ga
+gg
+gg
+gg
+gv
+fZ
 aa
 aa
 aa
@@ -56271,84 +56255,84 @@ aa
 aa
 aa
 aa
-iL
-iT
-ja
-ja
-ja
-ja
-ja
-ja
-ja
-ja
-ja
-ja
-ja
-kJ
-lc
-iT
-ja
-ja
-kJ
-lc
-lt
-nQ
-jb
-kL
-oY
-iK
+iG
+iR
+iY
+iY
+iY
+iY
+iY
+iY
+iY
+iY
+iY
+iY
+iY
+lo
+lK
+iR
+iY
+iY
+lo
+lK
+mg
+oN
 iZ
-iK
-rL
-rM
-lX
-tu
-rM
-uJ
-vh
-vw
-lX
-ws
-wP
-rR
-iz
-it
-qf
-yE
-lA
-za
-zo
-it
-zH
-Ac
-zH
-Ba
-zH
-zH
-zH
-zH
-zH
-zH
-Da
-Dj
-Db
-Dy
-DH
-DH
-DH
-DH
-DH
-DH
-DH
-DH
-ER
-EV
-Fe
-Fl
-Fr
-FF
-DJ
-DJ
+lq
+qp
+iF
+iX
+iF
+tJ
+tK
+mR
+vH
+tK
+xl
+xT
+ys
+mR
+zF
+Am
+tP
+iu
+io
+rN
+CX
+lS
+DF
+DT
+io
+Ep
+EK
+Ep
+FK
+Ep
+Ep
+Ep
+Ep
+Ep
+Ep
+HM
+HW
+HN
+Im
+It
+It
+It
+It
+It
+It
+It
+It
+JJ
+JQ
+Ka
+Ki
+Ko
+KC
+Iv
+Iv
 aa
 aa
 aa
@@ -56471,49 +56455,49 @@ aa
 aa
 aa
 aa
-ge
-gg
-gp
-gq
-gp
+fZ
+gb
+gk
+gl
+gk
+gw
 gB
-gG
-gg
-gp
-gq
-gp
+gb
+gk
+gl
+gk
+gw
+gk
+gk
+gh
+fZ
+gh
+gk
+gk
+gk
+gl
+hC
+gl
+gk
+gk
+gk
+gh
+fZ
+gh
+gk
+gk
+gb
+gh
+gl
+gh
+gw
 gB
-gp
-gp
-gm
-ge
-gm
-gp
-gp
-gp
-gq
-hH
-gq
-gp
-gp
-gp
-gm
-ge
-gm
-gp
-gp
-gg
-gm
-gq
-gm
-gB
-gG
-gg
-gm
-gq
-gm
-gB
-ge
+gb
+gh
+gl
+gh
+gw
+fZ
 aa
 aa
 aa
@@ -56528,84 +56512,84 @@ aa
 aa
 aa
 aa
-iK
-iU
-jb
-JZ
-jr
-jv
-jv
-jb
-jO
-jR
-jO
-JZ
-jb
-kL
-iK
-lw
-JZ
-jb
-mK
-iK
-nw
-nR
-oh
-lt
-oZ
-pu
-qb
-pu
-rM
-mq
-lX
-mq
-mp
-mq
-mq
-mq
-lX
-mq
-ws
-kT
-qP
-kT
-lk
-jB
-jB
-jB
-zp
-it
-zL
-Ad
-zN
-AG
-Bx
-zH
-BZ
-Ce
-BZ
-zH
-Db
-Dj
-Db
-Dy
-DI
-DT
-DT
-DT
-DT
-DT
-DT
-DI
-ER
-EV
-Fe
-Fl
-Fs
-Ef
-FE
-DJ
+iF
+iS
+iZ
+jf
+jq
+ju
+ju
+iZ
+jN
+jQ
+jN
+jf
+iZ
+lq
+iF
+mj
+jf
+iZ
+nJ
+iF
+ov
+oO
+pk
+mg
+qq
+qS
+rG
+qS
+tK
+nq
+mR
+nq
+np
+nq
+nq
+nq
+mR
+nq
+zF
+kZ
+ut
+kZ
+ly
+jA
+jA
+jA
+DU
+io
+Et
+EL
+Ev
+Fq
+Gi
+Ep
+GK
+GP
+GK
+Ep
+HN
+HW
+HN
+Im
+Iu
+IF
+IF
+IF
+IF
+IF
+IF
+Iu
+JJ
+JQ
+Ka
+Ki
+Kp
+IR
+KG
+Iv
 aa
 aa
 aa
@@ -56728,49 +56712,49 @@ aa
 aa
 aa
 aa
-ge
-gg
-gq
-gq
-gq
+fZ
+gb
+gl
+gl
+gl
+gw
 gB
-gG
-gg
-gq
-gq
-gq
+gb
+gl
+gl
+gl
+gw
+gk
+gk
+gh
+gl
+gh
+gk
+gk
+gk
+hC
+hE
+hC
+gk
+gk
+gk
+gh
+gl
+gh
+gk
+gk
+gb
+gl
+gl
+gl
+gw
 gB
-gp
-gp
-gm
-gq
-gm
-gp
-gp
-gp
-hH
-hJ
-hH
-gp
-gp
-gp
-gm
-gq
-gm
-gp
-gp
-gg
-gq
-gq
-gq
-gB
-gG
-gg
-gq
-gq
-gq
-gB
-ge
+gb
+gl
+gl
+gl
+gw
+fZ
 aa
 aa
 aa
@@ -56785,84 +56769,84 @@ aa
 aa
 aa
 aa
-iK
-iK
-iQ
-iK
-iK
-iK
-iK
-jF
-iK
-iK
-iK
-iK
-iQ
-iK
-iK
-iK
-iK
-mo
-iK
-iK
-iQ
-iZ
-oi
-ow
-iZ
-iK
-iZ
-iK
-rN
-rN
-iz
-iz
-ug
-iz
-iz
-iz
-is
-rN
-rN
-it
-iz
-it
-yu
-tz
-yO
-zb
-mb
-ir
-zM
-Ae
-AH
-Bb
-By
-zH
-zN
-zN
-zN
-zH
-Dc
-Dj
-Dp
-Dy
-DH
-DU
-DU
-DU
-DU
-DU
-DU
-DH
-ER
-EW
-Fc
-Fl
-Ft
-Ef
-FD
-DJ
+iF
+iF
+iN
+iF
+iF
+iF
+iF
+jE
+iF
+iF
+iF
+iF
+iN
+iF
+iF
+iF
+iF
+no
+iF
+iF
+iN
+iX
+pl
+pQ
+iX
+iF
+iX
+iF
+tL
+tL
+iu
+iu
+wC
+iu
+iu
+iu
+in
+tL
+tL
+io
+iu
+io
+CH
+vM
+Ds
+DG
+mm
+im
+Eu
+EM
+Fr
+FL
+Gj
+Ep
+Ev
+Ev
+Ev
+Ep
+HO
+HW
+Id
+Im
+It
+IG
+IG
+IG
+IG
+IG
+IG
+It
+JJ
+JR
+JY
+Ki
+Kq
+IR
+KA
+Iv
 aa
 aa
 aa
@@ -56985,49 +56969,49 @@ aa
 aa
 aa
 aa
-ge
-gg
-gp
-gq
-gp
+fZ
+gb
+gk
+gl
+gk
+gw
 gB
-gG
-gg
-gp
-gq
-gp
+gb
+gk
+gl
+gk
+gw
+gk
+gk
+gh
+fZ
+gh
+gk
+gk
+gk
+gl
+hC
+gl
+gk
+gk
+gk
+gh
+fZ
+gh
+gk
+gk
+gb
+gh
+gl
+gh
+gw
 gB
-gp
-gp
-gm
-ge
-gm
-gp
-gp
-gp
-gq
-hH
-gq
-gp
-gp
-gp
-gm
-ge
-gm
-gp
-gp
-gg
-gm
-gq
-gm
-gB
-gG
-gg
-gm
-gq
-gm
-gB
-ge
+gb
+gh
+gl
+gh
+gw
+fZ
 aa
 aa
 aa
@@ -57042,7 +57026,7 @@ aa
 aa
 aa
 aa
-it
+io
 aa
 aa
 aa
@@ -57055,71 +57039,71 @@ aa
 aa
 aa
 aa
-it
-ld
-iz
-lQ
-mp
-mL
-Kk
-nx
-mW
-mp
-mL
-pa
-it
-Kt
-it
-rM
-mq
-iz
-tv
-iH
-uK
-vi
-vx
-iz
-mq
-vh
-iz
-pw
-it
-it
-iz
-yP
-zc
-iz
-is
-zN
-Af
-zN
-Bb
-AY
-zH
-Ca
-Ct
-CE
-zH
-Db
-Dj
-Db
-Dy
+io
+lL
+iu
+mK
+np
+nK
+nV
+ow
+oP
+np
+nK
+qr
+io
+rH
+io
+tK
+nq
+iu
+vI
+iC
+xm
+xU
+yt
+iu
+nq
+xT
+iu
+rK
+io
+io
+iu
+Dt
 DH
-DV
-DV
-DV
-DV
-DV
-DV
-DH
-ER
-EV
-Fe
-Fl
-Fu
-DJ
-Ef
-DJ
+iu
+in
+Ev
+EN
+Ev
+FL
+FI
+Ep
+GL
+He
+Hr
+Ep
+HN
+HW
+HN
+Im
+It
+IH
+IH
+IH
+IH
+IH
+IH
+It
+JJ
+JQ
+Ka
+Ki
+Kr
+Iv
+IR
+Iv
 aa
 aa
 aa
@@ -57242,49 +57226,49 @@ aa
 aa
 aa
 aa
-ge
-gh
-gn
-gn
-gn
-gC
-ge
-gh
-gn
-gn
-gn
-gC
-ge
-gp
-gp
-gp
-gp
-gp
-ge
-gp
-gp
-gp
-gp
-gp
-ge
-gp
-gp
-gp
-gp
-gp
-ge
-gh
-gn
-gn
-gn
-gC
-ge
-gh
-gn
-gn
-gn
-gC
-ge
+fZ
+gc
+gi
+gi
+gi
+gx
+fZ
+gc
+gi
+gi
+gi
+gx
+fZ
+gk
+gk
+gk
+gk
+gk
+fZ
+gk
+gk
+gk
+gk
+gk
+fZ
+gk
+gk
+gk
+gk
+gk
+fZ
+gc
+gi
+gi
+gi
+gx
+fZ
+gc
+gi
+gi
+gi
+gx
+fZ
 aa
 aa
 aa
@@ -57299,7 +57283,7 @@ aa
 aa
 aa
 aa
-it
+io
 aa
 aa
 aa
@@ -57312,71 +57296,71 @@ aa
 aa
 aa
 aa
-it
-it
-it
-lR
-mq
-mq
-mq
-mq
-mq
-mq
-mq
-pb
-is
-it
-is
-rM
-mq
-it
-tw
-lk
-kr
-vj
-vy
-iz
-mq
-wQ
-is
-it
-is
-yv
-yF
-ul
-mp
-nS
-iz
-zO
-zQ
-AI
-Bc
-Bz
-zH
-zN
-zN
-zN
-zH
-Db
-Dj
-Db
-Dy
-DH
-DV
-DV
-DV
-DV
-DV
-DV
-DH
-ER
-EV
-Fe
-Fl
-Fg
-Ef
-FD
-DJ
+io
+io
+io
+mL
+nq
+nq
+nq
+nq
+nq
+nq
+nq
+qs
+in
+io
+in
+tK
+nq
+io
+vJ
+ly
+kl
+xV
+yu
+iu
+nq
+An
+in
+io
+in
+CI
+CY
+wH
+np
+oQ
+iu
+Ew
+Ey
+Fs
+FM
+Gk
+Ep
+Ev
+Ev
+Ev
+Ep
+HN
+HW
+HN
+Im
+It
+IH
+IH
+IH
+IH
+IH
+IH
+It
+JJ
+JQ
+Ka
+Ki
+Kc
+IR
+KA
+Iv
 aa
 aa
 aa
@@ -57499,49 +57483,49 @@ aa
 aa
 aa
 aa
-ge
-ge
-go
-go
-go
-ge
-ge
-ge
-go
-go
-go
-ge
-ge
-ge
-ge
-ge
-ge
-ge
-ge
-ge
-gp
-gp
-gp
-ge
-ge
-ge
-ge
-ge
-ge
-ge
-ge
-ge
-go
-go
-go
-ge
-ge
-ge
-go
-go
-go
-ge
-ge
+fZ
+fZ
+gj
+gj
+gj
+fZ
+fZ
+fZ
+gj
+gj
+gj
+fZ
+fZ
+fZ
+fZ
+fZ
+fZ
+fZ
+fZ
+fZ
+gk
+gk
+gk
+fZ
+fZ
+fZ
+fZ
+fZ
+fZ
+fZ
+fZ
+fZ
+gj
+gj
+gj
+fZ
+fZ
+fZ
+gj
+gj
+gj
+fZ
+fZ
 aa
 aa
 aa
@@ -57556,7 +57540,7 @@ aa
 aa
 aa
 aa
-it
+io
 aa
 aa
 aa
@@ -57569,71 +57553,71 @@ aa
 aa
 aa
 aa
-it
-le
-lx
-lS
-mq
-mq
-mq
-mq
-mq
-mq
-mq
-pb
-iz
-qc
-lx
-rM
-mq
-iz
-tx
-uh
-ks
-mO
-vz
-ir
-mq
-vh
-iz
-xH
-lx
-yw
-mq
-mq
-mq
-zq
-iz
-zP
-Ag
-Ag
-Ag
-BA
-BL
-Cb
-Cb
-CF
-BN
-Db
-Dj
-Db
-Dy
-DH
+io
+lM
+mk
+mM
+nq
+nq
+nq
+nq
+nq
+nq
+nq
+qs
+iu
+rI
+mk
+tK
+nq
+iu
+vK
+wD
+km
+nN
+yv
+im
+nq
+xT
+iu
+BE
+mk
+CJ
+nq
+nq
+nq
 DV
-DV
-Ew
-Ew
-DV
-DV
-DH
-ER
-EW
-Fc
-Fl
-Fv
-Ef
-FE
-DJ
+iu
+Ex
+EO
+EO
+EO
+Gl
+Gw
+GM
+GM
+Hs
+Gy
+HN
+HW
+HN
+Im
+It
+IH
+IH
+Ji
+Ji
+IH
+IH
+It
+JJ
+JR
+JY
+Ki
+Ks
+IR
+KG
+Iv
 aa
 aa
 aa
@@ -57756,49 +57740,49 @@ aa
 aa
 aa
 aa
-ge
-gf
-gl
-gl
-gl
-gA
-ge
-gf
-gl
-gl
-gl
-gA
-ge
-ge
-ge
-gV
-ge
-ge
-ge
-gp
-gp
-gp
-gp
-gp
-ge
-ge
-ge
-gV
-ge
-ge
-ge
-gf
-gl
-gl
-gl
-gA
-ge
-gf
-gl
-gl
-gl
-gA
-ge
+fZ
+ga
+gg
+gg
+gg
+gv
+fZ
+ga
+gg
+gg
+gg
+gv
+fZ
+fZ
+fZ
+gQ
+fZ
+fZ
+fZ
+gk
+gk
+gk
+gk
+gk
+fZ
+fZ
+fZ
+gQ
+fZ
+fZ
+fZ
+ga
+gg
+gg
+gg
+gv
+fZ
+ga
+gg
+gg
+gg
+gv
+fZ
 aa
 aa
 aa
@@ -57813,7 +57797,7 @@ aa
 aa
 aa
 aa
-it
+io
 aa
 aa
 aa
@@ -57826,71 +57810,71 @@ aa
 aa
 aa
 aa
-kM
-le
-kM
-lT
-mq
-mq
-mX
-ny
-nS
-mq
-mq
-pc
-pv
-qc
-pv
-rO
-mq
-iz
-ty
-ui
-ks
-ks
-sq
-iz
-mq
-mq
-pv
-xH
-pv
-ul
-mq
-mp
-mq
-ul
-zy
-zQ
-Ag
-AJ
-Ag
-BB
-BM
-Cc
-Cc
-Cc
-BM
-CZ
-Dj
-Db
-Dy
-DH
-DV
-DV
-Ex
-ED
-DV
-DV
-DH
-ER
-EX
-Ff
-Fl
-Fw
-FG
-Ef
-DJ
+lr
+lM
+lr
+mN
+nq
+nq
+nW
+ox
+oQ
+nq
+nq
+qt
+qT
+rI
+qT
+tM
+nq
+iu
+vL
+wE
+km
+km
+uv
+iu
+nq
+nq
+qT
+BE
+qT
+wH
+nq
+np
+nq
+wH
+Eg
+Ey
+EO
+Ft
+EO
+Gm
+Gx
+GN
+GN
+GN
+Gx
+HL
+HW
+HN
+Im
+It
+IH
+IH
+Jj
+Jq
+IH
+IH
+It
+JJ
+JS
+Kb
+Ki
+Kt
+KD
+IR
+Iv
 aa
 aa
 aa
@@ -58013,49 +57997,49 @@ aa
 aa
 aa
 aa
-ge
-gg
-gp
-gq
-gp
-gB
-go
-gg
-gp
-gq
-gp
-gB
-ge
-ge
-ge
-gV
-ge
-ge
-ge
-gp
-gm
-gm
-gm
-gp
-ge
-ge
-ge
-gV
-ge
-ge
-ge
-gg
-gm
-gq
-gm
-gB
-go
-gg
-gm
-gq
-gm
-gB
-ge
+fZ
+gb
+gk
+gl
+gk
+gw
+gj
+gb
+gk
+gl
+gk
+gw
+fZ
+fZ
+fZ
+gQ
+fZ
+fZ
+fZ
+gk
+gh
+gh
+gh
+gk
+fZ
+fZ
+fZ
+gQ
+fZ
+fZ
+fZ
+gb
+gh
+gl
+gh
+gw
+gj
+gb
+gh
+gl
+gh
+gw
+fZ
 aa
 aa
 aa
@@ -58070,7 +58054,7 @@ aa
 aa
 aa
 aa
-it
+io
 aa
 aa
 aa
@@ -58083,71 +58067,71 @@ aa
 aa
 aa
 aa
-it
-le
-iz
-lS
-mq
-mq
-mq
-mq
-mq
-mq
-mq
-pb
-lx
-qc
-iz
-rP
-mq
-iz
-tz
-uj
-ks
-mO
-vA
-ir
-mq
-uM
-lx
-xH
-iz
-yx
-mq
-mq
-mq
-zr
-iz
-zR
-Ag
-Ag
-Ag
-BA
-BN
-Cb
-Cb
-CF
-zH
-Db
-Dj
-Db
-Dy
-DH
-DV
-DV
-Ew
-Ew
-DV
-DV
-DH
-ER
-EY
-Fc
-Fl
-Fx
-Ef
-FE
-DJ
+io
+lM
+iu
+mM
+nq
+nq
+nq
+nq
+nq
+nq
+nq
+qs
+mk
+rI
+iu
+tN
+nq
+iu
+vM
+wF
+km
+nN
+yw
+im
+nq
+xo
+mk
+BE
+iu
+CK
+nq
+nq
+nq
+DW
+iu
+Ez
+EO
+EO
+EO
+Gl
+Gy
+GM
+GM
+Hs
+Ep
+HN
+HW
+HN
+Im
+It
+IH
+IH
+Ji
+Ji
+IH
+IH
+It
+JJ
+JT
+JY
+Ki
+Ku
+IR
+KG
+Iv
 aa
 aa
 aa
@@ -58270,49 +58254,49 @@ aa
 aa
 aa
 aa
-ge
-gg
-gq
-gq
-gq
-gB
-go
-gg
-gq
-gq
-gq
-gB
-gV
-gV
-gV
-gV
-gV
-gV
-ge
-gp
-ge
-gq
-ge
-gp
-ge
-gV
-gV
-gV
-gV
-gV
-gV
-gg
-gq
-gq
-gq
-gB
-go
-gg
-gq
-gq
-gq
-gB
-ge
+fZ
+gb
+gl
+gl
+gl
+gw
+gj
+gb
+gl
+gl
+gl
+gw
+gQ
+gQ
+gQ
+gQ
+gQ
+gQ
+fZ
+gk
+fZ
+gl
+fZ
+gk
+fZ
+gQ
+gQ
+gQ
+gQ
+gQ
+gQ
+gb
+gl
+gl
+gl
+gw
+gj
+gb
+gl
+gl
+gl
+gw
+fZ
 aa
 aa
 aa
@@ -58327,7 +58311,7 @@ aa
 aa
 aa
 aa
-it
+io
 aa
 aa
 aa
@@ -58340,71 +58324,71 @@ aa
 aa
 aa
 aa
-it
-it
-it
-lU
-mq
-mq
-mq
-mq
-mq
-mq
-mq
-pb
-is
-it
-is
-rP
-mq
-it
-tA
-lk
-kr
-vk
-vB
-iz
-mq
-wR
-is
-it
-is
-yy
-yG
-ul
-mp
-mX
-iz
-zS
-zQ
-AK
-Bd
-Bz
-zH
-zN
-zN
-zN
-zH
-Db
-Dj
-Db
-Dy
-DH
-DV
-DV
-DV
-DV
-DV
-DV
-DH
-ER
-EV
-Fe
-Fl
-Fg
-Ef
-FD
-DJ
+io
+io
+io
+mO
+nq
+nq
+nq
+nq
+nq
+nq
+nq
+qs
+in
+io
+in
+tN
+nq
+io
+vN
+ly
+kl
+xW
+yx
+iu
+nq
+Ao
+in
+io
+in
+CL
+CZ
+wH
+np
+nW
+iu
+EA
+Ey
+Fu
+FN
+Gk
+Ep
+Ev
+Ev
+Ev
+Ep
+HN
+HW
+HN
+Im
+It
+IH
+IH
+IH
+IH
+IH
+IH
+It
+JJ
+JQ
+Ka
+Ki
+Kc
+IR
+KA
+Iv
 aa
 aa
 aa
@@ -58527,49 +58511,49 @@ aa
 aa
 aa
 aa
-ge
-gg
-gp
-gp
-gp
+fZ
+gb
+gk
+gk
+gk
+gw
+gj
+gb
+gk
+gk
+gk
+gw
+fZ
+fZ
+fZ
+gQ
+fZ
 gB
-go
-gg
-gp
-gp
-gp
+fZ
+gk
+gh
+gh
+gh
+gk
+fZ
 gB
-ge
-ge
-ge
-gV
-ge
-gG
-ge
-gp
-gm
-gm
-gm
-gp
-ge
-gG
-ge
-gV
-ge
-ge
-ge
-gg
-gm
-gm
-gm
-gB
-go
-gg
-gm
-gm
-gm
-gB
-ge
+fZ
+gQ
+fZ
+fZ
+fZ
+gb
+gh
+gh
+gh
+gw
+gj
+gb
+gh
+gh
+gh
+gw
+fZ
 aa
 aa
 aa
@@ -58584,7 +58568,7 @@ aa
 aa
 aa
 aa
-it
+io
 aa
 aa
 aa
@@ -58597,71 +58581,71 @@ aa
 aa
 aa
 aa
-it
-lf
-iz
-lV
-mr
-mM
-mY
-nz
-mY
-mM
-mr
-pd
-it
-Ku
-iz
-rP
-mq
-iz
-qf
-iH
-uL
-vl
-mS
-iz
-mq
-uM
-iz
-lW
-it
-it
-iz
-yQ
-zd
-iz
-is
-zN
-Af
-zN
-Bb
-Bf
-zH
-Cd
-Ct
-CG
-zH
-Db
-Dj
-Db
-Dy
-DH
-DV
-DV
-DV
-DV
-DV
-DV
-DH
-ER
-EV
-Fe
-Fl
-Fy
-DJ
-Ef
-DJ
+io
+lN
+iu
+mP
+nr
+nL
+nX
+oy
+nX
+nL
+nr
+qu
+io
+rJ
+iu
+tN
+nq
+iu
+rN
+iC
+xn
+xX
+nw
+iu
+nq
+xo
+iu
+mQ
+io
+io
+iu
+Du
+DI
+iu
+in
+Ev
+EN
+Ev
+FL
+FP
+Ep
+GO
+He
+Ht
+Ep
+HN
+HW
+HN
+Im
+It
+IH
+IH
+IH
+IH
+IH
+IH
+It
+JJ
+JQ
+Ka
+Ki
+Kv
+Iv
+IR
+Iv
 aa
 aa
 aa
@@ -58784,49 +58768,49 @@ aa
 aa
 aa
 aa
-ge
-gh
-gn
-gn
-gn
-gC
-ge
-gh
-gn
-gn
-gn
-gC
-ge
-ge
-ge
-gV
-gG
-gG
-gG
-gp
-gp
-gp
-gp
-gp
-gG
-gG
-gG
-gV
-ge
-ge
-ge
-gh
-gn
-gn
-gn
-gC
-ge
-gh
-gn
-gn
-gn
-gC
-ge
+fZ
+gc
+gi
+gi
+gi
+gx
+fZ
+gc
+gi
+gi
+gi
+gx
+fZ
+fZ
+fZ
+gQ
+gB
+gB
+gB
+gk
+gk
+gk
+gk
+gk
+gB
+gB
+gB
+gQ
+fZ
+fZ
+fZ
+gc
+gi
+gi
+gi
+gx
+fZ
+gc
+gi
+gi
+gi
+gx
+fZ
 aa
 aa
 aa
@@ -58838,87 +58822,87 @@ aa
 aa
 aa
 aa
-iq
-iq
-iq
-iq
-iq
-iq
-iq
-iq
-iq
-iq
-iq
-iq
-iq
-iq
-iq
-iq
-iq
-iq
-iq
-iz
-it
-iz
-jc
-lx
-jc
-iz
-it
-iz
-it
-iz
-it
-rN
-rN
-iz
-iz
-ug
-iz
-iz
-iz
-is
-rN
-rN
-it
-iz
-it
-yz
-yH
-yR
-ze
-vi
-ir
-zM
-Ah
-AH
-Bb
-BC
-zH
-zN
-zN
-zN
-zH
-Dc
-Dj
-Dp
-Dy
-DH
-DW
-DW
-DW
-DW
-DW
-DW
-DH
-ER
-EW
-Fc
-Fl
-Fz
-Ef
-FE
+il
+il
+il
+il
+il
+il
+il
+il
+il
+il
+il
+il
+il
+il
+il
+il
+il
+il
+il
+iu
+io
+iu
+ja
+mk
+ja
+iu
+io
+iu
+io
+iu
+io
+tL
+tL
+iu
+iu
+wC
+iu
+iu
+iu
+in
+tL
+tL
+io
+iu
+io
+CM
+Da
+Dv
 DJ
+xU
+im
+Eu
+EP
+Fr
+FL
+Gn
+Ep
+Ev
+Ev
+Ev
+Ep
+HO
+HW
+Id
+Im
+It
+II
+II
+II
+II
+II
+II
+It
+JJ
+JR
+JY
+Ki
+Kw
+IR
+KG
+Iv
 aa
 aa
 aa
@@ -59041,49 +59025,49 @@ aa
 aa
 aa
 aa
-ge
-ge
-gr
-gr
-gr
-ge
-ge
-ge
-gO
-gO
-gO
-ge
-ge
-ge
-ge
-gV
-ge
-gG
-ge
-ge
-gp
-gp
-gp
-ge
-ge
-gG
-ge
-gV
-ge
-ge
-ge
-ge
-ge
-gU
-ge
-ge
-ge
-ge
+fZ
+fZ
 gm
 gm
 gm
-ge
-ge
+fZ
+fZ
+fZ
+gJ
+gJ
+gJ
+fZ
+fZ
+fZ
+fZ
+gQ
+fZ
+gB
+fZ
+fZ
+gk
+gk
+gk
+fZ
+fZ
+gB
+fZ
+gQ
+fZ
+fZ
+fZ
+fZ
+fZ
+gP
+fZ
+fZ
+fZ
+fZ
+gh
+gh
+gh
+fZ
+fZ
 aa
 aa
 aa
@@ -59095,87 +59079,87 @@ aa
 aa
 aa
 aa
+il
 iq
-iv
-iF
-iM
-iv
-iF
-iM
-iv
-iF
-iM
-iv
-iF
-iM
-iv
-iF
-iM
-iv
-iF
+iA
+iH
 iq
-lW
-it
-mN
-mN
-mN
-mN
-mN
-it
-lW
-iz
-pw
-iz
-rP
-mq
-lX
-mq
-mp
-mq
-mq
-mq
-lX
-mq
-wt
-kT
-qP
-kT
-lk
-jB
-jB
-jB
-zs
-it
-zL
-Ai
-zN
-AL
-BD
-zH
-Ce
-BZ
-Ce
-zH
-Da
-Dj
-Db
-Dy
-DI
-DT
-DT
-DT
-DT
-DT
-DT
-DI
-ER
-EV
-Fe
-Fl
-FA
-Ef
-FD
-DJ
+iA
+iH
+iq
+iA
+iH
+iq
+iA
+iH
+iq
+iA
+iH
+iq
+iA
+il
+mQ
+io
+nM
+nM
+nM
+nM
+nM
+io
+mQ
+iu
+rK
+iu
+tN
+nq
+mR
+nq
+np
+nq
+nq
+nq
+mR
+nq
+zG
+kZ
+ut
+kZ
+ly
+jA
+jA
+jA
+DX
+io
+Et
+EQ
+Ev
+Fv
+Go
+Ep
+GP
+GK
+GP
+Ep
+HM
+HW
+HN
+Im
+Iu
+IF
+IF
+IF
+IF
+IF
+IF
+Iu
+JJ
+JQ
+Ka
+Ki
+Kx
+IR
+KA
+Iv
 aa
 aa
 aa
@@ -59298,49 +59282,49 @@ aa
 aa
 aa
 aa
-ge
-ge
-gr
-gr
-gr
-gm
-gH
-gI
-gP
-gT
-gX
-hb
-ge
-ge
-ge
+fZ
+fZ
 gm
 gm
 gm
+gh
+gC
+gD
+gK
+gO
+gS
+gW
+fZ
+fZ
+fZ
+gh
+gh
+gh
+gh
+gh
+gh
+gh
+gh
+gh
+gh
+gh
+gh
+gh
+fZ
+fZ
+fZ
+fZ
+fZ
+gQ
+fZ
+fZ
+fZ
+fZ
 gm
 gm
 gm
-gm
-gm
-gm
-gm
-gm
-gm
-gm
-ge
-ge
-ge
-ge
-ge
-gV
-ge
-ge
-ge
-ge
-gr
-gr
-gr
-ge
-ge
+fZ
+fZ
 aa
 aa
 aa
@@ -59352,87 +59336,87 @@ aa
 aa
 aa
 aa
-iq
-iw
-iG
-iN
-iw
-iG
-iq
-iw
-iG
-iq
-iw
-iG
-iq
-iw
-iG
-iN
-iw
-iG
-iq
-is
+il
 ir
-iz
-jc
-lx
-jc
-iz
-it
-it
-it
-it
-it
-rQ
-rP
-lX
-tB
-rP
-uM
-uM
-vC
-lX
-wt
-wS
-xm
-iz
-it
-yA
-yI
-lA
-zf
-zt
-it
-zH
-Ac
-zH
-Ba
-zH
-zH
-zH
-zH
-zH
-zH
+iB
+iI
+ir
+iB
+il
+ir
+iB
+il
+ir
+iB
+il
+ir
+iB
+iI
+ir
+iB
+il
+in
+im
+iu
+ja
+mk
+ja
+iu
+io
+io
+io
+io
+io
+tO
+tN
+mR
+vO
+tN
+xo
+xo
+yy
+mR
+zG
+Ap
+AT
+iu
+io
+CN
 Db
-Dj
-Db
-Dy
-DH
-DH
-DH
-DH
-DH
-DH
-DH
-DH
-ER
-EV
-Fe
-Fl
-FB
-FF
-DJ
-DJ
+lS
+ns
+DY
+io
+Ep
+EK
+Ep
+FK
+Ep
+Ep
+Ep
+Ep
+Ep
+Ep
+HN
+HW
+HN
+Im
+It
+It
+It
+It
+It
+It
+It
+It
+JJ
+JQ
+Ka
+Ki
+Ky
+KC
+Iv
+Iv
 aa
 aa
 aa
@@ -59555,49 +59539,49 @@ aa
 aa
 aa
 aa
-ge
-ge
-gr
-gr
-gr
-gm
-gH
-gJ
-gp
-gn
-gp
-hc
-gK
+fZ
+fZ
 gm
 gm
 gm
+gh
+gC
+gE
+gk
+gi
+gk
+gX
+gF
+gh
+gh
+gh
+gh
+gh
+gh
+gh
+gh
+gh
+gh
+gh
+gh
+gh
+gh
+gh
+gh
+gh
+gB
+gB
+gB
+gQ
+fZ
+fZ
+fZ
+fZ
 gm
 gm
 gm
-gm
-gm
-gm
-gm
-gm
-gm
-gm
-gm
-gm
-gm
-gm
-gG
-gG
-gG
-gV
-ge
-ge
-ge
-ge
-gr
-gr
-gr
-ge
-ge
+fZ
+fZ
 aa
 aa
 aa
@@ -59609,85 +59593,85 @@ aa
 aa
 aa
 aa
-ir
-ix
-iH
-JW
-iV
-iV
-jh
-iV
-iV
-jA
-iV
-iV
-jS
-iV
-iV
-Kb
-kN
-iH
-kT
-lX
-Ke
-iO
-iV
-iV
-iV
-kN
-iz
-lf
-it
-it
-it
-rR
-lB
-it
-ir
-jc
-lx
-jc
-ir
-it
-iz
-iz
-it
-pw
-it
-iz
-ir
-iH
+im
+is
+iC
+iJ
+iT
+iT
+jg
+iT
+iT
+jz
+iT
+iT
+jR
+iT
+iT
+kS
+ls
+iC
+kZ
+mR
+kW
+iL
+iT
+iT
+iT
+ls
 iu
-iz
-it
-zJ
-Aj
-AL
-AF
-BE
-zH
-Cf
-Cu
-CH
-BM
-CZ
-Dj
-Dj
-Dz
-DG
-DX
-Em
-Ey
-Ey
-EF
-DX
-DG
-ES
-EU
-Fg
-Fc
-Fq
-DJ
+lN
+io
+io
+io
+tP
+lT
+io
+im
+ja
+mk
+ja
+im
+io
+iu
+iu
+io
+rK
+io
+iu
+im
+iC
+ip
+iu
+io
+Er
+ER
+Fv
+Fp
+Gp
+Ep
+GQ
+Hf
+Hu
+Gx
+HL
+HW
+HW
+In
+Is
+IJ
+IY
+Jk
+Jk
+Jt
+IJ
+Is
+JK
+JP
+Kc
+JY
+Kn
+Iv
 aa
 aa
 aa
@@ -59812,49 +59796,49 @@ aa
 aa
 aa
 aa
-ge
-ge
-gr
-gr
-gr
+fZ
+fZ
 gm
-gH
-gK
+gm
+gm
+gh
+gC
+gF
+gL
+gk
+gT
+gC
+fZ
+go
+fZ
+gh
+gh
+gh
+fZ
+fZ
+gB
+gB
+gB
+fZ
+fZ
+gh
+gh
+gh
+fZ
+go
+fZ
+fZ
+fZ
 gQ
-gp
-gY
-gH
-ge
-gt
-ge
+fZ
+fZ
+fZ
+fZ
 gm
 gm
 gm
-ge
-ge
-gG
-gG
-gG
-ge
-ge
-gm
-gm
-gm
-ge
-gt
-ge
-ge
-ge
-gV
-ge
-ge
-ge
-ge
-gr
-gr
-gr
-ge
-ge
+fZ
+fZ
 aa
 aa
 aa
@@ -59866,85 +59850,85 @@ aa
 aa
 aa
 aa
-is
-iy
-iH
-iP
-iW
-iW
-iW
-iW
-jw
-iH
+in
+it
+iC
+iK
+iU
+iU
+iU
+iU
+jv
+iC
+jF
+iU
+iU
+iU
+iU
+iU
+lt
+iC
+kZ
+mR
+iC
+iK
+iU
+iU
+jv
 jG
-iW
-iW
-iW
-iW
-iW
-kO
-iH
-kT
-lX
-iH
-iP
-iW
-iW
-jw
-jH
-iz
-pe
-it
-it
-pw
-iz
-qP
-it
-tC
-tC
-tC
-tC
-tC
-it
-pw
-lW
-it
-it
-it
-ld
-iz
-iH
-iz
-pe
-iz
-zK
-Ak
-AM
-Be
-Bv
-Ac
-Cg
-Cu
-CI
-BN
-Dd
-Dd
-Do
-zH
-zH
-DY
-DY
-DY
-DY
-DY
-DY
-DJ
-DJ
-DJ
-DJ
-Fk
-DJ
-DJ
+iu
+qv
+io
+io
+rK
+iu
+ut
+io
+vP
+vP
+vP
+vP
+vP
+io
+rK
+mQ
+io
+io
+io
+lL
+iu
+iC
+iu
+qv
+iu
+Es
+ES
+Fw
+FO
+Gg
+EK
+GR
+Hf
+Hv
+Gy
+HP
+HP
+Ic
+Ep
+Ep
+IK
+IK
+IK
+IK
+IK
+IK
+Iv
+Iv
+Iv
+Iv
+Kh
+Iv
+Iv
 aa
 aa
 aa
@@ -60069,49 +60053,49 @@ aa
 aa
 aa
 aa
-ge
-ge
-gr
-gr
-gr
-ge
-ge
-gK
+fZ
+fZ
 gm
 gm
 gm
-gH
-ge
-gt
-gG
-gm
-ho
-gm
-gp
+fZ
+fZ
+gF
+gh
+gh
+gh
+gC
+fZ
 go
-gp
+gB
+gh
+hj
+gh
+gk
+gj
+gk
+gj
+gk
+gj
+gk
+gh
+hj
+gh
+gB
 go
-gp
-go
-gp
+fZ
+fZ
+fZ
+gQ
+fZ
+fZ
+fZ
+fZ
 gm
-ho
 gm
-gG
-gt
-ge
-ge
-ge
-gV
-ge
-ge
-ge
-ge
-gr
-gr
-gr
-ge
-ge
+gm
+fZ
+fZ
 aa
 aa
 aa
@@ -60123,86 +60107,86 @@ aa
 aa
 aa
 aa
-it
-iz
-iz
-ir
-iz
-jc
-iz
-iz
-jx
-jB
-jH
-iz
-iz
-jc
-iz
-ir
-iz
-iz
-it
-iz
-jc
-iz
-iz
-iz
-jx
-Km
-ir
-iz
-it
-it
-iz
-ir
-lB
-it
-ir
-jc
-lx
-jc
-ir
-it
-iz
-iz
+io
 iu
-ir
-it
-it
-it
-lB
-it
-it
-it
-zH
-zN
-zH
-AX
-BF
-zH
-Ch
-Cu
-Cu
-CR
-Cu
-Cu
-Cu
-DA
-zH
-DZ
-En
-En
-En
-En
-EJ
-EN
-ET
-DJ
-Fc
-Fc
-DJ
-DJ
-DJ
+iu
+im
+iu
+ja
+iu
+iu
+jw
+jA
+jG
+iu
+iu
+ja
+iu
+im
+iu
+iu
+io
+iu
+ja
+iu
+iu
+iu
+jw
+pm
+im
+iu
+io
+io
+iu
+im
+lT
+io
+im
+ja
+mk
+ja
+im
+io
+iu
+iu
+ip
+im
+io
+io
+io
+lT
+io
+io
+io
+Ep
+Ev
+Ep
+FH
+Gq
+Ep
+GS
+Hf
+Hf
+HD
+Hf
+Hf
+Hf
+Io
+Ep
+IL
+IZ
+IZ
+IZ
+IZ
+Jx
+JE
+JL
+Iv
+JY
+JY
+Iv
+Iv
+Iv
 aa
 aa
 aa
@@ -60326,49 +60310,49 @@ aa
 aa
 aa
 aa
-ge
-ge
-gs
-gr
-gs
-ge
-ge
-gL
-gR
+fZ
+fZ
+gn
 gm
-gZ
-hd
-ge
-gt
+gn
+fZ
+fZ
 gG
-gm
-ho
-gm
+gM
+gh
+gU
+gY
+fZ
 go
-gp
+gB
+gh
+hj
+gh
+gj
+gk
+gj
+gk
+gj
+gk
+gj
+gh
+hj
+gh
+gB
 go
-gp
-go
-gp
-go
-gm
-ho
-gm
-gG
-gt
-gG
+gB
+gI
 gN
-gS
+gQ
 gV
 ha
-hf
-ge
-ge
-gs
-gr
-gs
-ge
-ge
+fZ
+fZ
+gn
+gm
+gn
+fZ
+fZ
 aa
 aa
 aa
@@ -60380,86 +60364,86 @@ aa
 aa
 aa
 aa
-it
-iA
-iI
-iI
-iX
-iH
-ji
-iz
-jx
-jB
-jH
-iz
-jT
-iH
-ko
-kv
-kP
-lg
-ir
-lY
-iH
-mO
-mZ
-iz
-jx
-jH
-iz
-pe
-iz
-qd
-qO
-iH
-sp
-it
-tD
-uk
-uN
-uk
-pa
-ir
-wu
-wT
-xn
-xI
-iz
-ld
-iz
-iH
-it
-pf
-ld
+io
+iv
+iD
+iD
+iV
+iC
+jh
+iu
+jw
+jA
+jG
+iu
+jS
+iC
+kx
+kT
+lu
+lO
+im
+mS
+iC
+nN
+nY
+iu
+jw
+jG
+iu
+qv
+iu
+rL
+sK
+iC
+uu
+io
+vQ
+wG
+xp
+wG
+qr
+im
 zH
-Al
-zN
-Bf
-Bb
-Ac
-Ci
-Cu
-Cu
-Cu
-Cu
-Cu
-Cu
-DB
-zH
-Ea
-Eo
+Aq
+AU
+BF
+iu
+lL
+iu
+iC
+io
+qw
+lL
 Ep
-Ep
-Eo
-EK
-EN
 ET
-DJ
-EO
-EO
-Ef
-FD
-DJ
+Ev
+FP
+FL
+EK
+GT
+Hf
+Hf
+Hf
+Hf
+Hf
+Hf
+Ip
+Ep
+IM
+Ja
+Jb
+Jb
+Ja
+Jy
+JE
+JL
+Iv
+JG
+JG
+IR
+KA
+Iv
 aa
 aa
 aa
@@ -60583,49 +60567,49 @@ aa
 aa
 aa
 aa
-ge
-ge
-gs
-gr
-gs
-ge
-ge
-gJ
-gp
+fZ
+fZ
 gn
-gp
-hc
-ge
-gt
-gG
 gm
-ho
-gm
-gp
+gn
+fZ
+fZ
+gE
+gk
+gi
+gk
+gX
+fZ
 go
-gp
+gB
+gh
+hj
+gh
+gk
+gj
+gk
+gj
+gk
+gj
+gk
+gh
+hj
+gh
+gB
 go
-gp
-go
-gp
+fZ
+fZ
+fZ
+gQ
+fZ
+fZ
+fZ
+fZ
+gn
 gm
-ho
-gm
-gG
-gt
-ge
-ge
-ge
-gV
-ge
-ge
-ge
-ge
-gs
-gr
-gs
-ge
-ge
+gn
+fZ
+fZ
 aa
 aa
 aa
@@ -60637,86 +60621,86 @@ aa
 aa
 aa
 aa
+ip
+iw
+iC
+iC
+iC
+iC
+ji
+im
+jw
+jA
+jG
+im
+jT
+iC
+iC
+iC
+iC
+iC
+kZ
+ly
+jA
+km
+nZ
+im
+jw
+jG
 iu
-iB
-iH
-iH
-iH
-iH
-jj
-ir
-jx
-jB
-jH
-ir
-jU
-iH
-iH
-iH
-iH
-iH
-kT
-lk
-jB
-ks
-na
-ir
-jx
-jH
-iz
-lf
-iz
-qe
-qO
-mv
-mS
-sU
-lU
-mq
-mq
-mq
-pb
-sU
-wv
-mq
-wU
-xJ
-iz
-pf
-iz
-jB
-it
-iz
-iz
-zH
-Am
-zN
-AX
-BF
-zH
-Cj
-Cb
-CJ
-CS
-De
-Dk
-Dq
-DC
-zH
-Ea
+lN
+iu
+rM
+sK
+mX
+nw
+vc
+mO
+nq
+nq
+nq
+qs
+vc
+zI
+nq
+Ar
+BG
+iu
+qw
+iu
+jA
+io
+iu
+iu
 Ep
-Ez
+EU
+Ev
+FH
+Gq
 Ep
+GU
+GM
+Hw
+HE
+HQ
+HX
+Ie
+Iq
 Ep
-EK
-EN
-ET
-DJ
-EO
-EO
-Ef
-Lu
-DJ
+IM
+Jb
+Jl
+Jb
+Jb
+Jy
+JE
+JL
+Iv
+JG
+JG
+IR
+KB
+Iv
 aa
 aa
 aa
@@ -60840,49 +60824,49 @@ aa
 aa
 aa
 aa
-ge
-ge
-gr
-gr
-gr
-ge
-ge
-gK
+fZ
+fZ
+gm
+gm
+gm
+fZ
+fZ
+gF
+gL
+gk
+gT
+gC
+fZ
+go
+fZ
+gh
+hj
+gh
+fZ
+gl
+hj
+hj
+hj
+gl
+fZ
+gh
+hj
+gh
+fZ
+go
+gB
+gB
+gB
 gQ
-gp
-gY
-gH
-ge
-gt
-ge
+fZ
+fZ
+fZ
+fZ
 gm
-ho
 gm
-ge
-gq
-ho
-ho
-ho
-gq
-ge
 gm
-ho
-gm
-ge
-gt
-gG
-gG
-gG
-gV
-ge
-ge
-ge
-ge
-gr
-gr
-gr
-ge
-ge
+fZ
+fZ
 aa
 aa
 aa
@@ -60894,86 +60878,86 @@ aa
 aa
 aa
 aa
-it
+io
+ix
+iE
+iE
+iW
 iC
-iJ
-iJ
-iY
-iH
-ji
-iz
-jx
-jB
-jH
-iz
-jV
-iH
-kp
-kw
-kQ
-lh
-ir
-lZ
-iH
-mO
-nb
-iz
-jx
-jH
-iz
-pe
-iz
-qf
-qO
-mb
-sq
-iz
-tE
-mq
-mq
-mq
-vD
-iz
-wv
-wU
-mq
-xK
-iz
-pe
-iz
-jB
-it
-Ld
-iH
-zH
-zN
-zH
-Bf
-Lk
-zH
-zH
-Ba
-zH
-zH
-Ac
-zH
-Ac
-zH
-zH
-Ea
-Eo
+jh
+iu
+jw
+jA
+jG
+iu
+jU
+iC
+ky
+kU
+lv
+lP
+im
+mT
+iC
+nN
+oa
+iu
+jw
+jG
+iu
+qv
+iu
+rN
+sK
+mm
+uv
+iu
+vR
+nq
+nq
+nq
+yz
+iu
+zI
+Ar
+nq
+BH
+iu
+qv
+iu
+jA
+io
+Dw
+iC
+Ep
+Ev
+Ep
+FP
+Gf
 Ep
 Ep
-Eo
+FK
+Ep
+Ep
 EK
-EN
-ET
-DJ
-EO
-EO
-Ef
-FD
-DJ
+Ep
+EK
+Ep
+Ep
+IM
+Ja
+Jb
+Jb
+Ja
+Jy
+JE
+JL
+Iv
+JG
+JG
+IR
+KA
+Iv
 aa
 aa
 aa
@@ -61097,49 +61081,49 @@ aa
 aa
 aa
 aa
-ge
-ge
-gr
-gr
-gr
-gm
-gH
-gK
+fZ
+fZ
 gm
 gm
 gm
-gH
-gq
-gt
-gq
+gh
+gC
+gF
+gh
+gh
+gh
+gC
+gl
+go
+gl
+gh
+hj
+gh
+gB
+hj
+hj
+hj
+hj
+hj
+gB
+gh
+hj
+gh
+gl
+go
+fZ
+fZ
+fZ
+gQ
+fZ
+fZ
+fZ
+fZ
 gm
-ho
 gm
-gG
-ho
-ho
-ho
-ho
-ho
-gG
 gm
-ho
-gm
-gq
-gt
-ge
-ge
-ge
-gV
-ge
-ge
-ge
-ge
-gr
-gr
-gr
-ge
-ge
+fZ
+fZ
 aa
 aa
 aa
@@ -61151,86 +61135,86 @@ aa
 aa
 aa
 aa
-it
-iz
-iz
-ir
-iz
-jc
-iz
-iz
-jx
-jB
-jH
-iz
-iz
-jc
-iz
-ir
-iz
-iz
-it
-iz
-jc
-iz
-iz
-iz
-jx
-Km
-ir
-iz
-ir
-qg
-qO
-jB
-sr
-sV
-tF
-ul
-mq
-mq
-mp
-wc
-ww
-mq
-wU
-xL
-it
-iz
-it
-Ld
-kT
-jB
-jB
-zT
-zX
-zT
-AX
-BF
-BK
-Ck
-AF
-AL
-AF
-AL
-AF
-AL
-Bd
-zH
-Eb
-Eq
-Eq
-Eq
-Eq
-EL
-EN
-ET
-DJ
-EO
-EO
-DJ
-DJ
-DJ
+io
+iu
+iu
+im
+iu
+ja
+iu
+iu
+jw
+jA
+jG
+iu
+iu
+ja
+iu
+im
+iu
+iu
+io
+iu
+ja
+iu
+iu
+iu
+jw
+pm
+im
+iu
+im
+rO
+sK
+jA
+uw
+vd
+vS
+wH
+nq
+nq
+np
+zk
+zJ
+nq
+Ar
+BI
+io
+iu
+io
+Dw
+kZ
+jA
+jA
+EB
+EF
+EB
+FH
+Gq
+Gv
+GV
+Fp
+Fv
+Fp
+Fv
+Fp
+Fv
+FN
+Ep
+IN
+Jc
+Jc
+Jc
+Jc
+Jz
+JE
+JL
+Iv
+JG
+JG
+Iv
+Iv
+Iv
 aa
 aa
 aa
@@ -61354,49 +61338,49 @@ aa
 aa
 aa
 aa
-ge
-ge
-gr
-gr
-gr
+fZ
+fZ
 gm
-gH
-gL
-gR
 gm
-gZ
-hd
-gq
-gt
-gq
 gm
-ho
-gm
+gh
+gC
 gG
-ho
-ho
-gq
-ho
-ho
-gG
-gm
-ho
-gm
-gq
-gt
-gG
+gM
+gh
+gU
+gY
+gl
+go
+gl
+gh
+hj
+gh
+gB
+hj
+hj
+gl
+hj
+hj
+gB
+gh
+hj
+gh
+gl
+go
+gB
+gI
 gN
-gS
+gQ
 gV
 ha
-hf
-ge
-ge
-gr
-gr
-gr
-ge
-ge
+fZ
+fZ
+gm
+gm
+gm
+fZ
+fZ
 aa
 aa
 aa
@@ -61408,84 +61392,84 @@ aa
 aa
 aa
 aa
-is
-iD
-iH
-iO
-iV
-iV
-iV
-iV
-jy
-iH
-jI
-iV
-iV
-iV
-iV
-iV
-kN
-iH
-kT
-lX
-iH
-iO
-iV
-iV
-jy
+in
+iy
+iC
+iL
+iT
+iT
+iT
+iT
+jx
+iC
 jH
-iz
-pf
-iz
-qh
-qO
-rS
-ss
-iz
-tE
-mq
-mq
-mq
-vD
-iz
-ww
-wU
-mq
-xM
-iz
-lf
-iz
-jB
-it
-iH
-iH
-zH
-Lj
-zH
-Bg
-Bc
-BK
-Ab
-Cv
-AM
-Cv
-AM
-Ln
-Dr
-BF
-zH
-Ec
-Ec
-Ec
-Ec
-Ec
-Ec
-DJ
-DJ
-DJ
-Fb
-Fb
-DJ
+iT
+iT
+iT
+iT
+iT
+ls
+iC
+kZ
+mR
+iC
+iL
+iT
+iT
+jx
+jG
+iu
+qw
+iu
+rP
+sK
+tQ
+ux
+iu
+vR
+nq
+nq
+nq
+yz
+iu
+zJ
+Ar
+nq
+BJ
+iu
+lN
+iu
+jA
+io
+iC
+iC
+Ep
+EV
+Ep
+FQ
+FM
+Gv
+EJ
+Hg
+Fw
+Hg
+Fw
+HY
+If
+Gq
+Ep
+IO
+IO
+IO
+IO
+IO
+IO
+Iv
+Iv
+Iv
+JX
+JX
+Iv
 aa
 aa
 aa
@@ -61611,49 +61595,49 @@ aa
 aa
 aa
 aa
-ge
-ge
-gr
-gr
-gr
+fZ
+fZ
 gm
-gH
-gJ
-gp
-gn
-gp
-hc
-gq
-gt
-gq
 gm
-ho
 gm
-gG
-ho
-ho
-ho
-ho
-ho
-gG
+gh
+gC
+gE
+gk
+gi
+gk
+gX
+gl
+go
+gl
+gh
+hj
+gh
+gB
+hj
+hj
+hj
+hj
+hj
+gB
+gh
+hj
+gh
+gl
+go
+fZ
+fZ
+fZ
+gQ
+fZ
+fZ
+fZ
+fZ
 gm
-ho
 gm
-gq
-gt
-ge
-ge
-ge
-gV
-ge
-ge
-ge
-ge
-gr
-gr
-gr
-ge
-ge
+gm
+fZ
+fZ
 aa
 aa
 aa
@@ -61665,84 +61649,84 @@ aa
 aa
 aa
 aa
-ir
-iE
-iH
-JX
-iW
-iW
-jk
-iW
-iW
-jC
-iW
-iW
-jW
-iW
-iW
-Kc
-kO
-iH
-kT
-lX
-zf
-iP
-iW
-iW
-iW
-kO
+im
 iz
-ld
-iz
-qi
-qO
+iC
+iM
+iU
+iU
+jj
+iU
+iU
 jB
-sr
-sV
-tF
-ul
-mq
-mq
-mp
-wc
-ww
-mq
-wU
-xN
-iz
-ld
-iz
-jB
-it
-it
-it
-zH
-zH
-zH
-zH
-zH
-zH
-zH
-zH
-zH
-zH
-zH
-zH
-Bf
-Bb
-zH
-Ed
-Ed
-Ed
-Ed
-Ed
-Ed
-DJ
-EO
-Lt
-EO
-EO
-DJ
+iU
+iU
+jV
+iU
+iU
+kV
+lt
+iC
+kZ
+mR
+ns
+iK
+iU
+iU
+iU
+lt
+iu
+lL
+iu
+rQ
+sK
+jA
+uw
+vd
+vS
+wH
+nq
+nq
+np
+zk
+zJ
+nq
+Ar
+BK
+iu
+lL
+iu
+jA
+io
+io
+io
+Ep
+Ep
+Ep
+Ep
+Ep
+Ep
+Ep
+Ep
+Ep
+Ep
+Ep
+Ep
+FP
+FL
+Ep
+IP
+IP
+IP
+IP
+IP
+IP
+Iv
+JG
+JU
+JG
+JG
+Iv
 aa
 aa
 aa
@@ -61868,49 +61852,49 @@ aa
 aa
 aa
 aa
-ge
-ge
-gr
-gr
-gr
-ge
-ge
-gK
+fZ
+fZ
+gm
+gm
+gm
+fZ
+fZ
+gF
+gL
+gk
+gT
+gC
+fZ
+go
+fZ
+gh
+hj
+gh
+fZ
+gl
+hj
+hj
+hj
+gl
+fZ
+gh
+hj
+gh
+fZ
+go
+gB
+gB
+gB
 gQ
-gp
-gY
-gH
-ge
-gt
-ge
+fZ
+fZ
+fZ
+fZ
 gm
-ho
 gm
-ge
-gq
-ho
-ho
-ho
-gq
-ge
 gm
-ho
-gm
-ge
-gt
-gG
-gG
-gG
-gV
-ge
-ge
-ge
-ge
-gr
-gr
-gr
-ge
-ge
+fZ
+fZ
 aa
 aa
 aa
@@ -61922,84 +61906,84 @@ aa
 aa
 aa
 aa
-iq
-iw
-iG
-iN
-iw
-iG
-iq
-iw
-iG
-iq
-iw
-iG
-iq
-iw
-iG
-iN
-iw
-iG
-iq
-is
+il
 ir
-iz
-jc
-lx
-jc
-iz
-it
-it
-it
-qj
-iH
-mb
-st
-iz
-tG
-um
-uO
-um
-vE
-iz
-wx
-wV
-ww
-xO
-iz
-lf
-iz
-iH
-it
+iB
+iI
+ir
+iB
+il
+ir
+iB
+il
+ir
+iB
+il
+ir
+iB
+iI
+ir
+iB
+il
+in
+im
+iu
+ja
+mk
+ja
+iu
+io
+io
+io
+rR
+iC
+mm
+uy
+iu
+vT
+wI
+xq
+wI
+yA
+iu
+zK
+As
+zJ
+BL
+iu
+lN
+iu
+iC
+io
 aa
 aa
 aa
-zH
-AN
-Bh
-Br
-zH
-BS
-BS
-BS
-BS
-BS
-zH
-AX
-BF
-zH
-DJ
-DJ
-DJ
-DJ
-DJ
-DJ
-DJ
-EO
-EO
-EO
-EO
-DJ
+Ep
+Fx
+FR
+Gb
+Ep
+GD
+GD
+GD
+GD
+GD
+Ep
+FH
+Gq
+Ep
+Iv
+Iv
+Iv
+Iv
+Iv
+Iv
+Iv
+JG
+JG
+JG
+JG
+Iv
 aa
 aa
 aa
@@ -62125,49 +62109,49 @@ aa
 aa
 aa
 aa
-ge
-ge
-gr
-gr
-gr
-ge
-ge
-gK
+fZ
+fZ
 gm
 gm
 gm
-gH
-ge
-gt
-gG
-gm
-ho
-gm
-gp
+fZ
+fZ
+gF
+gh
+gh
+gh
+gC
+fZ
 go
-gp
+gB
+gh
+hj
+gh
+gk
+gj
+gk
+gj
+gk
+gj
+gk
+gh
+hj
+gh
+gB
 go
-gp
-go
-gp
+fZ
+fZ
+fZ
+gQ
+fZ
+fZ
+fZ
+fZ
 gm
-ho
 gm
-gG
-gt
-ge
-ge
-ge
-gV
-ge
-ge
-ge
-ge
-gr
-gr
-gr
-ge
-ge
+gm
+fZ
+fZ
 aa
 aa
 aa
@@ -62179,84 +62163,84 @@ aa
 aa
 aa
 aa
+il
 iq
-iv
-iF
-iM
-iv
-iF
-iM
-iv
-iF
-iM
-iv
-iF
-iM
-iv
-iF
-iM
-iv
-iF
+iA
+iH
 iq
-ms
-mP
-oj
+iA
 iH
-kq
+iq
+iA
 iH
-ox
-it
-qk
-qk
-qk
-qQ
-LZ
-qk
-it
-ir
-jc
-lx
-jc
-ir
-it
-it
-it
-lB
-it
-it
-iz
-it
-lB
-it
+iq
+iA
+iH
+iq
+iA
+iH
+iq
+iA
+il
+mU
+nt
+nO
+iC
+kk
+iC
+pn
+io
+qx
+qx
+qx
+sL
+tR
+qx
+io
+im
+ja
+mk
+ja
+im
+io
+io
+io
+lT
+io
+io
+iu
+io
+lT
+io
 aa
 aa
 aa
-zH
-AO
-AU
-Bs
-BJ
-Bs
-Bs
-Bs
-Bs
-Bs
-Dg
-Bf
-Bb
-BK
-DL
-Eg
-Es
-EB
-Eg
-DL
-Eg
-EO
-EO
-DJ
-Fj
-DJ
+Ep
+Fy
+FE
+Gc
+Gu
+Gc
+Gc
+Gc
+Gc
+Gc
+HS
+FP
+FL
+Gv
+Ix
+IS
+Je
+Jo
+IS
+Ix
+IS
+JG
+JG
+Iv
+Kg
+Iv
 aa
 aa
 aa
@@ -62382,49 +62366,49 @@ aa
 aa
 aa
 aa
-ge
-ge
-gt
-gr
-gt
-ge
-ge
-gL
-gR
+fZ
+fZ
+go
 gm
-gZ
-hd
-ge
-gt
+go
+fZ
+fZ
 gG
-gm
-ho
-gm
+gM
+gh
+gU
+gY
+fZ
 go
-gp
+gB
+gh
+hj
+gh
+gj
+gk
+gj
+gk
+gj
+gk
+gj
+gh
+hj
+gh
+gB
 go
-gp
-go
-gp
-go
-gm
-ho
-gm
-gG
-gt
-gG
+gB
+gI
 gN
-gS
+gQ
 gV
 ha
-hf
-ge
-ge
-gt
-gr
-gt
-ge
-ge
+fZ
+fZ
+go
+gm
+go
+fZ
+fZ
 aa
 aa
 aa
@@ -62436,84 +62420,84 @@ aa
 aa
 aa
 aa
-iq
-iq
-iq
-iq
-iq
-iq
-iq
-iq
-iq
-iq
-iq
-iq
-iq
-iq
-iq
-iq
-iq
-iq
-iq
-kd
-ks
-ks
-ks
-ks
-ks
-oy
-is
-qk
-LX
-ql
-LY
-ql
-KG
-qk
-tH
-tH
-tH
-tH
-tH
-qk
-Ks
-ql
-LY
-Mb
-yS
-Lc
-yC
-yS
-Mc
+il
+il
+il
+il
+il
+il
+il
+il
+il
+il
+il
+il
+il
+il
+il
+il
+il
+il
+il
+ka
+km
+km
+km
+km
+km
+po
+in
+qx
+qU
+qV
+sM
+qV
+uz
+qx
+vU
+vU
+vU
+vU
+vU
+qx
+zL
+qV
+sM
+BM
+Cc
+CO
+CQ
+Cc
+DK
 aa
 aa
 aa
-zH
-AP
-Bi
-Bt
-zH
-Cl
-Cw
-CK
-CT
-Df
-zH
-Ds
-DD
-BK
-DL
-Eg
-Et
-EC
-Eg
-DL
-Eg
-EO
-EO
-DJ
-EO
-DJ
+Ep
+Fz
+FS
+Gd
+Ep
+GW
+Hh
+Hx
+HF
+HR
+Ep
+Ig
+Ir
+Gv
+Ix
+IS
+Jf
+Jp
+IS
+Ix
+IS
+JG
+JG
+Iv
+JG
+Iv
 aa
 aa
 aa
@@ -62639,49 +62623,49 @@ aa
 aa
 aa
 aa
-ge
-ge
-gr
-gr
-gr
-ge
-ge
-gJ
-gp
-gn
-gp
-hc
-ge
-gt
-gG
+fZ
+fZ
 gm
-ho
 gm
-gp
+gm
+fZ
+fZ
+gE
+gk
+gi
+gk
+gX
+fZ
 go
-gp
+gB
+gh
+hj
+gh
+gk
+gj
+gk
+gj
+gk
+gj
+gk
+gh
+hj
+gh
+gB
 go
-gp
-go
-gp
+fZ
+fZ
+fZ
+gQ
+fZ
+fZ
+fZ
+fZ
 gm
-ho
 gm
-gG
-gt
-ge
-ge
-ge
-gV
-ge
-ge
-ge
-ge
-gr
-gr
-gr
-ge
-ge
+gm
+fZ
+fZ
 aa
 aa
 aa
@@ -62704,73 +62688,73 @@ aa
 aa
 aa
 aa
-it
-jZ
-kq
-iH
-Ke
-iH
-ly
-it
-ke
-ks
-ks
-ks
-ks
-ks
-LJ
-it
-qk
-qk
-qk
-qQ
-qk
-qk
-qk
-qm
-rW
-sw
-rW
-qm
-qk
-qk
-qk
-qQ
-qk
-qk
-qk
-qk
-qQ
-qk
+io
+jW
+kk
+iC
+kW
+iC
+lQ
+io
+kb
+km
+km
+km
+km
+km
+pp
+io
+qx
+qx
+qx
+sL
+qx
+qx
+qx
+rS
+wJ
+xr
+wJ
+rS
+qx
+qx
+qx
+sL
+qx
+qx
+qx
+qx
+sL
+qx
 aa
 aa
 aa
-zH
-zH
-zH
-zH
-zH
-zH
-zH
-zH
-zH
-zH
-zH
-zN
-zN
-zH
-DJ
-DJ
-Ef
-Ef
-DJ
-DJ
-DJ
-Ef
-Ef
-DJ
-EO
-DJ
+Ep
+Ep
+Ep
+Ep
+Ep
+Ep
+Ep
+Ep
+Ep
+Ep
+Ep
+Ev
+Ev
+Ep
+Iv
+Iv
+IR
+IR
+Iv
+Iv
+Iv
+IR
+IR
+Iv
+JG
+Iv
 aa
 aa
 aa
@@ -62896,49 +62880,49 @@ aa
 aa
 aa
 aa
-ge
-ge
-gr
-gr
-gr
-ge
-ge
-gK
+fZ
+fZ
+gm
+gm
+gm
+fZ
+fZ
+gF
+gL
+gk
+gT
+gC
+fZ
+go
+fZ
+gh
+gh
+gh
+fZ
+fZ
+fZ
+fZ
+fZ
+fZ
+fZ
+gh
+gh
+gh
+fZ
+go
+fZ
+fZ
+fZ
 gQ
-gp
-gY
-gH
-ge
-gt
-ge
+fZ
+fZ
+fZ
+fZ
 gm
 gm
 gm
-ge
-ge
-ge
-ge
-ge
-ge
-ge
-gm
-gm
-gm
-ge
-gt
-ge
-ge
-ge
-gV
-ge
-ge
-ge
-ge
-gr
-gr
-gr
-ge
-ge
+fZ
+fZ
 aa
 aa
 aa
@@ -62961,44 +62945,44 @@ aa
 aa
 aa
 aa
-it
-ka
-kr
-kx
-kR
-li
-kr
-kT
-iH
-ks
-ks
-ks
-ks
-ks
-oy
-it
-xX
-xW
-qk
-qR
-rT
-su
-su
-KK
-un
-uP
-un
-KK
-su
-su
-rT
-xo
-qk
-xW
-qk
-yJ
-yS
-qk
+io
+jX
+kl
+kz
+kX
+lw
+kl
+kZ
+iC
+km
+km
+km
+km
+km
+po
+io
+qy
+qz
+qx
+sN
+tS
+uA
+uA
+vV
+wK
+xs
+wK
+vV
+uA
+uA
+tS
+AV
+qx
+qz
+qx
+Dc
+Cc
+qx
 aa
 aa
 aa
@@ -63012,22 +62996,22 @@ aa
 aa
 aa
 aa
-zH
-Al
-Am
-zN
-Lp
-Ef
-EA
-DK
-Ef
-Lp
-Ef
-EA
-DK
-DJ
-EO
-DJ
+Ep
+ET
+EU
+Ev
+IQ
+IR
+Jm
+Jr
+IR
+IQ
+IR
+Jm
+Jr
+Iv
+JG
+Iv
 aa
 aa
 aa
@@ -63153,49 +63137,49 @@ aa
 aa
 aa
 aa
-ge
-ge
-gr
-gr
-gr
-ge
-ge
-gK
+fZ
+fZ
 gm
 gm
 gm
-gH
-hh
-hn
+fZ
+fZ
+gF
+gh
+gh
+gh
+gC
+hc
+hi
+hm
 hr
-hw
-hD
-hD
-hD
-hD
-hD
-hD
-hD
-hD
-hD
-hD
-hD
-hN
+hy
+hy
+hy
+hy
+hy
+hy
+hy
+hy
+hy
+hy
+hy
+hI
+gh
+gh
+gB
+gB
+gB
+gQ
+fZ
+fZ
+fZ
+fZ
 gm
 gm
-gG
-gG
-gG
-gV
-ge
-ge
-ge
-ge
-gr
-gr
-gr
-ge
-ge
+gm
+fZ
+fZ
 aa
 aa
 aa
@@ -63218,44 +63202,44 @@ aa
 aa
 aa
 aa
-it
-kb
-kr
-ky
-kS
-li
-kr
-ir
-mt
-mQ
-nc
-nA
-iH
-iH
-kk
-it
-xW
-xX
-qk
-qS
-rU
-sv
-sv
-sv
-sv
-sv
-sv
-sv
-sv
-sv
-wW
-xp
-qk
-xW
-qk
-yK
-yC
-qk
+io
+jY
+kl
+kA
+kY
+lw
+kl
+im
+mV
+nu
+nP
+ob
+iC
+iC
+kh
+io
+qz
+qy
+qx
+sO
+tT
+uB
+uB
+uB
+uB
+uB
+uB
+uB
+uB
+uB
+At
+AW
+qx
+qz
+qx
+Dd
+CQ
+qx
 aa
 aa
 aa
@@ -63269,22 +63253,22 @@ aa
 aa
 aa
 aa
-zH
-zH
-zH
-zH
-DJ
-DJ
-DJ
-DJ
-DJ
-DJ
-DJ
-DJ
-DJ
-DJ
-EO
-DJ
+Ep
+Ep
+Ep
+Ep
+Iv
+Iv
+Iv
+Iv
+Iv
+Iv
+Iv
+Iv
+Iv
+Iv
+JG
+Iv
 aa
 aa
 aa
@@ -63410,49 +63394,49 @@ aa
 aa
 aa
 aa
-ge
-ge
-gr
-gr
-gr
-ge
-ge
-gL
-gR
+fZ
+fZ
 gm
-gZ
+gm
+gm
+fZ
+fZ
+gG
+gM
+gh
+gU
+gY
 hd
-hi
-ho
+hj
+hn
 hs
-hx
-gp
-gp
-gp
-gp
-gp
-gp
-gp
-gp
-gp
-gp
-gp
-hO
-ge
-ge
-ge
-ge
-ge
-gV
-ge
-ge
-ge
-ge
-gr
-gr
-gr
-ge
-ge
+gk
+gk
+gk
+gk
+gk
+gk
+gk
+gk
+gk
+gk
+gk
+hJ
+fZ
+fZ
+fZ
+fZ
+fZ
+gQ
+fZ
+fZ
+fZ
+fZ
+gm
+gm
+gm
+fZ
+fZ
 aa
 aa
 aa
@@ -63475,44 +63459,44 @@ aa
 aa
 aa
 aa
-it
-it
-jc
-it
-it
-it
-jc
-it
-it
-it
-it
-is
-jc
-jc
-is
-it
-Kq
-xX
-ql
-qU
-rU
-sv
-sW
-tI
-sv
-sv
-sv
-sv
-sv
-sv
-wW
-xs
-ql
-KZ
-qk
-LW
-Le
-qk
+io
+io
+ja
+io
+io
+io
+ja
+io
+io
+io
+io
+in
+ja
+ja
+in
+io
+qA
+qy
+qV
+sP
+tT
+uB
+ve
+vW
+uB
+uB
+uB
+uB
+uB
+uB
+At
+AX
+qV
+Cd
+qx
+De
+Dx
+qx
 aa
 aa
 aa
@@ -63539,9 +63523,9 @@ aa
 aa
 aa
 aa
-DJ
-Fm
-DJ
+Iv
+Kj
+Iv
 aa
 aa
 aa
@@ -63667,49 +63651,49 @@ aa
 aa
 aa
 aa
-ge
-ge
-gr
-gs
-gr
-ge
-ge
-gJ
-gq
-gq
-gq
-hc
-hi
-ho
+fZ
+fZ
+gm
+gn
+gm
+fZ
+fZ
+gE
+gl
+gl
+gl
+gX
+hd
+hj
+hn
 hs
-hx
-gp
-gq
-gp
-ge
-gq
-gq
-gq
-ge
-gp
-gq
-gp
-hO
-ge
-ge
-ge
+gk
+gl
+gk
+fZ
+gl
+gl
+gl
+fZ
+gk
+gl
+gk
+hJ
+fZ
+fZ
+fZ
+gI
 gN
-gS
+gQ
 gV
 ha
-hf
-ge
-ge
-gr
-gs
-gr
-ge
-ge
+fZ
+fZ
+gm
+gn
+gm
+fZ
+fZ
 aa
 aa
 aa
@@ -63732,44 +63716,44 @@ aa
 aa
 aa
 aa
-it
-kc
-iH
-kz
-is
-lj
-lz
-ma
-mu
-mR
-nd
-lk
-iH
-iH
+io
+jZ
+iC
+kB
+in
+lx
+lR
+ml
+mW
+nv
+nQ
 ly
-it
-xX
-xW
-qm
-qT
-rU
-sv
-sX
-tJ
-tI
-sv
-sv
-sv
-sv
-sv
-wW
-xq
-qm
-xX
-qk
-yJ
-yS
-qk
+iC
+iC
+lQ
+io
+qy
+qz
+rS
+sQ
+tT
+uB
+vf
+vX
+vW
+uB
+uB
+uB
+uB
+uB
+At
+AY
+rS
+qy
+qx
+Dc
+Cc
+qx
 aa
 aa
 aa
@@ -63795,14 +63779,14 @@ aa
 aa
 aa
 aa
-EZ
-EZ
-Fn
-EZ
-EZ
-EZ
-EZ
-EZ
+JV
+JV
+Kk
+JV
+JV
+JV
+JV
+JV
 aa
 aa
 aa
@@ -63924,49 +63908,49 @@ aa
 aa
 aa
 aa
-ge
-ge
-gr
-gr
-gr
-ge
-ge
-gK
-gQ
-gp
-gY
-gH
-hi
-ho
+fZ
+fZ
+gm
+gm
+gm
+fZ
+fZ
+gF
+gL
+gk
+gT
+gC
+hd
+hj
+hn
 hs
-hx
-gp
-gp
-gp
-gp
-gp
-gp
-gp
-gp
-gp
-gp
-gp
-hO
-ge
-ge
-ge
-ge
-ge
-gV
-ge
-ge
-ge
-ge
-gr
-gr
-gr
-ge
-ge
+gk
+gk
+gk
+gk
+gk
+gk
+gk
+gk
+gk
+gk
+gk
+hJ
+fZ
+fZ
+fZ
+fZ
+fZ
+gQ
+fZ
+fZ
+fZ
+fZ
+gm
+gm
+gm
+fZ
+fZ
 aa
 aa
 aa
@@ -63989,44 +63973,44 @@ aa
 aa
 aa
 aa
-it
-kd
-ks
-ks
-kT
-lk
-lA
-mb
-mv
-mS
-iz
-lk
-kr
-kr
-kq
-it
-xX
-xW
-qk
-qT
-rU
-sv
-sX
-tK
-tJ
-tI
-sv
-sv
-sv
-sv
-wW
-xq
-qk
-ql
-qk
-qk
-qQ
-qk
+io
+ka
+km
+km
+kZ
+ly
+lS
+mm
+mX
+nw
+iu
+ly
+kl
+kl
+kk
+io
+qy
+qz
+qx
+sQ
+tT
+uB
+vf
+vY
+vX
+vW
+uB
+uB
+uB
+uB
+At
+AY
+qx
+qV
+qx
+qx
+sL
+qx
 aa
 aa
 aa
@@ -64052,14 +64036,14 @@ aa
 aa
 aa
 aa
-Fa
-Fh
-Fh
-Fh
-Me
-Fh
-Fh
-Fa
+JW
+Kd
+Kd
+Kd
+KE
+Kd
+Kd
+JW
 aa
 aa
 aa
@@ -64181,49 +64165,49 @@ aa
 aa
 aa
 aa
-ge
-ge
-gr
-gr
-gr
-ge
-ge
-gM
-gO
-gO
-gO
+fZ
+fZ
+gm
+gm
+gm
+fZ
+fZ
+gH
+gJ
+gJ
+gJ
+gZ
 he
-hj
-hp
+hk
+ho
 ht
-hy
-gn
-gn
-gn
-gn
-gn
-gn
-gn
-gn
-gn
-gn
-gn
-hP
+gi
+gi
+gi
+gi
+gi
+gi
+gi
+gi
+gi
+gi
+gi
+hK
+gh
+gh
+gB
+gB
+gB
+gQ
+fZ
+fZ
+fZ
+fZ
 gm
 gm
-gG
-gG
-gG
-gV
-ge
-ge
-ge
-ge
-gr
-gr
-gr
-ge
-ge
+gm
+fZ
+fZ
 aa
 aa
 aa
@@ -64246,44 +64230,44 @@ aa
 aa
 aa
 aa
+ip
+kb
+km
+kC
+im
 iu
-ke
-ks
-kA
-ir
-iz
-lB
-iz
-iz
-iz
-ir
-nB
-mw
-ks
-oA
-it
-qk
-ql
-qk
-KD
-rU
-sv
-sW
-tL
-tL
-tL
-tL
-tL
-vF
-sv
-wW
-KT
-qk
-xY
+lT
+iu
+iu
+iu
+im
+oc
+mY
+km
+pq
+io
+qx
+qV
+qx
+sR
+tT
+uB
+ve
+vZ
+vZ
+vZ
+vZ
+vZ
 yB
-yL
-yT
-qk
+uB
+At
+AZ
+qx
+Ce
+CP
+Df
+Dy
+qx
 aa
 aa
 aa
@@ -64309,14 +64293,14 @@ aa
 aa
 aa
 aa
-EZ
-Fh
-Fh
-Fh
-Fh
-Fh
-Fh
-EZ
+JV
+Kd
+Kd
+Kd
+Kd
+Kd
+Kd
+JV
 aa
 aa
 aa
@@ -64438,49 +64422,49 @@ aa
 aa
 aa
 aa
-ge
-ge
-gr
-gr
-gr
-ge
-ge
-ge
-ge
-gU
-ge
-ge
-ge
-gt
-ge
+fZ
+fZ
+gm
+gm
+gm
+fZ
+fZ
+fZ
+fZ
+gP
+fZ
+fZ
+fZ
+go
+fZ
+hu
 hz
-hE
-hE
-ge
-ge
-ge
-ge
-ge
-ge
-ge
-hE
-hE
-hQ
-ge
-gt
-ge
-ge
-ge
-gV
-ge
-ge
-ge
-ge
-gr
-gr
-gr
-ge
-ge
+hz
+fZ
+fZ
+fZ
+fZ
+fZ
+fZ
+fZ
+hz
+hz
+hL
+fZ
+go
+fZ
+fZ
+fZ
+gQ
+fZ
+fZ
+fZ
+fZ
+gm
+gm
+gm
+fZ
+fZ
 aa
 aa
 aa
@@ -64503,44 +64487,44 @@ aa
 aa
 aa
 aa
-it
-kd
-kr
-kB
-kU
-kr
-kr
-kr
-kr
-kr
-iz
-nC
-mw
-ks
-oB
-it
-LK
-LN
-LQ
-qS
-rU
-sv
-sY
-tK
-tK
-tK
-vm
-tM
-wd
-sv
-wW
-xp
-xP
-xZ
-yC
-yC
-yS
-qk
+io
+ka
+kl
+kD
+la
+kl
+kl
+kl
+kl
+kl
+iu
+od
+mY
+km
+pr
+io
+qB
+qW
+rT
+sO
+tT
+uB
+vg
+vY
+vY
+vY
+xY
+wa
+zl
+uB
+At
+AW
+BN
+Cf
+CQ
+CQ
+Cc
+qx
 aa
 aa
 aa
@@ -64566,14 +64550,14 @@ aa
 aa
 aa
 aa
-EZ
-Fi
-Fi
-Fi
-Fi
-Fh
-Fi
-EZ
+JV
+Ke
+Ke
+Ke
+Ke
+Kd
+Ke
+JV
 aa
 aa
 aa
@@ -64695,49 +64679,49 @@ aa
 aa
 aa
 aa
-ge
-ge
-gr
-gr
-gr
-ge
-ge
-ge
-ge
-gV
-ge
-ge
-ge
-gt
-gG
+fZ
+fZ
+gm
+gm
+gm
+fZ
+fZ
+fZ
+fZ
+gQ
+fZ
+fZ
+fZ
+go
+gB
+hu
 hz
-hE
-hE
-hE
-hE
-ho
-gq
-ho
-hE
-hE
-hE
-hE
-hQ
-gG
-gt
-ge
-ge
-ge
-gV
-ge
-ge
-ge
-ge
-gr
-gr
-gr
-ge
-ge
+hz
+hz
+hz
+hj
+gl
+hj
+hz
+hz
+hz
+hz
+hL
+gB
+go
+fZ
+fZ
+fZ
+gQ
+fZ
+fZ
+fZ
+fZ
+gm
+gm
+gm
+fZ
+fZ
 aa
 aa
 aa
@@ -64760,44 +64744,44 @@ aa
 aa
 aa
 aa
-is
-kf
-kr
-kC
-kV
-kr
-ks
-mc
-mw
-kr
-iz
-nC
-mw
-ks
-oC
-it
-LL
-LF
-LH
-qS
+in
+kc
+kl
+kE
+lb
+kl
+km
+mn
+mY
+kl
+iu
+od
+mY
+km
+ps
+io
+qC
+qX
 rU
-sv
-sZ
-sY
-tK
-tK
-tK
-vF
-sZ
-sv
-wW
-xt
-xQ
-Mg
-yC
-yC
-yU
-qk
+sO
+tT
+uB
+vh
+vg
+vY
+vY
+vY
+yB
+vh
+uB
+At
+Ba
+BO
+Cg
+CQ
+CQ
+Dz
+qx
 aa
 aa
 aa
@@ -64823,14 +64807,14 @@ aa
 aa
 aa
 aa
-EZ
-Fi
-Fi
-Fi
-Fi
-Fh
-Fi
-EZ
+JV
+Ke
+Ke
+Ke
+Ke
+Kd
+Ke
+JV
 aa
 aa
 aa
@@ -64952,49 +64936,49 @@ aa
 aa
 aa
 aa
-ge
-ge
-gt
-gr
-gt
-ge
-ge
+fZ
+fZ
+go
+gm
+go
+fZ
+fZ
+gI
 gN
-gS
+gQ
 gV
 ha
-hf
-gG
-gt
-gG
+gB
+go
+gB
+hu
 hz
-hE
-hE
-ho
-hE
-hE
-ho
-hE
-hE
-ho
-hE
-hE
-hQ
-gG
-gt
-gG
+hz
+hj
+hz
+hz
+hj
+hz
+hz
+hj
+hz
+hz
+hL
+gB
+go
+gB
+gI
 gN
-gS
+gQ
 gV
 ha
-hf
-ge
-ge
-gt
-gr
-gt
-ge
-ge
+fZ
+fZ
+go
+gm
+go
+fZ
+fZ
 aa
 aa
 aa
@@ -65017,44 +65001,44 @@ aa
 aa
 aa
 aa
-ir
-kg
-kr
-kD
-kW
-kr
-ks
-md
-mw
-kr
-iz
-nC
-mw
-ks
-oD
-it
-LM
-LP
-LR
-qS
-rU
-sv
-sW
-tL
-uo
-tK
-tK
-tK
-vF
-sv
-wW
-xp
-xR
-xZ
-yC
-Mh
-yV
-qk
+im
+kd
+kl
+kF
+lc
+kl
+km
+mo
+mY
+kl
+iu
+od
+mY
+km
+pt
+io
+qD
+qY
+rV
+sO
+tT
+uB
+ve
+vZ
+wL
+vY
+vY
+vY
+yB
+uB
+At
+AW
+BP
+Cf
+CQ
+Dg
+DA
+qx
 aa
 aa
 aa
@@ -65080,14 +65064,14 @@ aa
 aa
 aa
 aa
-EZ
-Fh
-Fo
-Fh
-Fh
-Fh
-Fh
-EZ
+JV
+Kd
+Kl
+Kd
+Kd
+Kd
+Kd
+JV
 aa
 aa
 aa
@@ -65209,49 +65193,49 @@ aa
 aa
 aa
 aa
-ge
-ge
-gr
-gr
-gr
-ge
-ge
-ge
-ge
-gV
-ge
-ge
-ge
-gt
-gG
+fZ
+fZ
+gm
+gm
+gm
+fZ
+fZ
+fZ
+fZ
+gQ
+fZ
+fZ
+fZ
+go
+gB
+hu
 hz
-hE
-hE
-gq
-ho
-hE
-hE
-hE
-ho
-gq
-hE
-hE
-hQ
-gG
-gt
-ge
-ge
-ge
-gV
-ge
-ge
-ge
-ge
-gr
-gr
-gr
-ge
-ge
+hz
+gl
+hj
+hz
+hz
+hz
+hj
+gl
+hz
+hz
+hL
+gB
+go
+fZ
+fZ
+fZ
+gQ
+fZ
+fZ
+fZ
+fZ
+gm
+gm
+gm
+fZ
+fZ
 aa
 aa
 aa
@@ -65274,44 +65258,44 @@ aa
 aa
 aa
 aa
-is
-kh
-kr
-kE
-kX
-kr
-ks
-ks
-ks
-kr
-kT
-lk
-ks
-ks
-oE
-it
-qk
-ql
-qk
-KD
-rU
-sv
-sY
-tM
-tM
-tM
-tM
-tM
-wd
-sv
-wW
-KT
-qk
-ya
-yD
-yM
-yW
-qk
+in
+ke
+kl
+kG
+ld
+kl
+km
+km
+km
+kl
+kZ
+ly
+km
+km
+pu
+io
+qx
+qV
+qx
+sR
+tT
+uB
+vg
+wa
+wa
+wa
+wa
+wa
+zl
+uB
+At
+AZ
+qx
+Ch
+CR
+Dh
+DB
+qx
 aa
 aa
 aa
@@ -65337,14 +65321,14 @@ aa
 aa
 aa
 aa
-Fa
-Md
-Fp
-FC
-Mf
-Fh
-Fh
-Fa
+JW
+Kf
+Km
+Kz
+KF
+Kd
+Kd
+JW
 aa
 aa
 aa
@@ -65466,49 +65450,49 @@ aa
 aa
 aa
 aa
-ge
-ge
-gr
-gr
-gr
-ge
-ge
-ge
-ge
-gV
-gG
-gG
-gG
-gt
-ge
+fZ
+fZ
+gm
+gm
+gm
+fZ
+fZ
+fZ
+fZ
+gQ
+gB
+gB
+gB
+go
+fZ
+hu
 hz
-hE
-hE
-hE
-gq
-ho
-hE
-ho
-gq
-hE
-hE
-hE
-hQ
-ge
-gt
-gG
-gG
-gG
-gV
-ge
-ge
-ge
-ge
-gr
-gr
-gr
-ge
-ge
+hz
+hz
+gl
+hj
+hz
+hj
+gl
+hz
+hz
+hz
+hL
+fZ
+go
+gB
+gB
+gB
+gQ
+fZ
+fZ
+fZ
+fZ
+gm
+gm
+gm
+fZ
+fZ
 aa
 aa
 aa
@@ -65531,44 +65515,44 @@ aa
 aa
 aa
 aa
-ir
-ki
-kr
-kF
-kY
-kr
-ks
-md
-mw
-kr
-iz
-nC
-mw
-ks
-oF
-is
-xW
-xX
-qk
-qT
-rU
-sv
-sv
-sv
-sv
-uQ
-vn
-tK
-we
-sv
-wW
-xq
-qk
-ql
-qk
-qk
-qk
-qk
+im
+kf
+kl
+kH
+le
+kl
+km
+mo
+mY
+kl
+iu
+od
+mY
+km
+pv
+in
+qz
+qy
+qx
+sQ
+tT
+uB
+uB
+uB
+uB
+xt
+xZ
+vY
+zm
+uB
+At
+AY
+qx
+qV
+qx
+qx
+qx
+qx
 aa
 aa
 aa
@@ -65594,14 +65578,14 @@ aa
 aa
 aa
 aa
-EZ
-EZ
-EZ
-EZ
-EZ
-EZ
-EZ
-EZ
+JV
+JV
+JV
+JV
+JV
+JV
+JV
+JV
 aa
 aa
 aa
@@ -65723,49 +65707,49 @@ aa
 aa
 aa
 aa
-ge
-ge
-gr
-gr
-gr
-ge
-ge
-ge
-ge
-gV
-ge
-ge
-ge
-gt
+fZ
+fZ
+gm
+gm
+gm
+fZ
+fZ
+fZ
+fZ
+gQ
+fZ
+fZ
+fZ
+go
+hp
 hu
+fZ
 hz
-ge
-hE
-hE
-hE
-gq
-ho
-gq
-hE
-hE
-hE
-ge
-hQ
-hu
-gt
-ge
-ge
-ge
-gV
-ge
-ge
-ge
-ge
-gr
-gr
-gr
-ge
-ge
+hz
+hz
+gl
+hj
+gl
+hz
+hz
+hz
+fZ
+hL
+hp
+go
+fZ
+fZ
+fZ
+gQ
+fZ
+fZ
+fZ
+fZ
+gm
+gm
+gm
+fZ
+fZ
 aa
 aa
 aa
@@ -65788,41 +65772,41 @@ aa
 aa
 aa
 aa
-is
-kj
-kr
-kC
-kV
-kr
-ks
-mc
-mw
-kr
-iz
-nC
-mw
-ks
-oC
-it
-xX
-xW
-qm
-qT
-rU
-sv
-sv
-sv
-sv
-sv
-uQ
-vn
-we
-sv
-wW
-xq
-qm
-xW
-qk
+in
+kg
+kl
+kE
+lb
+kl
+km
+mn
+mY
+kl
+iu
+od
+mY
+km
+ps
+io
+qy
+qz
+rS
+sQ
+tT
+uB
+uB
+uB
+uB
+uB
+xt
+xZ
+zm
+uB
+At
+AY
+rS
+qz
+qx
 aa
 aa
 aa
@@ -65980,49 +65964,49 @@ aa
 aa
 aa
 aa
-ge
-ge
-gr
-gs
-gr
-ge
-ge
+fZ
+fZ
+gm
+gn
+gm
+fZ
+fZ
+gI
 gN
-gS
+gQ
 gV
 ha
-hf
-gG
-gt
+gB
+go
+hp
 hu
 hz
-hE
-ge
-hE
-hE
-hE
-hE
-hE
-hE
-hE
-ge
-hE
-hQ
-hu
-gt
-gG
+fZ
+hz
+hz
+hz
+hz
+hz
+hz
+hz
+fZ
+hz
+hL
+hp
+go
+gB
+gI
 gN
-gS
+gQ
 gV
 ha
-hf
-ge
-ge
-gr
-gs
-gr
-ge
-ge
+fZ
+fZ
+gm
+gn
+gm
+fZ
+fZ
 aa
 aa
 aa
@@ -66045,41 +66029,41 @@ aa
 aa
 aa
 aa
-it
-kd
-kr
-kB
-kZ
-kr
-kr
-kr
-kr
-kr
-iz
-nC
-mw
-ks
-oB
-it
-Kq
-xX
-ql
-qX
-rU
-sv
-sv
-sv
-sv
-sv
-sv
-uQ
-wd
-sv
-wW
-LT
-ql
-KZ
-qk
+io
+ka
+kl
+kD
+lf
+kl
+kl
+kl
+kl
+kl
+iu
+od
+mY
+km
+pr
+io
+qA
+qy
+qV
+sS
+tT
+uB
+uB
+uB
+uB
+uB
+uB
+xt
+zl
+uB
+At
+Bb
+qV
+Cd
+qx
 aa
 aa
 aa
@@ -66237,49 +66221,49 @@ aa
 aa
 aa
 aa
-ge
-ge
-gr
-gr
-gr
-ge
-ge
-ge
-ge
-gV
-ge
-ge
-ge
-gt
+fZ
+fZ
+gm
+gm
+gm
+fZ
+fZ
+fZ
+fZ
+gQ
+fZ
+fZ
+fZ
+go
+hp
 hu
+fZ
 hz
-ge
-hE
-hE
-hE
-gv
-hG
-gv
-hE
-hE
-hE
-ge
-hQ
-hu
-gt
-ge
-ge
-ge
-gV
-ge
-ge
-ge
-ge
-gr
-gr
-gr
-ge
-ge
+hz
+hz
+gq
+hB
+gq
+hz
+hz
+hz
+fZ
+hL
+hp
+go
+fZ
+fZ
+fZ
+gQ
+fZ
+fZ
+fZ
+fZ
+gm
+gm
+gm
+fZ
+fZ
 aa
 aa
 aa
@@ -66302,41 +66286,41 @@ aa
 aa
 aa
 aa
-iu
-ke
-ks
-kG
-ir
-ll
-lC
-me
-mx
-lC
-ir
-nB
-mw
-ks
-kd
-it
-xW
-xX
-qk
-qS
-rU
-sv
-sv
-sv
-sv
-sv
-sv
-sv
-sv
-sv
-wW
-xp
-qk
-xX
-qk
+ip
+kb
+km
+kI
+im
+lz
+lU
+mp
+mZ
+lU
+im
+oc
+mY
+km
+ka
+io
+qz
+qy
+qx
+sO
+tT
+uB
+uB
+uB
+uB
+uB
+uB
+uB
+uB
+uB
+At
+AW
+qx
+qy
+qx
 aa
 aa
 aa
@@ -66494,49 +66478,49 @@ aa
 aa
 aa
 aa
-ge
-ge
-gr
-gr
-gr
-ge
-ge
-ge
-ge
-gV
-gG
-gG
-gG
-gt
-ge
+fZ
+fZ
+gm
+gm
+gm
+fZ
+fZ
+fZ
+fZ
+gQ
+gB
+gB
+gB
+go
+fZ
+hu
 hz
-hE
-hE
-hE
-gv
-hG
-hE
-hG
-gv
-hE
-hE
-hE
-hQ
-ge
-gt
-gG
-gG
-gG
-gV
-ge
-ge
-ge
-ge
-gr
-gr
-gr
-ge
-ge
+hz
+hz
+gq
+hB
+hz
+hB
+gq
+hz
+hz
+hz
+hL
+fZ
+go
+gB
+gB
+gB
+gQ
+fZ
+fZ
+fZ
+fZ
+gm
+gm
+gm
+fZ
+fZ
 aa
 aa
 aa
@@ -66559,41 +66543,41 @@ aa
 aa
 aa
 aa
-it
-kd
-ks
-ks
-kT
-lk
-lD
-lE
-lE
-lD
-iz
-lk
-kr
-kr
-oG
-it
-xW
-xX
-qk
-qZ
-rV
-rV
-rV
-rV
-rV
-rV
-rV
-rV
-rV
-rV
-rV
-Ih
-qk
-xW
-qk
+io
+ka
+km
+km
+kZ
+ly
+lV
+lW
+lW
+lV
+iu
+ly
+kl
+kl
+pw
+io
+qz
+qy
+qx
+sT
+tU
+tU
+tU
+tU
+tU
+tU
+tU
+tU
+tU
+tU
+tU
+Bc
+qx
+qz
+qx
 aa
 aa
 aa
@@ -66751,49 +66735,49 @@ aa
 aa
 aa
 aa
-ge
-ge
-gr
-gr
-gr
-ge
-ge
-ge
-ge
-gV
-ge
-ge
-ge
-gt
-gG
+fZ
+fZ
+gm
+gm
+gm
+fZ
+fZ
+fZ
+fZ
+gQ
+fZ
+fZ
+fZ
+go
+gB
+hu
 hz
-hE
-hE
-gv
-hG
-hE
-hE
-hE
-hG
-gv
-hE
-hE
-hQ
-gG
-gt
-ge
-ge
-ge
-gV
-ge
-ge
-ge
-ge
-gr
-gr
-gr
-ge
-ge
+hz
+gq
+hB
+hz
+hz
+hz
+hB
+gq
+hz
+hz
+hL
+gB
+go
+fZ
+fZ
+fZ
+gQ
+fZ
+fZ
+fZ
+fZ
+gm
+gm
+gm
+fZ
+fZ
 aa
 aa
 aa
@@ -66816,41 +66800,41 @@ aa
 aa
 aa
 aa
-it
-kk
-kt
-kH
-is
-lm
-lE
-mf
-my
-lE
-ne
-lk
-nT
-ok
+io
 kh
-it
-qk
-qk
-qk
-LS
-HV
-HV
-HV
-HV
-HV
-HV
-HV
-HV
-HV
-HV
-HV
-LU
-qk
-qk
-qk
+kn
+kJ
+in
+lA
+lW
+mq
+na
+lW
+nR
+ly
+oz
+oR
+ke
+io
+qx
+qx
+qx
+sU
+tV
+tV
+tV
+tV
+tV
+tV
+tV
+tV
+tV
+tV
+tV
+Bd
+qx
+qx
+qx
 aa
 aa
 aa
@@ -67008,49 +66992,49 @@ aa
 aa
 aa
 aa
-ge
-ge
-gt
-gr
-gt
-ge
-ge
+fZ
+fZ
+go
+gm
+go
+fZ
+fZ
+gI
 gN
-gS
+gQ
 gV
 ha
-hf
-gG
-gt
-gG
+gB
+go
+gB
+hu
 hz
-hE
-hE
-hG
-hE
-hE
-hG
-hE
-hE
-hG
-hE
-hE
-hQ
-gG
-gt
-gG
+hz
+hB
+hz
+hz
+hB
+hz
+hz
+hB
+hz
+hz
+hL
+gB
+go
+gB
+gI
 gN
-gS
+gQ
 gV
 ha
-hf
-ge
-ge
-gt
-gr
-gt
-ge
-ge
+fZ
+fZ
+go
+gm
+go
+fZ
+fZ
 aa
 aa
 aa
@@ -67073,41 +67057,41 @@ aa
 aa
 aa
 aa
-it
-it
-it
-it
-it
-it
-iu
-it
-it
-ir
-it
-it
-it
-it
-it
-it
-qk
-qk
-qk
-ra
-ra
-ra
-ra
-ra
-ra
-ra
-ra
-ra
-ra
-ra
-ra
-ra
-qk
-qk
-qk
+io
+io
+io
+io
+io
+io
+ip
+io
+io
+im
+io
+io
+io
+io
+io
+io
+qx
+qx
+qx
+sV
+sV
+sV
+sV
+sV
+sV
+sV
+sV
+sV
+sV
+sV
+sV
+sV
+qx
+qx
+qx
 aa
 aa
 aa
@@ -67265,49 +67249,49 @@ aa
 aa
 aa
 aa
-ge
-ge
-gr
-gr
-gr
-ge
-ge
-ge
-ge
-gV
-ge
-ge
-ge
-gt
-gG
+fZ
+fZ
+gm
+gm
+gm
+fZ
+fZ
+fZ
+fZ
+gQ
+fZ
+fZ
+fZ
+go
+gB
+hu
 hz
-hE
-hE
-hE
-hE
-hG
-gv
-hG
-hE
-hE
-hE
-hE
-hQ
-gG
-gt
-ge
-ge
-ge
-gV
-ge
-ge
-ge
-ge
-gr
-gr
-gr
-ge
-ge
+hz
+hz
+hz
+hB
+gq
+hB
+hz
+hz
+hz
+hz
+hL
+gB
+go
+fZ
+fZ
+fZ
+gQ
+fZ
+fZ
+fZ
+fZ
+gm
+gm
+gm
+fZ
+fZ
 aa
 aa
 aa
@@ -67352,7 +67336,7 @@ aa
 aa
 aa
 aa
-ta
+vi
 aa
 aa
 aa
@@ -67522,49 +67506,49 @@ aa
 aa
 aa
 aa
-ge
-ge
-gr
-gr
-gr
-ge
-ge
-ge
-ge
-gV
-ge
-ge
-ge
-gt
-ge
+fZ
+fZ
+gm
+gm
+gm
+fZ
+fZ
+fZ
+fZ
+gQ
+fZ
+fZ
+fZ
+go
+fZ
+hu
 hz
-hE
-hE
-ge
-ge
-ge
-ge
-ge
-ge
-ge
-hE
-hE
-hQ
-ge
-gt
-ge
-ge
-ge
-gW
-ge
-ge
-ge
-ge
-gr
-gr
-gr
-ge
-ge
+hz
+fZ
+fZ
+fZ
+fZ
+fZ
+fZ
+fZ
+hz
+hz
+hL
+fZ
+go
+fZ
+fZ
+fZ
+gR
+fZ
+fZ
+fZ
+fZ
+gm
+gm
+gm
+fZ
+fZ
 aa
 aa
 aa
@@ -67779,49 +67763,49 @@ aa
 aa
 aa
 aa
-ge
-ge
-gr
-gr
-gr
-ge
-ge
-ge
-ge
-gV
-gG
-gG
-gG
+fZ
+fZ
 gm
 gm
-hA
-gu
-gu
-gu
-gu
-gu
-gu
-gu
-gu
-gu
-gu
-gu
-hR
+gm
+fZ
+fZ
+fZ
+fZ
+gQ
+gB
+gB
+gB
+gh
+gh
+hv
+gp
+gp
+gp
+gp
+gp
+gp
+gp
+gp
+gp
+gp
+gp
+hM
+hP
+hS
 hU
 hX
-hZ
-ic
-gT
-gT
-gT
-im
-ge
-ge
-gr
-gr
-gr
-ge
-ge
+gO
+gO
+gO
+ih
+fZ
+fZ
+gm
+gm
+gm
+fZ
+fZ
 aa
 aa
 aa
@@ -68036,49 +68020,49 @@ aa
 aa
 aa
 aa
-ge
-ge
-gr
-gr
-gr
-ge
-ge
-ge
-ge
-gV
-ge
-ge
-ge
-ge
-ge
+fZ
+fZ
+gm
+gm
+gm
+fZ
+fZ
+fZ
+fZ
+gQ
+fZ
+fZ
+fZ
+fZ
+fZ
+hw
+hf
+hf
+hf
+hf
+hf
+hf
+hf
+hf
+hf
+hf
+hf
+hN
+hQ
 hB
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hS
 hV
-hG
-ia
-gK
-ig
-hk
-ij
-gH
-ge
-ge
-gr
-gr
-gr
-ge
-ge
+gF
+ib
+hf
+ie
+gC
+fZ
+fZ
+gm
+gm
+gm
+fZ
+fZ
 aa
 aa
 aa
@@ -68293,49 +68277,49 @@ aa
 aa
 aa
 aa
-ge
-ge
-gr
-gs
-gr
-ge
-ge
+fZ
+fZ
+gm
+gn
+gm
+fZ
+fZ
+gI
 gN
-gS
+gQ
 gV
 ha
+gB
+fZ
+fZ
+hw
 hf
-gG
-ge
-ge
+gq
+hf
+fZ
+gq
+gq
+gq
+fZ
+hf
+gq
+hf
+hN
+hQ
 hB
-hk
-gv
-hk
-ge
-gv
-gv
-gv
-ge
-hk
-gv
-hk
-hS
 hV
-hG
-ia
-id
-gv
-gv
-gv
-in
-ge
-ge
-gr
-gs
-gr
-ge
-ge
+hY
+gq
+gq
+gq
+ii
+fZ
+fZ
+gm
+gn
+gm
+fZ
+fZ
 aa
 aa
 aa
@@ -68550,49 +68534,49 @@ aa
 aa
 aa
 aa
-ge
-ge
-gr
-gr
-gr
-ge
-ge
-ge
-ge
-gV
-ge
-ge
-ge
-ge
-ge
-hB
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hS
-hV
-hG
-ia
-ie
-ih
+fZ
+fZ
 gm
-ik
-io
-ge
-ge
-gr
-gr
-gr
-ge
-ge
+gm
+gm
+fZ
+fZ
+fZ
+fZ
+gQ
+fZ
+fZ
+fZ
+fZ
+fZ
+hw
+hf
+hf
+hf
+hf
+hf
+hf
+hf
+hf
+hf
+hf
+hf
+hN
+hQ
+hB
+hV
+hZ
+ic
+gh
+if
+ij
+fZ
+fZ
+gm
+gm
+gm
+fZ
+fZ
 aa
 aa
 aa
@@ -68807,49 +68791,49 @@ aa
 aa
 aa
 aa
-ge
-ge
-gr
-gr
-gr
-ge
-ge
-ge
-ge
-gV
-gG
-gG
-gG
+fZ
+fZ
 gm
 gm
-hC
-hF
-hF
-hF
-hF
-hF
-hF
-hF
-hF
-hF
-hF
-hF
+gm
+fZ
+fZ
+fZ
+fZ
+gQ
+gB
+gB
+gB
+gh
+gh
+hx
+hA
+hA
+hA
+hA
+hA
+hA
+hA
+hA
+hA
+hA
+hA
+hO
+hR
 hT
 hW
-hY
-ib
-gK
+gF
+gh
+gh
+gh
+gC
+fZ
+fZ
 gm
 gm
 gm
-gH
-ge
-ge
-gr
-gr
-gr
-ge
-ge
+fZ
+fZ
 aa
 aa
 aa
@@ -69064,49 +69048,49 @@ aa
 aa
 aa
 aa
-ge
-ge
-gr
-gr
-gr
-ge
-ge
-ge
-ge
-gV
-ge
-ge
-ge
-gt
-ge
+fZ
+fZ
 gm
 gm
 gm
-ge
-ge
-ge
-ge
-ge
-ge
-ge
+fZ
+fZ
+fZ
+fZ
+gQ
+fZ
+fZ
+fZ
+go
+fZ
+gh
+gh
+gh
+fZ
+fZ
+fZ
+fZ
+fZ
+fZ
+fZ
+gh
+gh
+gh
+fZ
+go
+fZ
+gF
+ib
+hf
+ie
+gC
+fZ
+fZ
 gm
 gm
 gm
-ge
-gt
-ge
-gK
-ig
-hk
-ij
-gH
-ge
-ge
-gr
-gr
-gr
-ge
-ge
+fZ
+fZ
 aa
 aa
 aa
@@ -69249,29 +69233,29 @@ af
 af
 af
 af
-bl
-bm
-bm
-bm
-bm
-bm
-bm
-bm
-bm
-bm
-bm
-bl
-dy
-dy
-dy
-dy
-dy
-dy
-dy
-dy
-dy
-dy
-fN
+bj
+bk
+bk
+bk
+bk
+bk
+bk
+bk
+bk
+bk
+bk
+bj
+dm
+dm
+dm
+dm
+dm
+dm
+dm
+dm
+dm
+dm
+fx
 aa
 aa
 aa
@@ -69321,49 +69305,49 @@ aa
 aa
 aa
 aa
-ge
-ge
-gr
-gr
-gr
-ge
-ge
-ge
-ge
-gV
-ge
-ge
-ge
-gt
-gG
+fZ
+fZ
 gm
-hG
 gm
-hk
-gx
-hk
-gx
-hk
-gx
-hk
 gm
-hG
+fZ
+fZ
+fZ
+fZ
+gQ
+fZ
+fZ
+fZ
+go
+gB
+gh
+hB
+gh
+hf
+gs
+hf
+gs
+hf
+gs
+hf
+gh
+hB
+gh
+gB
+go
+fZ
+hY
+hf
+gp
+hf
+ii
+fZ
+fZ
 gm
-gG
-gt
-ge
-id
-hk
-gu
-hk
-in
-ge
-ge
-gr
-gr
-gr
-ge
-ge
+gm
+gm
+fZ
+fZ
 aa
 aa
 aa
@@ -69497,38 +69481,38 @@ aa
 (215,1,1) = {"
 ac
 af
+aw
+af
+af
+aO
+aR
+aG
+af
 ax
 af
-af
-aQ
-aT
-aI
-af
-ay
-af
-bl
-bm
-bm
-bm
-bm
-bm
-bm
-bm
-bm
-bm
-bm
-bl
-dy
-dU
-dU
-dy
-dU
-dU
-dy
-dU
-dU
-dy
-fN
+bj
+bk
+bk
+bk
+bk
+bk
+bk
+bk
+bk
+bk
+bk
+bj
+dm
+dG
+dG
+dm
+dG
+dG
+dm
+dG
+dG
+dm
+fx
 aa
 aa
 aa
@@ -69578,49 +69562,49 @@ aa
 aa
 aa
 aa
-ge
-ge
-gt
-gr
-gt
-ge
-ge
+fZ
+fZ
+go
+gm
+go
+fZ
+fZ
+gI
 gN
-gS
+gQ
 gV
 ha
+gB
+go
+gB
+gh
+hB
+gh
+gs
 hf
-gG
-gt
-gG
+gs
+hf
+gs
+hf
+gs
+gh
+hB
+gh
+gB
+go
+fZ
+hZ
+ic
+gh
+if
+ij
+fZ
+fZ
+go
 gm
-hG
-gm
-gx
-hk
-gx
-hk
-gx
-hk
-gx
-gm
-hG
-gm
-gG
-gt
-ge
-ie
-ih
-gm
-ik
-io
-ge
-ge
-gt
-gr
-gt
-ge
-ge
+go
+fZ
+fZ
 aa
 aa
 aa
@@ -69754,38 +69738,38 @@ aa
 (216,1,1) = {"
 ac
 af
-ay
+ax
 af
 af
 af
 af
 af
 af
-ay
+ax
 af
-bl
-bm
-bm
-bm
-bm
-cj
-cw
-bm
-bm
-bm
-bm
-bl
-dy
-dU
-dU
-eJ
-dU
-dU
-eJ
-dU
-dU
-dy
-fN
+bj
+bk
+bk
+bk
+bk
+ce
+cq
+bk
+bk
+bk
+bk
+bj
+dm
+dG
+dG
+eu
+dG
+dG
+eu
+dG
+dG
+dm
+fx
 aa
 aa
 aa
@@ -69835,49 +69819,49 @@ aa
 aa
 aa
 aa
-ge
-ge
-gr
-gr
-gr
-ge
-ge
-ge
-ge
-gV
-ge
-ge
-ge
-gt
-gG
-gm
-hG
-gm
-hk
-gx
-hk
-gx
-hk
-gx
-hk
-gm
-hG
-gm
-gG
-gt
-ge
-gK
+fZ
+fZ
 gm
 gm
 gm
-gH
-ge
-ge
-gr
-gr
-gr
-ge
-ge
+fZ
+fZ
+fZ
+fZ
+gQ
+fZ
+fZ
+fZ
+go
+gB
+gh
+hB
+gh
+hf
+gs
+hf
+gs
+hf
+gs
+hf
+gh
+hB
+gh
+gB
+go
+fZ
+gF
+gh
+gh
+gh
+gC
+fZ
+fZ
+gm
+gm
+gm
+fZ
+fZ
 aa
 aa
 aa
@@ -70011,38 +69995,38 @@ aa
 (217,1,1) = {"
 ac
 af
-ay
-aI
-aO
+ax
+aG
+aM
 af
-aU
+aS
 af
 af
-aI
+aG
 af
-bl
-bm
-bm
-bm
-bm
-bm
-cx
-bm
-bm
-bm
-bm
-bl
-dy
-dU
-dU
-dy
-dU
-dU
-dy
-dU
-dU
-dy
-fN
+bj
+bk
+bk
+bk
+bk
+bk
+cr
+bk
+bk
+bk
+bk
+bj
+dm
+dG
+dG
+dm
+dG
+dG
+dm
+dG
+dG
+dm
+fx
 aa
 aa
 aa
@@ -70092,49 +70076,49 @@ aa
 aa
 aa
 aa
-ge
-ge
-gr
-gr
-gr
-ge
-ge
-ge
-ge
-gV
-gG
-gG
-gG
-gt
-ge
+fZ
+fZ
 gm
-hG
 gm
-ge
-gv
-hG
-hG
-hG
-gv
-ge
 gm
-hG
+fZ
+fZ
+fZ
+fZ
+gQ
+gB
+gB
+gB
+go
+fZ
+gh
+hB
+gh
+fZ
+gq
+hB
+hB
+hB
+gq
+fZ
+gh
+hB
+gh
+fZ
+go
+fZ
+gF
+ib
+hf
+ie
+gC
+fZ
+fZ
 gm
-ge
-gt
-ge
-gK
-ig
-hk
-ij
-gH
-ge
-ge
-gr
-gr
-gr
-ge
-ge
+gm
+gm
+fZ
+fZ
 aa
 aa
 aa
@@ -70272,34 +70256,34 @@ af
 af
 af
 af
-ax
+aw
 af
 af
 af
 af
-bl
-bm
-bm
-bm
-bm
-bm
-bm
-bm
-bm
-bm
-bm
-bl
-dy
-dy
-dy
-dy
-dy
-dy
-dy
-dy
-dy
-dy
-fN
+bj
+bk
+bk
+bk
+bk
+bk
+bk
+bk
+bk
+bk
+bk
+bj
+dm
+dm
+dm
+dm
+dm
+dm
+dm
+dm
+dm
+dm
+fx
 aa
 aa
 aa
@@ -70349,49 +70333,49 @@ aa
 aa
 aa
 aa
-ge
-ge
-gr
-gr
-gr
-ge
-ge
-ge
-ge
-gV
-ge
-ge
-ge
-gt
-gv
+fZ
+fZ
 gm
-hG
 gm
-gG
-hG
-hG
-hG
-hG
-hG
-gG
 gm
-hG
+fZ
+fZ
+fZ
+fZ
+gQ
+fZ
+fZ
+fZ
+go
+gq
+gh
+hB
+gh
+gB
+hB
+hB
+hB
+hB
+hB
+gB
+gh
+hB
+gh
+gq
+go
+gq
+hY
+hf
+gp
+hf
+ii
+gF
+gh
 gm
-gv
-gt
-gv
-id
-hk
-gu
-hk
-in
-gK
 gm
-gr
-gr
-gr
-ge
-ge
+gm
+fZ
+fZ
 aa
 aa
 aa
@@ -70606,49 +70590,49 @@ aa
 aa
 aa
 aa
-ge
-ge
-gr
-gr
-gr
-ge
-ge
+fZ
+fZ
+gm
+gm
+gm
+fZ
+fZ
+gI
 gN
-gS
+gQ
 gV
 ha
-hf
-gG
-gt
-gv
+gB
+go
+gq
+gh
+hB
+gh
+gB
+hB
+hB
+gq
+hB
+hB
+gB
+gh
+hB
+gh
+gq
+go
+gq
+hZ
+ic
+gh
+if
+ij
+gF
+gh
 gm
-hG
 gm
-gG
-hG
-hG
-gv
-hG
-hG
-gG
 gm
-hG
-gm
-gv
-gt
-gv
-ie
-ih
-gm
-ik
-io
-gK
-gm
-gr
-gr
-gr
-ge
-ge
+fZ
+fZ
 aa
 aa
 aa
@@ -70791,29 +70775,29 @@ ah
 ah
 ah
 ah
+bj
 bl
 bn
-bp
-bF
-cf
-bF
-bn
-cf
-bF
-bo
-bn
+bD
+ca
+bD
 bl
-dz
-dV
-er
-eK
-eL
-eK
-eL
-fi
-fv
-dz
-fN
+ca
+bD
+bm
+bl
+bj
+dn
+dH
+ed
+ev
+ew
+ev
+ew
+eW
+fj
+dn
+fx
 aa
 aa
 aa
@@ -70863,49 +70847,49 @@ aa
 aa
 aa
 aa
-ge
-ge
-gr
-gr
-gr
-ge
-ge
-ge
-ge
-gV
-ge
-ge
-ge
-gt
-gv
-gm
-hG
-gm
-gG
-hG
-hG
-hG
-hG
-hG
-gG
-gm
-hG
-gm
-gv
-gt
-gv
-gK
+fZ
+fZ
 gm
 gm
 gm
-gH
-gK
+fZ
+fZ
+fZ
+fZ
+gQ
+fZ
+fZ
+fZ
+go
+gq
+gh
+hB
+gh
+gB
+hB
+hB
+hB
+hB
+hB
+gB
+gh
+hB
+gh
+gq
+go
+gq
+gF
+gh
+gh
+gh
+gC
+gF
+gh
 gm
-gr
-gr
-gr
-ge
-ge
+gm
+gm
+fZ
+fZ
 aa
 aa
 aa
@@ -71048,29 +71032,29 @@ ai
 ai
 ai
 ai
+bj
+bm
+bD
+bR
 bl
-bo
-bF
-bU
-bn
-bn
-bG
+bl
+bE
+cD
 cK
-cR
-cR
-cf
-bl
-dz
-dW
-es
-eL
-eK
-eL
-eK
-fj
-fw
-dz
-fN
+cK
+ca
+bj
+dn
+dI
+ee
+ew
+ev
+ew
+ev
+eX
+fk
+dn
+fx
 aa
 aa
 aa
@@ -71120,49 +71104,49 @@ aa
 aa
 aa
 aa
-ge
-ge
-gr
-gr
-gr
-ge
-ge
-ge
-ge
-gV
-gG
-gG
-gG
-gt
-ge
+fZ
+fZ
 gm
-hG
 gm
-ge
-gv
-hG
-hG
-hG
-gv
-ge
 gm
-hG
+fZ
+fZ
+fZ
+fZ
+gQ
+gB
+gB
+gB
+go
+fZ
+gh
+hB
+gh
+fZ
+gq
+hB
+hB
+hB
+gq
+fZ
+gh
+hB
+gh
+fZ
+go
+fZ
+gF
+ib
+hf
+ie
+gC
+fZ
+fZ
 gm
-ge
-gt
-ge
-gK
-ig
-hk
-ij
-gH
-ge
-ge
-gr
-gr
-gr
-ge
-ge
+gm
+gm
+fZ
+fZ
 aa
 aa
 aa
@@ -71305,29 +71289,29 @@ aj
 aj
 aj
 aj
+bj
 bl
-bn
-bG
-bV
-cg
-bn
-bn
-bU
-cS
-cT
-bn
+bE
+bS
+cb
 bl
-dz
-dX
-er
-eK
-eL
-eK
-eL
-fi
+bl
+bR
+cL
+cM
+bl
+bj
+dn
+dJ
+ed
+ev
+ew
+ev
+ew
+eW
+fl
+dn
 fx
-dz
-fN
 aa
 aa
 aa
@@ -71377,49 +71361,49 @@ aa
 aa
 aa
 aa
-ge
-ge
-gs
-gr
-gs
-ge
-ge
-ge
-ge
-gV
-ge
-ge
-ge
-gt
-gG
+fZ
+fZ
+gn
 gm
-hG
-gm
-hk
-gx
-hk
-gx
-hk
-gx
-hk
-gm
-hG
-gm
-gG
-gt
-ge
-id
-hk
-gu
-hk
-in
-ge
-ge
+gn
+fZ
+fZ
+fZ
+fZ
+gQ
+fZ
+fZ
+fZ
+go
+gB
+gh
+hB
+gh
+hf
 gs
-gr
+hf
 gs
-ge
-ge
+hf
+gs
+hf
+gh
+hB
+gh
+gB
+go
+fZ
+hY
+hf
+gp
+hf
+ii
+fZ
+fZ
+gn
+gm
+gn
+fZ
+fZ
 aa
 aa
 aa
@@ -71562,29 +71546,29 @@ aj
 aj
 aj
 aj
-bl
-bp
-bH
-bW
-ch
+bj
 bn
-bo
-cL
-cT
-cR
-bp
+bF
+bT
+cc
 bl
-dz
-dY
-es
-eL
-eK
-eL
-eK
-fj
-fy
-dz
-fN
+bm
+cE
+cM
+cK
+bn
+bj
+dn
+dK
+ee
+ew
+ev
+ew
+ev
+eX
+fm
+dn
+fx
 ab
 ab
 ab
@@ -71634,49 +71618,49 @@ aa
 aa
 aa
 aa
-ge
-ge
-gs
-gr
-gs
-ge
-ge
+fZ
+fZ
+gn
+gm
+gn
+fZ
+fZ
+gI
 gN
-gS
+gQ
 gV
 ha
+gB
+go
+gB
+gh
+hB
+gh
+gs
 hf
-gG
-gt
-gG
-gm
-hG
-gm
-gx
-hk
-gx
-hk
-gx
-hk
-gx
-gm
-hG
-gm
-gG
-gt
-ge
-ie
-ih
-gm
-ik
-io
-ge
-ge
 gs
-gr
+hf
 gs
-ge
-ge
+hf
+gs
+gh
+hB
+gh
+gB
+go
+fZ
+hZ
+ic
+gh
+if
+ij
+fZ
+fZ
+gn
+gm
+gn
+fZ
+fZ
 aa
 aa
 aa
@@ -71809,46 +71793,46 @@ aa
 "}
 (224,1,1) = {"
 ac
-al
-aA
-aJ
+ak
+ay
+aH
 aj
-aJ
-aJ
+aH
+aH
 aj
-aJ
-aA
-be
+aH
+ay
+bc
+bj
 bl
-bn
-bn
-bF
-cf
-bn
-bF
-bn
-cU
-dd
-bn
 bl
-dz
-dV
-er
-eK
-eL
-eK
-eL
-fi
-fv
-dz
-fN
+bD
+ca
+bl
+bD
+bl
+cN
+cW
+bl
+bj
+dn
+dH
+ed
+ev
+ew
+ev
+ew
+eW
+fj
+dn
+fx
 ab
-fR
-fR
-fR
-fR
-fR
-fR
+fB
+fB
+fB
+fB
+fB
+fB
 ab
 aa
 aa
@@ -71891,49 +71875,49 @@ aa
 aa
 aa
 aa
-ge
-ge
-gr
-gr
-gr
-ge
-ge
-ge
-ge
-gV
-ge
-ge
-ge
-gt
-gG
-gm
-hG
-gm
-hk
-gx
-hk
-gx
-hk
-gx
-hk
-gm
-hG
-gm
-gG
-gt
-ge
-gK
+fZ
+fZ
 gm
 gm
 gm
-gH
-ge
-ge
-gr
-gr
-gr
-ge
-ge
+fZ
+fZ
+fZ
+fZ
+gQ
+fZ
+fZ
+fZ
+go
+gB
+gh
+hB
+gh
+hf
+gs
+hf
+gs
+hf
+gs
+hf
+gh
+hB
+gh
+gB
+go
+fZ
+gF
+gh
+gh
+gh
+gC
+fZ
+fZ
+gm
+gm
+gm
+fZ
+fZ
 aa
 aa
 aa
@@ -72100,12 +72084,12 @@ ag
 ag
 ab
 ab
-fS
-fS
-fS
-fS
-fS
-fS
+fC
+fC
+fC
+fC
+fC
+fC
 ab
 ab
 ab
@@ -72148,49 +72132,49 @@ aa
 aa
 aa
 aa
-ge
-ge
-gr
-gr
-gr
-ge
-ge
-ge
-ge
-gV
-ge
-ge
-ge
-gt
-ge
+fZ
+fZ
 gm
 gm
 gm
-ge
-ge
-gG
-gG
-gG
-ge
-ge
+fZ
+fZ
+fZ
+fZ
+gQ
+fZ
+fZ
+fZ
+go
+fZ
+gh
+gh
+gh
+fZ
+fZ
+gB
+gB
+gB
+fZ
+fZ
+gh
+gh
+gh
+fZ
+go
+fZ
+gF
+ib
+hf
+ie
+gC
+gF
+gh
 gm
 gm
 gm
-ge
-gt
-ge
-gK
-ig
-hk
-ij
-gH
-gK
-gm
-gr
-gr
-gr
-ge
-ge
+fZ
+fZ
 aa
 aa
 aa
@@ -72323,39 +72307,39 @@ aa
 "}
 (226,1,1) = {"
 ac
-am
-aB
-ao
-ao
-aR
-aR
-aR
-aR
-aR
-aR
-bl
-bq
-bI
-bJ
-bJ
-ck
-cy
-bJ
-cV
-bJ
-dj
+al
+az
+an
+an
+aP
+aP
+aP
+aP
+aP
+aP
+bj
+bo
+bG
+bH
+bH
+cf
+cs
+bH
+cO
+bH
+cZ
 ac
-dA
-dZ
-et
-eM
-eU
-eU
-eU
-fk
-dZ
-fD
-fN
+do
+dL
+ef
+ex
+eH
+eH
+eH
+eY
+dL
+fq
+fx
 ab
 ab
 ab
@@ -72363,91 +72347,91 @@ ab
 ab
 ab
 ab
+fU
+fV
+ab
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
 fZ
-ga
-ab
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-ge
-ge
-gr
-gr
-gr
-ge
-ge
-ge
-ge
-gV
-gG
-gG
-gG
+fZ
 gm
 gm
 gm
+fZ
+fZ
+fZ
+fZ
+gQ
+gB
+gB
+gB
+gh
+gh
+gh
+gh
+gh
+gh
+gh
+gh
+gh
+gh
+gh
+gh
+gh
+gh
+gh
+gh
+gh
+gC
+hY
+hf
+gp
+hf
+ii
+gF
+gh
 gm
 gm
 gm
-gm
-gm
-gm
-gm
-gm
-gm
-gm
-gm
-gm
-gm
-gm
-gH
-id
-hk
-gu
-hk
-in
-gK
-gm
-gr
-gr
-gr
-ge
-ge
+fZ
+fZ
 aa
 aa
 aa
@@ -72580,39 +72564,39 @@ aa
 "}
 (227,1,1) = {"
 ac
+am
 an
-ao
-aK
-ao
-aS
-aV
+aI
+an
+aQ
+aT
+aY
 ba
-bc
-bc
-bf
-bl
-br
-bJ
-bJ
-bJ
-bJ
-bJ
-bJ
-cW
-bJ
-dk
+ba
+bd
+bj
+bp
+bH
+bH
+bH
+bH
+bH
+bH
+cP
+bH
+da
 ac
-dB
-dZ
-eu
-eN
-eU
-eU
-eU
-fk
-dZ
-fD
-fN
+dp
+dL
+eg
+ey
+eH
+eH
+eH
+eY
+dL
+fq
+fx
 ab
 ab
 ab
@@ -72620,91 +72604,91 @@ ab
 ab
 ab
 ab
+fU
+fV
+ab
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
 fZ
-ga
-ab
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-ge
-ge
-gr
-gr
-gr
-ge
-ge
-ge
-ge
-gV
-ge
-ge
-ge
-ge
-ge
+fZ
 gm
 gm
 gm
+fZ
+fZ
+fZ
+fZ
+gQ
+fZ
+fZ
+fZ
+fZ
+fZ
+gh
+gh
+gh
+gh
+gh
+gh
+gh
+gh
+gh
+gh
+gh
+gh
+gh
+fZ
+fZ
+fZ
+ia
+id
+gJ
+ig
+ik
+gF
+gh
 gm
 gm
 gm
-gm
-gm
-gm
-gm
-gm
-gm
-gm
-ge
-ge
-ge
-if
-ii
-gO
-il
-ip
-gK
-gm
-gr
-gr
-gr
-ge
-ge
+fZ
+fZ
 aa
 aa
 aa
@@ -72837,39 +72821,39 @@ aa
 "}
 (228,1,1) = {"
 ac
-ao
-aC
-aL
-aP
-ao
-aW
-bb
-bb
-bb
-bg
-bl
-bs
-bJ
-bZ
-ci
-cm
-cA
-bJ
+an
+aA
+aJ
+aN
+an
+aU
+aZ
+aZ
+aZ
+be
+bj
+bq
+bH
+bU
+cd
+cg
+ct
+bH
+cQ
 cX
-dg
-dl
+db
 ac
-dC
-ea
-eu
-eO
-eU
-eU
-eU
-fl
-dZ
-fD
-fN
+dq
+dM
+eg
+ez
+eH
+eH
+eH
+eZ
+dL
+fq
+fx
 ab
 ab
 ab
@@ -72877,91 +72861,91 @@ ab
 ab
 ab
 ab
+fU
+fV
+ab
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
 fZ
-ga
-ab
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-ge
-ge
-gr
-gr
-gr
-ge
-ge
-ge
-ge
-gW
-ge
-ge
-ge
-ge
-ge
-gV
-ge
-gG
-ge
-ge
-hk
-hk
-hk
-ge
-ge
-gG
-ge
-gV
-ge
-ge
-ge
-ge
-gT
-gT
-gT
-ge
-ge
-ge
-gr
-gr
-gr
-ge
-ge
+fZ
+gm
+gm
+gm
+fZ
+fZ
+fZ
+fZ
+gR
+fZ
+fZ
+fZ
+fZ
+fZ
+gQ
+fZ
+gB
+fZ
+fZ
+hf
+hf
+hf
+fZ
+fZ
+gB
+fZ
+gQ
+fZ
+fZ
+fZ
+fZ
+gO
+gO
+gO
+fZ
+fZ
+fZ
+gm
+gm
+gm
+fZ
+fZ
 aa
 aa
 aa
@@ -73094,39 +73078,39 @@ aa
 "}
 (229,1,1) = {"
 ac
-ao
-aC
-aM
-aP
-ao
-aX
-bb
-bb
-bb
-bg
-bl
-bt
-bJ
-ca
-ci
-bJ
-bJ
-bJ
-bJ
-bJ
-dm
+an
+aA
+aK
+aN
+an
+aV
+aZ
+aZ
+aZ
+be
+bj
+br
+bH
+bV
+cd
+bH
+bH
+bH
+bH
+bH
+dc
 ac
-dD
-dZ
-eu
-eP
-eU
-eU
-eU
-fk
-dZ
-fD
-fN
+dr
+dL
+eg
+eA
+eH
+eH
+eH
+eY
+dL
+fq
+fx
 ab
 ab
 ab
@@ -73134,91 +73118,91 @@ ab
 ab
 ab
 ab
+fU
+fV
+ab
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
 fZ
-ga
-ab
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-ge
-gi
-gu
-gu
-gu
-gD
-ge
-gi
-gu
-gu
-gu
-gD
-ge
-ge
-ge
-gV
-gG
-gG
-gG
-hk
-hk
-hk
-hk
-hk
-gG
-gG
-gG
-gV
-ge
-ge
-ge
-gi
-gu
-gu
-gu
-gD
-ge
-gi
-gu
-gu
-gu
-gD
-ge
+gd
+gp
+gp
+gp
+gy
+fZ
+gd
+gp
+gp
+gp
+gy
+fZ
+fZ
+fZ
+gQ
+gB
+gB
+gB
+hf
+hf
+hf
+hf
+hf
+gB
+gB
+gB
+gQ
+fZ
+fZ
+fZ
+gd
+gp
+gp
+gp
+gy
+fZ
+gd
+gp
+gp
+gp
+gy
+fZ
 aa
 aa
 aa
@@ -73351,39 +73335,39 @@ aa
 "}
 (230,1,1) = {"
 ac
-ap
 ao
-aN
-ao
-aS
-aV
+an
+aL
+an
+aQ
+aT
+aZ
 bb
-bd
-bd
-bh
-bl
-bu
-bJ
-cb
-ci
-cn
-cB
-bJ
-bJ
-bJ
-dn
+bb
+bf
+bj
+bs
+bH
+bW
+cd
+ch
+cu
+bH
+bH
+bH
+dd
 ac
-dE
-dZ
-ev
-eM
-eU
-eU
-eU
-fk
-dZ
-fD
-fN
+ds
+dL
+eh
+ex
+eH
+eH
+eH
+eY
+dL
+fq
+fx
 ab
 ab
 ab
@@ -73391,91 +73375,91 @@ ab
 ab
 ab
 ab
+fU
+fV
+ab
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
 fZ
-ga
-ab
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
 ge
-gj
-gm
-gm
-gm
-gE
-gx
-gj
-gm
-gm
-gm
-gE
+gh
+gh
+gh
+gz
+gs
 ge
+gh
+gh
+gh
+gz
+fZ
+fZ
+fZ
+gQ
+fZ
+gB
+fZ
+hf
+gh
+gh
+gh
+hf
+fZ
+gB
+fZ
+gQ
+fZ
+fZ
+fZ
 ge
+gh
+gh
+gh
+gz
+gs
 ge
-gV
-ge
-gG
-ge
-hk
-gm
-gm
-gm
-hk
-ge
-gG
-ge
-gV
-ge
-ge
-ge
-gj
-gm
-gm
-gm
-gE
-gx
-gj
-gm
-gm
-gm
-gE
-ge
+gh
+gh
+gh
+gz
+fZ
 aa
 aa
 aa
@@ -73642,12 +73626,12 @@ ag
 ag
 ab
 ab
-fT
-fT
-fT
-fT
-fT
-fT
+fD
+fD
+fD
+fD
+fD
+fD
 ab
 ab
 ab
@@ -73690,49 +73674,49 @@ aa
 aa
 aa
 aa
+fZ
 ge
-gj
-gv
-gv
-gv
-gE
-gx
-gj
-gv
-gv
-gv
-gE
-gV
-gV
-gV
-gV
-gV
-gV
+gq
+gq
+gq
+gz
+gs
 ge
-hk
+gq
+gq
+gq
+gz
+gQ
+gQ
+gQ
+gQ
+gQ
+gQ
+fZ
+hf
+fZ
+gq
+fZ
+hf
+fZ
+gQ
+gQ
+gQ
+gQ
+gQ
+gQ
 ge
-gv
+gq
+gq
+gq
+gz
+gs
 ge
-hk
-ge
-gV
-gV
-gV
-gV
-gV
-gV
-gj
-gv
-gv
-gv
-gE
-gx
-gj
-gv
-gv
-gv
-gE
-ge
+gq
+gq
+gq
+gz
+fZ
 aa
 aa
 aa
@@ -73865,47 +73849,47 @@ aa
 "}
 (232,1,1) = {"
 ac
-aq
-aq
-aq
-aq
-aq
-aq
-aq
-aq
-aq
-aq
-bl
-bv
-bL
-bL
-bL
-co
-cC
-cM
-cM
-cM
-do
-bl
-dF
-eb
-ew
-ex
-eV
-fb
-ex
-fm
-fz
+ap
+ap
+ap
+ap
+ap
+ap
+ap
+ap
+ap
+ap
+bj
+bt
+bI
+bI
+bI
+ci
+cv
+cF
+cF
+cF
+de
+bj
+dt
+dN
+ei
+ej
+eI
+eP
+ej
+fa
+fn
+fr
+fx
+fy
 fE
+fL
 fN
-fP
-fU
-Iw
-IJ
-IJ
-Je
-fU
-fP
+fN
+fS
+fE
+fy
 ab
 aa
 aa
@@ -73947,49 +73931,49 @@ aa
 aa
 aa
 aa
+fZ
 ge
-gj
-gm
-gv
-gm
-gE
-gx
-gj
-gm
-gv
-gm
-gE
+gh
+gq
+gh
+gz
+gs
 ge
+gh
+gq
+gh
+gz
+fZ
+fZ
+fZ
+gQ
+fZ
+fZ
+fZ
+hf
+gh
+gh
+gh
+hf
+fZ
+fZ
+fZ
+gQ
+fZ
+fZ
+fZ
 ge
+gh
+gq
+gh
+gz
+gs
 ge
-gV
-ge
-ge
-ge
-hk
-gm
-gm
-gm
-hk
-ge
-ge
-ge
-gV
-ge
-ge
-ge
-gj
-gm
-gv
-gm
-gE
-gx
-gj
-gm
-gv
-gm
-gE
-ge
+gh
+gq
+gh
+gz
+fZ
 aa
 aa
 aa
@@ -74122,47 +74106,47 @@ aa
 "}
 (233,1,1) = {"
 ac
-aq
-aD
-aq
-aq
-aq
-aq
-aq
-aq
-aD
-aq
-bl
-bv
-bL
-cc
-bM
-cp
-cD
-bM
-cY
-cM
-do
-bl
-dG
-ec
-ex
-ex
-eW
-eW
-fh
-fn
-fA
-fF
-fN
-fQ
-fQ
-fQ
-fQ
-fQ
-fQ
-fQ
-fQ
+ap
+aB
+ap
+ap
+ap
+ap
+ap
+ap
+aB
+ap
+bj
+bt
+bI
+bX
+bJ
+cj
+cw
+bJ
+cR
+cF
+de
+bj
+du
+dO
+ej
+ej
+eJ
+eJ
+eV
+fb
+fo
+fs
+fx
+fz
+fz
+fz
+fz
+fz
+fz
+fz
+fz
 ab
 aa
 aa
@@ -74204,49 +74188,49 @@ aa
 aa
 aa
 aa
-ge
-gk
-gw
-gw
-gw
-gF
-ge
-gk
-gw
-gw
-gw
-gF
-ge
-ge
-ge
-gV
-ge
-ge
-ge
-hk
-hk
-hk
-hk
-hk
-ge
-ge
-ge
-gV
-ge
-ge
-ge
-gk
-gw
-gw
-gw
-gF
-ge
-gk
-gw
-gw
-gw
-gF
-ge
+fZ
+gf
+gr
+gr
+gr
+gA
+fZ
+gf
+gr
+gr
+gr
+gA
+fZ
+fZ
+fZ
+gQ
+fZ
+fZ
+fZ
+hf
+hf
+hf
+hf
+hf
+fZ
+fZ
+fZ
+gQ
+fZ
+fZ
+fZ
+gf
+gr
+gr
+gr
+gA
+fZ
+gf
+gr
+gr
+gr
+gA
+fZ
 aa
 aa
 aa
@@ -74379,47 +74363,47 @@ aa
 "}
 (234,1,1) = {"
 ac
-aq
-aq
-aq
-aq
-aD
-aD
-aq
-aq
-aq
-aq
-bl
-bw
-bM
-cc
-bM
-cp
-cD
-cN
-cY
-bM
-dp
-bl
-dG
-ed
-ey
-ex
-ex
-ex
-fh
+ap
+ap
+ap
+ap
+aB
+aB
+ap
+ap
+ap
+ap
+bj
+bu
+bJ
+bX
+bJ
+cj
+cw
+cG
+cR
+bJ
+df
+bj
+du
+dP
+ek
+ej
+ej
+ej
+eV
+fc
 fo
+fs
+fx
 fA
 fF
-fN
-Ij
-Il
-Il
-Il
-Il
-Il
-Il
-Ij
+fF
+fF
+fF
+fF
+fF
+fA
 ab
 aa
 aa
@@ -74461,49 +74445,49 @@ aa
 aa
 aa
 aa
-ge
-ge
-gx
-gx
-gx
-ge
-ge
-ge
-gx
-gx
-gx
-ge
-ge
-ge
-ge
-ge
-ge
-ge
-ge
-ge
-hk
-hk
-hk
-ge
-ge
-ge
-ge
-ge
-ge
-ge
-ge
-ge
-gx
-gx
-gx
-ge
-ge
-ge
-gx
-gx
-gx
-ge
-ge
+fZ
+fZ
+gs
+gs
+gs
+fZ
+fZ
+fZ
+gs
+gs
+gs
+fZ
+fZ
+fZ
+fZ
+fZ
+fZ
+fZ
+fZ
+fZ
+hf
+hf
+hf
+fZ
+fZ
+fZ
+fZ
+fZ
+fZ
+fZ
+fZ
+fZ
+gs
+gs
+gs
+fZ
+fZ
+fZ
+gs
+gs
+gs
+fZ
+fZ
 aa
 aa
 aa
@@ -74636,47 +74620,47 @@ aa
 "}
 (235,1,1) = {"
 ac
-aq
-aD
-aq
-aq
-aq
-aq
-aq
-aq
-aD
-aq
-bl
-bx
-bN
-cc
-bM
-cp
-cD
-bM
-cY
-cO
-dq
-bl
-dG
-ee
-ex
-ex
-eX
-eX
-fh
-fp
-fA
-fF
-fN
-fQ
-Im
-Im
-Im
-Im
-Im
-Im
-fQ
+ap
+aB
+ap
+ap
+ap
+ap
+ap
+ap
+aB
+ap
+bj
+bv
+bK
+bX
+bJ
+cj
+cw
+bJ
+cR
+cH
+dg
+bj
+du
+dQ
+ej
+ej
+eK
+eK
+eV
+fd
+fo
+fs
+fx
+fz
+fG
+fG
+fG
+fG
+fG
+fG
+fz
 ab
 aa
 aa
@@ -74718,49 +74702,49 @@ aa
 aa
 aa
 aa
-ge
-gi
-gu
-gu
-gu
-gD
-ge
-gi
-gu
-gu
-gu
-gD
-ge
-hk
-hk
-hk
-hk
-hk
-ge
-hk
-hk
-hk
-hk
-hk
-ge
-hk
-hk
-hk
-hk
-hk
-ge
-gi
-gu
-gu
-gu
-gD
-ge
-gi
-gu
-gu
-gu
-gD
-ge
+fZ
+gd
+gp
+gp
+gp
+gy
+fZ
+gd
+gp
+gp
+gp
+gy
+fZ
+hf
+hf
+hf
+hf
+hf
+fZ
+hf
+hf
+hf
+hf
+hf
+fZ
+hf
+hf
+hf
+hf
+hf
+fZ
+gd
+gp
+gp
+gp
+gy
+fZ
+gd
+gp
+gp
+gp
+gy
+fZ
 aa
 aa
 aa
@@ -74893,47 +74877,47 @@ aa
 "}
 (236,1,1) = {"
 ac
-aq
-aq
-aq
-aq
-aq
-aq
-aq
-aq
-aq
-aq
-bl
-bx
-bN
-bN
-bN
-cq
-cE
-cO
-cO
-cO
-dq
-bl
-dF
-ef
-ez
-ex
-eY
-fc
-ex
-fq
+ap
+ap
+ap
+ap
+ap
+ap
+ap
+ap
+ap
+ap
+bj
+bv
+bK
+bK
+bK
+ck
+cx
+cH
+cH
+cH
+dg
+bj
+dt
+dR
+el
+ej
+eL
+eQ
+ej
+fe
+fn
+ft
+fx
 fz
-fG
-fN
-fQ
-In
-In
-In
-In
-In
-In
-fQ
+fH
+fH
+fH
+fH
+fH
+fH
+fz
 ab
 aa
 aa
@@ -74975,49 +74959,49 @@ aa
 aa
 aa
 aa
+fZ
 ge
-gj
-gm
-gv
-gm
-gE
-gG
-gj
-gm
-gv
-gm
-gE
-hk
-hk
-gm
+gh
+gq
+gh
+gz
+gB
 ge
-gm
-hk
-hk
-hk
-gv
-hH
-gv
-hk
-hk
-hk
-gm
+gh
+gq
+gh
+gz
+hf
+hf
+gh
+fZ
+gh
+hf
+hf
+hf
+gq
+hC
+gq
+hf
+hf
+hf
+gh
+fZ
+gh
+hf
+hf
 ge
-gm
-hk
-hk
-gj
-gm
-gv
-gm
-gE
-gG
-gj
-gm
-gv
-gm
-gE
+gh
+gq
+gh
+gz
+gB
 ge
+gh
+gq
+gh
+gz
+fZ
 aa
 aa
 aa
@@ -75183,14 +75167,14 @@ ag
 ag
 ag
 ab
-fQ
-In
-In
-In
-In
-In
-In
-fQ
+fz
+fH
+fH
+fH
+fH
+fH
+fH
+fz
 ab
 aa
 aa
@@ -75232,49 +75216,49 @@ aa
 aa
 aa
 aa
+fZ
 ge
-gj
-gv
-gv
-gv
-gE
-gG
-gj
-gv
-gv
-gv
-gE
-hk
-hk
-gm
-gv
-gm
-hk
-hk
-hk
-hH
-hK
-hH
-hk
-hk
-hk
-gm
-gv
-gm
-hk
-hk
-gj
-gv
-gv
-gv
-gE
-gG
-gj
-gv
-gv
-gv
-gE
+gq
+gq
+gq
+gz
+gB
 ge
+gq
+gq
+gq
+gz
+hf
+hf
+gh
+gq
+gh
+hf
+hf
+hf
+hC
+hF
+hC
+hf
+hf
+hf
+gh
+gq
+gh
+hf
+hf
+ge
+gq
+gq
+gq
+gz
+gB
+ge
+gq
+gq
+gq
+gz
+fZ
 aa
 aa
 aa
@@ -75407,47 +75391,47 @@ aa
 "}
 (238,1,1) = {"
 ac
-ar
-ar
-ar
-ar
-ar
-ar
-ar
-ar
-ar
-ar
-bl
-by
-by
-by
-by
-by
-by
-by
-cZ
-di
-dr
-bl
-dH
-eg
-eA
-eQ
-eZ
-fd
-eZ
-fd
-eZ
-eD
-fN
-fQ
-In
-In
-fX
-fX
-In
-In
-fQ
+aq
+aq
+aq
+aq
+aq
+aq
+aq
+aq
+aq
+aq
+bj
+bw
+bw
+bw
+bw
+bw
+bw
+bw
+cS
+cY
+dh
+bj
+dv
+dS
+em
+eB
+eM
+eR
+eM
+eR
+eM
+ep
+fx
+fz
+fH
+fH
+fO
+fO
+fH
+fH
+fz
 ab
 aa
 aa
@@ -75489,49 +75473,49 @@ aa
 aa
 aa
 aa
+fZ
 ge
-gj
-gm
-gv
-gm
-gE
-gG
-gj
-gm
-gv
-gm
-gE
-hk
-hk
-gm
+gh
+gq
+gh
+gz
+gB
 ge
-gm
-hk
-hk
-hk
-gv
-hH
-gv
-hk
-hk
-hk
-gm
+gh
+gq
+gh
+gz
+hf
+hf
+gh
+fZ
+gh
+hf
+hf
+hf
+gq
+hC
+gq
+hf
+hf
+hf
+gh
+fZ
+gh
+hf
+hf
 ge
-gm
-hk
-hk
-gj
-gm
-gv
-gm
-gE
-gG
-gj
-gm
-gv
-gm
-gE
+gh
+gq
+gh
+gz
+gB
 ge
+gh
+gq
+gh
+gz
+fZ
 aa
 aa
 aa
@@ -75664,47 +75648,47 @@ aa
 "}
 (239,1,1) = {"
 ac
-ar
-ar
-ar
-ar
-ar
-ar
-ar
-ar
-ar
-ar
-bl
-by
-bO
-cd
-by
-cr
-by
-by
-da
-di
-dr
-bl
-dI
-eh
+aq
+aq
+aq
+aq
+aq
+aq
+aq
+aq
+aq
+aq
+bj
+bw
+bL
+bY
+bw
+cl
+bw
+bw
+cT
+cY
+dh
+bj
+dw
+dT
+en
 eB
-eQ
-fa
-fe
-fa
-fe
-fa
-eB
-fN
-fQ
-In
-In
-fY
-IY
-In
-In
-fQ
+eN
+eS
+eN
+eS
+eN
+en
+fx
+fz
+fH
+fH
+fP
+fR
+fH
+fH
+fz
 ab
 aa
 aa
@@ -75746,49 +75730,49 @@ aa
 aa
 aa
 aa
-ge
-gk
-gw
-gw
-gw
-gF
-ge
-gk
-gw
-gw
-gw
-gF
-ge
-hk
-hk
-hk
-hk
-hk
-ge
-hk
-hk
-hk
-hk
-hk
-ge
-hk
-hk
-hk
-hk
-hk
-ge
-gk
-gw
-gw
-gw
-gF
-ge
-gk
-gw
-gw
-gw
-gF
-ge
+fZ
+gf
+gr
+gr
+gr
+gA
+fZ
+gf
+gr
+gr
+gr
+gA
+fZ
+hf
+hf
+hf
+hf
+hf
+fZ
+hf
+hf
+hf
+hf
+hf
+fZ
+hf
+hf
+hf
+hf
+hf
+fZ
+gf
+gr
+gr
+gr
+gA
+fZ
+gf
+gr
+gr
+gr
+gA
+fZ
 aa
 aa
 aa
@@ -75921,47 +75905,47 @@ aa
 "}
 (240,1,1) = {"
 ac
-ar
-ar
-ar
-ar
-ar
-ar
-ar
-ar
-ar
-ar
-bl
-by
-by
-by
-by
-by
-by
-by
-db
-di
-dr
-bl
-dJ
-ei
-eC
-eQ
-eQ
-eQ
-eQ
-eQ
-eQ
-eQ
-fN
-fQ
-In
-In
-fX
-fX
-In
-In
-fQ
+aq
+aq
+aq
+aq
+aq
+aq
+aq
+aq
+aq
+aq
+bj
+bw
+bw
+bw
+bw
+bw
+bw
+bw
+cU
+cY
+dh
+bj
+dx
+dU
+eo
+eB
+eB
+eB
+eB
+eB
+eB
+eB
+fx
+fz
+fH
+fH
+fO
+fO
+fH
+fH
+fz
 ab
 aa
 aa
@@ -76003,49 +75987,49 @@ aa
 aa
 aa
 aa
-ge
-ge
-gx
-gx
-gx
-ge
-ge
-ge
-gx
-gx
-gx
-ge
-ge
-ge
-ge
-ge
-ge
-ge
-ge
-ge
-hk
-hk
-hk
-ge
-ge
-ge
-ge
-ge
-ge
-ge
-ge
-ge
-gx
-gx
-gx
-ge
-ge
-ge
-gx
-gx
-gx
-ge
-ge
+fZ
+fZ
+gs
+gs
+gs
+fZ
+fZ
+fZ
+gs
+gs
+gs
+fZ
+fZ
+fZ
+fZ
+fZ
+fZ
+fZ
+fZ
+fZ
+hf
+hf
+hf
+fZ
+fZ
+fZ
+fZ
+fZ
+fZ
+fZ
+fZ
+fZ
+gs
+gs
+gs
+fZ
+fZ
+fZ
+gs
+gs
+gs
+fZ
+fZ
 aa
 aa
 aa
@@ -76178,47 +76162,47 @@ aa
 "}
 (241,1,1) = {"
 ac
-ar
-ar
-ar
-ar
-ar
-ar
-ar
-ar
-ar
-ar
-bl
-by
-bP
-cd
-by
-by
-cF
-by
-cZ
-di
-dr
-bl
-dK
-ej
-eD
-eQ
-eZ
-fd
-eZ
-fd
-eZ
-eD
-fN
-fQ
-In
-In
-In
-In
-In
-In
-fQ
+aq
+aq
+aq
+aq
+aq
+aq
+aq
+aq
+aq
+aq
+bj
+bw
+bM
+bY
+bw
+bw
+cy
+bw
+cS
+cY
+dh
+bj
+dy
+dV
+ep
+eB
+eM
+eR
+eM
+eR
+eM
+ep
+fx
+fz
+fH
+fH
+fH
+fH
+fH
+fH
+fz
 ab
 aa
 aa
@@ -76260,49 +76244,49 @@ aa
 aa
 aa
 aa
-ge
-gi
-gu
-gu
-gu
-gD
-ge
-gi
-gu
-gu
-gu
-gD
-ge
-gi
-gu
-gu
-gu
-gD
-ge
-hk
-hk
-hk
-hk
-hk
-ge
-gi
-gu
-gu
-gu
-gD
-ge
-gi
-gu
-gu
-gu
-gD
-ge
-gi
-gu
-gu
-gu
-gD
-ge
+fZ
+gd
+gp
+gp
+gp
+gy
+fZ
+gd
+gp
+gp
+gp
+gy
+fZ
+gd
+gp
+gp
+gp
+gy
+fZ
+hf
+hf
+hf
+hf
+hf
+fZ
+gd
+gp
+gp
+gp
+gy
+fZ
+gd
+gp
+gp
+gp
+gy
+fZ
+gd
+gp
+gp
+gp
+gy
+fZ
 aa
 aa
 aa
@@ -76435,47 +76419,47 @@ aa
 "}
 (242,1,1) = {"
 ac
-ar
-ar
-ar
-ar
-ar
-ar
-ar
-ar
-ar
-ar
-bl
-by
-by
-by
-by
-by
-by
-by
-cZ
-di
-dr
-bl
-dL
-ek
-eE
-eQ
-fa
-fe
-fa
-fe
-fa
+aq
+aq
+aq
+aq
+aq
+aq
+aq
+aq
+aq
+aq
+bj
+bw
+bw
+bw
+bw
+bw
+bw
+bw
+cS
+cY
+dh
+bj
+dz
+dW
+eq
 eB
-fN
-fQ
-In
-In
-In
-In
-In
-In
-fQ
+eN
+eS
+eN
+eS
+eN
+en
+fx
+fz
+fH
+fH
+fH
+fH
+fH
+fH
+fz
 ab
 aa
 aa
@@ -76517,49 +76501,49 @@ aa
 aa
 aa
 aa
+fZ
 ge
-gj
-gm
-gv
-gm
-gE
-gx
-gj
-gm
-gv
-gm
-gE
-gx
-gj
-gm
-gv
-gm
-gE
+gh
+gq
+gh
+gz
+gs
 ge
-hk
-gm
-gm
-gm
-hk
+gh
+gq
+gh
+gz
+gs
 ge
-gj
-hk
-gv
-hk
-gE
-gx
-gj
-gm
-gv
-gm
-gE
-gx
-gj
-gm
-gv
-gm
-gE
+gh
+gq
+gh
+gz
+fZ
+hf
+gh
+gh
+gh
+hf
+fZ
 ge
+hf
+gq
+hf
+gz
+gs
+ge
+gh
+gq
+gh
+gz
+gs
+ge
+gh
+gq
+gh
+gz
+fZ
 aa
 aa
 aa
@@ -76725,14 +76709,14 @@ ag
 ag
 ag
 ab
-fQ
-Iu
-Iu
-Iu
-Iu
-Iu
-Iu
-fQ
+fz
+fI
+fI
+fI
+fI
+fI
+fI
+fz
 ab
 aa
 aa
@@ -76774,49 +76758,49 @@ aa
 aa
 aa
 aa
+fZ
 ge
-gj
-gv
-gv
-gv
-gE
-gx
-gj
-gv
-gv
-gv
-gE
-gx
-gj
-gv
-gv
-gv
-gE
+gq
+gq
+gq
+gz
+gs
 ge
-hk
+gq
+gq
+gq
+gz
+gs
 ge
-gv
+gq
+gq
+gq
+gz
+fZ
+hf
+fZ
+gq
+fZ
+hf
+fZ
 ge
-hk
+gq
+gq
+gq
+gz
+gs
 ge
-gj
-gv
-gv
-gv
-gE
-gx
-gj
-gv
-gv
-gv
-gE
-gx
-gj
-gv
-gv
-gv
-gE
+gq
+gq
+gq
+gz
+gs
 ge
+gq
+gq
+gq
+gz
+fZ
 aa
 aa
 aa
@@ -76949,47 +76933,47 @@ aa
 "}
 (244,1,1) = {"
 ac
-as
-as
-as
-as
-as
-as
-as
-as
-as
-as
-bl
+ar
+ar
+ar
+ar
+ar
+ar
+ar
+ar
+ar
+ar
+bj
+bx
+bN
+bN
+bN
+cm
+cz
+bN
+bN
+bN
 bz
-bQ
-bQ
-bQ
-cs
-cG
-bQ
-bQ
-bQ
-bB
-bl
-dM
-dM
-dM
-dM
-dM
-dM
-dM
-dM
-dM
-dM
-fN
-Ij
-Il
-Il
-Il
-Il
-Il
-Il
-Ij
+bj
+dA
+dA
+dA
+dA
+dA
+dA
+dA
+dA
+dA
+dA
+fx
+fA
+fF
+fF
+fF
+fF
+fF
+fF
+fA
 ab
 aa
 aa
@@ -77031,49 +77015,49 @@ aa
 aa
 aa
 aa
+fZ
 ge
-gj
-gm
-gm
-gm
-gE
-gx
-gj
-gm
-gm
-gm
-gE
-gx
-gj
-gm
-gv
-gm
-gE
+gh
+gh
+gh
+gz
+gs
 ge
-hk
-gm
-gm
-gm
-hk
+gh
+gh
+gh
+gz
+gs
 ge
-gj
-hk
-gv
-hk
-gE
-gx
-gj
-gm
-gm
-gm
-gE
-gx
-gj
-gm
-gm
-gm
-gE
+gh
+gq
+gh
+gz
+fZ
+hf
+gh
+gh
+gh
+hf
+fZ
 ge
+hf
+gq
+hf
+gz
+gs
+ge
+gh
+gh
+gh
+gz
+gs
+ge
+gh
+gh
+gh
+gz
+fZ
 aa
 aa
 aa
@@ -77206,47 +77190,47 @@ aa
 "}
 (245,1,1) = {"
 ac
-as
-aE
-as
-as
-as
-as
-as
-as
-aE
-as
-bl
-bA
-bQ
-bQ
-bQ
-cs
-cG
-bQ
-bQ
-bQ
-dt
-bl
-dM
-em
-dM
-QJ
-QL
-fg
-QL
-QK
-QL
-dM
-fN
-fQ
-fQ
-fQ
-fQ
-fQ
-fQ
-fQ
-fQ
+ar
+aC
+ar
+ar
+ar
+ar
+ar
+ar
+aC
+ar
+bj
+by
+bN
+bN
+bN
+cm
+cz
+bN
+bN
+bN
+di
+bj
+dA
+dX
+dA
+eC
+eO
+eT
+eO
+eD
+eO
+dA
+fx
+fz
+fz
+fz
+fz
+fz
+fz
+fz
+fz
 ab
 aa
 aa
@@ -77288,49 +77272,49 @@ aa
 aa
 aa
 aa
-ge
-gk
-gw
-gw
-gw
-gF
-ge
-gk
-gw
-gw
-gw
-gF
-ge
-gk
-gw
-gw
-gw
-gF
-ge
-hk
-hk
-hk
-hk
-hk
-ge
-gk
-gw
-gw
-gw
-gF
-ge
-gk
-gw
-gw
-gw
-gF
-ge
-gk
-gw
-gw
-gw
-gF
-ge
+fZ
+gf
+gr
+gr
+gr
+gA
+fZ
+gf
+gr
+gr
+gr
+gA
+fZ
+gf
+gr
+gr
+gr
+gA
+fZ
+hf
+hf
+hf
+hf
+hf
+fZ
+gf
+gr
+gr
+gr
+gA
+fZ
+gf
+gr
+gr
+gr
+gA
+fZ
+gf
+gr
+gr
+gr
+gA
+fZ
 aa
 aa
 aa
@@ -77463,47 +77447,47 @@ aa
 "}
 (246,1,1) = {"
 ac
-as
-as
-as
-aE
-as
-as
-aE
-as
-as
-as
-bl
-bA
-bQ
-bQ
-bQ
-cs
-cG
-bQ
-bQ
-bQ
-dt
-bl
-dM
-QH
-dM
-dM
-dM
-dM
-dM
-dM
-dM
-dM
-fN
-fP
-fV
-II
-IS
-IS
-Jq
-fV
-fP
+ar
+ar
+ar
+aC
+ar
+ar
+aC
+ar
+ar
+ar
+bj
+by
+bN
+bN
+bN
+cm
+cz
+bN
+bN
+bN
+di
+bj
+dA
+dY
+dA
+dA
+dA
+dA
+dA
+dA
+dA
+dA
+fx
+fy
+fJ
+fM
+fQ
+fQ
+fT
+fJ
+fy
 ab
 aa
 aa
@@ -77545,49 +77529,49 @@ aa
 aa
 aa
 aa
-ge
-ge
-gx
-gx
-gx
-ge
-ge
-ge
-gx
-gx
-gx
-ge
-ge
-ge
-hv
-hv
-hv
-ge
-ge
-ge
-ge
-ge
-ge
-ge
-ge
-ge
-hv
-hv
-hv
-ge
-ge
-ge
-gx
-gx
-gx
-ge
-ge
-ge
-gx
-gx
-gx
-ge
-ge
+fZ
+fZ
+gs
+gs
+gs
+fZ
+fZ
+fZ
+gs
+gs
+gs
+fZ
+fZ
+fZ
+hq
+hq
+hq
+fZ
+fZ
+fZ
+fZ
+fZ
+fZ
+fZ
+fZ
+fZ
+hq
+hq
+hq
+fZ
+fZ
+fZ
+gs
+gs
+gs
+fZ
+fZ
+fZ
+gs
+gs
+gs
+fZ
+fZ
 aa
 aa
 aa
@@ -77720,46 +77704,46 @@ aa
 "}
 (247,1,1) = {"
 ac
-as
-aE
-as
-as
-as
-as
-as
-as
-aE
-as
-bl
-bA
-bQ
-bQ
-bQ
-cs
-cG
-bQ
-bQ
-bQ
-dt
-bl
-dM
-QI
-dM
-QK
-QL
-QN
-QL
-fr
-QL
-dM
-fN
+ar
+aC
+ar
+ar
+ar
+ar
+ar
+ar
+aC
+ar
+bj
+by
+bN
+bN
+bN
+cm
+cz
+bN
+bN
+bN
+di
+bj
+dA
+dZ
+dA
+eD
+eO
+eU
+eO
+ff
+eO
+dA
+fx
 ab
-fT
-fT
-fT
-fT
-fT
-fT
+fD
+fD
+fD
+fD
+fD
+fD
 ab
 ab
 ab
@@ -77802,49 +77786,49 @@ aa
 aa
 aa
 aa
-ge
-gi
-gu
-gu
-gu
-gu
-gu
-gu
-gu
-gu
-gu
-gD
-hl
-hk
-hk
-hk
-hk
-hk
-ge
-hk
-hk
-hk
-hk
-hk
-ge
-hk
-hk
-hk
-hk
-hk
-hl
-gi
-gu
-gu
-gu
-gu
-gu
-gu
-gu
-gu
-gu
-gD
-ge
+fZ
+gd
+gp
+gp
+gp
+gp
+gp
+gp
+gp
+gp
+gp
+gy
+hg
+hf
+hf
+hf
+hf
+hf
+fZ
+hf
+hf
+hf
+hf
+hf
+fZ
+hf
+hf
+hf
+hf
+hf
+hg
+gd
+gp
+gp
+gp
+gp
+gp
+gp
+gp
+gp
+gp
+gy
+fZ
 aa
 aa
 aa
@@ -77977,39 +77961,39 @@ aa
 "}
 (248,1,1) = {"
 ac
-as
-as
-as
-as
-as
-as
-as
-as
-as
-as
-bl
-bB
-bQ
-bQ
-bQ
-cs
-cG
-bQ
-bQ
-bQ
+ar
+ar
+ar
+ar
+ar
+ar
+ar
+ar
+ar
+ar
+bj
 bz
-bl
-dM
-dM
-dM
-dM
-dM
-dM
-dM
-dM
-dM
-dM
-fN
+bN
+bN
+bN
+cm
+cz
+bN
+bN
+bN
+bx
+bj
+dA
+dA
+dA
+dA
+dA
+dA
+dA
+dA
+dA
+dA
+fx
 ab
 ab
 ab
@@ -78017,91 +78001,91 @@ ab
 ab
 ab
 ab
+fU
+fW
+ab
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
 fZ
-gb
-ab
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
 ge
-gj
-gm
-gm
-gm
-gm
-gm
-gm
-gm
-gm
-gm
-gE
+gh
+gh
+gh
+gh
+gh
+gh
+gh
+gh
+gh
+gz
+fZ
+hf
+gq
+gq
+gq
+hf
+hf
+hf
+hf
+hf
+hf
+hf
+hf
+hf
+gq
+gq
+gq
+hf
+fZ
 ge
-hk
-gv
-gv
-gv
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-gv
-gv
-gv
-hk
-ge
-gj
-gm
-gm
-gm
-gm
-gm
-gm
-gm
-gm
-gm
-gE
-ge
+gh
+gh
+gh
+gh
+gh
+gh
+gh
+gh
+gh
+gz
+fZ
 aa
 aa
 aa
@@ -78274,8 +78258,8 @@ ab
 ab
 ab
 ab
-fZ
-gb
+fU
+fW
 ab
 aa
 aa
@@ -78316,49 +78300,49 @@ aa
 aa
 aa
 aa
+fZ
 ge
-gj
-gm
-gy
-gm
-gy
-gm
-gy
-gm
-gy
-gm
-gE
+gh
+gt
+gh
+gt
+gh
+gt
+gh
+gt
+gh
+gz
+fZ
+hf
+gq
+hf
+hf
+hf
+hf
+hf
+hf
+hC
+hf
+hf
+hf
+hf
+hf
+hf
+gq
+hf
+fZ
 ge
-hk
-gv
-hk
-hk
-hk
-hk
-hk
-hk
-hH
-hk
-hk
-hk
-hk
-hk
-hk
-gv
-hk
-ge
-gj
-gm
-gy
-gm
-gy
-gm
-gy
-gm
-gy
-gm
-gE
-ge
+gh
+gt
+gh
+gt
+gh
+gt
+gh
+gt
+gh
+gz
+fZ
 aa
 aa
 aa
@@ -78491,39 +78475,39 @@ aa
 "}
 (250,1,1) = {"
 ac
-at
-aF
-aF
-aF
-aF
-aY
-aY
-aY
-aY
-bi
-bl
-bC
-bR
-bR
-bR
-ct
-cH
-cP
-cP
-cP
-dv
-bl
-dP
-dP
-dP
-dP
-dP
-dP
-dP
-dP
-dP
-dP
-fN
+as
+aD
+aD
+aD
+aD
+aW
+aW
+aW
+aW
+bg
+bj
+bA
+bO
+bO
+bO
+cn
+cA
+cI
+cI
+cI
+dj
+bj
+dB
+dB
+dB
+dB
+dB
+dB
+dB
+dB
+dB
+dB
+fx
 ab
 ab
 ab
@@ -78531,91 +78515,91 @@ ab
 ab
 ab
 ab
+fU
+fW
+ab
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
 fZ
-gb
-ab
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
 ge
-gj
-gm
-gy
-gm
-gy
-gm
-gy
-gm
-gy
-gm
-gE
+gh
+gt
+gh
+gt
+gh
+gt
+gh
+gt
+gh
+gz
+fZ
+hf
+gq
+hf
+hf
+hf
+hf
+hf
+hC
+hG
+hC
+hf
+hf
+hf
+hf
+hf
+gq
+hf
+fZ
 ge
-hk
-gv
-hk
-hk
-hk
-hk
-hk
-hH
-hL
-hH
-hk
-hk
-hk
-hk
-hk
-gv
-hk
-ge
-gj
-gm
-gy
-gm
-gy
-gm
-gy
-gm
-gy
-gm
-gE
-ge
+gh
+gt
+gh
+gt
+gh
+gt
+gh
+gt
+gh
+gz
+fZ
 aa
 aa
 aa
@@ -78748,39 +78732,39 @@ aa
 "}
 (251,1,1) = {"
 ac
-au
-aG
-aG
-aG
-aG
-aG
-aG
-aG
-aG
+at
+aE
+aE
+aE
+aE
+aE
+aE
+aE
+aE
+bh
 bj
-bl
-bD
-bS
-ce
-bS
-cu
-cI
-bS
-dc
-bS
-dw
-bl
-dQ
-eo
-eG
-eR
-eR
-eR
-eR
-fs
-fB
-fK
-fN
+bB
+bP
+bZ
+bP
+co
+cB
+bP
+cV
+bP
+dk
+bj
+dC
+ea
+er
+eE
+eE
+eE
+eE
+fg
+fp
+fu
+fx
 ab
 ab
 ab
@@ -78788,91 +78772,91 @@ ab
 ab
 ab
 ab
+fU
+fW
+ab
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
 fZ
-gb
-ab
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
 ge
-gj
-gm
-gy
-gm
-gy
-gm
-gy
-gm
-gy
-gm
-gE
+gh
+gt
+gh
+gt
+gh
+gt
+gh
+gt
+gh
+gz
+fZ
+hf
+gq
+hf
+hf
+hf
+hf
+hf
+hf
+hC
+hf
+hf
+hf
+hf
+hf
+hf
+gq
+hf
+fZ
 ge
-hk
-gv
-hk
-hk
-hk
-hk
-hk
-hk
-hH
-hk
-hk
-hk
-hk
-hk
-hk
-gv
-hk
-ge
-gj
-gm
-gy
-gm
-gy
-gm
-gy
-gm
-gy
-gm
-gE
-ge
+gh
+gt
+gh
+gt
+gh
+gt
+gh
+gt
+gh
+gz
+fZ
 aa
 aa
 aa
@@ -79005,39 +78989,39 @@ aa
 "}
 (252,1,1) = {"
 ac
-au
-aG
-aG
-aG
-aG
-aG
-aG
-aG
-aG
+at
+aE
+aE
+aE
+aE
+aE
+aE
+aE
+aE
+bh
 bj
-bl
-bD
-bS
-ce
-bS
-cu
-cI
-bS
-dc
-bS
-dw
-bl
-dR
-ep
-eH
-eS
-eS
-eS
-eS
-ft
-fB
-fL
-fN
+bB
+bP
+bZ
+bP
+co
+cB
+bP
+cV
+bP
+dk
+bj
+dD
+eb
+es
+eF
+eF
+eF
+eF
+fh
+fp
+fv
+fx
 ab
 ab
 ab
@@ -79045,91 +79029,91 @@ ab
 ab
 ab
 ab
+fU
+fW
+ab
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
 fZ
-gb
-ab
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
 ge
-gj
-gm
-gm
-gm
-gm
-gm
-gm
-gm
-gm
-gm
-gE
+gh
+gh
+gh
+gh
+gh
+gh
+gh
+gh
+gh
+gz
+fZ
+hf
+gq
+gq
+gq
+hf
+hf
+hf
+hf
+hf
+hf
+hf
+hf
+hf
+gq
+gq
+gq
+hf
+fZ
 ge
-hk
-gv
-gv
-gv
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-gv
-gv
-gv
-hk
-ge
-gj
-gm
-gm
-gm
-gm
-gm
-gm
-gm
-gm
-gm
-gE
-ge
+gh
+gh
+gh
+gh
+gh
+gh
+gh
+gh
+gh
+gz
+fZ
 aa
 aa
 aa
@@ -79262,49 +79246,49 @@ aa
 "}
 (253,1,1) = {"
 ac
-au
-aG
-aG
-aG
-aG
-aG
-aG
-aG
-aG
+at
+aE
+aE
+aE
+aE
+aE
+aE
+aE
+aE
+bh
 bj
-bl
-bD
-bS
-ce
-bS
-cu
-cI
-bS
-dc
-bS
-dw
-bl
-dS
-eq
-eI
-eT
-eT
-eT
-eT
-fu
-fB
-fM
-fN
+bB
+bP
+bZ
+bP
+co
+cB
+bP
+cV
+bP
+dk
+bj
+dE
+ec
+et
+eG
+eG
+eG
+eG
+fi
+fp
+fw
+fx
 ab
-fS
-fS
-fS
-fS
-fS
-fS
-ab
+fC
+fC
+fC
+fC
+fC
+fC
 ab
 ab
+ab
 aa
 aa
 aa
@@ -79344,49 +79328,49 @@ aa
 aa
 aa
 aa
-ge
-gk
-gw
-gw
-gw
-gw
-gw
-gw
-gw
-gw
-gw
-gF
-hl
-hk
-hk
-hk
-hk
-hk
-ge
-hk
-hk
-hk
-hk
-hk
-ge
-hk
-hk
-hk
-hk
-hk
-hl
-gk
-gw
-gw
-gw
-gw
-gw
-gw
-gw
-gw
-gw
-gF
-ge
+fZ
+gf
+gr
+gr
+gr
+gr
+gr
+gr
+gr
+gr
+gr
+gA
+hg
+hf
+hf
+hf
+hf
+hf
+fZ
+hf
+hf
+hf
+hf
+hf
+fZ
+hf
+hf
+hf
+hf
+hf
+hg
+gf
+gr
+gr
+gr
+gr
+gr
+gr
+gr
+gr
+gr
+gA
+fZ
 aa
 aa
 aa
@@ -79519,46 +79503,46 @@ aa
 "}
 (254,1,1) = {"
 ac
-av
-aH
-aH
-aH
-aH
-aZ
-aZ
-aZ
-aZ
-bk
-bl
-bE
-bT
-bT
-bT
-cv
+au
+aF
+aF
+aF
+aF
+aX
+aX
+aX
+aX
+bi
+bj
+bC
+bQ
+bQ
+bQ
+cp
+cC
 cJ
-cQ
-cQ
-cQ
-dx
-bl
-dT
-dT
-dT
-dT
-dT
-dT
-dT
-dT
-dT
-dT
-fN
+cJ
+cJ
+dl
+bj
+dF
+dF
+dF
+dF
+dF
+dF
+dF
+dF
+dF
+dF
+fx
 ab
-fW
-fW
-fW
-fW
-fW
-fW
+fK
+fK
+fK
+fK
+fK
+fK
 ab
 aa
 aa
@@ -79601,49 +79585,49 @@ aa
 aa
 aa
 aa
-ge
-ge
-ge
-ge
-ge
-ge
-ge
-ge
-ge
-ge
-ge
-ge
-ge
-ge
-ge
-ge
-ge
-ge
-ge
-ge
-ge
-ge
-ge
-ge
-ge
-ge
-ge
-ge
-ge
-ge
-ge
-ge
-ge
-ge
-ge
-ge
-ge
-ge
-ge
-ge
-ge
-ge
-ge
+fZ
+fZ
+fZ
+fZ
+fZ
+fZ
+fZ
+fZ
+fZ
+fZ
+fZ
+fZ
+fZ
+fZ
+fZ
+fZ
+fZ
+fZ
+fZ
+fZ
+fZ
+fZ
+fZ
+fZ
+fZ
+fZ
+fZ
+fZ
+fZ
+fZ
+fZ
+fZ
+fZ
+fZ
+fZ
+fZ
+fZ
+fZ
+fZ
+fZ
+fZ
+fZ
+fZ
 aa
 aa
 aa
@@ -79776,27 +79760,27 @@ aa
 "}
 (255,1,1) = {"
 ab
-aw
-aw
-aw
-aw
-aw
-aw
-aw
-aw
-aw
-aw
+av
+av
+av
+av
+av
+av
+av
+av
+av
+av
 ab
-aw
-aw
-aw
-aw
-aw
-aw
-aw
-aw
-aw
-aw
+av
+av
+av
+av
+av
+av
+av
+av
+av
+av
 ab
 ag
 ag
@@ -80028,6 +80012,6 @@ aa
 aa
 aa
 aa
-HT
-HT
+Mc
+Mc
 "}

--- a/_maps/map_files/generic/CentCom.dmm
+++ b/_maps/map_files/generic/CentCom.dmm
@@ -13628,10 +13628,9 @@
 /turf/closed/wall/mineral/titanium/nodiagonal,
 /area/centcom/evac)
 "Mk" = (
+/obj/structure/grille,
 /obj/structure/window/plastitanium,
-/turf/open/floor/plasteel/vault{
-	dir = 5
-	},
+/turf/open/floor/plating,
 /area/shuttle/syndicate/airlock)
 "Mz" = (
 /obj/structure/shuttle/engine/propulsion/right,
@@ -13799,6 +13798,7 @@
 	id = "syndieshutters";
 	name = "blast shutters"
 	},
+/obj/structure/grille,
 /turf/open/floor/plating,
 /area/shuttle/syndicate/bridge)
 "Pm" = (
@@ -13889,10 +13889,9 @@
 /turf/open/floor/holofloor,
 /area/holodeck/rec_center/school)
 "QP" = (
+/obj/structure/grille,
 /obj/structure/window/plastitanium,
-/turf/open/floor/plasteel/vault{
-	dir = 5
-	},
+/turf/open/floor/plating,
 /area/shuttle/syndicate/medical)
 "QT" = (
 /obj/effect/turf_decal/stripes/corner,
@@ -14091,10 +14090,9 @@
 	},
 /area/shuttle/syndicate/eva)
 "Tl" = (
+/obj/structure/grille,
 /obj/structure/window/plastitanium,
-/turf/open/floor/plasteel/vault{
-	dir = 5
-	},
+/turf/open/floor/plating,
 /area/shuttle/syndicate/eva)
 "Tm" = (
 /obj/machinery/status_display,
@@ -14250,10 +14248,9 @@
 /turf/open/floor/plasteel/vault,
 /area/shuttle/syndicate/medical)
 "Wd" = (
+/obj/structure/grille,
 /obj/structure/window/plastitanium,
-/turf/open/floor/plasteel/vault{
-	dir = 5
-	},
+/turf/open/floor/plating,
 /area/shuttle/syndicate/armory)
 "We" = (
 /obj/item/screwdriver{
@@ -14495,6 +14492,16 @@
 	},
 /turf/closed/wall/mineral/plastitanium,
 /area/shuttle/syndicate/medical)
+"ZZ" = (
+/obj/structure/grille,
+/obj/structure/window/plastitanium,
+/turf/open/floor/plating,
+/area/shuttle/syndicate/hallway)
+"OVERFLOW" = (
+/obj/structure/grille,
+/obj/structure/window/plastitanium,
+/turf/open/floor/plating,
+/area/shuttle/syndicate/hallway)
 
 (1,1,1) = {"
 aa
@@ -28554,7 +28561,7 @@ ZS
 QP
 QP
 pk
-Nc
+QP
 XJ
 XJ
 Nk
@@ -28804,7 +28811,7 @@ XN
 Ru
 XN
 XN
-Ur
+ZZ
 Pt
 Pt
 Pt
@@ -28813,7 +28820,7 @@ RF
 NV
 RD
 TT
-XL
+Ur
 de
 Jn
 hq
@@ -29318,7 +29325,7 @@ Om
 TW
 Om
 Om
-Ur
+OVERFLOW
 Pt
 Pt
 Pt
@@ -29327,7 +29334,7 @@ WW
 NV
 RD
 TT
-XL
+Ur
 de
 Mz
 hq
@@ -29582,7 +29589,7 @@ Se
 Wd
 Wd
 ZM
-ZE
+Wd
 Jz
 Jz
 Nk

--- a/_maps/map_files/generic/CentCom.dmm
+++ b/_maps/map_files/generic/CentCom.dmm
@@ -1,4 +1,4 @@
-//MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE 
+//MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
 "aa" = (
 /turf/open/space/basic,
 /area/space)
@@ -13629,9 +13629,8 @@
 /area/centcom/evac)
 "Mk" = (
 /obj/structure/window/plastitanium,
-/turf/open/floor/plasteel/vault{
-	dir = 5
-	},
+/obj/structure/grille,
+/turf/open/floor/plating,
 /area/shuttle/syndicate/airlock)
 "Mz" = (
 /obj/structure/shuttle/engine/propulsion/right,
@@ -13799,6 +13798,7 @@
 	id = "syndieshutters";
 	name = "blast shutters"
 	},
+/obj/structure/grille,
 /turf/open/floor/plating,
 /area/shuttle/syndicate/bridge)
 "Pm" = (
@@ -13890,9 +13890,8 @@
 /area/holodeck/rec_center/school)
 "QP" = (
 /obj/structure/window/plastitanium,
-/turf/open/floor/plasteel/vault{
-	dir = 5
-	},
+/obj/structure/grille,
+/turf/open/floor/plating,
 /area/shuttle/syndicate/medical)
 "QT" = (
 /obj/effect/turf_decal/stripes/corner,
@@ -14092,9 +14091,8 @@
 /area/shuttle/syndicate/eva)
 "Tl" = (
 /obj/structure/window/plastitanium,
-/turf/open/floor/plasteel/vault{
-	dir = 5
-	},
+/obj/structure/grille,
+/turf/open/floor/plating,
 /area/shuttle/syndicate/eva)
 "Tm" = (
 /obj/machinery/status_display,
@@ -14251,9 +14249,8 @@
 /area/shuttle/syndicate/medical)
 "Wd" = (
 /obj/structure/window/plastitanium,
-/turf/open/floor/plasteel/vault{
-	dir = 5
-	},
+/obj/structure/grille,
+/turf/open/floor/plating,
 /area/shuttle/syndicate/armory)
 "We" = (
 /obj/item/screwdriver{
@@ -14495,6 +14492,16 @@
 	},
 /turf/closed/wall/mineral/plastitanium,
 /area/shuttle/syndicate/medical)
+"ZZ" = (
+/obj/structure/window/plastitanium,
+/obj/structure/grille,
+/turf/open/floor/plating,
+/area/shuttle/syndicate/hallway)
+"OVERFLOW" = (
+/obj/structure/window/plastitanium,
+/obj/structure/grille,
+/turf/open/floor/plating,
+/area/shuttle/syndicate/hallway)
 
 (1,1,1) = {"
 aa
@@ -28554,7 +28561,7 @@ ZS
 QP
 QP
 pk
-Nc
+QP
 XJ
 XJ
 Nk
@@ -28804,7 +28811,7 @@ XN
 Ru
 XN
 XN
-Ur
+ZZ
 Pt
 Pt
 Pt
@@ -28813,7 +28820,7 @@ RF
 NV
 RD
 TT
-XL
+Ur
 de
 Jn
 hq
@@ -29318,7 +29325,7 @@ Om
 TW
 Om
 Om
-Ur
+OVERFLOW
 Pt
 Pt
 Pt
@@ -29327,7 +29334,7 @@ WW
 NV
 RD
 TT
-XL
+Ur
 de
 Mz
 hq
@@ -29582,7 +29589,7 @@ Se
 Wd
 Wd
 ZM
-ZE
+Wd
 Jz
 Jz
 Nk

--- a/_maps/shuttles/whiteship_box.dmm
+++ b/_maps/shuttles/whiteship_box.dmm
@@ -11,12 +11,14 @@
 "ad" = (
 /obj/machinery/door/airlock/titanium,
 /obj/docking_port/mobile{
+	callTime = 250;
 	dheight = 0;
 	dir = 2;
 	dwidth = 11;
 	height = 22;
 	id = "whiteship";
 	launch_status = 0;
+	movement_force = list("KNOCKDOWN" = 0, "THROW" = 0);
 	name = "NT Medical Ship";
 	port_direction = 8;
 	preferred_direction = 4;

--- a/_maps/shuttles/whiteship_meta.dmm
+++ b/_maps/shuttles/whiteship_meta.dmm
@@ -20,12 +20,14 @@
 /area/shuttle/abandoned)
 "ag" = (
 /obj/docking_port/mobile{
+	callTime = 250;
 	dheight = 0;
 	dir = 2;
 	dwidth = 11;
 	height = 15;
 	id = "whiteship";
 	launch_status = 0;
+	movement_force = list("KNOCKDOWN" = 0, "THROW" = 0);
 	name = "NT Recovery White-Ship";
 	port_direction = 8;
 	preferred_direction = 4;


### PR DESCRIPTION
This should hopefully fix everything the other branch  had problems with.


Box and metastation whiteships now no longer have any knockdown when you travel, but also spend 250 ticks in hyperspace instead of 100. This, coupled with not needing to be in a chair to avoid the annoying milisecond long knockdown, incentivizes people to walk around their ship and maybe fix it up or do something in it or bring some friends to go talk to when you're out adventuring all over the place.

This also moves the northwestern syndie infiltrator docking ports much closer in on box, meta, pubby, and delta, because they were waaaay out of the way, and dangerously close to the map's edge on meta's case. Finally, the infiltrator has some prettier looking window placement.
![](https://i.imgur.com/QXyF9H0.png)

:cl: WJohnston
tweak: Due to age, the abandoned ship's engines are now considerably slower when bringing it place to place. This does however mean that the ship now has a more gradual takeoff, with no sudden jolt to knock passengers off their feet.
/:cl: