### PR TITLE
Minor circuitry lab fixes

### DIFF
--- a/_maps/map_files/BoxStation/BoxStation.dmm
+++ b/_maps/map_files/BoxStation/BoxStation.dmm
@@ -37604,9 +37604,6 @@
 /obj/structure/disposalpipe/trunk{
 	dir = 8
 	},
-/obj/effect/turf_decal/stripes/corner{
-	dir = 2
-	},
 /turf/open/floor/plasteel,
 /area/science/misc_lab)
 "bOl" = (
@@ -37738,9 +37735,9 @@
 	dir = 10
 	},
 /obj/effect/turf_decal/stripes/line{
-	dir = 4
+	dir = 9
 	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/white,
 /area/science/misc_lab)
 "bOC" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
@@ -37987,7 +37984,6 @@
 /turf/open/floor/plating,
 /area/engine/atmos)
 "bPb" = (
-/turf/open/floor/plasteel,
 /obj/machinery/door/airlock/research/glass{
 	name = "Circuitry Lab";
 	req_access_txt = "47"
@@ -38002,7 +37998,7 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/door/firedoor,
-/turf/open/floor/circuit,
+/turf/open/floor/plasteel/white,
 /area/science/circuit)
 "bPc" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
@@ -38134,16 +38130,16 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/turf/open/floor/plasteel,
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/turf/open/floor/plasteel/white,
 /area/science/misc_lab)
 "bPt" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -41847,7 +41843,10 @@
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 8
 	},
-/turf/open/floor/plasteel,
+/obj/effect/turf_decal/stripes/line{
+	dir = 10
+	},
+/turf/open/floor/plasteel/white,
 /area/science/misc_lab)
 "bYp" = (
 /obj/structure/sign/securearea{
@@ -57476,6 +57475,11 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
+"Qqv" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/effect/landmark/event_spawn,
+/turf/open/floor/plasteel,
+/area/science/circuit)
 
 (1,1,1) = {"
 aaa
@@ -105950,19 +105954,19 @@ bMv
 bNv
 bMv
 Qpo
-Qpw
-QpB
-QpG
-QpK
-QpO
+Qpp
+Qpp
+Qpp
+Qpp
+Qpp
 QpS
 QpY
 bPb
 bQG
-Qqg
-Qqk
-Qqo
-bSl
+QpS
+Qpp
+Qpp
+Qpo
 bQZ
 bQZ
 bQZ
@@ -106213,13 +106217,13 @@ bTo
 bUp
 QpP
 QpT
-bXs
+QpE
 bPL
 bQI
 bTo
 Qql
 cbZ
-bSl
+Qpo
 cmo
 cNW
 cOx
@@ -106463,20 +106467,20 @@ bFU
 bMy
 bNx
 bOG
-Qpq
+Qpp
 Qpx
 bSk
-QpH
-QpL
+QpE
+QpE
 QpQ
 QpU
-QpZ
+QpU
 bPF
 bQI
-bXs
+QpE
 Qqm
 cbY
-bSl
+Qpo
 cOe
 cNW
 cNW
@@ -106720,20 +106724,20 @@ bFU
 bMA
 bNz
 bOI
-Qpr
+Qpp
 bRa
 QpD
 bTp
 QpM
 bVs
-QpV
+Qqv
 bXt
 bPM
 bZh
 Qqh
-cbe
+QpD
 Qqp
-bSl
+Qpo
 cOe
 ceS
 cae
@@ -106977,20 +106981,20 @@ bEC
 bEC
 bEC
 bEC
-Qps
+Qpo
 Qpy
 QpE
-QpI
-QpN
+QpE
+QpE
 QpR
 QpW
 Qqa
 Qqc
-bXs
-bXs
-bXs
-bXs
-bSl
+QpE
+QpE
+QpE
+QpE
+Qpo
 cOe
 ceR
 cbf
@@ -107234,7 +107238,7 @@ cNW
 bMB
 bNA
 cOe
-Qpt
+Qpo
 bRb
 QpF
 QpJ
@@ -107247,7 +107251,7 @@ Qqe
 Qqi
 Qqn
 Qqq
-bSl
+Qpo
 cOx
 Qqr
 ckS
@@ -107491,20 +107495,20 @@ cNX
 cNZ
 cNZ
 Qpj
-Qpu
-Qpz
-bSl
-bSl
-bSl
-bSl
-bSl
-bSl
-bSl
-bSl
-bSl
-bSl
-bSl
-bSl
+Qpo
+Qpo
+Qpo
+Qpo
+Qpo
+Qpo
+Qpo
+Qpo
+Qpo
+Qpo
+Qpo
+Qpo
+Qpo
+Qpo
 cNW
 cgr
 cNW
@@ -108785,7 +108789,7 @@ aaa
 aaf
 cNW
 bYs
-Qqf
+Qpm
 ciJ
 cbf
 cbf

--- a/_maps/map_files/Deltastation/DeltaStation2.dmm
+++ b/_maps/map_files/Deltastation/DeltaStation2.dmm
@@ -80400,6 +80400,9 @@
 "dhS" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/barricade/wooden,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
 /turf/open/floor/plating,
 /area/science/research/abandoned)
 "dhT" = (
@@ -81903,6 +81906,9 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
 /turf/open/floor/plasteel,
 /area/science/research/abandoned)
 "dli" = (
@@ -82426,6 +82432,12 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/structure/cable/white{
+	icon_state = "2-8"
 	},
 /turf/open/floor/plasteel,
 /area/science/research/abandoned)
@@ -86989,6 +87001,9 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 5
 	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
 /turf/open/floor/plasteel,
 /area/science/research/abandoned)
 "dwb" = (
@@ -86996,6 +87011,9 @@
 /obj/item/paper_bin,
 /obj/item/pen,
 /obj/effect/turf_decal/bot,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
 /turf/open/floor/plasteel,
 /area/science/research/abandoned)
 "dwc" = (
@@ -87003,7 +87021,9 @@
 	icon_state = "1-2"
 	},
 /obj/effect/landmark/blobstart,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
+	dir = 4
+	},
 /turf/open/floor/plasteel/neutral/side{
 	dir = 4
 	},
@@ -88558,11 +88578,17 @@
 	dir = 4
 	},
 /obj/effect/landmark/xeno_spawn,
+/obj/structure/cable/white{
+	icon_state = "4-8"
+	},
 /turf/open/floor/plasteel/neutral,
 /area/science/research/abandoned)
 "dzj" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
+	},
+/obj/structure/cable/white{
+	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel/neutral,
 /area/science/research/abandoned)
@@ -88573,6 +88599,9 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
+/obj/structure/cable/white{
+	icon_state = "4-8"
+	},
 /turf/open/floor/plasteel,
 /area/science/research/abandoned)
 "dzl" = (
@@ -88580,6 +88609,9 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/delivery,
+/obj/structure/cable/white{
+	icon_state = "4-8"
+	},
 /turf/open/floor/plasteel,
 /area/science/research/abandoned)
 "dzm" = (
@@ -88597,6 +88629,9 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
+/obj/structure/cable/white{
+	icon_state = "4-8"
+	},
 /turf/open/floor/plasteel,
 /area/science/research/abandoned)
 "dzn" = (
@@ -88606,6 +88641,9 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 5
+	},
+/obj/structure/cable/white{
+	icon_state = "4-8"
 	},
 /turf/open/floor/plating,
 /area/maintenance/port)
@@ -105405,6 +105443,110 @@
 "QOa" = (
 /turf/closed/wall/r_wall,
 /area/science/misc_lab)
+"QOb" = (
+/obj/machinery/power/apc{
+	areastring = "/area/science/research/abandoned";
+	dir = 1;
+	name = "Abandoned Research Lab APC";
+	pixel_y = 24
+	},
+/obj/structure/cable/white{
+	icon_state = "0-2"
+	},
+/turf/open/floor/plating,
+/area/science/research/abandoned)
+"QOc" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 6
+	},
+/obj/structure/cable/white{
+	icon_state = "1-4"
+	},
+/turf/open/floor/plasteel,
+/area/science/research/abandoned)
+"QOd" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/structure/cable/white{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plasteel,
+/area/science/research/abandoned)
+"QOe" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/science/research/abandoned)
+"QOf" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/science/research/abandoned)
+"QOg" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/turf/open/floor/plasteel/neutral/side{
+	dir = 8
+	},
+/area/maintenance/port)
+"QOh" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/turf/open/floor/circuit/green,
+/area/science/research/abandoned)
+"QOi" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable/white{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plating,
+/area/science/research/abandoned)
+"QOj" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
+	dir = 1
+	},
+/turf/open/floor/circuit/green,
+/area/science/research/abandoned)
+"QOk" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable/white{
+	icon_state = "1-4"
+	},
+/turf/open/floor/plasteel/neutral,
+/area/science/research/abandoned)
+"QOl" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable/white{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plasteel/neutral,
+/area/science/research/abandoned)
+"QOm" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
+	dir = 4
+	},
+/obj/structure/cable/white{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plating,
+/area/maintenance/port)
 
 (1,1,1) = {"
 aaa
@@ -129988,13 +130130,13 @@ cJT
 caE
 caE
 QNi
-QNn
-QNs
-QNB
-QNH
-QNN
-QNR
-QNY
+QNi
+QNi
+QNi
+QNi
+QNi
+QNi
+QNi
 dhQ
 dhQ
 dhQ
@@ -130251,7 +130393,7 @@ dmr
 dog
 dle
 drz
-dhR
+QNj
 dul
 dvZ
 dxH
@@ -130501,14 +130643,14 @@ cRP
 ddP
 deW
 cKk
-QNk
+QNj
 QNo
 QNt
 QNC
 QNI
 dpX
 QNS
-dhR
+QNj
 djs
 dlf
 dxI
@@ -130758,14 +130900,14 @@ cMY
 cMY
 cCM
 dgm
-dhR
+QNj
 djp
 QNu
 dmt
 doh
 QNO
 drA
-dhR
+QNj
 dum
 dli
 dpZ
@@ -131022,11 +131164,11 @@ QND
 QNJ
 QNP
 drB
-dhR
-dpZ
-dli
-dxJ
-dxJ
+QNj
+QOb
+QOc
+QOh
+QOj
 dxJ
 dBV
 dlg
@@ -131272,16 +131414,16 @@ dcb
 cMY
 deX
 dgn
-dhR
+QNj
 djr
-QNw
+QNu
 dmv
 doj
 QNQ
 QNT
-dhR
+QNj
 dun
-dli
+QOd
 dxK
 dzg
 dAr
@@ -131529,18 +131671,18 @@ cNd
 cMY
 deX
 dgo
-dhR
+QNj
 QNp
 QNx
 dmw
-dok
+QNx
 dqa
 drC
-dhR
+QNj
 duo
 dmu
-dlg
-dzh
+QOi
+QOk
 dxM
 doi
 dun
@@ -131786,18 +131928,18 @@ cMY
 cMY
 deY
 cKl
-dhR
+QNj
 djt
 QNy
-dmx
+QNy
 dol
 dqb
 drD
-dhR
+QNj
 dup
-dlg
+QOe
 dxL
-dzh
+QOl
 dAs
 dpY
 dDi
@@ -132043,14 +132185,14 @@ dcc
 cMY
 cOD
 cKj
-dhR
+QNj
 dju
 dlj
 dlj
 QNK
 dqc
 QNU
-dhR
+QNj
 duq
 dlh
 dxM
@@ -132300,16 +132442,16 @@ cRS
 cMY
 deZ
 dgo
-dhR
+QNj
 djv
 dlj
 dlj
-QNL
+QNK
 dqb
 drE
-dhR
+QNj
 dur
-dmu
+QOf
 dxN
 dzj
 don
@@ -132557,14 +132699,14 @@ dcd
 cMY
 deX
 dgo
-dhR
+QNj
 QNq
 QNz
 QNE
 doo
 dqd
 drF
-dhR
+QNj
 dus
 dwa
 dom
@@ -132815,13 +132957,13 @@ cMY
 dfa
 dgp
 QNm
-QNr
+QNm
 dll
-dhR
+QNj
 QNM
 dqe
-dhR
-dhR
+QNj
+QNj
 dut
 dwb
 dxO
@@ -133337,9 +133479,9 @@ dqg
 QNV
 dtd
 duu
+QOg
 djw
-djw
-cOm
+QOm
 dAu
 caE
 aaa
@@ -133849,7 +133991,7 @@ djA
 dos
 dqi
 QNX
-QOa
+QNX
 djA
 djA
 djA

--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -63716,6 +63716,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
+/obj/effect/landmark/lightsout,
 /turf/open/floor/plasteel,
 /area/science/misc_lab)
 "cBF" = (
@@ -80868,7 +80869,7 @@
 /obj/machinery/power/apc{
 	areastring = "/area/science/circuit";
 	dir = 1;
-	name = "Circuitry lab APC";
+	name = "Circuitry Lab APC";
 	pixel_y = 30
 	},
 /obj/structure/cable/yellow{
@@ -81061,6 +81062,10 @@
 /area/science/circuit)
 "Quf" = (
 /obj/structure/table/glass,
+/obj/machinery/camera/autoname{
+	dir = 4;
+	network = list("SS13")
+	},
 /turf/open/floor/plasteel,
 /area/science/misc_lab)
 "Qug" = (
@@ -81266,6 +81271,14 @@
 /obj/structure/lattice,
 /turf/open/space/basic,
 /area/space)
+"QuW" = (
+/obj/effect/landmark/event_spawn,
+/turf/open/floor/plasteel/white,
+/area/science/circuit)
+"QuX" = (
+/obj/effect/landmark/event_spawn,
+/turf/open/floor/plasteel/white,
+/area/science/circuit)
 
 (1,1,1) = {"
 aaa
@@ -116128,8 +116141,8 @@ cJa
 cJa
 QtP
 QtZ
-Qug
-Quu
+QtZ
+QtZ
 cBE
 cAJ
 cCE
@@ -116643,7 +116656,7 @@ cuZ
 cuZ
 cuZ
 Qui
-Quv
+Qtm
 czD
 cAL
 cBG
@@ -117154,10 +117167,10 @@ dxQ
 cuZ
 Qtt
 QtE
-cwZ
+QtE
 Quc
 Quk
-Qux
+Qtm
 cQv
 cAN
 cBI
@@ -117410,11 +117423,11 @@ ctk
 cuc
 cuZ
 dyp
-cwZ
-cwZ
-cyM
+QtE
+QtE
+Quc
 Qul
-Quy
+Qtm
 czF
 cAN
 cBJ
@@ -117437,7 +117450,7 @@ aaa
 aaf
 aaa
 aaa
-QuV
+Qtj
 aaa
 aaf
 aaa
@@ -117668,10 +117681,10 @@ Qtc
 cuZ
 Qtu
 QtF
-cxN
+QtF
 Qud
-cxO
-Quz
+QtG
+Qtm
 czG
 cAN
 cBK
@@ -117925,10 +117938,10 @@ cud
 cuZ
 Qtv
 QtG
-cxO
-cxO
+QtG
+QuW
 Qum
-QuA
+Qtm
 cQB
 cAO
 cBL
@@ -118183,9 +118196,9 @@ Qtl
 cwd
 QtH
 cxP
-cxO
+QtG
 Qun
-QuB
+Qtm
 czI
 cAP
 cAP
@@ -118440,9 +118453,9 @@ Qtm
 Qtw
 QtI
 QtR
-cxO
+QtG
 Quo
-QuC
+Qtm
 aaf
 aaf
 aaf
@@ -118693,13 +118706,13 @@ clY
 crZ
 dvY
 Qtf
-Qtn
+Qtm
 Qtx
 QtJ
 QtS
-cxO
-cxO
-QuD
+QuX
+QtG
+Qtm
 aaf
 aaa
 aaf
@@ -118950,13 +118963,13 @@ cra
 csa
 dvY
 Qtg
-Qto
+Qtm
 Qty
 QtK
 QtT
-cxO
+QtG
 Qup
-QuE
+Qtm
 aaa
 aaa
 aaa
@@ -119207,13 +119220,13 @@ cou
 csb
 dvY
 Qth
-Qtp
+Qtm
 Qtz
 QtL
 QtU
-cxO
+QtG
 Quq
-QuF
+Qtm
 aaa
 aaa
 aaa
@@ -119464,13 +119477,13 @@ cgs
 csc
 dvY
 Qti
-Qtq
+Qtm
 QtA
 QtM
 QtV
-cxO
+QtG
 Qur
-QuG
+Qtm
 aaa
 aaa
 aaa
@@ -119721,13 +119734,13 @@ dwN
 csc
 dvY
 Qtj
-Qtr
+Qtm
 QtB
 QtN
 QtW
-cxO
+QtG
 Qus
-QuH
+Qtm
 aaa
 aaa
 aaa
@@ -119977,14 +119990,14 @@ cpL
 crb
 csd
 dvY
-Qtk
-Qts
-QtC
+Qtj
+Qtm
+Qtm
 QtO
-QtX
-Que
-Qut
-QuI
+Qtm
+QtO
+Qtm
+Qtm
 aaa
 aaa
 aaa
@@ -120501,7 +120514,7 @@ aaf
 aaf
 aaf
 QuJ
-QuO
+QuJ
 aaf
 aaa
 aaf
@@ -122813,8 +122826,8 @@ aaa
 aaa
 aaf
 aaf
-QuK
-QuP
+QuJ
+QuJ
 aaf
 aaf
 aaa
@@ -125640,8 +125653,8 @@ aaa
 aaf
 aaf
 aaf
-QuL
-QuQ
+QuJ
+QuJ
 aaf
 aaf
 aaa


### PR DESCRIPTION
Fixes a couple minor things from #34493
Delta:
Added scrubber to abandoned lab
Added missing APC to abandoned lab

Meta:
Added camera to sci-maint hall
Added lights out landmark to the circuitry lab
Added event landmark to circuitry lab

Box:
Corrected random circuit floor tile underneath a door
Corrected APC name capitalization
Tweaked the floor pattern leading into the circuitry lab to match it with the toxins lab entrance
Added event spawn landmark
![image](https://user-images.githubusercontent.com/6209658/35017014-09ca2a3e-fae9-11e7-8686-eda6a73a8df9.png)
