### PR TITLE
Events take pre-game lobby time into account

### DIFF
--- a/code/modules/events/_event.dm
+++ b/code/modules/events/_event.dm
@@ -40,7 +40,7 @@
 /datum/round_event_control/proc/canSpawnEvent(var/players_amt, var/gamemode)
 	if(occurrences >= max_occurrences)
 		return FALSE
-	if(earliest_start >= world.time-ticker.ound_start_time)
+	if(earliest_start >= world.time-ticker.round_start_time)
 		return FALSE
 	if(wizardevent != SSevents.wizardmode)
 		return FALSE

--- a/code/modules/events/_event.dm
+++ b/code/modules/events/_event.dm
@@ -40,7 +40,7 @@
 /datum/round_event_control/proc/canSpawnEvent(var/players_amt, var/gamemode)
 	if(occurrences >= max_occurrences)
 		return FALSE
-	if(earliest_start >= world.time)
+	if(earliest_start >= world.time-ticker.ound_start_time)
 		return FALSE
 	if(wizardevent != SSevents.wizardmode)
 		return FALSE

--- a/code/modules/events/_event.dm
+++ b/code/modules/events/_event.dm
@@ -40,7 +40,7 @@
 /datum/round_event_control/proc/canSpawnEvent(var/players_amt, var/gamemode)
 	if(occurrences >= max_occurrences)
 		return FALSE
-	if(earliest_start >= world.time-ticker.round_start_time)
+	if(earliest_start >= world.time-SSticker.round_start_time)
 		return FALSE
 	if(wizardevent != SSevents.wizardmode)
 		return FALSE


### PR DESCRIPTION
Meteors happening before the shuttle can even be called was lame.