### PR TITLE
One more thing to allow more mobs to qdel nicely

### DIFF
--- a/code/_onclick/hud/alert.dm
+++ b/code/_onclick/hud/alert.dm
@@ -15,7 +15,7 @@
  Override makes it so the alert is not replaced until cleared by a clear_alert with clear_override, and it's used for hallucinations.
  */
 
-	if(!category)
+	if(!category || QDELETED(src))
 		return
 
 	var/obj/screen/alert/thealert
@@ -629,4 +629,5 @@ so as to remain in compliance with the most up-to-date laws."
 	. = ..()
 	severity = 0
 	master = null
+	mob_viewer = null
 	screen_loc = ""

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -4,6 +4,8 @@
 	GLOB.living_mob_list -= src
 	GLOB.all_clockwork_mobs -= src
 	GLOB.mob_directory -= tag
+	for (var/alert in alerts)
+		clear_alert(alert, TRUE)
 	if(observers && observers.len)
 		for(var/M in observers)
 			var/mob/dead/observe = M


### PR DESCRIPTION
With this patch, I can play locally with /mob/Destroy() returning QDEL_HINT_QUEUE and #define GC_FAILURE_HARD_LOOKUP. The only thing still harddeling is some initial /mob/dead/new_player from serverjoin, ~but it's a bit late for me to wrap my head around that one. The ref is `## TESTING: Found /mob/dead/new_player [0x3000105] in /client's movingmob var. World -> Naksuasdf` if anyone wants to take a crack at it.~

It's fairly straightforward, but what this does is 
1. clear all the alerts from mobs on Destroy()
2. clear the mob references from alerts in their respective Destroy()
3. prevent new alerts from being applied into mobs that are QDELETED

:cl: Naksu
fix: Cleaned up dangling mob references from alerts
/:cl:

