### PR TITLE
Fixes silicon mob contents becoming contaminated

### DIFF
--- a/code/__HELPERS/radiation.dm
+++ b/code/__HELPERS/radiation.dm
@@ -11,7 +11,14 @@
 		return
 	
 	for(var/i in 1 to location.contents.len)
-		var/static/list/ignored_things = typecacheof(list(/mob/dead, /obj/effect, /obj/docking_port, /turf, /atom/movable/lighting_object, /mob/camera))
+		var/static/list/ignored_things = typecacheof(list( // These types will never have radiation applied to them or be looked inside of
+			/mob/dead,
+			/mob/camera,
+			/obj/effect,
+			/obj/docking_port,
+			/atom/movable/lighting_object
+			))
+
 		var/atom/thing = location.contents[i]
 		if(ignored_things[thing.type])
 			continue

--- a/code/datums/radiation_wave.dm
+++ b/code/datums/radiation_wave.dm
@@ -89,7 +89,12 @@
 			continue
 		thing.rad_act(strength)
 
-		var/static/list/blacklisted = typecacheof(list(/turf, /mob, /obj/structure/cable, /obj/machinery/atmospherics))
+		var/static/list/blacklisted = typecacheof(list( //These types will never be contaminated
+			/turf,
+			/mob,
+			/obj/structure/cable,
+			/obj/machinery/atmospherics
+			))
 		if(!can_contaminate || blacklisted[thing.type])
 			continue
 		if(prob((strength-RAD_MINIMUM_CONTAMINATION) * RAD_CONTAMINATION_CHANCE_COEFFICIENT * min(1/(steps*range_modifier), 1))) // Only stronk rads get to have little baby rads

--- a/code/modules/mob/living/silicon/silicon.dm
+++ b/code/modules/mob/living/silicon/silicon.dm
@@ -47,6 +47,10 @@
 	diag_hud_set_status()
 	diag_hud_set_health()
 
+/mob/living/silicon/ComponentInitialize()
+	. = ..()
+	AddComponent(/datum/component/rad_insulation, RAD_NO_INSULATION, TRUE, TRUE)
+
 /mob/living/silicon/med_hud_set_health()
 	return //we use a different hud
 


### PR DESCRIPTION
:cl: ninjanomnom
fix: Contents of silicon mobs are no longer considered for targets of radiation. This blocks them from being contaminated.
/:cl:

fixes #31983