### PR TITLE
Makes changelings vomitting acid on things actually leave a puddle of acid

### DIFF
--- a/code/game/gamemodes/changeling/powers/biodegrade.dm
+++ b/code/game/gamemodes/changeling/powers/biodegrade.dm
@@ -54,17 +54,20 @@
 
 /obj/effect/proc_holder/changeling/biodegrade/proc/dissolve_handcuffs(mob/living/carbon/human/user, obj/O)
 	if(O && user.handcuffed == O)
-		visible_message("<span class='warning'>[O] dissolves into a puddle of sizzling goop.</span>")
+		user.visible_message("<span class='warning'>[O] dissolve[O.gender==PLURAL?"":"s"] into a puddle of sizzling goop.</span>")
+		new /obj/effect/decal/cleanable/greenglow(O.drop_location())
 		qdel(O)
 
 /obj/effect/proc_holder/changeling/biodegrade/proc/dissolve_straightjacket(mob/living/carbon/human/user, obj/S)
 	if(S && user.wear_suit == S)
-		visible_message("<span class='warning'>[S] dissolves into a puddle of sizzling goop.</span>")
+		user.visible_message("<span class='warning'>[S] dissolves into a puddle of sizzling goop.</span>")
+		new /obj/effect/decal/cleanable/greenglow(S.drop_location())
 		qdel(S)
 
 /obj/effect/proc_holder/changeling/biodegrade/proc/open_closet(mob/living/carbon/human/user, obj/structure/closet/C)
 	if(C && user.loc == C)
 		C.visible_message("<span class='warning'>[C]'s door breaks and opens!</span>")
+		new /obj/effect/decal/cleanable/greenglow(C.drop_location())
 		C.welded = FALSE
 		C.locked = FALSE
 		C.broken = TRUE
@@ -73,5 +76,6 @@
 
 /obj/effect/proc_holder/changeling/biodegrade/proc/dissolve_cocoon(mob/living/carbon/human/user, obj/structure/spider/cocoon/C)
 	if(C && user.loc == C)
+		new /obj/effect/decal/cleanable/greenglow(C.drop_location())
 		qdel(C) //The cocoon's destroy will move the changeling outside of it without interference
 		to_chat(user, "<span class='warning'>We dissolve the cocoon!</span>")


### PR DESCRIPTION
🆑 ShizCalev
tweak: Changelings using biodegrade to escape restraints will now leave a pile of goop.
fix: Fixed messages related to changelings using biodegrade not appearing.
/🆑

It always bothered me that changelings dissolving things into puddles of goop didn't actually leave puddles of goop.... so that's what this does.

Also fixes the chat messages regarding the cuffs dissolving not appearing.

Also corrects a minor grammar issue. "The handcuffs dissolves"