### PR TITLE
Blacklists holo injectors from surplus crates

### DIFF
--- a/code/modules/uplink/uplink_item.dm
+++ b/code/modules/uplink/uplink_item.dm
@@ -375,6 +375,8 @@ GLOBAL_LIST_EMPTY(uplink_items) // Global list so we only initialize this once.
 			organic host as a home base and source of fuel."
 	item = /obj/item/storage/box/syndie_kit/guardian
 	cost = 18
+	surplus = 0
+	refundable = TRUE
 	exclude_modes = list(/datum/game_mode/nuclear)
 	player_minimum = 25
 

--- a/code/modules/uplink/uplink_item.dm
+++ b/code/modules/uplink/uplink_item.dm
@@ -376,7 +376,6 @@ GLOBAL_LIST_EMPTY(uplink_items) // Global list so we only initialize this once.
 	item = /obj/item/storage/box/syndie_kit/guardian
 	cost = 18
 	surplus = 0
-	refundable = TRUE
 	exclude_modes = list(/datum/game_mode/nuclear)
 	player_minimum = 25
 


### PR DESCRIPTION
it really hurts when ghosts arent available and you just have this object of no use

:cl: Improvedname
tweak: Blacklists holoparasite's from surplus crates
/:cl:
