### PR TITLE
Additional safety and sanity checks for mutant human config option

### DIFF
--- a/code/modules/admin/secrets.dm
+++ b/code/modules/admin/secrets.dm
@@ -65,10 +65,11 @@
 			<A href='?src=\ref[src];[HrefToken()];secrets=whiteout'>Fix all lights</A><BR>
 			<A href='?src=\ref[src];[HrefToken()];secrets=floorlava'>The floor is lava! (DANGEROUS: extremely lame)</A><BR>
 			<BR>
-			<A href='?src=\ref[src];[HrefToken()];secrets=changebombcap'>Change bomb cap</A><BR>
-			<A href='?src=\ref[src];[HrefToken()];secrets=masspurrbation'>Mass Purrbation</A><BR>
-			<A href='?src=\ref[src];[HrefToken()];secrets=massremovepurrbation'>Mass Remove Purrbation</A><BR>
-			"}
+			<A href='?src=\ref[src];[HrefToken()];secrets=changebombcap'>Change bomb cap</A><BR>"
+		if(CONFIG_GET(flag/join_with_mutant_humans))
+			dat += "<A href='?src=\ref[src];[HrefToken()];secrets=masspurrbation'>Mass Purrbation</A><BR>"
+			dat += "<A href='?src=\ref[src];[HrefToken()];secrets=massremovepurrbation'>Mass Remove Purrbation</A><BR>"
+		dat += "}"
 
 	dat += "<BR>"
 
@@ -551,6 +552,9 @@
 				return
 			toggle_all_ctf(usr)
 		if("masspurrbation")
+			if(!CONFIG_GET(flag/join_with_mutant_humans))
+				log_admin("[key_name(usr)] has attempted to href exploit apply masspurrbation.")
+				return
 			if(!check_rights(R_FUN))
 				return
 			mass_purrbation()
@@ -558,6 +562,9 @@
 				purrbation!")
 			log_admin("[key_name(usr)] has put everyone on purrbation.")
 		if("massremovepurrbation")
+			if(!CONFIG_GET(flag/join_with_mutant_humans))
+				log_admin("[key_name(usr)] has attempted to href exploit apply massremovepurrbation.")
+				return
 			if(!check_rights(R_FUN))
 				return
 			mass_remove_purrbation()

--- a/code/modules/admin/secrets.dm
+++ b/code/modules/admin/secrets.dm
@@ -42,34 +42,32 @@
 			"}
 
 	if(check_rights(R_FUN,0))
-		dat += {"
-			<B>Fun Secrets</B><BR>
-			<BR>
-			<A href='?src=\ref[src];[HrefToken()];secrets=virus'>Trigger a Virus Outbreak</A><BR>
-			<A href='?src=\ref[src];[HrefToken()];secrets=monkey'>Turn all humans into monkeys</A><BR>
-			<A href='?src=\ref[src];[HrefToken()];secrets=anime'>Chinese Cartoons</A><BR>
-			<A href='?src=\ref[src];[HrefToken()];secrets=allspecies'>Change the species of all humans</A><BR>
-			<A href='?src=\ref[src];[HrefToken()];secrets=power'>Make all areas powered</A><BR>
-			<A href='?src=\ref[src];[HrefToken()];secrets=unpower'>Make all areas unpowered</A><BR>
-			<A href='?src=\ref[src];[HrefToken()];secrets=quickpower'>Power all SMES</A><BR>
-			<A href='?src=\ref[src];[HrefToken()];secrets=tripleAI'>Triple AI mode (needs to be used in the lobby)</A><BR>
-			<A href='?src=\ref[src];[HrefToken()];secrets=traitor_all'>Everyone is the traitor</A><BR>
-			<A href='?src=\ref[src];[HrefToken()];secrets=guns'>Summon Guns</A><BR>
-			<A href='?src=\ref[src];[HrefToken()];secrets=magic'>Summon Magic</A><BR>
-			<A href='?src=\ref[src];[HrefToken()];secrets=events'>Summon Events (Toggle)</A><BR>
-			<A href='?src=\ref[src];[HrefToken()];secrets=onlyone'>There can only be one!</A><BR>
-			<A href='?src=\ref[src];[HrefToken()];secrets=delayed_onlyone'>There can only be one! (40-second delay)</A><BR>
-			<A href='?src=\ref[src];[HrefToken()];secrets=retardify'>Make all players retarded</A><BR>
-			<A href='?src=\ref[src];[HrefToken()];secrets=eagles'>Egalitarian Station Mode</A><BR>
-			<A href='?src=\ref[src];[HrefToken()];secrets=blackout'>Break all lights</A><BR>
-			<A href='?src=\ref[src];[HrefToken()];secrets=whiteout'>Fix all lights</A><BR>
-			<A href='?src=\ref[src];[HrefToken()];secrets=floorlava'>The floor is lava! (DANGEROUS: extremely lame)</A><BR>
-			<BR>
-			<A href='?src=\ref[src];[HrefToken()];secrets=changebombcap'>Change bomb cap</A><BR>"
+		dat += "<B>Fun Secrets</B><BR>"
+		dat += "<BR>"
+		dat += "<A href='?src=\ref[src];[HrefToken()];secrets=virus'>Trigger a Virus Outbreak</A><BR>"
+		dat += "<A href='?src=\ref[src];[HrefToken()];secrets=monkey'>Turn all humans into monkeys</A><BR>"
+		dat += "<A href='?src=\ref[src];[HrefToken()];secrets=anime'>Chinese Cartoons</A><BR>"
+		dat += "<A href='?src=\ref[src];[HrefToken()];secrets=allspecies'>Change the species of all humans</A><BR>"
+		dat += "<A href='?src=\ref[src];[HrefToken()];secrets=power'>Make all areas powered</A><BR>"
+		dat += "<A href='?src=\ref[src];[HrefToken()];secrets=unpower'>Make all areas unpowered</A><BR>"
+		dat += "<A href='?src=\ref[src];[HrefToken()];secrets=quickpower'>Power all SMES</A><BR>"
+		dat += "<A href='?src=\ref[src];[HrefToken()];secrets=tripleAI'>Triple AI mode (needs to be used in the lobby)</A><BR>"
+		dat += "<A href='?src=\ref[src];[HrefToken()];secrets=traitor_all'>Everyone is the traitor</A><BR>"
+		dat += "<A href='?src=\ref[src];[HrefToken()];secrets=guns'>Summon Guns</A><BR>"
+		dat += "<A href='?src=\ref[src];[HrefToken()];secrets=magic'>Summon Magic</A><BR>"
+		dat += "<A href='?src=\ref[src];[HrefToken()];secrets=events'>Summon Events (Toggle)</A><BR>"
+		dat += "<A href='?src=\ref[src];[HrefToken()];secrets=onlyone'>There can only be one!</A><BR>"
+		dat += "<A href='?src=\ref[src];[HrefToken()];secrets=delayed_onlyone'>There can only be one! (40-second delay)</A><BR>"
+		dat += "<A href='?src=\ref[src];[HrefToken()];secrets=retardify'>Make all players retarded</A><BR>"
+		dat += "<A href='?src=\ref[src];[HrefToken()];secrets=eagles'>Egalitarian Station Mode</A><BR>"
+		dat += "<A href='?src=\ref[src];[HrefToken()];secrets=blackout'>Break all lights</A><BR>"
+		dat += "<A href='?src=\ref[src];[HrefToken()];secrets=whiteout'>Fix all lights</A><BR>"
+		dat += "<A href='?src=\ref[src];[HrefToken()];secrets=floorlava'>The floor is lava! (DANGEROUS: extremely lame)</A><BR>"
+		dat += "<BR>"
+		dat += "<A href='?src=\ref[src];[HrefToken()];secrets=changebombcap'>Change bomb cap</A><BR>"
 		if(CONFIG_GET(flag/join_with_mutant_humans))
 			dat += "<A href='?src=\ref[src];[HrefToken()];secrets=masspurrbation'>Mass Purrbation</A><BR>"
 			dat += "<A href='?src=\ref[src];[HrefToken()];secrets=massremovepurrbation'>Mass Remove Purrbation</A><BR>"
-		dat += "}"
 
 	dat += "<BR>"
 

--- a/code/modules/admin/verbs/randomverbs.dm
+++ b/code/modules/admin/verbs/randomverbs.dm
@@ -1094,6 +1094,8 @@ GLOBAL_LIST_EMPTY(custom_outfits) //Admin created outfits
 #define ON_PURRBATION(H) (!(H.dna.features["tail_human"] == "None" && H.dna.features["ears"] == "None"))
 
 /proc/mass_purrbation()
+	if(!CONFIG_GET(flag/join_with_mutant_humans))
+		return
 	for(var/M in GLOB.mob_list)
 		if(ishumanbasic(M))
 			purrbation_apply(M)
@@ -1106,6 +1108,8 @@ GLOBAL_LIST_EMPTY(custom_outfits) //Admin created outfits
 		CHECK_TICK
 
 /proc/purrbation_toggle(mob/living/carbon/human/H)
+	if(!CONFIG_GET(flag/join_with_mutant_humans))
+		return
 	if(!ishumanbasic(H))
 		return
 	if(!ON_PURRBATION(H))
@@ -1116,6 +1120,8 @@ GLOBAL_LIST_EMPTY(custom_outfits) //Admin created outfits
 		. = FALSE
 
 /proc/purrbation_apply(mob/living/carbon/human/H)
+	if(!CONFIG_GET(flag/join_with_mutant_humans))
+		return
 	if(!ishuman(H))
 		return
 	if(ON_PURRBATION(H))
@@ -1127,6 +1133,8 @@ GLOBAL_LIST_EMPTY(custom_outfits) //Admin created outfits
 	playsound(get_turf(H), 'sound/effects/meow1.ogg', 50, 1, -1)
 
 /proc/purrbation_remove(mob/living/carbon/human/H)
+	if(!CONFIG_GET(flag/join_with_mutant_humans))
+		return
 	if(!ishuman(H))
 		return
 	if(!ON_PURRBATION(H))

--- a/code/modules/mob/living/carbon/human/species_types/humans.dm
+++ b/code/modules/mob/living/carbon/human/species_types/humans.dm
@@ -1,3 +1,5 @@
+
+
 /datum/species/human
 	name = "Human"
 	id = "human"
@@ -10,6 +12,11 @@
 	disliked_food = GROSS | RAW
 	liked_food = JUNKFOOD | FRIED
 
+
+/datum/species/human/New()
+	if(!CONFIG_GET(flag/join_with_mutant_humans))
+		mutant_bodyparts = list()
+	..()
 
 /datum/species/human/qualifies_for_rank(rank, list/features)
 	return TRUE	//Pure humans are always allowed in all roles.
@@ -25,9 +32,10 @@
 		return TRUE
 
 datum/species/human/on_species_gain(mob/living/carbon/human/H, datum/species/old_species)
-	if(H.dna.features["ears"] == "Cat")
-		mutantears = /obj/item/organ/ears/cat
-	if(H.dna.features["tail_human"] == "Cat")
-		var/tail = /obj/item/organ/tail/cat
-		mutant_organs += tail
+	if(CONFIG_GET(flag/join_with_mutant_humans))
+		if(H.dna.features["ears"] == "Cat")
+			mutantears = /obj/item/organ/ears/cat
+		if(H.dna.features["tail_human"] == "Cat")
+			var/tail = /obj/item/organ/tail/cat
+			mutant_organs += tail
 	..()

--- a/code/modules/mob/living/carbon/human/species_types/humans.dm
+++ b/code/modules/mob/living/carbon/human/species_types/humans.dm
@@ -1,5 +1,3 @@
-
-
 /datum/species/human
 	name = "Human"
 	id = "human"


### PR DESCRIPTION
Since for whatever reason the bit in the save file prefs to null out cat ears if the config option is disabled, to ensure the config setting isn't bypassed via exploits, I have made all instances of mutant human parts being applied check for the config option before applying it.