### PR TITLE
Fixes zombie stun immunity, more pep in their step

### DIFF
--- a/code/modules/mob/living/carbon/human/species_types/zombies.dm
+++ b/code/modules/mob/living/carbon/human/species_types/zombies.dm
@@ -25,7 +25,7 @@
 	limbs_id = "zombie"
 	mutanthands = /obj/item/zombie_hand
 	armor = 20 // 120 damage to KO a zombie, which kills it
-	speedmod = 2
+	speedmod = 1.6
 	mutanteyes = /obj/item/organ/eyes/night_vision/zombie
 	var/regen_cooldown = 0
 
@@ -34,7 +34,7 @@
 
 
 /datum/species/zombie/infectious/spec_stun(mob/living/carbon/human/H,amount)
-	. = min(2, amount)
+	. = min(20, amount)
 
 /datum/species/zombie/infectious/apply_damage(damage, damagetype = BRUTE, def_zone = null, blocked, mob/living/carbon/human/H)
 	. = ..()


### PR DESCRIPTION
:cl: Robustin
fix: Zombies are now properly stunned for a maximum of 2 seconds instead of 2/10ths of a second.
tweak: Zombie slowdown adjusted from -2 to -1.6.
/:cl:

Apparently some stun refactor overlooked the zombie's stunmod. Since speedmods no longer require integers it made sense to make them a little quicker, still far slower than humans but hopefully slightly less painful in getting somewhere. 
