### PR TITLE
Makes Syndicate turrets assess cyborgs

### DIFF
--- a/code/game/machinery/porta_turret/portable_turret.dm
+++ b/code/game/machinery/porta_turret/portable_turret.dm
@@ -563,7 +563,7 @@
 /obj/machinery/porta_turret/syndicate/setup()
 	return
 
-/obj/machinery/porta_turret/syndicate/assess_perp(mob/living/carbon/human/perp)
+/obj/machinery/porta_turret/syndicate/assess_perp(mob/living/carbon/human/perp, /mob/living/silicon/robot)
 	return 10 //Syndicate turrets shoot everything not in their faction
 
 /obj/machinery/porta_turret/syndicate/pod


### PR DESCRIPTION
[Changelogs]: Syndicate turrets will now assess cyborgs as potential threats

:cl: 
fix: Syndicate turrets now consider cyborgs a potential threat
/:cl:

[why]: I feel like this is an oversight and probably unintended behaviour, feel free to say otherwise though
