### PR TITLE
Fix misplaced corners in the Hotel brig

### DIFF
--- a/_maps/RandomRuins/SpaceRuins/spacehotel.dmm
+++ b/_maps/RandomRuins/SpaceRuins/spacehotel.dmm
@@ -3301,18 +3301,6 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plating,
 /area/ruin/space/has_grav/hotel)
-"iX" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/structure/cable{
-	icon_state = "2-8"
-	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	dir = 1
-	},
-/turf/open/floor/plating,
-/area/ruin/space/has_grav/hotel)
 "iY" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -3944,7 +3932,7 @@
 /area/ruin/space/has_grav/hotel/security)
 "kP" = (
 /obj/effect/turf_decal/stripes/corner{
-	dir = 2
+	dir = 1
 	},
 /turf/open/floor/plasteel/darkyellow,
 /area/ruin/space/has_grav/hotel/security)


### PR DESCRIPTION
:cl:
fix: Some misplaced decals in the Hotel brig have been corrected.
/:cl:

Looked like this, now fixed:
![image](https://user-images.githubusercontent.com/222630/33151740-38b78ba6-cf8e-11e7-9401-49083b9fdb09.png)
