### PR TITLE
Fixes disabling leg actuators not setting power drain per step to the correct value

### DIFF
--- a/code/game/mecha/mecha.dm
+++ b/code/game/mecha/mecha.dm
@@ -28,6 +28,7 @@
 	var/mob/living/carbon/occupant = null
 	var/step_in = 10 //make a step in step_in/10 sec.
 	var/dir_in = 2//What direction will the mech face when entered/powered on? Defaults to South.
+	var/normal_step_energy_drain = 10 //How much energy the mech will consume each time it moves. This variable is a backup for when leg actuators affect the energy drain.
 	var/step_energy_drain = 10
 	var/melee_energy_drain = 15
 	var/overload_step_energy_drain_min = 100
@@ -210,7 +211,8 @@
 	var/obj/item/stock_parts/scanning_module/SM = locate() in contents
 	var/obj/item/stock_parts/capacitor/CP = locate() in contents
 	if(SM)
-		step_energy_drain = 20 - (5 * SM.rating) //10 is normal, so on lowest part its worse, on second its ok and on higher its real good up to 0 on best
+		normal_step_energy_drain = 20 - (5 * SM.rating) //10 is normal, so on lowest part its worse, on second its ok and on higher its real good up to 0 on best
+		step_energy_drain = normal_step_energy_drain
 		qdel(SM)
 	if(CP)
 		armor["energy"] += (CP.rating * 10) //Each level of capacitor protects the mech against emp by 10%

--- a/code/game/mecha/mecha_actions.dm
+++ b/code/game/mecha/mecha_actions.dm
@@ -209,7 +209,7 @@
 		chassis.leg_overload_mode = 0
 		chassis.bumpsmash = 0
 		chassis.step_in = initial(chassis.step_in)
-		chassis.step_energy_drain = initial(chassis.step_energy_drain)
+		chassis.step_energy_drain = chassis.normal_step_energy_drain
 		chassis.occupant_message("<span class='notice'>You disable leg actuators overload.</span>")
 	UpdateButtonIcon()
 


### PR DESCRIPTION
:cl: Y0SH1_M4S73R
fix: Disabling leg actuators sets the power drain per step to the correct value.
/:cl:

Fixes #31801, which existed before #31389 was merged. The cause of this issue was calling initial(step_energy_drain), which was declared as 10 in the base code for mechs. This change sets step_energy_drain to the part-tier-scaled energy drain, which is stored in the newly-created backup var normal_step_energy_drain.
