### PR TITLE
Consolidated t-ray scanner code

### DIFF
--- a/code/game/objects/items/devices/scanners.dm
+++ b/code/game/objects/items/devices/scanners.dm
@@ -26,19 +26,6 @@ GAS ANALYZER
 	if(on)
 		START_PROCESSING(SSobj, src)
 
-/obj/item/device/t_scanner/proc/flick_sonar(obj/pipe)
-	if(ismob(loc))
-		var/mob/M = loc
-		var/image/I = new(loc = get_turf(pipe))
-		var/mutable_appearance/MA = new(pipe)
-		MA.alpha = 128
-		MA.dir = pipe.dir
-		I.appearance = MA
-		I.dir = pipe.dir
-		// Workaround for a weird bug with icon direction on T-Ray scan not matching the actual disposal pipe dir.
-		if(M.client)
-			flick_overlay(I, list(M.client), 8)
-
 /obj/item/device/t_scanner/process()
 	if(!on)
 		STOP_PROCESSING(SSobj, src)
@@ -46,15 +33,25 @@ GAS ANALYZER
 	scan()
 
 /obj/item/device/t_scanner/proc/scan()
+	t_ray_scan(loc)
 
-	for(var/turf/T in range(2, src.loc) )
-		for(var/obj/O in T.contents)
+/proc/t_ray_scan(mob/viewer, flick_time = 8, distance = 2)
+	if(!ismob(viewer) || !viewer.client)
+		return
+	var/list/t_ray_images = list()
+	for(var/obj/O in orange(distance, viewer) )
+		if(O.level != 1)
+			continue
 
-			if(O.level != 1)
-				continue
-
-			if(O.invisibility == INVISIBILITY_MAXIMUM)
-				flick_sonar(O)
+		if(O.invisibility == INVISIBILITY_MAXIMUM)
+			var/image/I = new(loc = get_turf(O))
+			var/mutable_appearance/MA = new(O)
+			MA.alpha = 128
+			MA.dir = O.dir
+			I.appearance = MA
+			t_ray_images += I
+	if(t_ray_images.len)
+		flick_overlay(t_ray_images, list(viewer.client), flick_time)
 
 /obj/item/device/healthanalyzer
 	name = "health analyzer"

--- a/code/modules/clothing/glasses/engine_goggles.dm
+++ b/code/modules/clothing/glasses/engine_goggles.dm
@@ -70,26 +70,9 @@
 	if(user.glasses != src || !user.client)
 		return
 	if(mode == MODE_TRAY)
-		scan()
+		t_ray_scan(user, 8, range)
 	else if(mode == MODE_RAD)
 		show_rads()
-
-/obj/item/clothing/glasses/meson/engine/proc/scan()
-	for(var/turf/T in range(range, loc))
-		for(var/obj/O in T.contents)
-			if(O.level != 1)
-				continue
-
-			if(O.invisibility == INVISIBILITY_MAXIMUM)
-				flick_sonar(O)
-
-/obj/item/clothing/glasses/meson/engine/proc/flick_sonar(obj/pipe)
-	var/mob/M = loc
-	var/image/I = new(loc = get_turf(pipe))
-	var/mutable_appearance/MA = new(pipe)
-	MA.alpha = 128
-	I.appearance = MA
-	flick_overlay(I, list(M.client), 8)
 
 /obj/item/clothing/glasses/meson/engine/proc/show_rads()
 	var/mob/living/carbon/human/user = loc

--- a/code/modules/power/cable.dm
+++ b/code/modules/power/cable.dm
@@ -127,10 +127,7 @@ By design, d1 is the smallest direction and d2 is the highest
 	update_icon()
 
 /obj/structure/cable/update_icon()
-	if(invisibility)
-		icon_state = "[d1]-[d2]-f"
-	else
-		icon_state = "[d1]-[d2]"
+	icon_state = "[d1]-[d2]"
 	color = null
 	add_atom_colour(cable_color, FIXED_COLOUR_PRIORITY)
 


### PR DESCRIPTION
Fixes #33642
Fixes #33295

Combined duplicate code from engine goggles and t-ray scanners into one proc. Also refactored t-ray scanning slightly.

:cl:
fix: engine goggles set to t-ray mode will no longer show pipes with the wrong rotation.
fix: cables now show up on t-ray scans.
/:cl:
