### PR TITLE
Revolutionaries can now see deconversion message regardless of status

### DIFF
--- a/code/datums/antagonists/revolution.dm
+++ b/code/datums/antagonists/revolution.dm
@@ -134,11 +134,11 @@
 				
 /datum/antagonist/rev/farewell()
 	if(ishuman(owner.current))
-		owner.current.visible_message("[owner.current] looks like they just remembered their real allegiance!", \
-				"<span class='userdanger'><FONT size = 3>You are no longer a brainwashed revolutionary! Your memory is hazy from the time you were a rebel...the only thing you remember is the name of the one who brainwashed you...</FONT></span>")
+		owner.current.visible_message("[owner.current] looks like they just remembered their real allegiance!")
+		to_chat(owner, "<span class='userdanger'><FONT size = 3>You are no longer a brainwashed revolutionary! Your memory is hazy from the time you were a rebel...the only thing you remember is the name of the one who brainwashed you...</FONT></span>")
 	else if(issilicon(owner.current))
-		owner.current.visible_message("The frame beeps contentedly, purging the hostile memory engram from the MMI before initalizing it.", \
-				"<span class='userdanger'><FONT size = 3>The frame's firmware detects and deletes your neural reprogramming! You remember nothing but the name of the one who flashed you.</FONT></span>")
+		owner.current.visible_message("The frame beeps contentedly, purging the hostile memory engram from the MMI before initalizing it.")
+		to_chat(owner, "<span class='userdanger'><FONT size = 3>The frame's firmware detects and deletes your neural reprogramming! You remember nothing but the name of the one who flashed you.</FONT></span>")
 
 /datum/antagonist/rev/proc/remove_revolutionary(borged, deconverter)
 	log_attack("[owner.current] (Key: [key_name(owner.current)]) has been deconverted from the revolution by [deconverter] (Key: [key_name(deconverter)])!")


### PR DESCRIPTION
The issue here is that the message was getting the visible_message checks so they couldn't """see""" themselves get deconverted while in crit.

Fixes #33201