### PR TITLE
Adds NAMEOF, VARSET_CALLBACK, and VARSET_LIST_CALLBACK

### DIFF
--- a/code/__HELPERS/unsorted.dm
+++ b/code/__HELPERS/unsorted.dm
@@ -1523,7 +1523,7 @@ GLOBAL_DATUM_INIT(dview_mob, /mob/dview, new)
 
 #define VARSET_LIST_CALLBACK(target, var_name, var_value) CALLBACK(GLOBAL_PROC, /proc/___callbackvarset, ##target, ##var_name, ##var_value)
 //dupe code because dm can't handle 3 level deep macros
-#define VARSET_CALLBACK(datum, var, var_value) CALLBACK(GLOBAL_PROC, /proc/___callbackvarset, ##datum, NAMEOF(##src, ##var), ##var_value)
+#define VARSET_CALLBACK(datum, var, var_value) CALLBACK(GLOBAL_PROC, /proc/___callbackvarset, ##datum, NAMEOF(##datum, ##var), ##var_value)
 
 /proc/___callbackvarset(list_or_datum, var_name, var_value)
 	if(length(list_or_datum))

--- a/code/__HELPERS/unsorted.dm
+++ b/code/__HELPERS/unsorted.dm
@@ -1517,3 +1517,18 @@ GLOBAL_DATUM_INIT(dview_mob, /mob/dview, new)
 	for(var/V in GLOB.player_list)
 		if(is_servant_of_ratvar(V) || isobserver(V))
 			. += V
+
+//src may be null, but it does need to be a typed var
+#define NAMEOF(src, X) (list(src.X, #X)[2])
+
+#define VARSET_CALLBACK(src, var_name, var_value) CALLBACK(GLOBAL_PROC, /proc/___timervarset, src, var_name, var_value)
+
+/proc/___timervarset(list_or_datum, var_name, var_value)
+	if(length(list_or_datum))
+		list_or_datum[var_name] = var_value
+		return
+	var/datum/D = list_or_datum
+	if(IsAdminAdvancedProcCall())
+		D.vv_edit_var(var_name, var_value)	//same result generally, unless badmemes
+	else
+		D.vars[X] = Y

--- a/code/__HELPERS/unsorted.dm
+++ b/code/__HELPERS/unsorted.dm
@@ -1519,7 +1519,7 @@ GLOBAL_DATUM_INIT(dview_mob, /mob/dview, new)
 			. += V
 
 //src may be null, but it does need to be a typed var
-#define NAMEOF(datum, X) (list(datum.X, #X)[2])
+#define NAMEOF(datum, X) (list(datum.##X, #X)[2])
 
 #define VARSET_LIST_CALLBACK(target, var_name, var_value) CALLBACK(GLOBAL_PROC, /proc/___timervarset, target, var_name, var_value)
 //dupe code because dm can't handle deep macros
@@ -1533,4 +1533,4 @@ GLOBAL_DATUM_INIT(dview_mob, /mob/dview, new)
 	if(IsAdminAdvancedProcCall())
 		D.vv_edit_var(var_name, var_value)	//same result generally, unless badmemes
 	else
-		D.vars[X] = Y
+		D.vars[var_name] = var_value

--- a/code/__HELPERS/unsorted.dm
+++ b/code/__HELPERS/unsorted.dm
@@ -1519,11 +1519,11 @@ GLOBAL_DATUM_INIT(dview_mob, /mob/dview, new)
 			. += V
 
 //src may be null, but it does need to be a typed var
-#define NAMEOF(datum, X) (list(datum.##X, #X)[2])
+#define NAMEOF(datum, X) (list(##datum.##X, #X)[2])
 
-#define VARSET_LIST_CALLBACK(target, var_name, var_value) CALLBACK(GLOBAL_PROC, /proc/___timervarset, target, var_name, var_value)
-//dupe code because dm can't handle deep macros
-#define VARSET_CALLBACK(datum, var, var_value) CALLBACK(GLOBAL_PROC, /proc/___timervarset, datum, NAMEOF(src, var), var_value)
+#define VARSET_LIST_CALLBACK(target, var_name, var_value) CALLBACK(GLOBAL_PROC, /proc/___timervarset, ##target, ##var_name, ##var_value)
+//dupe code because dm can't handle 3 level deep macros
+#define VARSET_CALLBACK(datum, var, var_value) CALLBACK(GLOBAL_PROC, /proc/___timervarset, ##datum, NAMEOF(##src, ##var), ##var_value)
 
 /proc/___timervarset(list_or_datum, var_name, var_value)
 	if(length(list_or_datum))

--- a/code/__HELPERS/unsorted.dm
+++ b/code/__HELPERS/unsorted.dm
@@ -1521,7 +1521,7 @@ GLOBAL_DATUM_INIT(dview_mob, /mob/dview, new)
 //src may be null, but it does need to be a typed var
 #define NAMEOF(src, X) (list(src.X, #X)[2])
 
-#define VARSET_CALLBACK(src, var_name, var_value) CALLBACK(GLOBAL_PROC, /proc/___timervarset, src, var_name, var_value)
+#define VARSET_CALLBACK(src, var, var_value) CALLBACK(GLOBAL_PROC, /proc/___timervarset, src, NAMEOF(src, var), var_value)
 
 /proc/___timervarset(list_or_datum, var_name, var_value)
 	if(length(list_or_datum))

--- a/code/__HELPERS/unsorted.dm
+++ b/code/__HELPERS/unsorted.dm
@@ -1518,14 +1518,14 @@ GLOBAL_DATUM_INIT(dview_mob, /mob/dview, new)
 		if(is_servant_of_ratvar(V) || isobserver(V))
 			. += V
 
-//src may be null, but it does need to be a typed var
+//datum may be null, but it does need to be a typed var
 #define NAMEOF(datum, X) (list(##datum.##X, #X)[2])
 
-#define VARSET_LIST_CALLBACK(target, var_name, var_value) CALLBACK(GLOBAL_PROC, /proc/___timervarset, ##target, ##var_name, ##var_value)
+#define VARSET_LIST_CALLBACK(target, var_name, var_value) CALLBACK(GLOBAL_PROC, /proc/___callbackvarset, ##target, ##var_name, ##var_value)
 //dupe code because dm can't handle 3 level deep macros
-#define VARSET_CALLBACK(datum, var, var_value) CALLBACK(GLOBAL_PROC, /proc/___timervarset, ##datum, NAMEOF(##src, ##var), ##var_value)
+#define VARSET_CALLBACK(datum, var, var_value) CALLBACK(GLOBAL_PROC, /proc/___callbackvarset, ##datum, NAMEOF(##src, ##var), ##var_value)
 
-/proc/___timervarset(list_or_datum, var_name, var_value)
+/proc/___callbackvarset(list_or_datum, var_name, var_value)
 	if(length(list_or_datum))
 		list_or_datum[var_name] = var_value
 		return

--- a/code/__HELPERS/unsorted.dm
+++ b/code/__HELPERS/unsorted.dm
@@ -1519,9 +1519,11 @@ GLOBAL_DATUM_INIT(dview_mob, /mob/dview, new)
 			. += V
 
 //src may be null, but it does need to be a typed var
-#define NAMEOF(src, X) (list(src.X, #X)[2])
+#define NAMEOF(datum, X) (list(datum.X, #X)[2])
 
-#define VARSET_CALLBACK(src, var, var_value) CALLBACK(GLOBAL_PROC, /proc/___timervarset, src, NAMEOF(src, var), var_value)
+#define VARSET_LIST_CALLBACK(target, var_name, var_value) CALLBACK(GLOBAL_PROC, /proc/___timervarset, target, var_name, var_value)
+//dupe code because dm can't handle deep macros
+#define VARSET_CALLBACK(datum, var, var_value) CALLBACK(GLOBAL_PROC, /proc/___timervarset, datum, NAMEOF(src, var), var_value)
 
 /proc/___timervarset(list_or_datum, var_name, var_value)
 	if(length(list_or_datum))


### PR DESCRIPTION
`NAMEOF`: Compile time checked variable name to string conversion

```dm
/obj/bar
   var/rewq

var/datum/asdf
    var/fdas

var/datum/asdf/proc/foo()
    var/fdas_name = NAMEOF(src, fdsa)
    var/obj/bar/some_bar
    var/rewq_name = NAMEOF(some_bar, rewq)
```

`VARSET_CALLBACK`: Like `CALLBACK` except it just sets a var to a value without the need for a helper proc

`VARSET_LIST_CALLBACK`: Just like `VARSET_CALLBACK` except it takes a list and can set either a key index or object

```dm
addtimer(VARSET_CALLBACK(new /obj, loc, locate(50, 50, 1)), 50)
var/list/L = list(24, 56, 87)
addtimer(VARSET_LIST_CALLBACK(L, "key_name", 42), 50)
addtimer(VARSET_LIST_CALLBACK(L, 2, 95), 50)
addtimer(VARSET_LIST_CALLBACK(L, new /obj, 128), 50)
```