### PR TITLE
Removed named args from visible_message

### DIFF
--- a/code/datums/antagonists/clockcult.dm
+++ b/code/datums/antagonists/clockcult.dm
@@ -158,7 +158,7 @@
 	SSticker.mode.servants_of_ratvar -= owner
 	SSticker.mode.update_servant_icons_removed(owner)
 	if(!silent)
-		owner.current.visible_message("<span class='deconversion_message'>[owner] seems to have remembered their true allegiance!</span>", ignored_mob = owner.current)
+		owner.current.visible_message("<span class='deconversion_message'>[owner] seems to have remembered their true allegiance!</span>", null, null, null, owner.current)
 		to_chat(owner, "<span class='userdanger'>A cold, cold darkness flows through your mind, extinguishing the Justiciar's light and all of your memories as his servant.</span>")
 	owner.current.log_message("<font color=#BE8700>Has renounced the cult of Ratvar!</font>", INDIVIDUAL_ATTACK_LOG)
 	owner.special_role = null

--- a/code/datums/antagonists/cult.dm
+++ b/code/datums/antagonists/cult.dm
@@ -133,7 +133,7 @@
 	SSticker.mode.cult -= owner
 	SSticker.mode.update_cult_icons_removed(owner)
 	if(!silent)
-		owner.current.visible_message("<span class='deconversion_message'>[owner.current] looks like [owner.current.p_they()] just reverted to their old faith!</span>", ignored_mob = owner.current)
+		owner.current.visible_message("<span class='deconversion_message'>[owner.current] looks like [owner.current.p_they()] just reverted to their old faith!</span>", null, null, null, owner.current)
 		to_chat(owner.current, "<span class='userdanger'>An unfamiliar white light flashes through your mind, cleansing the taint of the Geometer and all your memories as her servant.</span>")
 		owner.current.log_message("<font color=#960000>Has renounced the cult of Nar'Sie!</font>", INDIVIDUAL_ATTACK_LOG)
 	if(cult_team.blood_target && cult_team.blood_target_image && owner.current.client)

--- a/code/datums/antagonists/revolution.dm
+++ b/code/datums/antagonists/revolution.dm
@@ -200,10 +200,10 @@
 
 /datum/antagonist/rev/farewell()
 	if(ishuman(owner.current))
-		owner.current.visible_message("<span class='deconversion_message'>[owner.current] looks like they just remembered their real allegiance!</span>", ignored_mob = owner.current)
+		owner.current.visible_message("<span class='deconversion_message'>[owner.current] looks like they just remembered their real allegiance!</span>", null, null, null, owner.current)
 		to_chat(owner, "<span class='userdanger'>You are no longer a brainwashed revolutionary! Your memory is hazy from the time you were a rebel...the only thing you remember is the name of the one who brainwashed you...</span>")
 	else if(issilicon(owner.current))
-		owner.current.visible_message("<span class='deconversion_message'>The frame beeps contentedly, purging the hostile memory engram from the MMI before initalizing it.</span>", ignored_mob = owner.current)
+		owner.current.visible_message("<span class='deconversion_message'>The frame beeps contentedly, purging the hostile memory engram from the MMI before initalizing it.</span>", null, null, null, owner.current)
 		to_chat(owner, "<span class='userdanger'>The frame's firmware detects and deletes your neural reprogramming! You remember nothing but the name of the one who flashed you.</span>")
 
 /datum/antagonist/rev/proc/remove_revolutionary(borged, deconverter)

--- a/code/datums/brain_damage/special.dm
+++ b/code/datums/brain_damage/special.dm
@@ -108,7 +108,7 @@
 		new /obj/effect/temp_visual/bluespace_fissure(get_turf(src))
 		new /obj/effect/temp_visual/bluespace_fissure(get_turf(linked_to))
 		user.forceMove(get_turf(linked_to))
-		user.visible_message("<span class='warning'>[user] [slip_in_message].</span>", ignored_mob = user)
+		user.visible_message("<span class='warning'>[user] [slip_in_message].</span>", null, null, null, user)
 		user.visible_message("<span class='warning'>[user] [slip_out_message].</span>", "<span class='notice'>...and find your way to the other side.</span>")
 
 /datum/brain_trauma/special/psychotic_brawling

--- a/code/game/gamemodes/clock_cult/clock_effects/city_of_cogs_rift.dm
+++ b/code/game/gamemodes/clock_cult/clock_effects/city_of_cogs_rift.dm
@@ -54,7 +54,7 @@
 	var/turf/T = get_turf(pick(GLOB.city_of_cogs_spawns))
 	if(is_servant_of_ratvar(AM))
 		T = GLOB.ark_of_the_clockwork_justiciar ? get_step(GLOB.ark_of_the_clockwork_justiciar, SOUTH) : get_turf(pick(GLOB.servant_spawns))
-	AM.visible_message("<span class='danger'>[AM] passes through [src]!</span>", ignored_mob = AM)
+	AM.visible_message("<span class='danger'>[AM] passes through [src]!</span>", null, null, null, AM)
 	AM.forceMove(T)
 	AM.visible_message("<span class='danger'>[AM] materializes from the air!</span>", \
 	"<span class='boldannounce'>You pass through [src] and appear [is_servant_of_ratvar(AM) ? "back at the City of Cogs" : "somewhere unfamiliar. Looks like it was a one-way trip.."].</span>")

--- a/code/game/gamemodes/clock_cult/clock_mobs/_eminence.dm
+++ b/code/game/gamemodes/clock_cult/clock_mobs/_eminence.dm
@@ -28,7 +28,7 @@
 		var/turf/T = get_turf(NewLoc)
 		for(var/obj/effect/blessing/B in T)
 			if(last_failed_turf != T)
-				T.visible_message("<span class='warning'>[T] suddenly emits a ringing sound!</span>", ignore_mob = src)
+				T.visible_message("<span class='warning'>[T] suddenly emits a ringing sound!</span>", null, null, null, src)
 				playsound(T, 'sound/machines/clockcult/ark_damage.ogg', 75, FALSE)
 				last_failed_turf = T
 			to_chat(src, "<span class='warning'>This turf is consecrated and can't be crossed!</span>")

--- a/code/game/objects/items/pet_carrier.dm
+++ b/code/game/objects/items/pet_carrier.dm
@@ -124,17 +124,17 @@
 		to_chat(loc, "<span class='warning'>You see [user] reach through the bars and fumble for the lock switch!</span>")
 		if(!do_after(user, rand(300, 400), target = user) || open || !locked || !user in occupants)
 			return
-		loc.visible_message("<span class='warning'>[user] flips the lock switch on [src] by reaching through!</span>", ignored_mob = user)
+		loc.visible_message("<span class='warning'>[user] flips the lock switch on [src] by reaching through!</span>", null, null, null, user)
 		to_chat(user, "<span class='boldannounce'>Bingo! The lock pops open!</span>")
 		locked = FALSE
 		playsound(src, 'sound/machines/boltsup.ogg', 30, TRUE)
 		update_icon()
 	else
-		loc.visible_message("<span class='warning'>[src] starts rattling as something pushes against the door!</span>", ignored_mob = user)
+		loc.visible_message("<span class='warning'>[src] starts rattling as something pushes against the door!</span>", null, null, null, user)
 		to_chat(user, "<span class='notice'>You start pushing out of [src]... (This will take about 20 seconds.)</span>")
 		if(!do_after(user, 200, target = user) || open || !locked || !user in occupants)
 			return
-		loc.visible_message("<span class='warning'>[user] shoves out of	[src]!</span>", ignored_mob = user)
+		loc.visible_message("<span class='warning'>[user] shoves out of	[src]!</span>", null, null, null, user)
 		to_chat(user, "<span class='notice'>You shove open [src]'s door against the lock's resistance and fall out!</span>")
 		locked = FALSE
 		open = TRUE
@@ -162,7 +162,7 @@
 		to_chat(user, "<span class='warning'>[src] is already carrying too much!</span>")
 		return
 	user.visible_message("<span class='notice'>[user] starts loading [target] into [src].</span>", \
-	"<span class='notice'>You start loading [target] into [src]...</span>", ignored_mob = target)
+	"<span class='notice'>You start loading [target] into [src]...</span>", null, null, target)
 	to_chat(target, "<span class='userdanger'>[user] starts loading you into their [name]!</span>")
 	if(!do_mob(user, target, 30))
 		return
@@ -172,7 +172,7 @@
 		to_chat(user, "<span class='warning'>[src] is already carrying too much!</span>")
 		return
 	user.visible_message("<span class='notice'>[user] loads [target] into [src]!</span>", \
-	"<span class='notice'>You load [target] into [src].</span>", ignored_mob = target)
+	"<span class='notice'>You load [target] into [src].</span>", null, null, target)
 	to_chat(target, "<span class='userdanger'>[user] loads you into their [name]!</span>")
 	add_occupant(target)
 


### PR DESCRIPTION
The following runtime has occurred 529 time(s).
runtime error: bad arg name 'ignore_mob'
proc name: visible message (/atom/proc/visible_message)

Someone typo'd. Safer to just remove them.