### PR TITLE
Replaces object armor lists with shared armor datums

### DIFF
--- a/code/datums/armor.dm
+++ b/code/datums/armor.dm
@@ -2,6 +2,12 @@
 
 GLOBAL_LIST_EMPTY(armorobjects)
 
+/proc/getArmor(melee = 0, bullet = 0, laser = 0, energy = 0, bomb = 0, bio = 0, rad = 0, fire = 0, acid = 0)
+  if (GLOB.armorobjects[ARMORLISTID])
+    return GLOB.armorobjects[ARMORLISTID]
+  else
+    return new /datum/armor(melee, bullet, laser, energy, bomb, bio, rad, fire, acid)
+
 /datum/armor
   var/melee
   var/bullet
@@ -12,12 +18,6 @@ GLOBAL_LIST_EMPTY(armorobjects)
   var/rad
   var/fire
   var/acid
-
-/proc/getArmor(melee = 0, bullet = 0, laser = 0, energy = 0, bomb = 0, bio = 0, rad = 0, fire = 0, acid = 0)
-  if (GLOB.armorobjects[ARMORLISTID])
-    return GLOB.armorobjects[ARMORLISTID]
-  else
-    return new /datum/armor(melee, bullet, laser, energy, bomb, bio, rad, fire, acid)
 
 /datum/armor/New(melee = 0, bullet = 0, laser = 0, energy = 0, bomb = 0, bio = 0, rad = 0, fire = 0, acid = 0)
   src.melee = melee
@@ -37,7 +37,7 @@ GLOBAL_LIST_EMPTY(armorobjects)
 /datum/armor/proc/modifyAllRatings(modifier = 0)
   return getArmor(src.melee+modifier, src.bullet+modifier, src.laser+modifier, src.energy+modifier, src.bomb+modifier, src.bio+modifier, src.rad+modifier, src.fire+modifier, src.acid+modifier)
 
-/datum/armor/proc/setRating(melee = null, bullet = null, laser = null, energy = null, bomb = null, bio = null, rad = null, fire = null, acid = null)
+/datum/armor/proc/setRating(melee, bullet, laser, energy, bomb, bio, rad, fire, acid)
   return getArmor((isnull(melee) ? src.melee : melee),\
                   (isnull(melee) ? src.bullet : bullet),\
                   (isnull(melee) ? src.laser : laser),\

--- a/code/datums/armor.dm
+++ b/code/datums/armor.dm
@@ -1,0 +1,57 @@
+#define ARMORLISTID "[melee]-[bullet]-[laser]-[energy]-[bomb]-[bio]-[rad]-[fire]-[acid]"
+
+GLOBAL_LIST_EMPTY(armorobjects)
+
+/datum/armor
+  var/melee
+  var/bullet
+  var/laser
+  var/energy
+  var/bomb
+  var/bio
+  var/rad
+  var/fire
+  var/acid
+
+/proc/getArmor(melee = 0, bullet = 0, laser = 0, energy = 0, bomb = 0, bio = 0, rad = 0, fire = 0, acid = 0)
+  if (GLOB.armorobjects[ARMORLISTID])
+    return GLOB.armorobjects[ARMORLISTID]
+  else
+    return new /datum/armor(melee, bullet, laser, energy, bomb, bio, rad, fire, acid)
+
+/datum/armor/New(melee = 0, bullet = 0, laser = 0, energy = 0, bomb = 0, bio = 0, rad = 0, fire = 0, acid = 0)
+  src.melee = melee
+  src.bullet = bullet
+  src.laser = laser
+  src.energy = energy
+  src.bomb = bomb
+  src.bio = bio
+  src.rad = rad
+  src.fire = fire
+  src.acid = acid
+  GLOB.armorobjects[ARMORLISTID] = src
+
+/datum/armor/proc/modifyRating(melee = 0, bullet = 0, laser = 0, energy = 0, bomb = 0, bio = 0, rad = 0, fire = 0, acid = 0)
+  return getArmor(src.melee+melee, src.bullet+bullet, src.laser+laser, src.energy+energy, src.bomb+bomb, src.bio+bio, src.rad+rad, src.fire+fire, src.acid+acid)
+
+/datum/armor/proc/modifyAllRatings(modifier = 0)
+  return getArmor(src.melee+modifier, src.bullet+modifier, src.laser+modifier, src.energy+modifier, src.bomb+modifier, src.bio+modifier, src.rad+modifier, src.fire+modifier, src.acid+modifier)
+
+/datum/armor/proc/setRating(melee = null, bullet = null, laser = null, energy = null, bomb = null, bio = null, rad = null, fire = null, acid = null)
+  return getArmor((isnull(melee) ? src.melee : melee),\
+                  (isnull(melee) ? src.bullet : bullet),\
+                  (isnull(melee) ? src.laser : laser),\
+                  (isnull(melee) ? src.energy : energy),\
+                  (isnull(melee) ? src.bomb : bomb),\
+                  (isnull(melee) ? src.bio : bio),\
+                  (isnull(melee) ? src.rad : rad),\
+                  (isnull(melee) ? src.fire : fire),\
+                  (isnull(melee) ? src.acid : acid))
+
+/datum/armor/proc/attachArmor(datum/armor/AA)
+  return getArmor(src.melee+AA.melee, src.bullet+AA.bullet, src.laser+AA.laser, src.energy+AA.energy, src.bomb+AA.bomb, src.bio+AA.bio, src.rad+AA.rad, src.fire+AA.fire, src.acid+AA.acid)
+
+/datum/armor/proc/detachArmor(datum/armor/AA)
+  return getArmor(src.melee-AA.melee, src.bullet-AA.bullet, src.laser-AA.laser, src.energy-AA.energy, src.bomb-AA.bomb, src.bio-AA.bio, src.rad-AA.rad, src.fire-AA.fire, src.acid-AA.acid)
+
+#undef ARMORLISTID

--- a/code/game/gamemodes/blob/blobs/blob_mobs.dm
+++ b/code/game/gamemodes/blob/blobs/blob_mobs.dm
@@ -115,8 +115,7 @@
 	is_zombie = 1
 	if(H.wear_suit)
 		var/obj/item/clothing/suit/armor/A = H.wear_suit
-		if(A.armor && A.armor["melee"])
-			maxHealth += A.armor["melee"] //That zombie's got armor, I want armor!
+		maxHealth += A.armor.melee //That zombie's got armor, I want armor!
 	maxHealth += 40
 	health = maxHealth
 	name = "blob zombie"

--- a/code/game/gamemodes/blob/theblob.dm
+++ b/code/game/gamemodes/blob/theblob.dm
@@ -275,7 +275,7 @@
 			return 0
 	var/armor_protection = 0
 	if(damage_flag)
-		armor_protection = armor[damage_flag]
+		armor_protection = armor.vars[damage_flag]
 	damage_amount = round(damage_amount * (100 - armor_protection)*0.01, 0.1)
 	if(overmind && damage_flag)
 		damage_amount = overmind.blob_reagent_datum.damage_reaction(src, damage_amount, damage_type, damage_flag)

--- a/code/game/mecha/mecha.dm
+++ b/code/game/mecha/mecha.dm
@@ -215,7 +215,7 @@
 		step_energy_drain = normal_step_energy_drain
 		qdel(SM)
 	if(CP)
-		armor["energy"] += (CP.rating * 10) //Each level of capacitor protects the mech against emp by 10%
+		armor.modifyRating(energy = (CP.rating * 10)) //Each level of capacitor protects the mech against emp by 10%
 		qdel(CP)
 
 ////////////////////////

--- a/code/game/objects/obj_defense.dm
+++ b/code/game/objects/obj_defense.dm
@@ -27,7 +27,7 @@
 			return 0
 	var/armor_protection = 0
 	if(damage_flag)
-		armor_protection = armor[damage_flag]
+		armor_protection = armor.vars[damage_flag]
 	if(armor_protection)		//Only apply weak-against-armor/hollowpoint effects if there actually IS armor.
 		armor_protection = CLAMP(armor_protection - armour_penetration, 0, 100)
 	return round(damage_amount * (100 - armor_protection)*0.01, 0.1)
@@ -178,7 +178,7 @@ GLOBAL_DATUM_INIT(acid_overlay, /mutable_appearance, mutable_appearance('icons/e
 	if(!(resistance_flags & ACID_PROOF))
 		for(var/armour_value in armor)
 			if(armour_value != "acid" && armour_value != "fire")
-				armor[armour_value] = max(armor[armour_value] - round(sqrt(acid_level)*0.1), 0)
+				armor.modifyAllRatings(0 - round(sqrt(acid_level)*0.1))
 		if(prob(33))
 			playsound(loc, 'sound/items/welder.ogg', 150, 1)
 		take_damage(min(1 + round(sqrt(acid_level)*0.3), 300), BURN, "acid", 0)

--- a/code/game/objects/objs.dm
+++ b/code/game/objects/objs.dm
@@ -7,7 +7,7 @@
 	var/damtype = BRUTE
 	var/force = 0
 
-	var/list/armor
+	var/datum/armor/armor
 	var/obj_integrity	//defaults to max_integrity
 	var/max_integrity = 500
 	var/integrity_failure = 0 //0 if we have no special broken behavior
@@ -40,8 +40,11 @@
 
 /obj/Initialize()
 	. = ..()
-	if (!armor)
-		armor = list(melee = 0, bullet = 0, laser = 0, energy = 0, bomb = 0, bio = 0, rad = 0, fire = 0, acid = 0)
+	if (islist(armor))
+		armor = getArmor(arglist(armor))
+	else if (!istype(armor, /datum/armor))
+		armor = getArmor()
+
 	if(obj_integrity == null)
 		obj_integrity = max_integrity
 	if(on_blueprints && isturf(loc))

--- a/code/game/turfs/simulated/lava.dm
+++ b/code/game/turfs/simulated/lava.dm
@@ -100,8 +100,8 @@
 				O.resistance_flags |= FLAMMABLE //Even fireproof things burn up in lava
 			if(O.resistance_flags & FIRE_PROOF)
 				O.resistance_flags &= ~FIRE_PROOF
-			if(O.armor["fire"] > 50) //obj with 100% fire armor still get slowly burned away.
-				O.armor["fire"] = 50
+			if(O.armor.fire > 50) //obj with 100% fire armor still get slowly burned away.
+				O.armor.setRating(fire = 50)
 			O.fire_act(10000, 1000)
 
 		else if (isliving(thing))

--- a/code/modules/clothing/under/accessories.dm
+++ b/code/modules/clothing/under/accessories.dm
@@ -28,8 +28,7 @@
 		pixel_y -= 8
 	U.add_overlay(src)
 
-	for(var/armor_type in armor)
-		U.armor[armor_type] += armor[armor_type]
+	U.armor.attachArmor(armor)
 
 	if(isliving(user))
 		on_uniform_equip(U, user)
@@ -42,8 +41,7 @@
 		pockets.forceMove(src)
 		U.pockets = null
 
-	for(var/armor_type in armor)
-		U.armor[armor_type] -= armor[armor_type]
+	U.armor.detachArmor(armor)
 
 	if(isliving(user))
 		on_uniform_dropped(U, user)

--- a/code/modules/events/wizard/rpgloot.dm
+++ b/code/modules/events/wizard/rpgloot.dm
@@ -109,7 +109,6 @@
 	I.force = max(0,I.force + quality_mod)
 	I.throwforce = max(0,I.throwforce + quality_mod)
 
-	for(var/value in I.armor)
-		I.armor[value] += quality
+	I.armor.modifyAllRatings(quality)
 
 	rename()

--- a/code/modules/food_and_drinks/drinks/drinks/bottle.dm
+++ b/code/modules/food_and_drinks/drinks/drinks/bottle.dm
@@ -68,12 +68,7 @@
 
 		//If they have a hat/helmet and the user is targeting their head.
 		if(istype(H.head, /obj/item/clothing/head) && affecting == "head")
-
-			// If their head has an armor value, assign headarmor to it, else give it 0.
-			if(H.head.armor["melee"])
-				headarmor = H.head.armor["melee"]
-			else
-				headarmor = 0
+			headarmor = H.head.armor.melee
 		else
 			headarmor = 0
 

--- a/code/modules/mining/equipment/goliath_hide.dm
+++ b/code/modules/mining/equipment/goliath_hide.dm
@@ -21,9 +21,8 @@
 		return
 	if(is_type_in_typecache(target, goliath_platable_armor_typecache))
 		var/obj/item/clothing/C = target
-		var/list/current_armor = C.armor
-		if(current_armor["melee"] < 60)
-			current_armor["melee"] = min(current_armor["melee"] + 10, 60)
+		if(armor.melee < 60)
+			armor.setRating(melee = min(armor.melee + 10, 60))
 			to_chat(user, "<span class='info'>You strengthen [target], improving its resistance against melee attacks.</span>")
 			use(1)
 		else
@@ -32,9 +31,10 @@
 		var/obj/mecha/working/ripley/D = target
 		if(D.hides < 3)
 			D.hides++
-			D.armor["melee"] = min(D.armor["melee"] + 10, 70)
-			D.armor["bullet"] = min(D.armor["bullet"] + 5, 50)
-			D.armor["laser"] = min(D.armor["laser"] + 5, 50)
+			D.armor.setRating(\
+				melee = min(D.armor.melee + 10, 70),\
+				bullet = min(D.armor.laser + 5, 50),\
+				laser = min(D.armor.laser + 5, 50))
 			to_chat(user, "<span class='info'>You strengthen [target], improving its resistance against melee attacks.</span>")
 			D.update_icon()
 			if(D.hides == 3)

--- a/code/modules/mob/living/carbon/human/human_defense.dm
+++ b/code/modules/mob/living/carbon/human/human_defense.dm
@@ -28,7 +28,7 @@
 		if(bp && istype(bp , /obj/item/clothing))
 			var/obj/item/clothing/C = bp
 			if(C.body_parts_covered & def_zone.body_part)
-				protection += C.armor[d_type]
+				protection += C.armor.vars[d_type]
 	return protection
 
 /mob/living/carbon/human/on_hit(obj/item/projectile/P)

--- a/code/modules/mob/living/simple_animal/friendly/dog.dm
+++ b/code/modules/mob/living/simple_animal/friendly/dog.dm
@@ -85,16 +85,16 @@
 	if(def_zone)
 		if(def_zone == "head")
 			if(inventory_head)
-				armorval = inventory_head.armor[type]
+				armorval = inventory_head.armor.vars[type]
 		else
 			if(inventory_back)
-				armorval = inventory_back.armor[type]
+				armorval = inventory_back.armor.vars[type]
 		return armorval
 	else
 		if(inventory_head)
-			armorval += inventory_head.armor[type]
+			armorval += inventory_head.armor.vars[type]
 		if(inventory_back)
-			armorval += inventory_back.armor[type]
+			armorval += inventory_back.armor.vars[type]
 	return armorval*0.5
 
 /mob/living/simple_animal/pet/dog/corgi/attackby(obj/item/O, mob/user, params)

--- a/code/modules/mob/living/simple_animal/friendly/drone/interaction.dm
+++ b/code/modules/mob/living/simple_animal/friendly/drone/interaction.dm
@@ -105,7 +105,7 @@
 	var/armorval = 0
 
 	if(head)
-		armorval = head.armor[type]
+		armorval = head.armor.vars[type]
 	return (armorval * get_armor_effectiveness()) //armor is reduced for tiny fragile drones
 
 /mob/living/simple_animal/drone/proc/get_armor_effectiveness()

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -247,6 +247,7 @@
 #include "code\controllers\subsystem\processing\projectiles.dm"
 #include "code\datums\action.dm"
 #include "code\datums\ai_laws.dm"
+#include "code\datums\armor.dm"
 #include "code\datums\beam.dm"
 #include "code\datums\browser.dm"
 #include "code\datums\callback.dm"


### PR DESCRIPTION
I don't expect this to be ready yet, there's probably something significant I've missed. Basically what this does is replaces 90000+ lists on objects with around 139 shared armor datums of which new ones will be created and shared with future user objects.

I've tested this and nothing SEEMS obviously broken...

:cl: Naksu
code: Slightly refactored object armor code
/:cl:
