### PR TITLE
Cleans up explosives at syndie base

### DIFF
--- a/_maps/RandomRuins/LavaRuins/lavaland_surface_syndicate_base1.dmm
+++ b/_maps/RandomRuins/LavaRuins/lavaland_surface_syndicate_base1.dmm
@@ -12,8 +12,7 @@
 /turf/closed/wall/mineral/plastitanium,
 /area/ruin/powered/syndicate_lava_base)
 "ae" = (
-/obj/item/bombcore/large/underwall,
-/turf/closed/wall/mineral/plastitanium,
+/turf/closed/wall/mineral/plastitanium/explosive,
 /area/ruin/powered/syndicate_lava_base)
 "af" = (
 /obj/structure/closet/secure_closet/bar{

--- a/code/game/machinery/syndicatebomb.dm
+++ b/code/game/machinery/syndicatebomb.dm
@@ -379,9 +379,6 @@
 	range_light = 20
 	range_flame = 20
 
-/obj/item/bombcore/large/underwall
-	layer = ABOVE_OPEN_TURF_LAYER
-
 /obj/item/bombcore/miniature
 	name = "small bomb core"
 	w_class = WEIGHT_CLASS_SMALL

--- a/code/game/turfs/simulated/wall/mineral_walls.dm
+++ b/code/game/turfs/simulated/wall/mineral_walls.dm
@@ -258,6 +258,12 @@
 	icon_state = "map-overspace"
 	fixed_underlay = list("space"=1)
 
+/turf/closed/wall/mineral/plastitanium/explosive/dismantle_wall(devastated, explode)
+	var/obj/item/bombcore/large/bombcore = new(get_turf(src))
+	if(devastated || explode)
+		bombcore.detonate()
+	..()
+
 //have to copypaste this code
 /turf/closed/wall/mineral/plastitanium/interior/copyTurf(turf/T)
 	if(T.type != type)


### PR DESCRIPTION
Fixes #31637

If the wall is bombed it will explode. The wall can be dismantled with a welder to extract the explosive charge.