### PR TITLE
Having station blueprints in your hands now reveals function of wires

### DIFF
--- a/code/datums/wires/wires.dm
+++ b/code/datums/wires/wires.dm
@@ -109,6 +109,12 @@
 	if(cut_wires.len == wires.len)
 		return TRUE
 
+/datum/wires/proc/is_dud(wire)
+	return dd_hasprefix(wire, WIRE_DUD_PREFIX)
+
+/datum/wires/proc/is_dud_color(color)
+	return is_dud(get_wire(color))
+
 /datum/wires/proc/cut(wire)
 	if(is_cut(wire))
 		cut_wires -= wire
@@ -208,10 +214,24 @@
 /datum/wires/ui_data(mob/user)
 	var/list/data = list()
 	var/list/payload = list()
+	var/reveal_wires = FALSE
+
+	// Admin ghost can see a purpose of each wire.
+	if(IsAdminGhost(user))
+		reveal_wires = TRUE
+
+	// Same for anyone with an abductor multitool.
+	else if(user.is_holding_item_of_type(/obj/item/device/multitool/abductor))
+		reveal_wires = TRUE
+
+	// Station blueprints do that too, but only if the wires are not randomized.
+	else if(user.is_holding_item_of_type(/obj/item/areaeditor/blueprints) && !randomize)
+		reveal_wires = TRUE
+
 	for(var/color in colors)
 		payload.Add(list(list(
 			"color" = color,
-			"wire" = (IsAdminGhost(user) || (user.is_holding_item_of_type(/obj/item/device/multitool/abductor)) ? get_wire(color) : null),
+			"wire" = ((reveal_wires && !is_dud_color(color)) ? get_wire(color) : null),
 			"cut" = is_color_cut(color),
 			"attached" = is_attached(color)
 		)))


### PR DESCRIPTION
Because why not?
![default](https://user-images.githubusercontent.com/3888532/35425425-cf949aae-026b-11e8-84bb-6da0e88065ae.png)
Note that only the purposes of the wires shown in blueprints are revealed. CE wouldn't be able to disarm Syndicate bombs that way.

:cl: ACCount
add: Having station blueprints in your hands now reveals function of wires in station objects.
/:cl: