### PR TITLE
[s] Removes scrubber and filter infinite pressure exploits.

### DIFF
--- a/code/modules/atmospherics/machinery/components/trinary_devices/filter.dm
+++ b/code/modules/atmospherics/machinery/components/trinary_devices/filter.dm
@@ -69,8 +69,8 @@
 
 	var/output_starting_pressure = air3.return_pressure()
 
-	if(output_starting_pressure >= target_pressure)
-		//No need to mix if target is already full!
+	if(output_starting_pressure >= target_pressure || air2.return_pressure() >= target_pressure)
+		//No need to transfer if target is already full!
 		return
 
 	//Calculate necessary moles to transfer using PV=nRT

--- a/code/modules/atmospherics/machinery/components/unary_devices/vent_scrubber.dm
+++ b/code/modules/atmospherics/machinery/components/unary_devices/vent_scrubber.dm
@@ -171,6 +171,9 @@
 	var/datum/gas_mixture/air_contents = AIR1
 	var/list/env_gases = environment.gases
 
+	if(air_contents.return_pressure() >= 50*ONE_ATMOSPHERE)
+		return FALSE
+
 	if(scrubbing & SCRUBBING)
 		var/should_we_scrub = FALSE
 		for(var/id in env_gases)
@@ -238,8 +241,6 @@
 			tile.air_update_turf()
 
 	else //Just siphoning all air
-		if(air_contents.return_pressure()>=50*ONE_ATMOSPHERE)
-			return FALSE
 
 		var/transfer_moles = environment.total_moles()*(volume_rate/environment.volume)
 


### PR DESCRIPTION
Fixes #26391.
Scrubbers are limited to the same pressure as they already were for syphoning.
Filters now stop transferring when either output is above the target pressure.

:cl:
fix: Scrubbers and filters no longer allow for infinite pressure in pipes.
/:cl: