### PR TITLE
Xenobiology toxin mutation rebalances

### DIFF
--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -932,9 +932,6 @@
 /mob/living/carbon/human/species/golem
 	race = /datum/species/golem
 
-/mob/living/carbon/human/species/golem/random
-	race = /datum/species/golem/random
-
 /mob/living/carbon/human/species/golem/adamantine
 	race = /datum/species/golem/adamantine
 

--- a/code/modules/mob/living/carbon/human/species_types/golems.dm
+++ b/code/modules/mob/living/carbon/human/species_types/golems.dm
@@ -18,7 +18,7 @@
 	// To prevent golem subtypes from overwhelming the odds when random species
 	// changes, only the Random Golem type can be chosen
 	blacklisted = TRUE
-	dangerous_existence = TRUE
+	dangerous_existence = FALSE
 	limbs_id = "golem"
 	fixed_mut_color = "aaa"
 	var/info_text = "As an <span class='danger'>Iron Golem</span>, you don't have any special traits."
@@ -41,25 +41,6 @@
 	var/golem_name = "[prefix] [golem_surname]"
 	return golem_name
 
-/datum/species/golem/random
-	name = "Random Golem"
-	blacklisted = FALSE
-	dangerous_existence = FALSE
-	var/static/list/random_golem_types
-
-/datum/species/golem/random/on_species_gain(mob/living/carbon/C, datum/species/old_species)
-	..()
-	if(!random_golem_types)
-		random_golem_types = subtypesof(/datum/species/golem) - type
-		for(var/V in random_golem_types)
-			var/datum/species/golem/G = V
-			if(!initial(G.random_eligible))
-				random_golem_types -= G
-	var/datum/species/golem/golem_type = pick(random_golem_types)
-	var/mob/living/carbon/human/H = C
-	H.set_species(golem_type)
-	to_chat(H, "[initial(golem_type.info_text)]")
-
 /datum/species/golem/adamantine
 	name = "Adamantine Golem"
 	id = "adamantine golem"
@@ -68,6 +49,7 @@
 	fixed_mut_color = "4ed"
 	info_text = "As an <span class='danger'>Adamantine Golem</span>, you possess special vocal cords allowing you to \"resonate\" messages to all golems."
 	prefix = "Adamantine"
+	dangerous_existence = TRUE
 
 //The suicide bombers of golemkind
 /datum/species/golem/plasma
@@ -81,6 +63,7 @@
 	heatmod = 0 //fine until they blow up
 	prefix = "Plasma"
 	special_names = list("Flood","Fire","Bar","Man")
+	dangerous_existence = TRUE
 	var/boom_warning = FALSE
 	var/datum/action/innate/ignite/ignite
 
@@ -138,6 +121,7 @@
 	info_text = "As a <span class='danger'>Diamond Golem</span>, you are more resistant than the average golem."
 	prefix = "Diamond"
 	special_names = list("Back")
+	dangerous_existence = TRUE
 
 //Faster but softer and less armoured
 /datum/species/golem/gold
@@ -149,6 +133,7 @@
 	meat = /obj/item/ore/gold
 	info_text = "As a <span class='danger'>Gold Golem</span>, you are faster but less resistant than the average golem."
 	prefix = "Golden"
+	dangerous_existence = TRUE
 
 //Heavier, thus higher chance of stunning when punching
 /datum/species/golem/silver
@@ -160,6 +145,7 @@
 	info_text = "As a <span class='danger'>Silver Golem</span>, your attacks are heavier and have a higher chance of stunning."
 	prefix = "Silver"
 	special_names = list("Surfer", "Chariot", "Lining")
+	dangerous_existence = TRUE
 
 //Harder to stun, deals more damage, but it's even slower
 /datum/species/golem/plasteel
@@ -176,6 +162,7 @@
 	attack_verb = "smash"
 	attack_sound = 'sound/effects/meteorimpact.ogg' //hits pretty hard
 	prefix = "Plasteel"
+	dangerous_existence = TRUE
 
 //Immune to ash storms
 /datum/species/golem/titanium
@@ -186,6 +173,7 @@
 	info_text = "As a <span class='danger'>Titanium Golem</span>, you are immune to ash storms, and slightly more resistant to burn damage."
 	burnmod = 0.9
 	prefix = "Titanium"
+	dangerous_existence = TRUE
 
 /datum/species/golem/titanium/on_species_gain(mob/living/carbon/C, datum/species/old_species)
 	. = ..()
@@ -204,6 +192,7 @@
 	info_text = "As a <span class='danger'>Plastitanium Golem</span>, you are immune to both ash storms and lava, and slightly more resistant to burn damage."
 	burnmod = 0.8
 	prefix = "Plastitanium"
+	dangerous_existence = TRUE
 
 /datum/species/golem/plastitanium/on_species_gain(mob/living/carbon/C, datum/species/old_species)
 	. = ..()
@@ -226,6 +215,7 @@
 	info_text = "As an <span class='danger'>Alloy Golem</span>, you are made of advanced alien materials: you are faster and regenerate over time. You are, however, only able to be heard by other alloy golems."
 	prefix = "Alien"
 	special_names = list("Outsider", "Technology", "Watcher", "Stranger") //ominous and unknown
+	dangerous_existence = TRUE
 
 //Regenerates because self-repairing super-advanced alien tech
 /datum/species/golem/alloy/spec_life(mob/living/carbon/human/H)
@@ -251,6 +241,7 @@
 	special_names = list("Bark", "Willow", "Catalpa", "Woody", "Oak", "Sap", "Twig", "Branch", "Maple", "Birch", "Elm", "Basswood", "Cottonwood", "Larch", "Aspen", "Ash", "Beech", "Buckeye", "Cedar", "Chestnut", "Cypress", "Fir", "Hawthorn", "Hazel", "Hickory", "Ironwood", "Juniper", "Leaf", "Mangrove", "Palm", "Pawpaw", "Pine", "Poplar", "Redwood", "Redbud", "Sassafras", "Spruce", "Sumac", "Trunk", "Walnut", "Yew")
 	human_surname_chance = 0
 	special_name_chance = 100
+	dangerous_existence = TRUE
 
 /datum/species/golem/wood/on_species_gain(mob/living/carbon/C, datum/species/old_species)
 	. = ..()
@@ -297,6 +288,7 @@
 	var/last_event = 0
 	var/active = null
 	prefix = "Uranium"
+	dangerous_existence = TRUE
 
 /datum/species/golem/uranium/spec_life(mob/living/carbon/human/H)
 	if(!active)
@@ -319,6 +311,7 @@
 	info_text = "As a <span class='danger'>Sand Golem</span>, you are immune to physical bullets and take very little brute damage, but are extremely vulnerable to burn damage. You will also turn to sand when dying, preventing any form of recovery."
 	attack_sound = 'sound/effects/shovel_dig.ogg'
 	prefix = "Sand"
+	dangerous_existence = TRUE
 
 /datum/species/golem/sand/spec_death(gibbed, mob/living/carbon/human/H)
 	H.visible_message("<span class='danger'>[H] turns into a pile of sand!</span>")
@@ -349,6 +342,7 @@
 	info_text = "As a <span class='danger'>Glass Golem</span>, you reflect lasers and energy weapons, and are very resistant to burn damage, but you are extremely vulnerable to brute damage. On death, you'll shatter beyond any hope of recovery."
 	attack_sound = 'sound/effects/glassbr2.ogg'
 	prefix = "Glass"
+	dangerous_existence = TRUE
 
 /datum/species/golem/glass/spec_death(gibbed, mob/living/carbon/human/H)
 	playsound(H, "shatter", 70, 1)
@@ -388,6 +382,7 @@
 	var/datum/action/innate/unstable_teleport/unstable_teleport
 	var/teleport_cooldown = 100
 	var/last_teleport = 0
+	dangerous_existence = TRUE
 
 /datum/species/golem/bluespace/proc/reactive_teleport(mob/living/carbon/human/H)
 	H.visible_message("<span class='warning'>[H] teleports!</span>", "<span class='danger'>You destabilize and teleport!</span>")
@@ -480,6 +475,7 @@
 	attack_verb = "honk"
 	attack_sound = 'sound/items/airhorn2.ogg'
 	prefix = "Bananium"
+	dangerous_existence = TRUE
 
 	var/last_honk = 0
 	var/honkooldown = 0
@@ -551,6 +547,7 @@
 	info_text = "As a <span class='danger'>Runic Golem</span>, you possess eldritch powers granted by the Elder God Nar'Sie."
 	species_traits = list(SPECIES_INORGANIC,NOBREATH,RESISTHOT,RESISTCOLD,RESISTPRESSURE,NOFIRE,NOGUNS,NOBLOOD,RADIMMUNE,PIERCEIMMUNE,NODISMEMBER,NO_UNDERWEAR) //no mutcolors
 	prefix = "Runic"
+	dangerous_existence = TRUE
 
 	var/obj/effect/proc_holder/spell/targeted/ethereal_jaunt/shift/golem/phase_shift
 	var/obj/effect/proc_holder/spell/targeted/abyssal_gaze/abyssal_gaze
@@ -612,6 +609,7 @@
 	siemens_coeff = 0
 	damage_overlay_type = "synth"
 	prefix = "Clockwork"
+	dangerous_existence = TRUE
 	var/has_corpse
 
 /datum/species/golem/clockwork/on_species_gain(mob/living/carbon/human/H)
@@ -663,6 +661,7 @@
 	punchstunthreshold = 7
 	punchdamagehigh = 8 // not as heavy as stone
 	prefix = "Cloth"
+	dangerous_existence = TRUE
 
 /datum/species/golem/cloth/check_roundstart_eligible()
 	if(SSevents.holidays && SSevents.holidays[HALLOWEEN])
@@ -757,6 +756,7 @@
 	prefix = "Plastic"
 	fixed_mut_color = "fff"
 	info_text = "As a <span class='danger'>Plastic Golem</span>, you are capable of ventcrawling, and passing through plastic flaps."
+	dangerous_existence = TRUE
 
 /datum/species/golem/plastic/on_species_gain(mob/living/carbon/C, datum/species/old_species)
 	. = ..()

--- a/code/modules/reagents/chemistry/reagents/other_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/other_reagents.dm
@@ -402,20 +402,45 @@
 	id = "stablemutationtoxin"
 	description = "A humanizing toxin produced by slimes."
 	color = "#5EFF3B" //RGB: 94, 255, 59
-	metabolization_rate = INFINITY //So it instantly removes all of itself
 	taste_description = "slime"
+	metabolization_rate = 0.04
+	var/cycles_to_transform = 20
+	// cycles_to_transform * metabolization_rate is the total
+	// amount needed to trigger the transformation, and you'll
 	var/datum/species/race = /datum/species/human
-	var/mutationtext = "<span class='danger'>The pain subsides. You feel... human.</span>"
+	var/list/attributes = list("vanilla", "ordinary", "elitist")
+
+	var/transforming = FALSE
 
 /datum/reagent/stableslimetoxin/on_mob_life(mob/living/carbon/human/H)
-	..()
+	if(!data)
+		data = 1
+	data++
+
 	if(!istype(H))
 		return
-	to_chat(H, "<span class='warning'><b>You crumple in agony as your flesh wildly morphs into new forms!</b></span>")
-	H.visible_message("<b>[H]</b> falls to the ground and screams as [H.p_their()] skin bubbles and froths!") //'froths' sounds painful when used with SKIN.
-	H.Knockdown(60)
-	addtimer(CALLBACK(src, .proc/mutate, H), 30)
-	return
+
+	to_chat(H, "[src], data [data]")
+
+	// If you're already a lizard, taking lizard mutation toxin makes you
+	// feel even more SCALEY
+	if(data < cycles_to_transform || istype(H.dna.species, race))
+		if(prob(10))
+			var/attr = pick(attributes)
+			if(prob(50))
+				to_chat(H, "<span class='warning'>Your skin feels [attr]!</span>")
+			else
+				to_chat(H, "<span class='notice'>You feel [attr].</span>")
+	else if(transforming)
+		// Don't remove the reagent while the transformation is in process
+		return
+	else
+		H.visible_message("<span class='warning'>[H] falls to the ground and screams as [H.p_their()] skin bubbles and froths!</span>", "<span class='userdanger'><b>You crumple in agony as your flesh wildly morphs into new forms!</b></span>") //'froths' sounds painful when used with SKIN.
+		H.Knockdown(60)
+		transforming = TRUE
+		addtimer(CALLBACK(src, .proc/mutate, H), 30)
+
+	holder.remove_reagent(id, metabolization_rate)	//fixed consumption
 
 /datum/reagent/stableslimetoxin/proc/mutate(mob/living/carbon/human/H)
 	if(QDELETED(H))
@@ -423,10 +448,9 @@
 	var/current_species = H.dna.species.type
 	var/datum/species/mutation = race
 	if(mutation && mutation != current_species)
-		to_chat(H, mutationtext)
+		to_chat(H, "<span class='danger'>The pain vanishes suddenly. You feel... [pick(attributes)].</span>")
 		H.set_species(mutation)
-	else
-		to_chat(H, "<span class='danger'>The pain vanishes suddenly. You feel no different.</span>")
+	transforming = FALSE
 
 /datum/reagent/stableslimetoxin/classic //The one from plasma on green slimes
 	name = "Mutation Toxin"
@@ -434,7 +458,7 @@
 	description = "A corruptive toxin produced by slimes."
 	color = "#13BC5E" // rgb: 19, 188, 94
 	race = /datum/species/jelly/slime
-	mutationtext = "<span class='danger'>The pain subsides. Your whole body feels like slime.</span>"
+	attributes = list("slimey", "goey", "squishy", "toxic", "like slime")
 
 /datum/reagent/stableslimetoxin/lizard
 	name = "Lizard Mutation Toxin"
@@ -442,7 +466,7 @@
 	description = "A lizarding toxin produced by slimes."
 	color = "#5EFF3B" //RGB: 94, 255, 59
 	race = /datum/species/lizard
-	mutationtext = "<span class='danger'>The pain subsides. You feel... scaly.</span>"
+	attributes = list("scaly", "controversial", "coldblooded", "lispy")
 
 /datum/reagent/stableslimetoxin/fly
 	name = "Fly Mutation Toxin"
@@ -450,7 +474,7 @@
 	description = "An insectifying toxin produced by slimes."
 	color = "#5EFF3B" //RGB: 94, 255, 59
 	race = /datum/species/fly
-	mutationtext = "<span class='danger'>The pain subsides. You feel... buzzy.</span>"
+	attributes = list("queasy", "smelly", "accidental", "buzzy")
 
 /datum/reagent/stableslimetoxin/pod
 	name = "Podperson Mutation Toxin"
@@ -458,7 +482,7 @@
 	description = "A vegetalizing toxin produced by slimes."
 	color = "#5EFF3B" //RGB: 94, 255, 59
 	race = /datum/species/pod
-	mutationtext = "<span class='danger'>The pain subsides. You feel... plantlike.</span>"
+	attributes = list("natural", "warm", "keen on sunshine", "untamed")
 
 /datum/reagent/stableslimetoxin/jelly
 	name = "Imperfect Mutation Toxin"
@@ -466,15 +490,15 @@
 	description = "An jellyfying toxin produced by slimes."
 	color = "#5EFF3B" //RGB: 94, 255, 59
 	race = /datum/species/jelly
-	mutationtext = "<span class='danger'>The pain subsides. You feel... wobbly.</span>"
+	attributes = list("slimey", "goey", "squishy", "toxic", "like slime")
 
 /datum/reagent/stableslimetoxin/golem
 	name = "Golem Mutation Toxin"
 	id = "golemmutationtoxin"
 	description = "A crystal toxin produced by slimes."
 	color = "#5EFF3B" //RGB: 94, 255, 59
-	race = /datum/species/golem/random
-	mutationtext = "<span class='danger'>The pain subsides. You feel... rocky.</span>"
+	race = /datum/species/golem
+	attributes = list("stoic", "tough", "slow", "metallic", "loyal")
 
 /datum/reagent/stableslimetoxin/abductor
 	name = "Abductor Mutation Toxin"
@@ -482,7 +506,7 @@
 	description = "An alien toxin produced by slimes."
 	color = "#5EFF3B" //RGB: 94, 255, 59
 	race = /datum/species/abductor
-	mutationtext = "<span class='danger'>The pain subsides. You feel... alien.</span>"
+	attributes = list("silent", "invasive", "grey")
 
 /datum/reagent/stableslimetoxin/android
 	name = "Android Mutation Toxin"
@@ -490,7 +514,7 @@
 	description = "A robotic toxin produced by slimes."
 	color = "#5EFF3B" //RGB: 94, 255, 59
 	race = /datum/species/android
-	mutationtext = "<span class='danger'>The pain subsides. You feel... artificial.</span>"
+	attributes = list("robotic", "overpowered", "electronic", "emotionless")
 
 
 //BLACKLISTED RACES
@@ -500,7 +524,7 @@
 	description = "A scary toxin produced by slimes."
 	color = "#5EFF3B" //RGB: 94, 255, 59
 	race = /datum/species/skeleton
-	mutationtext = "<span class='danger'>The pain subsides. You feel... spooky.</span>"
+	attributes = list("spooky", "scary", "skeleton", "shivery", "spiney")
 
 /datum/reagent/stableslimetoxin/zombie
 	name = "Zombie Mutation Toxin"
@@ -508,7 +532,7 @@
 	description = "An undead toxin produced by slimes."
 	color = "#5EFF3B" //RGB: 94, 255, 59
 	race = /datum/species/zombie //Not the infectious kind. The days of xenobio zombie outbreaks are long past.
-	mutationtext = "<span class='danger'>The pain subsides. You feel... undead.</span>"
+	attributes = list("decaying", "slow", "dead", "undead", "rotting")
 
 /datum/reagent/stableslimetoxin/ash
 	name = "Ash Mutation Toxin"
@@ -516,7 +540,8 @@
 	description = "An ashen toxin produced by slimes."
 	color = "#5EFF3B" //RGB: 94, 255, 59
 	race = /datum/species/lizard/ashwalker
-	mutationtext = "<span class='danger'>The pain subsides. You feel... savage.</span>"
+	attributes = list("scaly", "controversial", "coldblooded", "lispy")
+
 
 
 //DANGEROUS RACES
@@ -526,7 +551,7 @@
 	description = "A dark toxin produced by slimes."
 	color = "#5EFF3B" //RGB: 94, 255, 59
 	race = /datum/species/shadow
-	mutationtext = "<span class='danger'>The pain subsides. You feel... darker.</span>"
+	attributes = list("dark", "gothic", "gloomy", "once powerful")
 
 /datum/reagent/stableslimetoxin/plasma
 	name = "Plasma Mutation Toxin"
@@ -534,23 +559,20 @@
 	description = "A plasma-based toxin produced by slimes."
 	color = "#5EFF3B" //RGB: 94, 255, 59
 	race = /datum/species/plasmaman
-	mutationtext = "<span class='danger'>The pain subsides. You feel... flammable.</span>"
+	attributes = list("boney", "flammable", "elemental")
 
 /datum/reagent/stableslimetoxin/unstable //PSYCH
 	name = "Unstable Mutation Toxin"
 	id = "unstablemutationtoxin"
 	description = "An unstable and unpredictable corruptive toxin produced by slimes."
 	color = "#5EFF3B" //RGB: 94, 255, 59
-	mutationtext = "<span class='danger'>The pain subsides. You feel... different.</span>"
+	metabolization_rate = INFINITY
+	attributes = list("unknown", "enigmatic", "undetermined")
 
 /datum/reagent/stableslimetoxin/unstable/on_mob_life(mob/living/carbon/human/H)
-	var/list/possible_morphs = list()
-	for(var/type in subtypesof(/datum/species))
-		var/datum/species/S = type
-		if(initial(S.blacklisted))
-			continue
-		possible_morphs += S
-	race = pick(possible_morphs)
+	var/list/types = typesof(/datum/reagent/stableslimetoxin) - type
+	var/datum/reagent/picked_type = pick(types)
+	H.reagents.add_reagent(initial(picked_type.id), volume)
 	..()
 
 /datum/reagent/mulligan

--- a/code/modules/reagents/chemistry/recipes/slime_extracts.dm
+++ b/code/modules/reagents/chemistry/recipes/slime_extracts.dm
@@ -50,7 +50,7 @@
 	name = "Mutation Toxin"
 	id = "mutationtoxin"
 	results = list("mutationtoxin" = 1)
-	required_reagents = list("plasma" = 1)
+	required_reagents = list("plasma" = 5)
 	required_other = 1
 	required_container = /obj/item/slime_extract/green
 
@@ -58,8 +58,8 @@
 /datum/chemical_reaction/slime/slimemutate_unstable
 	name = "Unstable Mutation Toxin"
 	id = "unstablemutationtoxin"
-	results = list("unstablemutationtoxin" = 1)
-	required_reagents = list("radium" = 1)
+	results = list("unstablemutationtoxin" = 3)
+	required_reagents = list("radium" = 5)
 	required_other = 1
 	required_container = /obj/item/slime_extract/green
 	mix_message = "<span class='info'>The mixture rapidly expands and contracts, its appearance shifting into a sickening green.</span>"


### PR DESCRIPTION
:cl: coiax
balance: Green slime extract requires 5u of plasma, and produces 3u of
unstable mutation toxin.
balance: Mutation toxins are not instant, and require approximately 1u
of toxin to effect a change.
add: Mutation toxins may make users feel strange.
balance: Golem mutation toxin only turns you into an Iron Golem.
/:cl:

@XDTM approved.

- A single green slime can provide over 50 transformation pills, which
is enough to dose the entire station. Now a single, unboosted, green
slime extract will allow for 3 transformations.
- If someone doses you with mutation toxin, if you have any purgatives,
you might be able to stop it, rather than it being an instant
unavoidable transformation.
- Golems are already space proof and have stunning punches. People were
often using multiple doses of golem mutation toxin to access the very
powerful runic golems. Their power was supposed to be balanced by the
difficulty of obtaining runed metal, not by RNG and time. Go raid a cult
or something.

- Reminder, golems can swap into other completed shells to change their
materials.