### PR TITLE
Ruin Template Spawner (wip)

### DIFF
--- a/code/modules/mapping/mapping_helpers.dm
+++ b/code/modules/mapping/mapping_helpers.dm
@@ -72,7 +72,7 @@
 		return ..()
 	whitelist = typecacheof(whitelist)
 	return ..()
-	
+
 /obj/effect/baseturf_helper/picky/replace_baseturf(turf/thing)
 	if(!whitelist[thing.type])
 		return
@@ -100,4 +100,29 @@ GLOBAL_LIST_EMPTY(z_is_planet)
 	var/turf/T = get_turf(src)
 	GLOB.z_is_planet["[T.z]"] = TRUE
 	return INITIALIZE_HINT_QDEL
+
+/obj/effect/mapping_helpers/template_spawner //spawning templates
+	name = "template spawner"
+	icon = 'icons/obj/items_and_weapons.dmi'
+	icon_state = "syndballoon"
+	layer = POINT_LAYER
+	var/list/template_name = list("Biological Storage Facility") //list of potential templates to pull from, uses the template's name instead of ID
+	var/map_templates = "space_ruins_templates" //the mapping template list from the mapping subsystem
+	var/datum/map_template/template_to_spawn
+
+/obj/effect/mapping_helpers/template_spawner/proc/get_template(id)
+	var/template_to_spawn = SSmapping.[map_templates][id]
+	if(!template_to_spawn)
+		CRASH("Template ([id]) not found!")
+		qdel(src)
+	return template_to_spawn
+
+/obj/effect/mapping_helpers/template_spawner/Initialize(mapload)
+	if(mapload)
+		var/turf/deploy_location = get_turf(src)
+		var/datum/map_template/template_to_spawn = get_template(pick(template_name))
+		template_to_spawn.load(deploy_location, centered = TRUE)
+		return INITIALIZE_HINT_QDEL
+	else
+		return ..()
 


### PR DESCRIPTION

[why]: A way of having random ruin parts within ruins. Maybe something like a grid-based dungeon with tile segments that are random each time? I dunno, it's up to your imagination.

Adds a mapping helper that lets you place templates of your choice from a list, checks against whatever template list you select from the mapping subsystem.

WIP, as it currently works fine spawning in post-roundstart but mapping it in causes runtimes and I'm too much of a smooth-brain to figure out a way around it.

Runtime in gas_mixture.dm,387: Cannot read null.gases
Runtime in open.dm,137: Cannot execute null.compare().

Both cause enough errors to get silenced.



