### PR TITLE
Fixes integrated circuit reagent components not working while in mobs, adds new helper procs

### DIFF
--- a/code/modules/integrated_electronics/core/assemblies.dm
+++ b/code/modules/integrated_electronics/core/assemblies.dm
@@ -122,9 +122,8 @@
 		if(!battery)
 			to_chat(usr, "<span class='warning'>There's no power cell to remove from \the [src].</span>")
 		else
-			var/turf/T = get_turf(src)
-			battery.forceMove(T)
-			playsound(T, 'sound/items/Crowbar.ogg', 50, 1)
+			battery.forceMove(drop_location())
+			playsound(src, 'sound/items/Crowbar.ogg', 50, 1)
 			to_chat(usr, "<span class='notice'>You pull \the [battery] out of \the [src]'s power supplier.</span>")
 			battery = null
 
@@ -392,6 +391,17 @@
 /obj/item/device/electronic_assembly/proc/get_object()
 	return src
 
+
+// Returns the location to be used for dropping items.
+// Same as the regular drop_location(), but with checks being run on acting_object if necessary.
+/obj/item/integrated_circuit/drop_location()
+	var/atom/movable/acting_object = get_object()
+
+	// plz no infinite loops
+	if(acting_object == src)
+		return ..()
+
+	return acting_object.drop_location()
 
 
 

--- a/code/modules/integrated_electronics/core/integrated_circuit.dm
+++ b/code/modules/integrated_electronics/core/integrated_circuit.dm
@@ -330,3 +330,43 @@ a creative player the means to solve many problems.  Circuits are held inside an
 		return assembly.get_object()
 	else
 		return src	// If not, the component is acting on its own.
+
+
+// Returns the location to be used for dropping items.
+// Same as the regular drop_location(), but with proc being run on assembly if there is any.
+/obj/item/integrated_circuit/drop_location()
+	// If the component is located in an assembly, let the assembly figure that one out.
+	if(assembly)
+		return assembly.drop_location()
+	else
+		return ..()	// If not, the component is acting on its own.
+
+
+// Checks if the target object is reachable. Useful for various manipulators and manipulator-like objects.
+/obj/item/integrated_circuit/proc/check_target(atom/target, exclude_contents = FALSE, exclude_components = FALSE, exclude_self = FALSE)
+	if(!target)
+		return FALSE
+
+	var/atom/movable/acting_object = get_object()
+
+	if(exclude_self && target == acting_object)
+		return FALSE
+
+	if(exclude_components && assembly)
+		if(target in assembly.assembly_components)
+			return FALSE
+
+		if(target == assembly.battery)
+			return FALSE
+
+	if(target.Adjacent(acting_object) && isturf(target.loc))
+		return TRUE
+
+	if(!exclude_contents && (target in acting_object.GetAllContents()))
+		return TRUE
+
+	if(target in acting_object.loc)
+		return TRUE
+
+	return FALSE
+

--- a/code/modules/integrated_electronics/subtypes/manipulation.dm
+++ b/code/modules/integrated_electronics/subtypes/manipulation.dm
@@ -307,7 +307,7 @@
 		var/mode = get_pin_data(IC_INPUT, 2)
 
 		if(mode == 1)
-			if(AM.Adjacent(acting_object) && isturf(AM.loc))
+			if(check_target(AM, exclude_contents = TRUE))
 				if((contents.len < max_items) && (!max_w_class || AM.w_class <= max_w_class))
 					AM.forceMove(src)
 		if(mode == 0)
@@ -375,25 +375,19 @@
 	if(max_w_class && (A.w_class > max_w_class))
 		return
 
-	var/atom/movable/acting_object = get_object()
-	if(!(A.Adjacent(acting_object) && isturf(A.loc)) && !(A in acting_object.GetAllContents()))
+	// Is the target inside the assembly or close to it?
+	if(!check_target(A, exclude_components = TRUE))
 		return
 
-	var/turf/T = get_turf(acting_object)
+	var/turf/T = get_turf(get_object())
 	if(!T)
 		return
-
-	// No ejecting assembly components or power cells
-	if(assembly)
-		if((A in assembly.assembly_components) || A == assembly.battery)
-			return
 
 	// If the item is in mob's inventory, try to remove it from there.
 	if(ismob(A.loc))
 		var/mob/living/M = A.loc
 		if(!M.temporarilyRemoveItemFromInventory(A))
 			return
-
 
 	var/x_abs = Clamp(T.x + target_x_rel, 0, world.maxx)
 	var/y_abs = Clamp(T.y + target_y_rel, 0, world.maxy)


### PR DESCRIPTION
* New helper: `check_target`. Includes a lot of sanity checks you would like to run on targets in circuits that manipulate external objects.
* `drop_location()` proc now uses `get_object()` to determine actual drop location.
* Reagent IC components now use `check_target`, which gets rid of issues like pumps not working if the assembly is in your hand.
* Reagent ICs now run the draw/inject checks properly, fixing pumps being unable to draw reagents from tanks and similar issues.
* More reagent components code improvements and fixes.