### PR TITLE
Adds Toggle Underline button to PDA menu

### DIFF
--- a/code/game/objects/items/devices/PDA/PDA.dm
+++ b/code/game/objects/items/devices/PDA/PDA.dm
@@ -29,7 +29,7 @@ GLOBAL_LIST_EMPTY(PDAs)
 	var/font_index = 0 //This int tells DM which font is currently selected and lets DM know when the last font has been selected so that it can cycle back to the first font when "toggle font" is pressed again.
 	var/font_mode = "font-family:monospace;" //The currently selected font.
 	var/background_color = "#808000" //The currently selected background color.
-	
+
 	#define FONT_MONO "font-family:monospace;"
 	#define FONT_SHARE "font-family:\"Share Tech Mono\", monospace;letter-spacing:0px;"
 	#define FONT_ORBITRON "font-family:\"Orbitron\", monospace;letter-spacing:0px; font-size:15px"
@@ -70,11 +70,8 @@ GLOBAL_LIST_EMPTY(PDAs)
 	var/list/contained_item = list(/obj/item/pen, /obj/item/toy/crayon, /obj/item/lipstick, /obj/item/device/flashlight/pen, /obj/item/clothing/mask/cigarette)
 	var/obj/item/inserted_item //Used for pen, crayon, and lipstick insertion or removal. Same as above.
 	var/overlays_x_offset = 0	//x offset to use for certain overlays
-	
-	var/underline_flag = TRUE //flag for underline
 
-    #define UNDERLINE_OFF 0
-    #define UNDERLINE_ON 1
+	var/underline_flag = TRUE //flag for underline
 
 /obj/item/device/pda/examine(mob/user)
 	..()
@@ -186,7 +183,7 @@ GLOBAL_LIST_EMPTY(PDAs)
 		dat += "<br><a href='byond://?src=\ref[src];choice=Toggle_Font'>Toggle Font</a>"
 		dat += " | <a href='byond://?src=\ref[src];choice=Change_Color'>Change Color</a>"
 		dat += " | <a href='byond://?src=\ref[src];choice=Toggle_Underline'>Toggle Underline</a>" //underline button
-        
+
 		dat += "</div>"
 
 	dat += "<br>"
@@ -293,7 +290,7 @@ GLOBAL_LIST_EMPTY(PDAs)
 				if(cartridge)
 					dat += cartridge.message_header()
 
-				dat += "<h4><img src=pda_menu.png>Detected PDAs</h4>"
+				dat += "<h4><img src=pda_menu.png> Detected PDAs</h4>"
 
 				dat += "<ul>"
 				var/count = 0
@@ -314,10 +311,10 @@ GLOBAL_LIST_EMPTY(PDAs)
 					dat += "<a href='byond://?src=\ref[src];choice=MessageAll'>Send To All</a>"
 
 			if(21)
-				dat += "<h4><img src=pda_mail.png>SpaceMessenger V3.9.6</h4>"
+				dat += "<h4><img src=pda_mail.png> SpaceMessenger V3.9.6</h4>"
 				dat += "<a href='byond://?src=\ref[src];choice=Clear'><img src=pda_blank.png>Clear Messages</a>"
 
-				dat += "<h4><img src=pda_mail.png>Messages</h4>"
+				dat += "<h4><img src=pda_mail.png> Messages</h4>"
 
 				dat += tnote
 				dat += "<br>"
@@ -349,12 +346,12 @@ GLOBAL_LIST_EMPTY(PDAs)
 				dat += cartridge.generate_menu()
 
 	dat += "</body></html>"
-	
-	if (underline_flag == UNDERLINE_ON)
+
+	if (underline_flag)
 		dat = replacetext(dat, "text-decoration:none", "text-decoration:underline")
-	if (underline_flag == UNDERLINE_OFF)
+	if (!underline_flag)
 		dat = replacetext(dat, "text-decoration:underline", "text-decoration:none")
-	
+
 	user << browse(dat, "window=pda;size=400x450;border=1;can_resize=1;can_minimize=0")
 	onclose(user, "pda", src)
 
@@ -372,7 +369,7 @@ GLOBAL_LIST_EMPTY(PDAs)
 //BASIC FUNCTIONS===================================
 
 			if("Refresh")//Refresh, goes to the end of the proc.
-			
+
 			if ("Toggle_Font")
 				//CODE REVISION 2
 				font_index = (font_index + 1) % 4
@@ -389,9 +386,9 @@ GLOBAL_LIST_EMPTY(PDAs)
 			if ("Change_Color")
 				var/new_color = input("Please enter a color name or hex value (Default is \'#808000\').")as color
 				background_color = new_color
-                
+
 			if ("Toggle_Underline")
-				underline_flag = (underline_flag + 1) % 2
+				underline_flag = !underline_flag
 
 			if("Return")//Return
 				if(mode<=9)

--- a/code/game/objects/items/devices/PDA/PDA.dm
+++ b/code/game/objects/items/devices/PDA/PDA.dm
@@ -70,6 +70,11 @@ GLOBAL_LIST_EMPTY(PDAs)
 	var/list/contained_item = list(/obj/item/pen, /obj/item/toy/crayon, /obj/item/lipstick, /obj/item/device/flashlight/pen, /obj/item/clothing/mask/cigarette)
 	var/obj/item/inserted_item //Used for pen, crayon, and lipstick insertion or removal. Same as above.
 	var/overlays_x_offset = 0	//x offset to use for certain overlays
+	
+	var/underline_flag = TRUE //flag for underline
+
+    #define UNDERLINE_OFF 0
+    #define UNDERLINE_ON 1
 
 /obj/item/device/pda/examine(mob/user)
 	..()
@@ -166,34 +171,36 @@ GLOBAL_LIST_EMPTY(PDAs)
 		hidden_uplink.interact(user)
 		return
 
-	var/dat = "<!DOCTYPE html><html><head><title>Personal Data Assistant</title><link href=\"https://fonts.googleapis.com/css?family=Orbitron|Share+Tech+Mono|VT323\" rel=\"stylesheet\"></head><body bgcolor=\"" + background_color + "\"><style>body{" + font_mode + "}ul,ol{list-style-type: none;}a, a:link, a:visited, a:active, a:hover { color: #000000;text-decoration:none; }img {border-style:none;}</style>"
+	var/dat = "<!DOCTYPE html><html><head><title>Personal Data Assistant</title><link href=\"https://fonts.googleapis.com/css?family=Orbitron|Share+Tech+Mono|VT323\" rel=\"stylesheet\"></head><body bgcolor=\"" + background_color + "\"><style>body{" + font_mode + "}ul,ol{list-style-type: none;}a, a:link, a:visited, a:active, a:hover { color: #000000;text-decoration:none; }img {border-style:none;}a img{padding-right: 9px;}</style>"
 
 
-	dat += "<a href='byond://?src=\ref[src];choice=Refresh'><img src=pda_refresh.png> Refresh</a>"
+	dat += "<a href='byond://?src=\ref[src];choice=Refresh'><img src=pda_refresh.png>Refresh</a>"
 
 	if ((!isnull(cartridge)) && (mode == 0))
-		dat += " | <a href='byond://?src=\ref[src];choice=Eject'><img src=pda_eject.png> Eject [cartridge]</a>"
+		dat += " | <a href='byond://?src=\ref[src];choice=Eject'><img src=pda_eject.png>Eject [cartridge]</a>"
 	if (mode)
-		dat += " | <a href='byond://?src=\ref[src];choice=Return'><img src=pda_menu.png> Return</a>"
+		dat += " | <a href='byond://?src=\ref[src];choice=Return'><img src=pda_menu.png>Return</a>"
 
 	if (mode == 0)
 		dat += "<div align=\"center\">"
 		dat += "<br><a href='byond://?src=\ref[src];choice=Toggle_Font'>Toggle Font</a>"
 		dat += " | <a href='byond://?src=\ref[src];choice=Change_Color'>Change Color</a>"
+		dat += " | <a href='byond://?src=\ref[src];choice=Toggle_Underline'>Toggle Underline</a>" //underline button
+        
 		dat += "</div>"
 
 	dat += "<br>"
 
 	if (!owner)
 		dat += "Warning: No owner information entered.  Please swipe card.<br><br>"
-		dat += "<a href='byond://?src=\ref[src];choice=Refresh'><img src=pda_refresh.png> Retry</a>"
+		dat += "<a href='byond://?src=\ref[src];choice=Refresh'><img src=pda_refresh.png>Retry</a>"
 	else
 		switch (mode)
 			if (0)
 				dat += "<h2>PERSONAL DATA ASSISTANT v.1.2</h2>"
 				dat += "Owner: [owner], [ownjob]<br>"
-				dat += text("ID: <A href='?src=\ref[src];choice=Authenticate'>[id ? "[id.registered_name], [id.assignment]" : "----------"]")
-				dat += text("<br><A href='?src=\ref[src];choice=UpdateInfo'>[id ? "Update PDA Info" : ""]</A><br><br>")
+				dat += text("ID: <a href='?src=\ref[src];choice=Authenticate'>[id ? "[id.registered_name], [id.assignment]" : "----------"]")
+				dat += text("<br><a href='?src=\ref[src];choice=UpdateInfo'>[id ? "Update PDA Info" : ""]</A><br><br>")
 
 				dat += "[worldtime2text()]<br>" //:[world.time / 100 % 6][world.time / 100 % 10]"
 				dat += "[time2text(world.realtime, "MMM DD")] [GLOB.year_integer+540]"
@@ -202,38 +209,38 @@ GLOBAL_LIST_EMPTY(PDAs)
 
 				dat += "<h4>General Functions</h4>"
 				dat += "<ul>"
-				dat += "<li><a href='byond://?src=\ref[src];choice=1'><img src=pda_notes.png> Notekeeper</a></li>"
-				dat += "<li><a href='byond://?src=\ref[src];choice=2'><img src=pda_mail.png> Messenger</a></li>"
+				dat += "<li><a href='byond://?src=\ref[src];choice=1'><img src=pda_notes.png>Notekeeper</a></li>"
+				dat += "<li><a href='byond://?src=\ref[src];choice=2'><img src=pda_mail.png>Messenger</a></li>"
 
 				if (cartridge)
 					if (cartridge.access & CART_CLOWN)
-						dat += "<li><a href='byond://?src=\ref[src];choice=Honk'><img src=pda_honk.png> Honk Synthesizer</a></li>"
-						dat += "<li><a href='byond://?src=\ref[src];choice=Trombone'><img src=pda_honk.png> Sad Trombone</a></li>"
+						dat += "<li><a href='byond://?src=\ref[src];choice=Honk'><img src=pda_honk.png>Honk Synthesizer</a></li>"
+						dat += "<li><a href='byond://?src=\ref[src];choice=Trombone'><img src=pda_honk.png>Sad Trombone</a></li>"
 					if (cartridge.access & CART_MANIFEST)
-						dat += "<li><a href='byond://?src=\ref[src];choice=41'><img src=pda_notes.png> View Crew Manifest</a></li>"
+						dat += "<li><a href='byond://?src=\ref[src];choice=41'><img src=pda_notes.png>View Crew Manifest</a></li>"
 					if(cartridge.access & CART_STATUS_DISPLAY)
-						dat += "<li><a href='byond://?src=\ref[src];choice=42'><img src=pda_status.png> Set Status Display</a></li>"
+						dat += "<li><a href='byond://?src=\ref[src];choice=42'><img src=pda_status.png>Set Status Display</a></li>"
 					dat += "</ul>"
 					if (cartridge.access & CART_ENGINE)
 						dat += "<h4>Engineering Functions</h4>"
 						dat += "<ul>"
-						dat += "<li><a href='byond://?src=\ref[src];choice=43'><img src=pda_power.png> Power Monitor</a></li>"
+						dat += "<li><a href='byond://?src=\ref[src];choice=43'><img src=pda_power.png>Power Monitor</a></li>"
 						dat += "</ul>"
 					if (cartridge.access & CART_MEDICAL)
 						dat += "<h4>Medical Functions</h4>"
 						dat += "<ul>"
-						dat += "<li><a href='byond://?src=\ref[src];choice=44'><img src=pda_medical.png> Medical Records</a></li>"
-						dat += "<li><a href='byond://?src=\ref[src];choice=Medical Scan'><img src=pda_scanner.png> [scanmode == 1 ? "Disable" : "Enable"] Medical Scanner</a></li>"
+						dat += "<li><a href='byond://?src=\ref[src];choice=44'><img src=pda_medical.png>Medical Records</a></li>"
+						dat += "<li><a href='byond://?src=\ref[src];choice=Medical Scan'><img src=pda_scanner.png>[scanmode == 1 ? "Disable" : "Enable"] Medical Scanner</a></li>"
 						dat += "</ul>"
 					if (cartridge.access & CART_SECURITY)
 						dat += "<h4>Security Functions</h4>"
 						dat += "<ul>"
-						dat += "<li><a href='byond://?src=\ref[src];choice=45'><img src=pda_cuffs.png> Security Records</A></li>"
+						dat += "<li><a href='byond://?src=\ref[src];choice=45'><img src=pda_cuffs.png>Security Records</A></li>"
 						dat += "</ul>"
 					if(cartridge.access & CART_QUARTERMASTER)
 						dat += "<h4>Quartermaster Functions:</h4>"
 						dat += "<ul>"
-						dat += "<li><a href='byond://?src=\ref[src];choice=47'><img src=pda_crate.png> Supply Records</A></li>"
+						dat += "<li><a href='byond://?src=\ref[src];choice=47'><img src=pda_crate.png>Supply Records</A></li>"
 						dat += "</ul>"
 				dat += "</ul>"
 
@@ -241,25 +248,25 @@ GLOBAL_LIST_EMPTY(PDAs)
 				dat += "<ul>"
 				if (cartridge)
 					if(cartridge.bot_access_flags)
-						dat += "<li><a href='byond://?src=\ref[src];choice=54'><img src=pda_medbot.png> Bots Access</a></li>"
+						dat += "<li><a href='byond://?src=\ref[src];choice=54'><img src=pda_medbot.png>Bots Access</a></li>"
 					if (cartridge.access & CART_JANITOR)
-						dat += "<li><a href='byond://?src=\ref[src];choice=49'><img src=pda_bucket.png> Custodial Locator</a></li>"
+						dat += "<li><a href='byond://?src=\ref[src];choice=49'><img src=pda_bucket.png>Custodial Locator</a></li>"
 					if (istype(cartridge.radio, /obj/item/radio/integrated/signal))
-						dat += "<li><a href='byond://?src=\ref[src];choice=40'><img src=pda_signaler.png> Signaler System</a></li>"
+						dat += "<li><a href='byond://?src=\ref[src];choice=40'><img src=pda_signaler.png>Signaler System</a></li>"
 					if (cartridge.access & CART_NEWSCASTER)
-						dat += "<li><a href='byond://?src=\ref[src];choice=53'><img src=pda_notes.png> Newscaster Access </a></li>"
+						dat += "<li><a href='byond://?src=\ref[src];choice=53'><img src=pda_notes.png>Newscaster Access </a></li>"
 					if (cartridge.access & CART_REAGENT_SCANNER)
-						dat += "<li><a href='byond://?src=\ref[src];choice=Reagent Scan'><img src=pda_reagent.png> [scanmode == 3 ? "Disable" : "Enable"] Reagent Scanner</a></li>"
+						dat += "<li><a href='byond://?src=\ref[src];choice=Reagent Scan'><img src=pda_reagent.png>[scanmode == 3 ? "Disable" : "Enable"] Reagent Scanner</a></li>"
 					if (cartridge.access & CART_ENGINE)
-						dat += "<li><a href='byond://?src=\ref[src];choice=Halogen Counter'><img src=pda_reagent.png> [scanmode == 4 ? "Disable" : "Enable"] Halogen Counter</a></li>"
+						dat += "<li><a href='byond://?src=\ref[src];choice=Halogen Counter'><img src=pda_reagent.png>[scanmode == 4 ? "Disable" : "Enable"] Halogen Counter</a></li>"
 					if (cartridge.access & CART_ATMOS)
-						dat += "<li><a href='byond://?src=\ref[src];choice=Gas Scan'><img src=pda_reagent.png> [scanmode == 5 ? "Disable" : "Enable"] Gas Scanner</a></li>"
+						dat += "<li><a href='byond://?src=\ref[src];choice=Gas Scan'><img src=pda_reagent.png>[scanmode == 5 ? "Disable" : "Enable"] Gas Scanner</a></li>"
 					if (cartridge.access & CART_REMOTE_DOOR)
-						dat += "<li><a href='byond://?src=\ref[src];choice=Toggle Door'><img src=pda_rdoor.png> Toggle Remote Door</a></li>"
+						dat += "<li><a href='byond://?src=\ref[src];choice=Toggle Door'><img src=pda_rdoor.png>Toggle Remote Door</a></li>"
 					if (cartridge.access & CART_DRONEPHONE)
-						dat += "<li><a href='byond://?src=\ref[src];choice=Drone Phone'><img src=pda_dronephone.png> Drone Phone</a></li>"
-				dat += "<li><a href='byond://?src=\ref[src];choice=3'><img src=pda_atmos.png> Atmospheric Scan</a></li>"
-				dat += "<li><a href='byond://?src=\ref[src];choice=Light'><img src=pda_flashlight.png> [fon ? "Disable" : "Enable"] Flashlight</a></li>"
+						dat += "<li><a href='byond://?src=\ref[src];choice=Drone Phone'><img src=pda_dronephone.png>Drone Phone</a></li>"
+				dat += "<li><a href='byond://?src=\ref[src];choice=3'><img src=pda_atmos.png>Atmospheric Scan</a></li>"
+				dat += "<li><a href='byond://?src=\ref[src];choice=Light'><img src=pda_flashlight.png>[fon ? "Disable" : "Enable"] Flashlight</a></li>"
 				if (pai)
 					if(pai.loc != src)
 						pai = null
@@ -278,15 +285,15 @@ GLOBAL_LIST_EMPTY(PDAs)
 
 			if (2)
 				dat += "<h4><img src=pda_mail.png> SpaceMessenger V3.9.6</h4>"
-				dat += "<a href='byond://?src=\ref[src];choice=Toggle Ringer'><img src=pda_bell.png> Ringer: [silent == 1 ? "Off" : "On"]</a> | "
-				dat += "<a href='byond://?src=\ref[src];choice=Toggle Messenger'><img src=pda_mail.png> Send / Receive: [toff == 1 ? "Off" : "On"]</a> | "
-				dat += "<a href='byond://?src=\ref[src];choice=Ringtone'><img src=pda_bell.png> Set Ringtone</a> | "
-				dat += "<a href='byond://?src=\ref[src];choice=21'><img src=pda_mail.png> Messages</a><br>"
+				dat += "<a href='byond://?src=\ref[src];choice=Toggle Ringer'><img src=pda_bell.png>Ringer: [silent == 1 ? "Off" : "On"]</a> | "
+				dat += "<a href='byond://?src=\ref[src];choice=Toggle Messenger'><img src=pda_mail.png>Send / Receive: [toff == 1 ? "Off" : "On"]</a> | "
+				dat += "<a href='byond://?src=\ref[src];choice=Ringtone'><img src=pda_bell.png>Set Ringtone</a> | "
+				dat += "<a href='byond://?src=\ref[src];choice=21'><img src=pda_mail.png>Messages</a><br>"
 
 				if(cartridge)
 					dat += cartridge.message_header()
 
-				dat += "<h4><img src=pda_menu.png> Detected PDAs</h4>"
+				dat += "<h4><img src=pda_menu.png>Detected PDAs</h4>"
 
 				dat += "<ul>"
 				var/count = 0
@@ -307,10 +314,10 @@ GLOBAL_LIST_EMPTY(PDAs)
 					dat += "<a href='byond://?src=\ref[src];choice=MessageAll'>Send To All</a>"
 
 			if(21)
-				dat += "<h4><img src=pda_mail.png> SpaceMessenger V3.9.6</h4>"
-				dat += "<a href='byond://?src=\ref[src];choice=Clear'><img src=pda_blank.png> Clear Messages</a>"
+				dat += "<h4><img src=pda_mail.png>SpaceMessenger V3.9.6</h4>"
+				dat += "<a href='byond://?src=\ref[src];choice=Clear'><img src=pda_blank.png>Clear Messages</a>"
 
-				dat += "<h4><img src=pda_mail.png> Messages</h4>"
+				dat += "<h4><img src=pda_mail.png>Messages</h4>"
 
 				dat += tnote
 				dat += "<br>"
@@ -342,6 +349,12 @@ GLOBAL_LIST_EMPTY(PDAs)
 				dat += cartridge.generate_menu()
 
 	dat += "</body></html>"
+	
+	if (underline_flag == UNDERLINE_ON)
+		dat = replacetext(dat, "text-decoration:none", "text-decoration:underline")
+	if (underline_flag == UNDERLINE_OFF)
+		dat = replacetext(dat, "text-decoration:underline", "text-decoration:none")
+	
 	user << browse(dat, "window=pda;size=400x450;border=1;can_resize=1;can_minimize=0")
 	onclose(user, "pda", src)
 
@@ -376,6 +389,9 @@ GLOBAL_LIST_EMPTY(PDAs)
 			if ("Change_Color")
 				var/new_color = input("Please enter a color name or hex value (Default is \'#808000\').")as color
 				background_color = new_color
+                
+			if ("Toggle_Underline")
+				underline_flag = (underline_flag + 1) % 2
 
 			if("Return")//Return
 				if(mode<=9)


### PR DESCRIPTION
WOOO FIRST PR, let me know if something is wrong.

-Adds Toggle Underline button to PDA menu that, when pressed, applies underline styling to all <a> elements. Underline is on by default. Clickables now pop out more, making them a little easier to find on-screen than they were before.

-Cleaned some of the HTML. There were spaces in some elements like `<tag> Example Text</tag>` to separate text from adjacent icons. Instead, I've given any `<img>` that's the child of an `<a>` tag the `{padding-right: 9px;}` style.

:cl: Epoc
add: Added a Toggle Underline button to the PDA menu
code: Cleaned HTML spacing 
/:cl:

With an update to the PDA fonts a little while back, the underlines on links/clickable elements disappeared. This is an effort to bring them back and improve the readability of the PDA menu. To me, seeing what can and can not be interacted with saves a decent amount of time by not having to read unimportant text when trying to find whatever it is on that menu that I need to click. It seems like a relatively small change, but this sort of thing was annoying enough to force me to contribute something for the first time. 

Did I do that right?