### PR TITLE
Summon events changes

### DIFF
--- a/code/controllers/subsystem/events.dm
+++ b/code/controllers/subsystem/events.dm
@@ -13,6 +13,8 @@ SUBSYSTEM_DEF(events)
 
 	var/list/holidays			//List of all holidays occuring today or null if no holidays
 	var/wizardmode = 0
+	var/always_inform = FALSE
+	var/admin_veto = TRUE
 
 /datum/controller/subsystem/events/Initialize(time, zlevel)
 	for(var/type in typesof(/datum/round_event_control))
@@ -196,7 +198,7 @@ SUBSYSTEM_DEF(events)
 
 /datum/controller/subsystem/events/proc/toggleWizardmode()
 	wizardmode = !wizardmode
-	message_admins("Summon Events has been [wizardmode ? "enabled, events will occur every [SSevents.frequency_lower / 600] to [SSevents.frequency_upper / 600] minutes" : "disabled"]!")
+	message_admins("Summon Magical Events has been [wizardmode ? "enabled, magical events have been added to the pool" : "disabled"]!")
 	log_game("Summon Events was [wizardmode ? "enabled" : "disabled"]!")
 
 

--- a/code/game/gamemodes/wizard/spellbook.dm
+++ b/code/game/gamemodes/wizard/spellbook.dm
@@ -499,17 +499,41 @@
 	to_chat(user, "<span class='notice'>You have cast summon magic!</span>")
 	return 1
 
-/datum/spellbook_entry/summon/events
-	name = "Summon Events"
-	desc = "Give Murphy's law a little push and replace all events with special wizard ones that will confound and confuse everyone. Multiple castings increase the rate of these events."
+/datum/spellbook_entry/summon/event_chorus
+	name = "Summon Event Chorus"
+	desc = "In the course of a shift, random things will happen to the station. But what if they happened MORE often? Casting this spell will decrease the time between events, which means more things will be happening at once."
+	cost = 2
 	var/times = 0
 
-/datum/spellbook_entry/summon/events/IsAvailible()
+/datum/spellbook_entry/summon/event_chorus/Buy(mob/living/carbon/human/user,obj/item/spellbook/book)
+	SSblackbox.record_feedback("tally", "wizard_spell_learned", 1, name)
+	playsound(get_turf(user), 'sound/magic/castsummon.ogg', 50, 1)
+	times++
+	SSevents.frequency_lower /= 2
+	SSevents.frequency_upper /= 2
+	SSevents.reschedule()
+	to_chat(user, "<span class='notice'>You have summoned a chorus of events.</span>")
+	user.say("CHORUS[pick(" ", "`")]FIERI")
+
+	return TRUE
+
+/datum/spellbook_entry/summon/event_chorus/GetInfo()
+	. = ..()
+	if(times>0)
+		. += "You cast it [times] times.<br>"
+	return .
+
+/datum/spellbook_entry/summon/magical_events
+	name = "Summon Magical Events"
+	desc = "Add special wizard events to the mystical event pool, which will confound and confuse everyone! Multiple castings double the weight of these events within the mystical pool. If you want events to happen more often, summon an Event Chorus."
+	var/times = 0
+
+/datum/spellbook_entry/summon/magical_events/IsAvailible()
 	if(!SSticker.mode) // In case spellbook is placed on map
 		return 0
 	return !CONFIG_GET(flag/no_summon_events)
 
-/datum/spellbook_entry/summon/events/Buy(mob/living/carbon/human/user,obj/item/spellbook/book)
+/datum/spellbook_entry/summon/magical_events/Buy(mob/living/carbon/human/user,obj/item/spellbook/book)
 	SSblackbox.record_feedback("tally", "wizard_spell_learned", 1, name)
 	summonevents()
 	times++
@@ -517,7 +541,7 @@
 	to_chat(user, "<span class='notice'>You have cast summon events.</span>")
 	return 1
 
-/datum/spellbook_entry/summon/events/GetInfo()
+/datum/spellbook_entry/summon/magical_events/GetInfo()
 	. = ..()
 	if(times>0)
 		. += "You cast it [times] times.<br>"

--- a/code/modules/events/_event.dm
+++ b/code/modules/events/_event.dm
@@ -35,6 +35,9 @@
 /datum/round_event_control/wizard
 	wizardevent = 1
 
+/datum/round_event/wizard
+	fakeable = FALSE
+
 // Checks if the event can be spawned. Used by event controller and "false alarm" event.
 // Admin-created events override this.
 /datum/round_event_control/proc/canSpawnEvent(var/players_amt, var/gamemode)
@@ -42,7 +45,7 @@
 		return FALSE
 	if(earliest_start >= world.time-SSticker.round_start_time)
 		return FALSE
-	if(wizardevent != SSevents.wizardmode)
+	if(wizardevent && !SSevents.wizardmode)
 		return FALSE
 	if(players_amt < min_players)
 		return FALSE
@@ -59,7 +62,7 @@
 		return EVENT_CANT_RUN
 
 	triggering = TRUE
-	if (alertadmins)
+	if(SSevents.admin_veto && (alertadmins || SSevents.always_inform))
 		message_admins("Random Event triggering in 10 seconds: [name] (<a href='?src=[REF(src)];cancel=1'>CANCEL</a>)")
 		sleep(100)
 		var/gamemode = SSticker.mode.config_tag
@@ -93,7 +96,7 @@
 
 	testing("[time2text(world.time, "hh:mm:ss")] [E.type]")
 	if(random)
-		if(alertadmins)
+		if(alertadmins || SSevents.always_inform)
 			deadchat_broadcast("<span class='deadsay'><b>[name]</b> has just been randomly triggered!</span>") //STOP ASSUMING IT'S BADMINS!
 		log_game("Random Event triggering: [name] ([typepath])")
 

--- a/code/modules/events/wizard/advanced_darkness.dm
+++ b/code/modules/events/wizard/advanced_darkness.dm
@@ -1,6 +1,6 @@
 /datum/round_event_control/wizard/darkness
 	name = "Advanced Darkness"
-	weight = 2
+	weight = 5
 	typepath = /datum/round_event/wizard/darkness
 	max_occurrences = 2
 	earliest_start = 0

--- a/code/modules/events/wizard/aid.dm
+++ b/code/modules/events/wizard/aid.dm
@@ -2,7 +2,7 @@
 
 /datum/round_event_control/wizard/robelesscasting //EI NUDTH!
 	name = "Robeless Casting"
-	weight = 2
+	weight = 5
 	typepath = /datum/round_event/wizard/robelesscasting
 	max_occurrences = 1
 	earliest_start = 0

--- a/code/modules/events/wizard/blobies.dm
+++ b/code/modules/events/wizard/blobies.dm
@@ -1,6 +1,6 @@
 /datum/round_event_control/wizard/blobies //avast!
 	name = "Zombie Outbreak"
-	weight = 3
+	weight = 7
 	typepath = /datum/round_event/wizard/blobies
 	max_occurrences = 3
 	earliest_start = 12000 // 20 minutes (gotta get some bodies made!)

--- a/code/modules/events/wizard/curseditems.dm
+++ b/code/modules/events/wizard/curseditems.dm
@@ -1,6 +1,6 @@
 /datum/round_event_control/wizard/cursed_items //fashion disasters
 	name = "Cursed Items"
-	weight = 3
+	weight = 7
 	typepath = /datum/round_event/wizard/cursed_items
 	max_occurrences = 3
 	earliest_start = 0

--- a/code/modules/events/wizard/ghost.dm
+++ b/code/modules/events/wizard/ghost.dm
@@ -1,6 +1,6 @@
 /datum/round_event_control/wizard/ghost //The spook is real
 	name = "G-G-G-Ghosts!"
-	weight = 3
+	weight = 15
 	typepath = /datum/round_event/wizard/ghost
 	max_occurrences = 1
 	earliest_start = 0
@@ -14,7 +14,7 @@
 
 /datum/round_event_control/wizard/possession //Oh shit
 	name = "Possessing G-G-G-Ghosts!"
-	weight = 2
+	weight = 5
 	typepath = /datum/round_event/wizard/possession
 	max_occurrences = 5
 	earliest_start = 0

--- a/code/modules/events/wizard/greentext.dm
+++ b/code/modules/events/wizard/greentext.dm
@@ -1,6 +1,6 @@
 /datum/round_event_control/wizard/greentext //Gotta have it!
 	name = "Greentext"
-	weight = 4
+	weight = 10
 	typepath = /datum/round_event/wizard/greentext
 	max_occurrences = 1
 	earliest_start = 0

--- a/code/modules/events/wizard/imposter.dm
+++ b/code/modules/events/wizard/imposter.dm
@@ -1,6 +1,6 @@
 /datum/round_event_control/wizard/imposter //Mirror Mania
 	name = "Imposter Wizard"
-	weight = 1
+	weight = 2
 	typepath = /datum/round_event/wizard/imposter
 	max_occurrences = 1
 	earliest_start = 0

--- a/code/modules/events/wizard/invincible.dm
+++ b/code/modules/events/wizard/invincible.dm
@@ -1,6 +1,6 @@
 /datum/round_event_control/wizard/invincible //Boolet Proof
 	name = "Invincibility"
-	weight = 3
+	weight = 7
 	typepath = /datum/round_event/wizard/invincible
 	max_occurrences = 5
 	earliest_start = 0

--- a/code/modules/events/wizard/lava.dm
+++ b/code/modules/events/wizard/lava.dm
@@ -1,6 +1,6 @@
 /datum/round_event_control/wizard/lava //THE LEGEND NEVER DIES
 	name = "The Floor Is LAVA!"
-	weight = 2
+	weight = 5
 	typepath = /datum/round_event/wizard/lava
 	max_occurrences = 3
 	earliest_start = 0

--- a/code/modules/events/wizard/magicarp.dm
+++ b/code/modules/events/wizard/magicarp.dm
@@ -1,6 +1,6 @@
 /datum/round_event_control/wizard/magicarp //these fish is loaded
 	name = "Magicarp"
-	weight = 1
+	weight = 10
 	typepath = /datum/round_event/wizard/magicarp
 	max_occurrences = 1
 	earliest_start = 0
@@ -8,6 +8,7 @@
 /datum/round_event/wizard/magicarp
 	announceWhen	= 3
 	startWhen = 50
+	fakeable = TRUE
 
 /datum/round_event/wizard/magicarp/setup()
 	startWhen = rand(40, 60)

--- a/code/modules/events/wizard/petsplosion.dm
+++ b/code/modules/events/wizard/petsplosion.dm
@@ -1,6 +1,6 @@
 /datum/round_event_control/wizard/petsplosion //the horror
 	name = "Petsplosion"
-	weight = 2
+	weight = 5
 	typepath = /datum/round_event/wizard/petsplosion
 	max_occurrences = 1 //Exponential growth is nothing to sneeze at!
 	earliest_start = 0

--- a/code/modules/events/wizard/race.dm
+++ b/code/modules/events/wizard/race.dm
@@ -1,6 +1,6 @@
 /datum/round_event_control/wizard/race //Lizard Wizard? Lizard Wizard.
 	name = "Race Swap"
-	weight = 2
+	weight = 5
 	typepath = /datum/round_event/wizard/race
 	max_occurrences = 5
 	earliest_start = 0

--- a/code/modules/events/wizard/rpgloot.dm
+++ b/code/modules/events/wizard/rpgloot.dm
@@ -1,6 +1,6 @@
 /datum/round_event_control/wizard/rpgloot //its time to minmax your shit
 	name = "RPG Loot"
-	weight = 3
+	weight = 10
 	typepath = /datum/round_event/wizard/rpgloot
 	max_occurrences = 1
 	earliest_start = 0

--- a/code/modules/events/wizard/shuffle.dm
+++ b/code/modules/events/wizard/shuffle.dm
@@ -1,9 +1,6 @@
-/datum/round_event/wizard/shuffle/start()
-
-
 /datum/round_event_control/wizard/shuffleloc //Somewhere an AI is crying
 	name = "Change Places!"
-	weight = 2
+	weight = 10
 	typepath = /datum/round_event/wizard/shuffleloc
 	max_occurrences = 5
 	earliest_start = 0
@@ -39,7 +36,7 @@
 
 /datum/round_event_control/wizard/shufflenames //Face/off joke
 	name = "Change Faces!"
-	weight = 4
+	weight = 0
 	typepath = /datum/round_event/wizard/shufflenames
 	max_occurrences = 5
 	earliest_start = 0
@@ -73,7 +70,7 @@
 
 /datum/round_event_control/wizard/shuffleminds //Basically Mass Ranged Mindswap
 	name = "Change Minds!"
-	weight = 1
+	weight = 0
 	typepath = /datum/round_event/wizard/shuffleminds
 	max_occurrences = 3
 	earliest_start = 0

--- a/code/modules/spells/spell_types/rightandwrong.dm
+++ b/code/modules/spells/spell_types/rightandwrong.dm
@@ -176,18 +176,14 @@ GLOBAL_VAR_INIT(summon_magic_triggered, FALSE)
 
 /proc/summonevents()
 	if(!SSevents.wizardmode)
-		SSevents.frequency_lower = 600									//1 minute lower bound
-		SSevents.frequency_upper = 3000									//5 minutes upper bound
 		SSevents.toggleWizardmode()
 		SSevents.reschedule()
-
 	else 																//Speed it up
-		SSevents.frequency_upper -= 600	//The upper bound falls a minute each time, making the AVERAGE time between events lessen
-		if(SSevents.frequency_upper < SSevents.frequency_lower) //Sanity
-			SSevents.frequency_upper = SSevents.frequency_lower
-
+		for(var/datum/round_event_control/E in SSevents.control)
+			if(E.wizardevent)
+				E.weight *= 2
 		SSevents.reschedule()
-		message_admins("Summon Events intensifies, events will now occur every [SSevents.frequency_lower / 600] to [SSevents.frequency_upper / 600] minutes.")
-		log_game("Summon Events was increased!")
+		message_admins("Summon Magical Events intensifies, magical events have twice the weight.")
+		log_game("Summon Magical Events was increased!")
 
 #undef SPECIALIST_MAGIC_PROB


### PR DESCRIPTION
:cl: coiax
add: Summon Events has been split into two seperate entries in a
spellbook. Summon Event Chorus will decrease the time between ALL events
for each purchase, while Summon Magical Events will add, rather than replace with,
magical events to the general event pool. Each additional purchase will
double the weights of the wizard events, making them more likely to be
selected when an even is fired.
add: Change Faces and Change Minds will no longer fire as part of Summon
Magical Events.
/:cl:

- Changed pretty much all of the wizard event weights, because when a wizard Summons
Magical Events, they will be ADDED to the standard event pool, rather than replacing the
normal events entirely. GENERALLY, they've been approximately doubled.
- Change Faces and Change Minds are pretty toxic for a round's health,
as the loss of identity can really mess up the order and normal
functioning of the station, and there's no solution that can be applied,
aside from paranoid backing up of your genetic identity.

Added two new vars on SSevents (there because it makes debugging easier):

`always_inform` (default: false)
which means deadchat is always informed when an event fires,
even if it's Minor Space Dust.

`admin_veto` (default: true) which is whether admins want the option to
veto events for 10 seconds before they fire.