### PR TITLE
Dippable Component v2 - No Extraneous Commits Edition

### DIFF
--- a/code/__DEFINES/components.dm
+++ b/code/__DEFINES/components.dm
@@ -61,7 +61,7 @@
 // /obj/item signals
 #define COMSIG_ITEM_ATTACK "item_attack"						//from base of obj/item/attack(): (/mob/living/target, /mob/living/user)
 #define COMSIG_ITEM_ATTACK_SELF "item_attack_self"				//from base of obj/item/attack_self(): (/mob)
-#define COMSIG_ITEM_ATTACK_OBJ "item_attack_obj"
+#define COMSIG_ITEM_ATTACK_OBJ "item_attack_obj"				//from base of obj/item/attack_obj(): (/obj, /mob)
 #define COMSIG_ITEM_EQUIPPED "item_equip"						//from base of obj/item/equipped(): (/mob/equipper, slot)
 #define COMSIG_ITEM_DROPPED "item_drop"							//from base of obj/item/dropped(): (/mob/dropper)				//from base of obj/item/attack_obj(): (/obj, /mob)
 #define COMSIG_ITEM_ATTACK_REAGENT_CONTAINER "item_attack_reagent_container"	//from base of obj/item/reagnet_containers/attackby(): (/obj/item/reagent_containers, /mob, params)

--- a/code/__DEFINES/components.dm
+++ b/code/__DEFINES/components.dm
@@ -61,9 +61,10 @@
 // /obj/item signals
 #define COMSIG_ITEM_ATTACK "item_attack"						//from base of obj/item/attack(): (/mob/living/target, /mob/living/user)
 #define COMSIG_ITEM_ATTACK_SELF "item_attack_self"				//from base of obj/item/attack_self(): (/mob)
-#define COMSIG_ITEM_ATTACK_OBJ "item_attack_obj"				//from base of obj/item/attack_obj(): (/obj, /mob)
+#define COMSIG_ITEM_ATTACK_OBJ "item_attack_obj"
 #define COMSIG_ITEM_EQUIPPED "item_equip"						//from base of obj/item/equipped(): (/mob/equipper, slot)
 #define COMSIG_ITEM_DROPPED "item_drop"							//from base of obj/item/dropped(): (/mob/dropper)
+#define COMSIG_ITEM_ATTACK_REAGENT_CONTAINER "item_attack_reagent_container"	//from base of obj/item/reagnet_containers/attackby(): (/obj/item/reagent_containers, /mob)
 
 // /obj/item/clothing signals
 #define COMSIG_SHOES_STEP_ACTION "shoes_step_action"			//from base of obj/item/clothing/shoes/proc/step_action(): ()

--- a/code/__DEFINES/components.dm
+++ b/code/__DEFINES/components.dm
@@ -63,8 +63,8 @@
 #define COMSIG_ITEM_ATTACK_SELF "item_attack_self"				//from base of obj/item/attack_self(): (/mob)
 #define COMSIG_ITEM_ATTACK_OBJ "item_attack_obj"
 #define COMSIG_ITEM_EQUIPPED "item_equip"						//from base of obj/item/equipped(): (/mob/equipper, slot)
-#define COMSIG_ITEM_DROPPED "item_drop"							//from base of obj/item/dropped(): (/mob/dropper)
-#define COMSIG_ITEM_ATTACK_REAGENT_CONTAINER "item_attack_reagent_container"	//from base of obj/item/reagnet_containers/attackby(): (/obj/item/reagent_containers, /mob)
+#define COMSIG_ITEM_DROPPED "item_drop"							//from base of obj/item/dropped(): (/mob/dropper)				//from base of obj/item/attack_obj(): (/obj, /mob)
+#define COMSIG_ITEM_ATTACK_REAGENT_CONTAINER "item_attack_reagent_container"	//from base of obj/item/reagnet_containers/attackby(): (/obj/item/reagent_containers, /mob, params)
 
 // /obj/item/clothing signals
 #define COMSIG_SHOES_STEP_ACTION "shoes_step_action"			//from base of obj/item/clothing/shoes/proc/step_action(): ()

--- a/code/__DEFINES/components.dm
+++ b/code/__DEFINES/components.dm
@@ -63,7 +63,7 @@
 #define COMSIG_ITEM_ATTACK_SELF "item_attack_self"				//from base of obj/item/attack_self(): (/mob)
 #define COMSIG_ITEM_ATTACK_OBJ "item_attack_obj"				//from base of obj/item/attack_obj(): (/obj, /mob)
 #define COMSIG_ITEM_EQUIPPED "item_equip"						//from base of obj/item/equipped(): (/mob/equipper, slot)
-#define COMSIG_ITEM_DROPPED "item_drop"							//from base of obj/item/dropped(): (/mob/dropper)				//from base of obj/item/attack_obj(): (/obj, /mob)
+#define COMSIG_ITEM_DROPPED "item_drop"							//from base of obj/item/dropped(): (/mob/dropper)
 #define COMSIG_ITEM_ATTACK_REAGENT_CONTAINER "item_attack_reagent_container"	//from base of obj/item/reagnet_containers/attackby(): (/obj/item/reagent_containers, /mob, params)
 
 // /obj/item/clothing signals

--- a/code/datums/components/dippable.dm
+++ b/code/datums/components/dippable.dm
@@ -24,7 +24,7 @@ _attack_transfer_ratio: What fraction of the dipped item's reagents should be tr
 	var/attack_transfer_ratio	//How much of the dipped item's reagents should be applied to whatever is attacked with the dipped item?
 
 /datum/component/dippable/Initialize(capacity_already_defined = FALSE, _capacity = 0, _dip_mix_ratio = 0, _dip_transfer_rate = 0, _dip_transfer_type = DIP_TYPE_STATIC, _transfer_on_attack = FALSE, _attack_transfer_ratio = 0)
-	if(!istype(parent, /obj/item))
+	if(!isitem(parent))
 		. = COMPONENT_INCOMPATIBLE
 		CRASH("Attempted to put dippable component in [parent.type]!")
 	var/obj/item/container = parent

--- a/code/datums/components/dippable.dm
+++ b/code/datums/components/dippable.dm
@@ -1,0 +1,101 @@
+#define DIP_TYPE_STATIC 1 //Transfer an absolute amount of reagents from the dip container when dipping
+#define DIP_TYPE_FRACTIONAL_DIP_TOTAL 2 //Transfer a fraction of the dip container's current volume when dipping
+#define DIP_TYPE_FRACTIONAL_DIP_MAXIMUM 3 //Transfer a fraction of the dip container's maximum volume when dipping
+#define DIP_TYPE_FRACTIONAL_DIPPED_TOTAL 4 //Transfer a fraction of the dipped item's current volume from the dip container when dipping
+#define DIP_TYPE_FRACTIONAL_DIPPED_MAXIMUM 5 //Transfer a fraction of the dipped item's maximum volume from the dip container when dipping
+
+/*
+DIPPING:
+The following arguments in the Initialize function determine the dipping properties of the item:
+capacity_already_defined: If this is true, don't alter the item's max reagent volume. This is to be used for dippable foodstuffs like cookies.
+_capacity: If _size is zero, the dippable item's maximum capacity is this.
+_dip_mix_ratio: How much of the dipped item's reagents should be mixed with the dip before applying the dip?
+_dip_transfer_rate: How much of the dip is transferred to the dipped item?
+_dip_transfer_type: Refer to the defines above.
+_transfer_on_attack: Should the dipped item transfer its reagents to mobs that are attacked by it? This should be false for dippable foodstuffs.
+_attack_transfer_ratio: What fraction of the dipped item's reagents should be transferred to attacked mobs?
+*/
+
+/datum/component/dippable
+	var/dip_mix_ratio	//How much of the dipped item's reagents should be mixed with the dip before applying the dip?
+	var/dip_transfer_rate	//How much dip should we apply to the dipped item upon dipping?
+	var/dip_transfer_type	//Is the rate of dip transfer a fraction of the dippable item's capacity or a static quantity of reagent?
+	var/transfer_on_attack	//Should we transfer the dipped item's reagents when attacking someone?
+	var/attack_transfer_ratio	//How much of the dipped item's reagents should be applied to whatever is attacked with the dipped item?
+	var/obj/item/container	//This is to ensure that we can use obj or item-specific procs when referring to the component's parent.
+
+
+/datum/component/dippable/Initialize(capacity_already_defined = FALSE, _capacity = 0, _dip_mix_ratio = 0, _dip_transfer_rate = 0, _dip_transfer_type = DIP_TYPE_STATIC, _transfer_on_attack = FALSE, _attack_transfer_ratio = 0)
+	if(!istype(parent, /obj/item))
+		qdel(src)
+		CRASH("Attempted to put dippable component in [parent.type]!")
+	container = parent
+	if(!capacity_already_defined)
+		if(!container.reagents)
+			container.reagents = new /datum/reagents(maximum = _capacity)
+		else
+			container.reagents.maximum_volume = _capacity
+	else
+		if(!container.reagents)
+			container.reagents = new /datum/reagents(maximum = _capacity)
+	dip_mix_ratio = _dip_mix_ratio
+	dip_transfer_rate = _dip_transfer_rate
+	dip_transfer_type = _dip_transfer_type
+	transfer_on_attack = _transfer_on_attack
+	attack_transfer_ratio = _attack_transfer_ratio
+	RegisterSignal(COMSIG_ITEM_ATTACK_OBJ, .proc/on_attack_object)
+	RegisterSignal(COMSIG_ITEM_ATTACK, .proc/on_attack)
+
+/datum/component/dippable/proc/get_transfer_amount(datum/reagents/dip, datum/reagents/dipped)
+	switch(dip_transfer_type)
+		if(DIP_TYPE_STATIC)
+			return dip_transfer_rate
+		if(DIP_TYPE_FRACTIONAL_DIP_TOTAL)
+			return dip.total_volume * dip_transfer_rate
+		if(DIP_TYPE_FRACTIONAL_DIP_MAXIMUM)
+			return dip.maximum_volume * dip_transfer_rate
+		if(DIP_TYPE_FRACTIONAL_DIPPED_TOTAL)
+			return dipped.total_volume * dip_transfer_rate
+		if(DIP_TYPE_FRACTIONAL_DIPPED_MAXIMUM)
+			return dipped.maximum_volume * dip_transfer_rate
+		else
+			stack_trace("Null dip transfer type detected!")
+			return 0
+
+/datum/component/dippable/proc/on_attack_object(obj/target, mob/user)
+	if(transfer_on_attack)
+		var/datum/reagents/dip = target.reagents
+		var/datum/reagents/dipped = container.reagents
+		if(istype(target, /obj/item/reagent_containers))
+			if(!target.is_open_container())
+				return
+			if(dip && !dip.total_volume)
+				to_chat(user, "<span class='warning'>[target] doesn't have anything to dip [container] in!</span>")
+				return
+			var/datum/reagents/mixture = new
+			mixture.maximum_volume = dip.maximum_volume + dipped.maximum_volume
+			dipped.trans_to(mixture, dipped.total_volume * dip_mix_ratio, no_react = TRUE)
+			dip.trans_to(mixture, get_transfer_amount(dip, dipped), no_react = TRUE)
+			var/datum/reagents/reactants = new
+			reactants.maximum_volume = mixture.maximum_volume
+			var/spillover = mixture.total_volume - mixture.trans_to(reactants, dipped.maximum_volume, no_react = TRUE)
+			reactants.reaction(container, TOUCH)
+			reactants.trans_to(dipped, dipped.maximum_volume) //This transfer is okay with having reactions occur because reagents are being transferred to their final destination.
+			qdel(reactants)
+			spillover -= mixture.trans_to(dip, mixture.total_volume) //Same with transferring the reactants to the dipped item.
+			to_chat(user, "<span class='notice'>You dip [container] in [target][spillover ? "..." : "."]</span>")
+			if(spillover)
+				to_chat(user, "<span class='warning'>...but spill some of the contents!</span>")
+				mixture.reaction(get_turf(user), TOUCH)
+				mixture.clear_reagents()
+			qdel(mixture)
+
+/datum/component/dippable/proc/on_attack(mob/living/target, mob/living/user)
+	var/datum/reagents/dip = container.reagents
+	if(dip.total_volume)
+		var/datum/reagents/reactants = new
+		reactants.maximum_volume = dip.total_volume * attack_transfer_ratio
+		dip.trans_to(reactants, reactants.maximum_volume, no_react = TRUE)
+		reactants.reaction(target, TOUCH)
+		reactants.trans_to(target, reactants.maximum_volume)
+		qdel(reactants)

--- a/code/datums/components/dippable.dm
+++ b/code/datums/components/dippable.dm
@@ -44,7 +44,7 @@ _attack_transfer_ratio: What fraction of the dipped item's reagents should be tr
 	dip_transfer_type = _dip_transfer_type
 	transfer_on_attack = _transfer_on_attack
 	attack_transfer_ratio = _attack_transfer_ratio
-	RegisterSignal(COMSIG_ITEM_ATTACK_OBJ, .proc/on_attack_object)
+	RegisterSignal(COMSIG_ITEM_ATTACK_REAGENT_CONTAINER, .proc/on_dip)
 	RegisterSignal(COMSIG_ITEM_ATTACK, .proc/on_attack)
 
 /datum/component/dippable/proc/get_transfer_amount(datum/reagents/dip, datum/reagents/dipped)
@@ -63,32 +63,31 @@ _attack_transfer_ratio: What fraction of the dipped item's reagents should be tr
 			stack_trace("Null dip transfer type detected!")
 			return 0
 
-/datum/component/dippable/proc/on_attack_object(obj/target, mob/user)
+/datum/component/dippable/proc/on_dip(obj/item/reagent_containers/target, mob/user)
 	var/datum/reagents/dip = target.reagents
 	var/datum/reagents/dipped = container.reagents
-	if(istype(target, /obj/item/reagent_containers))
-		if(!target.is_open_container())
-			return
-		if(dip && !dip.total_volume)
-			to_chat(user, "<span class='warning'>[target] doesn't have anything to dip [container] in!</span>")
-			return
-		var/datum/reagents/mixture = new
-		mixture.maximum_volume = dip.maximum_volume + dipped.maximum_volume
-		dipped.trans_to(mixture, dipped.total_volume * dip_mix_ratio, no_react = TRUE)
-		dip.trans_to(mixture, get_transfer_amount(dip, dipped), no_react = TRUE)
-		var/datum/reagents/reactants = new
-		reactants.maximum_volume = mixture.maximum_volume
-		var/spillover = mixture.total_volume - mixture.trans_to(reactants, dipped.maximum_volume, no_react = TRUE)
-		reactants.reaction(container, TOUCH)
-		reactants.trans_to(dipped, dipped.maximum_volume) //This transfer is okay with having reactions occur because reagents are being transferred to their final destination.
-		qdel(reactants)
-		spillover -= mixture.trans_to(dip, mixture.total_volume) //Same with transferring the reactants to the dipped item.
-		to_chat(user, "<span class='notice'>You dip [container] in [target][spillover ? "..." : "."]</span>")
-		if(spillover)
-			to_chat(user, "<span class='warning'>...but spill some of the contents!</span>")
-			mixture.reaction(get_turf(user), TOUCH)
-			mixture.clear_reagents()
-		qdel(mixture)
+	if(!target.is_open_container())
+		return
+	if(dip && !dip.total_volume)
+		to_chat(user, "<span class='warning'>[target] doesn't have anything to dip [container] in!</span>")
+		return
+	var/datum/reagents/mixture = new
+	mixture.maximum_volume = dip.maximum_volume + dipped.maximum_volume
+	dipped.trans_to(mixture, dipped.total_volume * dip_mix_ratio, no_react = TRUE)
+	dip.trans_to(mixture, get_transfer_amount(dip, dipped), no_react = TRUE)
+	var/datum/reagents/reactants = new
+	reactants.maximum_volume = mixture.maximum_volume
+	var/spillover = mixture.total_volume - mixture.trans_to(reactants, dipped.maximum_volume, no_react = TRUE)
+	reactants.reaction(container, TOUCH)
+	reactants.trans_to(dipped, dipped.maximum_volume) //This transfer is okay with having reactions occur because reagents are being transferred to their final destination.
+	qdel(reactants)
+	spillover -= mixture.trans_to(dip, mixture.total_volume) //Same with transferring the reactants to the dipped item.
+	to_chat(user, "<span class='notice'>You dip [container] in [target][spillover ? "..." : "."]</span>")
+	if(spillover)
+		to_chat(user, "<span class='warning'>...but spill some of the contents!</span>")
+		mixture.reaction(get_turf(user), TOUCH)
+		mixture.clear_reagents()
+	qdel(mixture)
 
 /datum/component/dippable/proc/on_attack(mob/living/target, mob/living/user)
 	if(transfer_on_attack)

--- a/code/datums/components/dippable.dm
+++ b/code/datums/components/dippable.dm
@@ -90,7 +90,7 @@ _attack_transfer_ratio: What fraction of the dipped item's reagents should be tr
 	qdel(mixture)
 
 /datum/component/dippable/proc/on_attack(mob/living/target, mob/living/user)
-	if(transfer_on_attack)
+	if(transfer_on_attack && target.can_inject())
 		var/datum/reagents/dip = container.reagents
 		if(dip.total_volume)
 			var/datum/reagents/reactants = new

--- a/code/datums/components/dippable.dm
+++ b/code/datums/components/dippable.dm
@@ -22,23 +22,19 @@ _attack_transfer_ratio: What fraction of the dipped item's reagents should be tr
 	var/dip_transfer_type	//Is the rate of dip transfer a fraction of the dippable item's capacity or a static quantity of reagent?
 	var/transfer_on_attack	//Should we transfer the dipped item's reagents when attacking someone?
 	var/attack_transfer_ratio	//How much of the dipped item's reagents should be applied to whatever is attacked with the dipped item?
-	var/obj/item/container	//This is to ensure that we can use obj or item-specific procs when referring to the component's parent.
-
 
 /datum/component/dippable/Initialize(capacity_already_defined = FALSE, _capacity = 0, _dip_mix_ratio = 0, _dip_transfer_rate = 0, _dip_transfer_type = DIP_TYPE_STATIC, _transfer_on_attack = FALSE, _attack_transfer_ratio = 0)
 	if(!istype(parent, /obj/item))
-		stack_trace("Attempted to put dippable component in [parent.type]!")
-		qdel(src)
-		return COMPONENT_INCOMPATIBLE
-	container = parent
+		. = COMPONENT_INCOMPATIBLE
+		CRASH("Attempted to put dippable component in [parent.type]!")
+	var/obj/item/container = parent
 	if(!capacity_already_defined)
 		if(!container.reagents)
 			container.reagents = new /datum/reagents(maximum = _capacity)
 		else
 			container.reagents.maximum_volume = _capacity
-	else
-		if(!container.reagents)
-			container.reagents = new /datum/reagents(maximum = _capacity)
+	else if(!container.reagents)
+		container.reagents = new /datum/reagents(maximum = _capacity)
 	dip_mix_ratio = _dip_mix_ratio
 	dip_transfer_rate = _dip_transfer_rate
 	dip_transfer_type = _dip_transfer_type
@@ -64,6 +60,7 @@ _attack_transfer_ratio: What fraction of the dipped item's reagents should be tr
 			return 0
 
 /datum/component/dippable/proc/on_dip(obj/item/reagent_containers/target, mob/user)
+	var/obj/item/container = parent
 	var/datum/reagents/dip = target.reagents
 	var/datum/reagents/dipped = container.reagents
 	if(!target.is_open_container())
@@ -91,6 +88,7 @@ _attack_transfer_ratio: What fraction of the dipped item's reagents should be tr
 
 /datum/component/dippable/proc/on_attack(mob/living/target, mob/living/user)
 	if(transfer_on_attack && target.can_inject())
+		var/obj/item/container = parent
 		var/datum/reagents/dip = container.reagents
 		if(dip.total_volume)
 			var/datum/reagents/reactants = new

--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -141,6 +141,9 @@ GLOBAL_VAR_INIT(rpg_loot_items, FALSE)
 		if(damtype == "brute")
 			hitsound = "swing_hit"
 
+	if(is_sharp())
+		AddComponent(/datum/component/dippable, istype(src, /obj/item/reagent_containers), w_class*15, 1, 1, DIP_TYPE_FRACTIONAL_DIP_TOTAL, TRUE, 0.5)
+
 /obj/item/Destroy()
 	flags_1 &= ~DROPDEL_1	//prevent reqdels
 	if(ismob(loc))

--- a/code/game/objects/items/cigs_lighters.dm
+++ b/code/game/objects/items/cigs_lighters.dm
@@ -127,9 +127,11 @@ CIGARETTE PACKETS ARE IN FANCY.DM
 	reagents.set_reacting(FALSE) // so it doesn't react until you light it
 	if(list_reagents)
 		reagents.add_reagent_list(list_reagents)
+	AddComponent(/datum/component/knockoff,90,list("mouth"),list(slot_wear_mask))//90% to knock off when wearing a mask
 	if(starts_lit)
 		light()
-	AddComponent(/datum/component/knockoff,90,list("mouth"),list(slot_wear_mask))//90% to knock off when wearing a mask
+	else
+		AddComponent(/datum/component/dippable, TRUE, 0, 0, 1, DIP_TYPE_FRACTIONAL_DIPPED_MAXIMUM)
 
 /obj/item/clothing/mask/cigarette/Destroy()
 	STOP_PROCESSING(SSobj, src)
@@ -143,19 +145,6 @@ CIGARETTE PACKETS ARE IN FANCY.DM
 	else
 		return ..()
 
-/obj/item/clothing/mask/cigarette/afterattack(obj/item/reagent_containers/glass/glass, mob/user, proximity)
-	if(!proximity || lit) //can't dip if cigarette is lit (it will heat the reagents in the glass instead)
-		return
-	if(istype(glass))	//you can dip cigarettes into beakers
-		if(glass.reagents.trans_to(src, chem_volume))	//if reagents were transfered, show the message
-			to_chat(user, "<span class='notice'>You dip \the [src] into \the [glass].</span>")
-		else			//if not, either the beaker was empty, or the cigarette was full
-			if(!glass.reagents.total_volume)
-				to_chat(user, "<span class='notice'>[glass] is empty.</span>")
-			else
-				to_chat(user, "<span class='notice'>[src] is full.</span>")
-
-
 /obj/item/clothing/mask/cigarette/proc/light(flavor_text = null)
 	if(lit)
 		return
@@ -164,6 +153,9 @@ CIGARETTE PACKETS ARE IN FANCY.DM
 		item_state = icon_on
 		return
 
+	var/datum/component/dippable/D = GetExactComponent(/datum/component/dippable)
+	if(D)
+		qdel(D)	//This handles not being able to dip a cigarette anymore once lit.
 	lit = TRUE
 	name = "lit [name]"
 	attack_verb = list("burnt", "singed")

--- a/code/game/objects/items/weaponry.dm
+++ b/code/game/objects/items/weaponry.dm
@@ -294,10 +294,16 @@
 	resistance_flags = FIRE_PROOF
 	var/extended = 0
 
+/obj/item/switchblade/Initialize()
+	..()
+	AddComponent(/datum/component/dippable, FALSE, 45, 1, 1, DIP_TYPE_FRACTIONAL_DIP_TOTAL, FALSE, 0.5)
+
 /obj/item/switchblade/attack_self(mob/user)
 	extended = !extended
 	playsound(src.loc, 'sound/weapons/batonextend.ogg', 50, 1)
+	var/datum/component/dippable/D = GetExactComponent(/datum/component/dippable)
 	if(extended)
+		D.transfer_on_attack = TRUE
 		force = 20
 		w_class = WEIGHT_CLASS_NORMAL
 		throwforce = 23
@@ -306,6 +312,7 @@
 		hitsound = 'sound/weapons/bladeslice.ogg'
 		sharpness = IS_SHARP
 	else
+		D.transfer_on_attack = FALSE
 		force = 3
 		w_class = WEIGHT_CLASS_SMALL
 		throwforce = 5

--- a/code/modules/food_and_drinks/food.dm
+++ b/code/modules/food_and_drinks/food.dm
@@ -14,6 +14,7 @@
 	if(!mapload)
 		pixel_x = rand(-5, 5)
 		pixel_y = rand(-5, 5)
+	AddComponent(/datum/component/dippable, TRUE, 0, 0, 0.1, DIP_TYPE_FRACTIONAL_DIPPED_MAXIMUM)
 
 /obj/item/reagent_containers/food/proc/checkLiked(var/fraction, mob/M)
 	if(last_check_time + 50 < world.time)

--- a/code/modules/reagents/reagent_containers.dm
+++ b/code/modules/reagents/reagent_containers.dm
@@ -48,6 +48,10 @@
 /obj/item/reagent_containers/afterattack(obj/target, mob/user , flag)
 	return
 
+/obj/item/reagent_containers/attackby(obj/item/I, mob/living/user, params)
+	I.SendSignal(COMSIG_ITEM_ATTACK_REAGENT_CONTAINER, src, user)
+	return ..()
+
 /obj/item/reagent_containers/proc/canconsume(mob/eater, mob/user)
 	if(!iscarbon(eater))
 		return 0

--- a/code/modules/reagents/reagent_containers.dm
+++ b/code/modules/reagents/reagent_containers.dm
@@ -49,7 +49,7 @@
 	return
 
 /obj/item/reagent_containers/attackby(obj/item/I, mob/living/user, params)
-	I.SendSignal(COMSIG_ITEM_ATTACK_REAGENT_CONTAINER, src, user)
+	I.SendSignal(COMSIG_ITEM_ATTACK_REAGENT_CONTAINER, src, user, params)
 	return ..()
 
 /obj/item/reagent_containers/proc/canconsume(mob/eater, mob/user)

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -309,6 +309,7 @@
 #include "code\datums\components\caltrop.dm"
 #include "code\datums\components\chasm.dm"
 #include "code\datums\components\decal.dm"
+#include "code\datums\components\dippable.dm"
 #include "code\datums\components\infective.dm"
 #include "code\datums\components\jousting.dm"
 #include "code\datums\components\knockoff.dm"


### PR DESCRIPTION
:cl: Y0SH1_M4S73R
add: Food and sharp objects can be dipped in reagents. Sharp dipped objects will transfer some of their reagents to their victims via touch when attacking.
/:cl:

This adds the "dippable" component, whose parameters are explained in the comments at the top of dippable.dm.

Hopefully this time there won't be any extraneous commits crammed into this PR. Like before, feel free to address any balance concerns, and in this case, any rebase blunders.
