### PR TITLE
Everyone gains antag HUD at round end

### DIFF
--- a/code/__HELPERS/roundend.dm
+++ b/code/__HELPERS/roundend.dm
@@ -102,6 +102,14 @@
 
 	CHECK_TICK
 
+	// Add AntagHUD to everyone, see who was really evil the whole time!
+	for(var/datum/atom_hud/H in GLOB.huds)
+		if(istype(H, /datum/atom_hud/antag))
+			for(var/mob/M in GLOB.player_list)
+				H.add_hud_to(M)
+
+	CHECK_TICK
+
 	//Set news report and mode result
 	mode.set_round_result()
 

--- a/code/__HELPERS/roundend.dm
+++ b/code/__HELPERS/roundend.dm
@@ -103,10 +103,10 @@
 	CHECK_TICK
 
 	// Add AntagHUD to everyone, see who was really evil the whole time!
-	for(var/datum/atom_hud/H in GLOB.huds)
-		if(istype(H, /datum/atom_hud/antag))
-			for(var/mob/M in GLOB.player_list)
-				H.add_hud_to(M)
+	for(var/datum/atom_hud/antag/H in GLOB.huds)
+		for(var/m in GLOB.player_list)
+			var/mob/M = m
+			H.add_hud_to(M)
 
 	CHECK_TICK
 


### PR DESCRIPTION
:cl: coiax
add: At the end of the round, all players can see who the antagonists
are.
/:cl:

Gaining antag HUD at round end means it becomes more obvious to everyone
about information that is already public knowledge (because the round
end report has also been issued by this point).