### PR TITLE
Fixes brains being left in hands after being inserted into heads

### DIFF
--- a/code/modules/mob/living/brain/brain_item.dm
+++ b/code/modules/mob/living/brain/brain_item.dm
@@ -126,7 +126,7 @@
 //since these people will be dead M != usr
 
 	if(!C.getorgan(/obj/item/organ/brain))
-		if(!C.get_bodypart("head") || !C.temporarilyRemoveItemFromInventory(src))
+		if(!C.get_bodypart("head") || !user.temporarilyRemoveItemFromInventory(src))
 			return
 		var/msg = "[C] has [src] inserted into [C.p_their()] head by [user]."
 		if(C == user)


### PR DESCRIPTION
Fixes #33564
Was being removed from the wrong inventory. Note this bug didn't affect brain insertion through surgery.