### PR TITLE
makes vacuums "cold", sort of

### DIFF
--- a/code/__DEFINES/atmospherics.dm
+++ b/code/__DEFINES/atmospherics.dm
@@ -49,7 +49,7 @@
 #define SPACE_HEAT_TRANSFER_COEFFICIENT		0.2		//a hack to partly simulate radiative heat
 #define OPEN_HEAT_TRANSFER_COEFFICIENT		0.4
 #define WINDOW_HEAT_TRANSFER_COEFFICIENT	0.1		//a hack for now
-#define HEAT_CAPACITY_VACUUM				2000	//a hack to help make vacuums "cold", sacrificing realism for gameplay
+#define HEAT_CAPACITY_VACUUM				7000	//a hack to help make vacuums "cold", sacrificing realism for gameplay
 	//Must be between 0 and 1. Values closer to 1 equalize temperature faster
 	//Should not exceed 0.4 else strange heat flow occur
 #define FIRE_MINIMUM_TEMPERATURE_TO_SPREAD	150+T0C

--- a/code/__DEFINES/atmospherics.dm
+++ b/code/__DEFINES/atmospherics.dm
@@ -49,6 +49,7 @@
 #define SPACE_HEAT_TRANSFER_COEFFICIENT		0.2		//a hack to partly simulate radiative heat
 #define OPEN_HEAT_TRANSFER_COEFFICIENT		0.4
 #define WINDOW_HEAT_TRANSFER_COEFFICIENT	0.1		//a hack for now
+#define HEAT_CAPACITY_VACUUM				2000	//a hack to help make vacuums "cold", sacrificing realism for gameplay
 	//Must be between 0 and 1. Values closer to 1 equalize temperature faster
 	//Should not exceed 0.4 else strange heat flow occur
 #define FIRE_MINIMUM_TEMPERATURE_TO_SPREAD	150+T0C

--- a/code/modules/atmospherics/gasmixtures/gas_mixture.dm
+++ b/code/modules/atmospherics/gasmixtures/gas_mixture.dm
@@ -71,6 +71,9 @@ GLOBAL_LIST_INIT(gaslist_cache, init_gaslist_cache())
 	for(var/id in cached_gases)
 		var/gas_data = cached_gases[id]
 		. += gas_data[MOLES] * gas_data[GAS_META][META_GAS_SPECIFIC_HEAT]
+	if(!.) //if no heat capacity, we're a vacuum - things get weird like this but this hack sorta works
+		. += HEAT_CAPACITY_VACUUM
+
 
 /datum/gas_mixture/proc/heat_capacity_archived() //joules per kelvin
 	var/list/cached_gases = gases

--- a/code/modules/atmospherics/gasmixtures/immutable_mixtures.dm
+++ b/code/modules/atmospherics/gasmixtures/immutable_mixtures.dm
@@ -54,7 +54,7 @@
 	initial_temperature = TCMB
 
 /datum/gas_mixture/immutable/space/heat_capacity()
-	return 7000
+	return HEAT_CAPACITY_VACUUM
 
 /datum/gas_mixture/immutable/space/remove()
 	return copy() //we're always empty, so we can just return a copy.


### PR DESCRIPTION
Resolves #15726. This is a hack but due to the nature of things, this issue needed a hack to be resolved. The only alternative would be to make space not cold, but that's a gameplay point I don't want to give up. This hack sacrifices realism (vacuum having no heat capacity and this becoming the temperature of your breath) for gameplay (vacuums being cold, as players expect despite being unrealistic).