### PR TITLE
Gibber rebalance

### DIFF
--- a/code/modules/food_and_drinks/kitchen_machinery/gibber.dm
+++ b/code/modules/food_and_drinks/kitchen_machinery/gibber.dm
@@ -1,4 +1,3 @@
-
 /obj/machinery/gibber
 	name = "gibber"
 	desc = "The name isn't descriptive enough?"
@@ -12,10 +11,10 @@
 	circuit = /obj/item/circuitboard/machine/gibber
 
 	var/operating = FALSE //Is it on?
-	var/dirty = 0 // Does it need cleaning?
+	var/dirty = FALSE // Does it need cleaning?
 	var/gibtime = 40 // Time from starting until meat appears
 	var/meat_produced = 0
-	var/ignore_clothing = 0
+	var/ignore_clothing = FALSE
 
 
 /obj/machinery/gibber/Initialize()
@@ -30,7 +29,7 @@
 		gib_time -= 5 * M.rating
 		gibtime = gib_time
 		if(M.rating >= 2)
-			ignore_clothing = 1
+			ignore_clothing = TRUE
 
 /obj/machinery/gibber/update_icon()
 	cut_overlays()
@@ -61,6 +60,10 @@
 		to_chat(user, "<span class='danger'>It's locked and running.</span>")
 		return
 
+	if(!anchored)
+		to_chat(user, "<span class='notice'>[src] cannot be used unless bolted to the ground.</span>")
+		return
+
 	if(user.pulling && user.a_intent == INTENT_GRAB && isliving(user.pulling))
 		var/mob/living/L = user.pulling
 		if(!iscarbon(L))
@@ -70,12 +73,17 @@
 		if(C.buckled ||C.has_buckled_mobs())
 			to_chat(user, "<span class='warning'>[C] is attached to something!</span>")
 			return
-		if(C.abiotic(1) && !ignore_clothing)
-			to_chat(user, "<span class='danger'>Subject may not have abiotic items on.</span>")
-			return
+
+		if(!ignore_clothing)
+			for(var/obj/item/I in C.held_items + C.get_equipped_items())
+				if(!(I.flags_1 & NODROP_1))
+					to_chat(user, "<span class='danger'>Subject may not have abiotic items on.</span>")
+					return
 
 		user.visible_message("<span class='danger'>[user] starts to put [C] into the gibber!</span>")
-		src.add_fingerprint(user)
+
+		add_fingerprint(user)
+
 		if(do_after(user, gibtime, target = src))
 			if(C && user.pulling == C && !C.buckled && !C.has_buckled_mobs() && !occupant)
 				user.visible_message("<span class='danger'>[user] stuffs [C] into the gibber!</span>")

--- a/code/modules/mob/living/carbon/human/human_helpers.dm
+++ b/code/modules/mob/living/carbon/human/human_helpers.dm
@@ -91,17 +91,6 @@
 		return wear_id.GetID()
 
 
-/mob/living/carbon/human/abiotic(full_body = 0)
-	var/abiotic_hands = FALSE
-	for(var/obj/item/I in held_items)
-		if(!(I.flags_1 & NODROP_1))
-			abiotic_hands = TRUE
-			break
-	if(full_body && abiotic_hands && ((back && !(back.flags_1&NODROP_1)) || (wear_mask && !(wear_mask.flags_1&NODROP_1)) || (head && !(head.flags_1&NODROP_1)) || (shoes && !(shoes.flags_1&NODROP_1)) || (w_uniform && !(w_uniform.flags_1&NODROP_1)) || (wear_suit && !(wear_suit.flags_1&NODROP_1)) || (glasses && !(glasses.flags_1&NODROP_1)) || (ears && !(ears.flags_1&NODROP_1)) || (gloves && !(gloves.flags_1&NODROP_1)) ) )
-		return TRUE
-	return abiotic_hands
-
-
 /mob/living/carbon/human/IsAdvancedToolUser()
 	if(has_disability(MONKEYLIKE))
 		return FALSE

--- a/code/modules/mob/mob_helpers.dm
+++ b/code/modules/mob/mob_helpers.dm
@@ -285,11 +285,6 @@ It's fairly easy to fix if dealing with single letters but not so much with comp
 	firstname.Find(real_name)
 	return firstname.match
 
-/mob/proc/abiotic(full_body = 0)
-	for(var/obj/item/I in held_items)
-		if(!(I.flags_1 & NODROP_1))
-			return 1
-	return 0
 
 //change a mob's act-intent. Input the intent as a string such as "help" or use "right"/"left
 /mob/verb/a_intent_change(input as text)


### PR DESCRIPTION
:cl: coiax
balance: The kitchen gibber must be anchored in order to use.
balance: The gibber requires bodies to have no external items or
equipment.
/:cl:

Unanchoring the gibber, running around with it, ebowing people, then
shoving them in is not fun.

As a double check, you REALLY should be stripping them of all that
cloth, it'll jam up the gears.

- Removes the abiotic() proc, it's literally used only in the gibber,