### PR TITLE
Makes tanks made of metal

### DIFF
--- a/code/game/objects/items/tanks/tanks.dm
+++ b/code/game/objects/items/tanks/tanks.dm
@@ -11,6 +11,7 @@
 	throwforce = 10
 	throw_speed = 1
 	throw_range = 4
+	materials = list(MAT_METAL = 500)
 	actions_types = list(/datum/action/item_action/set_internals)
 	armor = list(melee = 0, bullet = 0, laser = 0, energy = 0, bomb = 10, bio = 0, rad = 0, fire = 80, acid = 30)
 	var/datum/gas_mixture/air_contents = null


### PR DESCRIPTION
Makes jetpacks / oxygen tanks / ect explode when put in the microwave.

(The number likely has to be tweaked, throw out suggestions or correct it afterward)

🆑 ShizCalev
fix: Gas tanks are now made of metal! Honk
/🆑

Fixes #34402