### PR TITLE
Makes swarmers check for mobs in objects

### DIFF
--- a/code/game/gamemodes/miniantags/bot_swarm/swarmer.dm
+++ b/code/game/gamemodes/miniantags/bot_swarm/swarmer.dm
@@ -402,6 +402,14 @@
 	to_chat(S, "<span class='warning'>This object does not contain enough materials to work with.</span>")
 	return FALSE
 
+/obj/structure/closet/swarmer_act(mob/living/simple_animal/hostile/swarmer/S)
+	if(!opened)
+		for(var/mob/living/L in contents)
+			if(!issilicon(L) && !isbrain(L))
+				to_chat(S, "<span class='warning'>An organism has been detected inside this object. Aborting.</span>")
+				return FALSE
+	..()
+
 ////END CTRL CLICK FOR SWARMERS////
 
 /mob/living/simple_animal/hostile/swarmer/proc/Fabricate(atom/fabrication_object,fabrication_cost = 0)

--- a/code/game/gamemodes/miniantags/bot_swarm/swarmer.dm
+++ b/code/game/gamemodes/miniantags/bot_swarm/swarmer.dm
@@ -167,9 +167,13 @@
 /turf/closed/indestructible/swarmer_act()
 	return FALSE
 
-/obj/swarmer_act()
+/obj/swarmer_act(mob/living/simple_animal/hostile/swarmer/S)
 	if(resistance_flags & INDESTRUCTIBLE)
 		return FALSE
+	for(var/mob/living/L in contents)
+		if(!issilicon(L) && !isbrain(L))
+			to_chat(S, "<span class='warning'>An organism has been detected inside this object. Aborting.</span>")
+			return FALSE
 	return ..()
 
 /obj/item/swarmer_act(mob/living/simple_animal/hostile/swarmer/S)
@@ -401,14 +405,6 @@
 /obj/machinery/hydroponics/soil/swarmer_act(mob/living/simple_animal/hostile/swarmer/S)
 	to_chat(S, "<span class='warning'>This object does not contain enough materials to work with.</span>")
 	return FALSE
-
-/obj/structure/closet/swarmer_act(mob/living/simple_animal/hostile/swarmer/S)
-	if(!opened)
-		for(var/mob/living/L in contents)
-			if(!issilicon(L) && !isbrain(L))
-				to_chat(S, "<span class='warning'>An organism has been detected inside this object. Aborting.</span>")
-				return FALSE
-	..()
 
 ////END CTRL CLICK FOR SWARMERS////
 


### PR DESCRIPTION
:cl: Swindly
fix: Swarmers can no longer deconstruct objects with living things in them.
/:cl:

Fixes https://github.com/tgstation/tgstation/issues/27912