### PR TITLE
[Box] Moves drone dispenser to Robotics maintenance

### DIFF
--- a/_maps/map_files/BoxStation/BoxStation.dmm
+++ b/_maps/map_files/BoxStation/BoxStation.dmm
@@ -57706,6 +57706,24 @@
 	dir = 8
 	},
 /area/medical/sleeper)
+"QoV" = (
+/obj/structure/rack,
+/obj/effect/spawner/lootdrop/maintenance{
+	lootcount = 2;
+	name = "2maintenance loot spawner"
+	},
+/turf/open/floor/plating,
+/area/maintenance/department/medical/morgue)
+"QoW" = (
+/obj/machinery/droneDispenser,
+/turf/open/floor/plating,
+/area/maintenance/department/medical/morgue)
+"QoX" = (
+/obj/structure/table,
+/obj/item/stack/sheet/metal/fifty,
+/obj/item/stack/sheet/glass/fifty,
+/turf/open/floor/plating,
+/area/maintenance/department/medical/morgue)
 
 (1,1,1) = {"
 aaa
@@ -98187,7 +98205,7 @@ aYV
 aYV
 bfO
 bfS
-biC
+biD
 bkd
 bfS
 cTO
@@ -98958,8 +98976,8 @@ aYV
 bez
 bfP
 bfS
-biD
-bke
+bfS
+bfS
 bfS
 cTO
 bmZ
@@ -99215,9 +99233,9 @@ bci
 beB
 bfS
 bfS
-bfS
-bfS
-bfS
+QoV
+QoW
+QoX
 cTO
 bmZ
 bon


### PR DESCRIPTION
:cl: coiax
add: The drone dispenser on Box Station has been moved from the Testing
Lab to the Morgue/Robotics maintenance tunnel.
/:cl:

This brings it in line with other stations where it's in the Robotics maintenance tunnels.

- I added a 2 drop maint loot spawner as well.

Before:
![image](https://user-images.githubusercontent.com/609465/33684956-ed45187e-dac7-11e7-94eb-992c07b22f13.png)

After:
![image](https://user-images.githubusercontent.com/609465/33684966-f59e1566-dac7-11e7-96d3-f8ca21467504.png)