### PR TITLE
Allows /obj/effect/decal/cleanable to qdel properly

### DIFF
--- a/code/game/objects/effects/decals/cleanable.dm
+++ b/code/game/objects/effects/decals/cleanable.dm
@@ -27,6 +27,11 @@
 	if(mergeable_decal)
 		qdel(C)
 
+/obj/effect/decal/cleanable/Destroy()
+	. = ..()
+	if (reagents)
+		qdel(reagents)
+
 /obj/effect/decal/cleanable/attackby(obj/item/W, mob/user, params)
 	if(istype(W, /obj/item/reagent_containers/glass) || istype(W, /obj/item/reagent_containers/food/drinks))
 		if(src.reagents && W.reagents)


### PR DESCRIPTION
Fixes #11370
Fixes #11369

[Changelogs]: 

:cl: Naksu
code: Tweaks to decal cleanup code
/:cl:

[why]: 
Bugfix
