### PR TITLE
Players can now see their own tracked playtime

### DIFF
--- a/code/modules/admin/verbs/randomverbs.dm
+++ b/code/modules/admin/verbs/randomverbs.dm
@@ -1261,6 +1261,10 @@ GLOBAL_LIST_EMPTY(custom_outfits) //Admin created outfits
 	if(!check_rights(R_ADMIN))
 		return
 
+	if(!CONFIG_GET(flag/use_exp_tracking))
+		to_chat(usr, "<span class='warning'>Tracking is disabled in the server configuration file.</span>")
+		return
+
 	var/list/msg = list()
 	msg += "<html><head><title>Playtime Report</title></head><body>Playtime:<BR><UL>"
 	for(var/client/C in GLOB.clients)
@@ -1273,6 +1277,9 @@ GLOBAL_LIST_EMPTY(custom_outfits) //Admin created outfits
 		return
 	if(!C)
 		to_chat(usr, "<span class='danger'>ERROR: Client not found.</span>")
+		return
+	if(!CONFIG_GET(flag/use_exp_tracking))
+		to_chat(usr, "<span class='warning'>Tracking is disabled in the server configuration file.</span>")
 		return
 
 	var/list/body = list()

--- a/code/modules/client/client_procs.dm
+++ b/code/modules/client/client_procs.dm
@@ -612,6 +612,8 @@ GLOBAL_LIST(external_rsc_urls)
 /client/proc/add_verbs_from_config()
 	if(CONFIG_GET(flag/see_own_notes))
 		verbs += /client/proc/self_notes
+	if(CONFIG_GET(flag/use_exp_tracking))
+		verbs += /client/proc/self_playtime
 
 
 #undef TOPIC_SPAM_DELAY

--- a/code/modules/client/verbs/ooc.dm
+++ b/code/modules/client/verbs/ooc.dm
@@ -245,6 +245,21 @@ GLOBAL_VAR_INIT(normal_ooc_colour, OOC_COLOR)
 
 	browse_messages(null, usr.ckey, null, TRUE)
 
+/client/proc/self_playtime()
+	set name = "View tracked playtime."
+	set category = "OOC"
+	set desc = "View the amount of playtime for roles the server has tracked."
+
+	if(!CONFIG_GET(flag/use_exp_tracking))
+		to_chat(usr, "<span class='notice'>Sorry, tracking is currently disabled.</span>")
+		return
+
+	var/list/body = list()
+	body += "<html><head><title>Playtime for [key]</title></head><BODY><BR>Playtime:"
+	body += get_exp_report()
+	body += "</BODY></HTML>"
+	usr << browse(body.Join(), "window=playerplaytime[ckey];size=550x615")
+
 /client/proc/ignore_key(client)
 	var/client/C = client
 	if(C.key in prefs.ignoring)

--- a/code/modules/jobs/job_exp.dm
+++ b/code/modules/jobs/job_exp.dm
@@ -12,7 +12,7 @@ GLOBAL_PROTECT(exp_to_update)
 		return 0
 	if(!job_is_xp_locked(src.title))
 		return 0
-	if(CONFIG_GET(flag/use_exp_restrictions_admin_bypass) && check_rights(R_ADMIN, FALSE, C.mob))
+	if(CONFIG_GET(flag/use_exp_restrictions_admin_bypass) && check_rights_for(C,R_ADMIN))
 		return 0
 	var/isexempt = C.prefs.db_flags & DB_FLAG_EXEMPT
 	if(isexempt)
@@ -73,10 +73,18 @@ GLOBAL_PROTECT(exp_to_update)
 		else
 			exp_data[category] = 0
 	for(var/category in GLOB.exp_specialmap)
-		if(play_records[category])
-			exp_data[category] = text2num(play_records[category])
+		if(category == EXP_TYPE_SPECIAL || category == EXP_TYPE_ANTAG)
+			if(GLOB.exp_specialmap[category])
+				for(var/innercat in GLOB.exp_specialmap[category])
+					if(play_records[innercat])
+						exp_data[innercat] = text2num(play_records[innercat])
+					else
+						exp_data[innercat] = 0
 		else
-			exp_data[category] = 0
+			if(play_records[category])
+				exp_data[category] = text2num(play_records[category])
+			else
+				exp_data[category] = 0
 	if(prefs.db_flags & DB_FLAG_EXEMPT)
 		return_text += "<LI>Exempt (all jobs auto-unlocked)</LI>"
 
@@ -87,7 +95,7 @@ GLOBAL_PROTECT(exp_to_update)
 				return_text += "<LI>[dep] [get_exp_format(exp_data[dep])] ([percentage]%)</LI>"
 			else
 				return_text += "<LI>[dep] [get_exp_format(exp_data[dep])] </LI>"
-	if(CONFIG_GET(flag/use_exp_restrictions_admin_bypass) && check_rights(R_ADMIN, 0, mob))
+	if(CONFIG_GET(flag/use_exp_restrictions_admin_bypass) && check_rights_for(src,R_ADMIN))
 		return_text += "<LI>Admin (all jobs auto-unlocked)</LI>"
 	return_text += "</UL>"
 	var/list/jobs_locked = list()


### PR DESCRIPTION
Antag tracking isn't shown on the panel yet as I'd like to find a better way to populate the antag exp list than doing it manually. The special roles were supposed to have been shown before, but I didn't read the array right.

:cl:
add: Players can now have a verb in the ooc tab to see their own tracked playtime
fix: fixed admin bypass not using the right proc
fix: Lavaland ghost roles should now show up in the playtime report
/:cl:
