### PR TITLE
Prevents proximity sensors from beeping when unarmed.

### DIFF
--- a/code/modules/assembly/proximity.dm
+++ b/code/modules/assembly/proximity.dm
@@ -53,7 +53,7 @@
 
 
 /obj/item/device/assembly/prox_sensor/sense()
-	if(!secured || next_activate > world.time)
+	if(!scanning || !secured || next_activate > world.time)
 		return 0
 	pulse(0)
 	audible_message("[icon2html(src, hearers(src))] *beep* *beep*", null, 3)


### PR DESCRIPTION
[Changelogs]: 
:cl: DaxDupont
fix: Proximity sensors no longer beep when unarmed.
/:cl:

[why]: I think this is the right way to fix https://github.com/tgstation/tgstation/issues/32779. proximity.dm with setrange of 0 seems to still report on same turf intentionally so the check needs to be moved. Unless there's a way to disable proximity monitoring completely.

Fixes #32779 