### PR TITLE
Fix PDA message photos not being viewable

### DIFF
--- a/code/game/machinery/telecomms/computers/message.dm
+++ b/code/game/machinery/telecomms/computers/message.dm
@@ -131,7 +131,7 @@
 					break
 				// Del - Sender   - Recepient - Message
 				// X   - Al Green - Your Mom  - WHAT UP!?
-				dat += "<tr><td width = '5%'><center><A href='?src=[REF(src)];delete=[REF(pda)]' style='color: rgb(255,0,0)'>X</a></center></td><td width='15%'>[pda.sender]</td><td width='15%'>[pda.recipient]</td><td width='300px'>[pda.message][pda.photo ? "<a href='byond://?src=[REF(pda)];photo=1'>(Photo)</a>":""]</td></tr>"
+				dat += "<tr><td width = '5%'><center><A href='?src=[REF(src)];delete=[REF(pda)]' style='color: rgb(255,0,0)'>X</a></center></td><td width='15%'>[pda.sender]</td><td width='15%'>[pda.recipient]</td><td width='300px'>[pda.message][pda.photo ? " <a href='byond://?src=[REF(pda)];photo=1'>(Photo)</a>":""]</td></tr>"
 			dat += "</table>"
 		//Hacking screen.
 		if(2)

--- a/code/game/machinery/telecomms/machines/message_server.dm
+++ b/code/game/machinery/telecomms/machines/message_server.dm
@@ -62,8 +62,9 @@
 		return
 
 	// log the signal
-	pda_msgs += new /datum/data_pda_msg(signal.format_target(), "[signal.data["name"]] ([signal.data["job"]])", signal.data["message"], signal.data["photo"])
-	signal.data -= "reject"  // only gets through if it's logged
+	var/datum/data_pda_msg/M = new(signal.format_target(), "[signal.data["name"]] ([signal.data["job"]])", signal.data["message"], signal.data["photo"])
+	pda_msgs += M
+	signal.logged = M
 
 	// pass it along to either the hub or the broadcaster
 	if(!relay_information(signal, /obj/machinery/telecomms/hub))
@@ -87,13 +88,13 @@
 /datum/signal/subspace/pda
 	frequency = FREQ_COMMON
 	server_type = /obj/machinery/telecomms/message_server
+	var/datum/data_pda_msg/logged
 
 /datum/signal/subspace/pda/New(source, data)
 	src.source = source
 	src.data = data
 	var/turf/T = get_turf(source)
 	levels = list(T.z)
-	data["reject"] = TRUE  // set to FALSE if a messaging server logs it
 
 /datum/signal/subspace/pda/copy()
 	var/datum/signal/subspace/pda/copy = new(source, data.Copy())
@@ -107,25 +108,16 @@
 	return data["targets"][1]
 
 /datum/signal/subspace/pda/proc/format_message()
-	if (data["photo"])
-		return "[data["message"]] <a href='byond://?src=[REF(src)];photo=1'>(Photo)</a>"
+	if (logged && data["photo"])
+		return "[data["message"]] (<a href='byond://?src=[REF(logged)];photo=1'>Photo</a>)"
 	return data["message"]
 
 /datum/signal/subspace/pda/broadcast()
+	if (!logged)  // Can only go through if a message server logs it
+		return
 	for (var/obj/item/device/pda/P in GLOB.PDAs)
 		if ("[P.owner] ([P.ownjob])" in data["targets"])
 			P.receive_message(src)
-
-/datum/signal/subspace/pda/Topic(href, href_list)
-	..()
-	if (href_list["photo"])
-		var/mob/M = usr
-		M << browse_rsc(data["photo"], "pda_photo.png")
-		M << browse("<html><head><title>PDA Photo</title></head>" \
-		+ "<body style='overflow:hidden;margin:0;text-align:center'>" \
-		+ "<img src='pda_photo.png' width='192' style='-ms-interpolation-mode:nearest-neighbor' />" \
-		+ "</body></html>", "window=pdaphoto;size=192x192")
-		onclose(M, "pdaphoto")
 
 
 // Log datums stored by the message server.
@@ -144,11 +136,6 @@
 		message = param_message
 	if(param_photo)
 		photo = param_photo
-
-/datum/data_pda_msg/proc/get_photo_ref()
-	if(photo)
-		return "<a href='byond://?src=[REF(src)];photo=1'>(Photo)</a>"
-	return ""
 
 /datum/data_pda_msg/Topic(href,href_list)
 	..()

--- a/code/game/machinery/telecomms/machines/message_server.dm
+++ b/code/game/machinery/telecomms/machines/message_server.dm
@@ -109,8 +109,8 @@
 
 /datum/signal/subspace/pda/proc/format_message()
 	if (logged && data["photo"])
-		return "[data["message"]] (<a href='byond://?src=[REF(logged)];photo=1'>Photo</a>)"
-	return data["message"]
+		return "\"[data["message"]]\" (<a href='byond://?src=[REF(logged)];photo=1'>Photo</a>)"
+	return "\"data["message"]\""
 
 /datum/signal/subspace/pda/broadcast()
 	if (!logged)  // Can only go through if a message server logs it


### PR DESCRIPTION
:cl:
fix: Viewing photos sent by PDA message works again.
/:cl:

Fixes #33922. Closes #33929 by inclusion, figured I might as well fix the merge conflict now rather than later.