### PR TITLE
Fix manually-given download objective description

### DIFF
--- a/code/datums/mind.dm
+++ b/code/datums/mind.dm
@@ -869,7 +869,7 @@
 				switch(new_obj_type)
 					if("download")
 						new_objective = new /datum/objective/download
-						new_objective.explanation_text = "Download [target_number] research levels."
+						new_objective.explanation_text = "Download [target_number] research node\s."
 					if("capture")
 						new_objective = new /datum/objective/capture
 						new_objective.explanation_text = "Capture [target_number] lifeforms with an energy net. Live, rare specimens are worth more."


### PR DESCRIPTION
:cl:
spellcheck: Admin-added "download research" objectives are now consistent with automatic ones.
/:cl:

For consistency with: https://github.com/tgstation/tgstation/blob/fb114df6eabe4d7c98acf18885448421dbee9744/code/game/gamemodes/objective.dm#L508-L511