### PR TITLE
Allows filling welders from open containers that have welding fuel in them

### DIFF
--- a/code/game/objects/items/tools.dm
+++ b/code/game/objects/items/tools.dm
@@ -462,7 +462,7 @@
 		var/obj/item/reagent_containers/container = I
 		if(amountNeeded > 0 && container.reagents.has_reagent("welding_fuel"))
 			container.reagents.trans_id_to(src, "welding_fuel", amountNeeded)
-			to_chat(user, "<span class='notice'>You transfer some fuel from \the [container] to \the [src].</span>")
+			to_chat(user, "<span class='notice'>You transfer some fuel from [container] to [src].</span>")
 	else
 		return ..()
 

--- a/code/game/objects/items/tools.dm
+++ b/code/game/objects/items/tools.dm
@@ -461,8 +461,8 @@
 		var/amountNeeded = max_fuel - get_fuel()
 		var/obj/item/reagent_containers/container = I
 		if(length(container.reagents.reagent_list) > 1)
-				to_chat(user, "<span class='warning'>[container] has too many chemicals mixed into it. You wouldn't want to put the wrong chemicals into [src].</span>")
-				return ..()
+			to_chat(user, "<span class='warning'>[container] has too many chemicals mixed into it. You wouldn't want to put the wrong chemicals into [src].</span>")
+			return ..()
 		if(amountNeeded > 0 && container.reagents.has_reagent("welding_fuel"))
 			container.reagents.trans_id_to(src, "welding_fuel", amountNeeded)
 			to_chat(user, "<span class='notice'>You transfer some fuel from [container] to [src].</span>")

--- a/code/game/objects/items/tools.dm
+++ b/code/game/objects/items/tools.dm
@@ -457,7 +457,7 @@
 		flamethrower_screwdriver(I, user)
 	else if(istype(I, /obj/item/stack/rods))
 		flamethrower_rods(I, user)
-	else if(istype(I, /obj/item/reagent_containers) && (I.container_type & OPENCONTAINER_1))
+	else if(istype(I, /obj/item/reagent_containers) && is_open_container())
 		var/amountNeeded = max_fuel - get_fuel()
 		var/obj/item/reagent_containers/container = I
 		if(amountNeeded > 0 && container.reagents.has_reagent("welding_fuel"))

--- a/code/game/objects/items/tools.dm
+++ b/code/game/objects/items/tools.dm
@@ -460,6 +460,9 @@
 	else if(istype(I, /obj/item/reagent_containers) && is_open_container())
 		var/amountNeeded = max_fuel - get_fuel()
 		var/obj/item/reagent_containers/container = I
+		if(length(container.reagents.reagent_list) > 1)
+				to_chat(user, "<span class='warning'>[container] has too many chemicals mixed into it. You wouldn't want to put the wrong chemicals into [src].</span>")
+				return ..()
 		if(amountNeeded > 0 && container.reagents.has_reagent("welding_fuel"))
 			container.reagents.trans_id_to(src, "welding_fuel", amountNeeded)
 			to_chat(user, "<span class='notice'>You transfer some fuel from [container] to [src].</span>")

--- a/code/game/objects/items/tools.dm
+++ b/code/game/objects/items/tools.dm
@@ -458,7 +458,7 @@
 	else if(istype(I, /obj/item/stack/rods))
 		flamethrower_rods(I, user)
 	else if(istype(I, /obj/item/reagent_containers) && (I.container_type & OPENCONTAINER_1))
-		var/amountNeeded = max_fuel - getFuel()
+		var/amountNeeded = max_fuel - get_fuel()
 		var/obj/item/reagent_containers/container = I
 		if(amountNeeded > 0 && container.reagents.has_reagent("welding_fuel"))
 			container.reagents.trans_id_to(src, "welding_fuel", amountNeeded)

--- a/code/game/objects/items/tools.dm
+++ b/code/game/objects/items/tools.dm
@@ -461,7 +461,7 @@
 		var/amountNeeded = max_fuel - getFuel()
 		var/obj/item/reagent_containers/container = I
 		if(amountNeeded > 0 && container.reagents.has_reagent("welding_fuel"))
-			trans_id_to(src, "welding_fuel", amountNeeded)
+			container.reagents.trans_id_to(src, "welding_fuel", amountNeeded)
 	else
 		return ..()
 

--- a/code/game/objects/items/tools.dm
+++ b/code/game/objects/items/tools.dm
@@ -457,6 +457,11 @@
 		flamethrower_screwdriver(I, user)
 	else if(istype(I, /obj/item/stack/rods))
 		flamethrower_rods(I, user)
+	else if(istype(I, /obj/item/reagent_containers) && (I.container_type & OPENCONTAINER_1))
+		var/amountNeeded = max_fuel - getFuel()
+		var/obj/item/reagent_containers/container = I
+		if(amountNeeded > 0 && container.reagents.has_reagent("welding_fuel"))
+			trans_id_to(src, "welding_fuel", amountNeeded)
 	else
 		return ..()
 

--- a/code/game/objects/items/tools.dm
+++ b/code/game/objects/items/tools.dm
@@ -462,6 +462,7 @@
 		var/obj/item/reagent_containers/container = I
 		if(amountNeeded > 0 && container.reagents.has_reagent("welding_fuel"))
 			container.reagents.trans_id_to(src, "welding_fuel", amountNeeded)
+			to_chat(user, "<span class='notice'>You transfer some fuel from \the [container] to \the [src].</span>")
 	else
 		return ..()
 


### PR DESCRIPTION
🆑
tweak: You can now use beakers/cups/etc that have welding fuel in them on welders to refuel them.
/:cl:

Closes https://github.com/tgstation/tgstation/issues/31339