### PR TITLE
Fix pulling things across space transitions

### DIFF
--- a/code/game/turfs/space/space.dm
+++ b/code/game/turfs/space/space.dm
@@ -139,9 +139,11 @@
 
 		if(isliving(A))
 			var/mob/living/L = A
-			if(L.pulling)
+			var/atom/movable/AM = L.pulling
+			if(AM)
 				var/turf/T = get_step(L.loc,turn(A.dir, 180))
-				L.pulling.forceMove(T)
+				AM.forceMove(T)
+				L.start_pulling(AM)
 
 		//now we're on the new z_level, proceed the space drifting
 		stoplag()//Let a diagonal move finish, if necessary


### PR DESCRIPTION
:cl:
fix: Passing a space transition no longer interrupts pulls.
/:cl:

Fixes #33676. Based on the ladder code which does the same.