### PR TITLE
Players can disable the ability to receive solo antag objectives in their prefs

### DIFF
--- a/code/datums/antagonists/changeling.dm
+++ b/code/datums/antagonists/changeling.dm
@@ -361,70 +361,70 @@
 		if(!CTO.escape_objective_compatible)
 			escape_objective_possible = FALSE
 			break
+	if(owner.current.client.prefs.receive_solo_objectives)
+		var/datum/objective/absorb/absorb_objective = new
+		absorb_objective.owner = owner
+		absorb_objective.gen_amount_goal(6, 8)
+		objectives += absorb_objective
 
-	var/datum/objective/absorb/absorb_objective = new
-	absorb_objective.owner = owner
-	absorb_objective.gen_amount_goal(6, 8)
-	objectives += absorb_objective
-
-	if(prob(60))
-		if(prob(85))
-			var/datum/objective/steal/steal_objective = new
-			steal_objective.owner = owner
-			steal_objective.find_target()
-			objectives += steal_objective
-		else
-			var/datum/objective/download/download_objective = new
-			download_objective.owner = owner
-			download_objective.gen_amount_goal()
-			objectives += download_objective
-
-	var/list/active_ais = active_ais()
-	if(active_ais.len && prob(100/GLOB.joined_player_list.len))
-		var/datum/objective/destroy/destroy_objective = new
-		destroy_objective.owner = owner
-		destroy_objective.find_target()
-		objectives += destroy_objective
-	else
-		if(prob(70))
-			var/datum/objective/assassinate/kill_objective = new
-			kill_objective.owner = owner
-			if(team_mode) //No backstabbing while in a team
-				kill_objective.find_target_by_role(role = "Changeling", role_type = 1, invert = 1)
+		if(prob(60))
+			if(prob(85))
+				var/datum/objective/steal/steal_objective = new
+				steal_objective.owner = owner
+				steal_objective.find_target()
+				objectives += steal_objective
 			else
-				kill_objective.find_target()
-			objectives += kill_objective
-		else
-			var/datum/objective/maroon/maroon_objective = new
-			maroon_objective.owner = owner
-			if(team_mode)
-				maroon_objective.find_target_by_role(role = "Changeling", role_type = 1, invert = 1)
-			else
-				maroon_objective.find_target()
-			objectives += maroon_objective
+				var/datum/objective/download/download_objective = new
+				download_objective.owner = owner
+				download_objective.gen_amount_goal()
+				objectives += download_objective
 
-			if (!(locate(/datum/objective/escape) in objectives) && escape_objective_possible)
+		var/list/active_ais = active_ais()
+		if(active_ais.len && prob(100/GLOB.joined_player_list.len))
+			var/datum/objective/destroy/destroy_objective = new
+			destroy_objective.owner = owner
+			destroy_objective.find_target()
+			objectives += destroy_objective
+		else
+			if(prob(70))
+				var/datum/objective/assassinate/kill_objective = new
+				kill_objective.owner = owner
+				if(team_mode) //No backstabbing while in a team
+					kill_objective.find_target_by_role(role = "Changeling", role_type = 1, invert = 1)
+				else
+					kill_objective.find_target()
+				objectives += kill_objective
+			else
+				var/datum/objective/maroon/maroon_objective = new
+				maroon_objective.owner = owner
+				if(team_mode)
+					maroon_objective.find_target_by_role(role = "Changeling", role_type = 1, invert = 1)
+				else
+					maroon_objective.find_target()
+				objectives += maroon_objective
+
+				if (!(locate(/datum/objective/escape) in objectives) && escape_objective_possible)
+					var/datum/objective/escape/escape_with_identity/identity_theft = new
+					identity_theft.owner = owner
+					identity_theft.target = maroon_objective.target
+					identity_theft.update_explanation_text()
+					objectives += identity_theft
+					escape_objective_possible = FALSE
+
+		if (!(locate(/datum/objective/escape) in objectives) && escape_objective_possible)
+			if(prob(50))
+				var/datum/objective/escape/escape_objective = new
+				escape_objective.owner = owner
+				objectives += escape_objective
+			else
 				var/datum/objective/escape/escape_with_identity/identity_theft = new
 				identity_theft.owner = owner
-				identity_theft.target = maroon_objective.target
-				identity_theft.update_explanation_text()
+				if(team_mode)
+					identity_theft.find_target_by_role(role = "Changeling", role_type = 1, invert = 1)
+				else
+					identity_theft.find_target()
 				objectives += identity_theft
-				escape_objective_possible = FALSE
-
-	if (!(locate(/datum/objective/escape) in objectives) && escape_objective_possible)
-		if(prob(50))
-			var/datum/objective/escape/escape_objective = new
-			escape_objective.owner = owner
-			objectives += escape_objective
-		else
-			var/datum/objective/escape/escape_with_identity/identity_theft = new
-			identity_theft.owner = owner
-			if(team_mode)
-				identity_theft.find_target_by_role(role = "Changeling", role_type = 1, invert = 1)
-			else
-				identity_theft.find_target()
-			objectives += identity_theft
-		escape_objective_possible = FALSE
+			escape_objective_possible = FALSE
 
 	owner.objectives |= objectives
 

--- a/code/datums/antagonists/ninja.dm
+++ b/code/datums/antagonists/ninja.dm
@@ -28,71 +28,72 @@
 	owner.store_memory("Officially, [helping_station?"Nanotrasen":"The Syndicate"] are my employer.")
 
 /datum/antagonist/ninja/proc/addObjectives(quantity = 6)
-	var/list/possible_targets = list()
-	for(var/datum/mind/M in SSticker.minds)
-		if(M.current && M.current.stat != DEAD)
-			if(ishuman(M.current))
-				if(M.special_role)
-					possible_targets[M] = 0						//bad-guy
-				else if(M.assigned_role in GLOB.command_positions)
-					possible_targets[M] = 1						//good-guy
+	if(owner.current.client.prefs.receive_solo_objectives)
+		var/list/possible_targets = list()
+		for(var/datum/mind/M in SSticker.minds)
+			if(M.current && M.current.stat != DEAD)
+				if(ishuman(M.current))
+					if(M.special_role)
+						possible_targets[M] = 0						//bad-guy
+					else if(M.assigned_role in GLOB.command_positions)
+						possible_targets[M] = 1						//good-guy
 
-	var/list/objectives = list(1,2,3,4)
-	while(owner.objectives.len < quantity)
-		switch(pick_n_take(objectives))
-			if(1)	//research
-				var/datum/objective/download/O = new /datum/objective/download()
-				O.owner = owner
-				O.gen_amount_goal()
-				owner.objectives += O
-
-			if(2)	//steal
-				var/datum/objective/steal/special/O = new /datum/objective/steal/special()
-				O.owner = owner
-				owner.objectives += O
-
-			if(3)	//protect/kill
-				if(!possible_targets.len)	continue
-				var/index = rand(1,possible_targets.len)
-				var/datum/mind/M = possible_targets[index]
-				var/is_bad_guy = possible_targets[M]
-				possible_targets.Cut(index,index+1)
-
-				if(is_bad_guy ^ helping_station)			//kill (good-ninja + bad-guy or bad-ninja + good-guy)
-					var/datum/objective/assassinate/O = new /datum/objective/assassinate()
-					O.owner = owner
-					O.target = M
-					O.explanation_text = "Slay \the [M.current.real_name], the [M.assigned_role]."
-					owner.objectives += O
-				else										//protect
-					var/datum/objective/protect/O = new /datum/objective/protect()
-					O.owner = owner
-					O.target = M
-					O.explanation_text = "Protect \the [M.current.real_name], the [M.assigned_role], from harm."
-					owner.objectives += O
-			if(4)	//debrain/capture
-				if(!possible_targets.len)	continue
-				var/selected = rand(1,possible_targets.len)
-				var/datum/mind/M = possible_targets[selected]
-				var/is_bad_guy = possible_targets[M]
-				possible_targets.Cut(selected,selected+1)
-
-				if(is_bad_guy ^ helping_station)			//debrain (good-ninja + bad-guy or bad-ninja + good-guy)
-					var/datum/objective/debrain/O = new /datum/objective/debrain()
-					O.owner = owner
-					O.target = M
-					O.explanation_text = "Steal the brain of [M.current.real_name]."
-					owner.objectives += O
-				else										//capture
-					var/datum/objective/capture/O = new /datum/objective/capture()
+		var/list/objectives = list(1,2,3,4)
+		while(owner.objectives.len < quantity)
+			switch(pick_n_take(objectives))
+				if(1)	//research
+					var/datum/objective/download/O = new /datum/objective/download()
 					O.owner = owner
 					O.gen_amount_goal()
 					owner.objectives += O
-			else
-				break
-	var/datum/objective/O = new /datum/objective/survive()
-	O.owner = owner
-	owner.objectives += O
+
+				if(2)	//steal
+					var/datum/objective/steal/special/O = new /datum/objective/steal/special()
+					O.owner = owner
+					owner.objectives += O
+
+				if(3)	//protect/kill
+					if(!possible_targets.len)	continue
+					var/index = rand(1,possible_targets.len)
+					var/datum/mind/M = possible_targets[index]
+					var/is_bad_guy = possible_targets[M]
+					possible_targets.Cut(index,index+1)
+
+					if(is_bad_guy ^ helping_station)			//kill (good-ninja + bad-guy or bad-ninja + good-guy)
+						var/datum/objective/assassinate/O = new /datum/objective/assassinate()
+						O.owner = owner
+						O.target = M
+						O.explanation_text = "Slay \the [M.current.real_name], the [M.assigned_role]."
+						owner.objectives += O
+					else										//protect
+						var/datum/objective/protect/O = new /datum/objective/protect()
+						O.owner = owner
+						O.target = M
+						O.explanation_text = "Protect \the [M.current.real_name], the [M.assigned_role], from harm."
+						owner.objectives += O
+				if(4)	//debrain/capture
+					if(!possible_targets.len)	continue
+					var/selected = rand(1,possible_targets.len)
+					var/datum/mind/M = possible_targets[selected]
+					var/is_bad_guy = possible_targets[M]
+					possible_targets.Cut(selected,selected+1)
+
+					if(is_bad_guy ^ helping_station)			//debrain (good-ninja + bad-guy or bad-ninja + good-guy)
+						var/datum/objective/debrain/O = new /datum/objective/debrain()
+						O.owner = owner
+						O.target = M
+						O.explanation_text = "Steal the brain of [M.current.real_name]."
+						owner.objectives += O
+					else										//capture
+						var/datum/objective/capture/O = new /datum/objective/capture()
+						O.owner = owner
+						O.gen_amount_goal()
+						owner.objectives += O
+				else
+					break
+		var/datum/objective/O = new /datum/objective/survive()
+		O.owner = owner
+		owner.objectives += O
 
 
 /proc/remove_ninja(mob/living/L)

--- a/code/datums/antagonists/wizard.dm
+++ b/code/datums/antagonists/wizard.dm
@@ -60,51 +60,52 @@
 	owner.current.forceMove(pick(GLOB.wizardstart))
 
 /datum/antagonist/wizard/proc/create_objectives()
-	switch(rand(1,100))
-		if(1 to 30)
-			var/datum/objective/assassinate/kill_objective = new
-			kill_objective.owner = owner
-			kill_objective.find_target()
-			objectives += kill_objective
+	if(owner.current.client.prefs.receive_solo_objectives)
+		switch(rand(1,100))
+			if(1 to 30)
+				var/datum/objective/assassinate/kill_objective = new
+				kill_objective.owner = owner
+				kill_objective.find_target()
+				objectives += kill_objective
 
-			if (!(locate(/datum/objective/escape) in owner.objectives))
-				var/datum/objective/escape/escape_objective = new
-				escape_objective.owner = owner
-				objectives += escape_objective
-		
-		if(31 to 60)
-			var/datum/objective/steal/steal_objective = new
-			steal_objective.owner = owner
-			steal_objective.find_target()
-			objectives += steal_objective
+				if (!(locate(/datum/objective/escape) in owner.objectives))
+					var/datum/objective/escape/escape_objective = new
+					escape_objective.owner = owner
+					objectives += escape_objective
 
-			if (!(locate(/datum/objective/escape) in owner.objectives))
-				var/datum/objective/escape/escape_objective = new
-				escape_objective.owner = owner
-				objectives += escape_objective
+			if(31 to 60)
+				var/datum/objective/steal/steal_objective = new
+				steal_objective.owner = owner
+				steal_objective.find_target()
+				objectives += steal_objective
 
-		if(61 to 85)
-			var/datum/objective/assassinate/kill_objective = new
-			kill_objective.owner = owner
-			kill_objective.find_target()
-			objectives += kill_objective
+				if (!(locate(/datum/objective/escape) in owner.objectives))
+					var/datum/objective/escape/escape_objective = new
+					escape_objective.owner = owner
+					objectives += escape_objective
 
-			var/datum/objective/steal/steal_objective = new
-			steal_objective.owner = owner
-			steal_objective.find_target()
-			objectives += steal_objective
+			if(61 to 85)
+				var/datum/objective/assassinate/kill_objective = new
+				kill_objective.owner = owner
+				kill_objective.find_target()
+				objectives += kill_objective
 
-			if (!(locate(/datum/objective/survive) in owner.objectives))
-				var/datum/objective/survive/survive_objective = new
-				survive_objective.owner = owner
-				objectives += survive_objective
+				var/datum/objective/steal/steal_objective = new
+				steal_objective.owner = owner
+				steal_objective.find_target()
+				objectives += steal_objective
 
-		else
-			if (!(locate(/datum/objective/hijack) in owner.objectives))
-				var/datum/objective/hijack/hijack_objective = new
-				hijack_objective.owner = owner
-				objectives += hijack_objective	
-	
+				if (!(locate(/datum/objective/survive) in owner.objectives))
+					var/datum/objective/survive/survive_objective = new
+					survive_objective.owner = owner
+					objectives += survive_objective
+
+			else
+				if (!(locate(/datum/objective/hijack) in owner.objectives))
+					var/datum/objective/hijack/hijack_objective = new
+					hijack_objective.owner = owner
+					objectives += hijack_objective
+
 	for(var/datum/objective/O in objectives)
 		owner.objectives += O
 

--- a/code/datums/mind.dm
+++ b/code/datums/mind.dm
@@ -1317,11 +1317,14 @@
 
 /datum/mind/proc/announce_objectives()
 	var/obj_count = 1
-	to_chat(current, "<span class='notice'>Your current objectives:</span>")
-	for(var/objective in objectives)
-		var/datum/objective/O = objective
-		to_chat(current, "<B>Objective #[obj_count]</B>: [O.explanation_text]")
-		obj_count++
+	if(objectives.len)
+		to_chat(current, "<span class='notice'>Your current objectives:</span>")
+		for(var/objective in objectives)
+			var/datum/objective/O = objective
+			to_chat(current, "<B>Objective #[obj_count]</B>: [O.explanation_text]")
+			obj_count++
+	else
+		to_chat(current, "<span class='notice'>You have not been assigned any objectives. Do as you wish.</span>")
 
 /datum/mind/proc/find_syndicate_uplink()
 	var/list/L = current.GetAllContents()

--- a/code/game/gamemodes/changeling/changeling.dm
+++ b/code/game/gamemodes/changeling/changeling.dm
@@ -122,12 +122,14 @@ GLOBAL_VAR(changeling_team_objective_type) //If this is not null, we hand our th
 						changelingwin = 0
 					count++
 
-			if(changelingwin)
-				text += "<br><font color='green'><b>The changeling was successful!</b></font>"
-				SSblackbox.add_details("changeling_success","SUCCESS")
+				if(changelingwin)
+					text += "<br><font color='green'><b>The changeling was successful!</b></font>"
+					SSblackbox.add_details("changeling_success","SUCCESS")
+				else
+					text += "<br><span class='boldannounce'>The changeling has failed.</span>"
+					SSblackbox.add_details("changeling_success","FAIL")
 			else
-				text += "<br><span class='boldannounce'>The changeling has failed.</span>"
-				SSblackbox.add_details("changeling_success","FAIL")
+				SSblackbox.add_details("changeling_success", "NO_OBJECTIVES")
 			text += "<br>"
 
 		to_chat(world, text)

--- a/code/game/gamemodes/traitor/traitor.dm
+++ b/code/game/gamemodes/traitor/traitor.dm
@@ -128,7 +128,7 @@
 
 			if(uplink_true)
 				text += " (used [TC_uses] TC) [purchases]"
-				if(TC_uses==0 && traitorwin && traitor.current.client.prefs.receive_solo_objectives)
+				if(TC_uses==0 && traitorwin && traitor.objectives.len)
 					var/static/icon/badass = icon('icons/badass.dmi', "badass")
 					text += "<BIG>[icon2html(badass, world)]</BIG>"
 

--- a/code/game/gamemodes/traitor/traitor.dm
+++ b/code/game/gamemodes/traitor/traitor.dm
@@ -60,7 +60,11 @@
 
 /datum/game_mode/traitor/post_setup()
 	for(var/datum/mind/traitor in pre_traitors)
-		var/datum/antagonist/traitor/new_antag = new antag_datum(traitor)
+		var/datum/antagonist/traitor/new_antag
+		if(traitor.current.client.prefs.receive_solo_objectives) //The IAA antag datum is too much of a clusterfuck for me to manage with the pref, so non-objective-receiving antags will be regular traitors during double_agents - Y0SH1_M4S73R
+			new_antag = new antag_datum(traitor)
+		else
+			new_antag = new ANTAG_DATUM_TRAITOR(traitor)
 		new_antag.should_specialise = TRUE
 		addtimer(CALLBACK(traitor, /datum/mind.proc/add_antag_datum, new_antag), rand(10,100))
 	if(!exchange_blue)
@@ -124,7 +128,7 @@
 
 			if(uplink_true)
 				text += " (used [TC_uses] TC) [purchases]"
-				if(TC_uses==0 && traitorwin)
+				if(TC_uses==0 && traitorwin && traitor.current.client.prefs.receive_solo_objectives)
 					var/static/icon/badass = icon('icons/badass.dmi', "badass")
 					text += "<BIG>[icon2html(badass, world)]</BIG>"
 
@@ -136,14 +140,16 @@
 			else
 				special_role_text = "antagonist"
 
-
-			if(traitorwin)
-				text += "<br><font color='green'><B>The [special_role_text] was successful!</B></font>"
-				SSblackbox.add_details("traitor_success","SUCCESS")
+			if(traitor.objectives.len)
+				if(traitorwin)
+					text += "<br><font color='green'><B>The [special_role_text] was successful!</B></font>"
+					SSblackbox.add_details("traitor_success","SUCCESS")
+				else
+					text += "<br><font color='red'><B>The [special_role_text] has failed!</B></font>"
+					SSblackbox.add_details("traitor_success","FAIL")
+					SEND_SOUND(traitor.current, 'sound/ambience/ambifailure.ogg')
 			else
-				text += "<br><font color='red'><B>The [special_role_text] has failed!</B></font>"
-				SSblackbox.add_details("traitor_success","FAIL")
-				SEND_SOUND(traitor.current, 'sound/ambience/ambifailure.ogg')
+				SSblackbox.add_details("traitor_success","NO_OBJECTIVES")
 
 			text += "<br>"
 

--- a/code/game/gamemodes/wizard/wizard.dm
+++ b/code/game/gamemodes/wizard/wizard.dm
@@ -97,13 +97,15 @@
 					SSblackbox.add_details("wizard_objective","[objective.type]|FAIL")
 					wizardwin = 0
 				count++
-
-			if(wizard.current && wizard.current.stat!=2 && wizardwin)
-				text += "<br><font color='green'><B>The wizard was successful!</B></font>"
-				SSblackbox.add_details("wizard_success","SUCCESS")
+			if(wizard.objectives.len)
+				if(wizard.current && wizard.current.stat!=2 && wizardwin)
+					text += "<br><font color='green'><B>The wizard was successful!</B></font>"
+					SSblackbox.add_details("wizard_success","SUCCESS")
+				else
+					text += "<br><font color='red'><B>The wizard has failed!</B></font>"
+					SSblackbox.add_details("wizard_success","FAIL")
 			else
-				text += "<br><font color='red'><B>The wizard has failed!</B></font>"
-				SSblackbox.add_details("wizard_success","FAIL")
+				SSblackbox.add_details("wizard_success","NO_OBJECTIVES")
 			if(wizard.spell_list.len>0)
 				text += "<br><B>[wizard.name] used the following spells: </B>"
 				var/i = 1

--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -27,7 +27,7 @@ GLOBAL_LIST_EMPTY(preferences_datums)
 	var/tmp/old_be_special = 0			//Bitflag version of be_special, used to update old savefiles and nothing more
 										//If it's 0, that's good, if it's anything but 0, the owner of this prefs file's antag choices were,
 										//autocorrected this round, not that you'd need to check that.
-
+	var/receive_solo_objectives = TRUE	//Whether or not a player will receive objectives as a solo antagonist
 
 	var/UI_style = "Midnight"
 	var/buttons_locked = FALSE
@@ -476,6 +476,7 @@ GLOBAL_LIST_EMPTY(preferences_datums)
 						dat += "<b>Be [capitalize(i)]:</b> <font color=red> \[IN [days_remaining] DAYS]</font><br>"
 					else
 						dat += "<b>Be [capitalize(i)]:</b> <a href='?_src_=prefs;preference=be_special;be_special_type=[i]'>[(i in be_special) ? "Yes" : "No"]</a><br>"
+			dat += "<b>Get Solo Objectives:</b> <a href='?_src_=prefs;preference=receive_solo_objectives'>[receive_solo_objectives ? "Yes" : "No"]</a><br>"
 
 			dat += "</td></tr></table>"
 
@@ -1189,6 +1190,9 @@ GLOBAL_LIST_EMPTY(preferences_datums)
 						be_special -= be_special_type
 					else
 						be_special += be_special_type
+
+				if("receive_solo_objectives")
+					receive_solo_objectives = !receive_solo_objectives
 
 				if("name")
 					be_random_name = !be_random_name

--- a/code/modules/client/preferences_savefile.dm
+++ b/code/modules/client/preferences_savefile.dm
@@ -140,6 +140,7 @@ SAVEFILE UPDATING/VERSIONING - 'Simplified', or rather, more coder-friendly ~Car
 	S["tgui_lock"]			>> tgui_lock
 	S["windowflash"]		>> windowflashing
 	S["be_special"] 		>> be_special
+	S["receive_solo_objectives"]	>>receive_solo_objectives
 
 
 	S["default_slot"]		>> default_slot
@@ -207,6 +208,7 @@ SAVEFILE UPDATING/VERSIONING - 'Simplified', or rather, more coder-friendly ~Car
 	WRITE_FILE(S["tgui_lock"], tgui_lock)
 	WRITE_FILE(S["windowflash"], windowflashing)
 	WRITE_FILE(S["be_special"], be_special)
+	WRITE_FILE(S["receive_solo_objectives"], receive_solo_objectives)
 	WRITE_FILE(S["default_slot"], default_slot)
 	WRITE_FILE(S["toggles"], toggles)
 	WRITE_FILE(S["chat_toggles"], chat_toggles)


### PR DESCRIPTION
:cl: Y0SH1_M4S73R
add: Adds a new preference, "Get Solo Objectives", that enables receiving objectives as a traitor, changeling, wizard, or ninja. This preference is enabled by default.
admin: Admins can still manually give objectives to antagonists with the "Get Solo Objectives" preference disabled.
tweak: Antagonists without objectives cannot receive greentext or redtext.
/:cl:

This PR is meant to make being an antagonist more enjoyable for people with excessively goal-oriented personalities (such as (and especially) myself; label this as "i ded" if you want). Such people may find that having an objective compels them to complete that objective, even if it would be more enjoyable to fuck around and be gimmicky. Furthermore, I feel that #32356 acts as an insult both to players that don't give a fuck and give too much of a fuck about their objectives. In the end, there should be no problem with a PR that allows players to enjoy the game more without making other players enjoy the game less, should there?