### PR TITLE
If the world is launched with the "no-init" param. Master.Initialize isn't called

### DIFF
--- a/code/game/world.dm
+++ b/code/game/world.dm
@@ -36,6 +36,9 @@ GLOBAL_PROTECT(security_mode)
 	if(fexists(RESTART_COUNTER_PATH))
 		GLOB.restart_counter = text2num(trim(file2text(RESTART_COUNTER_PATH)))
 		fdel(RESTART_COUNTER_PATH)
+	
+	if("no-init" in params)
+		return
 
 	Master.Initialize(10, FALSE)
 


### PR DESCRIPTION
Useful for debugging