### PR TITLE
Makes runtime station selectable by default

### DIFF
--- a/config/maps.txt
+++ b/config/maps.txt
@@ -35,5 +35,4 @@ map deltastation
 endmap
 
 map runtimestation
-	disabled
 endmap


### PR DESCRIPTION
Just a simple change to make using runtime station easier when testing.