### PR TITLE
Opening a PR requires a 25 cent deposit to be returned on merge.

### DIFF
--- a/tools/WebhookProcessor/github_webhook_processor.php
+++ b/tools/WebhookProcessor/github_webhook_processor.php
@@ -364,6 +364,7 @@ function handle_pr($payload) {
 			tag_pr($payload, true);
 			if($no_changelog)
 				check_dismiss_changelog_review($payload);
+			update_pr_balance($payload, -0.25);
 			if(get_pr_code_friendliness($payload) < 0){
 				$balances = pr_balances();
 				$author = $payload['pull_request']['user']['login'];
@@ -384,6 +385,7 @@ function handle_pr($payload) {
 		case 'closed':
 			if (!$payload['pull_request']['merged']) {
 				$action = 'closed';
+
 			}
 			else {
 				$action = 'merged';
@@ -499,7 +501,7 @@ function is_maintainer($payload, $author){
 }
 
 //payload is a merged pull request, updates the pr balances file with the correct positive or negative balance based on comments
-function update_pr_balance($payload) {
+function update_pr_balance($payload, $delta = null) {
 	global $startingPRBalance;
 	global $trackPRBalance;
 	if(!$trackPRBalance)
@@ -508,7 +510,9 @@ function update_pr_balance($payload) {
 	$balances = pr_balances();
 	if(!isset($balances[$author]))
 		$balances[$author] = $startingPRBalance;
-	$friendliness = get_pr_code_friendliness($payload, $balances[$author]);
+	$friendliness = $delta;
+	if ($delta === NULL)
+		$friendliness = 0.25+get_pr_code_friendliness($payload, $balances[$author]);
 	$balances[$author] += $friendliness;
 	if(!is_maintainer($payload, $author)){	//immune
 		if($balances[$author] < 0 && $friendliness < 0)


### PR DESCRIPTION
When you open a pr, 0.25 points are taken from your balance. When a pr of yours is merged, 0.25 points are added to your balance (on top of everything else (if anything)).

This is to create a very slight discouragement to making meme prs (while still allowing for them on occasion).

The amount is low because of how often a pr is closed because of a better fix, or other legit reasons (like test merge only prs and what not) (this is also to mirror the "aldi's" shopping cart system of requiring a 25 cent deposit to get a shopping cart that is returned if you bring your cart back to the front of the store, to avoid having to pay for cart attendants to fetch them from the parking lot)

This only applies on first initial open.

@tgstation/commit-access 