### PR TITLE
Fixes foam darts on cardboard cutouts and shooting range targets

### DIFF
--- a/code/game/objects/items/cardboard_cutouts.dm
+++ b/code/game/objects/items/cardboard_cutouts.dm
@@ -67,6 +67,8 @@
 			push_over()
 
 /obj/item/cardboard_cutout/bullet_act(obj/item/projectile/P)
+	if(istype(P, /obj/item/projectile/bullet/reusable))
+		P.on_hit(src, 0)
 	visible_message("<span class='danger'>[src] has been hit by [P]!</span>")
 	playsound(src, 'sound/weapons/slice.ogg', 50, 1)
 	if(prob(P.damage))

--- a/code/game/objects/items/shooting_range.dm
+++ b/code/game/objects/items/shooting_range.dm
@@ -65,10 +65,12 @@
 	playsound(src.loc, 'sound/items/bikehorn.ogg', 50, 1)
 
 /obj/item/target/bullet_act(obj/item/projectile/P)
+	if(istype(P, /obj/item/projectile/bullet/reusable)) // If it's a foam dart, don't bother with any of this other shit
+		return P.on_hit(src, 0)
 	var/p_x = P.p_x + pick(0,0,0,0,0,-1,1) // really ugly way of coding "sometimes offset P.p_x!"
 	var/p_y = P.p_y + pick(0,0,0,0,0,-1,1)
 	var/decaltype = DECALTYPE_SCORCH
-	if(istype(/obj/item/projectile/bullet, P))
+	if(istype(P, /obj/item/projectile/bullet))
 		decaltype = DECALTYPE_BULLET
 	var/icon/C = icon(icon,icon_state)
 	if(C.GetPixel(p_x, p_y) && P.original == src && overlays.len <= 35) // if the located pixel isn't blank (null)


### PR DESCRIPTION
Fixes #31404

Reusable projectiles such as foam darts no longer get deleted if they're shot at a shooting range target or a cardboard cutout.

[Changelogs]: 

:cl: Naksu
fix: Reusable projectiles such as foam darts no longer get deleted if they're shot at a shooting range target or a cardboard cutout.
/:cl:

[why]: 
bugfix