### PR TITLE
Remove advanced e-gun stun function

### DIFF
--- a/code/modules/projectiles/guns/energy/energy_gun.dm
+++ b/code/modules/projectiles/guns/energy/energy_gun.dm
@@ -101,7 +101,7 @@
 	pin = null
 	can_charge = 0
 	ammo_x_offset = 1
-	ammo_type = list(/obj/item/ammo_casing/energy/electrode, /obj/item/ammo_casing/energy/laser, /obj/item/ammo_casing/energy/disabler)
+	ammo_type = list(/obj/item/ammo_casing/energy/laser, /obj/item/ammo_casing/energy/disabler)
 	selfcharge = 1
 	var/fail_tick = 0
 	var/fail_chance = 0


### PR DESCRIPTION
:cl: Evsey9
del: The advanced E-Gun no longer has the stun function.
/:cl:

This makes it so that the advanced e-gun is not just a HOS gun with self-recharge, but an advanced _energy_ gun, like the ones you see in armory but with self-recharge.