### PR TITLE
Transit space blocks explosions

### DIFF
--- a/code/game/turfs/space/transit.dm
+++ b/code/game/turfs/space/transit.dm
@@ -3,6 +3,7 @@
 	dir = SOUTH
 	baseturf = /turf/open/space/transit
 	flags_1 = NOJAUNT_1 //This line goes out to every wizard that ever managed to escape the den. I'm sorry.
+	explosion_block = INFINITY
 
 /turf/open/space/transit/get_smooth_underlay_icon(mutable_appearance/underlay_appearance, turf/asking_turf, adjacency_dir)
 	. = ..()


### PR DESCRIPTION
\>Turn off bomb cap

\> Bomb main shuttle

\> Also bomb escape pods

\> Laugh maniacally

Also #32037 will be putting things other than shuttles in the same Z with space allocation. So this is necessary