### PR TITLE
Fixes orbiting stopping when entering disposals

### DIFF
--- a/code/modules/recycling/disposal/bin.dm
+++ b/code/modules/recycling/disposal/bin.dm
@@ -189,7 +189,7 @@
 	sleep(5)
 	if(QDELETED(src))
 		return
-	var/obj/structure/disposalholder/H = new()
+	var/obj/structure/disposalholder/H = new(src)
 	newHolderDestination(H)
 	H.init(src)
 	air_contents = new()

--- a/code/modules/recycling/disposal/holder.dm
+++ b/code/modules/recycling/disposal/holder.dm
@@ -45,6 +45,8 @@
 	// note AM since can contain mobs or objs
 	for(var/A in D)
 		var/atom/movable/AM = A
+		if(AM == src)
+			continue
 		AM.forceMove(src)
 		if(istype(AM, /obj/structure/bigDelivery) && !hasmob)
 			var/obj/structure/bigDelivery/T = AM


### PR DESCRIPTION
Fixes #33264
Orbit automatically stops if the target has a null turf. The disposalholder started out in nullspace, moved the contents of the disposal bin into itself, and then into the disposal trunk.