### PR TITLE
Romerol works on dead people

### DIFF
--- a/code/modules/reagents/chemistry/reagents/other_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/other_reagents.dm
@@ -1633,7 +1633,7 @@
 	can_synth = 0
 	taste_description = "brains"
 
-/datum/reagent/romerol/on_mob_life(mob/living/carbon/human/H)
+/datum/reagent/romerol/reaction_mob(mob/living/carbon/human/H, method=TOUCH, reac_volume)
 	// Silently add the zombie infection organ to be activated upon death
 	if(!H.getorganslot(ORGAN_SLOT_ZOMBIE))
 		var/obj/item/organ/zombie_infection/ZI = new()


### PR DESCRIPTION
:cl: coiax
balance: Romerol is now effective on dead bodies, not just ones that are
still alive.
/:cl:

Why? Because it seems silly that a zombie virus requires someone to be
alive, and zombie claws work on dead bodies.