### PR TITLE
Fixes mounting vehicles through obstacles

### DIFF
--- a/code/game/objects/buckling.dm
+++ b/code/game/objects/buckling.dm
@@ -56,7 +56,8 @@
 		M.pulledby.stop_pulling()
 
 	if(!check_loc && M.loc != loc)
-		M.forceMove(loc)
+		if (!M.Move(loc))
+			return FALSE
 
 	M.buckled = src
 	M.setDir(dir)

--- a/code/modules/vehicles/vehicle.dm
+++ b/code/modules/vehicles/vehicle.dm
@@ -36,6 +36,9 @@
 
 
 /obj/vehicle/user_buckle_mob(mob/living/M, mob/user)
+	. = ..()
+	if (!.) 
+		return
 	if(user.incapacitated())
 		return
 	for(var/atom/movable/A in get_turf(src))
@@ -43,7 +46,6 @@
 			if(A != src && A != M)
 				return
 	M.forceMove(get_turf(src))
-	..()
 	if(user.client)
 		user.client.change_view(view_range)
 	if(riding_datum)


### PR DESCRIPTION
Fixes #31426 

:cl: Epoc
fix: Fixed being able to mount vehicles through obstacles
/:cl:

[why]: The less people teleporting through walls on to skateboards, the better
