### PR TITLE
Both cult revive runes will now replace braindead/AFK cultists

### DIFF
--- a/code/game/gamemodes/clock_cult/clock_effects/clock_sigils.dm
+++ b/code/game/gamemodes/clock_cult/clock_effects/clock_sigils.dm
@@ -323,6 +323,20 @@
 					L.visible_message("<span class='warning'>[L] suddenly gets back up, [L.p_their()] body dripping blue ichor!</span>", "<span class='inathneq'>\"[text2ratvar("You will be okay, child.")]\"</span>")
 					GLOB.clockwork_vitality -= revival_cost
 				break
+			if(!L.client || L.client.is_afk())
+				set waitfor = FALSE
+				var/list/mob/dead/observer/candidates = pollCandidatesForMob("Do you want to play as a [name], an inactive clock cultist?", "[name]", null, job_rank, 50, owner.current)
+				var/mob/dead/observer/theghost = null
+				if(candidates.len)
+					to_chat(owner, "Your physical form has been taken over by another soul due to your inactivity! Ahelp if you wish to regain your form!")
+					message_admins("[key_name_admin(theghost)] has taken control of ([key_name_admin(owner.current)]) to replace an inactive clock cultist.")
+					owner.current.ghostize(0)
+					owner.current.key = theghost.key
+					var/obj/effect/temp_visual/ratvar/sigil/vitality/V = new /obj/effect/temp_visual/ratvar/sigil/vitality(get_turf(src))
+					animate(V, alpha = 0, transform = matrix()*2, time = 8)
+					playsound(L, 'sound/magic/staff_healing.ogg', 50, 1)
+					L.visible_message("<span class='warning'>[L]'s eyes suddenly open wide, gleaming with renewed vigor for the cause!</span>", "<span class='inathneq'>\"[text2ratvar("Awaken!")]\"</span>")
+					break
 			var/vitality_for_cycle = 3
 			if(!GLOB.ratvar_awakens)
 				if(L.stat == CONSCIOUS)

--- a/code/game/gamemodes/clock_cult/clock_effects/clock_sigils.dm
+++ b/code/game/gamemodes/clock_cult/clock_effects/clock_sigils.dm
@@ -310,7 +310,7 @@
 		else
 			if(L.stat == DEAD)
 				var/revival_cost = revive_cost
-				if(GLOB.ratvar_awakens)
+				if(GLOB.ratvar_awakens || L.suiciding) // No cost if Ratvar is summoned or if you're reviving a convert who suicided
 					revival_cost = 0
 				var/mob/dead/observer/ghost = L.get_ghost(TRUE)
 				if(GLOB.clockwork_vitality >= revival_cost && (ghost || (L.mind && L.mind.active)))

--- a/code/game/gamemodes/clock_cult/clock_effects/clock_sigils.dm
+++ b/code/game/gamemodes/clock_cult/clock_effects/clock_sigils.dm
@@ -325,13 +325,13 @@
 				break
 			if(!L.client || L.client.is_afk())
 				set waitfor = FALSE
-				var/list/mob/dead/observer/candidates = pollCandidatesForMob("Do you want to play as a [name], an inactive clock cultist?", "[name]", null, job_rank, 50, owner.current)
+				var/list/mob/dead/observer/candidates = pollCandidatesForMob("Do you want to play as a [L.name], an inactive clock cultist?", "[name]", null, "Clock Cultist", 50, L)
 				var/mob/dead/observer/theghost = null
 				if(candidates.len)
-					to_chat(owner, "Your physical form has been taken over by another soul due to your inactivity! Ahelp if you wish to regain your form!")
-					message_admins("[key_name_admin(theghost)] has taken control of ([key_name_admin(owner.current)]) to replace an inactive clock cultist.")
-					owner.current.ghostize(0)
-					owner.current.key = theghost.key
+					to_chat(L, "Your physical form has been taken over by another soul due to your inactivity! Ahelp if you wish to regain your form!")
+					message_admins("[key_name_admin(theghost)] has taken control of ([key_name_admin(L)]) to replace an inactive clock cultist.")
+					L.ghostize(0)
+					L.key = theghost.key
 					var/obj/effect/temp_visual/ratvar/sigil/vitality/V = new /obj/effect/temp_visual/ratvar/sigil/vitality(get_turf(src))
 					animate(V, alpha = 0, transform = matrix()*2, time = 8)
 					playsound(L, 'sound/magic/staff_healing.ogg', 50, 1)

--- a/code/game/gamemodes/cult/runes.dm
+++ b/code/game/gamemodes/cult/runes.dm
@@ -497,10 +497,10 @@ structure_check() searches for nearby cultist structures required for the invoca
 			message_admins("[key_name_admin(user)] erased a Narsie rune with a null rod")
 			..()
 
-//Rite of Resurrection: Requires the corpse of a cultist and that there have been less revives than the number of people GLOB.sacrificed
+//Rite of Resurrection: Requires a dead or inactive cultist. When reviving the dead, you can only perform one revival for every sacrifice your cult has carried out.
 /obj/effect/rune/raise_dead
-	cultist_name = "Resurrect Cultist"
-	cultist_desc = "requires the corpse of a cultist placed upon the rune. Provided there have been sufficient sacrifices, they will be revived."
+	cultist_name = "Revive Cultist"
+	cultist_desc = "requires a dead, mindless, or inactive cultist placed upon the rune. Provided there have been sufficient sacrifices, they will be given a new life."
 	invocation = "Pasnar val'keriam usinar. Savrae ines amutan. Yam'toth remium il'tarat!" //Depends on the name of the user - see below
 	icon_state = "1"
 	color = RUNE_COLOR_MEDIUMRED
@@ -521,16 +521,11 @@ structure_check() searches for nearby cultist structures required for the invoca
 		return
 	rune_in_use = TRUE
 	for(var/mob/living/M in T.contents)
-		if(iscultist(M) && M.stat == DEAD)
+		if(iscultist(M) && (M.stat == DEAD || !M.client || M.client.is_afk())
 			potential_revive_mobs |= M
 	if(!potential_revive_mobs.len)
 		to_chat(user, "<span class='cultitalic'>There are no dead cultists on the rune!</span>")
-		log_game("Raise Dead rune failed - no corpses to revive")
-		fail_invoke()
-		rune_in_use = FALSE
-		return
-	if(LAZYLEN(GLOB.sacrificed) <= revives_used)
-		to_chat(user, "<span class='warning'>You have sacrificed too few people to revive a cultist!</span>")
+		log_game("Raise Dead rune failed - no cultists to revive")
 		fail_invoke()
 		rune_in_use = FALSE
 		return
@@ -546,9 +541,25 @@ structure_check() searches for nearby cultist structures required for the invoca
 	else
 		invocation = initial(invocation)
 	..()
-	revives_used++
-	mob_to_revive.revive(1, 1) //This does remove disabilities and such, but the rune might actually see some use because of it!
-	mob_to_revive.grab_ghost()
+	if(mob_to_revive.stat == DEAD)
+		if(LAZYLEN(GLOB.sacrificed) <= revives_used)
+			to_chat(user, "<span class='warning'>Your cult must carry out another sacrifice before it can revive a cultist!</span>")
+			fail_invoke()
+			rune_in_use = FALSE
+			return
+		revives_used++
+		mob_to_revive.revive(1, 1) //This does remove disabilities and such, but the rune might actually see some use because of it!
+		mob_to_revive.grab_ghost()
+	else
+		set waitfor = FALSE
+		var/list/mob/dead/observer/candidates = pollCandidatesForMob("Do you want to play as a [name], an inactive blood cultist?", "[name]", null, job_rank, 50, owner.current)
+		var/mob/dead/observer/theghost = null
+		if(candidates.len)
+			theghost = pick(candidates)
+			to_chat(owner, "Your physical form has been taken over by another soul! Appeal your job ban if you want to avoid this in the future!")
+			message_admins("[key_name_admin(theghost)] has taken control of ([key_name_admin(owner.current)]) to replace an AFK player.")
+			owner.current.ghostize(0)
+			owner.current.key = theghost.key
 	to_chat(mob_to_revive, "<span class='cultlarge'>\"PASNAR SAVRAE YAM'TOTH. Arise.\"</span>")
 	mob_to_revive.visible_message("<span class='warning'>[mob_to_revive] draws in a huge breath, red light shining from [mob_to_revive.p_their()] eyes.</span>", \
 								  "<span class='cultlarge'>You awaken suddenly from the void. You're alive!</span>")

--- a/code/game/gamemodes/cult/runes.dm
+++ b/code/game/gamemodes/cult/runes.dm
@@ -556,7 +556,7 @@ structure_check() searches for nearby cultist structures required for the invoca
 		var/mob/dead/observer/theghost = null
 		if(candidates.len)
 			theghost = pick(candidates)
-			to_chat(owner, "Your physical form has been taken over by another soul! Appeal your job ban if you want to avoid this in the future!")
+			to_chat(owner, "Your physical form has been taken over by another soul due to your inactivity! Ahelp if you wish to regain your form.")
 			message_admins("[key_name_admin(theghost)] has taken control of ([key_name_admin(owner.current)]) to replace an AFK player.")
 			owner.current.ghostize(0)
 			owner.current.key = theghost.key

--- a/code/game/gamemodes/cult/runes.dm
+++ b/code/game/gamemodes/cult/runes.dm
@@ -521,7 +521,7 @@ structure_check() searches for nearby cultist structures required for the invoca
 		return
 	rune_in_use = TRUE
 	for(var/mob/living/M in T.contents)
-		if(iscultist(M) && (M.stat == DEAD || !M.client || M.client.is_afk())
+		if(iscultist(M) && (M.stat == DEAD || !M.client || M.client.is_afk()))
 			potential_revive_mobs |= M
 	if(!potential_revive_mobs.len)
 		to_chat(user, "<span class='cultitalic'>There are no dead cultists on the rune!</span>")

--- a/code/game/gamemodes/cult/runes.dm
+++ b/code/game/gamemodes/cult/runes.dm
@@ -550,16 +550,16 @@ structure_check() searches for nearby cultist structures required for the invoca
 		revives_used++
 		mob_to_revive.revive(1, 1) //This does remove disabilities and such, but the rune might actually see some use because of it!
 		mob_to_revive.grab_ghost()
-	else
+	else if(!mob_to_revive.client || mob_to_revive.client.is_afk())
 		set waitfor = FALSE
-		var/list/mob/dead/observer/candidates = pollCandidatesForMob("Do you want to play as a [name], an inactive blood cultist?", "[name]", null, job_rank, 50, owner.current)
+		var/list/mob/dead/observer/candidates = pollCandidatesForMob("Do you want to play as a [mob_to_revive.name], an inactive blood cultist?", "[name]", null, mob_to_revive.mind.job_rank, 50, mob_to_revive)
 		var/mob/dead/observer/theghost = null
 		if(candidates.len)
 			theghost = pick(candidates)
-			to_chat(owner, "Your physical form has been taken over by another soul due to your inactivity! Ahelp if you wish to regain your form.")
-			message_admins("[key_name_admin(theghost)] has taken control of ([key_name_admin(owner.current)]) to replace an AFK player.")
-			owner.current.ghostize(0)
-			owner.current.key = theghost.key
+			to_chat(mob_to_revive.mind, "Your physical form has been taken over by another soul due to your inactivity! Ahelp if you wish to regain your form.")
+			message_admins("[key_name_admin(theghost)] has taken control of ([key_name_admin(mob_to_revive)]) to replace an AFK player.")
+			mob_to_revive.ghostize(0)
+			mob_to_revive.key = theghost.key
 	to_chat(mob_to_revive, "<span class='cultlarge'>\"PASNAR SAVRAE YAM'TOTH. Arise.\"</span>")
 	mob_to_revive.visible_message("<span class='warning'>[mob_to_revive] draws in a huge breath, red light shining from [mob_to_revive.p_their()] eyes.</span>", \
 								  "<span class='cultlarge'>You awaken suddenly from the void. You're alive!</span>")

--- a/code/game/gamemodes/cult/runes.dm
+++ b/code/game/gamemodes/cult/runes.dm
@@ -552,7 +552,7 @@ structure_check() searches for nearby cultist structures required for the invoca
 		mob_to_revive.grab_ghost()
 	else if(!mob_to_revive.client || mob_to_revive.client.is_afk())
 		set waitfor = FALSE
-		var/list/mob/dead/observer/candidates = pollCandidatesForMob("Do you want to play as a [mob_to_revive.name], an inactive blood cultist?", "[name]", null, mob_to_revive.mind.job_rank, 50, mob_to_revive)
+		var/list/mob/dead/observer/candidates = pollCandidatesForMob("Do you want to play as a [mob_to_revive.name], an inactive blood cultist?", "[name]", null, "Blood Cultist", 50, mob_to_revive)
 		var/mob/dead/observer/theghost = null
 		if(candidates.len)
 			theghost = pick(candidates)


### PR DESCRIPTION
:cl: Robustin
add: The blood cult revive rune will now replace the souls of braindead or inactive cultists/constructs when properly invoked. These "revivals" will not count toward the revive limit.
add: The clock cult healing rune will now replace the souls of braindead or inactive cultists/constructs when left atop the rune. These "revivals" will not drain the rune's energy. 
/:cl:

Thinking of creative ways to improve the cults without provoking balance memes. Both cults have long suffered when you risk life and limb to pull off a conversion only to find out your victim ragequit or went AFK because they didnt want to be an artificer. Or sometimes shit happens.

Either way everyone understood the frustration of seeing their conversion go to waste. This gives the cults an IC-solution while taking the burden off admins and players alike.
