### PR TITLE
Fixes hostile mobs attacking surrounding tiles when trying to attack someone

### DIFF
--- a/code/__HELPERS/game.dm
+++ b/code/__HELPERS/game.dm
@@ -300,6 +300,21 @@
 		else
 			return get_step(start, EAST)
 
+/proc/get_cardinal_step_towards(atom/start, atom/finish) //returns the position of a step from start towards finish, in one of the cardinal directions
+	//returns only NORTH, SOUTH, EAST, or WEST
+	var/dx = start.x - finish.x
+	var/dy = start.y - finish.y
+	if(abs(dy) > abs (dx)) //slope is above 1:1 (move horizontally in a tie)
+		if(dy > 0)
+			return get_step(start, SOUTH)
+		else
+			return get_step(start, NORTH)
+	else
+		if(dx > 0)
+			return get_step(start, WEST)
+		else
+			return get_step(start, EAST)
+
 /proc/try_move_adjacent(atom/movable/AM)
 	var/turf/T = get_turf(AM)
 	for(var/direction in GLOB.cardinals)

--- a/code/modules/mob/living/simple_animal/hostile/megafauna/bubblegum.dm
+++ b/code/modules/mob/living/simple_animal/hostile/megafauna/bubblegum.dm
@@ -135,12 +135,12 @@ Difficulty: Hard
 /mob/living/simple_animal/hostile/megafauna/bubblegum/Move()
 	if(charging)
 		new /obj/effect/temp_visual/decoy/fading(loc,src)
-		DestroySurroundings()
+		DestroyPathToTarget()
 	. = ..()
 	if(!stat && .)
 		playsound(src, 'sound/effects/meteorimpact.ogg', 200, 1, 2, 1)
 	if(charging)
-		DestroySurroundings()
+		DestroyPathToTarget()
 
 /mob/living/simple_animal/hostile/megafauna/bubblegum/proc/warp_charge()
 	blood_warp()
@@ -152,7 +152,7 @@ Difficulty: Hard
 		return
 	new /obj/effect/temp_visual/dragon_swoop/bubblegum(T)
 	charging = TRUE
-	DestroySurroundings()
+	DestroyPathToTarget()
 	walk(src, 0)
 	setDir(get_dir(src, T))
 	var/obj/effect/temp_visual/decoy/D = new /obj/effect/temp_visual/decoy(loc,src)
@@ -176,7 +176,7 @@ Difficulty: Hard
 	if(charging)
 		if(isturf(A) || isobj(A) && A.density)
 			A.ex_act(EXPLODE_HEAVY)
-		DestroySurroundings()
+		DestroyPathToTarget()
 	..()
 
 /mob/living/simple_animal/hostile/megafauna/bubblegum/throw_impact(atom/A)

--- a/code/modules/mob/living/simple_animal/hostile/megafauna/dragon.dm
+++ b/code/modules/mob/living/simple_animal/hostile/megafauna/dragon.dm
@@ -85,7 +85,7 @@ Difficulty: Medium
 	if(!swooping)
 		return ..()
 
-/mob/living/simple_animal/hostile/megafauna/dragon/DestroySurroundings()
+/mob/living/simple_animal/hostile/megafauna/dragon/DestroyPathToTarget()
 	if(!swooping)
 		..()
 

--- a/code/modules/mob/living/simple_animal/hostile/megafauna/hierophant.dm
+++ b/code/modules/mob/living/simple_animal/hostile/megafauna/hierophant.dm
@@ -163,7 +163,7 @@ Difficulty: Hard
 		else
 			return ..()
 
-/mob/living/simple_animal/hostile/megafauna/hierophant/DestroySurroundings()
+/mob/living/simple_animal/hostile/megafauna/hierophant/DestroyPathToTarget()
 	if(!blinking)
 		..()
 

--- a/code/modules/mob/living/simple_animal/hostile/mimic.dm
+++ b/code/modules/mob/living/simple_animal/hostile/mimic.dm
@@ -45,7 +45,7 @@
 		for(var/obj/item/I in loc)
 			I.loc = src
 
-/mob/living/simple_animal/hostile/mimic/crate/DestroySurroundings()
+/mob/living/simple_animal/hostile/mimic/crate/DestroyPathToTarget()
 	..()
 	if(prob(90))
 		icon_state = "[initial(icon_state)]open"
@@ -165,7 +165,7 @@ GLOBAL_LIST_INIT(protected_objects, list(/obj/structure/table, /obj/structure/ca
 			qdel(O)
 		return 1
 
-/mob/living/simple_animal/hostile/mimic/copy/DestroySurroundings()
+/mob/living/simple_animal/hostile/mimic/copy/DestroyPathToTarget()
 	if(destroy_objects)
 		..()
 

--- a/code/modules/mob/living/simple_animal/hostile/statue.dm
+++ b/code/modules/mob/living/simple_animal/hostile/statue.dm
@@ -95,7 +95,7 @@
 	else
 		return ..()
 
-/mob/living/simple_animal/hostile/statue/DestroySurroundings()
+/mob/living/simple_animal/hostile/statue/DestroyPathToTarget()
 	if(!can_be_seen(get_turf(loc)))
 		..()
 


### PR DESCRIPTION
fix: rewrote the DestroySurroundings proc

tweak: renamed DestroySurroundings to DestroyPathToTarget to better illustrate its use and purpose (as opposed to randomly attacking things around it)
reflected the new name in the megafaunas codes

add: added a get_cardinal_step_towards proc to game.dm for use in the destroysurroundings proc

It makes hostile mobs attack normally instead of in a way that makes no sense and is potentially unnecessarily hazardous.

fix for issue #4237