### PR TITLE
Syndicate Comms base now has GPS signal

### DIFF
--- a/code/modules/ruins/lavaland_ruin_code.dm
+++ b/code/modules/ruins/lavaland_ruin_code.dm
@@ -136,7 +136,4 @@
 	new /obj/item/device/gps/internal/lavaland_syndicate_base(src)
 
 /obj/item/device/gps/internal/lavaland_syndicate_base
-	icon_state = null
 	gpstag = "Encrypted Signal"
-	desc = "A signal from an unidentifed broadcast."
-	invisibility = 100

--- a/code/modules/ruins/lavaland_ruin_code.dm
+++ b/code/modules/ruins/lavaland_ruin_code.dm
@@ -127,6 +127,16 @@
 /datum/outfit/lavaland_syndicate/comms
 	name = "Lavaland Syndicate Comms Agent"
 	r_hand = /obj/item/melee/transforming/energy/sword/saber
-	mask = /obj/item/clothing/mask/chameleon
+	mask = /obj/item/clothing/mask/chameleon/gps
 	suit = /obj/item/clothing/suit/armor/vest
 	l_pocket = /obj/item/card/id/syndicate/anyone
+
+/obj/item/clothing/mask/chameleon/gps/Initialize()
+	. = ..()
+	new /obj/item/device/gps/internal/lavaland_syndicate_base(src)
+
+/obj/item/device/gps/internal/lavaland_syndicate_base
+	icon_state = null
+	gpstag = "Encrypted Signal"
+	desc = "A signal from an unidentifed broadcast."
+	invisibility = 100


### PR DESCRIPTION
:cl: Kor
add: Spawning as a syndicate comms officer will now activate an encrypted signal in the Lavaland Syndicate Base, to aid the crew in retaliating.
/:cl:

I tied the GPS signal the voice changer so that it will only be active once the comms agent spawns (don't want it to be too easy for miners to locate an empty base and loot it)

I don't know how this makes any sense lorewise that their chameleon mask gives off a signal that miners can come track but hopefully it lets people raid the base more often when the comms agents start trolling the radio.
