### PR TITLE
Fixes AI visiblity checks

### DIFF
--- a/code/_onclick/ai.dm
+++ b/code/_onclick/ai.dm
@@ -38,11 +38,12 @@
 	if(isnull(pixel_turf))
 		return
 	if(!can_see(A))
-		log_admin("[key_name_admin(src)] might be running a modified client! (failed can_see on AI click of [A]([COORD(pixel_turf)]))")
 		message_admins("[key_name_admin(src)] might be running a modified client! (failed can_see on AI click of [A]([ADMIN_COORDJMP(pixel_turf)]))")
+		var/message = "[key_name(src)] might be running a modified client! (failed can_see on AI click of [A]([COORD(pixel_turf)]))"
+		log_admin(message)
 		if(REALTIMEOFDAY >= chnotify + 9000)
 			chnotify = REALTIMEOFDAY
-			send2irc_adminless_only("NOCHEAT", "[key_name(src)] might be running a modified client! (failed can_see on AI click of [A]([COORD(pixel_turf)]))")
+			send2irc_adminless_only("NOCHEAT", message)
 		return
 
 	var/list/modifiers = params2list(params)

--- a/code/_onclick/ai.dm
+++ b/code/_onclick/ai.dm
@@ -22,7 +22,6 @@
 	else
 		A.move_camera_by_click()
 
-
 /mob/living/silicon/ai/ClickOn(var/atom/A, params)
 	if(world.time <= next_click)
 		return
@@ -36,20 +35,15 @@
 		return
 
 	var/turf/pixel_turf = get_turf_pixel(A)
-	var/turf_visible
-	if(pixel_turf)
-		turf_visible = GLOB.cameranet.checkTurfVis(pixel_turf)
-		if(!turf_visible)
-			if(istype(loc, /obj/item/device/aicard) && (pixel_turf in view(client.view, loc)))
-				turf_visible = TRUE
-			else
-				if (pixel_turf.obscured)
-					log_admin("[key_name_admin(src)] might be running a modified client! (failed checkTurfVis on AI click of [A]([COORD(pixel_turf)])")
-					message_admins("[key_name_admin(src)] might be running a modified client! (failed checkTurfVis on AI click of [A]([ADMIN_COORDJMP(pixel_turf)]))")
-					if(REALTIMEOFDAY >= chnotify + 9000)
-						chnotify = REALTIMEOFDAY
-						send2irc_adminless_only("NOCHEAT", "[key_name(src)] might be running a modified client! (failed checkTurfVis on AI click of [A]([COORD(pixel_turf)]))")
-				return
+	if(isnull(pixel_turf))
+		return
+	if(!can_see(A))
+		log_admin("[key_name_admin(src)] might be running a modified client! (failed can_see on AI click of [A]([COORD(pixel_turf)]))")
+		message_admins("[key_name_admin(src)] might be running a modified client! (failed can_see on AI click of [A]([ADMIN_COORDJMP(pixel_turf)]))")
+		if(REALTIMEOFDAY >= chnotify + 9000)
+			chnotify = REALTIMEOFDAY
+			send2irc_adminless_only("NOCHEAT", "[key_name(src)] might be running a modified client! (failed can_see on AI click of [A]([COORD(pixel_turf)]))")
+		return
 
 	var/list/modifiers = params2list(params)
 	if(modifiers["shift"] && modifiers["ctrl"])
@@ -74,7 +68,7 @@
 	if(world.time <= next_move)
 		return
 
-	if(aicamera.in_camera_mode && pixel_turf && turf_visible)
+	if(aicamera.in_camera_mode)
 		aicamera.camera_mode_off()
 		aicamera.captureimage(pixel_turf, usr)
 		return

--- a/code/game/machinery/doors/airlock.dm
+++ b/code/game/machinery/doors/airlock.dm
@@ -789,7 +789,7 @@
 	// Otherwise it will runtime with this kind of error: null.Topic()
 	if(!nowindow)
 		..()
-	if(usr.incapacitated() && !IsAdminGhost(usr))
+	if(!usr.canUseTopic(src) && !IsAdminGhost(usr))
 		return
 	add_fingerprint(usr)
 	if(href_list["close"])

--- a/code/modules/mob/living/silicon/ai/ai.dm
+++ b/code/modules/mob/living/silicon/ai/ai.dm
@@ -813,12 +813,16 @@
 		return FALSE
 	if(be_close && !in_range(M, src))
 		return FALSE
-	//stop AIs from leaving windows open and using then after they lose vision
-	//apc_override is needed here because AIs use their own APC when powerless
-	//get_turf_pixel() is because APCs in maint aren't actually in view of the inner camera
-	if(M && GLOB.cameranet && !GLOB.cameranet.checkTurfVis(get_turf_pixel(M)) && !apc_override)
-		return FALSE
-	return TRUE
+	return can_see(M) //stop AIs from leaving windows open and using then after they lose vision
+
+/mob/living/silicon/ai/proc/can_see(atom/A)
+	if(isturf(loc)) //AI in core, check if on cameras
+		//get_turf_pixel() is because APCs in maint aren't actually in view of the inner camera
+		//apc_override is needed here because AIs use their own APC when depowered
+		return (GLOB.cameranet && GLOB.cameranet.checkTurfVis(get_turf_pixel(A))) || apc_override
+	//AI is carded/shunted
+	//view(src) returns nothing for carded/shunted AIs and they have x-ray vision so just use get_dist
+	return get_dist(src, A) <= client.view
 
 /mob/living/silicon/ai/proc/relay_speech(message, atom/movable/speaker, datum/language/message_language, raw_message, radio_freq, list/spans, message_mode)
 	raw_message = lang_treat(speaker, message_language, raw_message, spans, message_mode)

--- a/code/modules/tgui/states/default.dm
+++ b/code/modules/tgui/states/default.dm
@@ -42,8 +42,8 @@ GLOBAL_DATUM_INIT(default_state, /datum/ui_state/default, new)
 	if(. < UI_INTERACTIVE)
 		return
 
-	// The AI can interact with anything it can see nearby, or with cameras.
-	if((get_dist(src, src_object) <= client.view) || GLOB.cameranet.checkTurfVis(get_turf_pixel(src_object)))
+	// The AI can interact with anything it can see nearby, or with cameras while wireless control is enabled.
+	if(!control_disabled && can_see(src_object))
 		return UI_INTERACTIVE
 	return UI_CLOSE
 


### PR DESCRIPTION
New AI proc can_see() which only checks for camera visibility while the AI is in the core and only checks for proximity while the AI is carded/shunted. Also default_can_use_topic() will check for control_disabled in case the AI gets carded with a tgui window open.

Carded AIs will no longer be able to interact with things that are off-screen but on-camera. Fixes #24116
Carded AIs will be able to interact with things that are on-screen but off-camera. Fixes #27282