### PR TITLE
Newly crafted stacks are merged with held stacks of the same type

### DIFF
--- a/code/modules/mob/inventory.dm
+++ b/code/modules/mob/inventory.dm
@@ -205,8 +205,26 @@
 /mob/proc/put_in_hands(obj/item/I, del_on_fail = FALSE)
 	if(!I)
 		return FALSE
+
+	// If the item is a stack and we're already holding a stack then merge
+	if (istype(I, /obj/item/stack))
+		var/obj/item/stack/I_stack = I
+		var/obj/item/stack/active_stack = get_active_held_item()
+
+		if (active_stack && istype(I_stack, active_stack.merge_type))
+			if (I_stack.merge(active_stack))
+				to_chat(usr, "<span class='notice'>Your [active_stack.name] stack now contains [active_stack.get_amount()] [active_stack.singular_name]\s.</span>")
+				return TRUE
+		else
+			var/obj/item/stack/inactive_stack = get_inactive_held_item()
+			if (inactive_stack && istype(I_stack, inactive_stack.merge_type))
+				if (I_stack.merge(inactive_stack))
+					to_chat(usr, "<span class='notice'>Your [inactive_stack.name] stack now contains [inactive_stack.get_amount()] [inactive_stack.singular_name]\s.</span>")
+					return TRUE
+
 	if(put_in_active_hand(I))
 		return TRUE
+
 	var/hand = get_empty_held_index_for_side("l")
 	if(!hand)
 		hand =  get_empty_held_index_for_side("r")

--- a/code/modules/mob/inventory.dm
+++ b/code/modules/mob/inventory.dm
@@ -211,13 +211,13 @@
 		var/obj/item/stack/I_stack = I
 		var/obj/item/stack/active_stack = get_active_held_item()
 
-		if (active_stack && istype(I_stack, active_stack.merge_type))
+		if (istype(active_stack) && istype(I_stack, active_stack.merge_type))
 			if (I_stack.merge(active_stack))
 				to_chat(usr, "<span class='notice'>Your [active_stack.name] stack now contains [active_stack.get_amount()] [active_stack.singular_name]\s.</span>")
 				return TRUE
 		else
 			var/obj/item/stack/inactive_stack = get_inactive_held_item()
-			if (inactive_stack && istype(I_stack, inactive_stack.merge_type))
+			if (istype(inactive_stack) && istype(I_stack, inactive_stack.merge_type))
 				if (I_stack.merge(inactive_stack))
 					to_chat(usr, "<span class='notice'>Your [inactive_stack.name] stack now contains [inactive_stack.get_amount()] [inactive_stack.singular_name]\s.</span>")
 					return TRUE


### PR DESCRIPTION
[Changelogs]: Whenever you crafted some metal rods or tiles the first batch would be put in inactive hand if it was empty. However any newly created items would just appear on the ground. This makes it so if the type you're creating is already in your hand then it will merge the new item into the held one

:cl: JohnGinnane
add: Newly crafted stacks are merged with held stacks of the same type.
/:cl:

[why]: Minor frustration when creating these items. Mostly a quality of life thing