### PR TITLE
A few investigate_log and message_admin fixes

### DIFF
--- a/code/modules/flufftext/Hallucination.dm
+++ b/code/modules/flufftext/Hallucination.dm
@@ -13,13 +13,6 @@ Gunshots/explosions/opening doors/less rare audio (done)
 
 #define HAL_LINES_FILE "hallucination.json"
 
-/mob/living/carbon
-	var/image/halimage
-	var/image/halbody
-	var/obj/halitem
-	var/hal_screwyhud = SCREWYHUD_NONE
-	var/next_hallucination = 0
-
 GLOBAL_LIST_INIT(hallucinations_minor, list(
 	/datum/hallucination/sounds,
 	/datum/hallucination/bolts,
@@ -82,6 +75,7 @@ GLOBAL_LIST_INIT(hallucinations_major, list(
 
 /datum/hallucination/Destroy()
 	target.investigate_log("was afflicted with a hallucination of type [type]. [feedback_details]", INVESTIGATE_HALLUCINATIONS)
+	target = null
 	return ..()
 
 /obj/effect/hallucination
@@ -197,7 +191,6 @@ GLOBAL_LIST_INIT(hallucinations_major, list(
 	flood_turfs = list()
 	if(target.client)
 		target.client.images.Remove(flood_images)
-	target = null
 	qdel(flood_images)
 	flood_images = list()
 	return ..()
@@ -1153,4 +1146,3 @@ GLOBAL_LIST_INIT(hallucinations_major, list(
 	H.preparePixelProjectile(target, start)
 	H.fire()
 	qdel(src)
-

--- a/code/modules/mob/living/carbon/carbon_defines.dm
+++ b/code/modules/mob/living/carbon/carbon_defines.dm
@@ -49,3 +49,10 @@
 
 	var/icon_render_key = ""
 	var/static/list/limb_icon_cache = list()
+
+	//halucination vars
+	var/image/halimage
+	var/image/halbody
+	var/obj/halitem
+	var/hal_screwyhud = SCREWYHUD_NONE
+	var/next_hallucination = 0

--- a/code/modules/research/circuitprinter.dm
+++ b/code/modules/research/circuitprinter.dm
@@ -137,8 +137,8 @@ using metal and glass, it uses glass and reagents (usually sulfuric acis).
 
 /obj/machinery/rnd/circuit_imprinter/proc/do_print(path, list/matlist, notify_admins)
 	if(notify_admins && usr)
-			investigate_log("[key_name(usr)] built [path] at a circuit imprinter.", INVESTIGATE_RESEARCH)
-			message_admins("[ADMIN_LOOKUPFLW(usr)] has built [path] at a circuit imprinter.")
+		investigate_log("[key_name(usr)] built [path] at a circuit imprinter.", INVESTIGATE_RESEARCH)
+		message_admins("[ADMIN_LOOKUPFLW(usr)] has built [path] at a circuit imprinter.")
 	var/obj/item/I = new path(get_turf(src))
 	I.materials = matlist.Copy()
 	SSblackbox.record_feedback("nested_tally", "circuit_printed", 1, list("[type]", "[path]"))

--- a/code/modules/research/circuitprinter.dm
+++ b/code/modules/research/circuitprinter.dm
@@ -136,11 +136,9 @@ using metal and glass, it uses glass and reagents (usually sulfuric acis).
 	return TRUE
 
 /obj/machinery/rnd/circuit_imprinter/proc/do_print(path, list/matlist, notify_admins)
-	if(notify_admins)
-		if(usr)
-			usr.investigate_log("built [path] at a circuit imprinter.", INVESTIGATE_RESEARCH)
-			var/turf/T = get_turf(usr)
-			message_admins("[key_name(usr)][ADMIN_JMP(T)] has built [path] at a circuit imprinter at [COORD(usr)]")
+	if(notify_admins && usr)
+			investigate_log("[key_name(usr)] built [path] at a circuit imprinter.", INVESTIGATE_RESEARCH)
+			message_admins("[ADMIN_LOOKUPFLW(usr)] has built [path] at a circuit imprinter.")
 	var/obj/item/I = new path(get_turf(src))
 	I.materials = matlist.Copy()
 	SSblackbox.record_feedback("nested_tally", "circuit_printed", 1, list("[type]", "[path]"))

--- a/code/modules/research/protolathe.dm
+++ b/code/modules/research/protolathe.dm
@@ -144,8 +144,8 @@ Note: Must be placed west/left of and R&D console to function.
 
 /obj/machinery/rnd/protolathe/proc/do_print(path, amount, list/matlist, notify_admins)
 	if(notify_admins && usr)
-			investigate_log("[key_name(usr)] built [amount] of [path] at a protolathe.", INVESTIGATE_RESEARCH)
-			message_admins("[ADMIN_LOOKUPFLW(usr)] has built [amount] of [path] at a protolathe")
+		investigate_log("[key_name(usr)] built [amount] of [path] at a protolathe.", INVESTIGATE_RESEARCH)
+		message_admins("[ADMIN_LOOKUPFLW(usr)] has built [amount] of [path] at a protolathe")
 	for(var/i in 1 to amount)
 		var/obj/item/I = new path(get_turf(src))
 		if(!istype(I, /obj/item/stack/sheet) && !istype(I, /obj/item/ore/bluespace_crystal))

--- a/code/modules/research/protolathe.dm
+++ b/code/modules/research/protolathe.dm
@@ -143,11 +143,9 @@ Note: Must be placed west/left of and R&D console to function.
 	return TRUE
 
 /obj/machinery/rnd/protolathe/proc/do_print(path, amount, list/matlist, notify_admins)
-	if(notify_admins)
-		if(usr)
-			usr.investigate_log("built [amount] of [path] at a protolathe.", INVESTIGATE_RESEARCH)
-			var/turf/T = get_turf(usr)
-			message_admins("[key_name(usr)][ADMIN_JMP(T)] has built [amount] of [path] at a protolathe at [COORD(usr)]")
+	if(notify_admins && usr)
+			investigate_log("[key_name(usr)] built [amount] of [path] at a protolathe.", INVESTIGATE_RESEARCH)
+			message_admins("[ADMIN_LOOKUPFLW(usr)] has built [amount] of [path] at a protolathe")
 	for(var/i in 1 to amount)
 		var/obj/item/I = new path(get_turf(src))
 		if(!istype(I, /obj/item/stack/sheet) && !istype(I, /obj/item/ore/bluespace_crystal))

--- a/code/modules/research/rdconsole.dm
+++ b/code/modules/research/rdconsole.dm
@@ -150,7 +150,7 @@ doesn't have toxins access.
 		return FALSE
 	var/price = TN.get_price(stored_research)
 	if(stored_research.research_points >= price)
-		investigate_log("[key_name_admin(user)] researched [id]([price]) on techweb id [stored_research.id].", INVESTIGATE_RESEARCH)
+		investigate_log("[key_name(user)] researched [id]([price]) on techweb id [stored_research.id].", INVESTIGATE_RESEARCH)
 		if(stored_research == SSresearch.science_tech)
 			if(stored_research.researched_nodes.len < 30)
 				SSblackbox.record_feedback("tally", "science_techweb_unlock_first_thirty", 1, "[id]")


### PR DESCRIPTION
For protolathe and circuit printer: Combined two `if`s, removed pointless `usr` and fixed `investigate_log` not reporting the user and made `message_admins` use `ADMIN_LOOKUPFLW` rather than `key_name`

Changed `key_name_admin` to `key_name` for `investigate_log` in the RD console

Fixes runtime in hallucination `investigate_log` caused by `target` being nulled before the parent call.

And since I was nearby I moved some carbon vars that have been in `Hallucination.dm` for 6 years into `carbon_defines.dm`