### PR TITLE
[WIP] Refactors explosive guardian bombs to use components

### DIFF
--- a/code/__DEFINES/components.dm
+++ b/code/__DEFINES/components.dm
@@ -79,6 +79,9 @@
 #define COMSIG_MACHINE_PROCESS "machine_process"				//from machinery subsystem fire(): ()
 #define COMSIG_MACHINE_PROCESS_ATMOS "machine_process_atmos"	//from air subsystem process_atmos_machinery(): ()
 
+// /mob signals
+#define COMSIG_UNARMED_ATTACK "mob_unarmed_attack" // from base of /mob/proc/UnarmedAttack(): (/mob/attacker, proximity_flag)
+
 // /mob/living/carbon/human signals
 #define COMSIG_HUMAN_MELEE_UNARMED_ATTACK "human_melee_unarmed_attack"			//from mob/living/carbon/human/UnarmedAttack(): (atom/target)
 #define COMSIG_HUMAN_MELEE_UNARMED_ATTACKBY "human_melee_unarmed_attackby"		//from mob/living/carbon/human/UnarmedAttack(): (mob/living/carbon/human/attacker)

--- a/code/_onclick/click.dm
+++ b/code/_onclick/click.dm
@@ -254,7 +254,7 @@
 /mob/proc/UnarmedAttack(atom/A, proximity_flag)
 	if(ismob(A))
 		changeNext_move(CLICK_CD_MELEE)
-	return
+	SendSignal(COMSIG_UNARMED_ATTACK, A, src, proximity_flag)
 
 /*
 	Ranged unarmed attack:

--- a/code/_onclick/other_mobs.dm
+++ b/code/_onclick/other_mobs.dm
@@ -5,7 +5,6 @@
 	Otherwise pretty standard.
 */
 /mob/living/carbon/human/UnarmedAttack(atom/A, proximity)
-
 	if(!has_active_hand()) //can't attack without a hand.
 		to_chat(src, "<span class='notice'>You look at your arm and sigh.</span>")
 		return
@@ -25,6 +24,8 @@
 	if(override)
 		return
 
+
+	SendSignal(COMSIG_UNARMED_ATTACK, A, src, proximity)
 	SendSignal(COMSIG_HUMAN_MELEE_UNARMED_ATTACK, A)
 	A.attack_hand(src)
 	SendSignal(COMSIG_HUMAN_MELEE_UNARMED_ATTACKBY, src)
@@ -58,7 +59,8 @@
 /*
 	Animals & All Unspecified
 */
-/mob/living/UnarmedAttack(atom/A)
+/mob/living/UnarmedAttack(atom/A, proximity)
+	SendSignal(COMSIG_UNARMED_ATTACK, A, src, proximity)
 	A.attack_animal(src)
 
 /atom/proc/attack_animal(mob/user)
@@ -70,7 +72,8 @@
 /*
 	Monkeys
 */
-/mob/living/carbon/monkey/UnarmedAttack(atom/A)
+/mob/living/carbon/monkey/UnarmedAttack(atom/A, proximity)
+	SendSignal(COMSIG_UNARMED_ATTACK, A, src, proximity)
 	A.attack_paw(src)
 /atom/proc/attack_paw(mob/user)
 	return
@@ -113,7 +116,8 @@
 	Aliens
 	Defaults to same as monkey in most places
 */
-/mob/living/carbon/alien/UnarmedAttack(atom/A)
+/mob/living/carbon/alien/UnarmedAttack(atom/A, proximity)
+	SendSignal(COMSIG_UNARMED_ATTACK, A, src, proximity)
 	A.attack_alien(src)
 /atom/proc/attack_alien(mob/living/carbon/alien/user)
 	attack_paw(user)
@@ -122,7 +126,8 @@
 	return
 
 // Babby aliens
-/mob/living/carbon/alien/larva/UnarmedAttack(atom/A)
+/mob/living/carbon/alien/larva/UnarmedAttack(atom/A, proximity)
+	SendSignal(COMSIG_UNARMED_ATTACK, A, src, proximity)
 	A.attack_larva(src)
 /atom/proc/attack_larva(mob/user)
 	return
@@ -132,7 +137,8 @@
 	Slimes
 	Nothing happening here
 */
-/mob/living/simple_animal/slime/UnarmedAttack(atom/A)
+/mob/living/simple_animal/slime/UnarmedAttack(atom/A, proximity)
+	SendSignal(COMSIG_UNARMED_ATTACK, A, src, proximity)
 	A.attack_slime(src)
 /atom/proc/attack_slime(mob/user)
 	return
@@ -143,7 +149,8 @@
 /*
 	Drones
 */
-/mob/living/simple_animal/drone/UnarmedAttack(atom/A)
+/mob/living/simple_animal/drone/UnarmedAttack(atom/A, proximity)
+	SendSignal(COMSIG_UNARMED_ATTACK, A, src, proximity)
 	A.attack_drone(src)
 
 /atom/proc/attack_drone(mob/living/simple_animal/drone/user)
@@ -158,6 +165,7 @@
 */
 
 /mob/living/carbon/true_devil/UnarmedAttack(atom/A, proximity)
+	SendSignal(COMSIG_UNARMED_ATTACK, A, src, proximity)
 	A.attack_hand(src)
 
 /*
@@ -184,6 +192,7 @@
 	if(!dextrous)
 		return ..()
 	if(!ismob(A))
+		SendSignal(COMSIG_UNARMED_ATTACK, A, src, proximity)
 		A.attack_hand(src)
 		update_inv_hands()
 
@@ -195,7 +204,7 @@
 /mob/living/simple_animal/hostile/UnarmedAttack(atom/A)
 	target = A
 	if(dextrous && !is_type_in_typecache(A, environment_target_typecache) && !ismob(A))
-		..()
+		return ..()
 	else
 		AttackingTarget()
 

--- a/code/datums/components/explosive_trap.dm
+++ b/code/datums/components/explosive_trap.dm
@@ -1,0 +1,50 @@
+/datum/component/explosive_trap
+	// Touch or bump into an item with this component, and it'll explode
+	var/list/mob/immune = list()
+
+	var/color = "#000000"
+
+	var/disable_time = 60 SECONDS
+
+/datum/component/explosive_trap/Initialize(_immune, _color, _disable_time)
+	if(!ismovableatom(parent))
+		. = COMPONENT_INCOMPATIBLE
+		CRASH("[type] added to a [parent.type]")
+
+	if(_immune)
+		immune = _immune
+	if(_color)
+		color = _color
+	if(_disable_time)
+		disable_time = _disable_time
+
+	RegisterSignal(list(COMSIG_MOVABLE_COLLIDE, COMSIG_UNARMED_ATTACK), .proc/Detonate)
+	RegisterSignal(COMSIG_PARENT_ATTACKBY, .proc/Attackby)
+	RegisterSignal(COMSIG_PARENT_EXAMINE, .proc/Examine)
+
+	if(disable_time)
+		QDEL_IN(src, disable_time)
+
+/datum/component/explosive_trap/proc/Detonate(mob/living/victim)
+	if(!isliving(victim))
+		return FALSE
+
+	if(victim in immune)
+		to_chat(victim, "<span class='userdanger'>[parent] pulses softly with <font color=\"[color]\">light</font>")
+		return FALSE
+
+	to_chat(victim, "<span class='userdanger'>[parent] explodes with <font color=\"[color]\">light</font>!</span>")
+
+	new /obj/effect/temp_visual/explosion(get_turf(parent))
+	victim.ex_act(EXPLODE_HEAVY)
+	qdel(src)
+
+	return TRUE
+
+/datum/component/explosive_trap/proc/Attackby(obj/item/I, mob/living/user, params)
+	if(Detonate(user))
+		. = COMPONENT_NO_AFTERATTACK
+
+/datum/component/explosive_trap/proc/Examine(mob/living/user)
+	if(isobserver(user) || get_dist(user, parent) <= 2)
+		to_chat(user, "<span class='holoparasite'>It glows with a strange <font color=\"[color]\">light</font>!</span>")

--- a/code/datums/components/explosive_trap.dm
+++ b/code/datums/components/explosive_trap.dm
@@ -23,7 +23,12 @@
 	RegisterSignal(COMSIG_PARENT_EXAMINE, .proc/Examine)
 
 	if(disable_time)
-		QDEL_IN(src, disable_time)
+		addtimer(CALLBACK(src, .proc/Disable), disable_time)
+
+/datum/component/explosive_trap/proc/Disable()
+	for(var/i in immune)
+		to_chat(i, "<span class='danger'>The explosive trap on [parent] has expired without detonating.</span>")
+	qdel(src)
 
 /datum/component/explosive_trap/proc/Detonate(mob/living/victim)
 	if(!isliving(victim))
@@ -37,8 +42,11 @@
 
 	new /obj/effect/temp_visual/explosion(get_turf(parent))
 	victim.ex_act(EXPLODE_HEAVY)
-	qdel(src)
 
+	for(var/i in immune)
+		to_chat(i, "<span class='notice'>The explosive trap on [parent] has caught [victim]!</span>")
+
+	qdel(src)
 	return TRUE
 
 /datum/component/explosive_trap/proc/Attackby(obj/item/I, mob/living/user, params)

--- a/code/modules/mob/living/simple_animal/guardian/types/explosive.dm
+++ b/code/modules/mob/living/simple_animal/guardian/types/explosive.dm
@@ -38,60 +38,8 @@
 		return
 	if(isobj(A))
 		if(bomb_cooldown <= world.time && !stat)
-			var/obj/guardian_bomb/B = new /obj/guardian_bomb(get_turf(A))
+			A.AddComponent(/datum/component/explosive_trap, list(src, summoner), namedatum.colour)
 			to_chat(src, "<span class='danger'><B>Success! Bomb armed!</span></B>")
 			bomb_cooldown = world.time + 200
-			B.spawner = src
-			B.disguise(A)
 		else
 			to_chat(src, "<span class='danger'><B>Your powers are on cooldown! You must wait 20 seconds between bombs.</span></B>")
-
-/obj/guardian_bomb
-	name = "bomb"
-	desc = "You shouldn't be seeing this!"
-	var/obj/stored_obj
-	var/mob/living/simple_animal/hostile/guardian/spawner
-
-
-/obj/guardian_bomb/proc/disguise(obj/A)
-	A.forceMove(src)
-	stored_obj = A
-	opacity = A.opacity
-	anchored = A.anchored
-	density = A.density
-	appearance = A.appearance
-	addtimer(CALLBACK(src, .proc/disable), 600)
-
-/obj/guardian_bomb/proc/disable()
-	stored_obj.forceMove(get_turf(src))
-	to_chat(spawner, "<span class='danger'><B>Failure! Your trap didn't catch anyone this time.</span></B>")
-	qdel(src)
-
-/obj/guardian_bomb/proc/detonate(mob/living/user)
-	if(isliving(user))
-		if(user != spawner && user != spawner.summoner && !spawner.hasmatchingsummoner(user))
-			to_chat(user, "<span class='danger'><B>[src] was boobytrapped!</span></B>")
-			to_chat(spawner, "<span class='danger'><B>Success! Your trap caught [user]</span></B>")
-			var/turf/T = get_turf(src)
-			stored_obj.forceMove(T)
-			playsound(T,'sound/effects/explosion2.ogg', 200, 1)
-			new /obj/effect/temp_visual/explosion(T)
-			user.ex_act(EXPLODE_HEAVY)
-			qdel(src)
-		else
-			to_chat(user, "<span class='holoparasite'>[src] glows with a strange <font color=\"[spawner.namedatum.colour]\">light</font>, and you don't touch it.</span>")
-
-/obj/guardian_bomb/Collide(atom/A)
-	detonate(A)
-	..()
-
-/obj/guardian_bomb/attackby(mob/living/user)
-	detonate(user)
-
-/obj/guardian_bomb/attack_hand(mob/living/user)
-	detonate(user)
-
-/obj/guardian_bomb/examine(mob/user)
-	stored_obj.examine(user)
-	if(get_dist(user,src)<=2)
-		to_chat(user, "<span class='holoparasite'>It glows with a strange <font color=\"[spawner.namedatum.colour]\">light</font>!</span>")

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -312,6 +312,7 @@
 #include "code\datums\components\chasm.dm"
 #include "code\datums\components\cleaning.dm"
 #include "code\datums\components\decal.dm"
+#include "code\datums\components\explosive_trap.dm"
 #include "code\datums\components\forensics.dm"
 #include "code\datums\components\infective.dm"
 #include "code\datums\components\jousting.dm"


### PR DESCRIPTION
Why? Because component are better for what this is trying to do, and
means we don't have some ugly branch of /obj.

- Some messages have changed, but the behaviour should be ideally the same

Intended behaviour
- [x] The trap explodes when you hit the trapped object with something
- [ ] The trap explodes when you bump into the object (ie. airlock)
- [ ] The trap explodes when you pick up the object