### PR TITLE
Consolidates bot assemblies under one parent, fixes bot parts switching types when the bot is destroyed

### DIFF
--- a/_maps/RandomRuins/SpaceRuins/TheDerelict.dmm
+++ b/_maps/RandomRuins/SpaceRuins/TheDerelict.dmm
@@ -2333,7 +2333,7 @@
 /turf/open/floor/plasteel/airless/white,
 /area/ruin/space/derelict/medical)
 "hJ" = (
-/obj/item/firstaid_arm_assembly,
+/obj/item/bot_assembly/medbot,
 /turf/open/floor/plasteel/airless/white,
 /area/ruin/space/derelict/medical)
 "hK" = (

--- a/_maps/RandomZLevels/centcomAway.dmm
+++ b/_maps/RandomZLevels/centcomAway.dmm
@@ -2615,7 +2615,7 @@
 /area/awaymission/centcomAway/general)
 "jr" = (
 /obj/structure/table,
-/obj/item/firstaid_arm_assembly,
+/obj/item/bot_assembly/medbot,
 /turf/open/floor/plasteel/vault,
 /area/awaymission/centcomAway/hangar)
 "js" = (

--- a/_maps/map_files/Deltastation/DeltaStation2.dmm
+++ b/_maps/map_files/Deltastation/DeltaStation2.dmm
@@ -79462,7 +79462,7 @@
 /turf/open/floor/plating,
 /area/medical/medbay/central)
 "dfM" = (
-/obj/item/firstaid_arm_assembly,
+/obj/item/bot_assembly/medbot,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plasteel/neutral/side{
 	dir = 8

--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -5469,7 +5469,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 9
 	},
-/obj/item/bucket_sensor,
+/obj/item/bot_assembly/cleanbot,
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
 "alI" = (
@@ -7899,7 +7899,9 @@
 /area/maintenance/port)
 "aqP" = (
 /obj/structure/light_construct/small,
-/obj/item/toolbox_tiles_sensor,
+/obj/item/bot_assembly/floorbot{
+	build_step = 1
+	},
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
 "aqQ" = (

--- a/code/__DEFINES/robots.dm
+++ b/code/__DEFINES/robots.dm
@@ -46,3 +46,6 @@
 //Assembly defines
 #define ASSEMBLY_FIRST_STEP 	0
 #define ASSEMBLY_SECOND_STEP 	1
+#define ASSEMBLY_THIRD_STEP     2
+#define ASSEMBLY_FOURTH_STEP    3
+#define ASSEMBLY_FIFTH_STEP     4

--- a/code/game/objects/items/robot/robot_parts.dm
+++ b/code/game/objects/items/robot/robot_parts.dm
@@ -68,7 +68,7 @@
 		var/obj/item/stack/sheet/metal/M = W
 		if(!l_arm && !r_arm && !l_leg && !r_leg && !chest && !head)
 			if (M.use(1))
-				var/obj/item/ed209_assembly/B = new /obj/item/ed209_assembly
+				var/obj/item/bot_assembly/ed209/B = new
 				B.forceMove(drop_location())
 				to_chat(user, "<span class='notice'>You arm the robot frame.</span>")
 				var/holding_this = user.get_inactive_held_item()==src

--- a/code/game/objects/items/storage/boxes.dm
+++ b/code/game/objects/items/storage/boxes.dm
@@ -622,7 +622,7 @@ obj/item/storage/box/clown
 			return
 		qdel(I)
 		to_chat(user, "<span class='notice'>You add some wheels to the [src]! You've got an honkbot assembly now! Honk!</span>")
-		var/obj/item/honkbot_assembly/A = new
+		var/obj/item/bot_assembly/honkbot/A = new
 		qdel(src)
 		user.put_in_hands(A)
 	else

--- a/code/modules/clothing/head/helmet.dm
+++ b/code/modules/clothing/head/helmet.dm
@@ -29,7 +29,7 @@
 
 		if(S.secured)
 			qdel(S)
-			var/obj/item/secbot_assembly/A = new /obj/item/secbot_assembly
+			var/obj/item/bot_assembly/secbot/A = new
 			user.put_in_hands(A)
 			to_chat(user, "<span class='notice'>You add the signaler to the helmet.</span>")
 			qdel(src)

--- a/code/modules/mob/living/simple_animal/bot/bot.dm
+++ b/code/modules/mob/living/simple_animal/bot/bot.dm
@@ -88,6 +88,7 @@
 	var/path_image_color = "#FFFFFF"
 	var/reset_access_timer_id
 	var/ignorelistcleanuptimer = 1 // This ticks up every automated action, at 300 we clean the ignore list
+	var/robot_arm = /obj/item/bodypart/r_arm/robot
 
 	hud_possible = list(DIAG_STAT_HUD, DIAG_BOT_HUD, DIAG_HUD, DIAG_PATH_HUD = HUD_LIST_LIST) //Diagnostic HUD views
 
@@ -368,6 +369,20 @@
 	if(message_mode in GLOB.radiochannels)
 		Radio.talk_into(src, message, message_mode, spans, language)
 		return REDUCE_RANGE
+
+/mob/living/simple_animal/bot/proc/drop_part(obj/item/drop_item, dropzone)
+	var/dropped_item = new drop_item(dropzone)
+	drop_item = null
+
+	if(istype(dropped_item, /obj/item/stock_parts/cell))
+		var/obj/item/stock_parts/cell/dropped_cell = dropped_item
+		dropped_cell.charge = 0
+		dropped_cell.update_icon()
+
+	else if(istype(dropped_item, /obj/item/gun/energy))
+		var/obj/item/gun/energy/dropped_gun = dropped_item
+		dropped_gun.cell.charge = 0
+		dropped_gun.update_icon()
 
 //Generalized behavior code, override where needed!
 

--- a/code/modules/mob/living/simple_animal/bot/cleanbot.dm
+++ b/code/modules/mob/living/simple_animal/bot/cleanbot.dm
@@ -265,7 +265,7 @@
 	new /obj/item/device/assembly/prox_sensor(Tsec)
 
 	if(prob(50))
-		new /obj/item/bodypart/l_arm/robot(Tsec)
+		drop_part(robot_arm, Tsec)
 
 	do_sparks(3, TRUE, src)
 	..()

--- a/code/modules/mob/living/simple_animal/bot/construction.dm
+++ b/code/modules/mob/living/simple_animal/bot/construction.dm
@@ -1,79 +1,80 @@
 //Bot Construction
 
-//Cleanbot assembly
-/obj/item/bucket_sensor
-	desc = "It's a bucket. With a sensor attached."
-	name = "proxy bucket"
+/obj/item/bot_assembly
 	icon = 'icons/mob/aibots.dmi'
-	icon_state = "bucket_proxy"
+	w_class = WEIGHT_CLASS_NORMAL
 	force = 3
-	throwforce = 5
 	throw_speed = 2
 	throw_range = 5
-	w_class = WEIGHT_CLASS_NORMAL
-	var/created_name = "Cleanbot"
+	var/created_name
+	var/build_step = ASSEMBLY_FIRST_STEP
+	var/robot_arm = /obj/item/bodypart/r_arm/robot
 
-/obj/item/bucket_sensor/attackby(obj/item/W, mob/user as mob, params)
+/obj/item/bot_assembly/proc/rename_bot()
+	var/t = stripped_input(usr, "Enter new robot name", name, created_name,MAX_NAME_LEN)
+	if(!t)
+		return
+	if(!in_range(src, usr) && loc != usr)
+		return
+	created_name = t
+
+//Cleanbot assembly
+/obj/item/bot_assembly/cleanbot
+	desc = "It's a bucket with a sensor attached."
+	name = "incomplete cleanbot assembly"
+	icon_state = "bucket_proxy"
+	throwforce = 5
+	created_name = "Cleanbot"
+
+/obj/item/bot_assembly/cleanbot/attackby(obj/item/W, mob/user as mob, params)
 	..()
 	if(istype(W, /obj/item/bodypart/l_arm/robot) || istype(W, /obj/item/bodypart/r_arm/robot))
 		if(!user.temporarilyRemoveItemFromInventory(W))
 			return
-		qdel(W)
-		var/turf/T = get_turf(loc)
-		var/mob/living/simple_animal/bot/cleanbot/A = new /mob/living/simple_animal/bot/cleanbot(T)
+		var/mob/living/simple_animal/bot/cleanbot/A = new(drop_location())
 		A.name = created_name
-		to_chat(user, "<span class='notice'>You add the robot arm to the bucket and sensor assembly. Beep boop!</span>")
+		A.robot_arm = W.type
+		to_chat(user, "<span class='notice'>You add [W] to [src]. Beep boop!</span>")
+		qdel(W)
 		qdel(src)
 
 	else if(istype(W, /obj/item/pen))
-		var/t = stripped_input(user, "Enter new robot name", name, created_name,MAX_NAME_LEN)
-		if(!t)
-			return
-		if(!in_range(src, usr) && loc != usr)
-			return
-		created_name = t
+		rename_bot()
 
 //Edbot Assembly
 
-/obj/item/ed209_assembly
-	name = "\improper ED-209 assembly"
+/obj/item/bot_assembly/ed209
+	name = "incomplete ED-209 assembly"
 	desc = "Some sort of bizarre assembly."
-	icon = 'icons/mob/aibots.dmi'
 	icon_state = "ed209_frame"
 	item_state = "ed209_frame"
-	var/build_step = 0
-	var/created_name = "ED-209 Security Robot" //To preserve the name if it's a unique securitron I guess
+	created_name = "ED-209 Security Robot" //To preserve the name if it's a unique securitron I guess
 	var/lasercolor = ""
+	var/vest_type = /obj/item/clothing/suit/armor/vest
 
-/obj/item/ed209_assembly/attackby(obj/item/W, mob/user, params)
+/obj/item/bot_assembly/ed209/attackby(obj/item/W, mob/user, params)
 	..()
 
 	if(istype(W, /obj/item/pen))
-		var/t = stripped_input(user, "Enter new robot name", name, created_name,MAX_NAME_LEN)
-		if(!t)
-			return
-		if(!in_range(src, usr) && loc != usr)
-			return
-		created_name = t
-		return
+		rename_bot()
 
 	switch(build_step)
-		if(0,1)
+		if(ASSEMBLY_FIRST_STEP, ASSEMBLY_SECOND_STEP)
 			if(istype(W, /obj/item/bodypart/l_leg/robot) || istype(W, /obj/item/bodypart/r_leg/robot))
 				if(!user.temporarilyRemoveItemFromInventory(W))
 					return
-				qdel(W)
 				build_step++
-				to_chat(user, "<span class='notice'>You add the robot leg to [src].</span>")
+				to_chat(user, "<span class='notice'>You add [W] to [src].</span>")
+				qdel(W)
 				name = "legs/frame assembly"
-				if(build_step == 1)
+				if(build_step == ASSEMBLY_SECOND_STEP)
 					item_state = "ed209_leg"
 					icon_state = "ed209_leg"
 				else
 					item_state = "ed209_legs"
 					icon_state = "ed209_legs"
 
-		if(2)
+		if(ASSEMBLY_THIRD_STEP)
 			var/newcolor = ""
 			if(istype(W, /obj/item/clothing/suit/redtag))
 				newcolor = "r"
@@ -83,14 +84,15 @@
 				if(!user.temporarilyRemoveItemFromInventory(W))
 					return
 				lasercolor = newcolor
-				qdel(W)
+				vest_type = W.type
 				build_step++
-				to_chat(user, "<span class='notice'>You add the armor to [src].</span>")
+				to_chat(user, "<span class='notice'>You add [W] to [src].</span>")
+				qdel(W)
 				name = "vest/legs/frame assembly"
 				item_state = "[lasercolor]ed209_shell"
 				icon_state = "[lasercolor]ed209_shell"
 
-		if(3)
+		if(ASSEMBLY_FOURTH_STEP)
 			if(istype(W, /obj/item/weldingtool))
 				var/obj/item/weldingtool/WT = W
 				if(WT.remove_fuel(0,user))
@@ -113,20 +115,20 @@
 
 			if(!user.temporarilyRemoveItemFromInventory(W))
 				return
-			qdel(W)
 			build_step++
-			to_chat(user, "<span class='notice'>You add the helmet to [src].</span>")
+			to_chat(user, "<span class='notice'>You add [W] to [src].</span>")
+			qdel(W)
 			name = "covered and shielded frame assembly"
 			item_state = "[lasercolor]ed209_hat"
 			icon_state = "[lasercolor]ed209_hat"
 
-		if(5)
+		if(ASSEMBLY_FIFTH_STEP)
 			if(isprox(W))
 				if(!user.temporarilyRemoveItemFromInventory(W))
 					return
-				qdel(W)
 				build_step++
-				to_chat(user, "<span class='notice'>You add the prox sensor to [src].</span>")
+				to_chat(user, "<span class='notice'>You add [W] to [src].</span>")
+				qdel(W)
 				name = "covered, shielded and sensored frame assembly"
 				item_state = "[lasercolor]ed209_prox"
 				icon_state = "[lasercolor]ed209_prox"
@@ -142,7 +144,7 @@
 					if(coil.get_amount() >= 1 && build_step == 6)
 						coil.use(1)
 						build_step = 7
-						to_chat(user, "<span class='notice'>You wire the ED-209 assembly.</span>")
+						to_chat(user, "<span class='notice'>You wire [src].</span>")
 						name = "wired ED-209 assembly"
 
 		if(7)
@@ -185,36 +187,36 @@
 				if(!user.temporarilyRemoveItemFromInventory(W))
 					return
 				build_step++
+				var/mob/living/simple_animal/bot/ed209/B = new(drop_location(),created_name,lasercolor)
 				to_chat(user, "<span class='notice'>You complete the ED-209.</span>")
-				var/turf/T = get_turf(src)
-				new /mob/living/simple_animal/bot/ed209(T,created_name,lasercolor)
+				B.cell_type = W.type
 				qdel(W)
+				B.vest_type = vest_type
 				qdel(src)
 
 //Floorbot assemblies
-/obj/item/toolbox_tiles
+/obj/item/bot_assembly/floorbot
 	desc = "It's a toolbox with tiles sticking out the top."
 	name = "tiles and toolbox"
-	icon = 'icons/mob/aibots.dmi'
 	icon_state = "toolbox_tiles"
-	force = 3
 	throwforce = 10
-	throw_speed = 2
-	throw_range = 5
-	w_class = WEIGHT_CLASS_NORMAL
-	var/created_name = "Floorbot"
+	created_name = "Floorbot"
 
-/obj/item/toolbox_tiles_sensor
-	desc = "It's a toolbox with tiles sticking out the top and a sensor attached."
-	name = "tiles, toolbox and sensor arrangement"
-	icon = 'icons/mob/aibots.dmi'
-	icon_state = "toolbox_tiles_sensor"
-	force = 3
-	throwforce = 10
-	throw_speed = 2
-	throw_range = 5
-	w_class = WEIGHT_CLASS_NORMAL
-	var/created_name = "Floorbot"
+/obj/item/bot_assembly/floorbot/Initialize()
+	. = ..()
+	update_icon()
+
+/obj/item/bot_assembly/floorbot/update_icon()
+	..()
+	switch(build_step)
+		if(ASSEMBLY_FIRST_STEP)
+			desc = initial(desc)
+			name = initial(name)
+			icon_state = initial(icon_state)
+		if(ASSEMBLY_SECOND_STEP)
+			desc = "It's a toolbox with tiles sticking out the top and a sensor attached."
+			name = "incomplete floorbot assembly"
+			icon_state = "toolbox_tiles_sensor"
 
 /obj/item/storage/toolbox/mechanical/attackby(obj/item/stack/tile/plasteel/T, mob/user, params)
 	if(!istype(T, /obj/item/stack/tile/plasteel))
@@ -226,63 +228,42 @@
 	if(T.use(10))
 		if(user.s_active)
 			user.s_active.close(user)
-		var/obj/item/toolbox_tiles/B = new /obj/item/toolbox_tiles
+		var/obj/item/bot_assembly/floorbot/B = new
 		user.put_in_hands(B)
-		to_chat(user, "<span class='notice'>You add the tiles into the empty toolbox. They protrude from the top.</span>")
+		to_chat(user, "<span class='notice'>You add the tiles into the empty [src.name]. They protrude from the top.</span>")
 		qdel(src)
 	else
 		to_chat(user, "<span class='warning'>You need 10 floor tiles to start building a floorbot!</span>")
 		return
 
-/obj/item/toolbox_tiles/attackby(obj/item/W, mob/user, params)
+/obj/item/bot_assembly/floorbot/attackby(obj/item/W, mob/user, params)
 	..()
-	if(isprox(W))
+	if(istype(W, /obj/item/pen))
+		rename_bot()
+	else if(isprox(W) && build_step == ASSEMBLY_FIRST_STEP)
+		to_chat(user, "<span class='notice'>You add [W] to [src].</span>")
 		qdel(W)
-		var/obj/item/toolbox_tiles_sensor/B = new /obj/item/toolbox_tiles_sensor()
-		B.created_name = created_name
-		user.put_in_hands(B)
-		to_chat(user, "<span class='notice'>You add the sensor to the toolbox and tiles.</span>")
-		qdel(src)
-
-	else if(istype(W, /obj/item/pen))
-		var/t = stripped_input(user, "Enter new robot name", name, created_name,MAX_NAME_LEN)
-		if(!t)
-			return
-		if(!in_range(src, usr) && loc != usr)
-			return
-
-		created_name = t
-
-/obj/item/toolbox_tiles_sensor/attackby(obj/item/W, mob/user, params)
-	..()
-	if(istype(W, /obj/item/bodypart/l_arm/robot) || istype(W, /obj/item/bodypart/r_arm/robot))
-		qdel(W)
-		var/turf/T = get_turf(user.loc)
-		var/mob/living/simple_animal/bot/floorbot/A = new /mob/living/simple_animal/bot/floorbot(T)
+		build_step++
+		update_icon()
+	else if(istype(W, /obj/item/bodypart/l_arm/robot) || istype(W, /obj/item/bodypart/r_arm/robot) && build_step == ASSEMBLY_SECOND_STEP)
+		var/mob/living/simple_animal/bot/floorbot/A = new(drop_location())
 		A.name = created_name
-		to_chat(user, "<span class='notice'>You add the robot arm to the odd looking toolbox assembly. Boop beep!</span>")
+		A.robot_arm = W.type
+		to_chat(user, "<span class='notice'>You add [W] to [src]. Boop beep!</span>")
+		qdel(W)
 		qdel(src)
-	else if(istype(W, /obj/item/pen))
-		var/t = stripped_input(user, "Enter new robot name", name, created_name,MAX_NAME_LEN)
-		if(!t)
-			return
-		if(!in_range(src, usr) && loc != usr)
-			return
-
-		created_name = t
 
 //Medbot Assembly
-/obj/item/firstaid_arm_assembly
+/obj/item/bot_assembly/medbot
 	name = "incomplete medibot assembly"
 	desc = "A first aid kit with a robot arm permanently grafted to it."
-	icon = 'icons/mob/aibots.dmi'
 	icon_state = "firstaid_arm"
-	var/build_step = 0
-	var/created_name = "Medibot" //To preserve the name if it's a unique medbot I guess
+	created_name = "Medibot" //To preserve the name if it's a unique medbot I guess
 	var/skin = null //Same as medbot, set to tox or ointment for the respective kits.
-	w_class = WEIGHT_CLASS_NORMAL
+	var/healthanalyzer = /obj/item/device/healthanalyzer
+	var/firstaid = /obj/item/storage/firstaid
 
-/obj/item/firstaid_arm_assembly/Initialize()
+/obj/item/bot_assembly/medbot/Initialize()
 	. = ..()
 	spawn(5)
 		if(skin)
@@ -298,7 +279,7 @@
 		to_chat(user, "<span class='warning'>You need to empty [src] out first!</span>")
 		return
 
-	var/obj/item/firstaid_arm_assembly/A = new /obj/item/firstaid_arm_assembly
+	var/obj/item/bot_assembly/medbot/A = new
 	if(istype(src, /obj/item/storage/firstaid/fire))
 		A.skin = "ointment"
 	else if(istype(src, /obj/item/storage/firstaid/toxin))
@@ -307,57 +288,54 @@
 		A.skin = "o2"
 	else if(istype(src, /obj/item/storage/firstaid/brute))
 		A.skin = "brute"
-
-	qdel(S)
 	user.put_in_hands(A)
-	to_chat(user, "<span class='notice'>You add the robot arm to the first aid kit.</span>")
+	to_chat(user, "<span class='notice'>You add [S] to [src].</span>")
+	A.robot_arm = S.type
+	A.firstaid = type
+	qdel(S)
 	qdel(src)
 
 
-/obj/item/firstaid_arm_assembly/attackby(obj/item/W, mob/user, params)
+/obj/item/bot_assembly/medbot/attackby(obj/item/W, mob/user, params)
 	..()
 	if(istype(W, /obj/item/pen))
-		var/t = stripped_input(user, "Enter new robot name", name, created_name,MAX_NAME_LEN)
-		if(!t)
-			return
-		if(!in_range(src, usr) && loc != usr)
-			return
-		created_name = t
+		rename_bot()
 	else
 		switch(build_step)
-			if(0)
+			if(ASSEMBLY_FIRST_STEP)
 				if(istype(W, /obj/item/device/healthanalyzer))
 					if(!user.temporarilyRemoveItemFromInventory(W))
 						return
-					qdel(W)
+					healthanalyzer = W.type
 					build_step++
-					to_chat(user, "<span class='notice'>You add the health sensor to [src].</span>")
+					to_chat(user, "<span class='notice'>You add [W] to [src].</span>")
+					qdel(W)
 					name = "First aid/robot arm/health analyzer assembly"
 					add_overlay("na_scanner")
 
-			if(1)
+			if(ASSEMBLY_SECOND_STEP)
 				if(isprox(W))
 					if(!user.temporarilyRemoveItemFromInventory(W))
 						return
 					qdel(W)
 					build_step++
-					to_chat(user, "<span class='notice'>You complete the Medibot. Beep boop!</span>")
-					var/turf/T = get_turf(src)
-					var/mob/living/simple_animal/bot/medbot/S = new /mob/living/simple_animal/bot/medbot(T, skin)
+					var/mob/living/simple_animal/bot/medbot/S = new(drop_location(), skin)
+					to_chat(user, "<span class='notice'>You complete the Medbot. Beep boop!</span>")
 					S.name = created_name
+					S.firstaid = firstaid
+					S.robot_arm = robot_arm
+					S.healthanalyzer = healthanalyzer
 					qdel(src)
 
 
 //Honkbot Assembly
-/obj/item/honkbot_assembly
+/obj/item/bot_assembly/honkbot
 	name = "incomplete honkbot assembly"
 	desc = "The clown's up to no good once more"
-	icon = 'icons/mob/aibots.dmi'
 	icon_state = "honkbot_arm"
-	var/build_step = ASSEMBLY_FIRST_STEP
-	var/created_name = "Honkbot"
+	created_name = "Honkbot"
 
-/obj/item/honkbot_assembly/attackby(obj/item/I, mob/user, params)
+/obj/item/bot_assembly/honkbot/attackby(obj/item/I, mob/user, params)
 
 	if(isprox(I) && (build_step == ASSEMBLY_FIRST_STEP))
 		if(!user.temporarilyRemoveItemFromInventory(I))
@@ -374,8 +352,7 @@
 		if(!user.temporarilyRemoveItemFromInventory(I))
 			return
 		to_chat(user, "<span class='notice'>You add the [I] to [src]! Honk!</span>")
-		var/T = get_turf(loc) //important to spawn on turf.
-		var/mob/living/simple_animal/bot/honkbot/S = new(drop_location(T))
+		var/mob/living/simple_animal/bot/honkbot/S = new(drop_location())
 		S.name = created_name
 		S.spam_flag = TRUE // only long enough to hear the first ping.
 		addtimer(CALLBACK (S, .mob/living/simple_animal/bot/honkbot/proc/react_ping), 5)
@@ -383,27 +360,21 @@
 		qdel(src)
 
 	else if(istype(I, /obj/item/pen))
-		var/t = stripped_input(user, "Enter new robot name", name, created_name,MAX_NAME_LEN)
-		if(!t)
-			return
-		if(!in_range(src, usr) && loc != usr)
-			return
-		created_name = t
+		rename_bot()
 
 	else return ..()
 
 //Secbot Assembly
-/obj/item/secbot_assembly
+/obj/item/bot_assembly/secbot
 	name = "incomplete securitron assembly"
 	desc = "Some sort of bizarre assembly made from a proximity sensor, helmet, and signaler."
-	icon = 'icons/mob/aibots.dmi'
 	icon_state = "helmet_signaler"
 	item_state = "helmet"
-	var/build_step = 0
-	var/created_name = "Securitron" //To preserve the name if it's a unique securitron I guess
+	created_name = "Securitron" //To preserve the name if it's a unique securitron I guess
 
-/obj/item/secbot_assembly/attackby(obj/item/I, mob/user, params)
+/obj/item/bot_assembly/secbot/attackby(obj/item/I, mob/user, params)
 	..()
+	var/atom/Tsec = drop_location()
 	if(istype(I, /obj/item/weldingtool))
 		if(!build_step)
 			var/obj/item/weldingtool/WT = I
@@ -411,29 +382,30 @@
 				build_step++
 				add_overlay("hs_hole")
 				to_chat(user, "<span class='notice'>You weld a hole in [src]!</span>")
-		else if(build_step == 1)
+		else if(build_step == ASSEMBLY_SECOND_STEP)
 			var/obj/item/weldingtool/WT = I
 			if(WT.remove_fuel(0, user))
 				build_step--
 				cut_overlay("hs_hole")
 				to_chat(user, "<span class='notice'>You weld the hole in [src] shut!</span>")
 
-	else if(isprox(I) && (build_step == 1))
+	else if(isprox(I) && (build_step == ASSEMBLY_SECOND_STEP))
 		if(!user.temporarilyRemoveItemFromInventory(I))
 			return
 		build_step++
-		to_chat(user, "<span class='notice'>You add the prox sensor to [src]!</span>")
+		to_chat(user, "<span class='notice'>You add [I] to [src]!</span>")
 		add_overlay("hs_eye")
 		name = "helmet/signaler/prox sensor assembly"
 		qdel(I)
 
-	else if(((istype(I, /obj/item/bodypart/l_arm/robot)) || (istype(I, /obj/item/bodypart/r_arm/robot))) && (build_step == 2))
+	else if(((istype(I, /obj/item/bodypart/l_arm/robot)) || (istype(I, /obj/item/bodypart/r_arm/robot))) && (build_step == ASSEMBLY_THIRD_STEP))
 		if(!user.temporarilyRemoveItemFromInventory(I))
 			return
 		build_step++
-		to_chat(user, "<span class='notice'>You add the robot arm to [src]!</span>")
+		to_chat(user, "<span class='notice'>You add [I] to [src]!</span>")
 		name = "helmet/signaler/prox sensor/robot arm assembly"
 		add_overlay("hs_arm")
+		robot_arm = I.type
 		qdel(I)
 
 	else if((istype(I, /obj/item/melee/baton)) && (build_step >= 3))
@@ -441,35 +413,32 @@
 			return
 		build_step++
 		to_chat(user, "<span class='notice'>You complete the Securitron! Beep boop.</span>")
-		var/mob/living/simple_animal/bot/secbot/S = new /mob/living/simple_animal/bot/secbot(get_turf(src))
+		var/mob/living/simple_animal/bot/secbot/S = new(Tsec)
 		S.name = created_name
 		S.baton_type = I.type
+		S.robot_arm = robot_arm
 		qdel(I)
 		qdel(src)
 
 	else if(istype(I, /obj/item/pen))
-		var/t = stripped_input(user, "Enter new robot name", name, created_name,MAX_NAME_LEN)
-		if(!t)
-			return
-		if(!in_range(src, usr) && loc != usr)
-			return
-		created_name = t
+		rename_bot()
 
 	else if(istype(I, /obj/item/screwdriver))
 		if(!build_step)
-			new /obj/item/device/assembly/signaler(get_turf(src))
-			new /obj/item/clothing/head/helmet/sec(get_turf(src))
+			new /obj/item/device/assembly/signaler(Tsec)
+			new /obj/item/clothing/head/helmet/sec(Tsec)
 			to_chat(user, "<span class='notice'>You disconnect the signaler from the helmet.</span>")
 			qdel(src)
 
-		else if(build_step == 2)
+		else if(build_step == ASSEMBLY_THIRD_STEP)
 			cut_overlay("hs_eye")
-			new /obj/item/device/assembly/prox_sensor(get_turf(src))
+			new /obj/item/device/assembly/prox_sensor(Tsec)
 			to_chat(user, "<span class='notice'>You detach the proximity sensor from [src].</span>")
 			build_step--
 
-		else if(build_step == 3)
+		else if(build_step == ASSEMBLY_FOURTH_STEP)
 			cut_overlay("hs_arm")
-			new /obj/item/bodypart/l_arm/robot(get_turf(src))
-			to_chat(user, "<span class='notice'>You remove the robot arm from [src].</span>")
+			var/obj/item/bodypart/dropped_arm = new robot_arm(Tsec)
+			robot_arm = null
+			to_chat(user, "<span class='notice'>You remove [dropped_arm] from [src].</span>")
 			build_step--

--- a/code/modules/mob/living/simple_animal/bot/construction.dm
+++ b/code/modules/mob/living/simple_animal/bot/construction.dm
@@ -356,6 +356,7 @@
 		S.name = created_name
 		S.spam_flag = TRUE // only long enough to hear the first ping.
 		addtimer(CALLBACK (S, .mob/living/simple_animal/bot/honkbot/proc/react_ping), 5)
+		S.bikehorn = I.type
 		qdel(I)
 		qdel(src)
 

--- a/code/modules/mob/living/simple_animal/bot/ed209bot.dm
+++ b/code/modules/mob/living/simple_animal/bot/ed209bot.dm
@@ -41,6 +41,8 @@
 	var/arrest_type = 0 //If true, don't handcuff
 	var/projectile = /obj/item/projectile/energy/electrode //Holder for projectile type
 	var/shoot_sound = 'sound/weapons/taser.ogg'
+	var/cell_type = /obj/item/stock_parts/cell
+	var/vest_type = /obj/item/clothing/suit/armor/vest
 
 
 /mob/living/simple_animal/bot/ed209/Initialize(mapload,created_name,created_lasercolor)
@@ -374,11 +376,12 @@ Auto Patrol[]"},
 	visible_message("<span class='boldannounce'>[src] blows apart!</span>")
 	var/atom/Tsec = drop_location()
 
-	var/obj/item/ed209_assembly/Sa = new (Tsec)
+	var/obj/item/bot_assembly/ed209/Sa = new (Tsec)
 	Sa.build_step = 1
 	Sa.add_overlay("hs_hole")
 	Sa.created_name = name
 	new /obj/item/device/assembly/prox_sensor(Tsec)
+	drop_part(cell_type, Tsec)
 
 	if(!lasercolor)
 		var/obj/item/gun/energy/e_gun/advtaser/G = new (Tsec)
@@ -402,7 +405,7 @@ Auto Patrol[]"},
 			new /obj/item/clothing/head/helmet(Tsec)
 		else
 			if(!lasercolor)
-				new /obj/item/clothing/suit/armor/vest(Tsec)
+				drop_part(vest_type, Tsec)
 			if(lasercolor == "b")
 				new /obj/item/clothing/suit/bluetag(Tsec)
 			if(lasercolor == "r")

--- a/code/modules/mob/living/simple_animal/bot/floorbot.dm
+++ b/code/modules/mob/living/simple_animal/bot/floorbot.dm
@@ -375,7 +375,7 @@
 		empty_tiles()
 
 	if(prob(50))
-		new /obj/item/bodypart/l_arm/robot(Tsec)
+		drop_part(robot_arm, Tsec)
 
 	var/obj/item/stack/tile/plasteel/T = new (Tsec)
 	T.amount = 1

--- a/code/modules/mob/living/simple_animal/bot/honkbot.dm
+++ b/code/modules/mob/living/simple_animal/bot/honkbot.dm
@@ -35,6 +35,7 @@
 	var/check_records = TRUE
 	var/arrest_type = FALSE
 	var/weaponscheck = TRUE
+	var/bikehorn = /obj/item/bikehorn
 
 /mob/living/simple_animal/bot/honkbot/Initialize()
 	. = ..()
@@ -332,7 +333,7 @@ Maintenance panel panel is [open ? "opened" : "closed"]"},
 	//doesn't drop cardboard nor its assembly, since its a very frail material.
 	if(prob(50))
 		drop_part(robot_arm, Tsec)
-	new /obj/item/bikehorn(Tsec)
+	new bikehorn(Tsec)
 	new /obj/item/device/assembly/prox_sensor(Tsec)
 
 	var/datum/effect_system/spark_spread/s = new

--- a/code/modules/mob/living/simple_animal/bot/honkbot.dm
+++ b/code/modules/mob/living/simple_animal/bot/honkbot.dm
@@ -331,7 +331,7 @@ Maintenance panel panel is [open ? "opened" : "closed"]"},
 	var/atom/Tsec = drop_location()
 	//doesn't drop cardboard nor its assembly, since its a very frail material.
 	if(prob(50))
-		new /obj/item/bodypart/l_arm/robot(Tsec)
+		drop_part(robot_arm, Tsec)
 	new /obj/item/bikehorn(Tsec)
 	new /obj/item/device/assembly/prox_sensor(Tsec)
 

--- a/code/modules/mob/living/simple_animal/bot/medbot.dm
+++ b/code/modules/mob/living/simple_animal/bot/medbot.dm
@@ -28,6 +28,8 @@
 	path_image_color = "#DDDDFF"
 
 	var/obj/item/reagent_containers/glass/reagent_glass = null //Can be set to draw from this for reagents.
+	var/healthanalyzer = /obj/item/device/healthanalyzer
+	var/firstaid = /obj/item/storage/firstaid
 	var/skin = null //Set to "tox", "ointment" or "o2" for the other two firstaid kits.
 	var/mob/living/carbon/patient = null
 	var/mob/living/carbon/oldpatient = null
@@ -519,18 +521,15 @@
 	visible_message("<span class='boldannounce'>[src] blows apart!</span>")
 	var/atom/Tsec = drop_location()
 
-	new /obj/item/storage/firstaid(Tsec)
-
+	drop_part(firstaid, Tsec)
 	new /obj/item/device/assembly/prox_sensor(Tsec)
-
-	new /obj/item/device/healthanalyzer(Tsec)
+	drop_part(healthanalyzer, Tsec)
 
 	if(reagent_glass)
-		reagent_glass.forceMove(Tsec)
-		reagent_glass = null
+		drop_part(reagent_glass, Tsec)
 
 	if(prob(50))
-		new /obj/item/bodypart/l_arm/robot(Tsec)
+		drop_part(robot_arm, Tsec)
 
 	if(emagged && prob(25))
 		playsound(loc, 'sound/voice/minsult.ogg', 50, 0)

--- a/code/modules/mob/living/simple_animal/bot/secbot.dm
+++ b/code/modules/mob/living/simple_animal/bot/secbot.dm
@@ -15,13 +15,13 @@
 	bot_type = SEC_BOT
 	model = "Securitron"
 	bot_core_type = /obj/machinery/bot_core/secbot
-	var/baton_type = /obj/item/melee/baton
 	window_id = "autosec"
 	window_name = "Automatic Security Unit v1.6"
 	allow_pai = 0
 	data_hud_type = DATA_HUD_SECURITY_ADVANCED
 	path_image_color = "#FF0000"
 
+	var/baton_type = /obj/item/melee/baton
 	var/mob/living/carbon/target
 	var/oldtarget_name
 	var/threatlevel = 0
@@ -402,15 +402,15 @@ Auto Patrol: []"},
 	visible_message("<span class='boldannounce'>[src] blows apart!</span>")
 	var/atom/Tsec = drop_location()
 
-	var/obj/item/secbot_assembly/Sa = new (Tsec)
+	var/obj/item/bot_assembly/secbot/Sa = new (Tsec)
 	Sa.build_step = 1
 	Sa.add_overlay("hs_hole")
 	Sa.created_name = name
 	new /obj/item/device/assembly/prox_sensor(Tsec)
-	new baton_type(Tsec)
+	drop_part(baton_type, Tsec)
 
 	if(prob(50))
-		new /obj/item/bodypart/l_arm/robot(Tsec)
+		drop_part(robot_arm, Tsec)
 
 	do_sparks(3, TRUE, src)
 

--- a/code/modules/reagents/reagent_containers/glass.dm
+++ b/code/modules/reagents/reagent_containers/glass.dm
@@ -254,7 +254,7 @@
 		to_chat(user, "<span class='notice'>You add [O] to [src].</span>")
 		qdel(O)
 		qdel(src)
-		user.put_in_hands(new /obj/item/bucket_sensor)
+		user.put_in_hands(new /obj/item/bot_assembly/cleanbot)
 	else
 		..()
 


### PR DESCRIPTION
Fixes #34156
Removed `/obj/item/toolbox_tiles_sensor` path since it was redundant with the `build_step` var under the new `/obj/item/bot_assembly/floorbot` type.
Also fixed the same issue for a number of other bot parts.
  
:cl: ShizCalev
fix: Constructed security/honk/ect bots will now drop the correct parts when destroyed.
/:cl:
  