### PR TITLE
If the person inside a morgue tray is clonable, they now beep. Loudly.

### DIFF
--- a/code/game/objects/structures/morgue.dm
+++ b/code/game/objects/structures/morgue.dm
@@ -141,11 +141,20 @@ GLOBAL_LIST_EMPTY(bodycontainers) //Let them act as spawnpoints for revenants an
 	desc = "Used to keep bodies in until someone fetches them."
 	icon_state = "morgue1"
 	dir = EAST
+	var/beeper = TRUE
 
 /obj/structure/bodycontainer/morgue/New()
 	connected = new/obj/structure/tray/m_tray(src)
 	connected.connected = src
 	..()
+
+/obj/structure/bodycontainer/morgue/AltClick(mob/user)
+	..()
+	if(user.incapacitated())
+		to_chat(user, "<span class='warning'>You can't do that right now!</span>")
+		return
+	beeper = !beeper
+	to_chat(user, "<span class='notice'>You turn the speaker function [beeper ? "off" : "on"].</span>")
 
 /obj/structure/bodycontainer/morgue/update_icon()
 	if (!connected || connected.loc != src) // Open or tray is gone.
@@ -164,6 +173,8 @@ GLOBAL_LIST_EMPTY(bodycontainers) //Let them act as spawnpoints for revenants an
 				var/mob/living/mob_occupant = get_mob_or_brainmob(M)
 				if(mob_occupant.client && !mob_occupant.suiciding && !(mob_occupant.has_trait(TRAIT_NOCLONE)) && !mob_occupant.hellbound)
 					icon_state = "morgue4" // Cloneable
+					if(mob_occupant.stat == DEAD && beeper)
+						playsound(src, 'sound/weapons/smg_empty_alarm.ogg', 50, 0) //Clone them you blind fucks
 					break
 
 


### PR DESCRIPTION
:cl: 
add: Morgue trays now detect if a body inside them possesses a consciousness, and alerts people nearby
/:cl:

Morgue trays will now beep if you put someone in them who can be cloned (and their ghost is in their body).

They will also beep if the person in them re-enters their corpse at any point. Yes, this is spammable. If you keep hearing "BEEP BEEP BEEP BEEP BEEP BEEP BEEP BEEP" maybe you should clone them. Or just open the tray.

This doesn't add any functionality that doesn't already exist - morgues already display a green light if the body is clonable, this only adds a noise to that.