### PR TITLE
Ratvar summoning now ends the round/triggers mass proselytize 

### DIFF
--- a/code/game/gamemodes/clock_cult/clock_structures/ark_of_the_clockwork_justicar.dm
+++ b/code/game/gamemodes/clock_cult/clock_structures/ark_of_the_clockwork_justicar.dm
@@ -253,6 +253,7 @@
 					else
 						dist = FALSE
 					T.ratvar_act(dist)
+					CHECK_TICK
 
 
 

--- a/code/game/gamemodes/clock_cult/clock_structures/ark_of_the_clockwork_justicar.dm
+++ b/code/game/gamemodes/clock_cult/clock_structures/ark_of_the_clockwork_justicar.dm
@@ -235,13 +235,11 @@
 				sleep(125)
 				make_glow()
 				animate(glow, transform = matrix() * 3, alpha = 0, time = 5)
-				var/turf/startpoint = get_turf(src)
 				QDEL_IN(src, 3)
 				sleep(3)
 				GLOB.clockwork_gateway_activated = TRUE
-				var/obj/structure/destructible/clockwork/massive/ratvar/R = new(startpoint)
 				var/turf/T =  locate(round(world.maxx * 0.5, 1), round(world.maxy * 0.5, 1), ZLEVEL_STATION_PRIMARY) //approximate center of the station
-				R.forceMove(T)
+				var/obj/structure/destructible/clockwork/massive/ratvar/R = new(T)
 				SSticker.force_ending = TRUE
 				var/x0 = T.x
 				var/y0 = T.y

--- a/code/game/gamemodes/clock_cult/clock_structures/ark_of_the_clockwork_justicar.dm
+++ b/code/game/gamemodes/clock_cult/clock_structures/ark_of_the_clockwork_justicar.dm
@@ -239,7 +239,7 @@
 				sleep(3)
 				GLOB.clockwork_gateway_activated = TRUE
 				var/turf/T =  locate(round(world.maxx * 0.5, 1), round(world.maxy * 0.5, 1), ZLEVEL_STATION_PRIMARY) //approximate center of the station
-				var/obj/structure/destructible/clockwork/massive/ratvar/R = new(T)
+				new /obj/structure/destructible/clockwork/massive/ratvar(T)
 				SSticker.force_ending = TRUE
 				var/x0 = T.x
 				var/y0 = T.y

--- a/code/game/gamemodes/clock_cult/clock_structures/ark_of_the_clockwork_justicar.dm
+++ b/code/game/gamemodes/clock_cult/clock_structures/ark_of_the_clockwork_justicar.dm
@@ -245,7 +245,7 @@
 				SSticker.force_ending = TRUE
 				var/x0 = T.x
 				var/y0 = T.y
-				for(var/I in spiral_range_turfs(255, startpoint))
+				for(var/I in spiral_range_turfs(255, startpoint, tick_checked = TRUE))
 					var/turf/T2 = I
 					if(!T2)
 						continue
@@ -255,7 +255,6 @@
 					else
 						dist = FALSE
 					T.ratvar_act(dist)
-					CHECK_TICK
 
 
 

--- a/code/game/gamemodes/clock_cult/clock_structures/ark_of_the_clockwork_justicar.dm
+++ b/code/game/gamemodes/clock_cult/clock_structures/ark_of_the_clockwork_justicar.dm
@@ -242,6 +242,20 @@
 				var/obj/structure/destructible/clockwork/massive/ratvar/R = new(startpoint)
 				var/turf/T =  locate(round(world.maxx * 0.5, 1), round(world.maxy * 0.5, 1), ZLEVEL_STATION_PRIMARY) //approximate center of the station
 				R.forceMove(T)
+				SSticker.force_ending = TRUE
+				var/x0 = T.x
+				var/y0 = T.y
+				for(var/I in spiral_range_turfs(255, startpoint))
+					var/turf/T2 = I
+					if(!T2)
+						continue
+					var/dist = cheap_hypotenuse(T2.x, T2.y, x0, y0)
+					if(dist < 100)
+						dist = TRUE
+					else
+						dist = FALSE
+					T.ratvar_act(dist)
+					CHECK_TICK
 
 
 

--- a/code/game/gamemodes/clock_cult/clock_structures/ark_of_the_clockwork_justicar.dm
+++ b/code/game/gamemodes/clock_cult/clock_structures/ark_of_the_clockwork_justicar.dm
@@ -245,7 +245,7 @@
 				SSticker.force_ending = TRUE
 				var/x0 = T.x
 				var/y0 = T.y
-				for(var/I in spiral_range_turfs(255, startpoint, tick_checked = TRUE))
+				for(var/I in spiral_range_turfs(255, T, tick_checked = TRUE))
 					var/turf/T2 = I
 					if(!T2)
 						continue

--- a/code/modules/mob/living/living_defense.dm
+++ b/code/modules/mob/living/living_defense.dm
@@ -340,9 +340,8 @@
 		return
 	if(stat != DEAD && !is_servant_of_ratvar(src))
 		to_chat(src, "<span class='userdanger'>A blinding light boils you alive! <i>Run!</i></span>")
-		adjustFireLoss(35)
 		if(src)
-			adjust_fire_stacks(1)
+			adjust_fire_stacks(20)
 			IgniteMob()
 		return FALSE
 

--- a/code/modules/mob/living/living_defense.dm
+++ b/code/modules/mob/living/living_defense.dm
@@ -338,18 +338,13 @@
 /mob/living/ratvar_act()
 	if(status_flags & GODMODE)
 		return
-
 	if(stat != DEAD && !is_servant_of_ratvar(src))
-		for(var/obj/item/implant/mindshield/M in implants)
-			qdel(M)
-		if(!add_servant_of_ratvar(src))
-			to_chat(src, "<span class='userdanger'>A blinding light boils you alive! <i>Run!</i></span>")
-			adjustFireLoss(35)
-			if(src)
-				adjust_fire_stacks(1)
-				IgniteMob()
-			return FALSE
-	return TRUE
+		to_chat(src, "<span class='userdanger'>A blinding light boils you alive! <i>Run!</i></span>")
+		adjustFireLoss(35)
+		if(src)
+			adjust_fire_stacks(1)
+			IgniteMob()
+		return FALSE
 
 
 //called when the mob receives a bright flash

--- a/code/modules/mob/living/living_defense.dm
+++ b/code/modules/mob/living/living_defense.dm
@@ -340,9 +340,8 @@
 		return
 	if(stat != DEAD && !is_servant_of_ratvar(src))
 		to_chat(src, "<span class='userdanger'>A blinding light boils you alive! <i>Run!</i></span>")
-		if(src)
-			adjust_fire_stacks(20)
-			IgniteMob()
+		adjust_fire_stacks(20)
+		IgniteMob()
 		return FALSE
 
 


### PR DESCRIPTION
Mass Proselytize (the giant spiral of turf conversion) was always my favourite thing about old clock cult so I made it trigger when Ratvar arrives.

Ratvar arriving now ends the round because 90 seconds of postgame scarab party is preferable in my mind to 6 and half minutes of it

Ratvar act on mobs now just sets them on fire rather than trying to convert them. I'm not really attached to this change, I just think its weird to see all the people who lost the siege in the list of cultists/taking the same victory lap