### PR TITLE
Fixes glass shard/bananium floor behavior for cameras and ghosts

### DIFF
--- a/code/game/objects/items/stacks/sheets/glass.dm
+++ b/code/game/objects/items/stacks/sheets/glass.dm
@@ -251,7 +251,7 @@ GLOBAL_LIST_INIT(prglass_recipes, list ( \
 	else
 		return ..()
 
-/obj/item/shard/Crossed(mob/AM)
-	if(istype(AM) && has_gravity(loc))
+/obj/item/shard/Crossed(mob/living/L)
+	if(istype(L) && has_gravity(loc))
 		playsound(loc, 'sound/effects/glass_step.ogg', 50, 1)
 	. = ..()

--- a/code/game/turfs/simulated/floor/mineral_floor.dm
+++ b/code/game/turfs/simulated/floor/mineral_floor.dm
@@ -129,10 +129,10 @@
 	icons = list("bananium","bananium_dam")
 	var/spam_flag = 0
 
-/turf/open/floor/mineral/bananium/Entered(var/mob/AM)
+/turf/open/floor/mineral/bananium/Entered(var/mob/living/L)
 	.=..()
 	if(!.)
-		if(istype(AM))
+		if(istype(L))
 			squeek()
 
 /turf/open/floor/mineral/bananium/attackby(obj/item/W, mob/user, params)


### PR DESCRIPTION
Fixes #33461
Fixes #33422

:cl: Naksu
fix: glass shards and bananium floors no longer make a sound when "walked" over by a camera or a ghost
/:cl: