### PR TITLE
Fix name on Mech LMG tech node

### DIFF
--- a/code/modules/research/techweb/all_nodes.dm
+++ b/code/modules/research/techweb/all_nodes.dm
@@ -779,7 +779,7 @@
 
 /datum/techweb_node/mech_lmg
 	id = "mech_lmg"
-	display_name =  "Exosuit Weapon (PBT \"Pacifier\" Mounted Taser)"
+	display_name = "Exosuit Weapon (\"Ultra AC 2\" LMG)"
 	description = "An advanced piece of mech weaponry"
 	prereq_ids = list("adv_mecha", "adv_weaponry", "ballistic_weapons")
 	design_ids = list("mech_lmg")


### PR DESCRIPTION
:cl:
spellcheck: The techweb node for mech LMGs no longer claims to be for mech tasers.
/:cl:

Self-explanatory.