### PR TITLE
Cleans up some free nearstation lag

### DIFF
--- a/_maps/RandomRuins/SpaceRuins/derelict2.dmm
+++ b/_maps/RandomRuins/SpaceRuins/derelict2.dmm
@@ -7,7 +7,7 @@
 	dir = 4
 	},
 /turf/open/space,
-/area/space/nearstation)
+/area/space)
 "c" = (
 /obj/machinery/door/airlock/external,
 /turf/open/floor/plating,
@@ -17,7 +17,7 @@
 	dir = 8
 	},
 /turf/open/space,
-/area/space/nearstation)
+/area/space)
 "e" = (
 /obj/structure/window/reinforced{
 	dir = 4
@@ -52,7 +52,7 @@
 "k" = (
 /obj/structure/window/reinforced,
 /turf/open/space,
-/area/space/nearstation)
+/area/space)
 "l" = (
 /obj/structure/window/reinforced,
 /obj/structure/window/reinforced{
@@ -92,7 +92,7 @@
 	dir = 1
 	},
 /turf/open/space,
-/area/space/nearstation)
+/area/space)
 "q" = (
 /obj/machinery/light/small{
 	dir = 8

--- a/_maps/RandomRuins/SpaceRuins/vaporwave.dmm
+++ b/_maps/RandomRuins/SpaceRuins/vaporwave.dmm
@@ -5,7 +5,7 @@
 "b" = (
 /obj/structure/lattice,
 /turf/open/space,
-/area/space/nearstation)
+/area/space)
 "c" = (
 /obj/structure/lattice,
 /turf/open/floor/plating/asteroid/airless,

--- a/_maps/RandomZLevels/Academy.dmm
+++ b/_maps/RandomZLevels/Academy.dmm
@@ -10,7 +10,7 @@
 	faction = list("wizard")
 	},
 /turf/open/space,
-/area/space/nearstation)
+/area/space)
 "ad" = (
 /obj/structure/filingcabinet/filingcabinet,
 /turf/open/floor/carpet,
@@ -231,7 +231,7 @@
 "aP" = (
 /obj/structure/lattice,
 /turf/open/space,
-/area/space/nearstation)
+/area/space)
 "aQ" = (
 /obj/machinery/door/airlock/gold{
 	locked = 1
@@ -1240,7 +1240,7 @@
 "eu" = (
 /obj/singularity/academy,
 /turf/open/space,
-/area/space/nearstation)
+/area/space)
 "ev" = (
 /obj/structure/window/reinforced{
 	dir = 8
@@ -2988,7 +2988,7 @@
 	icon_state = "medium"
 	},
 /turf/open/space,
-/area/space/nearstation)
+/area/space)
 "jC" = (
 /obj/machinery/igniter,
 /turf/open/floor/plating,

--- a/_maps/RandomZLevels/centcomAway.dmm
+++ b/_maps/RandomZLevels/centcomAway.dmm
@@ -335,7 +335,7 @@
 "bk" = (
 /obj/structure/lattice,
 /turf/open/space,
-/area/space/nearstation)
+/area/space)
 "bl" = (
 /obj/machinery/door/poddoor{
 	id = "XCCHangar1";
@@ -3132,19 +3132,19 @@
 	dir = 1
 	},
 /turf/open/space,
-/area/space/nearstation)
+/area/space)
 "kU" = (
 /obj/structure/shuttle/engine/propulsion{
 	dir = 1
 	},
 /turf/open/space,
-/area/space/nearstation)
+/area/space)
 "kV" = (
 /obj/structure/shuttle/engine/propulsion/left{
 	dir = 1
 	},
 /turf/open/space,
-/area/space/nearstation)
+/area/space)
 "kW" = (
 /obj/structure/table,
 /obj/item/device/paicard,

--- a/_maps/RandomZLevels/challenge.dmm
+++ b/_maps/RandomZLevels/challenge.dmm
@@ -718,7 +718,7 @@
 	dir = 4
 	},
 /turf/open/space,
-/area/space/nearstation)
+/area/space)
 "cn" = (
 /turf/open/floor/circuit,
 /area/awaymission/challenge/end)
@@ -732,7 +732,7 @@
 	dir = 8
 	},
 /turf/open/space,
-/area/space/nearstation)
+/area/space)
 "cq" = (
 /obj/structure/table/wood,
 /obj/item/melee/chainofcommand,
@@ -787,14 +787,14 @@
 	dir = 4
 	},
 /turf/open/space,
-/area/space/nearstation)
+/area/space)
 "cz" = (
 /obj/structure/window/reinforced,
 /obj/structure/window/reinforced{
 	dir = 8
 	},
 /turf/open/space,
-/area/space/nearstation)
+/area/space)
 "cA" = (
 /obj/structure/sign/securearea,
 /turf/closed/indestructible{
@@ -840,7 +840,7 @@
 	dir = 1
 	},
 /turf/open/space,
-/area/space/nearstation)
+/area/space)
 "cI" = (
 /obj/structure/window/reinforced{
 	dir = 1
@@ -849,7 +849,7 @@
 	dir = 4
 	},
 /turf/open/space,
-/area/space/nearstation)
+/area/space)
 "cJ" = (
 /obj/structure/window/reinforced{
 	dir = 8
@@ -858,7 +858,7 @@
 	dir = 1
 	},
 /turf/open/space,
-/area/space/nearstation)
+/area/space)
 "cK" = (
 /obj/structure/window/reinforced{
 	dir = 4
@@ -867,7 +867,7 @@
 	dir = 1
 	},
 /turf/open/space,
-/area/space/nearstation)
+/area/space)
 "cL" = (
 /obj/structure/window/reinforced{
 	dir = 1
@@ -876,7 +876,7 @@
 	dir = 8
 	},
 /turf/open/space,
-/area/space/nearstation)
+/area/space)
 "cM" = (
 /obj/effect/spawner/structure/window/hollow/reinforced/directional{
 	dir = 9
@@ -998,7 +998,7 @@
 	},
 /obj/structure/window/reinforced,
 /turf/open/space,
-/area/space/nearstation)
+/area/space)
 "de" = (
 /obj/effect/spawner/structure/window/hollow/reinforced/end,
 /turf/open/floor/plating,
@@ -1040,7 +1040,7 @@
 	},
 /obj/structure/window/reinforced,
 /turf/open/space,
-/area/space/nearstation)
+/area/space)
 "dk" = (
 /obj/machinery/door/airlock/centcom{
 	name = "Gateway Access";

--- a/_maps/RandomZLevels/spacebattle.dmm
+++ b/_maps/RandomZLevels/spacebattle.dmm
@@ -2448,11 +2448,11 @@
 "ix" = (
 /obj/structure/lattice,
 /turf/open/space,
-/area/space/nearstation)
+/area/space)
 "iy" = (
 /obj/effect/mob_spawn/human/syndicatesoldier,
 /turf/open/space,
-/area/space/nearstation)
+/area/space)
 "iz" = (
 /turf/closed/wall/mineral/plastitanium,
 /area/space/nearstation)
@@ -2545,7 +2545,7 @@
 "iS" = (
 /obj/structure/shuttle/engine/propulsion,
 /turf/open/space,
-/area/space/nearstation)
+/area/space)
 "iT" = (
 /obj/machinery/door/airlock/external,
 /turf/open/floor/mineral/plastitanium,
@@ -3044,11 +3044,11 @@
 "kE" = (
 /obj/item/shard,
 /turf/open/space,
-/area/space/nearstation)
+/area/space)
 "kF" = (
 /obj/item/stack/rods,
 /turf/open/space,
-/area/space/nearstation)
+/area/space)
 "kG" = (
 /obj/item/ammo_casing/c10mm,
 /obj/item/ammo_casing/c10mm,
@@ -3067,17 +3067,17 @@
 "kI" = (
 /obj/item/stack/sheet/metal,
 /turf/open/space,
-/area/space/nearstation)
+/area/space)
 "kJ" = (
 /obj/item/shard,
 /obj/structure/lattice,
 /turf/open/space,
-/area/space/nearstation)
+/area/space)
 "kK" = (
 /obj/structure/lattice,
 /obj/item/stack/rods,
 /turf/open/space,
-/area/space/nearstation)
+/area/space)
 "kL" = (
 /obj/structure/closet/crate,
 /obj/item/stock_parts/cell/high,

--- a/_maps/RandomZLevels/undergroundoutpost45.dmm
+++ b/_maps/RandomZLevels/undergroundoutpost45.dmm
@@ -13138,7 +13138,7 @@
 "zi" = (
 /obj/effect/mapping_helpers/planet_z,
 /turf/open/space,
-/area/space/nearstation)
+/area/space)
 
 (1,1,1) = {"
 aa

--- a/_maps/RandomZLevels/wildwest.dmm
+++ b/_maps/RandomZLevels/wildwest.dmm
@@ -306,7 +306,7 @@
 "br" = (
 /obj/structure/lattice,
 /turf/open/space,
-/area/space/nearstation)
+/area/space)
 "bs" = (
 /obj/effect/mine/sound/bwoink,
 /obj/item/ammo_box/c10mm,
@@ -325,14 +325,14 @@
 	icon_state = "fwindow"
 	},
 /turf/open/space,
-/area/space/nearstation)
+/area/space)
 "bw" = (
 /obj/structure/lattice,
 /obj/structure/window/reinforced{
 	icon_state = "fwindow"
 	},
 /turf/open/space,
-/area/space/nearstation)
+/area/space)
 "bx" = (
 /obj/structure/closet/secure_closet/freezer/fridge,
 /turf/open/floor/plasteel/cafeteria{
@@ -434,7 +434,7 @@
 	dir = 4
 	},
 /turf/open/space,
-/area/space/nearstation)
+/area/space)
 "bP" = (
 /turf/closed/wall/mineral/sandstone,
 /area/awaymission/wildwest/gov)
@@ -489,7 +489,7 @@
 	dir = 8
 	},
 /turf/open/space,
-/area/space/nearstation)
+/area/space)
 "bU" = (
 /obj/structure/chair/wood/normal{
 	dir = 4
@@ -512,7 +512,7 @@
 	dir = 4
 	},
 /turf/open/space,
-/area/space/nearstation)
+/area/space)
 "bX" = (
 /obj/structure/window/reinforced{
 	icon_state = "fwindow";
@@ -669,12 +669,12 @@
 	dir = 8
 	},
 /turf/open/space,
-/area/space/nearstation)
+/area/space)
 "cu" = (
 /obj/structure/lattice,
 /obj/structure/lattice,
 /turf/open/space,
-/area/space/nearstation)
+/area/space)
 "cv" = (
 /obj/effect/decal/cleanable/blood/splatter,
 /turf/open/floor/carpet,
@@ -958,7 +958,7 @@
 	dir = 4
 	},
 /turf/open/space,
-/area/space/nearstation)
+/area/space)
 "dp" = (
 /obj/structure/bed,
 /obj/item/bedsheet/brown,
@@ -1215,7 +1215,7 @@
 	dir = 1
 	},
 /turf/open/space,
-/area/space/nearstation)
+/area/space)
 "ee" = (
 /obj/structure/lattice,
 /obj/structure/window/reinforced{
@@ -1223,7 +1223,7 @@
 	dir = 1
 	},
 /turf/open/space,
-/area/space/nearstation)
+/area/space)
 "ef" = (
 /obj/structure/window/reinforced{
 	icon_state = "fwindow";
@@ -1233,7 +1233,7 @@
 	dir = 4
 	},
 /turf/open/space,
-/area/space/nearstation)
+/area/space)
 "eg" = (
 /obj/structure/window/reinforced{
 	icon_state = "fwindow";
@@ -1261,7 +1261,7 @@
 	dir = 8
 	},
 /turf/open/space,
-/area/space/nearstation)
+/area/space)
 "ej" = (
 /obj/effect/decal/cleanable/blood,
 /turf/open/floor/plating/ironsand{
@@ -1681,7 +1681,7 @@
 	icon_state = "fwindow"
 	},
 /turf/open/space,
-/area/space/nearstation)
+/area/space)
 "fz" = (
 /obj/structure/window/reinforced{
 	icon_state = "fwindow";
@@ -1691,7 +1691,7 @@
 	icon_state = "fwindow"
 	},
 /turf/open/space,
-/area/space/nearstation)
+/area/space)
 "fA" = (
 /obj/structure/window/reinforced{
 	icon_state = "fwindow";
@@ -1796,7 +1796,7 @@
 	},
 /obj/structure/lattice,
 /turf/open/space,
-/area/space/nearstation)
+/area/space)
 "fO" = (
 /mob/living/simple_animal/hostile/syndicate,
 /turf/open/floor/plasteel,

--- a/_maps/map_files/BoxStation/BoxStation.dmm
+++ b/_maps/map_files/BoxStation/BoxStation.dmm
@@ -14,7 +14,7 @@
 	width = 18
 	},
 /turf/open/space,
-/area/space/nearstation)
+/area/space)
 "aae" = (
 /obj/effect/landmark/carpspawn,
 /turf/open/space,
@@ -22,17 +22,17 @@
 "aaf" = (
 /obj/structure/lattice,
 /turf/open/space,
-/area/space/nearstation)
+/area/space)
 "aag" = (
 /obj/structure/lattice/catwalk,
 /turf/open/space,
-/area/space/nearstation)
+/area/space)
 "aah" = (
 /obj/structure/sign/securearea{
 	pixel_y = -32
 	},
 /turf/open/space,
-/area/space/nearstation)
+/area/space)
 "aai" = (
 /turf/closed/wall/r_wall,
 /area/security/prison)
@@ -257,17 +257,17 @@
 	pixel_y = -32
 	},
 /turf/open/space,
-/area/space/nearstation)
+/area/space)
 "aaS" = (
 /obj/structure/grille,
 /obj/structure/lattice,
 /turf/open/space,
-/area/space/nearstation)
+/area/space)
 "aaT" = (
 /obj/structure/lattice,
 /obj/structure/grille,
 /turf/open/space,
-/area/space/nearstation)
+/area/space)
 "aaU" = (
 /obj/machinery/computer/arcade,
 /turf/open/floor/plasteel/floorgrime,
@@ -305,7 +305,7 @@
 /obj/structure/lattice,
 /obj/structure/grille/broken,
 /turf/open/space,
-/area/space/nearstation)
+/area/space)
 "abb" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 6
@@ -722,7 +722,7 @@
 "abY" = (
 /obj/structure/grille,
 /turf/open/space,
-/area/space/nearstation)
+/area/space)
 "abZ" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -894,7 +894,7 @@
 	},
 /obj/structure/lattice/catwalk,
 /turf/open/space,
-/area/space/nearstation)
+/area/space)
 "acx" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -906,7 +906,7 @@
 /obj/structure/lattice,
 /obj/item/stack/cable_coil/random,
 /turf/open/space,
-/area/space/nearstation)
+/area/space)
 "acz" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on,
 /obj/effect/turf_decal/stripes/line{
@@ -1414,7 +1414,7 @@
 	pixel_x = 32
 	},
 /turf/open/space,
-/area/space/nearstation)
+/area/space)
 "adC" = (
 /obj/structure/table,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -3857,7 +3857,7 @@
 "aiS" = (
 /obj/item/stack/rods,
 /turf/open/space,
-/area/space/nearstation)
+/area/space)
 "aiT" = (
 /turf/closed/wall,
 /area/security/processing)
@@ -6705,7 +6705,7 @@
 "apQ" = (
 /obj/structure/lattice,
 /turf/open/space,
-/area/space/nearstation)
+/area/space)
 "apR" = (
 /obj/item/paper/fluff/jobs/security/beepsky_mom,
 /turf/open/floor/plating,
@@ -7014,7 +7014,7 @@
 	name = "lavaland"
 	},
 /turf/open/space,
-/area/space/nearstation)
+/area/space)
 "aqH" = (
 /turf/closed/wall/mineral/titanium,
 /area/shuttle/pod_2)
@@ -8150,7 +8150,7 @@
 /obj/effect/landmark/carpspawn,
 /obj/structure/lattice,
 /turf/open/space,
-/area/space/nearstation)
+/area/space)
 "atS" = (
 /turf/closed/wall,
 /area/space/nearstation)
@@ -8955,7 +8955,7 @@
 	width = 18
 	},
 /turf/open/space,
-/area/space/nearstation)
+/area/space)
 "avU" = (
 /obj/item/paper/crumpled,
 /turf/open/floor/plasteel/airless{
@@ -10471,12 +10471,12 @@
 /obj/structure/lattice,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/space,
-/area/space/nearstation)
+/area/space)
 "azI" = (
 /obj/structure/lattice,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/space,
-/area/space/nearstation)
+/area/space)
 "azJ" = (
 /obj/machinery/gateway{
 	dir = 9
@@ -12811,7 +12811,7 @@
 	dir = 4
 	},
 /turf/open/space,
-/area/space/nearstation)
+/area/space)
 "aFr" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -13536,7 +13536,7 @@
 	dir = 4
 	},
 /turf/open/space,
-/area/space/nearstation)
+/area/space)
 "aGY" = (
 /obj/machinery/airalarm{
 	pixel_y = 25
@@ -21787,7 +21787,7 @@
 "bcU" = (
 /obj/item/stack/tile/plasteel,
 /turf/open/space,
-/area/space/nearstation)
+/area/space)
 "bcV" = (
 /obj/machinery/airalarm{
 	dir = 8;
@@ -32888,7 +32888,7 @@
 	pixel_y = 32
 	},
 /turf/open/space,
-/area/space/nearstation)
+/area/space)
 "bDj" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
@@ -37192,7 +37192,7 @@
 /obj/structure/lattice,
 /obj/structure/closet,
 /turf/open/space,
-/area/space/nearstation)
+/area/space)
 "bNc" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/closed/wall/r_wall,
@@ -39148,7 +39148,7 @@
 	dir = 4
 	},
 /turf/open/space,
-/area/space/nearstation)
+/area/space)
 "bRL" = (
 /obj/machinery/atmospherics/components/unary/outlet_injector/on{
 	dir = 8;
@@ -40287,7 +40287,7 @@
 	dir = 10
 	},
 /turf/open/space,
-/area/space/nearstation)
+/area/space)
 "bUs" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -40724,18 +40724,18 @@
 /obj/structure/lattice,
 /obj/machinery/atmospherics/pipe/simple/yellow/visible,
 /turf/open/space,
-/area/space/nearstation)
+/area/space)
 "bVv" = (
 /obj/structure/lattice,
 /obj/machinery/atmospherics/pipe/simple/green/visible{
 	dir = 4
 	},
 /turf/open/space,
-/area/space/nearstation)
+/area/space)
 "bVw" = (
 /obj/structure/lattice/catwalk,
 /turf/open/space,
-/area/space/nearstation)
+/area/space)
 "bVx" = (
 /obj/machinery/atmospherics/components/unary/outlet_injector/on{
 	dir = 2
@@ -42843,7 +42843,7 @@
 	dir = 5
 	},
 /turf/open/space,
-/area/space/nearstation)
+/area/space)
 "caK" = (
 /obj/structure/rack,
 /obj/effect/spawner/lootdrop/maintenance,
@@ -45988,7 +45988,7 @@
 	dir = 6
 	},
 /turf/open/space,
-/area/space/nearstation)
+/area/space)
 "ciD" = (
 /obj/machinery/atmospherics/components/unary/portables_connector/visible{
 	name = "output gas connector port"
@@ -48296,7 +48296,7 @@
 	name = "lavaland"
 	},
 /turf/open/space,
-/area/space/nearstation)
+/area/space)
 "cpg" = (
 /obj/item/grenade/barrier{
 	pixel_x = 4
@@ -48314,7 +48314,7 @@
 /obj/structure/lattice,
 /obj/machinery/atmospherics/pipe/simple/green/visible,
 /turf/open/space,
-/area/space/nearstation)
+/area/space)
 "cpi" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -48554,7 +48554,7 @@
 /obj/structure/lattice,
 /obj/machinery/atmospherics/pipe/simple/cyan/visible,
 /turf/open/space,
-/area/space/nearstation)
+/area/space)
 "cpQ" = (
 /obj/structure/lattice,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible,
@@ -49246,7 +49246,7 @@
 	dir = 4
 	},
 /turf/open/space,
-/area/space/nearstation)
+/area/space)
 "crI" = (
 /obj/machinery/meter,
 /obj/machinery/atmospherics/pipe/simple/general/visible{
@@ -49260,7 +49260,7 @@
 	dir = 4
 	},
 /turf/open/space,
-/area/space/nearstation)
+/area/space)
 "crK" = (
 /obj/machinery/atmospherics/pipe/heat_exchanging/junction{
 	dir = 8
@@ -49308,14 +49308,14 @@
 	dir = 4
 	},
 /turf/open/space,
-/area/space/nearstation)
+/area/space)
 "crU" = (
 /obj/structure/lattice/catwalk,
 /obj/machinery/atmospherics/pipe/heat_exchanging/simple{
 	dir = 10
 	},
 /turf/open/space,
-/area/space/nearstation)
+/area/space)
 "crV" = (
 /obj/machinery/atmospherics/pipe/manifold/general/visible{
 	dir = 8
@@ -49350,7 +49350,7 @@
 	},
 /obj/structure/lattice,
 /turf/open/space,
-/area/space/nearstation)
+/area/space)
 "csa" = (
 /obj/effect/spawner/structure/window/plasma/reinforced,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -49362,7 +49362,7 @@
 	dir = 9
 	},
 /turf/open/space,
-/area/space/nearstation)
+/area/space)
 "csc" = (
 /obj/structure/lattice,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible,
@@ -49391,7 +49391,7 @@
 	dir = 1
 	},
 /turf/open/space,
-/area/space/nearstation)
+/area/space)
 "csj" = (
 /obj/machinery/atmospherics/pipe/heat_exchanging/junction{
 	dir = 8
@@ -49408,7 +49408,7 @@
 	dir = 4
 	},
 /turf/open/space,
-/area/space/nearstation)
+/area/space)
 "csm" = (
 /obj/machinery/atmospherics/components/unary/outlet_injector/on{
 	dir = 1
@@ -49418,12 +49418,12 @@
 "csn" = (
 /obj/structure/transit_tube/horizontal,
 /turf/open/space,
-/area/space/nearstation)
+/area/space)
 "cso" = (
 /obj/structure/lattice,
 /obj/structure/transit_tube/crossing/horizontal,
 /turf/open/space,
-/area/space/nearstation)
+/area/space)
 "csq" = (
 /obj/machinery/computer/security/telescreen{
 	desc = "Used for watching the turbine vent.";
@@ -49462,7 +49462,7 @@
 /obj/structure/lattice/catwalk,
 /obj/machinery/atmospherics/pipe/heat_exchanging/simple,
 /turf/open/space,
-/area/space/nearstation)
+/area/space)
 "csu" = (
 /obj/structure/closet/firecloset,
 /turf/open/floor/plasteel/dark,
@@ -49473,17 +49473,17 @@
 	},
 /obj/structure/lattice,
 /turf/open/space,
-/area/space/nearstation)
+/area/space)
 "csw" = (
 /obj/structure/lattice,
 /obj/machinery/atmospherics/pipe/simple/yellow/visible,
 /turf/open/space,
-/area/space/nearstation)
+/area/space)
 "csx" = (
 /obj/structure/lattice,
 /obj/machinery/atmospherics/pipe/heat_exchanging/simple,
 /turf/open/space,
-/area/space/nearstation)
+/area/space)
 "csy" = (
 /obj/structure/table,
 /obj/item/weldingtool,
@@ -49547,7 +49547,7 @@
 /obj/machinery/atmospherics/pipe/simple/yellow/visible,
 /obj/structure/transit_tube/crossing/horizontal,
 /turf/open/space,
-/area/space/nearstation)
+/area/space)
 "csN" = (
 /obj/structure/transit_tube/horizontal,
 /turf/open/floor/plating,
@@ -49654,7 +49654,7 @@
 /obj/structure/lattice/catwalk,
 /obj/machinery/atmospherics/pipe/simple/yellow/visible,
 /turf/open/space,
-/area/space/nearstation)
+/area/space)
 "ctg" = (
 /obj/structure/closet/emcloset,
 /turf/open/floor/plating,
@@ -49886,14 +49886,14 @@
 	},
 /obj/structure/lattice,
 /turf/open/space,
-/area/space/nearstation)
+/area/space)
 "ctO" = (
 /obj/structure/lattice,
 /obj/machinery/atmospherics/pipe/simple/yellow/visible{
 	dir = 5
 	},
 /turf/open/space,
-/area/space/nearstation)
+/area/space)
 "ctP" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 4
@@ -50765,7 +50765,7 @@
 	start_active = 1
 	},
 /turf/open/space,
-/area/space/nearstation)
+/area/space)
 "cvG" = (
 /obj/machinery/porta_turret/ai{
 	dir = 4;
@@ -50812,7 +50812,7 @@
 	start_active = 1
 	},
 /turf/open/space,
-/area/space/nearstation)
+/area/space)
 "cvL" = (
 /obj/structure/sign/securearea{
 	pixel_x = 32
@@ -51328,7 +51328,7 @@
 	name = "lavaland"
 	},
 /turf/open/space,
-/area/space/nearstation)
+/area/space)
 "cwW" = (
 /obj/machinery/status_display,
 /turf/closed/wall/mineral/titanium,
@@ -51451,7 +51451,7 @@
 /obj/structure/lattice,
 /obj/effect/landmark/carpspawn,
 /turf/open/space,
-/area/space/nearstation)
+/area/space)
 "cxo" = (
 /obj/structure/extinguisher_cabinet{
 	pixel_x = -5;
@@ -52356,7 +52356,7 @@
 /obj/item/wrench,
 /obj/structure/lattice/catwalk,
 /turf/open/space,
-/area/space/nearstation)
+/area/space)
 "czJ" = (
 /obj/machinery/atmospherics/components/unary/outlet_injector/on{
 	dir = 1
@@ -52401,7 +52401,7 @@
 	name = "lavaland"
 	},
 /turf/open/space,
-/area/space/nearstation)
+/area/space)
 "czO" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
@@ -52854,7 +52854,7 @@
 	start_active = 1
 	},
 /turf/open/space,
-/area/space/nearstation)
+/area/space)
 "cAV" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -52889,7 +52889,7 @@
 	start_active = 1
 	},
 /turf/open/space,
-/area/space/nearstation)
+/area/space)
 "cAY" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -52951,7 +52951,7 @@
 	start_active = 1
 	},
 /turf/open/space,
-/area/space/nearstation)
+/area/space)
 "cBg" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/effect/landmark/event_spawn,
@@ -53249,7 +53249,7 @@
 	width = 18
 	},
 /turf/open/space,
-/area/space/nearstation)
+/area/space)
 "cBX" = (
 /obj/docking_port/stationary{
 	dheight = 9;
@@ -53262,7 +53262,7 @@
 	width = 18
 	},
 /turf/open/space,
-/area/space/nearstation)
+/area/space)
 "cBY" = (
 /obj/docking_port/stationary{
 	dheight = 9;
@@ -53275,7 +53275,7 @@
 	width = 18
 	},
 /turf/open/space,
-/area/space/nearstation)
+/area/space)
 "cBZ" = (
 /obj/structure/table/wood,
 /obj/item/clothing/under/burial,
@@ -53492,7 +53492,7 @@
 	dir = 10
 	},
 /turf/open/space,
-/area/space/nearstation)
+/area/space)
 "cCH" = (
 /obj/structure/lattice,
 /obj/machinery/atmospherics/pipe/simple/yellow/visible{
@@ -53500,12 +53500,12 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/orange/visible,
 /turf/open/space,
-/area/space/nearstation)
+/area/space)
 "cCI" = (
 /obj/structure/lattice,
 /obj/machinery/atmospherics/pipe/simple/orange/visible,
 /turf/open/space,
-/area/space/nearstation)
+/area/space)
 "cCJ" = (
 /obj/structure/lattice,
 /obj/machinery/atmospherics/pipe/simple/green/visible{
@@ -53513,26 +53513,26 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/orange/visible,
 /turf/open/space,
-/area/space/nearstation)
+/area/space)
 "cCP" = (
 /obj/structure/lattice,
 /obj/machinery/atmospherics/pipe/simple/orange/visible{
 	dir = 5
 	},
 /turf/open/space,
-/area/space/nearstation)
+/area/space)
 "cCQ" = (
 /obj/structure/lattice,
 /obj/machinery/atmospherics/pipe/simple/orange/visible{
 	dir = 4
 	},
 /turf/open/space,
-/area/space/nearstation)
+/area/space)
 "cCS" = (
 /obj/machinery/atmospherics/pipe/simple/orange/visible,
 /obj/structure/lattice,
 /turf/open/space,
-/area/space/nearstation)
+/area/space)
 "cCT" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 4
@@ -53833,14 +53833,14 @@
 	dir = 4
 	},
 /turf/open/space,
-/area/space/nearstation)
+/area/space)
 "cDY" = (
 /obj/structure/lattice,
 /obj/machinery/atmospherics/pipe/simple/orange/visible{
 	dir = 9
 	},
 /turf/open/space,
-/area/space/nearstation)
+/area/space)
 "cDZ" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -53927,7 +53927,7 @@
 	},
 /obj/structure/lattice,
 /turf/open/space,
-/area/space/nearstation)
+/area/space)
 "cEr" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/effect/turf_decal/stripes/line{
@@ -54076,7 +54076,7 @@
 	dir = 5
 	},
 /turf/open/space,
-/area/space/nearstation)
+/area/space)
 "cEK" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 6
@@ -54224,21 +54224,21 @@
 /obj/machinery/atmospherics/pipe/heat_exchanging/simple,
 /obj/structure/lattice,
 /turf/open/space,
-/area/space/nearstation)
+/area/space)
 "cFn" = (
 /obj/structure/lattice,
 /obj/machinery/atmospherics/pipe/heat_exchanging/simple{
 	dir = 6
 	},
 /turf/open/space,
-/area/space/nearstation)
+/area/space)
 "cFo" = (
 /obj/machinery/atmospherics/pipe/heat_exchanging/simple{
 	dir = 10
 	},
 /obj/structure/lattice,
 /turf/open/space,
-/area/space/nearstation)
+/area/space)
 "cFu" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -55814,7 +55814,7 @@
 	turf_type = /turf/open/space
 	},
 /turf/open/space/basic,
-/area/space/nearstation)
+/area/space)
 "Qlk" = (
 /obj/docking_port/stationary{
 	dheight = 9;
@@ -55827,7 +55827,7 @@
 	width = 18
 	},
 /turf/open/space/basic,
-/area/space/nearstation)
+/area/space)
 "Qll" = (
 /obj/machinery/door/airlock/titanium{
 	name = "recovery shuttle external airlock"
@@ -57465,41 +57465,41 @@
 /obj/structure/lattice,
 /obj/structure/grille,
 /turf/open/space/basic,
-/area/space/nearstation)
+/area/space)
 "Qoe" = (
 /obj/structure/lattice,
 /obj/structure/grille,
 /turf/open/space/basic,
-/area/space/nearstation)
+/area/space)
 "Qof" = (
 /obj/structure/lattice,
 /obj/structure/grille/broken,
 /turf/open/space/basic,
-/area/space/nearstation)
+/area/space)
 "Qog" = (
 /obj/structure/lattice,
 /obj/structure/grille,
 /turf/open/space/basic,
-/area/space/nearstation)
+/area/space)
 "Qoh" = (
 /obj/structure/lattice,
 /obj/structure/grille/broken,
 /turf/open/space/basic,
-/area/space/nearstation)
+/area/space)
 "Qoi" = (
 /obj/structure/lattice,
 /turf/open/space/basic,
-/area/space/nearstation)
+/area/space)
 "Qoj" = (
 /obj/structure/lattice,
 /obj/structure/grille/broken,
 /turf/open/space/basic,
-/area/space/nearstation)
+/area/space)
 "Qok" = (
 /obj/structure/lattice,
 /obj/structure/grille,
 /turf/open/space/basic,
-/area/space/nearstation)
+/area/space)
 "Qol" = (
 /obj/structure/grille,
 /turf/open/floor/plating/airless,
@@ -57508,32 +57508,32 @@
 /obj/structure/lattice,
 /obj/structure/grille,
 /turf/open/space/basic,
-/area/space/nearstation)
+/area/space)
 "Qon" = (
 /obj/structure/lattice,
 /obj/structure/grille,
 /turf/open/space/basic,
-/area/space/nearstation)
+/area/space)
 "Qoo" = (
 /obj/structure/lattice,
 /obj/structure/grille/broken,
 /turf/open/space/basic,
-/area/space/nearstation)
+/area/space)
 "Qop" = (
 /obj/structure/lattice,
 /obj/structure/grille,
 /turf/open/space/basic,
-/area/space/nearstation)
+/area/space)
 "Qoq" = (
 /obj/structure/lattice,
 /obj/structure/grille/broken,
 /turf/open/space/basic,
-/area/space/nearstation)
+/area/space)
 "Qor" = (
 /obj/structure/lattice,
 /obj/structure/grille/broken,
 /turf/open/space/basic,
-/area/space/nearstation)
+/area/space)
 "Qos" = (
 /obj/structure/grille,
 /turf/open/floor/plating/airless,
@@ -57542,12 +57542,12 @@
 /obj/structure/lattice,
 /obj/structure/grille,
 /turf/open/space/basic,
-/area/space/nearstation)
+/area/space)
 "Qou" = (
 /obj/structure/lattice,
 /obj/structure/grille,
 /turf/open/space/basic,
-/area/space/nearstation)
+/area/space)
 "Qov" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible{

--- a/_maps/map_files/Deltastation/DeltaStation2.dmm
+++ b/_maps/map_files/Deltastation/DeltaStation2.dmm
@@ -10,11 +10,11 @@
 /obj/structure/lattice,
 /obj/structure/grille,
 /turf/open/space,
-/area/space/nearstation)
+/area/space)
 "aad" = (
 /obj/structure/lattice,
 /turf/open/space,
-/area/space/nearstation)
+/area/space)
 "aae" = (
 /obj/machinery/power/tracker,
 /obj/structure/cable{
@@ -139,14 +139,14 @@
 	name = "lavaland"
 	},
 /turf/open/space,
-/area/space/nearstation)
+/area/space)
 "aat" = (
 /obj/docking_port/stationary/random{
 	id = "pod_lavaland2";
 	name = "lavaland"
 	},
 /turf/open/space,
-/area/space/nearstation)
+/area/space)
 "aau" = (
 /obj/structure/lattice/catwalk,
 /obj/effect/landmark/xeno_spawn,
@@ -538,7 +538,7 @@
 "abj" = (
 /obj/structure/lattice/catwalk,
 /turf/open/space,
-/area/space/nearstation)
+/area/space)
 "abk" = (
 /obj/machinery/vending/hydroseeds,
 /obj/effect/decal/cleanable/dirt{
@@ -3336,7 +3336,7 @@
 	width = 18
 	},
 /turf/open/space,
-/area/space/nearstation)
+/area/space)
 "agP" = (
 /obj/effect/decal/cleanable/dirt{
 	desc = "A thin layer of dust coating the floor.";
@@ -9138,14 +9138,14 @@
 	dir = 6
 	},
 /turf/open/space,
-/area/space/nearstation)
+/area/space)
 "atJ" = (
 /obj/machinery/atmospherics/pipe/heat_exchanging/simple{
 	dir = 10
 	},
 /obj/structure/lattice,
 /turf/open/space,
-/area/space/nearstation)
+/area/space)
 "atK" = (
 /obj/structure/table/reinforced,
 /obj/item/device/analyzer{
@@ -9794,7 +9794,7 @@
 	},
 /obj/structure/lattice/catwalk,
 /turf/open/space,
-/area/space/nearstation)
+/area/space)
 "auQ" = (
 /obj/machinery/atmospherics/pipe/heat_exchanging/simple{
 	dir = 4
@@ -9802,14 +9802,14 @@
 /obj/machinery/atmospherics/pipe/heat_exchanging/simple,
 /obj/structure/lattice/catwalk,
 /turf/open/space,
-/area/space/nearstation)
+/area/space)
 "auR" = (
 /obj/machinery/atmospherics/pipe/heat_exchanging/simple{
 	dir = 4
 	},
 /obj/structure/lattice/catwalk,
 /turf/open/space,
-/area/space/nearstation)
+/area/space)
 "auS" = (
 /obj/machinery/atmospherics/pipe/heat_exchanging/junction{
 	dir = 8
@@ -10370,7 +10370,7 @@
 	},
 /obj/structure/lattice/catwalk,
 /turf/open/space,
-/area/space/nearstation)
+/area/space)
 "awa" = (
 /obj/machinery/atmospherics/pipe/heat_exchanging/simple{
 	dir = 4
@@ -10378,7 +10378,7 @@
 /obj/machinery/atmospherics/pipe/heat_exchanging/simple,
 /obj/structure/lattice,
 /turf/open/space,
-/area/space/nearstation)
+/area/space)
 "awb" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/effect/turf_decal/bot,
@@ -10880,13 +10880,13 @@
 	},
 /obj/machinery/atmospherics/pipe/heat_exchanging/simple,
 /turf/open/space,
-/area/space/nearstation)
+/area/space)
 "axq" = (
 /obj/machinery/atmospherics/pipe/heat_exchanging/simple{
 	dir = 9
 	},
 /turf/open/space,
-/area/space/nearstation)
+/area/space)
 "axr" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/effect/turf_decal/bot,
@@ -11998,7 +11998,7 @@
 	},
 /obj/structure/lattice/catwalk,
 /turf/open/space,
-/area/space/nearstation)
+/area/space)
 "azO" = (
 /obj/structure/sign/securearea{
 	pixel_x = -32
@@ -13629,12 +13629,12 @@
 /obj/machinery/atmospherics/pipe/heat_exchanging/simple,
 /obj/structure/lattice/catwalk,
 /turf/open/space,
-/area/space/nearstation)
+/area/space)
 "aDl" = (
 /obj/machinery/atmospherics/pipe/heat_exchanging/simple,
 /obj/structure/lattice,
 /turf/open/space,
-/area/space/nearstation)
+/area/space)
 "aDm" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/stripes/line{
@@ -13710,7 +13710,7 @@
 /obj/structure/lattice/catwalk,
 /obj/machinery/atmospherics/pipe/simple/orange/visible,
 /turf/open/space,
-/area/space/nearstation)
+/area/space)
 "aDx" = (
 /obj/structure/sink{
 	dir = 8;
@@ -14221,7 +14221,7 @@
 /obj/structure/lattice,
 /obj/machinery/atmospherics/pipe/simple/orange/visible,
 /turf/open/space,
-/area/space/nearstation)
+/area/space)
 "aEB" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable/white{
@@ -14590,7 +14590,7 @@
 /obj/structure/lattice,
 /obj/structure/grille/broken,
 /turf/open/space,
-/area/space/nearstation)
+/area/space)
 "aFp" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
@@ -17505,7 +17505,7 @@
 /obj/structure/lattice/catwalk,
 /obj/item/wrench,
 /turf/open/space,
-/area/space/nearstation)
+/area/space)
 "aLc" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/closed/wall/r_wall,
@@ -18325,28 +18325,28 @@
 	dir = 5
 	},
 /turf/open/space,
-/area/space/nearstation)
+/area/space)
 "aMN" = (
 /obj/structure/lattice/catwalk,
 /obj/machinery/atmospherics/pipe/simple/orange/visible{
 	dir = 4
 	},
 /turf/open/space,
-/area/space/nearstation)
+/area/space)
 "aMO" = (
 /obj/structure/lattice,
 /obj/machinery/atmospherics/pipe/simple/orange/visible{
 	dir = 4
 	},
 /turf/open/space,
-/area/space/nearstation)
+/area/space)
 "aMP" = (
 /obj/structure/lattice/catwalk,
 /obj/machinery/atmospherics/pipe/simple/orange/visible{
 	dir = 10
 	},
 /turf/open/space,
-/area/space/nearstation)
+/area/space)
 "aMQ" = (
 /obj/structure/table/wood,
 /obj/item/clothing/glasses/sunglasses,
@@ -21302,7 +21302,7 @@
 	dir = 5
 	},
 /turf/open/space,
-/area/space/nearstation)
+/area/space)
 "aSQ" = (
 /obj/structure/lattice/catwalk,
 /obj/machinery/atmospherics/pipe/simple/general/visible{
@@ -21312,7 +21312,7 @@
 	dir = 4
 	},
 /turf/open/space,
-/area/space/nearstation)
+/area/space)
 "aSR" = (
 /obj/structure/lattice,
 /obj/machinery/atmospherics/pipe/simple/general/visible{
@@ -21322,7 +21322,7 @@
 	dir = 4
 	},
 /turf/open/space,
-/area/space/nearstation)
+/area/space)
 "aSS" = (
 /obj/structure/lattice/catwalk,
 /obj/machinery/atmospherics/pipe/simple/general/visible{
@@ -21332,7 +21332,7 @@
 	dir = 9
 	},
 /turf/open/space,
-/area/space/nearstation)
+/area/space)
 "aST" = (
 /obj/machinery/atmospherics/pipe/simple/cyan/visible,
 /turf/open/floor/plasteel/vault{
@@ -25686,7 +25686,7 @@
 	name = "lavaland"
 	},
 /turf/open/space,
-/area/space/nearstation)
+/area/space)
 "bbA" = (
 /obj/machinery/atmospherics/pipe/simple/cyan/visible,
 /obj/structure/sign/securearea{
@@ -30011,12 +30011,12 @@
 "bkE" = (
 /obj/structure/window/reinforced,
 /turf/open/space,
-/area/space/nearstation)
+/area/space)
 "bkF" = (
 /obj/structure/window/reinforced,
 /obj/structure/lattice,
 /turf/open/space,
-/area/space/nearstation)
+/area/space)
 "bkG" = (
 /obj/machinery/light/small{
 	dir = 8
@@ -30917,7 +30917,7 @@
 	dir = 4
 	},
 /turf/open/space,
-/area/space/nearstation)
+/area/space)
 "bmE" = (
 /obj/structure/window/reinforced{
 	dir = 1;
@@ -30958,7 +30958,7 @@
 	dir = 8
 	},
 /turf/open/space,
-/area/space/nearstation)
+/area/space)
 "bmI" = (
 /obj/machinery/atmospherics/components/unary/outlet_injector/on{
 	dir = 4;
@@ -31149,7 +31149,7 @@
 	dir = 9
 	},
 /turf/open/space,
-/area/space/nearstation)
+/area/space)
 "bne" = (
 /obj/structure/rack,
 /obj/effect/spawner/lootdrop/costume,
@@ -31663,7 +31663,7 @@
 	dir = 4
 	},
 /turf/open/space,
-/area/space/nearstation)
+/area/space)
 "bof" = (
 /obj/structure/window/reinforced{
 	dir = 8
@@ -31702,7 +31702,7 @@
 	dir = 8
 	},
 /turf/open/space,
-/area/space/nearstation)
+/area/space)
 "bok" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/atmospherics/pipe/manifold/cyan/visible{
@@ -32421,7 +32421,7 @@
 	},
 /obj/structure/lattice,
 /turf/open/space,
-/area/space/nearstation)
+/area/space)
 "bpG" = (
 /obj/structure/window/reinforced{
 	dir = 1;
@@ -32497,7 +32497,7 @@
 	},
 /obj/structure/lattice,
 /turf/open/space,
-/area/space/nearstation)
+/area/space)
 "bpO" = (
 /turf/open/floor/engine/vacuum,
 /area/engine/atmos)
@@ -33531,7 +33531,7 @@
 	dir = 8
 	},
 /turf/open/space,
-/area/space/nearstation)
+/area/space)
 "brM" = (
 /obj/structure/window/reinforced{
 	dir = 1;
@@ -33539,14 +33539,14 @@
 	},
 /obj/structure/lattice,
 /turf/open/space,
-/area/space/nearstation)
+/area/space)
 "brN" = (
 /obj/structure/window/reinforced{
 	dir = 1;
 	layer = 2.9
 	},
 /turf/open/space,
-/area/space/nearstation)
+/area/space)
 "brO" = (
 /obj/structure/lattice,
 /obj/structure/window/reinforced{
@@ -33554,7 +33554,7 @@
 	layer = 2.9
 	},
 /turf/open/space,
-/area/space/nearstation)
+/area/space)
 "brP" = (
 /obj/structure/lattice,
 /obj/structure/window/reinforced{
@@ -33563,7 +33563,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/space,
-/area/space/nearstation)
+/area/space)
 "brQ" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/window/reinforced{
@@ -33571,7 +33571,7 @@
 	layer = 2.9
 	},
 /turf/open/space,
-/area/space/nearstation)
+/area/space)
 "brR" = (
 /obj/structure/lattice,
 /obj/structure/window/reinforced{
@@ -33580,7 +33580,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/space,
-/area/space/nearstation)
+/area/space)
 "brS" = (
 /obj/structure/lattice,
 /obj/structure/window/reinforced{
@@ -33591,7 +33591,7 @@
 	dir = 4
 	},
 /turf/open/space,
-/area/space/nearstation)
+/area/space)
 "brT" = (
 /obj/machinery/light/small{
 	dir = 8
@@ -34564,7 +34564,7 @@
 	dir = 8
 	},
 /turf/open/space,
-/area/space/nearstation)
+/area/space)
 "btG" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/closed/wall/r_wall,
@@ -34582,7 +34582,7 @@
 	dir = 4
 	},
 /turf/open/space,
-/area/space/nearstation)
+/area/space)
 "btK" = (
 /obj/machinery/camera{
 	c_tag = "Atmospherics - Mix Cell";
@@ -43982,7 +43982,7 @@
 	dir = 8
 	},
 /turf/open/space,
-/area/space/nearstation)
+/area/space)
 "bLx" = (
 /obj/structure/table/reinforced,
 /obj/item/bodypart/chest/robot,
@@ -45022,7 +45022,7 @@
 	dir = 8
 	},
 /turf/open/space,
-/area/space/nearstation)
+/area/space)
 "bNv" = (
 /obj/machinery/light,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -45080,7 +45080,7 @@
 	dir = 4
 	},
 /turf/open/space,
-/area/space/nearstation)
+/area/space)
 "bNC" = (
 /obj/structure/window/reinforced{
 	dir = 8
@@ -45127,7 +45127,7 @@
 	dir = 4
 	},
 /turf/open/space,
-/area/space/nearstation)
+/area/space)
 "bNG" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/cable/white{
@@ -45137,7 +45137,7 @@
 	dir = 10
 	},
 /turf/open/space,
-/area/space/nearstation)
+/area/space)
 "bNH" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/cable/white{
@@ -45147,7 +45147,7 @@
 	dir = 6
 	},
 /turf/open/space,
-/area/space/nearstation)
+/area/space)
 "bNI" = (
 /obj/structure/cable/white{
 	icon_state = "4-8"
@@ -46075,7 +46075,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/space,
-/area/space/nearstation)
+/area/space)
 "bPL" = (
 /obj/machinery/light/small,
 /obj/structure/sign/vacuum{
@@ -46890,7 +46890,7 @@
 	dir = 8
 	},
 /turf/open/space,
-/area/space/nearstation)
+/area/space)
 "bRy" = (
 /obj/machinery/atmospherics/components/unary/portables_connector/visible,
 /obj/machinery/portable_atmospherics/canister/air,
@@ -47028,12 +47028,12 @@
 	dir = 4
 	},
 /turf/open/space,
-/area/space/nearstation)
+/area/space)
 "bRO" = (
 /obj/structure/lattice,
 /obj/structure/window/reinforced,
 /turf/open/space,
-/area/space/nearstation)
+/area/space)
 "bRP" = (
 /obj/structure/sign/vacuum,
 /turf/closed/wall,
@@ -47045,12 +47045,12 @@
 	dir = 4
 	},
 /turf/open/space,
-/area/space/nearstation)
+/area/space)
 "bRR" = (
 /obj/structure/lattice,
 /obj/structure/transit_tube/crossing/horizontal,
 /turf/open/space,
-/area/space/nearstation)
+/area/space)
 "bRS" = (
 /obj/structure/lattice,
 /obj/structure/transit_tube/curved{
@@ -47058,7 +47058,7 @@
 	dir = 8
 	},
 /turf/open/space,
-/area/space/nearstation)
+/area/space)
 "bRT" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/cable/white{
@@ -47068,7 +47068,7 @@
 	dir = 5
 	},
 /turf/open/space,
-/area/space/nearstation)
+/area/space)
 "bRU" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/cable/white{
@@ -47078,7 +47078,7 @@
 	dir = 9
 	},
 /turf/open/space,
-/area/space/nearstation)
+/area/space)
 "bRV" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
@@ -47821,7 +47821,7 @@
 	network = list("SS13")
 	},
 /turf/open/space,
-/area/space/nearstation)
+/area/space)
 "bTm" = (
 /obj/structure/window/reinforced{
 	dir = 8
@@ -48076,14 +48076,14 @@
 	dir = 4
 	},
 /turf/open/space,
-/area/space/nearstation)
+/area/space)
 "bTK" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/window/reinforced{
 	dir = 4
 	},
 /turf/open/space,
-/area/space/nearstation)
+/area/space)
 "bTL" = (
 /obj/structure/window/reinforced{
 	dir = 8
@@ -49390,14 +49390,14 @@
 	dir = 4
 	},
 /turf/open/space,
-/area/space/nearstation)
+/area/space)
 "bVW" = (
 /obj/structure/lattice/catwalk,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
 /turf/open/space,
-/area/space/nearstation)
+/area/space)
 "bVX" = (
 /obj/structure/lattice/catwalk,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -49408,7 +49408,7 @@
 	dir = 4
 	},
 /turf/open/space,
-/area/space/nearstation)
+/area/space)
 "bVY" = (
 /obj/structure/lattice/catwalk,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -49416,7 +49416,7 @@
 	},
 /obj/structure/transit_tube/crossing/horizontal,
 /turf/open/space,
-/area/space/nearstation)
+/area/space)
 "bVZ" = (
 /obj/structure/lattice/catwalk,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -49424,7 +49424,7 @@
 	},
 /obj/structure/transit_tube/horizontal,
 /turf/open/space,
-/area/space/nearstation)
+/area/space)
 "bWa" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/window/reinforced{
@@ -49438,7 +49438,7 @@
 	dir = 8
 	},
 /turf/open/space,
-/area/space/nearstation)
+/area/space)
 "bWb" = (
 /obj/structure/window/reinforced{
 	dir = 8
@@ -50617,7 +50617,7 @@
 /obj/structure/lattice,
 /obj/structure/transit_tube/diagonal,
 /turf/open/space,
-/area/space/nearstation)
+/area/space)
 "bYn" = (
 /obj/structure/window/reinforced{
 	dir = 8
@@ -51717,7 +51717,7 @@
 	dir = 4
 	},
 /turf/open/space,
-/area/space/nearstation)
+/area/space)
 "caq" = (
 /obj/structure/lattice,
 /obj/structure/transit_tube/curved/flipped{
@@ -51725,7 +51725,7 @@
 	dir = 8
 	},
 /turf/open/space,
-/area/space/nearstation)
+/area/space)
 "car" = (
 /turf/closed/wall/r_wall,
 /area/engine/engineering)
@@ -55129,7 +55129,7 @@
 	dir = 4
 	},
 /turf/open/space,
-/area/space/nearstation)
+/area/space)
 "chi" = (
 /obj/structure/cable/white{
 	icon_state = "0-2"
@@ -55281,7 +55281,7 @@
 	dir = 8
 	},
 /turf/open/space,
-/area/space/nearstation)
+/area/space)
 "cht" = (
 /obj/structure/window/reinforced{
 	dir = 1;
@@ -55292,7 +55292,7 @@
 	layer = 2.9
 	},
 /turf/open/space,
-/area/space/nearstation)
+/area/space)
 "chu" = (
 /obj/structure/reagent_dispensers/fueltank,
 /obj/effect/turf_decal/stripes/line,
@@ -56042,21 +56042,21 @@
 	network = list("Singularity")
 	},
 /turf/open/space,
-/area/space/nearstation)
+/area/space)
 "ciZ" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/cable{
 	icon_state = "2-4"
 	},
 /turf/open/space,
-/area/space/nearstation)
+/area/space)
 "cja" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
 /turf/open/space,
-/area/space/nearstation)
+/area/space)
 "cjb" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/cable{
@@ -56066,14 +56066,14 @@
 	icon_state = "4-8"
 	},
 /turf/open/space,
-/area/space/nearstation)
+/area/space)
 "cjc" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/cable{
 	icon_state = "2-8"
 	},
 /turf/open/space,
-/area/space/nearstation)
+/area/space)
 "cjd" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
@@ -56659,7 +56659,7 @@
 	icon_state = "1-2"
 	},
 /turf/open/space,
-/area/space/nearstation)
+/area/space)
 "ckv" = (
 /obj/effect/turf_decal/stripes/corner{
 	dir = 4
@@ -58205,7 +58205,7 @@
 	icon_state = "1-2"
 	},
 /turf/open/space,
-/area/space/nearstation)
+/area/space)
 "cnB" = (
 /obj/structure/cable{
 	icon_state = "0-8"
@@ -59430,24 +59430,24 @@
 	},
 /obj/structure/lattice,
 /turf/open/space,
-/area/space/nearstation)
+/area/space)
 "cqk" = (
 /obj/structure/lattice,
 /obj/structure/window/reinforced,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/space,
-/area/space/nearstation)
+/area/space)
 "cql" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/window/reinforced,
 /turf/open/space,
-/area/space/nearstation)
+/area/space)
 "cqm" = (
 /obj/structure/lattice,
 /obj/structure/window/reinforced,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/space,
-/area/space/nearstation)
+/area/space)
 "cqn" = (
 /obj/structure/window/reinforced,
 /obj/structure/window/reinforced{
@@ -59456,7 +59456,7 @@
 /obj/structure/lattice,
 /obj/structure/lattice,
 /turf/open/space,
-/area/space/nearstation)
+/area/space)
 "cqo" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 9
@@ -59998,7 +59998,7 @@
 	pixel_y = 32
 	},
 /turf/open/space,
-/area/space/nearstation)
+/area/space)
 "crE" = (
 /obj/structure/window/reinforced,
 /obj/structure/window/reinforced{
@@ -64394,14 +64394,14 @@
 	network = list("Singularity")
 	},
 /turf/open/space,
-/area/space/nearstation)
+/area/space)
 "cAH" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/cable{
 	icon_state = "1-4"
 	},
 /turf/open/space,
-/area/space/nearstation)
+/area/space)
 "cAI" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/cable{
@@ -64411,14 +64411,14 @@
 	icon_state = "4-8"
 	},
 /turf/open/space,
-/area/space/nearstation)
+/area/space)
 "cAJ" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/cable{
 	icon_state = "1-8"
 	},
 /turf/open/space,
-/area/space/nearstation)
+/area/space)
 "cAK" = (
 /obj/machinery/power/rad_collector/anchored,
 /obj/effect/decal/cleanable/dirt,

--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -14,7 +14,7 @@
 	width = 18
 	},
 /turf/open/space,
-/area/space/nearstation)
+/area/space)
 "aac" = (
 /obj/effect/landmark/carpspawn,
 /turf/open/space,
@@ -22,12 +22,12 @@
 "aaf" = (
 /obj/structure/lattice,
 /turf/open/space,
-/area/space/nearstation)
+/area/space)
 "aag" = (
 /obj/structure/grille,
 /obj/structure/lattice,
 /turf/open/space,
-/area/space/nearstation)
+/area/space)
 "aah" = (
 /obj/structure/cable{
 	icon_state = "0-2"
@@ -39,11 +39,11 @@
 /obj/structure/grille/broken,
 /obj/structure/lattice,
 /turf/open/space,
-/area/space/nearstation)
+/area/space)
 "aaj" = (
 /obj/structure/grille,
 /turf/open/space,
-/area/space/nearstation)
+/area/space)
 "aak" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -829,7 +829,7 @@
 "ack" = (
 /obj/structure/lattice/catwalk,
 /turf/open/space,
-/area/space/nearstation)
+/area/space)
 "acl" = (
 /obj/structure/cable,
 /obj/machinery/power/solar{
@@ -1563,7 +1563,7 @@
 	network = list("SS13")
 	},
 /turf/open/space,
-/area/space/nearstation)
+/area/space)
 "adE" = (
 /turf/open/floor/plating,
 /area/crew_quarters/fitness/recreation)
@@ -1586,7 +1586,7 @@
 	name = "lavaland"
 	},
 /turf/open/space,
-/area/space/nearstation)
+/area/space)
 "adH" = (
 /obj/structure/chair{
 	dir = 1
@@ -6521,7 +6521,7 @@
 /obj/structure/lattice,
 /obj/structure/grille,
 /turf/open/space,
-/area/space/nearstation)
+/area/space)
 "anU" = (
 /obj/structure/disposalpipe/trunk{
 	dir = 4
@@ -7813,7 +7813,7 @@
 /obj/structure/lattice,
 /obj/structure/grille/broken,
 /turf/open/space,
-/area/space/nearstation)
+/area/space)
 "aqC" = (
 /obj/machinery/space_heater,
 /obj/structure/sign/securearea{
@@ -11562,7 +11562,7 @@
 	},
 /obj/structure/lattice/catwalk,
 /turf/open/space,
-/area/space/nearstation)
+/area/space)
 "ayf" = (
 /obj/structure/closet/crate,
 /obj/item/stack/sheet/glass{
@@ -11980,7 +11980,7 @@
 	},
 /obj/structure/lattice/catwalk,
 /turf/open/space,
-/area/space/nearstation)
+/area/space)
 "aze" = (
 /obj/item/twohanded/required/kirbyplants{
 	icon_state = "plant-22"
@@ -17991,7 +17991,7 @@
 	dir = 4
 	},
 /turf/open/space,
-/area/space/nearstation)
+/area/space)
 "aLp" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
@@ -18057,7 +18057,7 @@
 	dir = 4
 	},
 /turf/open/space,
-/area/space/nearstation)
+/area/space)
 "aLx" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -18364,12 +18364,12 @@
 "aMq" = (
 /obj/structure/window/reinforced,
 /turf/open/space,
-/area/space/nearstation)
+/area/space)
 "aMr" = (
 /obj/structure/window/reinforced,
 /obj/structure/lattice,
 /turf/open/space,
-/area/space/nearstation)
+/area/space)
 "aMs" = (
 /obj/machinery/door/airlock/external{
 	name = "Supply Dock Airlock";
@@ -18830,7 +18830,7 @@
 	dir = 4
 	},
 /turf/open/space,
-/area/space/nearstation)
+/area/space)
 "aNx" = (
 /obj/structure/window/reinforced{
 	dir = 1;
@@ -18881,7 +18881,7 @@
 	},
 /obj/structure/lattice,
 /turf/open/space,
-/area/space/nearstation)
+/area/space)
 "aND" = (
 /obj/effect/spawner/structure/window/shuttle,
 /turf/open/floor/plating,
@@ -19555,14 +19555,14 @@
 	pixel_y = 1
 	},
 /turf/open/space,
-/area/space/nearstation)
+/area/space)
 "aOV" = (
 /obj/structure/window/reinforced{
 	dir = 1;
 	pixel_y = 1
 	},
 /turf/open/space,
-/area/space/nearstation)
+/area/space)
 "aOW" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/structure/lattice/catwalk,
@@ -19577,13 +19577,13 @@
 	pixel_y = 1
 	},
 /turf/open/space,
-/area/space/nearstation)
+/area/space)
 "aOY" = (
 /obj/structure/window/reinforced{
 	dir = 8
 	},
 /turf/open/space,
-/area/space/nearstation)
+/area/space)
 "aOZ" = (
 /turf/closed/wall/mineral/titanium,
 /area/shuttle/pod_1)
@@ -21290,7 +21290,7 @@
 	dir = 4
 	},
 /turf/open/space,
-/area/space/nearstation)
+/area/space)
 "aSE" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 5
@@ -21309,7 +21309,7 @@
 	},
 /obj/structure/window/reinforced,
 /turf/open/space,
-/area/space/nearstation)
+/area/space)
 "aSH" = (
 /obj/structure/chair{
 	dir = 4
@@ -21873,7 +21873,7 @@
 	},
 /obj/structure/lattice,
 /turf/open/space,
-/area/space/nearstation)
+/area/space)
 "aTR" = (
 /obj/structure/window/reinforced{
 	dir = 1;
@@ -22548,7 +22548,7 @@
 	dir = 8
 	},
 /turf/open/space,
-/area/space/nearstation)
+/area/space)
 "aVl" = (
 /obj/machinery/porta_turret/ai{
 	dir = 4
@@ -23180,7 +23180,7 @@
 	dir = 10
 	},
 /turf/open/space,
-/area/space/nearstation)
+/area/space)
 "aWL" = (
 /obj/machinery/ai_status_display{
 	pixel_x = -32
@@ -24091,7 +24091,7 @@
 	},
 /obj/structure/lattice,
 /turf/open/space,
-/area/space/nearstation)
+/area/space)
 "aYy" = (
 /obj/machinery/camera{
 	c_tag = "AI Chamber - Port";
@@ -26349,7 +26349,7 @@
 	dir = 8
 	},
 /turf/open/space,
-/area/space/nearstation)
+/area/space)
 "bcS" = (
 /turf/closed/wall/mineral/titanium,
 /area/shuttle/arrival)
@@ -27978,7 +27978,7 @@
 	layer = 2.9
 	},
 /turf/open/space,
-/area/space/nearstation)
+/area/space)
 "bgo" = (
 /obj/structure/window/reinforced{
 	dir = 4
@@ -27988,7 +27988,7 @@
 	layer = 2.9
 	},
 /turf/open/space,
-/area/space/nearstation)
+/area/space)
 "bgq" = (
 /obj/structure/chair,
 /turf/open/floor/mineral/titanium/blue,
@@ -28983,7 +28983,7 @@
 	name = "lavaland"
 	},
 /turf/open/space,
-/area/space/nearstation)
+/area/space)
 "bij" = (
 /obj/effect/spawner/structure/window/shuttle,
 /turf/open/floor/plating,
@@ -30602,18 +30602,18 @@
 	dir = 4
 	},
 /turf/open/space,
-/area/space/nearstation)
+/area/space)
 "blv" = (
 /obj/structure/lattice,
 /obj/structure/transit_tube/crossing/horizontal,
 /turf/open/space,
-/area/space/nearstation)
+/area/space)
 "blw" = (
 /obj/structure/transit_tube/curved{
 	dir = 8
 	},
 /turf/open/space,
-/area/space/nearstation)
+/area/space)
 "blx" = (
 /turf/closed/wall,
 /area/space/nearstation)
@@ -30623,7 +30623,7 @@
 	},
 /obj/structure/window/reinforced,
 /turf/open/space,
-/area/space/nearstation)
+/area/space)
 "blA" = (
 /obj/machinery/atmospherics/components/unary/outlet_injector/on,
 /obj/structure/window/reinforced,
@@ -31507,7 +31507,7 @@
 "bno" = (
 /obj/structure/transit_tube/diagonal,
 /turf/open/space,
-/area/space/nearstation)
+/area/space)
 "bnp" = (
 /obj/structure/window/reinforced{
 	dir = 1;
@@ -32555,7 +32555,7 @@
 	},
 /obj/structure/transit_tube/horizontal,
 /turf/open/space,
-/area/space/nearstation)
+/area/space)
 "bpx" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -32566,7 +32566,7 @@
 	},
 /obj/structure/transit_tube/crossing/horizontal,
 /turf/open/space,
-/area/space/nearstation)
+/area/space)
 "bpy" = (
 /obj/structure/lattice/catwalk,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -32577,7 +32577,7 @@
 	},
 /obj/structure/transit_tube/horizontal,
 /turf/open/space,
-/area/space/nearstation)
+/area/space)
 "bpz" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -32590,7 +32590,7 @@
 	dir = 8
 	},
 /turf/open/space,
-/area/space/nearstation)
+/area/space)
 "bpA" = (
 /obj/structure/lattice/catwalk,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -32600,7 +32600,7 @@
 	icon_state = "4-8"
 	},
 /turf/open/space,
-/area/space/nearstation)
+/area/space)
 "bpB" = (
 /obj/structure/window/reinforced{
 	dir = 4
@@ -32613,7 +32613,7 @@
 	icon_state = "4-8"
 	},
 /turf/open/space,
-/area/space/nearstation)
+/area/space)
 "bpC" = (
 /obj/structure/window/reinforced{
 	dir = 8
@@ -33815,7 +33815,7 @@
 	dir = 4
 	},
 /turf/open/space,
-/area/space/nearstation)
+/area/space)
 "brN" = (
 /obj/structure/window/reinforced{
 	dir = 4
@@ -33840,7 +33840,7 @@
 "brO" = (
 /obj/structure/transit_tube/diagonal/topleft,
 /turf/open/space,
-/area/space/nearstation)
+/area/space)
 "brP" = (
 /obj/structure/window/reinforced,
 /obj/structure/window/reinforced{
@@ -34108,7 +34108,7 @@
 	dir = 4
 	},
 /turf/open/space,
-/area/space/nearstation)
+/area/space)
 "bsk" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -34851,14 +34851,14 @@
 	dir = 4
 	},
 /turf/open/space,
-/area/space/nearstation)
+/area/space)
 "btJ" = (
 /obj/structure/lattice,
 /obj/structure/transit_tube/curved/flipped{
 	dir = 8
 	},
 /turf/open/space,
-/area/space/nearstation)
+/area/space)
 "btK" = (
 /obj/structure/window/reinforced{
 	dir = 1;
@@ -34866,7 +34866,7 @@
 	},
 /obj/structure/lattice,
 /turf/open/space,
-/area/space/nearstation)
+/area/space)
 "btL" = (
 /turf/closed/wall/r_wall,
 /area/tcommsat/computer)
@@ -38229,7 +38229,7 @@
 	},
 /obj/structure/lattice,
 /turf/open/space,
-/area/space/nearstation)
+/area/space)
 "bAT" = (
 /obj/structure/window/reinforced{
 	dir = 4
@@ -38239,7 +38239,7 @@
 	pixel_y = 2
 	},
 /turf/open/space,
-/area/space/nearstation)
+/area/space)
 "bAU" = (
 /obj/machinery/microwave{
 	pixel_y = 4
@@ -38318,7 +38318,7 @@
 	},
 /obj/structure/lattice,
 /turf/open/space,
-/area/space/nearstation)
+/area/space)
 "bBc" = (
 /obj/structure/closet/emcloset,
 /obj/effect/turf_decal/bot,
@@ -38989,7 +38989,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/orange/visible,
 /turf/open/space,
-/area/space/nearstation)
+/area/space)
 "bCA" = (
 /obj/machinery/meter,
 /obj/machinery/atmospherics/pipe/simple/yellow/visible{
@@ -40741,7 +40741,7 @@
 	dir = 4
 	},
 /turf/open/space,
-/area/space/nearstation)
+/area/space)
 "bFZ" = (
 /obj/machinery/meter,
 /obj/machinery/atmospherics/pipe/simple/green/visible{
@@ -42052,7 +42052,7 @@
 	dir = 4
 	},
 /turf/open/space,
-/area/space/nearstation)
+/area/space)
 "bJc" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/siphon/on{
 	dir = 8;
@@ -42125,7 +42125,7 @@
 	dir = 4
 	},
 /turf/open/space,
-/area/space/nearstation)
+/area/space)
 "bJm" = (
 /obj/machinery/telecomms/bus/preset_two,
 /turf/open/floor/circuit/telecomms/mainframe,
@@ -52844,31 +52844,31 @@
 /obj/structure/lattice,
 /obj/machinery/atmospherics/pipe/simple/green/visible,
 /turf/open/space,
-/area/space/nearstation)
+/area/space)
 "cfv" = (
 /obj/structure/lattice,
 /obj/machinery/atmospherics/pipe/simple/yellow/visible,
 /turf/open/space,
-/area/space/nearstation)
+/area/space)
 "cfw" = (
 /obj/structure/lattice,
 /obj/machinery/atmospherics/pipe/manifold/yellow/visible{
 	dir = 8
 	},
 /turf/open/space,
-/area/space/nearstation)
+/area/space)
 "cfx" = (
 /obj/structure/lattice,
 /obj/machinery/atmospherics/pipe/simple/yellow/visible{
 	dir = 9
 	},
 /turf/open/space,
-/area/space/nearstation)
+/area/space)
 "cfy" = (
 /obj/structure/lattice,
 /obj/machinery/atmospherics/pipe/simple/cyan/visible,
 /turf/open/space,
-/area/space/nearstation)
+/area/space)
 "cfz" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/cable{
@@ -55953,7 +55953,7 @@
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/general/visible,
 /turf/open/space,
-/area/space/nearstation)
+/area/space)
 "cmd" = (
 /obj/machinery/door/airlock/glass{
 	autoclose = 0;
@@ -57821,7 +57821,7 @@
 	dir = 5
 	},
 /turf/open/space,
-/area/space/nearstation)
+/area/space)
 "cpN" = (
 /obj/machinery/atmospherics/components/unary/outlet_injector/on{
 	dir = 8
@@ -57839,7 +57839,7 @@
 /obj/structure/lattice/catwalk,
 /obj/item/wrench,
 /turf/open/space,
-/area/space/nearstation)
+/area/space)
 "cpQ" = (
 /obj/structure/chair/stool,
 /turf/open/floor/wood{
@@ -58517,7 +58517,7 @@
 	dir = 5
 	},
 /turf/open/space,
-/area/space/nearstation)
+/area/space)
 "crd" = (
 /obj/structure/disposaloutlet{
 	dir = 2
@@ -58527,7 +58527,7 @@
 	},
 /obj/structure/lattice/catwalk,
 /turf/open/space,
-/area/space/nearstation)
+/area/space)
 "cre" = (
 /obj/structure/sign/fire,
 /turf/closed/wall/r_wall,
@@ -59672,11 +59672,11 @@
 	use_power = 0
 	},
 /turf/open/space,
-/area/space/nearstation)
+/area/space)
 "ctm" = (
 /obj/structure/grille/broken,
 /turf/open/space,
-/area/space/nearstation)
+/area/space)
 "ctn" = (
 /obj/machinery/vending/cigarette,
 /obj/effect/turf_decal/stripes/line{
@@ -61083,14 +61083,14 @@
 	},
 /obj/structure/lattice/catwalk,
 /turf/open/space,
-/area/space/nearstation)
+/area/space)
 "cwg" = (
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/structure/lattice/catwalk,
 /turf/open/space,
-/area/space/nearstation)
+/area/space)
 "cwh" = (
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
@@ -67399,7 +67399,7 @@
 	pixel_x = -32
 	},
 /turf/open/space,
-/area/space/nearstation)
+/area/space)
 "cIz" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -67694,7 +67694,7 @@
 	},
 /obj/structure/lattice/catwalk,
 /turf/open/space,
-/area/space/nearstation)
+/area/space)
 "cJg" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/item/bedsheet/medical,
@@ -72244,7 +72244,7 @@
 	name = "lavaland"
 	},
 /turf/open/space,
-/area/space/nearstation)
+/area/space)
 "cSQ" = (
 /obj/machinery/door/window/northleft{
 	dir = 4;
@@ -72696,7 +72696,7 @@
 	width = 18
 	},
 /turf/open/space,
-/area/space/nearstation)
+/area/space)
 "cUH" = (
 /obj/structure/table/optable,
 /turf/open/floor/plasteel/white,
@@ -72708,7 +72708,7 @@
 	name = "lavaland"
 	},
 /turf/open/space,
-/area/space/nearstation)
+/area/space)
 "cUM" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable/yellow{
@@ -75823,7 +75823,7 @@
 	width = 18
 	},
 /turf/open/space,
-/area/space/nearstation)
+/area/space)
 "dbC" = (
 /obj/docking_port/stationary{
 	dheight = 9;
@@ -75836,7 +75836,7 @@
 	width = 18
 	},
 /turf/open/space,
-/area/space/nearstation)
+/area/space)
 "dbD" = (
 /obj/docking_port/stationary{
 	dheight = 9;
@@ -75849,7 +75849,7 @@
 	width = 18
 	},
 /turf/open/space,
-/area/space/nearstation)
+/area/space)
 "dbE" = (
 /obj/machinery/plantgenes,
 /obj/effect/turf_decal/stripes/line{
@@ -77762,32 +77762,32 @@
 "dgd" = (
 /obj/machinery/atmospherics/pipe/heat_exchanging/simple,
 /turf/open/space,
-/area/space/nearstation)
+/area/space)
 "dge" = (
 /obj/machinery/atmospherics/pipe/heat_exchanging/simple,
 /obj/structure/lattice/catwalk,
 /turf/open/space,
-/area/space/nearstation)
+/area/space)
 "dgf" = (
 /obj/machinery/atmospherics/pipe/heat_exchanging/simple{
 	dir = 6
 	},
 /turf/open/space,
-/area/space/nearstation)
+/area/space)
 "dgg" = (
 /obj/machinery/atmospherics/pipe/heat_exchanging/simple{
 	dir = 6
 	},
 /obj/structure/lattice/catwalk,
 /turf/open/space,
-/area/space/nearstation)
+/area/space)
 "dgh" = (
 /obj/machinery/atmospherics/pipe/heat_exchanging/simple{
 	dir = 6
 	},
 /obj/structure/lattice,
 /turf/open/space,
-/area/space/nearstation)
+/area/space)
 "dgi" = (
 /obj/machinery/atmospherics/pipe/simple/orange/visible,
 /turf/open/floor/plating,
@@ -77798,7 +77798,7 @@
 	},
 /obj/structure/lattice,
 /turf/open/space,
-/area/space/nearstation)
+/area/space)
 "dgk" = (
 /obj/machinery/atmospherics/pipe/heat_exchanging/simple,
 /obj/machinery/atmospherics/pipe/heat_exchanging/simple{
@@ -77806,7 +77806,7 @@
 	},
 /obj/structure/lattice,
 /turf/open/space,
-/area/space/nearstation)
+/area/space)
 "dgm" = (
 /obj/machinery/atmospherics/pipe/heat_exchanging/simple{
 	dir = 4
@@ -77814,7 +77814,7 @@
 /obj/machinery/atmospherics/pipe/heat_exchanging/simple,
 /obj/structure/lattice,
 /turf/open/space,
-/area/space/nearstation)
+/area/space)
 "dgo" = (
 /obj/machinery/atmospherics/pipe/simple/orange/visible{
 	dir = 4
@@ -77834,33 +77834,33 @@
 	dir = 10
 	},
 /turf/open/space,
-/area/space/nearstation)
+/area/space)
 "dgt" = (
 /obj/machinery/atmospherics/pipe/heat_exchanging/simple,
 /obj/machinery/atmospherics/pipe/heat_exchanging/simple{
 	dir = 4
 	},
 /turf/open/space,
-/area/space/nearstation)
+/area/space)
 "dgu" = (
 /obj/machinery/atmospherics/pipe/heat_exchanging/simple{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/heat_exchanging/simple,
 /turf/open/space,
-/area/space/nearstation)
+/area/space)
 "dgv" = (
 /obj/machinery/atmospherics/pipe/heat_exchanging/simple{
 	dir = 9
 	},
 /obj/structure/lattice/catwalk,
 /turf/open/space,
-/area/space/nearstation)
+/area/space)
 "dgw" = (
 /obj/structure/lattice,
 /obj/machinery/atmospherics/pipe/simple/orange/visible,
 /turf/open/space,
-/area/space/nearstation)
+/area/space)
 "dgz" = (
 /obj/structure/closet/toolcloset,
 /obj/effect/turf_decal/delivery,
@@ -77871,49 +77871,49 @@
 /obj/structure/lattice/catwalk,
 /obj/machinery/atmospherics/pipe/simple/orange/visible,
 /turf/open/space,
-/area/space/nearstation)
+/area/space)
 "dgB" = (
 /obj/machinery/atmospherics/pipe/heat_exchanging/simple{
 	dir = 5
 	},
 /obj/structure/lattice/catwalk,
 /turf/open/space,
-/area/space/nearstation)
+/area/space)
 "dgI" = (
 /obj/machinery/atmospherics/pipe/simple/orange/visible{
 	dir = 5
 	},
 /turf/open/space,
-/area/space/nearstation)
+/area/space)
 "dgJ" = (
 /obj/structure/lattice,
 /obj/machinery/atmospherics/pipe/simple/orange/visible{
 	dir = 4
 	},
 /turf/open/space,
-/area/space/nearstation)
+/area/space)
 "dgK" = (
 /obj/machinery/atmospherics/pipe/simple/orange/visible{
 	dir = 4
 	},
 /turf/open/space,
-/area/space/nearstation)
+/area/space)
 "dgM" = (
 /obj/machinery/atmospherics/pipe/simple/orange/visible{
 	dir = 10
 	},
 /turf/open/space,
-/area/space/nearstation)
+/area/space)
 "dgN" = (
 /obj/structure/lattice,
 /obj/structure/grille,
 /obj/machinery/atmospherics/pipe/simple/orange/visible,
 /turf/open/space,
-/area/space/nearstation)
+/area/space)
 "dgO" = (
 /obj/machinery/atmospherics/pipe/simple/orange/visible,
 /turf/open/space,
-/area/space/nearstation)
+/area/space)
 "dgS" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -77925,7 +77925,7 @@
 /obj/structure/transit_tube/horizontal,
 /obj/machinery/atmospherics/pipe/simple/orange/visible,
 /turf/open/space,
-/area/space/nearstation)
+/area/space)
 "dha" = (
 /obj/structure/lattice,
 /obj/machinery/atmospherics/pipe/simple/green/visible{
@@ -77933,7 +77933,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/orange/visible,
 /turf/open/space,
-/area/space/nearstation)
+/area/space)
 "dhc" = (
 /obj/structure/lattice,
 /obj/machinery/atmospherics/pipe/simple/yellow/visible{
@@ -77941,7 +77941,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/orange/visible,
 /turf/open/space,
-/area/space/nearstation)
+/area/space)
 "dhe" = (
 /obj/machinery/atmospherics/pipe/simple/general/visible{
 	dir = 10
@@ -77996,7 +77996,7 @@
 	dir = 9
 	},
 /turf/open/space,
-/area/space/nearstation)
+/area/space)
 "dhn" = (
 /obj/structure/table,
 /obj/item/poster/random_contraband,
@@ -80641,7 +80641,7 @@
 	width = 18
 	},
 /turf/open/space/basic,
-/area/space/nearstation)
+/area/space)
 "EDb" = (
 /obj/structure/grille,
 /turf/open/floor/plating/airless,

--- a/_maps/map_files/OmegaStation/OmegaStation.dmm
+++ b/_maps/map_files/OmegaStation/OmegaStation.dmm
@@ -19,17 +19,17 @@
 "aae" = (
 /obj/structure/lattice,
 /turf/open/space,
-/area/space/nearstation)
+/area/space)
 "aaf" = (
 /obj/structure/lattice,
 /obj/structure/grille,
 /turf/open/space,
-/area/space/nearstation)
+/area/space)
 "aag" = (
 /obj/structure/lattice,
 /obj/structure/grille/broken,
 /turf/open/space,
-/area/space/nearstation)
+/area/space)
 "aah" = (
 /obj/structure/sign/securearea,
 /turf/closed/wall,
@@ -34038,7 +34038,7 @@
 	width = 18
 	},
 /turf/open/space/basic,
-/area/space/nearstation)
+/area/space)
 "sws" = (
 /obj/docking_port/stationary{
 	dheight = 9;
@@ -34051,7 +34051,7 @@
 	width = 18
 	},
 /turf/open/space,
-/area/space/nearstation)
+/area/space)
 "swt" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4

--- a/_maps/map_files/PubbyStation/PubbyStation.dmm
+++ b/_maps/map_files/PubbyStation/PubbyStation.dmm
@@ -14,16 +14,16 @@
 	width = 18
 	},
 /turf/open/space,
-/area/space/nearstation)
+/area/space)
 "aby" = (
 /obj/structure/lattice,
 /obj/structure/grille,
 /turf/open/space,
-/area/space/nearstation)
+/area/space)
 "abI" = (
 /obj/structure/lattice,
 /turf/open/space,
-/area/space/nearstation)
+/area/space)
 "abJ" = (
 /obj/structure/lattice,
 /obj/machinery/camera/motion{
@@ -32,7 +32,7 @@
 	network = list("MiniSat")
 	},
 /turf/open/space,
-/area/space/nearstation)
+/area/space)
 "abN" = (
 /obj/effect/landmark/carpspawn,
 /turf/open/space,
@@ -176,7 +176,7 @@
 	network = list("MiniSat")
 	},
 /turf/open/space,
-/area/space/nearstation)
+/area/space)
 "acn" = (
 /obj/machinery/porta_turret/ai{
 	dir = 4
@@ -268,7 +268,7 @@
 	network = list("MiniSat")
 	},
 /turf/open/space,
-/area/space/nearstation)
+/area/space)
 "acw" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -435,11 +435,11 @@
 /obj/structure/lattice,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/space,
-/area/space/nearstation)
+/area/space)
 "acO" = (
 /obj/structure/grille/broken,
 /turf/open/space,
-/area/space/nearstation)
+/area/space)
 "acP" = (
 /turf/closed/wall/r_wall,
 /area/ai_monitored/turret_protected/AIsatextAP)
@@ -827,7 +827,7 @@
 /obj/structure/grille,
 /obj/structure/lattice,
 /turf/open/space,
-/area/space/nearstation)
+/area/space)
 "adS" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/closed/wall/r_wall,
@@ -904,7 +904,7 @@
 /obj/structure/lattice,
 /obj/structure/grille/broken,
 /turf/open/space,
-/area/space/nearstation)
+/area/space)
 "aee" = (
 /turf/open/floor/plating,
 /area/ai_monitored/turret_protected/AIsatextAP)
@@ -1528,7 +1528,7 @@
 "afJ" = (
 /obj/effect/landmark/carpspawn,
 /turf/open/space/basic,
-/area/space/nearstation)
+/area/space)
 "afK" = (
 /obj/machinery/atmospherics/components/unary/tank/air{
 	dir = 1
@@ -1998,7 +1998,7 @@
 /obj/structure/transit_tube,
 /obj/structure/lattice/catwalk,
 /turf/open/space/basic,
-/area/space/nearstation)
+/area/space)
 "agT" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/door/poddoor/preopen{
@@ -2088,11 +2088,11 @@
 	pixel_y = 20
 	},
 /turf/open/space,
-/area/space/nearstation)
+/area/space)
 "ahi" = (
 /obj/structure/lattice/catwalk,
 /turf/open/space,
-/area/space/nearstation)
+/area/space)
 "ahj" = (
 /obj/item/device/radio/intercom{
 	freerange = 0;
@@ -2177,16 +2177,16 @@
 	network = list("MiniSat")
 	},
 /turf/open/space,
-/area/space/nearstation)
+/area/space)
 "ahs" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/transit_tube,
 /turf/open/space/basic,
-/area/space/nearstation)
+/area/space)
 "aht" = (
 /obj/structure/lattice,
 /turf/open/space/basic,
-/area/space/nearstation)
+/area/space)
 "ahu" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable{
@@ -2421,7 +2421,7 @@
 /obj/structure/lattice/catwalk,
 /obj/structure/transit_tube/crossing,
 /turf/open/space/basic,
-/area/space/nearstation)
+/area/space)
 "ahS" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable{
@@ -3146,7 +3146,7 @@
 	width = 18
 	},
 /turf/open/space,
-/area/space/nearstation)
+/area/space)
 "ajB" = (
 /obj/item/storage/box/mousetraps,
 /turf/open/floor/plating,
@@ -3831,7 +3831,7 @@
 	},
 /obj/structure/lattice/catwalk,
 /turf/open/space/basic,
-/area/space/nearstation)
+/area/space)
 "alb" = (
 /turf/open/floor/wood,
 /area/maintenance/department/crew_quarters/dorms)
@@ -4118,7 +4118,7 @@
 /obj/structure/transit_tube/diagonal,
 /obj/structure/lattice,
 /turf/open/space/basic,
-/area/space/nearstation)
+/area/space)
 "alP" = (
 /turf/open/floor/plating{
 	burnt = 1;
@@ -4482,17 +4482,17 @@
 	},
 /obj/structure/lattice/catwalk,
 /turf/open/space/basic,
-/area/space/nearstation)
+/area/space)
 "amB" = (
 /obj/structure/transit_tube/crossing/horizontal,
 /obj/structure/lattice/catwalk,
 /turf/open/space/basic,
-/area/space/nearstation)
+/area/space)
 "amC" = (
 /obj/structure/transit_tube/horizontal,
 /obj/structure/lattice/catwalk,
 /turf/open/space/basic,
-/area/space/nearstation)
+/area/space)
 "amD" = (
 /obj/structure/transit_tube/curved/flipped{
 	icon_state = "curved1";
@@ -4500,7 +4500,7 @@
 	},
 /obj/structure/lattice/catwalk,
 /turf/open/space/basic,
-/area/space/nearstation)
+/area/space)
 "amF" = (
 /turf/open/floor/wood{
 	broken = 1;
@@ -4760,7 +4760,7 @@
 "anl" = (
 /obj/structure/transit_tube/diagonal,
 /turf/open/space/basic,
-/area/space/nearstation)
+/area/space)
 "anm" = (
 /obj/machinery/door/airlock/maintenance/abandoned{
 	name = "Pete's Speakeasy";
@@ -5628,14 +5628,14 @@
 /obj/structure/transit_tube/diagonal/crossing,
 /obj/structure/lattice,
 /turf/open/space/basic,
-/area/space/nearstation)
+/area/space)
 "app" = (
 /obj/machinery/camera{
 	c_tag = "Bridge Starboard Exterior";
 	dir = 1
 	},
 /turf/open/space,
-/area/space/nearstation)
+/area/space)
 "apq" = (
 /obj/machinery/gateway{
 	dir = 8
@@ -5866,7 +5866,7 @@
 /obj/structure/transit_tube/curved,
 /obj/structure/lattice/catwalk,
 /turf/open/space/basic,
-/area/space/nearstation)
+/area/space)
 "apT" = (
 /turf/closed/wall/r_wall,
 /area/ai_monitored/nuke_storage)
@@ -6160,7 +6160,7 @@
 /obj/structure/window/reinforced,
 /obj/structure/lattice,
 /turf/open/space/basic,
-/area/space/nearstation)
+/area/space)
 "aqH" = (
 /obj/structure/cable{
 	icon_state = "2-4"
@@ -6570,7 +6570,7 @@
 	},
 /obj/structure/lattice,
 /turf/open/space/basic,
-/area/space/nearstation)
+/area/space)
 "arG" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -12857,7 +12857,7 @@
 	pixel_y = 32
 	},
 /turf/open/space,
-/area/space/nearstation)
+/area/space)
 "aGp" = (
 /obj/structure/lattice,
 /obj/structure/sign/logo{
@@ -12865,7 +12865,7 @@
 	pixel_y = 32
 	},
 /turf/open/space,
-/area/space/nearstation)
+/area/space)
 "aGq" = (
 /obj/structure/lattice,
 /obj/structure/sign/logo{
@@ -12873,7 +12873,7 @@
 	pixel_y = 32
 	},
 /turf/open/space,
-/area/space/nearstation)
+/area/space)
 "aGr" = (
 /obj/structure/lattice,
 /obj/structure/sign/logo{
@@ -12881,7 +12881,7 @@
 	pixel_y = 32
 	},
 /turf/open/space,
-/area/space/nearstation)
+/area/space)
 "aGs" = (
 /obj/structure/lattice,
 /obj/structure/sign/logo{
@@ -12889,7 +12889,7 @@
 	pixel_y = 32
 	},
 /turf/open/space,
-/area/space/nearstation)
+/area/space)
 "aGt" = (
 /obj/machinery/vending/cola,
 /obj/effect/turf_decal/delivery,
@@ -25482,7 +25482,7 @@
 	},
 /obj/structure/lattice,
 /turf/open/space/basic,
-/area/space/nearstation)
+/area/space)
 "bkF" = (
 /turf/closed/wall/r_wall,
 /area/science/xenobiology)
@@ -32317,7 +32317,7 @@
 "bzy" = (
 /obj/structure/grille,
 /turf/open/space,
-/area/space/nearstation)
+/area/space)
 "bzz" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/structure/chair{
@@ -32826,7 +32826,7 @@
 	dir = 4
 	},
 /turf/open/space/basic,
-/area/space/nearstation)
+/area/space)
 "bAJ" = (
 /obj/structure/transit_tube/horizontal,
 /obj/structure/window/reinforced/fulltile,
@@ -33367,7 +33367,7 @@
 "bBV" = (
 /obj/structure/transit_tube/curved,
 /turf/open/space,
-/area/space/nearstation)
+/area/space)
 "bBW" = (
 /turf/open/space,
 /area/space)
@@ -33896,7 +33896,7 @@
 /obj/structure/transit_tube,
 /obj/structure/lattice/catwalk,
 /turf/open/space,
-/area/space/nearstation)
+/area/space)
 "bDg" = (
 /obj/machinery/atmospherics/components/unary/tank/air{
 	dir = 2
@@ -35062,7 +35062,7 @@
 	width = 5
 	},
 /turf/open/space,
-/area/space/nearstation)
+/area/space)
 "bFF" = (
 /obj/machinery/atmospherics/components/unary/tank/air{
 	dir = 1
@@ -35475,7 +35475,7 @@
 	dir = 4
 	},
 /turf/open/space,
-/area/space/nearstation)
+/area/space)
 "bGE" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
@@ -35500,11 +35500,11 @@
 "bGH" = (
 /obj/structure/window/reinforced,
 /turf/open/space,
-/area/space/nearstation)
+/area/space)
 "bGI" = (
 /obj/structure/window/reinforced,
 /turf/open/space/basic,
-/area/space/nearstation)
+/area/space)
 "bGK" = (
 /obj/structure/closet/boxinggloves,
 /turf/open/floor/plating{
@@ -35961,7 +35961,7 @@
 "bHI" = (
 /obj/structure/grille/broken,
 /turf/open/space/basic,
-/area/space/nearstation)
+/area/space)
 "bHJ" = (
 /turf/open/floor/plating,
 /area/chapel/dock)
@@ -35989,7 +35989,7 @@
 	layer = 2.9
 	},
 /turf/open/space/basic,
-/area/space/nearstation)
+/area/space)
 "bHP" = (
 /obj/effect/decal/cleanable/cobweb,
 /turf/open/floor/plasteel/dark,
@@ -36463,7 +36463,7 @@
 	layer = 2.9
 	},
 /turf/open/space/basic,
-/area/space/nearstation)
+/area/space)
 "bIU" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/closed/wall,
@@ -36500,7 +36500,7 @@
 	layer = 2.9
 	},
 /turf/open/space/basic,
-/area/space/nearstation)
+/area/space)
 "bIZ" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
@@ -36944,7 +36944,7 @@
 	},
 /obj/structure/lattice,
 /turf/open/space/basic,
-/area/space/nearstation)
+/area/space)
 "bKa" = (
 /obj/machinery/airalarm{
 	dir = 4;
@@ -37363,7 +37363,7 @@
 	dir = 4
 	},
 /turf/open/space,
-/area/space/nearstation)
+/area/space)
 "bLb" = (
 /obj/machinery/atmospherics/pipe/simple{
 	dir = 4
@@ -37515,7 +37515,7 @@
 	layer = 2.9
 	},
 /turf/open/space,
-/area/space/nearstation)
+/area/space)
 "bLt" = (
 /obj/effect/decal/cleanable/oil{
 	icon_state = "floor6"
@@ -37935,7 +37935,7 @@
 	layer = 2.9
 	},
 /turf/open/space/basic,
-/area/space/nearstation)
+/area/space)
 "bMs" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -37992,7 +37992,7 @@
 	},
 /obj/structure/lattice,
 /turf/open/space,
-/area/space/nearstation)
+/area/space)
 "bMA" = (
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/engine,
@@ -38280,7 +38280,7 @@
 	dir = 4
 	},
 /turf/open/space,
-/area/space/nearstation)
+/area/space)
 "bNo" = (
 /obj/machinery/atmospherics/components/unary/outlet_injector/on{
 	dir = 8;
@@ -38304,7 +38304,7 @@
 /obj/structure/window/reinforced,
 /obj/structure/lattice,
 /turf/open/space,
-/area/space/nearstation)
+/area/space)
 "bNs" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating/airless,
@@ -38387,7 +38387,7 @@
 	},
 /obj/structure/lattice/catwalk,
 /turf/open/space,
-/area/space/nearstation)
+/area/space)
 "bNF" = (
 /obj/item/stack/medical/bruise_pack,
 /turf/open/floor/plasteel/dark,
@@ -38718,7 +38718,7 @@
 	},
 /obj/structure/lattice,
 /turf/open/space,
-/area/space/nearstation)
+/area/space)
 "bOw" = (
 /turf/open/floor/plating/asteroid,
 /area/chapel/asteroid{
@@ -39009,25 +39009,25 @@
 	},
 /obj/structure/lattice,
 /turf/open/space/basic,
-/area/space/nearstation)
+/area/space)
 "bPk" = (
 /obj/structure/lattice/catwalk,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
 	dir = 4
 	},
 /turf/open/space,
-/area/space/nearstation)
+/area/space)
 "bPl" = (
 /obj/structure/lattice/catwalk,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
 	dir = 9
 	},
 /turf/open/space,
-/area/space/nearstation)
+/area/space)
 "bPm" = (
 /obj/structure/lattice/catwalk,
 /turf/open/space,
-/area/space/nearstation)
+/area/space)
 "bPn" = (
 /obj/machinery/door/airlock/centcom{
 	name = "Chapel";
@@ -39094,21 +39094,21 @@
 /obj/machinery/atmospherics/pipe/manifold/cyan/hidden,
 /obj/structure/lattice,
 /turf/open/space/basic,
-/area/space/nearstation)
+/area/space)
 "bPw" = (
 /obj/machinery/atmospherics/pipe/manifold/cyan/hidden{
 	dir = 1
 	},
 /obj/structure/lattice,
 /turf/open/space/basic,
-/area/space/nearstation)
+/area/space)
 "bPx" = (
 /obj/machinery/atmospherics/pipe/simple/cyan/hidden{
 	dir = 4
 	},
 /obj/structure/lattice,
 /turf/open/space/basic,
-/area/space/nearstation)
+/area/space)
 "bPy" = (
 /obj/machinery/atmospherics/pipe/simple/cyan/hidden{
 	dir = 4
@@ -39116,14 +39116,14 @@
 /obj/structure/lattice,
 /obj/structure/disposalpipe/segment,
 /turf/open/space/basic,
-/area/space/nearstation)
+/area/space)
 "bPz" = (
 /obj/machinery/atmospherics/pipe/simple/cyan/hidden{
 	dir = 9
 	},
 /obj/structure/lattice,
 /turf/open/space/basic,
-/area/space/nearstation)
+/area/space)
 "bPA" = (
 /obj/machinery/portable_atmospherics/canister/air,
 /turf/open/floor/plating,
@@ -39353,7 +39353,7 @@
 	},
 /obj/structure/lattice,
 /turf/open/space,
-/area/space/nearstation)
+/area/space)
 "bQj" = (
 /obj/effect/spawner/structure/window,
 /turf/open/floor/plating,
@@ -39659,14 +39659,14 @@
 	},
 /obj/structure/window/reinforced,
 /turf/open/space,
-/area/space/nearstation)
+/area/space)
 "bQR" = (
 /obj/structure/window/reinforced{
 	dir = 8
 	},
 /obj/structure/window/reinforced,
 /turf/open/space,
-/area/space/nearstation)
+/area/space)
 "bQS" = (
 /obj/structure/table,
 /obj/effect/spawner/lootdrop/maintenance,
@@ -40001,7 +40001,7 @@
 /obj/structure/window/reinforced,
 /obj/structure/lattice,
 /turf/open/space,
-/area/space/nearstation)
+/area/space)
 "bRD" = (
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plating,
@@ -40295,7 +40295,7 @@
 	dir = 8
 	},
 /turf/open/space,
-/area/space/nearstation)
+/area/space)
 "bSo" = (
 /obj/machinery/disposal/bin,
 /obj/structure/disposalpipe/trunk{
@@ -40590,14 +40590,14 @@
 	dir = 8
 	},
 /turf/open/space,
-/area/space/nearstation)
+/area/space)
 "bTa" = (
 /obj/structure/disposalpipe/segment{
 	dir = 6
 	},
 /obj/structure/lattice,
 /turf/open/space,
-/area/space/nearstation)
+/area/space)
 "bTb" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -41017,7 +41017,7 @@
 /obj/structure/disposalpipe/segment,
 /obj/structure/lattice,
 /turf/open/space,
-/area/space/nearstation)
+/area/space)
 "bTX" = (
 /obj/structure/table,
 /obj/item/storage/box/mousetraps,
@@ -41246,7 +41246,7 @@
 	dir = 10
 	},
 /turf/open/space,
-/area/space/nearstation)
+/area/space)
 "bUB" = (
 /obj/docking_port/stationary{
 	dheight = 9;
@@ -41259,7 +41259,7 @@
 	width = 18
 	},
 /turf/open/space,
-/area/space/nearstation)
+/area/space)
 "bUC" = (
 /obj/structure/flora/ausbushes/fernybush,
 /turf/open/floor/plating/asteroid,
@@ -41272,14 +41272,14 @@
 	dir = 6
 	},
 /turf/open/space,
-/area/space/nearstation)
+/area/space)
 "bUE" = (
 /obj/structure/lattice,
 /obj/structure/disposalpipe/segment{
 	dir = 9
 	},
 /turf/open/space,
-/area/space/nearstation)
+/area/space)
 "bUF" = (
 /obj/structure/table,
 /obj/item/stack/cable_coil,
@@ -41610,7 +41610,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/purple/visible,
 /turf/open/space,
-/area/space/nearstation)
+/area/space)
 "bVn" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/siphon/on{
 	dir = 8;
@@ -41628,7 +41628,7 @@
 	dir = 4
 	},
 /turf/open/space/basic,
-/area/space/nearstation)
+/area/space)
 "bVr" = (
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plating/airless,
@@ -41987,7 +41987,7 @@
 /obj/structure/lattice,
 /obj/machinery/atmospherics/pipe/simple/purple/visible,
 /turf/open/space,
-/area/space/nearstation)
+/area/space)
 "bWe" = (
 /obj/machinery/air_sensor{
 	frequency = 1441;
@@ -42354,7 +42354,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/purple/visible,
 /turf/open/space,
-/area/space/nearstation)
+/area/space)
 "bWT" = (
 /obj/machinery/atmospherics/components/unary/outlet_injector/on{
 	dir = 8;
@@ -42872,7 +42872,7 @@
 /obj/machinery/atmospherics/pipe/simple/purple/visible,
 /obj/structure/lattice,
 /turf/open/space/basic,
-/area/space/nearstation)
+/area/space)
 "bYz" = (
 /obj/machinery/door/morgue{
 	name = "Confession Booth"
@@ -43247,12 +43247,12 @@
 /obj/structure/lattice,
 /obj/machinery/atmospherics/pipe/simple/green/visible,
 /turf/open/space,
-/area/space/nearstation)
+/area/space)
 "bZe" = (
 /obj/structure/lattice,
 /obj/machinery/atmospherics/pipe/simple/cyan/visible,
 /turf/open/space,
-/area/space/nearstation)
+/area/space)
 "bZf" = (
 /obj/machinery/power/apc{
 	dir = 8;
@@ -44761,7 +44761,7 @@
 "cdm" = (
 /obj/structure/lattice/catwalk,
 /turf/open/space/basic,
-/area/space/nearstation)
+/area/space)
 "cdo" = (
 /turf/open/floor/carpet,
 /area/chapel/office)
@@ -46084,7 +46084,7 @@
 "chy" = (
 /obj/structure/lattice,
 /turf/open/space,
-/area/space/nearstation)
+/area/space)
 "chz" = (
 /obj/structure/cable/yellow{
 	icon_state = "0-4"
@@ -47258,7 +47258,7 @@
 	width = 18
 	},
 /turf/open/space,
-/area/space/nearstation)
+/area/space)
 "clu" = (
 /obj/machinery/camera{
 	c_tag = "Telecomms External Fore";
@@ -47267,7 +47267,7 @@
 	start_active = 1
 	},
 /turf/open/space,
-/area/space/nearstation)
+/area/space)
 "clv" = (
 /turf/closed/mineral/iron,
 /area/mine/explored{
@@ -47288,7 +47288,7 @@
 	dir = 10
 	},
 /turf/open/space,
-/area/space/nearstation)
+/area/space)
 "clz" = (
 /obj/machinery/door/airlock/external{
 	cyclelinkeddir = 2;
@@ -47647,7 +47647,7 @@
 	network = list("Telecomms")
 	},
 /turf/open/space,
-/area/space/nearstation)
+/area/space)
 "cmu" = (
 /obj/machinery/status_display{
 	pixel_x = -32
@@ -47709,7 +47709,7 @@
 	network = list("Telecomms")
 	},
 /turf/open/space,
-/area/space/nearstation)
+/area/space)
 "cmA" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -47975,7 +47975,7 @@
 	network = list("Telecomms")
 	},
 /turf/open/space,
-/area/space/nearstation)
+/area/space)
 "cnz" = (
 /obj/structure/lattice,
 /obj/machinery/camera/motion{
@@ -47984,7 +47984,7 @@
 	network = list("Telecomms")
 	},
 /turf/open/space,
-/area/space/nearstation)
+/area/space)
 "cnA" = (
 /obj/docking_port/stationary{
 	dheight = 9;
@@ -47997,7 +47997,7 @@
 	width = 18
 	},
 /turf/open/space,
-/area/space/nearstation)
+/area/space)
 "cnC" = (
 /obj/machinery/turretid{
 	control_area = "/area/ai_monitored/turret_protected/aisat_interior";
@@ -48810,7 +48810,7 @@
 	},
 /obj/structure/window/reinforced,
 /turf/open/space/basic,
-/area/space/nearstation)
+/area/space)
 "cqV" = (
 /obj/structure/chair/office/light{
 	dir = 1
@@ -48831,7 +48831,7 @@
 /obj/structure/disposalpipe/segment,
 /obj/structure/lattice,
 /turf/open/space/basic,
-/area/space/nearstation)
+/area/space)
 "crb" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating/airless,
@@ -48842,7 +48842,7 @@
 	dir = 8
 	},
 /turf/open/space/basic,
-/area/space/nearstation)
+/area/space)
 "crg" = (
 /obj/structure/chair/wood/normal,
 /turf/open/floor/plasteel/dark,
@@ -48885,7 +48885,7 @@
 /obj/structure/lattice,
 /obj/structure/disposalpipe/segment,
 /turf/open/space,
-/area/space/nearstation)
+/area/space)
 "crt" = (
 /obj/structure/table/wood/fancy,
 /obj/item/folder,
@@ -48911,7 +48911,7 @@
 	dir = 5
 	},
 /turf/open/space,
-/area/space/nearstation)
+/area/space)
 "crz" = (
 /obj/machinery/door/airlock/external{
 	cyclelinkeddir = 4;
@@ -49030,7 +49030,7 @@
 	dir = 8
 	},
 /turf/open/space/basic,
-/area/space/nearstation)
+/area/space)
 "crS" = (
 /obj/machinery/airalarm{
 	frequency = 1439;
@@ -50303,7 +50303,7 @@
 	layer = 2.9
 	},
 /turf/open/space,
-/area/space/nearstation)
+/area/space)
 "cwO" = (
 /obj/item/device/flashlight/lantern,
 /turf/open/floor/plasteel/dark,
@@ -50314,7 +50314,7 @@
 	layer = 2.9
 	},
 /turf/open/space/basic,
-/area/space/nearstation)
+/area/space)
 "cwS" = (
 /obj/structure/reagent_dispensers/fueltank,
 /turf/open/floor/plating,
@@ -50336,7 +50336,7 @@
 	pixel_y = 1
 	},
 /turf/open/space/basic,
-/area/space/nearstation)
+/area/space)
 "cxh" = (
 /obj/structure/window/reinforced{
 	dir = 1;
@@ -50347,7 +50347,7 @@
 	layer = 2.9
 	},
 /turf/open/space/basic,
-/area/space/nearstation)
+/area/space)
 "cxk" = (
 /obj/structure/window/reinforced{
 	dir = 1;
@@ -50358,7 +50358,7 @@
 	layer = 2.9
 	},
 /turf/open/space/basic,
-/area/space/nearstation)
+/area/space)
 "cxn" = (
 /obj/machinery/newscaster{
 	pixel_x = -32;
@@ -50522,7 +50522,7 @@
 "cyK" = (
 /obj/structure/lattice,
 /turf/open/space/basic,
-/area/space/nearstation)
+/area/space)
 "cyL" = (
 /obj/structure/lattice,
 /obj/structure/lattice,
@@ -51115,7 +51115,7 @@
 	width = 18
 	},
 /turf/open/space/basic,
-/area/space/nearstation)
+/area/space)
 "cBP" = (
 /obj/machinery/smoke_machine,
 /turf/open/floor/plasteel/white,

--- a/_maps/map_files/debug/runtimestation.dmm
+++ b/_maps/map_files/debug/runtimestation.dmm
@@ -5,7 +5,7 @@
 "ab" = (
 /obj/structure/lattice,
 /turf/open/space,
-/area/space/nearstation)
+/area/space)
 "ac" = (
 /turf/open/space,
 /area/space)
@@ -16,14 +16,14 @@
 /obj/structure/lattice,
 /obj/structure/grille,
 /turf/open/space,
-/area/space/nearstation)
+/area/space)
 "af" = (
 /turf/open/floor/plating,
 /area/maintenance/department/bridge)
 "ag" = (
 /obj/structure/lattice,
 /turf/open/space,
-/area/space/nearstation)
+/area/space)
 "ah" = (
 /turf/closed/wall/r_wall,
 /area/engine/atmos)
@@ -56,7 +56,7 @@
 	icon_state = "1-4"
 	},
 /turf/open/space,
-/area/space/nearstation)
+/area/space)
 "ao" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/cable{
@@ -66,7 +66,7 @@
 	icon_state = "2-8"
 	},
 /turf/open/space,
-/area/space/nearstation)
+/area/space)
 "ap" = (
 /obj/machinery/airalarm{
 	frequency = 1439;
@@ -173,14 +173,14 @@
 	icon_state = "2-4"
 	},
 /turf/open/space,
-/area/space/nearstation)
+/area/space)
 "aB" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
 /turf/open/space,
-/area/space/nearstation)
+/area/space)
 "aC" = (
 /obj/machinery/door/airlock,
 /obj/structure/cable{
@@ -281,7 +281,7 @@
 	icon_state = "2-4"
 	},
 /turf/open/space,
-/area/space/nearstation)
+/area/space)
 "aR" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/cable{
@@ -291,7 +291,7 @@
 	icon_state = "1-2"
 	},
 /turf/open/space,
-/area/space/nearstation)
+/area/space)
 "aS" = (
 /obj/structure/table,
 /obj/item/device/flashlight{


### PR DESCRIPTION
Cleans up instances of nearstation being over a space tile, which is always fullbright even when dynamic lighting is enabled via starlight due to how they're handled. Should clear up some overhead.