### PR TITLE
Prevent placing posters on diagonal wall corners

### DIFF
--- a/code/__HELPERS/icon_smoothing.dm
+++ b/code/__HELPERS/icon_smoothing.dm
@@ -179,6 +179,10 @@
 				underlay_appearance.icon_state = DEFAULT_UNDERLAY_ICON_STATE
 		underlays = U
 
+		// Drop posters which were previously placed on this wall.
+		for(var/obj/structure/sign/poster/P in src)
+			P.roll_and_drop(src)
+
 
 /proc/cardinal_smooth(atom/A, adjacencies)
 	//NW CORNER

--- a/code/game/objects/effects/contraband.dm
+++ b/code/game/objects/effects/contraband.dm
@@ -121,6 +121,13 @@
 		to_chat(user, "<span class='warning'>[P] has no poster... inside it? Inform a coder!</span>")
 		return
 
+	// Deny placing posters on currently-diagonal walls, although the wall may change in the future.
+	if (smooth & SMOOTH_DIAGONAL)
+		for (var/O in our_overlays)
+			var/image/I = O
+			if (copytext(I.icon_state, 1, 3) == "d-")
+				return
+
 	var/stuff_on_wall = 0
 	for(var/obj/O in contents) //Let's see if it already has a poster on it or too much stuff
 		if(istype(O, /obj/structure/sign/poster))


### PR DESCRIPTION
:cl:
fix: Posters may no longer be placed on diagonal wall corners.
/:cl:

Fixes #21666. Kind of a hack, maybe? But it does prevent the most common problem of actually placing the poster on a currently-diagonally-smoothed wall.
