### PR TITLE
Fix double progress bars when digging basalt

### DIFF
--- a/code/game/turfs/simulated/floor/plating/asteroid.dm
+++ b/code/game/turfs/simulated/floor/plating/asteroid.dm
@@ -57,8 +57,6 @@
 		playsound(src, 'sound/weapons/genhit.ogg', 50, 1)
 		return
 
-	return ..()
-
 
 /turf/open/floor/plating/asteroid/singularity_act()
 	if(turf_z_is_planet(src))


### PR DESCRIPTION
🆑
fix: Digging on Lavaland no longer shows two progress bars.
/🆑

Probably shouldn't call `..()` twice. Fixes #32166.