### PR TITLE
fixes f1 ahelp

### DIFF
--- a/code/modules/admin/verbs/adminhelp.dm
+++ b/code/modules/admin/verbs/adminhelp.dm
@@ -475,6 +475,11 @@ GLOBAL_DATUM_INIT(ahelp_tickets, /datum/admin_help_tickets, new)
 	deltimer(adminhelptimerid)
 	adminhelptimerid = 0
 
+// Used for methods where input via arg doesn't work
+/client/proc/get_adminhelp()
+	var/msg = input(src, "Please describe your problem concisely and an admin will help as soon as they're able.", "Adminhelp contents") as text
+	adminhelp(msg)
+
 /client/verb/adminhelp(msg as text)
 	set category = "Admin"
 	set name = "Adminhelp"

--- a/code/modules/keybindings/bindings_client.dm
+++ b/code/modules/keybindings/bindings_client.dm
@@ -17,11 +17,14 @@
 			if(keys_held["Ctrl"] && keys_held["Shift"]) // Is this command ever used?
 				winset(src, null, "command=.options")
 			else
-				adminhelp()
+				get_adminhelp()
+			return
 		if("F2") // Screenshot. Hold shift to choose a name and location to save in
 			winset(src, null, "command=.screenshot [!keys_held["shift"] ? "auto" : ""]")
+			return
 		if("F12") // Toggles minimal HUD
 			mob.button_pressed_F12()
+			return
 
 	if(holder)
 		holder.key_down(_key, src)


### PR DESCRIPTION
:cl: ninjanomnom
fix: Pressing f1 to ahelp has been fixed
/:cl:

The text input was moved into the verb itself rather than being part of the args. This also lets us have a better message on the input window.