### PR TITLE
Fix a few syntactic aberrations

### DIFF
--- a/code/controllers/subsystem/ticker.dm
+++ b/code/controllers/subsystem/ticker.dm
@@ -30,8 +30,7 @@ SUBSYSTEM_DEF(ticker)
 	var/list/availablefactions = list()		//list of factions with openings
 	var/list/scripture_states = list(SCRIPTURE_DRIVER = TRUE, \
 	SCRIPTURE_SCRIPT = FALSE, \
-	SCRIPTURE_APPLICATION = FALSE, \
-	SCRIPTURE_JUDGEMENT = FALSE) //list of clockcult scripture states for announcements
+	SCRIPTURE_APPLICATION = FALSE) //list of clockcult scripture states for announcements
 
 	var/delay_end = 0						//if set true, the round will not restart on it's own
 

--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -77,7 +77,7 @@ GLOBAL_VAR_INIT(rpg_loot_items, FALSE)
 
 	var/mob/thrownby = null
 
-	/obj/item/mouse_drag_pointer = MOUSE_ACTIVE_POINTER //the icon to indicate this object is being dragged
+	mouse_drag_pointer = MOUSE_ACTIVE_POINTER //the icon to indicate this object is being dragged
 
 	//So items can have custom embedd values
 	//Because customisation is king

--- a/code/game/sound.dm
+++ b/code/game/sound.dm
@@ -102,7 +102,7 @@
 	UNTIL(SSticker.login_music) //wait for SSticker init to set the login music
 
 	if(prefs && (prefs.toggles & SOUND_LOBBY))
-		SEND_SOUND(src, sound(SSticker.login_music, repeat = 0, wait = 0, volume = vol, channel = CHANNEL_LOBBYMUSIC) // MAD JAMS)
+		SEND_SOUND(src, sound(SSticker.login_music, repeat = 0, wait = 0, volume = vol, channel = CHANNEL_LOBBYMUSIC)) // MAD JAMS
 
 /proc/get_rand_frequency()
 	return rand(32000, 55000) //Frequency stuff only works with 45kbps oggs.

--- a/code/modules/cargo/exports/seeds.dm
+++ b/code/modules/cargo/exports/seeds.dm
@@ -26,12 +26,12 @@
 	export_types = list(/obj/item/seeds)
 	needs_discovery = TRUE // Only for already discovered species
 
-/datum/export/seed/potency.get_cost(obj/O)
+/datum/export/seed/potency/get_cost(obj/O)
 	var/obj/item/seeds/S = O
 	var/cost = ..()
 	if(!cost)
 		return 0
 
 	var/potDiff = (S.potency - discoveredPlants[S.type])
-		
+
 	return round(..() * potDiff)

--- a/code/modules/mob/living/simple_animal/bot/construction.dm
+++ b/code/modules/mob/living/simple_animal/bot/construction.dm
@@ -282,11 +282,11 @@
 	var/skin = null //Same as medbot, set to tox or ointment for the respective kits.
 	w_class = WEIGHT_CLASS_NORMAL
 
-	/obj/item/firstaid_arm_assembly/New()
-		..()
-		spawn(5)
-			if(skin)
-				add_overlay("kit_skin_[skin]")
+/obj/item/firstaid_arm_assembly/New()
+	..()
+	spawn(5)
+		if(skin)
+			add_overlay("kit_skin_[skin]")
 
 /obj/item/storage/firstaid/attackby(obj/item/bodypart/S, mob/user, params)
 

--- a/code/modules/mob/living/simple_animal/hostile/wumborian_fugu.dm
+++ b/code/modules/mob/living/simple_animal/hostile/wumborian_fugu.dm
@@ -109,7 +109,7 @@
 	w_class = WEIGHT_CLASS_NORMAL
 	layer = MOB_LAYER
 	origin_tech = "biotech=6"
-	var/list/banned_mobs()
+	var/list/banned_mobs
 
 /obj/item/asteroid/fugu_gland/afterattack(atom/target, mob/user, proximity_flag)
 	if(proximity_flag && isanimal(target))

--- a/code/modules/reagents/reagent_containers/borghydro.dm
+++ b/code/modules/reagents/reagent_containers/borghydro.dm
@@ -199,7 +199,6 @@ Borg Shaker
 		to_chat(usr, "<span class='warning'>It is currently empty! Please allow some time for the synthesizer to produce more.</span>")
 
 /obj/item/reagent_containers/borghypo/borgshaker/hacked
-	..()
 	name = "cyborg shaker"
 	desc = "Will mix drinks that knock them dead."
 	icon = 'icons/obj/drinks.dmi'

--- a/code/modules/ruins/spaceruin_code/oldstation.dm
+++ b/code/modules/ruins/spaceruin_code/oldstation.dm
@@ -39,7 +39,7 @@
 /obj/item/paper/fluff/ruins/oldstation/protoinv
 	name = "Laboratory Inventory"
 	info = "<b>*Inventory*</b><br><br>(1) Prototype Hardsuit<br><br>(1)Health Analyser<br><br>(1)Prototype Energy Gun<br><br>(1)Singularity Generation Disk<br><br><b>DO NOT REMOVE WITHOUT \
-	THE CAPTAIN AND RESEARCH DIRECTOR'S AUTHORISATION<b/>"
+	THE CAPTAIN AND RESEARCH DIRECTOR'S AUTHORISATION</b>"
 
 /obj/item/paper/fluff/ruins/oldstation/report
 	name = "Crew Reawakening Report"


### PR DESCRIPTION
Pure code improvement.

* `SCRIPTURE_JUDGEMENT` isn't defined anywhere and this key is stripped anyways when `scripture_states` is next updated.
* Not a fan of abusing the fact that the preprocessor doesn't know about `//comments`.
* Various weird pathing situations like `..` in a definition context, path operators other than `/`, and indented absolute paths.