### PR TITLE
Small security QoL and consistency tweaks.

### DIFF
--- a/_maps/map_files/BoxStation/BoxStation.dmm
+++ b/_maps/map_files/BoxStation/BoxStation.dmm
@@ -878,6 +878,7 @@
 /area/security/main)
 "acq" = (
 /obj/effect/landmark/secequipment,
+/obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel/showroomfloor,
 /area/security/main)
 "acr" = (
@@ -59263,7 +59264,7 @@
 	name = "dust"
 	},
 /obj/effect/decal/remains/human{
-	desc = "They look like human remains, and have clearly been gnawed at.";
+	desc = "They look like human remains, and have clearly been gnawed at."
 	},
 /obj/item/gun/energy/laser/retro,
 /turf/open/floor/mineral/titanium/blue,
@@ -59339,7 +59340,7 @@
 	name = "dust"
 	},
 /obj/effect/decal/remains/human{
-	desc = "They look like human remains, and have clearly been gnawed at.";
+	desc = "They look like human remains, and have clearly been gnawed at."
 	},
 /turf/open/floor/mineral/titanium/blue,
 /area/shuttle/abandoned)
@@ -59418,7 +59419,7 @@
 	},
 /obj/item/soap/nanotrasen,
 /obj/effect/decal/remains/human{
-	desc = "They look like human remains, and have clearly been gnawed at.";
+	desc = "They look like human remains, and have clearly been gnawed at."
 	},
 /obj/effect/decal/cleanable/blood/gibs/old,
 /turf/open/floor/mineral/titanium,
@@ -59980,7 +59981,7 @@
 	name = "dust"
 	},
 /obj/effect/decal/remains/human{
-	desc = "They look like human remains, and have clearly been gnawed at.";
+	desc = "They look like human remains, and have clearly been gnawed at."
 	},
 /turf/open/floor/mineral/titanium,
 /area/shuttle/abandoned)
@@ -60147,7 +60148,7 @@
 	name = "\improper damaged CentCom hat"
 	},
 /obj/effect/decal/remains/human{
-	desc = "They look like human remains, and have clearly been gnawed at.";
+	desc = "They look like human remains, and have clearly been gnawed at."
 	},
 /turf/open/floor/mineral/titanium/blue,
 /area/shuttle/abandoned)
@@ -60529,7 +60530,7 @@
 	name = "dust"
 	},
 /obj/effect/decal/remains/xeno{
-	desc = "A pile of remains that look vaguely humanoid. The skull is abnormally elongated, and there are burns through some of the other bones.";
+	desc = "A pile of remains that look vaguely humanoid. The skull is abnormally elongated, and there are burns through some of the other bones."
 	},
 /turf/open/floor/mineral/titanium/blue,
 /area/shuttle/abandoned)

--- a/_maps/map_files/BoxStation/BoxStation.dmm
+++ b/_maps/map_files/BoxStation/BoxStation.dmm
@@ -661,6 +661,7 @@
 /area/security/main)
 "abP" = (
 /obj/structure/closet/secure_closet/security/sec,
+/obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel/showroomfloor,
 /area/security/main)
 "abQ" = (
@@ -680,6 +681,7 @@
 /obj/machinery/light{
 	dir = 4
 	},
+/obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel/showroomfloor,
 /area/security/main)
 "abS" = (

--- a/_maps/map_files/Deltastation/DeltaStation2.dmm
+++ b/_maps/map_files/Deltastation/DeltaStation2.dmm
@@ -45863,6 +45863,12 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/effect/turf_decal/bot,
 /obj/item/gun/ballistic/shotgun/riot,
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/structure/window/reinforced{
+	dir = 1
+	},
 /turf/open/floor/plasteel,
 /area/ai_monitored/security/armory)
 "bNh" = (
@@ -46823,6 +46829,9 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/effect/turf_decal/bot,
+/obj/structure/window/reinforced{
+	dir = 4
+	},
 /turf/open/floor/plasteel,
 /area/ai_monitored/security/armory)
 "bOX" = (
@@ -48142,6 +48151,9 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/effect/turf_decal/bot,
+/obj/structure/window/reinforced{
+	dir = 4
+	},
 /turf/open/floor/plasteel,
 /area/ai_monitored/security/armory)
 "bRd" = (
@@ -49583,6 +49595,10 @@
 	dir = 9
 	},
 /obj/effect/turf_decal/bot,
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/structure/window/reinforced,
 /turf/open/floor/plasteel,
 /area/ai_monitored/security/armory)
 "bTv" = (
@@ -134469,7 +134485,7 @@ aaa
 aiW
 ajL
 ajL
-alP
+akQ
 ajL
 YGJ
 eqb
@@ -136526,7 +136542,7 @@ aiW
 ajL
 akR
 ajL
-alP
+akQ
 ajL
 eps
 epu

--- a/_maps/map_files/Deltastation/DeltaStation2.dmm
+++ b/_maps/map_files/Deltastation/DeltaStation2.dmm
@@ -31714,6 +31714,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
+/obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel/vault{
 	dir = 5
 	},
@@ -32842,6 +32843,7 @@
 /area/security/main)
 "bpz" = (
 /obj/effect/landmark/secequipment,
+/obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel/vault{
 	dir = 5
 	},
@@ -33560,6 +33562,7 @@
 /obj/machinery/light/small{
 	dir = 4
 	},
+/obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel/vault{
 	dir = 5
 	},
@@ -34199,6 +34202,7 @@
 	pixel_x = 32
 	},
 /obj/effect/landmark/secequipment,
+/obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel/vault{
 	dir = 5
 	},

--- a/_maps/map_files/Deltastation/DeltaStation2.dmm
+++ b/_maps/map_files/Deltastation/DeltaStation2.dmm
@@ -53584,12 +53584,14 @@
 /area/security/brig)
 "caT" = (
 /obj/structure/closet/secure_closet/security/sec,
+/obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel/red/side{
 	dir = 5
 	},
 /area/security/brig)
 "caU" = (
 /obj/structure/closet/secure_closet/security/sec,
+/obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel/red,
 /area/security/brig)
 "caV" = (
@@ -55344,6 +55346,7 @@
 /area/security/brig)
 "cei" = (
 /obj/structure/closet/secure_closet/security/sec,
+/obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel/red/side{
 	dir = 6
 	},
@@ -55358,6 +55361,7 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
+/obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel/red/side{
 	dir = 10
 	},
@@ -55405,6 +55409,7 @@
 /obj/machinery/ai_status_display{
 	pixel_y = -32
 	},
+/obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel/red/side{
 	dir = 6
 	},

--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -4784,6 +4784,7 @@
 	pixel_y = 30
 	},
 /obj/structure/closet/secure_closet/security/sec,
+/obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel/showroomfloor,
 /area/security/warden)
 "ajz" = (
@@ -4794,6 +4795,7 @@
 /obj/machinery/airalarm{
 	pixel_y = 28
 	},
+/obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel/showroomfloor,
 /area/security/warden)
 "ajB" = (
@@ -5360,6 +5362,7 @@
 "akH" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on,
 /obj/structure/closet/secure_closet/security/sec,
+/obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel/showroomfloor,
 /area/security/warden)
 "akI" = (
@@ -5373,6 +5376,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
+/obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel/showroomfloor,
 /area/security/warden)
 "akK" = (
@@ -7394,6 +7398,7 @@
 	icon_state = "4-8"
 	},
 /obj/structure/closet/secure_closet/security/sec,
+/obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel/showroomfloor,
 /area/security/warden)
 "aoA" = (
@@ -8728,6 +8733,7 @@
 /area/security/warden)
 "arj" = (
 /obj/structure/closet/secure_closet/security/sec,
+/obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel/showroomfloor,
 /area/security/warden)
 "ark" = (

--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -4821,11 +4821,13 @@
 "ajE" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on,
 /obj/effect/landmark/secequipment,
+/obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel/vault,
 /area/security/main)
 "ajF" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/effect/landmark/secequipment,
+/obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel/vault,
 /area/security/main)
 "ajG" = (
@@ -4840,11 +4842,13 @@
 "ajH" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/effect/landmark/secequipment,
+/obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel/vault,
 /area/security/main)
 "ajI" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on,
 /obj/effect/landmark/secequipment,
+/obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel/vault,
 /area/security/main)
 "ajJ" = (
@@ -78558,7 +78562,7 @@
 	name = "dust"
 	},
 /obj/effect/decal/remains/human{
-	desc = "They look like human remains, and have clearly been gnawed at.";
+	desc = "They look like human remains, and have clearly been gnawed at."
 	},
 /obj/item/gun/energy/laser/retro,
 /turf/open/floor/mineral/titanium/blue,
@@ -78613,7 +78617,7 @@
 	name = "dust"
 	},
 /obj/effect/decal/remains/human{
-	desc = "They look like human remains, and have clearly been gnawed at.";
+	desc = "They look like human remains, and have clearly been gnawed at."
 	},
 /turf/open/floor/mineral/titanium/blue,
 /area/shuttle/abandoned)
@@ -78680,7 +78684,7 @@
 	},
 /obj/item/soap/nanotrasen,
 /obj/effect/decal/remains/human{
-	desc = "They look like human remains, and have clearly been gnawed at.";
+	desc = "They look like human remains, and have clearly been gnawed at."
 	},
 /obj/effect/decal/cleanable/blood/gibs/old,
 /turf/open/floor/mineral/titanium,
@@ -79166,7 +79170,7 @@
 	name = "dust"
 	},
 /obj/effect/decal/remains/human{
-	desc = "They look like human remains, and have clearly been gnawed at.";
+	desc = "They look like human remains, and have clearly been gnawed at."
 	},
 /turf/open/floor/mineral/titanium,
 /area/shuttle/abandoned)
@@ -79300,7 +79304,7 @@
 	name = "\improper damaged CentCom hat"
 	},
 /obj/effect/decal/remains/human{
-	desc = "They look like human remains, and have clearly been gnawed at.";
+	desc = "They look like human remains, and have clearly been gnawed at."
 	},
 /turf/open/floor/mineral/titanium/blue,
 /area/shuttle/abandoned)
@@ -79667,7 +79671,7 @@
 	name = "dust"
 	},
 /obj/effect/decal/remains/xeno{
-	desc = "A pile of remains that look vaguely humanoid. The skull is abnormally elongated, and there are burns through some of the other bones.";
+	desc = "A pile of remains that look vaguely humanoid. The skull is abnormally elongated, and there are burns through some of the other bones."
 	},
 /turf/open/floor/mineral/titanium/blue,
 /area/shuttle/abandoned)


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/6356337/31858197-c766e79e-b6bf-11e7-8619-eefe5f65e3f0.png)

Basically a port of the tiny map tweaks from https://github.com/Citadel-Station-13/Citadel-Station-13/pull/3490

:cl: deathride58
tweak: Deltastation's armory now contains reinforced windows surrounding the lethal weaponry. This makes Delta's armory consistent with Box.
tweak: There are now decals in places where extra Security lockers can spawn.
tweak: Cleaned up semicolons in Meta and Boxstation's .dmms
/:cl:

Delta's armory is now consistent with Box's
![image](https://user-images.githubusercontent.com/6356337/31858187-8a0ae01c-b6bf-11e7-897f-fff13ee9752f.png)

Metastation now has extra decals in places where extra Security lockers can spawn
![image](https://user-images.githubusercontent.com/6356337/31858256-21a863da-b6c1-11e7-980d-efedc36a43c9.png)
Ditto, for Delta
![image](https://user-images.githubusercontent.com/6356337/31858257-2e16c33c-b6c1-11e7-9483-407e955a4b18.png)
Ditto, for Box
![image](https://user-images.githubusercontent.com/6356337/31858263-660e983c-b6c1-11e7-89d7-26e6b8720686.png)

These changes should be self-explanatory.