### PR TITLE
Fixes Cybernetic Lungs not being available in cyber_organs techweb node

### DIFF
--- a/code/modules/research/techweb/all_nodes.dm
+++ b/code/modules/research/techweb/all_nodes.dm
@@ -387,7 +387,7 @@
 	display_name = "Cybernetic Organs"
 	description = "We have the technology to rebuild him."
 	prereq_ids = list("adv_biotech", "cyborg")
-	design_ids = list("cybernetic_heart", "cybernetic_liver", "cybernetic_liver_u")
+	design_ids = list("cybernetic_heart", "cybernetic_liver", "cybernetic_liver_u", "cybernetic_lungs")
 	research_cost = 2500
 	export_price = 10000
 


### PR DESCRIPTION
What it says on the tin. I assume this was an oversight and not a willing omission

:cl: Epoc
fix: Adds Cybernetic Lungs to the Cyber Organs research node
/:cl:

Fixes #33489