### PR TITLE
Allow mapping non-default scrubbers

### DIFF
--- a/code/modules/atmospherics/machinery/components/unary_devices/vent_scrubber.dm
+++ b/code/modules/atmospherics/machinery/components/unary_devices/vent_scrubber.dm
@@ -34,6 +34,10 @@
 	..()
 	if(!id_tag)
 		id_tag = assign_uid_vents()
+	for(var/f in filter_types)
+		if(istext(f))
+			filter_types -= f
+			filter_types += gas_id2path(f)
 
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on
 	on = TRUE


### PR DESCRIPTION
A little something for mappers, so they can set `filter_types = list("n2o")` or something like that if they want to map atypical atmos. I'm not entirely sure if this is the best way to do it or if letting the whole thing be a string and taking `"co2;n2o"` would be preferred, but this seemed simplest, and DM does let you set lists (though not datum typepaths).