### PR TITLE
Removes teleport beacon from Free Golem Ship

### DIFF
--- a/_maps/RandomRuins/LavaRuins/lavaland_surface_golem_ship.dmm
+++ b/_maps/RandomRuins/LavaRuins/lavaland_surface_golem_ship.dmm
@@ -106,7 +106,6 @@
 /turf/open/floor/mineral/titanium/purple,
 /area/ruin/powered/golem_ship)
 "s" = (
-/obj/machinery/bluespace_beacon,
 /turf/open/floor/mineral/titanium/purple,
 /area/ruin/powered/golem_ship)
 "t" = (

--- a/code/modules/mining/equipment/wormhole_jaunter.dm
+++ b/code/modules/mining/equipment/wormhole_jaunter.dm
@@ -28,16 +28,6 @@
 /obj/item/device/wormhole_jaunter/proc/get_destinations(mob/user)
 	var/list/destinations = list()
 
-	if(isgolem(user))
-		for(var/obj/item/device/radio/beacon/B in GLOB.teleportbeacons)
-			var/turf/T = get_turf(B)
-			if(istype(T.loc, /area/ruin/powered/golem_ship))
-				destinations += B
-
-	// In the event golem beacon is destroyed, send to station instead
-	if(destinations.len)
-		return destinations
-
 	for(var/obj/item/device/radio/beacon/B in GLOB.teleportbeacons)
 		var/turf/T = get_turf(B)
 		if(is_station_level(T.z))


### PR DESCRIPTION
:cl: coiax
del: The Free Golem Ship no longer has a teleport beacon.
del: Jaunters no longer have a special effect when teleporting golems.
/:cl:

Originally, when I changed the golem equipment vendor to just have all
regular items + some special ones, people were concerned that golems
would use jaunters to get back to the station, so I put a teleport
beacon in the ship, and made jaunters send golems to that beacon.

But in practice, now, golems don't try to leave for the station;
instead, you just have people teleporting to the ship for the loot, then
hand teleporting out.

It also telegraphs the golem's presence, lessening the surprise of
miners when they run into them in the wastes.

I talked to @KorPhaeron  about this, and he says it's fine.