### PR TITLE
Stray bullets and explosions don't blow up the entire syndi lava base anymore

### DIFF
--- a/code/datums/explosion.dm
+++ b/code/datums/explosion.dm
@@ -14,6 +14,7 @@ GLOBAL_LIST_EMPTY(explosions)
 
 /datum/explosion
 	var/explosion_id
+	var/atom/explosion_source
 	var/started_at
 	var/running = TRUE
 	var/stopped = 0		//This is the number of threads stopped !DOESN'T COUNT THREAD 2!
@@ -37,6 +38,7 @@ GLOBAL_LIST_EMPTY(explosions)
 
 	var/id = ++id_counter
 	explosion_id = id
+	explosion_source = epicenter
 
 	epicenter = get_turf(epicenter)
 	if(!epicenter)

--- a/code/datums/explosion.dm
+++ b/code/datums/explosion.dm
@@ -325,6 +325,7 @@ GLOBAL_LIST_EMPTY(explosions)
 	if(stopped < 2)	//wait for main thread and spiral_range thread
 		return QDEL_HINT_IWILLGC
 	GLOB.explosions -= src
+	explosion_source = null
 	return ..()
 
 /client/proc/check_bomb_impacts()

--- a/code/game/machinery/syndicatebomb.dm
+++ b/code/game/machinery/syndicatebomb.dm
@@ -293,7 +293,7 @@
 	if(adminlog)
 		message_admins(adminlog)
 		log_game(adminlog)
-	explosion(get_turf(src), range_heavy, range_medium, range_light, flame_range = range_flame)
+	explosion(src, range_heavy, range_medium, range_light, flame_range = range_flame)
 	if(loc && istype(loc, /obj/machinery/syndicatebomb/))
 		qdel(loc)
 	qdel(src)

--- a/code/game/turfs/simulated/wall/mineral_walls.dm
+++ b/code/game/turfs/simulated/wall/mineral_walls.dm
@@ -253,13 +253,10 @@
 	
 /turf/closed/wall/mineral/plastitanium/explosive/ex_act(severity)
 	var/datum/explosion/acted_explosion = null
-	log_game("Explosive wall exploded")
 	for(var/datum/explosion/E in GLOB.explosions)
 		if(E.explosion_id == explosion_id)
 			acted_explosion = E
 			break
-	if(acted_explosion)
-		log_game("Found explosion, triggered by [acted_explosion.explosion_source]")
 	if(acted_explosion && istype(acted_explosion.explosion_source, /obj/item/bombcore))
 		var/obj/item/bombcore/large/bombcore = new(get_turf(src))
 		bombcore.detonate()

--- a/code/game/turfs/simulated/wall/mineral_walls.dm
+++ b/code/game/turfs/simulated/wall/mineral_walls.dm
@@ -250,10 +250,18 @@
 /turf/closed/wall/mineral/plastitanium/overspace
 	icon_state = "map-overspace"
 	fixed_underlay = list("space"=1)
-
-/turf/closed/wall/mineral/plastitanium/explosive/dismantle_wall(devastated, explode)
-	var/obj/item/bombcore/large/bombcore = new(get_turf(src))
-	if(devastated || explode)
+	
+/turf/closed/wall/mineral/plastitanium/explosive/ex_act(severity)
+	var/datum/explosion/acted_explosion = null
+	log_game("Explosive wall exploded")
+	for(var/datum/explosion/E in GLOB.explosions)
+		if(E.explosion_id == explosion_id)
+			acted_explosion = E
+			break
+	if(acted_explosion)
+		log_game("Found explosion, triggered by [acted_explosion.explosion_source]")
+	if(acted_explosion && istype(acted_explosion.explosion_source, /obj/item/bombcore))
+		var/obj/item/bombcore/large/bombcore = new(get_turf(src))
 		bombcore.detonate()
 	..()
 


### PR DESCRIPTION
:cl: 
balance: you can't get 12 syndi bomb cores from stripping the syndi lava base for parts anymore
fix: fixed the syndi lava base blowing up from stray colossus shots, goliaths breaking in or miners throwing gibtonite at it.
/:cl:

Fixes #34144

Apparently this happens sometimes. Personally I think it's funny but on the other hand many of these explosive walls are placed on the outside walls and it's a bit messy. Also ghost roles get mad about I ded.
Oh yeah, this is also pretty snowflakey. If this has any real chance of getting merged I can make getting the explosion source a helper proc in a proper place.
