### PR TITLE
Fixes AIs being unable to interact with unscrewed airlocks

### DIFF
--- a/code/game/machinery/doors/airlock.dm
+++ b/code/game/machinery/doors/airlock.dm
@@ -49,6 +49,7 @@
 	var/normal_integrity = AIRLOCK_INTEGRITY_N
 	integrity_failure = 70
 	damage_deflection = AIRLOCK_DAMAGE_DEFLECTION_N
+	interact_open = TRUE
 
 	var/security_level = 0 //How much are wires secured
 	var/aiControlDisabled = 0 //If 1, AI control is disabled until the AI hacks back in and disables the lock. If 2, the AI has bypassed the lock. If -1, the control is enabled but the AI had bypassed it earlier, so if it is disabled again the AI would have no trouble getting back in.

--- a/code/modules/power/apc.dm
+++ b/code/modules/power/apc.dm
@@ -49,6 +49,7 @@
 	max_integrity = 200
 	integrity_failure = 50
 	resistance_flags = FIRE_PROOF
+	interact_open = TRUE
 
 	var/lon_range = 1.5
 	var/area/area
@@ -657,7 +658,7 @@
 		wires.interact(user)
 	else
 		return ..()
-		
+
 /obj/machinery/power/apc/AltClick(mob/user)
 	..()
 	if(!issilicon(user) && (!user.canUseTopic(src, be_close=TRUE) || !isturf(loc)))
@@ -665,7 +666,7 @@
 		return
 	else
 		togglelock(user)
-		
+
 /obj/machinery/power/apc/proc/togglelock(mob/living/user)
 	if(emagged)
 		to_chat(user, "<span class='warning'>The interface is broken!</span>")


### PR DESCRIPTION
:cl:
fix: AIs and cyborgs can interact with unscrewed airlocks and APCs.
/:cl:
