### PR TITLE
Fixes webhook diff selecting partial match (old, mistake)

### DIFF
--- a/tools/WebhookProcessor/github_webhook_processor.php
+++ b/tools/WebhookProcessor/github_webhook_processor.php
@@ -546,7 +546,7 @@ function auto_update($payload){
 	$content = file_get_contents('https://raw.githubusercontent.com/' . $repoOwnerAndName . '/' . $tracked_branch . '/'. $path_to_script);
 	$content_diff = "### Diff not available. :slightly_frowning_face:";
 	if($github_diff && preg_match('/(diff --git a\/' . preg_quote($path_to_script, '/') . '.+?)(?:^diff)?/sm', $github_diff, $matches)) {
-		$script_diff = $matches[1];
+		$script_diff = $matches[0];
 		if($script_diff) {
 			$content_diff = "``" . "`DIFF\n" . $script_diff ."\n``" . "`";
 		}


### PR DESCRIPTION
https://github.com/tgstation/tgstation/blob/f860a0ffb48d0f42d0e6d775ed0d9569bcf8415d/tools/WebhookProcessor/github_webhook_processor.php#L548-L549
[![](https://user-images.githubusercontent.com/5211576/34808404-bcbcb814-f65c-11e7-853e-56f1d73d1eb3.png)](http://php.net/manual/en/function.preg-match.php#refsect1-function.preg-match-parameters)

So, using `$matches[1]` resulted in only `(diff --git a\/' . preg_quote($path_to_script, '/') . '.+?)` getting shown, since it is the first capture group. 

![gTJtwjr.jpg](https://user-images.githubusercontent.com/5211576/34835339-82fc5d8a-f6c2-11e7-8e41-f393fbb0089d.jpg)
