### PR TITLE
Refactors the RCD code a tiny bit. One minor balance change

### DIFF
--- a/code/game/objects/items/RCD.dm
+++ b/code/game/objects/items/RCD.dm
@@ -9,6 +9,8 @@ ARCD
 */
 
 /obj/item/construction
+	name = "not for ingame use"
+	desc = "A device used to rapidly build and deconstruct. Reload with metal, plasteel, glass or compressed matter cartridges."
 	opacity = 0
 	density = FALSE
 	anchored = FALSE
@@ -32,11 +34,13 @@ ARCD
 
 /obj/item/construction/Initialize()
 	. = ..()
-	desc = "\A [src]. It currently holds [matter]/[max_matter] matter-units."
 	spark_system = new /datum/effect_system/spark_spread
 	spark_system.set_up(5, 0, src)
 	spark_system.attach(src)
 
+/obj/item/construction/examine(mob/user)
+	..()
+	to_chat(user, "\A [src]. It currently holds [matter]/[max_matter] matter-units." )
 
 /obj/item/construction/Destroy()
 	QDEL_NULL(spark_system)
@@ -61,7 +65,6 @@ ARCD
 		loaded = loadwithsheets(W, plasteelmultiplier*sheetmultiplier, user) //Plasteel is worth 3 times more than glass or metal
 	if(loaded)
 		to_chat(user, "<span class='notice'>[src] now holds [matter]/[max_matter] matter-units.</span>")
-		desc = "A RCD. It currently holds [matter]/[max_matter] matter-units."
 	else
 		return ..()
 
@@ -91,7 +94,6 @@ ARCD
 			to_chat(user, no_ammo_message)
 		return 0
 	matter -= amount
-	desc = "\A [src]. It currently holds [matter]/[max_matter] matter-units."
 	update_icon()
 	return 1
 
@@ -117,7 +119,6 @@ ARCD
 
 /obj/item/construction/rcd
 	name = "rapid-construction-device (RCD)"
-	desc = "A device used to rapidly build and deconstruct walls and floors."
 	icon = 'icons/obj/tools.dmi'
 	icon_state = "rcd"
 	lefthand_file = 'icons/mob/inhands/equipment/tools_lefthand.dmi'
@@ -125,7 +126,6 @@ ARCD
 	max_matter = 160
 	flags_2 = NO_MAT_REDEMPTION_2
 	var/mode = 1
-	var/canRturf = 0
 	var/ranged = FALSE
 	var/airlock_type = /obj/machinery/door/airlock
 	var/airlock_glass = FALSE // So the floor's rcd_act knows how much ammo to use
@@ -362,11 +362,10 @@ ARCD
 	qdel(src)
 
 
-/obj/item/construction/rcd/borg/New()
-	..()
+/obj/item/construction/rcd/borg
 	no_ammo_message = "<span class='warning'>Insufficient charge.</span>"
 	desc = "A device used to rapidly build walls and floors."
-	canRturf = 1
+
 
 /obj/item/construction/rcd/borg/useResource(amount, mob/user)
 	if(!iscyborg(user))
@@ -420,7 +419,7 @@ ARCD
 	ammoamt = 160
 
 
-/obj/item/construction/rcd/admin
+/obj/item/construction/rcd/combat/admin
 	name = "admin RCD"
 	max_matter = INFINITY
 	matter = INFINITY
@@ -431,7 +430,7 @@ ARCD
 
 /obj/item/construction/rcd/arcd
 	name = "advanced rapid-construction-device (ARCD)"
-	desc = "A prototype RCD with ranged capability and extended capacity."
+	desc = "A prototype RCD with ranged capability and extended capacity. Reload with metal, plasteel, glass or compressed matter cartridges."
 	max_matter = 300
 	matter = 300
 	delay_mod = 0.6
@@ -454,7 +453,7 @@ ARCD
 
 /obj/item/construction/rld
 	name = "rapid-light-device (RLD)"
-	desc = "A device used to rapidly provide lighting sources to an area."
+	desc = "A device used to rapidly provide lighting sources to an area. Reload with metal, plasteel, glass or compressed matter cartridges."
 	icon = 'icons/obj/tools.dmi'
 	icon_state = "rld-5"
 	lefthand_file = 'icons/mob/inhands/equipment/tools_lefthand.dmi'

--- a/code/game/objects/items/RCD.dm
+++ b/code/game/objects/items/RCD.dm
@@ -134,6 +134,7 @@ ARCD
 	var/list/conf_access = null
 	var/use_one_access = 0 //If the airlock should require ALL or only ONE of the listed accesses.
 	var/delay_mod = 1
+	var/canRturf = FALSE //Variable for R walls to deconstruct them
 
 
 /obj/item/construction/rcd/suicide_act(mob/user)
@@ -365,6 +366,7 @@ ARCD
 /obj/item/construction/rcd/borg
 	no_ammo_message = "<span class='warning'>Insufficient charge.</span>"
 	desc = "A device used to rapidly build walls and floors."
+	canRturf = TRUE
 
 
 /obj/item/construction/rcd/borg/useResource(amount, mob/user)
@@ -400,6 +402,7 @@ ARCD
 	name = "industrial RCD"
 	max_matter = 500
 	matter = 500
+	canRturf = TRUE
 
 /obj/item/rcd_ammo
 	name = "compressed matter cartridge"

--- a/code/game/turfs/simulated/wall/reinf_walls.dm
+++ b/code/game/turfs/simulated/wall/reinf_walls.dm
@@ -256,10 +256,10 @@
 			dismantle_wall()
 
 /turf/closed/wall/r_wall/rcd_vals(mob/user, obj/item/construction/rcd/the_rcd)
-	if(istype(the_rcd, /obj/item/construction/rcd/borg) || istype(the_rcd, /obj/item/construction/rcd/combat))
+	if(the_rcd.canRturf)
 		return ..()
 
 
 /turf/closed/wall/r_wall/rcd_act(mob/user, obj/item/construction/rcd/the_rcd, passed_mode)
-	if(istype(the_rcd, /obj/item/construction/rcd/borg) || istype(the_rcd, /obj/item/construction/rcd/combat))
+	if(the_rcd.canRturf)
 		return ..()

--- a/code/game/turfs/simulated/wall/reinf_walls.dm
+++ b/code/game/turfs/simulated/wall/reinf_walls.dm
@@ -256,11 +256,10 @@
 			dismantle_wall()
 
 /turf/closed/wall/r_wall/rcd_vals(mob/user, obj/item/construction/rcd/the_rcd)
-	if(!the_rcd.canRturf)
-		return FALSE
-	return ..()
+	if(istype(the_rcd, /obj/item/construction/rcd/borg) || istype(the_rcd, /obj/item/construction/rcd/combat))
+		return ..()
+
 
 /turf/closed/wall/r_wall/rcd_act(mob/user, obj/item/construction/rcd/the_rcd, passed_mode)
-	if(!the_rcd.canRturf)
-		return FALSE
-	return ..()
+	if(istype(the_rcd, /obj/item/construction/rcd/borg) || istype(the_rcd, /obj/item/construction/rcd/combat))
+		return ..()


### PR DESCRIPTION
Changed about the locations of descriptions for construction and children to reduce needless complexity and to standardize as well as removing one variable which is literally used for two checks at one location elsewhere in the code.

:cl: Jalleo
tweak: Removed a variable to state which RCD's can deconstruct reinforced walls
balance: Made combat (ERT ones) and admin RCDs able to deconstruct r walls alongside borg ones
/:cl:
