### PR TITLE
Fixes no eye damage being done if damage was exactly 3

### DIFF
--- a/code/modules/mob/living/carbon/carbon_defense.dm
+++ b/code/modules/mob/living/carbon/carbon_defense.dm
@@ -290,7 +290,7 @@
 			to_chat(src, "<span class='warning'>Your eyes burn.</span>")
 			adjust_eye_damage(rand(2, 4))
 
-		else if( damage > 3)
+		else if( damage >= 3)
 			to_chat(src, "<span class='warning'>Your eyes itch and burn severely!</span>")
 			adjust_eye_damage(rand(12, 16))
 


### PR DESCRIPTION
:cl:
fix: Fixed eye damage not being applied if it was exactly 3.
/:cl:

Fun fact. welding with thermals dealt no damage before.