### PR TITLE
Slime Blueprint Change

### DIFF
--- a/code/game/area/Space_Station_13_areas.dm
+++ b/code/game/area/Space_Station_13_areas.dm
@@ -171,6 +171,7 @@ NOTE: there are two lists of areas in the end of this file: centcom and station 
 /area/maintenance/department/science/xenobiology
 	name = "Xenobiology Maintenance"
 	icon_state = "xenomaint"
+	xenobiology_compatible = TRUE
 
 
 //Maintenance - Generic

--- a/code/game/area/areas.dm
+++ b/code/game/area/areas.dm
@@ -61,6 +61,7 @@
 	var/list/cameras
 	var/list/firealarms
 	var/firedoors_last_closed_on = 0
+	var/xenobiology_compatible = FALSE //Can the Xenobio management console transverse this area by default?
 
 /*Adding a wizard area teleport list because motherfucking lag -- Urist*/
 /*I am far too lazy to make it a proper list of areas so I'll just make it run the usual telepot routine at the start of the game*/

--- a/code/modules/research/xenobiology/xenobio_camera.dm
+++ b/code/modules/research/xenobiology/xenobio_camera.dm
@@ -12,7 +12,7 @@
 
 /mob/camera/aiEye/remote/xenobio/setLoc(var/t)
 	var/area/new_area = get_area(t)
-	if(new_area && new_area.name == allowed_area || istype(new_area, /area/science/xenobiology ))
+	if(new_area && new_area.name == allowed_area || new_area && new_area.xenobiology_compatible)
 		return ..()
 	else
 		return

--- a/code/modules/research/xenobiology/xenobiology.dm
+++ b/code/modules/research/xenobiology/xenobiology.dm
@@ -503,14 +503,14 @@
 
 /obj/item/areaeditor/blueprints/slime
 	name = "cerulean prints"
-	desc = "A one use yet of blueprints made of jelly like organic material. Renaming an area to 'Xenobiology Lab' will extend the reach of the management console."
+	desc = "A one use yet of blueprints made of jelly like organic material. Extends the reach of the management console."
 	color = "#2956B2"
 
 /obj/item/areaeditor/blueprints/slime/edit_area()
-	var/success = ..()
+	..()
 	var/area/A = get_area(src)
-	if(success)
-		for(var/turf/T in A)
-			T.remove_atom_colour(WASHABLE_COLOUR_PRIORITY)
-			T.add_atom_colour("#2956B2", FIXED_COLOUR_PRIORITY)
-		qdel(src)
+	for(var/turf/T in A)
+		T.remove_atom_colour(WASHABLE_COLOUR_PRIORITY)
+		T.add_atom_colour("#2956B2", FIXED_COLOUR_PRIORITY)
+	A.xenobiology_compatible = TRUE
+	qdel(src)


### PR DESCRIPTION
Xenobio blueprints now color an area blue and make it able to be transversed by the Xenobio camera, regardless of what you name the area (you can leave the area name alone if you wish, or change it to "nerd kingdom 500"...whatever suits your fancy).

The primary advantage of this is that you're not polluting the station with duplicate instances of "Xenobiology Lab", making it confusing to the rest of the station where things are at.

:cl: Fox McCloud
tweak: Slime blueprints can now make an area compatible with Xenobio consoles, regardless of the name of the new area
/:cl:
