### PR TITLE
[Super-Ready for review]Reworks healing symptoms into conditional healing symptoms

### DIFF
--- a/code/datums/diseases/advance/symptoms/heal.dm
+++ b/code/datums/diseases/advance/symptoms/heal.dm
@@ -10,6 +10,7 @@
 	symptom_delay_min = 1
 	symptom_delay_max = 1
 	var/hide_healing = FALSE
+	var/passive_message = "" //random message to infected but not actively healing people
 	threshold_desc = "<b>Stage Speed 6:</b> Doubles healing speed.<br>\
 					  <b>Stealth 4:</b> Healing will no longer be visible to onlookers."
 
@@ -30,6 +31,8 @@
 		if(4, 5)
 			var/effectiveness = CanHeal(A)
 			if(!effectiveness)
+				if(passive_message && prob(2) && passive_message_condition(M))
+					to_chat(M, passive_message)
 				return
 			else
 				Heal(M, A, effectiveness)
@@ -39,8 +42,10 @@
 	return power
 
 /datum/symptom/heal/proc/Heal(mob/living/M, datum/disease/advance/A, actual_power)
-	return 1
+	return TRUE
 
+/datum/symptom/heal/proc/passive_message_condition(mob/living/M)
+	return TRUE
 
 
 /datum/symptom/heal/toxin
@@ -51,6 +56,7 @@
 	stage_speed = -3
 	transmittable = -3
 	level = 6
+	passive_message = "<span class='notice'>You miss the feeling of starlight on your skin.</span>"
 	var/nearspace_penalty = 0.3
 	threshold_desc = "<b>Stage Speed 6:</b> Increases healing speed.<br>\
 					  <b>Transmission 6:</b> Removes penalty for only being close to space."
@@ -79,7 +85,10 @@
 	M.adjustToxLoss(-heal_amt)
 	return 1
 
-
+/datum/symptom/heal/toxin/passive_message_condition(mob/living/M)
+	if(M.getToxLoss())
+		return TRUE
+	return FALSE
 
 /datum/symptom/heal/chem
 	name = "Toxolysis"
@@ -144,10 +153,8 @@
 	var/lost_nutrition = 9 - (reduced_hunger * 5)
 	C.nutrition = max(C.nutrition - (lost_nutrition * HUNGER_FACTOR), 0) //Hunger depletes at 10x the normal speed
 	if(prob(2))
-		to_chat(M, "<span class='notice'>You feel an odd gurgle in your stomach, as if it was working much faster than normal.</span>")
+		to_chat(C, "<span class='notice'>You feel an odd gurgle in your stomach, as if it was working much faster than normal.</span>")
 	return 1
-
-
 
 /datum/symptom/heal/brute
 	name = "Cellular Molding"
@@ -157,6 +164,7 @@
 	stage_speed = -3
 	transmittable = -3
 	level = 6
+	passive_message = "<span class='notice'>You feel the flesh pulsing under your skin for a moment, but it's too cold to move.</span>"
 	threshold_desc = "<b>Stage Speed 8:</b> Doubles healing speed."
 
 /datum/symptom/heal/brute/Start(datum/disease/advance/A)
@@ -198,7 +206,10 @@
 			M.update_damage_overlays()
 	return 1
 
-
+/datum/symptom/heal/brute/passive_message_condition(mob/living/M)
+	if(M.getBruteLoss())
+		return TRUE
+	return FALSE
 
 /datum/symptom/heal/coma
 	name = "Regenerative Coma"
@@ -208,6 +219,7 @@
 	stage_speed = -2
 	transmittable = -2
 	level = 8
+	passive_message = "<span class='notice'>The pain from your wounds makes you feel oddly sleepy...</span>"
 	var/deathgasp = FALSE
 	var/active_coma = FALSE //to prevent multiple coma procs
 	threshold_desc = "<b>Stealth 2:</b> Host appears to die when falling into a coma.<br>\
@@ -269,7 +281,10 @@
 
 	return 1
 
-
+/datum/symptom/heal/coma/passive_message_condition(mob/living/M)
+	if((M.getBruteLoss() + M.getFireLoss()) > 30)
+		return TRUE
+	return FALSE
 
 /datum/symptom/heal/burn
 	name = "Tissue Hydration"
@@ -279,6 +294,7 @@
 	stage_speed = -3
 	transmittable = -3
 	level = 6
+	passive_message = "<span class='notice'>Your burned skin feels oddly dry...</span>"
 	var/absorption_coeff = 1
 	threshold_desc = "<b>Resistance 5:</b> Water is consumed at a much slower rate.<br>\
 					  <b>Stage Speed 7:</b> Increases healing speed."
@@ -321,7 +337,10 @@
 
 	return 1
 
-
+/datum/symptom/heal/burn/passive_message_condition(mob/living/M)
+	if(M.getFireLoss())
+		return TRUE
+	return FALSE
 
 /datum/symptom/heal/plasma
 	name = "Plasma Fixation"
@@ -331,6 +350,7 @@
 	stage_speed = -2
 	transmittable = -2
 	level = 8
+	passive_message = "<span class='notice'>You feel an odd attraction to plasma.</span>"
 	var/temp_rate = 1
 	threshold_desc = "<b>Transmission 6:</b> Increases temperature adjustment rate.<br>\
 					  <b>Stage Speed 7:</b> Increases healing speed."
@@ -365,7 +385,7 @@
 	var/list/parts = M.get_damaged_bodyparts(0,1) //burn only
 
 	if(prob(5))
-		to_chat(M, "<span class='notice'>You feel yourself absorbing plasma inside and around you.</span>")
+		to_chat(M, "<span class='notice'>You feel yourself absorbing plasma inside and around you...</span>")
 
 	if(M.bodytemperature > 310)
 		M.bodytemperature = max(310, M.bodytemperature - (20 * temp_rate * TEMPERATURE_DAMAGE_COEFFICIENT))
@@ -379,7 +399,7 @@
 	if(!parts.len)
 		return
 	if(prob(5))
-		to_chat(M, "<span class='notice'>The pain from your burns fades.</span>")
+		to_chat(M, "<span class='notice'>The pain from your burns fades rapidly.</span>")
 
 	for(var/obj/item/bodypart/L in parts)
 		if(L.heal_damage(0, heal_amt/parts.len))
@@ -398,6 +418,7 @@
 	level = 6
 	symptom_delay_min = 1
 	symptom_delay_max = 1
+	passive_message = "<span class='notice'>Your skin glows faintly for a moment.</span>"
 	var/cellular_damage = FALSE
 	threshold_desc = "<b>Transmission 6:</b> Additionally heals cellular damage.<br>\
 					  <b>Resistance 7:</b> Increases healing speed."

--- a/code/datums/diseases/advance/symptoms/heal.dm
+++ b/code/datums/diseases/advance/symptoms/heal.dm
@@ -112,6 +112,24 @@ Bonus
 		M.reagents.remove_reagent(R.id, actual_power)
 	return 1
 
+/datum/symptom/heal/metabolism
+	name = "Metabolic Boost"
+	stealth = -1
+	resistance = -2
+	stage_speed = 2
+	transmittable = 1
+	level = 8
+	desc = "The virus causes the host's metabolism to accelerate rapidly, making them process chemicals twice as fast,\
+	 but also causing increased hunger."
+
+/datum/symptom/heal/metabolism/Heal(mob/living/carbon/C, datum/disease/advance/A, actual_power)
+	if(!istype(C))
+		return
+	C.reagents.metabolize(C, can_overdose=TRUE) //this works even without a liver; it's intentional since the virus is metabolizing by itself
+	C.overeatduration = max(C.overeatduration - 2, 0)
+	C.nutrition = max(C.nutrition - (9 * HUNGER_FACTOR), 0) //Hunger depletes at 10x the normal speed
+	return 1
+
 /*
 //////////////////////////////////////
 

--- a/code/datums/diseases/advance/symptoms/heal.dm
+++ b/code/datums/diseases/advance/symptoms/heal.dm
@@ -11,7 +11,6 @@
 	symptom_delay_max = 1
 	var/hide_healing = FALSE
 	threshold_desc = "<b>Stage Speed 6:</b> Doubles healing speed.<br>\
-					  <b>Stage Speed 11:</b> Triples healing speed.<br>\
 					  <b>Stealth 4:</b> Healing will no longer be visible to onlookers."
 
 /datum/symptom/heal/Start(datum/disease/advance/A)
@@ -21,8 +20,6 @@
 		hide_healing = TRUE
 	if(A.properties["stage_rate"] >= 6) //stronger healing
 		power = 2
-	if(A.properties["stage_rate"] >= 11) //even stronger healing
-		power = 3
 
 /datum/symptom/heal/Activate(datum/disease/advance/A)
 	if(!..())
@@ -31,10 +28,17 @@
 	var/mob/living/M = A.affected_mob
 	switch(A.stage)
 		if(4, 5)
-			Heal(M, A)
+			var/effectiveness = CanHeal(A)
+			if(!effectiveness)
+				return
+			else
+				Heal(M, A, effectiveness)
 	return
 
-/datum/symptom/heal/proc/Heal(mob/living/M, datum/disease/advance/A)
+/datum/symptom/heal/proc/CanHeal(datum/disease/advance/A)
+	return power
+
+/datum/symptom/heal/proc/Heal(mob/living/M, datum/disease/advance/A, actual_power)
 	return 1
 
 /*
@@ -49,57 +53,63 @@ Toxin Filter
 	Fatal Level.
 
 Bonus
-	Heals toxins in the affected mob's blood stream.
+	Heals toxins when near or in space
 
 //////////////////////////////////////
 */
 
 /datum/symptom/heal/toxin
-	name = "Toxic Filter"
-	desc = "The virus synthesizes regenerative chemicals in the bloodstream, repairing damage caused by toxins."
+	name = "Starlight Condensation"
+	desc = "The virus reacts to direct starlight, producing regenerative chemicals."
 	stealth = 1
-	resistance = -4
-	stage_speed = -4
-	transmittable = -4
+	resistance = -3
+	stage_speed = -3
+	transmittable = -3
 	level = 6
 
-/datum/symptom/heal/toxin/Heal(mob/living/M, datum/disease/advance/A)
-	var/heal_amt = 1 * power
+/datum/symptom/heal/toxin/CanHeal(datum/disease/advance/A)
+	var/mob/living/M = A.affected_mob
+	if(istype(get_turf(M), /turf/open/space))
+		return power
+	else
+		for(var/turf/T in view(M, 2))
+			if(istype(T, /turf/open/space))
+				return power * 0.3
+
+/datum/symptom/heal/toxin/Heal(mob/living/M, datum/disease/advance/A, actual_power)
+	var/heal_amt = 1 * actual_power
 	if(M.toxloss > 0 && prob(base_message_chance) && !hide_healing)
-		new /obj/effect/temp_visual/heal(get_turf(M), "#66FF99")
+		new /obj/effect/temp_visual/heal(M.loc, "#66FF99")
 	M.adjustToxLoss(-heal_amt)
 	return 1
 
 /*
 //////////////////////////////////////
 
-Apoptosis
+Toxolysis
 
 	Lowers resistance.
 	Decreases stage speed.
 	Decreases transmittablity.
 
 Bonus
-	Heals toxins in the affected mob's blood stream faster.
+	Removes all chems in the host's body
 
 //////////////////////////////////////
 */
 
-/datum/symptom/heal/toxin/plus
-
-	name = "Apoptoxin filter"
+/datum/symptom/heal/chem
+	name = "Toxolysis"
 	stealth = 0
 	resistance = -2
 	stage_speed = -2
 	transmittable = -2
 	level = 8
-	desc = "The virus stimulates production of special stem cells in the bloodstream, causing rapid reparation of any damage caused by toxins."
+	desc = "The virus rapidly breaks down any foreign chemicals in the bloodstream."
 
-/datum/symptom/heal/toxin/plus/Heal(mob/living/M, datum/disease/advance/A)
-	var/heal_amt = 2 * power
-	if(M.toxloss > 0 && prob(base_message_chance) && !hide_healing)
-		new /obj/effect/temp_visual/heal(get_turf(M), "#00FF00")
-	M.adjustToxLoss(-heal_amt)
+/datum/symptom/heal/chem/Heal(mob/living/M, datum/disease/advance/A, actual_power)
+	for(var/datum/reagent/R in M.reagents.reagent_list) //Not just toxins!
+		M.reagents.remove_reagent(R.id, actual_power)
 	return 1
 
 /*
@@ -114,23 +124,39 @@ Regeneration
 	Fatal Level.
 
 Bonus
-	Heals brute damage slowly over time.
+	Heals brute damage when in a hot room.
 
 //////////////////////////////////////
 */
 
 /datum/symptom/heal/brute
-
-	name = "Regeneration"
-	desc = "The virus stimulates the regenerative process in the host, causing faster wound healing."
+	name = "Cellular Molding"
+	desc = "The virus is able to shift cells around when in conditions of high heat, repairing existing physical damage."
 	stealth = 1
-	resistance = -4
-	stage_speed = -4
-	transmittable = -4
+	resistance = -3
+	stage_speed = -3
+	transmittable = -3
 	level = 6
 
-/datum/symptom/heal/brute/Heal(mob/living/carbon/M, datum/disease/advance/A)
-	var/heal_amt = 2 * power
+/datum/symptom/heal/brute/CanHeal(datum/disease/advance/A)
+	var/mob/living/M = A.affected_mob
+	switch(M.bodytemperature)
+		if(0 to 340)
+			return FALSE
+		if(340 to BODYTEMP_HEAT_DAMAGE_LIMIT)
+			. = 0.3 * power
+		if(BODYTEMP_HEAT_DAMAGE_LIMIT to 400)
+			. = 0.5 * power
+		if(400 to 460)
+			. = 0.75 * power
+		else
+			. = power
+
+	if(M.on_fire)
+		. *= 2
+
+/datum/symptom/heal/brute/Heal(mob/living/carbon/M, datum/disease/advance/A, actual_power)
+	var/heal_amt = 1 * actual_power
 
 	var/list/parts = M.get_damaged_bodyparts(1,0) //brute only
 
@@ -142,7 +168,7 @@ Bonus
 			M.update_damage_overlays()
 
 	if(prob(base_message_chance) && !hide_healing)
-		new /obj/effect/temp_visual/heal(get_turf(M), "#FF3333")
+		new /obj/effect/temp_visual/heal(M.loc, "#FF3333")
 
 	return 1
 
@@ -150,7 +176,7 @@ Bonus
 /*
 //////////////////////////////////////
 
-Flesh Mending
+Regenerative Coma
 
 	No resistance change.
 	Decreases stage speed.
@@ -158,41 +184,46 @@ Flesh Mending
 	Fatal Level.
 
 Bonus
-	Heals brute damage over time. Turns cloneloss into burn damage.
+	Heals brute and burn while unconscious, but causes a long period of unconsciousness if the host is heavily damaged.
 
 //////////////////////////////////////
 */
 
-/datum/symptom/heal/brute/plus
-
-	name = "Flesh Mending"
-	desc = "The virus rapidly mutates into body cells, effectively allowing it to quickly fix the host's wounds."
+/datum/symptom/heal/coma
+	name = "Regenerative Coma"
+	desc = "The virus causes the host to fall into a coma when severely damaged, then rapidly fixes the damage."
 	stealth = 0
 	resistance = 0
 	stage_speed = -2
 	transmittable = -2
 	level = 8
 
-/datum/symptom/heal/brute/plus/Heal(mob/living/carbon/M, datum/disease/advance/A)
-	var/heal_amt = 4 * power
+/datum/symptom/heal/coma/CanHeal(datum/disease/advance/A)
+	var/mob/living/M = A.affected_mob
+	if(M.IsUnconscious() || M.stat == UNCONSCIOUS)
+		return power
+	else if(M.stat == SOFT_CRIT)
+		return power * 0.5
+	else if(M.IsSleeping())
+		return power * 0.25
+	else if(M.getBruteLoss() + M.getFireLoss() >= 70)
+		to_chat(M, "<span class='warning'>You feel yourself slip into a regenerative coma...</span>")
+		M.Unconscious(450)
 
-	var/list/parts = M.get_damaged_bodyparts(1,0) //brute only
+/datum/symptom/heal/coma/Heal(mob/living/carbon/M, datum/disease/advance/A, actual_power)
+	var/heal_amt = 3 * actual_power
 
-	if(M.getCloneLoss() > 0)
-		M.adjustCloneLoss(-1)
-		M.take_bodypart_damage(0, 1) //Deals BURN damage, which is not cured by this symptom
-		if(!hide_healing)
-			new /obj/effect/temp_visual/heal(get_turf(M), "#33FFCC")
+	var/list/parts = M.get_damaged_bodyparts(1,1)
 
 	if(!parts.len)
 		return
 
 	for(var/obj/item/bodypart/L in parts)
-		if(L.heal_damage(heal_amt/parts.len, 0))
+		if(L.heal_damage(heal_amt/parts.len, heal_amt/parts.len))
 			M.update_damage_overlays()
 
 	if(prob(base_message_chance) && !hide_healing)
-		new /obj/effect/temp_visual/heal(get_turf(M), "#CC1100")
+		new /obj/effect/temp_visual/heal(M.loc, "#CC1100")
 
 	return 1
 
@@ -215,16 +246,28 @@ Bonus
 
 /datum/symptom/heal/burn
 
-	name = "Tissue Regrowth"
-	desc = "The virus recycles dead and burnt tissues, speeding up the healing of damage caused by burns."
+	name = "Tissue Hydration"
+	desc = "The virus uses excess water inside and outside the body to repair burned tisue cells."
 	stealth = 1
-	resistance = -4
-	stage_speed = -4
-	transmittable = -4
+	resistance = -3
+	stage_speed = -3
+	transmittable = -3
 	level = 6
 
-/datum/symptom/heal/burn/Heal(mob/living/carbon/M, datum/disease/advance/A)
-	var/heal_amt = 2 * power
+/datum/symptom/heal/burn/CanHeal(datum/disease/advance/A)
+	var/mob/living/M = A.affected_mob
+	if(M.fire_stacks < 0)
+		M.fire_stacks = min(M.fire_stacks + 1, 0)
+		return power
+	else if(M.reagents.has_reagent("holywater"))
+		M.reagents.remove_reagent("holywater", 0.5)
+		return power * 0.60
+	else if(M.reagents.has_reagent("water"))
+		M.reagents.remove_reagent("water", 0.5)
+		return power * 0.5
+
+/datum/symptom/heal/burn/Heal(mob/living/carbon/M, datum/disease/advance/A, actual_power)
+	var/heal_amt = 2 * actual_power
 
 	var/list/parts = M.get_damaged_bodyparts(0,1) //burn only
 
@@ -236,7 +279,7 @@ Bonus
 			M.update_damage_overlays()
 
 	if(prob(base_message_chance) && !hide_healing)
-		new /obj/effect/temp_visual/heal(get_turf(M), "#FF9933")
+		new /obj/effect/temp_visual/heal(M.loc, "#FF9933")
 	return 1
 
 
@@ -256,18 +299,33 @@ Bonus
 //////////////////////////////////////
 */
 
-/datum/symptom/heal/burn/plus
-
-	name = "Temperature Adaptation"
-	desc = "The virus quickly balances body heat, while also replacing tissues damaged by external sources."
+/datum/symptom/heal/plasma
+	name = "Plasma Fixation"
+	desc = "The virus draws plasma from the atmosphere and from inside the body to stabilize body temperature and heal burns."
 	stealth = 0
 	resistance = 0
 	stage_speed = -2
 	transmittable = -2
 	level = 8
 
-/datum/symptom/heal/burn/plus/Heal(mob/living/carbon/M, datum/disease/advance/A)
-	var/heal_amt = 4 * power
+/datum/symptom/heal/plasma/CanHeal(datum/disease/advance/A)
+	var/mob/living/M = A.affected_mob
+	var/datum/gas_mixture/environment
+	var/list/gases
+
+	. = 0
+
+	if(M.loc)
+		environment = M.loc.return_air()
+	if(environment)
+		gases = environment.gases
+		if(gases["plasma"] && gases["plasma"][MOLES] > gases["plasma"][GAS_META][META_GAS_MOLES_VISIBLE]) //if there's enough plasma in the air to see
+			. += power * 0.5
+	if(M.reagents.has_reagent("plasma"))
+		. +=  power * 0.75
+
+/datum/symptom/heal/plasma/Heal(mob/living/carbon/M, datum/disease/advance/A, actual_power)
+	var/heal_amt = 4 * actual_power
 
 	var/list/parts = M.get_damaged_bodyparts(0,1) //burn only
 
@@ -284,7 +342,7 @@ Bonus
 			M.update_damage_overlays()
 
 	if(prob(base_message_chance) && !hide_healing)
-		new /obj/effect/temp_visual/heal(get_turf(M), "#CC6600")
+		new /obj/effect/temp_visual/heal(M.loc, "#CC6600")
 	return 1
 
 
@@ -305,25 +363,46 @@ Bonus
 //////////////////////////////////////
 */
 
-/datum/symptom/heal/dna
-
-	name = "Deoxyribonucleic Acid Restoration"
-	desc = "The virus repairs the host's genome, purging negative mutations."
+/datum/symptom/heal/radiation
+	name = "Radioactive Resonance"
+	desc = "The virus uses radiation to fix damage through dna mutations."
 	stealth = -1
-	resistance = -1
+	resistance = -2
 	stage_speed = 0
 	transmittable = -3
-	level = 5
-	symptom_delay_min = 3
-	symptom_delay_max = 8
-	threshold_desc = "<b>Stage Speed 6:</b> Additionally heals brain damage.<br>\
-					  <b>Stage Speed 11:</b> Increases brain damage healing."
+	level = 6
+	symptom_delay_min = 1
+	symptom_delay_max = 1
+	threshold_desc = "<b>Stage Speed 6:</b> Increases healing."
 
-/datum/symptom/heal/dna/Heal(mob/living/carbon/M, datum/disease/advance/A)
-	var/amt_healed = 2 * (power - 1)
-	M.adjustBrainLoss(-amt_healed)
-	//Non-power mutations, excluding race, so the virus does not force monkey -> human transformations.
-	var/list/unclean_mutations = (GLOB.not_good_mutations|GLOB.bad_mutations) - GLOB.mutations_list[RACEMUT]
-	M.dna.remove_mutation_group(unclean_mutations)
-	M.radiation = max(M.radiation - (2 * amt_healed), 0)
+/datum/symptom/heal/radiation/CanHeal(datum/disease/advance/A)
+	var/mob/living/M = A.affected_mob
+	switch(M.radiation)
+		if(0)
+			return FALSE
+		if(1 to 350)
+			return 0.25
+		if(351 to 750)
+			return 0.5
+		if(751 to 1250)
+			return 0.75
+		if(1251 to 2000)
+			return 1
+		else
+			return 1.5
+
+/datum/symptom/heal/radiation/Heal(mob/living/carbon/M, datum/disease/advance/A, actual_power)
+	var/heal_amt = 1 * actual_power
+
+	var/list/parts = M.get_damaged_bodyparts(1,1)
+
+	if(!parts.len)
+		return
+
+	for(var/obj/item/bodypart/L in parts)
+		if(L.heal_damage(heal_amt/parts.len, heal_amt/parts.len))
+			M.update_damage_overlays()
+
+	if(prob(base_message_chance) && !hide_healing)
+		new /obj/effect/temp_visual/heal(M.loc, "#66ff22")
 	return 1

--- a/code/datums/diseases/advance/symptoms/heal.dm
+++ b/code/datums/diseases/advance/symptoms/heal.dm
@@ -60,7 +60,7 @@ Bonus
 
 /datum/symptom/heal/toxin
 	name = "Starlight Condensation"
-	desc = "The virus reacts to direct starlight, producing regenerative chemicals."
+	desc = "The virus reacts to direct starlight, producing regenerative chemicals that can cure toxin damage."
 	stealth = 1
 	resistance = -3
 	stage_speed = -3
@@ -104,7 +104,7 @@ Bonus
 	resistance = -2
 	stage_speed = -2
 	transmittable = -2
-	level = 8
+	level = 7
 	desc = "The virus rapidly breaks down any foreign chemicals in the bloodstream."
 
 /datum/symptom/heal/chem/Heal(mob/living/M, datum/disease/advance/A, actual_power)
@@ -118,7 +118,7 @@ Bonus
 	resistance = -2
 	stage_speed = 2
 	transmittable = 1
-	level = 8
+	level = 7
 	desc = "The virus causes the host's metabolism to accelerate rapidly, making them process chemicals twice as fast,\
 	 but also causing increased hunger."
 
@@ -174,7 +174,7 @@ Bonus
 		. *= 2
 
 /datum/symptom/heal/brute/Heal(mob/living/carbon/M, datum/disease/advance/A, actual_power)
-	var/heal_amt = 1 * actual_power
+	var/heal_amt = 2 * actual_power
 
 	var/list/parts = M.get_damaged_bodyparts(1,0) //brute only
 
@@ -296,7 +296,7 @@ Bonus
 		return power
 	else if(M.reagents.has_reagent("holywater"))
 		M.reagents.remove_reagent("holywater", 0.5)
-		return power * 0.60
+		return power * 0.75
 	else if(M.reagents.has_reagent("water"))
 		M.reagents.remove_reagent("water", 0.5)
 		return power * 0.5
@@ -417,11 +417,11 @@ Bonus
 			return FALSE
 		if(1 to RAD_MOB_SAFE)
 			return 0.25
-		if(RAD_MOB_SAFE to 750)
+		if(RAD_MOB_SAFE to RAD_BURN_THRESHOLD)
 			return 0.5
-		if(751 to 1250)
+		if(RAD_BURN_THRESHOLD to RAD_MOB_MUTATE)
 			return 0.75
-		if(1251 to 2000)
+		if(RAD_MOB_MUTATE to RAD_MOB_KNOCKDOWN)
 			return 1
 		else
 			return 1.5

--- a/code/datums/diseases/advance/symptoms/heal.dm
+++ b/code/datums/diseases/advance/symptoms/heal.dm
@@ -382,7 +382,7 @@ Bonus
 			return FALSE
 		if(1 to RAD_MOB_SAFE)
 			return 0.25
-		if(RAD_MOB_SAFE + 1 to 750)
+		if(RAD_MOB_SAFE to 750)
 			return 0.5
 		if(751 to 1250)
 			return 0.75

--- a/code/datums/diseases/advance/symptoms/heal.dm
+++ b/code/datums/diseases/advance/symptoms/heal.dm
@@ -239,7 +239,7 @@ Bonus
 	if(prob(base_message_chance) && !hide_healing)
 		new /obj/effect/temp_visual/heal(M.loc, "#CC1100")
 
-	if(M.getBruteLoss() + M.getFireLoss() == 0)
+	if(active_coma && M.getBruteLoss() + M.getFireLoss() == 0)
 		uncoma(M)
 
 	return 1

--- a/code/datums/diseases/advance/symptoms/heal.dm
+++ b/code/datums/diseases/advance/symptoms/heal.dm
@@ -9,7 +9,6 @@
 	base_message_chance = 20 //here used for the overlays
 	symptom_delay_min = 1
 	symptom_delay_max = 1
-	var/hide_healing = FALSE
 	var/passive_message = "" //random message to infected but not actively healing people
 	threshold_desc = "<b>Stage Speed 6:</b> Doubles healing speed.<br>\
 					  <b>Stealth 4:</b> Healing will no longer be visible to onlookers."

--- a/code/datums/diseases/advance/symptoms/heal.dm
+++ b/code/datums/diseases/advance/symptoms/heal.dm
@@ -16,8 +16,6 @@
 /datum/symptom/heal/Start(datum/disease/advance/A)
 	if(!..())
 		return
-	if(A.properties["stealth"] >= 4) //invisible healing
-		hide_healing = TRUE
 	if(A.properties["stage_rate"] >= 6) //stronger healing
 		power = 2
 

--- a/code/datums/diseases/advance/symptoms/heal.dm
+++ b/code/datums/diseases/advance/symptoms/heal.dm
@@ -73,7 +73,9 @@
 				return power * nearspace_penalty
 
 /datum/symptom/heal/toxin/Heal(mob/living/M, datum/disease/advance/A, actual_power)
-	var/heal_amt = 1 * actual_power
+	var/heal_amt = actual_power
+	if(M.getToxLoss() && prob(5))
+		to_chat(M, "<span class='notice'>Your skin tingles as the starlight purges toxins from your bloodstream.</span>")
 	M.adjustToxLoss(-heal_amt)
 	return 1
 
@@ -104,6 +106,8 @@
 		M.reagents.remove_reagent(R.id, actual_power)
 		if(food_conversion)
 			M.nutrition += 0.3
+		if(prob(2))
+			to_chat(M, "<span class='notice'>You feel a mild warmth as your blood purifies itself.</span>")
 	return 1
 
 
@@ -139,6 +143,8 @@
 	C.overeatduration = max(C.overeatduration - 2, 0)
 	var/lost_nutrition = 9 - (reduced_hunger * 5)
 	C.nutrition = max(C.nutrition - (lost_nutrition * HUNGER_FACTOR), 0) //Hunger depletes at 10x the normal speed
+	if(prob(2))
+		to_chat(M, "<span class='notice'>You feel an odd gurgle in your stomach, as if it was working much faster than normal.</span>")
 	return 1
 
 
@@ -183,6 +189,9 @@
 
 	if(!parts.len)
 		return
+
+	if(prob(5))
+		to_chat(M, "<span class='notice'>You feel your flesh moving beneath your heated skin, mending your wounds.</span>")
 
 	for(var/obj/item/bodypart/L in parts)
 		if(L.heal_damage(heal_amt/parts.len, 0))
@@ -303,6 +312,9 @@
 	if(!parts.len)
 		return
 
+	if(prob(5))
+		to_chat(M, "<span class='notice'>You feel yourself absorbing the water around you to soothe your burned skin.</span>")
+
 	for(var/obj/item/bodypart/L in parts)
 		if(L.heal_damage(0, heal_amt/parts.len))
 			M.update_damage_overlays()
@@ -352,13 +364,22 @@
 
 	var/list/parts = M.get_damaged_bodyparts(0,1) //burn only
 
+	if(prob(5))
+		to_chat(M, "<span class='notice'>You feel yourself absorbing plasma inside and around you.</span>")
+
 	if(M.bodytemperature > 310)
 		M.bodytemperature = max(310, M.bodytemperature - (20 * temp_rate * TEMPERATURE_DAMAGE_COEFFICIENT))
+		if(prob(5))
+			to_chat(M, "<span class='notice'>You feel less hot.</span>")
 	else if(M.bodytemperature < 311)
 		M.bodytemperature = min(310, M.bodytemperature + (20 * temp_rate * TEMPERATURE_DAMAGE_COEFFICIENT))
+		if(prob(5))
+			to_chat(M, "<span class='notice'>You feel warmer.</span>")
 
 	if(!parts.len)
 		return
+	if(prob(5))
+		to_chat(M, "<span class='notice'>The pain from your burns fades.</span>")
 
 	for(var/obj/item/bodypart/L in parts)
 		if(L.heal_damage(0, heal_amt/parts.len))
@@ -406,7 +427,7 @@
 			return 1.5
 
 /datum/symptom/heal/radiation/Heal(mob/living/carbon/M, datum/disease/advance/A, actual_power)
-	var/heal_amt = 1 * actual_power
+	var/heal_amt = actual_power
 
 	if(cellular_damage)
 		M.adjustCloneLoss(-heal_amt * 0.5)
@@ -415,6 +436,9 @@
 
 	if(!parts.len)
 		return
+
+	if(prob(4))
+		to_chat(M, "<span class='notice'>Your skin glows faintly, and you feel your wounds mending themselves.</span>")
 
 	for(var/obj/item/bodypart/L in parts)
 		if(L.heal_damage(heal_amt/parts.len, heal_amt/parts.len))

--- a/code/datums/diseases/advance/symptoms/heal.dm
+++ b/code/datums/diseases/advance/symptoms/heal.dm
@@ -225,7 +225,7 @@ Bonus
 	M.status_flags &= ~FAKEDEATH
 
 /datum/symptom/heal/coma/Heal(mob/living/carbon/M, datum/disease/advance/A, actual_power)
-	var/heal_amt = 6 * actual_power
+	var/heal_amt = 4 * actual_power
 
 	var/list/parts = M.get_damaged_bodyparts(1,1)
 

--- a/code/datums/diseases/advance/symptoms/heal.dm
+++ b/code/datums/diseases/advance/symptoms/heal.dm
@@ -380,9 +380,9 @@ Bonus
 	switch(M.radiation)
 		if(0)
 			return FALSE
-		if(1 to 350)
+		if(1 to RAD_MOB_SAFE)
 			return 0.25
-		if(351 to 750)
+		if(RAD_MOB_SAFE + 1 to 750)
 			return 0.5
 		if(751 to 1250)
 			return 0.75

--- a/code/datums/diseases/advance/symptoms/weight.dm
+++ b/code/datums/diseases/advance/symptoms/weight.dm
@@ -1,55 +1,6 @@
 /*
 //////////////////////////////////////
 
-Weight Gain
-
-	Very Very Noticable.
-	Decreases resistance.
-	Decreases stage speed.
-	Reduced transmittable.
-	Intense Level.
-
-Bonus
-	Increases the weight gain of the mob,
-	forcing it to eventually turn fat.
-//////////////////////////////////////
-*/
-
-/datum/symptom/weight_gain
-	name = "Weight Gain"
-	desc = "The virus mutates the host's metabolism, making it gain weight much faster than normal."
-	stealth = -1
-	resistance = -3
-	stage_speed = 1
-	transmittable = -1
-	level = 4
-	severity = 3
-	base_message_chance = 100
-	symptom_delay_min = 15
-	symptom_delay_max = 45
-	threshold_desc = "<b>Stealth 4:</b> The symptom is less noticeable."
-
-/datum/symptom/weight_gain/Start(datum/disease/advance/A)
-	if(!..())
-		return
-	if(A.properties["stealth"] >= 4) //warn less often
-		base_message_chance = 25
-
-/datum/symptom/weight_gain/Activate(datum/disease/advance/A)
-	if(!..())
-		return
-	var/mob/living/M = A.affected_mob
-	switch(A.stage)
-		if(1, 2, 3, 4)
-			if(prob(base_message_chance))
-				to_chat(M, "<span class='warning'>[pick("You feel blubbery.", "Your stomach hurts.")]</span>")
-		else
-			M.overeatduration = min(M.overeatduration + 100, 600)
-			M.nutrition = min(M.nutrition + 100, NUTRITION_LEVEL_FULL)
-
-/*
-//////////////////////////////////////
-
 Weight Loss
 
 	Very Very Noticable.

--- a/code/datums/diseases/advance/symptoms/weight.dm
+++ b/code/datums/diseases/advance/symptoms/weight.dm
@@ -16,13 +16,12 @@ Bonus
 */
 
 /datum/symptom/weight_gain
-
 	name = "Weight Gain"
 	desc = "The virus mutates the host's metabolism, making it gain weight much faster than normal."
-	stealth = -3
+	stealth = -1
 	resistance = -3
-	stage_speed = -2
-	transmittable = -2
+	stage_speed = 1
+	transmittable = -1
 	level = 4
 	severity = 3
 	base_message_chance = 100
@@ -70,8 +69,8 @@ Bonus
 
 	name = "Weight Loss"
 	desc = "The virus mutates the host's metabolism, making it almost unable to gain nutrition from food."
-	stealth = -3
-	resistance = -2
+	stealth = -2
+	resistance = 2
 	stage_speed = -2
 	transmittable = -2
 	level = 3
@@ -99,43 +98,3 @@ Bonus
 			to_chat(M, "<span class='warning'><i>[pick("So hungry...", "You'd kill someone for a bite of food...", "Hunger cramps seize you...")]</i></span>")
 			M.overeatduration = max(M.overeatduration - 100, 0)
 			M.nutrition = max(M.nutrition - 100, 0)
-
-/*
-//////////////////////////////////////
-
-Weight Even
-
-	Very Noticable.
-	Decreases resistance.
-	Decreases stage speed.
-	Reduced transmittable.
-	High level.
-
-Bonus
-	Causes the weight of the mob to
-	be even, meaning eating isn't
-	required anymore.
-
-//////////////////////////////////////
-*/
-
-/datum/symptom/weight_even
-
-	name = "Weight Even"
-	desc = "The virus alters the host's metabolism, making it far more efficient then normal, and synthesizing nutrients from normally unedible sources."
-	stealth = -3
-	resistance = -2
-	stage_speed = -2
-	transmittable = -2
-	level = 4
-	symptom_delay_min = 5
-	symptom_delay_max = 5
-
-/datum/symptom/weight_even/Activate(datum/disease/advance/A)
-	if(!..())
-		return
-	var/mob/living/M = A.affected_mob
-	switch(A.stage)
-		if(4, 5)
-			M.overeatduration = 0
-			M.nutrition = NUTRITION_LEVEL_WELL_FED + 50


### PR DESCRIPTION
:cl: XDTM
balance: Viruses' healing symptoms have been reworked!
del: All existing healing symptoms have been removed in favour of new ones.
del: Weight Even and Weight Gain have been removed, so hunger can be used for balancing in symptoms.
add: Starlight Condensation heals toxin damage if you're in space using starlight as a catalyst. Being up to two tiles away also works, as long as you can still see it, but slower.
add: Toxolysis (level 7) rapidly cleanses all chemicals from the body, with no exception.
add: Cellular Molding heals brute damage depending on your body temperature: the higher the temperature, the faster the healing. Requires above-average temperature to activate, and the speed heavily increases while on fire.
add: Regenerative Coma (level 8) causes the virus to send you into a deep coma when you are heavily damaged (>70 brute+burn damage). While you are unconscious, either from the virus or from other sources, the virus will heal both brute and burn damage fairly quickly. Sleeping also works, but at reduced speed.
add: Tissue Hydration heals burn damage if you are wet (negative fire stacks) or if you have water in your bloodstream.
add: Plasma Fixation (level 8) stabilizes temperature and heals burns while plasma is in your body or while standing in a plasma cloud. Does not protect from the poisoning effects of plasma.
add: Radioactive Resonance gives a mild constant brute and burn healing while irradiated. The healing becomes more intense if you reach higher levels of radiation, but is still less than the alternatives.
add: Metabolic Boost (level 7) doubles the rate at which you process chemicals, good and bad, but also increases hunger tenfold.
/:cl:

Further suggestions welcome etc.
I hope it's enough to prevent virology from getting the axe.
