### PR TITLE
I forgot to nerf clockcult spess basing

### DIFF
--- a/code/game/gamemodes/clock_cult/clock_items/clockwork_slab.dm
+++ b/code/game/gamemodes/clock_cult/clock_items/clockwork_slab.dm
@@ -190,6 +190,10 @@
 		if(!GLOB.ratvar_awakens && !no_cost && !SSticker.scripture_states[initial_tier])
 			to_chat(user, "<span class='warning'>That scripture is not unlocked, and cannot be recited!</span>")
 			return FALSE
+	var/area/A = get_area(user)
+	if(A && !A.blob_allowed)
+		to_chat(user, "<span class='warning'>Ratvar, the Clockwork Justiciar's words echo...<i>Gurer'f n gvzr naq cynpr sbe rirelguvat, ohg abg abj!</i></span>")
+		return FALSE
 	var/datum/clockwork_scripture/scripture_to_recite = new scripture
 	scripture_to_recite.slab = src
 	scripture_to_recite.invoker = user


### PR DESCRIPTION
:cl: Iamgoofball
fix: Fixed clockcult space basing and general off-station and off-clockcult basing bullshit.
/:cl:

Totally forgot that clockcult could still space base with the last PR, and our design lead has made it clear he considers this technique not part of the game's design and a bug.

I checked and the actual clockcult base is not marked as disallowing blob so this should work.

note to self: rename var