### PR TITLE
Makes pluoxium no longer be considered a dangerous gas by air alarms.

### DIFF
--- a/code/modules/atmospherics/machinery/airalarm.dm
+++ b/code/modules/atmospherics/machinery/airalarm.dm
@@ -98,7 +98,7 @@
 		/datum/gas/tritium			= new/datum/tlv/dangerous,
 		/datum/gas/stimulum			= new/datum/tlv/dangerous,
 		/datum/gas/nitryl			= new/datum/tlv/dangerous,
-		/datum/gas/pluoxium			= new/datum/tlv/dangerous
+		/datum/gas/pluoxium			= new/datum/tlv(-1, -1, 135, 140) // Partial pressure, kpa
 	)
 
 /obj/machinery/airalarm/server // No checks here.
@@ -134,7 +134,7 @@
 		/datum/gas/tritium			= new/datum/tlv/dangerous,
 		/datum/gas/stimulum			= new/datum/tlv/dangerous,
 		/datum/gas/nitryl			= new/datum/tlv/dangerous,
-		/datum/gas/pluoxium			= new/datum/tlv/dangerous
+		/datum/gas/pluoxium			= new/datum/tlv(-1, -1, 135, 140) // Partial pressure, kpa
 	)
 
 /obj/machinery/airalarm/engine


### PR DESCRIPTION
:cl: 
tweak: Pluoxium is no longer considered dangerous for air alarms.
/:cl:

Why: Ever since pluoxium being made from irradiated Co2 became a thing, engineering has nonstop air alarms going off every round, which is annoying.
Pluoxium isn't even harmful.