### PR TITLE
Removes duplicate typecaches

### DIFF
--- a/code/__HELPERS/AStar.dm
+++ b/code/__HELPERS/AStar.dm
@@ -154,7 +154,7 @@ Actual Adjacent procs :
 /turf/proc/reachableAdjacentTurfs(caller, ID, simulated_only)
 	var/list/L = new()
 	var/turf/T
-	var/static/space_type_cache = typecacheof(list(/turf/open/space))
+	var/static/space_type_cache = typecacheof(/turf/open/space)
 
 	for(var/dir in GLOB.cardinals)
 		T = get_step(src,dir)

--- a/code/_globalvars/lists/typecache.dm
+++ b/code/_globalvars/lists/typecache.dm
@@ -3,9 +3,9 @@
 
 //Note: typecache can only replace istype if you know for sure the thing is at least a datum.
 
-GLOBAL_LIST_INIT(typecache_mob, typecacheof(list(/mob)))
+GLOBAL_LIST_INIT(typecache_mob, typecacheof(/mob))
 
-GLOBAL_LIST_INIT(typecache_living, typecacheof(list(/mob/living)))
+GLOBAL_LIST_INIT(typecache_living, typecacheof(/mob/living))
 
-GLOBAL_LIST_INIT(typecache_machine_or_structure, typecacheof(list(/obj/machinery))|typecacheof(list(/obj/structure)))
+GLOBAL_LIST_INIT(typecache_machine_or_structure, typecacheof(list(/obj/machinery, /obj/structure)))
 

--- a/code/game/machinery/iv_drip.dm
+++ b/code/game/machinery/iv_drip.dm
@@ -10,14 +10,13 @@
 	var/mob/living/carbon/attached = null
 	var/mode = IV_INJECTING
 	var/obj/item/reagent_containers/beaker = null
-	var/list/drip_containers = list(/obj/item/reagent_containers/blood,
+	var/static/list/drip_containers = typecacheof(list(/obj/item/reagent_containers/blood,
 									/obj/item/reagent_containers/food,
-									/obj/item/reagent_containers/glass)
+									/obj/item/reagent_containers/glass))
 
 /obj/machinery/iv_drip/Initialize()
 	. = ..()
 	update_icon()
-	drip_containers = typecacheof(drip_containers)
 
 /obj/machinery/iv_drip/Destroy()
 	attached = null

--- a/code/game/turfs/simulated/dirtystation.dm
+++ b/code/game/turfs/simulated/dirtystation.dm
@@ -72,7 +72,7 @@
 		return
 
 		//Hangars and pods covered in oil.
-	var/static/list/oily_areas = typecacheof(list(/area/quartermaster))
+	var/static/list/oily_areas = typecacheof(/area/quartermaster)
 	if(is_type_in_typecache(A, oily_areas))
 		if(prob(25))
 			new /obj/effect/decal/cleanable/oil(src)

--- a/code/modules/hydroponics/grown/towercap.dm
+++ b/code/modules/hydroponics/grown/towercap.dm
@@ -44,15 +44,11 @@
 	attack_verb = list("bashed", "battered", "bludgeoned", "whacked")
 	var/plank_type = /obj/item/stack/sheet/mineral/wood
 	var/plank_name = "wooden planks"
-	var/list/accepted = list(/obj/item/reagent_containers/food/snacks/grown/tobacco,
+	var/static/list/accepted = typecacheof(list(/obj/item/reagent_containers/food/snacks/grown/tobacco,
 	/obj/item/reagent_containers/food/snacks/grown/tea,
 	/obj/item/reagent_containers/food/snacks/grown/ambrosia/vulgaris,
 	/obj/item/reagent_containers/food/snacks/grown/ambrosia/deus,
-	/obj/item/reagent_containers/food/snacks/grown/wheat)
-
-/obj/item/grown/log/Initialize()
-	. = ..()
-	accepted = typecacheof(accepted)
+	/obj/item/reagent_containers/food/snacks/grown/wheat))
 
 /obj/item/grown/log/attackby(obj/item/W, mob/user, params)
 	if(W.sharpness)
@@ -69,7 +65,7 @@
 			to_chat(user, "<span class='notice'>You add the newly-formed [plank_name] to the stack. It now contains [plank.amount] [plank_name].</span>")
 		qdel(src)
 
-	if(is_type_in_typecache(W,accepted))
+	if(CheckAccepted(I))
 		var/obj/item/reagent_containers/food/snacks/grown/leaf = W
 		if(leaf.dry)
 			user.show_message("<span class='notice'>You wrap \the [W] around the log, turning it into a torch!</span>")
@@ -84,6 +80,9 @@
 	else
 		return ..()
 
+/obj/item/grown/log/proc/CheckAccepted(obj/item/I)
+	return is_type_in_typecache(I, accepted)
+
 /obj/item/grown/log/tree
 	seed = null
 	name = "wood log"
@@ -94,10 +93,11 @@
 	name = "steel-cap log"
 	desc = "It's made of metal."
 	icon_state = "steellogs"
-	accepted = list()
 	plank_type = /obj/item/stack/rods
 	plank_name = "rods"
 
+/obj/item/grown/log/steel/CheckAccepted(obj/item/I)
+	return FALSE
 
 /////////BONFIRES//////////
 

--- a/code/modules/hydroponics/grown/towercap.dm
+++ b/code/modules/hydroponics/grown/towercap.dm
@@ -65,7 +65,7 @@
 			to_chat(user, "<span class='notice'>You add the newly-formed [plank_name] to the stack. It now contains [plank.amount] [plank_name].</span>")
 		qdel(src)
 
-	if(CheckAccepted(I))
+	if(CheckAccepted(W))
 		var/obj/item/reagent_containers/food/snacks/grown/leaf = W
 		if(leaf.dry)
 			user.show_message("<span class='notice'>You wrap \the [W] around the log, turning it into a torch!</span>")

--- a/code/modules/mining/lavaland/necropolis_chests.dm
+++ b/code/modules/mining/lavaland/necropolis_chests.dm
@@ -880,11 +880,7 @@
 	var/create_delay = 30
 	var/reset_cooldown = 50
 	var/timer = 0
-	var/banned_turfs
-
-/obj/item/lava_staff/Initialize()
-	. = ..()
-	banned_turfs = typecacheof(list(/turf/open/space/transit, /turf/closed))
+	var/static/list/banned_turfs = typecacheof(list(/turf/open/space/transit, /turf/closed))
 
 /obj/item/lava_staff/afterattack(atom/target, mob/user, proximity_flag, click_parameters)
 	..()

--- a/code/modules/mob/living/carbon/human/human_defines.dm
+++ b/code/modules/mob/living/carbon/human/human_defines.dm
@@ -45,6 +45,6 @@
 	var/datum/personal_crafting/handcrafting
 	can_buckle = TRUE
 	buckle_lying = FALSE
-	can_ride_typecache = list(/mob/living/carbon/human, /mob/living/simple_animal/slime, /mob/living/simple_animal/parrot)
 
 	var/creamed = FALSE //to use with creampie overlays
+	var/static/list/can_ride_typecache = typecacheof(list(/mob/living/carbon/human, /mob/living/simple_animal/slime, /mob/living/simple_animal/parrot))

--- a/code/modules/mob/living/silicon/robot/robot.dm
+++ b/code/modules/mob/living/silicon/robot/robot.dm
@@ -95,7 +95,7 @@
 
 	can_buckle = TRUE
 	buckle_lying = FALSE
-	can_ride_typecache = list(/mob/living/carbon/human)
+	var/static/list/can_ride_typecache = typecacheof(/mob/living/carbon/human)
 
 /mob/living/silicon/robot/get_cell()
 	return cell

--- a/code/modules/mob/living/simple_animal/hostile/mecha_pilot.dm
+++ b/code/modules/mob/living/simple_animal/hostile/mecha_pilot.dm
@@ -41,7 +41,7 @@
 
 /mob/living/simple_animal/hostile/syndicate/mecha_pilot/no_mech/Initialize()
 	. = ..()
-	wanted_objects = typecacheof(/obj/mecha/combat, ignore_root_path=TRUE)
+	wanted_objects = typecacheof(/obj/mecha/combat, TRUE)
 
 /mob/living/simple_animal/hostile/syndicate/mecha_pilot/nanotrasen //nanotrasen are syndies! no it's just a weird path.
 	name = "Nanotrasen Mecha Pilot"
@@ -101,7 +101,7 @@
 	targets_from = src
 
 	//Find a new mecha
-	wanted_objects = typecacheof(/obj/mecha/combat, ignore_root_path=TRUE)
+	wanted_objects = typecacheof(/obj/mecha/combat, TRUE)
 	var/search_aggressiveness = 2
 	for(var/obj/mecha/combat/C in range(vision_range,src))
 		if(is_valid_mecha(C))

--- a/code/modules/mob/living/simple_animal/hostile/megafauna/colossus.dm
+++ b/code/modules/mob/living/simple_animal/hostile/megafauna/colossus.dm
@@ -663,12 +663,7 @@ Difficulty: Very Hard
 	activation_method = ACTIVATE_TOUCH
 	cooldown_add = 50
 	activation_sound = 'sound/magic/timeparadox2.ogg'
-	var/list/banned_items_typecache = list(/obj/item/storage, /obj/item/implant, /obj/item/implanter, /obj/item/disk/nuclear, /obj/item/projectile, /obj/item/spellbook)
-
-/obj/machinery/anomalous_crystal/refresher/Initialize()
-	. = ..()
-	banned_items_typecache = typecacheof(banned_items_typecache)
-
+	var/static/list/banned_items_typecache = typecacheof(list(/obj/item/storage, /obj/item/implant, /obj/item/implanter, /obj/item/disk/nuclear, /obj/item/projectile, /obj/item/spellbook))
 
 /obj/machinery/anomalous_crystal/refresher/ActivationReaction(mob/user, method)
 	if(..())

--- a/code/modules/mob/living/simple_animal/hostile/megafauna/swarmer.dm
+++ b/code/modules/mob/living/simple_animal/hostile/megafauna/swarmer.dm
@@ -172,15 +172,8 @@ GLOBAL_LIST_INIT(AISwarmerCapsByType, list(/mob/living/simple_animal/hostile/swa
 	search_objects = 1
 	attack_all_objects = TRUE //attempt to nibble everything
 	lose_patience_timeout = 150
-	var/static/list/sharedWanted = list(/turf/closed/mineral, /turf/closed/wall) //eat rocks and walls
+	var/static/list/sharedWanted = typecacheof(list(/turf/closed/mineral, /turf/closed/wall)) //eat rocks and walls
 	var/static/list/sharedIgnore = list()
-
-
-/mob/living/simple_animal/hostile/swarmer/ai/resource/Initialize()
-	. = ..()
-	sharedWanted = typecacheof(sharedWanted)
-	sharedIgnore = typecacheof(sharedIgnore)
-
 
 //This handles viable things to eat/attack
 //Place specific cases of AI derpiness here
@@ -239,16 +232,13 @@ GLOBAL_LIST_INIT(AISwarmerCapsByType, list(/mob/living/simple_animal/hostile/swa
 
 //So swarmers can learn what is and isn't food
 /mob/living/simple_animal/hostile/swarmer/ai/resource/proc/add_type_to_wanted(typepath)
-	LAZYINITLIST(sharedWanted)
 	if(!sharedWanted[typepath])// this and += is faster than |=
 		sharedWanted += typecacheof(typepath)
 
 
 /mob/living/simple_animal/hostile/swarmer/ai/resource/proc/add_type_to_ignore(typepath)
-	LAZYINITLIST(sharedIgnore)
 	if(!sharedIgnore[typepath])
 		sharedIgnore += typecacheof(typepath)
-
 
 
 //RANGED SWARMER

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -26,7 +26,6 @@
 	else
 		GLOB.living_mob_list += src
 	prepare_huds()
-	can_ride_typecache = typecacheof(can_ride_typecache)
 	for(var/v in GLOB.active_alternate_appearances)
 		if(!v)
 			continue

--- a/code/modules/mob/mob_defines.dm
+++ b/code/modules/mob/mob_defines.dm
@@ -140,7 +140,6 @@
 	var/list/observers = null	//The list of people observing this mob.
 
 	var/list/progressbars = null	//for stacking do_after bars
-	var/list/can_ride_typecache = list()
 
 	var/list/mousemove_intercept_objects
 

--- a/code/modules/procedural_mapping/mapGeneratorModules/helpers.dm
+++ b/code/modules/procedural_mapping/mapGeneratorModules/helpers.dm
@@ -32,7 +32,7 @@
 
 /datum/mapGeneratorModule/bottomLayer/massdelete/no_delete_mobs/New()
 	..()
-	ignore_typecache = typecacheof(list(/mob))
+	ignore_typecache = GLOB.typecache_mob
 
 /datum/mapGeneratorModule/bottomLayer/massdelete/leave_turfs
 	deleteturfs = FALSE
@@ -42,7 +42,7 @@
 
 /datum/mapGeneratorModule/bottomLayer/massdelete/regeneration_delete/New()
 	..()
-	ignore_typecache = typecacheof(list(/mob))
+	ignore_typecache = GLOB.typecache_mob
 
 //Only places atoms/turfs on area borders
 /datum/mapGeneratorModule/border

--- a/code/modules/surgery/organs/tongue.dm
+++ b/code/modules/surgery/organs/tongue.dm
@@ -8,10 +8,7 @@
 	var/list/languages_possible
 	var/say_mod = null
 	var/taste_sensitivity = 15 // lower is more sensitive.
-
-/obj/item/organ/tongue/Initialize(mapload)
-	. = ..()
-	languages_possible = typecacheof(list(
+	var/static/list/languages_possible_base = typecacheof(list(
 		/datum/language/common,
 		/datum/language/draconic,
 		/datum/language/codespeak,
@@ -20,6 +17,10 @@
 		/datum/language/beachbum,
 		/datum/language/ratvar
 	))
+
+/obj/item/organ/tongue/Initialize(mapload)
+	. = ..()
+	languages_possible = languages_possible_base
 
 /obj/item/organ/tongue/get_spans()
 	return list()
@@ -124,15 +125,16 @@
 	icon_state = "tonguexeno"
 	say_mod = "hisses"
 	taste_sensitivity = 10 // LIZARDS ARE ALIENS CONFIRMED
-
-/obj/item/organ/tongue/alien/Initialize(mapload)
-	. = ..()
-	languages_possible = typecacheof(list(
+	var/static/list/languages_possible_alien = typecacheof(list(
 		/datum/language/xenocommon,
 		/datum/language/common,
 		/datum/language/draconic,
 		/datum/language/ratvar,
 		/datum/language/monkey))
+
+/obj/item/organ/tongue/alien/Initialize(mapload)
+	. = ..()
+	languages_possible = languages_possible_alien
 
 /obj/item/organ/tongue/alien/TongueSpeech(var/message)
 	playsound(owner, "hiss", 25, 1, 1)


### PR DESCRIPTION
Requires #31882

Best reviewed as two commits.

The first commit is just making some typecaches which should be static static.

The second is a change to the proc

Added GLOB.typecaches_created as a performance metric
Added GLOB.master_typecache

All typecaches on only one type will go in this list (keyed by the type). Further calls to typecacheof for that type will return the cached version. Every time that happens, the "request_count" key is incremented. I'm interested to see if this is a performance boost and which typecaches are being created excessively