### PR TITLE
Fixes get_turf_pixel returning null when called on turfs

### DIFF
--- a/code/__HELPERS/unsorted.dm
+++ b/code/__HELPERS/unsorted.dm
@@ -511,14 +511,14 @@ Do not set recursive depth higher than MAX_PROC_DEPTH as byond breaks when that 
 */
 /atom/proc/GetAllContents(list/output=list(), recursive_depth=MAX_PROC_DEPTH, _current_depth=0)
 	. = output
-	output += src 
+	output += src
 	if(_current_depth == recursive_depth)
 		if(_current_depth == MAX_PROC_DEPTH)
 			WARNING("Get all contents reached the max recursive depth of [MAX_PROC_DEPTH]. More and we would break shit. Offending atom: [src]")
 		return
-	for(var/i in 1 to contents.len) 
-		var/atom/thing = contents[i] 
-		thing.GetAllContents(output, recursive_depth, ++_current_depth) 
+	for(var/i in 1 to contents.len)
+		var/atom/thing = contents[i]
+		thing.GetAllContents(output, recursive_depth, ++_current_depth)
 
 //Step-towards method of determining whether one atom can see another. Similar to viewers()
 /proc/can_see(atom/source, atom/target, length=5) // I couldnt be arsed to do actual raycasting :I This is horribly inaccurate.
@@ -739,7 +739,7 @@ Do not set recursive depth higher than MAX_PROC_DEPTH as byond breaks when that 
 
 */
 
-/proc/get_turf_pixel(atom/movable/AM)
+/proc/get_turf_pixel(atom/AM)
 	if(!istype(AM))
 		return
 


### PR DESCRIPTION
Fixes #23184
Fixes AIs being unable to call bots when clicking directly on a turf.