### PR TITLE
Unsets cache_lifespan

### DIFF
--- a/code/world.dm
+++ b/code/world.dm
@@ -6,7 +6,6 @@
 	turf = /turf/open/space/basic
 	area = /area/space
 	view = "15x15"
-	cache_lifespan = 7
 	hub = "Exadv1.spacestation13"
 	name = "/tg/ Station 13"
 	fps = 20


### PR DESCRIPTION
> Files uploaded by players are stored in the world's .rsc file for future use. If the file is not used for the specified amount of time, it will be removed to save space. 

If I'm reading this right only admins can affect the cache, and why would we want anything they upload to last more than a session

Correct me if this is used by the asset cache or something