### PR TITLE
Typo fix in Bubblegum desc and outdated comment

### DIFF
--- a/code/modules/mob/living/simple_animal/hostile/megafauna/bubblegum.dm
+++ b/code/modules/mob/living/simple_animal/hostile/megafauna/bubblegum.dm
@@ -14,7 +14,7 @@ If it fails to warp to a target, it may summon up to 6 slaughterlings from the b
 If it does not summon all 6 slaughterlings, it will instead charge at its target, dealing massive damage to anything it hits and spraying a stream of blood.
 At half health, it will either charge three times or warp, then charge, instead of doing a single charge.
 
-When Bubblegum dies, it leaves behind a chest that can contain three things:
+When Bubblegum dies, it leaves behind a H.E.C.K. mining suit as well as a chest that can contain three things:
  1. A bottle that, when activated, drives everyone nearby into a frenzy
  2. A contract that marks for death the chosen target
  3. A spellblade that can slice off limbs at range
@@ -25,7 +25,7 @@ Difficulty: Hard
 
 /mob/living/simple_animal/hostile/megafauna/bubblegum
 	name = "bubblegum"
-	desc = "In what passes for a heirarchy among slaughter demons, this one is king."
+	desc = "In what passes for a hierarchy among slaughter demons, this one is king."
 	health = 2500
 	maxHealth = 2500
 	attacktext = "rends"


### PR DESCRIPTION
:cl: Denton
spellcheck: Fixed Bubblegum's description.
/:cl:

Heirarchy -> hierarchy
Also updated the bubblegum.dm loot comment with the H.E.C.K. suit