### PR TITLE
Longer lasting candles.

### DIFF
--- a/code/game/objects/items/candle.dm
+++ b/code/game/objects/items/candle.dm
@@ -8,7 +8,7 @@
 	item_state = "candle1"
 	w_class = WEIGHT_CLASS_TINY
 	light_color = LIGHT_COLOR_FIRE
-	var/wax = 200
+	var/wax = 1000
 	var/lit = FALSE
 	var/infinite = FALSE
 	var/start_lit = FALSE
@@ -22,9 +22,9 @@
 
 /obj/item/candle/update_icon()
 	var/i
-	if(wax>150)
+	if(wax>750)
 		i = 1
-	else if(wax>80)
+	else if(wax>400)
 		i = 2
 	else i = 3
 	icon_state = "candle[i][lit ? "_lit" : ""]"


### PR DESCRIPTION
:cl: scrubs2009
tweak: Candles last longer
/:cl:

[why]: # (Please add a short description [two lines down] of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.)

It's nice to have your chapel look moody with dim lights and lots of shadows. Candles are great for this but they only last about 5 minutes and you only get a handful of packs unless you convince cargo to get more. With longer lasting candles you now have a viable chapel lighting system for your blood cults.

It's my first time coding. Let me know if I fucked up