### PR TITLE
Makes TGUI's reload.bat account for spaces in username

### DIFF
--- a/tgui/reload.bat
+++ b/tgui/reload.bat
@@ -3,7 +3,7 @@ REM Get the documents folder from the registry.
 for /f "tokens=3* delims= " %%a in (
     'reg query "HKEY_CURRENT_USER\Software\Microsoft\Windows\CurrentVersion\Explorer\Shell Folders" /v "Personal"'
 ) do (
-    set documents=%%a
+    set documents=%%a %%b
 )
 REM Copy assets to the BYOND cache
 cmd /c copy assets\* "%documents%\BYOND\cache" /y


### PR DESCRIPTION
[why]:  Reload.bat did not account for spaces in usernames so it could not find the directory.

