### PR TITLE
 Sulphuric Acid is no longer an option on the chem dispenser. Now has to be made with hydrogen, oxygen and sulfur.

### DIFF
--- a/code/modules/reagents/chemistry/machinery/chem_dispenser.dm
+++ b/code/modules/reagents/chemistry/machinery/chem_dispenser.dm
@@ -38,7 +38,6 @@
 		"water",
 		"ethanol",
 		"sugar",
-		"sacid",
 		"welding_fuel",
 		"silver",
 		"iodine",
@@ -288,7 +287,6 @@
 		list(
 			"lithium",
 			"sugar",
-			"sacid",
 			"copper",
 			"mercury",
 			"sodium",

--- a/code/modules/reagents/chemistry/recipes/toxins.dm
+++ b/code/modules/reagents/chemistry/recipes/toxins.dm
@@ -107,3 +107,10 @@
 	id = "anacea"
 	results = list("anacea" = 3)
 	required_reagents = list("haloperidol" = 1, "impedrezene" = 1, "radium" = 1)
+	
+/datum/chemical_reaction/acid
+	name = "Sulphuric Acid"
+	id = "sacid"
+	results = list("sacid" = 2)
+	required_reagents = list("sulfur" = 1, "oxygen" = 1, "hydrogen" = 1)
+	mix_message = "<span class='danger'>The mixture fizzles and an aura of burning comes from it.</span>"


### PR DESCRIPTION
🆑 Frozenguy5
tweak: Sulphuric Acid is removed as an option to the chem dispenser. You now have to make it with hydrogen (1), oxygen (1) and sulfur (1).
/🆑

I want to rework chemicals, to be hopefully more interesting and realistic, I also need to add much more reagents and reactions so a chemist's arsenal is more vast and flexible (or steal from goon because that's always a good idea). Also, I want to merge the portable chem dispenser and normal chem dispenser together because fuck them.

I'll also have to rename the reagent ids to work better with goofball/morty's chem macros (like stable_plasma (why is it stable?? what makes it stable??))