### PR TITLE
Fix miscapitalized integrated HUDs prereqs

### DIFF
--- a/code/modules/research/techweb/all_nodes.dm
+++ b/code/modules/research/techweb/all_nodes.dm
@@ -404,7 +404,7 @@
 	id = "adv_cyber_implants"
 	display_name = "Advanced Cybernetic Implants"
 	description = "Upgraded and more powerful cybernetic implants."
-	prereq_ids = list("neural_programming", "cyber_implants","integrated_HUDS")
+	prereq_ids = list("neural_programming", "cyber_implants","integrated_HUDs")
 	design_ids = list("ci-toolset", "ci-surgery", "ci-reviver")
 	research_cost = 2500
 	export_price = 10000
@@ -469,7 +469,7 @@
 	display_name = "Experimental Flight Equipment"
 	description = "Highly advanced construction tools."
 	design_ids = list("flightshoes", "flightpack", "flightsuit")
-	prereq_ids = list("adv_engi","integrated_HUDS", "adv_power" , "high_efficiency")
+	prereq_ids = list("adv_engi","integrated_HUDs", "adv_power" , "high_efficiency")
 	research_cost = 5000
 	export_price = 10000
 


### PR DESCRIPTION
:cl:
fix: The dependency by Advanced Cybernetic Implants and Experimental Flight Equipment on Integrated HUDs has been restored.
/:cl:

```
runtime error: 
[23:41:14]WARNING: Invalid research prerequisite node with ID integrated_HUDS detected in node Advanced Cybernetic Implants[adv_cyber_implants] removed.
[23:41:14]proc name: stack trace (/proc/stack_trace)
[23:41:14]  source file: unsorted.dm,1256
[23:41:14]  usr: (src)
[23:41:14]  src: null
[23:41:14]  call stack:
[23:41:14]stack trace("WARNING: Invalid research prer...")
[23:41:14]verify techweb nodes()
[23:41:14]initialize all techweb nodes(0)
[23:41:14]Research (/datum/controller/subsystem/research): Initialize(852742)
[23:41:14]Master (/datum/controller/master): Initialize(10, 0)
runtime error: 
[23:41:14]WARNING: Invalid research prerequisite node with ID integrated_HUDS detected in node Experimental Flight Equipment[exp_flight] removed.
[23:41:14]proc name: stack trace (/proc/stack_trace)
[23:41:14]  source file: unsorted.dm,1256
[23:41:14]  usr: (src)
[23:41:14]  src: null
[23:41:14]  call stack:
[23:41:14]stack trace("WARNING: Invalid research prer...")
[23:41:14]verify techweb nodes()
[23:41:14]initialize all techweb nodes(0)
[23:41:14]Research (/datum/controller/subsystem/research): Initialize(852742)
[23:41:14]Master (/datum/controller/master): Initialize(10, 0)
```
