### PR TITLE
Makes staff of change randomly assign a borg module

### DIFF
--- a/code/modules/projectiles/projectile/magic.dm
+++ b/code/modules/projectiles/projectile/magic.dm
@@ -132,16 +132,14 @@
 		if("monkey")
 			new_mob = new /mob/living/carbon/monkey(M.loc)
 		if("robot")
-			var/robot = pick("cyborg","syndiborg","drone")
+			var/robot = pick("random_cyborg","syndiborg","drone")
+			var/path
 			switch(robot)
-				if("cyborg")
-					new_mob = new /mob/living/silicon/robot(M.loc)
+				if("random_cyborg")
+					path = pick(typesof(/mob/living/silicon/robot/modules) - typesof(/mob/living/silicon/robot/modules/syndicate))
+					new_mob = new path(M.loc)
 				if("syndiborg")
-					var/path
-					if(prob(50))
-						path = /mob/living/silicon/robot/modules/syndicate
-					else
-						path = /mob/living/silicon/robot/modules/syndicate/medical
+					path = pick(typesof(/mob/living/silicon/robot/modules/syndicate))
 					new_mob = new path(M.loc)
 				if("drone")
 					new_mob = new /mob/living/simple_animal/drone/polymorphed(M.loc)


### PR DESCRIPTION
Effectively does the same thing as #30911, but a little more randomly. 

🆑 ShizCalev
tweak: The Staff of Change will now randomly assign a cyborg module when transforming a mob into a cyborg.
/🆑