### PR TITLE
Allows sillicons to use vending machines.

### DIFF
--- a/code/game/machinery/vending.dm
+++ b/code/game/machinery/vending.dm
@@ -411,10 +411,6 @@
 	if(..())
 		return
 
-	if(isAI(usr))
-		to_chat(usr, "<span class='notice'>The vending machine refuses to interface with you, as you are not in its target demographic!</span>")
-		return
-
 	if(href_list["remove_coin"])
 		if(!(coin || bill))
 			to_chat(usr, "<span class='notice'>There is no money in this machine.</span>")

--- a/code/game/machinery/vending.dm
+++ b/code/game/machinery/vending.dm
@@ -411,15 +411,9 @@
 	if(..())
 		return
 
-	if(issilicon(usr))
-		if(iscyborg(usr))
-			var/mob/living/silicon/robot/R = usr
-			if(!(R.module && istype(R.module, /obj/item/robot_module/butler) ))
-				to_chat(usr, "<span class='notice'>The vending machine refuses to interface with you, as you are not in its target demographic!</span>")
-				return
-		else
-			to_chat(usr, "<span class='notice'>The vending machine refuses to interface with you, as you are not in its target demographic!</span>")
-			return
+	if(isAI(usr))
+		to_chat(usr, "<span class='notice'>The vending machine refuses to interface with you, as you are not in its target demographic!</span>")
+		return
 
 	if(href_list["remove_coin"])
 		if(!(coin || bill))


### PR DESCRIPTION
[Changelogs]: 
:cl: DaxDupont
tweak: After lobbying by Robust Softdrinks and Getmore Chocolate Corp all vendor firmware has been changed to add sillicons to their target demographic. 
/:cl:

[why]: We were discussing the futility of borgs not being able to use vendors while they can do things such as red alert and open lockers. I have no idea why borgs were disallowed from doing so, except for the service borg. Kor suggested I'd make a PR. If anyone has a reason why cyborgs shouldn't be allowed to vend snacks, tools etc please inform people here!
