### PR TITLE
Fixes some broken random events

### DIFF
--- a/code/__HELPERS/game.dm
+++ b/code/__HELPERS/game.dm
@@ -326,25 +326,6 @@
 			return M
 	return null
 
-// Will return a list of active candidates. It increases the buffer 5 times until it finds a candidate which is active within the buffer.
-
-/proc/get_candidates(be_special_type, afk_bracket = CONFIG_GET(number/inactivity_period), jobbanType)
-	var/list/candidates = list()
-	// Keep looping until we find a non-afk candidate within the time bracket (we limit the bracket to 10 minutes (6000))
-	var/afk_period = CONFIG_GET(number/afk_period)
-	while(!candidates.len && afk_bracket < afk_period)
-		for(var/mob/dead/observer/G in GLOB.player_list)
-			if(G.client != null)
-				if(!(G.mind && G.mind.current && G.mind.current.stat != DEAD))
-					if(!G.client.is_afk(afk_bracket) && (be_special_type in G.client.prefs.be_special))
-						if (jobbanType)
-							if(!(jobban_isbanned(G, jobbanType) || jobban_isbanned(G, "Syndicate")))
-								candidates += G.client
-						else
-							candidates += G.client
-		afk_bracket += 600 // Add a minute to the bracket, for every attempt
-	return candidates
-
 /proc/considered_alive(datum/mind/M, enforce_human = TRUE)
 	if(M && M.current)
 		if(enforce_human)

--- a/code/datums/antagonists/wizard.dm
+++ b/code/datums/antagonists/wizard.dm
@@ -71,7 +71,7 @@
 				var/datum/objective/escape/escape_objective = new
 				escape_objective.owner = owner
 				objectives += escape_objective
-		
+
 		if(31 to 60)
 			var/datum/objective/steal/steal_objective = new
 			steal_objective.owner = owner
@@ -103,8 +103,8 @@
 			if (!(locate(/datum/objective/hijack) in owner.objectives))
 				var/datum/objective/hijack/hijack_objective = new
 				hijack_objective.owner = owner
-				objectives += hijack_objective	
-	
+				objectives += hijack_objective
+
 	for(var/datum/objective/O in objectives)
 		owner.objectives += O
 
@@ -128,7 +128,7 @@
 	if(H.age < wiz_age)
 		H.age = wiz_age
 	H.equipOutfit(outfit_type)
-	
+
 /datum/antagonist/wizard/greet()
 	to_chat(owner, "<span class='boldannounce'>You are the Space Wizard!</span>")
 	to_chat(owner, "<B>The Space Wizards Federation has given you the following tasks:</B>")
@@ -208,7 +208,7 @@
 			owner.AddSpell(new /obj/effect/proc_holder/spell/aoe_turf/knock(null))
 			owner.AddSpell(new /obj/effect/proc_holder/spell/targeted/mind_transfer(null))
 			to_chat(owner, "<B>Your service has not gone unrewarded, however. Studying under [master.current.real_name], you have learned stealthy, robeless spells. You are able to cast knock and mindswap.")
-			
+
 /datum/antagonist/wizard/apprentice/create_objectives()
 	var/datum/objective/protect/new_objective = new /datum/objective/protect
 	new_objective.owner = owner
@@ -221,6 +221,7 @@
 /datum/antagonist/wizard/apprentice/imposter
 	name = "Wizard Imposter"
 	allow_rename = FALSE
+	move_to_lair = FALSE
 
 /datum/antagonist/wizard/apprentice/imposter/greet()
 	to_chat(owner, "<B>You are an imposter! Trick and confuse the crew to misdirect malice from your handsome original!</B>")
@@ -266,7 +267,7 @@
 
 /datum/antagonist/wizard/academy/equip_wizard()
 	. = ..()
-	
+
 	owner.AddSpell(new /obj/effect/proc_holder/spell/targeted/ethereal_jaunt)
 	owner.AddSpell(new /obj/effect/proc_holder/spell/targeted/projectile/magic_missile)
 	owner.AddSpell(new /obj/effect/proc_holder/spell/aimed/fireball)
@@ -274,7 +275,7 @@
 	var/mob/living/M = owner.current
 	if(!istype(M))
 		return
-	
+
 	var/obj/item/implant/exile/Implant = new/obj/item/implant/exile(M)
 	Implant.implant(M)
 

--- a/code/modules/events/camerafailure.dm
+++ b/code/modules/events/camerafailure.dm
@@ -6,11 +6,9 @@
 	alertadmins = 0
 
 /datum/round_event/camera_failure
-	startWhen = 1
-	endWhen = 2
 	fakeable = FALSE
 
-/datum/round_event/camera_failure/tick()
+/datum/round_event/camera_failure/start()
 	var/iterations = 1
 	var/obj/machinery/camera/C = pick(GLOB.cameranet.cameras)
 	while(prob(round(100/iterations)))

--- a/code/modules/events/wizard/curseditems.dm
+++ b/code/modules/events/wizard/curseditems.dm
@@ -11,29 +11,29 @@
 
 /datum/round_event/wizard/cursed_items/start()
 	var/item_set = pick("wizardmimic", "swords", "bigfatdoobie", "boxing", "voicemodulators", "catgirls2015")
-	var/list/wearslots	= list(slot_wear_suit, slot_shoes, slot_head, slot_wear_mask, slot_gloves, slot_ears)
-	var/list/loadout = list()
+	var/list/loadout[slots_amt]
 	var/ruins_spaceworthiness
 	var/ruins_wizard_loadout
-	loadout.len = 7
 
 	switch(item_set)
 		if("wizardmimic")
-			loadout = list(/obj/item/clothing/suit/wizrobe, /obj/item/clothing/shoes/sandal/magic, /obj/item/clothing/head/wizard)
+			loadout[slot_wear_suit] = /obj/item/clothing/suit/wizrobe
+			loadout[slot_shoes] = /obj/item/clothing/shoes/sandal/magic
+			loadout[slot_head] = /obj/item/clothing/head/wizard
 			ruins_spaceworthiness = 1
 		if("swords")
-			loadout[5] = /obj/item/katana/cursed
+			loadout[slot_hands] = /obj/item/katana/cursed
 		if("bigfatdoobie")
-			loadout[4] = /obj/item/clothing/mask/cigarette/rollie/trippy
+			loadout[slot_wear_mask] = /obj/item/clothing/mask/cigarette/rollie/trippy
 			ruins_spaceworthiness = 1
 		if("boxing")
-			loadout[4] = /obj/item/clothing/mask/luchador
-			loadout[6] = /obj/item/clothing/gloves/boxing
+			loadout[slot_wear_mask] = /obj/item/clothing/mask/luchador
+			loadout[slot_gloves] = /obj/item/clothing/gloves/boxing
 			ruins_spaceworthiness = 1
 		if("voicemodulators")
-			loadout[4] = /obj/item/clothing/mask/chameleon
+			loadout[slot_wear_mask] = /obj/item/clothing/mask/chameleon
 		if("catgirls2015")
-			loadout[3] = /obj/item/clothing/head/kitty
+			loadout[slot_head] = /obj/item/clothing/head/kitty
 			ruins_spaceworthiness = 1
 			ruins_wizard_loadout = 1
 
@@ -44,14 +44,13 @@
 			continue
 		if(item_set == "catgirls2015") //Wizard code means never having to say you're sorry
 			H.gender = FEMALE
-		var/list/slots		= list(H.wear_suit, H.shoes, H.head, H.wear_mask, H.gloves, H.ears) //add new slots as needed to back
 		for(var/i in 1 to loadout.len)
 			if(loadout[i])
 				var/obj/item/J = loadout[i]
 				var/obj/item/I = new J //dumb but required because of byond throwing a fit anytime new gets too close to a list
-				H.temporarilyRemoveItemFromInventory(slots[i], TRUE)
-				H.equip_to_slot_or_del(I, wearslots[i])
-				I.flags_1 |= NODROP_1
+				H.dropItemToGround(H.get_item_by_slot(i), TRUE)
+				H.equip_to_slot_or_del(I, i)
+				I.flags_1 |= NODROP_1 | DROPDEL_1
 				I.name = "cursed " + I.name
 
 	for(var/mob/living/carbon/human/H in GLOB.alive_mob_list)

--- a/code/modules/events/wizard/imposter.dm
+++ b/code/modules/events/wizard/imposter.dm
@@ -6,12 +6,11 @@
 	earliest_start = 0
 
 /datum/round_event/wizard/imposter/start()
-
 	for(var/datum/mind/M in SSticker.mode.wizards)
 		if(!ishuman(M.current))
 			continue
 		var/mob/living/carbon/human/W = M.current
-		var/list/candidates = get_candidates(ROLE_WIZARD)
+		var/list/candidates = pollGhostCandidates("Would you like to be an imposter wizard?", ROLE_WIZARD)
 		if(!candidates)
 			return //Sad Trombone
 		var/client/C = pick(candidates)
@@ -28,10 +27,10 @@
 		var/datum/antagonist/wizard/master = M.has_antag_datum(/datum/antagonist/wizard)
 		if(!master.wiz_team)
 			master.create_wiz_team()
-		var/datum/antagonist/wizard/apprentice/imposter = new(I.mind)
+		var/datum/antagonist/wizard/apprentice/imposter/imposter = new(I.mind)
 		imposter.master = M
 		imposter.wiz_team = master.wiz_team
-		master.wiz_team += imposter
+		master.wiz_team.add_member(imposter)
 		I.mind.add_antag_datum(imposter)
 		//Remove if possible
 		SSticker.mode.apprentices += I.mind

--- a/code/modules/events/wizard/race.dm
+++ b/code/modules/events/wizard/race.dm
@@ -22,7 +22,7 @@
 
 	for(var/mob/living/carbon/human/H in GLOB.carbon_list) //yes, even the dead
 		H.set_species(new_species)
-		H.real_name = new_species.random_name(H.gender,1)
+		H.real_name = H.dna.species.random_name(H.gender,1)
 		H.dna.unique_enzymes = H.dna.generate_unique_enzymes()
 		to_chat(H, "<span class='notice'>You feel somehow... different?</span>")
 		if(!all_the_same)


### PR DESCRIPTION
:cl:
fix: Fixed the camera failure, race swap, cursed items, and imposter wizard random events
tweak: The cursed items event no longer nullspaces items
/:cl:

- Camera failure: tick() isn't called on the startWhen and endWhen ticks, so I just changed it to start() like all the other one tick events
- Race swap: random_name() was being called on the species typepath
- Cursed items: Fixed some items attempting to equip to the wrong slot. Also made replaced items get dropped to prevent objective items from getting destroyed and made cursed items delete on drop.
- Imposter wizard: Replaced the broken/outdated get_candidates() with pollGhostCandidates() and corrected some datum antag issues.