### PR TITLE
[512] Disallow cross-Z examination and manipulation

### DIFF
--- a/code/__DEFINES/is_helpers.dm
+++ b/code/__DEFINES/is_helpers.dm
@@ -4,7 +4,14 @@
 
 #define islist(L) (istype(L, /list))
 
+#if DM_VERSION >= 512
+#define in_range(source, user) (get_dist(source, user) <= 1 && (get_step(source, 0)?:z) == (get_step(user, 0)?:z))
+#if DM_VERSION > 512
+#warn Remove this check.
+#endif
+#else
 #define in_range(source, user) (get_dist(source, user) <= 1)
+#endif
 
 #define ismovableatom(A) (istype(A, /atom/movable))
 

--- a/code/_onclick/adjacent.dm
+++ b/code/_onclick/adjacent.dm
@@ -29,10 +29,10 @@
 	var/turf/T0 = get_turf(neighbor)
 
 	if(T0 == src) //same turf
-		return 1
+		return TRUE
 
-	if(get_dist(src,T0) > 1) //too far
-		return 0
+	if(get_dist(src, T0) > 1 || z != T0.z) //too far
+		return FALSE
 
 	// Non diagonal case
 	if(T0.x == x || T0.y == y)


### PR DESCRIPTION
:cl:
fix: Interacting with objects at the same X and Y but a different Z is no longer possible.
/:cl:

Will become important for multi-Z stuff, so people can't subtly pick items up, view turf contents through the alt-click menu, or manipulate machines from another Z-level.

Currently gated behind DM 512 for performance reasons, but it'll be beneficial for Sybil and kick in automatically when the other servers upgrade.