### PR TITLE
The ref runtime for use_tag without a tag set now only shows in TESTING

### DIFF
--- a/code/__HELPERS/unsorted.dm
+++ b/code/__HELPERS/unsorted.dm
@@ -1500,7 +1500,9 @@ GLOBAL_DATUM_INIT(dview_mob, /mob/dview, new)
 		var/datum/thing = input
 		if(thing.use_tag)
 			if(!thing.tag)
+			#ifdef TESTING
 				stack_trace("A ref was requested of an object with use_tag set but no tag: [thing]")
+			#endif
 				thing.use_tag = FALSE
 			else
 				return "\[[url_encode(thing.tag)]\]"


### PR DESCRIPTION
This was annoying and almost always not helpful.

The only better way to this would be to move use_tag from a bool to an enum, and have states that error and states that do not.