### PR TITLE
Adds an indestructible disco/dance machine for admemes and disco inferno shuttle

### DIFF
--- a/_maps/shuttles/emergency_discoinferno.dmm
+++ b/_maps/shuttles/emergency_discoinferno.dmm
@@ -114,12 +114,7 @@
 /turf/open/floor/mineral/plasma,
 /area/shuttle/escape)
 "v" = (
-/obj/machinery/disco{
-	anchored = 1;
-	max_integrity = 2000;
-	req_access = null;
-	resistance_flags = 51
-	},
+/obj/machinery/disco/indestructible,
 /turf/open/floor/light/colour_cycle,
 /area/shuttle/escape)
 "w" = (

--- a/_maps/shuttles/emergency_discoinferno.dmm
+++ b/_maps/shuttles/emergency_discoinferno.dmm
@@ -116,7 +116,9 @@
 "v" = (
 /obj/machinery/disco{
 	anchored = 1;
-	req_access = null
+	max_integrity = 2000;
+	req_access = null;
+	resistance_flags = 51
 	},
 /turf/open/floor/light/colour_cycle,
 /area/shuttle/escape)

--- a/code/game/machinery/dance_machine.dm
+++ b/code/game/machinery/dance_machine.dm
@@ -1,4 +1,4 @@
-// DISCO DANCE MACHINE - For engineering power optimization incentive nurturing test system (POINTS)
+// DISCO DANCE MACHINE - For admin, engineering and shuttle memes/abuse.
 
 /obj/machinery/disco
 	name = "radiant dance machine mark IV"
@@ -22,6 +22,14 @@
 		new /datum/track("Engineering's Ultimate High-Energy Hustle",	'sound/misc/boogie2.ogg',	1770, 	5),
 		)
 	var/datum/track/selection = null
+
+/obj/machinery/disco/indestructible
+	name = "radiant dance machine mark V"
+	desc = "Now redesigned with data gathered from the extensive disco and plasma research."
+	req_access = null
+	anchored = TRUE
+	resistance_flags = INDESTRUCTIBLE | LAVA_PROOF | FIRE_PROOF | UNACIDABLE | ACID_PROOF
+	flags_1 = NODECONSTRUCT_1
 
 /datum/track
 	var/song_name = "generic"
@@ -59,7 +67,7 @@
 	return ..()
 
 /obj/machinery/disco/attackby(obj/item/O, mob/user, params)
-	if(!active)
+	if(!active && !(flags_1 & NODECONSTRUCT_1))
 		if(istype(O, /obj/item/wrench))
 			if(!anchored && !isinspace())
 				to_chat(user,"<span class='notice'>You secure [src] to the floor.</span>")


### PR DESCRIPTION
🆑 Dax Dupont
add: Thanks to the extensive disco and plasma research gathered by the Disco Inferno shuttles, an indestructible mark V disco machine is now available. The latest edition of the Disco Inferno shuttle now carries it.
/🆑

[why]: Dance machine on the shuttle now has intended properties, can no longer break the pride and joy of the shuttle. Also kor asked me to make an admin/indestructible version for the shuttle.