### PR TITLE
Corrects caravan ambush tool speed

### DIFF
--- a/_maps/RandomRuins/SpaceRuins/caravanambush.dmm
+++ b/_maps/RandomRuins/SpaceRuins/caravanambush.dmm
@@ -735,30 +735,10 @@
 /area/ruin/powered)
 "cu" = (
 /obj/structure/closet/crate/secure/engineering,
-/obj/item/wrench{
-	color = "#ff0000";
-	desc = "A prototype of a new wrench design, allegedly the red color scheme makes it go faster.";
-	name = "experimental wrench";
-	toolspeed = 0.3
-	},
-/obj/item/screwdriver{
-	color = "#ff0000";
-	desc = "A prototype of a new screwdriver design, allegedly the red color scheme makes it go faster.";
-	name = "experimental screwdriver";
-	toolspeed = 0.3
-	},
-/obj/item/wirecutters{
-	color = "#ff0000";
-	desc = "A prototype of a new wirecutter design, allegedly the red color scheme makes it go faster.";
-	name = "experimental wirecutters";
-	toolspeed = 0.3
-	},
-/obj/item/crowbar/red{
-	color = "#ff0000";
-	desc = "A prototype of a new crowbar design, allegedly the red color scheme makes it go faster.";
-	name = "experimental crowbar";
-	toolspeed = 0.3
-	},
+/obj/item/wrench/caravan,
+/obj/item/screwdriver/caravan,
+/obj/item/wirecutters/caravan,
+/obj/item/crowbar/red/caravan,
 /turf/open/floor/mineral/plastitanium,
 /area/ruin/powered)
 "cv" = (

--- a/_maps/RandomRuins/SpaceRuins/caravanambush.dmm
+++ b/_maps/RandomRuins/SpaceRuins/caravanambush.dmm
@@ -739,25 +739,25 @@
 	color = "#ff0000";
 	desc = "A prototype of a new wrench design, allegedly the red color scheme makes it go faster.";
 	name = "experimental wrench";
-	toolspeed = 3
+	toolspeed = 0.3
 	},
 /obj/item/screwdriver{
 	color = "#ff0000";
 	desc = "A prototype of a new screwdriver design, allegedly the red color scheme makes it go faster.";
 	name = "experimental screwdriver";
-	toolspeed = 3
+	toolspeed = 0.3
 	},
 /obj/item/wirecutters{
 	color = "#ff0000";
 	desc = "A prototype of a new wirecutter design, allegedly the red color scheme makes it go faster.";
 	name = "experimental wirecutters";
-	toolspeed = 3
+	toolspeed = 0.3
 	},
 /obj/item/crowbar/red{
 	color = "#ff0000";
 	desc = "A prototype of a new crowbar design, allegedly the red color scheme makes it go faster.";
 	name = "experimental crowbar";
-	toolspeed = 3
+	toolspeed = 0.3
 	},
 /turf/open/floor/mineral/plastitanium,
 /area/ruin/powered)

--- a/code/modules/ruins/spaceruin_code/caravanambush.dm
+++ b/code/modules/ruins/spaceruin_code/caravanambush.dm
@@ -1,0 +1,27 @@
+//caravan ambush
+
+/obj/item/wrench/caravan
+	color = "#ff0000"
+	desc = "A prototype of a new wrench design, allegedly the red color scheme makes it go faster."
+	name = "experimental wrench"
+	toolspeed = 0.3
+
+/obj/item/screwdriver/caravan
+	color = "#ff0000"
+	desc = "A prototype of a new screwdriver design, allegedly the red color scheme makes it go faster."
+	name = "experimental screwdriver"
+	toolspeed = 0.3
+	random_color = FALSE
+
+/obj/item/wirecutters/caravan
+	color = "#ff0000"
+	desc = "A prototype of a new wirecutter design, allegedly the red color scheme makes it go faster."
+	name = "experimental wirecutters"
+	toolspeed = 0.3
+	random_color = FALSE
+
+/obj/item/crowbar/red/caravan
+	color = "#ff0000"
+	desc = "A prototype of a new crowbar design, allegedly the red color scheme makes it go faster."
+	name = "experimental crowbar"
+	toolspeed = 0.3

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -2074,6 +2074,7 @@
 #include "code\modules\ruins\objects_and_mobs\sin_ruins.dm"
 #include "code\modules\ruins\spaceruin_code\asteroid4.dm"
 #include "code\modules\ruins\spaceruin_code\bigderelict1.dm"
+#include "code\modules\ruins\spaceruin_code\caravanambush.dm"
 #include "code\modules\ruins\spaceruin_code\crashedclownship.dm"
 #include "code\modules\ruins\spaceruin_code\crashedship.dm"
 #include "code\modules\ruins\spaceruin_code\deepstorage.dm"


### PR DESCRIPTION
🆑 ShizCalev
fix: The tools on the Caravan Ambush space ruin have had their speeds corrected.
/🆑

Fixes #31789