### PR TITLE
Adds Display Name Argument to Techweb Logging

### DIFF
--- a/code/modules/research/rdconsole.dm
+++ b/code/modules/research/rdconsole.dm
@@ -153,7 +153,7 @@ doesn't have toxins access.
 	if(stored_research.research_points >= price)
 		investigate_log("[key_name(user)] researched [id]([price]) on techweb id [stored_research.id].", INVESTIGATE_RESEARCH)
 		if(stored_research == SSresearch.science_tech)
-			SSblackbox.record_feedback("associative", "science_techweb_unlock", 1, list("id" = "[id]", "name" = "[TN.display_name]", "price" = "[price]", "time" = "[SQLtime()]"))
+			SSblackbox.record_feedback("associative", "science_techweb_unlock", 1, list("id" = "[id]", "name" = TN.display_name, "price" = "[price]", "time" = SQLtime()))
 		if(stored_research.research_node(SSresearch.techweb_nodes[id]))
 			say("Sucessfully researched [TN.display_name].")
 			var/logname = "Unknown"

--- a/code/modules/research/rdconsole.dm
+++ b/code/modules/research/rdconsole.dm
@@ -153,7 +153,7 @@ doesn't have toxins access.
 	if(stored_research.research_points >= price)
 		investigate_log("[key_name(user)] researched [id]([price]) on techweb id [stored_research.id].", INVESTIGATE_RESEARCH)
 		if(stored_research == SSresearch.science_tech)
-			SSblackbox.record_feedback("associative", "science_techweb_unlock", 1, list("id" = "[id]", "price" = "[price]", "time" = "[SQLtime()]"))
+			SSblackbox.record_feedback("associative", "science_techweb_unlock", 1, list("id" = "[TN.name]", "price" = "[price]", "time" = "[SQLtime()]"))
 		if(stored_research.research_node(SSresearch.techweb_nodes[id]))
 			say("Sucessfully researched [TN.display_name].")
 			var/logname = "Unknown"

--- a/code/modules/research/rdconsole.dm
+++ b/code/modules/research/rdconsole.dm
@@ -153,7 +153,7 @@ doesn't have toxins access.
 	if(stored_research.research_points >= price)
 		investigate_log("[key_name(user)] researched [id]([price]) on techweb id [stored_research.id].", INVESTIGATE_RESEARCH)
 		if(stored_research == SSresearch.science_tech)
-			SSblackbox.record_feedback("associative", "science_techweb_unlock", 1, list("id" = "[TN.name]", "price" = "[price]", "time" = "[SQLtime()]"))
+			SSblackbox.record_feedback("associative", "science_techweb_unlock", 1, list("id" = "[id]", "name" = "[TN.display_name]", "price" = "[price]", "time" = "[SQLtime()]"))
 		if(stored_research.research_node(SSresearch.techweb_nodes[id]))
 			say("Sucessfully researched [TN.display_name].")
 			var/logname = "Unknown"

--- a/code/modules/research/techweb/_techweb.dm
+++ b/code/modules/research/techweb/_techweb.dm
@@ -20,7 +20,6 @@
 	var/organization = "Third-Party"							//Organization name, used for display.
 	var/last_bitcoins = 0										//Current per-second production, used for display only.
 	var/list/tiers = list()										//Assoc list, datum = number, 1 is available, 2 is all reqs are 1, so on
-	var/order = 1 //Currently only used for stat-tracking nodes
 
 /datum/techweb/New()
 	for(var/i in SSresearch.techweb_nodes_starting)
@@ -142,8 +141,6 @@
 	for(var/i in node.designs)
 		add_design(node.designs[i])
 	update_node_status(node)
-	SSblackbox.record_feedback("nested tally", "research_node_and_order", 1, list("[node.name]","[order]"))
-	order += 1
 	return TRUE
 
 /datum/techweb/proc/unresearch_node_id(id)

--- a/code/modules/research/techweb/_techweb.dm
+++ b/code/modules/research/techweb/_techweb.dm
@@ -20,6 +20,7 @@
 	var/organization = "Third-Party"							//Organization name, used for display.
 	var/last_bitcoins = 0										//Current per-second production, used for display only.
 	var/list/tiers = list()										//Assoc list, datum = number, 1 is available, 2 is all reqs are 1, so on
+	var/order = 1 //Currently only used for stat-tracking nodes
 
 /datum/techweb/New()
 	for(var/i in SSresearch.techweb_nodes_starting)
@@ -141,6 +142,8 @@
 	for(var/i in node.designs)
 		add_design(node.designs[i])
 	update_node_status(node)
+	SSblackbox.record_feedback("nested tally", "research_node_and_order", 1, list("[node.name]","[order]"))
+	order += 1
 	return TRUE
 
 /datum/techweb/proc/unresearch_node_id(id)


### PR DESCRIPTION
:cl:Cobby
code: Adds Stat Tracking to Techwebs by node and order.
/:cl:

Hopefully this works.

Purpose: Seeing what is researched most/least frequently and if people beeline for certain tech allows for more reactive balancing.
  