### PR TITLE
Removes BoH bomb confirmation dialog for antags

### DIFF
--- a/code/datums/mind.dm
+++ b/code/datums/mind.dm
@@ -1530,6 +1530,9 @@
 	if(G)
 		G.reenter_corpse()
 
+/datum/mind/proc/is_antag()
+	return LAZYLEN(antag_datums)
+
 /mob/proc/sync_mind()
 	mind_initialize()	//updates the mind (or creates and initializes one if one doesn't exist)
 	mind.active = 1		//indicates that the mind is currently synced with a client

--- a/code/game/objects/items/storage/backpack.dm
+++ b/code/game/objects/items/storage/backpack.dm
@@ -72,7 +72,7 @@
 
 /obj/item/storage/backpack/holding/handle_item_insertion(obj/item/W, prevent_warning = 0, mob/user)
 	if((istype(W, /obj/item/storage/backpack/holding) || count_by_type(W.GetAllContents(), /obj/item/storage/backpack/holding)))
-		if(user && user.mind && user.mind.is_antag())
+		if(!(user && user.mind && user.mind.is_antag()))
 			var/safety = alert(user, "Doing this will have extremely dire consequences for the station and its crew. Be sure you know what you're doing.", "Put in [name]?", "Proceed", "Abort")
 			if(safety == "Abort" || !in_range(src, user) || !src || !W || user.incapacitated())
 				return

--- a/code/game/objects/items/storage/backpack.dm
+++ b/code/game/objects/items/storage/backpack.dm
@@ -72,9 +72,10 @@
 
 /obj/item/storage/backpack/holding/handle_item_insertion(obj/item/W, prevent_warning = 0, mob/user)
 	if((istype(W, /obj/item/storage/backpack/holding) || count_by_type(W.GetAllContents(), /obj/item/storage/backpack/holding)))
-		var/safety = alert(user, "Doing this will have extremely dire consequences for the station and its crew. Be sure you know what you're doing.", "Put in [name]?", "Proceed", "Abort")
-		if(safety == "Abort" || !in_range(src, user) || !src || !W || user.incapacitated())
-			return
+		if(user && user.mind && user.mind.is_antag())
+			var/safety = alert(user, "Doing this will have extremely dire consequences for the station and its crew. Be sure you know what you're doing.", "Put in [name]?", "Proceed", "Abort")
+			if(safety == "Abort" || !in_range(src, user) || !src || !W || user.incapacitated())
+				return
 		investigate_log("has become a singularity. Caused by [user.key]", INVESTIGATE_SINGULO)
 		to_chat(user, "<span class='danger'>The Bluespace interfaces of the two devices catastrophically malfunction!</span>")
 		qdel(W)


### PR DESCRIPTION
Minor QoL thing

:cl:
tweak: Antags will not receive a confirmation prompt when Bag of Holding bombing
/:cl: