### PR TITLE
A short feature freeze while we decentralize RnD

### DIFF
--- a/config/game_options.txt
+++ b/config/game_options.txt
@@ -392,7 +392,7 @@ JOIN_WITH_MUTANT_RACE
 ## Uncommenting races will allow them to be choosen at roundstart while join_with_muntant_race is on. You'll need at least one.
 
 ## You probably want humans on your space station, but technically speaking you can turn them off without any ill effect
-ROUNDSTART_RACES human
+#ROUNDSTART_RACES human
 
 ## Races that are strictly worse than humans that could probably be turned on without balance concerns
 ROUNDSTART_RACES lizard


### PR DESCRIPTION
A short feature freeze until phase 1/mapping of https://github.com/tgstation/tgstation/projects/12 is complete or two weeks from now when we give up, whichever is first.

Techwebs and circuits are both massive PRs and I'd like to free up maintainer time for them and spare the two PRs from competing balance changes/conflicts/etc (and encourage other people to help on them!)

As usual anything that was made before this freeze is exempt (as are fixes, but I'd prefer no big refactors that cause conflicts in the aforementioned PRs)

I will give a copy of Furi to whoever sprites the departmental lathes to a standard WJ approves