### PR TITLE
fixes magic mirrors letting you be robustin zombies

### DIFF
--- a/code/game/objects/structures/mirror.dm
+++ b/code/game/objects/structures/mirror.dm
@@ -89,7 +89,7 @@
 	name = "magic mirror"
 	desc = "Turn and face the strange... face."
 	icon_state = "magic_mirror"
-	var/list/races_blacklist = list("skeleton", "agent", "angel", "military_synth", "memezombie")
+	var/list/races_blacklist = list("skeleton", "agent", "angel", "military_synth", "memezombies")
 	var/list/choosable_races = list()
 
 /obj/structure/mirror/magic/New()


### PR DESCRIPTION
title
the race id is "memezombies" while the blacklist list had "memezombie"
this is a fix and you cant disprove it :^)
EDIT: probably closes #28315