### PR TITLE
Fixes turf_decal layering

### DIFF
--- a/code/__DEFINES/layers.dm
+++ b/code/__DEFINES/layers.dm
@@ -13,6 +13,7 @@
 //#define TURF_LAYER 2 //For easy recordkeeping; this is a byond define
 #define MID_TURF_LAYER 2.02
 #define HIGH_TURF_LAYER 2.03
+#define TURF_DECAL_LAYER 2.039 //Makes turf decals appear in DM how they will look inworld.
 #define ABOVE_OPEN_TURF_LAYER 2.04
 #define CLOSED_TURF_LAYER 2.05
 #define BULLET_HOLE_LAYER 2.06
@@ -20,7 +21,6 @@
 #define LATTICE_LAYER 2.2
 #define DISPOSAL_PIPE_LAYER 2.3
 #define GAS_PIPE_HIDDEN_LAYER 2.35
-#define TURF_DECAL_LAYER 2.39
 #define WIRE_LAYER 2.4
 #define WIRE_TERMINAL_LAYER 2.45
 #define GAS_SCRUBBER_LAYER 2.46

--- a/code/datums/components/decal.dm
+++ b/code/datums/components/decal.dm
@@ -4,7 +4,7 @@
 	var/cleanable
 	var/mutable_appearance/pic
 
-/datum/component/decal/Initialize(_icon, _icon_state, _dir, _cleanable=CLEAN_GOD, _color, _layer=TURF_DECAL_LAYER)
+/datum/component/decal/Initialize(_icon, _icon_state, _dir, _cleanable=CLEAN_GOD, _color, _layer=TURF_LAYER)
 	if(!isatom(parent) || !_icon || !_icon_state)
 		. = COMPONENT_INCOMPATIBLE
 		CRASH("A turf decal was applied incorrectly to [parent.type]: icon:[_icon ? _icon : "none"] icon_state:[_icon_state ? _icon_state : "none"]")

--- a/code/game/objects/effects/decals/decal.dm
+++ b/code/game/objects/effects/decals/decal.dm
@@ -20,6 +20,7 @@
 /obj/effect/turf_decal
 	icon = 'icons/turf/decals.dmi'
 	icon_state = "warningline"
+	layer = TURF_DECAL_LAYER
 
 /obj/effect/turf_decal/Initialize()
 	..()

--- a/code/game/turfs/simulated/walls.dm
+++ b/code/game/turfs/simulated/walls.dm
@@ -29,12 +29,12 @@
 
 	var/static/list/dent_decal_list = list(
 	WALL_DENT_HIT = list(
-	mutable_appearance('icons/effects/effects.dmi', "impact1", TURF_DECAL_LAYER),
-	mutable_appearance('icons/effects/effects.dmi', "impact2", TURF_DECAL_LAYER),
-	mutable_appearance('icons/effects/effects.dmi', "impact3", TURF_DECAL_LAYER)
+	mutable_appearance('icons/effects/effects.dmi', "impact1", BULLET_HOLE_LAYER),
+	mutable_appearance('icons/effects/effects.dmi', "impact2", BULLET_HOLE_LAYER),
+	mutable_appearance('icons/effects/effects.dmi', "impact3", BULLET_HOLE_LAYER)
 	),
 	WALL_DENT_SHOT = list(
-	mutable_appearance('icons/effects/effects.dmi', "bullet_hole", TURF_DECAL_LAYER)
+	mutable_appearance('icons/effects/effects.dmi', "bullet_hole", BULLET_HOLE_LAYER)
 	)
 	)
 


### PR DESCRIPTION
turf_decal's layer was removed by accident in #31942. 

It was only there to show the decals properly in DM, which were then supposed to be applied as images on the TURF_LAYER when ingame.

Also fixes bullet holes using the wrong layer.

Adjusted the TURF_DECAL_LAYER to be beneath cleanable decals. I had it that high previously so you would see it above piping, however it's probably better to just have it 1:1 with how it'll ultimately look ingame.