### PR TITLE
Abstract landmarks are now indestructible

### DIFF
--- a/code/game/objects/effects/landmarks.dm
+++ b/code/game/objects/effects/landmarks.dm
@@ -4,6 +4,18 @@
 	icon_state = "x2"
 	anchored = TRUE
 	invisibility = INVISIBILITY_ABSTRACT
+	resistance_flags = INDESTRUCTIBLE | LAVA_PROOF | FIRE_PROOF | UNACIDABLE | ACID_PROOF
+
+/obj/effect/landmark/singularity_act()
+	return
+
+// Please stop bombing the Observer-Start landmark.
+/obj/effect/landmark/ex_act()
+	return
+
+/obj/effect/landmark/singularity_pull()
+	return
+
 
 /obj/effect/landmark/New()
 	..()


### PR DESCRIPTION
In situations where a maxcap has been dropped above the Bridge, which is
generally the Observer-Start landmark's location, it would destroy the
landmark, making observers get a debugging message asking them to ahelp
when they observed.

There should be a better way of making an object indestructible from any
ingame effect without having to make it QDEL_HINT_LETMELIVE.