### PR TITLE
The punisher no longer punishes ticker subsystems with delayed fires

### DIFF
--- a/code/controllers/master.dm
+++ b/code/controllers/master.dm
@@ -517,7 +517,7 @@ GLOBAL_REAL(Master, /datum/controller/master) = new
 			queue_node.times_fired++
 
 			if (queue_node_flags & SS_TICKER)
-				queue_node.next_fire = world.time + (world.tick_lag * (queue_node.wait + (queue_node.tick_overrun/100)))
+				queue_node.next_fire = world.time + (world.tick_lag * queue_node.wait)
 			else if (queue_node_flags & SS_POST_FIRE_TIMING)
 				queue_node.next_fire = world.time + queue_node.wait + (world.tick_lag * (queue_node.tick_overrun/100))
 			else if (queue_node_flags & SS_KEEP_TIMING)


### PR DESCRIPTION
When ticker subsystems go past their allocated time we don't punish them with delayed fires, (but we still reduce the amount of allocated time they get next fire)