### PR TITLE
Replaces glass in atmos tank windows with reinforced plasma glass

### DIFF
--- a/_maps/map_files/BoxStation/BoxStation.dmm
+++ b/_maps/map_files/BoxStation/BoxStation.dmm
@@ -38831,7 +38831,7 @@
 	},
 /area/engine/atmos)
 "bQA" = (
-/obj/effect/spawner/structure/window/reinforced,
+/obj/effect/spawner/structure/window/plasma/reinforced,
 /turf/open/floor/plating/airless,
 /area/engine/atmos)
 "bQB" = (

--- a/_maps/map_files/Deltastation/DeltaStation2.dmm
+++ b/_maps/map_files/Deltastation/DeltaStation2.dmm
@@ -102671,6 +102671,34 @@
 	},
 /turf/open/floor/circuit/green,
 /area/engine/supermatter)
+"YGM" = (
+/obj/effect/spawner/structure/window/plasma/reinforced,
+/turf/open/floor/plating,
+/area/engine/atmos)
+"YGN" = (
+/obj/effect/spawner/structure/window/plasma/reinforced,
+/turf/open/floor/plating,
+/area/engine/atmos)
+"YGO" = (
+/obj/effect/spawner/structure/window/plasma/reinforced,
+/turf/open/floor/plating,
+/area/engine/atmos)
+"YGP" = (
+/obj/effect/spawner/structure/window/plasma/reinforced,
+/turf/open/floor/plating,
+/area/engine/atmos)
+"YGQ" = (
+/obj/effect/spawner/structure/window/plasma/reinforced,
+/turf/open/floor/plating,
+/area/engine/atmos)
+"YGR" = (
+/obj/effect/spawner/structure/window/plasma/reinforced,
+/turf/open/floor/plating,
+/area/engine/atmos)
+"YGS" = (
+/obj/effect/spawner/structure/window/plasma/reinforced,
+/turf/open/floor/plating,
+/area/engine/atmos)
 
 (1,1,1) = {"
 aaa
@@ -124357,19 +124385,19 @@ aNF
 aPi
 aNV
 aSK
-aIU
+YGN
 aWc
 aNV
 aSK
-aIU
+YGP
 aWc
 aNV
 aSK
-aIU
+YGR
 aWc
 aNV
 aWc
-aIU
+YGS
 aSK
 aNV
 aaH
@@ -130780,15 +130808,15 @@ aaa
 aaf
 aNV
 aPy
-aIU
+YGM
 aTf
 aNV
 aWv
-aIU
+YGO
 aZy
 aNV
 aWv
-aIU
+YGQ
 aZy
 aNV
 aJg

--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -81046,6 +81046,34 @@
 	},
 /turf/closed/wall/mineral/titanium,
 /area/shuttle/abandoned)
+"EDo" = (
+/obj/effect/spawner/structure/window/plasma/reinforced,
+/turf/open/floor/plating,
+/area/engine/atmos)
+"EDp" = (
+/obj/effect/spawner/structure/window/plasma/reinforced,
+/turf/open/floor/plating,
+/area/engine/atmos)
+"EDq" = (
+/obj/effect/spawner/structure/window/plasma/reinforced,
+/turf/open/floor/plating,
+/area/engine/atmos)
+"EDr" = (
+/obj/effect/spawner/structure/window/plasma/reinforced,
+/turf/open/floor/plating,
+/area/engine/atmos)
+"EDs" = (
+/obj/effect/spawner/structure/window/plasma/reinforced,
+/turf/open/floor/plating,
+/area/engine/atmos)
+"EDt" = (
+/obj/effect/spawner/structure/window/plasma/reinforced,
+/turf/open/floor/plating,
+/area/engine/atmos)
+"EDu" = (
+/obj/effect/spawner/structure/window/plasma/reinforced,
+/turf/open/floor/plating,
+/area/engine/atmos)
 
 (1,1,1) = {"
 aaa
@@ -122573,7 +122601,7 @@ cbe
 ccO
 bza
 aaf
-bza
+EDs
 chO
 cjd
 ckG
@@ -123601,7 +123629,7 @@ cbi
 ccS
 bza
 aaf
-bza
+EDt
 chR
 cjg
 ckH
@@ -124629,7 +124657,7 @@ cVJ
 ccQ
 bza
 aaf
-bza
+EDu
 chU
 cjj
 ckJ
@@ -126151,19 +126179,19 @@ aaa
 aaf
 bAR
 dBC
-bza
+EDo
 bFZ
 bAR
 bCA
-bza
+EDp
 bFZ
 bAR
 bCA
-bza
+EDq
 bFZ
 bAR
 bCA
-bza
+EDr
 bFZ
 bAR
 aaf

--- a/_maps/map_files/OmegaStation/OmegaStation.dmm
+++ b/_maps/map_files/OmegaStation/OmegaStation.dmm
@@ -9050,10 +9050,10 @@
 /turf/closed/wall/r_wall,
 /area/engine/atmos)
 "aqE" = (
-/obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
+/obj/effect/spawner/structure/window/plasma/reinforced,
 /turf/open/floor/plating,
 /area/engine/atmos)
 "aqF" = (
@@ -10695,8 +10695,8 @@
 /turf/open/floor/engine/n2,
 /area/engine/atmos)
 "aty" = (
-/obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/atmospherics/pipe/simple/cyan/visible,
+/obj/effect/spawner/structure/window/plasma/reinforced,
 /turf/open/floor/plating,
 /area/engine/atmos)
 "atz" = (

--- a/_maps/map_files/PubbyStation/PubbyStation.dmm
+++ b/_maps/map_files/PubbyStation/PubbyStation.dmm
@@ -37954,7 +37954,7 @@
 	},
 /area/engine/atmos)
 "bMi" = (
-/obj/effect/spawner/structure/window/reinforced,
+/obj/effect/spawner/structure/window/plasma/reinforced,
 /turf/open/floor/plating/airless,
 /area/engine/atmos)
 "bMj" = (
@@ -51354,6 +51354,10 @@
 	},
 /turf/open/floor/plating/airless,
 /area/engine/engineering)
+"cBT" = (
+/obj/effect/spawner/structure/window/plasma/reinforced,
+/turf/open/floor/plating/airless,
+/area/maintenance/disposal/incinerator)
 
 (1,1,1) = {"
 aaa
@@ -89301,7 +89305,7 @@ bYs
 bYw
 bYw
 bYw
-cbz
+cBT
 bYw
 bYw
 bYw


### PR DESCRIPTION
It's way too easy for some random shit to vent them, and dealing with complete loss of all gas tanks isn't fun. 

This doesn't affect possibility of atmos sabotage, unless the saboteur was too dumb to bring some tools.