### PR TITLE
Adds homerun baseball bat as assistant only traitor item

### DIFF
--- a/code/modules/uplink/uplink_item.dm
+++ b/code/modules/uplink/uplink_item.dm
@@ -1293,6 +1293,14 @@ GLOBAL_LIST_EMPTY(uplink_items) // Global list so we only initialize this once.
 	cost = 20
 	restricted_roles = list("Assistant")
 	surplus = 0
+	
+/datum/uplink_item/role_restricted/homerunbat
+	name = "Homerun Baseball Bat"
+	item = /obj/item/melee/baseball_bat/homerun
+	desc = "A hefty wooden baseball bat, modified in the interior with Syndicate weight-shifting technology. Activate in-hand to gather strength; once charged, attacking with the bat will deal lethal damage as weight as shifted to the front of the blow mid-swing, causing the arc to accelerate to near-supersonic speeds."
+	cost = 20
+	restricted_roles = list("Assistant")
+	surplus = 0
 
 /datum/uplink_item/role_restricted/haunted_magic_eightball
 	name = "Haunted Magic Eightball"


### PR DESCRIPTION
its a bat you can charge up and then hit a guy for a instacrit
otherwise its just a normal old bat

:cl: Improvedname
add: Adds homerun baseball bat to assistant traitor uplinks
/:cl:

[why]: # (Please add a short description [two lines down] of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.) AND THE GREYTIDER GOES FOR THE RUN HE RUNS INTO BRIG SMACKS THE OFFICER AND ITS A HOMERUUUUN
