### PR TITLE
Standardizes false report weighting

### DIFF
--- a/code/controllers/configuration/configuration.dm
+++ b/code/controllers/configuration/configuration.dm
@@ -168,7 +168,10 @@ GLOBAL_PROTECT(config_dir)
 				mode_names[M.config_tag] = M.name
 				probabilities[M.config_tag] = M.probability
 				mode_reports[M.config_tag] = M.generate_report()
-				mode_false_report_weight[M.config_tag] = M.false_report_weight
+				if(M.probability)
+					mode_false_report_weight[M.config_tag] = M.false_report_weight
+				else
+					mode_false_report_weight[M.config_tag] = 1
 				if(M.votable)
 					votable_modes += M.config_tag
 		qdel(M)

--- a/code/game/gamemodes/changeling/changeling.dm
+++ b/code/game/gamemodes/changeling/changeling.dm
@@ -9,7 +9,7 @@ GLOBAL_VAR(changeling_team_objective_type) //If this is not null, we hand our th
 	name = "changeling"
 	config_tag = "changeling"
 	antag_flag = ROLE_CHANGELING
-	false_report_weight = 1
+	false_report_weight = 10
 	restricted_jobs = list("AI", "Cyborg")
 	protected_jobs = list("Security Officer", "Warden", "Detective", "Head of Security", "Captain")
 	required_players = 15

--- a/code/game/gamemodes/changeling/changeling.dm
+++ b/code/game/gamemodes/changeling/changeling.dm
@@ -9,7 +9,7 @@ GLOBAL_VAR(changeling_team_objective_type) //If this is not null, we hand our th
 	name = "changeling"
 	config_tag = "changeling"
 	antag_flag = ROLE_CHANGELING
-	false_report_weight = 10
+	false_report_weight = 1
 	restricted_jobs = list("AI", "Cyborg")
 	protected_jobs = list("Security Officer", "Warden", "Detective", "Head of Security", "Captain")
 	required_players = 15

--- a/code/game/gamemodes/traitor/double_agents.dm
+++ b/code/game/gamemodes/traitor/double_agents.dm
@@ -5,7 +5,7 @@
 /datum/game_mode/traitor/internal_affairs
 	name = "Internal Affairs"
 	config_tag = "internal_affairs"
-	false_report_weight = 10
+	false_report_weight = 1
 	required_players = 25
 	required_enemies = 5
 	recommended_enemies = 8

--- a/code/game/gamemodes/traitor/double_agents.dm
+++ b/code/game/gamemodes/traitor/double_agents.dm
@@ -5,7 +5,7 @@
 /datum/game_mode/traitor/internal_affairs
 	name = "Internal Affairs"
 	config_tag = "internal_affairs"
-	false_report_weight = 1
+	false_report_weight = 10
 	required_players = 25
 	required_enemies = 5
 	recommended_enemies = 8


### PR DESCRIPTION
:cl: Robustin
fix: Modes not in rotation have had their "false report" weights for the Command Report standardized 
/:cl:

Non-rotation modes are typically weighted at 1 while rotation modes start at 10.

A few modes that were shifted out of rotation (double agents, changeling) were left at 10.

This had the result of making it very easy to deduce the roundtype for certain rounds (Internal Affairs, Changeling, Nukeops, and Wizard listed on the report... if someone's not shitting magic in the next few minutes you better prepare for NukeOps). 
