### PR TITLE
Prevent infinite loops in orbit checks

### DIFF
--- a/code/modules/orbit/orbit.dm
+++ b/code/modules/orbit/orbit.dm
@@ -33,7 +33,9 @@
 		orbiting = null
 	return ..()
 
-/datum/orbit/proc/Check(turf/targetloc)
+/datum/orbit/proc/Check(turf/targetloc, list/checked_already = list())
+	//Avoid infinite loops for people who end up orbiting themself through another orbiter
+	checked_already[src] = TRUE
 	if (!orbiter)
 		qdel(src)
 		return
@@ -59,9 +61,10 @@
 	lastloc = orbiter.loc
 	for(var/other_orbit in orbiter.orbiters)
 		var/datum/orbit/OO = other_orbit
-		if(OO == src || OO.orbiter == orbiting)
+		//Skip if checked already
+		if(checked_already[OO])
 			continue
-		OO.Check(targetloc)
+		OO.Check(targetloc, checked_already)
 
 /atom/movable/var/datum/orbit/orbiting = null
 /atom/var/list/orbiters = null


### PR DESCRIPTION
We bookkeep the list of orbiters we've already checked, so if there is a
chain of orbiters orbiting each other we don't keep checking infinitely.

There is an argument that we should prevent this situation arising at
all, but the list should never grow that large so this should be fine

@MrStonedOne for code familiarity