### PR TITLE
Cycle-link airlocks in the mining base

### DIFF
--- a/_maps/map_files/Mining/Lavaland.dmm
+++ b/_maps/map_files/Mining/Lavaland.dmm
@@ -196,6 +196,7 @@
 /area/mine/laborcamp)
 "aI" = (
 /obj/machinery/door/airlock{
+	cyclelinkeddir = 4;
 	name = "Labor Camp External Access"
 	},
 /turf/open/floor/plasteel,
@@ -286,6 +287,7 @@
 /area/lavaland/surface/outdoors/explored)
 "aY" = (
 /obj/machinery/door/airlock/glass_security{
+	cyclelinkeddir = 4;
 	name = "Labor Camp Shuttle Security Airlock";
 	req_access_txt = "2"
 	},
@@ -449,6 +451,7 @@
 /area/mine/eva)
 "bx" = (
 /obj/machinery/door/airlock/glass_security{
+	cyclelinkeddir = 4;
 	name = "Labor Camp Shuttle Prisoner Airlock";
 	req_access_txt = "0"
 	},
@@ -659,6 +662,7 @@
 /area/mine/eva)
 "bX" = (
 /obj/machinery/door/airlock/external{
+	cyclelinkeddir = 4;
 	glass = 1;
 	name = "Mining External Airlock";
 	opacity = 0;
@@ -744,6 +748,7 @@
 /area/mine/laborcamp)
 "cj" = (
 /obj/machinery/door/airlock/external{
+	cyclelinkeddir = 4;
 	glass = 1;
 	name = "Mining Shuttle Airlock";
 	opacity = 0;
@@ -3317,6 +3322,49 @@
 /obj/effect/mapping_helpers/planet_z,
 /turf/open/lava/smooth/lava_land_surface,
 /area/lavaland/surface/outdoors)
+"WA" = (
+/obj/machinery/door/airlock{
+	cyclelinkeddir = 8;
+	name = "Labor Camp External Access"
+	},
+/turf/open/floor/plasteel,
+/area/mine/laborcamp)
+"WB" = (
+/obj/machinery/door/airlock/glass_security{
+	cyclelinkeddir = 8;
+	name = "Labor Camp Shuttle Security Airlock";
+	req_access_txt = "2"
+	},
+/turf/open/floor/plasteel,
+/area/mine/laborcamp)
+"WC" = (
+/obj/machinery/door/airlock/glass_security{
+	cyclelinkeddir = 8;
+	name = "Labor Camp Shuttle Prisoner Airlock";
+	req_access_txt = "0"
+	},
+/turf/open/floor/plasteel,
+/area/mine/laborcamp)
+"WD" = (
+/obj/machinery/door/airlock/external{
+	cyclelinkeddir = 8;
+	glass = 1;
+	name = "Mining External Airlock";
+	opacity = 0;
+	req_access_txt = "54"
+	},
+/turf/open/floor/plasteel,
+/area/mine/eva)
+"WE" = (
+/obj/machinery/door/airlock/external{
+	cyclelinkeddir = 8;
+	glass = 1;
+	name = "Mining Shuttle Airlock";
+	opacity = 0;
+	req_access_txt = "0"
+	},
+/turf/open/floor/plasteel,
+/area/mine/production)
 
 (1,1,1) = {"
 aa
@@ -8415,11 +8463,11 @@ aH
 az
 aQ
 aq
-aY
+WB
 aq
 bi
 aq
-bx
+WC
 aq
 bZ
 bZ
@@ -11238,7 +11286,7 @@ an
 an
 aD
 aq
-aI
+WA
 aq
 aT
 aD
@@ -17930,7 +17978,7 @@ aj
 aj
 br
 br
-cj
+WE
 br
 br
 ab
@@ -21270,7 +21318,7 @@ aj
 ab
 bf
 bg
-bX
+WD
 bg
 bf
 ai


### PR DESCRIPTION
:cl:
fix: External airlocks of the mining base and gulag are now cycle-linked.
/:cl:

QoL change. Affects the EVA and shuttle airlocks of the gulag and the mining base, 5 pairs of doors in total.