### PR TITLE
Unfucks supermatter extraction

### DIFF
--- a/code/game/objects/items/theft_tools.dm
+++ b/code/game/objects/items/theft_tools.dm
@@ -227,7 +227,7 @@
 	if(!sliver)
 		return
 	if(ismovableatom(O) && O != sliver)
-		Consume(O)
+		Consume(O, user)
 		to_chat(usr, "<span class='notice'>\The [sliver] is dusted along with \the [O]!</span>")
 		QDEL_NULL(sliver)
 		update_icon()
@@ -249,11 +249,12 @@
 	else
 		investigate_log("has consumed [AM].", "supermatter")
 		qdel(AM)
-	user.visible_message("<span class='danger'>As [user] touches \the [AM] with \a [src], silence fills the room...</span>",\
+	if (user)
+		user.visible_message("<span class='danger'>As [user] touches \the [AM] with \a [src], silence fills the room...</span>",\
 			"<span class='userdanger'>You touch \the [AM] with \the [src], and everything suddenly goes silent.</span>\n<span class='notice'>\The [AM] flashes into dust, and soon as you can register this, you do as well.</span>",\
 			"<span class='italics'>Everything suddenly goes silent.</span>")
+		user.dust()
 	radiation_pulse(user, 500, 2)
 	playsound(src, 'sound/effects/supermatter.ogg', 50, 1)
-	user.dust()
 	QDEL_NULL(sliver)
 	update_icon()

--- a/code/game/objects/items/theft_tools.dm
+++ b/code/game/objects/items/theft_tools.dm
@@ -233,9 +233,6 @@
 		return
 	if(ismovableatom(O) && O != sliver)
 		Consume(O, user)
-		to_chat(usr, "<span class='notice'>\The [sliver] is dusted along with \the [O]!</span>")
-		QDEL_NULL(sliver)
-		update_icon()
 
 /obj/item/hemostat/supermatter/throw_impact(atom/hit_atom) // no instakill supermatter javelins
 	if(sliver)
@@ -255,8 +252,8 @@
 		investigate_log("has consumed [AM].", "supermatter")
 		qdel(AM)
 	if (user)
-		user.visible_message("<span class='danger'>As [user] touches \the [AM] with \a [src], silence fills the room...</span>",\
-			"<span class='userdanger'>You touch \the [AM] with \the [src], and everything suddenly goes silent.</span>\n<span class='notice'>\The [AM] flashes into dust, and soon as you can register this, you do as well.</span>",\
+		user.visible_message("<span class='danger'>As [user] touches [AM] with \a [src], silence fills the room...</span>",\
+			"<span class='userdanger'>You touch [AM] with [src], and everything suddenly goes silent.</span>\n<span class='notice'>[AM] and [sliver] flash into dust, and soon as you can register this, you do as well.</span>",\
 			"<span class='italics'>Everything suddenly goes silent.</span>")
 		user.dust()
 	radiation_pulse(src, 500, 2)

--- a/code/game/objects/items/theft_tools.dm
+++ b/code/game/objects/items/theft_tools.dm
@@ -203,6 +203,7 @@
 	toolspeed = 0.5
 	damtype = "fire"
 	usesound = 'sound/weapons/bladeslice.ogg'
+	var/usesLeft = 2
 
 /obj/item/hemostat/supermatter
 	name = "supermatter extraction tongs"

--- a/code/game/objects/items/theft_tools.dm
+++ b/code/game/objects/items/theft_tools.dm
@@ -255,7 +255,7 @@
 			"<span class='userdanger'>You touch \the [AM] with \the [src], and everything suddenly goes silent.</span>\n<span class='notice'>\The [AM] flashes into dust, and soon as you can register this, you do as well.</span>",\
 			"<span class='italics'>Everything suddenly goes silent.</span>")
 		user.dust()
-	radiation_pulse(user, 500, 2)
+	radiation_pulse(src, 500, 2)
 	playsound(src, 'sound/effects/supermatter.ogg', 50, 1)
 	QDEL_NULL(sliver)
 	update_icon()

--- a/code/game/objects/items/theft_tools.dm
+++ b/code/game/objects/items/theft_tools.dm
@@ -203,7 +203,11 @@
 	toolspeed = 0.5
 	damtype = "fire"
 	usesound = 'sound/weapons/bladeslice.ogg'
-	var/usesLeft = 2
+	var/usesLeft
+
+/obj/item/scalpel/supermatter/Initialize()
+	. = ..()
+	usesLeft = rand(2, 4)
 
 /obj/item/hemostat/supermatter
 	name = "supermatter extraction tongs"

--- a/code/modules/power/supermatter/supermatter.dm
+++ b/code/modules/power/supermatter/supermatter.dm
@@ -543,7 +543,9 @@ GLOBAL_DATUM(main_supermatter_engine, /obj/machinery/power/supermatter_shard)
 		if(do_after(user, 60 * W.toolspeed, TRUE, src))
 			to_chat(user, "<span class='notice'>You extract a sliver from \the [src]. \The [src] begins to react violently!</span>")
 			new /obj/item/nuke_core/supermatter_sliver(drop_location())
+			lastwarning = REALTIMEOFDAY + 100 // Gives them some time to move out before it warns engineering, AI and/or the crew
 			matter_power += 200
+			damage += 250
 	else if(user.dropItemToGround(W))
 		user.visible_message("<span class='danger'>As [user] touches \the [src] with \a [W], silence fills the room...</span>",\
 			"<span class='userdanger'>You touch \the [src] with \the [W], and everything suddenly goes silent.</span>\n<span class='notice'>\The [W] flashes into dust as you flinch away from \the [src].</span>",\

--- a/code/modules/power/supermatter/supermatter.dm
+++ b/code/modules/power/supermatter/supermatter.dm
@@ -538,14 +538,17 @@ GLOBAL_DATUM(main_supermatter_engine, /obj/machinery/power/supermatter_shard)
 	if(!istype(W) || (W.flags_1 & ABSTRACT_1) || !istype(user))
 		return
 	if(istype(W, /obj/item/scalpel/supermatter))
+		var/obj/item/scalpel/supermatter/scalpel = W
 		playsound(src, W.usesound, 100, 1)
 		to_chat(user, "<span class='notice'>You carefully begin to scrape \the [src] with \the [W]...</span>")
 		if(do_after(user, 60 * W.toolspeed, TRUE, src))
-			to_chat(user, "<span class='notice'>You extract a sliver from \the [src]. \The [src] begins to react violently!</span>")
-			new /obj/item/nuke_core/supermatter_sliver(drop_location())
-			lastwarning = REALTIMEOFDAY + 100 // Gives them some time to move out before it warns engineering, AI and/or the crew
-			matter_power += 200
-			damage += 250
+			if (scalpel.usesLeft)
+				to_chat(user, "<span class='notice'>You extract a sliver from \the [src]. \The [src] begins to react violently!</span>")
+				new /obj/item/nuke_core/supermatter_sliver(drop_location())
+				matter_power += 200
+				scalpel.usesLeft -= 1
+			else 
+				to_chat(user, "<span class='notice'>You fail to extract a sliver from \the [src]. \The [W] isn't sharp enough anymore!</span>")
 	else if(user.dropItemToGround(W))
 		user.visible_message("<span class='danger'>As [user] touches \the [src] with \a [W], silence fills the room...</span>",\
 			"<span class='userdanger'>You touch \the [src] with \the [W], and everything suddenly goes silent.</span>\n<span class='notice'>\The [W] flashes into dust as you flinch away from \the [src].</span>",\

--- a/code/modules/power/supermatter/supermatter.dm
+++ b/code/modules/power/supermatter/supermatter.dm
@@ -546,7 +546,7 @@ GLOBAL_DATUM(main_supermatter_engine, /obj/machinery/power/supermatter_shard)
 				to_chat(user, "<span class='notice'>You extract a sliver from \the [src]. \The [src] begins to react violently!</span>")
 				new /obj/item/nuke_core/supermatter_sliver(drop_location())
 				matter_power += 200
-				scalpel.usesLeft -= 1
+				scalpel.usesLeft--
 			else 
 				to_chat(user, "<span class='notice'>You fail to extract a sliver from \the [src]. \The [W] isn't sharp enough anymore!</span>")
 	else if(user.dropItemToGround(W))

--- a/code/modules/power/supermatter/supermatter.dm
+++ b/code/modules/power/supermatter/supermatter.dm
@@ -540,15 +540,17 @@ GLOBAL_DATUM(main_supermatter_engine, /obj/machinery/power/supermatter_shard)
 	if(istype(W, /obj/item/scalpel/supermatter))
 		var/obj/item/scalpel/supermatter/scalpel = W
 		playsound(src, W.usesound, 100, 1)
-		to_chat(user, "<span class='notice'>You carefully begin to scrape \the [src] with \the [W]...</span>")
+		to_chat(user, "<span class='notice'>You carefully begin to scrape [src] with [W]...</span>")
 		if(do_after(user, 60 * W.toolspeed, TRUE, src))
 			if (scalpel.usesLeft)
-				to_chat(user, "<span class='notice'>You extract a sliver from \the [src]. \The [src] begins to react violently!</span>")
+				to_chat(user, "<span class='notice'>You extract a sliver from [src]. [src] begins to react violently!</span>")
 				new /obj/item/nuke_core/supermatter_sliver(drop_location())
 				matter_power += 200
 				scalpel.usesLeft--
+				if (!scalpel.usesLeft) 
+					to_chat(user, "<span class='notice'>A tiny piece of [W] falls off, rendering it useless!</span>")
 			else 
-				to_chat(user, "<span class='notice'>You fail to extract a sliver from \the [src]. \The [W] isn't sharp enough anymore!</span>")
+				to_chat(user, "<span class='notice'>You fail to extract a sliver from [src]. [W] isn't sharp enough anymore!</span>")
 	else if(user.dropItemToGround(W))
 		user.visible_message("<span class='danger'>As [user] touches \the [src] with \a [W], silence fills the room...</span>",\
 			"<span class='userdanger'>You touch \the [src] with \the [W], and everything suddenly goes silent.</span>\n<span class='notice'>\The [W] flashes into dust as you flinch away from \the [src].</span>",\


### PR DESCRIPTION
[Changelogs]: 

:cl: Dax Dupont
fix: People can no longer extract 300 supermatter shard slivers without it exploding.
fix: Fixed thongs not dusting people on use.
/:cl:

[why]: I was bored while cooking supper
Fixes #34730 by doing about 30% damage to the SM. They have about 10 seconds to scram before it warns people. 

Also fixes a runtime, for some reason nobody passed the user, that has now changed and a sanity check was added.
This will now dust people on attack, which might be a balance change. This seems like the intended goal of the code, unless it was just a sloppy copy pasta, please input @KorPhaeron.
