### PR TITLE
Declaring war as clock cult causes cultists to glow the entire round

### DIFF
--- a/code/datums/antagonists/datum_clockcult.dm
+++ b/code/datums/antagonists/datum_clockcult.dm
@@ -117,7 +117,7 @@
 	hierophant_network.Grant(current)
 	current.throw_alert("clockinfo", /obj/screen/alert/clockwork/infodump)
 	var/obj/structure/destructible/clockwork/massive/celestial_gateway/G = GLOB.ark_of_the_clockwork_justiciar
-	if(G.active && ishuman(current))
+	if((G.active || GLOB.ratvar_approaches) && ishuman(current))
 		current.add_overlay(mutable_appearance('icons/effects/genetics.dmi', "servitude", -MUTATIONS_LAYER))
 
 /datum/antagonist/clockcult/remove_innate_effects(mob/living/mob_override)

--- a/code/game/gamemodes/clock_cult/clock_structures/heralds_beacon.dm
+++ b/code/game/gamemodes/clock_cult/clock_structures/heralds_beacon.dm
@@ -104,6 +104,7 @@
 		if(is_servant_of_ratvar(H))
 			to_chat(H, "<span class='bold alloy'>The beacon's power warps your body into a clockwork form! You are now immune to many hazards, and your body is more robust against damage!</span>")
 			H.set_species(/datum/species/golem/clockwork/no_scrap)
+			H.add_overlay(mutable_appearance('icons/effects/genetics.dmi', "servitude", -MUTATIONS_LAYER))
 	SSshuttle.registerHostileEnvironment(GLOB.ark_of_the_clockwork_justiciar) //no leaving when we need to purge you, heretics
 	var/obj/structure/destructible/clockwork/massive/celestial_gateway/G = GLOB.ark_of_the_clockwork_justiciar
 	G.grace_period = FALSE //no grace period if we've declared war


### PR DESCRIPTION
:cl: Kor
add: Declaring war as clock cult causes cultists to glow the entire round.
/:cl:

The yellow aura they usually gain during the siege phase will apply the whole round.

Why: War ops declaration makes sense, as the crew usually does not have prep time for dealing with nuke ops. The entire clock cult mode is built around 40 minutes of prep time that the crew are going to get either way (and are likely going to be aware of you within ten minutes anyway) so declaration was a no brainer.

This change means you really have to toss stealth out the window in exchange for your power. Much harder choice, I think