### PR TITLE
Fixes turfs not inheriting their old turf's air when changing

### DIFF
--- a/code/game/turfs/simulated/floor.dm
+++ b/code/game/turfs/simulated/floor.dm
@@ -126,9 +126,11 @@
 		return ..()
 	var/old_icon = icon_regular_floor
 	var/old_dir = dir
+	var/datum/gas_mixture/turf/old_air = air
 	var/turf/open/floor/W = ..()
 	W.icon_regular_floor = old_icon
 	W.setDir(old_dir)
+	W.air = old_air
 	W.update_icon()
 	return W
 


### PR DESCRIPTION
Fixes #33913 

:cl: deathride58
fix: Tiles now retain their old air when they change to a different type of tile.
/:cl:
