### PR TITLE
Xrays go through walls but stop on mobs/blob

### DIFF
--- a/code/__DEFINES/flags.dm
+++ b/code/__DEFINES/flags.dm
@@ -74,7 +74,8 @@ GLOBAL_LIST_INIT(bitflags, list(1, 2, 4, 8, 16, 32, 64, 128, 256, 512, 1024, 204
 #define PASSGRILLE		4
 #define PASSBLOB		8
 #define PASSMOB			16
-#define LETPASSTHROW	32
+#define PASSCLOSEDTURF		32
+#define LETPASSTHROW	64
 
 
 //Movement Types

--- a/code/game/turfs/closed.dm
+++ b/code/game/turfs/closed.dm
@@ -15,6 +15,12 @@
 /turf/closed/get_smooth_underlay_icon(mutable_appearance/underlay_appearance, turf/asking_turf, adjacency_dir)
 	return FALSE
 
+/turf/closed/CanPass(atom/movable/mover, turf/target)
+	if(istype(mover) && mover.checkpass(PASSCLOSEDTURF))
+		return TRUE
+	else
+		..()
+
 /turf/closed/indestructible
 	name = "wall"
 	icon = 'icons/turf/walls.dmi'

--- a/code/modules/projectiles/projectile/beams.dm
+++ b/code/modules/projectiles/projectile/beams.dm
@@ -50,7 +50,8 @@
 	damage = 15
 	irradiate = 30
 	range = 15
-	forcedodge = 1
+	pass_flags = PASSTABLE | PASSGLASS | PASSGRILLE | PASSCLOSEDTURF
+
 	impact_effect_type = /obj/effect/temp_visual/impact_effect/green_laser
 	light_color = LIGHT_COLOR_GREEN
 


### PR DESCRIPTION
Why: Because the Xray gun (in some movies/games they function similarly as magrails or rail guns) is a classical Sci-Fi weapon and perhaps one of the items that have made sense to throw under the science RND. Improve, don't Remove haha!

:cl: Cobby
add: The Xray now only hits the first mob it comes into contact with instead of being outright removed from the game.
/:cl:

closes #32534

This also applies to blob tiles, so you cannot use the green gun to GG a well defended blob.