### PR TITLE
Prints out cultist names at round end

### DIFF
--- a/code/game/gamemodes/cult/cult.dm
+++ b/code/game/gamemodes/cult/cult.dm
@@ -256,6 +256,10 @@
 						SSticker.news_report = CULT_FAILURE
 
 			text += "<br><B>Objective #[obj_count]</B>: [explanation]"
+	if(cult.len)
+		text += "<br><b>The cultists were:</b>"
+		for(var/datum/mind/M in cult)
+			text += printplayer(M)
 	to_chat(world, text)
 	..()
 	return 1


### PR DESCRIPTION
:cl: Kor
fix: Cult mode will once again print out names at round end.
/:cl: