### PR TITLE
Nerfs water stuns

### DIFF
--- a/code/game/turfs/open.dm
+++ b/code/game/turfs/open.dm
@@ -225,7 +225,7 @@
 		var/turf/open/O = T
 		O.MakeSlippery(wet_setting = wet, wet_time_to_add = wet_time) //we're copied, copy how wet we are also
 
-/turf/open/proc/MakeSlippery(wet_setting = TURF_WET_WATER, min_wet_time = 0, wet_time_to_add = 0) // 1 = Water, 2 = Lube, 3 = Ice, 4 = Permafrost, 5 = Slide
+/turf/open/proc/MakeSlippery(wet_setting = TURF_WET_WATER, min_wet_time = 0, wet_time_to_add = 0)
 	wet_time = max(wet_time+wet_time_to_add, min_wet_time)
 	if(wet >= wet_setting)
 		return
@@ -258,7 +258,7 @@
 	var/lube_flags
 	switch(wet)
 		if(TURF_WET_WATER)
-			intensity = 60
+			intensity = 30
 			lube_flags = NO_SLIP_WHEN_WALKING
 		if(TURF_WET_LUBE)
 			intensity = 80


### PR DESCRIPTION
Apparently people think water is OP so instead of having a big circular argument in discord you can have it here. 

Takes water from a 6 second stun to a 3 second stun, which is just about enough to apply cablecuffs if you're quick I think.


:cl: Dorsidwarf
balance: Through reverse-engineering syndicate technology, we've found that grips on the bottom of shoes make trips and falls less unpleasant. We've applied this discovery to your feet, too.
/:cl:)

![](http://puu.sh/z8FX2/ff4570b987.png)
