### PR TITLE
Signal redirection component

### DIFF
--- a/code/datums/components/_component.dm
+++ b/code/datums/components/_component.dm
@@ -109,7 +109,7 @@
 		P.datum_components = null
 	parent = null
 
-/datum/component/proc/RegisterSignal(sig_type_or_types, proc_on_self, override = FALSE)
+/datum/component/proc/RegisterSignal(sig_type_or_types, proc_or_callback, override = FALSE)
 	if(QDELETED(src))
 		return
 	var/list/procs = signal_procs
@@ -123,8 +123,10 @@
 			. = procs[sig_type]
 			if(.)
 				stack_trace("[sig_type] overridden. Use override = TRUE to suppress this warning")
-		
-		procs[sig_type] = CALLBACK(src, proc_on_self)    
+
+		if(!istype(proc_or_callback, /datum/callback)) //if it wasnt a callback before, it is now
+			proc_or_callback = CALLBACK(src, proc_or_callback)
+		procs[sig_type] = proc_or_callback
 
 /datum/component/proc/InheritComponent(datum/component/C, i_am_original)
 	return

--- a/code/datums/components/signal_redirect.dm
+++ b/code/datums/components/signal_redirect.dm
@@ -1,11 +1,9 @@
 /datum/component/redirect
 	dupe_mode = COMPONENT_DUPE_ALLOWED
-	var/datum/callback/callback
 
 /datum/component/redirect/Initialize(list/signals, _callback)
 	//It's not our job to verify the right signals are registered here, just do it.
 	if(!signals || !signals.len || !_callback)
 		. = COMPONENT_INCOMPATIBLE
 		CRASH("A redirection component was initialized with incorrect args.")
-	for(var/i in 1 to signals.len)
-		RegisterSignal(signals[i], _callback)
+	RegisterSignal(signals, _callback)

--- a/code/datums/components/signal_redirect.dm
+++ b/code/datums/components/signal_redirect.dm
@@ -1,0 +1,14 @@
+/datum/component/redirect
+	dupe_mode = COMPONENT_DUPE_ALLOWED
+	var/datum/callback/callback
+
+/datum/component/redirect/Initialize(list/signals, _callback)
+	//It's not our job to verify the right signals are registered here, just do it.
+	if(!signals || !_callback)
+		WARNING("A redirection component was initialized with incorrect args.")
+		return COMPONENT_INCOMPATIBLE
+	for(var/i in 1 to signals.len)
+		RegisterSignal(signals[i], .proc/relay_signal)
+
+/datum/component/redirect/proc/relay_signal(...)
+	callback.Invoke(args)

--- a/code/datums/components/signal_redirect.dm
+++ b/code/datums/components/signal_redirect.dm
@@ -4,11 +4,8 @@
 
 /datum/component/redirect/Initialize(list/signals, _callback)
 	//It's not our job to verify the right signals are registered here, just do it.
-	if(!signals || !_callback)
-		WARNING("A redirection component was initialized with incorrect args.")
-		return COMPONENT_INCOMPATIBLE
+	if(!signals || !signals.len || !_callback)
+		. = COMPONENT_INCOMPATIBLE
+		CRASH("A redirection component was initialized with incorrect args.")
 	for(var/i in 1 to signals.len)
-		RegisterSignal(signals[i], .proc/relay_signal)
-
-/datum/component/redirect/proc/relay_signal(...)
-	callback.Invoke(args)
+		RegisterSignal(signals[i], _callback)

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -280,6 +280,7 @@
 #include "code\datums\components\paintable.dm"
 #include "code\datums\components\rad_insulation.dm"
 #include "code\datums\components\radioactive.dm"
+#include "code\datums\components\signal_redirect.dm"
 #include "code\datums\components\slippery.dm"
 #include "code\datums\components\spooky.dm"
 #include "code\datums\components\squeek.dm"


### PR DESCRIPTION
I realized an auto-pickup component is the wrong move and should be done as part of a much bigger container refactor. Here's a piece of it though that'll be useful at that time.

This component is used for when you want to listen in on the signals of a possibly distant object. Say you want to know if anything crosses a line of turfs you can register for the entered signal in all those turfs using this.

I was using this in auto-pickup so it could tell when the mob carrying it moved.