### PR TITLE
Revert "hey it's been a week, time to Remove Secborg (#32708)"

### DIFF
--- a/code/controllers/configuration/entries/game_options.dm
+++ b/code/controllers/configuration/entries/game_options.dm
@@ -52,6 +52,8 @@ CONFIG_DEF(flag/humans_need_surnames)
 
 CONFIG_DEF(flag/allow_ai)	// allow ai job
 
+CONFIG_DEF(flag/disable_secborg)	// disallow secborg module to be chosen.
+
 CONFIG_DEF(flag/disable_peaceborg)
 
 CONFIG_DEF(number/traitor_scaling_coeff)	//how much does the amount of players get divided by to determine traitors

--- a/code/modules/mob/living/silicon/robot/robot.dm
+++ b/code/modules/mob/living/silicon/robot/robot.dm
@@ -210,6 +210,8 @@
 	"Service" = /obj/item/robot_module/butler)
 	if(!CONFIG_GET(flag/disable_peaceborg))
 		modulelist["Peacekeeper"] = /obj/item/robot_module/peacekeeper
+	if(!CONFIG_GET(flag/disable_secborg))
+		modulelist["Security"] = /obj/item/robot_module/security
 
 	var/input_module = input("Please, select a module!", "Robot", null, null) as null|anything in modulelist
 	if(!input_module || module.type != /obj/item/robot_module)

--- a/config/game_options.txt
+++ b/config/game_options.txt
@@ -251,6 +251,10 @@ EVENTS_MIN_PLAYERS_MUL 1
 ## Allow the AI job to be picked.
 ALLOW_AI
 
+## Secborg ###
+## Uncomment to prevent the security cyborg module from being chosen
+#DISABLE_SECBORG
+
 ## Peacekeeper Borg ###
 ## Uncomment to prevent the peacekeeper cyborg module from being chosen
 #DISABLE_PEACEBORG


### PR DESCRIPTION
This reverts commit f59d9a870a7f4bc7d762afba673a1c4ac9ab283f. #32708 @Iamgoofball 


I will also be re-enabling secborgs.

@KorPhaeron Every argument you have made against this feature is wrong.

Hard counters like flash and borgs and laser pointers and other hard equipment checks are what make this game great. If you have a well balanced game with well balanced features where everything is perfect then you get a formulaic game that feels more like going thru the motions then actually fun. The hard counters and zero warning equipment checks are what keep this game unpredictable and lead to half the memorable and iconic stories in the stories of awesome thread.

Furthermore your inability to manage the admin team or create any sort of consensus doesn't lead to an argument against secborgs. How is it that the old headmin team lead mostly by hbl was able to keep borgs as ai right hands without them becoming security right hands but now they can't? What are we missing, how about we solve that issue rather then address the symptom?


