### PR TITLE
Fixes webhook tagging when tree is found anywhere

### DIFF
--- a/tools/WebhookProcessor/github_webhook_processor.php
+++ b/tools/WebhookProcessor/github_webhook_processor.php
@@ -547,7 +547,7 @@ function has_tree_been_edited($payload, $tree){
 	}
 	//find things in the _maps/map_files tree
 	//e.g. diff --git a/_maps/map_files/Cerestation/cerestation.dmm b/_maps/map_files/Cerestation/cerestation.dmm
-	return $github_diff !== FALSE && strpos($github_diff, 'diff --git a/' . $tree) !== FALSE;
+	return $github_diff !== FALSE && preg_match('/^diff --git a\/' . preg_quote($tree, '/') . '/m') !== FALSE;
 }
 
 $no_changelog = false;


### PR DESCRIPTION
As an example, this pr will be tagged as a map edit even though it doesn't edit the map, because of the comment at line 549 which is included in the diff context.

This fixes that issue by making sure the matched line starts with diff --git a/$tree instead of merely containing it.