### PR TITLE
Add check for soundloop runtime

### DIFF
--- a/code/game/machinery/computer/_computer.dm
+++ b/code/game/machinery/computer/_computer.dm
@@ -67,7 +67,8 @@
 /obj/machinery/computer/power_change()
 	..()
 	if(stat & NOPOWER)
-		soundloop.stop()
+		if(soundloop)
+			soundloop.stop()
 		set_light(0)
 	else
 		set_light(brightness_on)


### PR DESCRIPTION
Closes #32709

Check for a soundloop before calling to ensure we don't get a runtime.