### PR TITLE
Fixes missing tile under autolathe 

### DIFF
--- a/_maps/map_files/Deltastation/DeltaStation2.dmm
+++ b/_maps/map_files/Deltastation/DeltaStation2.dmm
@@ -4865,12 +4865,6 @@
 	},
 /turf/open/floor/plasteel/neutral,
 /area/hallway/secondary/entry)
-"akh" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/turf/open/floor/plasteel/neutral,
-/area/hallway/secondary/entry)
 "aki" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 1
@@ -16506,10 +16500,6 @@
 	icon_state = "wood-broken6"
 	},
 /area/hallway/secondary/service)
-"aIR" = (
-/obj/structure/closet/secure_closet/personal/cabinet,
-/turf/open/floor/wood,
-/area/hallway/secondary/service)
 "aIS" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 8
@@ -17766,13 +17756,6 @@
 "aLF" = (
 /obj/structure/table/wood,
 /obj/item/storage/briefcase,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/turf/open/floor/wood,
-/area/hallway/secondary/service)
-"aLG" = (
-/obj/item/twohanded/required/kirbyplants/random,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
@@ -20814,9 +20797,6 @@
 "aSa" = (
 /obj/machinery/holopad,
 /turf/open/floor/carpet,
-/area/crew_quarters/bar/atrium)
-"aSb" = (
-/turf/open/floor/plasteel/redyellow,
 /area/crew_quarters/bar/atrium)
 "aSc" = (
 /obj/machinery/door/firedoor,
@@ -25469,17 +25449,6 @@
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 1
-	},
-/turf/open/floor/plasteel/red/corner{
-	dir = 1
-	},
-/area/security/prison)
-"bbj" = (
-/obj/structure/cable/white{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
 	},
 /turf/open/floor/plasteel/red/corner{
 	dir = 1
@@ -37890,11 +37859,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/execution/transfer)
-"bAe" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/delivery,
-/turf/open/floor/plasteel,
-/area/security/execution/transfer)
 "bAf" = (
 /obj/machinery/door/airlock/external{
 	cyclelinkeddir = 8;
@@ -42327,12 +42291,6 @@
 /obj/effect/turf_decal/delivery,
 /turf/open/floor/plasteel,
 /area/engine/break_room)
-"bIj" = (
-/obj/structure/cable/white{
-	icon_state = "4-8"
-	},
-/turf/open/floor/plasteel/neutral,
-/area/engine/break_room)
 "bIk" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable/white{
@@ -42509,9 +42467,6 @@
 	},
 /obj/effect/turf_decal/delivery,
 /turf/open/floor/plasteel,
-/area/storage/primary)
-"bIy" = (
-/turf/open/floor/plasteel/neutral,
 /area/storage/primary)
 "bIz" = (
 /obj/structure/table/reinforced,
@@ -45820,9 +45775,6 @@
 	dir = 5
 	},
 /area/security/detectives_office)
-"bPn" = (
-/turf/open/floor/plasteel/neutral,
-/area/hallway/primary/starboard)
 "bPo" = (
 /obj/structure/closet/secure_closet/brig{
 	id = "brig2";
@@ -52704,10 +52656,6 @@
 	},
 /turf/open/floor/plasteel/neutral,
 /area/hallway/primary/central)
-"ccy" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/turf/open/floor/plasteel/blue/corner,
-/area/hallway/primary/central)
 "ccz" = (
 /obj/machinery/status_display,
 /turf/closed/wall/r_wall,
@@ -56380,11 +56328,6 @@
 	dir = 5
 	},
 /area/security/courtroom)
-"cjW" = (
-/turf/open/floor/plasteel/vault{
-	dir = 5
-	},
-/area/security/courtroom)
 "cjX" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/public/glass{
@@ -56801,12 +56744,6 @@
 /turf/open/floor/plasteel/grimy,
 /area/library)
 "ckR" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/turf/open/floor/plasteel/grimy,
-/area/library)
-"ckS" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
@@ -62658,9 +62595,6 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plasteel/neutral,
 /area/hallway/primary/central)
-"cxe" = (
-/turf/open/floor/plasteel/neutral,
-/area/hallway/primary/central)
 "cxf" = (
 /obj/machinery/door/firedoor,
 /obj/effect/turf_decal/stripes/line{
@@ -62864,17 +62798,6 @@
 	},
 /turf/open/floor/plating/airless,
 /area/space/nearstation)
-"cxC" = (
-/obj/machinery/power/rad_collector/anchored,
-/obj/machinery/power/rad_collector/anchored,
-/obj/structure/cable{
-	icon_state = "0-4"
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/engine/engineering)
 "cxD" = (
 /obj/structure/rack,
 /obj/item/crowbar,
@@ -63526,15 +63449,6 @@
 "cyS" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/plasteel/neutral,
-/area/crew_quarters/locker)
-"cyT" = (
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	dir = 1
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -67302,12 +67216,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/gateway)
-"cGG" = (
-/obj/structure/cable/white{
-	icon_state = "1-2"
-	},
-/turf/open/floor/plasteel/neutral,
-/area/hallway/primary/central)
 "cGH" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/mirror{
@@ -68206,15 +68114,6 @@
 	},
 /turf/closed/wall,
 /area/maintenance/port)
-"cIz" = (
-/obj/structure/cable/white{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/turf/open/floor/plasteel/neutral,
-/area/hallway/primary/central)
 "cIA" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden,
 /turf/open/floor/plasteel/neutral/corner{
@@ -69724,9 +69623,6 @@
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
 	dir = 4
 	},
-/turf/open/floor/plasteel/neutral,
-/area/crew_quarters/dorms)
-"cLh" = (
 /turf/open/floor/plasteel/neutral,
 /area/crew_quarters/dorms)
 "cLi" = (
@@ -72966,12 +72862,6 @@
 	},
 /turf/open/floor/plasteel/whitepurple/corner,
 /area/science/research)
-"cSt" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/turf/open/floor/plasteel/whitepurple/corner,
-/area/science/research)
 "cSu" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -73976,12 +73866,6 @@
 /turf/open/floor/plasteel/cmo,
 /area/medical/medbay/central)
 "cUx" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/turf/open/floor/plasteel/cmo,
-/area/medical/medbay/central)
-"cUy" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
@@ -81879,13 +81763,6 @@
 "dlj" = (
 /turf/open/floor/plasteel,
 /area/science/circuit)
-"dlk" = (
-/obj/structure/table,
-/obj/item/paper_bin,
-/obj/item/pen,
-/obj/effect/turf_decal/delivery,
-/turf/open/floor/plasteel,
-/area/science/research/abandoned)
 "dll" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 5
@@ -82424,13 +82301,6 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel,
-/area/science/research/abandoned)
-"dmz" = (
-/obj/structure/rack,
-/obj/item/storage/toolbox/electrical,
-/obj/item/device/multitool,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating,
 /area/science/research/abandoned)
 "dmA" = (
 /obj/effect/landmark/blobstart,
@@ -84088,16 +83958,6 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/wood,
 /area/crew_quarters/abandoned_gambling_den)
-"dpW" = (
-/obj/structure/table/reinforced,
-/obj/item/folder/white,
-/obj/item/stock_parts/cell/high,
-/obj/item/stack/sheet/glass,
-/obj/item/stack/sheet/glass,
-/obj/item/stack/sheet/glass,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating,
-/area/science/research/abandoned)
 "dpX" = (
 /obj/structure/chair/office/light{
 	dir = 8
@@ -85544,25 +85404,6 @@
 /obj/item/book/manual/wiki/engineering_hacking,
 /turf/open/floor/plating,
 /area/crew_quarters/abandoned_gambling_den)
-"dtb" = (
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating,
-/area/science/research/abandoned)
-"dtc" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/door/airlock/maintenance_hatch{
-	name = "Maintenance Hatch";
-	req_access_txt = "12"
-	},
-/obj/structure/barricade/wooden,
-/obj/effect/turf_decal/stripes/line{
-	dir = 2
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/science/research/abandoned)
 "dtd" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/closed/wall,
@@ -87241,12 +87082,6 @@
 /turf/open/floor/plasteel/neutral/corner{
 	dir = 8
 	},
-/area/hallway/primary/aft)
-"dwE" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/turf/open/floor/plasteel/neutral,
 /area/hallway/primary/aft)
 "dwF" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -99301,12 +99136,6 @@
 	dir = 8
 	},
 /area/medical/virology)
-"dVB" = (
-/obj/structure/cable/white{
-	icon_state = "1-2"
-	},
-/turf/open/floor/plasteel/green,
-/area/medical/virology)
 "dVC" = (
 /obj/item/device/radio/intercom{
 	name = "Station Intercom";
@@ -101650,9 +101479,6 @@
 /obj/machinery/vending/cola/random,
 /obj/effect/turf_decal/delivery,
 /turf/open/floor/plasteel,
-/area/hallway/secondary/exit/departure_lounge)
-"eaF" = (
-/turf/open/floor/plasteel/neutral,
 /area/hallway/secondary/exit/departure_lounge)
 "eaG" = (
 /obj/structure/reagent_dispensers/fueltank,
@@ -104894,10 +104720,6 @@
 	},
 /turf/closed/wall,
 /area/quartermaster/office)
-"ehu" = (
-/obj/machinery/rnd/protolathe/department/security,
-/turf/open/floor/plasteel/neutral,
-/area/security/main)
 "ehv" = (
 /turf/open/floor/plasteel/caution,
 /area/engine/engineering)
@@ -104908,84 +104730,7 @@
 	},
 /turf/open/floor/plasteel/caution,
 /area/engine/engineering)
-"ehx" = (
-/obj/structure/cable/white{
-	icon_state = "4-8"
-	},
-/obj/machinery/rnd/protolathe/department/engineering,
-/turf/open/floor/plasteel/neutral,
-/area/engine/engineering)
 "ehy" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 2
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/obj/effect/turf_decal/caution/stand_clear,
-/turf/open/floor/plasteel,
-/area/hallway/secondary/entry)
-"ehz" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 2
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/obj/effect/turf_decal/caution/stand_clear,
-/turf/open/floor/plasteel,
-/area/hallway/secondary/entry)
-"ehA" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 2
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/obj/effect/turf_decal/caution/stand_clear,
-/turf/open/floor/plasteel,
-/area/hallway/secondary/entry)
-"ehB" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 2
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/obj/effect/turf_decal/caution/stand_clear,
-/turf/open/floor/plasteel,
-/area/hallway/secondary/entry)
-"ehC" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 2
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/obj/effect/turf_decal/caution/stand_clear,
-/turf/open/floor/plasteel,
-/area/hallway/secondary/entry)
-"ehD" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 2
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/obj/effect/turf_decal/caution/stand_clear,
-/turf/open/floor/plasteel,
-/area/hallway/secondary/entry)
-"ehE" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 2
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/obj/effect/turf_decal/caution/stand_clear,
-/turf/open/floor/plasteel,
-/area/hallway/secondary/entry)
-"ehF" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 2
 	},
@@ -105062,39 +104807,12 @@
 /obj/effect/turf_decal/caution/stand_clear,
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit/departure_lounge)
-"ehN" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 2
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/obj/effect/turf_decal/caution/stand_clear,
-/turf/open/floor/plasteel,
-/area/hallway/secondary/exit/departure_lounge)
-"ehO" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 2
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/obj/effect/turf_decal/caution/stand_clear,
-/turf/open/floor/plasteel,
-/area/hallway/secondary/exit/departure_lounge)
 "ehP" = (
 /obj/machinery/computer/security/telescreen/entertainment{
 	pixel_y = -32
 	},
 /turf/open/floor/plasteel/dark,
 /area/library)
-"ehQ" = (
-/obj/structure/cable/white{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/turf/open/floor/plasteel/grimy,
-/area/chapel/main)
 "QNf" = (
 /obj/machinery/autolathe,
 /obj/machinery/door/window/southleft{
@@ -105106,7 +104824,9 @@
 	id = "rndlab1";
 	name = "Research and Development Shutter"
 	},
-/turf/open/floor/plating,
+/turf/open/floor/plasteel/whitepurple/side{
+	dir = 4
+	},
 /area/science/lab)
 "QNg" = (
 /obj/effect/turf_decal/loading_area,
@@ -105126,12 +104846,6 @@
 "QNi" = (
 /turf/closed/wall,
 /area/science/circuit)
-"QNj" = (
-/turf/closed/wall/r_wall,
-/area/science/circuit)
-"QNk" = (
-/turf/closed/wall/r_wall,
-/area/science/circuit)
 "QNl" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/closed/wall/r_wall,
@@ -105139,9 +104853,6 @@
 "QNm" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/closed/wall/r_wall,
-/area/science/circuit)
-"QNn" = (
-/turf/closed/wall,
 /area/science/circuit)
 "QNo" = (
 /obj/structure/table/reinforced,
@@ -105174,13 +104885,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/science/circuit)
-"QNr" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/turf/closed/wall/r_wall,
-/area/science/circuit)
-"QNs" = (
-/turf/closed/wall,
-/area/science/circuit)
 "QNt" = (
 /obj/structure/chair/office/light{
 	dir = 8
@@ -105202,23 +104906,6 @@
 	dir = 9
 	},
 /area/science/circuit)
-"QNw" = (
-/turf/open/floor/plasteel/white/side{
-	dir = 5
-	},
-/area/science/circuit)
-"QNx" = (
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/plasteel/white/side{
-	dir = 9
-	},
-/area/science/circuit)
-"QNy" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/science/circuit)
 "QNz" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -105231,9 +104918,6 @@
 	},
 /turf/open/floor/plasteel/whitepurple/side,
 /area/science/misc_lab)
-"QNB" = (
-/turf/closed/wall,
-/area/science/circuit)
 "QNC" = (
 /obj/structure/table/reinforced,
 /obj/item/device/integrated_electronics/analyzer,
@@ -105288,9 +104972,6 @@
 	dir = 4
 	},
 /area/science/misc_lab)
-"QNH" = (
-/turf/closed/wall,
-/area/science/circuit)
 "QNI" = (
 /obj/structure/table/reinforced,
 /obj/item/device/integrated_electronics/analyzer,
@@ -105309,16 +104990,9 @@
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plasteel,
 /area/science/circuit)
-"QNL" = (
-/obj/effect/turf_decal/stripes/line,
-/turf/open/floor/plasteel,
-/area/science/circuit)
 "QNM" = (
 /obj/structure/sign/nanotrasen,
 /turf/closed/wall/r_wall,
-/area/science/circuit)
-"QNN" = (
-/turf/closed/wall,
 /area/science/circuit)
 "QNO" = (
 /turf/open/floor/plasteel/white/side{
@@ -105338,9 +105012,6 @@
 /turf/open/floor/plasteel/white/side{
 	dir = 6
 	},
-/area/science/circuit)
-"QNR" = (
-/turf/closed/wall,
 /area/science/circuit)
 "QNS" = (
 /obj/structure/table/reinforced,
@@ -105385,14 +105056,8 @@
 "QNX" = (
 /turf/closed/wall/r_wall,
 /area/science/misc_lab)
-"QNY" = (
-/turf/closed/wall,
-/area/science/circuit)
 "QNZ" = (
 /turf/closed/wall,
-/area/science/misc_lab)
-"QOa" = (
-/turf/closed/wall/r_wall,
 /area/science/misc_lab)
 "QOb" = (
 /obj/machinery/power/apc{
@@ -130337,14 +130002,14 @@ cEo
 ddO
 cQt
 dgl
-QNj
+dhR
 djn
 dle
 dmr
 dog
 dle
 drz
-QNj
+dhR
 dul
 dvZ
 dxH
@@ -130594,14 +130259,14 @@ cRP
 ddP
 deW
 cKk
-QNj
+dhR
 QNo
 QNt
 QNC
 QNI
 dpX
 QNS
-QNj
+dhR
 djs
 dlf
 dxI
@@ -130851,14 +130516,14 @@ cMY
 cMY
 cCM
 dgm
-QNj
+dhR
 djp
 QNu
 dmt
 doh
 QNO
 drA
-QNj
+dhR
 dum
 dli
 dpZ
@@ -131115,7 +130780,7 @@ QND
 QNJ
 QNP
 drB
-QNj
+dhR
 QOb
 QOc
 QOh
@@ -131365,14 +131030,14 @@ dcb
 cMY
 deX
 dgn
-QNj
+dhR
 djr
 QNu
 dmv
 doj
 QNQ
 QNT
-QNj
+dhR
 dun
 QOd
 dxK
@@ -131622,14 +131287,14 @@ cNd
 cMY
 deX
 dgo
-QNj
+dhR
 QNp
-QNx
+dok
 dmw
-QNx
+dok
 dqa
 drC
-QNj
+dhR
 duo
 dmu
 QOi
@@ -131879,14 +131544,14 @@ cMY
 cMY
 deY
 cKl
-QNj
+dhR
 djt
-QNy
-QNy
+dmx
+dmx
 dol
 dqb
 drD
-QNj
+dhR
 dup
 QOe
 dxL
@@ -132136,14 +131801,14 @@ dcc
 cMY
 cOD
 cKj
-QNj
+dhR
 dju
 dlj
 dlj
 QNK
 dqc
 QNU
-QNj
+dhR
 duq
 dlh
 dxM
@@ -132393,14 +132058,14 @@ cRS
 cMY
 deZ
 dgo
-QNj
+dhR
 djv
 dlj
 dlj
 QNK
 dqb
 drE
-QNj
+dhR
 dur
 QOf
 dxN
@@ -132650,14 +132315,14 @@ dcd
 cMY
 deX
 dgo
-QNj
+dhR
 QNq
 QNz
 QNE
 doo
 dqd
 drF
-QNj
+dhR
 dus
 dwa
 dom
@@ -132860,7 +132525,7 @@ bBd
 bDb
 bEP
 bGw
-bIj
+bIf
 bKj
 bMc
 bOh
@@ -132910,11 +132575,11 @@ dgp
 QNm
 QNm
 dll
-QNj
+dhR
 QNM
 dqe
-QNj
-QNj
+dhR
+dhR
 dut
 dwb
 dxO
@@ -136987,7 +136652,7 @@ cei
 cfZ
 chQ
 cjt
-ckS
+ckR
 cms
 cnO
 cpu
@@ -137743,7 +137408,7 @@ bBr
 bDo
 bEY
 bGI
-bIy
+bGI
 bGI
 bGK
 bOr
@@ -139830,7 +139495,7 @@ bvM
 bvM
 bvM
 bvM
-cIz
+bFE
 cKu
 bsO
 cNm
@@ -140066,7 +139731,7 @@ bUA
 bWN
 bYV
 bYV
-ccy
+bYV
 cem
 bYV
 bYV
@@ -140393,7 +140058,7 @@ dKD
 dUp
 dVd
 dVS
-ehQ
+dVd
 dVd
 dVd
 dVd
@@ -142149,7 +141814,7 @@ bsO
 cNs
 cPb
 cQN
-cSt
+cSs
 cUi
 cQQ
 cXw
@@ -142857,7 +142522,7 @@ aLL
 aNh
 aOK
 aQt
-aSb
+aLL
 aTI
 aVs
 aNh
@@ -143739,7 +143404,7 @@ dXN
 dYH
 dZp
 dZZ
-eaF
+dUx
 ebm
 dYH
 ecH
@@ -144370,7 +144035,7 @@ adw
 aaa
 aaO
 ajw
-akh
+akg
 akL
 aaO
 amq
@@ -144481,7 +144146,7 @@ dqT
 cPk
 cXD
 cPk
-dwE
+cUp
 dlR
 cPk
 cPk
@@ -146776,7 +146441,7 @@ cNB
 cPr
 cQW
 cSF
-cUy
+cUx
 cQT
 cXL
 cZt
@@ -149080,7 +148745,7 @@ bvM
 bvM
 bvM
 bvM
-cGG
+bvM
 bvM
 bFE
 cKE
@@ -150607,7 +150272,7 @@ ccX
 ceO
 cgC
 cim
-cjW
+cjV
 clk
 cmS
 cou
@@ -150873,7 +150538,7 @@ crj
 csM
 cbk
 cvM
-cxe
+cxa
 bsE
 cAm
 cBL
@@ -153755,7 +153420,7 @@ dSe
 dSZ
 dTS
 dUP
-dVB
+dTS
 dWv
 dXj
 dYc
@@ -154729,7 +154394,7 @@ csW
 cux
 cvX
 cxo
-cyT
+cyR
 cAt
 cBY
 cDz
@@ -154965,7 +154630,7 @@ bHu
 bJq
 bHu
 bHu
-bPn
+bHu
 bHu
 bHu
 bVi
@@ -158078,7 +157743,7 @@ cFB
 cDI
 cIj
 cJr
-cLh
+cLd
 cMC
 cNV
 cPV
@@ -158539,7 +158204,7 @@ aUy
 aWg
 aXM
 aZu
-bbj
+bbd
 bcP
 bcM
 aad

--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -2719,14 +2719,6 @@
 	dir = 1
 	},
 /area/security/prison)
-"afQ" = (
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	dir = 2
-	},
-/turf/open/floor/plasteel/red/corner{
-	dir = 1
-	},
-/area/security/prison)
 "afR" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 1
@@ -11245,15 +11237,6 @@
 /turf/open/floor/plasteel/neutral/corner{
 	dir = 1
 	},
-/area/crew_quarters/dorms)
-"axH" = (
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
 /area/crew_quarters/dorms)
 "axI" = (
 /obj/machinery/door/airlock{
@@ -22647,10 +22630,6 @@
 /obj/effect/turf_decal/delivery,
 /turf/open/floor/plasteel,
 /area/quartermaster/storage)
-"aVI" = (
-/obj/effect/turf_decal/bot,
-/turf/open/floor/plasteel,
-/area/quartermaster/storage)
 "aVJ" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 5
@@ -27283,11 +27262,6 @@
 /area/quartermaster/office)
 "bfd" = (
 /obj/effect/turf_decal/bot,
-/turf/open/floor/plasteel,
-/area/hallway/primary/port)
-"bfe" = (
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plasteel,
 /area/hallway/primary/port)
 "bff" = (
@@ -39038,17 +39012,6 @@
 	dir = 1
 	},
 /area/hallway/secondary/command)
-"bDc" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/plasteel/neutral/corner{
-	dir = 1
-	},
-/area/hallway/secondary/command)
 "bDd" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -39211,14 +39174,6 @@
 	dir = 4
 	},
 /area/hallway/secondary/command)
-"bDt" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/turf/open/floor/plasteel/neutral/corner{
-	dir = 4
-	},
-/area/hallway/secondary/command)
 "bDu" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -39335,9 +39290,6 @@
 /area/crew_quarters/bar)
 "bDD" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on,
-/turf/open/floor/plasteel/bar,
-/area/crew_quarters/bar)
-"bDE" = (
 /turf/open/floor/plasteel/bar,
 /area/crew_quarters/bar)
 "bDF" = (
@@ -39609,9 +39561,6 @@
 /obj/structure/light_construct{
 	dir = 8
 	},
-/turf/open/floor/wood,
-/area/security/vacantoffice)
-"bEr" = (
 /turf/open/floor/wood,
 /area/security/vacantoffice)
 "bEs" = (
@@ -42836,10 +42785,6 @@
 /obj/structure/bookcase/random/adult,
 /turf/open/floor/wood,
 /area/library)
-"bLj" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/turf/open/floor/carpet,
-/area/library)
 "bLk" = (
 /obj/structure/bookcase/random/reference,
 /turf/open/floor/wood,
@@ -44182,9 +44127,6 @@
 /obj/machinery/light/small{
 	dir = 8
 	},
-/turf/open/floor/plasteel,
-/area/engine/atmos)
-"bNT" = (
 /turf/open/floor/plasteel,
 /area/engine/atmos)
 "bNU" = (
@@ -52259,11 +52201,6 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
-"ceM" = (
-/turf/open/floor/plasteel/whitepurple/side{
-	dir = 2
-	},
-/area/science/research)
 "ceN" = (
 /obj/structure/table,
 /obj/machinery/cell_charger,
@@ -52283,14 +52220,6 @@
 	pixel_x = -1;
 	pixel_y = -29
 	},
-/turf/open/floor/plasteel/whitepurple/side{
-	dir = 2
-	},
-/area/science/research)
-"ceP" = (
-/obj/structure/table,
-/obj/item/stock_parts/cell/potato,
-/obj/machinery/light,
 /turf/open/floor/plasteel/whitepurple/side{
 	dir = 2
 	},
@@ -53498,16 +53427,6 @@
 	},
 /area/science/lab)
 "chk" = (
-/turf/open/floor/plasteel/whitepurple/side{
-	dir = 1
-	},
-/area/science/lab)
-"chl" = (
-/obj/structure/noticeboard{
-	desc = "A board for pinning important notices upon.";
-	name = "notice board";
-	pixel_y = 31
-	},
 /turf/open/floor/plasteel/whitepurple/side{
 	dir = 1
 	},
@@ -57363,18 +57282,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/research)
-"cps" = (
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/turf/open/floor/plasteel/white,
-/area/science/research)
 "cpt" = (
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
@@ -60307,13 +60214,6 @@
 /obj/effect/turf_decal/delivery,
 /turf/open/floor/plasteel,
 /area/science/storage)
-"cuX" = (
-/obj/effect/landmark/xeno_spawn,
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/maintenance/starboard/aft)
 "cuY" = (
 /obj/structure/rack,
 /obj/item/extinguisher,
@@ -60326,33 +60226,6 @@
 "cuZ" = (
 /turf/closed/wall/r_wall,
 /area/science/circuit)
-"cva" = (
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/maintenance/starboard/aft)
-"cvb" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 5
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/maintenance/starboard/aft)
-"cvc" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
-	dir = 8
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/turf/open/floor/plating,
-/area/maintenance/starboard/aft)
 "cvd" = (
 /obj/structure/cable{
 	icon_state = "2-4"
@@ -60818,12 +60691,6 @@
 /obj/effect/turf_decal/delivery,
 /turf/open/floor/plasteel,
 /area/science/storage)
-"cvZ" = (
-/obj/structure/closet/crate,
-/obj/item/device/multitool,
-/obj/item/clothing/gloves/color/fyellow,
-/turf/open/floor/plating,
-/area/maintenance/starboard/aft)
 "cwa" = (
 /obj/structure/reagent_dispensers/watertank/high,
 /turf/open/floor/plating,
@@ -62444,15 +62311,6 @@
 /area/science/mixing)
 "czt" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on,
-/turf/open/floor/plasteel/white,
-/area/science/mixing)
-"czu" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 10
-	},
-/obj/machinery/atmospherics/pipe/simple/general/visible{
-	dir = 5
-	},
 /turf/open/floor/plasteel/white,
 /area/science/mixing)
 "czv" = (
@@ -65422,10 +65280,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/science/mixing)
-"cFt" = (
-/obj/effect/decal/cleanable/oil,
-/turf/open/floor/plating,
-/area/maintenance/starboard/aft)
 "cFu" = (
 /obj/structure/closet,
 /obj/item/device/assembly/prox_sensor{
@@ -66427,15 +66281,6 @@
 	},
 /turf/closed/wall/r_wall,
 /area/science/mixing)
-"cHj" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
-/turf/open/floor/plating{
-	icon_state = "platingdmg2"
-	},
-/area/maintenance/starboard/aft)
 "cHk" = (
 /obj/structure/cable,
 /obj/machinery/power/tracker,
@@ -69723,9 +69568,6 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 9
 	},
-/turf/open/floor/plasteel,
-/area/hallway/secondary/exit/departure_lounge)
-"cNM" = (
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit/departure_lounge)
 "cNN" = (
@@ -79377,10 +79219,6 @@
 	icon_state = "platingdmg3"
 	},
 /area/maintenance/port/aft)
-"dxO" = (
-/obj/structure/closet/emcloset,
-/turf/open/floor/plating,
-/area/maintenance/starboard/aft)
 "dxQ" = (
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
@@ -79433,17 +79271,6 @@
 /obj/effect/spawner/lootdrop/maintenance,
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
-"dyQ" = (
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/turf/open/floor/plating{
-	icon_state = "platingdmg1"
-	},
-/area/maintenance/starboard/aft)
 "dzc" = (
 /obj/machinery/space_heater,
 /turf/open/floor/plating,
@@ -79463,14 +79290,6 @@
 /area/maintenance/port/aft)
 "dzQ" = (
 /obj/structure/reagent_dispensers/fueltank,
-/turf/open/floor/plating,
-/area/maintenance/starboard/aft)
-"dzR" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
-/obj/effect/landmark/event_spawn,
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
 "dAd" = (
@@ -80429,7 +80248,7 @@
 	id = "research_shutters";
 	name = "research shutters"
 	},
-/turf/open/floor/plating,
+/turf/open/floor/plasteel/whitepurple,
 /area/science/lab)
 "QsY" = (
 /obj/structure/table,
@@ -80531,10 +80350,6 @@
 /obj/structure/lattice,
 /turf/open/space/basic,
 /area/space)
-"Qtk" = (
-/obj/structure/lattice,
-/turf/open/space/basic,
-/area/space)
 "Qtl" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable/yellow{
@@ -80548,24 +80363,6 @@
 /turf/open/floor/plasteel/white,
 /area/science/circuit)
 "Qtm" = (
-/turf/closed/wall,
-/area/science/circuit)
-"Qtn" = (
-/turf/closed/wall,
-/area/science/circuit)
-"Qto" = (
-/turf/closed/wall,
-/area/science/circuit)
-"Qtp" = (
-/turf/closed/wall,
-/area/science/circuit)
-"Qtq" = (
-/turf/closed/wall,
-/area/science/circuit)
-"Qtr" = (
-/turf/closed/wall,
-/area/science/circuit)
-"Qts" = (
 /turf/closed/wall,
 /area/science/circuit)
 "Qtt" = (
@@ -80675,26 +80472,11 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/circuit)
-"QtC" = (
-/turf/closed/wall,
-/area/science/circuit)
 "QtD" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
-/area/science/circuit)
-"QtE" = (
-/turf/open/floor/plasteel,
-/area/science/circuit)
-"QtF" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/science/circuit)
-"QtG" = (
-/turf/open/floor/plasteel/white,
 /area/science/circuit)
 "QtH" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -80805,9 +80587,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/circuit)
-"QtX" = (
-/turf/closed/wall,
-/area/science/circuit)
 "QtY" = (
 /obj/structure/chair/comfy,
 /turf/open/floor/plasteel,
@@ -80829,19 +80608,11 @@
 	},
 /turf/open/floor/plasteel,
 /area/science/circuit)
-"Quc" = (
-/obj/effect/turf_decal/stripes/line,
-/turf/open/floor/plasteel,
-/area/science/circuit)
 "Qud" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 6
 	},
 /turf/open/floor/plasteel,
-/area/science/circuit)
-"Que" = (
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating,
 /area/science/circuit)
 "Quf" = (
 /obj/structure/table/glass,
@@ -80849,13 +80620,6 @@
 	dir = 4;
 	network = list("SS13")
 	},
-/turf/open/floor/plasteel,
-/area/science/misc_lab)
-"Qug" = (
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plasteel,
 /area/science/misc_lab)
 "Quh" = (
@@ -80932,70 +80696,13 @@
 /obj/machinery/libraryscanner,
 /turf/open/floor/plasteel/white,
 /area/science/circuit)
-"Qut" = (
-/turf/closed/wall,
-/area/science/circuit)
-"Quu" = (
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/turf/open/floor/plasteel,
-/area/science/misc_lab)
-"Quv" = (
-/turf/closed/wall,
-/area/science/circuit)
 "Quw" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 2
 	},
 /turf/closed/wall,
 /area/science/circuit)
-"Qux" = (
-/turf/closed/wall,
-/area/science/circuit)
-"Quy" = (
-/turf/closed/wall,
-/area/science/circuit)
-"Quz" = (
-/turf/closed/wall,
-/area/science/circuit)
-"QuA" = (
-/turf/closed/wall,
-/area/science/circuit)
-"QuB" = (
-/turf/closed/wall,
-/area/science/circuit)
-"QuC" = (
-/turf/closed/wall,
-/area/science/circuit)
-"QuD" = (
-/turf/closed/wall,
-/area/science/circuit)
-"QuE" = (
-/turf/closed/wall,
-/area/science/circuit)
-"QuF" = (
-/turf/closed/wall,
-/area/science/circuit)
-"QuG" = (
-/turf/closed/wall,
-/area/science/circuit)
-"QuH" = (
-/turf/closed/wall,
-/area/science/circuit)
-"QuI" = (
-/turf/closed/wall,
-/area/science/circuit)
 "QuJ" = (
-/obj/structure/lattice,
-/turf/open/space/basic,
-/area/space/nearstation)
-"QuK" = (
-/obj/structure/lattice,
-/turf/open/space/basic,
-/area/space/nearstation)
-"QuL" = (
 /obj/structure/lattice,
 /turf/open/space/basic,
 /area/space/nearstation)
@@ -81012,18 +80719,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/science/mixing)
-"QuO" = (
-/obj/structure/lattice,
-/turf/open/space/basic,
-/area/space/nearstation)
-"QuP" = (
-/obj/structure/lattice,
-/turf/open/space/basic,
-/area/space/nearstation)
-"QuQ" = (
-/obj/structure/lattice,
-/turf/open/space/basic,
-/area/space/nearstation)
 "QuR" = (
 /obj/machinery/vending/snack/random,
 /turf/open/floor/plasteel,
@@ -81050,15 +80745,7 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
-"QuV" = (
-/obj/structure/lattice,
-/turf/open/space/basic,
-/area/space)
 "QuW" = (
-/obj/effect/landmark/event_spawn,
-/turf/open/floor/plasteel/white,
-/area/science/circuit)
-"QuX" = (
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/plasteel/white,
 /area/science/circuit)
@@ -96613,7 +96300,7 @@ bxJ
 bzx
 bBi
 bCM
-bEr
+bBg
 bBg
 bHM
 bJv
@@ -99420,7 +99107,7 @@ aQl
 aMv
 aSS
 aMv
-aVI
+aQl
 aXh
 aMv
 bar
@@ -100986,7 +100673,7 @@ bEy
 bGr
 bwd
 bwd
-bLj
+bwd
 bMK
 bOl
 bPR
@@ -102510,7 +102197,7 @@ aYT
 baC
 bbZ
 bdu
-bfe
+bbZ
 bgX
 biQ
 bkv
@@ -105093,7 +104780,7 @@ bAZ
 bkz
 bzN
 bBB
-bDc
+bDa
 bEG
 bGB
 bIb
@@ -105554,7 +105241,7 @@ ady
 adT
 adc
 aeW
-afQ
+afK
 agJ
 ahx
 ait
@@ -106945,7 +106632,7 @@ cKy
 cLo
 cLm
 cLm
-cNM
+cLm
 cOr
 cOU
 dDG
@@ -111004,7 +110691,7 @@ bwB
 byp
 bAd
 byo
-bDt
+bDj
 bEZ
 bGM
 bIp
@@ -113344,7 +113031,7 @@ cgo
 cgo
 cgo
 ccd
-cps
+cpr
 cci
 crQ
 ctc
@@ -114859,7 +114546,7 @@ bwN
 byz
 bAj
 bBU
-bDE
+bwO
 dDb
 bHb
 bMP
@@ -116949,9 +116636,9 @@ dwL
 dxQ
 cuZ
 Qtt
-QtE
-QtE
-Quc
+cwZ
+cwZ
+cyM
 Quk
 Qtm
 cQv
@@ -117206,9 +116893,9 @@ ctk
 cuc
 cuZ
 dyp
-QtE
-QtE
-Quc
+cwZ
+cwZ
+cyM
 Qul
 Qtm
 czF
@@ -117391,7 +117078,7 @@ asY
 aui
 avm
 asY
-axH
+aui
 ayO
 aAg
 aBA
@@ -117463,10 +117150,10 @@ dvY
 Qtc
 cuZ
 Qtu
-QtF
-QtF
+cxN
+cxN
 Qud
-QtG
+cxO
 Qtm
 czG
 cAN
@@ -117720,8 +117407,8 @@ dvY
 cud
 cuZ
 Qtv
-QtG
-QtG
+cxO
+cxO
 QuW
 Qum
 Qtm
@@ -117979,7 +117666,7 @@ Qtl
 cwd
 QtH
 cxP
-QtG
+cxO
 Qun
 Qtm
 czI
@@ -118236,7 +117923,7 @@ Qtm
 Qtw
 QtI
 QtR
-QtG
+cxO
 Quo
 Qtm
 aaf
@@ -118493,8 +118180,8 @@ Qtm
 Qtx
 QtJ
 QtS
-QuX
-QtG
+QuW
+cxO
 Qtm
 aaf
 aaa
@@ -118750,7 +118437,7 @@ Qtm
 Qty
 QtK
 QtT
-QtG
+cxO
 Qup
 Qtm
 aaa
@@ -119007,7 +118694,7 @@ Qtm
 Qtz
 QtL
 QtU
-QtG
+cxO
 Quq
 Qtm
 aaa
@@ -119264,7 +118951,7 @@ Qtm
 QtA
 QtM
 QtV
-QtG
+cxO
 Qur
 Qtm
 aaa
@@ -119521,7 +119208,7 @@ Qtm
 QtB
 QtN
 QtW
-QtG
+cxO
 Qus
 Qtm
 aaa
@@ -124117,7 +123804,7 @@ bHx
 bIU
 bKB
 bMh
-bNT
+bCi
 bCi
 bKD
 bCi


### PR DESCRIPTION
[Changelogs]: 

:cl: Dax Dupont
fix: Fixed missing tile under autolathes
/:cl:

[why]: Don't mind the removed entries, 
```
- map_files\Deltastation\DeltaStation2.dmm
Notice: Trimming 11 unused dictionary keys.
Succeeded.
 - map_files\MetaStation\MetaStation.dmm
Notice: Trimming 14 unused dictionary keys.
Succeeded.
```

Also i assume mapdiff bot will work so no screenshots