### PR TITLE
text2path wrapper for sdql2 as a shitty workaround to it not parsing paths

### DIFF
--- a/code/modules/admin/verbs/SDQL2/SDQL_2_wrappers.dm
+++ b/code/modules/admin/verbs/SDQL2/SDQL_2_wrappers.dm
@@ -176,6 +176,12 @@
 /proc/_list_swap(list/L, Index1, Index2)
 	L.Swap(Index1, Index2)
 
+/proc/_text2path(text)
+	return text2path(text)
+
+/proc/_path2text(path)
+	return "[path]"
+
 /proc/_walk(ref, dir, lag)
 	walk(ref, dir, lag)
 

--- a/code/modules/admin/verbs/SDQL2/SDQL_2_wrappers.dm
+++ b/code/modules/admin/verbs/SDQL2/SDQL_2_wrappers.dm
@@ -179,7 +179,7 @@
 /proc/_text2path(text)
 	return text2path(text)
 
-/proc/_path2text(path)
+/proc/_path2string(path)
 	return "[path]"
 
 /proc/_walk(ref, dir, lag)


### PR DESCRIPTION
Daily reminder I don't actually know how to modify sdql2 code and I just use it because somehow I get it to work?