### PR TITLE
Techwebs update 1: Departmental lathes/imprinters can now link to research consoles

### DIFF
--- a/code/modules/research/departmental_circuit_imprinter.dm
+++ b/code/modules/research/departmental_circuit_imprinter.dm
@@ -4,10 +4,8 @@
 	icon_state = "circuit_imprinter"
 	container_type = OPENCONTAINER_1
 	circuit = /obj/item/circuitboard/machine/circuit_imprinter/department
-	console_link = FALSE
 	requires_console = FALSE
 
-	var/list/allowed_department_flags = DEPARTMENTAL_FLAG_ALL
 	var/list/datum/design/cached_designs
 	var/list/datum/design/matching_designs
 	var/department_tag = "Unidentified"			//used for material distribution among other things.

--- a/code/modules/research/departmental_lathe.dm
+++ b/code/modules/research/departmental_lathe.dm
@@ -4,10 +4,8 @@
 	icon_state = "protolathe"
 	container_type = OPENCONTAINER_1
 	circuit = /obj/item/circuitboard/machine/protolathe/department
-	console_link = FALSE
 	requires_console = FALSE
 
-	var/list/allowed_department_flags = DEPARTMENTAL_FLAG_ALL
 	var/list/datum/design/cached_designs
 	var/list/datum/design/matching_designs
 	var/department_tag = "Unidentified"			//used for material distribution among other things.

--- a/code/modules/research/rdconsole.dm
+++ b/code/modules/research/rdconsole.dm
@@ -281,6 +281,8 @@ doesn't have toxins access.
 		var/datum/design/D = stored_research.researched_designs[v]
 		if(!(selected_category in D.category)|| !(D.build_type & PROTOLATHE))
 			continue
+		if(!(D.departmental_flags & linked_lathe.allowed_department_flags))
+			continue
 		var/temp_material
 		var/c = 50
 		var/t
@@ -331,6 +333,8 @@ doesn't have toxins access.
 	l += ui_protolathe_header()
 	var/coeff = linked_lathe.efficiency_coeff
 	for(var/datum/design/D in matching_designs)
+		if(!(D.departmental_flags & linked_lathe.allowed_department_flags))
+			continue
 		var/temp_material
 		var/c = 50
 		var/t
@@ -419,6 +423,8 @@ doesn't have toxins access.
 		var/datum/design/D = stored_research.researched_designs[v]
 		if(!(selected_category in D.category) || !(D.build_type & IMPRINTER))
 			continue
+		if(!(D.departmental_flags & linked_imprinter.allowed_department_flags))
+			continue
 		var/temp_materials
 		var/check_materials = TRUE
 
@@ -446,6 +452,8 @@ doesn't have toxins access.
 
 	var/coeff = linked_imprinter.efficiency_coeff
 	for(var/datum/design/D in matching_designs)
+		if(!(D.departmental_flags & linked_imprinter.allowed_department_flags))
+			continue
 		var/temp_materials
 		var/check_materials = TRUE
 		var/all_materials = D.materials + D.reagents_list

--- a/code/modules/research/rdmachines.dm
+++ b/code/modules/research/rdmachines.dm
@@ -1,5 +1,4 @@
 
-
 //All devices that link into the R&D console fall into thise type for easy identification and some shared procs.
 
 
@@ -15,6 +14,7 @@
 	var/shocked = FALSE
 	var/obj/machinery/computer/rdconsole/linked_console
 	var/obj/item/loaded_item = null //the item loaded inside the machine (currently only used by experimentor and destructive analyzer)
+	var/allowed_department_flags = ALL
 
 /obj/machinery/rnd/proc/reset_busy()
 	busy = FALSE


### PR DESCRIPTION
tfw feels bad after promising to start fixing shit about 2 weeks ago and only start fixing shit now...

rdconsoles will only display designs their linked lathe/imprinter **are able to print**.