### PR TITLE
Fix RPD runtimes and offsets of layered connector ports

### DIFF
--- a/code/game/objects/items/RPD.dm
+++ b/code/game/objects/items/RPD.dm
@@ -334,7 +334,7 @@ GLOBAL_LIST_INIT(disposal_pipe_recipes, list(
 
 				var/obj/item/pipe/P = new pipe_item_type(A, queued_p_type, queued_p_dir)
 
-				if(queued_p_flipped)
+				if(queued_p_flipped && istype(P, /obj/item/pipe/trinary/flippable))
 					var/obj/item/pipe/trinary/flippable/F = P
 					F.flipped = queued_p_flipped
 

--- a/code/modules/atmospherics/machinery/portable/portable_atmospherics.dm
+++ b/code/modules/atmospherics/machinery/portable/portable_atmospherics.dm
@@ -73,6 +73,8 @@
 	anchored = FALSE
 	connected_port.connected_device = null
 	connected_port = null
+	pixel_x = 0
+	pixel_y = 0
 	return TRUE
 
 /obj/machinery/portable_atmospherics/portableConnectorReturnAir()


### PR DESCRIPTION
:cl:
fix: The RPD will no longer fail to paint and layer pipes in some situations.
fix: Unwrenching canisters from connector ports on non-default layers now resets their pixel offset.
/:cl:

Setting the RPD to print anything flipped would break its ability to layer and color pipes until a non-flipped flippable was selected.

Also fixes this goofiness:
![image](https://user-images.githubusercontent.com/222630/34878496-304fefd2-f75f-11e7-9f98-a9671206fb57.png)

Full deets:
```
Runtime in RPD.dm, line 339: Undefined variable /obj/item/pipe/directional/var/flipped 
proc name: pre attackby (/obj/item/pipe_dispenser/pre_attackby)
usr: Vanca Lacunae (spacemaniac) (/mob/living/carbon/human)
usr.loc: The floor (153,111,2) (/turf/open/floor/plasteel)
src: Rapid Piping Device (RPD) (/obj/item/pipe_dispenser)
src.loc: Vanca Lacunae (/mob/living/carbon/human)
call stack:
Rapid Piping Device (RPD) (/obj/item/pipe_dispenser): pre attackby(the floor (152,110,2) (/turf/open/floor/plasteel), Vanca Lacunae (/mob/living/carbon/human), "icon-x=24;icon-y=20;left=1;scr...")
Rapid Piping Device (RPD) (/obj/item/pipe_dispenser): melee attack chain(Vanca Lacunae (/mob/living/carbon/human), the floor (152,110,2) (/turf/open/floor/plasteel), "icon-x=24;icon-y=20;left=1;scr...")
Vanca Lacunae (/mob/living/carbon/human): ClickOn(the floor (152,110,2) (/turf/open/floor/plasteel), "icon-x=24;icon-y=20;left=1;scr...")
the floor (152,110,2) (/turf/open/floor/plasteel): Click(the floor (152,110,2) (/turf/open/floor/plasteel), "mapwindow.map", "icon-x=24;icon-y=20;left=1;scr...")
```