### PR TITLE
Cult Scaling Refactor

### DIFF
--- a/code/game/gamemodes/cult/cult.dm
+++ b/code/game/gamemodes/cult/cult.dm
@@ -1,3 +1,5 @@
+#define CULT_SCALING_COEFFICIENT 9.3 //Roughly one new cultist at roundstart per this many players
+
 /datum/game_mode
 	var/list/datum/mind/cult = list()
 	var/list/cult_objectives = list()
@@ -64,7 +66,10 @@
 		restricted_jobs += "Assistant"
 
 	//cult scaling goes here
-	recommended_enemies = 3 + round(num_players()/15)
+	recommended_enemies = 1 + round(num_players()/CULT_SCALING_COEFFICIENT)
+	var/remaining = (num_players() % CULT_SCALING_COEFFICIENT) * 10 //Basically the % of how close the population is toward adding another cultis
+	if(prob(remaining))
+		recommended_enemies++
 
 
 	for(var/cultists_number = 1 to recommended_enemies)
@@ -304,3 +309,5 @@
 						SSticker.news_report = CULT_FAILURE
 			text += "<br><B>Objective #[obj_count]</B>: [explanation]"
 	to_chat(world, text)
+
+#undef CULT_SCALING_COEFFICIENT


### PR DESCRIPTION
:cl: Robustin
refactor: Cult population scaling no longer operates on arbitrary breakpoints. Each additional player between the between the breakpoints will add to the "chance" that an additional cultist will spawn.
tweak: On average you will see less roundstart cultists in lowpop and more roundstart cultists in highpop.
/:cl:

Why: 

When reviewing cult stats I have to scroll for weeks to find a primetime victory. Linear scaling with arbitrary breakpoints has been a proven failure. Simply put, having one additional cultist per 15 crew was too low while having a high "floor" (3) meant you had scenarios where 17% of the crew was a cultist on lowpop but 9% was cultist on highpop. The has proven counter-intuitive because even an experienced solo cultist could probably stroll to victory on lowpop but highpop feels downright oppressive when you're outnumbered 10:1 and its impossible to so much as draw a rune in maint without 5 assistants walking in on you in the process. 