### PR TITLE
Last resort now requires a confirmation.

### DIFF
--- a/code/game/gamemodes/changeling/powers/headcrab.dm
+++ b/code/game/gamemodes/changeling/powers/headcrab.dm
@@ -7,6 +7,9 @@
 	req_human = 1
 
 /obj/effect/proc_holder/changeling/headcrab/sting_action(mob/user)
+	switch(alert("Are we sure we wish to kill ourself and create a headcrab?",,"Yes", "No"))
+		if("No")
+			return
 	set waitfor = FALSE
 	var/datum/mind/M = user.mind
 	var/list/organs = user.getorganszone("head", 1)

--- a/code/game/gamemodes/changeling/powers/headcrab.dm
+++ b/code/game/gamemodes/changeling/powers/headcrab.dm
@@ -8,7 +8,7 @@
 
 /obj/effect/proc_holder/changeling/headcrab/sting_action(mob/user)
 	set waitfor = FALSE
-	if(alert("Are we sure we wish to kill ourself and create a headcrab?",,"Yes", "No") == "No")
+	if(alert("Are we sure we wish to kill ourself and create a headslug?",,"Yes", "No") == "No")
 		return
 	var/datum/mind/M = user.mind
 	var/list/organs = user.getorganszone("head", 1)

--- a/code/game/gamemodes/changeling/powers/headcrab.dm
+++ b/code/game/gamemodes/changeling/powers/headcrab.dm
@@ -8,9 +8,8 @@
 
 /obj/effect/proc_holder/changeling/headcrab/sting_action(mob/user)
 	set waitfor = FALSE
-	switch(alert("Are we sure we wish to kill ourself and create a headcrab?",,"Yes", "No"))
-		if("No")
-			return
+	if(alert("Are we sure we wish to kill ourself and create a headcrab?",,"Yes", "No") == "No")
+		return
 	var/datum/mind/M = user.mind
 	var/list/organs = user.getorganszone("head", 1)
 

--- a/code/game/gamemodes/changeling/powers/headcrab.dm
+++ b/code/game/gamemodes/changeling/powers/headcrab.dm
@@ -7,10 +7,11 @@
 	req_human = 1
 
 /obj/effect/proc_holder/changeling/headcrab/sting_action(mob/user)
+	set waitfor = FALSE
 	switch(alert("Are we sure we wish to kill ourself and create a headcrab?",,"Yes", "No"))
 		if("No")
+			set waitfor = TRUE
 			return
-	set waitfor = FALSE
 	var/datum/mind/M = user.mind
 	var/list/organs = user.getorganszone("head", 1)
 

--- a/code/game/gamemodes/changeling/powers/headcrab.dm
+++ b/code/game/gamemodes/changeling/powers/headcrab.dm
@@ -10,7 +10,6 @@
 	set waitfor = FALSE
 	switch(alert("Are we sure we wish to kill ourself and create a headcrab?",,"Yes", "No"))
 		if("No")
-			set waitfor = TRUE
 			return
 	var/datum/mind/M = user.mind
 	var/list/organs = user.getorganszone("head", 1)


### PR DESCRIPTION
[Changelogs]: 
:cl: optional name here
fix: Last resort now requires a confirmation
/:cl:

[why]: Because something possibly round-ending shouldn't be one bad click away.