### PR TITLE
CTF flags are no longer locked to CTF.

### DIFF
--- a/code/modules/awaymissions/capture_the_flag.dm
+++ b/code/modules/awaymissions/capture_the_flag.dm
@@ -48,9 +48,6 @@
 		STOP_PROCESSING(SSobj, src)
 
 /obj/item/twohanded/ctf/attack_hand(mob/living/user)
-	if(!is_ctf_target(user))
-		to_chat(user, "Non players shouldn't be moving the flag!")
-		return
 	if(team in user.faction)
 		to_chat(user, "You can't move your own flag!")
 		return

--- a/code/modules/awaymissions/capture_the_flag.dm
+++ b/code/modules/awaymissions/capture_the_flag.dm
@@ -26,6 +26,7 @@
 	flags_2 = SLOWS_WHILE_IN_HAND_2
 	var/team = WHITE_TEAM
 	var/reset_cooldown = 0
+	var/anyonecanpickup = TRUE
 	var/obj/effect/ctf/flag_reset/reset
 	var/reset_path = /obj/effect/ctf/flag_reset
 
@@ -48,6 +49,9 @@
 		STOP_PROCESSING(SSobj, src)
 
 /obj/item/twohanded/ctf/attack_hand(mob/living/user)
+	if(!is_ctf_target(user) && !anyonecanpickup)
+		to_chat(user, "Non players shouldn't be moving the flag!")
+		return
 	if(team in user.faction)
 		to_chat(user, "You can't move your own flag!")
 		return


### PR DESCRIPTION
This lock is more prohibitive than useful - normally only CTF players can get the flag regardless, as it's on the centcom z level behind indestructable walls. Beyond that, it prevents any sort of admin or christmas tree hijinks.