### PR TITLE
Fixes rollies not being effective

### DIFF
--- a/code/game/objects/items/cigs_lighters.dm
+++ b/code/game/objects/items/cigs_lighters.dm
@@ -301,6 +301,7 @@ CIGARETTE PACKETS ARE IN FANCY.DM
 	item_state = "spliffoff"
 	smoketime = 180
 	chem_volume = 50
+	list_reagents = null
 
 /obj/item/clothing/mask/cigarette/rollie/New()
 	..()


### PR DESCRIPTION
Rollies inherited cigarettes default reagents, which was nicotine, and inherited cigarettes set up, which automatically inserted nicotine into the cigarette. This means that any rollie made with any ingredients will have nicotine in it, and supposedly this is smoked before any other reagents. The cigarette set up procedure has a clause that does not insert anything if the default reagents list is null, however, so I've simply nulled the default reagents list for rollies.

Possibly fixes https://github.com/tgstation/tgstation/issues/20143 but I haven't tested.
Uses a fix based off of the notes in https://github.com/tgstation/tgstation/issues/20143#issuecomment-294937180 by @Tacolizard 