### PR TITLE
Fixes canceling cavity implants

### DIFF
--- a/code/modules/surgery/cavity_implant.dm
+++ b/code/modules/surgery/cavity_implant.dm
@@ -17,6 +17,11 @@
 	var/obj/item/bodypart/chest/CH = target.get_bodypart("chest")
 	IC = CH.cavity_item
 	if(tool)
+		if(istype(tool, /obj/item/surgical_drapes) || istype(tool, /obj/item/bedsheet))
+			var/obj/item/inactive = user.get_inactive_held_item()
+			if(istype(inactive, /obj/item/cautery) || istype(inactive, /obj/item/screwdriver) || iscyborg(user))
+				attempt_cancel_surgery(surgery, tool, target, user)
+				return -1
 		user.visible_message("[user] begins to insert [tool] into [target]'s [target_zone].", "<span class='notice'>You begin to insert [tool] into [target]'s [target_zone]...</span>")
 	else
 		user.visible_message("[user] checks for items in [target]'s [target_zone].", "<span class='notice'>You check for items in [target]'s [target_zone]...</span>")

--- a/code/modules/surgery/helpers.dm
+++ b/code/modules/surgery/helpers.dm
@@ -72,34 +72,31 @@
 			else
 				to_chat(user, "<span class='warning'>You need to expose [M]'s [parse_zone(selected_zone)] first!</span>")
 
-	// so hardcoded, we need to do something with it
 	else if(!current_surgery.step_in_progress)
-		if(current_surgery.status == 1)
-			M.surgeries -= current_surgery
-			user.visible_message("[user] removes the drapes from [M]'s [parse_zone(selected_zone)].", \
-				"<span class='notice'>You remove the drapes from [M]'s [parse_zone(selected_zone)].</span>")
-			qdel(current_surgery)
-		else if(current_surgery.can_cancel)
-			if(current_surgery.requires_bodypart_type == BODYPART_ORGANIC)
-				if(istype(user.get_inactive_held_item(), /obj/item/cautery))
-					M.surgeries -= current_surgery
-					user.visible_message("[user] mends the incision and removes the drapes from [M]'s [parse_zone(selected_zone)].", \
-						"<span class='notice'>You mend the incision and remove the drapes from [M]'s [parse_zone(selected_zone)].</span>")
-					qdel(current_surgery)
-				else
-					to_chat(user, "<span class='warning'>You need to hold a cautery in inactive hand to stop [M]'s surgery!</span>")
-			else if(current_surgery.requires_bodypart_type == BODYPART_ROBOTIC)
-				if(istype(user.get_inactive_held_item(), /obj/item/screwdriver))
-					M.surgeries -= current_surgery
-					user.visible_message("[user] screw the shell and removes the drapes from [M]'s [parse_zone(selected_zone)].", \
-						"<span class='notice'>You screw the shell and remove the drapes from [M]'s [parse_zone(selected_zone)].</span>")
-					qdel(current_surgery)
-				else
-					to_chat(user, "<span class='warning'>You need to hold a screwdriver in inactive hand to stop [M]'s surgery!</span>")
+		attempt_cancel_surgery(current_surgery, I, M, user)
 
 	return 1
 
-
+/proc/attempt_cancel_surgery(datum/surgery/S, obj/item/I, mob/living/M, mob/user)
+	var/selected_zone = user.zone_selected
+	if(S.status == 1)
+		M.surgeries -= S
+		user.visible_message("[user] removes [I] from [M]'s [parse_zone(selected_zone)].", \
+			"<span class='notice'>You remove [I] from [M]'s [parse_zone(selected_zone)].</span>")
+		qdel(S)
+	else if(S.can_cancel)
+		var/close_tool_type = /obj/item/cautery
+		var/obj/item/close_tool = user.get_inactive_held_item()
+		var/is_robotic = S.requires_bodypart_type == BODYPART_ROBOTIC
+		if(is_robotic)
+			close_tool_type = /obj/item/screwdriver
+		if(istype(close_tool, close_tool_type) || iscyborg(user))
+			M.surgeries -= S
+			user.visible_message("[user] closes [M]'s [parse_zone(selected_zone)] with [close_tool] and removes [I].", \
+				"<span class='notice'>You close [M]'s [parse_zone(selected_zone)] with [close_tool] and remove [I].</span>")
+			qdel(S)
+		else
+			to_chat(user, "<span class='warning'>You need to hold a [is_robotic ? "screwdriver" : "cautery"] in your inactive hand to stop [M]'s surgery!</span>")
 
 /proc/get_location_modifier(mob/M)
 	var/turf/T = get_turf(M)


### PR DESCRIPTION
:cl: Swindly
fix: You can now cancel a cavity implant during the implanting/removing step by using drapes while holding the appropriate tool in your inactive hand. Cyborgs can cancel the surgery by using drapes alone.
/:cl:

Added a helper for canceling surgeries. Checks for a cautery/screwdriver before calling it in handle_cavity so that people can still implant drapes if they want to.

Fixes https://github.com/tgstation/tgstation/issues/27956