### PR TITLE
Revert "Late join antagonists will try to target late join players"

### DIFF
--- a/code/datums/mind.dm
+++ b/code/datums/mind.dm
@@ -64,7 +64,6 @@
 	var/mob/living/enslaved_to //If this mind's master is another mob (i.e. adamantine golems)
 	var/datum/language_holder/language_holder
 	var/unconvertable = FALSE
-	var/late_joiner = FALSE
 
 /datum/mind/New(var/key)
 	src.key = key

--- a/code/game/gamemodes/objective.dm
+++ b/code/game/gamemodes/objective.dm
@@ -54,22 +54,9 @@
 /datum/objective/proc/find_target()
 	var/list/datum/mind/owners = get_owners()
 	var/list/possible_targets = list()
-	var/try_target_late_joiners = FALSE
-	for(var/I in owners)
-		var/datum/mind/O = I
-		if(O.late_joiner)
-			try_target_late_joiners = TRUE
 	for(var/datum/mind/possible_target in get_crewmember_minds())
 		if(!(possible_target in owners) && ishuman(possible_target.current) && (possible_target.current.stat != DEAD) && is_unique_objective(possible_target))
 			possible_targets += possible_target
-	if(try_target_late_joiners)
-		var/list/all_possible_targets = possible_targets.Copy()
-		for(var/I in all_possible_targets)
-			var/datum/mind/PT = I
-			if(!PT.late_joiner)
-				possible_targets -= PT
-		if(!possible_targets.len)
-			possible_targets = all_possible_targets
 	if(possible_targets.len > 0)
 		target = pick(possible_targets)
 	update_explanation_text()

--- a/code/modules/mob/dead/new_player/new_player.dm
+++ b/code/modules/mob/dead/new_player/new_player.dm
@@ -482,7 +482,6 @@
 	. = H
 	new_character = .
 	if(transfer_after)
-		mind.late_joiner = TRUE
 		transfer_character()
 
 /mob/dead/new_player/proc/transfer_character()

--- a/html/changelogs/AutoChangeLog-pr-32001.yml
+++ b/html/changelogs/AutoChangeLog-pr-32001.yml
@@ -1,0 +1,4 @@
+author: "Improvedname"
+delete-after: True
+changes: 
+  - tweak: "Blacklists holoparasite's from surplus crates"

--- a/html/changelogs/AutoChangeLog-pr-32001.yml
+++ b/html/changelogs/AutoChangeLog-pr-32001.yml
@@ -1,4 +1,0 @@
-author: "Improvedname"
-delete-after: True
-changes: 
-  - tweak: "Blacklists holoparasite's from surplus crates"


### PR DESCRIPTION
Reverts tgstation/tgstation#31560

Broke late joining: Runtime in new_player.dm, line 485: Cannot modify null.late_joiner.

Reverting for a test merge.