### PR TITLE
Fixes abductor teams getting assigned to same pod

### DIFF
--- a/code/game/gamemodes/miniantags/abduction/abduction.dm
+++ b/code/game/gamemodes/miniantags/abduction/abduction.dm
@@ -26,6 +26,7 @@
 	var/max_teams = 4
 	var/list/datum/objective_team/abductor_team/abductor_teams = list()
 	var/finished = FALSE
+	var/static/team_count = 0
 
 /datum/game_mode/abduction/announce()
 	to_chat(world, "<B>The current game mode is - Abduction!</B>")
@@ -44,7 +45,11 @@
 	return TRUE
 
 /datum/game_mode/abduction/proc/make_abductor_team(datum/mind/agent, datum/mind/scientist)
-	var/team_number = abductor_teams.len+1
+	team_count++ //TODO: Fix the edge case of abductor game mode rolling twice+ and failing to setup on first time.
+	var/team_number = team_count
+
+	if(team_number > max_teams)
+		return null //or should it try to stuff them in anway ?
 
 	var/datum/objective_team/abductor_team/team = new
 	team.team_number = team_number

--- a/code/game/gamemodes/miniantags/abduction/abduction.dm
+++ b/code/game/gamemodes/miniantags/abduction/abduction.dm
@@ -49,7 +49,7 @@
 	var/team_number = team_count
 
 	if(team_number > max_teams)
-		return null //or should it try to stuff them in anway ?
+		return //or should it try to stuff them in anway ?
 
 	var/datum/objective_team/abductor_team/team = new
 	team.team_number = team_number

--- a/code/modules/events/abductor.dm
+++ b/code/modules/events/abductor.dm
@@ -26,7 +26,11 @@
 	var/mob/living/carbon/human/agent = makeBody(pick_n_take(candidates))
 	var/mob/living/carbon/human/scientist = makeBody(pick_n_take(candidates))
 
-	GM.post_setup_team(GM.make_abductor_team(agent.mind, scientist.mind))
+	var/team = GM.make_abductor_team(agent.mind, scientist.mind)
+	if(!team)
+		return MAP_ERROR
+
+	GM.post_setup_team(team)
 
 	spawned_mobs += list(agent, scientist)
 	return SUCCESSFUL_SPAWN


### PR DESCRIPTION
Fixes #32798

I need to standardize team creation here after nuke ops. 