### PR TITLE
Fixes archdevils creating wall girders when trying to destroy walls.

### DIFF
--- a/code/game/objects/items/twohanded.dm
+++ b/code/game/objects/items/twohanded.dm
@@ -661,7 +661,8 @@
 		user.visible_message("<span class='danger'>[user] blasts \the [target] with \the [src]!</span>")
 		playsound(target, 'sound/magic/disintegrate.ogg', 100, 1)
 		W.break_wall()
-		return 1
+		W.ScrapeAway()
+		return
 	..()
 
 //HF blade


### PR DESCRIPTION

:cl: Goodstuff
fix: Archdevils can now destroy walls properly.
/:cl:

The break_wall proc was just spawning a girder and sheet of metal over walls that got hit by the pitchfork so now this makes the wall go away.

This works but I am not sure I did it in the best way so please tell me if it can be done better.
