### PR TITLE
Adds sleep immune trait and fixes latte

### DIFF
--- a/code/__DEFINES/traits.dm
+++ b/code/__DEFINES/traits.dm
@@ -18,6 +18,7 @@
 #define TRAIT_XENO_HOST			"xeno_host"	//Tracks whether we're gonna be a baby alien's mummy.
 #define TRAIT_STUNIMMUNE		"stun_immunity"
 #define TRAIT_PUSHIMMUNE		"push_immunity"
+#define TRAIT_SLEEPIMMUNE		"sleep_immunity"
 
 // common trait sources
 #define TRAIT_GENERIC "generic"

--- a/code/datums/status_effects/debuffs.dm
+++ b/code/datums/status_effects/debuffs.dm
@@ -51,6 +51,11 @@
 	var/mob/living/carbon/carbon_owner
 	var/mob/living/carbon/human/human_owner
 
+/datum/status_effect/incapacitating/sleeping/on_apply(mob/living/carbon/C)
+	if(C.has_trait(TRAIT_SLEEPIMMUNE))
+		return FALSE
+	return ..()
+
 /datum/status_effect/incapacitating/sleeping/on_creation(mob/living/new_owner, updating_canmove)
 	. = ..()
 	if(.)

--- a/code/modules/reagents/chemistry/reagents/drink_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/drink_reagents.dm
@@ -605,11 +605,11 @@
 	glass_name = "cafe latte"
 	glass_desc = "A nice, strong and refreshing beverage while you're reading."
 
-/datum/reagent/consumable/soy_latte/on_mob_add(mob/living/M)
+/datum/reagent/consumable/cafe_latte/on_mob_add(mob/living/M)
 	M.add_trait(TRAIT_SLEEPIMMUNE)
 	..()
 
-/datum/reagent/consumable/soy_latte/on_mob_delete(mob/living/M)
+/datum/reagent/consumable/cafe_latte/on_mob_delete(mob/living/M)
 	M.remove_trait(TRAIT_SLEEPIMMUNE)
 	..()
 

--- a/code/modules/reagents/chemistry/reagents/drink_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/drink_reagents.dm
@@ -576,10 +576,17 @@
 	glass_name = "soy latte"
 	glass_desc = "A nice and refreshing beverage while you're reading."
 
+/datum/reagent/consumable/soy_latte/on_mob_add(mob/living/M)
+	M.add_trait(TRAIT_SLEEPIMMUNE)
+	..()
+
+/datum/reagent/consumable/soy_latte/on_mob_delete(mob/living/M)
+	M.remove_trait(TRAIT_SLEEPIMMUNE)
+	..()
+
 /datum/reagent/consumable/soy_latte/on_mob_life(mob/living/M)
 	M.dizziness = max(0,M.dizziness-5)
 	M.drowsyness = max(0,M.drowsyness-3)
-	M.SetSleeping(0, FALSE)
 	if (M.bodytemperature < BODYTEMP_NORMAL)//310.15 is the normal bodytemp.
 		M.bodytemperature = min(BODYTEMP_NORMAL, M.bodytemperature + (5 * TEMPERATURE_DAMAGE_COEFFICIENT))
 	M.Jitter(5)
@@ -598,10 +605,17 @@
 	glass_name = "cafe latte"
 	glass_desc = "A nice, strong and refreshing beverage while you're reading."
 
+/datum/reagent/consumable/soy_latte/on_mob_add(mob/living/M)
+	M.add_trait(TRAIT_SLEEPIMMUNE)
+	..()
+
+/datum/reagent/consumable/soy_latte/on_mob_delete(mob/living/M)
+	M.remove_trait(TRAIT_SLEEPIMMUNE)
+	..()
+
 /datum/reagent/consumable/cafe_latte/on_mob_life(mob/living/M)
 	M.dizziness = max(0,M.dizziness-5)
 	M.drowsyness = max(0,M.drowsyness-3)
-	M.SetSleeping(0, FALSE)
 	if (M.bodytemperature < BODYTEMP_NORMAL)//310.15 is the normal bodytemp.
 		M.bodytemperature = min(BODYTEMP_NORMAL, M.bodytemperature + (5 * TEMPERATURE_DAMAGE_COEFFICIENT))
 	M.Jitter(5)


### PR DESCRIPTION
:cl: Sleepimmunity Trait
add: Adds TRAIT_SLEEPIMMUNE which will make you immune to any and all sleep effects.
fix: Replaces SetSleeping(0) on cafe latte and soy latte with the new sleepimmunity trait.
/:cl:

[why]: Cafe Latte never had the intended effect of making you not sleep, it only resulted in popping you in and out of sleep every cycle if you had a toxin in your system putting you to sleep.