### PR TITLE
Codespeak manual rebalance/recost

### DIFF
--- a/code/modules/uplink/uplink_items.dm
+++ b/code/modules/uplink/uplink_items.dm
@@ -1094,16 +1094,9 @@ GLOBAL_LIST_EMPTY(uplink_items) // Global list so we only initialize this once.
 
 /datum/uplink_item/device_tools/codespeak_manual
 	name = "Codespeak Manual"
-	desc = "Syndicate agents can be trained to use a series of codewords to convey complex information, which sounds like random concepts and drinks to anyone listening. This manual teaches you this Codespeak. You can also hit someone else with the manual in order to teach them. One use."
-	item = /obj/item/codespeak_manual
-	cost = 2
-	exclude_modes = list(/datum/game_mode/nuclear)
-
-/datum/uplink_item/device_tools/codespeak_manual_deluxe
-	name = "Deluxe Codespeak Manual"
-	desc = "Syndicate agents can be trained to use a series of codewords to convey complex information, which sounds like random concepts and drinks to anyone listening. This manual teaches you this Codespeak. You can also hit someone else with the manual in order to teach them. This is the deluxe edition, which has unlimited uses."
-	cost = 8
-	include_modes = list(/datum/game_mode/nuclear)
+	desc = "Syndicate agents can be trained to use a series of codewords to convey complex information, which sounds like random concepts and drinks to anyone listening. This manual teaches you this Codespeak. You can also hit someone else with the manual in order to teach them. This is the deluxe edition, which has unlimited used."
+	item = /obj/item/codespeak_manual/unlimited
+	cost = 3
 
 // Implants
 /datum/uplink_item/implants


### PR DESCRIPTION
:cl: coiax
balance: The codespeak manual now has unlimited uses and costs 3 TC.
fix: Nuke ops can now purchase the codespeak manual, as was intended.
/:cl:

It's an item that's just used for communication security, and also light
memeing, so I'll make it cheaper.

Also fixes a bug where I didn't specify the item path for the nuke ops
version, so they couldn't buy it.