### PR TITLE
Fixes emagged cleanbots not getting acid

### DIFF
--- a/code/modules/mob/living/simple_animal/bot/cleanbot.dm
+++ b/code/modules/mob/living/simple_animal/bot/cleanbot.dm
@@ -98,7 +98,7 @@
 	if(mode == BOT_CLEANING)
 		return
 
-	if(emagged == 2) //Emag functions
+	if(emagged) //Emag functions
 		if(isopenturf(loc))
 
 			for(var/mob/living/carbon/victim in loc)
@@ -117,7 +117,7 @@
 		if(!process_scan(target))
 			target = null
 
-	if(!target && emagged == 2) // When emagged, target humans who slipped on the water and melt their faces off
+	if(!target && emagged) // When emagged, target humans who slipped on the water and melt their faces off
 		target = scan(/mob/living/carbon)
 
 	if(!target && pests) //Search for pests to exterminate first.
@@ -125,7 +125,7 @@
 
 	if(!target) //Search for decals then.
 		target = scan(/obj/effect/decal/cleanable)
-	
+
 	if(!target) //Checks for remains
 		target = scan(/obj/effect/decal/remains)
 
@@ -229,7 +229,7 @@
 			M.death()
 		target = null
 
-	else if(emagged == 2) //Emag functions
+	else if(emagged) //Emag functions
 		if(istype(A, /mob/living/carbon))
 			var/mob/living/carbon/victim = A
 			if(victim.stat == DEAD)//cleanbots always finish the job


### PR DESCRIPTION
:cl: Kor
fix: Emagged cleanbots will actually do emagged things
/:cl:

I'm not sure if this was intentional, but emagging a cleanbot did nothing at all to it. Only AI hacked cleanbots had acid.