### PR TITLE
Precision in timekeeping is important, okay.

### DIFF
--- a/code/__HELPERS/time.dm
+++ b/code/__HELPERS/time.dm
@@ -19,11 +19,9 @@
 		if(month == MM && day == DD)
 			return 1
 
-//returns timestamp in a sql and ISO 8601 friendly format
+//returns timestamp in a sql and a not-quite-compliant ISO 8601 friendly format
 /proc/SQLtime(timevar)
-	if(!timevar)
-		timevar = world.realtime
-	return time2text(timevar, "YYYY-MM-DD hh:mm:ss")
+	return time2text(timevar || world.timeofday, "YYYY-MM-DD hh:mm:ss")
 
 
 GLOBAL_VAR_INIT(midnight_rollovers, 0)


### PR DESCRIPTION
May or may not contain a trojan.

:cl:
fix: Use world.timeofday instead of world.realtime
/:cl:

[why]: Because precision is important in timekeeping