### PR TITLE
Defines all subsystem priority values

### DIFF
--- a/code/__DEFINES/subsystems.dm
+++ b/code/__DEFINES/subsystems.dm
@@ -70,6 +70,40 @@
 #define INIT_ORDER_SQUEAK -40
 #define INIT_ORDER_PERSISTENCE -100
 
+// Subsystem fire priority, from lowest to highest priority
+// If the subsystem isn't listed here it's either DEFAULT or PROCESS (if it's a processing subsystem child)
+
+#define FIRE_PRIORITY_IDLE_NPC		1
+#define FIRE_PRIORITY_SERVER_MAINT	1
+
+#define FIRE_PRIORITY_GARBAGE		4
+#define FIRE_PRIORITY_RESEARCH		4
+#define FIRE_PRIORITY_AIR			5
+#define FIRE_PRIORITY_NPC			5
+#define FIRE_PRIORITY_PROCESS		6
+#define FIRE_PRIORITY_THROWING		6
+#define FIRE_PRIORITY_FLIGHTPACKS	7
+#define FIRE_PRIORITY_SPACEDRIFT	7
+#define FIRE_PRIOTITY_SMOOTHING		8
+#define FIRE_PRIORITY_ORBIT			8
+#define FIRE_PRIORITY_OBJ			9
+#define FIRE_PRIORUTY_FIELDS		9
+#define FIRE_PRIORITY_ACID			9
+#define FIRE_PRIOTITY_BURNING		9
+#define FIRE_PRIORITY_INBOUNDS		9
+
+#define FIRE_PRIORITY_DEFAULT		10
+
+#define FIRE_PRIORITY_PARALLAX		11
+#define FIRE_PRIORITY_NETWORKS		12
+#define FIRE_PRIORITY_MOBS			13
+#define FIRE_PRIORITY_TGUI			14
+
+#define FIRE_PRIORITY_TICKER		19
+#define FIRE_PRIORITY_OVERLAYS		20
+
+#define FIRE_PRIORITY_INPUT			100 // This must always always be the max highest priority. Player input must never be lost.
+
 // SS runlevels
 
 #define RUNLEVEL_INIT 0

--- a/code/controllers/subsystem.dm
+++ b/code/controllers/subsystem.dm
@@ -4,7 +4,7 @@
 	name = "fire coderbus" //name of the subsystem
 	var/init_order = INIT_ORDER_DEFAULT		//order of initialization. Higher numbers are initialized first, lower numbers later. Use defines in __DEFINES/subsystems.dm for easy understanding of order.
 	var/wait = 20			//time to wait (in deciseconds) between each call to fire(). Must be a positive integer.
-	var/priority = 50		//When mutiple subsystems need to run in the same tick, higher priority subsystems will run first and be given a higher share of the tick before MC_TICK_CHECK triggers a sleep
+	var/priority = FIRE_PRIORITY_DEFAULT	//When mutiple subsystems need to run in the same tick, higher priority subsystems will run first and be given a higher share of the tick before MC_TICK_CHECK triggers a sleep
 
 	var/flags = 0			//see MC.dm in __DEFINES Most flags must be set on world start to take full effect. (You can also restart the mc to force them to process again)
 

--- a/code/controllers/subsystem/acid.dm
+++ b/code/controllers/subsystem/acid.dm
@@ -1,6 +1,6 @@
 SUBSYSTEM_DEF(acid)
 	name = "Acid"
-	priority = 40
+	priority = FIRE_PRIORITY_ACID
 	flags = SS_NO_INIT|SS_BACKGROUND
 	runlevels = RUNLEVEL_GAME | RUNLEVEL_POSTGAME
 

--- a/code/controllers/subsystem/air.dm
+++ b/code/controllers/subsystem/air.dm
@@ -9,7 +9,7 @@
 SUBSYSTEM_DEF(air)
 	name = "Atmospherics"
 	init_order = INIT_ORDER_AIR
-	priority = 20
+	priority = FIRE_PRIORITY_AIR
 	wait = 5
 	flags = SS_BACKGROUND
 	runlevels = RUNLEVEL_GAME | RUNLEVEL_POSTGAME

--- a/code/controllers/subsystem/fire_burning.dm
+++ b/code/controllers/subsystem/fire_burning.dm
@@ -1,6 +1,6 @@
 SUBSYSTEM_DEF(fire_burning)
 	name = "Fire Burning"
-	priority = 40
+	priority = FIRE_PRIOTITY_BURNING
 	flags = SS_NO_INIT|SS_BACKGROUND
 	runlevels = RUNLEVEL_GAME | RUNLEVEL_POSTGAME
 

--- a/code/controllers/subsystem/garbage.dm
+++ b/code/controllers/subsystem/garbage.dm
@@ -1,6 +1,6 @@
 SUBSYSTEM_DEF(garbage)
 	name = "Garbage"
-	priority = 15
+	priority = FIRE_PRIORITY_GARBAGE
 	wait = 2 SECONDS
 	flags = SS_POST_FIRE_TIMING|SS_BACKGROUND|SS_NO_INIT
 	runlevels = RUNLEVELS_DEFAULT | RUNLEVEL_LOBBY

--- a/code/controllers/subsystem/icon_smooth.dm
+++ b/code/controllers/subsystem/icon_smooth.dm
@@ -2,7 +2,7 @@ SUBSYSTEM_DEF(icon_smooth)
 	name = "Icon Smoothing"
 	init_order = INIT_ORDER_ICON_SMOOTHING
 	wait = 1
-	priority = 35
+	priority = FIRE_PRIOTITY_SMOOTHING
 	flags = SS_TICKER
 
 	var/list/smooth_queue = list()

--- a/code/controllers/subsystem/idlenpcpool.dm
+++ b/code/controllers/subsystem/idlenpcpool.dm
@@ -1,7 +1,7 @@
 SUBSYSTEM_DEF(idlenpcpool)
 	name = "Idling NPC Pool"
 	flags = SS_POST_FIRE_TIMING|SS_NO_INIT|SS_BACKGROUND
-	priority = 10
+	priority = FIRE_PRIORITY_IDLE_NPC
 	wait = 60
 	runlevels = RUNLEVEL_GAME | RUNLEVEL_POSTGAME
 

--- a/code/controllers/subsystem/inbounds.dm
+++ b/code/controllers/subsystem/inbounds.dm
@@ -1,6 +1,6 @@
 SUBSYSTEM_DEF(inbounds)
 	name = "Inbounds"
-	priority = 40
+	priority = FIRE_PRIORITY_INBOUNDS
 	flags = SS_NO_INIT
 	runlevels = RUNLEVEL_GAME
 

--- a/code/controllers/subsystem/input.dm
+++ b/code/controllers/subsystem/input.dm
@@ -2,7 +2,7 @@ SUBSYSTEM_DEF(input)
 	name = "Input"
 	wait = 1 //SS_TICKER means this runs every tick
 	flags = SS_TICKER | SS_NO_INIT
-	priority = 1000
+	priority = FIRE_PRIORITY_INPUT
 	runlevels = RUNLEVELS_DEFAULT | RUNLEVEL_LOBBY
 
 /datum/controller/subsystem/input/fire()

--- a/code/controllers/subsystem/mobs.dm
+++ b/code/controllers/subsystem/mobs.dm
@@ -1,6 +1,6 @@
 SUBSYSTEM_DEF(mobs)
 	name = "Mobs"
-	priority = 100
+	priority = FIRE_PRIORITY_MOBS
 	flags = SS_KEEP_TIMING
 	runlevels = RUNLEVEL_GAME | RUNLEVEL_POSTGAME
 

--- a/code/controllers/subsystem/npcpool.dm
+++ b/code/controllers/subsystem/npcpool.dm
@@ -6,7 +6,7 @@
 SUBSYSTEM_DEF(npcpool)
 	name = "NPC Pool"
 	flags = SS_POST_FIRE_TIMING|SS_NO_INIT|SS_BACKGROUND
-	priority = 20
+	priority = FIRE_PRIORITY_NPC
 	runlevels = RUNLEVEL_GAME | RUNLEVEL_POSTGAME
 
 	var/list/canBeUsed = list()

--- a/code/controllers/subsystem/orbit.dm
+++ b/code/controllers/subsystem/orbit.dm
@@ -1,6 +1,6 @@
 SUBSYSTEM_DEF(orbit)
 	name = "Orbits"
-	priority = 35
+	priority = FIRE_PRIORITY_ORBIT
 	wait = 2
 	flags = SS_NO_INIT|SS_TICKER
 

--- a/code/controllers/subsystem/overlays.dm
+++ b/code/controllers/subsystem/overlays.dm
@@ -2,7 +2,7 @@ SUBSYSTEM_DEF(overlays)
 	name = "Overlay"
 	flags = SS_TICKER
 	wait = 1
-	priority = 500
+	priority = FIRE_PRIORITY_OVERLAYS
 	init_order = INIT_ORDER_OVERLAY
 	runlevels = RUNLEVELS_DEFAULT | RUNLEVEL_SETUP
 

--- a/code/controllers/subsystem/parallax.dm
+++ b/code/controllers/subsystem/parallax.dm
@@ -2,7 +2,7 @@ SUBSYSTEM_DEF(parallax)
 	name = "Parallax"
 	wait = 2
 	flags = SS_POST_FIRE_TIMING | SS_BACKGROUND | SS_NO_INIT
-	priority = 65
+	priority = FIRE_PRIORITY_PARALLAX
 	runlevels = RUNLEVEL_LOBBY | RUNLEVELS_DEFAULT
 	var/list/currentrun
 

--- a/code/controllers/subsystem/processing/fields.dm
+++ b/code/controllers/subsystem/processing/fields.dm
@@ -1,6 +1,6 @@
 PROCESSING_SUBSYSTEM_DEF(fields)
 	name = "Fields"
 	wait = 2
-	priority = 40
+	priority = FIRE_PRIORUTY_FIELDS
 	flags = SS_KEEP_TIMING | SS_NO_INIT
 	runlevels = RUNLEVEL_GAME | RUNLEVEL_POSTGAME

--- a/code/controllers/subsystem/processing/flightpacks.dm
+++ b/code/controllers/subsystem/processing/flightpacks.dm
@@ -1,6 +1,6 @@
 PROCESSING_SUBSYSTEM_DEF(flightpacks)
 	name = "Flightpack Movement"
-	priority = 30
+	priority = FIRE_PRIORITY_FLIGHTPACKS
 	wait = 2
 	stat_tag = "FM"
 	flags = SS_NO_INIT|SS_TICKER|SS_KEEP_TIMING

--- a/code/controllers/subsystem/processing/networks.dm
+++ b/code/controllers/subsystem/processing/networks.dm
@@ -1,6 +1,6 @@
 PROCESSING_SUBSYSTEM_DEF(networks)
 	name = "Networks"
-	priority = 80
+	priority = FIRE_PRIORITY_NETWORKS
 	wait = 1
 	stat_tag = "NET"
 	flags = SS_KEEP_TIMING

--- a/code/controllers/subsystem/processing/obj.dm
+++ b/code/controllers/subsystem/processing/obj.dm
@@ -1,6 +1,6 @@
 SUBSYSTEM_DEF(obj)
 	name = "Objects"
-	priority = 40
+	priority = FIRE_PRIORITY_OBJ
 	flags = SS_NO_INIT
 
 	var/list/processing = list()

--- a/code/controllers/subsystem/processing/processing.dm
+++ b/code/controllers/subsystem/processing/processing.dm
@@ -2,7 +2,7 @@
 
 SUBSYSTEM_DEF(processing)
 	name = "Processing"
-	priority = 25
+	priority = FIRE_PRIORITY_PROCESS
 	flags = SS_BACKGROUND|SS_POST_FIRE_TIMING|SS_NO_INIT
 	wait = 10
 

--- a/code/controllers/subsystem/processing/projectiles.dm
+++ b/code/controllers/subsystem/processing/projectiles.dm
@@ -1,6 +1,5 @@
 PROCESSING_SUBSYSTEM_DEF(projectiles)
 	name = "Projectiles"
-	priority = 25
 	wait = 1
 	stat_tag = "PP"
 	flags = SS_NO_INIT|SS_TICKER|SS_KEEP_TIMING

--- a/code/controllers/subsystem/radiation.dm
+++ b/code/controllers/subsystem/radiation.dm
@@ -1,7 +1,6 @@
 PROCESSING_SUBSYSTEM_DEF(radiation)
 	name = "Radiation"
 	flags = SS_NO_INIT | SS_BACKGROUND
-	priority = 25
 
 	var/list/warned_atoms = list()
 

--- a/code/controllers/subsystem/research.dm
+++ b/code/controllers/subsystem/research.dm
@@ -2,7 +2,7 @@
 SUBSYSTEM_DEF(research)
 	name = "Research"
 	flags = SS_KEEP_TIMING
-	priority = 15		//My powergame is priority.
+	priority = FIRE_PRIORITY_RESEARCH
 	wait = 10
 	init_order = INIT_ORDER_RESEARCH
 	var/list/invalid_design_ids = list()		//associative id = number of times

--- a/code/controllers/subsystem/server_maint.dm
+++ b/code/controllers/subsystem/server_maint.dm
@@ -4,7 +4,7 @@ SUBSYSTEM_DEF(server_maint)
 	name = "Server Tasks"
 	wait = 6
 	flags = SS_POST_FIRE_TIMING
-	priority = 10
+	priority = FIRE_PRIORITY_SERVER_MAINT
 	init_order = INIT_ORDER_SERVER_MAINT
 	runlevels = RUNLEVEL_LOBBY | RUNLEVELS_DEFAULT
 	var/list/currentrun

--- a/code/controllers/subsystem/spacedrift.dm
+++ b/code/controllers/subsystem/spacedrift.dm
@@ -1,6 +1,6 @@
 SUBSYSTEM_DEF(spacedrift)
 	name = "Space Drift"
-	priority = 30
+	priority = FIRE_PRIORITY_SPACEDRIFT
 	wait = 5
 	flags = SS_NO_INIT|SS_KEEP_TIMING
 	runlevels = RUNLEVEL_GAME | RUNLEVEL_POSTGAME

--- a/code/controllers/subsystem/tgui.dm
+++ b/code/controllers/subsystem/tgui.dm
@@ -2,7 +2,7 @@ SUBSYSTEM_DEF(tgui)
 	name = "tgui"
 	wait = 9
 	flags = SS_NO_INIT
-	priority = 110
+	priority = FIRE_PRIORITY_TGUI
 	runlevels = RUNLEVEL_LOBBY | RUNLEVELS_DEFAULT
 
 	var/list/currentrun = list()

--- a/code/controllers/subsystem/throwing.dm
+++ b/code/controllers/subsystem/throwing.dm
@@ -3,7 +3,7 @@
 
 SUBSYSTEM_DEF(throwing)
 	name = "Throwing"
-	priority = 25
+	priority = FIRE_PRIORITY_THROWING
 	wait = 1
 	flags = SS_NO_INIT|SS_KEEP_TIMING|SS_TICKER
 	runlevels = RUNLEVEL_GAME | RUNLEVEL_POSTGAME

--- a/code/controllers/subsystem/ticker.dm
+++ b/code/controllers/subsystem/ticker.dm
@@ -4,7 +4,7 @@ SUBSYSTEM_DEF(ticker)
 	name = "Ticker"
 	init_order = INIT_ORDER_TICKER
 
-	priority = 200
+	priority = FIRE_PRIORITY_TICKER
 	flags = SS_KEEP_TIMING
 	runlevels = RUNLEVEL_LOBBY | RUNLEVEL_SETUP | RUNLEVEL_GAME
 


### PR DESCRIPTION
Like initialization priority, the fire priority only means something in comparison to the other subsystem values. So I defined all of them to make comparing fire priority easier than going through all the subsystems yourself.