### PR TITLE
Adds Pax to the Peacekeeper Borg's "Peace Hypospray"

### DIFF
--- a/code/modules/reagents/reagent_containers/borghydro.dm
+++ b/code/modules/reagents/reagent_containers/borghydro.dm
@@ -225,13 +225,13 @@ Borg Shaker
 /obj/item/reagent_containers/borghypo/peace
 	name = "Peace Hypospray"
 
-	reagent_ids = list("dizzysolution","tiresolution")
+	reagent_ids = list("dizzysolution","tiresolution","pax")
 	accepts_reagent_upgrades = FALSE
 
 /obj/item/reagent_containers/borghypo/peace/hacked
 	desc = "Everything's peaceful in death!"
 	icon_state = "borghypo_s"
-	reagent_ids = list("dizzysolution","tiresolution","tirizene","sulfonal","sodium_thiopental","cyanide","neurotoxin2")
+	reagent_ids = list("dizzysolution","tiresolution","pax","tirizene","sulfonal","sodium_thiopental","cyanide","neurotoxin2")
 	accepts_reagent_upgrades = FALSE
 
 /obj/item/reagent_containers/borghypo/epi


### PR DESCRIPTION
:cl: Robustin
add: The Peacekeeper Borg's "Peace Hypospray" now includes the "Pax" reagent, which prevents the subject from carrying out many forms of direct harm.
/:cl:

I don't even like PK borgs but thematically speaking this just made too much sense. 
