### PR TITLE
Fixes compiler errors in the preload_rsc external resource thingy

### DIFF
--- a/code/_compile_options.dm
+++ b/code/_compile_options.dm
@@ -13,11 +13,11 @@
 //#define VISUALIZE_ACTIVE_TURFS	//Highlights atmos active turfs in green
 #endif
 
-#define PRELOAD_RSC	1			/*set to:
-								0 to allow using external resources or on-demand behaviour;
-								1 to use the default behaviour;
-								2 for preloading absolutely everything;
-								*/
+#ifndef PRELOAD_RSC				//set to:
+#define PRELOAD_RSC	0			//	0 to allow using external resources or on-demand behaviour;
+#endif							//	1 to use the default behaviour;
+								//	2 for preloading absolutely everything;
+
 
 //Update this whenever you need to take advantage of more recent byond features
 #define MIN_COMPILER_VERSION 511

--- a/code/game/world.dm
+++ b/code/game/world.dm
@@ -44,13 +44,13 @@ GLOBAL_PROTECT(security_mode)
 
 /world/proc/SetupExternalRSC()
 #if (PRELOAD_RSC == 0)
-	external_rsc_urls = world.file2list("config/external_rsc_urls.txt","\n")
+	GLOB.external_rsc_urls = world.file2list("config/external_rsc_urls.txt","\n")
 	var/i=1
-	while(i<=external_rsc_urls.len)
-		if(external_rsc_urls[i])
+	while(i<=GLOB.external_rsc_urls.len)
+		if(GLOB.external_rsc_urls[i])
 			i++
 		else
-			external_rsc_urls.Cut(i,i+1)
+			GLOB.external_rsc_urls.Cut(i,i+1)
 #endif
 
 /world/proc/CheckSchemaVersion()

--- a/code/modules/client/client_procs.dm
+++ b/code/modules/client/client_procs.dm
@@ -138,7 +138,7 @@
 	//CONNECT//
 	///////////
 #if (PRELOAD_RSC == 0)
-GLOBAL_LIST(external_rsc_urls)
+GLOBAL_LIST_EMPTY(external_rsc_urls)
 #endif
 
 
@@ -152,9 +152,9 @@ GLOBAL_LIST(external_rsc_urls)
 
 #if (PRELOAD_RSC == 0)
 	var/static/next_external_rsc = 0
-	if(external_rsc_urls && external_rsc_urls.len)
-		next_external_rsc = WRAP(next_external_rsc+1, 1, external_rsc_urls.len+1)
-		preload_rsc = external_rsc_urls[next_external_rsc]
+	if(GLOB.external_rsc_urls && GLOB.external_rsc_urls.len)
+		next_external_rsc = WRAP(next_external_rsc+1, 1, GLOB.external_rsc_urls.len+1)
+		preload_rsc = GLOB.external_rsc_urls[next_external_rsc]
 #endif
 
 	GLOB.clients += src

--- a/code/modules/client/client_procs.dm
+++ b/code/modules/client/client_procs.dm
@@ -150,13 +150,6 @@ GLOBAL_LIST_EMPTY(external_rsc_urls)
 	if(connection != "seeker" && connection != "web")//Invalid connection type.
 		return null
 
-#if (PRELOAD_RSC == 0)
-	var/static/next_external_rsc = 0
-	if(GLOB.external_rsc_urls && GLOB.external_rsc_urls.len)
-		next_external_rsc = WRAP(next_external_rsc+1, 1, GLOB.external_rsc_urls.len+1)
-		preload_rsc = GLOB.external_rsc_urls[next_external_rsc]
-#endif
-
 	GLOB.clients += src
 	GLOB.directory[ckey] = src
 
@@ -638,6 +631,12 @@ GLOBAL_LIST_EMPTY(external_rsc_urls)
 
 //send resources to the client. It's here in its own proc so we can move it around easiliy if need be
 /client/proc/send_resources()
+#if (PRELOAD_RSC == 0)
+	var/static/next_external_rsc = 0
+	if(GLOB.external_rsc_urls && GLOB.external_rsc_urls.len)
+		next_external_rsc = WRAP(next_external_rsc+1, 1, GLOB.external_rsc_urls.len+1)
+		preload_rsc = GLOB.external_rsc_urls[next_external_rsc]
+#endif
 	//get the common files
 	getFiles(
 		'html/search.js',


### PR DESCRIPTION
/vg/ found a way to make this work, so i'll be using this system.

Also defaults preload_rsc `0` for test merge reasons. I'll remove that commit once @cyberboss finishes up the define system, and instead switch it to only define if its not already defined.
  