### PR TITLE
Fixes emagged cleanbot acid attack doing no damage

### DIFF
--- a/code/modules/mob/living/carbon/monkey/monkey_defense.dm
+++ b/code/modules/mob/living/carbon/monkey/monkey_defense.dm
@@ -149,13 +149,13 @@
 	if(!bodyzone_hit || bodyzone_hit == "head")
 		if(wear_mask)
 			if(!(wear_mask.resistance_flags & UNACIDABLE))
-				wear_mask.acid_act(acidpwr)
+				wear_mask.acid_act(acidpwr, acid_volume)
 			else
 				to_chat(src, "<span class='warning'>Your mask protects you from the acid.</span>")
 			return
 		if(head)
 			if(!(head.resistance_flags & UNACIDABLE))
-				head.acid_act(acidpwr)
+				head.acid_act(acidpwr, acid_volume)
 			else
 				to_chat(src, "<span class='warning'>Your hat protects you from the acid.</span>")
 			return

--- a/code/modules/mob/living/simple_animal/bot/cleanbot.dm
+++ b/code/modules/mob/living/simple_animal/bot/cleanbot.dm
@@ -125,7 +125,7 @@
 
 	if(!target) //Search for decals then.
 		target = scan(/obj/effect/decal/cleanable)
-	
+
 	if(!target) //Checks for remains
 		target = scan(/obj/effect/decal/remains)
 
@@ -242,7 +242,7 @@
 			say(phrase)
 			victim.emote("scream")
 			playsound(src.loc, 'sound/effects/spray2.ogg', 50, 1, -6)
-			victim.acid_act(5, 2, 100)
+			victim.acid_act(5, 100)
 		else if(A == src) // Wets floors and spawns foam randomly
 			if(prob(75))
 				var/turf/open/T = loc


### PR DESCRIPTION
:cl:
fix: Emagged cleanbots can acid people again
fix: Headgear worn by monkeys can be affected by acid
/:cl:
Fixes #23943

This call of acid_act was still using the toxpwr param removed in #20793 which caused 100 to be assigned to the bodyzone_hit param and no body parts being targeted.