### PR TITLE
[s] Fixes pride mirror CentCom exploit

### DIFF
--- a/code/modules/ruins/objects_and_mobs/sin_ruins.dm
+++ b/code/modules/ruins/objects_and_mobs/sin_ruins.dm
@@ -101,8 +101,10 @@
 	user.visible_message("<span class='danger'><B>The ground splits beneath [user] as [user.p_their()] hand leaves the mirror!</B></span>", \
 	"<span class='notice'>Perfect. Much better! Now <i>nobody</i> will be able to resist yo-</span>")
 	var/turf/T = get_turf(user)
-	T.ChangeTurf(/turf/open/chasm/straight_down)
-	var/turf/open/chasm/straight_down/C = T
+	if(T.z = ZLEVEL_LAVALAND)
+		var/turf/open/chasm/straight_down/C = T.ChangeTurf(/turf/open/chasm/straight_down)
+	else
+		var/turf/open/chasm/C = T.ChangeTurf(/turf/open/chasm/)
 	C.drop(user)
 
 //can't be bothered to do sloth right now, will make later

--- a/code/modules/ruins/objects_and_mobs/sin_ruins.dm
+++ b/code/modules/ruins/objects_and_mobs/sin_ruins.dm
@@ -101,7 +101,8 @@
 	user.visible_message("<span class='danger'><B>The ground splits beneath [user] as [user.p_their()] hand leaves the mirror!</B></span>", \
 	"<span class='notice'>Perfect. Much better! Now <i>nobody</i> will be able to resist yo-</span>")
 	var/turf/T = get_turf(user)
-	if(T.z = ZLEVEL_LAVALAND)
+	var/turf/open/chasm/C
+	if(T.z == ZLEVEL_LAVALAND)
 		var/turf/open/chasm/straight_down/C = T.ChangeTurf(/turf/open/chasm/straight_down)
 	else
 		var/turf/open/chasm/C = T.ChangeTurf(/turf/open/chasm/)


### PR DESCRIPTION
:cl: Arianya
fix: Prevents pride's mirror from being used for nefarious hijinks. Before pride...
/:cl:

Closes #32470 
Fixes #31427

**Why:** Introducing a tweak simply because of an exploit is bad, and is also GBP fraud.

Please report your local 🐸 to the SEC for GBP fraud.

<hr>

More seriously, I don't like that its changing a perfectly functional part of sin ruins simply to fix an exploit

Fair credit to @Armhulen and @ShizCalev who did like, all of the work in investigating and finding a fix, this is basically just a Frankenstein's Monster of their code.

Yes this won't necessarily work with planetstation but ~~planetstation is dead~~ it'll require a new PR when planetstation comes out either way to set up the jungle path