### PR TITLE
Fixes EMP wire pulsing

### DIFF
--- a/code/datums/wires/wires.dm
+++ b/code/datums/wires/wires.dm
@@ -164,7 +164,7 @@
 		if(prob(33))
 			pulse(wire)
 			remaining_pulses--
-			if(remaining_pulses <= 0)
+			if(!remaining_pulses)
 				break
 
 // Overridable Procs

--- a/code/datums/wires/wires.dm
+++ b/code/datums/wires/wires.dm
@@ -74,7 +74,7 @@
 	"white",
 	"yellow"
 	)
-	
+
 	var/list/my_possible_colors = possible_colors.Copy()
 
 	for(var/wire in shuffle(wires))
@@ -163,9 +163,9 @@
 	for(var/wire in possible_wires)
 		if(prob(33))
 			pulse(wire)
-		remaining_pulses--
-		if(remaining_pulses >= 0)
-			break
+			remaining_pulses--
+			if(remaining_pulses <= 0)
+				break
 
 // Overridable Procs
 /datum/wires/proc/interactable(mob/user)


### PR DESCRIPTION
:cl:
fix: EMPs can pulse multiple wires
/:cl:

I think this is what @coiax intended.