### PR TITLE
closed turfs remove themselves from SSair.high_pressure_delta on change

### DIFF
--- a/code/game/turfs/closed.dm
+++ b/code/game/turfs/closed.dm
@@ -9,6 +9,10 @@
 	. = ..()
 	AddComponent(/datum/component/rad_insulation, RAD_MEDIUM_INSULATION)
 
+/turf/closed/ChangeTurf()
+	. = ..()
+	SSair.high_pressure_delta -= src
+
 /turf/closed/get_smooth_underlay_icon(mutable_appearance/underlay_appearance, turf/asking_turf, adjacency_dir)
 	return FALSE
 


### PR DESCRIPTION
Fixes #17386. Caused by an open turf which has yet to process its spacewind changing into a closed turf, whether by wall construction or whatever.