### PR TITLE
Fix the Ark's z-level checks

### DIFF
--- a/code/game/gamemodes/clock_cult/clock_structures/ark_of_the_clockwork_justicar.dm
+++ b/code/game/gamemodes/clock_cult/clock_structures/ark_of_the_clockwork_justicar.dm
@@ -52,7 +52,8 @@
 			audible_message("<span class='boldwarning'>An unearthly screaming sound resonates throughout Reebe!</span>")
 			for(var/V in GLOB.player_list)
 				var/mob/M = V
-				if(M.z == z || is_servant_of_ratvar(M) || isobserver(M))
+				var/turf/T = get_turf(M)
+				if((T && T.z == z) || is_servant_of_ratvar(M) || isobserver(M))
 					M.playsound_local(M, 'sound/machines/clockcult/ark_scream.ogg', 100, FALSE, pressure_affected = FALSE)
 			hierophant_message("<span class='big boldwarning'>The Ark is taking damage!</span>")
 	last_scream = world.time + ARK_SCREAM_COOLDOWN
@@ -71,7 +72,8 @@
 	visible_message("<span class='boldwarning'>[src] shudders and roars to life, its parts beginning to whirr and screech!</span>")
 	hierophant_message("<span class='bold large_brass'>The Ark is activating! You will be transported there soon!</span>")
 	for(var/mob/M in GLOB.player_list)
-		if(is_servant_of_ratvar(M) || isobserver(M) || M.z == z)
+		var/turf/T = get_turf(M)
+		if(is_servant_of_ratvar(M) || isobserver(M) || (T && T.z == z))
 			M.playsound_local(M, 'sound/magic/clockwork/ark_activation_sequence.ogg', 30, FALSE, pressure_affected = FALSE)
 	addtimer(CALLBACK(src, .proc/let_slip_the_dogs), 300)
 
@@ -145,7 +147,8 @@
 		qdel(countdown)
 		countdown = null
 	for(var/mob/L in GLOB.player_list)
-		if(L.z == z)
+		var/turf/T = get_turf(L)
+		if(T && T.z == z)
 			var/atom/movable/target = L
 			if(isobj(L.loc))
 				target = L.loc
@@ -169,7 +172,8 @@
 			visible_message("<span class='userdanger'>[src] begins to pulse uncontrollably... you might want to run!</span>")
 			sound_to_playing_players(volume = 50, channel = CHANNEL_JUSTICAR_ARK, S = sound('sound/effects/clockcult_gateway_disrupted.ogg'))
 			for(var/mob/M in GLOB.player_list)
-				if(M.z == z || is_servant_of_ratvar(M))
+				var/turf/T = get_turf(M)
+				if((T && T.z == z) || is_servant_of_ratvar(M))
 					M.playsound_local(M, 'sound/machines/clockcult/ark_deathrattle.ogg', 100, FALSE, pressure_affected = FALSE)
 			make_glow()
 			glow.icon_state = "clockwork_gateway_disrupted"
@@ -259,7 +263,8 @@
 	if(!first_sound_played || prob(7))
 		for(var/mob/M in GLOB.player_list)
 			if(M && !isnewplayer(M))
-				if(M.z == z)
+				var/turf/T = get_turf(M)
+				if(T && T.z == z)
 					to_chat(M, "<span class='warning'><b>You hear otherworldly sounds from the [dir2text(get_dir(get_turf(M), get_turf(src)))]...</span>")
 				else
 					to_chat(M, "<span class='boldwarning'>You hear otherworldly sounds from all around you...</span>")
@@ -274,7 +279,8 @@
 			O.update_icon()
 	for(var/V in GLOB.player_list)
 		var/mob/M = V
-		if(is_servant_of_ratvar(M) && M.z != z)
+		var/turf/T = get_turf(M)
+		if(is_servant_of_ratvar(M) && (!T || T.z != z))
 			M.forceMove(get_step(src, SOUTH))
 			M.overlay_fullscreen("flash", /obj/screen/fullscreen/flash)
 			M.clear_fullscreen("flash", 5)


### PR DESCRIPTION
:cl:
fix: The Ark's teleportation checks now take mechs and sleepers into account correctly.
/:cl:

Fixes #34304.
Fixes #32588 for real, #34297 did not actually fix it.
