### PR TITLE
Fixes ghost light not moving while orbiting

### DIFF
--- a/code/modules/orbit/orbit.dm
+++ b/code/modules/orbit/orbit.dm
@@ -55,6 +55,7 @@
 		return
 	orbiter.loc = targetloc
 	orbiter.update_parallax_contents()
+	orbiter.update_light()
 	lastloc = orbiter.loc
 	for(var/other_orbit in orbiter.orbiters)
 		var/datum/orbit/OO = other_orbit


### PR DESCRIPTION
Fixes #33877 

:cl:
fix: Ghost lights will follow the ghost while orbiting
/:cl:

I hate /dead forceMove memes