### PR TITLE
Fixes motion cameras runtiming when a target is deleted before they are detected to be  leaving the range/dead.

### DIFF
--- a/code/game/machinery/camera/motion.dm
+++ b/code/game/machinery/camera/motion.dm
@@ -17,7 +17,7 @@
 	else if (detectTime == -1)
 		for (var/targetref in getTargetList())
 			var/mob/target = locate(targetref) in GLOB.mob_list
-			if (target.stat == DEAD || QDELETED(target) || (!area_motion && !in_range(src, target)))
+			if (QDELETED(target) || target.stat == DEAD || (!area_motion && !in_range(src, target)))
 				//If not part of a monitored area and the camera is not in range or the target is dead
 				lostTarget(target)
 


### PR DESCRIPTION
moves qdeleted check up before target.stat == DEAD