### PR TITLE
Implements time delay on rejoining game with ghost roles

### DIFF
--- a/code/__DEFINES/mobs.dm
+++ b/code/__DEFINES/mobs.dm
@@ -186,3 +186,5 @@
 #define OFFSET_BACK "back"
 #define OFFSET_SUIT "suit"
 #define OFFSET_NECK "neck"
+
+#define DEFAULT_RESPAWN_TIME (5 MINUTES)

--- a/code/modules/awaymissions/corpse.dm
+++ b/code/modules/awaymissions/corpse.dm
@@ -27,7 +27,7 @@
 	var/show_flavour = TRUE
 	var/banType = "lavaland"
 
-/obj/effect/mob_spawn/attack_ghost(mob/user)
+/obj/effect/mob_spawn/attack_ghost(mob/dead/observer/user)
 	if(!SSticker.HasRoundStarted() || !loc)
 		return
 	if(!uses)
@@ -35,6 +35,8 @@
 		return
 	if(jobban_isbanned(user, banType))
 		to_chat(user, "<span class='warning'>You are jobanned!</span>")
+		return
+	if(!user.respawn_check(mob_name, DEFAULT_RESPAWN_TIME))
 		return
 	var/ghost_role = alert("Become [mob_name]? (Warning, You can no longer be cloned!)",,"Yes","No")
 	if(ghost_role == "No" || !loc)

--- a/code/modules/mob/dead/observer/observer.dm
+++ b/code/modules/mob/dead/observer/observer.dm
@@ -75,10 +75,15 @@ GLOBAL_VAR_INIT(observer_default_invisibility, INVISIBILITY_OBSERVER)
 	updateallghostimages()
 
 	var/turf/T
+
+	timeofdeath = world.time
+
 	var/mob/body = loc
 	if(ismob(body))
 		T = get_turf(body)				//Where is the body located?
 		logging = body.logging			//preserve our logs by copying them to our ghost
+
+		timeofdeath = body.timeofdeath
 
 		gender = body.gender
 		if(body.mind && body.mind.name)
@@ -826,3 +831,20 @@ This is the proc mobs get to turn into a ghost. Forked from ghostize due to comp
 		spawners_menu = new(src)
 
 	spawners_menu.ui_interact(src)
+
+/mob/dead/observer/proc/respawn_check(var/thing = "cancer rat", var/respawn_time = 2 MINUTES, feedback = TRUE)
+	if(!client)
+		return FALSE
+	if(mind && mind.current && mind.current.stat != DEAD && can_reenter_corpse)
+		if(feedback)
+			to_chat(src, "<span class='warning'>Your non-dead body prevents you from respawning as \a [thing].</span>")
+		return FALSE
+
+	var/timedifference = world.time - timeofdeath
+	if(respawn_time && timeofdeath && timedifference < respawn_time MINUTES)
+		var/timedifference_text = time2text(respawn_time - timedifference, "mm:ss")
+		if(feedback)
+			to_chat(src, "<span class='warning'>You must have been dead for [respawn_time / (1 MINUTES)] minute\s to respawn as [thing]. You have [timedifference_text] left.</span>")
+		return FALSE
+
+	return FALSE

--- a/code/modules/mob/dead/observer/observer.dm
+++ b/code/modules/mob/dead/observer/observer.dm
@@ -841,10 +841,10 @@ This is the proc mobs get to turn into a ghost. Forked from ghostize due to comp
 		return FALSE
 
 	var/timedifference = world.time - timeofdeath
-	if(respawn_time && timeofdeath && timedifference < respawn_time MINUTES)
+	if(respawn_time && timeofdeath && timedifference < respawn_time)
 		var/timedifference_text = time2text(respawn_time - timedifference, "mm:ss")
 		if(feedback)
 			to_chat(src, "<span class='warning'>You must have been dead for [respawn_time / (1 MINUTES)] minute\s to respawn as [thing]. You have [timedifference_text] left.</span>")
 		return FALSE
 
-	return FALSE
+	return TRUE

--- a/code/modules/mob/living/brain/posibrain.dm
+++ b/code/modules/mob/living/brain/posibrain.dm
@@ -80,10 +80,13 @@ GLOBAL_VAR(posibrain_notify_cooldown)
 	return FALSE
 
 //Two ways to activate a positronic brain. A clickable link in the ghost notif, or simply clicking the object itself.
-/obj/item/device/mmi/posibrain/proc/activate(mob/user)
+/obj/item/device/mmi/posibrain/proc/activate(mob/dead/observer/user)
 	if(QDELETED(brainmob))
 		return
 	if(is_occupied() || jobban_isbanned(user,"posibrain"))
+		return
+
+	if(!user.respawn_check(name, DEFAULT_RESPAWN_TIME))
 		return
 
 	var/posi_ask = alert("Become a [name]? (Warning, You can no longer be cloned, and all past lives will be forgotten!)","Are you positive?","Yes","No")

--- a/code/modules/mob/living/simple_animal/friendly/drone/drones_as_items.dm
+++ b/code/modules/mob/living/simple_animal/friendly/drone/drones_as_items.dm
@@ -11,7 +11,7 @@
 	desc = "A shell of a maintenance drone, an expendable robot built to perform station repairs."
 	icon = 'icons/mob/drone.dmi'
 	icon_state = "drone_maint_hat"//yes reuse the _hat state.
-	var/drone_type = /mob/living/simple_animal/drone //Type of drone that will be spawned
+	var/mob/living/simple_animal/drone/drone_type = /mob/living/simple_animal/drone //Type of drone that will be spawned
 	var/seasonal_hats = TRUE //If TRUE, and there are no default hats, different holidays will grant different hats
 	var/static/list/possible_seasonal_hats //This is built automatically in build_seasonal_hats() but can also be edited by admins!
 
@@ -37,7 +37,7 @@
 	GLOB.poi_list -= src
 	. = ..()
 
-/obj/item/drone_shell/attack_ghost(mob/user)
+/obj/item/drone_shell/attack_ghost(mob/dead/observer/user)
 	if(jobban_isbanned(user,"drone"))
 		return
 	if(CONFIG_GET(flag/use_age_restriction_for_jobs))
@@ -49,6 +49,9 @@
 	if(!SSticker.mode)
 		to_chat(user, "Can't become a drone before the game has started.")
 		return
+	if(!user.respawn_check("a drone", DEFAULT_RESPAWN_TIME))
+		return
+
 	var/be_drone = alert("Become a drone? (Warning, You can no longer be cloned!)",,"Yes","No")
 	if(be_drone == "No" || QDELETED(src) || !isobserver(user))
 		return


### PR DESCRIPTION
:cl:
del: Most ghost roles require you to have been dead for five minutes
before it's possible to rejoin the game. Please remember that when you
join as a ghost role, you have no memory of previous lives, even with
the same ghost role.
/:cl:

- Affects drones, swarmers, free golems, anything using the mob_spawn
effect.
- Does not affect any signups for events, or anything that uses a
"popup" window.
- Does not affect CTF.
- Does effect observers that have never died, if you lack a body, your
"timeofdeath" is when your ghost was created.

I am a big advocate for ghost roles, and I'm well aware that many people
just like observing at round start and playing drone or free golem. This
PR is not aimed at them.

Ghost roles are NOT a "free respawn" for you to pop into a new body and
immediately continue whatever you were doing before you died. You should
not (and now cannot) respawn as a drone constantly every time you are
killed, you should not become a wave of golems attacking the cult base
that all suddenly know exactly where the cult base is and feel very
strongly about killing cultists.

Behaviour like this gives people who actually enjoy ghost roles on their
own merits a bad name.

This change will allow some subsequent changes that I'd like to
implement that would probably be disallowed if instant ghost role
respawning was still present.