### PR TITLE
Replaces CLEAN_ON_MOVE_1 flag with cleaning component

### DIFF
--- a/code/__DEFINES/flags.dm
+++ b/code/__DEFINES/flags.dm
@@ -22,7 +22,7 @@ GLOBAL_LIST_INIT(bitflags, list(1, 2, 4, 8, 16, 32, 64, 128, 256, 512, 1024, 204
 #define ON_BORDER_1			512		// item has priority to check when entering or leaving
 
 #define NOSLIP_1			1024 		//prevents from slipping on wet floors, in space etc
-#define CLEAN_ON_MOVE_1		2048
+#define _UNUSED_1		2048
 
 // BLOCK_GAS_SMOKE_EFFECT_1 only used in masks at the moment.
 #define BLOCK_GAS_SMOKE_EFFECT_1 4096	// blocks the effect that chemical clouds would have on a mob --glasses, mask and helmets ONLY!

--- a/code/datums/components/cleaning.dm
+++ b/code/datums/components/cleaning.dm
@@ -1,12 +1,13 @@
 /datum/component/cleaning
 
 /datum/component/cleaning/Initialize()
-	if(!ismovable(parent))
+	if(!ismovableatom(parent))
 		. = COMPONENT_INCOMPATIBLE
 		CRASH("[type] added to a [parent.type]")
 	RegisterSignal(list(COMSIG_MOVABLE_MOVED), .proc/Clean)
 
 /datum/component/cleaning/proc/Clean()
+	var/atom/movable/AM = parent
 	var/turf/tile = AM.loc
 	if(!isturf(tile))
 		return

--- a/code/datums/components/cleaning.dm
+++ b/code/datums/components/cleaning.dm
@@ -1,0 +1,36 @@
+/datum/component/cleaning
+
+/datum/component/cleaning/Initialize()
+	RegisterSignal(list(COMSIG_MOVABLE_MOVED), .proc/Clean)
+
+/datum/component/cleaning/proc/Clean()
+	var/atom/movable/AM = parent
+	if(!istype(AM))
+		return
+	var/turf/tile = AM.loc
+	if(isturf(tile))
+		tile.clean_blood()
+		for(var/A in tile)
+			if(is_cleanable(A))
+				qdel(A)
+			else if(istype(A, /obj/item))
+				var/obj/item/cleaned_item = A
+				cleaned_item.clean_blood()
+			else if(ishuman(A))
+				var/mob/living/carbon/human/cleaned_human = A
+				if(cleaned_human.lying)
+					if(cleaned_human.head)
+						cleaned_human.head.clean_blood()
+						cleaned_human.update_inv_head()
+					if(cleaned_human.wear_suit)
+						cleaned_human.wear_suit.clean_blood()
+						cleaned_human.update_inv_wear_suit()
+					else if(cleaned_human.w_uniform)
+						cleaned_human.w_uniform.clean_blood()
+						cleaned_human.update_inv_w_uniform()
+					if(cleaned_human.shoes)
+						cleaned_human.shoes.clean_blood()
+						cleaned_human.update_inv_shoes()
+					cleaned_human.clean_blood()
+					cleaned_human.wash_cream()
+					to_chat(cleaned_human, "<span class='danger'>[AM] cleans your face!</span>")

--- a/code/datums/components/cleaning.dm
+++ b/code/datums/components/cleaning.dm
@@ -1,36 +1,38 @@
 /datum/component/cleaning
 
 /datum/component/cleaning/Initialize()
+	if(!ismovable(parent))
+		. = COMPONENT_INCOMPATIBLE
+		CRASH("[type] added to a [parent.type]")
 	RegisterSignal(list(COMSIG_MOVABLE_MOVED), .proc/Clean)
 
 /datum/component/cleaning/proc/Clean()
-	var/atom/movable/AM = parent
-	if(!istype(AM))
-		return
 	var/turf/tile = AM.loc
-	if(isturf(tile))
-		tile.clean_blood()
-		for(var/A in tile)
-			if(is_cleanable(A))
-				qdel(A)
-			else if(istype(A, /obj/item))
-				var/obj/item/cleaned_item = A
-				cleaned_item.clean_blood()
-			else if(ishuman(A))
-				var/mob/living/carbon/human/cleaned_human = A
-				if(cleaned_human.lying)
-					if(cleaned_human.head)
-						cleaned_human.head.clean_blood()
-						cleaned_human.update_inv_head()
-					if(cleaned_human.wear_suit)
-						cleaned_human.wear_suit.clean_blood()
-						cleaned_human.update_inv_wear_suit()
-					else if(cleaned_human.w_uniform)
-						cleaned_human.w_uniform.clean_blood()
-						cleaned_human.update_inv_w_uniform()
-					if(cleaned_human.shoes)
-						cleaned_human.shoes.clean_blood()
-						cleaned_human.update_inv_shoes()
-					cleaned_human.clean_blood()
-					cleaned_human.wash_cream()
-					to_chat(cleaned_human, "<span class='danger'>[AM] cleans your face!</span>")
+	if(!isturf(tile))
+		return
+
+	tile.clean_blood()
+	for(var/A in tile)
+		if(is_cleanable(A))
+			qdel(A)
+		else if(istype(A, /obj/item))
+			var/obj/item/cleaned_item = A
+			cleaned_item.clean_blood()
+		else if(ishuman(A))
+			var/mob/living/carbon/human/cleaned_human = A
+			if(cleaned_human.lying)
+				if(cleaned_human.head)
+					cleaned_human.head.clean_blood()
+					cleaned_human.update_inv_head()
+				if(cleaned_human.wear_suit)
+					cleaned_human.wear_suit.clean_blood()
+					cleaned_human.update_inv_wear_suit()
+				else if(cleaned_human.w_uniform)
+					cleaned_human.w_uniform.clean_blood()
+					cleaned_human.update_inv_w_uniform()
+				if(cleaned_human.shoes)
+					cleaned_human.shoes.clean_blood()
+					cleaned_human.update_inv_shoes()
+				cleaned_human.clean_blood()
+				cleaned_human.wash_cream()
+				to_chat(cleaned_human, "<span class='danger'>[AM] cleans your face!</span>")

--- a/code/datums/components/cleaning.dm
+++ b/code/datums/components/cleaning.dm
@@ -1,4 +1,5 @@
 /datum/component/cleaning
+	dupe_mode = COMPONENT_DUPE_UNIQUE_PASSARGS
 
 /datum/component/cleaning/Initialize()
 	if(!ismovableatom(parent))

--- a/code/game/atoms_movable.dm
+++ b/code/game/atoms_movable.dm
@@ -132,43 +132,11 @@
 	if (orbiting)
 		orbiting.Check()
 
-	if(flags_1 & CLEAN_ON_MOVE_1)
-		clean_on_move()
-
 	var/datum/proximity_monitor/proximity_monitor = src.proximity_monitor
 	if(proximity_monitor)
 		proximity_monitor.HandleMove()
 
 	return 1
-
-/atom/movable/proc/clean_on_move()
-	var/turf/tile = loc
-	if(isturf(tile))
-		tile.clean_blood()
-		for(var/A in tile)
-			if(is_cleanable(A))
-				qdel(A)
-			else if(istype(A, /obj/item))
-				var/obj/item/cleaned_item = A
-				cleaned_item.clean_blood()
-			else if(ishuman(A))
-				var/mob/living/carbon/human/cleaned_human = A
-				if(cleaned_human.lying)
-					if(cleaned_human.head)
-						cleaned_human.head.clean_blood()
-						cleaned_human.update_inv_head()
-					if(cleaned_human.wear_suit)
-						cleaned_human.wear_suit.clean_blood()
-						cleaned_human.update_inv_wear_suit()
-					else if(cleaned_human.w_uniform)
-						cleaned_human.w_uniform.clean_blood()
-						cleaned_human.update_inv_w_uniform()
-					if(cleaned_human.shoes)
-						cleaned_human.shoes.clean_blood()
-						cleaned_human.update_inv_shoes()
-					cleaned_human.clean_blood()
-					cleaned_human.wash_cream()
-					to_chat(cleaned_human, "<span class='danger'>[src] cleans your face!</span>")
 
 /atom/movable/Destroy(force)
 	var/inform_admins = (flags_2 & INFORM_ADMINS_ON_RELOCATE_2)

--- a/code/modules/mob/living/silicon/robot/robot.dm
+++ b/code/modules/mob/living/silicon/robot/robot.dm
@@ -991,9 +991,9 @@
 		status_flags &= ~CANPUSH
 
 	if(module.clean_on_move)
-		flags_1 |= CLEAN_ON_MOVE_1
+		AddComponent(/datum/component/cleaning)
 	else
-		flags_1 &= ~CLEAN_ON_MOVE_1
+		qdel(GetComponent(/datum/component/cleaning))
 
 	hat_offset = module.hat_offset
 

--- a/code/modules/mob/living/silicon/robot/robot.dm
+++ b/code/modules/mob/living/silicon/robot/robot.dm
@@ -991,7 +991,7 @@
 		status_flags &= ~CANPUSH
 
 	if(module.clean_on_move)
-		AddComponent(/datum/component/cleaning)
+		LoadComponent(/datum/component/cleaning)
 	else
 		qdel(GetComponent(/datum/component/cleaning))
 

--- a/code/modules/mob/living/silicon/robot/robot.dm
+++ b/code/modules/mob/living/silicon/robot/robot.dm
@@ -991,7 +991,7 @@
 		status_flags &= ~CANPUSH
 
 	if(module.clean_on_move)
-		LoadComponent(/datum/component/cleaning)
+		AddComponent(/datum/component/cleaning)
 	else
 		qdel(GetComponent(/datum/component/cleaning))
 

--- a/code/modules/vehicles/pimpin_ride.dm
+++ b/code/modules/vehicles/pimpin_ride.dm
@@ -14,7 +14,7 @@
 	D.set_riding_offsets(RIDING_OFFSET_ALL, list(TEXT_NORTH = list(0, 4), TEXT_SOUTH = list(0, 7), TEXT_EAST = list(-12, 7), TEXT_WEST = list( 12, 7)))
 
 	if(floorbuffer)
-		LoadComponent(/datum/component/cleaning)
+		AddComponent(/datum/component/cleaning)
 
 /obj/vehicle/ridden/janicart/Destroy()
 	if(mybag)
@@ -50,7 +50,7 @@
 		floorbuffer = TRUE
 		qdel(I)
 		to_chat(user, "<span class='notice'>You upgrade [src] with the floor buffer.</span>")
-		LoadComponent(/datum/component/cleaning)
+		AddComponent(/datum/component/cleaning)
 		update_icon()
 	else
 		return ..()

--- a/code/modules/vehicles/pimpin_ride.dm
+++ b/code/modules/vehicles/pimpin_ride.dm
@@ -13,6 +13,9 @@
 	var/datum/component/riding/D = LoadComponent(/datum/component/riding)
 	D.set_riding_offsets(RIDING_OFFSET_ALL, list(TEXT_NORTH = list(0, 4), TEXT_SOUTH = list(0, 7), TEXT_EAST = list(-12, 7), TEXT_WEST = list( 12, 7)))
 
+	if(floorbuffer)
+		LoadComponent(/datum/component/cleaning)
+
 /obj/vehicle/ridden/janicart/Destroy()
 	if(mybag)
 		qdel(mybag)
@@ -47,7 +50,7 @@
 		floorbuffer = TRUE
 		qdel(I)
 		to_chat(user, "<span class='notice'>You upgrade [src] with the floor buffer.</span>")
-		AddComponent(/datum/component/cleaning)
+		LoadComponent(/datum/component/cleaning)
 		update_icon()
 	else
 		return ..()
@@ -70,7 +73,3 @@
 
 /obj/vehicle/ridden/janicart/upgraded
 	floorbuffer = TRUE
-
-/obj/vehicle/ridden/janicart/upgraded/Initialize(mapload)
-	. = ..()
-	AddComponent(/datum/component/cleaning)

--- a/code/modules/vehicles/pimpin_ride.dm
+++ b/code/modules/vehicles/pimpin_ride.dm
@@ -47,7 +47,7 @@
 		floorbuffer = TRUE
 		qdel(I)
 		to_chat(user, "<span class='notice'>You upgrade [src] with the floor buffer.</span>")
-		flags_1 |= CLEAN_ON_MOVE_1
+		AddComponent(/datum/component/cleaning)
 		update_icon()
 	else
 		return ..()
@@ -70,3 +70,7 @@
 
 /obj/vehicle/ridden/janicart/upgraded
 	floorbuffer = TRUE
+
+/obj/vehicle/ridden/janicart/upgraded/Initialize(mapload)
+	. = ..()
+	AddComponent(/datum/component/cleaning)

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -308,6 +308,7 @@
 #include "code\datums\components\archaeology.dm"
 #include "code\datums\components\caltrop.dm"
 #include "code\datums\components\chasm.dm"
+#include "code\datums\components\cleaning.dm"
 #include "code\datums\components\decal.dm"
 #include "code\datums\components\infective.dm"
 #include "code\datums\components\jousting.dm"


### PR DESCRIPTION
CLEAN_ON_MOVE_1 is a flag checked on every atom movable's Moved() and
triggers a janiborg/upgraded janicart clean on the turf if present.

Replacing this with a component does the same thing and frees up a flag
slot.

Also fixes a bug where a spawned in "upgraded" janicart wouldn't
actually clean the floors.