### PR TITLE
revert vis_contents atmos gases so that 511 clients can see gas until byond can make 512 clients not crash

### DIFF
--- a/code/modules/atmospherics/environmental/LINDA_turf_tile.dm
+++ b/code/modules/atmospherics/environmental/LINDA_turf_tile.dm
@@ -98,11 +98,11 @@
 	var/list/new_overlay_types = tile_graphic()
 	var/list/atmos_overlay_types = src.atmos_overlay_types // Cache for free performance
 
-	#if DM_VERSION >= 513
+	/*#if DM_VERSION >= 513
 	#warning 512 is stable now for sure, remove the old code
-	#endif
+	#endif*/
 
-	#if DM_VERSION >= 512
+	/*#if DM_VERSION >= 512
 	if (atmos_overlay_types)
 		for(var/overlay in atmos_overlay_types-new_overlay_types) //doesn't remove overlays that would only be added
 			vars["vis_contents"] -= overlay
@@ -112,7 +112,7 @@
 			vars["vis_contents"] += new_overlay_types - atmos_overlay_types //don't add overlays that already exist
 		else
 			vars["vis_contents"] += new_overlay_types
-	#else
+	#else*/
 	if (atmos_overlay_types)
 		for(var/overlay in atmos_overlay_types-new_overlay_types) //doesn't remove overlays that would only be added
 			cut_overlay(overlay)
@@ -122,7 +122,7 @@
 			add_overlay(new_overlay_types - atmos_overlay_types) //don't add overlays that already exist
 		else
 			add_overlay(new_overlay_types)
-	#endif
+	//#endif
 
 	UNSETEMPTY(new_overlay_types)
 	src.atmos_overlay_types = new_overlay_types


### PR DESCRIPTION
Because I don't expect this to take longer then a few weeks, and because we might want to test this out again every byond version i'm not going to remove the code but instead comment it out to make it easier to re-add it and test merge

This makes it so 511 clients can see atmos gases again

:cl:
tweak: 511 Clients can see atmos gases
del: This reverts the fix that prevents atmos gas overlays from stealing clicks.
/:cl: