### PR TITLE
Spell action buttons finally fixed

### DIFF
--- a/code/datums/action.dm
+++ b/code/datums/action.dm
@@ -460,6 +460,8 @@
 		return FALSE
 	return TRUE
 
+/datum/action/spell_action/spell
+
 /datum/action/spell_action/spell/IsAvailable()
 	if(!target)
 		return FALSE

--- a/code/modules/mob/living/carbon/alien/humanoid/alien_powers.dm
+++ b/code/modules/mob/living/carbon/alien/humanoid/alien_powers.dm
@@ -12,7 +12,7 @@ Doesn't work on other aliens/AI.*/
 	var/plasma_cost = 0
 	var/check_turf = FALSE
 	has_action = TRUE
-	datum/action/spell_action/alien/action
+	base_action = /datum/action/spell_action/alien/action
 	action_icon = 'icons/mob/actions/actions_xeno.dmi'
 	action_icon_state = "spell_default"
 	action_background_icon_state = "bg_alien"

--- a/code/modules/mob/living/carbon/alien/humanoid/alien_powers.dm
+++ b/code/modules/mob/living/carbon/alien/humanoid/alien_powers.dm
@@ -12,7 +12,7 @@ Doesn't work on other aliens/AI.*/
 	var/plasma_cost = 0
 	var/check_turf = FALSE
 	has_action = TRUE
-	base_action = /datum/action/spell_action/alien/action
+	base_action = /datum/action/spell_action/alien
 	action_icon = 'icons/mob/actions/actions_xeno.dmi'
 	action_icon_state = "spell_default"
 	action_background_icon_state = "bg_alien"

--- a/code/modules/spells/spell.dm
+++ b/code/modules/spells/spell.dm
@@ -18,7 +18,7 @@
 /obj/effect/proc_holder/Initialize()
 	. = ..()
 	if(has_action)
-		action = new(src)
+		action = new base_action(src)
 
 /obj/effect/proc_holder/proc/on_gain(mob/living/user)
 	return

--- a/code/modules/spells/spell.dm
+++ b/code/modules/spells/spell.dm
@@ -13,7 +13,7 @@
 	var/action_icon = 'icons/mob/actions/actions_spells.dmi'
 	var/action_icon_state = "spell_default"
 	var/action_background_icon_state = "bg_spell"
-	var/base_action = /datum/action/spell_action/action
+	var/base_action = /datum/action/spell_action
 
 /obj/effect/proc_holder/Initialize()
 	. = ..()
@@ -98,7 +98,7 @@ GLOBAL_LIST_INIT(spells, typesof(/obj/effect/proc_holder/spell)) //needed for th
 	pass_flags = PASSTABLE
 	density = FALSE
 	opacity = 0
-	base_action = /datum/action/spell_action/spell/action
+	base_action = /datum/action/spell_action/spell
 
 	var/school = "evocation" //not relevant at now, but may be important later if there are changes to how spells work. the ones I used for now will probably be changed... maybe spell presets? lacking flexibility but with some other benefit?
 

--- a/code/modules/spells/spell.dm
+++ b/code/modules/spells/spell.dm
@@ -13,6 +13,7 @@
 	var/action_icon = 'icons/mob/actions/actions_spells.dmi'
 	var/action_icon_state = "spell_default"
 	var/action_background_icon_state = "bg_spell"
+	var/base_action = /datum/action/spell_action/action
 
 /obj/effect/proc_holder/Initialize()
 	. = ..()
@@ -97,6 +98,7 @@ GLOBAL_LIST_INIT(spells, typesof(/obj/effect/proc_holder/spell)) //needed for th
 	pass_flags = PASSTABLE
 	density = FALSE
 	opacity = 0
+	base_action = /datum/action/spell_action/spell/action
 
 	var/school = "evocation" //not relevant at now, but may be important later if there are changes to how spells work. the ones I used for now will probably be changed... maybe spell presets? lacking flexibility but with some other benefit?
 
@@ -143,7 +145,6 @@ GLOBAL_LIST_INIT(spells, typesof(/obj/effect/proc_holder/spell)) //needed for th
 	action_icon = 'icons/mob/actions/actions_spells.dmi'
 	action_icon_state = "spell_default"
 	action_background_icon_state = "bg_spell"
-	datum/action/spell_action/spell/action
 
 /obj/effect/proc_holder/spell/proc/cast_check(skipcharge = 0,mob/user = usr) //checks if the spell can be cast based on its settings; skipcharge is used when an additional cast_check is called inside the spell
 
@@ -249,7 +250,6 @@ GLOBAL_LIST_INIT(spells, typesof(/obj/effect/proc_holder/spell)) //needed for th
 
 /obj/effect/proc_holder/spell/Initialize()
 	. = ..()
-	action = new(src)
 	START_PROCESSING(SSfastprocess, src)
 
 	still_recharging_msg = "<span class='notice'>[name] is still recharging.</span>"

--- a/code/modules/spells/spell_types/touch_attacks.dm
+++ b/code/modules/spells/spell_types/touch_attacks.dm
@@ -26,7 +26,7 @@
 /obj/effect/proc_holder/spell/targeted/touch/can_cast(mob/user = usr)
 	if(attached_hand)
 		return TRUE
-	..()
+	return ..()
 
 /obj/effect/proc_holder/spell/targeted/touch/proc/ChargeHand(mob/living/carbon/user)
 	attached_hand = new hand_path(src)

--- a/code/modules/spells/spell_types/touch_attacks.dm
+++ b/code/modules/spells/spell_types/touch_attacks.dm
@@ -23,6 +23,11 @@
 		charge_counter = 0
 		stoplag(1)
 
+/obj/effect/proc_holder/spell/targeted/touch/can_cast(mob/user = usr)
+	if(attached_hand)
+		return TRUE
+	..()
+
 /obj/effect/proc_holder/spell/targeted/touch/proc/ChargeHand(mob/living/carbon/user)
 	attached_hand = new hand_path(src)
 	if(!user.put_in_hands(attached_hand))


### PR DESCRIPTION
:cl: Robustin
fix: The action button for spells should now accurately reflect when the spell is on cooldown
fix: You can now reliably use the button for "touch" spells to "recall" the spell
/:cl:

Fixes #33565 
Fixes #31039

Tested 150 hours approved. God I missed having working cooldowns on (spell) action buttons. 
