### PR TITLE
Fixed the simple rotation component

### DIFF
--- a/code/datums/components/rotation.dm
+++ b/code/datums/components/rotation.dm
@@ -63,10 +63,10 @@
 	if(rotation_flags & ROTATION_ALTCLICK)
 		to_chat(user, "<span class='notice'>Alt-click to rotate it clockwise.</span>")
 
-/datum/component/simple_rotation/proc/HandRot(mob/user, rotation)
-	if(!can_be_rotated.Invoke(user,default_rotation_direction) || !can_user_rotate.Invoke(user,default_rotation_direction))
+/datum/component/simple_rotation/proc/HandRot(mob/user, rotation = default_rotation_direction)
+	if(!can_be_rotated.Invoke(user, rotation) || !can_user_rotate.Invoke(user, rotation))
 		return
-	BaseRot(user,default_rotation_direction)
+	BaseRot(user, rotation)
 
 /datum/component/simple_rotation/proc/WrenchRot(obj/item/I, mob/living/user)
 	if(!can_be_rotated.Invoke(user,default_rotation_direction) || !can_user_rotate.Invoke(user,default_rotation_direction))


### PR DESCRIPTION
Fixes #34345 
You could only rotate things in the default rotation direction.
This does not actually fix the bug in #34345, but it does fix a very similar bug that replaced it from #34476.

:cl: 
fix: Fixed being able to rotate things in only one direction.
/:cl:

@AnturK 