### PR TITLE
Fixes rotations of reflectors on box and meta.

### DIFF
--- a/_maps/map_files/BoxStation/BoxStation.dmm
+++ b/_maps/map_files/BoxStation/BoxStation.dmm
@@ -57674,7 +57674,9 @@
 /turf/open/floor/plasteel/black,
 /area/engine/engineering)
 "cGU" = (
-/obj/structure/reflector/double/anchored,
+/obj/structure/reflector/double/anchored{
+	rotation_angle = 315
+	},
 /turf/open/floor/plasteel/black,
 /area/engine/engineering)
 "cGV" = (
@@ -57782,13 +57784,13 @@
 /area/engine/engineering)
 "cHo" = (
 /obj/structure/reflector/single/anchored{
-	dir = 1
+	rotation_angle = 315
 	},
 /turf/open/floor/plating,
 /area/engine/engineering)
 "cHp" = (
 /obj/structure/reflector/single/anchored{
-	dir = 4
+	rotation_angle = 45
 	},
 /turf/open/floor/plating,
 /area/engine/engineering)

--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -82774,7 +82774,7 @@
 /area/engine/engineering)
 "deY" = (
 /obj/structure/reflector/single/anchored{
-	dir = 1
+	rotation_angle = 315
 	},
 /turf/open/floor/plating,
 /area/engine/engineering)
@@ -82815,13 +82815,13 @@
 /area/engine/engineering)
 "dff" = (
 /obj/structure/reflector/double/anchored{
-	dir = 1
+	rotation_angle = 45
 	},
 /turf/open/floor/plasteel/black,
 /area/engine/engineering)
 "dfg" = (
 /obj/structure/reflector/single/anchored{
-	dir = 8
+	rotation_angle = 225
 	},
 /turf/open/floor/plating,
 /area/engine/engineering)


### PR DESCRIPTION
[Changelogs]: 
:cl: DaxDupont
fix: Fixes the default rotation of reflectors on Meta and Box.
/:cl:

[why]: https://github.com/tgstation/tgstation/pull/30599 turned rotation into a var based angle rather than relying on dir.
This broke the default rotation of the reflectors on all stations that use it. 
I didn't touch Delta station because I have no idea what the hell that was supposed to look like in the first place. 