### PR TITLE
Removes landmark tag generation

### DIFF
--- a/code/game/objects/effects/landmarks.dm
+++ b/code/game/objects/effects/landmarks.dm
@@ -20,7 +20,6 @@
 
 /obj/effect/landmark/New()
 	..()
-	tag = text("landmark*[]", name)
 	GLOB.landmarks_list += src
 
 /obj/effect/landmark/Destroy()


### PR DESCRIPTION
I believe the last things that used the tag system to find landmarks was cleaned up with the snukeop datumization, this should now be fully deprecated in favor of GLOB.landmarks_list at this point.