### PR TITLE
Reverts flying mobs passing through people

### DIFF
--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -105,7 +105,8 @@
 
 //Called when we bump onto a mob
 /mob/living/proc/MobCollide(mob/M)
-
+	//Even if we don't push/swap places, we "touched" them, so spread fire
+	spreadFire(M)
 	//Also diseases
 	for(var/thing in viruses)
 		var/datum/disease/D = thing
@@ -120,29 +121,6 @@
 	if(now_pushing)
 		return TRUE
 
-	//TODO FOR LATER PRS: Make passing tables an automatic thing for flying and passable objects be determined better to prevent huge amounts of flags being set when mobs fly.
-	if((movement_type) ^ (M.movement_type))	//Fly past each other.
-		now_pushing = TRUE
-		var/old = pass_flags & PASSMOB
-		var/old_p = pulling? (pulling.pass_flags & PASSMOB) : NONE
-		var/atom/movable/cached = pulling
-		pass_flags |= PASSMOB
-		var/obj/item/I = cached
-		if(cached && (isliving(cached) || (istype(I) && (I.w_class < WEIGHT_CLASS_BULKY))))
-			var/mob/living/l = cached
-			if(l.mob_size <= mob_size)
-				cached.pass_flags |= PASSMOB
-		Move(get_turf(M))
-		if(!old)
-			pass_flags &= ~PASSMOB
-		if(cached && !old_p)
-			cached.pass_flags &= ~PASSMOB
-		cached = null
-		now_pushing = FALSE
-		return TRUE
-
-	//Even if we don't push/swap places, we "touched" them, so spread fire
-	spreadFire(M)
 
 	//Should stop you pushing a restrained person out of the way
 	if(isliving(M))


### PR DESCRIPTION
Our melee combat is not the most fun in videogames even without everyone clipping past and floating through each other. I think this is especially apparent with marauders in clock cult rounds happily ignoring security/flying through them to go smash whatever they want.

It also makes hostile "flying" mobs way less threatening when you can just phase through them because they're hovering a foot off the ground.