### PR TITLE
Makes xeno deathsounds a var on /living

### DIFF
--- a/code/modules/mob/living/carbon/alien/humanoid/humanoid.dm
+++ b/code/modules/mob/living/carbon/alien/humanoid/humanoid.dm
@@ -16,6 +16,7 @@
 	var/custom_pixel_y_offset = 0
 	var/sneaking = 0 //For sneaky-sneaky mode and appropriate slowdown
 	var/drooling = 0 //For Neruotoxic spit overlays
+	death_sound = 'sound/voice/hiss6.ogg'
 	bodyparts = list(/obj/item/bodypart/chest/alien, /obj/item/bodypart/head/alien, /obj/item/bodypart/l_arm/alien,
 					 /obj/item/bodypart/r_arm/alien, /obj/item/bodypart/r_leg/alien, /obj/item/bodypart/l_leg/alien)
 

--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -1,5 +1,6 @@
 /mob/living/carbon
 	blood_volume = BLOOD_VOLUME_NORMAL
+	var/death_sound
 
 /mob/living/carbon/Initialize()
 	. = ..()

--- a/code/modules/mob/living/emote.dm
+++ b/code/modules/mob/living/emote.dm
@@ -82,8 +82,8 @@
 		message_simple = S.deathmessage
 	. = ..()
 	message_simple = initial(message_simple)
-	if(. && isalienadult(user))
-		playsound(user.loc, 'sound/voice/hiss6.ogg', 80, 1, 1)
+	if(. && death_sound)
+		playsound(user.loc, death_sound, 80, 1, 1)
 
 /datum/emote/living/drool
 	key = "drool"


### PR DESCRIPTION
:cl:
add: Any creature that makes a sound upon death can invoke it with the *deathgasp emote, not just xenos.
/:cl:

Pros:
Any creature with a death sound, including simple mobs, can now invoke it with the *deathgasp emote, just like xenos do
Allows var-editing of deathsounds
Allows for ease of adding or removing deathsounds from humans/monkeys should we add that at a later date