### PR TITLE
Gulag mining scanners can not disarm gibtonite

### DIFF
--- a/_maps/map_files/Mining/Lavaland.dmm
+++ b/_maps/map_files/Mining/Lavaland.dmm
@@ -111,7 +111,7 @@
 /obj/item/pickaxe,
 /obj/item/device/flashlight,
 /obj/item/clothing/glasses/meson,
-/obj/item/device/mining_scanner,
+/obj/item/device/mining_scanner/nogibtonite,
 /turf/open/floor/plasteel,
 /area/mine/laborcamp)
 "av" = (
@@ -120,7 +120,7 @@
 /obj/item/device/flashlight,
 /obj/item/pickaxe,
 /obj/item/clothing/glasses/meson,
-/obj/item/device/mining_scanner,
+/obj/item/device/mining_scanner/nogibtonite,
 /turf/open/floor/plasteel,
 /area/mine/laborcamp)
 "aw" = (

--- a/code/modules/mining/equipment/mineral_scanner.dm
+++ b/code/modules/mining/equipment/mineral_scanner.dm
@@ -11,6 +11,10 @@
 	slot_flags = SLOT_BELT
 	var/cooldown = 35
 	var/current_cooldown = 0
+	var/can_defuse = TRUE
+
+/obj/item/device/mining_scanner/nogibtonite
+	can_defuse = FALSE
 
 /obj/item/device/mining_scanner/attack_self(mob/user)
 	if(!user.client)

--- a/code/modules/mining/ores_coins.dm
+++ b/code/modules/mining/ores_coins.dm
@@ -223,6 +223,11 @@
 		return
 	if(primed)
 		if(istype(I, /obj/item/device/mining_scanner) || istype(I, /obj/item/device/t_scanner/adv_mining_scanner) || istype(I, /obj/item/device/multitool))
+			if(istype(I, /obj/item/device/mining_scanner))
+				var/obj/item/device/mining_scanner/S = I
+				if(!S.can_defuse)
+					to_chat(user, "<span class='boldwarning'>[S] does not have the necessary frequencies for disarming gibtonite!</span>")
+					return
 			primed = FALSE
 			if(det_timer)
 				deltimer(det_timer)

--- a/code/modules/mining/ores_coins.dm
+++ b/code/modules/mining/ores_coins.dm
@@ -221,6 +221,7 @@
 	if(istype(I, /obj/item/pickaxe) || istype(I, /obj/item/resonator) || I.force >= 10)
 		GibtoniteReaction(user)
 		return
+	var/do_disarm = alt_disarm || istype(I, /obj/item/device/t_scanner/adv_mining_scanner) || istype(I, /obj/item/device/multitool)
 	if(primed)
 		if(istype(I, /obj/item/device/mining_scanner))
 			var/obj/item/device/mining_scanner/S = I
@@ -228,7 +229,6 @@
 				to_chat(user, "<span class='boldwarning'>[S] does not have the necessary frequencies for disarming gibtonite!</span>")
 				return
 			do_disarm = TRUE
-	var/do_disarm = alt_disarm || istype(I, /obj/item/device/t_scanner/adv_mining_scanner) || istype(I, /obj/item/device/multitool)
 	if(do_disarm)
 		primed = FALSE
 		if(det_timer)

--- a/code/modules/mining/ores_coins.dm
+++ b/code/modules/mining/ores_coins.dm
@@ -221,7 +221,7 @@
 	if(istype(I, /obj/item/pickaxe) || istype(I, /obj/item/resonator) || I.force >= 10)
 		GibtoniteReaction(user)
 		return
-	var/do_disarm = alt_disarm || istype(I, /obj/item/device/t_scanner/adv_mining_scanner) || istype(I, /obj/item/device/multitool)
+	var/do_disarm = istype(I, /obj/item/device/t_scanner/adv_mining_scanner) || istype(I, /obj/item/device/multitool)
 	if(primed)
 		if(istype(I, /obj/item/device/mining_scanner))
 			var/obj/item/device/mining_scanner/S = I

--- a/code/modules/mining/ores_coins.dm
+++ b/code/modules/mining/ores_coins.dm
@@ -222,19 +222,21 @@
 		GibtoniteReaction(user)
 		return
 	if(primed)
-		if(istype(I, /obj/item/device/mining_scanner) || istype(I, /obj/item/device/t_scanner/adv_mining_scanner) || istype(I, /obj/item/device/multitool))
-			if(istype(I, /obj/item/device/mining_scanner))
-				var/obj/item/device/mining_scanner/S = I
-				if(!S.can_defuse)
-					to_chat(user, "<span class='boldwarning'>[S] does not have the necessary frequencies for disarming gibtonite!</span>")
-					return
-			primed = FALSE
-			if(det_timer)
-				deltimer(det_timer)
-			user.visible_message("The chain reaction was stopped! ...The ore's quality looks diminished.", "<span class='notice'>You stopped the chain reaction. ...The ore's quality looks diminished.</span>")
-			icon_state = "Gibtonite ore"
-			quality = GIBTONITE_QUALITY_LOW
-			return
+		if(istype(I, /obj/item/device/mining_scanner))
+			var/obj/item/device/mining_scanner/S = I
+			if(!S.can_defuse)
+				to_chat(user, "<span class='boldwarning'>[S] does not have the necessary frequencies for disarming gibtonite!</span>")
+				return
+			do_disarm = TRUE
+	var/do_disarm = alt_disarm || istype(I, /obj/item/device/t_scanner/adv_mining_scanner) || istype(I, /obj/item/device/multitool)
+	if(do_disarm)
+		primed = FALSE
+		if(det_timer)
+			deltimer(det_timer)
+		user.visible_message("The chain reaction was stopped! ...The ore's quality looks diminished.", "<span class='notice'>You stopped the chain reaction. ...The ore's quality looks diminished.</span>")
+		icon_state = "Gibtonite ore"
+		quality = GIBTONITE_QUALITY_LOW
+		return
 	..()
 
 /obj/item/twohanded/required/gibtonite/attack_self(user)


### PR DESCRIPTION
I believe the argument was it was too slow otherwise, but I don't think prisoners should have easy access to explosives either.