### PR TITLE
Fixes webhook diff selecting partial match

### DIFF
--- a/tools/WebhookProcessor/github_webhook_processor.php
+++ b/tools/WebhookProcessor/github_webhook_processor.php
@@ -545,7 +545,7 @@ function auto_update($payload){
 	get_diff($payload);
 	$content = file_get_contents('https://raw.githubusercontent.com/' . $repoOwnerAndName . '/' . $tracked_branch . '/'. $path_to_script);
 	$content_diff = "### Diff not available. :slightly_frowning_face:";
-	if($github_diff && preg_match('/(diff --git a\/' . preg_quote($path_to_script, '/') . '.+?)(?:^diff)?/sm', $github_diff, $matches)) {
+	if($github_diff && preg_match('/(diff --git a\/' . preg_quote($path_to_script, '/') . '.+?)(?:\Rdiff|$)/s', $github_diff, $matches)) {
 		$script_diff = $matches[1];
 		if($script_diff) {
 			$content_diff = "``" . "`DIFF\n" . $script_diff ."\n``" . "`";


### PR DESCRIPTION
Disabled PCRE multiline mode, so that we can use $ to match the end of the string, replaces ^diff with \Rdiff due to multiline being disabled.

This time i actually tested it with https://regexr.com

[![\R](https://user-images.githubusercontent.com/5211576/34844399-58e3a608-f6df-11e7-99e1-16c56d30c67d.png)](http://php.net/manual/en/regexp.reference.escape.php)


This should work assuming the PCRE s mode actually works (otherwise i'll have to replace the `.` with `[\s\S]`)
[![s](https://user-images.githubusercontent.com/5211576/34844764-8d923904-f6e0-11e7-811e-2c7d8bb69dc8.png)](http://php.net/manual/en/reference.pcre.pattern.modifiers.php)

Also for the record, I was completely wrong with #34303, `$matches[1]` was intended.

https://regexr.com/3j5bs