### PR TITLE
You will no longer trip on inactive Honkbots. [Tweak] 

### DIFF
--- a/code/modules/mob/living/simple_animal/bot/honkbot.dm
+++ b/code/modules/mob/living/simple_animal/bot/honkbot.dm
@@ -348,7 +348,7 @@ Maintenance panel panel is [open ? "opened" : "closed"]"},
 		mode = BOT_HUNT
 
 /mob/living/simple_animal/bot/honkbot/Crossed(atom/movable/AM)
-	if(ismob(AM))
+	if(ismob(AM) && (on)) //only if its online
 		if(prob(30)) //you're far more likely to trip on a honkbot
 			var/mob/living/carbon/C = AM
 			if(!istype(C) || !C || in_range(src, target))
@@ -362,7 +362,8 @@ Maintenance panel panel is [open ? "opened" : "closed"]"},
 						  	"[C] leaps out of [src]'s way!")]</span>")
 			C.Knockdown(10)
 			playsound(loc, 'sound/misc/sadtrombone.ogg', 50, 1, -1)
-			speak("Honk!")
+			if(!client)
+				speak("Honk!")
 			sensor_blink()
 			return
 	..()


### PR DESCRIPTION
[Changelogs]
:cl: 
tweak: You will no longer trip on inactive honkbots.
fix: Sentient Honkbots are no longer forced to speak when somebody trip on them.
/:cl:

[why]: Inactive honkbots are just cardboard boxes waiting to be turned on. They won't leap in your way, and are easily avoidable. It will also prevent the honkbot from emoting the sad trombone while they're turned off. Finally, we'll prevent it from honking if there's a player controlling it.