### PR TITLE
Removes glide_size, for SMOOTHER MOVEMENT

### DIFF
--- a/code/game/atoms_movable.dm
+++ b/code/game/atoms_movable.dm
@@ -22,7 +22,6 @@
 	var/moving_diagonally = 0 //0: not doing a diagonal move. 1 and 2: doing the first/second step of the diagonal move
 	var/list/client_mobs_in_contents // This contains all the client mobs within this container
 	var/list/acted_explosions	//for explosion dodging
-	glide_size = 8
 	appearance_flags = TILE_BOUND|PIXEL_SCALE
 	var/datum/forced_movement/force_moving = null	//handled soley by forced_movement.dm
 	var/floating = FALSE


### PR DESCRIPTION

:cl: 2016 called
code: Movement is smoother.
/:cl:

[why]: wonder what 2017 /tg/ think of this, will they hate it more or will they actually consider it. no, this is not obvious bait. i just want opinions on why players prefer our current movement rather a smoother alternative.

It's been over one year, people's opinions are subject to change. (no revert wars too please)

If this does not work, would it be possible to seek better movement that would feel less jarring for players. I am sick of people running at lightspeed.

tagging relevant people
@MrStonedOne @lzimann @optimumtact @KorPhaeron @Incoming5643 @Cyberboss @Fox-McCloud @Iamgoofball 