### PR TITLE
Removes Acid requirement from Express Supply Console board

### DIFF
--- a/code/modules/research/designs/mining_designs.dm
+++ b/code/modules/research/designs/mining_designs.dm
@@ -8,7 +8,6 @@
 	id = "cargoexpress"//the coder reading this
 	build_type = PROTOLATHE
 	materials = list(MAT_GLASS = 1000)
-	reagents_list = list("sacid" = 20)
 	build_path = /obj/item/circuitboard/computer/cargo/express
 	category = list("Mining Designs")
 	departmental_flags = DEPARTMENTAL_FLAG_CARGO


### PR DESCRIPTION
See title

:cl: Epoc
fix: Removes Sulfuric Acid requirement from Express Supply Console board
/:cl:

Addresses #34855
