### PR TITLE
[DNM] Allows miners to actually see station chat, by clipping spurious *click* messages

### DIFF
--- a/code/modules/projectiles/gun.dm
+++ b/code/modules/projectiles/gun.dm
@@ -64,6 +64,8 @@
 	var/zoom_out_amt = 0
 	var/datum/action/toggle_scope_zoom/azoom
 
+	var/next_empty_message
+
 /obj/item/gun/Initialize()
 	. = ..()
 	if(pin)
@@ -104,7 +106,9 @@
 	return TRUE
 
 /obj/item/gun/proc/shoot_with_empty_chamber(mob/living/user as mob|obj)
-	to_chat(user, "<span class='danger'>*click*</span>")
+	if (world.time > next_empty_message)
+		to_chat(user, "<span class='danger'>*click*</span>")
+		next_empty_message = world.time + 20
 	playsound(src, "gun_dry_fire", 50, 1)
 
 


### PR DESCRIPTION
Snick nik nok

:cl: Naksu
tweak: Reduced gun-related chat spam
/:cl:

I thought about removing the message altogether, but it might help out someone who is deaf or has byond audio disabled