### PR TITLE
Makes reset_perspective handle turf as eye

### DIFF
--- a/code/controllers/subsystem/parallax.dm
+++ b/code/controllers/subsystem/parallax.dm
@@ -21,8 +21,8 @@ SUBSYSTEM_DEF(parallax)
 				return
 			continue
 		var/atom/movable/A = C.eye
-		if(!A)
-			return
+		if(!istype(A))
+			continue
 		for (A; isloc(A.loc) && !isturf(A.loc); A = A.loc);
 
 		if(A != C.movingmob)

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -260,13 +260,13 @@
 			client.perspective = EYE_PERSPECTIVE
 			client.eye = A
 		else
-			if(isturf(loc))
+			if(isturf(loc) && (!A || loc == A))
 				client.eye = client.mob
 				client.perspective = MOB_PERSPECTIVE
 			else
 				client.perspective = EYE_PERSPECTIVE
-				client.eye = loc
-		return 1
+				client.eye = A
+		return 1 
 
 /mob/living/reset_perspective(atom/A)
 	if(..())


### PR DESCRIPTION
How i'm supposed to add meme features without this.
If anyone has idea for faster parallax check let me know.