### PR TITLE
ID ejecting from computers by alt-clicking

### DIFF
--- a/code/game/machinery/computer/card.dm
+++ b/code/game/machinery/computer/card.dm
@@ -69,6 +69,7 @@ GLOBAL_VAR_INIT(time_last_changed_position, 0)
 					return
 				modify = idcard
 				playsound(src, 'sound/machines/terminal_insert_disc.ogg', 50, 0)
+		updateUsrDialog()
 	else
 		return ..()
 
@@ -349,38 +350,9 @@ GLOBAL_VAR_INIT(time_last_changed_position, 0)
 	usr.set_machine(src)
 	switch(href_list["choice"])
 		if ("modify")
-			if (modify)
-				GLOB.data_core.manifest_modify(modify.registered_name, modify.assignment)
-				modify.update_label()
-				modify.forceMove(drop_location())
-				modify.verb_pickup()
-				playsound(src, 'sound/machines/terminal_insert_disc.ogg', 50, 0)
-				modify = null
-				region_access = null
-				head_subordinates = null
-			else
-				var/obj/item/I = usr.get_active_held_item()
-				if (istype(I, /obj/item/card/id))
-					if (!usr.transferItemToLoc(I,src))
-						return
-					playsound(src, 'sound/machines/terminal_insert_disc.ogg', 50, 0)
-					modify = I
-			authenticated = 0
-
+			eject_id_modify()
 		if ("scan")
-			if (scan)
-				scan.forceMove(drop_location())
-				scan.verb_pickup()
-				playsound(src, 'sound/machines/terminal_insert_disc.ogg', 50, 0)
-				scan = null
-			else
-				var/obj/item/I = usr.get_active_held_item()
-				if (istype(I, /obj/item/card/id))
-					if (!usr.transferItemToLoc(I,src))
-						return
-					playsound(src, 'sound/machines/terminal_insert_disc.ogg', 50, 0)
-					scan = I
-			authenticated = 0
+			eject_id_scan()
 		if ("auth")
 			if ((!( authenticated ) && (scan || issilicon(usr)) && (modify || mode)))
 				if (check_access(scan))
@@ -549,6 +521,51 @@ GLOBAL_VAR_INIT(time_last_changed_position, 0)
 		modify.update_label()
 	updateUsrDialog()
 	return
+
+/obj/machinery/computer/card/AltClick(mob/user)
+	if(user.canUseTopic(src))
+		if(user.stat)
+			return
+		if(scan)
+			eject_id_scan()
+		else if(modify)
+			eject_id_modify()
+
+/obj/machinery/computer/card/proc/eject_id_scan(mob/user)
+	if(scan)
+		scan.forceMove(drop_location())
+		scan.verb_pickup()
+		playsound(src, 'sound/machines/terminal_insert_disc.ogg', 50, 0)
+		scan = null
+	else
+		var/obj/item/I = usr.get_active_held_item()
+		if(istype(I, /obj/item/card/id))
+			if(!usr.transferItemToLoc(I,src))
+				return
+			playsound(src, 'sound/machines/terminal_insert_disc.ogg', 50, 0)
+			scan = I
+	authenticated = 0
+	updateUsrDialog()
+
+/obj/machinery/computer/card/proc/eject_id_modify(mob/user)
+	if(modify)
+		GLOB.data_core.manifest_modify(modify.registered_name, modify.assignment)
+		modify.update_label()
+		modify.forceMove(drop_location())
+		modify.verb_pickup()
+		playsound(src, 'sound/machines/terminal_insert_disc.ogg', 50, 0)
+		modify = null
+		region_access = null
+		head_subordinates = null
+	else
+		var/obj/item/I = usr.get_active_held_item()
+		if(istype(I, /obj/item/card/id))
+			if (!usr.transferItemToLoc(I,src))
+				return
+			playsound(src, 'sound/machines/terminal_insert_disc.ogg', 50, 0)
+			modify = I
+	authenticated = 0
+	updateUsrDialog()
 
 /obj/machinery/computer/card/proc/get_subordinates(rank)
 	for(var/datum/job/job in SSjob.occupations)

--- a/code/game/machinery/computer/card.dm
+++ b/code/game/machinery/computer/card.dm
@@ -45,6 +45,11 @@ GLOBAL_VAR_INIT(time_last_changed_position, 0)
 
 	light_color = LIGHT_COLOR_BLUE
 
+/obj/machinery/computer/card/examine(mob/user)
+	..()
+	if(scan || modify)
+		to_chat(user, "<span class='notice'>Alt-click to eject the ID card.</span>")
+
 /obj/machinery/computer/card/Initialize()
 	. = ..()
 	change_position_cooldown = CONFIG_GET(number/id_console_jobslot_delay)
@@ -537,7 +542,7 @@ GLOBAL_VAR_INIT(time_last_changed_position, 0)
 		scan.verb_pickup()
 		playsound(src, 'sound/machines/terminal_insert_disc.ogg', 50, 0)
 		scan = null
-	else
+	else //switching the ID with the one you're holding
 		var/obj/item/I = usr.get_active_held_item()
 		if(istype(I, /obj/item/card/id))
 			if(!usr.transferItemToLoc(I,src))
@@ -557,7 +562,7 @@ GLOBAL_VAR_INIT(time_last_changed_position, 0)
 		modify = null
 		region_access = null
 		head_subordinates = null
-	else
+	else //switching the ID with the one you're holding
 		var/obj/item/I = usr.get_active_held_item()
 		if(istype(I, /obj/item/card/id))
 			if (!usr.transferItemToLoc(I,src))

--- a/code/game/machinery/computer/card.dm
+++ b/code/game/machinery/computer/card.dm
@@ -355,9 +355,9 @@ GLOBAL_VAR_INIT(time_last_changed_position, 0)
 	usr.set_machine(src)
 	switch(href_list["choice"])
 		if ("modify")
-			eject_id_modify()
+			eject_id_modify(usr)
 		if ("scan")
-			eject_id_scan()
+			eject_id_scan(usr)
 		if ("auth")
 			if ((!( authenticated ) && (scan || issilicon(usr)) && (modify || mode)))
 				if (check_access(scan))
@@ -529,27 +529,25 @@ GLOBAL_VAR_INIT(time_last_changed_position, 0)
 
 /obj/machinery/computer/card/AltClick(mob/user)
 	if(user.canUseTopic(src))
-		if(user.stat)
-			return
 		if(scan)
-			eject_id_scan()
-		else if(modify)
-			eject_id_modify()
+			eject_id_scan(user)
+		if(modify)
+			eject_id_modify(user)
 
 /obj/machinery/computer/card/proc/eject_id_scan(mob/user)
 	if(scan)
 		scan.forceMove(drop_location())
-		scan.verb_pickup()
+		user.put_in_hands(scan)
 		playsound(src, 'sound/machines/terminal_insert_disc.ogg', 50, 0)
 		scan = null
 	else //switching the ID with the one you're holding
-		var/obj/item/I = usr.get_active_held_item()
+		var/obj/item/I = user.get_active_held_item()
 		if(istype(I, /obj/item/card/id))
-			if(!usr.transferItemToLoc(I,src))
+			if(!user.transferItemToLoc(I,src))
 				return
 			playsound(src, 'sound/machines/terminal_insert_disc.ogg', 50, 0)
 			scan = I
-	authenticated = 0
+	authenticated = FALSE
 	updateUsrDialog()
 
 /obj/machinery/computer/card/proc/eject_id_modify(mob/user)
@@ -557,19 +555,19 @@ GLOBAL_VAR_INIT(time_last_changed_position, 0)
 		GLOB.data_core.manifest_modify(modify.registered_name, modify.assignment)
 		modify.update_label()
 		modify.forceMove(drop_location())
-		modify.verb_pickup()
+		user.put_in_hands(modify)
 		playsound(src, 'sound/machines/terminal_insert_disc.ogg', 50, 0)
 		modify = null
 		region_access = null
 		head_subordinates = null
 	else //switching the ID with the one you're holding
-		var/obj/item/I = usr.get_active_held_item()
+		var/obj/item/I = user.get_active_held_item()
 		if(istype(I, /obj/item/card/id))
-			if (!usr.transferItemToLoc(I,src))
+			if (!user.transferItemToLoc(I,src))
 				return
 			playsound(src, 'sound/machines/terminal_insert_disc.ogg', 50, 0)
 			modify = I
-	authenticated = 0
+	authenticated = FALSE
 	updateUsrDialog()
 
 /obj/machinery/computer/card/proc/get_subordinates(rank)

--- a/code/game/machinery/computer/security.dm
+++ b/code/game/machinery/computer/security.dm
@@ -301,15 +301,7 @@ What a mess.*/
 				active2 = null
 
 			if("Confirm Identity")
-				if(scan)
-					usr.put_in_hands(scan)
-					scan = null
-				else
-					var/obj/item/I = usr.is_holding_item_of_type(/obj/item/card/id)
-					if(I)
-						if(!usr.transferItemToLoc(I, src))
-							return
-						scan = I
+				eject_id()
 
 			if("Log Out")
 				authenticated = null
@@ -790,3 +782,18 @@ What a mess.*/
 					if(!record2 || record2 == active2)
 						return 1
 	return 0
+
+/obj/machinery/computer/secure_data/AltClick(mob/user)
+	if(user.canUseTopic(src))
+		eject_id()
+
+/obj/machinery/computer/secure_data/proc/eject_id(mob/user)
+	if(scan)
+		usr.put_in_hands(scan)
+		scan = null
+	else
+		var/obj/item/I = usr.is_holding_item_of_type(/obj/item/card/id)
+		if(I)
+			if(!usr.transferItemToLoc(I, src))
+				return
+			scan = I

--- a/code/game/machinery/computer/security.dm
+++ b/code/game/machinery/computer/security.dm
@@ -23,6 +23,11 @@
 
 	light_color = LIGHT_COLOR_RED
 
+/obj/machinery/computer/secure_data/examine(mob/user)
+	..()
+	if(scan)
+		to_chat(user, "<span class='notice'>Alt-click to eject the ID card.</span>")
+
 /obj/machinery/computer/secure_data/syndie
 	icon_keyboard = "syndie_key"
 
@@ -41,6 +46,8 @@
 				return
 			scan = O
 			to_chat(user, "<span class='notice'>You insert [O].</span>")
+			playsound(src, 'sound/machines/terminal_insert_disc.ogg', 50, 0)
+			updateUsrDialog()
 		else
 			to_chat(user, "<span class='warning'>There's already an ID card in the console.</span>")
 	else
@@ -791,9 +798,11 @@ What a mess.*/
 	if(scan)
 		usr.put_in_hands(scan)
 		scan = null
-	else
+		playsound(src, 'sound/machines/terminal_insert_disc.ogg', 50, 0)
+	else //switching the ID with the one you're holding
 		var/obj/item/I = usr.is_holding_item_of_type(/obj/item/card/id)
 		if(I)
 			if(!usr.transferItemToLoc(I, src))
 				return
 			scan = I
+			playsound(src, 'sound/machines/terminal_insert_disc.ogg', 50, 0)

--- a/code/game/machinery/computer/security.dm
+++ b/code/game/machinery/computer/security.dm
@@ -308,7 +308,7 @@ What a mess.*/
 				active2 = null
 
 			if("Confirm Identity")
-				eject_id()
+				eject_id(usr)
 
 			if("Log Out")
 				authenticated = null
@@ -791,18 +791,18 @@ What a mess.*/
 	return 0
 
 /obj/machinery/computer/secure_data/AltClick(mob/user)
-	if(user.canUseTopic(src))
-		eject_id()
+	if(user.canUseTopic(src) && scan)
+		eject_id(user)
 
 /obj/machinery/computer/secure_data/proc/eject_id(mob/user)
 	if(scan)
-		usr.put_in_hands(scan)
+		user.put_in_hands(scan)
 		scan = null
 		playsound(src, 'sound/machines/terminal_insert_disc.ogg', 50, 0)
 	else //switching the ID with the one you're holding
-		var/obj/item/I = usr.is_holding_item_of_type(/obj/item/card/id)
+		var/obj/item/I = user.is_holding_item_of_type(/obj/item/card/id)
 		if(I)
-			if(!usr.transferItemToLoc(I, src))
+			if(!user.transferItemToLoc(I, src))
 				return
 			scan = I
 			playsound(src, 'sound/machines/terminal_insert_disc.ogg', 50, 0)

--- a/code/modules/modular_computers/hardware/card_slot.dm
+++ b/code/modules/modular_computers/hardware/card_slot.dm
@@ -57,6 +57,7 @@
 	else
 		stored_card2 = I
 	to_chat(user, "<span class='notice'>You insert \the [I] into \the [src].</span>")
+	playsound(src, 'sound/machines/terminal_insert_disc.ogg', 50, 0)
 
 	return TRUE
 
@@ -93,6 +94,7 @@
 				P.event_idremoved(1, slot)
 
 		to_chat(user, "<span class='notice'>You remove the card[ejected>1 ? "s" : ""] from \the [src].</span>")
+		playsound(src, 'sound/machines/terminal_insert_disc.ogg', 50, 0)
 		return TRUE
 	return FALSE
 


### PR DESCRIPTION
:cl:
add: Alt-clicking on a computer now ejects the ID card inside it.
/:cl:

What it says on the title.
Also makes the computer screen always refresh, and make the terminal_insert_disk sound, when you insert an ID.