### PR TITLE
[Ready]Ghosts can now Health Scan

### DIFF
--- a/code/_onclick/observer.dm
+++ b/code/_onclick/observer.dm
@@ -53,7 +53,9 @@
 	if(user.client)
 		if(IsAdminGhost(user))
 			attack_ai(user)
-		if(user.client.prefs.inquisitive_ghost)
+		else if(isliving(src) && user.health_scan)
+			healthscan(user, src, 1, TRUE)
+		else if(user.client.prefs.inquisitive_ghost)
 			user.examinate(src)
 
 // ---------------------------------------

--- a/code/_onclick/observer.dm
+++ b/code/_onclick/observer.dm
@@ -57,10 +57,9 @@
 			user.examinate(src)
 
 /mob/living/attack_ghost(mob/dead/observer/user)
-	if(user.client)
-		if(user.health_scan)
-			healthscan(user, src, 1, TRUE)
-			return
+	if(user.client && user.health_scan)
+		healthscan(user, src, 1, TRUE)
+		return
 	..()
 
 // ---------------------------------------

--- a/code/_onclick/observer.dm
+++ b/code/_onclick/observer.dm
@@ -53,10 +53,15 @@
 	if(user.client)
 		if(IsAdminGhost(user))
 			attack_ai(user)
-		else if(isliving(src) && user.health_scan)
-			healthscan(user, src, 1, TRUE)
 		else if(user.client.prefs.inquisitive_ghost)
 			user.examinate(src)
+
+/mob/living/attack_ghost(mob/dead/observer/user)
+	if(user.client)
+		if(user.health_scan)
+			healthscan(user, src, 1, TRUE)
+			return
+	..()
 
 // ---------------------------------------
 // And here are some good things for free:

--- a/code/game/objects/items/devices/scanners.dm
+++ b/code/game/objects/items/devices/scanners.dm
@@ -106,8 +106,8 @@ MASS SPECTROMETER
 
 
 // Used by the PDA medical scanner too
-/proc/healthscan(mob/living/user, mob/living/M, mode = 1, advanced = FALSE)
-	if(user.incapacitated() || user.eye_blind)
+/proc/healthscan(mob/user, mob/living/M, mode = 1, advanced = FALSE)
+	if(isliving(user) && (user.incapacitated() || user.eye_blind))
 		return
 	//Damage specifics
 	var/oxy_loss = M.getOxyLoss()

--- a/code/modules/mob/dead/observer/observer.dm
+++ b/code/modules/mob/dead/observer/observer.dm
@@ -30,6 +30,7 @@ GLOBAL_VAR_INIT(observer_default_invisibility, INVISIBILITY_OBSERVER)
 	var/mob/observetarget = null	//The target mob that the ghost is observing. Used as a reference in logout()
 	var/ghost_hud_enabled = 1 //did this ghost disable the on-screen HUD?
 	var/data_huds_on = 0 //Are data HUDs currently enabled?
+	var/health_scan = FALSE //Are health scans currently enabled?
 	var/list/datahuds = list(DATA_HUD_SECURITY_ADVANCED, DATA_HUD_MEDICAL_ADVANCED, DATA_HUD_DIAGNOSTIC) //list of data HUDs shown to ghosts.
 	var/ghost_orbit = GHOST_ORBIT_CIRCLE
 
@@ -674,6 +675,18 @@ This is the proc mobs get to turn into a ghost. Forked from ghostize due to comp
 		show_data_huds()
 		to_chat(src, "<span class='notice'>Data HUDs enabled.</span>")
 		data_huds_on = 1
+
+/mob/dead/observer/verb/toggle_health_scan()
+	set name = "Toggle Health Scan"
+	set desc = "Toggles whether you health-scan living beings on click"
+	set category = "Ghost"
+
+	if(health_scan) //remove old huds
+		to_chat(src, "<span class='notice'>Health scan disabled.</span>")
+		health_scan = 0
+	else
+		to_chat(src, "<span class='notice'>Health scan enabled.</span>")
+		health_scan = 1
 
 /mob/dead/observer/verb/restore_ghost_appearance()
 	set name = "Restore Ghost Character"

--- a/code/modules/mob/dead/observer/observer.dm
+++ b/code/modules/mob/dead/observer/observer.dm
@@ -683,10 +683,10 @@ This is the proc mobs get to turn into a ghost. Forked from ghostize due to comp
 
 	if(health_scan) //remove old huds
 		to_chat(src, "<span class='notice'>Health scan disabled.</span>")
-		health_scan = 0
+		health_scan = FALSE
 	else
 		to_chat(src, "<span class='notice'>Health scan enabled.</span>")
-		health_scan = 1
+		health_scan = TRUE
 
 /mob/dead/observer/verb/restore_ghost_appearance()
 	set name = "Restore Ghost Character"


### PR DESCRIPTION
:cl: XDTM
add: Ghosts now have a Toggle Health Scan verb, which allows them to health scan mobs they click on.
/:cl:

Gives some nice observer information, like damage types, time of death, diseases, and other afflictions that aren't evident without a full health scan.
