### PR TITLE
Actually fixes meteors, again

### DIFF
--- a/code/game/gamemodes/meteor/meteors.dm
+++ b/code/game/gamemodes/meteor/meteors.dm
@@ -98,7 +98,7 @@ GLOBAL_LIST_INIT(meteorsC, list(/obj/effect/meteor/dust)) //for space dust event
 	var/z_original = ZLEVEL_STATION_PRIMARY
 	var/threat = 0 // used for determining which meteors are most interesting
 	var/lifetime = DEFAULT_METEOR_LIFETIME
-
+	var/timerid = null
 	var/list/meteordrop = list(/obj/item/ore/iron)
 	var/dropamt = 2
 
@@ -117,6 +117,8 @@ GLOBAL_LIST_INIT(meteorsC, list(/obj/effect/meteor/dust)) //for space dust event
 			get_hit()
 
 /obj/effect/meteor/Destroy()
+	if (timerid)
+		deltimer(timerid)
 	GLOB.meteor_list -= src
 	SSaugury.unregister_doom(src)
 	walk(src,0) //this cancels the walk_towards() proc
@@ -127,7 +129,7 @@ GLOBAL_LIST_INIT(meteorsC, list(/obj/effect/meteor/dust)) //for space dust event
 	GLOB.meteor_list += src
 	SSaugury.register_doom(src, threat)
 	SpinAnimation()
-	QDEL_IN(src, lifetime)
+	timerid = QDEL_IN(src, lifetime)
 	chase_target(target)
 
 /obj/effect/meteor/Collide(atom/A)

--- a/code/modules/admin/verbs/debug.dm
+++ b/code/modules/admin/verbs/debug.dm
@@ -778,7 +778,7 @@ GLOBAL_PROTECT(LastAdminCalledProc)
 
 /client/proc/cmd_display_init_log()
 	set category = "Debug"
-	set name = "Display Initialzie() Log"
+	set name = "Display Initialize() Log"
 	set desc = "Displays a list of things that didn't handle Initialize() properly"
 
 	usr << browse(replacetext(SSatoms.InitLog(), "\n", "<br>"), "window=initlog")


### PR DESCRIPTION
Meteors will now qdel properly. I've made this PR in the past, but apparently i only got the ones that qdel'd due to the lifetime timer.

This time, it's for reals.

```
/obj/effect/meteor/meaty
qdel() Count: 83
Destroy() Cost: 9ms
```

As a freebie, this PR also finally fixes the "initialzie" typo in the admin debug verbs tab.

:cl: Naksu
fix: Removed meteor-related free lag
/:cl:
