### PR TITLE
Adds bag of holding to cargo protolathe

### DIFF
--- a/code/modules/research/designs/bluespace_designs.dm
+++ b/code/modules/research/designs/bluespace_designs.dm
@@ -22,7 +22,7 @@
 	build_path = /obj/item/storage/backpack/holding
 	category = list("Bluespace Designs")
 	dangerous_construction = TRUE
-	departmental_flags = DEPARTMENTAL_FLAG_SCIENCE
+	departmental_flags = DEPARTMENTAL_FLAG_SCIENCE | DEPARTMENTAL_FLAG_CARGO
 
 /datum/design/bluespace_crystal
 	name = "Artificial Bluespace Crystal"


### PR DESCRIPTION
:cl: imsxz
tweak: cargo protolathe can now print bag of holding
/:cl:

I find bag of holding extremely useful as mining, especially as there's so many mining items that can't fit in a normal backpack. Tons of tendril and megafauna loot uses it, alongside normal mining gear like the crusher. Additionally, miners tend to stock up on healing items too, which can take up a lot of inventory space.

I can't speak for all miners, but I end up printing them even more than I print NV mesons, and I shouldn't have to use another departments lathe to print something that I use so often.