### PR TITLE
Fix airlock console HTML

### DIFF
--- a/code/game/machinery/embedded_controller/airlock_controller.dm
+++ b/code/game/machinery/embedded_controller/airlock_controller.dm
@@ -281,6 +281,7 @@
 <div class='line'><div class='statusLabel'>\> Control Pump:</div><div class='statusValue'>[pump_status]</div></div>
 <div class='line'><div class='statusLabel'>\> Interior Door:</div><div class='statusValue'>[interior_status]</div></div>
 <div class='line'><div class='statusLabel'>\> Exterior Door:</div><div class='statusValue'>[exterior_status]</div></div>
+<div class='clearBoth'></div>
 </div>
 [state_options]"}
 


### PR DESCRIPTION
:cl:
fix: The interface of airlock consoles has been restored to normalcy.
/:cl:

Before:
![image](https://user-images.githubusercontent.com/222630/34828031-0674cd32-f691-11e7-83cd-fb3aa627e932.png)

After:
![image](https://user-images.githubusercontent.com/222630/34828034-09c20aae-f691-11e7-9c98-1ad3b0b39d5e.png)
