### PR TITLE
 Makes the lavaland mining base have more correct baseturfs

### DIFF
--- a/_maps/map_files/Mining/Lavaland.dmm
+++ b/_maps/map_files/Mining/Lavaland.dmm
@@ -802,6 +802,9 @@
 /turf/open/floor/plating,
 /area/mine/eva)
 "cq" = (
+/obj/effect/baseturf_helper/picky/lava_land/basalt{
+	whitelist = /turf/open/floor
+	},
 /turf/open/floor/mech_bay_recharge_floor,
 /area/mine/eva)
 "cr" = (
@@ -832,6 +835,9 @@
 /area/lavaland/surface/outdoors)
 "cw" = (
 /obj/machinery/computer/secure_data,
+/obj/effect/baseturf_helper/picky/lava_land/basalt{
+	whitelist = /turf/open/floor
+	},
 /turf/open/floor/plasteel,
 /area/mine/laborcamp/security)
 "cx" = (
@@ -1035,6 +1041,9 @@
 /obj/effect/turf_decal/loading_area{
 	dir = 8
 	},
+/obj/effect/baseturf_helper/picky/lava_land/basalt{
+	whitelist = /turf/open/floor
+	},
 /turf/open/floor/plasteel,
 /area/mine/production)
 "dc" = (
@@ -1188,7 +1197,6 @@
 /obj/structure/cable{
 	icon_state = "1-4"
 	},
-/obj/effect/baseturf_helper/lava_land/surface,
 /turf/open/floor/circuit,
 /area/mine/maintenance)
 "dy" = (
@@ -1214,6 +1222,9 @@
 	c_tag = "Communications Relay";
 	dir = 8;
 	network = list("MINE")
+	},
+/obj/effect/baseturf_helper/picky/lava_land/basalt{
+	whitelist = /turf/open/floor
 	},
 /turf/open/floor/circuit,
 /area/mine/maintenance)
@@ -3297,7 +3308,7 @@
 /turf/open/floor/plating/asteroid/basalt/lava_land_surface,
 /area/lavaland/surface/outdoors)
 "Wt" = (
-/obj/effect/baseturf_helper/lava_land/surface,
+/obj/effect/baseturf_helper/picky/lava_land/plating,
 /turf/closed/wall,
 /area/mine/laborcamp/security)
 "Wu" = (
@@ -3365,6 +3376,40 @@
 	},
 /turf/open/floor/plasteel,
 /area/mine/production)
+"WF" = (
+/obj/effect/baseturf_helper/picky/lava_land/plating,
+/turf/closed/wall,
+/area/mine/laborcamp)
+"WG" = (
+/obj/effect/baseturf_helper/picky/lava_land/basalt{
+	whitelist = /turf/open/floor
+	},
+/turf/open/floor/plasteel,
+/area/mine/laborcamp)
+"WH" = (
+/obj/effect/baseturf_helper/picky/lava_land/plating,
+/turf/closed/wall,
+/area/mine/eva)
+"WI" = (
+/obj/effect/baseturf_helper/picky/lava_land/plating,
+/turf/closed/wall,
+/area/mine/production)
+"WJ" = (
+/obj/effect/baseturf_helper/picky/lava_land/plating,
+/turf/closed/wall/r_wall,
+/area/mine/maintenance)
+"WK" = (
+/obj/effect/baseturf_helper/picky/lava_land/plating,
+/turf/closed/wall,
+/area/mine/living_quarters)
+"WL" = (
+/obj/effect/baseturf_helper/picky/lava_land/basalt{
+	whitelist = /turf/open/floor
+	},
+/turf/open/floor/plasteel/purple/corner{
+	dir = 8
+	},
+/area/mine/living_quarters)
 
 (1,1,1) = {"
 aa
@@ -8466,7 +8511,7 @@ aq
 WB
 aq
 bi
-aq
+WF
 WC
 aq
 bZ
@@ -8723,7 +8768,7 @@ aq
 ba
 aq
 bj
-az
+WG
 az
 aq
 ca
@@ -9755,7 +9800,7 @@ aq
 bA
 aq
 aq
-Wu
+aq
 aq
 aj
 aj
@@ -10791,7 +10836,7 @@ dg
 dg
 cQ
 dZ
-Ww
+dZ
 dZ
 cM
 fa
@@ -11817,7 +11862,7 @@ ai
 cQ
 dk
 dA
-cQ
+WJ
 ed
 er
 eM
@@ -12849,7 +12894,7 @@ dR
 ef
 es
 dZ
-cM
+WK
 fg
 cM
 cM
@@ -13106,7 +13151,7 @@ dQ
 ec
 er
 dZ
-eL
+WL
 fh
 ft
 eL
@@ -19012,7 +19057,7 @@ cI
 cP
 cn
 bP
-Wy
+bP
 bP
 bP
 eD
@@ -20035,9 +20080,9 @@ bt
 bH
 bV
 cq
-bf
+WH
 bq
-bq
+WI
 db
 bP
 bP
@@ -20290,7 +20335,7 @@ bf
 bp
 bu
 bI
-Wx
+bW
 cr
 bf
 ad

--- a/code/game/turfs/simulated/floor/plating/asteroid.dm
+++ b/code/game/turfs/simulated/floor/plating/asteroid.dm
@@ -67,6 +67,8 @@
 	. = SendSignal(COMSIG_ATOM_EX_ACT, severity, target)
 	contents_explosion(severity, target)
 
+/turf/open/floor/plating/lavaland_baseturf
+	baseturfs = /turf/open/floor/plating/asteroid/basalt/lava_land_surface
 
 /turf/open/floor/plating/asteroid/basalt
 	name = "volcanic floor"

--- a/code/modules/mapping/mapping_helpers.dm
+++ b/code/modules/mapping/mapping_helpers.dm
@@ -13,10 +13,12 @@
 	. = ..()
 	var/area/thearea = get_area(src)
 	for(var/turf/T in get_area_turfs(thearea, z))
-		if(T.baseturfs != T.type) //Don't break indestructible walls and the like
-			T.baseturfs = baseturf
+		replace_baseturf(T)
 	return INITIALIZE_HINT_QDEL
 
+/obj/effect/baseturf_helper/proc/replace_baseturf(turf/thing)
+	if(thing.baseturfs != thing.type)
+		thing.baseturfs = baseturf
 
 /obj/effect/baseturf_helper/space
 	name = "space baseturf editor"
@@ -54,6 +56,35 @@
 	name = "lavaland baseturf editor"
 	baseturf = /turf/open/lava/smooth/lava_land_surface
 
+// Does the same thing as baseturf_helper but only the specified kinds of turf (the kind it's placed on or varedited)
+/obj/effect/baseturf_helper/picky
+	var/list/whitelist
+	// Can be mapedited as: a single type, a list of types, or a typecache-like list
+	// The first 2 make a typecache of the given values
+	// The last uses it as is
+
+/obj/effect/baseturf_helper/picky/Initialize()
+	if(!whitelist)
+		whitelist = list(loc.type)
+	else if(!islist(whitelist))
+		whitelist = list(whitelist)
+	else if(whitelist[whitelist[1]]) // Checking if it's a typecache-like list
+		return ..()
+	whitelist = typecacheof(whitelist)
+	return ..()
+	
+/obj/effect/baseturf_helper/picky/replace_baseturf(turf/thing)
+	if(!whitelist[thing.type])
+		return
+	return ..()
+
+/obj/effect/baseturf_helper/picky/lava_land/plating
+	name = "picky lavaland plating baseturf helper"
+	baseturf = /turf/open/floor/plating/lavaland_baseturf
+
+/obj/effect/baseturf_helper/picky/lava_land/basalt
+	name = "picky lavaland basalt baseturf helper"
+	baseturf = /turf/open/floor/plating/asteroid/basalt/lava_land_surface
 
 //Contains the list of planetary z-levels defined by the planet_z helper.
 GLOBAL_LIST_EMPTY(z_is_planet)


### PR DESCRIPTION
:cl: ninjanomnom
fix: Mining base walls when broken turn into plating which in turn breaks down to the basalt surface.
/:cl:

In order to make the walls and flooring have different baseturfs I had to make a baseturf helper variant that only changed the baseturfs of specific kinds of turfs in the area.

fixes #34321
