### PR TITLE
One can no longer use cogscarab as a form of Eminence priority.

### DIFF
--- a/code/game/gamemodes/clock_cult/clock_structures/eminence_spire.dm
+++ b/code/game/gamemodes/clock_cult/clock_structures/eminence_spire.dm
@@ -36,10 +36,10 @@
 		nomination(user)
 
 /obj/structure/destructible/clockwork/eminence_spire/attack_drone(mob/living/simple_animal/drone/user)
-	if(!is_servantof_ratvar(user))
+	if(!is_servant_of_ratvar(user))
 		..()
 	else
-		to_chat(user, "<span class='notify'>You feel the omniscient gaze turn into a puzzled frown. Perhaps you should just stick to building.</span>")
+		to_chat(user, "<span class='warning'>You feel the omniscient gaze turn into a puzzled frown. Perhaps you should just stick to building.</span>")
 		return
 
 /obj/structure/destructible/clockwork/eminence_spire/attack_ghost(mob/user)

--- a/code/game/gamemodes/clock_cult/clock_structures/eminence_spire.dm
+++ b/code/game/gamemodes/clock_cult/clock_structures/eminence_spire.dm
@@ -35,6 +35,13 @@
 	else
 		nomination(user)
 
+/obj/structure/destructible/clockwork/eminence_spire/attack_drone(mob/living/simple_animal/drone/user)
+	if(!is_servantof_ratvar(user))
+		..()
+	else
+		to_chat(user, "<span class='notify'>You feel the omniscient gaze turn into a puzzled frown. Perhaps you should just stick to building.</span>")
+		return
+
 /obj/structure/destructible/clockwork/eminence_spire/attack_ghost(mob/user)
 	if(!IsAdminGhost(user))
 		return


### PR DESCRIPTION
Cogscarabs are meant to build, and wasting an integral (building) slot for something you can get as a ghost so you get priority is shitty to both other ghosts and team (the second one being an admin issue).

If you want to go eminence, you can roll for it as a ghost like everyone else.

