### PR TITLE
Step backwards version of hex2num

### DIFF
--- a/code/__HELPERS/type2type.dm
+++ b/code/__HELPERS/type2type.dm
@@ -14,9 +14,6 @@
 //breaks when hittin invalid characters thereafter
 /proc/hex2num(hex)
 	. = 0
-	if(!istext(hex))
-		return
-
 	var/place = 0
 	for(var/i in length(hex) to 1 step -1)
 		var/num = text2ascii(hex, i)

--- a/code/__HELPERS/type2type.dm
+++ b/code/__HELPERS/type2type.dm
@@ -14,30 +14,25 @@
 //breaks when hittin invalid characters thereafter
 /proc/hex2num(hex)
 	. = 0
-	if(istext(hex))
-		var/negative = 0
-		var/len = length(hex)
-		for(var/i=1, i<=len, i++)
-			var/num = text2ascii(hex,i)
-			switch(num)
-				if(48 to 57)
-					num -= 48	//0-9
-				if(97 to 102)
-					num -= 87	//a-f
-				if(65 to 70)
-					num -= 55	//A-F
-				if(45)
-					negative = 1//-
-				else
-					if(num)
-						break
-					else
-						continue
-			. *= 16
-			. += num
-		if(negative)
-			. *= -1
-	return .
+	if(!istext(hex))
+		return
+
+	var/place = 0
+	for(var/i in length(hex) to 1 step -1)
+		var/num = text2ascii(hex, i)
+		switch(num)
+			if(48 to 57)
+				num -= 48	//0-9
+			if(97 to 102)
+				num -= 87	//a-f
+			if(65 to 70)
+				num -= 55	//A-F
+			if(45)
+				return . * -1 // -
+			else
+				CRASH("Malformed hex number")
+
+		. += num * (16 ** place++)
 
 //Returns the hex value of a decimal number
 //len == length of returned string

--- a/code/__HELPERS/type2type.dm
+++ b/code/__HELPERS/type2type.dm
@@ -14,7 +14,7 @@
 //breaks when hittin invalid characters thereafter
 /proc/hex2num(hex)
 	. = 0
-	var/place = 0
+	var/place = 1
 	for(var/i in length(hex) to 1 step -1)
 		var/num = text2ascii(hex, i)
 		switch(num)
@@ -29,7 +29,8 @@
 			else
 				CRASH("Malformed hex number")
 
-		. += num * (16 ** place++)
+		. += num * place
+		place *= 16
 
 //Returns the hex value of a decimal number
 //len == length of returned string


### PR DESCRIPTION
I got interested so I just quickly threw together a better hex2num.

I tried a static list version and just a modified current version.

https://pastebin.com/dbPJ00j3

| Proc Name | Self CPU | Total CPU | Real Time | Calls |
| --- | --- | --- | --- | --- |
| /proc/goon_hex2num | 4.016 | 4.035 | 4.134 | 1000000 |
| /proc/my_list_hex2num | 3.640 | 3.655 | 3.761 | 1000000 |
| /proc/old_hex2num | 3.639 | 3.665 | 3.771 | 1000000 |
| /proc/my_modified_hex2num | 2.952 | 2.967 | 3.043 | 1000000 |

This also tested to ensure the values outputted are the same as before and makes it runtime when invalid characters are found
