### PR TITLE
Halloween race fixes

### DIFF
--- a/code/modules/mob/living/carbon/human/species_types/dullahan.dm
+++ b/code/modules/mob/living/carbon/human/species_types/dullahan.dm
@@ -18,8 +18,6 @@
 
 
 /datum/species/dullahan/check_roundstart_eligible()
-	if(SSevents.holidays && SSevents.holidays[HALLOWEEN])
-		return TRUE
 	return FALSE
 
 /datum/species/dullahan/on_species_gain(mob/living/carbon/human/H, datum/species/old_species)

--- a/code/modules/mob/living/carbon/human/species_types/dullahan.dm
+++ b/code/modules/mob/living/carbon/human/species_types/dullahan.dm
@@ -18,6 +18,8 @@
 
 
 /datum/species/dullahan/check_roundstart_eligible()
+	if(SSevents.holidays && SSevents.holidays[HALLOWEEN])
+		return TRUE
 	return FALSE
 
 /datum/species/dullahan/on_species_gain(mob/living/carbon/human/H, datum/species/old_species)
@@ -28,6 +30,7 @@
 		head.flags_1 = HEAR_1
 		head.throwforce = 25
 		myhead = new /obj/item/dullahan_relay (head, H)
+		H.put_in_hands(head)
 
 /datum/species/dullahan/on_species_loss(mob/living/carbon/human/H)
 	if(myhead)

--- a/code/modules/mob/living/carbon/human/species_types/dullahan.dm
+++ b/code/modules/mob/living/carbon/human/species_types/dullahan.dm
@@ -94,6 +94,10 @@
 	actions_types = list(/datum/action/item_action/organ_action/dullahan)
 	zone = "abstract"
 
+/datum/action/item_action/organ_action/dullahan
+	name = "Toggle Perspective"
+	desc = "Switch between seeing normally from your head, or blindly from your body."
+
 /datum/action/item_action/organ_action/dullahan/Trigger()
 	. = ..()
 	var/obj/item/organ/eyes/dullahan/DE = target

--- a/code/modules/mob/living/carbon/human/species_types/vampire.dm
+++ b/code/modules/mob/living/carbon/human/species_types/vampire.dm
@@ -44,7 +44,7 @@
 		C.adjustOxyLoss(-4)
 		C.adjustCloneLoss(-4)
 		return
-	C.blood_volume -= .75
+	C.blood_volume -= 0.75
 	if(C.blood_volume <= BLOOD_VOLUME_SURVIVE)
 		to_chat(C, "<span class='danger'>You ran out of blood!</span>")
 		C.dust()

--- a/code/modules/mob/living/carbon/human/species_types/vampire.dm
+++ b/code/modules/mob/living/carbon/human/species_types/vampire.dm
@@ -122,8 +122,4 @@
 	invocation = "Squeak!"
 	charge_max = 50
 	cooldown_min = 50
-
 	shapeshift_type = /mob/living/simple_animal/hostile/retaliate/bat
-	current_shapes = list(/mob/living/simple_animal/hostile/retaliate/bat)
-	current_casters = list()
-	possible_shapes = list(/mob/living/simple_animal/hostile/retaliate/bat)

--- a/code/modules/mob/living/carbon/human/species_types/vampire.dm
+++ b/code/modules/mob/living/carbon/human/species_types/vampire.dm
@@ -61,7 +61,7 @@
 	color = "#1C1C1C"
 	var/drain_cooldown = 0
 
-#define VAMP_DRAIN_AMOUNT 50
+#define VAMP_DRAIN_AMOUNT 100
 
 /datum/action/item_action/organ_action/vampire
 	name = "Drain Victim"

--- a/code/modules/mob/living/carbon/human/species_types/vampire.dm
+++ b/code/modules/mob/living/carbon/human/species_types/vampire.dm
@@ -24,9 +24,8 @@
 	to_chat(C, "[info_text]")
 	C.skin_tone = "albino"
 	C.update_body(0)
-	if(C.mind)
-		var/obj/effect/proc_holder/spell/targeted/shapeshift/bat/B = new
-		C.mind.AddSpell(B)
+	var/obj/effect/proc_holder/spell/targeted/shapeshift/bat/B = new
+	C.AddSpell(B)
 
 /datum/species/vampire/on_species_loss(mob/living/carbon/C)
 	. = ..()
@@ -45,7 +44,7 @@
 		C.adjustOxyLoss(-4)
 		C.adjustCloneLoss(-4)
 		return
-	C.blood_volume -= 1.5
+	C.blood_volume -= 1
 	if(C.blood_volume <= BLOOD_VOLUME_SURVIVE)
 		to_chat(C, "<span class='danger'>You ran out of blood!</span>")
 		C.dust()

--- a/code/modules/mob/living/carbon/human/species_types/vampire.dm
+++ b/code/modules/mob/living/carbon/human/species_types/vampire.dm
@@ -61,7 +61,7 @@
 	color = "#1C1C1C"
 	var/drain_cooldown = 0
 
-#define VAMP_DRAIN_AMOUNT 100
+#define VAMP_DRAIN_AMOUNT 50
 
 /datum/action/item_action/organ_action/vampire
 	name = "Drain Victim"

--- a/code/modules/mob/living/carbon/human/species_types/vampire.dm
+++ b/code/modules/mob/living/carbon/human/species_types/vampire.dm
@@ -44,7 +44,7 @@
 		C.adjustOxyLoss(-4)
 		C.adjustCloneLoss(-4)
 		return
-	C.blood_volume -= 1
+	C.blood_volume -= .75
 	if(C.blood_volume <= BLOOD_VOLUME_SURVIVE)
 		to_chat(C, "<span class='danger'>You ran out of blood!</span>")
 		C.dust()

--- a/code/modules/mob/living/simple_animal/hostile/retaliate/bat.dm
+++ b/code/modules/mob/living/simple_animal/hostile/retaliate/bat.dm
@@ -35,3 +35,6 @@
 	//Space bats need no air to fly in.
 	atmos_requirements = list("min_oxy" = 0, "max_oxy" = 0, "min_tox" = 0, "max_tox" = 0, "min_co2" = 0, "max_co2" = 0, "min_n2" = 0, "max_n2" = 0)
 	minbodytemp = 0
+
+/mob/living/simple_animal/hostile/retaliate/bat/Process_Spacemove(movement_dir = 0)
+	return 1

--- a/code/modules/spells/spell_types/shapeshift.dm
+++ b/code/modules/spells/spell_types/shapeshift.dm
@@ -22,6 +22,9 @@
 		/mob/living/simple_animal/hostile/construct/armored)
 
 /obj/effect/proc_holder/spell/targeted/shapeshift/cast(list/targets,mob/user = usr)
+	if(src in user.mob_spell_list)
+		user.mob_spell_list.Remove(src)
+		user.mind.AddSpell(src)
 	for(var/mob/living/M in targets)
 		if(!shapeshift_type)
 			var/list/animal_list = list()

--- a/code/modules/spells/spell_types/shapeshift.dm
+++ b/code/modules/spells/spell_types/shapeshift.dm
@@ -25,6 +25,8 @@
 	if(src in user.mob_spell_list)
 		user.mob_spell_list.Remove(src)
 		user.mind.AddSpell(src)
+	if(user.buckled)
+		user.buckled.unbuckle_mob(src,force=TRUE)
 	for(var/mob/living/M in targets)
 		if(!shapeshift_type)
 			var/list/animal_list = list()


### PR DESCRIPTION
If you selected dullahan from the start screen, it would drop your head in the title area before warping you to station. This is not desirable.

Vampires will get their spells/not lose them on transform, and blood drain is slower

Fixes? Space bats not being able to fly in space

Fixes dullahan eyes action being named "generic action"

Fixes buckling issues with shapeshift. Fixes https://github.com/tgstation/tgstation/issues/32179