### PR TITLE
Prevents the PA from being EMP'd

### DIFF
--- a/code/datums/wires/particle_accelerator.dm
+++ b/code/datums/wires/particle_accelerator.dm
@@ -43,3 +43,6 @@
 			C.strength_upper_limit = (mend ? 2 : 3)
 			if(C.strength_upper_limit < C.strength)
 				C.remove_strength()
+
+/datum/wires/particle_accelerator/control_box/emp_pulse() // to prevent singulo from pulsing wires
+	return

--- a/code/modules/power/singularity/particle_accelerator/particle_control.dm
+++ b/code/modules/power/singularity/particle_accelerator/particle_control.dm
@@ -320,9 +320,6 @@
 /obj/machinery/particle_accelerator/control_box/blob_act(obj/structure/blob/B)
 	if(prob(50))
 		qdel(src)
-		
-/obj/machinery/particle_accelerator/control_box/emp_act(severity) // this is to stop the singulo fucking with the PA.
-	return
 
 #undef PA_CONSTRUCTION_UNSECURED
 #undef PA_CONSTRUCTION_UNWIRED

--- a/code/modules/power/singularity/particle_accelerator/particle_control.dm
+++ b/code/modules/power/singularity/particle_accelerator/particle_control.dm
@@ -320,6 +320,9 @@
 /obj/machinery/particle_accelerator/control_box/blob_act(obj/structure/blob/B)
 	if(prob(50))
 		qdel(src)
+		
+/obj/machinery/particle_accelerator/control_box/emp_act(severity) // this is to stop the singulo fucking with the PA.
+	return
 
 #undef PA_CONSTRUCTION_UNSECURED
 #undef PA_CONSTRUCTION_UNWIRED


### PR DESCRIPTION
:cl: Frozenguy5
tweak: The Particle Accelerator's wires can no longer be EMP'd
/:cl:

Fixes #32413

note for hippiestation, tag me on discord if this gets merged and mirrored to your repo.