### PR TITLE
[512] Makes gas mouse transparent

### DIFF
--- a/code/modules/atmospherics/environmental/LINDA_turf_tile.dm
+++ b/code/modules/atmospherics/environmental/LINDA_turf_tile.dm
@@ -98,6 +98,12 @@
 /turf/open/proc/update_visuals()
 	var/list/new_overlay_types = tile_graphic()
 
+	#if DM_VERSION >= 512
+	#if DM_VERSION >= 513
+	#warning 512 is stable now for sure, remove the old code
+	#endif
+	vis_contents = new_overlay_types
+	#else
 	if (atmos_overlay_types)
 		for(var/overlay in atmos_overlay_types-new_overlay_types) //doesn't remove overlays that would only be added
 			cut_overlay(overlay)
@@ -110,6 +116,7 @@
 
 	UNSETEMPTY(new_overlay_types)
 	atmos_overlay_types = new_overlay_types
+	#endif
 
 /turf/open/proc/tile_graphic()
 	. = new /list

--- a/code/modules/atmospherics/environmental/LINDA_turf_tile.dm
+++ b/code/modules/atmospherics/environmental/LINDA_turf_tile.dm
@@ -97,13 +97,22 @@
 
 /turf/open/proc/update_visuals()
 	var/list/new_overlay_types = tile_graphic()
+	var/list/atmos_overlay_types = src.atmos_overlay_types // Cache for free performance
 
 	#if DM_VERSION >= 513
 	#warning 512 is stable now for sure, remove the old code
 	#endif
 	
 	#if DM_VERSION >= 512
-	vis_contents = new_overlay_types
+	if (atmos_overlay_types)
+		for(var/overlay in atmos_overlay_types-new_overlay_types) //doesn't remove overlays that would only be added
+			vis_contents -= overlay
+
+	if (new_overlay_types.len)
+		if (atmos_overlay_types)
+			vis_contents += new_overlay_types - atmos_overlay_types //don't add overlays that already exist
+		else
+			vis_contents += new_overlay_types
 	#else
 	if (atmos_overlay_types)
 		for(var/overlay in atmos_overlay_types-new_overlay_types) //doesn't remove overlays that would only be added
@@ -114,10 +123,10 @@
 			add_overlay(new_overlay_types - atmos_overlay_types) //don't add overlays that already exist
 		else
 			add_overlay(new_overlay_types)
+	#endif
 
 	UNSETEMPTY(new_overlay_types)
 	atmos_overlay_types = new_overlay_types
-	#endif
 
 /turf/open/proc/tile_graphic()
 	. = new /list

--- a/code/modules/atmospherics/environmental/LINDA_turf_tile.dm
+++ b/code/modules/atmospherics/environmental/LINDA_turf_tile.dm
@@ -98,10 +98,11 @@
 /turf/open/proc/update_visuals()
 	var/list/new_overlay_types = tile_graphic()
 
-	#if DM_VERSION >= 512
 	#if DM_VERSION >= 513
 	#warning 512 is stable now for sure, remove the old code
 	#endif
+	
+	#if DM_VERSION >= 512
 	vis_contents = new_overlay_types
 	#else
 	if (atmos_overlay_types)


### PR DESCRIPTION
:cl: ninjanomnom
fix: Gas overlays no longer block clicks, on 512
/:cl:

This is also way better performance wise. I'm not too sure but I think vis_contents is processed client side.

Proof it works btw:
![image](https://user-images.githubusercontent.com/1234602/32632462-c30a7132-c571-11e7-90de-d7826e5bb583.png)