### PR TITLE
Heart of darkness revives non-shadow as shadowpeople

### DIFF
--- a/code/modules/mob/living/carbon/human/species_types/shadowpeople.dm
+++ b/code/modules/mob/living/carbon/human/species_types/shadowpeople.dm
@@ -1,4 +1,5 @@
 #define HEART_RESPAWN_THRESHHOLD 40
+#define HEART_SPECIAL_SHADOWIFY 2
 
 /datum/species/shadow
 	// Humans cursed to stay in the darkness, lest their life forces drain. They regain health in shadow and die in light.
@@ -111,14 +112,15 @@
 
 /obj/item/organ/heart/nightmare/Insert(mob/living/carbon/M, special = 0)
 	..()
-	blade = new/obj/item/light_eater
-	M.put_in_hands(blade)
+	if(special != HEART_SPECIAL_SHADOWIFY)
+		blade = new/obj/item/light_eater
+		M.put_in_hands(blade)
 	START_PROCESSING(SSobj, src)
 
 /obj/item/organ/heart/nightmare/Remove(mob/living/carbon/M, special = 0)
 	STOP_PROCESSING(SSobj, src)
 	respawn_progress = 0
-	if(blade)
+	if(blade && special != HEART_SPECIAL_SHADOWIFY)
 		QDEL_NULL(blade)
 		M.visible_message("<span class='warning'>\The [blade] disintegrates!</span>")
 	..()
@@ -141,6 +143,13 @@
 			playsound(owner,'sound/effects/singlebeat.ogg',40,1)
 	if(respawn_progress >= HEART_RESPAWN_THRESHHOLD)
 		owner.revive(full_heal = TRUE)
+		if(!(owner.dna.species.id == "shadow" || owner.dna.species.id == "nightmare"))
+			var/mob/living/carbon/old_owner = owner
+			Remove(owner, HEART_SPECIAL_SHADOWIFY)
+			old_owner.set_species(/datum/species/shadow)
+			Insert(old_owner, HEART_SPECIAL_SHADOWIFY)
+			to_chat(owner, "<span class='userdanger'>You feel the shadows invade your skin, leaping into the center of your chest! You're alive!</span>")
+			SEND_SOUND(owner, sound('sound/effects/ghost.ogg'))
 		owner.visible_message("<span class='warning'>[owner] staggers to their feet!</span>")
 		playsound(owner, 'sound/hallucinations/far_noise.ogg', 50, 1)
 		respawn_progress = 0
@@ -195,4 +204,5 @@
 		O.burn()
 	playsound(src, 'sound/items/welder.ogg', 50, 1)
 
+#undef HEART_SPECIAL_SHADOWIFY
 #undef HEART_RESPAWN_THRESHHOLD


### PR DESCRIPTION
:cl: JJRcop
add: The heart of darkness revives you as a shadowperson if you aren't one already.
/:cl:
I changed the heart of darkness to revive you as a shadowperson if you aren't already a shadowperson or nightmare. It doesn't revive you as a nightmare, just a shadowperson, so you don't get shadow walk, and you're not an antag.

This only triggers when you die and are revived by the heart. Eating the heart (or implanting it) still functions as before, just giving you the light eater.

@KorPhaeron 