### PR TITLE
Allows for more than one cross server

### DIFF
--- a/code/__HELPERS/roundend.dm
+++ b/code/__HELPERS/roundend.dm
@@ -87,7 +87,7 @@
 	
 	send2irc("Server", "Round just ended.")
 	
-	if(CONFIG_GET(string/cross_server_address))
+	if(length(CONFIG_GET(keyed_string_list/cross_server)))
 		send_news_report()
 
 	CHECK_TICK

--- a/code/controllers/configuration/config_entry.dm
+++ b/code/controllers/configuration/config_entry.dm
@@ -81,12 +81,12 @@
 			if(LIST_MODE_TEXT)
 				temp = key_value
 				continue_check = temp
-		if(continue_check && ValidateKeyName(key_name))
+		if(continue_check && ValidateListEntry(key_name, temp))
 			value[key_name] = temp
 			return TRUE
 	return FALSE
 
-/datum/config_entry/proc/ValidateKeyName(key_name)
+/datum/config_entry/proc/ValidateListEntry(key_name, key_value)
 	return TRUE
 
 /datum/config_entry/string

--- a/code/controllers/configuration/entries/comms.dm
+++ b/code/controllers/configuration/entries/comms.dm
@@ -4,13 +4,13 @@ CONFIG_DEF(string/comms_key)
 	protection = CONFIG_ENTRY_HIDDEN
 
 /datum/config_entry/string/comms_key/ValidateAndSet(str_val)
-    return str_val != "default_pwd" && length(str_val) > 6 && ..()
+	return str_val != "default_pwd" && length(str_val) > 6 && ..()
 
 CONFIG_DEF(keyed_string_list/cross_server)
 	protection = CONFIG_ENTRY_LOCKED
 
 /datum/config_entry/keyed_string_list/cross_server/ValidateAndSet(str_val)
-    . = ..()
+	. = ..()
 	if(.)
 		var/list/newv = list()
 		for(var/I in value)
@@ -18,7 +18,7 @@ CONFIG_DEF(keyed_string_list/cross_server)
 		value = newv
 
 /datum/config_entry/keyed_string_list/cross_server/ValidateListEntry(key_name, key_value)
-    return key_value != "byond:\\address:port" && ..()
+	return key_value != "byond:\\address:port" && ..()
 
 CONFIG_DEF(string/cross_comms_name)
 

--- a/code/controllers/configuration/entries/comms.dm
+++ b/code/controllers/configuration/entries/comms.dm
@@ -6,11 +6,19 @@ CONFIG_DEF(string/comms_key)
 /datum/config_entry/string/comms_key/ValidateAndSet(str_val)
     return str_val != "default_pwd" && length(str_val) > 6 && ..()
 
-CONFIG_DEF(string/cross_server_address)
+CONFIG_DEF(keyed_string_list/cross_server)
 	protection = CONFIG_ENTRY_LOCKED
 
-/datum/config_entry/string/cross_server_address/ValidateAndSet(str_val)
-    return str_val != "byond:\\address:port" && ..()
+/datum/config_entry/keyed_string_list/cross_server/ValidateAndSet(str_val)
+    . = ..()
+	if(.)
+		var/list/newv = list()
+		for(var/I in value)
+			newv[replacetext(I, "+", " ")] = value[I]
+		value = newv
+
+/datum/config_entry/keyed_string_list/cross_server/ValidateListEntry(key_name, key_value)
+    return key_value != "byond:\\address:port" && ..()
 
 CONFIG_DEF(string/cross_comms_name)
 

--- a/code/controllers/configuration/entries/game_options.dm
+++ b/code/controllers/configuration/entries/game_options.dm
@@ -4,12 +4,12 @@ CONFIG_DEF(number_list/repeated_mode_adjust)
 
 CONFIG_DEF(keyed_number_list/probability)
 
-/datum/config_entry/keyed_number_list/probability/ValidateKeyName(key_name)
+/datum/config_entry/keyed_number_list/probability/ValidateListEntry(key_name)
 	return key_name in config.modes
 
 CONFIG_DEF(keyed_number_list/max_pop)
 
-/datum/config_entry/keyed_number_list/max_pop/ValidateKeyName(key_name)
+/datum/config_entry/keyed_number_list/max_pop/ValidateListEntry(key_name)
 	return key_name in config.modes
 
 CONFIG_DEF(keyed_number_list/min_pop)

--- a/code/controllers/configuration/entries/game_options.dm
+++ b/code/controllers/configuration/entries/game_options.dm
@@ -14,17 +14,17 @@ CONFIG_DEF(keyed_number_list/max_pop)
 
 CONFIG_DEF(keyed_number_list/min_pop)
 
-/datum/config_entry/keyed_number_list/min_pop/ValidateKeyName(key_name)
+/datum/config_entry/keyed_number_list/min_pop/ValidateListEntry(key_name, key_value)
 	return key_name in config.modes
 
 CONFIG_DEF(keyed_flag_list/continuous)	// which roundtypes continue if all antagonists die
 
-/datum/config_entry/keyed_flag_list/continuous/ValidateKeyName(key_name)
+/datum/config_entry/keyed_flag_list/continuous/ValidateListEntry(key_name, key_value)
 	return key_name in config.modes
 
 CONFIG_DEF(keyed_flag_list/midround_antag)	// which roundtypes use the midround antagonist system
 
-/datum/config_entry/keyed_flag_list/midround_antag/ValidateKeyName(key_name)
+/datum/config_entry/keyed_flag_list/midround_antag/ValidateListEntry(key_name, key_value)
 	return key_name in config.modes
 
 CONFIG_DEF(keyed_string_list/policy)

--- a/code/game/machinery/computer/communications.dm
+++ b/code/game/machinery/computer/communications.dm
@@ -463,8 +463,9 @@
 				if (authenticated==2)
 					dat += "<BR><BR><B>Captain Functions</B>"
 					dat += "<BR>\[ <A HREF='?src=[REF(src)];operation=announce'>Make a Captain's Announcement</A> \]"
-					if(CONFIG_GET(string/cross_server_address))
-						dat += "<BR>\[ <A HREF='?src=[REF(src)];operation=crossserver'>Send a message to an allied station</A> \]"
+					var/cross_servers_count = length(CONFIG_GET(keyed_string_list/cross_server))
+					if(cross_servers_count)
+						dat += "<BR>\[ <A HREF='?src=[REF(src)];operation=crossserver'>Send a message to [cross_servers_count == 1 ? "an " : ""]allied station[cross_servers_count > 1 ? "s" : ""]</A> \]"
 					if(SSmapping.config.allow_custom_shuttles)
 						dat += "<BR>\[ <A HREF='?src=[REF(src)];operation=purchase_menu'>Purchase Shuttle</A> \]"
 					dat += "<BR>\[ <A HREF='?src=[REF(src)];operation=changeseclevel'>Change Alert Level</A> \]"

--- a/code/modules/admin/verbs/adminhelp.dm
+++ b/code/modules/admin/verbs/adminhelp.dm
@@ -596,15 +596,18 @@ GLOBAL_DATUM_INIT(ahelp_tickets, /datum/admin_help_tickets, new)
 
 /proc/send2otherserver(source,msg,type = "Ahelp")
 	var/comms_key = CONFIG_GET(string/comms_key)
-	if(comms_key)
-		var/list/message = list()
-		message["message_sender"] = source
-		message["message"] = msg
-		message["source"] = "([CONFIG_GET(string/cross_comms_name)])"
-		message["key"] = comms_key
-		message["crossmessage"] = type
+	if(!comms_key)
+		return
+	var/list/message = list()
+	message["message_sender"] = source
+	message["message"] = msg
+	message["source"] = "([CONFIG_GET(string/cross_comms_name)])"
+	message["key"] = comms_key
+	message["crossmessage"] = type
 
-		world.Export("[CONFIG_GET(string/cross_server_address)]?[list2params(message)]")
+	var/list/servers = CONFIG_GET(keyed_string_list/cross_server)
+	for(var/I in servers)
+		world.Export("[servers[I]]?[list2params(message)]")
 
 
 /proc/ircadminwho()

--- a/code/modules/mob/dead/dead.dm
+++ b/code/modules/mob/dead/dead.dm
@@ -14,7 +14,7 @@ INITIALIZE_IMMEDIATE(/mob/dead)
 
 	prepare_huds()
 
-	if(CONFIG_GET(string/cross_server_address))
+	if(length(CONFIG_GET(keyed_string_list/cross_server)))
 		verbs += /mob/dead/proc/server_hop
 	set_focus(src)
 	return INITIALIZE_HINT_NORMAL
@@ -36,20 +36,36 @@ INITIALIZE_IMMEDIATE(/mob/dead)
 	set desc= "Jump to the other server"
 	if(notransform)
 		return
-	var/csa = CONFIG_GET(string/cross_server_address)
-	if(csa)
-		verbs -= /mob/dead/proc/server_hop
-		to_chat(src, "<span class='notice'>Server Hop has been disabled.</span>")
+	var/list/csa = CONFIG_GET(keyed_string_list/cross_server)
+	var/pick
+	switch(csa.len)
+		if(0)
+			verbs -= /mob/dead/proc/server_hop
+			to_chat(src, "<span class='notice'>Server Hop has been disabled.</span>")
+		if(1)
+			pick = csa[0]
+		else
+			pick = input(src, "Pick a server to jump to", "Server Hop") as null|anything in csa
+
+	if(!pick)
 		return
-	if (alert(src, "Jump to server running at [csa]?", "Server Hop", "Yes", "No") != "Yes")
-		return 0
-	if (client && csa)
-		to_chat(src, "<span class='notice'>Sending you to [csa].</span>")
-		new /obj/screen/splash(client)
-		notransform = TRUE
-		sleep(29)	//let the animation play
-		notransform = FALSE
-		winset(src, null, "command=.options") //other wise the user never knows if byond is downloading resources
-		client << link(csa + "?server_hop=[key]")
-	else
-		to_chat(src, "<span class='error'>There is no other server configured!</span>")
+	
+	var/addr = csa[pick]
+
+	if(alert(src, "Jump to server [pick] ([addr])?", "Server Hop", "Yes", "No") != "Yes")
+		return
+
+	var/client/C = client
+	to_chat(C, "<span class='notice'>Sending you to [pick].</span>")
+	new /obj/screen/splash(C)
+
+	notransform = TRUE
+	sleep(29)	//let the animation play
+	notransform = FALSE
+
+	if(!C)
+		return
+
+	winset(src, null, "command=.options") //other wise the user never knows if byond is downloading resources
+
+	C << link("[addr]?server_hop=[key]")

--- a/config/comms.txt
+++ b/config/comms.txt
@@ -2,7 +2,9 @@
 #COMMS_KEY default_pwd
 
 ## World address and port for server recieving cross server messages
-#CROSS_SERVER_ADDRESS byond:\\address:port
+## Use '+' to denote spaces in ServerName
+## Repeat this entry to add more servers
+#CROSS_SERVER ServerName byond:\\address:port
 
 ## Name that the server calls itself in communications
 #CROSS_COMMS_NAME


### PR DESCRIPTION
@MrStonedOne 

:cl:
config: Added multi string list entry CROSS_SERVER. e.g. CROSS_SERVER Server+Name byond://server.net:1337
config: CROSS_SERVER_ADDRESS removed
/:cl:

Server Hop verb now shows a list of servers if there is more than one. send2otherserver sends to all servers. They all still need the same comms key

Terry justifies this