### PR TITLE
Fixes a few more issues with the syndie lavaland base.

### DIFF
--- a/_maps/RandomRuins/LavaRuins/lavaland_surface_syndicate_base1.dmm
+++ b/_maps/RandomRuins/LavaRuins/lavaland_surface_syndicate_base1.dmm
@@ -4114,9 +4114,10 @@
 "kZ" = (
 /obj/machinery/atmospherics/components/trinary/mixer/flipped{
 	dir = 4;
-	node1_concentration = 0.2;
-	node2_concentration = 0.8;
-	on = 1
+	node1_concentration = 0.8;
+	node2_concentration = 0.1;
+	on = 1;
+	target_pressure = 4500
 	},
 /turf/open/floor/plasteel/floorgrime,
 /area/ruin/unpowered/syndicate_lava_base/engineering)
@@ -5758,17 +5759,15 @@
 /obj/machinery/light/small{
 	dir = 4
 	},
-/obj/machinery/atmospherics/components/binary/pump{
-	dir = 2;
-	on = 0;
-	target_pressure = 101.325
-	},
 /obj/machinery/doorButtons/access_button{
 	idDoor = "syndie_lavaland_incinerator_interior";
 	idSelf = "syndie_lavaland_incinerator_access";
 	name = "Incinerator airlock control";
 	pixel_x = -8;
 	pixel_y = 24
+	},
+/obj/machinery/atmospherics/components/binary/pump/on{
+	target_pressure = 4500
 	},
 /turf/open/floor/engine,
 /area/ruin/unpowered/syndicate_lava_base/engineering)

--- a/_maps/RandomRuins/LavaRuins/lavaland_surface_syndicate_base1.dmm
+++ b/_maps/RandomRuins/LavaRuins/lavaland_surface_syndicate_base1.dmm
@@ -2190,7 +2190,8 @@
 	light_color = "#FA8282";
 	name = "syndicate cargo shuttle terminal";
 	possible_destinations = "syndielavaland_cargo";
-	req_access_txt = "150"
+	req_access_txt = "150";
+	shuttleId = "syndie_cargo"
 	},
 /turf/open/floor/mineral/plastitanium,
 /area/ruin/unpowered/syndicate_lava_base/cargo)

--- a/_maps/RandomRuins/LavaRuins/lavaland_surface_syndicate_base1.dmm
+++ b/_maps/RandomRuins/LavaRuins/lavaland_surface_syndicate_base1.dmm
@@ -455,11 +455,6 @@
 /area/ruin/unpowered/syndicate_lava_base/cargo)
 "eb" = (
 /obj/structure/closet/crate,
-/obj/item/storage/box/monkeycubes{
-	pixel_x = -3;
-	pixel_y = 3
-	},
-/obj/item/storage/box/monkeycubes,
 /obj/item/storage/toolbox/electrical{
 	pixel_y = 4
 	},
@@ -546,7 +541,9 @@
 /obj/machinery/iv_drip,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
-/mob/living/carbon/monkey,
+/mob/living/carbon/monkey{
+	faction = list("syndicate")
+	},
 /turf/open/floor/plasteel/vault{
 	dir = 8
 	},
@@ -888,7 +885,9 @@
 /obj/machinery/iv_drip,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
-/mob/living/carbon/monkey,
+/mob/living/carbon/monkey{
+	faction = list("syndicate")
+	},
 /turf/open/floor/plasteel/vault{
 	dir = 8
 	},
@@ -2198,7 +2197,9 @@
 /area/ruin/unpowered/syndicate_lava_base/cargo)
 "hp" = (
 /obj/effect/decal/cleanable/dirt,
-/mob/living/carbon/monkey,
+/mob/living/carbon/monkey{
+	faction = list("syndicate")
+	},
 /turf/open/floor/plasteel/white/side{
 	dir = 9
 	},
@@ -2217,7 +2218,9 @@
 	},
 /area/ruin/unpowered/syndicate_lava_base/virology)
 "hr" = (
-/mob/living/carbon/monkey,
+/mob/living/carbon/monkey{
+	faction = list("syndicate")
+	},
 /turf/open/floor/plasteel/white/side{
 	dir = 5
 	},
@@ -2341,7 +2344,9 @@
 /area/ruin/unpowered/syndicate_lava_base/cargo)
 "hE" = (
 /obj/effect/decal/cleanable/dirt,
-/mob/living/carbon/monkey,
+/mob/living/carbon/monkey{
+	faction = list("syndicate")
+	},
 /turf/open/floor/plasteel/white/side{
 	dir = 10
 	},
@@ -2359,7 +2364,9 @@
 /area/ruin/unpowered/syndicate_lava_base/virology)
 "hG" = (
 /obj/effect/decal/cleanable/dirt,
-/mob/living/carbon/monkey,
+/mob/living/carbon/monkey{
+	faction = list("syndicate")
+	},
 /turf/open/floor/plasteel/white/side{
 	dir = 6
 	},
@@ -2595,6 +2602,7 @@
 	dir = 9
 	},
 /turf/open/floor/plating{
+	baseturfs = /turf/open/lava/smooth/lava_land_surface;
 	initial_gas_mix = "o2=14;n2=23;TEMP=300"
 	},
 /area/lavaland/surface/outdoors)
@@ -2603,6 +2611,7 @@
 	dir = 1
 	},
 /turf/open/floor/plating{
+	baseturfs = /turf/open/lava/smooth/lava_land_surface;
 	initial_gas_mix = "o2=14;n2=23;TEMP=300"
 	},
 /area/lavaland/surface/outdoors)
@@ -2707,12 +2716,14 @@
 	dir = 8
 	},
 /turf/open/floor/plating{
+	baseturfs = /turf/open/lava/smooth/lava_land_surface;
 	initial_gas_mix = "o2=14;n2=23;TEMP=300"
 	},
 /area/lavaland/surface/outdoors)
 "iv" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating{
+	baseturfs = /turf/open/lava/smooth/lava_land_surface;
 	initial_gas_mix = "o2=14;n2=23;TEMP=300"
 	},
 /area/lavaland/surface/outdoors)
@@ -2866,6 +2877,7 @@
 	dir = 4
 	},
 /turf/open/floor/plating{
+	baseturfs = /turf/open/lava/smooth/lava_land_surface;
 	initial_gas_mix = "o2=14;n2=23;TEMP=300"
 	},
 /area/ruin/unpowered/syndicate_lava_base/arrivals)
@@ -3091,6 +3103,7 @@
 	dir = 4
 	},
 /turf/open/floor/plating{
+	baseturfs = /turf/open/lava/smooth/lava_land_surface;
 	initial_gas_mix = "o2=14;n2=23;TEMP=300"
 	},
 /area/lavaland/surface/outdoors)
@@ -3154,6 +3167,7 @@
 /area/ruin/unpowered/syndicate_lava_base/main)
 "jk" = (
 /turf/open/floor/plating{
+	baseturfs = /turf/open/lava/smooth/lava_land_surface;
 	initial_gas_mix = "o2=14;n2=23;TEMP=300"
 	},
 /area/lavaland/surface/outdoors)
@@ -4141,6 +4155,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating{
+	baseturfs = /turf/open/lava/smooth/lava_land_surface;
 	initial_gas_mix = "o2=14;n2=23;TEMP=300"
 	},
 /area/ruin/unpowered/syndicate_lava_base/arrivals)
@@ -4316,12 +4331,14 @@
 	dir = 10
 	},
 /turf/open/floor/plating{
+	baseturfs = /turf/open/lava/smooth/lava_land_surface;
 	initial_gas_mix = "o2=14;n2=23;TEMP=300"
 	},
 /area/lavaland/surface/outdoors)
 "lw" = (
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plating{
+	baseturfs = /turf/open/lava/smooth/lava_land_surface;
 	initial_gas_mix = "o2=14;n2=23;TEMP=300"
 	},
 /area/lavaland/surface/outdoors)

--- a/_maps/RandomRuins/LavaRuins/lavaland_surface_syndicate_base1.dmm
+++ b/_maps/RandomRuins/LavaRuins/lavaland_surface_syndicate_base1.dmm
@@ -2340,9 +2340,6 @@
 /area/ruin/unpowered/syndicate_lava_base/cargo)
 "hE" = (
 /mob/living/carbon/monkey{
-	faction = list("syndicate")
-	},
-/mob/living/carbon/monkey{
 	faction = list("neutral","syndicate")
 	},
 /turf/open/floor/plasteel/white/side{

--- a/_maps/RandomRuins/LavaRuins/lavaland_surface_syndicate_base1.dmm
+++ b/_maps/RandomRuins/LavaRuins/lavaland_surface_syndicate_base1.dmm
@@ -542,7 +542,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /mob/living/carbon/monkey{
-	faction = list("syndicate")
+	faction = list("neutral","syndicate")
 	},
 /turf/open/floor/plasteel/vault{
 	dir = 8
@@ -886,7 +886,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /mob/living/carbon/monkey{
-	faction = list("syndicate")
+	faction = list("neutral","syndicate")
 	},
 /turf/open/floor/plasteel/vault{
 	dir = 8
@@ -2198,7 +2198,7 @@
 "hp" = (
 /obj/effect/decal/cleanable/dirt,
 /mob/living/carbon/monkey{
-	faction = list("syndicate")
+	faction = list("neutral","syndicate")
 	},
 /turf/open/floor/plasteel/white/side{
 	dir = 9
@@ -2219,7 +2219,7 @@
 /area/ruin/unpowered/syndicate_lava_base/virology)
 "hr" = (
 /mob/living/carbon/monkey{
-	faction = list("syndicate")
+	faction = list("neutral","syndicate")
 	},
 /turf/open/floor/plasteel/white/side{
 	dir = 5
@@ -2343,9 +2343,11 @@
 /turf/open/floor/mineral/plastitanium,
 /area/ruin/unpowered/syndicate_lava_base/cargo)
 "hE" = (
-/obj/effect/decal/cleanable/dirt,
 /mob/living/carbon/monkey{
 	faction = list("syndicate")
+	},
+/mob/living/carbon/monkey{
+	faction = list("neutral","syndicate")
 	},
 /turf/open/floor/plasteel/white/side{
 	dir = 10
@@ -2365,7 +2367,7 @@
 "hG" = (
 /obj/effect/decal/cleanable/dirt,
 /mob/living/carbon/monkey{
-	faction = list("syndicate")
+	faction = list("neutral","syndicate")
 	},
 /turf/open/floor/plasteel/white/side{
 	dir = 6

--- a/_maps/RandomRuins/LavaRuins/lavaland_surface_syndicate_base1.dmm
+++ b/_maps/RandomRuins/LavaRuins/lavaland_surface_syndicate_base1.dmm
@@ -2182,12 +2182,15 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
-/obj/machinery/computer/shuttle/syndicate/recall{
+/obj/machinery/computer/shuttle{
 	desc = "Occasionally used to call in a resupply shuttle if one is in range.";
 	dir = 8;
+	icon_keyboard = "syndie_key";
+	icon_screen = "syndishuttle";
+	light_color = "#FA8282";
 	name = "syndicate cargo shuttle terminal";
 	possible_destinations = "syndielavaland_cargo";
-	shuttleId = "syndie_cargo"
+	req_access_txt = "150"
 	},
 /turf/open/floor/mineral/plastitanium,
 /area/ruin/unpowered/syndicate_lava_base/cargo)

--- a/_maps/RandomRuins/LavaRuins/lavaland_surface_syndicate_base1.dmm
+++ b/_maps/RandomRuins/LavaRuins/lavaland_surface_syndicate_base1.dmm
@@ -117,6 +117,7 @@
 	req_access_txt = "150"
 	},
 /obj/effect/decal/cleanable/dirt,
+/obj/item/storage/box/beakers,
 /turf/open/floor/plasteel/white/side{
 	dir = 9
 	},
@@ -654,8 +655,8 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 9
 	},
-/obj/structure/closet/crate/bin,
 /obj/effect/decal/cleanable/dirt,
+/obj/structure/closet/crate/bin,
 /turf/open/floor/plasteel,
 /area/ruin/unpowered/syndicate_lava_base/chemistry)
 "et" = (
@@ -1012,9 +1013,6 @@
 /turf/open/floor/plasteel/floorgrime,
 /area/ruin/unpowered/syndicate_lava_base/chemistry)
 "eV" = (
-/obj/structure/closet/secure_closet/chemical{
-	req_access_txt = "150"
-	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/white/side{
 	dir = 6
@@ -1277,8 +1275,10 @@
 /turf/open/floor/plasteel/white,
 /area/ruin/unpowered/syndicate_lava_base/chemistry)
 "fp" = (
-/obj/structure/sign/chemistry,
-/turf/closed/wall/mineral/plastitanium/nodiagonal,
+/obj/machinery/smartfridge/chemistry/preloaded,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/floorgrime,
 /area/ruin/unpowered/syndicate_lava_base/chemistry)
 "fq" = (
 /obj/machinery/vending/assist,
@@ -1613,11 +1613,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/vending/medical{
-	desc = "Medical drug dispenser. Looks to have been outfitted with illicit software.";
-	extended_inventory = 1;
 	name = "SyndiMed Plus";
-	premium = list(/obj/item/reagent_containers/hypospray/medipen = 2, /obj/item/storage/belt/medical = 2);
-	products = list(/obj/item/reagent_containers/syringe = 6, /obj/item/reagent_containers/dropper = 2, /obj/item/stack/medical/gauze = 4, /obj/item/reagent_containers/pill/patch/styptic = 3, /obj/item/reagent_containers/pill/insulin = 5, /obj/item/reagent_containers/pill/patch/silver_sulf = 3, /obj/item/reagent_containers/glass/bottle/charcoal = 2, /obj/item/reagent_containers/spray/medical/sterilizer = 1, /obj/item/reagent_containers/glass/bottle/epinephrine = 2, /obj/item/reagent_containers/glass/bottle/morphine = 2, /obj/item/reagent_containers/glass/bottle/salglu_solution = 2, /obj/item/reagent_containers/glass/bottle/toxin = 2, /obj/item/reagent_containers/syringe/antiviral = 3, /obj/item/reagent_containers/pill/salbutamol = 1, /obj/item/device/healthanalyzer = 2);
 	req_access_txt = "150"
 	},
 /turf/open/floor/plasteel/white/side{
@@ -3836,10 +3832,13 @@
 /turf/open/floor/plating,
 /area/ruin/unpowered/syndicate_lava_base/main)
 "kt" = (
-/obj/structure/grille,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
+/obj/machinery/portable_atmospherics/canister/oxygen,
+/obj/structure/window/reinforced{
+	dir = 8
+	},
 /turf/open/floor/plating,
 /area/ruin/unpowered/syndicate_lava_base/main)
 "ku" = (
@@ -4022,9 +4021,11 @@
 /turf/open/floor/plasteel/dark,
 /area/ruin/unpowered/syndicate_lava_base/bar)
 "kN" = (
-/obj/structure/reagent_dispensers/beerkeg,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
+/obj/structure/sink/kitchen{
+	pixel_y = 28
+	},
 /turf/open/floor/plasteel/dark,
 /area/ruin/unpowered/syndicate_lava_base/bar)
 "kO" = (
@@ -4244,6 +4245,7 @@
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
+/obj/structure/reagent_dispensers/beerkeg,
 /turf/open/floor/plasteel/dark,
 /area/ruin/unpowered/syndicate_lava_base/bar)
 "lm" = (
@@ -5882,16 +5884,12 @@
 /turf/open/floor/plasteel/white,
 /area/ruin/unpowered/syndicate_lava_base/medbay)
 "os" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
 /obj/machinery/vending/medical{
-	desc = "Medical drug dispenser. Looks to have been outfitted with illicit software.";
-	extended_inventory = 1;
 	name = "SyndiMed Plus";
-	premium = list(/obj/item/reagent_containers/hypospray/medipen = 2, /obj/item/storage/belt/medical = 2);
-	products = list(/obj/item/reagent_containers/syringe = 6, /obj/item/reagent_containers/dropper = 2, /obj/item/stack/medical/gauze = 4, /obj/item/reagent_containers/pill/patch/styptic = 3, /obj/item/reagent_containers/pill/insulin = 5, /obj/item/reagent_containers/pill/patch/silver_sulf = 3, /obj/item/reagent_containers/glass/bottle/charcoal = 2, /obj/item/reagent_containers/spray/medical/sterilizer = 1, /obj/item/reagent_containers/glass/bottle/epinephrine = 2, /obj/item/reagent_containers/glass/bottle/morphine = 2, /obj/item/reagent_containers/glass/bottle/salglu_solution = 2, /obj/item/reagent_containers/glass/bottle/toxin = 2, /obj/item/reagent_containers/syringe/antiviral = 3, /obj/item/reagent_containers/pill/salbutamol = 1, /obj/item/device/healthanalyzer = 2);
 	req_access_txt = "150"
 	},
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/white,
 /area/ruin/unpowered/syndicate_lava_base/medbay)
 "ot" = (
@@ -6074,6 +6072,10 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/ruin/unpowered/syndicate_lava_base/bar)
+"oP" = (
+/obj/structure/sign/chemistry,
+/turf/closed/wall/mineral/plastitanium/nodiagonal,
+/area/ruin/unpowered/syndicate_lava_base/testlab)
 
 (1,1,1) = {"
 aa
@@ -6859,7 +6861,7 @@ jx
 kn
 kH
 jN
-oO
+jZ
 lU
 mt
 mU
@@ -7170,7 +7172,7 @@ ae
 ae
 ae
 ae
-ae
+oP
 fH
 gG
 he
@@ -7730,8 +7732,8 @@ ab
 ab
 ab
 ac
-dP
 dy
+dP
 eA
 fa
 dy


### PR DESCRIPTION
Fixed lavaland syndie turrets targetting the monkeys inside, outer catwalks leading to space when blown up, med vendors not having visible object names inside, atmos air mixer values being reversed, floating fire alarm in bar, added a smartfridge vendor and extra beakers in chemistry.

:cl: WJohnston
fix: Fixed a few more issues with the syndie lavaland base.
/:cl:
  
  
  