### PR TITLE
[READY] Allows the supermatter's radiation collectors to produce research points in short bursts

### DIFF
--- a/code/game/objects/items/devices/multitool.dm
+++ b/code/game/objects/items/devices/multitool.dm
@@ -25,6 +25,7 @@
 	var/obj/machinery/buffer // simple machine buffer for device linkage
 	hitsound = 'sound/weapons/tap.ogg'
 	toolspeed = 1
+	tool_behaviour = TOOL_MULTITOOL
 	var/datum/integrated_io/selected_io = null  //functional for integrated circuits.
 	var/mode = 0
 

--- a/code/modules/power/singularity/collector.dm
+++ b/code/modules/power/singularity/collector.dm
@@ -2,6 +2,7 @@
 #define RAD_COLLECTOR_EFFICIENCY 80 	// radiation needs to be over this amount to get power
 #define RAD_COLLECTOR_COEFFICIENT 100
 #define RAD_COLLECTOR_STORED_OUT 0.04	// (this*100)% of stored power outputted per tick. Doesn't actualy change output total, lower numbers just means collectors output for longer in absence of a source
+#define RAD_COLLECTOR_MINING_CONVERSION_RATE 0.00001 //This is gonna need a lot of tweaking to get right. This is the number used to calculate the conversion of watts to research points per process()
 
 /obj/machinery/power/rad_collector
 	name = "Radiation Collector Array"
@@ -19,6 +20,11 @@
 	var/active = 0
 	var/locked = FALSE
 	var/drainratio = 1
+	var/powerproduction_drain = 0.001
+
+	var/datum/techweb/linked_techweb
+	var/bitcoinproduction_drain = 0.15
+	var/bitcoinmining = FALSE
 
 /obj/machinery/power/rad_collector/anchored
 	anchored = TRUE
@@ -27,23 +33,41 @@
 	. = ..()
 	AddComponent(/datum/component/rad_insulation, RAD_EXTREME_INSULATION, FALSE, FALSE)
 
+/obj/machinery/power/rad_collector/anchored/Initialize()
+	. = ..()
+	if(z in GLOB.station_z_levels)
+		linked_techweb = SSresearch.science_tech
+
 /obj/machinery/power/rad_collector/Destroy()
 	return ..()
 
 /obj/machinery/power/rad_collector/process()
 	if(loaded_tank)
-		if(!loaded_tank.air_contents.gases[/datum/gas/plasma])
-			investigate_log("<font color='red'>out of fuel</font>.", INVESTIGATE_SINGULO)
-			eject()
-		else
-			loaded_tank.air_contents.gases[/datum/gas/plasma][MOLES] -= 0.001*drainratio
-			loaded_tank.air_contents.assert_gas(/datum/gas/tritium)
-			loaded_tank.air_contents.gases[/datum/gas/tritium][MOLES] += 0.001*drainratio
-			loaded_tank.air_contents.garbage_collect()
+		if(!bitcoinmining)
+			if(!loaded_tank.air_contents.gases[/datum/gas/plasma])
+				investigate_log("<font color='red'>out of fuel</font>.", INVESTIGATE_SINGULO)
+				eject()
+			else
+				loaded_tank.air_contents.gases[/datum/gas/plasma][MOLES] -= powerproduction_drain*drainratio
+				loaded_tank.air_contents.assert_gas(/datum/gas/tritium)
+				loaded_tank.air_contents.gases[/datum/gas/tritium][MOLES] += powerproduction_drain*drainratio
+				loaded_tank.air_contents.garbage_collect()
 
-			var/power_produced = min(last_power, (last_power*RAD_COLLECTOR_STORED_OUT)+1000) //Produces at least 1000 watts if it has more than that stored
-			add_avail(power_produced)
-			last_power-=power_produced
+				var/power_produced = min(last_power, (last_power*RAD_COLLECTOR_STORED_OUT)+1000) //Produces at least 1000 watts if it has more than that stored
+				add_avail(power_produced)
+				last_power-=power_produced
+		else if(linked_techweb)
+			if(!loaded_tank.air_contents.gases[/datum/gas/tritium] || !loaded_tank.air_contents.gases[/datum/gas/oxygen])
+				eject()
+			else
+				loaded_tank.air_contents.gases[/datum/gas/tritium][MOLES] -= bitcoinproduction_drain*drainratio
+				loaded_tank.air_contents.gases[/datum/gas/oxygen][MOLES] -= bitcoinproduction_drain*drainratio
+				loaded_tank.air_contents.assert_gas(/datum/gas/carbon_dioxide)
+				loaded_tank.air_contents.gases[/datum/gas/carbon_dioxide][MOLES] += bitcoinproduction_drain*2*drainratio
+				loaded_tank.air_contents.garbage_collect()
+				var/bitcoins_mined = min(last_power, (last_power*RAD_COLLECTOR_STORED_OUT))
+				linked_techweb.research_points += bitcoins_mined*RAD_COLLECTOR_MINING_CONVERSION_RATE
+				last_power-=bitcoins_mined
 
 /obj/machinery/power/rad_collector/attack_hand(mob/user)
 	if(..())
@@ -79,10 +103,7 @@
 			disconnect_from_network()
 
 /obj/machinery/power/rad_collector/attackby(obj/item/W, mob/user, params)
-	if(istype(W, /obj/item/device/multitool))
-		to_chat(user, "<span class='notice'>[W] detects that [last_power]W is being processed.</span>")
-		return TRUE
-	else if(istype(W, /obj/item/device/analyzer) && loaded_tank)
+	if(istype(W, /obj/item/device/analyzer) && loaded_tank)
 		atmosanalyzer_scan(loaded_tank.air_contents, user)
 	else if(istype(W, /obj/item/tank/internals/plasma))
 		if(!anchored)
@@ -95,19 +116,6 @@
 			return
 		loaded_tank = W
 		update_icons()
-	else if(istype(W, /obj/item/crowbar))
-		if(loaded_tank)
-			if(locked)
-				to_chat(user, "<span class='warning'>The controls are locked!</span>")
-				return TRUE
-			eject()
-			return TRUE
-		else
-			to_chat(user, "<span class='warning'>There isn't a tank loaded!</span>")
-			return TRUE
-	else if(istype(W, /obj/item/wrench))
-		default_unfasten_wrench(user, W, 0)
-		return TRUE
 	else if(W.GetID())
 		if(allowed(user))
 			if(active)
@@ -121,6 +129,39 @@
 	else
 		return ..()
 
+/obj/machinery/power/rad_collector/wrench_act(mob/living/user, obj/item/wrench)
+	default_unfasten_wrench(user, wrench, 0)
+	return TRUE
+
+/obj/machinery/power/rad_collector/crowbar_act(mob/living/user, obj/item/crowbar)
+	if(loaded_tank)
+		if(locked)
+			to_chat(user, "<span class='warning'>The controls are locked!</span>")
+			return TRUE
+		eject()
+		return TRUE
+	else
+		to_chat(user, "<span class='warning'>There isn't a tank loaded!</span>")
+		return TRUE
+
+/obj/machinery/power/rad_collector/multitool_act(mob/living/user, obj/item/multitool)
+	if(!linked_techweb)
+		to_chat(user, "<span class='warning'>[src] isn't linked to a research system!</span>")
+	if(locked)
+		to_chat(user, "<span class='warning'>[src] is locked!</span>")
+	if(active)
+		to_chat(user, "<span class='warning'>[src] is currently active, producing [bitcoinmining ? "research points":"power"].</span>")
+	bitcoinmining = !bitcoinmining
+	to_chat(user, "<span class='warning'>You [bitcoinmining ? "enable":"disable"] the research point production feature of [src].</span>")
+	return TRUE
+
+/obj/machinery/power/rad_collector/examine(mob/user)
+	. = ..()
+	if(active)
+		if(!bitcoinmining)
+			to_chat(user, "<span class='notice'>[src]'s display states that it is processing [DisplayPower(last_power)].</span>")
+		else
+			to_chat(user, "<span class='notice'>[src]'s display states that it is producing a total of [last_power*RAD_COLLECTOR_MINING_CONVERSION_RATE] research points.</span>")
 
 /obj/machinery/power/rad_collector/obj_break(damage_flag)
 	if(!(stat & BROKEN) && !(flags_1 & NODECONSTRUCT_1))

--- a/code/modules/power/singularity/collector.dm
+++ b/code/modules/power/singularity/collector.dm
@@ -33,7 +33,7 @@
 	. = ..()
 	AddComponent(/datum/component/rad_insulation, RAD_EXTREME_INSULATION, FALSE, FALSE)
 
-/obj/machinery/power/rad_collector/anchored/Initialize()
+/obj/machinery/power/rad_collector/Initialize()
 	. = ..()
 	if(z in GLOB.station_z_levels)
 		linked_techweb = SSresearch.science_tech
@@ -46,6 +46,7 @@
 		if(!bitcoinmining)
 			if(!loaded_tank.air_contents.gases[/datum/gas/plasma])
 				investigate_log("<font color='red'>out of fuel</font>.", INVESTIGATE_SINGULO)
+				playsound(src, 'sound/machines/ding.ogg', 50, 1)
 				eject()
 			else
 				loaded_tank.air_contents.gases[/datum/gas/plasma][MOLES] -= powerproduction_drain*drainratio
@@ -58,6 +59,7 @@
 				last_power-=power_produced
 		else if(linked_techweb)
 			if(!loaded_tank.air_contents.gases[/datum/gas/tritium] || !loaded_tank.air_contents.gases[/datum/gas/oxygen])
+				playsound(src, 'sound/machines/ding.ogg', 50, 1)
 				eject()
 			else
 				loaded_tank.air_contents.gases[/datum/gas/tritium][MOLES] -= bitcoinproduction_drain*drainratio
@@ -147,10 +149,13 @@
 /obj/machinery/power/rad_collector/multitool_act(mob/living/user, obj/item/multitool)
 	if(!linked_techweb)
 		to_chat(user, "<span class='warning'>[src] isn't linked to a research system!</span>")
+		return TRUE
 	if(locked)
 		to_chat(user, "<span class='warning'>[src] is locked!</span>")
+		return TRUE
 	if(active)
 		to_chat(user, "<span class='warning'>[src] is currently active, producing [bitcoinmining ? "research points":"power"].</span>")
+		return TRUE
 	bitcoinmining = !bitcoinmining
 	to_chat(user, "<span class='warning'>You [bitcoinmining ? "enable":"disable"] the research point production feature of [src].</span>")
 	return TRUE
@@ -159,9 +164,14 @@
 	. = ..()
 	if(active)
 		if(!bitcoinmining)
-			to_chat(user, "<span class='notice'>[src]'s display states that it is processing [DisplayPower(last_power)].</span>")
+			to_chat(user, "<span class='notice'>[src]'s display states that it is processing <b>[DisplayPower(last_power)]</b>.</span>")
 		else
-			to_chat(user, "<span class='notice'>[src]'s display states that it is producing a total of [last_power*RAD_COLLECTOR_MINING_CONVERSION_RATE] research points.</span>")
+			to_chat(user, "<span class='notice'>[src]'s display states that it is producing a total of <b>[last_power*RAD_COLLECTOR_MINING_CONVERSION_RATE]</b> research points per minute.</span>")
+	else
+		if(!bitcoinmining)
+			to_chat(user,"<span class='notice'><b>[src]'s display displays the words:</b> \"Power production mode. Please insert <b>Plasma</b>. Use a multitool to change production modes.\"</span>")
+		else
+			to_chat(user,"<span class='notice'><b>[src]'s display displays the words:</b> \"Research point production mode. Please insert <b>Tritium</b> and <b>Oxygen</b>. Use a multitool to change production modes.\"</span>")
 
 /obj/machinery/power/rad_collector/obj_break(damage_flag)
 	if(!(stat & BROKEN) && !(flags_1 & NODECONSTRUCT_1))

--- a/code/modules/power/singularity/collector.dm
+++ b/code/modules/power/singularity/collector.dm
@@ -65,7 +65,7 @@
 				loaded_tank.air_contents.assert_gas(/datum/gas/carbon_dioxide)
 				loaded_tank.air_contents.gases[/datum/gas/carbon_dioxide][MOLES] += bitcoinproduction_drain*2*drainratio
 				loaded_tank.air_contents.garbage_collect()
-				var/bitcoins_mined = min(last_power, (last_power*RAD_COLLECTOR_STORED_OUT))
+				var/bitcoins_mined = min(last_power, (last_power*RAD_COLLECTOR_STORED_OUT)+1000)
 				linked_techweb.research_points += bitcoins_mined*RAD_COLLECTOR_MINING_CONVERSION_RATE
 				last_power-=bitcoins_mined
 

--- a/code/modules/power/singularity/collector.dm
+++ b/code/modules/power/singularity/collector.dm
@@ -53,7 +53,7 @@
 			var/power_produced = min(last_power, (last_power*RAD_COLLECTOR_STORED_OUT)+1000) //Produces at least 1000 watts if it has more than that stored
 			add_avail(power_produced)
 			last_power-=power_produced
-	else if(z in GLOB.station_z_levels && SSresearch.science_tech)
+	else if(is_station_level(z) && SSresearch.science_tech)
 		if(!loaded_tank.air_contents.gases[/datum/gas/tritium] || !loaded_tank.air_contents.gases[/datum/gas/oxygen])
 			playsound(src, 'sound/machines/ding.ogg', 50, 1)
 			eject()
@@ -143,7 +143,7 @@
 	return TRUE
 
 /obj/machinery/power/rad_collector/multitool_act(mob/living/user, obj/item/multitool)
-	if(!linked_techweb)
+	if(!is_station_level(z) && !SSresearch.science_tech)
 		to_chat(user, "<span class='warning'>[src] isn't linked to a research system!</span>")
 		return TRUE
 	if(locked)


### PR DESCRIPTION
Title. This allows the supermatter's radiation collectors to ~~mine bitcoin~~ produce research points by combusting tritium and oxygen via radiation. While a rad collector is producing research points, it is unable to produce power. Radiation collectors require a mix of tritium and oxygen to produce research points. These gasses are consumed at a very rapid pace when the rad collector is in research point production mode. Work together with science or atmos techs to increase the station's research point production at the temporary cost of power production!

This PR also moves the multitool's (buggy) ability to display how many watts a rad collector is producing to the rad collector's examine text, and moves tool interactions to the proper procs.

For reference, one room temperature tank with 50% tritium, 50% oxygen will produce a total of 50 research points with the most frequently used supermatter setup. More radiation will increase the rate at which research points are generated, and packing more moles of both gasses into the tank will increase the amount of time a rad collector will be able to generate research points.

:cl: deathride58
add: By using a multitool on a radiation collector, you can use it to generate research points! This requires a tank filled with a mix of tritium and oxygen.
tweak: The display of rad collectors' power production rates has been moved from a multitool interaction to examine text.
tweak: Radiation collectors now emit a ding when they run out of fuel.
/:cl:

I also plan on making the turbine capable of producing research points in the future, as it rarely ever sees use.