### PR TITLE
isatom is now an alias for isloc

### DIFF
--- a/code/__DEFINES/is_helpers.dm
+++ b/code/__DEFINES/is_helpers.dm
@@ -8,7 +8,7 @@
 
 #define ismovableatom(A) (istype(A, /atom/movable))
 
-#define isatom(A) (istype(A, /atom))
+#define isatom(A) (isloc(A))
 
 //Turfs
 //#define isturf(A) (istype(A, /turf)) This is actually a byond built-in. Added here for completeness sake.


### PR DESCRIPTION
isloc() returns true on anything that can be a loc. Only atoms can be a loc. Its basically isatom, but with a odd ass name because byond.

It, like other builtin byond is* procs, uses typeid to check, not istype, saving the standard mess of recursive type searching that istype uses, thus its faster.
