### PR TITLE
Greatly increases the performance of station-ending plasma fires

### DIFF
--- a/code/_globalvars/lists/mobs.dm
+++ b/code/_globalvars/lists/mobs.dm
@@ -13,6 +13,7 @@ GLOBAL_LIST_EMPTY(player_list)				//all mobs **with clients attached**. Excludes
 GLOBAL_LIST_EMPTY(mob_list)					//all mobs, including clientless
 GLOBAL_LIST_EMPTY(mob_directory)            //mob_id -> mob
 GLOBAL_LIST_EMPTY(living_mob_list)			//all alive mobs, including clientless. Excludes /mob/dead/new_player
+GLOBAL_LIST_EMPTY(drones_list)
 GLOBAL_LIST_EMPTY(dead_mob_list)			//all dead mobs, including clientless. Excludes /mob/dead/new_player
 GLOBAL_LIST_EMPTY(joined_player_list)   	//all clients that have joined the game at round-start or as a latejoin.
 GLOBAL_LIST_EMPTY(silicon_mobs)				//all silicon mobs

--- a/code/_globalvars/lists/objects.dm
+++ b/code/_globalvars/lists/objects.dm
@@ -37,3 +37,4 @@ GLOBAL_LIST_EMPTY(wire_name_directory)
 GLOBAL_LIST_EMPTY(ai_status_displays)
 
 GLOBAL_LIST_EMPTY(mob_spawners) 		    // All mob_spawn objects
+GLOBAL_LIST_EMPTY(alert_consoles)			// Station alert consoles, /obj/machinery/computer/station_alert

--- a/code/game/area/areas.dm
+++ b/code/game/area/areas.dm
@@ -156,10 +156,6 @@ GLOBAL_LIST_EMPTY(teleportlocs)
 	if (state != poweralm)
 		poweralm = state
 		if(istype(source))	//Only report power alarms on the z-level where the source is located.
-			var/list/cameras = list()
-			for (var/item in cameras)
-				var/obj/machinery/camera/C = item
-				cameras += C
 			for (var/item in GLOB.silicon_mobs)
 				var/mob/living/silicon/aiPlayer = item
 				if (state == 1)

--- a/code/game/area/areas.dm
+++ b/code/game/area/areas.dm
@@ -58,6 +58,8 @@
 	flags_1 = CAN_BE_DIRTY_1
 
 	var/list/firedoors
+	var/list/cameras
+	var/list/firealarms
 	var/firedoors_last_closed_on = 0
 
 /*Adding a wizard area teleport list because motherfucking lag -- Urist*/
@@ -102,7 +104,7 @@ GLOBAL_LIST_EMPTY(teleportlocs)
 	uid = ++global_uid
 	related = list(src)
 	map_name = name // Save the initial (the name set in the map) name of the area.
-	
+
 	if(requires_power)
 		luminosity = 0
 	else
@@ -239,18 +241,24 @@ GLOBAL_LIST_EMPTY(teleportlocs)
 		if (!( RA.fire ))
 			RA.set_fire_alarm_effect()
 			RA.ModifyFiredoors(FALSE)
-			for(var/obj/machinery/firealarm/F in RA)
+			for(var/item in RA.firealarms)
+				var/obj/machinery/firealarm/F = item
 				F.update_icon()
-		for (var/obj/machinery/camera/C in RA)
+		for (var/item in RA.cameras)
+			var/obj/machinery/camera/C = item
 			cameras += C
 
-	for (var/obj/machinery/computer/station_alert/a in GLOB.machines)
+	for (var/item in GLOB.alert_consoles)
+		var/obj/machinery/computer/station_alert/a = item
 		a.triggerAlarm("Fire", src, cameras, source)
-	for (var/mob/living/silicon/aiPlayer in GLOB.player_list)
+	for (var/item in GLOB.silicon_mobs)
+		var/mob/living/silicon/aiPlayer = item
 		aiPlayer.triggerAlarm("Fire", src, cameras, source)
-	for (var/mob/living/simple_animal/drone/D in GLOB.mob_list)
+	for (var/item in GLOB.drones_list)
+		var/mob/living/simple_animal/drone/D = item
 		D.triggerAlarm("Fire", src, cameras, source)
-	for(var/datum/computer_file/program/alarm_monitor/p in GLOB.alarmdisplay)
+	for(var/item in GLOB.alarmdisplay)
+		var/datum/computer_file/program/alarm_monitor/p = item
 		p.triggerAlarm("Fire", src, cameras, source)
 
 	START_PROCESSING(SSobj, src)

--- a/code/game/area/areas.dm
+++ b/code/game/area/areas.dm
@@ -157,26 +157,31 @@ GLOBAL_LIST_EMPTY(teleportlocs)
 		poweralm = state
 		if(istype(source))	//Only report power alarms on the z-level where the source is located.
 			var/list/cameras = list()
-			for (var/obj/machinery/camera/C in src)
+			for (var/item in cameras)
+				var/obj/machinery/camera/C = item
 				cameras += C
-			for (var/mob/living/silicon/aiPlayer in GLOB.player_list)
+			for (var/item in GLOB.silicon_mobs)
+				var/mob/living/silicon/aiPlayer = item
 				if (state == 1)
 					aiPlayer.cancelAlarm("Power", src, source)
 				else
 					aiPlayer.triggerAlarm("Power", src, cameras, source)
 
-			for(var/obj/machinery/computer/station_alert/a in GLOB.machines)
+			for (var/item in GLOB.alert_consoles)
+				var/obj/machinery/computer/station_alert/a = item
 				if(state == 1)
 					a.cancelAlarm("Power", src, source)
 				else
 					a.triggerAlarm("Power", src, cameras, source)
 
-			for(var/mob/living/simple_animal/drone/D in GLOB.mob_list)
+			for (var/item in GLOB.drones_list)
+				var/mob/living/simple_animal/drone/D = item
 				if(state == 1)
 					D.cancelAlarm("Power", src, source)
 				else
 					D.triggerAlarm("Power", src, cameras, source)
-			for(var/datum/computer_file/program/alarm_monitor/p in GLOB.alarmdisplay)
+			for(var/item in GLOB.alarmdisplay)
+				var/datum/computer_file/program/alarm_monitor/p = item
 				if(state == 1)
 					p.cancelAlarm("Power", src, source)
 				else
@@ -187,26 +192,35 @@ GLOBAL_LIST_EMPTY(teleportlocs)
 		if (danger_level==2)
 			var/list/cameras = list()
 			for(var/area/RA in related)
-				for(var/obj/machinery/camera/C in RA)
+				for (var/item in RA.cameras)
+					var/obj/machinery/camera/C = item
 					cameras += C
 
-			for(var/mob/living/silicon/aiPlayer in GLOB.player_list)
+			for (var/item in GLOB.silicon_mobs)
+				var/mob/living/silicon/aiPlayer = item
 				aiPlayer.triggerAlarm("Atmosphere", src, cameras, source)
-			for(var/obj/machinery/computer/station_alert/a in GLOB.machines)
+			for (var/item in GLOB.alert_consoles)
+				var/obj/machinery/computer/station_alert/a = item
 				a.triggerAlarm("Atmosphere", src, cameras, source)
-			for(var/mob/living/simple_animal/drone/D in GLOB.mob_list)
+			for (var/item in GLOB.drones_list)
+				var/mob/living/simple_animal/drone/D = item
 				D.triggerAlarm("Atmosphere", src, cameras, source)
-			for(var/datum/computer_file/program/alarm_monitor/p in GLOB.alarmdisplay)
+			for(var/item in GLOB.alarmdisplay)
+				var/datum/computer_file/program/alarm_monitor/p = item
 				p.triggerAlarm("Atmosphere", src, cameras, source)
 
 		else if (src.atmosalm == 2)
-			for(var/mob/living/silicon/aiPlayer in GLOB.player_list)
+			for (var/item in GLOB.silicon_mobs)
+				var/mob/living/silicon/aiPlayer = item
 				aiPlayer.cancelAlarm("Atmosphere", src, source)
-			for(var/obj/machinery/computer/station_alert/a in GLOB.machines)
+			for (var/item in GLOB.alert_consoles)
+				var/obj/machinery/computer/station_alert/a = item
 				a.cancelAlarm("Atmosphere", src, source)
-			for(var/mob/living/simple_animal/drone/D in GLOB.mob_list)
+			for (var/item in GLOB.drones_list)
+				var/mob/living/simple_animal/drone/D = item
 				D.cancelAlarm("Atmosphere", src, source)
-			for(var/datum/computer_file/program/alarm_monitor/p in GLOB.alarmdisplay)
+			for(var/item in GLOB.alarmdisplay)
+				var/datum/computer_file/program/alarm_monitor/p = item
 				p.cancelAlarm("Atmosphere", src, source)
 
 		src.atmosalm = danger_level
@@ -270,16 +284,21 @@ GLOBAL_LIST_EMPTY(teleportlocs)
 			RA.mouse_opacity = MOUSE_OPACITY_TRANSPARENT
 			RA.updateicon()
 			RA.ModifyFiredoors(TRUE)
-			for(var/obj/machinery/firealarm/F in RA)
+			for(var/item in RA.firealarms)
+				var/obj/machinery/firealarm/F = item
 				F.update_icon()
 
-	for (var/mob/living/silicon/aiPlayer in GLOB.player_list)
+	for (var/item in GLOB.silicon_mobs)
+		var/mob/living/silicon/aiPlayer = item
 		aiPlayer.cancelAlarm("Fire", src, source)
-	for (var/obj/machinery/computer/station_alert/a in GLOB.machines)
+	for (var/item in GLOB.alert_consoles)
+		var/obj/machinery/computer/station_alert/a = item
 		a.cancelAlarm("Fire", src, source)
-	for (var/mob/living/simple_animal/drone/D in GLOB.mob_list)
+	for (var/item in GLOB.drones_list)
+		var/mob/living/simple_animal/drone/D = item
 		D.cancelAlarm("Fire", src, source)
-	for(var/datum/computer_file/program/alarm_monitor/p in GLOB.alarmdisplay)
+	for(var/item in GLOB.alarmdisplay)
+		var/datum/computer_file/program/alarm_monitor/p = item
 		p.cancelAlarm("Fire", src, source)
 
 	STOP_PROCESSING(SSobj, src)
@@ -307,7 +326,8 @@ GLOBAL_LIST_EMPTY(teleportlocs)
 		//Lockdown airlocks
 		for(var/obj/machinery/door/DOOR in RA)
 			close_and_lock_door(DOOR)
-		for (var/obj/machinery/camera/C in RA)
+		for (var/item in RA.cameras)
+			var/obj/machinery/camera/C = item
 			cameras += C
 
 	for (var/mob/living/silicon/SILICON in GLOB.player_list)

--- a/code/game/machinery/camera/camera.dm
+++ b/code/game/machinery/camera/camera.dm
@@ -26,7 +26,7 @@
 	var/invuln = null
 	var/obj/item/device/camera_bug/bug = null
 	var/obj/structure/camera_assembly/assembly = null
-	var/area/area = null
+	var/area/myarea = null
 
 	//OTHER
 
@@ -49,8 +49,8 @@
 	GLOB.cameranet.cameras += src
 	GLOB.cameranet.addCamera(src)
 	if (isturf(loc))
-		area = get_area(src)
-		LAZYADD(area.cameras, src)
+		myarea = get_area(src)
+		LAZYADD(myarea.cameras, src)
 	proximity_monitor = new(src, 1)
 
 	if(mapload && (z in GLOB.station_z_levels) && prob(3) && !start_active)
@@ -58,8 +58,8 @@
 
 /obj/machinery/camera/Destroy()
 	toggle_cam(null, 0) //kick anyone viewing out
-	if(isarea(area))
-		LAZYREMOVE(area.cameras, src)
+	if(isarea(myarea))
+		LAZYREMOVE(myarea.cameras, src)
 	if(assembly)
 		qdel(assembly)
 		assembly = null
@@ -279,15 +279,15 @@
 	if(can_use())
 		GLOB.cameranet.addCamera(src)
 		if (isturf(loc))
-			area = get_area(src)
-			LAZYADD(area.cameras, src)
+			myarea = get_area(src)
+			LAZYADD(myarea.cameras, src)
 		else
-			area = null
+			myarea = null
 	else
 		set_light(0)
 		GLOB.cameranet.removeCamera(src)
-		if (isarea(area))
-			LAZYREMOVE(area.cameras, src)
+		if (isarea(myarea))
+			LAZYREMOVE(myarea.cameras, src)
 	GLOB.cameranet.updateChunk(x, y, z)
 	var/change_msg = "deactivates"
 	if(status)

--- a/code/game/machinery/camera/camera.dm
+++ b/code/game/machinery/camera/camera.dm
@@ -47,8 +47,9 @@
 	assembly.state = 4
 	GLOB.cameranet.cameras += src
 	GLOB.cameranet.addCamera(src)
-	var/area/A = get_area(src)
-	LAZYADD(A.cameras, src)
+	if (isturf(loc))
+		var/area/A = get_area(src)
+		LAZYADD(A.cameras, src)
 	proximity_monitor = new(src, 1)
 
 	if(mapload && (z in GLOB.station_z_levels) && prob(3) && !start_active)
@@ -273,7 +274,8 @@
 	var/area/A = get_area(src)
 	if(can_use())
 		GLOB.cameranet.addCamera(src)
-		LAZYADD(A.cameras, src)
+		if (isturf(loc))
+			LAZYADD(A.cameras, src)
 	else
 		set_light(0)
 		GLOB.cameranet.removeCamera(src)

--- a/code/game/machinery/camera/camera.dm
+++ b/code/game/machinery/camera/camera.dm
@@ -47,6 +47,8 @@
 	assembly.state = 4
 	GLOB.cameranet.cameras += src
 	GLOB.cameranet.addCamera(src)
+	var/area/A = get_area(src)
+	LAZYADD(A.cameras, src)
 	proximity_monitor = new(src, 1)
 
 	if(mapload && (z in GLOB.station_z_levels) && prob(3) && !start_active)
@@ -54,6 +56,8 @@
 
 /obj/machinery/camera/Destroy()
 	toggle_cam(null, 0) //kick anyone viewing out
+	var/area/A = get_area(src)
+	LAZYREMOVE(A.cameras, src)
 	if(assembly)
 		qdel(assembly)
 		assembly = null
@@ -266,11 +270,14 @@
 
 /obj/machinery/camera/proc/toggle_cam(mob/user, displaymessage = 1)
 	status = !status
+	var/area/A = get_area(src)
 	if(can_use())
 		GLOB.cameranet.addCamera(src)
+		LAZYADD(A.cameras, src)
 	else
 		set_light(0)
 		GLOB.cameranet.removeCamera(src)
+		LAZYREMOVE(A.cameras, src)
 	GLOB.cameranet.updateChunk(x, y, z)
 	var/change_msg = "deactivates"
 	if(status)
@@ -298,12 +305,12 @@
 
 /obj/machinery/camera/proc/triggerCameraAlarm()
 	alarm_on = TRUE
-	for(var/mob/living/silicon/S in GLOB.mob_list)
+	for(var/mob/living/silicon/S in GLOB.silicon_mobs)
 		S.triggerAlarm("Camera", get_area(src), list(src), src)
 
 /obj/machinery/camera/proc/cancelCameraAlarm()
 	alarm_on = FALSE
-	for(var/mob/living/silicon/S in GLOB.mob_list)
+	for(var/mob/living/silicon/S in GLOB.silicon_mobs)
 		S.cancelAlarm("Camera", get_area(src), src)
 
 /obj/machinery/camera/proc/can_use()

--- a/code/game/machinery/computer/station_alert.dm
+++ b/code/game/machinery/computer/station_alert.dm
@@ -9,8 +9,8 @@
 	light_color = LIGHT_COLOR_CYAN
 
 /obj/machinery/computer/station_alert/Initialize()
+	. = ..()
 	GLOB.alert_consoles += src
-	return ..()
 
 /obj/machinery/computer/station_alert/Destroy()
 	GLOB.alert_consoles -= src

--- a/code/game/machinery/computer/station_alert.dm
+++ b/code/game/machinery/computer/station_alert.dm
@@ -8,6 +8,14 @@
 
 	light_color = LIGHT_COLOR_CYAN
 
+/obj/machinery/computer/station_alert/Initialize()
+	GLOB.alert_consoles += src
+	return ..()
+
+/obj/machinery/computer/station_alert/Destroy()
+	GLOB.alert_consoles -= src
+	return ..()
+
 /obj/machinery/computer/station_alert/ui_interact(mob/user, ui_key = "main", datum/tgui/ui = null, force_open = FALSE, \
 									datum/tgui/master_ui = null, datum/ui_state/state = GLOB.default_state)
 	ui = SStgui.try_update_ui(user, src, ui_key, ui, force_open)
@@ -16,15 +24,13 @@
 		ui.open()
 
 /obj/machinery/computer/station_alert/ui_data(mob/user)
-	var/list/data = list()
+	. = list()
 
-	data["alarms"] = list()
+	.["alarms"] = list()
 	for(var/class in alarms)
-		data["alarms"][class] = list()
+		.["alarms"][class] = list()
 		for(var/area in alarms[class])
-			data["alarms"][class] += area
-
-	return data
+			.["alarms"][class] += area
 
 /obj/machinery/computer/station_alert/proc/triggerAlarm(class, area/A, O, obj/source)
 	if(source.z != z)
@@ -67,10 +73,6 @@
 				cleared = 1
 				L -= I
 	return !cleared
-
-
-/obj/machinery/computer/station_alert/process()
-	..()
 
 /obj/machinery/computer/station_alert/update_icon()
 	..()

--- a/code/game/machinery/firealarm.dm
+++ b/code/game/machinery/firealarm.dm
@@ -28,6 +28,7 @@
 	var/buildstage = 2 // 2 = complete, 1 = no wires, 0 = circuit gone
 	resistance_flags = FIRE_PROOF
 	var/last_alarm = 0
+	var/area/myarea = null
 
 /obj/machinery/firealarm/New(loc, dir, building)
 	..()
@@ -39,12 +40,11 @@
 		pixel_x = (dir & 3)? 0 : (dir == 4 ? -24 : 24)
 		pixel_y = (dir & 3)? (dir ==1 ? -24 : 24) : 0
 	update_icon()
-	var/area/A = get_area(src)
-	LAZYADD(A.firealarms, src)
+	myarea = get_area(src)
+	LAZYADD(myarea.firealarms, src)
 
 /obj/machinery/firealarm/Destroy()
-	var/area/A = get_area(src)
-	LAZYREMOVE(A.firealarms, src)
+	LAZYREMOVE(myarea.firealarms, src)
 	return ..()
 
 /obj/machinery/firealarm/power_change()
@@ -252,8 +252,14 @@
 			if(prob(33))
 				alarm()
 
+/obj/machinery/firealarm/singularity_pull(S, current_size)
+	if (current_size >= STAGE_FIVE) // If the singulo is strong enough to pull anchored objects, the fire alarm experiences integrity failure
+		deconstruct()
+	..()
+
 /obj/machinery/firealarm/obj_break(damage_flag)
 	if(!(stat & BROKEN) && !(flags_1 & NODECONSTRUCT_1) && buildstage != 0) //can't break the electronics if there isn't any inside.
+		LAZYREMOVE(myarea.firealarms, src)
 		stat |= BROKEN
 		update_icon()
 

--- a/code/game/machinery/firealarm.dm
+++ b/code/game/machinery/firealarm.dm
@@ -1,4 +1,4 @@
-#define FIREALARM_COOLDOWN 60
+#define FIREALARM_COOLDOWN 67 // Chosen fairly arbitrarily, it is the length of the audio in FireAlarm.ogg. The actual track length is 7 seconds 8ms but but the audio stops at 6s 700ms
 
 /obj/item/electronics/firealarm
 	name = "fire alarm electronics"

--- a/code/modules/mob/living/simple_animal/friendly/drone/_drone.dm
+++ b/code/modules/mob/living/simple_animal/friendly/drone/_drone.dm
@@ -80,7 +80,7 @@
 
 /mob/living/simple_animal/drone/Initialize()
 	. = ..()
-
+	GLOB.drones_list += src
 	access_card = new /obj/item/card/id(src)
 	var/datum/job/captain/C = new /datum/job/captain
 	access_card.access = C.get_access()
@@ -124,6 +124,7 @@
 		holder.icon_state = "hudstat"
 
 /mob/living/simple_animal/drone/Destroy()
+	GLOB.drones_list -= src
 	qdel(access_card) //Otherwise it ends up on the floor!
 	return ..()
 


### PR DESCRIPTION
Hey guys, let's iterate through every item in every area in a list of areas looking for the two fire alarms, or maybe a camera. Let's iterate through every mob in the game looking for drones. Let's iterate through every machine looking for alert consoles. Why are three fire alarm-related procs in top10 total cpu?
Who cares, let's just fucking hammer the alarm() proc until the players go deaf, it works better the more you use it.

| Proc Name                                           | Self CPU | Total CPU | Real Time | Calls |
|-----------------------------------------------------|----------|-----------|-----------|-------|
| /area/proc/firealert                                | 9.699    | 9.801     | 9.782     | 3254  |
| /area/proc/newfirealert                             | 0.004    | 0.024     | 0.028     | 429   |
| /obj/machinery/firealarm/proc/NewAlarm              | 0.002    | 0.040     | 0.038     | 429   |
| /obj/machinery/firealarm/proc/newtemperature_expose | 0.003    | 0.042     | 0.042     | 3706  |
| /obj/machinery/firealarm/proc/OldAlarm              | 0.027    | 9.929     | 9.904     | 3254  |
| /obj/machinery/firealarm/proc/oldtemperature_expose | 0.005    | 9.936     | 9.908     | 3855  |

[Changelogs]: 

:cl: Naksu
fix: Removed fire-related free lag.
change: fire alarms and cameras no longer work after being ripped off a wall by a singulo
/:cl:

Problem with this is that I haven't tested this with other players