### PR TITLE
Fixes random in random seeds

### DIFF
--- a/code/modules/hydroponics/grown/random.dm
+++ b/code/modules/hydroponics/grown/random.dm
@@ -16,9 +16,9 @@
 	. = ..()
 	randomize_stats()
 	if(prob(60))
-		add_random_reagents()
+		add_random_reagents(lower=1, upper=3)
 	if(prob(50))
-		add_random_traits()
+		add_random_traits(lower=1, upper=2)
 	add_random_plant_type(35)
 
 /obj/item/reagent_containers/food/snacks/grown/random

--- a/code/modules/hydroponics/grown/random.dm
+++ b/code/modules/hydroponics/grown/random.dm
@@ -16,9 +16,9 @@
 	. = ..()
 	randomize_stats()
 	if(prob(60))
-		add_random_reagents(lower=1, upper=3)
+		add_random_reagents(1, 3)
 	if(prob(50))
-		add_random_traits(lower=1, upper=2)
+		add_random_traits(1, 2)
 	add_random_plant_type(35)
 
 /obj/item/reagent_containers/food/snacks/grown/random


### PR DESCRIPTION
The lower threshold on `add_random_reagents` and `add_random_traits` wasn't set, which resulted in strange seeds being less likely to have traits and reagents than it was intended.