### PR TITLE
Makes the soapstone engravings use examine to show the dialog

### DIFF
--- a/code/modules/library/soapstone.dm
+++ b/code/modules/library/soapstone.dm
@@ -193,7 +193,7 @@
 
 /obj/structure/chisel_message/examine(mob/user)
 	..()
-	to_chat(user, "<span class='warning'>[hidden_message]</span>")
+	ui_interact(user)
 
 /obj/structure/chisel_message/Destroy()
 	if(persists)
@@ -201,8 +201,10 @@
 	SSpersistence.chisel_messages -= src
 	. = ..()
 
-/obj/structure/chisel_message/ui_interact(mob/user, ui_key = "main", datum/tgui/ui = null, force_open = FALSE, datum/tgui/master_ui = null, datum/ui_state/state = GLOB.always_state)
+/obj/structure/chisel_message/interact()
+	return
 
+/obj/structure/chisel_message/ui_interact(mob/user, ui_key = "main", datum/tgui/ui = null, force_open = FALSE, datum/tgui/master_ui = null, datum/ui_state/state = GLOB.always_state)
 	ui = SStgui.try_update_ui(user, src, ui_key, ui, force_open)
 	if(!ui)
 		ui = new(user, src, ui_key, "engraved_message", name, 600, 300, master_ui, state)


### PR DESCRIPTION
[Changelogs]: 
:cl: Dax Dupont
tweak: You now need to examine engravings to pop open the menu. 
/:cl:

[why]:
This should prevent people from accidently clicking it during combat.
https://tgstation13.org/phpBB/viewtopic.php?f=9&t=15075
