### PR TITLE
Fixes medbots not injecting from one tile away

### DIFF
--- a/code/modules/mob/living/simple_animal/bot/medbot.dm
+++ b/code/modules/mob/living/simple_animal/bot/medbot.dm
@@ -343,7 +343,7 @@
 	if(C.stat == DEAD || (C.status_flags & FAKEDEATH))
 		return FALSE	//welp too late for them!
 	
-	if(!(loc == C.loc) || !(isturf(C.loc) && isturf(loc)))
+	if(!(loc == C.loc) && !(isturf(C.loc) && isturf(loc)))
 		return FALSE
 
 	if(C.suiciding)


### PR DESCRIPTION
[Changelogs]: 

:cl: DaxDupont
fix: Medbots can inject from one tile away again. 
/:cl:

[why]: fixes #32528