### PR TITLE
fixes supply drop pods being impossible to dissassemble

### DIFF
--- a/code/game/objects/structures/crates_lockers/closets/secure/bsdroppod.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/bsdroppod.dm
@@ -31,9 +31,6 @@
 	else
 		add_overlay("BDP_door")
 
-/obj/structure/closet/bsdroppod/tool_interact(obj/item/W, mob/user)
-	return TRUE
-
 /obj/structure/closet/bsdroppod/toggle(mob/living/user)
 	return
 


### PR DESCRIPTION
**[alt title: goddammit goof test your PRs](https://github.com/tgstation/tgstation/pull/34374)**

there was a tool_interact proc in bsdroppod that prevents tools affecting it, that was not removed by above pr. (therefore the pods would land in cargo and then would remain there forever)

will be reimplemented in a future PR. stay tuned