### PR TITLE
Fixes a common runtime on prefs screen

### DIFF
--- a/code/modules/surgery/bodyparts/dismemberment.dm
+++ b/code/modules/surgery/bodyparts/dismemberment.dm
@@ -121,14 +121,22 @@
 			O.transfer_to_limb(src, C)
 
 	update_icon_dropped()
-	forceMove(T)
 	C.update_health_hud() //update the healthdoll
 	C.update_body()
 	C.update_hair()
 	C.update_canmove()
+
+	if(!T)	// T = null happens when a "dummy human" used for rendering icons on prefs screen gets its limbs replaced.
+		qdel(src)
+		return
+
 	if(is_pseudopart)
 		drop_organs(C)	//Psuedoparts shouldn't have organs, but just in case
 		qdel(src)
+		return
+
+	forceMove(T)
+
 
 
 //when a limb is dropped, the internal organs are removed from the mob and put into the limb


### PR DESCRIPTION
The runtime was caused by limbs being replaced on dummy mobs used for generation of pref icons. For now, the only reason that happens is digitigrade legs being enabled or disabled.

One runtime fix a day keeps Baystation level of codebase clusterfuck away.