### PR TITLE
Text hallucinations use the victim's name more often

### DIFF
--- a/code/modules/flufftext/Hallucination.dm
+++ b/code/modules/flufftext/Hallucination.dm
@@ -736,6 +736,7 @@ GLOBAL_LIST_INIT(hallucinations_major, list(
 
 /datum/hallucination/whispers/New(mob/living/carbon/T, forced = TRUE)
 	..()
+	var/target_name = target.first_name()
 	var/speak_messages = list("[pick_list_replacements(HAL_LINES_FILE, "suspicion")]",\
 	"[pick_list_replacements(HAL_LINES_FILE, "greetings")][target.first_name()]!",\
 	"[pick_list_replacements(HAL_LINES_FILE, "getout")]",\
@@ -769,8 +770,10 @@ GLOBAL_LIST_INIT(hallucinations_major, list(
 				person = H
 		people += H
 	if(person) //Basic talk
+		var/chosen = pick(speak_messages)
+		chosen = replacetext(chosen, "%TARGETNAME%", target_name)
 		var/image/speech_overlay = image('icons/mob/talk.dmi', person, "default0", layer = ABOVE_MOB_LAYER)
-		var/message = target.compose_message(person,understood_language,pick(speak_messages),null,person.get_spans(),face_name = TRUE)
+		var/message = target.compose_message(person,understood_language,chosen,null,person.get_spans(),face_name = TRUE)
 		feedback_details += "Type: Talk, Source: [person.real_name], Message: [message]"
 		to_chat(target, message)
 		if(target.client)
@@ -778,11 +781,13 @@ GLOBAL_LIST_INIT(hallucinations_major, list(
 			sleep(30)
 			target.client.images.Remove(speech_overlay)
 	else // Radio talk
+		var/chosen = pick(radio_messages)
+		chosen = replacetext(chosen, "%TARGETNAME%", target_name)
 		var/list/humans = list()
 		for(var/mob/living/carbon/human/H in GLOB.alive_mob_list)
 			humans += H
 		person = pick(humans)
-		var/message = target.compose_message(person,understood_language,pick(radio_messages),"[FREQ_COMMON]",person.get_spans(),face_name = TRUE)
+		var/message = target.compose_message(person,understood_language,chosen,"[FREQ_COMMON]",person.get_spans(),face_name = TRUE)
 		feedback_details += "Type: Radio, Source: [person.real_name], Message: [message]"
 		to_chat(target, message)
 	qdel(src)

--- a/strings/hallucination.json
+++ b/strings/hallucination.json
@@ -1,8 +1,8 @@
 {
 	"suspicion": [
-		"I'm watching you...",
-		"I know what you're doing",
-		"What are you hiding?",
+		"@pick(add_name)i'm watching you...",
+		"@pick(add_name)i know what you're doing",
+		"@pick(add_name)what are you hiding?",
 		"I saw that"
 	],
 
@@ -16,12 +16,12 @@
 	],
 
 	"getout": [
-		"Get out",
-		"Get out!",
-		"Go away",
-		"Fuck off",
+		"@pick(add_name)get out",
+		"@pick(add_name)get out!",
+		"@pick(add_name)go away",
+		"@pick(add_name)fuck off",
 		"OUT!",
-		"Out!"
+		"@pick(add_name)out!"
 	],
 
 	"weird": [
@@ -43,10 +43,10 @@
 	"imatraitor": [
 		"Hail Ratvar",
 		"Hail Nar'Sie",
-		"Hey, i've got some TC left, want something?",
+		"Hey, @pick(add_name)i've got some TC left, want something?",
 		"Viva!",
 		"I'll spare you if you don't tell anybody about me",
-		"Hey, are you a traitor too?",
+		"Hey, @pick(add_name)are you a traitor too?",
 		"You're my target, but @pick(excuses)",
 		"Are you mr. @pick(ling_names)?"
 	],
@@ -79,19 +79,24 @@
 		"Omega"
 	],
 
+	"add_name": [
+		"%TARGETNAME%, ",
+		""
+	],
+
 	"doubt": [
 		"Why?",
 		"What?",
 		"Wait, what?",
-		"Wait",
-		"Hold on",
+		"@pick(add_name)wait",
+		"@pick(add_name)hold on",
 		"Uh..."
 	],
 
 	"aggressive": [
-		"Give me that!",
-		"I'm going to kill you!",
-		"Fuck you!"
+		"@pick(add_name)give me that!",
+		"@pick(add_name)i'm going to kill you!",
+		"@pick(add_name)fuck you!"
 	],
 
 	"help": [
@@ -105,19 +110,19 @@
 	],
 
 	"escape": [
-		"RUN!!",
+		"@pick(add_name)RUN!!",
 		"They're behind me!",
 		"It's here!",
-		"Follow me!",
-		"Follow me"
+		"@pick(add_name)follow me!",
+		"@pick(add_name)follow me"
 	],
 
 	"infection_advice": [
-		"stay away",
-		"don't get close",
-		"be careful",
-		"help me",
-		"kill me"
+		"@pick(add_name)stay away",
+		"@pick(add_name)don't get close",
+		"@pick(add_name)be careful",
+		"@pick(add_name)help me",
+		"@pick(add_name)kill me"
 	],
 
 	"people": [
@@ -131,7 +136,7 @@
 		"AI",
 		"Viro",
 		"Qm",
-		"[target.first_name()]"
+		"%TARGETNAME%"
 	],
 
 	"accusations": [
@@ -161,7 +166,8 @@
 		"Traitor",
 		"Harm",
 		"I hear flashing",
-		"Help"
+		"Help",
+		"%TARGETNAME%"
 	],
 
 	"location": [


### PR DESCRIPTION
:cl: XDTM
fix: Fixed a hallucination that would say [target.first_name()] instead of the actual name.
/:cl:

Fixes #33952

Thanks to Remie for the string replacement method.

Now many text hallucinations have a 50% chance of prefacing the target name, making them more believable.
