### PR TITLE
Allows toolbelts to carry geiger counters

### DIFF
--- a/code/game/objects/items/storage/belt.dm
+++ b/code/game/objects/items/storage/belt.dm
@@ -37,6 +37,7 @@
 		/obj/item/stack/cable_coil,
 		/obj/item/device/t_scanner,
 		/obj/item/device/analyzer,
+		/obj/item/device/geiger_counter,
 		/obj/item/extinguisher/mini,
 		/obj/item/device/radio,
 		/obj/item/clothing/gloves


### PR DESCRIPTION
As engineering now mainly works with the most radioactive engine and its handy to store a item where you sont lose it constantly 

:cl: improvedname
tweak: toolbelts can now carry geiger counters
/:cl:

[why]: # (Please add a short description [two lines down] of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.)
