### PR TITLE
Restore the Syndicate allinone to its full functionality

### DIFF
--- a/code/game/machinery/telecomms/machines/allinone.dm
+++ b/code/game/machinery/telecomms/machines/allinone.dm
@@ -21,10 +21,15 @@
 /obj/machinery/telecomms/allinone/receive_signal(datum/signal/subspace/signal)
 	if(!istype(signal) || signal.transmission_method != TRANSMISSION_SUBSPACE)  // receives on subspace only
 		return
-	if(!on || !(z in signal.levels) || !is_freq_listening(signal))  // has to be on to receive messages
+	if(!on || !is_freq_listening(signal))  // has to be on to receive messages
+		return
+	if (!intercept && !(z in signal.levels) && !(0 in signal.levels))  // has to be syndicate or on the right level
 		return
 
 	// Decompress the signal and mark it done
+	if (intercept)
+		signal.levels += 0  // Signal is broadcast to agents anywhere
+
 	signal.data["compression"] = 0
 	signal.mark_done()
 	if(signal.data["slow"] > 0)


### PR DESCRIPTION
:cl:
fix: The Syndicate radio channel works on the station properly again.
/:cl:

Fixes #33757. The all-in-one services only the Syndicate frequency and is not necessary for headsets with the Syndicate encryption key to hear the other well-known frequencies. As long as the all-in-one is not destroyed (the nuke ops shuttle bombed), Syndicate communications work anywhere.