### PR TITLE
Fixes Smoke Machine operating while unanchored

### DIFF
--- a/code/modules/reagents/chemistry/machinery/smoke_machine.dm
+++ b/code/modules/reagents/chemistry/machinery/smoke_machine.dm
@@ -64,7 +64,8 @@
 			to_chat(user, "<span class='notice'>You transfer [units] units of the solution to [src].</span>")
 			add_logs(usr, src, "has added [english_list(RC.reagents.reagent_list)] to [src]")
 			return
-	if(default_unfasten_wrench(user, I))
+	if(default_unfasten_wrench(user, I, 15))
+		on = FALSE
 		return
 	return ..()
 


### PR DESCRIPTION
:cl: Robustin
fix: The smoke machine will no longer remain running when unanchored
/:cl:
