### PR TITLE
Holorecord fixes and additions

### DIFF
--- a/code/datums/holocall.dm
+++ b/code/datums/holocall.dm
@@ -230,7 +230,7 @@
 				record = new
 			record.caller_name = holodiskOriginal.record.caller_name
 			record.caller_image = holodiskOriginal.record.caller_image
-			record.entries = holodiskOriginal.record.entries
+			record.entries = holodiskOriginal.record.entries.Copy()
 			record.language = holodiskOriginal.record.language
 			to_chat(user, "You copy the record from [holodiskOriginal] to [src] by connecting the ports!")
 			name = holodiskOriginal.name

--- a/code/datums/holocall.dm
+++ b/code/datums/holocall.dm
@@ -206,6 +206,8 @@
 	name = "holorecord disk"
 	desc = "Stores recorder holocalls."
 	icon_state = "holodisk"
+	obj_flags = UNIQUE_RENAME
+	materials = list(MAT_METAL = 100, MAT_GLASS = 100)
 	var/datum/holorecord/record
 	//Preset variables
 	var/preset_image_type
@@ -219,6 +221,14 @@
 /obj/item/disk/holodisk/Destroy()
 	QDEL_NULL(record)
 	return ..()
+
+/obj/item/disk/holodisk/attackby(obj/item/W, mob/user, params)
+	if(istype(W, /obj/item/disk/holodisk))
+		var/obj/item/disk/holodisk/holodiskOriginal = W
+		record = holodiskOriginal.record
+		to_chat(user, "You copy the record from [holodiskOriginal] to [src] by connecting the ports!")
+		name = holodiskOriginal.name
+	..()
 
 /obj/item/disk/holodisk/proc/build_record()
 	record = new

--- a/code/datums/holocall.dm
+++ b/code/datums/holocall.dm
@@ -225,9 +225,17 @@
 /obj/item/disk/holodisk/attackby(obj/item/W, mob/user, params)
 	if(istype(W, /obj/item/disk/holodisk))
 		var/obj/item/disk/holodisk/holodiskOriginal = W
-		record = holodiskOriginal.record
-		to_chat(user, "You copy the record from [holodiskOriginal] to [src] by connecting the ports!")
-		name = holodiskOriginal.name
+		if (holodiskOriginal.record)
+			if (!record)
+				record = new
+			record.caller_name = holodiskOriginal.record.caller_name
+			record.caller_image = holodiskOriginal.record.caller_image
+			record.entries = holodiskOriginal.record.entries
+			record.language = holodiskOriginal.record.language
+			to_chat(user, "You copy the record from [holodiskOriginal] to [src] by connecting the ports!")
+			name = holodiskOriginal.name
+		else 
+			to_chat(user, "[holodiskOriginal] has no record on it!")
 	..()
 
 /obj/item/disk/holodisk/proc/build_record()

--- a/code/game/machinery/hologram.dm
+++ b/code/game/machinery/hologram.dm
@@ -49,6 +49,7 @@ Possible to do for anyone motivated enough:
 	var/datum/holocall/outgoing_call	//do not modify the datums only check and call the public procs
 	var/obj/item/disk/holodisk/disk //Record disk
 	var/replay_mode = FALSE //currently replaying a recording
+	var/loop_mode = FALSE //currently looping a recording
 	var/record_mode = FALSE //currently recording
 	var/record_start = 0  	//recording start time
 	var/record_user			//user that inititiated the recording
@@ -150,19 +151,20 @@ Possible to do for anyone motivated enough:
 	if(temp)
 		dat = temp
 	else
-		dat = "<a href='?src=[REF(src)];AIrequest=1'>Request an AI's presence.</a><br>"
-		dat += "<a href='?src=[REF(src)];Holocall=1'>Call another holopad.</a><br>"
+		dat = "<a href='?src=[REF(src)];AIrequest=1'>Request an AI's presence</a><br>"
+		dat += "<a href='?src=[REF(src)];Holocall=1'>Call another holopad</a><br>"
 		if(disk)
 			if(disk.record)
 				//Replay
-				dat += "<a href='?src=[REF(src)];replay_start=1'>Replay disk recording.</a><br>"
+				dat += "<a href='?src=[REF(src)];replay_start=1'>Replay disk recording</a><br>"
+				dat += "<a href='?src=[REF(src)];loop_start=1'>Loop disk recording</a><br>"
 				//Clear
-				dat += "<a href='?src=[REF(src)];record_clear=1'>Clear disk recording.</a><br>"
+				dat += "<a href='?src=[REF(src)];record_clear=1'>Clear disk recording</a><br>"
 			else
 				//Record
-				dat += "<a href='?src=[REF(src)];record_start=1'>Start new recording.</a><br>"
+				dat += "<a href='?src=[REF(src)];record_start=1'>Start new recording</a><br>"
 			//Eject
-			dat += "<a href='?src=[REF(src)];disk_eject=1'>Eject disk.</a><br>"
+			dat += "<a href='?src=[REF(src)];disk_eject=1'>Eject disk</a><br>"
 
 		if(LAZYLEN(holo_calls))
 			dat += "=====================================================<br>"
@@ -172,7 +174,7 @@ Possible to do for anyone motivated enough:
 		for(var/I in holo_calls)
 			var/datum/holocall/HC = I
 			if(HC.connected_holopad != src)
-				dat += "<a href='?src=[REF(src)];connectcall=[REF(HC)]'>Answer call from [get_area(HC.calling_holopad)].</a><br>"
+				dat += "<a href='?src=[REF(src)];connectcall=[REF(HC)]'>Answer call from [get_area(HC.calling_holopad)]</a><br>"
 				one_unanswered_call = TRUE
 			else
 				one_answered_call = TRUE
@@ -183,10 +185,10 @@ Possible to do for anyone motivated enough:
 		for(var/I in holo_calls)
 			var/datum/holocall/HC = I
 			if(HC.connected_holopad == src)
-				dat += "<a href='?src=[REF(src)];disconnectcall=[REF(HC)]'>Disconnect call from [HC.user].</a><br>"
+				dat += "<a href='?src=[REF(src)];disconnectcall=[REF(HC)]'>Disconnect call from [HC.user]</a><br>"
 
 
-	var/datum/browser/popup = new(user, "holopad", name, 300, 150)
+	var/datum/browser/popup = new(user, "holopad", name, 300, 175)
 	popup.set_content(dat)
 	popup.set_title_image(user.browse_rsc_icon(src.icon, src.icon_state))
 	popup.open()
@@ -265,6 +267,9 @@ Possible to do for anyone motivated enough:
 	else if(href_list["replay_stop"])
 		replay_stop()
 	else if(href_list["replay_start"])
+		replay_start()
+	else if(href_list["loop_start"])
+		loop_mode = TRUE
 		replay_start()
 	else if(href_list["record_start"])
 		record_start(usr)
@@ -464,6 +469,7 @@ For the other part of the code, check silicon say.dm. Particularly robot talk.*/
 /obj/machinery/holopad/proc/replay_stop()
 	if(replay_mode)
 		replay_mode = FALSE
+		loop_mode = FALSE
 		temp = null
 		QDEL_NULL(replay_holo)
 		SetLightsAndPower()
@@ -516,8 +522,11 @@ For the other part of the code, check silicon say.dm. Particularly robot talk.*/
 	if(!replay_mode)
 		return
 	if(disk.record.entries.len < entry_number)
-		replay_stop()
-		return
+		if (loop_mode)	
+			entry_number = 1
+		else
+			replay_stop()
+			return
 	var/list/entry = disk.record.entries[entry_number]
 	var/command = entry[1]
 	switch(command)

--- a/code/game/machinery/hologram.dm
+++ b/code/game/machinery/hologram.dm
@@ -490,7 +490,7 @@ For the other part of the code, check silicon say.dm. Particularly robot talk.*/
 	if(!record_mode)
 		return
 	//make this command so you can have multiple languages in single record
-	if(!disk.record.caller_name && istype(speaker))
+	if((!disk.record.caller_name || disk.record.caller_name == "Unknown") && istype(speaker))
 		disk.record.caller_name = speaker.name
 	if(!disk.record.language)
 		disk.record.language = language

--- a/code/modules/research/designs/autolathe_designs.dm
+++ b/code/modules/research/designs/autolathe_designs.dm
@@ -836,6 +836,6 @@
 	name = "Holodisk"
 	id = "holodisk"
 	build_type = AUTOLATHE
-	materials = list(MAT_METAL = 1000)
+	materials = list(MAT_METAL = 100, MAT_GLASS = 100)
 	build_path = /obj/item/disk/holodisk
 	category = list("initial", "Misc")


### PR DESCRIPTION
[Changelogs]: 

:cl: Dax Dupont
add: You can now rename and copy holodisks!
add: Holorecordings now can be looped.
tweak: Holodisks now have materials and the autolathe cost has been adjusted.
fix: Fixed holodisk speaker name not getting set when on non-prerecorded messages.
/:cl:

[why]: Fixes holorecords not setting speaker name. Checked for Unknown, since that's the default and it's required for the preprocessed disks. 
Removed dots from the buttons because it looks weird.