### PR TITLE
Fixes a misnamed arg in a clockwork proc

### DIFF
--- a/code/game/gamemodes/clock_cult/clock_effects/city_of_cogs_rift.dm
+++ b/code/game/gamemodes/clock_cult/clock_effects/city_of_cogs_rift.dm
@@ -38,7 +38,7 @@
 		beckon(AM)
 
 /obj/effect/clockwork/city_of_cogs_rift/proc/beckon(atom/movable/AM)
-	AM.visible_message("<span class='danger'>[AM] passes through [src]!</span>", ignore_mob = AM)
+	AM.visible_message("<span class='danger'>[AM] passes through [src]!</span>", ignored_mob = AM)
 	AM.forceMove(pick(!is_servant_of_ratvar(AM) ? GLOB.city_of_cogs_spawns : GLOB.servant_spawns))
 	AM.visible_message("<span class='danger'>[AM] materializes from the air!</span>", \
 	"<span class='boldannounce'>You pass through [src] and appear [is_servant_of_ratvar(AM) ? "back at the City of Cogs" : "somewhere unfamiliar. Looks like it was a one-way trip.."].</span>")


### PR DESCRIPTION
MFW I was already working on this paragraph of code but atomized a one-character fix for GBP.

Fixes a runtime that took place every time the portal was used because of the bad arg name. 