### PR TITLE
Stops plating subtypes from stating it has holes for rods & you can now only build ontop of it with tiles.

### DIFF
--- a/code/game/turfs/simulated/floor/plating.dm
+++ b/code/game/turfs/simulated/floor/plating.dm
@@ -11,13 +11,17 @@
 	name = "plating"
 	icon_state = "plating"
 	intact = FALSE
+	var/attachment_holes = TRUE
 
 /turf/open/floor/plating/examine(mob/user)
 	..()
 	if(broken || burnt)
 		to_chat(user, "<span class='notice'>It looks like the dents could be <i>welded</i> smooth.</span>")
 		return
-	to_chat(user, "<span class='notice'>There are few attachment holes for a new <i>tile</i> or reinforcement <i>rods</i>.</span>")
+	if(attachment_holes)
+		to_chat(user, "<span class='notice'>There are few attachment holes for a new <i>tile</i> or reinforcement <i>rods</i>.</span>")
+	else
+		to_chat(user, "<span class='notice'>You might be able to build ontop of it with some <i>tiles</i>...</span>")
 
 /turf/open/floor/plating/Initialize()
 	if (!broken_states)

--- a/code/game/turfs/simulated/floor/plating.dm
+++ b/code/game/turfs/simulated/floor/plating.dm
@@ -40,7 +40,7 @@
 /turf/open/floor/plating/attackby(obj/item/C, mob/user, params)
 	if(..())
 		return
-	if(istype(C, /obj/item/stack/rods))
+	if(istype(C, /obj/item/stack/rods) && attachment_holes)
 		if(broken || burnt)
 			to_chat(user, "<span class='warning'>Repair the plating first!</span>")
 			return

--- a/code/game/turfs/simulated/floor/plating/asteroid.dm
+++ b/code/game/turfs/simulated/floor/plating/asteroid.dm
@@ -14,6 +14,7 @@
 	var/turf_type = /turf/open/floor/plating/asteroid //Because caves do whacky shit to revert to normal
 	var/floor_variance = 20 //probability floor has a different icon state
 	archdrops = list(/obj/item/ore/glass = 5)
+	attachment_holes = FALSE
 
 /turf/open/floor/plating/asteroid/Initialize()
 	var/proper_name = name

--- a/code/game/turfs/simulated/floor/plating/dirt.dm
+++ b/code/game/turfs/simulated/floor/plating/dirt.dm
@@ -6,6 +6,7 @@
 	baseturf = /turf/open/chasm/straight_down/jungle
 	initial_gas_mix = LAVALAND_DEFAULT_ATMOS
 	planetary_atmos = TRUE
+	attachment_holes = FALSE
 
 /turf/open/floor/plating/dirt/dark
 	icon_state = "greenerdirt"

--- a/code/game/turfs/simulated/floor/plating/misc_plating.dm
+++ b/code/game/turfs/simulated/floor/plating/misc_plating.dm
@@ -40,6 +40,7 @@
 	baseturf = /turf/open/floor/plating/ashplanet/wateryrock //I assume this will be a chasm eventually, once this becomes an actual surface
 	initial_gas_mix = LAVALAND_DEFAULT_ATMOS
 	planetary_atmos = TRUE
+	attachment_holes = FALSE
 
 /turf/open/floor/plating/ashplanet/Initialize()
 	if(smooth)
@@ -81,6 +82,7 @@
 	name = "beach"
 	icon = 'icons/misc/beach.dmi'
 	flags_1 = NONE
+	attachment_holes = FALSE
 
 /turf/open/floor/plating/beach/ex_act(severity, target)
 	contents_explosion(severity, target)
@@ -130,6 +132,7 @@
 	baseturf = /turf/open/floor/plating/ice
 	slowdown = 1
 	wet = TURF_WET_PERMAFROST
+	attachment_holes = FALSE
 
 /turf/open/floor/plating/ice/colder
 	temperature = 140
@@ -150,6 +153,7 @@
 	icon = 'icons/turf/snow.dmi'
 	icon_state = "snowplating"
 	temperature = 180
+	attachment_holes = FALSE
 
 /turf/open/floor/plating/snowed/colder
 	temperature = 140


### PR DESCRIPTION
🆑 ShizCalev
tweak: You can no longer build reinforced floors directly on top of dirt, asteroid sand, ice, or beaches. You'll have to first construct flooring on top of it instead.
/🆑

Stops beach turf (water, sand, coastline, ect), asteroid sand, ash planet sand, ice, and dirt from saying that it has "attachment holes for new tiles & rods".

Also stops you from being able to immediately build reinforced floors on top of the aforementioned turfs without first making it a regular floor with tiles.