### PR TITLE
Ghosts can *spin and *flip

### DIFF
--- a/code/datums/emotes.dm
+++ b/code/datums/emotes.dm
@@ -16,8 +16,9 @@
 	var/emote_type = EMOTE_VISIBLE //Whether the emote is visible or audible
 	var/restraint_check = FALSE //Checks if the mob is restrained before performing the emote
 	var/muzzle_ignore = FALSE //Will only work if the emote is EMOTE_AUDIBLE
-	var/list/mob_type_allowed_typecache //Types that are allowed to use that emote
+	var/list/mob_type_allowed_typecache = list(/mob) //Types that are allowed to use that emote
 	var/list/mob_type_blacklist_typecache //Types that are NOT allowed to use that emote
+	var/list/mob_type_ignore_stat_typecache
 	var/stat_allowed = CONSCIOUS
 	var/static/list/emote_list = list()
 
@@ -26,6 +27,7 @@
 		emote_list[key_third_person] = src
 	mob_type_allowed_typecache = typecacheof(mob_type_allowed_typecache)
 	mob_type_blacklist_typecache = typecacheof(mob_type_blacklist_typecache)
+	mob_type_ignore_stat_typecache = typecacheof(mob_type_ignore_stat_typecache)
 
 /datum/emote/proc/run_emote(mob/user, params, type_override)
 	. = TRUE
@@ -37,9 +39,10 @@
 
 	msg = replace_pronoun(user, msg)
 
-	var/mob/living/L = user
-	for(var/obj/item/implant/I in L.implants)
-		I.trigger(key, L)
+	if(isliving(user))
+		var/mob/living/L = user
+		for(var/obj/item/implant/I in L.implants)
+			I.trigger(key, L)
 
 	if(!msg)
 		return
@@ -97,7 +100,7 @@
 		return FALSE
 	if(is_type_in_typecache(user, mob_type_blacklist_typecache))
 		return FALSE
-	if(status_check)
+	if(status_check && !is_type_in_typecache(user, mob_type_ignore_stat_typecache))
 		if(user.stat > stat_allowed  || (user.status_flags & FAKEDEATH))
 			to_chat(user, "<span class='notice'>You cannot [key] while unconscious.</span>")
 			return FALSE

--- a/code/modules/mob/dead/observer/say.dm
+++ b/code/modules/mob/dead/observer/say.dm
@@ -6,7 +6,10 @@
 
 	log_talk(src,"Ghost/[src.key] : [message]", LOGSAY)
 
-	. = src.say_dead(message)
+	if(check_emote(message))
+		return
+
+	. = say_dead(message)
 
 /mob/dead/observer/Hear(message, atom/movable/speaker, message_language, raw_message, radio_freq, list/spans, message_mode)
 	var/atom/movable/to_follow = speaker

--- a/code/modules/mob/emote.dm
+++ b/code/modules/mob/emote.dm
@@ -1,0 +1,48 @@
+//The code execution of the emote datum is located at code/datums/emotes.dm
+/mob/emote(act, m_type = null, message = null)
+	act = lowertext(act)
+	var/param = message
+	var/custom_param = findchar(act, " ")
+	if(custom_param)
+		param = copytext(act, custom_param + 1, length(act) + 1)
+		act = copytext(act, 1, custom_param)
+
+	var/datum/emote/E
+	E = E.emote_list[act]
+	if(!E)
+		to_chat(src, "<span class='notice'>Unusable emote '[act]'. Say *help for a list.</span>")
+		return
+	E.run_emote(src, param, m_type)
+
+/datum/emote/flip
+	key = "flip"
+	key_third_person = "flips"
+	restraint_check = TRUE
+	mob_type_allowed_typecache = list(/mob/living, /mob/dead/observer)
+	mob_type_ignore_stat_typecache = list(/mob/dead/observer)
+
+/datum/emote/flip/run_emote(mob/user, params)
+	. = ..()
+	if(.)
+		user.SpinAnimation(7,1)
+
+/datum/emote/spin
+	key = "spin"
+	key_third_person = "spins"
+	restraint_check = TRUE
+	mob_type_allowed_typecache = list(/mob/living, /mob/dead/observer)
+	mob_type_ignore_stat_typecache = list(/mob/dead/observer)
+
+/datum/emote/spin/run_emote(mob/user)
+	. = ..()
+	if(.)
+		user.spin(20, 1)
+
+		if(iscyborg(user) && user.has_buckled_mobs())
+			var/mob/living/silicon/robot/R = user
+			GET_COMPONENT_FROM(riding_datum, /datum/component/riding, R)
+			if(riding_datum)
+				for(var/mob/M in R.buckled_mobs)
+					riding_datum.force_dismount(M)
+			else
+				R.unbuckle_all_mobs()

--- a/code/modules/mob/living/emote.dm
+++ b/code/modules/mob/living/emote.dm
@@ -1,18 +1,3 @@
-//The code execution of the emote datum is located at code/datums/emotes.dm
-/mob/living/emote(act, m_type = null, message = null)
-	act = lowertext(act)
-	var/param = message
-	var/custom_param = findchar(act, " ")
-	if(custom_param)
-		param = copytext(act, custom_param + 1, length(act) + 1)
-		act = copytext(act, 1, custom_param)
-
-	var/datum/emote/E
-	E = E.emote_list[act]
-	if(!E)
-		to_chat(src, "<span class='notice'>Unusable emote '[act]'. Say *help for a list.</span>")
-		return
-	E.run_emote(src, param, m_type)
 
 /* EMOTE DATUMS */
 /datum/emote/living
@@ -142,16 +127,6 @@
 	message = "flaps their wings ANGRILY!"
 	restraint_check = TRUE
 	wing_time = 10
-
-/datum/emote/living/flip
-	key = "flip"
-	key_third_person = "flips"
-	restraint_check = TRUE
-
-/datum/emote/living/flip/run_emote(mob/user, params)
-	. = ..()
-	if(.)
-		user.SpinAnimation(7,1)
 
 /datum/emote/living/frown
 	key = "frown"
@@ -481,25 +456,6 @@
 	message = "beeps."
 	message_param = "beeps at %t."
 	sound = 'sound/machines/twobeep.ogg'
-
-/datum/emote/living/spin
-	key = "spin"
-	key_third_person = "spins"
-	restraint_check = TRUE
-
-/datum/emote/living/spin/run_emote(mob/user)
-	. = ..()
-	if(.)
-		user.spin(20, 1)
-		if(iscyborg(user) && user.has_buckled_mobs())
-			var/mob/living/silicon/robot/R = user
-			GET_COMPONENT_FROM(riding_datum, /datum/component/riding, R)
-			if(riding_datum)
-				for(var/mob/M in R.buckled_mobs)
-					riding_datum.force_dismount(M)
-			else
-				R.unbuckle_all_mobs()
-
 
 /datum/emote/living/circle
 	key = "circle"

--- a/code/modules/mob/living/say.dm
+++ b/code/modules/mob/living/say.dm
@@ -294,11 +294,6 @@ GLOBAL_LIST_INIT(department_radio_keys, list(
 
 	return 1
 
-/mob/living/proc/check_emote(message)
-	if(copytext(message, 1, 2) == "*")
-		emote(copytext(message, 2))
-		return 1
-
 /mob/living/proc/get_message_mode(message)
 	var/key = copytext(message, 1, 2)
 	if(key == "#")

--- a/code/modules/mob/say.dm
+++ b/code/modules/mob/say.dm
@@ -73,6 +73,11 @@
 
 	deadchat_broadcast(rendered, follow_target = src, speaker_key = K)
 
+/mob/proc/check_emote(message)
+	if(copytext(message, 1, 2) == "*")
+		emote(copytext(message, 2))
+		return 1
+
 /mob/proc/emote(var/act)
 	return
 

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -1643,6 +1643,7 @@
 #include "code\modules\mining\lavaland\necropolis_chests.dm"
 #include "code\modules\mining\lavaland\ruins\gym.dm"
 #include "code\modules\mob\death.dm"
+#include "code\modules\mob\emote.dm"
 #include "code\modules\mob\inventory.dm"
 #include "code\modules\mob\login.dm"
 #include "code\modules\mob\logout.dm"


### PR DESCRIPTION
:cl: coiax
add: Ghosts can now use the *spin and *flip emotes.
/:cl:

The feature that we all deserve. Some procs were dropped from
/mob/living to /mob to make this possible, but everything else should be
fine.