### PR TITLE
Removes mob.lastattacked and replaces lastattacker with a string

### DIFF
--- a/code/_onclick/item_attack.dm
+++ b/code/_onclick/item_attack.dm
@@ -44,8 +44,8 @@
 	else if(hitsound)
 		playsound(loc, hitsound, get_clamped_volume(), 1, -1)
 
-	user.lastattacked = M
-	M.lastattacker = user
+	M.lastattacker = user.real_name
+	M.lastattackerckey = user.ckey
 
 	user.do_attack_animation(M)
 	M.attacked_by(src, user)

--- a/code/controllers/subsystem/blackbox.dm
+++ b/code/controllers/subsystem/blackbox.dm
@@ -191,12 +191,8 @@ SUBSYSTEM_DEF(blackbox)
 	var/sqljob = sanitizeSQL(L.mind.assigned_role)
 	var/sqlspecial = sanitizeSQL(L.mind.special_role)
 	var/sqlpod = sanitizeSQL(placeofdeath.name)
-	var/laname
-	var/lakey
-	if(L.lastattacker && ismob(L.lastattacker))
-		var/mob/LA = L.lastattacker
-		laname = sanitizeSQL(LA.real_name)
-		lakey = sanitizeSQL(LA.key)
+	var/laname = sanitizeSQL(L.lastattacker)
+	var/lakey = sanitizeSQL(L.lastattackerckey)
 	var/sqlbrute = sanitizeSQL(L.getBruteLoss())
 	var/sqlfire = sanitizeSQL(L.getFireLoss())
 	var/sqlbrain = sanitizeSQL(L.getBrainLoss())

--- a/code/game/gamemodes/miniantags/abduction/abduction_gear.dm
+++ b/code/game/gamemodes/miniantags/abduction/abduction_gear.dm
@@ -417,8 +417,9 @@ Congratulations! You are now trained for invasive xenobiology research!"}
 	toggle(user)
 
 /obj/item/abductor_baton/proc/StunAttack(mob/living/L,mob/living/user)
-	user.lastattacked = L
-	L.lastattacker = user
+
+	L.lastattacker = user.real_name
+	L.lastattackerckey = user.ckey
 
 	L.Knockdown(140)
 	L.apply_effect(STUTTER, 7)

--- a/code/game/objects/items/stunbaton.dm
+++ b/code/game/objects/items/stunbaton.dm
@@ -157,8 +157,8 @@
 	L.Knockdown(stunforce)
 	L.apply_effect(STUTTER, stunforce)
 	if(user)
-		user.lastattacked = L
-		L.lastattacker = user
+		L.lastattacker = user.real_name
+		L.lastattackerckey = user.ckey
 		L.visible_message("<span class='danger'>[user] has stunned [L] with [src]!</span>", \
 								"<span class='userdanger'>[user] has stunned you with [src]!</span>")
 		add_logs(user, L, "stunned")

--- a/code/game/objects/structures/manned_turret.dm
+++ b/code/game/objects/structures/manned_turret.dm
@@ -201,8 +201,8 @@
 	O.attacked_by(src, user)
 
 /obj/item/gun_control/attack(mob/living/M, mob/living/user)
-	user.lastattacked = M
-	M.lastattacker = user
+	M.lastattacker = user.real_name
+	M.lastattackerckey = user.ckey
 	M.attacked_by(src, user)
 	add_fingerprint(user)
 

--- a/code/modules/mob/mob_defines.dm
+++ b/code/modules/mob/mob_defines.dm
@@ -27,7 +27,7 @@
 	var/damageoverlaytemp = 0
 	var/computer_id = null
 	var/lastattacker = null
-	var/lastattacked = null
+	var/lastattackerckey = null
 	var/list/logging = list(INDIVIDUAL_ATTACK_LOG, INDIVIDUAL_SAY_LOG, INDIVIDUAL_EMOTE_LOG, INDIVIDUAL_OOC_LOG)
 	var/obj/machinery/machine = null
 	var/other_mobs = null


### PR DESCRIPTION
We shouldn't leave mob references dangling just so we can gamble on one of them still existing at roundend for stats generation. Lastattacked isn't used at all.

[Changelogs]: # (Your PR should contain a detailed changelog of notable changes, titled and categorized appropriately. This includes, new features, sprites, sounds, balance changes, admin tools, map edits, removals, big refactors, config changes, hosting changes and important fixes. An example changelog has been provided below for you to edit. If you need additional help, read https://github.com/tgstation/tgstation/wiki/Changelogs)

:cl: Naksu
code: Removed dangling mob references to last attacker/attacked
/:cl:

[why]: 
These cause mob harddels and all the death reporting subsystem needs is a name and a ckey.