### PR TITLE
Fixes a SET_CONFIG bug 

### DIFF
--- a/code/controllers/configuration/configuration.dm
+++ b/code/controllers/configuration/configuration.dm
@@ -147,7 +147,7 @@ GLOBAL_PROTECT(config_dir)
 	E = entries_by_type[entry_type]
 	if(!E)
 		CRASH("Missing config entry for [entry_type]!")
-	return E.ValidateAndSet(new_val)
+	return E.ValidateAndSet("[new_val]")
 
 /datum/controller/configuration/proc/LoadModes()
 	gamemode_cache = typecacheof(/datum/game_mode, TRUE)


### PR DESCRIPTION
`ValidateAndSet` always expects a string, but `SET_CONFIG` is often used with non-strings. This resulted in bugs down the line, such as admins being unable to disable random events.

Fixed by converting every value received by config's `Set` to a string while sending it to `ValidateAndSet`.