### PR TITLE
Fixes some syndicate duffelbags missing inhands

### DIFF
--- a/code/game/objects/items/storage/backpack.dm
+++ b/code/game/objects/items/storage/backpack.dm
@@ -419,7 +419,7 @@
 	name = "suspicious looking duffel bag"
 	desc = "A large duffel bag for holding extra tactical supplies."
 	icon_state = "duffel-syndie"
-	item_state = "duffel-syndie"
+	item_state = "duffel-syndieammo"
 	silent = 1
 	slowdown = 0
 


### PR DESCRIPTION
duffel-syndie inhands don't exist, duffel-syndieammo do. The icons for them look pretty much identical. Affects c4/x4 bags and most of the nuke bundles.