### PR TITLE
Fixes a division by zero in humans' ex_act()

### DIFF
--- a/code/modules/mob/living/carbon/human/human_defense.dm
+++ b/code/modules/mob/living/carbon/human/human_defense.dm
@@ -355,7 +355,8 @@
 
 
 /mob/living/carbon/human/ex_act(severity, target, origin)
-
+	if (!severity)
+		return
 	if(origin && istype(origin, /datum/spacevine_mutation) && isvineimmune(src))
 		return
 	..()

--- a/code/modules/mob/living/carbon/human/human_defense.dm
+++ b/code/modules/mob/living/carbon/human/human_defense.dm
@@ -355,11 +355,11 @@
 
 
 /mob/living/carbon/human/ex_act(severity, target, origin)
-	if (!severity)
-		return
 	if(origin && istype(origin, /datum/spacevine_mutation) && isvineimmune(src))
 		return
 	..()
+	if (!severity)
+		return
 	var/b_loss = 0
 	var/f_loss = 0
 	var/bomb_armor = getarmor(null, "bomb")


### PR DESCRIPTION
0 is a valid severity value, and it is safe to shortcircuit as all it does is apply 0 damage and runtime due to division by zero later.

And yes, this actually happens live, round 79468 on Bagil for example.
