### PR TITLE
Fixes aliums showing wrong sprite in softcrit

### DIFF
--- a/code/modules/mob/living/carbon/alien/humanoid/update_icons.dm
+++ b/code/modules/mob/living/carbon/alien/humanoid/update_icons.dm
@@ -12,7 +12,7 @@
 		else
 			icon_state = "alien[caste]_dead"
 
-	else if((stat == UNCONSCIOUS && !asleep) || IsKnockdown())
+	else if((stat == UNCONSCIOUS && !asleep) || stat == SOFT_CRIT || IsKnockdown())
 		icon_state = "alien[caste]_unconscious"
 	else if(leap_on_click)
 		icon_state = "alien[caste]_pounce"


### PR DESCRIPTION
Fixes #32898

🆑 ShizCalev
fix: Aliens in soft-crit will now use the correct sprite.
/🆑