### PR TITLE
Reduce away mission load time drastically

### DIFF
--- a/code/modules/mapping/map_template.dm
+++ b/code/modules/mapping/map_template.dm
@@ -49,8 +49,8 @@
 	SSair.setup_template_machinery(atmos_machines)
 
 /datum/map_template/proc/load_new_z()
-	var/x = round(world.maxx/2)
-	var/y = round(world.maxy/2)
+	var/x = round((world.maxx - width)/2)
+	var/y = round((world.maxy - height)/2)
 
 	var/list/bounds = maploader.load_map(file(mappath), x, y)
 	if(!bounds)


### PR DESCRIPTION
:cl:
fix: The startup load time of away missions has been drastically reduced.
/:cl:

The reduction is by about two minutes on my machine. Away mission loading is still iffy in other respects (particularly atmos) but at least now it's less of a pain for whoever wants to fix that.

The actual problem was a 255x255 map loading with its bottom-left corner at 127, 127... thereby expanding `maxx` and `maxy` and creating over one million excess space turfs.
  