### PR TITLE
Removes the ability to unweld a singletank

### DIFF
--- a/code/modules/assembly/bomb.dm
+++ b/code/modules/assembly/bomb.dm
@@ -51,10 +51,6 @@
 			GLOB.bombers += "[key_name(user)] welded a single tank bomb. Temp: [bombtank.air_contents.temperature-T0C]"
 			message_admins("[key_name_admin(user)] welded a single tank bomb. Temp: [bombtank.air_contents.temperature-T0C]")
 			to_chat(user, "<span class='notice'>A pressure hole has been bored to [bombtank] valve. \The [bombtank] can now be ignited.</span>")
-		else
-			status = FALSE
-			GLOB.bombers += "[key_name(user)] unwelded a single tank bomb. Temp: [bombtank.air_contents.temperature-T0C]"
-			to_chat(user, "<span class='notice'>The hole has been closed.</span>")
 	add_fingerprint(user)
 	..()
 


### PR DESCRIPTION
Fixes #27341

I doubt anything of value is truly lost by removing this, considering how I doubt this has ever been used except to spam admin logs

Also singletank code looks pretty bad at a glance and should probably be updated at some point by somebody better with code