### PR TITLE
Removes admin_only from notify command

### DIFF
--- a/code/modules/admin/chat_commands.dm
+++ b/code/modules/admin/chat_commands.dm
@@ -73,7 +73,6 @@ GLOBAL_LIST(round_end_notifiees)
 /datum/server_tools_command/notify
 	name = "notify"
 	help_text = "Pings the invoker when the round ends"
-	admin_only = TRUE
 
 /datum/server_tools_command/notify/Run(sender, params)
 	if(!SSticker.IsRoundInProgress() && SSticker.HasRoundStarted())


### PR DESCRIPTION
The ping always goes to the admin channel anyway