### PR TITLE
Removes modifying shuttle areas and adding new ones

### DIFF
--- a/code/__HELPERS/areas.dm
+++ b/code/__HELPERS/areas.dm
@@ -42,12 +42,13 @@
 	if(turfs.len > BP_MAX_ROOM_SIZE)
 		to_chat(creator, "<span class='warning'>The room you're in is too big. It is [((turfs.len / BP_MAX_ROOM_SIZE)-1)*100]% larger than allowed.</span>")
 		return
-	// This will fuck up shuttles that use the base area type but we need to fix those anyway
-	var/list/areas = list("New Area" = /area, "New Shuttle Area" = /area/shuttle/custom)
+	var/list/areas = list("New Area" = /area)
 	for(var/i in 1 to turfs.len)
 		var/area/place = get_area(turfs[i])
 		if(blacklisted_areas[place.type])
 			continue
+		if(!place.requires_power || place.noteleport || place.hidden)
+			continue // No expanding powerless rooms etc
 		areas[place.name] = place
 	var/area_choice = input(creator, "Choose an area to expand or make a new area.", "Area Expansion") as null|anything in areas
 	area_choice = areas[area_choice]


### PR DESCRIPTION
:cl: ninjanomnom
del: Removed the ability to create new shuttle areas or expand existing ones with blueprints.
fix: Special areas like rooms which require no power can no longer be expanded. You can still expand into them however.
/:cl:

It was interesting while it lasted but we need a more complete package of features to allow shuttle construction unfortunately.

fixes #34937
closes #34380