### PR TITLE
Fixes a camera issue with scout holoparasites

### DIFF
--- a/code/modules/mob/living/simple_animal/guardian/guardian.dm
+++ b/code/modules/mob/living/simple_animal/guardian/guardian.dm
@@ -320,6 +320,7 @@ GLOBAL_LIST_EMPTY(parasites) //all currently existing/living guardians
 		forceMove(summoner.loc)
 		new /obj/effect/temp_visual/guardian/phase(loc)
 		cooldown = world.time + 10
+		reset_perspective()
 		return TRUE
 	return FALSE
 


### PR DESCRIPTION
:cl:
fix: Ranged holoparasites in the scout mode have had their camera fixed.
/:cl:

Fixes https://github.com/tgstation/tgstation/issues/29146
Uses the fix mentioned in https://github.com/tgstation/tgstation/issues/29146#issuecomment-313998787 by @ExcessiveUseOfCobblestone so if it doesn't work it is their fault