### PR TITLE
Makes the NT Lepton Violet over lava windows lava proof

### DIFF
--- a/_maps/shuttles/emergency_wabbajack.dmm
+++ b/_maps/shuttles/emergency_wabbajack.dmm
@@ -316,7 +316,8 @@
 /area/shuttle/escape)
 "be" = (
 /obj/structure/window/reinforced{
-	dir = 1
+	dir = 1;
+	resistance_flags = 33
 	},
 /turf/open/lava/smooth/airless,
 /area/shuttle/escape)
@@ -327,9 +328,6 @@
 "bg" = (
 /obj/structure/shuttle/engine/propulsion,
 /turf/open/floor/plating/airless,
-/area/shuttle/escape)
-"bh" = (
-/turf/closed/wall/mineral/titanium/overspace,
 /area/shuttle/escape)
 "bi" = (
 /obj/machinery/light,


### PR DESCRIPTION
[Changelogs]: 

:cl: Dax Dupont
fix: The NT Violet Lepton shuttle has been retrofitted with lava proof windows for the lava engine. They will no longer catch fire and violently decompress the shuttle.
/:cl:

[why]: Closes #34234, also I did mapmerge, but I used **mapmerge2** as per new mapping guidelines so it violently deleted unused keys. 
