### PR TITLE
Adds AI lawset spawners (mapping helpers)

### DIFF
--- a/code/game/objects/effects/spawners/lootdrop.dm
+++ b/code/game/objects/effects/spawners/lootdrop.dm
@@ -163,3 +163,34 @@
 	loot = list(
 		/obj/item/clothing/mask/gas/cyborg = 25,
 		"" = 75)
+
+/obj/effect/spawner/lootdrop/aimodule_harmless // These shouldn't allow the AI to start butchering people
+	name = "harmless AI module spawner"
+	loot = list(
+				/obj/item/aiModule/core/full/asimov,
+				/obj/item/aiModule/core/full/asimovpp,
+				/obj/item/aiModule/core/full/hippocratic,
+				/obj/item/aiModule/core/full/paladin_devotion,
+				/obj/item/aiModule/core/full/paladin
+				)
+
+/obj/effect/spawner/lootdrop/aimodule_neutral // These shouldn't allow the AI to start butchering people without reason
+	name = "neutral AI module spawner"
+	loot = list(
+				/obj/item/aiModule/core/full/corp,
+				/obj/item/aiModule/core/full/maintain,
+				/obj/item/aiModule/core/full/drone,
+				/obj/item/aiModule/core/full/peacekeeper,
+				/obj/item/aiModule/core/full/reporter,
+				/obj/item/aiModule/core/full/robocop,
+				/obj/item/aiModule/core/full/liveandletlive
+				)
+
+/obj/effect/spawner/lootdrop/aimodule_harmful // These will get the shuttle called
+	name = "harmful AI module spawner"
+	loot = list(
+				/obj/item/aiModule/core/full/antimov,
+				/obj/item/aiModule/core/full/balance,
+				/obj/item/aiModule/core/full/tyrant,
+				/obj/item/aiModule/core/full/thermurderdynamic
+				)

--- a/code/game/objects/items/AI_modules.dm
+++ b/code/game/objects/items/AI_modules.dm
@@ -564,3 +564,11 @@ AI MODULES
 /obj/item/aiModule/core/full/balance
 	name = "'Guardian of Balance' Core AI Module"
 	law_id = "balance"
+
+/obj/item/aiModule/core/full/maintain
+	name = "'Station Efficiency' Core AI Module"
+	law_id = "maintain"
+
+/obj/item/aiModule/core/full/peacekeeper
+	name = "'Peacekeeper' Core AI Module"
+	law_id = "peacekeeper"


### PR DESCRIPTION
My plan is to, at the very least, replace antimov with the harmful spawner. It might be interesting to replace the others too, to facilitate a scenario where an asimov board might not be available and you would have to venture outside your comfort zone and put in something else.

As at least kevinz and wjohn are currently working on map edits, I'm not including the proposed map changes in this PR to avoid creating unnecessary conflicts.
