### PR TITLE
Fix lavaland turfs looking awkward to AIs

### DIFF
--- a/code/modules/mob/living/silicon/ai/freelook/chunk.dm
+++ b/code/modules/mob/living/silicon/ai/freelook/chunk.dm
@@ -110,6 +110,8 @@
 		if(obscuredTurfs[t])
 			if(!t.obscured)
 				t.obscured = image('icons/effects/cameravis.dmi', t, null, LIGHTING_LAYER+1)
+				t.obscured.pixel_x = -t.pixel_x
+				t.obscured.pixel_y = -t.pixel_y
 				t.obscured.plane = LIGHTING_PLANE+1
 			obscured += t.obscured
 			for(var/eye in seenby)
@@ -165,6 +167,8 @@
 		var/turf/t = turf
 		if(!t.obscured)
 			t.obscured = image('icons/effects/cameravis.dmi', t, null, LIGHTING_LAYER+1)
+			t.obscured.pixel_x = -t.pixel_x
+			t.obscured.pixel_y = -t.pixel_y
 			t.obscured.plane = LIGHTING_PLANE+1
 		obscured += t.obscured
 


### PR DESCRIPTION
:cl:
fix: AI eye camera static is now correctly positioned on Lavaland.
/:cl:

Fixes #24573 which looks like this:

![image](https://user-images.githubusercontent.com/222630/31425811-ad0bc520-ae15-11e7-811b-169b50252af7.png)
