### PR TITLE
Reverts part of #32196 "Nerfs smoke machine + improves grammar"

### DIFF
--- a/code/modules/reagents/chemistry/machinery/smoke_machine.dm
+++ b/code/modules/reagents/chemistry/machinery/smoke_machine.dm
@@ -13,7 +13,7 @@
 	var/useramount = 30 // Last used amount
 	var/volume = 300
 	var/setting = 3
-	var/list/possible_settings = list(3,6,9)
+	var/list/possible_settings = list(3,6,9,12,15)
 
 /datum/effect_system/smoke_spread/chem/smoke_machine/set_up(datum/reagents/carry, setting = 3, efficiency = 10, loc)
 	amount = setting


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/16315400/33920096-1a97e952-df8a-11e7-8a7d-628fd42f207e.png)

![image](https://user-images.githubusercontent.com/16315400/33920182-8f5ca854-df8a-11e7-8580-05b6ccbd971f.png)


Reverts part of #32196


@praisenarsie was specifically asked to add upgrading range via components, he never did so. As well, the GUI is misleading and implies that you can upgrade it. I lack the knowledge or skill to easily make these changes myself, so unless someone else is willing to do so, I am simply reverting the change. The reduced chem capacity and improved grammar has not be changed.