### PR TITLE
Fixes zombie head removal

### DIFF
--- a/code/modules/surgery/bodyparts/dismemberment.dm
+++ b/code/modules/surgery/bodyparts/dismemberment.dm
@@ -236,6 +236,11 @@
 		if(pill)
 			pill.forceMove(src)
 
+	//Make sure de-zombification happens before organ removal instead of during it
+	var/obj/item/organ/zombie_infection/ooze = owner.getorganslot(ORGAN_SLOT_ZOMBIE)
+	if(istype(ooze))
+		ooze.transfer_to_limb(src, owner)
+
 	name = "[owner.real_name]'s head"
 	..()
 


### PR DESCRIPTION
Fixes #33293 
Whenever a mob changes species, all of its organs are replaced. When an infectious zombie's head is cut off, its species changes in the middle of its head organs being removed, which meant that the head was ending up with now-replaced organs. This forces the zombie species change to before organs are iterated through.