### PR TITLE
Feedback fixes

### DIFF
--- a/code/controllers/subsystem/blackbox.dm
+++ b/code/controllers/subsystem/blackbox.dm
@@ -9,7 +9,8 @@ SUBSYSTEM_DEF(blackbox)
 	var/triggertime = 0
 	var/sealed = FALSE	//time to stop tracking stats?
 	var/list/research_levels = list() //list of highest tech levels attained that isn't lost lost by destruction of RD computers
-	var/list/versions = list("time_dilation_current" = 2) //associative list of any feedback variables that have had their format changed since creation and their current version, remember to update this
+	var/list/versions = list("time_dilation_current" = 2,
+							"science_techweb_unlock" = 2) //associative list of any feedback variables that have had their format changed since creation and their current version, remember to update this
 
 
 /datum/controller/subsystem/blackbox/Initialize()

--- a/code/controllers/subsystem/blackbox.dm
+++ b/code/controllers/subsystem/blackbox.dm
@@ -9,7 +9,7 @@ SUBSYSTEM_DEF(blackbox)
 	var/triggertime = 0
 	var/sealed = FALSE	//time to stop tracking stats?
 	var/list/research_levels = list() //list of highest tech levels attained that isn't lost lost by destruction of RD computers
-	var/list/versions = list() //associative list of any feedback variables that have had their format changed since creation and their current version, remember to update this
+	var/list/versions = list("time_dilation_current" = 2) //associative list of any feedback variables that have had their format changed since creation and their current version, remember to update this
 
 
 /datum/controller/subsystem/blackbox/Initialize()

--- a/code/controllers/subsystem/time_track.dm
+++ b/code/controllers/subsystem/time_track.dm
@@ -35,4 +35,4 @@ SUBSYSTEM_DEF(time_track)
 	last_tick_realtime = current_realtime
 	last_tick_byond_time = current_byondtime
 	last_tick_tickcount = current_tickcount
-	SSblackbox.record_feedback("tally", "time_dilation_current", 1, time_dilation_current)
+	SSblackbox.record_feedback("associative", "time_dilation_current", 1, list("[time_dilation_current]" = "[SQLtime()]"))

--- a/code/modules/events/_event.dm
+++ b/code/modules/events/_event.dm
@@ -88,7 +88,7 @@
 	var/datum/round_event/E = new typepath()
 	E.current_players = get_active_player_count(alive_check = 1, afk_check = 1, human_check = 1)
 	E.control = src
-	SSblackbox.record_feedback("tally", "event_ran", 1, "E")
+	SSblackbox.record_feedback("tally", "event_ran", 1, "[E]")
 	occurrences++
 
 	testing("[time2text(world.time, "hh:mm:ss")] [E.type]")

--- a/code/modules/research/rdconsole.dm
+++ b/code/modules/research/rdconsole.dm
@@ -152,9 +152,7 @@ doesn't have toxins access.
 	if(stored_research.research_points >= price)
 		investigate_log("[key_name_admin(user)] researched [id]([price]) on techweb id [stored_research.id].", INVESTIGATE_RESEARCH)
 		if(stored_research == SSresearch.science_tech)
-			if(stored_research.researched_nodes.len < 30)
-				SSblackbox.record_feedback("tally", "science_techweb_unlock_first_thirty", 1, "[id]")
-			SSblackbox.record_feedback("tally", "science_techweb_unlock", 1, "[id]")
+			SSblackbox.record_feedback("associative", "science_techweb_unlock", 1, list("id" = "[id]", "price" = "[price]", "time" = "[SQLtime()]"))
 		if(stored_research.research_node(SSresearch.techweb_nodes[id]))
 			say("Sucessfully researched [TN.display_name].")
 			var/logname = "Unknown"


### PR DESCRIPTION
`event_ran` was recording as the letter `E` (whoops).

`science_techweb_unlock_first_thirty` removed and rolled into `science_techweb_unlock` which now also tracks the price and timestamp of unlock.

`time_dilation_current` tracks timestamp of each feedback call.

Both timestamps are just `SQLtime()` aka current server time, but they could instead be as game duration @nfreader