### PR TITLE
[ready]Timer queuing tweaks: binary sorted inserts and rolling buckets.

### DIFF
--- a/code/__DEFINES/time.dm
+++ b/code/__DEFINES/time.dm
@@ -22,6 +22,6 @@ When using time2text(), please use "DDD" to find the weekday. Refrain from using
 
 #define TICKS *world.tick_lag
 
-#define DS2TICKS(DS) (DS/world.tick_lag)
+#define DS2TICKS(DS) ((DS)/world.tick_lag)
 
-#define TICKS2DS(T) (T TICKS)
+#define TICKS2DS(T) ((T) TICKS)

--- a/code/controllers/subsystem/timer.dm
+++ b/code/controllers/subsystem/timer.dm
@@ -30,9 +30,11 @@ SUBSYSTEM_DEF(timer)
 
 /datum/controller/subsystem/timer/PreInit()
 	bucket_list.len = BUCKET_LEN
+	head_offset = world.time
+	bucket_resolution = world.tick_lag
 
 /datum/controller/subsystem/timer/stat_entry(msg)
-	..("B:[bucket_count] P:[length(second_queue)] H:[length(hashes)] C:[length(clienttime_timers)]")
+	..("B:[bucket_count] P:[length(second_queue)] H:[length(hashes)] C:[length(clienttime_timers)] S:[length(timer_id_dict)]")
 
 /datum/controller/subsystem/timer/fire(resumed = FALSE)
 	var/lit = last_invoke_tick

--- a/code/controllers/subsystem/timer.dm
+++ b/code/controllers/subsystem/timer.dm
@@ -133,7 +133,6 @@ SUBSYSTEM_DEF(timer)
 		for (i in 1 to L)
 			timer = processing[i]
 			if (timer.timeToRun >= TIMER_MAX)
-				debug_admins("Ending timer minishift: i=[i], L = [L], timer.timeToRun = [timer.timeToRun], TIMER_MAX = [TIMER_MAX].")
 				break
 			bucket_count++
 			var/bucket_pos = max(1, BUCKET_POS(timer))


### PR DESCRIPTION
Client time timers now uses a binary search algorithm for its sorted inserts.

Processing now uses a binary sorted insert, rather then sorting it with sortTim during bucket_shifts.

Buckets now automatically wrap around rather then get regenerated every minute. (Rolling queue)

Fixed a bug where if the head of a bucket with 3 or more timers in it was deleted while the timer subsystem had paused mid way thru processing that bucket, when it resumed it would be stuck infinitely looping thru the remainder of that bucket.

fixes #29314
fixes #24475 
fixes #28626
fixes #25886
fixes #23818
fixes #32548

