### PR TITLE
Internal radio implant

### DIFF
--- a/code/game/objects/items/implants/implant_misc.dm
+++ b/code/game/objects/items/implants/implant_misc.dm
@@ -84,9 +84,12 @@
 	activated = TRUE
 	var/obj/item/device/radio/radio
 	var/radio_key = /obj/item/device/encryptionkey/syndicate
+	icon = 'icons/obj/radio.dmi'
+	icon_state = "walkietalkie"
 
 /obj/item/implant/radio/activate()
-	. = radio.interact(usr)
+	// needs to be GLOB.deep_inventory_state otherwise it won't open
+	radio.ui_interact(usr, "main", null, FALSE, null, GLOB.deep_inventory_state)
 
 /obj/item/implant/radio/Initialize(mapload)
 	. = ..()

--- a/code/game/objects/items/implants/implant_misc.dm
+++ b/code/game/objects/items/implants/implant_misc.dm
@@ -77,3 +77,37 @@
 		if (!healthstring)
 			healthstring = "ERROR"
 		return healthstring
+
+/obj/item/implant/radio
+	name = "internal radio implant"
+	desc = "Are you there God? It's me, Syndicate Comms Agent."
+	activated = TRUE
+	var/obj/item/device/radio/radio
+	var/radio_key = /obj/item/device/encryptionkey/syndicate
+
+/obj/item/implant/radio/activate()
+	. = radio.interact(usr)
+
+/obj/item/implant/radio/Initialize(mapload)
+	. = ..()
+
+	radio = new(src)
+	// almost like an internal headset, but without the
+	// "must be in ears to hear" restriction.
+	radio.name = "internal radio"
+	radio.subspace_transmission = TRUE
+	radio.canhear_range = 0
+	radio.keyslot = new radio_key
+	radio.recalculateChannels()
+
+
+/obj/item/implant/radio/get_data()
+	var/dat = {"<b>Implant Specifications:</b><BR>
+				<b>Name:</b> Internal Radio Implant<BR>
+				<b>Life:</b> 24 hours<BR>
+				<b>Implant Details:</b> Allows user to use an internal radio, useful if user expects equipment loss, or cannot equip conventional radios."}
+	return dat
+
+/obj/item/implanter/radio
+	name = "implanter (internal radio)"
+	imp_type = /obj/item/implant/radio

--- a/code/game/objects/items/storage/uplink_kits.dm
+++ b/code/game/objects/items/storage/uplink_kits.dm
@@ -305,3 +305,6 @@
 /obj/item/storage/box/syndie_kit/mimery/PopulateContents()
 	new /obj/item/spellbook/oneuse/mimery_blockade(src)
 	new /obj/item/spellbook/oneuse/mimery_guns(src)
+
+/obj/item/storage/box/syndie_kit/imp_radio/PopulateContents()
+	new /obj/item/implanter/radio(src)

--- a/code/modules/mob/living/say.dm
+++ b/code/modules/mob/living/say.dm
@@ -341,6 +341,15 @@ GLOBAL_LIST_INIT(department_radio_keys, list(
 	return message
 
 /mob/living/proc/radio(message, message_mode, list/spans, language)
+	var/obj/item/implant/radio/imp = locate() in src
+	if(imp && imp.radio.on)
+		if(message_mode == MODE_HEADSET)
+			imp.radio.talk_into(src, message, , spans, language)
+			return ITALICS | REDUCE_RANGE
+		if(message_mode == MODE_DEPARTMENT || message_mode in GLOB.radiochannels)
+			imp.radio.talk_into(src, message, message_mode, spans, language)
+			return ITALICS | REDUCE_RANGE
+
 	switch(message_mode)
 		if(MODE_WHISPER)
 			return ITALICS
@@ -362,6 +371,7 @@ GLOBAL_LIST_INIT(department_radio_keys, list(
 
 		if(MODE_BINARY)
 			return ITALICS | REDUCE_RANGE //Does not return 0 since this is only reached by humans, not borgs or AIs.
+
 	return 0
 
 /mob/living/say_mod(input, message_mode)

--- a/code/modules/research/xenobiology/xenobiology.dm
+++ b/code/modules/research/xenobiology/xenobiology.dm
@@ -199,11 +199,23 @@
 		to_chat(SM, "<span class='userdanger'>You are grateful to be self aware and owe [user.real_name] a great debt. Serve [user.real_name], and assist [user.p_them()] in completing [user.p_their()] goals at any cost.</span>")
 		to_chat(user, "<span class='notice'>[SM] accepts [src] and suddenly becomes attentive and aware. It worked!</span>")
 		SM.copy_known_languages_from(user, TRUE)
+		after_success(user, SM)
 		qdel(src)
 	else
 		to_chat(user, "<span class='notice'>[SM] looks interested for a moment, but then looks back down. Maybe you should try again later.</span>")
 		being_used = 0
 		..()
+
+/obj/item/slimepotion/sentience/proc/after_success(mob/living/user, mob/living/simple_animal/SM)
+	return
+
+/obj/item/slimepotion/sentience/nuclear
+	name = "syndicate intelligence potion"
+	desc = "A miraculous chemical mix that grants human like intelligence to living beings. It has been modified with Syndicate technology to also grant an internal radio implant to the target."
+
+/obj/item/slimepotion/sentience/nuclear/after_success(mob/living/user, mob/living/simple_animal/SM)
+	var/obj/item/implant/radio/imp = new(src)
+	imp.implant(SM, user)
 
 /obj/item/slimepotion/transference
 	name = "consciousness transference potion"

--- a/code/modules/uplink/uplink_items.dm
+++ b/code/modules/uplink/uplink_items.dm
@@ -1057,9 +1057,9 @@ GLOBAL_LIST_EMPTY(uplink_items) // Global list so we only initialize this once.
 	include_modes = list(/datum/game_mode/nuclear)
 
 /datum/uplink_item/device_tools/potion
-	name = "Sentience Potion"
-	item = /obj/item/slimepotion/sentience
-	desc = "A potion recovered at great risk by undercover syndicate operatives. Using it will make any animal sentient, and bound to serve you."
+	name = "Syndicate Sentience Potion"
+	item = /obj/item/slimepotion/sentience/nuclear
+	desc = "A potion recovered at great risk by undercover syndicate operatives and then subsequently modified with syndicate technology. Using it will make any animal sentient, and bound to serve you, as well as implanting an internal radio for communication."
 	cost = 4
 	include_modes = list(/datum/game_mode/nuclear)
 
@@ -1149,6 +1149,12 @@ GLOBAL_LIST_EMPTY(uplink_items) // Global list so we only initialize this once.
 	item = /obj/item/storage/box/syndie_kit/imp_macrobomb
 	cost = 20
 	include_modes = list(/datum/game_mode/nuclear)
+
+/datum/uplink_item/implants/radio
+	name = "Internal Syndicate Radio Implant"
+	desc = "An implant injected into the body, allowing the use of an internal syndicate radio. Used just like a regular headset, but can be disabled to use external headsets normally and to avoid detection."
+	item = /obj/item/storage/box/syndie_kit/imp_radio
+	cost = 4
 
 
 // Cybernetics


### PR DESCRIPTION
:cl: coiax
add: Adds an internal radio implant, allowing the use of the radio if
you expect to have your headset removed. Or if you don't have any ears
or hands. It can be purchased for 4 TC from any Syndicate uplink.
add: Nuke ops now buy special "syndicate intelligence potions" that automatically
insert an internal radio implant when used successfully. Cayenne can now
participate in your high level discussions.
/:cl:

Modifies saycode at the /mob/living/proc/radio level to check for a
radio implant, and talk into it if the implant is present and the radio
is on. This takes priority over an ear headset for humans, so you'll
have to turn off the internal radio to use a headset.

Why? Well, the main usecase I have in mind is giving it to Cayenne, so
the loyal nuke op fish can participate in all those delightful planning
conversations. But I'll also make it purchasable by regular traitors,
which means that their secret syndicate communications will only be
revealed by intrusive surgery.