### PR TITLE
Omegastation Updates & Fixes

### DIFF
--- a/_maps/map_files/OmegaStation/OmegaStation.dmm
+++ b/_maps/map_files/OmegaStation/OmegaStation.dmm
@@ -486,8 +486,10 @@
 /obj/structure/cable/white{
 	icon_state = "1-2"
 	},
-/turf/open/floor/plasteel/vault{
-	dir = 8
+/turf/open/floor/plasteel/vault/side{
+	tag = "icon-vault (NORTH)";
+	icon_state = "vault";
+	dir = 1
 	},
 /area/bridge)
 "aaY" = (
@@ -497,8 +499,10 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 6
 	},
-/turf/open/floor/plasteel/vault{
-	dir = 8
+/turf/open/floor/plasteel/vault/side{
+	tag = "icon-vault (NORTH)";
+	icon_state = "vault";
+	dir = 1
 	},
 /area/bridge)
 "aaZ" = (
@@ -518,8 +522,10 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
-/turf/open/floor/plasteel/vault{
-	dir = 5
+/turf/open/floor/plasteel/vault/side{
+	tag = "icon-vault (NORTH)";
+	icon_state = "vault";
+	dir = 1
 	},
 /area/bridge)
 "aba" = (
@@ -527,8 +533,10 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden,
-/turf/open/floor/plasteel/vault{
-	dir = 5
+/turf/open/floor/plasteel/vault/side{
+	tag = "icon-vault (NORTH)";
+	icon_state = "vault";
+	dir = 1
 	},
 /area/bridge)
 "abc" = (
@@ -541,7 +549,9 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
-/turf/open/floor/plasteel/vault{
+/turf/open/floor/plasteel/vault/side{
+	tag = "icon-vault (NORTHEAST)";
+	icon_state = "vault";
 	dir = 5
 	},
 /area/bridge)
@@ -573,8 +583,10 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 1
 	},
-/turf/open/floor/plasteel/vault{
-	dir = 5
+/turf/open/floor/plasteel/vault/side{
+	tag = "icon-vault (NORTH)";
+	icon_state = "vault";
+	dir = 1
 	},
 /area/bridge)
 "abf" = (
@@ -590,8 +602,10 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
-/turf/open/floor/plasteel/vault{
-	dir = 5
+/turf/open/floor/plasteel/vault/side{
+	tag = "icon-vault (NORTH)";
+	icon_state = "vault";
+	dir = 1
 	},
 /area/bridge)
 "abg" = (
@@ -602,8 +616,10 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/turf/open/floor/plasteel/vault{
-	dir = 8
+/turf/open/floor/plasteel/vault/side{
+	tag = "icon-vault (NORTH)";
+	icon_state = "vault";
+	dir = 1
 	},
 /area/bridge)
 "abh" = (
@@ -619,8 +635,10 @@
 /obj/structure/cable/white{
 	icon_state = "1-2"
 	},
-/turf/open/floor/plasteel/vault{
-	dir = 8
+/turf/open/floor/plasteel/vault/side{
+	tag = "icon-vault (NORTH)";
+	icon_state = "vault";
+	dir = 1
 	},
 /area/bridge)
 "abi" = (
@@ -691,8 +709,10 @@
 	},
 /area/bridge)
 "abo" = (
-/turf/open/floor/plasteel/vault{
-	dir = 8
+/turf/open/floor/plasteel/vault/side{
+	tag = "icon-vault (EAST)";
+	icon_state = "vault";
+	dir = 4
 	},
 /area/bridge)
 "abp" = (
@@ -777,7 +797,9 @@
 /obj/structure/cable/white{
 	icon_state = "1-2"
 	},
-/turf/open/floor/plasteel/vault{
+/turf/open/floor/plasteel/vault/side{
+	tag = "icon-vault (WEST)";
+	icon_state = "vault";
 	dir = 8
 	},
 /area/bridge)
@@ -786,8 +808,10 @@
 /obj/machinery/light_switch{
 	pixel_x = 24
 	},
-/turf/open/floor/plasteel/vault{
-	dir = 8
+/turf/open/floor/plasteel/vault/side{
+	tag = "icon-vault (EAST)";
+	icon_state = "vault";
+	dir = 4
 	},
 /area/bridge)
 "abA" = (
@@ -804,8 +828,10 @@
 /obj/machinery/light{
 	dir = 1
 	},
-/turf/open/floor/plasteel/vault{
-	dir = 8
+/turf/open/floor/plasteel/vault/side{
+	tag = "icon-vault (EAST)";
+	icon_state = "vault";
+	dir = 4
 	},
 /area/bridge)
 "abC" = (
@@ -825,7 +851,11 @@
 /obj/structure/cable/white{
 	icon_state = "4-8"
 	},
-/turf/open/floor/plasteel/vault,
+/turf/open/floor/plasteel/vault/side{
+	tag = "icon-vault (EAST)";
+	icon_state = "vault";
+	dir = 4
+	},
 /area/bridge)
 "abE" = (
 /obj/structure/cable/white{
@@ -865,7 +895,9 @@
 /obj/machinery/light{
 	dir = 1
 	},
-/turf/open/floor/plasteel/vault{
+/turf/open/floor/plasteel/vault/side{
+	tag = "icon-vault (WEST)";
+	icon_state = "vault";
 	dir = 8
 	},
 /area/bridge)
@@ -874,7 +906,9 @@
 /obj/machinery/light_switch{
 	pixel_x = -24
 	},
-/turf/open/floor/plasteel/vault{
+/turf/open/floor/plasteel/vault/side{
+	tag = "icon-vault (WEST)";
+	icon_state = "vault";
 	dir = 8
 	},
 /area/bridge)
@@ -886,8 +920,10 @@
 /obj/structure/extinguisher_cabinet{
 	pixel_x = 26
 	},
-/turf/open/floor/plasteel/vault{
-	dir = 8
+/turf/open/floor/plasteel/vault/side{
+	tag = "icon-vault (EAST)";
+	icon_state = "vault";
+	dir = 4
 	},
 /area/bridge)
 "abJ" = (
@@ -914,20 +950,19 @@
 /area/crew_quarters/heads/hop)
 "abL" = (
 /obj/structure/rack,
-/obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/cobweb,
 /obj/effect/spawner/lootdrop/maintenance{
 	lootcount = 2;
 	name = "2maintenance loot spawner"
 	},
 /obj/effect/turf_decal/bot,
+/obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plasteel,
 /area/maintenance/starboard/fore)
 "abM" = (
 /obj/structure/reagent_dispensers/watertank,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/bot,
+/obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plasteel,
 /area/maintenance/starboard/fore)
 "abN" = (
@@ -935,12 +970,11 @@
 /turf/closed/wall,
 /area/hallway/primary/central)
 "abO" = (
-/obj/structure/closet/emcloset/anchored,
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/light/small{
-	dir = 1
+/obj/machinery/space_heater,
+/obj/effect/turf_decal/stripes/line{
+	dir = 10
 	},
-/obj/effect/turf_decal/stripes/line,
+/obj/effect/decal/cleanable/cobweb/cobweb2,
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "abP" = (
@@ -959,7 +993,6 @@
 	name = "Asteroid"
 	})
 "abS" = (
-/obj/effect/decal/cleanable/dirt,
 /obj/item/ore/glass,
 /turf/open/floor/plating/astplate,
 /area/ruin/unpowered{
@@ -994,7 +1027,6 @@
 /turf/open/floor/plasteel/white,
 /area/security/detectives_office)
 "abW" = (
-/obj/effect/decal/cleanable/dirt,
 /obj/structure/closet/firecloset,
 /obj/machinery/light/small{
 	dir = 1
@@ -1091,14 +1123,22 @@
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
 	dir = 8
 	},
-/turf/open/floor/plasteel/vault,
+/turf/open/floor/plasteel/vault/side{
+	tag = "icon-vault (WEST)";
+	icon_state = "vault";
+	dir = 8
+	},
 /area/bridge)
 "ace" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
-/turf/open/floor/plasteel/vault,
+/turf/open/floor/plasteel/vault/side{
+	tag = "icon-vault (EAST)";
+	icon_state = "vault";
+	dir = 4
+	},
 /area/bridge)
 "acf" = (
 /obj/structure/cable/white{
@@ -1115,8 +1155,10 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
-/turf/open/floor/plasteel/vault{
-	dir = 8
+/turf/open/floor/plasteel/vault/side{
+	tag = "icon-vault (EAST)";
+	icon_state = "vault";
+	dir = 4
 	},
 /area/bridge)
 "ach" = (
@@ -1157,7 +1199,9 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
-/turf/open/floor/plasteel/vault{
+/turf/open/floor/plasteel/vault/side{
+	tag = "icon-vault (WEST)";
+	icon_state = "vault";
 	dir = 8
 	},
 /area/bridge)
@@ -1165,14 +1209,22 @@
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
 	dir = 4
 	},
-/turf/open/floor/plasteel/vault,
+/turf/open/floor/plasteel/vault/side{
+	tag = "icon-vault (WEST)";
+	icon_state = "vault";
+	dir = 8
+	},
 /area/bridge)
 "acn" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/structure/cable/white{
 	icon_state = "1-2"
 	},
-/turf/open/floor/plasteel/vault,
+/turf/open/floor/plasteel/vault/side{
+	tag = "icon-vault (EAST)";
+	icon_state = "vault";
+	dir = 4
+	},
 /area/bridge)
 "aco" = (
 /obj/structure/table/wood,
@@ -1193,8 +1245,10 @@
 	dir = 2;
 	name = "command camera"
 	},
-/turf/open/floor/plasteel/vault{
-	dir = 8
+/turf/open/floor/plasteel/vault/side{
+	tag = "icon-vault (EAST)";
+	icon_state = "vault";
+	dir = 4
 	},
 /area/crew_quarters/heads/hop)
 "acp" = (
@@ -1256,11 +1310,9 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 6
 	},
-/obj/effect/turf_decal/delivery,
-/turf/open/floor/plasteel,
+/turf/open/floor/plating,
 /area/maintenance/starboard/fore)
 "acv" = (
-/obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
@@ -1268,7 +1320,28 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "acw" = (
-/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
+	tag = "icon-manifold (NORTH)";
+	icon_state = "manifold";
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/hallway/primary/central)
+"acx" = (
+/obj/effect/decal/cleanable/blood/old,
+/obj/machinery/atmospherics/components/unary/vent_pump/on{
+	dir = 8
+	},
+/obj/effect/landmark/xeno_spawn,
+/obj/effect/turf_decal/stripes/corner{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/corner{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
+"acy" = (
 /obj/machinery/door/airlock/external{
 	name = "External Airlock";
 	req_access_txt = "13"
@@ -1276,30 +1349,8 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/obj/effect/turf_decal/stripes/line{
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/central)
-"acx" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/blood/old,
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
-	dir = 8
-	},
-/obj/effect/landmark/xeno_spawn,
-/obj/effect/turf_decal/delivery,
-/turf/open/floor/plasteel,
-/area/hallway/primary/central)
-"acy" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/door/airlock/external{
-	name = "External Airlock";
-	req_access_txt = "13"
 	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -1310,7 +1361,6 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "acz" = (
-/obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/stripes/line{
 	dir = 9
 	},
@@ -1342,10 +1392,11 @@
 	name = "Asteroid"
 	})
 "acE" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/blood/old,
-/turf/open/floor/plating,
+/turf/open/floor/plating{
+	broken = 1;
+	icon_state = "platingdmg1"
+	},
 /area/ruin/unpowered{
 	name = "Asteroid"
 	})
@@ -1356,7 +1407,6 @@
 	})
 "acG" = (
 /obj/structure/door_assembly/door_assembly_mhatch,
-/obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
@@ -1369,7 +1419,6 @@
 	})
 "acH" = (
 /obj/effect/decal/cleanable/cobweb/cobweb2,
-/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
 /area/ruin/unpowered{
 	name = "Asteroid"
@@ -1426,10 +1475,7 @@
 /area/security/detectives_office)
 "acN" = (
 /obj/effect/landmark/blobstart,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/delivery,
-/turf/open/floor/plasteel,
+/turf/open/floor/plating,
 /area/maintenance/fore)
 "acO" = (
 /obj/structure/mirror{
@@ -1498,8 +1544,10 @@
 /obj/structure/cable/white{
 	icon_state = "2-4"
 	},
-/turf/open/floor/plasteel/vault{
-	dir = 5
+/turf/open/floor/plasteel/vault/side{
+	tag = "icon-vault (WEST)";
+	icon_state = "vault";
+	dir = 8
 	},
 /area/bridge)
 "acV" = (
@@ -1507,8 +1555,10 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/manifold4w/scrubbers/hidden,
-/turf/open/floor/plasteel/vault{
-	dir = 5
+/turf/open/floor/plasteel/vault/side{
+	tag = "icon-vault (EAST)";
+	icon_state = "vault";
+	dir = 4
 	},
 /area/bridge)
 "acW" = (
@@ -1541,8 +1591,10 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
-/turf/open/floor/plasteel/vault{
-	dir = 5
+/turf/open/floor/plasteel/vault/side{
+	tag = "icon-vault (NORTH)";
+	icon_state = "vault";
+	dir = 1
 	},
 /area/bridge)
 "acY" = (
@@ -1644,8 +1696,10 @@
 /obj/structure/cable/white{
 	icon_state = "4-8"
 	},
-/turf/open/floor/plasteel/vault{
-	dir = 5
+/turf/open/floor/plasteel/vault/side{
+	tag = "icon-vault (WEST)";
+	icon_state = "vault";
+	dir = 8
 	},
 /area/bridge)
 "adf" = (
@@ -1658,8 +1712,10 @@
 /obj/structure/cable/white{
 	icon_state = "2-8"
 	},
-/turf/open/floor/plasteel/vault{
-	dir = 5
+/turf/open/floor/plasteel/vault/side{
+	tag = "icon-vault (EAST)";
+	icon_state = "vault";
+	dir = 4
 	},
 /area/bridge)
 "adg" = (
@@ -1672,8 +1728,10 @@
 	icon_state = "2-4"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/turf/open/floor/plasteel/vault{
-	dir = 8
+/turf/open/floor/plasteel/vault/side{
+	tag = "icon-vault (EAST)";
+	icon_state = "vault";
+	dir = 4
 	},
 /area/crew_quarters/heads/hop)
 "adh" = (
@@ -1739,7 +1797,7 @@
 /turf/open/floor/plasteel/white,
 /area/crew_quarters/heads/hop)
 "adm" = (
-/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/structure/cable/white{
 	icon_state = "0-2"
@@ -1750,9 +1808,9 @@
 	areastring = "/area/maintenance/starboard/fore";
 	pixel_x = 26
 	},
-/turf/open/floor/plasteel/neutral/corner{
-	dir = 8;
-	heat_capacity = 1e+006
+/turf/open/floor/plating{
+	tag = "icon-platingdmg2";
+	icon_state = "platingdmg2"
 	},
 /area/maintenance/starboard/fore)
 "adn" = (
@@ -1798,7 +1856,6 @@
 /turf/open/floor/plasteel,
 /area/shuttle/supply)
 "adv" = (
-/obj/effect/decal/cleanable/dirt,
 /obj/structure/closet/crate{
 	icon_state = "crateopen";
 	opened = 1
@@ -1809,17 +1866,18 @@
 	name = "Asteroid"
 	})
 "adw" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating,
+/turf/open/floor/plating{
+	burnt = 1;
+	icon_state = "panelscorched"
+	},
 /area/ruin/unpowered{
 	name = "Asteroid"
 	})
 "adx" = (
-/obj/effect/decal/cleanable/dirt,
 /obj/item/clothing/suit/space/orange,
 /obj/item/clothing/head/helmet/space/orange,
 /obj/effect/landmark/revenantspawn,
-/turf/open/floor/plasteel/neutral,
+/turf/open/floor/plating,
 /area/ruin/unpowered{
 	name = "Asteroid"
 	})
@@ -1879,10 +1937,11 @@
 /turf/open/floor/plasteel/white,
 /area/security/detectives_office)
 "adF" = (
-/obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/components/unary/vent_pump/on,
 /obj/effect/landmark/xeno_spawn,
-/turf/open/floor/plating,
+/turf/open/floor/plating{
+	icon_state = "platingdmg1"
+	},
 /area/maintenance/fore)
 "adG" = (
 /obj/structure/toilet{
@@ -1985,8 +2044,10 @@
 	name = "Station Intercom";
 	pixel_x = 28
 	},
-/turf/open/floor/plasteel/vault{
-	dir = 5
+/turf/open/floor/plasteel/vault/side{
+	tag = "icon-vault (EAST)";
+	icon_state = "vault";
+	dir = 4
 	},
 /area/bridge)
 "adO" = (
@@ -2027,8 +2088,10 @@
 /obj/structure/sign/nanotrasen{
 	pixel_x = -32
 	},
-/turf/open/floor/plasteel/vault{
-	dir = 5
+/turf/open/floor/plasteel/vault/side{
+	tag = "icon-vault (WEST)";
+	icon_state = "vault";
+	dir = 8
 	},
 /area/bridge)
 "adT" = (
@@ -2038,8 +2101,10 @@
 /obj/structure/cable/white{
 	icon_state = "1-2"
 	},
-/turf/open/floor/plasteel/vault{
-	dir = 5
+/turf/open/floor/plasteel/vault/side{
+	tag = "icon-vault (EAST)";
+	icon_state = "vault";
+	dir = 4
 	},
 /area/bridge)
 "adU" = (
@@ -2111,7 +2176,6 @@
 /obj/structure/sign/nanotrasen{
 	pixel_y = 32
 	},
-/obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/stripes/line{
 	dir = 2
 	},
@@ -2159,7 +2223,6 @@
 	dir = 8;
 	id = "cargounload"
 	},
-/obj/effect/decal/cleanable/dirt,
 /obj/structure/sign/directions/engineering{
 	desc = "A sign that shows there are doors here. There are doors everywhere!";
 	icon_state = "doors";
@@ -2234,20 +2297,20 @@
 /turf/open/floor/plasteel,
 /area/shuttle/supply)
 "ael" = (
-/obj/effect/decal/cleanable/dirt,
 /obj/structure/closet/crate,
 /obj/effect/spawner/lootdrop/maintenance{
 	lootcount = 2;
 	name = "2maintenance loot spawner"
 	},
-/turf/open/floor/plasteel/neutral/side{
-	dir = 10
-	},
+/turf/open/floor/plating,
 /area/ruin/unpowered{
 	name = "Asteroid"
 	})
 "aem" = (
-/turf/open/floor/plasteel/neutral/side,
+/turf/open/floor/plating{
+	broken = 1;
+	icon_state = "platingdmg3"
+	},
 /area/ruin/unpowered{
 	name = "Asteroid"
 	})
@@ -2270,9 +2333,10 @@
 	name = "Asteroid"
 	})
 "aep" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/neutral/corner{
-	dir = 4
+/turf/open/floor/plating,
+/turf/open/floor/plating{
+	tag = "icon-platingdmg2";
+	icon_state = "platingdmg2"
 	},
 /area/ruin/unpowered{
 	name = "Asteroid"
@@ -2306,11 +2370,7 @@
 /turf/open/floor/plating,
 /area/security/detectives_office)
 "aet" = (
-/obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
 /obj/machinery/power/apc{
 	dir = 8;
 	name = "Fore Maintenace APC";
@@ -2321,7 +2381,10 @@
 /obj/structure/cable/white{
 	icon_state = "0-2"
 	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plating{
+	broken = 1;
+	icon_state = "platingdmg3"
+	},
 /area/maintenance/fore)
 "aeu" = (
 /obj/structure/sign/nanotrasen,
@@ -2365,8 +2428,10 @@
 /obj/machinery/light{
 	dir = 4
 	},
-/turf/open/floor/plasteel/vault{
-	dir = 5
+/turf/open/floor/plasteel/vault/side{
+	tag = "icon-vault (EAST)";
+	icon_state = "vault";
+	dir = 4
 	},
 /area/bridge)
 "aez" = (
@@ -2388,14 +2453,23 @@
 /obj/structure/sign/nanotrasen{
 	pixel_x = -32
 	},
-/turf/open/floor/plasteel/vault{
-	dir = 8
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/turf/open/floor/plasteel/vault/side{
+	tag = "icon-vault (EAST)";
+	icon_state = "vault";
+	dir = 4
 	},
 /area/ai_monitored/turret_protected/ai)
 "aeA" = (
 /obj/structure/cable/white{
 	icon_state = "1-2"
 	},
+/obj/machinery/ai_slipper{
+	uses = 10
+	},
+/obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel/vault,
 /area/ai_monitored/turret_protected/ai)
 "aeB" = (
@@ -2409,6 +2483,9 @@
 /obj/machinery/newscaster/security_unit{
 	pixel_x = 4;
 	pixel_y = 33
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
 	},
 /turf/open/floor/plasteel/vault{
 	dir = 6
@@ -2457,9 +2534,6 @@
 /obj/structure/cable/white{
 	icon_state = "1-4"
 	},
-/obj/machinery/ai_slipper{
-	uses = 10
-	},
 /obj/machinery/requests_console{
 	department = "AI";
 	departmentType = 5;
@@ -2467,6 +2541,7 @@
 	pixel_x = 30;
 	pixel_y = 30
 	},
+/obj/effect/turf_decal/delivery,
 /turf/open/floor/circuit/green,
 /area/ai_monitored/turret_protected/ai)
 "aeD" = (
@@ -2480,6 +2555,9 @@
 /obj/structure/cable/white{
 	icon_state = "4-8"
 	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
 /turf/open/floor/plasteel/vault{
 	dir = 10
 	},
@@ -2491,6 +2569,10 @@
 /obj/structure/cable/white{
 	icon_state = "2-8"
 	},
+/obj/machinery/ai_slipper{
+	uses = 10
+	},
+/obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel/vault,
 /area/ai_monitored/turret_protected/ai)
 "aeF" = (
@@ -2508,7 +2590,12 @@
 	pixel_x = -3;
 	pixel_y = -3
 	},
-/turf/open/floor/plasteel/vault{
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/turf/open/floor/plasteel/vault/side{
+	tag = "icon-vault (WEST)";
+	icon_state = "vault";
 	dir = 8
 	},
 /area/ai_monitored/turret_protected/ai)
@@ -2520,8 +2607,10 @@
 /obj/machinery/computer/security/telescreen/entertainment{
 	pixel_x = -32
 	},
-/turf/open/floor/plasteel/vault{
-	dir = 5
+/turf/open/floor/plasteel/vault/side{
+	tag = "icon-vault (WEST)";
+	icon_state = "vault";
+	dir = 8
 	},
 /area/bridge)
 "aeH" = (
@@ -2531,8 +2620,10 @@
 /obj/structure/cable/white{
 	icon_state = "1-2"
 	},
-/turf/open/floor/plasteel/vault{
-	dir = 5
+/turf/open/floor/plasteel/vault/side{
+	tag = "icon-vault (EAST)";
+	icon_state = "vault";
+	dir = 4
 	},
 /area/bridge)
 "aeI" = (
@@ -2549,9 +2640,7 @@
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden,
 /obj/structure/bed/dogbed/ian,
 /mob/living/simple_animal/pet/dog/corgi/Ian,
-/turf/open/floor/plasteel/vault{
-	dir = 5
-	},
+/turf/open/floor/plasteel/vault/side,
 /area/crew_quarters/heads/hop)
 "aeK" = (
 /obj/structure/cable/white{
@@ -2561,25 +2650,19 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
-/turf/open/floor/plasteel/vault{
-	dir = 5
-	},
+/turf/open/floor/plasteel/vault/side,
 /area/crew_quarters/heads/hop)
 "aeL" = (
 /obj/machinery/photocopier,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 8
 	},
-/turf/open/floor/plasteel/vault{
-	dir = 8
-	},
+/turf/open/floor/plasteel/vault/side,
 /area/crew_quarters/heads/hop)
 "aeM" = (
 /obj/structure/filingcabinet/security,
 /obj/item/folder/documents,
-/turf/open/floor/plasteel/vault{
-	dir = 8
-	},
+/turf/open/floor/plasteel/vault/side,
 /area/crew_quarters/heads/hop)
 "aeN" = (
 /obj/structure/table/wood,
@@ -2597,9 +2680,7 @@
 	areastring = "/area/crew_quarters/heads/hop";
 	pixel_y = 25
 	},
-/turf/open/floor/plasteel/vault{
-	dir = 8
-	},
+/turf/open/floor/plasteel/vault/side,
 /area/crew_quarters/heads/hop)
 "aeO" = (
 /obj/structure/table/wood,
@@ -2616,7 +2697,9 @@
 	pixel_x = 28;
 	pixel_y = 24
 	},
-/turf/open/floor/plasteel/vault{
+/turf/open/floor/plasteel/vault/corner{
+	tag = "icon-vaultcorner (WEST)";
+	icon_state = "vaultcorner";
 	dir = 8
 	},
 /area/crew_quarters/heads/hop)
@@ -2626,7 +2709,6 @@
 	pixel_x = -32;
 	supply_display = 1
 	},
-/obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/loading_area,
 /turf/open/floor/plasteel,
 /area/quartermaster/storage)
@@ -2651,7 +2733,6 @@
 /turf/open/floor/plasteel,
 /area/quartermaster/storage)
 "aeU" = (
-/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/brown{
 	dir = 4
 	},
@@ -2676,8 +2757,6 @@
 /turf/open/floor/plasteel,
 /area/quartermaster/storage)
 "aeX" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
 /obj/machinery/light/small,
 /obj/effect/turf_decal/stripes/line{
 	dir = 2
@@ -2689,7 +2768,6 @@
 	name = "Supply Shuttle Airlock";
 	req_access_txt = "31"
 	},
-/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
 /area/shuttle/supply)
 "afa" = (
@@ -2700,15 +2778,13 @@
 /area/shuttle/supply)
 "afb" = (
 /obj/structure/door_assembly/door_assembly_mhatch,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/stripes/line{
 	dir = 2
 	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plating,
 /area/ruin/unpowered{
 	name = "Asteroid"
 	})
@@ -2724,8 +2800,10 @@
 /obj/structure/table/wood,
 /obj/item/device/taperecorder,
 /obj/item/restraints/handcuffs,
-/turf/open/floor/plasteel/vault{
-	dir = 8
+/turf/open/floor/plasteel/vault/side{
+	tag = "icon-vault (EAST)";
+	icon_state = "vault";
+	dir = 4
 	},
 /area/security/detectives_office)
 "afe" = (
@@ -2782,16 +2860,14 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plating,
 /area/maintenance/fore)
 "afj" = (
-/obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/effect/turf_decal/delivery,
 /obj/structure/cable/white{
 	icon_state = "1-2"
 	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plating,
 /area/maintenance/fore)
 "afk" = (
 /obj/structure/extinguisher_cabinet{
@@ -2799,7 +2875,11 @@
 	},
 /obj/machinery/suit_storage_unit/captain,
 /obj/effect/turf_decal/stripes/end,
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/vault/side{
+	tag = "icon-vault (EAST)";
+	icon_state = "vault";
+	dir = 4
+	},
 /area/crew_quarters/heads/captain/private)
 "afl" = (
 /obj/item/twohanded/required/kirbyplants{
@@ -2858,8 +2938,10 @@
 	dir = 8;
 	name = "command camera"
 	},
-/turf/open/floor/plasteel/vault{
-	dir = 5
+/turf/open/floor/plasteel/vault/side{
+	tag = "icon-vault (EAST)";
+	icon_state = "vault";
+	dir = 4
 	},
 /area/bridge)
 "afq" = (
@@ -2882,8 +2964,13 @@
 	network = list("Sat");
 	start_active = 1
 	},
-/turf/open/floor/plasteel/vault{
-	dir = 8
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/turf/open/floor/plasteel/vault/side{
+	tag = "icon-vault (EAST)";
+	icon_state = "vault";
+	dir = 4
 	},
 /area/ai_monitored/turret_protected/ai)
 "afr" = (
@@ -2909,7 +2996,12 @@
 	pixel_x = -3;
 	pixel_y = -3
 	},
-/turf/open/floor/plasteel/vault{
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/turf/open/floor/plasteel/vault/side{
+	tag = "icon-vault (WEST)";
+	icon_state = "vault";
 	dir = 8
 	},
 /area/ai_monitored/turret_protected/ai)
@@ -2926,8 +3018,10 @@
 	dir = 4;
 	name = "command camera"
 	},
-/turf/open/floor/plasteel/vault{
-	dir = 5
+/turf/open/floor/plasteel/vault/side{
+	tag = "icon-vault (WEST)";
+	icon_state = "vault";
+	dir = 8
 	},
 /area/bridge)
 "afu" = (
@@ -2941,8 +3035,10 @@
 /obj/structure/cable/white{
 	icon_state = "1-2"
 	},
-/turf/open/floor/plasteel/vault{
-	dir = 5
+/turf/open/floor/plasteel/vault/side{
+	tag = "icon-vault (EAST)";
+	icon_state = "vault";
+	dir = 4
 	},
 /area/bridge)
 "afv" = (
@@ -2979,9 +3075,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
-/turf/open/floor/plasteel/vault{
-	dir = 5
-	},
+/turf/open/floor/wood,
 /area/crew_quarters/heads/hop)
 "afx" = (
 /obj/structure/cable/white{
@@ -2994,8 +3088,8 @@
 	icon_state = "1-8"
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden,
-/turf/open/floor/plasteel/vault{
-	dir = 5
+/turf/open/floor/wood{
+	icon_state = "wood-broken"
 	},
 /area/crew_quarters/heads/hop)
 "afy" = (
@@ -3009,9 +3103,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
-/turf/open/floor/plasteel/vault{
-	dir = 5
-	},
+/turf/open/floor/wood,
 /area/crew_quarters/heads/hop)
 "afz" = (
 /obj/structure/cable/white{
@@ -3028,9 +3120,7 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 8
 	},
-/turf/open/floor/plasteel/vault{
-	dir = 5
-	},
+/turf/open/floor/wood,
 /area/crew_quarters/heads/hop)
 "afA" = (
 /obj/machinery/computer/secure_data{
@@ -3044,7 +3134,9 @@
 	dir = 8;
 	name = "command camera"
 	},
-/turf/open/floor/plasteel/vault{
+/turf/open/floor/plasteel/vault/side{
+	tag = "icon-vault (WEST)";
+	icon_state = "vault";
 	dir = 8
 	},
 /area/crew_quarters/heads/hop)
@@ -3066,7 +3158,6 @@
 	},
 /area/quartermaster/storage)
 "afD" = (
-/obj/effect/decal/cleanable/dirt,
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/plasteel/neutral,
 /area/quartermaster/storage)
@@ -3082,7 +3173,6 @@
 /turf/open/floor/plasteel/neutral,
 /area/quartermaster/storage)
 "afH" = (
-/obj/effect/decal/cleanable/dirt,
 /obj/machinery/conveyor_switch{
 	id = "cargounload"
 	},
@@ -3141,7 +3231,6 @@
 	name = "Asteroid"
 	})
 "afM" = (
-/obj/effect/decal/cleanable/dirt,
 /obj/item/ore/iron,
 /obj/structure/barricade/wooden,
 /turf/open/floor/plating/astplate,
@@ -3149,8 +3238,6 @@
 	name = "Asteroid"
 	})
 "afN" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/blood/old,
 /turf/open/floor/plating/astplate,
 /area/ruin/unpowered{
@@ -3172,8 +3259,10 @@
 	name = "Station Intercom";
 	pixel_x = -26
 	},
-/turf/open/floor/plasteel/vault{
-	dir = 8
+/turf/open/floor/plasteel/vault/side{
+	tag = "icon-vault (EAST)";
+	icon_state = "vault";
+	dir = 4
 	},
 /area/security/detectives_office)
 "afQ" = (
@@ -3223,14 +3312,12 @@
 /obj/structure/cable/white{
 	icon_state = "2-4"
 	},
-/obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/effect/turf_decal/delivery,
 /obj/effect/landmark/event_spawn,
 /obj/structure/cable/white{
 	icon_state = "1-2"
 	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plating,
 /area/maintenance/fore)
 "afW" = (
 /obj/machinery/door/firedoor,
@@ -3255,7 +3342,11 @@
 	icon_state = "4-8"
 	},
 /obj/effect/turf_decal/delivery,
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/vault/side{
+	tag = "icon-vault (EAST)";
+	icon_state = "vault";
+	dir = 4
+	},
 /area/crew_quarters/heads/captain/private)
 "afY" = (
 /obj/machinery/requests_console{
@@ -3321,16 +3412,20 @@
 /obj/structure/cable/white{
 	icon_state = "1-2"
 	},
-/turf/open/floor/plasteel/vault{
-	dir = 5
+/turf/open/floor/plasteel/vault/side{
+	tag = "icon-vault (WEST)";
+	icon_state = "vault";
+	dir = 8
 	},
 /area/bridge)
 "agf" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 4
 	},
-/turf/open/floor/plasteel/vault{
-	dir = 5
+/turf/open/floor/plasteel/vault/side{
+	tag = "icon-vault (EAST)";
+	icon_state = "vault";
+	dir = 4
 	},
 /area/bridge)
 "agg" = (
@@ -3357,9 +3452,14 @@
 	},
 /obj/item/clothing/neck/stethoscope,
 /obj/item/stack/sheet/mineral/diamond,
-/obj/item/gun/ballistic/automatic/pistol/deagle,
-/turf/open/floor/plasteel/vault{
-	dir = 5
+/obj/item/areaeditor/blueprints,
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/turf/open/floor/plasteel/vault/side{
+	tag = "icon-vault (EAST)";
+	icon_state = "vault";
+	dir = 4
 	},
 /area/ai_monitored/turret_protected/ai)
 "agh" = (
@@ -3369,7 +3469,6 @@
 	},
 /area/ai_monitored/turret_protected/ai)
 "agi" = (
-/obj/machinery/doomsday_device,
 /obj/structure/cable/white{
 	icon_state = "0-2"
 	},
@@ -3380,6 +3479,7 @@
 	areastring = "/area/ai_monitored/turret_protected/ai";
 	pixel_y = 24
 	},
+/obj/machinery/nuclearbomb/selfdestruct,
 /turf/open/floor/circuit/green,
 /area/ai_monitored/turret_protected/ai)
 "agj" = (
@@ -3396,14 +3496,21 @@
 /obj/structure/sign/nosmoking_2{
 	pixel_x = 32
 	},
-/turf/open/floor/plasteel/vault{
-	dir = 5
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/turf/open/floor/plasteel/vault/side{
+	tag = "icon-vault (WEST)";
+	icon_state = "vault";
+	dir = 8
 	},
 /area/ai_monitored/turret_protected/ai)
 "agl" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/turf/open/floor/plasteel/vault{
-	dir = 5
+/turf/open/floor/plasteel/vault/side{
+	tag = "icon-vault (WEST)";
+	icon_state = "vault";
+	dir = 8
 	},
 /area/bridge)
 "agm" = (
@@ -3434,25 +3541,19 @@
 /obj/item/stack/packageWrap,
 /obj/item/book/manual/wiki/security_space_law,
 /obj/item/hand_labeler,
-/turf/open/floor/plasteel/vault{
-	dir = 8
-	},
+/turf/open/floor/wood,
 /area/crew_quarters/heads/hop)
 "agp" = (
 /obj/machinery/pdapainter,
 /obj/structure/cable/white{
 	icon_state = "1-2"
 	},
-/turf/open/floor/plasteel/vault{
-	dir = 5
-	},
+/turf/open/floor/wood,
 /area/crew_quarters/heads/hop)
 "agq" = (
 /obj/machinery/vending/cart,
 /obj/machinery/light,
-/turf/open/floor/plasteel/vault{
-	dir = 8
-	},
+/turf/open/floor/wood,
 /area/crew_quarters/heads/hop)
 "agr" = (
 /obj/structure/table/wood,
@@ -3466,8 +3567,8 @@
 	c_tag = "Head of Personnel's Office";
 	dir = 1
 	},
-/turf/open/floor/plasteel/vault{
-	dir = 8
+/turf/open/floor/wood{
+	icon_state = "wood-broken5"
 	},
 /area/crew_quarters/heads/hop)
 "ags" = (
@@ -3477,8 +3578,8 @@
 	pixel_y = -42
 	},
 /obj/effect/landmark/start/head_of_personnel,
-/turf/open/floor/plasteel/vault{
-	dir = 5
+/turf/open/floor/wood{
+	icon_state = "wood-broken6"
 	},
 /area/crew_quarters/heads/hop)
 "agt" = (
@@ -3506,26 +3607,26 @@
 	pixel_y = -24;
 	req_access_txt = "57"
 	},
-/turf/open/floor/plasteel/vault{
+/turf/open/floor/plasteel/vault/side{
+	tag = "icon-vault (WEST)";
+	icon_state = "vault";
 	dir = 8
 	},
 /area/crew_quarters/heads/hop)
 "agu" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/effect/decal/cleanable/dirt,
 /obj/structure/cable/white{
 	icon_state = "1-2"
 	},
-/turf/open/floor/plasteel/neutral/corner{
-	dir = 8;
-	heat_capacity = 1e+006
+/turf/open/floor/plating{
+	burnt = 1;
+	icon_state = "panelscorched"
 	},
 /area/maintenance/starboard/fore)
 "agv" = (
 /obj/structure/extinguisher_cabinet{
 	pixel_x = -26
 	},
-/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/brown{
 	dir = 8
 	},
@@ -3578,7 +3679,6 @@
 /turf/open/floor/plasteel,
 /area/quartermaster/storage)
 "agC" = (
-/obj/effect/decal/cleanable/dirt,
 /obj/machinery/light/small{
 	dir = 1
 	},
@@ -3604,7 +3704,6 @@
 /turf/closed/wall/mineral/titanium,
 /area/shuttle/supply)
 "agE" = (
-/obj/effect/decal/cleanable/dirt,
 /obj/item/ore/silver,
 /obj/item/ore/iron,
 /turf/open/floor/plating/astplate,
@@ -3615,7 +3714,6 @@
 /turf/closed/wall/r_wall,
 /area/security/brig)
 "agG" = (
-/obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/oil,
 /turf/open/floor/plating,
 /area/ruin/unpowered{
@@ -3644,8 +3742,10 @@
 /obj/machinery/light{
 	dir = 8
 	},
-/turf/open/floor/plasteel/vault{
-	dir = 8
+/turf/open/floor/plasteel/vault/side{
+	tag = "icon-vault (EAST)";
+	icon_state = "vault";
+	dir = 4
 	},
 /area/security/detectives_office)
 "agJ" = (
@@ -3688,13 +3788,15 @@
 /turf/open/floor/plasteel/grimy,
 /area/security/detectives_office)
 "agN" = (
+/turf/open/floor/plating,
 /obj/structure/cable/white{
 	icon_state = "1-2"
 	},
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/turf/open/floor/plating,
+/turf/open/floor/plating{
+	tag = "icon-platingdmg2";
+	icon_state = "platingdmg2"
+	},
 /area/maintenance/fore)
 "agO" = (
 /obj/machinery/light{
@@ -3711,7 +3813,11 @@
 	icon_state = "0-4"
 	},
 /obj/effect/turf_decal/delivery,
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/vault/side{
+	tag = "icon-vault (EAST)";
+	icon_state = "vault";
+	dir = 4
+	},
 /area/crew_quarters/heads/captain/private)
 "agP" = (
 /obj/structure/cable/white{
@@ -3811,8 +3917,10 @@
 /obj/structure/cable/white{
 	icon_state = "1-2"
 	},
-/turf/open/floor/plasteel/vault{
-	dir = 5
+/turf/open/floor/plasteel/vault/side{
+	tag = "icon-vault (WEST)";
+	icon_state = "vault";
+	dir = 8
 	},
 /area/bridge)
 "agW" = (
@@ -3820,8 +3928,10 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 8
 	},
-/turf/open/floor/plasteel/vault{
-	dir = 5
+/turf/open/floor/plasteel/vault/side{
+	tag = "icon-vault (EAST)";
+	icon_state = "vault";
+	dir = 4
 	},
 /area/bridge)
 "agX" = (
@@ -3831,8 +3941,13 @@
 	name = "Station Intercom";
 	pixel_x = -26
 	},
-/turf/open/floor/plasteel/vault{
-	dir = 8
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/turf/open/floor/plasteel/vault/side{
+	tag = "icon-vault (EAST)";
+	icon_state = "vault";
+	dir = 4
 	},
 /area/ai_monitored/turret_protected/ai)
 "agY" = (
@@ -3864,6 +3979,7 @@
 	icon_state = "2-4"
 	},
 /obj/effect/landmark/start/cyborg,
+/obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel/vault{
 	dir = 5
 	},
@@ -3900,7 +4016,12 @@
 	network = list("Sat");
 	start_active = 1
 	},
-/turf/open/floor/plasteel/vault{
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/turf/open/floor/plasteel/vault/side{
+	tag = "icon-vault (WEST)";
+	icon_state = "vault";
 	dir = 8
 	},
 /area/ai_monitored/turret_protected/ai)
@@ -3908,8 +4029,10 @@
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
 	dir = 8
 	},
-/turf/open/floor/plasteel/vault{
-	dir = 5
+/turf/open/floor/plasteel/vault/side{
+	tag = "icon-vault (WEST)";
+	icon_state = "vault";
+	dir = 8
 	},
 /area/bridge)
 "ahf" = (
@@ -3920,8 +4043,10 @@
 /obj/structure/cable/white{
 	icon_state = "1-2"
 	},
-/turf/open/floor/plasteel/vault{
-	dir = 5
+/turf/open/floor/plasteel/vault/side{
+	tag = "icon-vault (EAST)";
+	icon_state = "vault";
+	dir = 4
 	},
 /area/bridge)
 "ahg" = (
@@ -3959,12 +4084,13 @@
 /turf/open/floor/plasteel,
 /area/crew_quarters/heads/hop)
 "ahj" = (
-/obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/structure/cable/white{
 	icon_state = "1-2"
 	},
-/turf/open/floor/plasteel/neutral/corner,
+/turf/open/floor/plating{
+	icon_state = "platingdmg1"
+	},
 /area/maintenance/starboard/fore)
 "ahk" = (
 /obj/machinery/firealarm{
@@ -3975,7 +4101,6 @@
 	pixel_x = -24;
 	pixel_y = -24
 	},
-/obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel,
 /area/quartermaster/storage)
@@ -3999,8 +4124,6 @@
 	dir = 4;
 	id = "cargoload"
 	},
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/effect/turf_decal/stripes/line{
 	dir = 9
@@ -4013,7 +4136,6 @@
 	dir = 4;
 	id = "cargoload"
 	},
-/obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/effect/turf_decal/stripes/line{
 	dir = 2
@@ -4028,7 +4150,6 @@
 	dir = 4;
 	id = "cargoload"
 	},
-/obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/stripes/line{
 	dir = 2
 	},
@@ -4042,7 +4163,6 @@
 	dir = 4;
 	id = "cargoload"
 	},
-/obj/effect/decal/cleanable/dirt,
 /obj/machinery/door/poddoor{
 	id = "cargoload";
 	name = "supply dock loading door"
@@ -4061,7 +4181,6 @@
 	id = "cargoload"
 	},
 /obj/structure/plasticflaps,
-/obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/stripes/line{
 	dir = 2
 	},
@@ -4094,14 +4213,13 @@
 /obj/structure/sign/nanotrasen{
 	pixel_y = 32
 	},
-/obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 4
 	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 6
 	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/vault/side,
 /area/security/brig)
 "ahw" = (
 /obj/structure/reagent_dispensers/peppertank{
@@ -4111,7 +4229,7 @@
 	dir = 10
 	},
 /obj/effect/turf_decal/delivery,
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/vault/side,
 /area/security/brig)
 "ahx" = (
 /obj/machinery/ai_status_display{
@@ -4124,7 +4242,7 @@
 	dir = 6
 	},
 /obj/effect/turf_decal/delivery,
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/vault/side,
 /area/security/brig)
 "ahy" = (
 /obj/machinery/suit_storage_unit/security,
@@ -4138,10 +4256,9 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 10
 	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/vault/side,
 /area/security/brig)
 "ahz" = (
-/obj/effect/decal/cleanable/dirt,
 /obj/structure/reagent_dispensers/fueltank,
 /obj/effect/turf_decal/stripes/line{
 	dir = 10
@@ -4155,8 +4272,6 @@
 /obj/item/clothing/suit/fire/firefighter,
 /obj/item/clothing/mask/gas,
 /obj/item/clothing/head/hardhat/red,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/stripes/line{
 	dir = 6
 	},
@@ -4173,7 +4288,11 @@
 /obj/structure/cable/white{
 	icon_state = "2-4"
 	},
-/turf/open/floor/plasteel/vault,
+/turf/open/floor/plasteel/vault/side{
+	tag = "icon-vault (EAST)";
+	icon_state = "vault";
+	dir = 4
+	},
 /area/security/detectives_office)
 "ahC" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -4236,10 +4355,8 @@
 /obj/structure/cable/white{
 	icon_state = "1-2"
 	},
-/obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/effect/turf_decal/delivery,
-/turf/open/floor/plasteel,
+/turf/open/floor/plating,
 /area/maintenance/fore)
 "ahH" = (
 /obj/structure/sign/securearea{
@@ -4249,7 +4366,12 @@
 /obj/effect/turf_decal/stripes/end{
 	dir = 1
 	},
-/turf/open/floor/plasteel,
+/obj/item/gun/energy/e_gun/hos,
+/turf/open/floor/plasteel/vault/side{
+	tag = "icon-vault (EAST)";
+	icon_state = "vault";
+	dir = 4
+	},
 /area/crew_quarters/heads/captain/private)
 "ahI" = (
 /obj/machinery/computer/communications{
@@ -4318,15 +4440,22 @@
 	pixel_x = 24
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/turf/open/floor/plasteel/vault{
-	dir = 8
+/turf/open/floor/plasteel/vault/side{
+	tag = "icon-vault (EAST)";
+	icon_state = "vault";
+	dir = 4
 	},
 /area/bridge)
 "ahP" = (
 /obj/structure/table/reinforced,
 /obj/item/aiModule/supplied/freeform,
-/turf/open/floor/plasteel/vault{
-	dir = 8
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/turf/open/floor/plasteel/vault/side{
+	tag = "icon-vault (EAST)";
+	icon_state = "vault";
+	dir = 4
 	},
 /area/ai_monitored/turret_protected/ai)
 "ahQ" = (
@@ -4370,7 +4499,12 @@
 	pixel_x = -3;
 	pixel_y = -3
 	},
-/turf/open/floor/plasteel/vault{
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/turf/open/floor/plasteel/vault/side{
+	tag = "icon-vault (WEST)";
+	icon_state = "vault";
 	dir = 8
 	},
 /area/ai_monitored/turret_protected/ai)
@@ -4389,8 +4523,10 @@
 /obj/structure/cable/white{
 	icon_state = "1-2"
 	},
-/turf/open/floor/plasteel/vault{
-	dir = 8
+/turf/open/floor/plasteel/vault/side{
+	tag = "icon-vault (EAST)";
+	icon_state = "vault";
+	dir = 4
 	},
 /area/bridge)
 "ahY" = (
@@ -4429,7 +4565,6 @@
 	req_access_txt = "0";
 	req_one_access_txt = "48;50"
 	},
-/obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/stripes/line{
 	dir = 2
 	},
@@ -4443,7 +4578,6 @@
 	dir = 1;
 	id = "cargoload"
 	},
-/obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/structure/plasticflaps,
 /obj/effect/turf_decal/stripes/line{
@@ -4460,7 +4594,6 @@
 /turf/open/floor/plating,
 /area/quartermaster/storage)
 "aig" = (
-/obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/stripes/line{
 	dir = 10
 	},
@@ -4482,7 +4615,6 @@
 /turf/open/floor/plasteel,
 /area/shuttle/supply)
 "aik" = (
-/obj/effect/decal/cleanable/dirt,
 /obj/structure/barricade/wooden,
 /turf/open/floor/plating/astplate,
 /area/ruin/unpowered{
@@ -4515,8 +4647,11 @@
 /obj/structure/extinguisher_cabinet{
 	pixel_x = -26
 	},
-/turf/open/floor/plasteel/vault{
-	dir = 8
+/obj/effect/turf_decal/bot,
+/turf/open/floor/plasteel/darkred/corner{
+	tag = "icon-darkredcorners (NORTH)";
+	icon_state = "darkredcorners";
+	dir = 1
 	},
 /area/security/brig)
 "ain" = (
@@ -4530,6 +4665,9 @@
 	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/security/brig)
@@ -4560,8 +4698,11 @@
 /obj/structure/sign/nosmoking_2{
 	pixel_y = 32
 	},
-/turf/open/floor/plasteel/vault{
-	dir = 8
+/obj/effect/turf_decal/bot,
+/turf/open/floor/plasteel/darkred/corner{
+	tag = "icon-darkredcorners (EAST)";
+	icon_state = "darkredcorners";
+	dir = 4
 	},
 /area/security/brig)
 "aip" = (
@@ -4674,7 +4815,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plating,
 /area/maintenance/fore)
 "aiy" = (
 /obj/machinery/door/firedoor,
@@ -4799,7 +4940,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plating,
 /area/maintenance/starboard/fore)
 "aiI" = (
 /obj/structure/filingcabinet/filingcabinet,
@@ -4812,7 +4953,6 @@
 	},
 /area/quartermaster/storage)
 "aiJ" = (
-/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/brown{
 	dir = 1
 	},
@@ -4824,7 +4964,6 @@
 	},
 /area/quartermaster/storage)
 "aiL" = (
-/obj/effect/decal/cleanable/dirt,
 /obj/machinery/conveyor_switch{
 	id = "cargoload"
 	},
@@ -4840,7 +4979,6 @@
 	dir = 1;
 	id = "cargoload"
 	},
-/obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/effect/turf_decal/stripes/end,
 /turf/open/floor/plating,
@@ -4889,14 +5027,20 @@
 /obj/machinery/status_display{
 	pixel_x = -32
 	},
-/turf/open/floor/plasteel/vault{
-	dir = 8
+/obj/effect/turf_decal/bot,
+/turf/open/floor/plasteel/darkred/corner{
+	tag = "icon-darkredcorners (NORTH)";
+	icon_state = "darkredcorners";
+	dir = 1
 	},
 /area/security/brig)
 "aiS" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/security/brig)
@@ -4906,8 +5050,11 @@
 /obj/item/clothing/suit/armor/laserproof,
 /obj/item/gun/energy/temperature/security,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on,
-/turf/open/floor/plasteel/vault{
-	dir = 8
+/obj/effect/turf_decal/bot,
+/turf/open/floor/plasteel/darkred/corner{
+	tag = "icon-darkredcorners (EAST)";
+	icon_state = "darkredcorners";
+	dir = 4
 	},
 /area/security/brig)
 "aiU" = (
@@ -5340,11 +5487,9 @@
 	},
 /area/hallway/primary/central)
 "ajH" = (
-/obj/effect/decal/cleanable/dirt,
 /obj/structure/plasticflaps{
 	opacity = 1
 	},
-/obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/delivery,
 /turf/open/floor/plasteel,
 /area/quartermaster/storage)
@@ -5361,7 +5506,6 @@
 	},
 /area/quartermaster/storage)
 "ajK" = (
-/obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -5410,7 +5554,6 @@
 /turf/open/floor/plating/airless,
 /area/shuttle/supply)
 "ajQ" = (
-/obj/effect/decal/cleanable/dirt,
 /obj/item/ore/iron,
 /turf/open/floor/plating/astplate,
 /area/ruin/unpowered{
@@ -5431,8 +5574,11 @@
 	name = "Station Intercom";
 	pixel_x = -26
 	},
-/turf/open/floor/plasteel/vault{
-	dir = 8
+/obj/effect/turf_decal/bot,
+/turf/open/floor/plasteel/darkred/corner{
+	tag = "icon-darkredcorners (NORTH)";
+	icon_state = "darkredcorners";
+	dir = 1
 	},
 /area/security/brig)
 "ajS" = (
@@ -5442,6 +5588,9 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/security/brig)
@@ -5478,8 +5627,11 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/turf/open/floor/plasteel/vault{
-	dir = 8
+/obj/effect/turf_decal/bot,
+/turf/open/floor/plasteel/darkred/corner{
+	tag = "icon-darkredcorners (EAST)";
+	icon_state = "darkredcorners";
+	dir = 4
 	},
 /area/security/brig)
 "ajU" = (
@@ -6228,7 +6380,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/freezer,
 /area/hallway/primary/central)
 "alf" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -6414,7 +6566,6 @@
 	id = "evashutters";
 	name = "E.V.A. Storage Shutters"
 	},
-/obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/effect/turf_decal/stripes/line{
 	dir = 2
@@ -6468,7 +6619,6 @@
 /turf/open/floor/plasteel,
 /area/quartermaster/storage)
 "alC" = (
-/obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 4
 	},
@@ -6504,8 +6654,6 @@
 	},
 /area/quartermaster/storage)
 "alG" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/blood/old,
 /obj/effect/landmark/revenantspawn,
 /turf/open/floor/plating,
@@ -6674,7 +6822,6 @@
 	},
 /area/hallway/primary/central)
 "alT" = (
-/obj/effect/decal/cleanable/dirt,
 /obj/structure/table,
 /obj/item/storage/firstaid/regular,
 /obj/structure/extinguisher_cabinet{
@@ -6684,14 +6831,12 @@
 	pixel_y = 32
 	},
 /obj/effect/turf_decal/bot,
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/freezer,
 /area/hallway/primary/central)
 "alU" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/effect/turf_decal/delivery,
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/freezer,
 /area/hallway/primary/central)
 "alV" = (
 /obj/structure/urinal{
@@ -6701,26 +6846,23 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/bot,
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/freezer,
 /area/hallway/primary/central)
 "alW" = (
 /obj/structure/urinal{
 	pixel_y = 28
 	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating,
+/turf/open/floor/plasteel/freezer,
 /area/hallway/primary/central)
 "alX" = (
-/obj/effect/decal/cleanable/dirt,
 /obj/structure/closet/crate/bin,
 /obj/machinery/light_switch{
 	pixel_y = 24
 	},
-/turf/open/floor/plating,
+/turf/open/floor/plasteel/freezer,
 /area/hallway/primary/central)
 "alY" = (
 /obj/machinery/shieldwallgen,
-/obj/effect/decal/cleanable/dirt,
 /obj/machinery/button/door{
 	id = "teleportershutters";
 	name = "Teleporter Shutters";
@@ -6728,10 +6870,13 @@
 	req_access_txt = "19"
 	},
 /obj/effect/turf_decal/delivery,
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/vault/side{
+	tag = "icon-vault (EAST)";
+	icon_state = "vault";
+	dir = 4
+	},
 /area/teleporter)
 "alZ" = (
-/obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 1
 	},
@@ -6768,7 +6913,11 @@
 	c_tag = "Teleporter"
 	},
 /obj/effect/turf_decal/delivery,
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/vault/side{
+	tag = "icon-vault (WEST)";
+	icon_state = "vault";
+	dir = 8
+	},
 /area/teleporter)
 "amd" = (
 /obj/structure/cable/white{
@@ -6793,7 +6942,11 @@
 	icon_state = "1-2"
 	},
 /obj/effect/turf_decal/delivery,
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/vault/side{
+	tag = "icon-vault (NORTHEAST)";
+	icon_state = "vault";
+	dir = 5
+	},
 /area/hallway/primary/central)
 "amg" = (
 /turf/open/floor/plasteel/neutral/corner{
@@ -6830,7 +6983,11 @@
 	icon_state = "1-2"
 	},
 /obj/effect/turf_decal/delivery,
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/vault/side{
+	tag = "icon-vault (NORTHWEST)";
+	icon_state = "vault";
+	dir = 9
+	},
 /area/hallway/primary/central)
 "amm" = (
 /obj/structure/cable/white{
@@ -6856,12 +7013,13 @@
 /obj/structure/cable/white{
 	icon_state = "4-8"
 	},
-/turf/open/floor/plasteel/vault{
-	dir = 8
+/turf/open/floor/plasteel/vault/side{
+	tag = "icon-vault (EAST)";
+	icon_state = "vault";
+	dir = 4
 	},
 /area/ai_monitored/storage/eva)
 "amp" = (
-/obj/effect/decal/cleanable/dirt,
 /obj/structure/cable/white{
 	icon_state = "1-8"
 	},
@@ -6896,14 +7054,15 @@
 /obj/item/storage/toolbox/mechanical,
 /obj/item/stack/cable_coil/white,
 /obj/item/device/multitool,
-/obj/effect/decal/cleanable/dirt,
 /obj/machinery/button/door{
 	id = "evashutters";
 	name = "E.V.A. Shutters";
 	pixel_x = 26;
 	req_access_txt = "19"
 	},
-/turf/open/floor/plasteel/vault{
+/turf/open/floor/plasteel/vault/side{
+	tag = "icon-vault (WEST)";
+	icon_state = "vault";
 	dir = 8
 	},
 /area/ai_monitored/storage/eva)
@@ -7003,7 +7162,6 @@
 /turf/open/floor/plating,
 /area/shuttle/mining)
 "amG" = (
-/obj/effect/decal/cleanable/dirt,
 /obj/structure/table,
 /obj/item/clothing/mask/gas,
 /obj/item/clothing/mask/gas,
@@ -7117,7 +7275,7 @@
 	pixel_x = -12
 	},
 /obj/effect/turf_decal/bot,
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/freezer,
 /area/hallway/primary/central)
 "amP" = (
 /obj/machinery/firealarm{
@@ -7128,11 +7286,10 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 1
 	},
-/turf/open/floor/plasteel/neutral/side,
+/turf/open/floor/plasteel/freezer,
 /area/hallway/primary/central)
 "amQ" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/neutral/side,
+/turf/open/floor/plasteel/freezer,
 /area/hallway/primary/central)
 "amR" = (
 /obj/machinery/airalarm{
@@ -7140,16 +7297,15 @@
 	pixel_y = -22
 	},
 /obj/machinery/light/small,
-/turf/open/floor/plasteel/neutral/side,
+/turf/open/floor/plasteel/freezer,
 /area/hallway/primary/central)
 "amS" = (
-/obj/effect/decal/cleanable/dirt,
 /obj/machinery/camera{
 	c_tag = "Locker Room Toilets";
 	dir = 8;
 	network = list("SS13")
 	},
-/turf/open/floor/plating,
+/turf/open/floor/plasteel/freezer,
 /area/hallway/primary/central)
 "amT" = (
 /obj/structure/table/reinforced,
@@ -7165,8 +7321,10 @@
 	dir = 4;
 	name = "command camera"
 	},
-/turf/open/floor/plasteel/vault{
-	dir = 8
+/turf/open/floor/plasteel/vault/side{
+	tag = "icon-vault (EAST)";
+	icon_state = "vault";
+	dir = 4
 	},
 /area/teleporter)
 "amU" = (
@@ -7197,7 +7355,9 @@
 /area/teleporter)
 "amX" = (
 /obj/machinery/teleport/hub,
-/turf/open/floor/plasteel/vault{
+/turf/open/floor/plasteel/vault/side{
+	tag = "icon-vault (WEST)";
+	icon_state = "vault";
 	dir = 8
 	},
 /area/teleporter)
@@ -7206,7 +7366,7 @@
 /turf/closed/wall/r_wall,
 /area/teleporter)
 "amZ" = (
-/obj/machinery/vending/snack,
+/obj/machinery/vending/snack/random,
 /obj/structure/sign/nanotrasen{
 	pixel_y = -32
 	},
@@ -7214,7 +7374,11 @@
 	icon_state = "1-8"
 	},
 /obj/effect/turf_decal/delivery,
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/vault/side{
+	tag = "icon-vault (EAST)";
+	icon_state = "vault";
+	dir = 4
+	},
 /area/hallway/primary/central)
 "ana" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -7242,7 +7406,11 @@
 	icon_state = "1-4"
 	},
 /obj/effect/turf_decal/delivery,
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/vault/side{
+	tag = "icon-vault (WEST)";
+	icon_state = "vault";
+	dir = 8
+	},
 /area/hallway/primary/central)
 "ane" = (
 /obj/structure/sign/electricshock,
@@ -7256,7 +7424,6 @@
 /turf/open/floor/plasteel,
 /area/ai_monitored/storage/eva)
 "ang" = (
-/obj/effect/decal/cleanable/dirt,
 /obj/structure/cable/white{
 	icon_state = "1-2"
 	},
@@ -7287,7 +7454,6 @@
 /area/ai_monitored/storage/eva)
 "anj" = (
 /obj/machinery/suit_storage_unit/standard_unit,
-/obj/effect/decal/cleanable/dirt,
 /obj/machinery/firealarm{
 	dir = 4;
 	icon_state = "fire0";
@@ -7369,7 +7535,6 @@
 	name = "Station Intercom";
 	pixel_y = 26
 	},
-/obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/stripes/line{
 	dir = 10
 	},
@@ -7377,8 +7542,6 @@
 /area/quartermaster/miningdock)
 "anr" = (
 /obj/machinery/mineral/equipment_vendor,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plasteel,
 /area/quartermaster/miningdock)
@@ -7393,7 +7556,6 @@
 	pixel_y = 26
 	},
 /obj/structure/closet/secure_closet/miner,
-/obj/effect/decal/cleanable/dirt,
 /obj/structure/cable/white{
 	icon_state = "0-2"
 	},
@@ -7420,7 +7582,6 @@
 /area/shuttle/mining)
 "anv" = (
 /obj/machinery/computer/shuttle/mining,
-/obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
@@ -7428,7 +7589,6 @@
 /area/shuttle/mining)
 "anw" = (
 /obj/structure/table/reinforced,
-/obj/effect/decal/cleanable/dirt,
 /obj/item/crowbar/red,
 /obj/item/wrench,
 /obj/item/tank/internals/emergency_oxygen/engi,
@@ -7608,7 +7768,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/freezer,
 /area/hallway/primary/central)
 "anK" = (
 /obj/machinery/door/airlock{
@@ -7637,8 +7797,10 @@
 	},
 /obj/structure/closet/crate/engineering,
 /obj/item/hand_tele,
-/turf/open/floor/plasteel/vault{
-	dir = 8
+/turf/open/floor/plasteel/vault/side{
+	tag = "icon-vault (EAST)";
+	icon_state = "vault";
+	dir = 4
 	},
 /area/teleporter)
 "anM" = (
@@ -7671,7 +7833,9 @@
 /obj/machinery/status_display{
 	pixel_x = 32
 	},
-/turf/open/floor/plasteel/vault{
+/turf/open/floor/plasteel/vault/side{
+	tag = "icon-vault (WEST)";
+	icon_state = "vault";
 	dir = 8
 	},
 /area/teleporter)
@@ -7769,7 +7933,6 @@
 	name = "E.V.A. RC";
 	pixel_x = 32
 	},
-/obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/machinery/camera{
 	c_tag = "Bridge - E.V.A. Storage";
@@ -7782,7 +7945,7 @@
 /turf/open/floor/plasteel,
 /area/ai_monitored/storage/eva)
 "anY" = (
-/turf/closed/wall,
+/turf/closed/wall/rust,
 /area/ai_monitored/storage/eva)
 "anZ" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -7867,8 +8030,6 @@
 /area/hallway/primary/central)
 "aoh" = (
 /obj/machinery/door/firedoor,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
@@ -7886,8 +8047,6 @@
 	pixel_x = -24;
 	pixel_y = 24
 	},
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
@@ -7898,7 +8057,6 @@
 /turf/open/floor/plasteel,
 /area/quartermaster/miningdock)
 "aoj" = (
-/obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 8
 	},
@@ -7907,7 +8065,6 @@
 	},
 /area/quartermaster/miningdock)
 "aok" = (
-/obj/effect/decal/cleanable/dirt,
 /obj/structure/cable/white{
 	icon_state = "1-2"
 	},
@@ -7917,13 +8074,11 @@
 	},
 /area/quartermaster/miningdock)
 "aol" = (
-/obj/effect/decal/cleanable/dirt,
 /obj/structure/ore_box,
 /obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel,
 /area/quartermaster/miningdock)
 "aom" = (
-/obj/effect/decal/cleanable/dirt,
 /obj/structure/closet/emcloset,
 /obj/machinery/light/small{
 	dir = 1
@@ -7948,7 +8103,6 @@
 /turf/open/floor/plasteel/neutral,
 /area/shuttle/mining)
 "aop" = (
-/obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/blood/old,
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -8014,7 +8168,11 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 5
 	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/vault/side{
+	tag = "icon-vault (EAST)";
+	icon_state = "vault";
+	dir = 4
+	},
 /area/security/brig)
 "aow" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -8091,7 +8249,6 @@
 	},
 /area/hallway/primary/central)
 "aoC" = (
-/obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/vomit/old,
 /obj/structure/toilet{
 	dir = 8
@@ -8101,10 +8258,9 @@
 	},
 /obj/machinery/light/small,
 /obj/effect/landmark/revenantspawn,
-/turf/open/floor/plating,
+/turf/open/floor/plasteel/freezer,
 /area/hallway/primary/central)
 "aoD" = (
-/obj/effect/decal/cleanable/dirt,
 /obj/structure/toilet{
 	dir = 8
 	},
@@ -8114,10 +8270,9 @@
 /obj/machinery/light/small,
 /obj/effect/landmark/blobstart,
 /obj/effect/turf_decal/bot,
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/freezer,
 /area/hallway/primary/central)
 "aoE" = (
-/obj/effect/decal/cleanable/dirt,
 /obj/structure/toilet{
 	dir = 8
 	},
@@ -8127,7 +8282,7 @@
 /obj/machinery/light/small,
 /obj/effect/landmark/start/assistant,
 /obj/effect/turf_decal/bot,
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/freezer,
 /area/hallway/primary/central)
 "aoF" = (
 /obj/structure/table/reinforced,
@@ -8138,8 +8293,10 @@
 	dir = 4;
 	pixel_x = -22
 	},
-/turf/open/floor/plasteel/vault{
-	dir = 8
+/turf/open/floor/plasteel/vault/side{
+	tag = "icon-vault (EAST)";
+	icon_state = "vault";
+	dir = 4
 	},
 /area/teleporter)
 "aoG" = (
@@ -8166,13 +8323,14 @@
 /obj/machinery/newscaster{
 	pixel_x = 32
 	},
-/turf/open/floor/plasteel/vault{
+/turf/open/floor/plasteel/vault/side{
+	tag = "icon-vault (WEST)";
+	icon_state = "vault";
 	dir = 8
 	},
 /area/teleporter)
 "aoJ" = (
 /obj/machinery/droneDispenser,
-/obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/stripes/line{
 	dir = 10
 	},
@@ -8180,15 +8338,12 @@
 /area/maintenance/port/central)
 "aoK" = (
 /obj/structure/table,
-/obj/effect/decal/cleanable/dirt,
 /obj/item/stack/sheet/metal{
 	amount = 30
 	},
 /obj/item/stack/sheet/glass{
 	amount = 30
 	},
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 6
 	},
@@ -8200,7 +8355,6 @@
 /obj/item/crowbar/red,
 /obj/item/wrench,
 /obj/item/tank/internals/emergency_oxygen/engi,
-/obj/effect/decal/cleanable/dirt,
 /obj/effect/spawner/lootdrop/maintenance,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
@@ -8221,6 +8375,14 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/delivery,
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/structure/table,
+/obj/item/stack/packageWrap,
+/obj/item/stack/cable_coil/white,
+/obj/item/hand_labeler,
+/obj/item/hand_labeler_refill,
 /turf/open/floor/plasteel,
 /area/crew_quarters/bar/atrium)
 "aoO" = (
@@ -8268,6 +8430,9 @@
 	icon_state = "4-8"
 	},
 /obj/effect/turf_decal/bot,
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/bar/atrium)
 "aoS" = (
@@ -8275,7 +8440,6 @@
 	name = "Maintenance Hatch";
 	req_access_txt = "12"
 	},
-/obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
@@ -8288,18 +8452,20 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plating,
 /area/maintenance/starboard/central)
 "aoT" = (
-/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
 /obj/structure/cable/white{
 	icon_state = "4-8"
 	},
-/obj/effect/turf_decal/delivery,
-/turf/open/floor/plasteel,
+/turf/open/floor/plating{
+	tag = "icon-platingdmg2";
+	icon_state = "platingdmg2"
+	},
 /area/maintenance/starboard/central)
 "aoU" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -8308,22 +8474,21 @@
 /obj/structure/cable/white{
 	icon_state = "2-8"
 	},
-/turf/open/floor/plasteel/caution{
-	dir = 1
-	},
+/turf/open/floor/plating,
 /area/maintenance/starboard/central)
 "aoV" = (
-/obj/machinery/shieldgen,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/stripes/line{
 	dir = 9
+	},
+/obj/structure/rack,
+/obj/item/storage/box/lights/mixed,
+/obj/item/stack/rods{
+	amount = 25
 	},
 /turf/open/floor/plasteel,
 /area/maintenance/starboard/central)
 "aoW" = (
 /obj/machinery/suit_storage_unit/standard_unit,
-/obj/effect/decal/cleanable/dirt,
 /obj/machinery/airalarm{
 	dir = 4;
 	pixel_x = -22
@@ -8446,7 +8611,6 @@
 /turf/open/floor/plasteel/brown/corner,
 /area/hallway/primary/central)
 "aph" = (
-/obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
@@ -8498,7 +8662,6 @@
 	},
 /area/quartermaster/miningdock)
 "apl" = (
-/obj/effect/decal/cleanable/dirt,
 /obj/structure/cable/white{
 	icon_state = "1-8"
 	},
@@ -8507,7 +8670,6 @@
 	},
 /area/quartermaster/miningdock)
 "apm" = (
-/obj/effect/decal/cleanable/dirt,
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/external{
 	name = "Mining Dock Airlock";
@@ -8523,9 +8685,11 @@
 /turf/open/floor/plasteel,
 /area/quartermaster/miningdock)
 "apn" = (
-/obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/stripes/line{
 	dir = 2
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/miningdock)
@@ -8656,7 +8820,11 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/vault/side{
+	tag = "icon-vault (EAST)";
+	icon_state = "vault";
+	dir = 4
+	},
 /area/security/brig)
 "apz" = (
 /obj/effect/landmark/start/security_officer,
@@ -8793,7 +8961,6 @@
 /area/storage/primary)
 "apK" = (
 /obj/machinery/shieldwallgen,
-/obj/effect/decal/cleanable/dirt,
 /obj/machinery/light_switch{
 	pixel_x = -24
 	},
@@ -8801,10 +8968,13 @@
 	pixel_y = -28
 	},
 /obj/effect/turf_decal/delivery,
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/vault/side{
+	tag = "icon-vault (EAST)";
+	icon_state = "vault";
+	dir = 4
+	},
 /area/teleporter)
 "apL" = (
-/obj/effect/decal/cleanable/dirt,
 /obj/machinery/status_display{
 	pixel_y = -32
 	},
@@ -8814,7 +8984,6 @@
 /turf/open/floor/plasteel,
 /area/teleporter)
 "apM" = (
-/obj/effect/decal/cleanable/dirt,
 /obj/machinery/power/apc{
 	dir = 2;
 	name = "Teleporter APC";
@@ -8841,7 +9010,6 @@
 /area/teleporter)
 "apO" = (
 /obj/machinery/shieldwallgen,
-/obj/effect/decal/cleanable/dirt,
 /obj/item/device/radio/intercom{
 	name = "Station Intercom";
 	pixel_x = 28
@@ -8850,15 +9018,19 @@
 	pixel_y = -32
 	},
 /obj/effect/turf_decal/delivery,
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/vault/side{
+	tag = "icon-vault (WEST)";
+	icon_state = "vault";
+	dir = 8
+	},
 /area/teleporter)
 "apP" = (
-/obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 6
 	},
-/turf/open/floor/plasteel/yellow/side{
-	dir = 9
+/turf/open/floor/plating{
+	broken = 1;
+	icon_state = "platingdmg1"
 	},
 /area/maintenance/port/central)
 "apQ" = (
@@ -8870,9 +9042,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/item/storage/box/lights/mixed,
-/turf/open/floor/plasteel/yellow/side{
-	dir = 5
-	},
+/turf/open/floor/plating,
 /area/maintenance/port/central)
 "apR" = (
 /obj/effect/decal/cleanable/dirt,
@@ -8890,7 +9060,6 @@
 	name = "Maintenance Hatch";
 	req_access_txt = "12"
 	},
-/obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
@@ -8906,7 +9075,6 @@
 /turf/open/floor/plasteel,
 /area/maintenance/port/central)
 "apT" = (
-/obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
@@ -8917,6 +9085,9 @@
 	icon_state = "4-8"
 	},
 /obj/effect/turf_decal/bot,
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/bar/atrium)
 "apU" = (
@@ -8946,12 +9117,20 @@
 /area/crew_quarters/bar/atrium)
 "apW" = (
 /obj/machinery/atmospherics/pipe/manifold4w/supply/hidden,
+/obj/effect/turf_decal/loading_area{
+	dir = 8
+	},
+/obj/effect/turf_decal/stripes/corner,
+/obj/effect/turf_decal/stripes/corner{
+	dir = 8
+	},
 /turf/open/floor/plasteel/neutral/corner,
 /area/crew_quarters/bar/atrium)
 "apX" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden,
 /obj/effect/turf_decal/delivery,
 /obj/machinery/rnd/protolathe/department/service,
+/obj/effect/turf_decal/stripes/box,
 /turf/open/floor/plasteel,
 /area/crew_quarters/bar/atrium)
 "apY" = (
@@ -8961,15 +9140,12 @@
 /turf/closed/wall,
 /area/maintenance/starboard/central)
 "apZ" = (
-/obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
-/obj/effect/turf_decal/bot,
-/turf/open/floor/plasteel,
+/turf/open/floor/plating,
 /area/maintenance/starboard/central)
 "aqa" = (
-/obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -8977,17 +9153,28 @@
 /obj/structure/cable/white{
 	icon_state = "1-2"
 	},
-/turf/open/floor/plasteel/caution,
+/turf/open/floor/plating{
+	burnt = 1;
+	icon_state = "panelscorched"
+	},
 /area/maintenance/starboard/central)
 "aqb" = (
-/obj/machinery/shieldgen,
-/obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 10
 	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 10
 	},
+/obj/structure/closet/crate{
+	name = "emergency supplies crate"
+	},
+/obj/item/storage/toolbox/emergency,
+/obj/item/tank/internals/oxygen,
+/obj/item/tank/internals/oxygen,
+/obj/item/device/flashlight,
+/obj/item/device/flashlight,
+/obj/item/device/flashlight/flare,
+/obj/item/device/flashlight/flare,
 /turf/open/floor/plasteel,
 /area/maintenance/starboard/central)
 "aqc" = (
@@ -8998,7 +9185,6 @@
 	},
 /obj/item/tank/jetpack/carbondioxide,
 /obj/item/wrench,
-/obj/effect/decal/cleanable/dirt,
 /obj/item/device/radio/intercom{
 	name = "Station Intercom";
 	pixel_x = -28
@@ -9006,12 +9192,13 @@
 /obj/structure/sign/nosmoking_2{
 	pixel_y = -32
 	},
-/turf/open/floor/plasteel/vault{
-	dir = 8
+/turf/open/floor/plasteel/vault/side{
+	tag = "icon-vault (EAST)";
+	icon_state = "vault";
+	dir = 4
 	},
 /area/ai_monitored/storage/eva)
 "aqd" = (
-/obj/effect/decal/cleanable/dirt,
 /obj/machinery/status_display{
 	pixel_y = -32
 	},
@@ -9069,7 +9256,9 @@
 /obj/structure/extinguisher_cabinet{
 	pixel_y = -28
 	},
-/turf/open/floor/plasteel/vault{
+/turf/open/floor/plasteel/vault/side{
+	tag = "icon-vault (WEST)";
+	icon_state = "vault";
 	dir = 8
 	},
 /area/ai_monitored/storage/eva)
@@ -9098,7 +9287,6 @@
 /obj/structure/chair{
 	dir = 1
 	},
-/obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
@@ -9146,7 +9334,6 @@
 /obj/structure/extinguisher_cabinet{
 	pixel_y = -26
 	},
-/obj/effect/decal/cleanable/dirt,
 /obj/machinery/camera{
 	c_tag = "Fore Primary Hallway East";
 	dir = 1
@@ -9203,7 +9390,6 @@
 /turf/open/floor/plasteel,
 /area/quartermaster/miningdock)
 "aqv" = (
-/obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/oil,
 /obj/structure/closet/crate,
 /obj/item/device/flashlight,
@@ -9219,7 +9405,6 @@
 /obj/structure/chair{
 	dir = 1
 	},
-/obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/stripes/end{
 	dir = 8
 	},
@@ -9229,7 +9414,6 @@
 /obj/structure/chair{
 	dir = 1
 	},
-/obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/stripes/line{
 	dir = 2
 	},
@@ -9239,7 +9423,6 @@
 /obj/structure/chair{
 	dir = 1
 	},
-/obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/stripes/end{
 	dir = 4
 	},
@@ -9288,8 +9471,6 @@
 /area/engine/atmos)
 "aqG" = (
 /obj/structure/door_assembly/door_assembly_mhatch,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
@@ -9310,8 +9491,10 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 6
 	},
-/turf/open/floor/plasteel/vault{
-	dir = 8
+/turf/open/floor/plasteel/vault/side{
+	tag = "icon-vault (EAST)";
+	icon_state = "vault";
+	dir = 4
 	},
 /area/security/brig)
 "aqJ" = (
@@ -9352,7 +9535,11 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 6
 	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/vault/side{
+	tag = "icon-vault (EAST)";
+	icon_state = "vault";
+	dir = 4
+	},
 /area/security/brig)
 "aqN" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden,
@@ -9423,7 +9610,6 @@
 /obj/item/storage/belt/utility,
 /obj/item/weldingtool,
 /obj/item/clothing/head/welding,
-/obj/effect/decal/cleanable/dirt,
 /obj/machinery/power/apc{
 	dir = 8;
 	name = "Primary Tool Storage APC";
@@ -9468,7 +9654,6 @@
 /area/storage/primary)
 "aqW" = (
 /obj/structure/reagent_dispensers/fueltank,
-/obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/oil,
 /obj/structure/extinguisher_cabinet{
 	pixel_y = 26
@@ -9485,7 +9670,6 @@
 /turf/open/floor/plasteel,
 /area/storage/primary)
 "aqY" = (
-/obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plating,
 /area/maintenance/port/central)
@@ -9494,8 +9678,9 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/turf/open/floor/plasteel/yellow/side{
-	dir = 4
+/turf/open/floor/plating{
+	burnt = 1;
+	icon_state = "panelscorched"
 	},
 /area/maintenance/port/central)
 "ara" = (
@@ -9560,18 +9745,14 @@
 /turf/open/floor/plating,
 /area/crew_quarters/bar/atrium)
 "arg" = (
-/obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/structure/cable/white{
 	icon_state = "1-2"
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 2
+/turf/open/floor/plating{
+	broken = 1;
+	icon_state = "platingdmg3"
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
 /area/maintenance/starboard/central)
 "arh" = (
 /obj/structure/girder,
@@ -9716,7 +9897,6 @@
 	pixel_y = 9
 	},
 /obj/structure/closet/crate/internals,
-/obj/effect/decal/cleanable/dirt,
 /obj/item/pickaxe/emergency,
 /obj/item/pickaxe/emergency,
 /obj/effect/turf_decal/delivery,
@@ -9741,7 +9921,6 @@
 /area/shuttle/mining)
 "arp" = (
 /obj/structure/ore_box,
-/obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/delivery,
 /obj/machinery/light/small{
 	dir = 4
@@ -9759,6 +9938,9 @@
 /obj/machinery/atmospherics/pipe/simple/cyan/visible{
 	dir = 4
 	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
 /turf/open/floor/plasteel/vault,
 /area/engine/atmos)
 "ars" = (
@@ -9769,7 +9951,7 @@
 /obj/structure/sign/fire{
 	pixel_y = 32
 	},
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel/vault{
 	dir = 8
 	},
@@ -9778,8 +9960,6 @@
 /obj/machinery/atmospherics/pipe/simple/cyan/visible{
 	dir = 4
 	},
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/stripes/line{
 	dir = 9
 	},
@@ -9804,7 +9984,6 @@
 /obj/machinery/atmospherics/pipe/simple/cyan/visible{
 	dir = 4
 	},
-/obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/stripes/line{
 	dir = 5
 	},
@@ -9815,8 +9994,6 @@
 /obj/machinery/atmospherics/pipe/simple/cyan/visible{
 	dir = 4
 	},
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
 /obj/machinery/camera{
 	c_tag = "Atmospherics Tank 4";
 	network = list("thunder");
@@ -9837,7 +10014,7 @@
 /obj/machinery/atmospherics/pipe/simple/cyan/visible{
 	dir = 4
 	},
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel/green/side{
 	dir = 1
 	},
@@ -9855,7 +10032,6 @@
 /obj/machinery/atmospherics/pipe/manifold/cyan/visible{
 	dir = 1
 	},
-/obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/delivery,
 /turf/open/floor/plasteel,
 /area/engine/atmos)
@@ -9866,8 +10042,6 @@
 /obj/structure/sign/nosmoking_2{
 	pixel_x = 32
 	},
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel,
 /area/engine/atmos)
@@ -9889,8 +10063,10 @@
 	dir = 1
 	},
 /obj/structure/closet/l3closet/security,
-/turf/open/floor/plasteel/vault{
-	dir = 5
+/turf/open/floor/plasteel/vault/side{
+	tag = "icon-vault (EAST)";
+	icon_state = "vault";
+	dir = 4
 	},
 /area/security/brig)
 "arE" = (
@@ -10097,7 +10273,6 @@
 /turf/open/floor/plating,
 /area/storage/primary)
 "arQ" = (
-/obj/effect/decal/cleanable/dirt,
 /obj/structure/cable/white{
 	icon_state = "1-2"
 	},
@@ -10118,14 +10293,12 @@
 	},
 /area/storage/primary)
 "arT" = (
-/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/yellow/side{
 	dir = 5
 	},
 /area/storage/primary)
 "arU" = (
 /obj/machinery/holopad,
-/obj/effect/decal/cleanable/dirt,
 /obj/item/device/radio/intercom{
 	name = "Station Intercom";
 	pixel_x = 26
@@ -10140,12 +10313,9 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 6
 	},
-/turf/open/floor/plasteel/yellow/side{
-	dir = 4
-	},
+/turf/open/floor/plating,
 /area/maintenance/port/central)
 "arW" = (
-/obj/effect/decal/cleanable/dirt,
 /obj/machinery/door/airlock/maintenance_hatch{
 	name = "Maintenance Hatch";
 	req_access_txt = "12"
@@ -10162,7 +10332,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plating,
 /area/maintenance/port/central)
 "arX" = (
 /obj/structure/cable/white{
@@ -10195,7 +10365,10 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
-/turf/open/floor/plasteel/neutral/corner,
+/turf/open/floor/plating{
+	broken = 1;
+	icon_state = "platingdmg3"
+	},
 /area/maintenance/port/central)
 "asa" = (
 /obj/effect/decal/cleanable/dirt,
@@ -10225,7 +10398,6 @@
 /turf/open/floor/plating,
 /area/maintenance/port/central)
 "asc" = (
-/obj/effect/decal/cleanable/dirt,
 /obj/structure/cable/white{
 	icon_state = "1-8"
 	},
@@ -10245,8 +10417,10 @@
 	dir = 4;
 	network = list("MINE")
 	},
-/turf/open/floor/plasteel/vault{
-	dir = 8
+/turf/open/floor/plasteel/vault/side{
+	tag = "icon-vault (EAST)";
+	icon_state = "vault";
+	dir = 4
 	},
 /area/crew_quarters/bar/atrium)
 "ase" = (
@@ -10276,11 +10450,13 @@
 /turf/open/floor/plasteel/redyellow,
 /area/crew_quarters/bar/atrium)
 "asj" = (
-/obj/machinery/vending/cola,
+/obj/machinery/vending/cola/random,
 /obj/machinery/newscaster{
 	pixel_x = 32
 	},
-/turf/open/floor/plasteel/vault{
+/turf/open/floor/plasteel/vault/side{
+	tag = "icon-vault (WEST)";
+	icon_state = "vault";
 	dir = 8
 	},
 /area/crew_quarters/bar/atrium)
@@ -10298,7 +10474,7 @@
 /obj/structure/cable/white{
 	icon_state = "4-8"
 	},
-/turf/open/floor/plasteel/neutral/corner,
+/turf/open/floor/plating,
 /area/maintenance/starboard/central)
 "asm" = (
 /obj/effect/decal/cleanable/dirt,
@@ -10322,14 +10498,16 @@
 /turf/open/floor/plasteel/neutral/corner,
 /area/maintenance/starboard/central)
 "aso" = (
-/obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
 /obj/structure/cable/white{
 	icon_state = "4-8"
 	},
-/turf/open/floor/plating,
+/turf/open/floor/plating{
+	burnt = 1;
+	icon_state = "panelscorched"
+	},
 /area/maintenance/starboard/central)
 "asp" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -10351,25 +10529,27 @@
 /turf/open/floor/plasteel/neutral/corner,
 /area/maintenance/starboard/central)
 "asr" = (
-/obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/loading_area{
 	dir = 4
 	},
+/obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "ass" = (
 /obj/machinery/mineral/mint,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/stripes/end,
 /obj/structure/sign/poster/official/random{
 	pixel_y = 32
 	},
+/obj/effect/turf_decal/bot,
+/obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "ast" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/loading_area,
+/obj/effect/decal/cleanable/oil,
+/obj/effect/turf_decal/bot,
+/obj/effect/turf_decal/stripes/line{
+	dir = 6
+	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "asu" = (
@@ -10424,6 +10604,7 @@
 	dir = 1;
 	pixel_y = 1
 	},
+/obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel/red/side{
 	dir = 9
 	},
@@ -10437,7 +10618,6 @@
 /turf/open/floor/plasteel,
 /area/engine/atmos)
 "asB" = (
-/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/neutral,
 /area/engine/atmos)
 "asC" = (
@@ -10466,7 +10646,6 @@
 /obj/machinery/atmospherics/pipe/manifold/green/visible{
 	dir = 1
 	},
-/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/neutral,
 /area/engine/atmos)
 "asF" = (
@@ -10475,7 +10654,6 @@
 	dir = 8;
 	name = "Air to Mix"
 	},
-/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/neutral,
 /area/engine/atmos)
 "asG" = (
@@ -10483,20 +10661,17 @@
 	dir = 2
 	},
 /obj/machinery/meter,
-/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/neutral,
 /area/engine/atmos)
 "asH" = (
 /obj/machinery/atmospherics/pipe/simple/cyan/visible{
 	dir = 10
 	},
-/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/caution{
 	dir = 4
 	},
 /area/engine/atmos)
 "asI" = (
-/obj/effect/decal/cleanable/dirt,
 /obj/structure/sign/vacuum{
 	pixel_x = -32
 	},
@@ -10514,8 +10689,10 @@
 /obj/structure/reagent_dispensers/peppertank{
 	pixel_y = -32
 	},
-/turf/open/floor/plasteel/vault{
-	dir = 1
+/turf/open/floor/plasteel/vault/corner{
+	tag = "icon-vaultcorner (EAST)";
+	icon_state = "vaultcorner";
+	dir = 4
 	},
 /area/security/brig)
 "asK" = (
@@ -10551,8 +10728,10 @@
 	dir = 1;
 	name = "security camera"
 	},
-/turf/open/floor/plasteel/vault{
-	dir = 8
+/turf/open/floor/plasteel/vault/side{
+	tag = "icon-vault (NORTH)";
+	icon_state = "vault";
+	dir = 1
 	},
 /area/security/brig)
 "asL" = (
@@ -10561,8 +10740,10 @@
 	dir = 1;
 	pixel_y = -26
 	},
-/turf/open/floor/plasteel/vault{
-	dir = 4
+/turf/open/floor/plasteel/vault/side{
+	tag = "icon-vault (NORTH)";
+	icon_state = "vault";
+	dir = 1
 	},
 /area/security/brig)
 "asM" = (
@@ -10595,7 +10776,11 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 9
 	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/vault/side{
+	tag = "icon-vault (NORTH)";
+	icon_state = "vault";
+	dir = 1
+	},
 /area/security/brig)
 "asP" = (
 /obj/structure/table/reinforced,
@@ -10614,7 +10799,11 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/vault/side{
+	tag = "icon-vault (NORTH)";
+	icon_state = "vault";
+	dir = 1
+	},
 /area/security/brig)
 "asQ" = (
 /obj/structure/table/reinforced,
@@ -10627,7 +10816,11 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/vault/side{
+	tag = "icon-vault (NORTH)";
+	icon_state = "vault";
+	dir = 1
+	},
 /area/security/brig)
 "asR" = (
 /obj/machinery/computer/security{
@@ -10649,8 +10842,10 @@
 	dir = 1;
 	name = "security camera"
 	},
-/turf/open/floor/plasteel/vault{
-	dir = 5
+/turf/open/floor/plasteel/vault/side{
+	tag = "icon-vault (NORTH)";
+	icon_state = "vault";
+	dir = 1
 	},
 /area/security/brig)
 "asS" = (
@@ -10667,8 +10862,10 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 1
 	},
-/turf/open/floor/plasteel/vault{
-	dir = 5
+/turf/open/floor/plasteel/vault/side{
+	tag = "icon-vault (NORTH)";
+	icon_state = "vault";
+	dir = 1
 	},
 /area/security/brig)
 "asT" = (
@@ -10723,7 +10920,6 @@
 /obj/structure/table/reinforced,
 /obj/item/stack/packageWrap,
 /obj/item/hand_labeler,
-/obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
@@ -10754,8 +10950,6 @@
 	},
 /area/storage/primary)
 "asZ" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
@@ -10766,15 +10960,15 @@
 /turf/open/floor/plasteel,
 /area/storage/primary)
 "atb" = (
-/obj/effect/decal/cleanable/dirt,
 /obj/structure/cable/white{
 	icon_state = "1-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 9
 	},
-/turf/open/floor/plasteel/yellow/side{
-	dir = 4
+/turf/open/floor/plating{
+	broken = 1;
+	icon_state = "platingdmg3"
 	},
 /area/maintenance/port/central)
 "atc" = (
@@ -10782,12 +10976,14 @@
 /turf/closed/wall,
 /area/maintenance/port/central)
 "atd" = (
-/obj/effect/decal/cleanable/dirt,
 /obj/structure/cable/white{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/turf/open/floor/plating,
+/turf/open/floor/plating{
+	burnt = 1;
+	icon_state = "panelscorched"
+	},
 /area/maintenance/port/central)
 "ate" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -10806,7 +11002,6 @@
 	name = "Theatre Backstage";
 	req_access_txt = "46"
 	},
-/obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/structure/cable/white{
 	icon_state = "1-2"
@@ -10833,8 +11028,10 @@
 /obj/machinery/light{
 	dir = 8
 	},
-/turf/open/floor/plasteel/vault{
-	dir = 8
+/turf/open/floor/plasteel/vault/side{
+	tag = "icon-vault (SOUTHEAST)";
+	icon_state = "vault";
+	dir = 6
 	},
 /area/crew_quarters/bar/atrium)
 "atj" = (
@@ -10847,8 +11044,10 @@
 /obj/machinery/light{
 	dir = 4
 	},
-/turf/open/floor/plasteel/vault{
-	dir = 8
+/turf/open/floor/plasteel/vault/side{
+	tag = "icon-vault (SOUTHWEST)";
+	icon_state = "vault";
+	dir = 10
 	},
 /area/crew_quarters/bar/atrium)
 "atl" = (
@@ -10874,8 +11073,9 @@
 /obj/structure/cable/white{
 	icon_state = "1-2"
 	},
-/turf/open/floor/plasteel/neutral/corner{
-	dir = 1
+/turf/open/floor/plating{
+	burnt = 1;
+	icon_state = "panelscorched"
 	},
 /area/maintenance/starboard/central)
 "atp" = (
@@ -10891,7 +11091,6 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
-/obj/effect/decal/cleanable/dirt,
 /obj/machinery/door/airlock/maintenance_hatch{
 	name = "Maintenance Hatch";
 	req_access_txt = "12"
@@ -10908,25 +11107,25 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
-/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
 /area/hallway/primary/central)
 "ats" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
-/obj/effect/turf_decal/bot,
-/obj/effect/landmark/event_spawn,
-/turf/open/floor/plasteel,
+/turf/open/floor/plating{
+	broken = 1;
+	icon_state = "platingdmg3"
+	},
 /area/hallway/primary/central)
 "att" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/delivery,
-/turf/open/floor/plasteel,
+/turf/open/floor/plating{
+	burnt = 1;
+	icon_state = "panelscorched"
+	},
 /area/hallway/primary/central)
 "atv" = (
 /obj/effect/decal/cleanable/dirt,
@@ -10981,6 +11180,7 @@
 /obj/structure/window/reinforced{
 	dir = 8
 	},
+/obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel/red/side{
 	dir = 8
 	},
@@ -10993,7 +11193,6 @@
 /area/engine/atmos)
 "atC" = (
 /obj/machinery/holopad,
-/obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel,
 /area/engine/atmos)
@@ -11046,7 +11245,6 @@
 /obj/structure/cable/white{
 	icon_state = "0-2"
 	},
-/obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
@@ -11058,18 +11256,18 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
-/turf/closed/wall/r_wall,
+/turf/closed/wall/r_wall/rust,
 /area/engine/atmos)
 "atK" = (
-/obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 10
 	},
 /obj/structure/sign/poster/contraband/random{
 	pixel_x = 32
 	},
-/turf/open/floor/plasteel/caution/corner{
-	dir = 1
+/turf/open/floor/plating{
+	burnt = 1;
+	icon_state = "panelscorched"
 	},
 /area/maintenance/port/fore)
 "atL" = (
@@ -11080,7 +11278,6 @@
 /obj/structure/cable/white{
 	icon_state = "1-2"
 	},
-/obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/effect/turf_decal/stripes/line{
 	dir = 2
@@ -11241,7 +11438,6 @@
 	pixel_y = 9
 	},
 /obj/structure/closet/crate/internals,
-/obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
@@ -11249,11 +11445,9 @@
 /turf/open/floor/plasteel,
 /area/storage/primary)
 "atU" = (
-/obj/effect/decal/cleanable/dirt,
 /obj/structure/plasticflaps{
 	opacity = 1
 	},
-/obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
@@ -11261,13 +11455,10 @@
 /turf/open/floor/plasteel,
 /area/storage/primary)
 "atV" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
-/obj/effect/turf_decal/delivery,
-/turf/open/floor/plasteel,
+/turf/open/floor/plating,
 /area/maintenance/port/central)
 "atW" = (
 /obj/effect/landmark/blobstart,
@@ -11278,7 +11469,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
-/turf/open/floor/plasteel/neutral/corner,
+/turf/open/floor/plating,
 /area/maintenance/port/central)
 "atX" = (
 /obj/structure/table/wood,
@@ -11298,14 +11489,16 @@
 /obj/machinery/light{
 	dir = 1
 	},
-/turf/open/floor/plasteel/grimy,
+/turf/open/floor/wood,
 /area/crew_quarters/theatre)
 "atZ" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/structure/cable/white{
 	icon_state = "1-2"
 	},
-/turf/open/floor/plasteel/grimy,
+/turf/open/floor/wood{
+	icon_state = "wood-broken6"
+	},
 /area/crew_quarters/theatre)
 "aua" = (
 /obj/structure/window/reinforced{
@@ -11320,12 +11513,14 @@
 	pixel_y = 32
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/turf/open/floor/plasteel/grimy,
+/turf/open/floor/wood,
 /area/crew_quarters/theatre)
 "aub" = (
 /obj/machinery/vending/cigarette,
-/turf/open/floor/plasteel/vault{
-	dir = 8
+/turf/open/floor/plasteel/vault/side{
+	tag = "icon-vault (EAST)";
+	icon_state = "vault";
+	dir = 4
 	},
 /area/crew_quarters/bar/atrium)
 "auc" = (
@@ -11432,12 +11627,16 @@
 /turf/closed/wall,
 /area/crew_quarters/bar/atrium)
 "aun" = (
+/turf/open/floor/plating,
 /obj/effect/landmark/blobstart,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/structure/cable/white{
 	icon_state = "1-2"
 	},
-/turf/open/floor/plating,
+/turf/open/floor/plating{
+	tag = "icon-platingdmg2";
+	icon_state = "platingdmg2"
+	},
 /area/maintenance/starboard/central)
 "auo" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -11498,7 +11697,7 @@
 /obj/structure/window/reinforced{
 	dir = 8
 	},
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel/red/side{
 	dir = 10
 	},
@@ -11551,7 +11750,6 @@
 	name = "Mix to Distro";
 	on = 0
 	},
-/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/neutral,
 /area/engine/atmos)
 "auB" = (
@@ -11582,7 +11780,6 @@
 "auE" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/machinery/space_heater,
-/obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/oil,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -11601,7 +11798,6 @@
 /area/maintenance/port/fore)
 "auG" = (
 /obj/effect/decal/cleanable/cobweb,
-/obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
@@ -11611,25 +11807,26 @@
 /obj/structure/cable/white{
 	icon_state = "2-4"
 	},
-/obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
 	dir = 1
 	},
 /obj/effect/landmark/event_spawn,
-/turf/open/floor/plasteel/red/corner,
+/turf/open/floor/plating,
 /area/maintenance/port/fore)
 "auI" = (
 /obj/structure/cable/white{
 	icon_state = "4-8"
 	},
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
-/turf/open/floor/plating,
+/turf/open/floor/plating{
+	burnt = 1;
+	icon_state = "panelscorched"
+	},
 /area/maintenance/port/fore)
 "auJ" = (
+/turf/open/floor/plating,
 /obj/structure/cable/white{
 	icon_state = "1-8"
 	},
@@ -11639,20 +11836,20 @@
 /obj/effect/decal/cleanable/blood/splatter,
 /obj/effect/landmark/revenantspawn,
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden,
-/turf/open/floor/plating,
+/turf/open/floor/plating{
+	tag = "icon-platingdmg2";
+	icon_state = "platingdmg2"
+	},
 /area/maintenance/port/fore)
 "auK" = (
 /obj/structure/cable/white{
 	icon_state = "4-8"
 	},
-/obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/turf/open/floor/plasteel/neutral/corner{
-	dir = 1
-	},
+/turf/open/floor/plating,
 /area/maintenance/port/fore)
 "auL" = (
 /obj/effect/landmark/blobstart,
@@ -11665,13 +11862,15 @@
 /obj/structure/cable/white{
 	icon_state = "2-4"
 	},
-/turf/open/floor/plasteel/red/corner,
+/turf/open/floor/plating{
+	burnt = 1;
+	icon_state = "panelscorched"
+	},
 /area/maintenance/port/fore)
 "auM" = (
 /obj/structure/cable/white{
 	icon_state = "4-8"
 	},
-/obj/effect/decal/cleanable/dirt,
 /obj/machinery/door/airlock/maintenance_hatch{
 	name = "Maintenance Hatch";
 	req_access_txt = "12"
@@ -11694,8 +11893,11 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
-/turf/open/floor/plasteel/vault{
-	dir = 5
+/obj/effect/turf_decal/bot,
+/turf/open/floor/plasteel/vault/side{
+	tag = "icon-vault (EAST)";
+	icon_state = "vault";
+	dir = 4
 	},
 /area/hallway/primary/central)
 "auO" = (
@@ -11765,7 +11967,6 @@
 	},
 /area/hallway/primary/central)
 "auT" = (
-/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/yellow/side{
 	dir = 10
 	},
@@ -11781,7 +11982,6 @@
 /turf/open/floor/plasteel/yellow/side,
 /area/storage/primary)
 "auW" = (
-/obj/effect/decal/cleanable/dirt,
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/plasteel/yellow/side{
 	dir = 6
@@ -11797,8 +11997,10 @@
 /turf/open/floor/plasteel,
 /area/storage/primary)
 "auY" = (
-/obj/effect/turf_decal/bot,
-/turf/open/floor/plasteel,
+/turf/open/floor/plating{
+	burnt = 1;
+	icon_state = "panelscorched"
+	},
 /area/maintenance/port/central)
 "auZ" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -11837,14 +12039,16 @@
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 4
 	},
-/turf/open/floor/plasteel/grimy,
+/turf/open/floor/wood,
 /area/crew_quarters/theatre)
 "ave" = (
 /obj/structure/table/wood,
 /obj/item/clothing/head/fedora,
 /obj/item/clothing/mask/cigarette/pipe,
-/turf/open/floor/plasteel/vault{
-	dir = 5
+/turf/open/floor/plasteel/vault/side{
+	tag = "icon-vault (EAST)";
+	icon_state = "vault";
+	dir = 4
 	},
 /area/crew_quarters/bar/atrium)
 "avf" = (
@@ -11962,12 +12166,14 @@
 /turf/closed/wall,
 /area/crew_quarters/bar/atrium)
 "avs" = (
-/obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/structure/cable/white{
 	icon_state = "1-2"
 	},
-/turf/open/floor/plating,
+/turf/open/floor/plating{
+	broken = 1;
+	icon_state = "platingdmg3"
+	},
 /area/maintenance/starboard/central)
 "avt" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
@@ -11990,12 +12196,13 @@
 /area/hallway/primary/central)
 "avv" = (
 /obj/machinery/shieldgen,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating,
+/obj/effect/turf_decal/stripes/line{
+	dir = 9
+	},
+/turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "avw" = (
 /obj/machinery/shieldgen,
-/obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/stripes/line{
 	dir = 5
 	},
@@ -12013,7 +12220,6 @@
 /obj/machinery/light{
 	dir = 8
 	},
-/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/vault{
 	dir = 5
 	},
@@ -12024,6 +12230,7 @@
 	dir = 4;
 	name = "N2 to Pure"
 	},
+/obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel/vault{
 	dir = 8
 	},
@@ -12032,7 +12239,6 @@
 /obj/machinery/atmospherics/pipe/simple/yellow/visible{
 	dir = 10
 	},
-/obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
@@ -12057,7 +12263,6 @@
 /obj/machinery/atmospherics/pipe/simple/yellow/visible{
 	dir = 6
 	},
-/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/neutral,
 /area/engine/atmos)
 "avE" = (
@@ -12103,12 +12308,13 @@
 /obj/structure/cable/white{
 	icon_state = "2-4"
 	},
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 6
 	},
-/turf/open/floor/plasteel/caution,
+/turf/open/floor/plating{
+	broken = 1;
+	icon_state = "platingdmg1"
+	},
 /area/maintenance/port/fore)
 "avJ" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -12118,13 +12324,15 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
-/turf/open/floor/plasteel/caution,
+/turf/open/floor/plating{
+	burnt = 1;
+	icon_state = "panelscorched"
+	},
 /area/maintenance/port/fore)
 "avK" = (
 /obj/structure/cable/white{
 	icon_state = "4-8"
 	},
-/obj/effect/decal/cleanable/dirt,
 /obj/machinery/door/airlock/maintenance_hatch{
 	name = "Maintenance Hatch";
 	req_access_txt = "12"
@@ -12144,7 +12352,6 @@
 /obj/structure/cable/white{
 	icon_state = "4-8"
 	},
-/obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
@@ -12163,14 +12370,15 @@
 /obj/structure/cable/white{
 	icon_state = "1-8"
 	},
-/obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 1
 	},
-/turf/open/floor/plating,
+/turf/open/floor/plating{
+	icon_state = "platingdmg3"
+	},
 /area/maintenance/port/fore)
 "avN" = (
 /obj/structure/girder,
@@ -12185,8 +12393,6 @@
 /obj/item/crowbar/red,
 /obj/item/wrench,
 /obj/machinery/light/small,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
@@ -12203,8 +12409,6 @@
 /obj/item/clothing/shoes/jackboots,
 /obj/item/device/radio,
 /obj/item/storage/secure/briefcase,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
 /obj/effect/spawner/lootdrop/maintenance{
 	lootcount = 2;
 	name = "2maintenance loot spawner"
@@ -12219,7 +12423,6 @@
 /obj/structure/table,
 /obj/item/clothing/under/rank/security,
 /obj/item/restraints/handcuffs,
-/obj/effect/decal/cleanable/dirt,
 /obj/structure/cable/white,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
@@ -12244,8 +12447,11 @@
 /obj/machinery/newscaster{
 	pixel_x = -32
 	},
-/turf/open/floor/plasteel/vault{
-	dir = 8
+/obj/effect/turf_decal/bot,
+/turf/open/floor/plasteel/vault/side{
+	tag = "icon-vault (EAST)";
+	icon_state = "vault";
+	dir = 4
 	},
 /area/hallway/primary/central)
 "avT" = (
@@ -12300,7 +12506,6 @@
 /obj/item/stock_parts/cell/high,
 /obj/item/stock_parts/cell/high,
 /obj/machinery/cell_charger,
-/obj/effect/decal/cleanable/dirt,
 /obj/machinery/firealarm{
 	dir = 8;
 	pixel_x = -24
@@ -12314,8 +12519,6 @@
 /area/storage/primary)
 "avZ" = (
 /obj/machinery/vending/tool,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
 /obj/machinery/status_display{
 	pixel_y = -32
 	},
@@ -12340,7 +12543,6 @@
 /obj/item/stack/sheet/glass{
 	amount = 30
 	},
-/obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel,
 /area/storage/primary)
@@ -12354,7 +12556,6 @@
 	pixel_y = 3
 	},
 /obj/item/stack/cable_coil/white,
-/obj/effect/decal/cleanable/dirt,
 /obj/machinery/newscaster{
 	pixel_x = 32
 	},
@@ -12363,7 +12564,6 @@
 /area/storage/primary)
 "awd" = (
 /obj/structure/closet/firecloset,
-/obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
@@ -12396,14 +12596,18 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/turf/open/floor/plasteel/grimy,
+/turf/open/floor/wood{
+	icon_state = "wood-broken"
+	},
 /area/crew_quarters/theatre)
 "awj" = (
 /obj/structure/chair/comfy/brown{
 	dir = 8
 	},
-/turf/open/floor/plasteel/vault{
-	dir = 5
+/turf/open/floor/plasteel/vault/side{
+	tag = "icon-vault (EAST)";
+	icon_state = "vault";
+	dir = 4
 	},
 /area/crew_quarters/bar/atrium)
 "awk" = (
@@ -12528,7 +12732,6 @@
 	},
 /area/crew_quarters/bar/atrium)
 "aww" = (
-/obj/effect/decal/cleanable/dirt,
 /obj/machinery/door/airlock/maintenance_hatch{
 	name = "Bar Maintenance";
 	req_access_txt = "25"
@@ -12546,7 +12749,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plating,
 /area/maintenance/starboard/central)
 "awx" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
@@ -12576,9 +12779,6 @@
 	},
 /area/hallway/primary/central)
 "awz" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
@@ -12617,6 +12817,7 @@
 	dir = 1;
 	pixel_y = 1
 	},
+/obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel/blue/side{
 	dir = 9
 	},
@@ -12644,11 +12845,9 @@
 	name = "Mix to Filter";
 	on = 1
 	},
-/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/neutral,
 /area/engine/atmos)
 "awI" = (
-/obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 4
 	},
@@ -12713,7 +12912,6 @@
 /turf/open/floor/plasteel,
 /area/maintenance/port/fore)
 "awN" = (
-/obj/effect/decal/cleanable/dirt,
 /obj/structure/plasticflaps{
 	opacity = 1
 	},
@@ -12869,7 +13067,6 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard/central)
 "axf" = (
-/obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/stripes/line{
 	dir = 10
 	},
@@ -12877,12 +13074,13 @@
 /area/hallway/primary/central)
 "axg" = (
 /obj/structure/rack,
-/obj/item/crowbar/red,
-/obj/item/wrench,
-/obj/item/tank/internals/emergency_oxygen/engi,
-/obj/effect/decal/cleanable/dirt,
 /obj/effect/spawner/lootdrop/maintenance,
-/turf/open/floor/plating,
+/obj/effect/turf_decal/stripes/line{
+	dir = 6
+	},
+/obj/item/wrench,
+/obj/item/wirecutters,
+/turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "axh" = (
 /obj/machinery/portable_atmospherics/canister/oxygen,
@@ -12899,7 +13097,6 @@
 /turf/open/floor/engine/o2,
 /area/engine/atmos)
 "axj" = (
-/obj/effect/decal/cleanable/dirt,
 /obj/machinery/camera{
 	c_tag = "Atmospherics Tank 2";
 	dir = 4;
@@ -12922,6 +13119,7 @@
 /obj/structure/window/reinforced{
 	dir = 8
 	},
+/obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel/blue/side{
 	dir = 8
 	},
@@ -12951,7 +13149,6 @@
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/visible{
 	dir = 2
 	},
-/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/neutral,
 /area/engine/atmos)
 "axp" = (
@@ -12975,7 +13172,6 @@
 /obj/item/twohanded/required/kirbyplants{
 	icon_state = "plant-21"
 	},
-/obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
@@ -12986,7 +13182,6 @@
 /obj/structure/cable/white{
 	icon_state = "1-2"
 	},
-/obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 9
 	},
@@ -13000,7 +13195,6 @@
 	pixel_x = 24;
 	pixel_y = 24
 	},
-/obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/oil,
 /obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel,
@@ -13032,13 +13226,11 @@
 /area/engine/atmos)
 "axw" = (
 /obj/machinery/portable_atmospherics/canister/oxygen,
-/obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel,
 /area/engine/atmos)
 "axx" = (
 /obj/machinery/portable_atmospherics/canister/air,
-/obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel,
 /area/engine/atmos)
@@ -13046,11 +13238,12 @@
 /obj/item/weldingtool,
 /obj/item/clothing/head/welding,
 /obj/structure/table/reinforced,
-/obj/effect/decal/cleanable/dirt,
 /obj/machinery/status_display{
 	pixel_y = 32
 	},
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
 /turf/open/floor/plasteel/caution{
 	dir = 9
 	},
@@ -13086,7 +13279,6 @@
 	pixel_x = 26;
 	pixel_y = 26
 	},
-/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/caution{
 	dir = 5
 	},
@@ -13117,30 +13309,34 @@
 	name = "Station Intercom";
 	pixel_x = -26
 	},
+/obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel/vault{
 	dir = 5
 	},
 /area/crew_quarters/dorms)
 "axE" = (
-/obj/structure/closet/secure_closet/personal,
 /obj/machinery/status_display{
 	pixel_y = 32
 	},
+/obj/effect/turf_decal/bot,
+/obj/structure/closet/wardrobe/white,
 /turf/open/floor/plasteel/vault{
 	dir = 5
 	},
 /area/crew_quarters/dorms)
 "axF" = (
-/obj/structure/closet/secure_closet/personal,
 /obj/machinery/light_switch{
 	pixel_y = 24
 	},
+/obj/effect/turf_decal/bot,
+/obj/structure/closet/wardrobe/grey,
 /turf/open/floor/plasteel/vault{
 	dir = 5
 	},
 /area/crew_quarters/dorms)
 "axG" = (
-/obj/structure/closet/secure_closet/personal,
+/obj/effect/turf_decal/bot,
+/obj/structure/closet/wardrobe/black,
 /turf/open/floor/plasteel/vault{
 	dir = 5
 	},
@@ -13349,6 +13545,7 @@
 /obj/structure/window/reinforced{
 	dir = 8
 	},
+/obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel/blue/side{
 	dir = 10
 	},
@@ -13372,7 +13569,6 @@
 	on = 1;
 	target_pressure = 4500
 	},
-/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/neutral,
 /area/engine/atmos)
 "ayf" = (
@@ -13382,7 +13578,6 @@
 	name = "waste filter";
 	on = 1
 	},
-/obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/stripes/corner{
 	dir = 8
 	},
@@ -13436,7 +13631,6 @@
 /obj/structure/cable/white{
 	icon_state = "1-2"
 	},
-/obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
@@ -13450,7 +13644,6 @@
 	dir = 4;
 	pixel_x = 24
 	},
-/obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/stripes/line{
 	dir = 5
 	},
@@ -13462,7 +13655,6 @@
 	dir = 8;
 	pixel_x = -24
 	},
-/obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/delivery,
 /turf/open/floor/plasteel,
 /area/engine/atmos)
@@ -13483,9 +13675,11 @@
 /area/engine/atmos)
 "ayq" = (
 /obj/structure/table/reinforced,
-/obj/effect/decal/cleanable/dirt,
 /obj/item/paper_bin,
 /obj/item/pen,
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
 /turf/open/floor/plasteel/caution{
 	dir = 8
 	},
@@ -13497,7 +13691,6 @@
 /obj/structure/cable/white{
 	icon_state = "2-4"
 	},
-/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/caution{
 	dir = 4
 	},
@@ -13615,7 +13808,7 @@
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 8
 	},
-/turf/open/floor/plasteel/grimy,
+/turf/open/floor/wood,
 /area/crew_quarters/theatre)
 "ayI" = (
 /obj/structure/table/wood,
@@ -13628,8 +13821,10 @@
 	dir = 4;
 	network = list("MINE")
 	},
-/turf/open/floor/plasteel/vault{
-	dir = 5
+/turf/open/floor/plasteel/vault/side{
+	tag = "icon-vault (EAST)";
+	icon_state = "vault";
+	dir = 4
 	},
 /area/crew_quarters/bar/atrium)
 "ayJ" = (
@@ -13684,7 +13879,6 @@
 /area/maintenance/starboard/central)
 "ayQ" = (
 /obj/structure/reagent_dispensers/fueltank,
-/obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/stripes/line{
 	dir = 10
 	},
@@ -13695,8 +13889,6 @@
 /obj/item/clothing/suit/fire/firefighter,
 /obj/item/clothing/mask/gas,
 /obj/item/clothing/head/hardhat/red,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
 /obj/machinery/light/small{
 	dir = 1
 	},
@@ -13737,11 +13929,16 @@
 "ayV" = (
 /obj/structure/closet/firecloset,
 /obj/effect/turf_decal/delivery,
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/vault/side{
+	tag = "icon-vault (WEST)";
+	icon_state = "vault";
+	dir = 8
+	},
 /area/hallway/primary/central)
 "ayW" = (
 /obj/structure/table/reinforced,
 /obj/structure/cable/white{
+	d2 = 4;
 	icon_state = "0-4"
 	},
 /obj/machinery/power/apc{
@@ -13758,6 +13955,7 @@
 	pixel_y = 23
 	},
 /obj/structure/cable/white{
+	d2 = 4;
 	icon_state = "0-4"
 	},
 /turf/open/floor/plasteel/red/side{
@@ -13772,6 +13970,8 @@
 	pixel_y = 32
 	},
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel/red/side{
@@ -13788,6 +13988,8 @@
 	pixel_y = 24
 	},
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel/red/side{
@@ -13800,6 +14002,8 @@
 	pixel_y = 32
 	},
 /obj/structure/cable/white{
+	d1 = 2;
+	d2 = 8;
 	icon_state = "2-8"
 	},
 /turf/open/floor/plasteel/red/side{
@@ -13880,7 +14084,7 @@
 	dir = 4;
 	name = "O2 to Pure"
 	},
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel/vault{
 	dir = 8
 	},
@@ -13935,7 +14139,6 @@
 /turf/open/floor/plasteel/neutral,
 /area/engine/atmos)
 "azr" = (
-/obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
 	dir = 1
 	},
@@ -13999,6 +14202,9 @@
 	icon_state = "2-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/corner{
 	dir = 4
 	},
 /turf/open/floor/plasteel/caution{
@@ -14077,7 +14283,9 @@
 	pixel_y = -22
 	},
 /obj/machinery/light,
-/turf/open/floor/plasteel/grimy,
+/turf/open/floor/wood{
+	icon_state = "wood-broken5"
+	},
 /area/crew_quarters/theatre)
 "azG" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
@@ -14086,7 +14294,7 @@
 /obj/structure/cable/white{
 	icon_state = "1-2"
 	},
-/turf/open/floor/plasteel/grimy,
+/turf/open/floor/wood,
 /area/crew_quarters/theatre)
 "azH" = (
 /obj/machinery/door/window/eastright{
@@ -14101,14 +14309,16 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/turf/open/floor/plasteel/grimy,
+/turf/open/floor/wood,
 /area/crew_quarters/theatre)
 "azI" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
-/turf/open/floor/plasteel/vault{
-	dir = 5
+/turf/open/floor/plasteel/vault/side{
+	tag = "icon-vault (EAST)";
+	icon_state = "vault";
+	dir = 4
 	},
 /area/crew_quarters/bar/atrium)
 "azJ" = (
@@ -14146,40 +14356,37 @@
 /turf/closed/wall,
 /area/maintenance/starboard/central)
 "azN" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
-/obj/effect/turf_decal/bot,
-/turf/open/floor/plasteel,
+/turf/open/floor/plating,
 /area/maintenance/starboard/central)
 "azO" = (
-/obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
 /obj/structure/cable/white{
 	icon_state = "1-2"
 	},
-/turf/open/floor/plasteel/neutral/side,
+/turf/open/floor/plating,
 /area/maintenance/starboard/central)
 "azP" = (
 /obj/effect/landmark/blobstart,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
-/turf/open/floor/plasteel/neutral/side,
+/turf/open/floor/plating{
+	icon_state = "platingdmg1"
+	},
 /area/maintenance/starboard/central)
 "azQ" = (
 /obj/machinery/atmospherics/pipe/manifold4w/scrubbers/hidden,
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
+/turf/open/floor/plating{
+	burnt = 1;
+	icon_state = "panelscorched"
 	},
-/turf/open/floor/plasteel,
 /area/maintenance/starboard/central)
 "azR" = (
-/obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
@@ -14190,7 +14397,6 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard/central)
 "azS" = (
-/obj/effect/decal/cleanable/dirt,
 /obj/machinery/door/airlock/maintenance_hatch{
 	name = "Maintenance Hatch";
 	req_access_txt = "12"
@@ -14204,7 +14410,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plating,
 /area/hallway/primary/central)
 "azT" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
@@ -14216,9 +14422,15 @@
 	},
 /area/hallway/primary/central)
 "azU" = (
-/obj/structure/closet/crate/bin,
-/obj/effect/turf_decal/delivery,
-/turf/open/floor/plasteel,
+/obj/effect/turf_decal/bot,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/turf/open/floor/plasteel/vault/side{
+	tag = "icon-vault (WEST)";
+	icon_state = "vault";
+	dir = 8
+	},
 /area/hallway/primary/central)
 "azV" = (
 /obj/structure/table/reinforced,
@@ -14244,6 +14456,8 @@
 "azY" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on,
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel/neutral,
@@ -14335,7 +14549,6 @@
 /obj/machinery/atmospherics/pipe/simple/cyan/visible{
 	dir = 4
 	},
-/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/vault{
 	dir = 5
 	},
@@ -14352,7 +14565,7 @@
 	dir = 1;
 	pixel_y = 1
 	},
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel/arrival{
 	dir = 9
 	},
@@ -14361,7 +14574,6 @@
 /obj/machinery/atmospherics/pipe/simple/cyan/visible{
 	dir = 9
 	},
-/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/neutral,
 /area/engine/atmos)
 "aAn" = (
@@ -14575,6 +14787,7 @@
 	dir = 8;
 	network = list("SS13")
 	},
+/obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel/arrival{
 	dir = 4
 	},
@@ -14602,7 +14815,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/vault,
 /area/crew_quarters/theatre)
 "aAN" = (
 /obj/machinery/power/apc{
@@ -14696,7 +14909,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plating,
 /area/maintenance/starboard/central)
 "aAU" = (
 /obj/effect/decal/cleanable/dirt,
@@ -14719,13 +14932,12 @@
 /obj/structure/cable/white{
 	icon_state = "1-4"
 	},
-/turf/open/floor/plasteel/neutral/side{
-	dir = 1;
-	heat_capacity = 1e+006
+/turf/open/floor/plating{
+	broken = 1;
+	icon_state = "platingdmg3"
 	},
 /area/maintenance/starboard/central)
 "aAW" = (
-/obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -14733,10 +14945,7 @@
 /obj/structure/cable/white{
 	icon_state = "4-8"
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plating,
 /area/maintenance/starboard/central)
 "aAX" = (
 /obj/machinery/atmospherics/pipe/manifold4w/supply/hidden,
@@ -14777,8 +14986,11 @@
 /turf/open/floor/plasteel/neutral/corner,
 /area/hallway/primary/central)
 "aBb" = (
-/obj/machinery/vending/cola,
-/turf/open/floor/plasteel/vault{
+/obj/machinery/vending/cola/random,
+/obj/effect/turf_decal/bot,
+/turf/open/floor/plasteel/vault/side{
+	tag = "icon-vault (WEST)";
+	icon_state = "vault";
 	dir = 8
 	},
 /area/hallway/primary/central)
@@ -14807,6 +15019,8 @@
 "aBf" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel/red/side,
@@ -14828,9 +15042,6 @@
 	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit)
@@ -14916,6 +15127,8 @@
 /obj/structure/window/reinforced{
 	dir = 8
 	},
+/obj/effect/turf_decal/bot,
+/obj/structure/window/reinforced,
 /turf/open/floor/plasteel/arrival{
 	dir = 8
 	},
@@ -15023,7 +15236,6 @@
 	dir = 4
 	},
 /obj/structure/closet/crate/bin,
-/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/caution{
 	dir = 10
 	},
@@ -15187,6 +15399,7 @@
 /area/crew_quarters/dorms)
 "aBT" = (
 /obj/machinery/washing_machine,
+/obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel/arrival{
 	dir = 4
 	},
@@ -15215,12 +15428,16 @@
 /obj/machinery/camera{
 	c_tag = "Theatre Storage"
 	},
-/turf/open/floor/plasteel/vault{
-	dir = 8
+/turf/open/floor/plasteel/vault/side{
+	tag = "icon-vault (EAST)";
+	icon_state = "vault";
+	dir = 4
 	},
 /area/crew_quarters/theatre)
 "aBW" = (
-/turf/open/floor/plasteel/grimy,
+/turf/open/floor/wood{
+	icon_state = "wood-broken7"
+	},
 /area/crew_quarters/theatre)
 "aBX" = (
 /obj/machinery/vending/autodrobe,
@@ -15309,19 +15526,23 @@
 	},
 /area/hallway/primary/central)
 "aCh" = (
-/obj/machinery/vending/snack,
+/obj/machinery/vending/snack/random,
 /obj/machinery/firealarm{
 	dir = 4;
 	icon_state = "fire0";
 	pixel_x = 24
 	},
-/turf/open/floor/plasteel/vault{
+/obj/effect/turf_decal/bot,
+/turf/open/floor/plasteel/vault/side{
+	tag = "icon-vault (WEST)";
+	icon_state = "vault";
 	dir = 8
 	},
 /area/hallway/primary/central)
 "aCi" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable/white{
+	d2 = 4;
 	icon_state = "0-4"
 	},
 /turf/open/floor/plating,
@@ -15329,9 +15550,13 @@
 "aCj" = (
 /obj/machinery/door/firedoor,
 /obj/structure/cable/white{
+	d1 = 2;
+	d2 = 4;
 	icon_state = "2-4"
 	},
 /obj/structure/cable/white{
+	d1 = 2;
+	d2 = 8;
 	icon_state = "2-8"
 	},
 /obj/machinery/door/window/brigdoor/southright{
@@ -15341,6 +15566,8 @@
 	},
 /obj/structure/table/reinforced,
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/item/folder/red,
@@ -15353,9 +15580,11 @@
 "aCk" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable/white{
+	d2 = 4;
 	icon_state = "0-4"
 	},
 /obj/structure/cable/white{
+	d2 = 8;
 	icon_state = "0-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -15364,17 +15593,19 @@
 "aCl" = (
 /obj/machinery/door/firedoor,
 /obj/structure/cable/white{
+	d1 = 2;
+	d2 = 8;
 	icon_state = "2-8"
 	},
 /obj/structure/cable/white{
+	d1 = 2;
+	d2 = 4;
 	icon_state = "2-4"
-	},
-/obj/machinery/door/airlock/security/glass{
-	name = "Holding Area";
-	req_access_txt = "2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/effect/turf_decal/stripes/line{
@@ -15383,11 +15614,16 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
+/obj/machinery/door/airlock/security/glass{
+	name = "Security Checkpoint";
+	req_access_txt = "63"
+	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit)
 "aCm" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable/white{
+	d2 = 8;
 	icon_state = "0-8"
 	},
 /turf/open/floor/plating,
@@ -15445,9 +15681,10 @@
 /obj/machinery/atmospherics/pipe/manifold/cyan/visible{
 	dir = 1
 	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/vault{
-	dir = 5
+/turf/open/floor/plasteel/vault/side{
+	tag = "icon-vault (NORTH)";
+	icon_state = "vault";
+	dir = 1
 	},
 /area/engine/atmos)
 "aCu" = (
@@ -15458,16 +15695,21 @@
 /obj/structure/sign/fire{
 	pixel_y = -32
 	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/vault{
-	dir = 8
+/obj/effect/turf_decal/bot,
+/turf/open/floor/plasteel/vault/side{
+	tag = "icon-vault (NORTH)";
+	icon_state = "vault";
+	dir = 1
 	},
 /area/engine/atmos)
 "aCv" = (
 /obj/machinery/atmospherics/pipe/manifold/yellow/visible,
 /obj/machinery/meter,
-/obj/effect/turf_decal/bot,
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/vault/side{
+	tag = "icon-vault (NORTH)";
+	icon_state = "vault";
+	dir = 1
+	},
 /area/engine/atmos)
 "aCw" = (
 /obj/machinery/atmospherics/pipe/simple/yellow/visible{
@@ -15478,7 +15720,11 @@
 	pixel_y = -32
 	},
 /obj/effect/turf_decal/bot,
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/vault/side{
+	tag = "icon-vault (NORTH)";
+	icon_state = "vault";
+	dir = 1
+	},
 /area/engine/atmos)
 "aCx" = (
 /obj/machinery/atmospherics/pipe/simple/yellow/visible{
@@ -15488,19 +15734,24 @@
 /obj/structure/fireaxecabinet{
 	pixel_y = -28
 	},
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/bot,
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/vault/side{
+	tag = "icon-vault (NORTH)";
+	icon_state = "vault";
+	dir = 1
+	},
 /area/engine/atmos)
 "aCy" = (
 /obj/machinery/atmospherics/pipe/simple/yellow/visible{
 	dir = 9
 	},
 /obj/structure/closet/secure_closet/atmospherics,
-/obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/bot,
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/vault/side{
+	tag = "icon-vault (NORTH)";
+	icon_state = "vault";
+	dir = 1
+	},
 /area/engine/atmos)
 "aCz" = (
 /obj/structure/table/reinforced,
@@ -15516,7 +15767,6 @@
 	pixel_y = -22
 	},
 /obj/machinery/light,
-/obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
@@ -15537,8 +15787,6 @@
 /obj/machinery/newscaster{
 	pixel_y = -32
 	},
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/arrival,
 /area/engine/atmos)
 "aCC" = (
@@ -15550,7 +15798,6 @@
 	dir = 1;
 	pixel_y = -26
 	},
-/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/escape,
 /area/engine/atmos)
 "aCD" = (
@@ -15558,8 +15805,9 @@
 	dir = 1
 	},
 /obj/machinery/portable_atmospherics/scrubber,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
 /turf/open/floor/plasteel/escape,
 /area/engine/atmos)
 "aCE" = (
@@ -15570,7 +15818,11 @@
 	icon_state = "1-2"
 	},
 /obj/effect/turf_decal/bot,
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/vault/side{
+	tag = "icon-vault (NORTH)";
+	icon_state = "vault";
+	dir = 1
+	},
 /area/engine/atmos)
 "aCF" = (
 /obj/machinery/atmospherics/components/binary/pump{
@@ -15584,7 +15836,11 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/bot,
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/vault/side{
+	tag = "icon-vault (NORTH)";
+	icon_state = "vault";
+	dir = 1
+	},
 /area/engine/atmos)
 "aCG" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -15713,8 +15969,10 @@
 /obj/structure/sign/poster/contraband/clown{
 	pixel_x = -32
 	},
-/turf/open/floor/plasteel/vault{
-	dir = 8
+/turf/open/floor/plasteel/vault/side{
+	tag = "icon-vault (EAST)";
+	icon_state = "vault";
+	dir = 4
 	},
 /area/crew_quarters/theatre)
 "aCQ" = (
@@ -15722,7 +15980,7 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 4
 	},
-/turf/open/floor/plasteel/grimy,
+/turf/open/floor/wood,
 /area/crew_quarters/theatre)
 "aCR" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -15732,7 +15990,7 @@
 /obj/structure/cable/white{
 	icon_state = "1-2"
 	},
-/turf/open/floor/plasteel/grimy,
+/turf/open/floor/wood,
 /area/crew_quarters/theatre)
 "aCS" = (
 /obj/structure/dresser,
@@ -15772,11 +16030,11 @@
 	c_tag = "Kitchen";
 	dir = 2
 	},
-/turf/open/floor/plasteel/vault,
+/turf/open/floor/plasteel/vault/side,
 /area/crew_quarters/kitchen)
 "aCW" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/turf/open/floor/plasteel/vault,
+/turf/open/floor/plasteel/vault/side,
 /area/crew_quarters/kitchen)
 "aCX" = (
 /obj/structure/sink/kitchen{
@@ -15784,7 +16042,7 @@
 	name = "sink";
 	pixel_y = 28
 	},
-/turf/open/floor/plasteel/vault,
+/turf/open/floor/plasteel/vault/side,
 /area/crew_quarters/kitchen)
 "aCY" = (
 /obj/structure/closet/secure_closet/freezer/fridge,
@@ -15797,14 +16055,14 @@
 	name = "Kitchen RC";
 	pixel_y = 32
 	},
-/turf/open/floor/plasteel/vault,
+/turf/open/floor/plasteel/vault/side,
 /area/crew_quarters/kitchen)
 "aCZ" = (
 /obj/structure/closet/secure_closet/freezer/fridge,
 /obj/machinery/newscaster{
 	pixel_y = 32
 	},
-/turf/open/floor/plasteel/vault,
+/turf/open/floor/plasteel/vault/side,
 /area/crew_quarters/kitchen)
 "aDa" = (
 /obj/structure/table/reinforced,
@@ -15818,18 +16076,15 @@
 /obj/structure/sign/nanotrasen{
 	pixel_x = 32
 	},
-/turf/open/floor/plasteel/vault,
+/turf/open/floor/plasteel/vault/side,
 /area/crew_quarters/kitchen)
 "aDb" = (
-/obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/structure/cable/white{
 	icon_state = "1-2"
 	},
 /obj/effect/landmark/event_spawn,
-/turf/open/floor/plasteel/neutral/corner{
-	dir = 1
-	},
+/turf/open/floor/plating,
 /area/maintenance/starboard/central)
 "aDc" = (
 /obj/machinery/status_display,
@@ -15851,6 +16106,8 @@
 /area/hallway/secondary/exit)
 "aDe" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 4;
 	icon_state = "1-4"
 	},
 /turf/open/floor/plasteel/escape{
@@ -15859,9 +16116,14 @@
 /area/hallway/secondary/exit)
 "aDg" = (
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 8;
 	icon_state = "1-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
 /turf/open/floor/plasteel/escape{
 	dir = 1
 	},
@@ -15876,9 +16138,6 @@
 	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit)
@@ -15998,7 +16257,6 @@
 	dir = 4
 	},
 /obj/machinery/portable_atmospherics/scrubber,
-/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/escape{
 	dir = 8
 	},
@@ -16107,13 +16365,15 @@
 /obj/structure/mirror{
 	pixel_x = -28
 	},
-/turf/open/floor/plasteel/vault{
-	dir = 8
+/turf/open/floor/plasteel/vault/side{
+	tag = "icon-vault (EAST)";
+	icon_state = "vault";
+	dir = 4
 	},
 /area/crew_quarters/theatre)
 "aDK" = (
 /obj/effect/landmark/start/mime,
-/turf/open/floor/plasteel/grimy,
+/turf/open/floor/wood,
 /area/crew_quarters/theatre)
 "aDL" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
@@ -16122,7 +16382,9 @@
 /obj/structure/cable/white{
 	icon_state = "1-4"
 	},
-/turf/open/floor/plasteel/grimy,
+/turf/open/floor/wood{
+	icon_state = "wood-broken5"
+	},
 /area/crew_quarters/theatre)
 "aDM" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -16294,6 +16556,9 @@
 /area/hallway/secondary/exit)
 "aEe" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
 /turf/open/floor/plasteel/neutral,
 /area/hallway/secondary/exit)
 "aEf" = (
@@ -16428,8 +16693,6 @@
 /area/shuttle/escape)
 "aEn" = (
 /obj/machinery/shieldgen,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
 /obj/structure/sign/nosmoking_2{
 	pixel_y = 32
 	},
@@ -16443,24 +16706,24 @@
 	network = list("SS13")
 	},
 /obj/effect/turf_decal/bot,
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/vault/side{
+	tag = "icon-vault (EAST)";
+	icon_state = "vault";
+	dir = 4
+	},
 /area/engine/engineering)
 "aEo" = (
 /obj/machinery/shieldgen,
-/obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/bot,
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/vault,
 /area/engine/engineering)
 "aEp" = (
-/obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/stripes/line{
 	dir = 9
 	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "aEq" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
 /obj/machinery/power/port_gen/pacman,
 /obj/effect/turf_decal/stripes/line{
 	dir = 5
@@ -16469,14 +16732,17 @@
 /area/engine/engineering)
 "aEr" = (
 /obj/machinery/portable_atmospherics/canister/toxins,
-/obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/bot,
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/vault,
 /area/engine/engineering)
 "aEs" = (
 /obj/machinery/portable_atmospherics/canister/nitrogen,
 /obj/effect/turf_decal/bot,
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/vault/side{
+	tag = "icon-vault (WEST)";
+	icon_state = "vault";
+	dir = 8
+	},
 /area/engine/engineering)
 "aEt" = (
 /turf/closed/wall/r_wall,
@@ -16497,7 +16763,8 @@
 /obj/machinery/light/small{
 	dir = 1
 	},
-/turf/open/floor/plasteel/vault,
+/obj/effect/turf_decal/bot,
+/turf/open/floor/plasteel/vault/side,
 /area/engine/engineering)
 "aEv" = (
 /obj/structure/cable/white{
@@ -16529,7 +16796,6 @@
 /area/engine/engineering)
 "aEx" = (
 /obj/structure/closet/radiation,
-/obj/effect/decal/cleanable/dirt,
 /obj/item/clothing/glasses/meson,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 6
@@ -16540,7 +16806,6 @@
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "aEy" = (
-/obj/effect/decal/cleanable/dirt,
 /obj/structure/cable/white{
 	icon_state = "1-2"
 	},
@@ -16656,6 +16921,7 @@
 	dir = 8;
 	pixel_x = -24
 	},
+/obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel/vault{
 	dir = 5
 	},
@@ -16667,12 +16933,14 @@
 /obj/machinery/status_display{
 	pixel_y = -32
 	},
+/obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel/vault{
 	dir = 5
 	},
 /area/crew_quarters/dorms)
 "aEM" = (
 /obj/structure/closet/crate/bin,
+/obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel/vault{
 	dir = 5
 	},
@@ -16689,6 +16957,7 @@
 	dir = 8;
 	network = list("SS13")
 	},
+/obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel/vault{
 	dir = 5
 	},
@@ -16746,8 +17015,10 @@
 /obj/structure/sign/poster/contraband/random{
 	pixel_y = -32
 	},
-/turf/open/floor/plasteel/vault{
-	dir = 8
+/turf/open/floor/plasteel/vault/corner{
+	tag = "icon-vaultcorner (EAST)";
+	icon_state = "vaultcorner";
+	dir = 4
 	},
 /area/crew_quarters/theatre)
 "aET" = (
@@ -16760,8 +17031,10 @@
 	name = "Station Intercom";
 	pixel_y = -26
 	},
-/turf/open/floor/plasteel/vault{
-	dir = 8
+/turf/open/floor/plasteel/vault/side{
+	tag = "icon-vault (NORTH)";
+	icon_state = "vault";
+	dir = 1
 	},
 /area/crew_quarters/theatre)
 "aEU" = (
@@ -16772,8 +17045,10 @@
 	pixel_y = -32
 	},
 /obj/structure/closet/crate/wooden/toy,
-/turf/open/floor/plasteel/vault{
-	dir = 5
+/turf/open/floor/plasteel/vault/side{
+	tag = "icon-vault (NORTH)";
+	icon_state = "vault";
+	dir = 1
 	},
 /area/crew_quarters/theatre)
 "aEV" = (
@@ -16785,8 +17060,10 @@
 	dir = 8;
 	pixel_x = 24
 	},
-/turf/open/floor/plasteel/vault{
-	dir = 8
+/turf/open/floor/plasteel/vault/side{
+	tag = "icon-vault (NORTH)";
+	icon_state = "vault";
+	dir = 1
 	},
 /area/crew_quarters/theatre)
 "aEW" = (
@@ -16825,6 +17102,7 @@
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
 	dir = 8
 	},
+/obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel/white,
 /area/crew_quarters/kitchen)
 "aFb" = (
@@ -16840,6 +17118,7 @@
 /obj/structure/cable/white{
 	icon_state = "2-4"
 	},
+/obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel/red,
 /area/crew_quarters/kitchen)
 "aFc" = (
@@ -16858,6 +17137,7 @@
 /obj/structure/cable/white{
 	icon_state = "4-8"
 	},
+/obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel/white,
 /area/crew_quarters/kitchen)
 "aFd" = (
@@ -16866,6 +17146,7 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/deepfryer,
+/obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel/red,
 /area/crew_quarters/kitchen)
 "aFe" = (
@@ -16878,7 +17159,6 @@
 /turf/open/floor/plasteel/white,
 /area/crew_quarters/kitchen)
 "aFf" = (
-/obj/effect/decal/cleanable/dirt,
 /obj/machinery/door/airlock/maintenance_hatch{
 	name = "Kitchen Maintenance";
 	req_access_txt = "28"
@@ -16896,7 +17176,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plating,
 /area/maintenance/starboard/central)
 "aFg" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
@@ -16951,7 +17231,9 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
-/obj/effect/turf_decal/delivery,
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit)
 "aFl" = (
@@ -16960,6 +17242,9 @@
 /area/hallway/secondary/exit)
 "aFn" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
 /turf/open/floor/plasteel/neutral,
@@ -16978,24 +17263,24 @@
 /area/shuttle/escape)
 "aFq" = (
 /obj/machinery/power/emitter,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
 /obj/machinery/light/small,
 /obj/effect/turf_decal/bot,
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/vault/side{
+	tag = "icon-vault (EAST)";
+	icon_state = "vault";
+	dir = 4
+	},
 /area/engine/engineering)
 "aFr" = (
 /obj/machinery/power/emitter,
-/obj/effect/decal/cleanable/dirt,
 /obj/machinery/firealarm{
 	dir = 1;
 	pixel_y = -26
 	},
 /obj/effect/turf_decal/bot,
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/vault,
 /area/engine/engineering)
 "aFs" = (
-/obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/stripes/line{
 	dir = 10
 	},
@@ -17008,13 +17293,11 @@
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "aFu" = (
-/obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/delivery,
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/vault,
 /area/engine/engineering)
 "aFv" = (
 /obj/structure/closet/crate,
-/obj/effect/decal/cleanable/dirt,
 /obj/item/crowbar/red,
 /obj/item/stack/sheet/mineral/plasma{
 	amount = 20
@@ -17022,13 +17305,16 @@
 /obj/item/device/gps/engineering{
 	gpstag = "ENG0"
 	},
-/obj/effect/decal/cleanable/dirt,
 /obj/machinery/light/small,
 /obj/structure/extinguisher_cabinet{
 	pixel_x = 26
 	},
 /obj/effect/turf_decal/bot,
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/vault/side{
+	tag = "icon-vault (WEST)";
+	icon_state = "vault";
+	dir = 8
+	},
 /area/engine/engineering)
 "aFw" = (
 /obj/structure/cable/white{
@@ -17037,10 +17323,12 @@
 /obj/structure/extinguisher_cabinet{
 	pixel_x = -26
 	},
-/obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/components/unary/vent_pump/on,
 /obj/effect/turf_decal/stripes/line{
 	dir = 2
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
 	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
@@ -17051,12 +17339,14 @@
 /obj/structure/cable{
 	icon_state = "0-2"
 	},
-/obj/effect/decal/cleanable/dirt,
 /obj/structure/cable{
 	icon_state = "2-4"
 	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 2
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
 	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
@@ -17068,7 +17358,6 @@
 	dir = 4;
 	pixel_x = 24
 	},
-/obj/effect/decal/cleanable/dirt,
 /obj/structure/cable{
 	icon_state = "0-8"
 	},
@@ -17080,11 +17369,13 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 2
 	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "aFz" = (
 /obj/structure/closet/radiation,
-/obj/effect/decal/cleanable/dirt,
 /obj/structure/extinguisher_cabinet{
 	pixel_x = -26
 	},
@@ -17099,7 +17390,6 @@
 /obj/structure/cable/white{
 	icon_state = "1-2"
 	},
-/obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 4
 	},
@@ -17112,7 +17402,6 @@
 	icon_state = "shower";
 	name = "emergency shower"
 	},
-/obj/effect/decal/cleanable/dirt,
 /obj/machinery/light/small,
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
 	dir = 4
@@ -17343,11 +17632,13 @@
 "aFY" = (
 /obj/machinery/holopad,
 /obj/effect/landmark/lightsout,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/structure/cable/white{
 	icon_state = "1-2"
 	},
 /obj/effect/turf_decal/bot,
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
+	dir = 8
+	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "aFZ" = (
@@ -17371,6 +17662,9 @@
 /obj/machinery/holopad,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/effect/turf_decal/bot,
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit)
 "aGc" = (
@@ -17410,8 +17704,6 @@
 	id = "engstorage";
 	name = "Engineering Secure Storage Lockdown"
 	},
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
@@ -17449,8 +17741,6 @@
 /obj/structure/cable/white{
 	icon_state = "1-4"
 	},
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
@@ -17492,7 +17782,6 @@
 /obj/structure/cable/white{
 	icon_state = "1-2"
 	},
-/obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/stripes/line{
 	dir = 2
 	},
@@ -17511,7 +17800,6 @@
 	dir = 4
 	},
 /obj/machinery/portable_atmospherics/pump,
-/obj/effect/decal/cleanable/dirt,
 /obj/structure/extinguisher_cabinet{
 	pixel_x = -24
 	},
@@ -17592,9 +17880,8 @@
 /area/maintenance/port/central)
 "aGz" = (
 /obj/structure/reagent_dispensers/watertank,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/bot,
+/obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plasteel,
 /area/maintenance/port/central)
 "aGA" = (
@@ -17604,20 +17891,18 @@
 	pixel_y = 28
 	},
 /obj/item/reagent_containers/glass/bucket,
-/obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/delivery,
+/obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plasteel,
 /area/maintenance/port/central)
 "aGB" = (
 /obj/structure/mopbucket,
-/obj/effect/decal/cleanable/dirt,
 /obj/item/mop,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
 /obj/machinery/light/small{
 	dir = 1
 	},
 /obj/effect/turf_decal/bot,
+/obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plasteel,
 /area/maintenance/port/central)
 "aGC" = (
@@ -17634,12 +17919,9 @@
 	areastring = "/area/maintenance/port/central";
 	pixel_y = 25
 	},
-/turf/open/floor/plasteel/neutral/corner{
-	dir = 1
-	},
+/turf/open/floor/plating,
 /area/maintenance/port/central)
 "aGE" = (
-/obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 6
 	},
@@ -17659,17 +17941,18 @@
 /turf/open/floor/plasteel/neutral/corner,
 /area/maintenance/port/central)
 "aGG" = (
-/obj/effect/decal/cleanable/dirt,
 /obj/structure/cable/white{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
-/turf/open/floor/plating,
+/turf/open/floor/plating{
+	burnt = 1;
+	icon_state = "panelscorched"
+	},
 /area/maintenance/port/central)
 "aGH" = (
-/obj/effect/decal/cleanable/dirt,
 /obj/structure/cable/white{
 	icon_state = "4-8"
 	},
@@ -17677,12 +17960,10 @@
 	icon_state = "1-8"
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden,
-/turf/open/floor/plasteel/neutral/corner{
-	dir = 1
-	},
+/turf/open/floor/plating,
 /area/maintenance/port/central)
 "aGI" = (
-/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
@@ -17690,10 +17971,10 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
+/turf/open/floor/plating{
+	tag = "icon-platingdmg2";
+	icon_state = "platingdmg2"
 	},
-/turf/open/floor/plasteel,
 /area/maintenance/port/central)
 "aGJ" = (
 /obj/structure/cable/white{
@@ -17702,11 +17983,10 @@
 /obj/structure/cable/white{
 	icon_state = "2-8"
 	},
-/obj/effect/turf_decal/delivery,
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
 	dir = 1
 	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plating,
 /area/maintenance/port/central)
 "aGK" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -17715,35 +17995,31 @@
 /obj/structure/cable/white{
 	icon_state = "4-8"
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
+/turf/open/floor/plating{
+	broken = 1;
+	icon_state = "platingdmg3"
 	},
-/turf/open/floor/plasteel,
 /area/maintenance/port/central)
 "aGL" = (
-/obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
 /obj/structure/cable/white{
 	icon_state = "4-8"
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
+/turf/open/floor/plating{
+	burnt = 1;
+	icon_state = "panelscorched"
 	},
-/turf/open/floor/plasteel,
 /area/maintenance/port/central)
 "aGM" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
 /obj/structure/cable/white{
 	icon_state = "4-8"
 	},
-/obj/effect/turf_decal/delivery,
-/turf/open/floor/plasteel,
+/turf/open/floor/plating,
 /area/maintenance/port/central)
 "aGN" = (
 /obj/structure/chair/stool,
@@ -17810,25 +18086,30 @@
 	dir = 1;
 	pixel_y = -32
 	},
-/turf/open/floor/plasteel/vault{
-	dir = 5
+/obj/effect/turf_decal/bot,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
 	},
+/turf/open/floor/plasteel/escape,
 /area/crew_quarters/kitchen)
 "aGS" = (
 /obj/machinery/processor,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/effect/turf_decal/stripes/end{
-	dir = 1
+/obj/effect/turf_decal/bot,
+/obj/effect/turf_decal/stripes/line{
+	dir = 5
 	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/escape,
 /area/crew_quarters/kitchen)
 "aGT" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/structure/cable/white{
 	icon_state = "1-2"
 	},
-/turf/open/floor/plasteel/vault{
-	dir = 8
+/turf/open/floor/plasteel/vault/side{
+	tag = "icon-vault (NORTH)";
+	icon_state = "vault";
+	dir = 1
 	},
 /area/crew_quarters/kitchen)
 "aGU" = (
@@ -17843,8 +18124,10 @@
 /obj/item/storage/box/donkpockets,
 /obj/item/clothing/head/chefhat,
 /obj/machinery/light,
-/turf/open/floor/plasteel/vault{
-	dir = 5
+/turf/open/floor/plasteel/vault/side{
+	tag = "icon-vault (NORTH)";
+	icon_state = "vault";
+	dir = 1
 	},
 /area/crew_quarters/kitchen)
 "aGV" = (
@@ -17858,8 +18141,10 @@
 	dir = 1;
 	pixel_y = -22
 	},
-/turf/open/floor/plasteel/vault{
-	dir = 5
+/turf/open/floor/plasteel/vault/side{
+	tag = "icon-vault (NORTH)";
+	icon_state = "vault";
+	dir = 1
 	},
 /area/crew_quarters/kitchen)
 "aGW" = (
@@ -17869,8 +18154,10 @@
 	pixel_x = -3;
 	pixel_y = 5
 	},
-/turf/open/floor/plasteel/vault{
-	dir = 5
+/turf/open/floor/plasteel/vault/side{
+	tag = "icon-vault (NORTH)";
+	icon_state = "vault";
+	dir = 1
 	},
 /area/crew_quarters/kitchen)
 "aGX" = (
@@ -17928,33 +18215,31 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 6
 	},
-/turf/open/floor/plasteel,
+/turf/open/floor/engine,
 /area/engine/engineering)
 "aHj" = (
 /obj/structure/cable/white{
 	icon_state = "4-8"
 	},
-/obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
 /obj/effect/turf_decal/stripes/corner{
 	dir = 4
 	},
-/turf/open/floor/plasteel,
+/turf/open/floor/engine,
 /area/engine/engineering)
 "aHk" = (
 /obj/structure/cable/white{
 	icon_state = "4-8"
 	},
-/obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
 /obj/effect/turf_decal/stripes/corner{
 	dir = 8
 	},
-/turf/open/floor/plasteel,
+/turf/open/floor/engine,
 /area/engine/engineering)
 "aHl" = (
 /obj/structure/cable/white{
@@ -17966,7 +18251,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
-/turf/open/floor/plasteel,
+/turf/open/floor/engine,
 /area/engine/engineering)
 "aHm" = (
 /obj/structure/cable/white{
@@ -17982,7 +18267,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
-/turf/open/floor/plasteel,
+/turf/open/floor/engine,
 /area/engine/engineering)
 "aHn" = (
 /obj/structure/cable/white{
@@ -18003,7 +18288,7 @@
 	network = list("SS13","Engine");
 	pixel_x = 23
 	},
-/turf/open/floor/plasteel,
+/turf/open/floor/engine,
 /area/engine/engineering)
 "aHo" = (
 /obj/structure/cable/white{
@@ -18012,12 +18297,11 @@
 /obj/structure/cable/white{
 	icon_state = "1-8"
 	},
-/obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden,
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
-/turf/open/floor/plasteel,
+/turf/open/floor/engine,
 /area/engine/engineering)
 "aHp" = (
 /obj/structure/cable{
@@ -18032,7 +18316,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
-/turf/open/floor/plasteel,
+/turf/open/floor/engine,
 /area/engine/engineering)
 "aHq" = (
 /obj/structure/cable/white{
@@ -18050,7 +18334,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
-/turf/open/floor/plasteel,
+/turf/open/floor/engine,
 /area/engine/engineering)
 "aHr" = (
 /obj/structure/cable/white{
@@ -18059,14 +18343,13 @@
 /obj/machinery/firealarm{
 	pixel_y = 24
 	},
-/obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
-/turf/open/floor/plasteel,
+/turf/open/floor/engine,
 /area/engine/engineering)
 "aHs" = (
 /obj/structure/cable/white{
@@ -18087,14 +18370,13 @@
 /obj/structure/cable/white{
 	icon_state = "1-8"
 	},
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
-/turf/open/floor/plasteel/caution{
+/obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
+/turf/open/floor/engine,
 /area/engine/engineering)
 "aHu" = (
 /obj/structure/cable/white{
@@ -18103,13 +18385,13 @@
 /obj/item/twohanded/required/kirbyplants{
 	icon_state = "plant-22"
 	},
-/obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
 	dir = 4
 	},
-/turf/open/floor/plasteel/caution{
+/obj/effect/turf_decal/stripes/line{
 	dir = 5
 	},
+/turf/open/floor/engine,
 /area/engine/engineering)
 "aHv" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -18153,7 +18435,6 @@
 /obj/structure/cable/white{
 	icon_state = "1-2"
 	},
-/obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/stripes/line{
 	dir = 2
 	},
@@ -18247,7 +18528,6 @@
 /turf/open/floor/plasteel/neutral/corner,
 /area/hallway/primary/central)
 "aHE" = (
-/obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
@@ -18255,10 +18535,13 @@
 	icon_state = "4-8"
 	},
 /obj/effect/turf_decal/bot,
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/vault/side{
+	tag = "icon-vault (WEST)";
+	icon_state = "vault";
+	dir = 8
+	},
 /area/hallway/primary/central)
 "aHF" = (
-/obj/effect/decal/cleanable/dirt,
 /obj/machinery/door/airlock/maintenance_hatch{
 	name = "Maintenance Hatch";
 	req_access_txt = "12"
@@ -18275,7 +18558,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plating,
 /area/maintenance/port/central)
 "aHG" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -18290,7 +18573,6 @@
 /turf/open/floor/plasteel,
 /area/maintenance/port/central)
 "aHH" = (
-/obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
@@ -18303,23 +18585,19 @@
 /obj/structure/cable/white{
 	icon_state = "2-8"
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 2
+/turf/open/floor/plating{
+	burnt = 1;
+	icon_state = "panelscorched"
 	},
-/turf/open/floor/plasteel,
 /area/maintenance/port/central)
 "aHI" = (
-/obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
 	dir = 1
 	},
 /obj/structure/cable/white{
 	icon_state = "4-8"
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 2
-	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plating,
 /area/maintenance/port/central)
 "aHJ" = (
 /obj/effect/decal/cleanable/dirt,
@@ -18357,7 +18635,7 @@
 /obj/structure/cable/white{
 	icon_state = "1-8"
 	},
-/turf/open/floor/plasteel/neutral/corner,
+/turf/open/floor/plating,
 /area/maintenance/port/central)
 "aHM" = (
 /turf/closed/wall,
@@ -18373,7 +18651,6 @@
 	name = "Hydroponic's Maintenance";
 	req_access_txt = "35"
 	},
-/obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
@@ -18387,7 +18664,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plating,
 /area/maintenance/port/central)
 "aHP" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
@@ -18468,7 +18745,11 @@
 /obj/item/paper_bin,
 /obj/item/pen,
 /obj/effect/turf_decal/delivery,
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/vault/side{
+	tag = "icon-vault (WEST)";
+	icon_state = "vault";
+	dir = 8
+	},
 /area/hallway/primary/central)
 "aHZ" = (
 /obj/item/twohanded/required/kirbyplants{
@@ -18518,19 +18799,18 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
-/turf/open/floor/plasteel,
+/turf/open/floor/engine,
 /area/engine/engineering)
 "aIg" = (
 /obj/structure/cable{
 	icon_state = "2-4"
 	},
-/obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/stripes/corner,
 /obj/machinery/atmospherics/pipe/simple/green/visible{
 	dir = 6
 	},
 /obj/machinery/meter,
-/turf/open/floor/plasteel,
+/turf/open/floor/engine,
 /area/engine/engineering)
 "aIh" = (
 /obj/structure/cable{
@@ -18540,7 +18820,7 @@
 /obj/machinery/atmospherics/pipe/simple/green/visible{
 	dir = 4
 	},
-/turf/open/floor/plasteel,
+/turf/open/floor/engine,
 /area/engine/engineering)
 "aIi" = (
 /obj/structure/cable{
@@ -18550,13 +18830,12 @@
 /obj/machinery/atmospherics/components/trinary/filter/flipped/critical{
 	dir = 4
 	},
-/turf/open/floor/plasteel,
+/turf/open/floor/engine,
 /area/engine/engineering)
 "aIj" = (
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 1
 	},
@@ -18564,7 +18843,7 @@
 /obj/machinery/atmospherics/pipe/simple/green/visible{
 	dir = 4
 	},
-/turf/open/floor/plasteel,
+/turf/open/floor/engine,
 /area/engine/engineering)
 "aIk" = (
 /obj/structure/cable{
@@ -18574,12 +18853,11 @@
 	dir = 1;
 	pixel_y = -26
 	},
-/obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/stripes/line,
 /obj/machinery/atmospherics/pipe/manifold/green/visible{
 	dir = 1
 	},
-/turf/open/floor/plasteel,
+/turf/open/floor/engine,
 /area/engine/engineering)
 "aIl" = (
 /obj/machinery/atmospherics/components/binary/pump{
@@ -18591,7 +18869,7 @@
 	icon_state = "4-8"
 	},
 /obj/effect/turf_decal/stripes/line,
-/turf/open/floor/plasteel,
+/turf/open/floor/engine,
 /area/engine/engineering)
 "aIm" = (
 /obj/machinery/button/door{
@@ -18610,13 +18888,12 @@
 /obj/machinery/atmospherics/pipe/manifold/cyan/visible{
 	dir = 1
 	},
-/turf/open/floor/plasteel,
+/turf/open/floor/engine,
 /area/engine/engineering)
 "aIn" = (
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 1
 	},
@@ -18624,7 +18901,7 @@
 /obj/machinery/atmospherics/pipe/simple/cyan/visible{
 	dir = 4
 	},
-/turf/open/floor/plasteel,
+/turf/open/floor/engine,
 /area/engine/engineering)
 "aIo" = (
 /obj/structure/cable{
@@ -18634,7 +18911,7 @@
 /obj/machinery/atmospherics/pipe/manifold/cyan/visible{
 	dir = 1
 	},
-/turf/open/floor/plasteel,
+/turf/open/floor/engine,
 /area/engine/engineering)
 "aIp" = (
 /obj/structure/cable{
@@ -18645,7 +18922,7 @@
 /obj/machinery/atmospherics/pipe/manifold/cyan/visible{
 	dir = 1
 	},
-/turf/open/floor/plasteel,
+/turf/open/floor/engine,
 /area/engine/engineering)
 "aIq" = (
 /obj/structure/cable{
@@ -18657,18 +18934,17 @@
 /obj/machinery/atmospherics/pipe/simple/cyan/visible{
 	dir = 10
 	},
-/turf/open/floor/plasteel,
+/turf/open/floor/engine,
 /area/engine/engineering)
 "aIr" = (
 /obj/structure/cable/white{
 	icon_state = "1-2"
 	},
-/obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
-/turf/open/floor/plasteel,
+/turf/open/floor/engine,
 /area/engine/engineering)
 "aIs" = (
 /obj/structure/table/reinforced,
@@ -18678,7 +18954,6 @@
 /obj/machinery/newscaster{
 	pixel_x = -32
 	},
-/obj/effect/decal/cleanable/dirt,
 /obj/machinery/camera{
 	c_tag = "Engineering Monitoring";
 	dir = 2;
@@ -18699,14 +18974,12 @@
 	pixel_y = 24
 	},
 /obj/structure/closet/crate/bin,
-/obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "aIv" = (
 /obj/structure/table/reinforced,
-/obj/effect/decal/cleanable/dirt,
 /obj/item/paper_bin,
 /obj/item/pen,
 /obj/effect/turf_decal/bot,
@@ -18793,31 +19066,33 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plating,
 /area/maintenance/port/central)
 "aID" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/closed/wall,
 /area/janitor)
 "aIE" = (
-/obj/effect/decal/cleanable/dirt,
 /obj/structure/closet,
 /obj/effect/spawner/lootdrop/maintenance{
 	lootcount = 3;
 	name = "3maintenance loot spawner"
 	},
-/obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/bot,
+/obj/effect/turf_decal/stripes/line{
+	dir = 5
+	},
 /turf/open/floor/plasteel,
 /area/maintenance/port/central)
 "aIF" = (
-/obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/structure/cable/white{
 	icon_state = "1-2"
 	},
-/obj/effect/turf_decal/delivery,
-/turf/open/floor/plasteel,
+/turf/open/floor/plating{
+	broken = 1;
+	icon_state = "platingdmg1"
+	},
 /area/maintenance/port/central)
 "aIG" = (
 /obj/item/crowbar/red,
@@ -18832,22 +19107,20 @@
 /obj/item/reagent_containers/glass/bucket,
 /obj/structure/closet/crate/hydroponics,
 /obj/effect/turf_decal/delivery,
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/vault/side,
 /area/hydroponics)
 "aIH" = (
 /obj/structure/sink{
 	dir = 4;
 	pixel_x = 12
 	},
-/obj/effect/turf_decal/delivery,
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/vault/side,
 /area/hydroponics)
 "aII" = (
 /obj/machinery/hydroponics/constructable,
 /obj/machinery/airalarm{
 	pixel_y = 23
 	},
-/obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/stripes/line{
 	dir = 10
 	},
@@ -18880,8 +19153,7 @@
 /obj/structure/cable/white{
 	icon_state = "1-2"
 	},
-/obj/effect/turf_decal/delivery,
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/vault/side,
 /area/hydroponics)
 "aIM" = (
 /obj/machinery/chem_master/condimaster{
@@ -18895,7 +19167,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/effect/turf_decal/bot,
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/vault/side,
 /area/hydroponics)
 "aIN" = (
 /obj/machinery/vending/hydronutrients,
@@ -18903,7 +19175,7 @@
 	pixel_y = 30
 	},
 /obj/effect/turf_decal/bot,
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/vault/side,
 /area/hydroponics)
 "aIO" = (
 /obj/machinery/vending/hydroseeds,
@@ -18919,7 +19191,7 @@
 	req_access_txt = "35"
 	},
 /obj/effect/turf_decal/bot,
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/vault/side,
 /area/hydroponics)
 "aIP" = (
 /obj/structure/table/reinforced,
@@ -18938,19 +19210,22 @@
 	pixel_x = 32
 	},
 /obj/structure/closet/crate/bin,
-/turf/open/floor/plasteel/redyellow,
+/turf/open/floor/plasteel/vault/side{
+	tag = "icon-vault (NORTHWEST)";
+	icon_state = "vault";
+	dir = 9
+	},
 /area/crew_quarters/bar/atrium)
 "aIR" = (
 /obj/structure/closet/secure_closet/freezer/meat,
 /obj/effect/turf_decal/bot,
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/freezer,
 /area/crew_quarters/kitchen)
 "aIS" = (
 /obj/structure/closet/chefcloset,
-/obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/effect/turf_decal/bot,
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/freezer,
 /area/crew_quarters/kitchen)
 "aIT" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
@@ -18962,8 +19237,7 @@
 /obj/structure/cable/white{
 	icon_state = "1-4"
 	},
-/obj/effect/turf_decal/delivery,
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/freezer,
 /area/crew_quarters/kitchen)
 "aIU" = (
 /obj/structure/sink/kitchen{
@@ -18997,10 +19271,8 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 6
-	},
 /obj/structure/reagent_dispensers/cooking_oil,
+/obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plasteel,
 /area/crew_quarters/kitchen)
 "aIX" = (
@@ -19086,7 +19358,6 @@
 /obj/machinery/light{
 	dir = 8
 	},
-/obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/bot_white/left,
 /turf/open/floor/plasteel/vault{
 	dir = 4
@@ -19114,7 +19385,6 @@
 	pixel_x = -24;
 	pixel_y = 32
 	},
-/obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on,
 /obj/machinery/camera{
 	c_tag = "Gravity Generator Entry";
@@ -19162,7 +19432,6 @@
 /turf/open/floor/plasteel,
 /area/engine/gravity_generator)
 "aJn" = (
-/obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/cobweb/cobweb2,
 /obj/machinery/power/smes{
 	charge = 5e+006
@@ -19196,7 +19465,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 9
 	},
-/turf/open/floor/plasteel,
+/turf/open/floor/engine,
 /area/engine/engineering)
 "aJq" = (
 /obj/structure/cable{
@@ -19206,7 +19475,7 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/green/visible,
-/turf/open/floor/plasteel,
+/turf/open/floor/engine,
 /area/engine/engineering)
 "aJr" = (
 /obj/item/wrench,
@@ -19214,7 +19483,7 @@
 	dir = 6
 	},
 /obj/effect/turf_decal/delivery,
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/dark,
 /area/engine/engineering)
 "aJs" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/visible{
@@ -19222,7 +19491,7 @@
 	},
 /obj/machinery/meter,
 /obj/effect/turf_decal/delivery,
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/dark,
 /area/engine/engineering)
 "aJt" = (
 /obj/structure/sign/radiation,
@@ -19245,9 +19514,8 @@
 	dir = 1;
 	name = "External Gas to Loop"
 	},
-/obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/delivery,
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/dark,
 /area/engine/engineering)
 "aJx" = (
 /obj/machinery/atmospherics/components/binary/pump{
@@ -19263,12 +19531,11 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/cyan/visible,
-/turf/open/floor/plasteel,
+/turf/open/floor/engine,
 /area/engine/engineering)
 "aJz" = (
 /obj/structure/cable/white{
@@ -19280,7 +19547,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
-/turf/open/floor/plasteel,
+/turf/open/floor/engine,
 /area/engine/engineering)
 "aJA" = (
 /obj/effect/spawner/structure/window/reinforced,
@@ -19310,6 +19577,9 @@
 /obj/item/grenade/chem_grenade/smart_metal_foam,
 /obj/item/grenade/chem_grenade/smart_metal_foam,
 /obj/item/crowbar,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
 /turf/open/floor/plasteel/yellow/side{
 	dir = 8
 	},
@@ -19321,6 +19591,9 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
 /turf/open/floor/plasteel/yellow,
 /area/engine/engineering)
 "aJD" = (
@@ -19328,6 +19601,9 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
 /turf/open/floor/plasteel/neutral,
 /area/engine/engineering)
 "aJE" = (
@@ -19336,6 +19612,9 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/bot,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "aJF" = (
@@ -19343,6 +19622,9 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
 /turf/open/floor/plasteel/neutral,
 /area/engine/engineering)
 "aJG" = (
@@ -19350,6 +19632,9 @@
 	dir = 4
 	},
 /obj/effect/landmark/start/station_engineer,
+/obj/effect/turf_decal/stripes/line{
+	dir = 5
+	},
 /turf/open/floor/plasteel/yellow,
 /area/engine/engineering)
 "aJH" = (
@@ -19359,6 +19644,7 @@
 /obj/machinery/computer/apc_control{
 	dir = 8
 	},
+/obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel/yellow/side{
 	dir = 4
 	},
@@ -19394,11 +19680,14 @@
 	c_tag = "Custodial Closet"
 	},
 /obj/effect/turf_decal/bot,
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/vault/side{
+	tag = "icon-vault (EAST)";
+	icon_state = "vault";
+	dir = 4
+	},
 /area/janitor)
 "aJJ" = (
 /obj/vehicle/ridden/janicart,
-/obj/effect/decal/cleanable/dirt,
 /obj/item/storage/bag/trash,
 /obj/item/key/janitor,
 /obj/machinery/power/apc/highcap/five_k{
@@ -19414,8 +19703,6 @@
 /turf/open/floor/plasteel,
 /area/janitor)
 "aJK" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
 /obj/structure/cable/white{
 	icon_state = "1-2"
 	},
@@ -19424,16 +19711,18 @@
 /area/janitor)
 "aJL" = (
 /obj/structure/closet/crate/bin,
-/obj/effect/decal/cleanable/dirt,
 /obj/structure/extinguisher_cabinet{
 	pixel_y = 26
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/effect/turf_decal/bot,
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/vault/side{
+	tag = "icon-vault (WEST)";
+	icon_state = "vault";
+	dir = 8
+	},
 /area/janitor)
 "aJM" = (
-/obj/effect/decal/cleanable/dirt,
 /obj/machinery/door/airlock/maintenance_hatch{
 	name = "Maintenance Hatch";
 	req_access_txt = "12"
@@ -19448,7 +19737,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plating,
 /area/maintenance/port/central)
 "aJN" = (
 /obj/machinery/seed_extractor,
@@ -19529,8 +19818,10 @@
 /turf/open/floor/plasteel/redyellow,
 /area/crew_quarters/bar/atrium)
 "aJX" = (
-/obj/machinery/vending/cola,
-/turf/open/floor/plasteel/vault{
+/obj/machinery/vending/cola/random,
+/turf/open/floor/plasteel/vault/side{
+	tag = "icon-vault (WEST)";
+	icon_state = "vault";
 	dir = 8
 	},
 /area/crew_quarters/bar/atrium)
@@ -19547,8 +19838,7 @@
 	dir = 4;
 	network = list("MINE")
 	},
-/obj/effect/turf_decal/delivery,
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/freezer,
 /area/crew_quarters/kitchen)
 "aKa" = (
 /obj/machinery/airalarm{
@@ -19602,11 +19892,9 @@
 /obj/structure/cable/white{
 	icon_state = "4-8"
 	},
-/obj/effect/turf_decal/delivery,
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/freezer,
 /area/crew_quarters/kitchen)
 "aKf" = (
-/obj/effect/decal/cleanable/dirt,
 /obj/structure/cable/white{
 	icon_state = "1-2"
 	},
@@ -19619,12 +19907,19 @@
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
 	dir = 4
 	},
-/turf/open/floor/plating,
+/turf/open/floor/plating{
+	burnt = 1;
+	icon_state = "panelscorched"
+	},
 /area/maintenance/starboard/central)
 "aKg" = (
 /obj/structure/closet/emcloset,
 /obj/effect/turf_decal/delivery,
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/vault/side{
+	tag = "icon-vault (NORTH)";
+	icon_state = "vault";
+	dir = 1
+	},
 /area/hallway/primary/central)
 "aKh" = (
 /obj/structure/sign/nanotrasen,
@@ -19644,11 +19939,9 @@
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit)
 "aKj" = (
-/obj/effect/decal/cleanable/dirt,
 /obj/structure/plasticflaps{
 	opacity = 1
 	},
-/obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/effect/turf_decal/delivery,
 /turf/open/floor/plasteel,
@@ -19703,7 +19996,6 @@
 	name = "Gravity Generator Chamber";
 	req_access_txt = "19; 61"
 	},
-/obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
@@ -19719,8 +20011,6 @@
 /turf/open/floor/plasteel,
 /area/engine/gravity_generator)
 "aKt" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 8
 	},
@@ -19734,7 +20024,6 @@
 /area/engine/gravity_generator)
 "aKu" = (
 /obj/machinery/holopad,
-/obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 9
 	},
@@ -19747,7 +20036,6 @@
 /turf/open/floor/plasteel/neutral,
 /area/engine/gravity_generator)
 "aKv" = (
-/obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/components/unary/vent_pump/on,
 /obj/structure/cable/white{
 	icon_state = "1-4"
@@ -19758,7 +20046,6 @@
 /turf/open/floor/plasteel,
 /area/engine/gravity_generator)
 "aKw" = (
-/obj/effect/decal/cleanable/dirt,
 /obj/structure/cable/white{
 	icon_state = "4-8"
 	},
@@ -19808,7 +20095,7 @@
 /obj/machinery/atmospherics/pipe/simple/green/visible{
 	dir = 6
 	},
-/turf/open/floor/plasteel,
+/turf/open/floor/engine,
 /area/engine/engineering)
 "aKz" = (
 /obj/machinery/portable_atmospherics/scrubber,
@@ -19816,7 +20103,7 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/bot,
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/dark,
 /area/engine/engineering)
 "aKA" = (
 /obj/machinery/atmospherics/components/binary/pump{
@@ -19827,7 +20114,6 @@
 	dir = 4;
 	pixel_x = -23
 	},
-/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/engine,
 /area/engine/supermatter)
 "aKB" = (
@@ -19841,7 +20127,6 @@
 	icon_state = "pump_map";
 	name = "Gas to Chamber"
 	},
-/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/engine,
 /area/engine/supermatter)
 "aKD" = (
@@ -19854,7 +20139,7 @@
 	},
 /obj/machinery/portable_atmospherics/canister/nitrogen,
 /obj/effect/turf_decal/bot,
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/dark,
 /area/engine/engineering)
 "aKF" = (
 /obj/structure/cable{
@@ -19876,7 +20161,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
-/turf/open/floor/plasteel,
+/turf/open/floor/engine,
 /area/engine/engineering)
 "aKH" = (
 /obj/machinery/door/firedoor,
@@ -19939,7 +20224,6 @@
 /obj/item/stack/cable_coil/white,
 /obj/item/electronics/airlock,
 /obj/item/electronics/airlock,
-/obj/effect/decal/cleanable/dirt,
 /obj/structure/cable/white{
 	icon_state = "4-8"
 	},
@@ -19970,6 +20254,9 @@
 /obj/structure/cable/white{
 	icon_state = "4-8"
 	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
 /turf/open/floor/plasteel/neutral,
 /area/engine/engineering)
 "aKO" = (
@@ -19985,6 +20272,7 @@
 /obj/machinery/computer/rdconsole/production{
 	dir = 8
 	},
+/obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel/yellow/side{
 	dir = 4
 	},
@@ -20003,7 +20291,11 @@
 	pixel_x = -32
 	},
 /obj/effect/turf_decal/bot,
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/vault/side{
+	tag = "icon-vault (EAST)";
+	icon_state = "vault";
+	dir = 4
+	},
 /area/janitor)
 "aKQ" = (
 /obj/effect/landmark/start/janitor,
@@ -20028,7 +20320,6 @@
 /area/janitor)
 "aKS" = (
 /obj/structure/janitorialcart,
-/obj/effect/decal/cleanable/dirt,
 /obj/machinery/light/small{
 	dir = 4
 	},
@@ -20036,12 +20327,19 @@
 	pixel_x = 32
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/turf/open/floor/plating,
+/obj/effect/turf_decal/bot,
+/turf/open/floor/plasteel/vault/side{
+	tag = "icon-vault (WEST)";
+	icon_state = "vault";
+	dir = 8
+	},
 /area/janitor)
 "aKT" = (
 /obj/machinery/shieldgen,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating,
+/obj/effect/turf_decal/stripes/line{
+	dir = 9
+	},
+/turf/open/floor/plasteel,
 /area/maintenance/port/central)
 "aKU" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -20079,7 +20377,7 @@
 	},
 /obj/item/reagent_containers/glass/bucket,
 /obj/effect/turf_decal/delivery,
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/neutral,
 /area/hydroponics)
 "aKY" = (
 /obj/structure/table/glass,
@@ -20093,7 +20391,7 @@
 /obj/item/reagent_containers/glass/bottle/nutrient/rh,
 /obj/item/reagent_containers/dropper,
 /obj/effect/turf_decal/delivery,
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/neutral,
 /area/hydroponics)
 "aKZ" = (
 /obj/structure/table/glass,
@@ -20102,7 +20400,7 @@
 /obj/item/grenade/chem_grenade/antiweed,
 /obj/item/grenade/chem_grenade/antiweed,
 /obj/effect/turf_decal/delivery,
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/neutral,
 /area/hydroponics)
 "aLa" = (
 /obj/machinery/holopad,
@@ -20111,7 +20409,7 @@
 	icon_state = "1-2"
 	},
 /obj/effect/turf_decal/bot,
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/neutral,
 /area/hydroponics)
 "aLb" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -20131,7 +20429,11 @@
 /obj/item/seeds/wheat,
 /obj/item/reagent_containers/food/snacks/grown/tomato,
 /obj/effect/turf_decal/bot,
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/vault/side{
+	tag = "icon-vault (NORTH)";
+	icon_state = "vault";
+	dir = 1
+	},
 /area/hydroponics)
 "aLd" = (
 /obj/structure/table/glass,
@@ -20146,7 +20448,11 @@
 	},
 /obj/item/seeds/tower,
 /obj/effect/turf_decal/bot,
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/vault/side{
+	tag = "icon-vault (NORTH)";
+	icon_state = "vault";
+	dir = 1
+	},
 /area/hydroponics)
 "aLe" = (
 /obj/machinery/smartfridge,
@@ -20160,7 +20466,7 @@
 /turf/open/floor/plasteel/redyellow,
 /area/crew_quarters/bar/atrium)
 "aLg" = (
-/obj/machinery/vending/snack,
+/obj/machinery/vending/snack/random,
 /obj/machinery/firealarm{
 	dir = 4;
 	icon_state = "fire0";
@@ -20169,7 +20475,9 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
-/turf/open/floor/plasteel/vault{
+/turf/open/floor/plasteel/vault/side{
+	tag = "icon-vault (WEST)";
+	icon_state = "vault";
 	dir = 8
 	},
 /area/crew_quarters/bar/atrium)
@@ -20185,6 +20493,9 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/bot,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/kitchen)
 "aLj" = (
@@ -20196,22 +20507,27 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/delivery,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/kitchen)
 "aLk" = (
 /obj/structure/kitchenspike,
-/obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 1
 	},
 /obj/effect/turf_decal/bot,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/kitchen)
 "aLl" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 9
 	},
-/turf/closed/wall,
+/turf/closed/wall/rust,
 /area/crew_quarters/kitchen)
 "aLm" = (
 /obj/structure/extinguisher_cabinet{
@@ -20277,7 +20593,6 @@
 	pixel_y = 3
 	},
 /obj/item/lazarus_injector,
-/obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/bot,
 /mob/living/simple_animal/bot/medbot{
 	name = "\improper emergency medibot";
@@ -20315,8 +20630,6 @@
 /turf/open/floor/plasteel/cmo,
 /area/shuttle/escape)
 "aLD" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
 /obj/machinery/power/port_gen/pacman,
 /obj/effect/turf_decal/stripes/line{
 	dir = 5
@@ -20327,7 +20640,6 @@
 /obj/machinery/status_display{
 	pixel_y = -32
 	},
-/obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 4
 	},
@@ -20339,7 +20651,6 @@
 /obj/structure/table/reinforced,
 /obj/item/stack/sheet/plasteel/twenty,
 /obj/item/wrench,
-/obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
@@ -20371,7 +20682,6 @@
 /turf/open/floor/plasteel,
 /area/engine/gravity_generator)
 "aLI" = (
-/obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
@@ -20396,13 +20706,11 @@
 /area/engine/gravity_generator)
 "aLK" = (
 /obj/structure/closet/radiation,
-/obj/effect/decal/cleanable/dirt,
 /obj/item/clothing/glasses/meson,
 /obj/machinery/airalarm{
 	dir = 1;
 	pixel_y = -22
 	},
-/obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
@@ -20424,7 +20732,6 @@
 /obj/structure/cable/white{
 	icon_state = "1-2"
 	},
-/obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
@@ -20432,7 +20739,7 @@
 	dir = 1;
 	filter_type = "n2"
 	},
-/turf/open/floor/plasteel,
+/turf/open/floor/engine,
 /area/engine/engineering)
 "aLN" = (
 /obj/structure/cable{
@@ -20447,7 +20754,7 @@
 /obj/machinery/atmospherics/pipe/simple/orange/visible{
 	dir = 10
 	},
-/turf/open/floor/plasteel,
+/turf/open/floor/engine,
 /area/engine/engineering)
 "aLO" = (
 /obj/machinery/ai_status_display,
@@ -20464,7 +20771,7 @@
 /obj/machinery/atmospherics/pipe/simple/general/visible{
 	dir = 9
 	},
-/turf/closed/wall/r_wall,
+/turf/closed/wall/r_wall/rust,
 /area/engine/supermatter)
 "aLR" = (
 /obj/machinery/door/airlock/atmos/glass{
@@ -20497,13 +20804,12 @@
 /obj/machinery/light{
 	dir = 8
 	},
-/obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/cyan/visible,
 /obj/effect/landmark/event_spawn,
-/turf/open/floor/plasteel,
+/turf/open/floor/engine,
 /area/engine/engineering)
 "aLW" = (
 /obj/structure/cable/white{
@@ -20512,7 +20818,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
-/turf/open/floor/plasteel,
+/turf/open/floor/engine,
 /area/engine/engineering)
 "aLX" = (
 /obj/effect/spawner/structure/window/reinforced,
@@ -20534,20 +20840,27 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 1
 	},
+/obj/effect/turf_decal/loading_area{
+	dir = 1
+	},
+/obj/effect/turf_decal/stripes/corner,
+/obj/effect/turf_decal/stripes/corner{
+	dir = 1
+	},
 /turf/open/floor/plasteel/yellow,
 /area/engine/engineering)
 "aMc" = (
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
 /turf/open/floor/plasteel/yellow,
 /area/engine/engineering)
 "aMd" = (
 /obj/structure/cable/white{
 	icon_state = "1-4"
 	},
-/obj/item/twohanded/required/kirbyplants{
-	icon_state = "plant-21"
-	},
 /obj/machinery/rnd/circuit_imprinter,
+/obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel/yellow/side{
 	dir = 4
 	},
@@ -20560,14 +20873,15 @@
 	},
 /obj/item/storage/box/lights/mixed,
 /obj/item/device/lightreplacer,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
 /obj/machinery/airalarm{
 	dir = 4;
 	pixel_x = -23
 	},
-/turf/open/floor/plating,
+/turf/open/floor/plasteel/vault/side{
+	tag = "icon-vault (EAST)";
+	icon_state = "vault";
+	dir = 4
+	},
 /area/janitor)
 "aMf" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on,
@@ -20593,26 +20907,25 @@
 	pixel_x = 12
 	},
 /obj/item/reagent_containers/glass/bucket,
-/obj/effect/decal/cleanable/dirt,
 /obj/item/mop,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 9
 	},
 /obj/effect/turf_decal/bot,
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/vault/side{
+	tag = "icon-vault (WEST)";
+	icon_state = "vault";
+	dir = 8
+	},
 /area/janitor)
 "aMi" = (
 /obj/machinery/shieldgen,
-/obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
 /area/maintenance/port/central)
 "aMj" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/structure/cable/white{
 	icon_state = "1-2"
@@ -20627,7 +20940,6 @@
 /obj/machinery/status_display{
 	pixel_x = -32
 	},
-/obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/stripes/line{
 	dir = 6
 	},
@@ -20762,7 +21074,11 @@
 	icon_state = "plant-22"
 	},
 /obj/effect/turf_decal/bot,
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/vault/side{
+	tag = "icon-vault (WEST)";
+	icon_state = "vault";
+	dir = 8
+	},
 /area/hallway/primary/central)
 "aMz" = (
 /obj/item/twohanded/required/kirbyplants{
@@ -20785,7 +21101,6 @@
 /turf/open/floor/plasteel/neutral,
 /area/hallway/secondary/exit)
 "aMC" = (
-/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/brown{
 	dir = 4
 	},
@@ -20795,7 +21110,6 @@
 /obj/machinery/status_display{
 	pixel_x = -32
 	},
-/obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/delivery,
 /obj/machinery/light{
 	dir = 8
@@ -20809,7 +21123,6 @@
 /turf/open/floor/plasteel,
 /area/shuttle/escape)
 "aMF" = (
-/obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/stripes/line{
 	dir = 6
 	},
@@ -20832,7 +21145,6 @@
 /obj/item/crowbar,
 /obj/item/wrench,
 /obj/item/device/radio,
-/obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel,
 /area/shuttle/escape)
@@ -20905,7 +21217,6 @@
 /obj/machinery/newscaster{
 	pixel_x = -32
 	},
-/obj/effect/decal/cleanable/dirt,
 /obj/machinery/camera{
 	c_tag = "Engineering Port";
 	dir = 4;
@@ -20917,20 +21228,19 @@
 /obj/machinery/atmospherics/components/trinary/filter/flipped/critical{
 	dir = 1
 	},
-/turf/open/floor/plasteel,
+/turf/open/floor/engine,
 /area/engine/engineering)
 "aMP" = (
 /obj/structure/cable{
 	icon_state = "1-4"
 	},
-/obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/manifold/orange/visible{
 	dir = 4
 	},
-/turf/open/floor/plasteel,
+/turf/open/floor/engine,
 /area/engine/engineering)
 "aMQ" = (
 /obj/structure/cable{
@@ -21026,17 +21336,14 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/cyan/visible,
-/turf/open/floor/plasteel,
+/turf/open/floor/engine,
 /area/engine/engineering)
 "aNa" = (
 /obj/machinery/suit_storage_unit/engine,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
 /obj/item/device/radio/intercom{
 	name = "Station Intercom";
 	pixel_x = -26
@@ -21054,7 +21361,6 @@
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "aNb" = (
-/obj/effect/decal/cleanable/dirt,
 /obj/structure/tank_dispenser,
 /obj/machinery/light,
 /obj/structure/extinguisher_cabinet{
@@ -21070,7 +21376,6 @@
 /obj/machinery/status_display{
 	pixel_y = -32
 	},
-/obj/effect/decal/cleanable/dirt,
 /obj/item/clothing/glasses/meson/engine,
 /obj/effect/turf_decal/stripes/line{
 	dir = 5
@@ -21087,6 +21392,7 @@
 	pixel_y = -32
 	},
 /obj/machinery/rnd/protolathe/department/engineering,
+/obj/effect/turf_decal/stripes/box,
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "aNe" = (
@@ -21101,7 +21407,6 @@
 /area/engine/engineering)
 "aNf" = (
 /obj/machinery/portable_atmospherics/canister/oxygen,
-/obj/effect/decal/cleanable/dirt,
 /obj/machinery/airalarm{
 	dir = 1;
 	pixel_y = -22
@@ -21114,7 +21419,6 @@
 /area/engine/engineering)
 "aNg" = (
 /obj/structure/reagent_dispensers/fueltank,
-/obj/effect/decal/cleanable/dirt,
 /obj/structure/sign/nosmoking_2{
 	pixel_y = -32
 	},
@@ -21152,14 +21456,16 @@
 "aNj" = (
 /obj/structure/reagent_dispensers/watertank,
 /obj/item/reagent_containers/glass/bucket,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
 /obj/machinery/firealarm{
 	dir = 1;
 	pixel_y = -26
 	},
 /obj/effect/turf_decal/bot,
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/vault/side{
+	tag = "icon-vault (EAST)";
+	icon_state = "vault";
+	dir = 4
+	},
 /area/janitor)
 "aNk" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -21181,9 +21487,12 @@
 /area/janitor)
 "aNm" = (
 /obj/structure/closet/l3closet/janitor,
-/obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/bot,
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/vault/side{
+	tag = "icon-vault (WEST)";
+	icon_state = "vault";
+	dir = 8
+	},
 /area/janitor)
 "aNn" = (
 /obj/structure/rack,
@@ -21191,14 +21500,12 @@
 /obj/item/crowbar/red,
 /obj/item/wrench,
 /obj/machinery/light/small,
-/obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/stripes/line{
 	dir = 10
 	},
 /turf/open/floor/plasteel,
 /area/maintenance/port/central)
 "aNo" = (
-/obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/blood/splatter,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/structure/cable/white{
@@ -21217,11 +21524,14 @@
 /obj/item/book/manual/hydroponics_pod_people,
 /obj/item/storage/box/syringes,
 /obj/item/paper/guides/jobs/hydroponics,
-/obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/bot,
 /obj/item/storage/box/disks_plantgene,
 /obj/item/toy/figure/botanist,
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/vault/side{
+	tag = "icon-vault (NORTH)";
+	icon_state = "vault";
+	dir = 1
+	},
 /area/hydroponics)
 "aNq" = (
 /obj/machinery/hydroponics/constructable,
@@ -21251,7 +21561,6 @@
 	pixel_y = -24
 	},
 /obj/machinery/light,
-/obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/stripes/line{
 	dir = 5
 	},
@@ -21259,8 +21568,11 @@
 /area/hydroponics)
 "aNt" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/effect/turf_decal/delivery,
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/vault/side{
+	tag = "icon-vault (NORTH)";
+	icon_state = "vault";
+	dir = 1
+	},
 /area/hydroponics)
 "aNu" = (
 /obj/structure/closet/crate/bin,
@@ -21271,7 +21583,11 @@
 	network = list("SS13")
 	},
 /obj/effect/turf_decal/bot,
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/vault/side{
+	tag = "icon-vault (NORTH)";
+	icon_state = "vault";
+	dir = 1
+	},
 /area/hydroponics)
 "aNv" = (
 /obj/structure/window/reinforced{
@@ -21322,7 +21638,6 @@
 /turf/open/floor/plasteel,
 /area/crew_quarters/bar/atrium)
 "aNA" = (
-/obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 5
 	},
@@ -21342,7 +21657,7 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard/central)
 "aNC" = (
-/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
@@ -21350,10 +21665,12 @@
 /obj/structure/cable/white{
 	icon_state = "4-8"
 	},
-/turf/open/floor/plating,
+/turf/open/floor/plating{
+	tag = "icon-platingdmg2";
+	icon_state = "platingdmg2"
+	},
 /area/maintenance/starboard/central)
 "aND" = (
-/obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
 	dir = 1
 	},
@@ -21405,7 +21722,6 @@
 /area/hallway/secondary/exit)
 "aNH" = (
 /obj/structure/closet/crate,
-/obj/effect/decal/cleanable/dirt,
 /obj/machinery/ai_status_display{
 	pixel_y = -32
 	},
@@ -21424,7 +21740,6 @@
 /area/hallway/secondary/exit)
 "aNJ" = (
 /obj/structure/closet/crate,
-/obj/effect/decal/cleanable/dirt,
 /obj/machinery/status_display{
 	pixel_y = -32
 	},
@@ -21453,13 +21768,11 @@
 	name = "Station Intercom";
 	pixel_y = -26
 	},
-/obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel,
 /area/shuttle/escape)
 "aNM" = (
 /obj/structure/reagent_dispensers/fueltank,
-/obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel,
 /area/shuttle/escape)
@@ -21486,7 +21799,6 @@
 /obj/structure/extinguisher_cabinet{
 	pixel_x = 24
 	},
-/obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel,
 /area/shuttle/escape)
@@ -21588,7 +21900,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible,
 /obj/machinery/meter,
-/turf/open/floor/plasteel,
+/turf/open/floor/engine,
 /area/engine/engineering)
 "aNZ" = (
 /obj/structure/cable{
@@ -21601,7 +21913,7 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/orange/visible,
-/turf/open/floor/plasteel,
+/turf/open/floor/engine,
 /area/engine/engineering)
 "aOa" = (
 /obj/machinery/power/supermatter_shard/crystal/engine,
@@ -21616,7 +21928,6 @@
 	name = "Radiation Chamber Shutters"
 	},
 /obj/effect/decal/cleanable/oil,
-/obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
@@ -21643,11 +21954,10 @@
 	pixel_x = 26
 	},
 /obj/structure/cable/white,
-/obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
-/turf/open/floor/plasteel,
+/turf/open/floor/engine,
 /area/engine/engineering)
 "aOe" = (
 /obj/structure/sign/nanotrasen,
@@ -21772,8 +22082,6 @@
 /turf/closed/wall,
 /area/maintenance/starboard/central)
 "aOu" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
 /obj/machinery/door/airlock/maintenance_hatch{
 	name = "Maintenance Hatch";
 	req_access_txt = "12"
@@ -21788,7 +22096,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plating,
 /area/maintenance/starboard/central)
 "aOv" = (
 /obj/machinery/computer/message_monitor{
@@ -21837,14 +22145,13 @@
 /obj/structure/cable/white{
 	icon_state = "1-2"
 	},
-/obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
 /obj/machinery/atmospherics/components/trinary/filter/flipped/critical{
 	dir = 1
 	},
-/turf/open/floor/plasteel,
+/turf/open/floor/engine,
 /area/engine/engineering)
 "aOB" = (
 /obj/structure/cable{
@@ -21902,12 +22209,11 @@
 /obj/structure/cable{
 	icon_state = "1-8"
 	},
-/obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/cyan/visible,
-/turf/open/floor/plasteel,
+/turf/open/floor/engine,
 /area/engine/engineering)
 "aOG" = (
 /obj/machinery/firealarm{
@@ -21917,7 +22223,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
-/turf/open/floor/plasteel,
+/turf/open/floor/engine,
 /area/engine/engineering)
 "aOH" = (
 /turf/closed/wall/r_wall,
@@ -21961,13 +22267,12 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 2
+/turf/open/floor/plating{
+	burnt = 1;
+	icon_state = "panelscorched"
 	},
-/turf/open/floor/plasteel,
 /area/maintenance/port)
 "aOM" = (
-/obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
@@ -21975,13 +22280,11 @@
 	icon_state = "4-8"
 	},
 /obj/effect/turf_decal/stripes/line{
-	dir = 2
+	dir = 4
 	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plating,
 /area/maintenance/port)
 "aON" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
 /obj/machinery/door/airlock/maintenance_hatch{
 	name = "Maintenance Hatch";
 	req_access_txt = "12"
@@ -22001,7 +22304,6 @@
 /turf/open/floor/plasteel,
 /area/maintenance/port)
 "aOO" = (
-/obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
@@ -22011,6 +22313,7 @@
 /obj/structure/cable/white{
 	icon_state = "4-8"
 	},
+/obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel/vault{
 	dir = 5
 	},
@@ -22474,14 +22777,17 @@
 /obj/structure/table,
 /obj/item/storage/briefcase,
 /obj/effect/turf_decal/delivery,
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/vault/side{
+	tag = "icon-vault (WEST)";
+	icon_state = "vault";
+	dir = 8
+	},
 /area/hallway/primary/central)
 "aPz" = (
 /obj/effect/spawner/structure/window/reinforced/tinted,
 /turf/open/floor/plating,
 /area/maintenance/starboard)
 "aPA" = (
-/obj/effect/decal/cleanable/dirt,
 /obj/structure/table/wood,
 /obj/item/storage/secure/briefcase,
 /obj/item/restraints/handcuffs,
@@ -22545,14 +22851,13 @@
 /obj/structure/extinguisher_cabinet{
 	pixel_x = -26
 	},
-/obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
 /obj/machinery/atmospherics/components/trinary/filter/flipped/critical{
 	dir = 1
 	},
-/turf/open/floor/plasteel,
+/turf/open/floor/engine,
 /area/engine/engineering)
 "aPJ" = (
 /obj/machinery/light{
@@ -22564,7 +22869,7 @@
 /obj/machinery/atmospherics/pipe/manifold/orange/visible{
 	dir = 4
 	},
-/turf/open/floor/plasteel,
+/turf/open/floor/engine,
 /area/engine/engineering)
 "aPK" = (
 /obj/structure/sign/electricshock,
@@ -22585,7 +22890,7 @@
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/cyan/visible,
-/turf/open/floor/plasteel,
+/turf/open/floor/engine,
 /area/engine/engineering)
 "aPN" = (
 /obj/machinery/newscaster{
@@ -22597,7 +22902,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
-/turf/open/floor/plasteel,
+/turf/open/floor/engine,
 /area/engine/engineering)
 "aPO" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
@@ -22606,8 +22911,6 @@
 /turf/closed/wall/r_wall,
 /area/maintenance/port)
 "aPP" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
 /obj/structure/cable/white{
 	icon_state = "1-2"
 	},
@@ -22618,18 +22921,18 @@
 /turf/open/floor/plating,
 /area/maintenance/port)
 "aPQ" = (
-/obj/effect/decal/cleanable/dirt,
 /obj/structure/closet,
 /obj/effect/spawner/lootdrop/maintenance{
 	lootcount = 3;
 	name = "3maintenance loot spawner"
 	},
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
 /obj/effect/turf_decal/delivery,
+/obj/effect/turf_decal/stripes/line{
+	dir = 9
+	},
 /turf/open/floor/plasteel,
 /area/maintenance/port)
 "aPR" = (
@@ -22640,40 +22943,43 @@
 /turf/open/floor/plating,
 /area/maintenance/port)
 "aPS" = (
-/obj/effect/decal/cleanable/dirt,
 /obj/structure/closet/firecloset,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
 /obj/effect/turf_decal/delivery,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
 /turf/open/floor/plasteel,
 /area/maintenance/port)
 "aPT" = (
 /obj/structure/rack,
 /obj/item/reagent_containers/food/drinks/bottle/whiskey,
 /obj/effect/spawner/lootdrop/maintenance,
-/obj/effect/decal/cleanable/dirt,
 /obj/machinery/light/small,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
 /obj/effect/turf_decal/delivery,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
 /turf/open/floor/plasteel,
 /area/maintenance/port)
 "aPU" = (
-/obj/effect/decal/cleanable/dirt,
 /obj/structure/rack,
 /obj/effect/spawner/lootdrop/maintenance{
 	lootcount = 2;
 	name = "2maintenance loot spawner"
 	},
-/obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
 /obj/effect/turf_decal/delivery,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
 /turf/open/floor/plasteel,
 /area/maintenance/port)
 "aPV" = (
@@ -22683,7 +22989,7 @@
 /turf/closed/wall,
 /area/maintenance/port)
 "aPW" = (
-/obj/machinery/vending/snack,
+/obj/machinery/vending/snack/random,
 /obj/machinery/firealarm{
 	dir = 8;
 	pixel_x = -24
@@ -22691,6 +22997,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
+/obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel/vault{
 	dir = 8
 	},
@@ -22967,7 +23274,11 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/bot,
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/vault/side{
+	tag = "icon-vault (WEST)";
+	icon_state = "vault";
+	dir = 8
+	},
 /area/hallway/primary/central)
 "aQB" = (
 /obj/structure/table/wood,
@@ -22983,7 +23294,6 @@
 	},
 /area/maintenance/starboard)
 "aQC" = (
-/obj/effect/decal/cleanable/dirt,
 /obj/structure/chair/office/dark{
 	dir = 4
 	},
@@ -22992,7 +23302,6 @@
 /turf/open/floor/wood,
 /area/maintenance/starboard)
 "aQD" = (
-/obj/effect/decal/cleanable/dirt,
 /obj/effect/landmark/xeno_spawn,
 /obj/machinery/atmospherics/components/unary/vent_pump/on,
 /turf/open/floor/wood{
@@ -23007,6 +23316,10 @@
 "aQG" = (
 /obj/machinery/atmospherics/pipe/simple/general/visible{
 	dir = 6
+	},
+/obj/effect/turf_decal/stripes/corner,
+/obj/effect/turf_decal/stripes/corner{
+	dir = 1
 	},
 /turf/open/floor/plasteel/vault/telecomms{
 	dir = 5
@@ -23041,7 +23354,7 @@
 /obj/machinery/atmospherics/pipe/manifold/orange/visible{
 	dir = 8
 	},
-/turf/open/floor/plasteel,
+/turf/open/floor/engine,
 /area/engine/engineering)
 "aQK" = (
 /obj/effect/turf_decal/stripes/line{
@@ -23050,7 +23363,7 @@
 /obj/machinery/atmospherics/pipe/simple/orange/visible{
 	dir = 4
 	},
-/turf/open/floor/plasteel,
+/turf/open/floor/engine,
 /area/engine/engineering)
 "aQM" = (
 /obj/effect/turf_decal/stripes/line{
@@ -23059,7 +23372,7 @@
 /obj/machinery/atmospherics/components/trinary/filter/critical{
 	dir = 4
 	},
-/turf/open/floor/plasteel,
+/turf/open/floor/engine,
 /area/engine/engineering)
 "aQN" = (
 /obj/effect/turf_decal/stripes/line{
@@ -23068,10 +23381,9 @@
 /obj/machinery/atmospherics/pipe/simple/orange/visible{
 	dir = 4
 	},
-/turf/open/floor/plasteel,
+/turf/open/floor/engine,
 /area/engine/engineering)
 "aQO" = (
-/obj/effect/decal/cleanable/dirt,
 /obj/machinery/camera{
 	c_tag = "Engineering Aft";
 	dir = 2;
@@ -23081,9 +23393,10 @@
 /obj/machinery/atmospherics/pipe/simple/orange/visible{
 	dir = 4
 	},
-/turf/open/floor/plasteel/vault{
-	dir = 5
+/obj/effect/turf_decal/loading_area{
+	dir = 1
 	},
+/turf/open/floor/plasteel/dark,
 /area/engine/engineering)
 "aQP" = (
 /obj/effect/turf_decal/stripes/line{
@@ -23092,7 +23405,7 @@
 /obj/machinery/atmospherics/pipe/simple/orange/visible{
 	dir = 4
 	},
-/turf/open/floor/plasteel,
+/turf/open/floor/engine,
 /area/engine/engineering)
 "aQQ" = (
 /obj/effect/decal/cleanable/dirt,
@@ -23105,7 +23418,6 @@
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "aQR" = (
-/obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
@@ -23113,7 +23425,7 @@
 /obj/machinery/atmospherics/pipe/manifold/orange/visible{
 	dir = 1
 	},
-/turf/open/floor/plasteel,
+/turf/open/floor/engine,
 /area/engine/engineering)
 "aQS" = (
 /obj/machinery/meter,
@@ -23123,14 +23435,13 @@
 /obj/machinery/atmospherics/pipe/manifold/cyan/visible{
 	dir = 4
 	},
-/turf/open/floor/plasteel,
+/turf/open/floor/engine,
 /area/engine/engineering)
 "aQT" = (
-/obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
-/turf/open/floor/plasteel,
+/turf/open/floor/engine,
 /area/engine/engineering)
 "aQU" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -23332,8 +23643,6 @@
 /turf/open/floor/plasteel,
 /area/science/research)
 "aRx" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
 /obj/machinery/door/airlock/maintenance_hatch{
 	name = "Maintenance Hatch";
 	req_access_txt = "12"
@@ -23348,7 +23657,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plating,
 /area/maintenance/starboard)
 "aRy" = (
 /obj/effect/spawner/structure/window/reinforced,
@@ -23358,9 +23667,7 @@
 /turf/closed/wall,
 /area/maintenance/starboard)
 "aRA" = (
-/obj/effect/decal/cleanable/dirt,
 /obj/structure/barricade/wooden,
-/obj/effect/decal/cleanable/dirt,
 /obj/machinery/door/airlock/maintenance_hatch{
 	name = "Maintenance Hatch";
 	req_access_txt = "12"
@@ -23375,18 +23682,19 @@
 /turf/open/floor/plasteel,
 /area/maintenance/starboard)
 "aRB" = (
-/turf/open/floor/plasteel/vault/telecomms{
-	dir = 5
-	},
+/obj/effect/turf_decal/bot,
+/obj/structure/table,
+/obj/item/clipboard,
+/obj/item/storage/firstaid/o2,
+/obj/item/crowbar,
+/turf/open/floor/plasteel/vault/side,
 /area/tcommsat/server)
 "aRD" = (
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
 /obj/structure/fans/tiny,
-/turf/open/floor/plasteel/vault/telecomms{
-	dir = 5
-	},
+/turf/open/floor/plasteel/vault/side,
 /area/tcommsat/server)
 "aRE" = (
 /obj/machinery/atmospherics/components/unary/thermomachine/freezer{
@@ -23395,9 +23703,8 @@
 	on = 1;
 	target_temperature = 80
 	},
-/turf/open/floor/plasteel/vault/telecomms{
-	dir = 5
-	},
+/obj/effect/turf_decal/bot,
+/turf/open/floor/plasteel/vault/side,
 /area/tcommsat/server)
 "aRF" = (
 /obj/structure/cable/white{
@@ -23407,14 +23714,13 @@
 	name = "Station Intercom";
 	pixel_x = -28
 	},
-/obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
-/turf/open/floor/plasteel,
+/turf/open/floor/engine,
 /area/engine/engineering)
 "aRG" = (
 /obj/structure/cable/white{
@@ -23428,7 +23734,7 @@
 	name = "Gas to Cooling Loop";
 	on = 1
 	},
-/turf/open/floor/plasteel/yellow,
+/turf/open/floor/engine,
 /area/engine/engineering)
 "aRH" = (
 /obj/structure/cable/white{
@@ -23437,7 +23743,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
-/turf/open/floor/plasteel/neutral,
+/turf/open/floor/engine,
 /area/engine/engineering)
 "aRI" = (
 /obj/structure/cable/white{
@@ -23446,7 +23752,7 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 8
 	},
-/turf/open/floor/plasteel/yellow,
+/turf/open/floor/engine,
 /area/engine/engineering)
 "aRJ" = (
 /obj/structure/cable/white{
@@ -23455,20 +23761,19 @@
 /obj/machinery/atmospherics/pipe/simple/general/visible{
 	dir = 5
 	},
-/turf/open/floor/plasteel/neutral,
+/turf/open/floor/engine,
 /area/engine/engineering)
 "aRK" = (
 /obj/structure/cable/white{
 	icon_state = "4-8"
 	},
-/obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/manifold/general/visible{
 	dir = 1
 	},
-/turf/open/floor/plasteel,
+/turf/open/floor/engine,
 /area/engine/engineering)
 "aRL" = (
 /obj/structure/cable/white{
@@ -23477,9 +23782,8 @@
 /obj/machinery/atmospherics/pipe/simple/general/visible{
 	dir = 4
 	},
-/turf/open/floor/plasteel/vault{
-	dir = 5
-	},
+/obj/effect/turf_decal/bot,
+/turf/open/floor/plasteel/dark,
 /area/engine/engineering)
 "aRM" = (
 /obj/machinery/atmospherics/pipe/manifold/general/visible{
@@ -23488,31 +23792,27 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
-/turf/open/floor/plasteel,
+/turf/open/floor/engine,
 /area/engine/engineering)
 "aRN" = (
-/obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/components/binary/pump{
 	dir = 4;
 	icon_state = "pump_map";
 	name = "Freezer to Gas"
 	},
-/turf/open/floor/plasteel/neutral,
+/turf/open/floor/engine,
 /area/engine/engineering)
 "aRO" = (
 /obj/effect/landmark/start/station_engineer,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/orange/visible{
 	dir = 9
 	},
-/turf/open/floor/plasteel/yellow,
+/turf/open/floor/engine,
 /area/engine/engineering)
 "aRP" = (
 /obj/machinery/holopad,
-/obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/bot,
-/turf/open/floor/plasteel,
+/turf/open/floor/engine,
 /area/engine/engineering)
 "aRQ" = (
 /obj/machinery/atmospherics/components/binary/pump{
@@ -23520,27 +23820,29 @@
 	name = "Gas to Cooling Loop";
 	on = 1
 	},
-/turf/open/floor/plasteel/yellow,
+/turf/open/floor/engine,
 /area/engine/engineering)
 "aRR" = (
 /obj/machinery/airalarm{
 	dir = 8;
 	pixel_x = 24
 	},
-/obj/effect/decal/cleanable/dirt,
 /obj/structure/closet/secure_closet/engineering_personal,
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
-/turf/open/floor/plasteel,
+/turf/open/floor/engine,
 /area/engine/engineering)
 "aRS" = (
-/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating,
 /obj/structure/cable/white{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/turf/open/floor/plating,
+/turf/open/floor/plating{
+	tag = "icon-platingdmg2";
+	icon_state = "platingdmg2"
+	},
 /area/maintenance/port)
 "aRT" = (
 /obj/structure/table/wood,
@@ -23598,6 +23900,8 @@
 /obj/machinery/light{
 	dir = 1
 	},
+/obj/item/paper_bin,
+/obj/item/pen,
 /turf/open/floor/plasteel/vault{
 	dir = 5
 	},
@@ -23610,14 +23914,14 @@
 /area/library)
 "aSa" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/turf/open/floor/plasteel/grimy,
+/turf/open/floor/wood,
 /area/library)
 "aSb" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/structure/cable/white{
 	icon_state = "1-2"
 	},
-/turf/open/floor/plasteel/grimy,
+/turf/open/floor/wood,
 /area/library)
 "aSc" = (
 /obj/structure/table/wood,
@@ -23638,9 +23942,10 @@
 /obj/structure/bodycontainer/morgue,
 /obj/effect/landmark/revenantspawn,
 /obj/effect/decal/cleanable/cobweb,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/vault{
-	dir = 8
+/turf/open/floor/plasteel/vault/side{
+	tag = "icon-vault (EAST)";
+	icon_state = "vault";
+	dir = 4
 	},
 /area/medical/morgue)
 "aSf" = (
@@ -23651,12 +23956,15 @@
 /turf/open/floor/plasteel/vault,
 /area/medical/morgue)
 "aSg" = (
-/obj/effect/decal/cleanable/dirt,
 /obj/structure/sign/nosmoking_2{
 	pixel_x = 32
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/turf/open/floor/plasteel/vault,
+/turf/open/floor/plasteel/vault/side{
+	tag = "icon-vault (WEST)";
+	icon_state = "vault";
+	dir = 8
+	},
 /area/medical/morgue)
 "aSh" = (
 /turf/closed/wall,
@@ -23710,6 +24018,10 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
+/obj/structure/table/glass,
+/obj/item/clipboard,
+/obj/item/storage/bag/chemistry,
+/obj/item/storage/pill_bottle/mutadone,
 /turf/open/floor/plasteel,
 /area/medical/chemistry)
 "aSm" = (
@@ -23825,9 +24137,8 @@
 /obj/structure/cable/white{
 	icon_state = "1-2"
 	},
-/obj/effect/turf_decal/stripes/end{
-	dir = 8
-	},
+/obj/effect/turf_decal/bot,
+/obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plasteel,
 /area/science/research)
 "aSB" = (
@@ -23837,17 +24148,20 @@
 	name = "emergency shower"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/effect/turf_decal/stripes/end{
-	dir = 4
-	},
+/obj/effect/turf_decal/bot,
+/obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plasteel,
 /area/science/research)
 "aSC" = (
+/turf/open/floor/plating,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/structure/cable/white{
 	icon_state = "1-2"
 	},
-/turf/open/floor/plasteel/neutral/corner,
+/turf/open/floor/plating{
+	tag = "icon-platingdmg2";
+	icon_state = "platingdmg2"
+	},
 /area/maintenance/starboard)
 "aSD" = (
 /obj/structure/girder,
@@ -23863,13 +24177,11 @@
 /area/maintenance/starboard)
 "aSF" = (
 /obj/structure/reagent_dispensers/watertank,
-/obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plasteel,
 /area/maintenance/starboard)
 "aSG" = (
 /obj/machinery/portable_atmospherics/canister/air,
-/obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/stripes/line{
 	dir = 6
 	},
@@ -23881,8 +24193,6 @@
 /area/maintenance/starboard)
 "aSI" = (
 /obj/effect/decal/cleanable/cobweb,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
 /obj/machinery/photocopier,
 /obj/item/newspaper{
 	pixel_x = 3;
@@ -23892,7 +24202,6 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard)
 "aSJ" = (
-/obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/wood{
 	icon_state = "wood-broken2"
@@ -23941,12 +24250,11 @@
 /turf/closed/wall/r_wall,
 /area/tcommsat/server)
 "aSP" = (
-/obj/effect/decal/cleanable/dirt,
 /obj/structure/closet/wardrobe/engineering_yellow,
 /obj/effect/turf_decal/stripes/line{
 	dir = 10
 	},
-/turf/open/floor/plasteel,
+/turf/open/floor/engine,
 /area/engine/engineering)
 "aSQ" = (
 /obj/machinery/atmospherics/pipe/simple/general/visible,
@@ -23960,21 +24268,24 @@
 	pixel_y = -32
 	},
 /obj/effect/turf_decal/bot,
-/turf/open/floor/plasteel,
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/engine,
 /area/engine/engineering)
 "aSS" = (
 /obj/item/clothing/gloves/color/black,
 /obj/item/clothing/glasses/meson/engine,
 /obj/structure/table/reinforced,
 /obj/effect/turf_decal/bot,
-/turf/open/floor/plasteel,
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/engine,
 /area/engine/engineering)
 "aST" = (
 /obj/structure/table/reinforced,
 /obj/item/storage/toolbox/mechanical,
 /obj/item/device/flashlight,
 /obj/effect/turf_decal/bot,
-/turf/open/floor/plasteel,
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/engine,
 /area/engine/engineering)
 "aSU" = (
 /obj/effect/turf_decal/stripes/line{
@@ -23987,7 +24298,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 9
 	},
-/turf/open/floor/plasteel,
+/turf/open/floor/engine,
 /area/engine/engineering)
 "aSV" = (
 /obj/machinery/power/emitter/anchored{
@@ -23999,10 +24310,8 @@
 /obj/machinery/status_display{
 	pixel_y = -32
 	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/vault{
-	dir = 8
-	},
+/obj/effect/turf_decal/bot,
+/turf/open/floor/plasteel/dark,
 /area/engine/engineering)
 "aSW" = (
 /obj/machinery/atmospherics/components/unary/thermomachine/freezer{
@@ -24017,11 +24326,12 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
-/turf/open/floor/plasteel,
+/turf/open/floor/engine,
 /area/engine/engineering)
 "aSX" = (
 /obj/structure/closet/crate/bin,
-/turf/open/floor/plasteel,
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/engine,
 /area/engine/engineering)
 "aSY" = (
 /obj/structure/table/reinforced,
@@ -24034,7 +24344,8 @@
 /obj/item/device/geiger_counter,
 /obj/item/device/geiger_counter,
 /obj/effect/turf_decal/bot,
-/turf/open/floor/plasteel,
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/engine,
 /area/engine/engineering)
 "aSZ" = (
 /obj/structure/table/reinforced,
@@ -24042,15 +24353,15 @@
 /obj/item/clothing/head/radiation,
 /obj/item/clothing/glasses/meson,
 /obj/effect/turf_decal/bot,
-/turf/open/floor/plasteel,
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/engine,
 /area/engine/engineering)
 "aTa" = (
-/obj/effect/decal/cleanable/dirt,
 /obj/structure/closet/secure_closet/engineering_personal,
 /obj/effect/turf_decal/stripes/line{
 	dir = 6
 	},
-/turf/open/floor/plasteel,
+/turf/open/floor/engine,
 /area/engine/engineering)
 "aTb" = (
 /obj/structure/cable/white{
@@ -24080,12 +24391,16 @@
 /area/library)
 "aTf" = (
 /obj/structure/table/wood,
+/obj/item/clipboard,
+/obj/item/storage/pill_bottle/dice,
 /turf/open/floor/plasteel/vault{
 	dir = 5
 	},
 /area/library)
 "aTg" = (
 /obj/structure/table/wood,
+/obj/item/folder,
+/obj/item/pen/red,
 /turf/open/floor/plasteel/dark,
 /area/library)
 "aTh" = (
@@ -24110,13 +24425,16 @@
 	pixel_y = 3
 	},
 /obj/item/storage/box/bodybags,
-/obj/effect/decal/cleanable/dirt,
 /obj/machinery/airalarm{
 	dir = 4;
 	locked = 0;
 	pixel_x = -23
 	},
-/turf/open/floor/plating,
+/turf/open/floor/plasteel/vault/side{
+	tag = "icon-vault (EAST)";
+	icon_state = "vault";
+	dir = 4
+	},
 /area/medical/morgue)
 "aTk" = (
 /obj/structure/cable/white{
@@ -24131,13 +24449,13 @@
 	},
 /area/medical/morgue)
 "aTl" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 4
 	},
-/turf/open/floor/plasteel/vault{
-	dir = 5
+/turf/open/floor/plasteel/vault/side{
+	tag = "icon-vault (WEST)";
+	icon_state = "vault";
+	dir = 8
 	},
 /area/medical/morgue)
 "aTm" = (
@@ -24153,7 +24471,7 @@
 	pixel_y = 32
 	},
 /obj/machinery/door/window/southleft,
-/turf/open/floor/plasteel/vault,
+/turf/open/floor/plasteel/vault/side,
 /area/medical/medbay/zone3)
 "aTn" = (
 /obj/machinery/light{
@@ -24164,12 +24482,12 @@
 	name = "Station Intercom";
 	pixel_y = 26
 	},
-/turf/open/floor/plasteel/vault,
+/turf/open/floor/plasteel/vault/side,
 /area/medical/medbay/zone3)
 "aTo" = (
 /obj/structure/window/reinforced,
 /obj/machinery/clonepod,
-/turf/open/floor/plasteel/vault,
+/turf/open/floor/plasteel/vault/side,
 /area/medical/medbay/zone3)
 "aTp" = (
 /obj/effect/spawner/structure/window/reinforced,
@@ -24200,16 +24518,13 @@
 /area/medical/chemistry)
 "aTt" = (
 /obj/effect/turf_decal/stripes/line,
-/obj/machinery/chem_master,
 /turf/open/floor/plasteel,
 /area/medical/chemistry)
 "aTu" = (
-/obj/structure/chair/office/light{
-	dir = 4
-	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 6
 	},
+/obj/machinery/chem_master,
 /turf/open/floor/plasteel,
 /area/medical/chemistry)
 "aTv" = (
@@ -24332,7 +24647,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 9
 	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/vault/side,
 /area/science/lab)
 "aTL" = (
 /obj/effect/spawner/structure/window/reinforced,
@@ -24365,7 +24680,6 @@
 	},
 /area/science/research)
 "aTO" = (
-/obj/effect/decal/cleanable/dirt,
 /obj/machinery/door/airlock/maintenance_hatch{
 	name = "Science Maintenance";
 	req_access_txt = "47"
@@ -24382,7 +24696,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plating,
 /area/science/research)
 "aTP" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden,
@@ -24395,8 +24709,8 @@
 /obj/structure/cable/white{
 	icon_state = "4-8"
 	},
-/turf/open/floor/plasteel/neutral/corner{
-	dir = 1
+/turf/open/floor/plating{
+	icon_state = "platingdmg1"
 	},
 /area/maintenance/starboard)
 "aTQ" = (
@@ -24422,8 +24736,10 @@
 /obj/structure/cable/white{
 	icon_state = "4-8"
 	},
-/obj/effect/turf_decal/delivery,
-/turf/open/floor/plasteel,
+/turf/open/floor/plating{
+	broken = 1;
+	icon_state = "platingdmg3"
+	},
 /area/maintenance/starboard)
 "aTS" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -24433,8 +24749,10 @@
 	icon_state = "4-8"
 	},
 /obj/effect/landmark/blobstart,
-/obj/effect/turf_decal/bot,
-/turf/open/floor/plasteel,
+/turf/open/floor/plating{
+	burnt = 1;
+	icon_state = "panelscorched"
+	},
 /area/maintenance/starboard)
 "aTT" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -24443,8 +24761,10 @@
 /obj/structure/cable/white{
 	icon_state = "2-8"
 	},
-/obj/effect/turf_decal/delivery,
-/turf/open/floor/plasteel,
+/turf/open/floor/plating{
+	burnt = 1;
+	icon_state = "panelscorched"
+	},
 /area/maintenance/starboard)
 "aTU" = (
 /obj/structure/table/wood,
@@ -24460,7 +24780,6 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard)
 "aTV" = (
-/obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/wood{
 	icon_state = "wood-broken7"
@@ -24476,6 +24795,7 @@
 /obj/machinery/light{
 	dir = 8
 	},
+/obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plasteel/vault/telecomms{
 	dir = 5
 	},
@@ -24487,6 +24807,7 @@
 /obj/machinery/atmospherics/pipe/simple/general/visible{
 	dir = 4
 	},
+/obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plasteel/vault/telecomms{
 	dir = 5
 	},
@@ -24498,22 +24819,22 @@
 /obj/machinery/atmospherics/pipe/simple/general/visible{
 	dir = 9
 	},
+/obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plasteel/vault/telecomms{
 	dir = 5
 	},
 /area/tcommsat/server)
 "aUa" = (
 /obj/machinery/atmospherics/pipe/heat_exchanging/junction,
-/turf/closed/wall/r_wall,
+/turf/closed/wall/r_wall/rust,
 /area/engine/engineering)
 "aUb" = (
-/obj/effect/decal/cleanable/dirt,
 /obj/structure/cable/white{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/effect/landmark/blobstart,
-/turf/open/floor/plasteel/neutral/corner,
+/turf/open/floor/plating,
 /area/maintenance/port)
 "aUc" = (
 /obj/machinery/power/apc{
@@ -24535,14 +24856,14 @@
 /obj/structure/cable/white{
 	icon_state = "4-8"
 	},
-/turf/open/floor/plasteel/grimy,
+/turf/open/floor/wood,
 /area/library)
 "aUe" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden,
 /obj/structure/cable/white{
 	icon_state = "4-8"
 	},
-/turf/open/floor/plasteel/grimy,
+/turf/open/floor/wood,
 /area/library)
 "aUf" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -24551,7 +24872,9 @@
 /obj/structure/cable/white{
 	icon_state = "4-8"
 	},
-/turf/open/floor/plasteel/grimy,
+/turf/open/floor/wood{
+	icon_state = "wood-broken5"
+	},
 /area/library)
 "aUg" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -24560,7 +24883,7 @@
 /obj/structure/cable/white{
 	icon_state = "4-8"
 	},
-/turf/open/floor/plasteel/grimy,
+/turf/open/floor/wood,
 /area/library)
 "aUh" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -24570,15 +24893,13 @@
 /obj/structure/cable/white{
 	icon_state = "1-8"
 	},
-/turf/open/floor/plasteel/grimy,
+/turf/open/floor/wood,
 /area/library)
 "aUi" = (
 /obj/structure/cable/white{
 	icon_state = "2-8"
 	},
-/turf/open/floor/plasteel/vault{
-	dir = 5
-	},
+/turf/open/floor/wood,
 /area/library)
 "aUj" = (
 /obj/machinery/photocopier,
@@ -24587,16 +24908,17 @@
 "aUk" = (
 /obj/structure/bodycontainer/morgue,
 /obj/effect/landmark/revenantspawn,
-/obj/effect/decal/cleanable/dirt,
 /obj/item/device/radio/intercom{
 	name = "Station Intercom";
 	pixel_x = -26
 	},
-/turf/open/floor/plating,
+/turf/open/floor/plasteel/vault/side{
+	tag = "icon-vault (EAST)";
+	icon_state = "vault";
+	dir = 4
+	},
 /area/medical/morgue)
 "aUl" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
 /obj/structure/cable/white{
 	icon_state = "1-2"
 	},
@@ -24607,8 +24929,10 @@
 /area/medical/morgue)
 "aUm" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/turf/open/floor/plasteel/vault{
-	dir = 5
+/turf/open/floor/plasteel/vault/side{
+	tag = "icon-vault (WEST)";
+	icon_state = "vault";
+	dir = 8
 	},
 /area/medical/morgue)
 "aUn" = (
@@ -24649,7 +24973,11 @@
 	pixel_y = 5
 	},
 /obj/effect/turf_decal/bot,
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/vault/side{
+	tag = "icon-vault (EAST)";
+	icon_state = "vault";
+	dir = 4
+	},
 /area/medical/chemistry)
 "aUt" = (
 /obj/structure/cable/white{
@@ -24699,13 +25027,13 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 9
 	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/vault/side,
 /area/science/lab)
 "aUB" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/vault,
 /area/science/lab)
 "aUC" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -24713,7 +25041,11 @@
 	dir = 5
 	},
 /obj/machinery/rnd/protolathe/department/science,
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/vault/side{
+	tag = "icon-vault (EAST)";
+	icon_state = "vault";
+	dir = 4
+	},
 /area/science/lab)
 "aUD" = (
 /obj/effect/landmark/event_spawn,
@@ -24742,7 +25074,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/vault/side,
 /area/science/lab)
 "aUF" = (
 /obj/machinery/light{
@@ -24795,12 +25127,13 @@
 /turf/closed/wall/r_wall,
 /area/science/research)
 "aUK" = (
-/obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/structure/cable/white{
 	icon_state = "1-2"
 	},
-/turf/open/floor/plasteel/neutral/corner,
+/turf/open/floor/plating{
+	icon_state = "platingdmg3"
+	},
 /area/maintenance/starboard)
 "aUL" = (
 /obj/structure/table/wood,
@@ -24834,6 +25167,12 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/general/visible,
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
 /turf/open/floor/plasteel/vault/telecomms{
 	dir = 5
 	},
@@ -24904,23 +25243,23 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 6
 	},
-/turf/open/floor/plasteel/grimy,
+/turf/open/floor/wood,
 /area/library)
 "aUX" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
-/turf/open/floor/plasteel/grimy,
+/turf/open/floor/wood,
 /area/library)
 "aUY" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
 	dir = 1
 	},
-/turf/open/floor/plasteel/grimy,
+/turf/open/floor/wood,
 /area/library)
 "aUZ" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden,
-/turf/open/floor/plasteel/grimy,
+/turf/open/floor/wood,
 /area/library)
 "aVa" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -24929,7 +25268,7 @@
 /obj/structure/cable/white{
 	icon_state = "1-2"
 	},
-/turf/open/floor/plasteel/dark,
+/turf/open/floor/wood,
 /area/library)
 "aVb" = (
 /obj/structure/table/wood,
@@ -24952,10 +25291,13 @@
 /obj/machinery/light{
 	dir = 8
 	},
-/turf/open/floor/plating,
+/turf/open/floor/plasteel/vault/side{
+	tag = "icon-vault (EAST)";
+	icon_state = "vault";
+	dir = 4
+	},
 /area/medical/morgue)
 "aVd" = (
-/obj/effect/decal/cleanable/dirt,
 /obj/structure/cable/white{
 	icon_state = "1-2"
 	},
@@ -24967,13 +25309,14 @@
 	},
 /area/medical/morgue)
 "aVe" = (
-/obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/turf/open/floor/plasteel/vault{
-	dir = 5
+/turf/open/floor/plasteel/vault/side{
+	tag = "icon-vault (WEST)";
+	icon_state = "vault";
+	dir = 8
 	},
 /area/medical/morgue)
 "aVf" = (
@@ -25028,7 +25371,11 @@
 /obj/item/reagent_containers/glass/bottle/epinephrine,
 /obj/item/reagent_containers/dropper,
 /obj/effect/turf_decal/bot,
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/vault/side{
+	tag = "icon-vault (EAST)";
+	icon_state = "vault";
+	dir = 4
+	},
 /area/medical/chemistry)
 "aVk" = (
 /obj/effect/landmark/start/chemist,
@@ -25108,7 +25455,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 10
 	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/vault/side,
 /area/science/lab)
 "aVu" = (
 /obj/effect/landmark/start/scientist,
@@ -25117,7 +25464,7 @@
 	icon_state = "2-8"
 	},
 /obj/effect/turf_decal/stripes/line,
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/vault,
 /area/science/lab)
 "aVv" = (
 /obj/item/reagent_containers/glass/beaker/sulphuric,
@@ -25126,7 +25473,11 @@
 	dir = 6
 	},
 /obj/machinery/rnd/circuit_imprinter/department/science,
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/vault/side{
+	tag = "icon-vault (EAST)";
+	icon_state = "vault";
+	dir = 4
+	},
 /area/science/lab)
 "aVw" = (
 /turf/open/floor/plasteel/whitepurple/corner,
@@ -25141,7 +25492,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/vault/side,
 /area/science/lab)
 "aVy" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -25199,15 +25550,13 @@
 /turf/closed/wall/r_wall,
 /area/science/research)
 "aVF" = (
-/obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
 	dir = 8
 	},
 /obj/structure/cable/white{
 	icon_state = "1-2"
 	},
-/obj/effect/turf_decal/delivery,
-/turf/open/floor/plasteel,
+/turf/open/floor/plating,
 /area/maintenance/starboard)
 "aVG" = (
 /obj/machinery/door/airlock/maintenance_hatch{
@@ -25224,7 +25573,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plating,
 /area/maintenance/starboard)
 "aVH" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -25263,13 +25612,14 @@
 	name = "Asteroid"
 	})
 "aVM" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
 /obj/structure/cable/white{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/turf/open/floor/plating,
+/turf/open/floor/plating{
+	burnt = 1;
+	icon_state = "panelscorched"
+	},
 /area/maintenance/port)
 "aVN" = (
 /obj/structure/table/wood,
@@ -25344,17 +25694,17 @@
 /area/library)
 "aVY" = (
 /obj/structure/table,
-/obj/effect/decal/cleanable/dirt,
 /obj/item/clothing/gloves/color/latex,
-/obj/effect/decal/cleanable/dirt,
 /obj/structure/extinguisher_cabinet{
 	pixel_x = -26
 	},
-/turf/open/floor/plasteel/vault,
+/turf/open/floor/plasteel/vault/side{
+	tag = "icon-vault (EAST)";
+	icon_state = "vault";
+	dir = 4
+	},
 /area/medical/morgue)
 "aVZ" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
 /obj/structure/cable/white{
 	icon_state = "1-2"
 	},
@@ -25369,9 +25719,10 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 5
 	},
-/obj/structure/closet/l3closet,
-/turf/open/floor/plasteel/vault{
-	dir = 5
+/turf/open/floor/plasteel/vault/side{
+	tag = "icon-vault (WEST)";
+	icon_state = "vault";
+	dir = 8
 	},
 /area/medical/morgue)
 "aWb" = (
@@ -25435,7 +25786,7 @@
 	},
 /obj/item/reagent_containers/dropper,
 /obj/effect/turf_decal/bot,
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/vault/corner,
 /area/medical/chemistry)
 "aWg" = (
 /obj/structure/table/glass,
@@ -25460,7 +25811,11 @@
 	},
 /obj/machinery/light,
 /obj/effect/turf_decal/bot,
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/vault/side{
+	tag = "icon-vault (NORTH)";
+	icon_state = "vault";
+	dir = 1
+	},
 /area/medical/chemistry)
 "aWh" = (
 /obj/structure/table/glass,
@@ -25479,7 +25834,11 @@
 /obj/item/grenade/chem_grenade,
 /obj/item/grenade/chem_grenade,
 /obj/effect/turf_decal/bot,
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/vault/side{
+	tag = "icon-vault (NORTH)";
+	icon_state = "vault";
+	dir = 1
+	},
 /area/medical/chemistry)
 "aWi" = (
 /obj/structure/cable/white{
@@ -25487,7 +25846,11 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/effect/turf_decal/delivery,
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/vault/side{
+	tag = "icon-vault (NORTH)";
+	icon_state = "vault";
+	dir = 1
+	},
 /area/medical/chemistry)
 "aWj" = (
 /obj/structure/table/glass,
@@ -25499,7 +25862,11 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/effect/turf_decal/bot,
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/vault/side{
+	tag = "icon-vault (NORTH)";
+	icon_state = "vault";
+	dir = 1
+	},
 /area/medical/chemistry)
 "aWk" = (
 /obj/structure/table,
@@ -25548,7 +25915,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 10
 	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/vault/side,
 /area/science/lab)
 "aWp" = (
 /obj/machinery/status_display,
@@ -25607,7 +25974,6 @@
 /obj/item/clipboard,
 /obj/item/electronics/airalarm,
 /obj/item/electronics/airlock,
-/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/wood,
 /area/maintenance/starboard)
 "aWx" = (
@@ -25617,14 +25983,12 @@
 /obj/item/stack/sheet/glass,
 /obj/item/stack/sheet/glass,
 /obj/item/circuitboard/machine/microwave,
-/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/wood,
 /area/maintenance/starboard)
 "aWy" = (
 /obj/structure/table/wood,
 /obj/item/storage/briefcase,
 /obj/item/device/taperecorder,
-/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
 /area/maintenance/starboard)
 "aWz" = (
@@ -25689,7 +26053,6 @@
 "aWH" = (
 /obj/structure/bodycontainer/morgue,
 /obj/effect/landmark/revenantspawn,
-/obj/effect/decal/cleanable/dirt,
 /obj/machinery/power/apc{
 	dir = 2;
 	name = "Morgue APC";
@@ -25699,11 +26062,13 @@
 /obj/structure/cable/white{
 	icon_state = "0-4"
 	},
-/turf/open/floor/plating,
+/turf/open/floor/plasteel/vault/side{
+	tag = "icon-vault (EAST)";
+	icon_state = "vault";
+	dir = 4
+	},
 /area/medical/morgue)
 "aWI" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/blood/old,
 /obj/structure/cable/white{
 	icon_state = "1-8"
@@ -25717,8 +26082,10 @@
 	dir = 8;
 	network = list("SS13")
 	},
-/turf/open/floor/plasteel/vault{
-	dir = 5
+/turf/open/floor/plasteel/vault/side{
+	tag = "icon-vault (WEST)";
+	icon_state = "vault";
+	dir = 8
 	},
 /area/medical/morgue)
 "aWK" = (
@@ -25902,9 +26269,9 @@
 /obj/structure/cable/white{
 	icon_state = "1-2"
 	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/neutral/corner{
-	dir = 1
+/turf/open/floor/plating{
+	burnt = 1;
+	icon_state = "panelscorched"
 	},
 /area/maintenance/starboard)
 "aXc" = (
@@ -26104,6 +26471,9 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/delivery,
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
 /turf/open/floor/plasteel,
 /area/science/research)
 "aXz" = (
@@ -26231,6 +26601,7 @@
 	dir = 8;
 	pixel_x = 24
 	},
+/obj/item/clothing/suit/armor/reactive/teleport,
 /turf/open/floor/plasteel/vault{
 	dir = 8
 	},
@@ -26243,12 +26614,10 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard)
 "aXK" = (
-/obj/effect/decal/cleanable/dirt,
 /obj/structure/closet/firecloset,
 /obj/machinery/light/small{
 	dir = 1
 	},
-/obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plasteel,
 /area/maintenance/starboard)
@@ -26268,8 +26637,6 @@
 /turf/closed/wall,
 /area/library)
 "aXN" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
 /obj/machinery/door/airlock/maintenance_hatch{
 	name = "Maintenance Hatch";
 	req_access_txt = "12"
@@ -26284,7 +26651,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plating,
 /area/maintenance/port)
 "aXO" = (
 /obj/structure/table/glass,
@@ -26348,6 +26715,7 @@
 	},
 /obj/item/storage/box/syringes,
 /obj/item/gun/syringe,
+/obj/item/reagent_containers/hypospray/CMO,
 /turf/open/floor/plasteel,
 /area/medical/medbay/zone3)
 "aXR" = (
@@ -26502,6 +26870,9 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/delivery,
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
 /turf/open/floor/plasteel,
 /area/science/research)
 "aYj" = (
@@ -26632,9 +27003,7 @@
 /obj/structure/cable/white{
 	icon_state = "1-4"
 	},
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/delivery,
-/turf/open/floor/plasteel,
+/turf/open/floor/plating,
 /area/maintenance/starboard)
 "aYu" = (
 /obj/machinery/door/airlock/maintenance_hatch{
@@ -26647,15 +27016,13 @@
 /obj/structure/cable/white{
 	icon_state = "4-8"
 	},
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plating,
 /area/maintenance/starboard)
 "aYv" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -26664,9 +27031,7 @@
 /obj/structure/cable/white{
 	icon_state = "2-8"
 	},
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/delivery,
-/turf/open/floor/plasteel,
+/turf/open/floor/plating,
 /area/maintenance/starboard)
 "aYw" = (
 /obj/structure/destructible/cult/tome,
@@ -26677,14 +27042,16 @@
 /obj/machinery/light_switch{
 	pixel_y = 24
 	},
-/turf/open/floor/plasteel/grimy,
+/turf/open/floor/wood{
+	icon_state = "wood-broken6"
+	},
 /area/library)
 "aYx" = (
 /obj/effect/landmark/start/librarian,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 1
 	},
-/turf/open/floor/plasteel/grimy,
+/turf/open/floor/wood,
 /area/library)
 "aYy" = (
 /obj/structure/bookcase{
@@ -26698,7 +27065,7 @@
 	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/turf/open/floor/plasteel/grimy,
+/turf/open/floor/wood,
 /area/library)
 "aYz" = (
 /obj/structure/cable/white{
@@ -26707,18 +27074,20 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 6
 	},
-/turf/open/floor/plating,
+/turf/open/floor/plating{
+	icon_state = "platingdmg3"
+	},
 /area/maintenance/port)
 "aYA" = (
-/obj/effect/decal/cleanable/dirt,
 /obj/structure/cable/white{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
-/turf/open/floor/plasteel/neutral/corner{
-	dir = 1
+/turf/open/floor/plating{
+	broken = 1;
+	icon_state = "platingdmg1"
 	},
 /area/maintenance/port)
 "aYB" = (
@@ -26740,8 +27109,8 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
-/obj/effect/turf_decal/delivery,
-/turf/open/floor/plasteel,
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/plating,
 /area/maintenance/port)
 "aYD" = (
 /obj/effect/decal/cleanable/dirt,
@@ -26755,7 +27124,6 @@
 /turf/open/floor/plasteel,
 /area/maintenance/port)
 "aYE" = (
-/obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden,
 /obj/structure/cable/white{
 	icon_state = "4-8"
@@ -26763,8 +27131,10 @@
 /obj/structure/cable/white{
 	icon_state = "1-8"
 	},
-/obj/effect/turf_decal/delivery,
-/turf/open/floor/plasteel,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/turf/open/floor/plating,
 /area/maintenance/port)
 "aYF" = (
 /obj/structure/cable/white{
@@ -26773,10 +27143,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 10
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 6
-	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plating,
 /area/maintenance/port)
 "aYG" = (
 /obj/structure/table/glass,
@@ -26963,7 +27330,6 @@
 /area/science/robotics/mechbay)
 "aZd" = (
 /obj/machinery/door/firedoor,
-/obj/effect/decal/cleanable/dirt,
 /obj/machinery/door/airlock/research{
 	name = "Mech Bay";
 	req_access_txt = "29"
@@ -27027,7 +27393,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 10
 	},
-/turf/closed/wall/r_wall,
+/turf/closed/wall/r_wall/rust,
 /area/science/robotics/lab)
 "aZn" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -27067,7 +27433,6 @@
 	pixel_y = 3
 	},
 /obj/item/storage/secure/briefcase,
-/obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/cobweb/cobweb2,
 /turf/open/floor/plasteel/vault{
 	dir = 4
@@ -27099,7 +27464,7 @@
 /obj/machinery/newscaster{
 	pixel_x = -32
 	},
-/turf/open/floor/plasteel/grimy,
+/turf/open/floor/wood,
 /area/library)
 "aZv" = (
 /obj/structure/table/wood,
@@ -27111,7 +27476,9 @@
 	name = "Station Intercom";
 	pixel_y = -26
 	},
-/turf/open/floor/plasteel/grimy,
+/turf/open/floor/wood{
+	icon_state = "wood-broken"
+	},
 /area/library)
 "aZw" = (
 /obj/structure/table/wood,
@@ -27126,7 +27493,7 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 1
 	},
-/turf/open/floor/plasteel/grimy,
+/turf/open/floor/wood,
 /area/library)
 "aZx" = (
 /obj/structure/cable/white{
@@ -27142,7 +27509,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 6
 	},
-/turf/closed/wall,
+/turf/closed/wall/rust,
 /area/maintenance/port)
 "aZz" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -27152,7 +27519,6 @@
 /turf/closed/wall,
 /area/maintenance/port)
 "aZA" = (
-/obj/effect/decal/cleanable/dirt,
 /obj/structure/barricade/wooden,
 /obj/machinery/door/airlock/maintenance_hatch{
 	name = "Maintenance Hatch";
@@ -27208,6 +27574,13 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on,
+/obj/effect/turf_decal/loading_area{
+	dir = 1
+	},
+/obj/effect/turf_decal/stripes/corner,
+/obj/effect/turf_decal/stripes/corner{
+	dir = 1
+	},
 /turf/open/floor/plasteel/cmo,
 /area/medical/medbay/zone3)
 "aZE" = (
@@ -27386,10 +27759,7 @@
 /area/hallway/primary/central)
 "aZU" = (
 /obj/machinery/recharge_station,
-/obj/effect/decal/cleanable/dirt,
 /obj/effect/landmark/start/cyborg,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
 /obj/machinery/airalarm{
 	dir = 4;
 	locked = 0;
@@ -27405,27 +27775,25 @@
 	icon_state = "0-2"
 	},
 /obj/effect/turf_decal/bot,
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/vault/side,
 /area/science/robotics/mechbay)
 "aZV" = (
 /obj/machinery/recharge_station,
-/obj/effect/decal/cleanable/dirt,
 /obj/effect/landmark/start/cyborg,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/effect/turf_decal/bot,
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/vault/side,
 /area/science/robotics/mechbay)
 "aZW" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/effect/turf_decal/delivery,
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/vault/side,
 /area/science/robotics/mechbay)
 "aZX" = (
 /obj/structure/reagent_dispensers/fueltank,
-/obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/oil,
 /obj/effect/turf_decal/bot,
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/vault/side,
 /area/science/robotics/mechbay)
 "aZY" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -27458,8 +27826,6 @@
 	},
 /obj/item/device/multitool,
 /obj/item/clothing/head/welding,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
 /obj/machinery/firealarm{
 	pixel_y = 24
 	},
@@ -27469,15 +27835,14 @@
 	network = list("SS13","RD")
 	},
 /obj/effect/turf_decal/bot,
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/vault/side,
 /area/science/robotics/lab)
 "bac" = (
 /obj/machinery/mecha_part_fabricator,
-/obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/stripes/end{
 	dir = 1
 	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/vault/side,
 /area/science/robotics/lab)
 "bad" = (
 /obj/structure/rack,
@@ -27485,13 +27850,11 @@
 /obj/item/storage/belt/utility/full,
 /obj/item/circuitboard/mecha/ripley/main,
 /obj/item/circuitboard/mecha/ripley/peripherals,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
 /obj/machinery/light{
 	dir = 1
 	},
 /obj/effect/turf_decal/bot,
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/vault/side,
 /area/science/robotics/lab)
 "bae" = (
 /obj/machinery/mecha_part_fabricator,
@@ -27518,7 +27881,7 @@
 	pixel_y = 32
 	},
 /obj/effect/turf_decal/bot,
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/vault/side,
 /area/science/robotics/lab)
 "bag" = (
 /obj/item/paper_bin,
@@ -27546,7 +27909,7 @@
 	pixel_x = 24
 	},
 /obj/effect/turf_decal/bot,
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/vault/side,
 /area/science/robotics/lab)
 "bah" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -27557,16 +27920,14 @@
 /obj/structure/cable/white{
 	icon_state = "1-2"
 	},
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/neutral/corner,
+/turf/open/floor/plating{
+	icon_state = "platingdmg1"
+	},
 /area/maintenance/starboard)
 "baj" = (
 /turf/closed/wall,
 /area/maintenance/port)
 "bak" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/dark,
 /area/maintenance/port)
 "bal" = (
@@ -27603,15 +27964,16 @@
 /turf/open/floor/plasteel,
 /area/maintenance/port)
 "bao" = (
-/obj/effect/decal/cleanable/dirt,
 /obj/structure/cable/white{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
 	dir = 4
 	},
-/obj/effect/turf_decal/delivery,
-/turf/open/floor/plasteel,
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/turf/open/floor/plating,
 /area/maintenance/port)
 "bap" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -27621,21 +27983,25 @@
 /obj/structure/table/wood,
 /obj/item/clothing/suit/syndicatefake,
 /obj/item/clothing/head/syndicatefake,
-/obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/cobweb,
-/turf/open/floor/plating,
+/turf/open/floor/plasteel/vault/side{
+	tag = "icon-vault (EAST)";
+	icon_state = "vault";
+	dir = 4
+	},
 /area/maintenance/port)
 "bar" = (
 /turf/open/floor/plating,
 /area/maintenance/port)
 "bas" = (
 /obj/structure/dresser,
-/obj/effect/decal/cleanable/dirt,
 /obj/machinery/light/small{
 	dir = 4
 	},
-/turf/open/floor/plasteel/vault{
-	dir = 1
+/turf/open/floor/plasteel/vault/side{
+	tag = "icon-vault (WEST)";
+	icon_state = "vault";
+	dir = 8
 	},
 /area/maintenance/port)
 "bat" = (
@@ -27678,6 +28044,7 @@
 	},
 /obj/effect/turf_decal/bot,
 /obj/machinery/rnd/protolathe/department/medical,
+/obj/effect/turf_decal/stripes/box,
 /turf/open/floor/plasteel,
 /area/medical/medbay/zone3)
 "bav" = (
@@ -27858,7 +28225,6 @@
 /turf/open/floor/plasteel,
 /area/science/robotics/mechbay)
 "baO" = (
-/obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/manifold4w/supply/hidden,
 /obj/structure/cable/white{
 	icon_state = "4-8"
@@ -27895,7 +28261,6 @@
 /area/science/robotics/mechbay)
 "baR" = (
 /obj/machinery/door/firedoor,
-/obj/effect/decal/cleanable/dirt,
 /obj/machinery/door/airlock/research{
 	name = "Mech Bay";
 	req_access_txt = "29"
@@ -27949,7 +28314,6 @@
 /turf/open/floor/plating,
 /area/science/robotics/lab)
 "baV" = (
-/obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
@@ -27983,7 +28347,6 @@
 /turf/open/floor/plasteel,
 /area/science/robotics/lab)
 "baZ" = (
-/obj/effect/decal/cleanable/dirt,
 /obj/effect/landmark/start/roboticist,
 /obj/effect/turf_decal/stripes/line{
 	dir = 5
@@ -28002,7 +28365,11 @@
 	pixel_x = 24
 	},
 /obj/effect/turf_decal/bot,
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/vault/side{
+	tag = "icon-vault (WEST)";
+	icon_state = "vault";
+	dir = 8
+	},
 /area/science/robotics/lab)
 "bbb" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -28025,7 +28392,6 @@
 /turf/open/floor/plasteel/dark,
 /area/maintenance/port)
 "bbe" = (
-/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/vault{
 	dir = 5
 	},
@@ -28037,8 +28403,8 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 5
 	},
-/obj/effect/turf_decal/delivery,
-/turf/open/floor/plasteel,
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/plating,
 /area/maintenance/port)
 "bbg" = (
 /obj/structure/cable/white{
@@ -28050,7 +28416,6 @@
 /turf/open/floor/plating,
 /area/maintenance/port)
 "bbh" = (
-/obj/effect/decal/cleanable/dirt,
 /obj/structure/cable/white{
 	icon_state = "4-8"
 	},
@@ -28058,7 +28423,10 @@
 	dir = 4
 	},
 /obj/effect/landmark/blobstart,
-/turf/open/floor/plating,
+/turf/open/floor/plating{
+	burnt = 1;
+	icon_state = "panelscorched"
+	},
 /area/maintenance/port)
 "bbi" = (
 /obj/structure/cable/white{
@@ -28073,40 +28441,35 @@
 /turf/open/floor/plasteel,
 /area/maintenance/port)
 "bbj" = (
-/obj/effect/decal/cleanable/dirt,
 /obj/structure/cable/white{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
 	dir = 1
 	},
-/obj/effect/turf_decal/delivery,
-/turf/open/floor/plasteel,
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/plating,
 /area/maintenance/port)
 "bbk" = (
-/obj/effect/decal/cleanable/dirt,
 /obj/structure/cable/white{
 	icon_state = "1-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 9
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 5
-	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plating,
 /area/maintenance/port)
 "bbl" = (
 /obj/structure/table/wood,
 /obj/item/clipboard,
 /obj/item/toy/syndicateballoon,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/vault{
-	dir = 1
+/turf/open/floor/plasteel/vault/side{
+	tag = "icon-vault (EAST)";
+	icon_state = "vault";
+	dir = 4
 	},
 /area/maintenance/port)
 "bbm" = (
-/obj/effect/decal/cleanable/dirt,
 /obj/effect/landmark/revenantspawn,
 /turf/open/floor/plasteel/bar,
 /area/maintenance/port)
@@ -28114,9 +28477,10 @@
 /obj/machinery/vending/autodrobe{
 	req_access_txt = "0"
 	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/vault{
-	dir = 4
+/turf/open/floor/plasteel/vault/side{
+	tag = "icon-vault (WEST)";
+	icon_state = "vault";
+	dir = 8
 	},
 /area/maintenance/port)
 "bbo" = (
@@ -28272,7 +28636,6 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "bbC" = (
-/obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
@@ -28292,7 +28655,6 @@
 /turf/open/floor/circuit,
 /area/science/robotics/mechbay)
 "bbE" = (
-/obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 8
 	},
@@ -28366,7 +28728,6 @@
 /turf/open/floor/plasteel,
 /area/science/robotics/lab)
 "bbK" = (
-/obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
@@ -28409,7 +28770,11 @@
 /obj/machinery/computer/rdconsole{
 	dir = 8
 	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/vault/side{
+	tag = "icon-vault (WEST)";
+	icon_state = "vault";
+	dir = 8
+	},
 /area/science/robotics/lab)
 "bbP" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -28417,7 +28782,6 @@
 	icon_state = "1-2"
 	},
 /obj/effect/landmark/blobstart,
-/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
 /area/maintenance/starboard)
 "bbQ" = (
@@ -28467,9 +28831,7 @@
 /turf/open/floor/plating,
 /area/maintenance/port)
 "bbW" = (
-/obj/effect/decal/cleanable/dirt,
 /obj/structure/barricade/wooden,
-/obj/effect/decal/cleanable/dirt,
 /obj/machinery/door/airlock/maintenance_hatch{
 	name = "Maintenance Hatch";
 	req_access_txt = "12"
@@ -28497,9 +28859,7 @@
 /turf/closed/wall,
 /area/maintenance/port)
 "bbZ" = (
-/obj/effect/decal/cleanable/dirt,
 /obj/structure/barricade/wooden,
-/obj/effect/decal/cleanable/dirt,
 /obj/machinery/door/airlock/maintenance_hatch{
 	name = "Maintenance Hatch";
 	req_access_txt = "12"
@@ -28521,8 +28881,9 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/effect/turf_decal/delivery,
-/turf/open/floor/plasteel,
+/turf/open/floor/plating{
+	icon_state = "platingdmg1"
+	},
 /area/maintenance/port)
 "bcc" = (
 /obj/structure/reagent_dispensers/watertank,
@@ -28541,6 +28902,10 @@
 	pixel_x = -26;
 	req_access_txt = "0";
 	use_power = 0
+	},
+/obj/effect/turf_decal/bot,
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
 	},
 /turf/open/floor/plasteel/vault{
 	dir = 8
@@ -28567,6 +28932,10 @@
 /obj/item/clothing/mask/surgical,
 /obj/item/surgical_drapes,
 /obj/structure/table/reinforced,
+/obj/effect/turf_decal/bot,
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
 /turf/open/floor/plasteel/vault{
 	dir = 8
 	},
@@ -28584,8 +28953,10 @@
 "bci" = (
 /obj/structure/bed/roller,
 /obj/machinery/iv_drip,
-/turf/open/floor/plasteel/vault{
-	dir = 1
+/turf/open/floor/plasteel/vault/side{
+	tag = "icon-vault (NORTHWEST)";
+	icon_state = "vault";
+	dir = 9
 	},
 /area/medical/medbay/zone3)
 "bcj" = (
@@ -28686,7 +29057,6 @@
 	id = "mechbay";
 	name = "Mech Bay Shutters"
 	},
-/obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
@@ -28722,7 +29092,6 @@
 /turf/open/floor/plasteel/whitepurple/corner,
 /area/science/research)
 "bcy" = (
-/obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/effect/turf_decal/stripes/line{
 	dir = 10
@@ -28730,7 +29099,6 @@
 /turf/open/floor/plasteel,
 /area/science/robotics/lab)
 "bcz" = (
-/obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/structure/cable/white{
 	icon_state = "1-2"
@@ -28754,11 +29122,14 @@
 	pixel_x = 24
 	},
 /obj/effect/turf_decal/bot,
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/vault/side{
+	tag = "icon-vault (WEST)";
+	icon_state = "vault";
+	dir = 8
+	},
 /area/science/robotics/lab)
 "bcD" = (
 /obj/structure/rack,
-/obj/effect/decal/cleanable/dirt,
 /obj/item/weldingtool,
 /obj/item/device/assembly/voice,
 /obj/item/clothing/head/welding,
@@ -28769,7 +29140,6 @@
 /turf/open/floor/plasteel,
 /area/maintenance/starboard)
 "bcE" = (
-/obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/cobweb/cobweb2,
 /obj/effect/turf_decal/stripes/line{
 	dir = 5
@@ -28778,7 +29148,6 @@
 /area/maintenance/starboard)
 "bcF" = (
 /obj/machinery/computer/slot_machine,
-/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/vault{
 	dir = 8
 	},
@@ -28802,19 +29171,16 @@
 /area/maintenance/port)
 "bcK" = (
 /obj/machinery/computer/slot_machine,
-/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
 /area/maintenance/port)
 "bcL" = (
 /obj/machinery/vending/cigarette,
-/obj/effect/decal/cleanable/dirt,
 /obj/machinery/newscaster{
 	pixel_x = -32
 	},
 /turf/open/floor/plating,
 /area/maintenance/port)
 "bcM" = (
-/obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plasteel/vault{
 	dir = 5
@@ -28824,7 +29190,6 @@
 /obj/structure/chair/comfy/black{
 	dir = 4
 	},
-/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/vault{
 	dir = 5
 	},
@@ -28849,11 +29214,9 @@
 /obj/structure/table/wood,
 /obj/item/device/instrument/guitar,
 /obj/effect/decal/cleanable/cobweb/cobweb2,
-/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
 /area/maintenance/port)
 "bcS" = (
-/obj/effect/decal/cleanable/dirt,
 /obj/structure/cable/white{
 	icon_state = "1-2"
 	},
@@ -28862,14 +29225,12 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/effect/landmark/blobstart,
-/obj/effect/turf_decal/bot,
-/turf/open/floor/plasteel,
+/turf/open/floor/plating,
 /area/maintenance/port)
 "bcT" = (
 /obj/structure/rack,
 /obj/item/storage/toolbox/mechanical,
 /obj/item/clothing/head/welding,
-/obj/effect/decal/cleanable/dirt,
 /obj/machinery/light/small{
 	dir = 4
 	},
@@ -28896,6 +29257,10 @@
 /obj/structure/mirror{
 	pixel_x = -28
 	},
+/obj/effect/turf_decal/bot,
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
 /turf/open/floor/plasteel/vault{
 	dir = 8
 	},
@@ -28916,6 +29281,10 @@
 /obj/structure/table/reinforced,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
+	},
+/obj/effect/turf_decal/bot,
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
 	},
 /turf/open/floor/plasteel/vault{
 	dir = 8
@@ -28941,7 +29310,9 @@
 "bcZ" = (
 /obj/structure/bed/roller,
 /obj/machinery/iv_drip,
-/turf/open/floor/plasteel/vault{
+/turf/open/floor/plasteel/vault/side{
+	tag = "icon-vault (WEST)";
+	icon_state = "vault";
 	dir = 8
 	},
 /area/medical/medbay/zone3)
@@ -28949,8 +29320,10 @@
 /obj/machinery/computer/med_data{
 	dir = 4
 	},
-/turf/open/floor/plasteel/vault{
-	dir = 8
+/turf/open/floor/plasteel/vault/side{
+	tag = "icon-vault (EAST)";
+	icon_state = "vault";
+	dir = 4
 	},
 /area/medical/medbay/zone3)
 "bdb" = (
@@ -29060,7 +29433,6 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "bdk" = (
-/obj/effect/decal/cleanable/dirt,
 /obj/machinery/door/poddoor/shutters{
 	id = "mechbay";
 	name = "Mech Bay Shutters"
@@ -29083,7 +29455,6 @@
 /turf/open/floor/plasteel,
 /area/science/robotics/mechbay)
 "bdl" = (
-/obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 1
 	},
@@ -29093,14 +29464,12 @@
 /turf/open/floor/plasteel,
 /area/science/robotics/mechbay)
 "bdm" = (
-/obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
 /turf/open/floor/circuit/green,
 /area/science/robotics/mechbay)
 "bdn" = (
-/obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 9
 	},
@@ -29142,11 +29511,10 @@
 /turf/open/floor/plasteel/whitepurple/corner,
 /area/science/research)
 "bds" = (
-/turf/closed/wall,
+/turf/closed/wall/rust,
 /area/science/robotics/lab)
 "bdt" = (
 /obj/structure/closet/wardrobe/robotics_black,
-/obj/effect/decal/cleanable/dirt,
 /obj/machinery/power/apc{
 	dir = 8;
 	name = "Robotics Lab APC";
@@ -29158,7 +29526,7 @@
 	icon_state = "0-4"
 	},
 /obj/effect/turf_decal/bot,
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/vault,
 /area/science/robotics/lab)
 "bdu" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -29172,7 +29540,7 @@
 	icon_state = "1-8"
 	},
 /obj/effect/turf_decal/bot,
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/vault,
 /area/science/robotics/lab)
 "bdv" = (
 /obj/structure/table/reinforced,
@@ -29183,7 +29551,11 @@
 /obj/item/surgical_drapes,
 /obj/item/cautery,
 /obj/effect/turf_decal/bot,
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/vault/side{
+	tag = "icon-vault (EAST)";
+	icon_state = "vault";
+	dir = 4
+	},
 /area/science/robotics/lab)
 "bdw" = (
 /obj/machinery/holopad,
@@ -29205,7 +29577,11 @@
 	pixel_x = 32
 	},
 /obj/effect/turf_decal/bot,
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/vault/side{
+	tag = "icon-vault (WEST)";
+	icon_state = "vault";
+	dir = 8
+	},
 /area/science/robotics/lab)
 "bdz" = (
 /obj/structure/cable/white{
@@ -29214,9 +29590,7 @@
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
 	dir = 8
 	},
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/delivery,
-/turf/open/floor/plasteel,
+/turf/open/floor/plating,
 /area/maintenance/starboard)
 "bdA" = (
 /obj/machinery/door/airlock/maintenance_hatch{
@@ -29232,22 +29606,20 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plating,
 /area/maintenance/starboard)
 "bdB" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/blood/old,
 /obj/effect/landmark/xeno_spawn,
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 8
 	},
-/turf/open/floor/plating,
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
 /area/maintenance/starboard)
 "bdC" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
 /obj/item/storage/box/lights/mixed,
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -29298,7 +29670,6 @@
 	pixel_y = 3
 	},
 /obj/item/storage/briefcase,
-/obj/effect/decal/cleanable/dirt,
 /obj/machinery/light/small{
 	dir = 8
 	},
@@ -29318,7 +29689,6 @@
 /obj/structure/chair/comfy/black{
 	dir = 4
 	},
-/obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
@@ -29349,8 +29719,6 @@
 /obj/item/clothing/head/helmet/justice/escape{
 	name = "justice helmet"
 	},
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
 /obj/machinery/light/small{
 	dir = 4
 	},
@@ -29362,17 +29730,15 @@
 	},
 /area/maintenance/port)
 "bdO" = (
-/obj/effect/decal/cleanable/dirt,
 /obj/structure/cable/white{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/effect/turf_decal/delivery,
-/turf/open/floor/plasteel,
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/plating,
 /area/maintenance/port)
 "bdP" = (
 /obj/structure/reagent_dispensers/fueltank,
-/obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/stripes/line{
 	dir = 10
 	},
@@ -29386,6 +29752,10 @@
 	},
 /obj/structure/extinguisher_cabinet{
 	pixel_y = -26
+	},
+/obj/effect/turf_decal/bot,
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
 	},
 /turf/open/floor/plasteel/vault{
 	dir = 8
@@ -29405,6 +29775,10 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
+	},
+/obj/effect/turf_decal/bot,
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
 	},
 /turf/open/floor/plasteel/vault{
 	dir = 8
@@ -29458,8 +29832,10 @@
 	dir = 8;
 	network = list("SS13")
 	},
-/turf/open/floor/plasteel/vault{
-	dir = 4
+/turf/open/floor/plasteel/vault/side{
+	tag = "icon-vault (WEST)";
+	icon_state = "vault";
+	dir = 8
 	},
 /area/medical/medbay/zone3)
 "bdX" = (
@@ -29474,8 +29850,10 @@
 	pixel_x = -26;
 	pixel_y = -26
 	},
-/turf/open/floor/plasteel/vault{
-	dir = 8
+/turf/open/floor/plasteel/vault/side{
+	tag = "icon-vault (EAST)";
+	icon_state = "vault";
+	dir = 4
 	},
 /area/medical/medbay/zone3)
 "bdY" = (
@@ -29558,7 +29936,6 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "beg" = (
-/obj/effect/decal/cleanable/dirt,
 /obj/item/device/radio/intercom{
 	name = "Station Intercom";
 	pixel_y = -24
@@ -29581,7 +29958,6 @@
 /turf/open/floor/circuit/green,
 /area/science/robotics/mechbay)
 "bei" = (
-/obj/effect/decal/cleanable/dirt,
 /obj/structure/sign/nosmoking_2{
 	pixel_y = -32
 	},
@@ -29600,6 +29976,9 @@
 "bek" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/effect/turf_decal/delivery,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
 /turf/open/floor/plasteel,
 /area/science/research)
 "bel" = (
@@ -29608,6 +29987,9 @@
 	icon_state = "1-2"
 	},
 /obj/effect/turf_decal/delivery,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
 /turf/open/floor/plasteel,
 /area/science/research)
 "bem" = (
@@ -29619,20 +30001,25 @@
 	name = "Station Intercom";
 	pixel_y = -26
 	},
-/obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/effect/turf_decal/bot,
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/vault/side{
+	tag = "icon-vault (NORTH)";
+	icon_state = "vault";
+	dir = 1
+	},
 /area/science/robotics/lab)
 "ben" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/structure/cable/white{
 	icon_state = "1-2"
 	},
 /obj/effect/turf_decal/delivery,
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/vault/side{
+	tag = "icon-vault (NORTH)";
+	icon_state = "vault";
+	dir = 1
+	},
 /area/science/robotics/lab)
 "beo" = (
 /obj/structure/table/reinforced,
@@ -29647,7 +30034,11 @@
 	},
 /obj/machinery/light,
 /obj/effect/turf_decal/bot,
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/vault/side{
+	tag = "icon-vault (EAST)";
+	icon_state = "vault";
+	dir = 4
+	},
 /area/science/robotics/lab)
 "bep" = (
 /obj/machinery/computer/operating{
@@ -29666,7 +30057,6 @@
 /obj/machinery/status_display{
 	pixel_y = -32
 	},
-/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/whitepurple/corner,
 /area/science/robotics/lab)
 "ber" = (
@@ -29682,16 +30072,22 @@
 	pixel_x = 28
 	},
 /obj/effect/turf_decal/bot,
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/vault/side{
+	tag = "icon-vault (WEST)";
+	icon_state = "vault";
+	dir = 8
+	},
 /area/science/robotics/lab)
 "bes" = (
 /obj/structure/rack,
 /obj/item/crowbar/red,
 /obj/item/wrench,
 /obj/item/tank/internals/emergency_oxygen/engi,
-/obj/effect/decal/cleanable/dirt,
 /obj/effect/spawner/lootdrop/maintenance,
-/turf/open/floor/plating,
+/obj/effect/turf_decal/stripes/line{
+	dir = 10
+	},
+/turf/open/floor/plasteel,
 /area/maintenance/starboard)
 "bet" = (
 /obj/structure/rack,
@@ -29702,7 +30098,6 @@
 /obj/item/stack/sheet/glass{
 	amount = 30
 	},
-/obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/stripes/line{
 	dir = 6
 	},
@@ -29711,12 +30106,10 @@
 "beu" = (
 /obj/structure/table/wood,
 /obj/item/storage/pill_bottle,
-/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
 /area/maintenance/port)
 "bev" = (
 /obj/machinery/computer/slot_machine,
-/obj/effect/decal/cleanable/dirt,
 /obj/machinery/light/small,
 /obj/structure/sign/poster/contraband/random{
 	pixel_y = -32
@@ -29727,7 +30120,6 @@
 /area/maintenance/port)
 "bew" = (
 /obj/structure/table/wood,
-/obj/effect/decal/cleanable/dirt,
 /obj/item/coin/iron{
 	icon_state = "coin_bananium_heads";
 	name = "arcade coin";
@@ -29752,7 +30144,6 @@
 	pixel_y = 5
 	},
 /obj/item/reagent_containers/syringe,
-/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/vault{
 	dir = 8
 	},
@@ -29761,12 +30152,9 @@
 /obj/structure/table/wood,
 /obj/item/newspaper,
 /obj/item/clothing/head/bowler,
-/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
 /area/maintenance/port)
 "bez" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
 /obj/structure/sign/poster/contraband/random{
 	pixel_y = -32
 	},
@@ -29786,7 +30174,6 @@
 	name = "Theatre Stage";
 	req_access_txt = "0"
 	},
-/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/bar,
 /area/maintenance/port)
 "beC" = (
@@ -29823,7 +30210,6 @@
 /area/medical/medbay/zone3)
 "beF" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/effect/decal/cleanable/dirt,
 /obj/machinery/door/airlock/maintenance_hatch{
 	name = "Medbay Maintenance";
 	req_access_txt = "5"
@@ -29956,7 +30342,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plating,
 /area/maintenance/starboard)
 "beQ" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -29965,7 +30351,6 @@
 /turf/closed/wall/r_wall,
 /area/science/robotics/lab)
 "beR" = (
-/obj/effect/decal/cleanable/dirt,
 /obj/structure/cable/white{
 	icon_state = "1-4"
 	},
@@ -29987,8 +30372,11 @@
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
 	dir = 1
 	},
-/obj/effect/turf_decal/delivery,
-/turf/open/floor/plasteel,
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/plating{
+	burnt = 1;
+	icon_state = "panelscorched"
+	},
 /area/maintenance/port)
 "beT" = (
 /obj/effect/decal/cleanable/dirt,
@@ -30023,8 +30411,8 @@
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
 	dir = 1
 	},
-/obj/effect/turf_decal/delivery,
-/turf/open/floor/plasteel,
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/plating,
 /area/maintenance/port)
 "beW" = (
 /obj/structure/cable/white{
@@ -30062,7 +30450,6 @@
 /turf/open/floor/plating,
 /area/maintenance/port)
 "bfa" = (
-/obj/effect/decal/cleanable/dirt,
 /obj/structure/cable/white{
 	icon_state = "4-8"
 	},
@@ -30073,9 +30460,10 @@
 	icon_state = "1-4"
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/delivery,
-/turf/open/floor/plasteel,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/turf/open/floor/plating,
 /area/maintenance/port)
 "bfb" = (
 /obj/structure/cable/white{
@@ -30084,8 +30472,9 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
-/turf/open/floor/plasteel/neutral/corner{
-	dir = 4
+/turf/open/floor/plating{
+	broken = 1;
+	icon_state = "platingdmg3"
 	},
 /area/maintenance/port)
 "bfc" = (
@@ -30099,10 +30488,11 @@
 /turf/open/floor/plasteel/neutral/corner,
 /area/maintenance/port)
 "bfd" = (
-/obj/effect/decal/cleanable/dirt,
 /obj/structure/closet/emcloset,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating,
+/obj/effect/turf_decal/stripes/line{
+	dir = 10
+	},
+/turf/open/floor/plasteel,
 /area/maintenance/port)
 "bfe" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -30209,7 +30599,6 @@
 /obj/structure/cable/white{
 	icon_state = "2-4"
 	},
-/obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/delivery,
 /turf/open/floor/plasteel,
 /area/maintenance/starboard)
@@ -30224,10 +30613,7 @@
 /obj/structure/cable/white{
 	icon_state = "1-4"
 	},
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/delivery,
-/turf/open/floor/plasteel,
+/turf/open/floor/plating,
 /area/maintenance/starboard)
 "bfo" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -30236,8 +30622,10 @@
 /obj/structure/cable/white{
 	icon_state = "4-8"
 	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/neutral/corner,
+/turf/open/floor/plating{
+	burnt = 1;
+	icon_state = "panelscorched"
+	},
 /area/maintenance/starboard)
 "bfp" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -30266,20 +30654,20 @@
 /obj/structure/cable/white{
 	icon_state = "4-8"
 	},
-/turf/open/floor/plasteel/neutral/corner{
-	dir = 1
-	},
+/turf/open/floor/plating,
 /area/maintenance/starboard)
 "bfs" = (
+/turf/open/floor/plating,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 10
 	},
 /obj/structure/cable/white{
 	icon_state = "4-8"
 	},
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/delivery,
-/turf/open/floor/plasteel,
+/turf/open/floor/plating{
+	tag = "icon-platingdmg2";
+	icon_state = "platingdmg2"
+	},
 /area/maintenance/starboard)
 "bft" = (
 /obj/structure/cable/white{
@@ -30291,8 +30679,6 @@
 	areastring = "/area/maintenance/starboard";
 	pixel_y = -26
 	},
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
 /area/maintenance/starboard)
 "bfu" = (
@@ -30368,7 +30754,6 @@
 	name = "Maintenance Hatch";
 	req_access_txt = "12"
 	},
-/obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/structure/cable/white{
 	icon_state = "1-2"
@@ -30382,17 +30767,25 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plating,
 /area/maintenance/port)
 "bfC" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden,
-/turf/closed/wall,
+/turf/closed/wall/rust,
 /area/chapel/main)
 "bfD" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 10
 	},
-/turf/open/floor/plating,
+/obj/effect/turf_decal/bot,
+/obj/effect/turf_decal/stripes/line{
+	dir = 5
+	},
+/obj/item/storage/backpack,
+/obj/item/crowbar,
+/obj/item/wrench,
+/obj/structure/rack,
+/turf/open/floor/plasteel,
 /area/maintenance/port)
 "bfE" = (
 /obj/structure/cable/white{
@@ -30403,27 +30796,33 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/effect/landmark/blobstart,
-/turf/open/floor/plasteel/neutral,
+/turf/open/floor/plating{
+	broken = 1;
+	icon_state = "platingdmg1"
+	},
 /area/maintenance/port)
 "bfF" = (
 /obj/structure/cable/white{
 	icon_state = "4-8"
 	},
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
 /obj/effect/landmark/event_spawn,
-/turf/open/floor/plasteel/neutral,
+/obj/item/tank/internals/oxygen/red,
+/obj/item/clothing/mask/gas,
+/turf/open/floor/plating,
 /area/maintenance/port)
 "bfG" = (
-/obj/effect/decal/cleanable/dirt,
 /obj/structure/cable/white{
 	icon_state = "4-8"
 	},
-/obj/effect/turf_decal/delivery,
-/turf/open/floor/plasteel,
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/turf/open/floor/plating{
+	burnt = 1;
+	icon_state = "panelscorched"
+	},
 /area/maintenance/port)
 "bfH" = (
-/obj/effect/decal/cleanable/dirt,
 /obj/machinery/door/airlock/maintenance_hatch{
 	name = "Maintenance Hatch";
 	req_access_txt = "12"
@@ -30437,7 +30836,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plating,
 /area/maintenance/port)
 "bfI" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -30586,8 +30985,10 @@
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 8
 	},
-/turf/open/floor/plasteel/vault{
-	dir = 8
+/turf/open/floor/plasteel/vault/side{
+	tag = "icon-vault (EAST)";
+	icon_state = "vault";
+	dir = 4
 	},
 /area/chapel/main)
 "bfU" = (
@@ -30685,13 +31086,20 @@
 	},
 /area/chapel/main)
 "bgc" = (
-/obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/turf/open/floor/plating,
+/obj/effect/turf_decal/bot,
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/machinery/portable_atmospherics/canister/oxygen,
+/turf/open/floor/plasteel,
 /area/maintenance/port)
 "bgd" = (
 /obj/structure/closet/firecloset,
-/turf/open/floor/plating,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
 /area/maintenance/port)
 "bge" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
@@ -30727,12 +31135,16 @@
 /turf/open/floor/plasteel/neutral/side,
 /area/hallway/primary/central)
 "bgl" = (
-/obj/machinery/vending/cola,
+/obj/machinery/vending/cola/random,
 /obj/machinery/newscaster{
 	pixel_x = 32
 	},
 /obj/effect/turf_decal/bot,
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/vault/side{
+	tag = "icon-vault (WEST)";
+	icon_state = "vault";
+	dir = 8
+	},
 /area/hallway/primary/central)
 "bgm" = (
 /turf/open/floor/plasteel/vault{
@@ -30769,7 +31181,6 @@
 /turf/open/floor/plasteel,
 /area/science/xenobiology)
 "bgq" = (
-/obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plasteel,
@@ -30812,30 +31223,25 @@
 "bgu" = (
 /obj/machinery/hydroponics/soil,
 /obj/item/seeds/tea,
-/obj/effect/decal/cleanable/dirt,
 /obj/item/reagent_containers/food/snacks/grown/tomato,
 /obj/effect/decal/cleanable/cobweb,
-/turf/open/floor/plating,
+/turf/open/floor/plasteel/vault/side,
 /area/maintenance/starboard)
 "bgv" = (
 /obj/machinery/biogenerator,
 /obj/item/wrench,
 /obj/effect/turf_decal/delivery,
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/vault/side,
 /area/maintenance/starboard)
 "bgw" = (
 /obj/item/twohanded/required/kirbyplants{
 	icon_state = "plant-22"
 	},
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/delivery,
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/vault/side,
 /area/maintenance/starboard)
 "bgx" = (
-/obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/effect/turf_decal/bot,
-/turf/open/floor/plasteel,
+/turf/open/floor/plating,
 /area/maintenance/starboard)
 "bgy" = (
 /obj/item/twohanded/required/kirbyplants{
@@ -30843,23 +31249,21 @@
 	pixel_x = -3;
 	pixel_y = 3
 	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating,
+/turf/open/floor/plasteel/vault/side,
 /area/maintenance/starboard)
 "bgz" = (
 /obj/machinery/seed_extractor,
 /obj/item/reagent_containers/glass/bucket,
 /obj/effect/turf_decal/delivery,
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/vault/side,
 /area/maintenance/starboard)
 "bgA" = (
 /obj/machinery/hydroponics/soil,
 /obj/item/seeds/poppy,
-/obj/effect/decal/cleanable/dirt,
 /obj/item/reagent_containers/food/snacks/grown/cherries,
 /obj/item/shovel/spade,
 /obj/effect/turf_decal/delivery,
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/vault/side,
 /area/maintenance/starboard)
 "bgB" = (
 /obj/structure/mirror{
@@ -30904,8 +31308,10 @@
 	dir = 4;
 	network = list("MINE")
 	},
-/turf/open/floor/plasteel/vault{
-	dir = 8
+/turf/open/floor/plasteel/vault/side{
+	tag = "icon-vault (EAST)";
+	icon_state = "vault";
+	dir = 4
 	},
 /area/chapel/main)
 "bgE" = (
@@ -30921,7 +31327,7 @@
 /area/chapel/main)
 "bgF" = (
 /obj/machinery/status_display,
-/turf/closed/wall,
+/turf/closed/wall/rust,
 /area/chapel/main)
 "bgG" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
@@ -31004,7 +31410,6 @@
 /turf/closed/wall,
 /area/hallway/secondary/entry)
 "bgO" = (
-/obj/effect/decal/cleanable/dirt,
 /obj/machinery/door/airlock/maintenance_hatch{
 	name = "Maintenance Hatch";
 	req_access_txt = "12"
@@ -31227,18 +31632,16 @@
 /obj/structure/sign/nosmoking_2{
 	pixel_x = -32
 	},
-/obj/effect/turf_decal/bot,
-/turf/open/floor/plasteel,
+/turf/open/floor/plating,
 /area/maintenance/starboard)
 "bhk" = (
-/turf/open/floor/plasteel/hydrofloor,
+/turf/open/floor/plating,
 /area/maintenance/starboard)
 "bhl" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
 /area/maintenance/starboard)
 "bhm" = (
-/obj/effect/decal/cleanable/dirt,
 /obj/effect/landmark/xeno_spawn,
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 1
@@ -31253,8 +31656,7 @@
 /obj/structure/sign/botany{
 	pixel_x = 32
 	},
-/obj/effect/turf_decal/bot,
-/turf/open/floor/plasteel,
+/turf/open/floor/plating,
 /area/maintenance/starboard)
 "bho" = (
 /obj/machinery/door/airlock/silver{
@@ -31474,7 +31876,11 @@
 	pixel_x = 24
 	},
 /obj/effect/turf_decal/delivery,
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/vault/side{
+	tag = "icon-vault (WEST)";
+	icon_state = "vault";
+	dir = 8
+	},
 /area/hallway/secondary/entry)
 "bhM" = (
 /obj/structure/disposalpipe/trunk{
@@ -31544,7 +31950,11 @@
 /obj/item/reagent_containers/food/snacks/grown/watermelon,
 /obj/item/cultivator,
 /obj/effect/turf_decal/delivery,
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/vault/side{
+	tag = "icon-vault (NORTH)";
+	icon_state = "vault";
+	dir = 1
+	},
 /area/maintenance/starboard)
 "bhU" = (
 /obj/item/twohanded/required/kirbyplants{
@@ -31552,37 +31962,49 @@
 	pixel_x = -3;
 	pixel_y = 3
 	},
-/obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/delivery,
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/vault/side{
+	tag = "icon-vault (NORTH)";
+	icon_state = "vault";
+	dir = 1
+	},
 /area/maintenance/starboard)
 "bhV" = (
 /obj/machinery/hydroponics/soil,
 /obj/item/reagent_containers/food/snacks/grown/wheat,
 /obj/item/reagent_containers/glass/bottle/nutrient/ez,
 /obj/effect/turf_decal/delivery,
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/vault/side{
+	tag = "icon-vault (NORTH)";
+	icon_state = "vault";
+	dir = 1
+	},
 /area/maintenance/starboard)
 "bhW" = (
-/obj/effect/decal/cleanable/dirt,
 /obj/machinery/light/small,
-/obj/effect/turf_decal/bot,
-/turf/open/floor/plasteel,
+/turf/open/floor/plating,
 /area/maintenance/starboard)
 "bhX" = (
 /obj/machinery/hydroponics/soil,
 /obj/item/reagent_containers/food/snacks/grown/tea,
 /obj/item/hatchet,
 /obj/effect/turf_decal/delivery,
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/vault/side{
+	tag = "icon-vault (NORTH)";
+	icon_state = "vault";
+	dir = 1
+	},
 /area/maintenance/starboard)
 "bhY" = (
 /obj/machinery/hydroponics/soil,
 /obj/item/seeds/tower,
-/obj/effect/decal/cleanable/dirt,
 /obj/item/reagent_containers/glass/bottle/nutrient/rh,
 /obj/effect/turf_decal/delivery,
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/vault/side{
+	tag = "icon-vault (NORTH)";
+	icon_state = "vault";
+	dir = 1
+	},
 /area/maintenance/starboard)
 "bhZ" = (
 /obj/structure/closet/wardrobe/chaplain_black,
@@ -31869,7 +32291,6 @@
 	},
 /area/hallway/secondary/entry)
 "biA" = (
-/obj/effect/decal/cleanable/dirt,
 /obj/machinery/newscaster{
 	pixel_x = 32
 	},
@@ -31880,7 +32301,11 @@
 	name = "arrivals camera"
 	},
 /obj/effect/turf_decal/delivery,
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/vault/side{
+	tag = "icon-vault (WEST)";
+	icon_state = "vault";
+	dir = 8
+	},
 /area/hallway/secondary/entry)
 "biB" = (
 /obj/structure/sign/biohazard,
@@ -32795,8 +33220,6 @@
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
 "bki" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/fans/tiny,
 /obj/effect/turf_decal/delivery,
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
@@ -32902,7 +33325,7 @@
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
 "bku" = (
-/obj/machinery/vending/snack,
+/obj/machinery/vending/snack/random,
 /obj/machinery/light{
 	dir = 1
 	},
@@ -32939,7 +33362,7 @@
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
 "bkz" = (
-/obj/machinery/vending/cola,
+/obj/machinery/vending/cola/random,
 /obj/effect/turf_decal/delivery,
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
@@ -33132,7 +33555,6 @@
 /area/shuttle/arrival)
 "blb" = (
 /obj/structure/closet/firecloset,
-/obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/delivery,
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
@@ -33199,8 +33621,12 @@
 	dir = 2;
 	network = list("SS13")
 	},
-/obj/effect/turf_decal/delivery,
-/turf/open/floor/plasteel,
+/obj/effect/turf_decal/bot,
+/turf/open/floor/plasteel/vault/side{
+	tag = "icon-vault (WEST)";
+	icon_state = "vault";
+	dir = 8
+	},
 /area/hallway/primary/central)
 "blj" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -33249,8 +33675,12 @@
 	dir = 2;
 	network = list("SS13")
 	},
-/obj/effect/turf_decal/delivery,
-/turf/open/floor/plasteel,
+/obj/effect/turf_decal/bot,
+/turf/open/floor/plasteel/vault/side{
+	tag = "icon-vault (WEST)";
+	icon_state = "vault";
+	dir = 8
+	},
 /area/hallway/primary/central)
 "bln" = (
 /obj/structure/cable/white{
@@ -33264,7 +33694,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
-/turf/open/floor/plasteel,
+/turf/open/floor/engine,
 /area/engine/engineering)
 "blo" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
@@ -33401,6 +33831,9 @@
 /obj/machinery/mass_driver{
 	id = "chapelgun"
 	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
 /turf/open/floor/plating,
 /area/chapel/main)
 "blD" = (
@@ -33416,12 +33849,16 @@
 	dir = 8;
 	pixel_x = 25
 	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
 /turf/open/floor/plasteel/vault{
 	dir = 5
 	},
 /area/chapel/main)
 "blF" = (
 /obj/structure/fans/tiny,
+/obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plating,
 /area/chapel/main)
 "blG" = (
@@ -33444,6 +33881,9 @@
 	id = "chapelgun";
 	pixel_x = 24;
 	pixel_y = 8
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
 	},
 /turf/open/floor/plasteel/vault{
 	dir = 5
@@ -33470,7 +33910,7 @@
 	icon_state = "pump_map";
 	name = "Gas to Loop"
 	},
-/turf/open/floor/plasteel,
+/turf/open/floor/engine,
 /area/engine/engineering)
 "blL" = (
 /obj/machinery/door/airlock/public/glass{
@@ -33539,14 +33979,32 @@
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit)
 "bmb" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on,
-/turf/open/floor/plasteel,
-/area/hallway/secondary/exit)
-"bmh" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
+/turf/open/floor/plasteel/escape{
+	tag = "icon-escape (NORTH)";
+	icon_state = "escape";
 	dir = 1
 	},
-/turf/open/floor/plasteel,
+/area/hallway/secondary/exit)
+"bmh" = (
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
+	dir = 1
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/machinery/door/firedoor,
+/turf/open/floor/plasteel/escape{
+	tag = "icon-escape (NORTH)";
+	icon_state = "escape";
+	dir = 1
+	},
 /area/hallway/secondary/exit)
 "bmw" = (
 /obj/item/twohanded/required/kirbyplants{
@@ -33555,23 +34013,39 @@
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit)
 "bmC" = (
-/obj/machinery/light{
-	dir = 8
+/obj/machinery/vending/snack/random,
+/obj/effect/turf_decal/bot,
+/turf/open/floor/plasteel/vault/side{
+	tag = "icon-vault (EAST)";
+	icon_state = "vault";
+	dir = 4
 	},
-/turf/open/floor/plasteel,
 /area/hallway/secondary/exit)
 "bmG" = (
-/obj/item/twohanded/required/kirbyplants{
-	icon_state = "plant-22"
+/obj/effect/turf_decal/bot,
+/obj/structure/cable/white{
+	tag = "icon-4-8";
+	icon_state = "4-8"
 	},
-/turf/open/floor/plasteel,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/turf/open/floor/plasteel/vault/side{
+	tag = "icon-vault (EAST)";
+	icon_state = "vault";
+	dir = 4
+	},
 /area/hallway/secondary/exit)
 "bsv" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/structure/cable/white{
+	d1 = 2;
+	d2 = 8;
 	icon_state = "2-8"
 	},
 /obj/structure/cable/white{
+	d1 = 2;
+	d2 = 4;
 	icon_state = "2-4"
 	},
 /turf/open/floor/plasteel/escape{
@@ -33585,6 +34059,8 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/effect/turf_decal/bot,
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel,
@@ -33600,6 +34076,8 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/effect/turf_decal/bot,
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel,
@@ -33651,6 +34129,7 @@
 	dir = 4
 	},
 /obj/structure/cable/white{
+	tag = "icon-4-8";
 	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel,
@@ -33659,18 +34138,20 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
-/obj/item/twohanded/required/kirbyplants{
-	icon_state = "plant-21"
-	},
 /obj/structure/cable/white{
+	tag = "icon-4-8";
 	icon_state = "4-8"
 	},
-/turf/open/floor/plasteel,
+/obj/machinery/status_display{
+	pixel_y = -32
+	},
+/turf/open/floor/plasteel/escape,
 /area/hallway/secondary/exit)
 "bsE" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden,
 /obj/machinery/light,
 /obj/structure/cable/white{
+	tag = "icon-4-8";
 	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel,
@@ -33679,26 +34160,35 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
-/obj/machinery/light,
-/obj/item/twohanded/required/kirbyplants{
-	icon_state = "plant-22"
-	},
 /obj/structure/cable/white{
+	tag = "icon-4-8";
 	icon_state = "4-8"
 	},
-/turf/open/floor/plasteel,
+/obj/structure/sign/poster/official/random{
+	pixel_y = -32
+	},
+/turf/open/floor/plasteel/escape,
 /area/hallway/secondary/exit)
 "bsM" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
 /obj/structure/cable/white{
+	tag = "icon-2-8";
 	icon_state = "2-8"
 	},
 /obj/structure/cable/white{
+	tag = "icon-4-8";
 	icon_state = "4-8"
 	},
-/turf/open/floor/plasteel,
+/obj/structure/cable/white{
+	tag = "icon-1-2";
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/turf/open/floor/plasteel/neutral/side{
+	dir = 4
+	},
 /area/hallway/secondary/exit)
 "bsN" = (
 /obj/machinery/door/firedoor,
@@ -33723,9 +34213,13 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
-/obj/effect/turf_decal/delivery,
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit)
@@ -33734,6 +34228,8 @@
 	dir = 1
 	},
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel/neutral,
@@ -33747,9 +34243,13 @@
 	},
 /obj/effect/turf_decal/bot,
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 8;
 	icon_state = "1-8"
 	},
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel,
@@ -33757,73 +34257,105 @@
 "bsR" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/structure/cable/white{
+	d1 = 2;
+	d2 = 8;
 	icon_state = "2-8"
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
 	},
 /turf/open/floor/plasteel/neutral,
 /area/hallway/secondary/exit)
 "bsS" = (
 /obj/structure/cable/white{
+	tag = "icon-1-2";
 	icon_state = "1-2"
 	},
-/turf/open/floor/plasteel,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/turf/open/floor/plasteel/escape{
+	tag = "icon-escape (EAST)";
+	icon_state = "escape";
+	dir = 4
+	},
 /area/hallway/secondary/exit)
 "bsT" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
 	},
 /turf/open/floor/plasteel/neutral,
 /area/hallway/secondary/exit)
 "bsV" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
 	},
 /turf/open/floor/plasteel/escape,
 /area/hallway/secondary/exit)
 "bsX" = (
 /obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/mining/glass{
-	name = "Cargo Port";
-	req_access_txt = "48;50"
-	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/effect/turf_decal/stripes/line{
 	dir = 2
 	},
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
+/obj/machinery/door/airlock/mining/glass{
+	name = "Cargo Office";
+	req_access_txt = "48;50"
+	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit)
 "bsY" = (
 /obj/structure/cable/white{
+	tag = "icon-1-4";
 	icon_state = "1-4"
+	},
+/obj/structure/cable/white{
+	tag = "icon-4-8";
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	tag = "icon-intact (NORTHWEST)";
+	icon_state = "intact";
+	dir = 9
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit)
 "bsZ" = (
 /obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/mining/glass{
-	name = "Cargo Port";
-	req_access_txt = "48;50"
-	},
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
+/obj/effect/turf_decal/delivery,
+/obj/machinery/door/airlock/mining/glass{
+	name = "Cargo Office";
+	req_access_txt = "48;50"
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit)
 "bta" = (
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel/brown{
@@ -33835,6 +34367,8 @@
 	dir = 6
 	},
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel/brown{
@@ -33847,6 +34381,8 @@
 	},
 /obj/effect/turf_decal/delivery,
 /obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel,
@@ -33854,6 +34390,8 @@
 "btd" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/structure/cable/white{
+	d1 = 1;
+	d2 = 8;
 	icon_state = "1-8"
 	},
 /turf/open/floor/plasteel/brown{
@@ -33884,7 +34422,6 @@
 /turf/closed/wall/mineral/plastitanium,
 /area/shuttle/arrival)
 "btk" = (
-/obj/effect/decal/cleanable/dirt,
 /obj/machinery/door/airlock/external{
 	cyclelinkeddir = 4;
 	name = "External Docking Port"
@@ -33911,7 +34448,6 @@
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
 "buy" = (
-/obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
@@ -33949,6 +34485,10 @@
 /obj/machinery/atmospherics/pipe/manifold/general/visible{
 	dir = 1
 	},
+/obj/effect/turf_decal/stripes/corner,
+/obj/effect/turf_decal/stripes/corner{
+	dir = 1
+	},
 /turf/open/floor/plasteel/vault/telecomms{
 	dir = 5
 	},
@@ -33968,6 +34508,12 @@
 /area/tcommsat/server)
 "buI" = (
 /obj/machinery/atmospherics/pipe/simple/general/visible,
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
 /turf/open/floor/plasteel/vault/telecomms{
 	dir = 5
 	},
@@ -33979,6 +34525,12 @@
 "buK" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 1
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
 	},
 /turf/open/floor/plasteel/vault/telecomms{
 	dir = 5
@@ -34015,12 +34567,21 @@
 /obj/machinery/status_display{
 	pixel_y = -32
 	},
+/obj/effect/turf_decal/stripes/corner{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/corner{
+	dir = 8
+	},
 /turf/open/floor/plasteel/vault/telecomms{
 	dir = 5
 	},
 /area/tcommsat/server)
 "buS" = (
 /obj/machinery/ntnet_relay,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
 /turf/open/floor/plasteel/vault/telecomms{
 	dir = 5
 	},
@@ -34030,6 +34591,9 @@
 	c_tag = "Communications Relay";
 	dir = 8;
 	network = list("MINE")
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
 	},
 /turf/open/floor/plasteel/vault/telecomms{
 	dir = 5
@@ -34066,11 +34630,15 @@
 	name = "Asteroid"
 	})
 "bvh" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating/airless/astplate,
-/area/ruin/unpowered{
-	name = "Asteroid"
-	})
+/obj/structure/closet/emcloset{
+	anchored = 1
+	},
+/obj/machinery/light/small{
+	dir = 1
+	},
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
 "bvo" = (
 /obj/structure/girder,
 /turf/open/floor/plating/airless,
@@ -34233,13 +34801,13 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
 	dir = 9
 	},
-/turf/open/floor/plasteel,
+/turf/open/floor/engine,
 /area/engine/engineering)
 "bwW" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 5
 	},
-/turf/closed/wall/r_wall,
+/turf/closed/wall/r_wall/rust,
 /area/tcommsat/server)
 "bwX" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -34267,7 +34835,7 @@
 /obj/machinery/atmospherics/pipe/simple/green/visible{
 	dir = 9
 	},
-/turf/open/floor/plasteel,
+/turf/open/floor/engine,
 /area/engine/engineering)
 "bxc" = (
 /obj/structure/lattice/catwalk,
@@ -34318,15 +34886,14 @@
 /turf/closed/wall/r_wall,
 /area/tcommsat/server)
 "bxu" = (
-/obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/general/visible,
-/turf/open/floor/plasteel/caution,
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/engine,
 /area/engine/engineering)
 "bxv" = (
 /obj/structure/cable{
 	icon_state = "1-4"
 	},
-/obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
@@ -34336,10 +34903,9 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/turf/open/floor/plasteel,
+/turf/open/floor/engine,
 /area/engine/engineering)
 "bxw" = (
-/obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/effect/landmark/event_spawn,
 /obj/structure/cable/white{
@@ -34353,8 +34919,10 @@
 	icon_state = "1-2"
 	},
 /obj/effect/landmark/event_spawn,
-/turf/open/floor/plasteel/vault{
-	dir = 5
+/turf/open/floor/plasteel/vault/side{
+	tag = "icon-vault (WEST)";
+	icon_state = "vault";
+	dir = 8
 	},
 /area/bridge)
 "bxy" = (
@@ -34365,9 +34933,7 @@
 	dir = 4
 	},
 /obj/effect/landmark/event_spawn,
-/turf/open/floor/plasteel/vault{
-	dir = 5
-	},
+/turf/open/floor/wood,
 /area/crew_quarters/heads/hop)
 "bxz" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -34403,7 +34969,10 @@
 	icon_state = "4-8"
 	},
 /obj/effect/landmark/event_spawn,
-/turf/open/floor/plasteel/neutral/corner,
+/turf/open/floor/plating{
+	burnt = 1;
+	icon_state = "panelscorched"
+	},
 /area/maintenance/starboard/central)
 "bxD" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -34413,7 +34982,6 @@
 	},
 /area/hallway/primary/central)
 "bxE" = (
-/obj/effect/decal/cleanable/dirt,
 /obj/structure/cable/white{
 	icon_state = "1-2"
 	},
@@ -34433,7 +35001,6 @@
 /turf/open/floor/plasteel/redyellow,
 /area/crew_quarters/bar/atrium)
 "bxH" = (
-/obj/effect/decal/cleanable/dirt,
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/plasteel/neutral,
 /area/engine/atmos)
@@ -34462,8 +35029,14 @@
 /turf/open/floor/plasteel/redyellow,
 /area/crew_quarters/bar/atrium)
 "bxM" = (
-/obj/effect/landmark/event_spawn,
-/turf/open/floor/plasteel,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/turf/open/floor/plasteel/escape{
+	tag = "icon-escape (NORTH)";
+	icon_state = "escape";
+	dir = 1
+	},
 /area/hallway/secondary/exit)
 "bxN" = (
 /obj/structure/cable/white{
@@ -34496,16 +35069,14 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/effect/landmark/event_spawn,
-/turf/open/floor/plasteel/neutral/corner{
-	dir = 1
-	},
+/turf/open/floor/plating,
 /area/maintenance/port)
 "bxS" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
 /obj/effect/landmark/event_spawn,
-/turf/open/floor/plasteel/grimy,
+/turf/open/floor/wood,
 /area/library)
 "bxT" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -34538,9 +35109,11 @@
 /obj/structure/cable/white{
 	icon_state = "4-8"
 	},
-/obj/effect/decal/cleanable/dirt,
 /obj/effect/landmark/event_spawn,
-/turf/open/floor/plating,
+/turf/open/floor/plating{
+	burnt = 1;
+	icon_state = "panelscorched"
+	},
 /area/maintenance/starboard)
 "bxY" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -34556,7 +35129,7 @@
 /turf/closed/wall,
 /area/maintenance/starboard/fore)
 "bye" = (
-/turf/closed/wall,
+/turf/closed/wall/rust,
 /area/maintenance/fore)
 "byf" = (
 /obj/structure/sign/vacuum,
@@ -34564,7 +35137,6 @@
 /area/maintenance/starboard/fore)
 "byg" = (
 /obj/structure/closet/emcloset/anchored,
-/obj/effect/decal/cleanable/dirt,
 /obj/machinery/light/small{
 	dir = 1
 	},
@@ -34572,15 +35144,15 @@
 /turf/open/floor/plasteel,
 /area/maintenance/starboard/fore)
 "byi" = (
-/obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
-/obj/effect/turf_decal/delivery,
-/turf/open/floor/plasteel,
+/turf/open/floor/plating{
+	burnt = 1;
+	icon_state = "panelscorched"
+	},
 /area/maintenance/starboard/fore)
 "byj" = (
-/obj/effect/decal/cleanable/dirt,
 /obj/machinery/door/airlock/external{
 	name = "External Airlock";
 	req_access_txt = "13"
@@ -34597,8 +35169,6 @@
 /turf/open/floor/plasteel,
 /area/maintenance/starboard/fore)
 "byk" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/blood/old,
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 8
@@ -34608,7 +35178,6 @@
 /turf/open/floor/plasteel,
 /area/maintenance/starboard/fore)
 "byl" = (
-/obj/effect/decal/cleanable/dirt,
 /obj/machinery/door/airlock/external{
 	name = "External Airlock";
 	req_access_txt = "13"
@@ -34622,15 +35191,11 @@
 /turf/open/floor/plasteel,
 /area/maintenance/starboard/fore)
 "bym" = (
-/obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/structure/cable/white{
 	icon_state = "1-2"
 	},
-/turf/open/floor/plasteel/neutral/corner{
-	dir = 8;
-	heat_capacity = 1e+006
-	},
+/turf/open/floor/plating,
 /area/maintenance/starboard/fore)
 "byn" = (
 /obj/structure/closet/wardrobe/grey,
@@ -34687,6 +35252,5069 @@
 /obj/machinery/rnd/protolathe/department/medical,
 /turf/closed/wall,
 /area/medical/medbay/zone3)
+"swv" = (
+/turf/closed/wall/r_wall/rust,
+/area/bridge)
+"sww" = (
+/turf/closed/wall/r_wall/rust,
+/area/bridge)
+"swx" = (
+/obj/structure/cable/white{
+	icon_state = "4-8"
+	},
+/obj/structure/cable/white{
+	icon_state = "1-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/turf/open/floor/plasteel/vault/side{
+	tag = "icon-vault (NORTHWEST)";
+	icon_state = "vault";
+	dir = 9
+	},
+/area/bridge)
+"swy" = (
+/turf/open/floor/plasteel/vault/side{
+	tag = "icon-vault (WEST)";
+	icon_state = "vault";
+	dir = 8
+	},
+/area/bridge)
+"swz" = (
+/turf/closed/wall/r_wall/rust,
+/area/crew_quarters/heads/hop)
+"swA" = (
+/turf/closed/wall/rust,
+/area/maintenance/starboard/fore)
+"swB" = (
+/turf/closed/wall/rust,
+/area/maintenance/starboard/fore)
+"swC" = (
+/turf/closed/wall/r_wall/rust,
+/area/crew_quarters/heads/captain/private)
+"swD" = (
+/obj/structure/cable/white{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plasteel/vault/side{
+	tag = "icon-vault (WEST)";
+	icon_state = "vault";
+	dir = 8
+	},
+/area/bridge)
+"swE" = (
+/turf/closed/wall/r_wall/rust,
+/area/crew_quarters/heads/hop)
+"swF" = (
+/obj/structure/sign/securearea,
+/turf/closed/wall/rust,
+/area/ruin/unpowered{
+	name = "Asteroid"
+	})
+"swG" = (
+/turf/closed/wall/rust,
+/area/security/detectives_office)
+"swH" = (
+/turf/closed/wall/r_wall/rust,
+/area/crew_quarters/heads/captain/private)
+"swI" = (
+/turf/closed/wall/r_wall/rust,
+/area/crew_quarters/heads/hop)
+"swJ" = (
+/obj/structure/cable/white{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/turf/open/floor/plasteel/vault/side{
+	tag = "icon-vault (EAST)";
+	icon_state = "vault";
+	dir = 4
+	},
+/area/bridge)
+"swK" = (
+/obj/structure/cable/white{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/turf/open/floor/plasteel/vault/side{
+	tag = "icon-vault (WEST)";
+	icon_state = "vault";
+	dir = 8
+	},
+/area/bridge)
+"swL" = (
+/turf/closed/wall/rust,
+/area/quartermaster/storage)
+"swM" = (
+/obj/machinery/status_display{
+	name = "cargo display";
+	supply_display = 1
+	},
+/turf/closed/wall/rust,
+/area/quartermaster/storage)
+"swN" = (
+/turf/closed/wall/rust,
+/area/ruin/unpowered{
+	name = "Asteroid"
+	})
+"swO" = (
+/turf/open/floor/plating{
+	burnt = 1;
+	icon_state = "panelscorched"
+	},
+/area/ruin/unpowered{
+	name = "Asteroid"
+	})
+"swP" = (
+/turf/closed/wall/r_wall/rust,
+/area/crew_quarters/heads/captain/private)
+"swQ" = (
+/turf/closed/wall/r_wall/rust,
+/area/bridge)
+"swR" = (
+/turf/closed/wall/rust,
+/area/ruin/unpowered{
+	name = "Asteroid"
+	})
+"swS" = (
+/turf/closed/wall/rust,
+/area/ruin/unpowered{
+	name = "Asteroid"
+	})
+"swT" = (
+/turf/closed/wall/rust,
+/area/security/detectives_office)
+"swU" = (
+/turf/closed/wall/r_wall/rust,
+/area/bridge)
+"swV" = (
+/turf/closed/wall/r_wall/rust,
+/area/crew_quarters/heads/hop)
+"swW" = (
+/turf/closed/wall/rust,
+/area/ruin/unpowered{
+	name = "Asteroid"
+	})
+"swX" = (
+/turf/closed/wall/rust,
+/area/ruin/unpowered{
+	name = "Asteroid"
+	})
+"swY" = (
+/turf/closed/wall/rust,
+/area/quartermaster/storage)
+"swZ" = (
+/turf/closed/wall/r_wall/rust,
+/area/security/brig)
+"sxa" = (
+/turf/closed/wall/r_wall/rust,
+/area/bridge)
+"sxb" = (
+/turf/closed/wall/r_wall/rust,
+/area/crew_quarters/heads/hop)
+"sxc" = (
+/turf/closed/wall/r_wall/rust,
+/area/ruin/unpowered{
+	name = "Asteroid"
+	})
+"sxd" = (
+/turf/closed/wall/r_wall/rust,
+/area/ruin/unpowered{
+	name = "Asteroid"
+	})
+"sxe" = (
+/turf/closed/wall/r_wall/rust,
+/area/security/brig)
+"sxf" = (
+/turf/closed/wall/rust,
+/area/ruin/unpowered{
+	name = "Asteroid"
+	})
+"sxg" = (
+/turf/closed/wall/r_wall/rust,
+/area/crew_quarters/heads/captain/private)
+"sxh" = (
+/turf/closed/wall/rust,
+/area/quartermaster/storage)
+"sxi" = (
+/turf/closed/wall,
+/area/space)
+"sxj" = (
+/turf/closed/wall,
+/area/space)
+"sxk" = (
+/turf/closed/wall,
+/area/space)
+"sxl" = (
+/turf/closed/wall,
+/area/space)
+"sxm" = (
+/turf/closed/wall,
+/area/space)
+"sxn" = (
+/turf/closed/wall,
+/area/space)
+"sxo" = (
+/turf/closed/wall,
+/area/space)
+"sxp" = (
+/obj/structure/table/reinforced,
+/obj/machinery/airalarm{
+	dir = 1;
+	pixel_y = -22
+	},
+/obj/machinery/firealarm{
+	dir = 8;
+	pixel_x = -24
+	},
+/obj/item/paper_bin,
+/obj/item/pen,
+/obj/effect/turf_decal/bot,
+/turf/open/floor/plasteel,
+/area/space)
+"sxq" = (
+/obj/structure/table/reinforced,
+/obj/machinery/light,
+/obj/machinery/requests_console{
+	department = "Mining";
+	departmentType = 0;
+	name = "Mining Dock RC";
+	pixel_y = -32
+	},
+/obj/item/folder/yellow,
+/obj/item/toy/figure/miner,
+/turf/open/floor/plasteel/brown{
+	dir = 10
+	},
+/area/space)
+"sxr" = (
+/obj/machinery/computer/security/mining,
+/obj/machinery/status_display{
+	pixel_x = 32
+	},
+/obj/machinery/newscaster{
+	pixel_y = -32
+	},
+/turf/open/floor/plasteel/purple/side{
+	dir = 6
+	},
+/area/space)
+"sxs" = (
+/turf/closed/wall,
+/area/space)
+"sxt" = (
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
+/area/space)
+"sxu" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/sign/vacuum,
+/turf/open/floor/plating,
+/area/space)
+"sxv" = (
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
+/area/space)
+"sxw" = (
+/turf/closed/wall/mineral/titanium,
+/area/space)
+"sxx" = (
+/obj/item/clothing/suit/hazardvest{
+	desc = "A high-visibility lifejacket complete with whistle and slot for oxygen tanks.";
+	name = "emergency lifejacket"
+	},
+/obj/item/clothing/suit/hazardvest{
+	desc = "A high-visibility lifejacket complete with whistle and slot for oxygen tanks.";
+	name = "emergency lifejacket"
+	},
+/obj/item/clothing/suit/hazardvest{
+	desc = "A high-visibility lifejacket complete with whistle and slot for oxygen tanks.";
+	name = "emergency lifejacket"
+	},
+/obj/item/clothing/suit/hazardvest{
+	desc = "A high-visibility lifejacket complete with whistle and slot for oxygen tanks.";
+	name = "emergency lifejacket"
+	},
+/obj/item/clothing/suit/hazardvest{
+	desc = "A high-visibility lifejacket complete with whistle and slot for oxygen tanks.";
+	name = "emergency lifejacket"
+	},
+/obj/item/tank/internals/emergency_oxygen/double{
+	pixel_x = 3
+	},
+/obj/item/tank/internals/emergency_oxygen/double{
+	pixel_x = 3
+	},
+/obj/item/tank/internals/emergency_oxygen/double{
+	pixel_x = 3
+	},
+/obj/item/tank/internals/emergency_oxygen/double{
+	pixel_x = 3
+	},
+/obj/item/tank/internals/emergency_oxygen/double{
+	pixel_x = 3
+	},
+/obj/item/clothing/mask/breath{
+	pixel_x = -3;
+	pixel_y = -3
+	},
+/obj/item/clothing/mask/breath{
+	pixel_x = -3;
+	pixel_y = -3
+	},
+/obj/item/clothing/mask/breath{
+	pixel_x = -3;
+	pixel_y = -3
+	},
+/obj/item/clothing/mask/breath{
+	pixel_x = -3;
+	pixel_y = -3
+	},
+/obj/item/clothing/mask/breath{
+	pixel_x = -3;
+	pixel_y = -3
+	},
+/obj/item/clothing/head/hardhat/orange{
+	name = "protective hat";
+	pixel_y = 9
+	},
+/obj/item/clothing/head/hardhat/orange{
+	name = "protective hat";
+	pixel_y = 9
+	},
+/obj/item/clothing/head/hardhat/orange{
+	name = "protective hat";
+	pixel_y = 9
+	},
+/obj/item/clothing/head/hardhat/orange{
+	name = "protective hat";
+	pixel_y = 9
+	},
+/obj/item/clothing/head/hardhat/orange{
+	name = "protective hat";
+	pixel_y = 9
+	},
+/obj/structure/closet/crate/internals,
+/obj/item/pickaxe/emergency,
+/obj/item/pickaxe/emergency,
+/obj/effect/turf_decal/delivery,
+/obj/machinery/light/small{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/space)
+"sxy" = (
+/obj/structure/shuttle/engine/heater,
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/plating,
+/area/space)
+"sxz" = (
+/obj/structure/ore_box,
+/obj/effect/turf_decal/delivery,
+/obj/machinery/light/small{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/space)
+"sxA" = (
+/turf/closed/wall/mineral/titanium,
+/area/space)
+"sxB" = (
+/turf/closed/wall/r_wall/rust,
+/area/security/brig)
+"sxC" = (
+/turf/closed/wall/r_wall/rust,
+/area/ai_monitored/turret_protected/ai)
+"sxD" = (
+/obj/machinery/mineral/mint,
+/obj/structure/sign/poster/official/random{
+	pixel_y = 32
+	},
+/obj/effect/turf_decal/bot,
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/plasteel,
+/area/space)
+"sxE" = (
+/obj/effect/decal/cleanable/oil,
+/obj/effect/turf_decal/bot,
+/obj/effect/turf_decal/stripes/line{
+	dir = 6
+	},
+/turf/open/floor/plasteel,
+/area/space)
+"sxF" = (
+/turf/open/floor/plating,
+/area/space)
+"sxG" = (
+/obj/machinery/space_heater,
+/obj/effect/turf_decal/stripes/line{
+	dir = 10
+	},
+/obj/effect/decal/cleanable/cobweb/cobweb2,
+/turf/open/floor/plasteel,
+/area/space)
+"sxH" = (
+/obj/structure/sign/vacuum,
+/turf/closed/wall,
+/area/space)
+"sxI" = (
+/obj/structure/closet/emcloset{
+	anchored = 1
+	},
+/obj/machinery/light/small{
+	dir = 1
+	},
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/plasteel,
+/area/space)
+"sxJ" = (
+/turf/closed/wall,
+/area/space)
+"sxK" = (
+/turf/closed/wall,
+/area/space)
+"sxL" = (
+/turf/closed/wall,
+/area/space)
+"sxM" = (
+/turf/closed/wall,
+/area/space)
+"sxN" = (
+/turf/closed/wall,
+/area/space)
+"sxO" = (
+/obj/structure/lattice,
+/turf/open/space,
+/area/space)
+"sxP" = (
+/obj/structure/lattice,
+/turf/open/space,
+/area/space)
+"sxQ" = (
+/turf/closed/wall/mineral/titanium,
+/area/space)
+"sxR" = (
+/turf/closed/wall/mineral/titanium,
+/area/space)
+"sxS" = (
+/obj/structure/shuttle/engine/propulsion/burst,
+/obj/structure/window/reinforced{
+	dir = 1;
+	layer = 2.9
+	},
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/plating/airless,
+/area/space)
+"sxT" = (
+/turf/closed/wall/mineral/titanium,
+/area/space)
+"sxU" = (
+/turf/closed/wall/mineral/titanium,
+/area/space)
+"sxV" = (
+/turf/closed/wall/rust,
+/area/quartermaster/storage)
+"sxW" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/space)
+"sxX" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/space)
+"sxY" = (
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
+	tag = "icon-manifold (NORTH)";
+	icon_state = "manifold";
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/space)
+"sxZ" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/space)
+"sya" = (
+/obj/machinery/door/airlock/external{
+	name = "External Airlock";
+	req_access_txt = "13"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/space)
+"syb" = (
+/obj/effect/landmark/xeno_spawn,
+/obj/machinery/atmospherics/components/unary/vent_pump/on{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/space)
+"syc" = (
+/obj/machinery/door/airlock/external{
+	name = "External Airlock";
+	req_access_txt = "13"
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/space)
+"syd" = (
+/turf/open/floor/plating/airless/astplate,
+/area/space)
+"sye" = (
+/turf/open/floor/plating/airless/astplate,
+/area/space)
+"syf" = (
+/turf/open/floor/plating/asteroid/airless,
+/area/space)
+"syg" = (
+/obj/structure/lattice,
+/turf/open/space,
+/area/space)
+"syh" = (
+/turf/closed/wall/r_wall/rust,
+/area/security/brig)
+"syi" = (
+/turf/closed/wall,
+/area/space)
+"syj" = (
+/turf/closed/wall,
+/area/space)
+"syk" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/turf/open/floor/plating,
+/area/space)
+"syl" = (
+/obj/structure/girder,
+/turf/open/floor/plating,
+/area/space)
+"sym" = (
+/turf/closed/wall,
+/area/space)
+"syn" = (
+/turf/closed/wall,
+/area/space)
+"syo" = (
+/obj/structure/sign/vacuum,
+/turf/closed/wall,
+/area/space)
+"syp" = (
+/turf/open/floor/plating/airless/astplate,
+/area/space)
+"syq" = (
+/turf/open/floor/plating/asteroid/airless,
+/area/space)
+"syr" = (
+/obj/structure/lattice,
+/obj/structure/grille,
+/turf/open/space,
+/area/space)
+"sys" = (
+/obj/machinery/shieldgen,
+/obj/effect/turf_decal/stripes/line{
+	dir = 5
+	},
+/turf/open/floor/plasteel,
+/area/space)
+"syt" = (
+/turf/closed/wall,
+/area/space)
+"syu" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/turf/open/floor/plating,
+/area/space)
+"syv" = (
+/obj/structure/easel,
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/space)
+"syw" = (
+/turf/closed/wall,
+/area/space)
+"syx" = (
+/turf/closed/mineral/random/labormineral,
+/area/space)
+"syy" = (
+/turf/closed/mineral/random/labormineral,
+/area/space)
+"syz" = (
+/turf/open/floor/plating/asteroid/airless,
+/area/space)
+"syA" = (
+/turf/open/floor/plating/asteroid/airless,
+/area/space)
+"syB" = (
+/obj/structure/lattice,
+/obj/structure/grille,
+/turf/open/space,
+/area/space)
+"syC" = (
+/turf/closed/wall/r_wall/rust,
+/area/teleporter)
+"syD" = (
+/turf/closed/wall/rust,
+/area/quartermaster/miningdock)
+"syE" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/space)
+"syF" = (
+/turf/closed/wall,
+/area/space)
+"syG" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/turf/open/floor/plating,
+/area/space)
+"syH" = (
+/obj/structure/closet/crate{
+	icon_state = "crateopen";
+	opened = 1
+	},
+/obj/effect/spawner/lootdrop/maintenance{
+	lootcount = 2;
+	name = "2maintenance loot spawner"
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/structure/sign/poster/contraband/random{
+	pixel_x = 32
+	},
+/turf/open/floor/plasteel,
+/area/space)
+"syI" = (
+/turf/closed/wall,
+/area/space)
+"syJ" = (
+/turf/closed/mineral/random/labormineral,
+/area/space)
+"syK" = (
+/turf/open/floor/plating/asteroid/airless,
+/area/space)
+"syL" = (
+/turf/open/floor/plating/asteroid/airless,
+/area/space)
+"syM" = (
+/obj/structure/lattice,
+/turf/open/space,
+/area/space)
+"syN" = (
+/obj/structure/lattice,
+/obj/structure/grille,
+/turf/open/space,
+/area/space)
+"syO" = (
+/obj/structure/lattice,
+/obj/structure/grille,
+/turf/open/space,
+/area/space)
+"syP" = (
+/obj/structure/lattice,
+/obj/structure/grille,
+/turf/open/space,
+/area/space)
+"syQ" = (
+/obj/structure/lattice,
+/obj/structure/grille,
+/turf/open/space,
+/area/space)
+"syR" = (
+/obj/structure/lattice,
+/obj/structure/grille,
+/turf/open/space,
+/area/space)
+"syS" = (
+/turf/closed/wall/rust,
+/area/hallway/primary/central)
+"syT" = (
+/turf/closed/wall/r_wall/rust,
+/area/ai_monitored/storage/eva)
+"syU" = (
+/obj/structure/rack,
+/obj/effect/spawner/lootdrop/maintenance,
+/turf/open/floor/plasteel,
+/area/space)
+"syV" = (
+/turf/closed/wall,
+/area/space)
+"syW" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/turf/open/floor/plating,
+/area/space)
+"syX" = (
+/obj/structure/rack,
+/obj/effect/spawner/lootdrop/maintenance,
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/space)
+"syY" = (
+/turf/closed/wall,
+/area/space)
+"syZ" = (
+/obj/structure/sign/securearea,
+/turf/closed/wall,
+/area/space)
+"sza" = (
+/turf/open/floor/plating/airless/astplate,
+/area/space)
+"szb" = (
+/obj/structure/lattice,
+/turf/open/space,
+/area/space)
+"szc" = (
+/obj/structure/lattice,
+/turf/open/space,
+/area/space)
+"szd" = (
+/obj/structure/lattice,
+/turf/open/space,
+/area/space)
+"sze" = (
+/obj/structure/lattice,
+/turf/open/space,
+/area/space)
+"szf" = (
+/obj/structure/lattice,
+/turf/open/space,
+/area/space)
+"szg" = (
+/obj/structure/lattice,
+/turf/open/space,
+/area/space)
+"szh" = (
+/obj/structure/lattice,
+/turf/open/space,
+/area/space)
+"szi" = (
+/obj/structure/lattice,
+/turf/open/space,
+/area/space)
+"szj" = (
+/obj/structure/lattice,
+/turf/open/space,
+/area/space)
+"szk" = (
+/obj/structure/lattice,
+/turf/open/space,
+/area/space)
+"szl" = (
+/obj/structure/lattice,
+/turf/open/space,
+/area/space)
+"szm" = (
+/obj/structure/lattice,
+/turf/open/space,
+/area/space)
+"szn" = (
+/turf/closed/wall/r_wall/rust,
+/area/security/brig)
+"szo" = (
+/turf/closed/wall,
+/area/space)
+"szp" = (
+/turf/closed/wall,
+/area/space)
+"szq" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/turf/open/floor/plating,
+/area/space)
+"szr" = (
+/obj/structure/girder,
+/turf/open/floor/plating,
+/area/space)
+"szs" = (
+/turf/closed/wall,
+/area/space)
+"szt" = (
+/turf/closed/mineral/random/labormineral,
+/area/space)
+"szu" = (
+/turf/closed/mineral/random/labormineral,
+/area/space)
+"szv" = (
+/turf/open/floor/plating/asteroid/airless,
+/area/space)
+"szw" = (
+/turf/open/floor/plating/asteroid/airless,
+/area/space)
+"szx" = (
+/obj/structure/lattice,
+/turf/open/space,
+/area/space)
+"szy" = (
+/turf/closed/wall,
+/area/space)
+"szz" = (
+/turf/closed/wall,
+/area/space)
+"szA" = (
+/turf/closed/wall,
+/area/space)
+"szB" = (
+/turf/closed/wall,
+/area/space)
+"szC" = (
+/turf/closed/wall,
+/area/space)
+"szD" = (
+/turf/closed/wall,
+/area/space)
+"szE" = (
+/turf/closed/wall,
+/area/space)
+"szF" = (
+/obj/structure/lattice,
+/turf/open/space,
+/area/space)
+"szG" = (
+/turf/closed/wall/rust,
+/area/hallway/primary/central)
+"szH" = (
+/turf/closed/wall/r_wall/rust,
+/area/teleporter)
+"szI" = (
+/turf/closed/wall/r_wall/rust,
+/area/ai_monitored/storage/eva)
+"szJ" = (
+/obj/effect/decal/cleanable/cobweb,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	tag = "icon-intact (SOUTHEAST)";
+	icon_state = "intact";
+	dir = 6
+	},
+/turf/open/floor/plating,
+/area/space)
+"szK" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/space)
+"szL" = (
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden,
+/turf/open/floor/plating,
+/area/space)
+"szM" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/space)
+"szN" = (
+/turf/closed/wall,
+/area/space)
+"szO" = (
+/turf/closed/mineral/random/labormineral,
+/area/space)
+"szP" = (
+/turf/closed/mineral/random/labormineral,
+/area/space)
+"szQ" = (
+/turf/closed/mineral/random/labormineral,
+/area/space)
+"szR" = (
+/turf/open/floor/plating/asteroid/airless,
+/area/space)
+"szS" = (
+/turf/open/floor/plating/asteroid/airless,
+/area/space)
+"szT" = (
+/turf/open/floor/plating/airless/astplate,
+/area/space)
+"szU" = (
+/turf/closed/wall,
+/area/space)
+"szV" = (
+/obj/structure/table/reinforced,
+/obj/structure/cable/white{
+	d2 = 4;
+	icon_state = "0-4"
+	},
+/obj/machinery/power/apc{
+	dir = 8;
+	name = "Departure Lounge APC";
+	areastring = "/area/hallway/secondary/exit";
+	pixel_x = -26;
+	pixel_y = 3
+	},
+/obj/item/crowbar,
+/obj/item/wrench,
+/obj/item/device/radio,
+/obj/machinery/airalarm{
+	pixel_y = 23
+	},
+/obj/structure/cable/white{
+	d2 = 4;
+	icon_state = "0-4"
+	},
+/turf/open/floor/plasteel/red/side{
+	dir = 9
+	},
+/area/space)
+"szW" = (
+/obj/structure/table/reinforced,
+/obj/item/restraints/handcuffs,
+/obj/item/device/assembly/flash/handheld,
+/obj/machinery/status_display{
+	pixel_y = 32
+	},
+/obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/open/floor/plasteel/red/side{
+	dir = 1
+	},
+/area/space)
+"szX" = (
+/obj/structure/chair,
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/item/device/radio/intercom{
+	name = "Station Intercom";
+	pixel_y = 24
+	},
+/obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/open/floor/plasteel/red/side{
+	dir = 1
+	},
+/area/space)
+"szY" = (
+/obj/structure/chair,
+/obj/machinery/ai_status_display{
+	pixel_y = 32
+	},
+/obj/structure/cable/white{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/turf/open/floor/plasteel/red/side{
+	dir = 1
+	},
+/area/space)
+"szZ" = (
+/obj/structure/chair,
+/obj/machinery/firealarm{
+	pixel_y = 24
+	},
+/turf/open/floor/plasteel/red/side{
+	dir = 5
+	},
+/area/space)
+"sAa" = (
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
+/area/space)
+"sAb" = (
+/obj/structure/lattice,
+/turf/open/space,
+/area/space)
+"sAc" = (
+/turf/closed/wall/rust,
+/area/storage/primary)
+"sAd" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/turf/open/floor/plating,
+/area/space)
+"sAe" = (
+/turf/closed/wall,
+/area/space)
+"sAf" = (
+/obj/structure/girder,
+/turf/open/floor/plating,
+/area/space)
+"sAg" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/plating,
+/area/space)
+"sAh" = (
+/turf/closed/wall,
+/area/space)
+"sAi" = (
+/turf/closed/wall,
+/area/space)
+"sAj" = (
+/turf/closed/wall,
+/area/space)
+"sAk" = (
+/turf/closed/wall,
+/area/space)
+"sAl" = (
+/obj/structure/sign/securearea,
+/turf/closed/wall,
+/area/space)
+"sAm" = (
+/turf/open/floor/plating/airless/astplate,
+/area/space)
+"sAn" = (
+/turf/open/floor/plating/airless/astplate,
+/area/space)
+"sAo" = (
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
+/area/space)
+"sAp" = (
+/obj/structure/table/reinforced,
+/obj/machinery/recharger,
+/turf/open/floor/plasteel/red/side{
+	dir = 8
+	},
+/area/space)
+"sAq" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
+	dir = 4
+	},
+/turf/open/floor/plasteel/neutral,
+/area/space)
+"sAr" = (
+/obj/machinery/holopad,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 10
+	},
+/obj/effect/turf_decal/bot,
+/turf/open/floor/plasteel,
+/area/space)
+"sAs" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on,
+/obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/open/floor/plasteel/neutral,
+/area/space)
+"sAt" = (
+/obj/structure/chair{
+	dir = 8
+	},
+/turf/open/floor/plasteel/red/side{
+	dir = 4
+	},
+/area/space)
+"sAu" = (
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
+/area/space)
+"sAv" = (
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
+/area/space)
+"sAw" = (
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
+/area/space)
+"sAx" = (
+/turf/closed/wall/r_wall/rust,
+/area/engine/atmos)
+"sAy" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/turf/closed/wall/r_wall/rust,
+/area/engine/atmos)
+"sAz" = (
+/turf/closed/wall/r_wall/rust,
+/area/storage/primary)
+"sAA" = (
+/turf/closed/wall/rust,
+/area/crew_quarters/bar/atrium)
+"sAB" = (
+/turf/closed/wall/r_wall/rust,
+/area/ai_monitored/storage/eva)
+"sAC" = (
+/turf/closed/wall/rust,
+/area/hallway/primary/central)
+"sAD" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/turf/open/floor/plating,
+/area/space)
+"sAE" = (
+/turf/closed/wall,
+/area/space)
+"sAF" = (
+/obj/structure/closet/wardrobe/grey,
+/turf/open/floor/plasteel/redblue,
+/area/space)
+"sAG" = (
+/turf/open/floor/plating,
+/area/space)
+"sAH" = (
+/obj/item/wallframe/apc,
+/turf/open/floor/plating,
+/area/space)
+"sAI" = (
+/obj/structure/closet/wardrobe/green,
+/obj/effect/decal/cleanable/cobweb/cobweb2,
+/turf/open/floor/plasteel/redblue,
+/area/space)
+"sAJ" = (
+/turf/closed/wall,
+/area/space)
+"sAK" = (
+/obj/structure/closet/firecloset,
+/obj/machinery/light/small{
+	dir = 1
+	},
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/plasteel,
+/area/space)
+"sAL" = (
+/turf/closed/wall,
+/area/space)
+"sAM" = (
+/obj/structure/grille,
+/obj/structure/window/reinforced/fulltile,
+/turf/open/floor/plating,
+/area/space)
+"sAN" = (
+/obj/structure/grille,
+/obj/structure/window/reinforced/fulltile,
+/turf/open/floor/plating,
+/area/space)
+"sAO" = (
+/turf/closed/wall,
+/area/space)
+"sAP" = (
+/obj/machinery/computer/security,
+/obj/machinery/newscaster/security_unit{
+	pixel_x = -32
+	},
+/turf/open/floor/plasteel/red/side{
+	dir = 10
+	},
+/area/space)
+"sAQ" = (
+/obj/structure/chair/office/dark,
+/turf/open/floor/plasteel/red/side,
+/area/space)
+"sAR" = (
+/obj/machinery/computer/secure_data,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/turf/open/floor/plasteel/red/side,
+/area/space)
+"sAS" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/open/floor/plasteel/red/side,
+/area/space)
+"sAT" = (
+/obj/machinery/camera{
+	c_tag = "Security - Departures Starboard";
+	dir = 1;
+	name = "security camera"
+	},
+/turf/open/floor/plasteel/red/side{
+	dir = 6
+	},
+/area/space)
+"sAU" = (
+/obj/machinery/door/airlock/external{
+	name = "External Docking Port";
+	req_access_txt = "63"
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/space)
+"sAV" = (
+/obj/structure/fans/tiny,
+/obj/effect/turf_decal/delivery,
+/turf/open/floor/plasteel,
+/area/space)
+"sAW" = (
+/obj/machinery/door/airlock/external{
+	name = "External Docking Port";
+	req_access_txt = "63"
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/space)
+"sAX" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/structure/cable/white{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plating{
+	icon_state = "platingdmg1"
+	},
+/area/maintenance/starboard/central)
+"sAY" = (
+/turf/open/floor/plating{
+	burnt = 1;
+	icon_state = "panelscorched"
+	},
+/area/hallway/primary/central)
+"sAZ" = (
+/turf/closed/wall/rust,
+/area/quartermaster/miningdock)
+"sBa" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/turf/open/floor/plating,
+/area/space)
+"sBb" = (
+/turf/closed/wall,
+/area/space)
+"sBc" = (
+/obj/structure/closet/wardrobe/black,
+/obj/item/clothing/accessory/waistcoat,
+/turf/open/floor/plating,
+/area/space)
+"sBd" = (
+/turf/open/floor/plasteel/redblue,
+/area/space)
+"sBe" = (
+/turf/open/floor/plating,
+/area/space)
+"sBf" = (
+/obj/structure/closet/wardrobe/white,
+/turf/open/floor/plasteel/redblue,
+/area/space)
+"sBg" = (
+/obj/structure/girder,
+/turf/open/floor/plating,
+/area/space)
+"sBh" = (
+/turf/open/floor/plating,
+/area/space)
+"sBi" = (
+/turf/closed/wall,
+/area/space)
+"sBj" = (
+/obj/structure/table,
+/obj/machinery/light/small{
+	dir = 8
+	},
+/obj/item/clothing/suit/hazardvest{
+	desc = "A high-visibility lifejacket complete with whistle and slot for oxygen tanks.";
+	name = "emergency lifejacket"
+	},
+/obj/item/clothing/suit/hazardvest{
+	desc = "A high-visibility lifejacket complete with whistle and slot for oxygen tanks.";
+	name = "emergency lifejacket"
+	},
+/obj/item/clothing/mask/breath,
+/obj/item/clothing/mask/breath,
+/turf/open/floor/plasteel,
+/area/space)
+"sBk" = (
+/obj/structure/table,
+/turf/open/floor/plasteel/escape{
+	tag = "icon-escape (NORTHEAST)";
+	icon_state = "escape";
+	dir = 5
+	},
+/area/space)
+"sBl" = (
+/turf/closed/wall,
+/area/space)
+"sBm" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/cable/white{
+	d2 = 4;
+	icon_state = "0-4"
+	},
+/turf/open/floor/plating,
+/area/space)
+"sBn" = (
+/obj/machinery/door/firedoor,
+/obj/structure/cable/white{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/obj/structure/cable/white{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/obj/machinery/door/window/brigdoor/southright{
+	dir = 1;
+	name = "Security Desk";
+	req_access_txt = "63"
+	},
+/obj/structure/table/reinforced,
+/obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/item/folder/red,
+/obj/item/device/radio,
+/obj/effect/turf_decal/stripes/line{
+	dir = 2
+	},
+/turf/open/floor/plasteel,
+/area/space)
+"sBo" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/cable/white{
+	d2 = 4;
+	icon_state = "0-4"
+	},
+/obj/structure/cable/white{
+	d2 = 8;
+	icon_state = "0-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/turf/open/floor/plating,
+/area/space)
+"sBp" = (
+/obj/machinery/door/firedoor,
+/obj/structure/cable/white{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/obj/structure/cable/white{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 2
+	},
+/turf/open/floor/plasteel,
+/area/space)
+"sBq" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/cable/white{
+	d2 = 8;
+	icon_state = "0-8"
+	},
+/turf/open/floor/plating,
+/area/space)
+"sBr" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/sign/vacuum,
+/turf/open/floor/plating,
+/area/space)
+"sBs" = (
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
+/area/space)
+"sBt" = (
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
+/area/space)
+"sBu" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/turf/closed/wall/r_wall/rust,
+/area/security/brig)
+"sBv" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/turf/closed/wall/rust,
+/area/crew_quarters/theatre)
+"sBw" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/turf/closed/wall/rust,
+/area/crew_quarters/bar/atrium)
+"sBx" = (
+/obj/effect/landmark/xeno_spawn,
+/obj/machinery/atmospherics/components/unary/vent_pump/on{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/hallway/primary/central)
+"sBy" = (
+/obj/machinery/door/airlock/external{
+	name = "External Airlock";
+	req_access_txt = "13"
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
+"sBz" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/turf/open/floor/plating,
+/area/space)
+"sBA" = (
+/turf/closed/wall,
+/area/space)
+"sBB" = (
+/turf/closed/wall,
+/area/space)
+"sBC" = (
+/obj/structure/sign/poster/contraband/random,
+/turf/closed/wall,
+/area/space)
+"sBD" = (
+/obj/structure/barricade/wooden,
+/obj/machinery/door/airlock/maintenance_hatch{
+	name = "Maintenance Hatch";
+	req_access_txt = "12"
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 2
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/space)
+"sBE" = (
+/turf/closed/wall,
+/area/space)
+"sBF" = (
+/obj/structure/girder,
+/turf/open/floor/plating,
+/area/space)
+"sBG" = (
+/obj/structure/cable/white{
+	tag = "icon-2-4";
+	icon_state = "2-4"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	tag = "icon-intact (SOUTHEAST)";
+	icon_state = "intact";
+	dir = 6
+	},
+/turf/open/floor/plating,
+/area/space)
+"sBH" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/machinery/door/airlock/maintenance_hatch{
+	name = "Maintenance Hatch";
+	req_access_txt = "12"
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/structure/cable/white{
+	tag = "icon-4-8";
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/space)
+"sBI" = (
+/obj/structure/cable/white{
+	tag = "icon-4-8";
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/turf/open/floor/plasteel/escape{
+	dir = 8
+	},
+/area/space)
+"sBJ" = (
+/obj/structure/cable/white{
+	tag = "icon-2-8";
+	icon_state = "2-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	tag = "icon-intact (SOUTHWEST)";
+	icon_state = "intact";
+	dir = 10
+	},
+/turf/open/floor/plasteel,
+/area/space)
+"sBK" = (
+/turf/closed/wall,
+/area/space)
+"sBL" = (
+/obj/structure/table,
+/obj/item/paper_bin,
+/obj/item/pen,
+/obj/machinery/airalarm{
+	dir = 4;
+	pixel_x = -23
+	},
+/obj/machinery/light{
+	dir = 8
+	},
+/obj/effect/turf_decal/delivery,
+/turf/open/floor/plasteel,
+/area/space)
+"sBM" = (
+/obj/structure/cable/white{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/turf/open/floor/plasteel/escape{
+	dir = 1
+	},
+/area/space)
+"sBN" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/structure/cable/white{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/obj/structure/cable/white{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/turf/open/floor/plasteel/escape{
+	dir = 1
+	},
+/area/space)
+"sBO" = (
+/obj/structure/cable/white{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/turf/open/floor/plasteel/escape{
+	dir = 1
+	},
+/area/space)
+"sBP" = (
+/obj/effect/turf_decal/delivery,
+/turf/open/floor/plasteel,
+/area/space)
+"sBQ" = (
+/obj/machinery/door/airlock/external{
+	name = "External Docking Port"
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/space)
+"sBR" = (
+/obj/structure/fans/tiny,
+/obj/effect/turf_decal/delivery,
+/turf/open/floor/plasteel,
+/area/space)
+"sBS" = (
+/obj/machinery/door/airlock/external{
+	name = "External Docking Port"
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/space)
+"sBT" = (
+/turf/closed/wall/rust,
+/area/hallway/primary/central)
+"sBU" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/turf/open/floor/plating,
+/area/hallway/primary/central)
+"sBV" = (
+/obj/structure/girder,
+/turf/open/floor/plating,
+/area/hallway/primary/central)
+"sBW" = (
+/obj/structure/sign/vacuum,
+/turf/closed/wall/rust,
+/area/hallway/primary/central)
+"sBX" = (
+/obj/structure/cable/white{
+	tag = "icon-4-8";
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden,
+/turf/open/floor/plating,
+/area/space)
+"sBY" = (
+/obj/structure/cable/white{
+	tag = "icon-4-8";
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/space)
+"sBZ" = (
+/obj/structure/cable/white{
+	tag = "icon-4-8";
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/space)
+"sCa" = (
+/obj/structure/cable/white{
+	tag = "icon-4-8";
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/space)
+"sCb" = (
+/obj/structure/cable/white{
+	tag = "icon-4-8";
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/space)
+"sCc" = (
+/obj/structure/cable/white{
+	tag = "icon-4-8";
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/space)
+"sCd" = (
+/obj/structure/cable/white{
+	tag = "icon-4-8";
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/space)
+"sCe" = (
+/obj/structure/cable/white{
+	tag = "icon-1-8";
+	icon_state = "1-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	tag = "icon-intact (NORTHWEST)";
+	icon_state = "intact";
+	dir = 9
+	},
+/turf/open/floor/plating,
+/area/space)
+"sCf" = (
+/turf/closed/wall,
+/area/space)
+"sCg" = (
+/obj/machinery/firealarm{
+	dir = 8;
+	pixel_x = -24;
+	pixel_y = 0
+	},
+/turf/open/floor/plasteel,
+/area/space)
+"sCh" = (
+/obj/structure/cable/white{
+	tag = "icon-1-2";
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/turf/open/floor/plasteel/escape{
+	tag = "icon-escape (EAST)";
+	icon_state = "escape";
+	dir = 4
+	},
+/area/space)
+"sCi" = (
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
+/area/space)
+"sCj" = (
+/obj/item/twohanded/required/kirbyplants{
+	icon_state = "plant-22"
+	},
+/obj/effect/turf_decal/bot,
+/turf/open/floor/plasteel,
+/area/space)
+"sCk" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on,
+/turf/open/floor/plasteel/neutral,
+/area/space)
+"sCl" = (
+/obj/structure/chair{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/effect/turf_decal/bot,
+/obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/open/floor/plasteel,
+/area/space)
+"sCm" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/turf/open/floor/plasteel/neutral,
+/area/space)
+"sCn" = (
+/obj/structure/chair{
+	dir = 8
+	},
+/obj/effect/turf_decal/bot,
+/turf/open/floor/plasteel,
+/area/space)
+"sCo" = (
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
+/area/space)
+"sCp" = (
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
+/area/space)
+"sCq" = (
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
+/area/space)
+"sCr" = (
+/turf/open/floor/plating,
+/obj/structure/cable/white{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/turf/open/floor/plating{
+	tag = "icon-platingdmg2";
+	icon_state = "platingdmg2"
+	},
+/area/maintenance/port/central)
+"sCs" = (
+/turf/open/floor/plating,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/turf/open/floor/plating{
+	tag = "icon-platingdmg2";
+	icon_state = "platingdmg2"
+	},
+/area/hallway/primary/central)
+"sCt" = (
+/obj/structure/easel,
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
+"sCu" = (
+/turf/closed/wall/rust,
+/area/hallway/primary/central)
+"sCv" = (
+/turf/closed/wall,
+/area/space)
+"sCw" = (
+/turf/closed/wall,
+/area/space)
+"sCx" = (
+/turf/closed/wall,
+/area/space)
+"sCy" = (
+/turf/closed/wall,
+/area/space)
+"sCz" = (
+/turf/closed/wall,
+/area/space)
+"sCA" = (
+/turf/closed/wall,
+/area/space)
+"sCB" = (
+/turf/closed/wall,
+/area/space)
+"sCC" = (
+/turf/closed/wall,
+/area/space)
+"sCD" = (
+/turf/closed/wall,
+/area/space)
+"sCE" = (
+/turf/open/floor/plasteel/escape{
+	dir = 8
+	},
+/area/space)
+"sCF" = (
+/obj/structure/cable/white{
+	tag = "icon-1-2";
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
+	tag = "icon-manifold (WEST)";
+	icon_state = "manifold";
+	dir = 8
+	},
+/turf/open/floor/plasteel/neutral/side{
+	dir = 4
+	},
+/area/space)
+"sCG" = (
+/obj/machinery/door/firedoor,
+/obj/machinery/door/airlock/glass{
+	name = "Departure Lounge"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/space)
+"sCH" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/effect/turf_decal/delivery,
+/turf/open/floor/plasteel,
+/area/space)
+"sCI" = (
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden,
+/turf/open/floor/plasteel/neutral,
+/area/space)
+"sCJ" = (
+/obj/structure/chair{
+	dir = 4
+	},
+/obj/effect/landmark/start/assistant,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/effect/turf_decal/bot,
+/obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/open/floor/plasteel,
+/area/space)
+"sCK" = (
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
+	dir = 4
+	},
+/turf/open/floor/plasteel/neutral,
+/area/space)
+"sCL" = (
+/obj/structure/chair{
+	dir = 8
+	},
+/obj/effect/turf_decal/bot,
+/turf/open/floor/plasteel,
+/area/space)
+"sCM" = (
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
+/area/space)
+"sCN" = (
+/obj/structure/lattice,
+/turf/open/space,
+/area/space)
+"sCO" = (
+/turf/closed/wall/rust,
+/area/hallway/primary/central)
+"sCP" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/turf/open/floor/plating,
+/area/hallway/primary/central)
+"sCQ" = (
+/obj/structure/closet/crate{
+	icon_state = "crateopen";
+	opened = 1
+	},
+/obj/effect/spawner/lootdrop/maintenance{
+	lootcount = 2;
+	name = "2maintenance loot spawner"
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/structure/sign/poster/contraband/random{
+	pixel_x = 32
+	},
+/obj/item/storage/box,
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
+"sCR" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/turf/open/floor/plasteel/escape{
+	tag = "icon-escape (NORTH)";
+	icon_state = "escape";
+	dir = 1
+	},
+/area/space)
+"sCS" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/machinery/status_display{
+	pixel_y = 32
+	},
+/turf/open/floor/plasteel,
+/area/space)
+"sCT" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on,
+/turf/open/floor/plasteel/escape{
+	tag = "icon-escape (NORTH)";
+	icon_state = "escape";
+	dir = 1
+	},
+/area/space)
+"sCU" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/machinery/airalarm{
+	pixel_y = 24
+	},
+/turf/open/floor/plasteel,
+/area/space)
+"sCV" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/turf/open/floor/plasteel/escape{
+	tag = "icon-escape (NORTH)";
+	icon_state = "escape";
+	dir = 1
+	},
+/area/space)
+"sCW" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/space)
+"sCX" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/turf/open/floor/plasteel/escape{
+	tag = "icon-escape (NORTH)";
+	icon_state = "escape";
+	dir = 1
+	},
+/area/space)
+"sCY" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/space)
+"sCZ" = (
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
+	dir = 1
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/machinery/door/firedoor,
+/turf/open/floor/plasteel/escape{
+	tag = "icon-escape (NORTH)";
+	icon_state = "escape";
+	dir = 1
+	},
+/area/space)
+"sDa" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/space)
+"sDb" = (
+/obj/structure/cable/white{
+	tag = "icon-1-2";
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
+	tag = "icon-manifold (EAST)";
+	icon_state = "manifold";
+	dir = 4
+	},
+/turf/open/floor/plasteel/neutral/side{
+	dir = 4
+	},
+/area/space)
+"sDc" = (
+/obj/machinery/door/firedoor,
+/obj/machinery/door/airlock/glass{
+	name = "Departure Lounge"
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/space)
+"sDd" = (
+/obj/effect/turf_decal/delivery,
+/turf/open/floor/plasteel,
+/area/space)
+"sDe" = (
+/obj/effect/landmark/event_spawn,
+/turf/open/floor/plasteel/neutral,
+/area/space)
+"sDf" = (
+/obj/structure/chair{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/effect/turf_decal/bot,
+/obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/open/floor/plasteel,
+/area/space)
+"sDg" = (
+/obj/machinery/holopad,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/effect/turf_decal/bot,
+/turf/open/floor/plasteel,
+/area/space)
+"sDh" = (
+/obj/structure/chair{
+	dir = 8
+	},
+/obj/machinery/camera{
+	c_tag = "Shuttle Docking Foyer";
+	dir = 8;
+	network = list("MINE")
+	},
+/obj/machinery/camera{
+	c_tag = "Escape Arm Airlocks";
+	dir = 8;
+	network = list("SS13")
+	},
+/obj/effect/turf_decal/bot,
+/turf/open/floor/plasteel,
+/area/space)
+"sDi" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/sign/directions/engineering{
+	desc = "A sign that shows there are doors here. There are doors everywhere!";
+	icon_state = "doors";
+	name = "WARNING: EXTERNAL AIRLOCK"
+	},
+/turf/open/floor/plating,
+/area/space)
+"sDj" = (
+/obj/structure/lattice,
+/turf/open/space,
+/area/space)
+"sDk" = (
+/turf/closed/wall/r_wall/rust,
+/area/engine/atmos)
+"sDl" = (
+/turf/closed/wall/rust,
+/area/crew_quarters/dorms)
+"sDm" = (
+/turf/closed/wall/rust,
+/area/crew_quarters/dorms)
+"sDn" = (
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/turf/open/floor/wood,
+/area/crew_quarters/theatre)
+"sDo" = (
+/turf/closed/wall/rust,
+/area/hallway/primary/central)
+"sDp" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/turf/open/floor/plating{
+	icon_state = "platingdmg1"
+	},
+/area/hallway/primary/central)
+"sDq" = (
+/obj/structure/rack,
+/obj/effect/spawner/lootdrop/maintenance,
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/item/tank/internals/air,
+/obj/item/clothing/mask/gas,
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
+"sDr" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/structure/cable/white{
+	tag = "icon-4-8";
+	icon_state = "4-8"
+	},
+/turf/open/floor/plasteel,
+/area/space)
+"sDs" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/structure/cable/white{
+	tag = "icon-4-8";
+	icon_state = "4-8"
+	},
+/obj/machinery/status_display{
+	pixel_y = -32
+	},
+/turf/open/floor/plasteel/escape,
+/area/space)
+"sDt" = (
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden,
+/obj/machinery/light,
+/obj/structure/cable/white{
+	tag = "icon-4-8";
+	icon_state = "4-8"
+	},
+/turf/open/floor/plasteel,
+/area/space)
+"sDu" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/structure/cable/white{
+	tag = "icon-4-8";
+	icon_state = "4-8"
+	},
+/turf/open/floor/plasteel/escape,
+/area/space)
+"sDv" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/structure/cable/white{
+	tag = "icon-4-8";
+	icon_state = "4-8"
+	},
+/turf/open/floor/plasteel,
+/area/space)
+"sDw" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/structure/cable/white{
+	tag = "icon-4-8";
+	icon_state = "4-8"
+	},
+/obj/structure/extinguisher_cabinet{
+	pixel_y = -28
+	},
+/obj/machinery/camera{
+	c_tag = "Departures Hallway";
+	dir = 1
+	},
+/turf/open/floor/plasteel/escape,
+/area/space)
+"sDx" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/structure/cable/white{
+	tag = "icon-4-8";
+	icon_state = "4-8"
+	},
+/turf/open/floor/plasteel,
+/area/space)
+"sDy" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/structure/cable/white{
+	tag = "icon-4-8";
+	icon_state = "4-8"
+	},
+/obj/structure/sign/poster/official/random{
+	pixel_y = -32
+	},
+/turf/open/floor/plasteel/escape,
+/area/space)
+"sDz" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/structure/cable/white{
+	tag = "icon-4-8";
+	icon_state = "4-8"
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/machinery/door/firedoor,
+/obj/machinery/atmospherics/components/unary/vent_pump/on{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/space)
+"sDA" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/structure/cable/white{
+	tag = "icon-4-8";
+	icon_state = "4-8"
+	},
+/turf/open/floor/plasteel/escape/corner{
+	tag = "icon-escapecorner (WEST)";
+	icon_state = "escapecorner";
+	dir = 8
+	},
+/area/space)
+"sDB" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/structure/cable/white{
+	tag = "icon-2-8";
+	icon_state = "2-8"
+	},
+/obj/structure/cable/white{
+	tag = "icon-4-8";
+	icon_state = "4-8"
+	},
+/obj/structure/cable/white{
+	tag = "icon-1-2";
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/turf/open/floor/plasteel/neutral/side{
+	dir = 4
+	},
+/area/space)
+"sDC" = (
+/obj/machinery/door/firedoor,
+/obj/machinery/door/airlock/glass{
+	name = "Departure Lounge"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/open/floor/plasteel,
+/area/space)
+"sDD" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/effect/turf_decal/delivery,
+/obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/open/floor/plasteel,
+/area/space)
+"sDE" = (
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
+	dir = 1
+	},
+/obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/open/floor/plasteel/neutral,
+/area/space)
+"sDF" = (
+/obj/structure/chair{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
+	dir = 4
+	},
+/obj/effect/turf_decal/bot,
+/obj/structure/cable/white{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/open/floor/plasteel,
+/area/space)
+"sDG" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/structure/cable/white{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/turf/open/floor/plasteel/neutral,
+/area/space)
+"sDH" = (
+/obj/structure/chair{
+	dir = 8
+	},
+/obj/effect/turf_decal/bot,
+/turf/open/floor/plasteel,
+/area/space)
+"sDI" = (
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
+/area/space)
+"sDJ" = (
+/obj/structure/lattice,
+/turf/open/space,
+/area/space)
+"sDK" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/turf/closed/wall/rust,
+/area/crew_quarters/theatre)
+"sDL" = (
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/turf/open/floor/wood,
+/area/crew_quarters/theatre)
+"sDM" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/turf/closed/wall/rust,
+/area/crew_quarters/bar/atrium)
+"sDN" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/turf/open/floor/plating{
+	burnt = 1;
+	icon_state = "panelscorched"
+	},
+/area/hallway/primary/central)
+"sDO" = (
+/obj/structure/girder,
+/turf/open/floor/plating,
+/area/hallway/primary/central)
+"sDP" = (
+/turf/closed/wall/rust,
+/area/hallway/secondary/exit)
+"sDQ" = (
+/obj/structure/sign/poster/contraband/random,
+/turf/closed/wall,
+/area/space)
+"sDR" = (
+/turf/closed/wall,
+/area/space)
+"sDS" = (
+/turf/closed/wall,
+/area/space)
+"sDT" = (
+/obj/structure/grille,
+/obj/structure/window/reinforced/fulltile,
+/turf/open/floor/plating,
+/area/space)
+"sDU" = (
+/turf/closed/wall,
+/area/space)
+"sDV" = (
+/turf/closed/wall,
+/area/space)
+"sDW" = (
+/obj/machinery/vending/cigarette,
+/obj/machinery/newscaster{
+	pixel_x = 0;
+	pixel_y = -30
+	},
+/turf/open/floor/plasteel/vault{
+	dir = 8
+	},
+/area/space)
+"sDX" = (
+/turf/closed/wall,
+/area/space)
+"sDY" = (
+/obj/structure/sign/nanotrasen,
+/turf/closed/wall,
+/area/space)
+"sDZ" = (
+/turf/open/floor/plasteel,
+/area/space)
+"sEa" = (
+/obj/structure/cable/white{
+	tag = "icon-1-2";
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/turf/open/floor/plasteel/escape{
+	tag = "icon-escape (EAST)";
+	icon_state = "escape";
+	dir = 4
+	},
+/area/space)
+"sEb" = (
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
+/area/space)
+"sEc" = (
+/obj/item/twohanded/required/kirbyplants{
+	icon_state = "plant-21"
+	},
+/obj/effect/turf_decal/bot,
+/turf/open/floor/plasteel,
+/area/space)
+"sEd" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
+	dir = 1
+	},
+/turf/open/floor/plasteel/neutral,
+/area/space)
+"sEe" = (
+/obj/structure/chair{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/effect/turf_decal/bot,
+/turf/open/floor/plasteel,
+/area/space)
+"sEf" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/open/floor/plasteel/neutral,
+/area/space)
+"sEg" = (
+/obj/structure/chair{
+	dir = 8
+	},
+/obj/effect/turf_decal/bot,
+/turf/open/floor/plasteel,
+/area/space)
+"sEh" = (
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
+/area/space)
+"sEi" = (
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
+/area/space)
+"sEj" = (
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
+/area/space)
+"sEk" = (
+/turf/closed/wall/rust,
+/area/crew_quarters/dorms)
+"sEl" = (
+/obj/effect/decal/cleanable/cobweb,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	tag = "icon-intact (SOUTHEAST)";
+	icon_state = "intact";
+	dir = 6
+	},
+/turf/open/floor/plating,
+/area/hallway/primary/central)
+"sEm" = (
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden,
+/turf/open/floor/plating,
+/area/hallway/primary/central)
+"sEn" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/hallway/primary/central)
+"sEo" = (
+/turf/closed/wall/rust,
+/area/hallway/secondary/exit)
+"sEp" = (
+/obj/structure/closet/emcloset{
+	anchored = 1
+	},
+/obj/machinery/light/small{
+	dir = 1
+	},
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/plasteel,
+/area/space)
+"sEq" = (
+/obj/structure/sign/securearea,
+/turf/closed/wall,
+/area/space)
+"sEr" = (
+/obj/structure/lattice,
+/turf/open/space,
+/area/space)
+"sEs" = (
+/obj/structure/lattice,
+/turf/open/space,
+/area/space)
+"sEt" = (
+/turf/closed/wall,
+/area/space)
+"sEu" = (
+/turf/closed/wall,
+/area/space)
+"sEv" = (
+/turf/closed/wall,
+/area/space)
+"sEw" = (
+/obj/machinery/vending/cola/random,
+/turf/open/floor/plasteel/vault{
+	dir = 8
+	},
+/area/space)
+"sEx" = (
+/turf/open/floor/plasteel/escape{
+	dir = 8
+	},
+/area/space)
+"sEy" = (
+/obj/structure/cable/white{
+	tag = "icon-1-2";
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/turf/open/floor/plasteel,
+/area/space)
+"sEz" = (
+/turf/closed/wall,
+/area/space)
+"sEA" = (
+/obj/structure/table,
+/obj/item/storage/pill_bottle/dice,
+/obj/machinery/firealarm{
+	dir = 8;
+	pixel_x = -24
+	},
+/obj/machinery/light{
+	dir = 8
+	},
+/obj/effect/turf_decal/delivery,
+/turf/open/floor/plasteel,
+/area/space)
+"sEB" = (
+/turf/open/floor/plasteel/escape,
+/area/space)
+"sEC" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/turf/open/floor/plasteel/escape,
+/area/space)
+"sED" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/open/floor/plasteel/escape,
+/area/space)
+"sEE" = (
+/obj/effect/turf_decal/delivery,
+/turf/open/floor/plasteel,
+/area/space)
+"sEF" = (
+/obj/machinery/door/airlock/external{
+	name = "External Docking Port"
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/space)
+"sEG" = (
+/obj/structure/fans/tiny,
+/obj/effect/turf_decal/delivery,
+/turf/open/floor/plasteel,
+/area/space)
+"sEH" = (
+/obj/machinery/door/airlock/external{
+	name = "External Docking Port"
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/space)
+"sEI" = (
+/turf/closed/wall/rust,
+/area/crew_quarters/dorms)
+"sEJ" = (
+/obj/structure/cable/white{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
+	dir = 8
+	},
+/turf/open/floor/plasteel/neutral/corner,
+/area/hallway/primary/central)
+"sEK" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/machinery/door/airlock/maintenance_hatch{
+	name = "Maintenance Hatch";
+	req_access_txt = "12"
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/structure/cable/white{
+	tag = "icon-4-8";
+	icon_state = "4-8"
+	},
+/turf/open/floor/plating,
+/area/hallway/primary/central)
+"sEL" = (
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
+	tag = "icon-manifold (EAST)";
+	icon_state = "manifold";
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/hallway/primary/central)
+"sEM" = (
+/obj/structure/girder,
+/turf/open/floor/plating,
+/area/hallway/primary/central)
+"sEN" = (
+/obj/machinery/door/firedoor,
+/obj/machinery/door/airlock/engineering{
+	name = "Technology Storage";
+	req_access_txt = "23"
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 2
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel/vault,
+/area/hallway/primary/central)
+"sEO" = (
+/obj/structure/girder,
+/turf/open/floor/plating,
+/area/hallway/primary/central)
+"sEP" = (
+/turf/closed/wall/rust,
+/area/hallway/primary/central)
+"sEQ" = (
+/obj/structure/sign/securearea,
+/turf/closed/wall,
+/area/hallway/primary/central)
+"sER" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on,
+/turf/open/floor/plating,
+/area/space)
+"sES" = (
+/turf/closed/wall,
+/area/space)
+"sET" = (
+/obj/machinery/door/poddoor/shutters{
+	id = "supplybridge"
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 2
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/space)
+"sEU" = (
+/obj/machinery/door/poddoor/shutters{
+	id = "supplybridge"
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 2
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/space)
+"sEV" = (
+/obj/machinery/door/poddoor/shutters{
+	id = "supplybridge"
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 2
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/space)
+"sEW" = (
+/turf/closed/wall,
+/area/space)
+"sEX" = (
+/obj/machinery/light/small{
+	dir = 1
+	},
+/obj/effect/turf_decal/stripes/line,
+/obj/structure/rack,
+/obj/item/clothing/under/color/grey,
+/obj/item/clothing/mask/gas,
+/obj/machinery/atmospherics/components/unary/vent_pump,
+/turf/open/floor/plasteel,
+/area/space)
+"sEY" = (
+/obj/structure/sign/poster/contraband/random,
+/turf/closed/wall,
+/area/space)
+"sEZ" = (
+/obj/machinery/vending/snack/random,
+/turf/open/floor/plasteel/vault{
+	dir = 8
+	},
+/area/space)
+"sFa" = (
+/turf/open/floor/plasteel,
+/area/space)
+"sFb" = (
+/obj/structure/cable/white{
+	tag = "icon-1-2";
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/turf/open/floor/plasteel/escape{
+	tag = "icon-escape (EAST)";
+	icon_state = "escape";
+	dir = 4
+	},
+/area/space)
+"sFc" = (
+/obj/structure/sign/nanotrasen,
+/turf/closed/wall,
+/area/space)
+"sFd" = (
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
+/area/space)
+"sFe" = (
+/obj/structure/table/reinforced,
+/obj/machinery/door/firedoor,
+/obj/item/folder/yellow,
+/obj/item/pen,
+/obj/machinery/door/window/southleft{
+	dir = 2;
+	name = "Cargo Desk";
+	req_access_txt = "50"
+	},
+/obj/effect/turf_decal/delivery,
+/turf/open/floor/plasteel,
+/area/space)
+"sFf" = (
+/obj/structure/plasticflaps{
+	opacity = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/effect/turf_decal/delivery,
+/turf/open/floor/plasteel,
+/area/space)
+"sFg" = (
+/obj/machinery/door/firedoor,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/effect/turf_decal/stripes/line{
+	dir = 2
+	},
+/obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/open/floor/plasteel,
+/area/space)
+"sFh" = (
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
+/area/space)
+"sFi" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/sign/vacuum,
+/turf/open/floor/plating,
+/area/space)
+"sFj" = (
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
+/area/space)
+"sFk" = (
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
+/area/space)
+"sFl" = (
+/turf/closed/wall/rust,
+/area/hallway/primary/central)
+"sFm" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/turf/open/floor/plating{
+	burnt = 1;
+	icon_state = "panelscorched"
+	},
+/area/hallway/primary/central)
+"sFn" = (
+/obj/effect/turf_decal/bot,
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/structure/rack,
+/obj/item/circuitboard/computer/cloning{
+	pixel_x = 3;
+	pixel_y = 3
+	},
+/obj/item/circuitboard/machine/clonepod,
+/obj/item/circuitboard/machine/clonescanner,
+/obj/item/circuitboard/computer/med_data{
+	pixel_x = -3;
+	pixel_y = -3
+	},
+/turf/open/floor/plasteel/vault/side{
+	tag = "icon-vault (EAST)";
+	icon_state = "vault";
+	dir = 4
+	},
+/area/hallway/primary/central)
+"sFo" = (
+/turf/open/floor/plasteel/vault/side{
+	tag = "icon-vault (NORTHWEST)";
+	icon_state = "vault";
+	dir = 9
+	},
+/area/hallway/primary/central)
+"sFp" = (
+/turf/open/floor/plasteel/vault/side{
+	tag = "icon-vault (NORTHEAST)";
+	icon_state = "vault";
+	dir = 5
+	},
+/area/hallway/primary/central)
+"sFq" = (
+/obj/effect/turf_decal/bot,
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/structure/table,
+/obj/item/clipboard,
+/obj/item/crowbar/red,
+/obj/item/device/aicard,
+/obj/item/device/analyzer,
+/obj/item/device/assembly/flash/handheld,
+/turf/open/floor/plasteel/vault/side{
+	tag = "icon-vault (WEST)";
+	icon_state = "vault";
+	dir = 8
+	},
+/area/hallway/primary/central)
+"sFr" = (
+/obj/structure/closet/firecloset,
+/obj/machinery/light/small{
+	dir = 1
+	},
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
+"sFs" = (
+/obj/structure/grille,
+/obj/structure/window/reinforced/fulltile,
+/turf/open/floor/plating,
+/area/hallway/secondary/exit)
+"sFt" = (
+/obj/structure/grille,
+/obj/structure/window/reinforced/fulltile,
+/turf/open/floor/plating,
+/area/hallway/secondary/exit)
+"sFu" = (
+/obj/structure/cable/white{
+	tag = "icon-4-8";
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden,
+/turf/open/floor/plating,
+/area/space)
+"sFv" = (
+/obj/machinery/button/door{
+	id = "supplybridge";
+	name = "Shuttle Bay Space Bridge Control";
+	pixel_y = 27;
+	req_access_txt = "0"
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/machinery/door/airlock/maintenance_hatch{
+	name = "Bridge Hatch";
+	req_access_txt = "12"
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/structure/cable/white{
+	tag = "icon-4-8";
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/space)
+"sFw" = (
+/obj/structure/cable/white{
+	tag = "icon-4-8";
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/space)
+"sFx" = (
+/obj/structure/cable/white{
+	tag = "icon-4-8";
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/space)
+"sFy" = (
+/obj/structure/cable/white{
+	tag = "icon-4-8";
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/space)
+"sFz" = (
+/obj/machinery/button/door{
+	id = "supplybridge";
+	name = "Shuttle Bay Space Bridge Control";
+	pixel_y = 27;
+	req_access_txt = "0"
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/machinery/door/airlock/maintenance_hatch{
+	name = "Bridge Hatch";
+	req_access_txt = "12"
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/structure/cable/white{
+	tag = "icon-4-8";
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/space)
+"sFA" = (
+/obj/structure/cable/white{
+	tag = "icon-4-8";
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden,
+/turf/open/floor/plating,
+/area/space)
+"sFB" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/machinery/door/airlock/maintenance_hatch{
+	name = "Maintenance Hatch";
+	req_access_txt = "12"
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/structure/cable/white{
+	tag = "icon-4-8";
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/space)
+"sFC" = (
+/obj/effect/turf_decal/bot,
+/obj/structure/cable/white{
+	tag = "icon-4-8";
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/space)
+"sFD" = (
+/obj/machinery/light,
+/obj/machinery/status_display{
+	pixel_y = -32
+	},
+/obj/structure/cable/white{
+	tag = "icon-4-8";
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/turf/open/floor/plasteel/escape{
+	tag = "icon-escape (SOUTHWEST)";
+	icon_state = "escape";
+	dir = 10
+	},
+/area/space)
+"sFE" = (
+/obj/structure/cable/white{
+	tag = "icon-1-4";
+	icon_state = "1-4"
+	},
+/obj/structure/cable/white{
+	tag = "icon-4-8";
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	tag = "icon-intact (NORTHWEST)";
+	icon_state = "intact";
+	dir = 9
+	},
+/turf/open/floor/plasteel,
+/area/space)
+"sFF" = (
+/obj/machinery/door/firedoor,
+/obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/open/floor/plasteel,
+/area/space)
+"sFG" = (
+/obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/open/floor/plasteel/brown{
+	dir = 9
+	},
+/area/space)
+"sFH" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 6
+	},
+/obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/open/floor/plasteel/brown{
+	dir = 1
+	},
+/area/space)
+"sFI" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 9
+	},
+/obj/effect/turf_decal/delivery,
+/obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/open/floor/plasteel,
+/area/space)
+"sFJ" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/structure/cable/white{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/turf/open/floor/plasteel/brown{
+	dir = 1
+	},
+/area/space)
+"sFK" = (
+/turf/open/floor/plasteel/brown{
+	dir = 5
+	},
+/area/space)
+"sFL" = (
+/obj/machinery/door/airlock/external{
+	name = "External Docking Port"
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/space)
+"sFM" = (
+/obj/structure/fans/tiny,
+/obj/effect/turf_decal/delivery,
+/turf/open/floor/plasteel,
+/area/space)
+"sFN" = (
+/obj/machinery/door/airlock/external{
+	name = "External Docking Port"
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/space)
+"sFO" = (
+/obj/structure/cable/white{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/turf/open/floor/plating{
+	broken = 1;
+	icon_state = "platingdmg1"
+	},
+/area/maintenance/port/central)
+"sFP" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/structure/cable/white{
+	icon_state = "1-2"
+	},
+/turf/open/floor/wood,
+/area/crew_quarters/theatre)
+"sFQ" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/turf/open/floor/plating{
+	icon_state = "platingdmg1"
+	},
+/area/hallway/primary/central)
+"sFR" = (
+/obj/effect/turf_decal/bot,
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/structure/rack,
+/obj/item/circuitboard/machine/autolathe{
+	pixel_x = 3;
+	pixel_y = 3
+	},
+/obj/item/circuitboard/machine/microwave,
+/obj/item/circuitboard/computer/secure_data{
+	pixel_x = -3;
+	pixel_y = -3
+	},
+/turf/open/floor/plasteel/vault/side{
+	tag = "icon-vault (EAST)";
+	icon_state = "vault";
+	dir = 4
+	},
+/area/hallway/primary/central)
+"sFS" = (
+/turf/open/floor/plasteel/vault/side{
+	tag = "icon-vault (SOUTHWEST)";
+	icon_state = "vault";
+	dir = 10
+	},
+/area/hallway/primary/central)
+"sFT" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on,
+/turf/open/floor/plasteel/vault/side{
+	tag = "icon-vault (SOUTHEAST)";
+	icon_state = "vault";
+	dir = 6
+	},
+/area/hallway/primary/central)
+"sFU" = (
+/obj/effect/turf_decal/bot,
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/structure/rack,
+/obj/item/clothing/gloves/color/yellow,
+/obj/item/storage/toolbox/electrical,
+/obj/item/electronics/apc,
+/obj/item/electronics/airlock,
+/obj/item/stock_parts/cell/high,
+/turf/open/floor/plasteel/vault/side{
+	tag = "icon-vault (WEST)";
+	icon_state = "vault";
+	dir = 8
+	},
+/area/hallway/primary/central)
+"sFV" = (
+/turf/open/floor/plating,
+/area/hallway/primary/central)
+"sFW" = (
+/turf/closed/wall/rust,
+/area/hallway/secondary/exit)
+"sFX" = (
+/obj/structure/table,
+/obj/machinery/light/small{
+	dir = 8
+	},
+/obj/item/clothing/suit/hazardvest{
+	desc = "A high-visibility lifejacket complete with whistle and slot for oxygen tanks.";
+	name = "emergency lifejacket"
+	},
+/obj/item/clothing/suit/hazardvest{
+	desc = "A high-visibility lifejacket complete with whistle and slot for oxygen tanks.";
+	name = "emergency lifejacket"
+	},
+/obj/item/clothing/mask/breath,
+/obj/item/clothing/mask/breath,
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/plasteel/vault/side{
+	tag = "icon-vault (NORTH)";
+	icon_state = "vault";
+	dir = 1
+	},
+/area/hallway/secondary/exit)
+"sFY" = (
+/obj/structure/table,
+/obj/effect/turf_decal/stripes/line,
+/obj/item/crowbar,
+/obj/item/crowbar,
+/obj/item/tank/internals/emergency_oxygen,
+/obj/item/tank/internals/emergency_oxygen,
+/turf/open/floor/plasteel/vault/side{
+	tag = "icon-vault (NORTH)";
+	icon_state = "vault";
+	dir = 1
+	},
+/area/hallway/secondary/exit)
+"sFZ" = (
+/turf/closed/wall,
+/area/space)
+"sGa" = (
+/obj/structure/sign/directions/engineering{
+	desc = "A sign that shows there are doors here. There are doors everywhere!";
+	icon_state = "doors";
+	name = "WARNING: EXTERNAL AIRLOCK";
+	tag = "icon-doors"
+	},
+/turf/closed/wall,
+/area/space)
+"sGb" = (
+/obj/machinery/door/poddoor/shutters{
+	id = "supplybridge"
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 2
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/space)
+"sGc" = (
+/obj/machinery/door/poddoor/shutters{
+	id = "supplybridge"
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 2
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/space)
+"sGd" = (
+/obj/machinery/door/poddoor/shutters{
+	id = "supplybridge"
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 2
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/space)
+"sGe" = (
+/obj/structure/sign/vacuum,
+/turf/closed/wall,
+/area/space)
+"sGf" = (
+/turf/closed/wall,
+/area/space)
+"sGg" = (
+/turf/closed/wall,
+/area/space)
+"sGh" = (
+/turf/closed/wall,
+/area/space)
+"sGi" = (
+/turf/closed/wall,
+/area/space)
+"sGj" = (
+/turf/closed/wall,
+/area/space)
+"sGk" = (
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
+/area/space)
+"sGl" = (
+/obj/item/twohanded/required/kirbyplants{
+	icon_state = "plant-21"
+	},
+/turf/open/floor/plasteel/brown{
+	dir = 8
+	},
+/area/space)
+"sGm" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
+	dir = 1
+	},
+/turf/open/floor/plasteel/neutral,
+/area/space)
+"sGn" = (
+/obj/machinery/holopad,
+/obj/effect/turf_decal/bot,
+/turf/open/floor/plasteel,
+/area/space)
+"sGo" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on{
+	dir = 1
+	},
+/obj/effect/landmark/lightsout,
+/turf/open/floor/plasteel/neutral,
+/area/space)
+"sGp" = (
+/turf/open/floor/plasteel/brown{
+	dir = 4
+	},
+/area/space)
+"sGq" = (
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
+/area/space)
+"sGr" = (
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
+/area/space)
+"sGs" = (
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
+/area/space)
+"sGt" = (
+/turf/closed/wall/rust,
+/area/crew_quarters/dorms)
+"sGu" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/turf/closed/wall/rust,
+/area/crew_quarters/theatre)
+"sGv" = (
+/turf/open/floor/plating,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/turf/open/floor/plating{
+	tag = "icon-platingdmg2";
+	icon_state = "platingdmg2"
+	},
+/area/hallway/primary/central)
+"sGw" = (
+/turf/closed/wall/rust,
+/area/hallway/primary/central)
+"sGx" = (
+/obj/structure/sign/poster/contraband/random,
+/turf/closed/wall,
+/area/hallway/primary/central)
+"sGy" = (
+/obj/machinery/door/firedoor,
+/obj/machinery/door/airlock/engineering{
+	name = "Technology Storage";
+	req_access_txt = "23"
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 2
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/turf/open/floor/plasteel/vault,
+/area/hallway/primary/central)
+"sGz" = (
+/obj/structure/girder,
+/turf/open/floor/plating,
+/area/hallway/primary/central)
+"sGA" = (
+/obj/structure/cable/white{
+	tag = "icon-2-4";
+	icon_state = "2-4"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	tag = "icon-intact (SOUTHEAST)";
+	icon_state = "intact";
+	dir = 6
+	},
+/turf/open/floor/plating{
+	burnt = 1;
+	icon_state = "panelscorched"
+	},
+/area/hallway/primary/central)
+"sGB" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/machinery/door/airlock/maintenance_hatch{
+	name = "Maintenance Hatch";
+	req_access_txt = "12"
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/structure/cable/white{
+	tag = "icon-4-8";
+	icon_state = "4-8"
+	},
+/turf/open/floor/plasteel,
+/area/hallway/secondary/exit)
+"sGC" = (
+/obj/structure/cable/white{
+	tag = "icon-4-8";
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/turf/open/floor/plasteel/escape{
+	dir = 8
+	},
+/area/hallway/secondary/exit)
+"sGD" = (
+/obj/structure/cable/white{
+	tag = "icon-2-8";
+	icon_state = "2-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	tag = "icon-intact (SOUTHWEST)";
+	icon_state = "intact";
+	dir = 10
+	},
+/turf/open/floor/plasteel,
+/area/hallway/secondary/exit)
+"sGE" = (
+/obj/structure/lattice,
+/turf/open/space,
+/area/space)
+"sGF" = (
+/obj/structure/lattice,
+/turf/open/space,
+/area/space)
+"sGG" = (
+/obj/structure/lattice,
+/turf/open/space,
+/area/space)
+"sGH" = (
+/obj/structure/lattice,
+/turf/open/space,
+/area/space)
+"sGI" = (
+/obj/structure/lattice,
+/turf/open/space,
+/area/space)
+"sGJ" = (
+/obj/structure/lattice,
+/turf/open/space,
+/area/space)
+"sGK" = (
+/obj/structure/lattice,
+/turf/open/space,
+/area/space)
+"sGL" = (
+/obj/structure/lattice,
+/turf/open/space,
+/area/space)
+"sGM" = (
+/turf/closed/wall,
+/area/space)
+"sGN" = (
+/obj/structure/table/reinforced,
+/obj/item/clipboard,
+/obj/item/folder/yellow,
+/obj/item/pen/red,
+/obj/item/stamp/denied{
+	pixel_x = 6;
+	pixel_y = 6
+	},
+/obj/item/stamp,
+/obj/machinery/airalarm{
+	dir = 4;
+	pixel_x = -23
+	},
+/turf/open/floor/plasteel/brown{
+	dir = 8
+	},
+/area/space)
+"sGO" = (
+/obj/structure/closet/crate,
+/obj/machinery/ai_status_display{
+	pixel_y = -32
+	},
+/obj/effect/turf_decal/bot,
+/turf/open/floor/plasteel,
+/area/space)
+"sGP" = (
+/obj/structure/closet/crate,
+/obj/item/device/radio/intercom{
+	name = "Station Intercom";
+	pixel_y = -24
+	},
+/obj/machinery/light,
+/obj/effect/turf_decal/delivery,
+/turf/open/floor/plasteel,
+/area/space)
+"sGQ" = (
+/obj/structure/closet/crate,
+/obj/machinery/status_display{
+	pixel_y = -32
+	},
+/obj/effect/turf_decal/bot,
+/turf/open/floor/plasteel,
+/area/space)
+"sGR" = (
+/obj/structure/closet/crate,
+/obj/machinery/firealarm{
+	dir = 1;
+	pixel_y = -26
+	},
+/obj/effect/turf_decal/delivery,
+/turf/open/floor/plasteel,
+/area/space)
+"sGS" = (
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
+/area/space)
+"sGT" = (
+/obj/structure/lattice,
+/turf/open/space,
+/area/space)
+"sGU" = (
+/obj/machinery/atmospherics/pipe/simple/cyan/hidden{
+	dir = 8
+	},
+/turf/closed/wall/r_wall/rust,
+/area/engine/atmos)
+"sGV" = (
+/turf/closed/wall/r_wall/rust,
+/area/engine/atmos)
+"sGW" = (
+/obj/structure/cable/white{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/turf/open/floor/plating{
+	broken = 1;
+	icon_state = "platingdmg3"
+	},
+/area/maintenance/port/central)
+"sGX" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 5
+	},
+/turf/open/floor/plating,
+/area/hallway/primary/central)
+"sGY" = (
+/obj/structure/cable/white{
+	tag = "icon-4-8";
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/hallway/primary/central)
+"sGZ" = (
+/obj/structure/cable/white{
+	tag = "icon-4-8";
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/hallway/primary/central)
+"sHa" = (
+/obj/structure/cable/white{
+	tag = "icon-4-8";
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/hallway/primary/central)
+"sHb" = (
+/obj/structure/cable/white{
+	tag = "icon-4-8";
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden,
+/turf/open/floor/plating{
+	burnt = 1;
+	icon_state = "panelscorched"
+	},
+/area/hallway/primary/central)
+"sHc" = (
+/obj/structure/cable/white{
+	tag = "icon-4-8";
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/hallway/primary/central)
+"sHd" = (
+/obj/structure/cable/white{
+	tag = "icon-4-8";
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/turf/open/floor/plating{
+	broken = 1;
+	icon_state = "platingdmg3"
+	},
+/area/hallway/primary/central)
+"sHe" = (
+/obj/structure/cable/white{
+	tag = "icon-1-8";
+	icon_state = "1-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	tag = "icon-intact (NORTHWEST)";
+	icon_state = "intact";
+	dir = 9
+	},
+/turf/open/floor/plating,
+/area/hallway/primary/central)
+"sHf" = (
+/obj/machinery/firealarm{
+	dir = 8;
+	pixel_x = -24;
+	pixel_y = 0
+	},
+/turf/open/floor/plasteel,
+/area/hallway/secondary/exit)
+"sHg" = (
+/obj/structure/cable/white{
+	tag = "icon-1-2";
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/turf/open/floor/plasteel/escape{
+	tag = "icon-escape (EAST)";
+	icon_state = "escape";
+	dir = 4
+	},
+/area/hallway/secondary/exit)
+"sHh" = (
+/obj/structure/lattice,
+/turf/open/space,
+/area/space)
+"sHi" = (
+/obj/structure/window/reinforced/tinted/fulltile,
+/obj/structure/grille,
+/turf/open/floor/plating,
+/area/space)
+"sHj" = (
+/obj/structure/window/reinforced/tinted/fulltile,
+/obj/structure/grille,
+/turf/open/floor/plating,
+/area/space)
+"sHk" = (
+/obj/structure/window/reinforced/tinted/fulltile,
+/obj/structure/grille,
+/turf/open/floor/plating,
+/area/space)
+"sHl" = (
+/obj/structure/window/reinforced/tinted/fulltile,
+/obj/structure/grille,
+/turf/open/floor/plating,
+/area/space)
+"sHm" = (
+/obj/structure/window/reinforced/tinted/fulltile,
+/obj/structure/grille,
+/turf/open/floor/plating,
+/area/space)
+"sHn" = (
+/obj/structure/lattice,
+/turf/open/space,
+/area/space)
+"sHo" = (
+/obj/structure/lattice,
+/obj/structure/grille,
+/turf/open/space,
+/area/space)
+"sHp" = (
+/obj/structure/lattice,
+/turf/open/space,
+/area/space)
+"sHq" = (
+/turf/closed/wall,
+/area/space)
+"sHr" = (
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
+/area/space)
+"sHs" = (
+/turf/closed/wall,
+/area/space)
+"sHt" = (
+/turf/closed/wall,
+/area/space)
+"sHu" = (
+/turf/closed/wall,
+/area/space)
+"sHv" = (
+/turf/closed/wall,
+/area/space)
+"sHw" = (
+/turf/closed/wall,
+/area/space)
+"sHx" = (
+/obj/structure/lattice,
+/turf/open/space,
+/area/space)
+"sHy" = (
+/turf/closed/wall/r_wall/rust,
+/area/ruin/unpowered{
+	name = "Asteroid"
+	})
+"sHz" = (
+/obj/structure/closet/crate/bin,
+/obj/effect/turf_decal/bot,
+/turf/open/floor/plasteel/vault/side{
+	tag = "icon-vault (WEST)";
+	icon_state = "vault";
+	dir = 8
+	},
+/area/hallway/primary/central)
+"sHA" = (
+/turf/closed/wall/rust,
+/area/hallway/secondary/exit)
+"sHB" = (
+/turf/open/floor/plasteel/escape{
+	dir = 8
+	},
+/area/hallway/secondary/exit)
+"sHC" = (
+/obj/structure/cable/white{
+	tag = "icon-1-2";
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
+	tag = "icon-manifold (WEST)";
+	icon_state = "manifold";
+	dir = 8
+	},
+/turf/open/floor/plasteel/neutral/side{
+	dir = 4
+	},
+/area/hallway/secondary/exit)
+"sHD" = (
+/obj/structure/lattice,
+/turf/open/space,
+/area/space)
+"sHE" = (
+/obj/effect/spawner/structure/window/reinforced/tinted,
+/turf/open/floor/plating,
+/area/space)
+"sHF" = (
+/obj/structure/table/wood,
+/obj/item/storage/secure/briefcase,
+/obj/item/restraints/handcuffs,
+/obj/item/grenade/smokebomb,
+/obj/effect/decal/cleanable/cobweb,
+/turf/open/floor/plating,
+/area/space)
+"sHG" = (
+/obj/structure/closet/secure_closet/personal/cabinet,
+/obj/item/clothing/suit/jacket{
+	desc = "All the class of a trenchcoat without the security fibers.";
+	icon_state = "greydet";
+	name = "trenchcoat"
+	},
+/obj/item/clothing/suit/jacket{
+	desc = "All the class of a trenchcoat without the security fibers.";
+	icon_state = "detective";
+	name = "trenchcoat"
+	},
+/obj/item/clothing/head/fedora,
+/obj/item/clothing/head/fedora{
+	icon_state = "detective"
+	},
+/obj/machinery/light/small{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/space)
+"sHH" = (
+/obj/structure/dresser,
+/turf/open/floor/wood,
+/area/space)
+"sHI" = (
+/obj/effect/spawner/structure/window/reinforced/tinted,
+/turf/open/floor/plating,
+/area/space)
+"sHJ" = (
+/obj/structure/lattice,
+/turf/open/space,
+/area/space)
+"sHK" = (
+/obj/structure/lattice,
+/obj/structure/grille,
+/turf/open/space,
+/area/space)
+"sHL" = (
+/obj/structure/lattice,
+/obj/structure/grille,
+/turf/open/space,
+/area/space)
+"sHM" = (
+/obj/structure/lattice,
+/turf/open/space,
+/area/space)
+"sHN" = (
+/obj/structure/lattice,
+/turf/open/space,
+/area/space)
+"sHO" = (
+/obj/structure/lattice,
+/turf/open/space,
+/area/space)
+"sHP" = (
+/obj/structure/lattice,
+/turf/open/space,
+/area/space)
+"sHQ" = (
+/obj/structure/lattice,
+/turf/open/space,
+/area/space)
+"sHR" = (
+/obj/structure/lattice,
+/turf/open/space,
+/area/space)
+"sHS" = (
+/obj/structure/lattice,
+/turf/open/space,
+/area/space)
+"sHT" = (
+/obj/structure/lattice,
+/turf/open/space,
+/area/space)
+"sHU" = (
+/obj/structure/lattice,
+/turf/open/space,
+/area/space)
+"sHV" = (
+/turf/closed/wall/r_wall/rust,
+/area/engine/engineering)
+"sHW" = (
+/turf/closed/wall/rust,
+/area/crew_quarters/dorms)
+"sHX" = (
+/turf/closed/wall/rust,
+/area/crew_quarters/dorms)
+"sHY" = (
+/turf/closed/wall/rust,
+/area/crew_quarters/dorms)
+"sHZ" = (
+/turf/closed/wall/rust,
+/area/crew_quarters/theatre)
+"sIa" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/turf/open/floor/plasteel/escape{
+	tag = "icon-escape (NORTH)";
+	icon_state = "escape";
+	dir = 1
+	},
+/area/hallway/secondary/exit)
+"sIb" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/machinery/status_display{
+	pixel_y = 32
+	},
+/turf/open/floor/plasteel,
+/area/hallway/secondary/exit)
+"sIc" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/machinery/airalarm{
+	pixel_y = 24
+	},
+/turf/open/floor/plasteel,
+/area/hallway/secondary/exit)
+"sId" = (
+/obj/structure/cable/white{
+	tag = "icon-1-2";
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
+	tag = "icon-manifold (EAST)";
+	icon_state = "manifold";
+	dir = 4
+	},
+/turf/open/floor/plasteel/neutral/side{
+	dir = 4
+	},
+/area/hallway/secondary/exit)
+"sIe" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/hallway/secondary/exit)
+"sIf" = (
+/obj/structure/lattice,
+/turf/open/space,
+/area/space)
+"sIg" = (
+/obj/effect/spawner/structure/window/reinforced/tinted,
+/turf/open/floor/plating,
+/area/space)
+"sIh" = (
+/obj/structure/table/wood,
+/obj/item/crowbar/red,
+/obj/item/book/manual/wiki/security_space_law{
+	pixel_x = 3;
+	pixel_y = 3
+	},
+/obj/item/book/manual/detective,
+/obj/item/device/camera/detective,
+/turf/open/floor/plasteel/vault{
+	dir = 5
+	},
+/area/space)
+"sIi" = (
+/obj/structure/chair/office/dark{
+	dir = 4
+	},
+/obj/effect/landmark/revenantspawn,
+/obj/effect/decal/cleanable/blood/old,
+/turf/open/floor/wood,
+/area/space)
+"sIj" = (
+/obj/effect/landmark/xeno_spawn,
+/obj/machinery/atmospherics/components/unary/vent_pump/on,
+/turf/open/floor/wood{
+	icon_state = "wood-broken"
+	},
+/area/space)
+"sIk" = (
+/obj/effect/spawner/structure/window/reinforced/tinted,
+/turf/open/floor/plating,
+/area/space)
+"sIl" = (
+/obj/structure/lattice,
+/turf/open/space,
+/area/space)
+"sIm" = (
+/obj/structure/lattice,
+/turf/open/space,
+/area/space)
+"sIn" = (
+/obj/structure/lattice,
+/obj/structure/grille,
+/turf/open/space,
+/area/space)
+"sIo" = (
+/obj/structure/lattice,
+/obj/structure/grille,
+/turf/open/space,
+/area/space)
+"sIp" = (
+/obj/structure/lattice,
+/obj/structure/grille,
+/turf/open/space,
+/area/space)
+"sIq" = (
+/obj/structure/lattice,
+/obj/structure/grille,
+/turf/open/space,
+/area/space)
+"sIr" = (
+/obj/structure/lattice,
+/obj/structure/grille,
+/turf/open/space,
+/area/space)
+"sIs" = (
+/obj/structure/lattice,
+/obj/structure/grille,
+/turf/open/space,
+/area/space)
+"sIt" = (
+/obj/structure/lattice,
+/obj/structure/grille,
+/turf/open/space,
+/area/space)
+"sIu" = (
+/turf/closed/wall/r_wall/rust,
+/area/engine/gravity_generator)
+"sIv" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/structure/cable/white{
+	tag = "icon-4-8";
+	icon_state = "4-8"
+	},
+/turf/open/floor/plasteel/escape,
+/area/hallway/secondary/exit)
+"sIw" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/structure/cable/white{
+	tag = "icon-4-8";
+	icon_state = "4-8"
+	},
+/obj/structure/extinguisher_cabinet{
+	pixel_y = -28
+	},
+/obj/machinery/camera{
+	c_tag = "Departures Hallway";
+	dir = 1
+	},
+/turf/open/floor/plasteel/escape,
+/area/hallway/secondary/exit)
+"sIx" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/structure/cable/white{
+	tag = "icon-4-8";
+	icon_state = "4-8"
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/machinery/door/firedoor,
+/obj/machinery/atmospherics/components/unary/vent_pump/on{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/hallway/secondary/exit)
+"sIy" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/structure/cable/white{
+	tag = "icon-4-8";
+	icon_state = "4-8"
+	},
+/turf/open/floor/plasteel/escape/corner{
+	tag = "icon-escapecorner (WEST)";
+	icon_state = "escapecorner";
+	dir = 8
+	},
+/area/hallway/secondary/exit)
+"sIz" = (
+/turf/closed/wall/r_wall/rust,
+/area/engine/gravity_generator)
+"sIA" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/turf/closed/wall/r_wall/rust,
+/area/engine/engineering)
+"sIB" = (
+/turf/closed/wall/rust,
+/area/hydroponics)
+"sIC" = (
+/turf/closed/wall/rust,
+/area/crew_quarters/kitchen)
+"sID" = (
+/turf/closed/wall/rust,
+/area/hallway/primary/central)
+"sIE" = (
+/obj/structure/sign/poster/contraband/random,
+/turf/closed/wall,
+/area/hallway/secondary/exit)
+"sIF" = (
+/obj/structure/grille,
+/obj/structure/window/reinforced/fulltile,
+/turf/open/floor/plating,
+/area/hallway/secondary/exit)
+"sIG" = (
+/obj/machinery/vending/cigarette,
+/obj/machinery/newscaster{
+	pixel_x = 0;
+	pixel_y = -30
+	},
+/obj/effect/turf_decal/bot,
+/turf/open/floor/plasteel/vault/side{
+	tag = "icon-vault (NORTH)";
+	icon_state = "vault";
+	dir = 1
+	},
+/area/hallway/secondary/exit)
+"sIH" = (
+/turf/closed/wall/r_wall/rust,
+/area/engine/gravity_generator)
+"sII" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/turf/closed/wall/r_wall/rust,
+/area/engine/gravity_generator)
+"sIJ" = (
+/turf/closed/wall/r_wall/rust,
+/area/engine/engineering)
+"sIK" = (
+/turf/closed/wall/rust,
+/area/janitor)
+"sIL" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/structure/cable/white{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plating{
+	icon_state = "platingdmg1"
+	},
+/area/maintenance/starboard/central)
+"sIM" = (
+/obj/structure/closet/emcloset{
+	anchored = 1
+	},
+/obj/machinery/light/small{
+	dir = 1
+	},
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/plasteel,
+/area/hallway/secondary/exit)
+"sIN" = (
+/obj/structure/sign/securearea,
+/turf/closed/wall/rust,
+/area/hallway/secondary/exit)
+"sIO" = (
+/turf/open/space/basic,
+/area/space/nearstation)
+"sIP" = (
+/obj/machinery/vending/cola/random,
+/obj/effect/turf_decal/bot,
+/turf/open/floor/plasteel/vault/side{
+	tag = "icon-vault (EAST)";
+	icon_state = "vault";
+	dir = 4
+	},
+/area/hallway/secondary/exit)
+"sIQ" = (
+/turf/open/floor/plasteel/escape{
+	dir = 8
+	},
+/area/hallway/secondary/exit)
+"sIR" = (
+/obj/structure/cable/white{
+	tag = "icon-1-2";
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/turf/open/floor/plasteel,
+/area/hallway/secondary/exit)
+"sIS" = (
+/turf/closed/wall/rust,
+/area/hydroponics)
+"sIT" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on,
+/turf/open/floor/plating{
+	burnt = 1;
+	icon_state = "panelscorched"
+	},
+/area/hallway/secondary/exit)
+"sIU" = (
+/obj/machinery/door/poddoor/shutters{
+	id = "supplybridge"
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 2
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/hallway/secondary/exit)
+"sIV" = (
+/obj/machinery/door/poddoor/shutters{
+	id = "supplybridge"
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 2
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/hallway/secondary/exit)
+"sIW" = (
+/obj/machinery/door/poddoor/shutters{
+	id = "supplybridge"
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 2
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/hallway/secondary/exit)
+"sIX" = (
+/turf/closed/wall/rust,
+/area/hallway/secondary/exit)
+"sIY" = (
+/obj/machinery/light/small{
+	dir = 1
+	},
+/obj/effect/turf_decal/stripes/line,
+/obj/structure/rack,
+/obj/machinery/atmospherics/components/unary/vent_pump/on,
+/obj/item/storage/toolbox/emergency,
+/obj/item/crowbar/red,
+/obj/item/clothing/mask/gas,
+/turf/open/floor/plasteel,
+/area/hallway/secondary/exit)
+"sIZ" = (
+/obj/structure/sign/poster/contraband/random,
+/turf/closed/wall,
+/area/hallway/secondary/exit)
+"sJa" = (
+/obj/structure/cable/white{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
+	dir = 8
+	},
+/turf/open/floor/plasteel/neutral/corner{
+	dir = 4
+	},
+/area/hallway/primary/central)
+"sJb" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/machinery/door/airlock/maintenance_hatch{
+	name = "Maintenance Hatch";
+	req_access_txt = "12"
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/structure/cable/white{
+	tag = "icon-4-8";
+	icon_state = "4-8"
+	},
+/turf/open/floor/plating,
+/area/hallway/primary/central)
+"sJc" = (
+/obj/structure/cable/white{
+	tag = "icon-4-8";
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden,
+/turf/open/floor/plating{
+	icon_state = "platingdmg1"
+	},
+/area/hallway/secondary/exit)
+"sJd" = (
+/obj/machinery/button/door{
+	id = "supplybridge";
+	name = "Shuttle Bay Space Bridge Control";
+	pixel_y = 27;
+	req_access_txt = "0"
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/machinery/door/airlock/maintenance_hatch{
+	name = "Bridge Hatch";
+	req_access_txt = "12"
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/structure/cable/white{
+	tag = "icon-4-8";
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/hallway/secondary/exit)
+"sJe" = (
+/obj/structure/cable/white{
+	tag = "icon-4-8";
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/hallway/secondary/exit)
+"sJf" = (
+/obj/structure/cable/white{
+	tag = "icon-4-8";
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/hallway/secondary/exit)
+"sJg" = (
+/obj/structure/cable/white{
+	tag = "icon-4-8";
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/turf/open/floor/plating{
+	burnt = 1;
+	icon_state = "panelscorched"
+	},
+/area/hallway/secondary/exit)
+"sJh" = (
+/obj/machinery/button/door{
+	id = "supplybridge";
+	name = "Shuttle Bay Space Bridge Control";
+	pixel_y = 27;
+	req_access_txt = "0"
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/machinery/door/airlock/maintenance_hatch{
+	name = "Bridge Hatch";
+	req_access_txt = "12"
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/structure/cable/white{
+	tag = "icon-4-8";
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/hallway/secondary/exit)
+"sJi" = (
+/obj/structure/cable/white{
+	tag = "icon-4-8";
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden,
+/turf/open/floor/plating,
+/area/hallway/secondary/exit)
+"sJj" = (
+/obj/machinery/door/airlock/maintenance_hatch{
+	name = "Maintenance Hatch";
+	req_access_txt = "12"
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/structure/cable/white{
+	tag = "icon-4-8";
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/hallway/secondary/exit)
+"sJk" = (
+/obj/machinery/light,
+/obj/machinery/status_display{
+	pixel_y = -32
+	},
+/obj/structure/cable/white{
+	tag = "icon-4-8";
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/turf/open/floor/plasteel/escape{
+	tag = "icon-escape (SOUTHWEST)";
+	icon_state = "escape";
+	dir = 10
+	},
+/area/hallway/secondary/exit)
+"sJl" = (
+/turf/closed/wall/r_wall/rust,
+/area/engine/gravity_generator)
+"sJm" = (
+/turf/closed/wall/rust,
+/area/janitor)
+"sJn" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/structure/cable/white{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plasteel/vault/side{
+	tag = "icon-vault (WEST)";
+	icon_state = "vault";
+	dir = 8
+	},
+/area/crew_quarters/bar/atrium)
+"sJo" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 10
+	},
+/obj/structure/cable/white{
+	icon_state = "2-8"
+	},
+/turf/open/floor/plating{
+	icon_state = "platingdmg1"
+	},
+/area/maintenance/starboard/central)
+"sJp" = (
+/turf/closed/wall/rust,
+/area/hallway/secondary/exit)
+"sJq" = (
+/obj/structure/sign/directions/engineering{
+	desc = "A sign that shows there are doors here. There are doors everywhere!";
+	icon_state = "doors";
+	name = "WARNING: EXTERNAL AIRLOCK";
+	tag = "icon-doors"
+	},
+/turf/closed/wall,
+/area/hallway/secondary/exit)
+"sJr" = (
+/obj/machinery/door/poddoor/shutters{
+	id = "supplybridge"
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 2
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/hallway/secondary/exit)
+"sJs" = (
+/obj/machinery/door/poddoor/shutters{
+	id = "supplybridge"
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 2
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/hallway/secondary/exit)
+"sJt" = (
+/obj/machinery/door/poddoor/shutters{
+	id = "supplybridge"
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 2
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/hallway/secondary/exit)
+"sJu" = (
+/obj/structure/sign/vacuum,
+/turf/closed/wall,
+/area/hallway/secondary/exit)
+"sJv" = (
+/turf/closed/wall/rust,
+/area/hallway/secondary/exit)
+"sJw" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/turf/closed/wall/r_wall/rust,
+/area/engine/gravity_generator)
+"sJx" = (
+/obj/structure/sink{
+	dir = 4;
+	pixel_x = 12
+	},
+/turf/open/floor/plasteel/vault/side{
+	tag = "icon-vault (NORTH)";
+	icon_state = "vault";
+	dir = 1
+	},
+/area/hydroponics)
+"sJy" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/turf/closed/wall/r_wall/rust,
+/area/tcommsat/server)
+"sJz" = (
+/turf/closed/wall/r_wall/rust,
+/area/engine/engineering)
+"sJA" = (
+/obj/structure/closet/firecloset,
+/obj/effect/turf_decal/delivery,
+/turf/open/floor/plasteel/vault/side,
+/area/hallway/primary/central)
+"sJB" = (
+/turf/closed/wall/rust,
+/area/hallway/secondary/exit)
+"sJC" = (
+/turf/closed/wall/rust,
+/area/hallway/secondary/exit)
+"sJD" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/turf/closed/wall/r_wall/rust,
+/area/tcommsat/server)
+"sJE" = (
+/obj/structure/cable/white{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/turf/open/floor/plating{
+	broken = 1;
+	icon_state = "platingdmg1"
+	},
+/area/maintenance/port)
+"sJF" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/turf/closed/wall/r_wall/rust,
+/area/tcommsat/server)
+"sJG" = (
+/turf/closed/wall/r_wall/rust,
+/area/engine/supermatter)
+"sJH" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/turf/closed/wall/r_wall/rust,
+/area/maintenance/port)
+"sJI" = (
+/turf/closed/wall/rust,
+/area/library)
+"sJJ" = (
+/obj/structure/closet/firecloset,
+/obj/effect/turf_decal/delivery,
+/turf/open/floor/plasteel/vault/side{
+	tag = "icon-vault (NORTH)";
+	icon_state = "vault";
+	dir = 1
+	},
+/area/hallway/primary/central)
+"sJK" = (
+/obj/structure/closet/crate/bin,
+/obj/effect/turf_decal/delivery,
+/turf/open/floor/plasteel/vault/side{
+	tag = "icon-vault (NORTH)";
+	icon_state = "vault";
+	dir = 1
+	},
+/area/hallway/primary/central)
+"sJL" = (
+/turf/closed/wall/r_wall,
+/area/science/research)
+"sJM" = (
+/turf/closed/wall/rust,
+/area/hallway/primary/central)
+"sJN" = (
+/turf/closed/wall/rust,
+/area/maintenance/starboard)
+"sJO" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/turf/open/floor/plasteel/vault/side,
+/area/tcommsat/server)
+"sJP" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/turf/open/floor/plasteel/vault/side,
+/area/tcommsat/server)
+"sJQ" = (
+/turf/closed/wall/r_wall,
+/area/science/research)
+"sJR" = (
+/obj/structure/sign/poster/contraband/random,
+/turf/closed/wall/rust,
+/area/maintenance/starboard)
+"sJS" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/structure/cable/white{
+	icon_state = "1-2"
+	},
+/turf/open/floor/wood{
+	icon_state = "wood-broken7"
+	},
+/area/library)
+"sJT" = (
+/turf/closed/wall/rust,
+/area/medical/morgue)
+"sJU" = (
+/turf/closed/wall/rust,
+/area/maintenance/starboard)
+"sJV" = (
+/turf/closed/wall/r_wall/rust,
+/area/tcommsat/server)
+"sJW" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/turf/closed/wall/r_wall/rust,
+/area/maintenance/port)
+"sJX" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/structure/cable/white{
+	icon_state = "4-8"
+	},
+/turf/open/floor/wood,
+/area/library)
+"sJY" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/structure/cable/white{
+	icon_state = "4-8"
+	},
+/turf/open/floor/wood,
+/area/library)
+"sJZ" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/structure/cable/white{
+	icon_state = "4-8"
+	},
+/turf/open/floor/wood,
+/area/library)
+"sKa" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/turf/closed/wall/r_wall/rust,
+/area/science/research)
+"sKb" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/turf/closed/wall/r_wall/rust,
+/area/maintenance/port)
+"sKc" = (
+/obj/structure/cable/white{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/turf/open/floor/plating{
+	burnt = 1;
+	icon_state = "panelscorched"
+	},
+/area/maintenance/port)
+"sKd" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/turf/open/floor/wood{
+	icon_state = "wood-broken"
+	},
+/area/library)
+"sKe" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/turf/open/floor/wood{
+	icon_state = "wood-broken2"
+	},
+/area/library)
+"sKf" = (
+/turf/closed/wall/rust,
+/area/science/research)
+"sKg" = (
+/turf/closed/wall/r_wall/rust,
+/area/tcommsat/server)
+"sKh" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/turf/closed/wall/r_wall/rust,
+/area/science/research)
+"sKi" = (
+/obj/structure/sign/poster/contraband/random,
+/turf/closed/wall/rust,
+/area/maintenance/starboard)
+"sKj" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/turf/open/floor/plasteel/vault/telecomms{
+	dir = 5
+	},
+/area/tcommsat/server)
+"sKk" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/turf/open/floor/plasteel/vault/telecomms{
+	dir = 5
+	},
+/area/tcommsat/server)
+"sKl" = (
+/turf/closed/wall/rust,
+/area/maintenance/starboard)
+"sKm" = (
+/turf/closed/wall/r_wall/rust,
+/area/tcommsat/server)
+"sKn" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel/vault/telecomms{
+	dir = 5
+	},
+/area/tcommsat/server)
+"sKo" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/turf/closed/wall/r_wall/rust,
+/area/maintenance/port)
+"sKp" = (
+/turf/closed/wall/rust,
+/area/medical/medbay/zone3)
+"sKq" = (
+/turf/closed/wall/rust,
+/area/hallway/primary/central)
+"sKr" = (
+/turf/closed/wall/rust,
+/area/maintenance/starboard)
+"sKs" = (
+/turf/closed/wall/r_wall/rust,
+/area/tcommsat/server)
+"sKt" = (
+/turf/closed/wall/r_wall/rust,
+/area/tcommsat/server)
+"sKu" = (
+/turf/closed/wall/rust,
+/area/library)
+"sKv" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/turf/closed/wall/r_wall/rust,
+/area/science/research)
+"sKw" = (
+/turf/closed/wall/r_wall/rust,
+/area/ruin/unpowered{
+	name = "Asteroid"
+	})
+"sKx" = (
+/turf/closed/wall/r_wall/rust,
+/area/maintenance/port)
+"sKy" = (
+/turf/closed/wall/rust,
+/area/maintenance/starboard)
+"sKz" = (
+/turf/closed/wall/r_wall/rust,
+/area/ruin/unpowered{
+	name = "Asteroid"
+	})
+"sKA" = (
+/turf/closed/wall/rust,
+/area/library)
+"sKB" = (
+/turf/closed/wall/rust,
+/area/security/checkpoint)
+"sKC" = (
+/turf/closed/wall/r_wall/rust,
+/area/ruin/unpowered{
+	name = "Asteroid"
+	})
+"sKD" = (
+/turf/closed/wall/rust,
+/area/library)
+"sKE" = (
+/turf/closed/wall/rust,
+/area/maintenance/port)
+"sKF" = (
+/turf/closed/wall/rust,
+/area/medical/medbay/zone3)
+"sKG" = (
+/turf/closed/wall/rust,
+/area/maintenance/starboard)
+"sKH" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/turf/closed/wall/rust,
+/area/maintenance/port)
+"sKI" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/turf/closed/wall/rust,
+/area/maintenance/port)
+"sKJ" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/turf/closed/wall/r_wall/rust,
+/area/science/robotics/lab)
+"sKK" = (
+/turf/closed/wall/rust,
+/area/maintenance/starboard)
+"sKL" = (
+/obj/structure/sign/poster/contraband/random,
+/turf/closed/wall/rust,
+/area/maintenance/port)
+"sKM" = (
+/turf/closed/wall/rust,
+/area/maintenance/port)
+"sKN" = (
+/turf/closed/wall/rust,
+/area/medical/medbay/zone3)
+"sKO" = (
+/turf/closed/wall/rust,
+/area/security/checkpoint)
+"sKP" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/turf/closed/wall/r_wall/rust,
+/area/science/robotics/mechbay)
+"sKQ" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/turf/closed/wall/r_wall/rust,
+/area/science/robotics/lab)
+"sKR" = (
+/turf/closed/wall/rust,
+/area/maintenance/starboard)
+"sKS" = (
+/turf/closed/wall/rust,
+/area/maintenance/port)
+"sKT" = (
+/turf/closed/wall/rust,
+/area/maintenance/port)
+"sKU" = (
+/turf/closed/wall/rust,
+/area/maintenance/port)
+"sKV" = (
+/turf/closed/wall/rust,
+/area/maintenance/port)
+"sKW" = (
+/turf/open/floor/plating{
+	burnt = 1;
+	icon_state = "panelscorched"
+	},
+/area/maintenance/port)
+"sKX" = (
+/turf/closed/wall/rust,
+/area/maintenance/port)
+"sKY" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/structure/cable/white{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plating{
+	icon_state = "platingdmg3"
+	},
+/area/maintenance/starboard)
+"sKZ" = (
+/turf/closed/wall/r_wall/rust,
+/area/science/xenobiology)
+"sLa" = (
+/turf/closed/wall/r_wall/rust,
+/area/science/xenobiology)
+"sLb" = (
+/turf/closed/wall/rust,
+/area/maintenance/starboard)
+"sLc" = (
+/obj/structure/barricade/wooden,
+/obj/machinery/door/airlock/maintenance_hatch{
+	name = "Maintenance Hatch";
+	req_access_txt = "12"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/effect/turf_decal/stripes/line{
+	dir = 2
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/maintenance/starboard)
+"sLd" = (
+/turf/closed/wall/r_wall/rust,
+/area/science/xenobiology)
+"sLe" = (
+/turf/closed/wall/rust,
+/area/maintenance/starboard)
+"sLf" = (
+/turf/closed/wall/rust,
+/area/chapel/main)
+"sLg" = (
+/obj/item/twohanded/required/kirbyplants{
+	icon_state = "plant-22"
+	},
+/obj/effect/turf_decal/delivery,
+/turf/open/floor/plasteel/vault/side{
+	tag = "icon-vault (NORTH)";
+	icon_state = "vault";
+	dir = 1
+	},
+/area/maintenance/starboard)
+"sLh" = (
+/turf/closed/wall/r_wall/rust,
+/area/science/xenobiology)
+"sLi" = (
+/turf/closed/wall/r_wall/rust,
+/area/science/xenobiology)
+"sLj" = (
+/turf/closed/wall/rust,
+/area/maintenance/starboard)
+"sLk" = (
+/turf/closed/wall/rust,
+/area/maintenance/starboard)
+"sLl" = (
+/turf/closed/wall/rust,
+/area/ruin/unpowered{
+	name = "Asteroid"
+	})
+"sLm" = (
+/turf/closed/wall/rust,
+/area/hallway/secondary/entry)
+"sLn" = (
+/turf/closed/wall/rust,
+/area/chapel/main)
+"sLo" = (
+/turf/closed/wall/rust,
+/area/chapel/main)
+"sLp" = (
+/turf/closed/wall/rust,
+/area/chapel/main)
+"sLq" = (
+/turf/closed/wall/r_wall/rust,
+/area/science/xenobiology)
+"sLr" = (
+/turf/closed/wall/r_wall/rust,
+/area/science/xenobiology)
+"sLs" = (
+/turf/closed/wall/rust,
+/area/chapel/main)
+"sLt" = (
+/turf/closed/wall/rust,
+/area/chapel/main)
+"sLu" = (
+/turf/closed/wall/r_wall/rust,
+/area/science/xenobiology)
+"sLv" = (
+/turf/closed/wall/rust,
+/area/hallway/secondary/entry)
 
 (1,1,1) = {"
 aaa
@@ -62044,11 +67672,11 @@ aad
 aad
 aad
 aGe
+sIz
 aGe
 aGe
 aGe
-aGe
-aGe
+sJl
 bwY
 abi
 aad
@@ -62300,7 +67928,7 @@ aad
 aad
 aad
 aad
-aGe
+sIu
 aHe
 aIb
 aJh
@@ -62558,14 +68186,14 @@ aad
 aad
 aad
 aGe
-aHf
+aId
 aIc
 aJi
 aKq
 aLE
-bwY
+sJw
 afM
-abP
+abu
 afM
 abi
 aad
@@ -62818,22 +68446,22 @@ aGe
 aHg
 aId
 aHe
-aKr
+aKq
 aLF
 bxj
+sJy
 bxl
-bxl
-bxl
+sJF
 aSO
 aMJ
 aMJ
+sJV
 aMJ
 aMJ
 aMJ
+sKm
 aMJ
-aMJ
-aMJ
-abP
+abu
 aad
 aad
 aaa
@@ -63073,7 +68701,7 @@ aad
 aad
 aGe
 aGe
-aGe
+sIH
 aJj
 aKs
 aLG
@@ -63088,10 +68716,10 @@ aTX
 buH
 buJ
 buO
-aRB
+sKn
 aMJ
 acG
-ahu
+sKz
 aad
 aac
 aaa
@@ -63339,12 +68967,12 @@ aNU
 aOw
 buC
 bxp
-aRB
+sJO
 aPG
 aQG
 aUO
 buK
-aRB
+sKj
 buR
 aMJ
 afM
@@ -63844,7 +69472,7 @@ aad
 aad
 aad
 afL
-bwY
+sII
 aJm
 aKv
 aLJ
@@ -63853,12 +69481,12 @@ aNW
 aOx
 buC
 bxp
-aRB
+sJP
 aPG
 buG
 buI
 buK
-aRB
+sKk
 buR
 aMJ
 aad
@@ -64097,7 +69725,7 @@ aAh
 aBp
 aCr
 aqz
-ahu
+sHy
 ahu
 ahu
 aaV
@@ -64117,7 +69745,7 @@ blq
 buN
 buQ
 buU
-aMJ
+sKs
 agE
 afL
 aad
@@ -64357,27 +69985,27 @@ aDn
 aEn
 aFq
 aGf
-aHh
+sIA
 aIe
 aJo
 aKx
 aLL
 aMN
 aMN
-aMN
+sJD
 aMN
 bxt
 bwW
 aMJ
 aMJ
 aMJ
+sKg
 aMJ
 aMJ
-aMJ
-aMJ
+sKt
 abi
 ahu
-ahu
+sKC
 aac
 aaa
 aaa
@@ -64597,11 +70225,11 @@ aad
 aad
 abi
 ajQ
-aqz
+sAx
 arr
-asy
+awC
 atz
-aus
+ayb
 avy
 awC
 axj
@@ -64850,7 +70478,7 @@ aaW
 abj
 abj
 abu
-abP
+abu
 aad
 aad
 acF
@@ -64867,7 +70495,7 @@ azj
 aAk
 aBq
 aCu
-aDp
+sGU
 aEp
 aFs
 aGh
@@ -65113,7 +70741,7 @@ abi
 abu
 awL
 art
-asA
+atB
 atB
 auu
 avA
@@ -65133,8 +70761,8 @@ aIh
 aJr
 aKz
 aLO
-aMQ
-aMQ
+aOB
+aOB
 aOB
 aLU
 aQK
@@ -65146,7 +70774,7 @@ aVL
 aUR
 aUQ
 bvo
-ahu
+sKw
 aad
 aac
 bvI
@@ -65375,9 +71003,9 @@ atC
 auv
 avB
 awF
-axl
+awF
 aye
-axl
+awF
 aAm
 aBs
 aCw
@@ -65393,7 +71021,7 @@ buW
 aMR
 aMX
 aMX
-buW
+sJG
 aQK
 aRI
 aSS
@@ -65404,7 +71032,7 @@ aWz
 aVL
 bvo
 ahu
-bvh
+bvg
 bvg
 aad
 aad
@@ -65628,7 +71256,7 @@ anx
 aqC
 arv
 asC
-atD
+auw
 auw
 auw
 auw
@@ -65659,7 +71287,7 @@ aUR
 aUU
 aWz
 aUQ
-bvh
+bvg
 bvo
 aad
 aad
@@ -65877,7 +71505,7 @@ abu
 abj
 aad
 aaV
-abP
+abu
 amG
 anx
 aoq
@@ -65897,7 +71525,7 @@ aBu
 aCy
 aDp
 aEt
-aEt
+sHV
 aGg
 aHn
 aIk
@@ -65917,7 +71545,7 @@ aUU
 aWz
 aVL
 bvg
-bvh
+bvg
 aad
 aad
 aad
@@ -66135,7 +71763,7 @@ abj
 abj
 abu
 abu
-adw
+acF
 anx
 aor
 apv
@@ -66158,8 +71786,8 @@ aFw
 aGk
 aHo
 aIl
-aJv
-aKB
+aLR
+aMU
 aLR
 aMU
 aOa
@@ -66387,25 +72015,25 @@ aad
 aad
 aad
 abi
-ail
+ael
 abj
 abu
 abu
 alG
-adw
+acF
 anx
 aoq
 apw
 aqF
 ary
 asF
-atG
+azm
 auz
 avE
 awI
 axn
 ayi
-azn
+azo
 aAo
 aBw
 aCA
@@ -66430,7 +72058,7 @@ aUS
 aUU
 aWz
 aVL
-bvh
+bvg
 aad
 aad
 aad
@@ -66679,7 +72307,7 @@ aMW
 aMW
 aOD
 buW
-aQQ
+aQK
 aRN
 aSX
 aPL
@@ -66910,7 +72538,7 @@ agE
 abi
 aad
 abi
-awL
+sAy
 arA
 asH
 atI
@@ -66923,7 +72551,7 @@ azp
 aAq
 aBy
 aCC
-aqz
+sGV
 aEt
 aEt
 aGg
@@ -66948,11 +72576,11 @@ bvo
 aOH
 aZo
 baj
-baj
+sKE
 baj
 aZo
 aZo
-baj
+sKM
 baj
 aad
 aad
@@ -67184,12 +72812,12 @@ aDs
 aEx
 aFz
 aGm
-aHs
+aHl
 aIp
-aJx
+aJw
 aKE
 aLU
-aMY
+aOE
 aOb
 aOE
 aLO
@@ -67202,7 +72830,7 @@ aUU
 aWz
 aUQ
 aad
-aOH
+sKx
 aZp
 bak
 bbc
@@ -67210,7 +72838,7 @@ bbQ
 bcF
 bdD
 beu
-baj
+sKS
 aad
 aad
 aad
@@ -67407,7 +73035,7 @@ aac
 aad
 aad
 aad
-aah
+swF
 aad
 aad
 aad
@@ -67444,15 +73072,15 @@ aGn
 aHt
 aIq
 aJy
-aKF
+aJy
 aLV
 aMZ
-aOc
+aMZ
 aOF
 aPM
 aQS
 aRQ
-aSQ
+bxu
 aUa
 aUU
 aUU
@@ -67674,16 +73302,16 @@ afL
 ahu
 agF
 agF
+syh
 agF
 agF
 agF
-agF
-agF
+szn
 agF
 agF
 aqH
 arC
-arC
+sBu
 arC
 auE
 avJ
@@ -67713,7 +73341,7 @@ aTa
 aEt
 bvo
 bvg
-bvh
+bvg
 bvo
 bvo
 aOH
@@ -67928,7 +73556,7 @@ aad
 aad
 abT
 agE
-ahu
+sxc
 aim
 aiR
 ajR
@@ -67956,7 +73584,7 @@ aEA
 aDv
 aDv
 aHv
-aEt
+sIJ
 aJA
 aKH
 aLX
@@ -67964,14 +73592,14 @@ aEt
 aEt
 aOH
 aPO
+sJH
 aQU
 aQU
+sJW
+sKb
 aQU
 aQU
-aQU
-aQU
-aQU
-aQU
+sKo
 aQU
 aQU
 aZs
@@ -68185,7 +73813,7 @@ aad
 aad
 afL
 abj
-ahu
+sxd
 ain
 aiS
 ajS
@@ -68225,16 +73853,16 @@ bxR
 aRS
 aTb
 aUb
-aRS
+sKc
 aVM
 aTb
-aXd
-aQV
 aTb
-aZt
+aTb
+aVM
+aTb
 bao
 bbf
-bbU
+aZA
 bbR
 bdF
 bcK
@@ -68476,7 +74104,7 @@ aKJ
 aLZ
 aNb
 aEt
-aOJ
+bbg
 aPQ
 aQW
 aQW
@@ -68488,7 +74116,7 @@ aQW
 aQW
 aQW
 aQW
-aQW
+sKA
 aQW
 bbg
 aZz
@@ -68694,7 +74322,7 @@ aad
 aad
 abi
 abi
-abT
+swN
 abi
 abT
 acG
@@ -68715,7 +74343,7 @@ asM
 agF
 auI
 avN
-aqz
+sDk
 axw
 ayo
 azv
@@ -68733,7 +74361,7 @@ aKK
 aMa
 aNc
 aEt
-aOK
+bbg
 aPR
 aQW
 aRT
@@ -68748,11 +74376,11 @@ aYw
 aZu
 aQW
 aYA
-aPV
+sKH
 bcK
 bdH
 bex
-baj
+sKT
 aad
 aad
 aad
@@ -68953,8 +74581,8 @@ aaW
 abj
 adv
 ael
-abT
-abP
+swW
+abu
 agF
 ahv
 aiq
@@ -68989,14 +74617,14 @@ aJE
 aKL
 aMb
 aNd
-aEt
+sJz
 aOL
 aPS
-aQW
-aRU
+sJI
+aSc
 aTc
 aUd
-aSa
+sKd
 aVO
 aWB
 aVO
@@ -69007,7 +74635,7 @@ aQW
 bbh
 aPV
 baj
-bca
+sKL
 baj
 aZo
 aad
@@ -69212,7 +74840,7 @@ abu
 acF
 abi
 afN
-agF
+swZ
 ahw
 air
 aiW
@@ -69247,7 +74875,7 @@ aKM
 aMa
 aNe
 aEt
-aOL
+sJE
 aPT
 aQW
 aRV
@@ -69261,7 +74889,7 @@ aXM
 aYy
 aZw
 aQW
-bbi
+bbg
 bbV
 bcL
 bdI
@@ -69465,7 +75093,7 @@ abj
 abj
 abS
 acD
-adw
+acF
 aem
 afb
 adw
@@ -69517,7 +75145,7 @@ aVQ
 aQW
 aQW
 aQW
-aQW
+sKD
 bbj
 bbW
 bcM
@@ -69723,9 +75351,9 @@ abj
 abu
 acE
 adx
-aen
+acF
 adz
-afc
+adw
 agF
 ahy
 ait
@@ -69766,15 +75394,15 @@ aPV
 aQW
 aRX
 aTf
-aUf
+sJX
 aUX
 aVR
 aVQ
 aXg
 aQW
 aYz
-aZx
-aRS
+aTb
+aTb
 bbk
 bbV
 bcN
@@ -69786,7 +75414,7 @@ aad
 aad
 abT
 abT
-abT
+sLl
 abT
 abT
 aad
@@ -69979,12 +75607,12 @@ aad
 aaW
 abu
 acF
-ady
+acF
 aeo
 abi
-afO
+acF
 agF
-agF
+sxe
 agF
 aiZ
 ajZ
@@ -70023,13 +75651,13 @@ aPW
 aQW
 aRY
 aTg
-aUf
+sJY
 bxS
 aVS
 aWE
 aXh
 aQW
-aYA
+bbg
 aZy
 bap
 bap
@@ -70037,10 +75665,10 @@ bbX
 bcO
 bdL
 beB
-baj
+sKU
 bfu
 bfu
-bfu
+sLf
 bfu
 bhZ
 biF
@@ -70237,7 +75865,7 @@ abi
 abi
 acG
 adz
-abT
+swR
 abi
 acF
 agG
@@ -70280,21 +75908,21 @@ aPX
 aQX
 aRZ
 aTh
-aUf
+sJZ
 aUY
 aVT
 aVQ
 aXi
 aQW
-aYB
+bbg
 aZz
 baq
 bbl
 bbY
 bcP
 bdM
-bcQ
-baj
+bcP
+sKV
 bfv
 bfS
 bgB
@@ -70493,13 +76121,13 @@ aad
 aad
 abT
 acH
-acF
+swO
 aep
-afc
 acF
+aem
 agH
 ahA
-agF
+sxB
 ajb
 akb
 ala
@@ -70538,17 +76166,17 @@ aQY
 aSa
 aSa
 aUg
-aUX
+sKe
 aVU
 aWE
 aXj
-aQW
+sKu
 aYC
 aZA
 bar
 bbm
 bbZ
-bcQ
+bcP
 bcP
 bcP
 baj
@@ -70560,7 +76188,7 @@ bib
 biH
 bjh
 bfu
-bfu
+sLp
 bfu
 aac
 aaa
@@ -70751,11 +76379,11 @@ aad
 abT
 abT
 abT
+swS
+swX
 abT
 abT
-abT
-abT
-abT
+sxf
 agF
 ajc
 ajc
@@ -70793,14 +76421,14 @@ aOR
 aPZ
 aQZ
 aSb
-aSb
+sJS
 aUh
 aUZ
 aVV
 aVQ
 aXk
 aQW
-aYD
+bbg
 aPV
 bas
 bbn
@@ -71061,7 +76689,7 @@ aYE
 aZB
 bap
 bap
-bap
+sKI
 bap
 bap
 bap
@@ -71285,7 +76913,7 @@ asT
 atN
 auS
 avX
-awQ
+sDl
 axE
 ayw
 azA
@@ -71296,7 +76924,7 @@ aDD
 aEL
 awQ
 aGz
-aHG
+aGM
 aIB
 aJJ
 aKQ
@@ -71315,13 +76943,13 @@ aWG
 aXl
 aQW
 aYF
-bxU
+bxR
 aRS
-bbo
+aTb
 bcb
 bcS
-bdO
-beD
+aTb
+aVM
 beR
 bfy
 bfT
@@ -71332,7 +76960,7 @@ biG
 bjk
 bjA
 bjL
-bfu
+sLs
 aaa
 aaa
 aaa
@@ -71519,7 +77147,7 @@ aac
 aac
 aad
 aad
-abv
+swG
 acK
 adC
 aes
@@ -71532,7 +77160,7 @@ ajf
 ake
 ald
 abt
-abt
+syS
 abt
 abt
 apI
@@ -71551,7 +77179,7 @@ aBP
 aCO
 aDE
 aEM
-awQ
+sHW
 aGA
 aHH
 aIC
@@ -71564,17 +77192,17 @@ aOU
 aQc
 aRb
 aRb
+sJT
 aRb
 aRb
 aRb
 aRb
-aRb
 aSh
 aSh
 aSh
 aSh
 aSh
-aSh
+sKF
 bcc
 bcT
 bdP
@@ -71586,7 +77214,7 @@ bgE
 bhr
 bif
 biL
-bfu
+sLn
 bfu
 bfu
 bfu
@@ -71826,7 +77454,7 @@ aUk
 aVc
 aVY
 aWH
-aSh
+sKp
 aXO
 aYG
 aZC
@@ -71836,7 +77464,7 @@ aSh
 aSh
 aSh
 aSh
-beT
+bbg
 bfA
 bfu
 bgF
@@ -72049,7 +77677,7 @@ alU
 amP
 abt
 abt
-apI
+sAc
 aqU
 arR
 asW
@@ -72059,7 +77687,7 @@ avZ
 awQ
 awQ
 awQ
-awQ
+sEI
 aAH
 bxK
 awQ
@@ -72067,11 +77695,11 @@ awQ
 awQ
 awQ
 aGC
-aHJ
+aGK
+sIK
 aIB
 aIB
-aIB
-aIB
+sJm
 aIB
 aIB
 aOW
@@ -72093,7 +77721,7 @@ bcd
 bcU
 bdQ
 aSh
-beU
+bbg
 bfA
 bfV
 bgG
@@ -72293,7 +77921,7 @@ abv
 abv
 abv
 abv
-abv
+swT
 afi
 afU
 afU
@@ -72304,7 +77932,7 @@ akh
 alf
 alV
 amQ
-anK
+anJ
 aoD
 apI
 aqV
@@ -72313,7 +77941,7 @@ asX
 atR
 auV
 awa
-awQ
+sDm
 axH
 ayz
 azD
@@ -72322,7 +77950,7 @@ aBQ
 azD
 aDG
 aEO
-awQ
+sHX
 aGD
 aHK
 aIE
@@ -72349,7 +77977,7 @@ aSh
 bce
 bcV
 bdR
-aSh
+sKN
 beV
 bfB
 bfW
@@ -72360,7 +77988,7 @@ biO
 bfu
 bfu
 bfu
-bfu
+sLt
 aaa
 aaa
 aaa
@@ -72562,7 +78190,7 @@ abt
 alW
 amR
 abt
-abt
+szG
 apI
 aqW
 arT
@@ -72587,7 +78215,7 @@ aJM
 aKU
 aMj
 aNo
-aOg
+aJM
 aOY
 aQf
 abt
@@ -72607,7 +78235,7 @@ bcf
 bcW
 blt
 aSh
-beW
+aOL
 bfA
 bfX
 bgI
@@ -72806,12 +78434,12 @@ aad
 abw
 abw
 abw
-abw
+swP
 abw
 abw
 afW
 abw
-abw
+sxg
 abw
 ajk
 akj
@@ -72840,14 +78468,14 @@ awQ
 bxN
 aHM
 aHM
-aHM
+sIS
 aHM
 aHM
 aHM
 aHM
 aOZ
 bxQ
-ayV
+sJJ
 aSh
 aTm
 aUo
@@ -72864,7 +78492,7 @@ bcg
 bcX
 bdS
 aSh
-bbg
+aOL
 bfy
 bfY
 bgJ
@@ -73060,7 +78688,7 @@ aad
 aad
 aad
 aad
-abw
+swC
 abX
 acO
 adG
@@ -73073,12 +78701,12 @@ abw
 ajl
 akk
 alg
-alg
+syC
 alg
 alg
 alg
 apJ
-apJ
+sAz
 apI
 aHF
 atU
@@ -73093,8 +78721,8 @@ aBS
 azD
 ayz
 aEQ
-awQ
-aGF
+sHY
+arY
 aHM
 aIG
 aJN
@@ -73121,7 +78749,7 @@ aUn
 aWb
 bdT
 aSh
-beY
+bbg
 bfA
 bfZ
 bgK
@@ -73357,11 +78985,11 @@ aIH
 aJO
 aKW
 aMl
-aIH
+sJx
 aOh
 aPb
 aQd
-azU
+sJK
 aSi
 aTo
 aUq
@@ -73391,14 +79019,14 @@ aaa
 aaa
 aaa
 bgU
-bkh
+bkj
 bgU
 aae
 aaa
 aaa
 aae
 bgU
-bkh
+bkj
 bgU
 aaa
 aaa
@@ -73588,7 +79216,7 @@ blf
 akm
 ali
 alZ
-amU
+anM
 bxB
 anM
 apL
@@ -73600,16 +79228,16 @@ atc
 awe
 awQ
 awQ
+sEk
 awQ
 awQ
 awQ
-awQ
-awQ
+sGt
 awQ
 awQ
 awQ
 arY
-aHM
+sIB
 aII
 aJP
 aKX
@@ -73642,7 +79270,7 @@ bgM
 bhx
 bin
 biT
-bfu
+sLo
 aae
 aae
 aae
@@ -73853,18 +79481,18 @@ alg
 arX
 atd
 atW
-atd
-atd
+sCr
+aBU
 bxE
-axL
-ayD
-atd
-atd
 aBU
-ayD
-atd
 aBU
-aFM
+atd
+atd
+sFO
+aBU
+sGW
+aBU
+atd
 aGH
 aHM
 aIJ
@@ -73892,7 +79520,7 @@ bci
 bcZ
 bdW
 aSh
-beU
+bbg
 bfA
 bfu
 bfu
@@ -73915,7 +79543,7 @@ bgU
 bkj
 bgU
 bjY
-bgP
+sLv
 bgU
 bgU
 aae
@@ -74103,7 +79731,7 @@ ako
 alj
 amb
 amW
-anO
+amW
 aoH
 apN
 alg
@@ -74113,12 +79741,12 @@ ath
 auZ
 auZ
 auZ
+sDK
 auZ
 auZ
 auZ
 auZ
-auZ
-auZ
+sGu
 auZ
 auZ
 auZ
@@ -74365,7 +79993,7 @@ aoI
 apO
 alg
 arZ
-atf
+sBv
 atX
 ava
 awf
@@ -74406,7 +80034,7 @@ aWK
 bda
 bdX
 aSh
-bfc
+aYF
 bfE
 bdO
 bgO
@@ -74599,11 +80227,11 @@ aaf
 aaa
 aai
 aay
-aak
+sww
 aam
 aak
 abw
-abw
+swH
 abw
 abw
 abw
@@ -74618,10 +80246,10 @@ alg
 amd
 amY
 alg
+szH
 alg
 alg
-alg
-asa
+arY
 atf
 atY
 avb
@@ -74635,7 +80263,7 @@ aBW
 aCQ
 aDK
 aET
-aAL
+sHZ
 aGK
 aHP
 aIM
@@ -74663,7 +80291,7 @@ bcj
 bdb
 bdY
 aSh
-bar
+sKW
 bfF
 aZo
 bgP
@@ -74862,8 +80490,8 @@ abk
 aby
 acd
 acU
-adM
-adM
+aby
+aby
 bxx
 age
 agV
@@ -74888,7 +80516,7 @@ axN
 ayG
 azG
 aAM
-atZ
+sFP
 aCR
 aDL
 aEU
@@ -74903,7 +80531,7 @@ aNv
 aOh
 aPb
 aQg
-aRj
+aRg
 aSn
 aTu
 aUw
@@ -75140,8 +80768,8 @@ ath
 aua
 avd
 awi
-awi
-awi
+sDn
+sDL
 ayH
 azH
 auZ
@@ -75162,7 +80790,7 @@ aPh
 aQk
 aRf
 aRg
-aTv
+aRf
 aRg
 aRf
 aRg
@@ -75177,7 +80805,7 @@ aSh
 aWK
 bea
 beG
-baj
+sKX
 bfH
 baj
 bgQ
@@ -75380,7 +81008,7 @@ aak
 aak
 aak
 aak
-aak
+sxa
 aak
 aak
 ajq
@@ -75390,8 +81018,8 @@ ame
 ame
 abt
 aoL
-apR
-ara
+arY
+sAA
 ara
 ara
 aub
@@ -75407,7 +81035,7 @@ aCT
 aDN
 aAL
 aAL
-apS
+aHF
 aHQ
 aIP
 aJV
@@ -75632,7 +81260,7 @@ aba
 abm
 abB
 acg
-acX
+swJ
 adO
 aez
 afq
@@ -76198,7 +81826,7 @@ aWQ
 abt
 aYc
 aYW
-byo
+sKB
 baI
 bby
 bcn
@@ -76656,9 +82284,9 @@ aal
 aau
 aaG
 aaR
-abc
-abo
-abD
+swx
+swy
+swD
 aci
 adb
 adQ
@@ -76709,7 +82337,7 @@ aUy
 aUy
 aUy
 aWS
-abt
+sKq
 aYe
 aYW
 byo
@@ -76924,7 +82552,7 @@ afr
 afr
 ahc
 ahU
-adQ
+sxC
 ajv
 aky
 alr
@@ -76975,7 +82603,7 @@ byo
 byo
 bdh
 byo
-byo
+sKO
 byo
 bfK
 avV
@@ -77174,7 +82802,7 @@ abe
 abm
 abG
 acl
-acX
+swK
 adO
 aeF
 afs
@@ -77211,7 +82839,7 @@ aHU
 aIQ
 aJX
 aLg
-aAR
+sJn
 ara
 aOr
 aPo
@@ -77432,8 +83060,8 @@ aak
 abA
 acf
 add
-aak
-aak
+swQ
+swU
 aak
 aak
 aak
@@ -77468,9 +83096,9 @@ aCe
 aCe
 aJY
 aLh
-aMv
+aAT
 ayP
-ayV
+sJA
 aPp
 aQt
 blp
@@ -77503,14 +83131,14 @@ aaa
 bjO
 bjZ
 bka
-bkm
+bkb
 bka
 bkb
 bkb
 bkb
 bkb
 bkG
-bkm
+bkb
 bka
 bka
 aaa
@@ -77681,7 +83309,7 @@ aaa
 aaf
 aae
 aae
-aak
+swv
 aaK
 aaT
 abg
@@ -77694,7 +83322,7 @@ aeG
 aft
 agl
 ahe
-ahW
+agl
 abq
 ajy
 akB
@@ -77725,7 +83353,7 @@ aCe
 aIR
 aJZ
 aLh
-aMw
+aso
 ayP
 ayP
 aPq
@@ -77753,7 +83381,7 @@ bgl
 bgX
 bhL
 biA
-bgP
+sLm
 aae
 aae
 aae
@@ -77949,7 +83577,7 @@ adf
 adT
 aeH
 afu
-agm
+acn
 ahf
 ahX
 aiC
@@ -77982,7 +83610,7 @@ aHV
 aIS
 aKa
 aLh
-aMx
+sJo
 aNA
 ayP
 aPr
@@ -78004,12 +83632,12 @@ bct
 bdl
 beg
 beL
-bfi
+aYu
 bfP
 bfP
 bfP
 bfP
-bfP
+sLh
 bfP
 bfP
 bfP
@@ -78201,7 +83829,7 @@ aak
 aaj
 aak
 abs
-abs
+swI
 abs
 abs
 aeI
@@ -78216,10 +83844,10 @@ alu
 amn
 ane
 alu
+szI
 alu
 alu
-alu
-asm
+asp
 atm
 aui
 avn
@@ -78240,7 +83868,7 @@ aIT
 aKb
 aLh
 aCe
-asn
+aso
 ayP
 aPs
 aQv
@@ -78260,8 +83888,8 @@ bbD
 bxV
 bdm
 beh
-beL
-bfj
+sKP
+bfp
 bfP
 blu
 bgY
@@ -78475,7 +84103,7 @@ anf
 anU
 aoW
 aqc
-alu
+sAB
 bxC
 atm
 auj
@@ -78485,7 +84113,7 @@ axb
 ara
 ayQ
 azN
-aAU
+asp
 aCe
 aCY
 aDV
@@ -78497,7 +84125,7 @@ aIU
 aKc
 aLi
 aCe
-asm
+asp
 ayP
 aPt
 aQv
@@ -78518,8 +84146,8 @@ bcv
 bdn
 bei
 beL
-bfk
-bfP
+aTS
+sKZ
 bgn
 bgZ
 bhM
@@ -78527,7 +84155,7 @@ bfP
 bgn
 bgZ
 bhM
-bfP
+sLq
 aad
 aad
 aad
@@ -78991,7 +84619,7 @@ aoX
 aqe
 alu
 asp
-atm
+sBw
 aul
 avq
 awv
@@ -79006,7 +84634,7 @@ aDX
 aFe
 aFW
 aGW
-aCe
+sIC
 aIW
 aKe
 aLk
@@ -79032,7 +84660,7 @@ aZe
 bdp
 aZe
 beL
-bfi
+aYu
 bfP
 bgp
 bhb
@@ -79247,13 +84875,13 @@ anX
 ani
 aqf
 alu
-asp
+sAX
 atn
 aum
 avr
 aww
 aum
-aum
+sDM
 ayT
 azQ
 aAW
@@ -79485,7 +85113,7 @@ aaa
 aae
 aaa
 abs
-abs
+swE
 acs
 adk
 adX
@@ -79504,27 +85132,27 @@ anY
 aoY
 aqg
 alu
-asq
+aMx
 ato
 aun
 avs
 awx
 axe
-axU
+ato
 axe
 azR
 aAX
-axU
-aDb
 axe
-aFg
-avs
+aDb
 ato
-aHX
+aFg
+axe
 avs
+axe
+sIL
 aKf
 ato
-avs
+axe
 aNE
 ayP
 blo
@@ -79749,14 +85377,14 @@ adX
 aeO
 afA
 agt
-abs
+sxb
 aic
 aiG
 ajE
 akI
 alu
 alu
-alu
+syT
 alu
 alu
 alu
@@ -79765,7 +85393,7 @@ abt
 abt
 abt
 abt
-abt
+sCO
 abt
 abt
 abt
@@ -79777,7 +85405,7 @@ abt
 abt
 abt
 abt
-abt
+sID
 abt
 abt
 abt
@@ -79803,7 +85431,7 @@ baa
 bds
 baa
 aZl
-bfi
+aYu
 bfP
 bgs
 bhb
@@ -79998,12 +85626,12 @@ aaa
 aad
 aah
 aad
+swz
 abs
 abs
 abs
 abs
-abs
-abs
+swV
 abs
 abs
 abs
@@ -80043,11 +85671,11 @@ aNF
 ank
 aPw
 aQz
-aVA
-aVA
+sJL
+sJQ
 aTO
 aUH
-aVA
+sKf
 aVA
 aVA
 aXF
@@ -80060,7 +85688,7 @@ bcy
 bdt
 bem
 beO
-bfj
+bfp
 bfP
 bgo
 bhe
@@ -80255,7 +85883,7 @@ aad
 aad
 aad
 aad
-bxZ
+swA
 abL
 acu
 adm
@@ -80264,7 +85892,7 @@ bym
 afB
 agu
 ahj
-adY
+bym
 aiH
 alz
 akK
@@ -80283,7 +85911,7 @@ atp
 arj
 arj
 arj
-arj
+sEJ
 aBa
 aBa
 anl
@@ -80294,7 +85922,7 @@ bsz
 aDZ
 aIY
 aDZ
-aDZ
+sJa
 arj
 arj
 anl
@@ -80327,7 +85955,7 @@ bjb
 bju
 bjH
 bfP
-bfP
+sLu
 aad
 aad
 aad
@@ -80518,10 +86146,10 @@ byi
 adn
 adn
 adn
+swY
 adn
 adn
-adn
-adn
+sxh
 adn
 ajH
 ado
@@ -80545,13 +86173,13 @@ aBb
 aCh
 aDc
 aEa
+sHz
 aFi
-blX
 bsA
 aHY
 aIZ
 blm
-ahZ
+azU
 aMy
 aHY
 aDc
@@ -80559,8 +86187,8 @@ aPy
 aQA
 abt
 aSD
-aTQ
-aUI
+bfp
+sKa
 aVC
 aWt
 aWZ
@@ -80797,26 +86425,26 @@ acx
 axf
 abt
 abt
-abt
+sEK
+sFl
 abt
 abt
 abt
 axW
 blL
-blY
 bsB
 axW
 abt
 abt
-abt
+sJb
 abt
 abt
 abt
 anQ
 anQ
-abt
+sJM
 aSE
-aTR
+bfp
 aUI
 aVD
 aWu
@@ -80824,19 +86452,19 @@ aXa
 aXI
 aYs
 aZj
-bae
+bac
 baY
 bbM
 bxW
 bdw
 bep
 aZl
-bfp
+sKY
 bfP
 bgm
 bhh
 bgm
-bfP
+sLi
 bjd
 bjw
 bjI
@@ -81026,7 +86654,7 @@ aac
 aad
 aad
 aad
-bxZ
+swB
 byg
 byk
 adn
@@ -81034,7 +86662,7 @@ aea
 aeQ
 afD
 agw
-aeV
+ajI
 aid
 aiJ
 agw
@@ -81048,27 +86676,27 @@ aqk
 abt
 ass
 ats
-abt
+sBT
 avw
 awz
 axg
 abt
-aaa
-aaa
-aaa
-aaa
-aaa
+sEl
+sEL
+sFm
+sFQ
+sGv
+sGX
 axW
-blM
-blZ
+sIa
 bsC
-axW
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+sIE
+sIM
+sIT
+sJc
+sJp
+aae
+aae
 aae
 aae
 aRy
@@ -81076,10 +86704,10 @@ aSF
 aTS
 aUJ
 aVE
+sKh
 aVE
 aVE
-aVE
-aVE
+sKv
 aZk
 baf
 baZ
@@ -81087,9 +86715,9 @@ bbN
 bcB
 bdx
 beq
-aZl
-bfo
-bfP
+sKQ
+bfp
+sLa
 bgm
 bhi
 bgm
@@ -81097,7 +86725,7 @@ bfP
 bje
 bjx
 bjI
-bfP
+sLr
 aad
 aad
 aad
@@ -81286,9 +86914,9 @@ aad
 bxZ
 byf
 byl
-adn
-aeb
-aeR
+swL
+aed
+aeT
 afE
 agx
 ahl
@@ -81308,22 +86936,22 @@ att
 abt
 abt
 abt
+sDo
+abt
+atr
+sEM
 abt
 abt
-aaa
-aaa
-aaa
-aaa
-aaa
+abt
+sGY
 axW
-blN
-blZ
+sIb
 bsD
 axW
-aaa
-aaa
-aaa
-aaa
+sIN
+axW
+sJd
+sJq
 aaa
 bte
 aPz
@@ -81333,9 +86961,9 @@ aSG
 aTT
 aUK
 aVF
-aWv
-aXb
 aXJ
+aXb
+aSC
 aYt
 aZl
 bag
@@ -81347,7 +86975,7 @@ ber
 aZl
 bxX
 bfP
-bfP
+sLd
 bfP
 bfP
 bfP
@@ -81541,13 +87169,13 @@ aad
 aad
 aad
 bvg
-bvh
-bvh
+bvg
+bvg
 adn
 aec
 aeS
 afF
-agy
+agx
 ahm
 adp
 aiL
@@ -81559,38 +87187,38 @@ adn
 aoe
 ape
 aqm
-abt
-abN
+sAC
+sAY
 acw
+sBU
+sCs
+sCP
+sDp
+sDN
+sEm
 abt
-aad
-aad
-aad
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+sFn
+sFR
+sGw
+sGZ
 axW
-blO
 bmb
 bsE
 axW
-aaa
-aaa
-aaa
-aaa
-aaa
+aae
+sIU
+sJe
+sJr
+aae
 bte
 aPA
 aQB
 aRz
-aSH
-aRz
+sJR
+sJU
 aSH
 aVG
-aSH
+sKi
 aRz
 aSH
 aYu
@@ -81598,7 +87226,7 @@ aZm
 bah
 bah
 bah
-bah
+sKJ
 bah
 bah
 beQ
@@ -81818,26 +87446,26 @@ apf
 aqn
 abt
 abO
-atv
-abt
-aad
-aad
-aad
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-azb
-blM
-blZ
-bsC
-azb
-aaa
-aaa
-aaa
-aaa
+atr
+sBV
+sCt
+sCQ
+sDq
+sDO
+sEn
+sEN
+sFo
+sFS
+sGx
+sHa
+axW
+sIc
+sIv
+sIF
+sIO
+sIV
+sJf
+sJs
 aaa
 bte
 aPB
@@ -81851,14 +87479,14 @@ aWw
 aRz
 aXK
 aYv
-aZn
-bai
-bbb
-bbP
 aXb
-bdz
+bai
 aXJ
-aZn
+bbP
+aUK
+bdz
+aXb
+aXJ
 bfr
 aSH
 bgv
@@ -82072,30 +87700,30 @@ amA
 ano
 aog
 apg
-aqo
+aqk
 abt
 abN
 acy
 abt
-aad
-aac
-aac
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-azb
-blM
+sCu
+abt
+abt
+abt
+abt
+abt
+sFp
+sFT
+sGy
+sHb
+axW
 bxM
 bsC
-azb
-aaa
-aaa
-aaa
-aaa
-aaa
+axW
+aae
+sIW
+sJg
+sJt
+aae
 bte
 aPC
 aQD
@@ -82106,20 +87734,20 @@ aUM
 aVI
 aWx
 aRz
+sKr
+aRz
+sKy
 aRz
 aRz
-aRz
-aRz
-aRz
-aRz
+sKG
 aSH
 bdA
 aRz
 aRz
-bfq
-aRz
+bfp
+sLb
 bgw
-bhl
+bhk
 bhV
 aRy
 bvg
@@ -82316,9 +87944,9 @@ aad
 aad
 ado
 aed
-aeV
+ajI
 afI
-aeV
+ajI
 ahp
 adn
 aiO
@@ -82332,26 +87960,26 @@ aph
 aqp
 abt
 bvh
-bvh
-bvg
-aac
-aac
-aae
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-azb
+sBx
+abt
+aad
+aad
+aah
+aad
+aad
+sEO
+sFq
+sFU
+abt
+sHc
+sHA
 blM
-blZ
-bsC
-azb
-aaa
-aaa
-aaa
-aaa
+sIw
+axW
+axW
+sIX
+sJh
+sJu
 aaa
 bte
 aPz
@@ -82374,11 +88002,11 @@ bdB
 bes
 aRz
 bfs
-aRA
+sLc
 bgx
 bhm
 bhW
-aRz
+sLj
 aac
 aaa
 aaa
@@ -82571,15 +88199,15 @@ aaa
 aaa
 aaa
 aac
-adp
-aef
-aeW
+swM
+aeh
+agB
 ado
 agB
 ahq
 adp
 ado
-adn
+sxV
 ado
 adn
 amC
@@ -82589,37 +88217,37 @@ api
 amD
 amC
 amC
-bvg
+sBy
+sBW
+aad
 aac
-aae
-aae
-aae
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-azb
-blM
-blZ
+bvg
+aad
+aad
+sEP
+abt
+abt
+sGz
+sHd
+axW
+bxM
 bsC
-azb
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+sIG
+axW
+sIY
+sJi
+axW
 aae
 aae
-aRz
+aae
+aae
+sJN
 aRy
 aRy
 aRy
 aRy
 aRy
-aRz
+sKl
 aad
 aac
 aad
@@ -82839,37 +88467,37 @@ aae
 aae
 aae
 aae
-amC
+syD
 anq
 aoi
 apj
 aqq
 ark
 amC
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+bvg
+bvg
+aac
+aac
+aae
+aac
+aad
+abt
+sFr
+sFV
+sGA
+sHe
 axW
 blO
-blZ
 bsJ
 axW
 axW
+sIZ
+sJj
 axW
-axW
-axW
-aaa
-aaa
-aaa
-aaa
+aae
+aaf
+aaf
+aae
 aaa
 aaa
 aaa
@@ -82883,15 +88511,15 @@ aac
 aac
 aad
 aRz
+sKK
 aRz
 aRz
-aRz
-aRz
+sKR
 aRz
 aRz
 bgz
 bhk
-bgw
+sLg
 aRy
 bvg
 aac
@@ -83087,9 +88715,9 @@ aaa
 aaa
 ado
 aeh
-aeW
+agB
 ado
-aeW
+agB
 ahq
 ado
 aaa
@@ -83103,27 +88731,27 @@ apk
 aqr
 arl
 amC
+bvg
+aac
+aac
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+aae
+aac
+aac
+sEQ
 axW
-blU
+sFW
+sGB
+axW
+axW
 bmh
-bsC
-bmw
-blZ
+sIx
+aKh
+sIP
 bmC
 bmG
 axW
-aaa
+aae
 aaa
 aaa
 aaa
@@ -83149,7 +88777,7 @@ aRz
 bgA
 bhn
 bhY
-aRz
+sLk
 aad
 aac
 aac
@@ -83359,31 +88987,31 @@ aok
 apl
 aqs
 arm
-amC
+sAZ
+aac
 aaa
 aaa
 aaa
+aae
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-axW
+aac
+bvg
+sFs
+sFX
+sGC
+sHf
+sHB
 blM
+sIy
 blZ
-bsC
+sIQ
 blZ
-blZ
-blZ
-blZ
-axW
+sJk
+sJv
+aae
 aaa
-aaa
-aaa
-aaa
+aaf
+aaf
 aaa
 aaa
 aaa
@@ -83403,7 +89031,7 @@ aac
 aad
 aad
 aRz
-aRz
+sLe
 aRz
 aRz
 aRz
@@ -83599,8 +89227,8 @@ aaa
 aaa
 abQ
 acz
-adr
-adr
+afa
+afa
 afa
 afK
 afa
@@ -83621,26 +89249,26 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-axW
-blM
-blZ
+aae
+aae
+bvg
+bvg
+sFt
+sFY
+sGD
+sHg
+sHC
+sId
 bsM
 bsS
-bsS
+sIR
 bsS
 bsY
 axW
-aaa
-aaa
-aaa
-aaa
+aae
+aae
+aae
+aaf
 aaa
 aaa
 aaa
@@ -83861,9 +89489,9 @@ aej
 ads
 ads
 ads
-adt
-aih
-aiP
+ads
+aii
+aiQ
 ajN
 akR
 aaa
@@ -83874,21 +89502,21 @@ apn
 aqu
 amD
 aae
-aaa
-aaa
-aaa
-aaa
-aaa
+aae
+aaf
+aaf
+aae
+aae
 axW
-axW
+sEo
 azb
 axW
 axW
 axW
 azb
-aFj
-aFZ
-bsN
+blL
+blY
+bsB
 azb
 axW
 aKh
@@ -83896,8 +89524,8 @@ bsZ
 azb
 axW
 axW
-aaa
-aaa
+aae
+aaf
 aaa
 aaa
 aaa
@@ -84113,21 +89741,21 @@ aaa
 aaa
 abQ
 buy
-adt
-adt
-adt
 ads
-adt
+ads
+ads
+ads
+ads
 ads
 aii
-aiP
-ajO
+aiQ
+ajN
 akR
 aaa
 aae
 ant
 aom
-apo
+apn
 aqv
 ant
 aae
@@ -84135,7 +89763,7 @@ aaa
 aaa
 aaa
 aaa
-aaa
+aae
 axW
 ayW
 azV
@@ -84144,7 +89772,7 @@ aCi
 aDd
 aEb
 aFk
-aDh
+sIe
 bsO
 aHZ
 aJa
@@ -84153,8 +89781,8 @@ bta
 aMz
 aNG
 azb
-aaa
-aaa
+aae
+aaf
 aaa
 aaa
 aaa
@@ -84369,8 +89997,8 @@ aaa
 aaa
 aaa
 abQ
-acB
-adt
+acA
+ads
 ads
 ads
 ads
@@ -84378,7 +90006,7 @@ ads
 ads
 aii
 aiQ
-ajO
+ajN
 akR
 aaa
 aaa
@@ -84391,8 +90019,8 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
+aaf
+aae
 axW
 ayX
 azW
@@ -84410,7 +90038,7 @@ btb
 aIa
 aNH
 axW
-aaa
+aae
 aaa
 aaa
 aaa
@@ -84627,12 +90255,12 @@ aaa
 aaa
 abQ
 acC
-adu
 aek
-adu
+aek
+aek
 buz
 aek
-adu
+aek
 aij
 abQ
 abQ
@@ -84648,8 +90276,8 @@ amE
 aaa
 aaa
 aaa
-aaa
-aaa
+aaf
+aae
 axW
 ayY
 azX
@@ -84666,8 +90294,8 @@ aKj
 btc
 aMA
 aNI
-axW
-aaa
+sJB
+aae
 aaa
 aaa
 aaa
@@ -84898,15 +90526,15 @@ aaa
 amE
 anu
 aon
-apq
+aon
 aqw
 arn
 amE
 aaa
 aaa
 aaa
-aaa
-aaa
+aaf
+aae
 axW
 ayZ
 azY
@@ -84923,9 +90551,9 @@ bsX
 btd
 aMB
 aNJ
-axW
-aaa
-aaa
+sJC
+aae
+aaf
 aaa
 aaa
 aaa
@@ -85163,7 +90791,7 @@ aaa
 aaa
 aaa
 aaa
-aaa
+aae
 axW
 aza
 azZ
@@ -85181,8 +90809,8 @@ aLt
 aMC
 aNK
 axW
-aaa
-aaa
+aae
+aaf
 aaa
 aaa
 aaa
@@ -85419,9 +91047,9 @@ amE
 aaa
 aaa
 aaa
-aaa
-aaa
-axW
+aaf
+aae
+sDP
 azb
 azb
 aBh
@@ -85438,8 +91066,8 @@ aDi
 azb
 azb
 axW
-aaa
-aaa
+aae
+aaf
 aaa
 aaa
 aaa
@@ -85676,26 +91304,26 @@ amE
 aaa
 aaa
 aaa
-aaa
-aaa
-aae
-aae
-azb
-aBi
-azb
-aBi
-azb
+aaf
 aae
 aae
 aae
 azb
-aBi
+aDh
 azb
-aLu
+aDh
 azb
 aae
 aae
-aaa
+aae
+azb
+aDh
+azb
+aDh
+azb
+aae
+aae
+aae
 aaa
 aaa
 aaa
@@ -85948,7 +91576,7 @@ aaa
 azb
 aDi
 azb
-aLv
+aDi
 azb
 aaa
 aaa
@@ -86980,7 +92608,7 @@ aLx
 aMF
 aNN
 axY
-aPF
+aPE
 aQE
 aaa
 aaa
@@ -87237,7 +92865,7 @@ aLy
 aMG
 aNO
 axX
-aPF
+aPE
 aQE
 aaa
 aaa
@@ -87751,7 +93379,7 @@ aLA
 aMH
 aNP
 axX
-aPF
+aPE
 aQE
 aaa
 aaa
@@ -88008,7 +93636,7 @@ aLB
 aLB
 aNQ
 axY
-aPF
+aPE
 aQE
 aaa
 aaa
@@ -88265,7 +93893,7 @@ aLB
 aLB
 aNR
 axY
-aPF
+aPE
 aQE
 aaa
 aaa
@@ -90544,32 +96172,32 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+sxi
+sxD
+sxW
+syi
+sys
+syE
+syU
+szo
+szJ
+sAd
+sAD
+sBa
+sBz
+sBX
+sCv
+sCR
+sDr
+sDQ
+sEp
+sER
+sFu
+sFZ
+sGE
+sHh
+sHD
+sIf
 aaa
 aaa
 aaa
@@ -90801,32 +96429,32 @@ aaa
 aaa
 aaa
 aaa
+sxj
+sxE
+sxX
+syj
+syt
+syF
+syV
+szp
+szK
+sAe
+sAE
+sBb
+sBA
+sBY
+sCw
+sCS
+sDs
+sDR
+sEq
+sES
+sFv
+sGa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+sHi
+sHE
+sIg
 aaa
 aaa
 aaa
@@ -91058,32 +96686,32 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+sxk
+sxF
+sxY
+syk
+syu
+syG
+syW
+szq
+szL
+sAf
+sAF
+sBc
+sBB
+sBZ
+sCx
+sCT
+sDt
+sDS
+sEr
+sET
+sFw
+sGb
+sGF
+sHj
+sHF
+sIh
 aaa
 aaa
 aaa
@@ -91315,32 +96943,32 @@ aaa
 aaa
 aaa
 aaa
+sxl
+sxG
+sxZ
+syl
+syv
+syH
+syX
+szr
+szM
+sAg
+sAG
+sBd
+sBC
+sCa
+sCy
+sCU
+sDu
+sDT
 aaa
+sEU
+sFx
+sGc
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+sHk
+sHG
+sIi
 aaa
 aaa
 aaa
@@ -91572,32 +97200,32 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+sxm
+sxH
+sya
+sym
+syw
+syI
+syY
+szs
+szN
+sAh
+sAH
+sBe
+sBD
+sCb
+sCz
+sCV
+sDv
+sDU
+sEs
+sEV
+sFy
+sGd
+sGG
+sHl
+sHH
+sIj
 aaa
 aaa
 aaa
@@ -91829,32 +97457,32 @@ aaa
 aaa
 aaa
 aaa
+sxn
+sxI
+syb
+syn
+syx
+syJ
+syZ
+szt
+szO
+sAi
+sAI
+sBf
+sBE
+sCc
+sCA
+sCW
+sDw
+sDV
+sEt
+sEW
+sFz
+sGe
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+sHm
+sHI
+sIk
 aaa
 aaa
 aaa
@@ -92086,32 +97714,32 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+sxo
+sxJ
+syc
+syo
+syy
+syK
+sza
+szu
+szP
+sAj
+sAJ
+sBg
+sBF
+sCd
+sCB
+sCX
+sDx
+sDW
+sEu
+sEX
+sFA
+sGf
+sGH
+sHn
+sHJ
+sIl
 aaa
 aaa
 aaa
@@ -92343,32 +97971,32 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+sxp
+sxK
+syd
+syp
+syz
+syL
+szb
+szv
+szQ
+sAk
+sAK
+sBh
+sBG
+sCe
+sCC
+sCY
+sDy
+sDX
+sEv
+sEY
+sFB
+sGg
+sGI
+sHo
+sHK
+sIm
 aaa
 aaa
 aaa
@@ -92600,29 +98228,29 @@ aaa
 aaa
 aaa
 aaa
+sxq
+sxL
+sye
+syq
+syA
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+szc
+szw
+szR
+sAl
+sAL
+sBi
+sBH
+sCf
+sCD
+sCZ
+sDz
+sDY
+sEw
+sEZ
+sFC
+sGh
+sGJ
 aaa
 aaa
 aaa
@@ -92857,32 +98485,32 @@ aaa
 aaa
 aaa
 aaa
+sxr
+sxM
+syf
 aaa
 aaa
 aaa
+szd
 aaa
+szS
+sAm
+sAM
+sBj
+sBI
+sCg
+sCE
+sDa
+sDA
+sDZ
+sEx
+sFa
+sFD
+sGi
+sGK
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+sHL
+sIn
 aaa
 aaa
 aaa
@@ -93114,32 +98742,32 @@ aaa
 aaa
 aaa
 aaa
+sxs
+sxN
 aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+sze
+szx
+szT
+sAn
+sAN
+sBk
+sBJ
+sCh
+sCF
+sDb
+sDB
+sEa
+sEy
+sFb
+sFE
+sGj
+sGL
+sHp
+sHM
+sIo
 aaa
 aaa
 aaa
@@ -93371,32 +98999,32 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+sxt
+sxO
+syg
+syr
+syB
+syM
+szf
+szy
+szU
+sAo
+sAO
+sBl
+sBK
+sCi
+sCG
+sDc
+sDC
+sEb
+sEz
+sFc
+sFF
+sGk
+sGM
+sHq
+sHN
+sIp
 aaa
 aaa
 aaa
@@ -93628,32 +99256,32 @@ aaa
 aaa
 aaa
 aaa
+sxu
+sxP
 aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+szg
+szz
+szV
+sAp
+sAP
+sBm
+sBL
+sCj
+sCH
+sDd
+sDD
+sEc
+sEA
+sFd
+sFG
+sGl
+sGN
+sHr
+sHO
+sIq
 aaa
 aaa
 aaa
@@ -93885,31 +99513,31 @@ aaa
 aaa
 aaa
 aaa
+sxv
 aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+syN
+szh
+szA
+szW
+sAq
+sAQ
+sBn
+sBM
+sCk
+sCI
+sDe
+sDE
+sEd
+sEB
+sFe
+sFH
+sGm
+sGO
+sHs
+sHP
 aaa
 aaa
 aaa
@@ -94142,31 +99770,31 @@ aaa
 aaa
 aaa
 aaa
+sxw
+sxQ
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+syO
+szi
+szB
+szX
+sAr
+sAR
+sBo
+sBN
+sCl
+sCJ
+sDf
+sDF
+sEe
+sEC
+sFf
+sFI
+sGn
+sGP
+sHt
+sHQ
 aaa
 aaa
 aaa
@@ -94399,32 +100027,32 @@ aaa
 aaa
 aaa
 aaa
+sxx
+sxR
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+syP
+szj
+szC
+szY
+sAs
+sAS
+sBp
+sBO
+sCm
+sCK
+sDg
+sDG
+sEf
+sED
+sFg
+sFJ
+sGo
+sGQ
+sHu
+sHR
+sIr
 aaa
 aaa
 aaa
@@ -94656,32 +100284,32 @@ aaa
 aaa
 aaa
 aaa
+sxy
+sxS
 aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+szk
+szD
+szZ
+sAt
+sAT
+sBq
+sBP
+sCn
+sCL
+sDh
+sDH
+sEg
+sEE
+sFh
+sFK
+sGp
+sGR
+sHv
+sHS
+sIs
 aaa
 aaa
 aaa
@@ -94913,32 +100541,32 @@ aaa
 aaa
 aaa
 aaa
+sxz
+sxT
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+syQ
+szl
+szE
+sAa
+sAu
+sAU
+sBr
+sBQ
+sCo
+sCM
+sDi
+sDI
+sEh
+sEF
+sFi
+sFL
+sGq
+sGS
+sHw
+sHT
+sIt
 aaa
 aaa
 aaa
@@ -95170,31 +100798,31 @@ aaa
 aaa
 aaa
 aaa
+sxA
+sxU
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+syR
+szm
+szF
+sAb
+sAv
+sAV
+sBs
+sBR
+sCp
+sCN
+sDj
+sDJ
+sEi
+sEG
+sFj
+sFM
+sGr
+sGT
+sHx
+sHU
 aaa
 aaa
 aaa
@@ -95436,19 +101064,19 @@ aaa
 aaa
 aaa
 aaa
+sAw
+sAW
+sBt
+sBS
+sCq
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+sEj
+sEH
+sFk
+sFN
+sGs
 aaa
 aaa
 aaa

--- a/_maps/map_files/OmegaStation/OmegaStation.dmm
+++ b/_maps/map_files/OmegaStation/OmegaStation.dmm
@@ -487,8 +487,6 @@
 	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel/vault/side{
-	tag = "icon-vault (NORTH)";
-	icon_state = "vault";
 	dir = 1
 	},
 /area/bridge)
@@ -500,8 +498,6 @@
 	dir = 6
 	},
 /turf/open/floor/plasteel/vault/side{
-	tag = "icon-vault (NORTH)";
-	icon_state = "vault";
 	dir = 1
 	},
 /area/bridge)
@@ -523,8 +519,6 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel/vault/side{
-	tag = "icon-vault (NORTH)";
-	icon_state = "vault";
 	dir = 1
 	},
 /area/bridge)
@@ -534,8 +528,6 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden,
 /turf/open/floor/plasteel/vault/side{
-	tag = "icon-vault (NORTH)";
-	icon_state = "vault";
 	dir = 1
 	},
 /area/bridge)
@@ -550,8 +542,6 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel/vault/side{
-	tag = "icon-vault (NORTHEAST)";
-	icon_state = "vault";
 	dir = 5
 	},
 /area/bridge)
@@ -584,8 +574,6 @@
 	dir = 1
 	},
 /turf/open/floor/plasteel/vault/side{
-	tag = "icon-vault (NORTH)";
-	icon_state = "vault";
 	dir = 1
 	},
 /area/bridge)
@@ -603,8 +591,6 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel/vault/side{
-	tag = "icon-vault (NORTH)";
-	icon_state = "vault";
 	dir = 1
 	},
 /area/bridge)
@@ -617,8 +603,6 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plasteel/vault/side{
-	tag = "icon-vault (NORTH)";
-	icon_state = "vault";
 	dir = 1
 	},
 /area/bridge)
@@ -636,8 +620,6 @@
 	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel/vault/side{
-	tag = "icon-vault (NORTH)";
-	icon_state = "vault";
 	dir = 1
 	},
 /area/bridge)
@@ -710,8 +692,6 @@
 /area/bridge)
 "abo" = (
 /turf/open/floor/plasteel/vault/side{
-	tag = "icon-vault (EAST)";
-	icon_state = "vault";
 	dir = 4
 	},
 /area/bridge)
@@ -798,8 +778,6 @@
 	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel/vault/side{
-	tag = "icon-vault (WEST)";
-	icon_state = "vault";
 	dir = 8
 	},
 /area/bridge)
@@ -809,8 +787,6 @@
 	pixel_x = 24
 	},
 /turf/open/floor/plasteel/vault/side{
-	tag = "icon-vault (EAST)";
-	icon_state = "vault";
 	dir = 4
 	},
 /area/bridge)
@@ -829,8 +805,6 @@
 	dir = 1
 	},
 /turf/open/floor/plasteel/vault/side{
-	tag = "icon-vault (EAST)";
-	icon_state = "vault";
 	dir = 4
 	},
 /area/bridge)
@@ -852,8 +826,6 @@
 	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel/vault/side{
-	tag = "icon-vault (EAST)";
-	icon_state = "vault";
 	dir = 4
 	},
 /area/bridge)
@@ -896,8 +868,6 @@
 	dir = 1
 	},
 /turf/open/floor/plasteel/vault/side{
-	tag = "icon-vault (WEST)";
-	icon_state = "vault";
 	dir = 8
 	},
 /area/bridge)
@@ -907,8 +877,6 @@
 	pixel_x = -24
 	},
 /turf/open/floor/plasteel/vault/side{
-	tag = "icon-vault (WEST)";
-	icon_state = "vault";
 	dir = 8
 	},
 /area/bridge)
@@ -921,8 +889,6 @@
 	pixel_x = 26
 	},
 /turf/open/floor/plasteel/vault/side{
-	tag = "icon-vault (EAST)";
-	icon_state = "vault";
 	dir = 4
 	},
 /area/bridge)
@@ -1124,8 +1090,6 @@
 	dir = 8
 	},
 /turf/open/floor/plasteel/vault/side{
-	tag = "icon-vault (WEST)";
-	icon_state = "vault";
 	dir = 8
 	},
 /area/bridge)
@@ -1135,8 +1099,6 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel/vault/side{
-	tag = "icon-vault (EAST)";
-	icon_state = "vault";
 	dir = 4
 	},
 /area/bridge)
@@ -1156,8 +1118,6 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel/vault/side{
-	tag = "icon-vault (EAST)";
-	icon_state = "vault";
 	dir = 4
 	},
 /area/bridge)
@@ -1200,8 +1160,6 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel/vault/side{
-	tag = "icon-vault (WEST)";
-	icon_state = "vault";
 	dir = 8
 	},
 /area/bridge)
@@ -1210,8 +1168,6 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel/vault/side{
-	tag = "icon-vault (WEST)";
-	icon_state = "vault";
 	dir = 8
 	},
 /area/bridge)
@@ -1221,8 +1177,6 @@
 	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel/vault/side{
-	tag = "icon-vault (EAST)";
-	icon_state = "vault";
 	dir = 4
 	},
 /area/bridge)
@@ -1246,8 +1200,6 @@
 	name = "command camera"
 	},
 /turf/open/floor/plasteel/vault/side{
-	tag = "icon-vault (EAST)";
-	icon_state = "vault";
 	dir = 4
 	},
 /area/crew_quarters/heads/hop)
@@ -1321,8 +1273,6 @@
 /area/hallway/primary/central)
 "acw" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	tag = "icon-manifold (NORTH)";
-	icon_state = "manifold";
 	dir = 1
 	},
 /turf/open/floor/plating,
@@ -1545,8 +1495,6 @@
 	icon_state = "2-4"
 	},
 /turf/open/floor/plasteel/vault/side{
-	tag = "icon-vault (WEST)";
-	icon_state = "vault";
 	dir = 8
 	},
 /area/bridge)
@@ -1556,8 +1504,6 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold4w/scrubbers/hidden,
 /turf/open/floor/plasteel/vault/side{
-	tag = "icon-vault (EAST)";
-	icon_state = "vault";
 	dir = 4
 	},
 /area/bridge)
@@ -1592,8 +1538,6 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel/vault/side{
-	tag = "icon-vault (NORTH)";
-	icon_state = "vault";
 	dir = 1
 	},
 /area/bridge)
@@ -1697,8 +1641,6 @@
 	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel/vault/side{
-	tag = "icon-vault (WEST)";
-	icon_state = "vault";
 	dir = 8
 	},
 /area/bridge)
@@ -1713,8 +1655,6 @@
 	icon_state = "2-8"
 	},
 /turf/open/floor/plasteel/vault/side{
-	tag = "icon-vault (EAST)";
-	icon_state = "vault";
 	dir = 4
 	},
 /area/bridge)
@@ -1729,8 +1669,6 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plasteel/vault/side{
-	tag = "icon-vault (EAST)";
-	icon_state = "vault";
 	dir = 4
 	},
 /area/crew_quarters/heads/hop)
@@ -1809,7 +1747,7 @@
 	pixel_x = 26
 	},
 /turf/open/floor/plating{
-	tag = "icon-platingdmg2";
+	broken = 1;
 	icon_state = "platingdmg2"
 	},
 /area/maintenance/starboard/fore)
@@ -1940,6 +1878,7 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on,
 /obj/effect/landmark/xeno_spawn,
 /turf/open/floor/plating{
+	broken = 1;
 	icon_state = "platingdmg1"
 	},
 /area/maintenance/fore)
@@ -1999,6 +1938,7 @@
 	dir = 1
 	},
 /turf/open/floor/wood{
+	broken = 1;
 	icon_state = "wood-broken"
 	},
 /area/crew_quarters/heads/captain/private)
@@ -2045,8 +1985,6 @@
 	pixel_x = 28
 	},
 /turf/open/floor/plasteel/vault/side{
-	tag = "icon-vault (EAST)";
-	icon_state = "vault";
 	dir = 4
 	},
 /area/bridge)
@@ -2089,8 +2027,6 @@
 	pixel_x = -32
 	},
 /turf/open/floor/plasteel/vault/side{
-	tag = "icon-vault (WEST)";
-	icon_state = "vault";
 	dir = 8
 	},
 /area/bridge)
@@ -2102,8 +2038,6 @@
 	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel/vault/side{
-	tag = "icon-vault (EAST)";
-	icon_state = "vault";
 	dir = 4
 	},
 /area/bridge)
@@ -2335,7 +2269,7 @@
 "aep" = (
 /turf/open/floor/plating,
 /turf/open/floor/plating{
-	tag = "icon-platingdmg2";
+	broken = 1;
 	icon_state = "platingdmg2"
 	},
 /area/ruin/unpowered{
@@ -2429,8 +2363,6 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel/vault/side{
-	tag = "icon-vault (EAST)";
-	icon_state = "vault";
 	dir = 4
 	},
 /area/bridge)
@@ -2457,8 +2389,6 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel/vault/side{
-	tag = "icon-vault (EAST)";
-	icon_state = "vault";
 	dir = 4
 	},
 /area/ai_monitored/turret_protected/ai)
@@ -2594,8 +2524,6 @@
 	dir = 8
 	},
 /turf/open/floor/plasteel/vault/side{
-	tag = "icon-vault (WEST)";
-	icon_state = "vault";
 	dir = 8
 	},
 /area/ai_monitored/turret_protected/ai)
@@ -2608,8 +2536,6 @@
 	pixel_x = -32
 	},
 /turf/open/floor/plasteel/vault/side{
-	tag = "icon-vault (WEST)";
-	icon_state = "vault";
 	dir = 8
 	},
 /area/bridge)
@@ -2621,8 +2547,6 @@
 	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel/vault/side{
-	tag = "icon-vault (EAST)";
-	icon_state = "vault";
 	dir = 4
 	},
 /area/bridge)
@@ -2698,8 +2622,6 @@
 	pixel_y = 24
 	},
 /turf/open/floor/plasteel/vault/corner{
-	tag = "icon-vaultcorner (WEST)";
-	icon_state = "vaultcorner";
 	dir = 8
 	},
 /area/crew_quarters/heads/hop)
@@ -2801,8 +2723,6 @@
 /obj/item/device/taperecorder,
 /obj/item/restraints/handcuffs,
 /turf/open/floor/plasteel/vault/side{
-	tag = "icon-vault (EAST)";
-	icon_state = "vault";
 	dir = 4
 	},
 /area/security/detectives_office)
@@ -2876,8 +2796,6 @@
 /obj/machinery/suit_storage_unit/captain,
 /obj/effect/turf_decal/stripes/end,
 /turf/open/floor/plasteel/vault/side{
-	tag = "icon-vault (EAST)";
-	icon_state = "vault";
 	dir = 4
 	},
 /area/crew_quarters/heads/captain/private)
@@ -2923,6 +2841,7 @@
 	dir = 8
 	},
 /turf/open/floor/wood{
+	broken = 1;
 	icon_state = "wood-broken2"
 	},
 /area/crew_quarters/heads/captain/private)
@@ -2930,7 +2849,6 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/machinery/firealarm{
 	dir = 4;
-	icon_state = "fire0";
 	pixel_x = 24
 	},
 /obj/machinery/camera{
@@ -2939,8 +2857,6 @@
 	name = "command camera"
 	},
 /turf/open/floor/plasteel/vault/side{
-	tag = "icon-vault (EAST)";
-	icon_state = "vault";
 	dir = 4
 	},
 /area/bridge)
@@ -2968,8 +2884,6 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel/vault/side{
-	tag = "icon-vault (EAST)";
-	icon_state = "vault";
 	dir = 4
 	},
 /area/ai_monitored/turret_protected/ai)
@@ -3000,8 +2914,6 @@
 	dir = 8
 	},
 /turf/open/floor/plasteel/vault/side{
-	tag = "icon-vault (WEST)";
-	icon_state = "vault";
 	dir = 8
 	},
 /area/ai_monitored/turret_protected/ai)
@@ -3019,8 +2931,6 @@
 	name = "command camera"
 	},
 /turf/open/floor/plasteel/vault/side{
-	tag = "icon-vault (WEST)";
-	icon_state = "vault";
 	dir = 8
 	},
 /area/bridge)
@@ -3036,8 +2946,6 @@
 	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel/vault/side{
-	tag = "icon-vault (EAST)";
-	icon_state = "vault";
 	dir = 4
 	},
 /area/bridge)
@@ -3089,6 +2997,7 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden,
 /turf/open/floor/wood{
+	broken = 1;
 	icon_state = "wood-broken"
 	},
 /area/crew_quarters/heads/hop)
@@ -3135,8 +3044,6 @@
 	name = "command camera"
 	},
 /turf/open/floor/plasteel/vault/side{
-	tag = "icon-vault (WEST)";
-	icon_state = "vault";
 	dir = 8
 	},
 /area/crew_quarters/heads/hop)
@@ -3260,8 +3167,6 @@
 	pixel_x = -26
 	},
 /turf/open/floor/plasteel/vault/side{
-	tag = "icon-vault (EAST)";
-	icon_state = "vault";
 	dir = 4
 	},
 /area/security/detectives_office)
@@ -3343,8 +3248,6 @@
 	},
 /obj/effect/turf_decal/delivery,
 /turf/open/floor/plasteel/vault/side{
-	tag = "icon-vault (EAST)";
-	icon_state = "vault";
 	dir = 4
 	},
 /area/crew_quarters/heads/captain/private)
@@ -3413,8 +3316,6 @@
 	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel/vault/side{
-	tag = "icon-vault (WEST)";
-	icon_state = "vault";
 	dir = 8
 	},
 /area/bridge)
@@ -3423,8 +3324,6 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel/vault/side{
-	tag = "icon-vault (EAST)";
-	icon_state = "vault";
 	dir = 4
 	},
 /area/bridge)
@@ -3457,8 +3356,6 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel/vault/side{
-	tag = "icon-vault (EAST)";
-	icon_state = "vault";
 	dir = 4
 	},
 /area/ai_monitored/turret_protected/ai)
@@ -3500,16 +3397,12 @@
 	dir = 8
 	},
 /turf/open/floor/plasteel/vault/side{
-	tag = "icon-vault (WEST)";
-	icon_state = "vault";
 	dir = 8
 	},
 /area/ai_monitored/turret_protected/ai)
 "agl" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plasteel/vault/side{
-	tag = "icon-vault (WEST)";
-	icon_state = "vault";
 	dir = 8
 	},
 /area/bridge)
@@ -3568,6 +3461,7 @@
 	dir = 1
 	},
 /turf/open/floor/wood{
+	broken = 1;
 	icon_state = "wood-broken5"
 	},
 /area/crew_quarters/heads/hop)
@@ -3579,6 +3473,7 @@
 	},
 /obj/effect/landmark/start/head_of_personnel,
 /turf/open/floor/wood{
+	broken = 1;
 	icon_state = "wood-broken6"
 	},
 /area/crew_quarters/heads/hop)
@@ -3608,8 +3503,6 @@
 	req_access_txt = "57"
 	},
 /turf/open/floor/plasteel/vault/side{
-	tag = "icon-vault (WEST)";
-	icon_state = "vault";
 	dir = 8
 	},
 /area/crew_quarters/heads/hop)
@@ -3743,8 +3636,6 @@
 	dir = 8
 	},
 /turf/open/floor/plasteel/vault/side{
-	tag = "icon-vault (EAST)";
-	icon_state = "vault";
 	dir = 4
 	},
 /area/security/detectives_office)
@@ -3794,7 +3685,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plating{
-	tag = "icon-platingdmg2";
+	broken = 1;
 	icon_state = "platingdmg2"
 	},
 /area/maintenance/fore)
@@ -3814,8 +3705,6 @@
 	},
 /obj/effect/turf_decal/delivery,
 /turf/open/floor/plasteel/vault/side{
-	tag = "icon-vault (EAST)";
-	icon_state = "vault";
 	dir = 4
 	},
 /area/crew_quarters/heads/captain/private)
@@ -3918,8 +3807,6 @@
 	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel/vault/side{
-	tag = "icon-vault (WEST)";
-	icon_state = "vault";
 	dir = 8
 	},
 /area/bridge)
@@ -3929,8 +3816,6 @@
 	dir = 8
 	},
 /turf/open/floor/plasteel/vault/side{
-	tag = "icon-vault (EAST)";
-	icon_state = "vault";
 	dir = 4
 	},
 /area/bridge)
@@ -3945,8 +3830,6 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel/vault/side{
-	tag = "icon-vault (EAST)";
-	icon_state = "vault";
 	dir = 4
 	},
 /area/ai_monitored/turret_protected/ai)
@@ -4020,8 +3903,6 @@
 	dir = 8
 	},
 /turf/open/floor/plasteel/vault/side{
-	tag = "icon-vault (WEST)";
-	icon_state = "vault";
 	dir = 8
 	},
 /area/ai_monitored/turret_protected/ai)
@@ -4030,8 +3911,6 @@
 	dir = 8
 	},
 /turf/open/floor/plasteel/vault/side{
-	tag = "icon-vault (WEST)";
-	icon_state = "vault";
 	dir = 8
 	},
 /area/bridge)
@@ -4044,8 +3923,6 @@
 	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel/vault/side{
-	tag = "icon-vault (EAST)";
-	icon_state = "vault";
 	dir = 4
 	},
 /area/bridge)
@@ -4089,6 +3966,7 @@
 	icon_state = "1-2"
 	},
 /turf/open/floor/plating{
+	broken = 1;
 	icon_state = "platingdmg1"
 	},
 /area/maintenance/starboard/fore)
@@ -4289,8 +4167,6 @@
 	icon_state = "2-4"
 	},
 /turf/open/floor/plasteel/vault/side{
-	tag = "icon-vault (EAST)";
-	icon_state = "vault";
 	dir = 4
 	},
 /area/security/detectives_office)
@@ -4368,8 +4244,6 @@
 	},
 /obj/item/gun/energy/e_gun/hos,
 /turf/open/floor/plasteel/vault/side{
-	tag = "icon-vault (EAST)";
-	icon_state = "vault";
 	dir = 4
 	},
 /area/crew_quarters/heads/captain/private)
@@ -4441,8 +4315,6 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plasteel/vault/side{
-	tag = "icon-vault (EAST)";
-	icon_state = "vault";
 	dir = 4
 	},
 /area/bridge)
@@ -4453,8 +4325,6 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel/vault/side{
-	tag = "icon-vault (EAST)";
-	icon_state = "vault";
 	dir = 4
 	},
 /area/ai_monitored/turret_protected/ai)
@@ -4503,8 +4373,6 @@
 	dir = 8
 	},
 /turf/open/floor/plasteel/vault/side{
-	tag = "icon-vault (WEST)";
-	icon_state = "vault";
 	dir = 8
 	},
 /area/ai_monitored/turret_protected/ai)
@@ -4524,8 +4392,6 @@
 	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel/vault/side{
-	tag = "icon-vault (EAST)";
-	icon_state = "vault";
 	dir = 4
 	},
 /area/bridge)
@@ -4649,8 +4515,6 @@
 	},
 /obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel/darkred/corner{
-	tag = "icon-darkredcorners (NORTH)";
-	icon_state = "darkredcorners";
 	dir = 1
 	},
 /area/security/brig)
@@ -4700,8 +4564,6 @@
 	},
 /obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel/darkred/corner{
-	tag = "icon-darkredcorners (EAST)";
-	icon_state = "darkredcorners";
 	dir = 4
 	},
 /area/security/brig)
@@ -5029,8 +4891,6 @@
 	},
 /obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel/darkred/corner{
-	tag = "icon-darkredcorners (NORTH)";
-	icon_state = "darkredcorners";
 	dir = 1
 	},
 /area/security/brig)
@@ -5052,8 +4912,6 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on,
 /obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel/darkred/corner{
-	tag = "icon-darkredcorners (EAST)";
-	icon_state = "darkredcorners";
 	dir = 4
 	},
 /area/security/brig)
@@ -5576,8 +5434,6 @@
 	},
 /obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel/darkred/corner{
-	tag = "icon-darkredcorners (NORTH)";
-	icon_state = "darkredcorners";
 	dir = 1
 	},
 /area/security/brig)
@@ -5629,8 +5485,6 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel/darkred/corner{
-	tag = "icon-darkredcorners (EAST)";
-	icon_state = "darkredcorners";
 	dir = 4
 	},
 /area/security/brig)
@@ -6871,8 +6725,6 @@
 	},
 /obj/effect/turf_decal/delivery,
 /turf/open/floor/plasteel/vault/side{
-	tag = "icon-vault (EAST)";
-	icon_state = "vault";
 	dir = 4
 	},
 /area/teleporter)
@@ -6914,8 +6766,6 @@
 	},
 /obj/effect/turf_decal/delivery,
 /turf/open/floor/plasteel/vault/side{
-	tag = "icon-vault (WEST)";
-	icon_state = "vault";
 	dir = 8
 	},
 /area/teleporter)
@@ -6943,8 +6793,6 @@
 	},
 /obj/effect/turf_decal/delivery,
 /turf/open/floor/plasteel/vault/side{
-	tag = "icon-vault (NORTHEAST)";
-	icon_state = "vault";
 	dir = 5
 	},
 /area/hallway/primary/central)
@@ -6984,8 +6832,6 @@
 	},
 /obj/effect/turf_decal/delivery,
 /turf/open/floor/plasteel/vault/side{
-	tag = "icon-vault (NORTHWEST)";
-	icon_state = "vault";
 	dir = 9
 	},
 /area/hallway/primary/central)
@@ -7014,8 +6860,6 @@
 	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel/vault/side{
-	tag = "icon-vault (EAST)";
-	icon_state = "vault";
 	dir = 4
 	},
 /area/ai_monitored/storage/eva)
@@ -7061,8 +6905,6 @@
 	req_access_txt = "19"
 	},
 /turf/open/floor/plasteel/vault/side{
-	tag = "icon-vault (WEST)";
-	icon_state = "vault";
 	dir = 8
 	},
 /area/ai_monitored/storage/eva)
@@ -7322,8 +7164,6 @@
 	name = "command camera"
 	},
 /turf/open/floor/plasteel/vault/side{
-	tag = "icon-vault (EAST)";
-	icon_state = "vault";
 	dir = 4
 	},
 /area/teleporter)
@@ -7356,8 +7196,6 @@
 "amX" = (
 /obj/machinery/teleport/hub,
 /turf/open/floor/plasteel/vault/side{
-	tag = "icon-vault (WEST)";
-	icon_state = "vault";
 	dir = 8
 	},
 /area/teleporter)
@@ -7375,8 +7213,6 @@
 	},
 /obj/effect/turf_decal/delivery,
 /turf/open/floor/plasteel/vault/side{
-	tag = "icon-vault (EAST)";
-	icon_state = "vault";
 	dir = 4
 	},
 /area/hallway/primary/central)
@@ -7407,8 +7243,6 @@
 	},
 /obj/effect/turf_decal/delivery,
 /turf/open/floor/plasteel/vault/side{
-	tag = "icon-vault (WEST)";
-	icon_state = "vault";
 	dir = 8
 	},
 /area/hallway/primary/central)
@@ -7456,7 +7290,6 @@
 /obj/machinery/suit_storage_unit/standard_unit,
 /obj/machinery/firealarm{
 	dir = 4;
-	icon_state = "fire0";
 	pixel_x = 24
 	},
 /obj/effect/turf_decal/stripes/end{
@@ -7798,8 +7631,6 @@
 /obj/structure/closet/crate/engineering,
 /obj/item/hand_tele,
 /turf/open/floor/plasteel/vault/side{
-	tag = "icon-vault (EAST)";
-	icon_state = "vault";
 	dir = 4
 	},
 /area/teleporter)
@@ -7834,8 +7665,6 @@
 	pixel_x = 32
 	},
 /turf/open/floor/plasteel/vault/side{
-	tag = "icon-vault (WEST)";
-	icon_state = "vault";
 	dir = 8
 	},
 /area/teleporter)
@@ -8169,8 +7998,6 @@
 	dir = 5
 	},
 /turf/open/floor/plasteel/vault/side{
-	tag = "icon-vault (EAST)";
-	icon_state = "vault";
 	dir = 4
 	},
 /area/security/brig)
@@ -8294,8 +8121,6 @@
 	pixel_x = -22
 	},
 /turf/open/floor/plasteel/vault/side{
-	tag = "icon-vault (EAST)";
-	icon_state = "vault";
 	dir = 4
 	},
 /area/teleporter)
@@ -8324,8 +8149,6 @@
 	pixel_x = 32
 	},
 /turf/open/floor/plasteel/vault/side{
-	tag = "icon-vault (WEST)";
-	icon_state = "vault";
 	dir = 8
 	},
 /area/teleporter)
@@ -8463,7 +8286,7 @@
 	icon_state = "4-8"
 	},
 /turf/open/floor/plating{
-	tag = "icon-platingdmg2";
+	broken = 1;
 	icon_state = "platingdmg2"
 	},
 /area/maintenance/starboard/central)
@@ -8821,8 +8644,6 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel/vault/side{
-	tag = "icon-vault (EAST)";
-	icon_state = "vault";
 	dir = 4
 	},
 /area/security/brig)
@@ -8969,8 +8790,6 @@
 	},
 /obj/effect/turf_decal/delivery,
 /turf/open/floor/plasteel/vault/side{
-	tag = "icon-vault (EAST)";
-	icon_state = "vault";
 	dir = 4
 	},
 /area/teleporter)
@@ -9019,8 +8838,6 @@
 	},
 /obj/effect/turf_decal/delivery,
 /turf/open/floor/plasteel/vault/side{
-	tag = "icon-vault (WEST)";
-	icon_state = "vault";
 	dir = 8
 	},
 /area/teleporter)
@@ -9193,8 +9010,6 @@
 	pixel_y = -32
 	},
 /turf/open/floor/plasteel/vault/side{
-	tag = "icon-vault (EAST)";
-	icon_state = "vault";
 	dir = 4
 	},
 /area/ai_monitored/storage/eva)
@@ -9257,8 +9072,6 @@
 	pixel_y = -28
 	},
 /turf/open/floor/plasteel/vault/side{
-	tag = "icon-vault (WEST)";
-	icon_state = "vault";
 	dir = 8
 	},
 /area/ai_monitored/storage/eva)
@@ -9492,8 +9305,6 @@
 	dir = 6
 	},
 /turf/open/floor/plasteel/vault/side{
-	tag = "icon-vault (EAST)";
-	icon_state = "vault";
 	dir = 4
 	},
 /area/security/brig)
@@ -9536,8 +9347,6 @@
 	dir = 6
 	},
 /turf/open/floor/plasteel/vault/side{
-	tag = "icon-vault (EAST)";
-	icon_state = "vault";
 	dir = 4
 	},
 /area/security/brig)
@@ -10064,8 +9873,6 @@
 	},
 /obj/structure/closet/l3closet/security,
 /turf/open/floor/plasteel/vault/side{
-	tag = "icon-vault (EAST)";
-	icon_state = "vault";
 	dir = 4
 	},
 /area/security/brig)
@@ -10418,8 +10225,6 @@
 	network = list("MINE")
 	},
 /turf/open/floor/plasteel/vault/side{
-	tag = "icon-vault (EAST)";
-	icon_state = "vault";
 	dir = 4
 	},
 /area/crew_quarters/bar/atrium)
@@ -10455,8 +10260,6 @@
 	pixel_x = 32
 	},
 /turf/open/floor/plasteel/vault/side{
-	tag = "icon-vault (WEST)";
-	icon_state = "vault";
 	dir = 8
 	},
 /area/crew_quarters/bar/atrium)
@@ -10690,8 +10493,6 @@
 	pixel_y = -32
 	},
 /turf/open/floor/plasteel/vault/corner{
-	tag = "icon-vaultcorner (EAST)";
-	icon_state = "vaultcorner";
 	dir = 4
 	},
 /area/security/brig)
@@ -10729,8 +10530,6 @@
 	name = "security camera"
 	},
 /turf/open/floor/plasteel/vault/side{
-	tag = "icon-vault (NORTH)";
-	icon_state = "vault";
 	dir = 1
 	},
 /area/security/brig)
@@ -10741,8 +10540,6 @@
 	pixel_y = -26
 	},
 /turf/open/floor/plasteel/vault/side{
-	tag = "icon-vault (NORTH)";
-	icon_state = "vault";
 	dir = 1
 	},
 /area/security/brig)
@@ -10777,8 +10574,6 @@
 	dir = 9
 	},
 /turf/open/floor/plasteel/vault/side{
-	tag = "icon-vault (NORTH)";
-	icon_state = "vault";
 	dir = 1
 	},
 /area/security/brig)
@@ -10800,8 +10595,6 @@
 	dir = 1
 	},
 /turf/open/floor/plasteel/vault/side{
-	tag = "icon-vault (NORTH)";
-	icon_state = "vault";
 	dir = 1
 	},
 /area/security/brig)
@@ -10817,8 +10610,6 @@
 	dir = 1
 	},
 /turf/open/floor/plasteel/vault/side{
-	tag = "icon-vault (NORTH)";
-	icon_state = "vault";
 	dir = 1
 	},
 /area/security/brig)
@@ -10843,8 +10634,6 @@
 	name = "security camera"
 	},
 /turf/open/floor/plasteel/vault/side{
-	tag = "icon-vault (NORTH)";
-	icon_state = "vault";
 	dir = 1
 	},
 /area/security/brig)
@@ -10863,8 +10652,6 @@
 	dir = 1
 	},
 /turf/open/floor/plasteel/vault/side{
-	tag = "icon-vault (NORTH)";
-	icon_state = "vault";
 	dir = 1
 	},
 /area/security/brig)
@@ -11029,8 +10816,6 @@
 	dir = 8
 	},
 /turf/open/floor/plasteel/vault/side{
-	tag = "icon-vault (SOUTHEAST)";
-	icon_state = "vault";
 	dir = 6
 	},
 /area/crew_quarters/bar/atrium)
@@ -11038,15 +10823,12 @@
 /obj/machinery/vending/coffee,
 /obj/machinery/firealarm{
 	dir = 4;
-	icon_state = "fire0";
 	pixel_x = 24
 	},
 /obj/machinery/light{
 	dir = 4
 	},
 /turf/open/floor/plasteel/vault/side{
-	tag = "icon-vault (SOUTHWEST)";
-	icon_state = "vault";
 	dir = 10
 	},
 /area/crew_quarters/bar/atrium)
@@ -11497,6 +11279,7 @@
 	icon_state = "1-2"
 	},
 /turf/open/floor/wood{
+	broken = 1;
 	icon_state = "wood-broken6"
 	},
 /area/crew_quarters/theatre)
@@ -11518,8 +11301,6 @@
 "aub" = (
 /obj/machinery/vending/cigarette,
 /turf/open/floor/plasteel/vault/side{
-	tag = "icon-vault (EAST)";
-	icon_state = "vault";
 	dir = 4
 	},
 /area/crew_quarters/bar/atrium)
@@ -11634,7 +11415,7 @@
 	icon_state = "1-2"
 	},
 /turf/open/floor/plating{
-	tag = "icon-platingdmg2";
+	broken = 1;
 	icon_state = "platingdmg2"
 	},
 /area/maintenance/starboard/central)
@@ -11837,7 +11618,7 @@
 /obj/effect/landmark/revenantspawn,
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden,
 /turf/open/floor/plating{
-	tag = "icon-platingdmg2";
+	broken = 1;
 	icon_state = "platingdmg2"
 	},
 /area/maintenance/port/fore)
@@ -11895,8 +11676,6 @@
 	},
 /obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel/vault/side{
-	tag = "icon-vault (EAST)";
-	icon_state = "vault";
 	dir = 4
 	},
 /area/hallway/primary/central)
@@ -12046,8 +11825,6 @@
 /obj/item/clothing/head/fedora,
 /obj/item/clothing/mask/cigarette/pipe,
 /turf/open/floor/plasteel/vault/side{
-	tag = "icon-vault (EAST)";
-	icon_state = "vault";
 	dir = 4
 	},
 /area/crew_quarters/bar/atrium)
@@ -12377,6 +12154,7 @@
 	dir = 1
 	},
 /turf/open/floor/plating{
+	broken = 1;
 	icon_state = "platingdmg3"
 	},
 /area/maintenance/port/fore)
@@ -12449,8 +12227,6 @@
 	},
 /obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel/vault/side{
-	tag = "icon-vault (EAST)";
-	icon_state = "vault";
 	dir = 4
 	},
 /area/hallway/primary/central)
@@ -12597,6 +12373,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/wood{
+	broken = 1;
 	icon_state = "wood-broken"
 	},
 /area/crew_quarters/theatre)
@@ -12605,8 +12382,6 @@
 	dir = 8
 	},
 /turf/open/floor/plasteel/vault/side{
-	tag = "icon-vault (EAST)";
-	icon_state = "vault";
 	dir = 4
 	},
 /area/crew_quarters/bar/atrium)
@@ -13822,8 +13597,6 @@
 	network = list("MINE")
 	},
 /turf/open/floor/plasteel/vault/side{
-	tag = "icon-vault (EAST)";
-	icon_state = "vault";
 	dir = 4
 	},
 /area/crew_quarters/bar/atrium)
@@ -13930,15 +13703,12 @@
 /obj/structure/closet/firecloset,
 /obj/effect/turf_decal/delivery,
 /turf/open/floor/plasteel/vault/side{
-	tag = "icon-vault (WEST)";
-	icon_state = "vault";
 	dir = 8
 	},
 /area/hallway/primary/central)
 "ayW" = (
 /obj/structure/table/reinforced,
 /obj/structure/cable/white{
-	d2 = 4;
 	icon_state = "0-4"
 	},
 /obj/machinery/power/apc{
@@ -13955,7 +13725,6 @@
 	pixel_y = 23
 	},
 /obj/structure/cable/white{
-	d2 = 4;
 	icon_state = "0-4"
 	},
 /turf/open/floor/plasteel/red/side{
@@ -13970,8 +13739,6 @@
 	pixel_y = 32
 	},
 /obj/structure/cable/white{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel/red/side{
@@ -13988,8 +13755,6 @@
 	pixel_y = 24
 	},
 /obj/structure/cable/white{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel/red/side{
@@ -14002,8 +13767,6 @@
 	pixel_y = 32
 	},
 /obj/structure/cable/white{
-	d1 = 2;
-	d2 = 8;
 	icon_state = "2-8"
 	},
 /turf/open/floor/plasteel/red/side{
@@ -14284,6 +14047,7 @@
 	},
 /obj/machinery/light,
 /turf/open/floor/wood{
+	broken = 1;
 	icon_state = "wood-broken5"
 	},
 /area/crew_quarters/theatre)
@@ -14316,8 +14080,6 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel/vault/side{
-	tag = "icon-vault (EAST)";
-	icon_state = "vault";
 	dir = 4
 	},
 /area/crew_quarters/bar/atrium)
@@ -14376,6 +14138,7 @@
 	dir = 4
 	},
 /turf/open/floor/plating{
+	broken = 1;
 	icon_state = "platingdmg1"
 	},
 /area/maintenance/starboard/central)
@@ -14427,8 +14190,6 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel/vault/side{
-	tag = "icon-vault (WEST)";
-	icon_state = "vault";
 	dir = 8
 	},
 /area/hallway/primary/central)
@@ -14456,8 +14217,6 @@
 "azY" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on,
 /obj/structure/cable/white{
-	d1 = 1;
-	d2 = 2;
 	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel/neutral,
@@ -14989,8 +14748,6 @@
 /obj/machinery/vending/cola/random,
 /obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel/vault/side{
-	tag = "icon-vault (WEST)";
-	icon_state = "vault";
 	dir = 8
 	},
 /area/hallway/primary/central)
@@ -15019,8 +14776,6 @@
 "aBf" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/structure/cable/white{
-	d1 = 1;
-	d2 = 2;
 	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel/red/side,
@@ -15429,13 +15184,12 @@
 	c_tag = "Theatre Storage"
 	},
 /turf/open/floor/plasteel/vault/side{
-	tag = "icon-vault (EAST)";
-	icon_state = "vault";
 	dir = 4
 	},
 /area/crew_quarters/theatre)
 "aBW" = (
 /turf/open/floor/wood{
+	broken = 1;
 	icon_state = "wood-broken7"
 	},
 /area/crew_quarters/theatre)
@@ -15529,20 +15283,16 @@
 /obj/machinery/vending/snack/random,
 /obj/machinery/firealarm{
 	dir = 4;
-	icon_state = "fire0";
 	pixel_x = 24
 	},
 /obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel/vault/side{
-	tag = "icon-vault (WEST)";
-	icon_state = "vault";
 	dir = 8
 	},
 /area/hallway/primary/central)
 "aCi" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable/white{
-	d2 = 4;
 	icon_state = "0-4"
 	},
 /turf/open/floor/plating,
@@ -15550,13 +15300,9 @@
 "aCj" = (
 /obj/machinery/door/firedoor,
 /obj/structure/cable/white{
-	d1 = 2;
-	d2 = 4;
 	icon_state = "2-4"
 	},
 /obj/structure/cable/white{
-	d1 = 2;
-	d2 = 8;
 	icon_state = "2-8"
 	},
 /obj/machinery/door/window/brigdoor/southright{
@@ -15566,8 +15312,6 @@
 	},
 /obj/structure/table/reinforced,
 /obj/structure/cable/white{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/item/folder/red,
@@ -15580,11 +15324,9 @@
 "aCk" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable/white{
-	d2 = 4;
 	icon_state = "0-4"
 	},
 /obj/structure/cable/white{
-	d2 = 8;
 	icon_state = "0-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -15593,19 +15335,13 @@
 "aCl" = (
 /obj/machinery/door/firedoor,
 /obj/structure/cable/white{
-	d1 = 2;
-	d2 = 8;
 	icon_state = "2-8"
 	},
 /obj/structure/cable/white{
-	d1 = 2;
-	d2 = 4;
 	icon_state = "2-4"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/structure/cable/white{
-	d1 = 1;
-	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/effect/turf_decal/stripes/line{
@@ -15623,7 +15359,6 @@
 "aCm" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable/white{
-	d2 = 8;
 	icon_state = "0-8"
 	},
 /turf/open/floor/plating,
@@ -15682,8 +15417,6 @@
 	dir = 1
 	},
 /turf/open/floor/plasteel/vault/side{
-	tag = "icon-vault (NORTH)";
-	icon_state = "vault";
 	dir = 1
 	},
 /area/engine/atmos)
@@ -15697,8 +15430,6 @@
 	},
 /obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel/vault/side{
-	tag = "icon-vault (NORTH)";
-	icon_state = "vault";
 	dir = 1
 	},
 /area/engine/atmos)
@@ -15706,8 +15437,6 @@
 /obj/machinery/atmospherics/pipe/manifold/yellow/visible,
 /obj/machinery/meter,
 /turf/open/floor/plasteel/vault/side{
-	tag = "icon-vault (NORTH)";
-	icon_state = "vault";
 	dir = 1
 	},
 /area/engine/atmos)
@@ -15721,8 +15450,6 @@
 	},
 /obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel/vault/side{
-	tag = "icon-vault (NORTH)";
-	icon_state = "vault";
 	dir = 1
 	},
 /area/engine/atmos)
@@ -15736,8 +15463,6 @@
 	},
 /obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel/vault/side{
-	tag = "icon-vault (NORTH)";
-	icon_state = "vault";
 	dir = 1
 	},
 /area/engine/atmos)
@@ -15748,8 +15473,6 @@
 /obj/structure/closet/secure_closet/atmospherics,
 /obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel/vault/side{
-	tag = "icon-vault (NORTH)";
-	icon_state = "vault";
 	dir = 1
 	},
 /area/engine/atmos)
@@ -15819,8 +15542,6 @@
 	},
 /obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel/vault/side{
-	tag = "icon-vault (NORTH)";
-	icon_state = "vault";
 	dir = 1
 	},
 /area/engine/atmos)
@@ -15837,8 +15558,6 @@
 	},
 /obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel/vault/side{
-	tag = "icon-vault (NORTH)";
-	icon_state = "vault";
 	dir = 1
 	},
 /area/engine/atmos)
@@ -15970,8 +15689,6 @@
 	pixel_x = -32
 	},
 /turf/open/floor/plasteel/vault/side{
-	tag = "icon-vault (EAST)";
-	icon_state = "vault";
 	dir = 4
 	},
 /area/crew_quarters/theatre)
@@ -16106,8 +15823,6 @@
 /area/hallway/secondary/exit)
 "aDe" = (
 /obj/structure/cable/white{
-	d1 = 1;
-	d2 = 4;
 	icon_state = "1-4"
 	},
 /turf/open/floor/plasteel/escape{
@@ -16116,8 +15831,6 @@
 /area/hallway/secondary/exit)
 "aDg" = (
 /obj/structure/cable/white{
-	d1 = 1;
-	d2 = 8;
 	icon_state = "1-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -16366,8 +16079,6 @@
 	pixel_x = -28
 	},
 /turf/open/floor/plasteel/vault/side{
-	tag = "icon-vault (EAST)";
-	icon_state = "vault";
 	dir = 4
 	},
 /area/crew_quarters/theatre)
@@ -16383,6 +16094,7 @@
 	icon_state = "1-4"
 	},
 /turf/open/floor/wood{
+	broken = 1;
 	icon_state = "wood-broken5"
 	},
 /area/crew_quarters/theatre)
@@ -16707,8 +16419,6 @@
 	},
 /obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel/vault/side{
-	tag = "icon-vault (EAST)";
-	icon_state = "vault";
 	dir = 4
 	},
 /area/engine/engineering)
@@ -16739,8 +16449,6 @@
 /obj/machinery/portable_atmospherics/canister/nitrogen,
 /obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel/vault/side{
-	tag = "icon-vault (WEST)";
-	icon_state = "vault";
 	dir = 8
 	},
 /area/engine/engineering)
@@ -16819,7 +16527,6 @@
 "aEz" = (
 /obj/machinery/shower{
 	dir = 8;
-	icon_state = "shower";
 	name = "emergency shower"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -16983,6 +16690,7 @@
 	pixel_y = -32
 	},
 /turf/open/floor/wood{
+	broken = 1;
 	icon_state = "wood-broken7"
 	},
 /area/crew_quarters/dorms)
@@ -17016,8 +16724,6 @@
 	pixel_y = -32
 	},
 /turf/open/floor/plasteel/vault/corner{
-	tag = "icon-vaultcorner (EAST)";
-	icon_state = "vaultcorner";
 	dir = 4
 	},
 /area/crew_quarters/theatre)
@@ -17032,8 +16738,6 @@
 	pixel_y = -26
 	},
 /turf/open/floor/plasteel/vault/side{
-	tag = "icon-vault (NORTH)";
-	icon_state = "vault";
 	dir = 1
 	},
 /area/crew_quarters/theatre)
@@ -17046,8 +16750,6 @@
 	},
 /obj/structure/closet/crate/wooden/toy,
 /turf/open/floor/plasteel/vault/side{
-	tag = "icon-vault (NORTH)";
-	icon_state = "vault";
 	dir = 1
 	},
 /area/crew_quarters/theatre)
@@ -17061,8 +16763,6 @@
 	pixel_x = 24
 	},
 /turf/open/floor/plasteel/vault/side{
-	tag = "icon-vault (NORTH)";
-	icon_state = "vault";
 	dir = 1
 	},
 /area/crew_quarters/theatre)
@@ -17266,8 +16966,6 @@
 /obj/machinery/light/small,
 /obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel/vault/side{
-	tag = "icon-vault (EAST)";
-	icon_state = "vault";
 	dir = 4
 	},
 /area/engine/engineering)
@@ -17311,8 +17009,6 @@
 	},
 /obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel/vault/side{
-	tag = "icon-vault (WEST)";
-	icon_state = "vault";
 	dir = 8
 	},
 /area/engine/engineering)
@@ -17399,7 +17095,6 @@
 "aFB" = (
 /obj/machinery/shower{
 	dir = 8;
-	icon_state = "shower";
 	name = "emergency shower"
 	},
 /obj/machinery/light/small,
@@ -17972,7 +17667,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plating{
-	tag = "icon-platingdmg2";
+	broken = 1;
 	icon_state = "platingdmg2"
 	},
 /area/maintenance/port/central)
@@ -18107,8 +17802,6 @@
 	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel/vault/side{
-	tag = "icon-vault (NORTH)";
-	icon_state = "vault";
 	dir = 1
 	},
 /area/crew_quarters/kitchen)
@@ -18125,8 +17818,6 @@
 /obj/item/clothing/head/chefhat,
 /obj/machinery/light,
 /turf/open/floor/plasteel/vault/side{
-	tag = "icon-vault (NORTH)";
-	icon_state = "vault";
 	dir = 1
 	},
 /area/crew_quarters/kitchen)
@@ -18142,8 +17833,6 @@
 	pixel_y = -22
 	},
 /turf/open/floor/plasteel/vault/side{
-	tag = "icon-vault (NORTH)";
-	icon_state = "vault";
 	dir = 1
 	},
 /area/crew_quarters/kitchen)
@@ -18155,8 +17844,6 @@
 	pixel_y = 5
 	},
 /turf/open/floor/plasteel/vault/side{
-	tag = "icon-vault (NORTH)";
-	icon_state = "vault";
 	dir = 1
 	},
 /area/crew_quarters/kitchen)
@@ -18536,8 +18223,6 @@
 	},
 /obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel/vault/side{
-	tag = "icon-vault (WEST)";
-	icon_state = "vault";
 	dir = 8
 	},
 /area/hallway/primary/central)
@@ -18746,8 +18431,6 @@
 /obj/item/pen,
 /obj/effect/turf_decal/delivery,
 /turf/open/floor/plasteel/vault/side{
-	tag = "icon-vault (WEST)";
-	icon_state = "vault";
 	dir = 8
 	},
 /area/hallway/primary/central)
@@ -19211,8 +18894,6 @@
 	},
 /obj/structure/closet/crate/bin,
 /turf/open/floor/plasteel/vault/side{
-	tag = "icon-vault (NORTHWEST)";
-	icon_state = "vault";
 	dir = 9
 	},
 /area/crew_quarters/bar/atrium)
@@ -19681,8 +19362,6 @@
 	},
 /obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel/vault/side{
-	tag = "icon-vault (EAST)";
-	icon_state = "vault";
 	dir = 4
 	},
 /area/janitor)
@@ -19717,8 +19396,6 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel/vault/side{
-	tag = "icon-vault (WEST)";
-	icon_state = "vault";
 	dir = 8
 	},
 /area/janitor)
@@ -19820,8 +19497,6 @@
 "aJX" = (
 /obj/machinery/vending/cola/random,
 /turf/open/floor/plasteel/vault/side{
-	tag = "icon-vault (WEST)";
-	icon_state = "vault";
 	dir = 8
 	},
 /area/crew_quarters/bar/atrium)
@@ -19916,8 +19591,6 @@
 /obj/structure/closet/emcloset,
 /obj/effect/turf_decal/delivery,
 /turf/open/floor/plasteel/vault/side{
-	tag = "icon-vault (NORTH)";
-	icon_state = "vault";
 	dir = 1
 	},
 /area/hallway/primary/central)
@@ -20124,7 +19797,6 @@
 "aKC" = (
 /obj/machinery/atmospherics/components/binary/pump{
 	dir = 2;
-	icon_state = "pump_map";
 	name = "Gas to Chamber"
 	},
 /turf/open/floor/engine,
@@ -20292,8 +19964,6 @@
 	},
 /obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel/vault/side{
-	tag = "icon-vault (EAST)";
-	icon_state = "vault";
 	dir = 4
 	},
 /area/janitor)
@@ -20329,8 +19999,6 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel/vault/side{
-	tag = "icon-vault (WEST)";
-	icon_state = "vault";
 	dir = 8
 	},
 /area/janitor)
@@ -20430,8 +20098,6 @@
 /obj/item/reagent_containers/food/snacks/grown/tomato,
 /obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel/vault/side{
-	tag = "icon-vault (NORTH)";
-	icon_state = "vault";
 	dir = 1
 	},
 /area/hydroponics)
@@ -20449,8 +20115,6 @@
 /obj/item/seeds/tower,
 /obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel/vault/side{
-	tag = "icon-vault (NORTH)";
-	icon_state = "vault";
 	dir = 1
 	},
 /area/hydroponics)
@@ -20469,15 +20133,12 @@
 /obj/machinery/vending/snack/random,
 /obj/machinery/firealarm{
 	dir = 4;
-	icon_state = "fire0";
 	pixel_x = 24
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
 /turf/open/floor/plasteel/vault/side{
-	tag = "icon-vault (WEST)";
-	icon_state = "vault";
 	dir = 8
 	},
 /area/crew_quarters/bar/atrium)
@@ -20878,8 +20539,6 @@
 	pixel_x = -23
 	},
 /turf/open/floor/plasteel/vault/side{
-	tag = "icon-vault (EAST)";
-	icon_state = "vault";
 	dir = 4
 	},
 /area/janitor)
@@ -20913,8 +20572,6 @@
 	},
 /obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel/vault/side{
-	tag = "icon-vault (WEST)";
-	icon_state = "vault";
 	dir = 8
 	},
 /area/janitor)
@@ -21075,8 +20732,6 @@
 	},
 /obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel/vault/side{
-	tag = "icon-vault (WEST)";
-	icon_state = "vault";
 	dir = 8
 	},
 /area/hallway/primary/central)
@@ -21151,7 +20806,6 @@
 "aMH" = (
 /obj/machinery/shower{
 	dir = 4;
-	icon_state = "shower";
 	name = "emergency shower"
 	},
 /turf/open/floor/plasteel/cmo,
@@ -21462,8 +21116,6 @@
 	},
 /obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel/vault/side{
-	tag = "icon-vault (EAST)";
-	icon_state = "vault";
 	dir = 4
 	},
 /area/janitor)
@@ -21489,8 +21141,6 @@
 /obj/structure/closet/l3closet/janitor,
 /obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel/vault/side{
-	tag = "icon-vault (WEST)";
-	icon_state = "vault";
 	dir = 8
 	},
 /area/janitor)
@@ -21528,8 +21178,6 @@
 /obj/item/storage/box/disks_plantgene,
 /obj/item/toy/figure/botanist,
 /turf/open/floor/plasteel/vault/side{
-	tag = "icon-vault (NORTH)";
-	icon_state = "vault";
 	dir = 1
 	},
 /area/hydroponics)
@@ -21569,8 +21217,6 @@
 "aNt" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plasteel/vault/side{
-	tag = "icon-vault (NORTH)";
-	icon_state = "vault";
 	dir = 1
 	},
 /area/hydroponics)
@@ -21584,8 +21230,6 @@
 	},
 /obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel/vault/side{
-	tag = "icon-vault (NORTH)";
-	icon_state = "vault";
 	dir = 1
 	},
 /area/hydroponics)
@@ -21666,7 +21310,7 @@
 	icon_state = "4-8"
 	},
 /turf/open/floor/plating{
-	tag = "icon-platingdmg2";
+	broken = 1;
 	icon_state = "platingdmg2"
 	},
 /area/maintenance/starboard/central)
@@ -22778,8 +22422,6 @@
 /obj/item/storage/briefcase,
 /obj/effect/turf_decal/delivery,
 /turf/open/floor/plasteel/vault/side{
-	tag = "icon-vault (WEST)";
-	icon_state = "vault";
 	dir = 8
 	},
 /area/hallway/primary/central)
@@ -23275,8 +22917,6 @@
 	},
 /obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel/vault/side{
-	tag = "icon-vault (WEST)";
-	icon_state = "vault";
 	dir = 8
 	},
 /area/hallway/primary/central)
@@ -23305,6 +22945,7 @@
 /obj/effect/landmark/xeno_spawn,
 /obj/machinery/atmospherics/components/unary/vent_pump/on,
 /turf/open/floor/wood{
+	broken = 1;
 	icon_state = "wood-broken"
 	},
 /area/maintenance/starboard)
@@ -23797,7 +23438,6 @@
 "aRN" = (
 /obj/machinery/atmospherics/components/binary/pump{
 	dir = 4;
-	icon_state = "pump_map";
 	name = "Freezer to Gas"
 	},
 /turf/open/floor/engine,
@@ -23840,7 +23480,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plating{
-	tag = "icon-platingdmg2";
+	broken = 1;
 	icon_state = "platingdmg2"
 	},
 /area/maintenance/port)
@@ -23943,8 +23583,6 @@
 /obj/effect/landmark/revenantspawn,
 /obj/effect/decal/cleanable/cobweb,
 /turf/open/floor/plasteel/vault/side{
-	tag = "icon-vault (EAST)";
-	icon_state = "vault";
 	dir = 4
 	},
 /area/medical/morgue)
@@ -23961,8 +23599,6 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plasteel/vault/side{
-	tag = "icon-vault (WEST)";
-	icon_state = "vault";
 	dir = 8
 	},
 /area/medical/morgue)
@@ -24126,7 +23762,6 @@
 "aSA" = (
 /obj/machinery/shower{
 	dir = 4;
-	icon_state = "shower";
 	name = "emergency shower"
 	},
 /obj/machinery/firealarm{
@@ -24144,7 +23779,6 @@
 "aSB" = (
 /obj/machinery/shower{
 	dir = 8;
-	icon_state = "shower";
 	name = "emergency shower"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -24159,7 +23793,7 @@
 	icon_state = "1-2"
 	},
 /turf/open/floor/plating{
-	tag = "icon-platingdmg2";
+	broken = 1;
 	icon_state = "platingdmg2"
 	},
 /area/maintenance/starboard)
@@ -24204,6 +23838,7 @@
 "aSJ" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/wood{
+	broken = 1;
 	icon_state = "wood-broken2"
 	},
 /area/maintenance/starboard)
@@ -24431,8 +24066,6 @@
 	pixel_x = -23
 	},
 /turf/open/floor/plasteel/vault/side{
-	tag = "icon-vault (EAST)";
-	icon_state = "vault";
 	dir = 4
 	},
 /area/medical/morgue)
@@ -24453,8 +24086,6 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel/vault/side{
-	tag = "icon-vault (WEST)";
-	icon_state = "vault";
 	dir = 8
 	},
 /area/medical/morgue)
@@ -24464,7 +24095,6 @@
 	},
 /obj/machinery/shower{
 	dir = 4;
-	icon_state = "shower";
 	name = "emergency shower"
 	},
 /obj/machinery/newscaster{
@@ -24710,6 +24340,7 @@
 	icon_state = "4-8"
 	},
 /turf/open/floor/plating{
+	broken = 1;
 	icon_state = "platingdmg1"
 	},
 /area/maintenance/starboard)
@@ -24782,6 +24413,7 @@
 "aTV" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/wood{
+	broken = 1;
 	icon_state = "wood-broken7"
 	},
 /area/maintenance/starboard)
@@ -24873,6 +24505,7 @@
 	icon_state = "4-8"
 	},
 /turf/open/floor/wood{
+	broken = 1;
 	icon_state = "wood-broken5"
 	},
 /area/library)
@@ -24913,8 +24546,6 @@
 	pixel_x = -26
 	},
 /turf/open/floor/plasteel/vault/side{
-	tag = "icon-vault (EAST)";
-	icon_state = "vault";
 	dir = 4
 	},
 /area/medical/morgue)
@@ -24930,8 +24561,6 @@
 "aUm" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plasteel/vault/side{
-	tag = "icon-vault (WEST)";
-	icon_state = "vault";
 	dir = 8
 	},
 /area/medical/morgue)
@@ -24974,8 +24603,6 @@
 	},
 /obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel/vault/side{
-	tag = "icon-vault (EAST)";
-	icon_state = "vault";
 	dir = 4
 	},
 /area/medical/chemistry)
@@ -25042,8 +24669,6 @@
 	},
 /obj/machinery/rnd/protolathe/department/science,
 /turf/open/floor/plasteel/vault/side{
-	tag = "icon-vault (EAST)";
-	icon_state = "vault";
 	dir = 4
 	},
 /area/science/lab)
@@ -25132,6 +24757,7 @@
 	icon_state = "1-2"
 	},
 /turf/open/floor/plating{
+	broken = 1;
 	icon_state = "platingdmg3"
 	},
 /area/maintenance/starboard)
@@ -25159,6 +24785,7 @@
 	},
 /obj/effect/landmark/xeno_spawn,
 /turf/open/floor/wood{
+	broken = 1;
 	icon_state = "wood-broken5"
 	},
 /area/maintenance/starboard)
@@ -25292,8 +24919,6 @@
 	dir = 8
 	},
 /turf/open/floor/plasteel/vault/side{
-	tag = "icon-vault (EAST)";
-	icon_state = "vault";
 	dir = 4
 	},
 /area/medical/morgue)
@@ -25314,8 +24939,6 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plasteel/vault/side{
-	tag = "icon-vault (WEST)";
-	icon_state = "vault";
 	dir = 8
 	},
 /area/medical/morgue)
@@ -25372,8 +24995,6 @@
 /obj/item/reagent_containers/dropper,
 /obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel/vault/side{
-	tag = "icon-vault (EAST)";
-	icon_state = "vault";
 	dir = 4
 	},
 /area/medical/chemistry)
@@ -25474,8 +25095,6 @@
 	},
 /obj/machinery/rnd/circuit_imprinter/department/science,
 /turf/open/floor/plasteel/vault/side{
-	tag = "icon-vault (EAST)";
-	icon_state = "vault";
 	dir = 4
 	},
 /area/science/lab)
@@ -25580,6 +25199,7 @@
 	dir = 4
 	},
 /turf/open/floor/wood{
+	broken = 1;
 	icon_state = "wood-broken"
 	},
 /area/maintenance/starboard)
@@ -25699,8 +25319,6 @@
 	pixel_x = -26
 	},
 /turf/open/floor/plasteel/vault/side{
-	tag = "icon-vault (EAST)";
-	icon_state = "vault";
 	dir = 4
 	},
 /area/medical/morgue)
@@ -25720,8 +25338,6 @@
 	dir = 5
 	},
 /turf/open/floor/plasteel/vault/side{
-	tag = "icon-vault (WEST)";
-	icon_state = "vault";
 	dir = 8
 	},
 /area/medical/morgue)
@@ -25812,8 +25428,6 @@
 /obj/machinery/light,
 /obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel/vault/side{
-	tag = "icon-vault (NORTH)";
-	icon_state = "vault";
 	dir = 1
 	},
 /area/medical/chemistry)
@@ -25835,8 +25449,6 @@
 /obj/item/grenade/chem_grenade,
 /obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel/vault/side{
-	tag = "icon-vault (NORTH)";
-	icon_state = "vault";
 	dir = 1
 	},
 /area/medical/chemistry)
@@ -25847,8 +25459,6 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/effect/turf_decal/delivery,
 /turf/open/floor/plasteel/vault/side{
-	tag = "icon-vault (NORTH)";
-	icon_state = "vault";
 	dir = 1
 	},
 /area/medical/chemistry)
@@ -25863,8 +25473,6 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel/vault/side{
-	tag = "icon-vault (NORTH)";
-	icon_state = "vault";
 	dir = 1
 	},
 /area/medical/chemistry)
@@ -26063,8 +25671,6 @@
 	icon_state = "0-4"
 	},
 /turf/open/floor/plasteel/vault/side{
-	tag = "icon-vault (EAST)";
-	icon_state = "vault";
 	dir = 4
 	},
 /area/medical/morgue)
@@ -26083,8 +25689,6 @@
 	network = list("SS13")
 	},
 /turf/open/floor/plasteel/vault/side{
-	tag = "icon-vault (WEST)";
-	icon_state = "vault";
 	dir = 8
 	},
 /area/medical/morgue)
@@ -27043,6 +26647,7 @@
 	pixel_y = 24
 	},
 /turf/open/floor/wood{
+	broken = 1;
 	icon_state = "wood-broken6"
 	},
 /area/library)
@@ -27075,6 +26680,7 @@
 	dir = 6
 	},
 /turf/open/floor/plating{
+	broken = 1;
 	icon_state = "platingdmg3"
 	},
 /area/maintenance/port)
@@ -27477,6 +27083,7 @@
 	pixel_y = -26
 	},
 /turf/open/floor/wood{
+	broken = 1;
 	icon_state = "wood-broken"
 	},
 /area/library)
@@ -27921,6 +27528,7 @@
 	icon_state = "1-2"
 	},
 /turf/open/floor/plating{
+	broken = 1;
 	icon_state = "platingdmg1"
 	},
 /area/maintenance/starboard)
@@ -27985,8 +27593,6 @@
 /obj/item/clothing/head/syndicatefake,
 /obj/effect/decal/cleanable/cobweb,
 /turf/open/floor/plasteel/vault/side{
-	tag = "icon-vault (EAST)";
-	icon_state = "vault";
 	dir = 4
 	},
 /area/maintenance/port)
@@ -27999,8 +27605,6 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel/vault/side{
-	tag = "icon-vault (WEST)";
-	icon_state = "vault";
 	dir = 8
 	},
 /area/maintenance/port)
@@ -28366,8 +27970,6 @@
 	},
 /obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel/vault/side{
-	tag = "icon-vault (WEST)";
-	icon_state = "vault";
 	dir = 8
 	},
 /area/science/robotics/lab)
@@ -28464,8 +28066,6 @@
 /obj/item/clipboard,
 /obj/item/toy/syndicateballoon,
 /turf/open/floor/plasteel/vault/side{
-	tag = "icon-vault (EAST)";
-	icon_state = "vault";
 	dir = 4
 	},
 /area/maintenance/port)
@@ -28478,8 +28078,6 @@
 	req_access_txt = "0"
 	},
 /turf/open/floor/plasteel/vault/side{
-	tag = "icon-vault (WEST)";
-	icon_state = "vault";
 	dir = 8
 	},
 /area/maintenance/port)
@@ -28535,7 +28133,6 @@
 "bbu" = (
 /obj/machinery/firealarm{
 	dir = 4;
-	icon_state = "fire0";
 	pixel_x = 24
 	},
 /obj/machinery/light{
@@ -28662,7 +28259,6 @@
 /area/science/robotics/mechbay)
 "bbF" = (
 /obj/machinery/mech_bay_recharge_port{
-	icon_state = "recharge_port";
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -28771,8 +28367,6 @@
 	dir = 8
 	},
 /turf/open/floor/plasteel/vault/side{
-	tag = "icon-vault (WEST)";
-	icon_state = "vault";
 	dir = 8
 	},
 /area/science/robotics/lab)
@@ -28786,6 +28380,7 @@
 /area/maintenance/starboard)
 "bbQ" = (
 /turf/open/floor/wood{
+	broken = 1;
 	icon_state = "wood-broken5"
 	},
 /area/maintenance/port)
@@ -28794,6 +28389,7 @@
 /area/maintenance/port)
 "bbS" = (
 /turf/open/floor/wood{
+	broken = 1;
 	icon_state = "wood-broken6"
 	},
 /area/maintenance/port)
@@ -28882,6 +28478,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plating{
+	broken = 1;
 	icon_state = "platingdmg1"
 	},
 /area/maintenance/port)
@@ -28954,8 +28551,6 @@
 /obj/structure/bed/roller,
 /obj/machinery/iv_drip,
 /turf/open/floor/plasteel/vault/side{
-	tag = "icon-vault (NORTHWEST)";
-	icon_state = "vault";
 	dir = 9
 	},
 /area/medical/medbay/zone3)
@@ -29123,8 +28718,6 @@
 	},
 /obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel/vault/side{
-	tag = "icon-vault (WEST)";
-	icon_state = "vault";
 	dir = 8
 	},
 /area/science/robotics/lab)
@@ -29162,6 +28755,7 @@
 /area/maintenance/port)
 "bcI" = (
 /turf/open/floor/wood{
+	broken = 1;
 	icon_state = "wood-broken2"
 	},
 /area/maintenance/port)
@@ -29311,8 +28905,6 @@
 /obj/structure/bed/roller,
 /obj/machinery/iv_drip,
 /turf/open/floor/plasteel/vault/side{
-	tag = "icon-vault (WEST)";
-	icon_state = "vault";
 	dir = 8
 	},
 /area/medical/medbay/zone3)
@@ -29321,8 +28913,6 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel/vault/side{
-	tag = "icon-vault (EAST)";
-	icon_state = "vault";
 	dir = 4
 	},
 /area/medical/medbay/zone3)
@@ -29552,8 +29142,6 @@
 /obj/item/cautery,
 /obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel/vault/side{
-	tag = "icon-vault (EAST)";
-	icon_state = "vault";
 	dir = 4
 	},
 /area/science/robotics/lab)
@@ -29578,8 +29166,6 @@
 	},
 /obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel/vault/side{
-	tag = "icon-vault (WEST)";
-	icon_state = "vault";
 	dir = 8
 	},
 /area/science/robotics/lab)
@@ -29635,12 +29221,14 @@
 /obj/structure/chair/stool/bar,
 /obj/effect/landmark/revenantspawn,
 /turf/open/floor/wood{
+	broken = 1;
 	icon_state = "wood-broken"
 	},
 /area/maintenance/port)
 "bdF" = (
 /obj/structure/chair/stool/bar,
 /turf/open/floor/wood{
+	broken = 1;
 	icon_state = "wood-broken5"
 	},
 /area/maintenance/port)
@@ -29648,6 +29236,7 @@
 /obj/structure/chair/stool/bar,
 /obj/effect/landmark/revenantspawn,
 /turf/open/floor/wood{
+	broken = 1;
 	icon_state = "wood-broken2"
 	},
 /area/maintenance/port)
@@ -29833,8 +29422,6 @@
 	network = list("SS13")
 	},
 /turf/open/floor/plasteel/vault/side{
-	tag = "icon-vault (WEST)";
-	icon_state = "vault";
 	dir = 8
 	},
 /area/medical/medbay/zone3)
@@ -29851,8 +29438,6 @@
 	pixel_y = -26
 	},
 /turf/open/floor/plasteel/vault/side{
-	tag = "icon-vault (EAST)";
-	icon_state = "vault";
 	dir = 4
 	},
 /area/medical/medbay/zone3)
@@ -29965,7 +29550,6 @@
 /area/science/robotics/mechbay)
 "bej" = (
 /obj/machinery/mech_bay_recharge_port{
-	icon_state = "recharge_port";
 	dir = 8
 	},
 /obj/effect/turf_decal/stripes/line{
@@ -30004,8 +29588,6 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel/vault/side{
-	tag = "icon-vault (NORTH)";
-	icon_state = "vault";
 	dir = 1
 	},
 /area/science/robotics/lab)
@@ -30016,8 +29598,6 @@
 	},
 /obj/effect/turf_decal/delivery,
 /turf/open/floor/plasteel/vault/side{
-	tag = "icon-vault (NORTH)";
-	icon_state = "vault";
 	dir = 1
 	},
 /area/science/robotics/lab)
@@ -30035,8 +29615,6 @@
 /obj/machinery/light,
 /obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel/vault/side{
-	tag = "icon-vault (EAST)";
-	icon_state = "vault";
 	dir = 4
 	},
 /area/science/robotics/lab)
@@ -30073,8 +29651,6 @@
 	},
 /obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel/vault/side{
-	tag = "icon-vault (WEST)";
-	icon_state = "vault";
 	dir = 8
 	},
 /area/science/robotics/lab)
@@ -30665,7 +30241,7 @@
 	icon_state = "4-8"
 	},
 /turf/open/floor/plating{
-	tag = "icon-platingdmg2";
+	broken = 1;
 	icon_state = "platingdmg2"
 	},
 /area/maintenance/starboard)
@@ -30712,6 +30288,7 @@
 	},
 /obj/effect/decal/remains/human,
 /turf/open/floor/plating{
+	burnt = 1;
 	icon_state = "panelscorched"
 	},
 /area/chapel/main)
@@ -30986,8 +30563,6 @@
 	dir = 8
 	},
 /turf/open/floor/plasteel/vault/side{
-	tag = "icon-vault (EAST)";
-	icon_state = "vault";
 	dir = 4
 	},
 /area/chapel/main)
@@ -31024,9 +30599,8 @@
 	name = "Station Intercom";
 	pixel_y = 24
 	},
-/turf/open/floor/plasteel{
-	dir = 1;
-	icon_state = "chapel"
+/turf/open/floor/plasteel/chapel{
+	dir = 1
 	},
 /area/chapel/main)
 "bfY" = (
@@ -31044,9 +30618,8 @@
 /obj/structure/cable/white{
 	icon_state = "0-2"
 	},
-/turf/open/floor/plasteel{
-	dir = 4;
-	icon_state = "chapel"
+/turf/open/floor/plasteel/chapel{
+	dir = 4
 	},
 /area/chapel/main)
 "bfZ" = (
@@ -31056,18 +30629,16 @@
 /obj/machinery/newscaster{
 	pixel_y = 32
 	},
-/turf/open/floor/plasteel{
-	dir = 1;
-	icon_state = "chapel"
+/turf/open/floor/plasteel/chapel{
+	dir = 1
 	},
 /area/chapel/main)
 "bga" = (
 /obj/structure/chair/wood/normal{
 	dir = 8
 	},
-/turf/open/floor/plasteel{
-	dir = 4;
-	icon_state = "chapel"
+/turf/open/floor/plasteel/chapel{
+	dir = 4
 	},
 /area/chapel/main)
 "bgb" = (
@@ -31141,8 +30712,6 @@
 	},
 /obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel/vault/side{
-	tag = "icon-vault (WEST)";
-	icon_state = "vault";
 	dir = 8
 	},
 /area/hallway/primary/central)
@@ -31309,8 +30878,6 @@
 	network = list("MINE")
 	},
 /turf/open/floor/plasteel/vault/side{
-	tag = "icon-vault (EAST)";
-	icon_state = "vault";
 	dir = 4
 	},
 /area/chapel/main)
@@ -31350,9 +30917,8 @@
 /obj/structure/cable/white{
 	icon_state = "4-8"
 	},
-/turf/open/floor/plasteel{
-	dir = 8;
-	icon_state = "chapel"
+/turf/open/floor/plasteel/chapel{
+	dir = 8
 	},
 /area/chapel/main)
 "bgJ" = (
@@ -31368,9 +30934,7 @@
 /obj/structure/cable/white{
 	icon_state = "2-8"
 	},
-/turf/open/floor/plasteel{
-	icon_state = "chapel"
-	},
+/turf/open/floor/plasteel/chapel,
 /area/chapel/main)
 "bgK" = (
 /obj/structure/chair/wood/normal{
@@ -31379,15 +30943,12 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 8
 	},
-/turf/open/floor/plasteel{
-	dir = 8;
-	icon_state = "chapel"
+/turf/open/floor/plasteel/chapel{
+	dir = 8
 	},
 /area/chapel/main)
 "bgL" = (
-/turf/open/floor/plasteel{
-	icon_state = "chapel"
-	},
+/turf/open/floor/plasteel/chapel,
 /area/chapel/main)
 "bgM" = (
 /obj/structure/table/wood,
@@ -31877,8 +31438,6 @@
 	},
 /obj/effect/turf_decal/delivery,
 /turf/open/floor/plasteel/vault/side{
-	tag = "icon-vault (WEST)";
-	icon_state = "vault";
 	dir = 8
 	},
 /area/hallway/secondary/entry)
@@ -31951,8 +31510,6 @@
 /obj/item/cultivator,
 /obj/effect/turf_decal/delivery,
 /turf/open/floor/plasteel/vault/side{
-	tag = "icon-vault (NORTH)";
-	icon_state = "vault";
 	dir = 1
 	},
 /area/maintenance/starboard)
@@ -31964,8 +31521,6 @@
 	},
 /obj/effect/turf_decal/delivery,
 /turf/open/floor/plasteel/vault/side{
-	tag = "icon-vault (NORTH)";
-	icon_state = "vault";
 	dir = 1
 	},
 /area/maintenance/starboard)
@@ -31975,8 +31530,6 @@
 /obj/item/reagent_containers/glass/bottle/nutrient/ez,
 /obj/effect/turf_decal/delivery,
 /turf/open/floor/plasteel/vault/side{
-	tag = "icon-vault (NORTH)";
-	icon_state = "vault";
 	dir = 1
 	},
 /area/maintenance/starboard)
@@ -31990,8 +31543,6 @@
 /obj/item/hatchet,
 /obj/effect/turf_decal/delivery,
 /turf/open/floor/plasteel/vault/side{
-	tag = "icon-vault (NORTH)";
-	icon_state = "vault";
 	dir = 1
 	},
 /area/maintenance/starboard)
@@ -32001,8 +31552,6 @@
 /obj/item/reagent_containers/glass/bottle/nutrient/rh,
 /obj/effect/turf_decal/delivery,
 /turf/open/floor/plasteel/vault/side{
-	tag = "icon-vault (NORTH)";
-	icon_state = "vault";
 	dir = 1
 	},
 /area/maintenance/starboard)
@@ -32106,9 +31655,8 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
-/turf/open/floor/plasteel{
-	dir = 1;
-	icon_state = "chapel"
+/turf/open/floor/plasteel/chapel{
+	dir = 1
 	},
 /area/chapel/main)
 "bik" = (
@@ -32121,9 +31669,8 @@
 /obj/structure/cable/white{
 	icon_state = "1-2"
 	},
-/turf/open/floor/plasteel{
-	dir = 4;
-	icon_state = "chapel"
+/turf/open/floor/plasteel/chapel{
+	dir = 4
 	},
 /area/chapel/main)
 "bil" = (
@@ -32133,9 +31680,8 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 6
 	},
-/turf/open/floor/plasteel{
-	dir = 1;
-	icon_state = "chapel"
+/turf/open/floor/plasteel/chapel{
+	dir = 1
 	},
 /area/chapel/main)
 "bim" = (
@@ -32143,9 +31689,8 @@
 	dir = 4
 	},
 /obj/effect/landmark/event_spawn,
-/turf/open/floor/plasteel{
-	dir = 4;
-	icon_state = "chapel"
+/turf/open/floor/plasteel/chapel{
+	dir = 4
 	},
 /area/chapel/main)
 "bin" = (
@@ -32302,8 +31847,6 @@
 	},
 /obj/effect/turf_decal/delivery,
 /turf/open/floor/plasteel/vault/side{
-	tag = "icon-vault (WEST)";
-	icon_state = "vault";
 	dir = 8
 	},
 /area/hallway/secondary/entry)
@@ -32314,7 +31857,6 @@
 "biC" = (
 /obj/machinery/shower{
 	dir = 4;
-	icon_state = "shower";
 	name = "emergency shower"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -32326,7 +31868,6 @@
 "biD" = (
 /obj/machinery/shower{
 	dir = 8;
-	icon_state = "shower";
 	name = "emergency shower"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -32453,9 +31994,8 @@
 /obj/structure/cable/white{
 	icon_state = "4-8"
 	},
-/turf/open/floor/plasteel{
-	dir = 8;
-	icon_state = "chapel"
+/turf/open/floor/plasteel/chapel{
+	dir = 8
 	},
 /area/chapel/main)
 "biQ" = (
@@ -32468,9 +32008,7 @@
 /obj/structure/cable/white{
 	icon_state = "1-8"
 	},
-/turf/open/floor/plasteel{
-	icon_state = "chapel"
-	},
+/turf/open/floor/plasteel/chapel,
 /area/chapel/main)
 "biR" = (
 /obj/structure/chair/wood/normal{
@@ -32479,9 +32017,8 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 9
 	},
-/turf/open/floor/plasteel{
-	dir = 8;
-	icon_state = "chapel"
+/turf/open/floor/plasteel/chapel{
+	dir = 8
 	},
 /area/chapel/main)
 "biS" = (
@@ -32494,9 +32031,7 @@
 	pixel_y = -24;
 	req_access_txt = "0"
 	},
-/turf/open/floor/plasteel{
-	icon_state = "chapel"
-	},
+/turf/open/floor/plasteel/chapel,
 /area/chapel/main)
 "biT" = (
 /obj/structure/bookcase,
@@ -33623,8 +33158,6 @@
 	},
 /obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel/vault/side{
-	tag = "icon-vault (WEST)";
-	icon_state = "vault";
 	dir = 8
 	},
 /area/hallway/primary/central)
@@ -33677,8 +33210,6 @@
 	},
 /obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel/vault/side{
-	tag = "icon-vault (WEST)";
-	icon_state = "vault";
 	dir = 8
 	},
 /area/hallway/primary/central)
@@ -33907,7 +33438,6 @@
 	},
 /obj/machinery/atmospherics/components/binary/pump{
 	dir = 4;
-	icon_state = "pump_map";
 	name = "Gas to Loop"
 	},
 /turf/open/floor/engine,
@@ -33984,8 +33514,6 @@
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on,
 /turf/open/floor/plasteel/escape{
-	tag = "icon-escape (NORTH)";
-	icon_state = "escape";
 	dir = 1
 	},
 /area/hallway/secondary/exit)
@@ -34001,8 +33529,6 @@
 	},
 /obj/machinery/door/firedoor,
 /turf/open/floor/plasteel/escape{
-	tag = "icon-escape (NORTH)";
-	icon_state = "escape";
 	dir = 1
 	},
 /area/hallway/secondary/exit)
@@ -34016,36 +33542,27 @@
 /obj/machinery/vending/snack/random,
 /obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel/vault/side{
-	tag = "icon-vault (EAST)";
-	icon_state = "vault";
 	dir = 4
 	},
 /area/hallway/secondary/exit)
 "bmG" = (
 /obj/effect/turf_decal/bot,
 /obj/structure/cable/white{
-	tag = "icon-4-8";
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
 /turf/open/floor/plasteel/vault/side{
-	tag = "icon-vault (EAST)";
-	icon_state = "vault";
 	dir = 4
 	},
 /area/hallway/secondary/exit)
 "bsv" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/structure/cable/white{
-	d1 = 2;
-	d2 = 8;
 	icon_state = "2-8"
 	},
 /obj/structure/cable/white{
-	d1 = 2;
-	d2 = 4;
 	icon_state = "2-4"
 	},
 /turf/open/floor/plasteel/escape{
@@ -34059,8 +33576,6 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/effect/turf_decal/bot,
 /obj/structure/cable/white{
-	d1 = 1;
-	d2 = 2;
 	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel,
@@ -34076,8 +33591,6 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/effect/turf_decal/bot,
 /obj/structure/cable/white{
-	d1 = 1;
-	d2 = 2;
 	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel,
@@ -34129,7 +33642,6 @@
 	dir = 4
 	},
 /obj/structure/cable/white{
-	tag = "icon-4-8";
 	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel,
@@ -34139,7 +33651,6 @@
 	dir = 4
 	},
 /obj/structure/cable/white{
-	tag = "icon-4-8";
 	icon_state = "4-8"
 	},
 /obj/machinery/status_display{
@@ -34151,7 +33662,6 @@
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden,
 /obj/machinery/light,
 /obj/structure/cable/white{
-	tag = "icon-4-8";
 	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel,
@@ -34161,7 +33671,6 @@
 	dir = 4
 	},
 /obj/structure/cable/white{
-	tag = "icon-4-8";
 	icon_state = "4-8"
 	},
 /obj/structure/sign/poster/official/random{
@@ -34174,15 +33683,12 @@
 	dir = 4
 	},
 /obj/structure/cable/white{
-	tag = "icon-2-8";
 	icon_state = "2-8"
 	},
 /obj/structure/cable/white{
-	tag = "icon-4-8";
 	icon_state = "4-8"
 	},
 /obj/structure/cable/white{
-	tag = "icon-1-2";
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -34214,8 +33720,6 @@
 	dir = 4
 	},
 /obj/structure/cable/white{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/effect/turf_decal/stripes/line{
@@ -34228,8 +33732,6 @@
 	dir = 1
 	},
 /obj/structure/cable/white{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel/neutral,
@@ -34243,13 +33745,9 @@
 	},
 /obj/effect/turf_decal/bot,
 /obj/structure/cable/white{
-	d1 = 1;
-	d2 = 8;
 	icon_state = "1-8"
 	},
 /obj/structure/cable/white{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel,
@@ -34257,8 +33755,6 @@
 "bsR" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/structure/cable/white{
-	d1 = 2;
-	d2 = 8;
 	icon_state = "2-8"
 	},
 /obj/effect/turf_decal/stripes/line{
@@ -34268,21 +33764,16 @@
 /area/hallway/secondary/exit)
 "bsS" = (
 /obj/structure/cable/white{
-	tag = "icon-1-2";
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plasteel/escape{
-	tag = "icon-escape (EAST)";
-	icon_state = "escape";
 	dir = 4
 	},
 /area/hallway/secondary/exit)
 "bsT" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/structure/cable/white{
-	d1 = 1;
-	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/effect/turf_decal/stripes/line{
@@ -34293,8 +33784,6 @@
 "bsV" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/structure/cable/white{
-	d1 = 1;
-	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/effect/turf_decal/stripes/line{
@@ -34309,8 +33798,6 @@
 	dir = 2
 	},
 /obj/structure/cable/white{
-	d1 = 1;
-	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/effect/turf_decal/stripes/line{
@@ -34324,16 +33811,12 @@
 /area/hallway/secondary/exit)
 "bsY" = (
 /obj/structure/cable/white{
-	tag = "icon-1-4";
 	icon_state = "1-4"
 	},
 /obj/structure/cable/white{
-	tag = "icon-4-8";
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	tag = "icon-intact (NORTHWEST)";
-	icon_state = "intact";
 	dir = 9
 	},
 /turf/open/floor/plasteel,
@@ -34341,8 +33824,6 @@
 "bsZ" = (
 /obj/machinery/door/firedoor,
 /obj/structure/cable/white{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/effect/turf_decal/delivery,
@@ -34354,8 +33835,6 @@
 /area/hallway/secondary/exit)
 "bta" = (
 /obj/structure/cable/white{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel/brown{
@@ -34367,8 +33846,6 @@
 	dir = 6
 	},
 /obj/structure/cable/white{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel/brown{
@@ -34381,8 +33858,6 @@
 	},
 /obj/effect/turf_decal/delivery,
 /obj/structure/cable/white{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel,
@@ -34390,8 +33865,6 @@
 "btd" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/structure/cable/white{
-	d1 = 1;
-	d2 = 8;
 	icon_state = "1-8"
 	},
 /turf/open/floor/plasteel/brown{
@@ -34920,8 +34393,6 @@
 	},
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/plasteel/vault/side{
-	tag = "icon-vault (WEST)";
-	icon_state = "vault";
 	dir = 8
 	},
 /area/bridge)
@@ -35033,8 +34504,6 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel/escape{
-	tag = "icon-escape (NORTH)";
-	icon_state = "escape";
 	dir = 1
 	},
 /area/hallway/secondary/exit)
@@ -35269,15 +34738,11 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel/vault/side{
-	tag = "icon-vault (NORTHWEST)";
-	icon_state = "vault";
 	dir = 9
 	},
 /area/bridge)
 "swy" = (
 /turf/open/floor/plasteel/vault/side{
-	tag = "icon-vault (WEST)";
-	icon_state = "vault";
 	dir = 8
 	},
 /area/bridge)
@@ -35298,8 +34763,6 @@
 	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel/vault/side{
-	tag = "icon-vault (WEST)";
-	icon_state = "vault";
 	dir = 8
 	},
 /area/bridge)
@@ -35329,8 +34792,6 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel/vault/side{
-	tag = "icon-vault (EAST)";
-	icon_state = "vault";
 	dir = 4
 	},
 /area/bridge)
@@ -35342,8 +34803,6 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel/vault/side{
-	tag = "icon-vault (WEST)";
-	icon_state = "vault";
 	dir = 8
 	},
 /area/bridge)
@@ -35742,8 +35201,6 @@
 /area/space)
 "sxY" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	tag = "icon-manifold (NORTH)";
-	icon_state = "manifold";
 	dir = 1
 	},
 /turf/open/floor/plating,
@@ -36119,8 +35576,6 @@
 "szJ" = (
 /obj/effect/decal/cleanable/cobweb,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	tag = "icon-intact (SOUTHEAST)";
-	icon_state = "intact";
 	dir = 6
 	},
 /turf/open/floor/plating,
@@ -36168,7 +35623,6 @@
 "szV" = (
 /obj/structure/table/reinforced,
 /obj/structure/cable/white{
-	d2 = 4;
 	icon_state = "0-4"
 	},
 /obj/machinery/power/apc{
@@ -36185,7 +35639,6 @@
 	pixel_y = 23
 	},
 /obj/structure/cable/white{
-	d2 = 4;
 	icon_state = "0-4"
 	},
 /turf/open/floor/plasteel/red/side{
@@ -36200,8 +35653,6 @@
 	pixel_y = 32
 	},
 /obj/structure/cable/white{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel/red/side{
@@ -36218,8 +35669,6 @@
 	pixel_y = 24
 	},
 /obj/structure/cable/white{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel/red/side{
@@ -36232,8 +35681,6 @@
 	pixel_y = 32
 	},
 /obj/structure/cable/white{
-	d1 = 2;
-	d2 = 8;
 	icon_state = "2-8"
 	},
 /turf/open/floor/plasteel/red/side{
@@ -36328,8 +35775,6 @@
 "sAs" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on,
 /obj/structure/cable/white{
-	d1 = 1;
-	d2 = 2;
 	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel/neutral,
@@ -36446,8 +35891,6 @@
 "sAS" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/structure/cable/white{
-	d1 = 1;
-	d2 = 2;
 	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel/red/side,
@@ -36495,6 +35938,7 @@
 	icon_state = "4-8"
 	},
 /turf/open/floor/plating{
+	broken = 1;
 	icon_state = "platingdmg1"
 	},
 /area/maintenance/starboard/central)
@@ -36559,8 +36003,6 @@
 "sBk" = (
 /obj/structure/table,
 /turf/open/floor/plasteel/escape{
-	tag = "icon-escape (NORTHEAST)";
-	icon_state = "escape";
 	dir = 5
 	},
 /area/space)
@@ -36570,7 +36012,6 @@
 "sBm" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable/white{
-	d2 = 4;
 	icon_state = "0-4"
 	},
 /turf/open/floor/plating,
@@ -36578,13 +36019,9 @@
 "sBn" = (
 /obj/machinery/door/firedoor,
 /obj/structure/cable/white{
-	d1 = 2;
-	d2 = 4;
 	icon_state = "2-4"
 	},
 /obj/structure/cable/white{
-	d1 = 2;
-	d2 = 8;
 	icon_state = "2-8"
 	},
 /obj/machinery/door/window/brigdoor/southright{
@@ -36594,8 +36031,6 @@
 	},
 /obj/structure/table/reinforced,
 /obj/structure/cable/white{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/item/folder/red,
@@ -36608,11 +36043,9 @@
 "sBo" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable/white{
-	d2 = 4;
 	icon_state = "0-4"
 	},
 /obj/structure/cable/white{
-	d2 = 8;
 	icon_state = "0-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -36621,19 +36054,13 @@
 "sBp" = (
 /obj/machinery/door/firedoor,
 /obj/structure/cable/white{
-	d1 = 2;
-	d2 = 8;
 	icon_state = "2-8"
 	},
 /obj/structure/cable/white{
-	d1 = 2;
-	d2 = 4;
 	icon_state = "2-4"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/structure/cable/white{
-	d1 = 1;
-	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/effect/turf_decal/stripes/line{
@@ -36644,7 +36071,6 @@
 "sBq" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable/white{
-	d2 = 8;
 	icon_state = "0-8"
 	},
 /turf/open/floor/plating,
@@ -36735,12 +36161,9 @@
 /area/space)
 "sBG" = (
 /obj/structure/cable/white{
-	tag = "icon-2-4";
 	icon_state = "2-4"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	tag = "icon-intact (SOUTHEAST)";
-	icon_state = "intact";
 	dir = 6
 	},
 /turf/open/floor/plating,
@@ -36760,7 +36183,6 @@
 	dir = 4
 	},
 /obj/structure/cable/white{
-	tag = "icon-4-8";
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -36770,7 +36192,6 @@
 /area/space)
 "sBI" = (
 /obj/structure/cable/white{
-	tag = "icon-4-8";
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -36782,12 +36203,9 @@
 /area/space)
 "sBJ" = (
 /obj/structure/cable/white{
-	tag = "icon-2-8";
 	icon_state = "2-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	tag = "icon-intact (SOUTHWEST)";
-	icon_state = "intact";
 	dir = 10
 	},
 /turf/open/floor/plasteel,
@@ -36811,8 +36229,6 @@
 /area/space)
 "sBM" = (
 /obj/structure/cable/white{
-	d1 = 1;
-	d2 = 4;
 	icon_state = "1-4"
 	},
 /turf/open/floor/plasteel/escape{
@@ -36822,13 +36238,9 @@
 "sBN" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/structure/cable/white{
-	d1 = 2;
-	d2 = 8;
 	icon_state = "2-8"
 	},
 /obj/structure/cable/white{
-	d1 = 2;
-	d2 = 4;
 	icon_state = "2-4"
 	},
 /turf/open/floor/plasteel/escape{
@@ -36837,8 +36249,6 @@
 /area/space)
 "sBO" = (
 /obj/structure/cable/white{
-	d1 = 1;
-	d2 = 8;
 	icon_state = "1-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -36890,7 +36300,6 @@
 /area/hallway/primary/central)
 "sBX" = (
 /obj/structure/cable/white{
-	tag = "icon-4-8";
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden,
@@ -36898,7 +36307,6 @@
 /area/space)
 "sBY" = (
 /obj/structure/cable/white{
-	tag = "icon-4-8";
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -36908,7 +36316,6 @@
 /area/space)
 "sBZ" = (
 /obj/structure/cable/white{
-	tag = "icon-4-8";
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -36918,7 +36325,6 @@
 /area/space)
 "sCa" = (
 /obj/structure/cable/white{
-	tag = "icon-4-8";
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -36928,7 +36334,6 @@
 /area/space)
 "sCb" = (
 /obj/structure/cable/white{
-	tag = "icon-4-8";
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -36938,7 +36343,6 @@
 /area/space)
 "sCc" = (
 /obj/structure/cable/white{
-	tag = "icon-4-8";
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -36948,7 +36352,6 @@
 /area/space)
 "sCd" = (
 /obj/structure/cable/white{
-	tag = "icon-4-8";
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -36958,12 +36361,9 @@
 /area/space)
 "sCe" = (
 /obj/structure/cable/white{
-	tag = "icon-1-8";
 	icon_state = "1-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	tag = "icon-intact (NORTHWEST)";
-	icon_state = "intact";
 	dir = 9
 	},
 /turf/open/floor/plating,
@@ -36974,20 +36374,16 @@
 "sCg" = (
 /obj/machinery/firealarm{
 	dir = 8;
-	pixel_x = -24;
-	pixel_y = 0
+	pixel_x = -24
 	},
 /turf/open/floor/plasteel,
 /area/space)
 "sCh" = (
 /obj/structure/cable/white{
-	tag = "icon-1-2";
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plasteel/escape{
-	tag = "icon-escape (EAST)";
-	icon_state = "escape";
 	dir = 4
 	},
 /area/space)
@@ -37013,8 +36409,6 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/effect/turf_decal/bot,
 /obj/structure/cable/white{
-	d1 = 1;
-	d2 = 2;
 	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel,
@@ -37049,7 +36443,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plating{
-	tag = "icon-platingdmg2";
+	broken = 1;
 	icon_state = "platingdmg2"
 	},
 /area/maintenance/port/central)
@@ -37057,7 +36451,7 @@
 /turf/open/floor/plating,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plating{
-	tag = "icon-platingdmg2";
+	broken = 1;
 	icon_state = "platingdmg2"
 	},
 /area/hallway/primary/central)
@@ -37105,12 +36499,9 @@
 /area/space)
 "sCF" = (
 /obj/structure/cable/white{
-	tag = "icon-1-2";
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	tag = "icon-manifold (WEST)";
-	icon_state = "manifold";
 	dir = 8
 	},
 /turf/open/floor/plasteel/neutral/side{
@@ -37152,8 +36543,6 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/effect/turf_decal/bot,
 /obj/structure/cable/white{
-	d1 = 1;
-	d2 = 2;
 	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel,
@@ -37209,8 +36598,6 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel/escape{
-	tag = "icon-escape (NORTH)";
-	icon_state = "escape";
 	dir = 1
 	},
 /area/space)
@@ -37229,8 +36616,6 @@
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on,
 /turf/open/floor/plasteel/escape{
-	tag = "icon-escape (NORTH)";
-	icon_state = "escape";
 	dir = 1
 	},
 /area/space)
@@ -37248,8 +36633,6 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel/escape{
-	tag = "icon-escape (NORTH)";
-	icon_state = "escape";
 	dir = 1
 	},
 /area/space)
@@ -37264,8 +36647,6 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel/escape{
-	tag = "icon-escape (NORTH)";
-	icon_state = "escape";
 	dir = 1
 	},
 /area/space)
@@ -37290,8 +36671,6 @@
 	},
 /obj/machinery/door/firedoor,
 /turf/open/floor/plasteel/escape{
-	tag = "icon-escape (NORTH)";
-	icon_state = "escape";
 	dir = 1
 	},
 /area/space)
@@ -37303,12 +36682,9 @@
 /area/space)
 "sDb" = (
 /obj/structure/cable/white{
-	tag = "icon-1-2";
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	tag = "icon-manifold (EAST)";
-	icon_state = "manifold";
 	dir = 4
 	},
 /turf/open/floor/plasteel/neutral/side{
@@ -37340,8 +36716,6 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/effect/turf_decal/bot,
 /obj/structure/cable/white{
-	d1 = 1;
-	d2 = 2;
 	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel,
@@ -37404,6 +36778,7 @@
 "sDp" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plating{
+	broken = 1;
 	icon_state = "platingdmg1"
 	},
 /area/hallway/primary/central)
@@ -37422,7 +36797,6 @@
 	dir = 4
 	},
 /obj/structure/cable/white{
-	tag = "icon-4-8";
 	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel,
@@ -37432,7 +36806,6 @@
 	dir = 4
 	},
 /obj/structure/cable/white{
-	tag = "icon-4-8";
 	icon_state = "4-8"
 	},
 /obj/machinery/status_display{
@@ -37444,7 +36817,6 @@
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden,
 /obj/machinery/light,
 /obj/structure/cable/white{
-	tag = "icon-4-8";
 	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel,
@@ -37454,7 +36826,6 @@
 	dir = 4
 	},
 /obj/structure/cable/white{
-	tag = "icon-4-8";
 	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel/escape,
@@ -37464,7 +36835,6 @@
 	dir = 4
 	},
 /obj/structure/cable/white{
-	tag = "icon-4-8";
 	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel,
@@ -37474,7 +36844,6 @@
 	dir = 4
 	},
 /obj/structure/cable/white{
-	tag = "icon-4-8";
 	icon_state = "4-8"
 	},
 /obj/structure/extinguisher_cabinet{
@@ -37491,7 +36860,6 @@
 	dir = 4
 	},
 /obj/structure/cable/white{
-	tag = "icon-4-8";
 	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel,
@@ -37501,7 +36869,6 @@
 	dir = 4
 	},
 /obj/structure/cable/white{
-	tag = "icon-4-8";
 	icon_state = "4-8"
 	},
 /obj/structure/sign/poster/official/random{
@@ -37514,7 +36881,6 @@
 	dir = 4
 	},
 /obj/structure/cable/white{
-	tag = "icon-4-8";
 	icon_state = "4-8"
 	},
 /obj/effect/turf_decal/stripes/line{
@@ -37534,12 +36900,9 @@
 	dir = 4
 	},
 /obj/structure/cable/white{
-	tag = "icon-4-8";
 	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel/escape/corner{
-	tag = "icon-escapecorner (WEST)";
-	icon_state = "escapecorner";
 	dir = 8
 	},
 /area/space)
@@ -37548,15 +36911,12 @@
 	dir = 4
 	},
 /obj/structure/cable/white{
-	tag = "icon-2-8";
 	icon_state = "2-8"
 	},
 /obj/structure/cable/white{
-	tag = "icon-4-8";
 	icon_state = "4-8"
 	},
 /obj/structure/cable/white{
-	tag = "icon-1-2";
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -37576,8 +36936,6 @@
 	dir = 8
 	},
 /obj/structure/cable/white{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel,
@@ -37588,8 +36946,6 @@
 	},
 /obj/effect/turf_decal/delivery,
 /obj/structure/cable/white{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel,
@@ -37599,8 +36955,6 @@
 	dir = 1
 	},
 /obj/structure/cable/white{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel/neutral,
@@ -37614,13 +36968,9 @@
 	},
 /obj/effect/turf_decal/bot,
 /obj/structure/cable/white{
-	d1 = 1;
-	d2 = 8;
 	icon_state = "1-8"
 	},
 /obj/structure/cable/white{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel,
@@ -37628,8 +36978,6 @@
 "sDG" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/structure/cable/white{
-	d1 = 2;
-	d2 = 8;
 	icon_state = "2-8"
 	},
 /turf/open/floor/plasteel/neutral,
@@ -37702,7 +37050,6 @@
 "sDW" = (
 /obj/machinery/vending/cigarette,
 /obj/machinery/newscaster{
-	pixel_x = 0;
 	pixel_y = -30
 	},
 /turf/open/floor/plasteel/vault{
@@ -37721,13 +37068,10 @@
 /area/space)
 "sEa" = (
 /obj/structure/cable/white{
-	tag = "icon-1-2";
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plasteel/escape{
-	tag = "icon-escape (EAST)";
-	icon_state = "escape";
 	dir = 4
 	},
 /area/space)
@@ -37759,8 +37103,6 @@
 "sEf" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/structure/cable/white{
-	d1 = 1;
-	d2 = 2;
 	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel/neutral,
@@ -37790,8 +37132,6 @@
 "sEl" = (
 /obj/effect/decal/cleanable/cobweb,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	tag = "icon-intact (SOUTHEAST)";
-	icon_state = "intact";
 	dir = 6
 	},
 /turf/open/floor/plating,
@@ -37853,7 +37193,6 @@
 /area/space)
 "sEy" = (
 /obj/structure/cable/white{
-	tag = "icon-1-2";
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -37885,8 +37224,6 @@
 "sED" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/structure/cable/white{
-	d1 = 1;
-	d2 = 2;
 	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel/escape,
@@ -37945,15 +37282,12 @@
 	dir = 4
 	},
 /obj/structure/cable/white{
-	tag = "icon-4-8";
 	icon_state = "4-8"
 	},
 /turf/open/floor/plating,
 /area/hallway/primary/central)
 "sEL" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	tag = "icon-manifold (EAST)";
-	icon_state = "manifold";
 	dir = 4
 	},
 /turf/open/floor/plating,
@@ -38059,13 +37393,10 @@
 /area/space)
 "sFb" = (
 /obj/structure/cable/white{
-	tag = "icon-1-2";
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plasteel/escape{
-	tag = "icon-escape (EAST)";
-	icon_state = "escape";
 	dir = 4
 	},
 /area/space)
@@ -38105,8 +37436,6 @@
 	dir = 2
 	},
 /obj/structure/cable/white{
-	d1 = 1;
-	d2 = 2;
 	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel,
@@ -38155,22 +37484,16 @@
 	pixel_y = -3
 	},
 /turf/open/floor/plasteel/vault/side{
-	tag = "icon-vault (EAST)";
-	icon_state = "vault";
 	dir = 4
 	},
 /area/hallway/primary/central)
 "sFo" = (
 /turf/open/floor/plasteel/vault/side{
-	tag = "icon-vault (NORTHWEST)";
-	icon_state = "vault";
 	dir = 9
 	},
 /area/hallway/primary/central)
 "sFp" = (
 /turf/open/floor/plasteel/vault/side{
-	tag = "icon-vault (NORTHEAST)";
-	icon_state = "vault";
 	dir = 5
 	},
 /area/hallway/primary/central)
@@ -38186,8 +37509,6 @@
 /obj/item/device/analyzer,
 /obj/item/device/assembly/flash/handheld,
 /turf/open/floor/plasteel/vault/side{
-	tag = "icon-vault (WEST)";
-	icon_state = "vault";
 	dir = 8
 	},
 /area/hallway/primary/central)
@@ -38211,7 +37532,6 @@
 /area/hallway/secondary/exit)
 "sFu" = (
 /obj/structure/cable/white{
-	tag = "icon-4-8";
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden,
@@ -38235,7 +37555,6 @@
 	dir = 4
 	},
 /obj/structure/cable/white{
-	tag = "icon-4-8";
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -38245,7 +37564,6 @@
 /area/space)
 "sFw" = (
 /obj/structure/cable/white{
-	tag = "icon-4-8";
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -38255,7 +37573,6 @@
 /area/space)
 "sFx" = (
 /obj/structure/cable/white{
-	tag = "icon-4-8";
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -38265,7 +37582,6 @@
 /area/space)
 "sFy" = (
 /obj/structure/cable/white{
-	tag = "icon-4-8";
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -38291,7 +37607,6 @@
 	dir = 4
 	},
 /obj/structure/cable/white{
-	tag = "icon-4-8";
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -38301,7 +37616,6 @@
 /area/space)
 "sFA" = (
 /obj/structure/cable/white{
-	tag = "icon-4-8";
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden,
@@ -38322,7 +37636,6 @@
 	dir = 4
 	},
 /obj/structure/cable/white{
-	tag = "icon-4-8";
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -38333,7 +37646,6 @@
 "sFC" = (
 /obj/effect/turf_decal/bot,
 /obj/structure/cable/white{
-	tag = "icon-4-8";
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -38347,30 +37659,23 @@
 	pixel_y = -32
 	},
 /obj/structure/cable/white{
-	tag = "icon-4-8";
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
 /turf/open/floor/plasteel/escape{
-	tag = "icon-escape (SOUTHWEST)";
-	icon_state = "escape";
 	dir = 10
 	},
 /area/space)
 "sFE" = (
 /obj/structure/cable/white{
-	tag = "icon-1-4";
 	icon_state = "1-4"
 	},
 /obj/structure/cable/white{
-	tag = "icon-4-8";
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	tag = "icon-intact (NORTHWEST)";
-	icon_state = "intact";
 	dir = 9
 	},
 /turf/open/floor/plasteel,
@@ -38378,16 +37683,12 @@
 "sFF" = (
 /obj/machinery/door/firedoor,
 /obj/structure/cable/white{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel,
 /area/space)
 "sFG" = (
 /obj/structure/cable/white{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel/brown{
@@ -38399,8 +37700,6 @@
 	dir = 6
 	},
 /obj/structure/cable/white{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel/brown{
@@ -38413,8 +37712,6 @@
 	},
 /obj/effect/turf_decal/delivery,
 /obj/structure/cable/white{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel,
@@ -38422,8 +37719,6 @@
 "sFJ" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/structure/cable/white{
-	d1 = 1;
-	d2 = 8;
 	icon_state = "1-8"
 	},
 /turf/open/floor/plasteel/brown{
@@ -38478,6 +37773,7 @@
 "sFQ" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plating{
+	broken = 1;
 	icon_state = "platingdmg1"
 	},
 /area/hallway/primary/central)
@@ -38497,23 +37793,17 @@
 	pixel_y = -3
 	},
 /turf/open/floor/plasteel/vault/side{
-	tag = "icon-vault (EAST)";
-	icon_state = "vault";
 	dir = 4
 	},
 /area/hallway/primary/central)
 "sFS" = (
 /turf/open/floor/plasteel/vault/side{
-	tag = "icon-vault (SOUTHWEST)";
-	icon_state = "vault";
 	dir = 10
 	},
 /area/hallway/primary/central)
 "sFT" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on,
 /turf/open/floor/plasteel/vault/side{
-	tag = "icon-vault (SOUTHEAST)";
-	icon_state = "vault";
 	dir = 6
 	},
 /area/hallway/primary/central)
@@ -38529,8 +37819,6 @@
 /obj/item/electronics/airlock,
 /obj/item/stock_parts/cell/high,
 /turf/open/floor/plasteel/vault/side{
-	tag = "icon-vault (WEST)";
-	icon_state = "vault";
 	dir = 8
 	},
 /area/hallway/primary/central)
@@ -38557,8 +37845,6 @@
 /obj/item/clothing/mask/breath,
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plasteel/vault/side{
-	tag = "icon-vault (NORTH)";
-	icon_state = "vault";
 	dir = 1
 	},
 /area/hallway/secondary/exit)
@@ -38570,8 +37856,6 @@
 /obj/item/tank/internals/emergency_oxygen,
 /obj/item/tank/internals/emergency_oxygen,
 /turf/open/floor/plasteel/vault/side{
-	tag = "icon-vault (NORTH)";
-	icon_state = "vault";
 	dir = 1
 	},
 /area/hallway/secondary/exit)
@@ -38582,8 +37866,7 @@
 /obj/structure/sign/directions/engineering{
 	desc = "A sign that shows there are doors here. There are doors everywhere!";
 	icon_state = "doors";
-	name = "WARNING: EXTERNAL AIRLOCK";
-	tag = "icon-doors"
+	name = "WARNING: EXTERNAL AIRLOCK"
 	},
 /turf/closed/wall,
 /area/space)
@@ -38700,7 +37983,7 @@
 /turf/open/floor/plating,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plating{
-	tag = "icon-platingdmg2";
+	broken = 1;
 	icon_state = "platingdmg2"
 	},
 /area/hallway/primary/central)
@@ -38732,12 +38015,9 @@
 /area/hallway/primary/central)
 "sGA" = (
 /obj/structure/cable/white{
-	tag = "icon-2-4";
 	icon_state = "2-4"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	tag = "icon-intact (SOUTHEAST)";
-	icon_state = "intact";
 	dir = 6
 	},
 /turf/open/floor/plating{
@@ -38760,14 +38040,12 @@
 	dir = 4
 	},
 /obj/structure/cable/white{
-	tag = "icon-4-8";
 	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit)
 "sGC" = (
 /obj/structure/cable/white{
-	tag = "icon-4-8";
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -38779,12 +38057,9 @@
 /area/hallway/secondary/exit)
 "sGD" = (
 /obj/structure/cable/white{
-	tag = "icon-2-8";
 	icon_state = "2-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	tag = "icon-intact (SOUTHWEST)";
-	icon_state = "intact";
 	dir = 10
 	},
 /turf/open/floor/plasteel,
@@ -38912,7 +38187,6 @@
 /area/hallway/primary/central)
 "sGY" = (
 /obj/structure/cable/white{
-	tag = "icon-4-8";
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -38922,7 +38196,6 @@
 /area/hallway/primary/central)
 "sGZ" = (
 /obj/structure/cable/white{
-	tag = "icon-4-8";
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -38932,7 +38205,6 @@
 /area/hallway/primary/central)
 "sHa" = (
 /obj/structure/cable/white{
-	tag = "icon-4-8";
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -38942,7 +38214,6 @@
 /area/hallway/primary/central)
 "sHb" = (
 /obj/structure/cable/white{
-	tag = "icon-4-8";
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden,
@@ -38953,7 +38224,6 @@
 /area/hallway/primary/central)
 "sHc" = (
 /obj/structure/cable/white{
-	tag = "icon-4-8";
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -38963,7 +38233,6 @@
 /area/hallway/primary/central)
 "sHd" = (
 /obj/structure/cable/white{
-	tag = "icon-4-8";
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -38976,12 +38245,9 @@
 /area/hallway/primary/central)
 "sHe" = (
 /obj/structure/cable/white{
-	tag = "icon-1-8";
 	icon_state = "1-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	tag = "icon-intact (NORTHWEST)";
-	icon_state = "intact";
 	dir = 9
 	},
 /turf/open/floor/plating,
@@ -38989,20 +38255,16 @@
 "sHf" = (
 /obj/machinery/firealarm{
 	dir = 8;
-	pixel_x = -24;
-	pixel_y = 0
+	pixel_x = -24
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit)
 "sHg" = (
 /obj/structure/cable/white{
-	tag = "icon-1-2";
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plasteel/escape{
-	tag = "icon-escape (EAST)";
-	icon_state = "escape";
 	dir = 4
 	},
 /area/hallway/secondary/exit)
@@ -39083,8 +38345,6 @@
 /obj/structure/closet/crate/bin,
 /obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel/vault/side{
-	tag = "icon-vault (WEST)";
-	icon_state = "vault";
 	dir = 8
 	},
 /area/hallway/primary/central)
@@ -39098,12 +38358,9 @@
 /area/hallway/secondary/exit)
 "sHC" = (
 /obj/structure/cable/white{
-	tag = "icon-1-2";
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	tag = "icon-manifold (WEST)";
-	icon_state = "manifold";
 	dir = 8
 	},
 /turf/open/floor/plasteel/neutral/side{
@@ -39225,8 +38482,6 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel/escape{
-	tag = "icon-escape (NORTH)";
-	icon_state = "escape";
 	dir = 1
 	},
 /area/hallway/secondary/exit)
@@ -39250,12 +38505,9 @@
 /area/hallway/secondary/exit)
 "sId" = (
 /obj/structure/cable/white{
-	tag = "icon-1-2";
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	tag = "icon-manifold (EAST)";
-	icon_state = "manifold";
 	dir = 4
 	},
 /turf/open/floor/plasteel/neutral/side{
@@ -39301,6 +38553,7 @@
 /obj/effect/landmark/xeno_spawn,
 /obj/machinery/atmospherics/components/unary/vent_pump/on,
 /turf/open/floor/wood{
+	broken = 1;
 	icon_state = "wood-broken"
 	},
 /area/space)
@@ -39359,7 +38612,6 @@
 	dir = 4
 	},
 /obj/structure/cable/white{
-	tag = "icon-4-8";
 	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel/escape,
@@ -39369,7 +38621,6 @@
 	dir = 4
 	},
 /obj/structure/cable/white{
-	tag = "icon-4-8";
 	icon_state = "4-8"
 	},
 /obj/structure/extinguisher_cabinet{
@@ -39386,7 +38637,6 @@
 	dir = 4
 	},
 /obj/structure/cable/white{
-	tag = "icon-4-8";
 	icon_state = "4-8"
 	},
 /obj/effect/turf_decal/stripes/line{
@@ -39406,12 +38656,9 @@
 	dir = 4
 	},
 /obj/structure/cable/white{
-	tag = "icon-4-8";
 	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel/escape/corner{
-	tag = "icon-escapecorner (WEST)";
-	icon_state = "escapecorner";
 	dir = 8
 	},
 /area/hallway/secondary/exit)
@@ -39443,13 +38690,10 @@
 "sIG" = (
 /obj/machinery/vending/cigarette,
 /obj/machinery/newscaster{
-	pixel_x = 0;
 	pixel_y = -30
 	},
 /obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel/vault/side{
-	tag = "icon-vault (NORTH)";
-	icon_state = "vault";
 	dir = 1
 	},
 /area/hallway/secondary/exit)
@@ -39474,6 +38718,7 @@
 	icon_state = "1-2"
 	},
 /turf/open/floor/plating{
+	broken = 1;
 	icon_state = "platingdmg1"
 	},
 /area/maintenance/starboard/central)
@@ -39498,8 +38743,6 @@
 /obj/machinery/vending/cola/random,
 /obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel/vault/side{
-	tag = "icon-vault (EAST)";
-	icon_state = "vault";
 	dir = 4
 	},
 /area/hallway/secondary/exit)
@@ -39510,7 +38753,6 @@
 /area/hallway/secondary/exit)
 "sIR" = (
 /obj/structure/cable/white{
-	tag = "icon-1-2";
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -39607,18 +38849,17 @@
 	dir = 4
 	},
 /obj/structure/cable/white{
-	tag = "icon-4-8";
 	icon_state = "4-8"
 	},
 /turf/open/floor/plating,
 /area/hallway/primary/central)
 "sJc" = (
 /obj/structure/cable/white{
-	tag = "icon-4-8";
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden,
 /turf/open/floor/plating{
+	broken = 1;
 	icon_state = "platingdmg1"
 	},
 /area/hallway/secondary/exit)
@@ -39640,7 +38881,6 @@
 	dir = 4
 	},
 /obj/structure/cable/white{
-	tag = "icon-4-8";
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -39650,7 +38890,6 @@
 /area/hallway/secondary/exit)
 "sJe" = (
 /obj/structure/cable/white{
-	tag = "icon-4-8";
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -39660,7 +38899,6 @@
 /area/hallway/secondary/exit)
 "sJf" = (
 /obj/structure/cable/white{
-	tag = "icon-4-8";
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -39670,7 +38908,6 @@
 /area/hallway/secondary/exit)
 "sJg" = (
 /obj/structure/cable/white{
-	tag = "icon-4-8";
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -39699,7 +38936,6 @@
 	dir = 4
 	},
 /obj/structure/cable/white{
-	tag = "icon-4-8";
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -39709,7 +38945,6 @@
 /area/hallway/secondary/exit)
 "sJi" = (
 /obj/structure/cable/white{
-	tag = "icon-4-8";
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden,
@@ -39727,7 +38962,6 @@
 	dir = 4
 	},
 /obj/structure/cable/white{
-	tag = "icon-4-8";
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -39741,15 +38975,12 @@
 	pixel_y = -32
 	},
 /obj/structure/cable/white{
-	tag = "icon-4-8";
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
 /turf/open/floor/plasteel/escape{
-	tag = "icon-escape (SOUTHWEST)";
-	icon_state = "escape";
 	dir = 10
 	},
 /area/hallway/secondary/exit)
@@ -39767,8 +38998,6 @@
 	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel/vault/side{
-	tag = "icon-vault (WEST)";
-	icon_state = "vault";
 	dir = 8
 	},
 /area/crew_quarters/bar/atrium)
@@ -39780,6 +39009,7 @@
 	icon_state = "2-8"
 	},
 /turf/open/floor/plating{
+	broken = 1;
 	icon_state = "platingdmg1"
 	},
 /area/maintenance/starboard/central)
@@ -39790,8 +39020,7 @@
 /obj/structure/sign/directions/engineering{
 	desc = "A sign that shows there are doors here. There are doors everywhere!";
 	icon_state = "doors";
-	name = "WARNING: EXTERNAL AIRLOCK";
-	tag = "icon-doors"
+	name = "WARNING: EXTERNAL AIRLOCK"
 	},
 /turf/closed/wall,
 /area/hallway/secondary/exit)
@@ -39850,8 +39079,6 @@
 	pixel_x = 12
 	},
 /turf/open/floor/plasteel/vault/side{
-	tag = "icon-vault (NORTH)";
-	icon_state = "vault";
 	dir = 1
 	},
 /area/hydroponics)
@@ -39907,8 +39134,6 @@
 /obj/structure/closet/firecloset,
 /obj/effect/turf_decal/delivery,
 /turf/open/floor/plasteel/vault/side{
-	tag = "icon-vault (NORTH)";
-	icon_state = "vault";
 	dir = 1
 	},
 /area/hallway/primary/central)
@@ -39916,8 +39141,6 @@
 /obj/structure/closet/crate/bin,
 /obj/effect/turf_decal/delivery,
 /turf/open/floor/plasteel/vault/side{
-	tag = "icon-vault (NORTH)";
-	icon_state = "vault";
 	dir = 1
 	},
 /area/hallway/primary/central)
@@ -39955,6 +39178,7 @@
 	icon_state = "1-2"
 	},
 /turf/open/floor/wood{
+	broken = 1;
 	icon_state = "wood-broken7"
 	},
 /area/library)
@@ -40021,6 +39245,7 @@
 "sKd" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/wood{
+	broken = 1;
 	icon_state = "wood-broken"
 	},
 /area/library)
@@ -40029,6 +39254,7 @@
 	dir = 4
 	},
 /turf/open/floor/wood{
+	broken = 1;
 	icon_state = "wood-broken2"
 	},
 /area/library)
@@ -40221,6 +39447,7 @@
 	icon_state = "4-8"
 	},
 /turf/open/floor/plating{
+	broken = 1;
 	icon_state = "platingdmg3"
 	},
 /area/maintenance/starboard)
@@ -40263,8 +39490,6 @@
 	},
 /obj/effect/turf_decal/delivery,
 /turf/open/floor/plasteel/vault/side{
-	tag = "icon-vault (NORTH)";
-	icon_state = "vault";
 	dir = 1
 	},
 /area/maintenance/starboard)


### PR DESCRIPTION
Basically does what it says in the changelog. The aesthetic overhaul includes changing of maintenance tiles and adding of rusted walls here and there, along with some other tile replacements. I should note I also removed all instances of /obj/effect/decal/cleanable/dirt

:cl: Okand37
add: Overhauled aesthetic of some portions of Omegastation
add: Overhauled Omegastation's departure lounge, fitting it with the rest of the station's theme
add: Replaced the personal closets with wardrobes in Omegastation's Lockerroom
add: Made Omegastation's engine room floortiles reinforced
add: Replaced the cola and snack machines with their random counterparts on Omegastation
fix: Fixed Omegastation's self destruct console being a doomsday device
fix: Fixed Omegastation's chemistry shutters not all being synced and rearranged the chemmaster.
add: Added a small technology storage in maintenance near departures on Omegastation
add: Added additional loot and emergency supplies to maintenance on Omegastation
add: Added the X-01 Multiphase to the Captain's Locker, Blueprints to Vault, Reactive Teleportation Armor to Server Room and theHypospray to Medical Storage on Omegastation
/:cl: