### PR TITLE
Blobs no longer stop the emergency shuttle from leaving

### DIFF
--- a/code/game/gamemodes/blob/overmind.dm
+++ b/code/game/gamemodes/blob/overmind.dm
@@ -51,8 +51,6 @@ GLOBAL_LIST_EMPTY(blob_nodes)
 	if(blob_core)
 		blob_core.update_icon()
 
-	SSshuttle.registerHostileEnvironment(src)
-
 	.= ..()
 
 /mob/camera/blob/Life()


### PR DESCRIPTION
:cl: Kjolstet
tweak: Blobs no longer stop the emergency shuttle from leaving. Rejoice!
/:cl:

This has honestly been a huge issue ever since blob was turned into ONLY a midround antagonist, and not a roundstart antagonist like it was designed around. Midround blobs have a HUGE advantage over the crew because:

- the crew is already preoccupied dealing with lings, cult, traitors, etc and has far less resources to fight the blob with
- the crew is often more interested in killing each other than killing the blob
- the blob delays the shuttle indefinitely, meaning that the helpless crew HAS to deal with the blob quickly (an extremely hard feat in the middle of a cult/ling/traitor round, mind you) or end up with a round an hour longer than it ever should have been.

All of these factors make blobs EXTREMELY unfun to play and play against, since it can postpone the round by upwards of one and a half hours in extreme cases. I've been on rounds where 90% of the crew is in deadchat, screaming at the networked fibers blob and ling with 30 maxcaps still fighting each other to just kill themselves already. While I think blob is a good gamemode, it should really just be a roundstart antag, which would fix all of the problems I mentioned above. This PR fixes the third issue, and turns blob into a true side-antagonist that hampers the progress of both the crew and traitors; but not stopping it completely; making for a more dynamic and interesting round.