### PR TITLE
Fixes a semi-inconsistent runtime with accessories and armor datums

### DIFF
--- a/code/modules/clothing/under/accessories.dm
+++ b/code/modules/clothing/under/accessories.dm
@@ -28,6 +28,12 @@
 		pixel_y -= 8
 	U.add_overlay(src)
 
+	if (islist(U.armor)) 										// This proc can run before /obj/Initialize has run for U and src,
+		U.armor = getArmor(arglist(U.armor))	// we have to check that the armor list has been transformed into a datum before we try to call a proc on it
+																					// This is safe to do as /obj/Initialize only handles setting up the datum if actually needed.
+	if (islist(armor))
+		armor = getArmor(arglist(armor))
+
 	U.armor = U.armor.attachArmor(armor)
 
 	if(isliving(user))


### PR DESCRIPTION
The attach() proc sometimes runs for uninitialized items, particularly at mapload for dummies, resulting in different runtimes depending on which item was uninitialized. Since we can't guard against this in attachArmor() because the datum holding the proc might not exist, we can handle it in the caller. It is the only user of attachArmor() for now, and hopefully further ones do not run before init.
