### PR TITLE
Refactored EMP doorshock chances

### DIFF
--- a/code/game/machinery/doors/door.dm
+++ b/code/game/machinery/doors/door.dm
@@ -195,7 +195,7 @@
 /obj/machinery/door/emp_act(severity)
 	if(prob(20/severity) && (istype(src, /obj/machinery/door/airlock) || istype(src, /obj/machinery/door/window)) )
 		INVOKE_ASYNC(src, .proc/open)
-	if(prob(40/severity))
+	if(prob(severity*10 - 20))
 		if(secondsElectrified == 0)
 			secondsElectrified = -1
 			shockedby += "\[[time_stamp()]\]EM Pulse"


### PR DESCRIPTION
:cl: Robustin
tweak: The EMP door shocking effect has a new formula. Heavy EMP's will no longer shock doors while light EMP's have a 10% chance (down from 13.33%). 
/:cl:

This is similar to the 2nd PR I ever attempted but never got around to fixing my branch. A heavy EMP should leave a door unpowered, having it increase the chance of shocking you compared to a light EMP makes no sense. 
