### PR TITLE
Fixes waste loop outlet burning down atmospherics

### DIFF
--- a/_maps/map_files/BoxStation/BoxStation.dmm
+++ b/_maps/map_files/BoxStation/BoxStation.dmm
@@ -6661,9 +6661,11 @@
 /obj/machinery/atmospherics/components/unary/outlet_injector/on{
 	dir = 1;
 	frequency = 1441;
-	id = "waste_out"
+	id = "waste_out";
+	volume_rate = 200
 	},
-/turf/open/floor/plating/airless,
+/obj/structure/lattice/catwalk,
+/turf/open/space,
 /area/engine/atmos)
 "apJ" = (
 /turf/closed/wall,
@@ -54540,7 +54542,7 @@
 /obj/machinery/atmospherics/components/binary/valve/digital{
 	dir = 4;
 	name = "Output Release";
-	open = 1;
+	open = 1
 	},
 /turf/open/floor/engine,
 /area/engine/engineering)
@@ -80472,7 +80474,7 @@ aaH
 bCq
 bHE
 bRh
-bSr
+bLu
 bCq
 bHE
 bLv
@@ -85394,7 +85396,7 @@ cSH
 cGu
 cGH
 QoB
-QoE
+QoB
 cGR
 csd
 csd
@@ -85615,7 +85617,7 @@ cjL
 cCb
 bNI
 bEP
-bVL
+bLu
 bVJ
 bVJ
 bVJ
@@ -86162,7 +86164,7 @@ cFe
 cMD
 cFM
 czE
-Qow
+Qov
 ccw
 cGT
 csd
@@ -87190,7 +87192,7 @@ cFh
 cMD
 cFM
 czE
-Qox
+Qov
 ccw
 cGT
 csd
@@ -87447,7 +87449,7 @@ cEz
 cMD
 cFR
 cSJ
-Qoy
+Qov
 cMm
 ciZ
 cHd
@@ -87710,7 +87712,7 @@ cGS
 cHe
 cHe
 cHr
-QoJ
+QoI
 ccw
 aaf
 aaT
@@ -87964,7 +87966,7 @@ cSK
 cGx
 cGK
 QoC
-QoF
+QoC
 cGY
 csd
 csd
@@ -104396,7 +104398,7 @@ cls
 cmr
 cNW
 cOe
-cmo
+cPa
 cNW
 aaf
 aaf
@@ -106440,7 +106442,7 @@ bPN
 bWr
 cbZ
 bQZ
-cmo
+cPa
 cNW
 cOx
 cNW

--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -73064,9 +73064,11 @@
 /obj/machinery/atmospherics/components/unary/outlet_injector/on{
 	dir = 1;
 	frequency = 1441;
-	id = "n2_in"
+	id = "n2_in";
+	volume_rate = 200
 	},
-/turf/open/floor/plating/airless,
+/obj/structure/lattice/catwalk,
+/turf/open/space,
 /area/engine/atmos)
 "cVB" = (
 /obj/structure/chair{
@@ -122375,7 +122377,7 @@ cbe
 ccO
 bza
 aaf
-EDs
+EDo
 chO
 cjd
 ckG
@@ -123403,7 +123405,7 @@ cbi
 ccS
 bza
 aaf
-EDt
+EDo
 chR
 cjg
 ckH
@@ -124431,7 +124433,7 @@ cVJ
 ccQ
 bza
 aaf
-EDu
+EDo
 chU
 cjj
 ckJ
@@ -125957,15 +125959,15 @@ EDo
 bFZ
 bAR
 bCA
-EDp
+EDo
 bFZ
 bAR
 bCA
-EDq
+EDo
 bFZ
 bAR
 bCA
-EDr
+EDo
 bFZ
 bAR
 aaf


### PR DESCRIPTION
Same as #32296, but without conflicts and unidentified DeltaStation changes. No idea what that was, DeltaStation doesn't even have exhaust injector.

:cl: ACCount
fix: The atmos exhaust line will no longer shatter the adjacent window and flood atmos with hot gas.
/:cl:

It's map merged this time.

Closes #32296