### PR TITLE
Fixes integrity value for non-reinforced plasma window

### DIFF
--- a/code/game/objects/structures/window.dm
+++ b/code/game/objects/structures/window.dm
@@ -525,7 +525,7 @@
 	icon = 'icons/obj/smooth_structures/plasma_window.dmi'
 	icon_state = "plasmawindow"
 	dir = FULLTILE_WINDOW_DIR
-	max_integrity = 100
+	max_integrity = 300
 	fulltile = TRUE
 	flags_1 = PREVENT_CLICK_UNDER_1
 	smooth = SMOOTH_TRUE


### PR DESCRIPTION
Fixes #34532 


:cl:
tweak: full-tile plasmaglass windows have had their integrity increased to the correct value.
/:cl:

Figured I should _probably_ make a PR that isn't a meme or controversial.