### PR TITLE
Only one chemist is allowed on OmegaStation

### DIFF
--- a/_maps/map_files/OmegaStation/job_changes.dm
+++ b/_maps/map_files/OmegaStation/job_changes.dm
@@ -67,6 +67,12 @@
 	spawn_positions = 3
 	access = list(ACCESS_MEDICAL, ACCESS_MORGUE, ACCESS_SURGERY, ACCESS_CHEMISTRY, ACCESS_VIROLOGY, ACCESS_GENETICS)
 	minimal_access = list(ACCESS_MEDICAL, ACCESS_MORGUE, ACCESS_SURGERY, ACCESS_CHEMISTRY, ACCESS_VIROLOGY, ACCESS_GENETICS)
+	
+/datum/job/chemist/New()
+	..()
+	MAP_JOB_CHECK
+	total_positions = 1
+	spawn_positions = 1
 
 //Engineering
 


### PR DESCRIPTION
:cl: Frozenguy5
tweak: There is now only one chemist on OmegaStation.
/:cl:


a) either we have one chemist
a.1) and remove doctor's access to chemistry
b) we remove chemists and merge them with medical doctors
c) add another chemistry station
