### PR TITLE
Fixes pneumatic cannon contents deletion

### DIFF
--- a/code/game/objects/items/pneumaticCannon.dm
+++ b/code/game/objects/items/pneumaticCannon.dm
@@ -207,9 +207,8 @@
 
 /obj/item/pneumatic_cannon/handle_atom_del(atom/A)
 	. = ..()
-	if (A in loadedItems)
+	if (loadedItems.Remove(A))
 		var/obj/item/I = A
-		loadedItems -= I
 		loadedWeightClass -= I.w_class
 	if (A == tank)
 		tank = null

--- a/code/game/objects/items/pneumaticCannon.dm
+++ b/code/game/objects/items/pneumaticCannon.dm
@@ -210,7 +210,7 @@
 	if (loadedItems.Remove(A))
 		var/obj/item/I = A
 		loadedWeightClass -= I.w_class
-	if (A == tank)
+	else if (A == tank)
 		tank = null
 		update_icons()
 

--- a/code/game/objects/items/pneumaticCannon.dm
+++ b/code/game/objects/items/pneumaticCannon.dm
@@ -205,6 +205,16 @@
 	var/turf/newtarget = locate(new_x, new_y, starting.z)
 	return newtarget
 
+/obj/item/pneumatic_cannon/handle_atom_del(atom/A)
+	. = ..()
+	if (A in loadedItems)
+		var/obj/item/I = A
+		loadedItems -= I
+		loadedWeightClass -= I.w_class
+	if (A == tank)
+		tank = null
+		update_icons()
+
 /obj/item/pneumatic_cannon/ghetto //Obtainable by improvised methods; more gas per use, less capacity, but smaller
 	name = "improvised pneumatic cannon"
 	desc = "A gas-powered, object-firing cannon made out of common parts."


### PR DESCRIPTION
Closes #9604

I couldn't actually replicate the bug exactly as stated, however I could replicate other ones with the use of regular grenades. It is likely that things have been refactored in the 3 years since that issue was made. Regardless, this ought to be a fairly general fix and handle even the scenario described even if it's still somehow relevant with different replication steps.


:cl: Naksu
fix: Pneumatic cannons no longer misbehave when their contents such as primed grenades get deleted (explode)
/:cl:
