### PR TITLE
Fixes AI eyes getting nullspaced when jumping to deleted cameras

### DIFF
--- a/code/_onclick/hud/ai.dm
+++ b/code/_onclick/hud/ai.dm
@@ -23,8 +23,7 @@
 	if(..())
 		return
 	var/mob/living/silicon/ai/AI = usr
-	var/camera = input(AI, "Choose which camera you want to view", "Cameras") as null|anything in AI.get_camera_list()
-	AI.ai_camera_list(camera)
+	AI.show_camera_list()
 
 /obj/screen/ai/camera_track
 	name = "Track With Camera"

--- a/code/game/machinery/camera/camera.dm
+++ b/code/game/machinery/camera/camera.dm
@@ -57,19 +57,17 @@
 		toggle_cam()
 
 /obj/machinery/camera/Destroy()
-	toggle_cam(null, 0) //kick anyone viewing out
+	if(can_use())
+		toggle_cam(null, 0) //kick anyone viewing out and remove from the camera chunks
+	GLOB.cameranet.cameras -= src
 	if(isarea(myarea))
 		LAZYREMOVE(myarea.cameras, src)
-	if(assembly)
-		qdel(assembly)
-		assembly = null
+	QDEL_NULL(assembly)
 	if(bug)
 		bug.bugged_cameras -= src.c_tag
 		if(bug.current == src)
 			bug.current = null
 		bug = null
-	GLOB.cameranet.removeCamera(src) //Will handle removal from the camera network and the chunks, so we don't need to worry about that
-	GLOB.cameranet.cameras -= src
 	return ..()
 
 /obj/machinery/camera/emp_act(severity)

--- a/code/game/machinery/camera/tracking.dm
+++ b/code/game/machinery/camera/tracking.dm
@@ -130,9 +130,9 @@
 /obj/machinery/camera/attack_ai(mob/living/silicon/ai/user)
 	if (!istype(user))
 		return
-	if (!src.can_use())
+	if (!can_use())
 		return
-	user.eyeobj.setLoc(get_turf(src))
+	ai.switchCamera(src)
 
 /proc/camera_sort(list/L)
 	var/obj/machinery/camera/a

--- a/code/game/machinery/camera/tracking.dm
+++ b/code/game/machinery/camera/tracking.dm
@@ -132,7 +132,7 @@
 		return
 	if (!can_use())
 		return
-	ai.switchCamera(src)
+	user.switchCamera(src)
 
 /proc/camera_sort(list/L)
 	var/obj/machinery/camera/a

--- a/code/game/machinery/camera/tracking.dm
+++ b/code/game/machinery/camera/tracking.dm
@@ -1,10 +1,4 @@
 /mob/living/silicon/ai/proc/get_camera_list()
-
-	track.cameras.Cut()
-
-	if(src.stat == DEAD)
-		return
-
 	var/list/L = list()
 	for (var/obj/machinery/camera/C in GLOB.cameranet.cameras)
 		L.Add(C)
@@ -18,25 +12,18 @@
 		if (tempnetwork.len)
 			T[text("[][]", C.c_tag, (C.can_use() ? null : " (Deactivated)"))] = C
 
-	track.cameras = T
 	return T
 
-
-/mob/living/silicon/ai/proc/ai_camera_list(camera)
-	if (!camera)
-		return 0
-
-	var/obj/machinery/camera/C = track.cameras[camera]
-	src.eyeobj.setLoc(C)
-
-	return
+/mob/living/silicon/ai/proc/show_camera_list()
+	var/list/cameras = get_camera_list()
+	var/camera = input(src, "Choose which camera you want to view", "Cameras") as null|anything in cameras
+	switchCamera(cameras[camera])
 
 /datum/trackable
 	var/list/names = list()
 	var/list/namecounts = list()
 	var/list/humans = list()
 	var/list/others = list()
-	var/list/cameras = list()
 
 /mob/living/silicon/ai/proc/trackable_mobs()
 
@@ -146,10 +133,6 @@
 	if (!src.can_use())
 		return
 	user.eyeobj.setLoc(get_turf(src))
-
-
-/mob/living/silicon/ai/attack_ai(mob/user)
-	ai_camera_list()
 
 /proc/camera_sort(list/L)
 	var/obj/machinery/camera/a

--- a/code/modules/mob/living/silicon/ai/ai.dm
+++ b/code/modules/mob/living/silicon/ai/ai.dm
@@ -430,19 +430,17 @@
 
 
 /mob/living/silicon/ai/proc/switchCamera(obj/machinery/camera/C)
-	if(!tracking)
-		cameraFollow = null
-
 	if(QDELETED(C))
 		return FALSE
 
-	if(!src.eyeobj)
+	if(!tracking)
+		cameraFollow = null
+
+	if(QDELETED(eyeobj))
 		view_core()
 		return
 	// ok, we're alive, camera is good and in our network...
 	eyeobj.setLoc(get_turf(C))
-	//machine = src
-
 	return TRUE
 
 /mob/living/silicon/ai/proc/botcall()

--- a/code/modules/mob/living/silicon/ai/ai.dm
+++ b/code/modules/mob/living/silicon/ai/ai.dm
@@ -430,11 +430,10 @@
 
 
 /mob/living/silicon/ai/proc/switchCamera(obj/machinery/camera/C)
-
 	if(!tracking)
 		cameraFollow = null
 
-	if (!C)
+	if(QDELETED(C))
 		return FALSE
 
 	if(!src.eyeobj)

--- a/code/modules/mob/living/silicon/ai/freelook/cameranet.dm
+++ b/code/modules/mob/living/silicon/ai/freelook/cameranet.dm
@@ -80,8 +80,7 @@ GLOBAL_DATUM_INIT(cameranet, /datum/cameranet, new)
 // Removes a camera from a chunk.
 
 /datum/cameranet/proc/removeCamera(obj/machinery/camera/c)
-	if(c.can_use())
-		majorChunkChange(c, 0)
+	majorChunkChange(c, 0)
 
 // Add a camera to a chunk.
 


### PR DESCRIPTION
Fixes #16314
Fixes #20238
Fixes #32752
Fixes an issue where you would continue tracking a mob after manually switching cameras

Cameras tend to get hard deleted so we need to use the QDELETED macro instead of just checking if it's null. I fixed a few instances of references to cameras not being cleared properly as well (though they still seem to sometimes hard delete).