### PR TITLE
Ridden vehicles now move mobs post-buckle via the buckle_mob proc instead of pre, fixing lavaboats setting people on fire

### DIFF
--- a/code/modules/vehicles/ridden.dm
+++ b/code/modules/vehicles/ridden.dm
@@ -61,14 +61,9 @@
 	return ..()
 
 /obj/vehicle/ridden/user_buckle_mob(mob/living/M, mob/user, check_loc = TRUE)
-	if(user.incapacitated())
-		return
-	for(var/atom/movable/A in get_turf(src))
-		if(A.density)
-			if(A != src && A != M)
-				return
-	M.forceMove(get_turf(src))
-	. = ..()
+	if(!in_range(user, src) || !in_range(M, src))
+		return FALSE
+	. = ..(M, user, FALSE)
 
 /obj/vehicle/ridden/buckle_mob(mob/living/M, force = FALSE, check_loc = TRUE)
 	if(!force && occupant_amount() >= max_occupants)


### PR DESCRIPTION
:cl:
fix: Lavaboats no longer set you on fire.
/:cl:
fixes #32472
  