### PR TITLE
Always use the area name when selecting a teleport beacon

### DIFF
--- a/code/game/machinery/computer/teleporter.dm
+++ b/code/game/machinery/computer/teleporter.dm
@@ -162,7 +162,8 @@
 	if(regime_set == "Teleporter")
 		for(var/obj/item/device/radio/beacon/R in GLOB.teleportbeacons)
 			if(is_eligible(R))
-				L[avoid_assoc_duplicate_keys(R.loc.loc.name, areaindex)] = R
+				var/area/A = get_area(R)
+				L[avoid_assoc_duplicate_keys(A.name, areaindex)] = R
 
 		for(var/obj/item/implant/tracking/I in GLOB.tracked_implants)
 			if(!I.imp_in || !ismob(I.loc))
@@ -185,7 +186,8 @@
 			return
 		for(var/obj/machinery/teleport/station/R in S)
 			if(is_eligible(R))
-				L[avoid_assoc_duplicate_keys(R.loc.loc.name, areaindex)] = R
+				var/area/A = get_area(R)
+				L[avoid_assoc_duplicate_keys(A.name, areaindex)] = R
 		var/desc = input("Please select a station to lock in.", "Locking Computer") as null|anything in L
 		target = L[desc]
 		if(target)


### PR DESCRIPTION
🆑
fix: The teleporter computer now always shows the area name of a beacon rather than the turf name in some situations.
/:cl:
