### PR TITLE
City of cogs atmos is now planetary, slowly resets

### DIFF
--- a/code/game/turfs/simulated/floor/misc_floor.dm
+++ b/code/game/turfs/simulated/floor/misc_floor.dm
@@ -228,6 +228,7 @@
 	icon_state = "reebe"
 	baseturfs = /turf/open/floor/clockwork/reebe
 	uses_overlay = FALSE
+	planetary_atmos = TRUE
 
 /turf/open/floor/bluespace
 	slowdown = -1


### PR DESCRIPTION
As it stands one gas attack during the ark phase of the mode means the air stays superheated for the rest of the round and anyone without a fireproof suit basically can't fight. This should make fire still usable as a weapon, but not indefinite area denial
