### PR TITLE
Rebalances Marauder shields

### DIFF
--- a/code/game/gamemodes/clock_cult/clock_mobs/clockwork_marauder.dm
+++ b/code/game/gamemodes/clock_cult/clock_mobs/clockwork_marauder.dm
@@ -1,13 +1,13 @@
 #define MARAUDER_SLOWDOWN_PERCENTAGE 0.40 //Below this percentage of health, marauders will become slower
-#define MARAUDER_SHIELD_REGEN_TIME 100 //In deciseconds, how long it takes for shields to regenerate after breaking
+#define MARAUDER_SHIELD_REGEN_TIME 200 //In deciseconds, how long it takes for shields to regenerate after breaking
 
 //Clockwork marauder: A well-rounded frontline construct. Only one can exist for every two human servants.
 /mob/living/simple_animal/hostile/clockwork/marauder
 	name = "clockwork marauder"
 	desc = "The stalwart apparition of a soldier, blazing with crimson flames. It's armed with a gladius and shield."
 	icon_state = "clockwork_marauder"
-	health = 150
-	maxHealth = 150
+	health = 120
+	maxHealth = 120
 	force_threshold = 8
 	speed = 0
 	obj_damage = 40
@@ -39,10 +39,11 @@
 		speed = initial(speed) + 1 //Yes, this slows them down
 	else
 		speed = initial(speed)
-	if(shield_health != max_shield_health && world.time >= shield_health_regen)
-		to_chat(src, "<span class='neovgre'>Your shield has recovered. <b>[max_shield_health]</b> blocks remaining!</span>")
+	if(shield_health < max_shield_health && world.time >= shield_health_regen)
+		shield_health_regen = world.time + MARAUDER_SHIELD_REGEN_TIME
+		to_chat(src, "<span class='neovgre'>Your shield has recovered, <b>[shield_health]</b> blocks remaining!</span>")
 		playsound_local(src, "shatter", 75, TRUE, frequency = -1)
-		shield_health = max_shield_health
+		shield_health++
 
 /mob/living/simple_animal/hostile/clockwork/marauder/update_values()
 	if(GLOB.ratvar_awakens) //Massive attack damage bonuses and health increase, because Ratvar


### PR DESCRIPTION
:cl: Robustin
balance: Marauder shields now take twice as long to regenerate and only recharge one charge at a time.
balance: Marauders now have 120hp down from 150hp. 
/:cl:

I've noticed Marauders have become really problematic, especially now that you cant just chase one down on Reebe without getting 50 traps shoved up your butt. 
 
I checked Marauder code for the first time to see just how tanky they were and my mind was blown at how fucking hugbox they are. Its the equivalent of the Nukeops Hardsuit shield (you know, the super expensive one) except it fully regenerates every TEN SECONDS and of course its on a simple mob that ignores all shit that usually balances shielding (slipping, atmosphere, slows, AOE stuns). No wonder they're so fucking ridiculous to deal with.

Against lasers the shield mechanic means the marauders functionally have 210hp and regenerate 6hp every second - it's very silly. 