### PR TITLE
Fixes empty IC syringe having 0 transfer amount

### DIFF
--- a/code/modules/integrated_electronics/subtypes/reagents.dm
+++ b/code/modules/integrated_electronics/subtypes/reagents.dm
@@ -193,7 +193,7 @@
 			activate_pin(3)
 			return
 
-		var/tramount = CLAMP(transfer_amount, 0, reagents.total_volume)
+		var/tramount = CLAMP(transfer_amount, 0, AM.reagents.total_volume)
 
 		if(isliving(AM))
 			var/mob/living/L = AM


### PR DESCRIPTION
:cl:
fix: fixed the syringe getting a transfer amount of 0 if the contents of it are 0, intended feature was probably to check the target and not the syringe itself for clamp.
/:cl:

Fixes #34628