### PR TITLE
Specifies that MariaDB is required for sql in the project readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,7 +114,8 @@ To enable an away mission open `config/awaymissionconfig.txt` and uncomment one 
 
 ## SQL SETUP
 
-The SQL backend requires a MySQL server. SQL is required for the library, stats tracking, admin notes, and job-only bans, among other features, mostly related to server administration. Your server details go in /config/dbconfig.txt, and the SQL schema is in /SQL/tgstation_schema.sql and /SQL/tgstation_schema_prefix.sql depending on if you want table prefixes.  More detailed setup instructions are located here: https://www.tgstation13.org/wiki/Downloading_the_source_code#Setting_up_the_database
+The SQL backend requires a Mariadb server running 10.2 or later. Mysql is not supported but Mariadb is a drop in replacement for mysql. SQL is required for the library, stats tracking, admin notes, and job-only bans, among other features, mostly related to server administration. Your server details go in /config/dbconfig.txt, and the SQL schema is in /SQL/tgstation_schema.sql and /SQL/tgstation_schema_prefix.sql depending on if you want table prefixes.  More detailed setup instructions are located here: https://www.tgstation13.org/wiki/Downloading_the_source_code#Setting_up_the_database
+
 
 ## IRC BOT SETUP
 


### PR DESCRIPTION
:cl: MrStonedOne and Jordie
server: As a late note, serverops be advise that mysql is no longer supported. existing mysql databases will need to be converted to mariadb
/:cl:

Mysql requires some stupid shitty shit with the json datatype that make it annoying to insert json directly into a column and create a situation where we have to choose to support one or the other or snowflake a bunch of code.

This seems like a better solution. 