### PR TITLE
Buffs two Clock Cult stuns

### DIFF
--- a/code/game/gamemodes/clock_cult/clock_effects/clock_sigils.dm
+++ b/code/game/gamemodes/clock_cult/clock_effects/clock_sigils.dm
@@ -76,7 +76,7 @@
 	if(iscultist(L))
 		to_chat(L, "<span class='heavy_brass'>\"Watch your step, wretch.\"</span>")
 		L.adjustBruteLoss(10)
-		L.Knockdown(80, FALSE)
+		L.Knockdown(120, FALSE)
 	L.visible_message("<span class='warning'>[src] appears around [L] in a burst of light!</span>", \
 	"<span class='userdanger'>[target_flashed ? "An unseen force":"The glowing sigil around you"] holds you in place!</span>")
 	L.Stun(40)

--- a/code/game/gamemodes/clock_cult/clock_effects/clock_sigils.dm
+++ b/code/game/gamemodes/clock_cult/clock_effects/clock_sigils.dm
@@ -79,7 +79,7 @@
 		L.Knockdown(120, FALSE)
 	L.visible_message("<span class='warning'>[src] appears around [L] in a burst of light!</span>", \
 	"<span class='userdanger'>[target_flashed ? "An unseen force":"The glowing sigil around you"] holds you in place!</span>")
-	L.Stun(40)
+	L.Stun(100)
 	L.apply_status_effect(STATUS_EFFECT_BELLIGERENT)
 	new /obj/effect/temp_visual/ratvar/sigil/transgression(get_turf(src))
 	qdel(src)

--- a/code/game/gamemodes/clock_cult/clock_effects/clock_sigils.dm
+++ b/code/game/gamemodes/clock_cult/clock_effects/clock_sigils.dm
@@ -76,10 +76,10 @@
 	if(iscultist(L))
 		to_chat(L, "<span class='heavy_brass'>\"Watch your step, wretch.\"</span>")
 		L.adjustBruteLoss(10)
-		L.Knockdown(120, FALSE)
+		L.Knockdown(90, FALSE)
 	L.visible_message("<span class='warning'>[src] appears around [L] in a burst of light!</span>", \
 	"<span class='userdanger'>[target_flashed ? "An unseen force":"The glowing sigil around you"] holds you in place!</span>")
-	L.Stun(100)
+	L.Stun(70)
 	L.apply_status_effect(STATUS_EFFECT_BELLIGERENT)
 	new /obj/effect/temp_visual/ratvar/sigil/transgression(get_turf(src))
 	qdel(src)

--- a/code/game/gamemodes/clock_cult/clock_items/judicial_visor.dm
+++ b/code/game/gamemodes/clock_cult/clock_items/judicial_visor.dm
@@ -169,7 +169,7 @@
 		var/datum/status_effect/belligerent/B = C.apply_status_effect(STATUS_EFFECT_BELLIGERENT)
 		if(!QDELETED(B))
 			B.duration = world.time + 30
-			C.Knockdown(5) //knocks down for half a second if affected
+			C.Knockdown(90) //knocks down for 9 seconds if affected
 	sleep(!GLOB.ratvar_approaches ? 16 : 10)
 	name = "judicial blast"
 	layer = ABOVE_ALL_MOB_LAYER

--- a/code/game/gamemodes/clock_cult/clock_items/judicial_visor.dm
+++ b/code/game/gamemodes/clock_cult/clock_items/judicial_visor.dm
@@ -168,8 +168,7 @@
 	for(var/mob/living/carbon/C in range(1, src))
 		var/datum/status_effect/belligerent/B = C.apply_status_effect(STATUS_EFFECT_BELLIGERENT)
 		if(!QDELETED(B))
-			B.duration = world.time + 30
-			C.Knockdown(80) //knocks down for 8 seconds if affected
+			B.duration = world.time + 80
 	sleep(!GLOB.ratvar_approaches ? 16 : 10)
 	name = "judicial blast"
 	layer = ABOVE_ALL_MOB_LAYER
@@ -188,7 +187,7 @@
 			L.visible_message("<span class='warning'>Strange energy flows into [L]'s [I.name]!</span>", \
 			"<span class='userdanger'>Your [I.name] shields you from [src]!</span>")
 			continue
-		L.Knockdown(15) //knocks down briefly when exploding
+		L.Knockdown(80) //knocks down briefly when exploding
 		if(!iscultist(L))
 			L.visible_message("<span class='warning'>[L] is struck by a judicial explosion!</span>", \
 			"<span class='userdanger'>[!issilicon(L) ? "An unseen force slams you into the ground!" : "ERROR: Motor servos disabled by external source!"]</span>")

--- a/code/game/gamemodes/clock_cult/clock_items/judicial_visor.dm
+++ b/code/game/gamemodes/clock_cult/clock_items/judicial_visor.dm
@@ -169,7 +169,7 @@
 		var/datum/status_effect/belligerent/B = C.apply_status_effect(STATUS_EFFECT_BELLIGERENT)
 		if(!QDELETED(B))
 			B.duration = world.time + 30
-			C.Knockdown(90) //knocks down for 9 seconds if affected
+			C.Knockdown(80) //knocks down for 8 seconds if affected
 	sleep(!GLOB.ratvar_approaches ? 16 : 10)
 	name = "judicial blast"
 	layer = ABOVE_ALL_MOB_LAYER

--- a/code/game/gamemodes/clock_cult/clock_items/judicial_visor.dm
+++ b/code/game/gamemodes/clock_cult/clock_items/judicial_visor.dm
@@ -168,7 +168,8 @@
 	for(var/mob/living/carbon/C in range(1, src))
 		var/datum/status_effect/belligerent/B = C.apply_status_effect(STATUS_EFFECT_BELLIGERENT)
 		if(!QDELETED(B))
-			B.duration = world.time + 80
+			B.duration = world.time + 50
+			C.Knockdown(8)
 	sleep(!GLOB.ratvar_approaches ? 16 : 10)
 	name = "judicial blast"
 	layer = ABOVE_ALL_MOB_LAYER
@@ -187,7 +188,7 @@
 			L.visible_message("<span class='warning'>Strange energy flows into [L]'s [I.name]!</span>", \
 			"<span class='userdanger'>Your [I.name] shields you from [src]!</span>")
 			continue
-		L.Knockdown(80) //knocks down briefly when exploding
+		L.Knockdown(55) //knocks down briefly when exploding
 		if(!iscultist(L))
 			L.visible_message("<span class='warning'>[L] is struck by a judicial explosion!</span>", \
 			"<span class='userdanger'>[!issilicon(L) ? "An unseen force slams you into the ground!" : "ERROR: Motor servos disabled by external source!"]</span>")


### PR DESCRIPTION
:cl: Robustin
balance: The Sigil of Transgression (stun rune) and Judicial Visor have both received substantial buffs to their stun duration. 
/:cl:

The stun rune got several nerfs (it glows, anyone can destroy them in one hit) and while its not my favorite tactic it should at least work as advertised. ~~Currently the rune lasts as long as slipping on a goddamn bar of soap.~~ **Just kidding, I misread the code, the rune currently lasts as long a slipping on fucking water, 2 ticks - this really shouldn't be up for debate.**

Likewise the judicial visor, which advertises an AOE stun, stuns for less than a second, considering how horribly long the windup is, and how small the AOE is (compared to say, flashbangs, these babies can't be cooked either, force you to wear "VALID ME" glasses, have the world's most obvious telegraph, etc.), the least they should do is stun long enough (9 seconds) for you to channel cuffs and apply them. 
