### PR TITLE
Plasma cutter now has a tool sound

### DIFF
--- a/code/modules/projectiles/guns/energy/special.dm
+++ b/code/modules/projectiles/guns/energy/special.dm
@@ -126,6 +126,8 @@
 	sharpness = IS_SHARP
 	can_charge = 0
 	heat = 3800
+
+	usesound = 'sound/items/welder.ogg'
 	toolspeed = 0.7 //plasmacutters can be used as welders for a few things, and are faster than standard welders
 
 /obj/item/gun/energy/plasmacutter/examine(mob/user)


### PR DESCRIPTION
It's used as a welder replacement in some construction steps, so using welder sound makes sense.