### PR TITLE
Fixes turret borg targeting and prevents non-Syndie borgs from accessing Syndie blastdoors

### DIFF
--- a/code/game/machinery/buttons.dm
+++ b/code/game/machinery/buttons.dm
@@ -56,6 +56,12 @@
 		else
 			icon_state = skin
 
+/obj/machinery/button/allowed(mob/M)
+	if(req_access_txt == ACCESS_SYNDICATE && issilicon(M)) //The syndicate figured out how to lock out borgs
+		if(!("syndicate" in M.faction))
+			return FALSE
+	..()
+
 /obj/machinery/button/attackby(obj/item/W, mob/user, params)
 	if(istype(W, /obj/item/screwdriver))
 		if(panel_open || allowed(user))

--- a/code/game/machinery/buttons.dm
+++ b/code/game/machinery/buttons.dm
@@ -57,7 +57,7 @@
 			icon_state = skin
 
 /obj/machinery/button/allowed(mob/M)
-	if(req_access_txt == ACCESS_SYNDICATE && issilicon(M)) //The syndicate figured out how to lock out borgs
+	if(req_access_txt == "syndicate" && issilicon(M)) //The syndicate figured out how to lock out borgs
 		if(!("syndicate" in M.faction))
 			return FALSE
 	return ..()

--- a/code/game/machinery/buttons.dm
+++ b/code/game/machinery/buttons.dm
@@ -60,7 +60,7 @@
 	if(req_access_txt == ACCESS_SYNDICATE && issilicon(M)) //The syndicate figured out how to lock out borgs
 		if(!("syndicate" in M.faction))
 			return FALSE
-	..()
+	return ..()
 
 /obj/machinery/button/attackby(obj/item/W, mob/user, params)
 	if(istype(W, /obj/item/screwdriver))

--- a/code/game/machinery/buttons.dm
+++ b/code/game/machinery/buttons.dm
@@ -57,7 +57,7 @@
 			icon_state = skin
 
 /obj/machinery/button/allowed(mob/M)
-	if(req_access_txt == "syndicate" && issilicon(M)) //The syndicate figured out how to lock out borgs
+	if(req_access == 150 && issilicon(M)) //The syndicate figured out how to lock out borgs
 		if(!("syndicate" in M.faction))
 			return FALSE
 	return ..()

--- a/code/game/machinery/porta_turret/portable_turret.dm
+++ b/code/game/machinery/porta_turret/portable_turret.dm
@@ -390,11 +390,11 @@
 				if(!in_faction(C))
 					targets += C
 		
-		if(issilicon(A))
-			var/mob/living/silicon/S = A
-			if(S.stat || in_faction(S) || S.emagged) //don't target if dead, in faction, or emagged
+		if(iscyborg(A))
+			var/mob/living/silicon/robot/R = A
+			if(R.stat || in_faction(R) || R.emagged) //don't target if dead, in faction, or emagged
 				continue
-			targets += S
+			targets += R
 
 		if(ismecha(A))
 			var/obj/mecha/M = A

--- a/code/game/machinery/porta_turret/portable_turret.dm
+++ b/code/game/machinery/porta_turret/portable_turret.dm
@@ -389,6 +389,12 @@
 			else if(check_anomalies) //non humans who are not simple animals (xenos etc)
 				if(!in_faction(C))
 					targets += C
+		
+		if(issilicon(A))
+			var/mob/living/silicon/S = A
+			if(S.stat || in_faction(S) || S.emagged) //don't target if dead, in faction, or emagged
+				continue
+			targets += S
 
 		if(ismecha(A))
 			var/obj/mecha/M = A


### PR DESCRIPTION
:cl: Robustin
balance: Nukeops rejoice! The syndicate shuttle blast doors can no longer be operated by station borgs. Don't forget to close the door since interior electronics remain vulnerable to borg tampering. 
fix: Syndicate turrets will now target any non-Syndicate or non-emagged Cyborgs.
/:cl:

The nukeops know its fair game for crew to fuck with their shuttle when they park it within eyeshot of the station, but virtually nobody was aware that gaps in turret and object code made loyal Cyborgs functionally identical to Syndieborgs - ensuring that a station borg reaching the Syndie shuttle all but guaranteed Nukeop failure.

Fixes #34845