### PR TITLE
Db schema version check by simplification

### DIFF
--- a/code/_compile_options.dm
+++ b/code/_compile_options.dm
@@ -79,5 +79,6 @@
 
 //Update this whenever the db schema changes
 //make sure you add an update to the schema_version stable in the db changelog
-#define DB_MAJOR_VERSION 4
-#define DB_MINOR_VERSION 0
+//yes these are meant to be strings
+#define DB_MAJOR_VERSION "4"
+#define DB_MINOR_VERSION "0"

--- a/code/_compile_options.dm
+++ b/code/_compile_options.dm
@@ -79,6 +79,5 @@
 
 //Update this whenever the db schema changes
 //make sure you add an update to the schema_version stable in the db changelog
-//yes these are meant to be strings
-#define DB_MAJOR_VERSION "4"
-#define DB_MINOR_VERSION "0"
+#define DB_MAJOR_VERSION 4
+#define DB_MINOR_VERSION 0

--- a/code/game/world.dm
+++ b/code/game/world.dm
@@ -57,18 +57,18 @@ GLOBAL_PROTECT(security_mode)
 			var/datum/DBQuery/query_db_version = SSdbcore.NewQuery("SELECT major, minor FROM [format_table_name("schema_revision")] ORDER BY date DESC LIMIT 1")
 			query_db_version.Execute()
 			if(query_db_version.NextRow())
-				var/db_major = query_db_version.item[1]
-				var/db_minor = query_db_version.item[2]
-				if(text2num(db_major + "." + db_minor) != text2num(DB_MAJOR_VERSION + "." + DB_MINOR_VERSION))
-					var/which = "behind"
-					if(text2num(db_major + "." + db_minor) > text2num(DB_MAJOR_VERSION + "." + DB_MINOR_VERSION))
-						which = "ahead of"
-					message_admins("Database schema ([db_major].[db_minor]) is [which] the latest schema version ([DB_MAJOR_VERSION].[DB_MINOR_VERSION]), this may lead to undefined behaviour or errors")
-					log_sql("Database schema ([db_major].[db_minor]) is [which] the latest schema version ([DB_MAJOR_VERSION].[DB_MINOR_VERSION]), this may lead to undefined behaviour or errors")
+				var/db_major = text2num(query_db_version.item[1])
+				var/db_minor = text2num(query_db_version.item[2])
+				if(db_major != DB_MAJOR_VERSION || db_minor != DB_MINOR_VERSION)
+					message_admins("Database schema ([db_major].[db_minor]) doesn't match the latest schema version ([DB_MAJOR_VERSION].[DB_MINOR_VERSION]), this may lead to undefined behaviour or errors")
+					log_sql("Database schema ([db_major].[db_minor]) doesn't match the latest schema version ([DB_MAJOR_VERSION].[DB_MINOR_VERSION]), this may lead to undefined behaviour or errors")
 			else
 				message_admins("Could not get schema version from database")
+				log_sql("Could not get schema version from database")
 		else
-			log_world("Your server failed to establish a connection with the database.")
+			log_sql("Your server failed to establish a connection with the database.")
+	else
+		log_sql("Database is not enabled in configuration.")
 
 /world/proc/SetRoundID()
 	if(CONFIG_GET(flag/sql_enabled))

--- a/code/game/world.dm
+++ b/code/game/world.dm
@@ -57,11 +57,11 @@ GLOBAL_PROTECT(security_mode)
 			var/datum/DBQuery/query_db_version = SSdbcore.NewQuery("SELECT major, minor FROM [format_table_name("schema_revision")] ORDER BY date DESC LIMIT 1")
 			query_db_version.Execute()
 			if(query_db_version.NextRow())
-				var/db_major = text2num(query_db_version.item[1])
-				var/db_minor = text2num(query_db_version.item[2])
-				if(db_major != DB_MAJOR_VERSION || db_minor != DB_MINOR_VERSION)
+				var/db_major = query_db_version.item[1]
+				var/db_minor = query_db_version.item[2]
+				if(text2num(db_major + db_minor) != text2num(DB_MAJOR_VERSION + DB_MINOR_VERSION))
 					var/which = "behind"
-					if(db_major < DB_MAJOR_VERSION || db_minor < DB_MINOR_VERSION)
+					if(text2num(db_major + db_minor) > text2num(DB_MAJOR_VERSION + DB_MINOR_VERSION))
 						which = "ahead of"
 					message_admins("Database schema ([db_major].[db_minor]) is [which] the latest schema version ([DB_MAJOR_VERSION].[DB_MINOR_VERSION]), this may lead to undefined behaviour or errors")
 					log_sql("Database schema ([db_major].[db_minor]) is [which] the latest schema version ([DB_MAJOR_VERSION].[DB_MINOR_VERSION]), this may lead to undefined behaviour or errors")

--- a/code/game/world.dm
+++ b/code/game/world.dm
@@ -59,9 +59,9 @@ GLOBAL_PROTECT(security_mode)
 			if(query_db_version.NextRow())
 				var/db_major = query_db_version.item[1]
 				var/db_minor = query_db_version.item[2]
-				if(text2num(db_major + db_minor) != text2num(DB_MAJOR_VERSION + DB_MINOR_VERSION))
+				if(text2num(db_major + "." + db_minor) != text2num(DB_MAJOR_VERSION + "." + DB_MINOR_VERSION))
 					var/which = "behind"
-					if(text2num(db_major + db_minor) > text2num(DB_MAJOR_VERSION + DB_MINOR_VERSION))
+					if(text2num(db_major + "." + db_minor) > text2num(DB_MAJOR_VERSION + "." + DB_MINOR_VERSION))
 						which = "ahead of"
 					message_admins("Database schema ([db_major].[db_minor]) is [which] the latest schema version ([DB_MAJOR_VERSION].[DB_MINOR_VERSION]), this may lead to undefined behaviour or errors")
 					log_sql("Database schema ([db_major].[db_minor]) is [which] the latest schema version ([DB_MAJOR_VERSION].[DB_MINOR_VERSION]), this may lead to undefined behaviour or errors")


### PR DESCRIPTION
Per #33573 the check would still be wrong where major is behind but minor is ahead. ~Concatenating both numbers before comparing avoids this.~ I had a quick look at proper versioning comparison and decided it's not really worth it for our use case so now a difference will just report that the two versions don't match.
Also a bit more logging.