### PR TITLE
Fixed a small typo in drone machine actions 

### DIFF
--- a/code/game/machinery/droneDispenser.dm
+++ b/code/game/machinery/droneDispenser.dm
@@ -46,7 +46,7 @@
 	var/recharge_message = "pings."
 	var/recharging_text = "It is whirring and clicking. It seems to be recharging."
 
-	var/break_message = "lets out a tinny alarm before falling dark."
+	var/break_message = "lets out a tiny alarm before falling dark."
 	var/break_sound = 'sound/machines/warning-buzzer.ogg'
 
 /obj/machinery/droneDispenser/Initialize()


### PR DESCRIPTION
[Changelog]: Fixed a small typo in drone machine actions.

More specifically, Tiny > Tinny

[why]: It reads better.
