### PR TITLE
Fixed PDAs not calling parent in equipped()

### DIFF
--- a/code/game/objects/items/devices/PDA/PDA.dm
+++ b/code/game/objects/items/devices/PDA/PDA.dm
@@ -94,6 +94,7 @@ GLOBAL_LIST_EMPTY(PDAs)
 	update_icon()
 
 /obj/item/device/pda/equipped(mob/user, slot)
+	. = ..()
 	if(!equipped)
 		if(user.client)
 			background_color = user.client.prefs.pda_color


### PR DESCRIPTION
Fixes #33763

:cl:
fix: Chameleon PDAs now have their chameleon action.
/:cl:
