### PR TITLE
switch smoke machine general logging from admin to game log

### DIFF
--- a/code/modules/reagents/chemistry/machinery/smoke_machine.dm
+++ b/code/modules/reagents/chemistry/machinery/smoke_machine.dm
@@ -117,7 +117,7 @@
 			on = !on
 			if(on)
 				message_admins("[key_name_admin(usr)] activated a smoke machine that contains [english_list(reagents.reagent_list)] at [ADMIN_COORDJMP(src)].")
-				log_admin("[key_name(usr)] activated a smoke machine that contains [english_list(reagents.reagent_list)] at [COORD(src)].")
+				log_game("[key_name(usr)] activated a smoke machine that contains [english_list(reagents.reagent_list)] at [COORD(src)].")
 				add_logs(usr, src, "has activated [src] which contains [english_list(reagents.reagent_list)].")
 		if("goScreen")
 			screen = params["screen"]


### PR DESCRIPTION
I should have caught this when I added the `message_admins()` call, but this was logging to the admin log instead of the game log, where it should be