### PR TITLE
Adds more observation messages in deadchat

### DIFF
--- a/code/controllers/subsystem/shuttle.dm
+++ b/code/controllers/subsystem/shuttle.dm
@@ -247,7 +247,7 @@ SUBSYSTEM_DEF(shuttle)
 			emergency.request(null, signal_origin, html_decode(emergency_reason), 0)
 
 	log_game("[key_name(user)] has called the shuttle.")
-	deadchat_broadcast("<span class='deadsay'><b>[user.name] has called the shuttle.</b></span>", user)
+	deadchat_broadcast("<span class='deadsay bold'>[user.name] has called the shuttle.</span>", user)
 	if(call_reason)
 		SSblackbox.record_feedback("text", "shuttle_reason", 1, "[call_reason]")
 		log_game("Shuttle call reason: [call_reason]")
@@ -285,7 +285,7 @@ SUBSYSTEM_DEF(shuttle)
 		emergency.cancel(get_area(user))
 		log_game("[key_name(user)] has recalled the shuttle.")
 		message_admins("[key_name_admin(user)] has recalled the shuttle.")
-		deadchat_broadcast("<span class='deadsay'><b>[user.name] has recalled the shuttle.</b></span>", user)
+		deadchat_broadcast("<span class='deadsay bold'>[user.name] has recalled the shuttle.</span>", user)
 		return 1
 
 /datum/controller/subsystem/shuttle/proc/canRecall()

--- a/code/controllers/subsystem/shuttle.dm
+++ b/code/controllers/subsystem/shuttle.dm
@@ -247,6 +247,7 @@ SUBSYSTEM_DEF(shuttle)
 			emergency.request(null, signal_origin, html_decode(emergency_reason), 0)
 
 	log_game("[key_name(user)] has called the shuttle.")
+	deadchat_broadcast("<span class='deadsay'><b>[user.name] has called the shuttle.</b></span>", user)
 	if(call_reason)
 		SSblackbox.record_feedback("text", "shuttle_reason", 1, "[call_reason]")
 		log_game("Shuttle call reason: [call_reason]")
@@ -284,6 +285,7 @@ SUBSYSTEM_DEF(shuttle)
 		emergency.cancel(get_area(user))
 		log_game("[key_name(user)] has recalled the shuttle.")
 		message_admins("[key_name_admin(user)] has recalled the shuttle.")
+		deadchat_broadcast("<span class='deadsay'><b>[user.name] has recalled the shuttle.</b></span>", user)
 		return 1
 
 /datum/controller/subsystem/shuttle/proc/canRecall()

--- a/code/game/machinery/computer/communications.dm
+++ b/code/game/machinery/computer/communications.dm
@@ -112,9 +112,10 @@
 						to_chat(usr, "<span class='notice'>Authorization confirmed. Modifying security level.</span>")
 						playsound(src, 'sound/machines/terminal_prompt_confirm.ogg', 50, 0)
 						//Only notify people if an actual change happened
-						log_game("[key_name(usr)] has changed the security level to [get_security_level()].")
-						message_admins("[key_name_admin(usr)] has changed the security level to [get_security_level()].")
-						deadchat_broadcast("<span class='deadsay bold'>[usr.name] has changed the security level to [get_security_level()].</span>", usr)
+						var/security_level = get_security_level()
+						log_game("[key_name(usr)] has changed the security level to [security_level].")
+						message_admins("[key_name_admin(usr)] has changed the security level to [security_level].")
+						deadchat_broadcast("<span class='deadsay bold'>[usr.name] has changed the security level to [security_level].</span>", usr)
 					tmp_alertlevel = 0
 				else
 					to_chat(usr, "<span class='warning'>You are not authorized to do this!</span>")
@@ -386,9 +387,10 @@
 			set_security_level(tmp_alertlevel)
 			if(GLOB.security_level != old_level)
 				//Only notify people if an actual change happened
-				log_game("[key_name(usr)] has changed the security level to [get_security_level()].")
-				message_admins("[key_name_admin(usr)] has changed the security level to [get_security_level()].")
-				deadchat_broadcast("<span class='deadsay bold'>[usr.name] has changed the security level to [get_security_level()].</span>", usr)
+				var/security_level = get_security_level()
+				log_game("[key_name(usr)] has changed the security level to [security_level].")
+				message_admins("[key_name_admin(usr)] has changed the security level to [security_level].")
+				deadchat_broadcast("<span class='deadsay bold'>[usr.name] has changed the security level to [security_level].</span>", usr)
 			tmp_alertlevel = 0
 			aistate = STATE_DEFAULT
 		if("ai-changeseclevel")

--- a/code/game/machinery/computer/communications.dm
+++ b/code/game/machinery/computer/communications.dm
@@ -114,7 +114,7 @@
 						//Only notify people if an actual change happened
 						log_game("[key_name(usr)] has changed the security level to [get_security_level()].")
 						message_admins("[key_name_admin(usr)] has changed the security level to [get_security_level()].")
-						deadchat_broadcast("<span class='deadsay'><b>[usr.name] has changed the security level to [get_security_level()].</b></span>", usr)
+						deadchat_broadcast("<span class='deadsay bold'>[usr.name] has changed the security level to [get_security_level()].</span>", usr)
 					tmp_alertlevel = 0
 				else
 					to_chat(usr, "<span class='warning'>You are not authorized to do this!</span>")
@@ -129,7 +129,7 @@
 			if(authenticated==2)
 				playsound(src, 'sound/machines/terminal_prompt.ogg', 50, 0)
 				make_announcement(usr)
-				deadchat_broadcast("<span class='deadsay'><b>[usr.name] made an priority announcement.</b></span>", usr)
+				deadchat_broadcast("<span class='deadsay bold'>[usr.name] made an priority announcement.</span>", usr)
 
 		if("crossserver")
 			if(authenticated==2)
@@ -146,7 +146,7 @@
 				minor_announce(input, title = "Outgoing message to allied station")
 				log_talk(usr,"[key_name(usr)] has sent a message to the other server: [input]",LOGSAY)
 				message_admins("[key_name_admin(usr)] has sent a message to the other server.")
-				deadchat_broadcast("<span class='deadsay'><b>[usr.name] has sent an outgoing message to the other station(s).</b></span>", usr)
+				deadchat_broadcast("<span class='deadsay bold'>[usr.name] has sent an outgoing message to the other station(s).</span>", usr)
 				CM.lastTimeUsed = world.time
 
 		if("purchase_menu")
@@ -249,13 +249,13 @@
 			make_maint_all_access()
 			log_game("[key_name(usr)] enabled emergency maintenance access.")
 			message_admins("[key_name_admin(usr)] enabled emergency maintenance access.")
-			deadchat_broadcast("<span class='deadsay'><b>[usr.name] enabled emergency maintenance access.</b></span>", usr)
+			deadchat_broadcast("<span class='deadsay bold'>[usr.name] enabled emergency maintenance access.</span>", usr)
 			state = STATE_DEFAULT
 		if("disableemergency")
 			revoke_maint_all_access()
 			log_game("[key_name(usr)] disabled emergency maintenance access.")
 			message_admins("[key_name_admin(usr)] disabled emergency maintenance access.")
-			deadchat_broadcast("<span class='deadsay'><b>[usr.name] disabled emergency maintenance access.</b></span>", usr)
+			deadchat_broadcast("<span class='deadsay bold'>[usr.name] disabled emergency maintenance access.</span>", usr)
 			state = STATE_DEFAULT
 
 		// Status display stuff
@@ -388,7 +388,7 @@
 				//Only notify people if an actual change happened
 				log_game("[key_name(usr)] has changed the security level to [get_security_level()].")
 				message_admins("[key_name_admin(usr)] has changed the security level to [get_security_level()].")
-				deadchat_broadcast("<span class='deadsay'><b>[usr.name] has changed the security level to [get_security_level()].</b></span>", usr)
+				deadchat_broadcast("<span class='deadsay bold'>[usr.name] has changed the security level to [get_security_level()].</span>", usr)
 			tmp_alertlevel = 0
 			aistate = STATE_DEFAULT
 		if("ai-changeseclevel")
@@ -399,13 +399,13 @@
 			make_maint_all_access()
 			log_game("[key_name(usr)] enabled emergency maintenance access.")
 			message_admins("[key_name_admin(usr)] enabled emergency maintenance access.")
-			deadchat_broadcast("<span class='deadsay'><b>[usr.name] enabled emergency maintenance access.</b></span>", usr)
+			deadchat_broadcast("<span class='deadsay bold'>[usr.name] enabled emergency maintenance access.</span>", usr)
 			aistate = STATE_DEFAULT
 		if("ai-disableemergency")
 			revoke_maint_all_access()
 			log_game("[key_name(usr)] disabled emergency maintenance access.")
 			message_admins("[key_name_admin(usr)] disabled emergency maintenance access.")
-			deadchat_broadcast("<span class='deadsay'><b>[usr.name] disabled emergency maintenance access.</b></span>", usr)
+			deadchat_broadcast("<span class='deadsay bold'>[usr.name] disabled emergency maintenance access.</span>", usr)
 			aistate = STATE_DEFAULT
 
 	updateUsrDialog()

--- a/code/game/machinery/computer/communications.dm
+++ b/code/game/machinery/computer/communications.dm
@@ -111,9 +111,10 @@
 					if(GLOB.security_level != old_level)
 						to_chat(usr, "<span class='notice'>Authorization confirmed. Modifying security level.</span>")
 						playsound(src, 'sound/machines/terminal_prompt_confirm.ogg', 50, 0)
-						//Only notify the admins if an actual change happened
+						//Only notify people if an actual change happened
 						log_game("[key_name(usr)] has changed the security level to [get_security_level()].")
 						message_admins("[key_name_admin(usr)] has changed the security level to [get_security_level()].")
+						deadchat_broadcast("<span class='deadsay'><b>[usr.name] has changed the security level to [get_security_level()].</b></span>", usr)
 					tmp_alertlevel = 0
 				else
 					to_chat(usr, "<span class='warning'>You are not authorized to do this!</span>")
@@ -128,6 +129,7 @@
 			if(authenticated==2)
 				playsound(src, 'sound/machines/terminal_prompt.ogg', 50, 0)
 				make_announcement(usr)
+				deadchat_broadcast("<span class='deadsay'><b>[usr.name] made an priority announcement.</b></span>", usr)
 
 		if("crossserver")
 			if(authenticated==2)
@@ -144,6 +146,7 @@
 				minor_announce(input, title = "Outgoing message to allied station")
 				log_talk(usr,"[key_name(usr)] has sent a message to the other server: [input]",LOGSAY)
 				message_admins("[key_name_admin(usr)] has sent a message to the other server.")
+				deadchat_broadcast("<span class='deadsay'><b>[usr.name] has sent an outgoing message to the other station(s).</b></span>", usr)
 				CM.lastTimeUsed = world.time
 
 		if("purchase_menu")
@@ -246,11 +249,13 @@
 			make_maint_all_access()
 			log_game("[key_name(usr)] enabled emergency maintenance access.")
 			message_admins("[key_name_admin(usr)] enabled emergency maintenance access.")
+			deadchat_broadcast("<span class='deadsay'><b>[usr.name] enabled emergency maintenance access.</b></span>", usr)
 			state = STATE_DEFAULT
 		if("disableemergency")
 			revoke_maint_all_access()
 			log_game("[key_name(usr)] disabled emergency maintenance access.")
 			message_admins("[key_name_admin(usr)] disabled emergency maintenance access.")
+			deadchat_broadcast("<span class='deadsay'><b>[usr.name] disabled emergency maintenance access.</b></span>", usr)
 			state = STATE_DEFAULT
 
 		// Status display stuff
@@ -284,8 +289,8 @@
 				CentCom_announce(input, usr)
 				to_chat(usr, "<span class='notice'>Message transmitted to Central Command.</span>")
 				log_talk(usr,"[key_name(usr)] has made a CentCom announcement: [input]",LOGSAY)
+				deadchat_broadcast("<span class='deadsay'><b>[usr.name] has messaged CentComm:</b> [input]</span>", usr)
 				CM.lastTimeUsed = world.time
-
 
 		// OMG SYNDICATE ...LETTERHEAD
 		if("MessageSyndicate")
@@ -301,6 +306,7 @@
 				Syndicate_announce(input, usr)
 				to_chat(usr, "<span class='danger'>SYSERR @l(19833)of(transmit.dm): !@$ MESSAGE TRANSMITTED TO SYNDICATE COMMAND.</span>")
 				log_talk(usr,"[key_name(usr)] has made a Syndicate announcement: [input]",LOGSAY)
+				deadchat_broadcast("<span class='deadsay'><b>[usr.name] has messaged the Syndicate:</b> [input]</span>", usr)
 				CM.lastTimeUsed = world.time
 
 		if("RestoreBackup")
@@ -379,9 +385,10 @@
 				tmp_alertlevel = SEC_LEVEL_BLUE //Cannot engage delta with this
 			set_security_level(tmp_alertlevel)
 			if(GLOB.security_level != old_level)
-				//Only notify the admins if an actual change happened
+				//Only notify people if an actual change happened
 				log_game("[key_name(usr)] has changed the security level to [get_security_level()].")
 				message_admins("[key_name_admin(usr)] has changed the security level to [get_security_level()].")
+				deadchat_broadcast("<span class='deadsay'><b>[usr.name] has changed the security level to [get_security_level()].</b></span>", usr)
 			tmp_alertlevel = 0
 			aistate = STATE_DEFAULT
 		if("ai-changeseclevel")
@@ -392,11 +399,13 @@
 			make_maint_all_access()
 			log_game("[key_name(usr)] enabled emergency maintenance access.")
 			message_admins("[key_name_admin(usr)] enabled emergency maintenance access.")
+			deadchat_broadcast("<span class='deadsay'><b>[usr.name] enabled emergency maintenance access.</b></span>", usr)
 			aistate = STATE_DEFAULT
 		if("ai-disableemergency")
 			revoke_maint_all_access()
 			log_game("[key_name(usr)] disabled emergency maintenance access.")
 			message_admins("[key_name_admin(usr)] disabled emergency maintenance access.")
+			deadchat_broadcast("<span class='deadsay'><b>[usr.name] disabled emergency maintenance access.</b></span>", usr)
 			aistate = STATE_DEFAULT
 
 	updateUsrDialog()


### PR DESCRIPTION
[Changelogs]: 
:cl: Dax Dupont
add: The following messages have been added to dead chat: Security level change, (re)calling, Emergency Access, CentComm/Syndicate console messages, outgoing server messages and announcements,    
/:cl:

[why]: With the exception of messages which already displayed a name ICly(buying shuttles/nukecodes) I added dead chat messages with following links. This should make observing more interesting, especially since you can now find out who and where things are coming from instead of having to rely on OOC to tell it after the round or log diving. Especially on highpop rounds this is a plus!