### PR TITLE
Quality of life: Newly constructed APCS are unlocked

### DIFF
--- a/code/modules/power/apc.dm
+++ b/code/modules/power/apc.dm
@@ -544,7 +544,7 @@
 		if(do_after(user, 10, target = src))
 			if(has_electronics==0)
 				has_electronics = 1
-				locked = TRUE //We placed new, locked board in
+				locked = FALSE
 				to_chat(user, "<span class='notice'>You place the power control board inside the frame.</span>")
 				qdel(W)
 
@@ -559,7 +559,7 @@
 			user.visible_message("<span class='notice'>[user] fabricates a circuit and places it into [src].</span>", \
 			"<span class='notice'>You adapt a power control board and click it into place in [src]'s guts.</span>")
 			has_electronics = TRUE
-			locked = TRUE
+			locked = FALSE
 		else if(!cell)
 			if(stat & MAINT)
 				to_chat(user, "<span class='warning'>There's no connector for a power cell.</span>")


### PR DESCRIPTION
INB4 CE POWERCREEP

:cl: 
add: NT has disabled their automatic APC lock
/:cl:

[why]: 


To encourage construction and make building rooms easier.