### PR TITLE
Vampire species for halloween

### DIFF
--- a/code/__DEFINES/DNA.dm
+++ b/code/__DEFINES/DNA.dm
@@ -118,6 +118,7 @@
 #define NOLIVER			27
 #define NOSTOMACH		28
 #define NO_DNA_COPY     29
+#define DRINKSBLOOD		30
 
 #define ORGAN_SLOT_BRAIN "brain"
 #define ORGAN_SLOT_APPENDIX "appendix"

--- a/code/modules/mob/living/blood.dm
+++ b/code/modules/mob/living/blood.dm
@@ -216,25 +216,23 @@
 	. = list()
 	if(!bloodtype)
 		return
-	switch(bloodtype)
-		if("A-")
-			return list("A-", "O-")
-		if("A+")
-			return list("A-", "A+", "O-", "O+")
-		if("B-")
-			return list("B-", "O-")
-		if("B+")
-			return list("B-", "B+", "O-", "O+")
-		if("AB-")
-			return list("A-", "B-", "O-", "AB-")
-		if("AB+")
-			return list("A-", "A+", "B-", "B+", "O-", "O+", "AB-", "AB+")
-		if("O-")
-			return list("O-")
-		if("O+")
-			return list("O-", "O+")
-		if("L")
-			return list("L")
+
+	var/static/list/bloodtypes_safe = list(
+		"A-" = list("A-", "O-"),
+		"A+" = list("A-", "A+", "O-", "O+"),
+		"B-" = list("B-", "O-"),
+		"B+" = list("B-", "B+", "O-", "O+"),
+		"AB-" = list("A-", "B-", "O-", "AB-"),
+		"AB+" = list("A-", "A+", "B-", "B+", "O-", "O+", "AB-", "AB+"),
+		"O-" = list("O-"),
+		"O+" = list("O-", "O+"),
+		"L" = list("L"),
+		"V" = list("A-", "A+", "B-", "B+", "O-", "O+", "AB-", "AB+", "L", "V")
+	)
+
+	var/safe = bloodtypes_safe[bloodtype]
+	if(safe)
+		. = safe
 
 //to add a splatter of blood or other mob liquid.
 /mob/living/proc/add_splatter_floor(turf/T, small_drip)

--- a/code/modules/mob/living/blood.dm
+++ b/code/modules/mob/living/blood.dm
@@ -227,7 +227,7 @@
 		"O-" = list("O-"),
 		"O+" = list("O-", "O+"),
 		"L" = list("L"),
-		"V" = list("A-", "A+", "B-", "B+", "O-", "O+", "AB-", "AB+", "L", "V")
+		"U" = list("A-", "A+", "B-", "B+", "O-", "O+", "AB-", "AB+", "L", "U")
 	)
 
 	var/safe = bloodtypes_safe[bloodtype]

--- a/code/modules/mob/living/carbon/human/species.dm
+++ b/code/modules/mob/living/carbon/human/species.dm
@@ -66,6 +66,7 @@ GLOBAL_LIST_EMPTY(roundstart_races)
 	var/breathid = "o2"
 
 	var/obj/item/organ/brain/mutant_brain = /obj/item/organ/brain
+	var/obj/item/organ/heart/mutant_heart = /obj/item/organ/heart
 	var/obj/item/organ/eyes/mutanteyes = /obj/item/organ/eyes
 	var/obj/item/organ/ears/mutantears = /obj/item/organ/ears
 	var/obj/item/mutanthands
@@ -162,7 +163,7 @@ GLOBAL_LIST_EMPTY(roundstart_races)
 		heart.Remove(C,1)
 		QDEL_NULL(heart)
 	if(should_have_heart && !heart)
-		heart = new()
+		heart = new mutant_heart()
 		heart.Insert(C)
 
 	if(lungs && (replace_current || !should_have_lungs))

--- a/code/modules/mob/living/carbon/human/species_types/vampire.dm
+++ b/code/modules/mob/living/carbon/human/species_types/vampire.dm
@@ -67,7 +67,7 @@
 			if(victim.stat == DEAD)
 				to_chat(H, "<span class='notice'>You need a living victim!</span>")
 				return
-			if(victim.blood_volume < 100)
+			if(victim.blood_volume < 50)
 				to_chat(H, "<span class='notice'>Your victim doesn't have enough blood left.</span>")
 				return
 			V.drain_cooldown = world.time + 30
@@ -76,8 +76,8 @@
 			to_chat(victim, "<span class='danger'>[H] is draining your blood!</span>")
 			to_chat(H, "<span class='notice'>You drain some blood!</span>")
 			playsound(H, 'sound/items/drink.ogg', 30, 1, -2)
-			victim.blood_volume = Clamp(victim.blood_volume - 100, 0, BLOOD_VOLUME_MAXIMUM)
-			H.blood_volume = Clamp(H.blood_volume + 100, 0, BLOOD_VOLUME_MAXIMUM)
+			victim.blood_volume = Clamp(victim.blood_volume - 50, 0, BLOOD_VOLUME_MAXIMUM)
+			H.blood_volume = Clamp(H.blood_volume + 50, 0, BLOOD_VOLUME_MAXIMUM)
 
 /obj/effect/proc_holder/spell/targeted/shapeshift/bat
 	name = "Bat Form"

--- a/code/modules/mob/living/carbon/human/species_types/vampire.dm
+++ b/code/modules/mob/living/carbon/human/species_types/vampire.dm
@@ -7,7 +7,7 @@
 	default_features = list("mcolor" = "FFF", "tail_human" = "None", "ears" = "None", "wings" = "None")
 	exotic_bloodtype = "U"
 	use_skintones = TRUE
-	mutanteyes = /obj/item/organ/eyes/night_vision
+	mutant_heart = /obj/item/organ/heart/vampire
 	mutanttongue = /obj/item/organ/tongue/vampire
 	blacklisted = TRUE
 	limbs_id = "human"
@@ -101,6 +101,21 @@
 				to_chat(H, "<span class='warning'>You finish off [victim]'s blood supply!</span>")
 
 #undef VAMP_DRAIN_AMOUNT
+
+/obj/item/organ/heart/vampire
+	name = "vampire heart"
+	actions_types = list(/datum/action/item_action/organ_action/vampire_heart)
+	color = "#1C1C1C"
+
+/datum/action/item_action/organ_action/vampire_heart
+	name = "Check Blood Level"
+	desc = "Check how much blood you have remaining."
+
+/datum/action/item_action/organ_action/vampire_heart/Trigger()
+	. = ..()
+	if(iscarbon(owner))
+		var/mob/living/carbon/H = owner
+		to_chat(H, "<span class='notice'>Current blood level: [H.blood_volume]/[BLOOD_VOLUME_MAXIMUM].</span>")
 
 /obj/effect/proc_holder/spell/targeted/shapeshift/bat
 	name = "Bat Form"

--- a/code/modules/mob/living/carbon/human/species_types/vampire.dm
+++ b/code/modules/mob/living/carbon/human/species_types/vampire.dm
@@ -1,0 +1,80 @@
+/datum/species/vampire
+	name = "vampire"
+	id = "vampire"
+	default_color = "FFFFFF"
+	species_traits = list(EYECOLOR,HAIR,FACEHAIR,LIPS,NOHUNGER)
+	mutant_bodyparts = list("tail_human", "ears", "wings")
+	default_features = list("mcolor" = "FFF", "tail_human" = "None", "ears" = "None", "wings" = "None")
+	use_skintones = TRUE
+	mutanteyes = /obj/item/organ/eyes/night_vision
+	mutanttongue = /obj/item/organ/tongue/vampire
+	blacklisted = TRUE
+	limbs_id = "human"
+	skinned_type = /obj/item/stack/sheet/animalhide/human
+	var/info_text = "You are a <span class='danger'>Vampire</span>. You will slowly but constantly lose blood if outside of a coffin. If inside a coffin, you will slowly heal. You may gain more blood by grabbing a live victim and using your drain ability."
+
+/datum/species/vampire/check_roundstart_eligible()
+	if(SSevents.holidays && SSevents.holidays[HALLOWEEN])
+		return TRUE
+	return FALSE
+
+/datum/species/vampire/on_species_gain(mob/living/carbon/human/C, datum/species/old_species)
+	. = ..()
+	to_chat(C, "[info_text]")
+	C.skin_tone = "albino"
+	C.update_body(0)
+	var/obj/effect/proc_holder/spell/targeted/shapeshift/bat/B = new
+	C.AddSpell(B)
+
+/datum/species/vampire/spec_life(mob/living/carbon/human/C)
+	. = ..()
+	if(istype(C.loc, /obj/structure/closet/coffin))
+		C.heal_overall_damage(4,4)
+		C.adjustToxLoss(-4)
+		C.adjustOxyLoss(-4)
+		return
+	C.blood_volume -= 1.5
+	if(C.blood_volume <= 0)
+		to_chat(C, "<span class='danger'>You ran out of blood!</span>")
+		C.dust()
+	var/area/A = get_area(C)
+	if(istype(A, /area/chapel))
+		to_chat(C, "<span class='danger'>You don't belong here!</span>")
+		C.adjustFireLoss(20)
+		C.adjust_fire_stacks(6)
+		C.IgniteMob()
+
+/obj/item/organ/tongue/vampire
+	name = "vampire tongue"
+	actions_types = list(/datum/action/item_action/organ_action/vampire)
+	color = "#1C1C1C"
+
+/datum/action/item_action/organ_action/vampire/Trigger()
+	. = ..()
+	if(iscarbon(owner))
+		var/mob/living/carbon/H = owner
+		if(H.pulling && iscarbon(H.pulling))
+			var/mob/living/carbon/victim = H.pulling
+			if(victim.stat == DEAD)
+				to_chat(H, "<span class='notice'>You need a living victim!</span>")
+				return
+			if(victim.blood_volume < 50)
+				to_chat(H, "<span class='notice'>Your victim doesn't have enough blood left.</span>")
+				return
+			if(!do_after(H, 30, target = victim))
+				return
+			to_chat(victim, "<span class='danger'>[H] is draining your blood!</span>")
+			to_chat(H, "<span class='notice'>You drain some blood!</span>")
+			playsound(H, 'sound/items/drink.ogg', 30, 1, -2)
+			victim.blood_volume = Clamp(victim.blood_volume - 50, 0, BLOOD_VOLUME_MAXIMUM)
+			H.blood_volume = Clamp(H.blood_volume + 50, 0, BLOOD_VOLUME_MAXIMUM)
+
+/obj/effect/proc_holder/spell/targeted/shapeshift/bat
+	name = "Bat Form"
+	desc = "Take on the shape a space bat."
+	invocation = "Squeak!"
+
+	shapeshift_type = /mob/living/simple_animal/hostile/retaliate/bat
+	list/current_shapes = list(/mob/living/simple_animal/hostile/retaliate/bat)
+	list/current_casters = list()
+	list/possible_shapes = list(/mob/living/simple_animal/hostile/retaliate/bat)

--- a/code/modules/mob/living/carbon/human/species_types/vampire.dm
+++ b/code/modules/mob/living/carbon/human/species_types/vampire.dm
@@ -2,7 +2,7 @@
 	name = "vampire"
 	id = "vampire"
 	default_color = "FFFFFF"
-	species_traits = list(EYECOLOR,HAIR,FACEHAIR,LIPS,NOHUNGER)
+	species_traits = list(EYECOLOR,HAIR,FACEHAIR,LIPS,NOHUNGER,NOBREATH)
 	mutant_bodyparts = list("tail_human", "ears", "wings")
 	default_features = list("mcolor" = "FFF", "tail_human" = "None", "ears" = "None", "wings" = "None")
 	use_skintones = TRUE
@@ -32,9 +32,10 @@
 		C.heal_overall_damage(4,4)
 		C.adjustToxLoss(-4)
 		C.adjustOxyLoss(-4)
+		C.adjustCloneLoss(-4)
 		return
 	C.blood_volume -= 1.5
-	if(C.blood_volume <= 0)
+	if(C.blood_volume <= BLOOD_VOLUME_SURVIVE)
 		to_chat(C, "<span class='danger'>You ran out of blood!</span>")
 		C.dust()
 	var/area/A = get_area(C)
@@ -67,6 +68,9 @@
 			if(victim.stat == DEAD)
 				to_chat(H, "<span class='notice'>You need a living victim!</span>")
 				return
+			if(victim.dna && ((NOBLOOD in victim.dna.species.species_traits) || victim.dna.species.exotic_bloodtype))
+				to_chat(H, "<span class='notice'>Your victim doesn't have blood!</span>")
+				return
 			if(victim.blood_volume < 50)
 				to_chat(H, "<span class='notice'>Your victim doesn't have enough blood left.</span>")
 				return
@@ -85,6 +89,6 @@
 	invocation = "Squeak!"
 
 	shapeshift_type = /mob/living/simple_animal/hostile/retaliate/bat
-	list/current_shapes = list(/mob/living/simple_animal/hostile/retaliate/bat)
-	list/current_casters = list()
-	list/possible_shapes = list(/mob/living/simple_animal/hostile/retaliate/bat)
+	current_shapes = list(/mob/living/simple_animal/hostile/retaliate/bat)
+	current_casters = list()
+	possible_shapes = list(/mob/living/simple_animal/hostile/retaliate/bat)

--- a/code/modules/mob/living/carbon/human/species_types/vampire.dm
+++ b/code/modules/mob/living/carbon/human/species_types/vampire.dm
@@ -48,6 +48,7 @@
 	name = "vampire tongue"
 	actions_types = list(/datum/action/item_action/organ_action/vampire)
 	color = "#1C1C1C"
+	var/drain_cooldown = 0
 
 /datum/action/item_action/organ_action/vampire
 	name = "Drain Victim"
@@ -57,21 +58,26 @@
 	. = ..()
 	if(iscarbon(owner))
 		var/mob/living/carbon/H = owner
+		var/obj/item/organ/tongue/vampire/V = target
+		if(V.drain_cooldown >= world.time)
+			to_chat(H, "<span class='notice'>You just drained blood, wait a few seconds.</span>")
+			return
 		if(H.pulling && iscarbon(H.pulling))
 			var/mob/living/carbon/victim = H.pulling
 			if(victim.stat == DEAD)
 				to_chat(H, "<span class='notice'>You need a living victim!</span>")
 				return
-			if(victim.blood_volume < 50)
+			if(victim.blood_volume < 100)
 				to_chat(H, "<span class='notice'>Your victim doesn't have enough blood left.</span>")
 				return
+			V.drain_cooldown = world.time + 30
 			if(!do_after(H, 30, target = victim))
 				return
 			to_chat(victim, "<span class='danger'>[H] is draining your blood!</span>")
 			to_chat(H, "<span class='notice'>You drain some blood!</span>")
 			playsound(H, 'sound/items/drink.ogg', 30, 1, -2)
-			victim.blood_volume = Clamp(victim.blood_volume - 50, 0, BLOOD_VOLUME_MAXIMUM)
-			H.blood_volume = Clamp(H.blood_volume + 50, 0, BLOOD_VOLUME_MAXIMUM)
+			victim.blood_volume = Clamp(victim.blood_volume - 100, 0, BLOOD_VOLUME_MAXIMUM)
+			H.blood_volume = Clamp(H.blood_volume + 100, 0, BLOOD_VOLUME_MAXIMUM)
 
 /obj/effect/proc_holder/spell/targeted/shapeshift/bat
 	name = "Bat Form"

--- a/code/modules/mob/living/carbon/human/species_types/vampire.dm
+++ b/code/modules/mob/living/carbon/human/species_types/vampire.dm
@@ -49,6 +49,10 @@
 	actions_types = list(/datum/action/item_action/organ_action/vampire)
 	color = "#1C1C1C"
 
+/datum/action/item_action/organ_action/vampire
+	name = "Drain Victim"
+	desc = "Leech blood from any carbon victim you are passively grabbing."
+
 /datum/action/item_action/organ_action/vampire/Trigger()
 	. = ..()
 	if(iscarbon(owner))

--- a/code/modules/mob/living/carbon/human/species_types/vampire.dm
+++ b/code/modules/mob/living/carbon/human/species_types/vampire.dm
@@ -2,9 +2,10 @@
 	name = "vampire"
 	id = "vampire"
 	default_color = "FFFFFF"
-	species_traits = list(EYECOLOR,HAIR,FACEHAIR,LIPS,NOHUNGER,NOBREATH)
+	species_traits = list(EYECOLOR,HAIR,FACEHAIR,LIPS,NOHUNGER,NOBREATH,DRINKSBLOOD)
 	mutant_bodyparts = list("tail_human", "ears", "wings")
 	default_features = list("mcolor" = "FFF", "tail_human" = "None", "ears" = "None", "wings" = "None")
+	exotic_bloodtype = "V"
 	use_skintones = TRUE
 	mutanteyes = /obj/item/organ/eyes/night_vision
 	mutanttongue = /obj/item/organ/tongue/vampire

--- a/code/modules/reagents/chemistry/reagents/other_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/other_reagents.dm
@@ -24,9 +24,9 @@
 			else //ingest, patch or inject
 				M.ForceContractDisease(D)
 
-	if(method == INJECT && iscarbon(M))
+	if(iscarbon(M))
 		var/mob/living/carbon/C = M
-		if(C.get_blood_id() == "blood")
+		if(C.get_blood_id() == "blood" && (method == INJECT || (method == INGEST && C.dna && C.dna.species && (DRINKSBLOOD in C.dna.species.species_traits))))
 			if(!data || !(data["blood_type"] in get_safe_blood(C.dna.blood_type)))
 				C.reagents.add_reagent("toxin", reac_volume * 0.5)
 			else

--- a/code/modules/reagents/reagent_containers/blood_pack.dm
+++ b/code/modules/reagents/reagent_containers/blood_pack.dm
@@ -65,8 +65,8 @@
 /obj/item/reagent_containers/blood/lizard
 	blood_type = "L"
 
-/obj/item/reagent_containers/blood/vampire
-	blood_type = "V"
+/obj/item/reagent_containers/blood/universal
+	blood_type = "U"
 
 /obj/item/reagent_containers/blood/empty
 	name = "blood pack"

--- a/code/modules/reagents/reagent_containers/blood_pack.dm
+++ b/code/modules/reagents/reagent_containers/blood_pack.dm
@@ -65,6 +65,9 @@
 /obj/item/reagent_containers/blood/lizard
 	blood_type = "L"
 
+/obj/item/reagent_containers/blood/vampire
+	blood_type = "V"
+
 /obj/item/reagent_containers/blood/empty
 	name = "blood pack"
 	icon_state = "empty"

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -1658,6 +1658,7 @@
 #include "code\modules\mob\living\carbon\human\species_types\shadowpeople.dm"
 #include "code\modules\mob\living\carbon\human\species_types\skeletons.dm"
 #include "code\modules\mob\living\carbon\human\species_types\synths.dm"
+#include "code\modules\mob\living\carbon\human\species_types\vampire.dm"
 #include "code\modules\mob\living\carbon\human\species_types\zombies.dm"
 #include "code\modules\mob\living\carbon\monkey\combat.dm"
 #include "code\modules\mob\living\carbon\monkey\death.dm"


### PR DESCRIPTION
:cl: Kor
add: Added vampires. They will be available as a roundstart race during the Halloween holiday event.
/:cl:

Vampires are another halloween species. 

They slowly lose blood constantly (unless in a coffin). They dust if they run out of blood.

They heal in coffins (but do not restore blood)

They can drain blood from other mobs they have in a passive grab.

They can turn into a bat.

They catch on fire if they enter the chapel.

Why: The more variety for halloween races the merrier. Having the background pressure of keeping your blood level up and finding "donors" without getting spaced by the AI might be fun as a limited time gimmick. This is also, bizarrely, one of the more commonly requested features as well.