### PR TITLE
Fixes excessive overlay churn 

### DIFF
--- a/code/game/objects/effects/decals/cleanable/humans.dm
+++ b/code/game/objects/effects/decals/cleanable/humans.dm
@@ -135,9 +135,10 @@
 		var/obj/item/clothing/shoes/S = H.shoes
 		if(S && S.bloody_shoes[blood_state])
 			S.bloody_shoes[blood_state] = max(S.bloody_shoes[blood_state] - BLOOD_LOSS_PER_STEP, 0)
-			entered_dirs|= H.dir
 			shoe_types |= H.shoes.type
-	update_icon()
+			if ((entered_dir & H.dir))
+				entered_dirs |= H.dir
+				update_icon()
 
 /obj/effect/decal/cleanable/blood/footprints/Uncrossed(atom/movable/O)
 	..()
@@ -146,9 +147,11 @@
 		var/obj/item/clothing/shoes/S = H.shoes
 		if(S && S.bloody_shoes[blood_state])
 			S.bloody_shoes[blood_state] = max(S.bloody_shoes[blood_state] - BLOOD_LOSS_PER_STEP, 0)
-			exited_dirs|= H.dir
-			shoe_types |= H.shoes.type
-	update_icon()
+			shoe_types  |= S.type
+			if (!(exited_dir & H.dir))
+				exited_dirs |= H.dir
+				update_icon()
+			
 
 /obj/effect/decal/cleanable/blood/footprints/update_icon()
 	cut_overlays()

--- a/code/game/objects/effects/decals/cleanable/humans.dm
+++ b/code/game/objects/effects/decals/cleanable/humans.dm
@@ -135,8 +135,8 @@
 		var/obj/item/clothing/shoes/S = H.shoes
 		if(S && S.bloody_shoes[blood_state])
 			S.bloody_shoes[blood_state] = max(S.bloody_shoes[blood_state] - BLOOD_LOSS_PER_STEP, 0)
-			shoe_types |= H.shoes.type
-			if ((entered_dir & H.dir))
+			shoe_types |= S.type
+			if (!(entered_dirs & H.dir))
 				entered_dirs |= H.dir
 				update_icon()
 
@@ -148,7 +148,7 @@
 		if(S && S.bloody_shoes[blood_state])
 			S.bloody_shoes[blood_state] = max(S.bloody_shoes[blood_state] - BLOOD_LOSS_PER_STEP, 0)
 			shoe_types  |= S.type
-			if (!(exited_dir & H.dir))
+			if (!(exited_dirs & H.dir))
 				exited_dirs |= H.dir
 				update_icon()
 			


### PR DESCRIPTION
Adding an overlay on every cross and uncross of every player (with how bloody the station gets this is called on just about every fucking movement, some times multiple times if there are multiple types of stains (oil, blood, alien, etc)) is an excessive as fuck amount of chern in the overlay subsystem.

This was almost always noops that ran on cross and uncross, only they still required an overlay chern and appearance recalculate.

This is likely the cause of `compile_overlays` being so high on profile, as well as some of the mc lag.
