### PR TITLE
Fixes splash-fried deepfryholders not having any cooking oil in them

### DIFF
--- a/code/modules/reagents/chemistry/reagents/food_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/food_reagents.dm
@@ -101,6 +101,7 @@
 			O.loc.visible_message("<span class='warning'>[O] rapidly fries as it's splashed with hot oil! Somehow.</span>")
 			var/obj/item/reagent_containers/food/snacks/deepfryholder/F = new(O.drop_location(), O)
 			F.fry(volume)
+			F.reagents.add_reagent("cooking_oil", reac_volume)
 
 /datum/reagent/consumable/cooking_oil/reaction_mob(mob/living/M, method = TOUCH, reac_volume, show_message = 1, touch_protection = 0)
 	if(!istype(M))


### PR DESCRIPTION
Fixes #34024 

```
You bite the lightly-fried metal rod.
You can taste oil.
I love this taste!
```

[Changelogs]: 

:cl: Naksu
fix: splash-fried food is now actually edible
/:cl:
