### PR TITLE
Removes pulling claw instant messageless stun

### DIFF
--- a/code/modules/integrated_electronics/subtypes/manipulation.dm
+++ b/code/modules/integrated_electronics/subtypes/manipulation.dm
@@ -363,14 +363,13 @@
 	activators = list("pulse in" = IC_PINTYPE_PULSE_IN,"pulse out" = IC_PINTYPE_PULSE_OUT,"released" = IC_PINTYPE_PULSE_OUT)
 	spawn_flags = IC_SPAWN_RESEARCH
 	power_draw_per_use = 50
-	var/max_grab = 2 //change it to 1 if you tired of drone kung-fu.Return it to 2 if you miss it.
+	var/max_grab = GRAB_PASSIVE
 
 /obj/item/integrated_circuit/manipulation/claw/do_work()
 	var/obj/acting_object = get_object()
 	var/atom/movable/AM = get_pin_data_as_type(IC_INPUT, 1, /atom/movable)
 	var/mode = get_pin_data(IC_INPUT, 2)
-	if(mode>max_grab)
-		return
+	mode = CLAMP(mode, GRAB_PASSIVE, max_grab
 	if(AM)
 		if(check_target(AM, exclude_contents = TRUE))
 			acting_object.start_pulling(AM,mode)

--- a/code/modules/integrated_electronics/subtypes/manipulation.dm
+++ b/code/modules/integrated_electronics/subtypes/manipulation.dm
@@ -369,7 +369,7 @@
 	var/obj/acting_object = get_object()
 	var/atom/movable/AM = get_pin_data_as_type(IC_INPUT, 1, /atom/movable)
 	var/mode = get_pin_data(IC_INPUT, 2)
-	mode = CLAMP(mode, GRAB_PASSIVE, max_grab
+	mode = CLAMP(mode, GRAB_PASSIVE, max_grab)
 	if(AM)
 		if(check_target(AM, exclude_contents = TRUE))
 			acting_object.start_pulling(AM,mode)


### PR DESCRIPTION
Right we removed shockers for a reason and atleast shockers gave you a message when stunning you.
Also why does pulling claw not generate any messages at all?
Also in the original PR it specified that pulling claw allowed circuit bots to pull. Nowhere was it specified that stuns were included.
:cl:
rscdel: pulling claw can now only passively grab
/:cl: