### PR TITLE
Removes cloneloss from speedcloning, due to it being obsoleted by limb/organ loss

### DIFF
--- a/code/game/machinery/cloning.dm
+++ b/code/game/machinery/cloning.dm
@@ -226,7 +226,6 @@
 			mob_occupant.Unconscious(80)
 			var/dmg_mult = CONFIG_GET(number/damage_multiplier)
 			 //Slowly get that clone healed and finished.
-			mob_occupant.adjustCloneLoss(-((speed_coeff / 2) * dmg_mult))
 			var/progress = CLONE_INITIAL_DAMAGE - mob_occupant.getCloneLoss()
 			// To avoid the default cloner making incomplete clones
 			progress += (100 - MINIMUM_HEAL_LEVEL)
@@ -242,6 +241,7 @@
 				else if(isbodypart(I))
 					var/obj/item/bodypart/BP = I
 					BP.attach_limb(mob_occupant)
+			mob_occupant.setCloneLoss(0)
 
 			//Premature clones may have brain damage.
 			mob_occupant.adjustBrainLoss(-((speed_coeff / 2) * dmg_mult))
@@ -253,7 +253,7 @@
 		else if((mob_occupant.cloneloss <= (100 - heal_level)))
 			connected_message("Cloning Process Complete.")
 			SPEAK("The cloning cycle of [mob_occupant.real_name] is complete.")
-
+			mob_occupant.setCloneLoss(0)
 			// If the cloner is upgraded to debugging high levels, sometimes
 			// organs and limbs can be missing.
 			for(var/i in unattached_flesh)

--- a/code/game/machinery/cloning.dm
+++ b/code/game/machinery/cloning.dm
@@ -225,7 +225,8 @@
 		else if(mob_occupant.cloneloss > (100 - heal_level))
 			mob_occupant.Unconscious(80)
 			var/dmg_mult = CONFIG_GET(number/damage_multiplier)
-			 //Slowly get that clone healed and finished.
+			//Slowly get that clone healed and finished.
+			mob_occupant.adjustCloneLoss(-((speed_coeff / 2) * dmg_mult))
 			var/progress = CLONE_INITIAL_DAMAGE - mob_occupant.getCloneLoss()
 			// To avoid the default cloner making incomplete clones
 			progress += (100 - MINIMUM_HEAL_LEVEL)
@@ -241,7 +242,6 @@
 				else if(isbodypart(I))
 					var/obj/item/bodypart/BP = I
 					BP.attach_limb(mob_occupant)
-			mob_occupant.setCloneLoss(0)
 
 			//Premature clones may have brain damage.
 			mob_occupant.adjustBrainLoss(-((speed_coeff / 2) * dmg_mult))
@@ -358,14 +358,13 @@
 		mob_occupant.grab_ghost()
 		to_chat(occupant, "<span class='notice'><b>There is a bright flash!</b><br><i>You feel like a new being.</i></span>")
 		mob_occupant.flash_act()
-
 	occupant.forceMove(T)
 	icon_state = "pod_0"
 	mob_occupant.domutcheck(1) //Waiting until they're out before possible monkeyizing. The 1 argument forces powers to manifest.
 	for(var/fl in unattached_flesh)
 		qdel(fl)
 	unattached_flesh.Cut()
-
+	mob_occupant.setCloneLoss(0)
 	occupant = null
 
 /obj/machinery/clonepod/proc/malfunction()


### PR DESCRIPTION
We already punish speedcloning with organ/limb loss. Cloneloss exists just for the cryotube to be needed, and for internal counting on "how long have we been cloning for".

