### PR TITLE
Fixes power_change being called on un-initialized machines

### DIFF
--- a/code/game/area/areas.dm
+++ b/code/game/area/areas.dm
@@ -120,8 +120,6 @@ GLOBAL_LIST_EMPTY(teleportlocs)
 
 	. = ..()
 
-	power_change()		// all machines set to current power level, also updates icon
-
 	blend_mode = BLEND_MULTIPLY // Putting this in the constructor so that it stops the icons being screwed up in the map editor.
 
 	if(!IS_DYNAMIC_LIGHTING(src))
@@ -142,6 +140,11 @@ GLOBAL_LIST_EMPTY(teleportlocs)
 		if(!areas_in_z["[z]"])
 			areas_in_z["[z]"] = list()
 		areas_in_z["[z]"] += src
+
+	return INITIALIZE_HINT_LATELOAD
+
+/area/LateInitialize()
+	power_change()		// all machines set to current power level, also updates icon
 
 /area/Destroy()
 	STOP_PROCESSING(SSobj, src)


### PR DESCRIPTION
Was causing a runtime for #32336 which starts or stops a soundloop created in initialize