### PR TITLE
Puts beakers in your hand on eject

### DIFF
--- a/code/modules/reagents/chemistry/machinery/chem_dispenser.dm
+++ b/code/modules/reagents/chemistry/machinery/chem_dispenser.dm
@@ -182,6 +182,8 @@
 		if("eject")
 			if(beaker)
 				beaker.forceMove(drop_location())
+				if(Adjacent(usr) && !issilicon(usr))
+					usr.put_in_hands(beaker)
 				beaker = null
 				cut_overlays()
 				. = TRUE

--- a/code/modules/reagents/chemistry/machinery/chem_heater.dm
+++ b/code/modules/reagents/chemistry/machinery/chem_heater.dm
@@ -29,9 +29,11 @@
 	else
 		icon_state = "mixer0b"
 
-/obj/machinery/chem_heater/proc/eject_beaker()
+/obj/machinery/chem_heater/proc/eject_beaker(mob/user)
 	if(beaker)
 		beaker.forceMove(drop_location())
+		if(Adjacent(user) && !issilicon(user))
+			user.put_in_hands(beaker)
 		beaker = null
 		update_icon()
 
@@ -129,5 +131,5 @@
 				target_temperature = CLAMP(target, 0, 1000)
 		if("eject")
 			on = FALSE
-			eject_beaker()
+			eject_beaker(usr)
 			. = TRUE

--- a/code/modules/reagents/chemistry/machinery/chem_master.dm
+++ b/code/modules/reagents/chemistry/machinery/chem_master.dm
@@ -59,10 +59,13 @@
 	else
 		icon_state = "mixer0"
 
-/obj/machinery/chem_master/proc/eject_beaker()
+/obj/machinery/chem_master/proc/eject_beaker(mob/user)
 	if(beaker)
 		beaker.forceMove(drop_location())
-		adjust_item_drop_location(beaker)
+		if(Adjacent(user) && !issilicon(user))
+			user.put_in_hands(beaker)
+		else
+			adjust_item_drop_location(beaker)
 		beaker = null
 		update_icon()
 
@@ -169,7 +172,7 @@
 		return
 	switch(action)
 		if("eject")
-			eject_beaker()
+			eject_beaker(usr)
 			. = TRUE
 
 		if("ejectp")

--- a/code/modules/reagents/chemistry/machinery/reagentgrinder.dm
+++ b/code/modules/reagents/chemistry/machinery/reagentgrinder.dm
@@ -201,6 +201,8 @@
 	if(!beaker)
 		return
 	beaker.forceMove(drop_location())
+	if(Adjacent(user) && !issilicon(user))
+		user.put_in_hands(beaker)
 	beaker = null
 	update_icon()
 	updateUsrDialog()


### PR DESCRIPTION
[Changelogs]:
:cl: Dax Dupont
add: Beakers and beaker-like objects now get put in your hand on ejection from chemistry devices.
/:cl:

[why]: Small QoL improvement, it's dumb to have the main beakers just drop and 512 is putting shit behind machines so I figured why not make this change.
