### PR TITLE
[wip] Pulling guns or baton related items out of backpacks will now take one second and also visibly show a message in doing so.

### DIFF
--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -60,6 +60,7 @@ GLOBAL_VAR_INIT(rpg_loot_items, FALSE)
 	var/equip_delay_self = 0 //In deciseconds, how long an item takes to equip; counts only for normal clothing slots, not pockets etc.
 	var/equip_delay_other = 20 //In deciseconds, how long an item takes to put on another person
 	var/strip_delay = 40 //In deciseconds, how long an item takes to remove from another person
+	var/equip_to_hand_delay = 0 //In deciseconds, how long it would take for a person to take a specific item out of their backpack
 	var/breakouttime = 0
 	var/being_removed = FALSE
 	var/list/materials

--- a/code/game/objects/items/storage/backpack.dm
+++ b/code/game/objects/items/storage/backpack.dm
@@ -23,7 +23,8 @@
 	storage_slots = 21
 	resistance_flags = NONE
 	max_integrity = 300
-
+	item_equip_delay = TRUE //By default, backpacks will delay equipping certain items
+	item_equip_delay_time = 10 //One second delay
 /*
  * Backpack Types
  */

--- a/code/game/objects/items/storage/storage.dm
+++ b/code/game/objects/items/storage/storage.dm
@@ -25,7 +25,7 @@
 	var/collection_mode = 1;  //0 = pick one at a time, 1 = pick all on tile, 2 = pick all of a type
 	var/preposition = "in" // You put things 'in' a bag, but trays need 'on'.
 	var/rustle_jimmies = TRUE	//Play the rustle sound on insertion
-
+	var/item_equip_delay = FALSE //If this storage item should delay equipping an item.
 
 /obj/item/storage/MouseDrop(atom/over_object)
 	if(ismob(usr)) //all the check for item manipulation are in other places, you can safely open any storages as anything and its not buggy, i checked

--- a/code/game/objects/items/storage/storage.dm
+++ b/code/game/objects/items/storage/storage.dm
@@ -382,16 +382,28 @@
 		W.dropped(M)
 	
 
-	if(new_location)
-		W.forceMove(new_location)
-		//Reset the items values
-		W.layer = initial(W.layer)
-		W.plane = initial(W.plane)
-		W.mouse_opacity = initial(W.mouse_opacity)
-		if(W.maptext)
-			W.maptext = ""
-		//We don't want to call this if the item is being destroyed
-		W.on_exit_storage(src)
+	if(new_location) 
+		if(item_equip_delay) && if(istype(new_location, /mob/living) //The item itself should be moving to the person picking it up
+			if(istype(W, /obj/item/melee/baton)) || if(istype(W, /obj/item/gun)) //If pulling out a baton or gun, alert people and delay
+				visible_message("[user] starts to pull a [W] out of the [src].", "<span class='notice'>You start to pull [W] out of the [src]</span>")
+				if(do_after(new_location, item_equip_delay_time , target =  W))
+					W.forceMove(new_location)  //Incoming copypasta
+					W.layer = initial(W.layer)
+					W.plane = initial(W.plane)
+					W.mouse_opacity = initial(W.mouse_opacity)
+					if(W.maptext)
+						W.maptext = ""
+					W.on_exit_storage(src)
+		else
+			W.forceMove(new_location)
+			//Reset the items values
+			W.layer = initial(W.layer)
+			W.plane = initial(W.plane)
+			W.mouse_opacity = initial(W.mouse_opacity)
+			if(W.maptext)
+				W.maptext = ""
+			//We don't want to call this if the item is being destroyed
+			W.on_exit_storage(src)
 
 	else
 		//Being destroyed, just move to nullspace now (so it's not in contents for the icon update)

--- a/code/game/objects/items/storage/storage.dm
+++ b/code/game/objects/items/storage/storage.dm
@@ -26,6 +26,8 @@
 	var/preposition = "in" // You put things 'in' a bag, but trays need 'on'.
 	var/rustle_jimmies = TRUE	//Play the rustle sound on insertion
 	var/item_equip_delay = FALSE //If this storage item should delay equipping an item.
+	var/item_equip_delay_time = 0 //How delayed grabbing an item should be, default is 10 deciseconds for backpacks.
+
 
 /obj/item/storage/MouseDrop(atom/over_object)
 	if(ismob(usr)) //all the check for item manipulation are in other places, you can safely open any storages as anything and its not buggy, i checked


### PR DESCRIPTION
:cl: ma44
balance: Pulling guns or baton related items out of a backpack will take one second as well as telling everyone nearby that your doing it. 
/:cl:

[why]: # (Please add a short description [two lines down] of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.)
1. Stops people from instantly drawing out tasers or revolvers or other stun memes 
2. Hugboxes the game further by making people at least either obviously noticeable weaponry or face a small delay in taking a weapon out. 

Things such as stun papers or anything else not related to those items will be effected.  Taking something out of your pocket, belt or suit storage won't trigger the effect, so having a non silenced pistol or a ebow can also work well in your favor. 

