### PR TITLE
Decal rotation fix

### DIFF
--- a/code/datums/components/decal.dm
+++ b/code/datums/components/decal.dm
@@ -48,8 +48,7 @@
 	if(old_dir == new_dir)
 		return
 	remove()
-	var/rotation = SIMPLIFY_DEGREES(dir2angle(new_dir)-dir2angle(old_dir))
-	pic.dir = turn(pic.dir, rotation)
+	pic.dir = turn(pic.dir, dir2angle(old_dir) - dir2angle(new_dir))
 	apply()
 
 /datum/component/decal/proc/clean_react(strength)


### PR DESCRIPTION
:cl: ninjanomnom
fix: Decals should now rotate the correct way around.
/:cl:

...there doesn't seem to be an issue for this but it's been around for a while