### PR TITLE
Next round of shuttle fixes at the cost of a small piece of my sanity

### DIFF
--- a/code/__DEFINES/shuttles.dm
+++ b/code/__DEFINES/shuttles.dm
@@ -58,6 +58,8 @@
 #define DOCKING_BLOCKED 1
 #define DOCKING_IMMOBILIZED 2
 #define DOCKING_AREA_EMPTY 4
+#define DOCKING_NULL_DESTINATION 8
+#define DOCKING_NULL_SOURCE 16
 
 //Docking turf movements
 #define MOVE_TURF 1

--- a/code/modules/shuttle/navigation_computer.dm
+++ b/code/modules/shuttle/navigation_computer.dm
@@ -127,7 +127,7 @@
 	checkLandingSpot()
 
 /obj/machinery/computer/camera_advanced/shuttle_docker/proc/checkLandingTurf(turf/T)
-	return T && (!blacklisted_turfs || !blacklisted_turfs[T]) && (!space_turfs_only || isspaceturf(T))
+	return T && (!blacklisted_turfs || !blacklisted_turfs[T]) && (!space_turfs_only || isspaceturf(T)) && (T.x > 1 && T.y > 1 && T.x < world.maxx && T.y < world.maxy)
 
 /obj/machinery/computer/camera_advanced/shuttle_docker/proc/generateBlacklistedTurfs()
 	blacklisted_turfs = list()

--- a/code/modules/shuttle/on_move.dm
+++ b/code/modules/shuttle/on_move.dm
@@ -62,6 +62,9 @@ All ShuttleMove procs go here
 	//Source turf changes
 	ChangeTurf(turf_type, baseturf_type, FALSE, TRUE)
 
+	if(rotation)
+		newT.shuttleRotate(rotation) //see shuttle_rotate.dm
+
 	return TRUE
 
 // Called on the new turf after everything has been moved
@@ -162,8 +165,9 @@ All ShuttleMove procs go here
 
 /obj/machinery/camera/beforeShuttleMove(turf/newT, rotation, move_mode)
 	. = ..()
-	GLOB.cameranet.removeCamera(src)
-	. |= MOVE_CONTENTS
+	if(. & MOVE_AREA)
+		. |= MOVE_CONTENTS
+		GLOB.cameranet.removeCamera(src)
 
 /obj/machinery/camera/afterShuttleMove(list/movement_force, shuttle_dir, shuttle_preferred_direction, move_dir)
 	. = ..()
@@ -200,7 +204,8 @@ All ShuttleMove procs go here
 
 /obj/machinery/thruster/beforeShuttleMove(turf/newT, rotation, move_mode)
 	. = ..()
-	. |= MOVE_CONTENTS
+	if(. & MOVE_AREA)
+		. |= MOVE_CONTENTS
 
 /obj/machinery/atmospherics/afterShuttleMove(list/movement_force, shuttle_dir, shuttle_preferred_direction, move_dir)
 	. = ..()
@@ -301,11 +306,13 @@ All ShuttleMove procs go here
 
 /obj/structure/grille/beforeShuttleMove(turf/newT, rotation, move_mode)
 	. = ..()
-	. |= MOVE_CONTENTS
+	if(. & MOVE_AREA)
+		. |= MOVE_CONTENTS
 
 /obj/structure/lattice/beforeShuttleMove(turf/newT, rotation, move_mode)
 	. = ..()
-	. |= MOVE_CONTENTS
+	if(. & MOVE_AREA)
+		. |= MOVE_CONTENTS
 
 /obj/structure/disposalpipe/afterShuttleMove(list/movement_force, shuttle_dir, shuttle_preferred_direction, move_dir)
 	. = ..()
@@ -319,7 +326,8 @@ All ShuttleMove procs go here
 
 /obj/structure/shuttle/beforeShuttleMove(turf/newT, rotation, move_mode)
 	. = ..()
-	. |= MOVE_CONTENTS
+	if(. & MOVE_AREA)
+		. |= MOVE_CONTENTS
 
 
 /************************************Misc move procs************************************/

--- a/code/modules/shuttle/shuttle.dm
+++ b/code/modules/shuttle/shuttle.dm
@@ -566,8 +566,10 @@
 		index++
 		var/turf/oldT = place
 		var/turf/newT = new_turfs[index]
-		if(!newT || !oldT)
-			continue
+		if(!newT)
+			return DOCKING_NULL_DESTINATION
+		if(!oldT)
+			return DOCKING_NULL_SOURCE
 
 		var/area/old_area = oldT.loc
 		var/move_mode = old_area.beforeShuttleMove(shuttle_areas)											//areas
@@ -674,9 +676,11 @@
 	// then try again
 	switch(mode)
 		if(SHUTTLE_CALL)
-			if(dock(destination, preferred_direction) != DOCKING_SUCCESS)
-				setTimer(20)
-				return
+			var/error = dock(destination, preferred_direction)
+			if(error && error & (DOCKING_NULL_DESTINATION | DOCKING_NULL_SOURCE))
+				var/msg = "A mobile dock in transit exited dock() with an error. This is most likely a mapping problem: Error: [error],  ([src]) ([previous])"
+				WARNING(msg)
+				message_admins(msg)
 		if(SHUTTLE_RECALL)
 			if(dock(previous) != DOCKING_SUCCESS)
 				setTimer(20)

--- a/code/modules/shuttle/shuttle.dm
+++ b/code/modules/shuttle/shuttle.dm
@@ -681,6 +681,11 @@
 				var/msg = "A mobile dock in transit exited dock() with an error. This is most likely a mapping problem: Error: [error],  ([src]) ([previous])"
 				WARNING(msg)
 				message_admins(msg)
+				mode = SHUTTLE_IDLE
+				return
+			else if(error)
+				setTimer(20)
+				return
 		if(SHUTTLE_RECALL)
 			if(dock(previous) != DOCKING_SUCCESS)
 				setTimer(20)


### PR DESCRIPTION
:cl: ninjanomnom
fix: Fixed turfs not rotating
fix: Fixed stealing structures you shouldn't be moving
/:cl:

Also stopped the custom docker from letting you land directly on the map edge.

Warns admins when a shuttle would land or launch in a location with null turfs (aka map edge)
This will leave people trapped in transit space until helped but is better than the alternative, and hopefully raises some awareness to get maps with the issue fixed.

fixes #31755 
fixes #31667 