### PR TITLE
Stops the config warnings when there's no config.txt

### DIFF
--- a/code/controllers/configuration/configuration.dm
+++ b/code/controllers/configuration/configuration.dm
@@ -22,7 +22,7 @@ GLOBAL_PROTECT(config_dir)
 	config = src
 	InitEntries()
 	LoadModes()
-	if(LoadEntries("config.txt") <= 1)
+	if(fexists("config.txt") && LoadEntries("config.txt") <= 1)
 		log_config("No $include directives found in config.txt! Loading legacy game_options/dbconfig/comms files...")
 		LoadEntries("game_options.txt")
 		LoadEntries("dbconfig.txt")


### PR DESCRIPTION
Required by #34198  