### PR TITLE
Radiation makes you vomit blood and some more balance changes

### DIFF
--- a/_maps/map_files/PubbyStation/PubbyStation.dmm
+++ b/_maps/map_files/PubbyStation/PubbyStation.dmm
@@ -46291,11 +46291,6 @@
 /area/engine/engineering)
 "car" = (
 /obj/structure/cable/yellow{
-	icon_state = "1-4";
-	d1 = 1;
-	d2 = 4
-	},
-/obj/structure/cable/yellow{
 	d1 = 1;
 	d2 = 8;
 	icon_state = "1-8"
@@ -47261,16 +47256,6 @@
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "ccV" = (
-/obj/structure/cable/yellow{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/structure/cable/yellow{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
-	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
@@ -47282,22 +47267,12 @@
 	id = "Singularity";
 	name = "radiation shutters"
 	},
-/obj/structure/cable/yellow{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
 /obj/effect/turf_decal/bot{
 	dir = 2
 	},
 /turf/open/floor/plasteel/black,
 /area/engine/engineering)
 "ccX" = (
-/obj/structure/cable/yellow{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
 /obj/structure/cable/yellow{
 	d1 = 2;
 	d2 = 4;
@@ -47326,11 +47301,6 @@
 /turf/open/floor/plating,
 /area/engine/engineering)
 "cda" = (
-/obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
-	},
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/plating,
 /area/engine/engineering)
@@ -47346,16 +47316,6 @@
 /turf/open/floor/plating,
 /area/engine/engineering)
 "cdc" = (
-/obj/structure/cable/yellow{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
-/obj/structure/cable/yellow{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
@@ -47599,19 +47559,9 @@
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "cdQ" = (
-/obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
 /turf/open/floor/plasteel/yellow/side,
 /area/engine/engineering)
 "cdR" = (
-/obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
 /obj/machinery/button/door{
 	id = "Singularity";
 	name = "Shutters Control";
@@ -47666,11 +47616,6 @@
 /turf/open/floor/plating,
 /area/engine/engineering)
 "cdX" = (
-/obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
 /obj/machinery/button/door{
 	id = "Singularity";
 	name = "Shutters Control";
@@ -47850,14 +47795,10 @@
 	id = "Singularity";
 	name = "radiation shutters"
 	},
-/obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
+/obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/engine/engineering)
 "ceu" = (
@@ -48053,9 +47994,6 @@
 /turf/open/floor/plating,
 /area/engine/engineering)
 "ceY" = (
-/obj/machinery/power/rad_collector/anchored,
-/obj/item/tank/internals/plasma,
-/obj/structure/cable/yellow,
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
@@ -48872,6 +48810,9 @@
 	icon_state = "0-8"
 	},
 /obj/machinery/power/tesla_coil,
+/obj/structure/window/plasma/reinforced{
+	dir = 4
+	},
 /turf/open/floor/plating/airless,
 /area/engine/engineering)
 "chy" = (
@@ -48884,6 +48825,9 @@
 	d2 = 4
 	},
 /obj/machinery/power/tesla_coil,
+/obj/structure/window/plasma/reinforced{
+	dir = 8
+	},
 /turf/open/floor/plating/airless,
 /area/engine/engineering)
 "chA" = (
@@ -49000,7 +48944,15 @@
 /turf/open/floor/plating/airless,
 /area/engine/engineering)
 "chQ" = (
-/turf/open/space/basic,
+/obj/structure/window/plasma/reinforced{
+	dir = 4
+	},
+/obj/machinery/power/rad_collector/anchored,
+/obj/structure/cable/yellow{
+	d2 = 8;
+	icon_state = "0-8"
+	},
+/turf/open/floor/plating/airless,
 /area/engine/engineering)
 "chR" = (
 /obj/structure/cable{
@@ -54065,6 +54017,78 @@
 /obj/machinery/smoke_machine,
 /turf/open/floor/plasteel/white,
 /area/medical/chemistry)
+"YXI" = (
+/obj/machinery/door/firedoor,
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "Singularity";
+	name = "radiation shutters"
+	},
+/obj/effect/turf_decal/bot{
+	dir = 2
+	},
+/turf/open/floor/plasteel/black,
+/area/engine/engineering)
+"YXJ" = (
+/obj/machinery/power/rad_collector/anchored,
+/turf/open/floor/plating,
+/area/engine/engineering)
+"YXK" = (
+/obj/machinery/power/rad_collector/anchored,
+/turf/open/floor/plating,
+/area/engine/engineering)
+"YXL" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/engine/engineering)
+"YXM" = (
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "1-4";
+	d1 = 1;
+	d2 = 4
+	},
+/obj/item/tank/internals/plasma,
+/turf/open/floor/plating/airless,
+/area/engine/engineering)
+"YXN" = (
+/obj/structure/window/plasma/reinforced{
+	dir = 8
+	},
+/obj/machinery/power/rad_collector/anchored,
+/obj/structure/cable/yellow{
+	icon_state = "0-4";
+	d2 = 4
+	},
+/turf/open/floor/plating/airless,
+/area/engine/engineering)
+"YXO" = (
+/obj/structure/window/plasma/reinforced{
+	dir = 8
+	},
+/obj/machinery/power/rad_collector/anchored,
+/obj/structure/cable/yellow{
+	icon_state = "0-4";
+	d2 = 4
+	},
+/turf/open/floor/plating/airless,
+/area/engine/engineering)
+"YXP" = (
+/obj/structure/window/plasma/reinforced{
+	dir = 8
+	},
+/obj/machinery/power/rad_collector/anchored,
+/obj/structure/cable/yellow{
+	icon_state = "0-4";
+	d2 = 4
+	},
+/turf/open/floor/plating/airless,
+/area/engine/engineering)
 
 (1,1,1) = {"
 aaa
@@ -81733,7 +81757,7 @@ bOG
 bva
 bDi
 bXk
-cbX
+YXJ
 cbX
 cdK
 bXk
@@ -81990,7 +82014,7 @@ bOG
 bTE
 cae
 bXk
-cbX
+YXK
 cbX
 cdK
 bXk
@@ -83790,20 +83814,20 @@ bZC
 cal
 cbh
 cam
-ccT
+cam
 cdQ
 cet
 ceY
-cfa
+cbX
 cfU
 cgu
 cgU
 chw
-cgU
+YXM
 chw
-cgU
 chw
-cgU
+chw
+chw
 cjs
 cfV
 cfV
@@ -84047,18 +84071,18 @@ bZA
 cam
 cam
 cam
-ccU
+cam
 cdQ
 cet
-ceZ
-cfa
+ceY
+cbX
 cfV
 cgv
 cfV
 chx
 chQ
 chx
-cfV
+chQ
 chx
 chQ
 chx
@@ -84307,8 +84331,8 @@ ccc
 ccV
 cdR
 cet
-ceZ
-cfa
+ceY
+cbX
 cfU
 cgv
 cgV
@@ -85586,9 +85610,9 @@ bXo
 bYi
 bYV
 bZA
-cas
-cbk
-cce
+cdN
+YXI
+YXL
 cda
 cdV
 cex
@@ -85846,7 +85870,7 @@ bZF
 cat
 bXk
 ccg
-cdb
+cey
 cdW
 cey
 cey
@@ -86363,8 +86387,8 @@ cch
 cdc
 cdX
 cet
-ceZ
-cfa
+ceY
+cbX
 cfU
 cgv
 cgV
@@ -86617,20 +86641,20 @@ bZA
 cam
 cam
 cam
-cdd
+cam
 cdQ
 cet
-ceZ
-cfa
+ceY
+cbX
 cfV
 cgv
 cfV
 chz
-chQ
+YXN
 chz
-cfV
+YXO
 chz
-chQ
+YXP
 chz
 cfV
 cfV
@@ -86874,20 +86898,20 @@ bZC
 cal
 cbm
 cci
-cde
+cam
 cdQ
 cet
-ceZ
-cfa
+ceY
+cbX
 cfU
 cgx
 cgU
 chA
-cgU
 chA
-cgU
 chA
-cgU
+chA
+chA
+chA
 cjt
 cfV
 cfV

--- a/code/__DEFINES/radiation.dm
+++ b/code/__DEFINES/radiation.dm
@@ -29,8 +29,6 @@ Ask ninjanomnom if they're around
 #define RAD_MOB_MUTATE 1000							// How much stored radiation to check for mutation
 #define RAD_MOB_HAIRLOSS 500						// How much stored radiation to check for hair loss
 
-#define RAD_KNOCKDOWN_TIME 200						// How much knockdown to apply
-
 #define RAD_NO_INSULATION 1.0						// For things that shouldn't become irradiated for whatever reason
 #define RAD_VERY_LIGHT_INSULATION 0.9				// What girders have
 #define RAD_LIGHT_INSULATION 0.8

--- a/code/__DEFINES/radiation.dm
+++ b/code/__DEFINES/radiation.dm
@@ -18,10 +18,15 @@ Ask ninjanomnom if they're around
 #define RAD_TOX_COEFFICIENT 0.05					// Toxin damage per tick coefficient
 
 #define RAD_MOB_SAFE 300							// How much stored radiation in a mob with no ill effects
-#define RAD_MOB_KNOCKDOWN 1500						// How much stored radiation to start stunning
-// If (mutate*2<knockdown) then monkeys will sometimes turn into gorillas before being knocked down
-// otherwise they only turn into gorillas *after* being knocked down
-#define RAD_MOB_MUTATE 800							// How much stored radiation to check for mutation
+
+#define RAD_MOB_KNOCKDOWN 2000						// How much stored radiation to check for stunning
+#define RAD_MOB_KNOCKDOWN_PROB 1					// Chance of knockdown per tick when over threshold
+#define RAD_MOB_KNOCKDOWN_AMOUNT 3					// Amount of knockdown when it occurs
+
+#define RAD_MOB_VOMIT 1500							// The amount of radiation to check for vomitting
+#define RAD_MOB_VOMIT_PROB 1						// Chance per tick of vomitting
+
+#define RAD_MOB_MUTATE 1000							// How much stored radiation to check for mutation
 #define RAD_MOB_HAIRLOSS 500						// How much stored radiation to check for hair loss
 
 #define RAD_KNOCKDOWN_TIME 200						// How much knockdown to apply

--- a/code/datums/radiation_wave.dm
+++ b/code/datums/radiation_wave.dm
@@ -89,7 +89,7 @@
 			continue
 		thing.rad_act(strength)
 
-		var/static/list/blacklisted = typecacheof(list(/turf, /obj/structure/cable, /obj/machinery/atmospherics))
+		var/static/list/blacklisted = typecacheof(list(/turf, /mob, /obj/structure/cable, /obj/machinery/atmospherics))
 		if(!can_contaminate || blacklisted[thing.type])
 			continue
 		if(prob((strength-RAD_MINIMUM_CONTAMINATION) * RAD_CONTAMINATION_CHANCE_COEFFICIENT * min(1/(steps*range_modifier), 1))) // Only stronk rads get to have little baby rads

--- a/code/game/machinery/computer/dna_console.dm
+++ b/code/game/machinery/computer/dna_console.dm
@@ -9,7 +9,7 @@
 #define RADIATION_DURATION_MAX 30
 #define RADIATION_ACCURACY_MULTIPLIER 3			//larger is less accurate
 
-#define RADIATION_IRRADIATION_MULTIPLIER 10		//multiplier for how much radiation a test subject recieves
+#define RADIATION_IRRADIATION_MULTIPLIER 1		//multiplier for how much radiation a test subject recieves
 
 #define SCANNER_ACTION_SE 1
 #define SCANNER_ACTION_UI 2

--- a/code/modules/mob/living/carbon/human/species.dm
+++ b/code/modules/mob/living/carbon/human/species.dm
@@ -984,7 +984,7 @@
 	if(radiation > RAD_MOB_KNOCKDOWN && prob(RAD_MOB_KNOCKDOWN_PROB))
 		if(!H.IsKnockdown())
 			H.emote("collapse")
-		H.Knockdown(RAD_KNOCKDOWN_TIME)
+		H.Knockdown(RAD_MOB_KNOCKDOWN_AMOUNT)
 		to_chat(H, "<span class='danger'>You feel weak.</span>")
 
 	if(radiation > RAD_MOB_VOMIT && prob(RAD_MOB_VOMIT_PROB))

--- a/code/modules/mob/living/carbon/human/species.dm
+++ b/code/modules/mob/living/carbon/human/species.dm
@@ -981,11 +981,14 @@
 		radiation = 0
 		return TRUE
 
-	if(radiation > RAD_MOB_KNOCKDOWN)
+	if(radiation > RAD_MOB_KNOCKDOWN && prob(RAD_MOB_KNOCKDOWN_PROB))
 		if(!H.IsKnockdown())
 			H.emote("collapse")
 		H.Knockdown(RAD_KNOCKDOWN_TIME)
 		to_chat(H, "<span class='danger'>You feel weak.</span>")
+
+	if(radiation > RAD_MOB_VOMIT && prob(RAD_MOB_VOMIT_PROB))
+		H.vomit(10, TRUE)
 	
 	if(radiation > RAD_MOB_MUTATE)
 		if(prob(1))
@@ -995,10 +998,9 @@
 			H.domutcheck()
 
 	if(radiation > RAD_MOB_HAIRLOSS)
-		if(prob(15))
-			if(!( H.hair_style == "Shaved") || !(H.hair_style == "Bald") || (HAIR in species_traits))
-				to_chat(H, "<span class='danger'>Your hair starts to fall out in clumps...</span>")
-				addtimer(CALLBACK(src, .proc/go_bald, H), 50)
+		if(prob(15) && !(H.hair_style == "Bald") && (HAIR in species_traits))
+			to_chat(H, "<span class='danger'>Your hair starts to fall out in clumps...</span>")
+			addtimer(CALLBACK(src, .proc/go_bald, H), 50)
 
 /datum/species/proc/go_bald(mob/living/carbon/human/H)
 	if(QDELETED(H))	//may be called from a timer

--- a/code/modules/mob/living/carbon/monkey/life.dm
+++ b/code/modules/mob/living/carbon/monkey/life.dm
@@ -24,10 +24,10 @@
 
 /mob/living/carbon/monkey/handle_mutations_and_radiation()
 	if(radiation)
-		if(radiation > RAD_MOB_KNOCKDOWN)
+		if(radiation > RAD_MOB_KNOCKDOWN && prob(RAD_MOB_KNOCKDOWN_PROB))
 			if(!IsKnockdown())
 				emote("collapse")
-			Knockdown(200)
+			Knockdown(RAD_MOB_KNOCKDOWN_AMOUNT)
 			to_chat(src, "<span class='danger'>You feel weak.</span>")
 		if(radiation > RAD_MOB_MUTATE)
 			if(prob(1))
@@ -39,6 +39,8 @@
 				if(radiation > RAD_MOB_MUTATE * 2 && prob(50))
 					gorillize()
 					return
+		if(radiation > RAD_MOB_VOMIT && prob(RAD_MOB_VOMIT_PROB))
+			vomit(10, TRUE)
 	return ..()
 
 /mob/living/carbon/monkey/handle_breath_temperature(datum/gas_mixture/breath)

--- a/code/modules/power/singularity/singularity.dm
+++ b/code/modules/power/singularity/singularity.dm
@@ -21,7 +21,7 @@
 	var/move_self = 1 //Do we move on our own?
 	var/grav_pull = 4 //How many tiles out do we pull?
 	var/consume_range = 0 //How many tiles out do we eat
-	var/event_chance = 15 //Prob for event each tick
+	var/event_chance = 10 //Prob for event each tick
 	var/target = null //its target. moves towards the target if it has one
 	var/last_failed_movement = 0//Will not move in the same dir if it couldnt before, will help with the getting stuck on fields thing
 	var/last_warning
@@ -114,7 +114,7 @@
 /obj/singularity/process()
 	if(current_size >= STAGE_TWO)
 		move()
-		radiation_pulse(src, energy, 0.5)
+		radiation_pulse(src, min(5000, (energy*3)+1000), RAD_DISTANCE_COEFFICIENT*0.5)
 		if(prob(event_chance))//Chance for it to run a special event TODO:Come up with one or two more that fit
 			event()
 	eat()
@@ -377,28 +377,19 @@
 
 
 /obj/singularity/proc/event()
-	var/numb = pick(1,2,3,4,5,6)
+	var/numb = rand(1,4)
 	switch(numb)
 		if(1)//EMP
 			emp_area()
-		if(2,3)//tox damage all carbon mobs in area
-			toxmob()
-		if(4)//Stun mobs who lack optic scanners
+		if(2)//Stun mobs who lack optic scanners
 			mezzer()
-		if(5,6) //Sets all nearby mobs on fire
+		if(3,4) //Sets all nearby mobs on fire
 			if(current_size < STAGE_SIX)
 				return 0
 			combust_mobs()
 		else
 			return 0
 	return 1
-
-
-/obj/singularity/proc/toxmob()
-	var/radiation = 15
-	if (energy>200)
-		radiation += round((energy-150)/10,1)
-	radiation_pulse(src, radiation)
 
 
 /obj/singularity/proc/combust_mobs()

--- a/code/modules/reagents/chemistry/reagents/medicine_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/medicine_reagents.dm
@@ -466,7 +466,7 @@
 	metabolization_rate = 0.5 * REAGENTS_METABOLISM
 
 /datum/reagent/medicine/pen_acid/on_mob_life(mob/living/M)
-	M.radiation -= min(M.radiation, log(M.radiation)*10)
+	M.radiation -= min(M.radiation-RAD_MOB_SAFE, 0)/100
 	M.adjustToxLoss(-2*REM, 0)
 	for(var/datum/reagent/R in M.reagents.reagent_list)
 		if(R != src)


### PR DESCRIPTION
:cl: ninjanomnom
add: You can vomit blood at high enough radiation.
balance: Radiation knockdown is far far shorter.
balance: Genetics modification is less harmful but still, upgrade your machines.
balance: Pentetic acid is useless for low amounts of radiation but indispensable for high amounts now.
balance: Singularity radiation has been normalized and Pubby engine has been remapped.
fix: No more hair loss spam
fix: Mob rad contamination has been disabled for now. Regular contamination is still a thing.
/:cl:

fixes #31729 
fixes #31724
fixes #31804
fixes #31797 
fixes #31862
fixes a runtime involving pen_acid's use of log()