### PR TITLE
Fix portable turrets attacking some heads and sec

### DIFF
--- a/code/game/machinery/porta_turret/portable_turret.dm
+++ b/code/game/machinery/porta_turret/portable_turret.dm
@@ -16,7 +16,7 @@
 	use_power = IDLE_POWER_USE				//this turret uses and requires power
 	idle_power_usage = 50		//when inactive, this turret takes up constant 50 Equipment power
 	active_power_usage = 300	//when active, this turret takes up constant 300 Equipment power
-	req_access = list(ACCESS_SECURITY)
+	req_access = list(ACCESS_SEC_DOORS)
 	power_channel = EQUIP	//drains power from the EQUIPMENT channel
 
 	var/base_icon_state = "standard"


### PR DESCRIPTION
:cl:
fix: The detective and heads of staff are no longer attacked by portable turrets.
/:cl:

Previously, when set to "non-security and non-command personnel", the portable turret would only allow the Captain, HoS, Warden, and Security Officers. Notably, the Detective and other command personnel would be attacked.

Now, the Detective, Lawyer, and other Heads of Staff are permitted.

Fixes #29138.