### PR TITLE
Removes SS_KEEP_TIMING from SSprojectiles

### DIFF
--- a/code/controllers/subsystem/processing/projectiles.dm
+++ b/code/controllers/subsystem/processing/projectiles.dm
@@ -2,5 +2,5 @@ PROCESSING_SUBSYSTEM_DEF(projectiles)
 	name = "Projectiles"
 	wait = 1
 	stat_tag = "PP"
-	flags = SS_NO_INIT|SS_TICKER|SS_KEEP_TIMING
+	flags = SS_NO_INIT|SS_TICKER
 	var/global_max_tick_moves = 10


### PR DESCRIPTION
Not needed. The only things it process, projectiles and processed vectors both will track time from when it last processed and adjust their speed per tick as necessary so having the subsystem fire faster when it misses is redundant.


....at least in theory.

@MrStonedOne hey uh you probably understand this better than me.