### PR TITLE
Plasma statues get fixed

### DIFF
--- a/code/game/objects/structures/statues.dm
+++ b/code/game/objects/structures/statues.dm
@@ -178,7 +178,7 @@
 		return ..()
 
 /obj/structure/statue/plasma/proc/PlasmaBurn(exposed_temperature)
-	atmos_spawn_air("plasma=oreAmount*10;TEMP=[exposed_temperature]")
+	atmos_spawn_air("plasma=[oreAmount*10];TEMP=[exposed_temperature]")
 	deconstruct(FALSE)
 
 /obj/structure/statue/plasma/proc/ignite(exposed_temperature)

--- a/code/game/objects/structures/statues.dm
+++ b/code/game/objects/structures/statues.dm
@@ -177,8 +177,8 @@
 	else
 		return ..()
 
-/obj/structure/statue/plasma/proc/PlasmaBurn()
-	atmos_spawn_air("plasma=400;TEMP=1000")
+/obj/structure/statue/plasma/proc/PlasmaBurn(exposed_temperature)
+	atmos_spawn_air("plasma=100;TEMP=[exposed_temperature]")
 	deconstruct(FALSE)
 
 /obj/structure/statue/plasma/proc/ignite(exposed_temperature)

--- a/code/game/objects/structures/statues.dm
+++ b/code/game/objects/structures/statues.dm
@@ -178,7 +178,7 @@
 		return ..()
 
 /obj/structure/statue/plasma/proc/PlasmaBurn(exposed_temperature)
-	atmos_spawn_air("plasma=100;TEMP=[exposed_temperature]")
+	atmos_spawn_air("plasma=oreAmount*10;TEMP=[exposed_temperature]")
 	deconstruct(FALSE)
 
 /obj/structure/statue/plasma/proc/ignite(exposed_temperature)


### PR DESCRIPTION
:cl: Robustin
tweak: Igniting plasma statues no longer ignores ignition temperature and only creates as much plasma as was used in its creation. 
/:cl:

As a totally unintended side effect plasma statues will no longer automatically create lethal temperatures and will only spawn plasma gas proportional to the amount of plasma used in its creation (approx. 1/8th of the current amount). 
