### PR TITLE
Fixed autolathes and ore redemption machines leaving things at previous shuttle locations

### DIFF
--- a/code/game/machinery/autolathe.dm
+++ b/code/game/machinery/autolathe.dm
@@ -172,7 +172,7 @@
 				use_power(power)
 				icon_state = "autolathe"
 				flick("autolathe_n",src)
-				var/time = is_stack ? 32*coeff : 32*coeff*multiplier
+				var/time = is_stack ? 32 : 32*coeff*multiplier
 				addtimer(CALLBACK(src, .proc/make_item, power, metal_cost, glass_cost, multiplier, coeff, is_stack), time)
 
 		if(href_list["search"])
@@ -194,7 +194,7 @@
 	GET_COMPONENT(materials, /datum/component/material_container)
 	var/turf/T = drop_location()
 	use_power(power)
-	var/list/materials_used = list(MAT_METAL=metal_cost*multiplier, MAT_GLASS=glass_cost*multiplier)
+	var/list/materials_used = list(MAT_METAL=metal_cost*coeff*multiplier, MAT_GLASS=glass_cost*coeff*multiplier)
 	materials.use_amount(materials_used)
 
 	if(is_stack)

--- a/code/game/machinery/autolathe.dm
+++ b/code/game/machinery/autolathe.dm
@@ -192,21 +192,21 @@
 
 /obj/machinery/autolathe/proc/make_item(power, metal_cost, glass_cost, multiplier, coeff, is_stack)
 	GET_COMPONENT(materials, /datum/component/material_container)
-	var/turf/T = drop_location()
+	var/atom/A = drop_location()
 	use_power(power)
 	var/list/materials_used = list(MAT_METAL=metal_cost*coeff*multiplier, MAT_GLASS=glass_cost*coeff*multiplier)
 	materials.use_amount(materials_used)
 
 	if(is_stack)
-		var/obj/item/stack/N = new being_built.build_path(T, multiplier)
+		var/obj/item/stack/N = new being_built.build_path(A, multiplier)
 		N.update_icon()
 		N.autolathe_crafted(src)
-		for(var/obj/item/stack/S in T.contents - N)
+		for(var/obj/item/stack/S in (A.contents - N))
 			if(istype(S, N.merge_type))
 				N.merge(S)
 	else
 		for(var/i=1, i<=multiplier, i++)
-			var/obj/item/new_item = new being_built.build_path(T)
+			var/obj/item/new_item = new being_built.build_path(A)
 			for(var/mat in materials_used)
 				new_item.materials[mat] = materials_used[mat] / multiplier
 			new_item.autolathe_crafted(src)

--- a/code/game/machinery/autolathe.dm
+++ b/code/game/machinery/autolathe.dm
@@ -172,10 +172,8 @@
 				use_power(power)
 				icon_state = "autolathe"
 				flick("autolathe_n",src)
-				if(is_stack)
-					addtimer(CALLBACK(src, .proc/make_stack, power, metal_cost, glass_cost, multiplier, coeff), 32*coeff)
-				else
-					addtimer(CALLBACK(src, .proc/make_nonstack, power, metal_cost, glass_cost, multiplier, coeff), 32*coeff*multiplier)
+				var/time = is_stack ? 32*coeff : 32*coeff*multiplier
+				addtimer(CALLBACK(src, .proc/make_item, power, metal_cost, glass_cost, multiplier, coeff, is_stack), time)
 
 		if(href_list["search"])
 			matching_designs.Cut()
@@ -192,35 +190,27 @@
 
 	return
 
-
-/obj/machinery/autolathe/proc/make_stack(power, metal_cost, glass_cost, multiplier, coeff)
+/obj/machinery/autolathe/proc/make_item(power, metal_cost, glass_cost, multiplier, coeff, is_stack)
 	GET_COMPONENT(materials, /datum/component/material_container)
-	var/turf/T = loc
+	var/turf/T = drop_location()
 	use_power(power)
 	var/list/materials_used = list(MAT_METAL=metal_cost*multiplier, MAT_GLASS=glass_cost*multiplier)
 	materials.use_amount(materials_used)
 
-	var/obj/item/stack/N = new being_built.build_path(T, multiplier)
-	N.update_icon()
-	N.autolathe_crafted(src)
+	if(is_stack)
+		var/obj/item/stack/N = new being_built.build_path(T, multiplier)
+		N.update_icon()
+		N.autolathe_crafted(src)
+		for(var/obj/item/stack/S in T.contents - N)
+			if(istype(S, N.merge_type))
+				N.merge(S)
+	else
+		for(var/i=1, i<=multiplier, i++)
+			var/obj/item/new_item = new being_built.build_path(T)
+			for(var/mat in materials_used)
+				new_item.materials[mat] = materials_used[mat] / multiplier
+			new_item.autolathe_crafted(src)
 
-	for(var/obj/item/stack/S in T.contents - N)
-		if(istype(S, N.merge_type))
-			N.merge(S)
-	busy = FALSE
-	updateDialog()
-
-/obj/machinery/autolathe/proc/make_nonstack(power, metal_cost, glass_cost, multiplier, coeff)
-	GET_COMPONENT(materials, /datum/component/material_container)
-	var/turf/T = loc
-	use_power(power)
-	var/list/materials_used = list(MAT_METAL=metal_cost*coeff*multiplier, MAT_GLASS=glass_cost*coeff*multiplier)
-	materials.use_amount(materials_used)
-	for(var/i=1, i<=multiplier, i++)
-		var/obj/item/new_item = new being_built.build_path(T)
-		for(var/mat in materials_used)
-			new_item.materials[mat] = materials_used[mat] / multiplier
-		new_item.autolathe_crafted(src)
 	busy = FALSE
 	updateDialog()
 

--- a/code/modules/mining/machine_redemption.dm
+++ b/code/modules/mining/machine_redemption.dm
@@ -257,9 +257,8 @@
 		if("Release")
 
 			if(check_access(inserted_id) || allowed(usr)) //Check the ID inside, otherwise check the user
-				var/out = get_step(src, output_dir)
 				if(params["id"] == "all")
-					materials.retrieve_all(out)
+					materials.retrieve_all(get_step(src, output_dir))
 				else
 					var/mat_id = params["id"]
 					if(!materials.materials[mat_id])
@@ -277,7 +276,7 @@
 						desired = input("How many sheets?", "How many sheets would you like to smelt?", 1) as null|num
 
 					var/sheets_to_remove = round(min(desired,50,stored_amount))
-					materials.retrieve_sheets(sheets_to_remove, mat_id, out)
+					materials.retrieve_sheets(sheets_to_remove, mat_id, get_step(src, output_dir))
 
 			else
 				to_chat(usr, "<span class='warning'>Required access not found.</span>")


### PR DESCRIPTION
Fixes #33654 

Also made autolathes use timers instead of spawns.

Tell me if you can think of any other machines that store a turf they are going to spit something out on and then sleep before spitting it out. Or just make your own PR for free PR points.