### PR TITLE
Replace CentComm with CentCom

### DIFF
--- a/code/__HELPERS/roundend.dm
+++ b/code/__HELPERS/roundend.dm
@@ -1,5 +1,5 @@
 #define POPCOUNT_SURVIVORS "survivors"					//Not dead at roundend
-#define POPCOUNT_ESCAPEES "escapees"					//Not dead and on centcomm/shuttles marked as escaped
+#define POPCOUNT_ESCAPEES "escapees"					//Not dead and on centcom/shuttles marked as escaped
 #define POPCOUNT_GHOSTS "ghosts"						//Ghosts on roundend
 #define POPCOUNT_HUMAN_ESCAPEES "human_escapees"		//Same as escapees but human only
 #define POPCOUNT_HUMAN_SURVIVORS "human_survivors"		//Same as survivors but human only

--- a/code/game/machinery/computer/communications.dm
+++ b/code/game/machinery/computer/communications.dm
@@ -289,7 +289,7 @@
 				CentCom_announce(input, usr)
 				to_chat(usr, "<span class='notice'>Message transmitted to Central Command.</span>")
 				log_talk(usr,"[key_name(usr)] has made a CentCom announcement: [input]",LOGSAY)
-				deadchat_broadcast("<span class='deadsay'><b>[usr.name] has messaged CentComm:</b> [input]</span>", usr)
+				deadchat_broadcast("<span class='deadsay'><b>[usr.name] has messaged CentCom:</b> [input]</span>", usr)
 				CM.lastTimeUsed = world.time
 
 		// OMG SYNDICATE ...LETTERHEAD

--- a/code/modules/research/research_disk.dm
+++ b/code/modules/research/research_disk.dm
@@ -13,7 +13,7 @@
 	stored_research = new /datum/techweb
 
 /obj/item/disk/tech_disk/debug
-	name = "centcomm technology disk"
+	name = "centcom technology disk"
 	desc = "A debug item for research"
 	materials = list()
 


### PR DESCRIPTION
:cl:
spellcheck: Replaced "CentComm" with "CentCom" in communications console deadchat announcement.
/:cl:
