### PR TITLE
Fixes topic logs exposing serviceCommsKey

### DIFF
--- a/code/game/world.dm
+++ b/code/game/world.dm
@@ -115,6 +115,9 @@ GLOBAL_PROTECT(security_mode)
 		warning("/tg/station 13 uses many file operations, a few shell()s, and some external call()s. Trusted mode is recommended. You can download our source code for your own browsing and compilation at https://github.com/tgstation/tgstation")
 
 /world/Topic(T, addr, master, key)
+
+	SERVER_TOOLS_ON_TOPIC	//redirect to server tools if necessary
+
 	var/static/list/topic_handlers = TopicHandlers()
 
 	var/list/input = params2list(T)
@@ -126,8 +129,6 @@ GLOBAL_PROTECT(security_mode)
 
 	if((!handler || initial(handler.log)) && config && CONFIG_GET(flag/log_world_topic))
 		WRITE_FILE(GLOB.world_game_log, "TOPIC: \"[T]\", from:[addr], master:[master], key:[key]")
-
-	SERVER_TOOLS_ON_TOPIC	//redirect to server tools if necessary
 
 	if(!handler)
 		return


### PR DESCRIPTION
Actions are already logged server tools side so needing to log the topics is dubious at best