### PR TITLE
Makes it clear that command reports are IC.

### DIFF
--- a/code/modules/admin/verbs/randomverbs.dm
+++ b/code/modules/admin/verbs/randomverbs.dm
@@ -472,7 +472,7 @@ Traitors and the like can also be revived with the previous role mostly intact.
 	if(!holder)
 		to_chat(src, "Only administrators may use this command.")
 		return
-	var/input = input(usr, "Please enter anything you want. Anything. Serious.", "What?", "") as message|null
+	var/input = input(usr, "Please enter the contents of the Centcomm report. Remember that this is an IC report and should be worded as such.", "What?", "") as message|null
 	if(!input)
 		return
 

--- a/code/modules/admin/verbs/randomverbs.dm
+++ b/code/modules/admin/verbs/randomverbs.dm
@@ -472,7 +472,7 @@ Traitors and the like can also be revived with the previous role mostly intact.
 	if(!holder)
 		to_chat(src, "Only administrators may use this command.")
 		return
-	var/input = input(usr, "Please enter the contents of the Centcomm report. Remember that this is an IC report and should be worded as such.", "What?", "") as message|null
+	var/input = input(usr, "Enter a Command Report. Ensure it makes sense IC.", "What?", "") as message|null
 	if(!input)
 		return
 


### PR DESCRIPTION
Closes #33936

Why: Those who have access to the admin forum will understand this. The tldr is that admins are using the report as an OOC announcement to banter with the crew, mock them for losing, or just shitpost on the round behind the veil of Centcomm when such comments should be saved for OOC post round. The text that I removed gave candidates the wrong impression- No, you cannot write literally anything. There are limits and at bare minimum it should be kept IC.