### PR TITLE
Resets client movement delay to its initial value on death

### DIFF
--- a/code/modules/mob/living/death.dm
+++ b/code/modules/mob/living/death.dm
@@ -73,6 +73,9 @@
 	med_hud_set_health()
 	med_hud_set_status()
 
+	if (client)
+		client.move_delay = initial(client.move_delay)
+
 	for(var/s in ownedSoullinks)
 		var/datum/soullink/S = s
 		S.ownerDies(gibbed)


### PR DESCRIPTION
Fixes #13633 

Tested to be working on both cliented and clientless mobs.

[Changelogs]: 

:cl: Naksu
fix: Ghosts no longer inherit the movement delay of their former bodies.
/:cl:

[why]: 
Bugfix
