### PR TITLE
RND Console Tweaks

### DIFF
--- a/code/modules/research/departmental_lathe.dm
+++ b/code/modules/research/departmental_lathe.dm
@@ -19,6 +19,7 @@
 	allowed_department_flags = DEPARTMENTAL_FLAG_ALL|DEPARTMENTAL_FLAG_ENGINEERING
 	department_tag = "Engineering"
 	circuit = /obj/item/circuitboard/machine/protolathe/department/engineering
+	console_link = TRUE
 
 /obj/machinery/rnd/protolathe/department/service
 	allowed_department_flags = DEPARTMENTAL_FLAG_ALL|DEPARTMENTAL_FLAG_SERVICE

--- a/code/modules/research/rdconsole.dm
+++ b/code/modules/research/rdconsole.dm
@@ -218,10 +218,8 @@ doesn't have toxins access.
 	var/list/l = list()
 	l += "<h2>Nanotrasen Research and Development</h2>[RDSCREEN_NOBREAK]"
 	l += "<div class='statusDisplay'><b>Connected Technology database: [stored_research == SSresearch.science_tech? "Nanotrasen" : "Third Party"]"
-	l += "Available Points: [stored_research.research_points]"
+	l += "Available Research Points: [stored_research.research_points]"
 	l += "Security protocols: [emagged? "<font color='red'>Disabled</font>" : "<font color='green'>Enabled</font>"]"
-	l += "Design Disk: [d_disk? "<font color='green'>Loaded</font>" : "<font color='red'>Not Loaded</font>"] | \
-	 Technology Disk: [t_disk? "<font color='green'>Loaded</font>" : "<font color='red'>Not Loaded</font>"]</b>"
 	l += "<a href='?src=[REF(src)];switch_screen=[RDSCREEN_MENU]'>Main Menu</a> | <a href='?src=[REF(src)];switch_screen=[back]'>Back</a></div>[RDSCREEN_NOBREAK]"
 	return l
 


### PR DESCRIPTION
:cl: Robustin
fix: The Engineering protolathe will now properly connect to its research console.
tweak: Cleaned up RD console header
/:cl:

Now that the disk choices only appear when a disk is inserted, its redundant to have that information also displayed (and cluttering) the RD console header. 
