### PR TITLE
Show the correct coordinates when a pulse rifle prize is found

### DIFF
--- a/code/modules/projectiles/guns/energy/pulse.dm
+++ b/code/modules/projectiles/guns/energy/pulse.dm
@@ -20,7 +20,8 @@
 /obj/item/gun/energy/pulse/prize/Initialize()
 	. = ..()
 	GLOB.poi_list += src
-	var/msg = "A pulse rifle prize has been created at [ADMIN_COORDJMP(src)]"
+	var/turf/T = get_turf(src)
+	var/msg = "A pulse rifle prize has been created at [ADMIN_COORDJMP(T)]"
 
 	message_admins(msg)
 	log_game(msg)


### PR DESCRIPTION
:cl:
fix: The admin notification for the pulse rifle prize now shows the correct coordinates.
/:cl:

It's typically in a bag so x/y/z are 0, making the readout and JMP button useless. Saves the admins having to find it in `GLOB.poi_list` manually. If it ever happens again, that is.