### PR TITLE
Fixes foam layer popping

### DIFF
--- a/code/game/objects/effects/effect_system/effects_foam.dm
+++ b/code/game/objects/effects/effect_system/effects_foam.dm
@@ -11,7 +11,7 @@
 	opacity = 0
 	anchored = TRUE
 	density = FALSE
-	layer = WALL_OBJ_LAYER
+	layer = EDGED_TURF_LAYER
 	mouse_opacity = MOUSE_OPACITY_TRANSPARENT
 	var/amount = 3
 	animate_movement = 0
@@ -216,6 +216,7 @@
 	density = TRUE
 	opacity = 1 	// changed in New()
 	anchored = TRUE
+	layer = EDGED_TURF_LAYER
 	resistance_flags = FIRE_PROOF | ACID_PROOF
 	name = "foamed metal"
 	desc = "A lightweight foamed metal wall."
@@ -265,7 +266,6 @@
 	icon_state = "atmos_resin"
 	alpha = 120
 	max_integrity = 10
-	layer = EDGED_TURF_LAYER
 
 /obj/structure/foamedmetal/resin/Initialize()
 	. = ..()


### PR DESCRIPTION
The basic foam didn't have a layer defined, resulting in objects popping on top and under it as your camera moved around. This makes it so that it will always conceal objects underneath it. 

Also changed the particle effect's layer to match.