### PR TITLE
Drone dispensers no longer trap the drones below them forcing ghosts to altclick

### DIFF
--- a/code/modules/mob/living/simple_animal/friendly/drone/drones_as_items.dm
+++ b/code/modules/mob/living/simple_animal/friendly/drone/drones_as_items.dm
@@ -15,6 +15,7 @@
 	var/seasonal_hats = TRUE //If TRUE, and there are no default hats, different holidays will grant different hats
 	var/static/list/possible_seasonal_hats //This is built automatically in build_seasonal_hats() but can also be edited by admins!
     layer = BELOW_MOB_LAYER
+
 /obj/item/drone_shell/Initialize()
 	. = ..()
 	var/area/A = get_area(src)

--- a/code/modules/mob/living/simple_animal/friendly/drone/drones_as_items.dm
+++ b/code/modules/mob/living/simple_animal/friendly/drone/drones_as_items.dm
@@ -15,6 +15,7 @@
 	var/seasonal_hats = TRUE //If TRUE, and there are no default hats, different holidays will grant different hats
 	var/static/list/possible_seasonal_hats //This is built automatically in build_seasonal_hats() but can also be edited by admins!
 	layer = BELOW_MOB_LAYER
+
 /obj/item/drone_shell/Initialize()
 	. = ..()
 	var/area/A = get_area(src)

--- a/code/modules/mob/living/simple_animal/friendly/drone/drones_as_items.dm
+++ b/code/modules/mob/living/simple_animal/friendly/drone/drones_as_items.dm
@@ -11,10 +11,11 @@
 	desc = "A shell of a maintenance drone, an expendable robot built to perform station repairs."
 	icon = 'icons/mob/drone.dmi'
 	icon_state = "drone_maint_hat"//yes reuse the _hat state.
+	layer = BELOW_MOB_LAYER
+	
 	var/drone_type = /mob/living/simple_animal/drone //Type of drone that will be spawned
 	var/seasonal_hats = TRUE //If TRUE, and there are no default hats, different holidays will grant different hats
 	var/static/list/possible_seasonal_hats //This is built automatically in build_seasonal_hats() but can also be edited by admins!
-	layer = BELOW_MOB_LAYER
 
 /obj/item/drone_shell/Initialize()
 	. = ..()

--- a/code/modules/mob/living/simple_animal/friendly/drone/drones_as_items.dm
+++ b/code/modules/mob/living/simple_animal/friendly/drone/drones_as_items.dm
@@ -14,7 +14,7 @@
 	var/drone_type = /mob/living/simple_animal/drone //Type of drone that will be spawned
 	var/seasonal_hats = TRUE //If TRUE, and there are no default hats, different holidays will grant different hats
 	var/static/list/possible_seasonal_hats //This is built automatically in build_seasonal_hats() but can also be edited by admins!
-
+    layer = BELOW_MOB_LAYER
 /obj/item/drone_shell/Initialize()
 	. = ..()
 	var/area/A = get_area(src)

--- a/code/modules/mob/living/simple_animal/friendly/drone/drones_as_items.dm
+++ b/code/modules/mob/living/simple_animal/friendly/drone/drones_as_items.dm
@@ -14,8 +14,7 @@
 	var/drone_type = /mob/living/simple_animal/drone //Type of drone that will be spawned
 	var/seasonal_hats = TRUE //If TRUE, and there are no default hats, different holidays will grant different hats
 	var/static/list/possible_seasonal_hats //This is built automatically in build_seasonal_hats() but can also be edited by admins!
-    layer = BELOW_MOB_LAYER
-
+	layer = BELOW_MOB_LAYER
 /obj/item/drone_shell/Initialize()
 	. = ..()
 	var/area/A = get_area(src)


### PR DESCRIPTION
:cl:
fix: Drone dispensers no longer hide drones
/:cl:

[why]:

Drone dispensers shouldn't be on a higher layer then drones.
