### PR TITLE
Makes vault safe slightly less explosion-proof

### DIFF
--- a/code/game/objects/items/grenades/plastic.dm
+++ b/code/game/objects/items/grenades/plastic.dm
@@ -55,6 +55,7 @@
 		if(!QDELETED(target))
 			location = get_turf(target)
 			target.cut_overlay(plastic_overlay, TRUE)
+			target.ex_act(2, target)
 	else
 		location = get_turf(src)
 	if(location)
@@ -63,7 +64,6 @@
 			explosion(get_step(T, aim_dir), boom_sizes[1], boom_sizes[2], boom_sizes[3])
 		else
 			explosion(location, boom_sizes[1], boom_sizes[2], boom_sizes[3])
-		location.ex_act(2, target)
 	if(ismob(target))
 		var/mob/M = target
 		M.gib()
@@ -247,10 +247,10 @@
 		if(!QDELETED(target))
 			location = get_turf(target)
 			target.cut_overlay(plastic_overlay, TRUE)
+			target.ex_act(2, target)
 	else
 		location = get_turf(src)
 	if(location)
-		location.ex_act(2, target)
 		explosion(location,0,0,3)
 	qdel(src)
 

--- a/code/game/objects/structures/safe.dm
+++ b/code/game/objects/structures/safe.dm
@@ -21,6 +21,7 @@ FLOOR SAFES
 	var/dial = 0		//where is the dial pointing?
 	var/space = 0		//the combined w_class of everything in the safe
 	var/maxspace = 24	//the maximum combined w_class of stuff in the safe
+	var/explosion_count = 0	//Tough, but breakable
 
 
 /obj/structure/safe/New()
@@ -47,6 +48,8 @@ FLOOR SAFES
 
 
 /obj/structure/safe/proc/check_unlocked(mob/user, canhear)
+	if(explosion_count > 2)
+		return 1
 	if(user && canhear)
 		if(tumbler_1_pos == tumbler_1_open)
 			to_chat(user, "<span class='italics'>You hear a [pick("tonk", "krunk", "plunk")] from [src].</span>")
@@ -182,7 +185,15 @@ FLOOR SAFES
 	return
 
 /obj/structure/safe/ex_act(severity, target)
-	return
+	if(((severity == 2 && target == src) || severity == 1) && explosion_count < 3)
+		explosion_count++
+		switch(explosion_count)
+			if(1)
+				desc = initial(desc) + "\nIt looks a little banged up."
+			if(2)
+				desc = initial(desc) + "\nIt's pretty heavily damaged."
+			if(3)
+				desc = initial(desc) + "\nThe lock seems to be broken."
 
 
 //FLOOR SAFES


### PR DESCRIPTION
[balance memes]
Three explosions of sufficient strength will render the vault safe door openable. 

Also fixes a bug where if a turf's contents were subjected to one explosion and then had c4 planted on them, half of the c4's explosion wouldn't work. 

:cl: QualityVan
balance: Due to budget cuts, the vault safe is now slightly less resistant to explosions.
/:cl:

Alternative to #33643 
ps send me thermal drill sprites
