### PR TITLE
Various deadchat messages are more informative and consistent

### DIFF
--- a/code/controllers/subsystem/shuttle.dm
+++ b/code/controllers/subsystem/shuttle.dm
@@ -246,8 +246,10 @@ SUBSYSTEM_DEF(shuttle)
 		else
 			emergency.request(null, signal_origin, html_decode(emergency_reason), 0)
 
+	var/area/A = get_area(user)
+
 	log_game("[key_name(user)] has called the shuttle.")
-	deadchat_broadcast("<span class='deadsay bold'>[user.name] has called the shuttle.</span>", user)
+	deadchat_broadcast("<span class='deadsay'><span class='name'>[user.name]</span> has called the shuttle at <span class='name'>[A.name]</span>.</span>", user)
 	if(call_reason)
 		SSblackbox.record_feedback("text", "shuttle_reason", 1, "[call_reason]")
 		log_game("Shuttle call reason: [call_reason]")
@@ -285,7 +287,8 @@ SUBSYSTEM_DEF(shuttle)
 		emergency.cancel(get_area(user))
 		log_game("[key_name(user)] has recalled the shuttle.")
 		message_admins("[key_name_admin(user)] has recalled the shuttle.")
-		deadchat_broadcast("<span class='deadsay bold'>[user.name] has recalled the shuttle.</span>", user)
+		var/area/A = get_area(user)
+		deadchat_broadcast("<span class='deadsay'><span class='name'>[user.name]</span> has recalled the shuttle at <span class='name'>[A.name]</span>.</span>", user)
 		return 1
 
 /datum/controller/subsystem/shuttle/proc/canRecall()

--- a/code/game/machinery/computer/communications.dm
+++ b/code/game/machinery/computer/communications.dm
@@ -57,6 +57,9 @@
 		return
 	usr.set_machine(src)
 
+	var/area/A = get_area(usr)
+	var/area_name = A.name
+
 	if(!href_list["operation"])
 		return
 	var/obj/item/circuitboard/computer/communications/CM = circuit
@@ -115,7 +118,7 @@
 						var/security_level = get_security_level()
 						log_game("[key_name(usr)] has changed the security level to [security_level].")
 						message_admins("[key_name_admin(usr)] has changed the security level to [security_level].")
-						deadchat_broadcast("<span class='deadsay bold'>[usr.name] has changed the security level to [security_level].</span>", usr)
+						deadchat_broadcast("<span class='deadsay'><span class='name'>[usr.name]</span> has changed the security level to [security_level] at <span class='name'>[area_name]</span>.</span>", usr)
 					tmp_alertlevel = 0
 				else
 					to_chat(usr, "<span class='warning'>You are not authorized to do this!</span>")
@@ -249,13 +252,13 @@
 			make_maint_all_access()
 			log_game("[key_name(usr)] enabled emergency maintenance access.")
 			message_admins("[key_name_admin(usr)] enabled emergency maintenance access.")
-			deadchat_broadcast("<span class='deadsay bold'>[usr.name] enabled emergency maintenance access.</span>", usr)
+			deadchat_broadcast("<span class='deadsay'><span class='name'>[usr.name]</span> enabled emergency maintenance access at <span class='name'>[area_name]</span>.</span>", usr)
 			state = STATE_DEFAULT
 		if("disableemergency")
 			revoke_maint_all_access()
 			log_game("[key_name(usr)] disabled emergency maintenance access.")
 			message_admins("[key_name_admin(usr)] disabled emergency maintenance access.")
-			deadchat_broadcast("<span class='deadsay bold'>[usr.name] disabled emergency maintenance access.</span>", usr)
+			deadchat_broadcast("<span class='deadsay'><span class='name'>[usr.name]</span> disabled emergency maintenance access at <span class='name'>[area_name]</span>.</span>", usr)
 			state = STATE_DEFAULT
 
 		// Status display stuff
@@ -289,7 +292,7 @@
 				CentCom_announce(input, usr)
 				to_chat(usr, "<span class='notice'>Message transmitted to Central Command.</span>")
 				log_talk(usr,"[key_name(usr)] has made a CentCom announcement: [input]",LOGSAY)
-				deadchat_broadcast("<span class='deadsay'><b>[usr.name] has messaged CentCom:</b> [input]</span>", usr)
+				deadchat_broadcast("<span class='deadsay'><span class='name'>[usr.name]</span> has messaged CentCom, \"[input]\" at <span class='name'>[area_name]</span>.</span>", usr)
 				CM.lastTimeUsed = world.time
 
 		// OMG SYNDICATE ...LETTERHEAD
@@ -306,7 +309,7 @@
 				Syndicate_announce(input, usr)
 				to_chat(usr, "<span class='danger'>SYSERR @l(19833)of(transmit.dm): !@$ MESSAGE TRANSMITTED TO SYNDICATE COMMAND.</span>")
 				log_talk(usr,"[key_name(usr)] has made a Syndicate announcement: [input]",LOGSAY)
-				deadchat_broadcast("<span class='deadsay'><b>[usr.name] has messaged the Syndicate:</b> [input]</span>", usr)
+				deadchat_broadcast("<span class='deadsay'><span class='name'>[usr.name]</span> has messaged the Syndicate, \"[input]\" at <span class='name'>[area_name]</span>.</span>", usr)
 				CM.lastTimeUsed = world.time
 
 		if("RestoreBackup")
@@ -389,7 +392,7 @@
 				var/security_level = get_security_level()
 				log_game("[key_name(usr)] has changed the security level to [security_level].")
 				message_admins("[key_name_admin(usr)] has changed the security level to [security_level].")
-				deadchat_broadcast("<span class='deadsay bold'>[usr.name] has changed the security level to [security_level].</span>", usr)
+				deadchat_broadcast("<span class='deadsay'><span class='name'>[usr.name]</span> has changed the security level to [security_level].</span>", usr)
 			tmp_alertlevel = 0
 			aistate = STATE_DEFAULT
 		if("ai-changeseclevel")
@@ -701,7 +704,8 @@
 	if(!input || !user.canUseTopic(src))
 		return
 	SScommunications.make_announcement(user, is_silicon, input)
-	deadchat_broadcast("<span class='deadsay bold'>[user.name] made an priority announcement.</span>", user)
+	var/area/A = get_area(user)
+	deadchat_broadcast("<span class='deadsay'><span class='name'>[user.name]</span> made an priority announcement at <span class='name'>[A.name]</span>.</span>", user)
 
 /obj/machinery/computer/communications/proc/post_status(command, data1, data2)
 

--- a/code/modules/security_levels/keycard_authentication.dm
+++ b/code/modules/security_levels/keycard_authentication.dm
@@ -1,5 +1,9 @@
 GLOBAL_DATUM_INIT(keycard_events, /datum/events, new)
 
+#define KEYCARD_RED_ALERT "Red Alert"
+#define KEYCARD_EMERGENCY_MAINTENANCE_ACCESS "Emergency Maintenance Access"
+#define KEYCARD_BSA_UNLOCK "Bluespace Artillery Unlock"
+
 /obj/machinery/keycard_auth
 	name = "Keycard Authentication Device"
 	desc = "This device is used to trigger station functions, which require more than one ID card to authenticate."
@@ -57,11 +61,11 @@ GLOBAL_DATUM_INIT(keycard_events, /datum/events, new)
 	switch(action)
 		if("red_alert")
 			if(!event_source)
-				sendEvent("Red Alert")
+				sendEvent(KEYCARD_RED_ALERT)
 				. = TRUE
 		if("emergency_maint")
 			if(!event_source)
-				sendEvent("Emergency Maintenance Access")
+				sendEvent(KEYCARD_EMERGENCY_MAINTENANCE_ACCESS)
 				. = TRUE
 		if("auth_swipe")
 			if(event_source)
@@ -70,7 +74,7 @@ GLOBAL_DATUM_INIT(keycard_events, /datum/events, new)
 				. = TRUE
 		if("bsa_unlock")
 			if(!event_source)
-				sendEvent("Bluespace Artillery Unlock")
+				sendEvent(KEYCARD_BSA_UNLOCK)
 				. = TRUE
 
 /obj/machinery/keycard_auth/proc/sendEvent(event_type)
@@ -97,12 +101,18 @@ GLOBAL_DATUM_INIT(keycard_events, /datum/events, new)
 /obj/machinery/keycard_auth/proc/trigger_event(confirmer)
 	log_game("[key_name(triggerer)] triggered and [key_name(confirmer)] confirmed event [event]")
 	message_admins("[key_name(triggerer)] triggered and [key_name(confirmer)] confirmed event [event]")
+
+	var/area/A1 = get_area(triggerer)
+	deadchat_broadcast("<span class='deadsay'><span class='name'>[triggerer]</span> triggered [event] at <span class='name'>[A1.name]</span>.</span>", triggerer)
+
+	var/area/A2 = get_area(confirmer)
+	deadchat_broadcast("<span class='deadsay'><span class='name'>[confirmer]</span> confirmed [event] at <span class='name'>[A2.name]</span>.</span>", confirmer)
 	switch(event)
-		if("Red Alert")
+		if(KEYCARD_RED_ALERT)
 			set_security_level(SEC_LEVEL_RED)
-		if("Emergency Maintenance Access")
+		if(KEYCARD_EMERGENCY_MAINTENANCE_ACCESS)
 			make_maint_all_access()
-		if("Bluespace Artillery Unlock")
+		if(KEYCARD_BSA_UNLOCK)
 			toggle_bluespace_artillery()
 
 GLOBAL_VAR_INIT(emergency_access, FALSE)
@@ -128,3 +138,7 @@ GLOBAL_VAR_INIT(emergency_access, FALSE)
 	GLOB.bsa_unlock = !GLOB.bsa_unlock
 	minor_announce("Bluespace Artillery firing protocols have been [GLOB.bsa_unlock? "unlocked" : "locked"]", "Weapons Systems Update:")
 	SSblackbox.record_feedback("nested tally", "keycard_auths", 1, list("bluespace artillery", GLOB.bsa_unlock? "unlocked" : "locked"))
+
+#undef KEYCARD_RED_ALERT
+#undef KEYCARD_EMERGENCY_MAINTENANCE_ACCESS
+#undef KEYCARD_BSA_UNLOCK


### PR DESCRIPTION
More deadchat messages now follow the following format.

> George Mellons has done a thing at AreaName.

- Shuttle calling
- Shuttle recalling
- Security level changing
- Maintenance accessing
- Swiping for red,emergency maint, bsa
- Messenging centcom, syndicate

Fixes #34230.
Fixes #34231.