### PR TITLE
Buffs the Contributing Guide (Fixes a typo)

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -387,7 +387,7 @@ Do not add any of the following in a Pull Request or risk getting the PR closed:
 * Code where one line of code is split across mutiple lines (except for multiple, separate strings and comments; in those cases, existing longer lines must not be split up)
 * Code adding, removing, or updating the availability of alien races/species/human mutants without prior approval. Pull requests attempting to add or remove features from said races/species/mutants require prior approval as well.
 
-Just becuase something isn't on this list doesn't mean that it's acceptable. Use common sense above all else.
+Just because something isn't on this list doesn't mean that it's acceptable. Use common sense above all else.
 
 ## A word on Git
 Yes, we know that the files have a tonne of mixed Windows and Linux line endings. Attempts to fix this have been met with less than stellar success, and as such we have decided to give up caring until there comes a time when it matters.


### PR DESCRIPTION
[why]: Because because is meant to be because. Why? Just because.