### PR TITLE
Secborg Rebalancing

### DIFF
--- a/code/game/objects/items/robot/robot_upgrades.dm
+++ b/code/game/objects/items/robot/robot_upgrades.dm
@@ -108,6 +108,7 @@
 		return
 
 	T.charge_delay = max(2 , T.charge_delay - 4)
+	ranged_cooldown_time = 0
 
 	return 1
 

--- a/code/game/objects/items/robot/robot_upgrades.dm
+++ b/code/game/objects/items/robot/robot_upgrades.dm
@@ -108,7 +108,7 @@
 		return
 
 	T.charge_delay = max(2 , T.charge_delay - 4)
-	T.semicd = 0
+	T.fire_delay = 0
 
 	return 1
 

--- a/code/game/objects/items/robot/robot_upgrades.dm
+++ b/code/game/objects/items/robot/robot_upgrades.dm
@@ -108,7 +108,7 @@
 		return
 
 	T.charge_delay = max(2 , T.charge_delay - 4)
-	ranged_cooldown_time = 0
+	T.semicd = 0
 
 	return 1
 

--- a/code/modules/mob/living/silicon/robot/robot_modules.dm
+++ b/code/modules/mob/living/silicon/robot/robot_modules.dm
@@ -330,7 +330,7 @@
 	basic_modules = list(
 		/obj/item/device/assembly/flash/cyborg,
 		/obj/item/restraints/handcuffs/cable/zipties/cyborg,
-		/obj/item/melee/baton/loaded,
+		/obj/item/melee/classic_baton/telescopic,
 		/obj/item/gun/energy/disabler/cyborg,
 		/obj/item/clothing/mask/gas/sechailer/cyborg)
 	emag_modules = list(/obj/item/gun/energy/laser/cyborg)

--- a/code/modules/projectiles/guns/energy/laser.dm
+++ b/code/modules/projectiles/guns/energy/laser.dm
@@ -55,6 +55,7 @@
 	desc = "An energy-based laser gun that draws power from the cyborg's internal energy cell directly. So this is what freedom looks like?"
 	origin_tech = null
 	use_cyborg_cell = 1
+	ranged_cooldown_time = 20
 
 /obj/item/gun/energy/laser/cyborg/emp_act()
 	return

--- a/code/modules/projectiles/guns/energy/laser.dm
+++ b/code/modules/projectiles/guns/energy/laser.dm
@@ -55,7 +55,7 @@
 	desc = "An energy-based laser gun that draws power from the cyborg's internal energy cell directly. So this is what freedom looks like?"
 	origin_tech = null
 	use_cyborg_cell = 1
-	fire_delay = 10
+	fire_delay = 50 ///Should be around the same as a swarmer
 
 /obj/item/gun/energy/laser/cyborg/emp_act()
 	return

--- a/code/modules/projectiles/guns/energy/laser.dm
+++ b/code/modules/projectiles/guns/energy/laser.dm
@@ -55,7 +55,7 @@
 	desc = "An energy-based laser gun that draws power from the cyborg's internal energy cell directly. So this is what freedom looks like?"
 	origin_tech = null
 	use_cyborg_cell = 1
-	ranged_cooldown_time = 20
+	semicd = 20
 
 /obj/item/gun/energy/laser/cyborg/emp_act()
 	return

--- a/code/modules/projectiles/guns/energy/laser.dm
+++ b/code/modules/projectiles/guns/energy/laser.dm
@@ -55,7 +55,7 @@
 	desc = "An energy-based laser gun that draws power from the cyborg's internal energy cell directly. So this is what freedom looks like?"
 	origin_tech = null
 	use_cyborg_cell = 1
-	semicd = 20
+	fire_delay = 10
 
 /obj/item/gun/energy/laser/cyborg/emp_act()
 	return

--- a/code/modules/projectiles/guns/energy/stun.dm
+++ b/code/modules/projectiles/guns/energy/stun.dm
@@ -47,5 +47,5 @@
 	desc = "An integrated disabler that draws from a cyborg's power cell. This weapon contains a limiter to prevent the cyborg's power cell from overheating."
 	can_charge = 0
 	use_cyborg_cell = 1
-	ranged_cooldown_time = 20
+	semicd = 20
 

--- a/code/modules/projectiles/guns/energy/stun.dm
+++ b/code/modules/projectiles/guns/energy/stun.dm
@@ -47,4 +47,5 @@
 	desc = "An integrated disabler that draws from a cyborg's power cell. This weapon contains a limiter to prevent the cyborg's power cell from overheating."
 	can_charge = 0
 	use_cyborg_cell = 1
+	ranged_cooldown_time = 20
 

--- a/code/modules/projectiles/guns/energy/stun.dm
+++ b/code/modules/projectiles/guns/energy/stun.dm
@@ -47,5 +47,5 @@
 	desc = "An integrated disabler that draws from a cyborg's power cell. This weapon contains a limiter to prevent the cyborg's power cell from overheating."
 	can_charge = 0
 	use_cyborg_cell = 1
-	semicd = 20
+	fire_delay = 10
 

--- a/code/modules/projectiles/guns/energy/stun.dm
+++ b/code/modules/projectiles/guns/energy/stun.dm
@@ -47,5 +47,5 @@
 	desc = "An integrated disabler that draws from a cyborg's power cell. This weapon contains a limiter to prevent the cyborg's power cell from overheating."
 	can_charge = 0
 	use_cyborg_cell = 1
-	fire_delay = 10
+	fire_delay = 50 //Should be around the same as a swarmer
 


### PR DESCRIPTION
[Changelogs]: Replaces the cyborg security module's stunbaton with a telebaton and halves the firing speed of the disabler and laser

:cl:
balance: Nanotrasen has decided to reduce their budget on the newly reinstated cyborg module. The module's disabler now fires half as fast and the baton has been replaced with a telescopic one. Rumours of laser functionality are, of course, false but if one _did_ exist it has been similarly reduced in speed.
/:cl:

[why]: I've been saying I'm gonna do this for over a year and I'm finally doing it. This isn't "i ded" so don't you put that tag on me I swear to God. 