### PR TITLE
Redesigns the syndicate lavaland base.

### DIFF
--- a/_maps/RandomRuins/LavaRuins/lavaland_surface_syndicate_base1.dmm
+++ b/_maps/RandomRuins/LavaRuins/lavaland_surface_syndicate_base1.dmm
@@ -274,7 +274,7 @@
 "dL" = (
 /obj/machinery/airalarm{
 	pixel_y = 24;
-	req_access = 152
+	req_access = 150
 	},
 /obj/structure/closet/crate,
 /obj/item/extinguisher{
@@ -432,7 +432,7 @@
 	dir = 8;
 	icon_state = "alarm0";
 	pixel_x = 24;
-	req_access = 152
+	req_access = 150
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/white/side{
@@ -747,7 +747,6 @@
 /area/ruin/unpowered/syndicate_lava_base/chemistry)
 "ex" = (
 /obj/machinery/light/small{
-	brightness = 3;
 	dir = 8
 	},
 /obj/machinery/firealarm{
@@ -1534,12 +1533,11 @@
 /obj/effect/turf_decal/bot,
 /obj/structure/closet/l3closet,
 /obj/machinery/light/small{
-	brightness = 3;
 	dir = 8
 	},
 /obj/machinery/airalarm{
 	pixel_y = 24;
-	req_access = 152
+	req_access = 150
 	},
 /turf/open/floor/plasteel/floorgrime,
 /area/ruin/unpowered/syndicate_lava_base/main)
@@ -2559,7 +2557,7 @@
 /obj/item/ammo_box/magazine/sniper_rounds,
 /obj/machinery/airalarm{
 	pixel_y = 24;
-	req_access = 152
+	req_access = 150
 	},
 /turf/open/floor/plasteel/grimy,
 /area/ruin/unpowered/syndicate_lava_base/dormitories)
@@ -2579,7 +2577,6 @@
 /area/ruin/unpowered/syndicate_lava_base/dormitories)
 "hP" = (
 /obj/machinery/light/small{
-	brightness = 3;
 	dir = 8
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
@@ -2594,7 +2591,7 @@
 /obj/item/ammo_box/magazine/m10mm,
 /obj/machinery/airalarm{
 	pixel_y = 24;
-	req_access = 152
+	req_access = 150
 	},
 /turf/open/floor/plasteel/grimy,
 /area/ruin/unpowered/syndicate_lava_base/dormitories)
@@ -2919,7 +2916,7 @@
 "iB" = (
 /obj/machinery/airalarm{
 	pixel_y = 24;
-	req_access = 152
+	req_access = 150
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on,
 /obj/effect/decal/cleanable/dirt,
@@ -3011,7 +3008,7 @@
 	dir = 8;
 	icon_state = "alarm0";
 	pixel_x = 24;
-	req_access = 152
+	req_access = 150
 	},
 /turf/open/floor/circuit/red,
 /area/ruin/unpowered/syndicate_lava_base/main)
@@ -3352,7 +3349,7 @@
 	},
 /obj/machinery/airalarm{
 	pixel_y = 24;
-	req_access = 152
+	req_access = 150
 	},
 /turf/open/floor/plasteel/grimy,
 /area/ruin/unpowered/syndicate_lava_base/dormitories)
@@ -3390,7 +3387,7 @@
 	},
 /obj/machinery/airalarm{
 	pixel_y = 24;
-	req_access = 152
+	req_access = 150
 	},
 /turf/open/floor/plasteel/grimy,
 /area/ruin/unpowered/syndicate_lava_base/dormitories)
@@ -3486,7 +3483,6 @@
 /area/ruin/unpowered/syndicate_lava_base/dormitories)
 "jC" = (
 /obj/machinery/light/small{
-	brightness = 3;
 	dir = 8
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
@@ -3601,7 +3597,7 @@
 	dir = 8;
 	icon_state = "alarm0";
 	pixel_x = 24;
-	req_access = 152
+	req_access = 150
 	},
 /obj/structure/cable/yellow{
 	d1 = 2;
@@ -3700,7 +3696,6 @@
 /area/ruin/unpowered/syndicate_lava_base/main)
 "jR" = (
 /obj/machinery/light/small{
-	brightness = 3;
 	dir = 8
 	},
 /turf/open/floor/plasteel/red/corner{
@@ -4022,7 +4017,7 @@
 	dir = 8;
 	icon_state = "alarm0";
 	pixel_x = 24;
-	req_access = 152
+	req_access = 150
 	},
 /obj/machinery/vending/coffee{
 	extended_inventory = 1
@@ -4970,7 +4965,7 @@
 	dir = 8;
 	icon_state = "alarm0";
 	pixel_x = 24;
-	req_access = 152
+	req_access = 150
 	},
 /turf/open/floor/plasteel/floorgrime,
 /area/ruin/unpowered/syndicate_lava_base/medbay)
@@ -5296,7 +5291,7 @@
 /obj/structure/sign/barsign{
 	pixel_y = -32;
 	req_access = null;
-	req_access_txt = "150"
+	req_access_txt = "0"
 	},
 /turf/open/floor/wood,
 /area/ruin/unpowered/syndicate_lava_base/bar)
@@ -5432,7 +5427,6 @@
 	use_power = 0
 	},
 /obj/machinery/light/small{
-	brightness = 3;
 	dir = 8
 	},
 /turf/open/floor/plasteel/vault{
@@ -5765,7 +5759,6 @@
 	req_access = 150
 	},
 /obj/machinery/light/small{
-	brightness = 3;
 	dir = 8
 	},
 /turf/open/floor/plasteel/vault{
@@ -5997,7 +5990,7 @@
 	},
 /obj/machinery/airalarm{
 	pixel_y = 24;
-	req_access = 152
+	req_access = 150
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -6398,7 +6391,6 @@
 	pixel_x = -32
 	},
 /obj/machinery/light/small{
-	brightness = 3;
 	dir = 8
 	},
 /turf/open/floor/plating,

--- a/_maps/RandomRuins/LavaRuins/lavaland_surface_syndicate_base1.dmm
+++ b/_maps/RandomRuins/LavaRuins/lavaland_surface_syndicate_base1.dmm
@@ -32,16 +32,16 @@
 	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel/white,
-/area/ruin/syndicate_lava_base/virology)
+/area/ruin/unpowered/syndicate_lava_base/virology)
 "ae" = (
 /turf/closed/wall/mineral/plastitanium/nodiagonal,
-/area/ruin/syndicate_lava_base/testlab)
+/area/ruin/unpowered/syndicate_lava_base/testlab)
 "af" = (
 /obj/machinery/light/small{
 	dir = 4
 	},
 /turf/open/floor/plasteel/floorgrime,
-/area/ruin/syndicate_lava_base/main)
+/area/ruin/unpowered/syndicate_lava_base/main)
 "ag" = (
 /obj/machinery/airalarm{
 	dir = 4;
@@ -52,19 +52,19 @@
 /turf/open/floor/plasteel/red/side{
 	dir = 8
 	},
-/area/ruin/syndicate_lava_base/main)
+/area/ruin/unpowered/syndicate_lava_base/main)
 "ap" = (
 /obj/machinery/light/small{
 	dir = 1
 	},
 /turf/open/floor/engine,
-/area/ruin/syndicate_lava_base/testlab)
+/area/ruin/unpowered/syndicate_lava_base/testlab)
 "aq" = (
 /turf/open/floor/engine,
-/area/ruin/syndicate_lava_base/testlab)
+/area/ruin/unpowered/syndicate_lava_base/testlab)
 "as" = (
 /turf/closed/wall/mineral/plastitanium/nodiagonal,
-/area/ruin/syndicate_lava_base/chemistry)
+/area/ruin/unpowered/syndicate_lava_base/chemistry)
 "at" = (
 /obj/structure/grille,
 /obj/structure/window/plastitanium,
@@ -73,10 +73,10 @@
 	layer = 2.9
 	},
 /turf/open/floor/plating,
-/area/ruin/syndicate_lava_base/chemistry)
+/area/ruin/unpowered/syndicate_lava_base/chemistry)
 "aL" = (
 /turf/closed/wall/mineral/plastitanium/explosive,
-/area/ruin/syndicate_lava_base/testlab)
+/area/ruin/unpowered/syndicate_lava_base/testlab)
 "aM" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -85,13 +85,13 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel,
-/area/ruin/syndicate_lava_base/chemistry)
+/area/ruin/unpowered/syndicate_lava_base/chemistry)
 "cA" = (
 /obj/structure/table/reinforced,
 /obj/item/book/manual/wiki/chemistry,
 /obj/item/book/manual/wiki/chemistry,
 /turf/open/floor/plasteel/floorgrime,
-/area/ruin/syndicate_lava_base/chemistry)
+/area/ruin/unpowered/syndicate_lava_base/chemistry)
 "cG" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -99,22 +99,22 @@
 /obj/machinery/chem_master,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/floorgrime,
-/area/ruin/syndicate_lava_base/chemistry)
+/area/ruin/unpowered/syndicate_lava_base/chemistry)
 "cO" = (
 /turf/closed/wall/mineral/plastitanium/explosive,
-/area/ruin/syndicate_lava_base/chemistry)
+/area/ruin/unpowered/syndicate_lava_base/chemistry)
 "dc" = (
 /obj/machinery/light/small{
 	dir = 8
 	},
 /turf/open/floor/engine,
-/area/ruin/syndicate_lava_base/testlab)
+/area/ruin/unpowered/syndicate_lava_base/testlab)
 "di" = (
 /obj/machinery/light/small{
 	dir = 4
 	},
 /turf/open/floor/engine,
-/area/ruin/syndicate_lava_base/testlab)
+/area/ruin/unpowered/syndicate_lava_base/testlab)
 "do" = (
 /obj/structure/closet/secure_closet/medical1{
 	req_access = null;
@@ -124,7 +124,7 @@
 /turf/open/floor/plasteel/white/side{
 	dir = 9
 	},
-/area/ruin/syndicate_lava_base/chemistry)
+/area/ruin/unpowered/syndicate_lava_base/chemistry)
 "du" = (
 /obj/machinery/light/small{
 	dir = 1
@@ -140,7 +140,7 @@
 /turf/open/floor/plasteel/white/side{
 	dir = 1
 	},
-/area/ruin/syndicate_lava_base/chemistry)
+/area/ruin/unpowered/syndicate_lava_base/chemistry)
 "dv" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 10
@@ -148,7 +148,7 @@
 /obj/machinery/chem_heater,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel,
-/area/ruin/syndicate_lava_base/chemistry)
+/area/ruin/unpowered/syndicate_lava_base/chemistry)
 "dw" = (
 /obj/structure/chair/office/light{
 	dir = 1
@@ -156,17 +156,17 @@
 /obj/effect/turf_decal/bot,
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plasteel,
-/area/ruin/syndicate_lava_base/chemistry)
+/area/ruin/unpowered/syndicate_lava_base/chemistry)
 "dx" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 6
 	},
 /obj/structure/closet/crate/bin,
 /turf/open/floor/plasteel/floorgrime,
-/area/ruin/syndicate_lava_base/chemistry)
+/area/ruin/unpowered/syndicate_lava_base/chemistry)
 "dy" = (
 /turf/closed/wall/mineral/plastitanium/nodiagonal,
-/area/ruin/syndicate_lava_base/cargo)
+/area/ruin/unpowered/syndicate_lava_base/cargo)
 "dA" = (
 /obj/structure/closet/l3closet,
 /obj/machinery/power/apc{
@@ -190,7 +190,7 @@
 /turf/open/floor/plasteel/white/side{
 	dir = 8
 	},
-/area/ruin/syndicate_lava_base/chemistry)
+/area/ruin/unpowered/syndicate_lava_base/chemistry)
 "dB" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 8;
@@ -199,14 +199,14 @@
 	pixel_y = 5
 	},
 /turf/open/floor/plasteel,
-/area/ruin/syndicate_lava_base/chemistry)
+/area/ruin/unpowered/syndicate_lava_base/chemistry)
 "dC" = (
 /turf/open/floor/plasteel/floorgrime,
-/area/ruin/syndicate_lava_base/chemistry)
+/area/ruin/unpowered/syndicate_lava_base/chemistry)
 "dD" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel,
-/area/ruin/syndicate_lava_base/chemistry)
+/area/ruin/unpowered/syndicate_lava_base/chemistry)
 "dE" = (
 /obj/structure/table/glass,
 /obj/item/stack/sheet/mineral/plasma{
@@ -232,7 +232,7 @@
 /turf/open/floor/plasteel/white/corner{
 	dir = 4
 	},
-/area/ruin/syndicate_lava_base/chemistry)
+/area/ruin/unpowered/syndicate_lava_base/chemistry)
 "dG" = (
 /obj/structure/lattice/catwalk,
 /turf/open/lava/smooth/lava_land_surface,
@@ -246,7 +246,7 @@
 /turf/open/floor/plasteel/white/side{
 	dir = 5
 	},
-/area/ruin/syndicate_lava_base/chemistry)
+/area/ruin/unpowered/syndicate_lava_base/chemistry)
 "dK" = (
 /obj/effect/turf_decal/box/white/corners{
 	icon_state = "box_corners_white";
@@ -270,7 +270,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/dark,
-/area/ruin/syndicate_lava_base/cargo)
+/area/ruin/unpowered/syndicate_lava_base/cargo)
 "dL" = (
 /obj/machinery/airalarm{
 	pixel_y = 24;
@@ -312,7 +312,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/dark,
-/area/ruin/syndicate_lava_base/cargo)
+/area/ruin/unpowered/syndicate_lava_base/cargo)
 "dM" = (
 /obj/effect/turf_decal/box/white/corners{
 	icon_state = "box_corners_white";
@@ -332,14 +332,14 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/dark,
-/area/ruin/syndicate_lava_base/cargo)
+/area/ruin/unpowered/syndicate_lava_base/cargo)
 "dP" = (
 /turf/closed/wall/mineral/plastitanium/explosive,
-/area/ruin/syndicate_lava_base/cargo)
+/area/ruin/unpowered/syndicate_lava_base/cargo)
 "dQ" = (
 /obj/structure/sign/securearea,
 /turf/closed/wall/mineral/plastitanium/nodiagonal,
-/area/ruin/syndicate_lava_base/testlab)
+/area/ruin/unpowered/syndicate_lava_base/testlab)
 "dR" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/hatch{
@@ -355,7 +355,7 @@
 /turf/open/floor/plasteel/vault{
 	dir = 8
 	},
-/area/ruin/syndicate_lava_base/testlab)
+/area/ruin/unpowered/syndicate_lava_base/testlab)
 "dS" = (
 /obj/structure/grille,
 /obj/structure/window/plastitanium,
@@ -366,7 +366,7 @@
 	name = "Syndicate Research Experimentation Shutters"
 	},
 /turf/open/floor/plating,
-/area/ruin/syndicate_lava_base/testlab)
+/area/ruin/unpowered/syndicate_lava_base/testlab)
 "dT" = (
 /obj/machinery/firealarm{
 	dir = 8;
@@ -389,32 +389,32 @@
 /turf/open/floor/plasteel/white/side{
 	dir = 8
 	},
-/area/ruin/syndicate_lava_base/chemistry)
+/area/ruin/unpowered/syndicate_lava_base/chemistry)
 "dU" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel,
-/area/ruin/syndicate_lava_base/chemistry)
+/area/ruin/unpowered/syndicate_lava_base/chemistry)
 "dV" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
-/area/ruin/syndicate_lava_base/chemistry)
+/area/ruin/unpowered/syndicate_lava_base/chemistry)
 "dX" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
-/area/ruin/syndicate_lava_base/chemistry)
+/area/ruin/unpowered/syndicate_lava_base/chemistry)
 "dY" = (
 /obj/structure/chair{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
-/area/ruin/syndicate_lava_base/chemistry)
+/area/ruin/unpowered/syndicate_lava_base/chemistry)
 "dZ" = (
 /obj/machinery/light/small{
 	dir = 4
@@ -438,7 +438,7 @@
 /turf/open/floor/plasteel/white/side{
 	dir = 4
 	},
-/area/ruin/syndicate_lava_base/chemistry)
+/area/ruin/unpowered/syndicate_lava_base/chemistry)
 "ea" = (
 /obj/effect/turf_decal/box/white/corners{
 	icon_state = "box_corners_white";
@@ -470,7 +470,7 @@
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on,
 /turf/open/floor/plasteel/dark,
-/area/ruin/syndicate_lava_base/cargo)
+/area/ruin/unpowered/syndicate_lava_base/cargo)
 "eb" = (
 /obj/structure/closet/crate,
 /obj/item/storage/box/monkeycubes{
@@ -483,7 +483,7 @@
 	},
 /obj/item/storage/toolbox/mechanical,
 /turf/open/floor/plasteel/dark,
-/area/ruin/syndicate_lava_base/cargo)
+/area/ruin/unpowered/syndicate_lava_base/cargo)
 "ec" = (
 /obj/effect/turf_decal/box/white/corners,
 /obj/structure/closet/crate/medical,
@@ -497,7 +497,7 @@
 	pixel_y = -3
 	},
 /turf/open/floor/plasteel/dark,
-/area/ruin/syndicate_lava_base/cargo)
+/area/ruin/unpowered/syndicate_lava_base/cargo)
 "ed" = (
 /obj/structure/table,
 /obj/item/paper_bin,
@@ -507,7 +507,7 @@
 /turf/open/floor/plasteel/vault{
 	dir = 5
 	},
-/area/ruin/syndicate_lava_base/cargo)
+/area/ruin/unpowered/syndicate_lava_base/cargo)
 "ee" = (
 /obj/structure/rack,
 /obj/item/device/flashlight{
@@ -519,7 +519,7 @@
 /turf/open/floor/plasteel/brown{
 	dir = 1
 	},
-/area/ruin/syndicate_lava_base/cargo)
+/area/ruin/unpowered/syndicate_lava_base/cargo)
 "ef" = (
 /obj/machinery/light/small{
 	dir = 1
@@ -540,7 +540,7 @@
 /turf/open/floor/plasteel/brown{
 	dir = 1
 	},
-/area/ruin/syndicate_lava_base/cargo)
+/area/ruin/unpowered/syndicate_lava_base/cargo)
 "eg" = (
 /obj/structure/closet/firecloset/full{
 	anchored = 1
@@ -550,17 +550,17 @@
 /turf/open/floor/plasteel/brown{
 	dir = 1
 	},
-/area/ruin/syndicate_lava_base/cargo)
+/area/ruin/unpowered/syndicate_lava_base/cargo)
 "eh" = (
 /turf/closed/wall/mineral/plastitanium/nodiagonal,
-/area/ruin/syndicate_lava_base/virology)
+/area/ruin/unpowered/syndicate_lava_base/virology)
 "ei" = (
 /obj/structure/disposaloutlet{
 	dir = 1
 	},
 /obj/structure/disposalpipe/trunk,
 /turf/open/floor/plating/asteroid/basalt/lava_land_surface,
-/area/ruin/syndicate_lava_base/virology)
+/area/ruin/unpowered/syndicate_lava_base/virology)
 "ej" = (
 /obj/structure/bed/roller,
 /obj/machinery/iv_drip,
@@ -570,12 +570,12 @@
 /turf/open/floor/plasteel/vault{
 	dir = 8
 	},
-/area/ruin/syndicate_lava_base/testlab)
+/area/ruin/unpowered/syndicate_lava_base/testlab)
 "ek" = (
 /obj/structure/grille,
 /obj/structure/window/plastitanium,
 /turf/open/floor/plating,
-/area/ruin/syndicate_lava_base/testlab)
+/area/ruin/unpowered/syndicate_lava_base/testlab)
 "el" = (
 /obj/effect/turf_decal/stripes/line{
 	icon_state = "warningline";
@@ -584,7 +584,7 @@
 /turf/open/floor/plasteel/vault{
 	dir = 8
 	},
-/area/ruin/syndicate_lava_base/testlab)
+/area/ruin/unpowered/syndicate_lava_base/testlab)
 "em" = (
 /obj/machinery/light/small{
 	dir = 1
@@ -603,7 +603,7 @@
 /turf/open/floor/plasteel/vault{
 	dir = 8
 	},
-/area/ruin/syndicate_lava_base/testlab)
+/area/ruin/unpowered/syndicate_lava_base/testlab)
 "eo" = (
 /obj/structure/table/reinforced,
 /obj/item/stack/sheet/metal/fifty,
@@ -614,7 +614,7 @@
 /turf/open/floor/plasteel/vault{
 	dir = 8
 	},
-/area/ruin/syndicate_lava_base/testlab)
+/area/ruin/unpowered/syndicate_lava_base/testlab)
 "ep" = (
 /obj/structure/table/reinforced,
 /obj/item/storage/toolbox/syndicate,
@@ -623,7 +623,7 @@
 /turf/open/floor/plasteel/vault{
 	dir = 8
 	},
-/area/ruin/syndicate_lava_base/testlab)
+/area/ruin/unpowered/syndicate_lava_base/testlab)
 "eq" = (
 /obj/structure/table/reinforced,
 /obj/item/device/assembly/timer{
@@ -653,7 +653,7 @@
 /turf/open/floor/plasteel/vault{
 	dir = 8
 	},
-/area/ruin/syndicate_lava_base/testlab)
+/area/ruin/unpowered/syndicate_lava_base/testlab)
 "er" = (
 /obj/machinery/light/small{
 	dir = 8
@@ -677,7 +677,7 @@
 /turf/open/floor/plasteel/white/side{
 	dir = 8
 	},
-/area/ruin/syndicate_lava_base/chemistry)
+/area/ruin/unpowered/syndicate_lava_base/chemistry)
 "es" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 9
@@ -685,13 +685,13 @@
 /obj/structure/closet/crate/bin,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel,
-/area/ruin/syndicate_lava_base/chemistry)
+/area/ruin/unpowered/syndicate_lava_base/chemistry)
 "et" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
-/area/ruin/syndicate_lava_base/chemistry)
+/area/ruin/unpowered/syndicate_lava_base/chemistry)
 "eu" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 5
@@ -699,10 +699,10 @@
 /obj/machinery/chem_heater,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/floorgrime,
-/area/ruin/syndicate_lava_base/chemistry)
+/area/ruin/unpowered/syndicate_lava_base/chemistry)
 "ev" = (
 /turf/open/floor/plasteel/white/corner,
-/area/ruin/syndicate_lava_base/chemistry)
+/area/ruin/unpowered/syndicate_lava_base/chemistry)
 "ew" = (
 /obj/structure/table/glass,
 /obj/item/stack/cable_coil/white{
@@ -744,7 +744,7 @@
 /turf/open/floor/plasteel/white/side{
 	dir = 6
 	},
-/area/ruin/syndicate_lava_base/chemistry)
+/area/ruin/unpowered/syndicate_lava_base/chemistry)
 "ex" = (
 /obj/machinery/light/small{
 	brightness = 3;
@@ -771,7 +771,7 @@
 /turf/open/floor/plasteel/vault{
 	dir = 5
 	},
-/area/ruin/syndicate_lava_base/cargo)
+/area/ruin/unpowered/syndicate_lava_base/cargo)
 "ey" = (
 /obj/structure/cable/yellow{
 	d1 = 4;
@@ -791,7 +791,7 @@
 /turf/open/floor/plasteel/vault{
 	dir = 5
 	},
-/area/ruin/syndicate_lava_base/cargo)
+/area/ruin/unpowered/syndicate_lava_base/cargo)
 "ez" = (
 /obj/structure/cable/yellow{
 	d1 = 4;
@@ -810,7 +810,7 @@
 /turf/open/floor/plasteel/vault{
 	dir = 5
 	},
-/area/ruin/syndicate_lava_base/cargo)
+/area/ruin/unpowered/syndicate_lava_base/cargo)
 "eA" = (
 /obj/machinery/door/firedoor,
 /obj/structure/cable/yellow{
@@ -835,7 +835,7 @@
 /turf/open/floor/plasteel/vault{
 	dir = 5
 	},
-/area/ruin/syndicate_lava_base/cargo)
+/area/ruin/unpowered/syndicate_lava_base/cargo)
 "eB" = (
 /obj/structure/cable/yellow{
 	d1 = 4;
@@ -852,7 +852,7 @@
 	pixel_y = 5
 	},
 /turf/open/floor/plasteel/floorgrime,
-/area/ruin/syndicate_lava_base/cargo)
+/area/ruin/unpowered/syndicate_lava_base/cargo)
 "eC" = (
 /obj/structure/cable/yellow{
 	d1 = 1;
@@ -870,11 +870,11 @@
 	pixel_y = 5
 	},
 /turf/open/floor/plasteel,
-/area/ruin/syndicate_lava_base/cargo)
+/area/ruin/unpowered/syndicate_lava_base/cargo)
 "eD" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/floorgrime,
-/area/ruin/syndicate_lava_base/cargo)
+/area/ruin/unpowered/syndicate_lava_base/cargo)
 "eE" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -884,7 +884,7 @@
 /obj/item/wrench,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/mineral/plastitanium,
-/area/ruin/syndicate_lava_base/cargo)
+/area/ruin/unpowered/syndicate_lava_base/cargo)
 "eF" = (
 /obj/structure/grille,
 /obj/structure/window/plastitanium,
@@ -894,14 +894,14 @@
 	layer = 2.9
 	},
 /turf/open/floor/plating,
-/area/ruin/syndicate_lava_base/cargo)
+/area/ruin/unpowered/syndicate_lava_base/cargo)
 "eG" = (
 /obj/structure/closet/secure_closet/personal/patient,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/white/side{
 	dir = 9
 	},
-/area/ruin/syndicate_lava_base/virology)
+/area/ruin/unpowered/syndicate_lava_base/virology)
 "eH" = (
 /obj/structure/bed,
 /obj/item/bedsheet,
@@ -911,16 +911,16 @@
 /turf/open/floor/plasteel/white/side{
 	dir = 5
 	},
-/area/ruin/syndicate_lava_base/virology)
+/area/ruin/unpowered/syndicate_lava_base/virology)
 "eI" = (
 /obj/structure/grille,
 /obj/structure/window/plastitanium,
 /turf/open/floor/plating,
-/area/ruin/syndicate_lava_base/virology)
+/area/ruin/unpowered/syndicate_lava_base/virology)
 "eJ" = (
 /obj/structure/disposalpipe/segment,
 /turf/closed/wall/mineral/plastitanium/nodiagonal,
-/area/ruin/syndicate_lava_base/virology)
+/area/ruin/unpowered/syndicate_lava_base/virology)
 "eK" = (
 /obj/machinery/light/small,
 /obj/structure/bed/roller,
@@ -931,7 +931,7 @@
 /turf/open/floor/plasteel/vault{
 	dir = 8
 	},
-/area/ruin/syndicate_lava_base/testlab)
+/area/ruin/unpowered/syndicate_lava_base/testlab)
 "eL" = (
 /obj/machinery/door/airlock/hatch{
 	name = "Monkey Pen";
@@ -941,7 +941,7 @@
 /turf/open/floor/plasteel/vault{
 	dir = 8
 	},
-/area/ruin/syndicate_lava_base/testlab)
+/area/ruin/unpowered/syndicate_lava_base/testlab)
 "eM" = (
 /obj/machinery/firealarm{
 	dir = 1;
@@ -957,7 +957,7 @@
 /turf/open/floor/plasteel/vault{
 	dir = 8
 	},
-/area/ruin/syndicate_lava_base/testlab)
+/area/ruin/unpowered/syndicate_lava_base/testlab)
 "eN" = (
 /obj/machinery/airalarm{
 	dir = 1;
@@ -973,7 +973,7 @@
 /turf/open/floor/plasteel/vault{
 	dir = 8
 	},
-/area/ruin/syndicate_lava_base/testlab)
+/area/ruin/unpowered/syndicate_lava_base/testlab)
 "eO" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
@@ -988,7 +988,7 @@
 /turf/open/floor/plasteel/vault{
 	dir = 8
 	},
-/area/ruin/syndicate_lava_base/testlab)
+/area/ruin/unpowered/syndicate_lava_base/testlab)
 "eP" = (
 /obj/structure/chair{
 	dir = 1
@@ -1005,7 +1005,7 @@
 /turf/open/floor/plasteel/vault{
 	dir = 8
 	},
-/area/ruin/syndicate_lava_base/testlab)
+/area/ruin/unpowered/syndicate_lava_base/testlab)
 "eQ" = (
 /obj/machinery/light/small,
 /obj/structure/table/reinforced,
@@ -1015,7 +1015,7 @@
 /turf/open/floor/plasteel/vault{
 	dir = 8
 	},
-/area/ruin/syndicate_lava_base/testlab)
+/area/ruin/unpowered/syndicate_lava_base/testlab)
 "eR" = (
 /obj/structure/cable/yellow{
 	d1 = 1;
@@ -1032,20 +1032,20 @@
 /turf/open/floor/plasteel/white/side{
 	dir = 10
 	},
-/area/ruin/syndicate_lava_base/chemistry)
+/area/ruin/unpowered/syndicate_lava_base/chemistry)
 "eS" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
 /obj/machinery/chem_master,
 /turf/open/floor/plasteel/floorgrime,
-/area/ruin/syndicate_lava_base/chemistry)
+/area/ruin/unpowered/syndicate_lava_base/chemistry)
 "eT" = (
 /obj/effect/turf_decal/bot,
 /obj/structure/chair/office/light,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel,
-/area/ruin/syndicate_lava_base/chemistry)
+/area/ruin/unpowered/syndicate_lava_base/chemistry)
 "eU" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -1053,7 +1053,7 @@
 /obj/machinery/chem_dispenser,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/floorgrime,
-/area/ruin/syndicate_lava_base/chemistry)
+/area/ruin/unpowered/syndicate_lava_base/chemistry)
 "eV" = (
 /obj/structure/closet/secure_closet/chemical{
 	req_access_txt = "152"
@@ -1062,7 +1062,7 @@
 /turf/open/floor/plasteel/white/side{
 	dir = 6
 	},
-/area/ruin/syndicate_lava_base/chemistry)
+/area/ruin/unpowered/syndicate_lava_base/chemistry)
 "eW" = (
 /obj/structure/cable/yellow{
 	d1 = 1;
@@ -1079,7 +1079,7 @@
 /turf/open/floor/plasteel/vault{
 	dir = 5
 	},
-/area/ruin/syndicate_lava_base/cargo)
+/area/ruin/unpowered/syndicate_lava_base/cargo)
 "eX" = (
 /obj/effect/turf_decal/box/white/corners{
 	icon_state = "box_corners_white";
@@ -1096,7 +1096,7 @@
 /obj/item/clothing/mask/gas,
 /obj/item/clothing/mask/gas,
 /turf/open/floor/plasteel/dark,
-/area/ruin/syndicate_lava_base/cargo)
+/area/ruin/unpowered/syndicate_lava_base/cargo)
 "eY" = (
 /obj/effect/turf_decal/box/white/corners{
 	icon_state = "box_corners_white";
@@ -1121,7 +1121,7 @@
 	pixel_y = 5
 	},
 /turf/open/floor/plasteel/dark,
-/area/ruin/syndicate_lava_base/cargo)
+/area/ruin/unpowered/syndicate_lava_base/cargo)
 "eZ" = (
 /obj/structure/rack{
 	dir = 8;
@@ -1136,20 +1136,20 @@
 /turf/open/floor/plasteel/vault{
 	dir = 5
 	},
-/area/ruin/syndicate_lava_base/cargo)
+/area/ruin/unpowered/syndicate_lava_base/cargo)
 "fa" = (
 /obj/structure/grille,
 /obj/structure/window/plastitanium,
 /obj/machinery/door/firedoor,
 /turf/open/floor/plating,
-/area/ruin/syndicate_lava_base/cargo)
+/area/ruin/unpowered/syndicate_lava_base/cargo)
 "fb" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/closet/crate/bin,
 /turf/open/floor/plasteel/brown/corner{
 	dir = 8
 	},
-/area/ruin/syndicate_lava_base/cargo)
+/area/ruin/unpowered/syndicate_lava_base/cargo)
 "fc" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -1159,7 +1159,7 @@
 	pixel_y = 5
 	},
 /turf/open/floor/plasteel,
-/area/ruin/syndicate_lava_base/cargo)
+/area/ruin/unpowered/syndicate_lava_base/cargo)
 "fd" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 8;
@@ -1168,7 +1168,7 @@
 	pixel_y = 5
 	},
 /turf/open/floor/plasteel/floorgrime,
-/area/ruin/syndicate_lava_base/cargo)
+/area/ruin/unpowered/syndicate_lava_base/cargo)
 "fe" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -1177,7 +1177,7 @@
 /obj/machinery/cell_charger,
 /obj/item/stock_parts/cell/high/plus,
 /turf/open/floor/mineral/plastitanium,
-/area/ruin/syndicate_lava_base/cargo)
+/area/ruin/unpowered/syndicate_lava_base/cargo)
 "ff" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 4;
@@ -1189,7 +1189,7 @@
 /turf/open/floor/plasteel/white/side{
 	dir = 10
 	},
-/area/ruin/syndicate_lava_base/virology)
+/area/ruin/unpowered/syndicate_lava_base/virology)
 "fg" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -1201,7 +1201,7 @@
 /turf/open/floor/plasteel/white/side{
 	dir = 6
 	},
-/area/ruin/syndicate_lava_base/virology)
+/area/ruin/unpowered/syndicate_lava_base/virology)
 "fh" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 4;
@@ -1212,7 +1212,7 @@
 /turf/open/floor/plasteel/white/side{
 	dir = 10
 	},
-/area/ruin/syndicate_lava_base/virology)
+/area/ruin/unpowered/syndicate_lava_base/virology)
 "fi" = (
 /obj/structure/table/glass,
 /obj/item/storage/box/beakers{
@@ -1235,7 +1235,7 @@
 /turf/open/floor/plasteel/white/side{
 	dir = 9
 	},
-/area/ruin/syndicate_lava_base/virology)
+/area/ruin/unpowered/syndicate_lava_base/virology)
 "fj" = (
 /obj/structure/table/glass,
 /obj/structure/reagent_dispensers/virusfood{
@@ -1255,7 +1255,7 @@
 /turf/open/floor/plasteel/white/side{
 	dir = 5
 	},
-/area/ruin/syndicate_lava_base/virology)
+/area/ruin/unpowered/syndicate_lava_base/virology)
 "fk" = (
 /obj/machinery/power/apc{
 	dir = 2;
@@ -1272,7 +1272,7 @@
 /turf/open/floor/plasteel/vault{
 	dir = 8
 	},
-/area/ruin/syndicate_lava_base/testlab)
+/area/ruin/unpowered/syndicate_lava_base/testlab)
 "fl" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -1292,7 +1292,7 @@
 /turf/open/floor/plasteel/vault{
 	dir = 8
 	},
-/area/ruin/syndicate_lava_base/testlab)
+/area/ruin/unpowered/syndicate_lava_base/testlab)
 "fm" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/medical{
@@ -1312,13 +1312,13 @@
 	pixel_y = 5
 	},
 /turf/open/floor/plasteel/white,
-/area/ruin/syndicate_lava_base/chemistry)
+/area/ruin/unpowered/syndicate_lava_base/chemistry)
 "fn" = (
 /obj/structure/grille,
 /obj/structure/window/plastitanium,
 /obj/machinery/door/firedoor,
 /turf/open/floor/plating,
-/area/ruin/syndicate_lava_base/chemistry)
+/area/ruin/unpowered/syndicate_lava_base/chemistry)
 "fo" = (
 /obj/machinery/door/firedoor,
 /obj/structure/table/reinforced,
@@ -1337,11 +1337,11 @@
 	req_access_txt = "150"
 	},
 /turf/open/floor/plasteel/white,
-/area/ruin/syndicate_lava_base/chemistry)
+/area/ruin/unpowered/syndicate_lava_base/chemistry)
 "fp" = (
 /obj/structure/sign/chemistry,
 /turf/closed/wall/mineral/plastitanium/nodiagonal,
-/area/ruin/syndicate_lava_base/chemistry)
+/area/ruin/unpowered/syndicate_lava_base/chemistry)
 "fq" = (
 /obj/machinery/vending/assist,
 /obj/effect/decal/cleanable/dirt,
@@ -1349,7 +1349,7 @@
 /turf/open/floor/plasteel/vault{
 	dir = 5
 	},
-/area/ruin/syndicate_lava_base/cargo)
+/area/ruin/unpowered/syndicate_lava_base/cargo)
 "fr" = (
 /obj/structure/cable/yellow{
 	d1 = 1;
@@ -1367,7 +1367,7 @@
 /turf/open/floor/plasteel/vault{
 	dir = 5
 	},
-/area/ruin/syndicate_lava_base/cargo)
+/area/ruin/unpowered/syndicate_lava_base/cargo)
 "fs" = (
 /obj/effect/turf_decal/box/white/corners{
 	icon_state = "box_corners_white";
@@ -1393,7 +1393,7 @@
 	pixel_y = -3
 	},
 /turf/open/floor/plasteel/dark,
-/area/ruin/syndicate_lava_base/cargo)
+/area/ruin/unpowered/syndicate_lava_base/cargo)
 "ft" = (
 /obj/effect/turf_decal/box/white/corners,
 /obj/structure/closet/crate,
@@ -1417,7 +1417,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/dark,
-/area/ruin/syndicate_lava_base/cargo)
+/area/ruin/unpowered/syndicate_lava_base/cargo)
 "fu" = (
 /obj/machinery/light/small{
 	dir = 8
@@ -1448,11 +1448,11 @@
 /turf/open/floor/plasteel/brown{
 	dir = 8
 	},
-/area/ruin/syndicate_lava_base/cargo)
+/area/ruin/unpowered/syndicate_lava_base/cargo)
 "fv" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plasteel,
-/area/ruin/syndicate_lava_base/cargo)
+/area/ruin/unpowered/syndicate_lava_base/cargo)
 "fw" = (
 /obj/effect/turf_decal/stripes/corner,
 /obj/machinery/firealarm{
@@ -1462,11 +1462,11 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel,
-/area/ruin/syndicate_lava_base/cargo)
+/area/ruin/unpowered/syndicate_lava_base/cargo)
 "fx" = (
 /obj/structure/sign/securearea,
 /turf/closed/wall/mineral/plastitanium/nodiagonal,
-/area/ruin/syndicate_lava_base/cargo)
+/area/ruin/unpowered/syndicate_lava_base/cargo)
 "fy" = (
 /obj/machinery/door/airlock/virology/glass{
 	name = "Isolation B";
@@ -1479,7 +1479,7 @@
 	pixel_y = 5
 	},
 /turf/open/floor/plasteel/white,
-/area/ruin/syndicate_lava_base/virology)
+/area/ruin/unpowered/syndicate_lava_base/virology)
 "fz" = (
 /obj/machinery/door/airlock/virology/glass{
 	name = "Isolation A";
@@ -1492,7 +1492,7 @@
 	pixel_y = 5
 	},
 /turf/open/floor/plasteel/white,
-/area/ruin/syndicate_lava_base/virology)
+/area/ruin/unpowered/syndicate_lava_base/virology)
 "fA" = (
 /obj/structure/table/glass,
 /obj/item/book/manual/wiki/infections{
@@ -1510,14 +1510,14 @@
 /turf/open/floor/plasteel/white/side{
 	dir = 8
 	},
-/area/ruin/syndicate_lava_base/virology)
+/area/ruin/unpowered/syndicate_lava_base/virology)
 "fB" = (
 /obj/structure/chair/stool,
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel/white/corner{
 	dir = 4
 	},
-/area/ruin/syndicate_lava_base/virology)
+/area/ruin/unpowered/syndicate_lava_base/virology)
 "fC" = (
 /obj/machinery/smartfridge/chemistry/virology/preloaded,
 /obj/effect/decal/cleanable/dirt,
@@ -1525,11 +1525,11 @@
 /turf/open/floor/plasteel/white/side{
 	dir = 5
 	},
-/area/ruin/syndicate_lava_base/virology)
+/area/ruin/unpowered/syndicate_lava_base/virology)
 "fD" = (
 /obj/structure/sign/biohazard,
 /turf/closed/wall/mineral/plastitanium/nodiagonal,
-/area/ruin/syndicate_lava_base/virology)
+/area/ruin/unpowered/syndicate_lava_base/virology)
 "fE" = (
 /obj/effect/turf_decal/bot,
 /obj/structure/closet/l3closet,
@@ -1542,7 +1542,7 @@
 	req_access = 152
 	},
 /turf/open/floor/plasteel/floorgrime,
-/area/ruin/syndicate_lava_base/main)
+/area/ruin/unpowered/syndicate_lava_base/main)
 "fF" = (
 /obj/effect/turf_decal/bot,
 /obj/machinery/shower{
@@ -1550,7 +1550,7 @@
 	pixel_y = 14
 	},
 /turf/open/floor/plasteel,
-/area/ruin/syndicate_lava_base/main)
+/area/ruin/unpowered/syndicate_lava_base/main)
 "fG" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -1572,13 +1572,13 @@
 /turf/open/floor/plasteel/vault{
 	dir = 8
 	},
-/area/ruin/syndicate_lava_base/testlab)
+/area/ruin/unpowered/syndicate_lava_base/testlab)
 "fH" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/white/side{
 	dir = 1
 	},
-/area/ruin/syndicate_lava_base/main)
+/area/ruin/unpowered/syndicate_lava_base/main)
 "fI" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable/yellow{
@@ -1596,12 +1596,12 @@
 /turf/open/floor/plasteel/white/side{
 	dir = 1
 	},
-/area/ruin/syndicate_lava_base/main)
+/area/ruin/unpowered/syndicate_lava_base/main)
 "fO" = (
 /turf/open/floor/plasteel/white/side{
 	dir = 1
 	},
-/area/ruin/syndicate_lava_base/main)
+/area/ruin/unpowered/syndicate_lava_base/main)
 "fW" = (
 /obj/machinery/door/firedoor,
 /obj/structure/cable/yellow{
@@ -1623,7 +1623,7 @@
 /turf/open/floor/plasteel/vault{
 	dir = 5
 	},
-/area/ruin/syndicate_lava_base/cargo)
+/area/ruin/unpowered/syndicate_lava_base/cargo)
 "fY" = (
 /obj/structure/extinguisher_cabinet{
 	pixel_x = -27;
@@ -1641,7 +1641,7 @@
 /turf/open/floor/plasteel/brown{
 	dir = 9
 	},
-/area/ruin/syndicate_lava_base/cargo)
+/area/ruin/unpowered/syndicate_lava_base/cargo)
 "gb" = (
 /obj/structure/table,
 /obj/item/paper_bin,
@@ -1650,7 +1650,7 @@
 /turf/open/floor/plasteel/brown/corner{
 	dir = 1
 	},
-/area/ruin/syndicate_lava_base/cargo)
+/area/ruin/unpowered/syndicate_lava_base/cargo)
 "gc" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -1660,14 +1660,14 @@
 	dir = 8
 	},
 /turf/open/floor/plasteel/floorgrime,
-/area/ruin/syndicate_lava_base/cargo)
+/area/ruin/unpowered/syndicate_lava_base/cargo)
 "gd" = (
 /obj/machinery/door/airlock/external{
 	req_access_txt = "150"
 	},
 /obj/structure/fans/tiny,
 /turf/open/floor/plating,
-/area/ruin/syndicate_lava_base/cargo)
+/area/ruin/unpowered/syndicate_lava_base/cargo)
 "gf" = (
 /obj/structure/sign/vacuum{
 	pixel_x = 0;
@@ -1675,7 +1675,7 @@
 	},
 /obj/machinery/light/small,
 /turf/open/floor/plating,
-/area/ruin/syndicate_lava_base/cargo)
+/area/ruin/unpowered/syndicate_lava_base/cargo)
 "gg" = (
 /obj/structure/sign/fire{
 	pixel_x = 0;
@@ -1686,17 +1686,17 @@
 	pixel_y = -32
 	},
 /turf/open/floor/plating,
-/area/ruin/syndicate_lava_base/cargo)
+/area/ruin/unpowered/syndicate_lava_base/cargo)
 "gh" = (
 /obj/structure/fans/tiny,
 /obj/machinery/door/airlock/external{
 	req_access_txt = "150"
 	},
 /turf/open/floor/plating,
-/area/ruin/syndicate_lava_base/cargo)
+/area/ruin/unpowered/syndicate_lava_base/cargo)
 "gj" = (
 /turf/closed/wall/mineral/plastitanium/explosive,
-/area/ruin/syndicate_lava_base/virology)
+/area/ruin/unpowered/syndicate_lava_base/virology)
 "go" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -1711,7 +1711,7 @@
 /turf/open/floor/plasteel/white/side{
 	dir = 4
 	},
-/area/ruin/syndicate_lava_base/virology)
+/area/ruin/unpowered/syndicate_lava_base/virology)
 "gp" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 5
@@ -1724,7 +1724,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/white,
-/area/ruin/syndicate_lava_base/virology)
+/area/ruin/unpowered/syndicate_lava_base/virology)
 "gq" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
 	dir = 1
@@ -1736,7 +1736,7 @@
 	pixel_y = 5
 	},
 /turf/open/floor/plasteel/white,
-/area/ruin/syndicate_lava_base/virology)
+/area/ruin/unpowered/syndicate_lava_base/virology)
 "gr" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -1748,7 +1748,7 @@
 	pixel_y = 5
 	},
 /turf/open/floor/plasteel/white,
-/area/ruin/syndicate_lava_base/virology)
+/area/ruin/unpowered/syndicate_lava_base/virology)
 "gs" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden,
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
@@ -1760,7 +1760,7 @@
 /obj/machinery/light/small,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/white,
-/area/ruin/syndicate_lava_base/virology)
+/area/ruin/unpowered/syndicate_lava_base/virology)
 "gt" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -1774,7 +1774,7 @@
 /turf/open/floor/plasteel/white/side{
 	dir = 9
 	},
-/area/ruin/syndicate_lava_base/virology)
+/area/ruin/unpowered/syndicate_lava_base/virology)
 "gu" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -1793,7 +1793,7 @@
 /turf/open/floor/plasteel/white/corner{
 	dir = 1
 	},
-/area/ruin/syndicate_lava_base/virology)
+/area/ruin/unpowered/syndicate_lava_base/virology)
 "gv" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
 	dir = 1
@@ -1811,7 +1811,7 @@
 	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel,
-/area/ruin/syndicate_lava_base/virology)
+/area/ruin/unpowered/syndicate_lava_base/virology)
 "gw" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -1830,7 +1830,7 @@
 /turf/open/floor/plasteel/white/side{
 	dir = 4
 	},
-/area/ruin/syndicate_lava_base/virology)
+/area/ruin/unpowered/syndicate_lava_base/virology)
 "gy" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 9
@@ -1850,7 +1850,7 @@
 	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel/floorgrime,
-/area/ruin/syndicate_lava_base/main)
+/area/ruin/unpowered/syndicate_lava_base/main)
 "gz" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 5
@@ -1870,7 +1870,7 @@
 	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel,
-/area/ruin/syndicate_lava_base/main)
+/area/ruin/unpowered/syndicate_lava_base/main)
 "gA" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/virology{
@@ -1903,7 +1903,7 @@
 	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel,
-/area/ruin/syndicate_lava_base/main)
+/area/ruin/unpowered/syndicate_lava_base/main)
 "gB" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -1922,7 +1922,7 @@
 /turf/open/floor/plasteel/red/side{
 	dir = 8
 	},
-/area/ruin/syndicate_lava_base/main)
+/area/ruin/unpowered/syndicate_lava_base/main)
 "gE" = (
 /obj/machinery/atmospherics/pipe/manifold4w/supply/hidden,
 /obj/structure/cable/yellow{
@@ -1947,7 +1947,7 @@
 	icon_state = "2-4"
 	},
 /turf/open/floor/plasteel/floorgrime,
-/area/ruin/syndicate_lava_base/main)
+/area/ruin/unpowered/syndicate_lava_base/main)
 "gF" = (
 /obj/machinery/light/small{
 	dir = 1
@@ -1967,7 +1967,7 @@
 	pixel_y = 5
 	},
 /turf/open/floor/plasteel/floorgrime,
-/area/ruin/syndicate_lava_base/main)
+/area/ruin/unpowered/syndicate_lava_base/main)
 "gG" = (
 /obj/structure/cable/yellow{
 	d1 = 4;
@@ -1984,7 +1984,7 @@
 	pixel_y = 5
 	},
 /turf/open/floor/plasteel,
-/area/ruin/syndicate_lava_base/main)
+/area/ruin/unpowered/syndicate_lava_base/main)
 "gH" = (
 /obj/structure/cable/yellow{
 	d1 = 4;
@@ -2004,7 +2004,7 @@
 	icon_state = "1-8"
 	},
 /turf/open/floor/plasteel,
-/area/ruin/syndicate_lava_base/main)
+/area/ruin/unpowered/syndicate_lava_base/main)
 "gI" = (
 /obj/structure/cable/yellow{
 	d1 = 4;
@@ -2021,7 +2021,7 @@
 	pixel_y = 5
 	},
 /turf/open/floor/plasteel/floorgrime,
-/area/ruin/syndicate_lava_base/main)
+/area/ruin/unpowered/syndicate_lava_base/main)
 "gJ" = (
 /obj/machinery/door/firedoor,
 /obj/structure/cable/yellow{
@@ -2039,7 +2039,7 @@
 	pixel_y = 5
 	},
 /turf/open/floor/plasteel/floorgrime,
-/area/ruin/syndicate_lava_base/main)
+/area/ruin/unpowered/syndicate_lava_base/main)
 "gK" = (
 /obj/machinery/light/small{
 	dir = 1
@@ -2061,7 +2061,7 @@
 /turf/open/floor/plasteel/brown/corner{
 	dir = 4
 	},
-/area/ruin/syndicate_lava_base/main)
+/area/ruin/unpowered/syndicate_lava_base/main)
 "gL" = (
 /obj/structure/cable/yellow{
 	d1 = 1;
@@ -2080,40 +2080,40 @@
 /turf/open/floor/plasteel/brown{
 	dir = 1
 	},
-/area/ruin/syndicate_lava_base/main)
+/area/ruin/unpowered/syndicate_lava_base/main)
 "gM" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/brown{
 	dir = 1
 	},
-/area/ruin/syndicate_lava_base/main)
+/area/ruin/unpowered/syndicate_lava_base/main)
 "gN" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/brown{
 	dir = 5
 	},
-/area/ruin/syndicate_lava_base/main)
+/area/ruin/unpowered/syndicate_lava_base/main)
 "gO" = (
 /obj/structure/sign/cargo,
 /turf/closed/wall/mineral/plastitanium/nodiagonal,
-/area/ruin/syndicate_lava_base/cargo)
+/area/ruin/unpowered/syndicate_lava_base/cargo)
 "gP" = (
 /obj/machinery/photocopier,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/brown/corner{
 	dir = 1
 	},
-/area/ruin/syndicate_lava_base/cargo)
+/area/ruin/unpowered/syndicate_lava_base/cargo)
 "gQ" = (
 /turf/open/floor/plasteel/floorgrime,
-/area/ruin/syndicate_lava_base/cargo)
+/area/ruin/unpowered/syndicate_lava_base/cargo)
 "gR" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
-/area/ruin/syndicate_lava_base/cargo)
+/area/ruin/unpowered/syndicate_lava_base/cargo)
 "gS" = (
 /obj/effect/turf_decal/stripes/corner{
 	dir = 8
@@ -2129,7 +2129,7 @@
 	req_access_txt = "150"
 	},
 /turf/open/floor/plasteel,
-/area/ruin/syndicate_lava_base/cargo)
+/area/ruin/unpowered/syndicate_lava_base/cargo)
 "gT" = (
 /obj/machinery/door/airlock/virology/glass{
 	name = "Monkey Pen";
@@ -2142,7 +2142,7 @@
 	pixel_y = 5
 	},
 /turf/open/floor/plasteel/white,
-/area/ruin/syndicate_lava_base/virology)
+/area/ruin/unpowered/syndicate_lava_base/virology)
 "gU" = (
 /obj/machinery/airalarm{
 	dir = 4;
@@ -2165,11 +2165,11 @@
 /turf/open/floor/plasteel/white/side{
 	dir = 8
 	},
-/area/ruin/syndicate_lava_base/virology)
+/area/ruin/unpowered/syndicate_lava_base/virology)
 "gV" = (
 /obj/structure/chair/office/light,
 /turf/open/floor/plasteel,
-/area/ruin/syndicate_lava_base/virology)
+/area/ruin/unpowered/syndicate_lava_base/virology)
 "gW" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 1
@@ -2178,7 +2178,7 @@
 	dir = 5
 	},
 /turf/open/floor/plasteel,
-/area/ruin/syndicate_lava_base/virology)
+/area/ruin/unpowered/syndicate_lava_base/virology)
 "gX" = (
 /obj/machinery/doorButtons/airlock_controller{
 	idExterior = "lavaland_syndie_virology_exterior";
@@ -2207,7 +2207,7 @@
 /turf/open/floor/plasteel/white/side{
 	dir = 4
 	},
-/area/ruin/syndicate_lava_base/virology)
+/area/ruin/unpowered/syndicate_lava_base/virology)
 "gY" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 10
@@ -2224,7 +2224,7 @@
 	dir = 1
 	},
 /turf/open/floor/plasteel/floorgrime,
-/area/ruin/syndicate_lava_base/main)
+/area/ruin/unpowered/syndicate_lava_base/main)
 "gZ" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 6
@@ -2236,16 +2236,16 @@
 	pixel_y = 5
 	},
 /turf/open/floor/plasteel/floorgrime,
-/area/ruin/syndicate_lava_base/main)
+/area/ruin/unpowered/syndicate_lava_base/main)
 "ha" = (
 /turf/closed/wall/mineral/plastitanium/nodiagonal,
-/area/ruin/syndicate_lava_base/main)
+/area/ruin/unpowered/syndicate_lava_base/main)
 "hb" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/red/side{
 	dir = 10
 	},
-/area/ruin/syndicate_lava_base/main)
+/area/ruin/unpowered/syndicate_lava_base/main)
 "hc" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -2262,36 +2262,36 @@
 /turf/open/floor/plasteel/red/corner{
 	dir = 8
 	},
-/area/ruin/syndicate_lava_base/main)
+/area/ruin/unpowered/syndicate_lava_base/main)
 "hd" = (
 /turf/open/floor/plasteel/red/corner,
-/area/ruin/syndicate_lava_base/main)
+/area/ruin/unpowered/syndicate_lava_base/main)
 "he" = (
 /turf/open/floor/plasteel/red/side,
-/area/ruin/syndicate_lava_base/main)
+/area/ruin/unpowered/syndicate_lava_base/main)
 "hf" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/red/side,
-/area/ruin/syndicate_lava_base/main)
+/area/ruin/unpowered/syndicate_lava_base/main)
 "hg" = (
 /obj/machinery/light/small,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/red/side,
-/area/ruin/syndicate_lava_base/main)
+/area/ruin/unpowered/syndicate_lava_base/main)
 "hh" = (
 /obj/machinery/door/firedoor,
 /turf/open/floor/plasteel/red/side,
-/area/ruin/syndicate_lava_base/main)
+/area/ruin/unpowered/syndicate_lava_base/main)
 "hi" = (
 /turf/open/floor/plasteel/red/corner{
 	dir = 8
 	},
-/area/ruin/syndicate_lava_base/main)
+/area/ruin/unpowered/syndicate_lava_base/main)
 "hj" = (
 /turf/open/floor/plasteel/brown{
 	dir = 4
 	},
-/area/ruin/syndicate_lava_base/main)
+/area/ruin/unpowered/syndicate_lava_base/main)
 "hk" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/mining/glass{
@@ -2299,20 +2299,20 @@
 	req_access_txt = "0"
 	},
 /turf/open/floor/plasteel/floorgrime,
-/area/ruin/syndicate_lava_base/cargo)
+/area/ruin/unpowered/syndicate_lava_base/cargo)
 "hl" = (
 /turf/open/floor/plasteel,
-/area/ruin/syndicate_lava_base/cargo)
+/area/ruin/unpowered/syndicate_lava_base/cargo)
 "hm" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel,
-/area/ruin/syndicate_lava_base/cargo)
+/area/ruin/unpowered/syndicate_lava_base/cargo)
 "hn" = (
 /obj/structure/chair{
 	dir = 4
 	},
 /turf/open/floor/plasteel/floorgrime,
-/area/ruin/syndicate_lava_base/cargo)
+/area/ruin/unpowered/syndicate_lava_base/cargo)
 "ho" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -2325,14 +2325,14 @@
 	shuttleId = "syndie_cargo"
 	},
 /turf/open/floor/mineral/plastitanium,
-/area/ruin/syndicate_lava_base/cargo)
+/area/ruin/unpowered/syndicate_lava_base/cargo)
 "hp" = (
 /obj/effect/decal/cleanable/dirt,
 /mob/living/carbon/monkey,
 /turf/open/floor/plasteel/white/side{
 	dir = 9
 	},
-/area/ruin/syndicate_lava_base/virology)
+/area/ruin/unpowered/syndicate_lava_base/virology)
 "hq" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 1
@@ -2345,13 +2345,13 @@
 /turf/open/floor/plasteel/white/side{
 	dir = 1
 	},
-/area/ruin/syndicate_lava_base/virology)
+/area/ruin/unpowered/syndicate_lava_base/virology)
 "hr" = (
 /mob/living/carbon/monkey,
 /turf/open/floor/plasteel/white/side{
 	dir = 5
 	},
-/area/ruin/syndicate_lava_base/virology)
+/area/ruin/unpowered/syndicate_lava_base/virology)
 "hs" = (
 /obj/machinery/computer/pandemic,
 /obj/effect/decal/cleanable/dirt,
@@ -2364,7 +2364,7 @@
 /turf/open/floor/plasteel/white/side{
 	dir = 10
 	},
-/area/ruin/syndicate_lava_base/virology)
+/area/ruin/unpowered/syndicate_lava_base/virology)
 "ht" = (
 /obj/structure/table,
 /obj/item/paper_bin{
@@ -2376,7 +2376,7 @@
 /obj/item/restraints/handcuffs,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/white/side,
-/area/ruin/syndicate_lava_base/virology)
+/area/ruin/unpowered/syndicate_lava_base/virology)
 "hu" = (
 /obj/structure/table,
 /obj/machinery/reagentgrinder,
@@ -2390,7 +2390,7 @@
 	amount = 10
 	},
 /turf/open/floor/plasteel/white/side,
-/area/ruin/syndicate_lava_base/virology)
+/area/ruin/unpowered/syndicate_lava_base/virology)
 "hv" = (
 /obj/machinery/disposal/bin,
 /obj/structure/sign/deathsposal{
@@ -2405,14 +2405,14 @@
 /turf/open/floor/plasteel/white/side{
 	dir = 6
 	},
-/area/ruin/syndicate_lava_base/virology)
+/area/ruin/unpowered/syndicate_lava_base/virology)
 "hw" = (
 /obj/machinery/door/airlock/external{
 	req_access_txt = "150"
 	},
 /obj/structure/fans/tiny,
 /turf/open/floor/plating,
-/area/ruin/syndicate_lava_base/main)
+/area/ruin/unpowered/syndicate_lava_base/main)
 "hx" = (
 /obj/machinery/airalarm{
 	dir = 4;
@@ -2436,27 +2436,27 @@
 /turf/open/floor/plasteel/red/side{
 	dir = 8
 	},
-/area/ruin/syndicate_lava_base/main)
+/area/ruin/unpowered/syndicate_lava_base/main)
 "hy" = (
 /turf/open/floor/plasteel/red/side{
 	dir = 4
 	},
-/area/ruin/syndicate_lava_base/main)
+/area/ruin/unpowered/syndicate_lava_base/main)
 "hz" = (
 /turf/closed/wall/mineral/plastitanium/nodiagonal,
-/area/ruin/syndicate_lava_base/dormitories)
+/area/ruin/unpowered/syndicate_lava_base/dormitories)
 "hA" = (
 /obj/structure/closet/emcloset/anchored,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/vault{
 	dir = 5
 	},
-/area/ruin/syndicate_lava_base/dormitories)
+/area/ruin/unpowered/syndicate_lava_base/dormitories)
 "hB" = (
 /turf/open/floor/plasteel/red/side{
 	dir = 8
 	},
-/area/ruin/syndicate_lava_base/main)
+/area/ruin/unpowered/syndicate_lava_base/main)
 "hC" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/mining/glass{
@@ -2464,7 +2464,7 @@
 	req_access_txt = "0"
 	},
 /turf/open/floor/plasteel,
-/area/ruin/syndicate_lava_base/cargo)
+/area/ruin/unpowered/syndicate_lava_base/cargo)
 "hD" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -2473,14 +2473,14 @@
 /obj/item/storage/belt/utility,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/mineral/plastitanium,
-/area/ruin/syndicate_lava_base/cargo)
+/area/ruin/unpowered/syndicate_lava_base/cargo)
 "hE" = (
 /obj/effect/decal/cleanable/dirt,
 /mob/living/carbon/monkey,
 /turf/open/floor/plasteel/white/side{
 	dir = 10
 	},
-/area/ruin/syndicate_lava_base/virology)
+/area/ruin/unpowered/syndicate_lava_base/virology)
 "hF" = (
 /obj/machinery/light/small,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
@@ -2491,14 +2491,14 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/white/side,
-/area/ruin/syndicate_lava_base/virology)
+/area/ruin/unpowered/syndicate_lava_base/virology)
 "hG" = (
 /obj/effect/decal/cleanable/dirt,
 /mob/living/carbon/monkey,
 /turf/open/floor/plasteel/white/side{
 	dir = 6
 	},
-/area/ruin/syndicate_lava_base/virology)
+/area/ruin/unpowered/syndicate_lava_base/virology)
 "hH" = (
 /obj/structure/grille,
 /obj/structure/window/plastitanium,
@@ -2507,17 +2507,17 @@
 	layer = 2.9
 	},
 /turf/open/floor/plating,
-/area/ruin/syndicate_lava_base/virology)
+/area/ruin/unpowered/syndicate_lava_base/virology)
 "hI" = (
 /obj/structure/sign/vacuum{
 	pixel_x = -32
 	},
 /turf/open/floor/plating,
-/area/ruin/syndicate_lava_base/main)
+/area/ruin/unpowered/syndicate_lava_base/main)
 "hJ" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
-/area/ruin/syndicate_lava_base/main)
+/area/ruin/unpowered/syndicate_lava_base/main)
 "hK" = (
 /obj/machinery/light/small{
 	dir = 4
@@ -2532,7 +2532,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
-/area/ruin/syndicate_lava_base/main)
+/area/ruin/unpowered/syndicate_lava_base/main)
 "hL" = (
 /obj/machinery/light/small{
 	dir = 8
@@ -2552,7 +2552,7 @@
 /turf/open/floor/plasteel/red/side{
 	dir = 8
 	},
-/area/ruin/syndicate_lava_base/main)
+/area/ruin/unpowered/syndicate_lava_base/main)
 "hM" = (
 /obj/structure/table/wood,
 /obj/item/ammo_box/magazine/m10mm,
@@ -2562,7 +2562,7 @@
 	req_access = 152
 	},
 /turf/open/floor/plasteel/grimy,
-/area/ruin/syndicate_lava_base/dormitories)
+/area/ruin/unpowered/syndicate_lava_base/dormitories)
 "hN" = (
 /obj/machinery/light/small{
 	dir = 4
@@ -2573,10 +2573,10 @@
 	pixel_y = 5
 	},
 /turf/open/floor/plasteel/grimy,
-/area/ruin/syndicate_lava_base/dormitories)
+/area/ruin/unpowered/syndicate_lava_base/dormitories)
 "hO" = (
 /turf/closed/wall/mineral/plastitanium/explosive,
-/area/ruin/syndicate_lava_base/dormitories)
+/area/ruin/unpowered/syndicate_lava_base/dormitories)
 "hP" = (
 /obj/machinery/light/small{
 	brightness = 3;
@@ -2588,7 +2588,7 @@
 	pixel_y = 5
 	},
 /turf/open/floor/plasteel/grimy,
-/area/ruin/syndicate_lava_base/dormitories)
+/area/ruin/unpowered/syndicate_lava_base/dormitories)
 "hQ" = (
 /obj/structure/table/wood,
 /obj/item/ammo_box/magazine/m10mm,
@@ -2597,13 +2597,13 @@
 	req_access = 152
 	},
 /turf/open/floor/plasteel/grimy,
-/area/ruin/syndicate_lava_base/dormitories)
+/area/ruin/unpowered/syndicate_lava_base/dormitories)
 "hR" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/brown/corner{
 	dir = 4
 	},
-/area/ruin/syndicate_lava_base/main)
+/area/ruin/unpowered/syndicate_lava_base/main)
 "hS" = (
 /obj/structure/table/reinforced,
 /obj/item/folder,
@@ -2614,37 +2614,37 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/brown,
-/area/ruin/syndicate_lava_base/cargo)
+/area/ruin/unpowered/syndicate_lava_base/cargo)
 "hT" = (
 /obj/machinery/vending/toyliberationstation{
 	req_access_txt = "150"
 	},
 /turf/open/floor/plasteel/brown,
-/area/ruin/syndicate_lava_base/cargo)
+/area/ruin/unpowered/syndicate_lava_base/cargo)
 "hU" = (
 /obj/machinery/light/small,
 /obj/structure/filingcabinet/chestdrawer,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/brown,
-/area/ruin/syndicate_lava_base/cargo)
+/area/ruin/unpowered/syndicate_lava_base/cargo)
 "hV" = (
 /obj/structure/filingcabinet/chestdrawer,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/brown,
-/area/ruin/syndicate_lava_base/cargo)
+/area/ruin/unpowered/syndicate_lava_base/cargo)
 "hW" = (
 /obj/machinery/porta_turret/syndicate{
 	dir = 10
 	},
 /turf/closed/wall/mineral/plastitanium/nodiagonal,
-/area/ruin/syndicate_lava_base/main)
+/area/ruin/unpowered/syndicate_lava_base/main)
 "hX" = (
 /obj/structure/fans/tiny,
 /obj/machinery/door/airlock/external{
 	req_access_txt = "150"
 	},
 /turf/open/floor/plating,
-/area/ruin/syndicate_lava_base/main)
+/area/ruin/unpowered/syndicate_lava_base/main)
 "hY" = (
 /obj/structure/fans/tiny,
 /obj/machinery/door/airlock/external{
@@ -2652,7 +2652,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
-/area/ruin/syndicate_lava_base/main)
+/area/ruin/unpowered/syndicate_lava_base/main)
 "hZ" = (
 /obj/machinery/firealarm{
 	dir = 8;
@@ -2675,7 +2675,7 @@
 /turf/open/floor/plasteel/red/side{
 	dir = 8
 	},
-/area/ruin/syndicate_lava_base/main)
+/area/ruin/unpowered/syndicate_lava_base/main)
 "ia" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 8;
@@ -2686,14 +2686,14 @@
 /turf/open/floor/plasteel/red/side{
 	dir = 4
 	},
-/area/ruin/syndicate_lava_base/main)
+/area/ruin/unpowered/syndicate_lava_base/main)
 "ib" = (
 /obj/effect/mob_spawn/human/lavaland_syndicate{
 	icon_state = "sleeper_s";
 	dir = 4
 	},
 /turf/open/floor/plasteel/grimy,
-/area/ruin/syndicate_lava_base/dormitories)
+/area/ruin/unpowered/syndicate_lava_base/dormitories)
 "ic" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -2702,7 +2702,7 @@
 	pixel_y = 5
 	},
 /turf/open/floor/plasteel/grimy,
-/area/ruin/syndicate_lava_base/dormitories)
+/area/ruin/unpowered/syndicate_lava_base/dormitories)
 "id" = (
 /obj/structure/toilet{
 	pixel_y = 18
@@ -2722,17 +2722,17 @@
 /turf/open/floor/plasteel/vault{
 	dir = 5
 	},
-/area/ruin/syndicate_lava_base/dormitories)
+/area/ruin/unpowered/syndicate_lava_base/dormitories)
 "ie" = (
 /obj/effect/mob_spawn/human/lavaland_syndicate/comms{
 	dir = 8;
 	icon_state = "sleeper_s"
 	},
 /turf/open/floor/plasteel/grimy,
-/area/ruin/syndicate_lava_base/dormitories)
+/area/ruin/unpowered/syndicate_lava_base/dormitories)
 "if" = (
 /turf/open/floor/plasteel/floorgrime,
-/area/ruin/syndicate_lava_base/main)
+/area/ruin/unpowered/syndicate_lava_base/main)
 "ig" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 9
@@ -2757,7 +2757,7 @@
 /turf/open/floor/plasteel/red/side{
 	dir = 9
 	},
-/area/ruin/syndicate_lava_base/main)
+/area/ruin/unpowered/syndicate_lava_base/main)
 "ij" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -2774,12 +2774,12 @@
 /turf/open/floor/plasteel/red/corner{
 	dir = 1
 	},
-/area/ruin/syndicate_lava_base/main)
+/area/ruin/unpowered/syndicate_lava_base/main)
 "ik" = (
 /turf/open/floor/plasteel/red/corner{
 	dir = 4
 	},
-/area/ruin/syndicate_lava_base/main)
+/area/ruin/unpowered/syndicate_lava_base/main)
 "il" = (
 /obj/machinery/door/airlock{
 	name = "Cabin 2";
@@ -2792,7 +2792,7 @@
 	pixel_y = 5
 	},
 /turf/open/floor/plasteel,
-/area/ruin/syndicate_lava_base/dormitories)
+/area/ruin/unpowered/syndicate_lava_base/dormitories)
 "im" = (
 /obj/machinery/door/airlock{
 	name = "Unisex Restrooms";
@@ -2802,7 +2802,7 @@
 /turf/open/floor/plasteel/vault{
 	dir = 5
 	},
-/area/ruin/syndicate_lava_base/dormitories)
+/area/ruin/unpowered/syndicate_lava_base/dormitories)
 "in" = (
 /obj/machinery/door/airlock{
 	name = "Cabin 4";
@@ -2815,15 +2815,15 @@
 	pixel_y = 5
 	},
 /turf/open/floor/plasteel,
-/area/ruin/syndicate_lava_base/dormitories)
+/area/ruin/unpowered/syndicate_lava_base/dormitories)
 "ip" = (
 /obj/effect/turf_decal/stripes/red/corner,
 /turf/open/floor/plasteel,
-/area/ruin/syndicate_lava_base/main)
+/area/ruin/unpowered/syndicate_lava_base/main)
 "iq" = (
 /obj/structure/sign/securearea,
 /turf/closed/wall/mineral/plastitanium/nodiagonal,
-/area/ruin/syndicate_lava_base/main)
+/area/ruin/unpowered/syndicate_lava_base/main)
 "ir" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/stripes/red/line{
@@ -2833,13 +2833,13 @@
 /turf/open/floor/plasteel/vault{
 	dir = 8
 	},
-/area/ruin/syndicate_lava_base/main)
+/area/ruin/unpowered/syndicate_lava_base/main)
 "is" = (
 /obj/machinery/light/small{
 	dir = 1
 	},
 /turf/open/floor/circuit/red,
-/area/ruin/syndicate_lava_base/main)
+/area/ruin/unpowered/syndicate_lava_base/main)
 "it" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/stripes/red/line{
@@ -2849,7 +2849,7 @@
 /turf/open/floor/plasteel/vault{
 	dir = 8
 	},
-/area/ruin/syndicate_lava_base/main)
+/area/ruin/unpowered/syndicate_lava_base/main)
 "iu" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -2876,7 +2876,7 @@
 /turf/open/floor/plasteel/red/side{
 	dir = 8
 	},
-/area/ruin/syndicate_lava_base/main)
+/area/ruin/unpowered/syndicate_lava_base/main)
 "ix" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -2891,19 +2891,19 @@
 	pixel_y = 0
 	},
 /turf/open/floor/plasteel/floorgrime,
-/area/ruin/syndicate_lava_base/main)
+/area/ruin/unpowered/syndicate_lava_base/main)
 "iy" = (
 /obj/machinery/door/airlock/public/glass{
 	name = "Dormitories"
 	},
 /obj/machinery/door/firedoor,
 /turf/open/floor/plasteel,
-/area/ruin/syndicate_lava_base/dormitories)
+/area/ruin/unpowered/syndicate_lava_base/dormitories)
 "iz" = (
 /turf/open/floor/plasteel/neutral/corner{
 	dir = 4
 	},
-/area/ruin/syndicate_lava_base/dormitories)
+/area/ruin/unpowered/syndicate_lava_base/dormitories)
 "iA" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -2915,7 +2915,7 @@
 /turf/open/floor/plasteel/neutral/side{
 	dir = 1
 	},
-/area/ruin/syndicate_lava_base/dormitories)
+/area/ruin/unpowered/syndicate_lava_base/dormitories)
 "iB" = (
 /obj/machinery/airalarm{
 	pixel_y = 24;
@@ -2926,10 +2926,10 @@
 /turf/open/floor/plasteel/neutral/corner{
 	dir = 1
 	},
-/area/ruin/syndicate_lava_base/dormitories)
+/area/ruin/unpowered/syndicate_lava_base/dormitories)
 "iC" = (
 /turf/open/floor/plasteel/floorgrime,
-/area/ruin/syndicate_lava_base/dormitories)
+/area/ruin/unpowered/syndicate_lava_base/dormitories)
 "iD" = (
 /obj/machinery/light/small{
 	dir = 1
@@ -2946,7 +2946,7 @@
 /turf/open/floor/plasteel/neutral/corner{
 	dir = 4
 	},
-/area/ruin/syndicate_lava_base/dormitories)
+/area/ruin/unpowered/syndicate_lava_base/dormitories)
 "iE" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -2957,14 +2957,14 @@
 /turf/open/floor/plasteel/neutral/side{
 	dir = 1
 	},
-/area/ruin/syndicate_lava_base/dormitories)
+/area/ruin/unpowered/syndicate_lava_base/dormitories)
 "iF" = (
 /obj/machinery/washing_machine,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/vault{
 	dir = 5
 	},
-/area/ruin/syndicate_lava_base/dormitories)
+/area/ruin/unpowered/syndicate_lava_base/dormitories)
 "iG" = (
 /obj/machinery/firealarm{
 	dir = 8;
@@ -2974,7 +2974,7 @@
 /turf/open/floor/plasteel/red/side{
 	dir = 8
 	},
-/area/ruin/syndicate_lava_base/main)
+/area/ruin/unpowered/syndicate_lava_base/main)
 "iH" = (
 /obj/effect/turf_decal/stripes/red/line{
 	icon_state = "warningline_red";
@@ -2986,7 +2986,7 @@
 	pixel_x = 6
 	},
 /turf/open/floor/plasteel,
-/area/ruin/syndicate_lava_base/main)
+/area/ruin/unpowered/syndicate_lava_base/main)
 "iI" = (
 /obj/machinery/door/airlock/vault{
 	id_tag = "syndie_lavaland_vault";
@@ -2996,16 +2996,16 @@
 /turf/open/floor/plasteel/vault{
 	dir = 8
 	},
-/area/ruin/syndicate_lava_base/main)
+/area/ruin/unpowered/syndicate_lava_base/main)
 "iJ" = (
 /turf/open/floor/circuit/red,
-/area/ruin/syndicate_lava_base/main)
+/area/ruin/unpowered/syndicate_lava_base/main)
 "iK" = (
 /obj/machinery/syndicatebomb/self_destruct{
 	anchored = 1
 	},
 /turf/open/floor/circuit/red,
-/area/ruin/syndicate_lava_base/main)
+/area/ruin/unpowered/syndicate_lava_base/main)
 "iL" = (
 /obj/machinery/airalarm{
 	dir = 8;
@@ -3014,7 +3014,7 @@
 	req_access = 152
 	},
 /turf/open/floor/circuit/red,
-/area/ruin/syndicate_lava_base/main)
+/area/ruin/unpowered/syndicate_lava_base/main)
 "iM" = (
 /obj/machinery/light/small{
 	dir = 4
@@ -3022,10 +3022,10 @@
 /turf/open/floor/plating{
 	initial_gas_mix = "o2=14;n2=23;TEMP=300"
 	},
-/area/ruin/syndicate_lava_base/arrivals)
+/area/ruin/unpowered/syndicate_lava_base/arrivals)
 "iN" = (
 /turf/closed/wall/mineral/plastitanium/explosive,
-/area/ruin/syndicate_lava_base/main)
+/area/ruin/unpowered/syndicate_lava_base/main)
 "iO" = (
 /obj/machinery/light/small{
 	dir = 8
@@ -3036,7 +3036,7 @@
 /turf/open/floor/plasteel/red/side{
 	dir = 8
 	},
-/area/ruin/syndicate_lava_base/main)
+/area/ruin/unpowered/syndicate_lava_base/main)
 "iP" = (
 /obj/structure/cable/yellow{
 	d1 = 1;
@@ -3051,7 +3051,7 @@
 	pixel_y = 5
 	},
 /turf/open/floor/plasteel,
-/area/ruin/syndicate_lava_base/main)
+/area/ruin/unpowered/syndicate_lava_base/main)
 "iQ" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -3068,7 +3068,7 @@
 	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel/floorgrime,
-/area/ruin/syndicate_lava_base/main)
+/area/ruin/unpowered/syndicate_lava_base/main)
 "iR" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/public/glass{
@@ -3089,7 +3089,7 @@
 	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel/floorgrime,
-/area/ruin/syndicate_lava_base/dormitories)
+/area/ruin/unpowered/syndicate_lava_base/dormitories)
 "iS" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
 	dir = 1
@@ -3107,7 +3107,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/neutral/side,
-/area/ruin/syndicate_lava_base/dormitories)
+/area/ruin/unpowered/syndicate_lava_base/dormitories)
 "iT" = (
 /obj/machinery/light/small,
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden,
@@ -3126,7 +3126,7 @@
 	dir = 8;
 	heat_capacity = 1e+006
 	},
-/area/ruin/syndicate_lava_base/dormitories)
+/area/ruin/unpowered/syndicate_lava_base/dormitories)
 "iU" = (
 /obj/machinery/atmospherics/pipe/manifold4w/supply/hidden,
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
@@ -3146,7 +3146,7 @@
 	icon_state = "2-4"
 	},
 /turf/open/floor/plasteel/floorgrime,
-/area/ruin/syndicate_lava_base/dormitories)
+/area/ruin/unpowered/syndicate_lava_base/dormitories)
 "iV" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -3169,7 +3169,7 @@
 	icon_state = "0-8"
 	},
 /turf/open/floor/plasteel/neutral/corner,
-/area/ruin/syndicate_lava_base/dormitories)
+/area/ruin/unpowered/syndicate_lava_base/dormitories)
 "iW" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
 	dir = 1
@@ -3181,7 +3181,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/neutral/side,
-/area/ruin/syndicate_lava_base/dormitories)
+/area/ruin/unpowered/syndicate_lava_base/dormitories)
 "iX" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 9
@@ -3197,7 +3197,7 @@
 	dir = 8;
 	heat_capacity = 1e+006
 	},
-/area/ruin/syndicate_lava_base/dormitories)
+/area/ruin/unpowered/syndicate_lava_base/dormitories)
 "iY" = (
 /obj/structure/table,
 /obj/structure/bedsheetbin,
@@ -3207,7 +3207,7 @@
 /turf/open/floor/plasteel/vault{
 	dir = 5
 	},
-/area/ruin/syndicate_lava_base/dormitories)
+/area/ruin/unpowered/syndicate_lava_base/dormitories)
 "iZ" = (
 /obj/structure/extinguisher_cabinet{
 	pixel_x = -27;
@@ -3217,7 +3217,7 @@
 /turf/open/floor/plasteel/red/side{
 	dir = 8
 	},
-/area/ruin/syndicate_lava_base/main)
+/area/ruin/unpowered/syndicate_lava_base/main)
 "ja" = (
 /obj/effect/turf_decal/stripes/red/corner{
 	icon_state = "warninglinecorner_red";
@@ -3233,7 +3233,7 @@
 	specialfunctions = 4
 	},
 /turf/open/floor/plasteel,
-/area/ruin/syndicate_lava_base/main)
+/area/ruin/unpowered/syndicate_lava_base/main)
 "jb" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/stripes/red/line{
@@ -3243,11 +3243,11 @@
 /turf/open/floor/plasteel/vault{
 	dir = 8
 	},
-/area/ruin/syndicate_lava_base/main)
+/area/ruin/unpowered/syndicate_lava_base/main)
 "jc" = (
 /obj/machinery/light/small,
 /turf/open/floor/circuit/red,
-/area/ruin/syndicate_lava_base/main)
+/area/ruin/unpowered/syndicate_lava_base/main)
 "jd" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/stripes/red/line{
@@ -3257,7 +3257,7 @@
 /turf/open/floor/plasteel/vault{
 	dir = 8
 	},
-/area/ruin/syndicate_lava_base/main)
+/area/ruin/unpowered/syndicate_lava_base/main)
 "je" = (
 /obj/effect/turf_decal/stripes/corner{
 	dir = 4
@@ -3279,7 +3279,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel,
-/area/ruin/syndicate_lava_base/dormitories)
+/area/ruin/unpowered/syndicate_lava_base/dormitories)
 "jg" = (
 /obj/machinery/door/airlock/maintenance,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -3296,7 +3296,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
-/area/ruin/syndicate_lava_base/dormitories)
+/area/ruin/unpowered/syndicate_lava_base/dormitories)
 "jh" = (
 /obj/machinery/door/airlock{
 	name = "Cabin 3";
@@ -3309,7 +3309,7 @@
 	pixel_y = 5
 	},
 /turf/open/floor/plasteel,
-/area/ruin/syndicate_lava_base/dormitories)
+/area/ruin/unpowered/syndicate_lava_base/dormitories)
 "ji" = (
 /obj/structure/cable/yellow{
 	icon_state = "0-2";
@@ -3325,10 +3325,10 @@
 /turf/open/floor/plasteel/red/side{
 	dir = 8
 	},
-/area/ruin/syndicate_lava_base/main)
+/area/ruin/unpowered/syndicate_lava_base/main)
 "jj" = (
 /turf/open/floor/plasteel,
-/area/ruin/syndicate_lava_base/main)
+/area/ruin/unpowered/syndicate_lava_base/main)
 "jk" = (
 /turf/open/floor/plating{
 	initial_gas_mix = "o2=14;n2=23;TEMP=300"
@@ -3338,13 +3338,13 @@
 /turf/open/floor/plasteel/red/side{
 	dir = 10
 	},
-/area/ruin/syndicate_lava_base/main)
+/area/ruin/unpowered/syndicate_lava_base/main)
 "jm" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/red/side{
 	dir = 6
 	},
-/area/ruin/syndicate_lava_base/main)
+/area/ruin/unpowered/syndicate_lava_base/main)
 "jn" = (
 /obj/effect/mob_spawn/human/lavaland_syndicate{
 	icon_state = "sleeper_s";
@@ -3355,7 +3355,7 @@
 	req_access = 152
 	},
 /turf/open/floor/plasteel/grimy,
-/area/ruin/syndicate_lava_base/dormitories)
+/area/ruin/unpowered/syndicate_lava_base/dormitories)
 "jo" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 1
@@ -3366,7 +3366,7 @@
 	pixel_y = 5
 	},
 /turf/open/floor/plasteel/grimy,
-/area/ruin/syndicate_lava_base/dormitories)
+/area/ruin/unpowered/syndicate_lava_base/dormitories)
 "jp" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -3382,7 +3382,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
-/area/ruin/syndicate_lava_base/main)
+/area/ruin/unpowered/syndicate_lava_base/main)
 "jq" = (
 /obj/effect/mob_spawn/human/lavaland_syndicate{
 	dir = 8;
@@ -3393,7 +3393,7 @@
 	req_access = 152
 	},
 /turf/open/floor/plasteel/grimy,
-/area/ruin/syndicate_lava_base/dormitories)
+/area/ruin/unpowered/syndicate_lava_base/dormitories)
 "jr" = (
 /obj/machinery/vending/snack/random{
 	extended_inventory = 1
@@ -3403,7 +3403,7 @@
 /turf/open/floor/plasteel/red/side{
 	dir = 9
 	},
-/area/ruin/syndicate_lava_base/main)
+/area/ruin/unpowered/syndicate_lava_base/main)
 "js" = (
 /obj/structure/cable/yellow{
 	d1 = 1;
@@ -3415,7 +3415,7 @@
 /turf/open/floor/plasteel/red/corner{
 	dir = 1
 	},
-/area/ruin/syndicate_lava_base/main)
+/area/ruin/unpowered/syndicate_lava_base/main)
 "jt" = (
 /obj/machinery/light/small{
 	dir = 4
@@ -3423,16 +3423,16 @@
 /turf/open/floor/plasteel/yellow/side{
 	dir = 4
 	},
-/area/ruin/syndicate_lava_base/main)
+/area/ruin/unpowered/syndicate_lava_base/main)
 "ju" = (
 /turf/closed/wall/mineral/plastitanium/nodiagonal,
-/area/ruin/syndicate_lava_base/engineering)
+/area/ruin/unpowered/syndicate_lava_base/engineering)
 "jv" = (
 /obj/effect/turf_decal/bot,
 /obj/structure/closet/toolcloset,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel,
-/area/ruin/syndicate_lava_base/engineering)
+/area/ruin/unpowered/syndicate_lava_base/engineering)
 "jw" = (
 /obj/effect/turf_decal/bot,
 /obj/structure/closet/firecloset/full{
@@ -3445,7 +3445,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel,
-/area/ruin/syndicate_lava_base/engineering)
+/area/ruin/unpowered/syndicate_lava_base/engineering)
 "jx" = (
 /obj/structure/grille,
 /obj/structure/window/plastitanium,
@@ -3455,23 +3455,23 @@
 	layer = 2.9
 	},
 /turf/open/floor/plating,
-/area/ruin/syndicate_lava_base/bar)
+/area/ruin/unpowered/syndicate_lava_base/bar)
 "jy" = (
 /turf/closed/wall/mineral/plastitanium/nodiagonal,
-/area/ruin/syndicate_lava_base/bar)
+/area/ruin/unpowered/syndicate_lava_base/bar)
 "jz" = (
 /obj/machinery/door/airlock/public/glass{
 	name = "Bar"
 	},
 /obj/machinery/door/firedoor,
 /turf/open/floor/plasteel,
-/area/ruin/syndicate_lava_base/bar)
+/area/ruin/unpowered/syndicate_lava_base/bar)
 "jA" = (
 /obj/structure/table/wood,
 /obj/item/ammo_box/magazine/m10mm,
 /obj/item/ammo_box/magazine/sniper_rounds,
 /turf/open/floor/plasteel/grimy,
-/area/ruin/syndicate_lava_base/dormitories)
+/area/ruin/unpowered/syndicate_lava_base/dormitories)
 "jB" = (
 /obj/machinery/light/small{
 	dir = 4
@@ -3483,7 +3483,7 @@
 	pixel_y = 5
 	},
 /turf/open/floor/plasteel/grimy,
-/area/ruin/syndicate_lava_base/dormitories)
+/area/ruin/unpowered/syndicate_lava_base/dormitories)
 "jC" = (
 /obj/machinery/light/small{
 	brightness = 3;
@@ -3496,7 +3496,7 @@
 	pixel_y = 5
 	},
 /turf/open/floor/plasteel/grimy,
-/area/ruin/syndicate_lava_base/dormitories)
+/area/ruin/unpowered/syndicate_lava_base/dormitories)
 "jD" = (
 /obj/machinery/vending/cola/random{
 	extended_inventory = 1
@@ -3505,7 +3505,7 @@
 /turf/open/floor/plasteel/red/side{
 	dir = 8
 	},
-/area/ruin/syndicate_lava_base/main)
+/area/ruin/unpowered/syndicate_lava_base/main)
 "jE" = (
 /obj/structure/cable/yellow{
 	d1 = 2;
@@ -3527,7 +3527,7 @@
 	pixel_y = 5
 	},
 /turf/open/floor/plasteel,
-/area/ruin/syndicate_lava_base/main)
+/area/ruin/unpowered/syndicate_lava_base/main)
 "jF" = (
 /obj/structure/cable/yellow{
 	d1 = 4;
@@ -3546,7 +3546,7 @@
 /turf/open/floor/plasteel/yellow/side{
 	dir = 4
 	},
-/area/ruin/syndicate_lava_base/main)
+/area/ruin/unpowered/syndicate_lava_base/main)
 "jG" = (
 /obj/effect/turf_decal/delivery,
 /obj/machinery/door/firedoor,
@@ -3569,7 +3569,7 @@
 	req_access_txt = "150"
 	},
 /turf/open/floor/plasteel,
-/area/ruin/syndicate_lava_base/engineering)
+/area/ruin/unpowered/syndicate_lava_base/engineering)
 "jH" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 9
@@ -3589,7 +3589,7 @@
 	pixel_y = 5
 	},
 /turf/open/floor/plasteel,
-/area/ruin/syndicate_lava_base/engineering)
+/area/ruin/unpowered/syndicate_lava_base/engineering)
 "jI" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 5
@@ -3618,7 +3618,7 @@
 	pixel_y = 5
 	},
 /turf/open/floor/plasteel,
-/area/ruin/syndicate_lava_base/engineering)
+/area/ruin/unpowered/syndicate_lava_base/engineering)
 "jJ" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
 	dir = 6;
@@ -3627,7 +3627,7 @@
 	pixel_y = 5
 	},
 /turf/closed/wall/mineral/plastitanium/nodiagonal,
-/area/ruin/syndicate_lava_base/engineering)
+/area/ruin/unpowered/syndicate_lava_base/engineering)
 "jK" = (
 /obj/machinery/atmospherics/components/unary/outlet_injector/on{
 	dir = 8;
@@ -3636,7 +3636,7 @@
 	pixel_y = 5
 	},
 /turf/open/floor/plating/asteroid/basalt/lava_land_surface,
-/area/ruin/syndicate_lava_base/engineering)
+/area/ruin/unpowered/syndicate_lava_base/engineering)
 "jL" = (
 /obj/structure/table,
 /obj/effect/decal/cleanable/dirt,
@@ -3651,7 +3651,7 @@
 /turf/open/floor/plasteel/vault{
 	dir = 5
 	},
-/area/ruin/syndicate_lava_base/bar)
+/area/ruin/unpowered/syndicate_lava_base/bar)
 "jM" = (
 /obj/machinery/light/small{
 	dir = 1
@@ -3667,22 +3667,22 @@
 	req_access_txt = "150"
 	},
 /turf/open/floor/plasteel/dark,
-/area/ruin/syndicate_lava_base/bar)
+/area/ruin/unpowered/syndicate_lava_base/bar)
 "jN" = (
 /turf/open/floor/plasteel/vault{
 	dir = 5
 	},
-/area/ruin/syndicate_lava_base/bar)
+/area/ruin/unpowered/syndicate_lava_base/bar)
 "jO" = (
 /obj/structure/extinguisher_cabinet{
 	pixel_x = 25;
 	pixel_y = 0
 	},
 /turf/open/floor/plasteel/dark,
-/area/ruin/syndicate_lava_base/bar)
+/area/ruin/unpowered/syndicate_lava_base/bar)
 "jP" = (
 /turf/closed/wall/mineral/plastitanium/explosive,
-/area/ruin/syndicate_lava_base/bar)
+/area/ruin/unpowered/syndicate_lava_base/bar)
 "jQ" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -3697,7 +3697,7 @@
 	pixel_y = 0
 	},
 /turf/open/floor/plating,
-/area/ruin/syndicate_lava_base/main)
+/area/ruin/unpowered/syndicate_lava_base/main)
 "jR" = (
 /obj/machinery/light/small{
 	brightness = 3;
@@ -3706,7 +3706,7 @@
 /turf/open/floor/plasteel/red/corner{
 	dir = 1
 	},
-/area/ruin/syndicate_lava_base/main)
+/area/ruin/unpowered/syndicate_lava_base/main)
 "jS" = (
 /obj/structure/cable/yellow{
 	d1 = 1;
@@ -3721,17 +3721,17 @@
 	pixel_y = 5
 	},
 /turf/open/floor/plasteel,
-/area/ruin/syndicate_lava_base/main)
+/area/ruin/unpowered/syndicate_lava_base/main)
 "jT" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/yellow/side{
 	dir = 4
 	},
-/area/ruin/syndicate_lava_base/main)
+/area/ruin/unpowered/syndicate_lava_base/main)
 "jU" = (
 /obj/structure/sign/engineering,
 /turf/closed/wall/mineral/plastitanium/nodiagonal,
-/area/ruin/syndicate_lava_base/engineering)
+/area/ruin/unpowered/syndicate_lava_base/engineering)
 "jV" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 10
@@ -3748,7 +3748,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel,
-/area/ruin/syndicate_lava_base/engineering)
+/area/ruin/unpowered/syndicate_lava_base/engineering)
 "jW" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 6
@@ -3767,7 +3767,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel,
-/area/ruin/syndicate_lava_base/engineering)
+/area/ruin/unpowered/syndicate_lava_base/engineering)
 "jX" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
 	piping_layer = 3;
@@ -3775,22 +3775,22 @@
 	pixel_y = 5
 	},
 /turf/closed/wall/mineral/plastitanium/explosive,
-/area/ruin/syndicate_lava_base/engineering)
+/area/ruin/unpowered/syndicate_lava_base/engineering)
 "jY" = (
 /obj/structure/chair{
 	dir = 1
 	},
 /turf/open/floor/plasteel/dark,
-/area/ruin/syndicate_lava_base/bar)
+/area/ruin/unpowered/syndicate_lava_base/bar)
 "jZ" = (
 /turf/open/floor/plasteel/dark,
-/area/ruin/syndicate_lava_base/bar)
+/area/ruin/unpowered/syndicate_lava_base/bar)
 "ka" = (
 /obj/structure/closet/crate/bin,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/dark,
-/area/ruin/syndicate_lava_base/bar)
+/area/ruin/unpowered/syndicate_lava_base/bar)
 "kb" = (
 /obj/structure/rack{
 	dir = 8;
@@ -3806,7 +3806,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
-/area/ruin/syndicate_lava_base/main)
+/area/ruin/unpowered/syndicate_lava_base/main)
 "kc" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 6
@@ -3824,7 +3824,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
-/area/ruin/syndicate_lava_base/main)
+/area/ruin/unpowered/syndicate_lava_base/main)
 "kd" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden,
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
@@ -3845,7 +3845,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
-/area/ruin/syndicate_lava_base/main)
+/area/ruin/unpowered/syndicate_lava_base/main)
 "ke" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
 	dir = 1
@@ -3868,7 +3868,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
-/area/ruin/syndicate_lava_base/main)
+/area/ruin/unpowered/syndicate_lava_base/main)
 "kf" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -3885,7 +3885,7 @@
 	icon_state = "4-8"
 	},
 /turf/open/floor/plating,
-/area/ruin/syndicate_lava_base/main)
+/area/ruin/unpowered/syndicate_lava_base/main)
 "kg" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -3903,7 +3903,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
-/area/ruin/syndicate_lava_base/main)
+/area/ruin/unpowered/syndicate_lava_base/main)
 "kh" = (
 /obj/machinery/door/airlock/maintenance,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -3921,7 +3921,7 @@
 	icon_state = "4-8"
 	},
 /turf/open/floor/plating,
-/area/ruin/syndicate_lava_base/main)
+/area/ruin/unpowered/syndicate_lava_base/main)
 "ki" = (
 /obj/structure/cable/yellow{
 	d1 = 1;
@@ -3938,7 +3938,7 @@
 	pixel_y = 5
 	},
 /turf/open/floor/plasteel,
-/area/ruin/syndicate_lava_base/main)
+/area/ruin/unpowered/syndicate_lava_base/main)
 "kj" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 8;
@@ -3950,7 +3950,7 @@
 	dir = 8
 	},
 /turf/open/floor/plasteel,
-/area/ruin/syndicate_lava_base/main)
+/area/ruin/unpowered/syndicate_lava_base/main)
 "kk" = (
 /obj/effect/turf_decal/delivery,
 /obj/machinery/door/firedoor,
@@ -3971,7 +3971,7 @@
 	req_access_txt = "150"
 	},
 /turf/open/floor/plasteel,
-/area/ruin/syndicate_lava_base/engineering)
+/area/ruin/unpowered/syndicate_lava_base/engineering)
 "kl" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
 	piping_layer = 3;
@@ -3979,7 +3979,7 @@
 	pixel_y = 5
 	},
 /turf/closed/wall/mineral/plastitanium/nodiagonal,
-/area/ruin/syndicate_lava_base/engineering)
+/area/ruin/unpowered/syndicate_lava_base/engineering)
 "km" = (
 /obj/structure/cable/yellow{
 	icon_state = "0-2";
@@ -3989,13 +3989,13 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/floorgrime,
-/area/ruin/syndicate_lava_base/engineering)
+/area/ruin/unpowered/syndicate_lava_base/engineering)
 "kn" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/vault{
 	dir = 5
 	},
-/area/ruin/syndicate_lava_base/bar)
+/area/ruin/unpowered/syndicate_lava_base/bar)
 "ko" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 4;
@@ -4007,7 +4007,7 @@
 /turf/open/floor/plasteel/vault{
 	dir = 5
 	},
-/area/ruin/syndicate_lava_base/bar)
+/area/ruin/unpowered/syndicate_lava_base/bar)
 "kp" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 10;
@@ -4016,7 +4016,7 @@
 	pixel_y = 5
 	},
 /turf/open/floor/plasteel/dark,
-/area/ruin/syndicate_lava_base/bar)
+/area/ruin/unpowered/syndicate_lava_base/bar)
 "kq" = (
 /obj/machinery/airalarm{
 	dir = 8;
@@ -4031,7 +4031,7 @@
 /turf/open/floor/plasteel/vault{
 	dir = 5
 	},
-/area/ruin/syndicate_lava_base/bar)
+/area/ruin/unpowered/syndicate_lava_base/bar)
 "kr" = (
 /obj/machinery/door/airlock/maintenance{
 	req_access_txt = "150"
@@ -4050,34 +4050,34 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
-/area/ruin/syndicate_lava_base/bar)
+/area/ruin/unpowered/syndicate_lava_base/bar)
 "ks" = (
 /obj/structure/reagent_dispensers/fueltank,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
-/area/ruin/syndicate_lava_base/main)
+/area/ruin/unpowered/syndicate_lava_base/main)
 "kt" = (
 /obj/structure/grille,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
-/area/ruin/syndicate_lava_base/main)
+/area/ruin/unpowered/syndicate_lava_base/main)
 "ku" = (
 /turf/open/floor/plasteel/white/side,
-/area/ruin/syndicate_lava_base/main)
+/area/ruin/unpowered/syndicate_lava_base/main)
 "kv" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/white/side,
-/area/ruin/syndicate_lava_base/main)
+/area/ruin/unpowered/syndicate_lava_base/main)
 "kw" = (
 /obj/structure/table,
 /obj/item/tank/internals/emergency_oxygen,
 /obj/item/clothing/mask/breath,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/white/side,
-/area/ruin/syndicate_lava_base/main)
+/area/ruin/unpowered/syndicate_lava_base/main)
 "kx" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 9
@@ -4089,7 +4089,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
-/area/ruin/syndicate_lava_base/engineering)
+/area/ruin/unpowered/syndicate_lava_base/engineering)
 "ky" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 5
@@ -4106,7 +4106,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
-/area/ruin/syndicate_lava_base/engineering)
+/area/ruin/unpowered/syndicate_lava_base/engineering)
 "kz" = (
 /obj/structure/cable/yellow{
 	d1 = 1;
@@ -4126,7 +4126,7 @@
 	pixel_y = 5
 	},
 /turf/open/floor/plasteel/floorgrime,
-/area/ruin/syndicate_lava_base/engineering)
+/area/ruin/unpowered/syndicate_lava_base/engineering)
 "kA" = (
 /obj/machinery/light/small{
 	dir = 1
@@ -4154,7 +4154,7 @@
 	pixel_y = 5
 	},
 /turf/open/floor/plasteel/floorgrime,
-/area/ruin/syndicate_lava_base/engineering)
+/area/ruin/unpowered/syndicate_lava_base/engineering)
 "kB" = (
 /obj/structure/cable/yellow{
 	d1 = 1;
@@ -4163,7 +4163,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/floorgrime,
-/area/ruin/syndicate_lava_base/engineering)
+/area/ruin/unpowered/syndicate_lava_base/engineering)
 "kC" = (
 /obj/machinery/computer/atmos_control/tank{
 	dir = 8;
@@ -4177,26 +4177,26 @@
 /turf/open/floor/plasteel/red/side{
 	dir = 4
 	},
-/area/ruin/syndicate_lava_base/engineering)
+/area/ruin/unpowered/syndicate_lava_base/engineering)
 "kD" = (
 /obj/structure/grille,
 /obj/structure/window/plastitanium,
 /turf/open/floor/plating,
-/area/ruin/syndicate_lava_base/engineering)
+/area/ruin/unpowered/syndicate_lava_base/engineering)
 "kE" = (
 /obj/machinery/air_sensor{
 	frequency = 1442;
 	id_tag = "syndie_lavaland_n2_sensor"
 	},
 /turf/open/floor/plating/airless,
-/area/ruin/syndicate_lava_base/engineering)
+/area/ruin/unpowered/syndicate_lava_base/engineering)
 "kF" = (
 /obj/machinery/atmospherics/miner/nitrogen,
 /obj/machinery/light/small{
 	dir = 4
 	},
 /turf/open/floor/plating/airless,
-/area/ruin/syndicate_lava_base/engineering)
+/area/ruin/unpowered/syndicate_lava_base/engineering)
 "kG" = (
 /obj/structure/table,
 /obj/item/reagent_containers/food/drinks/beer,
@@ -4204,19 +4204,19 @@
 /turf/open/floor/plasteel/vault{
 	dir = 5
 	},
-/area/ruin/syndicate_lava_base/bar)
+/area/ruin/unpowered/syndicate_lava_base/bar)
 "kH" = (
 /obj/structure/chair{
 	dir = 8
 	},
 /turf/open/floor/plasteel/dark,
-/area/ruin/syndicate_lava_base/bar)
+/area/ruin/unpowered/syndicate_lava_base/bar)
 "kI" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
-/area/ruin/syndicate_lava_base/bar)
+/area/ruin/unpowered/syndicate_lava_base/bar)
 "kJ" = (
 /obj/structure/chair/stool/bar,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -4226,14 +4226,14 @@
 /turf/open/floor/plasteel/vault{
 	dir = 5
 	},
-/area/ruin/syndicate_lava_base/bar)
+/area/ruin/unpowered/syndicate_lava_base/bar)
 "kK" = (
 /obj/structure/chair/stool/bar,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
-/area/ruin/syndicate_lava_base/bar)
+/area/ruin/unpowered/syndicate_lava_base/bar)
 "kL" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 10
@@ -4247,7 +4247,7 @@
 /turf/open/floor/plasteel/vault{
 	dir = 5
 	},
-/area/ruin/syndicate_lava_base/bar)
+/area/ruin/unpowered/syndicate_lava_base/bar)
 "kM" = (
 /obj/machinery/firealarm{
 	dir = 4;
@@ -4262,13 +4262,13 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/dark,
-/area/ruin/syndicate_lava_base/bar)
+/area/ruin/unpowered/syndicate_lava_base/bar)
 "kN" = (
 /obj/structure/reagent_dispensers/beerkeg,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/dark,
-/area/ruin/syndicate_lava_base/bar)
+/area/ruin/unpowered/syndicate_lava_base/bar)
 "kO" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -4284,24 +4284,24 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/dark,
-/area/ruin/syndicate_lava_base/bar)
+/area/ruin/unpowered/syndicate_lava_base/bar)
 "kP" = (
 /obj/structure/reagent_dispensers/watertank,
 /obj/item/reagent_containers/glass/bucket,
 /obj/item/mop,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
-/area/ruin/syndicate_lava_base/main)
+/area/ruin/unpowered/syndicate_lava_base/main)
 "kQ" = (
 /turf/closed/wall/mineral/plastitanium/nodiagonal,
-/area/ruin/syndicate_lava_base/medbay)
+/area/ruin/unpowered/syndicate_lava_base/medbay)
 "kR" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/medical/glass{
 	name = "Medbay"
 	},
 /turf/open/floor/plasteel/white,
-/area/ruin/syndicate_lava_base/medbay)
+/area/ruin/unpowered/syndicate_lava_base/medbay)
 "kS" = (
 /obj/machinery/door/firedoor,
 /obj/effect/decal/cleanable/dirt,
@@ -4309,14 +4309,14 @@
 	name = "Medbay"
 	},
 /turf/open/floor/plasteel/white,
-/area/ruin/syndicate_lava_base/medbay)
+/area/ruin/unpowered/syndicate_lava_base/medbay)
 "kT" = (
 /obj/structure/sign/bluecross_2,
 /turf/closed/wall/mineral/plastitanium/nodiagonal,
-/area/ruin/syndicate_lava_base/medbay)
+/area/ruin/unpowered/syndicate_lava_base/medbay)
 "kU" = (
 /turf/closed/wall/mineral/plastitanium/explosive,
-/area/ruin/syndicate_lava_base/engineering)
+/area/ruin/unpowered/syndicate_lava_base/engineering)
 "kV" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -4329,7 +4329,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
-/area/ruin/syndicate_lava_base/engineering)
+/area/ruin/unpowered/syndicate_lava_base/engineering)
 "kW" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -4338,7 +4338,7 @@
 /obj/structure/cable/yellow,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
-/area/ruin/syndicate_lava_base/engineering)
+/area/ruin/unpowered/syndicate_lava_base/engineering)
 "kX" = (
 /obj/machinery/atmospherics/pipe/simple/supply/visible{
 	icon_state = "intact";
@@ -4350,13 +4350,13 @@
 	pixel_y = 5
 	},
 /turf/open/floor/plasteel/floorgrime,
-/area/ruin/syndicate_lava_base/engineering)
+/area/ruin/unpowered/syndicate_lava_base/engineering)
 "kY" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/visible{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
-/area/ruin/syndicate_lava_base/engineering)
+/area/ruin/unpowered/syndicate_lava_base/engineering)
 "kZ" = (
 /obj/machinery/atmospherics/components/trinary/mixer/flipped{
 	dir = 4;
@@ -4365,7 +4365,7 @@
 	on = 1
 	},
 /turf/open/floor/plasteel/floorgrime,
-/area/ruin/syndicate_lava_base/engineering)
+/area/ruin/unpowered/syndicate_lava_base/engineering)
 "la" = (
 /obj/machinery/atmospherics/pipe/simple/supplymain/visible{
 	dir = 4
@@ -4376,7 +4376,7 @@
 /turf/open/floor/plasteel/red/side{
 	dir = 4
 	},
-/area/ruin/syndicate_lava_base/engineering)
+/area/ruin/unpowered/syndicate_lava_base/engineering)
 "lb" = (
 /obj/structure/grille,
 /obj/structure/window/plastitanium,
@@ -4384,7 +4384,7 @@
 	dir = 4
 	},
 /turf/open/floor/plating,
-/area/ruin/syndicate_lava_base/engineering)
+/area/ruin/unpowered/syndicate_lava_base/engineering)
 "lc" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/siphon/on{
 	dir = 8;
@@ -4393,10 +4393,10 @@
 	name = "nitrogen out"
 	},
 /turf/open/floor/plating/airless,
-/area/ruin/syndicate_lava_base/engineering)
+/area/ruin/unpowered/syndicate_lava_base/engineering)
 "ld" = (
 /turf/open/floor/plating/airless,
-/area/ruin/syndicate_lava_base/engineering)
+/area/ruin/unpowered/syndicate_lava_base/engineering)
 "le" = (
 /obj/machinery/light/small{
 	dir = 4
@@ -4405,7 +4405,7 @@
 /turf/open/floor/plating{
 	initial_gas_mix = "o2=14;n2=23;TEMP=300"
 	},
-/area/ruin/syndicate_lava_base/arrivals)
+/area/ruin/unpowered/syndicate_lava_base/arrivals)
 "lf" = (
 /obj/machinery/light/small{
 	dir = 8
@@ -4419,18 +4419,18 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/dark,
-/area/ruin/syndicate_lava_base/bar)
+/area/ruin/unpowered/syndicate_lava_base/bar)
 "lg" = (
 /obj/structure/chair/stool/bar,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/vault{
 	dir = 5
 	},
-/area/ruin/syndicate_lava_base/bar)
+/area/ruin/unpowered/syndicate_lava_base/bar)
 "lh" = (
 /obj/structure/table/wood,
 /turf/open/floor/wood,
-/area/ruin/syndicate_lava_base/bar)
+/area/ruin/unpowered/syndicate_lava_base/bar)
 "li" = (
 /obj/structure/table/wood,
 /obj/item/toy/cards/deck/syndicate{
@@ -4442,7 +4442,7 @@
 	broken = 1;
 	icon_state = "wood-broken4"
 	},
-/area/ruin/syndicate_lava_base/bar)
+/area/ruin/unpowered/syndicate_lava_base/bar)
 "lj" = (
 /obj/machinery/door/window/southleft{
 	base_state = "right";
@@ -4458,7 +4458,7 @@
 	pixel_y = 5
 	},
 /turf/open/floor/wood,
-/area/ruin/syndicate_lava_base/bar)
+/area/ruin/unpowered/syndicate_lava_base/bar)
 "lk" = (
 /obj/structure/table/wood,
 /obj/machinery/light/small{
@@ -4478,7 +4478,7 @@
 /obj/item/book/manual/barman_recipes,
 /obj/item/reagent_containers/food/drinks/shaker,
 /turf/open/floor/wood,
-/area/ruin/syndicate_lava_base/bar)
+/area/ruin/unpowered/syndicate_lava_base/bar)
 "ll" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -4493,7 +4493,7 @@
 	pixel_y = 0
 	},
 /turf/open/floor/plasteel/dark,
-/area/ruin/syndicate_lava_base/bar)
+/area/ruin/unpowered/syndicate_lava_base/bar)
 "lm" = (
 /obj/structure/closet/secure_closet/medical1{
 	req_access = null;
@@ -4504,12 +4504,12 @@
 /turf/open/floor/plasteel/white/side{
 	dir = 9
 	},
-/area/ruin/syndicate_lava_base/medbay)
+/area/ruin/unpowered/syndicate_lava_base/medbay)
 "ln" = (
 /turf/open/floor/plasteel/white/side{
 	dir = 1
 	},
-/area/ruin/syndicate_lava_base/medbay)
+/area/ruin/unpowered/syndicate_lava_base/medbay)
 "lo" = (
 /obj/machinery/light/small{
 	dir = 1
@@ -4521,7 +4521,7 @@
 /turf/open/floor/plasteel/white/side{
 	dir = 5
 	},
-/area/ruin/syndicate_lava_base/medbay)
+/area/ruin/unpowered/syndicate_lava_base/medbay)
 "lp" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 10
@@ -4535,7 +4535,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
-/area/ruin/syndicate_lava_base/engineering)
+/area/ruin/unpowered/syndicate_lava_base/engineering)
 "lq" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 6
@@ -4554,7 +4554,7 @@
 	icon_state = "2-8"
 	},
 /turf/open/floor/plating,
-/area/ruin/syndicate_lava_base/engineering)
+/area/ruin/unpowered/syndicate_lava_base/engineering)
 "lr" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
 	piping_layer = 3;
@@ -4562,17 +4562,17 @@
 	pixel_y = 5
 	},
 /turf/open/floor/plasteel,
-/area/ruin/syndicate_lava_base/engineering)
+/area/ruin/unpowered/syndicate_lava_base/engineering)
 "ls" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
-/area/ruin/syndicate_lava_base/engineering)
+/area/ruin/unpowered/syndicate_lava_base/engineering)
 "lt" = (
 /obj/machinery/atmospherics/pipe/simple/supplymain/visible,
 /turf/open/floor/plasteel,
-/area/ruin/syndicate_lava_base/engineering)
+/area/ruin/unpowered/syndicate_lava_base/engineering)
 "lu" = (
 /obj/machinery/light/small{
 	dir = 4
@@ -4580,7 +4580,7 @@
 /obj/machinery/portable_atmospherics/scrubber,
 /obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel/floorgrime,
-/area/ruin/syndicate_lava_base/engineering)
+/area/ruin/unpowered/syndicate_lava_base/engineering)
 "lv" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 10
@@ -4603,11 +4603,11 @@
 /turf/open/floor/plasteel/vault{
 	dir = 5
 	},
-/area/ruin/syndicate_lava_base/bar)
+/area/ruin/unpowered/syndicate_lava_base/bar)
 "ly" = (
 /obj/structure/chair/stool/bar,
 /turf/open/floor/plasteel/dark,
-/area/ruin/syndicate_lava_base/bar)
+/area/ruin/unpowered/syndicate_lava_base/bar)
 "lz" = (
 /obj/structure/table/wood,
 /obj/item/reagent_containers/glass/rag{
@@ -4620,10 +4620,10 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/wood,
-/area/ruin/syndicate_lava_base/bar)
+/area/ruin/unpowered/syndicate_lava_base/bar)
 "lA" = (
 /turf/open/floor/wood,
-/area/ruin/syndicate_lava_base/bar)
+/area/ruin/unpowered/syndicate_lava_base/bar)
 "lB" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -4632,7 +4632,7 @@
 	pixel_y = 5
 	},
 /turf/open/floor/wood,
-/area/ruin/syndicate_lava_base/bar)
+/area/ruin/unpowered/syndicate_lava_base/bar)
 "lC" = (
 /obj/structure/table/wood,
 /obj/machinery/reagentgrinder,
@@ -4642,17 +4642,17 @@
 	pixel_y = 0
 	},
 /turf/open/floor/wood,
-/area/ruin/syndicate_lava_base/bar)
+/area/ruin/unpowered/syndicate_lava_base/bar)
 "lD" = (
 /obj/machinery/vending/boozeomat{
 	req_access_txt = "0"
 	},
 /turf/closed/wall/mineral/plastitanium/nodiagonal,
-/area/ruin/syndicate_lava_base/bar)
+/area/ruin/unpowered/syndicate_lava_base/bar)
 "lE" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/dark,
-/area/ruin/syndicate_lava_base/bar)
+/area/ruin/unpowered/syndicate_lava_base/bar)
 "lF" = (
 /obj/machinery/light/small{
 	dir = 4
@@ -4682,7 +4682,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/dark,
-/area/ruin/syndicate_lava_base/bar)
+/area/ruin/unpowered/syndicate_lava_base/bar)
 "lG" = (
 /obj/structure/table,
 /obj/item/storage/box/syringes,
@@ -4692,20 +4692,20 @@
 /turf/open/floor/plasteel/white/side{
 	dir = 9
 	},
-/area/ruin/syndicate_lava_base/medbay)
+/area/ruin/unpowered/syndicate_lava_base/medbay)
 "lH" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/white/corner{
 	dir = 1
 	},
-/area/ruin/syndicate_lava_base/medbay)
+/area/ruin/unpowered/syndicate_lava_base/medbay)
 "lI" = (
 /turf/open/floor/plasteel,
-/area/ruin/syndicate_lava_base/medbay)
+/area/ruin/unpowered/syndicate_lava_base/medbay)
 "lJ" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel,
-/area/ruin/syndicate_lava_base/medbay)
+/area/ruin/unpowered/syndicate_lava_base/medbay)
 "lK" = (
 /obj/structure/table,
 /obj/item/storage/firstaid/regular,
@@ -4713,7 +4713,7 @@
 /turf/open/floor/plasteel/white/side{
 	dir = 4
 	},
-/area/ruin/syndicate_lava_base/medbay)
+/area/ruin/unpowered/syndicate_lava_base/medbay)
 "lL" = (
 /obj/machinery/airalarm{
 	dir = 4;
@@ -4740,7 +4740,7 @@
 /obj/item/clothing/head/welding,
 /obj/item/pipe_dispenser,
 /turf/open/floor/plasteel/floorgrime,
-/area/ruin/syndicate_lava_base/engineering)
+/area/ruin/unpowered/syndicate_lava_base/engineering)
 "lM" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -4755,7 +4755,7 @@
 	pixel_y = 5
 	},
 /turf/open/floor/plasteel,
-/area/ruin/syndicate_lava_base/engineering)
+/area/ruin/unpowered/syndicate_lava_base/engineering)
 "lN" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
 	dir = 9;
@@ -4764,10 +4764,10 @@
 	pixel_y = 5
 	},
 /turf/open/floor/plasteel,
-/area/ruin/syndicate_lava_base/engineering)
+/area/ruin/unpowered/syndicate_lava_base/engineering)
 "lO" = (
 /turf/open/floor/plasteel/floorgrime,
-/area/ruin/syndicate_lava_base/engineering)
+/area/ruin/unpowered/syndicate_lava_base/engineering)
 "lP" = (
 /obj/machinery/computer/atmos_control/tank{
 	dir = 8;
@@ -4780,34 +4780,34 @@
 /turf/open/floor/plasteel/blue/side{
 	dir = 4
 	},
-/area/ruin/syndicate_lava_base/engineering)
+/area/ruin/unpowered/syndicate_lava_base/engineering)
 "lQ" = (
 /obj/machinery/air_sensor{
 	frequency = 1442;
 	id_tag = "Syndicate_Construction_o2_sensor"
 	},
 /turf/open/floor/plating/airless,
-/area/ruin/syndicate_lava_base/engineering)
+/area/ruin/unpowered/syndicate_lava_base/engineering)
 "lR" = (
 /obj/machinery/atmospherics/miner/oxygen,
 /obj/machinery/light/small{
 	dir = 4
 	},
 /turf/open/floor/plating/airless,
-/area/ruin/syndicate_lava_base/engineering)
+/area/ruin/unpowered/syndicate_lava_base/engineering)
 "lS" = (
 /obj/machinery/porta_turret/syndicate{
 	dir = 9
 	},
 /turf/closed/wall/mineral/plastitanium/nodiagonal,
-/area/ruin/syndicate_lava_base/arrivals)
+/area/ruin/unpowered/syndicate_lava_base/arrivals)
 "lT" = (
 /obj/structure/fans/tiny,
 /obj/machinery/door/airlock/external{
 	req_access_txt = "150"
 	},
 /turf/open/floor/plating,
-/area/ruin/syndicate_lava_base/arrivals)
+/area/ruin/unpowered/syndicate_lava_base/arrivals)
 "lU" = (
 /obj/machinery/airalarm{
 	dir = 4;
@@ -4819,13 +4819,13 @@
 /turf/open/floor/plasteel/vault{
 	dir = 5
 	},
-/area/ruin/syndicate_lava_base/bar)
+/area/ruin/unpowered/syndicate_lava_base/bar)
 "lV" = (
 /obj/structure/chair/stool/bar,
 /turf/open/floor/plasteel/vault{
 	dir = 5
 	},
-/area/ruin/syndicate_lava_base/bar)
+/area/ruin/unpowered/syndicate_lava_base/bar)
 "lW" = (
 /obj/structure/table/wood,
 /obj/structure/cable/yellow{
@@ -4835,7 +4835,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/wood,
-/area/ruin/syndicate_lava_base/bar)
+/area/ruin/unpowered/syndicate_lava_base/bar)
 "lX" = (
 /obj/structure/cable/yellow{
 	d1 = 4;
@@ -4843,7 +4843,7 @@
 	icon_state = "4-8"
 	},
 /turf/open/floor/wood,
-/area/ruin/syndicate_lava_base/bar)
+/area/ruin/unpowered/syndicate_lava_base/bar)
 "lY" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 5
@@ -4860,7 +4860,7 @@
 	icon_state = "4-8"
 	},
 /turf/open/floor/wood,
-/area/ruin/syndicate_lava_base/bar)
+/area/ruin/unpowered/syndicate_lava_base/bar)
 "lZ" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -4877,7 +4877,7 @@
 	icon_state = "4-8"
 	},
 /turf/open/floor/wood,
-/area/ruin/syndicate_lava_base/bar)
+/area/ruin/unpowered/syndicate_lava_base/bar)
 "ma" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -4898,7 +4898,7 @@
 	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel/dark,
-/area/ruin/syndicate_lava_base/bar)
+/area/ruin/unpowered/syndicate_lava_base/bar)
 "mb" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -4915,7 +4915,7 @@
 	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel/dark,
-/area/ruin/syndicate_lava_base/bar)
+/area/ruin/unpowered/syndicate_lava_base/bar)
 "mc" = (
 /obj/structure/closet/crate,
 /obj/item/storage/box/donkpockets{
@@ -4945,14 +4945,14 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/dark,
-/area/ruin/syndicate_lava_base/bar)
+/area/ruin/unpowered/syndicate_lava_base/bar)
 "md" = (
 /obj/machinery/sleeper/syndie{
 	dir = 4
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/floorgrime,
-/area/ruin/syndicate_lava_base/medbay)
+/area/ruin/unpowered/syndicate_lava_base/medbay)
 "me" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	piping_layer = 3;
@@ -4960,7 +4960,7 @@
 	pixel_y = 5
 	},
 /turf/open/floor/plasteel,
-/area/ruin/syndicate_lava_base/medbay)
+/area/ruin/unpowered/syndicate_lava_base/medbay)
 "mf" = (
 /obj/structure/sink{
 	dir = 4;
@@ -4973,7 +4973,7 @@
 	req_access = 152
 	},
 /turf/open/floor/plasteel/floorgrime,
-/area/ruin/syndicate_lava_base/medbay)
+/area/ruin/unpowered/syndicate_lava_base/medbay)
 "mg" = (
 /obj/machinery/firealarm{
 	dir = 8;
@@ -4984,7 +4984,7 @@
 /obj/item/stock_parts/cell/high/plus,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/floorgrime,
-/area/ruin/syndicate_lava_base/engineering)
+/area/ruin/unpowered/syndicate_lava_base/engineering)
 "mh" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -4993,14 +4993,14 @@
 	pixel_y = 0
 	},
 /turf/open/floor/plasteel,
-/area/ruin/syndicate_lava_base/engineering)
+/area/ruin/unpowered/syndicate_lava_base/engineering)
 "mi" = (
 /obj/machinery/atmospherics/pipe/simple/orange/visible{
 	icon_state = "intact";
 	dir = 6
 	},
 /turf/open/floor/plasteel/floorgrime,
-/area/ruin/syndicate_lava_base/engineering)
+/area/ruin/unpowered/syndicate_lava_base/engineering)
 "mj" = (
 /obj/machinery/atmospherics/components/binary/pump{
 	dir = 8;
@@ -5009,11 +5009,11 @@
 	target_pressure = 4500
 	},
 /turf/open/floor/plasteel/floorgrime,
-/area/ruin/syndicate_lava_base/engineering)
+/area/ruin/unpowered/syndicate_lava_base/engineering)
 "mk" = (
 /obj/machinery/atmospherics/pipe/manifold/supplymain/visible,
 /turf/open/floor/plasteel/floorgrime,
-/area/ruin/syndicate_lava_base/engineering)
+/area/ruin/unpowered/syndicate_lava_base/engineering)
 "ml" = (
 /obj/machinery/atmospherics/pipe/simple/supplymain/visible{
 	dir = 4
@@ -5022,7 +5022,7 @@
 /turf/open/floor/plasteel/blue/side{
 	dir = 4
 	},
-/area/ruin/syndicate_lava_base/engineering)
+/area/ruin/unpowered/syndicate_lava_base/engineering)
 "mm" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/siphon/on{
 	dir = 8;
@@ -5031,13 +5031,13 @@
 	name = "oxygen out"
 	},
 /turf/open/floor/plating/airless,
-/area/ruin/syndicate_lava_base/engineering)
+/area/ruin/unpowered/syndicate_lava_base/engineering)
 "mn" = (
 /turf/closed/wall/mineral/plastitanium/nodiagonal,
-/area/ruin/syndicate_lava_base/telecomms)
+/area/ruin/unpowered/syndicate_lava_base/telecomms)
 "mo" = (
 /turf/closed/wall/mineral/plastitanium/explosive,
-/area/ruin/syndicate_lava_base/telecomms)
+/area/ruin/unpowered/syndicate_lava_base/telecomms)
 "mp" = (
 /obj/structure/grille,
 /obj/structure/window/plastitanium,
@@ -5047,16 +5047,16 @@
 	layer = 2.9
 	},
 /turf/open/floor/plating,
-/area/ruin/syndicate_lava_base/telecomms)
+/area/ruin/unpowered/syndicate_lava_base/telecomms)
 "mq" = (
 /obj/structure/sign/vacuum{
 	pixel_x = -32
 	},
 /turf/open/floor/plating,
-/area/ruin/syndicate_lava_base/arrivals)
+/area/ruin/unpowered/syndicate_lava_base/arrivals)
 "mr" = (
 /turf/open/floor/plating,
-/area/ruin/syndicate_lava_base/arrivals)
+/area/ruin/unpowered/syndicate_lava_base/arrivals)
 "ms" = (
 /obj/machinery/light/small{
 	dir = 4
@@ -5069,13 +5069,13 @@
 /obj/item/device/flashlight/seclite,
 /obj/item/clothing/mask/gas,
 /turf/open/floor/plating,
-/area/ruin/syndicate_lava_base/arrivals)
+/area/ruin/unpowered/syndicate_lava_base/arrivals)
 "mt" = (
 /obj/machinery/computer/arcade/orion_trail,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/dark,
-/area/ruin/syndicate_lava_base/bar)
+/area/ruin/unpowered/syndicate_lava_base/bar)
 "mu" = (
 /obj/item/twohanded/required/kirbyplants{
 	icon_state = "plant-22"
@@ -5083,7 +5083,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/dark,
-/area/ruin/syndicate_lava_base/bar)
+/area/ruin/unpowered/syndicate_lava_base/bar)
 "mv" = (
 /obj/structure/table/wood,
 /obj/machinery/light/small,
@@ -5096,23 +5096,23 @@
 	req_access = 150
 	},
 /turf/open/floor/wood,
-/area/ruin/syndicate_lava_base/bar)
+/area/ruin/unpowered/syndicate_lava_base/bar)
 "mw" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/wood,
-/area/ruin/syndicate_lava_base/bar)
+/area/ruin/unpowered/syndicate_lava_base/bar)
 "mx" = (
 /obj/structure/table/wood,
 /obj/machinery/microwave,
 /turf/open/floor/wood,
-/area/ruin/syndicate_lava_base/bar)
+/area/ruin/unpowered/syndicate_lava_base/bar)
 "my" = (
 /obj/structure/closet/secure_closet/freezer/fridge,
 /obj/item/reagent_containers/food/condiment/enzyme,
 /obj/item/reagent_containers/food/snacks/chocolatebar,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/dark,
-/area/ruin/syndicate_lava_base/bar)
+/area/ruin/unpowered/syndicate_lava_base/bar)
 "mz" = (
 /obj/machinery/door/airlock/maintenance,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -5129,7 +5129,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
-/area/ruin/syndicate_lava_base/main)
+/area/ruin/unpowered/syndicate_lava_base/main)
 "mA" = (
 /obj/machinery/light/small{
 	dir = 8
@@ -5145,7 +5145,7 @@
 /turf/open/floor/plasteel/white/side{
 	dir = 8
 	},
-/area/ruin/syndicate_lava_base/medbay)
+/area/ruin/unpowered/syndicate_lava_base/medbay)
 "mB" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 6
@@ -5156,19 +5156,19 @@
 	pixel_y = 5
 	},
 /turf/open/floor/plasteel,
-/area/ruin/syndicate_lava_base/medbay)
+/area/ruin/unpowered/syndicate_lava_base/medbay)
 "mC" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
-/area/ruin/syndicate_lava_base/medbay)
+/area/ruin/unpowered/syndicate_lava_base/medbay)
 "mD" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
-/area/ruin/syndicate_lava_base/medbay)
+/area/ruin/unpowered/syndicate_lava_base/medbay)
 "mE" = (
 /obj/structure/table/reinforced,
 /obj/item/scalpel,
@@ -5183,7 +5183,7 @@
 /turf/open/floor/plasteel/white/side{
 	dir = 4
 	},
-/area/ruin/syndicate_lava_base/medbay)
+/area/ruin/unpowered/syndicate_lava_base/medbay)
 "mF" = (
 /obj/structure/extinguisher_cabinet{
 	pixel_x = -27;
@@ -5191,7 +5191,7 @@
 	},
 /obj/structure/chair/stool,
 /turf/open/floor/plasteel/floorgrime,
-/area/ruin/syndicate_lava_base/engineering)
+/area/ruin/unpowered/syndicate_lava_base/engineering)
 "mG" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -5200,14 +5200,14 @@
 	pixel_y = 0
 	},
 /turf/open/floor/plasteel/floorgrime,
-/area/ruin/syndicate_lava_base/engineering)
+/area/ruin/unpowered/syndicate_lava_base/engineering)
 "mH" = (
 /obj/machinery/atmospherics/pipe/manifold/orange/visible{
 	icon_state = "manifold";
 	dir = 8
 	},
 /turf/open/floor/plasteel/floorgrime,
-/area/ruin/syndicate_lava_base/engineering)
+/area/ruin/unpowered/syndicate_lava_base/engineering)
 "mI" = (
 /obj/effect/turf_decal/stripes/corner,
 /obj/machinery/light/small,
@@ -5218,7 +5218,7 @@
 /obj/structure/reagent_dispensers/fueltank,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/floorgrime,
-/area/ruin/syndicate_lava_base/engineering)
+/area/ruin/unpowered/syndicate_lava_base/engineering)
 "mJ" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/machinery/atmospherics/pipe/simple/orange/visible{
@@ -5228,7 +5228,7 @@
 /obj/structure/reagent_dispensers/watertank,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/floorgrime,
-/area/ruin/syndicate_lava_base/engineering)
+/area/ruin/unpowered/syndicate_lava_base/engineering)
 "mK" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/machinery/computer/atmos_control/tank{
@@ -5242,14 +5242,14 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel,
-/area/ruin/syndicate_lava_base/engineering)
+/area/ruin/unpowered/syndicate_lava_base/engineering)
 "mM" = (
 /turf/open/floor/circuit/green,
-/area/ruin/syndicate_lava_base/telecomms)
+/area/ruin/unpowered/syndicate_lava_base/telecomms)
 "mN" = (
 /obj/structure/sign/securearea,
 /turf/closed/wall/mineral/plastitanium/nodiagonal,
-/area/ruin/syndicate_lava_base/telecomms)
+/area/ruin/unpowered/syndicate_lava_base/telecomms)
 "mO" = (
 /obj/structure/filingcabinet/security,
 /obj/machinery/button/door{
@@ -5260,36 +5260,36 @@
 	req_access_txt = "150"
 	},
 /turf/open/floor/plasteel/dark,
-/area/ruin/syndicate_lava_base/telecomms)
+/area/ruin/unpowered/syndicate_lava_base/telecomms)
 "mP" = (
 /obj/structure/filingcabinet/security,
 /turf/open/floor/plasteel/dark,
-/area/ruin/syndicate_lava_base/telecomms)
+/area/ruin/unpowered/syndicate_lava_base/telecomms)
 "mQ" = (
 /turf/open/floor/plasteel/dark,
-/area/ruin/syndicate_lava_base/telecomms)
+/area/ruin/unpowered/syndicate_lava_base/telecomms)
 "mR" = (
 /obj/structure/table,
 /obj/item/storage/toolbox/syndicate,
 /obj/item/device/multitool,
 /turf/open/floor/plasteel/dark,
-/area/ruin/syndicate_lava_base/telecomms)
+/area/ruin/unpowered/syndicate_lava_base/telecomms)
 "mS" = (
 /obj/machinery/door/airlock/external{
 	req_access_txt = "150"
 	},
 /obj/structure/fans/tiny,
 /turf/open/floor/plating,
-/area/ruin/syndicate_lava_base/arrivals)
+/area/ruin/unpowered/syndicate_lava_base/arrivals)
 "mT" = (
 /turf/closed/wall/mineral/plastitanium/nodiagonal,
-/area/ruin/syndicate_lava_base/arrivals)
+/area/ruin/unpowered/syndicate_lava_base/arrivals)
 "mU" = (
 /obj/structure/grille,
 /obj/structure/window/plastitanium,
 /obj/machinery/door/firedoor,
 /turf/open/floor/plating,
-/area/ruin/syndicate_lava_base/bar)
+/area/ruin/unpowered/syndicate_lava_base/bar)
 "mV" = (
 /obj/structure/table/wood,
 /obj/machinery/chem_dispenser/drinks/beer,
@@ -5299,12 +5299,12 @@
 	req_access_txt = "150"
 	},
 /turf/open/floor/wood,
-/area/ruin/syndicate_lava_base/bar)
+/area/ruin/unpowered/syndicate_lava_base/bar)
 "mW" = (
 /obj/structure/table/wood,
 /obj/machinery/chem_dispenser/drinks,
 /turf/open/floor/wood,
-/area/ruin/syndicate_lava_base/bar)
+/area/ruin/unpowered/syndicate_lava_base/bar)
 "mX" = (
 /obj/structure/rack{
 	dir = 8;
@@ -5320,7 +5320,7 @@
 /turf/open/floor/plasteel/red/side{
 	dir = 8
 	},
-/area/ruin/syndicate_lava_base/arrivals)
+/area/ruin/unpowered/syndicate_lava_base/arrivals)
 "mY" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -5339,13 +5339,13 @@
 /turf/open/floor/plasteel/white/side{
 	dir = 4
 	},
-/area/ruin/syndicate_lava_base/arrivals)
+/area/ruin/unpowered/syndicate_lava_base/arrivals)
 "mZ" = (
 /obj/machinery/sleeper/syndie{
 	dir = 4
 	},
 /turf/open/floor/plasteel/floorgrime,
-/area/ruin/syndicate_lava_base/medbay)
+/area/ruin/unpowered/syndicate_lava_base/medbay)
 "na" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -5354,7 +5354,7 @@
 	pixel_y = 5
 	},
 /turf/open/floor/plasteel/floorgrime,
-/area/ruin/syndicate_lava_base/medbay)
+/area/ruin/unpowered/syndicate_lava_base/medbay)
 "nb" = (
 /obj/structure/table/optable,
 /obj/item/surgical_drapes,
@@ -5362,7 +5362,7 @@
 /turf/open/floor/plasteel/white/side{
 	dir = 4
 	},
-/area/ruin/syndicate_lava_base/medbay)
+/area/ruin/unpowered/syndicate_lava_base/medbay)
 "nc" = (
 /obj/machinery/computer/turbine_computer{
 	dir = 1;
@@ -5385,7 +5385,7 @@
 /obj/effect/turf_decal/stripes/line,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/floorgrime,
-/area/ruin/syndicate_lava_base/engineering)
+/area/ruin/unpowered/syndicate_lava_base/engineering)
 "nd" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -5396,7 +5396,7 @@
 /obj/effect/turf_decal/stripes/line,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel,
-/area/ruin/syndicate_lava_base/engineering)
+/area/ruin/unpowered/syndicate_lava_base/engineering)
 "ne" = (
 /obj/machinery/atmospherics/pipe/simple/orange/visible,
 /obj/machinery/doorButtons/airlock_controller{
@@ -5416,17 +5416,17 @@
 /obj/effect/turf_decal/stripes/line,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/floorgrime,
-/area/ruin/syndicate_lava_base/engineering)
+/area/ruin/unpowered/syndicate_lava_base/engineering)
 "nf" = (
 /obj/structure/sign/fire,
 /turf/closed/wall/mineral/plastitanium/nodiagonal,
-/area/ruin/syndicate_lava_base/engineering)
+/area/ruin/unpowered/syndicate_lava_base/engineering)
 "ng" = (
 /obj/structure/grille,
 /obj/structure/window/plastitanium,
 /obj/machinery/atmospherics/pipe/simple/orange/visible,
 /turf/open/floor/plating,
-/area/ruin/syndicate_lava_base/engineering)
+/area/ruin/unpowered/syndicate_lava_base/engineering)
 "nh" = (
 /obj/machinery/telecomms/relay/preset/ruskie{
 	use_power = 0
@@ -5438,12 +5438,12 @@
 /turf/open/floor/plasteel/vault{
 	dir = 5
 	},
-/area/ruin/syndicate_lava_base/telecomms)
+/area/ruin/unpowered/syndicate_lava_base/telecomms)
 "ni" = (
 /turf/open/floor/plasteel/vault{
 	dir = 5
 	},
-/area/ruin/syndicate_lava_base/telecomms)
+/area/ruin/unpowered/syndicate_lava_base/telecomms)
 "nj" = (
 /obj/machinery/door/airlock/hatch{
 	name = "Telecommunications Control";
@@ -5452,7 +5452,7 @@
 /turf/open/floor/plasteel/vault{
 	dir = 5
 	},
-/area/ruin/syndicate_lava_base/telecomms)
+/area/ruin/unpowered/syndicate_lava_base/telecomms)
 "nk" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 4;
@@ -5463,7 +5463,7 @@
 /turf/open/floor/plasteel/vault{
 	dir = 5
 	},
-/area/ruin/syndicate_lava_base/telecomms)
+/area/ruin/unpowered/syndicate_lava_base/telecomms)
 "nl" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4;
@@ -5474,7 +5474,7 @@
 /turf/open/floor/plasteel/vault{
 	dir = 5
 	},
-/area/ruin/syndicate_lava_base/telecomms)
+/area/ruin/unpowered/syndicate_lava_base/telecomms)
 "nm" = (
 /obj/machinery/light/small{
 	dir = 4
@@ -5493,13 +5493,13 @@
 /turf/open/floor/plasteel/vault{
 	dir = 5
 	},
-/area/ruin/syndicate_lava_base/telecomms)
+/area/ruin/unpowered/syndicate_lava_base/telecomms)
 "nn" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
 /turf/open/floor/plasteel/floorgrime,
-/area/ruin/syndicate_lava_base/arrivals)
+/area/ruin/unpowered/syndicate_lava_base/arrivals)
 "no" = (
 /obj/effect/turf_decal/stripes/corner{
 	dir = 4
@@ -5507,24 +5507,24 @@
 /turf/open/floor/plasteel/red/corner{
 	dir = 4
 	},
-/area/ruin/syndicate_lava_base/arrivals)
+/area/ruin/unpowered/syndicate_lava_base/arrivals)
 "np" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/red/side{
 	dir = 1
 	},
-/area/ruin/syndicate_lava_base/arrivals)
+/area/ruin/unpowered/syndicate_lava_base/arrivals)
 "nq" = (
 /turf/open/floor/plasteel/red/side{
 	dir = 1
 	},
-/area/ruin/syndicate_lava_base/arrivals)
+/area/ruin/unpowered/syndicate_lava_base/arrivals)
 "nr" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/red/side{
 	dir = 5
 	},
-/area/ruin/syndicate_lava_base/arrivals)
+/area/ruin/unpowered/syndicate_lava_base/arrivals)
 "ns" = (
 /obj/structure/closet/emcloset/anchored,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -5545,7 +5545,7 @@
 /turf/open/floor/plasteel/red/side{
 	dir = 9
 	},
-/area/ruin/syndicate_lava_base/arrivals)
+/area/ruin/unpowered/syndicate_lava_base/arrivals)
 "nt" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -5576,7 +5576,7 @@
 /turf/open/floor/plasteel/red/side{
 	dir = 1
 	},
-/area/ruin/syndicate_lava_base/arrivals)
+/area/ruin/unpowered/syndicate_lava_base/arrivals)
 "nu" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -5595,7 +5595,7 @@
 /turf/open/floor/plasteel/red/side{
 	dir = 1
 	},
-/area/ruin/syndicate_lava_base/arrivals)
+/area/ruin/unpowered/syndicate_lava_base/arrivals)
 "nv" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -5614,7 +5614,7 @@
 /turf/open/floor/plasteel/red/corner{
 	dir = 1
 	},
-/area/ruin/syndicate_lava_base/arrivals)
+/area/ruin/unpowered/syndicate_lava_base/arrivals)
 "nw" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden,
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
@@ -5636,7 +5636,7 @@
 /turf/open/floor/plasteel/white/side{
 	dir = 4
 	},
-/area/ruin/syndicate_lava_base/arrivals)
+/area/ruin/unpowered/syndicate_lava_base/arrivals)
 "nx" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -5657,7 +5657,7 @@
 	name = "Medbay"
 	},
 /turf/open/floor/plasteel/white,
-/area/ruin/syndicate_lava_base/medbay)
+/area/ruin/unpowered/syndicate_lava_base/medbay)
 "ny" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -5676,7 +5676,7 @@
 /turf/open/floor/plasteel/white/side{
 	dir = 8
 	},
-/area/ruin/syndicate_lava_base/medbay)
+/area/ruin/unpowered/syndicate_lava_base/medbay)
 "nz" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 9
@@ -5693,7 +5693,7 @@
 	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel,
-/area/ruin/syndicate_lava_base/medbay)
+/area/ruin/unpowered/syndicate_lava_base/medbay)
 "nA" = (
 /obj/structure/cable/yellow{
 	d1 = 2;
@@ -5701,14 +5701,14 @@
 	icon_state = "2-8"
 	},
 /turf/open/floor/plasteel/white/corner,
-/area/ruin/syndicate_lava_base/medbay)
+/area/ruin/unpowered/syndicate_lava_base/medbay)
 "nB" = (
 /obj/structure/table/reinforced,
 /obj/item/surgicaldrill,
 /obj/item/cautery,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/white/side,
-/area/ruin/syndicate_lava_base/medbay)
+/area/ruin/unpowered/syndicate_lava_base/medbay)
 "nC" = (
 /obj/structure/table/reinforced,
 /obj/item/retractor,
@@ -5717,7 +5717,7 @@
 /turf/open/floor/plasteel/white/side{
 	dir = 6
 	},
-/area/ruin/syndicate_lava_base/medbay)
+/area/ruin/unpowered/syndicate_lava_base/medbay)
 "nD" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -5736,11 +5736,11 @@
 	req_access_txt = "150"
 	},
 /turf/open/floor/engine,
-/area/ruin/syndicate_lava_base/engineering)
+/area/ruin/unpowered/syndicate_lava_base/engineering)
 "nE" = (
 /obj/machinery/atmospherics/pipe/simple/orange/visible,
 /turf/closed/wall/mineral/plastitanium/nodiagonal,
-/area/ruin/syndicate_lava_base/engineering)
+/area/ruin/unpowered/syndicate_lava_base/engineering)
 "nF" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/siphon/on{
 	dir = 1;
@@ -5749,14 +5749,14 @@
 	name = "toxin out"
 	},
 /turf/open/floor/plating/airless,
-/area/ruin/syndicate_lava_base/engineering)
+/area/ruin/unpowered/syndicate_lava_base/engineering)
 "nG" = (
 /obj/machinery/air_sensor{
 	frequency = 1442;
 	id_tag = "syndie_lavaland_tox_sensor"
 	},
 /turf/open/floor/plating/airless,
-/area/ruin/syndicate_lava_base/engineering)
+/area/ruin/unpowered/syndicate_lava_base/engineering)
 "nH" = (
 /obj/machinery/airalarm{
 	dir = 4;
@@ -5771,13 +5771,13 @@
 /turf/open/floor/plasteel/vault{
 	dir = 5
 	},
-/area/ruin/syndicate_lava_base/telecomms)
+/area/ruin/unpowered/syndicate_lava_base/telecomms)
 "nI" = (
 /obj/machinery/computer/camera_advanced,
 /turf/open/floor/plasteel/vault{
 	dir = 5
 	},
-/area/ruin/syndicate_lava_base/telecomms)
+/area/ruin/unpowered/syndicate_lava_base/telecomms)
 "nJ" = (
 /obj/structure/table/reinforced,
 /obj/item/device/radio/intercom{
@@ -5790,7 +5790,7 @@
 /turf/open/floor/plasteel/vault{
 	dir = 5
 	},
-/area/ruin/syndicate_lava_base/telecomms)
+/area/ruin/unpowered/syndicate_lava_base/telecomms)
 "nK" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 5
@@ -5809,7 +5809,7 @@
 /turf/open/floor/plasteel/vault{
 	dir = 5
 	},
-/area/ruin/syndicate_lava_base/telecomms)
+/area/ruin/unpowered/syndicate_lava_base/telecomms)
 "nL" = (
 /obj/machinery/door/airlock/hatch{
 	name = "Telecommunications";
@@ -5832,7 +5832,7 @@
 /turf/open/floor/plasteel/vault{
 	dir = 5
 	},
-/area/ruin/syndicate_lava_base/telecomms)
+/area/ruin/unpowered/syndicate_lava_base/telecomms)
 "nM" = (
 /obj/machinery/light/small,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -5851,7 +5851,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/floorgrime,
-/area/ruin/syndicate_lava_base/arrivals)
+/area/ruin/unpowered/syndicate_lava_base/arrivals)
 "nN" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -5868,7 +5868,7 @@
 	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel,
-/area/ruin/syndicate_lava_base/arrivals)
+/area/ruin/unpowered/syndicate_lava_base/arrivals)
 "nO" = (
 /obj/effect/turf_decal/stripes/corner,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -5886,7 +5886,7 @@
 	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel/floorgrime,
-/area/ruin/syndicate_lava_base/arrivals)
+/area/ruin/unpowered/syndicate_lava_base/arrivals)
 "nP" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/effect/turf_decal/caution/stand_clear{
@@ -5908,7 +5908,7 @@
 	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel,
-/area/ruin/syndicate_lava_base/arrivals)
+/area/ruin/unpowered/syndicate_lava_base/arrivals)
 "nQ" = (
 /obj/effect/turf_decal/stripes/corner{
 	dir = 1
@@ -5929,7 +5929,7 @@
 	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel,
-/area/ruin/syndicate_lava_base/arrivals)
+/area/ruin/unpowered/syndicate_lava_base/arrivals)
 "nR" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -5948,7 +5948,7 @@
 /turf/open/floor/plasteel/red/corner{
 	dir = 4
 	},
-/area/ruin/syndicate_lava_base/arrivals)
+/area/ruin/unpowered/syndicate_lava_base/arrivals)
 "nS" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
 	dir = 1
@@ -5971,7 +5971,7 @@
 /turf/open/floor/plasteel/red/side{
 	dir = 1
 	},
-/area/ruin/syndicate_lava_base/arrivals)
+/area/ruin/unpowered/syndicate_lava_base/arrivals)
 "nT" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -5990,7 +5990,7 @@
 /turf/open/floor/plasteel/red/side{
 	dir = 1
 	},
-/area/ruin/syndicate_lava_base/arrivals)
+/area/ruin/unpowered/syndicate_lava_base/arrivals)
 "nU" = (
 /obj/machinery/light/small{
 	dir = 1
@@ -6017,7 +6017,7 @@
 /turf/open/floor/plasteel/red/side{
 	dir = 1
 	},
-/area/ruin/syndicate_lava_base/arrivals)
+/area/ruin/unpowered/syndicate_lava_base/arrivals)
 "nV" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 9
@@ -6036,31 +6036,31 @@
 /turf/open/floor/plasteel/red/corner{
 	dir = 1
 	},
-/area/ruin/syndicate_lava_base/arrivals)
+/area/ruin/unpowered/syndicate_lava_base/arrivals)
 "nW" = (
 /turf/open/floor/plasteel,
-/area/ruin/syndicate_lava_base/arrivals)
+/area/ruin/unpowered/syndicate_lava_base/arrivals)
 "nX" = (
 /turf/open/floor/plasteel/floorgrime,
-/area/ruin/syndicate_lava_base/arrivals)
+/area/ruin/unpowered/syndicate_lava_base/arrivals)
 "nY" = (
 /obj/machinery/light/small,
 /turf/open/floor/plasteel/floorgrime,
-/area/ruin/syndicate_lava_base/arrivals)
+/area/ruin/unpowered/syndicate_lava_base/arrivals)
 "nZ" = (
 /turf/open/floor/plasteel/white/side{
 	dir = 4
 	},
-/area/ruin/syndicate_lava_base/arrivals)
+/area/ruin/unpowered/syndicate_lava_base/arrivals)
 "oa" = (
 /turf/open/floor/plasteel/white/side{
 	dir = 10
 	},
-/area/ruin/syndicate_lava_base/medbay)
+/area/ruin/unpowered/syndicate_lava_base/medbay)
 "ob" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/white/side,
-/area/ruin/syndicate_lava_base/medbay)
+/area/ruin/unpowered/syndicate_lava_base/medbay)
 "oc" = (
 /obj/machinery/light/small,
 /obj/structure/extinguisher_cabinet{
@@ -6079,7 +6079,7 @@
 /turf/open/floor/plasteel/white/side{
 	dir = 6
 	},
-/area/ruin/syndicate_lava_base/medbay)
+/area/ruin/unpowered/syndicate_lava_base/medbay)
 "od" = (
 /obj/machinery/light/small{
 	dir = 8
@@ -6093,7 +6093,7 @@
 	pixel_y = -24
 	},
 /turf/open/floor/engine,
-/area/ruin/syndicate_lava_base/engineering)
+/area/ruin/unpowered/syndicate_lava_base/engineering)
 "oe" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -6102,7 +6102,7 @@
 	pixel_y = 0
 	},
 /turf/open/floor/engine,
-/area/ruin/syndicate_lava_base/engineering)
+/area/ruin/unpowered/syndicate_lava_base/engineering)
 "of" = (
 /obj/machinery/light/small{
 	dir = 4
@@ -6120,12 +6120,12 @@
 	pixel_y = 24
 	},
 /turf/open/floor/engine,
-/area/ruin/syndicate_lava_base/engineering)
+/area/ruin/unpowered/syndicate_lava_base/engineering)
 "og" = (
 /obj/machinery/atmospherics/miner/toxins,
 /obj/machinery/light/small,
 /turf/open/floor/plating/airless,
-/area/ruin/syndicate_lava_base/engineering)
+/area/ruin/unpowered/syndicate_lava_base/engineering)
 "oh" = (
 /obj/machinery/firealarm{
 	dir = 8;
@@ -6134,7 +6134,7 @@
 /turf/open/floor/plasteel/vault{
 	dir = 5
 	},
-/area/ruin/syndicate_lava_base/telecomms)
+/area/ruin/unpowered/syndicate_lava_base/telecomms)
 "oi" = (
 /obj/structure/chair/office/dark{
 	dir = 4
@@ -6142,7 +6142,7 @@
 /turf/open/floor/plasteel/vault{
 	dir = 5
 	},
-/area/ruin/syndicate_lava_base/telecomms)
+/area/ruin/unpowered/syndicate_lava_base/telecomms)
 "oj" = (
 /obj/structure/table/reinforced,
 /obj/item/device/radio/intercom{
@@ -6155,7 +6155,7 @@
 /turf/open/floor/plasteel/vault{
 	dir = 5
 	},
-/area/ruin/syndicate_lava_base/telecomms)
+/area/ruin/unpowered/syndicate_lava_base/telecomms)
 "ok" = (
 /obj/structure/chair{
 	dir = 8
@@ -6171,7 +6171,7 @@
 /turf/open/floor/plasteel/vault{
 	dir = 5
 	},
-/area/ruin/syndicate_lava_base/telecomms)
+/area/ruin/unpowered/syndicate_lava_base/telecomms)
 "ol" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -6186,11 +6186,11 @@
 /obj/item/device/mining_scanner,
 /obj/item/pickaxe,
 /turf/open/floor/mineral/plastitanium,
-/area/ruin/syndicate_lava_base/arrivals)
+/area/ruin/unpowered/syndicate_lava_base/arrivals)
 "om" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/red/side,
-/area/ruin/syndicate_lava_base/arrivals)
+/area/ruin/unpowered/syndicate_lava_base/arrivals)
 "on" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 1
@@ -6201,10 +6201,10 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/red/side,
-/area/ruin/syndicate_lava_base/arrivals)
+/area/ruin/unpowered/syndicate_lava_base/arrivals)
 "oo" = (
 /turf/open/floor/plasteel/red/side,
-/area/ruin/syndicate_lava_base/arrivals)
+/area/ruin/unpowered/syndicate_lava_base/arrivals)
 "op" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 1;
@@ -6213,7 +6213,7 @@
 	pixel_y = 5
 	},
 /turf/open/floor/plasteel/red/side,
-/area/ruin/syndicate_lava_base/arrivals)
+/area/ruin/unpowered/syndicate_lava_base/arrivals)
 "oq" = (
 /obj/machinery/button/door{
 	id = "lavalandsyndi_arrivals";
@@ -6223,7 +6223,7 @@
 	req_access_txt = "150"
 	},
 /turf/open/floor/plasteel/red/side,
-/area/ruin/syndicate_lava_base/arrivals)
+/area/ruin/unpowered/syndicate_lava_base/arrivals)
 "or" = (
 /obj/structure/rack{
 	dir = 8;
@@ -6235,7 +6235,7 @@
 /obj/item/clothing/glasses/hud/health,
 /obj/item/clothing/neck/stethoscope,
 /turf/open/floor/plasteel/white,
-/area/ruin/syndicate_lava_base/medbay)
+/area/ruin/unpowered/syndicate_lava_base/medbay)
 "os" = (
 /obj/machinery/vending/medical{
 	desc = "Medical drug dispenser. Looks to have been outfitted with illicit software.";
@@ -6248,7 +6248,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/white,
-/area/ruin/syndicate_lava_base/medbay)
+/area/ruin/unpowered/syndicate_lava_base/medbay)
 "ot" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -6267,23 +6267,23 @@
 	req_access_txt = "150"
 	},
 /turf/open/floor/engine,
-/area/ruin/syndicate_lava_base/engineering)
+/area/ruin/unpowered/syndicate_lava_base/engineering)
 "ou" = (
 /obj/machinery/computer/message_monitor{
 	dir = 1
 	},
 /obj/item/paper/monitorkey,
 /turf/open/floor/plasteel/dark,
-/area/ruin/syndicate_lava_base/telecomms)
+/area/ruin/unpowered/syndicate_lava_base/telecomms)
 "ov" = (
 /obj/structure/table/reinforced,
 /obj/item/paper_bin,
 /obj/item/pen,
 /turf/open/floor/plasteel/dark,
-/area/ruin/syndicate_lava_base/telecomms)
+/area/ruin/unpowered/syndicate_lava_base/telecomms)
 "ow" = (
 /turf/closed/wall/mineral/plastitanium/explosive,
-/area/ruin/syndicate_lava_base/arrivals)
+/area/ruin/unpowered/syndicate_lava_base/arrivals)
 "ox" = (
 /obj/structure/grille,
 /obj/structure/window/plastitanium,
@@ -6293,15 +6293,15 @@
 	layer = 2.9
 	},
 /turf/open/floor/plating,
-/area/ruin/syndicate_lava_base/arrivals)
+/area/ruin/unpowered/syndicate_lava_base/arrivals)
 "oy" = (
 /turf/closed/wall/mineral/plastitanium/explosive,
-/area/ruin/syndicate_lava_base/medbay)
+/area/ruin/unpowered/syndicate_lava_base/medbay)
 "oz" = (
 /turf/open/floor/engine{
 	initial_gas_mix = "o2=14;n2=23;TEMP=300"
 	},
-/area/ruin/syndicate_lava_base/engineering)
+/area/ruin/unpowered/syndicate_lava_base/engineering)
 "oA" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -6318,7 +6318,7 @@
 /turf/open/floor/engine{
 	initial_gas_mix = "o2=14;n2=23;TEMP=300"
 	},
-/area/ruin/syndicate_lava_base/engineering)
+/area/ruin/unpowered/syndicate_lava_base/engineering)
 "oB" = (
 /obj/structure/sign/securearea{
 	desc = "A warning sign which reads 'EXTERNAL AIRLOCK'";
@@ -6335,7 +6335,7 @@
 /turf/open/floor/engine{
 	initial_gas_mix = "o2=14;n2=23;TEMP=300"
 	},
-/area/ruin/syndicate_lava_base/engineering)
+/area/ruin/unpowered/syndicate_lava_base/engineering)
 "oC" = (
 /obj/machinery/door/poddoor{
 	id = "syndie_lavaland_auxincineratorvent";
@@ -6344,7 +6344,7 @@
 /turf/open/floor/engine{
 	initial_gas_mix = "o2=14;n2=23;TEMP=300"
 	},
-/area/ruin/syndicate_lava_base/engineering)
+/area/ruin/unpowered/syndicate_lava_base/engineering)
 "oD" = (
 /obj/structure/sign/xeno_warning_mining{
 	pixel_x = -32
@@ -6353,7 +6353,7 @@
 	pixel_x = 32
 	},
 /turf/open/floor/plating,
-/area/ruin/syndicate_lava_base/arrivals)
+/area/ruin/unpowered/syndicate_lava_base/arrivals)
 "oE" = (
 /obj/structure/cable,
 /obj/structure/cable{
@@ -6369,11 +6369,11 @@
 /turf/open/floor/engine{
 	initial_gas_mix = "o2=14;n2=23;TEMP=300"
 	},
-/area/ruin/syndicate_lava_base/engineering)
+/area/ruin/unpowered/syndicate_lava_base/engineering)
 "oF" = (
 /obj/structure/sign/securearea,
 /turf/closed/wall/mineral/plastitanium/nodiagonal,
-/area/ruin/syndicate_lava_base/arrivals)
+/area/ruin/unpowered/syndicate_lava_base/arrivals)
 "oG" = (
 /obj/structure/cable,
 /obj/machinery/power/turbine{
@@ -6383,7 +6383,7 @@
 /turf/open/floor/engine{
 	initial_gas_mix = "o2=14;n2=23;TEMP=300"
 	},
-/area/ruin/syndicate_lava_base/engineering)
+/area/ruin/unpowered/syndicate_lava_base/engineering)
 "oH" = (
 /obj/machinery/door/poddoor{
 	id = "syndie_lavaland_turbinevent";
@@ -6392,7 +6392,7 @@
 /turf/open/floor/engine{
 	initial_gas_mix = "o2=14;n2=23;TEMP=300"
 	},
-/area/ruin/syndicate_lava_base/engineering)
+/area/ruin/unpowered/syndicate_lava_base/engineering)
 "oI" = (
 /obj/structure/sign/vacuum{
 	pixel_x = -32
@@ -6402,7 +6402,7 @@
 	dir = 8
 	},
 /turf/open/floor/plating,
-/area/ruin/syndicate_lava_base/arrivals)
+/area/ruin/unpowered/syndicate_lava_base/arrivals)
 
 (1,1,1) = {"
 aa

--- a/_maps/RandomRuins/LavaRuins/lavaland_surface_syndicate_base1.dmm
+++ b/_maps/RandomRuins/LavaRuins/lavaland_surface_syndicate_base1.dmm
@@ -27,8 +27,6 @@
 	pixel_y = 5
 	},
 /obj/structure/cable/yellow{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel/white,
@@ -45,7 +43,6 @@
 "ag" = (
 /obj/machinery/airalarm{
 	dir = 4;
-	icon_state = "alarm0";
 	pixel_x = -24;
 	req_access = 150
 	},
@@ -69,8 +66,7 @@
 /obj/structure/grille,
 /obj/structure/window/plastitanium,
 /obj/machinery/door/poddoor{
-	id = "lavalandsyndi_chemistry";
-	layer = 2.9
+	id = "lavalandsyndi_chemistry"
 	},
 /turf/open/floor/plating,
 /area/ruin/unpowered/syndicate_lava_base/chemistry)
@@ -132,7 +128,6 @@
 /obj/machinery/button/door{
 	id = "lavalandsyndi_chemistry";
 	name = "Chemistry Blast Door Control";
-	pixel_x = 0;
 	pixel_y = 26;
 	req_access_txt = "150"
 	},
@@ -173,12 +168,10 @@
 	dir = 8;
 	name = "Chemistry APC";
 	pixel_x = -24;
-	pixel_y = 0;
 	req_access = 150
 	},
 /obj/structure/cable/yellow{
-	icon_state = "0-2";
-	d2 = 2
+	icon_state = "0-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 6;
@@ -216,7 +209,6 @@
 	},
 /obj/item/stack/sheet/mineral/plasma{
 	amount = 5;
-	pixel_x = 0;
 	pixel_y = 2
 	},
 /obj/item/stack/sheet/mineral/plasma{
@@ -324,7 +316,6 @@
 	pixel_y = 6
 	},
 /obj/item/storage/box/donkpockets{
-	pixel_x = 0;
 	pixel_y = 3
 	},
 /obj/item/storage/box/donkpockets{
@@ -348,7 +339,6 @@
 	},
 /obj/machinery/door/poddoor/preopen{
 	id = "lavalandsyndi";
-	layer = 2.9;
 	name = "Syndicate Research Experimentation Shutters"
 	},
 /obj/effect/decal/cleanable/dirt,
@@ -362,7 +352,6 @@
 /obj/machinery/door/firedoor,
 /obj/machinery/door/poddoor/preopen{
 	id = "lavalandsyndi";
-	layer = 2.9;
 	name = "Syndicate Research Experimentation Shutters"
 	},
 /turf/open/floor/plating,
@@ -373,10 +362,7 @@
 	pixel_x = -26
 	},
 /obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 6
@@ -430,7 +416,6 @@
 /obj/item/reagent_containers/dropper,
 /obj/machinery/airalarm{
 	dir = 8;
-	icon_state = "alarm0";
 	pixel_x = 24;
 	req_access = 150
 	},
@@ -448,7 +433,6 @@
 	req_access_txt = "150"
 	},
 /obj/item/ammo_box/c10mm{
-	pixel_x = 0;
 	pixel_y = 6
 	},
 /obj/item/ammo_box/c10mm,
@@ -525,13 +509,11 @@
 	dir = 1
 	},
 /obj/structure/cable/yellow{
-	icon_state = "0-2";
-	d2 = 2
+	icon_state = "0-2"
 	},
 /obj/machinery/power/apc{
 	dir = 1;
 	name = "Cargo Bay APC";
-	pixel_x = 0;
 	pixel_y = 24;
 	req_access = 150
 	},
@@ -592,7 +574,6 @@
 /obj/machinery/button/door{
 	id = "lavalandsyndi";
 	name = "Syndicate Experimentation Lockdown Control";
-	pixel_x = 0;
 	pixel_y = 26;
 	req_access_txt = "150"
 	},
@@ -663,10 +644,7 @@
 	pixel_y = 1
 	},
 /obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -754,8 +732,6 @@
 	pixel_x = -26
 	},
 /obj/structure/cable/yellow{
-	d1 = 2;
-	d2 = 4;
 	icon_state = "2-4"
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
@@ -773,8 +749,6 @@
 /area/ruin/unpowered/syndicate_lava_base/cargo)
 "ey" = (
 /obj/structure/cable/yellow{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -793,8 +767,6 @@
 /area/ruin/unpowered/syndicate_lava_base/cargo)
 "ez" = (
 /obj/structure/cable/yellow{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -813,8 +785,6 @@
 "eA" = (
 /obj/machinery/door/firedoor,
 /obj/structure/cable/yellow{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -837,8 +807,6 @@
 /area/ruin/unpowered/syndicate_lava_base/cargo)
 "eB" = (
 /obj/structure/cable/yellow{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -854,8 +822,6 @@
 /area/ruin/unpowered/syndicate_lava_base/cargo)
 "eC" = (
 /obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 8;
 	icon_state = "1-8"
 	},
 /obj/effect/decal/cleanable/dirt,
@@ -889,8 +855,7 @@
 /obj/structure/window/plastitanium,
 /obj/machinery/door/firedoor,
 /obj/machinery/door/poddoor{
-	id = "lavalandsyndi_cargo";
-	layer = 2.9
+	id = "lavalandsyndi_cargo"
 	},
 /turf/open/floor/plating,
 /area/ruin/unpowered/syndicate_lava_base/cargo)
@@ -944,7 +909,6 @@
 "eM" = (
 /obj/machinery/firealarm{
 	dir = 1;
-	pixel_x = 0;
 	pixel_y = -24
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
@@ -1017,10 +981,7 @@
 /area/ruin/unpowered/syndicate_lava_base/testlab)
 "eR" = (
 /obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -1064,10 +1025,7 @@
 /area/ruin/unpowered/syndicate_lava_base/chemistry)
 "eW" = (
 /obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -1107,7 +1065,6 @@
 	pixel_y = 6
 	},
 /obj/item/storage/box/donkpockets{
-	pixel_x = 0;
 	pixel_y = 3
 	},
 /obj/item/storage/box/donkpockets{
@@ -1123,8 +1080,7 @@
 /area/ruin/unpowered/syndicate_lava_base/cargo)
 "eZ" = (
 /obj/structure/rack{
-	dir = 8;
-	layer = 2.9
+	dir = 8
 	},
 /obj/item/stack/sheet/cardboard{
 	amount = 3
@@ -1222,13 +1178,11 @@
 /obj/machinery/power/apc{
 	dir = 1;
 	name = "Virology APC";
-	pixel_x = 0;
 	pixel_y = 24;
 	req_access = 150
 	},
 /obj/structure/cable/yellow{
-	icon_state = "0-2";
-	d2 = 2
+	icon_state = "0-2"
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/white/side{
@@ -1238,7 +1192,6 @@
 "fj" = (
 /obj/structure/table/glass,
 /obj/structure/reagent_dispensers/virusfood{
-	pixel_x = 0;
 	pixel_y = 28
 	},
 /obj/item/clothing/gloves/color/latex,
@@ -1248,8 +1201,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/firealarm{
 	dir = 4;
-	pixel_x = 26;
-	pixel_y = 0
+	pixel_x = 26
 	},
 /turf/open/floor/plasteel/white/side{
 	dir = 5
@@ -1259,12 +1211,10 @@
 /obj/machinery/power/apc{
 	dir = 2;
 	name = "Experimentation Lab APC";
-	pixel_x = 0;
 	pixel_y = -24;
 	req_access = 150
 	},
 /obj/structure/cable/yellow{
-	d2 = 4;
 	icon_state = "0-4"
 	},
 /obj/effect/decal/cleanable/dirt,
@@ -1280,12 +1230,9 @@
 	pixel_y = 5
 	},
 /obj/structure/extinguisher_cabinet{
-	pixel_x = 25;
-	pixel_y = 0
+	pixel_x = 25
 	},
 /obj/structure/cable/yellow{
-	d1 = 2;
-	d2 = 8;
 	icon_state = "2-8"
 	},
 /turf/open/floor/plasteel/vault{
@@ -1299,10 +1246,7 @@
 	req_access_txt = "150"
 	},
 /obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -1351,10 +1295,7 @@
 /area/ruin/unpowered/syndicate_lava_base/cargo)
 "fr" = (
 /obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -1423,7 +1364,6 @@
 	},
 /obj/machinery/airalarm{
 	dir = 4;
-	icon_state = "alarm0";
 	pixel_x = -24;
 	req_access = 150
 	},
@@ -1437,12 +1377,10 @@
 	pixel_x = -8
 	},
 /obj/item/device/radio{
-	pixel_x = 5;
-	pixel_y = 0
+	pixel_x = 5
 	},
 /obj/item/device/radio{
-	pixel_x = 5;
-	pixel_y = 0
+	pixel_x = 5
 	},
 /turf/open/floor/plasteel/brown{
 	dir = 8
@@ -1456,8 +1394,7 @@
 /obj/effect/turf_decal/stripes/corner,
 /obj/machinery/firealarm{
 	dir = 4;
-	pixel_x = 26;
-	pixel_y = 0
+	pixel_x = 26
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel,
@@ -1501,10 +1438,7 @@
 /obj/item/reagent_containers/dropper,
 /obj/item/reagent_containers/spray/cleaner,
 /obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel/white/side{
 	dir = 8
@@ -1544,7 +1478,6 @@
 "fF" = (
 /obj/effect/turf_decal/bot,
 /obj/machinery/shower{
-	pixel_x = 0;
 	pixel_y = 14
 	},
 /turf/open/floor/plasteel,
@@ -1562,10 +1495,7 @@
 	req_access_txt = "150"
 	},
 /obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel/vault{
 	dir = 8
@@ -1580,10 +1510,7 @@
 "fI" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -1603,10 +1530,7 @@
 "fW" = (
 /obj/machinery/door/firedoor,
 /obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -1668,7 +1592,6 @@
 /area/ruin/unpowered/syndicate_lava_base/cargo)
 "gf" = (
 /obj/structure/sign/vacuum{
-	pixel_x = 0;
 	pixel_y = -32
 	},
 /obj/machinery/light/small,
@@ -1676,11 +1599,9 @@
 /area/ruin/unpowered/syndicate_lava_base/cargo)
 "gg" = (
 /obj/structure/sign/fire{
-	pixel_x = 0;
 	pixel_y = 32
 	},
 /obj/structure/sign/xeno_warning_mining{
-	pixel_x = 0;
 	pixel_y = -32
 	},
 /turf/open/floor/plating,
@@ -1784,8 +1705,6 @@
 	pixel_y = 5
 	},
 /obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 4;
 	icon_state = "1-4"
 	},
 /turf/open/floor/plasteel/white/corner{
@@ -1804,8 +1723,6 @@
 	},
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable/yellow{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel,
@@ -1821,8 +1738,6 @@
 	pixel_y = 5
 	},
 /obj/structure/cable/yellow{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel/white/side{
@@ -1843,8 +1758,6 @@
 	pixel_y = 5
 	},
 /obj/structure/cable/yellow{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel/floorgrime,
@@ -1863,8 +1776,6 @@
 	pixel_y = 5
 	},
 /obj/structure/cable/yellow{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel,
@@ -1882,7 +1793,6 @@
 	idDoor = "lavaland_syndie_virology_exterior";
 	idSelf = "lavaland_syndie_virology_control";
 	name = "Virology Access Button";
-	pixel_x = 0;
 	pixel_y = -24;
 	req_access_txt = "150"
 	},
@@ -1896,8 +1806,6 @@
 	pixel_y = 5
 	},
 /obj/structure/cable/yellow{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel,
@@ -1913,8 +1821,6 @@
 	pixel_y = 5
 	},
 /obj/structure/cable/yellow{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel/red/side{
@@ -1924,8 +1830,6 @@
 "gE" = (
 /obj/machinery/atmospherics/pipe/manifold4w/supply/hidden,
 /obj/structure/cable/yellow{
-	d1 = 2;
-	d2 = 8;
 	icon_state = "2-8"
 	},
 /obj/machinery/atmospherics/pipe/manifold4w/scrubbers/hidden{
@@ -1934,14 +1838,9 @@
 	pixel_y = 5
 	},
 /obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /obj/structure/cable/yellow{
-	d1 = 2;
-	d2 = 4;
 	icon_state = "2-4"
 	},
 /turf/open/floor/plasteel/floorgrime,
@@ -1951,8 +1850,6 @@
 	dir = 1
 	},
 /obj/structure/cable/yellow{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -1968,8 +1865,6 @@
 /area/ruin/unpowered/syndicate_lava_base/main)
 "gG" = (
 /obj/structure/cable/yellow{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -1985,8 +1880,6 @@
 /area/ruin/unpowered/syndicate_lava_base/main)
 "gH" = (
 /obj/structure/cable/yellow{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden,
@@ -1997,16 +1890,12 @@
 	pixel_y = 5
 	},
 /obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 8;
 	icon_state = "1-8"
 	},
 /turf/open/floor/plasteel,
 /area/ruin/unpowered/syndicate_lava_base/main)
 "gI" = (
 /obj/structure/cable/yellow{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -2023,8 +1912,6 @@
 "gJ" = (
 /obj/machinery/door/firedoor,
 /obj/structure/cable/yellow{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -2043,8 +1930,6 @@
 	dir = 1
 	},
 /obj/structure/cable/yellow{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -2062,8 +1947,6 @@
 /area/ruin/unpowered/syndicate_lava_base/main)
 "gL" = (
 /obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 8;
 	icon_state = "1-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -2123,7 +2006,6 @@
 	id = "lavalandsyndi_cargo";
 	name = "Cargo Bay Blast Door Control";
 	pixel_x = 26;
-	pixel_y = 0;
 	req_access_txt = "150"
 	},
 /turf/open/floor/plasteel,
@@ -2144,7 +2026,6 @@
 "gU" = (
 /obj/machinery/airalarm{
 	dir = 4;
-	icon_state = "alarm0";
 	pixel_x = -24;
 	req_access = 150
 	},
@@ -2193,7 +2074,6 @@
 	},
 /obj/effect/turf_decal/caution/red{
 	dir = 1;
-	icon_state = "caution_red";
 	pixel_y = -6
 	},
 /obj/machinery/light/small{
@@ -2252,10 +2132,7 @@
 	pixel_y = 5
 	},
 /obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel/red/corner{
 	dir = 8
@@ -2392,8 +2269,7 @@
 "hv" = (
 /obj/machinery/disposal/bin,
 /obj/structure/sign/deathsposal{
-	pixel_x = 32;
-	pixel_y = 0
+	pixel_x = 32
 	},
 /obj/effect/turf_decal/stripes/red/box,
 /obj/structure/disposalpipe/trunk{
@@ -2414,7 +2290,6 @@
 "hx" = (
 /obj/machinery/airalarm{
 	dir = 4;
-	icon_state = "alarm0";
 	pixel_x = -24;
 	req_access = 150
 	},
@@ -2425,10 +2300,7 @@
 	pixel_y = 5
 	},
 /obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/red/side{
@@ -2501,8 +2373,7 @@
 /obj/structure/grille,
 /obj/structure/window/plastitanium,
 /obj/machinery/door/poddoor/preopen{
-	id = "lavalandsyndi_virology";
-	layer = 2.9
+	id = "lavalandsyndi_virology"
 	},
 /turf/open/floor/plating,
 /area/ruin/unpowered/syndicate_lava_base/virology)
@@ -2542,10 +2413,7 @@
 	pixel_y = 5
 	},
 /obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel/red/side{
 	dir = 8
@@ -2657,10 +2525,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
@@ -2763,10 +2628,7 @@
 	pixel_y = 5
 	},
 /obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel/red/corner{
 	dir = 1
@@ -2882,10 +2744,7 @@
 	pixel_y = 5
 	},
 /obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel/floorgrime,
 /area/ruin/unpowered/syndicate_lava_base/main)
@@ -2979,7 +2838,6 @@
 	},
 /obj/effect/turf_decal/caution/red{
 	dir = 8;
-	icon_state = "caution_red";
 	pixel_x = 6
 	},
 /turf/open/floor/plasteel,
@@ -3006,7 +2864,6 @@
 "iL" = (
 /obj/machinery/airalarm{
 	dir = 8;
-	icon_state = "alarm0";
 	pixel_x = 24;
 	req_access = 150
 	},
@@ -3036,8 +2893,6 @@
 /area/ruin/unpowered/syndicate_lava_base/main)
 "iP" = (
 /obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 4;
 	icon_state = "1-4"
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden,
@@ -3060,8 +2915,6 @@
 	pixel_y = 5
 	},
 /obj/structure/cable/yellow{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel/floorgrime,
@@ -3081,8 +2934,6 @@
 	pixel_y = 5
 	},
 /obj/structure/cable/yellow{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel/floorgrime,
@@ -3098,8 +2949,6 @@
 	pixel_y = 5
 	},
 /obj/structure/cable/yellow{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/effect/decal/cleanable/dirt,
@@ -3115,8 +2964,6 @@
 	pixel_y = 5
 	},
 /obj/structure/cable/yellow{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel/neutral/corner{
@@ -3133,13 +2980,9 @@
 	pixel_y = 5
 	},
 /obj/structure/cable/yellow{
-	d1 = 2;
-	d2 = 8;
 	icon_state = "2-8"
 	},
 /obj/structure/cable/yellow{
-	d1 = 2;
-	d2 = 4;
 	icon_state = "2-4"
 	},
 /turf/open/floor/plasteel/floorgrime,
@@ -3157,12 +3000,10 @@
 /obj/machinery/power/apc{
 	dir = 2;
 	name = "Dormitories APC";
-	pixel_x = 0;
 	pixel_y = -24;
 	req_access = 150
 	},
 /obj/structure/cable/yellow{
-	d2 = 8;
 	icon_state = "0-8"
 	},
 /turf/open/floor/plasteel/neutral/corner,
@@ -3286,10 +3127,7 @@
 	pixel_y = 5
 	},
 /obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
@@ -3309,14 +3147,12 @@
 /area/ruin/unpowered/syndicate_lava_base/dormitories)
 "ji" = (
 /obj/structure/cable/yellow{
-	icon_state = "0-2";
-	d2 = 2
+	icon_state = "0-2"
 	},
 /obj/machinery/power/apc{
 	dir = 8;
 	name = "Primary Hallway APC";
 	pixel_x = -24;
-	pixel_y = 0;
 	req_access = 150
 	},
 /turf/open/floor/plasteel/red/side{
@@ -3372,10 +3208,7 @@
 	pixel_y = 5
 	},
 /obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
@@ -3403,10 +3236,7 @@
 /area/ruin/unpowered/syndicate_lava_base/main)
 "js" = (
 /obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on,
 /turf/open/floor/plasteel/red/corner{
@@ -3448,8 +3278,7 @@
 /obj/structure/window/plastitanium,
 /obj/machinery/door/firedoor,
 /obj/machinery/door/poddoor/preopen{
-	id = "lavalandsyndi_bar";
-	layer = 2.9
+	id = "lavalandsyndi_bar"
 	},
 /turf/open/floor/plating,
 /area/ruin/unpowered/syndicate_lava_base/bar)
@@ -3504,13 +3333,9 @@
 /area/ruin/unpowered/syndicate_lava_base/main)
 "jE" = (
 /obj/structure/cable/yellow{
-	d1 = 2;
-	d2 = 4;
 	icon_state = "2-4"
 	},
 /obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 4;
 	icon_state = "1-4"
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
@@ -3526,8 +3351,6 @@
 /area/ruin/unpowered/syndicate_lava_base/main)
 "jF" = (
 /obj/structure/cable/yellow{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -3547,8 +3370,6 @@
 /obj/effect/turf_decal/delivery,
 /obj/machinery/door/firedoor,
 /obj/structure/cable/yellow{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -3571,8 +3392,6 @@
 	dir = 9
 	},
 /obj/structure/cable/yellow{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
@@ -3595,13 +3414,10 @@
 	},
 /obj/machinery/airalarm{
 	dir = 8;
-	icon_state = "alarm0";
 	pixel_x = 24;
 	req_access = 150
 	},
 /obj/structure/cable/yellow{
-	d1 = 2;
-	d2 = 8;
 	icon_state = "2-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -3658,7 +3474,6 @@
 /obj/machinery/button/door{
 	id = "lavalandsyndi_bar";
 	name = "Bar Blast Door Control";
-	pixel_x = 0;
 	pixel_y = 26;
 	req_access_txt = "150"
 	},
@@ -3671,8 +3486,7 @@
 /area/ruin/unpowered/syndicate_lava_base/bar)
 "jO" = (
 /obj/structure/extinguisher_cabinet{
-	pixel_x = 25;
-	pixel_y = 0
+	pixel_x = 25
 	},
 /turf/open/floor/plasteel/dark,
 /area/ruin/unpowered/syndicate_lava_base/bar)
@@ -3687,10 +3501,7 @@
 	pixel_y = 5
 	},
 /obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /turf/open/floor/plating,
 /area/ruin/unpowered/syndicate_lava_base/main)
@@ -3704,10 +3515,7 @@
 /area/ruin/unpowered/syndicate_lava_base/main)
 "jS" = (
 /obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -3732,8 +3540,7 @@
 	dir = 10
 	},
 /obj/structure/rack{
-	dir = 8;
-	layer = 2.9
+	dir = 8
 	},
 /obj/item/clothing/gloves/combat,
 /obj/item/crowbar,
@@ -3749,10 +3556,7 @@
 	dir = 6
 	},
 /obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -3788,8 +3592,7 @@
 /area/ruin/unpowered/syndicate_lava_base/bar)
 "kb" = (
 /obj/structure/rack{
-	dir = 8;
-	layer = 2.9
+	dir = 8
 	},
 /obj/item/storage/box/lights/bulbs,
 /obj/item/stack/rods{
@@ -3813,8 +3616,6 @@
 	pixel_y = 5
 	},
 /obj/structure/cable/yellow{
-	d1 = 2;
-	d2 = 4;
 	icon_state = "2-4"
 	},
 /obj/effect/decal/cleanable/dirt,
@@ -3829,13 +3630,9 @@
 	pixel_y = 5
 	},
 /obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 4;
 	icon_state = "1-4"
 	},
 /obj/structure/cable/yellow{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/effect/decal/cleanable/dirt,
@@ -3852,13 +3649,9 @@
 	pixel_y = 5
 	},
 /obj/structure/cable/yellow{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/structure/cable/yellow{
-	d1 = 2;
-	d2 = 8;
 	icon_state = "2-8"
 	},
 /obj/effect/decal/cleanable/dirt,
@@ -3875,8 +3668,6 @@
 	pixel_y = 5
 	},
 /obj/structure/cable/yellow{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/open/floor/plating,
@@ -3892,8 +3683,6 @@
 	pixel_y = 5
 	},
 /obj/structure/cable/yellow{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/effect/decal/cleanable/dirt,
@@ -3911,16 +3700,12 @@
 	pixel_y = 5
 	},
 /obj/structure/cable/yellow{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/open/floor/plating,
 /area/ruin/unpowered/syndicate_lava_base/main)
 "ki" = (
 /obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 8;
 	icon_state = "1-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -3950,10 +3735,7 @@
 /obj/effect/turf_decal/delivery,
 /obj/machinery/door/firedoor,
 /obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -3977,8 +3759,7 @@
 /area/ruin/unpowered/syndicate_lava_base/engineering)
 "km" = (
 /obj/structure/cable/yellow{
-	icon_state = "0-2";
-	d2 = 2
+	icon_state = "0-2"
 	},
 /obj/machinery/computer/monitor,
 /obj/effect/decal/cleanable/dirt,
@@ -4015,7 +3796,6 @@
 "kq" = (
 /obj/machinery/airalarm{
 	dir = 8;
-	icon_state = "alarm0";
 	pixel_x = 24;
 	req_access = 150
 	},
@@ -4038,10 +3818,7 @@
 	pixel_y = 5
 	},
 /obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"	
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
@@ -4078,8 +3855,6 @@
 	dir = 9
 	},
 /obj/structure/cable/yellow{
-	d1 = 2;
-	d2 = 4;
 	icon_state = "2-4"
 	},
 /obj/effect/decal/cleanable/dirt,
@@ -4090,13 +3865,9 @@
 	dir = 5
 	},
 /obj/structure/cable/yellow{
-	d1 = 2;
-	d2 = 4;
 	icon_state = "2-4"
 	},
 /obj/structure/cable/yellow{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/effect/decal/cleanable/dirt,
@@ -4104,13 +3875,9 @@
 /area/ruin/unpowered/syndicate_lava_base/engineering)
 "kz" = (
 /obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 8;
 	icon_state = "1-8"
 	},
 /obj/structure/cable/yellow{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/visible,
@@ -4129,17 +3896,13 @@
 /obj/machinery/power/apc{
 	dir = 1;
 	name = "Engineering APC";
-	pixel_x = 0;
 	pixel_y = 24;
 	req_access = 150
 	},
 /obj/structure/cable/yellow{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/structure/cable/yellow{
-	d2 = 8;
 	icon_state = "0-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
@@ -4152,8 +3915,6 @@
 /area/ruin/unpowered/syndicate_lava_base/engineering)
 "kB" = (
 /obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 8;
 	icon_state = "1-8"
 	},
 /obj/effect/decal/cleanable/dirt,
@@ -4245,13 +4006,10 @@
 "kM" = (
 /obj/machinery/firealarm{
 	dir = 4;
-	pixel_x = 26;
-	pixel_y = 0
+	pixel_x = 26
 	},
 /obj/machinery/vending/cigarette{
-	extended_inventory = 1;
-	pixel_x = 0;
-	pixel_y = 0
+	extended_inventory = 1
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -4271,10 +4029,7 @@
 	pixel_y = 5
 	},
 /obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/dark,
@@ -4481,10 +4236,7 @@
 	pixel_y = 5
 	},
 /obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel/dark,
 /area/ruin/unpowered/syndicate_lava_base/bar)
@@ -4524,7 +4276,6 @@
 	dir = 1
 	},
 /obj/structure/cable{
-	d2 = 4;
 	icon_state = "0-4"
 	},
 /obj/effect/decal/cleanable/dirt,
@@ -4539,12 +4290,9 @@
 	},
 /obj/structure/cable{
 	icon_state = "0-2";
-	pixel_y = 1;
-	d2 = 2
+	pixel_y = 1
 	},
 /obj/structure/cable{
-	d1 = 2;
-	d2 = 8;
 	icon_state = "2-8"
 	},
 /turf/open/floor/plating,
@@ -4632,8 +4380,7 @@
 /obj/machinery/reagentgrinder,
 /obj/item/kitchen/rollingpin,
 /obj/item/kitchen/knife{
-	pixel_x = 6;
-	pixel_y = 0
+	pixel_x = 6
 	},
 /turf/open/floor/wood,
 /area/ruin/unpowered/syndicate_lava_base/bar)
@@ -4669,10 +4416,7 @@
 	pixel_y = 5
 	},
 /obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/dark,
@@ -4711,7 +4455,6 @@
 "lL" = (
 /obj/machinery/airalarm{
 	dir = 4;
-	icon_state = "alarm0";
 	pixel_x = -24;
 	req_access = 150
 	},
@@ -4737,10 +4480,7 @@
 /area/ruin/unpowered/syndicate_lava_base/engineering)
 "lM" = (
 /obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 4;
@@ -4804,7 +4544,6 @@
 "lU" = (
 /obj/machinery/airalarm{
 	dir = 4;
-	icon_state = "alarm0";
 	pixel_x = -24;
 	req_access = 150
 	},
@@ -4822,8 +4561,6 @@
 "lW" = (
 /obj/structure/table/wood,
 /obj/structure/cable/yellow{
-	d1 = 2;
-	d2 = 4;
 	icon_state = "2-4"
 	},
 /obj/effect/decal/cleanable/dirt,
@@ -4831,8 +4568,6 @@
 /area/ruin/unpowered/syndicate_lava_base/bar)
 "lX" = (
 /obj/structure/cable/yellow{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/open/floor/wood,
@@ -4848,8 +4583,6 @@
 	pixel_y = 5
 	},
 /obj/structure/cable/yellow{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/open/floor/wood,
@@ -4865,8 +4598,6 @@
 	pixel_y = 5
 	},
 /obj/structure/cable/yellow{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/open/floor/wood,
@@ -4886,8 +4617,6 @@
 	req_access_txt = "150"
 	},
 /obj/structure/cable/yellow{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel/dark,
@@ -4903,8 +4632,6 @@
 	pixel_y = 5
 	},
 /obj/structure/cable/yellow{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel/dark,
@@ -4916,7 +4643,6 @@
 	pixel_y = 6
 	},
 /obj/item/storage/box/donkpockets{
-	pixel_x = 0;
 	pixel_y = 3
 	},
 /obj/item/storage/box/donkpockets{
@@ -4932,8 +4658,6 @@
 	pixel_y = 5
 	},
 /obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 8;
 	icon_state = "1-8"
 	},
 /obj/effect/decal/cleanable/dirt,
@@ -4961,7 +4685,6 @@
 	},
 /obj/machinery/airalarm{
 	dir = 8;
-	icon_state = "alarm0";
 	pixel_x = 24;
 	req_access = 150
 	},
@@ -4980,10 +4703,7 @@
 /area/ruin/unpowered/syndicate_lava_base/engineering)
 "mh" = (
 /obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel,
 /area/ruin/unpowered/syndicate_lava_base/engineering)
@@ -5035,8 +4755,7 @@
 /obj/structure/window/plastitanium,
 /obj/machinery/door/firedoor,
 /obj/machinery/door/poddoor/preopen{
-	id = "lavalandsyndi_telecomms";
-	layer = 2.9
+	id = "lavalandsyndi_telecomms"
 	},
 /turf/open/floor/plating,
 /area/ruin/unpowered/syndicate_lava_base/telecomms)
@@ -5083,7 +4802,6 @@
 /obj/machinery/power/apc{
 	dir = 2;
 	name = "Bar APC";
-	pixel_x = 0;
 	pixel_y = -24;
 	req_access = 150
 	},
@@ -5114,10 +4832,7 @@
 	pixel_y = 5
 	},
 /obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
@@ -5186,10 +4901,7 @@
 /area/ruin/unpowered/syndicate_lava_base/engineering)
 "mG" = (
 /obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel/floorgrime,
 /area/ruin/unpowered/syndicate_lava_base/engineering)
@@ -5246,7 +4958,6 @@
 /obj/machinery/button/door{
 	id = "lavalandsyndi_telecomms";
 	name = "Telecomms Blast Door Control";
-	pixel_x = 0;
 	pixel_y = 26;
 	req_access_txt = "150"
 	},
@@ -5298,8 +5009,7 @@
 /area/ruin/unpowered/syndicate_lava_base/bar)
 "mX" = (
 /obj/structure/rack{
-	dir = 8;
-	layer = 2.9
+	dir = 8
 	},
 /obj/item/storage/toolbox/mechanical,
 /obj/item/stack/cable_coil/yellow{
@@ -5320,10 +5030,7 @@
 	pixel_y = 5
 	},
 /obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -5379,10 +5086,7 @@
 /area/ruin/unpowered/syndicate_lava_base/engineering)
 "nd" = (
 /obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /obj/effect/turf_decal/stripes/line,
 /obj/effect/decal/cleanable/dirt,
@@ -5527,8 +5231,6 @@
 	pixel_y = 5
 	},
 /obj/structure/cable/yellow{
-	d1 = 2;
-	d2 = 4;
 	icon_state = "2-4"
 	},
 /obj/effect/decal/cleanable/dirt,
@@ -5547,20 +5249,16 @@
 	pixel_y = 5
 	},
 /obj/structure/cable/yellow{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/power/apc{
 	dir = 1;
 	name = "Arrival Hallway APC";
-	pixel_x = 0;
 	pixel_y = 24;
 	req_access = 150
 	},
 /obj/structure/cable/yellow{
-	d2 = 4;
 	icon_state = "0-4"
 	},
 /turf/open/floor/plasteel/red/side{
@@ -5578,8 +5276,6 @@
 	pixel_y = 5
 	},
 /obj/structure/cable/yellow{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel/red/side{
@@ -5597,8 +5293,6 @@
 	pixel_y = 5
 	},
 /obj/structure/cable/yellow{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel/red/corner{
@@ -5614,13 +5308,9 @@
 	pixel_y = 5
 	},
 /obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 4;
 	icon_state = "1-4"
 	},
 /obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 8;
 	icon_state = "1-8"
 	},
 /turf/open/floor/plasteel/white/side{
@@ -5639,8 +5329,6 @@
 	pixel_y = 5
 	},
 /obj/structure/cable/yellow{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/door/airlock/medical/glass{
@@ -5659,8 +5347,6 @@
 	pixel_y = 5
 	},
 /obj/structure/cable/yellow{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel/white/side{
@@ -5678,16 +5364,12 @@
 	pixel_y = 5
 	},
 /obj/structure/cable/yellow{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel,
 /area/ruin/unpowered/syndicate_lava_base/medbay)
 "nA" = (
 /obj/structure/cable/yellow{
-	d1 = 2;
-	d2 = 8;
 	icon_state = "2-8"
 	},
 /turf/open/floor/plasteel/white/corner,
@@ -5710,10 +5392,7 @@
 /area/ruin/unpowered/syndicate_lava_base/medbay)
 "nD" = (
 /obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /obj/machinery/door/airlock/glass{
 	autoclose = 0;
@@ -5750,7 +5429,6 @@
 "nH" = (
 /obj/machinery/airalarm{
 	dir = 4;
-	icon_state = "alarm0";
 	pixel_x = -24;
 	req_access = 150
 	},
@@ -5791,8 +5469,6 @@
 	pixel_y = 5
 	},
 /obj/structure/cable/yellow{
-	d1 = 2;
-	d2 = 4;
 	icon_state = "2-4"
 	},
 /turf/open/floor/plasteel/vault{
@@ -5814,8 +5490,6 @@
 	pixel_y = 5
 	},
 /obj/structure/cable/yellow{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel/vault{
@@ -5834,8 +5508,6 @@
 	pixel_y = 5
 	},
 /obj/structure/cable/yellow{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/effect/decal/cleanable/dirt,
@@ -5852,8 +5524,6 @@
 	pixel_y = 5
 	},
 /obj/structure/cable/yellow{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel,
@@ -5870,8 +5540,6 @@
 	pixel_y = 5
 	},
 /obj/structure/cable/yellow{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel/floorgrime,
@@ -5892,8 +5560,6 @@
 	pixel_y = 5
 	},
 /obj/structure/cable/yellow{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel,
@@ -5913,8 +5579,6 @@
 	pixel_y = 5
 	},
 /obj/structure/cable/yellow{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel,
@@ -5930,8 +5594,6 @@
 	pixel_y = 5
 	},
 /obj/structure/cable/yellow{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel/red/corner{
@@ -5953,8 +5615,6 @@
 	pixel_y = 24
 	},
 /obj/structure/cable/yellow{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel/red/side{
@@ -5972,8 +5632,6 @@
 	pixel_y = 5
 	},
 /obj/structure/cable/yellow{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel/red/side{
@@ -5998,8 +5656,6 @@
 	pixel_y = 5
 	},
 /obj/structure/cable/yellow{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/effect/decal/cleanable/dirt,
@@ -6018,8 +5674,6 @@
 	pixel_y = 5
 	},
 /obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 8;
 	icon_state = "1-8"
 	},
 /turf/open/floor/plasteel/red/corner{
@@ -6053,7 +5707,6 @@
 "oc" = (
 /obj/machinery/light/small,
 /obj/structure/extinguisher_cabinet{
-	pixel_x = 0;
 	pixel_y = -29
 	},
 /obj/structure/cable/yellow,
@@ -6061,7 +5714,6 @@
 	dir = 4;
 	name = "Medbay APC";
 	pixel_x = 24;
-	pixel_y = 0;
 	req_access = 150
 	},
 /obj/effect/decal/cleanable/dirt,
@@ -6085,10 +5737,7 @@
 /area/ruin/unpowered/syndicate_lava_base/engineering)
 "oe" = (
 /obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /turf/open/floor/engine,
 /area/ruin/unpowered/syndicate_lava_base/engineering)
@@ -6153,7 +5802,6 @@
 /obj/machinery/power/apc{
 	dir = 2;
 	name = "Telecommunications APC";
-	pixel_x = 0;
 	pixel_y = -24;
 	req_access = 150
 	},
@@ -6166,8 +5814,7 @@
 	dir = 1
 	},
 /obj/structure/rack{
-	dir = 8;
-	layer = 2.9
+	dir = 8
 	},
 /obj/item/clothing/suit/space/syndicate,
 /obj/item/clothing/mask/gas/syndicate,
@@ -6185,7 +5832,6 @@
 	dir = 1
 	},
 /obj/structure/extinguisher_cabinet{
-	pixel_x = 0;
 	pixel_y = -29
 	},
 /obj/effect/decal/cleanable/dirt,
@@ -6207,7 +5853,6 @@
 /obj/machinery/button/door{
 	id = "lavalandsyndi_arrivals";
 	name = "Arrivals Blast Door Control";
-	pixel_x = 0;
 	pixel_y = -26;
 	req_access_txt = "150"
 	},
@@ -6215,8 +5860,7 @@
 /area/ruin/unpowered/syndicate_lava_base/arrivals)
 "or" = (
 /obj/structure/rack{
-	dir = 8;
-	layer = 2.9
+	dir = 8
 	},
 /obj/item/storage/belt/medical,
 /obj/effect/decal/cleanable/dirt,
@@ -6240,10 +5884,7 @@
 /area/ruin/unpowered/syndicate_lava_base/medbay)
 "ot" = (
 /obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /obj/machinery/door/airlock/glass{
 	autoclose = 0;
@@ -6278,8 +5919,7 @@
 /obj/structure/window/plastitanium,
 /obj/machinery/door/firedoor,
 /obj/machinery/door/poddoor{
-	id = "lavalandsyndi_arrivals";
-	layer = 2.9
+	id = "lavalandsyndi_arrivals"
 	},
 /turf/open/floor/plating,
 /area/ruin/unpowered/syndicate_lava_base/arrivals)
@@ -6293,10 +5933,7 @@
 /area/ruin/unpowered/syndicate_lava_base/engineering)
 "oA" = (
 /obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /obj/machinery/igniter{
 	icon_state = "igniter0";
@@ -6347,8 +5984,7 @@
 /obj/structure/cable,
 /obj/structure/cable{
 	icon_state = "0-2";
-	pixel_y = 1;
-	d2 = 2
+	pixel_y = 1
 	},
 /obj/machinery/power/compressor{
 	comp_id = "syndie_lavaland_incineratorturbine";

--- a/_maps/RandomRuins/LavaRuins/lavaland_surface_syndicate_base1.dmm
+++ b/_maps/RandomRuins/LavaRuins/lavaland_surface_syndicate_base1.dmm
@@ -2740,7 +2740,7 @@
 /turf/open/floor/plating{
 	initial_gas_mix = "o2=14;n2=23;TEMP=300"
 	},
-/area/ruin/syndicate_lava_base/arrivals)
+/area/lavaland/surface/outdoors)
 "ih" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -2748,7 +2748,7 @@
 /turf/open/floor/plating{
 	initial_gas_mix = "o2=14;n2=23;TEMP=300"
 	},
-/area/ruin/syndicate_lava_base/arrivals)
+/area/lavaland/surface/outdoors)
 "ii" = (
 /obj/structure/table,
 /obj/item/storage/toolbox/emergency,
@@ -2857,13 +2857,13 @@
 /turf/open/floor/plating{
 	initial_gas_mix = "o2=14;n2=23;TEMP=300"
 	},
-/area/ruin/syndicate_lava_base/arrivals)
+/area/lavaland/surface/outdoors)
 "iv" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating{
 	initial_gas_mix = "o2=14;n2=23;TEMP=300"
 	},
-/area/ruin/syndicate_lava_base/arrivals)
+/area/lavaland/surface/outdoors)
 "iw" = (
 /obj/structure/chair{
 	dir = 4
@@ -3265,7 +3265,7 @@
 /turf/open/floor/plating{
 	initial_gas_mix = "o2=14;n2=23;TEMP=300"
 	},
-/area/ruin/syndicate_lava_base/arrivals)
+/area/lavaland/surface/outdoors)
 "jf" = (
 /obj/machinery/door/airlock{
 	name = "Cabin 1";
@@ -3333,7 +3333,7 @@
 /turf/open/floor/plating{
 	initial_gas_mix = "o2=14;n2=23;TEMP=300"
 	},
-/area/ruin/syndicate_lava_base/arrivals)
+/area/lavaland/surface/outdoors)
 "jl" = (
 /turf/open/floor/plasteel/red/side{
 	dir = 10
@@ -4588,13 +4588,13 @@
 /turf/open/floor/plating{
 	initial_gas_mix = "o2=14;n2=23;TEMP=300"
 	},
-/area/ruin/syndicate_lava_base/arrivals)
+/area/lavaland/surface/outdoors)
 "lw" = (
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plating{
 	initial_gas_mix = "o2=14;n2=23;TEMP=300"
 	},
-/area/ruin/syndicate_lava_base/arrivals)
+/area/lavaland/surface/outdoors)
 "lx" = (
 /obj/structure/bookcase/random,
 /obj/effect/decal/cleanable/dirt,

--- a/_maps/RandomRuins/LavaRuins/lavaland_surface_syndicate_base1.dmm
+++ b/_maps/RandomRuins/LavaRuins/lavaland_surface_syndicate_base1.dmm
@@ -1673,6 +1673,7 @@
 	pixel_x = 0;
 	pixel_y = -32
 	},
+/obj/machinery/light/small,
 /turf/open/floor/plating,
 /area/ruin/syndicate_lava_base/cargo)
 "gg" = (
@@ -6392,6 +6393,16 @@
 	initial_gas_mix = "o2=14;n2=23;TEMP=300"
 	},
 /area/ruin/syndicate_lava_base/engineering)
+"oI" = (
+/obj/structure/sign/vacuum{
+	pixel_x = -32
+	},
+/obj/machinery/light/small{
+	brightness = 3;
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/ruin/syndicate_lava_base/arrivals)
 
 (1,1,1) = {"
 aa
@@ -7184,7 +7195,7 @@ mU
 np
 nP
 mS
-mq
+oI
 oD
 lT
 ab

--- a/_maps/RandomRuins/LavaRuins/lavaland_surface_syndicate_base1.dmm
+++ b/_maps/RandomRuins/LavaRuins/lavaland_surface_syndicate_base1.dmm
@@ -241,7 +241,6 @@
 /area/ruin/unpowered/syndicate_lava_base/chemistry)
 "dK" = (
 /obj/effect/turf_decal/box/white/corners{
-	icon_state = "box_corners_white";
 	dir = 4
 	},
 /obj/structure/closet/crate/secure/gear{
@@ -307,7 +306,6 @@
 /area/ruin/unpowered/syndicate_lava_base/cargo)
 "dM" = (
 /obj/effect/turf_decal/box/white/corners{
-	icon_state = "box_corners_white";
 	dir = 1
 	},
 /obj/structure/closet/crate,
@@ -426,7 +424,6 @@
 /area/ruin/unpowered/syndicate_lava_base/chemistry)
 "ea" = (
 /obj/effect/turf_decal/box/white/corners{
-	icon_state = "box_corners_white";
 	dir = 8
 	},
 /obj/structure/closet/crate/secure/weapon{
@@ -1039,7 +1036,6 @@
 /area/ruin/unpowered/syndicate_lava_base/cargo)
 "eX" = (
 /obj/effect/turf_decal/box/white/corners{
-	icon_state = "box_corners_white";
 	dir = 4
 	},
 /obj/structure/closet/crate/internals,
@@ -1056,7 +1052,6 @@
 /area/ruin/unpowered/syndicate_lava_base/cargo)
 "eY" = (
 /obj/effect/turf_decal/box/white/corners{
-	icon_state = "box_corners_white";
 	dir = 1
 	},
 /obj/structure/closet/crate,
@@ -1310,7 +1305,6 @@
 /area/ruin/unpowered/syndicate_lava_base/cargo)
 "fs" = (
 /obj/effect/turf_decal/box/white/corners{
-	icon_state = "box_corners_white";
 	dir = 8
 	},
 /obj/structure/closet/crate,
@@ -1578,7 +1572,6 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/caution/stand_clear{
-	icon_state = "stand_clear";
 	dir = 8
 	},
 /turf/open/floor/plasteel/floorgrime,
@@ -4083,7 +4076,6 @@
 /area/ruin/unpowered/syndicate_lava_base/engineering)
 "kX" = (
 /obj/machinery/atmospherics/pipe/simple/supply/visible{
-	icon_state = "intact";
 	dir = 5
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
@@ -4176,7 +4168,6 @@
 "li" = (
 /obj/structure/table/wood,
 /obj/item/toy/cards/deck/syndicate{
-	icon_state = "deck_syndicate_full";
 	pixel_x = -6;
 	pixel_y = 6
 	},
@@ -4702,7 +4693,6 @@
 /area/ruin/unpowered/syndicate_lava_base/engineering)
 "mi" = (
 /obj/machinery/atmospherics/pipe/simple/orange/visible{
-	icon_state = "intact";
 	dir = 6
 	},
 /turf/open/floor/plasteel/floorgrime,
@@ -4900,7 +4890,6 @@
 /area/ruin/unpowered/syndicate_lava_base/engineering)
 "mH" = (
 /obj/machinery/atmospherics/pipe/manifold/orange/visible{
-	icon_state = "manifold";
 	dir = 8
 	},
 /turf/open/floor/plasteel/floorgrime,
@@ -4909,7 +4898,6 @@
 /obj/effect/turf_decal/stripes/corner,
 /obj/machinery/light/small,
 /obj/machinery/atmospherics/pipe/simple/orange/visible{
-	icon_state = "intact";
 	dir = 8
 	},
 /obj/structure/reagent_dispensers/fueltank,
@@ -4919,7 +4907,6 @@
 "mJ" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/machinery/atmospherics/pipe/simple/orange/visible{
-	icon_state = "intact";
 	dir = 10
 	},
 /obj/structure/reagent_dispensers/watertank,
@@ -5539,7 +5526,6 @@
 "nP" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/effect/turf_decal/caution/stand_clear{
-	icon_state = "stand_clear";
 	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -5927,7 +5913,6 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/igniter{
-	icon_state = "igniter0";
 	id = "syndie_lavaland_Incinerator";
 	luminosity = 2;
 	on = 0

--- a/_maps/RandomRuins/LavaRuins/lavaland_surface_syndicate_base1.dmm
+++ b/_maps/RandomRuins/LavaRuins/lavaland_surface_syndicate_base1.dmm
@@ -925,7 +925,8 @@
 /obj/machinery/airalarm{
 	dir = 1;
 	pixel_y = -24;
-	req_access = null
+	req_access = null;
+	req_access_txt = "150"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4;
@@ -1016,7 +1017,7 @@
 /area/ruin/unpowered/syndicate_lava_base/chemistry)
 "eV" = (
 /obj/structure/closet/secure_closet/chemical{
-	req_access_txt = "152"
+	req_access_txt = "150"
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/white/side{
@@ -1785,7 +1786,6 @@
 /obj/machinery/door/airlock/virology{
 	frequency = 1449;
 	id_tag = "lavaland_syndie_virology_exterior";
-	locked = 0;
 	name = "Virology Lab Exterior Airlock";
 	req_access_txt = "150"
 	},
@@ -2686,7 +2686,6 @@
 "ir" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/stripes/red/line{
-	icon_state = "warningline_red";
 	dir = 9
 	},
 /turf/open/floor/plasteel/vault{
@@ -2702,7 +2701,6 @@
 "it" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/stripes/red/line{
-	icon_state = "warningline_red";
 	dir = 5
 	},
 /turf/open/floor/plasteel/vault{
@@ -2833,7 +2831,6 @@
 /area/ruin/unpowered/syndicate_lava_base/main)
 "iH" = (
 /obj/effect/turf_decal/stripes/red/line{
-	icon_state = "warningline_red";
 	dir = 4
 	},
 /obj/effect/turf_decal/caution/red{
@@ -3075,7 +3072,6 @@
 "jb" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/stripes/red/line{
-	icon_state = "warningline_red";
 	dir = 10
 	},
 /turf/open/floor/plasteel/vault{
@@ -3089,7 +3085,6 @@
 "jd" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/stripes/red/line{
-	icon_state = "warningline_red";
 	dir = 6
 	},
 /turf/open/floor/plasteel/vault{

--- a/_maps/RandomRuins/LavaRuins/lavaland_surface_syndicate_base1.dmm
+++ b/_maps/RandomRuins/LavaRuins/lavaland_surface_syndicate_base1.dmm
@@ -4163,7 +4163,6 @@
 /obj/machinery/computer/atmos_control/tank{
 	dir = 8;
 	frequency = 1442;
-	input_tag = null;
 	name = "Nitrogen Supply Control";
 	output_tag = "syndie_lavaland_n2_out";
 	sensors = list("syndie_lavaland_n2_sensor" = "Tank")
@@ -4767,7 +4766,6 @@
 /obj/machinery/computer/atmos_control/tank{
 	dir = 8;
 	frequency = 1442;
-	input_tag = null;
 	name = "Oxygen Supply Control";
 	output_tag = "syndie_lavaland_o2_out";
 	sensors = list("syndie_lavaland_o2_sensor" = "Tank")
@@ -4997,10 +4995,9 @@
 /turf/open/floor/plasteel/floorgrime,
 /area/ruin/unpowered/syndicate_lava_base/engineering)
 "mj" = (
-/obj/machinery/atmospherics/components/binary/pump{
+/obj/machinery/atmospherics/components/binary/pump/on{
 	dir = 8;
 	name = "O2 to Incinerator";
-	on = 1;
 	target_pressure = 4500
 	},
 /turf/open/floor/plasteel/floorgrime,
@@ -5229,7 +5226,6 @@
 /obj/machinery/computer/atmos_control/tank{
 	dir = 1;
 	frequency = 1442;
-	input_tag = null;
 	name = "Toxins Supply Control";
 	output_tag = "syndie_lavaland_tox_out";
 	sensors = list("syndie_lavaland_tox_sensor" = "Tank")

--- a/_maps/RandomRuins/LavaRuins/lavaland_surface_syndicate_base1.dmm
+++ b/_maps/RandomRuins/LavaRuins/lavaland_surface_syndicate_base1.dmm
@@ -560,7 +560,6 @@
 /area/ruin/unpowered/syndicate_lava_base/testlab)
 "el" = (
 /obj/effect/turf_decal/stripes/line{
-	icon_state = "warningline";
 	dir = 1
 	},
 /turf/open/floor/plasteel/vault{
@@ -3055,7 +3054,6 @@
 /area/ruin/unpowered/syndicate_lava_base/main)
 "ja" = (
 /obj/effect/turf_decal/stripes/red/corner{
-	icon_state = "warninglinecorner_red";
 	dir = 1
 	},
 /obj/machinery/button/door{
@@ -3813,7 +3811,7 @@
 	pixel_y = 5
 	},
 /obj/structure/cable/yellow{
-	icon_state = "1-2"	
+	icon_state = "1-2"
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
@@ -5393,7 +5391,6 @@
 	autoclose = 0;
 	frequency = 1449;
 	heat_proof = 1;
-	icon_state = "closed";
 	id_tag = "syndie_lavaland_incinerator_interior";
 	locked = 1;
 	name = "Turbine Interior Airlock";
@@ -5885,7 +5882,6 @@
 	autoclose = 0;
 	frequency = 1449;
 	heat_proof = 1;
-	icon_state = "closed";
 	id_tag = "syndie_lavaland_incinerator_exterior";
 	locked = 1;
 	name = "Turbine Exterior Airlock";
@@ -5941,17 +5937,15 @@
 	},
 /area/ruin/unpowered/syndicate_lava_base/engineering)
 "oB" = (
-/obj/structure/sign/securearea{
-	desc = "A warning sign which reads 'EXTERNAL AIRLOCK'";
-	icon_state = "space";
-	layer = 4;
-	name = "EXTERNAL AIRLOCK";
-	pixel_y = -32
-	},
 /obj/machinery/atmospherics/components/unary/outlet_injector/on{
 	dir = 1;
 	frequency = 1441;
 	id = "syndie_lavaland_inc_in"
+	},
+/obj/structure/sign/vacuum{
+	desc = "A warning sign which reads 'EXTERNAL AIRLOCK'";
+	name = "EXTERNAL AIRLOCK";
+	pixel_y = -32
 	},
 /turf/open/floor/engine{
 	initial_gas_mix = "o2=14;n2=23;TEMP=300"

--- a/_maps/RandomRuins/LavaRuins/lavaland_surface_syndicate_base1.dmm
+++ b/_maps/RandomRuins/LavaRuins/lavaland_surface_syndicate_base1.dmm
@@ -9,1185 +9,5775 @@
 /turf/open/floor/plating/asteroid/basalt/lava_land_surface,
 /area/lavaland/surface/outdoors)
 "ad" = (
-/turf/closed/wall/mineral/plastitanium,
-/area/ruin/powered/syndicate_lava_base)
+/obj/machinery/door/firedoor,
+/obj/machinery/door/airlock/virology{
+	frequency = 1449;
+	id_tag = "lavaland_syndie_virology_interior";
+	locked = 1;
+	name = "Virology Lab Interior Airlock";
+	req_access_txt = "150"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4;
+	piping_layer = 3;
+	pixel_x = 5;
+	pixel_y = 5
+	},
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/open/floor/plasteel/white,
+/area/ruin/syndicate_lava_base/virology)
 "ae" = (
-/turf/closed/wall/mineral/plastitanium/explosive,
-/area/ruin/powered/syndicate_lava_base)
+/turf/closed/wall/mineral/plastitanium/nodiagonal,
+/area/ruin/syndicate_lava_base/testlab)
 "af" = (
-/obj/structure/closet/secure_closet/bar{
+/obj/machinery/light/small{
+	dir = 4
+	},
+/turf/open/floor/plasteel/floorgrime,
+/area/ruin/syndicate_lava_base/main)
+"ag" = (
+/obj/machinery/airalarm{
+	dir = 4;
+	icon_state = "alarm0";
+	pixel_x = -24;
+	req_access = 150
+	},
+/turf/open/floor/plasteel/red/side{
+	dir = 8
+	},
+/area/ruin/syndicate_lava_base/main)
+"ap" = (
+/obj/machinery/light/small{
+	dir = 1
+	},
+/turf/open/floor/engine,
+/area/ruin/syndicate_lava_base/testlab)
+"aq" = (
+/turf/open/floor/engine,
+/area/ruin/syndicate_lava_base/testlab)
+"as" = (
+/turf/closed/wall/mineral/plastitanium/nodiagonal,
+/area/ruin/syndicate_lava_base/chemistry)
+"at" = (
+/obj/structure/grille,
+/obj/structure/window/plastitanium,
+/obj/machinery/door/poddoor{
+	id = "lavalandsyndi_chemistry";
+	layer = 2.9
+	},
+/turf/open/floor/plating,
+/area/ruin/syndicate_lava_base/chemistry)
+"aL" = (
+/turf/closed/wall/mineral/plastitanium/explosive,
+/area/ruin/syndicate_lava_base/testlab)
+"aM" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/machinery/chem_dispenser,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel,
+/area/ruin/syndicate_lava_base/chemistry)
+"cA" = (
+/obj/structure/table/reinforced,
+/obj/item/book/manual/wiki/chemistry,
+/obj/item/book/manual/wiki/chemistry,
+/turf/open/floor/plasteel/floorgrime,
+/area/ruin/syndicate_lava_base/chemistry)
+"cG" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/machinery/chem_master,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/floorgrime,
+/area/ruin/syndicate_lava_base/chemistry)
+"cO" = (
+/turf/closed/wall/mineral/plastitanium/explosive,
+/area/ruin/syndicate_lava_base/chemistry)
+"dc" = (
+/obj/machinery/light/small{
+	dir = 8
+	},
+/turf/open/floor/engine,
+/area/ruin/syndicate_lava_base/testlab)
+"di" = (
+/obj/machinery/light/small{
+	dir = 4
+	},
+/turf/open/floor/engine,
+/area/ruin/syndicate_lava_base/testlab)
+"do" = (
+/obj/structure/closet/secure_closet/medical1{
 	req_access = null;
 	req_access_txt = "150"
 	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/white/side{
+	dir = 9
+	},
+/area/ruin/syndicate_lava_base/chemistry)
+"du" = (
+/obj/machinery/light/small{
+	dir = 1
+	},
+/obj/machinery/button/door{
+	id = "lavalandsyndi_chemistry";
+	name = "Chemistry Blast Door Control";
+	pixel_x = 0;
+	pixel_y = 26;
+	req_access_txt = "150"
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/white/side{
+	dir = 1
+	},
+/area/ruin/syndicate_lava_base/chemistry)
+"dv" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 10
 	},
-/turf/open/floor/mineral/plastitanium,
-/area/ruin/powered/syndicate_lava_base)
-"ag" = (
-/obj/structure/table/wood,
-/obj/item/reagent_containers/food/snacks/syndicake,
-/obj/item/reagent_containers/food/snacks/syndicake,
-/obj/item/reagent_containers/food/snacks/syndicake,
-/obj/structure/sign/barsign{
-	pixel_y = 32;
-	req_access = null;
-	req_access_txt = "150"
-	},
-/obj/machinery/light/small{
+/obj/machinery/chem_heater,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel,
+/area/ruin/syndicate_lava_base/chemistry)
+"dw" = (
+/obj/structure/chair/office/light{
 	dir = 1
 	},
+/obj/effect/turf_decal/bot,
 /obj/effect/turf_decal/stripes/line,
-/turf/open/floor/mineral/plastitanium,
-/area/ruin/powered/syndicate_lava_base)
-"ah" = (
-/obj/structure/table/wood,
-/obj/item/reagent_containers/food/snacks/salad/validsalad,
+/turf/open/floor/plasteel,
+/area/ruin/syndicate_lava_base/chemistry)
+"dx" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 6
 	},
-/turf/open/floor/mineral/plastitanium,
-/area/ruin/powered/syndicate_lava_base)
-"ai" = (
-/obj/structure/rack{
-	icon = 'icons/obj/stationobjs.dmi';
-	icon_state = "minibar_left";
-	name = "skeletal minibar"
+/obj/structure/closet/crate/bin,
+/turf/open/floor/plasteel/floorgrime,
+/area/ruin/syndicate_lava_base/chemistry)
+"dy" = (
+/turf/closed/wall/mineral/plastitanium/nodiagonal,
+/area/ruin/syndicate_lava_base/cargo)
+"dA" = (
+/obj/structure/closet/l3closet,
+/obj/machinery/power/apc{
+	dir = 8;
+	name = "Chemistry APC";
+	pixel_x = -24;
+	pixel_y = 0;
+	req_access = 150
 	},
-/obj/item/reagent_containers/food/drinks/bottle/vodka,
-/obj/machinery/light/small{
-	dir = 1
+/obj/structure/cable/yellow{
+	icon_state = "0-2";
+	d2 = 2
 	},
-/turf/open/floor/wood,
-/area/ruin/powered/syndicate_lava_base)
-"aj" = (
-/obj/structure/rack{
-	icon = 'icons/obj/stationobjs.dmi';
-	icon_state = "minibar_right";
-	name = "skeletal minibar"
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 6;
+	piping_layer = 3;
+	pixel_x = 5;
+	pixel_y = 5
 	},
-/obj/item/reagent_containers/food/drinks/bottle/gin,
-/turf/open/floor/wood,
-/area/ruin/powered/syndicate_lava_base)
-"ak" = (
-/obj/structure/dresser,
-/obj/structure/mirror{
-	pixel_x = -26
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/white/side{
+	dir = 8
 	},
-/turf/open/floor/plasteel/vault,
-/area/ruin/powered/syndicate_lava_base)
-"al" = (
-/obj/item/twohanded/required/kirbyplants{
-	icon_state = "plant-21"
+/area/ruin/syndicate_lava_base/chemistry)
+"dB" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
+	dir = 8;
+	piping_layer = 3;
+	pixel_x = 5;
+	pixel_y = 5
 	},
-/turf/open/floor/plasteel/vault,
-/area/ruin/powered/syndicate_lava_base)
-"am" = (
-/obj/item/twohanded/required/kirbyplants{
-	icon_state = "plant-22"
+/turf/open/floor/plasteel,
+/area/ruin/syndicate_lava_base/chemistry)
+"dC" = (
+/turf/open/floor/plasteel/floorgrime,
+/area/ruin/syndicate_lava_base/chemistry)
+"dD" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel,
+/area/ruin/syndicate_lava_base/chemistry)
+"dE" = (
+/obj/structure/table/glass,
+/obj/item/stack/sheet/mineral/plasma{
+	amount = 5;
+	pixel_x = -2;
+	pixel_y = 6
 	},
-/turf/open/floor/plasteel/vault,
-/area/ruin/powered/syndicate_lava_base)
-"an" = (
-/obj/structure/table/wood,
-/obj/item/clipboard,
-/obj/item/toy/figure/syndie,
-/turf/open/floor/plasteel/vault,
-/area/ruin/powered/syndicate_lava_base)
-"ao" = (
-/obj/machinery/portable_atmospherics/canister/air,
-/obj/effect/turf_decal/stripes/line{
+/obj/item/stack/sheet/mineral/plasma{
+	amount = 5;
+	pixel_x = 0;
+	pixel_y = 2
+	},
+/obj/item/stack/sheet/mineral/plasma{
+	amount = 5;
+	pixel_x = 2;
+	pixel_y = -2
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/item/reagent_containers/glass/bottle/charcoal{
+	pixel_x = 6
+	},
+/obj/item/reagent_containers/glass/bottle/epinephrine,
+/turf/open/floor/plasteel/white/corner{
+	dir = 4
+	},
+/area/ruin/syndicate_lava_base/chemistry)
+"dG" = (
+/obj/structure/lattice/catwalk,
+/turf/open/lava/smooth/lava_land_surface,
+/area/lavaland/surface/outdoors)
+"dI" = (
+/obj/structure/table/glass,
+/obj/machinery/reagentgrinder{
+	pixel_y = 5
+	},
+/obj/item/reagent_containers/glass/beaker/large,
+/turf/open/floor/plasteel/white/side{
 	dir = 5
 	},
-/turf/open/floor/mineral/plastitanium,
-/area/ruin/powered/syndicate_lava_base)
-"ap" = (
+/area/ruin/syndicate_lava_base/chemistry)
+"dK" = (
+/obj/effect/turf_decal/box/white/corners{
+	icon_state = "box_corners_white";
+	dir = 4
+	},
+/obj/structure/closet/crate/secure/gear{
+	req_access_txt = "150"
+	},
+/obj/item/clothing/gloves/combat,
+/obj/item/clothing/gloves/combat,
+/obj/item/clothing/under/syndicate/combat,
+/obj/item/clothing/under/syndicate/combat,
+/obj/item/storage/belt/military,
+/obj/item/storage/belt/military,
+/obj/item/clothing/shoes/combat,
+/obj/item/clothing/shoes/combat,
+/obj/item/clothing/mask/gas/syndicate,
+/obj/item/clothing/mask/gas/syndicate,
+/obj/item/clothing/glasses/night,
+/obj/item/clothing/glasses/night,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/dark,
-/area/ruin/powered/syndicate_lava_base)
-"aq" = (
+/area/ruin/syndicate_lava_base/cargo)
+"dL" = (
+/obj/machinery/airalarm{
+	pixel_y = 24;
+	req_access = 152
+	},
+/obj/structure/closet/crate,
+/obj/item/extinguisher{
+	pixel_x = -5;
+	pixel_y = 5
+	},
+/obj/item/extinguisher{
+	pixel_x = -2;
+	pixel_y = 2
+	},
+/obj/item/extinguisher{
+	pixel_x = 1;
+	pixel_y = -1
+	},
+/obj/item/device/flashlight{
+	pixel_x = -5;
+	pixel_y = 5
+	},
+/obj/item/device/flashlight{
+	pixel_x = -2;
+	pixel_y = 2
+	},
+/obj/item/device/flashlight{
+	pixel_x = 1;
+	pixel_y = -1
+	},
+/obj/item/device/radio/headset/syndicate/alt{
+	pixel_x = -3;
+	pixel_y = 3
+	},
+/obj/item/device/radio/headset/syndicate/alt,
+/obj/item/device/radio/headset/syndicate/alt{
+	pixel_x = 3;
+	pixel_y = -3
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/dark,
+/area/ruin/syndicate_lava_base/cargo)
+"dM" = (
+/obj/effect/turf_decal/box/white/corners{
+	icon_state = "box_corners_white";
+	dir = 1
+	},
+/obj/structure/closet/crate,
+/obj/item/storage/box/donkpockets{
+	pixel_x = -2;
+	pixel_y = 6
+	},
+/obj/item/storage/box/donkpockets{
+	pixel_x = 0;
+	pixel_y = 3
+	},
+/obj/item/storage/box/donkpockets{
+	pixel_x = 2
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/dark,
+/area/ruin/syndicate_lava_base/cargo)
+"dP" = (
+/turf/closed/wall/mineral/plastitanium/explosive,
+/area/ruin/syndicate_lava_base/cargo)
+"dQ" = (
+/obj/structure/sign/securearea,
+/turf/closed/wall/mineral/plastitanium/nodiagonal,
+/area/ruin/syndicate_lava_base/testlab)
+"dR" = (
+/obj/machinery/door/firedoor,
+/obj/machinery/door/airlock/hatch{
+	name = "Experimentation Room";
+	req_access_txt = "150"
+	},
+/obj/machinery/door/poddoor/preopen{
+	id = "lavalandsyndi";
+	layer = 2.9;
+	name = "Syndicate Research Experimentation Shutters"
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/vault{
+	dir = 8
+	},
+/area/ruin/syndicate_lava_base/testlab)
+"dS" = (
+/obj/structure/grille,
+/obj/structure/window/plastitanium,
+/obj/machinery/door/firedoor,
+/obj/machinery/door/poddoor/preopen{
+	id = "lavalandsyndi";
+	layer = 2.9;
+	name = "Syndicate Research Experimentation Shutters"
+	},
+/turf/open/floor/plating,
+/area/ruin/syndicate_lava_base/testlab)
+"dT" = (
+/obj/machinery/firealarm{
+	dir = 8;
+	pixel_x = -26
+	},
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	pixel_y = 0
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	piping_layer = 3;
+	pixel_x = 5;
+	pixel_y = 5
+	},
+/turf/open/floor/plasteel/white/side{
+	dir = 8
+	},
+/area/ruin/syndicate_lava_base/chemistry)
+"dU" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel,
+/area/ruin/syndicate_lava_base/chemistry)
+"dV" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/ruin/syndicate_lava_base/chemistry)
+"dX" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/ruin/syndicate_lava_base/chemistry)
+"dY" = (
+/obj/structure/chair{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/ruin/syndicate_lava_base/chemistry)
+"dZ" = (
+/obj/machinery/light/small{
+	dir = 4
+	},
+/obj/structure/table/glass,
+/obj/item/folder/white,
+/obj/item/reagent_containers/glass/beaker/large{
+	pixel_x = -3
+	},
+/obj/item/reagent_containers/glass/beaker/large{
+	pixel_x = -3
+	},
+/obj/item/reagent_containers/dropper,
+/obj/machinery/airalarm{
+	dir = 8;
+	icon_state = "alarm0";
+	pixel_x = 24;
+	req_access = 152
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/white/side{
+	dir = 4
+	},
+/area/ruin/syndicate_lava_base/chemistry)
+"ea" = (
+/obj/effect/turf_decal/box/white/corners{
+	icon_state = "box_corners_white";
+	dir = 8
+	},
+/obj/structure/closet/crate/secure/weapon{
+	req_access_txt = "150"
+	},
+/obj/item/ammo_box/c10mm{
+	pixel_x = 0;
+	pixel_y = 6
+	},
+/obj/item/ammo_box/c10mm,
+/obj/item/ammo_box/magazine/m10mm{
+	pixel_x = -5;
+	pixel_y = 5
+	},
+/obj/item/ammo_box/magazine/m10mm{
+	pixel_x = -2;
+	pixel_y = 2
+	},
+/obj/item/ammo_box/magazine/m10mm{
+	pixel_x = 1;
+	pixel_y = -1
+	},
+/obj/item/ammo_box/magazine/m10mm{
+	pixel_x = 4;
+	pixel_y = -4
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on,
+/turf/open/floor/plasteel/dark,
+/area/ruin/syndicate_lava_base/cargo)
+"eb" = (
+/obj/structure/closet/crate,
+/obj/item/storage/box/monkeycubes{
+	pixel_x = -3;
+	pixel_y = 3
+	},
+/obj/item/storage/box/monkeycubes,
+/obj/item/storage/toolbox/electrical{
+	pixel_y = 4
+	},
+/obj/item/storage/toolbox/mechanical,
+/turf/open/floor/plasteel/dark,
+/area/ruin/syndicate_lava_base/cargo)
+"ec" = (
+/obj/effect/turf_decal/box/white/corners,
+/obj/structure/closet/crate/medical,
+/obj/item/storage/firstaid/fire{
+	pixel_x = 3;
+	pixel_y = 3
+	},
+/obj/item/storage/firstaid/brute,
+/obj/item/storage/firstaid/regular{
+	pixel_x = -3;
+	pixel_y = -3
+	},
+/turf/open/floor/plasteel/dark,
+/area/ruin/syndicate_lava_base/cargo)
+"ed" = (
+/obj/structure/table,
+/obj/item/paper_bin,
+/obj/item/pen,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/vault{
 	dir = 5
 	},
-/area/ruin/powered/syndicate_lava_base)
-"ar" = (
-/obj/item/stack/sheet/mineral/plastitanium{
-	amount = 30
+/area/ruin/syndicate_lava_base/cargo)
+"ee" = (
+/obj/structure/rack,
+/obj/item/device/flashlight{
+	pixel_x = -3;
+	pixel_y = 3
 	},
-/obj/item/stack/rods/fifty,
+/obj/item/device/flashlight,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/brown{
+	dir = 1
+	},
+/area/ruin/syndicate_lava_base/cargo)
+"ef" = (
+/obj/machinery/light/small{
+	dir = 1
+	},
+/obj/structure/cable/yellow{
+	icon_state = "0-2";
+	d2 = 2
+	},
+/obj/machinery/power/apc{
+	dir = 1;
+	name = "Cargo Bay APC";
+	pixel_x = 0;
+	pixel_y = 24;
+	req_access = 150
+	},
+/obj/structure/closet/emcloset/anchored,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/brown{
+	dir = 1
+	},
+/area/ruin/syndicate_lava_base/cargo)
+"eg" = (
+/obj/structure/closet/firecloset/full{
+	anchored = 1
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/brown{
+	dir = 1
+	},
+/area/ruin/syndicate_lava_base/cargo)
+"eh" = (
+/turf/closed/wall/mineral/plastitanium/nodiagonal,
+/area/ruin/syndicate_lava_base/virology)
+"ei" = (
+/obj/structure/disposaloutlet{
+	dir = 1
+	},
+/obj/structure/disposalpipe/trunk,
+/turf/open/floor/plating/asteroid/basalt/lava_land_surface,
+/area/ruin/syndicate_lava_base/virology)
+"ej" = (
+/obj/structure/bed/roller,
+/obj/machinery/iv_drip,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/mob/living/carbon/monkey,
+/turf/open/floor/plasteel/vault{
+	dir = 8
+	},
+/area/ruin/syndicate_lava_base/testlab)
+"ek" = (
+/obj/structure/grille,
+/obj/structure/window/plastitanium,
+/turf/open/floor/plating,
+/area/ruin/syndicate_lava_base/testlab)
+"el" = (
+/obj/effect/turf_decal/stripes/line{
+	icon_state = "warningline";
+	dir = 1
+	},
+/turf/open/floor/plasteel/vault{
+	dir = 8
+	},
+/area/ruin/syndicate_lava_base/testlab)
+"em" = (
+/obj/machinery/light/small{
+	dir = 1
+	},
+/obj/machinery/button/door{
+	id = "lavalandsyndi";
+	name = "Syndicate Experimentation Lockdown Control";
+	pixel_x = 0;
+	pixel_y = 26;
+	req_access_txt = "150"
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/stripes/corner{
+	dir = 4
+	},
+/turf/open/floor/plasteel/vault{
+	dir = 8
+	},
+/area/ruin/syndicate_lava_base/testlab)
+"eo" = (
 /obj/structure/table/reinforced,
+/obj/item/stack/sheet/metal/fifty,
+/obj/item/grenade/chem_grenade,
+/obj/item/grenade/chem_grenade,
+/obj/item/grenade/chem_grenade,
+/obj/item/grenade/chem_grenade,
+/turf/open/floor/plasteel/vault{
+	dir = 8
+	},
+/area/ruin/syndicate_lava_base/testlab)
+"ep" = (
+/obj/structure/table/reinforced,
+/obj/item/storage/toolbox/syndicate,
+/obj/item/stack/cable_coil/yellow,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/vault{
+	dir = 8
+	},
+/area/ruin/syndicate_lava_base/testlab)
+"eq" = (
+/obj/structure/table/reinforced,
+/obj/item/device/assembly/timer{
+	pixel_x = 3;
+	pixel_y = 3
+	},
+/obj/item/device/assembly/timer{
+	pixel_x = 3;
+	pixel_y = 3
+	},
+/obj/item/device/assembly/timer{
+	pixel_x = 3;
+	pixel_y = 3
+	},
+/obj/item/device/assembly/igniter,
+/obj/item/device/assembly/igniter,
+/obj/item/device/assembly/igniter,
+/obj/item/device/assembly/voice,
+/obj/item/device/assembly/voice,
+/obj/item/device/assembly/voice,
+/obj/item/device/assembly/signaler,
+/obj/item/device/assembly/signaler,
+/obj/item/device/assembly/signaler,
+/obj/item/screwdriver/nuke,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/vault{
+	dir = 8
+	},
+/area/ruin/syndicate_lava_base/testlab)
+"er" = (
+/obj/machinery/light/small{
+	dir = 8
+	},
+/obj/structure/extinguisher_cabinet{
+	pixel_x = -27;
+	pixel_y = 1
+	},
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	pixel_y = 0
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	piping_layer = 3;
+	pixel_x = 5;
+	pixel_y = 5
+	},
+/turf/open/floor/plasteel/white/side{
+	dir = 8
+	},
+/area/ruin/syndicate_lava_base/chemistry)
+"es" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 9
 	},
-/turf/open/floor/mineral/plastitanium,
-/area/ruin/powered/syndicate_lava_base)
-"as" = (
-/turf/open/floor/wood,
-/area/ruin/powered/syndicate_lava_base)
-"at" = (
-/obj/effect/mob_spawn/human/lavaland_syndicate{
-	icon_state = "sleeper_s";
-	dir = 4
-	},
-/turf/open/floor/plasteel/grimy,
-/area/ruin/powered/syndicate_lava_base)
-"au" = (
-/turf/open/floor/plasteel/grimy,
-/area/ruin/powered/syndicate_lava_base)
-"av" = (
-/obj/effect/mob_spawn/human/lavaland_syndicate{
-	icon_state = "sleeper_s";
-	dir = 8
-	},
-/turf/open/floor/plasteel/grimy,
-/area/ruin/powered/syndicate_lava_base)
-"aw" = (
-/obj/structure/reagent_dispensers/watertank,
+/obj/structure/closet/crate/bin,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel,
+/area/ruin/syndicate_lava_base/chemistry)
+"et" = (
 /obj/effect/turf_decal/stripes/line{
-	dir = 4
+	dir = 1
 	},
-/turf/open/floor/mineral/plastitanium,
-/area/ruin/powered/syndicate_lava_base)
-"ax" = (
-/obj/item/stack/cable_coil/white,
-/obj/item/stack/cable_coil/white,
-/obj/item/stack/packageWrap,
-/obj/item/hand_labeler,
-/obj/structure/table/reinforced,
-/obj/machinery/light{
-	dir = 4
-	},
+/turf/open/floor/plasteel,
+/area/ruin/syndicate_lava_base/chemistry)
+"eu" = (
 /obj/effect/turf_decal/stripes/line{
-	dir = 8
+	dir = 5
 	},
-/turf/open/floor/mineral/plastitanium,
-/area/ruin/powered/syndicate_lava_base)
-"ay" = (
-/obj/structure/table/wood,
-/obj/item/ammo_box/magazine/m10mm,
-/obj/item/ammo_box/magazine/m10mm,
-/obj/item/ammo_box/magazine/m10mm,
-/obj/item/ammo_box/magazine/m10mm,
-/obj/item/ammo_box/magazine/sniper_rounds,
-/obj/item/ammo_box/magazine/sniper_rounds,
-/obj/item/ammo_box/magazine/sniper_rounds,
+/obj/machinery/chem_heater,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/floorgrime,
+/area/ruin/syndicate_lava_base/chemistry)
+"ev" = (
+/turf/open/floor/plasteel/white/corner,
+/area/ruin/syndicate_lava_base/chemistry)
+"ew" = (
+/obj/structure/table/glass,
+/obj/item/stack/cable_coil/white{
+	pixel_x = 3;
+	pixel_y = 3
+	},
+/obj/item/stack/cable_coil/white,
+/obj/item/device/assembly/igniter{
+	pixel_x = -3;
+	pixel_y = -3
+	},
+/obj/item/device/assembly/igniter{
+	pixel_x = -3;
+	pixel_y = -3
+	},
+/obj/item/device/assembly/igniter{
+	pixel_x = -3;
+	pixel_y = -3
+	},
+/obj/item/device/assembly/timer{
+	pixel_x = 3;
+	pixel_y = 3
+	},
+/obj/item/device/assembly/timer{
+	pixel_x = 3;
+	pixel_y = 3
+	},
+/obj/item/device/assembly/timer{
+	pixel_x = 3;
+	pixel_y = 3
+	},
+/obj/item/grenade/chem_grenade,
+/obj/item/grenade/chem_grenade,
+/obj/item/grenade/chem_grenade,
+/obj/item/screwdriver{
+	pixel_y = 20
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/white/side{
+	dir = 6
+	},
+/area/ruin/syndicate_lava_base/chemistry)
+"ex" = (
 /obj/machinery/light/small{
 	brightness = 3;
 	dir = 8
 	},
-/turf/open/floor/plasteel/grimy,
-/area/ruin/powered/syndicate_lava_base)
-"az" = (
-/obj/structure/table/wood,
-/obj/item/ammo_box/magazine/m10mm,
-/obj/item/ammo_box/magazine/m10mm,
-/obj/item/ammo_box/magazine/m10mm,
-/obj/item/ammo_box/magazine/m10mm,
-/obj/item/ammo_box/magazine/sniper_rounds,
-/obj/item/ammo_box/magazine/sniper_rounds,
-/obj/item/ammo_box/magazine/sniper_rounds,
-/obj/item/ammo_box/magazine/sniper_rounds,
-/obj/item/ammo_box/magazine/sniper_rounds,
-/obj/item/ammo_box/magazine/sniper_rounds,
+/obj/machinery/firealarm{
+	dir = 8;
+	pixel_x = -26
+	},
+/obj/structure/cable/yellow{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 6;
+	piping_layer = 3;
+	pixel_x = 5;
+	pixel_y = 5
+	},
+/turf/open/floor/plasteel/vault{
+	dir = 5
+	},
+/area/ruin/syndicate_lava_base/cargo)
+"ey" = (
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4;
+	piping_layer = 3;
+	pixel_x = 5;
+	pixel_y = 5
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/vault{
+	dir = 5
+	},
+/area/ruin/syndicate_lava_base/cargo)
+"ez" = (
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
+	dir = 1;
+	piping_layer = 3;
+	pixel_x = 5;
+	pixel_y = 5
+	},
+/turf/open/floor/plasteel/vault{
+	dir = 5
+	},
+/area/ruin/syndicate_lava_base/cargo)
+"eA" = (
+/obj/machinery/door/firedoor,
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4;
+	piping_layer = 3;
+	pixel_x = 5;
+	pixel_y = 5
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/door/airlock/mining/glass{
+	name = "Warehouse";
+	req_access_txt = "150"
+	},
+/turf/open/floor/plasteel/vault{
+	dir = 5
+	},
+/area/ruin/syndicate_lava_base/cargo)
+"eB" = (
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4;
+	piping_layer = 3;
+	pixel_x = 5;
+	pixel_y = 5
+	},
+/turf/open/floor/plasteel/floorgrime,
+/area/ruin/syndicate_lava_base/cargo)
+"eC" = (
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 10;
+	piping_layer = 3;
+	pixel_x = 5;
+	pixel_y = 5
+	},
+/turf/open/floor/plasteel,
+/area/ruin/syndicate_lava_base/cargo)
+"eD" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/floorgrime,
+/area/ruin/syndicate_lava_base/cargo)
+"eE" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/structure/table,
+/obj/item/storage/box/lights/bulbs,
+/obj/item/wrench,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/mineral/plastitanium,
+/area/ruin/syndicate_lava_base/cargo)
+"eF" = (
+/obj/structure/grille,
+/obj/structure/window/plastitanium,
+/obj/machinery/door/firedoor,
+/obj/machinery/door/poddoor{
+	id = "lavalandsyndi_cargo";
+	layer = 2.9
+	},
+/turf/open/floor/plating,
+/area/ruin/syndicate_lava_base/cargo)
+"eG" = (
+/obj/structure/closet/secure_closet/personal/patient,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/white/side{
+	dir = 9
+	},
+/area/ruin/syndicate_lava_base/virology)
+"eH" = (
+/obj/structure/bed,
+/obj/item/bedsheet,
+/obj/machinery/light/small{
+	dir = 1
+	},
+/turf/open/floor/plasteel/white/side{
+	dir = 5
+	},
+/area/ruin/syndicate_lava_base/virology)
+"eI" = (
+/obj/structure/grille,
+/obj/structure/window/plastitanium,
+/turf/open/floor/plating,
+/area/ruin/syndicate_lava_base/virology)
+"eJ" = (
+/obj/structure/disposalpipe/segment,
+/turf/closed/wall/mineral/plastitanium/nodiagonal,
+/area/ruin/syndicate_lava_base/virology)
+"eK" = (
+/obj/machinery/light/small,
+/obj/structure/bed/roller,
+/obj/machinery/iv_drip,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/mob/living/carbon/monkey,
+/turf/open/floor/plasteel/vault{
+	dir = 8
+	},
+/area/ruin/syndicate_lava_base/testlab)
+"eL" = (
+/obj/machinery/door/airlock/hatch{
+	name = "Monkey Pen";
+	req_access_txt = "150"
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/vault{
+	dir = 8
+	},
+/area/ruin/syndicate_lava_base/testlab)
+"eM" = (
+/obj/machinery/firealarm{
+	dir = 1;
+	pixel_x = 0;
+	pixel_y = -24
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
+	dir = 4;
+	piping_layer = 3;
+	pixel_x = 5;
+	pixel_y = 5
+	},
+/turf/open/floor/plasteel/vault{
+	dir = 8
+	},
+/area/ruin/syndicate_lava_base/testlab)
+"eN" = (
+/obj/machinery/airalarm{
+	dir = 1;
+	pixel_y = -24;
+	req_access = null
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4;
+	piping_layer = 3;
+	pixel_x = 5;
+	pixel_y = 5
+	},
+/turf/open/floor/plasteel/vault{
+	dir = 8
+	},
+/area/ruin/syndicate_lava_base/testlab)
+"eO" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/components/unary/vent_pump/on{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4;
+	piping_layer = 3;
+	pixel_x = 5;
+	pixel_y = 5
+	},
+/turf/open/floor/plasteel/vault{
+	dir = 8
+	},
+/area/ruin/syndicate_lava_base/testlab)
+"eP" = (
+/obj/structure/chair{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 10;
+	piping_layer = 3;
+	pixel_x = 5;
+	pixel_y = 5
+	},
+/turf/open/floor/plasteel/vault{
+	dir = 8
+	},
+/area/ruin/syndicate_lava_base/testlab)
+"eQ" = (
+/obj/machinery/light/small,
+/obj/structure/table/reinforced,
+/obj/item/restraints/handcuffs,
+/obj/item/device/taperecorder,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/vault{
+	dir = 8
+	},
+/area/ruin/syndicate_lava_base/testlab)
+"eR" = (
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	pixel_y = 0
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	piping_layer = 3;
+	pixel_x = 5;
+	pixel_y = 5
+	},
+/turf/open/floor/plasteel/white/side{
+	dir = 10
+	},
+/area/ruin/syndicate_lava_base/chemistry)
+"eS" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/machinery/chem_master,
+/turf/open/floor/plasteel/floorgrime,
+/area/ruin/syndicate_lava_base/chemistry)
+"eT" = (
+/obj/effect/turf_decal/bot,
+/obj/structure/chair/office/light,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel,
+/area/ruin/syndicate_lava_base/chemistry)
+"eU" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/machinery/chem_dispenser,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/floorgrime,
+/area/ruin/syndicate_lava_base/chemistry)
+"eV" = (
+/obj/structure/closet/secure_closet/chemical{
+	req_access_txt = "152"
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/white/side{
+	dir = 6
+	},
+/area/ruin/syndicate_lava_base/chemistry)
+"eW" = (
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	pixel_y = 0
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	piping_layer = 3;
+	pixel_x = 5;
+	pixel_y = 5
+	},
+/turf/open/floor/plasteel/vault{
+	dir = 5
+	},
+/area/ruin/syndicate_lava_base/cargo)
+"eX" = (
+/obj/effect/turf_decal/box/white/corners{
+	icon_state = "box_corners_white";
+	dir = 4
+	},
+/obj/structure/closet/crate/internals,
+/obj/item/tank/internals/oxygen/yellow,
+/obj/item/tank/internals/oxygen/yellow,
+/obj/item/tank/internals/oxygen/yellow,
+/obj/item/tank/internals/emergency_oxygen/double,
+/obj/item/tank/internals/emergency_oxygen/double,
+/obj/item/tank/internals/emergency_oxygen/double,
+/obj/item/clothing/mask/gas,
+/obj/item/clothing/mask/gas,
+/obj/item/clothing/mask/gas,
+/turf/open/floor/plasteel/dark,
+/area/ruin/syndicate_lava_base/cargo)
+"eY" = (
+/obj/effect/turf_decal/box/white/corners{
+	icon_state = "box_corners_white";
+	dir = 1
+	},
+/obj/structure/closet/crate,
+/obj/item/storage/box/donkpockets{
+	pixel_x = -2;
+	pixel_y = 6
+	},
+/obj/item/storage/box/donkpockets{
+	pixel_x = 0;
+	pixel_y = 3
+	},
+/obj/item/storage/box/donkpockets{
+	pixel_x = 2
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
+	dir = 1;
+	piping_layer = 3;
+	pixel_x = 5;
+	pixel_y = 5
+	},
+/turf/open/floor/plasteel/dark,
+/area/ruin/syndicate_lava_base/cargo)
+"eZ" = (
+/obj/structure/rack{
+	dir = 8;
+	layer = 2.9
+	},
+/obj/item/stack/sheet/cardboard{
+	amount = 3
+	},
+/obj/item/stack/rods/twentyfive,
+/obj/item/stock_parts/cell/high/plus,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/vault{
+	dir = 5
+	},
+/area/ruin/syndicate_lava_base/cargo)
+"fa" = (
+/obj/structure/grille,
+/obj/structure/window/plastitanium,
+/obj/machinery/door/firedoor,
+/turf/open/floor/plating,
+/area/ruin/syndicate_lava_base/cargo)
+"fb" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/closet/crate/bin,
+/turf/open/floor/plasteel/brown/corner{
+	dir = 8
+	},
+/area/ruin/syndicate_lava_base/cargo)
+"fc" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 5;
+	piping_layer = 3;
+	pixel_x = 5;
+	pixel_y = 5
+	},
+/turf/open/floor/plasteel,
+/area/ruin/syndicate_lava_base/cargo)
+"fd" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
+	dir = 8;
+	piping_layer = 3;
+	pixel_x = 5;
+	pixel_y = 5
+	},
+/turf/open/floor/plasteel/floorgrime,
+/area/ruin/syndicate_lava_base/cargo)
+"fe" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/structure/table,
+/obj/machinery/cell_charger,
+/obj/item/stock_parts/cell/high/plus,
+/turf/open/floor/mineral/plastitanium,
+/area/ruin/syndicate_lava_base/cargo)
+"ff" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
+	dir = 4;
+	piping_layer = 3;
+	pixel_x = 5;
+	pixel_y = 5
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/white/side{
+	dir = 10
+	},
+/area/ruin/syndicate_lava_base/virology)
+"fg" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 10;
+	piping_layer = 3;
+	pixel_x = 5;
+	pixel_y = 5
+	},
+/turf/open/floor/plasteel/white/side{
+	dir = 6
+	},
+/area/ruin/syndicate_lava_base/virology)
+"fh" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
+	dir = 4;
+	piping_layer = 3;
+	pixel_x = 5;
+	pixel_y = 5
+	},
+/turf/open/floor/plasteel/white/side{
+	dir = 10
+	},
+/area/ruin/syndicate_lava_base/virology)
+"fi" = (
+/obj/structure/table/glass,
+/obj/item/storage/box/beakers{
+	pixel_x = 2;
+	pixel_y = 2
+	},
+/obj/item/storage/box/syringes,
+/obj/machinery/power/apc{
+	dir = 1;
+	name = "Virology APC";
+	pixel_x = 0;
+	pixel_y = 24;
+	req_access = 150
+	},
+/obj/structure/cable/yellow{
+	icon_state = "0-2";
+	d2 = 2
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/white/side{
+	dir = 9
+	},
+/area/ruin/syndicate_lava_base/virology)
+"fj" = (
+/obj/structure/table/glass,
+/obj/structure/reagent_dispensers/virusfood{
+	pixel_x = 0;
+	pixel_y = 28
+	},
+/obj/item/clothing/gloves/color/latex,
+/obj/item/device/healthanalyzer,
+/obj/item/clothing/glasses/hud/health,
+/obj/structure/disposalpipe/segment,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/firealarm{
+	dir = 4;
+	pixel_x = 26;
+	pixel_y = 0
+	},
+/turf/open/floor/plasteel/white/side{
+	dir = 5
+	},
+/area/ruin/syndicate_lava_base/virology)
+"fk" = (
+/obj/machinery/power/apc{
+	dir = 2;
+	name = "Experimentation Lab APC";
+	pixel_x = 0;
+	pixel_y = -24;
+	req_access = 150
+	},
+/obj/structure/cable/yellow{
+	d2 = 4;
+	icon_state = "0-4"
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/vault{
+	dir = 8
+	},
+/area/ruin/syndicate_lava_base/testlab)
+"fl" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	piping_layer = 3;
+	pixel_x = 5;
+	pixel_y = 5
+	},
+/obj/structure/extinguisher_cabinet{
+	pixel_x = 25;
+	pixel_y = 0
+	},
+/obj/structure/cable/yellow{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/turf/open/floor/plasteel/vault{
+	dir = 8
+	},
+/area/ruin/syndicate_lava_base/testlab)
+"fm" = (
+/obj/machinery/door/firedoor,
+/obj/machinery/door/airlock/medical{
+	name = "Chemistry Lab";
+	req_access_txt = "150"
+	},
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	pixel_y = 0
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	piping_layer = 3;
+	pixel_x = 5;
+	pixel_y = 5
+	},
+/turf/open/floor/plasteel/white,
+/area/ruin/syndicate_lava_base/chemistry)
+"fn" = (
+/obj/structure/grille,
+/obj/structure/window/plastitanium,
+/obj/machinery/door/firedoor,
+/turf/open/floor/plating,
+/area/ruin/syndicate_lava_base/chemistry)
+"fo" = (
+/obj/machinery/door/firedoor,
+/obj/structure/table/reinforced,
+/obj/machinery/door/window/southleft{
+	base_state = "left";
+	dir = 2;
+	icon_state = "left";
+	name = "Chemistry";
+	req_access_txt = "0"
+	},
+/obj/machinery/door/window/southleft{
+	base_state = "left";
+	dir = 1;
+	icon_state = "left";
+	name = "Chemistry";
+	req_access_txt = "150"
+	},
+/turf/open/floor/plasteel/white,
+/area/ruin/syndicate_lava_base/chemistry)
+"fp" = (
+/obj/structure/sign/chemistry,
+/turf/closed/wall/mineral/plastitanium/nodiagonal,
+/area/ruin/syndicate_lava_base/chemistry)
+"fq" = (
+/obj/machinery/vending/assist,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/vault{
+	dir = 5
+	},
+/area/ruin/syndicate_lava_base/cargo)
+"fr" = (
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	pixel_y = 0
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	piping_layer = 3;
+	pixel_x = 5;
+	pixel_y = 5
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/vault{
+	dir = 5
+	},
+/area/ruin/syndicate_lava_base/cargo)
+"fs" = (
+/obj/effect/turf_decal/box/white/corners{
+	icon_state = "box_corners_white";
+	dir = 8
+	},
+/obj/structure/closet/crate,
+/obj/item/reagent_containers/glass/beaker/waterbottle/large{
+	pixel_x = -3;
+	pixel_y = 3
+	},
+/obj/item/reagent_containers/glass/beaker/waterbottle/large{
+	pixel_x = -3;
+	pixel_y = 3
+	},
+/obj/item/reagent_containers/glass/beaker/waterbottle/large,
+/obj/item/reagent_containers/glass/beaker/waterbottle/large,
+/obj/item/reagent_containers/glass/beaker/waterbottle/large{
+	pixel_x = 3;
+	pixel_y = -3
+	},
+/obj/item/reagent_containers/glass/beaker/waterbottle/large{
+	pixel_x = 3;
+	pixel_y = -3
+	},
+/turf/open/floor/plasteel/dark,
+/area/ruin/syndicate_lava_base/cargo)
+"ft" = (
+/obj/effect/turf_decal/box/white/corners,
+/obj/structure/closet/crate,
+/obj/item/reagent_containers/glass/beaker/waterbottle/large{
+	pixel_x = -3;
+	pixel_y = 3
+	},
+/obj/item/reagent_containers/glass/beaker/waterbottle/large{
+	pixel_x = -3;
+	pixel_y = 3
+	},
+/obj/item/reagent_containers/glass/beaker/waterbottle/large,
+/obj/item/reagent_containers/glass/beaker/waterbottle/large,
+/obj/item/reagent_containers/glass/beaker/waterbottle/large{
+	pixel_x = 3;
+	pixel_y = -3
+	},
+/obj/item/reagent_containers/glass/beaker/waterbottle/large{
+	pixel_x = 3;
+	pixel_y = -3
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/dark,
+/area/ruin/syndicate_lava_base/cargo)
+"fu" = (
+/obj/machinery/light/small{
+	dir = 8
+	},
+/obj/machinery/airalarm{
+	dir = 4;
+	icon_state = "alarm0";
+	pixel_x = -24;
+	req_access = 150
+	},
+/obj/structure/table,
+/obj/item/clothing/suit/hazardvest,
+/obj/item/clothing/suit/hazardvest,
+/obj/item/clothing/head/soft{
+	pixel_x = -8
+	},
+/obj/item/clothing/head/soft{
+	pixel_x = -8
+	},
+/obj/item/device/radio{
+	pixel_x = 5;
+	pixel_y = 0
+	},
+/obj/item/device/radio{
+	pixel_x = 5;
+	pixel_y = 0
+	},
+/turf/open/floor/plasteel/brown{
+	dir = 8
+	},
+/area/ruin/syndicate_lava_base/cargo)
+"fv" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/turf/open/floor/plasteel,
+/area/ruin/syndicate_lava_base/cargo)
+"fw" = (
+/obj/effect/turf_decal/stripes/corner,
+/obj/machinery/firealarm{
+	dir = 4;
+	pixel_x = 26;
+	pixel_y = 0
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel,
+/area/ruin/syndicate_lava_base/cargo)
+"fx" = (
+/obj/structure/sign/securearea,
+/turf/closed/wall/mineral/plastitanium/nodiagonal,
+/area/ruin/syndicate_lava_base/cargo)
+"fy" = (
+/obj/machinery/door/airlock/virology/glass{
+	name = "Isolation B";
+	req_access_txt = "150"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	piping_layer = 3;
+	pixel_x = 5;
+	pixel_y = 5
+	},
+/turf/open/floor/plasteel/white,
+/area/ruin/syndicate_lava_base/virology)
+"fz" = (
+/obj/machinery/door/airlock/virology/glass{
+	name = "Isolation A";
+	req_access_txt = "150"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	piping_layer = 3;
+	pixel_x = 5;
+	pixel_y = 5
+	},
+/turf/open/floor/plasteel/white,
+/area/ruin/syndicate_lava_base/virology)
+"fA" = (
+/obj/structure/table/glass,
+/obj/item/book/manual/wiki/infections{
+	pixel_y = 7
+	},
+/obj/item/reagent_containers/syringe/antiviral,
+/obj/item/reagent_containers/dropper,
+/obj/item/reagent_containers/spray/cleaner,
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	pixel_y = 0
+	},
+/turf/open/floor/plasteel/white/side{
+	dir = 8
+	},
+/area/ruin/syndicate_lava_base/virology)
+"fB" = (
+/obj/structure/chair/stool,
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/plasteel/white/corner{
+	dir = 4
+	},
+/area/ruin/syndicate_lava_base/virology)
+"fC" = (
+/obj/machinery/smartfridge/chemistry/virology/preloaded,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/white/side{
+	dir = 5
+	},
+/area/ruin/syndicate_lava_base/virology)
+"fD" = (
+/obj/structure/sign/biohazard,
+/turf/closed/wall/mineral/plastitanium/nodiagonal,
+/area/ruin/syndicate_lava_base/virology)
+"fE" = (
+/obj/effect/turf_decal/bot,
+/obj/structure/closet/l3closet,
+/obj/machinery/light/small{
+	brightness = 3;
+	dir = 8
+	},
+/obj/machinery/airalarm{
+	pixel_y = 24;
+	req_access = 152
+	},
+/turf/open/floor/plasteel/floorgrime,
+/area/ruin/syndicate_lava_base/main)
+"fF" = (
+/obj/effect/turf_decal/bot,
+/obj/machinery/shower{
+	pixel_x = 0;
+	pixel_y = 14
+	},
+/turf/open/floor/plasteel,
+/area/ruin/syndicate_lava_base/main)
+"fG" = (
+/obj/machinery/door/firedoor,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	piping_layer = 3;
+	pixel_x = 5;
+	pixel_y = 5
+	},
+/obj/machinery/door/airlock/hatch{
+	name = "Experimentation Lab";
+	req_access_txt = "150"
+	},
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	pixel_y = 0
+	},
+/turf/open/floor/plasteel/vault{
+	dir = 8
+	},
+/area/ruin/syndicate_lava_base/testlab)
+"fH" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/white/side{
+	dir = 1
+	},
+/area/ruin/syndicate_lava_base/main)
+"fI" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	pixel_y = 0
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	piping_layer = 3;
+	pixel_x = 5;
+	pixel_y = 5
+	},
+/turf/open/floor/plasteel/white/side{
+	dir = 1
+	},
+/area/ruin/syndicate_lava_base/main)
+"fO" = (
+/turf/open/floor/plasteel/white/side{
+	dir = 1
+	},
+/area/ruin/syndicate_lava_base/main)
+"fW" = (
+/obj/machinery/door/firedoor,
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	pixel_y = 0
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	piping_layer = 3;
+	pixel_x = 5;
+	pixel_y = 5
+	},
+/obj/machinery/door/airlock/mining/glass{
+	name = "Warehouse";
+	req_access_txt = "150"
+	},
+/turf/open/floor/plasteel/vault{
+	dir = 5
+	},
+/area/ruin/syndicate_lava_base/cargo)
+"fY" = (
+/obj/structure/extinguisher_cabinet{
+	pixel_x = -27;
+	pixel_y = 1
+	},
+/obj/structure/table,
+/obj/item/folder/yellow,
+/obj/item/stack/wrapping_paper{
+	pixel_y = 5
+	},
+/obj/item/stack/packageWrap,
+/obj/item/hand_labeler,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/brown{
+	dir = 9
+	},
+/area/ruin/syndicate_lava_base/cargo)
+"gb" = (
+/obj/structure/table,
+/obj/item/paper_bin,
+/obj/item/pen,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/brown/corner{
+	dir = 1
+	},
+/area/ruin/syndicate_lava_base/cargo)
+"gc" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/effect/turf_decal/caution/stand_clear{
+	icon_state = "stand_clear";
+	dir = 8
+	},
+/turf/open/floor/plasteel/floorgrime,
+/area/ruin/syndicate_lava_base/cargo)
+"gd" = (
+/obj/machinery/door/airlock/external{
+	req_access_txt = "150"
+	},
+/obj/structure/fans/tiny,
+/turf/open/floor/plating,
+/area/ruin/syndicate_lava_base/cargo)
+"gf" = (
+/obj/structure/sign/vacuum{
+	pixel_x = 0;
+	pixel_y = -32
+	},
+/turf/open/floor/plating,
+/area/ruin/syndicate_lava_base/cargo)
+"gg" = (
+/obj/structure/sign/fire{
+	pixel_x = 0;
+	pixel_y = 32
+	},
+/obj/structure/sign/xeno_warning_mining{
+	pixel_x = 0;
+	pixel_y = -32
+	},
+/turf/open/floor/plating,
+/area/ruin/syndicate_lava_base/cargo)
+"gh" = (
+/obj/structure/fans/tiny,
+/obj/machinery/door/airlock/external{
+	req_access_txt = "150"
+	},
+/turf/open/floor/plating,
+/area/ruin/syndicate_lava_base/cargo)
+"gj" = (
+/turf/closed/wall/mineral/plastitanium/explosive,
+/area/ruin/syndicate_lava_base/virology)
+"go" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/vending/medical{
+	desc = "Medical drug dispenser. Looks to have been outfitted with illicit software.";
+	extended_inventory = 1;
+	name = "SyndiMed Plus";
+	premium = list(/obj/item/reagent_containers/hypospray/medipen = 2, /obj/item/storage/belt/medical = 2);
+	products = list(/obj/item/reagent_containers/syringe = 6, /obj/item/reagent_containers/dropper = 2, /obj/item/stack/medical/gauze = 4, /obj/item/reagent_containers/pill/patch/styptic = 3, /obj/item/reagent_containers/pill/insulin = 5, /obj/item/reagent_containers/pill/patch/silver_sulf = 3, /obj/item/reagent_containers/glass/bottle/charcoal = 2, /obj/item/reagent_containers/spray/medical/sterilizer = 1, /obj/item/reagent_containers/glass/bottle/epinephrine = 2, /obj/item/reagent_containers/glass/bottle/morphine = 2, /obj/item/reagent_containers/glass/bottle/salglu_solution = 2, /obj/item/reagent_containers/glass/bottle/toxin = 2, /obj/item/reagent_containers/syringe/antiviral = 3, /obj/item/reagent_containers/pill/salbutamol = 1, /obj/item/device/healthanalyzer = 2);
+	req_access_txt = "150"
+	},
+/turf/open/floor/plasteel/white/side{
+	dir = 4
+	},
+/area/ruin/syndicate_lava_base/virology)
+"gp" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 5;
+	piping_layer = 3;
+	pixel_x = 5;
+	pixel_y = 5
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/white,
+/area/ruin/syndicate_lava_base/virology)
+"gq" = (
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
+	dir = 1;
+	piping_layer = 3;
+	pixel_x = 5;
+	pixel_y = 5
+	},
+/turf/open/floor/plasteel/white,
+/area/ruin/syndicate_lava_base/virology)
+"gr" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4;
+	piping_layer = 3;
+	pixel_x = 5;
+	pixel_y = 5
+	},
+/turf/open/floor/plasteel/white,
+/area/ruin/syndicate_lava_base/virology)
+"gs" = (
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden,
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
+	dir = 2;
+	piping_layer = 3;
+	pixel_x = 5;
+	pixel_y = 5
+	},
+/obj/machinery/light/small,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/white,
+/area/ruin/syndicate_lava_base/virology)
+"gt" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
+	dir = 1;
+	piping_layer = 3;
+	pixel_x = 5;
+	pixel_y = 5
+	},
+/turf/open/floor/plasteel/white/side{
+	dir = 9
+	},
+/area/ruin/syndicate_lava_base/virology)
+"gu" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4;
+	piping_layer = 3;
+	pixel_x = 5;
+	pixel_y = 5
+	},
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/turf/open/floor/plasteel/white/corner{
+	dir = 1
+	},
+/area/ruin/syndicate_lava_base/virology)
+"gv" = (
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4;
+	piping_layer = 3;
+	pixel_x = 5;
+	pixel_y = 5
+	},
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/open/floor/plasteel,
+/area/ruin/syndicate_lava_base/virology)
+"gw" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4;
+	piping_layer = 3;
+	pixel_x = 5;
+	pixel_y = 5
+	},
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/open/floor/plasteel/white/side{
+	dir = 4
+	},
+/area/ruin/syndicate_lava_base/virology)
+"gy" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4;
+	piping_layer = 3;
+	pixel_x = 5;
+	pixel_y = 5
+	},
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/open/floor/plasteel/floorgrime,
+/area/ruin/syndicate_lava_base/main)
+"gz" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
+	dir = 1;
+	piping_layer = 3;
+	pixel_x = 5;
+	pixel_y = 5
+	},
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/open/floor/plasteel,
+/area/ruin/syndicate_lava_base/main)
+"gA" = (
+/obj/machinery/door/firedoor,
+/obj/machinery/door/airlock/virology{
+	frequency = 1449;
+	id_tag = "lavaland_syndie_virology_exterior";
+	locked = 0;
+	name = "Virology Lab Exterior Airlock";
+	req_access_txt = "150"
+	},
+/obj/machinery/doorButtons/access_button{
+	idDoor = "lavaland_syndie_virology_exterior";
+	idSelf = "lavaland_syndie_virology_control";
+	name = "Virology Access Button";
+	pixel_x = 0;
+	pixel_y = -24;
+	req_access_txt = "150"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4;
+	piping_layer = 3;
+	pixel_x = 5;
+	pixel_y = 5
+	},
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/open/floor/plasteel,
+/area/ruin/syndicate_lava_base/main)
+"gB" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4;
+	piping_layer = 3;
+	pixel_x = 5;
+	pixel_y = 5
+	},
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/open/floor/plasteel/red/side{
+	dir = 8
+	},
+/area/ruin/syndicate_lava_base/main)
+"gE" = (
+/obj/machinery/atmospherics/pipe/manifold4w/supply/hidden,
+/obj/structure/cable/yellow{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/obj/machinery/atmospherics/pipe/manifold4w/scrubbers/hidden{
+	piping_layer = 3;
+	pixel_x = 5;
+	pixel_y = 5
+	},
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	pixel_y = 0
+	},
+/obj/structure/cable/yellow{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/turf/open/floor/plasteel/floorgrime,
+/area/ruin/syndicate_lava_base/main)
+"gF" = (
+/obj/machinery/light/small{
+	dir = 1
+	},
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4;
+	piping_layer = 3;
+	pixel_x = 5;
+	pixel_y = 5
+	},
+/turf/open/floor/plasteel/floorgrime,
+/area/ruin/syndicate_lava_base/main)
+"gG" = (
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4;
+	piping_layer = 3;
+	pixel_x = 5;
+	pixel_y = 5
+	},
+/turf/open/floor/plasteel,
+/area/ruin/syndicate_lava_base/main)
+"gH" = (
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden,
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
+	dir = 2;
+	piping_layer = 3;
+	pixel_x = 5;
+	pixel_y = 5
+	},
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/turf/open/floor/plasteel,
+/area/ruin/syndicate_lava_base/main)
+"gI" = (
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4;
+	piping_layer = 3;
+	pixel_x = 5;
+	pixel_y = 5
+	},
+/turf/open/floor/plasteel/floorgrime,
+/area/ruin/syndicate_lava_base/main)
+"gJ" = (
+/obj/machinery/door/firedoor,
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4;
+	piping_layer = 3;
+	pixel_x = 5;
+	pixel_y = 5
+	},
+/turf/open/floor/plasteel/floorgrime,
+/area/ruin/syndicate_lava_base/main)
+"gK" = (
+/obj/machinery/light/small{
+	dir = 1
+	},
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4;
+	piping_layer = 3;
+	pixel_x = 5;
+	pixel_y = 5
+	},
+/turf/open/floor/plasteel/brown/corner{
+	dir = 4
+	},
+/area/ruin/syndicate_lava_base/main)
+"gL" = (
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 9;
+	piping_layer = 3;
+	pixel_x = 5;
+	pixel_y = 5
+	},
+/turf/open/floor/plasteel/brown{
+	dir = 1
+	},
+/area/ruin/syndicate_lava_base/main)
+"gM" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/brown{
+	dir = 1
+	},
+/area/ruin/syndicate_lava_base/main)
+"gN" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/brown{
+	dir = 5
+	},
+/area/ruin/syndicate_lava_base/main)
+"gO" = (
+/obj/structure/sign/cargo,
+/turf/closed/wall/mineral/plastitanium/nodiagonal,
+/area/ruin/syndicate_lava_base/cargo)
+"gP" = (
+/obj/machinery/photocopier,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/brown/corner{
+	dir = 1
+	},
+/area/ruin/syndicate_lava_base/cargo)
+"gQ" = (
+/turf/open/floor/plasteel/floorgrime,
+/area/ruin/syndicate_lava_base/cargo)
+"gR" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/components/unary/vent_pump/on{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/ruin/syndicate_lava_base/cargo)
+"gS" = (
+/obj/effect/turf_decal/stripes/corner{
+	dir = 8
+	},
 /obj/machinery/light/small{
 	dir = 4
 	},
-/turf/open/floor/plasteel/grimy,
-/area/ruin/powered/syndicate_lava_base)
-"aA" = (
-/obj/structure/reagent_dispensers/fueltank,
-/obj/effect/turf_decal/stripes/line{
-	dir = 6
+/obj/machinery/button/door{
+	id = "lavalandsyndi_cargo";
+	name = "Cargo Bay Blast Door Control";
+	pixel_x = 26;
+	pixel_y = 0;
+	req_access_txt = "150"
 	},
-/turf/open/floor/mineral/plastitanium,
-/area/ruin/powered/syndicate_lava_base)
-"aB" = (
-/obj/item/stack/sheet/metal/fifty,
-/obj/item/stack/sheet/glass/fifty,
-/obj/structure/table/reinforced,
-/obj/item/wrench,
+/turf/open/floor/plasteel,
+/area/ruin/syndicate_lava_base/cargo)
+"gT" = (
+/obj/machinery/door/airlock/virology/glass{
+	name = "Monkey Pen";
+	req_access_txt = "150"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	piping_layer = 3;
+	pixel_x = 5;
+	pixel_y = 5
+	},
+/turf/open/floor/plasteel/white,
+/area/ruin/syndicate_lava_base/virology)
+"gU" = (
+/obj/machinery/airalarm{
+	dir = 4;
+	icon_state = "alarm0";
+	pixel_x = -24;
+	req_access = 150
+	},
+/obj/structure/sink{
+	dir = 8;
+	pixel_x = -12;
+	pixel_y = 2
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
+	dir = 1;
+	piping_layer = 3;
+	pixel_x = 5;
+	pixel_y = 5
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/white/side{
+	dir = 8
+	},
+/area/ruin/syndicate_lava_base/virology)
+"gV" = (
+/obj/structure/chair/office/light,
+/turf/open/floor/plasteel,
+/area/ruin/syndicate_lava_base/virology)
+"gW" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on{
+	dir = 1
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 5
+	},
+/turf/open/floor/plasteel,
+/area/ruin/syndicate_lava_base/virology)
+"gX" = (
+/obj/machinery/doorButtons/airlock_controller{
+	idExterior = "lavaland_syndie_virology_exterior";
+	idInterior = "lavaland_syndie_virology_interior";
+	idSelf = "lavaland_syndie_virology_control";
+	name = "Virology Access Console";
+	pixel_x = 24;
+	pixel_y = -5;
+	req_access_txt = "150"
+	},
+/obj/machinery/light_switch{
+	pixel_x = 25;
+	pixel_y = 8
+	},
+/obj/effect/turf_decal/caution/red{
+	dir = 1;
+	icon_state = "caution_red";
+	pixel_y = -6
+	},
+/obj/machinery/light/small{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 10
+	},
+/turf/open/floor/plasteel/white/side{
+	dir = 4
+	},
+/area/ruin/syndicate_lava_base/virology)
+"gY" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 10
 	},
-/turf/open/floor/mineral/plastitanium,
-/area/ruin/powered/syndicate_lava_base)
-"aC" = (
-/obj/structure/table/wood,
-/obj/item/paper_bin,
-/obj/item/pen,
-/turf/open/floor/wood{
-	icon_state = "wood-broken4"
+/obj/machinery/doorButtons/access_button{
+	idDoor = "lavaland_syndie_virology_interior";
+	idSelf = "lavaland_syndie_virology_control";
+	name = "Virology Access Button";
+	pixel_x = -24;
+	pixel_y = 8;
+	req_access_txt = "150"
 	},
-/area/ruin/powered/syndicate_lava_base)
-"aD" = (
-/obj/structure/table/wood,
-/obj/item/storage/box/drinkingglasses,
-/turf/open/floor/wood,
-/area/ruin/powered/syndicate_lava_base)
-"aE" = (
-/obj/structure/table/wood,
-/obj/item/toy/nuke,
-/obj/item/book/manual/nuclear,
-/turf/open/floor/wood,
-/area/ruin/powered/syndicate_lava_base)
-"aF" = (
-/obj/structure/table/wood,
-/obj/item/lighter{
-	pixel_y = 3
+/obj/machinery/atmospherics/components/unary/vent_pump/on{
+	dir = 1
 	},
-/obj/item/storage/fancy/cigarettes/cigpack_syndicate,
-/turf/open/floor/wood,
-/area/ruin/powered/syndicate_lava_base)
-"aG" = (
-/obj/structure/table/wood,
-/obj/item/storage/fancy/donut_box,
-/turf/open/floor/wood,
-/area/ruin/powered/syndicate_lava_base)
-"aH" = (
-/obj/structure/extinguisher_cabinet{
-	pixel_x = 26
+/turf/open/floor/plasteel/floorgrime,
+/area/ruin/syndicate_lava_base/main)
+"gZ" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 6
 	},
-/turf/open/floor/wood,
-/area/ruin/powered/syndicate_lava_base)
-"aI" = (
-/obj/effect/mob_spawn/human/lavaland_syndicate/comms{
-	icon_state = "sleeper_s";
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
+	dir = 1;
+	piping_layer = 3;
+	pixel_x = 5;
+	pixel_y = 5
+	},
+/turf/open/floor/plasteel/floorgrime,
+/area/ruin/syndicate_lava_base/main)
+"ha" = (
+/turf/closed/wall/mineral/plastitanium/nodiagonal,
+/area/ruin/syndicate_lava_base/main)
+"hb" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/red/side{
+	dir = 10
+	},
+/area/ruin/syndicate_lava_base/main)
+"hc" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	piping_layer = 3;
+	pixel_x = 5;
+	pixel_y = 5
+	},
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	pixel_y = 0
+	},
+/turf/open/floor/plasteel/red/corner{
+	dir = 8
+	},
+/area/ruin/syndicate_lava_base/main)
+"hd" = (
+/turf/open/floor/plasteel/red/corner,
+/area/ruin/syndicate_lava_base/main)
+"he" = (
+/turf/open/floor/plasteel/red/side,
+/area/ruin/syndicate_lava_base/main)
+"hf" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/red/side,
+/area/ruin/syndicate_lava_base/main)
+"hg" = (
+/obj/machinery/light/small,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/red/side,
+/area/ruin/syndicate_lava_base/main)
+"hh" = (
+/obj/machinery/door/firedoor,
+/turf/open/floor/plasteel/red/side,
+/area/ruin/syndicate_lava_base/main)
+"hi" = (
+/turf/open/floor/plasteel/red/corner{
+	dir = 8
+	},
+/area/ruin/syndicate_lava_base/main)
+"hj" = (
+/turf/open/floor/plasteel/brown{
 	dir = 4
 	},
-/turf/open/floor/plasteel/grimy,
-/area/ruin/powered/syndicate_lava_base)
-"aJ" = (
-/obj/structure/sign/nosmoking_2,
-/turf/closed/wall/mineral/plastitanium,
-/area/ruin/powered/syndicate_lava_base)
-"aK" = (
-/obj/structure/closet/crate/bin,
-/obj/item/trash/syndi_cakes,
-/turf/open/floor/plasteel/dark,
-/area/ruin/powered/syndicate_lava_base)
-"aL" = (
-/obj/structure/chair/stool/bar,
+/area/ruin/syndicate_lava_base/main)
+"hk" = (
+/obj/machinery/door/firedoor,
+/obj/machinery/door/airlock/mining/glass{
+	name = "Cargo Bay";
+	req_access_txt = "0"
+	},
+/turf/open/floor/plasteel/floorgrime,
+/area/ruin/syndicate_lava_base/cargo)
+"hl" = (
+/turf/open/floor/plasteel,
+/area/ruin/syndicate_lava_base/cargo)
+"hm" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel,
+/area/ruin/syndicate_lava_base/cargo)
+"hn" = (
+/obj/structure/chair{
+	dir = 4
+	},
+/turf/open/floor/plasteel/floorgrime,
+/area/ruin/syndicate_lava_base/cargo)
+"ho" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/machinery/computer/shuttle/syndicate/recall{
+	desc = "Occasionally used to call in a resupply shuttle if one is in range.";
+	dir = 8;
+	name = "syndicate cargo shuttle terminal";
+	possible_destinations = "syndielavaland_cargo";
+	shuttleId = "syndie_cargo"
+	},
+/turf/open/floor/mineral/plastitanium,
+/area/ruin/syndicate_lava_base/cargo)
+"hp" = (
+/obj/effect/decal/cleanable/dirt,
+/mob/living/carbon/monkey,
+/turf/open/floor/plasteel/white/side{
+	dir = 9
+	},
+/area/ruin/syndicate_lava_base/virology)
+"hq" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	piping_layer = 3;
+	pixel_x = 5;
+	pixel_y = 5
+	},
+/turf/open/floor/plasteel/white/side{
+	dir = 1
+	},
+/area/ruin/syndicate_lava_base/virology)
+"hr" = (
+/mob/living/carbon/monkey,
+/turf/open/floor/plasteel/white/side{
+	dir = 5
+	},
+/area/ruin/syndicate_lava_base/virology)
+"hs" = (
+/obj/machinery/computer/pandemic,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/button/door{
+	id = "lavalandsyndi_virology";
+	name = "Virology Blast Door Control";
+	pixel_x = -26;
+	req_access_txt = "150"
+	},
+/turf/open/floor/plasteel/white/side{
+	dir = 10
+	},
+/area/ruin/syndicate_lava_base/virology)
+"ht" = (
+/obj/structure/table,
+/obj/item/paper_bin{
+	pixel_x = -2;
+	pixel_y = 5
+	},
+/obj/item/hand_labeler,
+/obj/item/pen/red,
+/obj/item/restraints/handcuffs,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/white/side,
+/area/ruin/syndicate_lava_base/virology)
+"hu" = (
+/obj/structure/table,
+/obj/machinery/reagentgrinder,
+/obj/item/stack/sheet/mineral/plasma{
+	amount = 5
+	},
+/obj/item/stack/sheet/mineral/uranium{
+	amount = 10
+	},
+/obj/item/stack/sheet/mineral/gold{
+	amount = 10
+	},
+/turf/open/floor/plasteel/white/side,
+/area/ruin/syndicate_lava_base/virology)
+"hv" = (
+/obj/machinery/disposal/bin,
+/obj/structure/sign/deathsposal{
+	pixel_x = 32;
+	pixel_y = 0
+	},
+/obj/effect/turf_decal/stripes/red/box,
+/obj/structure/disposalpipe/trunk{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/white/side{
+	dir = 6
+	},
+/area/ruin/syndicate_lava_base/virology)
+"hw" = (
+/obj/machinery/door/airlock/external{
+	req_access_txt = "150"
+	},
+/obj/structure/fans/tiny,
+/turf/open/floor/plating,
+/area/ruin/syndicate_lava_base/main)
+"hx" = (
+/obj/machinery/airalarm{
+	dir = 4;
+	icon_state = "alarm0";
+	pixel_x = -24;
+	req_access = 150
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	piping_layer = 3;
+	pixel_x = 5;
+	pixel_y = 5
+	},
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	pixel_y = 0
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/red/side{
+	dir = 8
+	},
+/area/ruin/syndicate_lava_base/main)
+"hy" = (
+/turf/open/floor/plasteel/red/side{
+	dir = 4
+	},
+/area/ruin/syndicate_lava_base/main)
+"hz" = (
+/turf/closed/wall/mineral/plastitanium/nodiagonal,
+/area/ruin/syndicate_lava_base/dormitories)
+"hA" = (
+/obj/structure/closet/emcloset/anchored,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/vault{
 	dir = 5
 	},
-/area/ruin/powered/syndicate_lava_base)
-"aM" = (
-/obj/structure/chair/stool/bar,
-/turf/open/floor/plasteel/dark,
-/area/ruin/powered/syndicate_lava_base)
-"aN" = (
-/obj/structure/table/wood,
-/obj/item/lipstick/random{
-	pixel_x = 3;
-	pixel_y = 3
-	},
-/obj/item/lipstick/random{
-	pixel_x = -3;
-	pixel_y = -3
-	},
-/obj/item/lipstick/random,
-/obj/item/soap/syndie,
-/turf/open/floor/plasteel/vault{
+/area/ruin/syndicate_lava_base/dormitories)
+"hB" = (
+/turf/open/floor/plasteel/red/side{
 	dir = 8
 	},
-/area/ruin/powered/syndicate_lava_base)
-"aO" = (
-/turf/open/floor/plasteel/vault{
+/area/ruin/syndicate_lava_base/main)
+"hC" = (
+/obj/machinery/door/firedoor,
+/obj/machinery/door/airlock/mining/glass{
+	name = "Cargo Bay";
+	req_access_txt = "0"
+	},
+/turf/open/floor/plasteel,
+/area/ruin/syndicate_lava_base/cargo)
+"hD" = (
+/obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
-/area/ruin/powered/syndicate_lava_base)
-"aP" = (
-/obj/structure/dresser,
-/obj/structure/mirror{
-	pixel_x = 26
+/obj/structure/rack,
+/obj/item/storage/belt/utility,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/mineral/plastitanium,
+/area/ruin/syndicate_lava_base/cargo)
+"hE" = (
+/obj/effect/decal/cleanable/dirt,
+/mob/living/carbon/monkey,
+/turf/open/floor/plasteel/white/side{
+	dir = 10
 	},
-/turf/open/floor/plasteel/vault{
-	dir = 5
+/area/ruin/syndicate_lava_base/virology)
+"hF" = (
+/obj/machinery/light/small,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
+	dir = 1;
+	piping_layer = 3;
+	pixel_x = 5;
+	pixel_y = 5
 	},
-/area/ruin/powered/syndicate_lava_base)
-"aQ" = (
-/obj/item/target,
-/turf/open/floor/plasteel/vault{
-	dir = 8
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/white/side,
+/area/ruin/syndicate_lava_base/virology)
+"hG" = (
+/obj/effect/decal/cleanable/dirt,
+/mob/living/carbon/monkey,
+/turf/open/floor/plasteel/white/side{
+	dir = 6
 	},
-/area/ruin/powered/syndicate_lava_base)
-"aR" = (
+/area/ruin/syndicate_lava_base/virology)
+"hH" = (
+/obj/structure/grille,
+/obj/structure/window/plastitanium,
+/obj/machinery/door/poddoor/preopen{
+	id = "lavalandsyndi_virology";
+	layer = 2.9
+	},
+/turf/open/floor/plating,
+/area/ruin/syndicate_lava_base/virology)
+"hI" = (
+/obj/structure/sign/vacuum{
+	pixel_x = -32
+	},
+/turf/open/floor/plating,
+/area/ruin/syndicate_lava_base/main)
+"hJ" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating,
+/area/ruin/syndicate_lava_base/main)
+"hK" = (
+/obj/machinery/light/small{
+	dir = 4
+	},
+/obj/structure/sign/fire{
+	pixel_x = 32
+	},
 /obj/structure/closet/emcloset/anchored,
 /obj/item/tank/internals/emergency_oxygen/engi,
 /obj/item/device/flashlight/seclite,
 /obj/item/clothing/mask/gas,
-/obj/effect/turf_decal/stripes/line{
-	dir = 5
-	},
-/turf/open/floor/mineral/plastitanium,
-/area/ruin/powered/syndicate_lava_base)
-"aS" = (
-/obj/item/twohanded/required/kirbyplants{
-	icon_state = "plant-21"
-	},
-/turf/open/floor/plasteel/vault{
-	dir = 5
-	},
-/area/ruin/powered/syndicate_lava_base)
-"aT" = (
-/obj/machinery/door/airlock/hatch{
-	name = "Dormitories";
-	req_access_txt = "150"
-	},
-/turf/open/floor/plasteel/vault{
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating,
+/area/ruin/syndicate_lava_base/main)
+"hL" = (
+/obj/machinery/light/small{
 	dir = 8
 	},
-/area/ruin/powered/syndicate_lava_base)
-"aU" = (
-/obj/structure/closet/emcloset,
-/obj/item/tank/internals/emergency_oxygen/engi,
-/obj/item/device/flashlight/seclite,
-/obj/item/clothing/mask/gas,
-/obj/machinery/light{
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	piping_layer = 3;
+	pixel_x = 5;
+	pixel_y = 5
+	},
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	pixel_y = 0
+	},
+/turf/open/floor/plasteel/red/side{
 	dir = 8
 	},
-/obj/effect/turf_decal/stripes/line{
+/area/ruin/syndicate_lava_base/main)
+"hM" = (
+/obj/structure/table/wood,
+/obj/item/ammo_box/magazine/m10mm,
+/obj/item/ammo_box/magazine/sniper_rounds,
+/obj/machinery/airalarm{
+	pixel_y = 24;
+	req_access = 152
+	},
+/turf/open/floor/plasteel/grimy,
+/area/ruin/syndicate_lava_base/dormitories)
+"hN" = (
+/obj/machinery/light/small{
 	dir = 4
 	},
-/turf/open/floor/mineral/plastitanium,
-/area/ruin/powered/syndicate_lava_base)
-"aV" = (
-/obj/machinery/door/airlock/hatch{
-	name = "Storage Closet";
-	req_access_txt = "150"
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
+	piping_layer = 3;
+	pixel_x = 5;
+	pixel_y = 5
 	},
-/turf/open/floor/plasteel/vault{
+/turf/open/floor/plasteel/grimy,
+/area/ruin/syndicate_lava_base/dormitories)
+"hO" = (
+/turf/closed/wall/mineral/plastitanium/explosive,
+/area/ruin/syndicate_lava_base/dormitories)
+"hP" = (
+/obj/machinery/light/small{
+	brightness = 3;
 	dir = 8
 	},
-/area/ruin/powered/syndicate_lava_base)
-"aW" = (
-/obj/machinery/door/airlock/hatch{
-	name = "Restroom";
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
+	piping_layer = 3;
+	pixel_x = 5;
+	pixel_y = 5
+	},
+/turf/open/floor/plasteel/grimy,
+/area/ruin/syndicate_lava_base/dormitories)
+"hQ" = (
+/obj/structure/table/wood,
+/obj/item/ammo_box/magazine/m10mm,
+/obj/machinery/airalarm{
+	pixel_y = 24;
+	req_access = 152
+	},
+/turf/open/floor/plasteel/grimy,
+/area/ruin/syndicate_lava_base/dormitories)
+"hR" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/brown/corner{
+	dir = 4
+	},
+/area/ruin/syndicate_lava_base/main)
+"hS" = (
+/obj/structure/table/reinforced,
+/obj/item/folder,
+/obj/item/suppressor,
+/obj/item/clothing/ears/earmuffs,
+/obj/item/clothing/ears/earmuffs,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/brown,
+/area/ruin/syndicate_lava_base/cargo)
+"hT" = (
+/obj/machinery/vending/toyliberationstation{
 	req_access_txt = "150"
 	},
-/turf/open/floor/plasteel/vault{
+/turf/open/floor/plasteel/brown,
+/area/ruin/syndicate_lava_base/cargo)
+"hU" = (
+/obj/machinery/light/small,
+/obj/structure/filingcabinet/chestdrawer,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/brown,
+/area/ruin/syndicate_lava_base/cargo)
+"hV" = (
+/obj/structure/filingcabinet/chestdrawer,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/brown,
+/area/ruin/syndicate_lava_base/cargo)
+"hW" = (
+/obj/machinery/porta_turret/syndicate{
+	dir = 10
+	},
+/turf/closed/wall/mineral/plastitanium/nodiagonal,
+/area/ruin/syndicate_lava_base/main)
+"hX" = (
+/obj/structure/fans/tiny,
+/obj/machinery/door/airlock/external{
+	req_access_txt = "150"
+	},
+/turf/open/floor/plating,
+/area/ruin/syndicate_lava_base/main)
+"hY" = (
+/obj/structure/fans/tiny,
+/obj/machinery/door/airlock/external{
+	req_access_txt = "150"
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating,
+/area/ruin/syndicate_lava_base/main)
+"hZ" = (
+/obj/machinery/firealarm{
+	dir = 8;
+	pixel_x = -26
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	pixel_y = 0
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
+	dir = 8;
+	piping_layer = 3;
+	pixel_x = 5;
+	pixel_y = 5
+	},
+/turf/open/floor/plasteel/red/side{
 	dir = 8
 	},
-/area/ruin/powered/syndicate_lava_base)
-"aX" = (
-/obj/structure/mirror{
-	pixel_x = 28
+/area/ruin/syndicate_lava_base/main)
+"ia" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
+	dir = 8;
+	piping_layer = 3;
+	pixel_x = 5;
+	pixel_y = 5
+	},
+/turf/open/floor/plasteel/red/side{
+	dir = 4
+	},
+/area/ruin/syndicate_lava_base/main)
+"ib" = (
+/obj/effect/mob_spawn/human/lavaland_syndicate{
+	icon_state = "sleeper_s";
+	dir = 4
+	},
+/turf/open/floor/plasteel/grimy,
+/area/ruin/syndicate_lava_base/dormitories)
+"ic" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	piping_layer = 3;
+	pixel_x = 5;
+	pixel_y = 5
+	},
+/turf/open/floor/plasteel/grimy,
+/area/ruin/syndicate_lava_base/dormitories)
+"id" = (
+/obj/structure/toilet{
+	pixel_y = 18
 	},
 /obj/structure/sink{
 	dir = 4;
 	pixel_x = 11
 	},
+/obj/machinery/light/small{
+	dir = 8
+	},
+/obj/structure/mirror{
+	pixel_x = 28
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/vault{
 	dir = 5
 	},
-/area/ruin/powered/syndicate_lava_base)
-"aY" = (
+/area/ruin/syndicate_lava_base/dormitories)
+"ie" = (
+/obj/effect/mob_spawn/human/lavaland_syndicate/comms{
+	dir = 8;
+	icon_state = "sleeper_s"
+	},
+/turf/open/floor/plasteel/grimy,
+/area/ruin/syndicate_lava_base/dormitories)
+"if" = (
+/turf/open/floor/plasteel/floorgrime,
+/area/ruin/syndicate_lava_base/main)
+"ig" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 9
 	},
-/turf/open/floor/mineral/plastitanium,
-/area/ruin/powered/syndicate_lava_base)
-"aZ" = (
+/turf/open/floor/plating{
+	initial_gas_mix = "o2=14;n2=23;TEMP=300"
+	},
+/area/ruin/syndicate_lava_base/arrivals)
+"ih" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/turf/open/floor/plating{
+	initial_gas_mix = "o2=14;n2=23;TEMP=300"
+	},
+/area/ruin/syndicate_lava_base/arrivals)
+"ii" = (
+/obj/structure/table,
+/obj/item/storage/toolbox/emergency,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/red/side{
+	dir = 9
+	},
+/area/ruin/syndicate_lava_base/main)
+"ij" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	piping_layer = 3;
+	pixel_x = 5;
+	pixel_y = 5
+	},
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	pixel_y = 0
+	},
+/turf/open/floor/plasteel/red/corner{
+	dir = 1
+	},
+/area/ruin/syndicate_lava_base/main)
+"ik" = (
+/turf/open/floor/plasteel/red/corner{
+	dir = 4
+	},
+/area/ruin/syndicate_lava_base/main)
+"il" = (
+/obj/machinery/door/airlock{
+	name = "Cabin 2";
+	req_access_txt = "0"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	piping_layer = 3;
+	pixel_x = 5;
+	pixel_y = 5
+	},
+/turf/open/floor/plasteel,
+/area/ruin/syndicate_lava_base/dormitories)
+"im" = (
+/obj/machinery/door/airlock{
+	name = "Unisex Restrooms";
+	req_access_txt = "0"
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/vault{
+	dir = 5
+	},
+/area/ruin/syndicate_lava_base/dormitories)
+"in" = (
+/obj/machinery/door/airlock{
+	name = "Cabin 4";
+	req_access_txt = "0"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	piping_layer = 3;
+	pixel_x = 5;
+	pixel_y = 5
+	},
+/turf/open/floor/plasteel,
+/area/ruin/syndicate_lava_base/dormitories)
+"ip" = (
+/obj/effect/turf_decal/stripes/red/corner,
+/turf/open/floor/plasteel,
+/area/ruin/syndicate_lava_base/main)
+"iq" = (
+/obj/structure/sign/securearea,
+/turf/closed/wall/mineral/plastitanium/nodiagonal,
+/area/ruin/syndicate_lava_base/main)
+"ir" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/stripes/red/line{
+	icon_state = "warningline_red";
+	dir = 9
+	},
+/turf/open/floor/plasteel/vault{
+	dir = 8
+	},
+/area/ruin/syndicate_lava_base/main)
+"is" = (
+/obj/machinery/light/small{
+	dir = 1
+	},
+/turf/open/floor/circuit/red,
+/area/ruin/syndicate_lava_base/main)
+"it" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/stripes/red/line{
+	icon_state = "warningline_red";
+	dir = 5
+	},
+/turf/open/floor/plasteel/vault{
+	dir = 8
+	},
+/area/ruin/syndicate_lava_base/main)
+"iu" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/turf/open/floor/plating{
+	initial_gas_mix = "o2=14;n2=23;TEMP=300"
+	},
+/area/ruin/syndicate_lava_base/arrivals)
+"iv" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating{
+	initial_gas_mix = "o2=14;n2=23;TEMP=300"
+	},
+/area/ruin/syndicate_lava_base/arrivals)
+"iw" = (
+/obj/structure/chair{
+	dir = 4
+	},
+/obj/structure/extinguisher_cabinet{
+	pixel_x = -27;
+	pixel_y = 1
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/red/side{
+	dir = 8
+	},
+/area/ruin/syndicate_lava_base/main)
+"ix" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	piping_layer = 3;
+	pixel_x = 5;
+	pixel_y = 5
+	},
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	pixel_y = 0
+	},
+/turf/open/floor/plasteel/floorgrime,
+/area/ruin/syndicate_lava_base/main)
+"iy" = (
+/obj/machinery/door/airlock/public/glass{
+	name = "Dormitories"
+	},
+/obj/machinery/door/firedoor,
+/turf/open/floor/plasteel,
+/area/ruin/syndicate_lava_base/dormitories)
+"iz" = (
+/turf/open/floor/plasteel/neutral/corner{
+	dir = 4
+	},
+/area/ruin/syndicate_lava_base/dormitories)
+"iA" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	piping_layer = 3;
+	pixel_x = 5;
+	pixel_y = 5
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/neutral/side{
+	dir = 1
+	},
+/area/ruin/syndicate_lava_base/dormitories)
+"iB" = (
+/obj/machinery/airalarm{
+	pixel_y = 24;
+	req_access = 152
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/neutral/corner{
+	dir = 1
+	},
+/area/ruin/syndicate_lava_base/dormitories)
+"iC" = (
+/turf/open/floor/plasteel/floorgrime,
+/area/ruin/syndicate_lava_base/dormitories)
+"iD" = (
+/obj/machinery/light/small{
+	dir = 1
+	},
+/obj/machinery/firealarm{
+	dir = 2;
+	pixel_y = 24
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
+	piping_layer = 3;
+	pixel_x = 5;
+	pixel_y = 5
+	},
+/turf/open/floor/plasteel/neutral/corner{
+	dir = 4
+	},
+/area/ruin/syndicate_lava_base/dormitories)
+"iE" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	piping_layer = 3;
+	pixel_x = 5;
+	pixel_y = 5
+	},
+/turf/open/floor/plasteel/neutral/side{
+	dir = 1
+	},
+/area/ruin/syndicate_lava_base/dormitories)
+"iF" = (
+/obj/machinery/washing_machine,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/vault{
+	dir = 5
+	},
+/area/ruin/syndicate_lava_base/dormitories)
+"iG" = (
+/obj/machinery/firealarm{
+	dir = 8;
+	pixel_x = -26
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/red/side{
+	dir = 8
+	},
+/area/ruin/syndicate_lava_base/main)
+"iH" = (
+/obj/effect/turf_decal/stripes/red/line{
+	icon_state = "warningline_red";
+	dir = 4
+	},
+/obj/effect/turf_decal/caution/red{
+	dir = 8;
+	icon_state = "caution_red";
+	pixel_x = 6
+	},
+/turf/open/floor/plasteel,
+/area/ruin/syndicate_lava_base/main)
+"iI" = (
+/obj/machinery/door/airlock/vault{
+	id_tag = "syndie_lavaland_vault";
+	locked = 1;
+	req_access_txt = "150"
+	},
+/turf/open/floor/plasteel/vault{
+	dir = 8
+	},
+/area/ruin/syndicate_lava_base/main)
+"iJ" = (
+/turf/open/floor/circuit/red,
+/area/ruin/syndicate_lava_base/main)
+"iK" = (
+/obj/machinery/syndicatebomb/self_destruct{
+	anchored = 1
+	},
+/turf/open/floor/circuit/red,
+/area/ruin/syndicate_lava_base/main)
+"iL" = (
+/obj/machinery/airalarm{
+	dir = 8;
+	icon_state = "alarm0";
+	pixel_x = 24;
+	req_access = 152
+	},
+/turf/open/floor/circuit/red,
+/area/ruin/syndicate_lava_base/main)
+"iM" = (
+/obj/machinery/light/small{
+	dir = 4
+	},
+/turf/open/floor/plating{
+	initial_gas_mix = "o2=14;n2=23;TEMP=300"
+	},
+/area/ruin/syndicate_lava_base/arrivals)
+"iN" = (
+/turf/closed/wall/mineral/plastitanium/explosive,
+/area/ruin/syndicate_lava_base/main)
+"iO" = (
+/obj/machinery/light/small{
+	dir = 8
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on{
+	dir = 4
+	},
+/turf/open/floor/plasteel/red/side{
+	dir = 8
+	},
+/area/ruin/syndicate_lava_base/main)
+"iP" = (
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 5;
+	piping_layer = 3;
+	pixel_x = 5;
+	pixel_y = 5
+	},
+/turf/open/floor/plasteel,
+/area/ruin/syndicate_lava_base/main)
+"iQ" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4;
+	piping_layer = 3;
+	pixel_x = 5;
+	pixel_y = 5
+	},
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/open/floor/plasteel/floorgrime,
+/area/ruin/syndicate_lava_base/main)
+"iR" = (
+/obj/machinery/door/firedoor,
+/obj/machinery/door/airlock/public/glass{
+	name = "Dormitories"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4;
+	piping_layer = 3;
+	pixel_x = 5;
+	pixel_y = 5
+	},
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/open/floor/plasteel/floorgrime,
+/area/ruin/syndicate_lava_base/dormitories)
+"iS" = (
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
+	dir = 1;
+	piping_layer = 3;
+	pixel_x = 5;
+	pixel_y = 5
+	},
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/neutral/side,
+/area/ruin/syndicate_lava_base/dormitories)
+"iT" = (
+/obj/machinery/light/small,
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden,
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
+	dir = 2;
+	piping_layer = 3;
+	pixel_x = 5;
+	pixel_y = 5
+	},
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/open/floor/plasteel/neutral/corner{
+	dir = 8;
+	heat_capacity = 1e+006
+	},
+/area/ruin/syndicate_lava_base/dormitories)
+"iU" = (
+/obj/machinery/atmospherics/pipe/manifold4w/supply/hidden,
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
+	dir = 1;
+	piping_layer = 3;
+	pixel_x = 5;
+	pixel_y = 5
+	},
+/obj/structure/cable/yellow{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/obj/structure/cable/yellow{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/turf/open/floor/plasteel/floorgrime,
+/area/ruin/syndicate_lava_base/dormitories)
+"iV" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4;
+	piping_layer = 3;
+	pixel_x = 5;
+	pixel_y = 5
+	},
+/obj/machinery/power/apc{
+	dir = 2;
+	name = "Dormitories APC";
+	pixel_x = 0;
+	pixel_y = -24;
+	req_access = 150
+	},
+/obj/structure/cable/yellow{
+	d2 = 8;
+	icon_state = "0-8"
+	},
+/turf/open/floor/plasteel/neutral/corner,
+/area/ruin/syndicate_lava_base/dormitories)
+"iW" = (
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/manifold4w/scrubbers/hidden{
+	piping_layer = 3;
+	pixel_x = 5;
+	pixel_y = 5
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/neutral/side,
+/area/ruin/syndicate_lava_base/dormitories)
+"iX" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 9;
+	piping_layer = 3;
+	pixel_x = 5;
+	pixel_y = 5
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/neutral/corner{
+	dir = 8;
+	heat_capacity = 1e+006
+	},
+/area/ruin/syndicate_lava_base/dormitories)
+"iY" = (
+/obj/structure/table,
+/obj/structure/bedsheetbin,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/vault{
+	dir = 5
+	},
+/area/ruin/syndicate_lava_base/dormitories)
+"iZ" = (
+/obj/structure/extinguisher_cabinet{
+	pixel_x = -27;
+	pixel_y = 1
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/red/side{
+	dir = 8
+	},
+/area/ruin/syndicate_lava_base/main)
+"ja" = (
+/obj/effect/turf_decal/stripes/red/corner{
+	icon_state = "warninglinecorner_red";
+	dir = 1
+	},
+/obj/machinery/button/door{
+	id = "syndie_lavaland_vault";
+	name = "Vault Bolt Control";
+	normaldoorcontrol = 1;
+	pixel_x = 24;
+	pixel_y = 8;
+	req_access_txt = "150";
+	specialfunctions = 4
+	},
+/turf/open/floor/plasteel,
+/area/ruin/syndicate_lava_base/main)
+"jb" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/stripes/red/line{
+	icon_state = "warningline_red";
+	dir = 10
+	},
+/turf/open/floor/plasteel/vault{
+	dir = 8
+	},
+/area/ruin/syndicate_lava_base/main)
+"jc" = (
+/obj/machinery/light/small,
+/turf/open/floor/circuit/red,
+/area/ruin/syndicate_lava_base/main)
+"jd" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/stripes/red/line{
+	icon_state = "warningline_red";
+	dir = 6
+	},
+/turf/open/floor/plasteel/vault{
+	dir = 8
+	},
+/area/ruin/syndicate_lava_base/main)
+"je" = (
+/obj/effect/turf_decal/stripes/corner{
+	dir = 4
+	},
+/turf/open/floor/plating{
+	initial_gas_mix = "o2=14;n2=23;TEMP=300"
+	},
+/area/ruin/syndicate_lava_base/arrivals)
+"jf" = (
+/obj/machinery/door/airlock{
+	name = "Cabin 1";
+	req_access_txt = "0"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	piping_layer = 3;
+	pixel_x = 5;
+	pixel_y = 5
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel,
+/area/ruin/syndicate_lava_base/dormitories)
+"jg" = (
+/obj/machinery/door/airlock/maintenance,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	piping_layer = 3;
+	pixel_x = 5;
+	pixel_y = 5
+	},
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	pixel_y = 0
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating,
+/area/ruin/syndicate_lava_base/dormitories)
+"jh" = (
+/obj/machinery/door/airlock{
+	name = "Cabin 3";
+	req_access_txt = "0"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	piping_layer = 3;
+	pixel_x = 5;
+	pixel_y = 5
+	},
+/turf/open/floor/plasteel,
+/area/ruin/syndicate_lava_base/dormitories)
+"ji" = (
+/obj/structure/cable/yellow{
+	icon_state = "0-2";
+	d2 = 2
+	},
+/obj/machinery/power/apc{
+	dir = 8;
+	name = "Primary Hallway APC";
+	pixel_x = -24;
+	pixel_y = 0;
+	req_access = 150
+	},
+/turf/open/floor/plasteel/red/side{
+	dir = 8
+	},
+/area/ruin/syndicate_lava_base/main)
+"jj" = (
+/turf/open/floor/plasteel,
+/area/ruin/syndicate_lava_base/main)
+"jk" = (
+/turf/open/floor/plating{
+	initial_gas_mix = "o2=14;n2=23;TEMP=300"
+	},
+/area/ruin/syndicate_lava_base/arrivals)
+"jl" = (
+/turf/open/floor/plasteel/red/side{
+	dir = 10
+	},
+/area/ruin/syndicate_lava_base/main)
+"jm" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/red/side{
+	dir = 6
+	},
+/area/ruin/syndicate_lava_base/main)
+"jn" = (
+/obj/effect/mob_spawn/human/lavaland_syndicate{
+	icon_state = "sleeper_s";
+	dir = 4
+	},
+/obj/machinery/airalarm{
+	pixel_y = 24;
+	req_access = 152
+	},
+/turf/open/floor/plasteel/grimy,
+/area/ruin/syndicate_lava_base/dormitories)
+"jo" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	piping_layer = 3;
+	pixel_x = 5;
+	pixel_y = 5
+	},
+/turf/open/floor/plasteel/grimy,
+/area/ruin/syndicate_lava_base/dormitories)
+"jp" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	piping_layer = 3;
+	pixel_x = 5;
+	pixel_y = 5
+	},
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	pixel_y = 0
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating,
+/area/ruin/syndicate_lava_base/main)
+"jq" = (
+/obj/effect/mob_spawn/human/lavaland_syndicate{
+	dir = 8;
+	icon_state = "sleeper_s"
+	},
+/obj/machinery/airalarm{
+	pixel_y = 24;
+	req_access = 152
+	},
+/turf/open/floor/plasteel/grimy,
+/area/ruin/syndicate_lava_base/dormitories)
+"jr" = (
+/obj/machinery/vending/snack/random{
+	extended_inventory = 1
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/red/side{
+	dir = 9
+	},
+/area/ruin/syndicate_lava_base/main)
+"js" = (
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	pixel_y = 0
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on,
+/turf/open/floor/plasteel/red/corner{
+	dir = 1
+	},
+/area/ruin/syndicate_lava_base/main)
+"jt" = (
+/obj/machinery/light/small{
+	dir = 4
+	},
+/turf/open/floor/plasteel/yellow/side{
+	dir = 4
+	},
+/area/ruin/syndicate_lava_base/main)
+"ju" = (
+/turf/closed/wall/mineral/plastitanium/nodiagonal,
+/area/ruin/syndicate_lava_base/engineering)
+"jv" = (
+/obj/effect/turf_decal/bot,
+/obj/structure/closet/toolcloset,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel,
+/area/ruin/syndicate_lava_base/engineering)
+"jw" = (
+/obj/effect/turf_decal/bot,
+/obj/structure/closet/firecloset/full{
+	anchored = 1
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
+	piping_layer = 3;
+	pixel_x = 5;
+	pixel_y = 5
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel,
+/area/ruin/syndicate_lava_base/engineering)
+"jx" = (
+/obj/structure/grille,
+/obj/structure/window/plastitanium,
+/obj/machinery/door/firedoor,
+/obj/machinery/door/poddoor/preopen{
+	id = "lavalandsyndi_bar";
+	layer = 2.9
+	},
+/turf/open/floor/plating,
+/area/ruin/syndicate_lava_base/bar)
+"jy" = (
+/turf/closed/wall/mineral/plastitanium/nodiagonal,
+/area/ruin/syndicate_lava_base/bar)
+"jz" = (
+/obj/machinery/door/airlock/public/glass{
+	name = "Bar"
+	},
+/obj/machinery/door/firedoor,
+/turf/open/floor/plasteel,
+/area/ruin/syndicate_lava_base/bar)
+"jA" = (
+/obj/structure/table/wood,
+/obj/item/ammo_box/magazine/m10mm,
+/obj/item/ammo_box/magazine/sniper_rounds,
+/turf/open/floor/plasteel/grimy,
+/area/ruin/syndicate_lava_base/dormitories)
+"jB" = (
+/obj/machinery/light/small{
+	dir = 4
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
+	dir = 1;
+	piping_layer = 3;
+	pixel_x = 5;
+	pixel_y = 5
+	},
+/turf/open/floor/plasteel/grimy,
+/area/ruin/syndicate_lava_base/dormitories)
+"jC" = (
+/obj/machinery/light/small{
+	brightness = 3;
+	dir = 8
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
+	dir = 1;
+	piping_layer = 3;
+	pixel_x = 5;
+	pixel_y = 5
+	},
+/turf/open/floor/plasteel/grimy,
+/area/ruin/syndicate_lava_base/dormitories)
+"jD" = (
+/obj/machinery/vending/cola/random{
+	extended_inventory = 1
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/red/side{
+	dir = 8
+	},
+/area/ruin/syndicate_lava_base/main)
+"jE" = (
+/obj/structure/cable/yellow{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 6;
+	piping_layer = 3;
+	pixel_x = 5;
+	pixel_y = 5
+	},
+/turf/open/floor/plasteel,
+/area/ruin/syndicate_lava_base/main)
+"jF" = (
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4;
+	piping_layer = 3;
+	pixel_x = 5;
+	pixel_y = 5
+	},
+/turf/open/floor/plasteel/yellow/side{
+	dir = 4
+	},
+/area/ruin/syndicate_lava_base/main)
+"jG" = (
+/obj/effect/turf_decal/delivery,
+/obj/machinery/door/firedoor,
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4;
+	piping_layer = 3;
+	pixel_x = 5;
+	pixel_y = 5
+	},
+/obj/machinery/door/airlock/engineering{
+	name = "Engineering";
+	req_access_txt = "150"
+	},
+/turf/open/floor/plasteel,
+/area/ruin/syndicate_lava_base/engineering)
+"jH" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 9
+	},
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4;
+	piping_layer = 3;
+	pixel_x = 5;
+	pixel_y = 5
+	},
+/turf/open/floor/plasteel,
+/area/ruin/syndicate_lava_base/engineering)
+"jI" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 5
 	},
-/turf/open/floor/mineral/plastitanium,
-/area/ruin/powered/syndicate_lava_base)
-"ba" = (
+/obj/machinery/light/small{
+	dir = 4
+	},
+/obj/machinery/airalarm{
+	dir = 8;
+	icon_state = "alarm0";
+	pixel_x = 24;
+	req_access = 152
+	},
+/obj/structure/cable/yellow{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
+	dir = 4;
+	piping_layer = 3;
+	pixel_x = 5;
+	pixel_y = 5
+	},
+/turf/open/floor/plasteel,
+/area/ruin/syndicate_lava_base/engineering)
+"jJ" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
+	dir = 6;
+	piping_layer = 3;
+	pixel_x = 5;
+	pixel_y = 5
+	},
+/turf/closed/wall/mineral/plastitanium/nodiagonal,
+/area/ruin/syndicate_lava_base/engineering)
+"jK" = (
+/obj/machinery/atmospherics/components/unary/outlet_injector/on{
+	dir = 8;
+	piping_layer = 3;
+	pixel_x = 5;
+	pixel_y = 5
+	},
+/turf/open/floor/plating/asteroid/basalt/lava_land_surface,
+/area/ruin/syndicate_lava_base/engineering)
+"jL" = (
+/obj/structure/table,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/item/lighter{
+	pixel_x = 7;
+	pixel_y = 6
+	},
+/obj/item/storage/fancy/cigarettes/cigpack_syndicate{
+	pixel_x = -3
+	},
+/turf/open/floor/plasteel/vault{
+	dir = 5
+	},
+/area/ruin/syndicate_lava_base/bar)
+"jM" = (
+/obj/machinery/light/small{
+	dir = 1
+	},
+/obj/structure/chair{
+	dir = 8
+	},
+/obj/machinery/button/door{
+	id = "lavalandsyndi_bar";
+	name = "Bar Blast Door Control";
+	pixel_x = 0;
+	pixel_y = 26;
+	req_access_txt = "150"
+	},
+/turf/open/floor/plasteel/dark,
+/area/ruin/syndicate_lava_base/bar)
+"jN" = (
+/turf/open/floor/plasteel/vault{
+	dir = 5
+	},
+/area/ruin/syndicate_lava_base/bar)
+"jO" = (
+/obj/structure/extinguisher_cabinet{
+	pixel_x = 25;
+	pixel_y = 0
+	},
+/turf/open/floor/plasteel/dark,
+/area/ruin/syndicate_lava_base/bar)
+"jP" = (
+/turf/closed/wall/mineral/plastitanium/explosive,
+/area/ruin/syndicate_lava_base/bar)
+"jQ" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	piping_layer = 3;
+	pixel_x = 5;
+	pixel_y = 5
+	},
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	pixel_y = 0
+	},
+/turf/open/floor/plating,
+/area/ruin/syndicate_lava_base/main)
+"jR" = (
+/obj/machinery/light/small{
+	brightness = 3;
+	dir = 8
+	},
+/turf/open/floor/plasteel/red/corner{
+	dir = 1
+	},
+/area/ruin/syndicate_lava_base/main)
+"jS" = (
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	pixel_y = 0
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	piping_layer = 3;
+	pixel_x = 5;
+	pixel_y = 5
+	},
+/turf/open/floor/plasteel,
+/area/ruin/syndicate_lava_base/main)
+"jT" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/yellow/side{
+	dir = 4
+	},
+/area/ruin/syndicate_lava_base/main)
+"jU" = (
+/obj/structure/sign/engineering,
+/turf/closed/wall/mineral/plastitanium/nodiagonal,
+/area/ruin/syndicate_lava_base/engineering)
+"jV" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 10
+	},
+/obj/structure/rack{
+	dir = 8;
+	layer = 2.9
+	},
+/obj/item/clothing/gloves/combat,
+/obj/item/crowbar,
+/obj/machinery/atmospherics/components/unary/vent_pump/on{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel,
+/area/ruin/syndicate_lava_base/engineering)
+"jW" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 6
+	},
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	pixel_y = 0
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	piping_layer = 3;
+	pixel_x = 5;
+	pixel_y = 5
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel,
+/area/ruin/syndicate_lava_base/engineering)
+"jX" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
+	piping_layer = 3;
+	pixel_x = 5;
+	pixel_y = 5
+	},
+/turf/closed/wall/mineral/plastitanium/explosive,
+/area/ruin/syndicate_lava_base/engineering)
+"jY" = (
+/obj/structure/chair{
+	dir = 1
+	},
+/turf/open/floor/plasteel/dark,
+/area/ruin/syndicate_lava_base/bar)
+"jZ" = (
+/turf/open/floor/plasteel/dark,
+/area/ruin/syndicate_lava_base/bar)
+"ka" = (
+/obj/structure/closet/crate/bin,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/dark,
+/area/ruin/syndicate_lava_base/bar)
+"kb" = (
+/obj/structure/rack{
+	dir = 8;
+	layer = 2.9
+	},
+/obj/item/storage/box/lights/bulbs,
+/obj/item/stack/rods{
+	amount = 50
+	},
+/obj/item/clothing/head/welding,
+/obj/item/stock_parts/cell/high/plus,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating,
+/area/ruin/syndicate_lava_base/main)
+"kc" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 6;
+	piping_layer = 3;
+	pixel_x = 5;
+	pixel_y = 5
+	},
+/obj/structure/cable/yellow{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating,
+/area/ruin/syndicate_lava_base/main)
+"kd" = (
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden,
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
+	dir = 2;
+	piping_layer = 3;
+	pixel_x = 5;
+	pixel_y = 5
+	},
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating,
+/area/ruin/syndicate_lava_base/main)
+"ke" = (
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
+	dir = 1;
+	piping_layer = 3;
+	pixel_x = 5;
+	pixel_y = 5
+	},
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/cable/yellow{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating,
+/area/ruin/syndicate_lava_base/main)
+"kf" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4;
+	piping_layer = 3;
+	pixel_x = 5;
+	pixel_y = 5
+	},
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/open/floor/plating,
+/area/ruin/syndicate_lava_base/main)
+"kg" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4;
+	piping_layer = 3;
+	pixel_x = 5;
+	pixel_y = 5
+	},
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating,
+/area/ruin/syndicate_lava_base/main)
+"kh" = (
+/obj/machinery/door/airlock/maintenance,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4;
+	piping_layer = 3;
+	pixel_x = 5;
+	pixel_y = 5
+	},
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/open/floor/plating,
+/area/ruin/syndicate_lava_base/main)
+"ki" = (
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
+	dir = 2;
+	piping_layer = 3;
+	pixel_x = 5;
+	pixel_y = 5
+	},
+/turf/open/floor/plasteel,
+/area/ruin/syndicate_lava_base/main)
+"kj" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
+	dir = 8;
+	piping_layer = 3;
+	pixel_x = 5;
+	pixel_y = 5
+	},
+/obj/structure/chair{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/ruin/syndicate_lava_base/main)
+"kk" = (
+/obj/effect/turf_decal/delivery,
+/obj/machinery/door/firedoor,
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	pixel_y = 0
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	piping_layer = 3;
+	pixel_x = 5;
+	pixel_y = 5
+	},
+/obj/machinery/door/airlock/engineering{
+	name = "Engineering";
+	req_access_txt = "150"
+	},
+/turf/open/floor/plasteel,
+/area/ruin/syndicate_lava_base/engineering)
+"kl" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
+	piping_layer = 3;
+	pixel_x = 5;
+	pixel_y = 5
+	},
+/turf/closed/wall/mineral/plastitanium/nodiagonal,
+/area/ruin/syndicate_lava_base/engineering)
+"km" = (
+/obj/structure/cable/yellow{
+	icon_state = "0-2";
+	d2 = 2
+	},
+/obj/machinery/computer/monitor,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/floorgrime,
+/area/ruin/syndicate_lava_base/engineering)
+"kn" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/vault{
+	dir = 5
+	},
+/area/ruin/syndicate_lava_base/bar)
+"ko" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
+	dir = 4;
+	piping_layer = 3;
+	pixel_x = 5;
+	pixel_y = 5
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/vault{
+	dir = 5
+	},
+/area/ruin/syndicate_lava_base/bar)
+"kp" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 10;
+	piping_layer = 3;
+	pixel_x = 5;
+	pixel_y = 5
+	},
+/turf/open/floor/plasteel/dark,
+/area/ruin/syndicate_lava_base/bar)
+"kq" = (
+/obj/machinery/airalarm{
+	dir = 8;
+	icon_state = "alarm0";
+	pixel_x = 24;
+	req_access = 152
+	},
+/obj/machinery/vending/coffee{
+	extended_inventory = 1
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/vault{
+	dir = 5
+	},
+/area/ruin/syndicate_lava_base/bar)
+"kr" = (
+/obj/machinery/door/airlock/maintenance{
+	req_access_txt = "150"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	piping_layer = 3;
+	pixel_x = 5;
+	pixel_y = 5
+	},
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	pixel_y = 0
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating,
+/area/ruin/syndicate_lava_base/bar)
+"ks" = (
+/obj/structure/reagent_dispensers/fueltank,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating,
+/area/ruin/syndicate_lava_base/main)
+"kt" = (
+/obj/structure/grille,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating,
+/area/ruin/syndicate_lava_base/main)
+"ku" = (
+/turf/open/floor/plasteel/white/side,
+/area/ruin/syndicate_lava_base/main)
+"kv" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/white/side,
+/area/ruin/syndicate_lava_base/main)
+"kw" = (
+/obj/structure/table,
+/obj/item/tank/internals/emergency_oxygen,
+/obj/item/clothing/mask/breath,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/white/side,
+/area/ruin/syndicate_lava_base/main)
+"kx" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 9
+	},
+/obj/structure/cable/yellow{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating,
+/area/ruin/syndicate_lava_base/engineering)
+"ky" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 5
+	},
+/obj/structure/cable/yellow{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating,
+/area/ruin/syndicate_lava_base/engineering)
+"kz" = (
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/visible,
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/visible{
+	dir = 8;
+	piping_layer = 3;
+	pixel_x = 5;
+	pixel_y = 5
+	},
+/turf/open/floor/plasteel/floorgrime,
+/area/ruin/syndicate_lava_base/engineering)
+"kA" = (
+/obj/machinery/light/small{
+	dir = 1
+	},
+/obj/machinery/power/apc{
+	dir = 1;
+	name = "Engineering APC";
+	pixel_x = 0;
+	pixel_y = 24;
+	req_access = 150
+	},
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/cable/yellow{
+	d2 = 8;
+	icon_state = "0-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
+	dir = 9;
+	piping_layer = 3;
+	pixel_x = 5;
+	pixel_y = 5
+	},
+/turf/open/floor/plasteel/floorgrime,
+/area/ruin/syndicate_lava_base/engineering)
+"kB" = (
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/floorgrime,
+/area/ruin/syndicate_lava_base/engineering)
+"kC" = (
+/obj/machinery/computer/atmos_control/tank{
+	dir = 8;
+	frequency = 1442;
+	input_tag = null;
+	name = "Nitrogen Supply Control";
+	output_tag = "syndie_lavaland_n2_out";
+	sensors = list("syndie_lavaland_n2_sensor" = "Tank")
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/red/side{
+	dir = 4
+	},
+/area/ruin/syndicate_lava_base/engineering)
+"kD" = (
+/obj/structure/grille,
+/obj/structure/window/plastitanium,
+/turf/open/floor/plating,
+/area/ruin/syndicate_lava_base/engineering)
+"kE" = (
+/obj/machinery/air_sensor{
+	frequency = 1442;
+	id_tag = "syndie_lavaland_n2_sensor"
+	},
+/turf/open/floor/plating/airless,
+/area/ruin/syndicate_lava_base/engineering)
+"kF" = (
+/obj/machinery/atmospherics/miner/nitrogen,
+/obj/machinery/light/small{
+	dir = 4
+	},
+/turf/open/floor/plating/airless,
+/area/ruin/syndicate_lava_base/engineering)
+"kG" = (
+/obj/structure/table,
+/obj/item/reagent_containers/food/drinks/beer,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/vault{
+	dir = 5
+	},
+/area/ruin/syndicate_lava_base/bar)
+"kH" = (
+/obj/structure/chair{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
+/area/ruin/syndicate_lava_base/bar)
+"kI" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
+/area/ruin/syndicate_lava_base/bar)
+"kJ" = (
+/obj/structure/chair/stool/bar,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/vault{
+	dir = 5
+	},
+/area/ruin/syndicate_lava_base/bar)
+"kK" = (
+/obj/structure/chair/stool/bar,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
+/area/ruin/syndicate_lava_base/bar)
+"kL" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	piping_layer = 3;
+	pixel_x = 5;
+	pixel_y = 5
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/vault{
+	dir = 5
+	},
+/area/ruin/syndicate_lava_base/bar)
+"kM" = (
+/obj/machinery/firealarm{
+	dir = 4;
+	pixel_x = 26;
+	pixel_y = 0
+	},
+/obj/machinery/vending/cigarette{
+	extended_inventory = 1;
+	pixel_x = 0;
+	pixel_y = 0
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/dark,
+/area/ruin/syndicate_lava_base/bar)
+"kN" = (
+/obj/structure/reagent_dispensers/beerkeg,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/dark,
+/area/ruin/syndicate_lava_base/bar)
+"kO" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	piping_layer = 3;
+	pixel_x = 5;
+	pixel_y = 5
+	},
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	pixel_y = 0
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/dark,
+/area/ruin/syndicate_lava_base/bar)
+"kP" = (
+/obj/structure/reagent_dispensers/watertank,
+/obj/item/reagent_containers/glass/bucket,
+/obj/item/mop,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating,
+/area/ruin/syndicate_lava_base/main)
+"kQ" = (
+/turf/closed/wall/mineral/plastitanium/nodiagonal,
+/area/ruin/syndicate_lava_base/medbay)
+"kR" = (
+/obj/machinery/door/firedoor,
+/obj/machinery/door/airlock/medical/glass{
+	name = "Medbay"
+	},
+/turf/open/floor/plasteel/white,
+/area/ruin/syndicate_lava_base/medbay)
+"kS" = (
+/obj/machinery/door/firedoor,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/door/airlock/medical/glass{
+	name = "Medbay"
+	},
+/turf/open/floor/plasteel/white,
+/area/ruin/syndicate_lava_base/medbay)
+"kT" = (
+/obj/structure/sign/bluecross_2,
+/turf/closed/wall/mineral/plastitanium/nodiagonal,
+/area/ruin/syndicate_lava_base/medbay)
+"kU" = (
+/turf/closed/wall/mineral/plastitanium/explosive,
+/area/ruin/syndicate_lava_base/engineering)
+"kV" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/machinery/power/smes/engineering,
+/obj/structure/cable/yellow,
+/obj/structure/sign/electricshock{
+	pixel_x = -32
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating,
+/area/ruin/syndicate_lava_base/engineering)
+"kW" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/machinery/power/smes/engineering,
+/obj/structure/cable/yellow,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating,
+/area/ruin/syndicate_lava_base/engineering)
+"kX" = (
+/obj/machinery/atmospherics/pipe/simple/supply/visible{
+	icon_state = "intact";
+	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
+	piping_layer = 3;
+	pixel_x = 5;
+	pixel_y = 5
+	},
+/turf/open/floor/plasteel/floorgrime,
+/area/ruin/syndicate_lava_base/engineering)
+"kY" = (
+/obj/machinery/atmospherics/pipe/manifold/supply/visible{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/ruin/syndicate_lava_base/engineering)
+"kZ" = (
+/obj/machinery/atmospherics/components/trinary/mixer/flipped{
+	dir = 4;
+	node1_concentration = 0.2;
+	node2_concentration = 0.8;
+	on = 1
+	},
+/turf/open/floor/plasteel/floorgrime,
+/area/ruin/syndicate_lava_base/engineering)
+"la" = (
+/obj/machinery/atmospherics/pipe/simple/supplymain/visible{
+	dir = 4
+	},
+/obj/effect/turf_decal/bot,
+/obj/machinery/portable_atmospherics/scrubber,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/red/side{
+	dir = 4
+	},
+/area/ruin/syndicate_lava_base/engineering)
+"lb" = (
+/obj/structure/grille,
+/obj/structure/window/plastitanium,
+/obj/machinery/atmospherics/pipe/simple/supplymain/visible{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/ruin/syndicate_lava_base/engineering)
+"lc" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/siphon/on{
+	dir = 8;
+	frequency = 1442;
+	id_tag = "syndie_lavaland_n2_out";
+	name = "nitrogen out"
+	},
+/turf/open/floor/plating/airless,
+/area/ruin/syndicate_lava_base/engineering)
+"ld" = (
+/turf/open/floor/plating/airless,
+/area/ruin/syndicate_lava_base/engineering)
+"le" = (
+/obj/machinery/light/small{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating{
+	initial_gas_mix = "o2=14;n2=23;TEMP=300"
+	},
+/area/ruin/syndicate_lava_base/arrivals)
+"lf" = (
+/obj/machinery/light/small{
+	dir = 8
+	},
+/obj/structure/chair{
+	dir = 1
+	},
+/obj/machinery/firealarm{
+	dir = 8;
+	pixel_x = -26
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/dark,
+/area/ruin/syndicate_lava_base/bar)
+"lg" = (
+/obj/structure/chair/stool/bar,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/vault{
+	dir = 5
+	},
+/area/ruin/syndicate_lava_base/bar)
+"lh" = (
+/obj/structure/table/wood,
+/turf/open/floor/wood,
+/area/ruin/syndicate_lava_base/bar)
+"li" = (
+/obj/structure/table/wood,
+/obj/item/toy/cards/deck/syndicate{
+	icon_state = "deck_syndicate_full";
+	pixel_x = -6;
+	pixel_y = 6
+	},
+/turf/open/floor/wood{
+	broken = 1;
+	icon_state = "wood-broken4"
+	},
+/area/ruin/syndicate_lava_base/bar)
+"lj" = (
+/obj/machinery/door/window/southleft{
+	base_state = "right";
+	dir = 1;
+	icon_state = "right";
+	name = "Bar";
+	req_access_txt = "0"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	piping_layer = 3;
+	pixel_x = 5;
+	pixel_y = 5
+	},
+/turf/open/floor/wood,
+/area/ruin/syndicate_lava_base/bar)
+"lk" = (
+/obj/structure/table/wood,
+/obj/machinery/light/small{
+	dir = 4
+	},
+/obj/machinery/computer/security/telescreen/entertainment{
+	pixel_x = 30
+	},
+/obj/structure/window/reinforced{
+	dir = 1;
+	pixel_y = 1
+	},
+/obj/item/book/manual/chef_recipes{
+	pixel_x = 2;
+	pixel_y = 6
+	},
+/obj/item/book/manual/barman_recipes,
+/obj/item/reagent_containers/food/drinks/shaker,
+/turf/open/floor/wood,
+/area/ruin/syndicate_lava_base/bar)
+"ll" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	piping_layer = 3;
+	pixel_x = 5;
+	pixel_y = 5
+	},
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	pixel_y = 0
+	},
+/turf/open/floor/plasteel/dark,
+/area/ruin/syndicate_lava_base/bar)
+"lm" = (
+/obj/structure/closet/secure_closet/medical1{
+	req_access = null;
+	req_access_txt = "150"
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/white/side{
+	dir = 9
+	},
+/area/ruin/syndicate_lava_base/medbay)
+"ln" = (
+/turf/open/floor/plasteel/white/side{
+	dir = 1
+	},
+/area/ruin/syndicate_lava_base/medbay)
+"lo" = (
+/obj/machinery/light/small{
+	dir = 1
+	},
+/obj/structure/table,
+/obj/item/storage/firstaid/fire,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/white/side{
+	dir = 5
+	},
+/area/ruin/syndicate_lava_base/medbay)
+"lp" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 10
+	},
+/obj/machinery/power/terminal{
+	dir = 1
+	},
+/obj/structure/cable{
+	d2 = 4;
+	icon_state = "0-4"
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating,
+/area/ruin/syndicate_lava_base/engineering)
+"lq" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 6
+	},
+/obj/machinery/power/terminal{
+	dir = 1
+	},
+/obj/structure/cable{
+	icon_state = "0-2";
+	pixel_y = 1;
+	d2 = 2
+	},
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/turf/open/floor/plating,
+/area/ruin/syndicate_lava_base/engineering)
+"lr" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
+	piping_layer = 3;
+	pixel_x = 5;
+	pixel_y = 5
+	},
+/turf/open/floor/plasteel,
+/area/ruin/syndicate_lava_base/engineering)
+"ls" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/ruin/syndicate_lava_base/engineering)
+"lt" = (
+/obj/machinery/atmospherics/pipe/simple/supplymain/visible,
+/turf/open/floor/plasteel,
+/area/ruin/syndicate_lava_base/engineering)
+"lu" = (
+/obj/machinery/light/small{
+	dir = 4
+	},
+/obj/machinery/portable_atmospherics/scrubber,
+/obj/effect/turf_decal/bot,
+/turf/open/floor/plasteel/floorgrime,
+/area/ruin/syndicate_lava_base/engineering)
+"lv" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 10
+	},
+/turf/open/floor/plating{
+	initial_gas_mix = "o2=14;n2=23;TEMP=300"
+	},
+/area/ruin/syndicate_lava_base/arrivals)
+"lw" = (
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/plating{
+	initial_gas_mix = "o2=14;n2=23;TEMP=300"
+	},
+/area/ruin/syndicate_lava_base/arrivals)
+"lx" = (
+/obj/structure/bookcase/random,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/vault{
+	dir = 5
+	},
+/area/ruin/syndicate_lava_base/bar)
+"ly" = (
+/obj/structure/chair/stool/bar,
+/turf/open/floor/plasteel/dark,
+/area/ruin/syndicate_lava_base/bar)
+"lz" = (
+/obj/structure/table/wood,
+/obj/item/reagent_containers/glass/rag{
+	pixel_x = -4;
+	pixel_y = 9
+	},
+/obj/item/reagent_containers/food/drinks/beer{
+	pixel_x = 5;
+	pixel_y = -2
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/wood,
+/area/ruin/syndicate_lava_base/bar)
+"lA" = (
+/turf/open/floor/wood,
+/area/ruin/syndicate_lava_base/bar)
+"lB" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	piping_layer = 3;
+	pixel_x = 5;
+	pixel_y = 5
+	},
+/turf/open/floor/wood,
+/area/ruin/syndicate_lava_base/bar)
+"lC" = (
+/obj/structure/table/wood,
+/obj/machinery/reagentgrinder,
+/obj/item/kitchen/rollingpin,
+/obj/item/kitchen/knife{
+	pixel_x = 6;
+	pixel_y = 0
+	},
+/turf/open/floor/wood,
+/area/ruin/syndicate_lava_base/bar)
+"lD" = (
+/obj/machinery/vending/boozeomat{
+	req_access_txt = "0"
+	},
+/turf/closed/wall/mineral/plastitanium/nodiagonal,
+/area/ruin/syndicate_lava_base/bar)
+"lE" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/dark,
+/area/ruin/syndicate_lava_base/bar)
+"lF" = (
+/obj/machinery/light/small{
+	dir = 4
+	},
+/obj/structure/closet/crate,
+/obj/item/vending_refill/snack{
+	pixel_x = -3;
+	pixel_y = 3
+	},
+/obj/item/vending_refill/snack{
+	pixel_x = -3;
+	pixel_y = 3
+	},
+/obj/item/vending_refill/coffee,
+/obj/item/vending_refill/cola,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	piping_layer = 3;
+	pixel_x = 5;
+	pixel_y = 5
+	},
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	pixel_y = 0
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/dark,
+/area/ruin/syndicate_lava_base/bar)
+"lG" = (
+/obj/structure/table,
+/obj/item/storage/box/syringes,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/item/gun/syringe/syndicate,
+/turf/open/floor/plasteel/white/side{
+	dir = 9
+	},
+/area/ruin/syndicate_lava_base/medbay)
+"lH" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/white/corner{
+	dir = 1
+	},
+/area/ruin/syndicate_lava_base/medbay)
+"lI" = (
+/turf/open/floor/plasteel,
+/area/ruin/syndicate_lava_base/medbay)
+"lJ" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel,
+/area/ruin/syndicate_lava_base/medbay)
+"lK" = (
+/obj/structure/table,
+/obj/item/storage/firstaid/regular,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/white/side{
+	dir = 4
+	},
+/area/ruin/syndicate_lava_base/medbay)
+"lL" = (
+/obj/machinery/airalarm{
+	dir = 4;
+	icon_state = "alarm0";
+	pixel_x = -24;
+	req_access = 150
+	},
+/obj/machinery/light/small{
+	dir = 8
+	},
+/obj/structure/table,
+/obj/item/stack/sheet/metal/fifty{
+	pixel_x = -1;
+	pixel_y = 1
+	},
+/obj/item/stack/sheet/mineral/plastitanium{
+	amount = 30
+	},
+/obj/item/stack/sheet/glass/fifty{
+	pixel_x = 1;
+	pixel_y = -1
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/item/clothing/head/welding,
+/obj/item/pipe_dispenser,
+/turf/open/floor/plasteel/floorgrime,
+/area/ruin/syndicate_lava_base/engineering)
+"lM" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	pixel_y = 0
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
+	dir = 4;
+	piping_layer = 3;
+	pixel_x = 5;
+	pixel_y = 5
+	},
+/turf/open/floor/plasteel,
+/area/ruin/syndicate_lava_base/engineering)
+"lN" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
+	dir = 9;
+	piping_layer = 3;
+	pixel_x = 5;
+	pixel_y = 5
+	},
+/turf/open/floor/plasteel,
+/area/ruin/syndicate_lava_base/engineering)
+"lO" = (
+/turf/open/floor/plasteel/floorgrime,
+/area/ruin/syndicate_lava_base/engineering)
+"lP" = (
+/obj/machinery/computer/atmos_control/tank{
+	dir = 8;
+	frequency = 1442;
+	input_tag = null;
+	name = "Oxygen Supply Control";
+	output_tag = "syndie_lavaland_o2_out";
+	sensors = list("syndie_lavaland_o2_sensor" = "Tank")
+	},
+/turf/open/floor/plasteel/blue/side{
+	dir = 4
+	},
+/area/ruin/syndicate_lava_base/engineering)
+"lQ" = (
+/obj/machinery/air_sensor{
+	frequency = 1442;
+	id_tag = "Syndicate_Construction_o2_sensor"
+	},
+/turf/open/floor/plating/airless,
+/area/ruin/syndicate_lava_base/engineering)
+"lR" = (
+/obj/machinery/atmospherics/miner/oxygen,
+/obj/machinery/light/small{
+	dir = 4
+	},
+/turf/open/floor/plating/airless,
+/area/ruin/syndicate_lava_base/engineering)
+"lS" = (
+/obj/machinery/porta_turret/syndicate{
+	dir = 9
+	},
+/turf/closed/wall/mineral/plastitanium/nodiagonal,
+/area/ruin/syndicate_lava_base/arrivals)
+"lT" = (
+/obj/structure/fans/tiny,
+/obj/machinery/door/airlock/external{
+	req_access_txt = "150"
+	},
+/turf/open/floor/plating,
+/area/ruin/syndicate_lava_base/arrivals)
+"lU" = (
+/obj/machinery/airalarm{
+	dir = 4;
+	icon_state = "alarm0";
+	pixel_x = -24;
+	req_access = 150
+	},
+/obj/structure/chair/stool,
+/turf/open/floor/plasteel/vault{
+	dir = 5
+	},
+/area/ruin/syndicate_lava_base/bar)
+"lV" = (
+/obj/structure/chair/stool/bar,
+/turf/open/floor/plasteel/vault{
+	dir = 5
+	},
+/area/ruin/syndicate_lava_base/bar)
+"lW" = (
+/obj/structure/table/wood,
+/obj/structure/cable/yellow{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/wood,
+/area/ruin/syndicate_lava_base/bar)
+"lX" = (
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/open/floor/wood,
+/area/ruin/syndicate_lava_base/bar)
+"lY" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 5;
+	piping_layer = 3;
+	pixel_x = 5;
+	pixel_y = 5
+	},
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/open/floor/wood,
+/area/ruin/syndicate_lava_base/bar)
+"lZ" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4;
+	piping_layer = 3;
+	pixel_x = 5;
+	pixel_y = 5
+	},
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/open/floor/wood,
+/area/ruin/syndicate_lava_base/bar)
+"ma" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4;
+	piping_layer = 3;
+	pixel_x = 5;
+	pixel_y = 5
+	},
+/obj/machinery/door/airlock{
+	name = "Bar Storage";
+	req_access_txt = "150"
+	},
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/open/floor/plasteel/dark,
+/area/ruin/syndicate_lava_base/bar)
+"mb" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4;
+	piping_layer = 3;
+	pixel_x = 5;
+	pixel_y = 5
+	},
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/open/floor/plasteel/dark,
+/area/ruin/syndicate_lava_base/bar)
+"mc" = (
+/obj/structure/closet/crate,
+/obj/item/storage/box/donkpockets{
+	pixel_x = -2;
+	pixel_y = 6
+	},
+/obj/item/storage/box/donkpockets{
+	pixel_x = 0;
+	pixel_y = 3
+	},
+/obj/item/storage/box/donkpockets{
+	pixel_x = 2
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 9;
+	piping_layer = 3;
+	pixel_x = 5;
+	pixel_y = 5
+	},
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/dark,
+/area/ruin/syndicate_lava_base/bar)
+"md" = (
+/obj/machinery/sleeper/syndie{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/floorgrime,
+/area/ruin/syndicate_lava_base/medbay)
+"me" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
+	piping_layer = 3;
+	pixel_x = 5;
+	pixel_y = 5
+	},
+/turf/open/floor/plasteel,
+/area/ruin/syndicate_lava_base/medbay)
+"mf" = (
+/obj/structure/sink{
+	dir = 4;
+	pixel_x = 11
+	},
+/obj/machinery/airalarm{
+	dir = 8;
+	icon_state = "alarm0";
+	pixel_x = 24;
+	req_access = 152
+	},
+/turf/open/floor/plasteel/floorgrime,
+/area/ruin/syndicate_lava_base/medbay)
+"mg" = (
+/obj/machinery/firealarm{
+	dir = 8;
+	pixel_x = -26
+	},
+/obj/structure/table,
+/obj/machinery/cell_charger,
+/obj/item/stock_parts/cell/high/plus,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/floorgrime,
+/area/ruin/syndicate_lava_base/engineering)
+"mh" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	pixel_y = 0
+	},
+/turf/open/floor/plasteel,
+/area/ruin/syndicate_lava_base/engineering)
+"mi" = (
+/obj/machinery/atmospherics/pipe/simple/orange/visible{
+	icon_state = "intact";
+	dir = 6
+	},
+/turf/open/floor/plasteel/floorgrime,
+/area/ruin/syndicate_lava_base/engineering)
+"mj" = (
+/obj/machinery/atmospherics/components/binary/pump{
+	dir = 8;
+	name = "O2 to Incinerator";
+	on = 1;
+	target_pressure = 4500
+	},
+/turf/open/floor/plasteel/floorgrime,
+/area/ruin/syndicate_lava_base/engineering)
+"mk" = (
+/obj/machinery/atmospherics/pipe/manifold/supplymain/visible,
+/turf/open/floor/plasteel/floorgrime,
+/area/ruin/syndicate_lava_base/engineering)
+"ml" = (
+/obj/machinery/atmospherics/pipe/simple/supplymain/visible{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/blue/side{
+	dir = 4
+	},
+/area/ruin/syndicate_lava_base/engineering)
+"mm" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/siphon/on{
+	dir = 8;
+	frequency = 1442;
+	id_tag = "syndie_lavaland_o2_out";
+	name = "oxygen out"
+	},
+/turf/open/floor/plating/airless,
+/area/ruin/syndicate_lava_base/engineering)
+"mn" = (
+/turf/closed/wall/mineral/plastitanium/nodiagonal,
+/area/ruin/syndicate_lava_base/telecomms)
+"mo" = (
+/turf/closed/wall/mineral/plastitanium/explosive,
+/area/ruin/syndicate_lava_base/telecomms)
+"mp" = (
+/obj/structure/grille,
+/obj/structure/window/plastitanium,
+/obj/machinery/door/firedoor,
+/obj/machinery/door/poddoor/preopen{
+	id = "lavalandsyndi_telecomms";
+	layer = 2.9
+	},
+/turf/open/floor/plating,
+/area/ruin/syndicate_lava_base/telecomms)
+"mq" = (
+/obj/structure/sign/vacuum{
+	pixel_x = -32
+	},
+/turf/open/floor/plating,
+/area/ruin/syndicate_lava_base/arrivals)
+"mr" = (
+/turf/open/floor/plating,
+/area/ruin/syndicate_lava_base/arrivals)
+"ms" = (
+/obj/machinery/light/small{
+	dir = 4
+	},
+/obj/structure/sign/fire{
+	pixel_x = 32
+	},
 /obj/structure/closet/emcloset/anchored,
 /obj/item/tank/internals/emergency_oxygen/engi,
 /obj/item/device/flashlight/seclite,
 /obj/item/clothing/mask/gas,
-/obj/effect/turf_decal/stripes/line{
-	dir = 6
-	},
-/turf/open/floor/mineral/plastitanium,
-/area/ruin/powered/syndicate_lava_base)
-"bb" = (
+/turf/open/floor/plating,
+/area/ruin/syndicate_lava_base/arrivals)
+"mt" = (
+/obj/machinery/computer/arcade/orion_trail,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/dark,
+/area/ruin/syndicate_lava_base/bar)
+"mu" = (
 /obj/item/twohanded/required/kirbyplants{
 	icon_state = "plant-22"
 	},
-/turf/open/floor/plasteel/vault{
-	dir = 5
-	},
-/area/ruin/powered/syndicate_lava_base)
-"bc" = (
-/obj/structure/bookcase/random,
-/turf/open/floor/plasteel/vault{
-	dir = 5
-	},
-/area/ruin/powered/syndicate_lava_base)
-"bd" = (
-/obj/item/twohanded/required/kirbyplants{
-	icon_state = "plant-21"
-	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/dark,
+/area/ruin/syndicate_lava_base/bar)
+"mv" = (
+/obj/structure/table/wood,
 /obj/machinery/light/small,
+/obj/structure/cable/yellow,
+/obj/machinery/power/apc{
+	dir = 2;
+	name = "Bar APC";
+	pixel_x = 0;
+	pixel_y = -24;
+	req_access = 150
+	},
+/turf/open/floor/wood,
+/area/ruin/syndicate_lava_base/bar)
+"mw" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/wood,
+/area/ruin/syndicate_lava_base/bar)
+"mx" = (
+/obj/structure/table/wood,
+/obj/machinery/microwave,
+/turf/open/floor/wood,
+/area/ruin/syndicate_lava_base/bar)
+"my" = (
+/obj/structure/closet/secure_closet/freezer/fridge,
+/obj/item/reagent_containers/food/condiment/enzyme,
+/obj/item/reagent_containers/food/snacks/chocolatebar,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/dark,
-/area/ruin/powered/syndicate_lava_base)
-"be" = (
-/obj/structure/bookcase/random,
-/turf/open/floor/plasteel/dark,
-/area/ruin/powered/syndicate_lava_base)
-"bf" = (
-/obj/structure/toilet{
-	dir = 8
-	},
-/obj/machinery/light/small{
-	dir = 8
-	},
-/turf/open/floor/plasteel/vault{
-	dir = 5
-	},
-/area/ruin/powered/syndicate_lava_base)
-"bg" = (
-/obj/machinery/door/airlock/hatch{
-	name = "Lounge";
-	req_access_txt = "150"
-	},
-/turf/open/floor/plasteel/vault{
-	dir = 8
-	},
-/area/ruin/powered/syndicate_lava_base)
-"bh" = (
-/obj/machinery/chem_dispenser,
-/obj/effect/turf_decal/stripes/line{
-	dir = 9
-	},
-/turf/open/floor/mineral/plastitanium,
-/area/ruin/powered/syndicate_lava_base)
-"bi" = (
-/obj/structure/table/reinforced,
-/obj/item/reagent_containers/glass/beaker/large,
-/obj/item/reagent_containers/glass/beaker,
-/obj/item/reagent_containers/dropper,
-/obj/item/reagent_containers/syringe,
-/obj/structure/sign/nosmoking_2{
-	pixel_y = 32
-	},
-/obj/item/reagent_containers/glass/beaker/large,
-/obj/item/reagent_containers/glass/beaker/large,
-/obj/item/reagent_containers/glass/beaker/large,
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/turf/open/floor/mineral/plastitanium,
-/area/ruin/powered/syndicate_lava_base)
-"bj" = (
-/obj/machinery/chem_master,
-/obj/effect/turf_decal/stripes/line{
-	dir = 5
-	},
-/turf/open/floor/mineral/plastitanium,
-/area/ruin/powered/syndicate_lava_base)
-"bk" = (
-/obj/structure/noticeboard{
-	pixel_y = 32
-	},
-/obj/machinery/reagentgrinder{
-	desc = "Used to grind things up into raw materials and liquids.";
+/area/ruin/syndicate_lava_base/bar)
+"mz" = (
+/obj/machinery/door/airlock/maintenance,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	piping_layer = 3;
+	pixel_x = 5;
 	pixel_y = 5
 	},
-/obj/structure/table/reinforced,
-/turf/open/floor/plasteel/vault{
-	dir = 8
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	pixel_y = 0
 	},
-/area/ruin/powered/syndicate_lava_base)
-"bl" = (
-/obj/structure/table/reinforced,
-/obj/item/clipboard,
-/obj/item/folder/white,
-/obj/item/book/manual/wiki/chemistry,
-/obj/item/book/manual/wiki/chemistry,
-/obj/item/device/assembly/signaler,
-/obj/item/device/assembly/signaler,
-/obj/item/device/assembly/voice,
-/obj/item/device/assembly/voice,
-/obj/machinery/light{
-	dir = 1
-	},
-/turf/open/floor/plasteel/vault{
-	dir = 8
-	},
-/area/ruin/powered/syndicate_lava_base)
-"bm" = (
-/obj/structure/table/reinforced,
-/obj/item/storage/box/beakers{
-	pixel_x = 3;
-	pixel_y = 3
-	},
-/obj/item/storage/box/syringes,
-/obj/item/gun/syringe/syndicate,
-/obj/item/storage/box/beakers,
-/turf/open/floor/plasteel/vault{
-	dir = 8
-	},
-/area/ruin/powered/syndicate_lava_base)
-"bn" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating,
+/area/ruin/syndicate_lava_base/main)
+"mA" = (
 /obj/machinery/light/small{
 	dir = 8
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 9
-	},
-/turf/open/floor/mineral/plastitanium,
-/area/ruin/powered/syndicate_lava_base)
-"bo" = (
-/obj/machinery/light/small{
-	dir = 4
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 5
-	},
-/turf/open/floor/mineral/plastitanium,
-/area/ruin/powered/syndicate_lava_base)
-"bp" = (
-/obj/structure/table/reinforced,
-/obj/machinery/reagentgrinder{
-	desc = "Used to grind things up into raw materials and liquids.";
-	pixel_y = 5
-	},
-/obj/structure/noticeboard{
-	pixel_y = 32
-	},
-/obj/effect/turf_decal/stripes/corner,
-/turf/open/floor/mineral/plastitanium,
-/area/ruin/powered/syndicate_lava_base)
-"bq" = (
-/obj/structure/reagent_dispensers/virusfood{
-	pixel_y = 32
-	},
-/obj/structure/table/reinforced,
-/obj/item/device/healthanalyzer,
-/obj/item/stack/sheet/mineral/plasma{
-	amount = 5
-	},
-/obj/effect/turf_decal/stripes/line,
-/turf/open/floor/mineral/plastitanium,
-/area/ruin/powered/syndicate_lava_base)
-"br" = (
-/obj/structure/extinguisher_cabinet{
-	pixel_y = 32
-	},
-/obj/machinery/computer/pandemic,
-/obj/effect/turf_decal/stripes/line{
-	dir = 10
-	},
-/turf/open/floor/mineral/plastitanium,
-/area/ruin/powered/syndicate_lava_base)
-"bs" = (
-/obj/structure/table/reinforced,
-/obj/item/storage/box/beakers{
-	pixel_x = 3;
-	pixel_y = 3
-	},
-/obj/item/storage/box/syringes,
-/obj/machinery/light{
-	dir = 1
-	},
-/obj/effect/turf_decal/stripes/line,
-/turf/open/floor/mineral/plastitanium,
-/area/ruin/powered/syndicate_lava_base)
-"bt" = (
 /obj/structure/bed/roller,
 /obj/machinery/iv_drip,
-/obj/item/reagent_containers/blood/random,
-/obj/effect/turf_decal/stripes/line{
-	dir = 6
-	},
-/turf/open/floor/mineral/plastitanium,
-/area/ruin/powered/syndicate_lava_base)
-"bu" = (
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating,
-/area/ruin/powered/syndicate_lava_base)
-"bv" = (
-/obj/machinery/light/small{
-	dir = 1
-	},
-/mob/living/carbon/monkey,
-/turf/open/floor/plasteel/vault{
-	dir = 8
-	},
-/area/ruin/powered/syndicate_lava_base)
-"bw" = (
-/obj/structure/bed/roller,
-/turf/open/floor/plasteel/vault{
-	dir = 8
-	},
-/area/ruin/powered/syndicate_lava_base)
-"bx" = (
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plasteel/vault{
-	dir = 5
-	},
-/area/ruin/powered/syndicate_lava_base)
-"by" = (
-/mob/living/carbon/monkey,
-/turf/open/floor/plasteel/vault{
-	dir = 5
-	},
-/area/ruin/powered/syndicate_lava_base)
-"bz" = (
-/obj/structure/window/reinforced,
-/turf/open/floor/plasteel/vault{
-	dir = 5
-	},
-/area/ruin/powered/syndicate_lava_base)
-"bA" = (
-/obj/machinery/door/window/brigdoor,
-/turf/open/floor/plasteel/vault{
-	dir = 8
-	},
-/area/ruin/powered/syndicate_lava_base)
-"bB" = (
-/obj/machinery/chem_heater,
-/obj/structure/extinguisher_cabinet{
+/obj/item/reagent_containers/blood/OMinus,
+/obj/machinery/firealarm{
+	dir = 8;
 	pixel_x = -26
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 10
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/white/side{
+	dir = 8
 	},
-/turf/open/floor/mineral/plastitanium,
-/area/ruin/powered/syndicate_lava_base)
-"bC" = (
-/obj/structure/chair/office/dark{
+/area/ruin/syndicate_lava_base/medbay)
+"mB" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	piping_layer = 3;
+	pixel_x = 5;
+	pixel_y = 5
+	},
+/turf/open/floor/plasteel,
+/area/ruin/syndicate_lava_base/medbay)
+"mC" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/ruin/syndicate_lava_base/medbay)
+"mD" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/ruin/syndicate_lava_base/medbay)
+"mE" = (
+/obj/structure/table/reinforced,
+/obj/item/scalpel,
+/obj/item/circular_saw{
+	pixel_y = 9
+	},
+/obj/machinery/light/small{
 	dir = 1
 	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/white/side{
+	dir = 4
+	},
+/area/ruin/syndicate_lava_base/medbay)
+"mF" = (
+/obj/structure/extinguisher_cabinet{
+	pixel_x = -27;
+	pixel_y = 1
+	},
+/obj/structure/chair/stool,
+/turf/open/floor/plasteel/floorgrime,
+/area/ruin/syndicate_lava_base/engineering)
+"mG" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	pixel_y = 0
+	},
+/turf/open/floor/plasteel/floorgrime,
+/area/ruin/syndicate_lava_base/engineering)
+"mH" = (
+/obj/machinery/atmospherics/pipe/manifold/orange/visible{
+	icon_state = "manifold";
+	dir = 8
+	},
+/turf/open/floor/plasteel/floorgrime,
+/area/ruin/syndicate_lava_base/engineering)
+"mI" = (
+/obj/effect/turf_decal/stripes/corner,
+/obj/machinery/light/small,
+/obj/machinery/atmospherics/pipe/simple/orange/visible{
+	icon_state = "intact";
+	dir = 8
+	},
+/obj/structure/reagent_dispensers/fueltank,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/floorgrime,
+/area/ruin/syndicate_lava_base/engineering)
+"mJ" = (
 /obj/effect/turf_decal/stripes/line,
-/turf/open/floor/mineral/plastitanium,
-/area/ruin/powered/syndicate_lava_base)
-"bD" = (
-/obj/structure/closet/crate/bin,
-/obj/effect/turf_decal/stripes/line{
-	dir = 6
+/obj/machinery/atmospherics/pipe/simple/orange/visible{
+	icon_state = "intact";
+	dir = 10
 	},
-/turf/open/floor/mineral/plastitanium,
-/area/ruin/powered/syndicate_lava_base)
-"bE" = (
-/turf/open/floor/plasteel/vault,
-/area/ruin/powered/syndicate_lava_base)
-"bF" = (
-/obj/item/device/assembly/igniter,
-/obj/item/device/assembly/igniter,
-/obj/item/device/assembly/igniter,
-/obj/item/device/assembly/timer{
-	pixel_x = 3;
-	pixel_y = 3
+/obj/structure/reagent_dispensers/watertank,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/floorgrime,
+/area/ruin/syndicate_lava_base/engineering)
+"mK" = (
+/obj/effect/turf_decal/stripes/line,
+/obj/machinery/computer/atmos_control/tank{
+	dir = 1;
+	frequency = 1442;
+	input_tag = null;
+	name = "Toxins Supply Control";
+	output_tag = "syndie_lavaland_tox_out";
+	sensors = list("syndie_lavaland_tox_sensor" = "Tank")
 	},
-/obj/item/device/assembly/timer{
-	pixel_x = 3;
-	pixel_y = 3
-	},
-/obj/item/device/assembly/timer{
-	pixel_x = 3;
-	pixel_y = 3
-	},
-/obj/structure/table/reinforced,
-/turf/open/floor/plasteel/vault{
-	dir = 8
-	},
-/area/ruin/powered/syndicate_lava_base)
-"bG" = (
-/obj/structure/table/reinforced,
-/obj/item/book/manual/wiki/infections,
-/obj/item/stack/sheet/mineral/silver{
-	amount = 10
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 6
-	},
-/turf/open/floor/mineral/plastitanium,
-/area/ruin/powered/syndicate_lava_base)
-"bH" = (
-/obj/structure/chair/office/dark{
-	dir = 8
-	},
-/turf/open/floor/plasteel/vault{
-	dir = 5
-	},
-/area/ruin/powered/syndicate_lava_base)
-"bI" = (
-/obj/machinery/door/airlock/hatch{
-	name = "Monkey Pen";
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel,
+/area/ruin/syndicate_lava_base/engineering)
+"mM" = (
+/turf/open/floor/circuit/green,
+/area/ruin/syndicate_lava_base/telecomms)
+"mN" = (
+/obj/structure/sign/securearea,
+/turf/closed/wall/mineral/plastitanium/nodiagonal,
+/area/ruin/syndicate_lava_base/telecomms)
+"mO" = (
+/obj/structure/filingcabinet/security,
+/obj/machinery/button/door{
+	id = "lavalandsyndi_telecomms";
+	name = "Telecomms Blast Door Control";
+	pixel_x = 0;
+	pixel_y = 26;
 	req_access_txt = "150"
 	},
 /turf/open/floor/plasteel/dark,
-/area/ruin/powered/syndicate_lava_base)
-"bJ" = (
-/obj/structure/table/reinforced,
-/obj/item/gun/ballistic/automatic/c20r/toy/unrestricted/riot,
-/obj/item/gun/ballistic/automatic/c20r/toy/unrestricted/riot,
-/turf/open/floor/plasteel/vault{
-	dir = 8
-	},
-/area/ruin/powered/syndicate_lava_base)
-"bK" = (
-/obj/item/twohanded/required/kirbyplants{
-	icon_state = "plant-21"
-	},
-/turf/open/floor/plasteel/vault{
-	dir = 8
-	},
-/area/ruin/powered/syndicate_lava_base)
-"bL" = (
-/obj/structure/table/reinforced,
-/obj/item/clothing/gloves/color/latex,
-/obj/item/clothing/gloves/color/latex,
-/obj/item/clothing/suit/toggle/labcoat,
-/obj/item/clothing/suit/toggle/labcoat,
-/obj/item/clothing/glasses/science,
-/obj/item/clothing/glasses/science,
-/obj/item/clothing/glasses/hud/health,
-/obj/item/clothing/glasses/hud/health,
-/turf/open/floor/plasteel/vault{
-	dir = 8
-	},
-/area/ruin/powered/syndicate_lava_base)
-"bM" = (
-/obj/machinery/smartfridge/chemistry/virology/preloaded,
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/turf/open/floor/mineral/plastitanium,
-/area/ruin/powered/syndicate_lava_base)
-"bN" = (
-/obj/machinery/vending/toyliberationstation{
-	req_access_txt = "150"
-	},
-/obj/machinery/light{
-	dir = 8
-	},
-/turf/open/floor/plasteel/vault{
-	dir = 5
-	},
-/area/ruin/powered/syndicate_lava_base)
-"bO" = (
-/obj/machinery/iv_drip,
-/obj/item/reagent_containers/blood/random,
-/turf/open/floor/plasteel/vault{
-	dir = 5
-	},
-/area/ruin/powered/syndicate_lava_base)
-"bP" = (
-/obj/structure/closet/crate/bin,
-/obj/effect/turf_decal/stripes/line{
-	dir = 9
-	},
-/turf/open/floor/mineral/plastitanium,
-/area/ruin/powered/syndicate_lava_base)
-"bQ" = (
-/obj/structure/chair/office/dark,
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/turf/open/floor/mineral/plastitanium,
-/area/ruin/powered/syndicate_lava_base)
-"bR" = (
-/obj/machinery/chem_heater,
-/obj/effect/turf_decal/stripes/line{
-	dir = 5
-	},
-/turf/open/floor/mineral/plastitanium,
-/area/ruin/powered/syndicate_lava_base)
-"bS" = (
-/obj/structure/table/reinforced,
-/obj/item/reagent_containers/glass/beaker/large,
-/obj/item/reagent_containers/glass/beaker,
-/obj/item/reagent_containers/dropper,
-/obj/item/reagent_containers/syringe,
-/obj/item/reagent_containers/glass/beaker/large,
-/obj/effect/turf_decal/stripes/line{
-	dir = 5
-	},
-/turf/open/floor/mineral/plastitanium,
-/area/ruin/powered/syndicate_lava_base)
-"bT" = (
-/obj/structure/chair/office/dark,
-/turf/open/floor/plasteel/vault{
-	dir = 5
-	},
-/area/ruin/powered/syndicate_lava_base)
-"bU" = (
-/obj/machinery/door/airlock/hatch{
-	name = "Monkey Pen";
-	req_access_txt = "150"
-	},
-/turf/open/floor/plasteel/vault{
-	dir = 5
-	},
-/area/ruin/powered/syndicate_lava_base)
-"bV" = (
-/obj/structure/table/reinforced,
-/obj/item/folder,
-/obj/item/clothing/ears/earmuffs,
-/obj/item/clothing/ears/earmuffs,
-/turf/open/floor/plasteel/vault{
-	dir = 8
-	},
-/area/ruin/powered/syndicate_lava_base)
-"bW" = (
-/obj/structure/table/reinforced,
-/obj/item/suppressor/specialoffer,
-/obj/item/gun/ballistic/automatic/toy/pistol/unrestricted,
-/obj/item/gun/ballistic/automatic/toy/pistol/unrestricted,
-/turf/open/floor/plasteel/vault{
-	dir = 8
-	},
-/area/ruin/powered/syndicate_lava_base)
-"bX" = (
-/obj/machinery/chem_master,
-/obj/effect/turf_decal/stripes/line{
-	dir = 10
-	},
-/turf/open/floor/mineral/plastitanium,
-/area/ruin/powered/syndicate_lava_base)
-"bY" = (
-/obj/structure/table/reinforced,
-/obj/item/reagent_containers/glass/beaker/large,
-/obj/item/reagent_containers/glass/beaker,
-/obj/item/reagent_containers/dropper,
-/obj/item/reagent_containers/syringe,
-/obj/item/reagent_containers/glass/beaker/large,
-/obj/item/reagent_containers/glass/beaker/large,
-/obj/item/reagent_containers/glass/beaker/large,
-/obj/effect/turf_decal/stripes/line,
-/turf/open/floor/mineral/plastitanium,
-/area/ruin/powered/syndicate_lava_base)
-"bZ" = (
-/obj/machinery/chem_dispenser,
-/obj/structure/extinguisher_cabinet{
-	pixel_x = 26
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 6
-	},
-/turf/open/floor/mineral/plastitanium,
-/area/ruin/powered/syndicate_lava_base)
-"ca" = (
-/obj/structure/table/reinforced,
-/obj/item/clothing/suit/bio_suit/general,
-/obj/item/clothing/mask/surgical,
-/obj/item/clothing/head/bio_hood/general,
-/obj/item/clothing/glasses/hud/health,
-/obj/item/clothing/glasses/science,
-/obj/effect/turf_decal/stripes/line{
-	dir = 6
-	},
-/turf/open/floor/mineral/plastitanium,
-/area/ruin/powered/syndicate_lava_base)
-"cb" = (
-/obj/machinery/shower{
-	dir = 4;
-	icon_state = "shower";
-	name = "emergency shower"
-	},
-/obj/machinery/shower{
-	dir = 8;
-	icon_state = "shower";
-	name = "emergency shower"
-	},
-/turf/open/floor/plasteel/vault{
-	dir = 5
-	},
-/area/ruin/powered/syndicate_lava_base)
-"cc" = (
-/obj/structure/table/reinforced,
-/obj/item/paper_bin,
-/obj/item/pen,
-/obj/machinery/light,
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/turf/open/floor/mineral/plastitanium,
-/area/ruin/powered/syndicate_lava_base)
-"cd" = (
-/obj/structure/table/reinforced,
-/obj/item/folder/white,
-/obj/item/stack/sheet/mineral/gold{
-	amount = 10
-	},
-/obj/item/stack/sheet/mineral/uranium{
-	amount = 10
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 5
-	},
-/turf/open/floor/mineral/plastitanium,
-/area/ruin/powered/syndicate_lava_base)
-"ce" = (
-/obj/structure/bed/roller,
-/mob/living/carbon/monkey,
-/turf/open/floor/plasteel/vault{
-	dir = 8
-	},
-/area/ruin/powered/syndicate_lava_base)
-"cf" = (
-/obj/structure/sign/securearea,
-/turf/closed/wall/mineral/plastitanium,
-/area/ruin/powered/syndicate_lava_base)
-"cg" = (
-/obj/machinery/door/airlock/hatch{
-	name = "Firing Range";
-	req_access_txt = "150"
-	},
-/turf/open/floor/plasteel/vault{
-	dir = 8
-	},
-/area/ruin/powered/syndicate_lava_base)
-"ch" = (
-/obj/machinery/door/airlock/hatch{
-	name = "Chemistry Lab";
-	req_access_txt = "150"
-	},
-/turf/open/floor/plasteel/vault{
-	dir = 8
-	},
-/area/ruin/powered/syndicate_lava_base)
-"ci" = (
-/obj/structure/sign/chemistry,
-/turf/closed/wall/mineral/plastitanium,
-/area/ruin/powered/syndicate_lava_base)
-"cj" = (
-/obj/structure/sign/biohazard,
-/turf/closed/wall/mineral/plastitanium,
-/area/ruin/powered/syndicate_lava_base)
-"ck" = (
-/obj/machinery/door/airlock/hatch{
-	name = "Virology Lab";
-	req_access_txt = "150"
-	},
-/turf/open/floor/plasteel/vault{
-	dir = 8
-	},
-/area/ruin/powered/syndicate_lava_base)
-"cl" = (
-/obj/structure/rack,
-/obj/item/ammo_box/foambox{
-	pixel_x = -3;
-	pixel_y = 3
-	},
-/obj/item/ammo_box/foambox,
-/obj/item/ammo_box/foambox{
-	pixel_x = 3;
-	pixel_y = -3
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 5
-	},
-/turf/open/floor/mineral/plastitanium,
-/area/ruin/powered/syndicate_lava_base)
-"cm" = (
-/obj/item/twohanded/required/kirbyplants{
-	icon_state = "plant-22"
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 9
-	},
-/turf/open/floor/mineral/plastitanium,
-/area/ruin/powered/syndicate_lava_base)
-"cn" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/turf/open/floor/mineral/plastitanium,
-/area/ruin/powered/syndicate_lava_base)
-"co" = (
-/obj/effect/turf_decal/stripes/corner{
-	dir = 4
-	},
-/turf/open/floor/mineral/plastitanium,
-/area/ruin/powered/syndicate_lava_base)
-"cp" = (
-/obj/effect/turf_decal/stripes/corner{
-	dir = 8
-	},
-/turf/open/floor/mineral/plastitanium,
-/area/ruin/powered/syndicate_lava_base)
-"cq" = (
-/obj/item/twohanded/required/kirbyplants{
-	icon_state = "plant-21"
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 5
-	},
-/turf/open/floor/mineral/plastitanium,
-/area/ruin/powered/syndicate_lava_base)
-"cr" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/structure/sign/bluecross_2,
-/turf/open/floor/plating,
-/area/ruin/powered/syndicate_lava_base)
-"cs" = (
+/area/ruin/syndicate_lava_base/telecomms)
+"mP" = (
+/obj/structure/filingcabinet/security,
+/turf/open/floor/plasteel/dark,
+/area/ruin/syndicate_lava_base/telecomms)
+"mQ" = (
+/turf/open/floor/plasteel/dark,
+/area/ruin/syndicate_lava_base/telecomms)
+"mR" = (
 /obj/structure/table,
-/obj/item/storage/firstaid/regular{
-	pixel_x = 3;
-	pixel_y = 3
+/obj/item/storage/toolbox/syndicate,
+/obj/item/device/multitool,
+/turf/open/floor/plasteel/dark,
+/area/ruin/syndicate_lava_base/telecomms)
+"mS" = (
+/obj/machinery/door/airlock/external{
+	req_access_txt = "150"
 	},
-/obj/item/storage/firstaid/fire,
-/obj/item/storage/firstaid/regular{
-	pixel_x = -3;
+/obj/structure/fans/tiny,
+/turf/open/floor/plating,
+/area/ruin/syndicate_lava_base/arrivals)
+"mT" = (
+/turf/closed/wall/mineral/plastitanium/nodiagonal,
+/area/ruin/syndicate_lava_base/arrivals)
+"mU" = (
+/obj/structure/grille,
+/obj/structure/window/plastitanium,
+/obj/machinery/door/firedoor,
+/turf/open/floor/plating,
+/area/ruin/syndicate_lava_base/bar)
+"mV" = (
+/obj/structure/table/wood,
+/obj/machinery/chem_dispenser/drinks/beer,
+/obj/structure/sign/barsign{
+	pixel_y = -32;
+	req_access = null;
+	req_access_txt = "150"
+	},
+/turf/open/floor/wood,
+/area/ruin/syndicate_lava_base/bar)
+"mW" = (
+/obj/structure/table/wood,
+/obj/machinery/chem_dispenser/drinks,
+/turf/open/floor/wood,
+/area/ruin/syndicate_lava_base/bar)
+"mX" = (
+/obj/structure/rack{
+	dir = 8;
+	layer = 2.9
+	},
+/obj/item/storage/toolbox/mechanical,
+/obj/item/stack/cable_coil/yellow{
+	pixel_x = 2;
 	pixel_y = -3
 	},
-/turf/open/floor/plasteel/vault,
-/area/ruin/powered/syndicate_lava_base)
-"ct" = (
+/obj/item/device/multitool,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/red/side{
+	dir = 8
+	},
+/area/ruin/syndicate_lava_base/arrivals)
+"mY" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	piping_layer = 3;
+	pixel_x = 5;
+	pixel_y = 5
+	},
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	pixel_y = 0
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/white/side{
+	dir = 4
+	},
+/area/ruin/syndicate_lava_base/arrivals)
+"mZ" = (
 /obj/machinery/sleeper/syndie{
-	dir = 8
+	dir = 4
 	},
-/turf/open/floor/plasteel/vault{
-	dir = 8
+/turf/open/floor/plasteel/floorgrime,
+/area/ruin/syndicate_lava_base/medbay)
+"na" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	piping_layer = 3;
+	pixel_x = 5;
+	pixel_y = 5
 	},
-/area/ruin/powered/syndicate_lava_base)
-"cu" = (
-/obj/structure/closet/crate/secure,
-/obj/item/target,
-/obj/item/target,
-/obj/item/target/alien,
-/obj/item/target/alien,
-/obj/item/target/clown,
-/obj/item/target/clown,
-/obj/effect/turf_decal/stripes/line{
-	dir = 6
+/turf/open/floor/plasteel/floorgrime,
+/area/ruin/syndicate_lava_base/medbay)
+"nb" = (
+/obj/structure/table/optable,
+/obj/item/surgical_drapes,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/white/side{
+	dir = 4
 	},
-/turf/open/floor/mineral/plastitanium,
-/area/ruin/powered/syndicate_lava_base)
-"cv" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 10
+/area/ruin/syndicate_lava_base/medbay)
+"nc" = (
+/obj/machinery/computer/turbine_computer{
+	dir = 1;
+	id = "syndie_lavaland_incineratorturbine"
 	},
-/turf/open/floor/mineral/plastitanium,
-/area/ruin/powered/syndicate_lava_base)
-"cw" = (
-/obj/effect/turf_decal/stripes/line,
-/turf/open/floor/mineral/plastitanium,
-/area/ruin/powered/syndicate_lava_base)
-"cx" = (
-/obj/structure/extinguisher_cabinet{
-	pixel_y = -32
-	},
-/obj/effect/turf_decal/stripes/line,
-/turf/open/floor/mineral/plastitanium,
-/area/ruin/powered/syndicate_lava_base)
-"cy" = (
-/obj/effect/turf_decal/stripes/corner{
-	dir = 1
-	},
-/turf/open/floor/mineral/plastitanium,
-/area/ruin/powered/syndicate_lava_base)
-"cz" = (
-/obj/effect/turf_decal/stripes/corner,
-/turf/open/floor/mineral/plastitanium,
-/area/ruin/powered/syndicate_lava_base)
-"cA" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 6
-	},
-/turf/open/floor/mineral/plastitanium,
-/area/ruin/powered/syndicate_lava_base)
-"cB" = (
-/obj/machinery/door/airlock/hatch{
-	name = "Infirmary";
+/obj/machinery/button/door{
+	id = "syndie_lavaland_turbinevent";
+	name = "Turbine Vent Control";
+	pixel_x = 6;
+	pixel_y = -24;
 	req_access_txt = "150"
 	},
-/turf/open/floor/plasteel/vault{
-	dir = 8
+/obj/machinery/button/door{
+	id = "syndie_lavaland_auxincineratorvent";
+	name = "Auxiliary Vent Control";
+	pixel_x = -6;
+	pixel_y = -24;
+	req_access_txt = "150"
 	},
-/area/ruin/powered/syndicate_lava_base)
-"cC" = (
-/obj/structure/bed/roller,
-/obj/machinery/iv_drip,
-/obj/item/reagent_containers/blood/random,
-/turf/open/floor/plasteel/vault{
-	dir = 8
+/obj/effect/turf_decal/stripes/line,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/floorgrime,
+/area/ruin/syndicate_lava_base/engineering)
+"nd" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	pixel_y = 0
 	},
-/area/ruin/powered/syndicate_lava_base)
-"cD" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/door/poddoor/preopen{
-	id = "lavalandsyndi";
-	name = "Syndicate Research Experimentor Shutters"
+/obj/effect/turf_decal/stripes/line,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel,
+/area/ruin/syndicate_lava_base/engineering)
+"ne" = (
+/obj/machinery/atmospherics/pipe/simple/orange/visible,
+/obj/machinery/doorButtons/airlock_controller{
+	idExterior = "syndie_lavaland_incinerator_exterior";
+	idInterior = "syndie_lavaland_incinerator_interior";
+	idSelf = "syndie_lavaland_incinerator_access";
+	name = "Incinerator Access Console";
+	pixel_x = -8;
+	pixel_y = -26;
+	req_access_txt = "150"
 	},
+/obj/machinery/button/ignition{
+	id = "syndie_lavaland_Incinerator";
+	pixel_x = 6;
+	pixel_y = -24
+	},
+/obj/effect/turf_decal/stripes/line,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/floorgrime,
+/area/ruin/syndicate_lava_base/engineering)
+"nf" = (
+/obj/structure/sign/fire,
+/turf/closed/wall/mineral/plastitanium/nodiagonal,
+/area/ruin/syndicate_lava_base/engineering)
+"ng" = (
+/obj/structure/grille,
+/obj/structure/window/plastitanium,
+/obj/machinery/atmospherics/pipe/simple/orange/visible,
 /turf/open/floor/plating,
-/area/ruin/powered/syndicate_lava_base)
-"cE" = (
-/obj/machinery/door/airlock/hatch{
-	name = "Experimentation Room";
-	req_access_txt = "150"
+/area/ruin/syndicate_lava_base/engineering)
+"nh" = (
+/obj/machinery/telecomms/relay/preset/ruskie{
+	use_power = 0
 	},
-/turf/open/floor/plasteel/vault{
+/obj/machinery/light/small{
+	brightness = 3;
 	dir = 8
 	},
-/area/ruin/powered/syndicate_lava_base)
-"cF" = (
+/turf/open/floor/plasteel/vault{
+	dir = 5
+	},
+/area/ruin/syndicate_lava_base/telecomms)
+"ni" = (
+/turf/open/floor/plasteel/vault{
+	dir = 5
+	},
+/area/ruin/syndicate_lava_base/telecomms)
+"nj" = (
 /obj/machinery/door/airlock/hatch{
 	name = "Telecommunications Control";
 	req_access_txt = "150"
 	},
 /turf/open/floor/plasteel/vault{
-	dir = 8
+	dir = 5
 	},
-/area/ruin/powered/syndicate_lava_base)
-"cG" = (
-/turf/open/floor/engine,
-/area/ruin/powered/syndicate_lava_base)
-"cH" = (
+/area/ruin/syndicate_lava_base/telecomms)
+"nk" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
+	dir = 4;
+	piping_layer = 3;
+	pixel_x = 5;
+	pixel_y = 5
+	},
+/turf/open/floor/plasteel/vault{
+	dir = 5
+	},
+/area/ruin/syndicate_lava_base/telecomms)
+"nl" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4;
+	piping_layer = 3;
+	pixel_x = 5;
+	pixel_y = 5
+	},
+/turf/open/floor/plasteel/vault{
+	dir = 5
+	},
+/area/ruin/syndicate_lava_base/telecomms)
+"nm" = (
+/obj/machinery/light/small{
+	dir = 4
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 10;
+	piping_layer = 3;
+	pixel_x = 5;
+	pixel_y = 5
+	},
 /obj/structure/noticeboard{
-	pixel_y = 32
+	dir = 8;
+	pixel_x = 27
 	},
-/obj/machinery/light{
+/turf/open/floor/plasteel/vault{
+	dir = 5
+	},
+/area/ruin/syndicate_lava_base/telecomms)
+"nn" = (
+/obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
-/turf/open/floor/plasteel/vault{
+/turf/open/floor/plasteel/floorgrime,
+/area/ruin/syndicate_lava_base/arrivals)
+"no" = (
+/obj/effect/turf_decal/stripes/corner{
+	dir = 4
+	},
+/turf/open/floor/plasteel/red/corner{
+	dir = 4
+	},
+/area/ruin/syndicate_lava_base/arrivals)
+"np" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/red/side{
+	dir = 1
+	},
+/area/ruin/syndicate_lava_base/arrivals)
+"nq" = (
+/turf/open/floor/plasteel/red/side{
+	dir = 1
+	},
+/area/ruin/syndicate_lava_base/arrivals)
+"nr" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/red/side{
 	dir = 5
 	},
-/area/ruin/powered/syndicate_lava_base)
-"cI" = (
-/obj/structure/table,
-/obj/item/storage/toolbox/syndicate,
-/obj/item/device/multitool,
-/turf/open/floor/plasteel/vault{
-	dir = 8
+/area/ruin/syndicate_lava_base/arrivals)
+"ns" = (
+/obj/structure/closet/emcloset/anchored,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 6
 	},
-/area/ruin/powered/syndicate_lava_base)
-"cJ" = (
-/obj/item/surgicaldrill,
-/obj/item/circular_saw,
-/obj/structure/table/reinforced,
-/turf/open/floor/plasteel/vault{
-	dir = 8
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 6;
+	piping_layer = 3;
+	pixel_x = 5;
+	pixel_y = 5
 	},
-/area/ruin/powered/syndicate_lava_base)
-"cK" = (
-/obj/structure/sink{
+/obj/structure/cable/yellow{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/red/side{
+	dir = 9
+	},
+/area/ruin/syndicate_lava_base/arrivals)
+"nt" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4;
-	pixel_x = 11
+	piping_layer = 3;
+	pixel_x = 5;
+	pixel_y = 5
 	},
-/obj/structure/mirror{
-	pixel_x = 30
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/power/apc{
+	dir = 1;
+	name = "Arrival Hallway APC";
+	pixel_x = 0;
+	pixel_y = 24;
+	req_access = 150
+	},
+/obj/structure/cable/yellow{
+	d2 = 4;
+	icon_state = "0-4"
+	},
+/turf/open/floor/plasteel/red/side{
+	dir = 1
+	},
+/area/ruin/syndicate_lava_base/arrivals)
+"nu" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4;
+	piping_layer = 3;
+	pixel_x = 5;
+	pixel_y = 5
+	},
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/open/floor/plasteel/red/side{
+	dir = 1
+	},
+/area/ruin/syndicate_lava_base/arrivals)
+"nv" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4;
+	piping_layer = 3;
+	pixel_x = 5;
+	pixel_y = 5
+	},
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/open/floor/plasteel/red/corner{
+	dir = 1
+	},
+/area/ruin/syndicate_lava_base/arrivals)
+"nw" = (
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden,
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
+	dir = 2;
+	piping_layer = 3;
+	pixel_x = 5;
+	pixel_y = 5
+	},
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/turf/open/floor/plasteel/white/side{
+	dir = 4
+	},
+/area/ruin/syndicate_lava_base/arrivals)
+"nx" = (
+/obj/machinery/door/firedoor,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4;
+	piping_layer = 3;
+	pixel_x = 5;
+	pixel_y = 5
+	},
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/door/airlock/medical/glass{
+	name = "Medbay"
+	},
+/turf/open/floor/plasteel/white,
+/area/ruin/syndicate_lava_base/medbay)
+"ny" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4;
+	piping_layer = 3;
+	pixel_x = 5;
+	pixel_y = 5
+	},
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/open/floor/plasteel/white/side{
+	dir = 8
+	},
+/area/ruin/syndicate_lava_base/medbay)
+"nz" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 9;
+	piping_layer = 3;
+	pixel_x = 5;
+	pixel_y = 5
+	},
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/open/floor/plasteel,
+/area/ruin/syndicate_lava_base/medbay)
+"nA" = (
+/obj/structure/cable/yellow{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/turf/open/floor/plasteel/white/corner,
+/area/ruin/syndicate_lava_base/medbay)
+"nB" = (
+/obj/structure/table/reinforced,
+/obj/item/surgicaldrill,
+/obj/item/cautery,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/white/side,
+/area/ruin/syndicate_lava_base/medbay)
+"nC" = (
+/obj/structure/table/reinforced,
+/obj/item/retractor,
+/obj/item/hemostat,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/white/side{
+	dir = 6
+	},
+/area/ruin/syndicate_lava_base/medbay)
+"nD" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	pixel_y = 0
+	},
+/obj/machinery/door/airlock/glass{
+	autoclose = 0;
+	frequency = 1449;
+	heat_proof = 1;
+	icon_state = "closed";
+	id_tag = "syndie_lavaland_incinerator_interior";
+	locked = 1;
+	name = "Turbine Interior Airlock";
+	req_access_txt = "150"
+	},
+/turf/open/floor/engine,
+/area/ruin/syndicate_lava_base/engineering)
+"nE" = (
+/obj/machinery/atmospherics/pipe/simple/orange/visible,
+/turf/closed/wall/mineral/plastitanium/nodiagonal,
+/area/ruin/syndicate_lava_base/engineering)
+"nF" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/siphon/on{
+	dir = 1;
+	frequency = 1442;
+	id_tag = "syndie_lavaland_tox_out";
+	name = "toxin out"
+	},
+/turf/open/floor/plating/airless,
+/area/ruin/syndicate_lava_base/engineering)
+"nG" = (
+/obj/machinery/air_sensor{
+	frequency = 1442;
+	id_tag = "syndie_lavaland_tox_sensor"
+	},
+/turf/open/floor/plating/airless,
+/area/ruin/syndicate_lava_base/engineering)
+"nH" = (
+/obj/machinery/airalarm{
+	dir = 4;
+	icon_state = "alarm0";
+	pixel_x = -24;
+	req_access = 150
+	},
+/obj/machinery/light/small{
+	brightness = 3;
+	dir = 8
 	},
 /turf/open/floor/plasteel/vault{
 	dir = 5
 	},
-/area/ruin/powered/syndicate_lava_base)
-"cL" = (
-/obj/item/stack/cable_coil/white{
-	pixel_x = 3;
-	pixel_y = 3
-	},
-/obj/structure/table/reinforced,
-/obj/item/storage/toolbox/syndicate,
-/obj/item/stack/cable_coil/white,
+/area/ruin/syndicate_lava_base/telecomms)
+"nI" = (
+/obj/machinery/computer/camera_advanced,
 /turf/open/floor/plasteel/vault{
-	dir = 8
+	dir = 5
 	},
-/area/ruin/powered/syndicate_lava_base)
-"cM" = (
-/obj/structure/table/reinforced,
-/obj/item/device/flashlight/lamp,
-/turf/open/floor/plasteel/vault{
-	dir = 8
-	},
-/area/ruin/powered/syndicate_lava_base)
-"cN" = (
+/area/ruin/syndicate_lava_base/telecomms)
+"nJ" = (
 /obj/structure/table/reinforced,
 /obj/item/device/radio/intercom{
 	broadcasting = 0;
@@ -1197,67 +5787,362 @@
 	name = "Pirate Radio Listening Channel"
 	},
 /turf/open/floor/plasteel/vault{
-	dir = 8
+	dir = 5
 	},
-/area/ruin/powered/syndicate_lava_base)
-"cO" = (
-/obj/machinery/computer/camera_advanced,
+/area/ruin/syndicate_lava_base/telecomms)
+"nK" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 5;
+	piping_layer = 3;
+	pixel_x = 5;
+	pixel_y = 5
+	},
+/obj/structure/cable/yellow{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
 /turf/open/floor/plasteel/vault{
 	dir = 5
 	},
-/area/ruin/powered/syndicate_lava_base)
-"cP" = (
-/obj/structure/filingcabinet/chestdrawer,
+/area/ruin/syndicate_lava_base/telecomms)
+"nL" = (
+/obj/machinery/door/airlock/hatch{
+	name = "Telecommunications";
+	req_access_txt = "150"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4;
+	piping_layer = 3;
+	pixel_x = 5;
+	pixel_y = 5
+	},
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
 /turf/open/floor/plasteel/vault{
+	dir = 5
+	},
+/area/ruin/syndicate_lava_base/telecomms)
+"nM" = (
+/obj/machinery/light/small,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4;
+	piping_layer = 3;
+	pixel_x = 5;
+	pixel_y = 5
+	},
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/floorgrime,
+/area/ruin/syndicate_lava_base/arrivals)
+"nN" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4;
+	piping_layer = 3;
+	pixel_x = 5;
+	pixel_y = 5
+	},
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/open/floor/plasteel,
+/area/ruin/syndicate_lava_base/arrivals)
+"nO" = (
+/obj/effect/turf_decal/stripes/corner,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4;
+	piping_layer = 3;
+	pixel_x = 5;
+	pixel_y = 5
+	},
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/open/floor/plasteel/floorgrime,
+/area/ruin/syndicate_lava_base/arrivals)
+"nP" = (
+/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/caution/stand_clear{
+	icon_state = "stand_clear";
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4;
+	piping_layer = 3;
+	pixel_x = 5;
+	pixel_y = 5
+	},
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/open/floor/plasteel,
+/area/ruin/syndicate_lava_base/arrivals)
+"nQ" = (
+/obj/effect/turf_decal/stripes/corner{
+	dir = 1
+	},
+/obj/machinery/light/small,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4;
+	piping_layer = 3;
+	pixel_x = 5;
+	pixel_y = 5
+	},
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/open/floor/plasteel,
+/area/ruin/syndicate_lava_base/arrivals)
+"nR" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4;
+	piping_layer = 3;
+	pixel_x = 5;
+	pixel_y = 5
+	},
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/open/floor/plasteel/red/corner{
+	dir = 4
+	},
+/area/ruin/syndicate_lava_base/arrivals)
+"nS" = (
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4;
+	piping_layer = 3;
+	pixel_x = 5;
+	pixel_y = 5
+	},
+/obj/machinery/firealarm{
+	dir = 2;
+	pixel_y = 24
+	},
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/open/floor/plasteel/red/side{
+	dir = 1
+	},
+/area/ruin/syndicate_lava_base/arrivals)
+"nT" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
+	dir = 1;
+	piping_layer = 3;
+	pixel_x = 5;
+	pixel_y = 5
+	},
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/open/floor/plasteel/red/side{
+	dir = 1
+	},
+/area/ruin/syndicate_lava_base/arrivals)
+"nU" = (
+/obj/machinery/light/small{
+	dir = 1
+	},
+/obj/machinery/airalarm{
+	pixel_y = 24;
+	req_access = 152
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4;
+	piping_layer = 3;
+	pixel_x = 5;
+	pixel_y = 5
+	},
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/red/side{
+	dir = 1
+	},
+/area/ruin/syndicate_lava_base/arrivals)
+"nV" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 9;
+	piping_layer = 3;
+	pixel_x = 5;
+	pixel_y = 5
+	},
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/turf/open/floor/plasteel/red/corner{
+	dir = 1
+	},
+/area/ruin/syndicate_lava_base/arrivals)
+"nW" = (
+/turf/open/floor/plasteel,
+/area/ruin/syndicate_lava_base/arrivals)
+"nX" = (
+/turf/open/floor/plasteel/floorgrime,
+/area/ruin/syndicate_lava_base/arrivals)
+"nY" = (
+/obj/machinery/light/small,
+/turf/open/floor/plasteel/floorgrime,
+/area/ruin/syndicate_lava_base/arrivals)
+"nZ" = (
+/turf/open/floor/plasteel/white/side{
+	dir = 4
+	},
+/area/ruin/syndicate_lava_base/arrivals)
+"oa" = (
+/turf/open/floor/plasteel/white/side{
+	dir = 10
+	},
+/area/ruin/syndicate_lava_base/medbay)
+"ob" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/white/side,
+/area/ruin/syndicate_lava_base/medbay)
+"oc" = (
+/obj/machinery/light/small,
+/obj/structure/extinguisher_cabinet{
+	pixel_x = 0;
+	pixel_y = -29
+	},
+/obj/structure/cable/yellow,
+/obj/machinery/power/apc{
+	dir = 4;
+	name = "Medbay APC";
+	pixel_x = 24;
+	pixel_y = 0;
+	req_access = 150
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/white/side{
+	dir = 6
+	},
+/area/ruin/syndicate_lava_base/medbay)
+"od" = (
+/obj/machinery/light/small{
 	dir = 8
 	},
-/area/ruin/powered/syndicate_lava_base)
-"cQ" = (
-/obj/item/cautery,
-/obj/item/scalpel,
-/obj/structure/table/reinforced,
-/turf/open/floor/plasteel/vault{
-	dir = 8
+/obj/machinery/doorButtons/access_button{
+	idDoor = "syndie_lavaland_incinerator_exterior";
+	idSelf = "syndie_lavaland_incinerator_access";
+	layer = 3.1;
+	name = "Incinerator airlock control";
+	pixel_x = 8;
+	pixel_y = -24
 	},
-/area/ruin/powered/syndicate_lava_base)
-"cR" = (
-/obj/structure/table/optable,
-/obj/item/surgical_drapes,
-/turf/open/floor/plasteel/vault{
-	dir = 8
+/turf/open/floor/engine,
+/area/ruin/syndicate_lava_base/engineering)
+"oe" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	pixel_y = 0
 	},
-/area/ruin/powered/syndicate_lava_base)
-"cS" = (
-/obj/item/retractor,
-/obj/item/hemostat,
-/obj/structure/table/reinforced,
+/turf/open/floor/engine,
+/area/ruin/syndicate_lava_base/engineering)
+"of" = (
 /obj/machinery/light/small{
 	dir = 4
 	},
-/turf/open/floor/plasteel/vault{
-	dir = 8
+/obj/machinery/atmospherics/components/binary/pump{
+	dir = 2;
+	on = 0;
+	target_pressure = 101.325
 	},
-/area/ruin/powered/syndicate_lava_base)
-"cT" = (
-/obj/structure/sign/nosmoking_2{
-	pixel_x = 32
+/obj/machinery/doorButtons/access_button{
+	idDoor = "syndie_lavaland_incinerator_interior";
+	idSelf = "syndie_lavaland_incinerator_access";
+	name = "Incinerator airlock control";
+	pixel_x = -8;
+	pixel_y = 24
 	},
-/turf/open/floor/plasteel/vault{
-	dir = 5
-	},
-/area/ruin/powered/syndicate_lava_base)
-"cU" = (
-/obj/item/twohanded/required/kirbyplants{
-	icon_state = "plant-22"
-	},
-/obj/structure/extinguisher_cabinet{
+/turf/open/floor/engine,
+/area/ruin/syndicate_lava_base/engineering)
+"og" = (
+/obj/machinery/atmospherics/miner/toxins,
+/obj/machinery/light/small,
+/turf/open/floor/plating/airless,
+/area/ruin/syndicate_lava_base/engineering)
+"oh" = (
+/obj/machinery/firealarm{
+	dir = 8;
 	pixel_x = -26
 	},
 /turf/open/floor/plasteel/vault{
 	dir = 5
 	},
-/area/ruin/powered/syndicate_lava_base)
-"cV" = (
+/area/ruin/syndicate_lava_base/telecomms)
+"oi" = (
+/obj/structure/chair/office/dark{
+	dir = 4
+	},
+/turf/open/floor/plasteel/vault{
+	dir = 5
+	},
+/area/ruin/syndicate_lava_base/telecomms)
+"oj" = (
 /obj/structure/table/reinforced,
 /obj/item/device/radio/intercom{
 	broadcasting = 1;
@@ -1267,455 +6152,246 @@
 	name = "Pirate Radio Broadcast Channel"
 	},
 /turf/open/floor/plasteel/vault{
+	dir = 5
+	},
+/area/ruin/syndicate_lava_base/telecomms)
+"ok" = (
+/obj/structure/chair{
 	dir = 8
 	},
-/area/ruin/powered/syndicate_lava_base)
-"cW" = (
-/obj/structure/sign/fire{
-	pixel_x = -32
-	},
-/turf/open/floor/engine,
-/area/ruin/powered/syndicate_lava_base)
-"cX" = (
-/obj/structure/table/reinforced,
-/obj/item/device/assembly/signaler,
-/obj/item/device/assembly/signaler,
-/obj/item/device/assembly/voice,
-/obj/item/device/assembly/voice,
-/obj/item/screwdriver/nuke,
-/turf/open/floor/plasteel/vault{
-	dir = 8
-	},
-/area/ruin/powered/syndicate_lava_base)
-"cY" = (
-/obj/structure/table/reinforced,
-/obj/item/stack/sheet/plasteel{
-	amount = 15
-	},
-/obj/item/device/electropack,
-/obj/item/device/taperecorder,
-/turf/open/floor/plasteel/vault{
-	dir = 8
-	},
-/area/ruin/powered/syndicate_lava_base)
-"cZ" = (
-/obj/structure/filingcabinet/security,
-/obj/machinery/light{
-	dir = 8
+/obj/structure/cable/yellow,
+/obj/machinery/power/apc{
+	dir = 2;
+	name = "Telecommunications APC";
+	pixel_x = 0;
+	pixel_y = -24;
+	req_access = 150
 	},
 /turf/open/floor/plasteel/vault{
 	dir = 5
 	},
-/area/ruin/powered/syndicate_lava_base)
-"da" = (
+/area/ruin/syndicate_lava_base/telecomms)
+"ol" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/structure/rack{
+	dir = 8;
+	layer = 2.9
+	},
+/obj/item/clothing/suit/space/syndicate,
+/obj/item/clothing/mask/gas/syndicate,
+/obj/item/clothing/head/helmet/space/syndicate,
+/obj/item/device/mining_scanner,
+/obj/item/pickaxe,
+/turf/open/floor/mineral/plastitanium,
+/area/ruin/syndicate_lava_base/arrivals)
+"om" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/red/side,
+/area/ruin/syndicate_lava_base/arrivals)
+"on" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on{
+	dir = 1
+	},
+/obj/structure/extinguisher_cabinet{
+	pixel_x = 0;
+	pixel_y = -29
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/red/side,
+/area/ruin/syndicate_lava_base/arrivals)
+"oo" = (
+/turf/open/floor/plasteel/red/side,
+/area/ruin/syndicate_lava_base/arrivals)
+"op" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
+	dir = 1;
+	piping_layer = 3;
+	pixel_x = 5;
+	pixel_y = 5
+	},
+/turf/open/floor/plasteel/red/side,
+/area/ruin/syndicate_lava_base/arrivals)
+"oq" = (
+/obj/machinery/button/door{
+	id = "lavalandsyndi_arrivals";
+	name = "Arrivals Blast Door Control";
+	pixel_x = 0;
+	pixel_y = -26;
+	req_access_txt = "150"
+	},
+/turf/open/floor/plasteel/red/side,
+/area/ruin/syndicate_lava_base/arrivals)
+"or" = (
+/obj/structure/rack{
+	dir = 8;
+	layer = 2.9
+	},
+/obj/item/storage/belt/medical,
+/obj/effect/decal/cleanable/dirt,
+/obj/item/crowbar,
+/obj/item/clothing/glasses/hud/health,
+/obj/item/clothing/neck/stethoscope,
+/turf/open/floor/plasteel/white,
+/area/ruin/syndicate_lava_base/medbay)
+"os" = (
+/obj/machinery/vending/medical{
+	desc = "Medical drug dispenser. Looks to have been outfitted with illicit software.";
+	extended_inventory = 1;
+	name = "SyndiMed Plus";
+	premium = list(/obj/item/reagent_containers/hypospray/medipen = 2, /obj/item/storage/belt/medical = 2);
+	products = list(/obj/item/reagent_containers/syringe = 6, /obj/item/reagent_containers/dropper = 2, /obj/item/stack/medical/gauze = 4, /obj/item/reagent_containers/pill/patch/styptic = 3, /obj/item/reagent_containers/pill/insulin = 5, /obj/item/reagent_containers/pill/patch/silver_sulf = 3, /obj/item/reagent_containers/glass/bottle/charcoal = 2, /obj/item/reagent_containers/spray/medical/sterilizer = 1, /obj/item/reagent_containers/glass/bottle/epinephrine = 2, /obj/item/reagent_containers/glass/bottle/morphine = 2, /obj/item/reagent_containers/glass/bottle/salglu_solution = 2, /obj/item/reagent_containers/glass/bottle/toxin = 2, /obj/item/reagent_containers/syringe/antiviral = 3, /obj/item/reagent_containers/pill/salbutamol = 1, /obj/item/device/healthanalyzer = 2);
+	req_access_txt = "150"
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/white,
+/area/ruin/syndicate_lava_base/medbay)
+"ot" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	pixel_y = 0
+	},
+/obj/machinery/door/airlock/glass{
+	autoclose = 0;
+	frequency = 1449;
+	heat_proof = 1;
+	icon_state = "closed";
+	id_tag = "syndie_lavaland_incinerator_exterior";
+	locked = 1;
+	name = "Turbine Exterior Airlock";
+	req_access_txt = "150"
+	},
+/turf/open/floor/engine,
+/area/ruin/syndicate_lava_base/engineering)
+"ou" = (
+/obj/machinery/computer/message_monitor{
+	dir = 1
+	},
+/obj/item/paper/monitorkey,
+/turf/open/floor/plasteel/dark,
+/area/ruin/syndicate_lava_base/telecomms)
+"ov" = (
 /obj/structure/table/reinforced,
 /obj/item/paper_bin,
 /obj/item/pen,
-/turf/open/floor/plasteel/vault{
-	dir = 8
+/turf/open/floor/plasteel/dark,
+/area/ruin/syndicate_lava_base/telecomms)
+"ow" = (
+/turf/closed/wall/mineral/plastitanium/explosive,
+/area/ruin/syndicate_lava_base/arrivals)
+"ox" = (
+/obj/structure/grille,
+/obj/structure/window/plastitanium,
+/obj/machinery/door/firedoor,
+/obj/machinery/door/poddoor{
+	id = "lavalandsyndi_arrivals";
+	layer = 2.9
 	},
-/area/ruin/powered/syndicate_lava_base)
-"db" = (
-/obj/machinery/computer/message_monitor,
-/obj/item/paper/monitorkey,
-/turf/open/floor/plasteel/vault{
-	dir = 8
+/turf/open/floor/plating,
+/area/ruin/syndicate_lava_base/arrivals)
+"oy" = (
+/turf/closed/wall/mineral/plastitanium/explosive,
+/area/ruin/syndicate_lava_base/medbay)
+"oz" = (
+/turf/open/floor/engine{
+	initial_gas_mix = "o2=14;n2=23;TEMP=300"
 	},
-/area/ruin/powered/syndicate_lava_base)
-"dd" = (
-/obj/effect/baseturf_helper/lava_land/surface,
-/turf/open/floor/plasteel/vault{
-	dir = 5
+/area/ruin/syndicate_lava_base/engineering)
+"oA" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	pixel_y = 0
 	},
-/area/ruin/powered/syndicate_lava_base)
-"de" = (
-/obj/machinery/button/door{
-	id = "lavalandsyndi";
-	name = "Syndicate Experimentor Lockdown Control";
-	pixel_x = 26;
-	req_access_txt = "150"
+/obj/machinery/igniter{
+	icon_state = "igniter0";
+	id = "syndie_lavaland_Incinerator";
+	luminosity = 2;
+	on = 0
 	},
-/turf/open/floor/engine,
-/area/ruin/powered/syndicate_lava_base)
-"df" = (
-/obj/machinery/button/door{
-	id = "lavalandsyndi";
-	name = "Syndicate Experimentor Lockdown Control";
-	pixel_x = -26;
-	req_access_txt = "150"
+/turf/open/floor/engine{
+	initial_gas_mix = "o2=14;n2=23;TEMP=300"
 	},
-/turf/open/floor/plasteel/vault{
-	dir = 5
+/area/ruin/syndicate_lava_base/engineering)
+"oB" = (
+/obj/structure/sign/securearea{
+	desc = "A warning sign which reads 'EXTERNAL AIRLOCK'";
+	icon_state = "space";
+	layer = 4;
+	name = "EXTERNAL AIRLOCK";
+	pixel_y = -32
 	},
-/area/ruin/powered/syndicate_lava_base)
-"dg" = (
-/obj/item/stack/sheet/mineral/plastitanium{
-	amount = 30
+/obj/machinery/atmospherics/components/unary/outlet_injector/on{
+	dir = 1;
+	frequency = 1441;
+	id = "syndie_lavaland_inc_in"
 	},
-/obj/item/stack/rods/fifty,
-/obj/structure/table/reinforced,
-/obj/machinery/light{
-	dir = 4
+/turf/open/floor/engine{
+	initial_gas_mix = "o2=14;n2=23;TEMP=300"
 	},
-/turf/open/floor/plasteel/vault{
-	dir = 8
+/area/ruin/syndicate_lava_base/engineering)
+"oC" = (
+/obj/machinery/door/poddoor{
+	id = "syndie_lavaland_auxincineratorvent";
+	name = "Auxiliary Incinerator Vent"
 	},
-/area/ruin/powered/syndicate_lava_base)
-"dh" = (
-/obj/structure/filingcabinet/medical,
-/turf/open/floor/plasteel/vault{
-	dir = 5
+/turf/open/floor/engine{
+	initial_gas_mix = "o2=14;n2=23;TEMP=300"
 	},
-/area/ruin/powered/syndicate_lava_base)
-"di" = (
-/turf/open/floor/circuit/green,
-/area/ruin/powered/syndicate_lava_base)
-"dj" = (
-/obj/machinery/door/poddoor/preopen{
-	id = "lavalandsyndi";
-	name = "Syndicate Research Experimentor Shutters"
-	},
-/obj/machinery/door/airlock/hatch{
-	name = "Experimentation Room";
-	req_access_txt = "150"
-	},
-/turf/open/floor/plasteel/vault{
-	dir = 8
-	},
-/area/ruin/powered/syndicate_lava_base)
-"dk" = (
-/obj/item/stack/sheet/metal/fifty,
-/obj/item/grenade/chem_grenade,
-/obj/item/grenade/chem_grenade,
-/obj/item/grenade/chem_grenade,
-/obj/structure/table/reinforced,
-/obj/item/grenade/chem_grenade,
-/obj/item/grenade/chem_grenade/large,
-/obj/item/grenade/chem_grenade/large,
-/obj/item/grenade/chem_grenade/large,
-/obj/item/grenade/chem_grenade/large,
-/turf/open/floor/plasteel/vault{
-	dir = 8
-	},
-/area/ruin/powered/syndicate_lava_base)
-"dl" = (
-/obj/machinery/door/airlock/hatch{
-	name = "Self Destruct Control";
-	req_access_txt = "150"
-	},
-/turf/open/floor/plasteel/vault{
-	dir = 8
-	},
-/area/ruin/powered/syndicate_lava_base)
-"dm" = (
-/obj/machinery/telecomms/relay/preset/ruskie{
-	use_power = 0
-	},
-/turf/open/floor/plasteel/vault{
-	dir = 5
-	},
-/area/ruin/powered/syndicate_lava_base)
-"dn" = (
-/obj/machinery/door/airlock/hatch{
-	name = "Syndicate Recon Outpost";
-	req_access_txt = "150"
-	},
-/obj/structure/fans/tiny,
-/turf/open/floor/plasteel/vault{
-	dir = 8
-	},
-/area/ruin/powered/syndicate_lava_base)
-"do" = (
-/turf/open/floor/circuit/red,
-/area/ruin/powered/syndicate_lava_base)
-"dp" = (
-/obj/machinery/door/airlock/hatch{
-	name = "Monkey Pen";
-	req_access_txt = "150"
-	},
-/turf/open/floor/plasteel/vault{
-	dir = 8
-	},
-/area/ruin/powered/syndicate_lava_base)
-"dq" = (
-/obj/structure/sign/vacuum{
+/area/ruin/syndicate_lava_base/engineering)
+"oD" = (
+/obj/structure/sign/xeno_warning_mining{
 	pixel_x = -32
 	},
-/obj/machinery/light/small{
-	brightness = 3;
-	dir = 8
-	},
-/turf/open/floor/plasteel/vault{
-	dir = 8
-	},
-/area/ruin/powered/syndicate_lava_base)
-"dr" = (
-/obj/structure/sign/xeno_warning_mining{
+/obj/structure/sign/fire{
 	pixel_x = 32
 	},
-/turf/open/floor/plasteel/vault{
-	dir = 8
+/turf/open/floor/plating,
+/area/ruin/syndicate_lava_base/arrivals)
+"oE" = (
+/obj/structure/cable,
+/obj/structure/cable{
+	icon_state = "0-2";
+	pixel_y = 1;
+	d2 = 2
 	},
-/area/ruin/powered/syndicate_lava_base)
-"ds" = (
-/obj/machinery/syndicatebomb/self_destruct,
-/turf/open/floor/circuit/red,
-/area/ruin/powered/syndicate_lava_base)
-"dt" = (
-/obj/structure/bed/roller,
-/obj/machinery/iv_drip,
-/mob/living/carbon/monkey,
-/turf/open/floor/plasteel/vault{
-	dir = 8
+/obj/machinery/power/compressor{
+	comp_id = "syndie_lavaland_incineratorturbine";
+	dir = 1;
+	luminosity = 2
 	},
-/area/ruin/powered/syndicate_lava_base)
-"fJ" = (
-/obj/machinery/light{
-	dir = 8
+/turf/open/floor/engine{
+	initial_gas_mix = "o2=14;n2=23;TEMP=300"
 	},
-/turf/open/floor/wood,
-/area/ruin/powered/syndicate_lava_base)
-"fK" = (
-/obj/machinery/light{
-	dir = 4
+/area/ruin/syndicate_lava_base/engineering)
+"oF" = (
+/obj/structure/sign/securearea,
+/turf/closed/wall/mineral/plastitanium/nodiagonal,
+/area/ruin/syndicate_lava_base/arrivals)
+"oG" = (
+/obj/structure/cable,
+/obj/machinery/power/turbine{
+	dir = 2;
+	luminosity = 2
 	},
-/turf/open/floor/wood,
-/area/ruin/powered/syndicate_lava_base)
-"fL" = (
-/obj/machinery/light{
-	dir = 4
+/turf/open/floor/engine{
+	initial_gas_mix = "o2=14;n2=23;TEMP=300"
 	},
-/turf/open/floor/plasteel/vault{
-	dir = 5
+/area/ruin/syndicate_lava_base/engineering)
+"oH" = (
+/obj/machinery/door/poddoor{
+	id = "syndie_lavaland_turbinevent";
+	name = "Turbine Vent"
 	},
-/area/ruin/powered/syndicate_lava_base)
-"fM" = (
-/obj/item/twohanded/required/kirbyplants{
-	icon_state = "plant-22"
+/turf/open/floor/engine{
+	initial_gas_mix = "o2=14;n2=23;TEMP=300"
 	},
-/obj/machinery/light/small,
-/turf/open/floor/plasteel/vault{
-	dir = 5
-	},
-/area/ruin/powered/syndicate_lava_base)
-"fN" = (
-/obj/machinery/light/small,
-/turf/open/floor/plasteel/vault{
-	dir = 5
-	},
-/area/ruin/powered/syndicate_lava_base)
-"fP" = (
-/obj/machinery/light{
-	dir = 8
-	},
-/turf/open/floor/plasteel/vault{
-	dir = 5
-	},
-/area/ruin/powered/syndicate_lava_base)
-"fQ" = (
-/obj/structure/bed/roller,
-/obj/machinery/light/small{
-	dir = 1
-	},
-/turf/open/floor/plasteel/vault{
-	dir = 8
-	},
-/area/ruin/powered/syndicate_lava_base)
-"fR" = (
-/obj/machinery/light{
-	dir = 4
-	},
-/turf/open/floor/plasteel/dark,
-/area/ruin/powered/syndicate_lava_base)
-"fS" = (
-/obj/machinery/iv_drip,
-/obj/item/reagent_containers/blood/random,
-/obj/machinery/light{
-	dir = 8
-	},
-/turf/open/floor/plasteel/vault{
-	dir = 5
-	},
-/area/ruin/powered/syndicate_lava_base)
-"fT" = (
-/obj/machinery/light/small{
-	brightness = 3;
-	dir = 8
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/turf/open/floor/mineral/plastitanium,
-/area/ruin/powered/syndicate_lava_base)
-"fU" = (
-/obj/machinery/light/small{
-	dir = 4
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/turf/open/floor/mineral/plastitanium,
-/area/ruin/powered/syndicate_lava_base)
-"fV" = (
-/obj/machinery/light/small,
-/turf/open/floor/plasteel/vault{
-	dir = 8
-	},
-/area/ruin/powered/syndicate_lava_base)
-"fX" = (
-/obj/machinery/light/small{
-	dir = 1
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/turf/open/floor/mineral/plastitanium,
-/area/ruin/powered/syndicate_lava_base)
-"fZ" = (
-/obj/machinery/light{
-	dir = 1
-	},
-/turf/open/floor/plasteel/vault{
-	dir = 5
-	},
-/area/ruin/powered/syndicate_lava_base)
-"ga" = (
-/obj/machinery/light/small,
-/obj/effect/turf_decal/stripes/line,
-/turf/open/floor/mineral/plastitanium,
-/area/ruin/powered/syndicate_lava_base)
-"ge" = (
-/obj/machinery/light{
-	dir = 8
-	},
-/turf/open/floor/engine,
-/area/ruin/powered/syndicate_lava_base)
-"gi" = (
-/obj/machinery/light/small{
-	dir = 4
-	},
-/turf/open/floor/circuit/green,
-/area/ruin/powered/syndicate_lava_base)
-"gk" = (
-/obj/machinery/light/small{
-	dir = 8
-	},
-/turf/open/floor/circuit/red,
-/area/ruin/powered/syndicate_lava_base)
-"gl" = (
-/obj/machinery/light/small{
-	dir = 4
-	},
-/turf/open/floor/circuit/red,
-/area/ruin/powered/syndicate_lava_base)
-"gm" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 10
-	},
-/turf/open/floor/mineral/plastitanium,
-/area/ruin/powered/syndicate_lava_base)
-"gn" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 6
-	},
-/turf/open/floor/mineral/plastitanium,
-/area/ruin/powered/syndicate_lava_base)
-"go" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/turf/open/floor/mineral/plastitanium,
-/area/ruin/powered/syndicate_lava_base)
-"gp" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/turf/open/floor/mineral/plastitanium,
-/area/ruin/powered/syndicate_lava_base)
-"gq" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/turf/open/floor/mineral/plastitanium,
-/area/ruin/powered/syndicate_lava_base)
-"gr" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/turf/open/floor/mineral/plastitanium,
-/area/ruin/powered/syndicate_lava_base)
-"gs" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/turf/open/floor/mineral/plastitanium,
-/area/ruin/powered/syndicate_lava_base)
-"gt" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/turf/open/floor/mineral/plastitanium,
-/area/ruin/powered/syndicate_lava_base)
-"gu" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/turf/open/floor/mineral/plastitanium,
-/area/ruin/powered/syndicate_lava_base)
-"gv" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/turf/open/floor/mineral/plastitanium,
-/area/ruin/powered/syndicate_lava_base)
-"gw" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/turf/open/floor/mineral/plastitanium,
-/area/ruin/powered/syndicate_lava_base)
-"gx" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/turf/open/floor/mineral/plastitanium,
-/area/ruin/powered/syndicate_lava_base)
-"gy" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/turf/open/floor/mineral/plastitanium,
-/area/ruin/powered/syndicate_lava_base)
-"gz" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/turf/open/floor/mineral/plastitanium,
-/area/ruin/powered/syndicate_lava_base)
-"gA" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/turf/open/floor/mineral/plastitanium,
-/area/ruin/powered/syndicate_lava_base)
-"gB" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/turf/open/floor/mineral/plastitanium,
-/area/ruin/powered/syndicate_lava_base)
-"gC" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/turf/open/floor/mineral/plastitanium,
-/area/ruin/powered/syndicate_lava_base)
-"gD" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/turf/open/floor/mineral/plastitanium,
-/area/ruin/powered/syndicate_lava_base)
+/area/ruin/syndicate_lava_base/engineering)
 
 (1,1,1) = {"
 aa
@@ -1723,8 +6399,10 @@ aa
 aa
 aa
 aa
-ab
-ab
+aa
+aa
+aa
+aa
 ab
 ab
 ab
@@ -1754,6 +6432,11 @@ ab
 ab
 ab
 ab
+ab
+aa
+aa
+aa
+aa
 aa
 aa
 "}
@@ -1762,6 +6445,9 @@ aa
 aa
 aa
 aa
+aa
+aa
+aa
 ab
 ab
 ab
@@ -1795,10 +6481,19 @@ ab
 ab
 ab
 ab
+ab
+ab
+aa
+aa
 aa
 "}
 (3,1,1) = {"
 aa
+aa
+aa
+aa
+ab
+aa
 ab
 ab
 ab
@@ -1836,9 +6531,12 @@ ab
 ab
 ab
 ab
+ab
+aa
 "}
 (4,1,1) = {"
 aa
+aa
 ab
 ab
 ab
@@ -1871,72 +6569,25 @@ ab
 ab
 ab
 ab
+mn
+mn
+mn
 ab
 ab
 ab
 ab
+ab
+ab
+aa
 aa
 "}
 (5,1,1) = {"
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-"}
-(6,1,1) = {"
 aa
 ab
 ab
 ab
 ab
 ab
-ac
-ab
-ab
-ab
-ab
-ab
-ac
-ab
-ab
-ab
-ac
-ac
-ac
 ab
 ab
 ab
@@ -1956,6 +6607,73 @@ ab
 ab
 ab
 ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+mn
+mn
+nh
+mn
+mn
+ab
+ab
+ab
+ab
+ab
+ab
+aa
+"}
+(6,1,1) = {"
+aa
+aa
+aa
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+mn
+mM
+ni
+mM
+mn
+ab
+ab
+ab
+ab
+ab
+aa
+aa
 "}
 (7,1,1) = {"
 aa
@@ -1969,6 +6687,12 @@ ab
 ab
 ab
 ab
+eh
+eh
+eh
+eh
+gj
+eh
 ab
 ab
 ab
@@ -1978,26 +6702,47 @@ ab
 ab
 ab
 ab
-ac
-ab
-ac
-ac
-ab
-ab
-ab
-ac
-ab
-ac
-ac
-ac
-ac
 ab
 ab
 ab
 ab
 ab
+ab
+ab
+mo
+mN
+nj
+mn
+mn
+mn
+ab
+ab
+ab
+ab
+ab
+aa
 "}
 (8,1,1) = {"
+aa
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ac
+eh
+eG
+ff
+eI
+go
+eh
+eh
+eh
+eh
 ab
 ab
 ab
@@ -2006,38 +6751,27 @@ ab
 ab
 ab
 ab
-ac
-ac
-ac
-ab
-ab
-ac
-ac
-ac
-ac
-ab
-ac
-ac
-ab
-ab
-ac
-ad
-ad
-ad
-ad
-ad
-ad
-ae
-ad
-ad
-ac
 ab
 ab
 ab
 ab
 ab
+mn
+mO
+ni
+nH
+oh
+mn
+mn
+ab
+ab
+ab
+ab
+aa
 "}
 (9,1,1) = {"
+aa
+aa
 ab
 ab
 ab
@@ -2046,31 +6780,36 @@ ab
 ab
 ab
 ab
-ac
-ad
-ad
-ad
-ad
-ad
-ae
-ad
-ad
-ad
-ad
-ad
-ad
-ae
-ad
-ad
-cG
-ge
-cG
-cW
-cG
-ge
-cG
-ad
-ac
+ab
+eh
+eH
+fg
+fy
+gp
+eI
+hp
+hE
+eh
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+mp
+mP
+nk
+nI
+oi
+ou
+mn
 ab
 ab
 ab
@@ -2087,30 +6826,37 @@ ab
 ab
 ab
 ab
-ad
-aq
-aq
-aq
-aY
-fP
-gm
-bz
-bJ
-bN
-bV
-cf
-cl
-cu
-ad
-cG
-cG
-cG
-cG
-cG
-cG
-cG
-ad
 ab
+ac
+eh
+eI
+eI
+eI
+gq
+gT
+hq
+hF
+eh
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+mp
+mQ
+nl
+nJ
+oj
+ov
+mn
 ab
 ab
 ab
@@ -2118,39 +6864,46 @@ ab
 ab
 "}
 (11,1,1) = {"
+aa
+ab
+ab
+ab
+ab
 ab
 ab
 ab
 ab
 ab
 ac
+eh
+eG
+fh
+eI
+gr
+eI
+hr
+hG
+eh
 ab
 ab
 ab
-ad
-aq
-aQ
-aO
-aO
-aO
-aO
-bA
-aO
-aq
-aq
-cg
-aq
-aq
-cD
-cG
-cG
-cG
-cG
-cG
-cG
-cG
-ad
 ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+mp
+mR
+nm
+nK
+ok
+mn
+mn
 ab
 ab
 ab
@@ -2165,31 +6918,38 @@ ab
 ab
 ab
 ab
-ac
-ac
-ad
-aq
-fL
-aq
-aZ
-aq
-gn
-bz
-bK
-aq
-bW
-ad
-aS
-aq
-ad
-cG
-cG
-cG
-cG
-cG
-cG
-cG
-ad
+ab
+ab
+ab
+ab
+eh
+eH
+fg
+fz
+gs
+eh
+gj
+eh
+eh
+ab
+ab
+ab
+ab
+ab
+ab
+dG
+dG
+dG
+dG
+dG
+dG
+lS
+mn
+mo
+mn
+nL
+mn
+mn
 ab
 ab
 ab
@@ -2204,33 +6964,40 @@ ab
 ab
 ab
 ab
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-bu
-cg
-ad
-cG
-cG
-cG
-cG
-cG
-cG
-cG
-ad
-ac
+ab
+ab
+ab
+ab
+ab
+eh
+eh
+eI
+eI
+gt
+gU
+hs
+hH
+ab
+ab
+ab
+ab
+ab
+ab
+dG
+dG
+ig
+iu
+iu
+iu
+lv
+lT
+mq
+mS
+nn
+nM
+mT
+mT
+ab
 ab
 ab
 ab
@@ -2244,33 +7011,40 @@ ab
 ab
 ab
 ab
-ad
-ao
-aw
-aA
-aJ
-aR
-aU
-ba
-ad
-bh
-bB
-aS
-fS
-bO
-cf
-cm
-gm
-ad
-cG
-cG
-cG
-cG
-cG
-cG
-cG
-ad
+ab
+ab
+ab
+ab
+ab
 ac
+eh
+fi
+fA
+gu
+gV
+ht
+hH
+ab
+ab
+ab
+ab
+ab
+dG
+dG
+ig
+je
+iv
+jk
+le
+lw
+lT
+mr
+mS
+nn
+nN
+ol
+mT
+ab
 ab
 ab
 ab
@@ -2284,34 +7058,41 @@ ab
 ab
 ab
 ab
-ad
-ap
-aq
-ap
-aq
-aq
-ap
-aq
-ad
-bi
-bC
-aq
-ap
-aq
-ch
-cn
-cw
-ad
-cG
-cG
-cG
-cG
-de
-cG
-cG
-ad
-ac
-ac
+ab
+ab
+ab
+ab
+ab
+ei
+eJ
+fj
+fB
+gv
+gW
+hu
+hH
+ab
+ab
+ab
+ab
+dG
+dG
+ig
+je
+jk
+jx
+jx
+jP
+jy
+jy
+ms
+mT
+no
+nN
+ol
+ow
+ab
+ab
 ab
 ab
 ab
@@ -2323,35 +7104,42 @@ ab
 ab
 ab
 ab
+ab
 ac
-ad
-aq
-ap
-aq
-ap
-ap
-aq
-ap
-ad
-bj
-bD
-aq
-aq
-aq
-ci
-cn
-cx
-ad
-cf
-cD
-cD
-cD
-ad
-dj
-ad
+ab
+ac
+ac
 ae
-ad
-ad
+ae
+aL
+ae
+fC
+gw
+gX
+hv
+hH
+ab
+ab
+ab
+dG
+dG
+ig
+je
+jk
+jx
+jx
+kG
+lf
+lx
+jy
+jy
+jy
+np
+nO
+mT
+mT
+mT
+oF
 ab
 ab
 ab
@@ -2362,36 +7150,43 @@ ab
 ab
 ab
 ab
-ab
-ac
-ad
-ar
-ax
-aB
-ad
-aS
-aq
-bb
-ad
-bk
-bE
-aq
-bP
-bX
-ad
-fX
-ga
 ae
-aS
-cL
-bF
-cX
-df
-aq
-cU
-bu
-dt
+ae
+ae
+aL
+ae
+ae
+ae
+ej
+eK
+ae
+fD
 ad
+eh
+gj
+eh
+hW
+dG
+dG
+dG
+ig
+je
+iv
+jx
+jx
+kn
+kH
+jN
+jZ
+lU
+mt
+mU
+np
+nP
+mS
+mq
+oD
+lT
 ab
 ab
 ab
@@ -2401,37 +7196,44 @@ ab
 ab
 ab
 ab
-ab
-ab
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-aV
-ad
 ae
-bl
-bE
-aq
-bQ
-bY
-bu
-cn
-cw
-cE
+ae
 aq
 aq
 aq
+dc
 aq
-aq
-aq
-aq
-dp
-aO
-ad
+dQ
+ek
+eL
+ae
+fE
+gy
+gY
+hw
+hI
+hX
+ig
+iu
+iu
+je
+jk
+jx
+jx
+jN
+jZ
+jN
+jZ
+jN
+jZ
+kn
+mU
+nq
+nQ
+mT
+mT
+mT
+oF
 ab
 ab
 ab
@@ -2441,37 +7243,44 @@ ab
 ab
 ab
 ab
-ab
-ab
-ad
-af
-as
-fJ
-aC
-aK
-aq
+ae
 ap
-bc
-ad
-bm
-bF
-bL
-bR
-bZ
-ad
-cn
-cw
-cf
 aq
-fL
-cT
-cY
-dg
-dk
-aS
-bu
-dt
-ad
+aq
+aq
+aq
+aq
+dR
+el
+eM
+ae
+fF
+gz
+gZ
+hw
+hJ
+hY
+ih
+iv
+iM
+iv
+iv
+jx
+jL
+jY
+jN
+kI
+lg
+ly
+lV
+mu
+mU
+nr
+nR
+om
+mT
+ab
+ab
 ab
 ab
 ab
@@ -2481,37 +7290,44 @@ ab
 ab
 ab
 ab
-ab
-ab
-ad
-ag
-as
-as
-aD
-aL
-ap
+ae
 aq
-bd
-ad
-ad
-bu
-bu
-bu
-ad
-ad
-cn
-cw
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-cf
+aq
+aq
+aq
+aq
+aq
+ae
+em
+eN
+ae
+ae
+gA
+ha
+ha
+hK
+ha
+ha
+ha
+iN
+ha
+ha
+jy
+jM
+jN
+jZ
+kJ
+lh
+lz
+lW
+mv
+jy
+jy
+nS
+on
+ow
+ab
+ab
 ab
 ab
 ab
@@ -2521,37 +7337,44 @@ ab
 ab
 ab
 ab
+ae
+aq
+aq
+aq
+aq
+aq
+aq
+dS
+eo
+eO
+fk
+ae
+gB
+hb
+ha
+ha
+ha
+ii
+iw
+iO
+hB
+jl
+jz
+jN
+jZ
+ko
+kK
+li
+lA
+lX
+mw
+mV
+jy
+nu
+oo
+ox
 ab
 ab
-ad
-ah
-as
-as
-aE
-aM
-aq
-ap
-aq
-bg
-bn
-go
-go
-go
-fT
-go
-co
-cy
-go
-fT
-go
-go
-fT
-go
-gm
-dn
-dq
-aO
-dn
 ab
 ab
 ab
@@ -2561,37 +7384,44 @@ ab
 ab
 ab
 ab
-ab
-ab
 ae
-ad
-as
-as
-aF
-aL
 ap
 aq
-ap
-bg
-bo
-gp
-gp
-gp
-fU
-gp
-cp
-cz
-gp
-fU
-gp
-gp
-fU
-gp
-gn
-dn
-dr
-aO
-dn
+aq
+aq
+aq
+aq
+dS
+ep
+eP
+fl
+fG
+gE
+hc
+hx
+hL
+hZ
+ij
+ix
+iP
+hd
+jm
+jz
+jO
+jN
+kp
+kL
+lj
+lB
+lY
+lA
+mW
+jy
+nT
+op
+ox
+ab
+ab
 ab
 ab
 ab
@@ -2601,37 +7431,44 @@ ab
 ab
 ab
 ab
-ab
-ab
-ad
-ai
-as
-as
-aG
-ap
+ae
+ae
 aq
-ap
-fM
-ad
-ad
-bu
-bu
-bu
-ad
-ad
-cn
-cw
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-cf
+aq
+aq
+di
+aq
+dS
+eq
+eQ
+ae
+dQ
+gF
+hd
+hy
+hy
+ia
+ik
+if
+iQ
+hz
+hz
+jy
+jy
+ka
+kq
+kM
+lk
+lC
+lZ
+mx
+jy
+jy
+nU
+oo
+ox
+ab
+ab
 ab
 ab
 ab
@@ -2642,35 +7479,42 @@ ab
 ab
 ab
 ab
+ae
+ae
+ae
+aL
+ae
+ae
+ae
+ae
+ae
+ae
+fH
+gG
+he
+hz
+hz
+hz
+hz
+iy
+iR
+hz
+jn
+jA
+jP
+jy
+jy
+jy
+jy
+lD
+ma
+jy
+jy
+ns
+nV
+oo
+ox
 ab
-ad
-aj
-as
-fK
-aH
-aq
-ap
-aq
-be
-ad
-bp
-bG
-bM
-bS
-ca
-cj
-cn
-cw
-ae
-aS
-aq
-cU
-cZ
-dh
-ae
-ac
-ac
-ac
 ab
 ab
 ab
@@ -2683,33 +7527,40 @@ ab
 ab
 ab
 ab
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-aT
-ad
-ad
-bq
-bH
-aq
-aq
-cb
-ck
-cn
-cw
-cF
-aq
-ap
-ap
-ap
-aq
-ad
 ac
 ac
+as
+do
+dA
+dT
+er
+eR
+fm
+fI
+gH
+he
+hz
+hM
+ib
+hz
+iz
+iS
+jf
+jo
+jB
+hz
+kb
+jy
+kN
+jZ
+lE
+mb
+my
+jy
+nt
+nW
+oq
+mT
 ab
 ab
 ab
@@ -2723,35 +7574,42 @@ ab
 ab
 ab
 ab
-ad
-ak
-at
-ay
-aI
-aN
-ad
-aq
-aS
-ad
-br
-aq
-ap
-aq
-bP
-ad
-fX
-ga
-cf
-aq
-cM
-cV
-da
-aq
-ad
-ad
-ad
-ad
-ad
+ab
+as
+as
+du
+dB
+dU
+es
+eS
+fn
+fO
+gG
+hf
+hz
+hN
+ic
+il
+iA
+iT
+hz
+hz
+hz
+hz
+kc
+kr
+kO
+ll
+lF
+mc
+jy
+jy
+nu
+nX
+om
+ow
+ab
+ab
 ab
 ab
 ab
@@ -2763,35 +7621,42 @@ ab
 ab
 ab
 ab
-ad
-al
-au
-au
-au
-aO
-aT
-aq
-fN
-ad
-bs
-aq
-ap
-aq
-cc
-bu
-cn
-cw
-ad
-cH
-cN
-bH
-db
-aq
-ad
-aq
-gk
-aq
-ad
+ab
+at
+aM
+dv
+dC
+dV
+et
+eT
+fo
+fO
+gG
+hg
+hz
+hO
+hz
+hz
+iB
+iU
+jg
+jp
+jp
+jQ
+kd
+jy
+jy
+jy
+jy
+jP
+jy
+mX
+nv
+nY
+mT
+mT
+ab
+ab
 ab
 ab
 ab
@@ -2803,35 +7668,42 @@ ab
 ab
 ab
 ab
-ad
-ad
-ad
-ae
-ad
-ad
-ad
-aq
-aq
-ad
-bt
-aq
-ap
-bT
-cd
-bu
-cn
-cw
-ad
-aq
-cO
-aq
-aq
-aq
-dl
-do
-ds
-do
-ad
+ab
+at
+cA
+dw
+dD
+dX
+eu
+eU
+fn
+fH
+gG
+he
+hA
+hz
+id
+im
+iC
+iV
+hz
+hz
+hz
+hz
+ke
+jQ
+jQ
+jQ
+jp
+jp
+mz
+mY
+nw
+nZ
+mT
+ab
+ab
+ab
 ab
 ab
 ab
@@ -2843,35 +7715,42 @@ ab
 ab
 ab
 ab
-ad
-am
-au
-au
-au
-aO
-aT
-aq
-fN
-ae
-bu
-bu
-ap
-bx
-bx
-ae
-cq
-gn
-ad
-cI
-cP
-aO
-aO
-bK
-ad
-aq
-gl
-aq
-ad
+ab
+at
+cG
+dx
+dE
+dY
+ev
+eV
+fp
+fH
+gI
+he
+hz
+hz
+hz
+hz
+iD
+iW
+jh
+jo
+jC
+hz
+kf
+ks
+kP
+kQ
+kQ
+kQ
+kQ
+kT
+nx
+kR
+kQ
+kQ
+ab
+ab
 ab
 ab
 ab
@@ -2883,35 +7762,42 @@ ab
 ab
 ab
 ab
-ad
-an
-av
-az
-av
-aP
-ad
-aq
-aS
-ad
-bv
-bI
-ap
-bI
-fV
-ad
-cr
-cB
-ad
-ad
-ad
-ad
-cF
-ad
-ad
-ad
-ad
-ad
-ad
+ab
+as
+cO
+as
+dI
+dZ
+ew
+as
+cO
+as
+gJ
+hh
+hz
+hP
+ic
+in
+iE
+iX
+hz
+jq
+jA
+hO
+kg
+kt
+kQ
+kQ
+lG
+md
+mA
+mZ
+ny
+oa
+or
+kQ
+ab
+ab
 ab
 ab
 ab
@@ -2923,34 +7809,41 @@ ab
 ab
 ab
 ab
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-aW
-ad
-ad
-bw
-bx
-ap
-bx
-ce
-ad
-cs
-aq
-aq
-cJ
-cQ
-ad
-aq
-di
-di
-ad
 ab
 ab
+ac
+cO
+as
+as
+as
+as
+fq
+dy
+gK
+he
+hz
+hQ
+ie
+hz
+iF
+iY
+hz
+hz
+hz
+hz
+kh
+ha
+kQ
+lm
+lH
+me
+mB
+na
+nz
+ob
+os
+oy
+ac
 ab
 ab
 ab
@@ -2958,7 +7851,7 @@ ab
 ab
 "}
 (32,1,1) = {"
-ab
+aa
 ab
 ab
 ab
@@ -2966,31 +7859,38 @@ ab
 ab
 ab
 ac
+dy
+dK
+ea
+ex
+eW
+fr
+fW
+gL
+he
+hz
+hz
+hz
+hz
+hO
+hz
+hz
+jr
+jD
+jR
+iQ
+ku
+kR
+ln
+lI
+lI
+mC
+lI
+nA
+oc
+kQ
+kQ
 ac
-ab
-ac
-ad
-aX
-bf
-ad
-bx
-bx
-ap
-bx
-bx
-ad
-fZ
-aq
-aq
-aq
-cR
-ad
-dd
-di
-dm
-ad
-ab
-ab
 ab
 ab
 ab
@@ -2998,37 +7898,44 @@ ab
 ab
 "}
 (33,1,1) = {"
+aa
 ab
 ab
 ab
 ab
 ab
-ac
 ab
 ab
-ab
-ab
-ab
-ad
-ad
-ad
-ad
-fQ
-bI
-ap
-bU
-fV
-ad
-ct
-cC
-ct
-cK
-cS
-ad
-aq
-gi
-di
-ad
+dy
+dL
+eb
+ey
+eX
+fs
+fa
+gM
+hi
+hB
+hB
+hB
+ag
+iG
+iZ
+ji
+js
+jE
+jS
+ki
+kv
+kS
+ln
+lJ
+mf
+mD
+lI
+nB
+kQ
+kQ
 ac
 ab
 ab
@@ -3038,38 +7945,45 @@ ab
 ab
 "}
 (34,1,1) = {"
+aa
+aa
 ab
 ab
 ab
 ab
 ab
 ab
-ab
-ab
-ab
+dy
+dM
+ec
+ez
+eY
+ft
+dy
+gN
+hj
+hj
+hR
+af
+ip
+iH
+ja
+jj
+jj
+gI
+if
+kj
+kw
+kT
+lo
+lK
+kQ
+mE
+nb
+nC
+kQ
 ac
-ac
 ab
-ab
-ac
-ad
-by
-bx
-fR
-bx
-ce
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ac
 ab
 ab
 ab
@@ -3078,86 +7992,335 @@ ab
 ab
 "}
 (35,1,1) = {"
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
 aa
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+dy
+dy
+ed
+ey
+eZ
+dy
+dy
+gO
+hk
+hC
+dy
+ha
+iq
+iI
+iq
+ha
+jt
+jF
+jT
+ju
+ju
+kU
+ju
+ju
+ju
+ju
+ju
+kU
+ju
+ju
+ju
+ju
+ab
+ab
+ab
+ab
+ab
 "}
 (36,1,1) = {"
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
 aa
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ac
+dP
+dy
+eA
+fa
+dy
+fY
+gP
+gQ
+hl
+hS
+ha
+ir
+iJ
+jb
+ha
+ju
+jG
+jU
+ju
+kx
+kV
+lp
+lL
+mg
+mF
+nc
+ju
+od
+ju
+oz
+ju
+ju
+nf
+ab
+ab
+ab
 "}
 (37,1,1) = {"
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+dy
+ee
+eB
+fb
+fu
+gb
+gQ
+hl
+gQ
+hT
+ha
+is
+iK
+jc
+ha
+jv
+jH
+jV
+ju
+ky
+kW
+lq
+lM
+mh
+mG
+nd
+nD
+oe
+ot
+oA
+oE
+oG
+oH
+ab
+ab
+ab
+"}
+(38,1,1) = {"
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+dy
+ef
+eC
+fc
+fv
+fv
+gR
+hm
+hl
+hU
+ha
+it
+iL
+jd
+ha
+jw
+jI
+jW
+kk
+kz
+kX
+lr
+lN
+mi
+mH
+ne
+nE
+of
+nE
+oB
+ju
+ju
+nf
+ab
+ab
+ab
+"}
+(39,1,1) = {"
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+dy
+eg
+eD
+fd
+fw
+gc
+gS
+hn
+gQ
+hV
+ha
+ha
+ha
+ha
+ha
+ju
+jJ
+jX
+kl
+kA
+kY
+ls
+lO
+mj
+mI
+nf
+ju
+ju
+ju
+oC
+nf
+ab
+ab
+ab
+ab
+ab
+"}
+(40,1,1) = {"
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+dy
+dy
+eE
+fe
+dy
+gd
+dy
+ho
+hD
+dy
+dy
+ac
+ab
+ab
+ab
+ac
+jK
+ju
+km
+kB
+kZ
+lt
+lt
+mk
+mJ
+ng
+nF
+ld
+ju
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+"}
+(41,1,1) = {"
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+dy
+eF
+eF
+dP
+gf
+dy
+eF
+eF
+dy
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ju
+ju
+kC
+la
+lu
+lP
+ml
+mK
+kD
+nG
+og
+ju
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+"}
+(42,1,1) = {"
 aa
 ab
 ab
@@ -3171,6 +8334,41 @@ ab
 ab
 ab
 ab
+dy
+gg
+dy
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ju
+kD
+lb
+kU
+kD
+lb
+ju
+ju
+ju
+ju
+ju
+ab
+ab
+ab
+ab
+ab
+ab
+aa
+"}
+(43,1,1) = {"
+aa
 ab
 ab
 ab
@@ -3183,8 +8381,27 @@ ab
 ab
 ab
 ab
+fx
+gh
+fx
 ab
 ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ju
+kE
+lc
+ju
+lQ
+mm
+ju
 ab
 ab
 ab
@@ -3197,12 +8414,207 @@ ab
 ab
 aa
 "}
-(38,1,1) = {"
+(44,1,1) = {"
+aa
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ju
+kF
+ld
+ju
+lR
+ld
+ju
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+aa
+aa
+"}
+(45,1,1) = {"
 aa
 aa
 ab
 aa
 ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ju
+ju
+ju
+ju
+ju
+ju
+ju
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+aa
+"}
+(46,1,1) = {"
+aa
+aa
+aa
+aa
+ab
+ab
+aa
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+aa
+aa
+"}
+(47,1,1) = {"
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+aa
+aa
+"}
+(48,1,1) = {"
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
 ab
 ab
 ab

--- a/_maps/RandomRuins/LavaRuins/lavaland_surface_syndicate_base1.dmm
+++ b/_maps/RandomRuins/LavaRuins/lavaland_surface_syndicate_base1.dmm
@@ -4458,8 +4458,6 @@
 	pixel_y = -1
 	},
 /obj/effect/decal/cleanable/dirt,
-/obj/item/clothing/head/welding,
-/obj/item/pipe_dispenser,
 /turf/open/floor/plasteel/floorgrime,
 /area/ruin/unpowered/syndicate_lava_base/engineering)
 "lM" = (
@@ -4683,6 +4681,9 @@
 /obj/machinery/cell_charger,
 /obj/item/stock_parts/cell/high/plus,
 /obj/effect/decal/cleanable/dirt,
+/obj/item/pipe_dispenser{
+	pixel_y = 12
+	},
 /turf/open/floor/plasteel/floorgrime,
 /area/ruin/unpowered/syndicate_lava_base/engineering)
 "mh" = (
@@ -4902,6 +4903,8 @@
 	},
 /obj/structure/reagent_dispensers/fueltank,
 /obj/effect/decal/cleanable/dirt,
+/obj/item/clothing/head/welding,
+/obj/item/weldingtool/largetank,
 /turf/open/floor/plasteel/floorgrime,
 /area/ruin/unpowered/syndicate_lava_base/engineering)
 "mJ" = (
@@ -5090,6 +5093,7 @@
 	},
 /obj/effect/turf_decal/stripes/line,
 /obj/effect/decal/cleanable/dirt,
+/obj/machinery/portable_atmospherics/canister,
 /turf/open/floor/plasteel/floorgrime,
 /area/ruin/unpowered/syndicate_lava_base/engineering)
 "nf" = (

--- a/code/game/area/areas/ruins/lavaland.dm
+++ b/code/game/area/areas/ruins/lavaland.dm
@@ -32,42 +32,42 @@
 /area/ruin/powered/seedvault
 	icon_state = "dk_yellow"
 
-/area/ruin/syndicate_lava_base
+/area/ruin/unpowered/syndicate_lava_base
 	name = "Secret Base"
 	icon_state = "dk_yellow"
 	ambientsounds = HIGHSEC
 
-/area/ruin/syndicate_lava_base/engineering
+/area/ruin/unpowered/syndicate_lava_base/engineering
 	name = "Syndicate Lavaland Engineering"
 
-/area/ruin/syndicate_lava_base/medbay
+/area/ruin/unpowered/syndicate_lava_base/medbay
 	name = "Syndicate Lavaland Medbay"
 
-/area/ruin/syndicate_lava_base/arrivals
+/area/ruin/unpowered/syndicate_lava_base/arrivals
 	name = "Syndicate Lavaland Arrivals"
 
-/area/ruin/syndicate_lava_base/bar
+/area/ruin/unpowered/syndicate_lava_base/bar
 	name = "Syndicate Lavaland Bar"
 
-/area/ruin/syndicate_lava_base/main
+/area/ruin/unpowered/syndicate_lava_base/main
 	name = "Syndicate Lavaland Primary Hallway"
 
-/area/ruin/syndicate_lava_base/cargo
+/area/ruin/unpowered/syndicate_lava_base/cargo
 	name = "Syndicate Lavaland Cargo Bay"
 
-/area/ruin/syndicate_lava_base/chemistry
+/area/ruin/unpowered/syndicate_lava_base/chemistry
 	name = "Syndicate Lavaland Chemistry"
 
-/area/ruin/syndicate_lava_base/virology
+/area/ruin/unpowered/syndicate_lava_base/virology
 	name = "Syndicate Lavaland Virology"
 
-/area/ruin/syndicate_lava_base/testlab
+/area/ruin/unpowered/syndicate_lava_base/testlab
 	name = "Syndicate Lavaland Experimentation Lab"
 
-/area/ruin/syndicate_lava_base/dormitories
+/area/ruin/unpowered/syndicate_lava_base/dormitories
 	name = "Syndicate Lavaland Dormitories"
 
-/area/ruin/syndicate_lava_base/telecomms
+/area/ruin/unpowered/syndicate_lava_base/telecomms
 	name = "Syndicate Lavaland Telecommunications"
 
 

--- a/code/game/area/areas/ruins/lavaland.dm
+++ b/code/game/area/areas/ruins/lavaland.dm
@@ -32,9 +32,44 @@
 /area/ruin/powered/seedvault
 	icon_state = "dk_yellow"
 
-/area/ruin/powered/syndicate_lava_base
+/area/ruin/syndicate_lava_base
 	name = "Secret Base"
 	icon_state = "dk_yellow"
+	ambientsounds = HIGHSEC
+
+/area/ruin/syndicate_lava_base/engineering
+	name = "Syndicate Lavaland Engineering"
+
+/area/ruin/syndicate_lava_base/medbay
+	name = "Syndicate Lavaland Medbay"
+
+/area/ruin/syndicate_lava_base/arrivals
+	name = "Syndicate Lavaland Arrivals"
+
+/area/ruin/syndicate_lava_base/bar
+	name = "Syndicate Lavaland Bar"
+
+/area/ruin/syndicate_lava_base/main
+	name = "Syndicate Lavaland Primary Hallway"
+
+/area/ruin/syndicate_lava_base/cargo
+	name = "Syndicate Lavaland Cargo Bay"
+
+/area/ruin/syndicate_lava_base/chemistry
+	name = "Syndicate Lavaland Chemistry"
+
+/area/ruin/syndicate_lava_base/virology
+	name = "Syndicate Lavaland Virology"
+
+/area/ruin/syndicate_lava_base/testlab
+	name = "Syndicate Lavaland Experimentation Lab"
+
+/area/ruin/syndicate_lava_base/dormitories
+	name = "Syndicate Lavaland Dormitories"
+
+/area/ruin/syndicate_lava_base/telecomms
+	name = "Syndicate Lavaland Telecommunications"
+
 
 //Xeno Nest
 


### PR DESCRIPTION
Redesigned the syndicate lavaland base because I felt the current one was visually kind of uninteresting with its square, boxy shapes and neatly organized rooms. So I made it dark, dank, and a bit more stylish!

This also provides it with functioning atmospherics and power, as well as a turbine engine that people can muck around with (and possibly die to). Finally, there are a couple of UNUSED potential shuttle docks, in case someone (namely me) wants to allow shuttles to dock with this station, such as the whiteship or nuke op ship or something else I design.

The shuttle computer in cargo bay does not actually do anything or connect to any existing shuttle. It's just for show. And yes, all external airlocks have tiny fans to prevent atmos processing all the time as well as objects going off into the lava.

Overall this map is around 50x46 (I can't quite remember) whereas it was previously around 38x38.

A full view of the map:
https://www.dropbox.com/s/wp7k24mnudr0otp/scrnshot1.png?dl=0
NOTE: This map was generated via templates, it seems that loading those in doesn't appreciate the placement of catwalks on lava which have been burnt off. These SHOULD normally be present when loaded in pre-round. If not, I would like to see that changed in the future.

An in-person view from the bar to show the AESTHETICS of the base off.
![](https://i.imgur.com/ioy2db2.png)

:cl: WJohnston
add: Redesigned the entire syndicate lavaland base to be more stylish, have functioning power and atmos as well as a turbine to play with.
/:cl:
