### PR TITLE
Adds Fungal TB to disease outbreak event

### DIFF
--- a/code/modules/events/disease_outbreak.dm
+++ b/code/modules/events/disease_outbreak.dm
@@ -27,7 +27,7 @@
 		advanced_virus = TRUE
 
 	if(!virus_type && !advanced_virus)
-		virus_type = pick(/datum/disease/dnaspread, /datum/disease/advance/flu, /datum/disease/advance/cold, /datum/disease/brainrot, /datum/disease/magnitis)
+		virus_type = pick(/datum/disease/dnaspread, /datum/disease/advance/flu, /datum/disease/advance/cold, /datum/disease/brainrot, /datum/disease/magnitis, /datum/disease/tuberculosis)
 
 	for(var/mob/living/carbon/human/H in shuffle(GLOB.alive_mob_list))
 		var/turf/T = get_turf(H)


### PR DESCRIPTION
:cl: 
Reports indicate that an explosion at a secret Syndicate bioweapons lab has spread a deadly pathogen throughout a nearby population center. Be on the lookout for outbreaks!
/:cl:

Reasons:
1: As-is, fungal tb is ONLY from nuke ops. If fungal tb appears, you know immediately that there are ops, preventing you from using it for any sort of stealth ops.
2; Disease outbreak is fairly rare, and most of the diseases on the list are tame. A rare but deadly outbreak is a nice change of pace from "oh no, i'm coughing."