### PR TITLE
Fix drone shells runtiming if no holidays are active

### DIFF
--- a/code/modules/mob/living/simple_animal/friendly/drone/drones_as_items.dm
+++ b/code/modules/mob/living/simple_animal/friendly/drone/drones_as_items.dm
@@ -26,7 +26,7 @@
 
 /obj/item/drone_shell/proc/build_seasonal_hats()
 	possible_seasonal_hats = list()
-	if(!SSevents.holidays.len)
+	if(!length(SSevents.holidays))
 		return //no holidays, no hats; we'll keep the empty list so we never call this proc again
 	for(var/V in SSevents.holidays)
 		var/datum/holiday/holiday = SSevents.holidays[V]


### PR DESCRIPTION
When no holidays are active, `SSevents.holidays` is null, not an empty list. Noticed locally, but also [observed on live](https://tgstation13.org/parsed-logs/sybil/data/logs/2018/01/04/round-81334/runtime.txt) (first error in the log).
  