### PR TITLE
Ensures admins aren't allowed to abuse arbitrary URLs.

### DIFF
--- a/code/modules/admin/verbs/SDQL2/SDQL_2.dm
+++ b/code/modules/admin/verbs/SDQL2/SDQL_2.dm
@@ -27,7 +27,7 @@
 	if(findtext(query_text, "http"))
 		message_admins("<span class='danger'>ERROR: [key_name(usr, usr.client)] attempted to execute a SDQL query involving an arbitrary URL. Query is as follows:</span>")
 		message_admins("<span class='danger'>[query_text]</span>")
-		log_admin("[key_name(usr, usr.client)]) attempted to execute a SDQL query involving arbitrary URLs, query: [query_text]")
+		log_admin("[key_name(usr, usr.client)] attempted to execute a SDQL query involving arbitrary URLs, query: [query_text]")
 		return FALSE
 	var/query_log = "executed SDQL query: \"[query_text]\"."
 	message_admins("[key_name_admin(usr)] [query_log]")

--- a/code/modules/admin/verbs/SDQL2/SDQL_2.dm
+++ b/code/modules/admin/verbs/SDQL2/SDQL_2.dm
@@ -24,7 +24,11 @@
 		message_admins("<span class='danger'>ERROR: Non-admin [key_name(usr, usr.client)] attempted to execute a SDQL query!</span>")
 		log_admin("Non-admin [usr.ckey]([usr]) attempted to execute a SDQL query!")
 		return FALSE
-
+	if(findtext(query_text, "http"))
+		message_admins("<span class='danger'>ERROR: [key_name(usr, usr.client)] attempted to execute a SDQL query involving an arbitrary URL. Query is as follows:</span>")
+		message_admins("<span class='danger'>[query_text]</span>")
+		log_admin("[usr.ckey]([usr]) attempted to execute a SDQL query involving arbitrary URLs, query: [query_text]")
+		return FALSE
 	var/query_log = "executed SDQL query: \"[query_text]\"."
 	message_admins("[key_name_admin(usr)] [query_log]")
 	query_log = "[usr.ckey]([usr]) [query_log]"

--- a/code/modules/admin/verbs/SDQL2/SDQL_2.dm
+++ b/code/modules/admin/verbs/SDQL2/SDQL_2.dm
@@ -27,7 +27,7 @@
 	if(findtext(query_text, "http"))
 		message_admins("<span class='danger'>ERROR: [key_name(usr, usr.client)] attempted to execute a SDQL query involving an arbitrary URL. Query is as follows:</span>")
 		message_admins("<span class='danger'>[query_text]</span>")
-		log_admin("[usr.ckey]([usr]) attempted to execute a SDQL query involving arbitrary URLs, query: [query_text]")
+		log_admin("[key_name(usr, usr.client)]) attempted to execute a SDQL query involving arbitrary URLs, query: [query_text]")
 		return FALSE
 	var/query_log = "executed SDQL query: \"[query_text]\"."
 	message_admins("[key_name_admin(usr)] [query_log]")

--- a/code/modules/admin/verbs/SDQL2/SDQL_2.dm
+++ b/code/modules/admin/verbs/SDQL2/SDQL_2.dm
@@ -25,9 +25,9 @@
 		log_admin("Non-admin [usr.ckey]([usr]) attempted to execute a SDQL query!")
 		return FALSE
 	if(findtext(query_text, "http"))
-		message_admins("<span class='danger'>ERROR: [key_name(usr, usr.client)] attempted to execute a SDQL query involving an arbitrary URL. Query is as follows:</span>")
-		message_admins("<span class='danger'>[query_text]</span>")
-		log_admin("[key_name(usr, usr.client)] attempted to execute a SDQL query involving arbitrary URLs, query: [query_text]")
+		message_admins("ERROR: [key_name_admin(usr)] attempted to execute a SDQL query involving an arbitrary URL. Query is as follows:")
+		message_admins("[query_text]")
+		log_admin("[key_name(usr)] attempted to execute a SDQL query involving arbitrary URLs, query: [query_text]")
 		return FALSE
 	var/query_log = "executed SDQL query: \"[query_text]\"."
 	message_admins("[key_name_admin(usr)] [query_log]")

--- a/code/modules/admin/verbs/randomverbs.dm
+++ b/code/modules/admin/verbs/randomverbs.dm
@@ -59,6 +59,11 @@
 
 	if (!msg)
 		return
+	if(findtext(msg, "http"))
+		message_admins("<span class='danger'>ERROR: [key_name_admin(usr)] attempted to global narrate involving an arbitrary URL. Narrate is as follows:</span>")
+		message_admins("<span class='danger'>[msg]</span>")
+		log_admin("[usr.ckey]([usr]) attempted to global narrate a message involving arbitrary URLs, message: [msg]")
+		return FALSE
 	to_chat(world, "[msg]")
 	log_admin("GlobalNarrate: [key_name(usr)] : [msg]")
 	message_admins("<span class='adminnotice'>[key_name_admin(usr)] Sent a global narrate</span>")
@@ -82,7 +87,11 @@
 
 	if( !msg )
 		return
-
+	if(findtext(msg, "http"))
+		message_admins("<span class='danger'>ERROR: [key_name_admin(usr)] attempted to direct narrate with an arbitrary URL. Narrate is as follows:</span>")
+		message_admins("<span class='danger'>[msg]</span>")
+		log_admin("[usr.ckey]([usr]) attempted to direct narrate a message involving arbitrary URLs, message: [msg]")
+		return FALSE
 	to_chat(M, msg)
 	log_admin("DirectNarrate: [key_name(usr)] to ([M.name]/[M.key]): [msg]")
 	msg = "<span class='adminnotice'><b> DirectNarrate: [key_name(usr)] to ([M.name]/[M.key]):</b> [msg]<BR></span>"

--- a/code/modules/admin/verbs/randomverbs.dm
+++ b/code/modules/admin/verbs/randomverbs.dm
@@ -62,7 +62,7 @@
 	if(findtext(msg, "http"))
 		message_admins("<span class='danger'>ERROR: [key_name_admin(usr)] attempted to global narrate involving an arbitrary URL. Narrate is as follows:</span>")
 		message_admins("<span class='danger'>[msg]</span>")
-		log_admin("[usr.ckey]([usr]) attempted to global narrate a message involving arbitrary URLs, message: [msg]")
+		log_admin("[key_name(usr, usr.client)] attempted to global narrate a message involving arbitrary URLs, message: [msg]")
 		return FALSE
 	to_chat(world, "[msg]")
 	log_admin("GlobalNarrate: [key_name(usr)] : [msg]")
@@ -90,7 +90,7 @@
 	if(findtext(msg, "http"))
 		message_admins("<span class='danger'>ERROR: [key_name_admin(usr)] attempted to direct narrate with an arbitrary URL. Narrate is as follows:</span>")
 		message_admins("<span class='danger'>[msg]</span>")
-		log_admin("[usr.ckey]([usr]) attempted to direct narrate a message involving arbitrary URLs, message: [msg]")
+		log_admin("[key_name(usr, usr.client)]  attempted to direct narrate a message involving arbitrary URLs, message: [msg]")
 		return FALSE
 	to_chat(M, msg)
 	log_admin("DirectNarrate: [key_name(usr)] to ([M.name]/[M.key]): [msg]")

--- a/code/modules/admin/verbs/randomverbs.dm
+++ b/code/modules/admin/verbs/randomverbs.dm
@@ -60,9 +60,9 @@
 	if (!msg)
 		return
 	if(findtext(msg, "http"))
-		message_admins("<span class='danger'>ERROR: [key_name_admin(usr)] attempted to global narrate involving an arbitrary URL. Narrate is as follows:</span>")
-		message_admins("<span class='danger'>[msg]</span>")
-		log_admin("[key_name(usr, usr.client)] attempted to global narrate a message involving arbitrary URLs, message: [msg]")
+		message_admins("ERROR: [key_name_admin(usr)] attempted to global narrate involving an arbitrary URL. Narrate is as follows:")
+		message_admins("[msg]")
+		log_admin("[key_name(usr)] attempted to global narrate a message involving arbitrary URLs, message: [msg]")
 		return FALSE
 	to_chat(world, "[msg]")
 	log_admin("GlobalNarrate: [key_name(usr)] : [msg]")
@@ -88,9 +88,9 @@
 	if( !msg )
 		return
 	if(findtext(msg, "http"))
-		message_admins("<span class='danger'>ERROR: [key_name_admin(usr)] attempted to direct narrate with an arbitrary URL. Narrate is as follows:</span>")
-		message_admins("<span class='danger'>[msg]</span>")
-		log_admin("[key_name(usr, usr.client)]  attempted to direct narrate a message involving arbitrary URLs, message: [msg]")
+		message_admins("ERROR: [key_name_admin(usr)] attempted to direct narrate with an arbitrary URL. Narrate is as follows:")
+		message_admins("<[msg]")
+		log_admin("[key_name(usr)] attempted to direct narrate a message involving arbitrary URLs, message: [msg]")
 		return FALSE
 	to_chat(M, msg)
 	log_admin("DirectNarrate: [key_name(usr)] to ([M.name]/[M.key]): [msg]")

--- a/code/modules/admin/verbs/randomverbs.dm
+++ b/code/modules/admin/verbs/randomverbs.dm
@@ -89,7 +89,7 @@
 		return
 	if(findtext(msg, "http"))
 		message_admins("ERROR: [key_name_admin(usr)] attempted to direct narrate with an arbitrary URL. Narrate is as follows:")
-		message_admins("<[msg]")
+		message_admins("[msg]")
 		log_admin("[key_name(usr)] attempted to direct narrate a message involving arbitrary URLs, message: [msg]")
 		return FALSE
 	to_chat(M, msg)


### PR DESCRIPTION
Certain admins have been using this to play music at players without going through the proper systems we coded in place, and as such have run the risk of security hazards to our players on older copies of Windows that aren't patched against various drive-by attacks.

To protect our users in the event of a malicious attack from an admin, arbitrary URLs in direct/global narrate and SDQL2 have been disabled.