### PR TITLE
Fixes placing the pipe last

### DIFF
--- a/code/modules/atmospherics/machinery/datum_pipeline.dm
+++ b/code/modules/atmospherics/machinery/datum_pipeline.dm
@@ -88,6 +88,8 @@
 /datum/pipeline/proc/addMember(obj/machinery/atmospherics/A, obj/machinery/atmospherics/N)
 	if(istype(A, /obj/machinery/atmospherics/pipe))
 		var/obj/machinery/atmospherics/pipe/P = A
+		if(P.parent)
+			merge(P.parent)
 		P.parent = src
 		var/list/adjacent = P.pipeline_expansion()
 		for(var/obj/machinery/atmospherics/pipe/I in adjacent)


### PR DESCRIPTION
:cl:
fix: fixed a strange pipenet issue that happens when a singular pipe or manifold is placed directly between two or more components and wrenched last.
/:cl:

I am angry and I spent atleast a week trying to find this issue when I was messing around with reagent pipes and stuff broke anytime I constructed the pipes last which is so very counter-intuitive.

Also I need someone who is able to parse atmos code without spiders crawling out of their nostrils to read over this change as it may have other implications that I missed.