### PR TITLE
Alt clicking additions

### DIFF
--- a/code/modules/atmospherics/machinery/airalarm.dm
+++ b/code/modules/atmospherics/machinery/airalarm.dm
@@ -678,15 +678,7 @@
 				update_icon()
 				return
 			else if(istype(W, /obj/item/card/id) || istype(W, /obj/item/device/pda))// trying to unlock the interface with an ID card
-				if(stat & (NOPOWER|BROKEN))
-					to_chat(user, "<span class='warning'>It does nothing!</span>")
-				else
-					if(src.allowed(usr) && !wires.is_cut(WIRE_IDSCAN))
-						locked = !locked
-						to_chat(user, "<span class='notice'>You [ locked ? "lock" : "unlock"] the air alarm interface.</span>")
-					else
-						to_chat(user, "<span class='danger'>Access denied.</span>")
-				return
+				togglelock(user)
 			else if(panel_open && is_wire_tool(W))
 				wires.interact(user)
 				return
@@ -751,6 +743,25 @@
 				return
 
 	return ..()
+	
+/obj/machinery/airalarm/AltClick(mob/user)
+	..()
+	if(!issilicon(user) && (!user.canUseTopic(src, be_close=TRUE) || !isturf(loc)))
+		to_chat(user, "<span class='warning'>You can't do that right now!</span>")
+		return
+	else
+		togglelock(user)
+		
+/obj/machinery/airalarm/proc/togglelock(mob/living/user)
+	if(stat & (NOPOWER|BROKEN))
+		to_chat(user, "<span class='warning'>It does nothing!</span>")
+	else
+		if(src.allowed(usr) && !wires.is_cut(WIRE_IDSCAN))
+			locked = !locked
+			to_chat(user, "<span class='notice'>You [ locked ? "lock" : "unlock"] the air alarm interface.</span>")
+		else
+			to_chat(user, "<span class='danger'>Access denied.</span>")
+	return
 
 /obj/machinery/airalarm/power_change()
 	..()

--- a/code/modules/power/apc.dm
+++ b/code/modules/power/apc.dm
@@ -487,21 +487,7 @@
 			update_icon()
 
 	else if (W.GetID())			// trying to unlock the interface with an ID card
-		if(emagged)
-			to_chat(user, "<span class='warning'>The interface is broken!</span>")
-		else if(opened)
-			to_chat(user, "<span class='warning'>You must close the cover to swipe an ID card!</span>")
-		else if(panel_open)
-			to_chat(user, "<span class='warning'>You must close the panel!</span>")
-		else if(stat & (BROKEN|MAINT))
-			to_chat(user, "<span class='warning'>Nothing happens!</span>")
-		else
-			if(allowed(usr) && !wires.is_cut(WIRE_IDSCAN) && !malfhack)
-				locked = !locked
-				to_chat(user, "<span class='notice'>You [ locked ? "lock" : "unlock"] the APC interface.</span>")
-				update_icon()
-			else
-				to_chat(user, "<span class='warning'>Access denied.</span>")
+		togglelock(user)
 
 	else if (istype(W, /obj/item/stack/cable_coil) && opened)
 		var/turf/host_turf = get_turf(src)
@@ -671,6 +657,31 @@
 		wires.interact(user)
 	else
 		return ..()
+		
+/obj/machinery/power/apc/AltClick(mob/user)
+	..()
+	if(!issilicon(user) && (!user.canUseTopic(src, be_close=TRUE) || !isturf(loc)))
+		to_chat(user, "<span class='warning'>You can't do that right now!</span>")
+		return
+	else
+		togglelock(user)
+		
+/obj/machinery/power/apc/proc/togglelock(mob/living/user)
+	if(emagged)
+		to_chat(user, "<span class='warning'>The interface is broken!</span>")
+	else if(opened)
+		to_chat(user, "<span class='warning'>You must close the cover to swipe an ID card!</span>")
+	else if(panel_open)
+		to_chat(user, "<span class='warning'>You must close the panel!</span>")
+	else if(stat & (BROKEN|MAINT))
+		to_chat(user, "<span class='warning'>Nothing happens!</span>")
+	else
+		if(allowed(usr) && !wires.is_cut(WIRE_IDSCAN) && !malfhack)
+			locked = !locked
+			to_chat(user, "<span class='notice'>You [ locked ? "lock" : "unlock"] the APC interface.</span>")
+			update_icon()
+		else
+			to_chat(user, "<span class='warning'>Access denied.</span>")
 
 /obj/machinery/power/apc/run_obj_armor(damage_amount, damage_type, damage_flag = 0, attack_dir)
 	if(damage_flag == "melee" && damage_amount < 15 && (!(stat & BROKEN) || malfai))


### PR DESCRIPTION
Adds alt clicking to lock/unlock for apc and air alarm

[Changelogs]: # 
:cl: 

tweak: alt clicking apcs and air alarms locks/unlocks them if you have the required ID

/:cl:

[why]: # QoL
