### PR TITLE
Fixes a bunch of runtimes involving supermatter suicides, also some initialize fixes

### DIFF
--- a/code/game/objects/effects/landmarks.dm
+++ b/code/game/objects/effects/landmarks.dm
@@ -254,7 +254,7 @@
 	..()
 	GLOB.prisonwarp += loc
 	return INITIALIZE_HINT_QDEL
-	
+
 /obj/effect/landmark/ert_spawn
 	name = "Emergencyresponseteam"
 
@@ -310,7 +310,7 @@
 /obj/effect/landmark/servant_of_ratvar/Initialize(mapload)
 	..()
 	GLOB.servant_spawns += loc
-	qdel(src)
+	return INITIALIZE_HINT_QDEL
 
 //City of Cogs entrances
 /obj/effect/landmark/city_of_cogs
@@ -320,7 +320,7 @@
 /obj/effect/landmark/city_of_cogs/Initialize(mapload)
 	..()
 	GLOB.city_of_cogs_spawns += loc
-	qdel(src)
+	return INITIALIZE_HINT_QDEL
 
 //generic event spawns
 /obj/effect/landmark/event_spawn

--- a/code/game/objects/structures/window.dm
+++ b/code/game/objects/structures/window.dm
@@ -650,7 +650,7 @@
 /obj/structure/window/reinforced/clockwork/Initialize(mapload, direct)
 	if(fulltile)
 		made_glow = TRUE
-	..()
+	. = ..()
 	QDEL_LIST(debris)
 	var/amount_of_gears = 2
 	if(fulltile)

--- a/code/game/turfs/simulated/wall/misc_walls.dm
+++ b/code/game/turfs/simulated/wall/misc_walls.dm
@@ -59,7 +59,7 @@
 	var/obj/effect/clockwork/overlay/wall/realappearence
 
 /turf/closed/wall/clockwork/Initialize()
-	..()
+	. = ..()
 	new /obj/effect/temp_visual/ratvar/wall(src)
 	new /obj/effect/temp_visual/ratvar/beam(src)
 	realappearence = new /obj/effect/clockwork/overlay/wall(src)

--- a/code/modules/mob/living/death.dm
+++ b/code/modules/mob/living/death.dm
@@ -34,7 +34,7 @@
 
 	dust_animation()
 	spawn_dust(just_ash)
-	qdel(src)
+	QDEL_IN(src,5) // since this is sometimes called in the middle of movement, allow half a second for movement to finish, ghosting to happen and animation to play. Looks much nicer and doesn't cause multiple runtimes.
 
 /mob/living/proc/dust_animation()
 	return

--- a/code/modules/mob/living/silicon/ai/ai.dm
+++ b/code/modules/mob/living/silicon/ai/ai.dm
@@ -988,6 +988,6 @@
 	return
 
 /mob/living/silicon/ai/spawned/Initialize(mapload, datum/ai_laws/L, mob/target_ai)
+	. = ..()
 	if(!target_ai)
 		target_ai = src //cheat! just give... ourselves as the spawned AI, because that's technically correct
-	return ..()

--- a/code/modules/mob/living/silicon/ai/ai.dm
+++ b/code/modules/mob/living/silicon/ai/ai.dm
@@ -86,7 +86,7 @@
 	var/chnotify = 0
 
 /mob/living/silicon/ai/Initialize(mapload, datum/ai_laws/L, mob/target_ai)
-	..()
+	. = ..()
 	if(!target_ai) //If there is no player/brain inside.
 		new/obj/structure/AIcore/deactivated(loc) //New empty terminal.
 		qdel(src)//Delete AI.
@@ -990,4 +990,4 @@
 /mob/living/silicon/ai/spawned/Initialize(mapload, datum/ai_laws/L, mob/target_ai)
 	if(!target_ai)
 		target_ai = src //cheat! just give... ourselves as the spawned AI, because that's technically correct
-	..()
+	return ..()


### PR DESCRIPTION
I was going to just fix some initialize stuff but it turned out the observer initialize failure was caused by runtimes resulting from early qdel in dust(), and after I looked closer it actually caused a whole bunch of them.

Incidentally, did you know there's an animation that plays when you get dusted? Now you can actually see it.

:cl: Naksu
code: Fixed dusting code, supermatter-suicides no longer spam the runtime logs.
code: Fixed some initialize paths.
/:cl:
