### PR TITLE
Fixes suicidal blobbernauts

### DIFF
--- a/code/game/gamemodes/blob/powers.dm
+++ b/code/game/gamemodes/blob/powers.dm
@@ -168,7 +168,6 @@
 		blobber.factory = B
 		blobber.overmind = src
 		blobber.update_icons()
-		blobber.notransform = 1 //stop the naut from moving around
 		blobber.adjustHealth(blobber.maxHealth * 0.5)
 		blob_mobs += blobber
 		var/client/C = pick(candidates)

--- a/code/game/gamemodes/blob/powers.dm
+++ b/code/game/gamemodes/blob/powers.dm
@@ -154,33 +154,35 @@
 		return
 	if(!can_buy(40))
 		return
-	B.max_integrity = initial(B.max_integrity) * 0.25 //factories that produced a blobbernaut have much lower health
-	B.obj_integrity = min(B.obj_integrity, B.max_integrity)
-	B.update_icon()
-	B.visible_message("<span class='warning'><b>The blobbernaut [pick("rips", "tears", "shreds")] its way out of the factory blob!</b></span>")
-	playsound(B.loc, 'sound/effects/splat.ogg', 50, 1)
-	var/mob/living/simple_animal/hostile/blob/blobbernaut/blobber = new /mob/living/simple_animal/hostile/blob/blobbernaut(get_turf(B))
-	flick("blobbernaut_produce", blobber)
-	B.naut = blobber
-	blobber.factory = B
-	blobber.overmind = src
-	blobber.update_icons()
-	blobber.notransform = 1 //stop the naut from moving around
-	blobber.adjustHealth(blobber.maxHealth * 0.5)
-	blob_mobs += blobber
-	var/list/mob/dead/observer/candidates = pollCandidatesForMob("Do you want to play as a [blob_reagent_datum.name] blobbernaut?", ROLE_BLOB, null, ROLE_BLOB, 50, blobber) //players must answer rapidly
+
+	var/list/mob/dead/observer/candidates = pollCandidatesForMob("Do you want to play as a [blob_reagent_datum.name] blobbernaut?", ROLE_BLOB, null, ROLE_BLOB, 50) //players must answer rapidly
 	if(candidates.len) //if we got at least one candidate, they're a blobbernaut now.
+		B.max_integrity = initial(B.max_integrity) * 0.25 //factories that produced a blobbernaut have much lower health
+		B.obj_integrity = min(B.obj_integrity, B.max_integrity)
+		B.update_icon()
+		B.visible_message("<span class='warning'><b>The blobbernaut [pick("rips", "tears", "shreds")] its way out of the factory blob!</b></span>")
+		playsound(B.loc, 'sound/effects/splat.ogg', 50, 1)
+		var/mob/living/simple_animal/hostile/blob/blobbernaut/blobber = new /mob/living/simple_animal/hostile/blob/blobbernaut(get_turf(B))
+		flick("blobbernaut_produce", blobber)
+		B.naut = blobber
+		blobber.factory = B
+		blobber.overmind = src
+		blobber.update_icons()
+		blobber.notransform = 1 //stop the naut from moving around
+		blobber.adjustHealth(blobber.maxHealth * 0.5)
+		blob_mobs += blobber
 		var/client/C = pick(candidates)
 		blobber.key = C.key
 		SEND_SOUND(blobber, sound('sound/effects/blobattack.ogg'))
 		SEND_SOUND(blobber, sound('sound/effects/attackblob.ogg'))
 		to_chat(blobber, "<b>You are a blobbernaut!</b>")
-		to_chat(blobber, "You are powerful, hard to kill, and slowly regenerate near nodes and cores, but will slowly die if not near the blob or if the factory that made you is killed.")
+		to_chat(blobber, "You are powerful, hard to kill, and slowly regenerate near nodes and cores, <span class='cultlarge'>but will slowly die if not near the blob</span> or if the factory that made you is killed.")
 		to_chat(blobber, "You can communicate with other blobbernauts and overminds via <b>:b</b>")
 		to_chat(blobber, "Your overmind's blob reagent is: <b><font color=\"[blob_reagent_datum.color]\">[blob_reagent_datum.name]</b></font>!")
 		to_chat(blobber, "The <b><font color=\"[blob_reagent_datum.color]\">[blob_reagent_datum.name]</b></font> reagent [blob_reagent_datum.shortdesc ? "[blob_reagent_datum.shortdesc]" : "[blob_reagent_datum.description]"]")
-	if(blobber)
-		blobber.notransform = 0
+	else
+		to_chat(src, "<span class='warning'>You could not conjure a sentience for your blobbernaut. Your points have been refunded. Try again later.</span>")
+		add_points(40)
 
 /mob/camera/blob/verb/relocate_core()
 	set category = "Blob"


### PR DESCRIPTION
:cl: Kor
fix: Blobbernauts will no longer spawn if a player is not selected to control it, preventing AI blobbernauts from running off the blob and to their deaths.
/:cl:

Why: Our AI is not smart enough to understand if it walks off the blob it dies, and that is a massive waste of points.

I also put the "you will die if you walk off the blob" in massive obnoxious letters to hopefully curb player controlled blobbernauts doing the same
