### PR TITLE
Honkbots Tablecrafting

### DIFF
--- a/code/modules/crafting/recipes.dm
+++ b/code/modules/crafting/recipes.dm
@@ -179,6 +179,16 @@
 	time = 40
 	category = CAT_ROBOT
 
+/datum/crafting_recipe/honkbot
+	name = "Honkbot"
+	result = /mob/living/simple_animal/bot/honkbot
+	reqs = list(/obj/item/storage/box/clown = 1,
+				/obj/item/bodypart/r_arm/robot = 1,
+				/obj/item/device/assembly/prox_sensor = 1,
+				/obj/item/bikehorn/ = 1)
+	time = 40
+	category = CAT_ROBOT
+
 /datum/crafting_recipe/improvised_pneumatic_cannon //Pretty easy to obtain but
 	name = "Pneumatic Cannon"
 	result = /obj/item/pneumatic_cannon/ghetto


### PR DESCRIPTION
[Changelogs]: #
:cl: 
add: You can now tablecraft Honkbots.
/:cl:
[why]: # Consistency. Every bots has a tablecrafting recipe, and honkbots should be no exception.