### PR TITLE
Rebalances virus healing

### DIFF
--- a/code/datums/diseases/advance/symptoms/heal.dm
+++ b/code/datums/diseases/advance/symptoms/heal.dm
@@ -74,7 +74,7 @@
 			if(istype(T, /turf/open/space))
 				return power * nearspace_penalty
 
-/datum/symptom/heal/starlight/Heal(mob/living/M, datum/disease/advance/A, actual_power)
+/datum/symptom/heal/starlight/Heal(mob/living/carbon/M, datum/disease/advance/A, actual_power)
 	var/heal_amt = actual_power
 	if(M.getToxLoss() && prob(5))
 		to_chat(M, "<span class='notice'>Your skin tingles as the starlight seems to heal you.</span>")

--- a/code/datums/diseases/advance/symptoms/heal.dm
+++ b/code/datums/diseases/advance/symptoms/heal.dm
@@ -1,10 +1,10 @@
 /datum/symptom/heal
 	name = "Basic Healing (does nothing)" //warning for adminspawn viruses
 	desc = "You should not be seeing this."
-	stealth = 1
-	resistance = -4
-	stage_speed = -4
-	transmittable = -4
+	stealth = 0
+	resistance = 0
+	stage_speed = 0
+	transmittable = 0
 	level = 0 //not obtainable
 	base_message_chance = 20 //here used for the overlays
 	symptom_delay_min = 1
@@ -22,7 +22,6 @@
 /datum/symptom/heal/Activate(datum/disease/advance/A)
 	if(!..())
 		return
-	 //100% chance to activate for slow but consistent healing
 	var/mob/living/M = A.affected_mob
 	switch(A.stage)
 		if(4, 5)
@@ -45,20 +44,20 @@
 	return TRUE
 
 
-/datum/symptom/heal/toxin
+/datum/symptom/heal/starlight
 	name = "Starlight Condensation"
-	desc = "The virus reacts to direct starlight, producing regenerative chemicals that can cure toxin damage."
-	stealth = 1
-	resistance = -3
-	stage_speed = -3
-	transmittable = -3
+	desc = "The virus reacts to direct starlight, producing regenerative chemicals. Works best against toxin-based damage."
+	stealth = -1
+	resistance = -2
+	stage_speed = 0
+	transmittable = 1
 	level = 6
 	passive_message = "<span class='notice'>You miss the feeling of starlight on your skin.</span>"
 	var/nearspace_penalty = 0.3
 	threshold_desc = "<b>Stage Speed 6:</b> Increases healing speed.<br>\
 					  <b>Transmission 6:</b> Removes penalty for only being close to space."
 
-/datum/symptom/heal/toxin/Start(datum/disease/advance/A)
+/datum/symptom/heal/starlight/Start(datum/disease/advance/A)
 	if(!..())
 		return
 	if(A.properties["transmission"] >= 6)
@@ -66,7 +65,7 @@
 	if(A.properties["stage_rate"] >= 6)
 		power = 2
 
-/datum/symptom/heal/toxin/CanHeal(datum/disease/advance/A)
+/datum/symptom/heal/starlight/CanHeal(datum/disease/advance/A)
 	var/mob/living/M = A.affected_mob
 	if(istype(get_turf(M), /turf/open/space))
 		return power
@@ -75,15 +74,25 @@
 			if(istype(T, /turf/open/space))
 				return power * nearspace_penalty
 
-/datum/symptom/heal/toxin/Heal(mob/living/M, datum/disease/advance/A, actual_power)
+/datum/symptom/heal/starlight/Heal(mob/living/M, datum/disease/advance/A, actual_power)
 	var/heal_amt = actual_power
 	if(M.getToxLoss() && prob(5))
-		to_chat(M, "<span class='notice'>Your skin tingles as the starlight purges toxins from your bloodstream.</span>")
-	M.adjustToxLoss(-heal_amt)
+		to_chat(M, "<span class='notice'>Your skin tingles as the starlight seems to heal you.</span>")
+
+	M.adjustToxLoss(-(4 * heal_amt)) //most effective on toxins
+
+	var/list/parts = M.get_damaged_bodyparts(1,1)
+
+	if(!parts.len)
+		return
+
+	for(var/obj/item/bodypart/L in parts)
+		if(L.heal_damage(heal_amt/parts.len, heal_amt/parts.len))
+			M.update_damage_overlays()
 	return 1
 
-/datum/symptom/heal/toxin/passive_message_condition(mob/living/M)
-	if(M.getToxLoss())
+/datum/symptom/heal/starlight/passive_message_condition(mob/living/M)
+	if(M.getBruteLoss() || M.getFireLoss() || M.getToxLoss())
 		return TRUE
 	return FALSE
 
@@ -91,7 +100,7 @@
 	name = "Toxolysis"
 	stealth = 0
 	resistance = -2
-	stage_speed = -2
+	stage_speed = 2
 	transmittable = -2
 	level = 7
 	var/food_conversion = FALSE
@@ -153,58 +162,50 @@
 		to_chat(C, "<span class='notice'>You feel an odd gurgle in your stomach, as if it was working much faster than normal.</span>")
 	return 1
 
-/datum/symptom/heal/brute
-	name = "Cellular Molding"
-	desc = "The virus is able to shift cells around when in conditions of high heat, repairing existing physical damage."
-	stealth = 1
-	resistance = -3
-	stage_speed = -3
-	transmittable = -3
+/datum/symptom/heal/darkness
+	name = "Nocturnal Regeneration"
+	desc = "The virus is able to mend the host's flesh when in conditions of low light, repairing physical damage. More effective against brute damage."
+	stealth = 2
+	resistance = -1
+	stage_speed = -2
+	transmittable = -1
 	level = 6
-	passive_message = "<span class='notice'>You feel the flesh pulsing under your skin for a moment, but it's too cold to move.</span>"
+	passive_message = "<span class='notice'>You feel tingling on your skin as light passes over it.</span>"
 	threshold_desc = "<b>Stage Speed 8:</b> Doubles healing speed."
 
-/datum/symptom/heal/brute/Start(datum/disease/advance/A)
+/datum/symptom/heal/darkness/Start(datum/disease/advance/A)
 	if(!..())
 		return
 	if(A.properties["stage_rate"] >= 8)
 		power = 2
 
-/datum/symptom/heal/brute/CanHeal(datum/disease/advance/A)
+/datum/symptom/heal/darkness/CanHeal(datum/disease/advance/A)
 	var/mob/living/M = A.affected_mob
-	switch(M.bodytemperature)
-		if(0 to 340)
-			return FALSE
-		if(340 to BODYTEMP_HEAT_DAMAGE_LIMIT)
-			. = 0.3 * power
-		if(BODYTEMP_HEAT_DAMAGE_LIMIT to 400)
-			. = 0.75 * power
-		if(400 to 460)
-			. = power
-		else
-			. = 1.5 * power
+	var/light_amount = 0
+	if(isturf(M.loc)) //else, there's considered to be no light
+		var/turf/T = M.loc
+		light_amount = min(1,T.get_lumcount()) - 0.5
+		if(light_amount < SHADOW_SPECIES_LIGHT_THRESHOLD)
+			return power
 
-	if(M.on_fire)
-		. *= 2
-
-/datum/symptom/heal/brute/Heal(mob/living/carbon/M, datum/disease/advance/A, actual_power)
+/datum/symptom/heal/darkness/Heal(mob/living/carbon/M, datum/disease/advance/A, actual_power)
 	var/heal_amt = 2 * actual_power
 
-	var/list/parts = M.get_damaged_bodyparts(1,0) //brute only
+	var/list/parts = M.get_damaged_bodyparts(1,1)
 
 	if(!parts.len)
 		return
 
 	if(prob(5))
-		to_chat(M, "<span class='notice'>You feel your flesh moving beneath your heated skin, mending your wounds.</span>")
+		to_chat(M, "<span class='notice'>The darkness soothes and mends your wounds.</span>")
 
 	for(var/obj/item/bodypart/L in parts)
-		if(L.heal_damage(heal_amt/parts.len, 0))
+		if(L.heal_damage(heal_amt/parts.len, heal_amt/parts.len * 0.5)) //more effective on brute
 			M.update_damage_overlays()
 	return 1
 
-/datum/symptom/heal/brute/passive_message_condition(mob/living/M)
-	if(M.getBruteLoss())
+/datum/symptom/heal/darkness/passive_message_condition(mob/living/M)
+	if(M.getBruteLoss() || M.getFireLoss())
 		return TRUE
 	return FALSE
 
@@ -212,8 +213,8 @@
 	name = "Regenerative Coma"
 	desc = "The virus causes the host to fall into a death-like coma when severely damaged, then rapidly fixes the damage."
 	stealth = 0
-	resistance = 0
-	stage_speed = -2
+	resistance = 2
+	stage_speed = -3
 	transmittable = -2
 	level = 8
 	passive_message = "<span class='notice'>The pain from your wounds makes you feel oddly sleepy...</span>"
@@ -283,20 +284,20 @@
 		return TRUE
 	return FALSE
 
-/datum/symptom/heal/burn
+/datum/symptom/heal/water
 	name = "Tissue Hydration"
-	desc = "The virus uses excess water inside and outside the body to repair burned tisue cells."
-	stealth = 1
-	resistance = -3
-	stage_speed = -3
-	transmittable = -3
+	desc = "The virus uses excess water inside and outside the body to repair damaged tissue cells. More effective against burns."
+	stealth = 0
+	resistance = -1
+	stage_speed = 0
+	transmittable = 1
 	level = 6
-	passive_message = "<span class='notice'>Your burned skin feels oddly dry...</span>"
+	passive_message = "<span class='notice'>Your skin feels oddly dry...</span>"
 	var/absorption_coeff = 1
 	threshold_desc = "<b>Resistance 5:</b> Water is consumed at a much slower rate.<br>\
 					  <b>Stage Speed 7:</b> Increases healing speed."
 
-/datum/symptom/heal/burn/Start(datum/disease/advance/A)
+/datum/symptom/heal/water/Start(datum/disease/advance/A)
 	if(!..())
 		return
 	if(A.properties["stage_rate"] >= 7)
@@ -304,7 +305,7 @@
 	if(A.properties["stealth"] >= 2)
 		absorption_coeff = 0.25
 
-/datum/symptom/heal/burn/CanHeal(datum/disease/advance/A)
+/datum/symptom/heal/water/CanHeal(datum/disease/advance/A)
 	. = 0
 	var/mob/living/M = A.affected_mob
 	if(M.fire_stacks < 0)
@@ -317,33 +318,33 @@
 		M.reagents.remove_reagent("water", 0.5 * absorption_coeff)
 		. += power * 0.5
 
-/datum/symptom/heal/burn/Heal(mob/living/carbon/M, datum/disease/advance/A, actual_power)
+/datum/symptom/heal/water/Heal(mob/living/carbon/M, datum/disease/advance/A, actual_power)
 	var/heal_amt = 2 * actual_power
 
-	var/list/parts = M.get_damaged_bodyparts(0,1) //burn only
+	var/list/parts = M.get_damaged_bodyparts(1,1) //more effective on burns
 
 	if(!parts.len)
 		return
 
 	if(prob(5))
-		to_chat(M, "<span class='notice'>You feel yourself absorbing the water around you to soothe your burned skin.</span>")
+		to_chat(M, "<span class='notice'>You feel yourself absorbing the water around you to soothe your damaged skin.</span>")
 
 	for(var/obj/item/bodypart/L in parts)
-		if(L.heal_damage(0, heal_amt/parts.len))
+		if(L.heal_damage(heal_amt/parts.len * 0.5, heal_amt/parts.len))
 			M.update_damage_overlays()
 
 	return 1
 
-/datum/symptom/heal/burn/passive_message_condition(mob/living/M)
-	if(M.getFireLoss())
+/datum/symptom/heal/water/passive_message_condition(mob/living/M)
+	if(M.getBruteLoss() || M.getFireLoss())
 		return TRUE
 	return FALSE
 
 /datum/symptom/heal/plasma
 	name = "Plasma Fixation"
-	desc = "The virus draws plasma from the atmosphere and from inside the body to stabilize body temperature and heal burns."
+	desc = "The virus draws plasma from the atmosphere and from inside the body to heal and stabilize body temperature."
 	stealth = 0
-	resistance = 0
+	resistance = 3
 	stage_speed = -2
 	transmittable = -2
 	level = 8
@@ -379,8 +380,6 @@
 /datum/symptom/heal/plasma/Heal(mob/living/carbon/M, datum/disease/advance/A, actual_power)
 	var/heal_amt = 4 * actual_power
 
-	var/list/parts = M.get_damaged_bodyparts(0,1) //burn only
-
 	if(prob(5))
 		to_chat(M, "<span class='notice'>You feel yourself absorbing plasma inside and around you...</span>")
 
@@ -393,16 +392,17 @@
 		if(prob(5))
 			to_chat(M, "<span class='notice'>You feel warmer.</span>")
 
+	M.adjustToxLoss(-heal_amt)
+
+	var/list/parts = M.get_damaged_bodyparts(1,1)
 	if(!parts.len)
 		return
 	if(prob(5))
-		to_chat(M, "<span class='notice'>The pain from your burns fades rapidly.</span>")
-
+		to_chat(M, "<span class='notice'>The pain from your wounds fades rapidly.</span>")
 	for(var/obj/item/bodypart/L in parts)
-		if(L.heal_damage(0, heal_amt/parts.len))
+		if(L.heal_damage(heal_amt/parts.len, heal_amt/parts.len))
 			M.update_damage_overlays()
 	return 1
-
 
 
 /datum/symptom/heal/radiation
@@ -410,7 +410,7 @@
 	desc = "The virus uses radiation to fix damage through dna mutations."
 	stealth = -1
 	resistance = -2
-	stage_speed = 0
+	stage_speed = 2
 	transmittable = -3
 	level = 6
 	symptom_delay_min = 1
@@ -449,6 +449,8 @@
 
 	if(cellular_damage)
 		M.adjustCloneLoss(-heal_amt * 0.5)
+
+	M.adjustToxLoss(-(2 * heal_amt))
 
 	var/list/parts = M.get_damaged_bodyparts(1,1)
 


### PR DESCRIPTION
:cl: XDTM
balance: Rebalanced healing symptoms.
balance: Cellular Molding was replaced by Nocturnal Regeneration, which only works in darkness.
balance: All healing symptoms now heal both brute and burn damage, although the basic ones will still be more effective on one damage type.
balance: Plasma Fixation and Radioactive Metabolism heal toxin damage, offsetting the damage done by their healing sources.
balance: Changed healing symptoms' stats, generally making them less punishing.
/:cl:

My reasoning for this:
* Virology is very weak right now, so a buff is generally justified.
* Being able to choose the source of healing rather than being locked to "one damage-type = one method" allows customization of the virus, instead of requiring the same every time if you want to heal brute and burn. You can stack multiple sources, or try to max stats for one of your choice.
* This is also better for the receivers of the virus as they dont have to find a separate source for every type of damage they come across.
* Curing toxin damage for plasma and radiation based symptoms makes them not deadly to use; plasma is still balanced around scarcity (or having to be in a very flammable cloud of plasma) and radiation maintains its side effects.
