### PR TITLE
Fixes goon escape shuttle

### DIFF
--- a/_maps/shuttles/emergency_goon.dmm
+++ b/_maps/shuttles/emergency_goon.dmm
@@ -12,6 +12,9 @@
 /obj/structure/shuttle/engine/heater{
 	dir = 8
 	},
+/obj/structure/window/reinforced{
+	dir = 1
+	},
 /turf/open/floor/plating,
 /area/shuttle/escape)
 "d" = (
@@ -265,6 +268,29 @@
 	},
 /turf/open/floor/mineral/titanium/blue,
 /area/shuttle/escape)
+"W" = (
+/obj/structure/shuttle/engine/propulsion{
+	dir = 4
+	},
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/shuttle/escape)
+"X" = (
+/obj/structure/shuttle/engine/propulsion{
+	dir = 4
+	},
+/obj/structure/window/reinforced,
+/turf/open/floor/plating,
+/area/shuttle/escape)
+"Y" = (
+/obj/structure/shuttle/engine/heater{
+	dir = 8
+	},
+/obj/structure/window/reinforced,
+/turf/open/floor/plating,
+/area/shuttle/escape)
 
 (1,1,1) = {"
 a
@@ -280,7 +306,7 @@ d
 a
 "}
 (2,1,1) = {"
-b
+W
 d
 p
 p
@@ -290,7 +316,7 @@ p
 p
 p
 d
-b
+X
 "}
 (3,1,1) = {"
 c
@@ -303,7 +329,7 @@ H
 H
 H
 d
-c
+Y
 "}
 (4,1,1) = {"
 d


### PR DESCRIPTION
Added a couple of windows around the engines on the goon shuttle, as they were letting the air in the dock out.

:cl: Thunder12345
fix: The NES Port emergency shuttle will no longer drain the CentComm emergency dock of air
/:cl:
