### PR TITLE
Replaces the RnD labs on Box, Delta, and Meta with circuitry labs

### DIFF
--- a/_maps/map_files/BoxStation/BoxStation.dmm
+++ b/_maps/map_files/BoxStation/BoxStation.dmm
@@ -17340,7 +17340,7 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "aRi" = (
-/obj/machinery/computer/atmos_alert,
+/obj/machinery/computer/rdconsole/core,
 /turf/open/floor/plasteel/yellow/side{
 	dir = 10
 	},
@@ -17367,7 +17367,7 @@
 	},
 /area/bridge)
 "aRl" = (
-/obj/machinery/computer/station_alert,
+/obj/machinery/modular_computer/console/preset/engineering,
 /turf/open/floor/plasteel/yellow/side,
 /area/bridge)
 "aRm" = (
@@ -23543,6 +23543,7 @@
 	dir = 1
 	},
 /obj/machinery/rnd/circuit_imprinter,
+/obj/item/reagent_containers/glass/beaker/sulphuric,
 /turf/open/floor/plasteel/white,
 /area/science/robotics/lab)
 "bhy" = (
@@ -23605,29 +23606,15 @@
 /turf/open/floor/plating,
 /area/science/lab)
 "bhE" = (
-/obj/structure/table,
-/obj/item/stack/sheet/glass/fifty{
-	pixel_x = 3;
-	pixel_y = 3
-	},
-/obj/item/stack/sheet/metal/fifty,
-/obj/item/clothing/glasses/welding,
-/turf/open/floor/plasteel/white,
+/obj/machinery/rnd/protolathe/department/science,
+/turf/open/floor/plasteel,
 /area/science/lab)
 "bhF" = (
-/obj/structure/table,
-/obj/item/storage/toolbox/mechanical{
-	pixel_x = 2;
-	pixel_y = 3
-	},
-/obj/item/storage/toolbox/mechanical{
-	pixel_x = -2;
-	pixel_y = -1
-	},
 /obj/machinery/light{
 	dir = 1
 	},
-/turf/open/floor/plasteel/white,
+/obj/machinery/rnd/destructive_analyzer,
+/turf/open/floor/plasteel,
 /area/science/lab)
 "bhG" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -23790,17 +23777,13 @@
 /turf/open/floor/plating,
 /area/quartermaster/sorting)
 "bib" = (
-/obj/machinery/disposal/bin,
-/obj/structure/disposalpipe/trunk{
-	dir = 8
-	},
 /obj/item/device/radio/intercom{
 	freerange = 0;
 	frequency = 1459;
 	name = "Station Intercom (General)";
 	pixel_x = 29
 	},
-/turf/open/floor/plasteel/white,
+/turf/open/floor/plasteel,
 /area/science/lab)
 "bic" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -24621,21 +24604,13 @@
 /turf/open/floor/circuit,
 /area/science/robotics/mechbay)
 "bki" = (
-/obj/structure/table/glass,
-/obj/item/reagent_containers/glass/beaker/large{
-	pixel_x = -3;
-	pixel_y = 3
-	},
-/obj/item/reagent_containers/glass/beaker{
-	pixel_x = 8;
-	pixel_y = 2
-	},
-/obj/item/reagent_containers/dropper,
 /obj/machinery/airalarm{
 	dir = 8;
 	pixel_x = 24
 	},
-/turf/open/floor/plasteel/white,
+/obj/structure/chair/stool,
+/obj/effect/landmark/start/scientist,
+/turf/open/floor/plasteel,
 /area/science/lab)
 "bkj" = (
 /obj/structure/closet/emcloset,
@@ -24738,10 +24713,21 @@
 /turf/open/floor/plasteel,
 /area/quartermaster/storage)
 "bkv" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
+/obj/structure/table,
+/obj/item/stack/sheet/metal/fifty,
+/obj/item/stack/sheet/metal/fifty{
+	pixel_x = -3;
+	pixel_y = 2
 	},
-/turf/open/floor/plasteel/white,
+/obj/item/storage/toolbox/electrical,
+/obj/item/storage/toolbox/mechanical{
+	pixel_x = -3;
+	pixel_y = 2
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
 /area/science/lab)
 "bkw" = (
 /obj/structure/disposalpipe/segment,
@@ -25443,31 +25429,16 @@
 /turf/open/floor/plasteel,
 /area/quartermaster/storage)
 "blZ" = (
-/obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/components/unary/vent_pump/on,
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
 /turf/open/floor/plasteel/white,
 /area/science/lab)
 "bma" = (
-/obj/structure/table/glass,
-/obj/item/stock_parts/manipulator,
-/obj/item/stock_parts/capacitor,
-/obj/item/stock_parts/capacitor,
-/obj/item/stock_parts/manipulator,
-/obj/item/stock_parts/micro_laser,
-/obj/item/stock_parts/micro_laser,
-/obj/item/stack/cable_coil{
-	pixel_x = 3;
-	pixel_y = 3
-	},
-/obj/item/stack/cable_coil,
 /obj/machinery/firealarm{
 	dir = 4;
 	pixel_x = 24
 	},
-/turf/open/floor/plasteel/white,
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/plasteel,
 /area/science/lab)
 "bmb" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -25880,8 +25851,8 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 10
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
+/obj/structure/disposalpipe/segment{
+	dir = 10
 	},
 /turf/open/floor/plasteel/white,
 /area/science/lab)
@@ -25889,8 +25860,8 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 4
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
 /turf/open/floor/plasteel/white,
 /area/science/lab)
@@ -25938,31 +25909,16 @@
 /turf/open/floor/plasteel,
 /area/science/robotics/lab)
 "bnk" = (
-/obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/structure/cable{
 	icon_state = "2-4"
 	},
-/obj/effect/turf_decal/stripes/corner{
-	dir = 4
-	},
 /turf/open/floor/plasteel/white,
 /area/science/lab)
 "bnl" = (
-/obj/item/stack/sheet/glass,
-/obj/structure/table/glass,
-/obj/item/stack/sheet/glass,
-/obj/item/stack/sheet/glass,
-/obj/item/stock_parts/matter_bin,
-/obj/item/stock_parts/matter_bin,
 /obj/machinery/light{
 	dir = 4
 	},
-/obj/item/stock_parts/scanning_module{
-	pixel_x = 2;
-	pixel_y = 3
-	},
-/obj/item/stock_parts/scanning_module,
 /obj/machinery/power/apc{
 	dir = 4;
 	name = "Research Lab APC";
@@ -26532,9 +26488,10 @@
 /turf/open/floor/plasteel,
 /area/science/research)
 "boA" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
+/obj/structure/disposalpipe/trunk{
+	dir = 4
 	},
+/obj/machinery/disposal/bin,
 /turf/open/floor/plasteel/white,
 /area/science/lab)
 "boB" = (
@@ -26643,11 +26600,13 @@
 /area/science/research)
 "boP" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel/white,
 /area/science/lab)
 "boQ" = (
 /obj/structure/table,
 /obj/machinery/cell_charger,
+/obj/item/stock_parts/cell/high/plus,
 /obj/item/stock_parts/cell/high/plus,
 /obj/item/stock_parts/cell/high/plus,
 /turf/open/floor/plasteel/white,
@@ -26873,7 +26832,6 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "bpo" = (
-/obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -27179,12 +27137,13 @@
 /turf/open/floor/plasteel/dark,
 /area/science/robotics/lab)
 "bpZ" = (
-/obj/item/folder/white,
 /obj/structure/table,
-/obj/item/disk/tech_disk,
-/obj/item/disk/tech_disk,
-/obj/item/disk/design_disk,
-/obj/item/disk/design_disk,
+/obj/item/paper_bin{
+	pixel_x = 1;
+	pixel_y = 9
+	},
+/obj/item/pen,
+/obj/item/folder/white,
 /turf/open/floor/plasteel/white,
 /area/science/lab)
 "bqa" = (
@@ -27219,6 +27178,7 @@
 	name = "research lab shutters"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel/white,
 /area/science/lab)
 "bqg" = (
@@ -27253,7 +27213,6 @@
 /turf/open/floor/plating,
 /area/quartermaster/storage)
 "bqk" = (
-/obj/structure/disposalpipe/segment,
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
@@ -27676,12 +27635,12 @@
 	},
 /area/science/research)
 "brn" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 9
 	},
 /turf/open/floor/plasteel/white,
 /area/science/research)
@@ -27697,9 +27656,6 @@
 	},
 /area/science/research)
 "brp" = (
-/obj/structure/disposalpipe/segment{
-	dir = 9
-	},
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
@@ -30302,9 +30258,6 @@
 /turf/open/floor/plating,
 /area/maintenance/aft)
 "bxi" = (
-/obj/machinery/computer/aifixer{
-	dir = 8
-	},
 /obj/machinery/requests_console{
 	announcementConsole = 1;
 	department = "Research Director's Desk";
@@ -30316,6 +30269,9 @@
 	},
 /obj/structure/window/reinforced{
 	dir = 4
+	},
+/obj/machinery/computer/rdconsole{
+	dir = 8
 	},
 /turf/open/floor/plasteel/cafeteria,
 /area/crew_quarters/heads/hor)
@@ -30342,6 +30298,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 9
 	},
+/obj/item/device/aicard,
 /turf/open/floor/plasteel/white,
 /area/crew_quarters/heads/hor)
 "bxm" = (
@@ -30808,10 +30765,13 @@
 /area/crew_quarters/heads/hor)
 "bys" = (
 /obj/structure/rack,
-/obj/item/device/aicard,
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
+/obj/item/disk/tech_disk,
+/obj/item/disk/tech_disk,
+/obj/item/disk/design_disk,
+/obj/item/disk/design_disk,
 /turf/open/floor/plasteel/white,
 /area/crew_quarters/heads/hor)
 "byt" = (
@@ -57013,6 +56973,53 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/sleeper)
+"QoZ" = (
+/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel/white,
+/area/science/lab)
+"Qpa" = (
+/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel/white,
+/area/science/lab)
+"Qpb" = (
+/obj/structure/table,
+/obj/item/device/assembly/signaler,
+/obj/item/device/assembly/signaler,
+/obj/item/stack/cable_coil,
+/obj/item/stack/cable_coil{
+	pixel_x = 3;
+	pixel_y = -7
+	},
+/obj/item/device/multitool,
+/obj/item/device/multitool{
+	pixel_x = 4
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/science/lab)
+"Qpc" = (
+/obj/structure/table,
+/obj/item/device/integrated_circuit_printer{
+	pixel_x = 4;
+	pixel_y = -1
+	},
+/obj/item/device/integrated_circuit_printer{
+	pixel_x = -2;
+	pixel_y = 6
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 10
+	},
+/turf/open/floor/plasteel,
+/area/science/lab)
 
 (1,1,1) = {"
 aaa
@@ -103921,8 +103928,8 @@ bfX
 bhC
 biU
 bks
-blI
-bnn
+biW
+biW
 boA
 bpZ
 boB
@@ -104177,9 +104184,9 @@ aYV
 bfX
 bhD
 biV
+blL
 biW
-blK
-bnp
+biW
 bng
 boQ
 brx
@@ -104435,8 +104442,8 @@ bgb
 bhC
 biU
 biW
-blJ
-bno
+biW
+biW
 bnf
 boP
 bqf
@@ -104691,8 +104698,8 @@ bcq
 bgc
 bgc
 biX
-bhV
-bka
+biW
+biW
 blZ
 bnk
 bpo
@@ -104947,10 +104954,10 @@ bdw
 beG
 bgc
 bhE
-biW
+QoZ
 bkv
-blL
-biW
+Qpb
+Qpc
 bnh
 biW
 brx
@@ -105204,7 +105211,7 @@ bdy
 beI
 bgc
 bhF
-biW
+Qpa
 bib
 bki
 bma

--- a/_maps/map_files/Deltastation/DeltaStation2.dmm
+++ b/_maps/map_files/Deltastation/DeltaStation2.dmm
@@ -36850,22 +36850,22 @@
 /turf/open/floor/plasteel/dark,
 /area/bridge)
 "byo" = (
-/obj/machinery/computer/station_alert,
 /obj/structure/cable/white{
 	icon_state = "1-2"
 	},
+/obj/machinery/computer/rdconsole/core,
 /turf/open/floor/plasteel/darkyellow/side{
 	dir = 1
 	},
 /area/bridge)
 "byp" = (
-/obj/machinery/computer/atmos_alert,
+/obj/machinery/modular_computer/console/preset/engineering,
 /turf/open/floor/plasteel/darkyellow/side{
 	dir = 1
 	},
 /area/bridge)
 "byq" = (
-/obj/machinery/computer/monitor,
+/obj/machinery/modular_computer/console/preset/engineering,
 /turf/open/floor/plasteel/darkyellow/corner{
 	dir = 4
 	},
@@ -77213,12 +77213,10 @@
 "daW" = (
 /obj/structure/table,
 /obj/item/stack/sheet/metal/fifty,
-/obj/item/stack/sheet/glass/fifty,
-/obj/item/wrench,
-/obj/item/clothing/glasses/welding,
 /obj/machinery/newscaster{
 	pixel_y = 32
 	},
+/obj/item/crowbar,
 /turf/open/floor/plasteel/whitepurple/corner{
 	dir = 4
 	},
@@ -78029,18 +78027,18 @@
 /area/science/research)
 "dcE" = (
 /obj/structure/table/reinforced,
-/obj/item/stock_parts/matter_bin{
-	pixel_x = 3;
-	pixel_y = 3
-	},
-/obj/item/stock_parts/matter_bin,
-/obj/item/stock_parts/micro_laser,
 /obj/machinery/airalarm{
 	dir = 4;
 	pixel_x = -23
 	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
+	},
+/obj/item/stack/sheet/metal/fifty,
+/obj/item/storage/toolbox/mechanical,
+/obj/item/storage/toolbox/electrical{
+	pixel_x = -3;
+	pixel_y = 2
 	},
 /turf/open/floor/plasteel,
 /area/science/lab)
@@ -78064,11 +78062,7 @@
 /turf/open/floor/plasteel,
 /area/science/lab)
 "dcJ" = (
-/obj/effect/turf_decal/loading_area,
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/whitepurple/corner,
 /area/science/lab)
 "dcK" = (
 /obj/machinery/ai_status_display{
@@ -78077,10 +78071,11 @@
 /obj/machinery/light{
 	dir = 4
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 5
-	},
 /obj/machinery/rnd/protolathe/department/science,
+/obj/effect/turf_decal/delivery,
+/obj/effect/turf_decal/stripes/line{
+	dir = 9
+	},
 /turf/open/floor/plasteel,
 /area/science/lab)
 "dcL" = (
@@ -78680,18 +78675,6 @@
 /area/science/research)
 "ded" = (
 /obj/structure/table/reinforced,
-/obj/item/stack/cable_coil/white{
-	pixel_x = 3;
-	pixel_y = 3
-	},
-/obj/item/stack/cable_coil/white,
-/obj/item/stock_parts/scanning_module{
-	pixel_x = 3;
-	pixel_y = 3
-	},
-/obj/item/stock_parts/capacitor,
-/obj/item/stock_parts/manipulator,
-/obj/item/stock_parts/manipulator,
 /obj/item/device/radio/intercom{
 	name = "Station Intercom";
 	pixel_x = -26
@@ -78699,6 +78682,13 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
+/obj/item/device/assembly/signaler,
+/obj/item/device/assembly/signaler,
+/obj/item/device/multitool{
+	pixel_x = 3;
+	pixel_y = -1
+	},
+/obj/item/device/multitool,
 /turf/open/floor/plasteel,
 /area/science/lab)
 "dee" = (
@@ -78730,11 +78720,11 @@
 /turf/open/floor/plasteel,
 /area/science/lab)
 "dej" = (
-/obj/item/reagent_containers/glass/beaker/sulphuric,
+/obj/machinery/rnd/destructive_analyzer,
+/obj/effect/turf_decal/delivery,
 /obj/effect/turf_decal/stripes/line{
-	dir = 6
+	dir = 8
 	},
-/obj/machinery/rnd/circuit_imprinter/department/science,
 /turf/open/floor/plasteel,
 /area/science/lab)
 "dek" = (
@@ -79220,11 +79210,6 @@
 /area/science/research)
 "dfq" = (
 /obj/structure/table/reinforced,
-/obj/item/folder/white,
-/obj/item/stock_parts/cell/high,
-/obj/item/stack/sheet/glass,
-/obj/item/stack/sheet/glass,
-/obj/item/stack/sheet/glass,
 /obj/structure/cable/white{
 	icon_state = "0-4"
 	},
@@ -79238,6 +79223,9 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 6
 	},
+/obj/machinery/cell_charger,
+/obj/item/stock_parts/cell/high,
+/obj/item/stock_parts/cell/high,
 /turf/open/floor/plasteel,
 /area/science/lab)
 "dfr" = (
@@ -79940,6 +79928,9 @@
 "dgM" = (
 /obj/structure/table,
 /obj/item/clipboard,
+/obj/item/paper_bin,
+/obj/item/folder,
+/obj/item/pen,
 /obj/item/toy/figure/scientist,
 /turf/open/floor/plasteel/whitepurple/side{
 	dir = 10
@@ -79950,14 +79941,14 @@
 	icon_state = "1-2"
 	},
 /obj/structure/table,
-/obj/item/disk/tech_disk{
-	pixel_x = -6
-	},
-/obj/item/disk/tech_disk{
-	pixel_x = 6
-	},
-/obj/item/disk/tech_disk{
+/obj/item/device/integrated_circuit_printer,
+/obj/item/device/integrated_circuit_printer{
+	pixel_x = -2;
 	pixel_y = 6
+	},
+/obj/item/device/integrated_circuit_printer{
+	pixel_x = -4;
+	pixel_y = 12
 	},
 /turf/open/floor/plasteel/whitepurple/side{
 	dir = 6
@@ -81327,6 +81318,8 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 9
 	},
+/obj/item/stock_parts/cell/high,
+/obj/item/stock_parts/cell/high,
 /turf/open/floor/plasteel,
 /area/science/lab)
 "djZ" = (
@@ -81343,13 +81336,7 @@
 /area/science/lab)
 "dka" = (
 /obj/structure/table/reinforced,
-/obj/item/storage/toolbox/mechanical{
-	pixel_x = -3;
-	pixel_y = 3
-	},
 /obj/item/storage/toolbox/mechanical,
-/obj/item/stack/cable_coil/white,
-/obj/item/stack/cable_coil/white,
 /obj/machinery/status_display{
 	pixel_y = -32
 	},
@@ -81359,6 +81346,12 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 5
 	},
+/obj/item/storage/toolbox/electrical{
+	pixel_x = -3;
+	pixel_y = 2
+	},
+/obj/item/stack/cable_coil/white,
+/obj/item/stack/cable_coil/white,
 /turf/open/floor/plasteel,
 /area/science/lab)
 "dkb" = (
@@ -81372,16 +81365,17 @@
 /area/science/lab)
 "dkc" = (
 /obj/structure/table/reinforced,
-/obj/item/folder/white,
-/obj/item/reagent_containers/glass/beaker/large,
-/obj/item/reagent_containers/glass/beaker,
-/obj/item/reagent_containers/dropper,
 /obj/structure/extinguisher_cabinet{
 	pixel_y = -32
 	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 9
 	},
+/obj/item/stack/sheet/metal/fifty{
+	pixel_x = 2;
+	pixel_y = -4
+	},
+/obj/item/stack/sheet/metal/fifty,
 /turf/open/floor/plasteel,
 /area/science/lab)
 "dkd" = (
@@ -86314,9 +86308,6 @@
 	},
 /area/crew_quarters/heads/hor)
 "duM" = (
-/obj/machinery/computer/aifixer{
-	dir = 4
-	},
 /obj/structure/cable/white{
 	icon_state = "1-2"
 	},
@@ -86324,6 +86315,9 @@
 	icon_state = "1-4"
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
+	dir = 4
+	},
+/obj/machinery/computer/rdconsole{
 	dir = 4
 	},
 /turf/open/floor/plasteel/white,
@@ -142782,8 +142776,8 @@ cQQ
 cXA
 cZp
 daU
-dcI
-deh
+dcH
+dcH
 dcH
 dgO
 dcH
@@ -143040,7 +143034,7 @@ cXB
 cZo
 daV
 dcJ
-dei
+dcJ
 dfu
 dgP
 dil

--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -28456,7 +28456,7 @@
 	},
 /area/bridge)
 "bhl" = (
-/obj/machinery/computer/station_alert,
+/obj/machinery/computer/rdconsole/core,
 /turf/open/floor/plasteel/darkbrown/side{
 	dir = 1
 	},
@@ -28473,7 +28473,7 @@
 	},
 /area/bridge)
 "bhn" = (
-/obj/machinery/computer/atmos_alert,
+/obj/machinery/modular_computer/console/preset/engineering,
 /turf/open/floor/plasteel/darkbrown/side{
 	dir = 1
 	},
@@ -53641,17 +53641,9 @@
 	},
 /area/hallway/primary/aft)
 "chi" = (
-/obj/structure/table,
-/obj/item/crowbar,
-/obj/item/wrench,
-/obj/item/clothing/mask/gas,
-/obj/item/device/multitool{
-	pixel_x = 3
+/turf/open/floor/plasteel/whitepurple/side{
+	dir = 9
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
 /area/science/lab)
 "chj" = (
 /obj/structure/sink/kitchen{
@@ -53660,7 +53652,7 @@
 	pixel_y = 28
 	},
 /turf/open/floor/plasteel/whitepurple/side{
-	dir = 9
+	dir = 1
 	},
 /area/science/lab)
 "chk" = (
@@ -54282,28 +54274,34 @@
 	},
 /area/medical/chemistry)
 "ciB" = (
-/obj/machinery/rnd/destructive_analyzer,
 /obj/machinery/airalarm{
 	dir = 4;
 	pixel_x = -23
 	},
+/obj/structure/chair/office/light{
+	icon_state = "officechair_white";
+	dir = 4
+	},
+/obj/effect/landmark/start/scientist,
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
 /area/science/lab)
 "ciC" = (
+/obj/structure/table,
+/obj/item/device/integrated_circuit_printer,
+/obj/item/device/integrated_circuit_printer{
+	pixel_x = -4;
+	pixel_y = 3
+	},
 /obj/effect/turf_decal/stripes/line{
-	dir = 1
+	dir = 5
 	},
 /turf/open/floor/plasteel,
 /area/science/lab)
 "ciD" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/obj/machinery/rnd/protolathe/department/science,
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/white,
 /area/science/lab)
 "ciE" = (
 /obj/structure/disposalpipe/segment{
@@ -54315,22 +54313,15 @@
 /turf/open/floor/plasteel/white,
 /area/science/lab)
 "ciF" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on,
+/obj/effect/turf_decal/stripes/corner,
 /turf/open/floor/plasteel/white,
 /area/science/lab)
 "ciG" = (
-/obj/machinery/disposal/bin{
-	pixel_x = 5
-	},
-/obj/structure/disposalpipe/trunk{
-	dir = 8
-	},
 /obj/structure/extinguisher_cabinet{
 	pixel_x = 24
 	},
+/obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plasteel/whitepurple/side{
 	dir = 4
 	},
@@ -54964,20 +54955,11 @@
 /turf/open/floor/plasteel/white,
 /area/science/lab)
 "ckc" = (
-/obj/structure/table,
-/obj/item/stock_parts/manipulator,
-/obj/item/stock_parts/capacitor,
-/obj/item/stock_parts/capacitor,
-/obj/item/stock_parts/manipulator,
-/obj/item/stock_parts/micro_laser,
-/obj/item/stock_parts/micro_laser,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
-/obj/item/clothing/glasses/science,
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
+/obj/machinery/rnd/protolathe/department/science,
+/obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel,
 /area/science/lab)
 "ckd" = (
@@ -55621,21 +55603,13 @@
 	},
 /area/hallway/primary/aft)
 "clz" = (
-/obj/item/stack/sheet/glass/fifty{
-	pixel_x = 3;
-	pixel_y = 3
+/turf/open/floor/plasteel/whitepurple/side{
+	dir = 10
 	},
-/obj/item/stack/sheet/metal/fifty,
-/obj/item/clothing/glasses/welding,
-/obj/structure/table,
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
 /area/science/lab)
 "clA" = (
 /obj/effect/landmark/event_spawn,
-/turf/open/floor/plasteel/whitepurple/side{
+/turf/open/floor/plasteel/whitepurple/corner{
 	dir = 8
 	},
 /area/science/lab)
@@ -55656,17 +55630,14 @@
 /turf/open/floor/plasteel/white,
 /area/science/lab)
 "clE" = (
-/obj/structure/table,
-/obj/item/stock_parts/matter_bin,
-/obj/item/stock_parts/matter_bin,
-/obj/item/stock_parts/scanning_module,
-/obj/item/stock_parts/scanning_module,
 /obj/machinery/light{
 	dir = 4
 	},
 /obj/structure/sign/nosmoking_2{
 	pixel_x = 30
 	},
+/obj/machinery/rnd/destructive_analyzer,
+/obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel,
 /area/science/lab)
 "clF" = (
@@ -56167,11 +56138,20 @@
 /obj/structure/table,
 /obj/item/stack/cable_coil,
 /obj/item/stack/cable_coil,
-/obj/item/stock_parts/scanning_module{
-	pixel_x = 2;
-	pixel_y = 3
+/obj/item/device/assembly/signaler,
+/obj/item/device/assembly/signaler,
+/obj/item/stock_parts/cell/high{
+	charge = 100;
+	maxcharge = 15000
 	},
-/obj/item/stock_parts/scanning_module,
+/obj/item/stock_parts/cell/high{
+	charge = 100;
+	maxcharge = 15000
+	},
+/obj/item/stock_parts/cell/high{
+	charge = 100;
+	maxcharge = 15000
+	},
 /turf/open/floor/plasteel,
 /area/science/lab)
 "cmK" = (
@@ -56803,7 +56783,6 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
-/obj/structure/chair/stool,
 /turf/open/floor/plasteel/white,
 /area/science/lab)
 "cnU" = (
@@ -56824,15 +56803,11 @@
 /turf/open/floor/plasteel/white,
 /area/science/lab)
 "cnW" = (
-/obj/structure/table,
-/obj/item/stack/sheet/glass,
-/obj/item/stack/sheet/glass,
-/obj/item/stack/sheet/glass,
-/obj/item/stock_parts/cell/high{
-	charge = 100;
-	maxcharge = 15000
-	},
 /obj/effect/turf_decal/stripes/line,
+/obj/structure/disposalpipe/trunk,
+/obj/machinery/disposal/bin{
+	pixel_x = 5
+	},
 /turf/open/floor/plasteel,
 /area/science/lab)
 "cnX" = (
@@ -57434,9 +57409,7 @@
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 10
-	},
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel/whitepurple/side{
 	dir = 4
 	},
@@ -58158,6 +58131,10 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
+/obj/item/stock_parts/cell/high{
+	charge = 100;
+	maxcharge = 15000
+	},
 /turf/open/floor/plasteel,
 /area/science/lab)
 "cqy" = (
@@ -58165,20 +58142,17 @@
 	pixel_x = 2;
 	pixel_y = 3
 	},
-/obj/item/storage/toolbox/mechanical{
-	pixel_x = -2;
-	pixel_y = -1
-	},
 /obj/machinery/firealarm{
 	dir = 1;
 	pixel_y = -24
 	},
-/obj/item/stack/cable_coil,
-/obj/item/stack/cable_coil,
 /obj/structure/table,
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
+/obj/item/storage/toolbox/electrical,
+/obj/item/stack/cable_coil,
+/obj/item/stack/cable_coil,
 /turf/open/floor/plasteel,
 /area/science/lab)
 "cqz" = (
@@ -59487,13 +59461,9 @@
 /turf/open/floor/plating,
 /area/crew_quarters/heads/hor)
 "csZ" = (
-/obj/machinery/computer/security/telescreen{
-	desc = "Used for watching the RD's goons from the safety of his office.";
-	name = "Research Monitor";
-	network = list("RD");
-	pixel_y = 2
+/obj/machinery/computer/rdconsole{
+	dir = 4
 	},
-/obj/structure/table/reinforced,
 /turf/open/floor/plasteel/cafeteria{
 	dir = 5
 	},
@@ -80629,6 +80599,36 @@
 /obj/structure/sign/poster/official/random,
 /turf/closed/wall,
 /area/hydroponics)
+"Ljx" = (
+/obj/structure/table,
+/obj/item/stack/sheet/metal/fifty,
+/obj/item/stack/sheet/metal/fifty,
+/obj/item/device/multitool{
+	pixel_x = -1;
+	pixel_y = -2
+	},
+/obj/item/device/multitool{
+	pixel_x = 3
+	},
+/obj/item/crowbar,
+/obj/effect/turf_decal/stripes/line{
+	dir = 6
+	},
+/turf/open/floor/plasteel,
+/area/science/lab)
+"Ljy" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/structure/table/reinforced,
+/obj/machinery/computer/security/telescreen{
+	desc = "Used for watching the RD's goons from the safety of his office.";
+	name = "Research Monitor";
+	network = list("RD");
+	pixel_y = 2
+	},
+/turf/open/floor/plasteel/cafeteria{
+	dir = 5
+	},
+/area/crew_quarters/heads/hor)
 
 (1,1,1) = {"
 aaa
@@ -108795,7 +108795,7 @@ ceM
 cgd
 chi
 ciB
-cjX
+cjY
 clz
 cgd
 cnR
@@ -109052,7 +109052,7 @@ ceN
 cgd
 chj
 ciC
-cjY
+Ljx
 clA
 cmF
 cnS
@@ -109309,9 +109309,9 @@ ceO
 cgd
 chk
 ciD
-cjZ
-clB
-cmG
+ciD
+ciD
+ciD
 cnT
 cpe
 cqy
@@ -109565,12 +109565,12 @@ cdJ
 ceP
 cgd
 chl
-ciE
-cka
-clC
-cmH
-cnU
-cpf
+ciD
+ciD
+ciD
+ciD
+cnT
+cpe
 cqz
 cgd
 csP
@@ -109827,7 +109827,7 @@ ckb
 clD
 cmI
 cnV
-cpg
+cpe
 cqA
 crI
 csQ
@@ -112400,7 +112400,7 @@ coe
 cpq
 cqJ
 crP
-cuN
+Ljy
 ctR
 cuN
 cvR


### PR DESCRIPTION
Title. Since RnD is now decentralized with techwebs, and circuitry is supposed to be the thing to replace RnD in the science department, this change should have been made a long time ago.

This also re-adds the RnD console to the bridge, as that was supposed to be done with the initial techwebs PR, according to #32606

This also moves the RnD console that used to be in the RnD area to the RD's office.

:cl: deathride58
add: The research department on Boxstation, Deltastation, and Metastation now contain circuitry labs instead of RnD labs. Have fun creating all sorts of unique devices!
/:cl:

## Screenshots
Boxstation
![image](https://user-images.githubusercontent.com/6356337/34647159-d8188dc0-f348-11e7-96f6-f698bbf893b2.png)

Metastation
![image](https://user-images.githubusercontent.com/6356337/34647160-e3cd8f44-f348-11e7-9425-c47510d7483c.png)

Deltastation
![image](https://user-images.githubusercontent.com/6356337/34647163-ec599a68-f348-11e7-850e-c94c4eec35d7.png)

The empty space is mostly to provide room to test drones and other devices that require an open space to function.