### PR TITLE
Adds single use autosurgeons for both the RD and HoS to their lockers.

### DIFF
--- a/code/game/objects/structures/crates_lockers/closets/secure/medical.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/medical.dm
@@ -70,7 +70,7 @@
 	new /obj/item/device/healthanalyzer/advanced(src)
 	new /obj/item/device/assembly/flash/handheld(src)
 	new /obj/item/reagent_containers/hypospray/CMO(src)
-	new /obj/item/device/autosurgeon/cmo(src)
+	new /obj/item/device/autosurgeon/single_use/cmo(src)
 	new /obj/item/door_remote/chief_medical_officer(src)
 
 /obj/structure/closet/secure_closet/animal

--- a/code/game/objects/structures/crates_lockers/closets/secure/scientist.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/scientist.dm
@@ -25,3 +25,4 @@
 	new /obj/item/device/laser_pointer(src)
 	new /obj/item/door_remote/research_director(src)
 	new /obj/item/storage/box/firingpins(src)
+	new /obj/item/device/autosurgeon/single_use/rd(src)

--- a/code/game/objects/structures/crates_lockers/closets/secure/security.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/security.dm
@@ -84,6 +84,7 @@
 	new /obj/item/gun/energy/e_gun/hos(src)
 	new /obj/item/device/flashlight/seclite(src)
 	new /obj/item/pinpointer/nuke(src)
+	new /obj/item/device/autosurgeon/single_use/hos(src)
 
 /obj/structure/closet/secure_closet/warden
 	name = "\proper warden's locker"

--- a/code/modules/surgery/organs/augments_eyes.dm
+++ b/code/modules/surgery/organs/augments_eyes.dm
@@ -40,6 +40,12 @@
 	origin_tech = "materials=4;programming=4;biotech=3;combat=3"
 	HUD_type = DATA_HUD_SECURITY_ADVANCED
 
+/obj/item/organ/cyberimp/eyes/hud/diagnostics
+	name = "Diagnostics HUD implant"
+	desc = "These Cybernetic eye implants will display a diagnostic HUD over robots and mechas."
+	origin_tech = "materials=4;programming=4;biotech=4;engineering=4"
+	HUD_type = DATA_HUD_DIAGNOSTIC
+
 /obj/item/organ/cyberimp/eyes/hud/security/syndicate
 	name = "Contraband Security HUD Implant"
 	desc = "A Cybersun Industries brand Security HUD Implant. These illicit cybernetic eye implants will display a security HUD over everything you see."

--- a/code/modules/surgery/organs/autosurgeon.dm
+++ b/code/modules/surgery/organs/autosurgeon.dm
@@ -68,10 +68,20 @@
 			if(!uses)
 				desc = "[initial(desc)] Looks like it's been used up."
 
-/obj/item/device/autosurgeon/cmo
-	desc = "A single use autosurgeon that contains a medical heads-up display augment. A screwdriver can be used to remove it, but implants can't be placed back in."
+/obj/item/device/autosurgeon/single_use
 	uses = 1
+
+/obj/item/device/autosurgeon/single_use/cmo
+	desc = "A single use autosurgeon that contains a medical heads-up display augment. A screwdriver can be used to remove it, but implants can't be placed back in."
 	starting_organ = /obj/item/organ/cyberimp/eyes/hud/medical
+
+/obj/item/device/autosurgeon/single_use/hos
+	desc = "A single use autosurgeon that contains a security heads-up display augment. A screwdriver can be used to remove it, but implants can't be placed back in."
+	starting_organ = /obj/item/organ/cyberimp/eyes/hud/security
+
+/obj/item/device/autosurgeon/single_use/rd
+	desc = "A single use autosurgeon that contains a diagnostics heads-up display augment. A screwdriver can be used to remove it, but implants can't be placed back in."
+	starting_organ = /obj/item/organ/cyberimp/eyes/hud/diagnostics
 
 
 /obj/item/device/autosurgeon/thermal_eyes


### PR DESCRIPTION
This PR adds two new autosurgeons. One for a security hud, and another for a diagnostics hud. And it adds the security one to the HoS's locker, and the diagnostic one to the RD's locker. I was inspired by the CMO recieving a medical hud autosurgeon.

:cl: Firecage
add: Adds a security autosurgeon to the HoS locker, and a diadnostics autosurgeon to the RD locker. Be warned, only one set of eye augments can be active at a time. Using another will remove the one you had and replace it.
/:cl:
