### PR TITLE
Makes templates able to use PlaceOnTop

### DIFF
--- a/_maps/RandomRuins/LavaRuins/lavaland_biodome_beach.dmm
+++ b/_maps/RandomRuins/LavaRuins/lavaland_biodome_beach.dmm
@@ -458,11 +458,6 @@
 /obj/machinery/light,
 /turf/open/floor/plating/beach/water,
 /area/ruin/powered/beach)
-"cz" = (
-/obj/effect/turf_decal/sand,
-/obj/effect/baseturf_helper/lava_land/surface,
-/turf/open/floor/plating/beach/sand,
-/area/ruin/powered/beach)
 "cR" = (
 /obj/structure/table/wood,
 /obj/item/tank/internals/oxygen,
@@ -1029,7 +1024,7 @@ aK
 aK
 aK
 aK
-cz
+aA
 ar
 ar
 ar

--- a/_maps/RandomRuins/LavaRuins/lavaland_biodome_clown_planet.dmm
+++ b/_maps/RandomRuins/LavaRuins/lavaland_biodome_clown_planet.dmm
@@ -832,16 +832,6 @@
 	wet = 5
 	},
 /area/ruin/powered/clownplanet)
-"dR" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/baseturf_helper/lava_land/surface,
-/turf/open/indestructible/sound{
-	icon_state = "bananium";
-	name = "bananium floor";
-	sound = 'sound/effects/clownstep1.ogg';
-	wet = 5
-	},
-/area/ruin/powered/clownplanet)
 "eX" = (
 /turf/open/floor/noslip{
 	initial_gas_mix = "o2=14;n2=23;TEMP=300"
@@ -1153,7 +1143,7 @@ bx
 bA
 bB
 bH
-dR
+bH
 bB
 bH
 bB

--- a/_maps/RandomRuins/LavaRuins/lavaland_surface_animal_hospital.dmm
+++ b/_maps/RandomRuins/LavaRuins/lavaland_surface_animal_hospital.dmm
@@ -190,12 +190,6 @@
 	dir = 1
 	},
 /area/ruin/powered/animal_hospital)
-"aM" = (
-/obj/effect/mob_spawn/human/doctor/alive/lavaland,
-/turf/open/floor/plasteel/blue/side{
-	dir = 1
-	},
-/area/ruin/powered/animal_hospital)
 "aN" = (
 /obj/structure/closet/crate/freezer,
 /obj/item/reagent_containers/blood/random,
@@ -432,10 +426,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/ruin/powered/animal_hospital)
-"bw" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/white,
-/area/ruin/powered/animal_hospital)
 "bx" = (
 /obj/machinery/door/airlock/medical{
 	name = "Rejuvenation Pods"
@@ -464,12 +454,6 @@
 /obj/structure/table/reinforced,
 /obj/item/storage/box/hug,
 /turf/open/floor/plasteel,
-/area/ruin/powered/animal_hospital)
-"bC" = (
-/obj/structure/chair/office/light{
-	dir = 1
-	},
-/turf/open/floor/plasteel/white,
 /area/ruin/powered/animal_hospital)
 "bD" = (
 /mob/living/simple_animal/bot/medbot{
@@ -519,14 +503,6 @@
 /obj/structure/fans/tiny/invisible,
 /turf/open/floor/plasteel,
 /area/ruin/powered/animal_hospital)
-"bK" = (
-/obj/item/reagent_containers/glass/bowl,
-/obj/item/reagent_containers/food/snacks/grown/wheat,
-/obj/item/reagent_containers/food/snacks/grown/wheat,
-/obj/item/reagent_containers/food/snacks/grown/wheat,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/white,
-/area/ruin/powered/animal_hospital)
 "bL" = (
 /obj/vehicle/ridden/scooter/skateboard{
 	dir = 4
@@ -541,14 +517,6 @@
 	initial_gas_mix = "o2=14;n2=23;TEMP=300"
 	},
 /area/lavaland/surface/outdoors)
-"bN" = (
-/obj/effect/mob_spawn/cow{
-	dir = 4;
-	flavour_text = "<span class='big bold'>You're a cow.</span><b> You've lived a pampered life as a prized show heifer, a real blue-ribbon winner. After showing signs of a minor respiratory infection, your master took you to the hospital right away. He'd better come back soon. You're getting quite impatient.</b>";
-	mob_name = "Flossie"
-	},
-/turf/open/floor/plasteel/white,
-/area/ruin/powered/animal_hospital)
 "bO" = (
 /obj/structure/flora/ausbushes/ppflowers,
 /turf/open/floor/grass{
@@ -738,15 +706,6 @@
 	},
 /turf/open/floor/plasteel/cmo,
 /area/ruin/powered/animal_hospital)
-"ct" = (
-/obj/effect/mob_spawn/human/doctor/alive/lavaland,
-/obj/machinery/light/small{
-	dir = 1
-	},
-/turf/open/floor/plasteel/blue/side{
-	dir = 1
-	},
-/area/ruin/powered/animal_hospital)
 "cv" = (
 /obj/machinery/light/small{
 	dir = 1
@@ -808,10 +767,6 @@
 	},
 /turf/open/floor/plating/asteroid/basalt/lava_land_surface,
 /area/lavaland/surface/outdoors)
-"cF" = (
-/obj/effect/baseturf_helper/lava_land/surface,
-/turf/closed/wall/mineral/titanium/nodiagonal,
-/area/ruin/powered/animal_hospital)
 "cG" = (
 /obj/machinery/door/airlock/shuttle{
 	desc = "There's a smudged note wedged into it that says something about pizza dropoffs.";
@@ -977,7 +932,7 @@ aT
 aY
 bf
 ae
-cF
+ae
 ae
 ae
 ae

--- a/_maps/RandomRuins/LavaRuins/lavaland_surface_ash_walker1.dmm
+++ b/_maps/RandomRuins/LavaRuins/lavaland_surface_ash_walker1.dmm
@@ -66,31 +66,6 @@
 	},
 /turf/closed/mineral/volcanic,
 /area/lavaland/surface/outdoors)
-"am" = (
-/obj/structure/stone_tile{
-	dir = 4
-	},
-/turf/closed/mineral/volcanic/lava_land_surface,
-/area/lavaland/surface/outdoors)
-"an" = (
-/obj/structure/stone_tile/cracked{
-	dir = 1
-	},
-/turf/closed/mineral/volcanic/lava_land_surface,
-/area/lavaland/surface/outdoors)
-"ao" = (
-/obj/structure/stone_tile,
-/obj/structure/stone_tile/cracked{
-	dir = 4
-	},
-/turf/closed/mineral/volcanic/lava_land_surface,
-/area/lavaland/surface/outdoors)
-"ap" = (
-/obj/structure/stone_tile{
-	dir = 1
-	},
-/turf/closed/mineral/volcanic/lava_land_surface,
-/area/lavaland/surface/outdoors)
 "aq" = (
 /obj/structure/stone_tile/block/cracked{
 	dir = 8
@@ -205,10 +180,6 @@
 /obj/item/storage/toolbox/syndicate,
 /turf/open/floor/plating/asteroid/basalt/lava_land_surface,
 /area/ruin/unpowered/ash_walkers)
-"aD" = (
-/obj/structure/table/optable,
-/turf/open/floor/plating/asteroid/basalt/lava_land_surface,
-/area/ruin/unpowered/ash_walkers)
 "aE" = (
 /obj/structure/stone_tile{
 	dir = 4
@@ -276,13 +247,6 @@
 /mob/living/simple_animal/hostile/asteroid/gutlunch/gubbuck,
 /turf/open/indestructible/boss/air,
 /area/ruin/unpowered/ash_walkers)
-"aL" = (
-/obj/structure/stone_tile{
-	dir = 8
-	},
-/obj/structure/stone_tile/cracked,
-/turf/closed/mineral/volcanic/lava_land_surface,
-/area/lavaland/surface/outdoors)
 "aM" = (
 /obj/structure/stone_tile/cracked{
 	dir = 4
@@ -363,11 +327,6 @@
 	},
 /turf/open/indestructible/boss/air,
 /area/ruin/unpowered/ash_walkers)
-"aX" = (
-/obj/item/seeds/glowshroom,
-/obj/item/seeds/glowshroom,
-/turf/open/floor/plating/asteroid/basalt/lava_land_surface,
-/area/ruin/unpowered/ash_walkers)
 "aY" = (
 /obj/structure/stone_tile,
 /obj/structure/stone_tile{
@@ -403,13 +362,6 @@
 	},
 /turf/open/floor/plating/asteroid/basalt/lava_land_surface,
 /area/ruin/unpowered/ash_walkers)
-"bb" = (
-/obj/structure/stone_tile/block{
-	dir = 8
-	},
-/obj/structure/stone_tile/cracked,
-/turf/closed/mineral/volcanic/lava_land_surface,
-/area/lavaland/surface/outdoors)
 "bc" = (
 /obj/structure/stone_tile/block{
 	dir = 4
@@ -599,12 +551,6 @@
 /obj/item/device/flashlight/lantern,
 /turf/open/indestructible/boss/air,
 /area/ruin/unpowered/ash_walkers)
-"bu" = (
-/obj/structure/stone_tile/cracked{
-	dir = 8
-	},
-/turf/closed/mineral/volcanic/lava_land_surface,
-/area/lavaland/surface/outdoors)
 "bv" = (
 /obj/structure/stone_tile/cracked{
 	dir = 8
@@ -724,15 +670,6 @@
 /obj/structure/stone_tile/surrounding_tile,
 /turf/closed/mineral/volcanic,
 /area/lavaland/surface/outdoors)
-"bK" = (
-/obj/structure/stone_tile{
-	dir = 8
-	},
-/obj/structure/stone_tile/cracked{
-	dir = 1
-	},
-/turf/closed/mineral/volcanic/lava_land_surface,
-/area/lavaland/surface/outdoors)
 "bL" = (
 /obj/structure/stone_tile{
 	dir = 4
@@ -834,23 +771,10 @@
 	},
 /turf/open/floor/plating/asteroid/basalt/lava_land_surface,
 /area/lavaland/surface/outdoors)
-"ca" = (
-/obj/structure/stone_tile{
-	dir = 1
-	},
-/obj/structure/stone_tile/cracked{
-	dir = 4
-	},
-/turf/open/floor/plating/asteroid/basalt/lava_land_surface,
-/area/lavaland/surface/outdoors)
 "cb" = (
 /obj/structure/stone_tile{
 	dir = 1
 	},
-/turf/open/floor/plating/asteroid/basalt/lava_land_surface,
-/area/lavaland/surface/outdoors)
-"cc" = (
-/obj/effect/decal/cleanable/blood,
 /turf/open/floor/plating/asteroid/basalt/lava_land_surface,
 /area/lavaland/surface/outdoors)
 "cd" = (
@@ -1010,14 +934,6 @@
 	},
 /turf/open/floor/plating/asteroid/basalt/lava_land_surface,
 /area/ruin/unpowered/ash_walkers)
-"cw" = (
-/obj/machinery/hydroponics/soil,
-/turf/open/floor/plating/asteroid/basalt/lava_land_surface,
-/area/lavaland/surface/outdoors)
-"cx" = (
-/obj/item/reagent_containers/glass/bucket,
-/turf/open/floor/plating/asteroid/basalt/lava_land_surface,
-/area/lavaland/surface/outdoors)
 "cy" = (
 /obj/structure/stone_tile{
 	dir = 8
@@ -1058,10 +974,6 @@
 /obj/effect/decal/cleanable/blood,
 /turf/open/floor/plating/asteroid/basalt/lava_land_surface,
 /area/ruin/unpowered/ash_walkers)
-"cC" = (
-/obj/item/device/flashlight/lantern,
-/turf/open/floor/plating/asteroid/basalt/lava_land_surface,
-/area/lavaland/surface/outdoors)
 "cD" = (
 /obj/structure/stone_tile/block/cracked{
 	dir = 4
@@ -1071,7 +983,6 @@
 /area/ruin/unpowered/ash_walkers)
 "cE" = (
 /obj/structure/stone_tile/surrounding/cracked,
-/obj/effect/baseturf_helper/lava_land/surface,
 /turf/open/floor/plating/asteroid/basalt/lava_land_surface,
 /area/ruin/unpowered/ash_walkers)
 "cF" = (
@@ -1087,14 +998,6 @@
 /obj/item/storage/belt,
 /turf/open/indestructible/boss/air,
 /area/ruin/unpowered/ash_walkers)
-"cG" = (
-/obj/structure/reagent_dispensers/watertank,
-/turf/open/floor/plating/asteroid/basalt/lava_land_surface,
-/area/lavaland/surface/outdoors)
-"cH" = (
-/obj/item/stack/sheet/mineral/wood,
-/turf/open/floor/plating/asteroid/basalt/lava_land_surface,
-/area/lavaland/surface/outdoors)
 "cI" = (
 /obj/structure/stone_tile/cracked{
 	dir = 4
@@ -1180,24 +1083,10 @@
 /obj/structure/stone_tile/surrounding_tile/cracked,
 /turf/closed/mineral/volcanic,
 /area/lavaland/surface/outdoors)
-"cS" = (
-/obj/effect/decal/cleanable/blood,
-/obj/effect/mob_spawn/human/corpse/damaged,
-/obj/structure/stone_tile{
-	dir = 4
-	},
-/turf/open/floor/plating/asteroid/basalt/lava_land_surface,
-/area/lavaland/surface/outdoors)
 "cT" = (
 /obj/structure/stone_tile,
 /obj/structure/stone_tile/block{
 	dir = 1
-	},
-/turf/closed/mineral/volcanic,
-/area/lavaland/surface/outdoors)
-"cU" = (
-/obj/structure/stone_tile/block{
-	dir = 8
 	},
 /turf/closed/mineral/volcanic,
 /area/lavaland/surface/outdoors)
@@ -1239,20 +1128,6 @@
 	},
 /turf/open/floor/plating/asteroid/basalt/lava_land_surface,
 /area/lavaland/surface/outdoors)
-"da" = (
-/obj/structure/stone_tile/surrounding_tile/cracked{
-	dir = 8
-	},
-/turf/closed/mineral/volcanic,
-/area/lavaland/surface/outdoors)
-"db" = (
-/obj/structure/stone_tile/block,
-/turf/closed/mineral/volcanic,
-/area/lavaland/surface/outdoors)
-"dc" = (
-/obj/structure/stone_tile/block,
-/turf/closed/mineral/volcanic,
-/area/lavaland/surface/outdoors)
 "dd" = (
 /obj/structure/stone_tile/surrounding_tile/cracked,
 /turf/open/floor/plating/asteroid/basalt/lava_land_surface,
@@ -1279,13 +1154,6 @@
 "dg" = (
 /obj/structure/bonfire/dense,
 /obj/structure/stone_tile/center,
-/turf/open/floor/plating/asteroid/basalt/lava_land_surface,
-/area/lavaland/surface/outdoors)
-"dh" = (
-/obj/structure/stone_tile/block/cracked,
-/obj/structure/stone_tile/block{
-	dir = 1
-	},
 /turf/open/floor/plating/asteroid/basalt/lava_land_surface,
 /area/lavaland/surface/outdoors)
 "di" = (
@@ -1320,13 +1188,6 @@
 /obj/structure/stone_tile/cracked,
 /obj/structure/stone_tile/cracked{
 	dir = 8
-	},
-/turf/open/floor/plating/asteroid/basalt/lava_land_surface,
-/area/lavaland/surface/outdoors)
-"dm" = (
-/obj/structure/stone_tile/block,
-/obj/structure/stone_tile/block{
-	dir = 1
 	},
 /turf/open/floor/plating/asteroid/basalt/lava_land_surface,
 /area/lavaland/surface/outdoors)
@@ -1471,10 +1332,6 @@
 	},
 /turf/closed/mineral/volcanic,
 /area/lavaland/surface/outdoors)
-"dF" = (
-/obj/structure/stone_tile,
-/turf/closed/mineral/volcanic,
-/area/lavaland/surface/outdoors)
 
 (1,1,1) = {"
 aa
@@ -1502,14 +1359,14 @@ aa
 aa
 ah
 ab
-cU
+aF
 cV
 ah
 ah
 bi
 ah
 bi
-da
+cO
 ah
 ah
 ah
@@ -1531,7 +1388,7 @@ as
 ak
 as
 as
-db
+cP
 ah
 ah
 bN
@@ -1553,7 +1410,7 @@ cY
 bj
 bv
 ak
-db
+cP
 bN
 cg
 cl
@@ -1644,7 +1501,7 @@ ak
 cb
 df
 bX
-dh
+co
 bO
 dq
 bZ
@@ -1679,7 +1536,7 @@ aa
 ai
 aq
 at
-cU
+aF
 aR
 aR
 bo
@@ -1710,7 +1567,7 @@ bF
 bE
 cb
 bL
-dh
+co
 cb
 dt
 dy
@@ -1732,7 +1589,7 @@ ak
 bP
 bL
 bX
-dh
+co
 do
 du
 dz
@@ -1782,7 +1639,7 @@ ah
 bi
 bi
 bi
-da
+cO
 "}
 (15,1,1) = {"
 ac
@@ -1870,7 +1727,7 @@ cB
 cF
 cN
 ak
-db
+cP
 "}
 (19,1,1) = {"
 ag

--- a/_maps/RandomRuins/LavaRuins/lavaland_surface_biodome_winter.dmm
+++ b/_maps/RandomRuins/LavaRuins/lavaland_surface_biodome_winter.dmm
@@ -274,12 +274,6 @@
 	initial_gas_mix = "o2=22;n2=82;TEMP=180"
 	},
 /area/ruin/powered/snow_biodome)
-"bS" = (
-/obj/effect/baseturf_helper/lava_land/surface,
-/turf/open/floor/plating/asteroid/snow{
-	initial_gas_mix = "o2=22;n2=82;TEMP=180"
-	},
-/area/ruin/powered/snow_biodome)
 "dS" = (
 /obj/machinery/light/small,
 /turf/open/floor/pod/dark,
@@ -765,7 +759,7 @@ bl
 ak
 aI
 ak
-bS
+ak
 ak
 Wg
 Wg

--- a/_maps/RandomRuins/LavaRuins/lavaland_surface_cultaltar.dmm
+++ b/_maps/RandomRuins/LavaRuins/lavaland_surface_cultaltar.dmm
@@ -27,24 +27,12 @@
 	initial_gas_mix = "o2=14;n2=23;TEMP=300"
 	},
 /area/ruin/unpowered)
-"h" = (
-/obj/effect/decal/cleanable/blood/old,
-/turf/open/floor/engine/cult{
-	initial_gas_mix = "o2=14;n2=23;TEMP=300"
-	},
-/area/ruin/unpowered)
 "i" = (
 /obj/effect/decal/remains/human,
 /obj/effect/decal/cleanable/blood/old,
 /turf/open/floor/engine/cult{
 	initial_gas_mix = "o2=14;n2=23;TEMP=300"
 	},
-/area/ruin/unpowered)
-"j" = (
-/turf/open/floor/plasteel/cult{
-	initial_gas_mix = "o2=14;n2=23;TEMP=300"
-	},
-/turf/closed/wall/mineral/cult,
 /area/ruin/unpowered)
 "k" = (
 /obj/effect/decal/remains/human,
@@ -63,12 +51,6 @@
 /area/ruin/unpowered)
 "m" = (
 /obj/effect/decal/remains/human,
-/turf/open/floor/engine/cult{
-	initial_gas_mix = "o2=14;n2=23;TEMP=300"
-	},
-/area/ruin/unpowered)
-"n" = (
-/obj/effect/decal/cleanable/blood/old,
 /turf/open/floor/engine/cult{
 	initial_gas_mix = "o2=14;n2=23;TEMP=300"
 	},
@@ -95,12 +77,6 @@
 	initial_gas_mix = "o2=14;n2=23;TEMP=300"
 	},
 /area/ruin/unpowered)
-"p" = (
-/obj/effect/decal/cleanable/blood/old,
-/turf/open/floor/engine/cult{
-	initial_gas_mix = "o2=14;n2=23;TEMP=300"
-	},
-/area/ruin/unpowered)
 "q" = (
 /obj/effect/decal/remains/human,
 /obj/item/clothing/shoes/cult,
@@ -110,17 +86,10 @@
 	initial_gas_mix = "o2=14;n2=23;TEMP=300"
 	},
 /area/ruin/unpowered)
-"r" = (
-/obj/effect/decal/cleanable/blood/old,
-/turf/open/floor/engine/cult{
-	initial_gas_mix = "o2=14;n2=23;TEMP=300"
-	},
-/area/ruin/unpowered)
 "s" = (
 /turf/open/floor/plating/asteroid/basalt/lava_land_surface,
 /area/ruin/unpowered)
 "t" = (
-/obj/effect/baseturf_helper/lava_land/surface,
 /turf/closed/wall/mineral/cult,
 /area/ruin/unpowered)
 

--- a/_maps/RandomRuins/LavaRuins/lavaland_surface_envy.dmm
+++ b/_maps/RandomRuins/LavaRuins/lavaland_surface_envy.dmm
@@ -1,4 +1,4 @@
-//MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE 
+//MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
 "a" = (
 /turf/open/floor/plating/asteroid/basalt/lava_land_surface,
 /area/lavaland/surface/outdoors)
@@ -101,10 +101,6 @@
 /obj/machinery/door/airlock/hatch,
 /turf/open/floor/plating,
 /area/ruin/unpowered)
-"r" = (
-/obj/effect/baseturf_helper/lava_land/surface,
-/turf/closed/wall/rust,
-/area/ruin/unpowered)
 
 (1,1,1) = {"
 a
@@ -160,7 +156,7 @@ d
 d
 d
 d
-r
+d
 d
 d
 d

--- a/_maps/RandomRuins/LavaRuins/lavaland_surface_fountain_hall.dmm
+++ b/_maps/RandomRuins/LavaRuins/lavaland_surface_fountain_hall.dmm
@@ -28,10 +28,6 @@
 /obj/structure/fans/tiny/invisible,
 /turf/open/floor/engine/cult,
 /area/ruin/unpowered)
-"i" = (
-/obj/effect/baseturf_helper/lava_land/surface,
-/turf/open/floor/engine/cult,
-/area/ruin/unpowered)
 
 (1,1,1) = {"
 a
@@ -95,7 +91,7 @@ f
 f
 f
 f
-i
+f
 f
 f
 f

--- a/_maps/RandomRuins/LavaRuins/lavaland_surface_gluttony.dmm
+++ b/_maps/RandomRuins/LavaRuins/lavaland_surface_gluttony.dmm
@@ -1,4 +1,4 @@
-//MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE 
+//MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
 "a" = (
 /turf/closed/mineral/volcanic/lava_land_surface,
 /area/lavaland/surface/outdoors)
@@ -82,10 +82,6 @@
 /obj/machinery/light/small{
 	dir = 4
 	},
-/turf/open/floor/plasteel/freezer,
-/area/ruin/powered/gluttony)
-"D" = (
-/obj/effect/baseturf_helper/lava_land/surface,
 /turf/open/floor/plasteel/freezer,
 /area/ruin/powered/gluttony)
 "R" = (
@@ -218,7 +214,7 @@ b
 c
 R
 i
-D
+i
 v
 R
 c

--- a/_maps/RandomRuins/LavaRuins/lavaland_surface_golem_ship.dmm
+++ b/_maps/RandomRuins/LavaRuins/lavaland_surface_golem_ship.dmm
@@ -105,9 +105,6 @@
 /obj/machinery/computer/shuttle,
 /turf/open/floor/mineral/titanium/purple,
 /area/ruin/powered/golem_ship)
-"s" = (
-/turf/open/floor/mineral/titanium/purple,
-/area/ruin/powered/golem_ship)
 "t" = (
 /obj/structure/extinguisher_cabinet{
 	pixel_y = 30
@@ -208,14 +205,6 @@
 /obj/machinery/light/small,
 /turf/open/floor/plating,
 /area/ruin/powered/golem_ship)
-"J" = (
-/obj/machinery/light/small,
-/turf/open/floor/plating,
-/area/ruin/powered/golem_ship)
-"K" = (
-/obj/machinery/light/small,
-/turf/open/floor/plating,
-/area/ruin/powered/golem_ship)
 "L" = (
 /obj/machinery/light/small{
 	dir = 1
@@ -241,27 +230,7 @@
 	},
 /turf/open/floor/mineral/titanium/purple,
 /area/ruin/powered/golem_ship)
-"P" = (
-/obj/machinery/light/small{
-	dir = 1
-	},
-/turf/open/floor/mineral/titanium/purple,
-/area/ruin/powered/golem_ship)
 "Q" = (
-/obj/machinery/light/small,
-/turf/open/floor/mineral/titanium/purple,
-/area/ruin/powered/golem_ship)
-"R" = (
-/obj/machinery/light/small,
-/turf/open/floor/mineral/titanium/purple,
-/area/ruin/powered/golem_ship)
-"S" = (
-/obj/machinery/light{
-	dir = 8
-	},
-/turf/open/floor/mineral/titanium/purple,
-/area/ruin/powered/golem_ship)
-"T" = (
 /obj/machinery/light/small,
 /turf/open/floor/mineral/titanium/purple,
 /area/ruin/powered/golem_ship)
@@ -275,22 +244,6 @@
 	dir = 1
 	},
 /turf/open/floor/plating,
-/area/ruin/powered/golem_ship)
-"W" = (
-/obj/machinery/light/small{
-	dir = 1
-	},
-/turf/open/floor/plating,
-/area/ruin/powered/golem_ship)
-"X" = (
-/obj/machinery/light/small{
-	dir = 1
-	},
-/turf/open/floor/plating,
-/area/ruin/powered/golem_ship)
-"Y" = (
-/obj/effect/baseturf_helper/lava_land/surface,
-/turf/open/floor/mineral/titanium/purple,
 /area/ruin/powered/golem_ship)
 
 (1,1,1) = {"
@@ -567,7 +520,7 @@ j
 l
 l
 l
-s
+l
 l
 l
 l
@@ -611,7 +564,7 @@ b
 l
 l
 l
-Y
+l
 l
 l
 l

--- a/_maps/RandomRuins/LavaRuins/lavaland_surface_greed.dmm
+++ b/_maps/RandomRuins/LavaRuins/lavaland_surface_greed.dmm
@@ -122,10 +122,6 @@
 /obj/machinery/light/small,
 /turf/open/floor/engine/cult,
 /area/ruin/powered/greed)
-"z" = (
-/obj/effect/baseturf_helper/lava_land/surface,
-/turf/open/floor/engine/cult,
-/area/ruin/powered/greed)
 "J" = (
 /obj/machinery/door/airlock/gold,
 /obj/structure/fans/tiny/invisible,
@@ -323,7 +319,7 @@ h
 l
 m
 m
-z
+m
 l
 m
 v

--- a/_maps/RandomRuins/LavaRuins/lavaland_surface_hermit.dmm
+++ b/_maps/RandomRuins/LavaRuins/lavaland_surface_hermit.dmm
@@ -174,10 +174,6 @@
 	initial_gas_mix = "o2=14;n2=23;TEMP=300"
 	},
 /area/ruin/powered)
-"L" = (
-/obj/effect/baseturf_helper/lava_land/surface,
-/turf/open/floor/plating/asteroid/basalt,
-/area/ruin/powered)
 
 (1,1,1) = {"
 a
@@ -330,7 +326,7 @@ f
 i
 g
 f
-L
+f
 o
 o
 o

--- a/_maps/RandomRuins/LavaRuins/lavaland_surface_pizzaparty.dmm
+++ b/_maps/RandomRuins/LavaRuins/lavaland_surface_pizzaparty.dmm
@@ -1,4 +1,4 @@
-//MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE 
+//MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
 "a" = (
 /turf/template_noop,
 /area/template_noop)
@@ -302,13 +302,6 @@
 	initial_gas_mix = "o2=14;n2=23;TEMP=300"
 	},
 /area/ruin/unpowered)
-"S" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/baseturf_helper/lava_land/surface,
-/turf/open/floor/wood{
-	initial_gas_mix = "o2=14;n2=23;TEMP=300"
-	},
-/area/ruin/unpowered)
 
 (1,1,1) = {"
 a
@@ -474,7 +467,7 @@ d
 g
 o
 h
-S
+h
 C
 J
 h

--- a/_maps/RandomRuins/LavaRuins/lavaland_surface_pride.dmm
+++ b/_maps/RandomRuins/LavaRuins/lavaland_surface_pride.dmm
@@ -1,4 +1,4 @@
-//MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE 
+//MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
 "a" = (
 /turf/open/floor/plating/asteroid/basalt/lava_land_surface,
 /area/lavaland/surface/outdoors)
@@ -62,10 +62,6 @@
 /area/ruin/powered/pride)
 "r" = (
 /obj/machinery/light/small,
-/turf/open/floor/mineral/silver,
-/area/ruin/powered/pride)
-"u" = (
-/obj/effect/baseturf_helper/lava_land/surface,
 /turf/open/floor/mineral/silver,
 /area/ruin/powered/pride)
 "G" = (
@@ -205,7 +201,7 @@ g
 g
 g
 g
-u
+g
 g
 g
 g

--- a/_maps/RandomRuins/LavaRuins/lavaland_surface_seed_vault.dmm
+++ b/_maps/RandomRuins/LavaRuins/lavaland_surface_seed_vault.dmm
@@ -1,4 +1,4 @@
-//MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE 
+//MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
 "a" = (
 /turf/closed/mineral/volcanic/lava_land_surface,
 /area/lavaland/surface/outdoors)
@@ -260,10 +260,6 @@
 /obj/machinery/light,
 /turf/open/floor/plasteel/freezer,
 /area/ruin/powered/seedvault)
-"Z" = (
-/obj/effect/baseturf_helper/lava_land/surface,
-/turf/closed/wall/r_wall,
-/area/ruin/powered/seedvault)
 
 (1,1,1) = {"
 a
@@ -456,7 +452,7 @@ h
 C
 h
 k
-Z
+Q
 M
 a
 a

--- a/_maps/RandomRuins/LavaRuins/lavaland_surface_sloth.dmm
+++ b/_maps/RandomRuins/LavaRuins/lavaland_surface_sloth.dmm
@@ -41,13 +41,6 @@
 	slowdown = 10
 	},
 /area/ruin/unpowered)
-"h" = (
-/obj/effect/baseturf_helper/lava_land/surface,
-/turf/open/floor/sepia{
-	blocks_air = 0;
-	slowdown = 10
-	},
-/area/ruin/unpowered)
 
 (1,1,1) = {"
 a
@@ -126,7 +119,7 @@ a
 b
 a
 d
-h
+d
 d
 d
 a

--- a/_maps/RandomRuins/LavaRuins/lavaland_surface_survivalpod.dmm
+++ b/_maps/RandomRuins/LavaRuins/lavaland_surface_survivalpod.dmm
@@ -1,4 +1,4 @@
-//MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE 
+//MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
 "a" = (
 /turf/template_noop,
 /area/template_noop)
@@ -168,10 +168,6 @@
 /obj/effect/decal/cleanable/blood/drip,
 /turf/open/floor/plating/asteroid/basalt/lava_land_surface,
 /area/lavaland/surface/outdoors)
-"B" = (
-/obj/effect/baseturf_helper/lava_land/surface,
-/turf/closed/wall/mineral/titanium/survival/pod,
-/area/ruin/powered)
 
 (1,1,1) = {"
 a
@@ -278,7 +274,7 @@ b
 b
 d
 d
-B
+d
 d
 d
 z

--- a/_maps/RandomRuins/LavaRuins/lavaland_surface_swarmer_crash.dmm
+++ b/_maps/RandomRuins/LavaRuins/lavaland_surface_swarmer_crash.dmm
@@ -1,4 +1,4 @@
-//MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE 
+//MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
 "a" = (
 /turf/template_noop,
 /area/template_noop)
@@ -20,10 +20,6 @@
 "f" = (
 /mob/living/simple_animal/hostile/megafauna/swarmer_swarm_beacon,
 /turf/open/floor/mineral/plastitanium,
-/area/ruin/unpowered)
-"g" = (
-/obj/effect/baseturf_helper/lava_land/surface,
-/turf/closed/wall/mineral/plastitanium,
 /area/ruin/unpowered)
 
 (1,1,1) = {"
@@ -208,7 +204,7 @@ d
 d
 d
 d
-g
+c
 b
 b
 a

--- a/_maps/RandomRuins/LavaRuins/lavaland_surface_syndicate_base1.dmm
+++ b/_maps/RandomRuins/LavaRuins/lavaland_surface_syndicate_base1.dmm
@@ -195,7 +195,6 @@
 /turf/open/floor/plasteel,
 /area/ruin/unpowered/syndicate_lava_base/chemistry)
 "dC" = (
-/obj/effect/baseturf_helper/lava_land/surface,
 /turf/open/floor/plasteel/floorgrime,
 /area/ruin/unpowered/syndicate_lava_base/chemistry)
 "dD" = (
@@ -1679,7 +1678,6 @@
 	pixel_x = 5;
 	pixel_y = 5
 	},
-/obj/effect/baseturf_helper/lava_land/surface,
 /turf/open/floor/plasteel/white/side{
 	dir = 9
 	},
@@ -1982,7 +1980,6 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 1
 	},
-/obj/effect/baseturf_helper/lava_land/surface,
 /turf/open/floor/plasteel,
 /area/ruin/unpowered/syndicate_lava_base/cargo)
 "gS" = (
@@ -3034,7 +3031,6 @@
 	pixel_y = 5
 	},
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/baseturf_helper/lava_land/surface,
 /turf/open/floor/plasteel/neutral/corner{
 	dir = 8;
 	heat_capacity = 1e+006
@@ -4508,7 +4504,6 @@
 /turf/open/floor/plasteel,
 /area/ruin/unpowered/syndicate_lava_base/engineering)
 "lO" = (
-/obj/effect/baseturf_helper/lava_land/surface,
 /turf/open/floor/plasteel/floorgrime,
 /area/ruin/unpowered/syndicate_lava_base/engineering)
 "lP" = (
@@ -4963,16 +4958,6 @@
 /obj/structure/sign/warning/securearea,
 /turf/closed/wall/mineral/plastitanium/nodiagonal,
 /area/ruin/unpowered/syndicate_lava_base/telecomms)
-"mO" = (
-/obj/structure/filingcabinet/security,
-/obj/machinery/button/door{
-	id = "lavalandsyndi_telecomms";
-	name = "Telecomms Blast Door Control";
-	pixel_y = 26;
-	req_access_txt = "150"
-	},
-/turf/open/floor/plasteel/dark,
-/area/ruin/unpowered/syndicate_lava_base/telecomms)
 "mP" = (
 /obj/structure/filingcabinet/security,
 /turf/open/floor/plasteel/dark,
@@ -5171,7 +5156,6 @@
 	pixel_x = 5;
 	pixel_y = 5
 	},
-/obj/effect/baseturf_helper/lava_land/surface,
 /turf/open/floor/plasteel/vault{
 	dir = 5
 	},
@@ -6021,45 +6005,6 @@
 	},
 /turf/open/floor/plating,
 /area/ruin/unpowered/syndicate_lava_base/arrivals)
-"oJ" = (
-/obj/effect/baseturf_helper/lava_land/surface,
-/turf/open/floor/engine,
-/area/ruin/unpowered/syndicate_lava_base/testlab)
-"oK" = (
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4;
-	piping_layer = 3;
-	pixel_x = 5;
-	pixel_y = 5
-	},
-/obj/effect/baseturf_helper/lava_land/surface,
-/turf/open/floor/plasteel,
-/area/ruin/unpowered/syndicate_lava_base/main)
-"oL" = (
-/obj/effect/baseturf_helper/lava_land/surface,
-/turf/open/floor/plasteel/dark,
-/area/ruin/unpowered/syndicate_lava_base/bar)
-"oM" = (
-/obj/effect/baseturf_helper/lava_land/surface,
-/turf/open/floor/plasteel,
-/area/ruin/unpowered/syndicate_lava_base/medbay)
-"oN" = (
-/obj/effect/baseturf_helper/lava_land/surface,
-/turf/open/floor/plasteel/red/side,
-/area/ruin/unpowered/syndicate_lava_base/arrivals)
-"oO" = (
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = -26
-	},
-/turf/open/floor/plasteel/dark,
-/area/ruin/unpowered/syndicate_lava_base/bar)
 "oP" = (
 /obj/structure/sign/departments/chemistry,
 /turf/closed/wall/mineral/plastitanium/nodiagonal,
@@ -6966,7 +6911,7 @@ ae
 aq
 aq
 aq
-oJ
+aq
 aq
 aq
 ae
@@ -6987,7 +6932,7 @@ ha
 jy
 jM
 jN
-oL
+jZ
 kJ
 lh
 lz
@@ -7137,7 +7082,7 @@ mx
 jy
 jy
 nU
-oN
+oo
 ox
 ab
 ab
@@ -7303,7 +7248,7 @@ et
 eT
 fo
 fO
-oK
+gG
 hg
 hz
 hO
@@ -7555,7 +7500,7 @@ ku
 kR
 ln
 lI
-oM
+lI
 mC
 lI
 nA

--- a/_maps/RandomRuins/LavaRuins/lavaland_surface_ufo_crash.dmm
+++ b/_maps/RandomRuins/LavaRuins/lavaland_surface_ufo_crash.dmm
@@ -1,4 +1,4 @@
-//MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE 
+//MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
 "a" = (
 /turf/closed/mineral/volcanic/lava_land_surface,
 /area/lavaland/surface/outdoors)
@@ -97,7 +97,6 @@
 "s" = (
 /obj/structure/table/optable/abductor,
 /obj/item/cautery/alien,
-/obj/effect/baseturf_helper/lava_land/surface,
 /turf/open/floor/plating/abductor{
 	initial_gas_mix = "o2=16;n2=23;TEMP=300"
 	},

--- a/_maps/RandomRuins/LavaRuins/lavaland_surface_xeno_nest.dmm
+++ b/_maps/RandomRuins/LavaRuins/lavaland_surface_xeno_nest.dmm
@@ -7,11 +7,6 @@
 /obj/structure/alien/resin/wall,
 /turf/open/floor/plating/asteroid/basalt/lava_land_surface,
 /area/ruin/unpowered/xenonest)
-"c" = (
-/obj/structure/alien/weeds,
-/obj/structure/alien/resin/wall,
-/turf/open/floor/plating/asteroid/basalt/lava_land_surface,
-/area/ruin/unpowered/xenonest)
 "d" = (
 /obj/structure/alien/resin/wall,
 /obj/structure/alien/weeds,
@@ -31,11 +26,6 @@
 /obj/structure/alien/weeds,
 /turf/open/floor/plating/asteroid/basalt/lava_land_surface,
 /area/ruin/unpowered/xenonest)
-"h" = (
-/obj/structure/alien/weeds,
-/obj/structure/alien/resin/wall,
-/turf/open/floor/plating/asteroid/basalt/lava_land_surface,
-/area/ruin/unpowered/xenonest)
 "i" = (
 /obj/structure/alien/weeds,
 /obj/structure/bed/nest,
@@ -46,23 +36,8 @@
 /mob/living/simple_animal/hostile/alien,
 /turf/open/floor/plating/asteroid/basalt/lava_land_surface,
 /area/ruin/unpowered/xenonest)
-"k" = (
-/obj/structure/alien/weeds,
-/obj/structure/alien/egg/burst,
-/turf/open/floor/plating/asteroid/basalt/lava_land_surface,
-/area/ruin/unpowered/xenonest)
 "l" = (
 /obj/structure/alien/weeds/node,
-/turf/open/floor/plating/asteroid/basalt/lava_land_surface,
-/area/ruin/unpowered/xenonest)
-"m" = (
-/obj/structure/alien/weeds,
-/obj/structure/bed/nest,
-/turf/open/floor/plating/asteroid/basalt/lava_land_surface,
-/area/ruin/unpowered/xenonest)
-"n" = (
-/obj/structure/alien/weeds,
-/obj/structure/bed/nest,
 /turf/open/floor/plating/asteroid/basalt/lava_land_surface,
 /area/ruin/unpowered/xenonest)
 "o" = (
@@ -71,14 +46,6 @@
 /obj/effect/decal/cleanable/blood/gibs,
 /obj/item/clothing/mask/facehugger/impregnated,
 /obj/item/gun/ballistic/automatic/pistol,
-/turf/open/floor/plating/asteroid/basalt/lava_land_surface,
-/area/ruin/unpowered/xenonest)
-"p" = (
-/obj/structure/alien/weeds,
-/turf/open/floor/plating/asteroid/basalt/lava_land_surface,
-/area/ruin/unpowered/xenonest)
-"q" = (
-/obj/structure/alien/weeds,
 /turf/open/floor/plating/asteroid/basalt/lava_land_surface,
 /area/ruin/unpowered/xenonest)
 "r" = (
@@ -107,16 +74,6 @@
 /obj/effect/decal/cleanable/blood,
 /turf/open/floor/plating/asteroid/basalt/lava_land_surface,
 /area/ruin/unpowered/xenonest)
-"w" = (
-/obj/structure/alien/weeds,
-/obj/effect/decal/cleanable/blood/gibs,
-/turf/open/floor/plating/asteroid/basalt/lava_land_surface,
-/area/ruin/unpowered/xenonest)
-"x" = (
-/obj/structure/alien/weeds,
-/obj/structure/alien/egg/burst,
-/turf/open/floor/plating/asteroid/basalt/lava_land_surface,
-/area/ruin/unpowered/xenonest)
 "y" = (
 /obj/structure/alien/weeds/node,
 /obj/structure/alien/resin/wall,
@@ -133,11 +90,6 @@
 /obj/item/clothing/head/helmet,
 /turf/open/floor/plating/asteroid/basalt/lava_land_surface,
 /area/ruin/unpowered/xenonest)
-"A" = (
-/obj/structure/alien/weeds,
-/obj/structure/alien/egg,
-/turf/open/floor/plating/asteroid/basalt/lava_land_surface,
-/area/ruin/unpowered/xenonest)
 "B" = (
 /obj/structure/alien/weeds,
 /obj/structure/alien/egg/burst,
@@ -148,11 +100,6 @@
 /obj/structure/alien/weeds,
 /obj/structure/alien/egg/burst,
 /obj/effect/decal/cleanable/blood,
-/turf/open/floor/plating/asteroid/basalt/lava_land_surface,
-/area/ruin/unpowered/xenonest)
-"D" = (
-/obj/structure/alien/weeds,
-/obj/effect/decal/cleanable/blood/gibs,
 /turf/open/floor/plating/asteroid/basalt/lava_land_surface,
 /area/ruin/unpowered/xenonest)
 "E" = (
@@ -172,13 +119,6 @@
 	},
 /turf/open/floor/plating/asteroid/basalt/lava_land_surface,
 /area/ruin/unpowered/xenonest)
-"G" = (
-/obj/structure/alien/weeds,
-/mob/living/simple_animal/hostile/alien/drone{
-	plants_off = 1
-	},
-/turf/open/floor/plating/asteroid/basalt/lava_land_surface,
-/area/ruin/unpowered/xenonest)
 "H" = (
 /obj/structure/alien/weeds,
 /obj/effect/decal/cleanable/blood,
@@ -192,11 +132,6 @@
 /obj/item/clothing/mask/facehugger/impregnated,
 /obj/item/clothing/under/syndicate,
 /obj/item/clothing/glasses/night,
-/turf/open/floor/plating/asteroid/basalt/lava_land_surface,
-/area/ruin/unpowered/xenonest)
-"J" = (
-/obj/structure/alien/weeds,
-/mob/living/simple_animal/hostile/alien/sentinel,
 /turf/open/floor/plating/asteroid/basalt/lava_land_surface,
 /area/ruin/unpowered/xenonest)
 "K" = (
@@ -222,20 +157,10 @@
 /obj/item/clothing/mask/facehugger/impregnated,
 /turf/open/floor/plating/asteroid/basalt/lava_land_surface,
 /area/ruin/unpowered/xenonest)
-"N" = (
-/obj/structure/alien/weeds,
-/obj/structure/alien/resin/wall,
-/turf/template_noop,
-/area/template_noop)
 "O" = (
 /obj/structure/alien/weeds/node,
 /turf/template_noop,
 /area/ruin/unpowered/xenonest)
-"P" = (
-/obj/structure/alien/weeds,
-/obj/structure/alien/resin/wall,
-/turf/template_noop,
-/area/template_noop)
 "Q" = (
 /obj/structure/alien/weeds,
 /obj/effect/decal/cleanable/blood,
@@ -247,30 +172,6 @@
 "R" = (
 /obj/structure/alien/weeds,
 /turf/template_noop,
-/area/ruin/unpowered/xenonest)
-"S" = (
-/obj/structure/alien/weeds,
-/turf/template_noop,
-/area/ruin/unpowered/xenonest)
-"T" = (
-/obj/structure/alien/weeds/node,
-/obj/structure/alien/resin/wall,
-/turf/template_noop,
-/area/template_noop)
-"U" = (
-/obj/structure/alien/weeds,
-/obj/structure/alien/resin/wall,
-/turf/template_noop,
-/area/template_noop)
-"V" = (
-/obj/structure/alien/weeds,
-/turf/template_noop,
-/area/template_noop)
-"W" = (
-/obj/structure/alien/weeds,
-/obj/structure/alien/resin/wall,
-/obj/effect/baseturf_helper/lava_land/surface,
-/turf/open/floor/plating/asteroid/basalt/lava_land_surface,
 /area/ruin/unpowered/xenonest)
 
 (1,1,1) = {"
@@ -861,7 +762,7 @@ b
 g
 g
 g
-W
+b
 g
 g
 g

--- a/code/__DEFINES/turf_flags.dm
+++ b/code/__DEFINES/turf_flags.dm
@@ -1,3 +1,4 @@
 #define CHANGETURF_DEFER_CHANGE		1
 #define CHANGETURF_IGNORE_AIR		2
 #define CHANGETURF_FORCEOP			4
+#define CHANGETURF_SKIP				8 // A flag for PlaceOnTop to just instance the new turf instead of calling ChangeTurf. Used for uninitialized turfs NOTHING ELSE

--- a/code/game/turfs/ChangeTurf.dm
+++ b/code/game/turfs/ChangeTurf.dm
@@ -55,6 +55,8 @@ GLOBAL_LIST_INIT(blacklisted_automated_baseturfs, typecacheof(list(
 		path = /turf/open/space
 	if(!GLOB.use_preloader && path == type && !(flags & CHANGETURF_FORCEOP)) // Don't no-op if the map loader requires it to be reconstructed
 		return src
+	if(flags & CHANGETURF_SKIP)
+		return new path(src)
 
 	var/old_opacity = opacity
 	var/old_dynamic_lighting = dynamic_lighting
@@ -150,15 +152,21 @@ GLOBAL_LIST_INIT(blacklisted_automated_baseturfs, typecacheof(list(
 
 // Make a new turf and put it on top
 // The args behave identical to PlaceOnBottom except they go on top
+// Things placed on top of closed turfs will ignore the topmost closed turf
 // Returns the new turf
 /turf/proc/PlaceOnTop(list/new_baseturfs, turf/fake_turf_type, flags)
 	var/turf/newT
+	if(flags & CHANGETURF_SKIP) // We haven't been initialized
+		if(initialized)
+			stack_trace("CHANGETURF_SKIP was used in a PlaceOnTop call for a turf that's initialized. This is a mistake. [src]([type])")
+		assemble_baseturfs()
 	if(fake_turf_type)
 		if(!new_baseturfs) // If no baseturfs list then we want to create one from the turf type
 			if(!length(baseturfs))
 				baseturfs = list(baseturfs)
 			var/list/old_baseturfs = baseturfs.Copy()
-			old_baseturfs += type
+			if(!istype(src, /turf/closed))
+				old_baseturfs += type
 			newT = ChangeTurf(fake_turf_type, null, flags)
 			newT.assemble_baseturfs(initial(fake_turf_type.baseturfs)) // The baseturfs list is created like roundstart
 			if(!length(newT.baseturfs))
@@ -168,12 +176,14 @@ GLOBAL_LIST_INIT(blacklisted_automated_baseturfs, typecacheof(list(
 			return newT
 		if(!length(baseturfs))
 			baseturfs = list(baseturfs)
-		baseturfs += type
+		if(!istype(src, /turf/closed))
+			baseturfs += type
 		baseturfs += new_baseturfs
 		return ChangeTurf(fake_turf_type, null, flags)
 	if(!length(baseturfs))
 		baseturfs = list(baseturfs)
-	baseturfs += type
+	if(!istype(src, /turf/closed))
+		baseturfs += type
 	var/turf/change_type
 	if(length(new_baseturfs))
 		change_type = new_baseturfs[new_baseturfs.len]

--- a/code/game/turfs/simulated/minerals.dm
+++ b/code/game/turfs/simulated/minerals.dm
@@ -171,7 +171,7 @@
 /turf/closed/mineral/random/high_chance/volcanic
 	environment_type = "basalt"
 	turf_type = /turf/open/floor/plating/asteroid/basalt/lava_land_surface
-	baseturfs = /turf/open/lava/smooth/lava_land_surface
+	baseturfs = /turf/open/floor/plating/asteroid/basalt/lava_land_surface
 	initial_gas_mix = LAVALAND_DEFAULT_ATMOS
 	defer_change = 1
 	mineralSpawnChanceList = list(
@@ -192,7 +192,7 @@
 /turf/closed/mineral/random/volcanic
 	environment_type = "basalt"
 	turf_type = /turf/open/floor/plating/asteroid/basalt/lava_land_surface
-	baseturfs = /turf/open/lava/smooth/lava_land_surface
+	baseturfs = /turf/open/floor/plating/asteroid/basalt/lava_land_surface
 	initial_gas_mix = LAVALAND_DEFAULT_ATMOS
 	defer_change = 1
 
@@ -214,7 +214,7 @@
 /turf/closed/mineral/random/labormineral/volcanic
 	environment_type = "basalt"
 	turf_type = /turf/open/floor/plating/asteroid/basalt/lava_land_surface
-	baseturfs = /turf/open/lava/smooth/lava_land_surface
+	baseturfs = /turf/open/floor/plating/asteroid/basalt/lava_land_surface
 	initial_gas_mix = LAVALAND_DEFAULT_ATMOS
 	defer_change = 1
 	mineralSpawnChanceList = list(
@@ -354,7 +354,7 @@
 /turf/closed/mineral/volcanic/lava_land_surface
 	environment_type = "basalt"
 	turf_type = /turf/open/floor/plating/asteroid/basalt/lava_land_surface
-	baseturfs = /turf/open/lava/smooth/lava_land_surface
+	baseturfs = /turf/open/floor/plating/asteroid/basalt/lava_land_surface
 	defer_change = 1
 
 /turf/closed/mineral/ash_rock //wall piece

--- a/code/modules/mapping/map_template.dm
+++ b/code/modules/mapping/map_template.dm
@@ -53,7 +53,7 @@
 	var/y = round((world.maxy - height)/2)
 
 	var/datum/space_level/level = SSmapping.add_new_zlevel(name, UNAFFECTED, list(ZTRAIT_AWAY = TRUE))
-	var/list/bounds = maploader.load_map(file(mappath), x, y, level.z_value, no_changeturf=(SSatoms.initialized == INITIALIZATION_INSSATOMS))
+	var/list/bounds = maploader.load_map(file(mappath), x, y, level.z_value, no_changeturf=(SSatoms.initialized == INITIALIZATION_INSSATOMS), placeOnTop=TRUE)
 	if(!bounds)
 		return FALSE
 
@@ -75,7 +75,7 @@
 	if(T.y+height > world.maxy)
 		return
 
-	var/list/bounds = maploader.load_map(file(mappath), T.x, T.y, T.z, cropMap=TRUE, no_changeturf=(SSatoms.initialized == INITIALIZATION_INSSATOMS))
+	var/list/bounds = maploader.load_map(file(mappath), T.x, T.y, T.z, cropMap=TRUE, no_changeturf=(SSatoms.initialized == INITIALIZATION_INSSATOMS), placeOnTop=TRUE)
 	if(!bounds)
 		return
 

--- a/code/modules/mapping/reader.dm
+++ b/code/modules/mapping/reader.dm
@@ -29,21 +29,21 @@ GLOBAL_DATUM_INIT(_preloader, /dmm_suite/preloader, new)
  * 2) Read the map line by line, parsing the result (using parse_grid)
  *
  */
-/dmm_suite/load_map(dmm_file as file, x_offset as num, y_offset as num, z_offset as num, cropMap as num, measureOnly as num, no_changeturf as num, lower_crop_x as num,  lower_crop_y as num, upper_crop_x as num, upper_crop_y as num)
+/dmm_suite/load_map(dmm_file as file, x_offset as num, y_offset as num, z_offset as num, cropMap as num, measureOnly as num, no_changeturf as num, lower_crop_x as num,  lower_crop_y as num, upper_crop_x as num, upper_crop_y as num, placeOnTop as num)
 	//How I wish for RAII
 	Master.StartLoadingMap()
 	space_key = null
 	#ifdef TESTING
 	turfsSkipped = 0
 	#endif
-	. = load_map_impl(dmm_file, x_offset, y_offset, z_offset, cropMap, measureOnly, no_changeturf, lower_crop_x, upper_crop_x, lower_crop_y, upper_crop_y)
+	. = load_map_impl(dmm_file, x_offset, y_offset, z_offset, cropMap, measureOnly, no_changeturf, lower_crop_x, upper_crop_x, lower_crop_y, upper_crop_y, placeOnTop)
 	#ifdef TESTING
 	if(turfsSkipped)
 		testing("Skipped loading [turfsSkipped] default turfs")
 	#endif
 	Master.StopLoadingMap()
 
-/dmm_suite/proc/load_map_impl(dmm_file, x_offset, y_offset, z_offset, cropMap, measureOnly, no_changeturf, x_lower = -INFINITY, x_upper = INFINITY, y_lower = -INFINITY, y_upper = INFINITY)
+/dmm_suite/proc/load_map_impl(dmm_file, x_offset, y_offset, z_offset, cropMap, measureOnly, no_changeturf, x_lower = -INFINITY, x_upper = INFINITY, y_lower = -INFINITY, y_upper = INFINITY, placeOnTop = FALSE)
 	var/tfile = dmm_file//the map file we're creating
 	if(isfile(tfile))
 		tfile = file2text(tfile)
@@ -156,7 +156,7 @@ GLOBAL_DATUM_INIT(_preloader, /dmm_suite/preloader, new)
 								if(!no_afterchange || (model_key != space_key))
 									if(!grid_models[model_key])
 										throw EXCEPTION("Undefined model key in DMM.")
-									parse_grid(grid_models[model_key], model_key, xcrd, ycrd, zcrd, no_changeturf || zexpansion)
+									parse_grid(grid_models[model_key], model_key, xcrd, ycrd, zcrd, no_changeturf || zexpansion, placeOnTop)
 								#ifdef TESTING
 								else
 									++turfsSkipped
@@ -198,7 +198,7 @@ GLOBAL_DATUM_INIT(_preloader, /dmm_suite/preloader, new)
  * 4) Instanciates the atom with its variables
  *
  */
-/dmm_suite/proc/parse_grid(model as text, model_key as text, xcrd as num,ycrd as num,zcrd as num, no_changeturf as num)
+/dmm_suite/proc/parse_grid(model as text, model_key as text, xcrd as num,ycrd as num,zcrd as num, no_changeturf as num, placeOnTop as num)
 	/*Method parse_grid()
 	- Accepts a text string containing a comma separated list of type paths of the
 		same construction as those contained in a .dmm file, and instantiates them.
@@ -312,20 +312,20 @@ GLOBAL_DATUM_INIT(_preloader, /dmm_suite/preloader, new)
 	//instanciate the first /turf
 	var/turf/T
 	if(members[first_turf_index] != /turf/template_noop)
-		T = instance_atom(members[first_turf_index],members_attributes[first_turf_index],crds,no_changeturf)
+		T = instance_atom(members[first_turf_index],members_attributes[first_turf_index],crds,no_changeturf,placeOnTop)
 
 	if(T)
 		//if others /turf are presents, simulates the underlays piling effect
 		index = first_turf_index + 1
 		while(index <= members.len - 1) // Last item is an /area
 			var/underlay = T.appearance
-			T = instance_atom(members[index],members_attributes[index],crds,no_changeturf)//instance new turf
+			T = instance_atom(members[index],members_attributes[index],crds,no_changeturf,placeOnTop)//instance new turf
 			T.underlays += underlay
 			index++
 
 	//finally instance all remainings objects/mobs
 	for(index in 1 to first_turf_index-1)
-		instance_atom(members[index],members_attributes[index],crds,no_changeturf)
+		instance_atom(members[index],members_attributes[index],crds,no_changeturf,placeOnTop)
 	//Restore initialization to the previous value
 	SSatoms.map_loader_stop()
 
@@ -334,12 +334,15 @@ GLOBAL_DATUM_INIT(_preloader, /dmm_suite/preloader, new)
 ////////////////
 
 //Instance an atom at (x,y,z) and gives it the variables in attributes
-/dmm_suite/proc/instance_atom(path,list/attributes, turf/crds, no_changeturf)
+/dmm_suite/proc/instance_atom(path,list/attributes, turf/crds, no_changeturf, placeOnTop)
 	GLOB._preloader.setup(attributes, path)
 
 	if(crds)
 		if(!no_changeturf && ispath(path, /turf))
-			. = crds.ChangeTurf(path, null, CHANGETURF_DEFER_CHANGE)
+			if(placeOnTop)
+				. = crds.PlaceOnTop(null, path, CHANGETURF_DEFER_CHANGE)
+			else
+				. = crds.ChangeTurf(path, null, CHANGETURF_DEFER_CHANGE)
 		else
 			. = create_atom(path, crds)//first preloader pass
 

--- a/code/modules/mapping/reader.dm
+++ b/code/modules/mapping/reader.dm
@@ -338,11 +338,13 @@ GLOBAL_DATUM_INIT(_preloader, /dmm_suite/preloader, new)
 	GLOB._preloader.setup(attributes, path)
 
 	if(crds)
-		if(!no_changeturf && ispath(path, /turf))
+		if(ispath(path, /turf))
 			if(placeOnTop)
-				. = crds.PlaceOnTop(null, path, CHANGETURF_DEFER_CHANGE)
-			else
+				. = crds.PlaceOnTop(null, path, CHANGETURF_DEFER_CHANGE | (no_changeturf ? CHANGETURF_SKIP : NONE))
+			else if(!no_changeturf)
 				. = crds.ChangeTurf(path, null, CHANGETURF_DEFER_CHANGE)
+			else
+				. = create_atom(path, crds)//first preloader pass
 		else
 			. = create_atom(path, crds)//first preloader pass
 


### PR DESCRIPTION
:cl: ninjanomnom
fix: Loaded templates now get placed on top of existing terrain so as to preserve baseturfs. This fixes survival pods walls breaking to lava as well as allows some future fixes.
/:cl:

fixes #34586

This edits reader.dm. I tested and it seems to work fine but for the love of all that's holy a testmerge needs to happen to verify.