### PR TITLE
Makes rollerbeds normal-sized items

### DIFF
--- a/code/game/objects/structures/beds_chairs/bed.dm
+++ b/code/game/objects/structures/beds_chairs/bed.dm
@@ -105,7 +105,7 @@
 	desc = "A collapsed roller bed that can be carried around."
 	icon = 'icons/obj/rollerbed.dmi'
 	icon_state = "folded"
-	w_class = WEIGHT_CLASS_BULKY // Can't be put in backpacks.
+	w_class = WEIGHT_CLASS_NORMAL // No more excuses, stop getting blood everywhere
 
 /obj/item/roller/attackby(obj/item/I, mob/living/user, params)
 	if(istype(I, /obj/item/roller/robo))


### PR DESCRIPTION
[Changelogs]: Rollerbeds are now normal-sized

:cl: optional name here
tweak: Rollerbeds are now normal-sized
/:cl:

[why]: Allows medical doctors to use rollerbeds to transport a patient without causing them to lose blood. There are other methods sure but none quite so convenient or carryable as the rollerbed (and people seem to think something untoward is happening if you use bodybags).
