### PR TITLE
2 borg metal fixes for the price of one

### DIFF
--- a/code/game/objects/items/stacks/stack.dm
+++ b/code/game/objects/items/stacks/stack.dm
@@ -109,7 +109,7 @@
 	if (recipes_sublist && recipe_list[recipes_sublist] && istype(recipe_list[recipes_sublist], /datum/stack_recipe_list))
 		var/datum/stack_recipe_list/srl = recipe_list[recipes_sublist]
 		recipe_list = srl.recipes
-	var/t1 = "Amount Left: [amount]<br>"
+	var/t1 = "Amount Left: [get_amount()]<br>"
 	for(var/i in 1 to length(recipe_list))
 		var/E = recipe_list[i]
 		if (isnull(E))
@@ -161,8 +161,8 @@
 	if (href_list["sublist"] && !href_list["make"])
 		interact(usr, text2num(href_list["sublist"]))
 	if (href_list["make"])
-		if (get_amount() < 1)
-			qdel(src) //Never should happen
+		if (get_amount() < 1 && !is_cyborg)
+			qdel(src)
 
 		var/list/recipes_list = recipes
 		if (href_list["sublist"])


### PR DESCRIPTION
[Changelogs]: 
:cl: Dax Dupont
fix: Borgs will no longer have their metal/glass/etc stacks commit sudoku when it runs out of metal. They will also show the correct amount instead of a constant of "1" on menu interaction.
/:cl:

[why]: Fixes https://github.com/tgstation/tgstation/issues/33725 and unreported issue regarding amount of sheets left.
