### PR TITLE
Removes duplicate data for ai airlock menu

### DIFF
--- a/code/game/machinery/doors/airlock.dm
+++ b/code/game/machinery/doors/airlock.dm
@@ -1375,8 +1375,6 @@
 	power["backup_timeleft"] = src.secondsBackupPowerLost
 	data["power"] = power
 
-	data["density"] = density
-	data["welded"] = welded
 	data["shock"] = secondsElectrified == 0 ? 2 : 0
 	data["shock_timeleft"] = secondsElectrified
 	data["id_scanner"] = !aiDisabledIdScanner


### PR DESCRIPTION
Shame on me, in #32761 I didn't notice that data.density was already there so I added data.opened, and I also failed to notice that welded was already provided, and I just overwrote it with the same thing. 
https://github.com/tgstation/tgstation/blob/db1b6e32418b2db3e4aa4098172fcf248b25c4bd/code/game/machinery/doors/airlock.dm#L1386-L1387
I'm just going to remove the old data I didn't notice so that way I don't have to change the .ract to use density instead.