### PR TITLE
Greatly increases the Lavaland bombcap.

### DIFF
--- a/code/datums/explosion.dm
+++ b/code/datums/explosion.dm
@@ -1,6 +1,6 @@
 #define EXPLOSION_THROW_SPEED 4
 #define CITYOFCOGS_CAP_MULTIPLIER 0.5
-#define MINING_CAP_MULTIPLIER 3
+#define MINING_CAP_MULTIPLIER 12
 
 GLOBAL_LIST_EMPTY(explosions)
 //Against my better judgement, I will return the explosion datum


### PR DESCRIPTION
A great portion of the lag caused by gigantic, server-killing explosions was due to ore constantly being thrown everywhere.  #33062 should largely solve that issue. I'd prefer to remove the cap entirely but this is a good stepping stone.