### PR TITLE
Fix Camera Failure crashing the server if there are no cameras

### DIFF
--- a/code/modules/events/camerafailure.dm
+++ b/code/modules/events/camerafailure.dm
@@ -10,10 +10,13 @@
 
 /datum/round_event/camera_failure/start()
 	var/iterations = 1
-	var/obj/machinery/camera/C = pick(GLOB.cameranet.cameras)
+	var/list/cameras = GLOB.cameranet.cameras.Copy()
 	while(prob(round(100/iterations)))
-		while(!("SS13" in C.network))
-			C = pick(GLOB.cameranet.cameras)
+		var/obj/machinery/camera/C = pick_n_take(cameras)
+		if (!C)
+			break
+		if (!("SS13" in C.network))
+			continue
 		if(C.status)
 			C.toggle_cam(null, 0)
 		iterations *= 2.5


### PR DESCRIPTION
:cl:
fix: The Camera Failure event no longer crashes the server if the station has no cameras.
/:cl:

Idling on RuntimeStation is apparently a good way to find bugs.
