### PR TITLE
Allow certain mobs to be var-edited to become completely docile.

### DIFF
--- a/code/modules/mob/living/simple_animal/hostile/retaliate/retaliate.dm
+++ b/code/modules/mob/living/simple_animal/hostile/retaliate/retaliate.dm
@@ -3,6 +3,8 @@
 	var/docile = FALSE
 
 /mob/living/simple_animal/hostile/retaliate/Found(atom/A)
+	if(docile)
+		return
 	if(isliving(A))
 		var/mob/living/L = A
 		if(!L.stat)

--- a/code/modules/mob/living/simple_animal/hostile/retaliate/retaliate.dm
+++ b/code/modules/mob/living/simple_animal/hostile/retaliate/retaliate.dm
@@ -1,5 +1,6 @@
 /mob/living/simple_animal/hostile/retaliate
 	var/list/enemies = list()
+	var/docile = FALSE
 
 /mob/living/simple_animal/hostile/retaliate/Found(atom/A)
 	if(isliving(A))
@@ -22,7 +23,8 @@
 
 /mob/living/simple_animal/hostile/retaliate/proc/Retaliate()
 	var/list/around = view(src, vision_range)
-
+	if(docile)
+		return
 	for(var/atom/movable/A in around)
 		if(A == src)
 			continue
@@ -43,5 +45,5 @@
 
 /mob/living/simple_animal/hostile/retaliate/adjustHealth(amount, updating_health = TRUE, forced = FALSE)
 	. = ..()
-	if(. > 0 && stat == CONSCIOUS)
+	if(. > 0 && stat == CONSCIOUS && !docile)
 		Retaliate()


### PR DESCRIPTION
[Changelogs]

:cl:
balance: Certain mobs can now be var-edited to become completely docile.
/:cl:

[why]: # (Please add a short description [two lines down] of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.)

Certain mobs can be var-edited to become completely docile. (ie: simple_animal/hostile/retaliate)
*They no longer look around for enemies.
*They no longer retaliate against friendly fire.
*They still take their anger on furniture, so beware.

Why?  Because players likes to find and keep weird pets, and their behavior can be very erratic,.
Even with the faction system, there will be trouble. For example, I saw a pet watcher kill a vampire player in bat form in one shot. I doubt he was pleased about it. It gives admins and coders more leeway to what creatures they want to feature in their events and/or items. 