### PR TITLE
Makes Chameleon Kits less restricted

### DIFF
--- a/code/modules/uplink/uplink_items.dm
+++ b/code/modules/uplink/uplink_items.dm
@@ -712,7 +712,7 @@ GLOBAL_LIST_EMPTY(uplink_items) // Global list so we only initialize this once.
 	item = /obj/item/storage/box/syndie_kit/chameleon
 	cost = 4
 	exclude_modes = list(/datum/game_mode/nuclear)
-	player_minimum = 20
+	player_minimum = 12
 
 /datum/uplink_item/stealthy_tools/chameleon/nuke
 	cost = 6


### PR DESCRIPTION
[Changelogs]: The Syndicate would like to apologise to its agents on under-manned stations for failing to supply them with proper disguises 

:cl:
balance: The Syndicate Chameleon Kit is now available during rounds of lower population. Because of course you can have an e-sword and revolver without restriction but disguising and RP is verboten because we deathmatch station now.
/:cl:

[why]: I'd rather remove the restriction entirely but I'm sure someone will complain that a perfect disguise is OP on low-pop but Sleeping Carp/Revolver/etc isn't somehow
