### PR TITLE
Mark pirate ship docking port non-timid

### DIFF
--- a/_maps/templates/pirate_ship.dmm
+++ b/_maps/templates/pirate_ship.dmm
@@ -664,6 +664,7 @@
 	name = "Pirate Ship";
 	port_direction = 8;
 	preferred_direction = 1;
+	timid = 0;
 	width = 23
 	},
 /obj/docking_port/stationary{


### PR DESCRIPTION
:cl:
fix: The pirate ship can now fly again.
/:cl:

Shuttle changes mean the docking port doesn't register when the template loads in. Not sure if this is the right thing to do? @coiax 

https://github.com/tgstation/tgstation/blob/66d888ad08208c13f43dfa78b94ee916c3be0c97/code/modules/events/pirates.dm#L60-L69