### PR TITLE
Makes holy weapons re-nameble

### DIFF
--- a/code/game/objects/items/holy_weapons.dm
+++ b/code/game/objects/items/holy_weapons.dm
@@ -10,6 +10,7 @@
 	throw_range = 4
 	throwforce = 10
 	w_class = WEIGHT_CLASS_TINY
+	unique_rename = TRUE
 	var/reskinned = FALSE
 
 /obj/item/nullrod/suicide_act(mob/user)


### PR DESCRIPTION
THIS IS MY ASCENDED Sord
ITS A SORT THAT HAS ASCENDED FROM ITS PLASTIC FORM INTO ENERGY SORD

:cl: Improvedname
add: You can now put custom name and lore on your holy weapon by using a pen on it!
/:cl:

