### PR TITLE
Makes some turning procs consistently turn clockwise

### DIFF
--- a/code/game/machinery/doppler_array.dm
+++ b/code/game/machinery/doppler_array.dm
@@ -49,10 +49,9 @@ GLOBAL_LIST_EMPTY(doppler_arrays)
 		return
 	if(usr.stat || usr.restrained() || !usr.canmove)
 		return
-	setDir(turn(dir, 90))
+	setDir(turn(dir, -90))
 	to_chat(usr, "<span class='notice'>You adjust [src]'s dish to face to the [dir2text(dir)].</span>")
 	playsound(src, 'sound/items/screwdriver2.ogg', 50, 1)
-	return
 
 /obj/machinery/doppler_array/AltClick(mob/living/user)
 	if(!istype(user) || user.incapacitated())

--- a/code/game/objects/structures/beds_chairs/chair.dm
+++ b/code/game/objects/structures/beds_chairs/chair.dm
@@ -95,7 +95,7 @@
 	handle_layer()
 
 /obj/structure/chair/proc/spin()
-	setDir(turn(dir, 90))
+	setDir(turn(dir, -90))
 
 /obj/structure/chair/setDir(newdir)
 	..()

--- a/code/modules/assembly/infrared.dm
+++ b/code/modules/assembly/infrared.dm
@@ -139,8 +139,7 @@
 	if(usr.incapacitated())
 		return
 
-	setDir(turn(dir, 90))
-	return
+	setDir(turn(dir, -90))
 
 /obj/item/device/assembly/infra/AltClick(mob/user)
 	..()

--- a/code/modules/power/singularity/particle_accelerator/particle_accelerator.dm
+++ b/code/modules/power/singularity/particle_accelerator/particle_accelerator.dm
@@ -89,7 +89,7 @@
 	if (anchored)
 		to_chat(usr, "It is fastened to the floor!")
 		return 0
-	setDir(turn(dir, 90))
+	setDir(turn(dir, -90))
 	return 1
 
 /obj/structure/particle_accelerator/attackby(obj/item/W, mob/user, params)


### PR DESCRIPTION
Also cleans up some trailing returns

🆑 ShizCalev
fix: Chairs, PA parts, infrared emitters, and doppler arrays will now rotate clockwise.
/🆑