### PR TITLE
Adds killstreaks

### DIFF
--- a/code/datums/mind.dm
+++ b/code/datums/mind.dm
@@ -81,6 +81,8 @@
 			world << "<B>[name] is WICKED SICK!!</B>"
 		if(13)
 			world << "<B>[name] is GODLIKE!</B>"
+		if(15)
+			world << "<B>[name] is a KILLIONAIRE!</B>"
 
 /datum/mind/New(var/key)
 	src.key = key

--- a/code/datums/mind.dm
+++ b/code/datums/mind.dm
@@ -65,6 +65,22 @@
 	var/datum/language_holder/language_holder
 	var/unconvertable = FALSE
 	var/late_joiner = FALSE
+	var/kill_streak = 0 //How many kills we have
+
+/datum/mind/proc/kill_streak_act()
+	switch(kill_streak)
+		if(3)
+			world << "<B>[name] is on a killing spree!</B>"
+		if(5)
+			world << "<B>[name] is dominating!</B>"
+		if(7)
+			world << "<B>[name] got a MEGA KILL!</B>"
+		if(9)
+			world << "<B>[name] is UNSTOPPABLE!</B>"
+		if(11)
+			world << "<B>[name] is WICKED SICK!!</B>"
+		if(13)
+			world << "<B>[name] is GODLIKE!</B>"
 
 /datum/mind/New(var/key)
 	src.key = key
@@ -111,7 +127,7 @@
 	if(current)
 		current.transfer_observers_to(new_character)	//transfer anyone observing the old character to the new one
 	current = new_character								//associate ourself with our new body
-	new_character.mind = src							//and associate our new body with ourself		
+	new_character.mind = src							//and associate our new body with ourself
 	for(var/a in antag_datums)	//Makes sure all antag datums effects are applied in the new body
 		var/datum/antagonist/A = a
 		A.on_body_transfer(old_current, current)

--- a/code/modules/mob/living/carbon/death.dm
+++ b/code/modules/mob/living/carbon/death.dm
@@ -7,6 +7,12 @@
 
 	if(!gibbed)
 		emote("deathgasp")
+	if(istype(LAssailant, /mob/living))
+		var/mob/living/L = LAssailant
+		if(L.mind && LAssailant != src)
+			L.mind.kill_streak++
+			L.mind.kill_streak_act()
+
 
 	. = ..()
 	if(SSticker.mode)

--- a/code/modules/mob/living/carbon/human/human_defense.dm
+++ b/code/modules/mob/living/carbon/human/human_defense.dm
@@ -77,6 +77,7 @@
 
 				return -1 // complete projectile permutation
 
+		LAssailant = P.firer
 		if(check_shields(P, P.damage, "the [P.name]", PROJECTILE_ATTACK, P.armour_penetration))
 			P.on_hit(src, 100, def_zone)
 			return 2
@@ -128,6 +129,7 @@
 		throwpower = I.throwforce
 		if(I.thrownby == src) //No throwing stuff at yourself to trigger hit reactions
 			return ..()
+		LAssailant = I.thrownby
 	if(check_shields(AM, throwpower, "\the [AM.name]", THROWN_PROJECTILE_ATTACK))
 		hitpush = FALSE
 		skipcatch = TRUE
@@ -164,6 +166,7 @@
 	if(!I || !user)
 		return 0
 
+	LAssailant = user
 	var/obj/item/bodypart/affecting
 	if(user == src)
 		affecting = get_bodypart(check_zone(user.zone_selected)) //stabbing yourself always hits the right target


### PR DESCRIPTION
:cl:
add: Centcom now offers kill tracking, courtesy of their MLG360PRO subsidiary.
/:cl:
![image](https://user-images.githubusercontent.com/16315400/35137527-e4eccfac-fcb7-11e7-89d1-c4e853176d2d.png)
tOO LATE

Open to suggestions for more killstreak names. Shamelessly copied from #14059, credit KorPhaeron.