### PR TITLE
Moderate Damage Examination

### DIFF
--- a/code/modules/mob/living/carbon/human/examine.dm
+++ b/code/modules/mob/living/carbon/human/examine.dm
@@ -207,11 +207,11 @@
 	temp = getCloneLoss()
 	if(temp)
 		if(temp < 25)
-			msg += "[t_He] [t_is] slightly deformed.\n"
+			msg += "[t_He] [t_has] minor cellular damage.\n"
 		else if (temp < 50)
-			msg += "[t_He] [t_is] <b>moderately</b> deformed!\n"
+			msg += "[t_He] [t_has] <b>moderate</b> cellular damage!\n"
 		else
-			msg += "<b>[t_He] [t_is] severely deformed!</b>\n"
+			msg += "<b>[t_He] [t_has] severe cellular damage!</b>\n"
 
 
 	if(fire_stacks > 0)

--- a/code/modules/mob/living/carbon/human/examine.dm
+++ b/code/modules/mob/living/carbon/human/examine.dm
@@ -188,7 +188,7 @@
 		msg += "[t_He] [p_do()]n't seem all there.\n"
 
 	if(temp)
-		if (temp < 25)
+		if(temp < 25)
 			msg += "[t_He] [t_has] minor bruising.\n"
 		else if (temp < 50)
 			msg += "[t_He] [t_has] <b>moderate</b> bruising!\n"
@@ -197,7 +197,7 @@
 
 	temp = getFireLoss()
 	if(temp)
-		if (temp < 25)
+		if(temp < 25)
 			msg += "[t_He] [t_has] minor burns.\n"
 		else if (temp < 50)
 			msg += "[t_He] [t_has] <b>moderate</b> burns!\n"

--- a/code/modules/mob/living/carbon/human/examine.dm
+++ b/code/modules/mob/living/carbon/human/examine.dm
@@ -190,7 +190,7 @@
 	if(temp)
 		if(temp < 25)
 			msg += "[t_He] [t_has] minor bruising.\n"
-		else if (temp < 50)
+		else if(temp < 50)
 			msg += "[t_He] [t_has] <b>moderate</b> bruising!\n"
 		else
 			msg += "<B>[t_He] [t_has] severe bruising!</B>\n"

--- a/code/modules/mob/living/carbon/human/examine.dm
+++ b/code/modules/mob/living/carbon/human/examine.dm
@@ -188,24 +188,30 @@
 		msg += "[t_He] [p_do()]n't seem all there.\n"
 
 	if(temp)
-		if(temp < 30)
+		if (temp < 25)
 			msg += "[t_He] [t_has] minor bruising.\n"
+		else if (temp < 50)
+			msg += "[t_He] [t_has] <b>moderate</b> bruising!\n"
 		else
 			msg += "<B>[t_He] [t_has] severe bruising!</B>\n"
 
 	temp = getFireLoss()
 	if(temp)
-		if(temp < 30)
+		if (temp < 25)
 			msg += "[t_He] [t_has] minor burns.\n"
+		else if (temp < 50)
+			msg += "[t_He] [t_has] <b>moderate</b> burns!\n"
 		else
 			msg += "<B>[t_He] [t_has] severe burns!</B>\n"
 
 	temp = getCloneLoss()
 	if(temp)
-		if(temp < 30)
-			msg += "[t_He] [t_has] minor cellular damage.\n"
+		if(temp < 25)
+			msg += "[t_He] [t_is] slightly deformed.\n"
+		else if (temp < 50)
+			msg += "[t_He] [t_is] <b>moderately</b> deformed!\n"
 		else
-			msg += "<B>[t_He] [t_has] severe cellular damage.</B>\n"
+			msg += "<b>[t_He] [t_is] severely deformed!</b>\n"
 
 
 	if(fire_stacks > 0)

--- a/code/modules/mob/living/carbon/human/examine.dm
+++ b/code/modules/mob/living/carbon/human/examine.dm
@@ -208,7 +208,7 @@
 	if(temp)
 		if(temp < 25)
 			msg += "[t_He] [t_has] minor cellular damage.\n"
-		else if (temp < 50)
+		else if(temp < 50)
 			msg += "[t_He] [t_has] <b>moderate</b> cellular damage!\n"
 		else
 			msg += "<b>[t_He] [t_has] severe cellular damage!</b>\n"


### PR DESCRIPTION
Ok so the last one only worked on carbons who weren't humans, woops. See: https://github.com/tgstation/tgstation/pull/32707


🆑 Robustin
tweak: Damage examinations now include a "moderate" classification. Before minor was <30 and severe was anything 30 or above. Now minor is <25, moderate is 25 to <50, and severe is 50+.
/🆑