### PR TITLE
Fix: Nuke ops can buy camokits again

### DIFF
--- a/code/modules/uplink/uplink_items.dm
+++ b/code/modules/uplink/uplink_items.dm
@@ -715,7 +715,8 @@ GLOBAL_LIST_EMPTY(uplink_items) // Global list so we only initialize this once.
 	player_minimum = 20
 
 /datum/uplink_item/stealthy_tools/chameleon/nuke
-	cost = 6
+	cost = 8
+	exclude_modes = list()
 	include_modes = list(/datum/game_mode/nuclear)
 
 /datum/uplink_item/stealthy_tools/syndigaloshes
@@ -727,6 +728,11 @@ GLOBAL_LIST_EMPTY(uplink_items) // Global list so we only initialize this once.
 	exclude_modes = list(/datum/game_mode/nuclear)
 	player_minimum = 20
 
+/datum/uplink_item/stealthy_tools/syndigaloshes/nuke
+	cost = 4
+	exclude_modes = list()
+	include_modes = list(/datum/game_mode/nuclear)
+
 /datum/uplink_item/stealthy_tools/frame
 	name = "F.R.A.M.E. PDA Cartridge"
 	desc = "When inserted into a personal digital assistant, this cartridge gives you five PDA viruses which \
@@ -735,15 +741,6 @@ GLOBAL_LIST_EMPTY(uplink_items) // Global list so we only initialize this once.
 			telecrystals normally."
 	item = /obj/item/cartridge/virus/frame
 	cost = 4
-
-/datum/uplink_item/stealthy_tools/syndigaloshes/nuke
-	name = "Stealthy No-Slip Chameleon Shoes"
-	desc = "These shoes will allow the wearer to run on wet floors and slippery objects without falling down. \
-			They do not work on heavily lubricated surfaces. The manufacturer claims they are much more stealthy than the normal brand."
-	item = /obj/item/clothing/shoes/chameleon
-	cost = 4
-	exclude_modes = list()
-	include_modes = list(/datum/game_mode/nuclear)
 
 /datum/uplink_item/stealthy_tools/agent_card
 	name = "Agent Identification Card"


### PR DESCRIPTION
Fixes a bug introduced in #18739.

:cl: coiax
add: Nuclear operatives now have access to chamelon kits for 8 TC.
/:cl:

Why? Camokits were never intentionally removed (which is what I
thought), but were accidentally removed because of an oversight in how
`include_modes` and `exclude_modes` interact.

Price is now 8 TC, because camokits include noslips, which cost 4 TC for
nuke ops.

- Also removes a duplicate entry for "Stealthy" noslips, which are
exactly the same. They just cost more for nuke ops, for entirely
plausible and realistic reasons.