### PR TITLE
Adds the camera and it's film to the autolathe and changes the materials on them

### DIFF
--- a/code/modules/paperwork/photography.dm
+++ b/code/modules/paperwork/photography.dm
@@ -21,6 +21,7 @@
 	righthand_file = 'icons/mob/inhands/misc/devices_righthand.dmi'
 	w_class = WEIGHT_CLASS_TINY
 	resistance_flags = FLAMMABLE
+	materials = list(MAT_METAL = 10, MAT_GLASS = 10)
 
 /*
  * Photo
@@ -116,7 +117,7 @@
 	w_class = WEIGHT_CLASS_SMALL
 	flags_1 = CONDUCT_1
 	slot_flags = SLOT_BELT
-	materials = list(MAT_METAL=2000)
+	materials = list(MAT_METAL = 50, MAT_GLASS = 150)
 	var/pictures_max = 10
 	var/pictures_left = 10
 	var/on = TRUE

--- a/code/modules/research/designs/autolathe_designs.dm
+++ b/code/modules/research/designs/autolathe_designs.dm
@@ -163,6 +163,22 @@
 	build_path = /obj/item/electronics/firealarm
 	category = list("initial", "Electronics")
 
+/datum/design/camera
+	name = "Camera"
+	id = "camera"
+	build_type = AUTOLATHE
+	materials = list(MAT_METAL = 50, MAT_GLASS = 100)
+	build_path = /obj/item/device/camera
+	category = list("initial", "Misc")
+
+/datum/design/camera_film
+	name = "Camera Film Cartridge"
+	id = "camera_film"
+	build_type = AUTOLATHE
+	materials = list(MAT_METAL = 10, MAT_GLASS = 10)
+	build_path = /obj/item/device/camera_film
+	category = list("initial", "Misc")
+
 /datum/design/earmuffs
 	name = "Earmuffs"
 	id = "earmuffs"
@@ -436,7 +452,7 @@
 	id = "tape"
 	build_type = AUTOLATHE
 	materials = list(MAT_METAL = 20, MAT_GLASS = 5)
-	build_path = /obj/item/device/tape
+	build_path = /obj/item/device/tape/random
 	category = list("initial", "Misc")
 
 /datum/design/igniter


### PR DESCRIPTION
[Changelogs]: 
:cl: Dax Dupont
add: Fans of clown photography have successfully lobbied Nanotrasen to include camera and camera accessories designs in the autolathe.
tweak: Brings material values for the camera in line with other devices. 
tweak: The tapes printed by autolathes now come in random colors.
/:cl:

[why]: Since the tape recorder is in the autolathe, I figured why not add the camera. Cameras can't harm and don't change the balance of things. This way there's no artificial limitation on cameras and people are free to take pictures of clowns.