### PR TITLE
Makes cyclelinkeddir rotate with shuttle

### DIFF
--- a/code/modules/shuttle/shuttle_rotate.dm
+++ b/code/modules/shuttle/shuttle_rotate.dm
@@ -105,3 +105,8 @@ If ever any of these procs are useful for non-shuttles, rename it to proc/rotate
 /obj/machinery/gravity_generator/shuttleRotate(rotation, params)
 	params = NONE
 	return ..()
+
+/obj/machinery/door/airlock/shuttleRotate(rotation, params)
+	. = ..()
+	if(cyclelinkeddir)
+		cyclelinkeddir = angle2dir(rotation+dir2angle(cyclelinkeddir))

--- a/code/modules/shuttle/shuttle_rotate.dm
+++ b/code/modules/shuttle/shuttle_rotate.dm
@@ -110,3 +110,4 @@ If ever any of these procs are useful for non-shuttles, rename it to proc/rotate
 	. = ..()
 	if(cyclelinkeddir)
 		cyclelinkeddir = angle2dir(rotation+dir2angle(cyclelinkeddir))
+		cyclelinkairlock()


### PR DESCRIPTION
:cl: ninjanomnom
fix: Cycling airlocks on shuttles should work correctly when rotated now.
/:cl: