### PR TITLE
Blob fixes

### DIFF
--- a/code/game/gamemodes/blob/blobs/core.dm
+++ b/code/game/gamemodes/blob/blobs/core.dm
@@ -23,7 +23,11 @@
 	if(overmind)
 		update_icon()
 	point_rate = new_rate
+	addtimer(CALLBACK(src, .proc/generate_announcement), 1800)
 	. = ..()
+
+/obj/structure/blob/core/proc/generate_announcement()
+	priority_announce("Confirmed outbreak of level 5 biohazard aboard [station_name()]. All personnel must contain the outbreak.", "Biohazard Alert", 'sound/ai/outbreak5.ogg')
 
 /obj/structure/blob/core/scannerreport()
 	return "Directs the blob's expansion, gradually expands, and sustains nearby blob spores and blobbernauts."

--- a/code/game/gamemodes/blob/overmind.dm
+++ b/code/game/gamemodes/blob/overmind.dm
@@ -72,11 +72,13 @@ GLOBAL_LIST_EMPTY(blob_nodes)
 		set_security_level("delta")
 		max_blob_points = INFINITY
 		blob_points = INFINITY
-		addtimer(CALLBACK(src, .proc/victory), 660)
+		addtimer(CALLBACK(src, .proc/victory), 450)
 	..()
 
 
 /mob/camera/blob/proc/victory()
+	sound_to_playing_players('sound/machines/alarm.ogg')
+	sleep(100)
 	for(var/mob/living/L in GLOB.mob_list)
 		var/turf/T = get_turf(L)
 		if(!T || !(T.z in GLOB.station_z_levels))

--- a/code/modules/admin/player_panel.dm
+++ b/code/modules/admin/player_panel.dm
@@ -593,7 +593,8 @@
 		var/list/blob_minds = list()
 		for(var/mob/camera/blob/B in GLOB.mob_list)
 			blob_minds |= B.mind
-
+			if(blob_minds.len)
+				dat += "<br><table cellspacing=5><tr><td><B>Blob</B></td><td></td><td></td></tr>"
 			for(var/datum/mind/blob in blob_minds)
 				var/mob/camera/blob/M = blob.current
 				if(M)

--- a/code/modules/events/blob.dm
+++ b/code/modules/events/blob.dm
@@ -9,7 +9,11 @@
 	gamemode_blacklist = list("blob") //Just in case a blob survives that long
 
 /datum/round_event/ghost_role/blob
+	announceWhen	= -1
 	role_name = "blob overmind"
+
+/datum/round_event/ghost_role/blob/announce()
+	priority_announce("Confirmed outbreak of level 5 biohazard aboard [station_name()]. All personnel must contain the outbreak.", "Biohazard Alert", 'sound/ai/outbreak5.ogg')
 
 /datum/round_event/ghost_role/blob/spawn_role()
 	if(!GLOB.blobstart.len)

--- a/code/modules/events/blob.dm
+++ b/code/modules/events/blob.dm
@@ -9,11 +9,7 @@
 	gamemode_blacklist = list("blob") //Just in case a blob survives that long
 
 /datum/round_event/ghost_role/blob
-	announceWhen	= 12
 	role_name = "blob overmind"
-
-/datum/round_event/ghost_role/blob/announce()
-	priority_announce("Confirmed outbreak of level 5 biohazard aboard [station_name()]. All personnel must contain the outbreak.", "Biohazard Alert", 'sound/ai/outbreak5.ogg')
 
 /datum/round_event/ghost_role/blob/spawn_role()
 	if(!GLOB.blobstart.len)

--- a/code/modules/mob/transform_procs.dm
+++ b/code/modules/mob/transform_procs.dm
@@ -464,10 +464,7 @@
 
 /mob/proc/become_overmind(starting_points = 60)
 	var/mob/camera/blob/B = new /mob/camera/blob(loc, starting_points)
-	if(mind)
-		mind.transfer_to(B)
-	else
-		B.key = key
+	B.key = key
 	. = B
 	qdel(src)
 


### PR DESCRIPTION
Fixed the antag panel missing its blob header Fixes https://github.com/tgstation/tgstation/issues/31917

Fixed the report being sent too early for event blobs Fixes https://github.com/tgstation/tgstation/issues/31916

Fixes assigning players to blob 

Fixes https://github.com/tgstation/tgstation/issues/31940

Fixes https://github.com/tgstation/tgstation/issues/31938

Added an alarm that plays just before the round ends during critical mass. Same alarm that plays before a nuke/malf victory

Also made the time spent in critical mass a little shorter in general