### PR TITLE
Fix runtimes using Tweak Component Ratings on non-machines

### DIFF
--- a/code/modules/admin/verbs/machine_upgrade.dm
+++ b/code/modules/admin/verbs/machine_upgrade.dm
@@ -1,6 +1,9 @@
 /proc/machine_upgrade(obj/machinery/M in world)
 	set name = "Tweak Component Ratings"
 	set category = "Debug"
+	if (!istype(M))
+		return
+
 	var/new_rating = input("Enter new rating:","Num") as num
 	if(new_rating && M.component_parts)
 		for(var/obj/item/stock_parts/P in M.component_parts)


### PR DESCRIPTION
I guess there isn't a way to just make the verb not show up on non-machines so at least now the prompt doesn't show and then runtime.