### PR TITLE
Removes mob references from camera motion tracking

### DIFF
--- a/code/game/machinery/camera/motion.dm
+++ b/code/game/machinery/camera/motion.dm
@@ -15,8 +15,9 @@
 		if (elapsed > alarm_delay)
 			triggerAlarm()
 	else if (detectTime == -1)
-		for (var/mob/target in getTargetList())
-			if (target.stat == DEAD || (!area_motion && !in_range(src, target)))
+		for (var/targetref in getTargetList())
+			var/mob/target = locate(targetref)
+			if (target.stat == DEAD || QDELETED(target) || (!area_motion && !in_range(src, target)))
 				//If not part of a monitored area and the camera is not in range or the target is dead
 				lostTarget(target)
 
@@ -31,8 +32,8 @@
 	if (detectTime == 0)
 		detectTime = world.time // start the clock
 	var/list/targets = getTargetList()
-	if (!(target in targets))
-		targets += target
+	if (!("\ref[target]" in targets))
+		targets += "\ref[target]"
 	return 1
 
 /obj/machinery/camera/Destroy()
@@ -43,8 +44,8 @@
 
 /obj/machinery/camera/proc/lostTarget(mob/target)
 	var/list/targets = getTargetList()
-	if (target in targets)
-		targets -= target
+	if ("\ref[target]" in targets)
+		targets -= "\ref[target]"
 	if (targets.len == 0)
 		cancelAlarm()
 

--- a/code/game/machinery/camera/motion.dm
+++ b/code/game/machinery/camera/motion.dm
@@ -32,9 +32,7 @@
 	if (detectTime == 0)
 		detectTime = world.time // start the clock
 	var/list/targets = getTargetList()
-	var/ref = "\ref[target]"
-	if (!(ref in targets))
-		targets += ref
+	targets |= "\ref[target]"
 	return 1
 
 /obj/machinery/camera/Destroy()
@@ -45,9 +43,7 @@
 
 /obj/machinery/camera/proc/lostTarget(mob/target)
 	var/list/targets = getTargetList()
-	var/ref = "\ref[target]"
-	if (ref in targets)
-		targets -= ref
+	targets -= "\ref[target]"
 	if (targets.len == 0)
 		cancelAlarm()
 

--- a/code/game/machinery/camera/motion.dm
+++ b/code/game/machinery/camera/motion.dm
@@ -32,8 +32,9 @@
 	if (detectTime == 0)
 		detectTime = world.time // start the clock
 	var/list/targets = getTargetList()
-	if (!("\ref[target]" in targets))
-		targets += "\ref[target]"
+	var/ref = "\ref[target]"
+	if (!(ref in targets))
+		targets += ref
 	return 1
 
 /obj/machinery/camera/Destroy()
@@ -44,8 +45,9 @@
 
 /obj/machinery/camera/proc/lostTarget(mob/target)
 	var/list/targets = getTargetList()
-	if ("\ref[target]" in targets)
-		targets -= "\ref[target]"
+	var/ref = "\ref[target]"
+	if (ref in targets)
+		targets -= ref
 	if (targets.len == 0)
 		cancelAlarm()
 

--- a/code/game/machinery/camera/motion.dm
+++ b/code/game/machinery/camera/motion.dm
@@ -16,7 +16,7 @@
 			triggerAlarm()
 	else if (detectTime == -1)
 		for (var/targetref in getTargetList())
-			var/mob/target = locate(targetref)
+			var/mob/target = locate(targetref) in GLOB.mob_list
 			if (target.stat == DEAD || QDELETED(target) || (!area_motion && !in_range(src, target)))
 				//If not part of a monitored area and the camera is not in range or the target is dead
 				lostTarget(target)


### PR DESCRIPTION
With this and #31981 , mobs should generally qdel softly on the station.

[Changelogs]: 

:cl: Naksu
code: Cameras no longer keep hard references to mobs in their motion tracking list.
/:cl:

[why]: 
These also cause harddels for mobs.
