### PR TITLE
Slight change to the behavior of Assimilate_Air()

### DIFF
--- a/code/game/turfs/turf.dm
+++ b/code/game/turfs/turf.dm
@@ -277,12 +277,12 @@
 
 //////Assimilate Air//////
 /turf/open/proc/Assimilate_Air()
-	if(blocks_air)
+	var/turf_count = LAZYLEN(atmos_adjacent_turfs)
+	if(blocks_air || !turf_count) //if there weren't any open turfs, no need to update.
 		return
 
 	var/datum/gas_mixture/total = new//Holders to assimilate air from nearby turfs
 	var/list/total_gases = total.gases
-	var/turf_count = LAZYLEN(atmos_adjacent_turfs)
 
 	for(var/T in atmos_adjacent_turfs)
 		var/turf/open/S = T
@@ -295,9 +295,6 @@
 		total.temperature += S.air.temperature
 
 	air.copy_from(total)
-
-	if(!turf_count) //if there weren't any open turfs, no need to update.
-		return
 
 	var/list/air_gases = air.gases
 	for(var/id in air_gases)


### PR DESCRIPTION
Old behavior was that an isolated (no atmos_adjacent_turfs) closed turf would become a vacuum when changed to an open turf. New behavior is that it takes on the default gas mixture of the new open turf according to its type. 
Fixes #27734.

This behavior may not always be desirable, though I'm unsure if any existing situations exist where it would be truly detrimental. Nonetheless, the cases in which this behavior is desirable are far more numerable than those in which it would not be.