### PR TITLE
Exp now updates every minute

### DIFF
--- a/code/controllers/subsystem/blackbox.dm
+++ b/code/controllers/subsystem/blackbox.dm
@@ -31,7 +31,7 @@ SUBSYSTEM_DEF(blackbox)
 	query_record_playercount.Execute()
 
 	if(CONFIG_GET(flag/use_exp_tracking))
-		if((triggertime < 0) || (world.time > (triggertime +3000)))	//subsystem fires once at roundstart then once every 10 minutes. a 5 min check skips the first fire. The <0 is midnight rollover check
+		if((triggertime < 0) || (world.time > (triggertime +300)))	//subsystem fires once at roundstart then once every 10 minutes. a 5 min check skips the first fire. The <0 is midnight rollover check
 			update_exp(1, FALSE)
 
 

--- a/code/controllers/subsystem/blackbox.dm
+++ b/code/controllers/subsystem/blackbox.dm
@@ -32,7 +32,7 @@ SUBSYSTEM_DEF(blackbox)
 
 	if(CONFIG_GET(flag/use_exp_tracking))
 		if((triggertime < 0) || (world.time > (triggertime +3000)))	//subsystem fires once at roundstart then once every 10 minutes. a 5 min check skips the first fire. The <0 is midnight rollover check
-			update_exp(10,FALSE)
+			update_exp(1, FALSE)
 
 
 /datum/controller/subsystem/blackbox/Recover()

--- a/code/controllers/subsystem/blackbox.dm
+++ b/code/controllers/subsystem/blackbox.dm
@@ -1,6 +1,6 @@
 SUBSYSTEM_DEF(blackbox)
 	name = "Blackbox"
-	wait = 6000
+	wait = 600
 	flags = SS_NO_TICK_CHECK
 	runlevels = RUNLEVEL_GAME | RUNLEVEL_POSTGAME
 	init_order = INIT_ORDER_BLACKBOX


### PR DESCRIPTION
As opposed to 10 minutes

:cl:
fix: Resolution for job EXP tracking increased to 1 minute from 10
/:cl:

Also pop count

This fixes people not getting up to 9 minutes of EXP when they die