### PR TITLE
Allows mobs to get shocked when they smash things

### DIFF
--- a/code/game/machinery/doors/airlock.dm
+++ b/code/game/machinery/doors/airlock.dm
@@ -756,6 +756,11 @@
 		if(user)
 			src.attack_ai(user)
 
+/obj/machinery/door/airlock/attack_animal(mob/user)
+	. = ..()
+	if(isElectrified())
+		shock(user, 100)
+
 /obj/machinery/door/airlock/attack_paw(mob/user)
 	return src.attack_hand(user)
 

--- a/code/game/objects/structures/grille.dm
+++ b/code/game/objects/structures/grille.dm
@@ -67,6 +67,10 @@
 	var/mob/M = AM
 	shock(M, 70)
 
+/obj/structure/grille/attack_animal(mob/user)
+	. = ..()
+	if(!shock(user, 70))
+		take_damage(rand(5,10), BRUTE, "melee", 1)
 
 /obj/structure/grille/attack_paw(mob/user)
 	attack_hand(user)

--- a/code/modules/reagents/chemistry/reagents/other_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/other_reagents.dm
@@ -1585,7 +1585,7 @@
 /datum/reagent/magillitis/on_mob_life(mob/living/carbon/M)
 	..()
 	if((ismonkey(M) || ishuman(M)) && current_cycle >= 10)
-		return M.gorillize()
+		M.gorillize()
 
 /datum/reagent/growthserum
 	name = "Growth Serum"


### PR DESCRIPTION
Fixes #30131

also fixes an unrelated runtime involving magillitis, on_mob_life of magillitis was returning a reference to the gorilla for whatever reason to the reagent holder which would attempt to += it to an int.

[Changelogs]: 

:cl: Naksu
fix: Fixed mobs being able to smash shocked objects without taking damage.
/:cl:

[why]: 
Closes issue, fixes a runtime.
