### PR TITLE
Improves loot drop spawners, adds AI law spawners to cores

### DIFF
--- a/_maps/map_files/BoxStation/BoxStation.dmm
+++ b/_maps/map_files/BoxStation/BoxStation.dmm
@@ -22225,7 +22225,8 @@
 	req_access_txt = "20"
 	},
 /obj/structure/window/reinforced,
-/obj/item/aiModule/core/full/corp,
+/obj/effect/spawner/lootdrop/aimodule_harmless,
+/obj/effect/spawner/lootdrop/aimodule_neutral,
 /obj/structure/window/reinforced{
 	dir = 1
 	},
@@ -22286,7 +22287,7 @@
 	},
 /obj/item/aiModule/reset/purge,
 /obj/structure/window/reinforced,
-/obj/item/aiModule/core/full/antimov,
+/obj/effect/spawner/lootdrop/aimodule_harmful,
 /obj/structure/window/reinforced{
 	dir = 1
 	},

--- a/_maps/map_files/Deltastation/DeltaStation2.dmm
+++ b/_maps/map_files/Deltastation/DeltaStation2.dmm
@@ -54238,15 +54238,7 @@
 	name = "Core Modules";
 	req_access_txt = "20"
 	},
-/obj/item/aiModule/core/full/paladin{
-	pixel_x = 3;
-	pixel_y = 3
-	},
-/obj/item/aiModule/core/full/asimov,
-/obj/item/aiModule/core/full/corp{
-	pixel_x = -3;
-	pixel_y = -3
-	},
+/obj/effect/spawner/lootdrop/aimodule_harmless/three,
 /obj/structure/sign/nanotrasen{
 	pixel_x = -32
 	},
@@ -54298,12 +54290,8 @@
 	name = "Core Modules";
 	req_access_txt = "20"
 	},
-/obj/item/aiModule/core/full/antimov{
-	pixel_x = 3;
-	pixel_y = 3
-	},
-/obj/item/aiModule/supplied/oxygen,
-/obj/item/aiModule/supplied/protectStation{
+/obj/effect/spawner/lootdrop/aimodule_harmful/two,
+/obj/item/aiModule/supplied/oxygen{
 	pixel_x = -3;
 	pixel_y = -3
 	},
@@ -55157,6 +55145,10 @@
 	pixel_y = 3
 	},
 /obj/item/aiModule/core/full/custom,
+/obj/item/aiModule/core/full/asimov{
+	pixel_x = -3;
+	pixel_y = -3
+	},
 /turf/open/floor/plasteel/vault{
 	dir = 8
 	},
@@ -55239,7 +55231,7 @@
 	req_access_txt = "20"
 	},
 /obj/structure/window/reinforced,
-/obj/item/aiModule/core/full/tyrant{
+/obj/item/aiModule/supplied/protectStation{
 	pixel_x = 3;
 	pixel_y = 3
 	},
@@ -57290,15 +57282,7 @@
 /area/ai_monitored/turret_protected/ai_upload)
 "clQ" = (
 /obj/structure/table/reinforced,
-/obj/item/aiModule/core/full/drone{
-	pixel_x = 3;
-	pixel_y = 3
-	},
-/obj/item/aiModule/core/full/reporter,
-/obj/item/aiModule/core/full/liveandletlive{
-	pixel_x = -3;
-	pixel_y = -3
-	},
+/obj/effect/spawner/lootdrop/aimodule_neutral/three,
 /turf/open/floor/plasteel/vault{
 	dir = 8
 	},

--- a/_maps/map_files/Deltastation/DeltaStation2.dmm
+++ b/_maps/map_files/Deltastation/DeltaStation2.dmm
@@ -54239,8 +54239,8 @@
 	req_access_txt = "20"
 	},
 /obj/effect/spawner/lootdrop/aimodule_harmless{
-	fan_out_items = 1,
-	lootdoubles = 0,
+	fan_out_items = 1;
+	lootdoubles = 0;
 	lootcount = 3
 	},
 /obj/structure/sign/nanotrasen{
@@ -54295,8 +54295,8 @@
 	req_access_txt = "20"
 	},
 /obj/effect/spawner/lootdrop/aimodule_harmful{
-	fan_out_items = 1,
-	lootdoubles = 0,
+	fan_out_items = 1;
+	lootdoubles = 0;
 	lootcount = 2
 	},
 /obj/item/aiModule/supplied/oxygen{
@@ -57291,8 +57291,8 @@
 "clQ" = (
 /obj/structure/table/reinforced,
 /obj/effect/spawner/lootdrop/aimodule_neutral{
-	fan_out_items = 1,
-	lootdoubles = 0,
+	fan_out_items = 1;
+	lootdoubles = 0;
 	lootcount = 3
 	},
 /turf/open/floor/plasteel/vault{

--- a/_maps/map_files/Deltastation/DeltaStation2.dmm
+++ b/_maps/map_files/Deltastation/DeltaStation2.dmm
@@ -54238,7 +54238,11 @@
 	name = "Core Modules";
 	req_access_txt = "20"
 	},
-/obj/effect/spawner/lootdrop/aimodule_harmless/three,
+/obj/effect/spawner/lootdrop/aimodule_harmless{
+	fan_out_items = 1,
+	lootdoubles = 0,
+	lootcount = 3
+	},
 /obj/structure/sign/nanotrasen{
 	pixel_x = -32
 	},
@@ -54290,7 +54294,11 @@
 	name = "Core Modules";
 	req_access_txt = "20"
 	},
-/obj/effect/spawner/lootdrop/aimodule_harmful/two,
+/obj/effect/spawner/lootdrop/aimodule_harmful{
+	fan_out_items = 1,
+	lootdoubles = 0,
+	lootcount = 2
+	},
 /obj/item/aiModule/supplied/oxygen{
 	pixel_x = -3;
 	pixel_y = -3
@@ -57282,7 +57290,11 @@
 /area/ai_monitored/turret_protected/ai_upload)
 "clQ" = (
 /obj/structure/table/reinforced,
-/obj/effect/spawner/lootdrop/aimodule_neutral/three,
+/obj/effect/spawner/lootdrop/aimodule_neutral{
+	fan_out_items = 1,
+	lootdoubles = 0,
+	lootcount = 3
+	},
 /turf/open/floor/plasteel/vault{
 	dir = 8
 	},

--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -18478,6 +18478,7 @@
 "aMG" = (
 /obj/structure/table,
 /obj/item/aiModule/core/full/asimov,
+/obj/effect/spawner/lootdrop/aimodule_harmless,
 /obj/item/aiModule/core/freeformcore,
 /obj/machinery/door/window{
 	base_state = "right";
@@ -18487,7 +18488,7 @@
 	req_access_txt = "20"
 	},
 /obj/structure/window/reinforced,
-/obj/item/aiModule/core/full/corp,
+/obj/effect/spawner/lootdrop/aimodule_neutral,
 /obj/item/aiModule/core/full/custom,
 /obj/machinery/flasher{
 	pixel_y = 24;
@@ -18512,7 +18513,7 @@
 	pixel_y = 24;
 	id = "AI"
 	},
-/obj/item/aiModule/core/full/antimov,
+/obj/effect/spawner/lootdrop/aimodule_harmful,
 /obj/item/aiModule/supplied/oxygen,
 /obj/item/aiModule/supplied/protectStation,
 /obj/item/aiModule/zeroth/oneHuman,

--- a/_maps/map_files/OmegaStation/OmegaStation.dmm
+++ b/_maps/map_files/OmegaStation/OmegaStation.dmm
@@ -2376,7 +2376,11 @@
 	name = "Core Modules";
 	req_access_txt = "20"
 	},
-/obj/effect/spawner/lootdrop/aimodule_harmless/three,
+/obj/effect/spawner/lootdrop/aimodule_harmless{
+	fan_out_items = 1,
+	lootdoubles = 0,
+	lootcount = 3
+	},
 /obj/structure/sign/nanotrasen{
 	pixel_x = -32
 	},
@@ -2491,7 +2495,11 @@
 	name = "Core Modules";
 	req_access_txt = "20"
 	},
-/obj/effect/spawner/lootdrop/aimodule_harmful/two,
+/obj/effect/spawner/lootdrop/aimodule_harmful{
+	fan_out_items = 1,
+	lootdoubles = 0,
+	lootcount = 2
+	},
 /obj/item/aiModule/supplied/oxygen{
 	pixel_x = -3;
 	pixel_y = -3
@@ -4353,7 +4361,11 @@
 /area/ai_monitored/turret_protected/ai)
 "ahV" = (
 /obj/structure/table/reinforced,
-/obj/effect/spawner/lootdrop/aimodule_neutral/three,
+/obj/effect/spawner/lootdrop/aimodule_neutral{
+	fan_out_items = 1,
+	lootdoubles = 0,
+	lootcount = 3
+	},
 /turf/open/floor/plasteel/vault{
 	dir = 8
 	},

--- a/_maps/map_files/OmegaStation/OmegaStation.dmm
+++ b/_maps/map_files/OmegaStation/OmegaStation.dmm
@@ -2377,8 +2377,8 @@
 	req_access_txt = "20"
 	},
 /obj/effect/spawner/lootdrop/aimodule_harmless{
-	fan_out_items = 1,
-	lootdoubles = 0,
+	fan_out_items = 1;
+	lootdoubles = 0;
 	lootcount = 3
 	},
 /obj/structure/sign/nanotrasen{
@@ -2496,8 +2496,8 @@
 	req_access_txt = "20"
 	},
 /obj/effect/spawner/lootdrop/aimodule_harmful{
-	fan_out_items = 1,
-	lootdoubles = 0,
+	fan_out_items = 1;
+	lootdoubles = 0;
 	lootcount = 2
 	},
 /obj/item/aiModule/supplied/oxygen{
@@ -4362,8 +4362,8 @@
 "ahV" = (
 /obj/structure/table/reinforced,
 /obj/effect/spawner/lootdrop/aimodule_neutral{
-	fan_out_items = 1,
-	lootdoubles = 0,
+	fan_out_items = 1;
+	lootdoubles = 0;
 	lootcount = 3
 	},
 /turf/open/floor/plasteel/vault{

--- a/_maps/map_files/OmegaStation/OmegaStation.dmm
+++ b/_maps/map_files/OmegaStation/OmegaStation.dmm
@@ -2376,15 +2376,7 @@
 	name = "Core Modules";
 	req_access_txt = "20"
 	},
-/obj/item/aiModule/core/full/paladin{
-	pixel_x = 3;
-	pixel_y = 3
-	},
-/obj/item/aiModule/core/full/asimov,
-/obj/item/aiModule/core/full/corp{
-	pixel_x = -3;
-	pixel_y = -3
-	},
+/obj/effect/spawner/lootdrop/aimodule_harmless/three,
 /obj/structure/sign/nanotrasen{
 	pixel_x = -32
 	},
@@ -2499,12 +2491,8 @@
 	name = "Core Modules";
 	req_access_txt = "20"
 	},
-/obj/item/aiModule/core/full/antimov{
-	pixel_x = 3;
-	pixel_y = 3
-	},
-/obj/item/aiModule/supplied/oxygen,
-/obj/item/aiModule/supplied/protectStation{
+/obj/effect/spawner/lootdrop/aimodule_harmful/two,
+/obj/item/aiModule/supplied/oxygen{
 	pixel_x = -3;
 	pixel_y = -3
 	},
@@ -2875,6 +2863,10 @@
 	pixel_y = 3
 	},
 /obj/item/aiModule/core/full/custom,
+/obj/item/aiModule/core/full/asimov{
+	pixel_x = -3;
+	pixel_y = -3
+	},
 /obj/machinery/camera{
 	c_tag = "AI Core - Port";
 	dir = 4;
@@ -2900,7 +2892,7 @@
 	req_access_txt = "20"
 	},
 /obj/structure/window/reinforced,
-/obj/item/aiModule/core/full/tyrant{
+/obj/item/aiModule/supplied/protectStation{
 	pixel_x = 3;
 	pixel_y = 3
 	},
@@ -4361,15 +4353,7 @@
 /area/ai_monitored/turret_protected/ai)
 "ahV" = (
 /obj/structure/table/reinforced,
-/obj/item/aiModule/core/full/drone{
-	pixel_x = 3;
-	pixel_y = 3
-	},
-/obj/item/aiModule/core/full/reporter,
-/obj/item/aiModule/core/full/liveandletlive{
-	pixel_x = -3;
-	pixel_y = -3
-	},
+/obj/effect/spawner/lootdrop/aimodule_neutral/three,
 /turf/open/floor/plasteel/vault{
 	dir = 8
 	},

--- a/_maps/map_files/PubbyStation/PubbyStation.dmm
+++ b/_maps/map_files/PubbyStation/PubbyStation.dmm
@@ -12139,6 +12139,7 @@
 "aED" = (
 /obj/structure/table,
 /obj/item/aiModule/core/full/asimov,
+/obj/effect/spawner/lootdrop/aimodule_harmless,
 /obj/item/aiModule/core/freeformcore,
 /obj/machinery/door/window{
 	base_state = "right";
@@ -12147,7 +12148,7 @@
 	name = "Core Modules";
 	req_access_txt = "20"
 	},
-/obj/item/aiModule/core/full/corp,
+/obj/effect/spawner/lootdrop/aimodule_neutral,
 /obj/item/aiModule/core/full/custom,
 /obj/structure/window/reinforced{
 	dir = 1;
@@ -12196,7 +12197,7 @@
 	req_access_txt = "20"
 	},
 /obj/item/aiModule/reset/purge,
-/obj/item/aiModule/core/full/antimov,
+/obj/effect/spawner/lootdrop/aimodule_harmful,
 /obj/item/aiModule/supplied/protectStation,
 /obj/structure/window/reinforced{
 	dir = 1;

--- a/code/game/objects/effects/spawners/lootdrop.dm
+++ b/code/game/objects/effects/spawners/lootdrop.dm
@@ -5,19 +5,29 @@
 	var/lootcount = 1		//how many items will be spawned
 	var/lootdoubles = TRUE	//if the same item can be spawned twice
 	var/list/loot			//a list of possible items to spawn e.g. list(/obj/item, /obj/structure, /obj/effect)
+	var/fan_out_items = FALSE //Whether the items should be distributed to offsets 0,3,-3,6,-6,9,-9.. This overrides pixel_x/y on the spawner itself
 
 /obj/effect/spawner/lootdrop/Initialize(mapload)
 	..()
 	if(loot && loot.len)
 		var/turf/T = get_turf(src)
-		while(lootcount && loot.len)
+		var/loot_spawned = 0
+		while((lootcount-loot_spawned) && loot.len)
 			var/lootspawn = pickweight(loot)
 			if(!lootdoubles)
 				loot.Remove(lootspawn)
 
 			if(lootspawn)
-				new lootspawn(T)
-			lootcount--
+				var/atom/movable/spawned_loot = new lootspawn(T)
+				if (!fan_out_items)
+					if (pixel_x != 0)
+						spawned_loot.pixel_x = pixel_x
+					if (pixel_y != 0)
+						spawned_loot.pixel_y = pixel_y
+				else
+					if (loot_spawned)
+						spawned_loot.pixel_x = spawned_loot.pixel_y = ((!(loot_spawned%2)*loot_spawned/2)*-3)+((loot_spawned%2)*(loot_spawned+1)/2*3)
+			loot_spawned++
 	return INITIALIZE_HINT_QDEL
 
 /obj/effect/spawner/lootdrop/armory_contraband
@@ -174,6 +184,16 @@
 				/obj/item/aiModule/core/full/paladin
 				)
 
+/obj/effect/spawner/lootdrop/aimodule_harmless/two
+	fan_out_items = TRUE
+	lootdoubles = FALSE
+	lootcount = 2
+
+/obj/effect/spawner/lootdrop/aimodule_harmless/three
+	fan_out_items = TRUE
+	lootdoubles = FALSE
+	lootcount = 3
+
 /obj/effect/spawner/lootdrop/aimodule_neutral // These shouldn't allow the AI to start butchering people without reason
 	name = "neutral AI module spawner"
 	loot = list(
@@ -186,6 +206,16 @@
 				/obj/item/aiModule/core/full/liveandletlive
 				)
 
+/obj/effect/spawner/lootdrop/aimodule_neutral/two
+	fan_out_items = TRUE
+	lootdoubles = FALSE
+	lootcount = 2
+
+/obj/effect/spawner/lootdrop/aimodule_neutral/three
+	fan_out_items = TRUE
+	lootdoubles = FALSE
+	lootcount = 3
+
 /obj/effect/spawner/lootdrop/aimodule_harmful // These will get the shuttle called
 	name = "harmful AI module spawner"
 	loot = list(
@@ -194,3 +224,13 @@
 				/obj/item/aiModule/core/full/tyrant,
 				/obj/item/aiModule/core/full/thermurderdynamic
 				)
+
+/obj/effect/spawner/lootdrop/aimodule_harmful/two
+	fan_out_items = TRUE
+	lootdoubles = FALSE
+	lootcount = 2
+
+/obj/effect/spawner/lootdrop/aimodule_harmful/three
+	fan_out_items = TRUE
+	lootdoubles = FALSE
+	lootcount = 3

--- a/code/game/objects/effects/spawners/lootdrop.dm
+++ b/code/game/objects/effects/spawners/lootdrop.dm
@@ -184,16 +184,6 @@
 				/obj/item/aiModule/core/full/paladin
 				)
 
-/obj/effect/spawner/lootdrop/aimodule_harmless/two
-	fan_out_items = TRUE
-	lootdoubles = FALSE
-	lootcount = 2
-
-/obj/effect/spawner/lootdrop/aimodule_harmless/three
-	fan_out_items = TRUE
-	lootdoubles = FALSE
-	lootcount = 3
-
 /obj/effect/spawner/lootdrop/aimodule_neutral // These shouldn't allow the AI to start butchering people without reason
 	name = "neutral AI module spawner"
 	loot = list(
@@ -206,16 +196,6 @@
 				/obj/item/aiModule/core/full/liveandletlive
 				)
 
-/obj/effect/spawner/lootdrop/aimodule_neutral/two
-	fan_out_items = TRUE
-	lootdoubles = FALSE
-	lootcount = 2
-
-/obj/effect/spawner/lootdrop/aimodule_neutral/three
-	fan_out_items = TRUE
-	lootdoubles = FALSE
-	lootcount = 3
-
 /obj/effect/spawner/lootdrop/aimodule_harmful // These will get the shuttle called
 	name = "harmful AI module spawner"
 	loot = list(
@@ -224,13 +204,3 @@
 				/obj/item/aiModule/core/full/tyrant,
 				/obj/item/aiModule/core/full/thermurderdynamic
 				)
-
-/obj/effect/spawner/lootdrop/aimodule_harmful/two
-	fan_out_items = TRUE
-	lootdoubles = FALSE
-	lootcount = 2
-
-/obj/effect/spawner/lootdrop/aimodule_harmful/three
-	fan_out_items = TRUE
-	lootdoubles = FALSE
-	lootcount = 3


### PR DESCRIPTION
@Okand37 @pubby @ShizCalev 

The map changelogs are kind of really spammy if i write them into the changelog proper, so here they are

delta & omega:
* replaced paladin and corp boards with a "harmless" 3 law spawner (may spawn a duplicate asimov in the core)
* moved asimov onto the same tile with default and freeform core modules (one tile down)
* replaced drone, reporter and liveandletlive with a "neutral" 3 law spawner
* replaced antimov and tyrant with a "harmful" 2 law spawner
* moved protectstation one tile down to chill with purge and onehuman

box, meta & pubby:
* replaced corp with a "neutral" spawner
* replaced antimov with a "harmful" spawner
* added a "harmless" spawner to the core modules "locker". This can be a duplicate asimov.

[Changelogs]: 

:cl: Naksu
code: loot drop spawners now assign their pixel offsets to the items they spawn, also have a "fanout" setting to distribute items in a neat fashion like in omega/delta's core and some tech storages.
tweak: replaced several law boards in uploads with spawners, the net result being one more board in uploads that may be a duplicate asimov (but hopefully isn't)
/:cl:
