### PR TITLE
Warp whistle now respects notransform

### DIFF
--- a/code/modules/antagonists/wizard/equipment/artefact.dm
+++ b/code/modules/antagonists/wizard/equipment/artefact.dm
@@ -347,7 +347,7 @@
 	var/mob/living/carbon/last_user
 
 /obj/item/warpwhistle/proc/interrupted(mob/living/carbon/user)
-	if(!user || QDELETED(src))
+	if(!user || QDELETED(src) || user.notransform)
 		on_cooldown = FALSE
 		return TRUE
 	return FALSE


### PR DESCRIPTION
Fixes #35015

:cl: Naksu
fix: Warp whistle can no longer pick up its user from inside various animation/in-between states and effects such as transformations, jellypeople split, talisman of immortality effect period or rod form.
/:cl: