### PR TITLE
Adds package wrapping to autolathes

### DIFF
--- a/code/modules/research/designs/autolathe_designs.dm
+++ b/code/modules/research/designs/autolathe_designs.dm
@@ -814,7 +814,8 @@
 	materials = list(MAT_METAL = 200, MAT_GLASS = 200)
 	build_path = /obj/item/stack/packageWrap
 	category = list("initial", "Misc")
-	
+	maxstack = 30
+
 /datum/design/holodisk
 	name = "Holodisk"
 	id = "holodisk"

--- a/code/modules/research/designs/autolathe_designs.dm
+++ b/code/modules/research/designs/autolathe_designs.dm
@@ -807,6 +807,14 @@
 	build_path = /obj/item/stock_parts/cell/emergency_light
 	category = list("initial", "Electronics")
 
+/datum/design/packageWrap
+	name = "Package Wrapping"
+	id = "packagewrap"
+	build_type = AUTOLATHE
+	materials = list(MAT_METAL = 200, MAT_GLASS = 200)
+	build_path = /obj/item/stack/packageWrap
+	category = list("initial", "Misc")
+	
 /datum/design/holodisk
 	name = "Holodisk"
 	id = "holodisk"


### PR DESCRIPTION
adds package wrap to autolathes for 200 metal 200 glass

:cl: MrDoomBringer
add: Advances in NanoTrasen's wrapping department have resulted in the easy creation of package wrap from all station autolathes!
/:cl:

>break into delivery office, click twice on a table
>sorry buster no more package wrap for the station. ever.
