### PR TITLE
[Metastation] Easel in Quiet Room moved to art storage

### DIFF
--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -32286,10 +32286,12 @@
 /obj/machinery/light_switch{
 	pixel_x = 27
 	},
-/obj/machinery/photocopier,
 /obj/machinery/light/small{
 	dir = 4
 	},
+/obj/structure/easel,
+/obj/item/canvas/twentythreeXtwentythree,
+/obj/item/canvas/twentythreeXtwentythree,
 /turf/open/floor/plasteel,
 /area/storage/art)
 "boP" = (
@@ -101271,7 +101273,7 @@ bzE
 bLk
 bML
 bue
-bMQ
+bzE
 bRj
 bSB
 bPR


### PR DESCRIPTION
That easel awkwardly blocks access to the table in the corner, so I've
moved it to art storage, removing a photocopier from art storage to
allow it to fit.

![image](https://user-images.githubusercontent.com/609465/33528006-2a659f26-d852-11e7-9f12-6d9e93534631.png)
![image](https://user-images.githubusercontent.com/609465/33528010-3d549d58-d852-11e7-9156-77d4d8ea909d.png)

