### PR TITLE
Silicons now know the Lepidopterian language

### DIFF
--- a/code/modules/language/language_holder.dm
+++ b/code/modules/language/language_holder.dm
@@ -127,7 +127,7 @@
 
 /datum/language_holder/synthetic
 	languages = list(/datum/language/common)
-	shadow_languages = list(/datum/language/common, /datum/language/machine, /datum/language/draconic)
+	shadow_languages = list(/datum/language/common, /datum/language/machine, /datum/language/draconic, /datum/language/moth)
 
 /datum/language_holder/universal/New()
 	..()


### PR DESCRIPTION
:cl: coiax
add: Silicons have had Lepidopterian added to their language database.
/:cl:

Bit of an oversight here; when I added Draconic, giving it to silicons
was one of the "balances" I think people semi-agreed on. This means that
the moths can't plan to kill all the humans without silicons noticing.