### PR TITLE
Hallucinations no longer show open doors "bolting"

### DIFF
--- a/code/modules/flufftext/Hallucination.dm
+++ b/code/modules/flufftext/Hallucination.dm
@@ -706,7 +706,9 @@ GLOBAL_LIST_INIT(hallucinations_major, list(
 	for(var/obj/machinery/door/airlock/A in range(7, target))
 		if(count>door_number && door_number>0)
 			break
-		if(A.density)
+		if(!A.density)
+			continue
+		else
 			count++
 			I = image(A.overlays_file, get_turf(A), "lights_bolts",layer=A.layer+0.1)
 			doors += I

--- a/code/modules/flufftext/Hallucination.dm
+++ b/code/modules/flufftext/Hallucination.dm
@@ -708,14 +708,13 @@ GLOBAL_LIST_INIT(hallucinations_major, list(
 			break
 		if(!A.density)
 			continue
-		else
-			count++
-			I = image(A.overlays_file, get_turf(A), "lights_bolts",layer=A.layer+0.1)
-			doors += I
-			if(target.client)
-				target.client.images |= I
-				target.playsound_local(get_turf(A), 'sound/machines/boltsdown.ogg',30,0,3)
-			sleep(rand(6,12))
+		count++
+		I = image(A.overlays_file, get_turf(A), "lights_bolts",layer=A.layer+0.1)
+		doors += I
+		if(target.client)
+			target.client.images |= I
+			target.playsound_local(get_turf(A), 'sound/machines/boltsdown.ogg',30,0,3)
+		sleep(rand(6,12))
 	sleep(100)
 	for(var/image/B in doors)
 		if(target.client)

--- a/code/modules/flufftext/Hallucination.dm
+++ b/code/modules/flufftext/Hallucination.dm
@@ -706,13 +706,14 @@ GLOBAL_LIST_INIT(hallucinations_major, list(
 	for(var/obj/machinery/door/airlock/A in range(7, target))
 		if(count>door_number && door_number>0)
 			break
-		count++
-		I = image(A.overlays_file, get_turf(A), "lights_bolts",layer=A.layer+0.1)
-		doors += I
-		if(target.client)
-			target.client.images |= I
-			target.playsound_local(get_turf(A), 'sound/machines/boltsdown.ogg',30,0,3)
-		sleep(rand(6,12))
+		if(A.density)
+			count++
+			I = image(A.overlays_file, get_turf(A), "lights_bolts",layer=A.layer+0.1)
+			doors += I
+			if(target.client)
+				target.client.images |= I
+				target.playsound_local(get_turf(A), 'sound/machines/boltsdown.ogg',30,0,3)
+			sleep(rand(6,12))
 	sleep(100)
 	for(var/image/B in doors)
 		if(target.client)


### PR DESCRIPTION
:cl: Robustin
fix: Hallucinations will no longer show open doors "bolting".
/:cl:

Hallucinations have become a lot more meaningful this year, but that effect depends on the new hallucinations being convincing. Often the first "tell" for me is seeing a bunch of open doors around me flash red bolt lights - this fixes that.