### PR TITLE
Fixes double camera assemblies when deconstructing cameras

### DIFF
--- a/code/game/machinery/camera/camera.dm
+++ b/code/game/machinery/camera/camera.dm
@@ -42,10 +42,13 @@
 
 	var/internal_light = TRUE //Whether it can light up when an AI views it
 
-/obj/machinery/camera/Initialize(mapload)
+/obj/machinery/camera/Initialize(mapload, obj/structure/camera_assembly/CA)
 	. = ..()
-	assembly = new(src)
-	assembly.state = 4
+	if(CA)
+		assembly = CA
+	else
+		assembly = new(src)
+		assembly.state = 4
 	GLOB.cameranet.cameras += src
 	GLOB.cameranet.addCamera(src)
 	if (isturf(loc))

--- a/code/game/machinery/camera/camera_assembly.dm
+++ b/code/game/machinery/camera/camera_assembly.dm
@@ -100,9 +100,8 @@
 		to_chat(user, "<span class='warning'>No network found, please hang up and try your call again!</span>")
 		return
 	state = 4
-	var/obj/machinery/camera/C = new(src.loc)
+	var/obj/machinery/camera/C = new(loc, src)
 	forceMove(C)
-	C.assembly = src
 	C.setDir(src.dir)
 
 	C.network = tempnetwork


### PR DESCRIPTION
Fixes #32335
Can't have two assemblies in the camera's contents because machines dump contents in Destroy()