### PR TITLE
Stops manned turrets from firing when the user unbuckles themselves from the turret

### DIFF
--- a/code/game/objects/structures/manned_turret.dm
+++ b/code/game/objects/structures/manned_turret.dm
@@ -68,14 +68,15 @@
 	START_PROCESSING(SSfastprocess, src)
 
 /obj/machinery/manned_turret/process()
-	if(!LAZYLEN(buckled_mobs))
+	if (!update_positioning())
 		return PROCESS_KILL
-	update_positioning()
 
 /obj/machinery/manned_turret/proc/update_positioning()
+	if (!LAZYLEN(buckled_mobs))
+		return FALSE
 	var/mob/living/controller = buckled_mobs[1]
 	if(!istype(controller))
-		return
+		return FALSE
 	var/client/C = controller.client
 	if(C)
 		var/atom/A = C.mouseObject
@@ -143,7 +144,7 @@
 		addtimer(CALLBACK(src, /obj/machinery/manned_turret/.proc/fire_helper, user), i*rate_of_fire)
 
 /obj/machinery/manned_turret/proc/fire_helper(mob/user)
-	if(user.incapacitated())
+	if(user.incapacitated() || !(user in buckled_mobs))
 		return
 	update_positioning()						//REFRESH MOUSE TRACKING!!
 	var/turf/targets_from = get_turf(src)

--- a/code/modules/power/power.dm
+++ b/code/modules/power/power.dm
@@ -278,7 +278,7 @@
 //dist_check - set to only shock mobs within 1 of source (vendors, airlocks, etc.)
 //No animations will be performed by this proc.
 /proc/electrocute_mob(mob/living/carbon/M, power_source, obj/source, siemens_coeff = 1, dist_check = FALSE)
-	if(ismecha(M.loc))
+	if(!istype(M) || ismecha(M.loc))
 		return 0	//feckin mechs are dumb
 	if(dist_check)
 		if(!in_range(source,M))

--- a/code/modules/power/power.dm
+++ b/code/modules/power/power.dm
@@ -278,7 +278,7 @@
 //dist_check - set to only shock mobs within 1 of source (vendors, airlocks, etc.)
 //No animations will be performed by this proc.
 /proc/electrocute_mob(mob/living/carbon/M, power_source, obj/source, siemens_coeff = 1, dist_check = FALSE)
-	if(!istype(M) || ismecha(M.loc))
+	if(!M || ismecha(M.loc))
 		return 0	//feckin mechs are dumb
 	if(dist_check)
 		if(!in_range(source,M))


### PR DESCRIPTION
Fixes #31718

Also fixes a semi-related runtime when electrocution code attempts to check if a projectile is inside a mech, and the cast to mob/living doesn't quite work.

[Changelogs]: 

:cl: Naksu
fix: Manned turrets stop firing when there's no-one in the turret shooting.
/:cl:

[why]: 
Bugfix