### PR TITLE
Spinning resin or laying eggs on vents prompts the user if they're sure

### DIFF
--- a/code/modules/mob/living/carbon/alien/humanoid/alien_powers.dm
+++ b/code/modules/mob/living/carbon/alien/humanoid/alien_powers.dm
@@ -63,7 +63,7 @@ Doesn't work on other aliens/AI.*/
 	var/obj/machinery/atmospherics/components/unary/atmos_thing = locate() in user.loc
 	if(atmos_thing)
 		var/rusure = alert(user, "Laying eggs and shaping resin here would block access to [atmos_thing]. Do you want to continue?", "Blocking Atmospheric Component", "Yes", "No")
-		if(rusure == "No")
+		if(rusure != "No")
 			return FALSE
 	return TRUE
 

--- a/code/modules/mob/living/carbon/alien/humanoid/alien_powers.dm
+++ b/code/modules/mob/living/carbon/alien/humanoid/alien_powers.dm
@@ -59,6 +59,14 @@ Doesn't work on other aliens/AI.*/
 		return 0
 	return 1
 
+/obj/effect/proc_holder/alien/proc/check_vent_block(mob/living/user)
+	var/obj/machinery/atmospherics/components/unary/atmos_thing = locate() in user.loc
+	if(atmos_thing)
+		var/rusure = alert(user, "Laying eggs and shaping resin here would block access to [atmos_thing]. Do you want to continue?", "Blocking Atmospheric Component", "Yes", "No")
+		if(rusure == "No")
+			return FALSE
+	return TRUE
+
 /obj/effect/proc_holder/alien/plant
 	name = "Plant Weeds"
 	desc = "Plants some alien weeds."
@@ -256,9 +264,7 @@ Doesn't work on other aliens/AI.*/
 		to_chat(user, "<span class='danger'>There is already a resin structure there.</span>")
 		return FALSE
 
-	var/atom/movable/atmos_thing = locate(/obj/machinery/atmospherics/components/unary) in user.loc
-	if(atmos_thing)
-		to_chat(user, "<span class='danger'>A resin structure here would block access to [atmos_thing].</span>")
+	if(!check_vent_block(user))
 		return FALSE
 
 	var/choice = input("Choose what you wish to shape.","Resin building") as null|anything in structures
@@ -271,7 +277,7 @@ Doesn't work on other aliens/AI.*/
 
 	choice = structures[choice]
 	new choice(user.loc)
-	return FALSE
+	return TRUE
 
 /obj/effect/proc_holder/alien/regurgitate
 	name = "Regurgitate"

--- a/code/modules/mob/living/carbon/alien/humanoid/alien_powers.dm
+++ b/code/modules/mob/living/carbon/alien/humanoid/alien_powers.dm
@@ -243,7 +243,7 @@ Doesn't work on other aliens/AI.*/
 	name = "Secrete Resin"
 	desc = "Secrete tough malleable resin."
 	plasma_cost = 55
-	check_turf = 1
+	check_turf = TRUE
 	var/list/structures = list(
 		"resin wall" = /obj/structure/alien/resin/wall,
 		"resin membrane" = /obj/structure/alien/resin/membrane,
@@ -254,18 +254,24 @@ Doesn't work on other aliens/AI.*/
 /obj/effect/proc_holder/alien/resin/fire(mob/living/carbon/user)
 	if(locate(/obj/structure/alien/resin) in user.loc)
 		to_chat(user, "<span class='danger'>There is already a resin structure there.</span>")
-		return 0
+		return FALSE
+
+	var/atom/movable/atmos_thing = locate(/obj/machinery/atmospherics/components/unary) in user.loc
+	if(atmos_thing)
+		to_chat(user, "<span class='danger'>A resin structure here would block access to [atmos_thing].</span>")
+		return FALSE
+
 	var/choice = input("Choose what you wish to shape.","Resin building") as null|anything in structures
 	if(!choice)
-		return 0
+		return FALSE
 	if (!cost_check(check_turf,user))
-		return 0
+		return FALSE
 	to_chat(user, "<span class='notice'>You shape a [choice].</span>")
 	user.visible_message("<span class='notice'>[user] vomits up a thick purple substance and begins to shape it.</span>")
 
 	choice = structures[choice]
 	new choice(user.loc)
-	return 1
+	return FALSE
 
 /obj/effect/proc_holder/alien/regurgitate
 	name = "Regurgitate"

--- a/code/modules/mob/living/carbon/alien/humanoid/queen.dm
+++ b/code/modules/mob/living/carbon/alien/humanoid/queen.dm
@@ -84,12 +84,10 @@
 
 /obj/effect/proc_holder/alien/lay_egg/fire(mob/living/carbon/user)
 	if(locate(/obj/structure/alien/egg) in get_turf(user))
-		to_chat(user, "There's already an egg here.")
+		to_chat(user, "<span class='alertalien'>There's already an egg here.</span>")
 		return FALSE
 
-	var/atom/movable/atmos_thing = locate(/obj/machinery/atmospherics/components/unary) in user.loc
-	if(atmos_thing)
-		to_chat(user, "<span class='danger'>An egg here would block access to [atmos_thing].</span>")
+	if(!check_vent_block(user))
 		return FALSE
 
 	user.visible_message("<span class='alertalien'>[user] has laid an egg!</span>")

--- a/code/modules/mob/living/carbon/alien/humanoid/queen.dm
+++ b/code/modules/mob/living/carbon/alien/humanoid/queen.dm
@@ -79,16 +79,22 @@
 	name = "Lay Egg"
 	desc = "Lay an egg to produce huggers to impregnate prey with."
 	plasma_cost = 75
-	check_turf = 1
+	check_turf = TRUE
 	action_icon_state = "alien_egg"
 
 /obj/effect/proc_holder/alien/lay_egg/fire(mob/living/carbon/user)
 	if(locate(/obj/structure/alien/egg) in get_turf(user))
 		to_chat(user, "There's already an egg here.")
-		return 0
+		return FALSE
+
+	var/atom/movable/atmos_thing = locate(/obj/machinery/atmospherics/components/unary) in user.loc
+	if(atmos_thing)
+		to_chat(user, "<span class='danger'>An egg here would block access to [atmos_thing].</span>")
+		return FALSE
+
 	user.visible_message("<span class='alertalien'>[user] has laid an egg!</span>")
 	new /obj/structure/alien/egg(user.loc)
-	return 1
+	return TRUE
 
 //Button to let queen choose her praetorian.
 /obj/effect/proc_holder/alien/royal/queen/promote


### PR DESCRIPTION
:cl: coiax
tweak: Aliens (and humans with alien organs) will have a prompt
if they try to create resin structures or lay eggs atop vents or scrubbers.
/:cl:

@WJohnston approved.

This stops stupid aliens from obscuring entrances to the very helpful
and useful atmospheric piping system. Unless they're really stupid and ignore the pop up message.