### PR TITLE
Listening fix

### DIFF
--- a/_maps/RandomRuins/SpaceRuins/listeningstation.dmm
+++ b/_maps/RandomRuins/SpaceRuins/listeningstation.dmm
@@ -178,6 +178,7 @@
 	pixel_x = 5;
 	pixel_y = 5
 	},
+/mob/living/simple_animal/hostile/syndicate/ranged,
 /turf/open/floor/plasteel/vault{
 	dir = 5
 	},
@@ -646,6 +647,7 @@
 	pixel_x = 5;
 	pixel_y = 5
 	},
+/mob/living/simple_animal/hostile/syndicate/ranged,
 /turf/open/floor/plasteel,
 /area/ruin/space/has_grav/listeningstation)
 "bc" = (
@@ -892,11 +894,6 @@
 /turf/open/floor/plasteel/grimy,
 /area/ruin/space/has_grav/listeningstation)
 "bx" = (
-/obj/effect/mob_spawn/human/lavaland_syndicate/comms{
-	assignedrole = "Space Syndicate";
-	dir = 8;
-	flavour_text = "<span class='big bold'>You are a syndicate agent,</span><b> assigned to a small listening post station situated near your hated enemy's top secret research facility: Space Station 13. <b>Monitor enemy activity as best you can, and try to keep a low profile. <font size=6>DON'T</font> abandon the base without good cause.</b> Use the communication equipment to provide support to any field agents, and sow disinformation to throw Nanotrasen off your trail. Do not let the base fall into enemy hands!</b>"
-	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 8;
 	piping_layer = 3;

--- a/code/modules/ruins/lavaland_ruin_code.dm
+++ b/code/modules/ruins/lavaland_ruin_code.dm
@@ -130,6 +130,5 @@
 /datum/outfit/lavaland_syndicate/comms
 	name = "Lavaland Syndicate Comms Agent"
 	r_hand = /obj/item/melee/transforming/energy/sword/saber
-	mask = /obj/item/clothing/mask/chameleon
 	suit = /obj/item/clothing/suit/armor/vest
 	l_pocket = /obj/item/card/id/syndicate/anyone

--- a/code/modules/ruins/lavaland_ruin_code.dm
+++ b/code/modules/ruins/lavaland_ruin_code.dm
@@ -130,5 +130,6 @@
 /datum/outfit/lavaland_syndicate/comms
 	name = "Lavaland Syndicate Comms Agent"
 	r_hand = /obj/item/melee/transforming/energy/sword/saber
+	mask = /obj/item/clothing/mask/chameleon
 	suit = /obj/item/clothing/suit/armor/vest
 	l_pocket = /obj/item/card/id/syndicate/anyone


### PR DESCRIPTION
#Fixes #35019

:cl: optional name here
del: Space ghost syndicate comms guy removed.
/:cl:

[why]: Two birds one stone. It resolves it being too often and this is a change @KorPhaeron requested