### PR TITLE
Removes Sulfuric Acid requirements from computer parts

### DIFF
--- a/code/modules/research/designs/computer_part_designs.dm
+++ b/code/modules/research/designs/computer_part_designs.dm
@@ -72,7 +72,6 @@
 	id = "netcard_advanced"
 	build_type = IMPRINTER
 	materials = list(MAT_METAL = 500, MAT_GLASS = 200)
-	reagents_list = list("sacid" = 20)
 	build_path = /obj/item/computer_hardware/network_card/advanced
 	category = list("Computer Parts")
 	departmental_flags = DEPARTMENTAL_FLAG_SCIENCE | DEPARTMENTAL_FLAG_ENGINEERING
@@ -82,7 +81,6 @@
 	id = "netcard_wired"
 	build_type = IMPRINTER
 	materials = list(MAT_METAL = 2500, MAT_GLASS = 400)
-	reagents_list = list("sacid" = 20)
 	build_path = /obj/item/computer_hardware/network_card/wired
 	category = list("Computer Parts")
 	departmental_flags = DEPARTMENTAL_FLAG_SCIENCE | DEPARTMENTAL_FLAG_ENGINEERING
@@ -103,7 +101,6 @@
 	id = "portadrive_advanced"
 	build_type = IMPRINTER
 	materials = list(MAT_GLASS = 1600)
-	reagents_list = list("sacid" = 20)
 	build_path = /obj/item/computer_hardware/hard_drive/portable/advanced
 	category = list("Computer Parts")
 	departmental_flags = DEPARTMENTAL_FLAG_SCIENCE | DEPARTMENTAL_FLAG_ENGINEERING
@@ -113,7 +110,6 @@
 	id = "portadrive_super"
 	build_type = IMPRINTER
 	materials = list(MAT_GLASS = 3200)
-	reagents_list = list("sacid" = 20)
 	build_path = /obj/item/computer_hardware/hard_drive/portable/super
 	category = list("Computer Parts")
 	departmental_flags = DEPARTMENTAL_FLAG_SCIENCE | DEPARTMENTAL_FLAG_ENGINEERING
@@ -219,7 +215,6 @@
 	id = "cpu_normal"
 	build_type = IMPRINTER
 	materials = list(MAT_GLASS = 1600)
-	reagents_list = list("sacid" = 20)
 	build_path = /obj/item/computer_hardware/processor_unit
 	category = list("Computer Parts")
 	departmental_flags = DEPARTMENTAL_FLAG_SCIENCE | DEPARTMENTAL_FLAG_ENGINEERING
@@ -229,7 +224,6 @@
 	id = "cpu_small"
 	build_type = IMPRINTER
 	materials = list(MAT_GLASS = 800)
-	reagents_list = list("sacid" = 20)
 	build_path = /obj/item/computer_hardware/processor_unit/small
 	category = list("Computer Parts")
 	departmental_flags = DEPARTMENTAL_FLAG_SCIENCE | DEPARTMENTAL_FLAG_ENGINEERING
@@ -239,7 +233,6 @@
 	id = "pcpu_normal"
 	build_type = IMPRINTER
 	materials = list(MAT_GLASS= 6400, MAT_GOLD = 2000)
-	reagents_list = list("sacid" = 40)
 	build_path = /obj/item/computer_hardware/processor_unit/photonic
 	category = list("Computer Parts")
 	departmental_flags = DEPARTMENTAL_FLAG_SCIENCE | DEPARTMENTAL_FLAG_ENGINEERING
@@ -249,7 +242,6 @@
 	id = "pcpu_small"
 	build_type = IMPRINTER
 	materials = list(MAT_GLASS = 3200, MAT_GOLD = 1000)
-	reagents_list = list("sacid" = 20)
 	build_path = /obj/item/computer_hardware/processor_unit/photonic/small
 	category = list("Computer Parts")
 	departmental_flags = DEPARTMENTAL_FLAG_SCIENCE | DEPARTMENTAL_FLAG_ENGINEERING


### PR DESCRIPTION
See title

:cl: Epoc
tweak: Removed Sulfuric Acid requirements from computer parts
/:cl:

because no for sulf for the lathes I guess, hopefully I beat cyberboss to it this time
Fixes #34905