### PR TITLE
Reverts hidden deathgasp changes from #33405

### DIFF
--- a/code/game/objects/items/implants/implant_explosive.dm
+++ b/code/game/objects/items/implants/implant_explosive.dm
@@ -14,6 +14,10 @@
 /obj/item/implant/explosive/on_mob_death(mob/living/L, gibbed)
 	activate("death")
 
+/obj/item/implant/explosive/trigger(emote, mob/source)
+	if(emote == "deathgasp")
+		activate("deathgasp")
+
 /obj/item/implant/explosive/get_data()
 	var/dat = {"<b>Implant Specifications:</b><BR>
 				<b>Name:</b> Robust Corp RX-78 Employee Management Implant<BR>


### PR DESCRIPTION
Reverts changes from #33405
If you want a feature to be in the game, make a separate PR for it instead of hiding it inside a unrelated PR. Don't be a Goofball.


:cl: 
Add: Deathgasps will now activate explosive implants
/:cl: