### PR TITLE
Makes the crematorium swole

### DIFF
--- a/code/game/objects/structures/morgue.dm
+++ b/code/game/objects/structures/morgue.dm
@@ -168,6 +168,7 @@ GLOBAL_LIST_EMPTY(crematoriums)
 	icon_state = "crema1"
 	opendir = SOUTH
 	var/id = 1
+	max_integrity = 4000
 
 /obj/structure/bodycontainer/crematorium/attack_robot(mob/user) //Borgs can't use crematoriums without help
 	to_chat(user, "<span class='warning'>[src] is locked against you.</span>")


### PR DESCRIPTION
[Changelogs]: The crematorium now has 10x health
:cl: 
balance: Raises crematorium integrity by 1000%
/:cl:

[why]: While object damage is a mistake we must live with, changelings effortlessly using their armblade to break the few things that can actually kill their invulnerable bodies is a problem. 
I _would_ like a better solution than this but I lack the know-how to give it damage_deflection and no one else seems willing to do anything about it so consider this a slap patch until either someone else actually fixes it or I spontaneously learn how to become proficient over night.  

At the very least, this will waste their time.
