### PR TITLE
Makes enterTransit check canMove and sets mode to idle

### DIFF
--- a/code/modules/shuttle/shuttle.dm
+++ b/code/modules/shuttle/shuttle.dm
@@ -416,7 +416,8 @@
 	mode = SHUTTLE_RECALL
 
 /obj/docking_port/mobile/proc/enterTransit()
-	if(SSshuttle.lockdown && (z in GLOB.station_z_levels))	//emp went off, no escape
+	if((SSshuttle.lockdown && (z in GLOB.station_z_levels)) || !canMove())	//emp went off, no escape
+		mode = SHUTTLE_IDLE
 		return
 	previous = null
 //		if(!destination)


### PR DESCRIPTION
:cl: ninjanomnom
fix: Fixes the cargo shuttle occasionally breaking if a mob got on at exactly the right time.
/:cl:

fixes #26470