### PR TITLE
Makes player-controlled minebots a target for ocular wardens

### DIFF
--- a/code/game/gamemodes/clock_cult/clock_structures/ocular_warden.dm
+++ b/code/game/gamemodes/clock_cult/clock_structures/ocular_warden.dm
@@ -118,7 +118,7 @@
 			var/mob/living/simple_animal/hostile/H = L
 			if(ismegafauna(H) || (!H.mind && H.AIStatus == AI_OFF))
 				continue
-			if(("ratvar" in H.faction) || ("neutral" in H.faction))
+			if(("ratvar" in H.faction) || (!H.mind && "neutral" in H.faction))
 				continue
 		else if(isrevenant(L))
 			var/mob/living/simple_animal/revenant/R = L
@@ -127,10 +127,15 @@
 		else if(!L.mind)
 			continue
 		. += L
+	var/list/viewcache = list()
 	for(var/N in GLOB.mechas_list)
 		var/obj/mecha/M = N
-		if(get_dist(M, src) <= sight_range && M.occupant && !is_servant_of_ratvar(M.occupant) && (M in view(sight_range, src)))
-			. += M
+		if(get_dist(M, src) <= sight_range && M.occupant && !is_servant_of_ratvar(M.occupant))
+			if(!length(viewcache))
+				for (var/obj/Z in view(sight_range, src))
+					viewcache += Z
+			if (M in viewcache)
+				. += M
 
 /obj/structure/destructible/clockwork/ocular_warden/proc/lose_target()
 	if(!target)

--- a/code/game/gamemodes/clock_cult/clock_structures/ocular_warden.dm
+++ b/code/game/gamemodes/clock_cult/clock_structures/ocular_warden.dm
@@ -116,9 +116,9 @@
 			continue
 		if(ishostile(L))
 			var/mob/living/simple_animal/hostile/H = L
-			if(ismegafauna(H) || (!H.mind && H.AIStatus == AI_OFF))
-				continue
 			if(("ratvar" in H.faction) || (!H.mind && "neutral" in H.faction))
+				continue
+			if(ismegafauna(H) || (!H.mind && H.AIStatus == AI_OFF))
 				continue
 		else if(isrevenant(L))
 			var/mob/living/simple_animal/revenant/R = L


### PR DESCRIPTION
Fixes #31527

Also contains an extremely slight perf increase on ocular wardens' target-acquiring routine. It turned out to be only a couple % in most cases, but I'm not backing out free perf.

[Changelogs]: 

:cl: Naksu
fix: Player-controlled "neutral" mobs such as minebots are now considered valid targets by clock cult's ocular wardens.
/:cl:

[why]: 
Bugfix.
