### PR TITLE
Webhook processor will comment negative PR balances on unlabelled PRs

### DIFF
--- a/tools/WebhookProcessor/github_webhook_processor.php
+++ b/tools/WebhookProcessor/github_webhook_processor.php
@@ -362,7 +362,7 @@ function handle_pr($payload) {
 			tag_pr($payload, true);
 			if($no_changelog)
 				check_dismiss_changelog_review($payload);
-			if(get_pr_code_friendliness($payload) < 0){
+			if(get_pr_code_friendliness($payload) <= 0){
 				$balances = pr_balances();
 				$author = $payload['pull_request']['user']['login'];
 				if(isset($balances[$author]) && $balances[$author] < 0 && !is_maintainer($payload, $author))


### PR DESCRIPTION
This was actually a PR on my own repo for the past month, whoops