### PR TITLE
restores safety check in gas mixture temperature_share()

### DIFF
--- a/code/modules/atmospherics/gasmixtures/gas_mixture.dm
+++ b/code/modules/atmospherics/gasmixtures/gas_mixture.dm
@@ -371,8 +371,8 @@ GLOBAL_LIST_INIT(gaslist_cache, init_gaslist_cache())
 			var/heat = conduction_coefficient*temperature_delta* \
 				(self_heat_capacity*sharer_heat_capacity/(self_heat_capacity+sharer_heat_capacity))
 
-			temperature -= heat/self_heat_capacity
-			sharer_temperature += heat/sharer_heat_capacity
+			temperature = max(temperature + heat/self_heat_capacity, TCMB)
+			sharer_temperature = max(sharer_temperature - heat/sharer_heat_capacity, TCMB)
 			if(sharer)
 				sharer.temperature = sharer_temperature
 	return sharer_temperature


### PR DESCRIPTION
Resolves #31715. This is the only place in `gas_mixture.dm` where temperature could possibly be going from positive to negative - all other modifications of temperature maintain its sign. What's more, it can't be caused by a reaction, since all reactions which modify temperature correctly return `REACTING`, which forces a `TCMB` sanity check in `react()`.