### PR TITLE
Christmas event changes

### DIFF
--- a/code/game/objects/structures/flora.dm
+++ b/code/game/objects/structures/flora.dm
@@ -10,66 +10,72 @@
 	density = TRUE
 	pixel_x = -16
 	layer = FLY_LAYER
-	var/cut = FALSE
 	var/log_amount = 10
 
 /obj/structure/flora/tree/attackby(obj/item/W, mob/user, params)
-	if(!cut && log_amount && (!(flags_1 & NODECONSTRUCT_1)))
+	if(log_amount && (!(flags_1 & NODECONSTRUCT_1)))
 		if(W.sharpness && W.force > 0)
 			if(W.hitsound)
 				playsound(get_turf(src), W.hitsound, 100, 0, 0)
 			user.visible_message("<span class='notice'>[user] begins to cut down [src] with [W].</span>","<span class='notice'>You begin to cut down [src] with [W].</span>", "You hear the sound of sawing.")
-			if(do_after(user, 1000/W.force, target = user)) //5 seconds with 20 force, 8 seconds with a hatchet, 20 seconds with a shard.
-				if(cut)
-					return
+			if(do_after(user, 1000/W.force, target = src)) //5 seconds with 20 force, 8 seconds with a hatchet, 20 seconds with a shard.
 				user.visible_message("<span class='notice'>[user] fells [src] with the [W].</span>","<span class='notice'>You fell [src] with the [W].</span>", "You hear the sound of a tree falling.")
 				playsound(get_turf(src), 'sound/effects/meteorimpact.ogg', 100 , 0, 0)
-				icon = 'icons/obj/flora/pinetrees.dmi'
-				icon_state = "tree_stump"
-				density = FALSE
-				pixel_x = -16
-				name += " stump"
-				cut = TRUE
 				for(var/i=1 to log_amount)
 					new /obj/item/grown/log/tree(get_turf(src))
 
+				var/obj/structure/flora/stump/S = new(loc)
+				S.name = "[name] stump"
+
+				qdel(src)
+
 	else
 		return ..()
+
+/obj/structure/flora/stump
+	name = "stump"
+	desc = "This represents our promise to the crew, and the station itself, to cut down as many trees as possible." //running naked through the trees
+	icon = 'icons/obj/flora/pinetrees.dmi'
+	icon_state = "tree_stump"
+	density = FALSE
+	pixel_x = -16
 
 /obj/structure/flora/tree/pine
 	name = "pine tree"
 	desc = "A coniferous pine tree."
 	icon = 'icons/obj/flora/pinetrees.dmi'
 	icon_state = "pine_1"
+	var/list/icon_states = list("pine_1", "pine_2", "pine_3")
 
 /obj/structure/flora/tree/pine/Initialize()
-	icon_state = "pine_[rand(1, 3)]"
 	. = ..()
+
+	if(islist(icon_states && icon_states.len))
+		icon_state = pick(icon_states)
 
 /obj/structure/flora/tree/pine/xmas
 	name = "xmas tree"
 	desc = "A wondrous decorated Christmas tree."
 	icon_state = "pine_c"
-	var/gifts_under_tree = FALSE
+	icon_states = null
+
+/obj/structure/flora/tree/pine/xmas/presents
+	icon_state = "pinepresents"
+	desc = "A wondrous decorated Christmas tree. It has presents!"
+	var/gift_type = /obj/item/a_gift/anything
 	var/list/ckeys_that_took = list()
 
-/obj/structure/flora/tree/pine/xmas/attack_hand(mob/living/user)
-	if(!gifts_under_tree)
-		return
+/obj/structure/flora/tree/pine/xmas/presents/attack_hand(mob/living/user)
 	if(!user.ckey)
 		return
+
 	if(ckeys_that_took[user.ckey])
-		to_chat(user, "<span class='warning'>You already took your gift.</span>")
+		to_chat(user, "<span class='warning'>There are no presents with your name on.</span>")
 		return
 	to_chat(user, "<span class='warning'>After a bit of rummaging, you locate a gift with your name on it!</span>")
 	ckeys_that_took[user.ckey] = TRUE
-	var/obj/item/a_gift/anything/A = new
-	user.put_in_hands(A)
-
-/obj/structure/flora/tree/pine/xmas/presents
-	gifts_under_tree = TRUE
-	icon_state = "pinepresents"
-	desc = "A wondrous decorated Christmas tree. It has presents!"
+	var/obj/item/G = new gift_type(src)
+	user.put_in_hands(G)
 
 /obj/structure/flora/tree/dead
 	icon = 'icons/obj/flora/deadtrees.dmi'

--- a/code/game/objects/structures/flora.dm
+++ b/code/game/objects/structures/flora.dm
@@ -66,9 +66,10 @@
 	var/obj/item/a_gift/anything/A = new
 	user.put_in_hands(A)
 
-/obj/structure/flora/tree/pine/xmas/Initialize()
-	. = ..()
-	icon_state = "pine_c"
+/obj/structure/flora/tree/pine/xmas/presents
+	gifts_under_tree = TRUE
+	icon_state = "pinepresents"
+	desc = "A wondrous decorated Christmas tree. It has presents!"
 
 /obj/structure/flora/tree/dead
 	icon = 'icons/obj/flora/deadtrees.dmi'

--- a/code/modules/events/holiday/xmas.dm
+++ b/code/modules/events/holiday/xmas.dm
@@ -12,7 +12,7 @@
 		if(!(xmas.z in GLOB.station_z_levels))
 			continue
 
-		new /obj/structure/flora/tree/pine/xmas/presents(get_turf(xmas))
+		new /obj/structure/flora/tree/pine/xmas/presents(xmas.loc)
 		qdel(xmas)
 
 	for(var/mob/living/simple_animal/pet/dog/corgi/Ian/Ian in GLOB.mob_living_list)

--- a/code/modules/events/holiday/xmas.dm
+++ b/code/modules/events/holiday/xmas.dm
@@ -11,8 +11,10 @@
 	for(var/obj/structure/flora/tree/pine/xmas/xmas in world)
 		if(!(xmas.z in GLOB.station_z_levels))
 			continue
-		xmas.icon_state = "pinepresents"
-		xmas.gifts_under_tree = TRUE
+
+		new /obj/structure/flora/tree/pine/xmas/presents(get_turf(xmas))
+		qdel(xmas)
+
 	for(var/mob/living/simple_animal/pet/dog/corgi/Ian/Ian in GLOB.mob_living_list)
 		Ian.place_on_head(new /obj/item/clothing/head/helmet/space/santahat(Ian))
 	for(var/obj/machinery/computer/security/telescreen/entertainment/Monitor in GLOB.machines)

--- a/code/modules/events/holiday/xmas.dm
+++ b/code/modules/events/holiday/xmas.dm
@@ -1,29 +1,3 @@
-//this is an example of a possible round-start event
-/datum/round_event_control/presents
-	name = "Presents under Trees (Christmas)"
-	holidayID = CHRISTMAS
-	typepath = /datum/round_event/presents
-	weight = -1							//forces it to be called, regardless of weight
-	max_occurrences = 1
-	earliest_start = 0
-
-/datum/round_event/presents/start()
-	for(var/obj/structure/flora/tree/pine/xmas/xmas in world)
-		if(!(xmas.z in GLOB.station_z_levels))
-			continue
-
-		new /obj/structure/flora/tree/pine/xmas/presents(xmas.loc)
-		qdel(xmas)
-
-	for(var/mob/living/simple_animal/pet/dog/corgi/Ian/Ian in GLOB.mob_living_list)
-		Ian.place_on_head(new /obj/item/clothing/head/helmet/space/santahat(Ian))
-	for(var/obj/machinery/computer/security/telescreen/entertainment/Monitor in GLOB.machines)
-		Monitor.icon_state = "entertainment_xmas"
-
-/datum/round_event/presents/announce(fake)
-	priority_announce("Ho Ho Ho, Merry Xmas!", "Unknown Transmission")
-
-
 /obj/item/toy/xmas_cracker
 	name = "xmas cracker"
 	icon = 'icons/obj/christmas.dmi'
@@ -67,17 +41,21 @@
 
 /obj/effect/landmark/xmastree
 	name = "christmas tree spawner"
-	var/tree = /obj/structure/flora/tree/pine/xmas
+	var/festive_tree = /obj/structure/flora/tree/pine/xmas
+	var/christmas_tree = /obj/structure/flora/tree/pine/xmas/presents
 
 /obj/effect/landmark/xmastree/Initialize(mapload)
 	..()
-	if(FESTIVE_SEASON in SSevents.holidays)
-		new tree(get_turf(src))
+	if((CHRISTMAS in SSevents.holidays) && christmas_tree)
+		new christmas_tree(get_turf(src))
+	else if((FESTIVE_SEASON in SSevents.holidays) && festive_tree)
+		new festive_tree(get_turf(src))
 	return INITIALIZE_HINT_QDEL
 
 /obj/effect/landmark/xmastree/rdrod
 	name = "festivus pole spawner"
-	tree = /obj/structure/festivus
+	festive_tree = /obj/structure/festivus
+	christmas_tree = null
 
 /datum/round_event_control/santa
 	name = "Santa is coming to town! (Christmas)"
@@ -94,7 +72,7 @@
 	priority_announce("Santa is coming to town!", "Unknown Transmission")
 
 /datum/round_event/santa/start()
-	var/list/candidates = pollGhostCandidates("Santa is coming to town! Do you want to be santa?", poll_time=150)
+	var/list/candidates = pollGhostCandidates("Santa is coming to town! Do you want to be Santa?", poll_time=150)
 	if(LAZYLEN(candidates))
 		var/mob/dead/observer/Z = pick(candidates)
 		santa = new /mob/living/carbon/human(pick(GLOB.blobstart))

--- a/code/modules/holiday/holidays.dm
+++ b/code/modules/holiday/holidays.dm
@@ -403,6 +403,17 @@ Since Ramadan is an entire month that lasts 29.5 days on average, the start and 
 /datum/holiday/xmas/greet()
 	return "Have a merry Christmas!"
 
+/datum/holiday/xmas/celebrate()
+	SSticker.OnRoundstart(CALLBACK(src, .proc/roundstart_celebrate))
+
+/datum/holiday/xmas/proc/roundstart_celebrate()
+	for(var/obj/machinery/computer/security/telescreen/entertainment/Monitor in GLOB.machines)
+		Monitor.icon_state = "entertainment_xmas"
+
+	for(var/mob/living/simple_animal/pet/dog/corgi/Ian/Ian in GLOB.mob_living_list)
+		Ian.place_on_head(new /obj/item/clothing/head/helmet/space/santahat(Ian))
+
+
 /datum/holiday/festive_season
 	name = FESTIVE_SEASON
 	begin_day = 1


### PR DESCRIPTION
- Admins can now spawn `/obj/structure/flora/tree/pine/xmas/presents`
directly, instead of spawning regular christmas trees and then
triggering the event.

- The Presents Under Trees event has been removed entirely, present trees are spawned directly by the landmark spawners, and Ian hat and christmas entertainment monitor are done by celebrate()

- Stumps are now seperate items, and not just a reskinning of the tree