### PR TITLE
Allows turrets to shoot cyborgs.

### DIFF
--- a/code/game/machinery/porta_turret/portable_turret.dm
+++ b/code/game/machinery/porta_turret/portable_turret.dm
@@ -57,12 +57,12 @@
 	var/shot_delay = 15		//ticks until next shot (1.5 ?)
 
 
-	var/check_records = 1	//checks if it can use the security records
-	var/criminals = 1		//checks if it can shoot people on arrest
-	var/auth_weapons = 0	//checks if it can shoot people that have a weapon they aren't authorized to have
-	var/stun_all = 0		//if this is active, the turret shoots everything that isn't security or head of staff
-	var/check_anomalies = 1	//checks if it can shoot at unidentified lifeforms (ie xenos)
-	var/target_silicons = 0 //checks if it can shoot silicons
+	var/check_records = TRUE	//checks if it can use the security records
+	var/criminals = TRUE		//checks if it can shoot people on arrest
+	var/auth_weapons = FALSE	//checks if it can shoot people that have a weapon they aren't authorized to have
+	var/stun_all = FALSE		//if this is active, the turret shoots everything that isn't security or head of staff
+	var/check_anomalies = TRUE	//checks if it can shoot at unidentified lifeforms (ie xenos)
+	var/target_silicons = FALSE //checks if it can shoot silicons
 
 	var/attacked = 0		//if set to 1, the turret gets pissed off and shoots at people nearby (unless they have sec access!)
 
@@ -403,7 +403,7 @@
 					
 		if(issilicon(A))
 			var/mob/living/silicon/S = A
-			if(!in_faction(C) && target_silicons) //if the target is a silicon and not in our faction, target it if we are allowed to target silicons
+			if(target_silicons && !in_faction(S)) //if the target is a silicon and not in our faction, target it if we are allowed to target silicons
 				targets += S
 
 	if(!tryToShootAt(targets))
@@ -559,7 +559,7 @@
 	faction = "syndicate"
 	emp_vunerable = 0
 	desc = "A ballistic machine gun auto-turret."
-	target_silicons = 1
+	target_silicons = TRUE
 
 /obj/machinery/porta_turret/syndicate/energy
 	icon_state = "standard_stun"

--- a/code/game/machinery/porta_turret/portable_turret.dm
+++ b/code/game/machinery/porta_turret/portable_turret.dm
@@ -62,6 +62,7 @@
 	var/auth_weapons = 0	//checks if it can shoot people that have a weapon they aren't authorized to have
 	var/stun_all = 0		//if this is active, the turret shoots everything that isn't security or head of staff
 	var/check_anomalies = 1	//checks if it can shoot at unidentified lifeforms (ie xenos)
+	var/target_silicons = 0 //checks if it can shoot silicons
 
 	var/attacked = 0		//if set to 1, the turret gets pissed off and shoots at people nearby (unless they have sec access!)
 
@@ -175,6 +176,7 @@
 		dat += "Neutralize Identified Criminals: <A href='?src=[REF(src)];operation=shootcrooks'>[criminals ? "Yes" : "No"]</A><BR>"
 		dat += "Neutralize All Non-Security and Non-Command Personnel: <A href='?src=[REF(src)];operation=shootall'>[stun_all ? "Yes" : "No"]</A><BR>"
 		dat += "Neutralize All Unidentified Life Signs: <A href='?src=[REF(src)];operation=checkxenos'>[check_anomalies ? "Yes" : "No"]</A><BR>"
+		dat += "Neutralize All Silicons: <A href'?src=[REF(src)];operation=targetsilicons'>[target_silicons ? "Yes" : "No"]</A><BR>"
 
 	var/datum/browser/popup = new(user, "autosec", "Automatic Portable Turret Installation", 300, 300)
 	popup.set_content(dat)
@@ -206,6 +208,8 @@
 				stun_all = !stun_all
 			if("checkxenos")
 				check_anomalies = !check_anomalies
+			if("targetsilicons")
+				target_silicons = !target_silicons
 		interact(usr)
 
 /obj/machinery/porta_turret/power_change()
@@ -396,6 +400,11 @@
 			if(M.occupant && !in_faction(M.occupant))
 				if(assess_perp(M.occupant) >= 4)
 					targets += M
+					
+		if(issilicon(A))
+			var/mob/living/silicon/S = A
+			if(!in_faction(C) && target_silicons) //if the target is a silicon and not in our faction, target it if we are allowed to target silicons
+				targets += S
 
 	if(!tryToShootAt(targets))
 		if(!always_up)
@@ -550,6 +559,7 @@
 	faction = "syndicate"
 	emp_vunerable = 0
 	desc = "A ballistic machine gun auto-turret."
+	target_silicons = 1
 
 /obj/machinery/porta_turret/syndicate/energy
 	icon_state = "standard_stun"


### PR DESCRIPTION
:cl: Y0SH1 M4S73R (with credit to Anonmare)
add: Turrets can target silicons. Whether or not they will can be configured in the turret's interface.
fix: Syndicate turrets will shoot at non-Syndicate silicons by default.
/:cl:

Basically #32938 but with working code.
