### PR TITLE
Latejoin procs

### DIFF
--- a/code/game/gamemodes/changeling/changeling.dm
+++ b/code/game/gamemodes/changeling/changeling.dm
@@ -115,6 +115,10 @@ GLOBAL_LIST_INIT(slot2type, list("head" = /obj/item/clothing/head/changeling, "w
 					if(!(character.job in restricted_jobs))
 						character.mind.make_Changling()
 
+/datum/game_mode/changeling/handle_late_join(mob/living/carbon/human/character)
+	addtimer(CALLBACK(src, .proc/make_antag_chance, character), 100)
+	return 0
+
 /datum/game_mode/proc/forge_changeling_objectives(datum/mind/changeling, var/team_mode = 0)
 	//OBJECTIVES - random traitor objectives. Unique objectives "steal brain" and "identity theft".
 	//No escape alone because changelings aren't suited for it and it'd probably just lead to rampant robusting

--- a/code/game/gamemodes/game_mode.dm
+++ b/code/game/gamemodes/game_mode.dm
@@ -104,6 +104,8 @@
 		replacementmode.make_antag_chance(character)
 	return
 
+/datum/game_mode/proc/handle_late_join(mob/living/carbon/human/character)
+	return 0
 
 ///Allows rounds to basically be "rerolled" should the initial premise fall through. Also known as mulligan antags.
 /datum/game_mode/proc/convert_roundtype()

--- a/code/game/gamemodes/traitor/traitor.dm
+++ b/code/game/gamemodes/traitor/traitor.dm
@@ -83,7 +83,9 @@
 /datum/game_mode/traitor/proc/add_latejoin_traitor(datum/mind/character)
 	character.add_antag_datum(antag_datum)
 
-
+/datum/game_mode/traitor/handle_late_join(mob/living/carbon/human/character)
+	addtimer(CALLBACK(src, .proc/make_antag_chance, character), 100)
+	return 0
 
 /datum/game_mode/traitor/declare_completion()
 	..()

--- a/code/modules/mob/dead/new_player/new_player.dm
+++ b/code/modules/mob/dead/new_player/new_player.dm
@@ -80,7 +80,7 @@
 		if(SSticker.current_state == GAME_STATE_PREGAME)
 			var/time_remaining = SSticker.GetTimeLeft()
 			if(time_remaining > 0)
-				stat("Time To Start:", "[round(time_remaining/10)]s")			
+				stat("Time To Start:", "[round(time_remaining/10)]s")
 			else if(time_remaining == -10)
 				stat("Time To Start:", "DELAYED")
 			else
@@ -343,10 +343,26 @@
 	SSticker.queued_players -= src
 	SSticker.queue_delay = 4
 
-	SSjob.AssignRole(src, rank, 1)
-
 	var/mob/living/character = create_character(TRUE)	//creates the human and transfers vars and mind
+
+	var/mob/living/carbon/human/humanc
+	if(ishuman(character))
+		humanc = character	//Let's retypecast the var to be human,
+
+	if(CONFIG_GET(flag/allow_latejoin_antagonists) && humanc)	//Borgs aren't allowed to be antags. Will need to be tweaked if we get true latejoin ais.
+		if(SSshuttle.emergency)
+			switch(SSshuttle.emergency.mode)
+				if(SHUTTLE_RECALL, SHUTTLE_IDLE)
+					if(SSticker.mode.handle_late_join(humanc))
+						return
+				if(SHUTTLE_CALL)
+					if(SSshuttle.emergency.timeLeft(1) > initial(SSshuttle.emergencyCallTime)*0.5)
+						if(SSticker.mode.handle_late_join(humanc))
+							return
+
+	SSjob.AssignRole(src, rank, 1)
 	var/equip = SSjob.EquipRank(character, rank, 1)
+
 	if(isliving(equip))	//Borgs get borged in the equip, so we need to make sure we handle the new mob.
 		character = equip
 
@@ -361,9 +377,7 @@
 
 	SSticker.minds += character.mind
 
-	var/mob/living/carbon/human/humanc
-	if(ishuman(character))
-		humanc = character	//Let's retypecast the var to be human,
+
 
 	if(humanc)	//These procs all expect humans
 		GLOB.data_core.manifest_inject(humanc)
@@ -377,15 +391,6 @@
 			humanc.make_scottish()
 
 	GLOB.joined_player_list += character.ckey
-
-	if(CONFIG_GET(flag/allow_latejoin_antagonists) && humanc)	//Borgs aren't allowed to be antags. Will need to be tweaked if we get true latejoin ais.
-		if(SSshuttle.emergency)
-			switch(SSshuttle.emergency.mode)
-				if(SHUTTLE_RECALL, SHUTTLE_IDLE)
-					SSticker.mode.make_antag_chance(humanc)
-				if(SHUTTLE_CALL)
-					if(SSshuttle.emergency.timeLeft(1) > initial(SSshuttle.emergencyCallTime)*0.5)
-						SSticker.mode.make_antag_chance(humanc)
 
 /mob/dead/new_player/proc/AddEmploymentContract(mob/living/carbon/human/employee)
 	//TODO:  figure out a way to exclude wizards/nukeops/demons from this.


### PR DESCRIPTION
Instead of latejoiners calling the create new antag proc, it calls a handle latejoin proc (which for traitor and changeling call said create antag proc) to allow us to do things like increase nuke op TC count per latejoin, or add more clock cultists to rebee, etc

I had to reorder some of the way latejoiners were created so we can cancel giving them a job/equipping them etc if they get chosen to be an off station antag reinforcement