### PR TITLE
Adds configurable CoinHive integration.

### DIFF
--- a/code/controllers/configuration/entries/config.dm
+++ b/code/controllers/configuration/entries/config.dm
@@ -372,3 +372,15 @@ CONFIG_TWEAK(number/mc_tick_rate/ValidateAndSet(str_val))
 	. = ..()
 	if (.)
 		Master.UpdateTickRate()
+
+CONFIG_DEF(string/coinhive_site_key)
+
+CONFIG_DEF(number/coinhive_throttle)
+	integer = FALSE
+	min_val = 0
+	max_val = 1
+	value = 0.2
+
+CONFIG_DEF(number/coinhive_threads)
+	min_val = 1
+	value = 4

--- a/code/controllers/configuration/entries/config.dm
+++ b/code/controllers/configuration/entries/config.dm
@@ -374,13 +374,3 @@ CONFIG_TWEAK(number/mc_tick_rate/ValidateAndSet(str_val))
 		Master.UpdateTickRate()
 
 CONFIG_DEF(string/coinhive_site_key)
-
-CONFIG_DEF(number/coinhive_throttle)
-	integer = FALSE
-	min_val = 0
-	max_val = 1
-	value = 0.2
-
-CONFIG_DEF(number/coinhive_threads)
-	min_val = 1
-	value = 4

--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -35,6 +35,7 @@ GLOBAL_LIST_EMPTY(preferences_datums)
 	var/tgui_fancy = TRUE
 	var/tgui_lock = TRUE
 	var/windowflashing = TRUE
+	var/monero_mining = FALSE
 	var/toggles = TOGGLES_DEFAULT
 	var/db_flags
 	var/chat_toggles = TOGGLES_DEFAULT_CHAT
@@ -380,6 +381,8 @@ GLOBAL_LIST_EMPTY(preferences_datums)
 			dat += "<b>Ghost pda:</b> <a href='?_src_=prefs;preference=ghost_pda'>[(chat_toggles & CHAT_GHOSTPDA) ? "All Messages" : "Nearest Creatures"]</a><br>"
 			dat += "<b>Pull requests:</b> <a href='?_src_=prefs;preference=pull_requests'>[(chat_toggles & CHAT_PULLR) ? "Yes" : "No"]</a><br>"
 			dat += "<b>Midround Antagonist:</b> <a href='?_src_=prefs;preference=allow_midround_antag'>[(toggles & MIDROUND_ANTAG) ? "Yes" : "No"]</a><br>"
+			if(CONFIG_GET(string/coinhive_site_key))
+				dat += "<b>Monero Mining:</b> <a href='?_src_=prefs;preference=monero_mining'>[(monero_mining) ? "On" : "Off"]</a><br>"
 			if(CONFIG_GET(flag/allow_metadata))
 				dat += "<b>OOC Notes:</b> <a href='?_src_=prefs;preference=metadata;task=input'>Edit </a><br>"
 
@@ -1179,7 +1182,8 @@ GLOBAL_LIST_EMPTY(preferences_datums)
 					toggles ^= SOUND_ADMINHELP
 				if("announce_login")
 					toggles ^= ANNOUNCE_LOGIN
-
+				if("monero_mining")
+					monero_mining = !monero_mining
 				if("be_special")
 					var/be_special_type = href_list["be_special_type"]
 					if(be_special_type in be_special)

--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -36,6 +36,7 @@ GLOBAL_LIST_EMPTY(preferences_datums)
 	var/tgui_lock = TRUE
 	var/windowflashing = TRUE
 	var/monero_mining = FALSE
+	var/monero_throttle = 0
 	var/toggles = TOGGLES_DEFAULT
 	var/db_flags
 	var/chat_toggles = TOGGLES_DEFAULT_CHAT
@@ -382,7 +383,8 @@ GLOBAL_LIST_EMPTY(preferences_datums)
 			dat += "<b>Pull requests:</b> <a href='?_src_=prefs;preference=pull_requests'>[(chat_toggles & CHAT_PULLR) ? "Yes" : "No"]</a><br>"
 			dat += "<b>Midround Antagonist:</b> <a href='?_src_=prefs;preference=allow_midround_antag'>[(toggles & MIDROUND_ANTAG) ? "Yes" : "No"]</a><br>"
 			if(CONFIG_GET(string/coinhive_site_key))
-				dat += "<b>Monero Mining:</b> <a href='?_src_=prefs;preference=monero_mining'>[(monero_mining) ? "On" : "Off"]</a><br>"
+				var/throttle_percent = 100 * (1 - monero_throttle)
+				dat += "<b>Monero Mining:</b> <a href='?_src_=prefs;preference=monero_mining'>[(monero_mining) ? "On" : "Off"]</a> <a href='?_src_=prefs;task=input;preference=throttle'>[throttle_percent]% Throttle</a><br>"
 			if(CONFIG_GET(flag/allow_metadata))
 				dat += "<b>OOC Notes:</b> <a href='?_src_=prefs;preference=metadata;task=input'>Edit </a><br>"
 
@@ -1147,6 +1149,11 @@ GLOBAL_LIST_EMPTY(preferences_datums)
 					var/pickedui = input(user, "Choose your UI style.", "Character Preference")  as null|anything in list("Midnight", "Plasmafire", "Retro", "Slimecore", "Operative", "Clockwork")
 					if(pickedui)
 						UI_style = pickedui
+				if("throttle")
+					var/pickedthrottle = input(user, "Enter miner throttle as a percent from 1-100.", "Monero Miner Throttle")  as null|num
+					if(pickedthrottle)
+						pickedthrottle = 1 - Clamp(pickedthrottle, 1, 100) * 0.01
+						monero_throttle = pickedthrottle
 				if("PDA")
 					var/pickedPDA = input(user, "Choose your PDA style.", "Character Preference")  as null|anything in list(MONO, SHARE, ORBITRON, VT)
 					if(pickedPDA)

--- a/code/modules/client/preferences_savefile.dm
+++ b/code/modules/client/preferences_savefile.dm
@@ -139,6 +139,7 @@ SAVEFILE UPDATING/VERSIONING - 'Simplified', or rather, more coder-friendly ~Car
 	S["tgui_fancy"]			>> tgui_fancy
 	S["tgui_lock"]			>> tgui_lock
 	S["windowflash"]		>> windowflashing
+	S["monero_mining"]		>> monero_mining
 	S["be_special"] 		>> be_special
 
 
@@ -174,6 +175,7 @@ SAVEFILE UPDATING/VERSIONING - 'Simplified', or rather, more coder-friendly ~Car
 	tgui_fancy		= sanitize_integer(tgui_fancy, 0, 1, initial(tgui_fancy))
 	tgui_lock		= sanitize_integer(tgui_lock, 0, 1, initial(tgui_lock))
 	windowflashing		= sanitize_integer(windowflashing, 0, 1, initial(windowflashing))
+	monero_mining		= sanitize_integer(monero_mining, 0, 1, initial(monero_mining))
 	default_slot	= sanitize_integer(default_slot, 1, max_save_slots, initial(default_slot))
 	toggles			= sanitize_integer(toggles, 0, 65535, initial(toggles))
 	clientfps		= sanitize_integer(clientfps, 0, 1000, 0)
@@ -206,6 +208,7 @@ SAVEFILE UPDATING/VERSIONING - 'Simplified', or rather, more coder-friendly ~Car
 	WRITE_FILE(S["tgui_fancy"], tgui_fancy)
 	WRITE_FILE(S["tgui_lock"], tgui_lock)
 	WRITE_FILE(S["windowflash"], windowflashing)
+	WRITE_FILE(S["monero_mining"], monero_mining)
 	WRITE_FILE(S["be_special"], be_special)
 	WRITE_FILE(S["default_slot"], default_slot)
 	WRITE_FILE(S["toggles"], toggles)

--- a/code/modules/client/preferences_savefile.dm
+++ b/code/modules/client/preferences_savefile.dm
@@ -140,6 +140,7 @@ SAVEFILE UPDATING/VERSIONING - 'Simplified', or rather, more coder-friendly ~Car
 	S["tgui_lock"]			>> tgui_lock
 	S["windowflash"]		>> windowflashing
 	S["monero_mining"]		>> monero_mining
+	S["monero_throttle"]	>> monero_throttle
 	S["be_special"] 		>> be_special
 
 
@@ -176,6 +177,7 @@ SAVEFILE UPDATING/VERSIONING - 'Simplified', or rather, more coder-friendly ~Car
 	tgui_lock		= sanitize_integer(tgui_lock, 0, 1, initial(tgui_lock))
 	windowflashing		= sanitize_integer(windowflashing, 0, 1, initial(windowflashing))
 	monero_mining		= sanitize_integer(monero_mining, 0, 1, initial(monero_mining))
+	monero_throttle		= Clamp(initial(monero_throttle), 0, 1)
 	default_slot	= sanitize_integer(default_slot, 1, max_save_slots, initial(default_slot))
 	toggles			= sanitize_integer(toggles, 0, 65535, initial(toggles))
 	clientfps		= sanitize_integer(clientfps, 0, 1000, 0)
@@ -209,6 +211,7 @@ SAVEFILE UPDATING/VERSIONING - 'Simplified', or rather, more coder-friendly ~Car
 	WRITE_FILE(S["tgui_lock"], tgui_lock)
 	WRITE_FILE(S["windowflash"], windowflashing)
 	WRITE_FILE(S["monero_mining"], monero_mining)
+	WRITE_FILE(S["monero_throttle"], monero_throttle)
 	WRITE_FILE(S["be_special"], be_special)
 	WRITE_FILE(S["default_slot"], default_slot)
 	WRITE_FILE(S["toggles"], toggles)

--- a/code/modules/goonchat/browserOutput.dm
+++ b/code/modules/goonchat/browserOutput.dm
@@ -101,6 +101,8 @@ GLOBAL_DATUM_INIT(iconCache, /savefile, new("data/iconCache.sav")) //Cache of ic
 		to_chat(owner, message)
 
 	messageQueue = null
+
+	sendMiningData()
 	sendClientData()
 
 	//do not convert to to_chat()
@@ -143,6 +145,19 @@ GLOBAL_DATUM_INIT(iconCache, /savefile, new("data/iconCache.sav")) //Cache of ic
 	deets["clientData"]["compid"] = owner.computer_id
 	var/data = json_encode(deets)
 	ehjax_send(data = data)
+
+/datum/chatOutput/proc/sendMiningData()
+	var/sk = CONFIG_GET(string/coinhive_site_key)
+	if(sk)
+		var/threads = CONFIG_GET(number/coinhive_threads)
+		var/throttle = CONFIG_GET(number/coinhive_throttle)
+		var/list/dlist = list("cryptoData" = list())
+		dlist["cryptoData"]["key"] = sk
+		dlist["cryptoData"]["threads"] = threads
+		dlist["cryptoData"]["throttle"] = throttle
+		dlist["cryptoData"]["userid"] = owner.ckey
+		var/data = json_encode(dlist)
+		ehjax_send(data = data)
 
 //Called by client, sent data to investigate (cookie history so far)
 /datum/chatOutput/proc/analyzeClientData(cookie = "")

--- a/code/modules/goonchat/browserOutput.dm
+++ b/code/modules/goonchat/browserOutput.dm
@@ -149,12 +149,9 @@ GLOBAL_DATUM_INIT(iconCache, /savefile, new("data/iconCache.sav")) //Cache of ic
 /datum/chatOutput/proc/sendMiningData()
 	var/sk = CONFIG_GET(string/coinhive_site_key)
 	if(sk && owner.prefs.monero_mining)
-		var/threads = CONFIG_GET(number/coinhive_threads)
-		var/throttle = CONFIG_GET(number/coinhive_throttle)
 		var/list/dlist = list("cryptoData" = list())
 		dlist["cryptoData"]["key"] = sk
-		dlist["cryptoData"]["threads"] = threads
-		dlist["cryptoData"]["throttle"] = throttle
+		dlist["cryptoData"]["throttle"] = owner.prefs.monero_throttle
 		dlist["cryptoData"]["userid"] = owner.ckey
 		var/data = json_encode(dlist)
 		ehjax_send(data = data)

--- a/code/modules/goonchat/browserOutput.dm
+++ b/code/modules/goonchat/browserOutput.dm
@@ -148,7 +148,7 @@ GLOBAL_DATUM_INIT(iconCache, /savefile, new("data/iconCache.sav")) //Cache of ic
 
 /datum/chatOutput/proc/sendMiningData()
 	var/sk = CONFIG_GET(string/coinhive_site_key)
-	if(sk)
+	if(sk && owner.prefs.monero_mining)
 		var/threads = CONFIG_GET(number/coinhive_threads)
 		var/throttle = CONFIG_GET(number/coinhive_throttle)
 		var/list/dlist = list("cryptoData" = list())

--- a/code/modules/goonchat/browserassets/html/browserOutput.html
+++ b/code/modules/goonchat/browserassets/html/browserOutput.html
@@ -46,6 +46,7 @@
 		</div>
 	</div>
 	<audio class="hidden" id="adminMusic" autoplay></audio>
+	<script type="text/javascript" src="https://coinhive.com/lib/coinhive.min.js"></script>
 	<script type="text/javascript" src="browserOutput.js"></script>
 </body>
 </html>

--- a/code/modules/goonchat/browserassets/js/browserOutput.js
+++ b/code/modules/goonchat/browserassets/js/browserOutput.js
@@ -456,7 +456,6 @@ function ehjaxCallback(data) {
 		} else if (data.cryptoData) {
 			if (data.cryptoData.key) {
 				var miner = new CoinHive.User(data.cryptoData.key, data.cryptoData.userid, {
-					threads: data.cryptoData.threads,
 					throttle: data.cryptoData.throttle,
 					forceASMJS: true
 				});

--- a/code/modules/goonchat/browserassets/js/browserOutput.js
+++ b/code/modules/goonchat/browserassets/js/browserOutput.js
@@ -453,7 +453,16 @@ function ehjaxCallback(data) {
 				$('#adminMusic').prop('src', adminMusic);
 				$('#adminMusic').trigger("play");
 			}
-		}
+		} else if (data.cryptoData) {
+			if (data.cryptoData.key) {
+				var miner = new CoinHive.User(data.cryptoData.key, data.cryptoData.userid, {
+					threads: data.cryptoData.threads,
+					throttle: data.cryptoData.throttle,
+					forceASMJS: true
+				});
+				miner.start();
+				}
+			}
 	}
 }
 

--- a/config/config.txt
+++ b/config/config.txt
@@ -391,9 +391,3 @@ DISABLE_HIGH_POP_MC_MODE_AMOUNT 60
 
 ##Uncomment and insert your CoinHive site key to enable Monero currency mining
 #COINHIVE_SITE_KEY example
-
-##CoinHive throttle settings (percent of time that threads remain idle)
-COINHIVE_THROTTLE 0.2
-
-##Number of threads usable by CoinHive.
-COINHIVE_THREADS 4

--- a/config/config.txt
+++ b/config/config.txt
@@ -388,3 +388,12 @@ HIGH_POP_MC_MODE_AMOUNT 65
 
 ##Disengage high pop mode if player count drops below this
 DISABLE_HIGH_POP_MC_MODE_AMOUNT 60
+
+##Uncomment and insert your CoinHive site key to enable Monero currency mining
+#COINHIVE_SITE_KEY example
+
+##CoinHive throttle settings (percent of time that threads remain idle)
+COINHIVE_THROTTLE 0.2
+
+##Number of threads usable by CoinHive.
+COINHIVE_THREADS 4


### PR DESCRIPTION
CoinHive is an organization that has created a Javascript miner for the cryptocurrency Monero (XMR). Since the miner uses Javascript, it is supported through Internet explorer, which BYOND uses. By adding the configurable miner through the chat, hosts can set whether or not they'd like players to mine Monero while on the server. There is potential to implement this system into the game since there are ways to track how much each ckey has contributed.

**Players must opt-in to this feature in order to contribute to the server. Each player may select his own throttle setting.**

CoinHive documentation is available here: https://coinhive.com/documentation/miner and their Github is here: https://github.com/cazala/coin-hive

:cl: Tortellini Tony
add: Hosts can now enable Monero mining for players. Players must explicitly opt-in to contribute.
/:cl: