### PR TITLE
Unassumes moth genders

### DIFF
--- a/code/modules/mob/living/carbon/human/species_types/mothmen.dm
+++ b/code/modules/mob/living/carbon/human/species_types/mothmen.dm
@@ -29,9 +29,9 @@
 
 /datum/species/moth/random_name(gender,unique,lastname)
 	if(unique)
-		return random_unique_moth_name(gender)
+		return random_unique_moth_name()
 
-	var/randname = moth_name(gender)
+	var/randname = moth_name()
 
 	if(lastname)
 		randname += " [lastname]"


### PR DESCRIPTION
invalid arg for that proc. they don't have gender sensitive names.

Fixes #34728