### PR TITLE
Fix MULEbot ID numbers showing nowhere but the alt-click menu

### DIFF
--- a/code/modules/mob/living/simple_animal/bot/mulebot.dm
+++ b/code/modules/mob/living/simple_animal/bot/mulebot.dm
@@ -29,7 +29,7 @@
 	model = "MULE"
 	bot_core_type = /obj/machinery/bot_core/mulebot
 
-	suffix = ""
+	var/id
 
 	path_image_color = "#7F5200"
 
@@ -60,8 +60,8 @@
 
 	var/static/mulebot_count = 0
 	mulebot_count += 1
-	if(!suffix)
-		set_suffix("#[mulebot_count]")
+	set_id(suffix || id || "#[mulebot_count]")
+	suffix = null
 
 /mob/living/simple_animal/bot/mulebot/Destroy()
 	unload(0)
@@ -69,12 +69,12 @@
 	wires = null
 	return ..()
 
-/mob/living/simple_animal/bot/mulebot/proc/set_suffix(suffix)
-	src.suffix = suffix
+/mob/living/simple_animal/bot/mulebot/proc/set_id(new_id)
+	id = new_id
 	if(paicard)
-		bot_name = "\improper MULEbot ([suffix])"
+		bot_name = "\improper MULEbot ([new_id])"
 	else
-		name = "\improper MULEbot ([suffix])"
+		name = "\improper MULEbot ([new_id])"
 
 /mob/living/simple_animal/bot/mulebot/bot_reset()
 	..()
@@ -233,9 +233,9 @@
 			if(new_dest)
 				set_destination(new_dest)
 		if("setid")
-			var/new_id = stripped_input(user, "Enter ID:", name, suffix, MAX_NAME_LEN)
+			var/new_id = stripped_input(user, "Enter ID:", name, id, MAX_NAME_LEN)
 			if(new_id)
-				set_suffix(new_id)
+				set_id(new_id)
 		if("sethome")
 			var/new_home = input(user, "Enter Home:", name, home_destination) as null|anything in GLOB.deliverybeacontags
 			if(new_home)
@@ -260,7 +260,7 @@
 	var/ai = issilicon(user)
 	var/dat
 	dat += "<h3>Multiple Utility Load Effector Mk. V</h3>"
-	dat += "<b>ID:</b> [suffix]<BR>"
+	dat += "<b>ID:</b> [id]<BR>"
 	dat += "<b>Power:</b> [on ? "On" : "Off"]<BR>"
 	dat += "<h3>Status</h3>"
 	dat += "<div class='statusDisplay'>"


### PR DESCRIPTION
:cl:
fix: The MULEbots that the station starts with now show their ID numbers.
/:cl:

MULEbots on the stations have `suffix` set and only show it in the stat panel, which I assume almost nobody looks at, but not the name. Those ordered via crate show it in *both* places. There's no reason for it to show in the stat panel separately, so let's just put it in the name.

Context: `suffix` is a BYOND variable which is extra text to show after the object in stat panels. The only relevant stat panel is the turf alt-click menu.
