### PR TITLE
Removed trim from debugger string input

### DIFF
--- a/code/modules/integrated_electronics/core/debugger.dm
+++ b/code/modules/integrated_electronics/core/debugger.dm
@@ -20,7 +20,7 @@
 	switch(type_to_use)
 		if("string")
 			accepting_refs = FALSE
-			new_data = stripped_input(user, "Now type in a string.","[src] string writing")
+			new_data = stripped_input(user, "Now type in a string.","[src] string writing", no_trim = TRUE)
 			if(istext(new_data) && user.IsAdvancedToolUser())
 				data_to_write = new_data
 				to_chat(user, "<span class='notice'>You set \the [src]'s memory to \"[new_data]\".</span>")


### PR DESCRIPTION
[Changelogs]:

:cl: 
tweak: Now debugger accepts whitespaces and newlines as input.
/:cl:

[why]: Because text parsing. Seriously, how am I supposed, for example, to explode or concat string with space as delimiter if I can't write space to input pin?