### PR TITLE
adjusted default internet song volume to 25

### DIFF
--- a/code/modules/goonchat/browserOutput.dm
+++ b/code/modules/goonchat/browserOutput.dm
@@ -13,7 +13,7 @@ GLOBAL_DATUM_INIT(iconCache, /savefile, new("data/iconCache.sav")) //Cache of ic
 	var/cookieSent   = FALSE // Has the client sent a cookie for analysis
 	var/broken       = FALSE
 	var/list/connectionHistory //Contains the connection history passed from chat cookie
-	var/adminMusicVolume = 100 //This is for the Play Global Sound verb
+	var/adminMusicVolume = 25 //This is for the Play Global Sound verb
 
 /datum/chatOutput/New(client/C)
 	owner = C

--- a/code/modules/goonchat/browserassets/js/browserOutput.js
+++ b/code/modules/goonchat/browserassets/js/browserOutput.js
@@ -65,6 +65,8 @@ var opts = {
 	'volumeUpdateDelay': 5000, //Time from when the volume updates to data being sent to the server
 	'volumeUpdating': false, //True if volume update function set to fire
 	'updatedVolume': 0, //The volume level that is sent to the server
+	
+	'defaultMusicVolume': 25,
 
 };
 
@@ -604,6 +606,8 @@ $(function() {
 		opts.updatedVolume = newVolume;
 		sendVolumeUpdate();
 		internalOutput('<span class="internal boldnshit">Loaded music volume of: '+savedConfig.smusicVolume+'</span>', 'internal');
+	} else {
+		$('#adminMusic').prop('volume', opts.defaultMusicVolume);
 	}
 
 	(function() {


### PR DESCRIPTION
:cl: Qbopper and JJRcop
tweak: The default internet sound volume was changed from 100 to 25. Stop complaining in OOC about your ears!
/:cl:

literally any time any admin plays anything there's 2-3 people who say "MY EARS" because the default volume is TOO LOUD and they don't change it

i tested this and it actually worked so if it doesn't work i'm gonna be mad