### PR TITLE
Gives clockwork marauders a reasonable cost/cooldown

### DIFF
--- a/code/__DEFINES/clockcult.dm
+++ b/code/__DEFINES/clockcult.dm
@@ -83,9 +83,9 @@ GLOBAL_LIST_EMPTY(all_scripture) //a list containing scripture instances; not us
 
 #define RATVARIAN_SPEAR_COOLDOWN 300 //The cooldown period between summoning another Ratvarian spear
 
-#define MARAUDER_SCRIPTURE_SCALING_THRESHOLD 200 //The amount of deciseconds that must pass before marauder scripture will not gain a recital penalty
+#define MARAUDER_SCRIPTURE_SCALING_THRESHOLD 600 //The amount of deciseconds that must pass before marauder scripture will not gain a recital penalty
 
-#define MARAUDER_SCRIPTURE_SCALING_TIME 50 //The amount of extra deciseconds tacked on to the marauder scripture recital time per recent marauder
+#define MARAUDER_SCRIPTURE_SCALING_TIME 20 //The amount of extra deciseconds tacked on to the marauder scripture recital time per recent marauder
 
 #define MARAUDER_SCRIPTURE_SCALING_MAX 300 //The maximum extra time applied to the marauder scripture
 

--- a/code/game/gamemodes/clock_cult/clock_scriptures/scripture_applications.dm
+++ b/code/game/gamemodes/clock_cult/clock_scriptures/scripture_applications.dm
@@ -102,9 +102,6 @@
 	if(recent_marauders)
 		to_chat(invoker, "<span class='warning'>The Hierophant Network needs [MARAUDER_SCRIPTURE_SCALING_THRESHOLD / 10] seconds to recover from marauder summoning; recent summoning has limited the number of available marauders by [recent_marauders]!</span>")
 
-
-/datum/clockwork_scripture/create_object/construct/clockwork_marauder/check_special_requirements()
-
 /datum/clockwork_scripture/create_object/construct/clockwork_marauder/pre_recital()
 	channel_time = initial(channel_time)
 	calculate_scaling()

--- a/code/game/gamemodes/clock_cult/clock_scriptures/scripture_applications.dm
+++ b/code/game/gamemodes/clock_cult/clock_scriptures/scripture_applications.dm
@@ -74,7 +74,7 @@
 	desc = "Creates a shell for a clockwork marauder, a balanced frontline construct that can deflect projectiles with its shield."
 	invocations = list("Arise, avatar of Arbiter!", "Defend the Ark with vengeful zeal.")
 	channel_time = 80
-	power_cost = 7000
+	power_cost = 8000
 	creator_message = "<span class='brass'>Your slab disgorges several chunks of replicant alloy that form into a suit of thrumming armor.</span>"
 	usage_tip = "Reciting this scripture multiple times in a short period will cause it to take longer!"
 	tier = SCRIPTURE_APPLICATION

--- a/code/game/gamemodes/clock_cult/clock_scriptures/scripture_applications.dm
+++ b/code/game/gamemodes/clock_cult/clock_scriptures/scripture_applications.dm
@@ -94,8 +94,8 @@
 	var/human_servants = 0
 	for(var/V in SSticker.mode.servants_of_ratvar)
 		var/datum/mind/M = V
-		var/datum/mob/C = M.current
-		if(ishuman(C) && C.stat != DEAD)
+		var/mob/living/L = M.current
+		if(ishuman(L) && L.stat != DEAD)
 			human_servants++
 	construct_limit = human_servants / 4 //1 per 4 human servants, and a maximum of 3 marauders
 	construct_limit = CLAMP(construct_limit - recent_marauders, 1, 3) 

--- a/code/game/gamemodes/clock_cult/clock_scriptures/scripture_applications.dm
+++ b/code/game/gamemodes/clock_cult/clock_scriptures/scripture_applications.dm
@@ -96,8 +96,13 @@
 		var/datum/mind/M = V
 		if(ishuman(M.current))
 			human_servants++
-	construct_limit = human_servants / 4 //1 per 4 human servants, and a maximum of 3 marauders
-	construct_limit = CLAMP(construct_limit, 1, 3)
+	construct_limit = human_servants / 5 //1 per 5 human servants, and a maximum of 3 marauders
+	construct_limit = CLAMP(construct_limit - recent_marauders, 1, 3) 
+	if(recent_marauders)
+		to_chat(invoker, "<span class='warning'>The Hierophant Network needs [MARAUDER_SCRIPTURE_SCALING_THRESHOLD / 10] seconds to recover from marauder summoning; recent summoning has limited the number of available marauders by [recent_marauders]!</span>")
+
+
+/datum/clockwork_scripture/create_object/construct/clockwork_marauder/check_special_requirements()
 
 /datum/clockwork_scripture/create_object/construct/clockwork_marauder/pre_recital()
 	channel_time = initial(channel_time)

--- a/code/game/gamemodes/clock_cult/clock_scriptures/scripture_applications.dm
+++ b/code/game/gamemodes/clock_cult/clock_scriptures/scripture_applications.dm
@@ -94,9 +94,10 @@
 	var/human_servants = 0
 	for(var/V in SSticker.mode.servants_of_ratvar)
 		var/datum/mind/M = V
-		if(ishuman(M.current))
+		var/datum/mob/C = M.current
+		if(ishuman(C) && C.stat != DEAD)
 			human_servants++
-	construct_limit = human_servants / 5 //1 per 5 human servants, and a maximum of 3 marauders
+	construct_limit = human_servants / 4 //1 per 4 human servants, and a maximum of 3 marauders
 	construct_limit = CLAMP(construct_limit - recent_marauders, 1, 3) 
 	if(recent_marauders)
 		to_chat(invoker, "<span class='warning'>The Hierophant Network needs [MARAUDER_SCRIPTURE_SCALING_THRESHOLD / 10] seconds to recover from marauder summoning; recent summoning has limited the number of available marauders by [recent_marauders]!</span>")

--- a/code/game/gamemodes/clock_cult/clock_scriptures/scripture_applications.dm
+++ b/code/game/gamemodes/clock_cult/clock_scriptures/scripture_applications.dm
@@ -73,8 +73,8 @@
 	name = "Clockwork Marauder"
 	desc = "Creates a shell for a clockwork marauder, a balanced frontline construct that can deflect projectiles with its shield."
 	invocations = list("Arise, avatar of Arbiter!", "Defend the Ark with vengeful zeal.")
-	channel_time = 50
-	power_cost = 1000
+	channel_time = 80
+	power_cost = 10000
 	creator_message = "<span class='brass'>Your slab disgorges several chunks of replicant alloy that form into a suit of thrumming armor.</span>"
 	usage_tip = "Reciting this scripture multiple times in a short period will cause it to take longer!"
 	tier = SCRIPTURE_APPLICATION

--- a/code/game/gamemodes/clock_cult/clock_scriptures/scripture_applications.dm
+++ b/code/game/gamemodes/clock_cult/clock_scriptures/scripture_applications.dm
@@ -74,7 +74,7 @@
 	desc = "Creates a shell for a clockwork marauder, a balanced frontline construct that can deflect projectiles with its shield."
 	invocations = list("Arise, avatar of Arbiter!", "Defend the Ark with vengeful zeal.")
 	channel_time = 80
-	power_cost = 10000
+	power_cost = 7000
 	creator_message = "<span class='brass'>Your slab disgorges several chunks of replicant alloy that form into a suit of thrumming armor.</span>"
 	usage_tip = "Reciting this scripture multiple times in a short period will cause it to take longer!"
 	tier = SCRIPTURE_APPLICATION


### PR DESCRIPTION
:cl: Robustin
balance: Clockwork marauders now take more time (+3s) and power (7x) to create.
balance: The "recent marauder" time limit is now 60 seconds, up from 20. The limit now has a significantly smaller effect on summon time but will act as a further cap on marauder summoning until it has passed.
tweak: The marauder cap will now only account for living cultists. 
/:cl:

I told Xhuis to fix this shit months ago. 

A marauder is summoned in 5 seconds using less power than a single fucking brass wall
**A single stargazer generates enough power for a marauder in 50 seconds, 38 seconds during warcult**
Someone actually thinks this is OK to cycle an endless stream of constructs from nothing