### PR TITLE
Speeds up saycode by almost doubling get_hearers_in_view() performance

### DIFF
--- a/code/__HELPERS/game.dm
+++ b/code/__HELPERS/game.dm
@@ -219,16 +219,24 @@
 	if(!T)
 		return
 
+	var/list/processing_list = list()  
 	if (R == 0) // if the range is zero, we know exactly where to look for, we can skip view
-		. = recursive_hear_check(T)
+		processing_list += T.contents // We can shave off one iteration by assuming turfs cannot hear
 	else  // A variation of get_hear inlined here to take advantage of the compiler's fastpath for obj/mob in view
 		var/lum = T.luminosity
-		T.luminosity = 6
+		T.luminosity = 6 // This is the maximum luminosity
 		for(var/obj/O in view(R, T))
-			. += recursive_hear_check(O)
+			processing_list += O
 		for(var/mob/M in view(R, T))
-			. += recursive_hear_check(M)
+			processing_list += M
 		T.luminosity = lum
+
+	while(processing_list.len) // recursive_hear_check inlined here
+		var/atom/A = processing_list[1]
+		if(A.flags_1 & HEAR_1)
+			. += A
+		processing_list.Cut(1, 2)
+		processing_list += A.contents
 
 /proc/get_mobs_in_radio_ranges(list/obj/item/device/radio/radios)
 

--- a/code/__HELPERS/game.dm
+++ b/code/__HELPERS/game.dm
@@ -214,17 +214,21 @@
 /proc/get_hearers_in_view(R, atom/source)
 	// Returns a list of hearers in view(R) from source (ignoring luminosity). Used in saycode.
 	var/turf/T = get_turf(source)
-	var/list/hear = list()
+	. = list()
 
 	if(!T)
-		return hear
+		return
 
-	var/list/range = get_hear(R, T)
-	for(var/atom/movable/A in range)
-		hear |= recursive_hear_check(A)
-
-	return hear
-
+	if (R == 0) // if the range is zero, we know exactly where to look for, we can skip view
+		. = recursive_hear_check(T)
+	else  // A variation of get_hear inlined here to take advantage of the compiler's fastpath for obj/mob in view
+		var/lum = T.luminosity
+		T.luminosity = 6
+		for(var/obj/O in view(R, T))
+			. += recursive_hear_check(O)
+		for(var/mob/M in view(R, T))
+			. += recursive_hear_check(M)
+		T.luminosity = lum
 
 /proc/get_mobs_in_radio_ranges(list/obj/item/device/radio/radios)
 

--- a/code/__HELPERS/game.dm
+++ b/code/__HELPERS/game.dm
@@ -219,16 +219,15 @@
 	if(!T)
 		return
 
-	var/list/processing_list = list()  
+	var/list/processing_list = list()
 	if (R == 0) // if the range is zero, we know exactly where to look for, we can skip view
 		processing_list += T.contents // We can shave off one iteration by assuming turfs cannot hear
 	else  // A variation of get_hear inlined here to take advantage of the compiler's fastpath for obj/mob in view
 		var/lum = T.luminosity
 		T.luminosity = 6 // This is the maximum luminosity
+		processing_list = viewers(R, T)
 		for(var/obj/O in view(R, T))
 			processing_list += O
-		for(var/mob/M in view(R, T))
-			processing_list += M
 		T.luminosity = lum
 
 	while(processing_list.len) // recursive_hear_check inlined here


### PR DESCRIPTION
This is the proc that is ultimately responsible for tcomms being in top10 during highpop. These numbers come from throwing station-bounced radios (canhear range 6) around and spamming the headset radio a lot, the actual results might be better on a real highpop environment where there are lots of range 0 radios around.


**Updated perf comparison for latest commit**

| Proc Name                                           | Self CPU | Total CPU | Real Time | Calls |
|-----------------------------------------------------|----------|-----------|-----------|-------|
|/proc/oldget_hearers_in_view|0.243|0.715|0.718|6355|
|/proc/newget_hearers_in_view|0.384|0.384|0.385|6115|

Due to insufficiently robust testing, this definitely requires a testmerge.

[Changelogs]:

:cl: Naksu
fix: Sped up saycode to remove free lag from highpop
/:cl:
