### PR TITLE
Allows rotating computer frames, fixes rotation on deconstruction, switches dropped materials to use drop_location()

### DIFF
--- a/code/game/machinery/computer/_computer.dm
+++ b/code/game/machinery/computer/_computer.dm
@@ -111,15 +111,16 @@
 	if(!(flags_1 & NODECONSTRUCT_1))
 		if(circuit) //no circuit, no computer frame
 			var/obj/structure/frame/computer/A = new /obj/structure/frame/computer(src.loc)
+			A.dir = dir
 			A.circuit = circuit
 			A.anchored = TRUE
 			if(stat & BROKEN)
 				if(user)
 					to_chat(user, "<span class='notice'>The broken glass falls out.</span>")
 				else
-					playsound(src.loc, 'sound/effects/hit_on_shattered_glass.ogg', 70, 1)
-				new /obj/item/shard(src.loc)
-				new /obj/item/shard(src.loc)
+					playsound(src, 'sound/effects/hit_on_shattered_glass.ogg', 70, 1)
+				new /obj/item/shard(drop_location())
+				new /obj/item/shard(drop_location())
 				A.state = 3
 				A.icon_state = "3"
 			else

--- a/code/game/machinery/computer/buildandrepair.dm
+++ b/code/game/machinery/computer/buildandrepair.dm
@@ -8,7 +8,7 @@
 	switch(state)
 		if(0)
 			if(istype(P, /obj/item/wrench))
-				playsound(src.loc, P.usesound, 50, 1)
+				playsound(src, P.usesound, 50, 1)
 				to_chat(user, "<span class='notice'>You start wrenching the frame into place...</span>")
 				if(do_after(user, 20*P.toolspeed, target = src))
 					to_chat(user, "<span class='notice'>You wrench the frame into place.</span>")
@@ -21,19 +21,19 @@
 					if(!WT.isOn())
 						to_chat(user, "<span class='warning'>[WT] must be on to complete this task!</span>")
 					return
-				playsound(src.loc, P.usesound, 50, 1)
+				playsound(src, P.usesound, 50, 1)
 				to_chat(user, "<span class='notice'>You start deconstructing the frame...</span>")
 				if(do_after(user, 20*P.toolspeed, target = src))
 					if(!src || !WT.isOn())
 						return
 					to_chat(user, "<span class='notice'>You deconstruct the frame.</span>")
-					var/obj/item/stack/sheet/metal/M = new (loc, 5)
+					var/obj/item/stack/sheet/metal/M = new (drop_location(), 5)
 					M.add_fingerprint(user)
 					qdel(src)
 				return
 		if(1)
 			if(istype(P, /obj/item/wrench))
-				playsound(src.loc, P.usesound, 50, 1)
+				playsound(src, P.usesound, 50, 1)
 				to_chat(user, "<span class='notice'>You start to unfasten the frame...</span>")
 				if(do_after(user, 20*P.toolspeed, target = src))
 					to_chat(user, "<span class='notice'>You unfasten the frame.</span>")
@@ -43,7 +43,7 @@
 			if(istype(P, /obj/item/circuitboard/computer) && !circuit)
 				if(!user.transferItemToLoc(P, null))
 					return
-				playsound(src.loc, 'sound/items/deconstruct.ogg', 50, 1)
+				playsound(src, 'sound/items/deconstruct.ogg', 50, 1)
 				to_chat(user, "<span class='notice'>You place [P] inside the frame.</span>")
 				icon_state = "1"
 				circuit = P
@@ -54,13 +54,13 @@
 				to_chat(user, "<span class='warning'>This frame does not accept circuit boards of this type!</span>")
 				return
 			if(istype(P, /obj/item/screwdriver) && circuit)
-				playsound(src.loc, P.usesound, 50, 1)
+				playsound(src, P.usesound, 50, 1)
 				to_chat(user, "<span class='notice'>You screw [circuit] into place.</span>")
 				state = 2
 				icon_state = "2"
 				return
 			if(istype(P, /obj/item/crowbar) && circuit)
-				playsound(src.loc, P.usesound, 50, 1)
+				playsound(src, P.usesound, 50, 1)
 				to_chat(user, "<span class='notice'>You remove [circuit].</span>")
 				state = 1
 				icon_state = "0"
@@ -70,7 +70,7 @@
 				return
 		if(2)
 			if(istype(P, /obj/item/screwdriver) && circuit)
-				playsound(src.loc, P.usesound, 50, 1)
+				playsound(src, P.usesound, 50, 1)
 				to_chat(user, "<span class='notice'>You unfasten the circuit board.</span>")
 				state = 1
 				icon_state = "1"
@@ -78,7 +78,7 @@
 			if(istype(P, /obj/item/stack/cable_coil))
 				var/obj/item/stack/cable_coil/C = P
 				if(C.get_amount() >= 5)
-					playsound(src.loc, 'sound/items/deconstruct.ogg', 50, 1)
+					playsound(src, 'sound/items/deconstruct.ogg', 50, 1)
 					to_chat(user, "<span class='notice'>You start adding cables to the frame...</span>")
 					if(do_after(user, 20*P.toolspeed, target = src))
 						if(C.get_amount() >= 5 && state == 2)
@@ -91,11 +91,11 @@
 				return
 		if(3)
 			if(istype(P, /obj/item/wirecutters))
-				playsound(src.loc, P.usesound, 50, 1)
+				playsound(src, P.usesound, 50, 1)
 				to_chat(user, "<span class='notice'>You remove the cables.</span>")
 				state = 2
 				icon_state = "2"
-				var/obj/item/stack/cable_coil/A = new (loc)
+				var/obj/item/stack/cable_coil/A = new (drop_location())
 				A.amount = 5
 				A.add_fingerprint(user)
 				return
@@ -106,7 +106,7 @@
 					to_chat(user, "<span class='warning'>You need two glass sheets to continue construction!</span>")
 					return
 				else
-					playsound(src.loc, 'sound/items/deconstruct.ogg', 50, 1)
+					playsound(src, 'sound/items/deconstruct.ogg', 50, 1)
 					to_chat(user, "<span class='notice'>You start to put in the glass panel...</span>")
 					if(do_after(user, 20, target = src))
 						if(G.get_amount() >= 2 && state == 3)
@@ -117,17 +117,17 @@
 				return
 		if(4)
 			if(istype(P, /obj/item/crowbar))
-				playsound(src.loc, P.usesound, 50, 1)
+				playsound(src, P.usesound, 50, 1)
 				to_chat(user, "<span class='notice'>You remove the glass panel.</span>")
 				state = 3
 				icon_state = "3"
-				var/obj/item/stack/sheet/glass/G = new (loc, 2)
+				var/obj/item/stack/sheet/glass/G = new (drop_location(), 2)
 				G.add_fingerprint(user)
 				return
 			if(istype(P, /obj/item/screwdriver))
-				playsound(src.loc, P.usesound, 50, 1)
+				playsound(src, P.usesound, 50, 1)
 				to_chat(user, "<span class='notice'>You connect the monitor.</span>")
-				var/obj/B = new src.circuit.build_path (src.loc, circuit)
+				var/obj/B = new src.circuit.build_path (src, circuit)
 				transfer_fingerprints_to(B)
 				qdel(src)
 				return
@@ -138,9 +138,19 @@
 /obj/structure/frame/computer/deconstruct(disassembled = TRUE)
 	if(!(flags_1 & NODECONSTRUCT_1))
 		if(state == 4)
-			new /obj/item/shard(loc)
-			new /obj/item/shard(loc)
+			new /obj/item/shard(drop_location())
+			new /obj/item/shard(drop_location())
 		if(state >= 3)
-			new /obj/item/stack/cable_coil(loc , 5)
-
+			new /obj/item/stack/cable_coil(drop_location(), 5)
 	..()
+
+/obj/structure/frame/computer/AltClick(mob/user)
+	..()
+	if(!in_range(src, user) || user.incapacitated())
+		return
+	
+	if(anchored)
+		to_chat(usr, "<span class='warning'>You must unwrench [src] before rotating it!</span>")
+		return
+
+	setDir(turn(dir, -90))

--- a/code/game/machinery/computer/buildandrepair.dm
+++ b/code/game/machinery/computer/buildandrepair.dm
@@ -146,9 +146,9 @@
 
 /obj/structure/frame/computer/AltClick(mob/user)
 	..()
-	if(!in_range(src, user) || user.incapacitated())
+	if(!in_range(src, user) || !isliving(user) || user.incapacitated())
 		return
-	
+
 	if(anchored)
 		to_chat(usr, "<span class='warning'>You must unwrench [src] before rotating it!</span>")
 		return


### PR DESCRIPTION
Fixes #32870

🆑 ShizCalev
fix: Computers will no longer rotate incorrectly when being deconstructed.
fix: You can now rotate computer frames during construction.
/🆑