### PR TITLE
Tesla no longer NOTHING PERSONNEL's the power beacon

### DIFF
--- a/code/game/machinery/syndicatebeacon.dm
+++ b/code/game/machinery/syndicatebeacon.dm
@@ -88,10 +88,10 @@
 	if(surplus() > 1500)
 		add_load(1500)
 		if(cooldown <= world.time)
-			cooldown = world.time + 100
+			cooldown = world.time + 80
 			for(var/obj/singularity/singulo in GLOB.singularities)
 				if(singulo.z == z)
-					say("The [singulo] is now [get_dist(src,singulo)] standard lengths away to the [dir2text(get_dir(src,singulo))]")
+					say("[singulo] is now [get_dist(src,singulo)] standard lengths away to the [dir2text(get_dir(src,singulo))]")
 	else
 		Deactivate()
 		say("Insufficient charge detected - powering down")

--- a/code/modules/power/tesla/energy_ball.dm
+++ b/code/modules/power/tesla/energy_ball.dm
@@ -78,7 +78,7 @@
 	var/move_bias = pick(GLOB.alldirs)
 	for(var/i in 0 to move_amount)
 		var/move_dir = pick(GLOB.alldirs + move_bias) //ensures large-ball teslas don't just sit around 
-		if(target && prob(60))
+		if(target && prob(10))
 			move_dir = get_dir(src,target)
 		var/turf/T = get_step(src, move_dir)
 		if(can_move(T))


### PR DESCRIPTION
:cl: Robustin
tweak: The tesla will now move toward power beacons at a significantly slower rate. 
/:cl:

Also the announcement got a grammar fix and will occur slightly more frequently.

Currently the SM spawns teslas with 30+ balls, which means turning on a beacon will bring the Tesla to your position within seconds. I don't know why I keep messing with tesla and beacon code...
