### PR TITLE
Adds /area/asteroid/nearstation to GLOB.the_station_areas blacklist

### DIFF
--- a/code/controllers/subsystem/mapping.dm
+++ b/code/controllers/subsystem/mapping.dm
@@ -148,7 +148,7 @@ SUBSYSTEM_DEF(mapping)
 GLOBAL_LIST_EMPTY(the_station_areas)
 
 /datum/controller/subsystem/mapping/proc/generate_station_area_list()
-	var/list/station_areas_blacklist = typecacheof(list(/area/space, /area/mine, /area/ruin))
+	var/list/station_areas_blacklist = typecacheof(list(/area/space, /area/mine, /area/ruin, /area/asteroid/nearstation))
 	for(var/area/A in world)
 		var/turf/picked = safepick(get_area_turfs(A.type))
 		if(picked && is_station_level(picked.z))


### PR DESCRIPTION
Forgot to add this when I made the path.