### PR TITLE
Rebalances transformation sting

### DIFF
--- a/code/game/gamemodes/changeling/powers/tiny_prick.dm
+++ b/code/game/gamemodes/changeling/powers/tiny_prick.dm
@@ -69,7 +69,7 @@
 	desc = "We silently sting a human, injecting a retrovirus that forces them to transform."
 	helptext = "The victim will transform much like a changeling would. Does not provide a warning to others. Mutations will not be transferred, and monkeys will become human."
 	sting_icon = "sting_transform"
-	chemical_cost = 50
+	chemical_cost = 25
 	dna_cost = 3
 	var/datum/changelingprofile/selected_dna = null
 


### PR DESCRIPTION
[Changelogs]: 
:cl: Dax Dupont
balance: Halved the chemical cost of DNA transformation stings.
/:cl:

[why]: At 50 chemical cost, it requires 5 times more chemicals than frost sting memes and double of blinding.
DNA transformation is relatively harmless and it also is instant so it's an big VALID ME sign if you sting someone outside of very busy situations.
As such, I feel like 25 is pretty good since it's the **highest** value in the file.
