### PR TITLE
Fixes VV not displaying false values in keyed lists

### DIFF
--- a/code/datums/datumvars.dm
+++ b/code/datums/datumvars.dm
@@ -53,7 +53,7 @@
 		return
 
 	var/title = ""
-	var/refid = "[REF(D)]"
+	var/refid = REF(D)
 	var/icon/sprite
 	var/hash
 
@@ -453,7 +453,7 @@
 				var/val
 				if (IS_NORMAL_LIST(L) && !isnum(key))
 					val = L[key]
-				if (!val)
+				if (isnull(val))	// we still want to display non-null false values, such as 0 or ""
 					val = key
 					key = i
 


### PR DESCRIPTION
Left: before, right: after.
![default](https://user-images.githubusercontent.com/3888532/32493431-da209698-c3ce-11e7-80be-4a4dba21f5d5.png)
It still doesn't display nulls, but that's intentional. There is no way to tell a key that was assigned null from a key that was never used.

The other change is removing unnecessary `"[]"`, `REF()` always returns a string anyway.