### PR TITLE
 Changes how Santa gift generation works

### DIFF
--- a/code/game/objects/items/gift.dm
+++ b/code/game/objects/items/gift.dm
@@ -8,21 +8,30 @@
  * Gifts
  */
 
-GLOBAL_LIST_EMPTY(possible_gifts)
+GLOBAL_LIST_EMPTY(possible_toy_gifts)
+GLOBAL_LIST_EMPTY(possible_anything_gifts)
 
 /obj/item/a_gift
-	name = "gift"
-	desc = "PRESENTS!!!! eek!"
+	name = "christmas gift"
+	desc = "It could be anything!"
 	icon = 'icons/obj/storage.dmi'
 	icon_state = "giftdeliverypackage3"
 	item_state = "gift"
 	resistance_flags = FLAMMABLE
+	var/obj/item/gift_type
 
-/obj/item/a_gift/New()
-	..()
+/obj/item/a_gift/Initialize(mapload)
+	. = ..()
 	pixel_x = rand(-10,10)
 	pixel_y = rand(-10,10)
 	icon_state = "giftdeliverypackage[rand(1,5)]"
+
+	gift_type = get_gift_type()
+
+/obj/item/a_gift/examine(mob/user)
+	. = ..()
+	if(isobserver(user) || (user && user.mind && user.mind.special_role == "Santa"))
+		to_chat(user, "<span class='notice'>This gift contains \a <b>[initial(gift_type.name)]</b>.</span>")
 
 /obj/item/a_gift/suicide_act(mob/user)
 	user.visible_message("<span class='suicide'>[user] peeks inside [src] and cries [user.p_them()]self to death! It looks like [user.p_they()] [user.p_were()] on the naughty list...</span>")
@@ -33,71 +42,75 @@ GLOBAL_LIST_EMPTY(possible_gifts)
 		to_chat(M, "<span class='warning'>You're supposed to be spreading gifts, not opening them yourself!</span>")
 		return
 
-	var/gift_type = get_gift_type()
+	unwrap(M)
 
+/obj/item/a_gift/proc/unwrap(mob/M)
 	qdel(src)
-	var/obj/item/I = new gift_type(M)
-	M.put_in_hands(I)
-	I.add_fingerprint(M)
+
+	var/obj/item/I
+	if(M)
+		I = new gift_type(M)
+		M.put_in_hands(I)
+		I.add_fingerprint(M)
+	else
+		I = new gift_type(get_turf(src))
 
 /obj/item/a_gift/proc/get_gift_type()
-	var/gift_type_list = list(/obj/item/sord,
-		/obj/item/storage/wallet,
-		/obj/item/storage/photo_album,
-		/obj/item/storage/box/snappops,
-		/obj/item/storage/crayons,
-		/obj/item/storage/backpack/holding,
-		/obj/item/storage/belt/champion,
-		/obj/item/soap/deluxe,
-		/obj/item/pickaxe/diamond,
-		/obj/item/pen/invisible,
-		/obj/item/lipstick/random,
-		/obj/item/grenade/smokebomb,
-		/obj/item/grown/corncob,
-		/obj/item/poster/random_contraband,
-		/obj/item/poster/random_official,
-		/obj/item/book/manual/barman_recipes,
-		/obj/item/book/manual/chef_recipes,
-		/obj/item/bikehorn,
-		/obj/item/toy/beach_ball,
-		/obj/item/toy/beach_ball/holoball,
-		/obj/item/banhammer,
-		/obj/item/reagent_containers/food/snacks/grown/ambrosia/deus,
-		/obj/item/reagent_containers/food/snacks/grown/ambrosia/vulgaris,
-		/obj/item/device/paicard,
-		/obj/item/device/instrument/violin,
-		/obj/item/device/instrument/guitar,
-		/obj/item/storage/belt/utility/full,
-		/obj/item/clothing/neck/tie/horrible,
-		/obj/item/clothing/suit/jacket/leather,
-		/obj/item/clothing/suit/jacket/leather/overcoat,
-		/obj/item/clothing/suit/poncho,
-		/obj/item/clothing/suit/poncho/green,
-		/obj/item/clothing/suit/poncho/red,
-		/obj/item/clothing/suit/snowman,
-		/obj/item/clothing/head/snowman,
-		/obj/item/trash/coal)
+	if(!GLOB.possible_toy_gifts.len)
+		var/gift_type_list = list(/obj/item/sord,
+			/obj/item/storage/wallet,
+			/obj/item/storage/photo_album,
+			/obj/item/storage/box/snappops,
+			/obj/item/storage/crayons,
+			/obj/item/storage/backpack/holding,
+			/obj/item/storage/belt/champion,
+			/obj/item/soap/deluxe,
+			/obj/item/pickaxe/diamond,
+			/obj/item/pen/invisible,
+			/obj/item/lipstick/random,
+			/obj/item/grenade/smokebomb,
+			/obj/item/grown/corncob,
+			/obj/item/poster/random_contraband,
+			/obj/item/poster/random_official,
+			/obj/item/book/manual/barman_recipes,
+			/obj/item/book/manual/chef_recipes,
+			/obj/item/bikehorn,
+			/obj/item/toy/beach_ball,
+			/obj/item/toy/beach_ball/holoball,
+			/obj/item/banhammer,
+			/obj/item/reagent_containers/food/snacks/grown/ambrosia/deus,
+			/obj/item/reagent_containers/food/snacks/grown/ambrosia/vulgaris,
+			/obj/item/device/paicard,
+			/obj/item/device/instrument/violin,
+			/obj/item/device/instrument/guitar,
+			/obj/item/storage/belt/utility/full,
+			/obj/item/clothing/neck/tie/horrible,
+			/obj/item/clothing/suit/jacket/leather,
+			/obj/item/clothing/suit/jacket/leather/overcoat,
+			/obj/item/clothing/suit/poncho,
+			/obj/item/clothing/suit/poncho/green,
+			/obj/item/clothing/suit/poncho/red,
+			/obj/item/clothing/suit/snowman,
+			/obj/item/clothing/head/snowman,
+			/obj/item/trash/coal)
 
-	gift_type_list += subtypesof(/obj/item/clothing/head/collectable)
-	gift_type_list += subtypesof(/obj/item/toy) - (((typesof(/obj/item/toy/cards) - /obj/item/toy/cards/deck) + /obj/item/toy/figure + /obj/item/toy/ammo)) //All toys, except for abstract types and syndicate cards.
+		gift_type_list += subtypesof(/obj/item/clothing/head/collectable)
+		gift_type_list += subtypesof(/obj/item/toy) - (((typesof(/obj/item/toy/cards) - /obj/item/toy/cards/deck) + /obj/item/toy/figure + /obj/item/toy/ammo)) //All toys, except for abstract types and syndicate cards.
 
-	var/gift_type = pick(gift_type_list)
+		GLOB.possible_toy_gifts += gift_type_list
+
+	var/gift_type = pick(GLOB.possible_toy_gifts)
 
 	return gift_type
 
-
-/obj/item/a_gift/anything
-	name = "christmas gift"
-	desc = "It could be anything!"
-
 /obj/item/a_gift/anything/get_gift_type()
-	if(!GLOB.possible_gifts.len)
+	if(!GLOB.possible_anything_gifts.len)
 		var/list/gift_types_list = subtypesof(/obj/item)
 		for(var/V in gift_types_list)
 			var/obj/item/I = V
 			if((!initial(I.icon_state)) || (!initial(I.item_state)) || (initial(I.flags_1) & ABSTRACT_1))
 				gift_types_list -= V
-				GLOB.possible_gifts = gift_types_list
-	var/gift_type = pick(GLOB.possible_gifts)
+				GLOB.possible_anything_gifts = gift_types_list
+	var/gift_type = pick(GLOB.possible_anything_gifts)
 
 	return gift_type

--- a/code/modules/clothing/outfits/event.dm
+++ b/code/modules/clothing/outfits/event.dm
@@ -28,4 +28,10 @@
 	var/obj/item/a_gift/gift = new(H)
 	while(bag.can_be_inserted(gift, 1))
 		bag.handle_item_insertion(gift, 1)
-		gift = new(H)
+		if(prob(50))
+			gift = new /obj/item/a_gift(H)
+		else
+			gift = new /obj/item/a_gift/anything(H)
+
+	// Remove the last gift that doesn't fit.
+	qdel(gift)

--- a/code/modules/events/holiday/xmas.dm
+++ b/code/modules/events/holiday/xmas.dm
@@ -92,7 +92,7 @@
 	priority_announce("Santa is coming to town!", "Unknown Transmission")
 
 /datum/round_event/santa/start()
-	var/list/candidates = pollGhostCandidates("Santa is coming to town! Do you want to be santa?", poll_time=150)
+	var/list/candidates = pollGhostCandidates("Santa is coming to town! Do you want to be Santa?", poll_time=150)
 	if(LAZYLEN(candidates))
 		var/mob/dead/observer/Z = pick(candidates)
 		santa = new /mob/living/carbon/human(pick(GLOB.blobstart))

--- a/code/modules/events/holiday/xmas.dm
+++ b/code/modules/events/holiday/xmas.dm
@@ -107,9 +107,10 @@
 		santa_objective.completed = 1 //lets cut our santas some slack.
 		santa_objective.owner = santa.mind
 		santa.mind.objectives += santa_objective
-		santa.mind.AddSpell(new /obj/effect/proc_holder/spell/aoe_turf/conjure/presents)
-		var/obj/effect/proc_holder/spell/targeted/area_teleport/teleport/telespell = new(santa)
-		telespell.clothes_req = 0 //santa robes aren't actually magical.
-		santa.mind.AddSpell(telespell) //does the station have chimneys? WHO KNOWS!
+		santa.mind.AddSpell(new /obj/effect/proc_holder/spell/targeted/conjure_item/minor_christmas_gift)
+		santa.mind.AddSpell(new /obj/effect/proc_holder/spell/targeted/conjure_item/wild_christmas_gift)
+		santa.mind.AddSpell(new /obj/effect/proc_holder/spell/targeted/area_teleport/teleport/santa)
 
-		to_chat(santa, "<span class='boldannounce'>You are Santa! Your objective is to bring joy to the people on this station. You can conjure more presents using a spell, and there are several presents in your bag.</span>")
+		to_chat(santa, "<span class='boldannounce'>You are Santa! Your objective is to bring joy to the people on this station. You can conjure more presents using your spells, and there are several presents in your bag. You have a special present vision, which means you can examine presents to see what they will contain.</span>")
+
+/obj/effect/proc_holder/spell/targeted/conjure_item/toy_present

--- a/code/modules/spells/spell_types/conjure.dm
+++ b/code/modules/spells/spell_types/conjure.dm
@@ -75,6 +75,7 @@
 	include_user = 1
 	range = -1
 	clothes_req = 0
+	var/only_one = TRUE
 	var/obj/item/item
 	var/item_type = /obj/item/banhammer
 	school = "conjuration"
@@ -82,19 +83,18 @@
 	cooldown_min = 10
 
 /obj/effect/proc_holder/spell/targeted/conjure_item/cast(list/targets, mob/user = usr)
-	if (item && !QDELETED(item))
-		qdel(item)
-		item = null
+	if(only_one && item && !QDELETED(item))
+		QDEL_NULL(item)
 	else
 		for(var/mob/living/carbon/C in targets)
 			if(C.dropItemToGround(C.get_active_held_item()))
-				C.put_in_hands(make_item(), TRUE)
+				C.put_in_hands(make_item(user), TRUE)
 
 /obj/effect/proc_holder/spell/targeted/conjure_item/Destroy()
-	if(item)
+	if(item && only_one)
 		qdel(item)
 	return ..()
 
-/obj/effect/proc_holder/spell/targeted/conjure_item/proc/make_item()
-	item = new item_type
+/obj/effect/proc_holder/spell/targeted/conjure_item/proc/make_item(mob/user)
+	item = new item_type(get_turf(user))
 	return item

--- a/code/modules/spells/spell_types/santa.dm
+++ b/code/modules/spells/spell_types/santa.dm
@@ -13,3 +13,24 @@
 	summon_type = list("/obj/item/a_gift")
 	summon_lifespan = 0
 	summon_amt = 5
+
+/obj/effect/proc_holder/spell/targeted/area_teleport/teleport/santa
+	name = "Teleport"
+	invocation = "REINDEER AWAY! TO THE"
+	clothes_req = FALSE
+
+/obj/effect/proc_holder/spell/targeted/conjure_item/minor_christmas_gift
+	name = "Make Minor Christmas Present"
+	desc = "Summons a wrapped minor present and puts it in your hand."
+	item_type = /obj/item/a_gift
+	invocation = "HO HO HO"
+	only_one = FALSE
+	charge_max = 1 MINUTES
+
+/obj/effect/proc_holder/spell/targeted/conjure_item/wild_christmas_gift
+	name = "Make Wild Christmas Present"
+	desc = "Summons a wrapped present that could be almost anything, and puts it in your hand."
+	item_type = /obj/item/a_gift/anything
+	invocation = "HO HO HO"
+	only_one = FALSE
+	charge_max = 2 MINUTES


### PR DESCRIPTION
:cl: coiax
add: Santa now has two spells to generate presents, one for
generating
toy-like presents, and one for generating wild presents that could
be almost anything.
add: Santa (and observers) can use their gift sense to determine
what is inside an unopened gift.
/:cl:

- Minor Christmas Gift contains items from the old gift spawn system
- Wild Christmas Gift is the new anything gift style.

Minor has a 1 minute cooldown, generates 1 present.
Wild has a 2 minute cooldown, generates 1 present.

Santa starts with approximately 50% wild and 50% minor gifts in his
bag,
and can examine the gifts to determine what is appropriate.

Santa continues to be unable to open gifts himself.

Santa teleport has a new invocation.

Why? Because Santa gifts should be as fun and exciting as the gift
from under the tree, and if he's not happy with your explanation of
whether you've been a good boy or girl this year, he'll just give you a pack
of cards. If he's happy with it, he'll give you a chainsaw.