### PR TITLE
Makes the tag warning a stack_trace

### DIFF
--- a/code/__HELPERS/unsorted.dm
+++ b/code/__HELPERS/unsorted.dm
@@ -1500,7 +1500,7 @@ GLOBAL_DATUM_INIT(dview_mob, /mob/dview, new)
 		var/datum/thing = input
 		if(thing.use_tag)
 			if(!thing.tag)
-				WARNING("A ref was requested of an object with use_tag set but no tag: [thing]")
+				stack_trace("A ref was requested of an object with use_tag set but no tag: [thing]")
 				thing.use_tag = FALSE
 			else
 				return "\[[url_encode(thing.tag)]\]"


### PR DESCRIPTION
This fixes nothing but the problem shows we should be checking the stack trace when things go wrong here.