### PR TITLE
Removes custom AI board no laws warning

### DIFF
--- a/code/game/objects/items/AI_modules.dm
+++ b/code/game/objects/items/AI_modules.dm
@@ -408,8 +408,7 @@ AI MODULES
 
 		laws += line
 
-	if(!laws.len) //Failsafe if something goes wrong with silicon_laws.txt.
-		WARNING("ERROR: empty custom board created, empty custom board deleted. Please check silicon_laws.txt. (this may be intended by the server host)")
+	if(!laws.len)
 		return INITIALIZE_HINT_QDEL
 
 

--- a/code/game/objects/items/AI_modules.dm
+++ b/code/game/objects/items/AI_modules.dm
@@ -398,8 +398,8 @@ AI MODULES
 /obj/item/aiModule/core/full/custom
 	name = "Default Core AI Module"
 
-/obj/item/aiModule/core/full/custom/New()
-	..()
+/obj/item/aiModule/core/full/custom/Initialize()
+	. = ..()
 	for(var/line in world.file2list("config/silicon_laws.txt"))
 		if(!line)
 			continue
@@ -410,7 +410,7 @@ AI MODULES
 
 	if(!laws.len) //Failsafe if something goes wrong with silicon_laws.txt.
 		WARNING("ERROR: empty custom board created, empty custom board deleted. Please check silicon_laws.txt. (this may be intended by the server host)")
-		qdel(src)
+		return INITIALIZE_HINT_QDEL
 
 
 /****************** T.Y.R.A.N.T. *****************/


### PR DESCRIPTION
An empty or missing silicon_laws.txt is still a valid configuration

Required by #34198
  