### PR TITLE
Stealthier Stun Talismans

### DIFF
--- a/code/game/gamemodes/cult/talisman.dm
+++ b/code/game/gamemodes/cult/talisman.dm
@@ -168,17 +168,16 @@
 			target.visible_message("<span class='warning'>[target]'s holy weapon absorbs the talisman's light!</span>", \
 								   "<span class='userdanger'>Your holy weapon absorbs the blinding light!</span>")
 		else
-			target.Knockdown(200)
+			target.Stun(200)
 			target.flash_act(1,1)
 			if(issilicon(target))
 				var/mob/living/silicon/S = target
 				S.emp_act(EMP_HEAVY)
 			else if(iscarbon(target))
 				var/mob/living/carbon/C = target
-				C.silent += 5
-				C.stuttering += 15
-				C.cultslurring += 15
-				C.Jitter(15)
+				C.silent += 8
+				C.stuttering += 16
+				C.cultslurring += 16
 			if(is_servant_of_ratvar(target))
 				target.adjustBruteLoss(15)
 		qdel(src)


### PR DESCRIPTION
:cl: Robustin
tweak: Stun talismans are now stealthier - the stun will no longer knock down the target and the silence effort will now last for a few more seconds. 
/:cl:

Cults winrate has been in the dumpster since I forced them to summon in limited/public locations. One of the problems is that with our pop numbers stealth seems almost like a fantasy - with cultists being given "public" summon locations they have to convert a lot of crew to secure victory, but a vast majority of the crew simply doesn't hang out in super isolated spots where you can stun/convert/release without being spotted. 

So this is the super modest first step to make being a cultist less oppressive. Stun talismans no longer carry the obvious tell of you dragging a KO'd body toward maint. The silence is also slightly longer because it just didn't feel practical to expect the average cultist to get a talisman victim over a rune within 10 seconds. 