### PR TITLE
Crash to timers and INFINITY check to beams.

### DIFF
--- a/code/controllers/subsystem/timer.dm
+++ b/code/controllers/subsystem/timer.dm
@@ -357,7 +357,7 @@ SUBSYSTEM_DEF(timer)
 
 	wait = max(wait, 0)
 
-	if(wait == INFINITY)
+	if(wait >= INFINITY)
 		CRASH("Attempted to create timer with INFINITY delay")
 
 	var/hash

--- a/code/controllers/subsystem/timer.dm
+++ b/code/controllers/subsystem/timer.dm
@@ -357,6 +357,9 @@ SUBSYSTEM_DEF(timer)
 
 	wait = max(wait, 0)
 
+	if(wait == INFINITY)
+		CRASH("Attempted to create timer with INFINITY delay")
+
 	var/hash
 
 	if (flags & TIMER_UNIQUE)

--- a/code/datums/beam.dm
+++ b/code/datums/beam.dm
@@ -29,7 +29,8 @@
 	icon = beam_icon
 	icon_state = beam_icon_state
 	beam_type = btype
-	addtimer(CALLBACK(src,.proc/End), time)
+	if(time != INFINITY)
+		addtimer(CALLBACK(src,.proc/End), time)
 
 /datum/beam/proc/Start()
 	Draw()

--- a/code/datums/beam.dm
+++ b/code/datums/beam.dm
@@ -29,7 +29,7 @@
 	icon = beam_icon
 	icon_state = beam_icon_state
 	beam_type = btype
-	if(time >= INFINITY)
+	if(time < INFINITY)
 		addtimer(CALLBACK(src,.proc/End), time)
 
 /datum/beam/proc/Start()

--- a/code/datums/beam.dm
+++ b/code/datums/beam.dm
@@ -29,7 +29,7 @@
 	icon = beam_icon
 	icon_state = beam_icon_state
 	beam_type = btype
-	if(time != INFINITY)
+	if(time >= INFINITY)
 		addtimer(CALLBACK(src,.proc/End), time)
 
 /datum/beam/proc/Start()


### PR DESCRIPTION
Added `crash` to addtimer so it wont create timers with INFINITY time.
Added INFINITY time check to beam creation, so it wont try to create INFINITY time timer.

Cyberboss and Antur told me on IRC that INFINITY time timers is misuse, and it's good to crash if someone tries to use it (alternative is to add support for INFINITY time, simply don't add timer with such time, but it seems it's bad solution).