### PR TITLE
Couple of chemistry fixes

### DIFF
--- a/code/game/objects/effects/effect_system/effects_foam.dm
+++ b/code/game/objects/effects/effect_system/effects_foam.dm
@@ -189,7 +189,7 @@
 		location = get_turf(loca)
 
 	amount = round(sqrt(amt / 2), 1)
-	carry.copy_to(chemholder, 4*carry.total_volume) //The foam holds 4 times the total reagents volume for balance purposes.
+	carry.copy_to(chemholder, carry.total_volume, 4) //The foam holds 4 times the total reagents volume for balance purposes.
 
 /datum/effect_system/foam_spread/metal/set_up(amt=5, loca, datum/reagents/carry = null, metaltype)
 	..()

--- a/code/game/objects/effects/effect_system/effects_smoke.dm
+++ b/code/game/objects/effects/effect_system/effects_smoke.dm
@@ -271,7 +271,7 @@
 	else
 		location = get_turf(loca)
 	amount = radius
-	carry.copy_to(chemholder, 4*carry.total_volume) //The smoke holds 4 times the total reagents volume for balance purposes.
+	carry.copy_to(chemholder, carry.total_volume, 4) //The smoke holds 4 times the total reagents volume for balance purposes.
 
 	if(!silent)
 		var/contained = ""

--- a/code/modules/reagents/chemistry/holder.dm
+++ b/code/modules/reagents/chemistry/holder.dm
@@ -158,7 +158,7 @@
 	if(istype(target, /datum/reagents))
 		R = target
 	else
-		if(!target.reagents || src.total_volume<=0)
+		if(!target.reagents)
 			return
 		R = target.reagents
 	amount = min(min(amount, src.total_volume), R.maximum_volume-R.total_volume)
@@ -181,14 +181,14 @@
 
 /datum/reagents/proc/copy_to(obj/target, amount=1, multiplier=1, preserve_data=1)
 	var/list/cached_reagents = reagent_list
-	if(!target)
+	if(!target || !total_volume)
 		return
 
 	var/datum/reagents/R
 	if(istype(target, /datum/reagents))
 		R = target
 	else
-		if(!target.reagents || src.total_volume<=0)
+		if(!target.reagents)
 			return
 		R = target.reagents
 

--- a/code/modules/reagents/chemistry/reagents/pyrotechnic_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/pyrotechnic_reagents.dm
@@ -187,7 +187,7 @@
 /datum/reagent/cryostylane/on_mob_life(mob/living/M) //TODO: code freezing into an ice cube
 	if(M.reagents.has_reagent("oxygen"))
 		M.reagents.remove_reagent("oxygen", 0.5)
-		M.bodytemperature -= 15
+		M.bodytemperature = max(M.bodytemperature - 15,0)
 	..()
 
 /datum/reagent/cryostylane/reaction_turf(turf/T, reac_volume)

--- a/code/modules/reagents/chemistry/recipes/pyrotechnics.dm
+++ b/code/modules/reagents/chemistry/recipes/pyrotechnics.dm
@@ -346,15 +346,17 @@
 	id = "cryostylane_oxygen"
 	results = list("cryostylane" = 1)
 	required_reagents = list("cryostylane" = 1, "oxygen" = 1)
+	mob_react = FALSE
 
 /datum/chemical_reaction/cryostylane_oxygen/on_reaction(datum/reagents/holder, created_volume)
-	holder.chem_temp -= 10*created_volume
+	holder.chem_temp = max(holder.chem_temp - 10*created_volume,0)
 
 /datum/chemical_reaction/pyrosium_oxygen
 	name = "ephemeral pyrosium reaction"
 	id = "pyrosium_oxygen"
 	results = list("pyrosium" = 1)
 	required_reagents = list("pyrosium" = 1, "oxygen" = 1)
+	mob_react = FALSE
 
 /datum/chemical_reaction/pyrosium_oxygen/on_reaction(datum/reagents/holder, created_volume)
 	holder.chem_temp += 10*created_volume


### PR DESCRIPTION
:cl:
balance: foam and smoke now get 4x the reagents as they should according to the comments
fix: fixes pyrosium and cryostylane not heating or cooling humans at all
fix: fixes cryostylane cooling beakers to negative kelvin, it's now limited to what the description says
fix: fixes cryostylane cooling people to negative body temperature
code: removed redundant check in trans_to
code: fixes a runtime when total_volume is 0 in copy_to
/:cl:

Body Temperature in this game is completely fucked up. I need feedback on the smoke/foam change. From what I can see, this will not change the radius of smoke/foam, only the concentration of applied chems.

