### PR TITLE
re-implements issue template hiding and improves wording/structure

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,9 +1,9 @@
-[Directions]: # (If you discovered this issue from playing tgstation hosted servers
+[Round ID]: # (If you discovered this issue from playing tgstation hosted servers:)
+[Round ID]: # (**INCLUDE THE ROUND ID**)
+[Round ID]: # (It can be found in the Status panel or retrieved from https://atlantaned.space/statbus/round.php ! The round id let's us look up valuable information and logs for the round the bug happened.)
 
+[Testmerges]: # (If you believe the issue to be caused by a test merge [OOC tab -> Show Server Revision], report it in the pull request's comment section instead.)
 
-INCLUDE THE ROUND ID 
-
-
-from the Status panel or retrieve it from https://atlantaned.space/statbus/round.php ! If you believe the issue to be caused by a test merge [OOC tab -> Show Server Revision], report it in the pull request's comment section instead. Explain your issue in detail, including the steps to reproduce it.)
+[Reproduction]: # (Explain your issue in detail, including the steps to reproduce it. Issues without proper reproduction steps or explanation are open to being ignored/closed by maintainers.)
 
 [For Admins]: # (Oddities induced by var-edits and other admin tools are not necessarily bugs. Verify that your issues occur under regular circumstances before reporting them.)


### PR DESCRIPTION
Before:
https://puu.sh/yKVoF/bdf908fa35.png
After:
https://puu.sh/yKWna/70db78b521.png

It was annoying to look at and the parenthesis on top looked unmatched even though it had its match past two blank lines.

Also clarifies some wording and puts in a warning about issues with not enough information.