### PR TITLE
Increasew the size of the katana from normal to huge

### DIFF
--- a/code/game/objects/items/weaponry.dm
+++ b/code/game/objects/items/weaponry.dm
@@ -201,7 +201,7 @@
 	slot_flags = SLOT_BELT | SLOT_BACK
 	force = 40
 	throwforce = 10
-	w_class = WEIGHT_CLASS_NORMAL
+	w_class = WEIGHT_CLASS_HUGE
 	hitsound = 'sound/weapons/bladeslice.ogg'
 	attack_verb = list("attacked", "slashed", "stabbed", "sliced", "torn", "ripped", "diced", "cut")
 	block_chance = 50


### PR DESCRIPTION
Two feature freezes ago the katana size was decreased from huge to normal
So the katana could fit in your backpack a weapon that does 40 brute damage and 50 block chance
The reason that it was decreased was because it was added to a syndi bundle everyone argued how nobody would want it of how obvious it be on your back/belt 

But i think thats just using a excuse its a super powerfull weapon and the kit comes with adrenals and a cham projector so i want to revert this powercreep change

🆑 Improvedname
Tweak: Reverts katana's to its orginal size being huge
/🆑