### PR TITLE
Fixes dynamic lighting / nearstation area issues.

### DIFF
--- a/_maps/RandomRuins/SpaceRuins/abandonedzoo.dmm
+++ b/_maps/RandomRuins/SpaceRuins/abandonedzoo.dmm
@@ -671,7 +671,7 @@
 "bK" = (
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plating/airless,
-/area/space)
+/area/space/nearstation)
 "bL" = (
 /obj/machinery/light/small{
 	dir = 8
@@ -717,7 +717,7 @@
 	},
 /obj/structure/disposaloutlet,
 /turf/open/floor/plating/airless,
-/area/space)
+/area/space/nearstation)
 "bS" = (
 /obj/structure/cable{
 	icon_state = "1-4"

--- a/_maps/RandomRuins/SpaceRuins/derelict2.dmm
+++ b/_maps/RandomRuins/SpaceRuins/derelict2.dmm
@@ -7,7 +7,7 @@
 	dir = 4
 	},
 /turf/open/space,
-/area/space)
+/area/space/nearstation)
 "c" = (
 /obj/machinery/door/airlock/external,
 /turf/open/floor/plating,
@@ -17,7 +17,7 @@
 	dir = 8
 	},
 /turf/open/space,
-/area/space)
+/area/space/nearstation)
 "e" = (
 /obj/structure/window/reinforced{
 	dir = 4
@@ -52,7 +52,7 @@
 "k" = (
 /obj/structure/window/reinforced,
 /turf/open/space,
-/area/space)
+/area/space/nearstation)
 "l" = (
 /obj/structure/window/reinforced,
 /obj/structure/window/reinforced{
@@ -92,7 +92,7 @@
 	dir = 1
 	},
 /turf/open/space,
-/area/space)
+/area/space/nearstation)
 "q" = (
 /obj/machinery/light/small{
 	dir = 8

--- a/_maps/RandomRuins/SpaceRuins/oldstation.dmm
+++ b/_maps/RandomRuins/SpaceRuins/oldstation.dmm
@@ -1228,7 +1228,7 @@
 "dF" = (
 /obj/structure/lattice,
 /turf/template_noop,
-/area/space)
+/area/space/nearstation)
 "dG" = (
 /turf/open/floor/plasteel/airless,
 /area/template_noop)
@@ -2498,7 +2498,7 @@
 	dir = 4
 	},
 /turf/open/floor/plating/airless,
-/area/space)
+/area/space/nearstation)
 "gG" = (
 /obj/effect/spawner/structure/window/hollow/reinforced,
 /obj/structure/cable{

--- a/_maps/RandomRuins/SpaceRuins/vaporwave.dmm
+++ b/_maps/RandomRuins/SpaceRuins/vaporwave.dmm
@@ -5,7 +5,7 @@
 "b" = (
 /obj/structure/lattice,
 /turf/open/space,
-/area/space)
+/area/space/nearstation)
 "c" = (
 /obj/structure/lattice,
 /turf/open/floor/plating/asteroid/airless,

--- a/_maps/RandomZLevels/Academy.dmm
+++ b/_maps/RandomZLevels/Academy.dmm
@@ -10,7 +10,7 @@
 	faction = list("wizard")
 	},
 /turf/open/space,
-/area/space)
+/area/space/nearstation)
 "ad" = (
 /obj/structure/filingcabinet/filingcabinet,
 /turf/open/floor/carpet,
@@ -183,7 +183,7 @@
 /area/awaymission/academy/headmaster)
 "aG" = (
 /turf/closed/indestructible/rock,
-/area/space)
+/area/space/nearstation)
 "aH" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -231,7 +231,7 @@
 "aP" = (
 /obj/structure/lattice,
 /turf/open/space,
-/area/space)
+/area/space/nearstation)
 "aQ" = (
 /obj/machinery/door/airlock/gold{
 	locked = 1
@@ -1240,7 +1240,7 @@
 "eu" = (
 /obj/singularity/academy,
 /turf/open/space,
-/area/space)
+/area/space/nearstation)
 "ev" = (
 /obj/structure/window/reinforced{
 	dir = 8
@@ -2988,7 +2988,7 @@
 	icon_state = "medium"
 	},
 /turf/open/space,
-/area/space)
+/area/space/nearstation)
 "jC" = (
 /obj/machinery/igniter,
 /turf/open/floor/plating,
@@ -3916,7 +3916,7 @@
 /area/awaymission/academy/academycellar)
 "mY" = (
 /turf/closed/mineral/random,
-/area/space)
+/area/space/nearstation)
 "mZ" = (
 /turf/closed/indestructible/fakeglass{
 	icon_state = "fakewindows";

--- a/_maps/RandomZLevels/caves.dmm
+++ b/_maps/RandomZLevels/caves.dmm
@@ -1,7 +1,7 @@
 //MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
 "aa" = (
 /turf/closed/indestructible/rock,
-/area/space)
+/area/space/nearstation)
 "ab" = (
 /turf/open/space,
 /area/space)
@@ -2680,7 +2680,7 @@
 "gW" = (
 /obj/effect/mapping_helpers/planet_z,
 /turf/closed/indestructible/rock,
-/area/space)
+/area/space/nearstation)
 
 (1,1,1) = {"
 aa

--- a/_maps/RandomZLevels/centcomAway.dmm
+++ b/_maps/RandomZLevels/centcomAway.dmm
@@ -335,7 +335,7 @@
 "bk" = (
 /obj/structure/lattice,
 /turf/open/space,
-/area/space)
+/area/space/nearstation)
 "bl" = (
 /obj/machinery/door/poddoor{
 	id = "XCCHangar1";
@@ -2332,7 +2332,7 @@
 "iv" = (
 /obj/effect/spawner/structure/window/hollow/reinforced,
 /turf/open/floor/plating,
-/area/space)
+/area/space/nearstation)
 "iw" = (
 /obj/effect/spawner/structure/window/hollow/reinforced/middle,
 /turf/open/floor/plating,
@@ -3135,19 +3135,19 @@
 	dir = 1
 	},
 /turf/open/space,
-/area/space)
+/area/space/nearstation)
 "kU" = (
 /obj/structure/shuttle/engine/propulsion{
 	dir = 1
 	},
 /turf/open/space,
-/area/space)
+/area/space/nearstation)
 "kV" = (
 /obj/structure/shuttle/engine/propulsion/left{
 	dir = 1
 	},
 /turf/open/space,
-/area/space)
+/area/space/nearstation)
 "kW" = (
 /obj/structure/table,
 /obj/item/device/paicard,

--- a/_maps/RandomZLevels/challenge.dmm
+++ b/_maps/RandomZLevels/challenge.dmm
@@ -718,7 +718,7 @@
 	dir = 4
 	},
 /turf/open/space,
-/area/space)
+/area/space/nearstation)
 "cn" = (
 /turf/open/floor/circuit,
 /area/awaymission/challenge/end)
@@ -732,7 +732,7 @@
 	dir = 8
 	},
 /turf/open/space,
-/area/space)
+/area/space/nearstation)
 "cq" = (
 /obj/structure/table/wood,
 /obj/item/melee/chainofcommand,
@@ -787,14 +787,14 @@
 	dir = 4
 	},
 /turf/open/space,
-/area/space)
+/area/space/nearstation)
 "cz" = (
 /obj/structure/window/reinforced,
 /obj/structure/window/reinforced{
 	dir = 8
 	},
 /turf/open/space,
-/area/space)
+/area/space/nearstation)
 "cA" = (
 /obj/structure/sign/securearea,
 /turf/closed/indestructible{
@@ -840,7 +840,7 @@
 	dir = 1
 	},
 /turf/open/space,
-/area/space)
+/area/space/nearstation)
 "cI" = (
 /obj/structure/window/reinforced{
 	dir = 1
@@ -849,7 +849,7 @@
 	dir = 4
 	},
 /turf/open/space,
-/area/space)
+/area/space/nearstation)
 "cJ" = (
 /obj/structure/window/reinforced{
 	dir = 8
@@ -858,7 +858,7 @@
 	dir = 1
 	},
 /turf/open/space,
-/area/space)
+/area/space/nearstation)
 "cK" = (
 /obj/structure/window/reinforced{
 	dir = 4
@@ -867,7 +867,7 @@
 	dir = 1
 	},
 /turf/open/space,
-/area/space)
+/area/space/nearstation)
 "cL" = (
 /obj/structure/window/reinforced{
 	dir = 1
@@ -876,7 +876,7 @@
 	dir = 8
 	},
 /turf/open/space,
-/area/space)
+/area/space/nearstation)
 "cM" = (
 /obj/effect/spawner/structure/window/hollow/reinforced/directional{
 	dir = 9
@@ -998,7 +998,7 @@
 	},
 /obj/structure/window/reinforced,
 /turf/open/space,
-/area/space)
+/area/space/nearstation)
 "de" = (
 /obj/effect/spawner/structure/window/hollow/reinforced/end,
 /turf/open/floor/plating,
@@ -1040,7 +1040,7 @@
 	},
 /obj/structure/window/reinforced,
 /turf/open/space,
-/area/space)
+/area/space/nearstation)
 "dk" = (
 /obj/machinery/door/airlock/centcom{
 	name = "Gateway Access";

--- a/_maps/RandomZLevels/research.dmm
+++ b/_maps/RandomZLevels/research.dmm
@@ -4,10 +4,10 @@
 /area/space)
 "ab" = (
 /turf/closed/mineral,
-/area/space)
+/area/space/nearstation)
 "ac" = (
 /turf/open/floor/plating/asteroid/airless,
-/area/space)
+/area/space/nearstation)
 "ad" = (
 /turf/closed/mineral,
 /area/awaymission/research/exterior)
@@ -268,7 +268,7 @@
 	amount = 50
 	},
 /turf/open/floor/plating/asteroid/airless,
-/area/space)
+/area/space/nearstation)
 "aY" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -355,7 +355,7 @@
 "bk" = (
 /obj/item/bikehorn,
 /turf/open/floor/plating/asteroid/airless,
-/area/space)
+/area/space/nearstation)
 "bl" = (
 /turf/closed/wall/r_wall,
 /area/awaymission/research/interior/gateway)
@@ -449,7 +449,7 @@
 "by" = (
 /obj/item/clothing/mask/gas/clown_hat,
 /turf/open/floor/plating/asteroid/airless,
-/area/space)
+/area/space/nearstation)
 "bz" = (
 /turf/open/floor/plasteel/dark,
 /area/awaymission/research/interior/gateway)
@@ -3756,7 +3756,7 @@
 /area/awaymission/research/interior/dorm)
 "ln" = (
 /turf/open/floor/plasteel,
-/area/space)
+/area/space/nearstation)
 "lo" = (
 /obj/structure/table/wood,
 /obj/structure/bedsheetbin,
@@ -4343,23 +4343,23 @@
 /area/awaymission/research/interior/escapepods)
 "na" = (
 /turf/closed/wall/mineral/plasma,
-/area/space)
+/area/space/nearstation)
 "nb" = (
 /obj/structure/table/wood,
 /obj/item/spellbook/oneuse/random,
 /turf/open/floor/mineral/plasma,
-/area/space)
+/area/space/nearstation)
 "nc" = (
 /mob/living/simple_animal/hostile/creature,
 /turf/open/floor/mineral/plasma,
-/area/space)
+/area/space/nearstation)
 "nd" = (
 /obj/structure/healingfountain,
 /turf/open/floor/mineral/plasma,
-/area/space)
+/area/space/nearstation)
 "ne" = (
 /turf/open/floor/mineral/plasma,
-/area/space)
+/area/space/nearstation)
 
 (1,1,1) = {"
 aa

--- a/_maps/RandomZLevels/spacebattle.dmm
+++ b/_maps/RandomZLevels/spacebattle.dmm
@@ -1,7 +1,7 @@
 //MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
 "aa" = (
 /turf/closed/mineral/random,
-/area/space)
+/area/space/nearstation)
 "ab" = (
 /turf/open/space,
 /area/space)
@@ -2476,46 +2476,46 @@
 "ix" = (
 /obj/structure/lattice,
 /turf/open/space,
-/area/space)
+/area/space/nearstation)
 "iy" = (
 /obj/effect/mob_spawn/human/syndicatesoldier,
 /turf/open/space,
-/area/space)
+/area/space/nearstation)
 "iz" = (
 /turf/closed/wall/mineral/plastitanium,
-/area/space)
+/area/space/nearstation)
 "iA" = (
 /turf/open/space,
 /turf/closed/wall/mineral/plastitanium{
 	dir = 1;
 	icon_state = "diagonalWall3"
 	},
-/area/space)
+/area/space/nearstation)
 "iB" = (
 /obj/machinery/sleeper,
 /turf/open/floor/mineral/plastitanium/airless,
-/area/space)
+/area/space/nearstation)
 "iC" = (
 /turf/open/floor/mineral/plastitanium/airless,
-/area/space)
+/area/space/nearstation)
 "iD" = (
 /obj/effect/mob_spawn/human/syndicatesoldier,
 /turf/open/floor/mineral/plastitanium/airless,
-/area/space)
+/area/space/nearstation)
 "iE" = (
 /turf/closed/mineral/clown,
-/area/space)
+/area/space/nearstation)
 "iF" = (
 /obj/machinery/door/airlock/external,
 /turf/open/floor/plasteel/airless{
 	icon_state = "floor4";
 	dir = 10
 	},
-/area/space)
+/area/space/nearstation)
 "iG" = (
 /obj/item/stack/rods,
 /turf/open/floor/mineral/plastitanium/airless,
-/area/space)
+/area/space/nearstation)
 "iH" = (
 /turf/open/space,
 /turf/closed/wall/mineral/plastitanium{
@@ -2536,7 +2536,7 @@
 "iK" = (
 /obj/machinery/sleeper,
 /turf/open/floor/plasteel/airless,
-/area/space)
+/area/space/nearstation)
 "iL" = (
 /turf/open/floor/mineral/plastitanium,
 /area/awaymission/spacebattle/syndicate5)
@@ -2549,14 +2549,14 @@
 /turf/closed/wall/mineral/plastitanium{
 	icon_state = "diagonalWall3"
 	},
-/area/space)
+/area/space/nearstation)
 "iO" = (
 /turf/open/space,
 /turf/closed/wall/mineral/plastitanium{
 	dir = 4;
 	icon_state = "diagonalWall3"
 	},
-/area/space)
+/area/space/nearstation)
 "iP" = (
 /obj/machinery/sleeper,
 /turf/open/floor/mineral/plastitanium,
@@ -2574,11 +2574,11 @@
 	dir = 1
 	},
 /turf/open/floor/plating/airless,
-/area/space)
+/area/space/nearstation)
 "iS" = (
 /obj/structure/shuttle/engine/propulsion,
 /turf/open/space,
-/area/space)
+/area/space/nearstation)
 "iT" = (
 /obj/machinery/door/airlock/external,
 /turf/open/floor/mineral/plastitanium,
@@ -2672,7 +2672,7 @@
 /area/awaymission/spacebattle/syndicate6)
 "jk" = (
 /turf/open/floor/plating/asteroid/airless,
-/area/space)
+/area/space/nearstation)
 "jl" = (
 /turf/closed/wall/mineral/plasma,
 /area/awaymission/spacebattle/secret)
@@ -3083,11 +3083,11 @@
 "kE" = (
 /obj/item/shard,
 /turf/open/space,
-/area/space)
+/area/space/nearstation)
 "kF" = (
 /obj/item/stack/rods,
 /turf/open/space,
-/area/space)
+/area/space/nearstation)
 "kG" = (
 /obj/item/ammo_casing/c10mm,
 /obj/item/ammo_casing/c10mm,
@@ -3106,17 +3106,17 @@
 "kI" = (
 /obj/item/stack/sheet/metal,
 /turf/open/space,
-/area/space)
+/area/space/nearstation)
 "kJ" = (
 /obj/item/shard,
 /obj/structure/lattice,
 /turf/open/space,
-/area/space)
+/area/space/nearstation)
 "kK" = (
 /obj/structure/lattice,
 /obj/item/stack/rods,
 /turf/open/space,
-/area/space)
+/area/space/nearstation)
 "kL" = (
 /obj/structure/closet/crate,
 /obj/item/stock_parts/cell/high,
@@ -3127,7 +3127,7 @@
 "kM" = (
 /obj/effect/mapping_helpers/planet_z,
 /turf/closed/mineral/random,
-/area/space)
+/area/space/nearstation)
 
 (1,1,1) = {"
 aa

--- a/_maps/RandomZLevels/undergroundoutpost45.dmm
+++ b/_maps/RandomZLevels/undergroundoutpost45.dmm
@@ -5223,7 +5223,7 @@
 /turf/open/floor/plasteel/white{
 	heat_capacity = 1e+006
 	},
-/area/space)
+/area/space/nearstation)
 "la" = (
 /obj/machinery/shower{
 	pixel_y = 15
@@ -13138,7 +13138,7 @@
 "zi" = (
 /obj/effect/mapping_helpers/planet_z,
 /turf/open/space,
-/area/space)
+/area/space/nearstation)
 
 (1,1,1) = {"
 aa

--- a/_maps/RandomZLevels/wildwest.dmm
+++ b/_maps/RandomZLevels/wildwest.dmm
@@ -153,7 +153,7 @@
 /area/awaymission/wildwest/vaultdoors)
 "aG" = (
 /turf/closed/mineral,
-/area/space)
+/area/space/nearstation)
 "aH" = (
 /turf/closed/mineral/diamond,
 /area/awaymission/wildwest/mines)
@@ -259,7 +259,7 @@
 /area/awaymission/wildwest/mines)
 "bg" = (
 /turf/closed/wall/mineral/sandstone,
-/area/space)
+/area/space/nearstation)
 "bh" = (
 /obj/structure/closet/crate/large,
 /turf/open/floor/plating,
@@ -307,7 +307,7 @@
 "br" = (
 /obj/structure/lattice,
 /turf/open/space,
-/area/space)
+/area/space/nearstation)
 "bs" = (
 /obj/effect/mine/sound/bwoink,
 /obj/item/ammo_box/c10mm,
@@ -326,14 +326,14 @@
 	icon_state = "fwindow"
 	},
 /turf/open/space,
-/area/space)
+/area/space/nearstation)
 "bw" = (
 /obj/structure/lattice,
 /obj/structure/window/reinforced{
 	icon_state = "fwindow"
 	},
 /turf/open/space,
-/area/space)
+/area/space/nearstation)
 "bx" = (
 /obj/structure/closet/secure_closet/freezer/fridge,
 /turf/open/floor/plasteel/cafeteria{
@@ -435,7 +435,7 @@
 	dir = 4
 	},
 /turf/open/space,
-/area/space)
+/area/space/nearstation)
 "bP" = (
 /turf/closed/wall/mineral/sandstone,
 /area/awaymission/wildwest/gov)
@@ -490,7 +490,7 @@
 	dir = 8
 	},
 /turf/open/space,
-/area/space)
+/area/space/nearstation)
 "bU" = (
 /obj/structure/chair/wood/normal{
 	dir = 4
@@ -513,7 +513,7 @@
 	dir = 4
 	},
 /turf/open/space,
-/area/space)
+/area/space/nearstation)
 "bX" = (
 /obj/structure/window/reinforced{
 	icon_state = "fwindow";
@@ -670,12 +670,12 @@
 	dir = 8
 	},
 /turf/open/space,
-/area/space)
+/area/space/nearstation)
 "cu" = (
 /obj/structure/lattice,
 /obj/structure/lattice,
 /turf/open/space,
-/area/space)
+/area/space/nearstation)
 "cv" = (
 /obj/effect/decal/cleanable/blood/splatter,
 /turf/open/floor/carpet,
@@ -959,7 +959,7 @@
 	dir = 4
 	},
 /turf/open/space,
-/area/space)
+/area/space/nearstation)
 "dp" = (
 /obj/structure/bed,
 /obj/item/bedsheet/brown,
@@ -1216,7 +1216,7 @@
 	dir = 1
 	},
 /turf/open/space,
-/area/space)
+/area/space/nearstation)
 "ee" = (
 /obj/structure/lattice,
 /obj/structure/window/reinforced{
@@ -1224,7 +1224,7 @@
 	dir = 1
 	},
 /turf/open/space,
-/area/space)
+/area/space/nearstation)
 "ef" = (
 /obj/structure/window/reinforced{
 	icon_state = "fwindow";
@@ -1234,7 +1234,7 @@
 	dir = 4
 	},
 /turf/open/space,
-/area/space)
+/area/space/nearstation)
 "eg" = (
 /obj/structure/window/reinforced{
 	icon_state = "fwindow";
@@ -1262,7 +1262,7 @@
 	dir = 8
 	},
 /turf/open/space,
-/area/space)
+/area/space/nearstation)
 "ej" = (
 /obj/effect/decal/cleanable/blood,
 /turf/open/floor/plating/ironsand{
@@ -1682,7 +1682,7 @@
 	icon_state = "fwindow"
 	},
 /turf/open/space,
-/area/space)
+/area/space/nearstation)
 "fz" = (
 /obj/structure/window/reinforced{
 	icon_state = "fwindow";
@@ -1692,7 +1692,7 @@
 	icon_state = "fwindow"
 	},
 /turf/open/space,
-/area/space)
+/area/space/nearstation)
 "fA" = (
 /obj/structure/window/reinforced{
 	icon_state = "fwindow";
@@ -1797,7 +1797,7 @@
 	},
 /obj/structure/lattice,
 /turf/open/space,
-/area/space)
+/area/space/nearstation)
 "fO" = (
 /mob/living/simple_animal/hostile/syndicate,
 /turf/open/floor/plasteel,
@@ -1896,10 +1896,10 @@
 	dir = 8
 	},
 /turf/open/floor/plasteel/airless,
-/area/space)
+/area/space/nearstation)
 "gd" = (
 /turf/open/floor/plasteel/airless,
-/area/space)
+/area/space/nearstation)
 "ge" = (
 /obj/effect/mob_spawn/human/miner/rig,
 /turf/open/floor/plasteel,

--- a/_maps/map_files/BoxStation/BoxStation.dmm
+++ b/_maps/map_files/BoxStation/BoxStation.dmm
@@ -14,7 +14,7 @@
 	width = 18
 	},
 /turf/open/space,
-/area/space)
+/area/space/nearstation)
 "aae" = (
 /obj/effect/landmark/carpspawn,
 /turf/open/space,
@@ -22,17 +22,17 @@
 "aaf" = (
 /obj/structure/lattice,
 /turf/open/space,
-/area/space)
+/area/space/nearstation)
 "aag" = (
 /obj/structure/lattice/catwalk,
 /turf/open/space,
-/area/space)
+/area/space/nearstation)
 "aah" = (
 /obj/structure/sign/securearea{
 	pixel_y = -32
 	},
 /turf/open/space,
-/area/space)
+/area/space/nearstation)
 "aai" = (
 /turf/closed/wall/r_wall,
 /area/security/prison)
@@ -257,17 +257,17 @@
 	pixel_y = -32
 	},
 /turf/open/space,
-/area/space)
+/area/space/nearstation)
 "aaS" = (
 /obj/structure/grille,
 /obj/structure/lattice,
 /turf/open/space,
-/area/space)
+/area/space/nearstation)
 "aaT" = (
 /obj/structure/lattice,
 /obj/structure/grille,
 /turf/open/space,
-/area/space)
+/area/space/nearstation)
 "aaU" = (
 /obj/machinery/computer/arcade,
 /turf/open/floor/plasteel/floorgrime,
@@ -305,7 +305,7 @@
 /obj/structure/lattice,
 /obj/structure/grille/broken,
 /turf/open/space,
-/area/space)
+/area/space/nearstation)
 "abb" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 6
@@ -722,7 +722,7 @@
 "abY" = (
 /obj/structure/grille,
 /turf/open/space,
-/area/space)
+/area/space/nearstation)
 "abZ" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -894,7 +894,7 @@
 	},
 /obj/structure/lattice/catwalk,
 /turf/open/space,
-/area/space)
+/area/space/nearstation)
 "acx" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -906,7 +906,7 @@
 /obj/structure/lattice,
 /obj/item/stack/cable_coil/random,
 /turf/open/space,
-/area/space)
+/area/space/nearstation)
 "acz" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on,
 /obj/effect/turf_decal/stripes/line{
@@ -1414,7 +1414,7 @@
 	pixel_x = 32
 	},
 /turf/open/space,
-/area/space)
+/area/space/nearstation)
 "adC" = (
 /obj/structure/table,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -3857,7 +3857,7 @@
 "aiS" = (
 /obj/item/stack/rods,
 /turf/open/space,
-/area/space)
+/area/space/nearstation)
 "aiT" = (
 /turf/closed/wall,
 /area/security/processing)
@@ -6380,7 +6380,7 @@
 /area/maintenance/port/fore)
 "aoV" = (
 /turf/open/space,
-/area/space/nearstation)
+/area/space)
 "aoW" = (
 /obj/structure/table,
 /obj/item/stamp,
@@ -7014,7 +7014,7 @@
 	name = "lavaland"
 	},
 /turf/open/space,
-/area/space)
+/area/space/nearstation)
 "aqH" = (
 /turf/closed/wall/mineral/titanium,
 /area/shuttle/pod_2)
@@ -8955,7 +8955,7 @@
 	width = 18
 	},
 /turf/open/space,
-/area/space)
+/area/space/nearstation)
 "avU" = (
 /obj/item/paper/crumpled,
 /turf/open/floor/plasteel/airless{
@@ -10471,12 +10471,12 @@
 /obj/structure/lattice,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/space,
-/area/space)
+/area/space/nearstation)
 "azI" = (
 /obj/structure/lattice,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/space,
-/area/space)
+/area/space/nearstation)
 "azJ" = (
 /obj/machinery/gateway{
 	dir = 9
@@ -12811,7 +12811,7 @@
 	dir = 4
 	},
 /turf/open/space,
-/area/space)
+/area/space/nearstation)
 "aFr" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -13536,7 +13536,7 @@
 	dir = 4
 	},
 /turf/open/space,
-/area/space)
+/area/space/nearstation)
 "aGY" = (
 /obj/machinery/airalarm{
 	pixel_y = 25
@@ -32888,7 +32888,7 @@
 	pixel_y = 32
 	},
 /turf/open/space,
-/area/space)
+/area/space/nearstation)
 "bDj" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
@@ -48296,7 +48296,7 @@
 	name = "lavaland"
 	},
 /turf/open/space,
-/area/space)
+/area/space/nearstation)
 "cpg" = (
 /obj/item/grenade/barrier{
 	pixel_x = 4
@@ -49246,7 +49246,7 @@
 	dir = 4
 	},
 /turf/open/space,
-/area/space)
+/area/space/nearstation)
 "crI" = (
 /obj/machinery/meter,
 /obj/machinery/atmospherics/pipe/simple/general/visible{
@@ -49260,7 +49260,7 @@
 	dir = 4
 	},
 /turf/open/space,
-/area/space)
+/area/space/nearstation)
 "crK" = (
 /obj/machinery/atmospherics/pipe/heat_exchanging/junction{
 	dir = 8
@@ -49309,14 +49309,14 @@
 	dir = 4
 	},
 /turf/open/space,
-/area/space)
+/area/space/nearstation)
 "crU" = (
 /obj/structure/lattice/catwalk,
 /obj/machinery/atmospherics/pipe/heat_exchanging/simple{
 	dir = 10
 	},
 /turf/open/space,
-/area/space)
+/area/space/nearstation)
 "crV" = (
 /obj/machinery/atmospherics/pipe/manifold/general/visible{
 	dir = 8
@@ -49351,7 +49351,7 @@
 	},
 /obj/structure/lattice,
 /turf/open/space,
-/area/space)
+/area/space/nearstation)
 "csa" = (
 /obj/effect/spawner/structure/window/plasma/reinforced,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -49363,7 +49363,7 @@
 	dir = 9
 	},
 /turf/open/space,
-/area/space)
+/area/space/nearstation)
 "csc" = (
 /obj/structure/lattice,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible,
@@ -49392,7 +49392,7 @@
 	dir = 1
 	},
 /turf/open/space,
-/area/space)
+/area/space/nearstation)
 "csj" = (
 /obj/machinery/atmospherics/pipe/heat_exchanging/junction{
 	dir = 8
@@ -49409,7 +49409,7 @@
 	dir = 4
 	},
 /turf/open/space,
-/area/space)
+/area/space/nearstation)
 "csm" = (
 /obj/machinery/atmospherics/components/unary/outlet_injector/on{
 	dir = 1
@@ -49419,12 +49419,12 @@
 "csn" = (
 /obj/structure/transit_tube/horizontal,
 /turf/open/space,
-/area/space)
+/area/space/nearstation)
 "cso" = (
 /obj/structure/lattice,
 /obj/structure/transit_tube/crossing/horizontal,
 /turf/open/space,
-/area/space)
+/area/space/nearstation)
 "csq" = (
 /obj/machinery/computer/security/telescreen{
 	desc = "Used for watching the turbine vent.";
@@ -49463,7 +49463,7 @@
 /obj/structure/lattice/catwalk,
 /obj/machinery/atmospherics/pipe/heat_exchanging/simple,
 /turf/open/space,
-/area/space)
+/area/space/nearstation)
 "csu" = (
 /obj/structure/closet/firecloset,
 /turf/open/floor/plasteel/dark,
@@ -49474,17 +49474,17 @@
 	},
 /obj/structure/lattice,
 /turf/open/space,
-/area/space)
+/area/space/nearstation)
 "csw" = (
 /obj/structure/lattice,
 /obj/machinery/atmospherics/pipe/simple/yellow/visible,
 /turf/open/space,
-/area/space)
+/area/space/nearstation)
 "csx" = (
 /obj/structure/lattice,
 /obj/machinery/atmospherics/pipe/heat_exchanging/simple,
 /turf/open/space,
-/area/space)
+/area/space/nearstation)
 "csy" = (
 /obj/structure/table,
 /obj/item/weldingtool,
@@ -49496,7 +49496,7 @@
 "csz" = (
 /obj/effect/landmark/carpspawn,
 /turf/open/space,
-/area/space/nearstation)
+/area/space)
 "csA" = (
 /obj/machinery/door/poddoor/shutters/preopen{
 	id = "engsm";
@@ -49548,7 +49548,7 @@
 /obj/machinery/atmospherics/pipe/simple/yellow/visible,
 /obj/structure/transit_tube/crossing/horizontal,
 /turf/open/space,
-/area/space)
+/area/space/nearstation)
 "csN" = (
 /obj/structure/transit_tube/horizontal,
 /turf/open/floor/plating,
@@ -49655,7 +49655,7 @@
 /obj/structure/lattice/catwalk,
 /obj/machinery/atmospherics/pipe/simple/yellow/visible,
 /turf/open/space,
-/area/space)
+/area/space/nearstation)
 "ctg" = (
 /obj/structure/closet/emcloset,
 /turf/open/floor/plating,
@@ -49760,7 +49760,7 @@
 /area/ai_monitored/turret_protected/aisat_interior)
 "ctv" = (
 /turf/closed/wall/r_wall,
-/area/space)
+/area/space/nearstation)
 "ctw" = (
 /obj/machinery/airalarm{
 	dir = 4;
@@ -49887,14 +49887,14 @@
 	},
 /obj/structure/lattice,
 /turf/open/space,
-/area/space)
+/area/space/nearstation)
 "ctO" = (
 /obj/structure/lattice,
 /obj/machinery/atmospherics/pipe/simple/yellow/visible{
 	dir = 5
 	},
 /turf/open/space,
-/area/space)
+/area/space/nearstation)
 "ctP" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 4
@@ -50766,7 +50766,7 @@
 	start_active = 1
 	},
 /turf/open/space,
-/area/space)
+/area/space/nearstation)
 "cvG" = (
 /obj/machinery/porta_turret/ai{
 	dir = 4;
@@ -50813,7 +50813,7 @@
 	start_active = 1
 	},
 /turf/open/space,
-/area/space)
+/area/space/nearstation)
 "cvL" = (
 /obj/structure/sign/securearea{
 	pixel_x = 32
@@ -51329,7 +51329,7 @@
 	name = "lavaland"
 	},
 /turf/open/space,
-/area/space)
+/area/space/nearstation)
 "cwW" = (
 /obj/machinery/status_display,
 /turf/closed/wall/mineral/titanium,
@@ -51452,7 +51452,7 @@
 /obj/structure/lattice,
 /obj/effect/landmark/carpspawn,
 /turf/open/space,
-/area/space)
+/area/space/nearstation)
 "cxo" = (
 /obj/structure/extinguisher_cabinet{
 	pixel_x = -5;
@@ -52403,7 +52403,7 @@
 	name = "lavaland"
 	},
 /turf/open/space,
-/area/space)
+/area/space/nearstation)
 "czO" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
@@ -52549,7 +52549,7 @@
 	dir = 1
 	},
 /turf/open/floor/plating/airless,
-/area/space)
+/area/space/nearstation)
 "cAg" = (
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/plasteel/cafeteria,
@@ -52856,7 +52856,7 @@
 	start_active = 1
 	},
 /turf/open/space,
-/area/space)
+/area/space/nearstation)
 "cAV" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -52891,7 +52891,7 @@
 	start_active = 1
 	},
 /turf/open/space,
-/area/space)
+/area/space/nearstation)
 "cAY" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -52953,7 +52953,7 @@
 	start_active = 1
 	},
 /turf/open/space,
-/area/space)
+/area/space/nearstation)
 "cBg" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/effect/landmark/event_spawn,
@@ -53251,7 +53251,7 @@
 	width = 18
 	},
 /turf/open/space,
-/area/space)
+/area/space/nearstation)
 "cBX" = (
 /obj/docking_port/stationary{
 	dheight = 9;
@@ -53264,7 +53264,7 @@
 	width = 18
 	},
 /turf/open/space,
-/area/space)
+/area/space/nearstation)
 "cBY" = (
 /obj/docking_port/stationary{
 	dheight = 9;
@@ -53277,7 +53277,7 @@
 	width = 18
 	},
 /turf/open/space,
-/area/space)
+/area/space/nearstation)
 "cBZ" = (
 /obj/structure/table/wood,
 /obj/item/clothing/under/burial,
@@ -53835,7 +53835,7 @@
 	dir = 4
 	},
 /turf/open/space,
-/area/space)
+/area/space/nearstation)
 "cDY" = (
 /obj/structure/lattice,
 /obj/machinery/atmospherics/pipe/simple/orange/visible{
@@ -53929,7 +53929,7 @@
 	},
 /obj/structure/lattice,
 /turf/open/space,
-/area/space)
+/area/space/nearstation)
 "cEr" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/effect/turf_decal/stripes/line{
@@ -54078,7 +54078,7 @@
 	dir = 5
 	},
 /turf/open/space,
-/area/space)
+/area/space/nearstation)
 "cEK" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 6
@@ -54226,21 +54226,21 @@
 /obj/machinery/atmospherics/pipe/heat_exchanging/simple,
 /obj/structure/lattice,
 /turf/open/space,
-/area/space)
+/area/space/nearstation)
 "cFn" = (
 /obj/structure/lattice,
 /obj/machinery/atmospherics/pipe/heat_exchanging/simple{
 	dir = 6
 	},
 /turf/open/space,
-/area/space)
+/area/space/nearstation)
 "cFo" = (
 /obj/machinery/atmospherics/pipe/heat_exchanging/simple{
 	dir = 10
 	},
 /obj/structure/lattice,
 /turf/open/space,
-/area/space)
+/area/space/nearstation)
 "cFu" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -55816,7 +55816,7 @@
 	turf_type = /turf/open/space
 	},
 /turf/open/space/basic,
-/area/space)
+/area/space/nearstation)
 "Qlk" = (
 /obj/docking_port/stationary{
 	dheight = 9;
@@ -55829,7 +55829,7 @@
 	width = 18
 	},
 /turf/open/space/basic,
-/area/space)
+/area/space/nearstation)
 "Qll" = (
 /obj/machinery/door/airlock/titanium{
 	name = "recovery shuttle external airlock"
@@ -57467,89 +57467,89 @@
 /obj/structure/lattice,
 /obj/structure/grille,
 /turf/open/space/basic,
-/area/space)
+/area/space/nearstation)
 "Qoe" = (
 /obj/structure/lattice,
 /obj/structure/grille,
 /turf/open/space/basic,
-/area/space)
+/area/space/nearstation)
 "Qof" = (
 /obj/structure/lattice,
 /obj/structure/grille/broken,
 /turf/open/space/basic,
-/area/space)
+/area/space/nearstation)
 "Qog" = (
 /obj/structure/lattice,
 /obj/structure/grille,
 /turf/open/space/basic,
-/area/space)
+/area/space/nearstation)
 "Qoh" = (
 /obj/structure/lattice,
 /obj/structure/grille/broken,
 /turf/open/space/basic,
-/area/space)
+/area/space/nearstation)
 "Qoi" = (
 /obj/structure/lattice,
 /turf/open/space/basic,
-/area/space)
+/area/space/nearstation)
 "Qoj" = (
 /obj/structure/lattice,
 /obj/structure/grille/broken,
 /turf/open/space/basic,
-/area/space)
+/area/space/nearstation)
 "Qok" = (
 /obj/structure/lattice,
 /obj/structure/grille,
 /turf/open/space/basic,
-/area/space)
+/area/space/nearstation)
 "Qol" = (
 /obj/structure/grille,
 /turf/open/floor/plating/airless,
-/area/space)
+/area/space/nearstation)
 "Qom" = (
 /obj/structure/lattice,
 /obj/structure/grille,
 /turf/open/space/basic,
-/area/space)
+/area/space/nearstation)
 "Qon" = (
 /obj/structure/lattice,
 /obj/structure/grille,
 /turf/open/space/basic,
-/area/space)
+/area/space/nearstation)
 "Qoo" = (
 /obj/structure/lattice,
 /obj/structure/grille/broken,
 /turf/open/space/basic,
-/area/space)
+/area/space/nearstation)
 "Qop" = (
 /obj/structure/lattice,
 /obj/structure/grille,
 /turf/open/space/basic,
-/area/space)
+/area/space/nearstation)
 "Qoq" = (
 /obj/structure/lattice,
 /obj/structure/grille/broken,
 /turf/open/space/basic,
-/area/space)
+/area/space/nearstation)
 "Qor" = (
 /obj/structure/lattice,
 /obj/structure/grille/broken,
 /turf/open/space/basic,
-/area/space)
+/area/space/nearstation)
 "Qos" = (
 /obj/structure/grille,
 /turf/open/floor/plating/airless,
-/area/space)
+/area/space/nearstation)
 "Qot" = (
 /obj/structure/lattice,
 /obj/structure/grille,
 /turf/open/space/basic,
-/area/space)
+/area/space/nearstation)
 "Qou" = (
 /obj/structure/lattice,
 /obj/structure/grille,
 /turf/open/space/basic,
-/area/space)
+/area/space/nearstation)
 "Qov" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible{

--- a/_maps/map_files/Deltastation/DeltaStation2.dmm
+++ b/_maps/map_files/Deltastation/DeltaStation2.dmm
@@ -10,11 +10,11 @@
 /obj/structure/lattice,
 /obj/structure/grille,
 /turf/open/space,
-/area/space)
+/area/space/nearstation)
 "aad" = (
 /obj/structure/lattice,
 /turf/open/space,
-/area/space)
+/area/space/nearstation)
 "aae" = (
 /obj/machinery/power/tracker,
 /obj/structure/cable{
@@ -139,14 +139,14 @@
 	name = "lavaland"
 	},
 /turf/open/space,
-/area/space)
+/area/space/nearstation)
 "aat" = (
 /obj/docking_port/stationary/random{
 	id = "pod_lavaland2";
 	name = "lavaland"
 	},
 /turf/open/space,
-/area/space)
+/area/space/nearstation)
 "aau" = (
 /obj/structure/lattice/catwalk,
 /obj/effect/landmark/xeno_spawn,
@@ -538,7 +538,7 @@
 "abj" = (
 /obj/structure/lattice/catwalk,
 /turf/open/space,
-/area/space)
+/area/space/nearstation)
 "abk" = (
 /obj/machinery/vending/hydroseeds,
 /obj/effect/decal/cleanable/dirt{
@@ -3336,7 +3336,7 @@
 	width = 18
 	},
 /turf/open/space,
-/area/space)
+/area/space/nearstation)
 "agP" = (
 /obj/effect/decal/cleanable/dirt{
 	desc = "A thin layer of dust coating the floor.";
@@ -4528,7 +4528,7 @@
 "ajr" = (
 /obj/structure/grille,
 /turf/closed/wall/r_wall,
-/area/space)
+/area/space/nearstation)
 "ajs" = (
 /obj/structure/table,
 /obj/item/storage/briefcase,
@@ -9138,14 +9138,14 @@
 	dir = 6
 	},
 /turf/open/space,
-/area/space)
+/area/space/nearstation)
 "atJ" = (
 /obj/machinery/atmospherics/pipe/heat_exchanging/simple{
 	dir = 10
 	},
 /obj/structure/lattice,
 /turf/open/space,
-/area/space)
+/area/space/nearstation)
 "atK" = (
 /obj/structure/table/reinforced,
 /obj/item/device/analyzer{
@@ -9794,7 +9794,7 @@
 	},
 /obj/structure/lattice/catwalk,
 /turf/open/space,
-/area/space)
+/area/space/nearstation)
 "auQ" = (
 /obj/machinery/atmospherics/pipe/heat_exchanging/simple{
 	dir = 4
@@ -9802,14 +9802,14 @@
 /obj/machinery/atmospherics/pipe/heat_exchanging/simple,
 /obj/structure/lattice/catwalk,
 /turf/open/space,
-/area/space)
+/area/space/nearstation)
 "auR" = (
 /obj/machinery/atmospherics/pipe/heat_exchanging/simple{
 	dir = 4
 	},
 /obj/structure/lattice/catwalk,
 /turf/open/space,
-/area/space)
+/area/space/nearstation)
 "auS" = (
 /obj/machinery/atmospherics/pipe/heat_exchanging/junction{
 	dir = 8
@@ -10370,7 +10370,7 @@
 	},
 /obj/structure/lattice/catwalk,
 /turf/open/space,
-/area/space)
+/area/space/nearstation)
 "awa" = (
 /obj/machinery/atmospherics/pipe/heat_exchanging/simple{
 	dir = 4
@@ -10378,7 +10378,7 @@
 /obj/machinery/atmospherics/pipe/heat_exchanging/simple,
 /obj/structure/lattice,
 /turf/open/space,
-/area/space)
+/area/space/nearstation)
 "awb" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/effect/turf_decal/bot,
@@ -10880,13 +10880,13 @@
 	},
 /obj/machinery/atmospherics/pipe/heat_exchanging/simple,
 /turf/open/space,
-/area/space)
+/area/space/nearstation)
 "axq" = (
 /obj/machinery/atmospherics/pipe/heat_exchanging/simple{
 	dir = 9
 	},
 /turf/open/space,
-/area/space)
+/area/space/nearstation)
 "axr" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/effect/turf_decal/bot,
@@ -11998,7 +11998,7 @@
 	},
 /obj/structure/lattice/catwalk,
 /turf/open/space,
-/area/space)
+/area/space/nearstation)
 "azO" = (
 /obj/structure/sign/securearea{
 	pixel_x = -32
@@ -13626,12 +13626,12 @@
 /obj/machinery/atmospherics/pipe/heat_exchanging/simple,
 /obj/structure/lattice/catwalk,
 /turf/open/space,
-/area/space)
+/area/space/nearstation)
 "aDl" = (
 /obj/machinery/atmospherics/pipe/heat_exchanging/simple,
 /obj/structure/lattice,
 /turf/open/space,
-/area/space)
+/area/space/nearstation)
 "aDm" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/stripes/line{
@@ -13707,7 +13707,7 @@
 /obj/structure/lattice/catwalk,
 /obj/machinery/atmospherics/pipe/simple/orange/visible,
 /turf/open/space,
-/area/space)
+/area/space/nearstation)
 "aDx" = (
 /obj/structure/sink{
 	dir = 8;
@@ -14218,7 +14218,7 @@
 /obj/structure/lattice,
 /obj/machinery/atmospherics/pipe/simple/orange/visible,
 /turf/open/space,
-/area/space)
+/area/space/nearstation)
 "aEB" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable/white{
@@ -14587,7 +14587,7 @@
 /obj/structure/lattice,
 /obj/structure/grille/broken,
 /turf/open/space,
-/area/space)
+/area/space/nearstation)
 "aFp" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
@@ -16815,7 +16815,7 @@
 /area/security/prison)
 "aJD" = (
 /turf/closed/wall,
-/area/space)
+/area/space/nearstation)
 "aJE" = (
 /obj/machinery/power/solar_control{
 	dir = 4;
@@ -17503,7 +17503,7 @@
 /obj/structure/lattice/catwalk,
 /obj/item/wrench,
 /turf/open/space,
-/area/space)
+/area/space/nearstation)
 "aLc" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/closed/wall/r_wall,
@@ -18325,28 +18325,28 @@
 	dir = 5
 	},
 /turf/open/space,
-/area/space)
+/area/space/nearstation)
 "aMN" = (
 /obj/structure/lattice/catwalk,
 /obj/machinery/atmospherics/pipe/simple/orange/visible{
 	dir = 4
 	},
 /turf/open/space,
-/area/space)
+/area/space/nearstation)
 "aMO" = (
 /obj/structure/lattice,
 /obj/machinery/atmospherics/pipe/simple/orange/visible{
 	dir = 4
 	},
 /turf/open/space,
-/area/space)
+/area/space/nearstation)
 "aMP" = (
 /obj/structure/lattice/catwalk,
 /obj/machinery/atmospherics/pipe/simple/orange/visible{
 	dir = 10
 	},
 /turf/open/space,
-/area/space)
+/area/space/nearstation)
 "aMQ" = (
 /obj/structure/table/wood,
 /obj/item/clothing/glasses/sunglasses,
@@ -20396,7 +20396,7 @@
 	dir = 4
 	},
 /turf/open/floor/plating/airless,
-/area/space)
+/area/space/nearstation)
 "aRn" = (
 /obj/machinery/atmospherics/components/unary/outlet_injector/on,
 /obj/structure/disposalpipe/segment{
@@ -21302,7 +21302,7 @@
 	dir = 5
 	},
 /turf/open/space,
-/area/space)
+/area/space/nearstation)
 "aSQ" = (
 /obj/structure/lattice/catwalk,
 /obj/machinery/atmospherics/pipe/simple/general/visible{
@@ -21312,7 +21312,7 @@
 	dir = 4
 	},
 /turf/open/space,
-/area/space)
+/area/space/nearstation)
 "aSR" = (
 /obj/structure/lattice,
 /obj/machinery/atmospherics/pipe/simple/general/visible{
@@ -21322,7 +21322,7 @@
 	dir = 4
 	},
 /turf/open/space,
-/area/space)
+/area/space/nearstation)
 "aSS" = (
 /obj/structure/lattice/catwalk,
 /obj/machinery/atmospherics/pipe/simple/general/visible{
@@ -21332,7 +21332,7 @@
 	dir = 9
 	},
 /turf/open/space,
-/area/space)
+/area/space/nearstation)
 "aST" = (
 /obj/machinery/atmospherics/pipe/simple/cyan/visible,
 /turf/open/floor/plasteel/vault{
@@ -25684,7 +25684,7 @@
 	name = "lavaland"
 	},
 /turf/open/space,
-/area/space)
+/area/space/nearstation)
 "bbA" = (
 /obj/machinery/atmospherics/pipe/simple/cyan/visible,
 /obj/structure/sign/securearea{
@@ -30001,12 +30001,12 @@
 "bkE" = (
 /obj/structure/window/reinforced,
 /turf/open/space,
-/area/space)
+/area/space/nearstation)
 "bkF" = (
 /obj/structure/window/reinforced,
 /obj/structure/lattice,
 /turf/open/space,
-/area/space)
+/area/space/nearstation)
 "bkG" = (
 /obj/machinery/light/small{
 	dir = 8
@@ -30912,7 +30912,7 @@
 	dir = 4
 	},
 /turf/open/space,
-/area/space)
+/area/space/nearstation)
 "bmE" = (
 /obj/structure/window/reinforced{
 	dir = 1;
@@ -30953,7 +30953,7 @@
 	dir = 8
 	},
 /turf/open/space,
-/area/space)
+/area/space/nearstation)
 "bmI" = (
 /obj/machinery/atmospherics/components/unary/outlet_injector/on{
 	dir = 4;
@@ -31144,7 +31144,7 @@
 	dir = 9
 	},
 /turf/open/space,
-/area/space)
+/area/space/nearstation)
 "bne" = (
 /obj/structure/rack,
 /obj/effect/spawner/lootdrop/costume,
@@ -31652,7 +31652,7 @@
 	dir = 4
 	},
 /turf/open/space,
-/area/space)
+/area/space/nearstation)
 "bof" = (
 /obj/structure/window/reinforced{
 	dir = 8
@@ -31691,7 +31691,7 @@
 	dir = 8
 	},
 /turf/open/space,
-/area/space)
+/area/space/nearstation)
 "bok" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/atmospherics/pipe/manifold/cyan/visible{
@@ -32410,7 +32410,7 @@
 	},
 /obj/structure/lattice,
 /turf/open/space,
-/area/space)
+/area/space/nearstation)
 "bpG" = (
 /obj/structure/window/reinforced{
 	dir = 1;
@@ -32486,7 +32486,7 @@
 	},
 /obj/structure/lattice,
 /turf/open/space,
-/area/space)
+/area/space/nearstation)
 "bpO" = (
 /turf/open/floor/engine/vacuum,
 /area/engine/atmos)
@@ -33520,7 +33520,7 @@
 	dir = 8
 	},
 /turf/open/space,
-/area/space)
+/area/space/nearstation)
 "brM" = (
 /obj/structure/window/reinforced{
 	dir = 1;
@@ -33528,14 +33528,14 @@
 	},
 /obj/structure/lattice,
 /turf/open/space,
-/area/space)
+/area/space/nearstation)
 "brN" = (
 /obj/structure/window/reinforced{
 	dir = 1;
 	layer = 2.9
 	},
 /turf/open/space,
-/area/space)
+/area/space/nearstation)
 "brO" = (
 /obj/structure/lattice,
 /obj/structure/window/reinforced{
@@ -33543,7 +33543,7 @@
 	layer = 2.9
 	},
 /turf/open/space,
-/area/space)
+/area/space/nearstation)
 "brP" = (
 /obj/structure/lattice,
 /obj/structure/window/reinforced{
@@ -33552,7 +33552,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/space,
-/area/space)
+/area/space/nearstation)
 "brQ" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/window/reinforced{
@@ -33560,7 +33560,7 @@
 	layer = 2.9
 	},
 /turf/open/space,
-/area/space)
+/area/space/nearstation)
 "brR" = (
 /obj/structure/lattice,
 /obj/structure/window/reinforced{
@@ -33569,7 +33569,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/space,
-/area/space)
+/area/space/nearstation)
 "brS" = (
 /obj/structure/lattice,
 /obj/structure/window/reinforced{
@@ -33580,7 +33580,7 @@
 	dir = 4
 	},
 /turf/open/space,
-/area/space)
+/area/space/nearstation)
 "brT" = (
 /obj/machinery/light/small{
 	dir = 8
@@ -34553,7 +34553,7 @@
 	dir = 8
 	},
 /turf/open/space,
-/area/space)
+/area/space/nearstation)
 "btG" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/closed/wall/r_wall,
@@ -34571,7 +34571,7 @@
 	dir = 4
 	},
 /turf/open/space,
-/area/space)
+/area/space/nearstation)
 "btK" = (
 /obj/machinery/camera{
 	c_tag = "Atmospherics - Mix Cell";
@@ -35547,7 +35547,7 @@
 "bvJ" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
-/area/space)
+/area/space/nearstation)
 "bvK" = (
 /obj/structure/closet/emcloset,
 /obj/effect/turf_decal/delivery,
@@ -43965,7 +43965,7 @@
 	dir = 8
 	},
 /turf/open/space,
-/area/space)
+/area/space/nearstation)
 "bLx" = (
 /obj/structure/table/reinforced,
 /obj/item/bodypart/chest/robot,
@@ -45005,7 +45005,7 @@
 	dir = 8
 	},
 /turf/open/space,
-/area/space)
+/area/space/nearstation)
 "bNv" = (
 /obj/machinery/light,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -45063,7 +45063,7 @@
 	dir = 4
 	},
 /turf/open/space,
-/area/space)
+/area/space/nearstation)
 "bNC" = (
 /obj/structure/window/reinforced{
 	dir = 8
@@ -45110,7 +45110,7 @@
 	dir = 4
 	},
 /turf/open/space,
-/area/space)
+/area/space/nearstation)
 "bNG" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/cable/white{
@@ -45120,7 +45120,7 @@
 	dir = 10
 	},
 /turf/open/space,
-/area/space)
+/area/space/nearstation)
 "bNH" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/cable/white{
@@ -45130,7 +45130,7 @@
 	dir = 6
 	},
 /turf/open/space,
-/area/space)
+/area/space/nearstation)
 "bNI" = (
 /obj/structure/cable/white{
 	icon_state = "4-8"
@@ -46058,7 +46058,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/space,
-/area/space)
+/area/space/nearstation)
 "bPL" = (
 /obj/machinery/light/small,
 /obj/structure/sign/vacuum{
@@ -46873,7 +46873,7 @@
 	dir = 8
 	},
 /turf/open/space,
-/area/space)
+/area/space/nearstation)
 "bRy" = (
 /obj/machinery/atmospherics/components/unary/portables_connector/visible,
 /obj/machinery/portable_atmospherics/canister/air,
@@ -47011,16 +47011,16 @@
 	dir = 4
 	},
 /turf/open/space,
-/area/space)
+/area/space/nearstation)
 "bRO" = (
 /obj/structure/lattice,
 /obj/structure/window/reinforced,
 /turf/open/space,
-/area/space)
+/area/space/nearstation)
 "bRP" = (
 /obj/structure/sign/vacuum,
 /turf/closed/wall,
-/area/space)
+/area/space/nearstation)
 "bRQ" = (
 /obj/structure/lattice,
 /obj/structure/transit_tube/curved/flipped{
@@ -47028,12 +47028,12 @@
 	dir = 4
 	},
 /turf/open/space,
-/area/space)
+/area/space/nearstation)
 "bRR" = (
 /obj/structure/lattice,
 /obj/structure/transit_tube/crossing/horizontal,
 /turf/open/space,
-/area/space)
+/area/space/nearstation)
 "bRS" = (
 /obj/structure/lattice,
 /obj/structure/transit_tube/curved{
@@ -47041,7 +47041,7 @@
 	dir = 8
 	},
 /turf/open/space,
-/area/space)
+/area/space/nearstation)
 "bRT" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/cable/white{
@@ -47051,7 +47051,7 @@
 	dir = 5
 	},
 /turf/open/space,
-/area/space)
+/area/space/nearstation)
 "bRU" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/cable/white{
@@ -47061,7 +47061,7 @@
 	dir = 9
 	},
 /turf/open/space,
-/area/space)
+/area/space/nearstation)
 "bRV" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
@@ -47804,7 +47804,7 @@
 	network = list("SS13")
 	},
 /turf/open/space,
-/area/space)
+/area/space/nearstation)
 "bTm" = (
 /obj/structure/window/reinforced{
 	dir = 8
@@ -48059,14 +48059,14 @@
 	dir = 4
 	},
 /turf/open/space,
-/area/space)
+/area/space/nearstation)
 "bTK" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/window/reinforced{
 	dir = 4
 	},
 /turf/open/space,
-/area/space)
+/area/space/nearstation)
 "bTL" = (
 /obj/structure/window/reinforced{
 	dir = 8
@@ -49373,14 +49373,14 @@
 	dir = 4
 	},
 /turf/open/space,
-/area/space)
+/area/space/nearstation)
 "bVW" = (
 /obj/structure/lattice/catwalk,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
 /turf/open/space,
-/area/space)
+/area/space/nearstation)
 "bVX" = (
 /obj/structure/lattice/catwalk,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -49391,7 +49391,7 @@
 	dir = 4
 	},
 /turf/open/space,
-/area/space)
+/area/space/nearstation)
 "bVY" = (
 /obj/structure/lattice/catwalk,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -49399,7 +49399,7 @@
 	},
 /obj/structure/transit_tube/crossing/horizontal,
 /turf/open/space,
-/area/space)
+/area/space/nearstation)
 "bVZ" = (
 /obj/structure/lattice/catwalk,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -49407,7 +49407,7 @@
 	},
 /obj/structure/transit_tube/horizontal,
 /turf/open/space,
-/area/space)
+/area/space/nearstation)
 "bWa" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/window/reinforced{
@@ -49421,7 +49421,7 @@
 	dir = 8
 	},
 /turf/open/space,
-/area/space)
+/area/space/nearstation)
 "bWb" = (
 /obj/structure/window/reinforced{
 	dir = 8
@@ -50600,7 +50600,7 @@
 /obj/structure/lattice,
 /obj/structure/transit_tube/diagonal,
 /turf/open/space,
-/area/space)
+/area/space/nearstation)
 "bYn" = (
 /obj/structure/window/reinforced{
 	dir = 8
@@ -51697,7 +51697,7 @@
 	dir = 4
 	},
 /turf/open/space,
-/area/space)
+/area/space/nearstation)
 "caq" = (
 /obj/structure/lattice,
 /obj/structure/transit_tube/curved/flipped{
@@ -51705,7 +51705,7 @@
 	dir = 8
 	},
 /turf/open/space,
-/area/space)
+/area/space/nearstation)
 "car" = (
 /turf/closed/wall/r_wall,
 /area/engine/engineering)
@@ -53229,7 +53229,7 @@
 	dir = 4
 	},
 /turf/open/floor/plating/airless,
-/area/space)
+/area/space/nearstation)
 "cdC" = (
 /turf/open/floor/plating/airless,
 /area/engine/engineering)
@@ -55109,7 +55109,7 @@
 	dir = 4
 	},
 /turf/open/space,
-/area/space)
+/area/space/nearstation)
 "chi" = (
 /obj/structure/cable/white{
 	icon_state = "0-2"
@@ -55261,7 +55261,7 @@
 	dir = 8
 	},
 /turf/open/space,
-/area/space)
+/area/space/nearstation)
 "cht" = (
 /obj/structure/window/reinforced{
 	dir = 1;
@@ -55272,7 +55272,7 @@
 	layer = 2.9
 	},
 /turf/open/space,
-/area/space)
+/area/space/nearstation)
 "chu" = (
 /obj/structure/reagent_dispensers/fueltank,
 /obj/effect/turf_decal/stripes/line,
@@ -56019,21 +56019,21 @@
 	network = list("Singularity")
 	},
 /turf/open/space,
-/area/space)
+/area/space/nearstation)
 "ciZ" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/cable{
 	icon_state = "2-4"
 	},
 /turf/open/space,
-/area/space)
+/area/space/nearstation)
 "cja" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
 /turf/open/space,
-/area/space)
+/area/space/nearstation)
 "cjb" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/cable{
@@ -56043,14 +56043,14 @@
 	icon_state = "4-8"
 	},
 /turf/open/space,
-/area/space)
+/area/space/nearstation)
 "cjc" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/cable{
 	icon_state = "2-8"
 	},
 /turf/open/space,
-/area/space)
+/area/space/nearstation)
 "cjd" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
@@ -56636,26 +56636,26 @@
 	icon_state = "1-2"
 	},
 /turf/open/space,
-/area/space)
+/area/space/nearstation)
 "ckv" = (
 /obj/effect/turf_decal/stripes/corner{
 	dir = 4
 	},
 /turf/open/floor/plating/airless,
-/area/space)
+/area/space/nearstation)
 "ckw" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
 /turf/open/floor/plating/airless,
-/area/space)
+/area/space/nearstation)
 "ckx" = (
 /obj/structure/cable,
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
 /turf/open/floor/plating/airless,
-/area/space)
+/area/space/nearstation)
 "cky" = (
 /obj/structure/cable,
 /obj/effect/turf_decal/stripes/line{
@@ -56663,7 +56663,7 @@
 	},
 /obj/machinery/power/tesla_coil,
 /turf/open/floor/plating/airless,
-/area/space)
+/area/space/nearstation)
 "ckz" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -56672,7 +56672,7 @@
 	dir = 8
 	},
 /turf/open/floor/plating/airless,
-/area/space)
+/area/space/nearstation)
 "ckA" = (
 /obj/effect/decal/cleanable/oil,
 /obj/machinery/door/poddoor/shutters/preopen{
@@ -57288,7 +57288,7 @@
 	dir = 8
 	},
 /turf/open/floor/plating/airless,
-/area/space)
+/area/space/nearstation)
 "clS" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 9
@@ -57297,7 +57297,7 @@
 	anchored = 1
 	},
 /turf/open/floor/plating/airless,
-/area/space)
+/area/space/nearstation)
 "clT" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 5
@@ -57306,7 +57306,7 @@
 	anchored = 1
 	},
 /turf/open/floor/plating/airless,
-/area/space)
+/area/space/nearstation)
 "clU" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -57315,7 +57315,7 @@
 	dir = 4
 	},
 /turf/open/floor/plating/airless,
-/area/space)
+/area/space/nearstation)
 "clV" = (
 /obj/machinery/door/poddoor/shutters/preopen{
 	id = "engpa";
@@ -58180,7 +58180,7 @@
 	icon_state = "1-2"
 	},
 /turf/open/space,
-/area/space)
+/area/space/nearstation)
 "cnB" = (
 /obj/structure/cable{
 	icon_state = "0-8"
@@ -58189,7 +58189,7 @@
 	dir = 8
 	},
 /turf/open/floor/plating/airless,
-/area/space)
+/area/space/nearstation)
 "cnC" = (
 /obj/structure/sign/radiation,
 /turf/closed/wall/r_wall,
@@ -59405,24 +59405,24 @@
 	},
 /obj/structure/lattice,
 /turf/open/space,
-/area/space)
+/area/space/nearstation)
 "cqk" = (
 /obj/structure/lattice,
 /obj/structure/window/reinforced,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/space,
-/area/space)
+/area/space/nearstation)
 "cql" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/window/reinforced,
 /turf/open/space,
-/area/space)
+/area/space/nearstation)
 "cqm" = (
 /obj/structure/lattice,
 /obj/structure/window/reinforced,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/space,
-/area/space)
+/area/space/nearstation)
 "cqn" = (
 /obj/structure/window/reinforced,
 /obj/structure/window/reinforced{
@@ -59431,19 +59431,19 @@
 /obj/structure/lattice,
 /obj/structure/lattice,
 /turf/open/space,
-/area/space)
+/area/space/nearstation)
 "cqo" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 9
 	},
 /turf/open/floor/plating/airless,
-/area/space)
+/area/space/nearstation)
 "cqp" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 5
 	},
 /turf/open/floor/plating/airless,
-/area/space)
+/area/space/nearstation)
 "cqq" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -59973,7 +59973,7 @@
 	pixel_y = 32
 	},
 /turf/open/space,
-/area/space)
+/area/space/nearstation)
 "crE" = (
 /obj/structure/window/reinforced,
 /obj/structure/window/reinforced{
@@ -60023,17 +60023,17 @@
 	},
 /obj/machinery/power/tesla_coil,
 /turf/open/floor/plating/airless,
-/area/space)
+/area/space/nearstation)
 "crJ" = (
 /obj/item/wrench,
 /turf/open/floor/plating/airless,
-/area/space)
+/area/space/nearstation)
 "crK" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
 /turf/open/floor/plating/airless,
-/area/space)
+/area/space/nearstation)
 "crL" = (
 /obj/structure/cable{
 	icon_state = "1-4"
@@ -60045,7 +60045,7 @@
 	dir = 4
 	},
 /turf/open/floor/plating/airless,
-/area/space)
+/area/space/nearstation)
 "crM" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable{
@@ -60832,17 +60832,17 @@
 	dir = 10
 	},
 /turf/open/floor/plating/airless,
-/area/space)
+/area/space/nearstation)
 "ctn" = (
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plating/airless,
-/area/space)
+/area/space/nearstation)
 "cto" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 6
 	},
 /turf/open/floor/plating/airless,
-/area/space)
+/area/space/nearstation)
 "ctp" = (
 /obj/item/wrench,
 /turf/open/floor/plating,
@@ -62882,7 +62882,7 @@
 	anchored = 1
 	},
 /turf/open/floor/plating/airless,
-/area/space)
+/area/space/nearstation)
 "cxB" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 6
@@ -62891,7 +62891,7 @@
 	anchored = 1
 	},
 /turf/open/floor/plating/airless,
-/area/space)
+/area/space/nearstation)
 "cxC" = (
 /obj/machinery/power/rad_collector/anchored,
 /obj/machinery/power/rad_collector/anchored,
@@ -63733,14 +63733,14 @@
 	dir = 1
 	},
 /turf/open/floor/plating/airless,
-/area/space)
+/area/space/nearstation)
 "czp" = (
 /obj/structure/cable{
 	icon_state = "0-2"
 	},
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plating/airless,
-/area/space)
+/area/space/nearstation)
 "czq" = (
 /obj/structure/cable{
 	icon_state = "0-2"
@@ -63748,14 +63748,14 @@
 /obj/effect/turf_decal/stripes/line,
 /obj/machinery/power/tesla_coil,
 /turf/open/floor/plating/airless,
-/area/space)
+/area/space/nearstation)
 "czr" = (
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
 /obj/effect/turf_decal/stripes/corner,
 /turf/open/floor/plating/airless,
-/area/space)
+/area/space/nearstation)
 "czs" = (
 /obj/machinery/door/poddoor/shutters/preopen{
 	id = "engpa";
@@ -64369,14 +64369,14 @@
 	network = list("Singularity")
 	},
 /turf/open/space,
-/area/space)
+/area/space/nearstation)
 "cAH" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/cable{
 	icon_state = "1-4"
 	},
 /turf/open/space,
-/area/space)
+/area/space/nearstation)
 "cAI" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/cable{
@@ -64386,14 +64386,14 @@
 	icon_state = "4-8"
 	},
 /turf/open/space,
-/area/space)
+/area/space/nearstation)
 "cAJ" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/cable{
 	icon_state = "1-8"
 	},
 /turf/open/space,
-/area/space)
+/area/space/nearstation)
 "cAK" = (
 /obj/machinery/power/rad_collector/anchored,
 /obj/effect/decal/cleanable/dirt,

--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -14,7 +14,7 @@
 	width = 18
 	},
 /turf/open/space,
-/area/space)
+/area/space/nearstation)
 "aac" = (
 /obj/effect/landmark/carpspawn,
 /turf/open/space,
@@ -22,12 +22,12 @@
 "aaf" = (
 /obj/structure/lattice,
 /turf/open/space,
-/area/space)
+/area/space/nearstation)
 "aag" = (
 /obj/structure/grille,
 /obj/structure/lattice,
 /turf/open/space,
-/area/space)
+/area/space/nearstation)
 "aah" = (
 /obj/structure/cable{
 	icon_state = "0-2"
@@ -39,11 +39,11 @@
 /obj/structure/grille/broken,
 /obj/structure/lattice,
 /turf/open/space,
-/area/space)
+/area/space/nearstation)
 "aaj" = (
 /obj/structure/grille,
 /turf/open/space,
-/area/space)
+/area/space/nearstation)
 "aak" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -831,7 +831,7 @@
 "ack" = (
 /obj/structure/lattice/catwalk,
 /turf/open/space,
-/area/space)
+/area/space/nearstation)
 "acl" = (
 /obj/structure/cable,
 /obj/machinery/power/solar{
@@ -1565,7 +1565,7 @@
 	network = list("SS13")
 	},
 /turf/open/space,
-/area/space)
+/area/space/nearstation)
 "adE" = (
 /turf/open/floor/plating,
 /area/crew_quarters/fitness/recreation)
@@ -1588,7 +1588,7 @@
 	name = "lavaland"
 	},
 /turf/open/space,
-/area/space)
+/area/space/nearstation)
 "adH" = (
 /obj/structure/chair{
 	dir = 1
@@ -6518,12 +6518,12 @@
 /area/engine/gravity_generator)
 "anS" = (
 /turf/open/floor/plating/airless,
-/area/space)
+/area/space/nearstation)
 "anT" = (
 /obj/structure/lattice,
 /obj/structure/grille,
 /turf/open/space,
-/area/space)
+/area/space/nearstation)
 "anU" = (
 /obj/structure/disposalpipe/trunk{
 	dir = 4
@@ -7272,7 +7272,7 @@
 "apq" = (
 /obj/effect/spawner/lootdrop/maintenance,
 /turf/open/floor/plating/airless,
-/area/space)
+/area/space/nearstation)
 "apr" = (
 /obj/machinery/navbeacon{
 	codes_txt = "delivery;dir=1";
@@ -7815,7 +7815,7 @@
 /obj/structure/lattice,
 /obj/structure/grille/broken,
 /turf/open/space,
-/area/space)
+/area/space/nearstation)
 "aqC" = (
 /obj/machinery/space_heater,
 /obj/structure/sign/securearea{
@@ -9779,7 +9779,7 @@
 	opened = 1
 	},
 /turf/open/floor/plating/airless,
-/area/space)
+/area/space/nearstation)
 "auD" = (
 /obj/structure/closet/crate{
 	icon_state = "crateopen";
@@ -10378,7 +10378,7 @@
 	pixel_y = 2
 	},
 /turf/open/floor/plating/airless,
-/area/space)
+/area/space/nearstation)
 "avJ" = (
 /obj/machinery/door/airlock/external,
 /turf/open/floor/plating,
@@ -11564,7 +11564,7 @@
 	},
 /obj/structure/lattice/catwalk,
 /turf/open/space,
-/area/space)
+/area/space/nearstation)
 "ayf" = (
 /obj/structure/closet/crate,
 /obj/item/stack/sheet/glass{
@@ -11572,7 +11572,7 @@
 	},
 /obj/item/stack/rods,
 /turf/open/floor/plating/airless,
-/area/space)
+/area/space/nearstation)
 "ayg" = (
 /obj/structure/table,
 /turf/open/floor/mineral/titanium/blue,
@@ -11982,7 +11982,7 @@
 	},
 /obj/structure/lattice/catwalk,
 /turf/open/space,
-/area/space)
+/area/space/nearstation)
 "aze" = (
 /obj/item/twohanded/required/kirbyplants{
 	icon_state = "plant-22"
@@ -11993,7 +11993,7 @@
 "azg" = (
 /obj/item/stack/cable_coil,
 /turf/open/floor/plating/airless,
-/area/space)
+/area/space/nearstation)
 "azh" = (
 /turf/open/floor/mineral/titanium/blue,
 /area/shuttle/mining)
@@ -17993,7 +17993,7 @@
 	dir = 4
 	},
 /turf/open/space,
-/area/space)
+/area/space/nearstation)
 "aLp" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
@@ -18059,7 +18059,7 @@
 	dir = 4
 	},
 /turf/open/space,
-/area/space)
+/area/space/nearstation)
 "aLx" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -18366,12 +18366,12 @@
 "aMq" = (
 /obj/structure/window/reinforced,
 /turf/open/space,
-/area/space)
+/area/space/nearstation)
 "aMr" = (
 /obj/structure/window/reinforced,
 /obj/structure/lattice,
 /turf/open/space,
-/area/space)
+/area/space/nearstation)
 "aMs" = (
 /obj/machinery/door/airlock/external{
 	name = "Supply Dock Airlock";
@@ -18832,7 +18832,7 @@
 	dir = 4
 	},
 /turf/open/space,
-/area/space)
+/area/space/nearstation)
 "aNx" = (
 /obj/structure/window/reinforced{
 	dir = 1;
@@ -18883,7 +18883,7 @@
 	},
 /obj/structure/lattice,
 /turf/open/space,
-/area/space)
+/area/space/nearstation)
 "aND" = (
 /obj/effect/spawner/structure/window/shuttle,
 /turf/open/floor/plating,
@@ -19557,14 +19557,14 @@
 	pixel_y = 1
 	},
 /turf/open/space,
-/area/space)
+/area/space/nearstation)
 "aOV" = (
 /obj/structure/window/reinforced{
 	dir = 1;
 	pixel_y = 1
 	},
 /turf/open/space,
-/area/space)
+/area/space/nearstation)
 "aOW" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/structure/lattice/catwalk,
@@ -19579,13 +19579,13 @@
 	pixel_y = 1
 	},
 /turf/open/space,
-/area/space)
+/area/space/nearstation)
 "aOY" = (
 /obj/structure/window/reinforced{
 	dir = 8
 	},
 /turf/open/space,
-/area/space)
+/area/space/nearstation)
 "aOZ" = (
 /turf/closed/wall/mineral/titanium,
 /area/shuttle/pod_1)
@@ -21292,7 +21292,7 @@
 	dir = 4
 	},
 /turf/open/space,
-/area/space)
+/area/space/nearstation)
 "aSE" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 5
@@ -21311,7 +21311,7 @@
 	},
 /obj/structure/window/reinforced,
 /turf/open/space,
-/area/space)
+/area/space/nearstation)
 "aSH" = (
 /obj/structure/chair{
 	dir = 4
@@ -21875,7 +21875,7 @@
 	},
 /obj/structure/lattice,
 /turf/open/space,
-/area/space)
+/area/space/nearstation)
 "aTR" = (
 /obj/structure/window/reinforced{
 	dir = 1;
@@ -22550,7 +22550,7 @@
 	dir = 8
 	},
 /turf/open/space,
-/area/space)
+/area/space/nearstation)
 "aVl" = (
 /obj/machinery/porta_turret/ai{
 	dir = 4
@@ -23182,7 +23182,7 @@
 	dir = 10
 	},
 /turf/open/space,
-/area/space)
+/area/space/nearstation)
 "aWL" = (
 /obj/machinery/ai_status_display{
 	pixel_x = -32
@@ -24093,7 +24093,7 @@
 	},
 /obj/structure/lattice,
 /turf/open/space,
-/area/space)
+/area/space/nearstation)
 "aYy" = (
 /obj/machinery/camera{
 	c_tag = "AI Chamber - Port";
@@ -26350,7 +26350,7 @@
 	dir = 8
 	},
 /turf/open/space,
-/area/space)
+/area/space/nearstation)
 "bcS" = (
 /turf/closed/wall/mineral/titanium,
 /area/shuttle/arrival)
@@ -27087,7 +27087,7 @@
 	name = "EXTERNAL AIRLOCK"
 	},
 /turf/closed/wall/r_wall,
-/area/space)
+/area/space/nearstation)
 "bes" = (
 /obj/structure/window/reinforced{
 	dir = 8
@@ -27979,7 +27979,7 @@
 	layer = 2.9
 	},
 /turf/open/space,
-/area/space)
+/area/space/nearstation)
 "bgo" = (
 /obj/structure/window/reinforced{
 	dir = 4
@@ -27989,7 +27989,7 @@
 	layer = 2.9
 	},
 /turf/open/space,
-/area/space)
+/area/space/nearstation)
 "bgq" = (
 /obj/structure/chair,
 /turf/open/floor/mineral/titanium/blue,
@@ -28984,7 +28984,7 @@
 	name = "lavaland"
 	},
 /turf/open/space,
-/area/space)
+/area/space/nearstation)
 "bij" = (
 /obj/effect/spawner/structure/window/shuttle,
 /turf/open/floor/plating,
@@ -30603,28 +30603,28 @@
 	dir = 4
 	},
 /turf/open/space,
-/area/space)
+/area/space/nearstation)
 "blv" = (
 /obj/structure/lattice,
 /obj/structure/transit_tube/crossing/horizontal,
 /turf/open/space,
-/area/space)
+/area/space/nearstation)
 "blw" = (
 /obj/structure/transit_tube/curved{
 	dir = 8
 	},
 /turf/open/space,
-/area/space)
+/area/space/nearstation)
 "blx" = (
 /turf/closed/wall,
-/area/space)
+/area/space/nearstation)
 "bly" = (
 /obj/structure/window/reinforced{
 	dir = 4
 	},
 /obj/structure/window/reinforced,
 /turf/open/space,
-/area/space)
+/area/space/nearstation)
 "blA" = (
 /obj/machinery/atmospherics/components/unary/outlet_injector/on,
 /obj/structure/window/reinforced,
@@ -31508,7 +31508,7 @@
 "bno" = (
 /obj/structure/transit_tube/diagonal,
 /turf/open/space,
-/area/space)
+/area/space/nearstation)
 "bnp" = (
 /obj/structure/window/reinforced{
 	dir = 1;
@@ -32531,7 +32531,7 @@
 /area/security/checkpoint/customs)
 "bpu" = (
 /turf/closed/wall/r_wall,
-/area/space)
+/area/space/nearstation)
 "bpv" = (
 /obj/structure/sign/securearea{
 	pixel_y = 32
@@ -32556,7 +32556,7 @@
 	},
 /obj/structure/transit_tube/horizontal,
 /turf/open/space,
-/area/space)
+/area/space/nearstation)
 "bpx" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -32567,7 +32567,7 @@
 	},
 /obj/structure/transit_tube/crossing/horizontal,
 /turf/open/space,
-/area/space)
+/area/space/nearstation)
 "bpy" = (
 /obj/structure/lattice/catwalk,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -32578,7 +32578,7 @@
 	},
 /obj/structure/transit_tube/horizontal,
 /turf/open/space,
-/area/space)
+/area/space/nearstation)
 "bpz" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -32591,7 +32591,7 @@
 	dir = 8
 	},
 /turf/open/space,
-/area/space)
+/area/space/nearstation)
 "bpA" = (
 /obj/structure/lattice/catwalk,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -32601,7 +32601,7 @@
 	icon_state = "4-8"
 	},
 /turf/open/space,
-/area/space)
+/area/space/nearstation)
 "bpB" = (
 /obj/structure/window/reinforced{
 	dir = 4
@@ -32614,7 +32614,7 @@
 	icon_state = "4-8"
 	},
 /turf/open/space,
-/area/space)
+/area/space/nearstation)
 "bpC" = (
 /obj/structure/window/reinforced{
 	dir = 8
@@ -33816,7 +33816,7 @@
 	dir = 4
 	},
 /turf/open/space,
-/area/space)
+/area/space/nearstation)
 "brN" = (
 /obj/structure/window/reinforced{
 	dir = 4
@@ -33841,7 +33841,7 @@
 "brO" = (
 /obj/structure/transit_tube/diagonal/topleft,
 /turf/open/space,
-/area/space)
+/area/space/nearstation)
 "brP" = (
 /obj/structure/window/reinforced,
 /obj/structure/window/reinforced{
@@ -34109,7 +34109,7 @@
 	dir = 4
 	},
 /turf/open/space,
-/area/space)
+/area/space/nearstation)
 "bsk" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -34852,14 +34852,14 @@
 	dir = 4
 	},
 /turf/open/space,
-/area/space)
+/area/space/nearstation)
 "btJ" = (
 /obj/structure/lattice,
 /obj/structure/transit_tube/curved/flipped{
 	dir = 8
 	},
 /turf/open/space,
-/area/space)
+/area/space/nearstation)
 "btK" = (
 /obj/structure/window/reinforced{
 	dir = 1;
@@ -34867,7 +34867,7 @@
 	},
 /obj/structure/lattice,
 /turf/open/space,
-/area/space)
+/area/space/nearstation)
 "btL" = (
 /turf/closed/wall/r_wall,
 /area/tcommsat/computer)
@@ -37485,12 +37485,12 @@
 /obj/structure/lattice,
 /obj/structure/grille,
 /turf/closed/wall/r_wall,
-/area/space)
+/area/space/nearstation)
 "bzj" = (
 /obj/structure/grille,
 /obj/structure/lattice,
 /turf/closed/wall/r_wall,
-/area/space)
+/area/space/nearstation)
 "bzk" = (
 /obj/structure/window/reinforced,
 /obj/structure/window/reinforced{
@@ -38230,7 +38230,7 @@
 	},
 /obj/structure/lattice,
 /turf/open/space,
-/area/space)
+/area/space/nearstation)
 "bAT" = (
 /obj/structure/window/reinforced{
 	dir = 4
@@ -38240,7 +38240,7 @@
 	pixel_y = 2
 	},
 /turf/open/space,
-/area/space)
+/area/space/nearstation)
 "bAU" = (
 /obj/machinery/microwave{
 	pixel_y = 4
@@ -38319,7 +38319,7 @@
 	},
 /obj/structure/lattice,
 /turf/open/space,
-/area/space)
+/area/space/nearstation)
 "bBc" = (
 /obj/structure/closet/emcloset,
 /obj/effect/turf_decal/bot,
@@ -38990,7 +38990,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/orange/visible,
 /turf/open/space,
-/area/space)
+/area/space/nearstation)
 "bCA" = (
 /obj/machinery/meter,
 /obj/machinery/atmospherics/pipe/simple/yellow/visible{
@@ -40742,7 +40742,7 @@
 	dir = 4
 	},
 /turf/open/space,
-/area/space)
+/area/space/nearstation)
 "bFZ" = (
 /obj/machinery/meter,
 /obj/machinery/atmospherics/pipe/simple/green/visible{
@@ -42053,7 +42053,7 @@
 	dir = 4
 	},
 /turf/open/space,
-/area/space)
+/area/space/nearstation)
 "bJc" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/siphon/on{
 	dir = 8;
@@ -42072,13 +42072,13 @@
 /obj/structure/lattice,
 /obj/structure/lattice,
 /turf/closed/wall/r_wall,
-/area/space)
+/area/space/nearstation)
 "bJf" = (
 /obj/structure/lattice,
 /obj/structure/grille,
 /obj/structure/lattice,
 /turf/closed/wall/r_wall,
-/area/space)
+/area/space/nearstation)
 "bJg" = (
 /obj/machinery/message_server,
 /turf/open/floor/circuit/telecomms/mainframe,
@@ -42126,7 +42126,7 @@
 	dir = 4
 	},
 /turf/open/space,
-/area/space)
+/area/space/nearstation)
 "bJm" = (
 /obj/machinery/telecomms/bus/preset_two,
 /turf/open/floor/circuit/telecomms/mainframe,
@@ -42809,7 +42809,7 @@
 /obj/structure/lattice,
 /obj/structure/lattice,
 /turf/closed/wall/r_wall,
-/area/space)
+/area/space/nearstation)
 "bKL" = (
 /obj/machinery/telecomms/processor/preset_two,
 /turf/open/floor/circuit/telecomms/mainframe,
@@ -52845,31 +52845,31 @@
 /obj/structure/lattice,
 /obj/machinery/atmospherics/pipe/simple/green/visible,
 /turf/open/space,
-/area/space)
+/area/space/nearstation)
 "cfv" = (
 /obj/structure/lattice,
 /obj/machinery/atmospherics/pipe/simple/yellow/visible,
 /turf/open/space,
-/area/space)
+/area/space/nearstation)
 "cfw" = (
 /obj/structure/lattice,
 /obj/machinery/atmospherics/pipe/manifold/yellow/visible{
 	dir = 8
 	},
 /turf/open/space,
-/area/space)
+/area/space/nearstation)
 "cfx" = (
 /obj/structure/lattice,
 /obj/machinery/atmospherics/pipe/simple/yellow/visible{
 	dir = 9
 	},
 /turf/open/space,
-/area/space)
+/area/space/nearstation)
 "cfy" = (
 /obj/structure/lattice,
 /obj/machinery/atmospherics/pipe/simple/cyan/visible,
 /turf/open/space,
-/area/space)
+/area/space/nearstation)
 "cfz" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/cable{
@@ -55954,7 +55954,7 @@
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/general/visible,
 /turf/open/space,
-/area/space)
+/area/space/nearstation)
 "cmd" = (
 /obj/machinery/door/airlock/glass{
 	autoclose = 0;
@@ -57822,7 +57822,7 @@
 	dir = 5
 	},
 /turf/open/space,
-/area/space)
+/area/space/nearstation)
 "cpN" = (
 /obj/machinery/atmospherics/components/unary/outlet_injector/on{
 	dir = 8
@@ -57840,7 +57840,7 @@
 /obj/structure/lattice/catwalk,
 /obj/item/wrench,
 /turf/open/space,
-/area/space)
+/area/space/nearstation)
 "cpQ" = (
 /obj/structure/chair/stool,
 /turf/open/floor/wood{
@@ -58518,7 +58518,7 @@
 	dir = 5
 	},
 /turf/open/space,
-/area/space)
+/area/space/nearstation)
 "crd" = (
 /obj/structure/disposaloutlet{
 	dir = 2
@@ -58528,7 +58528,7 @@
 	},
 /obj/structure/lattice/catwalk,
 /turf/open/space,
-/area/space)
+/area/space/nearstation)
 "cre" = (
 /obj/structure/sign/fire,
 /turf/closed/wall/r_wall,
@@ -59673,11 +59673,11 @@
 	use_power = 0
 	},
 /turf/open/space,
-/area/space)
+/area/space/nearstation)
 "ctm" = (
 /obj/structure/grille/broken,
 /turf/open/space,
-/area/space)
+/area/space/nearstation)
 "ctn" = (
 /obj/machinery/vending/cigarette,
 /obj/effect/turf_decal/stripes/line{
@@ -61084,14 +61084,14 @@
 	},
 /obj/structure/lattice/catwalk,
 /turf/open/space,
-/area/space)
+/area/space/nearstation)
 "cwg" = (
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/structure/lattice/catwalk,
 /turf/open/space,
-/area/space)
+/area/space/nearstation)
 "cwh" = (
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
@@ -64661,7 +64661,7 @@
 	dir = 8
 	},
 /turf/open/floor/plating/airless,
-/area/space)
+/area/space/nearstation)
 "cDv" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -65282,7 +65282,7 @@
 "cEA" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
-/area/space)
+/area/space/nearstation)
 "cEB" = (
 /obj/structure/chair{
 	dir = 4
@@ -67400,7 +67400,7 @@
 	pixel_x = -32
 	},
 /turf/open/space,
-/area/space)
+/area/space/nearstation)
 "cIz" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -67695,7 +67695,7 @@
 	},
 /obj/structure/lattice/catwalk,
 /turf/open/space,
-/area/space)
+/area/space/nearstation)
 "cJg" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/item/bedsheet/medical,
@@ -69320,13 +69320,13 @@
 	dir = 6
 	},
 /turf/open/floor/plating/airless,
-/area/space)
+/area/space/nearstation)
 "cMu" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
 /turf/open/floor/plating/airless,
-/area/space)
+/area/space/nearstation)
 "cMv" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -69830,7 +69830,7 @@
 	dir = 1
 	},
 /turf/open/floor/plating/airless,
-/area/space)
+/area/space/nearstation)
 "cNs" = (
 /obj/machinery/atmospherics/components/unary/outlet_injector/on{
 	dir = 1
@@ -72245,7 +72245,7 @@
 	name = "lavaland"
 	},
 /turf/open/space,
-/area/space)
+/area/space/nearstation)
 "cSQ" = (
 /obj/machinery/door/window/northleft{
 	dir = 4;
@@ -72697,7 +72697,7 @@
 	width = 18
 	},
 /turf/open/space,
-/area/space)
+/area/space/nearstation)
 "cUH" = (
 /obj/structure/table/optable,
 /turf/open/floor/plasteel/white,
@@ -72709,7 +72709,7 @@
 	name = "lavaland"
 	},
 /turf/open/space,
-/area/space)
+/area/space/nearstation)
 "cUM" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable/yellow{
@@ -75825,7 +75825,7 @@
 	width = 18
 	},
 /turf/open/space,
-/area/space)
+/area/space/nearstation)
 "dbC" = (
 /obj/docking_port/stationary{
 	dheight = 9;
@@ -75838,7 +75838,7 @@
 	width = 18
 	},
 /turf/open/space,
-/area/space)
+/area/space/nearstation)
 "dbD" = (
 /obj/docking_port/stationary{
 	dheight = 9;
@@ -75851,7 +75851,7 @@
 	width = 18
 	},
 /turf/open/space,
-/area/space)
+/area/space/nearstation)
 "dbE" = (
 /obj/machinery/plantgenes,
 /obj/effect/turf_decal/stripes/line{
@@ -77764,32 +77764,32 @@
 "dgd" = (
 /obj/machinery/atmospherics/pipe/heat_exchanging/simple,
 /turf/open/space,
-/area/space)
+/area/space/nearstation)
 "dge" = (
 /obj/machinery/atmospherics/pipe/heat_exchanging/simple,
 /obj/structure/lattice/catwalk,
 /turf/open/space,
-/area/space)
+/area/space/nearstation)
 "dgf" = (
 /obj/machinery/atmospherics/pipe/heat_exchanging/simple{
 	dir = 6
 	},
 /turf/open/space,
-/area/space)
+/area/space/nearstation)
 "dgg" = (
 /obj/machinery/atmospherics/pipe/heat_exchanging/simple{
 	dir = 6
 	},
 /obj/structure/lattice/catwalk,
 /turf/open/space,
-/area/space)
+/area/space/nearstation)
 "dgh" = (
 /obj/machinery/atmospherics/pipe/heat_exchanging/simple{
 	dir = 6
 	},
 /obj/structure/lattice,
 /turf/open/space,
-/area/space)
+/area/space/nearstation)
 "dgi" = (
 /obj/machinery/atmospherics/pipe/simple/orange/visible,
 /turf/open/floor/plating,
@@ -77800,7 +77800,7 @@
 	},
 /obj/structure/lattice,
 /turf/open/space,
-/area/space)
+/area/space/nearstation)
 "dgk" = (
 /obj/machinery/atmospherics/pipe/heat_exchanging/simple,
 /obj/machinery/atmospherics/pipe/heat_exchanging/simple{
@@ -77808,7 +77808,7 @@
 	},
 /obj/structure/lattice,
 /turf/open/space,
-/area/space)
+/area/space/nearstation)
 "dgm" = (
 /obj/machinery/atmospherics/pipe/heat_exchanging/simple{
 	dir = 4
@@ -77816,7 +77816,7 @@
 /obj/machinery/atmospherics/pipe/heat_exchanging/simple,
 /obj/structure/lattice,
 /turf/open/space,
-/area/space)
+/area/space/nearstation)
 "dgo" = (
 /obj/machinery/atmospherics/pipe/simple/orange/visible{
 	dir = 4
@@ -77836,33 +77836,33 @@
 	dir = 10
 	},
 /turf/open/space,
-/area/space)
+/area/space/nearstation)
 "dgt" = (
 /obj/machinery/atmospherics/pipe/heat_exchanging/simple,
 /obj/machinery/atmospherics/pipe/heat_exchanging/simple{
 	dir = 4
 	},
 /turf/open/space,
-/area/space)
+/area/space/nearstation)
 "dgu" = (
 /obj/machinery/atmospherics/pipe/heat_exchanging/simple{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/heat_exchanging/simple,
 /turf/open/space,
-/area/space)
+/area/space/nearstation)
 "dgv" = (
 /obj/machinery/atmospherics/pipe/heat_exchanging/simple{
 	dir = 9
 	},
 /obj/structure/lattice/catwalk,
 /turf/open/space,
-/area/space)
+/area/space/nearstation)
 "dgw" = (
 /obj/structure/lattice,
 /obj/machinery/atmospherics/pipe/simple/orange/visible,
 /turf/open/space,
-/area/space)
+/area/space/nearstation)
 "dgz" = (
 /obj/structure/closet/toolcloset,
 /obj/effect/turf_decal/delivery,
@@ -77873,49 +77873,49 @@
 /obj/structure/lattice/catwalk,
 /obj/machinery/atmospherics/pipe/simple/orange/visible,
 /turf/open/space,
-/area/space)
+/area/space/nearstation)
 "dgB" = (
 /obj/machinery/atmospherics/pipe/heat_exchanging/simple{
 	dir = 5
 	},
 /obj/structure/lattice/catwalk,
 /turf/open/space,
-/area/space)
+/area/space/nearstation)
 "dgI" = (
 /obj/machinery/atmospherics/pipe/simple/orange/visible{
 	dir = 5
 	},
 /turf/open/space,
-/area/space)
+/area/space/nearstation)
 "dgJ" = (
 /obj/structure/lattice,
 /obj/machinery/atmospherics/pipe/simple/orange/visible{
 	dir = 4
 	},
 /turf/open/space,
-/area/space)
+/area/space/nearstation)
 "dgK" = (
 /obj/machinery/atmospherics/pipe/simple/orange/visible{
 	dir = 4
 	},
 /turf/open/space,
-/area/space)
+/area/space/nearstation)
 "dgM" = (
 /obj/machinery/atmospherics/pipe/simple/orange/visible{
 	dir = 10
 	},
 /turf/open/space,
-/area/space)
+/area/space/nearstation)
 "dgN" = (
 /obj/structure/lattice,
 /obj/structure/grille,
 /obj/machinery/atmospherics/pipe/simple/orange/visible,
 /turf/open/space,
-/area/space)
+/area/space/nearstation)
 "dgO" = (
 /obj/machinery/atmospherics/pipe/simple/orange/visible,
 /turf/open/space,
-/area/space)
+/area/space/nearstation)
 "dgS" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -77927,7 +77927,7 @@
 /obj/structure/transit_tube/horizontal,
 /obj/machinery/atmospherics/pipe/simple/orange/visible,
 /turf/open/space,
-/area/space)
+/area/space/nearstation)
 "dha" = (
 /obj/structure/lattice,
 /obj/machinery/atmospherics/pipe/simple/green/visible{
@@ -77935,7 +77935,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/orange/visible,
 /turf/open/space,
-/area/space)
+/area/space/nearstation)
 "dhc" = (
 /obj/structure/lattice,
 /obj/machinery/atmospherics/pipe/simple/yellow/visible{
@@ -77943,7 +77943,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/orange/visible,
 /turf/open/space,
-/area/space)
+/area/space/nearstation)
 "dhe" = (
 /obj/machinery/atmospherics/pipe/simple/general/visible{
 	dir = 10
@@ -77998,7 +77998,7 @@
 	dir = 9
 	},
 /turf/open/space,
-/area/space)
+/area/space/nearstation)
 "dhn" = (
 /obj/structure/table,
 /obj/item/poster/random_contraband,
@@ -80643,35 +80643,35 @@
 	width = 18
 	},
 /turf/open/space/basic,
-/area/space)
+/area/space/nearstation)
 "EDb" = (
 /obj/structure/grille,
 /turf/open/floor/plating/airless,
-/area/space)
+/area/space/nearstation)
 "EDc" = (
 /obj/structure/grille,
 /turf/open/floor/plating/airless,
-/area/space)
+/area/space/nearstation)
 "EDd" = (
 /obj/structure/grille,
 /turf/open/floor/plating/airless,
-/area/space)
+/area/space/nearstation)
 "EDe" = (
 /obj/structure/grille,
 /turf/open/floor/plating/airless,
-/area/space)
+/area/space/nearstation)
 "EDf" = (
 /obj/structure/grille,
 /turf/open/floor/plating/airless,
-/area/space)
+/area/space/nearstation)
 "EDg" = (
 /obj/structure/grille,
 /turf/open/floor/plating/airless,
-/area/space)
+/area/space/nearstation)
 "EDh" = (
 /obj/structure/grille,
 /turf/open/floor/plating/airless,
-/area/space)
+/area/space/nearstation)
 "EDi" = (
 /obj/docking_port/mobile{
 	callTime = 250;

--- a/_maps/map_files/OmegaStation/OmegaStation.dmm
+++ b/_maps/map_files/OmegaStation/OmegaStation.dmm
@@ -19,17 +19,17 @@
 "aae" = (
 /obj/structure/lattice,
 /turf/open/space,
-/area/space)
+/area/space/nearstation)
 "aaf" = (
 /obj/structure/lattice,
 /obj/structure/grille,
 /turf/open/space,
-/area/space)
+/area/space/nearstation)
 "aag" = (
 /obj/structure/lattice,
 /obj/structure/grille/broken,
 /turf/open/space,
-/area/space)
+/area/space/nearstation)
 "aah" = (
 /obj/structure/sign/securearea,
 /turf/closed/wall,
@@ -34038,7 +34038,7 @@
 	width = 18
 	},
 /turf/open/space/basic,
-/area/space)
+/area/space/nearstation)
 "sws" = (
 /obj/docking_port/stationary{
 	dheight = 9;
@@ -34051,7 +34051,7 @@
 	width = 18
 	},
 /turf/open/space,
-/area/space)
+/area/space/nearstation)
 "swt" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4

--- a/_maps/map_files/PubbyStation/PubbyStation.dmm
+++ b/_maps/map_files/PubbyStation/PubbyStation.dmm
@@ -14,16 +14,16 @@
 	width = 18
 	},
 /turf/open/space,
-/area/space)
+/area/space/nearstation)
 "aby" = (
 /obj/structure/lattice,
 /obj/structure/grille,
 /turf/open/space,
-/area/space)
+/area/space/nearstation)
 "abI" = (
 /obj/structure/lattice,
 /turf/open/space,
-/area/space)
+/area/space/nearstation)
 "abJ" = (
 /obj/structure/lattice,
 /obj/machinery/camera/motion{
@@ -32,7 +32,7 @@
 	network = list("MiniSat")
 	},
 /turf/open/space,
-/area/space)
+/area/space/nearstation)
 "abN" = (
 /obj/effect/landmark/carpspawn,
 /turf/open/space,
@@ -176,7 +176,7 @@
 	network = list("MiniSat")
 	},
 /turf/open/space,
-/area/space)
+/area/space/nearstation)
 "acn" = (
 /obj/machinery/porta_turret/ai{
 	dir = 4
@@ -268,7 +268,7 @@
 	network = list("MiniSat")
 	},
 /turf/open/space,
-/area/space)
+/area/space/nearstation)
 "acw" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -435,11 +435,11 @@
 /obj/structure/lattice,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/space,
-/area/space)
+/area/space/nearstation)
 "acO" = (
 /obj/structure/grille/broken,
 /turf/open/space,
-/area/space)
+/area/space/nearstation)
 "acP" = (
 /turf/closed/wall/r_wall,
 /area/ai_monitored/turret_protected/AIsatextAP)
@@ -827,7 +827,7 @@
 /obj/structure/grille,
 /obj/structure/lattice,
 /turf/open/space,
-/area/space)
+/area/space/nearstation)
 "adS" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/closed/wall/r_wall,
@@ -904,7 +904,7 @@
 /obj/structure/lattice,
 /obj/structure/grille/broken,
 /turf/open/space,
-/area/space)
+/area/space/nearstation)
 "aee" = (
 /turf/open/floor/plating,
 /area/ai_monitored/turret_protected/AIsatextAP)
@@ -1528,7 +1528,7 @@
 "afJ" = (
 /obj/effect/landmark/carpspawn,
 /turf/open/space/basic,
-/area/space)
+/area/space/nearstation)
 "afK" = (
 /obj/machinery/atmospherics/components/unary/tank/air{
 	dir = 1
@@ -1998,7 +1998,7 @@
 /obj/structure/transit_tube,
 /obj/structure/lattice/catwalk,
 /turf/open/space/basic,
-/area/space)
+/area/space/nearstation)
 "agT" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/door/poddoor/preopen{
@@ -2088,11 +2088,11 @@
 	pixel_y = 20
 	},
 /turf/open/space,
-/area/space)
+/area/space/nearstation)
 "ahi" = (
 /obj/structure/lattice/catwalk,
 /turf/open/space,
-/area/space)
+/area/space/nearstation)
 "ahj" = (
 /obj/item/device/radio/intercom{
 	freerange = 0;
@@ -2177,16 +2177,16 @@
 	network = list("MiniSat")
 	},
 /turf/open/space,
-/area/space)
+/area/space/nearstation)
 "ahs" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/transit_tube,
 /turf/open/space/basic,
-/area/space)
+/area/space/nearstation)
 "aht" = (
 /obj/structure/lattice,
 /turf/open/space/basic,
-/area/space)
+/area/space/nearstation)
 "ahu" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable{
@@ -2421,7 +2421,7 @@
 /obj/structure/lattice/catwalk,
 /obj/structure/transit_tube/crossing,
 /turf/open/space/basic,
-/area/space)
+/area/space/nearstation)
 "ahS" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable{
@@ -3146,7 +3146,7 @@
 	width = 18
 	},
 /turf/open/space,
-/area/space)
+/area/space/nearstation)
 "ajB" = (
 /obj/item/storage/box/mousetraps,
 /turf/open/floor/plating,
@@ -3831,7 +3831,7 @@
 	},
 /obj/structure/lattice/catwalk,
 /turf/open/space/basic,
-/area/space)
+/area/space/nearstation)
 "alb" = (
 /turf/open/floor/wood,
 /area/maintenance/department/crew_quarters/dorms)
@@ -4118,7 +4118,7 @@
 /obj/structure/transit_tube/diagonal,
 /obj/structure/lattice,
 /turf/open/space/basic,
-/area/space)
+/area/space/nearstation)
 "alP" = (
 /turf/open/floor/plating{
 	burnt = 1;
@@ -4482,17 +4482,17 @@
 	},
 /obj/structure/lattice/catwalk,
 /turf/open/space/basic,
-/area/space)
+/area/space/nearstation)
 "amB" = (
 /obj/structure/transit_tube/crossing/horizontal,
 /obj/structure/lattice/catwalk,
 /turf/open/space/basic,
-/area/space)
+/area/space/nearstation)
 "amC" = (
 /obj/structure/transit_tube/horizontal,
 /obj/structure/lattice/catwalk,
 /turf/open/space/basic,
-/area/space)
+/area/space/nearstation)
 "amD" = (
 /obj/structure/transit_tube/curved/flipped{
 	icon_state = "curved1";
@@ -4500,7 +4500,7 @@
 	},
 /obj/structure/lattice/catwalk,
 /turf/open/space/basic,
-/area/space)
+/area/space/nearstation)
 "amF" = (
 /turf/open/floor/wood{
 	broken = 1;
@@ -4760,7 +4760,7 @@
 "anl" = (
 /obj/structure/transit_tube/diagonal,
 /turf/open/space/basic,
-/area/space)
+/area/space/nearstation)
 "anm" = (
 /obj/machinery/door/airlock/maintenance/abandoned{
 	name = "Pete's Speakeasy";
@@ -5628,14 +5628,14 @@
 /obj/structure/transit_tube/diagonal/crossing,
 /obj/structure/lattice,
 /turf/open/space/basic,
-/area/space)
+/area/space/nearstation)
 "app" = (
 /obj/machinery/camera{
 	c_tag = "Bridge Starboard Exterior";
 	dir = 1
 	},
 /turf/open/space,
-/area/space)
+/area/space/nearstation)
 "apq" = (
 /obj/machinery/gateway{
 	dir = 8
@@ -5866,7 +5866,7 @@
 /obj/structure/transit_tube/curved,
 /obj/structure/lattice/catwalk,
 /turf/open/space/basic,
-/area/space)
+/area/space/nearstation)
 "apT" = (
 /turf/closed/wall/r_wall,
 /area/ai_monitored/nuke_storage)
@@ -6160,7 +6160,7 @@
 /obj/structure/window/reinforced,
 /obj/structure/lattice,
 /turf/open/space/basic,
-/area/space)
+/area/space/nearstation)
 "aqH" = (
 /obj/structure/cable{
 	icon_state = "2-4"
@@ -6570,7 +6570,7 @@
 	},
 /obj/structure/lattice,
 /turf/open/space/basic,
-/area/space)
+/area/space/nearstation)
 "arG" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -12857,7 +12857,7 @@
 	pixel_y = 32
 	},
 /turf/open/space,
-/area/space)
+/area/space/nearstation)
 "aGp" = (
 /obj/structure/lattice,
 /obj/structure/sign/logo{
@@ -12865,7 +12865,7 @@
 	pixel_y = 32
 	},
 /turf/open/space,
-/area/space)
+/area/space/nearstation)
 "aGq" = (
 /obj/structure/lattice,
 /obj/structure/sign/logo{
@@ -12873,7 +12873,7 @@
 	pixel_y = 32
 	},
 /turf/open/space,
-/area/space)
+/area/space/nearstation)
 "aGr" = (
 /obj/structure/lattice,
 /obj/structure/sign/logo{
@@ -12881,7 +12881,7 @@
 	pixel_y = 32
 	},
 /turf/open/space,
-/area/space)
+/area/space/nearstation)
 "aGs" = (
 /obj/structure/lattice,
 /obj/structure/sign/logo{
@@ -12889,7 +12889,7 @@
 	pixel_y = 32
 	},
 /turf/open/space,
-/area/space)
+/area/space/nearstation)
 "aGt" = (
 /obj/machinery/vending/cola,
 /obj/effect/turf_decal/delivery,
@@ -25482,7 +25482,7 @@
 	},
 /obj/structure/lattice,
 /turf/open/space/basic,
-/area/space)
+/area/space/nearstation)
 "bkF" = (
 /turf/closed/wall/r_wall,
 /area/science/xenobiology)
@@ -30666,7 +30666,7 @@
 	dir = 8
 	},
 /turf/open/floor/plating/airless,
-/area/space)
+/area/space/nearstation)
 "bwp" = (
 /obj/machinery/door/airlock/external,
 /turf/open/floor/pod/light,
@@ -32317,7 +32317,7 @@
 "bzy" = (
 /obj/structure/grille,
 /turf/open/space,
-/area/space)
+/area/space/nearstation)
 "bzz" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/structure/chair{
@@ -32826,7 +32826,7 @@
 	dir = 4
 	},
 /turf/open/space/basic,
-/area/space)
+/area/space/nearstation)
 "bAJ" = (
 /obj/structure/transit_tube/horizontal,
 /obj/structure/window/reinforced/fulltile,
@@ -33367,7 +33367,7 @@
 "bBV" = (
 /obj/structure/transit_tube/curved,
 /turf/open/space,
-/area/space)
+/area/space/nearstation)
 "bBW" = (
 /turf/open/space,
 /area/space)
@@ -33896,7 +33896,7 @@
 /obj/structure/transit_tube,
 /obj/structure/lattice/catwalk,
 /turf/open/space,
-/area/space)
+/area/space/nearstation)
 "bDg" = (
 /obj/machinery/atmospherics/components/unary/tank/air{
 	dir = 2
@@ -35062,7 +35062,7 @@
 	width = 5
 	},
 /turf/open/space,
-/area/space)
+/area/space/nearstation)
 "bFF" = (
 /obj/machinery/atmospherics/components/unary/tank/air{
 	dir = 1
@@ -35475,7 +35475,7 @@
 	dir = 4
 	},
 /turf/open/space,
-/area/space)
+/area/space/nearstation)
 "bGE" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
@@ -35500,11 +35500,11 @@
 "bGH" = (
 /obj/structure/window/reinforced,
 /turf/open/space,
-/area/space)
+/area/space/nearstation)
 "bGI" = (
 /obj/structure/window/reinforced,
 /turf/open/space/basic,
-/area/space)
+/area/space/nearstation)
 "bGK" = (
 /obj/structure/closet/boxinggloves,
 /turf/open/floor/plating{
@@ -35961,7 +35961,7 @@
 "bHI" = (
 /obj/structure/grille/broken,
 /turf/open/space/basic,
-/area/space)
+/area/space/nearstation)
 "bHJ" = (
 /turf/open/floor/plating,
 /area/chapel/dock)
@@ -35989,7 +35989,7 @@
 	layer = 2.9
 	},
 /turf/open/space/basic,
-/area/space)
+/area/space/nearstation)
 "bHP" = (
 /obj/effect/decal/cleanable/cobweb,
 /turf/open/floor/plasteel/dark,
@@ -36463,7 +36463,7 @@
 	layer = 2.9
 	},
 /turf/open/space/basic,
-/area/space)
+/area/space/nearstation)
 "bIU" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/closed/wall,
@@ -36500,7 +36500,7 @@
 	layer = 2.9
 	},
 /turf/open/space/basic,
-/area/space)
+/area/space/nearstation)
 "bIZ" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
@@ -36944,7 +36944,7 @@
 	},
 /obj/structure/lattice,
 /turf/open/space/basic,
-/area/space)
+/area/space/nearstation)
 "bKa" = (
 /obj/machinery/airalarm{
 	dir = 4;
@@ -37363,7 +37363,7 @@
 	dir = 4
 	},
 /turf/open/space,
-/area/space)
+/area/space/nearstation)
 "bLb" = (
 /obj/machinery/atmospherics/pipe/simple{
 	dir = 4
@@ -37515,7 +37515,7 @@
 	layer = 2.9
 	},
 /turf/open/space,
-/area/space)
+/area/space/nearstation)
 "bLt" = (
 /obj/effect/decal/cleanable/oil{
 	icon_state = "floor6"
@@ -37935,7 +37935,7 @@
 	layer = 2.9
 	},
 /turf/open/space/basic,
-/area/space)
+/area/space/nearstation)
 "bMs" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -37992,7 +37992,7 @@
 	},
 /obj/structure/lattice,
 /turf/open/space,
-/area/space)
+/area/space/nearstation)
 "bMA" = (
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/engine,
@@ -38280,7 +38280,7 @@
 	dir = 4
 	},
 /turf/open/space,
-/area/space)
+/area/space/nearstation)
 "bNo" = (
 /obj/machinery/atmospherics/components/unary/outlet_injector/on{
 	dir = 8;
@@ -38304,7 +38304,7 @@
 /obj/structure/window/reinforced,
 /obj/structure/lattice,
 /turf/open/space,
-/area/space)
+/area/space/nearstation)
 "bNs" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating/airless,
@@ -38387,7 +38387,7 @@
 	},
 /obj/structure/lattice/catwalk,
 /turf/open/space,
-/area/space)
+/area/space/nearstation)
 "bNF" = (
 /obj/item/stack/medical/bruise_pack,
 /turf/open/floor/plasteel/dark,
@@ -38718,7 +38718,7 @@
 	},
 /obj/structure/lattice,
 /turf/open/space,
-/area/space)
+/area/space/nearstation)
 "bOw" = (
 /turf/open/floor/plating/asteroid,
 /area/chapel/asteroid{
@@ -39009,21 +39009,21 @@
 	},
 /obj/structure/lattice,
 /turf/open/space/basic,
-/area/space)
+/area/space/nearstation)
 "bPk" = (
 /obj/structure/lattice/catwalk,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
 	dir = 4
 	},
 /turf/open/space,
-/area/space)
+/area/space/nearstation)
 "bPl" = (
 /obj/structure/lattice/catwalk,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
 	dir = 9
 	},
 /turf/open/space,
-/area/space)
+/area/space/nearstation)
 "bPm" = (
 /obj/structure/lattice/catwalk,
 /turf/open/space,
@@ -39094,21 +39094,21 @@
 /obj/machinery/atmospherics/pipe/manifold/cyan/hidden,
 /obj/structure/lattice,
 /turf/open/space/basic,
-/area/space)
+/area/space/nearstation)
 "bPw" = (
 /obj/machinery/atmospherics/pipe/manifold/cyan/hidden{
 	dir = 1
 	},
 /obj/structure/lattice,
 /turf/open/space/basic,
-/area/space)
+/area/space/nearstation)
 "bPx" = (
 /obj/machinery/atmospherics/pipe/simple/cyan/hidden{
 	dir = 4
 	},
 /obj/structure/lattice,
 /turf/open/space/basic,
-/area/space)
+/area/space/nearstation)
 "bPy" = (
 /obj/machinery/atmospherics/pipe/simple/cyan/hidden{
 	dir = 4
@@ -39116,14 +39116,14 @@
 /obj/structure/lattice,
 /obj/structure/disposalpipe/segment,
 /turf/open/space/basic,
-/area/space)
+/area/space/nearstation)
 "bPz" = (
 /obj/machinery/atmospherics/pipe/simple/cyan/hidden{
 	dir = 9
 	},
 /obj/structure/lattice,
 /turf/open/space/basic,
-/area/space)
+/area/space/nearstation)
 "bPA" = (
 /obj/machinery/portable_atmospherics/canister/air,
 /turf/open/floor/plating,
@@ -39353,7 +39353,7 @@
 	},
 /obj/structure/lattice,
 /turf/open/space,
-/area/space)
+/area/space/nearstation)
 "bQj" = (
 /obj/effect/spawner/structure/window,
 /turf/open/floor/plating,
@@ -39659,14 +39659,14 @@
 	},
 /obj/structure/window/reinforced,
 /turf/open/space,
-/area/space)
+/area/space/nearstation)
 "bQR" = (
 /obj/structure/window/reinforced{
 	dir = 8
 	},
 /obj/structure/window/reinforced,
 /turf/open/space,
-/area/space)
+/area/space/nearstation)
 "bQS" = (
 /obj/structure/table,
 /obj/effect/spawner/lootdrop/maintenance,
@@ -40001,7 +40001,7 @@
 /obj/structure/window/reinforced,
 /obj/structure/lattice,
 /turf/open/space,
-/area/space)
+/area/space/nearstation)
 "bRD" = (
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plating,
@@ -40295,7 +40295,7 @@
 	dir = 8
 	},
 /turf/open/space,
-/area/space)
+/area/space/nearstation)
 "bSo" = (
 /obj/machinery/disposal/bin,
 /obj/structure/disposalpipe/trunk{
@@ -40590,20 +40590,20 @@
 	dir = 8
 	},
 /turf/open/space,
-/area/space)
+/area/space/nearstation)
 "bTa" = (
 /obj/structure/disposalpipe/segment{
 	dir = 6
 	},
 /obj/structure/lattice,
 /turf/open/space,
-/area/space)
+/area/space/nearstation)
 "bTb" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
 /turf/open/floor/plating/airless,
-/area/space)
+/area/space/nearstation)
 "bTc" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/disposalpipe/segment{
@@ -41017,7 +41017,7 @@
 /obj/structure/disposalpipe/segment,
 /obj/structure/lattice,
 /turf/open/space,
-/area/space)
+/area/space/nearstation)
 "bTX" = (
 /obj/structure/table,
 /obj/item/storage/box/mousetraps,
@@ -41246,7 +41246,7 @@
 	dir = 10
 	},
 /turf/open/space,
-/area/space)
+/area/space/nearstation)
 "bUB" = (
 /obj/docking_port/stationary{
 	dheight = 9;
@@ -41259,7 +41259,7 @@
 	width = 18
 	},
 /turf/open/space,
-/area/space)
+/area/space/nearstation)
 "bUC" = (
 /obj/structure/flora/ausbushes/fernybush,
 /turf/open/floor/plating/asteroid,
@@ -41272,14 +41272,14 @@
 	dir = 6
 	},
 /turf/open/space,
-/area/space)
+/area/space/nearstation)
 "bUE" = (
 /obj/structure/lattice,
 /obj/structure/disposalpipe/segment{
 	dir = 9
 	},
 /turf/open/space,
-/area/space)
+/area/space/nearstation)
 "bUF" = (
 /obj/structure/table,
 /obj/item/stack/cable_coil,
@@ -41610,7 +41610,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/purple/visible,
 /turf/open/space,
-/area/space)
+/area/space/nearstation)
 "bVn" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/siphon/on{
 	dir = 8;
@@ -41628,11 +41628,11 @@
 	dir = 4
 	},
 /turf/open/space/basic,
-/area/space)
+/area/space/nearstation)
 "bVr" = (
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plating/airless,
-/area/space)
+/area/space/nearstation)
 "bVs" = (
 /obj/structure/mopbucket,
 /obj/item/mop,
@@ -41987,7 +41987,7 @@
 /obj/structure/lattice,
 /obj/machinery/atmospherics/pipe/simple/purple/visible,
 /turf/open/space,
-/area/space)
+/area/space/nearstation)
 "bWe" = (
 /obj/machinery/air_sensor{
 	frequency = 1441;
@@ -42354,7 +42354,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/purple/visible,
 /turf/open/space,
-/area/space)
+/area/space/nearstation)
 "bWT" = (
 /obj/machinery/atmospherics/components/unary/outlet_injector/on{
 	dir = 8;
@@ -42872,7 +42872,7 @@
 /obj/machinery/atmospherics/pipe/simple/purple/visible,
 /obj/structure/lattice,
 /turf/open/space/basic,
-/area/space)
+/area/space/nearstation)
 "bYz" = (
 /obj/machinery/door/morgue{
 	name = "Confession Booth"
@@ -43247,12 +43247,12 @@
 /obj/structure/lattice,
 /obj/machinery/atmospherics/pipe/simple/green/visible,
 /turf/open/space,
-/area/space)
+/area/space/nearstation)
 "bZe" = (
 /obj/structure/lattice,
 /obj/machinery/atmospherics/pipe/simple/cyan/visible,
 /turf/open/space,
-/area/space)
+/area/space/nearstation)
 "bZf" = (
 /obj/machinery/power/apc{
 	dir = 8;
@@ -44761,7 +44761,7 @@
 "cdm" = (
 /obj/structure/lattice/catwalk,
 /turf/open/space/basic,
-/area/space)
+/area/space/nearstation)
 "cdo" = (
 /turf/open/floor/carpet,
 /area/chapel/office)
@@ -45870,7 +45870,7 @@
 "cgP" = (
 /obj/structure/transit_tube,
 /turf/open/floor/plating/airless,
-/area/space)
+/area/space/nearstation)
 "cgQ" = (
 /obj/machinery/light/small{
 	dir = 8
@@ -45925,10 +45925,10 @@
 /area/space/nearstation)
 "cgW" = (
 /turf/open/space,
-/area/space/nearstation)
+/area/space)
 "cgX" = (
 /turf/open/space/basic,
-/area/space/nearstation)
+/area/space)
 "cgY" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -46293,7 +46293,7 @@
 "cig" = (
 /obj/structure/transit_tube/crossing,
 /turf/open/floor/plating/airless,
-/area/space)
+/area/space/nearstation)
 "cih" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -47258,7 +47258,7 @@
 	width = 18
 	},
 /turf/open/space,
-/area/space)
+/area/space/nearstation)
 "clu" = (
 /obj/machinery/camera{
 	c_tag = "Telecomms External Fore";
@@ -47267,7 +47267,7 @@
 	start_active = 1
 	},
 /turf/open/space,
-/area/space)
+/area/space/nearstation)
 "clv" = (
 /turf/closed/mineral/iron,
 /area/mine/explored{
@@ -47288,7 +47288,7 @@
 	dir = 10
 	},
 /turf/open/space,
-/area/space)
+/area/space/nearstation)
 "clz" = (
 /obj/machinery/door/airlock/external{
 	cyclelinkeddir = 2;
@@ -47647,7 +47647,7 @@
 	network = list("Telecomms")
 	},
 /turf/open/space,
-/area/space)
+/area/space/nearstation)
 "cmu" = (
 /obj/machinery/status_display{
 	pixel_x = -32
@@ -47709,7 +47709,7 @@
 	network = list("Telecomms")
 	},
 /turf/open/space,
-/area/space)
+/area/space/nearstation)
 "cmA" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -47975,7 +47975,7 @@
 	network = list("Telecomms")
 	},
 /turf/open/space,
-/area/space)
+/area/space/nearstation)
 "cnz" = (
 /obj/structure/lattice,
 /obj/machinery/camera/motion{
@@ -47984,7 +47984,7 @@
 	network = list("Telecomms")
 	},
 /turf/open/space,
-/area/space)
+/area/space/nearstation)
 "cnA" = (
 /obj/docking_port/stationary{
 	dheight = 9;
@@ -47997,7 +47997,7 @@
 	width = 18
 	},
 /turf/open/space,
-/area/space)
+/area/space/nearstation)
 "cnC" = (
 /obj/machinery/turretid{
 	control_area = "/area/ai_monitored/turret_protected/aisat_interior";
@@ -48803,14 +48803,14 @@
 "cqS" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating/airless,
-/area/space)
+/area/space/nearstation)
 "cqU" = (
 /obj/structure/window/reinforced{
 	dir = 4
 	},
 /obj/structure/window/reinforced,
 /turf/open/space/basic,
-/area/space)
+/area/space/nearstation)
 "cqV" = (
 /obj/structure/chair/office/light{
 	dir = 1
@@ -48831,7 +48831,7 @@
 /obj/structure/disposalpipe/segment,
 /obj/structure/lattice,
 /turf/open/space/basic,
-/area/space)
+/area/space/nearstation)
 "crb" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating/airless,
@@ -48842,7 +48842,7 @@
 	dir = 8
 	},
 /turf/open/space/basic,
-/area/space)
+/area/space/nearstation)
 "crg" = (
 /obj/structure/chair/wood/normal,
 /turf/open/floor/plasteel/dark,
@@ -48885,7 +48885,7 @@
 /obj/structure/lattice,
 /obj/structure/disposalpipe/segment,
 /turf/open/space,
-/area/space)
+/area/space/nearstation)
 "crt" = (
 /obj/structure/table/wood/fancy,
 /obj/item/folder,
@@ -48911,7 +48911,7 @@
 	dir = 5
 	},
 /turf/open/space,
-/area/space)
+/area/space/nearstation)
 "crz" = (
 /obj/machinery/door/airlock/external{
 	cyclelinkeddir = 4;
@@ -49030,7 +49030,7 @@
 	dir = 8
 	},
 /turf/open/space/basic,
-/area/space)
+/area/space/nearstation)
 "crS" = (
 /obj/machinery/airalarm{
 	frequency = 1439;
@@ -49487,7 +49487,7 @@
 	dir = 1
 	},
 /turf/open/floor/plating/airless,
-/area/space)
+/area/space/nearstation)
 "ctV" = (
 /obj/structure/closet,
 /obj/item/clothing/suit/holidaypriest,
@@ -50303,7 +50303,7 @@
 	layer = 2.9
 	},
 /turf/open/space,
-/area/space)
+/area/space/nearstation)
 "cwO" = (
 /obj/item/device/flashlight/lantern,
 /turf/open/floor/plasteel/dark,
@@ -50314,7 +50314,7 @@
 	layer = 2.9
 	},
 /turf/open/space/basic,
-/area/space)
+/area/space/nearstation)
 "cwS" = (
 /obj/structure/reagent_dispensers/fueltank,
 /turf/open/floor/plating,
@@ -50336,7 +50336,7 @@
 	pixel_y = 1
 	},
 /turf/open/space/basic,
-/area/space)
+/area/space/nearstation)
 "cxh" = (
 /obj/structure/window/reinforced{
 	dir = 1;
@@ -50347,7 +50347,7 @@
 	layer = 2.9
 	},
 /turf/open/space/basic,
-/area/space)
+/area/space/nearstation)
 "cxk" = (
 /obj/structure/window/reinforced{
 	dir = 1;
@@ -50358,7 +50358,7 @@
 	layer = 2.9
 	},
 /turf/open/space/basic,
-/area/space)
+/area/space/nearstation)
 "cxn" = (
 /obj/machinery/newscaster{
 	pixel_x = -32;
@@ -51115,7 +51115,7 @@
 	width = 18
 	},
 /turf/open/space/basic,
-/area/space)
+/area/space/nearstation)
 "cBP" = (
 /obj/machinery/smoke_machine,
 /turf/open/floor/plasteel/white,

--- a/_maps/map_files/debug/runtimestation.dmm
+++ b/_maps/map_files/debug/runtimestation.dmm
@@ -5,10 +5,10 @@
 "ab" = (
 /obj/structure/lattice,
 /turf/open/space,
-/area/space)
+/area/space/nearstation)
 "ac" = (
 /turf/open/space,
-/area/space/nearstation)
+/area/space)
 "ad" = (
 /turf/closed/wall/r_wall,
 /area/maintenance/department/bridge)

--- a/_maps/shuttles/emergency_asteroid.dmm
+++ b/_maps/shuttles/emergency_asteroid.dmm
@@ -24,7 +24,7 @@
 /area/shuttle/escape)
 "ag" = (
 /turf/open/space,
-/area/space/nearstation)
+/area/space)
 "ah" = (
 /obj/effect/spawner/structure/window/shuttle,
 /turf/open/floor/plating,


### PR DESCRIPTION
🆑 ShizCalev
fix: The structures external to stations are now properly lit. Make sure you bring a flashlight.
/🆑

Fixes areas external to stations but containing objects using `/area/space` instead of `/area/space/nearstation`

This resulted in these areas having `DYNAMIC_LIGHTING_DISABLED` instead of `DYNAMIC_LIGHTING_IFSTARLIGHT`, meaning that they were always fullbright instead of being lit up by starlight.

Also corrected some incorrect `/area/space/nearstation` usage, where the squares ONLY contained space. This results in nothing happening since the space tile itself is fullbright.

Examples:
![4](https://user-images.githubusercontent.com/6209658/33017490-8de53f1c-cdc0-11e7-9b36-dde246141a02.png)

Corrected to:
![3](https://user-images.githubusercontent.com/6209658/33017499-9386294a-cdc0-11e7-8fa5-f359dc95071d.png)

-----------------

![8](https://user-images.githubusercontent.com/6209658/33017492-8dfe987c-cdc0-11e7-976c-195af768a593.png)

Corrected to:
![2](https://user-images.githubusercontent.com/6209658/33017498-9379fc2e-cdc0-11e7-8118-fcfcb9eb9da1.png)


