### PR TITLE
Makes action buttons use the overlay system

### DIFF
--- a/code/datums/action.dm
+++ b/code/datums/action.dm
@@ -152,13 +152,13 @@
 		..(current_button)
 	else if(target && current_button.appearance_cache != target.appearance) //replace with /ref comparison if this is not valid.
 		var/obj/item/I = target
-		current_button.appearance_cache = I.appearance
 		var/old_layer = I.layer
 		var/old_plane = I.plane
 		I.layer = FLOAT_LAYER //AAAH
 		I.plane = FLOAT_PLANE //^ what that guy said
 		current_button.cut_overlays()
 		current_button.add_overlay(I)
+		current_button.appearance_cache = I.appearance
 		I.layer = old_layer
 		I.plane = old_plane
 

--- a/code/datums/action.dm
+++ b/code/datums/action.dm
@@ -158,9 +158,9 @@
 		I.plane = FLOAT_PLANE //^ what that guy said
 		current_button.cut_overlays()
 		current_button.add_overlay(I)
-		current_button.appearance_cache = I.appearance
 		I.layer = old_layer
 		I.plane = old_plane
+		current_button.appearance_cache = I.appearance
 
 /datum/action/item_action/toggle_light
 	name = "Toggle Light"

--- a/code/datums/action.dm
+++ b/code/datums/action.dm
@@ -157,7 +157,8 @@
 		var/old_plane = I.plane
 		I.layer = FLOAT_LAYER //AAAH
 		I.plane = FLOAT_PLANE //^ what that guy said
-		current_button.overlays = list(I)
+		current_button.cut_overlays()
+		current_button.add_overlay(I)
 		I.layer = old_layer
 		I.plane = old_plane
 


### PR DESCRIPTION
There is a bug with all overlays that are based off of atoms that I'm about to fix, but this won't benefit from that if it's not using the overlay system