### PR TITLE
Fixes custom shuttle docker display

### DIFF
--- a/code/modules/shuttle/navigation_computer.dm
+++ b/code/modules/shuttle/navigation_computer.dm
@@ -38,22 +38,25 @@
 	var/mob/camera/aiEye/remote/shuttle_docker/the_eye = eyeobj
 	the_eye.origin = src
 	the_eye.dir = M.dir
-	var/area/A = get_area(M)
-	if(QDELETED(A))
-		return
+
 	var/turf/origin = locate(M.x + x_offset, M.y + y_offset, M.z)
-	for(var/turf/T in A)
-		if(T.z != origin.z)
+
+	for(var/i in M.shuttle_areas)
+		var/area/place = i
+		if(QDELETED(place))
 			continue
-		var/image/I = image('icons/effects/alphacolors.dmi', origin, "red")
-		I.layer = ABOVE_NORMAL_TURF_LAYER
-		I.plane = 0
-		I.mouse_opacity = 0
-		var/x_off = T.x - origin.x
-		var/y_off = T.y - origin.y
-		I.pixel_x = x_off * 32
-		I.pixel_y = y_off * 32
-		the_eye.placement_images[I] = list(x_off, y_off)
+		for(var/turf/T in place)
+			if(T.z != origin.z)
+				continue
+			var/image/I = image('icons/effects/alphacolors.dmi', origin, "red")
+			I.layer = ABOVE_NORMAL_TURF_LAYER
+			I.plane = 0
+			I.mouse_opacity = 0
+			var/x_off = T.x - origin.x
+			var/y_off = T.y - origin.y
+			I.pixel_x = x_off * 32
+			I.pixel_y = y_off * 32
+			the_eye.placement_images[I] = list(x_off, y_off)
 	generateBlacklistedTurfs()
 
 /obj/machinery/computer/camera_advanced/shuttle_docker/give_eye_control(mob/user)


### PR DESCRIPTION
:cl: ninjanomnom
fix: The custom shuttle placement highlight now works for multi area shuttles.
/:cl:

All this does is add an extra loop for looping through all shuttle areas and gets the areas via the shuttle var rather than getting the area the dock is in.

fixes #31501 
I can only assume this is what the issue was talking about as I see no other problems