### PR TITLE
Mining zlevel has a bomb cap of three times the configured cap

### DIFF
--- a/code/datums/explosion.dm
+++ b/code/datums/explosion.dm
@@ -1,5 +1,6 @@
 #define EXPLOSION_THROW_SPEED 4
-#define REEBE_HUGBOX_COEFFICIENT 0.5
+#define CITYOFCOGS_CAP_MULTIPLIER 0.5
+#define MINING_CAP_MULTIPLIER 3
 
 GLOBAL_LIST_EMPTY(explosions)
 //Against my better judgement, I will return the explosion datum
@@ -53,21 +54,21 @@ GLOBAL_LIST_EMPTY(explosions)
 	var/orig_dev_range = devastation_range
 	var/orig_heavy_range = heavy_impact_range
 	var/orig_light_range = light_impact_range
-
-	if(!ignorecap && epicenter.z != ZLEVEL_MINING)
-		//Clamp all values to MAX_EXPLOSION_RANGE
-		devastation_range = min(GLOB.MAX_EX_DEVESTATION_RANGE, devastation_range)
-		heavy_impact_range = min(GLOB.MAX_EX_HEAVY_RANGE, heavy_impact_range)
-		light_impact_range = min(GLOB.MAX_EX_LIGHT_RANGE, light_impact_range)
-		flash_range = min(GLOB.MAX_EX_FLASH_RANGE, flash_range)
-		flame_range = min(GLOB.MAX_EX_FLAME_RANGE, flame_range)
-		
-	if(!ignorecap && epicenter.z == ZLEVEL_CITYOFCOGS)
-		devastation_range = min(GLOB.MAX_EX_DEVESTATION_RANGE * REEBE_HUGBOX_COEFFICIENT, devastation_range)
-		heavy_impact_range = min(GLOB.MAX_EX_HEAVY_RANGE * REEBE_HUGBOX_COEFFICIENT, heavy_impact_range)
-		light_impact_range = min(GLOB.MAX_EX_LIGHT_RANGE * REEBE_HUGBOX_COEFFICIENT, light_impact_range)
-		flash_range = min(GLOB.MAX_EX_FLASH_RANGE * REEBE_HUGBOX_COEFFICIENT, flash_range)
-		flame_range = min(GLOB.MAX_EX_FLAME_RANGE * REEBE_HUGBOX_COEFFICIENT, flame_range)
+	
+	//Zlevel specific bomb cap multiplier
+	var/cap_multiplier = 1
+	switch(epicenter.z)
+		if(ZLEVEL_CITYOFCOGS)
+			cap_multiplier = CITYOFCOGS_CAP_MULTIPLIER
+		if(ZLEVEL_MINING)
+			cap_multiplier = MINING_CAP_MULTIPLIER
+	
+	if(!ignorecap)
+		devastation_range = min(GLOB.MAX_EX_DEVESTATION_RANGE * cap_multiplier, devastation_range)
+		heavy_impact_range = min(GLOB.MAX_EX_HEAVY_RANGE * cap_multiplier, heavy_impact_range)
+		light_impact_range = min(GLOB.MAX_EX_LIGHT_RANGE * cap_multiplier, light_impact_range)
+		flash_range = min(GLOB.MAX_EX_FLASH_RANGE * cap_multiplier, flash_range)
+		flame_range = min(GLOB.MAX_EX_FLAME_RANGE * cap_multiplier, flame_range)
 
 	//DO NOT REMOVE THIS STOPLAG, IT BREAKS THINGS
 	//not sleeping causes us to ex_act() the thing that triggered the explosion
@@ -406,4 +407,5 @@ GLOBAL_LIST_EMPTY(explosions)
 // 5 explosion power is a (0, 1, 3) explosion.
 // 1 explosion power is a (0, 0, 1) explosion.
 
-#undef REEBE_HUGBOX_COEFFICIENT
+#undef CITYOFCOGS_CAP_MULTIPLIER
+#undef MINING_CAP_MULTIPLIER


### PR DESCRIPTION
Also adds an easier way of z-level specific bombcap multiplier.

Alternative to #32393

This still let's people blow big bombs on lavaland, while preventing insanely huge bombs that can potentially freeze/crash the server. The number can still be tweaked if this is too much/too little.