### PR TITLE
Generalizes some reagent heating

### DIFF
--- a/code/game/objects/effects/decals/cleanable.dm
+++ b/code/game/objects/effects/decals/cleanable.dm
@@ -47,10 +47,8 @@
 			return
 		else
 			var/hotness = W.is_hot()
-			var/added_heat = (hotness / 100)
-			src.reagents.chem_temp = min(src.reagents.chem_temp + added_heat, hotness)
-			src.reagents.handle_reactions()
-			to_chat(user, "<span class='notice'>You heat [src] with [W]!</span>")
+			reagents.expose_temperature(hotness)
+			to_chat(user, "<span class='notice'>You heat [name] with [W]!</span>")
 	else
 		return ..()
 
@@ -62,8 +60,7 @@
 
 /obj/effect/decal/cleanable/fire_act(exposed_temperature, exposed_volume)
 	if(reagents)
-		reagents.chem_temp += 30
-		reagents.handle_reactions()
+		reagents.expose_temperature(exposed_temperature)
 	..()
 
 

--- a/code/modules/food_and_drinks/drinks/drinks.dm
+++ b/code/modules/food_and_drinks/drinks/drinks.dm
@@ -90,12 +90,10 @@
 			addtimer(CALLBACK(reagents, /datum/reagents.proc/add_reagent, refill, trans), 600)
 
 /obj/item/reagent_containers/food/drinks/attackby(obj/item/I, mob/user, params)
-	if(I.is_hot())
-		var/added_heat = (I.is_hot() / 100) //ishot returns a temperature
-		if(reagents)
-			reagents.chem_temp += added_heat
-			to_chat(user, "<span class='notice'>You heat [src] with [I].</span>")
-			reagents.handle_reactions()
+	var/hotness = I.is_hot()
+	if(hotness && reagents)
+		reagents.expose_temperature(hotness)
+		to_chat(user, "<span class='notice'>You heat [name] with [I]!</span>")
 	..()
 
 

--- a/code/modules/reagents/chemistry/holder.dm
+++ b/code/modules/reagents/chemistry/holder.dm
@@ -231,7 +231,6 @@
 	var/list/cached_addictions = addiction_list
 	if(C)
 		expose_temperature(C.bodytemperature, 0.25)
-		handle_reactions()
 	var/need_mob_update = 0
 	for(var/reagent in cached_reagents)
 		var/datum/reagent/R = reagent

--- a/code/modules/reagents/chemistry/holder.dm
+++ b/code/modules/reagents/chemistry/holder.dm
@@ -230,9 +230,7 @@
 	var/list/cached_reagents = reagent_list
 	var/list/cached_addictions = addiction_list
 	if(C)
-		var/avg_temp = (chem_temp * total_volume + C.bodytemperature * (maximum_volume - total_volume)) / maximum_volume
-		chem_temp = avg_temp
-		C.bodytemperature = avg_temp
+		expose_temperature(C.bodytemperature, 0.25)
 		handle_reactions()
 	var/need_mob_update = 0
 	for(var/reagent in cached_reagents)
@@ -737,8 +735,8 @@
 
 	return english_list(out, "something indescribable")
 	
-/datum/reagents/proc/expose_temperature(var/temperature)
-	var/temp_delta = (temperature - chem_temp) / 50
+/datum/reagents/proc/expose_temperature(var/temperature, var/coeff=0.02)
+	var/temp_delta = (temperature - chem_temp) * coeff
 	if(temp_delta > 0)
 		chem_temp = min(chem_temp + max(temp_delta, 1), temperature)
 	else

--- a/code/modules/reagents/chemistry/holder.dm
+++ b/code/modules/reagents/chemistry/holder.dm
@@ -230,7 +230,9 @@
 	var/list/cached_reagents = reagent_list
 	var/list/cached_addictions = addiction_list
 	if(C)
-		chem_temp = C.bodytemperature
+		var/avg_temp = (chem_temp * total_volume + C.bodytemperature * (maximum_volume - total_volume)) / maximum_volume
+		chem_temp = avg_temp
+		C.bodytemperature = avg_temp
 		handle_reactions()
 	var/need_mob_update = 0
 	for(var/reagent in cached_reagents)
@@ -734,6 +736,15 @@
 					out += "[taste_desc]"
 
 	return english_list(out, "something indescribable")
+	
+/datum/reagents/proc/expose_temperature(var/temperature)
+	var/temp_delta = (temperature - chem_temp) / 50
+	if(temp_delta > 0)
+		chem_temp = min(chem_temp + max(temp_delta, 1), temperature)
+	else
+		chem_temp = max(chem_temp + min(temp_delta, -1), temperature)
+	chem_temp = round(chem_temp)
+	handle_reactions()
 
 ///////////////////////////////////////////////////////////////////////////////////
 

--- a/code/modules/reagents/reagent_containers.dm
+++ b/code/modules/reagents/reagent_containers.dm
@@ -80,8 +80,7 @@
 		..()
 
 /obj/item/reagent_containers/fire_act(exposed_temperature, exposed_volume)
-	reagents.chem_temp += 30
-	reagents.handle_reactions()
+	reagents.expose_temperature(exposed_temperature)
 	..()
 
 /obj/item/reagent_containers/throw_impact(atom/target)
@@ -125,6 +124,9 @@
 
 /obj/item/reagent_containers/microwave_act(obj/machinery/microwave/M)
 	if(is_open_container())
-		reagents.chem_temp = max(reagents.chem_temp, 1000)
+		reagents.expose_temperature(1000)
 		reagents.handle_reactions()
 	..()
+
+/obj/item/reagent_containers/temperature_expose(datum/gas_mixture/air, exposed_temperature, exposed_volume)
+	reagents.expose_temperature(exposed_temperature)

--- a/code/modules/reagents/reagent_containers.dm
+++ b/code/modules/reagents/reagent_containers.dm
@@ -125,7 +125,6 @@
 /obj/item/reagent_containers/microwave_act(obj/machinery/microwave/M)
 	if(is_open_container())
 		reagents.expose_temperature(1000)
-		reagents.handle_reactions()
 	..()
 
 /obj/item/reagent_containers/temperature_expose(datum/gas_mixture/air, exposed_temperature, exposed_volume)

--- a/code/modules/reagents/reagent_containers/glass.dm
+++ b/code/modules/reagents/reagent_containers/glass.dm
@@ -91,15 +91,9 @@
 
 /obj/item/reagent_containers/glass/attackby(obj/item/I, mob/user, params)
 	var/hotness = I.is_hot()
-	if(hotness)
-		var/added_heat = (hotness / 100) //ishot returns a temperature
-		if(reagents)
-			if(reagents.chem_temp < hotness) //can't be heated to be hotter than the source
-				reagents.chem_temp += added_heat
-				to_chat(user, "<span class='notice'>You heat [src] with [I].</span>")
-				reagents.handle_reactions()
-			else
-				to_chat(user, "<span class='warning'>[src] is already hotter than [I]!</span>")
+	if(hotness && reagents)
+		reagents.expose_temperature(hotness)
+		to_chat(user, "<span class='notice'>You heat [name] with [I]!</span>")
 
 	if(istype(I, /obj/item/reagent_containers/food/snacks/egg)) //breaking eggs
 		var/obj/item/reagent_containers/food/snacks/egg/E = I

--- a/code/modules/reagents/reagent_containers/spray.dm
+++ b/code/modules/reagents/reagent_containers/spray.dm
@@ -123,6 +123,13 @@
 		current_range = spray_range
 	to_chat(user, "<span class='notice'>You switch the nozzle setting to [stream_mode ? "\"stream\"":"\"spray\""]. You'll now use [amount_per_transfer_from_this] units per use.</span>")
 
+/obj/item/reagent_containers/spray/attackby(obj/item/I, mob/user, params)
+	var/hotness = I.is_hot()
+	if(hotness && reagents)
+		reagents.expose_temperature(hotness)
+		to_chat(user, "<span class='notice'>You heat [name] with [I]!</span>")
+	..()
+
 /obj/item/reagent_containers/spray/verb/empty()
 	set name = "Empty Spray Bottle"
 	set category = "Object"

--- a/code/modules/reagents/reagent_containers/spray.dm
+++ b/code/modules/reagents/reagent_containers/spray.dm
@@ -128,7 +128,7 @@
 	if(hotness && reagents)
 		reagents.expose_temperature(hotness)
 		to_chat(user, "<span class='notice'>You heat [name] with [I]!</span>")
-	..()
+	return ..()
 
 /obj/item/reagent_containers/spray/verb/empty()
 	set name = "Empty Spray Bottle"


### PR DESCRIPTION
:cl: Swindly
fix: Fixed hot items and fire heating reagents to temperatures higher than their heat source.
fix: Sprays can now be heated with hot items.
tweak: The heating of reagents by hot items, fire, and microwaves now scales linearly with the difference between the reagent holder's temperature and the heat source's temperature instead of constantly.
tweak: The body temperature of a mob with reagents is affected by the temperature of the mob's reagents.
tweak: Reagent containers can now be heated by hot air.
/:cl:

Fixes https://github.com/tgstation/tgstation/issues/29557 and https://github.com/tgstation/tgstation/issues/32372
 
Added expose_temperature proc to be used for heating reagents in a consistent manner instead of different reagent holders being heated differently. It heats linearly similar to the way the chem heater works.
Added temperature_expose for reagent containers so that they can be heated by the environment for realism or something.
Metabolizing reagents causes the temperatures of the reagents to quickly, but not instantly, change towards the body temperature. Instantly changing to the body temperature prevented expected behavior of some reagents and reactions (i.e. cryostylane synthesis) from occurring.
