### PR TITLE
Fix ghosts causing portals to spark

### DIFF
--- a/code/_onclick/observer.dm
+++ b/code/_onclick/observer.dm
@@ -60,12 +60,6 @@
 // And here are some good things for free:
 // Now you can click through portals, wormholes, gateways, and teleporters while observing. -Sayu
 
-/obj/machinery/teleport/hub/attack_ghost(mob/user)
-	var/atom/l = loc
-	var/obj/machinery/computer/teleporter/com = locate(/obj/machinery/computer/teleporter, locate(l.x - 2, l.y, l.z))
-	if(com && com.locked)
-		user.forceMove(get_turf(com.locked))
-
 /obj/effect/portal/attack_ghost(mob/user)
 	if(linked)
 		user.forceMove(get_turf(linked))

--- a/code/game/objects/effects/portals.dm
+++ b/code/game/objects/effects/portals.dm
@@ -125,7 +125,7 @@
 	return ..()
 
 /obj/effect/portal/proc/teleport(atom/movable/M)
-	if(!istype(M) || istype(M, /obj/effect) || (ismecha(M) && !mech_sized) || (!isobj(M) && !ismob(M))) //Things that shouldn't teleport.
+	if(!istype(M) || istype(M, /obj/effect) || isobserver(M) || (ismecha(M) && !mech_sized) || (!isobj(M) && !ismob(M))) //Things that shouldn't teleport.
 		return
 	var/turf/real_target = get_link_target_turf()
 	if(!istype(real_target))


### PR DESCRIPTION
:cl:
fix: Ghosts can no longer create sparks from the hand teleporter's portals.
/:cl:

Fixes #28667.

The deleted proc is dead code, the same proc is overridden just a few lines down and doesn't call `..()`.