### PR TITLE
Fixes some misuse of fully_replace_character_name

### DIFF
--- a/code/datums/components/spooky.dm
+++ b/code/datums/components/spooky.dm
@@ -57,4 +57,4 @@
 	var/t = stripped_input(H, "Enter your new skeleton name", H.real_name, null, MAX_NAME_LEN)
 	if(!t)
 		t = "spooky skeleton"
-	H.fully_replace_character_name(H.real_name, t)
+	H.fully_replace_character_name(null, t)

--- a/code/modules/awaymissions/mission_code/Academy.dm
+++ b/code/modules/awaymissions/mission_code/Academy.dm
@@ -139,7 +139,7 @@
 /obj/structure/academy_wizard_spawner/proc/summon_wizard()
 	var/turf/T = src.loc
 	var/mob/living/carbon/human/wizbody = new(T)
-	wizbody.fully_replace_character_name("Academy Teacher")
+	wizbody.fully_replace_character_name(wizbody.real_name, "Academy Teacher")
 	wizbody.mind_initialize()
 	var/datum/mind/wizmind = wizbody.mind
 	wizmind.special_role = "Academy Defender"


### PR DESCRIPTION
Academy Teacher didn't have a newname param, which means that it would just return instead of actually doing anything.

Skeletons were accidentally updating the player's PDA/record/ID name when their name changed (my b.)