### PR TITLE
Add a safety check for usr in airlock shocking

### DIFF
--- a/code/datums/wires/airlock.dm
+++ b/code/datums/wires/airlock.dm
@@ -155,4 +155,5 @@
 			A.lights = mend
 			A.update_icon()
 		if(WIRE_ZAP1, WIRE_ZAP2) // Ouch.
-			A.shock(usr, 50)
+			if(usr)
+				A.shock(usr, 50)


### PR DESCRIPTION
This fixes a runtime caused when usr is null or zero and shock is still
called.

This is a hack and illustrates why use of usr is considered bad practice
