### PR TITLE
Fixes cancelling equipment selection being equivalent to selecting "Naked"

### DIFF
--- a/code/modules/admin/verbs/debug.dm
+++ b/code/modules/admin/verbs/debug.dm
@@ -694,7 +694,7 @@ GLOBAL_PROTECT(AdminProcCallSpamPrevention)
 	SSblackbox.record_feedback("tally", "admin_verb", 1, "Select Equipment") //If you are copy-pasting this, ensure the 2nd parameter is unique to the new proc!
 	for (var/obj/item/I in M.get_equipped_items())
 		qdel(I)
-	if(!(dresscode == "Naked"))
+	if(dresscode != "Naked")
 		M.equipOutfit(dresscode)
 
 	M.regenerate_icons()

--- a/code/modules/admin/verbs/debug.dm
+++ b/code/modules/admin/verbs/debug.dm
@@ -688,10 +688,13 @@ GLOBAL_PROTECT(AdminProcCallSpamPrevention)
 
 	var/dresscode = robust_dress_shop()
 
+	if(!dresscode)
+		return
+
 	SSblackbox.record_feedback("tally", "admin_verb", 1, "Select Equipment") //If you are copy-pasting this, ensure the 2nd parameter is unique to the new proc!
 	for (var/obj/item/I in M.get_equipped_items())
 		qdel(I)
-	if(dresscode)
+	if(!(dresscode == "Naked"))
 		M.equipOutfit(dresscode)
 
 	M.regenerate_icons()
@@ -700,7 +703,7 @@ GLOBAL_PROTECT(AdminProcCallSpamPrevention)
 	message_admins("<span class='adminnotice'>[key_name_admin(usr)] changed the equipment of [key_name_admin(M)] to [dresscode].</span>")
 
 /client/proc/robust_dress_shop()
-	var/list/outfits = list("Naked","Custom","As Job...")
+	var/list/outfits = list("Cancel","Naked","Custom","As Job...")
 	var/list/paths = subtypesof(/datum/outfit) - typesof(/datum/outfit/job)
 	for(var/path in paths)
 		var/datum/outfit/O = path //not much to initalize here but whatever
@@ -714,7 +717,7 @@ GLOBAL_PROTECT(AdminProcCallSpamPrevention)
 	if (outfits[dresscode])
 		dresscode = outfits[dresscode]
 
-	if(dresscode == "Naked")
+	if(dresscode == "Cancel")
 		return
 
 	if (dresscode == "As Job...")


### PR DESCRIPTION
Title. Also adds in a bonus pre-order exclusive "Cancel" entry DLC!

:cl: deathride58
fix: Cancelling the "Change equipment" command now works as expected again.
/:cl:

Fixes #34444 