### PR TITLE
Revises the_station_areas list

### DIFF
--- a/code/controllers/subsystem/mapping.dm
+++ b/code/controllers/subsystem/mapping.dm
@@ -62,6 +62,7 @@ SUBSYSTEM_DEF(mapping)
 	repopulate_sorted_areas()
 	// Set up Z-level transistions.
 	setup_map_transitions()
+	generate_station_area_list()
 	..()
 
 /* Nuke threats, for making the blue tiles on the station go RED
@@ -138,6 +139,19 @@ SUBSYSTEM_DEF(mapping)
 		msg += ". Yell at your server host!"
 		INIT_ANNOUNCE(msg)
 #undef INIT_ANNOUNCE
+
+GLOBAL_LIST_EMPTY(the_station_areas)
+
+/datum/controller/subsystem/mapping/proc/generate_station_area_list()
+	var/list/station_areas_blacklist = typecacheof(list(/area/space, /area/mine, /area/ruin))
+	for(var/area/A in world)
+		var/turf/picked = safepick(get_area_turfs(A.type))
+		if(picked && (picked.z in GLOB.station_z_levels))
+			if(!(A.type in GLOB.the_station_areas) && !is_type_in_typecache(A, station_areas_blacklist))
+				GLOB.the_station_areas.Add(A.type)
+
+	if(!GLOB.the_station_areas.len)
+		log_world("ERROR: Station areas list failed to generate!")
 
 /datum/controller/subsystem/mapping/proc/maprotate()
 	var/players = GLOB.clients.len

--- a/code/game/area/Space_Station_13_areas.dm
+++ b/code/game/area/Space_Station_13_areas.dm
@@ -1486,36 +1486,3 @@ NOTE: there are two lists of areas in the end of this file: centcom and station 
 /area/tcommsat/lounge
 	name = "Telecommunications Satellite Lounge"
 	icon_state = "tcomsatlounge"
-
-/////////////////////////////////////////////////////////////////////
-/*
- Lists of areas to be used with is_type_in_list.
- Used in gamemodes code at the moment. --rastaf0
-*/
-
-//SPACE STATION 13
-GLOBAL_LIST_INIT(the_station_areas, list (
-	/area/bridge,
-	/area/chapel,
-	/area/construction,
-	/area/crew_quarters,
-	/area/engine,
-	/area/hallway,
-	/area/holodeck,
-	/area/hydroponics,
-	/area/janitor,
-	/area/lawoffice,
-	/area/library,
-	/area/maintenance,
-	/area/medical,
-	/area/quartermaster,
-	/area/science,
-	/area/security,
-	/area/solar,
-	/area/storage,
-	/area/teleporter,
-	/area/ai_monitored/storage/eva, //do not try to simplify to "/area/ai_monitored" --rastaf0
-	/area/ai_monitored/turret_protected/ai_upload, //do not try to simplify to "/area/ai_monitored/turret_protected" --rastaf0
-	/area/ai_monitored/turret_protected/ai_upload_foyer,
-	/area/ai_monitored/turret_protected/ai,
-))


### PR DESCRIPTION
Instead of maintaining a list whenever a new path is used or removed from the station, this changes the list to populate with all areas on the station during mapping init.