### PR TITLE
Science lathe prints everything again

### DIFF
--- a/code/modules/research/departmental_lathe.dm
+++ b/code/modules/research/departmental_lathe.dm
@@ -36,7 +36,7 @@
 	circuit = /obj/item/circuitboard/machine/protolathe/department/cargo
 
 /obj/machinery/rnd/protolathe/department/science
-	allowed_department_flags = DEPARTMENTAL_FLAG_ALL|DEPARTMENTAL_FLAG_SCIENCE
+	allowed_department_flags = DEPARTMENTAL_FLAG_ALL|DEPARTMENTAL_FLAG_SCIENCE |DEPARTMENTAL_FLAG_CARGO|DEPARTMENTAL_FLAG_SECURITY|DEPARTMENTAL_FLAG_MEDICAL|DEPARTMENTAL_FLAG_SERVICE
 	department_tag = "Science"
 	circuit = /obj/item/circuitboard/machine/protolathe/department/science
 


### PR DESCRIPTION
Techwebs are still messy and unbalanced with bad UI and no documentation and the ore distribution is a mess and we're in a weird awkward situation where every department is supposed to print their own stuff but only science picks which stuff and cargo never gives security minerals anyway

It's a one line change to let science build everything again while we clean up techwebs and once techwebs are nice and functional and people are used to them we can try the decentralization thing and maybe everyone will stop being so salty in the mean time