### PR TITLE
Maybe make R&D console icons load faster

### DIFF
--- a/code/modules/client/asset_cache.dm
+++ b/code/modules/client/asset_cache.dm
@@ -375,3 +375,39 @@ GLOBAL_LIST_EMPTY(asset_datums)
 	var/meter = icon('icons/obj/atmospherics/pipes/simple.dmi', "meterX", SOUTH, frame, movement_states)
 	if(meter)
 		register_asset(sanitize_filename("[prefix].south.meterX.png"), fcopy_rsc(meter))
+
+// Representative icons for each research design
+/datum/asset/simple/research_designs/register()
+	for (var/path in subtypesof(/datum/design))
+		var/datum/design/D = path
+
+		// construct the icon and slap it into the resource cache
+		var/atom/item = initial(D.build_path)
+		if (!ispath(item, /atom))
+			// biogenerator outputs to beakers by default
+			if (initial(D.build_type) & BIOGENERATOR)
+				item = /obj/item/reagent_containers/glass/beaker/large
+			else
+				continue  // shouldn't happen, but just in case
+
+		// circuit boards become their resulting machines or computers
+		if (ispath(item, /obj/item/circuitboard))
+			var/obj/item/circuitboard/C = item
+			var/machine = initial(C.build_path)
+			if (machine)
+				item = machine
+		var/icon_file = initial(item.icon)
+		var/icon/I = icon(icon_file, initial(item.icon_state), SOUTH)
+
+		// computers (and snowflakes) get their screen and keyboard sprites
+		if (ispath(item, /obj/machinery/computer) || ispath(item, /obj/machinery/power/solar_control))
+			var/obj/machinery/computer/C = item
+			var/screen = initial(C.icon_screen)
+			var/keyboard = initial(C.icon_keyboard)
+			if (screen)
+				I.Blend(icon(icon_file, screen, SOUTH), ICON_OVERLAY)
+			if (keyboard)
+				I.Blend(icon(icon_file, keyboard, SOUTH), ICON_OVERLAY)
+
+		assets["design_[initial(D.id)].png"] = I
+	return ..()

--- a/code/modules/research/designs.dm
+++ b/code/modules/research/designs.dm
@@ -50,41 +50,6 @@ other types of metals and chemistry for reagents).
 	CRASH("DESIGN DATUMS SHOULD NOT EVER BE DESTROYED AS THEY ARE ONLY MEANT TO BE IN A GLOBAL LIST AND REFERENCED FOR US.")
 	return ..()
 
-/datum/asset/simple/research_designs/register()
-	for (var/path in subtypesof(/datum/design))
-		var/datum/design/D = path
-
-		// construct the icon and slap it into the resource cache
-		var/atom/item = initial(D.build_path)
-		if (!ispath(item, /atom))
-			// biogenerator outputs to beakers by default
-			if (initial(D.build_type) & BIOGENERATOR)
-				item = /obj/item/reagent_containers/glass/beaker/large
-			else
-				continue  // shouldn't happen, but just in case
-
-		// circuit boards become their resulting machines or computers
-		if (ispath(item, /obj/item/circuitboard))
-			var/obj/item/circuitboard/C = item
-			var/machine = initial(C.build_path)
-			if (machine)
-				item = machine
-		var/icon_file = initial(item.icon)
-		var/icon/I = icon(icon_file, initial(item.icon_state), SOUTH)
-
-		// computers (and snowflakes) get their screen and keyboard sprites
-		if (ispath(item, /obj/machinery/computer) || ispath(item, /obj/machinery/power/solar_control))
-			var/obj/machinery/computer/C = item
-			var/screen = initial(C.icon_screen)
-			var/keyboard = initial(C.icon_keyboard)
-			if (screen)
-				I.Blend(icon(icon_file, screen, SOUTH), ICON_OVERLAY)
-			if (keyboard)
-				I.Blend(icon(icon_file, keyboard, SOUTH), ICON_OVERLAY)
-
-		assets["design_[initial(D.id)].png"] = I
-	return ..()
-
 /datum/design/proc/icon_html(client/user)
 	send_asset(user, "design_[id].png", FALSE)
 	return "<img class='icon' src=\"design_[id].png\">"

--- a/code/modules/research/designs.dm
+++ b/code/modules/research/designs.dm
@@ -50,16 +50,18 @@ other types of metals and chemistry for reagents).
 	CRASH("DESIGN DATUMS SHOULD NOT EVER BE DESTROYED AS THEY ARE ONLY MEANT TO BE IN A GLOBAL LIST AND REFERENCED FOR US.")
 	return ..()
 
-/datum/design/proc/icon_html(client/user)
-	if (!icon_cache)
+/datum/asset/simple/research_designs/register()
+	for (var/path in subtypesof(/datum/design))
+		var/datum/design/D = path
+
 		// construct the icon and slap it into the resource cache
-		var/atom/item = build_path
+		var/atom/item = initial(D.build_path)
 		if (!ispath(item, /atom))
 			// biogenerator outputs to beakers by default
-			if (build_type & BIOGENERATOR)
+			if (initial(D.build_type) & BIOGENERATOR)
 				item = /obj/item/reagent_containers/glass/beaker/large
 			else
-				return  // shouldn't happen, but just in case
+				continue  // shouldn't happen, but just in case
 
 		// circuit boards become their resulting machines or computers
 		if (ispath(item, /obj/item/circuitboard))
@@ -80,11 +82,12 @@ other types of metals and chemistry for reagents).
 			if (keyboard)
 				I.Blend(icon(icon_file, keyboard, SOUTH), ICON_OVERLAY)
 
-		// based on icon2html
-		icon_cache = "[generate_asset_name(I)].png"
-		register_asset(icon_cache, I)
-	send_asset(user, icon_cache, FALSE)
-	return "<img class='icon' src=\"[url_encode(icon_cache)]\">"
+		assets["design_[initial(D.id)].png"] = I
+	return ..()
+
+/datum/design/proc/icon_html(client/user)
+	send_asset(user, "design_[id].png", FALSE)
+	return "<img class='icon' src=\"design_[id].png\">"
 
 ////////////////////////////////////////
 //Disks for transporting design datums//


### PR DESCRIPTION
:cl:
code: The R&D console has been made more responsive by tweaking how design icons are loaded.
/:cl:

I'm a little worried about frontloading all these design icons on players who will mostly never touch an R&D console, but in my tests this does significantly speed up the UI for those who do use it.