### PR TITLE
Hide already-downloaded programs from NTNet downloader

### DIFF
--- a/code/modules/modular_computers/file_system/programs/ntdownloader.dm
+++ b/code/modules/modular_computers/file_system/programs/ntdownloader.dm
@@ -130,7 +130,7 @@
 		for(var/A in GLOB.ntnet_global.available_station_software)
 			var/datum/computer_file/program/P = A
 			// Only those programs our user can run will show in the list
-			if(!P.can_run(user,transfer = 1))
+			if(!P.can_run(user,transfer = 1) || hard_drive.find_file_by_name(P.filename))
 				continue
 			all_entries.Add(list(list(
 			"filename" = P.filename,
@@ -144,6 +144,8 @@
 			var/list/hacked_programs[0]
 			for(var/S in GLOB.ntnet_global.available_antag_software)
 				var/datum/computer_file/program/P = S
+				if(hard_drive.find_file_by_name(P.filename))
+					continue
 				data["hackedavailable"] = 1
 				hacked_programs.Add(list(list(
 				"filename" = P.filename,


### PR DESCRIPTION
🆑 
fix: Already-downloaded software is now hidden from the NTNet software downloader.
/🆑 

Fixes #29079.