### PR TITLE
Refactor weather to use Z traits, assorted related cleanup

### DIFF
--- a/code/__DEFINES/maps.dm
+++ b/code/__DEFINES/maps.dm
@@ -49,6 +49,7 @@ Last space-z level = empty
 #define ZLEVEL_SPACE_RUIN_COUNT 5
 
 // traits
+// boolean - marks a level as having that property if present
 #define ZTRAIT_CENTCOM "CentCom"
 #define ZTRAIT_STATION "Station"
 #define ZTRAIT_MINING "Mining"
@@ -57,6 +58,7 @@ Last space-z level = empty
 #define ZTRAIT_AWAY "Away Mission"
 #define ZTRAIT_SPACE_RUINS "Space Ruins"
 #define ZTRAIT_LAVA_RUINS "Lava Ruins"
+// number - bombcap is multiplied by this before being applied to bombs
 #define ZTRAIT_BOMBCAP_MULTIPLIER "Bombcap Multiplier"
 
 // trait definitions

--- a/code/__DEFINES/maps.dm
+++ b/code/__DEFINES/maps.dm
@@ -37,7 +37,6 @@ Last space-z level = empty
 
 //zlevel defines, can be overridden for different maps in the appropriate _maps file.
 #define ZLEVEL_STATION_PRIMARY 2
-#define ZLEVEL_LAVALAND 5
 #define ZLEVEL_EMPTY_SPACE 12
 //Unless you modify it in map config should be equal to ZLEVEL_SPACEMAX
 #define ZLEVEL_TRANSIT 13

--- a/code/__DEFINES/maps.dm
+++ b/code/__DEFINES/maps.dm
@@ -38,11 +38,6 @@ Last space-z level = empty
 //zlevel defines, can be overridden for different maps in the appropriate _maps file.
 #define ZLEVEL_STATION_PRIMARY 2
 #define ZLEVEL_EMPTY_SPACE 12
-//Unless you modify it in map config should be equal to ZLEVEL_SPACEMAX
-#define ZLEVEL_TRANSIT 13
-
-#define ZLEVEL_SPACEMIN 3
-#define ZLEVEL_SPACEMAX 13
 
 #define SPACERUIN_MAP_EDGE_PAD 15
 #define ZLEVEL_SPACE_RUIN_COUNT 5

--- a/code/__HELPERS/unsorted.dm
+++ b/code/__HELPERS/unsorted.dm
@@ -1199,19 +1199,6 @@ B --><-- A
 	sleep(duration)
 	A.cut_overlay(O)
 
-/proc/get_areas_in_z(zlevel)
-	. = list()
-	var/validarea = FALSE
-	for(var/V in GLOB.sortedAreas)
-		var/area/A = V
-		validarea = TRUE
-		for(var/turf/T in A)
-			if(T.z != zlevel)
-				validarea = FALSE
-				break
-		if(validarea)
-			. += A
-
 /proc/get_closest_atom(type, list, source)
 	var/closest_atom
 	var/closest_distance

--- a/code/_globalvars/lists/mapping.dm
+++ b/code/_globalvars/lists/mapping.dm
@@ -2,17 +2,6 @@ GLOBAL_LIST_INIT(cardinals, list(NORTH, SOUTH, EAST, WEST))
 GLOBAL_LIST_INIT(alldirs, list(NORTH, SOUTH, EAST, WEST, NORTHEAST, NORTHWEST, SOUTHEAST, SOUTHWEST))
 GLOBAL_LIST_INIT(diagonals, list(NORTHEAST, NORTHWEST, SOUTHEAST, SOUTHWEST))
 
-GLOBAL_LIST(global_map)
-	//list/global_map = list(list(1,5),list(4,3))//an array of map Z levels.
-	//Resulting sector map looks like
-	//|_1_|_4_|
-	//|_5_|_3_|
-	//
-	//1 - SS13
-	//4 - Derelict
-	//3 - AI satellite
-	//5 - empty space
-
 GLOBAL_LIST_EMPTY(landmarks_list)				//list of all landmarks created
 GLOBAL_LIST_EMPTY(start_landmarks_list)			//list of all spawn points created
 GLOBAL_LIST_EMPTY(department_security_spawns)	//list of all department security spawns

--- a/code/controllers/subsystem/mapping.dm
+++ b/code/controllers/subsystem/mapping.dm
@@ -24,6 +24,7 @@ SUBSYSTEM_DEF(mapping)
 
 	// Z-manager stuff
 	var/list/z_list
+	var/datum/space_level/transit
 
 /datum/controller/subsystem/mapping/PreInit()
 	if(!config)
@@ -47,7 +48,7 @@ SUBSYSTEM_DEF(mapping)
 	for(var/I in 1 to ZLEVEL_SPACE_RUIN_COUNT)
 		add_new_zlevel("Empty Area [2 + I]", CROSSLINKED, list(ZTRAIT_SPACE_RUINS = TRUE))
 	add_new_zlevel("Empty Area [3 + ZLEVEL_SPACE_RUIN_COUNT]", CROSSLINKED, list())  // no ruins
-	add_new_zlevel("Transit", UNAFFECTED, list(ZTRAIT_TRANSIT = TRUE))
+	transit = add_new_zlevel("Transit", UNAFFECTED, list(ZTRAIT_TRANSIT = TRUE))
 
 	// Pick a random away mission.
 	createRandomZlevel()

--- a/code/controllers/subsystem/mapping.dm
+++ b/code/controllers/subsystem/mapping.dm
@@ -52,8 +52,6 @@ SUBSYSTEM_DEF(mapping)
 
 	// Pick a random away mission.
 	createRandomZlevel()
-	if (z_list.len < world.maxz)
-		add_new_zlevel("Away Mission", UNAFFECTED, list(ZTRAIT_AWAY = TRUE))
 
 	// Generate mining ruins
 	loading_ruins = TRUE

--- a/code/controllers/subsystem/shuttle.dm
+++ b/code/controllers/subsystem/shuttle.dm
@@ -82,8 +82,9 @@ SUBSYSTEM_DEF(shuttle)
 
 /datum/controller/subsystem/shuttle/proc/setup_transit_zone()
 	// transit zone
-	var/turf/A = get_turf(locate(SHUTTLE_TRANSIT_BORDER,SHUTTLE_TRANSIT_BORDER,ZLEVEL_TRANSIT))
-	var/turf/B = get_turf(locate(world.maxx - SHUTTLE_TRANSIT_BORDER,world.maxy - SHUTTLE_TRANSIT_BORDER,ZLEVEL_TRANSIT))
+	var/z = SSmapping.transit.z_value
+	var/turf/A = get_turf(locate(SHUTTLE_TRANSIT_BORDER,SHUTTLE_TRANSIT_BORDER,z))
+	var/turf/B = get_turf(locate(world.maxx - SHUTTLE_TRANSIT_BORDER,world.maxy - SHUTTLE_TRANSIT_BORDER,z))
 	for(var/i in block(A, B))
 		var/turf/T = i
 		T.ChangeTurf(/turf/open/space)
@@ -92,8 +93,9 @@ SUBSYSTEM_DEF(shuttle)
 
 #ifdef HIGHLIGHT_DYNAMIC_TRANSIT
 /datum/controller/subsystem/shuttle/proc/color_space()
-	var/turf/A = get_turf(locate(SHUTTLE_TRANSIT_BORDER,SHUTTLE_TRANSIT_BORDER,ZLEVEL_TRANSIT))
-	var/turf/B = get_turf(locate(world.maxx - SHUTTLE_TRANSIT_BORDER,world.maxy - SHUTTLE_TRANSIT_BORDER,ZLEVEL_TRANSIT))
+	var/z = SSmapping.transit.z_value
+	var/turf/A = get_turf(locate(SHUTTLE_TRANSIT_BORDER,SHUTTLE_TRANSIT_BORDER,z))
+	var/turf/B = get_turf(locate(world.maxx - SHUTTLE_TRANSIT_BORDER,world.maxy - SHUTTLE_TRANSIT_BORDER,z))
 	for(var/i in block(A, B))
 		var/turf/T = i
 		// Only dying the "pure" space, not the transit tiles

--- a/code/datums/weather/weather.dm
+++ b/code/datums/weather/weather.dm
@@ -1,10 +1,5 @@
 //The effects of weather occur across an entire z-level. For instance, lavaland has periodic ash storms that scorch most unprotected creatures.
 
-#define STARTUP_STAGE 1
-#define MAIN_STAGE 2
-#define WIND_DOWN_STAGE 3
-#define END_STAGE 4
-
 /datum/weather
 	var/name = "space wind"
 	var/desc = "Heavy gusts of wind blanket the area, periodically knocking down anyone caught in the open."
@@ -30,7 +25,7 @@
 	var/area_type = /area/space //Types of area to affect
 	var/list/impacted_areas = list() //Areas to be affected by the weather, calculated when the weather begins
 	var/list/protected_areas = list()//Areas that are protected and excluded from the affected areas.
-	var/target_z = ZLEVEL_STATION_PRIMARY //The z-level to affect
+	var/impacted_z_levels // The list of z-levels that this weather is actively affecting
 
 	var/overlay_layer = AREA_LAYER //Since it's above everything else, this is the layer used by default. TURF_LAYER is below mobs and walls if you need to use that.
 	var/aesthetic = FALSE //If the weather has no purpose other than looks
@@ -38,15 +33,13 @@
 
 	var/stage = END_STAGE //The stage of the weather, from 1-4
 
-	var/probability = FALSE //Percent chance to happen if there are other possible weathers on the z-level
+	// These are read by the weather subsystem and used to determine when and where to run the weather.
+	var/probability = 0 // Weight amongst other eligible weather. If zero, will never happen randomly.
+	var/target_trait = ZTRAIT_STATION // The z-level trait to affect when run randomly or when not overridden.
 
-/datum/weather/New()
+/datum/weather/New(z_levels)
 	..()
-	SSweather.existing_weather += src
-
-/datum/weather/Destroy()
-	SSweather.existing_weather -= src
-	..()
+	impacted_z_levels = z_levels
 
 /datum/weather/proc/telegraph()
 	if(stage == STARTUP_STAGE)
@@ -59,13 +52,14 @@
 		affectareas -= get_areas(V)
 	for(var/V in affectareas)
 		var/area/A = V
-		if(A.z == target_z)
+		if(A.z in impacted_z_levels)
 			impacted_areas |= A
 	weather_duration = rand(weather_duration_lower, weather_duration_upper)
+	START_PROCESSING(SSweather, src)
 	update_areas()
-	for(var/V in GLOB.player_list)
-		var/mob/M = V
-		if(M.z == target_z)
+	for(var/M in GLOB.player_list)
+		var/turf/mob_turf = get_turf(M)
+		if(mob_turf && (mob_turf.z in impacted_z_levels))
 			if(telegraph_message)
 				to_chat(M, telegraph_message)
 			if(telegraph_sound)
@@ -77,14 +71,13 @@
 		return
 	stage = MAIN_STAGE
 	update_areas()
-	for(var/V in GLOB.player_list)
-		var/mob/M = V
-		if(M.z == target_z)
+	for(var/M in GLOB.player_list)
+		var/turf/mob_turf = get_turf(M)
+		if(mob_turf && (mob_turf.z in impacted_z_levels))
 			if(weather_message)
 				to_chat(M, weather_message)
 			if(weather_sound)
 				SEND_SOUND(M, sound(weather_sound))
-	START_PROCESSING(SSweather, src)
 	addtimer(CALLBACK(src, .proc/wind_down), weather_duration)
 
 /datum/weather/proc/wind_down()
@@ -92,25 +85,25 @@
 		return
 	stage = WIND_DOWN_STAGE
 	update_areas()
-	for(var/V in GLOB.player_list)
-		var/mob/M = V
-		if(M.z == target_z)
+	for(var/M in GLOB.player_list)
+		var/turf/mob_turf = get_turf(M)
+		if(mob_turf && (mob_turf.z in impacted_z_levels))
 			if(end_message)
 				to_chat(M, end_message)
 			if(end_sound)
 				SEND_SOUND(M, sound(end_sound))
-	STOP_PROCESSING(SSweather, src)
 	addtimer(CALLBACK(src, .proc/end), end_duration)
 
 /datum/weather/proc/end()
 	if(stage == END_STAGE)
 		return 1
 	stage = END_STAGE
+	STOP_PROCESSING(SSweather, src)
 	update_areas()
 
 /datum/weather/proc/can_weather_act(mob/living/L) //Can this weather impact a mob?
 	var/turf/mob_turf = get_turf(L)
-	if(mob_turf && (mob_turf.z != target_z))
+	if(mob_turf && !(mob_turf.z in impacted_z_levels))
 		return
 	if(immunity_type in L.weather_immunities)
 		return

--- a/code/datums/weather/weather_types/acid_rain.dm
+++ b/code/datums/weather/weather_types/acid_rain.dm
@@ -18,7 +18,7 @@
 	end_sound = 'sound/ambience/acidrain_end.ogg'
 
 	area_type = /area/lavaland/surface/outdoors
-	target_z = ZLEVEL_LAVALAND
+	target_trait = ZTRAIT_MINING
 
 	immunity_type = "acid" // temp
 

--- a/code/datums/weather/weather_types/advanced_darkness.dm
+++ b/code/datums/weather/weather_types/advanced_darkness.dm
@@ -14,7 +14,7 @@
 	end_duration = 0
 
 	area_type = /area
-	target_z = ZLEVEL_STATION_PRIMARY
+	target_trait = ZTRAIT_STATION
 
 /datum/weather/advanced_darkness/update_areas()
 	for(var/V in impacted_areas)

--- a/code/datums/weather/weather_types/ash_storm.dm
+++ b/code/datums/weather/weather_types/ash_storm.dm
@@ -17,7 +17,7 @@
 	end_overlay = "light_ash"
 
 	area_type = /area/lavaland/surface/outdoors
-	target_z = ZLEVEL_LAVALAND
+	target_trait = ZTRAIT_MINING
 
 	immunity_type = "ash"
 
@@ -32,7 +32,9 @@
 	. = ..()
 	var/list/inside_areas = list()
 	var/list/outside_areas = list()
-	var/list/eligible_areas = SSmapping.areas_in_z["[target_z]"]
+	var/list/eligible_areas = list()
+	for (var/z in impacted_z_levels)
+		eligible_areas += SSmapping.areas_in_z["[z]"]
 	for(var/i in 1 to eligible_areas.len)
 		var/area/place = eligible_areas[i]
 		if(place.outdoors)

--- a/code/datums/weather/weather_types/floor_is_lava.dm
+++ b/code/datums/weather/weather_types/floor_is_lava.dm
@@ -16,14 +16,14 @@
 
 	area_type = /area
 	protected_areas = list(/area/space)
-	target_z = ZLEVEL_STATION_PRIMARY
+	target_trait = ZTRAIT_STATION
 
 	overlay_layer = ABOVE_OPEN_TURF_LAYER //Covers floors only
 	immunity_type = "lava"
-	
+
 
 /datum/weather/floor_is_lava/weather_act(mob/living/L)
-	for(var/obj/structure/O in L.loc)			
+	for(var/obj/structure/O in L.loc)
 		if(O.density || (L in O.buckled_mobs && istype(O, /obj/structure/bed)))
 			return
 	if(L.loc.density)

--- a/code/datums/weather/weather_types/radiation_storm.dm
+++ b/code/datums/weather/weather_types/radiation_storm.dm
@@ -19,7 +19,7 @@
 	area_type = /area
 	protected_areas = list(/area/maintenance, /area/ai_monitored/turret_protected/ai_upload, /area/ai_monitored/turret_protected/ai_upload_foyer,
 	/area/ai_monitored/turret_protected/ai, /area/storage/emergency/starboard, /area/storage/emergency/port, /area/shuttle)
-	target_z = ZLEVEL_STATION_PRIMARY
+	target_trait = ZTRAIT_STATION
 
 	immunity_type = "rad"
 

--- a/code/game/area/areas.dm
+++ b/code/game/area/areas.dm
@@ -384,9 +384,9 @@ GLOBAL_LIST_EMPTY(teleportlocs)
 			icon_state = "blue-red"
 	else
 		var/weather_icon
-		for(var/V in SSweather.existing_weather)
+		for(var/V in SSweather.processing)
 			var/datum/weather/W = V
-			if(src in W.impacted_areas)
+			if(W.stage != END_STAGE && (src in W.impacted_areas))
 				W.update_areas()
 				weather_icon = TRUE
 		if(!weather_icon)

--- a/code/game/atoms_movable.dm
+++ b/code/game/atoms_movable.dm
@@ -646,7 +646,7 @@
 		flags_2 |= STATIONLOVING_2
 
 /atom/movable/proc/relocate()
-	var/targetturf = find_safe_turf(ZLEVEL_STATION_PRIMARY)
+	var/targetturf = find_safe_turf()
 	if(!targetturf)
 		if(GLOB.blobstart.len > 0)
 			targetturf = get_turf(pick(GLOB.blobstart))

--- a/code/game/gamemodes/clock_cult/clock_structures/ark_of_the_clockwork_justicar.dm
+++ b/code/game/gamemodes/clock_cult/clock_structures/ark_of_the_clockwork_justicar.dm
@@ -324,7 +324,7 @@
 				QDEL_IN(src, 3)
 				sleep(3)
 				GLOB.clockwork_gateway_activated = TRUE
-				var/turf/T =  locate(round(world.maxx * 0.5, 1), round(world.maxy * 0.5, 1), ZLEVEL_STATION_PRIMARY) //approximate center of the station
+				var/turf/T = SSmapping.get_station_center()
 				new /obj/structure/destructible/clockwork/massive/ratvar(T)
 				SSticker.force_ending = TRUE
 				var/x0 = T.x

--- a/code/modules/admin/secrets.dm
+++ b/code/modules/admin/secrets.dm
@@ -421,7 +421,7 @@
 				L.fix()
 
 		if("floorlava")
-			SSweather.run_weather("the floor is lava")
+			SSweather.run_weather(/datum/weather/floor_is_lava)
 
 		if("virus")
 			if(!check_rights(R_FUN))

--- a/code/modules/awaymissions/zlevel.dm
+++ b/code/modules/awaymissions/zlevel.dm
@@ -8,7 +8,7 @@ GLOBAL_LIST_INIT(potentialRandomZlevels, generateMapList(filename = "config/away
 	if(GLOB.potentialRandomZlevels && GLOB.potentialRandomZlevels.len)
 		to_chat(world, "<span class='boldannounce'>Loading away mission...</span>")
 		var/map = pick(GLOB.potentialRandomZlevels)
-		load_new_z_level(map)
+		load_new_z_level(map, "Away Mission")
 		to_chat(world, "<span class='boldannounce'>Away mission loaded.</span>")
 
 /proc/reset_gateway_spawns(reset = FALSE)

--- a/code/modules/events/portal_storm.dm
+++ b/code/modules/events/portal_storm.dm
@@ -33,14 +33,16 @@
 	var/list/hostiles_spawn = list()
 	var/list/hostile_types = list()
 	var/number_of_hostiles
-	var/list/station_areas = list()
+	var/list/station_areas
 	var/mutable_appearance/storm
 
 /datum/round_event/portal_storm/setup()
 	storm = mutable_appearance('icons/obj/tesla_engine/energy_ball.dmi', "energy_ball_fast", FLY_LAYER)
 	storm.color = "#00FF00"
 
-	station_areas = get_areas_in_z(ZLEVEL_STATION_PRIMARY)
+	station_areas = list()
+	for (var/z in SSmapping.levels_by_trait(ZTRAIT_STATION))
+		station_areas |= SSmapping.areas_in_z["[z]"]
 
 	number_of_bosses = 0
 	for(var/boss in boss_types)

--- a/code/modules/events/radiation_storm.dm
+++ b/code/modules/events/radiation_storm.dm
@@ -16,4 +16,4 @@
 	//sound not longer matches the text, but an audible warning is probably good
 
 /datum/round_event/radiation_storm/start()
-	SSweather.run_weather("radiation storm",ZLEVEL_STATION_PRIMARY)
+	SSweather.run_weather(/datum/weather/rad_storm)

--- a/code/modules/events/wizard/advanced_darkness.dm
+++ b/code/modules/events/wizard/advanced_darkness.dm
@@ -13,4 +13,4 @@
 /datum/round_event/wizard/darkness/start()
 	if(!started)
 		started = TRUE
-		SSweather.run_weather("advanced darkness", ZLEVEL_STATION_PRIMARY)
+		SSweather.run_weather(/datum/weather/advanced_darkness)

--- a/code/modules/events/wizard/lava.dm
+++ b/code/modules/events/wizard/lava.dm
@@ -12,4 +12,4 @@
 /datum/round_event/wizard/lava/start()
 	if(!started)
 		started = TRUE
-		SSweather.run_weather("the floor is lava", ZLEVEL_STATION_PRIMARY)
+		SSweather.run_weather(/datum/weather/floor_is_lava)

--- a/code/modules/mapping/map_template.dm
+++ b/code/modules/mapping/map_template.dm
@@ -52,7 +52,8 @@
 	var/x = round((world.maxx - width)/2)
 	var/y = round((world.maxy - height)/2)
 
-	var/list/bounds = maploader.load_map(file(mappath), x, y)
+	var/datum/space_level/level = SSmapping.add_new_zlevel(name, UNAFFECTED, list(ZTRAIT_AWAY = TRUE))
+	var/list/bounds = maploader.load_map(file(mappath), x, y, level.z_value, no_changeturf=(SSatoms.initialized == INITIALIZATION_INSSATOMS))
 	if(!bounds)
 		return FALSE
 

--- a/code/modules/mapping/space_management/traits.dm
+++ b/code/modules/mapping/space_management/traits.dm
@@ -44,3 +44,8 @@
 			if (S.traits[trait])
 				. += S.z_value
 				break
+
+// Prefer not to use this one too often
+/datum/controller/subsystem/mapping/proc/get_station_center()
+	var/station_z = levels_by_trait(ZTRAIT_STATION)[1]
+	return locate(round(world.maxx * 0.5, 1), round(world.maxy * 0.5, 1), station_z)

--- a/code/modules/mapping/space_management/zlevel_manager.dm
+++ b/code/modules/mapping/space_management/zlevel_manager.dm
@@ -24,7 +24,7 @@
 	// TODO: sleep here if the Z level needs to be cleared
 	var/datum/space_level/S = new z_type(new_z, name, linkage, traits)
 	z_list += S
-	return new_z
+	return S
 
 /datum/controller/subsystem/mapping/proc/get_level(z)
 	. = z_list[z]

--- a/code/modules/mob/dead/observer/observer.dm
+++ b/code/modules/mob/dead/observer/observer.dm
@@ -106,7 +106,7 @@ GLOBAL_VAR_INIT(observer_default_invisibility, INVISIBILITY_OBSERVER)
 		if(turfs.len)
 			T = pick(turfs)
 		else
-			T = locate(round(world.maxx/2), round(world.maxy/2), ZLEVEL_STATION_PRIMARY)	//middle of the station
+			T = SSmapping.get_station_center()
 
 	forceMove(T)
 

--- a/code/modules/mob/living/simple_animal/hostile/megafauna/legion.dm
+++ b/code/modules/mob/living/simple_animal/hostile/megafauna/legion.dm
@@ -170,17 +170,18 @@ Difficulty: Medium
 		return
 
 	var/area/user_area = get_area(user)
-	if(user_area.type in excluded_areas)
+	var/turf/user_turf = get_turf(user)
+	if(!user_area || !user_turf || (user_area.type in excluded_areas))
 		to_chat(user, "<span class='warning'>Something is preventing you from using the staff here.</span>")
 		return
 	var/datum/weather/A
-	for(var/V in SSweather.existing_weather)
+	for(var/V in SSweather.processing)
 		var/datum/weather/W = V
-		if(W.target_z == user.z && W.area_type == user_area.type)
+		if((user_turf.z in W.impacted_z_levels) && W.area_type == user_area.type)
 			A = W
 			break
-	if(A)
 
+	if(A)
 		if(A.stage != END_STAGE)
 			if(A.stage == WIND_DOWN_STAGE)
 				to_chat(user, "<span class='warning'>The storm is already ending! It would be a waste to use the staff now.</span>")
@@ -191,10 +192,9 @@ Difficulty: Medium
 			A.wind_down()
 			return
 	else
-		A = new storm_type
+		A = new storm_type(list(user_turf.z))
 		A.name = "staff storm"
 		A.area_type = user_area.type
-		A.target_z = user.z
 		A.telegraph_duration = 100
 		A.end_duration = 100
 


### PR DESCRIPTION
:cl:
refactor: Weather and certain events have been updated to use Z traits.
fix: The Staff of Storms now correctly starts and ends storms if used from inside lockers.
fix: Weather telegraph messages are now shown to those inside lockers and mechs.
/:cl:

Continuation of #34090, eliminating the last easy use of hardcoded z-levels pursuant to #32037. Remaining:

* Use of `ZLEVEL_EMPTY_SPACE` by the pirate event
* Use of `ZLEVEL_STATION_PRIMARY` by secret satchel persistence
* Use of `ZLEVEL_STATION_PRIMARY` by map loading

These should be solved by the remaining hard work of the z-manager, namely the map loading changes and the heap z-level feature.