### PR TITLE
Fixes Arm Implant EMP Effect

### DIFF
--- a/code/modules/surgery/organs/augments_arms.dm
+++ b/code/modules/surgery/organs/augments_arms.dm
@@ -61,7 +61,7 @@
 /obj/item/organ/cyberimp/arm/emag_act()
 	return 0
 
-/obj/item/organ/cyberimp/arm/gun/emp_act(severity)
+/obj/item/organ/cyberimp/arm/emp_act(severity)
 	if(prob(15/severity) && owner)
 		to_chat(owner, "<span class='warning'>[src] is hit by EMP!</span>")
 		// give the owner an idea about why his implant is glitching


### PR DESCRIPTION
Just a super minor fix.

`/obj/item/organ/cyberimp/arm/emp_act` was defined twice, I suspect because arm implants were originally only about guns..either case, I'm pretty sure, given the location of the code, not to mention generalized functionality, that this `emp_act` is meant to apply to any arm implant.

:cl: Fox McCloud
fix: Fixes arm implants being immune to EMPs
/:cl:
