### PR TITLE
Reduces the amount of bombs on the lavaland syndie base from 28 to 9.

### DIFF
--- a/_maps/RandomRuins/LavaRuins/lavaland_surface_syndicate_base1.dmm
+++ b/_maps/RandomRuins/LavaRuins/lavaland_surface_syndicate_base1.dmm
@@ -6308,7 +6308,7 @@ eh
 eh
 eh
 eh
-gj
+eh
 eh
 ab
 ab
@@ -6326,7 +6326,7 @@ ab
 ab
 ab
 mn
-mo
+mn
 mN
 nj
 mn
@@ -6562,8 +6562,8 @@ dG
 dG
 lS
 mn
-mo
 mn
+mo
 nL
 mn
 mn
@@ -6699,7 +6699,7 @@ je
 jk
 jx
 jx
-jP
+jy
 jy
 jy
 ms
@@ -6707,7 +6707,7 @@ mT
 no
 nN
 ol
-ow
+mT
 ab
 ab
 ab
@@ -6728,7 +6728,7 @@ ac
 ac
 ae
 ae
-aL
+ae
 ae
 fC
 gw
@@ -6770,7 +6770,7 @@ ab
 ae
 ae
 ae
-aL
+ae
 ae
 ae
 ae
@@ -6780,7 +6780,7 @@ ae
 fD
 ad
 eh
-gj
+eh
 eh
 hW
 dG
@@ -6926,10 +6926,10 @@ hK
 ha
 ha
 ha
-iN
 ha
 ha
-jy
+ha
+jP
 jM
 jN
 jZ
@@ -6942,7 +6942,7 @@ jy
 jy
 nS
 on
-ow
+mT
 ab
 ab
 ab
@@ -6969,7 +6969,7 @@ ae
 gB
 hb
 ha
-ha
+iN
 ha
 ii
 iw
@@ -7033,7 +7033,7 @@ lB
 lY
 lA
 mW
-jy
+jP
 nT
 op
 ox
@@ -7099,9 +7099,9 @@ ab
 ae
 ae
 ae
+ae
+ae
 aL
-ae
-ae
 ae
 ae
 ae
@@ -7118,7 +7118,7 @@ iR
 hz
 jn
 jA
-jP
+jy
 jy
 jy
 jy
@@ -7224,7 +7224,7 @@ jy
 nu
 nX
 om
-ow
+mT
 ab
 ab
 ab
@@ -7251,7 +7251,7 @@ fO
 gG
 hg
 hz
-hO
+hz
 hz
 hz
 iB
@@ -7265,7 +7265,7 @@ jy
 jy
 jy
 jy
-jP
+jy
 jy
 mX
 nv
@@ -7381,13 +7381,13 @@ ab
 ab
 ab
 as
-cO
+as
 as
 dI
 dZ
 ew
 as
-cO
+as
 as
 gJ
 hh
@@ -7400,7 +7400,7 @@ iX
 hz
 jq
 jA
-hO
+hz
 kg
 kt
 kQ
@@ -7429,7 +7429,7 @@ ab
 ab
 ab
 ac
-cO
+as
 as
 as
 as
@@ -7445,7 +7445,7 @@ hz
 iF
 iY
 hz
-hz
+hO
 hz
 hz
 kh
@@ -7459,7 +7459,7 @@ na
 nz
 ob
 os
-oy
+kQ
 ac
 ab
 ab
@@ -7489,7 +7489,7 @@ hz
 hz
 hz
 hz
-hO
+hz
 hz
 hz
 jr
@@ -7576,7 +7576,7 @@ ec
 ez
 eY
 ft
-dy
+dP
 gN
 hj
 hj
@@ -7638,13 +7638,13 @@ jF
 jT
 ju
 ju
+ju
+ju
+ju
 kU
 ju
 ju
 ju
-ju
-ju
-kU
 ju
 ju
 ju
@@ -7666,7 +7666,7 @@ ab
 ab
 ac
 dy
-dP
+dy
 eA
 fa
 dy
@@ -7823,7 +7823,7 @@ ha
 ha
 ju
 jJ
-jX
+kl
 kl
 kA
 kY
@@ -7904,7 +7904,7 @@ ab
 dy
 eF
 eF
-dP
+dy
 gf
 dy
 eF
@@ -7968,7 +7968,7 @@ ab
 ju
 kD
 lb
-kU
+ju
 kD
 lb
 ju


### PR DESCRIPTION
Exactly what it says on the tin. Tested to properly still fully destroy the base, all the bombs will detonate.

Bandaid fixes #34965 

:cl: WJohnston
fix: The lavaland syndie base is now packed with considerably fewer explosives, and should lag far less brutally when exploding.
/:cl:

Closes #34978