### PR TITLE
Actually fixes the glowshroom runtime

### DIFF
--- a/code/game/objects/effects/glowshroom.dm
+++ b/code/game/objects/effects/glowshroom.dm
@@ -59,8 +59,11 @@
 	obj_integrity = myseed.endurance
 	max_integrity = myseed.endurance
 	var/datum/plant_gene/trait/glow/G = myseed.get_gene(/datum/plant_gene/trait/glow)
-	if(G)
-		set_light(G.glow_range(myseed), G.glow_power(myseed), G.glow_color)
+	if(ispath(G)) // Seeds were ported to initialize so their genes are still typepaths here, luckily their initializer is smart enough to handle us doing this
+		myseed.genes -= G
+		G = new G
+		myseed.genes += G
+	set_light(G.glow_range(myseed), G.glow_power(myseed), G.glow_color)
 	setDir(CalcDir())
 	var/base_icon_state = initial(icon_state)
 	if(!floor)


### PR DESCRIPTION
#32719 please test your changes

Instantiating a needed typepath out-of-order like this has a whiff of unsavoriness, but the seed initializer can actually handle that and we need the gene's procs and vars here. Another option would be to INITIALIZE_IMMEDIATE seeds but that seems very brute forcey also...