### PR TITLE
Cyborg Balance

### DIFF
--- a/code/modules/mob/living/silicon/robot/robot_modules.dm
+++ b/code/modules/mob/living/silicon/robot/robot_modules.dm
@@ -325,7 +325,6 @@
 	basic_modules = list(
 		/obj/item/device/assembly/flash/cyborg,
 		/obj/item/restraints/handcuffs/cable/zipties/cyborg,
-		/obj/item/melee/baton/loaded,
 		/obj/item/gun/energy/disabler/cyborg,
 		/obj/item/clothing/mask/gas/sechailer/cyborg)
 	emag_modules = list(/obj/item/gun/energy/laser/cyborg)

--- a/code/modules/projectiles/ammunition/energy.dm
+++ b/code/modules/projectiles/ammunition/energy.dm
@@ -33,8 +33,10 @@
 /obj/item/ammo_casing/energy/lasergun/old
 	projectile_type = /obj/item/projectile/beam/laser
 	e_cost = 200
-	select_name = "kill"
 
+/obj/item/ammo_casing/energy/laser/cyborg
+	e_cost = 350
+	
 /obj/item/ammo_casing/energy/laser/hos
 	e_cost = 100
 

--- a/code/modules/projectiles/ammunition/energy.dm
+++ b/code/modules/projectiles/ammunition/energy.dm
@@ -142,6 +142,9 @@
 	e_cost = 50
 	fire_sound = 'sound/weapons/taser2.ogg'
 
+/obj/item/ammo_casing/energy/disabler/cyborg
+	e_cost = 500
+
 /obj/item/ammo_casing/energy/plasma
 	projectile_type = /obj/item/projectile/plasma
 	select_name = "plasma burst"

--- a/code/modules/projectiles/ammunition/special.dm
+++ b/code/modules/projectiles/ammunition/special.dm
@@ -88,5 +88,5 @@
 	projectile_type = /obj/item/projectile/bullet/c3d
 	select_name = "spraydown"
 	fire_sound = 'sound/weapons/gunshot_smg.ogg'
-	e_cost = 20
+	e_cost = 125
 	firing_effect_type = /obj/effect/temp_visual/dir_setting/firing_effect

--- a/code/modules/projectiles/guns/energy/laser.dm
+++ b/code/modules/projectiles/guns/energy/laser.dm
@@ -50,7 +50,7 @@
 	can_charge = 0
 	desc = "An energy-based laser gun that draws power from the cyborg's internal energy cell directly. So this is what freedom looks like?"
 	use_cyborg_cell = 1
-	ammo_type = list(/obj/item/ammo_casing/energy/lasergun/cyborg)
+	ammo_type = list(/obj/item/ammo_casing/energy/laser/cyborg)
 
 /obj/item/gun/energy/laser/cyborg/emp_act()
 	return

--- a/code/modules/projectiles/guns/energy/laser.dm
+++ b/code/modules/projectiles/guns/energy/laser.dm
@@ -50,6 +50,7 @@
 	can_charge = 0
 	desc = "An energy-based laser gun that draws power from the cyborg's internal energy cell directly. So this is what freedom looks like?"
 	use_cyborg_cell = 1
+	ammo_type = list(/obj/item/ammo_casing/energy/lasergun/cyborg)
 
 /obj/item/gun/energy/laser/cyborg/emp_act()
 	return

--- a/code/modules/projectiles/guns/energy/stun.dm
+++ b/code/modules/projectiles/guns/energy/stun.dm
@@ -43,4 +43,5 @@
 	desc = "An integrated disabler that draws from a cyborg's power cell. This weapon contains a limiter to prevent the cyborg's power cell from overheating."
 	can_charge = 0
 	use_cyborg_cell = 1
+	ammo_type = list(/obj/item/ammo_casing/energy/disabler/cyborg)
 

--- a/code/modules/projectiles/guns/energy/stun.dm
+++ b/code/modules/projectiles/guns/energy/stun.dm
@@ -43,5 +43,6 @@
 	desc = "An integrated disabler that draws from a cyborg's power cell. This weapon contains a limiter to prevent the cyborg's power cell from overheating."
 	can_charge = 0
 	use_cyborg_cell = 1
+	force = 0 
 	ammo_type = list(/obj/item/ammo_casing/energy/disabler/cyborg)
 


### PR DESCRIPTION
:cl: Robustin
balance: The Syndicate Cyborg LMG now costs 5x more energy to fire.
balance: The Secborg disabler now costs 10x more energy to fire and can longer be used to harm. The Secborg laser now costs 3.5x more energy to fire.
removal:  The Secborg baton has been removed.
/:cl:

Another long overdue change. Currently Syndieborgs can fire over 1,200 rounds before needing to recharge their default cell (it was over 1000% more efficient to shoot your gun to travel through space than it was to use the Ion Thrusters). Secborgs with a high-cap cell (available at roundstart) could fire 300 disabler rounds. 

In addition,  the secborg baton poses a problem. People understand that borgs can flash them with little warning. And people also understand what a borg shooting at them means. Even an officer has to "show" their baton to use it. The secborg baton has no "tell" and with one of the longest stuns in the game it is part of the frustration associated with Secborg strength. Furthermore it also the notorious source of Secborg harm, 15 brute allowed these borgs to quickly and efficiently kill crewmembers when its laws (frequently) allow. 

We already (regrettably) gave flashes a long stun. The secborg can use this in combination with the disabler to detain suspects. This PR also has the effect of removing all sources of harm from an un-hacked Secborg - if it wants to kill people on its own it will have to exercise at least a sliver of creativity. 