### PR TITLE
Clown traitors can buy clown bombs now

### DIFF
--- a/code/game/machinery/syndicatebeacon.dm
+++ b/code/game/machinery/syndicatebeacon.dm
@@ -129,6 +129,6 @@
 	desc = "A label on it reads: <i>Warning: Activating this device will send a power draining device to your location</i>."
 	droptype = /obj/item/device/powersink
 
-/obj/item/device/sbeacondrop/bomb
+/obj/item/device/sbeacondrop/clownbomb
 	desc = "A label on it reads: <i>Warning: Activating this device will send a silly explosive to your location</i>."
 	droptype = /obj/machinery/syndicatebomb/badmin/clown

--- a/code/game/machinery/syndicatebeacon.dm
+++ b/code/game/machinery/syndicatebeacon.dm
@@ -128,3 +128,7 @@
 /obj/item/device/sbeacondrop/powersink
 	desc = "A label on it reads: <i>Warning: Activating this device will send a power draining device to your location</i>."
 	droptype = /obj/item/device/powersink
+
+/obj/item/device/sbeacondrop/bomb
+	desc = "A label on it reads: <i>Warning: Activating this device will send a silly explosive to your location</i>."
+	droptype = /obj/machinery/syndicatebomb/badmin/clown

--- a/code/game/machinery/syndicatebomb.dm
+++ b/code/game/machinery/syndicatebomb.dm
@@ -363,7 +363,7 @@
 
 /obj/item/bombcore/badmin/summon/clown
 	summon_path = /mob/living/simple_animal/hostile/retaliate/clown
-	amt_summon 	= 100
+	amt_summon 	= 50
 
 /obj/item/bombcore/badmin/summon/clown/defuse()
 	playsound(src, 'sound/misc/sadtrombone.ogg', 50)

--- a/code/modules/uplink/uplink_items.dm
+++ b/code/modules/uplink/uplink_items.dm
@@ -1300,7 +1300,7 @@ GLOBAL_LIST_EMPTY(uplink_items) // Global list so we only initialize this once.
 			transported to you that will teleport the actual bomb to it upon activation. Note that this bomb can \
 			be defused, and some crew may attempt to do so."
 	item = /obj/item/device/sbeacondrop/clownbomb
-	cost = 12
+	cost = 15
 	restricted_roles = list("Clown")
 
 // Pointless

--- a/code/modules/uplink/uplink_items.dm
+++ b/code/modules/uplink/uplink_items.dm
@@ -1301,6 +1301,7 @@ GLOBAL_LIST_EMPTY(uplink_items) // Global list so we only initialize this once.
 			be defused, and some crew may attempt to do so."
 	item = /obj/item/device/sbeacondrop/clownbomb
 	cost = 12
+	restricted_roles = list("Clown")
 
 // Pointless
 /datum/uplink_item/badass

--- a/code/modules/uplink/uplink_items.dm
+++ b/code/modules/uplink/uplink_items.dm
@@ -1292,6 +1292,16 @@ GLOBAL_LIST_EMPTY(uplink_items) // Global list so we only initialize this once.
 	limited_stock = 2 //you can't use more than two!
 	restricted_roles = list("Shaft Miner")
 
+/datum/uplink_item/device_tools/clown_bomb
+	name = "Clown Bomb"
+	desc = "The Clown bomb is a hilarious device capable of massive pranks. It has an adjustable timer, \
+			with a minimum of 60 seconds, and can be bolted to the floor with a wrench to prevent \
+			movement. The bomb is bulky and cannot be moved; upon ordering this item, a smaller beacon will be \
+			transported to you that will teleport the actual bomb to it upon activation. Note that this bomb can \
+			be defused, and some crew may attempt to do so."
+	item = /obj/item/device/sbeacondrop/clownbomb
+	cost = 12
+
 // Pointless
 /datum/uplink_item/badass
 	category = "(Pointless) Badassery"


### PR DESCRIPTION
🆑 imsxz
add: Traitor clowns are now able to purchase clown bombs from their uplinks. Honk!
add: Clown bombs can now be placed via a small beacon, the same way normal syndicate bombs can be.
tweak: clown bomb payload now summons 50 clowns instead of 100
/🆑

There was an admin event last night involving lots of clowns, and I realized that this would be a neat thing for clowns to be able to purchase. I'm not sure on the cost yet, but the first person I asked said to do 12 TC, so that's the current placeholder. Honk.