### PR TITLE
Lowers rack layer to 2.8

### DIFF
--- a/code/game/objects/structures/tables_racks.dm
+++ b/code/game/objects/structures/tables_racks.dm
@@ -411,6 +411,7 @@
 	desc = "Different from the Middle Ages version."
 	icon = 'icons/obj/objects.dmi'
 	icon_state = "rack"
+	layer = TABLE_LAYER
 	density = TRUE
 	anchored = TRUE
 	pass_flags = LETPASSTHROW //You can throw objects over this, despite it's density.


### PR DESCRIPTION
This helps prevent cases where items are placed underneath racks (most noticeable in template spawned ships, at least that I've seen).

:cl: WJohnston
fix: Fixed a case where items would sometimes be placed underneath racks.
/:cl: