### PR TITLE
Allows the vault's bank machine to convert cargo credits to research points and vice versa

### DIFF
--- a/code/controllers/configuration/entries/game_options.dm
+++ b/code/controllers/configuration/entries/game_options.dm
@@ -261,3 +261,7 @@
 
 /datum/config_entry/number/cargo_credits_per_research_point
 	value = 500
+
+/datum/config_entry/number/research_to_credit_modifier
+	value = 0.01
+	integer = FALSE

--- a/code/controllers/configuration/entries/game_options.dm
+++ b/code/controllers/configuration/entries/game_options.dm
@@ -258,3 +258,6 @@
 	integer = FALSE
 
 /datum/config_entry/flag/ic_printing
+
+/datum/config_entry/number/cargo_credits_per_research_point
+	value = 500

--- a/code/game/machinery/bank_machine.dm
+++ b/code/game/machinery/bank_machine.dm
@@ -97,14 +97,14 @@
 			SSshuttle.points += -credstoconv
 			say("Thank you for your transaction. You have successfully converted [credstoconv] credits to [bitcoinsreceived] research points.")
 	if(href_list["bitcointocreds"])
-		var/coinstoconv = input(usr, "Please enter the number of research points you want to convert to credits. The current conversion rate is 1 research point to [CONFIG_GET(number/cargo_credits_per_research_point)*0.1] credits", "Research Points to Credits") as null|num
+		var/coinstoconv = input(usr, "Please enter the number of research points you want to convert to credits. The current conversion rate is 1 research point to [CONFIG_GET(number/cargo_credits_per_research_point)*CONFIG_GET(number/research_to_credit_modifier)] credits", "Research Points to Credits") as null|num
 		if(!in_range(src, usr) && src.loc != usr && (!isAI(usr) && !IsAdminGhost(usr)))
 			return
 		if(coinstoconv)
 			if(coinstoconv > linked_techweb.research_points)
 				say("Insufficient research points.")
 				return
-			var/creditssreceived = coinstoconv*(CONFIG_GET(number/cargo_credits_per_research_point)*0.1)
+			var/creditssreceived = coinstoconv*(CONFIG_GET(number/cargo_credits_per_research_point)*CONFIG_GET(number/research_to_credit_modifier))
 			linked_techweb.research_points += creditssreceived
 			SSshuttle.points += -coinstoconv
 			say("Thank you for your transaction. You have successfully converted [coinstoconv] research points to [creditssreceived] credits.")

--- a/code/game/machinery/bank_machine.dm
+++ b/code/game/machinery/bank_machine.dm
@@ -67,6 +67,7 @@
 	if(istype(linked_techweb))
 		dat += "Current Research Point Balance: [linked_techweb.research_points] research points.<br>"
 		dat += "<A href='?src=[REF(src)];credstobitcoin=1'>Exchange Credits for Research Points</A><br>"
+		dat += "<A href='?src=[REF(src)];bitcointocreds=1'>Exchange Research Points for Credits</A><br>"
 
 	if(!siphoning)
 		dat += "<A href='?src=[REF(src)];siphon=1'>Siphon Credits</A><br>"
@@ -88,10 +89,25 @@
 		if(!in_range(src, usr) && src.loc != usr && (!isAI(usr) && !IsAdminGhost(usr)))
 			return
 		if(credstoconv)
+			if(credstoconv > SSshuttle.points)
+				say("Insufficient credits.")
+				return
 			var/bitcoinsreceived = credstoconv/CONFIG_GET(number/cargo_credits_per_research_point)
 			linked_techweb.research_points += bitcoinsreceived
 			SSshuttle.points += -credstoconv
-			say("Thank you for your transaction. You have successfully converted [credstoconv] to [bitcoinsreceived] research points.")
+			say("Thank you for your transaction. You have successfully converted [credstoconv] credits to [bitcoinsreceived] research points.")
+	if(href_list["bitcointocreds"])
+		var/coinstoconv = input(usr, "Please enter the number of research points you want to convert to credits. The current conversion rate is [CONFIG_GET(number/cargo_credits_per_research_point)] credits to 1 research point", "Research Points to Credits") as null|num
+		if(!in_range(src, usr) && src.loc != usr && (!isAI(usr) && !IsAdminGhost(usr)))
+			return
+		if(coinstoconv)
+			if(coinstoconv > linked_techweb.research_points)
+				say("Insufficient research points.")
+				return
+			var/creditssreceived = coinstoconv*CONFIG_GET(number/cargo_credits_per_research_point)
+			linked_techweb.research_points += creditssreceived
+			SSshuttle.points += -coinstoconv
+			say("Thank you for your transaction. You have successfully converted [coinstoconv] research points to [creditssreceived] credits.")
 	if(href_list["siphon"])
 		say("Siphon of station credits has begun!")
 		siphoning = TRUE

--- a/code/game/machinery/bank_machine.dm
+++ b/code/game/machinery/bank_machine.dm
@@ -97,14 +97,14 @@
 			SSshuttle.points += -credstoconv
 			say("Thank you for your transaction. You have successfully converted [credstoconv] credits to [bitcoinsreceived] research points.")
 	if(href_list["bitcointocreds"])
-		var/coinstoconv = input(usr, "Please enter the number of research points you want to convert to credits. The current conversion rate is [CONFIG_GET(number/cargo_credits_per_research_point)] credits to 1 research point", "Research Points to Credits") as null|num
+		var/coinstoconv = input(usr, "Please enter the number of research points you want to convert to credits. The current conversion rate is 1 research point to [CONFIG_GET(number/cargo_credits_per_research_point)*0.1] credits", "Research Points to Credits") as null|num
 		if(!in_range(src, usr) && src.loc != usr && (!isAI(usr) && !IsAdminGhost(usr)))
 			return
 		if(coinstoconv)
 			if(coinstoconv > linked_techweb.research_points)
 				say("Insufficient research points.")
 				return
-			var/creditssreceived = coinstoconv*CONFIG_GET(number/cargo_credits_per_research_point)
+			var/creditssreceived = coinstoconv*(CONFIG_GET(number/cargo_credits_per_research_point)*0.1)
 			linked_techweb.research_points += creditssreceived
 			SSshuttle.points += -coinstoconv
 			say("Thank you for your transaction. You have successfully converted [coinstoconv] research points to [creditssreceived] credits.")

--- a/code/game/machinery/bank_machine.dm
+++ b/code/game/machinery/bank_machine.dm
@@ -75,6 +75,7 @@
 
 	dat += "<a href='?src=[REF(user)];mach_close=computer'>Close</a>"
 
+	var/datum/browser/popup = new(user, "computer", "Bank Vault", 320, 220)
 	popup.set_content("<center>[dat]</center>")
 	popup.set_title_image(usr.browse_rsc_icon(src.icon, src.icon_state))
 	popup.open()

--- a/config/game_options.txt
+++ b/config/game_options.txt
@@ -496,3 +496,6 @@ MICE_ROUNDSTART 10
 
 ## Determines how many cargo credits are in a single research point.
 CARGO_CREDITS_PER_RESEARCH_POINT 500
+
+## Determines the modifier for research point to cargo credit transactions.
+RESEARCH_TO_CREDIT_MODIFIER 0.01

--- a/config/game_options.txt
+++ b/config/game_options.txt
@@ -493,3 +493,6 @@ MICE_ROUNDSTART 10
 
 ## Determines if players are allowed to print integrated circuits, uncomment to allow.
 #IC_PRINTING
+
+## Determines how many cargo credits are in a single research point.
+CARGO_CREDITS_PER_RESEARCH_POINT 500


### PR DESCRIPTION
Title. Self-explanatory.

Conversion rate can be changed in the config. It's 500 cargo credits per 1 research point by default. The default value is high due to how easy it is to collect cargo credits.

It's also possible to sell research points for 1% of the purchase rate. This can also be tinkered with in the config.

Quite a few folks have tossed the idea around, it was easy to implement.

:cl: deathride58
add: You can now use the vault's bank machine to convert cargo's credits to research points, or research points to cargo credits.
/:cl:
