### PR TITLE
Fixes some chameleon projector bugs

### DIFF
--- a/code/game/objects/items/devices/chameleonproj.dm
+++ b/code/game/objects/items/devices/chameleonproj.dm
@@ -29,7 +29,7 @@
 	disrupt()
 
 /obj/item/device/chameleon/attack_self(mob/user)
-	if(!isTurf(user.loc))
+	if(!isturf(user.loc))
 		to_chat(user, "<span class='warning'>You must be standing on a regular floor to use this.</span>")
 		return
 	toggle()

--- a/code/game/objects/items/devices/chameleonproj.dm
+++ b/code/game/objects/items/devices/chameleonproj.dm
@@ -28,7 +28,10 @@
 	..()
 	disrupt()
 
-/obj/item/device/chameleon/attack_self()
+/obj/item/device/chameleon/attack_self(mob/user)
+	if(!isTurf(user.loc))
+		to_chat(user, "<span class='warning'>You must be standing on a regular floor to use this.</span>")
+		return
 	toggle()
 
 /obj/item/device/chameleon/afterattack(atom/target, mob/user , proximity)


### PR DESCRIPTION
Fixes #20185
Fixes #31833

🆑
fix: Chameleon projectors can no longer be used while inside of closets, sleepers, etc
/:cl:

Basically just does what I suggested here: https://github.com/tgstation/tgstation/issues/20185#issuecomment-299394143