### PR TITLE
Advanced mob laziness

### DIFF
--- a/code/__DEFINES/mobs.dm
+++ b/code/__DEFINES/mobs.dm
@@ -108,6 +108,7 @@
 #define AI_ON		1
 #define AI_IDLE		2
 #define AI_OFF		3
+#define AI_Z_OFF	4
 
 //determines if a mob can smash through it
 #define ENVIRONMENT_SMASH_NONE 0

--- a/code/_globalvars/lists/mobs.dm
+++ b/code/_globalvars/lists/mobs.dm
@@ -22,7 +22,7 @@ GLOBAL_LIST_EMPTY(carbon_list)				//all instances of /mob/living/carbon and subt
 GLOBAL_LIST_EMPTY(ai_list)
 GLOBAL_LIST_EMPTY(pai_list)
 GLOBAL_LIST_EMPTY(available_ai_shells)
-GLOBAL_LIST_INIT(simple_animals, list(list(),list(),list())) // One for each AI_* status define
+GLOBAL_LIST_INIT(simple_animals, list(list(),list(),list(),list())) // One for each AI_* status define
 GLOBAL_LIST_EMPTY(spidermobs)				//all sentient spider mobs
 GLOBAL_LIST_EMPTY(bots_list)
 

--- a/code/controllers/subsystem/idlenpcpool.dm
+++ b/code/controllers/subsystem/idlenpcpool.dm
@@ -1,15 +1,21 @@
 SUBSYSTEM_DEF(idlenpcpool)
 	name = "Idling NPC Pool"
-	flags = SS_POST_FIRE_TIMING|SS_NO_INIT|SS_BACKGROUND
+	flags = SS_POST_FIRE_TIMING|SS_BACKGROUND
 	priority = FIRE_PRIORITY_IDLE_NPC
 	wait = 60
 	runlevels = RUNLEVEL_GAME | RUNLEVEL_POSTGAME
 
 	var/list/currentrun = list()
+	var/static/list/idle_mobs_by_zlevel[][]
 
 /datum/controller/subsystem/idlenpcpool/stat_entry()
 	var/list/idlelist = GLOB.simple_animals[AI_IDLE]
-	..("IdleNPCS:[idlelist.len]")
+	var/list/zlist = GLOB.simple_animals[AI_Z_OFF]
+	..("IdleNPCS:[idlelist.len]|Z:[zlist.len]")
+
+/datum/controller/subsystem/idlenpcpool/Initialize(start_timeofday)
+	idle_mobs_by_zlevel = new /list(world.maxz,0)
+	return ..()
 
 /datum/controller/subsystem/idlenpcpool/fire(resumed = FALSE)
 
@@ -24,6 +30,9 @@ SUBSYSTEM_DEF(idlenpcpool)
 	while(currentrun.len)
 		var/mob/living/simple_animal/SA = currentrun[currentrun.len]
 		--currentrun.len
+		if (!SA)
+			GLOB.simple_animals[AI_IDLE] -= SA
+			continue
 
 		if(!SA.ckey)
 			if(SA.stat != DEAD)

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -1035,9 +1035,12 @@
 		if (client)
 			if (new_z)
 				SSmobs.clients_by_zlevel[new_z] += src
-				for (var/I in SSidlenpcpool.idle_mobs_by_zlevel[new_z].len to 1 step -1) //Backwards loop because we're removing (guarantees optimal rather than worst-case performance)
+				for (var/I in length(SSidlenpcpool.idle_mobs_by_zlevel[new_z]) to 1 step -1) //Backwards loop because we're removing (guarantees optimal rather than worst-case performance), it's fine to use .len here but doesn't compile on 511
 					var/mob/living/simple_animal/SA = SSidlenpcpool.idle_mobs_by_zlevel[new_z][I]
-					SA.toggle_ai(AI_ON) // Guarantees responsiveness for when appearing right next to mobs
+					if (SA)
+						SA.toggle_ai(AI_ON) // Guarantees responsiveness for when appearing right next to mobs
+					else
+						SSidlenpcpool.idle_mobs_by_zlevel[new_z] -= SA
 
 			registered_z = new_z
 		else

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -1035,6 +1035,10 @@
 		if (client)
 			if (new_z)
 				SSmobs.clients_by_zlevel[new_z] += src
+				for (var/I in SSidlenpcpool.idle_mobs_by_zlevel[new_z].len to 1 step -1) //Backwards loop because we're removing (guarantees optimal rather than worst-case performance)
+					var/mob/living/simple_animal/SA = SSidlenpcpool.idle_mobs_by_zlevel[new_z][I]
+					SA.toggle_ai(AI_ON) // Guarantees responsiveness for when appearing right next to mobs
+
 			registered_z = new_z
 		else
 			registered_z = null

--- a/code/modules/mob/living/simple_animal/hostile/hostile.dm
+++ b/code/modules/mob/living/simple_animal/hostile/hostile.dm
@@ -275,7 +275,7 @@
 		if(search_objects)//Turn off item searching and ignore whatever item we were looking at, we're more concerned with fight or flight
 			target = null
 			LoseSearchObjects()
-		if(AIStatus == AI_IDLE)
+		if(AIStatus != AI_ON && AIStatus != AI_OFF)
 			toggle_ai(AI_ON)
 			FindTarget()
 		else if(target != null && prob(40))//No more pulling a mob forever and having a second player attack it, it can switch targets now if it finds a more suitable one
@@ -465,6 +465,31 @@ mob/living/simple_animal/hostile/proc/DestroySurroundings() // for use with mega
 
 /mob/living/simple_animal/hostile/consider_wakeup()
 	..()
-	if(AIStatus == AI_IDLE && FindTarget(ListTargets(), 1))
+	var/list/tlist
+	var/turf/T = get_turf(src)
+
+	if (!T)
+		return
+
+	if (!SSmobs.clients_by_zlevel[T.z].len)
+		toggle_ai(AI_Z_OFF)
+		return
+
+	if (isturf(T) && !(T.z in GLOB.station_z_levels))
+		tlist = ListTargetsLazy(T.z)
+	else
+		tlist = ListTargets()
+
+	if(AIStatus == AI_IDLE && FindTarget(tlist, 1))
 		toggle_ai(AI_ON)
 
+/mob/living/simple_animal/hostile/proc/ListTargetsLazy(var/_Z)//Step 1, find out what we can see
+	var/static/hostile_machines = typecacheof(list(/obj/machinery/porta_turret, /obj/mecha, /obj/structure/destructible/clockwork/ocular_warden))
+	. = list()
+	for (var/I in SSmobs.clients_by_zlevel[_Z])
+		var/mob/M = I
+		if (get_dist(M, src) < vision_range)
+			if (isturf(M.loc))
+				. += M
+			else if (M.loc.type in hostile_machines)
+				. += M.loc

--- a/code/modules/mob/living/simple_animal/hostile/hostile.dm
+++ b/code/modules/mob/living/simple_animal/hostile/hostile.dm
@@ -471,7 +471,7 @@ mob/living/simple_animal/hostile/proc/DestroySurroundings() // for use with mega
 	if (!T)
 		return
 
-	if (!SSmobs.clients_by_zlevel[T.z].len)
+	if (!length(SSmobs.clients_by_zlevel[T.z])) // It's fine to use .len here but doesn't compile on 511
 		toggle_ai(AI_Z_OFF)
 		return
 


### PR DESCRIPTION
If this looks as good on live servers as it does on solo testing, we could make idlenpcpool tick much faster  to increase lavaland mob responsiveness.

:cl: Naksu
tweak: Hostile mobs on z-levels without living players will now conserve their efforts and simply not run AI routines at all. Also, idling mob routines should be significantly cheaper on non-station Z-levels. 
/:cl:
