### PR TITLE
Fixed the shuttle navigation computer allowing you to move docking ports

### DIFF
--- a/code/modules/shuttle/navigation_computer.dm
+++ b/code/modules/shuttle/navigation_computer.dm
@@ -9,7 +9,7 @@
 	var/shuttlePortName = ""
 	var/list/jumpto_ports = list() //hashset of ports to jump to and ignore for collision purposes
 	var/list/blacklisted_turfs
-	var/obj/docking_port/stationary/custom_placed/my_port
+	var/obj/docking_port/stationary/my_port
 	var/view_range = 7
 	var/x_offset = 0
 	var/y_offset = 0
@@ -77,7 +77,7 @@
 		return FALSE
 	var/mob/camera/aiEye/remote/shuttle_docker/the_eye = eyeobj
 	if(!my_port)
-		my_port = new /obj/docking_port/stationary/custom_placed()
+		my_port = new /obj/docking_port/stationary()
 		my_port.name = shuttlePortName
 		my_port.id = shuttlePortId
 		var/obj/docking_port/mobile/M = SSshuttle.getShuttle(shuttleId)

--- a/code/modules/shuttle/navigation_computer.dm
+++ b/code/modules/shuttle/navigation_computer.dm
@@ -9,7 +9,7 @@
 	var/shuttlePortName = ""
 	var/list/jumpto_ports = list() //hashset of ports to jump to and ignore for collision purposes
 	var/list/blacklisted_turfs
-	var/obj/docking_port/stationary/my_port
+	var/obj/docking_port/stationary/custom_placed/my_port
 	var/view_range = 7
 	var/x_offset = 0
 	var/y_offset = 0
@@ -77,7 +77,7 @@
 		return FALSE
 	var/mob/camera/aiEye/remote/shuttle_docker/the_eye = eyeobj
 	if(!my_port)
-		my_port = new /obj/docking_port/stationary
+		my_port = new /obj/docking_port/stationary/custom_placed()
 		my_port.name = shuttlePortName
 		my_port.id = shuttlePortId
 		var/obj/docking_port/mobile/M = SSshuttle.getShuttle(shuttleId)

--- a/code/modules/shuttle/on_move.dm
+++ b/code/modules/shuttle/on_move.dm
@@ -330,10 +330,11 @@ All ShuttleMove procs go here
 /atom/movable/light/onShuttleMove(turf/newT, turf/oldT, rotation, list/movement_force, move_dir, old_dock)
 	return FALSE
 
-/obj/docking_port/stationary/onShuttleMove(turf/newT, turf/oldT, rotation, list/movement_force, move_dir, old_dock)
+/obj/docking_port/stationary/onShuttleMove(turf/newT, turf/oldT, rotation, list/movement_force, move_dir, obj/docking_port/stationary/old_dock)
 	if(old_dock == src) //Don't move the dock we're leaving
 		return FALSE
-
+	if(old_dock && !old_dock.can_move_docking_ports_from)
+		return FALSE
 	. = ..()
 
 /obj/docking_port/stationary/public_mining_dock/onShuttleMove(turf/newT, turf/oldT, rotation, list/movement_force, move_dir, old_dock)

--- a/code/modules/shuttle/on_move.dm
+++ b/code/modules/shuttle/on_move.dm
@@ -331,9 +331,7 @@ All ShuttleMove procs go here
 	return FALSE
 
 /obj/docking_port/stationary/onShuttleMove(turf/newT, turf/oldT, rotation, list/movement_force, move_dir, obj/docking_port/stationary/old_dock, obj/docking_port/mobile/moving_dock)
-	if(old_dock == src) //Don't move the dock we're leaving
-		return FALSE
-	if(moving_dock && !moving_dock.can_move_docking_ports)
+	if(!moving_dock.can_move_docking_ports || (old_dock == src))
 		return FALSE
 	. = ..()
 

--- a/code/modules/shuttle/on_move.dm
+++ b/code/modules/shuttle/on_move.dm
@@ -76,7 +76,7 @@ All ShuttleMove procs go here
 	return move_mode
 
 // Called on atoms to move the atom to the new location
-/atom/movable/proc/onShuttleMove(turf/newT, turf/oldT, rotation, list/movement_force, move_dir, old_dock)
+/atom/movable/proc/onShuttleMove(turf/newT, turf/oldT, rotation, list/movement_force, move_dir, obj/docking_port/stationary/old_dock, obj/docking_port/mobile/moving_dock)
 	if(newT == oldT) // In case of in place shuttle rotation shenanigans.
 		return
 
@@ -268,7 +268,7 @@ All ShuttleMove procs go here
 
 /************************************Mob move procs************************************/
 
-/mob/onShuttleMove(turf/newT, turf/oldT, rotation, list/movement_force, move_dir, old_dock)
+/mob/onShuttleMove(turf/newT, turf/oldT, rotation, list/movement_force, move_dir, obj/docking_port/stationary/old_dock, obj/docking_port/mobile/moving_dock)
 	if(!move_on_shuttle)
 		return
 	. = ..()
@@ -293,7 +293,7 @@ All ShuttleMove procs go here
 		if(movement_force["KNOCKDOWN"])
 			Knockdown(movement_force["KNOCKDOWN"])
 
-/mob/living/simple_animal/hostile/megafauna/onShuttleMove(turf/newT, turf/oldT, rotation, list/movement_force, move_dir, old_dock)
+/mob/living/simple_animal/hostile/megafauna/onShuttleMove(turf/newT, turf/oldT, rotation, list/movement_force, move_dir, obj/docking_port/stationary/old_dock, obj/docking_port/mobile/moving_dock)
 	. = ..()
 	message_admins("Megafauna [src] [ADMIN_FLW(src)] moved via shuttle from [ADMIN_COORDJMP(oldT)] to [ADMIN_COORDJMP(loc)]")
 
@@ -324,22 +324,22 @@ All ShuttleMove procs go here
 
 /************************************Misc move procs************************************/
 
-/atom/movable/lighting_object/onShuttleMove(turf/newT, turf/oldT, rotation, list/movement_force, move_dir, old_dock)
+/atom/movable/lighting_object/onShuttleMove(turf/newT, turf/oldT, rotation, list/movement_force, move_dir, obj/docking_port/stationary/old_dock, obj/docking_port/mobile/moving_dock)
 	return FALSE
 
-/atom/movable/light/onShuttleMove(turf/newT, turf/oldT, rotation, list/movement_force, move_dir, old_dock)
+/atom/movable/light/onShuttleMove(turf/newT, turf/oldT, rotation, list/movement_force, move_dir, obj/docking_port/stationary/old_dock, obj/docking_port/mobile/moving_dock)
 	return FALSE
 
-/obj/docking_port/stationary/onShuttleMove(turf/newT, turf/oldT, rotation, list/movement_force, move_dir, obj/docking_port/stationary/old_dock)
+/obj/docking_port/stationary/onShuttleMove(turf/newT, turf/oldT, rotation, list/movement_force, move_dir, obj/docking_port/stationary/old_dock, obj/docking_port/mobile/moving_dock)
 	if(old_dock == src) //Don't move the dock we're leaving
 		return FALSE
-	if(old_dock && !old_dock.can_move_docking_ports_from)
+	if(moving_dock && !moving_dock.can_move_docking_ports)
 		return FALSE
 	. = ..()
 
-/obj/docking_port/stationary/public_mining_dock/onShuttleMove(turf/newT, turf/oldT, rotation, list/movement_force, move_dir, old_dock)
+/obj/docking_port/stationary/public_mining_dock/onShuttleMove(turf/newT, turf/oldT, rotation, list/movement_force, move_dir, obj/docking_port/stationary/old_dock, obj/docking_port/mobile/moving_dock)
 	id = "mining_public" //It will not move with the base, but will become enabled as a docking point.
 
-/obj/effect/abstract/proximity_checker/onShuttleMove(turf/newT, turf/oldT, rotation, list/movement_force, move_dir, old_dock)
+/obj/effect/abstract/proximity_checker/onShuttleMove(turf/newT, turf/oldT, rotation, list/movement_force, move_dir, obj/docking_port/stationary/old_dock, obj/docking_port/mobile/moving_dock)
 	//timer so it only happens once
 	addtimer(CALLBACK(monitor, /datum/proximity_monitor/proc/SetRange, monitor.current_range, TRUE), 0, TIMER_UNIQUE)

--- a/code/modules/shuttle/shuttle.dm
+++ b/code/modules/shuttle/shuttle.dm
@@ -175,7 +175,7 @@
 
 //return first-found touching dockingport
 /obj/docking_port/proc/get_docked()
-	return locate(/obj/docking_port/stationary) in loc
+	return null
 
 /obj/docking_port/proc/getDockedId()
 	var/obj/docking_port/P = get_docked()
@@ -192,6 +192,8 @@
 	var/list/baseturf_cache
 
 	var/last_dock_time
+
+	var/can_move_docking_ports_from = TRUE
 
 /obj/docking_port/stationary/Initialize(mapload)
 	. = ..()
@@ -272,6 +274,8 @@
 
 	var/obj/docking_port/stationary/transit/assigned_transit
 
+	var/obj/docking_port/stationary/last_docked_at
+
 	var/launch_status = NOLAUNCH
 
 	var/list/movement_force = list("KNOCKDOWN" = 3, "THROW" = 0)
@@ -321,6 +325,11 @@
 	#ifdef DOCKING_PORT_HIGHLIGHT
 	highlight("#0f0")
 	#endif
+
+/obj/docking_port/mobile/get_docked()
+	if(last_docked_at)
+		return last_docked_at
+	return locate(/obj/docking_port/stationary) in loc
 
 //this is a hook for custom behaviour. Maybe at some point we could add checks to see if engines are intact
 /obj/docking_port/mobile/proc/canMove()
@@ -512,6 +521,7 @@
 			return DOCKING_IMMOBILIZED
 
 	var/obj/docking_port/stationary/old_dock = get_docked()
+	last_docked_at = new_dock
 	var/underlying_turf_type = /turf/open/space //The turf that gets placed under where the shuttle moved from
 	var/underlying_baseturf_type = /turf/open/space //The baseturf that the gets assigned to the turf_type above
 	var/underlying_area_type = /area/space //The area that gets placed under where the shuttle moved from
@@ -920,5 +930,8 @@
 
 /obj/docking_port/mobile/emergency/on_emergency_dock()
 	return
+
+/obj/docking_port/stationary/custom_placed
+	can_move_docking_ports_from = FALSE
 
 #undef DOCKING_PORT_HIGHLIGHT


### PR DESCRIPTION
Moving any shuttle to a custom location that included a docking port would cause that docking port to be moved with the shuttle next time it left. With some finagling you could even move the custom docking port to transit space.
Fixes #31486 