### PR TITLE
Moves GLOB.movement_keys into SSinput and adds movement direction badminry

### DIFF
--- a/code/controllers/subsystem/input.dm
+++ b/code/controllers/subsystem/input.dm
@@ -7,9 +7,12 @@ SUBSYSTEM_DEF(input)
 	runlevels = RUNLEVELS_DEFAULT | RUNLEVEL_LOBBY
 
 	var/list/macro_sets
+	var/list/movement_keys
 
 /datum/controller/subsystem/input/Initialize()
 	setup_default_macro_sets()
+
+	setup_default_movement_keys()
 
 	initialized = TRUE
 
@@ -88,6 +91,15 @@ SUBSYSTEM_DEF(input)
 		old_default["Ctrl+[key]+UP"] = "\"KeyUp [override]\""
 
 	macro_sets = default_macro_sets
+
+// For initially setting up or resetting to default the movement keys
+/datum/controller/subsystem/input/proc/setup_default_movement_keys()
+	var/static/list/default_movement_keys = list(
+		"W" = NORTH, "A" = WEST, "S" = SOUTH, "D" = EAST,				// WASD
+		"North" = NORTH, "West" = WEST, "South" = SOUTH, "East" = EAST,	// Arrow keys & Numpad
+		)
+
+	movement_keys = default_movement_keys.Copy()
 
 // Badmins just wanna have fun ♪
 /datum/controller/subsystem/input/proc/refresh_client_macro_sets()

--- a/code/modules/admin/secrets.dm
+++ b/code/modules/admin/secrets.dm
@@ -65,6 +65,10 @@
 			<A href='?src=[REF(src)];[HrefToken()];secrets=whiteout'>Fix all lights</A><BR>
 			<A href='?src=[REF(src)];[HrefToken()];secrets=floorlava'>The floor is lava! (DANGEROUS: extremely lame)</A><BR>
 			<BR>
+			<A href='?src=[REF(src)];[HrefToken()];secrets=flipmovement'>Flip client movement directions</A><BR>
+			<A href='?src=[REF(src)];[HrefToken()];secrets=randommovement'>Randomize client movement directions</A><BR>
+			<A href='?src=[REF(src)];[HrefToken()];secrets=custommovement'>Set each movement direction manually</A><BR>
+			<BR>
 			<A href='?src=[REF(src)];[HrefToken()];secrets=changebombcap'>Change bomb cap</A><BR>
 			<A href='?src=[REF(src)];[HrefToken()];secrets=masspurrbation'>Mass Purrbation</A><BR>
 			<A href='?src=[REF(src)];[HrefToken()];secrets=massremovepurrbation'>Mass Remove Purrbation</A><BR>
@@ -564,6 +568,52 @@
 			message_admins("[key_name_admin(usr)] has removed everyone from \
 				purrbation.")
 			log_admin("[key_name(usr)] has removed everyone from purrbation.")
+
+		if("flipmovement")
+			if(!check_rights(R_FUN))
+				return
+			if(alert("Flip all movement controls?","Confirm","Yes","Cancel") == "Cancel")
+				return
+			var/list/movement_keys = GLOB.movement_keys
+			for(var/i in 1 to movement_keys.len)
+				var/key = movement_keys[i]
+				movement_keys[key] = turn(movement_keys[key], 180)
+			message_admins("[key_name_admin(usr)] has flipped all movement directions.")
+			log_admin("[key_name(usr)] has flipped all movement directions.")
+
+		if("randommovement")
+			if(!check_rights(R_FUN))
+				return
+			if(alert("Randomize all movement controls?","Confirm","Yes","Cancel") == "Cancel")
+				return
+			var/list/movement_keys = GLOB.movement_keys
+			for(var/i in 1 to movement_keys.len)
+				var/key = movement_keys[i]
+				movement_keys[key] = turn(movement_keys[key], 45 * rand(1, 8))
+			message_admins("[key_name_admin(usr)] has randomized all movement directions.")
+			log_admin("[key_name(usr)] has randomized all movement directions.")
+
+		if("custommovement")
+			if(!check_rights(R_FUN))
+				return
+			if(alert("Are you sure you want to change every movement key?","Confirm","Yes","Cancel") == "Cancel")
+				return
+			var/list/movement_keys = GLOB.movement_keys
+			var/list/new_movement = list()
+			for(var/i in 1 to movement_keys.len)
+				var/key = movement_keys[i]
+				
+				var/msg = "Please input the new movement direction when the user presses [key]. Ex. northeast"
+				var/title = "New direction for [key]"
+				var/new_direction = text2dir(input(usr, msg, title) as text|null)
+				if(!new_direction)
+					new_direction = movement_keys[key]
+				
+				new_movement[key] = new_direction
+			GLOB.movement_keys = new_movement
+			message_admins("[key_name_admin(usr)] has configured all movement directions.")
+			log_admin("[key_name(usr)] has configured all movement directions.")
+
 
 	if(E)
 		E.processing = FALSE

--- a/code/modules/admin/secrets.dm
+++ b/code/modules/admin/secrets.dm
@@ -68,6 +68,7 @@
 			<A href='?src=[REF(src)];[HrefToken()];secrets=flipmovement'>Flip client movement directions</A><BR>
 			<A href='?src=[REF(src)];[HrefToken()];secrets=randommovement'>Randomize client movement directions</A><BR>
 			<A href='?src=[REF(src)];[HrefToken()];secrets=custommovement'>Set each movement direction manually</A><BR>
+			<A href='?src=[REF(src)];[HrefToken()];secrets=resetmovement'>Reset movement directions to default</A><BR>
 			<BR>
 			<A href='?src=[REF(src)];[HrefToken()];secrets=changebombcap'>Change bomb cap</A><BR>
 			<A href='?src=[REF(src)];[HrefToken()];secrets=masspurrbation'>Mass Purrbation</A><BR>
@@ -574,7 +575,7 @@
 				return
 			if(alert("Flip all movement controls?","Confirm","Yes","Cancel") == "Cancel")
 				return
-			var/list/movement_keys = GLOB.movement_keys
+			var/list/movement_keys = SSinput.movement_keys
 			for(var/i in 1 to movement_keys.len)
 				var/key = movement_keys[i]
 				movement_keys[key] = turn(movement_keys[key], 180)
@@ -586,7 +587,7 @@
 				return
 			if(alert("Randomize all movement controls?","Confirm","Yes","Cancel") == "Cancel")
 				return
-			var/list/movement_keys = GLOB.movement_keys
+			var/list/movement_keys = SSinput.movement_keys
 			for(var/i in 1 to movement_keys.len)
 				var/key = movement_keys[i]
 				movement_keys[key] = turn(movement_keys[key], 45 * rand(1, 8))
@@ -598,7 +599,7 @@
 				return
 			if(alert("Are you sure you want to change every movement key?","Confirm","Yes","Cancel") == "Cancel")
 				return
-			var/list/movement_keys = GLOB.movement_keys
+			var/list/movement_keys = SSinput.movement_keys
 			var/list/new_movement = list()
 			for(var/i in 1 to movement_keys.len)
 				var/key = movement_keys[i]
@@ -610,10 +611,18 @@
 					new_direction = movement_keys[key]
 				
 				new_movement[key] = new_direction
-			GLOB.movement_keys = new_movement
+			SSinput.movement_keys = new_movement
 			message_admins("[key_name_admin(usr)] has configured all movement directions.")
 			log_admin("[key_name(usr)] has configured all movement directions.")
 
+		if("resetmovement")
+			if(!check_rights(R_FUN))
+				return
+			if(alert("Are you sure you want to reset movement keys to default?","Confirm","Yes","Cancel") == "Cancel")
+				return
+			SSinput.setup_default_movement_keys()
+			message_admins("[key_name_admin(usr)] has reset all movement keys.")
+			log_admin("[key_name(usr)] has reset all movement keys.")
 
 	if(E)
 		E.processing = FALSE

--- a/code/modules/keybindings/bindings_atom.dm
+++ b/code/modules/keybindings/bindings_atom.dm
@@ -5,7 +5,7 @@
 	if(!user.keys_held["Ctrl"])
 		var/movement_dir = NONE
 		for(var/_key in user.keys_held)
-			movement_dir = movement_dir | GLOB.movement_keys[_key]
+			movement_dir = movement_dir | SSinput.movement_keys[_key]
 		if(user.next_move_dir_add)
 			movement_dir |= user.next_move_dir_add
 		if(user.next_move_dir_sub)

--- a/code/modules/keybindings/bindings_client.dm
+++ b/code/modules/keybindings/bindings_client.dm
@@ -5,7 +5,7 @@
 	set hidden = TRUE
 
 	keys_held[_key] = world.time
-	var/movement = GLOB.movement_keys[_key]
+	var/movement = SSinput.movement_keys[_key]
 	if(!(next_move_dir_sub & movement))
 		next_move_dir_add |= movement
 
@@ -36,7 +36,7 @@
 	set hidden = TRUE
 
 	keys_held -= _key
-	var/movement = GLOB.movement_keys[_key]
+	var/movement = SSinput.movement_keys[_key]
 	if(!(next_move_dir_add & movement))
 		next_move_dir_sub |= movement
 

--- a/code/modules/keybindings/bindings_mob.dm
+++ b/code/modules/keybindings/bindings_mob.dm
@@ -56,7 +56,7 @@
 			return
 
 	if(client.keys_held["Ctrl"])
-		switch(GLOB.movement_keys[_key])
+		switch(SSinput.movement_keys[_key])
 			if(NORTH)
 				northface()
 				return

--- a/code/modules/keybindings/setup.dm
+++ b/code/modules/keybindings/setup.dm
@@ -14,12 +14,6 @@
 /datum/proc/keyLoop(client/user) // Called once every frame
 	return
 
-// Keys used for movement
-GLOBAL_LIST_INIT(movement_keys, list(
-	"W" = NORTH, "A" = WEST, "S" = SOUTH, "D" = EAST,														// WASD
-	"North" = NORTH, "West" = WEST, "South" = SOUTH, "East" = EAST,											// Arrow keys & Numpad
-	))
-
 // removes all the existing macros
 /client/proc/erase_all_macros()
 	var/list/macro_sets = params2list(winget(src, null, "macros"))


### PR DESCRIPTION
:cl: ninjanomnom
admin: There are 3 new helpers in the secrets menu for messing with movement controls
/:cl:

It's possible with var edits but this makes it so you can replace all the movement directions at once with no intermediate step of only some directions being edited.

Also hey it's fun.
