### PR TITLE
goonchat linkify has been vastly improved

### DIFF
--- a/code/__HELPERS/mobs.dm
+++ b/code/__HELPERS/mobs.dm
@@ -427,6 +427,8 @@ Proc for attack log creation, because really why not
 				step(X, pick(NORTH, SOUTH, EAST, WEST))
 
 /proc/deadchat_broadcast(message, mob/follow_target=null, turf/turf_target=null, speaker_key=null, message_type=DEADCHAT_REGULAR)
+	//Linkify targets
+	message = "<span class='linkify'>[message]</span>"
 	for(var/mob/M in GLOB.player_list)
 		var/datum/preferences/prefs
 		if(M.client && M.client.prefs)
@@ -466,9 +468,9 @@ Proc for attack log creation, because really why not
 				var/turf_link = TURF_LINK(M, turf_target)
 				rendered_message = "[turf_link] [message]"
 
-			to_chat(M, rendered_message)
+			to_chat(M, rendered_message, linkify=TRUE)
 		else
-			to_chat(M, message)
+			to_chat(M, message, linkify=TRUE)
 
 
 /proc/log_talk(mob/user,message,logtype)

--- a/code/modules/admin/admin.dm
+++ b/code/modules/admin/admin.dm
@@ -1,12 +1,12 @@
 
 ////////////////////////////////
 /proc/message_admins(msg)
-	msg = "<span class=\"admin\"><span class=\"prefix\">ADMIN LOG:</span> <span class=\"message\">[msg]</span></span>"
-	to_chat(GLOB.admins, msg)
+	msg = "<span class=\"admin\"><span class=\"prefix\">ADMIN LOG:</span> <span class=\"message linkify\">[msg]</span></span>"
+	to_chat(GLOB.admins, msg, linkify=TRUE)
 
 /proc/relay_msg_admins(msg)
-	msg = "<span class=\"admin\"><span class=\"prefix\">RELAY:</span> <span class=\"message\">[msg]</span></span>"
-	to_chat(GLOB.admins, msg)
+	msg = "<span class=\"admin\"><span class=\"prefix\">RELAY:</span> <span class=\"message linkify\">[msg]</span></span>"
+	to_chat(GLOB.admins, msg, linkify=TRUE)
 
 
 ///////////////////////////////////////////////////////////////////////////////////////////////Panels

--- a/code/modules/admin/admin_verbs.dm
+++ b/code/modules/admin/admin_verbs.dm
@@ -147,6 +147,7 @@ GLOBAL_LIST_INIT(admin_verbs_debug, world.AVerbsDebug())
 	/client/proc/create_outfits,
 	/client/proc/modify_goals,
 	/client/proc/debug_huds,
+	/client/proc/goon_chat_debug,
 	/client/proc/map_template_load,
 	/client/proc/map_template_upload,
 	/client/proc/jump_to_ruin,

--- a/code/modules/admin/verbs/deadsay.dm
+++ b/code/modules/admin/verbs/deadsay.dm
@@ -1,17 +1,11 @@
 /client/proc/dsay(msg as text)
 	set category = "Special Verbs"
-	set name = "Dsay" //Gave this shit a shorter name so you only have to time out "dsay" rather than "dead say" to use it --NeoFite
+	set name = "Dsay"
 	set hidden = 1
-	if(!src.holder)
+	if(!holder)
 		to_chat(src, "Only administrators may use this command.")
 		return
-	if(!src.mob)
-		return
-	if(prefs.muted & MUTE_DEADCHAT)
-		to_chat(src, "<span class='danger'>You cannot send DSAY messages (muted).</span>")
-		return
-
-	if (src.handle_spam_prevention(msg,MUTE_DEADCHAT))
+	if(!mob)
 		return
 
 	msg = copytext(sanitize(msg), 1, MAX_MESSAGE_LEN)
@@ -20,13 +14,7 @@
 	if (!msg)
 		return
 	var/static/nicknames = world.file2list("[global.config.directory]/admin_nicknames.txt")
-
 	var/rendered = "<span class='game deadsay'><span class='prefix'>DEAD:</span> <span class='name'>ADMIN([src.holder.fakekey ? pick(nicknames) : src.key])</span> says, <span class='message'>\"[msg]\"</span></span>"
 
-	for (var/mob/M in GLOB.player_list)
-		if(isnewplayer(M))
-			continue
-		if (M.stat == DEAD || (M.client && M.client.holder && (M.client.prefs.chat_toggles & CHAT_DEAD))) //admins can toggle deadchat on and off. This is a proc in admin.dm and is only give to Administrators and above
-			M.show_message(rendered, 2)
-
+	deadchat_broadcast(rendered)
 	SSblackbox.record_feedback("tally", "admin_verb", 1, "Dsay") //If you are copy-pasting this, ensure the 2nd parameter is unique to the new proc!

--- a/code/modules/admin/verbs/debug.dm
+++ b/code/modules/admin/verbs/debug.dm
@@ -16,6 +16,9 @@
 	SSblackbox.record_feedback("tally", "admin_verb", 1, "Toggle Debug Two") //If you are copy-pasting this, ensure the 2nd parameter is unique to the new proc!
 
 /client/proc/goon_chat_debug()
+	set category = "Debug"
+	set name = "GoonChat Debug Console"
+	
 	chatOutput.enable_firebug()
 
 /* 21st Sept 2010

--- a/code/modules/admin/verbs/debug.dm
+++ b/code/modules/admin/verbs/debug.dm
@@ -15,7 +15,8 @@
 
 	SSblackbox.record_feedback("tally", "admin_verb", 1, "Toggle Debug Two") //If you are copy-pasting this, ensure the 2nd parameter is unique to the new proc!
 
-
+/client/proc/goon_chat_debug()
+	chatOutput.enable_firebug()
 
 /* 21st Sept 2010
 Updated by Skie -- Still not perfect but better!

--- a/code/modules/admin/verbs/pray.dm
+++ b/code/modules/admin/verbs/pray.dm
@@ -39,11 +39,11 @@
 			font_color = "blue"
 			prayer_type = "SPIRITUAL PRAYER"
 
-	msg = "<span class='adminnotice'>[icon2html(cross, GLOB.admins)]<b><font color=[font_color]>[prayer_type][deity ? " (to [deity])" : ""]: </font>[ADMIN_FULLMONTY(src)] [ADMIN_SC(src)]:</b> [msg]</span>"
+	msg = "<span class='adminnotice'>[icon2html(cross, GLOB.admins)]<b><font color=[font_color]>[prayer_type][deity ? " (to [deity])" : ""]: </font>[ADMIN_FULLMONTY(src)] [ADMIN_SC(src)]:</b> <span class='linkify'>[msg]</span></span>"
 
 	for(var/client/C in GLOB.admins)
 		if(C.prefs.chat_toggles & CHAT_PRAYER)
-			to_chat(C, msg)
+			to_chat(C, msg, linkify=TRUE)
 			if(C.prefs.toggles & SOUND_PRAYERS)
 				if(usr.job == "Chaplain")
 					SEND_SOUND(C, sound('sound/effects/pray.ogg'))

--- a/code/modules/client/verbs/ooc.dm
+++ b/code/modules/client/verbs/ooc.dm
@@ -63,7 +63,7 @@
 			if(holder)
 				if(!holder.fakekey || C.holder)
 					if(check_rights_for(src, R_ADMIN))
-						to_chat(C, "<span class='adminooc'>[CONFIG_GET(flag/allow_admin_ooccolor) && prefs.ooccolor ? "<font color=[prefs.ooccolor]>" :"" ]<span class='prefix'>OOC:</span> <EM>[keyname][holder.fakekey ? "/([holder.fakekey])" : ""]:</EM> <span class='message linkify'>[msg]</span></span></font>", linkify=TRUE)
+						to_chat(C, "<span class='adminooc'>[CONFIG_GET(flag/allow_admin_ooccolor) && prefs.ooccolor ? "<font color=[prefs.ooccolor]>" :"" ]<span class='prefix'>OOC:</span> <EM>[keyname][holder.fakekey ? "/([holder.fakekey])" : ""]:</EM> <span class='message linkify'>[msg]</span></font></span>", linkify=TRUE)
 					else
 						to_chat(C, "<span class='adminobserverooc'><span class='prefix'>OOC:</span> <EM>[keyname][holder.fakekey ? "/([holder.fakekey])" : ""]:</EM> <span class='message linkify'>[msg]</span></span>", linkify=TRUE)
 				else

--- a/code/modules/client/verbs/ooc.dm
+++ b/code/modules/client/verbs/ooc.dm
@@ -56,18 +56,20 @@
 	if(prefs.unlock_content)
 		if(prefs.toggles & MEMBER_PUBLIC)
 			keyname = "<font color='[prefs.ooccolor ? prefs.ooccolor : GLOB.normal_ooc_colour]'>[icon2html('icons/member_content.dmi', world, "blag")][keyname]</font>"
+
+	//The linkify span classes and linkify=TRUE below make ooc text get clickable chat href links if you pass in something resembling a url
 	for(var/client/C in GLOB.clients)
 		if(C.prefs.chat_toggles & CHAT_OOC)
 			if(holder)
 				if(!holder.fakekey || C.holder)
 					if(check_rights_for(src, R_ADMIN))
-						to_chat(C, "<span class='adminooc'>[CONFIG_GET(flag/allow_admin_ooccolor) && prefs.ooccolor ? "<font color=[prefs.ooccolor]>" :"" ]<span class='prefix'>OOC:</span> <EM>[keyname][holder.fakekey ? "/([holder.fakekey])" : ""]:</EM> <span class='message'>[msg]</span></span></font>")
+						to_chat(C, "<span class='adminooc'>[CONFIG_GET(flag/allow_admin_ooccolor) && prefs.ooccolor ? "<font color=[prefs.ooccolor]>" :"" ]<span class='prefix'>OOC:</span> <EM>[keyname][holder.fakekey ? "/([holder.fakekey])" : ""]:</EM> <span class='message linkify'>[msg]</span></span></font>", linkify=TRUE)
 					else
-						to_chat(C, "<span class='adminobserverooc'><span class='prefix'>OOC:</span> <EM>[keyname][holder.fakekey ? "/([holder.fakekey])" : ""]:</EM> <span class='message'>[msg]</span></span>")
+						to_chat(C, "<span class='adminobserverooc'><span class='prefix'>OOC:</span> <EM>[keyname][holder.fakekey ? "/([holder.fakekey])" : ""]:</EM> <span class='message linkify'>[msg]</span></span>", linkify=TRUE)
 				else
-					to_chat(C, "<font color='[GLOB.normal_ooc_colour]'><span class='ooc'><span class='prefix'>OOC:</span> <EM>[holder.fakekey ? holder.fakekey : key]:</EM> <span class='message'>[msg]</span></span></font>")
+					to_chat(C, "<font color='[GLOB.normal_ooc_colour]'><span class='ooc'><span class='prefix'>OOC:</span> <EM>[holder.fakekey ? holder.fakekey : key]:</EM> <span class='message linkify'>[msg]</span></span></font>", linkify=TRUE)
 			else if(!(key in C.prefs.ignoring))
-				to_chat(C, "<font color='[GLOB.normal_ooc_colour]'><span class='ooc'><span class='prefix'>OOC:</span> <EM>[keyname]:</EM> <span class='message'>[msg]</span></span></font>")
+				to_chat(C, "<font color='[GLOB.normal_ooc_colour]'><span class='ooc'><span class='prefix'>OOC:</span> <EM>[keyname]:</EM> <span class='message linkify'>[msg]</span></span></font>", linkify=TRUE)
 
 /proc/toggle_ooc(toggle = null)
 	if(toggle != null) //if we're specifically en/disabling ooc

--- a/code/modules/goonchat/browserassets/css/browserOutput.css
+++ b/code/modules/goonchat/browserassets/css/browserOutput.css
@@ -119,6 +119,23 @@ a.popt {text-decoration: none;}
 	top: 0;
 	right: 0;
 }
+#debug {
+	position: fixed;
+	display:none;
+	background:white;
+	width:100%;
+}
+#debugOutput {
+	height:200px;
+	width:100%;
+	background: white;
+	overflow-y:scroll;
+	overflow-x:hidden;
+	border-bottom: solid black 1px;
+}
+.debugControl {
+	display:block;
+}
 #userBar .subCell {
 	background: #ddd;
     height: 30px;

--- a/code/modules/goonchat/browserassets/html/browserOutput.html
+++ b/code/modules/goonchat/browserassets/html/browserOutput.html
@@ -19,6 +19,20 @@
 			If it <b>still</b> doesn't work, use the bug report button at the top right of the window.
 		</div>
 	</div>
+	<div id = "debug">
+		<textarea id="debugInput" rows="10", cols="80"></textarea>
+		<div class="debugControl">
+			<button id="debugbutton">Run script</button>
+			<button id="debuglogEnable">Set debug level</button>
+			<select id="debugLevel">
+			<option value="1">Normal</option>
+			<option value="2">Verbose</option>
+			<option value="3">Extreme</option>
+			</select>
+		</div>
+		<div id="debugOutput">
+		</div>
+	</div>
 	<div id="messages">
 
 	</div>

--- a/code/modules/goonchat/browserassets/js/browserOutput.js
+++ b/code/modules/goonchat/browserassets/js/browserOutput.js
@@ -124,7 +124,8 @@ function linkify(message) {
 		});
 		
 		// convert the processed jquery dom tree back to html for final insertion later in output processing
-		text = jqtext.html();
+		// NB: outerHTML because we need the div it's living inside as well
+		text = jqtext[0].outerHTML
 		return text;   
 }
 


### PR DESCRIPTION
    You must now explicitly specify if you want linkification by setting
    linkify=TRUE in the to_chat call, right now this is only enabled by
    default for OOC

    The linkification process is now also restricted to only the content
    inside spans that contain the class .linkify. This is because if we ran
    the linkify unrestricted on the entire message we would break things that
    are using URL's for specific purposes.

    For example, goonchat images are served as an <img src="url"> link, and if
    we were to replace the url in that with a clickable a href we would break
    the images being sent to chat

    The combination of flag and span class is entirely for performance, if there's no
    reason to run the linkify process over the message text, we can simply
    avoid doing so and not waste time doing work we don't need to do

Why:
previously in the image below, my name would have appeared as a clickable link in ic messages as well
![](https://file.house/_use.png)


The regex will match links of the form
www.tgstation13.org
https://tgstation13.org
https://tgstation13.org/some/url/shit
http://tgstation13.org
http://www.tgstation13.org
byond://sybil.tgstation13.org 

etc etc

Fixes #33996
Fixes #36924


I added a basic debug console that calls eval, which helps when doing on sight debugging of issues. It also gives you somewhere to send debug output that isn't just the main game screen. So you can leave it in as reuseable for future devs.
![](https://file.house/Aepq.png)
  