### PR TITLE
Adds round ID to status world topic

### DIFF
--- a/code/datums/world_topic.dm
+++ b/code/datums/world_topic.dm
@@ -142,6 +142,7 @@
 	.["vote"] = CONFIG_GET(flag/allow_vote_mode)
 	.["ai"] = CONFIG_GET(flag/allow_ai)
 	.["host"] = world.host ? world.host : null
+	.["round_id"] = GLOB.round_id
 	.["players"] = GLOB.clients.len
 	.["revision"] = GLOB.revdata.commit
 	.["revision_date"] = GLOB.revdata.date


### PR DESCRIPTION

:cl:
code: Added round id to the status world topic
/:cl:

Found it odd that this wasn't added earlier, considering round ID is kinda important.
Need to get the round ID for some refactor work on nbot, and afaik the website game banners also use world status.