### PR TITLE
Removed drone light in favor of night vision

### DIFF
--- a/code/modules/mob/living/simple_animal/friendly/drone/_drone.dm
+++ b/code/modules/mob/living/simple_animal/friendly/drone/_drone.dm
@@ -58,7 +58,6 @@
 	"1. You may not involve yourself in the matters of another being, even if such matters conflict with Law Two or Law Three, unless the other being is another Drone.\n"+\
 	"2. You may not harm any being, regardless of intent or circumstance.\n"+\
 	"3. Your goals are to build, maintain, repair, improve, and provide power to the best of your abilities, You must never actively work against these goals."
-	//var/light_on = 0
 	var/heavy_emp_damage = 25 //Amount of damage sustained if hit by a heavy EMP pulse
 	var/alarms = list("Atmosphere" = list(), "Fire" = list(), "Power" = list())
 	var/obj/item/internal_storage //Drones can store one item, of any size/type in their body

--- a/code/modules/mob/living/simple_animal/friendly/drone/_drone.dm
+++ b/code/modules/mob/living/simple_animal/friendly/drone/_drone.dm
@@ -48,6 +48,7 @@
 	faction = list("neutral","silicon","turret")
 	dextrous = TRUE
 	dextrous_hud_type = /datum/hud/dextrous/drone
+	lighting_alpha = LIGHTING_PLANE_ALPHA_MOSTLY_INVISIBLE
 	var/staticChoice = "static"
 	var/list/staticChoices = list("static", "blank", "letter", "animal")
 	var/picked = FALSE //Have we picked our visual appearence (+ colour if applicable)
@@ -57,7 +58,7 @@
 	"1. You may not involve yourself in the matters of another being, even if such matters conflict with Law Two or Law Three, unless the other being is another Drone.\n"+\
 	"2. You may not harm any being, regardless of intent or circumstance.\n"+\
 	"3. Your goals are to build, maintain, repair, improve, and provide power to the best of your abilities, You must never actively work against these goals."
-	var/light_on = 0
+	//var/light_on = 0
 	var/heavy_emp_damage = 25 //Amount of damage sustained if hit by a heavy EMP pulse
 	var/alarms = list("Atmosphere" = list(), "Fire" = list(), "Power" = list())
 	var/obj/item/internal_storage //Drones can store one item, of any size/type in their body

--- a/code/modules/mob/living/simple_animal/friendly/drone/extra_drone_types.dm
+++ b/code/modules/mob/living/simple_animal/friendly/drone/extra_drone_types.dm
@@ -148,7 +148,7 @@
 	qdel(access_card) //we don't have free access
 	access_card = null
 	verbs -= /mob/living/simple_animal/drone/verb/check_laws
-	verbs -= /mob/living/simple_animal/drone/verb/toggle_light
+	//verbs -= /mob/living/simple_animal/drone/verb/toggle_light
 	verbs -= /mob/living/simple_animal/drone/verb/drone_ping
 
 /mob/living/simple_animal/drone/cogscarab/Login()

--- a/code/modules/mob/living/simple_animal/friendly/drone/extra_drone_types.dm
+++ b/code/modules/mob/living/simple_animal/friendly/drone/extra_drone_types.dm
@@ -148,7 +148,6 @@
 	qdel(access_card) //we don't have free access
 	access_card = null
 	verbs -= /mob/living/simple_animal/drone/verb/check_laws
-	//verbs -= /mob/living/simple_animal/drone/verb/toggle_light
 	verbs -= /mob/living/simple_animal/drone/verb/drone_ping
 
 /mob/living/simple_animal/drone/cogscarab/Login()

--- a/code/modules/mob/living/simple_animal/friendly/drone/verbs.dm
+++ b/code/modules/mob/living/simple_animal/friendly/drone/verbs.dm
@@ -12,23 +12,6 @@
 	to_chat(src, "<b>Drone Laws</b>")
 	to_chat(src, laws)
 
-/* Removed in favor of night vision
-/mob/living/simple_animal/drone/verb/toggle_light()
-	set category = "Drone"
-	set name = "Toggle drone light"
-	if(stat == DEAD)
-		to_chat(src, "<span class='warning'>There's no light in your life... by that I mean you're dead.</span>")
-		return
-	if(light_on)
-		set_light(0)
-	else
-		set_light(8)
-
-	light_on = !light_on
-
-	to_chat(src, "<span class='notice'>Your light is now [light_on ? "on" : "off"].</span>")
-*/
-
 /mob/living/simple_animal/drone/verb/drone_ping()
 	set category = "Drone"
 	set name = "Drone ping"

--- a/code/modules/mob/living/simple_animal/friendly/drone/verbs.dm
+++ b/code/modules/mob/living/simple_animal/friendly/drone/verbs.dm
@@ -12,6 +12,7 @@
 	to_chat(src, "<b>Drone Laws</b>")
 	to_chat(src, laws)
 
+/* Removed in favor of night vision
 /mob/living/simple_animal/drone/verb/toggle_light()
 	set category = "Drone"
 	set name = "Toggle drone light"
@@ -26,6 +27,7 @@
 	light_on = !light_on
 
 	to_chat(src, "<span class='notice'>Your light is now [light_on ? "on" : "off"].</span>")
+*/
 
 /mob/living/simple_animal/drone/verb/drone_ping()
 	set category = "Drone"


### PR DESCRIPTION
Fixes #33447

This is because drone's light could interfere with shadowlings and some other cases, and also because there was a bug where drone's lights could be seen from outside of vents when they were vent crawling.

[Changelogs]: # (Your PR should contain a detailed changelog of notable changes, titled and categorized appropriately. This includes, new features, sprites, sounds, balance changes, admin tools, map edits, removals, big refactors, config changes, hosting changes and important fixes. An example changelog has been provided below for you to edit. If you need additional help, read https://github.com/tgstation/tgstation/wiki/Changelogs)

:cl: AverageJoe82
add: drones now have night vision
del: drones no longer have lights
/:cl:

[why]: # (Please add a short description [two lines down] of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.)
