### PR TITLE
Gives the nuclear disk wanderlust

### DIFF
--- a/code/datums/components/wanderlust.dm
+++ b/code/datums/components/wanderlust.dm
@@ -20,7 +20,6 @@
 	. = ..()
 
 /datum/component/wanderlust/process()
-	var/atom/movable/AM = parent
 	var/current_turf = get_turf(parent)
 	if(last_turf != current_turf)
 		addtimer(CALLBACK(src, .proc/Relocate), rand(minimum_time, maximum_time), TIMER_UNIQUE|TIMER_OVERRIDE|TIMER_NO_HASH_WAIT)

--- a/code/datums/components/wanderlust.dm
+++ b/code/datums/components/wanderlust.dm
@@ -1,0 +1,33 @@
+/datum/component/wanderlust
+	var/minimum_time = 10 MINUTES
+	var/maximum_time = 10 MINUTES
+
+	var/turf/last_turf
+
+/datum/component/wanderlust/Initialize(_min_time = 10 MINUTES, _max_time = 10 MINUTES)
+	if(!ismovableatom(parent))
+		. = COMPONENT_INCOMPATIBLE
+		CRASH("[type] added to a [parent.type]")	
+
+	minimum_time = _min_time
+	maximum_time = _max_time
+
+	START_PROCESSING(SSprocessing, src)
+
+/datum/component/wanderlust/Destroy()
+	STOP_PROCESSING(SSprocessing, src)
+	last_turf = null
+	. = ..()
+
+/datum/component/wanderlust/process()
+	var/atom/movable/AM = parent
+	var/current_turf = get_turf(parent)
+	if(last_turf != current_turf)
+		addtimer(CALLBACK(src, .proc/Relocate), rand(minimum_time, maximum_time), TIMER_UNIQUE|TIMER_OVERRIDE|TIMER_NO_HASH_WAIT)
+
+	last_turf = current_turf
+
+/datum/component/proc/Relocate()
+	var/atom/movable/AM = parent
+	. = AM.relocate()
+	

--- a/code/game/gamemodes/nuclear/nuclearbomb.dm
+++ b/code/game/gamemodes/nuclear/nuclearbomb.dm
@@ -528,6 +528,7 @@ This is here to make the tiles around the station mininuke change when it's arme
 	..()
 	GLOB.poi_list |= src
 	set_stationloving(TRUE, inform_admins=TRUE)
+	AddComponent(/datum/component/wanderlust)
 
 /obj/item/disk/nuclear/attackby(obj/item/I, mob/living/user, params)
 	if(istype(I, /obj/item/claymore/highlander))

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -328,6 +328,7 @@
 #include "code\datums\components\spooky.dm"
 #include "code\datums\components\squeek.dm"
 #include "code\datums\components\thermite.dm"
+#include "code\datums\components\wanderlust.dm"
 #include "code\datums\components\decals\blood.dm"
 #include "code\datums\diseases\_disease.dm"
 #include "code\datums\diseases\_MobProcs.dm"


### PR DESCRIPTION
:cl: coiax
add: The nuclear disk will relocate if it's stationary for more than ten
minutes.
/:cl:

Why? Because this neatly handles the "safe problem" in a clean way,
without resorting to special casing. The best disk storage has always
been on a person, because they're the ones that are best equipped to run
away.

Positive side effects:

- If no one picks up the disk at roundstart, it will slowly go on a tour
of the station (the disk only relocates to human breathable areas) until
someone picks it up. This also means that nuke ops can't just take
advantage of an absent captain and race to the station, because it'll
move by the time they've gotten there. (Unless they manage to organise
the whole operation in less than 10 minutes, in which case kudos).
- You can still put the disk in a containment field with a tesla, just
put it on a conveyer belt or something.
- This PR adds the "wanderlust" component, which currently only the
nuclear disk has, but might be used by other things in the future.