### PR TITLE
Pwr Game can now produce research points when consumed by scientists

### DIFF
--- a/code/modules/reagents/chemistry/reagents/drink_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/drink_reagents.dm
@@ -489,6 +489,7 @@
 	if (M.bodytemperature > 310)
 		M.bodytemperature = max(310, M.bodytemperature - (8 * TEMPERATURE_DAMAGE_COEFFICIENT)) //310 is the normal bodytemp. 310.055
 	if(M.mind && M.mind.assigned_role == "Scientist")
+		M.drunkenness = max((H.drunkenness + (sqrt(volume) * 65 * ALCOHOL_RATE)), 0)
 		if(SSresearch.science_tech)
 			SSresearch.science_tech.research_points += 0.5*REM
 	..()

--- a/code/modules/reagents/chemistry/reagents/drink_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/drink_reagents.dm
@@ -484,16 +484,13 @@
 	glass_icon_state = "glass_red"
 	glass_name = "glass of Pwr Game"
 	glass_desc = "Goes well with a Vlad's salad."
-	var/datum/techweb/linked_techweb
 
 /datum/reagent/consumable/pwr_game/on_mob_life(mob/living/M)
 	if (M.bodytemperature > 310)
 		M.bodytemperature = max(310, M.bodytemperature - (8 * TEMPERATURE_DAMAGE_COEFFICIENT)) //310 is the normal bodytemp. 310.055
 	if(M.mind && M.mind.assigned_role == "Scientist")
-		if(istype(linked_techweb))
-			linked_techweb.research_points += 0.5*REM
-		else if(SSresearch.science_tech)
-			linked_techweb = SSresearch.science_tech
+		if(SSresearch.science_tech)
+			SSresearch.science_tech.research_points += 0.5*REM
 	..()
 
 /datum/reagent/consumable/shamblers

--- a/code/modules/reagents/chemistry/reagents/drink_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/drink_reagents.dm
@@ -484,10 +484,16 @@
 	glass_icon_state = "glass_red"
 	glass_name = "glass of Pwr Game"
 	glass_desc = "Goes well with a Vlad's salad."
+	var/datum/techweb/linked_techweb
 
 /datum/reagent/consumable/pwr_game/on_mob_life(mob/living/M)
 	if (M.bodytemperature > 310)
 		M.bodytemperature = max(310, M.bodytemperature - (8 * TEMPERATURE_DAMAGE_COEFFICIENT)) //310 is the normal bodytemp. 310.055
+	if(M.mind && M.mind.assigned_role == "Scientist")
+		if(istype(linked_techweb))
+			linked_techweb.research_points += 0.5*REM
+		else if(SSresearch.science_tech)
+			linked_techweb = SSresearch.science_tech
 	..()
 
 /datum/reagent/consumable/shamblers


### PR DESCRIPTION
Title.

:cl: deathride58
add: Drinking Pwr Game as a scientist will now increase the station's research point generation rate!
add: Unfortunately, though, scientists are now capable of getting drunk off of Pwr Game!
/:cl:

The players want pwrgame&d back. This restores pwrgame&d.

~~The generation rate is 0.5 research points per metabolism cycle, for those too lazy to read the code.~~