### PR TITLE
Fixed empty HUD_List breaking alternate_appearances

### DIFF
--- a/code/game/alternate_appearance.dm
+++ b/code/game/alternate_appearance.dm
@@ -82,7 +82,7 @@ GLOBAL_LIST_EMPTY(active_alternate_appearances)
 		QDEL_NULL(ghost_appearance)
 
 /datum/atom_hud/alternate_appearance/basic/add_to_hud(atom/A)
-	A.hud_list[appearance_key] = theImage
+	LAZYADD(A.hud_list[appearance_key], theImage)
 	. = ..()
 
 /datum/atom_hud/alternate_appearance/basic/remove_from_hud(atom/A)

--- a/code/game/alternate_appearance.dm
+++ b/code/game/alternate_appearance.dm
@@ -82,7 +82,8 @@ GLOBAL_LIST_EMPTY(active_alternate_appearances)
 		QDEL_NULL(ghost_appearance)
 
 /datum/atom_hud/alternate_appearance/basic/add_to_hud(atom/A)
-	LAZYADD(A.hud_list[appearance_key], theImage)
+	LAZYINITLIST(A.hud_list)
+	A.hud_list[appearance_key] = theImage
 	. = ..()
 
 /datum/atom_hud/alternate_appearance/basic/remove_from_hud(atom/A)


### PR DESCRIPTION
Alternate Appearances would runtime and fail when used on anything that didn't already have a HUD_list (most objects).