### PR TITLE
You can no longer equip pet collars on humans

### DIFF
--- a/code/modules/clothing/neck/neck.dm
+++ b/code/modules/clothing/neck/neck.dm
@@ -149,6 +149,11 @@
 	item_color = "petcollar"
 	var/tagname = null
 
+/obj/item/clothing/neck/petcollar/mob_can_equip(mob/M, mob/equipper, slot, disable_warning = 0)
+	if(ishuman(M))
+		return FALSE
+	return ..()
+
 /obj/item/clothing/neck/petcollar/attack_self(mob/user)
 	tagname = copytext(sanitize(input(user, "Would you like to change the name on the tag?", "Name your new pet", "Spot") as null|text),1,MAX_NAME_LEN)
 	name = "[initial(name)] - [tagname]"


### PR DESCRIPTION
This just heads the drama all off at the pass and should be a non issue as it doesn't break the supposed functionality of the item.

:cl: oranges
del: Pet collars no longer fit on humans
/:cl:
