### PR TITLE
Fixes genetics mutations disappearing

### DIFF
--- a/code/datums/mutations/speech.dm
+++ b/code/datums/mutations/speech.dm
@@ -98,6 +98,7 @@
 /datum/mutation/human/unintelligible
 	name = "Unintelligible"
 	quality = NEGATIVE
+	dna_block = NON_SCANNABLE
 	text_gain_indication = "<span class='danger'>You can't seem to form any coherent thoughts!</span>"
 	text_lose_indication = "<span class='danger'>Your mind feels more clear.</span>"
 


### PR DESCRIPTION
Fixes #33486 

:cl: deathride58
fix: Genetics will no longer have a random block completely disappear each round
/:cl:

This was broken after the brain damage rework, unintelligible was meant to be removed from genetics, and the block count was decreased as a result, yet unintelligible wasn't actually removed from the pool of possible mutations, resulting in one random mutation being unobtainable each round while unintelligible remained a genetical mutation