### PR TITLE
Brings back collector power scaling with the amount of plasma

### DIFF
--- a/code/modules/power/singularity/collector.dm
+++ b/code/modules/power/singularity/collector.dm
@@ -24,9 +24,11 @@
 	var/active = FALSE
 	var/locked = FALSE
 	var/drainratio = 1
+
 	var/pressure_ratio = 1
 	var/plasma_ratio = 1
 	var/temperature_ratio = 1
+	var/total_ratio = 1
 
 /obj/machinery/power/rad_collector/anchored
 	anchored = TRUE
@@ -49,21 +51,19 @@
 			var/total_moles = air_contents.total_moles()
 			var/temperature = air_contents.temperature
 
-			if(temperature < TCMB) // Is this even possible?
-				temperature = TCMB
-
 			pressure_ratio = 1 + ((pressure / RAD_COLLECTOR_BASE_PRESSURE - 1) * RAD_COLLECTOR_PRESSURE_COEFFICIENT)
 			plasma_ratio = air_contents.gases[/datum/gas/plasma][MOLES]/total_moles
-			temperature_ratio = 1 + (temperature / T20C - 1) * RAD_COLLECTOR_TEMP_COEFFICIENT
+			temperature_ratio = 1 + (T20C / temperature - 1) * RAD_COLLECTOR_TEMP_COEFFICIENT
+			// Temperature < TCMB should not be possible. If you see a "division by zero" runtime here, blame gas mixture code.
 
-			var/ratio = pressure_ratio * plasma_ratio * temperature_ratio
+			total_ratio = pressure_ratio * plasma_ratio * temperature_ratio
 
 
 			air_contents.gases[/datum/gas/plasma][MOLES] -= 0.001*drainratio
 			air_contents.garbage_collect()
 
 			var/power_produced = min(last_power, (last_power*RAD_COLLECTOR_STORED_OUT)+1000) //Produces at least 1000 watts if it has more than that stored
-			add_avail(power_produced * ratio)
+			add_avail(power_produced * total_ratio)
 			last_power-=power_produced
 
 /obj/machinery/power/rad_collector/attack_hand(mob/user)


### PR DESCRIPTION
This PR makes the efficiency of radiation collectors increase with plasma pressure and decrease with plasma temperature once again. This feature was removed in the recent radiation rework, and, honestly, it doesn't have anything to do with recent radiation rework.

This time, the power scaling has coefficients in defines. For example, pressure scaling coefficient is 0.15, and this means that filling plasma tanks up to 1013kPa increases power output 135% instead of old 335%. This makes power scaling less overpowered and makes increasing power generation by other means (core gas mix, emitter setup) more viable.

I plan to add more gas interactions to the collectors in the future, but this is out of scope of this PR.

:cl: ACCount
balance: Radiation collector power scaling is back. Have fun with high-pressure supercooled plasma!
/:cl: