### PR TITLE
Allow remove_disability() to wipe ALL disabilties by type

### DIFF
--- a/code/modules/mob/living/status_procs.dm
+++ b/code/modules/mob/living/status_procs.dm
@@ -149,7 +149,11 @@
 /mob/living/proc/remove_disability(disability, list/sources)
 	if(!disabilities[disability])
 		return
-
+		
+	if (!sources) // FULPSTATION: If you never specified a source, then you must want to remove ALL sources, such as in fully_heal()
+		disabilities -= disability
+		return
+		
 	if(!islist(sources))
 		sources = list(sources)
 


### PR DESCRIPTION
The new disabilities/source system didn't go through and add sources to all instances of cure_husk(), cure_blindness(), etc, thus making them useless. Example: fully_heal() aka admin heal used to cure husk and blindness, but now does nothing because no type is specified there.

This change wipes all sources of a disability if no source was specified. This way, admin heal and other types of panacea remedies will always have an effect, and no refactoring needs to happen to get every occurence of those procs to work again.

[Changelogs]: # (Your PR should contain a detailed changelog of notable changes, titled and categorized appropriately. This includes, new features, sprites, sounds, balance changes, admin tools, map edits, removals, big refactors, config changes, hosting changes and important fixes. An example changelog has been provided below for you to edit. If you need additional help, read https://github.com/tgstation/tgstation/wiki/Changelogs)

:cl: optional name here
add: Added new things
add: Added more things
del: Removed old things
tweak: tweaked a few things
balance: rebalanced something
fix: fixed a few things
soundadd: added a new sound thingy
sounddel: removed an old sound thingy
imageadd: added some icons and images
imagedel: deleted some icons and images
spellcheck: fixed a few typos
code: changed some code
refactor: refactored some code
config: changed some config setting
admin: messed with admin stuff
server: something server ops should know
/:cl:

[why]: # (Please add a short description [two lines down] of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.)
