### PR TITLE
Fixes humans missing legs moving slower in zero-g enviroments

### DIFF
--- a/code/modules/surgery/bodyparts/helpers.dm
+++ b/code/modules/surgery/bodyparts/helpers.dm
@@ -89,10 +89,7 @@
 	return TRUE
 
 /mob/living/carbon/human/get_leg_ignore()
-	if(movement_type & FLYING)
-		return TRUE
-	var/obj/item/tank/jetpack/J = get_jetpack()
-	if(J && J.on && !has_gravity())
+	if((movement_type & FLYING) || floating)
 		return TRUE
 	return FALSE
 


### PR DESCRIPTION
Fixes #24459

🆑 ShizCalev
fix: Humans missing legs or are legcuffed will no longer move slower in areas without gravity.
/🆑