### PR TITLE
Fixes species.after_equip_job() running before a player's joining species is finalized

### DIFF
--- a/code/modules/jobs/job_types/job.dm
+++ b/code/modules/jobs/job_types/job.dm
@@ -70,13 +70,13 @@
 	if(outfit)
 		H.equipOutfit(outfit, visualsOnly)
 
-	H.dna.species.after_equip_job(src, H, visualsOnly)
-
 	if(CONFIG_GET(flag/enforce_human_authority) && (title in GLOB.command_positions))
 		if(H.dna.species.id != "human")
 			H.set_species(/datum/species/human)
 			H.rename_self("human", H.client)
 		purrbation_remove(H, silent=TRUE)
+
+	H.dna.species.after_equip_job(src, H, visualsOnly)
 
 	if(!visualsOnly && announce)
 		announce(H)


### PR DESCRIPTION
Fixes #34943

:cl: Naksu
fix: Attempting to join into a command role as a nonhuman species no longer lets you keep your nonhuman species languages if you are transformed into a human because of a config option
/:cl: