### PR TITLE
Inventory overhaul to support replaceable slots

### DIFF
--- a/code/__DEFINES/inventory.dm
+++ b/code/__DEFINES/inventory.dm
@@ -161,3 +161,8 @@
 
 #define TINT_DARKENED 2			//Threshold of tint level to apply weld mask overlay
 #define TINT_BLIND 3			//Threshold of tint level to obscure vision fully
+
+//What solutions are possible from canEquip
+#define EQUIP_ABLE 1
+#define EQUIP_UNABLE 2
+#define EQUIP_REPLACEABLE 3

--- a/code/_onclick/hud/screen_objects.dm
+++ b/code/_onclick/hud/screen_objects.dm
@@ -116,7 +116,7 @@
 	if(hud && hud.mymob && slot_id)
 		var/obj/item/inv_item = hud.mymob.get_item_by_slot(slot_id)
 		if(inv_item)
-			return inv_item.Click(location, control, params)
+			inv_item.Click(location, control, params)
 
 	if(usr.attack_ui(slot_id))
 		usr.update_inv_hands()

--- a/code/game/gamemodes/clock_cult/clock_items/clockwork_armor.dm
+++ b/code/game/gamemodes/clock_cult/clock_items/clockwork_armor.dm
@@ -54,7 +54,7 @@
 
 /obj/item/clothing/head/helmet/clockwork/mob_can_equip(mob/M, mob/equipper, slot, disable_warning = 0)
 	if(equipper && !is_servant_of_ratvar(equipper))
-		return 0
+		return EQUIP_UNABLE
 	return ..()
 
 /obj/item/clothing/suit/armor/clockwork
@@ -98,7 +98,7 @@
 
 /obj/item/clothing/suit/armor/clockwork/mob_can_equip(mob/M, mob/equipper, slot, disable_warning = 0)
 	if(equipper && !is_servant_of_ratvar(equipper))
-		return 0
+		return EQUIP_UNABLE
 	return ..()
 
 /obj/item/clothing/suit/armor/clockwork/equipped(mob/living/user, slot)
@@ -159,7 +159,7 @@
 
 /obj/item/clothing/gloves/clockwork/mob_can_equip(mob/M, mob/equipper, slot, disable_warning = 0)
 	if(equipper && !is_servant_of_ratvar(equipper))
-		return 0
+		return EQUIP_UNABLE
 	return ..()
 
 /obj/item/clothing/gloves/clockwork/equipped(mob/living/user, slot)
@@ -209,7 +209,7 @@
 
 /obj/item/clothing/shoes/clockwork/mob_can_equip(mob/M, mob/equipper, slot, disable_warning = 0)
 	if(equipper && !is_servant_of_ratvar(equipper))
-		return 0
+		return EQUIP_UNABLE
 	return ..()
 
 /obj/item/clothing/shoes/clockwork/equipped(mob/living/user, slot)

--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -437,7 +437,7 @@ GLOBAL_VAR_INIT(rpg_loot_items, FALSE)
 //Set disable_warning to 1 if you wish it to not give you outputs.
 /obj/item/proc/mob_can_equip(mob/living/M, mob/living/equipper, slot, disable_warning = FALSE, bypass_equip_delay_self = FALSE)
 	if(!M)
-		return 0
+		return EQUIP_UNABLE
 
 	return M.can_equip(src, slot, disable_warning, bypass_equip_delay_self)
 

--- a/code/game/objects/items/twohanded.dm
+++ b/code/game/objects/items/twohanded.dm
@@ -149,7 +149,7 @@
 /obj/item/twohanded/required/mob_can_equip(mob/M, mob/equipper, slot, disable_warning = 0)
 	if(wielded && !slot_flags)
 		to_chat(M, "<span class='warning'>[src] is too cumbersome to carry with anything but your hands!</span>")
-		return 0
+		return EQUIP_UNABLE
 	return ..()
 
 /obj/item/twohanded/required/attack_hand(mob/user)//Can't even pick it up without both hands empty

--- a/code/modules/mob/inventory.dm
+++ b/code/modules/mob/inventory.dm
@@ -143,10 +143,10 @@
 
 
 
-//Returns if a certain item can be equipped to a certain slot.
-// Currently invalid for two-handed items - call obj/item/mob_can_equip() instead.
+//Returns if a certain item can be equipped to a certain slot, called from
+// item mob_can_equip callback by default (assuming the item confirms the mob can equip)
 /mob/proc/can_equip(obj/item/I, slot, disable_warning = 0)
-	return FALSE
+	return EQUIP_UNABLE
 
 /mob/proc/can_put_in_hand(I, hand_index)
 	if(!put_in_hand_check(I))

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -231,10 +231,11 @@
 
 			var/delay_denominator = 1
 			if(pocket_item && !(pocket_item.flags_1&ABSTRACT_1))
-				if(pocket_item.flags_1 & NODROP_1)
+				if(!canUnEquip(pocket_item))
 					to_chat(usr, "<span class='warning'>You try to empty [src]'s [pocket_side] pocket, it seems to be stuck!</span>")
+					return
 				to_chat(usr, "<span class='notice'>You try to empty [src]'s [pocket_side] pocket.</span>")
-			else if(place_item && place_item.mob_can_equip(src, usr, pocket_id, 1) && !(place_item.flags_1&ABSTRACT_1))
+			else if(place_item && place_item.mob_can_equip(src, usr, pocket_id, 1) == EQUIP_ABLE && !(place_item.flags_1&ABSTRACT_1))
 				to_chat(usr, "<span class='notice'>You try to place [place_item] into [src]'s [pocket_side] pocket.</span>")
 				delay_denominator = 4
 			else
@@ -242,11 +243,14 @@
 
 			if(do_mob(usr, src, POCKET_STRIP_DELAY/delay_denominator)) //placing an item into the pocket is 4 times faster
 				if(pocket_item)
+					if(!canUnEquip(pocket_item))
+						to_chat(usr, "<span class='warning'>You try to empty [src]'s [pocket_side] pocket, it seems to be stuck!</span>")
+						return
 					if(pocket_item == (pocket_id == slot_r_store ? r_store : l_store)) //item still in the pocket we search
 						dropItemToGround(pocket_item)
 				else
 					if(place_item)
-						if(place_item.mob_can_equip(src, usr, pocket_id, FALSE, TRUE))
+						if(place_item.mob_can_equip(src, usr, pocket_id, FALSE, TRUE) == EQUIP_ABLE && !(place_item.flags_1&ABSTRACT_1))
 							usr.temporarilyRemoveItemFromInventory(place_item, TRUE)
 							equip_to_slot(place_item, pocket_id, TRUE)
 						//do nothing otherwise

--- a/code/modules/mob/living/carbon/monkey/inventory.dm
+++ b/code/modules/mob/living/carbon/monkey/inventory.dm
@@ -2,33 +2,30 @@
 	switch(slot)
 		if(slot_hands)
 			if(get_empty_held_indexes())
-				return TRUE
-			return FALSE
+				return EQUIP_ABLE
+			return EQUIP_UNABLE
 		if(slot_wear_mask)
 			if(wear_mask)
-				return FALSE
+				return EQUIP_UNABLE
 			if( !(I.slot_flags & SLOT_MASK) )
-				return FALSE
-			return TRUE
+				return EQUIP_UNABLE
+			return EQUIP_ABLE
 		if(slot_neck)
 			if(wear_neck)
-				return FALSE
+				return EQUIP_UNABLE
 			if( !(I.slot_flags & SLOT_NECK) )
-				return FALSE
-			return TRUE
+				return EQUIP_UNABLE
+			return EQUIP_ABLE
 		if(slot_head)
 			if(head)
-				return FALSE
+				return EQUIP_UNABLE
 			if( !(I.slot_flags & SLOT_HEAD) )
-				return FALSE
-			return TRUE
+				return EQUIP_UNABLE
+			return EQUIP_ABLE
 		if(slot_back)
 			if(back)
-				return FALSE
+				return EQUIP_UNABLE
 			if( !(I.slot_flags & SLOT_BACK) )
-				return FALSE
-			return TRUE
-	return FALSE //Unsupported slot
-
-
-
+				return EQUIP_UNABLE
+			return EQUIP_ABLE
+	return EQUIP_UNABLE //Unsupported slot

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -685,7 +685,7 @@
 // The src mob is trying to strip an item from someone
 // Override if a certain type of mob should be behave differently when stripping items (can't, for example)
 /mob/living/stripPanelUnequip(obj/item/what, mob/who, where)
-	if(what.flags_1 & NODROP_1)
+	if(!canUnEquip(what))
 		to_chat(src, "<span class='warning'>You can't remove \the [what.name], it appears to be stuck!</span>")
 		return
 	who.visible_message("<span class='danger'>[src] tries to remove [who]'s [what.name].</span>", \
@@ -706,10 +706,10 @@
 // Override if a certain mob should be behave differently when placing items (can't, for example)
 /mob/living/stripPanelEquip(obj/item/what, mob/who, where)
 	what = src.get_active_held_item()
-	if(what && (what.flags_1 & NODROP_1))
-		to_chat(src, "<span class='warning'>You can't put \the [what.name] on [who], it's stuck to your hand!</span>")
-		return
 	if(what)
+		if(!canUnEquip(what))
+			to_chat(src, "<span class='warning'>You can't put \the [what.name] on [who], it's stuck to your hand!</span>")
+			return
 		var/list/where_list
 		var/final_where
 
@@ -719,13 +719,13 @@
 		else
 			final_where = where
 
-		if(!what.mob_can_equip(who, src, final_where, TRUE, TRUE))
+		if(what.mob_can_equip(who, src, final_where, TRUE, TRUE) != EQUIP_ABLE)
 			to_chat(src, "<span class='warning'>\The [what.name] doesn't fit in that place!</span>")
 			return
 
 		visible_message("<span class='notice'>[src] tries to put [what] on [who].</span>")
 		if(do_mob(src, who, what.equip_delay_other))
-			if(what && Adjacent(who) && what.mob_can_equip(who, src, final_where, TRUE, TRUE))
+			if(what && Adjacent(who) && what.mob_can_equip(who, src, final_where, TRUE, TRUE) != EQUIP_ABLE)
 				if(temporarilyRemoveItemFromInventory(what))
 					if(where_list)
 						if(!who.put_in_hand(what, where_list[2]))

--- a/code/modules/mob/living/simple_animal/friendly/drone/inventory.dm
+++ b/code/modules/mob/living/simple_animal/friendly/drone/inventory.dm
@@ -23,14 +23,14 @@
 	switch(slot)
 		if(slot_head)
 			if(head)
-				return 0
+				return EQUIP_UNABLE
 			if(!((I.slot_flags & SLOT_HEAD) || (I.slot_flags & SLOT_MASK)))
-				return 0
-			return 1
+				return EQUIP_UNABLE
+			return EQUIP_ABLE
 		if(slot_generic_dextrous_storage)
 			if(internal_storage)
-				return 0
-			return 1
+				return EQUIP_UNABLE
+			return EQUIP_ABLE
 	..()
 
 

--- a/code/modules/mob/living/simple_animal/guardian/types/dextrous.dm
+++ b/code/modules/mob/living/simple_animal/guardian/types/dextrous.dm
@@ -71,8 +71,8 @@
 	switch(slot)
 		if(slot_generic_dextrous_storage)
 			if(internal_storage)
-				return 0
-			return 1
+				return EQUIP_UNABLE
+			return EQUIP_ABLE
 	..()
 
 /mob/living/simple_animal/hostile/guardian/dextrous/equip_to_slot(obj/item/I, slot)


### PR DESCRIPTION
These are inventory slots you can replace the item in the slot with,
without dropping any of the sub items that the slot is responsible for
supporting.

Currently the only replaceable slot is the jumpsuit, so you can change
out the jumpsuit without having to put your id card, pocket slots and
belt into your backpack

This also does some refactor work on the can_equip proc in the species
datum to make it slightly less copypasta

Replacing items takes a few seconds, and you cannot move during that time

:cl: oranges
tweak: you can swap out a jumpsuit without dropping all your items now, click on the inventory slot with the new jumpsuit to swap it out, make sure you stay still while it's happening
/:cl:

It's not very fun to have to juggle all your items to swap out your jumpsuit, so this is a nice feature.