### PR TITLE
Added observer verb View Gases

### DIFF
--- a/code/modules/admin/verbs/diagnostics.dm
+++ b/code/modules/admin/verbs/diagnostics.dm
@@ -12,7 +12,7 @@
 		var/gas = env_gases[id]
 		var/moles = gas[MOLES]
 		if (moles >= 0.00001)
-			lines += "[gas[GAS_META][META_GAS_NAME]]: [moles]"
+			lines += "[gas[GAS_META][META_GAS_NAME]]: [moles] moles"
 	to_chat(usr, lines.Join("\n"))
 
 /client/proc/air_status(turf/target)

--- a/code/modules/admin/verbs/diagnostics.dm
+++ b/code/modules/admin/verbs/diagnostics.dm
@@ -12,7 +12,7 @@
 		var/gas = env_gases[id]
 		var/moles = gas[MOLES]
 		if (moles >= 0.00001)
-			lines += "[gas[GAS_META][META_GAS_NAME]]: [moles] moles"
+			lines += "[gas[GAS_META][META_GAS_NAME]]: [moles] mole\s"
 	to_chat(usr, lines.Join("\n"))
 
 /client/proc/air_status(turf/target)

--- a/code/modules/admin/verbs/diagnostics.dm
+++ b/code/modules/admin/verbs/diagnostics.dm
@@ -12,7 +12,7 @@
 		var/gas = env_gases[id]
 		var/moles = gas[MOLES]
 		if (moles >= 0.00001)
-			lines += "[gas[GAS_META][META_GAS_NAME]]: [moles] mole\s"
+			lines += "[gas[GAS_META][META_GAS_NAME]]: [moles] mol"
 	to_chat(usr, lines.Join("\n"))
 
 /client/proc/air_status(turf/target)

--- a/code/modules/mob/dead/observer/observer.dm
+++ b/code/modules/mob/dead/observer/observer.dm
@@ -59,7 +59,8 @@ GLOBAL_VAR_INIT(observer_default_invisibility, INVISIBILITY_OBSERVER)
 
 	verbs += list(
 		/mob/dead/observer/proc/dead_tele,
-		/mob/dead/observer/proc/open_spawners_menu)
+		/mob/dead/observer/proc/open_spawners_menu,
+		/mob/dead/observer/proc/view_gas)
 
 	if(icon_state in GLOB.ghost_forms_with_directions_list)
 		ghostimage_default = image(src.icon,src,src.icon_state + "_nodir")
@@ -372,6 +373,14 @@ This is the proc mobs get to turn into a ghost. Forked from ghostize due to comp
 
 	usr.forceMove(pick(L))
 	update_parallax_contents()
+
+/mob/dead/observer/proc/view_gas()
+	set category = "Ghost"
+	set name = "View Gases"
+	set desc= "View the atmospheric conditions in a location"
+
+	var/turf/loc = get_turf(src)
+	show_air_status_to(loc, usr)
 
 /mob/dead/observer/verb/follow()
 	set category = "Ghost"


### PR DESCRIPTION
:cl:
add: Observers can now view the atmospheric contents of the tile they're floating above.
/:cl:

We've needed this for ages. Observers get a View Gases proc that tells them the moles, temperature, and pressure of the tile they're floating on:

![](https://imgur.com/1zD6Hss.jpg)

Also modified the debug proc this is based off of so it will show the unit (moles) instead of being ambiguous.

Known issues:
It will say "moles" even if there is 1 mole or less, no idea how to fix that.