### PR TITLE
Material containers only insert on help intent

### DIFF
--- a/code/datums/components/material_container.dm
+++ b/code/datums/components/material_container.dm
@@ -51,7 +51,7 @@
 
 /datum/component/material_container/proc/OnAttackBy(obj/item/I, mob/living/user)
 	var/list/tc = allowed_typecache
-	if(user.a_intent == INTENT_HARM)
+	if(user.a_intent != INTENT_HELP)
 		return
 	if((I.flags_2 & (HOLOGRAM_2 | NO_MAT_REDEMPTION_2)) || (tc && !is_type_in_typecache(I, tc)))
 		to_chat(user, "<span class='warning'>[parent] won't accept [I]!</span>")


### PR DESCRIPTION
I'm going to close #33794 with this because adding a prompt for everything you insert into a mat container is dumb

:cl:
tweak: Objects that can have materials inserted into them only will do so on help intent
/:cl: