### PR TITLE
Fixes directional character previews (And probably other things, too)

### DIFF
--- a/code/__HELPERS/icons.dm
+++ b/code/__HELPERS/icons.dm
@@ -849,7 +849,7 @@ The _flatIcons list is a cache for generated icon files.
 	if(A.alpha < 255)
 		flat.Blend(rgb(255, 255, 255, A.alpha), ICON_MULTIPLY)
 
-	return icon(flat, "", SOUTH)
+	return icon(flat, "", curdir)
 
 /proc/getIconMask(atom/A)//By yours truly. Creates a dynamic mask for a mob/whatever. /N
 	var/icon/alpha_mask = new(A.icon,A.icon_state)//So we want the default icon and icon state of A.


### PR DESCRIPTION
,,,,, The issue was that getflaticon was always returning an icon facing south, rather than an icon in the direction specified.

Fixes #25506

:cl: deathride58
fix: Directional character icon previews now function properly. Other things relying on getflaticon probably work with directional icons again, as well.
/:cl:

obligatory screenshot of the fix in action:
![image](https://user-images.githubusercontent.com/6356337/32305686-4f927ada-bf4d-11e7-950b-3197556651d9.png)
