### PR TITLE
Updates the exp config default override hours and clarifies it a bit.

### DIFF
--- a/config/config.txt
+++ b/config/config.txt
@@ -51,7 +51,8 @@ BAN_LEGACY_SYSTEM
 ## Unhash this to enable playtime requirements for head jobs.
 #USE_EXP_RESTRICTIONS_HEADS
 ## Unhash this to override head jobs' playtime requirements with this number of hours.
-#USE_EXP_RESTRICTIONS_HEADS_HOURS 15
+## Leave this commented out to use the values defined in the job datums. Values in the datums are stored as minutes.
+#USE_EXP_RESTRICTIONS_HEADS_HOURS 3
 ## Unhash this to change head jobs' playtime requirements so that they're based on department playtime, rather than crew playtime.
 #USE_EXP_RESTRICTIONS_HEADS_DEPARTMENT 
 ## Unhash this to enable playtime requirements for certain non-head jobs, like Engineer and Scientist.


### PR DESCRIPTION
Requested by @MrStonedOne 

:cl:
config: The default config for head of staff exp override is closer to the actual default with no override.
/:cl: