### PR TITLE
Fixes borg light issues

### DIFF
--- a/code/modules/lighting/lighting_source.dm
+++ b/code/modules/lighting/lighting_source.dm
@@ -203,6 +203,9 @@
 /datum/light_source/proc/update_corners()
 	var/update = FALSE
 
+	if(QDELETED(src))
+		return
+
 	if (!source_atom || QDELETED(source_atom))
 		qdel(src)
 		return


### PR DESCRIPTION
From what i can tell update corners gets called on already qdeleted source, and since lights assume soft deletion they're never collected since they're added back to affecting turfs.