### PR TITLE
Meteor gating tweaks

### DIFF
--- a/code/modules/events/meteor_wave.dm
+++ b/code/modules/events/meteor_wave.dm
@@ -4,7 +4,7 @@
 	name = "Meteor Wave: Normal"
 	typepath = /datum/round_event/meteor_wave
 	weight = 4
-	min_players = 25
+	min_players = 15
 	max_occurrences = 3
 	earliest_start = 25 MINUTES
 
@@ -56,7 +56,7 @@
 	name = "Meteor Wave: Threatening"
 	typepath = /datum/round_event/meteor_wave/threatening
 	weight = 5
-	min_players = 35
+	min_players = 20
 	max_occurrences = 3
 	earliest_start = 35 MINUTES
 
@@ -67,7 +67,7 @@
 	name = "Meteor Wave: Catastrophic"
 	typepath = /datum/round_event/meteor_wave/catastrophic
 	weight = 7
-	min_players = 50
+	min_players = 25
 	max_occurrences = 3
 	earliest_start = 45 MINUTES
 

--- a/code/modules/events/meteor_wave.dm
+++ b/code/modules/events/meteor_wave.dm
@@ -4,8 +4,9 @@
 	name = "Meteor Wave: Normal"
 	typepath = /datum/round_event/meteor_wave
 	weight = 4
-	min_players = 5
+	min_players = 25
 	max_occurrences = 3
+	earliest_start = 25 MINUTES
 
 /datum/round_event/meteor_wave
 	startWhen		= 6
@@ -54,9 +55,10 @@
 /datum/round_event_control/meteor_wave/threatening
 	name = "Meteor Wave: Threatening"
 	typepath = /datum/round_event/meteor_wave/threatening
-	weight = 2
-	min_players = 5
+	weight = 5
+	min_players = 35
 	max_occurrences = 3
+	earliest_start = 35 MINUTES
 
 /datum/round_event/meteor_wave/threatening
 	wave_name = "threatening"
@@ -64,9 +66,10 @@
 /datum/round_event_control/meteor_wave/catastrophic
 	name = "Meteor Wave: Catastrophic"
 	typepath = /datum/round_event/meteor_wave/catastrophic
-	weight = 1
-	min_players = 5
+	weight = 7
+	min_players = 50
 	max_occurrences = 3
+	earliest_start = 45 MINUTES
 
 /datum/round_event/meteor_wave/catastrophic
 	wave_name = "catastrophic"


### PR DESCRIPTION
:cl:
tweak: Meteor events will not happen before 25 minutes, the worst versions before 35 and 45 minutes. 
tweak: Meteor events are now player gated to 15, 20, and 25 players respectively
balance: The more destructive versions of meteor events now have a slightly higher chance of triggering, to offset the decrease in how often it is that they will even qualify.
/:cl:

[why]: # (Please add a short description [two lines down] of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.)

Because people on the forums said they were happening too early.
