### PR TITLE
Remove NODROP from water tank misters

### DIFF
--- a/code/game/objects/items/tanks/watertank.dm
+++ b/code/game/objects/items/tanks/watertank.dm
@@ -93,6 +93,10 @@
 	else
 		return ..()
 
+/obj/item/watertank/dropped(mob/user)
+	..()
+	remove_noz()
+
 // This mister item is intended as an extension of the watertank and always attached to it.
 // Therefore, it's designed to be "locked" to the player's hands or extended back onto
 // the watertank backpack. Allowing it to be placed elsewhere or created without a parent
@@ -109,7 +113,7 @@
 	amount_per_transfer_from_this = 50
 	possible_transfer_amounts = list(25,50,100)
 	volume = 500
-	flags_1 = NODROP_1 | NOBLUDGEON_1
+	flags_1 = NOBLUDGEON_1
 	container_type = OPENCONTAINER_1
 	slot_flags = 0
 
@@ -221,7 +225,6 @@
 	precision = 1
 	cooling_power = 5
 	w_class = WEIGHT_CLASS_HUGE
-	flags_1 = NODROP_1 //Necessary to ensure that the nozzle and tank never separate
 	var/obj/item/watertank/tank
 	var/nozzle_mode = 0
 	var/metal_synthesis_cooldown = 0


### PR DESCRIPTION
:cl:
fix: Fix water misters being inappropriately glued to hands in some cases.
/:cl:

Fixes #21275. Dropping or removing the tank, and it being stripped, will now properly retract the mister, and dropping the mister will also retract it. Previously, if the backpack was stripped or dropped in isolation, the mister would not return, remain usable, and be undroppable without recovering the backpack.