### PR TITLE
Fix teleporter consoles rotating themselves

### DIFF
--- a/code/game/machinery/computer/gulag_teleporter.dm
+++ b/code/game/machinery/computer/gulag_teleporter.dm
@@ -129,8 +129,8 @@
 /obj/machinery/computer/gulag_teleporter_computer/proc/findteleporter()
 	var/obj/machinery/gulag_teleporter/teleporterf = null
 
-	for(dir in GLOB.cardinals)
-		teleporterf = locate(/obj/machinery/gulag_teleporter, get_step(src, dir))
+	for(var/direction in GLOB.cardinals)
+		teleporterf = locate(/obj/machinery/gulag_teleporter, get_step(src, direction))
 		if(teleporterf && teleporterf.is_operational())
 			return teleporterf
 

--- a/code/game/machinery/computer/teleporter.dm
+++ b/code/game/machinery/computer/teleporter.dm
@@ -27,8 +27,8 @@
 /obj/machinery/computer/teleporter/proc/link_power_station()
 	if(power_station)
 		return
-	for(dir in GLOB.cardinals)
-		power_station = locate(/obj/machinery/teleport/station, get_step(src, dir))
+	for(var/direction in GLOB.cardinals)
+		power_station = locate(/obj/machinery/teleport/station, get_step(src, direction))
 		if(power_station)
 			break
 	return power_station

--- a/code/game/machinery/teleporter.dm
+++ b/code/game/machinery/teleporter.dm
@@ -35,8 +35,8 @@
 /obj/machinery/teleport/hub/proc/link_power_station()
 	if(power_station)
 		return
-	for(dir in list(NORTH,EAST,SOUTH,WEST))
-		power_station = locate(/obj/machinery/teleport/station, get_step(src, dir))
+	for(var/direction in list(NORTH,EAST,SOUTH,WEST))
+		power_station = locate(/obj/machinery/teleport/station, get_step(src, direction))
 		if(power_station)
 			break
 	return power_station


### PR DESCRIPTION
:cl:
fix: Teleporter computers no longer always face towards the teleporter.
/:cl:

Fixes one of the things that's been coming up with the new directional computer sprites.