### PR TITLE
[ready] Adds a system to get a stack trace as a list.

### DIFF
--- a/code/__HELPERS/unsorted.dm
+++ b/code/__HELPERS/unsorted.dm
@@ -1258,6 +1258,14 @@ proc/pick_closest_path(value, list/matches = get_fancy_list_of_atom_types())
 /datum/proc/stack_trace(msg)
 	CRASH(msg)
 
+GLOBAL_REAL_VAR(list/stack_trace_storage)
+/proc/gib_stack_trace()
+	stack_trace_storage = list()
+	stack_trace()
+	stack_trace_storage.Cut(1, min(3,stack_trace_storage.len))
+	. = stack_trace_storage
+	stack_trace_storage = null
+
 //Key thing that stops lag. Cornerstone of performance in ss13, Just sitting here, in unsorted.dm.
 
 //Increases delay as the server gets more overloaded,

--- a/code/modules/error_handler/error_handler.dm
+++ b/code/modules/error_handler/error_handler.dm
@@ -20,6 +20,11 @@ GLOBAL_VAR_INIT(total_runtimes_skipped, 0)
 		log_world("The bug with recursion runtimes has been fixed. Please remove the snowflake check from world/Error in [__FILE__]:[__LINE__]")
 		return //this will never happen.
 
+	if (islist(stack_trace_storage))
+		for (var/line in splittext(E.desc, "\n"))
+			if (text2ascii(line) != 32)
+				stack_trace_storage += line
+
 	var/static/list/error_last_seen = list()
 	var/static/list/error_cooldown = list() /* Error_cooldown items will either be positive(cooldown time) or negative(silenced error)
 												If negative, starts at -1, and goes down by 1 each time that error gets skipped*/


### PR DESCRIPTION
note: also includes seperate commit that uses this system to try and find the cause of #34212.

Do not merge until that commit is removed since it adds an unacceptable amount of snowflake to overlays to work.
  