### PR TITLE
More nuanced damage examination

### DIFF
--- a/code/modules/mob/living/carbon/examine.dm
+++ b/code/modules/mob/living/carbon/examine.dm
@@ -44,22 +44,28 @@
 	msg += "<span class='warning'>"
 	var/temp = getBruteLoss()
 	if(temp)
-		if (temp < 30)
+		if (temp < 20)
 			msg += "[t_He] [t_has] minor bruising.\n"
+		else if (temp >= 20 && temp < 40)
+			msg += "[t_He] [t_has] <b>moderate</b> bruising.\n"
 		else
 			msg += "<B>[t_He] [t_has] severe bruising!</B>\n"
 
 	temp = getFireLoss()
 	if(temp)
-		if (temp < 30)
+		if (temp < 20)
 			msg += "[t_He] [t_has] minor burns.\n"
+		else if (temp >= 20 && temp < 40)
+			msg += "[t_He] [t_has] <b>moderate</b> burns.\n"
 		else
 			msg += "<B>[t_He] [t_has] severe burns!</B>\n"
 
 	temp = getCloneLoss()
 	if(temp)
-		if(getCloneLoss() < 30)
+		if(temp < 20)
 			msg += "[t_He] [t_is] slightly deformed.\n"
+		else if (temp >= 20 && temp < 40)
+			msg += "[t_He] [t_is] <b>moderately</b> deformed.\n"
 		else
 			msg += "<b>[t_He] [t_is] severely deformed.</b>\n"
 

--- a/code/modules/mob/living/carbon/examine.dm
+++ b/code/modules/mob/living/carbon/examine.dm
@@ -46,7 +46,7 @@
 	if(temp)
 		if (temp < 25)
 			msg += "[t_He] [t_has] minor bruising.\n"
-		else if (temp >= 25 && temp < 50)
+		else if (temp < 50)
 			msg += "[t_He] [t_has] <b>moderate</b> bruising!\n"
 		else
 			msg += "<B>[t_He] [t_has] severe bruising!</B>\n"
@@ -55,7 +55,7 @@
 	if(temp)
 		if (temp < 25)
 			msg += "[t_He] [t_has] minor burns.\n"
-		else if (temp >= 25 && temp < 50)
+		else if (temp < 50)
 			msg += "[t_He] [t_has] <b>moderate</b> burns!\n"
 		else
 			msg += "<B>[t_He] [t_has] severe burns!</B>\n"
@@ -64,7 +64,7 @@
 	if(temp)
 		if(temp < 25)
 			msg += "[t_He] [t_is] slightly deformed.\n"
-		else if (temp >= 25 && temp < 50)
+		else if (temp < 50)
 			msg += "[t_He] [t_is] <b>moderately</b> deformed!\n"
 		else
 			msg += "<b>[t_He] [t_is] severely deformed!</b>\n"

--- a/code/modules/mob/living/carbon/examine.dm
+++ b/code/modules/mob/living/carbon/examine.dm
@@ -44,30 +44,30 @@
 	msg += "<span class='warning'>"
 	var/temp = getBruteLoss()
 	if(temp)
-		if (temp < 20)
+		if (temp < 25)
 			msg += "[t_He] [t_has] minor bruising.\n"
-		else if (temp >= 20 && temp < 40)
-			msg += "[t_He] [t_has] <b>moderate</b> bruising.\n"
+		else if (temp >= 25 && temp < 50)
+			msg += "[t_He] [t_has] <b>moderate</b> bruising!\n"
 		else
 			msg += "<B>[t_He] [t_has] severe bruising!</B>\n"
 
 	temp = getFireLoss()
 	if(temp)
-		if (temp < 20)
+		if (temp < 25)
 			msg += "[t_He] [t_has] minor burns.\n"
-		else if (temp >= 20 && temp < 40)
-			msg += "[t_He] [t_has] <b>moderate</b> burns.\n"
+		else if (temp >= 25 && temp < 50)
+			msg += "[t_He] [t_has] <b>moderate</b> burns!\n"
 		else
 			msg += "<B>[t_He] [t_has] severe burns!</B>\n"
 
 	temp = getCloneLoss()
 	if(temp)
-		if(temp < 20)
+		if(temp < 25)
 			msg += "[t_He] [t_is] slightly deformed.\n"
-		else if (temp >= 20 && temp < 40)
-			msg += "[t_He] [t_is] <b>moderately</b> deformed.\n"
+		else if (temp >= 25 && temp < 50)
+			msg += "[t_He] [t_is] <b>moderately</b> deformed!\n"
 		else
-			msg += "<b>[t_He] [t_is] severely deformed.</b>\n"
+			msg += "<b>[t_He] [t_is] severely deformed!</b>\n"
 
 	if(getBrainLoss() > 60)
 		msg += "[t_He] seems to be clumsy and unable to think.\n"


### PR DESCRIPTION
:cl: Robustin
tweak: Damage examinations now include a "moderate" classification. Before minor was <30 and severe was anything 30 or above. Now minor is <25, moderate is 25 to <50, and severe is 50+. 
/:cl:

Its always been low-key frustrating that someone can be crippled by minor injuries and having 30 as the breakpoint made it hard to assess someone's injuries. 30 is also rather low for a SEVERE classification and it was also weird that it would go straight from minor to severe.
