### PR TITLE
Makes greyscaled cables' color viewable in map editing

### DIFF
--- a/code/game/objects/items/handcuffs.dm
+++ b/code/game/objects/items/handcuffs.dm
@@ -91,6 +91,7 @@
 	icon_state = "cuff"
 	item_state = "coil"
 	item_color = "red"
+	color = "#ff0000"
 	lefthand_file = 'icons/mob/inhands/equipment/tools_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/equipment/tools_righthand.dmi'
 	materials = list(MAT_METAL=150, MAT_GLASS=75)
@@ -109,6 +110,7 @@
 	update_icon()
 
 /obj/item/restraints/handcuffs/cable/update_icon()
+	color = null
 	add_atom_colour(item_color, FIXED_COLOUR_PRIORITY)
 
 /obj/item/restraints/handcuffs/cable/attack(mob/living/carbon/C, mob/living/carbon/human/user)
@@ -130,24 +132,31 @@
 
 /obj/item/restraints/handcuffs/cable/red
 	item_color = "red"
+	color = "#ff0000"
 
 /obj/item/restraints/handcuffs/cable/yellow
 	item_color = "yellow"
+	color = "#ffff00"
 
 /obj/item/restraints/handcuffs/cable/blue
 	item_color = "blue"
+	color = "#1919c8"
 
 /obj/item/restraints/handcuffs/cable/green
 	item_color = "green"
+	color = "#00aa00"
 
 /obj/item/restraints/handcuffs/cable/pink
 	item_color = "pink"
+	color = "#ff3ccd"
 
 /obj/item/restraints/handcuffs/cable/orange
 	item_color = "orange"
+	color = "#ff8000"
 
 /obj/item/restraints/handcuffs/cable/cyan
 	item_color = "cyan"
+	color = "#00ffff"
 
 /obj/item/restraints/handcuffs/cable/white
 	item_color = "white"

--- a/code/modules/power/cable.dm
+++ b/code/modules/power/cable.dm
@@ -48,24 +48,31 @@ By design, d1 is the smallest direction and d2 is the highest
 	var/obj/item/stack/cable_coil/stored
 
 	var/cable_color = "red"
+	color = "#ff0000"
 
 /obj/structure/cable/yellow
 	cable_color = "yellow"
+	color = "#ffff00"
 
 /obj/structure/cable/green
 	cable_color = "green"
+	color = "#00aa00"
 
 /obj/structure/cable/blue
 	cable_color = "blue"
+	color = "#1919c8"
 
 /obj/structure/cable/pink
 	cable_color = "pink"
+	color = "#ff3cc8"
 
 /obj/structure/cable/orange
 	cable_color = "orange"
+	color = "#ff8000"
 
 /obj/structure/cable/cyan
 	cable_color = "cyan"
+	color = "#00ffff"
 
 /obj/structure/cable/white
 	cable_color = "white"
@@ -123,6 +130,7 @@ By design, d1 is the smallest direction and d2 is the highest
 		icon_state = "[d1]-[d2]-f"
 	else
 		icon_state = "[d1]-[d2]"
+	color = null
 	add_atom_colour(cable_color, FIXED_COLOUR_PRIORITY)
 
 /obj/structure/cable/proc/handlecable(obj/item/W, mob/user, params)
@@ -523,6 +531,7 @@ GLOBAL_LIST_INIT(cable_coil_recipes, list (new/datum/stack_recipe("cable restrai
 /obj/item/stack/cable_coil/update_icon()
 	icon_state = "[initial(item_state)][amount < 3 ? amount : ""]"
 	name = "cable [amount < 3 ? "piece" : "coil"]"
+	color = null
 	add_atom_colour(item_color, FIXED_COLOUR_PRIORITY)
 
 /obj/item/stack/cable_coil/attack_hand(mob/user)
@@ -743,30 +752,38 @@ GLOBAL_LIST_INIT(cable_coil_recipes, list (new/datum/stack_recipe("cable restrai
 
 /obj/item/stack/cable_coil/red
 	item_color = "red"
+	color = "#ff0000"
 
 /obj/item/stack/cable_coil/yellow
 	item_color = "yellow"
+	color = "#ffff00"
 
 /obj/item/stack/cable_coil/blue
 	item_color = "blue"
+	color = "#1919c8"
 
 /obj/item/stack/cable_coil/green
 	item_color = "green"
+	color = "#00aa00"
 
 /obj/item/stack/cable_coil/pink
 	item_color = "pink"
+	color = "#ff3ccd"
 
 /obj/item/stack/cable_coil/orange
 	item_color = "orange"
+	color = "#ff8000"
 
 /obj/item/stack/cable_coil/cyan
 	item_color = "cyan"
+	color = "#00ffff"
 
 /obj/item/stack/cable_coil/white
 	item_color = "white"
 
 /obj/item/stack/cable_coil/random
 	item_color = null
+	color = "#ffffff"
 
 /obj/item/stack/cable_coil/random/five
 	amount = 5


### PR DESCRIPTION
Sorry I didn't do this originally @WJohn 

Makes it so cables aren't all white in the map editor.