### PR TITLE
Log PDA messages sent by the message monitor console

### DIFF
--- a/code/game/machinery/telecomms/computers/message.dm
+++ b/code/game/machinery/telecomms/computers/message.dm
@@ -417,6 +417,7 @@
 						))
 						// this will log the signal and transmit it to the target
 						linkedServer.receive_information(signal, null)
+						log_talk(usr, "[key_name(usr)] (PDA: [name]) sent \"[custommessage]\" to [signal.format_target()]", LOGPDA)
 
 
 		//Request Console Logs - KEY REQUIRED


### PR DESCRIPTION
:cl:
fix: PDA messages sent by the message monitor console are now included in the talk logs.
/:cl:

Fixes #34542.