### PR TITLE
Fixes AI anti-cheat false positives

### DIFF
--- a/code/_onclick/ai.dm
+++ b/code/_onclick/ai.dm
@@ -38,6 +38,8 @@
 	if(isnull(pixel_turf))
 		return
 	if(!can_see(A))
+		if(isturf(A)) //On unmodified clients clicking the static overlay clicks the turf underneath
+			return //So there's no point messaging admins
 		message_admins("[key_name_admin(src)] might be running a modified client! (failed can_see on AI click of [A]([ADMIN_COORDJMP(pixel_turf)]))")
 		var/message = "[key_name(src)] might be running a modified client! (failed can_see on AI click of [A]([COORD(pixel_turf)]))"
 		log_admin(message)


### PR DESCRIPTION
I broke this with #32000 since
https://github.com/tgstation/tgstation/blob/b8bb7279d01acdf0019cb97f97363317be9ad100/code/_onclick/ai.dm#L38
isn't true for turfs anymore.