### PR TITLE
Gives the R&D Server a description and makes its name improper

### DIFF
--- a/code/modules/research/server.dm
+++ b/code/modules/research/server.dm
@@ -1,5 +1,6 @@
 /obj/machinery/rnd/server
 	name = "R&D Server"
+	desc = "A computer system running a deep neural network that processes arbitrary information to produce data useable in the development of new technologies. In layman's terms, it makes research points."
 	icon = 'icons/obj/machines/research.dmi'
 	icon_state = "server"
 	var/datum/techweb/stored_research

--- a/code/modules/research/server.dm
+++ b/code/modules/research/server.dm
@@ -1,5 +1,5 @@
 /obj/machinery/rnd/server
-	name = "R&D Server"
+	name = "\improper R&D Server"
 	desc = "A computer system running a deep neural network that processes arbitrary information to produce data useable in the development of new technologies. In layman's terms, it makes research points."
 	icon = 'icons/obj/machines/research.dmi'
 	icon_state = "server"


### PR DESCRIPTION
:cl: Y0SH1 M4S73R
spellcheck: The R&D Server's name is now improper.
spellcheck: The R&D Server now has an explanation of what it does.
/:cl:

Because for some reason it doesn't have a description, therefore it defaults to "some kind of machine"
