### PR TITLE
Fixes buckled message spam for ghosts inside talking scythes

### DIFF
--- a/code/game/objects/items/holy_weapons.dm
+++ b/code/game/objects/items/holy_weapons.dm
@@ -229,7 +229,7 @@
 	hitsound = 'sound/weapons/rapierhit.ogg'
 	var/possessed = FALSE
 
-/obj/item/nullrod/scythe/talking/relaymove()
+/obj/item/nullrod/scythe/talking/relaymove(mob/user)
 	return //stops buckled message spam for the ghost.
 
 /obj/item/nullrod/scythe/talking/attack_self(mob/living/user)

--- a/code/game/objects/items/holy_weapons.dm
+++ b/code/game/objects/items/holy_weapons.dm
@@ -229,6 +229,9 @@
 	hitsound = 'sound/weapons/rapierhit.ogg'
 	var/possessed = FALSE
 
+/obj/item/nullrod/scythe/talking/relaymove()
+	return //stops buckled message spam for the ghost.
+
 /obj/item/nullrod/scythe/talking/attack_self(mob/living/user)
 	if(possessed)
 		return

--- a/code/modules/mob/living/brain/MMI.dm
+++ b/code/modules/mob/living/brain/MMI.dm
@@ -198,7 +198,7 @@
 		else
 			to_chat(user, "<span class='notice'>The MMI indicates the brain is active.</span>")
 
-/obj/item/device/mmi/relaymove()
+/obj/item/device/mmi/relaymove(mob/user)
 	return //so that the MMI won't get a warning about not being able to move if it tries to move
 
 /obj/item/device/mmi/syndie

--- a/code/modules/mob/living/inhand_holder.dm
+++ b/code/modules/mob/living/inhand_holder.dm
@@ -63,7 +63,7 @@
 		qdel(src)
 	return TRUE
 
-/obj/item/clothing/head/mob_holder/relaymove()
+/obj/item/clothing/head/mob_holder/relaymove(mob/user)
 	release()
 
 /obj/item/clothing/head/mob_holder/container_resist()


### PR DESCRIPTION
🆑 ShizCalev
fix: Ghosts possessing the chaplain's blade will no longer be spammed with the buckled movement message.
/🆑  