### PR TITLE
Enables upgrading and supercooling servers to produce more points.

### DIFF
--- a/code/controllers/subsystem/research.dm
+++ b/code/controllers/subsystem/research.dm
@@ -21,7 +21,6 @@ SUBSYSTEM_DEF(research)
 	var/list/errored_datums = list()
 	//----------------------------------------------
 	var/single_server_income = 40.7
-	var/multi_server_multiplier = 2.9
 	var/multiserver_calculation = TRUE
 	var/last_income = 0
 	//^^^^^^^^ ALL OF THESE ARE PER SECOND! ^^^^^^^^
@@ -48,7 +47,7 @@ SUBSYSTEM_DEF(research)
 	if(multiserver_calculation)
 		var/eff = calculate_server_coefficient()
 		for(var/obj/machinery/rnd/server/miner in servers)
-			bitcoins += (miner.mine() * eff * multi_server_income)	//SLAVE AWAY, SLAVE.
+			bitcoins += (miner.mine() * eff)	//SLAVE AWAY, SLAVE.
 	else
 		for(var/obj/machinery/rnd/server/miner in servers)
 			if(miner.working)
@@ -64,8 +63,8 @@ SUBSYSTEM_DEF(research)
 	var/amt = servers.len
 	if(!amt)
 		return 0
-	var/coeff = 100
-	coeff = sqrt(coeff / amt)
+	var/coeff = 0.5
+	coeff = 1 / max(amt, 0)
 	return coeff
 
 /datum/controller/subsystem/research/proc/autosort_categories()

--- a/code/controllers/subsystem/research.dm
+++ b/code/controllers/subsystem/research.dm
@@ -21,7 +21,8 @@ SUBSYSTEM_DEF(research)
 	var/list/errored_datums = list()
 	//----------------------------------------------
 	var/single_server_income = 40.7
-	var/multiserver_calculation = FALSE
+	var/multi_server_multiplier = 2.9
+	var/multiserver_calculation = TRUE
 	var/last_income = 0
 	//^^^^^^^^ ALL OF THESE ARE PER SECOND! ^^^^^^^^
 
@@ -47,7 +48,7 @@ SUBSYSTEM_DEF(research)
 	if(multiserver_calculation)
 		var/eff = calculate_server_coefficient()
 		for(var/obj/machinery/rnd/server/miner in servers)
-			bitcoins += (miner.mine() * eff)	//SLAVE AWAY, SLAVE.
+			bitcoins += (miner.mine() * eff * multi_server_income)	//SLAVE AWAY, SLAVE.
 	else
 		for(var/obj/machinery/rnd/server/miner in servers)
 			if(miner.working)

--- a/config/admins.txt
+++ b/config/admins.txt
@@ -132,3 +132,4 @@ excessiveuseofcobby = Game Master
 Plizzard = Game Master
 octareenroon91 = Game Master
 Serpentarium = Game Master
+Buggy1234 = Game Master


### PR DESCRIPTION
Servers will now produce 33% more points per tier of parts, double with triphasic scanners. They also linearly produce more points the colder they are, double at the lowest possible temperature. This can stack to a maximum of 4x point generate rate. The default, round-start point generation has not been changed.

Active servers must be cooled in order to function, at room temperature they will not generate any points at all. Additionally, servers now utilize cooperative computing; the points generated are a sum of the active research servers. You won't generate more points by making more servers, however if any actives servers are not upgraded or poorly cooled you will generate less points proportional to the state of the servers.

For example, 1 default server at the normal temperature of a freezer will generate 2,500 points a minute. So will 2, or 10 under the same conditions. 1 server in such a state, and 1 sitting at room temperature will generate 1,250 points per minute; the poorly cooled server will bog down the other server as they try to work together. One fully upgraded server and one normal server will generate 1.5x as many points as normal. And so on.

I would change it such that building more servers generates more points, but Kor explicitly forbade that and closed the last PR which did exactly that. If you want that to work, change his mind.
