### PR TITLE
Space vacuum damage doubled

### DIFF
--- a/code/__DEFINES/atmospherics.dm
+++ b/code/__DEFINES/atmospherics.dm
@@ -109,7 +109,7 @@
 
 #define PRESSURE_DAMAGE_COEFFICIENT			4		//The amount of pressure damage someone takes is equal to (pressure / HAZARD_HIGH_PRESSURE)*PRESSURE_DAMAGE_COEFFICIENT, with the maximum of MAX_PRESSURE_DAMAGE
 #define MAX_HIGH_PRESSURE_DAMAGE			4
-#define LOW_PRESSURE_DAMAGE					2		//The amount of damage someone takes when in a low pressure area (The pressure threshold is so low that it doesn't make sense to do any calculations, so it just applies this flat value).
+#define LOW_PRESSURE_DAMAGE					4		//The amount of damage someone takes when in a low pressure area (The pressure threshold is so low that it doesn't make sense to do any calculations, so it just applies this flat value).
 
 #define COLD_SLOWDOWN_FACTOR				20		//Humans are slowed by the difference between bodytemp and BODYTEMP_COLD_DAMAGE_LIMIT divided by this
 


### PR DESCRIPTION
[Changelogs]: #
:cl: nicn
balance: Damage from low pressure has been doubled.
/:cl:

Ok so the reasons

* Space is not supposed to be something to fuck with.
* Spacewalk without proper suits is not too much damaging and this is quite annoying to traitors dragging off people into space and people fighting back while in space and people getting out of airlocks to run for a traitor.
* WHY NOT
* Really, if we find out this to be bad for players we can just revert it
