### PR TITLE
Removes laser tag firing pins crate

### DIFF
--- a/code/modules/cargo/packs.dm
+++ b/code/modules/cargo/packs.dm
@@ -1387,13 +1387,6 @@
 					/obj/item/clothing/head/helmet/bluetaghelm)
 	crate_name = "laser tag crate"
 
-/datum/supply_pack/misc/lasertag/pins
-	name = "Laser Tag Firing Pins Crate"
-	cost = 3000
-	contraband = TRUE
-	contains = list(/obj/item/storage/box/lasertagpins)
-	crate_name = "laser tag crate"
-
 /datum/supply_pack/misc/clownpin
 	name = "Hilarious Firing Pin Crate"
 	cost = 5000


### PR DESCRIPTION
Only to be merged with #32259

:cl: Improvedname
del: Removes laser tag pins from cargo
/:cl:

[why]: # (Please add a short description [two lines down] of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.)

Laser tag pins never may be ordered because nobody knows its true potentional
It essentialy can be used as ghetto mindshield inplants
Requiring you to wear a laser tag vest or you cant use it so if somoene disarms you they cant use their gun against you.
