### PR TITLE
Reverts explosion shaking

### DIFF
--- a/code/datums/explosion.dm
+++ b/code/datums/explosion.dm
@@ -55,8 +55,6 @@ GLOBAL_LIST_EMPTY(explosions)
 	var/orig_heavy_range = heavy_impact_range
 	var/orig_light_range = light_impact_range
 	
-	var/orig_max_distance = max(devastation_range, heavy_impact_range, light_impact_range, flash_range, flame_range)
-	
 	//Zlevel specific bomb cap multiplier
 	var/cap_multiplier = 1
 	switch(epicenter.z)
@@ -121,13 +119,11 @@ GLOBAL_LIST_EMPTY(explosions)
 				// If inside the blast radius + world.view - 2
 				if(dist <= round(max_range + world.view - 2, 1))
 					M.playsound_local(epicenter, null, 100, 1, frequency, falloff = 5, S = explosion_sound)
-					shake_camera(M, 25, min(orig_max_distance - dist, 100))
 				// You hear a far explosion if you're outside the blast radius. Small bombs shouldn't be heard all over the station.
 				else if(dist <= far_dist)
 					var/far_volume = CLAMP(far_dist, 30, 50) // Volume is based on explosion size and dist
 					far_volume += (dist <= far_dist * 0.5 ? 50 : 0) // add 50 volume if the mob is pretty close to the explosion
 					M.playsound_local(epicenter, null, far_volume, 1, frequency, falloff = 5, S = far_explosion_sound)
-					shake_camera(M, 10, min(orig_max_distance - dist, 50))
 			EX_PREPROCESS_CHECK_TICK
 
 	//postpone processing for a bit


### PR DESCRIPTION
:cl: Frozenguy5
del: Explosions causing camera shake now have been removed.
/:cl:

Fixes #34004
[why]: visually unappealing and ~~clearly untested~~