### PR TITLE
Code fix for stat_entry on NO_FIRE subsystems

### DIFF
--- a/code/controllers/subsystem.dm
+++ b/code/controllers/subsystem.dm
@@ -172,7 +172,7 @@
 
 
 
-	if(can_fire && !(SS_NO_FIRE in flags))
+	if(can_fire && !(SS_NO_FIRE & flags))
 		msg = "[round(cost,1)]ms|[round(tick_usage,1)]%([round(tick_overrun,1)]%)|[round(ticks,0.1)]\t[msg]"
 	else
 		msg = "OFFLINE\t[msg]"


### PR DESCRIPTION
:cl:
fix: Fix attempt to use `in` on a non-list. Pretty sure bitfields do not work that way.
admin: SS_NO_FIRE subsystems will no longer display pointless cost statistics in MC panel
/:cl:

* This appears to be the original intent of the author @AnturK in #24305