### PR TITLE
Fixes omega missing a wheat fridge and runtiming pipenets

### DIFF
--- a/_maps/map_files/OmegaStation/OmegaStation.dmm
+++ b/_maps/map_files/OmegaStation/OmegaStation.dmm
@@ -1266,9 +1266,6 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},

--- a/_maps/map_files/OmegaStation/OmegaStation.dmm
+++ b/_maps/map_files/OmegaStation/OmegaStation.dmm
@@ -15162,7 +15162,6 @@
 /turf/open/floor/plasteel/vault/side,
 /area/crew_quarters/kitchen)
 "aCY" = (
-/obj/structure/closet/secure_closet/freezer/fridge,
 /obj/machinery/light{
 	dir = 1
 	},
@@ -15172,6 +15171,7 @@
 	name = "Kitchen RC";
 	pixel_y = 32
 	},
+/obj/structure/closet/secure_closet/freezer/kitchen,
 /turf/open/floor/plasteel/vault/side,
 /area/crew_quarters/kitchen)
 "aCZ" = (
@@ -29395,12 +29395,6 @@
 	dir = 8;
 	heat_capacity = 1e+006
 	},
-/area/hallway/primary/central)
-"bgh" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/turf/open/floor/plasteel/neutral/side,
 /area/hallway/primary/central)
 "bgl" = (
 /obj/machinery/vending/cola/random,
@@ -77507,7 +77501,7 @@ bed
 beI
 bff
 bfL
-bgh
+aYc
 bgU
 bhI
 blv


### PR DESCRIPTION
[Changelogs]: 
:cl: Dax Dupont
fix: Fixed missing wheat fridge on omega and removes a duplicate pipe.
/:cl:


[why]: Fixes #34780 and removes duplicate pipe causing runtimes
