### PR TITLE
Refactors and improvements to xenobio slime processor

### DIFF
--- a/_maps/map_files/BoxStation/BoxStation.dmm
+++ b/_maps/map_files/BoxStation/BoxStation.dmm
@@ -36905,10 +36905,7 @@
 /turf/open/floor/plasteel/white,
 /area/science/xenobiology)
 "bMl" = (
-/obj/machinery/processor{
-	desc = "A machine used to process slimes and retrieve their extract.";
-	name = "Slime Processor"
-	},
+/obj/machinery/processor/slime,
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plasteel,
 /area/science/xenobiology)

--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -71830,10 +71830,7 @@
 /turf/open/floor/plating,
 /area/chapel/main)
 "cRM" = (
-/obj/machinery/processor{
-	desc = "A machine used to process slimes and retrieve their extract.";
-	name = "Slime Processor"
-	},
+/obj/machinery/processor/slime,
 /obj/effect/turf_decal/stripes/corner{
 	dir = 2
 	},

--- a/_maps/map_files/PubbyStation/PubbyStation.dmm
+++ b/_maps/map_files/PubbyStation/PubbyStation.dmm
@@ -27869,10 +27869,7 @@
 /turf/open/floor/plasteel/white,
 /area/science/explab)
 "bqv" = (
-/obj/machinery/processor{
-	desc = "A machine used to process slimes and retrieve their extract.";
-	name = "Slime Processor"
-	},
+/obj/machinery/processor/slime,
 /obj/machinery/light{
 	dir = 8
 	},

--- a/code/modules/food_and_drinks/kitchen_machinery/processor.dm
+++ b/code/modules/food_and_drinks/kitchen_machinery/processor.dm
@@ -24,8 +24,6 @@
 
 /obj/machinery/processor/process()
 	..()
-	// The irony
-	// To be clear, if it's grinding, then it can't suck them up
 	if(processing)
 		return
 	var/mob/living/simple_animal/slime/picked_slime
@@ -43,125 +41,40 @@
 		return
 
 	src.visible_message("[picked_slime] is sucked into [src].")
-	picked_slime.loc = src
+	picked_slime.forceMove(src)
 
-/datum/food_processor_process
-	var/input
-	var/output
-	var/time = 40
-/datum/food_processor_process/proc/process_food(loc, what, obj/machinery/processor/processor)
-	if (src.output && loc && processor)
-		for(var/i = 0, i < processor.rating_amount, i++)
-			new src.output(loc)
+/obj/machinery/processor/proc/process_food(datum/food_processor_process/recipe, atom/movable/what)
+	if (recipe.output && loc && !QDELETED(src))
+		for(var/i = 0, i < rating_amount, i++)
+			new recipe.output(drop_location())
 	if (what)
-		qdel(what) // Note to self: Make this safer
-
-	/* objs */
-/datum/food_processor_process/meat
-	input = /obj/item/reagent_containers/food/snacks/meat/slab
-	output = /obj/item/reagent_containers/food/snacks/faggot
-
-/datum/food_processor_process/bacon
-	input = /obj/item/reagent_containers/food/snacks/meat/rawcutlet
-	output = /obj/item/reagent_containers/food/snacks/meat/rawbacon
-
-/datum/food_processor_process/potatowedges
-	input = /obj/item/reagent_containers/food/snacks/grown/potato/wedges
-	output = /obj/item/reagent_containers/food/snacks/fries
-
-/datum/food_processor_process/sweetpotato
-	input = /obj/item/reagent_containers/food/snacks/grown/potato/sweet
-	output = /obj/item/reagent_containers/food/snacks/yakiimo
-
-/datum/food_processor_process/potato
-	input = /obj/item/reagent_containers/food/snacks/grown/potato
-	output = /obj/item/reagent_containers/food/snacks/tatortot
-
-/datum/food_processor_process/carrot
-	input = /obj/item/reagent_containers/food/snacks/grown/carrot
-	output = /obj/item/reagent_containers/food/snacks/carrotfries
-
-/datum/food_processor_process/soybeans
-	input = /obj/item/reagent_containers/food/snacks/grown/soybeans
-	output = /obj/item/reagent_containers/food/snacks/soydope
-
-/datum/food_processor_process/spaghetti
-	input = /obj/item/reagent_containers/food/snacks/doughslice
-	output = /obj/item/reagent_containers/food/snacks/spaghetti
-
-/datum/food_processor_process/corn
-	input = /obj/item/reagent_containers/food/snacks/grown/corn
-	output = /obj/item/reagent_containers/food/snacks/tortilla
-
-/datum/food_processor_process/parsnip
-	input = /obj/item/reagent_containers/food/snacks/grown/parsnip
-	output = /obj/item/reagent_containers/food/snacks/roastparsnip
-
-/* mobs */
-/datum/food_processor_process/mob/process_food(loc, what, processor)
-	..()
+		qdel(what)
 
 
-/datum/food_processor_process/mob/slime/process_food(loc, what, obj/machinery/processor/processor)
+/obj/machinery/processor/slime/process_food(datum/food_processor_process/recipe, atom/movable/what)
 	var/mob/living/simple_animal/slime/S = what
 	var/C = S.cores
 	if(S.stat != DEAD)
-		S.loc = loc
+		S.forceMove(drop_location())
 		S.visible_message("<span class='notice'>[C] crawls free of the processor!</span>")
 		return
-	for(var/i in 1 to (C+processor.rating_amount-1))
-		new S.coretype(loc)
+	for(var/i in 1 to (C+rating_amount-1))
+		var/atom/movable/item = new S.coretype(drop_location())
+		adjust_item_drop_location(item)
 		SSblackbox.add_details("slime_core_harvested","[replacetext(S.colour," ","_")]")
-	..()
+	S.gib(TRUE,TRUE,TRUE)
 
-/datum/food_processor_process/mob/slime/input = /mob/living/simple_animal/slime
-/datum/food_processor_process/mob/slime/output = null
-
-/datum/food_processor_process/mob/monkey/process_food(loc, what, processor)
-	var/mob/living/carbon/monkey/O = what
-	if (O.client) //grief-proof
-		O.loc = loc
-		O.visible_message("<span class='notice'>Suddenly [O] jumps out from the processor!</span>", \
-				"<span class='notice'>You jump out from the processor!</span>", \
-				"<span class='italics'>You hear chimpering.</span>")
-		return
-	var/obj/bucket = new /obj/item/reagent_containers/glass/bucket(loc)
-
-	var/datum/reagent/blood/B = new()
-	B.holder = bucket
-	B.volume = 70
-	//set reagent data
-	B.data["donor"] = O
-
-	for(var/thing in O.viruses)
-		var/datum/disease/D = thing
-		if(!(D.spread_flags & VIRUS_SPREAD_SPECIAL))
-			B.data["viruses"] += D.Copy()
-	if(O.has_dna())
-		B.data["blood_DNA"] = O.dna.unique_enzymes
-
-	if(O.resistances&&O.resistances.len)
-		B.data["resistances"] = O.resistances.Copy()
-	bucket.reagents.reagent_list += B
-	bucket.reagents.update_total()
-	bucket.on_reagent_change()
-	//bucket_of_blood.reagents.handle_reactions() //blood doesn't react
-	..()
-
-/datum/food_processor_process/mob/monkey/input = /mob/living/carbon/monkey
-/datum/food_processor_process/mob/monkey/output = null
 
 /obj/machinery/processor/proc/select_recipe(X)
-	for (var/Type in subtypesof(/datum/food_processor_process) - /datum/food_processor_process/mob)
-		var/datum/food_processor_process/P = new Type()
-		if (!istype(X, P.input))
+	for (var/type in subtypesof(/datum/food_processor_process) - /datum/food_processor_process/mob)
+		var/datum/food_processor_process/recipe = new type()
+		if (!istype(X, recipe.input) || !istype(src, recipe.required_machine))
 			continue
-		return P
-	return 0
+		return recipe
 
 /obj/machinery/processor/attackby(obj/item/O, mob/user, params)
 	if(src.processing)
-		to_chat(user, "<span class='warning'>The processor is in the process of processing!</span>")
+		to_chat(user, "<span class='warning'>[src] is in the process of processing!</span>")
 		return 1
 	if(default_deconstruction_screwdriver(user, "processor", "processor1", O))
 		return
@@ -205,12 +118,12 @@
 			return ..()
 
 /obj/machinery/processor/attack_hand(mob/user)
-	if (src.stat != 0) //NOPOWER etc
+	if(stat & (NOPOWER|BROKEN))
 		return
 	if(src.processing)
-		to_chat(user, "<span class='warning'>The processor is in the process of processing!</span>")
+		to_chat(user, "<span class='warning'>[src] is in the process of processing!</span>")
 		return 1
-	if(user.a_intent == INTENT_GRAB && user.pulling && (isslime(user.pulling) || ismonkey(user.pulling)))
+	if(user.a_intent == INTENT_GRAB && user.pulling && select_recipe(user.pulling))
 		if(user.grab_state < GRAB_AGGRESSIVE)
 			to_chat(user, "<span class='warning'>You need a better grip to do that!</span>")
 			return
@@ -220,7 +133,7 @@
 		user.stop_pulling()
 		return
 	if(src.contents.len == 0)
-		to_chat(user, "<span class='warning'>The processor is empty!</span>")
+		to_chat(user, "<span class='warning'>[src] is empty!</span>")
 		return 1
 	processing = TRUE
 	user.visible_message("[user] turns on [src].", \
@@ -238,12 +151,12 @@
 	var/offset = prob(50) ? -2 : 2
 	animate(src, pixel_x = pixel_x + offset, time = 0.2, loop = (total_time / rating_speed)*5) //start shaking
 	sleep(total_time / rating_speed)
-	for(var/O in src.contents)
+	for(var/atom/movable/O in src.contents)
 		var/datum/food_processor_process/P = select_recipe(O)
 		if (!P)
-			log_admin("DEBUG: [O] in processor havent suitable recipe. How do you put it in?") //-rastaf0
+			log_admin("DEBUG: [O] in processor havent suitable recipe. How do you put it in?")
 			continue
-		P.process_food(src.loc, O, src)
+		process_food(P, O)
 	pixel_x = initial(pixel_x) //return to its spot after shaking
 	processing = FALSE
 	src.visible_message("\The [src] finishes processing.")
@@ -267,10 +180,24 @@
 	return
 
 /obj/machinery/processor/slime
-	name = "Slime processor"
+	name = "slime processor"
 	desc = "An industrial grinder with a sticker saying appropriated for science department. Keep hands clear of intake area while operating."
 
 /obj/machinery/processor/slime/Initialize()
 	. = ..()
 	var/obj/item/circuitboard/machine/B = new /obj/item/circuitboard/machine/processor/slime(null)
 	B.apply_default_parts(src)
+
+/obj/machinery/processor/slime/adjust_item_drop_location(atom/movable/AM)
+	var/list/slimecores = subtypesof(/obj/item/slime_extract)
+	var/i = 0
+	if(!(i = slimecores.Find(AM.type))) // If the item is not found
+		return
+	if (i <= 16) // If in the first 12 slots
+		AM.pixel_x = -12 + ((i%4)*8)
+		AM.pixel_y = -12 + (round(i/4)*8)
+		return i
+	var/ii = i - 16
+	AM.pixel_x = -8 + ((ii%3)*8)
+	AM.pixel_y = -8 + (round(ii/3)*8)
+	return i

--- a/code/modules/food_and_drinks/kitchen_machinery/processor.dm
+++ b/code/modules/food_and_drinks/kitchen_machinery/processor.dm
@@ -47,22 +47,26 @@
 	if (recipe.output && loc && !QDELETED(src))
 		for(var/i = 0, i < rating_amount, i++)
 			new recipe.output(drop_location())
-	if (what)
+	if (ismob(what))
+		var/mob/themob = what
+		themob.gib(TRUE,TRUE,TRUE)
+	else
 		qdel(what)
 
 
 /obj/machinery/processor/slime/process_food(datum/food_processor_process/recipe, atom/movable/what)
 	var/mob/living/simple_animal/slime/S = what
-	var/C = S.cores
-	if(S.stat != DEAD)
-		S.forceMove(drop_location())
-		S.visible_message("<span class='notice'>[C] crawls free of the processor!</span>")
-		return
-	for(var/i in 1 to (C+rating_amount-1))
-		var/atom/movable/item = new S.coretype(drop_location())
-		adjust_item_drop_location(item)
-		SSblackbox.add_details("slime_core_harvested","[replacetext(S.colour," ","_")]")
-	S.gib(TRUE,TRUE,TRUE)
+	if (istype(S))
+		var/C = S.cores
+		if(S.stat != DEAD)
+			S.forceMove(drop_location())
+			S.visible_message("<span class='notice'>[C] crawls free of the processor!</span>")
+			return
+		for(var/i in 1 to (C+rating_amount-1))
+			var/atom/movable/item = new S.coretype(drop_location())
+			adjust_item_drop_location(item)
+			SSblackbox.add_details("slime_core_harvested","[replacetext(S.colour," ","_")]")
+	..()
 
 
 /obj/machinery/processor/proc/select_recipe(X)

--- a/code/modules/food_and_drinks/kitchen_machinery/processor.dm
+++ b/code/modules/food_and_drinks/kitchen_machinery/processor.dm
@@ -189,7 +189,7 @@
 	B.apply_default_parts(src)
 
 /obj/machinery/processor/slime/adjust_item_drop_location(atom/movable/AM)
-	var/list/slimecores = subtypesof(/obj/item/slime_extract)
+	var/static/list/slimecores = subtypesof(/obj/item/slime_extract)
 	var/i = 0
 	if(!(i = slimecores.Find(AM.type))) // If the item is not found
 		return

--- a/code/modules/food_and_drinks/recipes/processor_recipes.dm
+++ b/code/modules/food_and_drinks/recipes/processor_recipes.dm
@@ -1,0 +1,50 @@
+/datum/food_processor_process
+	var/input
+	var/output
+	var/time = 40
+	var/required_machine = /obj/machinery/processor
+
+/datum/food_processor_process/meat
+	input = /obj/item/reagent_containers/food/snacks/meat/slab
+	output = /obj/item/reagent_containers/food/snacks/faggot
+
+/datum/food_processor_process/bacon
+	input = /obj/item/reagent_containers/food/snacks/meat/rawcutlet
+	output = /obj/item/reagent_containers/food/snacks/meat/rawbacon
+
+/datum/food_processor_process/potatowedges
+	input = /obj/item/reagent_containers/food/snacks/grown/potato/wedges
+	output = /obj/item/reagent_containers/food/snacks/fries
+
+/datum/food_processor_process/sweetpotato
+	input = /obj/item/reagent_containers/food/snacks/grown/potato/sweet
+	output = /obj/item/reagent_containers/food/snacks/yakiimo
+
+/datum/food_processor_process/potato
+	input = /obj/item/reagent_containers/food/snacks/grown/potato
+	output = /obj/item/reagent_containers/food/snacks/tatortot
+
+/datum/food_processor_process/carrot
+	input = /obj/item/reagent_containers/food/snacks/grown/carrot
+	output = /obj/item/reagent_containers/food/snacks/carrotfries
+
+/datum/food_processor_process/soybeans
+	input = /obj/item/reagent_containers/food/snacks/grown/soybeans
+	output = /obj/item/reagent_containers/food/snacks/soydope
+
+/datum/food_processor_process/spaghetti
+	input = /obj/item/reagent_containers/food/snacks/doughslice
+	output = /obj/item/reagent_containers/food/snacks/spaghetti
+
+/datum/food_processor_process/corn
+	input = /obj/item/reagent_containers/food/snacks/grown/corn
+	output = /obj/item/reagent_containers/food/snacks/tortilla
+
+/datum/food_processor_process/parsnip
+	input = /obj/item/reagent_containers/food/snacks/grown/parsnip
+	output = /obj/item/reagent_containers/food/snacks/roastparsnip
+
+/datum/food_processor_process/mob/slime
+	input = /mob/living/simple_animal/slime
+	output = null
+	required_machine = /obj/machinery/processor/slime

--- a/code/modules/research/designs/machine_designs.dm
+++ b/code/modules/research/designs/machine_designs.dm
@@ -315,7 +315,7 @@
 	category = list ("Misc. Machinery")
 
 /datum/design/board/processor
-	name = "Machine Design (Food processor Board)"
+	name = "Machine Design (Food Processor Board)"
 	desc = "The circuit board for a food processor."
 	id = "processor"
 	req_tech = list("programming" = 1)

--- a/code/modules/research/designs/machine_designs.dm
+++ b/code/modules/research/designs/machine_designs.dm
@@ -315,11 +315,19 @@
 	category = list ("Misc. Machinery")
 
 /datum/design/board/processor
-	name = "Machine Design (Processor Board)"
-	desc = "The circuit board for a processor."
+	name = "Machine Design (Food processor Board)"
+	desc = "The circuit board for a food processor."
 	id = "processor"
 	req_tech = list("programming" = 1)
 	build_path = /obj/item/circuitboard/machine/processor
+	category = list ("Misc. Machinery")
+
+/datum/design/board/slimeprocessor
+	name = "Machine Design (Slime Processor Board)"
+	desc = "The circuit board for a slime processor."
+	id = "slimeprocessor"
+	req_tech = list("programming" = 1, "plasmatech" = 1)
+	build_path = /obj/item/circuitboard/machine/processor/slime
 	category = list ("Misc. Machinery")
 
 /datum/design/board/recycler

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -1385,6 +1385,7 @@
 #include "code\modules\food_and_drinks\kitchen_machinery\smartfridge.dm"
 #include "code\modules\food_and_drinks\recipes\drinks_recipes.dm"
 #include "code\modules\food_and_drinks\recipes\food_mixtures.dm"
+#include "code\modules\food_and_drinks\recipes\processor_recipes.dm"
 #include "code\modules\food_and_drinks\recipes\tablecraft\recipes_bread.dm"
 #include "code\modules\food_and_drinks\recipes\tablecraft\recipes_burger.dm"
 #include "code\modules\food_and_drinks\recipes\tablecraft\recipes_cake.dm"


### PR DESCRIPTION
This PR:
1. Slightly refactors the food processor code to remove datum procs and associated nonsense. I wouldn't call the result "perfect" but it is in my opinion better.
2. Completes the separation between the food processor and the slime processor by making the slime processor board available via r&d, and fixes some of the maps that were still using a var edited food processor in xenobio to use the slime processor. Thanks for that prank by the way.
3. Adds deterministic output slots to the slime processor. A unique slot for every type.
4. Removes the food processor recipe of turning monkeys into buckets. Yes, really, that was apparently a thing?

[Changelogs]:

:cl: Naksu
tweak: Added deterministic output slots to the slime processor
/:cl:


