### PR TITLE
Removes a misleading message when handling full stacks of sheets.

### DIFF
--- a/code/game/objects/items/stacks/stack.dm
+++ b/code/game/objects/items/stacks/stack.dm
@@ -297,7 +297,7 @@
 
 
 /obj/item/stack/attackby(obj/item/W, mob/user, params)
-	if(istype(W, merge_type))
+	if(istype(W, merge_type) && amount < max_amount)
 		var/obj/item/stack/S = W
 		merge(S)
 		to_chat(user, "<span class='notice'>Your [S.name] stack now contains [S.get_amount()] [S.singular_name]\s.</span>")


### PR DESCRIPTION
Fixes #30055

kinda. It's not really a bug, you can pick up sheets as normal, just trying to pick them up with a hand containing a full stack of sheets would give you a confusing message saying your stack now contains [max amount] of sheets, leading you to believe something happened or was supposed to happen.

[Changelogs]: 

:cl: Naksu
spellcheck: Removed a misleading message when handling full stacks of sheets.
/:cl:
