### PR TITLE
Prevents tiles from being placed on top of buckled mobs

### DIFF
--- a/code/game/turfs/simulated/floor/plating.dm
+++ b/code/game/turfs/simulated/floor/plating.dm
@@ -55,6 +55,11 @@
 				return
 	else if(istype(C, /obj/item/stack/tile))
 		if(!broken && !burnt)
+			for(var/obj/O in src)
+				if(O.level == 1) //ex. pipes laid underneath a tile
+					for(var/M in O.buckled_mobs)
+						to_chat(user, "<span class='warning'>Someone is buckled to \the [O]! Unbuckle [M] to move \him out of the way.</span>")
+						return
 			var/obj/item/stack/tile/W = C
 			if(!W.use(1))
 				return


### PR DESCRIPTION
Fixes #24866.
This only prevents placing on TOP of buckled mobs - i.e., mobs buckled to level 1 (the piping level).