### PR TITLE
Makes bot emagging more consistent

### DIFF
--- a/code/modules/mob/living/simple_animal/bot/ed209bot.dm
+++ b/code/modules/mob/living/simple_animal/bot/ed209bot.dm
@@ -161,7 +161,7 @@ Auto Patrol[]"},
 		final = final|JUDGE_RECORDCHECK
 	if(weaponscheck)
 		final = final|JUDGE_WEAPONCHECK
-	if(emagged)
+	if(emagged == 2)
 		final = final|JUDGE_EMAGGED
 	//ED209's ignore monkeys
 	final = final|JUDGE_IGNOREMONKEYS

--- a/code/modules/mob/living/simple_animal/bot/honkbot.dm
+++ b/code/modules/mob/living/simple_animal/bot/honkbot.dm
@@ -102,7 +102,7 @@ Maintenance panel panel is [open ? "opened" : "closed"]"},
 	var/final = NONE
 	if(check_records)
 		final = final|JUDGE_RECORDCHECK
-	if(emagged)
+	if(emagged == 2)
 		final = final|JUDGE_EMAGGED
 	return final
 

--- a/code/modules/mob/living/simple_animal/bot/secbot.dm
+++ b/code/modules/mob/living/simple_animal/bot/secbot.dm
@@ -163,7 +163,7 @@ Auto Patrol: []"},
         final = final|JUDGE_RECORDCHECK
     if(weaponscheck)
         final = final|JUDGE_WEAPONCHECK
-    if(emagged)
+    if(emagged == 2)
         final = final|JUDGE_EMAGGED
     return final
 


### PR DESCRIPTION
:cl:
fix: Securitrons/ED-209s/Honkbots will only activate their emag functions after their internals are emagged
/:cl:

emagged == 1 is for interface unlocked and emagged == 2 is for actually emagged
