### PR TITLE
Fixed mobs getting rotated by shuttles even if they are not moved

### DIFF
--- a/code/modules/shuttle/on_move.dm
+++ b/code/modules/shuttle/on_move.dm
@@ -272,6 +272,8 @@ All ShuttleMove procs go here
 	. = ..()
 
 /mob/afterShuttleMove(list/movement_force, shuttle_dir, shuttle_preferred_direction, move_dir, rotation)
+	if(!move_on_shuttle)
+		return
 	. = ..()
 	if(client && movement_force)
 		var/shake_force = max(movement_force["THROW"], movement_force["KNOCKDOWN"])


### PR DESCRIPTION
Fixes #32867 

If the navigation computer's camera eye was on the shuttle when it moved, afterShuttleMove would be called on it and cause it to rotate even though it was not actually moved by the shuttle. This would cause the navigation computer's graphic to get out of sync with the actual docking port's rotation, making lots of messy things happen.