### PR TITLE
Makes clown burgers honk

### DIFF
--- a/code/modules/food_and_drinks/food/snacks.dm
+++ b/code/modules/food_and_drinks/food/snacks.dm
@@ -36,8 +36,8 @@
 	else
 		..()
 
-/obj/item/reagent_containers/food/snacks/proc/On_Consume()
-	if(!usr)
+/obj/item/reagent_containers/food/snacks/proc/On_Consume(mob/M)
+	if(!usr || !M)
 		return
 	if(!reagents.total_volume)
 		var/obj/item/trash_item = generate_trash(usr)
@@ -109,8 +109,9 @@
 				var/fraction = min(bitesize / reagents.total_volume, 1)
 				reagents.reaction(M, INGEST, fraction)
 				reagents.trans_to(M, bitesize)
+				reagents.maximum_volume -= bitesize
 				bitecount++
-				On_Consume()
+				On_Consume(M)
 				checkLiked(fraction, M)
 				return 1
 

--- a/code/modules/food_and_drinks/food/snacks_burgers.dm
+++ b/code/modules/food_and_drinks/food/snacks_burgers.dm
@@ -105,6 +105,10 @@
 	bonus_reagents = list("nutriment" = 4, "vitamin" = 6, "banana" = 6)
 	foodtype = GRAIN | FRUIT
 
+/obj/item/reagent_containers/food/snacks/burger/clown/On_Consume(mob/M)
+	playsound(src, 'sound/items/bikehorn.ogg', 50, 1)
+	..()
+
 /obj/item/reagent_containers/food/snacks/burger/mime
 	name = "mime burger"
 	desc = "Its taste defies language."

--- a/code/modules/hydroponics/grown.dm
+++ b/code/modules/hydroponics/grown.dm
@@ -116,7 +116,7 @@
 
 	qdel(src)
 
-/obj/item/reagent_containers/food/snacks/grown/On_Consume()
+/obj/item/reagent_containers/food/snacks/grown/On_Consume(mob/M)
 	if(iscarbon(usr))
 		if(seed)
 			for(var/datum/plant_gene/trait/T in seed.genes)


### PR DESCRIPTION
:cl: Swindly
add: Clown burgers honk when eaten
balance: The maximum reagent volume of food decreases as it is eaten
/:cl:

[why]:  (Please add a short description [two lines down] of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.)

I modified food's On_Consume so that it can do stuff when overridden. This provides a method of giving special effects to food as an alternative to adding reagents.