### PR TITLE
Fix the station integrity report to read the correct Z

### DIFF
--- a/code/controllers/subsystem/ticker.dm
+++ b/code/controllers/subsystem/ticker.dm
@@ -295,7 +295,7 @@ SUBSYSTEM_DEF(ticker)
 	set waitfor = FALSE
 	mode.post_setup()
 	GLOB.start_state = new /datum/station_state()
-	GLOB.start_state.count(1)
+	GLOB.start_state.count()
 	//Cleanup some stuff
 	for(var/obj/effect/landmark/start/S in GLOB.landmarks_list)
 		//Deleting Startpoints but we need the ai point to AI-ize people later

--- a/code/game/gamemodes/blob/blob_report.dm
+++ b/code/game/gamemodes/blob/blob_report.dm
@@ -6,56 +6,47 @@
 	var/door = 0
 	var/grille = 0
 	var/mach = 0
-	var/num_territories = 1//Number of total valid territories for gang mode
+
+/datum/station_state/proc/count()
+	for(var/Z in GLOB.station_z_levels)
+		for(var/turf/T in block(locate(1,1,Z), locate(world.maxx,world.maxy,Z)))
+			// don't count shuttles since they may have just left
+			if(istype(T.loc, /area/shuttle))
+				continue
+
+			if(isfloorturf(T))
+				var/turf/open/floor/TF = T
+				if(!(TF.burnt))
+					floor += 12
+				else
+					floor += 1
+
+			if(iswallturf(T))
+				var/turf/closed/wall/TW = T
+				if(TW.intact)
+					wall += 2
+				else
+					wall += 1
+
+			if(istype(T, /turf/closed/wall/r_wall))
+				var/turf/closed/wall/r_wall/TRW = T
+				if(TRW.intact)
+					r_wall += 2
+				else
+					r_wall += 1
 
 
-/datum/station_state/proc/count(count_territories)
-	for(var/turf/T in block(locate(1,1,1), locate(world.maxx,world.maxy,1)))
-
-		if(isfloorturf(T))
-			var/turf/open/floor/TF = T
-			if(!(TF.burnt))
-				src.floor += 12
-			else
-				src.floor += 1
-
-		if(iswallturf(T))
-			var/turf/closed/wall/TW = T
-			if(TW.intact)
-				src.wall += 2
-			else
-				src.wall += 1
-
-		if(istype(T, /turf/closed/wall/r_wall))
-			var/turf/closed/wall/r_wall/TRW = T
-			if(TRW.intact)
-				src.r_wall += 2
-			else
-				src.r_wall += 1
-
-
-		for(var/obj/O in T.contents)
-			if(istype(O, /obj/structure/window))
-				src.window += 1
-			else if(istype(O, /obj/structure/grille))
-				var/obj/structure/grille/GR = O
-				if(!GR.broken)
-					src.grille += 1
-			else if(istype(O, /obj/machinery/door))
-				src.door += 1
-			else if(ismachinery(O))
-				src.mach += 1
-
-	if(count_territories)
-		var/list/valid_territories = list()
-		for(var/area/A in world) //First, collect all area types on the station zlevel
-			if(A.z in GLOB.station_z_levels)
-				if(!(A.type in valid_territories) && A.valid_territory)
-					valid_territories |= A.type
-		if(valid_territories.len)
-			num_territories = valid_territories.len //Add them all up to make the total number of area types
-		else
-			to_chat(world, "ERROR: NO VALID TERRITORIES")
+			for(var/obj/O in T.contents)
+				if(istype(O, /obj/structure/window))
+					window += 1
+				else if(istype(O, /obj/structure/grille))
+					var/obj/structure/grille/GR = O
+					if(!GR.broken)
+						grille += 1
+				else if(istype(O, /obj/machinery/door))
+					door += 1
+				else if(ismachinery(O))
+					mach += 1
 
 /datum/station_state/proc/score(datum/station_state/result)
 	if(!result)


### PR DESCRIPTION
:cl:
fix: The post-round station integrity report is now functional again.
/:cl:

Fixes a bug where the integrity of CentCom was being taken instead, coming out at about 85% no matter what happened during the round. Also removes the gang territory calculation now that it isn't used anywhere.
