### PR TITLE
Fixes changeling egg when slug destroyed

### DIFF
--- a/code/modules/mob/living/simple_animal/hostile/headcrab.dm
+++ b/code/modules/mob/living/simple_animal/hostile/headcrab.dm
@@ -72,7 +72,7 @@
 	for(var/obj/item/organ/I in src)
 		I.Insert(M, 1)
 
-	if(origin && origin.current && (origin.current.stat == DEAD))
+	if(origin && (origin.current ? (origin.current.stat == DEAD) : origin.get_ghost()))
 		origin.transfer_to(M)
 		var/datum/antagonist/changeling/C = origin.has_antag_datum(/datum/antagonist/changeling)
 		if(!C)


### PR DESCRIPTION
When using Last Resort, if you successfully inject an egg into a corpse, but your brainslug gets destroyed before the egg hatches, when the egg does hatch you will not be put into the monkey.

:cl: JJRcop
fix: Fixes changeling eggs not putting the changeling in control if the brainslug is destroyed before hatching.
/:cl: