### PR TITLE
Shameless Cleanbot Buff

### DIFF
--- a/code/modules/mob/living/simple_animal/bot/cleanbot.dm
+++ b/code/modules/mob/living/simple_animal/bot/cleanbot.dm
@@ -206,7 +206,8 @@
 				if(A && isturf(A.loc))
 					var/atom/movable/AM = A
 					if(istype(AM, /obj/effect/decal/cleanable))
-						qdel(AM)
+						for(var/obj/effect/decal/cleanable/C in A.loc)
+							qdel(C)
 
 				anchored = FALSE
 				target = null


### PR DESCRIPTION
When cleanbot cleans a tile, it will now fully clean the tile as opposed to taking out one stain at a time.

Considering a tile can have multiple blood drips, blood stains, blood tire tracks, oil versions of all the above, pie smears. dust, glowing goo, and so forth I consider this a mercy. 

Note that a cleanbot is still woefully under equipped to keep a station clean by its lonesome, which is the core of its charm.