### PR TITLE
Illusions now properly use the health argument of Copy_Parent

### DIFF
--- a/code/modules/mob/living/simple_animal/hostile/illusion.dm
+++ b/code/modules/mob/living/simple_animal/hostile/illusion.dm
@@ -27,11 +27,12 @@
 		death()
 
 
-/mob/living/simple_animal/hostile/illusion/proc/Copy_Parent(mob/living/original, life = 50, health = 100, damage = 0, replicate = 0 )
+/mob/living/simple_animal/hostile/illusion/proc/Copy_Parent(mob/living/original, life = 50, hp = 100, damage = 0, replicate = 0 )
 	appearance = original.appearance
 	parent_mob = original
 	setDir(original.dir)
 	life_span = world.time+life
+	health = hp
 	melee_damage_lower = damage
 	melee_damage_upper = damage
 	multiply_chance = replicate


### PR DESCRIPTION
The health argument of this proc wasn't being utilized so the mob HP was always 100. 