### PR TITLE
Readds bz canisters to cargo order packs

### DIFF
--- a/code/modules/cargo/packs.dm
+++ b/code/modules/cargo/packs.dm
@@ -864,6 +864,14 @@
 /datum/supply_pack/science
 	group = "Science"
 	crate_type = /obj/structure/closet/crate/science
+	
+/datum/supply_pack/science/bz
+	name = "BZ canister"
+	cost = 2000
+	access = ACCESS_TOX_STORAGE
+	contains = list(/obj/machinery/portable_atmospherics/canister/bz)
+	crate_name = "BZ canister crate"
+	crate_type = /obj/structure/closet/crate/secure/science
 
 /datum/supply_pack/science/robotics
 	name = "Robotics Assembly Crate"
@@ -982,7 +990,7 @@
 					/obj/item/pizzabox/meat,
 					/obj/item/pizzabox/vegetable)
 	crate_name = "pizza crate"
-
+	
 /datum/supply_pack/organic/cream_piee
 	name = "High-yield Clown-grade Cream Pie Crate"
 	cost = 6000

--- a/code/modules/cargo/packs.dm
+++ b/code/modules/cargo/packs.dm
@@ -867,7 +867,7 @@
 	
 /datum/supply_pack/science/bz
 	name = "BZ canister"
-	cost = 2000
+	cost = 4000
 	access = ACCESS_TOX_STORAGE
 	contains = list(/obj/machinery/portable_atmospherics/canister/bz)
 	crate_name = "BZ canister crate"


### PR DESCRIPTION
i dont know why it was removed but it auctall had an use

:cl: improvedname
add: Adds bz to cargo
/:cl:

[why]: # (Please add a short description [two lines down] of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.)

Lets be honest here, BZ has one use and thats stopping slimes from functioning at all.
and yes i know you can make it at atmos, but honest its to much of an hassle for that one purpose and it had great use at xenobiology so your slimes wouldn't starve as you did your work.
