### PR TITLE
"Mummies" (cloth golems) for Halloween

### DIFF
--- a/code/modules/mob/living/carbon/human/species_types/golems.dm
+++ b/code/modules/mob/living/carbon/human/species_types/golems.dm
@@ -647,6 +647,11 @@
 	punchdamagehigh = 8 // not as heavy as stone
 	prefix = "Cloth"
 
+/datum/species/golem/cloth/check_roundstart_eligible()
+	if(SSevents.holidays && SSevents.holidays[HALLOWEEN])
+		return TRUE
+	return ..()
+
 /datum/species/golem/cloth/random_name(gender,unique,lastname)
 	var/pharaoh_name = pick("Neferkare", "Hudjefa", "Khufu", "Mentuhotep", "Ahmose", "Amenhotep", "Thutmose", "Hatshepsut", "Tutankhamun", "Ramses", "Seti", \
 	"Merenptah", "Djer", "Semerkhet", "Nynetjer", "Khafre", "Pepi", "Intef", "Ay") //yes, Ay was an actual pharaoh


### PR DESCRIPTION
:cl: Kor
add: Cloth golems will be available as a roundstart race during Halloween.
/:cl:

Why: They're basically mummies so they fit the theme, already coded/sprited/tested/balanced etc, and the more variety we have in Halloween races the less likely it will be that every single person is a skeleton.

Last one* I promise

*This year anyway