### PR TITLE
TTVs are too big to fit in bags

### DIFF
--- a/code/game/objects/items/devices/transfer_valve.dm
+++ b/code/game/objects/items/devices/transfer_valve.dm
@@ -6,6 +6,7 @@
 	lefthand_file = 'icons/mob/inhands/weapons/bombs_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/weapons/bombs_righthand.dmi'
 	desc = "Regulates the transfer of air between two tanks."
+	w_class = WEIGHT_CLASS_BULKY
 	var/obj/item/tank/tank_one
 	var/obj/item/tank/tank_two
 	var/obj/item/device/assembly/attached_device
@@ -27,15 +28,11 @@
 				return
 			tank_one = item
 			to_chat(user, "<span class='notice'>You attach the tank to the transfer valve.</span>")
-			if(item.w_class > w_class)
-				w_class = item.w_class
 		else if(!tank_two)
 			if(!user.transferItemToLoc(item, src))
 				return
 			tank_two = item
 			to_chat(user, "<span class='notice'>You attach the tank to the transfer valve.</span>")
-			if(item.w_class > w_class)
-				w_class = item.w_class
 
 		update_icon()
 //TODO: Have this take an assemblyholder


### PR DESCRIPTION
A bunch of people on the forums have suggested this and made a pretty good case for it.

Vaporizing the entire map will require a bit more risk and setup if you can't hide bombs in your backpack, giving others a chance to react rather than entire departments or the escape shuttle vanishing without warning. Seems like a preferable way to address the issue of 15 minute maxcap spam rather than lowering bombcap or making TTVs explode smaller. Fits nicely with bags of holding being one of the things science can still build as well.


