### PR TITLE
Arena shuttle teleport fix

### DIFF
--- a/_maps/map_files/generic/CentCom.dmm
+++ b/_maps/map_files/generic/CentCom.dmm
@@ -13774,11 +13774,11 @@
 /area/tdome/tdomeadmin)
 "JV" = (
 /turf/closed/wall/mineral/titanium,
-/area/shuttle/escape)
+/area/shuttle/escape/backup)
 "JW" = (
 /obj/machinery/status_display,
 /turf/closed/wall/mineral/titanium,
-/area/shuttle/escape)
+/area/shuttle/escape/backup)
 "JX" = (
 /obj/machinery/door/firedoor,
 /obj/effect/turf_decal/stripes/line{
@@ -13821,16 +13821,16 @@
 /area/tdome/tdomeadmin)
 "Kd" = (
 /turf/open/floor/mineral/titanium,
-/area/shuttle/escape)
+/area/shuttle/escape/backup)
 "Ke" = (
 /turf/open/floor/mineral/plastitanium,
-/area/shuttle/escape)
+/area/shuttle/escape/backup)
 "Kf" = (
 /obj/machinery/computer/emergency_shuttle{
 	dir = 8
 	},
 /turf/open/floor/mineral/titanium,
-/area/shuttle/escape)
+/area/shuttle/escape/backup)
 "Kg" = (
 /turf/closed/indestructible/fakedoor{
 	name = "Thunderdome Admin"
@@ -13870,18 +13870,18 @@
 	},
 /obj/docking_port/mobile/emergency/backup,
 /turf/open/floor/plating,
-/area/shuttle/escape)
+/area/shuttle/escape/backup)
 "Kl" = (
 /obj/structure/chair/office/light{
 	dir = 4
 	},
 /turf/open/floor/mineral/titanium,
-/area/shuttle/escape)
+/area/shuttle/escape/backup)
 "Km" = (
 /obj/structure/table/wood,
 /obj/item/paper/fluff/stations/centcom/broken_evac,
 /turf/open/floor/mineral/titanium,
-/area/shuttle/escape)
+/area/shuttle/escape/backup)
 "Kn" = (
 /obj/structure/bookcase/random,
 /turf/open/floor/plasteel/vault{
@@ -14017,7 +14017,7 @@
 /obj/structure/table/wood,
 /obj/item/book/manual/random,
 /turf/open/floor/mineral/titanium,
-/area/shuttle/escape)
+/area/shuttle/escape/backup)
 "KA" = (
 /obj/structure/flora/ausbushes/lavendergrass,
 /obj/structure/flora/ausbushes/sparsegrass,
@@ -14049,13 +14049,13 @@
 	dir = 8
 	},
 /turf/open/floor/mineral/titanium,
-/area/shuttle/escape)
+/area/shuttle/escape/backup)
 "KF" = (
 /obj/machinery/light{
 	dir = 4
 	},
 /turf/open/floor/mineral/titanium,
-/area/shuttle/escape)
+/area/shuttle/escape/backup)
 "KG" = (
 /obj/structure/flora/ausbushes/lavendergrass,
 /obj/structure/flora/ausbushes/sparsegrass,

--- a/code/game/area/areas/shuttles.dm
+++ b/code/game/area/areas/shuttles.dm
@@ -76,6 +76,9 @@
 /area/shuttle/escape
 	name = "Emergency Shuttle"
 
+/area/shuttle/escape/backup
+	name = "Backup Emergency Shuttle"
+
 /area/shuttle/escape/luxury
 	name = "Luxurious Emergency Shuttle"
 	noteleport = TRUE

--- a/code/modules/admin/fun_balloon.dm
+++ b/code/modules/admin/fun_balloon.dm
@@ -117,19 +117,25 @@
 
 /obj/effect/forcefield/arena_shuttle
 	name = "portal"
-	var/list/warp_points = list()
+	var/list/warp_points
 
+/obj/effect/forcefield/arena_shuttle/Initialize()
+	. = ..()
+	warp_points = get_area_turfs(/area/shuttle/escape)
+	for(var/thing in warp_points)
+		CHECK_TICK
+		var/turf/T = thing
+		if(istype(T.loc, /area/shuttle/escape/backup))
+			warp_points -= T
+			continue
+		for(var/atom/movable/TAM in T)
+			if(TAM.density && TAM.anchored)
+				warp_points -= T
+				break
 
 /obj/effect/forcefield/arena_shuttle/CollidedWith(atom/movable/AM)
 	if(!isliving(AM))
 		return
-	if(!warp_points.len)
-		warp_points = get_area_turfs(/area/shuttle/escape)
-		for(var/turf/T in warp_points)
-			for(var/atom/movable/TAM in T)
-				if(TAM.density && TAM.anchored)
-					warp_points -= T
-					break
 
 	var/mob/living/L = AM
 	if(L.pulling && istype(L.pulling, /obj/item/bodypart/head))


### PR DESCRIPTION
:cl: ninjanomnom
fix: The backup shuttle has it's own area now and you should no longer occasionally be teleported there by the arena shuttle.
/:cl:

This also moves the population of the teleport destination list to initialization and check ticks it.

fixes #33760
