### PR TITLE
SendSignal optimization

### DIFF
--- a/code/datums/components/README.md
+++ b/code/datums/components/README.md
@@ -34,7 +34,7 @@ Stands have a lot of procs which mimic mob procs. Rather than inserting hooks fo
     * Lazy associated list of type -> component/list of components.
 1. `/datum/component/var/enabled` (protected, boolean)
     * If the component is enabled. If not, it will not react to signals
-    * `TRUE` by default
+    * `FALSE` by default, set to `TRUE` when a signal is registered
 1. `/datum/component/var/dupe_mode` (protected, enum)
     * How duplicate component types are handled when added to the datum.
         * `COMPONENT_DUPE_HIGHLANDER` (default): Old component will be deleted, new component will first have `/datum/component/proc/InheritComponent(datum/component/old, FALSE)` on it

--- a/code/datums/components/_component.dm
+++ b/code/datums/components/_component.dm
@@ -175,6 +175,8 @@
 		if(!C.enabled)
 			return NONE
 		var/datum/callback/CB = C.signal_procs[sigtype]
+		if(!CB)
+			return NONE
 		. = CB.InvokeAsync(arglist(arguments))
 		if(. & COMPONENT_ACTIVATED)
 			ComponentActivated(C)
@@ -186,6 +188,8 @@
 			if(!C.enabled)
 				continue
 			var/datum/callback/CB = C.signal_procs[sigtype]
+			if(!CB)
+				continue
 			var/retval = CB.InvokeAsync(arglist(arguments))
 			. |= retval
 			if(retval & COMPONENT_ACTIVATED)

--- a/code/datums/components/_component.dm
+++ b/code/datums/components/_component.dm
@@ -1,5 +1,5 @@
 /datum/component
-	var/enabled = TRUE
+	var/enabled = FALSE
 	var/dupe_mode = COMPONENT_DUPE_HIGHLANDER
 	var/dupe_type
 	var/list/signal_procs
@@ -133,6 +133,8 @@
 		if(!istype(proc_or_callback, /datum/callback)) //if it wasnt a callback before, it is now
 			proc_or_callback = CALLBACK(src, proc_or_callback)
 		procs[sig_type] = proc_or_callback
+	
+	enabled = TRUE
 
 /datum/component/proc/InheritComponent(datum/component/C, i_am_original)
 	return
@@ -172,10 +174,7 @@
 		var/datum/component/C = target
 		if(!C.enabled)
 			return NONE
-		var/list/sps = C.signal_procs
-		var/datum/callback/CB = LAZYACCESS(sps, sigtype)
-		if(!CB)
-			return NONE
+		var/datum/callback/CB = C.signal_procs[sigtype]
 		. = CB.InvokeAsync(arglist(arguments))
 		if(. & COMPONENT_ACTIVATED)
 			ComponentActivated(C)
@@ -186,10 +185,7 @@
 			var/datum/component/C = I
 			if(!C.enabled)
 				continue
-			var/list/sps = C.signal_procs
-			var/datum/callback/CB = LAZYACCESS(sps, sigtype)
-			if(!CB)
-				continue
+			var/datum/callback/CB = C.signal_procs[sigtype]
 			var/retval = CB.InvokeAsync(arglist(arguments))
 			. |= retval
 			if(retval & COMPONENT_ACTIVATED)


### PR DESCRIPTION
Just don't set enabled until we actually register for a signal. Then we don't need to lazy access the signal procs