### PR TITLE
removes pipe construction cache

### DIFF
--- a/code/controllers/subsystem/air.dm
+++ b/code/controllers/subsystem/air.dm
@@ -27,7 +27,7 @@ SUBSYSTEM_DEF(air)
 	var/list/hotspots = list()
 	var/list/networks = list()
 	var/list/obj/machinery/atmos_machinery = list()
-	var/list/pipe_construction_generation_cache = list()
+	var/list/pipe_init_dirs_cache = list()
 
 
 
@@ -377,19 +377,16 @@ SUBSYSTEM_DEF(air)
 		AM.build_network()
 		CHECK_TICK
 
-/datum/controller/subsystem/air/proc/get_pipe_cache(type, direction=NORTH)
-	if(!pipe_construction_generation_cache[type])
-		pipe_construction_generation_cache[type] = list()
+/datum/controller/subsystem/air/proc/get_init_dirs(type, dir)
+	if(!pipe_init_dirs_cache[type])
+		pipe_init_dirs_cache[type] = list()
 
-	if(!pipe_construction_generation_cache[type]["[direction]"])
-		var/obj/machinery/atmospherics/cached = new type(null, FALSE, direction)
-		pipe_construction_generation_cache[type]["[direction]"] = cached
-		STOP_PROCESSING(SSmachines, cached)
-		STOP_PROCESSING(SSfastprocess, cached)
-		GLOB.machines -= cached
+	if(!pipe_init_dirs_cache[type]["[dir]"])
+		var/obj/machinery/atmospherics/temp = new type(null, FALSE, dir)
+		pipe_init_dirs_cache[type]["[dir]"] = temp.GetInitDirections()
+		qdel(temp)
 
-	return pipe_construction_generation_cache[type]["[direction]"]
-
+	return pipe_init_dirs_cache[type]["[dir]"]
 
 #undef SSAIR_PIPENETS
 #undef SSAIR_ATMOSMACHINERY

--- a/code/game/machinery/pipe/construction.dm
+++ b/code/game/machinery/pipe/construction.dm
@@ -69,9 +69,9 @@ Buildable meters
 	return ..()
 
 /obj/item/pipe/proc/setPipingLayer(new_layer = PIPING_LAYER_DEFAULT)
-	var/obj/machinery/atmospherics/fakeA = SSair.get_pipe_cache(pipe_type)
+	var/obj/machinery/atmospherics/fakeA = pipe_type
 
-	if(fakeA.pipe_flags & PIPING_ALL_LAYER)
+	if(initial(fakeA.pipe_flags) & PIPING_ALL_LAYER)
 		new_layer = PIPING_LAYER_DEFAULT
 	piping_layer = new_layer
 
@@ -80,9 +80,9 @@ Buildable meters
 	layer = initial(layer) + ((piping_layer - PIPING_LAYER_DEFAULT) * PIPING_LAYER_LCHANGE)
 
 /obj/item/pipe/proc/update()
-	var/obj/machinery/atmospherics/A = SSair.get_pipe_cache(pipe_type)
-	name = "[A.name] fitting"
-	icon_state = A.pipe_state
+	var/obj/machinery/atmospherics/fakeA = pipe_type
+	name = "[initial(fakeA.name)] fitting"
+	icon_state = initial(fakeA.pipe_state)
 
 // rotate the pipe item clockwise
 
@@ -156,15 +156,15 @@ Buildable meters
 
 	fixdir()
 
-	var/obj/machinery/atmospherics/fakeA = SSair.get_pipe_cache(pipe_type, dir)
-
+	var/obj/machinery/atmospherics/fakeA = pipe_type
+	var/flags = initial(fakeA.pipe_flags)
 	for(var/obj/machinery/atmospherics/M in loc)
-		if((M.pipe_flags & fakeA.pipe_flags & PIPING_ONE_PER_TURF))	//Only one dense/requires density object per tile, eg connectors/cryo/heater/coolers.
+		if((M.pipe_flags & flags & PIPING_ONE_PER_TURF))	//Only one dense/requires density object per tile, eg connectors/cryo/heater/coolers.
 			to_chat(user, "<span class='warning'>Something is hogging the tile!</span>")
 			return TRUE
-		if((M.piping_layer != piping_layer) && !((M.pipe_flags | fakeA.pipe_flags) & PIPING_ALL_LAYER)) //don't continue if either pipe goes across all layers
+		if((M.piping_layer != piping_layer) && !((M.pipe_flags | flags) & PIPING_ALL_LAYER)) //don't continue if either pipe goes across all layers
 			continue
-		if(M.GetInitDirections() & fakeA.GetInitDirections())	// matches at least one direction on either type of pipe
+		if(M.GetInitDirections() & SSair.get_init_dirs(pipe_type, dir))	// matches at least one direction on either type of pipe
 			to_chat(user, "<span class='warning'>There is already a pipe at that location!</span>")
 			return TRUE
 	// no conflicts found

--- a/code/game/objects/items/RPD.dm
+++ b/code/game/objects/items/RPD.dm
@@ -580,10 +580,8 @@ GLOBAL_LIST_INIT(RPD_recipes, list(
 			if(do_after(user, 2, target = A))
 				activate()
 
-				var/pipe_item_type = /obj/item/pipe
-				var/obj/machinery/atmospherics/cached_pipe = SSair.get_pipe_cache(queued_p_type)
-				if(istype(cached_pipe) && cached_pipe.construction_type)
-					pipe_item_type = cached_pipe.construction_type
+				var/obj/machinery/atmospherics/path = queued_p_type
+				var/pipe_item_type = initial(path.construction_type) || /obj/item/pipe
 
 				var/obj/item/pipe/P = new pipe_item_type(A, queued_p_type, queued_p_dir)
 


### PR DESCRIPTION
replaces it with `initial()` on typepaths and a cache of init_dirs for a given pipe/direction pair