### PR TITLE
Fixes EMP runtime

### DIFF
--- a/code/modules/reagents/chemistry/machinery/chem_dispenser.dm
+++ b/code/modules/reagents/chemistry/machinery/chem_dispenser.dm
@@ -217,7 +217,7 @@
 	if(beaker && beaker.reagents)
 		beaker.reagents.remove_all()
 	cell.use(total/powerefficiency)
-	cell.emp_act()
+	cell.emp_act(severity)
 	visible_message("<span class='danger'>[src] malfunctions, spraying chemicals everywhere!</span>")
 	..()
 


### PR DESCRIPTION
EMP's would runtime every time they affected any chem_dispenser because they would called emp_act() without any arguments on the power cell which would then try to divide by null. 