### PR TITLE
Corrects Meta console direction

### DIFF
--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -51027,7 +51027,7 @@
 /area/security/checkpoint/medical)
 "cbQ" = (
 /obj/machinery/computer/secure_data{
-	dir = 1
+	dir = 4
 	},
 /obj/machinery/computer/security/telescreen{
 	desc = "Used for monitoring medbay to ensure patient safety.";
@@ -51796,9 +51796,7 @@
 /turf/closed/wall,
 /area/medical/medbay/central)
 "cdx" = (
-/obj/machinery/computer/crew{
-	dir = 8
-	},
+/obj/machinery/computer/crew,
 /turf/open/floor/plasteel/vault,
 /area/medical/medbay/central)
 "cdy" = (


### PR DESCRIPTION
Closes #32802

:cl: ShizCalev
fix: MetaStation - The consoles in medbay have had their directions corrected.
/:cl: