### PR TITLE
Removes hardcoded "full bottle" icons from several pre-filled reagent bottles

### DIFF
--- a/code/modules/hydroponics/hydroitemdefines.dm
+++ b/code/modules/hydroponics/hydroitemdefines.dm
@@ -158,7 +158,6 @@
 /obj/item/reagent_containers/glass/bottle/nutrient
 	name = "bottle of nutrient"
 	icon = 'icons/obj/chemical.dmi'
-	icon_state = "bottle16"
 	volume = 50
 	w_class = WEIGHT_CLASS_TINY
 	amount_per_transfer_from_this = 10
@@ -174,7 +173,6 @@
 	name = "bottle of E-Z-Nutrient"
 	desc = "Contains a fertilizer that causes mild mutations with each harvest."
 	icon = 'icons/obj/chemical.dmi'
-	icon_state = "bottle16"
 
 /obj/item/reagent_containers/glass/bottle/nutrient/ez/Initialize()
 	. = ..()
@@ -184,7 +182,6 @@
 	name = "bottle of Left 4 Zed"
 	desc = "Contains a fertilizer that limits plant yields to no more than one and causes significant mutations in plants."
 	icon = 'icons/obj/chemical.dmi'
-	icon_state = "bottle18"
 
 /obj/item/reagent_containers/glass/bottle/nutrient/l4z/Initialize()
 	. = ..()
@@ -194,7 +191,6 @@
 	name = "bottle of Robust Harvest"
 	desc = "Contains a fertilizer that increases the yield of a plant by 30% while causing no mutations."
 	icon = 'icons/obj/chemical.dmi'
-	icon_state = "bottle15"
 
 /obj/item/reagent_containers/glass/bottle/nutrient/rh/Initialize()
 	. = ..()
@@ -203,12 +199,10 @@
 /obj/item/reagent_containers/glass/bottle/nutrient/empty
 	name = "bottle"
 	icon = 'icons/obj/chemical.dmi'
-	icon_state = "bottle16"
 
 /obj/item/reagent_containers/glass/bottle/killer
 	name = "bottle"
 	icon = 'icons/obj/chemical.dmi'
-	icon_state = "bottle16"
 	volume = 50
 	w_class = WEIGHT_CLASS_TINY
 	amount_per_transfer_from_this = 10
@@ -218,7 +212,6 @@
 	name = "bottle of weed killer"
 	desc = "Contains a herbicide."
 	icon = 'icons/obj/chemical.dmi'
-	icon_state = "bottle19"
 
 /obj/item/reagent_containers/glass/bottle/killer/weedkiller/Initialize()
 	. = ..()
@@ -228,7 +221,6 @@
 	name = "bottle of pest spray"
 	desc = "Contains a pesticide."
 	icon = 'icons/obj/chemical.dmi'
-	icon_state = "bottle20"
 
 /obj/item/reagent_containers/glass/bottle/killer/pestkiller/Initialize()
 	. = ..()

--- a/code/modules/reagents/reagent_containers/bottle.dm
+++ b/code/modules/reagents/reagent_containers/bottle.dm
@@ -43,32 +43,27 @@
 /obj/item/reagent_containers/glass/bottle/epinephrine
 	name = "epinephrine bottle"
 	desc = "A small bottle. Contains epinephrine - used to stabilize patients."
-	icon_state = "bottle16"
 	list_reagents = list("epinephrine" = 30)
 
 /obj/item/reagent_containers/glass/bottle/toxin
 	name = "toxin bottle"
 	desc = "A small bottle of toxins. Do not drink, it is poisonous."
-	icon_state = "bottle12"
 	list_reagents = list("toxin" = 30)
 
 /obj/item/reagent_containers/glass/bottle/cyanide
 	name = "cyanide bottle"
 	desc = "A small bottle of cyanide. Bitter almonds?"
-	icon_state = "bottle12"
 	list_reagents = list("cyanide" = 30)
 
 /obj/item/reagent_containers/glass/bottle/spewium
 	name = "spewium bottle"
 	desc = "A small bottle of spewium."
-	icon_state = "bottle12"
 	list_reagents = list("spewium" = 30)
 
 /obj/item/reagent_containers/glass/bottle/morphine
 	name = "morphine bottle"
 	desc = "A small bottle of morphine."
 	icon = 'icons/obj/chemical.dmi'
-	icon_state = "bottle20"
 	list_reagents = list("morphine" = 30)
 
 /obj/item/reagent_containers/glass/bottle/chloralhydrate
@@ -80,49 +75,41 @@
 /obj/item/reagent_containers/glass/bottle/charcoal
 	name = "antitoxin bottle"
 	desc = "A small bottle of charcoal."
-	icon_state = "bottle17"
 	list_reagents = list("charcoal" = 30)
 
 /obj/item/reagent_containers/glass/bottle/mutagen
 	name = "unstable mutagen bottle"
 	desc = "A small bottle of unstable mutagen. Randomly changes the DNA structure of whoever comes in contact."
-	icon_state = "bottle20"
 	list_reagents = list("mutagen" = 30)
 
 /obj/item/reagent_containers/glass/bottle/plasma
 	name = "liquid plasma bottle"
 	desc = "A small bottle of liquid plasma. Extremely toxic and reacts with micro-organisms inside blood."
-	icon_state = "bottle8"
 	list_reagents = list("plasma" = 30)
 
 /obj/item/reagent_containers/glass/bottle/synaptizine
 	name = "synaptizine bottle"
 	desc = "A small bottle of synaptizine."
-	icon_state = "bottle20"
 	list_reagents = list("synaptizine" = 30)
 
 /obj/item/reagent_containers/glass/bottle/formaldehyde
 	name = "formaldehyde bottle"
 	desc = "A small bottle of formaldehyde."
-	icon_state = "bottle20"
 	list_reagents = list("formaldehyde" = 30)
 
 /obj/item/reagent_containers/glass/bottle/ammonia
 	name = "ammonia bottle"
 	desc = "A small bottle of ammonia."
-	icon_state = "bottle20"
 	list_reagents = list("ammonia" = 30)
 
 /obj/item/reagent_containers/glass/bottle/diethylamine
 	name = "diethylamine bottle"
 	desc = "A small bottle of diethylamine."
-	icon_state = "bottle17"
 	list_reagents = list("diethylamine" = 30)
 
 /obj/item/reagent_containers/glass/bottle/facid
 	name = "Fluorosulfuric Acid Bottle"
 	desc = "A small bottle. Contains a small amount of fluorosulfuric acid."
-	icon_state = "bottle17"
 	list_reagents = list("facid" = 30)
 
 /obj/item/reagent_containers/glass/bottle/adminordrazine
@@ -135,20 +122,17 @@
 /obj/item/reagent_containers/glass/bottle/capsaicin
 	name = "Capsaicin Bottle"
 	desc = "A small bottle. Contains hot sauce."
-	icon_state = "bottle3"
 	list_reagents = list("capsaicin" = 30)
 
 /obj/item/reagent_containers/glass/bottle/frostoil
 	name = "Frost Oil Bottle"
 	desc = "A small bottle. Contains cold sauce."
-	icon_state = "bottle17"
 	list_reagents = list("frostoil" = 30)
 
 /obj/item/reagent_containers/glass/bottle/traitor
 	name = "syndicate bottle"
 	desc = "A small bottle. Contains a random nasty chemical."
 	icon = 'icons/obj/chemical.dmi'
-	icon_state = "bottle16"
 	var/extra_reagent = null
 
 /obj/item/reagent_containers/glass/bottle/traitor/Initialize()
@@ -159,85 +143,71 @@
 /obj/item/reagent_containers/glass/bottle/polonium
 	name = "polonium bottle"
 	desc = "A small bottle. Contains Polonium."
-	icon_state = "bottle16"
 	list_reagents = list("polonium" = 30)
 
 /obj/item/reagent_containers/glass/bottle/magillitis
 	name = "magillitis bottle"
 	desc = "A small bottle. Contains a serum known only as 'magillitis'."
-	icon_state = "bottle16"
 	list_reagents = list("magillitis" = 5)
 
 /obj/item/reagent_containers/glass/bottle/venom
 	name = "venom bottle"
 	desc = "A small bottle. Contains Venom."
-	icon_state = "bottle16"
 	list_reagents = list("venom" = 30)
 
 /obj/item/reagent_containers/glass/bottle/neurotoxin2
 	name = "neurotoxin bottle"
 	desc = "A small bottle. Contains Neurotoxin."
-	icon_state = "bottle16"
 	list_reagents = list("neurotoxin2" = 30)
 
 /obj/item/reagent_containers/glass/bottle/formaldehyde
 	name = "formaldehyde bottle"
 	desc = "A small bottle. Contains Formaldehyde."
-	icon_state = "bottle16"
 	list_reagents = list("formaldehyde" = 30)
 
 /obj/item/reagent_containers/glass/bottle/initropidril
 	name = "initropidril bottle"
 	desc = "A small bottle. Contains initropidril."
-	icon_state = "bottle16"
 	list_reagents = list("initropidril" = 30)
 
 /obj/item/reagent_containers/glass/bottle/pancuronium
 	name = "pancuronium bottle"
 	desc = "A small bottle. Contains pancuronium."
-	icon_state = "bottle16"
 	list_reagents = list("pancuronium" = 30)
 
 /obj/item/reagent_containers/glass/bottle/sodium_thiopental
 	name = "sodium thiopental bottle"
 	desc = "A small bottle. Contains sodium thiopental."
-	icon_state = "bottle16"
 	list_reagents = list("sodium_thiopental" = 30)
 
 /obj/item/reagent_containers/glass/bottle/coniine
 	name = "coniine bottle"
 	desc = "A small bottle. Contains coniine."
-	icon_state = "bottle16"
 	list_reagents = list("coniine" = 30)
 
 /obj/item/reagent_containers/glass/bottle/curare
 	name = "curare bottle"
 	desc = "A small bottle. Contains curare."
-	icon_state = "bottle16"
 	list_reagents = list("curare" = 30)
 
 /obj/item/reagent_containers/glass/bottle/amanitin
 	name = "amanitin bottle"
 	desc = "A small bottle. Contains amanitin."
-	icon_state = "bottle16"
 	list_reagents = list("amanitin" = 30)
 
 /obj/item/reagent_containers/glass/bottle/histamine
 	name = "histamine bottle"
 	desc = "A small bottle. Contains Histamine."
-	icon_state = "bottle16"
 	list_reagents = list("histamine" = 30)
 
 /obj/item/reagent_containers/glass/bottle/diphenhydramine
 	name = "antihistamine bottle"
 	desc = "A small bottle of diphenhydramine."
-	icon_state = "bottle20"
 	list_reagents = list("diphenhydramine" = 30)
 
 /obj/item/reagent_containers/glass/bottle/potass_iodide
 	name = "anti-radiation bottle"
 	desc = "A small bottle of potassium iodide."
-	icon_state = "bottle11"
 	list_reagents = list("potass_iodide" = 30)
 
 /obj/item/reagent_containers/glass/bottle/salglu_solution
@@ -249,68 +219,57 @@
 /obj/item/reagent_containers/glass/bottle/atropine
 	name = "atropine bottle"
 	desc = "A small bottle of atropine."
-	icon_state = "bottle12"
 	list_reagents = list("atropine" = 30)
 
 /obj/item/reagent_containers/glass/bottle/romerol
 	name = "romerol bottle"
 	desc = "A small bottle of Romerol. The REAL zombie powder."
-	icon_state = "bottle12"
 	list_reagents = list("romerol" = 30)
 
 /obj/item/reagent_containers/glass/bottle/flu_virion
 	name = "Flu virion culture bottle"
 	desc = "A small bottle. Contains H13N1 flu virion culture in synthblood medium."
-	icon_state = "bottle3"
 	spawned_disease = /datum/disease/advance/flu
 
 /obj/item/reagent_containers/glass/bottle/epiglottis_virion
 	name = "Epiglottis virion culture bottle"
 	desc = "A small bottle. Contains Epiglottis virion culture in synthblood medium."
-	icon_state = "bottle3"
 	spawned_disease = /datum/disease/advance/voice_change
 
 /obj/item/reagent_containers/glass/bottle/liver_enhance_virion
 	name = "Liver enhancement virion culture bottle"
 	desc = "A small bottle. Contains liver enhancement virion culture in synthblood medium."
-	icon_state = "bottle3"
 	spawned_disease = /datum/disease/advance/heal
 
 /obj/item/reagent_containers/glass/bottle/hallucigen_virion
 	name = "Hallucigen virion culture bottle"
 	desc = "A small bottle. Contains hallucigen virion culture in synthblood medium."
-	icon_state = "bottle3"
 	spawned_disease = /datum/disease/advance/hallucigen
 
 /obj/item/reagent_containers/glass/bottle/pierrot_throat
 	name = "Pierrot's Throat culture bottle"
 	desc = "A small bottle. Contains H0NI<42 virion culture in synthblood medium."
-	icon_state = "bottle3"
 	spawned_disease = /datum/disease/pierrot_throat
 
 /obj/item/reagent_containers/glass/bottle/cold
 	name = "Rhinovirus culture bottle"
 	desc = "A small bottle. Contains XY-rhinovirus culture in synthblood medium."
-	icon_state = "bottle3"
 	spawned_disease = /datum/disease/advance/cold
 
 /obj/item/reagent_containers/glass/bottle/retrovirus
 	name = "Retrovirus culture bottle"
 	desc = "A small bottle. Contains a retrovirus culture in a synthblood medium."
-	icon_state = "bottle3"
 	spawned_disease = /datum/disease/dna_retrovirus
 
 /obj/item/reagent_containers/glass/bottle/gbs
 	name = "GBS culture bottle"
 	desc = "A small bottle. Contains Gravitokinetic Bipotential SADS+ culture in synthblood medium."//Or simply - General BullShit
-	icon_state = "bottle3"
 	amount_per_transfer_from_this = 5
 	spawned_disease = /datum/disease/gbs
 
 /obj/item/reagent_containers/glass/bottle/fake_gbs
 	name = "GBS culture bottle"
 	desc = "A small bottle. Contains Gravitokinetic Bipotential SADS- culture in synthblood medium."//Or simply - General BullShit
-	icon_state = "bottle3"
 	spawned_disease = /datum/disease/fake_gbs
 
 /obj/item/reagent_containers/glass/bottle/brainrot
@@ -322,41 +281,34 @@
 /obj/item/reagent_containers/glass/bottle/magnitis
 	name = "Magnitis culture bottle"
 	desc = "A small bottle. Contains a small dosage of Fukkos Miracos."
-	icon_state = "bottle3"
 	spawned_disease = /datum/disease/magnitis
 
 /obj/item/reagent_containers/glass/bottle/wizarditis
 	name = "Wizarditis culture bottle"
 	desc = "A small bottle. Contains a sample of Rincewindus Vulgaris."
-	icon_state = "bottle3"
 	spawned_disease = /datum/disease/wizarditis
 
 /obj/item/reagent_containers/glass/bottle/anxiety
 	name = "Severe Anxiety culture bottle"
 	desc = "A small bottle. Contains a sample of Lepidopticides."
-	icon_state = "bottle3"
 	spawned_disease = /datum/disease/anxiety
 
 /obj/item/reagent_containers/glass/bottle/beesease
 	name = "Beesease culture bottle"
 	desc = "A small bottle. Contains a sample of invasive Apidae."
-	icon_state = "bottle3"
 	spawned_disease = /datum/disease/beesease
 
 /obj/item/reagent_containers/glass/bottle/fluspanish
 	name = "Spanish flu culture bottle"
 	desc = "A small bottle. Contains a sample of Inquisitius."
-	icon_state = "bottle3"
 	spawned_disease = /datum/disease/fluspanish
 
 /obj/item/reagent_containers/glass/bottle/tuberculosis
 	name = "Fungal Tuberculosis culture bottle"
 	desc = "A small bottle. Contains a sample of Fungal Tubercle bacillus."
-	icon_state = "bottle3"
 	spawned_disease = /datum/disease/tuberculosis
 
 /obj/item/reagent_containers/glass/bottle/tuberculosiscure
 	name = "BVAK bottle"
 	desc = "A small bottle containing Bio Virus Antidote Kit."
-	icon_state = "bottle5"
 	list_reagents = list("atropine" = 5, "epinephrine" = 5, "salbutamol" = 10, "spaceacillin" = 10)


### PR DESCRIPTION
This makes pre-filled bottles like botany's e-z nutrient bottle actually show how much stuff is inside, and also makes the color of the contents match up with what you would get if you put the same stuff inside an empty bottle. The latter is mostly a medbay issue.

[Changelogs]: 

:cl: Naksu
fix: Pre-filled glass bottles (uplink, medbay, botany) will now give visual feedback about how much stuff is left inside, and the color of contents will match an empty bottle being filled with the same reagent.
/:cl:

[why]: 
Dealing with empty bottles that look full is annoying as hell.
