### PR TITLE
Fixes afterattack running when clicking a portal

### DIFF
--- a/code/game/objects/effects/portals.dm
+++ b/code/game/objects/effects/portals.dm
@@ -42,6 +42,7 @@
 /obj/effect/portal/attackby(obj/item/W, mob/user, params)
 	if(user && Adjacent(user))
 		user.forceMove(get_turf(src))
+		return TRUE
 
 /obj/effect/portal/Crossed(atom/movable/AM, oldloc)
 	if(isobserver(AM))


### PR DESCRIPTION
:cl:
fix: You no longer cut yourself with shards when clicking a portal
/:cl:
  
 Fixes #34030 