### PR TITLE
Reduces the memory footprint of the gas_mixture datum

### DIFF
--- a/code/modules/atmospherics/gasmixtures/gas_mixture.dm
+++ b/code/modules/atmospherics/gasmixtures/gas_mixture.dm
@@ -22,18 +22,16 @@ GLOBAL_LIST_INIT(gaslist_cache, init_gaslist_cache())
 
 /datum/gas_mixture
 	var/list/gases
-	var/temperature //kelvins
-	var/tmp/temperature_archived
-	var/volume //liters
-	var/last_share
+	var/temperature = 0 //kelvins
+	var/tmp/temperature_archived = 0
+	var/volume = CELL_VOLUME //liters
+	var/last_share = 0
 	var/list/reaction_results
 
-/datum/gas_mixture/New(volume = CELL_VOLUME)
+/datum/gas_mixture/New(volume)
 	gases = new
-	temperature = 0
-	temperature_archived = 0
-	src.volume = volume
-	last_share = 0
+	if (!isnull(volume))
+		src.volume = volume
 	reaction_results = new
 
 //listmos procs


### PR DESCRIPTION
To save memory, byond only stores vars that are written to, referring to the original compile time value stored once for each type, otherwise.

Originally we set defaults in New() to control the order of the vars in this changed vars list to optimize access speed, but this no longer makes sense to do because byond moved that from a linked list to a binary insertion sorted vector.

And making the volume default to the most popular case, and only get written too otherwise should be a noticeable memory improvement.
