### PR TITLE
Makes the sloth an actual sloth

### DIFF
--- a/code/modules/mob/living/simple_animal/friendly/sloth.dm
+++ b/code/modules/mob/living/simple_animal/friendly/sloth.dm
@@ -19,7 +19,8 @@
 	melee_damage_upper = 18
 	health = 50
 	maxHealth = 50
-	speed = 2
+	speed = 10
+	glide_size = 2
 
 
 //Cargo Sloth


### PR DESCRIPTION
Glide_size change lowers their tile glide rate to be slow as well.


:cl:
tweak: The sloth no longer suspiciously moves fast when gliding between tiles.
balance: The sloth's movespeed when inhabited by a player has been lowered from once every 1/5 of a second to once every second.
/:cl:
