### PR TITLE
DeltaStation now has xmastree spawn landmarks

### DIFF
--- a/_maps/map_files/Deltastation/DeltaStation2.dmm
+++ b/_maps/map_files/Deltastation/DeltaStation2.dmm
@@ -19939,6 +19939,7 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/effect/landmark/xmastree,
 /turf/open/floor/carpet,
 /area/crew_quarters/bar/atrium)
 "aQo" = (
@@ -99442,10 +99443,10 @@
 /obj/structure/cable/white{
 	icon_state = "1-2"
 	},
-/obj/effect/landmark/lightsout,
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
 	dir = 4
 	},
+/obj/effect/landmark/xmastree,
 /turf/open/floor/plasteel/grimy,
 /area/chapel/main)
 "dVT" = (
@@ -105093,6 +105094,14 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/library)
+"ehQ" = (
+/obj/structure/cable/white{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/effect/landmark/lightsout,
+/turf/open/floor/plasteel/grimy,
+/area/chapel/main)
 
 (1,1,1) = {"
 aaa
@@ -139988,7 +139997,7 @@ dKD
 dUp
 dVd
 dVS
-dVd
+ehQ
 dVd
 dVd
 dVd


### PR DESCRIPTION
:cl: coiax
add: Deltastation now has christmas trees during seasonally appropriate
times.
/:cl:

- I moved a lightsout landmark one down so we didn't have two landmarks on one space.

@Okand37 approved.
Chapel:
![image](https://user-images.githubusercontent.com/609465/34368273-700948c4-eaaa-11e7-974c-09cbf6ff86a8.png)

Bar:
![image](https://user-images.githubusercontent.com/609465/34368277-7ce8e022-eaaa-11e7-9a0a-d78e7a2ee81b.png)
