### PR TITLE
Revert "Moves Smoke Machine boards to tech storage"

### DIFF
--- a/_maps/map_files/BoxStation/BoxStation.dmm
+++ b/_maps/map_files/BoxStation/BoxStation.dmm
@@ -27831,6 +27831,7 @@
 /obj/structure/table,
 /obj/item/folder/white,
 /obj/item/device/radio/headset/headset_med,
+/obj/item/circuitboard/machine/smoke_machine,
 /turf/open/floor/plasteel/white,
 /area/medical/chemistry)
 "boe" = (
@@ -37461,7 +37462,6 @@
 /obj/item/circuitboard/machine/clonescanner,
 /obj/item/circuitboard/machine/clonepod,
 /obj/item/circuitboard/computer/scan_consolenew,
-/obj/item/circuitboard/machine/smoke_machine,
 /turf/open/floor/plating,
 /area/storage/tech)
 "bJl" = (

--- a/_maps/map_files/Deltastation/DeltaStation2.dmm
+++ b/_maps/map_files/Deltastation/DeltaStation2.dmm
@@ -39367,7 +39367,6 @@
 	pixel_y = -3
 	},
 /obj/effect/turf_decal/bot,
-/obj/item/circuitboard/machine/smoke_machine,
 /turf/open/floor/plasteel,
 /area/storage/tech)
 "bAP" = (
@@ -77225,6 +77224,7 @@
 /obj/structure/table/glass,
 /obj/item/clipboard,
 /obj/item/toy/figure/chemist,
+/obj/item/circuitboard/machine/smoke_machine,
 /turf/open/floor/plasteel/whiteyellow/corner{
 	dir = 1
 	},

--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -27681,7 +27681,6 @@
 /obj/item/circuitboard/machine/clonescanner,
 /obj/item/circuitboard/machine/clonepod,
 /obj/item/circuitboard/computer/scan_consolenew,
-/obj/item/circuitboard/machine/smoke_machine,
 /turf/open/floor/plasteel/black,
 /area/storage/tech)
 "bbo" = (
@@ -59767,6 +59766,7 @@
 	dir = 1;
 	pixel_y = -24
 	},
+/obj/item/circuitboard/machine/smoke_machine,
 /turf/open/floor/plasteel/whiteyellow{
 	dir = 4
 	},

--- a/_maps/map_files/PubbyStation/PubbyStation.dmm
+++ b/_maps/map_files/PubbyStation/PubbyStation.dmm
@@ -32785,6 +32785,7 @@
 /obj/item/hand_labeler,
 /obj/item/device/radio/headset/headset_med,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/item/circuitboard/machine/smoke_machine,
 /turf/open/floor/plasteel/white,
 /area/medical/chemistry)
 "bwW" = (
@@ -41750,7 +41751,6 @@
 /obj/structure/sign/poster/official/random{
 	pixel_y = 32
 	},
-/obj/item/circuitboard/machine/smoke_machine,
 /turf/open/floor/plasteel/darkgreen,
 /area/storage/tech)
 "bQw" = (


### PR DESCRIPTION
Reverts tgstation/tgstation#31546

Re-add it back to tech storage after a few days, but nothing wrong with exposing that something exists to players.

Also, the pr had no changelog, players who knew where it was would not know where it went.

:cl:
fix: Fixed the Smoke Machine board getting moved to tech storage.
/:cl:

Any attempt to close or stop this pr without, at the very least, fixing the changelog issue, will be meant with increasing levels of mso autism.