### PR TITLE
Fixes players not being immune to their own slime timestops

### DIFF
--- a/code/modules/fields/timestop.dm
+++ b/code/modules/fields/timestop.dm
@@ -18,12 +18,12 @@
 
 /obj/effect/timestop/Initialize(mapload, radius, time, list/immune_atoms, start = TRUE)	//Immune atoms assoc list atom = TRUE
 	. = ..()
-	if(immune_atoms)
-		immune = immune_atoms.Copy()
 	if(!isnull(time))
 		duration = time
 	if(!isnull(radius))
 		freezerange = radius
+	for(var/A in immune_atoms)
+		immune[A] = TRUE
 	for(var/mob/living/L in GLOB.player_list)
 		if(locate(/obj/effect/proc_holder/spell/aoe_turf/conjure/timestop) in L.mind.spell_list) //People who can stop time are immune to its effects
 			immune[L] = TRUE

--- a/code/modules/reagents/chemistry/recipes/slime_extracts.dm
+++ b/code/modules/reagents/chemistry/recipes/slime_extracts.dm
@@ -552,10 +552,9 @@
 	required_other = 1
 
 /datum/chemical_reaction/slime/slimestop/on_reaction(datum/reagents/holder)
-	var/obj/effect/timestop/T = new /obj/effect/timestop
-	T.forceMove(get_turf(holder.my_atom))
-	T.immune += get_mob_by_key(holder.my_atom.fingerprintslast)
-	T.timestop()
+	var/turf/T = get_turf(holder.my_atom)
+	var/list/M = list(get_mob_by_key(holder.my_atom.fingerprintslast))
+	new /obj/effect/timestop(T, null, null, M)
 	..()
 
 /datum/chemical_reaction/slime/slimecamera


### PR DESCRIPTION
:cl:
fix: Players are immune to their own slime time stops again
/:cl:

Relevant code: https://github.com/tgstation/tgstation/blob/91f461856b760b7973e3640e928da9f2c0db561d/code/modules/fields/timestop.dm#L65