### PR TITLE
Proper and improper macros are removed before sending to irc

### DIFF
--- a/code/modules/admin/verbs/adminhelp.dm
+++ b/code/modules/admin/verbs/adminhelp.dm
@@ -489,9 +489,9 @@ GLOBAL_DATUM_INIT(ahelp_tickets, /datum/admin_help_tickets, new)
 		return
 	if(handle_spam_prevention(msg,MUTE_ADMINHELP))
 		return
-	
+
 	msg = trim(msg)
-	
+
 	if(!msg)
 		return
 
@@ -591,6 +591,8 @@ GLOBAL_DATUM_INIT(ahelp_tickets, /datum/admin_help_tickets, new)
 
 /proc/send2irc(msg,msg2)
 	if(SERVER_TOOLS_PRESENT)
+		msg = replacetext(replacetext(msg, "\proper", ""), "\improper", "")
+		msg2 = replacetext(replacetext(msg2, "\proper", ""), "\improper", "")
 		SERVER_TOOLS_RELAY_BROADCAST("[msg] | [msg2]")
 
 /proc/send2otherserver(source,msg,type = "Ahelp")

--- a/code/modules/admin/verbs/adminhelp.dm
+++ b/code/modules/admin/verbs/adminhelp.dm
@@ -590,10 +590,9 @@ GLOBAL_DATUM_INIT(ahelp_tickets, /datum/admin_help_tickets, new)
 
 
 /proc/send2irc(msg,msg2)
-	if(SERVER_TOOLS_PRESENT)
-		msg = replacetext(replacetext(msg, "\proper", ""), "\improper", "")
-		msg2 = replacetext(replacetext(msg2, "\proper", ""), "\improper", "")
-		SERVER_TOOLS_RELAY_BROADCAST("[msg] | [msg2]")
+	msg = replacetext(replacetext(msg, "\proper", ""), "\improper", "")
+	msg2 = replacetext(replacetext(msg2, "\proper", ""), "\improper", "")
+	SERVER_TOOLS_RELAY_BROADCAST("[msg] | [msg2]")
 
 /proc/send2otherserver(source,msg,type = "Ahelp")
 	var/comms_key = CONFIG_GET(string/comms_key)


### PR DESCRIPTION
Should work fine. I am not entirely sure if you need the regex datum for a `replacetextEx`.

This fixes messages such as 
![](https://leoz.space/qVoT.png)