### PR TITLE
Unblocks things on the walls in medbay and also removes an additional Radiation Collector

### DIFF
--- a/_maps/map_files/BoxStation/BoxStation.dmm
+++ b/_maps/map_files/BoxStation/BoxStation.dmm
@@ -94661,7 +94661,7 @@ bAt
 bvj
 bCM
 bDZ
-QoZ
+bDR
 bDR
 bIl
 bJC

--- a/_maps/map_files/BoxStation/BoxStation.dmm
+++ b/_maps/map_files/BoxStation/BoxStation.dmm
@@ -33889,7 +33889,6 @@
 	pixel_x = 11
 	},
 /obj/machinery/requests_console{
-	announcementConsole = 0;
 	department = "Medbay";
 	departmentType = 1;
 	name = "Medbay RC";
@@ -57742,7 +57741,6 @@
 	pixel_y = -3
 	},
 /obj/item/device/radio/intercom{
-	broadcasting = 0;
 	freerange = 0;
 	frequency = 1485;
 	listening = 1;
@@ -57753,7 +57751,6 @@
 /area/medical/sleeper)
 "QoZ" = (
 /obj/machinery/requests_console{
-	announcementConsole = 0;
 	department = "Medbay";
 	departmentType = 1;
 	name = "Medbay RC";

--- a/_maps/map_files/BoxStation/BoxStation.dmm
+++ b/_maps/map_files/BoxStation/BoxStation.dmm
@@ -33888,6 +33888,13 @@
 	dir = 4;
 	pixel_x = 11
 	},
+/obj/machinery/requests_console{
+	announcementConsole = 0;
+	department = "Medbay";
+	departmentType = 1;
+	name = "Medbay RC";
+	pixel_w = 30
+	},
 /turf/open/floor/plasteel/white,
 /area/medical/sleeper)
 "bFB" = (
@@ -35051,13 +35058,6 @@
 /area/medical/sleeper)
 "bIk" = (
 /obj/structure/table,
-/obj/machinery/requests_console{
-	announcementConsole = 0;
-	department = "Medbay";
-	departmentType = 1;
-	name = "Medbay RC";
-	pixel_y = -30
-	},
 /obj/item/storage/firstaid/fire{
 	pixel_x = 3;
 	pixel_y = 3
@@ -35076,14 +35076,6 @@
 /area/medical/sleeper)
 "bIl" = (
 /obj/structure/table,
-/obj/item/device/radio/intercom{
-	broadcasting = 0;
-	freerange = 0;
-	frequency = 1485;
-	listening = 1;
-	name = "Station Intercom (Medbay)";
-	pixel_y = -30
-	},
 /obj/item/storage/firstaid/toxin{
 	pixel_x = 3;
 	pixel_y = 3
@@ -57748,6 +57740,24 @@
 /obj/item/reagent_containers/syringe{
 	pixel_x = 6;
 	pixel_y = -3
+	},
+/obj/item/device/radio/intercom{
+	broadcasting = 0;
+	freerange = 0;
+	frequency = 1485;
+	listening = 1;
+	name = "Station Intercom (Medbay)";
+	pixel_x = 30
+	},
+/turf/open/floor/plasteel/white,
+/area/medical/sleeper)
+"QoZ" = (
+/obj/machinery/requests_console{
+	announcementConsole = 0;
+	department = "Medbay";
+	departmentType = 1;
+	name = "Medbay RC";
+	pixel_y = -30
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/sleeper)
@@ -94651,7 +94661,7 @@ bAt
 bvj
 bCM
 bDZ
-bDR
+QoZ
 bDR
 bIl
 bJC

--- a/_maps/map_files/Deltastation/DeltaStation2.dmm
+++ b/_maps/map_files/Deltastation/DeltaStation2.dmm
@@ -70964,7 +70964,6 @@
 	},
 /obj/machinery/requests_console{
 	department = "Medbay Storage";
-	departmentType = 0;
 	name = "Medbay Storage RC";
 	pixel_y = 28
 	},

--- a/_maps/map_files/Deltastation/DeltaStation2.dmm
+++ b/_maps/map_files/Deltastation/DeltaStation2.dmm
@@ -70958,6 +70958,16 @@
 /obj/machinery/disposal/bin,
 /obj/structure/disposalpipe/trunk,
 /obj/effect/turf_decal/bot,
+/obj/machinery/airalarm{
+	dir = 8;
+	pixel_x = 24
+	},
+/obj/machinery/requests_console{
+	department = "Medbay Storage";
+	departmentType = 0;
+	name = "Medbay Storage RC";
+	pixel_y = 28
+	},
 /turf/open/floor/plasteel,
 /area/medical/storage)
 "cNQ" = (
@@ -73328,10 +73338,6 @@
 	pixel_x = -3;
 	pixel_y = -3
 	},
-/obj/machinery/airalarm{
-	dir = 8;
-	pixel_x = 24
-	},
 /obj/machinery/light{
 	dir = 4
 	},
@@ -74211,12 +74217,6 @@
 /obj/item/storage/firstaid/o2{
 	pixel_x = -3;
 	pixel_y = -3
-	},
-/obj/machinery/requests_console{
-	department = "Medbay Storage";
-	departmentType = 0;
-	name = "Medbay Storage RC";
-	pixel_x = 32
 	},
 /obj/machinery/door/window/westleft{
 	name = "First-Aid Supplies";

--- a/_maps/map_files/Deltastation/DeltaStation2.dmm
+++ b/_maps/map_files/Deltastation/DeltaStation2.dmm
@@ -128633,7 +128633,7 @@ cqr
 ctp
 cuQ
 cjd
-cxC
+cje
 cje
 cAK
 cCr

--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -51784,6 +51784,12 @@
 	dir = 8
 	},
 /obj/structure/closet/l3closet,
+/obj/machinery/power/apc{
+	dir = 2;
+	name = "Medbay Storage APC";
+	areastring = "/area/medical/storage";
+	pixel_y = -24
+	},
 /turf/open/floor/plasteel/whiteblue/side{
 	dir = 10
 	},
@@ -52991,12 +52997,6 @@
 /obj/item/storage/firstaid/brute{
 	pixel_x = -3;
 	pixel_y = -3
-	},
-/obj/machinery/power/apc{
-	dir = 2;
-	name = "Medbay Storage APC";
-	areastring = "/area/medical/storage";
-	pixel_y = -24
 	},
 /obj/structure/cable/yellow{
 	icon_state = "0-4"

--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -51035,6 +51035,9 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
+/obj/structure/cable/yellow{
+	icon_state = "2-4"
+	},
 /turf/open/floor/plasteel/whiteblue/side{
 	dir = 8
 	},
@@ -51043,6 +51046,9 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
 /turf/open/floor/plasteel/white,
 /area/medical/storage)
 "cbL" = (
@@ -51050,11 +51056,17 @@
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
 	dir = 2
 	},
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
 /turf/open/floor/plasteel/white,
 /area/medical/storage)
 "cbM" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 10
+	},
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/storage)
@@ -51063,6 +51075,9 @@
 /obj/effect/landmark/start/medical_doctor,
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "1-8"
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/storage)
@@ -51790,6 +51805,7 @@
 	areastring = "/area/medical/storage";
 	pixel_y = -24
 	},
+/obj/structure/cable/yellow,
 /turf/open/floor/plasteel/whiteblue/side{
 	dir = 10
 	},
@@ -52998,9 +53014,6 @@
 	pixel_x = -3;
 	pixel_y = -3
 	},
-/obj/structure/cable/yellow{
-	icon_state = "0-4"
-	},
 /obj/machinery/light_switch{
 	pixel_x = -26
 	},
@@ -53015,9 +53028,6 @@
 	},
 /area/medical/storage)
 "cfM" = (
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 5
 	},
@@ -53026,9 +53036,6 @@
 	},
 /area/medical/storage)
 "cfN" = (
-/obj/structure/cable/yellow{
-	icon_state = "2-8"
-	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 10
 	},


### PR DESCRIPTION
[Changelogs]: 
:cl: Dax Dupont
fix: APCs and other wall mounted objects are no longer blocked by the secure medbay storage parts.
fix: Removed a duplicate radiation collector on Deltastation.
/:cl:

[why]: 
https://github.com/tgstation/tgstation/pull/33686 accidently blocked access to some APCs and consoles.
I've moved them around on maps that were affected. 
![hqgclpl 1](https://user-images.githubusercontent.com/17237624/34422400-862e1172-ec15-11e7-9ef0-ebebd84dbeec.png)
![xj6mtcq 1](https://user-images.githubusercontent.com/17237624/34420161-5399216e-ec08-11e7-9184-43ef3d545fb6.png)
![kv57hem 1](https://user-images.githubusercontent.com/17237624/34420041-87687176-ec07-11e7-9587-7eed8c7b86ea.png)
Also fixes https://github.com/tgstation/tgstation/issues/33909