### PR TITLE
properly disables fusion

### DIFF
--- a/code/modules/atmospherics/gasmixtures/reactions.dm
+++ b/code/modules/atmospherics/gasmixtures/reactions.dm
@@ -181,10 +181,10 @@
 			location.temperature_expose(air, temperature, CELL_VOLUME)
 
 	return cached_results[id] ? REACTING : NO_REACTION
-/*
+
 //fusion: a terrible idea that was fun but broken. Now reworked to be less broken and more interesting.
 /datum/gas_reaction/fusion
-	exclude = FALSE
+	exclude = TRUE
 	priority = 2
 	name = "Plasmic Fusion"
 	id = "fusion"
@@ -232,7 +232,7 @@
 			air.temperature = max(((temperature*old_heat_capacity + reaction_energy)/new_heat_capacity),TCMB)
 			//Prevents whatever mechanism is causing it to hit negative temperatures.
 		return REACTING
-*/
+
 /datum/gas_reaction/nitrylformation //The formation of nitryl. Endothermic. Requires N2O as a catalyst.
 	priority = 3
 	name = "Nitryl formation"


### PR DESCRIPTION
just so you guys know for the future, please use the `exclude` var when disabling reactions. done this way I can still debug on live which is sometimes necessary for these things. thanks!