### PR TITLE
Fixes flamethrower icon not updating on plasma tank removal

### DIFF
--- a/code/game/objects/items/flamethrower.dm
+++ b/code/game/objects/items/flamethrower.dm
@@ -140,6 +140,7 @@
 		user.put_in_hands(ptank)
 		ptank = null
 		to_chat(user, "<span class='notice'>You remove the plasma tank from [src]!</span>")
+		update_icon()
 
 /obj/item/flamethrower/examine(mob/user)
 	..()


### PR DESCRIPTION
`update_icon` was missing, easy fix.