### PR TITLE
Modified the starting locations of advanced camera console eyes

### DIFF
--- a/code/game/machinery/computer/camera_advanced.dm
+++ b/code/game/machinery/computer/camera_advanced.dm
@@ -83,12 +83,23 @@
 
 	if(!eyeobj.eye_initialized)
 		var/camera_location
-		for(var/obj/machinery/camera/C in GLOB.cameranet.cameras)
-			if(!C.can_use() || z_lock.len && !(C.z in z_lock))
-				continue
-			if(C.network & networks)
-				camera_location = get_turf(C)
-				break
+		var/turf/myturf = get_turf(src)
+		if(eyeobj.use_static)
+			if(GLOB.cameranet.checkTurfVis(myturf))
+				camera_location = myturf
+			else
+				for(var/obj/machinery/camera/C in GLOB.cameranet.cameras)
+					if(!C.can_use() || z_lock.len && !(C.z in z_lock))
+						continue
+					var/list/network_overlap = C.network & networks
+					if(network_overlap.len)
+						camera_location = get_turf(C)
+						break
+		else
+			camera_location = myturf
+			if(z_lock.len && !(myturf.z in z_lock))
+				camera_location = locate(round(world.maxx/2), round(world.maxy/2), z_lock[1])
+
 		if(camera_location)
 			eyeobj.eye_initialized = TRUE
 			give_eye_control(L)

--- a/code/game/machinery/computer/camera_advanced.dm
+++ b/code/game/machinery/computer/camera_advanced.dm
@@ -85,13 +85,13 @@
 		var/camera_location
 		var/turf/myturf = get_turf(src)
 		if(eyeobj.use_static)
-			if(GLOB.cameranet.checkTurfVis(myturf))
+			if((!z_lock.len || (myturf.z in z_lock)) && GLOB.cameranet.checkTurfVis(myturf))
 				camera_location = myturf
 			else
 				for(var/obj/machinery/camera/C in GLOB.cameranet.cameras)
 					if(!C.can_use() || z_lock.len && !(C.z in z_lock))
 						continue
-					var/list/network_overlap = C.network & networks
+					var/list/network_overlap = networks & C.network
 					if(network_overlap.len)
 						camera_location = get_turf(C)
 						break

--- a/code/modules/shuttle/navigation_computer.dm
+++ b/code/modules/shuttle/navigation_computer.dm
@@ -173,7 +173,10 @@
 	var/mob/camera/aiEye/remote/shuttle_docker/the_eye = eyeobj
 	var/turf/eyeturf = get_turf(the_eye)
 	if(!eyeturf)
-		return
+		return SHUTTLE_DOCKER_BLOCKED
+	if(z_lock.len && !(eyeturf.z in z_lock))
+		return SHUTTLE_DOCKER_BLOCKED
+
 	. = SHUTTLE_DOCKER_LANDING_CLEAR
 	var/list/bounds = shuttle_port.return_coords(the_eye.x - x_offset, the_eye.y - y_offset, the_eye.dir)
 	var/list/overlappers = SSshuttle.get_dock_overlap(bounds[1], bounds[2], bounds[3], bounds[4], the_eye.z)


### PR DESCRIPTION
If the camera eye uses static, it will start the eye on the console if the console is visible to any camera. If it is not visible, it will loop through cameras like it used to do, except it will now properly respect the network that the cameras use instead of always picking the thunderdome camera, which happens to always be first in the camera list.

If the camera eye does not use static, it will start the eye on the camera console, unless it is not on a z level the console can see, in which case it will start in the center of the map on the first z level in the console's z_lock list.

Also shuttle navigation computers will not allow you to place a landing location in a z level they should not have access too, even if the eye somehow gets there.