### PR TITLE
Makes false alarm use more explicit in event code.

### DIFF
--- a/code/modules/events/_event.dm
+++ b/code/modules/events/_event.dm
@@ -108,11 +108,12 @@
 	var/datum/round_event_control/control
 
 	var/startWhen		= 0	//When in the lifetime to call start().
-	var/announceWhen	= 0	//When in the lifetime to call announce(). Set an event's announceWhen to >0 if there is an announcement.
+	var/announceWhen	= 0	//When in the lifetime to call announce(). Set an event's announceWhen to -1 if announcement should not be shown.
 	var/endWhen			= 0	//When in the lifetime the event should end.
 
 	var/activeFor		= 0	//How long the event has existed. You don't need to change this.
 	var/current_players	= 0 //Amount of of alive, non-AFK human players on server at the time of event start
+	var/fakeable = TRUE		//Can be faked by fake news event.
 
 //Called first before processing.
 //Allows you to setup your event, such as randomly
@@ -133,7 +134,7 @@
 //Called when the tick is equal to the announceWhen variable.
 //Allows you to announce before starting or vice versa.
 //Only called once.
-/datum/round_event/proc/announce()
+/datum/round_event/proc/announce(fake)
 	return
 
 //Called on or after the tick counter is equal to startWhen.
@@ -167,7 +168,7 @@
 
 	if(activeFor == announceWhen)
 		processing = FALSE
-		announce()
+		announce(FALSE)
 		processing = TRUE
 
 	if(startWhen < activeFor && activeFor < endWhen)

--- a/code/modules/events/abductor.dm
+++ b/code/modules/events/abductor.dm
@@ -9,6 +9,7 @@
 /datum/round_event/ghost_role/abductor
 	minimum_required = 2
 	role_name = "abductor team"
+	fakeable = FALSE //Nothing to fake here
 
 /datum/round_event/ghost_role/abductor/spawn_role()
 	var/list/mob/dead/observer/candidates = get_candidates("abductor", null, ROLE_ABDUCTOR)

--- a/code/modules/events/alien_infestation.dm
+++ b/code/modules/events/alien_infestation.dm
@@ -29,8 +29,8 @@
 		control.occurrences--
 	return ..()
 
-/datum/round_event/ghost_role/alien_infestation/announce()
-	if(successSpawn)
+/datum/round_event/ghost_role/alien_infestation/announce(fake)
+	if(successSpawn || fake)
 		priority_announce("Unidentified lifesigns detected coming aboard [station_name()]. Secure any exterior access, including ducting and ventilation.", "Lifesign Alert", 'sound/ai/aliens.ogg')
 
 

--- a/code/modules/events/anomaly.dm
+++ b/code/modules/events/anomaly.dm
@@ -24,7 +24,7 @@
 	if(!turf_test.len)
 		setup(safety_loop)
 
-/datum/round_event/anomaly/announce()
+/datum/round_event/anomaly/announce(fake)
 	priority_announce("Localized energetic flux wave detected on long range scanners. Expected location of impact: [impact_area.name].", "Anomaly Alert")
 
 /datum/round_event/anomaly/start()

--- a/code/modules/events/anomaly_bluespace.dm
+++ b/code/modules/events/anomaly_bluespace.dm
@@ -9,7 +9,7 @@
 	announceWhen = 10
 
 
-/datum/round_event/anomaly/anomaly_bluespace/announce()
+/datum/round_event/anomaly/anomaly_bluespace/announce(fake)
 	priority_announce("Unstable bluespace anomaly detected on long range scanners. Expected location: [impact_area.name].", "Anomaly Alert")
 
 

--- a/code/modules/events/anomaly_flux.dm
+++ b/code/modules/events/anomaly_flux.dm
@@ -10,7 +10,7 @@
 	startWhen = 10
 	announceWhen = 3
 
-/datum/round_event/anomaly/anomaly_flux/announce()
+/datum/round_event/anomaly/anomaly_flux/announce(fake)
 	priority_announce("Localized hyper-energetic flux wave detected on long range scanners. Expected location: [impact_area.name].", "Anomaly Alert")
 
 

--- a/code/modules/events/anomaly_grav.dm
+++ b/code/modules/events/anomaly_grav.dm
@@ -8,7 +8,7 @@
 	startWhen = 3
 	announceWhen = 20
 
-/datum/round_event/anomaly/anomaly_grav/announce()
+/datum/round_event/anomaly/anomaly_grav/announce(fake)
 	priority_announce("Gravitational anomaly detected on long range scanners. Expected location: [impact_area.name].", "Anomaly Alert")
 
 /datum/round_event/anomaly/anomaly_grav/start()

--- a/code/modules/events/anomaly_pyro.dm
+++ b/code/modules/events/anomaly_pyro.dm
@@ -8,7 +8,7 @@
 	startWhen = 3
 	announceWhen = 10
 
-/datum/round_event/anomaly/anomaly_pyro/announce()
+/datum/round_event/anomaly/anomaly_pyro/announce(fake)
 	priority_announce("Pyroclastic anomaly detected on long range scanners. Expected location: [impact_area.name].", "Anomaly Alert")
 
 /datum/round_event/anomaly/anomaly_pyro/start()

--- a/code/modules/events/anomaly_vortex.dm
+++ b/code/modules/events/anomaly_vortex.dm
@@ -10,7 +10,7 @@
 	startWhen = 10
 	announceWhen = 3
 
-/datum/round_event/anomaly/anomaly_vortex/announce()
+/datum/round_event/anomaly/anomaly_vortex/announce(fake)
 	priority_announce("Localized high-intensity vortex anomaly detected on long range scanners. Expected location: [impact_area.name]", "Anomaly Alert")
 
 /datum/round_event/anomaly/anomaly_vortex/start()

--- a/code/modules/events/blob.dm
+++ b/code/modules/events/blob.dm
@@ -12,7 +12,7 @@
 	announceWhen	= -1
 	role_name = "blob overmind"
 
-/datum/round_event/ghost_role/blob/announce()
+/datum/round_event/ghost_role/blob/announce(fake)
 	priority_announce("Confirmed outbreak of level 5 biohazard aboard [station_name()]. All personnel must contain the outbreak.", "Biohazard Alert", 'sound/ai/outbreak5.ogg')
 
 /datum/round_event/ghost_role/blob/spawn_role()

--- a/code/modules/events/brand_intelligence.dm
+++ b/code/modules/events/brand_intelligence.dm
@@ -21,9 +21,14 @@
 									 "You don't want to buy anything? Yeah, well, I didn't want to buy your mom either.")
 
 
-/datum/round_event/brand_intelligence/announce()
-	priority_announce("Rampant brand intelligence has been detected aboard [station_name()]. Please stand by. The origin is believed to be \a [originMachine.name].", "Machine Learning Alert")
-
+/datum/round_event/brand_intelligence/announce(fake)
+	var/source = "unknown machine"
+	if(fake)
+		var/obj/machinery/vending/cola/example = /obj/machinery/vending/cola
+		source = initial(example.name)
+	else if(originMachine)
+		source = originMachine.name
+	priority_announce("Rampant brand intelligence has been detected aboard [station_name()]. Please stand by. The origin is believed to be \a [source].", "Machine Learning Alert")
 
 /datum/round_event/brand_intelligence/start()
 	for(var/obj/machinery/vending/V in GLOB.machines)

--- a/code/modules/events/camerafailure.dm
+++ b/code/modules/events/camerafailure.dm
@@ -8,7 +8,7 @@
 /datum/round_event/camera_failure
 	startWhen = 1
 	endWhen = 2
-	announceWhen = 0
+	fakeable = FALSE
 
 /datum/round_event/camera_failure/tick()
 	var/iterations = 1

--- a/code/modules/events/carp_migration.dm
+++ b/code/modules/events/carp_migration.dm
@@ -13,7 +13,7 @@
 /datum/round_event/carp_migration/setup()
 	startWhen = rand(40, 60)
 
-/datum/round_event/carp_migration/announce()
+/datum/round_event/carp_migration/announce(fake)
 	priority_announce("Unknown biological entities have been detected near [station_name()], please stand-by.", "Lifesign Alert")
 
 

--- a/code/modules/events/communications_blackout.dm
+++ b/code/modules/events/communications_blackout.dm
@@ -6,7 +6,7 @@
 /datum/round_event/communications_blackout
 	announceWhen	= 1
 
-/datum/round_event/communications_blackout/announce()
+/datum/round_event/communications_blackout/announce(fake)
 	var/alert = pick(	"Ionospheric anomalies detected. Temporary telecommunication failure imminent. Please contact you*%fj00)`5vc-BZZT", \
 						"Ionospheric anomalies detected. Temporary telecommunication failu*3mga;b4;'1v�-BZZZT", \
 						"Ionospheric anomalies detected. Temporary telec#MCi46:5.;@63-BZZZZT", \
@@ -17,7 +17,7 @@
 	for(var/mob/living/silicon/ai/A in GLOB.ai_list)	//AIs are always aware of communication blackouts.
 		to_chat(A, "<br><span class='warning'><b>[alert]</b></span><br>")
 
-	if(prob(30))	//most of the time, we don't want an announcement, so as to allow AIs to fake blackouts.
+	if(prob(30) || fake)	//most of the time, we don't want an announcement, so as to allow AIs to fake blackouts.
 		priority_announce(alert)
 
 

--- a/code/modules/events/devil.dm
+++ b/code/modules/events/devil.dm
@@ -6,6 +6,7 @@
 /datum/round_event/ghost_role/devil
 	var/success_spawn = 0
 	role_name = "devil"
+	fakeable = FALSE
 
 /datum/round_event/ghost_role/devil/kill()
 	if(!success_spawn && control)

--- a/code/modules/events/disease_outbreak.dm
+++ b/code/modules/events/disease_outbreak.dm
@@ -13,7 +13,7 @@
 	var/max_severity = 3
 
 
-/datum/round_event/disease_outbreak/announce()
+/datum/round_event/disease_outbreak/announce(fake)
 	priority_announce("Confirmed outbreak of level 7 viral biohazard aboard [station_name()]. All personnel must contain the outbreak.", "Biohazard Alert", 'sound/ai/outbreak7.ogg')
 
 /datum/round_event/disease_outbreak/setup()

--- a/code/modules/events/dust.dm
+++ b/code/modules/events/dust.dm
@@ -9,7 +9,7 @@
 /datum/round_event/space_dust
 	startWhen		= 1
 	endWhen			= 2
-	announceWhen	= 0
+	fakeable = FALSE
 
 /datum/round_event/space_dust/start()
 	spawn_meteors(1, GLOB.meteorsC)
@@ -25,6 +25,7 @@
 	startWhen = 1
 	endWhen = 150 // ~5 min
 	announceWhen = 0
+	fakeable = FALSE
 
 /datum/round_event/sandstorm/tick()
 	spawn_meteors(10, GLOB.meteorsC)

--- a/code/modules/events/electrical_storm.dm
+++ b/code/modules/events/electrical_storm.dm
@@ -11,7 +11,7 @@
 	var/lightsoutRange	= 25
 	announceWhen	= 1
 
-/datum/round_event/electrical_storm/announce()
+/datum/round_event/electrical_storm/announce(fake)
 	priority_announce("An electrical storm has been detected in your area, please repair potential electronic overloads.", "Electrical Storm Alert")
 
 

--- a/code/modules/events/false_alarm.dm
+++ b/code/modules/events/false_alarm.dm
@@ -13,10 +13,8 @@
 	var/list/possible_types = list()
 
 	for(var/datum/round_event_control/E in SSevents.control)
-		if(istype(E, /datum/round_event_control/falsealarm))
-			continue
 		var/datum/round_event/event = E.typepath
-		if(initial(event.announceWhen) <= 0)
+		if(!initial(event.fakeable))
 			continue
 		possible_types += E
 	
@@ -28,8 +26,11 @@
 /datum/round_event/falsealarm
 	announceWhen	= 0
 	endWhen			= 1
+	fakeable = FALSE
 
-/datum/round_event/falsealarm/announce()
+/datum/round_event/falsealarm/announce(fake)
+	if(fake) //What are you doing
+		return
 	var/players_amt = get_active_player_count(alive_check = 1, afk_check = 1, human_check = 1)
 	var/gamemode = SSticker.mode.config_tag
 
@@ -56,6 +57,6 @@
 			continue
 
 		var/datum/round_event/event = E.typepath
-		if(initial(event.announceWhen) <= 0)
+		if(!initial(event.fakeable))
 			continue
 		. += E

--- a/code/modules/events/false_alarm.dm
+++ b/code/modules/events/false_alarm.dm
@@ -46,7 +46,7 @@
 		var/datum/round_event/Event = new event_control.typepath()
 		message_admins("False Alarm: [Event]")
 		Event.kill() 		//do not process this event - no starts, no ticks, no ends
-		Event.announce() 	//just announce it like it's happening
+		Event.announce(TRUE) 	//just announce it like it's happening
 
 /proc/gather_false_events(players_amt, gamemode)
 	. = list()

--- a/code/modules/events/grid_check.dm
+++ b/code/modules/events/grid_check.dm
@@ -8,7 +8,7 @@
 	announceWhen	= 1
 	startWhen = 1
 
-/datum/round_event/grid_check/announce()
+/datum/round_event/grid_check/announce(fake)
 	priority_announce("Abnormal activity detected in [station_name()]'s powernet. As a precautionary measure, the station's power will be shut off for an indeterminate duration.", "Critical Power Failure", 'sound/ai/poweroff.ogg')
 
 

--- a/code/modules/events/holiday/friday13th.dm
+++ b/code/modules/events/holiday/friday13th.dm
@@ -13,6 +13,6 @@
 	events.frequency_lower /= 2
 	events.frequency_upper /= 2
 
-/datum/round_event/fridaythethirteen/announce()
+/datum/round_event/fridaythethirteen/announce(fake)
 	for(var/mob/living/L in player_list)
 		to_chat(L, "<span class='warning'>You are feeling unlucky today.</span>")

--- a/code/modules/events/holiday/halloween.dm
+++ b/code/modules/events/holiday/halloween.dm
@@ -19,7 +19,7 @@
 		new /mob/living/simple_animal/parrot/Poly/ghost(Poly.loc)
 		qdel(Poly)
 
-/datum/round_event/spooky/announce()
+/datum/round_event/spooky/announce(fake)
 	priority_announce(pick("RATTLE ME BONES!","THE RIDE NEVER ENDS!", "A SKELETON POPS OUT!", "SPOOKY SCARY SKELETONS!", "CREWMEMBERS BEWARE, YOU'RE IN FOR A SCARE!") , "THE CALL IS COMING FROM INSIDE THE HOUSE")
 
 //spooky foods (you can't actually make these when it's not halloween)

--- a/code/modules/events/holiday/vday.dm
+++ b/code/modules/events/holiday/vday.dm
@@ -61,7 +61,7 @@
 	to_chat(lover, "<span class='warning'><B>You're on a date with [date]! Protect them at all costs. This takes priority over all other loyalties.</B></span>")
 
 
-/datum/round_event/valentines/announce()
+/datum/round_event/valentines/announce(fake)
 	priority_announce("It's Valentine's Day! Give a valentine to that special someone!")
 
 /obj/item/valentine

--- a/code/modules/events/holiday/xmas.dm
+++ b/code/modules/events/holiday/xmas.dm
@@ -35,7 +35,7 @@
 	for(var/obj/machinery/computer/security/telescreen/entertainment/Monitor in GLOB.machines)
 		Monitor.icon_state = "entertainment_xmas"
 
-/datum/round_event/presents/announce()
+/datum/round_event/presents/announce(fake)
 	priority_announce("Ho Ho Ho, Merry Xmas!", "Unknown Transmission")
 
 
@@ -105,7 +105,7 @@
 /datum/round_event/santa
 	var/mob/living/carbon/human/santa //who is our santa?
 
-/datum/round_event/santa/announce()
+/datum/round_event/santa/announce(fake)
 	priority_announce("Santa is coming to town!", "Unknown Transmission")
 
 /datum/round_event/santa/start()

--- a/code/modules/events/immovable_rod.dm
+++ b/code/modules/events/immovable_rod.dm
@@ -16,7 +16,7 @@ In my current plan for it, 'solid' will be defined as anything with density == 1
 /datum/round_event/immovable_rod
 	announceWhen = 5
 
-/datum/round_event/immovable_rod/announce()
+/datum/round_event/immovable_rod/announce(fake)
 	priority_announce("What the fuck was that?!", "General Alert")
 
 /datum/round_event/immovable_rod/start()

--- a/code/modules/events/ion_storm.dm
+++ b/code/modules/events/ion_storm.dm
@@ -25,8 +25,8 @@
 	shuffleLawsChance = 0
 	botEmagChance = 0
 
-/datum/round_event/ion_storm/announce()
-	if(announceEvent == ION_ANNOUNCE || (announceEvent == ION_RANDOM && prob(ionAnnounceChance)))
+/datum/round_event/ion_storm/announce(fake)
+	if(announceEvent == ION_ANNOUNCE || (announceEvent == ION_RANDOM && prob(ionAnnounceChance)) || fake)
 		priority_announce("Ion storm detected near the station. Please check all AI-controlled equipment for errors.", "Anomaly Alert", 'sound/ai/ionstorm.ogg')
 
 

--- a/code/modules/events/major_dust.dm
+++ b/code/modules/events/major_dust.dm
@@ -6,7 +6,7 @@
 /datum/round_event/meteor_wave/major_dust
 	wave_name = "space dust"
 
-/datum/round_event/meteor_wave/major_dust/announce()
+/datum/round_event/meteor_wave/major_dust/announce(fake)
 	var/reason = pick(
 		"The station is passing through a debris cloud, expect minor damage \
 		to external fittings and fixtures.",

--- a/code/modules/events/mass_hallucination.dm
+++ b/code/modules/events/mass_hallucination.dm
@@ -5,6 +5,9 @@
 	max_occurrences = 2
 	min_players = 1
 
+/datum/round_event/mass_hallucination
+	fakeable = FALSE
+
 /datum/round_event/mass_hallucination/start()
 	for(var/mob/living/carbon/C in GLOB.living_mob_list)
 		C.hallucination += rand(20, 50)

--- a/code/modules/events/meateor_wave.dm
+++ b/code/modules/events/meateor_wave.dm
@@ -7,5 +7,5 @@
 /datum/round_event/meteor_wave/meaty
 	wave_name = "meaty"
 
-/datum/round_event/meteor_wave/meaty/announce()
+/datum/round_event/meteor_wave/meaty/announce(fake)
 	priority_announce("Meaty ores have been detected on collision course with the station.", "Oh crap, get the mop.",'sound/ai/meteors.ogg')

--- a/code/modules/events/meteor_wave.dm
+++ b/code/modules/events/meteor_wave.dm
@@ -45,7 +45,7 @@
 			WARNING("Wave name of [wave_name] not recognised.")
 			kill()
 
-/datum/round_event/meteor_wave/announce()
+/datum/round_event/meteor_wave/announce(fake)
 	priority_announce("Meteors have been detected on collision course with the station.", "Meteor Alert", 'sound/ai/meteors.ogg')
 
 /datum/round_event/meteor_wave/tick()

--- a/code/modules/events/mice_migration.dm
+++ b/code/modules/events/mice_migration.dm
@@ -4,11 +4,10 @@
 	weight = 10
 
 /datum/round_event/mice_migration
-	announceWhen = 0
 	var/minimum_mice = 5
 	var/maximum_mice = 15
 
-/datum/round_event/mice_migration/announce()
+/datum/round_event/mice_migration/announce(fake)
 	var/cause = pick("space-winter", "budget-cuts", "Ragnarok",
 		"space being cold", "\[REDACTED\]", "climate change",
 		"bad luck")

--- a/code/modules/events/nightmare.dm
+++ b/code/modules/events/nightmare.dm
@@ -7,6 +7,7 @@
 /datum/round_event/ghost_role/nightmare
 	minimum_required = 1
 	role_name = "nightmare"
+	fakeable = FALSE
 
 /datum/round_event/ghost_role/nightmare/spawn_role()
 	var/list/candidates = get_candidates("alien", null, ROLE_ALIEN)

--- a/code/modules/events/operative.dm
+++ b/code/modules/events/operative.dm
@@ -7,6 +7,7 @@
 /datum/round_event/ghost_role/operative
 	minimum_required = 1
 	role_name = "lone operative"
+	fakeable = FALSE
 
 /datum/round_event/ghost_role/operative/spawn_role()
 	var/list/candidates = get_candidates("operative", null, ROLE_OPERATIVE)

--- a/code/modules/events/portal_storm.dm
+++ b/code/modules/events/portal_storm.dm
@@ -66,7 +66,7 @@
 
 	next_boss_spawn = startWhen + Ceiling(2 * number_of_hostiles / number_of_bosses)
 
-/datum/round_event/portal_storm/announce()
+/datum/round_event/portal_storm/announce(fake)
 	set waitfor = 0
 	sound_to_playing_players('sound/magic/lightning_chargeup.ogg')
 	sleep(80)

--- a/code/modules/events/prison_break.dm
+++ b/code/modules/events/prison_break.dm
@@ -28,7 +28,7 @@
 				areasToOpen += A
 
 
-/datum/round_event/grey_tide/announce()
+/datum/round_event/grey_tide/announce(fake)
 	if(areasToOpen && areasToOpen.len > 0)
 		priority_announce("Gr3y.T1d3 virus detected in [station_name()] door subroutines. Severity level of [severity]. Recommend station AI involvement.", "Security Alert")
 	else

--- a/code/modules/events/processor_overload.dm
+++ b/code/modules/events/processor_overload.dm
@@ -7,7 +7,7 @@
 /datum/round_event/processor_overload
 	announceWhen	= 1
 
-/datum/round_event/processor_overload/announce()
+/datum/round_event/processor_overload/announce(fake)
 	var/alert = pick(	"Exospheric bubble inbound. Processor overload is likely. Please contact you*%xp25)`6cq-BZZT", \
 						"Exospheric bubble inbound. Processor overload is likel*1eta;c5;'1v¬-BZZZT", \
 						"Exospheric bubble inbound. Processor ov#MCi46:5.;@63-BZZZZT", \
@@ -22,7 +22,7 @@
 	// Announce most of the time, but leave a little gap so people don't know
 	// whether it's, say, a tesla zapping tcomms, or some selective
 	// modification of the tcomms bus
-	if(prob(80))
+	if(prob(80) || fake)
 		priority_announce(alert)
 
 

--- a/code/modules/events/radiation_storm.dm
+++ b/code/modules/events/radiation_storm.dm
@@ -11,7 +11,7 @@
 	endWhen = startWhen + 1
 	announceWhen	= 1
 
-/datum/round_event/radiation_storm/announce()
+/datum/round_event/radiation_storm/announce(fake)
 	priority_announce("High levels of radiation detected near the station. Maintenance is best shielded from radiation.", "Anomaly Alert", 'sound/ai/radiation.ogg')
 	//sound not longer matches the text, but an audible warning is probably good
 

--- a/code/modules/events/sentience.dm
+++ b/code/modules/events/sentience.dm
@@ -10,8 +10,8 @@
 	var/animals = 1
 	var/one = "one"
 
-/datum/round_event/ghost_role/sentience/start()
-	var/sentience_report = "<font size=3><b>[command_name()] Medium-Priority Update</b></font>"
+/datum/round_event/ghost_role/sentience/announce(fake)
+	var/sentience_report = ""
 
 	var/data = pick("scans from our long-range sensors", "our sophisticated probabilistic models", "our omnipotence", "the communications traffic on your station", "energy emissions we detected", "\[REDACTED\]")
 	var/pets = pick("animals/bots", "bots/animals", "pets", "simple animals", "lesser lifeforms", "\[REDACTED\]")
@@ -19,8 +19,7 @@
 
 	sentience_report += "<br><br>Based on [data], we believe that [one] of the station's [pets] has developed [strength] level intelligence, and the ability to communicate."
 
-	print_command_report(text=sentience_report)
-	..()
+	priority_announce(sentience_report,"[command_name()] Medium-Priority Update")
 
 /datum/round_event/ghost_role/sentience/spawn_role()
 	var/list/mob/dead/observer/candidates

--- a/code/modules/events/shuttle_loan.dm
+++ b/code/modules/events/shuttle_loan.dm
@@ -20,10 +20,10 @@
 	var/bonus_points = 10000
 	var/thanks_msg = "The cargo shuttle should return in five minutes. Have some supply points for your trouble."
 
-/datum/round_event/shuttle_loan/start()
+/datum/round_event/shuttle_loan/setup()
 	dispatch_type = pick(HIJACK_SYNDIE, RUSKY_PARTY, SPIDER_GIFT, DEPARTMENT_RESUPPLY, ANTIDOTE_NEEDED, PIZZA_DELIVERY)
 
-/datum/round_event/shuttle_loan/announce()
+/datum/round_event/shuttle_loan/announce(fake)
 	SSshuttle.shuttle_loan = src
 	switch(dispatch_type)
 		if(HIJACK_SYNDIE)

--- a/code/modules/events/spacevine.dm
+++ b/code/modules/events/spacevine.dm
@@ -5,6 +5,9 @@
 	max_occurrences = 3
 	min_players = 10
 
+/datum/round_event/spacevine
+	fakeable = FALSE
+
 /datum/round_event/spacevine/start()
 	var/list/turfs = list() //list of all the empty floor turfs in the hallway areas
 

--- a/code/modules/events/spider_infestation.dm
+++ b/code/modules/events/spider_infestation.dm
@@ -15,7 +15,7 @@
 	announceWhen = rand(announceWhen, announceWhen + 50)
 	spawncount = rand(5, 8)
 
-/datum/round_event/spider_infestation/announce()
+/datum/round_event/spider_infestation/announce(fake)
 	priority_announce("Unidentified lifesigns detected coming aboard [station_name()]. Secure any exterior access, including ducting and ventilation.", "Lifesign Alert", 'sound/ai/aliens.ogg')
 
 

--- a/code/modules/events/spontaneous_appendicitis.dm
+++ b/code/modules/events/spontaneous_appendicitis.dm
@@ -6,6 +6,9 @@
 	earliest_start = 6000
 	min_players = 5 // To make your chance of getting help a bit higher.
 
+/datum/round_event/spontaneous_appendicitis
+	fakeable = FALSE
+
 /datum/round_event/spontaneous_appendicitis/start()
 	for(var/mob/living/carbon/human/H in shuffle(GLOB.living_mob_list))
 		if(!H.client)

--- a/code/modules/events/vent_clog.dm
+++ b/code/modules/events/vent_clog.dm
@@ -12,7 +12,7 @@
 	var/list/gunk = list("water","carbon","flour","radium","toxin","cleaner","nutriment","condensedcapsaicin","mushroomhallucinogen","lube",
 								 "plantbgone","banana","charcoal","space_drugs","morphine","holywater","ethanol","hot_coco","sacid")
 
-/datum/round_event/vent_clog/announce()
+/datum/round_event/vent_clog/announce(fake)
 	priority_announce("The scrubbers network is experiencing a backpressure surge. Some ejection of contents may occur.", "Atmospherics alert")
 
 

--- a/code/modules/events/weightless.dm
+++ b/code/modules/events/weightless.dm
@@ -12,7 +12,7 @@
 	startWhen = rand(0,10)
 	endWhen = rand(40,80)
 
-/datum/round_event/weightless/announce()
+/datum/round_event/weightless/announce(fake)
 	command_alert("Warning: Failsafes for the station's artificial gravity arrays have been triggered. Please be aware that if this problem recurs it may result in formation of gravitational anomalies. Nanotrasen wishes to remind you that the unauthorised formation of anomalies within Nanotrasen facilities is strictly prohibited by health and safety regulation [rand(99,9999)][pick("a","b","c")]:subclause[rand(1,20)][pick("a","b","c")].")
 
 /datum/round_event/weightless/start()

--- a/code/modules/events/wizard/magicarp.dm
+++ b/code/modules/events/wizard/magicarp.dm
@@ -12,7 +12,7 @@
 /datum/round_event/wizard/magicarp/setup()
 	startWhen = rand(40, 60)
 
-/datum/round_event/wizard/magicarp/announce()
+/datum/round_event/wizard/magicarp/announce(fake)
 	priority_announce("Unknown magical entities have been detected near [station_name()], please stand-by.", "Lifesign Alert")
 
 /datum/round_event/wizard/magicarp/start()

--- a/code/modules/events/wormholes.dm
+++ b/code/modules/events/wormholes.dm
@@ -28,7 +28,7 @@
 		var/turf/T = pick(pick_turfs)
 		wormholes += new /obj/effect/portal/wormhole(T, null, 0, null, FALSE)
 
-/datum/round_event/wormholes/announce()
+/datum/round_event/wormholes/announce(fake)
 	priority_announce("Space-time anomalies detected on the station. There is no additional data.", "Anomaly Alert", 'sound/ai/spanomalies.ogg')
 
 /datum/round_event/wormholes/tick()

--- a/code/modules/holiday/easter.dm
+++ b/code/modules/holiday/easter.dm
@@ -10,7 +10,7 @@
 	max_occurrences = 1
 	earliest_start = 0
 
-/datum/round_event/easter/announce()
+/datum/round_event/easter/announce(fake)
 	priority_announce(pick("Hip-hop into Easter!","Find some Bunny's stash!","Today is National 'Hunt a Wabbit' Day.","Be kind, give Chocolate Eggs!"))
 
 
@@ -21,7 +21,7 @@
 	weight = 5
 	max_occurrences = 10
 
-/datum/round_event/rabbitrelease/announce()
+/datum/round_event/rabbitrelease/announce(fake)
 	priority_announce("Unidentified furry objects detected coming aboard [station_name()]. Beware of Adorable-ness.", "Fluffy Alert", 'sound/ai/aliens.ogg')
 
 


### PR DESCRIPTION
Instead of relying on announcWhen it's now seperate variable.
In addition announce has an argument signifying it's fake alarm so in case it needs to do something more than what's in setup()

WIP, because it's blind PR i need to test.