### PR TITLE
Increases time able to be defibbed

### DIFF
--- a/code/__DEFINES/misc.dm
+++ b/code/__DEFINES/misc.dm
@@ -340,8 +340,8 @@ GLOBAL_LIST_INIT(ghost_others_options, list(GHOST_OTHERS_SIMPLE, GHOST_OTHERS_DE
 #define MAP_MAXZ 6
 
 // Defib stats
-#define DEFIB_TIME_LIMIT 120
-#define DEFIB_TIME_LOSS 60
+#define DEFIB_TIME_LIMIT 300
+#define DEFIB_TIME_LOSS 150
 
 // Diagonal movement
 #define FIRST_DIAG_STEP 1


### PR DESCRIPTION
2 minutes to be defibbed is too short, even with the hoping your body doesn't take too much damage and not being husked. Buffing the time to 5 minutes will hopefully stop docs from cloning everything they poke with a stick. I also changed the time before you take brain damage to 2.5 minutes in relation to the time increase.

:cl: optional name here
balance: Increased time able to be defibbed to 5 minutes.
balance: Increased time before you take brain damage when dead to 2 minutes and 30 seconds.
/:cl:

