### PR TITLE
Actual performance improvements for GetAllContents

### DIFF
--- a/code/__HELPERS/unsorted.dm
+++ b/code/__HELPERS/unsorted.dm
@@ -504,21 +504,19 @@ Turf and target are separate in case you want to teleport some distance from a t
 	return y
 
 /*
-Recursively gets all contents of contents and returns them all in a list.
-
-recursive_depth is useful if you only want a turf and everything on it (recursive_depth=1)
-Do not set recursive depth higher than MAX_PROC_DEPTH as byond breaks when that limit is reached.
+	Gets all contents of contents and returns them all in a list.
 */
-/atom/proc/GetAllContents(list/output=list(), recursive_depth=MAX_PROC_DEPTH, _current_depth=0)
-	. = output
-	output += src 
-	if(_current_depth == recursive_depth)
-		if(_current_depth == MAX_PROC_DEPTH)
-			WARNING("Get all contents reached the max recursive depth of [MAX_PROC_DEPTH]. More and we would break shit. Offending atom: [src]")
-		return
-	for(var/i in 1 to contents.len) 
-		var/atom/thing = contents[i] 
-		thing.GetAllContents(output, recursive_depth, ++_current_depth) 
+/atom/proc/GetAllContents()
+	var/list/processing_list = list(src)
+	var/list/assembled = list()
+	while(processing_list.len)
+		var/atom/A = processing_list[1]
+		processing_list -= A
+		//Byond does not allow things to be in multiple contents, or double parent-child hierarchies, so only += is needed
+		//This is also why we don't need to check against assembled as we go along
+		processing_list += A.contents 
+		assembled += A
+	return assembled
 
 //Step-towards method of determining whether one atom can see another. Similar to viewers()
 /proc/can_see(atom/source, atom/target, length=5) // I couldnt be arsed to do actual raycasting :I This is horribly inaccurate.

--- a/code/__HELPERS/unsorted.dm
+++ b/code/__HELPERS/unsorted.dm
@@ -511,7 +511,7 @@ Turf and target are separate in case you want to teleport some distance from a t
 	var/list/assembled = list()
 	while(processing_list.len)
 		var/atom/A = processing_list[1]
-		processing_list -= A
+		processing_list.Cut(1, 2)
 		//Byond does not allow things to be in multiple contents, or double parent-child hierarchies, so only += is needed
 		//This is also why we don't need to check against assembled as we go along
 		processing_list += A.contents 


### PR DESCRIPTION
## Preamble
I spotted this when the original PR was made, but considering I have no obligations anymore, I only just now got around to testing my theory.

Recursion has no use as a performance enhancer in DM, it is only usable in DM as a structural thing (Recursive descent parsers, for example)

@ninjanomnom You optimised the proc, that's true, but you misinterpreted why it was faster.
Recursion was not why it became faster, it became faster due to the removal of the ```|=``` operations (now ```+=```) and the constant removal of ```assembled``` from the contents lists.

Some of you may be thinking, as the original author obviously did, "But what about duplicates?" It's quite simple, byond doesn't allow hierarchies that cause duplicates (as I showed for one of the many ```get_turf``` iterations we used, before we eventually got ```get_step(A, 0)```, where I showed that an A in B in A relationship simply nulls the last atom applied's loc, preventing infinite loops of contents)

And if you still don't believe me, then simply look at the CURRENT ```GetAllContents()```, Ninja's, it would already return duplicates if it could.

I have also removed the recursion depth nonsense, since with no recursion, there's no need for it (the comment above the proc mentions using it to perhaps find a turf and the turfs contents only, yet that's just ```turf.contents```... so it has no value).

I have not re-added the typecache stuff, because I agree with the change of it being done after the fact.

## Profile/Tests
My profile (This was ran a few times, with only a variance of 1-2 on both procs (eg: if Ninja's was 12, mine was 6, if Ninja's was 13, mine was closer to 7, etc.))

The test was performed using 1 million calls, a 50% prob between procs, and a basic exponential hierarchy of 1 child -> 2 children -> 3 children.
![capture](https://user-images.githubusercontent.com/4043781/31889624-656b2660-b7f8-11e7-8f35-9646935ad2bc.PNG)
If you're unsure how to read that profile, look at the two ```test_wrapper_*()``` procs, you can't compare the calls and cpu of the raw procs since the recursive one is guaranteed to have more calls, because it calls itself.

## Code structure comparison
And here is a comparison of the original GetAllContents (boiled down to remove the typecache stuff) and my new one, to illustrate the optimisations.

Original:
```
/atom/proc/GetAllContents()
	var/list/processing_list = list(src)
	var/list/assembled = list()
	while(processing_list.len)
		var/atom/A = processing_list[1]
		processing_list -= A
		processing_list |= (A.contents - assembled)
		assembled += A
	return assembled
```
Mine:
```
/atom/proc/GetAllContents()
	var/list/processing_list = list(src)
	var/list/assembled = list()
	while(processing_list.len)
		var/atom/A = processing_list[1]
		processing_list -= A
		processing_list += A.contents
		assembled += A
	return assembled
```

## tl;dr 
stop it, recursion is a no-no.
