### PR TITLE
Integrated circuit smoke circuit now requires atleast 10 units of reagents to generate smoke

### DIFF
--- a/code/modules/integrated_electronics/subtypes/reagents.dm
+++ b/code/modules/integrated_electronics/subtypes/reagents.dm
@@ -1,3 +1,5 @@
+#define IC_SMOKE_REAGENTS_MINIMUM_UNITS 10
+
 /obj/item/integrated_circuit/reagent
 	category_text = "Reagent"
 	resistance_flags = UNACIDABLE | FIRE_PROOF
@@ -7,8 +9,6 @@
 	. = ..()
 	if(volume)
 		create_reagents(volume)
-
-
 
 /obj/item/integrated_circuit/reagent/smoke
 	name = "smoke generator"
@@ -44,6 +44,8 @@
 	push_data()
 
 /obj/item/integrated_circuit/reagent/smoke/do_work()
+	if(!reagents || (reagents.total_volume < IC_SMOKE_REAGENTS_MINIMUM_UNITS))
+		return
 	var/location = get_turf(src)
 	var/datum/effect_system/smoke_spread/chem/S = new
 	S.attach(location)
@@ -54,10 +56,8 @@
 			notified = TRUE
 		S.start()
 
-	if(reagents)
-		reagents.clear_reagents()
+	reagents.clear_reagents()
 	activate_pin(2)
-
 
 /obj/item/integrated_circuit/reagent/injector
 	name = "integrated hypo-injector"


### PR DESCRIPTION
Limitless smoke is getting stale. It's a wizard spell for a reason. Scream no fun allowed all you want but people being able to render the halls unusable with a copypasted bot is getting stale.

It's still very possible to spam. It just takes more effort than copy, paste, put in cell, and press button.

:cl:
del: Integrated circuit smoke circuits now require 10 units of reagents to fire.
/:cl: