### PR TITLE
Adds new tool helpers: welder_act and tool_act

### DIFF
--- a/code/__DEFINES/tools.dm
+++ b/code/__DEFINES/tools.dm
@@ -1,6 +1,7 @@
-#define TOOL_NONE 0
+// Tool types
 #define TOOL_CROWBAR 1
 #define TOOL_MULTITOOL 2
 #define TOOL_SCREWDRIVER 3
 #define TOOL_WIRECUTTER 4
 #define TOOL_WRENCH 5
+#define TOOL_WELDER 6

--- a/code/__DEFINES/tools.dm
+++ b/code/__DEFINES/tools.dm
@@ -1,7 +1,7 @@
 // Tool types
-#define TOOL_CROWBAR 1
-#define TOOL_MULTITOOL 2
-#define TOOL_SCREWDRIVER 3
-#define TOOL_WIRECUTTER 4
-#define TOOL_WRENCH 5
-#define TOOL_WELDER 6
+#define TOOL_CROWBAR 		"crowbar"
+#define TOOL_MULTITOOL 		"multitool"
+#define TOOL_SCREWDRIVER 	"screwdriver"
+#define TOOL_WIRECUTTER 	"wirecutter"
+#define TOOL_WRENCH 		"wrench"
+#define TOOL_WELDER 		"welder"

--- a/code/_onclick/item_attack.dm
+++ b/code/_onclick/item_attack.dm
@@ -1,6 +1,6 @@
 
 /obj/item/proc/melee_attack_chain(mob/user, atom/target, params)
-	if(!tool_check(user, target) && pre_attackby(target, user, params))
+	if(!tool_attack_chain(user, target) && pre_attackby(target, user, params))
 		// Return 1 in attackby() to prevent afterattack() effects (when safely moving items for example)
 		var/resolved = target.attackby(src, user, params)
 		if(!resolved && target && !QDELETED(src))
@@ -8,20 +8,12 @@
 
 
 //Checks if the item can work as a tool, calling the appropriate tool behavior on the target
-/obj/item/proc/tool_check(mob/user, atom/target)
-	switch(tool_behaviour)
-		if(TOOL_NONE)
-			return FALSE
-		if(TOOL_CROWBAR)
-			return target.crowbar_act(user, src)
-		if(TOOL_MULTITOOL)
-			return target.multitool_act(user, src)
-		if(TOOL_SCREWDRIVER)
-			return target.screwdriver_act(user, src)
-		if(TOOL_WRENCH)
-			return target.wrench_act(user, src)
-		if(TOOL_WIRECUTTER)
-			return target.wirecutter_act(user, src)
+/obj/item/proc/tool_attack_chain(mob/user, atom/target)
+	if(!tool_behaviour)
+		return FALSE
+
+	if(target.tool_act(user, src, tool_behaviour))
+		return TRUE
 
 
 // Called when the item is in the active hand, and clicked; alternately, there is an 'activate held object' verb or you can hit pagedown.

--- a/code/_onclick/item_attack.dm
+++ b/code/_onclick/item_attack.dm
@@ -12,8 +12,7 @@
 	if(!tool_behaviour)
 		return FALSE
 
-	if(target.tool_act(user, src, tool_behaviour))
-		return TRUE
+	return target.tool_act(user, src, tool_behaviour)
 
 
 // Called when the item is in the active hand, and clicked; alternately, there is an 'activate held object' verb or you can hit pagedown.

--- a/code/game/atoms.dm
+++ b/code/game/atoms.dm
@@ -531,21 +531,41 @@
 /atom/proc/return_temperature()
 	return
 
-// Default tool behaviors proc
+// Tool behavior procedure. Redirects to tool-specific procs by default.
+// You can override it to catch all tool interactions, for use in complex deconstruction procs.
+// Just don't forget to return ..() in the end.
+/atom/proc/tool_act(mob/living/user, obj/item/tool, tool_type)
+	switch(tool_type)
+		if(TOOL_CROWBAR)
+			return crowbar_act(user, tool)
+		if(TOOL_MULTITOOL)
+			return multitool_act(user, tool)
+		if(TOOL_SCREWDRIVER)
+			return screwdriver_act(user, tool)
+		if(TOOL_WRENCH)
+			return wrench_act(user, tool)
+		if(TOOL_WIRECUTTER)
+			return wirecutter_act(user, tool)
+		if(TOOL_WELDER)
+			return welder_act(user, tool)
 
-/atom/proc/crowbar_act(mob/user, obj/item/tool)
+// Tool-specific behavior procs. To be overridden in subtypes.
+/atom/proc/crowbar_act(mob/living/user, obj/item/tool)
 	return
 
-/atom/proc/multitool_act(mob/user, obj/item/tool)
+/atom/proc/multitool_act(mob/living/user, obj/item/tool)
 	return
 
-/atom/proc/screwdriver_act(mob/user, obj/item/tool)
+/atom/proc/screwdriver_act(mob/living/user, obj/item/tool)
 	return
 
-/atom/proc/wrench_act(mob/user, obj/item/tool)
+/atom/proc/wrench_act(mob/living/user, obj/item/tool)
 	return
 
-/atom/proc/wirecutter_act(mob/user, obj/item/tool)
+/atom/proc/wirecutter_act(mob/living/user, obj/item/tool)
+	return
+
+/atom/proc/welder_act(mob/living/user, obj/item/tool)
 	return
 
 /atom/proc/GenerateTag()

--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -91,7 +91,7 @@ GLOBAL_VAR_INIT(rpg_loot_items, FALSE)
 	var/heat = 0
 	var/sharpness = IS_BLUNT
 
-	var/tool_behaviour = TOOL_NONE
+	var/tool_behaviour = NONE
 	var/toolspeed = 1
 
 	var/block_chance = 0

--- a/code/game/objects/items/tools/weldingtool.dm
+++ b/code/game/objects/items/tools/weldingtool.dm
@@ -30,6 +30,7 @@
 	var/light_intensity = 2 //how powerful the emitted light is when used.
 	var/burned_fuel_for = 0	//when fuel was last removed
 	heat = 3800
+	tool_behaviour = TOOL_WELDER
 	toolspeed = 1
 
 /obj/item/weldingtool/Initialize()

--- a/code/modules/projectiles/guns/energy/special.dm
+++ b/code/modules/projectiles/guns/energy/special.dm
@@ -125,10 +125,11 @@
 	force = 12
 	sharpness = IS_SHARP
 	can_charge = 0
-	heat = 3800
 
+	heat = 3800
 	usesound = 'sound/items/welder.ogg'
-	toolspeed = 0.7 //plasmacutters can be used as welders for a few things, and are faster than standard welders
+	tool_behaviour = TOOL_WELDER
+	toolspeed = 0.7 //plasmacutters can be used as welders, and are faster than standard welders
 
 /obj/item/gun/energy/plasmacutter/examine(mob/user)
 	..()


### PR DESCRIPTION
The new way to do tool checks, introduced in #32602, now also supports welders. 

You can now override `tool_act` if you want to catch more than one tool type in a single proc, which is pretty common for objects with complex interactions.

Not sure what tag it is, code improvement I guess.