### PR TITLE
Heartless humans now display as unsuitable for abductor experiments

### DIFF
--- a/code/modules/antagonists/abductor/equipment/abduction_gear.dm
+++ b/code/modules/antagonists/abductor/equipment/abduction_gear.dm
@@ -558,7 +558,11 @@ Congratulations! You are now trained for invasive xenobiology research!"}
 		if(temp)
 			helptext = "<span class='warning'>Experimental gland detected!</span>"
 		else
-			helptext = "<span class='notice'>Subject suitable for experiments.</span>"
+			var/obj/item/organ/heart/hasheart = L.getorganslot(ORGAN_SLOT_HEART)
+			if (hasheart)
+				helptext = "<span class='notice'>Subject suitable for experiments.</span>"
+			else
+				helptext = "<span class='warning'>Subject unsuitable for experiments.</span>"
 
 	to_chat(user, "<span class='notice'>Probing result:</span>[species]")
 	to_chat(user, "[helptext]")

--- a/code/modules/antagonists/abductor/equipment/abduction_gear.dm
+++ b/code/modules/antagonists/abductor/equipment/abduction_gear.dm
@@ -558,8 +558,7 @@ Congratulations! You are now trained for invasive xenobiology research!"}
 		if(temp)
 			helptext = "<span class='warning'>Experimental gland detected!</span>"
 		else
-			var/obj/item/organ/heart/hasheart = L.getorganslot(ORGAN_SLOT_HEART)
-			if (hasheart)
+			if (L.getorganslot(ORGAN_SLOT_HEART))
 				helptext = "<span class='notice'>Subject suitable for experiments.</span>"
 			else
 				helptext = "<span class='warning'>Subject unsuitable for experiments.</span>"


### PR DESCRIPTION
Fixes #34334

:cl: Naksu
fix: Subjects without hearts now display as unsuitable for abductor experiments when probed with the advanced baton. 
/:cl:
