### PR TITLE
removes the block chance from bloody bastard swords

### DIFF
--- a/code/game/gamemodes/cult/cult_items.dm
+++ b/code/game/gamemodes/cult/cult_items.dm
@@ -76,7 +76,6 @@
 	name = "bloody bastard sword"
 	desc = "An enormous sword used by Nar-Sien cultists to rapidly harvest the souls of non-believers."
 	w_class = WEIGHT_CLASS_HUGE
-	block_chance = 50
 	throwforce = 20
 	force = 35
 	armour_penetration = 45


### PR DESCRIPTION
They were meant to be a counter to hulks and they dont need an block chance when their litteraly spin 2 win technique reflects all gun shots

:cl: Improvedname
tweak: Bloody bastard sword no longer blocks shots
/:cl:

[why]: # (Please add a short description [two lines down] of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.) 
