### PR TITLE
Add JMP buttons to SDQL select results

### DIFF
--- a/code/modules/admin/verbs/SDQL2/SDQL_2.dm
+++ b/code/modules/admin/verbs/SDQL2/SDQL_2.dm
@@ -95,7 +95,7 @@
 				for(var/datum/d in objs)
 					world.SDQL_var(d, query_tree["call"][1], source = d)
 					CHECK_TICK
-					
+
 			if("delete")
 				for(var/datum/d in objs)
 					SDQL_qdel_datum(d)
@@ -133,9 +133,9 @@
 		var/turf/T = a.loc
 		var/turf/actual = get_turf(a)
 		if(istype(T))
-			text += ": [t] at turf [T] [COORD(T)]<br>"
+			text += ": [t] <font color='gray'>at turf</font> [T] [ADMIN_COORDJMP(T)]<br>"
 		else if(a.loc && istype(actual))
-			text += ": [t] in [a.loc] at turf [actual] [COORD(actual)]<br>"
+			text += ": [t] <font color='gray'>in</font> [a.loc] <font color='gray'>at turf</font> [actual] [ADMIN_COORDJMP(actual)]<br>"
 		else
 			text += ": [t]<br>"
 	else


### PR DESCRIPTION
:cl:
admin: SDQL "select" outputs now have buttons to jump to the coordinates of the found objects.
/:cl:
