### PR TITLE
It's a time to stop warning about paper bins eating pens

### DIFF
--- a/code/modules/paperwork/paperbin.dm
+++ b/code/modules/paperwork/paperbin.dm
@@ -25,10 +25,6 @@
 		P.loc = src
 		bin_pen = P
 		update_icon()
-		var/static/warned = FALSE
-		if(P.type == /obj/item/pen && !warned)
-			warning("one or more paperbins ate a pen duing initialize()")
-			warned = TRUE
 
 /obj/item/paper_bin/fire_act(exposed_temperature, exposed_volume)
 	if(!total_paper)


### PR DESCRIPTION
Do we actually want mappers to start varediting paper bins to contain a pen and have a custom icon and refer to it in bin_pen?

[Changelogs]: 
:cl: Naksu
server: Paper bins no longer let server admins know that pens were eaten.
/:cl:

