### PR TITLE
Allows for qdel in shuttleMove procs

### DIFF
--- a/code/modules/shuttle/shuttle.dm
+++ b/code/modules/shuttle/shuttle.dm
@@ -665,6 +665,8 @@
 	for(var/i in 1 to moved_atoms.len)
 		CHECK_TICK
 		var/atom/movable/moved_object = moved_atoms[i]
+		if(QDELETED(moved_object))
+			continue
 		var/turf/oldT = moved_atoms[moved_object]
 		moved_object.afterShuttleMove(oldT, movement_force, dir, preferred_direction, movement_direction, rotation)//atoms
 


### PR DESCRIPTION
Some stuff gets qdeleted during the move, don't want to be processing them after the fact.