### PR TITLE
Removes comms agent bluespace transmitter and voice changer mask.

### DIFF
--- a/_maps/RandomRuins/SpaceRuins/listeningstation.dmm
+++ b/_maps/RandomRuins/SpaceRuins/listeningstation.dmm
@@ -51,14 +51,6 @@
 	dir = 4
 	},
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/newscaster{
-	pixel_y = 32
-	},
-/obj/item/device/radio/intercom{
-	freerange = 1;
-	name = "Syndicate Radio Intercom";
-	pixel_x = -30
-	},
 /turf/open/floor/plasteel/dark,
 /area/ruin/space/has_grav/listeningstation)
 "ai" = (
@@ -77,10 +69,8 @@
 	},
 /area/ruin/space/has_grav/listeningstation)
 "ak" = (
-/obj/machinery/telecomms/relay/preset/ruskie{
-	use_power = 0
-	},
 /obj/effect/decal/cleanable/dirt,
+/obj/structure/table,
 /turf/open/floor/plasteel/dark,
 /area/ruin/space/has_grav/listeningstation)
 "al" = (
@@ -152,10 +142,10 @@
 /area/ruin/space/has_grav/listeningstation)
 "as" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/computer/med_data/syndie{
-	dir = 4;
-	req_one_access = null
-	},
+/obj/structure/table,
+/obj/item/paper_bin,
+/obj/item/paper/fluff/ruins/listeningstation/reports/november,
+/obj/item/pen,
 /turf/open/floor/plasteel/dark,
 /area/ruin/space/has_grav/listeningstation)
 "at" = (
@@ -190,9 +180,13 @@
 	pixel_x = 25
 	},
 /obj/structure/table,
-/obj/item/paper_bin,
-/obj/item/paper/fluff/ruins/listeningstation/reports/november,
-/obj/item/pen,
+/obj/item/device/radio/headset/syndicate/alt{
+	pixel_x = 3;
+	pixel_y = 3
+	},
+/obj/item/device/radio/headset/syndicate/alt{
+	pixel_x = -3
+	},
 /turf/open/floor/plasteel/dark,
 /area/ruin/space/has_grav/listeningstation)
 "aw" = (
@@ -272,9 +266,8 @@
 /obj/structure/rack{
 	dir = 8
 	},
-/obj/item/device/multitool,
-/obj/item/device/radio/headset/syndicate/alt,
 /obj/effect/decal/cleanable/dirt,
+/obj/item/crowbar/red,
 /turf/open/floor/plasteel/dark,
 /area/ruin/space/has_grav/listeningstation)
 "aC" = (
@@ -895,7 +888,8 @@
 /obj/effect/mob_spawn/human/lavaland_syndicate/comms{
 	assignedrole = "Space Syndicate";
 	dir = 8;
-	flavour_text = "<span class='big bold'>You are a syndicate agent,</span><b> assigned to a small listening post station situated near your hated enemy's top secret research facility: Space Station 13. <b>Monitor enemy activity as best you can, and try to keep a low profile. <font size=6>DON'T</font> abandon the base without good cause.</b> Use the communication equipment to provide support to any field agents, and sow disinformation to throw Nanotrasen off your trail. Do not let the base fall into enemy hands!</b>"
+	flavour_text = "<span class='big bold'>You are a syndicate agent,</span><b> assigned to a small listening post station situated near your hated enemy's top secret research facility: Space Station 13. <b>Monitor enemy activity as best you can, and try to keep a low profile. <font size=6>DON'T</font> abandon the base without good cause.</b> Use the communication equipment to provide support to any field agents, and sow disinformation to throw Nanotrasen off your trail. Do not let the base fall into enemy hands!</b>";
+	mask = null
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 8;


### PR DESCRIPTION
An alternative to the other PRs. The syndie listening post no longer has a bluespace transmitter, voice changer, crew medical records console, or intercom, and can now only communicate with syndies to watch over them and provide guidance, without dicking over the crew by confusing them.
Fixes #35019 
Closes #35083 
Closes #35078 

:cl: WJohnston
tweak: The space syndicate listening post can no longer communicate or interfere with the crew, only syndicates.
/:cl: