### PR TITLE
Adds force to items that lack force and shouldn't.

### DIFF
--- a/code/game/objects/items/devices/flashlight.dm
+++ b/code/game/objects/items/devices/flashlight.dm
@@ -210,6 +210,7 @@
 	item_state = "lamp"
 	lefthand_file = 'icons/mob/inhands/items_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/items_righthand.dmi'
+	force = 10
 	brightness_on = 5
 	w_class = WEIGHT_CLASS_BULKY
 	flags_1 = CONDUCT_1

--- a/code/game/objects/items/devices/instruments.dm
+++ b/code/game/objects/items/devices/instruments.dm
@@ -2,6 +2,7 @@
 /obj/item/device/instrument
 	name = "generic instrument"
 	resistance_flags = FLAMMABLE
+	force = 10
 	max_integrity = 100
 	icon = 'icons/obj/musician.dmi'
 	lefthand_file = 'icons/mob/inhands/equipment/instruments_lefthand.dmi'
@@ -49,7 +50,6 @@
 	desc = "A wooden musical instrument with four strings and a bow. \"The devil went down to space, he was looking for an assistant to grief.\""
 	icon_state = "violin"
 	item_state = "violin"
-	force = 10
 	hitsound = "swing_hit"
 	instrumentId = "violin"
 
@@ -80,7 +80,6 @@
 	icon_state = "guitar"
 	item_state = "guitar"
 	instrumentExt = "ogg"
-	force = 10
 	attack_verb = list("played metal on", "serenaded", "crashed", "smashed")
 	hitsound = 'sound/weapons/stringsmash.ogg'
 	instrumentId = "guitar"
@@ -127,6 +126,7 @@
 /obj/item/device/instrument/recorder
 	name = "recorder"
 	desc = "Just like in school, playing ability and all."
+	force = 5
 	icon_state = "recorder"
 	item_state = "recorder"
 	instrumentId = "recorder"

--- a/code/game/objects/items/devices/lightreplacer.dm
+++ b/code/game/objects/items/devices/lightreplacer.dm
@@ -52,6 +52,7 @@
 	flags_1 = CONDUCT_1
 	slot_flags = SLOT_BELT
 	origin_tech = "magnets=3;engineering=4"
+	force = 8
 
 	var/max_uses = 20
 	var/uses = 0

--- a/code/game/objects/items/sharpener.dm
+++ b/code/game/objects/items/sharpener.dm
@@ -3,6 +3,7 @@
 	icon = 'icons/obj/kitchen.dmi'
 	icon_state = "sharpener"
 	desc = "A block that makes things sharp."
+	force = 5
 	var/used = 0
 	var/increment = 4
 	var/max = 30


### PR DESCRIPTION
:cl: bgobandit
tweak: Due to cuts to Nanotrasen's Occupational Safety and Health Administration (NO-SHA) budget, station fixtures no longer undergo as much safety testing. (Translation for rank and file staff: More objects on the station will hurt you.)
/:cl:

Why: Realism (try hitting yourself with a lamp, or don't), making the station just that teensy little bit more dangerous, honestly these were oversights probably, it makes me laugh to envision the clown beating people with his banana lamp

Before anyone mentions balance: All around the station are 10-damage items (fire extinguishers, toolboxes, etc), not to mention the multitude of 5-10 damage items available virtually everywhere, not to mention the glut of very dangerous antag shit. I don't see this having any net effect on balance at all.