### PR TITLE
Fixes race swap ruining rounds

### DIFF
--- a/code/modules/events/wizard/race.dm
+++ b/code/modules/events/wizard/race.dm
@@ -12,7 +12,7 @@
 
 	for(var/speciestype in subtypesof(/datum/species))
 		var/datum/species/S = new speciestype()
-		if(!S.dangerous_existence)
+		if(!S.dangerous_existence && !S.blacklisted)
 			all_species += speciestype
 
 	var/datum/species/new_species = pick(all_species)


### PR DESCRIPTION
:cl: Robustin
fix: The wizard event "race swap" should now stick to "safer" species. 
/:cl:

This should address everyone's head exploding as Dullahans or 100% zombie memes. 
