### PR TITLE
Deterministic output slots for smartfridges

### DIFF
--- a/code/game/machinery/_machinery.dm
+++ b/code/game/machinery/_machinery.dm
@@ -509,6 +509,9 @@ Class Procs:
 
 /obj/machinery/proc/adjust_item_drop_location(atom/movable/AM)	// Adjust item drop location to a 3x3 grid inside the tile, returns slot id from 0 to 8
 	var/md5 = md5(AM.name)										// Oh, and it's deterministic too. A specific item will always drop from the same slot.
+#if DM_VERSION > 511
+#warn Refactor the loop in /obj/machinery/proc/adjust_item_drop_location() to make use of 512's list-like access to characters in a string
+#endif
 	for (var/i in 1 to 32)
 		. += hex2num(copytext(md5,i,i+1))
 	. = . % 9

--- a/code/game/machinery/_machinery.dm
+++ b/code/game/machinery/_machinery.dm
@@ -506,3 +506,11 @@ Class Procs:
 	. = ..()
 	if (AM == occupant)
 		occupant = null
+
+/obj/machinery/proc/adjust_item_drop_location(atom/movable/AM)	// Adjust item drop location to a 3x3 grid inside the tile, returns slot id from 0 to 8
+	var/md5 = md5(AM.name)										// Oh, and it's deterministic too. A specific item will always drop from the same slot.
+	for (var/i in 1 to 32)
+		. += hex2num(copytext(md5,i,i+1))
+	. = . % 9
+	AM.pixel_x = -8 + ((.%3)*8)
+	AM.pixel_y = -8 + (round( . / 3)*8)

--- a/code/modules/food_and_drinks/kitchen_machinery/smartfridge.dm
+++ b/code/modules/food_and_drinks/kitchen_machinery/smartfridge.dm
@@ -194,10 +194,19 @@
 					break
 				if(O.name == params["name"])
 					O.forceMove(drop_location())
+					adjust_item_drop_location(O)
 					desired--
 			return TRUE
 	return FALSE
 
+
+/obj/machinery/smartfridge/proc/adjust_item_drop_location(obj/item/item)	// Adjust item drop location to a 3x3 grid inside the tile, returns slot id from 0 to 8
+	var/md5 = md5(item.name)												// Oh, and it's deterministic too. A specific item will always drop from the same slot.
+	for (var/i in 1 to 32)
+		. += hex2num(copytext(md5,i,i+1))
+	. = . % 9
+	item.pixel_x = -8 + ((.%3)*8)
+	item.pixel_y = -8 + (round( . / 3)*8)
 
 // ----------------------------
 //  Drying Rack 'smartfridge'

--- a/code/modules/food_and_drinks/kitchen_machinery/smartfridge.dm
+++ b/code/modules/food_and_drinks/kitchen_machinery/smartfridge.dm
@@ -200,14 +200,6 @@
 	return FALSE
 
 
-/obj/machinery/smartfridge/proc/adjust_item_drop_location(obj/item/item)	// Adjust item drop location to a 3x3 grid inside the tile, returns slot id from 0 to 8
-	var/md5 = md5(item.name)												// Oh, and it's deterministic too. A specific item will always drop from the same slot.
-	for (var/i in 1 to 32)
-		. += hex2num(copytext(md5,i,i+1))
-	. = . % 9
-	item.pixel_x = -8 + ((.%3)*8)
-	item.pixel_y = -8 + (round( . / 3)*8)
-
 // ----------------------------
 //  Drying Rack 'smartfridge'
 // ----------------------------

--- a/code/modules/reagents/chemistry/machinery/chem_master.dm
+++ b/code/modules/reagents/chemistry/machinery/chem_master.dm
@@ -220,8 +220,7 @@
 					else
 						P = new/obj/item/reagent_containers/pill(drop_location())
 					P.name = trim("[name] pill")
-					P.pixel_x = rand(-7, 7) //random position
-					P.pixel_y = rand(-7, 7)
+					adjust_item_drop_location(P)
 					reagents.trans_to(P,vol_each)
 			else
 				var/name = stripped_input(usr, "Name:", "Name your pack!", reagents.get_master_reagent_name(), MAX_NAME_LEN)
@@ -337,7 +336,10 @@
 		AM.pixel_y = 8
 		return null
 	else if (AM == bottle)
-		AM.pixel_x = -8
+		if (length(bottle.contents))
+			AM.pixel_x = -13
+		else
+			AM.pixel_x = -7
 		AM.pixel_y = -8
 		return null
 	else
@@ -345,7 +347,7 @@
 		for (var/i in 1 to 32)
 			. += hex2num(copytext(md5,i,i+1))
 		. = . % 9
-		AM.pixel_x = ((.%3)*4)
+		AM.pixel_x = ((.%3)*6)
 		AM.pixel_y = -8 + (round( . / 3)*8)
 
 /obj/machinery/chem_master/condimaster

--- a/code/modules/reagents/chemistry/machinery/chem_master.dm
+++ b/code/modules/reagents/chemistry/machinery/chem_master.dm
@@ -62,11 +62,13 @@
 /obj/machinery/chem_master/attackby(obj/item/I, mob/user, params)
 	if(default_deconstruction_screwdriver(user, "mixer0_nopower", "mixer0", I))
 		if(beaker)
-			beaker.loc = src.loc
+			beaker.forceMove(drop_location())
+			adjust_item_drop_location(beaker)
 			beaker = null
 			reagents.clear_reagents()
 		if(bottle)
-			bottle.loc = src.loc
+			bottle.forceMove(drop_location())
+			adjust_item_drop_location(bottle)
 			bottle = null
 		return
 
@@ -153,7 +155,8 @@
 	switch(action)
 		if("eject")
 			if(beaker)
-				beaker.loc = src.loc
+				beaker.forceMove(drop_location())
+				adjust_item_drop_location(beaker)
 				beaker = null
 				reagents.clear_reagents()
 				icon_state = "mixer0"
@@ -161,7 +164,8 @@
 
 		if("ejectp")
 			if(bottle)
-				bottle.loc = src.loc
+				bottle.forceMove(drop_location())
+				adjust_item_drop_location(bottle)
 				bottle = null
 				. = TRUE
 
@@ -214,7 +218,7 @@
 					if(bottle && bottle.contents.len < bottle.storage_slots)
 						P = new/obj/item/reagent_containers/pill(bottle)
 					else
-						P = new/obj/item/reagent_containers/pill(src.loc)
+						P = new/obj/item/reagent_containers/pill(drop_location())
 					P.name = trim("[name] pill")
 					P.pixel_x = rand(-7, 7) //random position
 					P.pixel_y = rand(-7, 7)
@@ -223,7 +227,7 @@
 				var/name = stripped_input(usr, "Name:", "Name your pack!", reagents.get_master_reagent_name(), MAX_NAME_LEN)
 				if(!name || !reagents.total_volume || !src || QDELETED(src) || !usr.canUseTopic(src, be_close=TRUE))
 					return
-				var/obj/item/reagent_containers/food/condiment/pack/P = new/obj/item/reagent_containers/food/condiment/pack(src.loc)
+				var/obj/item/reagent_containers/food/condiment/pack/P = new/obj/item/reagent_containers/food/condiment/pack(drop_location())
 
 				P.originalname = name
 				P.name = trim("[name] pack")
@@ -248,10 +252,9 @@
 			var/obj/item/reagent_containers/pill/P
 
 			for(var/i = 0; i < amount; i++)
-				P = new/obj/item/reagent_containers/pill/patch(src.loc)
+				P = new/obj/item/reagent_containers/pill/patch(drop_location())
 				P.name = trim("[name] patch")
-				P.pixel_x = rand(-7, 7) //random position
-				P.pixel_y = rand(-7, 7)
+				adjust_item_drop_location(P)
 				reagents.trans_to(P,vol_each)
 			. = TRUE
 
@@ -264,7 +267,7 @@
 				var/name = stripped_input(usr, "Name:","Name your bottle!", (reagents.total_volume ? reagents.get_master_reagent_name() : " "), MAX_NAME_LEN)
 				if(!name || !reagents.total_volume || !src || QDELETED(src) || !usr.canUseTopic(src, be_close=TRUE))
 					return
-				var/obj/item/reagent_containers/food/condiment/P = new(src.loc)
+				var/obj/item/reagent_containers/food/condiment/P = new(drop_location())
 				P.originalname = name
 				P.name = trim("[name] bottle")
 				reagents.trans_to(P, P.volume)
@@ -280,15 +283,15 @@
 
 				var/obj/item/reagent_containers/glass/bottle/P
 				for(var/i = 0; i < amount_full; i++)
-					P = new/obj/item/reagent_containers/glass/bottle(src.loc)
-					P.pixel_x = rand(-7, 7) //random position
-					P.pixel_y = rand(-7, 7)
+					P = new/obj/item/reagent_containers/glass/bottle(drop_location())
 					P.name = trim("[name] bottle")
+					adjust_item_drop_location(P)
 					reagents.trans_to(P, 30)
 
 				if(vol_part)
-					P = new/obj/item/reagent_containers/glass/bottle(src.loc)
+					P = new/obj/item/reagent_containers/glass/bottle(drop_location())
 					P.name = trim("[name] bottle")
+					adjust_item_drop_location(P)
 					reagents.trans_to(P, vol_part)
 			. = TRUE
 
@@ -327,6 +330,23 @@
 	else
 		return 0
 
+
+/obj/machinery/chem_master/adjust_item_drop_location(atom/movable/AM) // Special version for chemmasters and condimasters
+	if (AM == beaker)
+		AM.pixel_x = -8
+		AM.pixel_y = 8
+		return null
+	else if (AM == bottle)
+		AM.pixel_x = -8
+		AM.pixel_y = -8
+		return null
+	else
+		var/md5 = md5(AM.name)
+		for (var/i in 1 to 32)
+			. += hex2num(copytext(md5,i,i+1))
+		. = . % 9
+		AM.pixel_x = ((.%3)*4)
+		AM.pixel_y = -8 + (round( . / 3)*8)
 
 /obj/machinery/chem_master/condimaster
 	name = "CondiMaster 3000"

--- a/code/modules/reagents/chemistry/machinery/chem_master.dm
+++ b/code/modules/reagents/chemistry/machinery/chem_master.dm
@@ -344,6 +344,9 @@
 		return null
 	else
 		var/md5 = md5(AM.name)
+#if DM_VERSION > 511
+#warn Refactor the loop in /obj/machinery/chem_master/adjust_item_drop_location() to make use of 512's list-like access to characters in a string
+#endif
 		for (var/i in 1 to 32)
 			. += hex2num(copytext(md5,i,i+1))
 		. = . % 9


### PR DESCRIPTION
Simply put, when you take items out of a smartfridge, they are output in one of the slots in a 3x3 grid inside the fridge tile in a deterministic fashion, so that a 9u pill of cyanide you might use to escape an assignment in security will always pop out at the same slot. This hopefully reduces the right-click menu usage a fair bit.

Looks kinda like this:

![image](https://user-images.githubusercontent.com/20017308/32146648-32d3ce06-bce3-11e7-8e60-557b43d7eb13.png)


[Changelogs]: 

:cl: Naksu
tweak: Smartfridges and chem/condimasters now output items in a deterministic 3x3 grid rather than in a huge pile in the middle of the tile.
/:cl:
