### PR TITLE
[s] Removes a handful of ways ghosts can affect the world

### DIFF
--- a/code/game/objects/items/crayons.dm
+++ b/code/game/objects/items/crayons.dm
@@ -144,10 +144,11 @@
 		ui.open()
 
 /obj/item/toy/crayon/spraycan/AltClick(mob/user)
-	if(has_cap)
-		is_capped = !is_capped
-		to_chat(user, "<span class='notice'>The cap on [src] is now [is_capped ? "on" : "off"].</span>")
-		update_icon()
+	if(user.canUseTopic(src, be_close=TRUE))
+		if(has_cap)
+			is_capped = !is_capped
+			to_chat(user, "<span class='notice'>The cap on [src] is now [is_capped ? "on" : "off"].</span>")
+			update_icon()
 
 /obj/item/toy/crayon/ui_data()
 	var/list/data = list()

--- a/code/game/objects/items/storage/lockbox.dm
+++ b/code/game/objects/items/storage/lockbox.dm
@@ -128,11 +128,12 @@
 	if(!locked)
 		to_chat(user, "<span class='notice'>Alt-click to [open ? "close":"open"] it.</span>")
 
-/obj/item/storage/lockbox/medal/AltClick()
-	if(!locked)
-		open = (open ? FALSE : TRUE)
-		update_icon()
-	..()
+/obj/item/storage/lockbox/medal/AltClick(mob/user)
+	if(user.canUseTopic(src, be_close=TRUE))
+		if(!locked)
+			open = (open ? FALSE : TRUE)
+			update_icon()
+		..()
 
 /obj/item/storage/lockbox/medal/PopulateContents()
 	new /obj/item/clothing/accessory/medal/gold/captain(src)

--- a/code/game/objects/items/twohanded.dm
+++ b/code/game/objects/items/twohanded.dm
@@ -457,15 +457,15 @@
 			explosive.prime()
 			qdel(src)
 
-/obj/item/twohanded/spear/AltClick()
-	..()
-	if(!explosive)
-		return
-	if(ismob(loc))
-		var/mob/M = loc
-		var/input = stripped_input(M,"What do you want your war cry to be? You will shout it when you hit someone in melee.", ,"", 50)
-		if(input)
-			src.war_cry = input
+/obj/item/twohanded/spear/AltClick(mob/user)
+	if(user.canUseTopic(src, be_close=TRUE))
+		..()
+		if(!explosive)
+			return
+		if(istype(user) && loc == user)
+			var/input = stripped_input(user,"What do you want your war cry to be? You will shout it when you hit someone in melee.", ,"", 50)
+			if(input)
+				src.war_cry = input
 
 /obj/item/twohanded/spear/CheckParts(list/parts_list)
 	var/obj/item/twohanded/spear/S = locate() in parts_list

--- a/code/modules/clothing/head/jobs.dm
+++ b/code/modules/clothing/head/jobs.dm
@@ -86,17 +86,17 @@
 	..()
 	to_chat(user, "<span class='notice'>Alt-click to take a candy corn.</span>")
 
-/obj/item/clothing/head/fedora/det_hat/AltClick()
-	..()
-	if(ismob(loc))
-		var/mob/M = loc
-		if(candy_cooldown < world.time)
-			var/obj/item/reagent_containers/food/snacks/candy_corn/CC = new /obj/item/reagent_containers/food/snacks/candy_corn(src)
-			M.put_in_hands(CC)
-			to_chat(M, "You slip a candy corn from your hat.")
-			candy_cooldown = world.time+1200
-		else
-			to_chat(M, "You just took a candy corn! You should wait a couple minutes, lest you burn through your stash.")
+/obj/item/clothing/head/fedora/det_hat/AltClick(mob/user)
+	if(user.canUseTopic(src, be_close=TRUE))
+		..()
+		if(loc == user)
+			if(candy_cooldown < world.time)
+				var/obj/item/reagent_containers/food/snacks/candy_corn/CC = new /obj/item/reagent_containers/food/snacks/candy_corn(src)
+				user.put_in_hands(CC)
+				to_chat(user, "You slip a candy corn from your hat.")
+				candy_cooldown = world.time+1200
+			else
+				to_chat(user, "You just took a candy corn! You should wait a couple minutes, lest you burn through your stash.")
 
 
 //Mime

--- a/code/modules/clothing/under/accessories.dm
+++ b/code/modules/clothing/under/accessories.dm
@@ -64,10 +64,11 @@
 /obj/item/clothing/accessory/proc/on_uniform_dropped(obj/item/clothing/under/U, user)
 	return
 
-/obj/item/clothing/accessory/AltClick()
-	if(initial(above_suit))
-		above_suit = !above_suit
-		to_chat(usr, "\The [src] will be worn [above_suit ? "above" : "below"] your suit.")
+/obj/item/clothing/accessory/AltClick(mob/user)
+	if(user.canUseTopic(src, be_close=TRUE))
+		if(initial(above_suit))
+			above_suit = !above_suit
+			to_chat(user, "[src] will be worn [above_suit ? "above" : "below"] your suit.")
 
 /obj/item/clothing/accessory/examine(mob/user)
 	..()


### PR DESCRIPTION
Fixes #32451

@AnturK ping for ghost memes

Ghosts are able to, by using the observe verb and alt-click:
1. Take candy corn from the detective's hat and place it in the detective's hands
2. Set a war cry on a wielded explosive spear
3. Mess with clothing accessories
4. Open and close the medals lockbox in captain's quarters if unlocked
5. Take the cap off spray cans

This patch removes all that

[Changelogs]: 

:cl: Naksu
fix: Fixed some interactions with ghosts and items
/:cl:

