### PR TITLE
Fixed fancy boxes not showing proper content amount.

### DIFF
--- a/code/game/objects/items/storage/fancy.dm
+++ b/code/game/objects/items/storage/fancy.dm
@@ -29,7 +29,7 @@
 
 /obj/item/storage/fancy/update_icon()
 	if(fancy_open)
-		icon_state = "[icon_type]box[src.contents.len]"
+		icon_state = "[icon_type]box[contents.len]"
 	else
 		icon_state = "[icon_type]box"
 
@@ -37,9 +37,9 @@
 	..()
 	if(fancy_open)
 		if(contents.len == 1)
-			to_chat(user, "There is one [src.icon_type] left.")
+			to_chat(user, "There is one [icon_type] left.")
 		else
-			to_chat(user, "There are [contents.len <= 0 ? "no" : "[src.contents.len]"] [src.icon_type]s left.")
+			to_chat(user, "There are [contents.len <= 0 ? "no" : "[contents.len]"] [icon_type]s left.")
 
 /obj/item/storage/fancy/attack_self(mob/user)
 	fancy_open = !fancy_open

--- a/code/game/objects/items/storage/fancy.dm
+++ b/code/game/objects/items/storage/fancy.dm
@@ -29,8 +29,7 @@
 
 /obj/item/storage/fancy/update_icon(itemremoved = 0)
 	if(fancy_open)
-		var/total_contents = src.contents.len - itemremoved
-		icon_state = "[icon_type]box[total_contents]"
+		icon_state = "[icon_type]box[src.contents.len]"
 	else
 		icon_state = "[icon_type]box"
 

--- a/code/game/objects/items/storage/fancy.dm
+++ b/code/game/objects/items/storage/fancy.dm
@@ -27,7 +27,7 @@
 	for(var/i = 1 to storage_slots)
 		new spawn_type(src)
 
-/obj/item/storage/fancy/update_icon(itemremoved = 0)
+/obj/item/storage/fancy/update_icon()
 	if(fancy_open)
 		icon_state = "[icon_type]box[src.contents.len]"
 	else

--- a/code/game/objects/items/storage/fancy.dm
+++ b/code/game/objects/items/storage/fancy.dm
@@ -57,9 +57,7 @@
 
 /obj/item/storage/fancy/remove_from_storage(obj/item/W, atom/new_location, burn = 0)
 	fancy_open = TRUE
-	. = ..()
-	//Recall update icon  with the fancy item snowflake arg (ugh)
-	update_icon(1)
+	return ..()
 
 /*
  * Donut Box


### PR DESCRIPTION
[Changelogs]: 
:cl: DaxDupont
fix: Fancy boxes(ie: donut boxes) now show the proper content amount in the sprite and no longer go invisible when empty.
/:cl:

Fixes #31762
