### PR TITLE
[s] Fixes datum antag is_banned

### DIFF
--- a/code/datums/antagonists/abductor.dm
+++ b/code/datums/antagonists/abductor.dm
@@ -1,5 +1,6 @@
 /datum/antagonist/abductor
 	name = "Abductor"
+	job_rank = ROLE_ABDUCTOR
 	var/datum/objective_team/abductor_team/team
 	var/sub_role
 	var/outfit

--- a/code/datums/antagonists/antag_datum.dm
+++ b/code/datums/antagonists/antag_datum.dm
@@ -55,17 +55,13 @@ GLOBAL_LIST_EMPTY(antagonists)
 		if(!silent)
 			greet()
 		apply_innate_effects()
-		if(is_banned(owner) && replace_banned)
+		if(is_banned(owner.current) && replace_banned)
 			replace_banned_player()
 
-/datum/antagonist/proc/is_banned(datum/mind/M)
+/datum/antagonist/proc/is_banned(mob/M)
 	if(!M)
 		return FALSE
-	if(jobban_isbanned(M,"Syndicate"))
-		return TRUE
-	if(job_rank && jobban_isbanned(M,job_rank))
-		return TRUE
-	return FALSE
+	. = (jobban_isbanned(M,"Syndicate") || (job_rank && jobban_isbanned(M,job_rank)))
 
 /datum/antagonist/proc/replace_banned_player()
 	set waitfor = FALSE

--- a/code/datums/antagonists/brother.dm
+++ b/code/datums/antagonists/brother.dm
@@ -1,5 +1,6 @@
 /datum/antagonist/brother
 	name = "Brother"
+	job_rank = ROLE_BROTHER
 	var/special_role = "blood brother"
 	var/datum/objective_team/brother_team/team
 

--- a/code/datums/antagonists/datum_traitor.dm
+++ b/code/datums/antagonists/datum_traitor.dm
@@ -1,5 +1,6 @@
 /datum/antagonist/traitor
 	name = "Traitor"
+	job_rank = ROLE_TRAITOR
 	var/should_specialise = TRUE //do we split into AI and human
 	var/base_datum_custom = ANTAG_DATUM_TRAITOR_CUSTOM //used for body transfer
 	var/ai_datum = ANTAG_DATUM_TRAITOR_AI

--- a/code/datums/antagonists/devil.dm
+++ b/code/datums/antagonists/devil.dm
@@ -85,6 +85,8 @@ GLOBAL_LIST_INIT(devil_title, list("Lord ", "Prelate ", "Count ", "Viscount ", "
 GLOBAL_LIST_INIT(devil_syllable, list("hal", "ve", "odr", "neit", "ci", "quon", "mya", "folth", "wren", "geyr", "hil", "niet", "twou", "phi", "coa"))
 GLOBAL_LIST_INIT(devil_suffix, list(" the Red", " the Soulless", " the Master", ", the Lord of all things", ", Jr."))
 /datum/antagonist/devil
+	name = "Devil"
+	job_rank = ROLE_DEVIL
 	//Don't delete upon mind destruction, otherwise soul re-selling will break.
 	delete_on_mind_deletion = FALSE
 	var/obligation
@@ -107,7 +109,6 @@ GLOBAL_LIST_INIT(devil_suffix, list(" the Red", " the Soulless", " the Master", 
 		/obj/effect/proc_holder/spell/targeted/conjure_item/violin,
 		/obj/effect/proc_holder/spell/targeted/summon_dancefloor))
 	var/ascendable = FALSE
-	name = "Devil"
 
 
 /datum/antagonist/devil/New()

--- a/code/datums/antagonists/ninja.dm
+++ b/code/datums/antagonists/ninja.dm
@@ -1,5 +1,6 @@
 /datum/antagonist/ninja
 	name = "Ninja"
+	job_rank = ROLE_NINJA
 	var/helping_station = 0
 	var/give_objectives = TRUE
 

--- a/code/modules/admin/banjob.dm
+++ b/code/modules/admin/banjob.dm
@@ -1,7 +1,7 @@
-//returns a reason if M is banned from rank, returns 0 otherwise
+//returns a reason if M is banned from rank, returns FALSE otherwise
 /proc/jobban_isbanned(mob/M, rank)
 	if(!M || !istype(M) || !M.ckey)
-		return 0
+		return FALSE
 
 	if(!M.client) //no cache. fallback to a datum/DBQuery
 		var/datum/DBQuery/query_jobban_check_ban = SSdbcore.NewQuery("SELECT reason FROM [format_table_name("ban")] WHERE ckey = '[sanitizeSQL(M.ckey)]' AND (bantype = 'JOB_PERMABAN'  OR (bantype = 'JOB_TEMPBAN' AND expiration_time > Now())) AND isnull(unbanned) AND job = '[sanitizeSQL(rank)]'")
@@ -9,17 +9,17 @@
 			return
 		if(query_jobban_check_ban.NextRow())
 			var/reason = query_jobban_check_ban.item[1]
-			return reason ? reason : 1 //we don't want to return "" if there is no ban reason, as that would evaluate to false
+			return reason ? reason : TRUE //we don't want to return "" if there is no ban reason, as that would evaluate to false
 		else
-			return 0
+			return FALSE
 
 	if(!M.client.jobbancache)
 		jobban_buildcache(M.client)
 
 	if(rank in M.client.jobbancache)
 		var/reason = M.client.jobbancache[rank]
-		return (reason) ? reason : 1 //see above for why we need to do this
-	return 0
+		return (reason) ? reason : TRUE //see above for why we need to do this
+	return FALSE
 
 /proc/jobban_buildcache(client/C)
 	if(!SSdbcore.Connect())


### PR DESCRIPTION
Datum antag is_banned is broken because mind was passed instead of mob, also some antag datums didn't have the job_rank which antag datums check against for role-specific job bans.