### PR TITLE
Adds some suicide acts

### DIFF
--- a/code/game/gamemodes/miniantags/revenant/revenant.dm
+++ b/code/game/gamemodes/miniantags/revenant/revenant.dm
@@ -413,6 +413,7 @@
 
 /obj/item/ectoplasm/revenant/suicide_act(mob/user)
 	user.visible_message("<span class='suicide'>[user] is inhaling [src]! It looks like [user.p_theyre()] trying to visit the shadow realm!</span>")
+	scatter()
 	return (OXYLOSS)
 
 /obj/item/ectoplasm/revenant/Destroy()

--- a/code/game/gamemodes/miniantags/revenant/revenant.dm
+++ b/code/game/gamemodes/miniantags/revenant/revenant.dm
@@ -411,6 +411,10 @@
 	revenant = null
 	qdel(src)
 
+/obj/item/ectoplasm/revenant/suicide_act(mob/user)
+	user.visible_message("<span class='suicide'>[user] is inhaling [src]! It looks like [user.p_theyre()] trying to visit the shadow realm!</span>")
+	return (OXYLOSS)
+
 /obj/item/ectoplasm/revenant/Destroy()
 	if(!QDELETED(revenant))
 		qdel(revenant)

--- a/code/game/gamemodes/nuclear/nuclearbomb.dm
+++ b/code/game/gamemodes/nuclear/nuclearbomb.dm
@@ -564,10 +564,7 @@ This is here to make the tiles around the station mininuke change when it's arme
 
 /obj/item/disk/fakenucleardisk/suicide_act(mob/user)
 	user.visible_message("<span class='suicide'>[user] is pretending to go delta! It looks like [user.p_theyre()] trying to commit suicide!</span>")
-	playsound(user.loc, 'sound/machines/alarm.ogg', 50, -1, 1)
-	for(var/i in 1 to 100)
-		addtimer(CALLBACK(user, /atom/proc/add_atom_colour, (i % 2)? "#00FF00" : "#FF0000", ADMIN_COLOUR_PRIORITY), i)
-	addtimer(CALLBACK(user, /atom/proc/remove_atom_colour, ADMIN_COLOUR_PRIORITY), 101)
+	playsound(user.loc, 'sound/machines/alarm.ogg', 30, -1, 1)
 	addtimer(CALLBACK(user, /atom/proc/visible_message, "<span class='suicide'>[user] was destroyed by the nuclear blast!</span>"), 101)
 	addtimer(CALLBACK(user, /mob/living/proc/adjustOxyLoss, 200), 101)
 	addtimer(CALLBACK(user, /mob/proc/death, 0), 101)

--- a/code/game/gamemodes/nuclear/nuclearbomb.dm
+++ b/code/game/gamemodes/nuclear/nuclearbomb.dm
@@ -561,3 +561,14 @@ This is here to make the tiles around the station mininuke change when it's arme
 	name = "cheap plastic imitation of the nuclear authentication disk"
 	desc = "Broken dreams and a faint odor of cheese."
 	icon_state = "nucleardisk"
+
+/obj/item/disk/fakenucleardisk/suicide_act(mob/user)
+	user.visible_message("<span class='suicide'>[user] is pretending to go delta! It looks like [user.p_theyre()] trying to commit suicide!</span>")
+	playsound(user.loc, 'sound/machines/alarm.ogg', 50, -1, 1)
+	for(var/i in 1 to 100)
+		addtimer(CALLBACK(user, /atom/proc/add_atom_colour, (i % 2)? "#00FF00" : "#FF0000", ADMIN_COLOUR_PRIORITY), i)
+	addtimer(CALLBACK(user, /atom/proc/remove_atom_colour, ADMIN_COLOUR_PRIORITY), 101)
+	addtimer(CALLBACK(user, /atom/proc/visible_message, "<span class='suicide'>[user] was destroyed by the nuclear blast!</span>"), 101)
+	addtimer(CALLBACK(user, /mob/living/proc/adjustOxyLoss, 200), 101)
+	addtimer(CALLBACK(user, /mob/proc/death, 0), 101)
+	return MANUAL_SUICIDE

--- a/code/game/gamemodes/nuclear/nuclearbomb.dm
+++ b/code/game/gamemodes/nuclear/nuclearbomb.dm
@@ -554,7 +554,7 @@ This is here to make the tiles around the station mininuke change when it's arme
 	addtimer(CALLBACK(src, .proc/manual_suicide, user), 101)
 	return MANUAL_SUICIDE
 	
-/obj/item/disk/nuclear/proc/manual_suicide(mob/living/user)
+/obj/item/disk/proc/manual_suicide(mob/living/user)
 	user.remove_atom_colour(ADMIN_COLOUR_PRIORITY)
 	user.visible_message("<span class='suicide'>[user] was destroyed by the nuclear blast!</span>")
 	user.adjustOxyLoss(200)
@@ -570,8 +570,3 @@ This is here to make the tiles around the station mininuke change when it's arme
 	playsound(src, 'sound/machines/alarm.ogg', 30, -1, 1)
 	addtimer(CALLBACK(src, .proc/manual_suicide, user), 101)
 	return MANUAL_SUICIDE
-	
-/obj/item/disk/fakenucleardisk/proc/manual_suicide(mob/living/user)
-	user.visible_message("<span class='suicide'>[user] was destroyed by the nuclear blast!</span>")
-	user.adjustOxyLoss(200)
-	user.death(0)

--- a/code/game/gamemodes/nuclear/nuclearbomb.dm
+++ b/code/game/gamemodes/nuclear/nuclearbomb.dm
@@ -548,14 +548,17 @@ This is here to make the tiles around the station mininuke change when it's arme
 
 /obj/item/disk/nuclear/suicide_act(mob/user)
 	user.visible_message("<span class='suicide'>[user] is going delta! It looks like [user.p_theyre()] trying to commit suicide!</span>")
-	playsound(user.loc, 'sound/machines/alarm.ogg', 50, -1, 1)
+	playsound(src, 'sound/machines/alarm.ogg', 50, -1, 1)
 	for(var/i in 1 to 100)
 		addtimer(CALLBACK(user, /atom/proc/add_atom_colour, (i % 2)? "#00FF00" : "#FF0000", ADMIN_COLOUR_PRIORITY), i)
-	addtimer(CALLBACK(user, /atom/proc/remove_atom_colour, ADMIN_COLOUR_PRIORITY), 101)
-	addtimer(CALLBACK(user, /atom/proc/visible_message, "<span class='suicide'>[user] was destroyed by the nuclear blast!</span>"), 101)
-	addtimer(CALLBACK(user, /mob/living/proc/adjustOxyLoss, 200), 101)
-	addtimer(CALLBACK(user, /mob/proc/death, 0), 101)
+	addtimer(CALLBACK(src, .proc/manual_suicide, user), 101)
 	return MANUAL_SUICIDE
+	
+/obj/item/disk/nuclear/proc/manual_suicide(mob/living/user)
+	user.remove_atom_colour(ADMIN_COLOUR_PRIORITY)
+	user.visible_message("<span class='suicide'>[user] was destroyed by the nuclear blast!</span>")
+	user.adjustOxyLoss(200)
+	user.death(0)
 
 /obj/item/disk/fakenucleardisk
 	name = "cheap plastic imitation of the nuclear authentication disk"
@@ -564,8 +567,11 @@ This is here to make the tiles around the station mininuke change when it's arme
 
 /obj/item/disk/fakenucleardisk/suicide_act(mob/user)
 	user.visible_message("<span class='suicide'>[user] is pretending to go delta! It looks like [user.p_theyre()] trying to commit suicide!</span>")
-	playsound(user.loc, 'sound/machines/alarm.ogg', 30, -1, 1)
-	addtimer(CALLBACK(user, /atom/proc/visible_message, "<span class='suicide'>[user] was destroyed by the nuclear blast!</span>"), 101)
-	addtimer(CALLBACK(user, /mob/living/proc/adjustOxyLoss, 200), 101)
-	addtimer(CALLBACK(user, /mob/proc/death, 0), 101)
+	playsound(src, 'sound/machines/alarm.ogg', 30, -1, 1)
+	addtimer(CALLBACK(src, .proc/manual_suicide, user), 101)
 	return MANUAL_SUICIDE
+	
+/obj/item/disk/fakenucleardisk/proc/manual_suicide(mob/living/user)
+	user.visible_message("<span class='suicide'>[user] was destroyed by the nuclear blast!</span>")
+	user.adjustOxyLoss(200)
+	user.death(0)

--- a/code/game/objects/items/bodybag.dm
+++ b/code/game/objects/items/bodybag.dm
@@ -21,6 +21,16 @@
 	R.add_fingerprint(user)
 	qdel(src)
 
+/obj/item/bodybag/suicide_act(mob/user)
+	if(isopenturf(user.loc))
+		user.visible_message("<span class='suicide'>[user] is crawling into [src]! It looks like [user.p_theyre()] trying to commit suicide!</span>")
+		var/obj/structure/closet/body_bag/R = new unfoldedbag_path(user.loc)
+		R.add_fingerprint(user)
+		qdel(src)
+		user.forceMove(R)
+		playsound(loc, 'sound/items/zip.ogg', 15, 1, -3)
+		return (OXYLOSS)
+	..()	
 
 // Bluespace bodybag
 

--- a/code/game/objects/items/bodybag.dm
+++ b/code/game/objects/items/bodybag.dm
@@ -28,7 +28,7 @@
 		R.add_fingerprint(user)
 		qdel(src)
 		user.forceMove(R)
-		playsound(loc, 'sound/items/zip.ogg', 15, 1, -3)
+		playsound(src, 'sound/items/zip.ogg', 15, 1, -3)
 		return (OXYLOSS)
 	..()	
 

--- a/code/game/objects/items/dice.dm
+++ b/code/game/objects/items/dice.dm
@@ -30,6 +30,10 @@
 	if(special_die == "100")
 		new /obj/item/dice/d100(src)
 
+/obj/item/storage/pill_bottle/dice/suicide_act(mob/user)
+	user.visible_message("<span class='suicide'>[user] is gambling with death! It looks like [user.p_theyre()] trying to commit suicide!</span>")
+	return (OXYLOSS)
+
 /obj/item/dice //depreciated d6, use /obj/item/dice/d6 if you actually want a d6
 	name = "die"
 	desc = "A die with six sides. Basic and servicable."
@@ -46,6 +50,10 @@
 	result = rand(1, sides)
 	update_icon()
 	..()
+
+/obj/item/dice/suicide_act(mob/user)
+	user.visible_message("<span class='suicide'>[user] is gambling with death! It looks like [user.p_theyre()] trying to commit suicide!</span>")
+	return (OXYLOSS)
 
 /obj/item/dice/d1
 	name = "d1"

--- a/code/game/objects/items/stacks/medical.dm
+++ b/code/game/objects/items/stacks/medical.dm
@@ -113,6 +113,10 @@
 	origin_tech = "biotech=2"
 	self_delay = 20
 
+/obj/item/stack/medical/bruise_pack/suicide_act(mob/user)
+	user.visible_message("<span class='suicide'>[user] is bludgeoning [user.p_them()]self with [src]! It looks like [user.p_theyre()] trying to commit suicide!</span>")
+	return (BRUTELOSS)
+
 /obj/item/stack/medical/gauze
 	name = "medical gauze"
 	desc = "A roll of elastic cloth that is extremely effective at stopping bleeding, but does not heal wounds."

--- a/code/game/objects/items/storage/firstaid.dm
+++ b/code/game/objects/items/storage/firstaid.dm
@@ -167,6 +167,10 @@
 				usr.s_active.close(usr)
 			src.show_to(usr)
 
+/obj/item/storage/pill_bottle/suicide_act(mob/user)
+	user.visible_message("<span class='suicide'>[user] is trying to get the cap off [src]! It looks like [user.p_theyre()] trying to commit suicide!</span>")
+	return (TOXLOSS)
+
 /obj/item/storage/pill_bottle/charcoal
 	name = "bottle of charcoal pills"
 	desc = "Contains pills used to counter toxins."

--- a/code/game/objects/items/theft_tools.dm
+++ b/code/game/objects/items/theft_tools.dm
@@ -34,6 +34,10 @@
 		cooldown = world.time
 		flick(pulseicon, src)
 		radiation_pulse(src, 400, 2)
+		
+/obj/item/nuke_core/suicide_act(mob/user)
+	user.visible_message("<span class='suicide'>[user] is rubbing [src] against [user.p_them()]self! It looks like [user.p_theyre()] trying to commit suicide!</span>")
+	return (TOXLOSS)
 
 //nuke core box, for carrying the core
 /obj/item/nuke_core_container

--- a/code/game/objects/items/weaponry.dm
+++ b/code/game/objects/items/weaponry.dm
@@ -398,7 +398,7 @@
 	icon_state = "ectoplasm"
 
 /obj/item/ectoplasm/suicide_act(mob/user)
-	user.visible_message("<span class='suicide'>[user] is inhaling [src]! It looks like [user.p_theyre()] trying to visit the astral plane.</span>")
+	user.visible_message("<span class='suicide'>[user] is inhaling [src]! It looks like [user.p_theyre()] trying to visit the astral plane!</span>")
 	return (OXYLOSS)
 
 /obj/item/mounted_chainsaw

--- a/code/modules/hydroponics/grown/melon.dm
+++ b/code/modules/hydroponics/grown/melon.dm
@@ -14,6 +14,13 @@
 	mutatelist = list(/obj/item/seeds/watermelon/holy)
 	reagents_add = list("water" = 0.2, "vitamin" = 0.04, "nutriment" = 0.2)
 
+/obj/item/seeds/watermelon/suicide_act(mob/user)
+	user.visible_message("<span class='suicide'>[user] is swallowing [src]! It looks like [user.p_theyre()] trying to commit suicide!</span>")
+	user.gib()
+	new product(loc)
+	qdel(src)
+	return (BRUTELOSS)
+
 /obj/item/reagent_containers/food/snacks/grown/watermelon
 	seed = /obj/item/seeds/watermelon
 	name = "watermelon"

--- a/code/modules/hydroponics/grown/melon.dm
+++ b/code/modules/hydroponics/grown/melon.dm
@@ -17,7 +17,7 @@
 /obj/item/seeds/watermelon/suicide_act(mob/user)
 	user.visible_message("<span class='suicide'>[user] is swallowing [src]! It looks like [user.p_theyre()] trying to commit suicide!</span>")
 	user.gib()
-	new product(loc)
+	new product(drop_location())
 	qdel(src)
 	return MANUAL_SUICIDE
 

--- a/code/modules/hydroponics/grown/melon.dm
+++ b/code/modules/hydroponics/grown/melon.dm
@@ -19,7 +19,7 @@
 	user.gib()
 	new product(loc)
 	qdel(src)
-	return (BRUTELOSS)
+	return MANUAL_SUICIDE
 
 /obj/item/reagent_containers/food/snacks/grown/watermelon
 	seed = /obj/item/seeds/watermelon


### PR DESCRIPTION
:cl: Swindly
add: You can kill yourself with a few more items.
/:cl:

[why]: (Please add a short description [two lines down] of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.)

suicide should always be encouraged

Adds suicide_act() for:

- glimmering residue
- cheap plastic imitation of the nuclear authentication disk
- body bag
- bag of dice
- die
- bruise pack
- pill bottle
- plutonium core
- pack of watermelon seeds