### PR TITLE
[Metastation] Removes window on ORM and the spare ORM

### DIFF
--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -26555,7 +26555,6 @@
 /obj/structure/extinguisher_cabinet{
 	pixel_x = -27
 	},
-/obj/machinery/mineral/ore_redemption,
 /turf/open/floor/plasteel/brown{
 	dir = 8
 	},

--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -30945,8 +30945,7 @@
 /turf/open/floor/plating,
 /area/quartermaster/sorting)
 "bmh" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/mineral/ore_redemption,
+/obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plasteel/dark,
 /area/quartermaster/office)
 "bmi" = (

--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -30947,7 +30947,6 @@
 "bmh" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/mineral/ore_redemption,
-/obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plasteel/dark,
 /area/quartermaster/office)
 "bmi" = (

--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -30945,7 +30945,8 @@
 /turf/open/floor/plating,
 /area/quartermaster/sorting)
 "bmh" = (
-/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/door/firedoor,
+/obj/machinery/mineral/ore_redemption,
 /turf/open/floor/plasteel/dark,
 /area/quartermaster/office)
 "bmi" = (


### PR DESCRIPTION
There's an ORM on Metastation encased in a window. It can't be used without removing the window. This PR removes that window.