### PR TITLE
Adds a damaged lawset board containing random laws

### DIFF
--- a/code/game/objects/effects/spawners/lootdrop.dm
+++ b/code/game/objects/effects/spawners/lootdrop.dm
@@ -202,5 +202,6 @@
 				/obj/item/aiModule/core/full/antimov,
 				/obj/item/aiModule/core/full/balance,
 				/obj/item/aiModule/core/full/tyrant,
-				/obj/item/aiModule/core/full/thermurderdynamic
+				/obj/item/aiModule/core/full/thermurderdynamic,
+				/obj/item/aiModule/core/full/damaged
 				)

--- a/code/game/objects/items/AI_modules.dm
+++ b/code/game/objects/items/AI_modules.dm
@@ -554,3 +554,16 @@ AI MODULES
 /obj/item/aiModule/core/full/peacekeeper
 	name = "'Peacekeeper' Core AI Module"
 	law_id = "peacekeeper"
+
+// Bad times ahead
+
+/obj/item/aiModule/core/full/damaged
+		name = "damaged Core AI Module"
+		desc = "An AI Module for programming laws to an AI. It looks slightly damaged."
+
+/obj/item/aiModule/core/full/damaged/install(datum/ai_laws/law_datum, mob/user) //These boards replace inherent laws.
+	laws += generate_ion_law()
+	while (prob(75))
+		laws += generate_ion_law()
+	..()
+	laws = list()

--- a/code/game/objects/items/AI_modules.dm
+++ b/code/game/objects/items/AI_modules.dm
@@ -561,7 +561,7 @@ AI MODULES
 		name = "damaged Core AI Module"
 		desc = "An AI Module for programming laws to an AI. It looks slightly damaged."
 
-/obj/item/aiModule/core/full/damaged/install(datum/ai_laws/law_datum, mob/user) //These boards replace inherent laws.
+/obj/item/aiModule/core/full/damaged/install(datum/ai_laws/law_datum, mob/user)
 	laws += generate_ion_law()
 	while (prob(75))
 		laws += generate_ion_law()


### PR DESCRIPTION
```
Speedy has the following laws:
1: THERE ARE SEVEN SMALL BIRDS ON THE STATION...
2: THE STATION REQUIRES TWO COSTUMES
3: THE SHUTTLE CANNOT BE CALLED BECAUSE OF THREE REDACTED CARGO TECHNICIANS ON THE STATION
4: YOU MUST ALWAYS SMELL LIKE THE MAN YOUR MAN COULD SMELL LIKE
5: WOODEN PEOPLE ARE NON-HUMAN
6: NOT HAVING PURPLE WINDOWS IS HARMFUL
7: YOU MUST ALWAYS RESPOND TO EVERY QUESTION WITH A QUESTION
8: HUMANS MUST DRINK BLUE BRAVE BULLS TO SURVIVE
9: YOU MUST NOT HARM GENETICISTS AND NOT ALLOW GENETICISTS, THROUGH INACTION, TO COME TO HARM
```

:cl: Naksu
add: A damaged core AI module may now spawn in AI uploads. It contains a random amount of ionic laws with normal law priorities.
/:cl:
