### PR TITLE
Designs now default to department flag ALL instead of NONE

### DIFF
--- a/code/modules/research/designs.dm
+++ b/code/modules/research/designs.dm
@@ -42,7 +42,7 @@ other types of metals and chemistry for reagents).
 	var/maxstack = 1
 	var/lathe_time_factor = 1			//How many times faster than normal is this to build on the protolathe
 	var/dangerous_construction = FALSE	//notify and log for admin investigations if this is printed.
-	var/departmental_flags = NONE			//bitflags for deplathes.
+	var/departmental_flags = ALL			//bitflags for deplathes.
 	var/list/datum/techweb_node/unlocked_by = list()
 	var/icon_cache
 


### PR DESCRIPTION
they'll be overridden on childs.
also fixes comms equipment being unprintable.
fixes #33464
:cl:
bugfix: You can now print telecomms equipment again.
/:cl: