### PR TITLE
Revert Defines all subsystem priority values (#33537)

### DIFF
--- a/code/__DEFINES/subsystems.dm
+++ b/code/__DEFINES/subsystems.dm
@@ -76,40 +76,6 @@
 #define INIT_ORDER_SQUEAK -40
 #define INIT_ORDER_PERSISTENCE -100
 
-// Subsystem fire priority, from lowest to highest priority
-// If the subsystem isn't listed here it's either DEFAULT or PROCESS (if it's a processing subsystem child)
-
-#define FIRE_PRIORITY_IDLE_NPC		1
-#define FIRE_PRIORITY_SERVER_MAINT	1
-
-#define FIRE_PRIORITY_GARBAGE		4
-#define FIRE_PRIORITY_RESEARCH		4
-#define FIRE_PRIORITY_AIR			5
-#define FIRE_PRIORITY_NPC			5
-#define FIRE_PRIORITY_PROCESS		6
-#define FIRE_PRIORITY_THROWING		6
-#define FIRE_PRIORITY_FLIGHTPACKS	7
-#define FIRE_PRIORITY_SPACEDRIFT	7
-#define FIRE_PRIOTITY_SMOOTHING		8
-#define FIRE_PRIORITY_ORBIT			8
-#define FIRE_PRIORITY_OBJ			9
-#define FIRE_PRIORUTY_FIELDS		9
-#define FIRE_PRIORITY_ACID			9
-#define FIRE_PRIOTITY_BURNING		9
-#define FIRE_PRIORITY_INBOUNDS		9
-
-#define FIRE_PRIORITY_DEFAULT		10
-
-#define FIRE_PRIORITY_PARALLAX		11
-#define FIRE_PRIORITY_NETWORKS		12
-#define FIRE_PRIORITY_MOBS			13
-#define FIRE_PRIORITY_TGUI			14
-
-#define FIRE_PRIORITY_TICKER		19
-#define FIRE_PRIORITY_OVERLAYS		20
-
-#define FIRE_PRIORITY_INPUT			100 // This must always always be the max highest priority. Player input must never be lost.
-
 // SS runlevels
 
 #define RUNLEVEL_INIT 0

--- a/code/controllers/subsystem.dm
+++ b/code/controllers/subsystem.dm
@@ -4,7 +4,7 @@
 	name = "fire coderbus" //name of the subsystem
 	var/init_order = INIT_ORDER_DEFAULT		//order of initialization. Higher numbers are initialized first, lower numbers later. Use defines in __DEFINES/subsystems.dm for easy understanding of order.
 	var/wait = 20			//time to wait (in deciseconds) between each call to fire(). Must be a positive integer.
-	var/priority = FIRE_PRIORITY_DEFAULT	//When mutiple subsystems need to run in the same tick, higher priority subsystems will run first and be given a higher share of the tick before MC_TICK_CHECK triggers a sleep
+	var/priority = 50		//When mutiple subsystems need to run in the same tick, higher priority subsystems will run first and be given a higher share of the tick before MC_TICK_CHECK triggers a sleep
 
 	var/flags = 0			//see MC.dm in __DEFINES Most flags must be set on world start to take full effect. (You can also restart the mc to force them to process again)
 

--- a/code/controllers/subsystem/acid.dm
+++ b/code/controllers/subsystem/acid.dm
@@ -1,6 +1,6 @@
 SUBSYSTEM_DEF(acid)
 	name = "Acid"
-	priority = FIRE_PRIORITY_ACID
+	priority = 40
 	flags = SS_NO_INIT|SS_BACKGROUND
 	runlevels = RUNLEVEL_GAME | RUNLEVEL_POSTGAME
 

--- a/code/controllers/subsystem/air.dm
+++ b/code/controllers/subsystem/air.dm
@@ -9,7 +9,7 @@
 SUBSYSTEM_DEF(air)
 	name = "Atmospherics"
 	init_order = INIT_ORDER_AIR
-	priority = FIRE_PRIORITY_AIR
+	priority = 20
 	wait = 5
 	flags = SS_BACKGROUND
 	runlevels = RUNLEVEL_GAME | RUNLEVEL_POSTGAME

--- a/code/controllers/subsystem/fire_burning.dm
+++ b/code/controllers/subsystem/fire_burning.dm
@@ -1,6 +1,6 @@
 SUBSYSTEM_DEF(fire_burning)
 	name = "Fire Burning"
-	priority = FIRE_PRIOTITY_BURNING
+	priority = 40
 	flags = SS_NO_INIT|SS_BACKGROUND
 	runlevels = RUNLEVEL_GAME | RUNLEVEL_POSTGAME
 

--- a/code/controllers/subsystem/garbage.dm
+++ b/code/controllers/subsystem/garbage.dm
@@ -1,6 +1,6 @@
 SUBSYSTEM_DEF(garbage)
 	name = "Garbage"
-	priority = FIRE_PRIORITY_GARBAGE
+	priority = 15
 	wait = 2 SECONDS
 	flags = SS_POST_FIRE_TIMING|SS_BACKGROUND|SS_NO_INIT
 	runlevels = RUNLEVELS_DEFAULT | RUNLEVEL_LOBBY

--- a/code/controllers/subsystem/icon_smooth.dm
+++ b/code/controllers/subsystem/icon_smooth.dm
@@ -2,7 +2,7 @@ SUBSYSTEM_DEF(icon_smooth)
 	name = "Icon Smoothing"
 	init_order = INIT_ORDER_ICON_SMOOTHING
 	wait = 1
-	priority = FIRE_PRIOTITY_SMOOTHING
+	priority = 35
 	flags = SS_TICKER
 
 	var/list/smooth_queue = list()

--- a/code/controllers/subsystem/idlenpcpool.dm
+++ b/code/controllers/subsystem/idlenpcpool.dm
@@ -1,7 +1,7 @@
 SUBSYSTEM_DEF(idlenpcpool)
 	name = "Idling NPC Pool"
 	flags = SS_POST_FIRE_TIMING|SS_BACKGROUND
-	priority = FIRE_PRIORITY_IDLE_NPC
+	priority = 10
 	wait = 60
 	runlevels = RUNLEVEL_GAME | RUNLEVEL_POSTGAME
 

--- a/code/controllers/subsystem/inbounds.dm
+++ b/code/controllers/subsystem/inbounds.dm
@@ -1,6 +1,6 @@
 SUBSYSTEM_DEF(inbounds)
 	name = "Inbounds"
-	priority = FIRE_PRIORITY_INBOUNDS
+	priority = 40
 	flags = SS_NO_INIT
 	runlevels = RUNLEVEL_GAME
 

--- a/code/controllers/subsystem/input.dm
+++ b/code/controllers/subsystem/input.dm
@@ -3,7 +3,7 @@ SUBSYSTEM_DEF(input)
 	wait = 1 //SS_TICKER means this runs every tick
 	init_order = INIT_ORDER_INPUT
 	flags = SS_TICKER
-	priority = FIRE_PRIORITY_INPUT
+	priority = 1000
 	runlevels = RUNLEVELS_DEFAULT | RUNLEVEL_LOBBY
 
 	var/list/macro_sets
@@ -23,7 +23,7 @@ SUBSYSTEM_DEF(input)
 // This is for when macro sets are eventualy datumized
 /datum/controller/subsystem/input/proc/setup_default_macro_sets()
 	var/list/static/default_macro_sets
-	
+
 	if(default_macro_sets)
 		macro_sets = default_macro_sets
 		return

--- a/code/controllers/subsystem/mobs.dm
+++ b/code/controllers/subsystem/mobs.dm
@@ -1,6 +1,6 @@
 SUBSYSTEM_DEF(mobs)
 	name = "Mobs"
-	priority = FIRE_PRIORITY_MOBS
+	priority = 100
 	flags = SS_KEEP_TIMING
 	runlevels = RUNLEVEL_GAME | RUNLEVEL_POSTGAME
 

--- a/code/controllers/subsystem/npcpool.dm
+++ b/code/controllers/subsystem/npcpool.dm
@@ -6,7 +6,7 @@
 SUBSYSTEM_DEF(npcpool)
 	name = "NPC Pool"
 	flags = SS_POST_FIRE_TIMING|SS_NO_INIT|SS_BACKGROUND
-	priority = FIRE_PRIORITY_NPC
+	priority = 20
 	runlevels = RUNLEVEL_GAME | RUNLEVEL_POSTGAME
 
 	var/list/canBeUsed = list()

--- a/code/controllers/subsystem/orbit.dm
+++ b/code/controllers/subsystem/orbit.dm
@@ -1,6 +1,6 @@
 SUBSYSTEM_DEF(orbit)
 	name = "Orbits"
-	priority = FIRE_PRIORITY_ORBIT
+	priority = 35
 	wait = 2
 	flags = SS_NO_INIT|SS_TICKER
 

--- a/code/controllers/subsystem/overlays.dm
+++ b/code/controllers/subsystem/overlays.dm
@@ -2,7 +2,7 @@ SUBSYSTEM_DEF(overlays)
 	name = "Overlay"
 	flags = SS_TICKER
 	wait = 1
-	priority = FIRE_PRIORITY_OVERLAYS
+	priority = 500
 	init_order = INIT_ORDER_OVERLAY
 	runlevels = RUNLEVELS_DEFAULT | RUNLEVEL_SETUP
 

--- a/code/controllers/subsystem/parallax.dm
+++ b/code/controllers/subsystem/parallax.dm
@@ -2,7 +2,7 @@ SUBSYSTEM_DEF(parallax)
 	name = "Parallax"
 	wait = 2
 	flags = SS_POST_FIRE_TIMING | SS_BACKGROUND | SS_NO_INIT
-	priority = FIRE_PRIORITY_PARALLAX
+	priority = 65
 	runlevels = RUNLEVEL_LOBBY | RUNLEVELS_DEFAULT
 	var/list/currentrun
 

--- a/code/controllers/subsystem/processing/fields.dm
+++ b/code/controllers/subsystem/processing/fields.dm
@@ -1,6 +1,6 @@
 PROCESSING_SUBSYSTEM_DEF(fields)
 	name = "Fields"
 	wait = 2
-	priority = FIRE_PRIORUTY_FIELDS
+	priority = 40
 	flags = SS_KEEP_TIMING | SS_NO_INIT
 	runlevels = RUNLEVEL_GAME | RUNLEVEL_POSTGAME

--- a/code/controllers/subsystem/processing/flightpacks.dm
+++ b/code/controllers/subsystem/processing/flightpacks.dm
@@ -1,6 +1,6 @@
 PROCESSING_SUBSYSTEM_DEF(flightpacks)
 	name = "Flightpack Movement"
-	priority = FIRE_PRIORITY_FLIGHTPACKS
+	priority = 30
 	wait = 2
 	stat_tag = "FM"
 	flags = SS_NO_INIT|SS_TICKER|SS_KEEP_TIMING

--- a/code/controllers/subsystem/processing/networks.dm
+++ b/code/controllers/subsystem/processing/networks.dm
@@ -1,6 +1,6 @@
 PROCESSING_SUBSYSTEM_DEF(networks)
 	name = "Networks"
-	priority = FIRE_PRIORITY_NETWORKS
+	priority = 80
 	wait = 1
 	stat_tag = "NET"
 	flags = SS_KEEP_TIMING

--- a/code/controllers/subsystem/processing/obj.dm
+++ b/code/controllers/subsystem/processing/obj.dm
@@ -1,6 +1,6 @@
 SUBSYSTEM_DEF(obj)
 	name = "Objects"
-	priority = FIRE_PRIORITY_OBJ
+	priority = 40
 	flags = SS_NO_INIT
 
 	var/list/processing = list()

--- a/code/controllers/subsystem/processing/processing.dm
+++ b/code/controllers/subsystem/processing/processing.dm
@@ -2,7 +2,7 @@
 
 SUBSYSTEM_DEF(processing)
 	name = "Processing"
-	priority = FIRE_PRIORITY_PROCESS
+	priority = 25
 	flags = SS_BACKGROUND|SS_POST_FIRE_TIMING|SS_NO_INIT
 	wait = 10
 

--- a/code/controllers/subsystem/processing/projectiles.dm
+++ b/code/controllers/subsystem/processing/projectiles.dm
@@ -1,5 +1,6 @@
 PROCESSING_SUBSYSTEM_DEF(projectiles)
 	name = "Projectiles"
+	priority = 25
 	wait = 1
 	stat_tag = "PP"
 	flags = SS_NO_INIT|SS_TICKER

--- a/code/controllers/subsystem/radiation.dm
+++ b/code/controllers/subsystem/radiation.dm
@@ -1,6 +1,7 @@
 PROCESSING_SUBSYSTEM_DEF(radiation)
 	name = "Radiation"
 	flags = SS_NO_INIT | SS_BACKGROUND
+	priority = 25
 
 	var/list/warned_atoms = list()
 

--- a/code/controllers/subsystem/research.dm
+++ b/code/controllers/subsystem/research.dm
@@ -2,7 +2,7 @@
 SUBSYSTEM_DEF(research)
 	name = "Research"
 	flags = SS_KEEP_TIMING
-	priority = FIRE_PRIORITY_RESEARCH
+	priority = 15		//My powergame is priority.
 	wait = 10
 	init_order = INIT_ORDER_RESEARCH
 	var/list/invalid_design_ids = list()		//associative id = number of times

--- a/code/controllers/subsystem/server_maint.dm
+++ b/code/controllers/subsystem/server_maint.dm
@@ -4,7 +4,7 @@ SUBSYSTEM_DEF(server_maint)
 	name = "Server Tasks"
 	wait = 6
 	flags = SS_POST_FIRE_TIMING
-	priority = FIRE_PRIORITY_SERVER_MAINT
+	priority = 10
 	init_order = INIT_ORDER_SERVER_MAINT
 	runlevels = RUNLEVEL_LOBBY | RUNLEVELS_DEFAULT
 	var/list/currentrun

--- a/code/controllers/subsystem/spacedrift.dm
+++ b/code/controllers/subsystem/spacedrift.dm
@@ -1,6 +1,6 @@
 SUBSYSTEM_DEF(spacedrift)
 	name = "Space Drift"
-	priority = FIRE_PRIORITY_SPACEDRIFT
+	priority = 30
 	wait = 5
 	flags = SS_NO_INIT|SS_KEEP_TIMING
 	runlevels = RUNLEVEL_GAME | RUNLEVEL_POSTGAME

--- a/code/controllers/subsystem/tgui.dm
+++ b/code/controllers/subsystem/tgui.dm
@@ -2,7 +2,7 @@ SUBSYSTEM_DEF(tgui)
 	name = "tgui"
 	wait = 9
 	flags = SS_NO_INIT
-	priority = FIRE_PRIORITY_TGUI
+	priority = 110
 	runlevels = RUNLEVEL_LOBBY | RUNLEVELS_DEFAULT
 
 	var/list/currentrun = list()

--- a/code/controllers/subsystem/throwing.dm
+++ b/code/controllers/subsystem/throwing.dm
@@ -3,7 +3,7 @@
 
 SUBSYSTEM_DEF(throwing)
 	name = "Throwing"
-	priority = FIRE_PRIORITY_THROWING
+	priority = 25
 	wait = 1
 	flags = SS_NO_INIT|SS_KEEP_TIMING|SS_TICKER
 	runlevels = RUNLEVEL_GAME | RUNLEVEL_POSTGAME

--- a/code/controllers/subsystem/ticker.dm
+++ b/code/controllers/subsystem/ticker.dm
@@ -4,7 +4,7 @@ SUBSYSTEM_DEF(ticker)
 	name = "Ticker"
 	init_order = INIT_ORDER_TICKER
 
-	priority = FIRE_PRIORITY_TICKER
+	priority = 200
 	flags = SS_KEEP_TIMING
 	runlevels = RUNLEVEL_LOBBY | RUNLEVEL_SETUP | RUNLEVEL_GAME
 


### PR DESCRIPTION
Reverts Defines all subsystem priority values (#33537)

Prioritys are a weight that controls how much of the byond tick the subsystem will be allowed to have, 50 was the default, so a subsystem with a priority of 100 would be allocated twice the amount of runtime as normal, and 25 would get half the amount.

Changing them to be consecutive numbers was improper and broke some of the things done to keep everything fair, and caused more overhead because costly but important subsystems were having to spread their workload out over more ticks.

@tgstation/commit-access high priority please.

@ninjanomnom Please redo this with just the define changes without changing the values.