### PR TITLE
Fixed alt-click not working with stacks

### DIFF
--- a/code/game/objects/items/stacks/stack.dm
+++ b/code/game/objects/items/stacks/stack.dm
@@ -321,7 +321,7 @@
 	var/obj/item/stack/F = new type(user, amount, FALSE)
 	. = F
 	F.copy_evidences(src)
-	user.put_in_hands(F)
+	user.put_in_hands(F, merge_stacks=FALSE)
 	add_fingerprint(user)
 	F.add_fingerprint(user)
 	use(amount, TRUE)

--- a/code/modules/mob/inventory.dm
+++ b/code/modules/mob/inventory.dm
@@ -202,25 +202,26 @@
 //Puts the item our active hand if possible. Failing that it tries other hands. Returns TRUE on success.
 //If both fail it drops it on the floor and returns FALSE.
 //This is probably the main one you need to know :)
-/mob/proc/put_in_hands(obj/item/I, del_on_fail = FALSE)
+/mob/proc/put_in_hands(obj/item/I, del_on_fail = FALSE, merge_stacks = TRUE)
 	if(!I)
 		return FALSE
 
 	// If the item is a stack and we're already holding a stack then merge
-	if (istype(I, /obj/item/stack))
-		var/obj/item/stack/I_stack = I
-		var/obj/item/stack/active_stack = get_active_held_item()
+	if (merge_stacks)
+		if (istype(I, /obj/item/stack))
+			var/obj/item/stack/I_stack = I
+			var/obj/item/stack/active_stack = get_active_held_item()
 
-		if (istype(active_stack) && istype(I_stack, active_stack.merge_type))
-			if (I_stack.merge(active_stack))
-				to_chat(usr, "<span class='notice'>Your [active_stack.name] stack now contains [active_stack.get_amount()] [active_stack.singular_name]\s.</span>")
-				return TRUE
-		else
-			var/obj/item/stack/inactive_stack = get_inactive_held_item()
-			if (istype(inactive_stack) && istype(I_stack, inactive_stack.merge_type))
-				if (I_stack.merge(inactive_stack))
-					to_chat(usr, "<span class='notice'>Your [inactive_stack.name] stack now contains [inactive_stack.get_amount()] [inactive_stack.singular_name]\s.</span>")
+			if (istype(active_stack) && istype(I_stack, active_stack.merge_type))
+				if (I_stack.merge(active_stack))
+					to_chat(usr, "<span class='notice'>Your [active_stack.name] stack now contains [active_stack.get_amount()] [active_stack.singular_name]\s.</span>")
 					return TRUE
+			else
+				var/obj/item/stack/inactive_stack = get_inactive_held_item()
+				if (istype(inactive_stack) && istype(I_stack, inactive_stack.merge_type))
+					if (I_stack.merge(inactive_stack))
+						to_chat(usr, "<span class='notice'>Your [inactive_stack.name] stack now contains [inactive_stack.get_amount()] [inactive_stack.singular_name]\s.</span>")
+						return TRUE
 
 	if(put_in_active_hand(I))
 		return TRUE

--- a/code/modules/mob/inventory.dm
+++ b/code/modules/mob/inventory.dm
@@ -207,11 +207,14 @@
 		return FALSE
 
 	// If the item is a stack and we're already holding a stack then merge
-	if (merge_stacks)
-		if (istype(I, /obj/item/stack))
-			var/obj/item/stack/I_stack = I
-			var/obj/item/stack/active_stack = get_active_held_item()
+	if (istype(I, /obj/item/stack))
+		var/obj/item/stack/I_stack = I
+		var/obj/item/stack/active_stack = get_active_held_item()
 
+		if (I_stack.zero_amount())
+			return FALSE
+
+		if (merge_stacks)
 			if (istype(active_stack) && istype(I_stack, active_stack.merge_type))
 				if (I_stack.merge(active_stack))
 					to_chat(usr, "<span class='notice'>Your [active_stack.name] stack now contains [active_stack.get_amount()] [active_stack.singular_name]\s.</span>")

--- a/code/modules/mob/living/simple_animal/simple_animal.dm
+++ b/code/modules/mob/living/simple_animal/simple_animal.dm
@@ -499,8 +499,8 @@
 		if(H)
 			H.update_icon()
 
-/mob/living/simple_animal/put_in_hands(obj/item/I)
-	..()
+/mob/living/simple_animal/put_in_hands(obj/item/I, del_on_fail = FALSE, merge_stacks = TRUE)
+	..(I, del_on_fail, merge_stacks)
 	update_inv_hands()
 
 /mob/living/simple_animal/update_inv_hands()


### PR DESCRIPTION
[Changelogs]: I've added a new argument to `mob/put_in_hands()` that let's you stop the stacks from merging automatically. This is set to `TRUE` by default. I also fixed scenario where you end with a stack of 0 reinforced glass sheets in your hand after crafting via click on glass with rods. Fixes #34302 and fixes #34397

:cl: JohnGinnane
fix: Fixed not being able to alt click on a stack
/:cl:

I have tested this on my PC, but let me know if there's other scenarios where you might want to not automatically merge stacks in your hands
