### PR TITLE
Makes Renault appear consistently across all stations. Fixes missing petbed on Meta.

### DIFF
--- a/_maps/map_files/BoxStation/BoxStation.dmm
+++ b/_maps/map_files/BoxStation/BoxStation.dmm
@@ -60798,6 +60798,11 @@
 /obj/structure/grille,
 /turf/open/space/basic,
 /area/space)
+"Qov" = (
+/obj/structure/bed/dogbed/renault,
+/mob/living/simple_animal/pet/fox/Renault,
+/turf/open/floor/wood,
+/area/crew_quarters/heads/captain)
 
 (1,1,1) = {"
 aaa
@@ -93049,7 +93054,7 @@ aVv
 aXg
 aYF
 aZV
-bbw
+Qov
 bcn
 bbw
 ben

--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -40840,6 +40840,7 @@
 	network = list("MiniSat","tcomm");
 	pixel_y = -29
 	},
+/obj/structure/bed/dogbed/renault,
 /mob/living/simple_animal/pet/fox/Renault,
 /turf/open/floor/carpet,
 /area/crew_quarters/heads/captain/private)

--- a/_maps/map_files/OmegaStation/OmegaStation.dmm
+++ b/_maps/map_files/OmegaStation/OmegaStation.dmm
@@ -3507,6 +3507,8 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 5
 	},
+/obj/structure/bed/dogbed/renault,
+/mob/living/simple_animal/pet/fox/Renault,
 /turf/open/floor/wood,
 /area/crew_quarters/heads/captain/private)
 "agd" = (

--- a/_maps/map_files/PubbyStation/PubbyStation.dmm
+++ b/_maps/map_files/PubbyStation/PubbyStation.dmm
@@ -54065,6 +54065,11 @@
 /obj/machinery/smoke_machine,
 /turf/open/floor/plasteel/white,
 /area/medical/chemistry)
+"YXI" = (
+/obj/structure/bed/dogbed/renault,
+/mob/living/simple_animal/pet/fox/Renault,
+/turf/open/floor/plasteel/black,
+/area/crew_quarters/heads/captain)
 
 (1,1,1) = {"
 aaa
@@ -82687,7 +82692,7 @@ aAy
 aBp
 aCC
 aDG
-aBm
+YXI
 aFz
 aGm
 awR


### PR DESCRIPTION
🆑 ShizCalev
add: Renault will now be present in the captain's office on all stations.
/🆑

Makes Renault appear consistently in the captain's office on all maps.

Also fixes missing petbed in the captain's office on Meta.

(Resolves the concerns voiced in #31679)