### PR TITLE
Xenomorph maids (and Barmaids) clean on move

### DIFF
--- a/code/modules/mob/living/simple_animal/hostile/alien.dm
+++ b/code/modules/mob/living/simple_animal/hostile/alien.dm
@@ -164,6 +164,10 @@
 	icon_living = "maid"
 	icon_dead = "maid_dead"
 
+/mob/living/simple_animal/hostile/alien/maid/Initialize(mapload)
+	. = ..()
+	AddComponent(/datum/component/cleaning)
+
 /mob/living/simple_animal/hostile/alien/maid/AttackingTarget()
 	if(ismovableatom(target))
 		if(istype(target, /obj/effect/decal/cleanable))


### PR DESCRIPTION
:cl: coiax
add: A xenomorph maid (or barmaid) cleans the floor as they walk on it.
Lie down, and they'll clean your face.
/:cl:

- Clearly a massive xenobiology buff by letting them create simple mob
janitors.
- Actually implemented so the Barmaid can clean up the Emergency Escape
Bar, but sure, let's buff the regular maid as well.