### PR TITLE
Tweaks to GC_FAILURE_HARD_LOOKUP

### DIFF
--- a/code/_compile_options.dm
+++ b/code/_compile_options.dm
@@ -4,12 +4,19 @@
 								//uncommented, but not visible in the release version)
 
 #ifdef TESTING
-//#define GC_FAILURE_HARD_LOOKUP	//makes paths that fail to GC call find_references before del'ing.
-									//Also allows for recursive reference searching of datums.
-									//Sets world.loop_checks to false and prevents find references from sleeping
+#define GC_FAILURE_HARD_LOOKUP	//makes paths that fail to GC call find_references before del'ing.
+								//Sets world.loop_checks to false and prevents find references from sleeping
+
+//#define GC_FAILURE_HARDER_LOOKUP	//Allows for recursive reference searching of datums.
+									//Very convenient for triggering a stack overflow crash every time.
+									//See GC_LOOKUP_MAX_ITERATION_DEPTH below
 
 //#define VISUALIZE_ACTIVE_TURFS	//Highlights atmos active turfs in green
 #endif
+
+#define GC_LOOKUP_MAX_ITERATION_DEPTH 64 //Maximum iteration depth for DoSearchVar used for finding references to things. Adjust this to prevent stack overflows.
+
+#define GC_LOOKUP_RESTRICT_ATOM_Z 2 //Restrict GC find_references lookups to this Z level, for atoms
 
 #define PRELOAD_RSC	1			/*set to:
 								0 to allow using external resources or on-demand behaviour;

--- a/code/_compile_options.dm
+++ b/code/_compile_options.dm
@@ -5,13 +5,13 @@
 
 #ifdef TESTING
 //#define GC_FAILURE_HARD_LOOKUP	//makes paths that fail to GC call find_references before del'ing.
-								//Sets world.loop_checks to false and prevents find references from sleeping
+
 
 //#define GC_FAILURE_HARDER_LOOKUP	//Allows for recursive reference searching of datums.
 									//Very convenient for triggering a stack overflow crash every time.
 									//See GC_LOOKUP_MAX_ITERATION_DEPTH below
 
-#define GC_FAILURE_LOOKUP_CHECK_TICK  //CHECK_TICK in DoSearchVar. Undef this for a big speed boost, allowing you to finish in mere 10 hours.
+#define GC_FAILURE_LOOKUP_CHECK_TICK  //CHECK_TICK in DoSearchVar. Undef this to prevent find references from sleeping
 
 //#define VISUALIZE_ACTIVE_TURFS	//Highlights atmos active turfs in green
 

--- a/code/_compile_options.dm
+++ b/code/_compile_options.dm
@@ -15,12 +15,13 @@
 
 //#define VISUALIZE_ACTIVE_TURFS	//Highlights atmos active turfs in green
 
-#define GC_LOOKUP_MAX_ITERATION_DEPTH 64 //Maximum iteration depth for DoSearchVar used for finding references to things. Adjust this to prevent stack overflows.
+
 
 //#define GC_LOOKUP_RESTRICT_ATOM_Z 2 //Restrict GC find_references lookups to this Z level, for atoms
 
 #endif
 
+#define GC_LOOKUP_MAX_ITERATION_DEPTH 64 //Maximum iteration depth for DoSearchVar used for finding references to things. Adjust this to prevent stack overflows.
 
 #define PRELOAD_RSC	1			/*set to:
 								0 to allow using external resources or on-demand behaviour;

--- a/code/_compile_options.dm
+++ b/code/_compile_options.dm
@@ -4,7 +4,7 @@
 								//uncommented, but not visible in the release version)
 
 #ifdef TESTING
-#define GC_FAILURE_HARD_LOOKUP	//makes paths that fail to GC call find_references before del'ing.
+//#define GC_FAILURE_HARD_LOOKUP	//makes paths that fail to GC call find_references before del'ing.
 								//Sets world.loop_checks to false and prevents find references from sleeping
 
 //#define GC_FAILURE_HARDER_LOOKUP	//Allows for recursive reference searching of datums.

--- a/code/_compile_options.dm
+++ b/code/_compile_options.dm
@@ -16,7 +16,7 @@
 
 #define GC_LOOKUP_MAX_ITERATION_DEPTH 64 //Maximum iteration depth for DoSearchVar used for finding references to things. Adjust this to prevent stack overflows.
 
-#define GC_LOOKUP_RESTRICT_ATOM_Z 2 //Restrict GC find_references lookups to this Z level, for atoms
+//#define GC_LOOKUP_RESTRICT_ATOM_Z 2 //Restrict GC find_references lookups to this Z level, for atoms
 
 #define PRELOAD_RSC	1			/*set to:
 								0 to allow using external resources or on-demand behaviour;

--- a/code/_compile_options.dm
+++ b/code/_compile_options.dm
@@ -11,12 +11,16 @@
 									//Very convenient for triggering a stack overflow crash every time.
 									//See GC_LOOKUP_MAX_ITERATION_DEPTH below
 
+#define GC_FAILURE_LOOKUP_CHECK_TICK  //CHECK_TICK in DoSearchVar. Undef this for a big speed boost, allowing you to finish in mere 10 hours.
+
 //#define VISUALIZE_ACTIVE_TURFS	//Highlights atmos active turfs in green
-#endif
 
 #define GC_LOOKUP_MAX_ITERATION_DEPTH 64 //Maximum iteration depth for DoSearchVar used for finding references to things. Adjust this to prevent stack overflows.
 
 //#define GC_LOOKUP_RESTRICT_ATOM_Z 2 //Restrict GC find_references lookups to this Z level, for atoms
+
+#endif
+
 
 #define PRELOAD_RSC	1			/*set to:
 								0 to allow using external resources or on-demand behaviour;

--- a/code/controllers/subsystem/garbage.dm
+++ b/code/controllers/subsystem/garbage.dm
@@ -363,13 +363,8 @@ SUBSYSTEM_DEF(garbage)
 	testing("Beginning search for references to a [type].")
 	last_find_references = world.time
 	DoSearchVar(GLOB)
-	var/counter = 0
-	var/maxlen = length(world.contents)
 	for(var/datum/thing in world)
-		if (counter % 100 == 0)
-			testing("World search progress: [counter] / [maxlen]")
 		DoSearchVar(thing, "WorldRef: [thing]")
-		counter++
 	testing("Completed search for references to a [type].")
 	if(usr && usr.client)
 		usr.client.running_find_references = null
@@ -391,7 +386,6 @@ SUBSYSTEM_DEF(garbage)
 
 /datum/proc/DoSearchVar(X, Xname, TTL = GC_LOOKUP_MAX_ITERATION_DEPTH)
 	if (TTL <= 0)
-		testing("TTL Exceeded on [X], [Xname]")
 		return
 	if(usr && usr.client && !usr.client.running_find_references)
 		return
@@ -400,7 +394,7 @@ SUBSYSTEM_DEF(garbage)
 #ifdef GC_LOOKUP_RESTRICT_ATOM_Z
 		if (istype(D, /atom))
 			var/atom/A = D
-			if(!A.loc || A.loc.z != 2)
+			if(!A.loc || A.loc.z != GC_LOOKUP_RESTRICT_ATOM_Z)
 				return
 #endif
 		if(D.last_find_references == last_find_references)
@@ -426,7 +420,8 @@ SUBSYSTEM_DEF(garbage)
 #ifdef GC_FAILURE_HARDER_LOOKUP
 		for(var/I in X)
 			DoSearchVar(I, Xname + ": list", TTL-1)
-#else
+#endif
+#ifdef GC_FAILURE_LOOKUP_CHECK_TICK
 	CHECK_TICK
 #endif
 


### PR DESCRIPTION
Fixes #31910

Doesn't make it useful yet, since it takes days to run even with the simplest of settings. But at least it doesn't crash anymore.

[Changelogs]: 

:cl: Naksu
code: find_references() now technically works, however takes days to run. Doesn't crash though.
/:cl:

