### PR TITLE
Fixes observers not being transfered to new mobs

### DIFF
--- a/code/datums/mind.dm
+++ b/code/datums/mind.dm
@@ -110,6 +110,7 @@
 	var/mob/living/old_current = current
 	current = new_character								//associate ourself with our new body
 	new_character.mind = src							//and associate our new body with ourself
+	old_current.transfer_observers_to(current)			//transfer anyone observing the old character to the new one
 	for(var/a in antag_datums)	//Makes sure all antag datums effects are applied in the new body
 		var/datum/antagonist/A = a
 		A.on_body_transfer(old_current, current)

--- a/code/modules/mob/living/carbon/alien/alien.dm
+++ b/code/modules/mob/living/carbon/alien/alien.dm
@@ -147,8 +147,6 @@ Des: Removes all infected images from the alien.
 		mind.transfer_to(new_xeno)
 	qdel(src)
 
-	// TODO make orbiters orbit the new xeno, or make xenos species rather than types
-
 #undef HEAT_DAMAGE_LEVEL_1
 #undef HEAT_DAMAGE_LEVEL_2
 #undef HEAT_DAMAGE_LEVEL_3


### PR DESCRIPTION
Fixes #33973 

🆑 ShizCalev
fix: Observers will no longer stop following a character if their mob changes.
/🆑