### PR TITLE
Allows revenants to leave the station z-level

### DIFF
--- a/code/modules/mob/mob_movement.dm
+++ b/code/modules/mob/mob_movement.dm
@@ -217,6 +217,12 @@
 				if (locate(/obj/effect/blessing, stepTurf))
 					to_chat(L, "<span class='warning'>Holy energies block your path!</span>")
 					return
+				if (istype(stepTurf, /turf/open/space))
+					var/turf/open/space/spess = stepTurf
+					if (spess.destination_z)
+						L.loc = locate(spess.destination_x, spess.destination_y, spess.destination_z)
+						L.setDir(direct)
+						return TRUE
 
 				L.loc = get_step(L, direct)
 			L.setDir(direct)


### PR DESCRIPTION
Fixes #12203


:cl: Naksu
fix: Revenants are able to leave the station level and follow spacemen into deep space just by touching one of the border turfs, just like everyone else
/:cl: