### PR TITLE
Changelings are now unable to revive while on fire

### DIFF
--- a/code/game/gamemodes/changeling/powers/fakedeath.dm
+++ b/code/game/gamemodes/changeling/powers/fakedeath.dm
@@ -19,14 +19,21 @@
 	addtimer(CALLBACK(src, .proc/ready_to_regenerate, user), LING_FAKEDEATH_TIME, TIMER_UNIQUE)
 	return TRUE
 
-/obj/effect/proc_holder/changeling/fakedeath/proc/ready_to_regenerate(mob/user)
+/obj/effect/proc_holder/changeling/fakedeath/proc/ready_to_regenerate(mob/living/user)
 	if(user && user.mind)
+		if(user.on_fire)
+			to_chat(user, "<span class='warning'>The fire prevents us from reviving!</span>")
+			C.chem_charges += chemical_cost
+			return 0
 		var/datum/antagonist/changeling/C = user.mind.has_antag_datum(/datum/antagonist/changeling)
 		if(C && C.purchasedpowers)
 			to_chat(user, "<span class='notice'>We are ready to revive.</span>")
 			C.purchasedpowers += new /obj/effect/proc_holder/changeling/revive(null)
 
-/obj/effect/proc_holder/changeling/fakedeath/can_sting(mob/user)
+/obj/effect/proc_holder/changeling/fakedeath/can_sting(mob/living/user)
+	if(user.on_fire)
+		to_chat(user, "<span class='warning'>The fire prevents us from reviving!</span>")
+		return
 	if(user.status_flags & FAKEDEATH)
 		to_chat(user, "<span class='warning'>We are already reviving.</span>")
 		return

--- a/code/game/gamemodes/changeling/powers/fakedeath.dm
+++ b/code/game/gamemodes/changeling/powers/fakedeath.dm
@@ -21,11 +21,12 @@
 
 /obj/effect/proc_holder/changeling/fakedeath/proc/ready_to_regenerate(mob/living/user)
 	if(user && user.mind)
+		var/datum/antagonist/changeling/C = user.mind.has_antag_datum(/datum/antagonist/changeling)
 		if(user.on_fire)
 			to_chat(user, "<span class='warning'>The fire prevents us from reviving!</span>")
 			C.chem_charges += chemical_cost
 			return 0
-		var/datum/antagonist/changeling/C = user.mind.has_antag_datum(/datum/antagonist/changeling)
+
 		if(C && C.purchasedpowers)
 			to_chat(user, "<span class='notice'>We are ready to revive.</span>")
 			C.purchasedpowers += new /obj/effect/proc_holder/changeling/revive(null)

--- a/code/game/gamemodes/changeling/powers/revive.dm
+++ b/code/game/gamemodes/changeling/powers/revive.dm
@@ -8,24 +8,28 @@
 
 //Revive from revival stasis
 /obj/effect/proc_holder/changeling/revive/sting_action(mob/living/carbon/user)
-	user.status_flags &= ~(FAKEDEATH)
-	user.tod = null
-	user.revive(full_heal = 1)
-	var/list/missing = user.get_missing_limbs()
-	missing -= "head" // headless changelings are funny
-	if(missing.len)
-		playsound(user, 'sound/magic/demon_consume.ogg', 50, 1)
-		user.visible_message("<span class='warning'>[user]'s missing limbs \
-			reform, making a loud, grotesque sound!</span>",
-			"<span class='userdanger'>Your limbs regrow, making a \
-			loud, crunchy sound and giving you great pain!</span>",
-			"<span class='italics'>You hear organic matter ripping \
-			and tearing!</span>")
-		user.emote("scream")
-		user.regenerate_limbs(0, list("head"))
-	user.regenerate_organs()
-	to_chat(user, "<span class='notice'>We have revived ourselves.</span>")
 	var/datum/antagonist/changeling/changeling = user.mind.has_antag_datum(/datum/antagonist/changeling)
+	if(!user.on_fire)
+		user.status_flags &= ~(FAKEDEATH)
+		user.tod = null
+		user.revive(full_heal = 1)
+		var/list/missing = user.get_missing_limbs()
+		missing -= "head" // headless changelings are funny
+		if(missing.len)
+			playsound(user, 'sound/magic/demon_consume.ogg', 50, 1)
+			user.visible_message("<span class='warning'>[user]'s missing limbs \
+				reform, making a loud, grotesque sound!</span>",
+				"<span class='userdanger'>Your limbs regrow, making a \
+				loud, crunchy sound and giving you great pain!</span>",
+				"<span class='italics'>You hear organic matter ripping \
+				and tearing!</span>")
+			user.emote("scream")
+			user.regenerate_limbs(0, list("head"))
+		user.regenerate_organs()
+		to_chat(user, "<span class='notice'>We have revived ourselves.</span>")
+	else
+		to_chat(user, "<span class='warning'>The fire prevents us from reviving!</span>")
+		changeling.chem_charges += 15
 	changeling.purchasedpowers -= src
 	return TRUE
 


### PR DESCRIPTION
:cl: Kor
add: Changelings are now unable to revive while on fire.
/:cl:

Why: Changelings often smash the gibber and crematorium right away and then the crew is stuck dealing with a whole team of monsters that are constantly unstunning, healing, coming back to life on a 40 second timer with very few reliable ways to restrain them temporarily never mind eliminating them for good.

This seemed like a lore friendly way to give people a backup option for delaying a changelings respawn without completely nullifying their ability to do so (fire is gonna go out eventually, unless maintained)

I'm not 100% sold on this so arguments as to why this is awful are welcome