### PR TITLE
Makes silicon chat more visible

### DIFF
--- a/code/modules/goonchat/browserassets/css/browserOutput.css
+++ b/code/modules/goonchat/browserassets/css/browserOutput.css
@@ -253,6 +253,9 @@ em						{font-style: normal;	font-weight: bold;}
 
 .say					{}
 .deadsay				{color: #5c00e6;}
+.binarysay    			{color: #20c20e; background-color: #000000; display: block;}
+.binarysay a  			{color: #00ff00;}
+.binarysay a:active, .binarysay a:visited {color: #88ff88;}
 .radio					{color: #008000;}
 .sciradio				{color: #993399;}
 .comradio				{color: #948f02;}

--- a/code/modules/mob/living/silicon/say.dm
+++ b/code/modules/mob/living/silicon/say.dm
@@ -10,11 +10,11 @@
 		var/mob/living/silicon/S = src
 		desig = trim_left(S.designation + " " + S.job)
 	var/message_a = say_quote(message, get_spans())
-	var/rendered = "<i><span class='game say'>Robotic Talk, <span class='name'>[name]</span> <span class='message'>[message_a]</span></span></i>"
+	var/rendered = "<span class='binarysay'>Robotic Talk, <span class='name'>[name]</span> <span class='message'>[message_a]</span></span>"
 	for(var/mob/M in GLOB.player_list)
 		if(M.binarycheck())
 			if(isAI(M))
-				var/renderedAI = "<i><span class='game say'>Robotic Talk, <a href='?src=[REF(M)];track=[html_encode(name)]'><span class='name'>[name] ([desig])</span></a> <span class='message'>[message_a]</span></span></i>"
+				var/renderedAI = "<span class='binarysay'>Robotic Talk, <a href='?src=[REF(M)];track=[html_encode(name)]'><span class='name'>[name] ([desig])</span></a> <span class='message'>[message_a]</span></span>"
 				to_chat(M, renderedAI)
 			else
 				to_chat(M, rendered)

--- a/interface/stylesheet.dm
+++ b/interface/stylesheet.dm
@@ -36,6 +36,9 @@ em						{font-style: normal;	font-weight: bold;}
 
 .say					{}
 .deadsay				{color: #5c00e6;}
+.binarysay    			{color: #20c20e; background-color: #000000; display: block;}
+.binarysay a  			{color: #00ff00;}
+.binarysay a:active, .binarysay a:visited {color: #88ff88;}
 .radio					{color: #008000;}
 .sciradio				{color: #993399;}
 .comradio				{color: #948f02;}


### PR DESCRIPTION
[Changelogs]:
before: 
![2uiqzsd 1](https://user-images.githubusercontent.com/17237624/33518420-18caae40-d795-11e7-8a47-348ac872812a.png)
after(went with Alek's suggestion): 
![dreamseeker_2017-12-02_19-04-36](https://camo.githubusercontent.com/39a1ea1727165b731ff211e458f09c2dcd4256be/68747470733a2f2f692e6779617a6f2e636f6d2f66623238323764343564303832646639653033336662363663643339356264642e706e67)

:cl: Dax Dupont & Alek2ander
tweak: Binary chat messages been made more visible.
/:cl:

[why]: Reasons are here: https://tgstation13.org/phpBB/viewtopic.php?f=9&t=14181
tl;dr borgs often miss commands since it's way too similar.

