### PR TITLE
Fix conflicts between helmet/mech HUDs and HUD glasses

### DIFF
--- a/code/datums/hud.dm
+++ b/code/datums/hud.dm
@@ -31,11 +31,10 @@ GLOBAL_LIST_INIT(huds, list(
 /datum/atom_hud/proc/remove_hud_from(mob/M)
 	if(!M)
 		return
-	if(src in M.permanent_huds)
-		return
-	for(var/atom/A in hudatoms)
-		remove_from_single_hud(M, A)
-	hudusers -= M
+	if (!--hudusers[M])
+		hudusers -= M
+		for(var/atom/A in hudatoms)
+			remove_from_single_hud(M, A)
 
 /datum/atom_hud/proc/remove_from_hud(atom/A)
 	if(!A)
@@ -54,9 +53,12 @@ GLOBAL_LIST_INIT(huds, list(
 /datum/atom_hud/proc/add_hud_to(mob/M)
 	if(!M)
 		return
-	hudusers[M] = TRUE
-	for(var/atom/A in hudatoms)
-		add_to_single_hud(M, A)
+	if (!hudusers[M])
+		hudusers[M] = 1
+		for(var/atom/A in hudatoms)
+			add_to_single_hud(M, A)
+	else
+		hudusers[M]++
 
 /datum/atom_hud/proc/add_to_hud(atom/A)
 	if(!A)

--- a/code/game/mecha/medical/odysseus.dm
+++ b/code/game/mecha/medical/odysseus.dm
@@ -9,25 +9,16 @@
 	internal_damage_threshold = 35
 	deflect_chance = 15
 	step_energy_drain = 6
-	var/builtin_hud_user = 0
 
 /obj/mecha/medical/odysseus/moved_inside(mob/living/carbon/human/H)
-	if(..())
-		if(H.glasses && istype(H.glasses, /obj/item/clothing/glasses/hud))
-			occupant_message("<span class='warning'>Your [H.glasses] prevent you from using the built-in medical hud.</span>")
-		else
-			var/datum/atom_hud/data/human/medical/advanced/A = GLOB.huds[DATA_HUD_MEDICAL_ADVANCED]
-			A.add_hud_to(H)
-			builtin_hud_user = 1
-		return 1
-	else
-		return 0
+	. = ..()
+	if(.)
+		var/datum/atom_hud/hud = GLOB.huds[DATA_HUD_MEDICAL_ADVANCED]
+		hud.add_hud_to(H)
 
 /obj/mecha/medical/odysseus/go_out()
-	if(ishuman(occupant) && builtin_hud_user)
+	if(ishuman(occupant))
 		var/mob/living/carbon/human/H = occupant
-		var/datum/atom_hud/data/human/medical/advanced/A = GLOB.huds[DATA_HUD_MEDICAL_ADVANCED]
-		A.remove_hud_from(H)
+		var/datum/atom_hud/hud = GLOB.huds[DATA_HUD_MEDICAL_ADVANCED]
+		hud.remove_hud_from(H)
 	..()
-	return
-

--- a/code/modules/clothing/spacesuits/hardsuit.dm
+++ b/code/modules/clothing/spacesuits/hardsuit.dm
@@ -444,7 +444,6 @@
 	icon_state = "hardsuit0-rd"
 	item_color = "rd"
 	resistance_flags = ACID_PROOF | FIRE_PROOF
-	var/onboard_hud_enabled = 0 //stops conflicts with another diag HUD
 	max_heat_protection_temperature = FIRE_SUIT_MAX_TEMP_PROTECT
 	armor = list(melee = 30, bullet = 5, laser = 10, energy = 5, bomb = 100, bio = 100, rad = 60, fire = 60, acid = 80)
 	var/obj/machinery/doppler_array/integrated/bomb_radar
@@ -457,16 +456,13 @@
 
 /obj/item/clothing/head/helmet/space/hardsuit/rd/equipped(mob/living/carbon/human/user, slot)
 	..()
-	if(user.glasses && istype(user.glasses, /obj/item/clothing/glasses/hud/diagnostic))
-		to_chat(user, ("<span class='warning'>Your [user.glasses] prevents you using [src]'s diagnostic visor HUD.</span>"))
-	else
-		onboard_hud_enabled = 1
+	if (slot == slot_head)
 		var/datum/atom_hud/DHUD = GLOB.huds[DATA_HUD_DIAGNOSTIC]
 		DHUD.add_hud_to(user)
 
 /obj/item/clothing/head/helmet/space/hardsuit/rd/dropped(mob/living/carbon/human/user)
 	..()
-	if(onboard_hud_enabled && !(user.glasses && istype(user.glasses, /obj/item/clothing/glasses/hud/diagnostic)))
+	if (user.head == src)
 		var/datum/atom_hud/DHUD = GLOB.huds[DATA_HUD_DIAGNOSTIC]
 		DHUD.remove_hud_from(user)
 

--- a/code/modules/mob/mob_defines.dm
+++ b/code/modules/mob/mob_defines.dm
@@ -134,8 +134,6 @@
 
 	var/turf/listed_turf = null	//the current turf being examined in the stat panel
 
-	var/list/permanent_huds = list()
-
 	var/resize = 1 //Badminnery resize
 
 	var/list/observers = null	//The list of people observing this mob.

--- a/code/modules/surgery/organs/augments_eyes.dm
+++ b/code/modules/surgery/organs/augments_eyes.dm
@@ -19,12 +19,10 @@
 	if(HUD_type)
 		var/datum/atom_hud/H = GLOB.huds[HUD_type]
 		H.add_hud_to(M)
-		M.permanent_huds |= H
 
 /obj/item/organ/cyberimp/eyes/hud/Remove(var/mob/living/carbon/M, var/special = 0)
 	if(HUD_type)
 		var/datum/atom_hud/H = GLOB.huds[HUD_type]
-		M.permanent_huds ^= H
 		H.remove_hud_from(M)
 	..()
 


### PR DESCRIPTION
:cl:
fix: HUDs from mechs and helmets no longer conflict with HUD glasses and no longer inappropriately remove implanted HUDs.
/:cl:

Fixes #29705. Hides the conflict message when you are already wearing a medical HUD and ensures the HUD isn't removed on exit if it wasn't actually added on entry.
