### PR TITLE
Command Report Obfuscation

### DIFF
--- a/code/controllers/configuration/configuration.dm
+++ b/code/controllers/configuration/configuration.dm
@@ -168,7 +168,10 @@ GLOBAL_PROTECT(config_dir)
 				mode_names[M.config_tag] = M.name
 				probabilities[M.config_tag] = M.probability
 				mode_reports[M.config_tag] = M.generate_report()
-				mode_false_report_weight[M.config_tag] = M.false_report_weight
+				if(M.probability)
+					mode_false_report_weight[M.config_tag] = M.false_report_weight
+				else
+					mode_false_report_weight[M.config_tag] = 1
 				if(M.votable)
 					votable_modes += M.config_tag
 		qdel(M)

--- a/code/controllers/configuration/configuration.dm
+++ b/code/controllers/configuration/configuration.dm
@@ -168,7 +168,7 @@ GLOBAL_PROTECT(config_dir)
 				mode_names[M.config_tag] = M.name
 				probabilities[M.config_tag] = M.probability
 				mode_reports[M.config_tag] = M.generate_report()
-				if(M.probability)
+				if(probabilities[M.config_tag]>0)
 					mode_false_report_weight[M.config_tag] = M.false_report_weight
 				else
 					mode_false_report_weight[M.config_tag] = 1

--- a/code/game/gamemodes/changeling/changeling.dm
+++ b/code/game/gamemodes/changeling/changeling.dm
@@ -9,7 +9,7 @@ GLOBAL_VAR(changeling_team_objective_type) //If this is not null, we hand our th
 	name = "changeling"
 	config_tag = "changeling"
 	antag_flag = ROLE_CHANGELING
-	false_report_weight = 1
+	false_report_weight = 10
 	restricted_jobs = list("AI", "Cyborg")
 	protected_jobs = list("Security Officer", "Warden", "Detective", "Head of Security", "Captain")
 	required_players = 15

--- a/code/game/gamemodes/changeling/changeling.dm
+++ b/code/game/gamemodes/changeling/changeling.dm
@@ -9,7 +9,7 @@ GLOBAL_VAR(changeling_team_objective_type) //If this is not null, we hand our th
 	name = "changeling"
 	config_tag = "changeling"
 	antag_flag = ROLE_CHANGELING
-	false_report_weight = 10
+	false_report_weight = 1
 	restricted_jobs = list("AI", "Cyborg")
 	protected_jobs = list("Security Officer", "Warden", "Detective", "Head of Security", "Captain")
 	required_players = 15

--- a/code/game/gamemodes/game_mode.dm
+++ b/code/game/gamemodes/game_mode.dm
@@ -297,11 +297,15 @@
 	var/list/report_weights = config.mode_false_report_weight.Copy()
 	report_weights[config_tag] = 0 //Prevent the current mode from being falsely selected.
 	var/list/reports = list()
-	for(var/i in 1 to rand(3,5)) //Between three and five wrong entries on the list.
+	var/Count = 0 //To compensate for missing correct report
+	if(prob(65)) // 65% chance the actual mode will appear on the list
+		reports += config.mode_reports[config_tag]
+		Count++
+	for(var/i in Count to rand(3,5)) //Between three and five wrong entries on the list.
 		var/false_report_type = pickweightAllowZero(report_weights)
 		report_weights[false_report_type] = 0 //Make it so the same false report won't be selected twice
 		reports += config.mode_reports[false_report_type]
-	reports += config.mode_reports[config_tag]
+
 	reports = shuffle(reports) //Randomize the order, so the real one is at a random position.
 
 	for(var/report in reports)

--- a/code/game/gamemodes/traitor/double_agents.dm
+++ b/code/game/gamemodes/traitor/double_agents.dm
@@ -5,7 +5,7 @@
 /datum/game_mode/traitor/internal_affairs
 	name = "Internal Affairs"
 	config_tag = "internal_affairs"
-	false_report_weight = 10
+	false_report_weight = 1
 	required_players = 25
 	required_enemies = 5
 	recommended_enemies = 8

--- a/code/game/gamemodes/traitor/double_agents.dm
+++ b/code/game/gamemodes/traitor/double_agents.dm
@@ -5,7 +5,7 @@
 /datum/game_mode/traitor/internal_affairs
 	name = "Internal Affairs"
 	config_tag = "internal_affairs"
-	false_report_weight = 1
+	false_report_weight = 10
 	required_players = 25
 	required_enemies = 5
 	recommended_enemies = 8


### PR DESCRIPTION
:cl: Robustin
tweak: The current mode now only has a 65% of appearing in the Command Report, down from 100%. 
fix: The Command Report should now properly discount the chance of "non-standard" modes appearing in the report.
/:cl:

Note: Haven't tested this, still not quite sure why if(M.probability) wasn't ever returning true, hopefully this will. The result was that every mode was weighted equally for false reporting so we saw reports filled with shit likes Devils, Devil Agents, Internal Affairs, etc. as often as actual modes. 