### PR TITLE
Chaplain traitor item: Reusuable soulstone

### DIFF
--- a/code/game/gamemodes/wizard/soulstone.dm
+++ b/code/game/gamemodes/wizard/soulstone.dm
@@ -23,10 +23,10 @@
 			whatever spark it once held long extinguished."
 
 /obj/item/device/soulstone/anybody
-	usability = 1
+	name = "mysterious old shard"
+	usability = TRUE
 
 /obj/item/device/soulstone/anybody/chaplain
-	name = "mysterious old shard"
 	reusable = FALSE
 
 /obj/item/device/soulstone/pickup(mob/living/user)

--- a/code/modules/uplink/uplink_items.dm
+++ b/code/modules/uplink/uplink_items.dm
@@ -1245,6 +1245,14 @@ GLOBAL_LIST_EMPTY(uplink_items) // Global list so we only initialize this once.
 	restricted_roles = list("Chaplain")
 	surplus = 5 //Very low chance to get it in a surplus crate even without being the chaplain
 
+/datum/uplink_item/role_restricted/multiuse_soulstone
+	name = "Multiuse Soulstone"
+	desc = "A more coherent fragment of the legendary treasure known simply as the 'Soul Stone'. This fragment looks like the mysterious old shard that some chaplains own, but can be reused multiple times to make an army of loyal shades."
+	item = /obj/item/device/soulstone/anybody
+	cost = 10
+	restricted_roles = list("Chaplain")
+	surplus = 20 // Could be a useful ie. gibber in a stone
+
 /datum/uplink_item/role_restricted/pie_cannon
 	name = "Banana Cream Pie Cannon"
 	desc = "A special pie cannon for a special clown, this gadget can hold up to 20 pies and automatically fabricates one every two seconds!"


### PR DESCRIPTION
:cl: coiax
add: Syndicate chaplains can buy a reusable soulstone for 10TC.
/:cl:

Originally, the mysterious old shard was reusable, but I nerfed that
after it got abused by traitor chaplains to make an army of shades.
Well, now let's put a price on that.

Looks the same as a normal chaplain shard.

All anybody soulstones are called "mysterious old shard" now.