### PR TITLE
Reverts pull facing change of #32778

### DIFF
--- a/code/modules/mob/mob_movement.dm
+++ b/code/modules/mob/mob_movement.dm
@@ -187,9 +187,6 @@
 		for(var/obj/O in mob.user_movement_hooks)
 			O.intercept_user_move(direct, mob, n, oldloc)
 
-	if(mob.pulling && !ismob(mob.pulling))
-		mob.dir = turn(mob.dir, 180)
-
 /mob/Moved(oldLoc, dir, Forced = FALSE)
 	. = ..()
 	for(var/obj/O in contents)


### PR DESCRIPTION
Reverts the pull facing part of #32778

I talked to some people on the server and a lot of people agreed that it looks kinda odd.

 Physically it might be "right", but it translates rather badly to our tile based game. For example when it comes to small objects such as cigarettes and books and whatnot, turning around because you are dragging a cigarette bud is just weird. People walking backwards at 20km/h also feels a lot more unnatural than someone not facing an object they are dragging.