### PR TITLE
Adds a config option to change world.sleep_offline

### DIFF
--- a/code/controllers/configuration/entries/config.dm
+++ b/code/controllers/configuration/entries/config.dm
@@ -372,3 +372,10 @@ CONFIG_TWEAK(number/mc_tick_rate/ValidateAndSet(str_val))
 	. = ..()
 	if (.)
 		Master.UpdateTickRate()
+
+CONFIG_DEF(flag/resume_after_initializations)
+
+CONFIG_TWEAK(flag/ValidateAndSet(str_val))
+	. = ..()
+	if(. && Master.current_run_level)
+		world.sleep_offline = !value

--- a/code/controllers/configuration/entries/config.dm
+++ b/code/controllers/configuration/entries/config.dm
@@ -377,5 +377,5 @@ CONFIG_DEF(flag/resume_after_initializations)
 
 CONFIG_TWEAK(flag/ValidateAndSet(str_val))
 	. = ..()
-	if(. && Master.current_run_level)
+	if(. && Master.current_runlevel)
 		world.sleep_offline = !value

--- a/code/controllers/master.dm
+++ b/code/controllers/master.dm
@@ -189,10 +189,12 @@ GLOBAL_REAL(Master, /datum/controller/master) = new
 	// Sort subsystems by display setting for easy access.
 	sortTim(subsystems, /proc/cmp_subsystem_display)
 	// Set world options.
-	world.sleep_offline = 1
+	world.sleep_offline = TRUE
 	world.fps = CONFIG_GET(number/fps)
 	var/initialized_tod = REALTIMEOFDAY
 	sleep(1)
+	if(CONFIG_GET(flag/resume_after_initializations))
+		world.sleep_offline = FALSE
 	initializations_finished_with_no_players_logged_in = initialized_tod < REALTIMEOFDAY - 10
 	// Loop.
 	Master.StartProcessing(0)

--- a/config/config.txt
+++ b/config/config.txt
@@ -388,3 +388,6 @@ HIGH_POP_MC_MODE_AMOUNT 65
 
 ##Disengage high pop mode if player count drops below this
 DISABLE_HIGH_POP_MC_MODE_AMOUNT 60
+
+## Uncomment to prevent the world from sleeping while no players are connected after initializations
+#RESUME_AFTER_INITIALIZATIONS


### PR DESCRIPTION
It will still enable it when initializations finish regardless of the setting. This applies to after that