### PR TITLE
Improves the way chem machines handle qdel, fixes some runtimes

### DIFF
--- a/code/modules/reagents/chemistry/machinery/chem_dispenser.dm
+++ b/code/modules/reagents/chemistry/machinery/chem_dispenser.dm
@@ -59,6 +59,11 @@
 	recharge()
 	dispensable_reagents = sortList(dispensable_reagents)
 
+/obj/machinery/chem_dispenser/Destroy()
+	QDEL_NULL(beaker)
+	QDEL_NULL(cell)
+	return ..()
+
 /obj/machinery/chem_dispenser/process()
 
 	if(recharged < 0)
@@ -303,6 +308,7 @@
 	if(beaker)
 		beaker.forceMove(drop_location())
 		beaker = null
+	return ..()
 
 /obj/machinery/chem_dispenser/drinks
 	name = "soda dispenser"

--- a/code/modules/reagents/chemistry/machinery/chem_heater.dm
+++ b/code/modules/reagents/chemistry/machinery/chem_heater.dm
@@ -13,6 +13,28 @@
 	var/heater_coefficient = 0.1
 	var/on = FALSE
 
+/obj/machinery/chem_heater/Destroy()
+	QDEL_NULL(beaker)
+	return ..()
+
+/obj/machinery/chem_heater/handle_atom_del(atom/A)
+	. = ..()
+	if(A == beaker)
+		beaker = null
+		update_icon()
+
+/obj/machinery/chem_heater/update_icon()
+	if(beaker)
+		icon_state = "mixer1b"
+	else
+		icon_state = "mixer0b"
+
+/obj/machinery/chem_heater/proc/eject_beaker()
+	if(beaker)
+		beaker.forceMove(drop_location())
+		beaker = null
+		update_icon()
+
 /obj/machinery/chem_heater/RefreshParts()
 	heater_coefficient = 0.1
 	for(var/obj/item/stock_parts/micro_laser/M in component_parts)
@@ -52,12 +74,13 @@
 			return
 		beaker = I
 		to_chat(user, "<span class='notice'>You add [I] to [src].</span>")
-		icon_state = "mixer1b"
+		update_icon()
 		return
 	return ..()
 
 /obj/machinery/chem_heater/on_deconstruction()
 	eject_beaker()
+	return ..()
 
 /obj/machinery/chem_heater/ui_interact(mob/user, ui_key = "main", datum/tgui/ui = null, force_open = FALSE, \
 										datum/tgui/master_ui = null, datum/ui_state/state = GLOB.default_state)
@@ -108,10 +131,3 @@
 			on = FALSE
 			eject_beaker()
 			. = TRUE
-
-/obj/machinery/chem_heater/proc/eject_beaker()
-	if(beaker)
-		beaker.forceMove(drop_location())
-		beaker.reagents.handle_reactions()
-		beaker = null
-		icon_state = "mixer0b"

--- a/code/modules/reagents/chemistry/machinery/pandemic.dm
+++ b/code/modules/reagents/chemistry/machinery/pandemic.dm
@@ -25,6 +25,12 @@
 	QDEL_NULL(beaker)
 	return ..()
 
+/obj/machinery/computer/pandemic/handle_atom_del(atom/A)
+	. = ..()
+	if(A == beaker)
+		beaker = null
+		update_icon()
+
 /obj/machinery/computer/pandemic/proc/get_by_index(thing, index)
 	if(!beaker || !beaker.reagents)
 		return
@@ -121,9 +127,10 @@
 		add_overlay("waitlight")
 
 /obj/machinery/computer/pandemic/proc/eject_beaker()
-	beaker.forceMove(drop_location())
-	beaker = null
-	update_icon()
+	if(beaker)
+		beaker.forceMove(drop_location())
+		beaker = null
+		update_icon()
 
 /obj/machinery/computer/pandemic/ui_interact(mob/user, ui_key = "main", datum/tgui/ui, force_open = FALSE, datum/tgui/master_ui, datum/ui_state/state = GLOB.default_state)
 	ui = SStgui.try_update_ui(user, src, ui_key, ui, force_open)
@@ -159,8 +166,7 @@
 		return
 	switch(action)
 		if("eject_beaker")
-			if(beaker)
-				eject_beaker()
+			eject_beaker()
 			. = TRUE
 		if("empty_beaker")
 			if(beaker)
@@ -236,7 +242,5 @@
 		return ..()
 
 /obj/machinery/computer/pandemic/on_deconstruction()
-	if(beaker)
-		beaker.forceMove(drop_location())
-		beaker = null
+	eject_beaker()
 	. = ..()


### PR DESCRIPTION
Some of the chem machines lacked `Destroy()`, others lacked `handle_atom_del()`, some were missing `on_deconstruction()`, some lacked `..()` calls. This PR fixes it.

Not having `handle_atom_del()` actually resulted in runtimes during chem explosions, others were just possible qdel faults and inconsistent behavior.