### PR TITLE
Removes the armory from RD's closet

### DIFF
--- a/code/game/objects/structures/crates_lockers/closets/secure/scientist.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/scientist.dm
@@ -24,4 +24,3 @@
 	new /obj/item/device/assembly/flash/handheld(src)
 	new /obj/item/device/laser_pointer(src)
 	new /obj/item/door_remote/research_director(src)
-	new /obj/item/device/firing_pin/test_range(src)

--- a/code/game/objects/structures/crates_lockers/closets/secure/scientist.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/scientist.dm
@@ -24,4 +24,4 @@
 	new /obj/item/device/assembly/flash/handheld(src)
 	new /obj/item/device/laser_pointer(src)
 	new /obj/item/door_remote/research_director(src)
-	new /obj/item/storage/box/firingpins(src)
+	new /obj/item/device/firing_pin/test_range(src)


### PR DESCRIPTION
I'm pretty sure the box defeats the reason we added firing pins in the first place. I assumed they were getting them from another dept. but nope, found out the RD gets a bloody box of em at roundstart.

Science having a bag full of functional advanced eguns at 10 minutes into the shift is just stupid, we added pins and only made minshield pins easy to get so that security could have some control over who gets access to guns. It's the equivalent of having ID-locked gun crates at cargo but then spawning a warden's ID in the QM's locker.