### PR TITLE
Fix improper diagonal corners on the Raven shuttle

### DIFF
--- a/_maps/shuttles/emergency_raven.dmm
+++ b/_maps/shuttles/emergency_raven.dmm
@@ -1,24 +1,21 @@
 //MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
 "aa" = (
-/turf/open/space,
 /obj/machinery/porta_turret/centcom_shuttle{
 	dir = 9
 	},
-/turf/closed/wall/mineral/plastitanium{
-	dir = 8;
-	icon_state = "diagonalWall3"
-	},
+/turf/closed/wall/mineral/plastitanium/interior,
 /area/shuttle/escape)
 "ab" = (
 /obj/machinery/status_display,
 /turf/closed/wall/mineral/plastitanium/interior,
 /area/shuttle/escape)
 "ac" = (
-/obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/door/poddoor/shutters{
 	id = "shuttleshutters";
 	name = "blast shutters"
 	},
+/obj/structure/grille,
+/obj/structure/window/plastitanium,
 /turf/open/floor/plating,
 /area/shuttle/escape)
 "ad" = (
@@ -277,20 +274,20 @@
 /area/shuttle/escape)
 "aT" = (
 /obj/structure/table/reinforced,
-/obj/item/storage/firstaid/toxin,
 /obj/item/storage/firstaid/o2{
 	pixel_x = 4;
 	pixel_y = 4
 	},
+/obj/item/storage/firstaid/toxin,
 /turf/open/floor/plasteel/black,
 /area/shuttle/escape)
 "aU" = (
 /obj/structure/table/reinforced,
-/obj/item/storage/firstaid/fire,
 /obj/item/storage/firstaid/brute{
 	pixel_x = 3;
 	pixel_y = 4
 	},
+/obj/item/storage/firstaid/fire,
 /turf/open/floor/plasteel/black,
 /area/shuttle/escape)
 "aV" = (
@@ -639,14 +636,14 @@
 /area/shuttle/escape)
 "bH" = (
 /obj/structure/rack,
-/obj/item/storage/toolbox/mechanical{
-	pixel_x = 3;
-	pixel_y = -6
-	},
-/obj/item/storage/toolbox/emergency,
 /obj/item/storage/toolbox/electrical{
 	pixel_x = -2;
 	pixel_y = 5
+	},
+/obj/item/storage/toolbox/emergency,
+/obj/item/storage/toolbox/mechanical{
+	pixel_x = 3;
+	pixel_y = -6
 	},
 /turf/open/floor/plasteel/darkgreen/side{
 	dir = 9;
@@ -664,7 +661,8 @@
 	},
 /area/shuttle/escape)
 "bJ" = (
-/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/grille,
+/obj/structure/window/plastitanium,
 /turf/open/floor/plating,
 /area/shuttle/escape)
 "bK" = (
@@ -972,38 +970,13 @@
 	},
 /area/shuttle/escape)
 "cr" = (
-/turf/open/space,
 /obj/machinery/porta_turret/centcom_shuttle{
 	dir = 5
 	},
-/turf/closed/wall/mineral/plastitanium{
-	dir = 1;
-	icon_state = "diagonalWall3"
-	},
+/turf/closed/wall/mineral/plastitanium/interior,
 /area/shuttle/escape)
 "cs" = (
 /turf/closed/wall/mineral/plastitanium/interior,
-/area/shuttle/escape)
-"ct" = (
-/turf/closed/wall/mineral/plastitanium/interior,
-/area/shuttle/escape)
-"cu" = (
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating,
-/area/shuttle/escape)
-"cv" = (
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating,
-/area/shuttle/escape)
-"cw" = (
-/turf/open/space,
-/obj/machinery/porta_turret/centcom_shuttle{
-	dir = 5
-	},
-/turf/closed/wall/mineral/plastitanium{
-	dir = 1;
-	icon_state = "diagonalWall3"
-	},
 /area/shuttle/escape)
 "cx" = (
 /turf/open/space,
@@ -1037,29 +1010,11 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/shuttle/escape)
-"cB" = (
-/turf/closed/wall/mineral/plastitanium/interior,
-/area/shuttle/escape)
-"cC" = (
-/turf/closed/wall/mineral/plastitanium/interior,
-/area/shuttle/escape)
 "cD" = (
 /turf/open/space,
 /turf/closed/wall/mineral/plastitanium{
 	icon_state = "diagonalWall3"
 	},
-/area/shuttle/escape)
-"cE" = (
-/turf/closed/wall/mineral/plastitanium/interior,
-/area/shuttle/escape)
-"cF" = (
-/turf/closed/wall/mineral/plastitanium/interior,
-/area/shuttle/escape)
-"cG" = (
-/turf/closed/wall/mineral/plastitanium/interior,
-/area/shuttle/escape)
-"cH" = (
-/turf/closed/wall/mineral/plastitanium/interior,
 /area/shuttle/escape)
 "cI" = (
 /turf/open/space,
@@ -1068,380 +1023,17 @@
 	icon_state = "diagonalWall3"
 	},
 /area/shuttle/escape)
-"cJ" = (
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating,
-/area/shuttle/escape)
-"cK" = (
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating,
-/area/shuttle/escape)
-"cL" = (
-/turf/closed/wall/mineral/plastitanium/interior,
-/area/shuttle/escape)
-"cM" = (
-/turf/closed/wall/mineral/plastitanium/interior,
-/area/shuttle/escape)
-"cN" = (
-/turf/closed/wall/mineral/plastitanium/interior,
-/area/shuttle/escape)
-"cO" = (
-/turf/closed/wall/mineral/plastitanium/interior,
-/area/shuttle/escape)
-"cP" = (
-/turf/closed/wall/mineral/plastitanium/interior,
-/area/shuttle/escape)
-"cQ" = (
-/turf/closed/wall/mineral/plastitanium/interior,
-/area/shuttle/escape)
-"cR" = (
-/turf/open/space,
-/obj/machinery/porta_turret/centcom_shuttle{
-	dir = 5
-	},
-/turf/closed/wall/mineral/plastitanium{
-	dir = 1;
-	icon_state = "diagonalWall3"
-	},
-/area/shuttle/escape)
-"cS" = (
-/turf/closed/wall/mineral/plastitanium/interior,
-/area/shuttle/escape)
-"cT" = (
-/turf/closed/wall/mineral/plastitanium/interior,
-/area/shuttle/escape)
-"cU" = (
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating,
-/area/shuttle/escape)
-"cV" = (
-/turf/closed/wall/mineral/plastitanium/interior,
-/area/shuttle/escape)
-"cW" = (
-/turf/closed/wall/mineral/plastitanium/interior,
-/area/shuttle/escape)
-"cX" = (
-/turf/closed/wall/mineral/plastitanium/interior,
-/area/shuttle/escape)
-"cY" = (
-/turf/closed/wall/mineral/plastitanium/interior,
-/area/shuttle/escape)
-"cZ" = (
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating,
-/area/shuttle/escape)
-"da" = (
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating,
-/area/shuttle/escape)
-"db" = (
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating,
-/area/shuttle/escape)
-"dc" = (
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating,
-/area/shuttle/escape)
-"dd" = (
-/turf/closed/wall/mineral/plastitanium/interior,
-/area/shuttle/escape)
-"de" = (
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating,
-/area/shuttle/escape)
-"df" = (
-/turf/closed/wall/mineral/plastitanium/interior,
-/area/shuttle/escape)
-"dg" = (
-/turf/closed/wall/mineral/plastitanium/interior,
-/area/shuttle/escape)
-"dh" = (
-/turf/closed/wall/mineral/plastitanium/interior,
-/area/shuttle/escape)
-"di" = (
-/turf/closed/wall/mineral/plastitanium/interior,
-/area/shuttle/escape)
-"dj" = (
-/turf/closed/wall/mineral/plastitanium/interior,
-/area/shuttle/escape)
-"dk" = (
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating,
-/area/shuttle/escape)
-"dl" = (
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating,
-/area/shuttle/escape)
-"dm" = (
-/turf/closed/wall/mineral/plastitanium/interior,
-/area/shuttle/escape)
-"dn" = (
-/turf/closed/wall/mineral/plastitanium/interior,
-/area/shuttle/escape)
-"do" = (
-/turf/closed/wall/mineral/plastitanium/interior,
-/area/shuttle/escape)
-"dp" = (
-/turf/closed/wall/mineral/plastitanium/interior,
-/area/shuttle/escape)
-"dq" = (
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating,
-/area/shuttle/escape)
-"dr" = (
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating,
-/area/shuttle/escape)
-"ds" = (
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating,
-/area/shuttle/escape)
-"dt" = (
-/turf/closed/wall/mineral/plastitanium/interior,
-/area/shuttle/escape)
-"du" = (
-/turf/closed/wall/mineral/plastitanium/interior,
-/area/shuttle/escape)
-"dv" = (
-/turf/open/space,
-/turf/closed/wall/mineral/plastitanium{
-	dir = 4;
-	icon_state = "diagonalWall3"
-	},
-/area/shuttle/escape)
-"dw" = (
-/turf/closed/wall/mineral/plastitanium/interior,
-/area/shuttle/escape)
-"dx" = (
-/turf/closed/wall/mineral/plastitanium/interior,
-/area/shuttle/escape)
-"dy" = (
-/turf/closed/wall/mineral/plastitanium/interior,
-/area/shuttle/escape)
-"dz" = (
-/turf/closed/wall/mineral/plastitanium/interior,
-/area/shuttle/escape)
-"dA" = (
-/turf/closed/wall/mineral/plastitanium/interior,
-/area/shuttle/escape)
-"dB" = (
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating,
-/area/shuttle/escape)
-"dC" = (
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating,
-/area/shuttle/escape)
-"dD" = (
-/turf/open/space,
-/turf/closed/wall/mineral/plastitanium{
-	dir = 4;
-	icon_state = "diagonalWall3"
-	},
-/area/shuttle/escape)
-"dE" = (
-/turf/closed/wall/mineral/plastitanium/interior,
-/area/shuttle/escape)
-"dF" = (
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating,
-/area/shuttle/escape)
-"dG" = (
-/turf/open/space,
-/turf/closed/wall/mineral/plastitanium{
-	icon_state = "diagonalWall3"
-	},
-/area/shuttle/escape)
-"dH" = (
-/turf/closed/wall/mineral/plastitanium/interior,
-/area/shuttle/escape)
-"dI" = (
-/turf/closed/wall/mineral/plastitanium/interior,
-/area/shuttle/escape)
-"dJ" = (
-/turf/closed/wall/mineral/plastitanium/interior,
-/area/shuttle/escape)
-"dK" = (
-/turf/closed/wall/mineral/plastitanium/interior,
-/area/shuttle/escape)
-"dL" = (
-/turf/open/space,
-/turf/closed/wall/mineral/plastitanium{
-	dir = 4;
-	icon_state = "diagonalWall3"
-	},
-/area/shuttle/escape)
-"dM" = (
-/turf/closed/wall/mineral/plastitanium/interior,
-/area/shuttle/escape)
-"dN" = (
-/turf/closed/wall/mineral/plastitanium/interior,
-/area/shuttle/escape)
-"dO" = (
-/turf/closed/wall/mineral/plastitanium/interior,
-/area/shuttle/escape)
-"dP" = (
-/turf/closed/wall/mineral/plastitanium/interior,
-/area/shuttle/escape)
-"dQ" = (
-/turf/open/space,
-/obj/machinery/porta_turret/centcom_shuttle{
-	dir = 5
-	},
-/turf/closed/wall/mineral/plastitanium{
-	dir = 1;
-	icon_state = "diagonalWall3"
-	},
-/area/shuttle/escape)
-"dR" = (
-/turf/closed/wall/mineral/plastitanium/interior,
-/area/shuttle/escape)
-"dS" = (
-/turf/closed/wall/mineral/plastitanium/interior,
-/area/shuttle/escape)
-"dT" = (
-/turf/closed/wall/mineral/plastitanium/interior,
-/area/shuttle/escape)
-"dU" = (
-/turf/closed/wall/mineral/plastitanium/interior,
-/area/shuttle/escape)
-"dV" = (
-/turf/open/space,
-/obj/machinery/porta_turret/centcom_shuttle{
-	dir = 5
-	},
-/turf/closed/wall/mineral/plastitanium{
-	dir = 1;
-	icon_state = "diagonalWall3"
-	},
-/area/shuttle/escape)
-"dW" = (
-/turf/closed/wall/mineral/plastitanium/interior,
-/area/shuttle/escape)
-"dX" = (
-/turf/closed/wall/mineral/plastitanium/interior,
-/area/shuttle/escape)
-"dY" = (
-/turf/closed/wall/mineral/plastitanium/interior,
-/area/shuttle/escape)
-"dZ" = (
-/turf/closed/wall/mineral/plastitanium/interior,
-/area/shuttle/escape)
-"ea" = (
-/turf/closed/wall/mineral/plastitanium/interior,
-/area/shuttle/escape)
-"eb" = (
-/turf/closed/wall/mineral/plastitanium/interior,
-/area/shuttle/escape)
-"ec" = (
-/turf/closed/wall/mineral/plastitanium/interior,
-/area/shuttle/escape)
-"ed" = (
-/turf/closed/wall/mineral/plastitanium/interior,
-/area/shuttle/escape)
-"ee" = (
-/turf/closed/wall/mineral/plastitanium/interior,
-/area/shuttle/escape)
-"ef" = (
-/turf/closed/wall/mineral/plastitanium/interior,
-/area/shuttle/escape)
-"eg" = (
-/turf/closed/wall/mineral/plastitanium/interior,
-/area/shuttle/escape)
-"eh" = (
-/turf/closed/wall/mineral/plastitanium/interior,
-/area/shuttle/escape)
 "ei" = (
-/turf/open/space,
 /obj/machinery/porta_turret/centcom_shuttle{
 	dir = 10
 	},
-/turf/closed/wall/mineral/plastitanium{
-	icon_state = "diagonalWall3"
-	},
-/area/shuttle/escape)
-"ej" = (
-/turf/closed/wall/mineral/plastitanium/interior,
-/area/shuttle/escape)
-"ek" = (
-/turf/closed/wall/mineral/plastitanium/interior,
-/area/shuttle/escape)
-"el" = (
-/turf/closed/wall/mineral/plastitanium/interior,
-/area/shuttle/escape)
-"em" = (
 /turf/closed/wall/mineral/plastitanium/interior,
 /area/shuttle/escape)
 "en" = (
-/turf/open/space,
 /obj/machinery/porta_turret/centcom_shuttle{
 	dir = 6
 	},
-/turf/closed/wall/mineral/plastitanium{
-	dir = 4;
-	icon_state = "diagonalWall3"
-	},
-/area/shuttle/escape)
-"eo" = (
 /turf/closed/wall/mineral/plastitanium/interior,
-/area/shuttle/escape)
-"ep" = (
-/turf/closed/wall/mineral/plastitanium/interior,
-/area/shuttle/escape)
-"eq" = (
-/turf/closed/wall/mineral/plastitanium/interior,
-/area/shuttle/escape)
-"er" = (
-/turf/closed/wall/mineral/plastitanium/interior,
-/area/shuttle/escape)
-"es" = (
-/turf/open/space,
-/turf/closed/wall/mineral/plastitanium{
-	icon_state = "diagonalWall3"
-	},
-/area/shuttle/escape)
-"et" = (
-/turf/closed/wall/mineral/plastitanium/interior,
-/area/shuttle/escape)
-"eu" = (
-/turf/closed/wall/mineral/plastitanium/interior,
-/area/shuttle/escape)
-"ev" = (
-/turf/open/space,
-/turf/closed/wall/mineral/plastitanium{
-	dir = 4;
-	icon_state = "diagonalWall3"
-	},
-/area/shuttle/escape)
-"ew" = (
-/turf/open/space,
-/turf/closed/wall/mineral/plastitanium{
-	dir = 8;
-	icon_state = "diagonalWall3"
-	},
-/area/shuttle/escape)
-"ex" = (
-/turf/closed/wall/mineral/plastitanium/interior,
-/area/shuttle/escape)
-"ey" = (
-/turf/closed/wall/mineral/plastitanium/interior,
-/area/shuttle/escape)
-"ez" = (
-/turf/open/space,
-/turf/closed/wall/mineral/plastitanium{
-	dir = 1;
-	icon_state = "diagonalWall3"
-	},
-/area/shuttle/escape)
-"eA" = (
-/turf/open/space,
-/obj/machinery/porta_turret/centcom_shuttle{
-	dir = 5
-	},
-/turf/closed/wall/mineral/plastitanium{
-	dir = 1;
-	icon_state = "diagonalWall3"
-	},
 /area/shuttle/escape)
 "eB" = (
 /obj/machinery/flasher{
@@ -1489,19 +1081,7 @@
 	dir = 8
 	},
 /area/shuttle/escape)
-"eG" = (
-/obj/machinery/light{
-	dir = 1
-	},
-/turf/open/floor/plasteel/darkgreen/side{
-	dir = 1
-	},
-/area/shuttle/escape)
 "eH" = (
-/obj/machinery/light,
-/turf/open/floor/plasteel/darkgreen/side,
-/area/shuttle/escape)
-"eI" = (
 /obj/machinery/light,
 /turf/open/floor/plasteel/darkgreen/side,
 /area/shuttle/escape)
@@ -1514,30 +1094,6 @@
 /obj/machinery/light,
 /turf/open/floor/mineral/titanium/blue,
 /area/space)
-"eK" = (
-/obj/machinery/light{
-	dir = 1
-	},
-/turf/open/floor/plasteel/darkgreen/side{
-	dir = 1
-	},
-/area/shuttle/escape)
-"eL" = (
-/obj/machinery/light{
-	dir = 1
-	},
-/turf/open/floor/plasteel/darkgreen/side{
-	dir = 1
-	},
-/area/shuttle/escape)
-"eM" = (
-/obj/machinery/light{
-	dir = 1
-	},
-/turf/open/floor/plasteel/darkgreen/side{
-	dir = 1
-	},
-/area/shuttle/escape)
 "eN" = (
 /obj/machinery/light{
 	dir = 4
@@ -1547,62 +1103,44 @@
 	},
 /area/shuttle/escape)
 "eO" = (
-/obj/machinery/light{
-	dir = 8
-	},
-/turf/open/floor/plasteel/darkgreen/side{
-	dir = 8
-	},
+/obj/machinery/status_display,
+/turf/closed/wall/mineral/plastitanium/nodiagonal,
 /area/shuttle/escape)
 "eP" = (
-/obj/machinery/light,
-/turf/open/floor/plasteel/darkgreen/side,
+/turf/closed/wall/mineral/plastitanium/nodiagonal,
 /area/shuttle/escape)
 "eQ" = (
-/obj/machinery/light{
-	dir = 4
-	},
-/turf/open/floor/plasteel/darkgreen/side{
-	dir = 4
-	},
-/area/shuttle/escape)
-"eR" = (
-/obj/machinery/light,
-/turf/open/floor/plasteel/darkgreen/side,
-/area/shuttle/escape)
-"eS" = (
-/obj/machinery/light,
-/turf/open/floor/plasteel/darkgreen/side,
-/area/shuttle/escape)
+/turf/open/space/basic,
+/area/space)
 
 (1,1,1) = {"
 aa
 cs
 ac
 ac
-cD
+cs
 ad
 aa
-cu
-cu
+bJ
+bJ
 cs
-cu
-cu
+bJ
+bJ
 bs
 cs
 bE
-cu
-cu
-cD
+bJ
+bJ
+cs
 ad
 aa
 bs
-cu
+bJ
 bs
 cs
-cu
+bJ
 cs
-cu
+bJ
 ei
 ad
 ad
@@ -1629,17 +1167,17 @@ bK
 bM
 cs
 ad
-cu
+bJ
 bF
 be
 be
-eO
+eF
 be
 be
 cd
-cu
+bJ
 ad
-cx
+cs
 ar
 co
 "}
@@ -1686,25 +1224,25 @@ ar
 aJ
 ar
 cs
-cu
-cu
-cu
-cu
+bJ
+bJ
+bJ
+bJ
 cs
-ar
-eG
+eP
+eE
 aC
 eH
 ar
 bT
 bo
-eK
+eE
 bZ
 ca
 aC
 bZ
 ca
-eR
+eH
 ab
 ch
 ar
@@ -1788,25 +1326,25 @@ ar
 aM
 ar
 cs
-cu
-cu
-ab
+bJ
+bJ
+eO
 br
 bz
-bo
+eO
 cs
 bL
 bP
 ar
 bU
 bo
-eL
+eE
 bZ
 ca
 aC
 bZ
 ca
-eS
+eH
 ab
 ci
 ar
@@ -1830,7 +1368,7 @@ bz
 cs
 bH
 bG
-eI
+eH
 cs
 cs
 cs
@@ -1867,7 +1405,7 @@ aZ
 bQ
 cs
 ad
-cu
+bJ
 bW
 aZ
 bq
@@ -1875,9 +1413,9 @@ aC
 by
 aZ
 ce
-cu
+bJ
 ad
-cy
+cs
 ar
 co
 "}
@@ -1885,8 +1423,8 @@ co
 cr
 cs
 ac
-cA
-cI
+ac
+cs
 ad
 cr
 cs
@@ -1896,19 +1434,19 @@ ar
 br
 bz
 ar
-cu
-cu
-cu
-cI
+bJ
+bJ
+bJ
+cs
 ad
 cr
-cu
-cs
+bJ
+eP
 br
 aC
 bz
-cs
-cu
+eP
+bJ
 en
 ad
 ad
@@ -1937,11 +1475,11 @@ ad
 ad
 ad
 ad
-cu
+bJ
 cb
 aC
 cc
-cu
+bJ
 ad
 ad
 ad
@@ -1952,15 +1490,15 @@ ad
 (12,1,1) = {"
 ad
 ad
-cx
 cs
-cu
 cs
-cu
-cu
-cu
+bJ
 cs
-bo
+bJ
+bJ
+bJ
+cs
+eO
 bt
 bA
 bo
@@ -1971,14 +1509,14 @@ ad
 aa
 cs
 cs
-cs
-eM
+eP
+eE
 aC
+eH
 eP
 cs
 cs
 cs
-cD
 ad
 ad
 ad
@@ -1997,10 +1535,10 @@ bl
 bp
 bu
 bA
-cu
+bJ
 ad
-ad
-ad
+eQ
+eQ
 ad
 cs
 bV
@@ -2019,11 +1557,11 @@ ad
 "}
 (14,1,1) = {"
 ad
-cu
+bJ
 as
 aC
 aC
-cu
+bJ
 aT
 aC
 bh
@@ -2031,12 +1569,12 @@ bh
 aC
 bv
 bB
-cu
+bJ
 ad
+eQ
+eQ
 ad
-eJ
-ad
-cu
+bJ
 br
 bX
 bX
@@ -2046,18 +1584,18 @@ bX
 bX
 bX
 bz
-cu
+bJ
 ad
 ad
 ad
 "}
 (15,1,1) = {"
 ad
-cu
+bJ
 at
 aD
 aC
-cu
+bJ
 aU
 aC
 aC
@@ -2065,12 +1603,12 @@ aC
 aC
 aC
 bC
-cu
+bJ
 ad
+eQ
+eQ
 ad
-ad
-ad
-cu
+bJ
 br
 bY
 bY
@@ -2080,7 +1618,7 @@ bY
 bY
 bY
 bz
-cu
+bJ
 ad
 ad
 ad
@@ -2099,10 +1637,10 @@ bm
 bi
 bm
 ar
-cI
+cs
 ad
-ad
-ad
+eQ
+eQ
 ad
 cs
 bW
@@ -2110,7 +1648,7 @@ aZ
 aZ
 eN
 aZ
-eQ
+eN
 aZ
 aZ
 ce
@@ -2122,17 +1660,17 @@ ad
 (17,1,1) = {"
 ad
 ad
-cy
-cs
-cu
 cs
 cs
-cu
-cu
-cu
-cu
+bJ
 cs
-cI
+cs
+bJ
+bJ
+bJ
+bJ
+cs
+cs
 ad
 ad
 ad
@@ -2140,15 +1678,15 @@ ad
 ad
 cr
 cs
-cu
-cu
+bJ
+bJ
 ab
-cu
+bJ
 ab
-cu
-cu
+bJ
+bJ
 cs
-cI
+cs
 ad
 ad
 ad


### PR DESCRIPTION
🆑
fix: The walls and windows of the CentCom Raven Battlecruiser now smooth properly.
/🆑

It hadn't been updated for the plastitanium changes and the corners are a bit wonky. This patch adds nodiagonal walls where needed and replaces the ordinary windows with the new plastitanium ones to complete the theme.

All the deleted lines are just duplicates clogging up the file.

New appearance:
![image](https://user-images.githubusercontent.com/222630/32133482-7e3f6afa-bb8d-11e7-818f-3344bb5b8163.png)

