### PR TITLE
removed an extra checktick that could cause issues in shuttles

### DIFF
--- a/code/modules/shuttle/docking.dm
+++ b/code/modules/shuttle/docking.dm
@@ -88,8 +88,6 @@
 		if(!canMove())
 			return DOCKING_IMMOBILIZED
 
-	CHECK_TICK
-
 	takeoff(old_turfs, new_turfs, moved_atoms, rotation, movement_direction, old_dock, underlying_old_area)
 
 	CHECK_TICK


### PR DESCRIPTION
The check_dock call has to be done on the same tick as the actual move for things like the cargo shuttle.
