### PR TITLE
Prevents (cat)grilles from magically regenerating.

### DIFF
--- a/code/game/objects/structures/grille.dm
+++ b/code/game/objects/structures/grille.dm
@@ -26,7 +26,7 @@
 	update_icon()
 
 /obj/structure/grille/update_icon()
-	if(QDELETED(src))
+	if(QDELETED(src) || broken)
 		return
 
 	var/ratio = obj_integrity / max_integrity


### PR DESCRIPTION
[Changelogs]: 
:cl: Dax Dupont
fix: Grilles now no longer revert to a pre-broken icon state when you hit them after they broke.
/:cl:

[why]: Grilles would revert to the damaged state icons after being hit after being in broken state.