### PR TITLE
Fix shuttle autocalls when the round is already over

### DIFF
--- a/code/controllers/subsystem/shuttle.dm
+++ b/code/controllers/subsystem/shuttle.dm
@@ -305,6 +305,9 @@ SUBSYSTEM_DEF(shuttle)
 	return 1
 
 /datum/controller/subsystem/shuttle/proc/autoEvac()
+	if (!SSticker.IsRoundInProgress())
+		return
+
 	var/callShuttle = 1
 
 	for(var/thing in GLOB.shuttle_caller_list)


### PR DESCRIPTION
:cl:
fix: The shuttle will no longer be autocalled if the round has already ended.
/:cl:

Fixes #25502.
