### PR TITLE
Can't put the disk in the safe

### DIFF
--- a/code/game/objects/structures/safe.dm
+++ b/code/game/objects/structures/safe.dm
@@ -158,6 +158,9 @@ FLOOR SAFES
 /obj/structure/safe/attackby(obj/item/I, mob/user, params)
 	if(open)
 		. = 1 //no afterattack
+		if(istype(I, /obj/item/disk/nuclear))
+			to_chat(user, "<span class='warning'>For what you are sure are entirely plausible and immersive reasons, you can't put that in there.</span>")
+			return
 		if(I.w_class + space <= maxspace)
 			space += I.w_class
 			if(!user.transferItemToLoc(I, src))


### PR DESCRIPTION
Why: Have already seen a round in which the crew put the disk in the safe and destroyed all stethoscopes making the disk essentially irretrievable, making it feel like an exploit (yes I know you can do some convoluted shit and order a particle accelerator and build a singularity on top of the safe or go mining so you can make bags of holding but that is so far outside of what what is realistic for the average nuke team to achieve). Even when the crew doesn't nuke all the stethoscopes, the nuke ops having to sit and defend a single shitty room for 10 minutes while someone fiddles with a buggy and clunky interface to open a box cripples them.

Rather than gut the safe and make it worthless for holding things by weakening it, better to just block a single game mode critical item from being put in it. It's snowflake, but we already do similar to prevent the disk being spaced.

Open to better solutions though