### PR TITLE
Stunarm charge cost increase

### DIFF
--- a/code/game/objects/items/robot/robot_items.dm
+++ b/code/game/objects/items/robot/robot_items.dm
@@ -8,7 +8,7 @@
 /obj/item/borg/stun
 	name = "electrically-charged arm"
 	icon_state = "elecarm"
-	var/charge_cost = 30
+	var/charge_cost = 500
 
 /obj/item/borg/stun/attack(mob/living/M, mob/living/user)
 	if(ishuman(M))


### PR DESCRIPTION
[Changelogs]: Stunarms now require 500 charge per stunarm use. On the roundstart batter, that's 15 stuns and 30 on the high-cap assuming no energy drain from anything else. 

:cl:
balance: The stunarm hacked module now requires 500 energy, 94% more than it used before
/:cl:

[why]: The general feeling is that the energy cost of the stunarm is too low with most not even aware it even *had* one. The charge increase should make it less devastating and overuse can drain you dry fast. Bear in mind that I don't want to make it too expensive to use or else the robo factory will be worth even less than it normally is to a traitor AI as stunarms are the only reliable means of keeping someone down long enough to convert them.