### PR TITLE
Removes R&D chem dispensers

### DIFF
--- a/code/modules/research/designs/machine_designs.dm
+++ b/code/modules/research/designs/machine_designs.dm
@@ -130,14 +130,6 @@
 	build_path = /obj/item/circuitboard/machine/cryo_tube
 	category = list ("Medical Machinery")
 
-/datum/design/board/chem_dispenser
-	name = "Machine Design (Portable Chem Dispenser Board)"
-	desc = "The circuit board for a portable chem dispenser."
-	id = "chem_dispenser"
-	req_tech = list("programming" = 5, "biotech" = 3, "materials" = 4, "plasmatech" = 4)
-	build_path = /obj/item/circuitboard/machine/chem_dispenser
-	category = list ("Medical Machinery")
-
 /datum/design/board/chem_master
 	name = "Machine Design (Chem Master Board)"
 	desc = "The circuit board for a Chem Master 3000."


### PR DESCRIPTION
1. R&D already makes all the guns, all the armor, all the mechas, all the simple_mob armies, and all the bombs
2. they dont need to make all the chemicals too, we have a department for that

"m-muh sulphuric"
go to chemistry
"b-but it needs upgrades"
repeat after me:
👏 time 👏 gates 👏 aren't 👏 balance 👏 
