### PR TITLE
Turrets now check borgs!

### DIFF
--- a/code/game/machinery/porta_turret/portable_turret.dm
+++ b/code/game/machinery/porta_turret/portable_turret.dm
@@ -370,6 +370,13 @@
 				if(SA.stat || in_faction(SA)) //don't target if dead or in faction
 					continue
 				targets += SA
+			if(issilicon(A)
+				var/mob/living/silicon/sillycone = A
+				if(sillycone.stat || in_faction(sillycone))
+					continue
+				if(faction == "syndicate" && sillycone.emagged == 1) //syndicate turrets are bros with emagged (not ratvar-magged) borgs
+					break
+				targets += sillycone
 
 		if(iscarbon(A))
 			var/mob/living/carbon/C = A

--- a/code/game/machinery/porta_turret/portable_turret.dm
+++ b/code/game/machinery/porta_turret/portable_turret.dm
@@ -370,7 +370,7 @@
 				if(SA.stat || in_faction(SA)) //don't target if dead or in faction
 					continue
 				targets += SA
-			if(issilicon(A)
+			if(issilicon(A))
 				var/mob/living/silicon/sillycone = A
 				if(sillycone.stat || in_faction(sillycone))
 					continue

--- a/code/game/machinery/porta_turret/portable_turret.dm
+++ b/code/game/machinery/porta_turret/portable_turret.dm
@@ -374,8 +374,12 @@
 				var/mob/living/silicon/sillycone = A
 				if(sillycone.stat || in_faction(sillycone))
 					continue
-				if(faction == "syndicate" && sillycone.emagged == 1) //syndicate turrets are bros with emagged (not ratvar-magged) borgs
-					break
+
+				if(iscyborg(sillycone))
+					var/mob/living/silicon/robot/sillyconerobot = A
+					if(faction == "syndicate" && sillyconerobot.emagged == 1)
+						continue
+
 				targets += sillycone
 
 		if(iscarbon(A))

--- a/code/modules/mob/living/silicon/robot/robot_modules.dm
+++ b/code/modules/mob/living/silicon/robot/robot_modules.dm
@@ -552,6 +552,16 @@
 	can_be_pushed = FALSE
 	hat_offset = 3
 
+/obj/item/robot_module/syndicate/rebuild_modules()
+	..()
+	var/mob/living/silicon/robot/Syndi = loc
+	Syndi.faction  -= "silicon" //ai turrets
+
+/obj/item/robot_module/syndicate/remove_module(obj/item/I, delete_after)
+	..()
+	var/mob/living/silicon/robot/Syndi = loc
+	Syndi.faction += "silicon" //ai is your bff now!
+
 /obj/item/robot_module/syndicate_medical
 	name = "Syndicate Medical"
 	basic_modules = list(

--- a/code/modules/mob/living/silicon/silicon.dm
+++ b/code/modules/mob/living/silicon/silicon.dm
@@ -41,6 +41,7 @@
 /mob/living/silicon/Initialize()
 	. = ..()
 	GLOB.silicon_mobs += src
+	faction += "silicon"
 	for(var/datum/atom_hud/data/diagnostic/diag_hud in GLOB.huds)
 		diag_hud.add_to_hud(src)
 	diag_hud_set_status()


### PR DESCRIPTION
:cl:Cobby
fix: Turrets now check for borgs. Syndicate turrets are nice to emagged borgs too!
/:cl:

Reason is you can cheese op turrets as borg (as in they don't target you).

I figured this was an oversight rather than an intentional feature.

# ~~Not Tested~~ Tested!

## WARNING

I put this under check_anomalies since they're kinda a weird thing but someone may want to turn check_anomalies into a bit for each type of mob. I would but > UI editing