### PR TITLE
Fixes white power cables in DM

### DIFF
--- a/code/modules/power/cable.dm
+++ b/code/modules/power/cable.dm
@@ -76,6 +76,7 @@ By design, d1 is the smallest direction and d2 is the highest
 
 /obj/structure/cable/white
 	cable_color = "white"
+	color = "#ffffff"
 
 // the power cable object
 /obj/structure/cable/Initialize(mapload, param_color)


### PR DESCRIPTION
They were showing as red since their color wasn't properly set.