### PR TITLE
Huge atmos nerf, tweak buff

### DIFF
--- a/tools/WebhookProcessor/github_webhook_processor.php
+++ b/tools/WebhookProcessor/github_webhook_processor.php
@@ -452,13 +452,11 @@ function get_pr_code_friendliness($payload, $oldbalance = null){
 		'Grammar and Formatting' => 1,
 		'Priority: High' => 4,
 		'Priority: CRITICAL' => 5,
-		'Atmospherics' => 4,
 		'Logging' => 1,
 		'Feedback' => 1,
 		'Performance' => 3,
 		'Feature' => -1,
 		'Balance/Rebalance' => -1,
-		'Tweak' => -1,
 		'PRB: Reset' => $startingPRBalance - $oldbalance,
 	);
 


### PR DESCRIPTION
It's not that different from other subsystems to justify the huge extra point cost, and the people who make atmos related changes have attained a great number of points.

Tweak is for small things that shouldn't affect the point balance either way
