### PR TITLE
Prevents Nar-Sie from being double-summoned

### DIFF
--- a/code/game/gamemodes/cult/runes.dm
+++ b/code/game/gamemodes/cult/runes.dm
@@ -484,8 +484,9 @@ structure_check() searches for nearby cultist structures required for the invoca
 
 	if(locate(/obj/singularity/narsie) in GLOB.poi_list)
 		for(var/M in invokers)
-			to_chat(M, "<span class='warning'>Nar-Sie is already on this plane!</span>")
-		log_game("Summon Nar-Sie rune failed - already summoned")
+			to_chat(M, "<span class='warning'>[src] fizzles uselessly, Nar-Sie is already on this plane!</span>")
+		playsound(src, 'sound/items/welder.ogg', 50, 1)
+		log_game("Summon Nar-Sie rune at [COORD(src)] failed - already summoned")
 		return
 	//BEGIN THE SUMMONING
 	used = TRUE
@@ -493,6 +494,10 @@ structure_check() searches for nearby cultist structures required for the invoca
 	sound_to_playing_players('sound/effects/dimensional_rend.ogg')
 	var/turf/T = get_turf(src)
 	sleep(40)
+	if(locate(/obj/singularity/narsie) in GLOB.poi_list)
+		T.visible_message("<span class='warning'>A faint fizzle could be heard echoing along with a soft chorus of screams and chanting...</span>")
+		playsound(T, 'sound/items/welder.ogg', 25, 1)
+		return
 	if(src)
 		color = RUNE_COLOR_RED
 	new /obj/singularity/narsie/large/cult(T) //Causes Nar-Sie to spawn even if the rune has been removed


### PR DESCRIPTION
Fixes #34016 

🆑 ShizCalev
fix: Nar-Sie can no longer be summoned twice at the same time.
/🆑