### PR TITLE
[DNM] Blessed turfs are visible to people who care about blessed turfs

### DIFF
--- a/code/_globalvars/lists/objects.dm
+++ b/code/_globalvars/lists/objects.dm
@@ -39,3 +39,6 @@ GLOBAL_LIST_EMPTY(ai_status_displays)
 
 GLOBAL_LIST_EMPTY(mob_spawners) 		    // All mob_spawn objects
 GLOBAL_LIST_EMPTY(alert_consoles)			// Station alert consoles, /obj/machinery/computer/station_alert
+
+// all blessings, effects that block ethereal travel
+GLOBAL_LIST_EMPTY(blessings)

--- a/code/_globalvars/lists/objects.dm
+++ b/code/_globalvars/lists/objects.dm
@@ -39,6 +39,3 @@ GLOBAL_LIST_EMPTY(ai_status_displays)
 
 GLOBAL_LIST_EMPTY(mob_spawners) 		    // All mob_spawn objects
 GLOBAL_LIST_EMPTY(alert_consoles)			// Station alert consoles, /obj/machinery/computer/station_alert
-
-// all blessings, effects that block ethereal travel
-GLOBAL_LIST_EMPTY(blessings)

--- a/code/game/gamemodes/miniantags/revenant/revenant.dm
+++ b/code/game/gamemodes/miniantags/revenant/revenant.dm
@@ -225,7 +225,6 @@
 	invisibility = INVISIBILITY_ABSTRACT
 	revealed = FALSE
 	ghostize(0)//Don't re-enter invisible corpse
-	return
 
 
 //reveal, stun, icon updates, cast checks, and essence changing

--- a/code/game/gamemodes/miniantags/revenant/revenant_abilities.dm
+++ b/code/game/gamemodes/miniantags/revenant/revenant_abilities.dm
@@ -238,8 +238,8 @@
 			INVOKE_ASYNC(src, .proc/defile, T)
 
 /obj/effect/proc_holder/spell/aoe_turf/revenant/defile/proc/defile(turf/T)
-	if(GLOB.blessings[T])
-		qdel(GLOB.blessings[T])
+	for(var/obj/effect/blessing/B in T)
+		qdel(B)
 		new /obj/effect/temp_visual/revenant(T)
 
 	if(!isplatingturf(T) && !istype(T, /turf/open/floor/engine/cult) && isfloorturf(T) && prob(15))

--- a/code/game/gamemodes/miniantags/revenant/revenant_abilities.dm
+++ b/code/game/gamemodes/miniantags/revenant/revenant_abilities.dm
@@ -238,9 +238,10 @@
 			INVOKE_ASYNC(src, .proc/defile, T)
 
 /obj/effect/proc_holder/spell/aoe_turf/revenant/defile/proc/defile(turf/T)
-	if(T.flags_1 & NOJAUNT_1)
-		T.flags_1 &= ~NOJAUNT_1
+	if(GLOB.blessings[T])
+		qdel(GLOB.blessings[T])
 		new /obj/effect/temp_visual/revenant(T)
+
 	if(!isplatingturf(T) && !istype(T, /turf/open/floor/engine/cult) && isfloorturf(T) && prob(15))
 		var/turf/open/floor/floor = T
 		if(floor.intact && floor.floor_tile)

--- a/code/game/objects/effects/blessing.dm
+++ b/code/game/objects/effects/blessing.dm
@@ -6,20 +6,12 @@
 	color = "#ffff00"
 	anchored = TRUE
 	density = FALSE
-	layer = RIPPLE_LAYER
+	layer = ABOVE_OPEN_TURF_LAYER
 	mouse_opacity = MOUSE_OPACITY_TRANSPARENT
 	alpha = 150
 
 /obj/effect/blessing/Initialize(mapload)
-	var/turf/T = get_turf(src)
-	if(GLOB.blessings[T])
-		// already blessing in this location
-		return INITIALIZE_HINT_QDEL
-	else
-		GLOB.blessings[T] = src
-		. = ..()
-
-/obj/effect/blessing/Destroy()
-	var/turf/T = get_turf(src)
-	GLOB.blessings[T] = null
 	. = ..()
+	for(var/obj/effect/blessing/B in loc)
+		if(B != src)
+			return INITIALIZE_HINT_QDEL

--- a/code/game/objects/effects/blessing.dm
+++ b/code/game/objects/effects/blessing.dm
@@ -1,0 +1,25 @@
+/obj/effect/blessing
+	name = "holy blessing"
+	desc = "Holy energies interfere with ethereal travel at this location."
+	icon = 'icons/effects/effects.dmi'
+	icon_state = "wave1"
+	color = "#ffff00"
+	anchored = TRUE
+	density = FALSE
+	layer = RIPPLE_LAYER
+	mouse_opacity = MOUSE_OPACITY_TRANSPARENT
+	alpha = 150
+
+/obj/effect/blessing/Initialize(mapload)
+	var/turf/T = get_turf(src)
+	if(GLOB.blessings[T])
+		// already blessing in this location
+		return INITIALIZE_HINT_QDEL
+	else
+		GLOB.blessings[T] = src
+		. = ..()
+
+/obj/effect/blessing/Destroy()
+	var/turf/T = get_turf(src)
+	GLOB.blessings[T] = null
+	. = ..()

--- a/code/game/turfs/turf.dm
+++ b/code/game/turfs/turf.dm
@@ -319,9 +319,6 @@
 	for(var/obj/mecha/M in src)
 		M.take_damage(damage*2, BRUTE, "melee", 1)
 
-/turf/proc/Bless()
-	flags_1 |= NOJAUNT_1
-
 /turf/storage_contents_dump_act(obj/item/storage/src_object, mob/user)
 	if(src_object.contents.len)
 		to_chat(usr, "<span class='notice'>You start dumping out the contents...</span>")

--- a/code/modules/mob/mob_movement.dm
+++ b/code/modules/mob/mob_movement.dm
@@ -212,9 +212,13 @@
 						R.stun(20)
 					return
 				if(stepTurf.flags_1 & NOJAUNT_1)
-					to_chat(L, "<span class='warning'>Holy energies block your path.</span>")
-				else
-					L.loc = get_step(L, direct)
+					to_chat(L, "<span class='warning'>Some strange aura is blocking the way.</span>")
+					return
+				if(GLOB.blessings[stepTurf])
+					to_chat(L, "<span class='warning'>Holy energies block your path!</span>")
+					return
+
+				L.loc = get_step(L, direct)
 			L.setDir(direct)
 	return TRUE
 

--- a/code/modules/mob/mob_movement.dm
+++ b/code/modules/mob/mob_movement.dm
@@ -214,7 +214,7 @@
 				if(stepTurf.flags_1 & NOJAUNT_1)
 					to_chat(L, "<span class='warning'>Some strange aura is blocking the way.</span>")
 					return
-				if(GLOB.blessings[stepTurf])
+				for(var/obj/effect/blessing/B in stepTurf)
 					to_chat(L, "<span class='warning'>Holy energies block your path!</span>")
 					return
 

--- a/code/modules/reagents/chemistry/reagents/other_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/other_reagents.dm
@@ -236,7 +236,8 @@
 	if(reac_volume>=10)
 		for(var/obj/effect/rune/R in T)
 			qdel(R)
-	T.Bless()
+
+	new /obj/effect/blessing(T)
 
 /datum/reagent/fuel/unholywater		//if you somehow managed to extract this from someone, dont splash it on yourself and have a smoke
 	name = "Unholy Water"

--- a/code/modules/spells/spell_types/ethereal_jaunt.dm
+++ b/code/modules/spells/spell_types/ethereal_jaunt.dm
@@ -90,7 +90,7 @@
 	if(newLoc.flags_1 & NOJAUNT_1)
 		to_chat(user, "<span class='warning'>Some strange aura is blocking the way.</span>")
 		return
-	if(GLOB.blessings[newLoc])
+	for(var/obj/effect/blessing/B in newLoc)
 		to_chat(user, "<span class='warning'>Holy energies block your path!</span>")
 		return
 

--- a/code/modules/spells/spell_types/ethereal_jaunt.dm
+++ b/code/modules/spells/spell_types/ethereal_jaunt.dm
@@ -84,11 +84,17 @@
 		return
 	var/turf/newLoc = get_step(src,direction)
 	setDir(direction)
-	if(!(newLoc.flags_1 & NOJAUNT_1))
-		forceMove(newLoc)
-	else
-		to_chat(user, "<span class='warning'>Some strange aura is blocking the way!</span>")
+
 	movedelay = world.time + movespeed
+
+	if(newLoc.flags_1 & NOJAUNT_1)
+		to_chat(user, "<span class='warning'>Some strange aura is blocking the way.</span>")
+		return
+	if(GLOB.blessings[newLoc])
+		to_chat(user, "<span class='warning'>Holy energies block your path!</span>")
+		return
+
+	forceMove(newLoc)
 
 /obj/effect/dummy/spell_jaunt/ex_act(blah)
 	return

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -761,6 +761,7 @@
 #include "code\game\objects\structures.dm"
 #include "code\game\objects\effects\alien_acid.dm"
 #include "code\game\objects\effects\anomalies.dm"
+#include "code\game\objects\effects\blessing.dm"
 #include "code\game\objects\effects\bump_teleporter.dm"
 #include "code\game\objects\effects\contraband.dm"
 #include "code\game\objects\effects\countdown.dm"


### PR DESCRIPTION
- Chaplains, revenants, anyone with an ethereal jaunt spell will be able to see a glowing yellow shimmer on turfs that are "blessed".
- NOJAUNT_1 still exists as a flag, but that can no longer be set by any players, it's a pure admin only flag, for technical turfs.

- [ ] Sprites for the blessing, tuned so they're visible but not overwhelming
- [ ] Actually making it so only those groups of people (+observers) can see the blessings