### PR TITLE
Fix supermatter tongs icon bug

### DIFF
--- a/code/game/objects/items/theft_tools.dm
+++ b/code/game/objects/items/theft_tools.dm
@@ -226,6 +226,7 @@
 		Consume(O)
 		to_chat(usr, "<span class='notice'>\The [sliver] is dusted along with \the [O]!</span>")
 		QDEL_NULL(sliver)
+		update_icon()
 
 /obj/item/hemostat/supermatter/throw_impact(atom/hit_atom) // no instakill supermatter javelins
 	if(sliver)


### PR DESCRIPTION
Fixes #33161

Lack of an update_icon was giving the false impression that empty tongs still held a sliver.