### PR TITLE
Remove mobs/idlenpcpool Initializers, make mob/client expansion happen when maxz is incremented

### DIFF
--- a/code/controllers/subsystem/idlenpcpool.dm
+++ b/code/controllers/subsystem/idlenpcpool.dm
@@ -14,8 +14,16 @@ SUBSYSTEM_DEF(idlenpcpool)
 	..("IdleNPCS:[idlelist.len]|Z:[zlist.len]")
 
 /datum/controller/subsystem/idlenpcpool/Initialize(start_timeofday)
-	idle_mobs_by_zlevel = new /list(world.maxz,0)
+	MaxZChanged()
 	return ..()
+
+/datum/controller/subsystem/idlenpcpool/proc/MaxZChanged()
+	if (!islist(idle_mobs_by_zlevel))
+		idle_mobs_by_zlevel = new /list(world.maxz,0)
+	while (SSidlenpcpool.idle_mobs_by_zlevel.len < world.maxz)
+		SSidlenpcpool.idle_mobs_by_zlevel.len++
+		SSidlenpcpool.idle_mobs_by_zlevel[idle_mobs_by_zlevel.len] = list()
+		warning("new idle_mobs_by_zlevel list created at MaxZChanged()")
 
 /datum/controller/subsystem/idlenpcpool/fire(resumed = FALSE)
 

--- a/code/controllers/subsystem/idlenpcpool.dm
+++ b/code/controllers/subsystem/idlenpcpool.dm
@@ -1,6 +1,6 @@
 SUBSYSTEM_DEF(idlenpcpool)
 	name = "Idling NPC Pool"
-	flags = SS_POST_FIRE_TIMING|SS_BACKGROUND
+	flags = SS_POST_FIRE_TIMING|SS_BACKGROUND|SS_NO_INIT
 	priority = FIRE_PRIORITY_IDLE_NPC
 	wait = 60
 	runlevels = RUNLEVEL_GAME | RUNLEVEL_POSTGAME
@@ -13,17 +13,12 @@ SUBSYSTEM_DEF(idlenpcpool)
 	var/list/zlist = GLOB.simple_animals[AI_Z_OFF]
 	..("IdleNPCS:[idlelist.len]|Z:[zlist.len]")
 
-/datum/controller/subsystem/idlenpcpool/Initialize(start_timeofday)
-	MaxZChanged()
-	return ..()
-
 /datum/controller/subsystem/idlenpcpool/proc/MaxZChanged()
 	if (!islist(idle_mobs_by_zlevel))
 		idle_mobs_by_zlevel = new /list(world.maxz,0)
 	while (SSidlenpcpool.idle_mobs_by_zlevel.len < world.maxz)
 		SSidlenpcpool.idle_mobs_by_zlevel.len++
 		SSidlenpcpool.idle_mobs_by_zlevel[idle_mobs_by_zlevel.len] = list()
-		warning("new idle_mobs_by_zlevel list created at MaxZChanged()")
 
 /datum/controller/subsystem/idlenpcpool/fire(resumed = FALSE)
 

--- a/code/controllers/subsystem/mobs.dm
+++ b/code/controllers/subsystem/mobs.dm
@@ -11,8 +11,16 @@ SUBSYSTEM_DEF(mobs)
 	..("P:[GLOB.mob_living_list.len]")
 
 /datum/controller/subsystem/mobs/Initialize(start_timeofday)
-	clients_by_zlevel = new /list(world.maxz,0)
+	MaxZChanged()
 	return ..()
+
+/datum/controller/subsystem/mobs/proc/MaxZChanged()
+	if (!islist(clients_by_zlevel))
+		clients_by_zlevel = new /list(world.maxz,0)
+	while (clients_by_zlevel.len < world.maxz)
+		clients_by_zlevel.len++
+		clients_by_zlevel[clients_by_zlevel.len] = list()
+		warning("new clients_by_zlevel list created at MaxZChanged()")
 
 /datum/controller/subsystem/mobs/fire(resumed = 0)
 	var/seconds = wait * 0.1

--- a/code/controllers/subsystem/mobs.dm
+++ b/code/controllers/subsystem/mobs.dm
@@ -1,7 +1,7 @@
 SUBSYSTEM_DEF(mobs)
 	name = "Mobs"
 	priority = FIRE_PRIORITY_MOBS
-	flags = SS_KEEP_TIMING
+	flags = SS_KEEP_TIMING | SS_NO_INIT
 	runlevels = RUNLEVEL_GAME | RUNLEVEL_POSTGAME
 
 	var/list/currentrun = list()
@@ -10,17 +10,12 @@ SUBSYSTEM_DEF(mobs)
 /datum/controller/subsystem/mobs/stat_entry()
 	..("P:[GLOB.mob_living_list.len]")
 
-/datum/controller/subsystem/mobs/Initialize(start_timeofday)
-	MaxZChanged()
-	return ..()
-
 /datum/controller/subsystem/mobs/proc/MaxZChanged()
 	if (!islist(clients_by_zlevel))
 		clients_by_zlevel = new /list(world.maxz,0)
 	while (clients_by_zlevel.len < world.maxz)
 		clients_by_zlevel.len++
 		clients_by_zlevel[clients_by_zlevel.len] = list()
-		warning("new clients_by_zlevel list created at MaxZChanged()")
 
 /datum/controller/subsystem/mobs/fire(resumed = 0)
 	var/seconds = wait * 0.1

--- a/code/game/world.dm
+++ b/code/game/world.dm
@@ -38,7 +38,7 @@ GLOBAL_PROTECT(security_mode)
 	if(fexists(RESTART_COUNTER_PATH))
 		GLOB.restart_counter = text2num(trim(file2text(RESTART_COUNTER_PATH)))
 		fdel(RESTART_COUNTER_PATH)
-	
+
 	if(NO_INIT_PARAMETER in params)
 		return
 
@@ -269,3 +269,9 @@ GLOBAL_PROTECT(security_mode)
 		hub_password = "kMZy3U5jJHSiBQjr"
 	else
 		hub_password = "SORRYNOPASSWORD"
+
+/world/proc/incrementMaxZ()
+	maxz++
+	warning("New Z-level created at /world/incrementMaxZ()")
+	SSmobs.MaxZChanged()
+	SSidlenpcpool.MaxZChanged()

--- a/code/game/world.dm
+++ b/code/game/world.dm
@@ -272,6 +272,5 @@ GLOBAL_PROTECT(security_mode)
 
 /world/proc/incrementMaxZ()
 	maxz++
-	warning("New Z-level created at /world/incrementMaxZ()")
 	SSmobs.MaxZChanged()
 	SSidlenpcpool.MaxZChanged()

--- a/code/modules/mapping/reader.dm
+++ b/code/modules/mapping/reader.dm
@@ -98,7 +98,8 @@ GLOBAL_DATUM_INIT(_preloader, /dmm_suite/preloader, new)
 				if(cropMap)
 					continue
 				else
-					world.maxz = zcrd //create a new z_level if needed
+					while (zcrd > world.maxz) //create a new z_level if needed
+						world.incrementMaxZ()
 				if(!no_changeturf)
 					WARNING("Z-level expansion occurred without no_changeturf set, this may cause problems when /turf/AfterChange is called")
 

--- a/code/modules/mapping/space_management/zlevel_manager.dm
+++ b/code/modules/mapping/space_management/zlevel_manager.dm
@@ -19,7 +19,7 @@
 /datum/controller/subsystem/mapping/proc/add_new_zlevel(name, linkage = SELFLOOPING, traits = list(), z_type = /datum/space_level)
 	var/new_z = z_list.len + 1
 	if (world.maxz < new_z)
-		++world.maxz
+		world.incrementMaxZ()
 		CHECK_TICK
 	// TODO: sleep here if the Z level needs to be cleared
 	var/datum/space_level/S = new z_type(new_z, name, linkage, traits)


### PR DESCRIPTION
Fixes #34377

:cl: Naksu
fix: Away missions no longer require manually adjusting subsystem mob/client lists in order to not have the AI break.
/:cl:
