### PR TITLE
SSinput tweaks to address server side lag

### DIFF
--- a/code/controllers/subsystem/input.dm
+++ b/code/controllers/subsystem/input.dm
@@ -1,8 +1,8 @@
 SUBSYSTEM_DEF(input)
 	name = "Input"
 	wait = 1 //SS_TICKER means this runs every tick
-	flags = SS_TICKER | SS_NO_INIT | SS_KEEP_TIMING
-	priority = 151
+	flags = SS_TICKER | SS_NO_INIT
+	priority = 1000
 	runlevels = RUNLEVELS_DEFAULT | RUNLEVEL_LOBBY
 
 /datum/controller/subsystem/input/fire()


### PR DESCRIPTION
To hopefully address some concerns in #33502

- Give it priority higher than SSoverlays (500)
- Remove SS_KEEP_TIMING which I believe is mainly responsible for the issue outlined (@MrStonedOne please confirm)

It still remains fundamentally unfixable because input lag isn't hidden anymore (@optimumtact was fucking right)