### PR TITLE
Silver slime extract foods now fry correctly

### DIFF
--- a/code/modules/reagents/chemistry/recipes/slime_extracts.dm
+++ b/code/modules/reagents/chemistry/recipes/slime_extracts.dm
@@ -152,11 +152,10 @@
 		var/chosen = pick(borks)
 		var/obj/B = new chosen(T)
 		if(prob(5))//Fry it!
-			var/obj/item/reagent_containers/food/snacks/deepfryholder/D = new(T)
-			var/datum/reagents/reagents = new(25)
-			reagents.add_reagent("nutriment", 25)
-			D.fry(B, reagents)
-			B = D
+			var/obj/item/reagent_containers/food/snacks/deepfryholder/fried
+			fried = new(T, B)
+			fried.fry() // actually set the name and colour it
+			B = fried
 		if(prob(50))
 			for(var/j in 1 to rand(1, 3))
 				step(B, pick(NORTH,SOUTH,EAST,WEST))

--- a/code/modules/reagents/reagent_containers/syringes.dm
+++ b/code/modules/reagents/reagent_containers/syringes.dm
@@ -209,7 +209,7 @@
 
 /obj/item/reagent_containers/syringe/plasma
 	name = "syringe (plasma)"
-	desc = "Contain plasma."
+	desc = "Contains plasma."
 	list_reagents = list("plasma" = 15)
 
 /obj/item/reagent_containers/syringe/lethal

--- a/code/modules/reagents/reagent_containers/syringes.dm
+++ b/code/modules/reagents/reagent_containers/syringes.dm
@@ -207,6 +207,11 @@
 	desc = "Contains calomel."
 	list_reagents = list("calomel" = 15)
 
+/obj/item/reagent_containers/syringe/plasma
+	name = "syringe (plasma)"
+	desc = "Contain plasma."
+	list_reagents = list("plasma" = 15)
+
 /obj/item/reagent_containers/syringe/lethal
 	name = "lethal injection syringe"
 	desc = "A syringe used for lethal injections. It can hold up to 50 units."


### PR DESCRIPTION
The invocation to create fried food wasn't correct, and was ending up
creating fried food that had the default name and description.

- Also adds a "syringe/plasma" type, because it's annoying having to
spawn in plasma sheets and grind them and then put them into a syringe,
if you want to test slime spawning stuff.