### PR TITLE
Fixes stimulum running out before the next breath

### DIFF
--- a/code/modules/reagents/chemistry/reagents/other_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/other_reagents.dm
@@ -1173,7 +1173,8 @@
 	M.AdjustKnockdown(-20, 0)
 	M.AdjustUnconscious(-20, 0)
 	M.adjustStaminaLoss(-0.5*REM, 0)
-	..()
+	current_cycle++
+	holder.remove_reagent(id, 0.99)		Gives time for the next tick of life().
 	. = TRUE //Update status effects.
 
 /datum/reagent/nitryl

--- a/code/modules/reagents/chemistry/reagents/other_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/other_reagents.dm
@@ -1174,7 +1174,7 @@
 	M.AdjustUnconscious(-20, 0)
 	M.adjustStaminaLoss(-0.5*REM, 0)
 	current_cycle++
-	holder.remove_reagent(id, 0.99)		Gives time for the next tick of life().
+	holder.remove_reagent(id, 0.99)		//Gives time for the next tick of life().
 	. = TRUE //Update status effects.
 
 /datum/reagent/nitryl

--- a/code/modules/surgery/organs/lungs.dm
+++ b/code/modules/surgery/organs/lungs.dm
@@ -283,7 +283,8 @@
 	// Stimulum
 		gas_breathed = breath_gases[/datum/gas/stimulum][MOLES]
 		if (gas_breathed > gas_stimulation_min)
-			H.reagents.add_reagent("stimulum",1)
+			var/existing = H.reagents.get_reagent_amount("stimulum")
+			H.reagents.add_reagent("stimulum",max(0, 5 - existing))
 		breath_gases[/datum/gas/stimulum][MOLES]-=gas_breathed
 		handle_breath_temperature(breath, H)
 		breath.garbage_collect()

--- a/code/modules/surgery/organs/lungs.dm
+++ b/code/modules/surgery/organs/lungs.dm
@@ -284,7 +284,7 @@
 		gas_breathed = breath_gases[/datum/gas/stimulum][MOLES]
 		if (gas_breathed > gas_stimulation_min)
 			var/existing = H.reagents.get_reagent_amount("stimulum")
-			H.reagents.add_reagent("stimulum",max(0, 5 - existing))
+			H.reagents.add_reagent("stimulum",max(0, 1 - existing))
 		breath_gases[/datum/gas/stimulum][MOLES]-=gas_breathed
 		handle_breath_temperature(breath, H)
 		breath.garbage_collect()


### PR DESCRIPTION
You now get your stimulum amount set to 1 if it's below that on breath, and it metabolizes slower.
Fixes #32727