### PR TITLE
Larvas bursting from infected people no longer gib them

### DIFF
--- a/code/modules/mob/living/carbon/alien/special/alien_embryo.dm
+++ b/code/modules/mob/living/carbon/alien/special/alien_embryo.dm
@@ -63,7 +63,7 @@
 
 
 
-/obj/item/organ/body_egg/alien_embryo/proc/AttemptGrow(gib_on_success=FALSE)
+/obj/item/organ/body_egg/alien_embryo/proc/AttemptGrow(gib_on_success=FALSE, adrenaline_rush=TRUE)
 	if(!owner || bursting)
 		return
 
@@ -106,6 +106,22 @@
 		new_xeno.visible_message("<span class='danger'>[new_xeno] bursts out of [owner] in a shower of gore!</span>", "<span class='userdanger'>You exit [owner], your previous host.</span>", "<span class='italics'>You hear organic matter ripping and tearing!</span>")
 		owner.gib(TRUE)
 	else
+		if(adrenaline_rush)
+			if(owner.buckled || handcuffed)
+				owner.uncuff()
+				unbuckle_mob(owner)
+				owner.visible_message("<span class='danger'>[owner] screams and breaks free!</span>", "<span class='userdanger'>As the larva breaks out of your chest, you panic and break free!</span>")
+			else
+				owner.visible_message("<span class='danger'>[owner] screams!</span>", "<span class='userdanger'>As the larva breaks out of your chest, you scream and panic!</span>")
+			owner.SetStun(0)
+			owner.SetKnockdown(0)
+			owner.SetUnconscious(0)
+			owner.adjustStaminaLoss(-75)
+			owner.jitter(50)
+			owner.lying = 0
+			owner.reagents.add_reagent("ephedrine", 10)
+			owner.reagents.add_reagent("synaptizine", 10)
+			owner.update_canmove()
 		new_xeno.visible_message("<span class='danger'>[new_xeno] wriggles out of [owner]!</span>", "<span class='userdanger'>You exit [owner], your previous host.</span>")
 		owner.adjustBruteLoss(40)
 		owner.cut_overlay(overlay)

--- a/code/modules/mob/living/carbon/alien/special/alien_embryo.dm
+++ b/code/modules/mob/living/carbon/alien/special/alien_embryo.dm
@@ -107,7 +107,7 @@
 		owner.gib(TRUE)
 	else
 		if(adrenaline_rush)
-			if(owner.buckled || handcuffed)
+			if(owner.buckled || owner.handcuffed)
 				owner.uncuff()
 				unbuckle_mob(owner)
 				owner.visible_message("<span class='danger'>[owner] screams and breaks free!</span>", "<span class='userdanger'>As the larva breaks out of your chest, you panic and break free!</span>")

--- a/code/modules/mob/living/carbon/alien/special/alien_embryo.dm
+++ b/code/modules/mob/living/carbon/alien/special/alien_embryo.dm
@@ -63,7 +63,7 @@
 
 
 
-/obj/item/organ/body_egg/alien_embryo/proc/AttemptGrow(gib_on_success=TRUE)
+/obj/item/organ/body_egg/alien_embryo/proc/AttemptGrow(gib_on_success=FALSE)
 	if(!owner || bursting)
 		return
 

--- a/code/modules/mob/living/carbon/alien/special/alien_embryo.dm
+++ b/code/modules/mob/living/carbon/alien/special/alien_embryo.dm
@@ -117,7 +117,7 @@
 			owner.SetKnockdown(0)
 			owner.SetUnconscious(0)
 			owner.adjustStaminaLoss(-75)
-			owner.jitter(50)
+			owner.Jitter(50)
 			owner.lying = 0
 			owner.reagents.add_reagent("ephedrine", 10)
 			owner.reagents.add_reagent("synaptizine", 10)


### PR DESCRIPTION
Why? Because I thought it might be interesting, and the code was already there and completely unused.


If you want a more thorough answer, Xenos have gone relatively unchanged for ages now. The meta has gotten stale, even if being a Xeno is still interesting because its so rare.

This change makes it so that instead of gibbing the infected, a larva bursting out of someone does 40 brute damage. The target must be re-infected with another hugger afterwards if they want to get another larva out. This substantially changes the Xeno-human dynamic:

- Getting huggered is no longer a complete death sentence. Xenos have much more incentive to keep people alive and unhurt, and the infected have more opportunities to escape or be rescued.

- Even if they die, they aren't permanently removed from the round anymore because they can still be cloned.

- Facehuggers aren't ranged 1-hit delayed gib unless you get surgery.

- Xenos can produce 2-3, or potentially even 4 larva from a single captive given enough time, so long as they bring them in unhurt.


Overall, this unlinks the human-Xeno ratio. 1 more Xeno in the round does not mean that there is exactly 1 less human. Xenos can replicate quickly without simultaneously decimating the crew, enabling for a more interesting and prolonged conflict than "Oh shit, Xenos! Call the shuttle so when we're all dead in 10 minutes they can escape!".

Overall, I hope this makes Xenos a fun and interesting fight instead of a instant round-ender, without actually nerfing them.

🆑 
Reports indicate the infamous alien infestations have evolved. Xenomorph larva no longer kill their host while emerging.
/🆑 