### PR TITLE
Adds logging crew manifest to seperate file

### DIFF
--- a/code/__HELPERS/_logging.dm
+++ b/code/__HELPERS/_logging.dm
@@ -131,10 +131,6 @@
 		return "[A.loc] (0, 0, 0) ([A.loc.type])"
 
 
-/proc/log_manifest(/datum/mind/mind,mob/body,latejoin = FALSE)
+/proc/log_manifest(datum/mind/mind,mob/body,latejoin = FALSE)
 	if (CONFIG_GET(flag/log_manifest))
-		var/ckey = mind.ckey
-		var/assigned_role = mind.assigned_role
-		var/special_role = mind.special_role
-		var/name = body.real_name
-		WRITE_FILE(GLOB.manifest_log, "[ckey] - [name] - [assigned_role] - [special_role][latejoin ? " - LATEJOIN":""]")
+		WRITE_FILE(GLOB.manifest_log, "[mind.key] - [boyd.real_name] - [mind.assigned_role] - [mind.special_role][latejoin ? " - LATEJOIN":""]")

--- a/code/__HELPERS/_logging.dm
+++ b/code/__HELPERS/_logging.dm
@@ -133,4 +133,4 @@
 
 /proc/log_manifest(key,datum/mind/mind,mob/body,latejoin = FALSE)
 	if (CONFIG_GET(flag/log_manifest))
-		WRITE_FILE(GLOB.manifest_log, "[key] - [body.real_name] - [mind.assigned_role] - [mind.special_role][latejoin ? " - LATEJOIN":""]")
+		WRITE_FILE(GLOB.manifest_log, "[key] \\ [body.real_name] \\ [mind.assigned_role] \\ [mind.special_role ? mind.special_role : "NONE"] \\ [latejoin ? "LATEJOIN":"ROUNDSTART"]")

--- a/code/__HELPERS/_logging.dm
+++ b/code/__HELPERS/_logging.dm
@@ -133,4 +133,4 @@
 
 /proc/log_manifest(datum/mind/mind,mob/body,latejoin = FALSE)
 	if (CONFIG_GET(flag/log_manifest))
-		WRITE_FILE(GLOB.manifest_log, "[mind.key] - [boyd.real_name] - [mind.assigned_role] - [mind.special_role][latejoin ? " - LATEJOIN":""]")
+		WRITE_FILE(GLOB.manifest_log, "[mind.key] - [body.real_name] - [mind.assigned_role] - [mind.special_role][latejoin ? " - LATEJOIN":""]")

--- a/code/__HELPERS/_logging.dm
+++ b/code/__HELPERS/_logging.dm
@@ -129,3 +129,12 @@
 		return "[A.loc] [COORD(T)] ([A.loc.type])"
 	else if(A.loc)
 		return "[A.loc] (0, 0, 0) ([A.loc.type])"
+
+
+/proc/log_manifest(/datum/mind/mind,mob/body,latejoin = FALSE)
+	if (CONFIG_GET(flag/log_manifest))
+		var/ckey = mind.ckey
+		var/assigned_role = mind.assigned_role
+		var/special_role = mind.special_role
+		var/name = body.real_name
+		WRITE_FILE(GLOB.manifest_log, "[ckey] - [name] - [assigned_role] - [special_role][latejoin ? " - LATEJOIN":""]")

--- a/code/__HELPERS/_logging.dm
+++ b/code/__HELPERS/_logging.dm
@@ -131,6 +131,6 @@
 		return "[A.loc] (0, 0, 0) ([A.loc.type])"
 
 
-/proc/log_manifest(datum/mind/mind,mob/body,latejoin = FALSE)
+/proc/log_manifest(key,datum/mind/mind,mob/body,latejoin = FALSE)
 	if (CONFIG_GET(flag/log_manifest))
-		WRITE_FILE(GLOB.manifest_log, "[mind.key] - [body.real_name] - [mind.assigned_role] - [mind.special_role][latejoin ? " - LATEJOIN":""]")
+		WRITE_FILE(GLOB.manifest_log, "[key] - [body.real_name] - [mind.assigned_role] - [mind.special_role][latejoin ? " - LATEJOIN":""]")

--- a/code/_globalvars/logging.dm
+++ b/code/_globalvars/logging.dm
@@ -18,6 +18,8 @@ GLOBAL_VAR(sql_error_log)
 GLOBAL_PROTECT(sql_error_log)
 GLOBAL_VAR(world_pda_log)
 GLOBAL_PROTECT(world_pda_log)
+GLOBAL_VAR(manifest_log)
+GLOBAL_PROTECT(manifest_log)
 
 GLOBAL_LIST_EMPTY(bombers)
 GLOBAL_PROTECT(bombers)

--- a/code/controllers/configuration/entries/config.dm
+++ b/code/controllers/configuration/entries/config.dm
@@ -55,6 +55,8 @@ CONFIG_DEF(flag/log_twitter)	// log certain expliotable parrots and other such f
 
 CONFIG_DEF(flag/log_world_topic)	// log all world.Topic() calls
 
+CONFIG_DEF(flag/log_manifest)	// log crew manifest to seperate file
+
 CONFIG_DEF(flag/allow_admin_ooccolor)	// Allows admins with relevant permissions to have their own ooc colour
 
 CONFIG_DEF(flag/allow_vote_restart)	// allow votes to restart

--- a/code/datums/datacore.dm
+++ b/code/datums/datacore.dm
@@ -79,7 +79,7 @@
 /datum/datacore/proc/manifest()
 	for(var/mob/dead/new_player/N in GLOB.player_list)
 		if(N.new_character)
-			log_manifest(N.mind,N.new_character)
+			log_manifest(N.ckey,N.new_character.mind,N.new_character)
 		if(ishuman(N.new_character))
 			manifest_inject(N.new_character, N.client)
 		CHECK_TICK

--- a/code/datums/datacore.dm
+++ b/code/datums/datacore.dm
@@ -78,7 +78,8 @@
 
 /datum/datacore/proc/manifest()
 	for(var/mob/dead/new_player/N in GLOB.player_list)
-		log_manifest(N.mind,N.new_character)
+		if(N.new_character)
+			log_manifest(N.mind,N.new_character)
 		if(ishuman(N.new_character))
 			manifest_inject(N.new_character, N.client)
 		CHECK_TICK

--- a/code/datums/datacore.dm
+++ b/code/datums/datacore.dm
@@ -78,6 +78,7 @@
 
 /datum/datacore/proc/manifest()
 	for(var/mob/dead/new_player/N in GLOB.player_list)
+		log_manifest(N.mind,N.new_character)
 		if(ishuman(N.new_character))
 			manifest_inject(N.new_character, N.client)
 		CHECK_TICK

--- a/code/game/world.dm
+++ b/code/game/world.dm
@@ -91,6 +91,7 @@ GLOBAL_PROTECT(security_mode)
 	WRITE_FILE(GLOB.world_attack_log, "\n\nStarting up round ID [GLOB.round_id]. [time_stamp()]\n---------------------")
 	WRITE_FILE(GLOB.world_runtime_log, "\n\nStarting up round ID [GLOB.round_id]. [time_stamp()]\n---------------------")
 	WRITE_FILE(GLOB.world_pda_log, "\n\nStarting up round ID [GLOB.round_id]. [time_stamp()]\n---------------------")
+	WRITE_FILE(GLOB.manifest_log, "\n\nStarting up round ID [GLOB.round_id]. [time_stamp()]\n---------------------")
 	GLOB.changelog_hash = md5('html/changelog.html')					//used for telling if the changelog has changed recently
 	if(fexists(GLOB.config_error_log))
 		fcopy(GLOB.config_error_log, "[GLOB.log_directory]/config_error.log")

--- a/code/game/world.dm
+++ b/code/game/world.dm
@@ -6,7 +6,7 @@ GLOBAL_PROTECT(security_mode)
 
 	SetupExternalRSC()
 
-	GLOB.config_error_log = GLOB.world_pda_log = GLOB.sql_error_log = GLOB.world_href_log = GLOB.world_runtime_log = GLOB.world_attack_log = GLOB.world_game_log = file("data/logs/config_error.log") //temporary file used to record errors with loading config, moved to log directory once logging is set bl
+	GLOB.config_error_log = GLOB.manifest_log = GLOB.world_pda_log = GLOB.sql_error_log = GLOB.world_href_log = GLOB.world_runtime_log = GLOB.world_attack_log = GLOB.world_game_log = file("data/logs/config_error.log") //temporary file used to record errors with loading config, moved to log directory once logging is set bl
 
 	CheckSecurityMode()
 
@@ -86,6 +86,7 @@ GLOBAL_PROTECT(security_mode)
 	GLOB.world_href_log = file("[GLOB.log_directory]/hrefs.html")
 	GLOB.world_pda_log = file("[GLOB.log_directory]/pda.log")
 	GLOB.sql_error_log = file("[GLOB.log_directory]/sql.log")
+	GLOB.manifest_log = file("[GLOB.log_directory]/manifest.log")
 	WRITE_FILE(GLOB.world_game_log, "\n\nStarting up round ID [GLOB.round_id]. [time_stamp()]\n---------------------")
 	WRITE_FILE(GLOB.world_attack_log, "\n\nStarting up round ID [GLOB.round_id]. [time_stamp()]\n---------------------")
 	WRITE_FILE(GLOB.world_runtime_log, "\n\nStarting up round ID [GLOB.round_id]. [time_stamp()]\n---------------------")

--- a/code/modules/mob/dead/new_player/new_player.dm
+++ b/code/modules/mob/dead/new_player/new_player.dm
@@ -387,7 +387,7 @@
 					if(SSshuttle.emergency.timeLeft(1) > initial(SSshuttle.emergencyCallTime)*0.5)
 						SSticker.mode.make_antag_chance(humanc)
 
-	log_manifest(character.mind,character,latejoin = TRUE)
+	log_manifest(character.mind.key,character.mind,character,latejoin = TRUE)
 
 /mob/dead/new_player/proc/AddEmploymentContract(mob/living/carbon/human/employee)
 	//TODO:  figure out a way to exclude wizards/nukeops/demons from this.

--- a/code/modules/mob/dead/new_player/new_player.dm
+++ b/code/modules/mob/dead/new_player/new_player.dm
@@ -387,6 +387,8 @@
 					if(SSshuttle.emergency.timeLeft(1) > initial(SSshuttle.emergencyCallTime)*0.5)
 						SSticker.mode.make_antag_chance(humanc)
 
+	log_manifest(character.mind,character,latejoin = TRUE)
+
 /mob/dead/new_player/proc/AddEmploymentContract(mob/living/carbon/human/employee)
 	//TODO:  figure out a way to exclude wizards/nukeops/demons from this.
 	for(var/C in GLOB.employmentCabinets)

--- a/config/config.txt
+++ b/config/config.txt
@@ -93,6 +93,9 @@ LOG_PRAYER
 ## log lawchanges
 LOG_LAW
 
+## log crew manifest to seperate file
+LOG_MANIFEST
+
 ## log all world.Topic() calls
 # LOG_WORLD_TOPIC
 


### PR DESCRIPTION
Because this really shouldn't need to inferred indirectly. 
Logs roundstart and latejoin assigned role and special roles.
Format up to change, also need to test this.

@nfreader Probably could be useful for you too.

Example log:
```


Starting up round ID . 15:49:25
---------------------
anturke \ S H O C K  \ AI \ traitor \ ROUNDSTART
```