### PR TITLE
Adds new helper: use_tool, shakes things up in tool code

### DIFF
--- a/code/__DEFINES/tools.dm
+++ b/code/__DEFINES/tools.dm
@@ -5,3 +5,8 @@
 #define TOOL_WIRECUTTER 	"wirecutter"
 #define TOOL_WRENCH 		"wrench"
 #define TOOL_WELDER 		"welder"
+
+
+// If delay between the start and the end of tool operation is less than MIN_TOOL_SOUND_DELAY,
+// tool sound is only played when op is started. If not, it's played twice.
+#define MIN_TOOL_SOUND_DELAY 20

--- a/code/game/atoms.dm
+++ b/code/game/atoms.dm
@@ -534,38 +534,38 @@
 // Tool behavior procedure. Redirects to tool-specific procs by default.
 // You can override it to catch all tool interactions, for use in complex deconstruction procs.
 // Just don't forget to return ..() in the end.
-/atom/proc/tool_act(mob/living/user, obj/item/tool, tool_type)
+/atom/proc/tool_act(mob/living/user, obj/item/I, tool_type)
 	switch(tool_type)
 		if(TOOL_CROWBAR)
-			return crowbar_act(user, tool)
+			return crowbar_act(user, I)
 		if(TOOL_MULTITOOL)
-			return multitool_act(user, tool)
+			return multitool_act(user, I)
 		if(TOOL_SCREWDRIVER)
-			return screwdriver_act(user, tool)
+			return screwdriver_act(user, I)
 		if(TOOL_WRENCH)
-			return wrench_act(user, tool)
+			return wrench_act(user, I)
 		if(TOOL_WIRECUTTER)
-			return wirecutter_act(user, tool)
+			return wirecutter_act(user, I)
 		if(TOOL_WELDER)
-			return welder_act(user, tool)
+			return welder_act(user, I)
 
 // Tool-specific behavior procs. To be overridden in subtypes.
-/atom/proc/crowbar_act(mob/living/user, obj/item/tool)
+/atom/proc/crowbar_act(mob/living/user, obj/item/I)
 	return
 
-/atom/proc/multitool_act(mob/living/user, obj/item/tool)
+/atom/proc/multitool_act(mob/living/user, obj/item/I)
 	return
 
-/atom/proc/screwdriver_act(mob/living/user, obj/item/tool)
+/atom/proc/screwdriver_act(mob/living/user, obj/item/I)
 	return
 
-/atom/proc/wrench_act(mob/living/user, obj/item/tool)
+/atom/proc/wrench_act(mob/living/user, obj/item/I)
 	return
 
-/atom/proc/wirecutter_act(mob/living/user, obj/item/tool)
+/atom/proc/wirecutter_act(mob/living/user, obj/item/I)
 	return
 
-/atom/proc/welder_act(mob/living/user, obj/item/tool)
+/atom/proc/welder_act(mob/living/user, obj/item/I)
 	return
 
 /atom/proc/GenerateTag()

--- a/code/game/machinery/PDApainter.dm
+++ b/code/game/machinery/PDApainter.dm
@@ -80,21 +80,21 @@
 		update_icon()
 
 	else if(istype(O, /obj/item/weldingtool) && user.a_intent != INTENT_HARM)
-		var/obj/item/weldingtool/WT = O
 		if(stat & BROKEN)
-			if(WT.remove_fuel(0,user))
-				user.visible_message("[user] is repairing [src].", \
-								"<span class='notice'>You begin repairing [src]...</span>", \
-								"<span class='italics'>You hear welding.</span>")
-				playsound(loc, WT.usesound, 40, 1)
-				if(do_after(user,40*WT.toolspeed, 1, target = src))
-					if(!WT.isOn() || !(stat & BROKEN))
-						return
-					to_chat(user, "<span class='notice'>You repair [src].</span>")
-					playsound(loc, 'sound/items/welder2.ogg', 50, 1)
-					stat &= ~BROKEN
-					obj_integrity = max_integrity
-					update_icon()
+			if(!O.tool_start_check(user, amount=0))
+				return
+			user.visible_message("[user] is repairing [src].", \
+							"<span class='notice'>You begin repairing [src]...</span>", \
+							"<span class='italics'>You hear welding.</span>")
+			playsound(loc, O.usesound, 40, 1)
+			if(O.use_tool(src, user, 40))
+				if(!(stat & BROKEN))
+					return
+				to_chat(user, "<span class='notice'>You repair [src].</span>")
+				playsound(loc, 'sound/items/welder2.ogg', 50, 1)
+				stat &= ~BROKEN
+				obj_integrity = max_integrity
+				update_icon()
 		else
 			to_chat(user, "<span class='notice'>[src] does not need repairs.</span>")
 	else

--- a/code/game/machinery/_machinery.dm
+++ b/code/game/machinery/_machinery.dm
@@ -375,7 +375,7 @@ Class Procs:
 		playsound(loc, W.usesound, 50, 1)
 		var/prev_anchored = anchored
 		//as long as we're the same anchored state and we're either on a floor or are anchored, toggle our anchored state
-		if(!time || do_after(user, time*W.toolspeed, target = src, extra_checks = CALLBACK(src, .proc/unfasten_wrench_check, prev_anchored, user)))
+		if(W.use_tool(src, user, time, extra_checks = CALLBACK(src, .proc/unfasten_wrench_check, prev_anchored, user)))
 			to_chat(user, "<span class='notice'>You [anchored ? "un" : ""]secure [src].</span>")
 			anchored = !anchored
 			playsound(loc, 'sound/items/deconstruct.ogg', 50, 1)

--- a/code/game/machinery/_machinery.dm
+++ b/code/game/machinery/_machinery.dm
@@ -290,18 +290,17 @@ Class Procs:
 /obj/machinery/proc/RefreshParts() //Placeholder proc for machines that are built using frames.
 	return
 
-/obj/machinery/proc/default_pry_open(obj/item/crowbar/C)
-	. = !(state_open || panel_open || is_operational() || (flags_1 & NODECONSTRUCT_1)) && istype(C)
+/obj/machinery/proc/default_pry_open(obj/item/I)
+	. = !(state_open || panel_open || is_operational() || (flags_1 & NODECONSTRUCT_1)) && I.tool_behaviour == TOOL_CROWBAR
 	if(.)
-		playsound(loc, C.usesound, 50, 1)
+		I.play_tool_sound(src, 50)
 		visible_message("<span class='notice'>[usr] pries open \the [src].</span>", "<span class='notice'>You pry open \the [src].</span>")
 		open_machine()
-		return 1
 
-/obj/machinery/proc/default_deconstruction_crowbar(obj/item/crowbar/C, ignore_panel = 0)
-	. = istype(C) && (panel_open || ignore_panel) &&  !(flags_1 & NODECONSTRUCT_1)
+/obj/machinery/proc/default_deconstruction_crowbar(obj/item/I, ignore_panel = 0)
+	. = (panel_open || ignore_panel) && !(flags_1 & NODECONSTRUCT_1) && I.tool_behaviour == TOOL_CROWBAR
 	if(.)
-		playsound(loc, C.usesound, 50, 1)
+		I.play_tool_sound(src, 50)
 		deconstruct(TRUE)
 
 /obj/machinery/deconstruct(disassembled = TRUE)
@@ -337,9 +336,9 @@ Class Procs:
 		update_icon()
 		updateUsrDialog()
 
-/obj/machinery/proc/default_deconstruction_screwdriver(mob/user, icon_state_open, icon_state_closed, obj/item/screwdriver/S)
-	if(istype(S) &&  !(flags_1 & NODECONSTRUCT_1))
-		playsound(loc, S.usesound, 50, 1)
+/obj/machinery/proc/default_deconstruction_screwdriver(mob/user, icon_state_open, icon_state_closed, obj/item/I)
+	if(!(flags_1 & NODECONSTRUCT_1) && I.tool_behaviour == TOOL_SCREWDRIVER)
+		I.play_tool_sound(src, 50)
 		if(!panel_open)
 			panel_open = TRUE
 			icon_state = icon_state_open
@@ -351,9 +350,9 @@ Class Procs:
 		return 1
 	return 0
 
-/obj/machinery/proc/default_change_direction_wrench(mob/user, obj/item/wrench/W)
-	if(panel_open && istype(W))
-		playsound(loc, W.usesound, 50, 1)
+/obj/machinery/proc/default_change_direction_wrench(mob/user, obj/item/I)
+	if(panel_open && I.tool_behaviour == TOOL_WRENCH)
+		I.play_tool_sound(src, 50)
 		setDir(turn(dir,-90))
 		to_chat(user, "<span class='notice'>You rotate [src].</span>")
 		return 1
@@ -365,20 +364,20 @@ Class Procs:
 		return FAILED_UNFASTEN
 	return SUCCESSFUL_UNFASTEN
 
-/obj/proc/default_unfasten_wrench(mob/user, obj/item/wrench/W, time = 20) //try to unwrench an object in a WONDERFUL DYNAMIC WAY
-	if(istype(W) && !(flags_1 & NODECONSTRUCT_1))
+/obj/proc/default_unfasten_wrench(mob/user, obj/item/I, time = 20) //try to unwrench an object in a WONDERFUL DYNAMIC WAY
+	if(!(flags_1 & NODECONSTRUCT_1) && I.tool_behaviour == TOOL_WRENCH)
 		var/can_be_unfasten = can_be_unfasten_wrench(user)
 		if(!can_be_unfasten || can_be_unfasten == FAILED_UNFASTEN)
 			return can_be_unfasten
 		if(time)
 			to_chat(user, "<span class='notice'>You begin [anchored ? "un" : ""]securing [src]...</span>")
-		playsound(loc, W.usesound, 50, 1)
+		I.play_tool_sound(src, 50)
 		var/prev_anchored = anchored
 		//as long as we're the same anchored state and we're either on a floor or are anchored, toggle our anchored state
-		if(W.use_tool(src, user, time, extra_checks = CALLBACK(src, .proc/unfasten_wrench_check, prev_anchored, user)))
+		if(I.use_tool(src, user, time, extra_checks = CALLBACK(src, .proc/unfasten_wrench_check, prev_anchored, user)))
 			to_chat(user, "<span class='notice'>You [anchored ? "un" : ""]secure [src].</span>")
 			anchored = !anchored
-			playsound(loc, 'sound/items/deconstruct.ogg', 50, 1)
+			playsound(src, 'sound/items/deconstruct.ogg', 50, 1)
 			return SUCCESSFUL_UNFASTEN
 		return FAILED_UNFASTEN
 	return CANT_UNFASTEN

--- a/code/game/machinery/aug_manipulator.dm
+++ b/code/game/machinery/aug_manipulator.dm
@@ -74,21 +74,23 @@
 			update_icon()
 
 	else if(istype(O, /obj/item/weldingtool) && user.a_intent != INTENT_HARM)
-		var/obj/item/weldingtool/WT = O
 		if(obj_integrity < max_integrity)
-			if(WT.remove_fuel(0,user))
-				user.visible_message("[user] begins repairing [src].", \
-								"<span class='notice'>You begin repairing [src]...</span>", \
-								"<span class='italics'>You hear welding.</span>")
-				playsound(src, WT.usesound, 40, 1)
-				if(do_after(user,40*WT.toolspeed, TRUE, target = src))
-					if(!WT.isOn() || !(stat & BROKEN))
-						return
-					to_chat(user, "<span class='notice'>You repair [src].</span>")
-					playsound(src, 'sound/items/welder2.ogg', 50, 1)
-					stat &= ~BROKEN
-					obj_integrity = max(obj_integrity, max_integrity)
-					update_icon()
+			if(!O.tool_start_check(user, amount=0))
+				return
+
+			user.visible_message("[user] begins repairing [src].", \
+				"<span class='notice'>You begin repairing [src]...</span>", \
+				"<span class='italics'>You hear welding.</span>")
+
+			playsound(src, O.usesound, 40, 1)
+			if(O.use_tool(src, user, 40))
+				if(!(stat & BROKEN))
+					return
+				to_chat(user, "<span class='notice'>You repair [src].</span>")
+				playsound(src, 'sound/items/welder2.ogg', 50, 1)
+				stat &= ~BROKEN
+				obj_integrity = max(obj_integrity, max_integrity)
+				update_icon()
 		else
 			to_chat(user, "<span class='notice'>[src] does not need repairs.</span>")
 	else

--- a/code/game/machinery/buttons.dm
+++ b/code/game/machinery/buttons.dm
@@ -88,7 +88,7 @@
 		if(!device && !board && istype(W, /obj/item/wrench))
 			to_chat(user, "<span class='notice'>You start unsecuring the button frame...</span>")
 			playsound(loc, W.usesound, 50, 1)
-			if(do_after(user, 40*W.toolspeed, target = src))
+			if(W.use_tool(src, user, 40))
 				to_chat(user, "<span class='notice'>You unsecure the button frame.</span>")
 				transfer_fingerprints_to(new /obj/item/wallframe/button(get_turf(src)))
 				playsound(loc, 'sound/items/deconstruct.ogg', 50, 1)

--- a/code/game/machinery/camera/camera.dm
+++ b/code/game/machinery/camera/camera.dm
@@ -367,19 +367,16 @@
 
 	return null
 
-/obj/machinery/camera/proc/weld(obj/item/weldingtool/WT, mob/living/user)
+/obj/machinery/camera/proc/weld(obj/item/weldingtool/W, mob/living/user)
 	if(busy)
 		return FALSE
-	if(!WT.remove_fuel(0, user))
+	if(!W.tool_start_check(user, amount=0))
 		return FALSE
 
 	to_chat(user, "<span class='notice'>You start to weld [src]...</span>")
-	playsound(src.loc, WT.usesound, 50, 1)
 	busy = TRUE
-	if(do_after(user, 100*WT.toolspeed, target = src))
+	if(W.use_tool(src, user, 100, volume=50))
 		busy = FALSE
-		if(!WT.isOn())
-			return FALSE
 		return TRUE
 	busy = FALSE
 	return FALSE

--- a/code/game/machinery/camera/camera_assembly.dm
+++ b/code/game/machinery/camera/camera_assembly.dm
@@ -128,15 +128,14 @@
 	qdel(src)
 	return TRUE
 
-/obj/structure/camera_assembly/proc/weld(obj/item/weldingtool/WT, mob/living/user)
-	if(!WT.remove_fuel(0, user))
+/obj/structure/camera_assembly/proc/weld(obj/item/weldingtool/W, mob/living/user)
+	if(!W.tool_start_check(user, amount=0))
 		return 0
 	to_chat(user, "<span class='notice'>You start to weld \the [src]...</span>")
-	playsound(src.loc, WT.usesound, 50, 1)
-	if(do_after(user, 20*WT.toolspeed, target = src))
-		if(WT.isOn())
-			playsound(loc, 'sound/items/welder2.ogg', 50, 1)
-			return 1
+	playsound(src.loc, W.usesound, 50, 1)
+	if(W.use_tool(src, user, 20))
+		playsound(loc, 'sound/items/welder2.ogg', 50, 1)
+		return 1
 	return 0
 
 /obj/structure/camera_assembly/deconstruct(disassembled = TRUE)

--- a/code/game/machinery/camera/camera_assembly.dm
+++ b/code/game/machinery/camera/camera_assembly.dm
@@ -130,13 +130,13 @@
 
 /obj/structure/camera_assembly/proc/weld(obj/item/weldingtool/W, mob/living/user)
 	if(!W.tool_start_check(user, amount=0))
-		return 0
+		return FALSE
 	to_chat(user, "<span class='notice'>You start to weld \the [src]...</span>")
 	playsound(src.loc, W.usesound, 50, 1)
 	if(W.use_tool(src, user, 20))
 		playsound(loc, 'sound/items/welder2.ogg', 50, 1)
-		return 1
-	return 0
+		return TRUE
+	return FALSE
 
 /obj/structure/camera_assembly/deconstruct(disassembled = TRUE)
 	if(!(flags_1 & NODECONSTRUCT_1))

--- a/code/game/machinery/computer/_computer.dm
+++ b/code/game/machinery/computer/_computer.dm
@@ -72,7 +72,7 @@
 /obj/machinery/computer/screwdriver_act(mob/living/user, obj/item/I)
 	if(circuit && !(flags_1&NODECONSTRUCT_1))
 		to_chat(user, "<span class='notice'>You start to disconnect the monitor...</span>")
-		if(I.use_tool(src, user, 40, volume=50))
+		if(I.use_tool(src, user, 20, volume=50))
 			deconstruct(TRUE, user)
 	return TRUE
 

--- a/code/game/machinery/computer/_computer.dm
+++ b/code/game/machinery/computer/_computer.dm
@@ -69,14 +69,13 @@
 	update_icon()
 	return
 
-/obj/machinery/computer/attackby(obj/item/I, mob/user, params)
-	if(istype(I, /obj/item/screwdriver) && circuit && !(flags_1&NODECONSTRUCT_1))
-		playsound(src.loc, I.usesound, 50, 1)
-		to_chat(user, "<span class='notice'> You start to disconnect the monitor...</span>")
-		if(do_after(user, 20*I.toolspeed, target = src))
+/obj/machinery/computer/screwdriver_act(mob/living/user, obj/item/I)
+	if(circuit && !(flags_1&NODECONSTRUCT_1))
+		to_chat(user, "<span class='notice'>You start to disconnect the monitor...</span>")
+		if(I.use_tool(src, user, 40, volume=50))
 			deconstruct(TRUE, user)
-	else
-		return ..()
+	return TRUE
+
 
 /obj/machinery/computer/play_attack_sound(damage_amount, damage_type = BRUTE, damage_flag = 0)
 	switch(damage_type)

--- a/code/game/machinery/computer/buildandrepair.dm
+++ b/code/game/machinery/computer/buildandrepair.dm
@@ -8,24 +8,18 @@
 	switch(state)
 		if(0)
 			if(istype(P, /obj/item/wrench))
-				playsound(src, P.usesound, 50, 1)
 				to_chat(user, "<span class='notice'>You start wrenching the frame into place...</span>")
-				if(do_after(user, 20*P.toolspeed, target = src))
+				if(P.use_tool(src, user, 20, volume=50))
 					to_chat(user, "<span class='notice'>You wrench the frame into place.</span>")
 					anchored = TRUE
 					state = 1
 				return
 			if(istype(P, /obj/item/weldingtool))
-				var/obj/item/weldingtool/WT = P
-				if(!WT.remove_fuel(0, user))
-					if(!WT.isOn())
-						to_chat(user, "<span class='warning'>[WT] must be on to complete this task!</span>")
+				if(!P.tool_start_check(user, amount=0))
 					return
-				playsound(src, P.usesound, 50, 1)
+
 				to_chat(user, "<span class='notice'>You start deconstructing the frame...</span>")
-				if(do_after(user, 20*P.toolspeed, target = src))
-					if(!src || !WT.isOn())
-						return
+				if(P.use_tool(src, user, 20, volume=50))
 					to_chat(user, "<span class='notice'>You deconstruct the frame.</span>")
 					var/obj/item/stack/sheet/metal/M = new (drop_location(), 5)
 					M.add_fingerprint(user)
@@ -33,9 +27,8 @@
 				return
 		if(1)
 			if(istype(P, /obj/item/wrench))
-				playsound(src, P.usesound, 50, 1)
 				to_chat(user, "<span class='notice'>You start to unfasten the frame...</span>")
-				if(do_after(user, 20*P.toolspeed, target = src))
+				if(P.use_tool(src, user, 20, volume=50))
 					to_chat(user, "<span class='notice'>You unfasten the frame.</span>")
 					anchored = FALSE
 					state = 0
@@ -76,18 +69,16 @@
 				icon_state = "1"
 				return
 			if(istype(P, /obj/item/stack/cable_coil))
-				var/obj/item/stack/cable_coil/C = P
-				if(C.get_amount() >= 5)
-					playsound(src, 'sound/items/deconstruct.ogg', 50, 1)
-					to_chat(user, "<span class='notice'>You start adding cables to the frame...</span>")
-					if(do_after(user, 20*P.toolspeed, target = src))
-						if(C.get_amount() >= 5 && state == 2)
-							C.use(5)
-							to_chat(user, "<span class='notice'>You add cables to the frame.</span>")
-							state = 3
-							icon_state = "3"
-				else
-					to_chat(user, "<span class='warning'>You need five lengths of cable to wire the frame!</span>")
+				if(!P.tool_start_check(user, amount=5))
+					return
+				playsound(src, 'sound/items/deconstruct.ogg', 50, 1)
+				to_chat(user, "<span class='notice'>You start adding cables to the frame...</span>")
+				if(P.use_tool(src, user, 20, amount=5))
+					if(state != 2)
+						return
+					to_chat(user, "<span class='notice'>You add cables to the frame.</span>")
+					state = 3
+					icon_state = "3"
 				return
 		if(3)
 			if(istype(P, /obj/item/wirecutters))
@@ -95,25 +86,21 @@
 				to_chat(user, "<span class='notice'>You remove the cables.</span>")
 				state = 2
 				icon_state = "2"
-				var/obj/item/stack/cable_coil/A = new (drop_location())
-				A.amount = 5
+				var/obj/item/stack/cable_coil/A = new (drop_location(), 5)
 				A.add_fingerprint(user)
 				return
 
 			if(istype(P, /obj/item/stack/sheet/glass))
-				var/obj/item/stack/sheet/glass/G = P
-				if(G.get_amount() < 2)
-					to_chat(user, "<span class='warning'>You need two glass sheets to continue construction!</span>")
+				if(!P.tool_start_check(user, amount=2))
 					return
-				else
-					playsound(src, 'sound/items/deconstruct.ogg', 50, 1)
-					to_chat(user, "<span class='notice'>You start to put in the glass panel...</span>")
-					if(do_after(user, 20, target = src))
-						if(G.get_amount() >= 2 && state == 3)
-							G.use(2)
-							to_chat(user, "<span class='notice'>You put in the glass panel.</span>")
-							state = 4
-							src.icon_state = "4"
+				playsound(src, 'sound/items/deconstruct.ogg', 50, 1)
+				to_chat(user, "<span class='notice'>You start to put in the glass panel...</span>")
+				if(P.use_tool(src, user, 20, amount=2))
+					if(state != 3)
+						return
+					to_chat(user, "<span class='notice'>You put in the glass panel.</span>")
+					state = 4
+					src.icon_state = "4"
 				return
 		if(4)
 			if(istype(P, /obj/item/crowbar))

--- a/code/game/machinery/constructable_frame.dm
+++ b/code/game/machinery/constructable_frame.dm
@@ -81,24 +81,20 @@
 				to_chat(user, "<span class='warning'>This frame does not accept circuit boards of this type!</span>")
 				return
 			if(istype(P, /obj/item/stack/cable_coil))
-				var/obj/item/stack/cable_coil/C = P
-				if(C.get_amount() >= 5)
-					playsound(src.loc, 'sound/items/deconstruct.ogg', 50, 1)
-					to_chat(user, "<span class='notice'>You start to add cables to the frame...</span>")
-					if(do_after(user, 20*P.toolspeed, target = src))
-						if(C.get_amount() >= 5 && state == 1)
-							C.use(5)
-							to_chat(user, "<span class='notice'>You add cables to the frame.</span>")
-							state = 2
-							icon_state = "box_1"
-				else
-					to_chat(user, "<span class='warning'>You need five length of cable to wire the frame!</span>")
+				if(!P.tool_start_check(user, amount=5))
+					return
+
+				to_chat(user, "<span class='notice'>You start to add cables to the frame...</span>")
+				if(P.use_tool(src, user, 20, volume=50, amount=5))
+					to_chat(user, "<span class='notice'>You add cables to the frame.</span>")
+					state = 2
+					icon_state = "box_1"
+
 				return
 			if(istype(P, /obj/item/screwdriver) && !anchored)
-				playsound(src.loc, P.usesound, 50, 1)
 				user.visible_message("<span class='warning'>[user] disassembles the frame.</span>", \
 									"<span class='notice'>You start to disassemble the frame...</span>", "You hear banging and clanking.")
-				if(do_after(user, 40*P.toolspeed, target = src))
+				if(P.use_tool(src, user, 40, volume=50))
 					if(state == 1)
 						to_chat(user, "<span class='notice'>You disassemble the frame.</span>")
 						var/obj/item/stack/sheet/metal/M = new (loc, 5)
@@ -107,8 +103,7 @@
 				return
 			if(istype(P, /obj/item/wrench))
 				to_chat(user, "<span class='notice'>You start [anchored ? "un" : ""]securing [name]...</span>")
-				playsound(src.loc, P.usesound, 75, 1)
-				if(do_after(user, 40*P.toolspeed, target = src))
+				if(P.use_tool(src, user, 40, volume=75))
 					if(state == 1)
 						to_chat(user, "<span class='notice'>You [anchored ? "un" : ""]secure [name].</span>")
 						anchored = !anchored
@@ -117,8 +112,7 @@
 		if(2)
 			if(istype(P, /obj/item/wrench))
 				to_chat(user, "<span class='notice'>You start [anchored ? "un" : ""]securing [name]...</span>")
-				playsound(src.loc, P.usesound, 75, 1)
-				if(do_after(user, 40*P.toolspeed, target = src))
+				if(P.use_tool(src, user, 40, volume=75))
 					to_chat(user, "<span class='notice'>You [anchored ? "un" : ""]secure [name].</span>")
 					anchored = !anchored
 				return
@@ -149,8 +143,7 @@
 				to_chat(user, "<span class='notice'>You remove the cables.</span>")
 				state = 1
 				icon_state = "box_0"
-				var/obj/item/stack/cable_coil/A = new /obj/item/stack/cable_coil( src.loc )
-				A.amount = 5
+				new /obj/item/stack/cable_coil(drop_location(), 5)
 				return
 
 		if(3)

--- a/code/game/machinery/deployable.dm
+++ b/code/game/machinery/deployable.dm
@@ -27,13 +27,13 @@
 
 /obj/structure/barricade/attackby(obj/item/I, mob/user, params)
 	if(istype(I, /obj/item/weldingtool) && user.a_intent != INTENT_HARM && material == METAL)
-		var/obj/item/weldingtool/WT = I
 		if(obj_integrity < max_integrity)
-			if(WT.remove_fuel(0,user))
-				to_chat(user, "<span class='notice'>You begin repairing [src]...</span>")
-				playsound(loc, WT.usesound, 40, 1)
-				if(do_after(user, 40*I.toolspeed, target = src))
-					obj_integrity = CLAMP(obj_integrity + 20, 0, max_integrity)
+			if(!I.tool_start_check(user, amount=0))
+				return
+
+			to_chat(user, "<span class='notice'>You begin repairing [src]...</span>")
+			if(I.use_tool(src, user, 40, volume=40))
+				obj_integrity = CLAMP(obj_integrity + 20, 0, max_integrity)
 	else
 		return ..()
 

--- a/code/game/machinery/doors/airlock.dm
+++ b/code/game/machinery/doors/airlock.dm
@@ -782,15 +782,12 @@
 					return
 			if(AIRLOCK_SECURITY_METAL)
 				if(istype(C, /obj/item/weldingtool))
-					var/obj/item/weldingtool/WT = C
-					if(!WT.remove_fuel(2, user))
+					if(!C.tool_start_check(user, amount=2))
 						return
 					to_chat(user, "<span class='notice'>You begin cutting the panel's shielding...</span>")
-					playsound(loc, WT.usesound, 40, 1)
-					if(do_after(user, 40*WT.toolspeed, 1, target = src))
-						if(!panel_open || !WT.isOn())
+					if(C.use_tool(src, user, 40, volume=50, amount = 2))
+						if(!panel_open)
 							return
-						playsound(loc, WT.usesound, 50, 1)
 						user.visible_message("<span class='notice'>[user] cuts through \the [src]'s shielding.</span>",
 										"<span class='notice'>You cut through \the [src]'s shielding.</span>",
 										"<span class='italics'>You hear welding.</span>")
@@ -802,8 +799,7 @@
 				if(istype(C, /obj/item/crowbar))
 					var/obj/item/crowbar/W = C
 					to_chat(user, "<span class='notice'>You start removing the inner layer of shielding...</span>")
-					playsound(src, W.usesound, 100, 1)
-					if(do_after(user, 40*W.toolspeed, 1, target = src))
+					if(W.use_tool(src, user, 40, volume=100))
 						if(!panel_open)
 							return
 						if(security_level != AIRLOCK_SECURITY_PLASTEEL_I_S)
@@ -818,15 +814,12 @@
 					return
 			if(AIRLOCK_SECURITY_PLASTEEL_I)
 				if(istype(C, /obj/item/weldingtool))
-					var/obj/item/weldingtool/WT = C
-					if(!WT.remove_fuel(2, user))
+					if(!C.tool_start_check(user, amount=2))
 						return
 					to_chat(user, "<span class='notice'>You begin cutting the inner layer of shielding...</span>")
-					playsound(loc, WT.usesound, 40, 1)
-					if(do_after(user, 40*WT.toolspeed, 1, target = src))
-						if(!panel_open || !WT.isOn())
+					if(C.use_tool(src, user, 40, volume=50, amount=2))
+						if(!panel_open)
 							return
-						playsound(loc, WT.usesound, 50, 1)
 						user.visible_message("<span class='notice'>[user] cuts through \the [src]'s shielding.</span>",
 										"<span class='notice'>You cut through \the [src]'s shielding.</span>",
 										"<span class='italics'>You hear welding.</span>")
@@ -834,10 +827,8 @@
 					return
 			if(AIRLOCK_SECURITY_PLASTEEL_O_S)
 				if(istype(C, /obj/item/crowbar))
-					var/obj/item/crowbar/W = C
 					to_chat(user, "<span class='notice'>You start removing outer layer of shielding...</span>")
-					playsound(src, W.usesound, 100, 1)
-					if(do_after(user, 40*W.toolspeed, 1, target = src))
+					if(C.use_tool(src, user, 40, volume=100))
 						if(!panel_open)
 							return
 						if(security_level != AIRLOCK_SECURITY_PLASTEEL_O_S)
@@ -849,15 +840,12 @@
 					return
 			if(AIRLOCK_SECURITY_PLASTEEL_O)
 				if(istype(C, /obj/item/weldingtool))
-					var/obj/item/weldingtool/WT = C
-					if(!WT.remove_fuel(2, user))
+					if(!C.tool_start_check(user, amount=2))
 						return
 					to_chat(user, "<span class='notice'>You begin cutting the outer layer of shielding...</span>")
-					playsound(loc, WT.usesound, 40, 1)
-					if(do_after(user, 40*WT.toolspeed, 1, target = src))
-						if(!panel_open || !WT.isOn())
+					if(C.use_tool(src, user, 40, volume=50, amount=2))
+						if(!panel_open)
 							return
-						playsound(loc, WT.usesound, 50, 1)
 						user.visible_message("<span class='notice'>[user] cuts through \the [src]'s shielding.</span>",
 										"<span class='notice'>You cut through \the [src]'s shielding.</span>",
 										"<span class='italics'>You hear welding.</span>")
@@ -865,12 +853,10 @@
 					return
 			if(AIRLOCK_SECURITY_PLASTEEL)
 				if(istype(C, /obj/item/wirecutters))
-					var/obj/item/wirecutters/W = C
 					if(src.hasPower() && src.shock(user, 60)) // Protective grille of wiring is electrified
 						return
 					to_chat(user, "<span class='notice'>You start cutting through the outer grille.</span>")
-					playsound(src, W.usesound, 100, 1)
-					if(do_after(user, 10*W.toolspeed, 1, target = src))
+					if(C.use_tool(src, user, 10, volume=100))
 						if(!panel_open)
 							return
 						user.visible_message("<span class='notice'>[user] cut through \the [src]'s outer grille.</span>",
@@ -932,36 +918,38 @@
 /obj/machinery/door/airlock/try_to_weld(obj/item/weldingtool/W, mob/user)
 	if(!operating && density)
 		if(user.a_intent != INTENT_HELP)
-			if(W.remove_fuel(0,user))
-				user.visible_message("[user] is [welded ? "unwelding":"welding"] the airlock.", \
-								"<span class='notice'>You begin [welded ? "unwelding":"welding"] the airlock...</span>", \
-								"<span class='italics'>You hear welding.</span>")
-				playsound(loc, W.usesound, 40, 1)
-				if(do_after(user,40*W.toolspeed, 1, target = src, extra_checks = CALLBACK(src, .proc/weld_checks, W, user)))
-					playsound(loc, 'sound/items/welder2.ogg', 50, 1)
-					welded = !welded
-					user.visible_message("[user.name] has [welded? "welded shut":"unwelded"] [src].", \
-										"<span class='notice'>You [welded ? "weld the airlock shut":"unweld the airlock"].</span>")
-					update_icon()
+			if(!W.tool_start_check(user, amount=0))
+				return
+			user.visible_message("[user] is [welded ? "unwelding":"welding"] the airlock.", \
+							"<span class='notice'>You begin [welded ? "unwelding":"welding"] the airlock...</span>", \
+							"<span class='italics'>You hear welding.</span>")
+			playsound(loc, W.usesound, 40, 1)
+			if(W.use_tool(src, user, 40, extra_checks = CALLBACK(src, .proc/weld_checks, W, user)))
+				playsound(loc, 'sound/items/welder2.ogg', 50, 1)
+				welded = !welded
+				user.visible_message("[user.name] has [welded? "welded shut":"unwelded"] [src].", \
+									"<span class='notice'>You [welded ? "weld the airlock shut":"unweld the airlock"].</span>")
+				update_icon()
 		else
 			if(obj_integrity < max_integrity)
-				if(W.remove_fuel(0,user))
-					user.visible_message("[user] is welding the airlock.", \
-									"<span class='notice'>You begin repairing the airlock...</span>", \
-									"<span class='italics'>You hear welding.</span>")
-					playsound(loc, W.usesound, 40, 1)
-					if(do_after(user,40*W.toolspeed, 1, target = src, extra_checks = CALLBACK(src, .proc/weld_checks, W, user)))
-						playsound(loc, 'sound/items/welder2.ogg', 50, 1)
-						obj_integrity = max_integrity
-						stat &= ~BROKEN
-						user.visible_message("[user.name] has repaired [src].", \
-											"<span class='notice'>You finish repairing the airlock.</span>")
-						update_icon()
+				if(!W.tool_start_check(user, amount=0))
+					return
+				user.visible_message("[user] is welding the airlock.", \
+								"<span class='notice'>You begin repairing the airlock...</span>", \
+								"<span class='italics'>You hear welding.</span>")
+				playsound(loc, W.usesound, 40, 1)
+				if(W.use_tool(src, user, 40, extra_checks = CALLBACK(src, .proc/weld_checks, W, user)))
+					playsound(loc, 'sound/items/welder2.ogg', 50, 1)
+					obj_integrity = max_integrity
+					stat &= ~BROKEN
+					user.visible_message("[user.name] has repaired [src].", \
+										"<span class='notice'>You finish repairing the airlock.</span>")
+					update_icon()
 			else
 				to_chat(user, "<span class='notice'>The airlock doesn't need repairing.</span>")
 
 /obj/machinery/door/airlock/proc/weld_checks(obj/item/weldingtool/W, mob/user)
-	return !operating && density && user && W && W.isOn() && user.loc
+	return !operating && density
 
 /obj/machinery/door/airlock/try_to_crowbar(obj/item/I, mob/living/user)
 	var/beingcrowbarred = null
@@ -972,7 +960,7 @@
 	if(panel_open && charge)
 		to_chat(user, "<span class='notice'>You carefully start removing [charge] from [src]...</span>")
 		playsound(get_turf(src), I.usesound, 50, 1)
-		if(!do_after(user, 150*I.toolspeed, target = src))
+		if(!I.use_tool(src, user, 150))
 			to_chat(user, "<span class='warning'>You slip and [charge] detonates!</span>")
 			charge.ex_act(EXPLODE_DEVASTATE)
 			user.Knockdown(60)
@@ -986,10 +974,9 @@
 		playsound(src.loc, I.usesound, 100, 1)
 		user.visible_message("[user] removes the electronics from the airlock assembly.", \
 							 "<span class='notice'>You start to remove electronics from the airlock assembly...</span>")
-		if(do_after(user,40*I.toolspeed, target = src))
-			if(src.loc)
-				deconstruct(TRUE, user)
-				return
+		if(I.use_tool(src, user, 40))
+			deconstruct(TRUE, user)
+			return
 	else if(hasPower())
 		to_chat(user, "<span class='warning'>The airlock's motors resist your efforts to force it!</span>")
 	else if(locked)

--- a/code/game/machinery/doors/airlock_types.dm
+++ b/code/game/machinery/doors/airlock_types.dm
@@ -557,16 +557,14 @@
 	else if(istype(I, /obj/item/wrench))
 		if(construction_state == GEAR_SECURE)
 			user.visible_message("<span class='notice'>[user] begins loosening [src]'s cogwheel...</span>", "<span class='notice'>You begin loosening [src]'s cogwheel...</span>")
-			playsound(src, I.usesound, 50, 1)
-			if(!do_after(user, 75*I.toolspeed, target = src) || construction_state != GEAR_SECURE)
+			if(!I.use_tool(src, user, 75, volume=50) || construction_state != GEAR_SECURE)
 				return 1
 			user.visible_message("<span class='notice'>[user] loosens [src]'s cogwheel!</span>", "<span class='notice'>[src]'s cogwheel pops off and dangles loosely.</span>")
 			playsound(src, 'sound/items/deconstruct.ogg', 50, 1)
 			construction_state = GEAR_LOOSE
 		else if(construction_state == GEAR_LOOSE)
 			user.visible_message("<span class='notice'>[user] begins tightening [src]'s cogwheel...</span>", "<span class='notice'>You begin tightening [src]'s cogwheel into place...</span>")
-			playsound(src, I.usesound, 50, 1)
-			if(!do_after(user, 75*I.toolspeed, target = src) || construction_state != GEAR_LOOSE)
+			if(!I.use_tool(src, user, 75, volume=50) || construction_state != GEAR_LOOSE)
 				return 1
 			user.visible_message("<span class='notice'>[user] tightens [src]'s cogwheel!</span>", "<span class='notice'>You firmly tighten [src]'s cogwheel into place.</span>")
 			playsound(src, 'sound/items/deconstruct.ogg', 50, 1)
@@ -578,8 +576,7 @@
 			return 1
 		else if(construction_state == GEAR_LOOSE)
 			user.visible_message("<span class='notice'>[user] begins slowly lifting off [src]'s cogwheel...</span>", "<span class='notice'>You slowly begin lifting off [src]'s cogwheel...</span>")
-			playsound(src, I.usesound, 50, 1)
-			if(!do_after(user, 75*I.toolspeed, target = src) || construction_state != GEAR_LOOSE)
+			if(!I.use_tool(src, user, 75, volume=50) || construction_state != GEAR_LOOSE)
 				return 1
 			user.visible_message("<span class='notice'>[user] lifts off [src]'s cogwheel, causing it to fall apart!</span>", \
 			"<span class='notice'>You lift off [src]'s cogwheel, causing it to fall apart!</span>")

--- a/code/game/machinery/doors/firedoor.dm
+++ b/code/game/machinery/doors/firedoor.dm
@@ -103,7 +103,7 @@
 			playsound(get_turf(src), C.usesound, 50, 1)
 			user.visible_message("<span class='notice'>[user] starts undoing [src]'s bolts...</span>", \
 								 "<span class='notice'>You start unfastening [src]'s floor bolts...</span>")
-			if(!do_after(user, 50*C.toolspeed, target = src))
+			if(!C.use_tool(src, user, 50))
 				return
 			playsound(get_turf(src), 'sound/items/deconstruct.ogg', 50, 1)
 			user.visible_message("<span class='notice'>[user] unfastens [src]'s bolts.</span>", \
@@ -123,14 +123,13 @@
 	return
 
 /obj/machinery/door/firedoor/try_to_weld(obj/item/weldingtool/W, mob/user)
-	if(W.remove_fuel(0, user))
-		playsound(get_turf(src), W.usesound, 50, 1)
-		user.visible_message("<span class='notice'>[user] starts [welded ? "unwelding" : "welding"] [src].</span>", "<span class='notice'>You start welding [src].</span>")
-		if(do_after(user, 40*W.toolspeed, 1, target=src))
-			playsound(get_turf(src), W.usesound, 50, 1)
-			welded = !welded
-			to_chat(user, "<span class='danger'>[user] [welded?"welds":"unwelds"] [src].</span>", "<span class='notice'>You [welded ? "weld" : "unweld"] [src].</span>")
-			update_icon()
+	if(!W.tool_start_check(user, amount=0))
+		return
+	user.visible_message("<span class='notice'>[user] starts [welded ? "unwelding" : "welding"] [src].</span>", "<span class='notice'>You start welding [src].</span>")
+	if(W.use_tool(src, user, 40, volume=50))
+		welded = !welded
+		to_chat(user, "<span class='danger'>[user] [welded?"welds":"unwelds"] [src].</span>", "<span class='notice'>You [welded ? "weld" : "unweld"] [src].</span>")
+		update_icon()
 
 /obj/machinery/door/firedoor/try_to_crowbar(obj/item/I, mob/user)
 	if(welded || operating)
@@ -282,7 +281,7 @@
 				playsound(get_turf(src), C.usesound, 50, 1)
 				user.visible_message("<span class='notice'>[user] starts prying something out from [src]...</span>", \
 									 "<span class='notice'>You begin prying out the wire cover...</span>")
-				if(!do_after(user, 50*C.toolspeed, target = src))
+				if(!C.use_tool(src, user, 50))
 					return
 				if(constructionStep != CONSTRUCTION_PANEL_OPEN)
 					return
@@ -299,7 +298,7 @@
 				playsound(get_turf(src), C.usesound, 50, 1)
 				user.visible_message("<span class='notice'>[user] starts bolting down [src]...</span>", \
 									 "<span class='notice'>You begin bolting [src]...</span>")
-				if(!do_after(user, 30*C.toolspeed, target = src))
+				if(!C.use_tool(src, user, 30))
 					return
 				if(locate(/obj/machinery/door/firedoor) in get_turf(src))
 					return
@@ -338,7 +337,7 @@
 				playsound(get_turf(src), C.usesound, 50, 1)
 				user.visible_message("<span class='notice'>[user] starts cutting the wires from [src]...</span>", \
 									 "<span class='notice'>You begin removing [src]'s wires...</span>")
-				if(!do_after(user, 60*C.toolspeed, target = src))
+				if(!C.use_tool(src, user, 60))
 					return
 				if(constructionStep != CONSTRUCTION_WIRES_EXPOSED)
 					return
@@ -353,7 +352,7 @@
 				playsound(get_turf(src), C.usesound, 50, 1)
 				user.visible_message("<span class='notice'>[user] starts prying a metal plate into [src]...</span>", \
 									 "<span class='notice'>You begin prying the cover plate back onto [src]...</span>")
-				if(!do_after(user, 80*C.toolspeed, target = src))
+				if(!C.use_tool(src, user, 80))
 					return
 				if(constructionStep != CONSTRUCTION_WIRES_EXPOSED)
 					return
@@ -368,7 +367,7 @@
 				user.visible_message("<span class='notice'>[user] begins removing the circuit board from [src]...</span>", \
 									 "<span class='notice'>You begin prying out the circuit board from [src]...</span>")
 				playsound(get_turf(src), C.usesound, 50, 1)
-				if(!do_after(user, 50*C.toolspeed, target = src))
+				if(!C.use_tool(src, user, 50))
 					return
 				if(constructionStep != CONSTRUCTION_GUTTED)
 					return
@@ -399,13 +398,14 @@
 				return
 		if(CONSTRUCTION_NOCIRCUIT)
 			if(istype(C, /obj/item/weldingtool))
-				var/obj/item/weldingtool/W = C
-				if(W.remove_fuel(1,user))
-					playsound(get_turf(src), W.usesound, 50, 1)
-					user.visible_message("<span class='notice'>[user] begins cutting apart [src]'s frame...</span>", \
-										 "<span class='notice'>You begin slicing [src] apart...</span>")
-					if(!do_after(user, 80*C.toolspeed, target = src))
-						return
+				if(!C.tool_start_check(user, amount=1))
+					return
+				playsound(get_turf(src), C.usesound, 50, 1)
+				user.visible_message("<span class='notice'>[user] begins cutting apart [src]'s frame...</span>", \
+									 "<span class='notice'>You begin slicing [src] apart...</span>")
+
+				if(C.use_tool(src, user, 40, amount=1))
+					return
 					if(constructionStep != CONSTRUCTION_NOCIRCUIT)
 						return
 					user.visible_message("<span class='notice'>[user] cuts apart [src]!</span>", \

--- a/code/game/machinery/doors/windowdoor.dm
+++ b/code/game/machinery/doors/windowdoor.dm
@@ -234,10 +234,9 @@
 
 		if(istype(I, /obj/item/crowbar))
 			if(panel_open && !density && !operating)
-				playsound(src.loc, I.usesound, 100, 1)
 				user.visible_message("[user] removes the electronics from the [src.name].", \
 									 "<span class='notice'>You start to remove electronics from the [src.name]...</span>")
-				if(do_after(user,40*I.toolspeed, target = src))
+				if(I.use_tool(src, user, 40, volume=50))
 					if(panel_open && !density && !operating && src.loc)
 						var/obj/structure/windoor_assembly/WA = new /obj/structure/windoor_assembly(src.loc)
 						switch(base_state)

--- a/code/game/machinery/droneDispenser.dm
+++ b/code/game/machinery/droneDispenser.dm
@@ -210,35 +210,26 @@
 	else
 		icon_state = icon_on
 
-/obj/machinery/droneDispenser/attackby(obj/item/O, mob/living/user)
-	if(istype(O, /obj/item/crowbar))
+/obj/machinery/droneDispenser/attackby(obj/item/I, mob/living/user)
+	if(istype(I, /obj/item/crowbar))
 		GET_COMPONENT(materials, /datum/component/material_container)
 		materials.retrieve_all()
-		playsound(loc, O.usesound, 50, 1)
+		playsound(loc, I.usesound, 50, 1)
 		to_chat(user, "<span class='notice'>You retrieve the materials from [src].</span>")
 
-	else if(istype(O, /obj/item/weldingtool))
+	else if(istype(I, /obj/item/weldingtool))
 		if(!(stat & BROKEN))
 			to_chat(user, "<span class='warning'>[src] doesn't need repairs.</span>")
 			return
 
-		var/obj/item/weldingtool/WT = O
-
-		if(!WT.isOn())
+		if(!I.tool_start_check(user, amount=1))
 			return
 
-		if(WT.get_fuel() < 1)
-			to_chat(user, "<span class='warning'>You need more fuel to complete this task!</span>")
-			return
-
-		playsound(src, WT.usesound, 50, 1)
 		user.visible_message(
-			"<span class='notice'>[user] begins patching up [src] with [WT].</span>",
+			"<span class='notice'>[user] begins patching up [src] with [I].</span>",
 			"<span class='notice'>You begin restoring the damage to [src]...</span>")
 
-		if(!do_after(user, 40*O.toolspeed, target = src))
-			return
-		if(!src || !WT.remove_fuel(1, user))
+		if(!I.use_tool(src, user, 40, volume=50, amount=1))
 			return
 
 		user.visible_message(

--- a/code/game/machinery/firealarm.dm
+++ b/code/game/machinery/firealarm.dm
@@ -158,15 +158,16 @@
 	if(panel_open)
 
 		if(istype(W, /obj/item/weldingtool) && user.a_intent == INTENT_HELP)
-			var/obj/item/weldingtool/WT = W
 			if(obj_integrity < max_integrity)
-				if(WT.remove_fuel(0,user))
-					to_chat(user, "<span class='notice'>You begin repairing [src]...</span>")
-					playsound(loc, WT.usesound, 40, 1)
-					if(do_after(user, 40*WT.toolspeed, target = src))
-						obj_integrity = max_integrity
-						playsound(loc, 'sound/items/welder2.ogg', 50, 1)
-						to_chat(user, "<span class='notice'>You repair [src].</span>")
+				if(!W.tool_start_check(user, amount=0))
+					return
+
+				to_chat(user, "<span class='notice'>You begin repairing [src]...</span>")
+				playsound(loc, W.usesound, 40, 1)
+				if(W.use_tool(src, user, 40))
+					obj_integrity = max_integrity
+					playsound(loc, 'sound/items/welder2.ogg', 50, 1)
+					to_chat(user, "<span class='notice'>You repair [src].</span>")
 			else
 				to_chat(user, "<span class='warning'>[src] is already in good condition!</span>")
 			return
@@ -201,10 +202,9 @@
 					return
 
 				else if(istype(W, /obj/item/crowbar))
-					playsound(src.loc, W.usesound, 50, 1)
 					user.visible_message("[user.name] removes the electronics from [src.name].", \
 										"<span class='notice'>You start prying out the circuit...</span>")
-					if(do_after(user, 20*W.toolspeed, target = src))
+					if(W.use_tool(src, user, 20, volume=50))
 						if(buildstage == 1)
 							if(stat & BROKEN)
 								to_chat(user, "<span class='notice'>You remove the destroyed circuit.</span>")

--- a/code/game/machinery/flasher.dm
+++ b/code/game/machinery/flasher.dm
@@ -54,8 +54,7 @@
 	if (istype(W, /obj/item/wirecutters))
 		if (bulb)
 			user.visible_message("[user] begins to disconnect [src]'s flashbulb.", "<span class='notice'>You begin to disconnect [src]'s flashbulb...</span>")
-			playsound(src.loc, W.usesound, 100, 1)
-			if(do_after(user, 30*W.toolspeed, target = src) && bulb)
+			if(W.use_tool(src, user, 30, volume=50) && bulb)
 				user.visible_message("[user] has disconnected [src]'s flashbulb!", "<span class='notice'>You disconnect [src]'s flashbulb.</span>")
 				bulb.forceMove(loc)
 				bulb = null
@@ -74,8 +73,7 @@
 	else if (istype(W, /obj/item/wrench))
 		if(!bulb)
 			to_chat(user, "<span class='notice'>You start unsecuring the flasher frame...</span>")
-			playsound(loc, W.usesound, 50, 1)
-			if(do_after(user, 40*W.toolspeed, target = src))
+			if(W.use_tool(src, user, 40, volume=50))
 				to_chat(user, "<span class='notice'>You unsecure the flasher frame.</span>")
 				deconstruct(TRUE)
 		else

--- a/code/game/machinery/newscaster.dm
+++ b/code/game/machinery/newscaster.dm
@@ -725,7 +725,7 @@ GLOBAL_LIST_EMPTY(allCasters)
 	if(istype(I, /obj/item/wrench))
 		to_chat(user, "<span class='notice'>You start [anchored ? "un" : ""]securing [name]...</span>")
 		playsound(loc, I.usesound, 50, 1)
-		if(do_after(user, 60*I.toolspeed, target = src))
+		if(I.use_tool(src, user, 60))
 			playsound(loc, 'sound/items/deconstruct.ogg', 50, 1)
 			if(stat & BROKEN)
 				to_chat(user, "<span class='warning'>The broken remains of [src] fall on the ground.</span>")
@@ -737,21 +737,21 @@ GLOBAL_LIST_EMPTY(allCasters)
 				new /obj/item/wallframe/newscaster(loc)
 			qdel(src)
 	else if(istype(I, /obj/item/weldingtool) && user.a_intent != INTENT_HARM)
-		var/obj/item/weldingtool/WT = I
 		if(stat & BROKEN)
-			if(WT.remove_fuel(0,user))
-				user.visible_message("[user] is repairing [src].", \
-								"<span class='notice'>You begin repairing [src]...</span>", \
-								"<span class='italics'>You hear welding.</span>")
-				playsound(loc, WT.usesound, 40, 1)
-				if(do_after(user,40*WT.toolspeed, 1, target = src))
-					if(!WT.isOn() || !(stat & BROKEN))
-						return
-					to_chat(user, "<span class='notice'>You repair [src].</span>")
-					playsound(loc, 'sound/items/welder2.ogg', 50, 1)
-					obj_integrity = max_integrity
-					stat &= ~BROKEN
-					update_icon()
+			if(!I.tool_start_check(user, amount=0))
+				return
+			user.visible_message("[user] is repairing [src].", \
+							"<span class='notice'>You begin repairing [src]...</span>", \
+							"<span class='italics'>You hear welding.</span>")
+			playsound(loc, I.usesound, 40, 1)
+			if(I.use_tool(src, user, 40))
+				if(!(stat & BROKEN))
+					return
+				to_chat(user, "<span class='notice'>You repair [src].</span>")
+				playsound(loc, 'sound/items/welder2.ogg', 50, 1)
+				obj_integrity = max_integrity
+				stat &= ~BROKEN
+				update_icon()
 		else
 			to_chat(user, "<span class='notice'>[src] does not need repairs.</span>")
 	else

--- a/code/game/machinery/pipe/pipe_dispenser.dm
+++ b/code/game/machinery/pipe/pipe_dispenser.dm
@@ -64,34 +64,14 @@
 		to_chat(usr, "<span class='notice'>You put [W] back into [src].</span>")
 		qdel(W)
 		return
-	else if (istype(W, /obj/item/wrench))
-		if (!anchored && !isinspace())
-			playsound(src, W.usesound, 50, 1)
-			to_chat(user, "<span class='notice'>You begin to fasten \the [src] to the floor...</span>")
-			if (do_after(user, 40*W.toolspeed, target = src))
-				add_fingerprint(user)
-				user.visible_message( \
-					"[user] fastens \the [src].", \
-					"<span class='notice'>You fasten \the [src]. Now it can dispense pipes.</span>", \
-					"<span class='italics'>You hear ratchet.</span>")
-				anchored = TRUE
-				stat &= MAINT
-				if (usr.machine==src)
-					usr << browse(null, "window=pipedispenser")
-		else if(anchored)
-			playsound(src, W.usesound, 50, 1)
-			to_chat(user, "<span class='notice'>You begin to unfasten \the [src] from the floor...</span>")
-			if (do_after(user, 20*W.toolspeed, target = src))
-				add_fingerprint(user)
-				user.visible_message( \
-					"[user] unfastens \the [src].", \
-					"<span class='notice'>You unfasten \the [src]. Now it can be pulled somewhere else.</span>", \
-					"<span class='italics'>You hear ratchet.</span>")
-				anchored = FALSE
-				stat |= ~MAINT
-				power_change()
 	else
 		return ..()
+
+/obj/machinery/pipedispenser/wrench_act(mob/living/user, obj/item/I)
+	if(default_unfasten_wrench(user, I, 40))
+		user << browse(null, "window=pipedispenser")
+
+	return TRUE
 
 
 /obj/machinery/pipedispenser/disposal

--- a/code/game/machinery/porta_turret/portable_turret.dm
+++ b/code/game/machinery/porta_turret/portable_turret.dm
@@ -232,7 +232,7 @@
 			//If the turret is destroyed, you can remove it with a crowbar to
 			//try and salvage its components
 			to_chat(user, "<span class='notice'>You begin prying the metal coverings off...</span>")
-			if(do_after(user, 20*I.toolspeed, target = src))
+			if(I.use_tool(src, user, 20))
 				if(prob(70))
 					if(stored_gun)
 						stored_gun.forceMove(loc)

--- a/code/game/machinery/porta_turret/portable_turret_construct.dm
+++ b/code/game/machinery/porta_turret/portable_turret_construct.dm
@@ -63,21 +63,15 @@
 				return
 
 			else if(istype(I, /obj/item/weldingtool))
-				var/obj/item/weldingtool/WT = I
-				if(!WT.isOn())
-					return
-				if(WT.get_fuel() < 5) //uses up 5 fuel.
-					to_chat(user, "<span class='warning'>You need more fuel to complete this task!</span>")
+				if(!I.tool_start_check(user, amount=5)) //uses up 5 fuel
 					return
 
-				playsound(loc, WT.usesound, 50, 1)
 				to_chat(user, "<span class='notice'>You start to remove the turret's interior metal armor...</span>")
-				if(do_after(user, 20*I.toolspeed, target = src))
-					if(!WT.isOn() || !WT.remove_fuel(5, user))
-						return
+
+				if(I.use_tool(src, user, 20, volume=50, amount=5)) //uses up 5 fuel
 					build_step = PTURRET_BOLTED
 					to_chat(user, "<span class='notice'>You remove the turret's interior metal armor.</span>")
-					new /obj/item/stack/sheet/metal( loc, 2)
+					new /obj/item/stack/sheet/metal(drop_location(), 2)
 					return
 
 
@@ -133,17 +127,11 @@
 
 		if(PTURRET_START_EXTERNAL_ARMOUR)
 			if(istype(I, /obj/item/weldingtool))
-				var/obj/item/weldingtool/WT = I
-				if(!WT.isOn())
+				if(!I.tool_start_check(user, amount=5))
 					return
-				if(WT.get_fuel() < 5)
-					to_chat(user, "<span class='warning'>You need more fuel to complete this task!</span>")
 
-				playsound(loc, WT.usesound, 50, 1)
 				to_chat(user, "<span class='notice'>You begin to weld the turret's armor down...</span>")
-				if(do_after(user, 30*I.toolspeed, target = src))
-					if(!WT.isOn() || !WT.remove_fuel(5, user))
-						return
+				if(I.use_tool(src, user, 30, volume=50, amount=5))
 					build_step = PTURRET_EXTERNAL_ARMOUR_ON
 					to_chat(user, "<span class='notice'>You weld the turret's armor down.</span>")
 

--- a/code/game/machinery/syndicatebomb.dm
+++ b/code/game/machinery/syndicatebomb.dm
@@ -159,18 +159,12 @@
 	else if(istype(I, /obj/item/weldingtool))
 		if(payload || !wires.is_all_cut() || !open_panel)
 			return
-		var/obj/item/weldingtool/WT = I
-		if(!WT.isOn())
-			return
-		if(WT.get_fuel() < 5) //uses up 5 fuel.
-			to_chat(user, "<span class='warning'>You need more fuel to complete this task!</span>")
+
+		if(!I.tool_start_check(user, amount=5))  //uses up 5 fuel
 			return
 
-		playsound(loc, WT.usesound, 50, 1)
 		to_chat(user, "<span class='notice'>You start to cut [src] apart...</span>")
-		if(do_after(user, 20*I.toolspeed, target = src))
-			if(!WT.isOn() || !WT.remove_fuel(5, user))
-				return
+		if(I.use_tool(src, user, 20, volume=50, amount=5)) //uses up 5 fuel
 			to_chat(user, "<span class='notice'>You cut [src] apart.</span>")
 			new /obj/item/stack/sheet/plasteel( loc, 5)
 			qdel(src)

--- a/code/game/mecha/mecha_construction_paths.dm
+++ b/code/game/mecha/mecha_construction_paths.dm
@@ -13,8 +13,7 @@
 		return I.use_tool(holder, user, 0, volume=50)
 
 	else if(istype(I, /obj/item/stack))
-		if(!I.use_tool(holder, user, 0, volume=50, amount=5))
-			return FALSE
+		return I.use_tool(holder, user, 0, volume=50, amount=5)
 
 	return TRUE
 
@@ -29,8 +28,7 @@
 		return I.use_tool(holder, user, 0, volume=50)
 
 	else if(istype(I, /obj/item/stack))
-		if(!I.use_tool(holder, user, 0, volume=50, amount=5))
-			return FALSE
+		return I.use_tool(holder, user, 0, volume=50, amount=5)
 
 	return TRUE
 

--- a/code/game/mecha/mecha_construction_paths.dm
+++ b/code/game/mecha/mecha_construction_paths.dm
@@ -2,77 +2,36 @@
 ///// Construction datums //////
 ////////////////////////////////
 
-/datum/construction/mecha/custom_action(step, atom/used_atom, mob/user)
-	if(istype(used_atom, /obj/item/weldingtool))
-		var/obj/item/weldingtool/W = used_atom
-		if (W.remove_fuel(0, user))
+/datum/construction/mecha/custom_action(step, obj/item/I, mob/user)
+	if(I.tool_behaviour == TOOL_WELDER)
+		if(I.use_tool(holder, user, 0))
 			playsound(holder, 'sound/items/welder2.ogg', 50, 1)
 		else
 			return FALSE
-	else if(istype(used_atom, /obj/item/wrench))
-		var/obj/item/W = used_atom
-		playsound(holder, W.usesound, 50, 1)
 
-	else if(istype(used_atom, /obj/item/screwdriver))
-		var/obj/item/W = used_atom
-		playsound(holder, W.usesound, 50, 1)
+	else if(I.tool_behaviour)
+		return I.use_tool(holder, user, 0, volume=50)
 
-	else if(istype(used_atom, /obj/item/wirecutters))
-		var/obj/item/W = used_atom
-		playsound(holder, W.usesound, 50, 1)
-
-	else if(istype(used_atom, /obj/item/stack/cable_coil))
-		var/obj/item/stack/cable_coil/C = used_atom
-		if(C.use(4))
-			playsound(holder, 'sound/items/deconstruct.ogg', 50, 1)
-		else
-			to_chat(user, ("<span class='warning'>There's not enough cable to finish the task!</span>"))
+	else if(istype(I, /obj/item/stack))
+		if(!I.use_tool(holder, user, 0, volume=50, amount=5))
 			return FALSE
-	else if(istype(used_atom, /obj/item/stack/ore/bluespace_crystal))
-		var/obj/item/stack/ore/bluespace_crystal/BSC = used_atom
-		BSC.use(1)
-	else if(istype(used_atom, /obj/item/stack))
-		var/obj/item/stack/S = used_atom
-		if(S.get_amount() < 5)
-			to_chat(user, ("<span class='warning'>There's not enough material in this stack!</span>"))
-			return FALSE
-		else
-			S.use(5)
+
 	return TRUE
 
-/datum/construction/reversible/mecha/custom_action(index as num, diff as num, atom/used_atom, mob/user)
-	if(istype(used_atom, /obj/item/weldingtool))
-		var/obj/item/weldingtool/W = used_atom
-		if (W.remove_fuel(0, user))
+/datum/construction/reversible/mecha/custom_action(index as num, diff as num, obj/item/I, mob/user)
+	if(I.tool_behaviour == TOOL_WELDER)
+		if(I.use_tool(holder, user, 0))
 			playsound(holder, 'sound/items/welder2.ogg', 50, 1)
 		else
 			return FALSE
-	else if(istype(used_atom, /obj/item/wrench))
-		var/obj/item/W = used_atom
-		playsound(holder, W.usesound, 50, 1)
 
-	else if(istype(used_atom, /obj/item/screwdriver))
-		var/obj/item/W = used_atom
-		playsound(holder, W.usesound, 50, 1)
+	else if(I.tool_behaviour)
+		return I.use_tool(holder, user, 0, volume=50)
 
-	else if(istype(used_atom, /obj/item/wirecutters))
-		var/obj/item/W = used_atom
-		playsound(holder, W.usesound, 50, 1)
-
-	else if(istype(used_atom, /obj/item/stack/cable_coil))
-		var/obj/item/stack/cable_coil/C = used_atom
-		if (C.use(4))
-			playsound(holder, 'sound/items/deconstruct.ogg', 50, 1)
-		else
-			to_chat(user, ("<span class='warning'>There's not enough cable to finish the task!</span>"))
+	else if(istype(I, /obj/item/stack))
+		if(!I.use_tool(holder, user, 0, volume=50, amount=5))
 			return FALSE
-	else if(istype(used_atom, /obj/item/stack))
-		var/obj/item/stack/S = used_atom
-		if(S.get_amount() < 5)
-			to_chat(user, ("<span class='warning'>There's not enough material in this stack!</span>"))
-			return FALSE
-		else
-			S.use(5)
+
 	return TRUE
 
 

--- a/code/game/mecha/mecha_defense.dm
+++ b/code/game/mecha/mecha_defense.dm
@@ -240,9 +240,8 @@
 
 	else if(istype(W, /obj/item/weldingtool) && user.a_intent != INTENT_HARM)
 		user.changeNext_move(CLICK_CD_MELEE)
-		var/obj/item/weldingtool/WT = W
-		if(obj_integrity<max_integrity)
-			if(WT.remove_fuel(1, user))
+		if(obj_integrity < max_integrity)
+			if(W.use_tool(src, user, 0, volume=50, amount=1))
 				if (internal_damage & MECHA_INT_TANK_BREACH)
 					clearInternalDamage(MECHA_INT_TANK_BREACH)
 					to_chat(user, "<span class='notice'>You repair the damaged gas tank.</span>")
@@ -251,9 +250,7 @@
 					obj_integrity += min(10, max_integrity-obj_integrity)
 					if(obj_integrity == max_integrity)
 						to_chat(user, "<span class='notice'>It looks to be fully repaired now.</span>")
-			else
-				to_chat(user, "<span class='warning'>[WT] needs to be on for this task!</span>")
-				return 1
+			return 1
 		else
 			to_chat(user, "<span class='warning'>The [name] is at full integrity!</span>")
 		return 1

--- a/code/game/mecha/mecha_wreckage.dm
+++ b/code/game/mecha/mecha_wreckage.dm
@@ -36,22 +36,23 @@
 
 /obj/structure/mecha_wreckage/attackby(obj/item/I, mob/user, params)
 	if(istype(I, /obj/item/weldingtool))
-		if(salvage_num <= 0)
+		if(salvage_num <= 0 || !length(welder_salvage))
 			to_chat(user, "<span class='warning'>You don't see anything that can be cut with [I]!</span>")
 			return
-		var/obj/item/weldingtool/WT = I
-		if(welder_salvage && welder_salvage.len && WT.remove_fuel(0, user))
-			var/type = prob(70) ? pick(welder_salvage) : null
-			if(type)
-				var/N = new type(get_turf(user))
-				user.visible_message("[user] cuts [N] from [src].", "<span class='notice'>You cut [N] from [src].</span>")
-				if(istype(N, /obj/item/mecha_parts/part))
-					welder_salvage -= type
-				salvage_num--
-			else
-				to_chat(user, "<span class='warning'>You fail to salvage anything valuable from [src]!</span>")
-		else
+
+		if(!I.use_tool(src, user, 0, volume=50))
 			return
+
+		var/type = prob(70) ? pick(welder_salvage) : null
+		if(type)
+			var/N = new type(get_turf(user))
+			user.visible_message("[user] cuts [N] from [src].", "<span class='notice'>You cut [N] from [src].</span>")
+			if(istype(N, /obj/item/mecha_parts/part))
+				welder_salvage -= type
+			salvage_num--
+		else
+			to_chat(user, "<span class='warning'>You fail to salvage anything valuable from [src]!</span>")
+		return
 
 	else if(istype(I, /obj/item/wirecutters))
 		if(salvage_num <= 0)

--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -749,7 +749,7 @@ GLOBAL_VAR_INIT(rpg_loot_items, FALSE)
 /obj/item/proc/use_tool(atom/target, mob/living/user, delay, amount=0, volume=0, datum/callback/extra_checks)
 	// No delay means there is no start message, and no reason to call tool_start_check before use_tool.
 	// Run the start check here so we wouldn't have to call it manually.
-	if(!delay && tool_start_check(user, amount))
+	if(!delay && !tool_start_check(user, amount))
 		return
 
 	delay *= toolspeed

--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -742,3 +742,67 @@ GLOBAL_VAR_INIT(rpg_loot_items, FALSE)
 /obj/item/MouseExited()
 	deltimer(tip_timer)//delete any in-progress timer if the mouse is moved off the item before it finishes
 	closeToolTip(usr)
+
+
+// Called when a mob tries to use the item as a tool.
+// Handles most checks.
+/obj/item/proc/use_tool(atom/target, mob/living/user, delay, amount=0, volume=0, datum/callback/extra_checks)
+	// No delay means there is no start message, and no reason to call tool_start_check before use_tool.
+	// Run the start check here so we wouldn't have to call it manually.
+	if(!delay && tool_start_check(user, amount))
+		return
+
+	delay *= toolspeed
+
+	// Play tool sound at the beginning of tool usage.
+	play_tool_sound(target, volume)
+
+	if(delay)
+		// Create a callback with checks that would be called every tick by do_after.
+		var/datum/callback/tool_check = CALLBACK(src, .proc/tool_check_callback, user, amount, extra_checks)
+
+		if(ismob(target))
+			if(!do_mob(user, target, delay, extra_checks=tool_check))
+				return
+
+		else
+			if(!do_after(user, delay, target=target, extra_checks=tool_check))
+				return
+	else
+		// Invoke the extra checks once, just in case.
+		if(extra_checks && !extra_checks.Invoke())
+			return
+
+	// Use tool's fuel, stack sheets or charges if amount is set.
+	if(amount && !use(amount))
+		return
+
+	// Play tool sound at the end of tool usage,
+	// but only if the delay between the beginning and the end is not too small
+	if(delay >= MIN_TOOL_SOUND_DELAY)
+		play_tool_sound(target, volume)
+
+	return TRUE
+
+// Called before use_tool if there is a delay, or by use_tool if there isn't.
+// Only ever used by welding tools and stacks, so it's not added on any other use_tool checks.
+/obj/item/proc/tool_start_check(mob/living/user, amount=0)
+	return tool_use_check(user, amount)
+
+// A check called by tool_start_check once, and by use_tool on every tick of delay.
+/obj/item/proc/tool_use_check(mob/living/user, amount)
+	return !amount
+
+// Generic use proc. Depending on the item, it uses up fuel, charges, sheets, etc.
+// Returns TRUE on success, FALSE on failure.
+/obj/item/proc/use(used)
+	return !used
+
+// Plays item's usesound, if any.
+/obj/item/proc/play_tool_sound(atom/target, volume)
+	if(target && usesound && volume)
+		playsound(target, usesound, volume, 1)
+
+// Used in a callback that is passed by use_tool into do_after call. Do not override, do not call manually.
+/obj/item/proc/tool_check_callback(mob/living/user, amount, datum/callback/extra_checks)
+	return tool_use_check(user, amount) && (!extra_checks || extra_checks.Invoke())

--- a/code/game/objects/items/airlock_painter.dm
+++ b/code/game/objects/items/airlock_painter.dm
@@ -11,6 +11,7 @@
 
 	flags_1 = CONDUCT_1 | NOBLUDGEON_1
 	slot_flags = SLOT_BELT
+	usesound = 'sound/effects/spray2.ogg'
 
 	var/obj/item/device/toner/ink = null
 
@@ -20,7 +21,7 @@
 
 //This proc doesn't just check if the painter can be used, but also uses it.
 //Only call this if you are certain that the painter will be used right after this check!
-/obj/item/airlock_painter/proc/use(mob/user)
+/obj/item/airlock_painter/proc/use_paint(mob/user)
 	if(can_use(user))
 		ink.charges--
 		playsound(src.loc, 'sound/effects/spray2.ogg', 50, 1)

--- a/code/game/objects/items/devices/geiger_counter.dm
+++ b/code/game/objects/items/devices/geiger_counter.dm
@@ -170,7 +170,7 @@
 			return 0
 		user.visible_message("<span class='notice'>[user] unscrews [src]'s maintenance panel and begins fiddling with its innards...</span>", "<span class='notice'>You begin resetting [src]...</span>")
 		playsound(user, I.usesound, 50, 1)
-		if(!do_after(user, 40*I.toolspeed, target = user))
+		if(!I.use_tool(src, user, 40))
 			return 0
 		user.visible_message("<span class='notice'>[user] refastens [src]'s maintenance panel!</span>", "<span class='notice'>You reset [src] to its factory settings!</span>")
 		playsound(user, 'sound/items/screwdriver2.ogg', 50, 1)

--- a/code/game/objects/items/devices/radio/intercom.dm
+++ b/code/game/objects/items/devices/radio/intercom.dm
@@ -57,37 +57,32 @@
 
 /obj/item/device/radio/intercom/attackby(obj/item/I, mob/living/user, params)
 	if(istype(I, /obj/item/screwdriver))
-		var/obj/item/screwdriver/S = I
 		if(unfastened)
 			user.visible_message("<span class='notice'>[user] starts tightening [src]'s screws...</span>", "<span class='notice'>You start screwing in [src]...</span>")
-			playsound(src, S.usesound, 50, 1)
-			if(!do_after(user, 30 * S.toolspeed, target = src))
-				return
-			user.visible_message("<span class='notice'>[user] tightens [src]'s screws!</span>", "<span class='notice'>You tighten [src]'s screws.</span>")
-			playsound(src, 'sound/items/screwdriver2.ogg', 50, 1)
-			unfastened = FALSE
+			playsound(src, I.usesound, 50, 1)
+			if(I.use_tool(src, user, 30))
+				user.visible_message("<span class='notice'>[user] tightens [src]'s screws!</span>", "<span class='notice'>You tighten [src]'s screws.</span>")
+				playsound(src, 'sound/items/screwdriver2.ogg', 50, 1)
+				unfastened = FALSE
 		else
 			user.visible_message("<span class='notice'>[user] starts loosening [src]'s screws...</span>", "<span class='notice'>You start unscrewing [src]...</span>")
-			playsound(src, S.usesound, 50, 1)
-			if(!do_after(user, 60 * S.toolspeed, target = src))
-				return
-			user.visible_message("<span class='notice'>[user] loosens [src]'s screws!</span>", "<span class='notice'>You unscrew [src], loosening it from the wall.</span>")
-			playsound(src, 'sound/items/screwdriver2.ogg', 50, 1)
-			unfastened = TRUE
+			playsound(src, I.usesound, 50, 1)
+			if(I.use_tool(src, user, 40))
+				user.visible_message("<span class='notice'>[user] loosens [src]'s screws!</span>", "<span class='notice'>You unscrew [src], loosening it from the wall.</span>")
+				playsound(src, 'sound/items/screwdriver2.ogg', 50, 1)
+				unfastened = TRUE
 		return
 	else if(istype(I, /obj/item/wrench))
 		if(!unfastened)
 			to_chat(user, "<span class='warning'>You need to unscrew [src] from the wall first!</span>")
 			return
-		var/obj/item/wrench/W = I
 		user.visible_message("<span class='notice'>[user] starts unsecuring [src]...</span>", "<span class='notice'>You start unsecuring [src]...</span>")
-		playsound(src, W.usesound, 50, 1)
-		if(!do_after(user, 80 * W.toolspeed, target = src))
-			return
-		user.visible_message("<span class='notice'>[user] unsecures [src]!</span>", "<span class='notice'>You detach [src] from the wall.</span>")
-		playsound(src, 'sound/items/deconstruct.ogg', 50, 1)
-		new/obj/item/wallframe/intercom(get_turf(src))
-		qdel(src)
+		playsound(src, I.usesound, 50, 1)
+		if(I.use_tool(src, user, 80))
+			user.visible_message("<span class='notice'>[user] unsecures [src]!</span>", "<span class='notice'>You detach [src] from the wall.</span>")
+			playsound(src, 'sound/items/deconstruct.ogg', 50, 1)
+			new/obj/item/wallframe/intercom(get_turf(src))
+			qdel(src)
 		return
 	return ..()
 

--- a/code/game/objects/items/devices/taperecorder.dm
+++ b/code/game/objects/items/devices/taperecorder.dm
@@ -276,17 +276,11 @@
 
 
 /obj/item/device/tape/attackby(obj/item/I, mob/user, params)
-	if(ruined)
-		var/delay = -1
-		if (istype(I, /obj/item/screwdriver))
-			delay = 120*I.toolspeed
-		else if(istype(I, /obj/item/pen))
-			delay = 120*1.5
-		if (delay != -1)
-			to_chat(user, "<span class='notice'>You start winding the tape back in...</span>")
-			if(do_after(user, delay, target = src))
-				to_chat(user, "<span class='notice'>You wound the tape back in.</span>")
-				fix()
+	if(ruined && istype(I, /obj/item/screwdriver) || istype(I, /obj/item/pen))
+		to_chat(user, "<span class='notice'>You start winding the tape back in...</span>")
+		if(I.use_tool(src, user, 120))
+			to_chat(user, "<span class='notice'>You wound the tape back in.</span>")
+			fix()
 
 //Random colour tapes
 /obj/item/device/tape/random

--- a/code/game/objects/items/shooting_range.dm
+++ b/code/game/objects/items/shooting_range.dm
@@ -25,14 +25,11 @@
 	if(pinnedLoc)
 		pinnedLoc.forceMove(loc)
 
-/obj/item/target/attackby(obj/item/W, mob/user, params)
-	if(istype(W, /obj/item/weldingtool))
-		var/obj/item/weldingtool/WT = W
-		if(WT.remove_fuel(0, user))
-			removeOverlays()
-			to_chat(user, "<span class='notice'>You slice off [src]'s uneven chunks of aluminium and scorch marks.</span>")
-	else
-		return ..()
+/obj/item/target/welder_act(mob/living/user, obj/item/I)
+	if(I.use_tool(src, user, 0, volume=40))
+		removeOverlays()
+		to_chat(user, "<span class='notice'>You slice off [src]'s uneven chunks of aluminium and scorch marks.</span>")
+	return TRUE
 
 /obj/item/target/attack_hand(mob/user)
 	if(pinnedLoc)

--- a/code/game/objects/items/stacks/rods.dm
+++ b/code/game/objects/items/stacks/rods.dm
@@ -40,17 +40,15 @@ GLOBAL_LIST_INIT(rod_recipes, list ( \
 		icon_state = "rods"
 
 /obj/item/stack/rods/attackby(obj/item/W, mob/user, params)
-	if (istype(W, /obj/item/weldingtool))
-		var/obj/item/weldingtool/WT = W
-
+	if(istype(W, /obj/item/weldingtool))
 		if(get_amount() < 2)
 			to_chat(user, "<span class='warning'>You need at least two rods to do this!</span>")
 			return
 
-		if(WT.remove_fuel(0,user))
+		if(W.use_tool(src, user, 0, volume=40))
 			var/obj/item/stack/sheet/metal/new_item = new(usr.loc)
-			user.visible_message("[user.name] shaped [src] into metal with the welding tool.", \
-						 "<span class='notice'>You shape [src] into metal with the welding tool.</span>", \
+			user.visible_message("[user.name] shaped [src] into metal with [W].", \
+						 "<span class='notice'>You shape [src] into metal with [W].</span>", \
 						 "<span class='italics'>You hear welding.</span>")
 			var/obj/item/stack/rods/R = src
 			src = null

--- a/code/game/objects/items/stacks/sheets/glass.dm
+++ b/code/game/objects/items/stacks/sheets/glass.dm
@@ -244,20 +244,21 @@ GLOBAL_LIST_INIT(prglass_recipes, list ( \
 /obj/item/shard/attackby(obj/item/I, mob/user, params)
 	if(istype(I, /obj/item/device/lightreplacer))
 		I.attackby(src, user)
-	else if(istype(I, /obj/item/weldingtool))
-		var/obj/item/weldingtool/WT = I
-		if(WT.remove_fuel(0, user))
-			var/obj/item/stack/sheet/glass/NG = new (user.loc)
-			for(var/obj/item/stack/sheet/glass/G in user.loc)
-				if(G == NG)
-					continue
-				if(G.amount >= G.max_amount)
-					continue
-				G.attackby(NG, user)
-			to_chat(user, "<span class='notice'>You add the newly-formed glass to the stack. It now contains [NG.amount] sheet\s.</span>")
-			qdel(src)
 	else
 		return ..()
+
+/obj/item/shard/welder_act(mob/living/user, obj/item/I)
+	if(I.use_tool(src, user, 0, volume=50))
+		var/obj/item/stack/sheet/glass/NG = new (user.loc)
+		for(var/obj/item/stack/sheet/glass/G in user.loc)
+			if(G == NG)
+				continue
+			if(G.amount >= G.max_amount)
+				continue
+			G.attackby(NG, user)
+		to_chat(user, "<span class='notice'>You add the newly-formed glass to the stack. It now contains [NG.amount] sheet\s.</span>")
+		qdel(src)
+	return TRUE
 
 /obj/item/shard/Crossed(mob/living/L)
 	if(istype(L) && has_gravity(loc))

--- a/code/game/objects/items/stacks/stack.dm
+++ b/code/game/objects/items/stacks/stack.dm
@@ -25,7 +25,7 @@
 
 /obj/item/stack/on_grind()
 	for(var/i in 1 to grind_results.len) //This should only call if it's ground, so no need to check if grind_results exists
-		grind_results[grind_results[i]] *= amount //Gets the key at position i, then the reagent amount of that key, then multiplies it by stack size
+		grind_results[grind_results[i]] *= get_amount() //Gets the key at position i, then the reagent amount of that key, then multiplies it by stack size
 
 /obj/item/stack/grind_requirements()
 	if(is_cyborg)
@@ -247,7 +247,7 @@
 					return 0
 	return 1
 
-/obj/item/stack/proc/use(used, transfer = FALSE) // return 0 = borked; return 1 = had enough
+/obj/item/stack/use(used, transfer = FALSE) // return 0 = borked; return 1 = had enough
 	if(zero_amount())
 		return 0
 	if (is_cyborg)
@@ -259,6 +259,20 @@
 	update_icon()
 	update_weight()
 	return 1
+
+/obj/item/stack/tool_use_check(mob/living/user, amount)
+	if(get_amount() < amount)
+		if(singular_name)
+			if(amount > 1)
+				to_chat(user, "<span class='warning'>You need at least [amount] [singular_name]\s to do this!</span>")
+			else
+				to_chat(user, "<span class='warning'>You need at least [amount] [singular_name] to do this!</span>")
+		else
+			to_chat(user, "<span class='warning'>You need at least [amount] to do this!</span>")
+
+		return FALSE
+
+	return TRUE
 
 /obj/item/stack/proc/zero_amount()
 	if(is_cyborg)

--- a/code/game/objects/items/stacks/tiles/tile_types.dm
+++ b/code/game/objects/items/stacks/tiles/tile_types.dm
@@ -21,18 +21,15 @@
 /obj/item/stack/tile/attackby(obj/item/W, mob/user, params)
 
 	if (istype(W, /obj/item/weldingtool))
-		var/obj/item/weldingtool/WT = W
-
 		if(get_amount() < 4)
 			to_chat(user, "<span class='warning'>You need at least four tiles to do this!</span>")
 			return
 
-		if(WT.is_hot() && !mineralType)
+		if(!mineralType)
 			to_chat(user, "<span class='warning'>You can not reform this!</span>")
 			return
 
-		if(WT.remove_fuel(0,user))
-
+		if(W.use_tool(src, user, 0, volume=40))
 			if(mineralType == "plasma")
 				atmos_spawn_air("plasma=5;TEMP=1000")
 				user.visible_message("<span class='warning'>[user.name] sets the plasma tiles on fire!</span>", \

--- a/code/game/objects/items/storage/secure.dm
+++ b/code/game/objects/items/storage/secure.dm
@@ -34,7 +34,7 @@
 /obj/item/storage/secure/attackby(obj/item/W, mob/user, params)
 	if(locked)
 		if (istype(W, /obj/item/screwdriver))
-			if (do_after(user, 20*W.toolspeed, target = user))
+			if (W.use_tool(src, user, 20))
 				open =! open
 				to_chat(user, "<span class='notice'>You [open ? "open" : "close"] the service panel.</span>")
 			return
@@ -44,7 +44,7 @@
 			if(src.open == 1)
 				to_chat(user, "<span class='danger'>Now attempting to reset internal memory, please hold.</span>")
 				src.l_hacking = 1
-				if (do_after(usr, 400*W.toolspeed, target = user))
+				if (W.use_tool(src, user, 400))
 					to_chat(user, "<span class='danger'>Internal memory reset - lock has been disengaged.</span>")
 					src.l_set = 0
 					src.l_hacking = 0

--- a/code/game/objects/items/tools/weldingtool.dm
+++ b/code/game/objects/items/tools/weldingtool.dm
@@ -73,7 +73,7 @@
 			damtype = "fire"
 			++burned_fuel_for
 			if(burned_fuel_for >= WELDER_FUEL_BURN_INTERVAL)
-				remove_fuel(1)
+				use(1)
 			update_icon()
 
 	//This is to start fires. process() is only called if the welder is on.
@@ -107,10 +107,10 @@
 	var/obj/item/bodypart/affecting = H.get_bodypart(check_zone(user.zone_selected))
 
 	if(affecting && affecting.status == BODYPART_ROBOTIC && user.a_intent != INTENT_HARM)
-		if(src.remove_fuel(1))
-			playsound(loc, usesound, 50, 1)
+		if(src.use_tool(H, user, 0, volume=50, amount=1))
 			if(user == H)
-				user.visible_message("<span class='notice'>[user] starts to fix some of the dents on [H]'s [affecting.name].</span>", "<span class='notice'>You start fixing some of the dents on [H]'s [affecting.name].</span>")
+				user.visible_message("<span class='notice'>[user] starts to fix some of the dents on [H]'s [affecting.name].</span>",
+					"<span class='notice'>You start fixing some of the dents on [H]'s [affecting.name].</span>")
 				if(!do_mob(user, H, 50))
 					return
 			item_heal_robotic(H, user, 15, 0)
@@ -125,8 +125,8 @@
 		reagents.trans_to(O, reagents.total_volume)
 		to_chat(user, "<span class='notice'>You empty [src]'s fuel tank into [O].</span>")
 		update_icon()
-	if(welding)
-		remove_fuel(1)
+	if(isOn())
+		use(1)
 		var/turf/location = get_turf(user)
 		location.hotspot_expose(700, 50, 1)
 		if(get_fuel() <= 0)
@@ -150,26 +150,23 @@
 	update_icon()
 
 
-//Returns the amount of fuel in the welder
+// Returns the amount of fuel in the welder
 /obj/item/weldingtool/proc/get_fuel()
 	return reagents.get_reagent_amount("welding_fuel")
 
 
-//Removes fuel from the welding tool. If a mob is passed, it will try to flash the mob's eyes. This should probably be renamed to use()
-/obj/item/weldingtool/proc/remove_fuel(amount = 1, mob/living/M = null)
-	if(!welding || !check_fuel())
-		return 0
-	if(amount)
+// Uses fuel from the welding tool.
+/obj/item/weldingtool/use(used = 0)
+	if(!isOn() || !check_fuel())
+		return FALSE
+
+	if(used)
 		burned_fuel_for = 0
-	if(get_fuel() >= amount)
-		reagents.remove_reagent("welding_fuel", amount)
+	if(get_fuel() >= used)
+		reagents.remove_reagent("welding_fuel", used)
 		check_fuel()
-		if(M)
-			M.flash_act(light_intensity)
 		return TRUE
 	else
-		if(M)
-			to_chat(M, "<span class='warning'>You need more welding fuel to complete this task!</span>")
 		return FALSE
 
 
@@ -231,6 +228,24 @@
 /obj/item/weldingtool/proc/isOn()
 	return welding
 
+// When welding is about to start, run a normal tool_use_check, then flash a mob if it succeeds.
+/obj/item/weldingtool/tool_start_check(mob/living/user, amount=0)
+	. = tool_use_check(user, amount)
+	if(. && user)
+		user.flash_act(light_intensity)
+
+// If welding tool ran out of fuel during a construction task, construction fails.
+/obj/item/weldingtool/tool_use_check(mob/living/user, amount)
+	if(!isOn() || !check_fuel())
+		to_chat(user, "<span class='warning'>[src] has to be on to complete this task!</span>")
+		return FALSE
+
+	if(get_fuel() >= amount)
+		return TRUE
+	else
+		to_chat(user, "<span class='warning'>You need more welding fuel to complete this task!</span>")
+		return FALSE
+
 
 /obj/item/weldingtool/proc/flamethrower_screwdriver(obj/item/I, mob/user)
 	if(welding)
@@ -260,10 +275,10 @@
 			to_chat(user, "<span class='warning'>You need one rod to start building a flamethrower!</span>")
 
 /obj/item/weldingtool/ignition_effect(atom/A, mob/user)
-	if(welding && remove_fuel(1, user))
-		. = "<span class='notice'>[user] casually lights [A] with [src], what a badass.</span>"
+	if(use_tool(A, user, 0, amount=1))
+		return "<span class='notice'>[user] casually lights [A] with [src], what a badass.</span>"
 	else
-		. = ""
+		return ""
 
 /obj/item/weldingtool/largetank
 	name = "industrial welding tool"

--- a/code/game/objects/structures/ai_core.dm
+++ b/code/game/objects/structures/ai_core.dm
@@ -32,13 +32,12 @@
 			if(state != EMPTY_CORE)
 				to_chat(user, "<span class='warning'>The core must be empty to deconstruct it!</span>")
 				return
-			var/obj/item/weldingtool/WT = P
-			if(!WT.isOn())
-				to_chat(user, "<span class='warning'>The welder must be on for this task!</span>")
+
+			if(!P.tool_start_check(user, amount=0))
 				return
-			playsound(loc, WT.usesound, 50, 1)
+
 			to_chat(user, "<span class='notice'>You start to deconstruct the frame...</span>")
-			if(do_after(user, 20*P.toolspeed, target = src) && src && state == EMPTY_CORE && WT && WT.remove_fuel(0, user))
+			if(P.use_tool(src, user, 20, volume=50) && state == EMPTY_CORE)
 				to_chat(user, "<span class='notice'>You deconstruct the frame.</span>")
 				deconstruct(TRUE)
 			return

--- a/code/game/objects/structures/crates_lockers/closets.dm
+++ b/code/game/objects/structures/crates_lockers/closets.dm
@@ -29,7 +29,6 @@
 	var/cutting_tool = /obj/item/weldingtool
 	var/open_sound = 'sound/machines/click.ogg'
 	var/close_sound = 'sound/machines/click.ogg'
-	var/cutting_sound = 'sound/items/welder.ogg'
 	var/material_drop = /obj/item/stack/sheet/metal
 	var/material_drop_amount = 2
 	var/delivery_icon = "deliverycloset" //which icon to use when packagewrapped. null to be unwrappable.
@@ -216,19 +215,18 @@
 	if(opened)
 		if(istype(W, cutting_tool))
 			if(istype(W, /obj/item/weldingtool))
-				var/obj/item/weldingtool/WT = W
-				if(WT.remove_fuel(0, user))
-					to_chat(user, "<span class='notice'>You begin cutting \the [src] apart...</span>")
-					playsound(loc, cutting_sound, 40, 1)
-					if(do_after(user, 40*WT.toolspeed, 1, target = src))
-						if(!opened || !WT.isOn())
-							return
-						playsound(loc, cutting_sound, 50, 1)
-						user.visible_message("<span class='notice'>[user] slices apart \the [src].</span>",
-										"<span class='notice'>You cut \the [src] apart with \the [WT].</span>",
-										"<span class='italics'>You hear welding.</span>")
-						deconstruct(TRUE)
+				if(!W.tool_start_check(user, amount=0))
 					return
+
+				to_chat(user, "<span class='notice'>You begin cutting \the [src] apart...</span>")
+				if(W.use_tool(src, user, 40, volume=50))
+					if(!opened)
+						return
+					user.visible_message("<span class='notice'>[user] slices apart \the [src].</span>",
+									"<span class='notice'>You cut \the [src] apart with \the [W].</span>",
+									"<span class='italics'>You hear welding.</span>")
+					deconstruct(TRUE)
+				return
 			else // for example cardboard box is cut with wirecutters
 				user.visible_message("<span class='notice'>[user] cut apart \the [src].</span>", \
 									"<span class='notice'>You cut \the [src] apart with \the [W].</span>")
@@ -237,18 +235,16 @@
 		if(user.transferItemToLoc(W, drop_location())) // so we put in unlit welder too
 			return
 	else if(istype(W, /obj/item/weldingtool) && can_weld_shut)
-		var/obj/item/weldingtool/WT = W
-		if(!WT.remove_fuel(0, user))
+		if(!W.tool_start_check(user, amount=0))
 			return
+
 		to_chat(user, "<span class='notice'>You begin [welded ? "unwelding":"welding"] \the [src]...</span>")
-		playsound(loc, 'sound/items/welder2.ogg', 40, 1)
-		if(do_after(user, 40*WT.toolspeed, 1, target = src))
-			if(opened || !WT.isOn())
+		if(W.use_tool(src, user, 40, volume=50))
+			if(opened)
 				return
-			playsound(loc, WT.usesound, 50, 1)
 			welded = !welded
 			user.visible_message("<span class='notice'>[user] [welded ? "welds shut" : "unweldeds"] \the [src].</span>",
-							"<span class='notice'>You [welded ? "weld" : "unwelded"] \the [src] with \the [WT].</span>",
+							"<span class='notice'>You [welded ? "weld" : "unwelded"] \the [src] with \the [W].</span>",
 							"<span class='italics'>You hear welding.</span>")
 			update_icon()
 	else if(istype(W, /obj/item/wrench) && anchorable)

--- a/code/game/objects/structures/crates_lockers/closets/cardboardbox.dm
+++ b/code/game/objects/structures/crates_lockers/closets/cardboardbox.dm
@@ -10,7 +10,6 @@
 	can_weld_shut = 0
 	cutting_tool = /obj/item/wirecutters
 	open_sound = "rustle"
-	cutting_sound = 'sound/items/poster_ripped.ogg'
 	material_drop = /obj/item/stack/sheet/cardboard
 	delivery_icon = "deliverybox"
 	anchorable = FALSE
@@ -68,6 +67,5 @@
 	move_speed_multiplier = 2
 	cutting_tool = /obj/item/weldingtool
 	open_sound = 'sound/machines/click.ogg'
-	cutting_sound = 'sound/items/welder.ogg'
 	material_drop = /obj/item/stack/sheet/plasteel
 #undef SNAKE_SPAM_TICKS

--- a/code/game/objects/structures/displaycase.dm
+++ b/code/game/objects/structures/displaycase.dm
@@ -96,11 +96,13 @@
 		else
 			to_chat(user,  "<span class='warning'>Access denied.</span>")
 	else if(istype(W, /obj/item/weldingtool) && user.a_intent == INTENT_HELP && !broken)
-		var/obj/item/weldingtool/WT = W
-		if(obj_integrity < max_integrity && WT.remove_fuel(5, user))
+		if(obj_integrity < max_integrity)
+			if(!W.tool_start_check(user, amount=5))
+				return
+
 			to_chat(user, "<span class='notice'>You begin repairing [src].</span>")
-			playsound(loc, WT.usesound, 40, 1)
-			if(do_after(user, 40*W.toolspeed, target = src))
+			playsound(loc, W.usesound, 40, 1)
+			if(W.use_tool(src, user, 40, amount=5))
 				obj_integrity = max_integrity
 				playsound(loc, 'sound/items/welder2.ogg', 50, 1)
 				update_icon()
@@ -117,7 +119,7 @@
 				qdel(src)
 		else
 			to_chat(user, "<span class='notice'>You start to [open ? "close":"open"] [src].</span>")
-			if(do_after(user, 20*W.toolspeed, target = src))
+			if(W.use_tool(src, user, 20))
 				to_chat(user,  "<span class='notice'>You [open ? "close":"open"] [src].</span>")
 				toggle_lock(user)
 	else if(open && !showpiece)
@@ -178,7 +180,7 @@
 	if(istype(I, /obj/item/wrench)) //The player can only deconstruct the wooden frame
 		to_chat(user, "<span class='notice'>You start disassembling [src]...</span>")
 		playsound(src.loc, I.usesound, 50, 1)
-		if(do_after(user, 30*I.toolspeed, target = src))
+		if(I.use_tool(src, user, 30))
 			playsound(src.loc, 'sound/items/deconstruct.ogg', 50, 1)
 			new /obj/item/stack/sheet/mineral/wood(get_turf(src), 5)
 			qdel(src)

--- a/code/game/objects/structures/door_assembly.dm
+++ b/code/game/objects/structures/door_assembly.dm
@@ -59,40 +59,35 @@
 		created_name = t
 
 	else if(istype(W, /obj/item/weldingtool) && (mineral || glass || !anchored ))
-		var/obj/item/weldingtool/WT = W
-		if(WT.remove_fuel(0,user))
-			playsound(src, 'sound/items/welder2.ogg', 50, 1)
-			if(mineral)
-				var/obj/item/stack/sheet/mineral/mineral_path = text2path("/obj/item/stack/sheet/mineral/[mineral]")
-				user.visible_message("[user] welds the [mineral] plating off the airlock assembly.", "You start to weld the [mineral] plating off the airlock assembly...")
-				if(do_after(user, 40 * WT.toolspeed, target = src))
-					if(!src || !WT.isOn())
-						return
-					to_chat(user, "<span class='notice'>You weld the [mineral] plating off.</span>")
-					new mineral_path(loc, 2)
-					var/obj/structure/door_assembly/PA = new previous_assembly(loc)
-					transfer_assembly_vars(src, PA)
+		if(!W.tool_start_check(user, amount=0))
+			return
 
-			else if(glass)
-				user.visible_message("[user] welds the glass panel out of the airlock assembly.", "You start to weld the glass panel out of the airlock assembly...")
-				if(do_after(user, 40 * WT.toolspeed, target = src))
-					if(!src || !WT.isOn())
-						return
-					to_chat(user, "<span class='notice'>You weld the glass panel out.</span>")
-					if(heat_proof_finished)
-						new /obj/item/stack/sheet/rglass(get_turf(src))
-						heat_proof_finished = 0
-					else
-						new /obj/item/stack/sheet/glass(get_turf(src))
-					glass = 0
-			else if(!anchored)
-				user.visible_message("<span class='warning'>[user] disassembles the airlock assembly.</span>", \
-									"You start to disassemble the airlock assembly...")
-				if(do_after(user, 40*W.toolspeed, target = src))
-					if(!WT.isOn())
-						return
-					to_chat(user, "<span class='notice'>You disassemble the airlock assembly.</span>")
-					deconstruct(TRUE)
+		playsound(src, 'sound/items/welder2.ogg', 50, 1)
+		if(mineral)
+			var/obj/item/stack/sheet/mineral/mineral_path = text2path("/obj/item/stack/sheet/mineral/[mineral]")
+			user.visible_message("[user] welds the [mineral] plating off the airlock assembly.", "You start to weld the [mineral] plating off the airlock assembly...")
+			if(W.use_tool(src, user, 40))
+				to_chat(user, "<span class='notice'>You weld the [mineral] plating off.</span>")
+				new mineral_path(loc, 2)
+				var/obj/structure/door_assembly/PA = new previous_assembly(loc)
+				transfer_assembly_vars(src, PA)
+
+		else if(glass)
+			user.visible_message("[user] welds the glass panel out of the airlock assembly.", "You start to weld the glass panel out of the airlock assembly...")
+			if(W.use_tool(src, user, 40))
+				to_chat(user, "<span class='notice'>You weld the glass panel out.</span>")
+				if(heat_proof_finished)
+					new /obj/item/stack/sheet/rglass(get_turf(src))
+					heat_proof_finished = 0
+				else
+					new /obj/item/stack/sheet/glass(get_turf(src))
+				glass = 0
+		else if(!anchored)
+			user.visible_message("<span class='warning'>[user] disassembles the airlock assembly.</span>", \
+								"You start to disassemble the airlock assembly...")
+			if(W.use_tool(src, user, 40))
+				to_chat(user, "<span class='notice'>You disassemble the airlock assembly.</span>")
+				deconstruct(TRUE)
 
 	else if(istype(W, /obj/item/wrench))
 		if(!anchored )
@@ -103,12 +98,11 @@
 					break
 
 			if(door_check)
-				playsound(src, W.usesound, 100, 1)
 				user.visible_message("[user] secures the airlock assembly to the floor.", \
 									 "<span class='notice'>You start to secure the airlock assembly to the floor...</span>", \
 									 "<span class='italics'>You hear wrenching.</span>")
 
-				if(do_after(user, 40*W.toolspeed, target = src))
+				if(W.use_tool(src, user, 40, volume=100))
 					if(anchored)
 						return
 					to_chat(user, "<span class='notice'>You secure the airlock assembly.</span>")
@@ -118,38 +112,34 @@
 				to_chat(user, "There is another door here!")
 
 		else
-			playsound(src, W.usesound, 100, 1)
 			user.visible_message("[user] unsecures the airlock assembly from the floor.", \
 								 "<span class='notice'>You start to unsecure the airlock assembly from the floor...</span>", \
 								 "<span class='italics'>You hear wrenching.</span>")
-			if(do_after(user, 40*W.toolspeed, target = src))
-				if(!anchored )
+			if(W.use_tool(src, user, 40, volume=100))
+				if(!anchored)
 					return
 				to_chat(user, "<span class='notice'>You unsecure the airlock assembly.</span>")
 				name = "airlock assembly"
 				anchored = FALSE
 
 	else if(istype(W, /obj/item/stack/cable_coil) && state == AIRLOCK_ASSEMBLY_NEEDS_WIRES && anchored )
-		var/obj/item/stack/cable_coil/C = W
-		if (C.get_amount() < 1)
-			to_chat(user, "<span class='warning'>You need one length of cable to wire the airlock assembly!</span>")
+		if(!W.tool_start_check(user, amount=1))
 			return
+
 		user.visible_message("[user] wires the airlock assembly.", \
 							"<span class='notice'>You start to wire the airlock assembly...</span>")
-		if(do_after(user, 40, target = src))
-			if(C.get_amount() < 1 || state != AIRLOCK_ASSEMBLY_NEEDS_WIRES)
+		if(W.use_tool(src, user, 40, amount=1))
+			if(state != AIRLOCK_ASSEMBLY_NEEDS_WIRES)
 				return
-			C.use(1)
 			state = AIRLOCK_ASSEMBLY_NEEDS_ELECTRONICS
 			to_chat(user, "<span class='notice'>You wire the airlock assembly.</span>")
 			name = "wired airlock assembly"
 
 	else if(istype(W, /obj/item/wirecutters) && state == AIRLOCK_ASSEMBLY_NEEDS_ELECTRONICS )
-		playsound(src, W.usesound, 100, 1)
 		user.visible_message("[user] cuts the wires from the airlock assembly.", \
 							"<span class='notice'>You start to cut the wires from the airlock assembly...</span>")
 
-		if(do_after(user, 40*W.toolspeed, target = src))
+		if(W.use_tool(src, user, 40, volume=100))
 			if(state != AIRLOCK_ASSEMBLY_NEEDS_ELECTRONICS)
 				return
 			to_chat(user, "<span class='notice'>You cut the wires from the airlock assembly.</span>")
@@ -174,11 +164,10 @@
 
 
 	else if(istype(W, /obj/item/crowbar) && state == AIRLOCK_ASSEMBLY_NEEDS_SCREWDRIVER )
-		playsound(src, W.usesound, 100, 1)
 		user.visible_message("[user] removes the electronics from the airlock assembly.", \
 								"<span class='notice'>You start to remove electronics from the airlock assembly...</span>")
 
-		if(do_after(user, 40*W.toolspeed, target = src))
+		if(W.use_tool(src, user, 40, volume=100))
 			if(state != AIRLOCK_ASSEMBLY_NEEDS_SCREWDRIVER)
 				return
 			to_chat(user, "<span class='notice'>You remove the airlock electronics.</span>")
@@ -237,11 +226,10 @@
 					to_chat(user, "<span class='warning'>You cannot add [G] to [src]!</span>")
 
 	else if(istype(W, /obj/item/screwdriver) && state == AIRLOCK_ASSEMBLY_NEEDS_SCREWDRIVER )
-		playsound(src, W.usesound, 100, 1)
 		user.visible_message("[user] finishes the airlock.", \
 							 "<span class='notice'>You start finishing the airlock...</span>")
 
-		if(do_after(user, 40*W.toolspeed, target = src))
+		if(W.use_tool(src, user, 40, volume=100))
 			if(loc && state == AIRLOCK_ASSEMBLY_NEEDS_SCREWDRIVER)
 				to_chat(user, "<span class='notice'>You finish the airlock.</span>")
 				var/obj/machinery/door/airlock/door

--- a/code/game/objects/structures/extinguisher.dm
+++ b/code/game/objects/structures/extinguisher.dm
@@ -44,7 +44,7 @@
 	if(istype(I, /obj/item/wrench) && !stored_extinguisher)
 		to_chat(user, "<span class='notice'>You start unsecuring [name]...</span>")
 		playsound(loc, I.usesound, 50, 1)
-		if(do_after(user, 60*I.toolspeed, target = src))
+		if(I.use_tool(src, user, 60))
 			playsound(loc, 'sound/items/deconstruct.ogg', 50, 1)
 			to_chat(user, "<span class='notice'>You unsecure [name].</span>")
 			deconstruct(TRUE)

--- a/code/game/objects/structures/false_walls.dm
+++ b/code/game/objects/structures/false_walls.dm
@@ -109,12 +109,9 @@
 		else
 			to_chat(user, "<span class='warning'>You can't reach, close it first!</span>")
 
-	else if(istype(W, /obj/item/weldingtool))
-		var/obj/item/weldingtool/WT = W
-		if(WT.remove_fuel(0,user))
+	else if(istype(W, /obj/item/weldingtool) || istype(W, /obj/item/gun/energy/plasmacutter))
+		if(W.use_tool(src, user, 0, volume=50))
 			dismantle(user, TRUE)
-	else if(istype(W, /obj/item/gun/energy/plasmacutter))
-		dismantle(user, TRUE)
 	else if(istype(W, /obj/item/pickaxe/drill/jackhammer))
 		var/obj/item/pickaxe/drill/jackhammer/D = W
 		D.playDigSound()

--- a/code/game/objects/structures/fireaxe.dm
+++ b/code/game/objects/structures/fireaxe.dm
@@ -25,11 +25,13 @@
 	if(iscyborg(user) || istype(I, /obj/item/device/multitool))
 		toggle_lock(user)
 	else if(istype(I, /obj/item/weldingtool) && user.a_intent == INTENT_HELP && !broken)
-		var/obj/item/weldingtool/WT = I
-		if(obj_integrity < max_integrity && WT.remove_fuel(2, user))
+		if(obj_integrity < max_integrity)
+			if(!I.tool_start_check(user, amount=2))
+				return
+
 			to_chat(user, "<span class='notice'>You begin repairing [src].</span>")
-			playsound(loc, WT.usesound, 40, 1)
-			if(do_after(user, 40*I.toolspeed, target = src))
+			playsound(loc, I.usesound, 40, 1)
+			if(I.use_tool(src, user, 40, amount=2))
 				obj_integrity = max_integrity
 				playsound(loc, 'sound/items/welder2.ogg', 50, 1)
 				update_icon()

--- a/code/game/objects/structures/girders.dm
+++ b/code/game/objects/structures/girders.dm
@@ -34,8 +34,7 @@
 
 	if(istype(W, /obj/item/gun/energy/plasmacutter))
 		to_chat(user, "<span class='notice'>You start slicing apart the girder...</span>")
-		playsound(src, 'sound/items/welder.ogg', 100, 1)
-		if(do_after(user, 40*W.toolspeed, target = src))
+		if(W.use_tool(src, user, 40, volume=100))
 			to_chat(user, "<span class='notice'>You slice apart the girder.</span>")
 			var/obj/item/stack/sheet/metal/M = new (loc, 2)
 			M.add_fingerprint(user)
@@ -68,7 +67,7 @@
 					return
 				to_chat(user, "<span class='notice'>You start building a reinforced false wall...</span>")
 				if(do_after(user, 20, target = src))
-					if(!src.loc || !S || S.get_amount() < 2)
+					if(S.get_amount() < 2)
 						return
 					S.use(2)
 					to_chat(user, "<span class='notice'>You create a false wall. Push on it to open or close the passage.</span>")
@@ -80,8 +79,8 @@
 					to_chat(user, "<span class='warning'>You need at least five rods to add plating!</span>")
 					return
 				to_chat(user, "<span class='notice'>You start adding plating...</span>")
-				if (do_after(user, 40, target = src))
-					if(!src.loc || !S || S.get_amount() < 5)
+				if(do_after(user, 40, target = src))
+					if(S.get_amount() < 5)
 						return
 					S.use(5)
 					to_chat(user, "<span class='notice'>You add the plating.</span>")
@@ -102,7 +101,7 @@
 					return
 				to_chat(user, "<span class='notice'>You start building a false wall...</span>")
 				if(do_after(user, 20, target = src))
-					if(!src.loc || !S || S.get_amount() < 2)
+					if(S.get_amount() < 2)
 						return
 					S.use(2)
 					to_chat(user, "<span class='notice'>You create a false wall. Push on it to open or close the passage.</span>")
@@ -115,7 +114,7 @@
 					return
 				to_chat(user, "<span class='notice'>You start adding plating...</span>")
 				if (do_after(user, 40, target = src))
-					if(loc == null || S.get_amount() < 2)
+					if(S.get_amount() < 2)
 						return
 					S.use(2)
 					to_chat(user, "<span class='notice'>You add the plating.</span>")
@@ -132,7 +131,7 @@
 					return
 				to_chat(user, "<span class='notice'>You start building a reinforced false wall...</span>")
 				if(do_after(user, 20, target = src))
-					if(!src.loc || !S || S.get_amount() < 2)
+					if(S.get_amount() < 2)
 						return
 					S.use(2)
 					to_chat(user, "<span class='notice'>You create a reinforced false wall. Push on it to open or close the passage.</span>")
@@ -145,7 +144,7 @@
 						return
 					to_chat(user, "<span class='notice'>You start finalizing the reinforced wall...</span>")
 					if(do_after(user, 50, target = src))
-						if(!src.loc || !S || S.get_amount() < 1)
+						if(S.get_amount() < 1)
 							return
 						S.use(1)
 						to_chat(user, "<span class='notice'>You fully reinforce the wall.</span>")
@@ -158,8 +157,8 @@
 					if(S.get_amount() < 1)
 						return
 					to_chat(user, "<span class='notice'>You start reinforcing the girder...</span>")
-					if (do_after(user, 60, target = src))
-						if(!src.loc || !S || S.get_amount() < 1)
+					if(do_after(user, 60, target = src))
+						if(S.get_amount() < 1)
 							return
 						S.use(1)
 						to_chat(user, "<span class='notice'>You reinforce the girder.</span>")
@@ -175,7 +174,7 @@
 					to_chat(user, "<span class='warning'>You need at least two sheets to create a false wall!</span>")
 					return
 				if(do_after(user, 20, target = src))
-					if(!src.loc || !S || S.get_amount() < 2)
+					if(S.get_amount() < 2)
 						return
 					S.use(2)
 					to_chat(user, "<span class='notice'>You create a false wall. Push on it to open or close the passage.</span>")
@@ -189,7 +188,7 @@
 					return
 				to_chat(user, "<span class='notice'>You start adding plating...</span>")
 				if (do_after(user, 40, target = src))
-					if(!src.loc || !S || S.get_amount() < 2)
+					if(S.get_amount() < 2)
 						return
 					S.use(2)
 					to_chat(user, "<span class='notice'>You add the plating.</span>")
@@ -214,11 +213,10 @@
 /obj/structure/girder/screwdriver_act(mob/user, obj/item/tool)
 	. = FALSE
 	if(state == GIRDER_DISPLACED)
-		playsound(src, tool.usesound, 100, 1)
 		user.visible_message("<span class='warning'>[user] disassembles the girder.</span>",
 							 "<span class='notice'>You start to disassemble the girder...</span>",
 							 "You hear clanking and banging noises.")
-		if(do_after(user, 40 * tool.toolspeed, target = src))
+		if(tool.use_tool(src, user, 40, volume=100))
 			if(state != GIRDER_DISPLACED)
 				return
 			state = GIRDER_DISASSEMBLED
@@ -226,65 +224,60 @@
 			var/obj/item/stack/sheet/metal/M = new (loc, 2)
 			M.add_fingerprint(user)
 			qdel(src)
-			return TRUE
+		return TRUE
 
 	else if(state == GIRDER_REINF)
-		playsound(src, tool.usesound, 100, 1)
 		to_chat(user, "<span class='notice'>You start unsecuring support struts...</span>")
-		if(do_after(user, 40 * tool.toolspeed, target = src))
+		if(tool.use_tool(src, user, 40, volume=100))
 			if(state != GIRDER_REINF)
 				return
 			to_chat(user, "<span class='notice'>You unsecure the support struts.</span>")
 			state = GIRDER_REINF_STRUTS
-			return TRUE
+		return TRUE
 
 	else if(state == GIRDER_REINF_STRUTS)
-		playsound(src, tool.usesound, 100, 1)
 		to_chat(user, "<span class='notice'>You start securing support struts...</span>")
-		if(do_after(user, 40 * tool.toolspeed, target = src))
+		if(tool.use_tool(src, user, 40, volume=100))
 			if(state != GIRDER_REINF_STRUTS)
 				return
 			to_chat(user, "<span class='notice'>You secure the support struts.</span>")
 			state = GIRDER_REINF
-			return TRUE
+		return TRUE
 
 // Wirecutter behavior for girders
 /obj/structure/girder/wirecutter_act(mob/user, obj/item/tool)
 	. = FALSE
 	if(state == GIRDER_REINF_STRUTS)
-		playsound(src.loc, tool.usesound, 100, 1)
 		to_chat(user, "<span class='notice'>You start removing the inner grille...</span>")
-		if(do_after(user, 40 * tool.toolspeed, target = src))
+		if(tool.use_tool(src, user, 40, volume=100))
 			to_chat(user, "<span class='notice'>You remove the inner grille.</span>")
 			new /obj/item/stack/sheet/plasteel(get_turf(src))
 			var/obj/structure/girder/G = new (loc)
 			transfer_fingerprints_to(G)
 			qdel(src)
-			return TRUE
+		return TRUE
 
 /obj/structure/girder/wrench_act(mob/user, obj/item/tool)
 	. = FALSE
 	if(state == GIRDER_DISPLACED)
 		if(!isfloorturf(loc))
 			to_chat(user, "<span class='warning'>A floor must be present to secure the girder!</span>")
-			return
-		playsound(src, tool.usesound, 100, 1)
+
 		to_chat(user, "<span class='notice'>You start securing the girder...</span>")
-		if(do_after(user, 40 * tool.toolspeed, target = src))
+		if(tool.use_tool(src, user, 40, volume=100))
 			to_chat(user, "<span class='notice'>You secure the girder.</span>")
 			var/obj/structure/girder/G = new (loc)
 			transfer_fingerprints_to(G)
 			qdel(src)
-			return TRUE
+		return TRUE
 	else if(state == GIRDER_NORMAL && can_displace)
-		playsound(src, tool.usesound, 100, 1)
 		to_chat(user, "<span class='notice'>You start unsecuring the girder...</span>")
-		if(do_after(user, 40 * tool.toolspeed, target = src))
+		if(tool.use_tool(src, user, 40, volume=100))
 			to_chat(user, "<span class='notice'>You unsecure the girder.</span>")
 			var/obj/structure/girder/displaced/D = new (loc)
 			transfer_fingerprints_to(D)
 			qdel(src)
-			return TRUE
+		return TRUE
 
 /obj/structure/girder/CanPass(atom/movable/mover, turf/target)
 	if(istype(mover) && (mover.pass_flags & PASSGRILLE))
@@ -348,39 +341,24 @@
 	add_fingerprint(user)
 	if(istype(W, /obj/item/melee/cultblade/dagger) && iscultist(user)) //Cultists can demolish cult girders instantly with their tomes
 		user.visible_message("<span class='warning'>[user] strikes [src] with [W]!</span>", "<span class='notice'>You demolish [src].</span>")
-		var/obj/item/stack/sheet/runed_metal/R = new(get_turf(src))
-		R.amount = 1
+		new /obj/item/stack/sheet/runed_metal(drop_location(), 1)
 		qdel(src)
 
-	else if(istype(W, /obj/item/weldingtool))
-		var/obj/item/weldingtool/WT = W
-		if(WT.remove_fuel(0,user))
-			playsound(src.loc, W.usesound, 50, 1)
-			to_chat(user, "<span class='notice'>You start slicing apart the girder...</span>")
-			if(do_after(user, 40*W.toolspeed, target = src))
-				if( !WT.isOn() )
-					return
-				to_chat(user, "<span class='notice'>You slice apart the girder.</span>")
-				var/obj/item/stack/sheet/runed_metal/R = new(get_turf(src))
-				R.amount = 1
-				transfer_fingerprints_to(R)
-				qdel(src)
+	else if(istype(W, /obj/item/weldingtool) || istype(W, /obj/item/gun/energy/plasmacutter))
+		if(!W.tool_start_check(user, amount=0))
+			return
 
-	else if(istype(W, /obj/item/gun/energy/plasmacutter))
 		to_chat(user, "<span class='notice'>You start slicing apart the girder...</span>")
-		playsound(src, 'sound/items/welder.ogg', 100, 1)
-		if(do_after(user, 40*W.toolspeed, target = src))
+		if(W.use_tool(src, user, 40, volume=50))
 			to_chat(user, "<span class='notice'>You slice apart the girder.</span>")
-			var/obj/item/stack/sheet/runed_metal/R = new(get_turf(src))
-			R.amount = 1
+			var/obj/item/stack/sheet/runed_metal/R = new(drop_location(), 1)
 			transfer_fingerprints_to(R)
 			qdel(src)
 
 	else if(istype(W, /obj/item/pickaxe/drill/jackhammer))
 		var/obj/item/pickaxe/drill/jackhammer/D = W
 		to_chat(user, "<span class='notice'>Your jackhammer smashes through the girder!</span>")
-		var/obj/item/stack/sheet/runed_metal/R = new(get_turf(src))
-		R.amount = 2
+		var/obj/item/stack/sheet/runed_metal/R = new(drop_location(), 2)
 		transfer_fingerprints_to(R)
 		D.playDigSound()
 		qdel(src)
@@ -392,7 +370,7 @@
 			return 0
 		user.visible_message("<span class='notice'>[user] begins laying runed metal on [src]...</span>", "<span class='notice'>You begin constructing a runed wall...</span>")
 		if(do_after(user, 50, target = src))
-			if(R.get_amount() < 1 || !R)
+			if(R.get_amount() < 1)
 				return
 			user.visible_message("<span class='notice'>[user] plates [src] with runed metal.</span>", "<span class='notice'>You construct a runed wall.</span>")
 			R.use(1)

--- a/code/game/objects/structures/janicart.dm
+++ b/code/game/objects/structures/janicart.dm
@@ -82,7 +82,7 @@
 		mybag.attackby(I, user)
 	else if(istype(I, /obj/item/crowbar))
 		user.visible_message("[user] begins to empty the contents of [src].", "<span class='notice'>You begin to empty the contents of [src]...</span>")
-		if(do_after(user, 30*I.toolspeed, target = src))
+		if(I.use_tool(src, user, 30))
 			to_chat(usr, "<span class='notice'>You empty the contents of [src]'s bucket onto the floor.</span>")
 			reagents.reaction(src.loc)
 			src.reagents.clear_reagents()

--- a/code/game/objects/structures/kitchen_spike.dm
+++ b/code/game/objects/structures/kitchen_spike.dm
@@ -23,18 +23,13 @@
 			transfer_fingerprints_to(F)
 			qdel(src)
 	else if(istype(I, /obj/item/weldingtool))
-		var/obj/item/weldingtool/WT = I
-		if(!WT.remove_fuel(0, user))
+		if(!I.tool_start_check(user, amount=0))
 			return
 		to_chat(user, "<span class='notice'>You begin cutting \the [src] apart...</span>")
-		playsound(src.loc, WT.usesound, 40, 1)
-		if(do_after(user, 40*WT.toolspeed, 1, target = src))
-			if(!WT.isOn())
-				return
-			playsound(src.loc, WT.usesound, 50, 1)
+		if(I.use_tool(src, user, 50, volume=50))
 			visible_message("<span class='notice'>[user] slices apart \the [src].</span>",
-							"<span class='notice'>You cut \the [src] apart with \the [WT].</span>",
-							"<span class='italics'>You hear welding.</span>")
+				"<span class='notice'>You cut \the [src] apart with \the [I].</span>",
+				"<span class='italics'>You hear welding.</span>")
 			new /obj/item/stack/sheet/metal(src.loc, 4)
 			qdel(src)
 		return

--- a/code/game/objects/structures/kitchen_spike.dm
+++ b/code/game/objects/structures/kitchen_spike.dm
@@ -51,18 +51,15 @@
 /obj/structure/kitchenspike/attack_paw(mob/user)
 	return src.attack_hand(usr)
 
+/obj/structure/kitchenspike/crowbar_act(mob/living/user, obj/item/I)
+	if(has_buckled_mobs())
+		to_chat(user, "<span class='notice'>You can't do that while something's on the spike!</span>")
+		return TRUE
 
-/obj/structure/kitchenspike/attackby(obj/item/I, mob/user, params)
-	if(istype(I, /obj/item/crowbar))
-		if(!has_buckled_mobs())
-			playsound(loc, I.usesound, 100, 1)
-			if(do_after(user, 20*I.toolspeed, target = src))
-				to_chat(user, "<span class='notice'>You pry the spikes out of the frame.</span>")
-				deconstruct(TRUE)
-		else
-			to_chat(user, "<span class='notice'>You can't do that while something's on the spike!</span>")
-	else
-		return ..()
+	if(I.use_tool(src, user, 20, volume=100))
+		to_chat(user, "<span class='notice'>You pry the spikes out of the frame.</span>")
+		deconstruct(TRUE)
+	return TRUE
 
 /obj/structure/kitchenspike/attack_hand(mob/user)
 	if(VIABLE_MOB_CHECK(user.pulling) && user.a_intent == INTENT_GRAB && !has_buckled_mobs())

--- a/code/game/objects/structures/mirror.dm
+++ b/code/game/objects/structures/mirror.dm
@@ -59,21 +59,24 @@
 			new /obj/item/shard( src.loc )
 	qdel(src)
 
-/obj/structure/mirror/attackby(obj/item/I, mob/living/user, params)
-	if(istype(I, /obj/item/weldingtool) && user.a_intent != INTENT_HARM)
-		if(!broken)
-			return
+/obj/structure/mirror/welder_act(mob/living/user, obj/item/I)
+	if(user.a_intent == INTENT_HARM)
+		return FALSE
 
-		if(!I.tool_start_check(user, amount=0))
-			return
-		to_chat(user, "<span class='notice'>You begin repairing [src]...</span>")
-		if(I.use_tool(src, user, 20, volume=50))
-			to_chat(user, "<span class='notice'>You repair [src].</span>")
-			broken = 0
-			icon_state = initial(icon_state)
-			desc = initial(desc)
-	else
-		return ..()
+	if(!broken)
+		return TRUE
+
+	if(!I.tool_start_check(user, amount=0))
+		return TRUE
+
+	to_chat(user, "<span class='notice'>You begin repairing [src]...</span>")
+	if(I.use_tool(src, user, 10, volume=50))
+		to_chat(user, "<span class='notice'>You repair [src].</span>")
+		broken = 0
+		icon_state = initial(icon_state)
+		desc = initial(desc)
+
+	return TRUE
 
 /obj/structure/mirror/play_attack_sound(damage_amount, damage_type = BRUTE, damage_flag = 0)
 	switch(damage_type)

--- a/code/game/objects/structures/mirror.dm
+++ b/code/game/objects/structures/mirror.dm
@@ -61,19 +61,17 @@
 
 /obj/structure/mirror/attackby(obj/item/I, mob/living/user, params)
 	if(istype(I, /obj/item/weldingtool) && user.a_intent != INTENT_HARM)
-		var/obj/item/weldingtool/WT = I
-		if(broken)
-			user.changeNext_move(CLICK_CD_MELEE)
-			if(WT.remove_fuel(0, user))
-				to_chat(user, "<span class='notice'>You begin repairing [src]...</span>")
-				playsound(src, 'sound/items/welder.ogg', 100, 1)
-				if(do_after(user, 10*I.toolspeed, target = src))
-					if(!user || !WT || !WT.isOn())
-						return
-					to_chat(user, "<span class='notice'>You repair [src].</span>")
-					broken = 0
-					icon_state = initial(icon_state)
-					desc = initial(desc)
+		if(!broken)
+			return
+
+		if(!I.tool_start_check(user, amount=0))
+			return
+		to_chat(user, "<span class='notice'>You begin repairing [src]...</span>")
+		if(I.use_tool(src, user, 20, volume=50))
+			to_chat(user, "<span class='notice'>You repair [src].</span>")
+			broken = 0
+			icon_state = initial(icon_state)
+			desc = initial(desc)
 	else
 		return ..()
 

--- a/code/game/objects/structures/musician.dm
+++ b/code/game/objects/structures/musician.dm
@@ -370,25 +370,6 @@
 	user.set_machine(src)
 	song.interact(user)
 
-/obj/structure/piano/attackby(obj/item/O, mob/user, params)
-	if (istype(O, /obj/item/wrench))
-		if (!anchored && !isinspace())
-			playsound(src, O.usesound, 50, 1)
-			to_chat(user, "<span class='notice'> You begin to tighten \the [src] to the floor...</span>")
-			if (do_after(user, 20*O.toolspeed, target = src))
-				user.visible_message( \
-					"[user] tightens \the [src]'s casters.", \
-					"<span class='notice'>You tighten \the [src]'s casters. Now it can be played again.</span>", \
-					"<span class='italics'>You hear ratchet.</span>")
-				anchored = TRUE
-		else if(anchored)
-			playsound(src, O.usesound, 50, 1)
-			to_chat(user, "<span class='notice'> You begin to loosen \the [src]'s casters...</span>")
-			if (do_after(user, 40*O.toolspeed, target = src))
-				user.visible_message( \
-					"[user] loosens \the [src]'s casters.", \
-					"<span class='notice'>You loosen \the [src]. Now it can be pulled somewhere else.</span>", \
-					"<span class='italics'>You hear ratchet.</span>")
-				anchored = FALSE
-	else
-		return ..()
+/obj/structure/piano/wrench_act(mob/living/user, obj/item/I)
+	default_unfasten_wrench(user, I, 40)
+	return TRUE

--- a/code/game/objects/structures/plasticflaps.dm
+++ b/code/game/objects/structures/plasticflaps.dm
@@ -21,18 +21,16 @@
 	add_fingerprint(user)
 	if(istype(W, /obj/item/screwdriver))
 		if(state == PLASTIC_FLAPS_NORMAL)
-			playsound(src.loc, W.usesound, 100, 1)
 			user.visible_message("<span class='warning'>[user] unscrews [src] from the floor.</span>", "<span class='notice'>You start to unscrew [src] from the floor...</span>", "You hear rustling noises.")
-			if(do_after(user, 100*W.toolspeed, target = src))
+			if(W.use_tool(src, user, 100, volume=100))
 				if(state != PLASTIC_FLAPS_NORMAL)
 					return
 				state = PLASTIC_FLAPS_DETACHED
 				anchored = FALSE
 				to_chat(user, "<span class='notice'>You unscrew [src] from the floor.</span>")
 		else if(state == PLASTIC_FLAPS_DETACHED)
-			playsound(src.loc, W.usesound, 100, 1)
 			user.visible_message("<span class='warning'>[user] screws [src] to the floor.</span>", "<span class='notice'>You start to screw [src] to the floor...</span>", "You hear rustling noises.")
-			if(do_after(user, 40*W.toolspeed, target = src))
+			if(W.use_tool(src, user, 40, volume=100))
 				if(state != PLASTIC_FLAPS_DETACHED)
 					return
 				state = PLASTIC_FLAPS_NORMAL
@@ -40,9 +38,8 @@
 				to_chat(user, "<span class='notice'>You screw [src] from the floor.</span>")
 	else if(istype(W, /obj/item/wirecutters))
 		if(state == PLASTIC_FLAPS_DETACHED)
-			playsound(src.loc, W.usesound, 100, 1)
 			user.visible_message("<span class='warning'>[user] cuts apart [src].</span>", "<span class='notice'>You start to cut apart [src].</span>", "You hear cutting.")
-			if(do_after(user, 50*W.toolspeed, target = src))
+			if(W.use_tool(src, user, 50, volume=100))
 				if(state != PLASTIC_FLAPS_DETACHED)
 					return
 				to_chat(user, "<span class='notice'>You cut apart [src].</span>")

--- a/code/game/objects/structures/reflector.dm
+++ b/code/game/objects/structures/reflector.dm
@@ -89,47 +89,46 @@
 			to_chat(user, "<span class='warning'>Unweld [src] from the floor first!</span>")
 			return
 		user.visible_message("[user] starts to dismantle [src].", "<span class='notice'>You start to dismantle [src]...</span>")
-		if(do_after(user, 80*W.toolspeed, target = src))
-			playsound(src, W.usesound, 50, 1)
+		if(W.use_tool(src, user, 80, volume=50))
 			to_chat(user, "<span class='notice'>You dismantle [src].</span>")
 			new framebuildstacktype(drop_location(), framebuildstackamount)
 			if(buildstackamount)
 				new buildstacktype(drop_location(), buildstackamount)
 			qdel(src)
 	else if(istype(W, /obj/item/weldingtool))
-		var/obj/item/weldingtool/WT = W
-
 		if(obj_integrity < max_integrity)
-			if(WT.remove_fuel(0,user))
-				user.visible_message("[user] starts to repair [src].",
-									"<span class='notice'>You begin repairing [src]...</span>",
-									"<span class='italics'>You hear welding.</span>")
-				playsound(src, W.usesound, 40, 1)
-				if(do_after(user,40*WT.toolspeed, target = src))
-					obj_integrity = max_integrity
-					user.visible_message("[user] has repaired [src].", \
-										"<span class='notice'>You finish repairing [src].</span>")
+			if(!W.tool_start_check(user, amount=0))
+				return
+
+			user.visible_message("[user] starts to repair [src].",
+								"<span class='notice'>You begin repairing [src]...</span>",
+								"<span class='italics'>You hear welding.</span>")
+			if(W.use_tool(src, user, 40, volume=40))
+				obj_integrity = max_integrity
+				user.visible_message("[user] has repaired [src].", \
+									"<span class='notice'>You finish repairing [src].</span>")
 
 		else if(!anchored)
-			if (WT.remove_fuel(0,user))
-				playsound(src, W.usesound, 50, 1)
-				user.visible_message("[user] starts to weld [src] to the floor.",
-									"<span class='notice'>You start to weld [src] to the floor...</span>",
-									"<span class='italics'>You hear welding.</span>")
-				if (do_after(user,20*W.toolspeed, target = src))
-					if(!WT.isOn())
-						return
-					anchored = TRUE
-					to_chat(user, "<span class='notice'>You weld [src] to the floor.</span>")
+			if(!W.tool_start_check(user, amount=0))
+				return
+
+			user.visible_message("[user] starts to weld [src] to the floor.",
+								"<span class='notice'>You start to weld [src] to the floor...</span>",
+								"<span class='italics'>You hear welding.</span>")
+			if (W.use_tool(src, user, 20, volume=50))
+				anchored = TRUE
+				to_chat(user, "<span class='notice'>You weld [src] to the floor.</span>")
 		else
-			if (WT.remove_fuel(0,user))
-				playsound(src, W.usesound, 50, 1)
-				user.visible_message("[user] starts to cut [src] free from the floor.", "<span class='notice'>You start to cut [src] free from the floor...</span>", "<span class='italics'>You hear welding.</span>")
-				if (do_after(user,20*W.toolspeed, target = src))
-					if(!WT.isOn())
-						return
-					anchored = FALSE
-					to_chat(user, "<span class='notice'>You cut [src] free from the floor.</span>")
+			if(!W.tool_start_check(user, amount=0))
+				return
+
+			user.visible_message("[user] starts to cut [src] free from the floor.",
+								"<span class='notice'>You start to cut [src] free from the floor...</span>",
+								"<span class='italics'>You hear welding.</span>")
+			if (W.use_tool(src, user, 20, volume=50))
+				anchored = FALSE
+				to_chat(user, "<span class='notice'>You cut [src] free from the floor.</span>")
+
 	//Finishing the frame
 	else if(istype(W, /obj/item/stack/sheet))
 		if(finished)

--- a/code/game/objects/structures/showcase.dm
+++ b/code/game/objects/structures/showcase.dm
@@ -120,10 +120,9 @@
 			deconstruction_state = SHOWCASE_SCREWDRIVERED
 
 	if(istype(W, /obj/item/crowbar) && deconstruction_state == SHOWCASE_SCREWDRIVERED)
-		if(do_after(user, 20*W.toolspeed, target = src))
-			playsound(loc, W.usesound, 100, 1)
+		if(W.use_tool(src, user, 20, volume=100))
 			to_chat(user, "<span class='notice'>You start to crowbar the showcase apart...</span>")
-			new /obj/item/stack/sheet/metal (get_turf(src), 4)
+			new /obj/item/stack/sheet/metal(drop_location(), 4)
 			qdel(src)
 
 	if(deconstruction_state == SHOWCASE_CONSTRUCTED && default_unfasten_wrench(user, W))

--- a/code/game/objects/structures/signs/_signs.dm
+++ b/code/game/objects/structures/signs/_signs.dm
@@ -27,21 +27,21 @@
 		if(BURN)
 			playsound(loc, 'sound/items/welder.ogg', 80, 1)
 
-/obj/structure/sign/attackby(obj/item/O, mob/user, params)
-	if(istype(O, /obj/item/wrench) && buildable_sign)
+/obj/structure/sign/attackby(obj/item/I, mob/user, params)
+	if(istype(I, /obj/item/wrench) && buildable_sign)
 		user.visible_message("<span class='notice'>[user] starts removing [src]...</span>", \
 							 "<span class='notice'>You start unfastening [src].</span>")
-		playsound(src, O.usesound, 50, 1)
-		if(!do_after(user, 30*O.toolspeed, target = src))
-			return
-		playsound(src, 'sound/items/deconstruct.ogg', 50, 1)
-		user.visible_message("<span class='notice'>[user] unfastens [src].</span>", \
-							 "<span class='notice'>You unfasten [src].</span>")
-		var/obj/item/sign_backing/SB = new (get_turf(user))
-		SB.icon_state = icon_state
-		SB.sign_path = type
-		qdel(src)
-	else if(istype(O, /obj/item/pen) && buildable_sign)
+		playsound(src, I.usesound, 50, 1)
+		if(I.use_tool(src, user, 40))
+			playsound(src, 'sound/items/deconstruct.ogg', 50, 1)
+			user.visible_message("<span class='notice'>[user] unfastens [src].</span>", \
+								 "<span class='notice'>You unfasten [src].</span>")
+			var/obj/item/sign_backing/SB = new (get_turf(user))
+			SB.icon_state = icon_state
+			SB.sign_path = type
+			qdel(src)
+		return
+	else if(istype(I, /obj/item/pen) && buildable_sign)
 		var/list/sign_types = list("Secure Area", "Biohazard", "High Voltage", "Radiation", "Hard Vacuum Ahead", "Disposal: Leads To Space", "Danger: Fire", "No Smoking", "Medbay", "Science", "Chemistry", \
 		"Hydroponics", "Xenobiology")
 		var/obj/structure/sign/sign_type

--- a/code/game/objects/structures/statues.dm
+++ b/code/game/objects/structures/statues.dm
@@ -18,11 +18,10 @@
 	user.changeNext_move(CLICK_CD_MELEE)
 	if(istype(W, /obj/item/wrench))
 		if(anchored)
-			playsound(src.loc, W.usesound, 100, 1)
 			user.visible_message("[user] is loosening the [name]'s bolts.", \
 								 "<span class='notice'>You are loosening the [name]'s bolts...</span>")
-			if(do_after(user,40*W.toolspeed, target = src))
-				if(!src.loc || !anchored)
+			if(W.use_tool(src, user, 40, volume=100))
+				if(!anchored)
 					return
 				user.visible_message("[user] loosened the [name]'s bolts!", \
 									 "<span class='notice'>You loosen the [name]'s bolts!</span>")
@@ -31,26 +30,14 @@
 			if(!isfloorturf(src.loc))
 				user.visible_message("<span class='warning'>A floor must be present to secure the [name]!</span>")
 				return
-			playsound(src.loc, W.usesound, 100, 1)
 			user.visible_message("[user] is securing the [name]'s bolts...", \
 								 "<span class='notice'>You are securing the [name]'s bolts...</span>")
-			if(do_after(user, 40*W.toolspeed, target = src))
-				if(!src.loc || anchored)
+			if(W.use_tool(src, user, 40, volume=100))
+				if(anchored)
 					return
 				user.visible_message("[user] has secured the [name]'s bolts.", \
 									 "<span class='notice'>You have secured the [name]'s bolts.</span>")
 				anchored = TRUE
-
-	else if(istype(W, /obj/item/gun/energy/plasmacutter))
-		playsound(src, 'sound/items/welder.ogg', 100, 1)
-		user.visible_message("[user] is slicing apart the [name]...", \
-							 "<span class='notice'>You are slicing apart the [name]...</span>")
-		if(do_after(user,40*W.toolspeed, target = src))
-			if(!src.loc)
-				return
-			user.visible_message("[user] slices apart the [name].", \
-								 "<span class='notice'>You slice apart the [name].</span>")
-			deconstruct(TRUE)
 
 	else if(istype(W, /obj/item/pickaxe/drill/jackhammer))
 		var/obj/item/pickaxe/drill/jackhammer/D = W
@@ -61,13 +48,14 @@
 		D.playDigSound()
 		qdel(src)
 
-	else if(istype(W, /obj/item/weldingtool) && !anchored)
+	else if(istype(W, /obj/item/weldingtool) || istype(W, /obj/item/gun/energy/plasmacutter))
+		if(!W.tool_start_check(user, amount=0))
+			return FALSE
+
 		playsound(loc, W.usesound, 40, 1)
 		user.visible_message("[user] is slicing apart the [name].", \
 							 "<span class='notice'>You are slicing apart the [name]...</span>")
-		if(do_after(user, 40*W.toolspeed, target = src))
-			if(!src.loc)
-				return
+		if(W.use_tool(src, user, 40))
 			playsound(loc, 'sound/items/welder2.ogg', 50, 1)
 			user.visible_message("[user] slices apart the [name].", \
 								 "<span class='notice'>You slice apart the [name]!</span>")

--- a/code/game/objects/structures/table_frames.dm
+++ b/code/game/objects/structures/table_frames.dm
@@ -25,7 +25,7 @@
 	if(istype(I, /obj/item/wrench))
 		to_chat(user, "<span class='notice'>You start disassembling [src]...</span>")
 		playsound(src.loc, I.usesound, 50, 1)
-		if(do_after(user, 30*I.toolspeed, target = src))
+		if(I.use_tool(src, user, 30))
 			playsound(src.loc, 'sound/items/deconstruct.ogg', 50, 1)
 			deconstruct(TRUE)
 	else if(istype(I, /obj/item/stack/sheet/plasteel))

--- a/code/game/objects/structures/tables_racks.dm
+++ b/code/game/objects/structures/tables_racks.dm
@@ -101,15 +101,13 @@
 	if(!(flags_1 & NODECONSTRUCT_1))
 		if(istype(I, /obj/item/screwdriver) && deconstruction_ready)
 			to_chat(user, "<span class='notice'>You start disassembling [src]...</span>")
-			playsound(src.loc, I.usesound, 50, 1)
-			if(do_after(user, 20*I.toolspeed, target = src))
+			if(I.use_tool(src, user, 20, volume=50))
 				deconstruct(TRUE)
 			return
 
 		if(istype(I, /obj/item/wrench) && deconstruction_ready)
 			to_chat(user, "<span class='notice'>You start deconstructing [src]...</span>")
-			playsound(src.loc, I.usesound, 50, 1)
-			if(do_after(user, 40*I.toolspeed, target = src))
+			if(I.use_tool(src, user, 40, volume=50))
 				playsound(src.loc, 'sound/items/deconstruct.ogg', 50, 1)
 				deconstruct(TRUE, 1)
 			return
@@ -307,23 +305,19 @@
 
 /obj/structure/table/reinforced/attackby(obj/item/W, mob/user, params)
 	if(istype(W, /obj/item/weldingtool))
-		var/obj/item/weldingtool/WT = W
-		if(WT.remove_fuel(0, user))
-			playsound(src.loc, W.usesound, 50, 1)
-			if(deconstruction_ready)
-				to_chat(user, "<span class='notice'>You start strengthening the reinforced table...</span>")
-				if (do_after(user, 50*W.toolspeed, target = src))
-					if(!src || !WT.isOn())
-						return
-					to_chat(user, "<span class='notice'>You strengthen the table.</span>")
-					deconstruction_ready = 0
-			else
-				to_chat(user, "<span class='notice'>You start weakening the reinforced table...</span>")
-				if (do_after(user, 50*W.toolspeed, target = src))
-					if(!src || !WT.isOn())
-						return
-					to_chat(user, "<span class='notice'>You weaken the table.</span>")
-					deconstruction_ready = 1
+		if(!W.tool_start_check(user, amount=0))
+			return
+
+		if(deconstruction_ready)
+			to_chat(user, "<span class='notice'>You start strengthening the reinforced table...</span>")
+			if (W.use_tool(src, user, 50, volume=50))
+				to_chat(user, "<span class='notice'>You strengthen the table.</span>")
+				deconstruction_ready = 0
+		else
+			to_chat(user, "<span class='notice'>You start weakening the reinforced table...</span>")
+			if (W.use_tool(src, user, 50, volume=50))
+				to_chat(user, "<span class='notice'>You weaken the table.</span>")
+				deconstruction_ready = 1
 	else
 		. = ..()
 

--- a/code/game/objects/structures/transit_tubes/transit_tube.dm
+++ b/code/game/objects/structures/transit_tubes/transit_tube.dm
@@ -42,8 +42,7 @@
 				to_chat(user, "<span class='warning'>Remove the pod first!</span>")
 				return
 			user.visible_message("[user] starts to deattach \the [src].", "<span class='notice'>You start to deattach the [name]...</span>")
-			playsound(src.loc, W.usesound, 50, 1)
-			if(do_after(user, 35*W.toolspeed, target = src))
+			if(W.use_tool(src, user, 40, volume=50))
 				to_chat(user, "<span class='notice'>You deattach the [name].</span>")
 				var/obj/structure/c_transit_tube/R = new tube_construction(loc)
 				R.setDir(dir)

--- a/code/game/objects/structures/transit_tubes/transit_tube_construction.dm
+++ b/code/game/objects/structures/transit_tubes/transit_tube_construction.dm
@@ -28,22 +28,17 @@
 			build_type = flipped_build_type
 		else
 			build_type = initial(build_type)
-		icon_state = "[base_icon][flipped]"	
+		icon_state = "[base_icon][flipped]"
 
-/obj/structure/c_transit_tube/attackby(obj/item/I, mob/user, params)
-	if(istype(I, /obj/item/wrench))
-		to_chat(user, "<span class='notice'>You start attaching the [name]...</span>")
-		add_fingerprint(user)
-		playsound(src.loc, I.usesound, 50, 1)
-		if(do_after(user, 40*I.toolspeed, target = src))
-			if(QDELETED(src))
-				return
-			to_chat(user, "<span class='notice'>You attach the [name].</span>")
-			var/obj/structure/transit_tube/R = new build_type(loc, dir)
-			transfer_fingerprints_to(R)
-			qdel(src)
-	else
-		return ..()
+/obj/structure/c_transit_tube/wrench_act(mob/living/user, obj/item/I)
+	to_chat(user, "<span class='notice'>You start attaching the [name]...</span>")
+	add_fingerprint(user)
+	if(I.use_tool(src, user, 40, volume=50))
+		to_chat(user, "<span class='notice'>You attach the [name].</span>")
+		var/obj/structure/transit_tube/R = new build_type(loc, dir)
+		transfer_fingerprints_to(R)
+		qdel(src)
+	return TRUE
 
 // transit tube station
 /obj/structure/c_transit_tube/station

--- a/code/game/objects/structures/watercloset.dm
+++ b/code/game/objects/structures/watercloset.dm
@@ -75,7 +75,7 @@
 	if(istype(I, /obj/item/crowbar))
 		to_chat(user, "<span class='notice'>You start to [cistern ? "replace the lid on the cistern" : "lift the lid off the cistern"]...</span>")
 		playsound(loc, 'sound/effects/stonedoor_openclose.ogg', 50, 1)
-		if(do_after(user, 30*I.toolspeed, target = src))
+		if(I.use_tool(src, user, 30))
 			user.visible_message("[user] [cistern ? "replaces the lid on the cistern" : "lifts the lid off the cistern"]!", "<span class='notice'>You [cistern ? "replace the lid on the cistern" : "lift the lid off the cistern"]!</span>", "<span class='italics'>You hear grinding porcelain.</span>")
 			cistern = !cistern
 			update_icon()
@@ -162,7 +162,7 @@
 	if(istype(I, /obj/item/screwdriver))
 		to_chat(user, "<span class='notice'>You start to [exposed ? "screw the cap back into place" : "unscrew the cap to the drain protector"]...</span>")
 		playsound(loc, 'sound/effects/stonedoor_openclose.ogg', 50, 1)
-		if(do_after(user, 20*I.toolspeed, target = src))
+		if(I.use_tool(src, user, 20))
 			user.visible_message("[user] [exposed ? "screws the cap back into place" : "unscrew the cap to the drain protector"]!", "<span class='notice'>You [exposed ? "screw the cap back into place" : "unscrew the cap on the drain"]!</span>", "<span class='italics'>You hear metal and squishing noises.</span>")
 			exposed = !exposed
 	else if(exposed)
@@ -244,7 +244,7 @@
 		to_chat(user, "<span class='notice'>The water temperature seems to be [watertemp].</span>")
 	if(istype(I, /obj/item/wrench))
 		to_chat(user, "<span class='notice'>You begin to adjust the temperature valve with \the [I]...</span>")
-		if(do_after(user, 50*I.toolspeed, target = src))
+		if(I.use_tool(src, user, 40))
 			switch(watertemp)
 				if("normal")
 					watertemp = "freezing"
@@ -610,7 +610,7 @@
 		if(anchored)
 			playsound(src.loc, W.usesound, 100, 1)
 			user.visible_message("<span class='warning'>[user] unscrews [src] from the floor.</span>", "<span class='notice'>You start to unscrew [src] from the floor...</span>", "You hear rustling noises.")
-			if(do_after(user, 50*W.toolspeed, target = src))
+			if(W.use_tool(src, user, 40))
 				if(!anchored)
 					return
 				anchored = FALSE
@@ -618,7 +618,7 @@
 		else
 			playsound(src.loc, W.usesound, 100, 1)
 			user.visible_message("<span class='warning'>[user] screws [src] to the floor.</span>", "<span class='notice'>You start to screw [src] to the floor...</span>", "You hear rustling noises.")
-			if(do_after(user, 50*W.toolspeed, target = src))
+			if(W.use_tool(src, user, 40))
 				if(anchored)
 					return
 				anchored = TRUE
@@ -627,7 +627,7 @@
 		if(!anchored)
 			playsound(src.loc, W.usesound, 100, 1)
 			user.visible_message("<span class='warning'>[user] cuts apart [src].</span>", "<span class='notice'>You start to cut apart [src].</span>", "You hear cutting.")
-			if(do_after(user, 50*W.toolspeed, target = src))
+			if(W.use_tool(src, user, 40))
 				if(anchored)
 					return
 				to_chat(user, "<span class='notice'>You cut apart [src].</span>")

--- a/code/game/objects/structures/watercloset.dm
+++ b/code/game/objects/structures/watercloset.dm
@@ -159,13 +159,7 @@
 		..()
 
 /obj/structure/urinal/attackby(obj/item/I, mob/living/user, params)
-	if(istype(I, /obj/item/screwdriver))
-		to_chat(user, "<span class='notice'>You start to [exposed ? "screw the cap back into place" : "unscrew the cap to the drain protector"]...</span>")
-		playsound(loc, 'sound/effects/stonedoor_openclose.ogg', 50, 1)
-		if(I.use_tool(src, user, 20))
-			user.visible_message("[user] [exposed ? "screws the cap back into place" : "unscrew the cap to the drain protector"]!", "<span class='notice'>You [exposed ? "screw the cap back into place" : "unscrew the cap on the drain"]!</span>", "<span class='italics'>You hear metal and squishing noises.</span>")
-			exposed = !exposed
-	else if(exposed)
+	if(exposed)
 		if (hiddenitem)
 			to_chat(user, "<span class='warning'>There is already something in the drain enclosure.</span>")
 			return
@@ -177,6 +171,18 @@
 			return
 		hiddenitem = I
 		to_chat(user, "<span class='notice'>You place [I] into the drain enclosure.</span>")
+	else
+		return ..()
+
+/obj/structure/urinal/screwdriver_act(mob/living/user, obj/item/I)
+	to_chat(user, "<span class='notice'>You start to [exposed ? "screw the cap back into place" : "unscrew the cap to the drain protector"]...</span>")
+	playsound(loc, 'sound/effects/stonedoor_openclose.ogg', 50, 1)
+	if(I.use_tool(src, user, 20))
+		user.visible_message("[user] [exposed ? "screws the cap back into place" : "unscrew the cap to the drain protector"]!",
+			"<span class='notice'>You [exposed ? "screw the cap back into place" : "unscrew the cap on the drain"]!</span>",
+			"<span class='italics'>You hear metal and squishing noises.</span>")
+		exposed = !exposed
+	return TRUE
 
 
 /obj/item/reagent_containers/food/urinalcake
@@ -242,19 +248,23 @@
 /obj/machinery/shower/attackby(obj/item/I, mob/user, params)
 	if(I.type == /obj/item/device/analyzer)
 		to_chat(user, "<span class='notice'>The water temperature seems to be [watertemp].</span>")
-	if(istype(I, /obj/item/wrench))
-		to_chat(user, "<span class='notice'>You begin to adjust the temperature valve with \the [I]...</span>")
-		if(I.use_tool(src, user, 40))
-			switch(watertemp)
-				if("normal")
-					watertemp = "freezing"
-				if("freezing")
-					watertemp = "boiling"
-				if("boiling")
-					watertemp = "normal"
-			user.visible_message("<span class='notice'>[user] adjusts the shower with \the [I].</span>", "<span class='notice'>You adjust the shower with \the [I] to [watertemp] temperature.</span>")
-			log_game("[key_name(user)] has wrenched a shower to [watertemp] at ([x],[y],[z])")
-			add_hiddenprint(user)
+	else
+		return ..()
+
+/obj/machinery/shower/wrench_act(mob/living/user, obj/item/I)
+	to_chat(user, "<span class='notice'>You begin to adjust the temperature valve with \the [I]...</span>")
+	if(I.use_tool(src, user, 50))
+		switch(watertemp)
+			if("normal")
+				watertemp = "freezing"
+			if("freezing")
+				watertemp = "boiling"
+			if("boiling")
+				watertemp = "normal"
+		user.visible_message("<span class='notice'>[user] adjusts the shower with \the [I].</span>", "<span class='notice'>You adjust the shower with \the [I] to [watertemp] temperature.</span>")
+		log_game("[key_name(user)] has wrenched a shower to [watertemp] at ([x],[y],[z])")
+		add_hiddenprint(user)
+	return TRUE
 
 
 /obj/machinery/shower/update_icon()	//this is terribly unreadable, but basically it makes the shower mist up
@@ -606,34 +616,24 @@
 /obj/structure/curtain/attackby(obj/item/W, mob/user)
 	if (istype(W, /obj/item/toy/crayon))
 		color = input(user,"","Choose Color",color) as color
-	else if(istype(W, /obj/item/screwdriver))
-		if(anchored)
-			playsound(src.loc, W.usesound, 100, 1)
-			user.visible_message("<span class='warning'>[user] unscrews [src] from the floor.</span>", "<span class='notice'>You start to unscrew [src] from the floor...</span>", "You hear rustling noises.")
-			if(W.use_tool(src, user, 40))
-				if(!anchored)
-					return
-				anchored = FALSE
-				to_chat(user, "<span class='notice'>You unscrew [src] from the floor.</span>")
-		else
-			playsound(src.loc, W.usesound, 100, 1)
-			user.visible_message("<span class='warning'>[user] screws [src] to the floor.</span>", "<span class='notice'>You start to screw [src] to the floor...</span>", "You hear rustling noises.")
-			if(W.use_tool(src, user, 40))
-				if(anchored)
-					return
-				anchored = TRUE
-				to_chat(user, "<span class='notice'>You screw [src] to the floor.</span>")
-	else if(istype(W, /obj/item/wirecutters))
-		if(!anchored)
-			playsound(src.loc, W.usesound, 100, 1)
-			user.visible_message("<span class='warning'>[user] cuts apart [src].</span>", "<span class='notice'>You start to cut apart [src].</span>", "You hear cutting.")
-			if(W.use_tool(src, user, 40))
-				if(anchored)
-					return
-				to_chat(user, "<span class='notice'>You cut apart [src].</span>")
-				deconstruct()
 	else
-		. = ..()
+		return ..()
+
+/obj/structure/curtain/wrench_act(mob/living/user, obj/item/I)
+	default_unfasten_wrench(user, I, 50)
+	return TRUE
+
+/obj/structure/curtain/wirecutter_act(mob/living/user, obj/item/I)
+	if(anchored)
+		return TRUE
+
+	user.visible_message("<span class='warning'>[user] cuts apart [src].</span>",
+		"<span class='notice'>You start to cut apart [src].</span>", "You hear cutting.")
+	if(I.use_tool(src, user, 50, volume=100) && !anchored)
+		to_chat(user, "<span class='notice'>You cut apart [src].</span>")
+		deconstruct()
+
+	return TRUE
 
 
 /obj/structure/curtain/attack_hand(mob/user)

--- a/code/game/objects/structures/windoor_assembly.dm
+++ b/code/game/objects/structures/windoor_assembly.dm
@@ -87,24 +87,23 @@
 	add_fingerprint(user)
 	switch(state)
 		if("01")
-			if(istype(W, /obj/item/weldingtool) && !anchored )
-				var/obj/item/weldingtool/WT = W
-				if (WT.remove_fuel(0,user))
-					user.visible_message("[user] disassembles the windoor assembly.", "<span class='notice'>You start to disassemble the windoor assembly...</span>")
-					playsound(loc, 'sound/items/welder2.ogg', 50, 1)
-
-					if(do_after(user, 40*W.toolspeed, target = src))
-						if(!src || !WT.isOn())
-							return
-						to_chat(user, "<span class='notice'>You disassemble the windoor assembly.</span>")
-						var/obj/item/stack/sheet/rglass/RG = new (get_turf(src), 5)
-						RG.add_fingerprint(user)
-						if(secure)
-							var/obj/item/stack/rods/R = new (get_turf(src), 4)
-							R.add_fingerprint(user)
-						qdel(src)
-				else
+			if(istype(W, /obj/item/weldingtool) && !anchored)
+				if(!W.tool_start_check(user, amount=0))
 					return
+
+				user.visible_message("[user] disassembles the windoor assembly.",
+					"<span class='notice'>You start to disassemble the windoor assembly...</span>")
+				playsound(loc, 'sound/items/welder2.ogg', 50, 1)
+
+				if(W.use_tool(src, user, 40))
+					to_chat(user, "<span class='notice'>You disassemble the windoor assembly.</span>")
+					var/obj/item/stack/sheet/rglass/RG = new (get_turf(src), 5)
+					RG.add_fingerprint(user)
+					if(secure)
+						var/obj/item/stack/rods/R = new (get_turf(src), 4)
+						R.add_fingerprint(user)
+					qdel(src)
+				return
 
 			//Wrenching an unsecure assembly anchors it in place. Step 4 complete
 			if(istype(W, /obj/item/wrench) && !anchored)
@@ -112,11 +111,11 @@
 					if(WD.dir == dir)
 						to_chat(user, "<span class='warning'>There is already a windoor in that location!</span>")
 						return
-				playsound(loc, W.usesound, 100, 1)
-				user.visible_message("[user] secures the windoor assembly to the floor.", "<span class='notice'>You start to secure the windoor assembly to the floor...</span>")
+				user.visible_message("[user] secures the windoor assembly to the floor.",
+					"<span class='notice'>You start to secure the windoor assembly to the floor...</span>")
 
-				if(do_after(user, 40*W.toolspeed, target = src))
-					if(!src || anchored)
+				if(W.use_tool(src, user, 40, volume=100))
+					if(anchored)
 						return
 					for(var/obj/machinery/door/window/WD in loc)
 						if(WD.dir == dir)
@@ -131,11 +130,11 @@
 
 			//Unwrenching an unsecure assembly un-anchors it. Step 4 undone
 			else if(istype(W, /obj/item/wrench) && anchored)
-				playsound(loc, W.usesound, 100, 1)
-				user.visible_message("[user] unsecures the windoor assembly to the floor.", "<span class='notice'>You start to unsecure the windoor assembly to the floor...</span>")
+				user.visible_message("[user] unsecures the windoor assembly to the floor.",
+					"<span class='notice'>You start to unsecure the windoor assembly to the floor...</span>")
 
-				if(do_after(user, 40*W.toolspeed, target = src))
-					if(!src || !anchored)
+				if(W.use_tool(src, user, 40, volume=100))
+					if(!anchored)
 						return
 					to_chat(user, "<span class='notice'>You unsecure the windoor assembly.</span>")
 					anchored = FALSE
@@ -188,11 +187,10 @@
 
 			//Removing wire from the assembly. Step 5 undone.
 			if(istype(W, /obj/item/wirecutters))
-				playsound(loc, W.usesound, 100, 1)
 				user.visible_message("[user] cuts the wires from the airlock assembly.", "<span class='notice'>You start to cut the wires from airlock assembly...</span>")
 
-				if(do_after(user, 40*W.toolspeed, target = src))
-					if(!src || state != "02")
+				if(W.use_tool(src, user, 40, volume=100))
+					if(state != "02")
 						return
 
 					to_chat(user, "<span class='notice'>You cut the windoor wires.</span>")
@@ -208,7 +206,8 @@
 				if(!user.transferItemToLoc(W, src))
 					return
 				playsound(loc, W.usesound, 100, 1)
-				user.visible_message("[user] installs the electronics into the airlock assembly.", "<span class='notice'>You start to install electronics into the airlock assembly...</span>")
+				user.visible_message("[user] installs the electronics into the airlock assembly.",
+					"<span class='notice'>You start to install electronics into the airlock assembly...</span>")
 
 				if(do_after(user, 40, target = src))
 					if(!src || electronics)
@@ -225,12 +224,10 @@
 				if(!electronics)
 					return
 
-				playsound(loc, W.usesound, 100, 1)
-				user.visible_message("[user] removes the electronics from the airlock assembly.", "<span class='notice'>You start to uninstall electronics from the airlock assembly...</span>")
+				user.visible_message("[user] removes the electronics from the airlock assembly.",
+					"<span class='notice'>You start to uninstall electronics from the airlock assembly...</span>")
 
-				if(do_after(user, 40*W.toolspeed, target = src))
-					if(!src || !electronics)
-						return
+				if(W.use_tool(src, user, 40, volume=100) && electronics)
 					to_chat(user, "<span class='notice'>You remove the airlock electronics.</span>")
 					name = "wired windoor assembly"
 					var/obj/item/electronics/airlock/ae
@@ -254,58 +251,56 @@
 				if(!electronics)
 					to_chat(usr, "<span class='warning'>The assembly is missing electronics!</span>")
 					return
-				usr << browse(null, "window=windoor_access")
-				playsound(loc, W.usesound, 100, 1)
-				user.visible_message("[user] pries the windoor into the frame.", "<span class='notice'>You start prying the windoor into the frame...</span>")
+				user << browse(null, "window=windoor_access")
+				user.visible_message("[user] pries the windoor into the frame.",
+					"<span class='notice'>You start prying the windoor into the frame...</span>")
 
-				if(do_after(user, 40*W.toolspeed, target = src))
+				if(W.use_tool(src, user, 40, volume=100) && electronics)
 
-					if(loc && electronics)
+					density = TRUE //Shouldn't matter but just incase
+					to_chat(user, "<span class='notice'>You finish the windoor.</span>")
 
-						density = TRUE //Shouldn't matter but just incase
-						to_chat(user, "<span class='notice'>You finish the windoor.</span>")
-
-						if(secure)
-							var/obj/machinery/door/window/brigdoor/windoor = new /obj/machinery/door/window/brigdoor(loc)
-							if(facing == "l")
-								windoor.icon_state = "leftsecureopen"
-								windoor.base_state = "leftsecure"
-							else
-								windoor.icon_state = "rightsecureopen"
-								windoor.base_state = "rightsecure"
-							windoor.setDir(dir)
-							windoor.density = FALSE
-
-							if(electronics.one_access)
-								windoor.req_one_access = electronics.accesses
-							else
-								windoor.req_access = electronics.accesses
-							windoor.electronics = electronics
-							electronics.forceMove(windoor)
-							if(created_name)
-								windoor.name = created_name
-							qdel(src)
-							windoor.close()
-
-
+					if(secure)
+						var/obj/machinery/door/window/brigdoor/windoor = new /obj/machinery/door/window/brigdoor(loc)
+						if(facing == "l")
+							windoor.icon_state = "leftsecureopen"
+							windoor.base_state = "leftsecure"
 						else
-							var/obj/machinery/door/window/windoor = new /obj/machinery/door/window(loc)
-							if(facing == "l")
-								windoor.icon_state = "leftopen"
-								windoor.base_state = "left"
-							else
-								windoor.icon_state = "rightopen"
-								windoor.base_state = "right"
-							windoor.setDir(dir)
-							windoor.density = FALSE
+							windoor.icon_state = "rightsecureopen"
+							windoor.base_state = "rightsecure"
+						windoor.setDir(dir)
+						windoor.density = FALSE
 
+						if(electronics.one_access)
+							windoor.req_one_access = electronics.accesses
+						else
 							windoor.req_access = electronics.accesses
-							windoor.electronics = electronics
-							electronics.loc = windoor
-							if(created_name)
-								windoor.name = created_name
-							qdel(src)
-							windoor.close()
+						windoor.electronics = electronics
+						electronics.forceMove(windoor)
+						if(created_name)
+							windoor.name = created_name
+						qdel(src)
+						windoor.close()
+
+
+					else
+						var/obj/machinery/door/window/windoor = new /obj/machinery/door/window(loc)
+						if(facing == "l")
+							windoor.icon_state = "leftopen"
+							windoor.base_state = "left"
+						else
+							windoor.icon_state = "rightopen"
+							windoor.base_state = "right"
+						windoor.setDir(dir)
+						windoor.density = FALSE
+
+						windoor.req_access = electronics.accesses
+						windoor.electronics = electronics
+						electronics.loc = windoor
+						if(created_name)
+							windoor.name = created_name
+						qdel(src)
+						windoor.close()
 
 
 			else
@@ -318,7 +313,13 @@
 
 /obj/structure/windoor_assembly/ComponentInitialize()
 	. = ..()
-	AddComponent(/datum/component/simple_rotation,ROTATION_ALTCLICK | ROTATION_CLOCKWISE | ROTATION_COUNTERCLOCKWISE | ROTATION_VERBS,null,CALLBACK(src, .proc/can_be_rotated),CALLBACK(src,.proc/after_rotation))
+	AddComponent(
+		/datum/component/simple_rotation,
+		ROTATION_ALTCLICK | ROTATION_CLOCKWISE | ROTATION_COUNTERCLOCKWISE | ROTATION_VERBS,
+		null,
+		CALLBACK(src, .proc/can_be_rotated),
+		CALLBACK(src,.proc/after_rotation)
+		)
 
 /obj/structure/windoor_assembly/proc/can_be_rotated(mob/user,rotation_type)
 	if(anchored)

--- a/code/game/objects/structures/window.dm
+++ b/code/game/objects/structures/window.dm
@@ -178,17 +178,19 @@
 		return 1 //skip the afterattack
 
 	add_fingerprint(user)
+
 	if(istype(I, /obj/item/weldingtool) && user.a_intent == INTENT_HELP)
-		var/obj/item/weldingtool/WT = I
 		if(obj_integrity < max_integrity)
-			if(WT.remove_fuel(0,user))
-				to_chat(user, "<span class='notice'>You begin repairing [src]...</span>")
-				playsound(src, WT.usesound, 40, 1)
-				if(do_after(user, 40*I.toolspeed, target = src))
-					obj_integrity = max_integrity
-					playsound(src, 'sound/items/Welder2.ogg', 50, 1)
-					update_nearby_icons()
-					to_chat(user, "<span class='notice'>You repair [src].</span>")
+			if(!I.tool_start_check(user, amount=0))
+				return
+
+			to_chat(user, "<span class='notice'>You begin repairing [src]...</span>")
+			playsound(src, I.usesound, 40, 1)
+			if(I.use_tool(src, user, 40))
+				obj_integrity = max_integrity
+				playsound(src, 'sound/items/Welder2.ogg', 50, 1)
+				update_nearby_icons()
+				to_chat(user, "<span class='notice'>You repair [src].</span>")
 		else
 			to_chat(user, "<span class='warning'>[src] is already in good condition!</span>")
 		return
@@ -199,18 +201,18 @@
 			if(reinf)
 				if(state == WINDOW_SCREWED_TO_FRAME || state == WINDOW_IN_FRAME)
 					to_chat(user, "<span class='notice'>You begin to [state == WINDOW_SCREWED_TO_FRAME ? "unscrew the window from":"screw the window to"] the frame...</span>")
-					if(do_after(user, decon_speed*I.toolspeed, target = src, extra_checks = CALLBACK(src, .proc/check_state_and_anchored, state, anchored)))
+					if(I.use_tool(src, user, decon_speed, extra_checks = CALLBACK(src, .proc/check_state_and_anchored, state, anchored)))
 						state = (state == WINDOW_IN_FRAME ? WINDOW_SCREWED_TO_FRAME : WINDOW_IN_FRAME)
 						to_chat(user, "<span class='notice'>You [state == WINDOW_IN_FRAME ? "unfasten the window from":"fasten the window to"] the frame.</span>")
 				else if(state == WINDOW_OUT_OF_FRAME)
 					to_chat(user, "<span class='notice'>You begin to [anchored ? "unscrew the frame from":"screw the frame to"] the floor...</span>")
-					if(do_after(user, decon_speed*I.toolspeed, target = src, extra_checks = CALLBACK(src, .proc/check_state_and_anchored, state, anchored)))
+					if(I.use_tool(src, user, decon_speed, extra_checks = CALLBACK(src, .proc/check_state_and_anchored, state, anchored)))
 						anchored = !anchored
 						update_nearby_icons()
 						to_chat(user, "<span class='notice'>You [anchored ? "fasten the frame to":"unfasten the frame from"] the floor.</span>")
 			else //if we're not reinforced, we don't need to check or update state
 				to_chat(user, "<span class='notice'>You begin to [anchored ? "unscrew the window from":"screw the window to"] the floor...</span>")
-				if(do_after(user, decon_speed*I.toolspeed, target = src, extra_checks = CALLBACK(src, .proc/check_anchored, anchored)))
+				if(I.use_tool(src, user, decon_speed, extra_checks = CALLBACK(src, .proc/check_anchored, anchored)))
 					anchored = !anchored
 					air_update_turf(TRUE)
 					update_nearby_icons()
@@ -221,7 +223,7 @@
 		else if (istype(I, /obj/item/crowbar) && reinf && (state == WINDOW_OUT_OF_FRAME || state == WINDOW_IN_FRAME))
 			to_chat(user, "<span class='notice'>You begin to lever the window [state == WINDOW_OUT_OF_FRAME ? "into":"out of"] the frame...</span>")
 			playsound(src, I.usesound, 75, 1)
-			if(do_after(user, decon_speed*I.toolspeed, target = src, extra_checks = CALLBACK(src, .proc/check_state_and_anchored, state, anchored)))
+			if(I.use_tool(src, user, decon_speed, extra_checks = CALLBACK(src, .proc/check_state_and_anchored, state, anchored)))
 				state = (state == WINDOW_OUT_OF_FRAME ? WINDOW_IN_FRAME : WINDOW_OUT_OF_FRAME)
 				to_chat(user, "<span class='notice'>You pry the window [state == WINDOW_IN_FRAME ? "into":"out of"] the frame.</span>")
 			return
@@ -229,7 +231,7 @@
 		else if(istype(I, /obj/item/wrench) && !anchored)
 			playsound(src, I.usesound, 75, 1)
 			to_chat(user, "<span class='notice'> You begin to disassemble [src]...</span>")
-			if(do_after(user, decon_speed*I.toolspeed, target = src, extra_checks = CALLBACK(src, .proc/check_state_and_anchored, state, anchored)))
+			if(I.use_tool(src, user, decon_speed, extra_checks = CALLBACK(src, .proc/check_state_and_anchored, state, anchored)))
 				var/obj/item/stack/sheet/G = new glass_type(user.loc, glass_amount)
 				G.add_fingerprint(user)
 				playsound(src, 'sound/items/Deconstruct.ogg', 50, 1)

--- a/code/game/shuttle_engines.dm
+++ b/code/game/shuttle_engines.dm
@@ -39,30 +39,34 @@
 	if(default_unfasten_wrench(user, I))
 		return
 	else if(istype(I, /obj/item/weldingtool))
-		var/obj/item/weldingtool/WT = I
 		switch(state)
 			if(ENGINE_UNWRENCHED)
 				to_chat(user, "<span class='warning'>The [src.name] needs to be wrenched to the floor!</span>")
 			if(EM_SECURED)
-				if(WT.remove_fuel(0,user))
-					playsound(loc, WT.usesound, 50, 1)
-					user.visible_message("[user.name] starts to weld the [name] to the floor.", \
-						"<span class='notice'>You start to weld \the [src] to the floor...</span>", \
-						"<span class='italics'>You hear welding.</span>")
-					if(do_after(user,ENGINE_WELDTIME*WT.toolspeed, target = src) && WT.isOn())
-						state = ENGINE_WELDED
-						to_chat(user, "<span class='notice'>You weld \the [src] to the floor.</span>")
-						alter_engine_power(engine_power)
+				if(!I.tool_start_check(user, amount=0))
+					return
+
+				user.visible_message("[user.name] starts to weld the [name] to the floor.", \
+					"<span class='notice'>You start to weld \the [src] to the floor...</span>", \
+					"<span class='italics'>You hear welding.</span>")
+
+				if(I.use_tool(src, user, ENGINE_WELDTIME, volume=50))
+					state = ENGINE_WELDED
+					to_chat(user, "<span class='notice'>You weld \the [src] to the floor.</span>")
+					alter_engine_power(engine_power)
+
 			if(EM_WELDED)
-				if(WT.remove_fuel(0,user))
-					playsound(loc, WT.usesound, 50, 1)
-					user.visible_message("[user.name] starts to cut the [name] free from the floor.", \
-						"<span class='notice'>You start to cut \the [src] free from the floor...</span>", \
-						"<span class='italics'>You hear welding.</span>")
-					if(do_after(user,ENGINE_WELDTIME*WT.toolspeed, target = src) && WT.isOn())
-						state = ENGINE_WRENCHED
-						to_chat(user, "<span class='notice'>You cut \the [src] free from the floor.</span>")
-						alter_engine_power(-engine_power)
+				if(!I.tool_start_check(user, amount=0))
+					return
+
+				user.visible_message("[user.name] starts to cut the [name] free from the floor.", \
+					"<span class='notice'>You start to cut \the [src] free from the floor...</span>", \
+					"<span class='italics'>You hear welding.</span>")
+
+				if(I.use_tool(src, user, ENGINE_WELDTIME, volume=50))
+					state = ENGINE_WRENCHED
+					to_chat(user, "<span class='notice'>You cut \the [src] free from the floor.</span>")
+					alter_engine_power(-engine_power)
 		return
 	else
 		return ..()

--- a/code/game/turfs/simulated/floor/misc_floor.dm
+++ b/code/game/turfs/simulated/floor/misc_floor.dm
@@ -196,19 +196,14 @@
 		flick_overlay(I, viewing, 8)
 		L.adjustToxLoss(-3, TRUE, TRUE)
 
-/turf/open/floor/clockwork/attackby(obj/item/I, mob/living/user, params)
+/turf/open/floor/clockwork/crowbar_act(mob/living/user, obj/item/I)
 	if(baseturfs == type)
-		return
-	if(istype(I, /obj/item/crowbar))
-		user.visible_message("<span class='notice'>[user] begins slowly prying up [src]...</span>", "<span class='notice'>You begin painstakingly prying up [src]...</span>")
-		playsound(src, I.usesound, 20, 1)
-		if(!do_after(user, 70*I.toolspeed, target = src))
-			return 0
+		return TRUE
+	user.visible_message("<span class='notice'>[user] begins slowly prying up [src]...</span>", "<span class='notice'>You begin painstakingly prying up [src]...</span>")
+	if(I.use_tool(src, user, 70, volume=80))
 		user.visible_message("<span class='notice'>[user] pries up [src]!</span>", "<span class='notice'>You pry up [src]!</span>")
-		playsound(src, I.usesound, 80, 1)
 		make_plating()
-		return 1
-	return ..()
+	return TRUE
 
 /turf/open/floor/clockwork/make_plating()
 	new /obj/item/stack/tile/brass(src)

--- a/code/game/turfs/simulated/floor/plating.dm
+++ b/code/game/turfs/simulated/floor/plating.dm
@@ -78,12 +78,15 @@
 			playsound(src, 'sound/weapons/genhit.ogg', 50, 1)
 		else
 			to_chat(user, "<span class='warning'>This section is too damaged to support a tile! Use a welder to fix the damage.</span>")
-	else if(istype(C, /obj/item/weldingtool)  && (broken || burnt))
-		if(C.use_tool(src, user, 0, volume=80))
-			to_chat(user, "<span class='danger'>You fix some dents on the broken plating.</span>")
-			icon_state = icon_plating
-			burnt = 0
-			broken = 0
+
+/turf/open/floor/plating/welder_act(mob/living/user, obj/item/I)
+	if((broken || burnt) && I.use_tool(src, user, 0, volume=80))
+		to_chat(user, "<span class='danger'>You fix some dents on the broken plating.</span>")
+		icon_state = icon_plating
+		burnt = FALSE
+		broken = FALSE
+
+	return TRUE
 
 /turf/open/floor/plating/foam
 	name = "metal foam plating"

--- a/code/game/turfs/simulated/floor/plating.dm
+++ b/code/game/turfs/simulated/floor/plating.dm
@@ -78,15 +78,12 @@
 			playsound(src, 'sound/weapons/genhit.ogg', 50, 1)
 		else
 			to_chat(user, "<span class='warning'>This section is too damaged to support a tile! Use a welder to fix the damage.</span>")
-	else if(istype(C, /obj/item/weldingtool))
-		var/obj/item/weldingtool/welder = C
-		if( welder.isOn() && (broken || burnt) )
-			if(welder.remove_fuel(0,user))
-				to_chat(user, "<span class='danger'>You fix some dents on the broken plating.</span>")
-				playsound(src, welder.usesound, 80, 1)
-				icon_state = icon_plating
-				burnt = 0
-				broken = 0
+	else if(istype(C, /obj/item/weldingtool)  && (broken || burnt))
+		if(C.use_tool(src, user, 0, volume=80))
+			to_chat(user, "<span class='danger'>You fix some dents on the broken plating.</span>")
+			icon_state = icon_plating
+			burnt = 0
+			broken = 0
 
 /turf/open/floor/plating/foam
 	name = "metal foam plating"

--- a/code/game/turfs/simulated/floor/reinf_floor.dm
+++ b/code/game/turfs/simulated/floor/reinf_floor.dm
@@ -25,18 +25,14 @@
 		..()
 	return //unplateable
 
-/turf/open/floor/engine/attackby(obj/item/C, mob/user, params)
-	if(!C || !user)
-		return
-	if(istype(C, /obj/item/wrench))
-		to_chat(user, "<span class='notice'>You begin removing rods...</span>")
-		playsound(src, C.usesound, 80, 1)
-		if(do_after(user, 30*C.toolspeed, target = src))
-			if(!istype(src, /turf/open/floor/engine))
-				return
-			new /obj/item/stack/rods(src, 2)
-			ChangeTurf(/turf/open/floor/plating)
-			return
+/turf/open/floor/engine/wrench_act(mob/living/user, obj/item/I)
+	to_chat(user, "<span class='notice'>You begin removing rods...</span>")
+	if(I.use_tool(src, user, 30, volume=80))
+		if(!istype(src, /turf/open/floor/engine))
+			return TRUE
+		new /obj/item/stack/rods(src, 2)
+		ChangeTurf(/turf/open/floor/plating)
+	return TRUE
 
 /turf/open/floor/engine/acid_act(acidpwr, acid_volume)
 	acidpwr = min(acidpwr, 50) //we reduce the power so reinf floor never get melted.

--- a/code/game/turfs/simulated/wall/reinf_walls.dm
+++ b/code/game/turfs/simulated/wall/reinf_walls.dm
@@ -77,9 +77,8 @@
 		if(SUPPORT_LINES)
 			if(istype(W, /obj/item/screwdriver))
 				to_chat(user, "<span class='notice'>You begin unsecuring the support lines...</span>")
-				playsound(src, W.usesound, 100, 1)
-				if(do_after(user, 40*W.toolspeed, target = src))
-					if(!istype(src, /turf/closed/wall/r_wall) || !W || d_state != SUPPORT_LINES)
+				if(W.use_tool(src, user, 40, volume=100))
+					if(!istype(src, /turf/closed/wall/r_wall) || d_state != SUPPORT_LINES)
 						return 1
 					d_state = COVER
 					update_icon()
@@ -94,24 +93,12 @@
 				return 1
 
 		if(COVER)
-			if(istype(W, /obj/item/weldingtool))
-				var/obj/item/weldingtool/WT = W
-				if(WT.remove_fuel(0,user))
-					to_chat(user, "<span class='notice'>You begin slicing through the metal cover...</span>")
-					playsound(src, W.usesound, 100, 1)
-					if(do_after(user, 60*W.toolspeed, target = src))
-						if(!istype(src, /turf/closed/wall/r_wall) || !WT || !WT.isOn() || d_state != COVER)
-							return 1
-						d_state = CUT_COVER
-						update_icon()
-						to_chat(user, "<span class='notice'>You press firmly on the cover, dislodging it.</span>")
-				return 1
-
-			if(istype(W, /obj/item/gun/energy/plasmacutter))
+			if(istype(W, /obj/item/weldingtool) || istype(W, /obj/item/gun/energy/plasmacutter))
+				if(!W.tool_start_check(user, amount=0))
+					return
 				to_chat(user, "<span class='notice'>You begin slicing through the metal cover...</span>")
-				playsound(src, 'sound/items/welder.ogg', 100, 1)
-				if(do_after(user, 60*W.toolspeed, target = src))
-					if(!istype(src, /turf/closed/wall/r_wall) || !W || d_state != COVER)
+				if(W.use_tool(src, user, 60, volume=100))
+					if(!istype(src, /turf/closed/wall/r_wall) || d_state != COVER)
 						return 1
 					d_state = CUT_COVER
 					update_icon()
@@ -120,9 +107,8 @@
 
 			if(istype(W, /obj/item/screwdriver))
 				to_chat(user, "<span class='notice'>You begin securing the support lines...</span>")
-				playsound(src, W.usesound, 100, 1)
-				if(do_after(user, 40*W.toolspeed, target = src))
-					if(!istype(src, /turf/closed/wall/r_wall) || !W || d_state != COVER)
+				if(W.use_tool(src, user, 40, volume=100))
+					if(!istype(src, /turf/closed/wall/r_wall) || d_state != COVER)
 						return 1
 					d_state = SUPPORT_LINES
 					update_icon()
@@ -132,9 +118,8 @@
 		if(CUT_COVER)
 			if(istype(W, /obj/item/crowbar))
 				to_chat(user, "<span class='notice'>You struggle to pry off the cover...</span>")
-				playsound(src, W.usesound, 100, 1)
-				if(do_after(user, 100*W.toolspeed, target = src))
-					if(!istype(src, /turf/closed/wall/r_wall) || !W || d_state != CUT_COVER)
+				if(W.use_tool(src, user, 100, volume=100))
+					if(!istype(src, /turf/closed/wall/r_wall) || d_state != CUT_COVER)
 						return 1
 					d_state = BOLTS
 					update_icon()
@@ -142,24 +127,22 @@
 				return 1
 
 			if(istype(W, /obj/item/weldingtool))
-				var/obj/item/weldingtool/WT = W
-				if(WT.remove_fuel(0,user))
-					to_chat(user, "<span class='notice'>You begin welding the metal cover back to the frame...</span>")
-					playsound(src, WT.usesound, 100, 1)
-					if(do_after(user, 60*WT.toolspeed, target = src))
-						if(!istype(src, /turf/closed/wall/r_wall) || !WT || !WT.isOn() || d_state != CUT_COVER)
-							return 1
-						d_state = COVER
-						update_icon()
-						to_chat(user, "<span class='notice'>The metal cover has been welded securely to the frame.</span>")
+				if(!W.tool_start_check(user, amount=0))
+					return
+				to_chat(user, "<span class='notice'>You begin welding the metal cover back to the frame...</span>")
+				if(W.use_tool(src, user, 60, volume=100))
+					if(!istype(src, /turf/closed/wall/r_wall) || d_state != CUT_COVER)
+						return 1
+					d_state = COVER
+					update_icon()
+					to_chat(user, "<span class='notice'>The metal cover has been welded securely to the frame.</span>")
 				return 1
 
 		if(BOLTS)
 			if(istype(W, /obj/item/wrench))
 				to_chat(user, "<span class='notice'>You start loosening the anchoring bolts which secure the support rods to their frame...</span>")
-				playsound(src, W.usesound, 100, 1)
-				if(do_after(user, 40*W.toolspeed, target = src))
-					if(!istype(src, /turf/closed/wall/r_wall) || !W || d_state != BOLTS)
+				if(W.use_tool(src, user, 40, volume=100))
+					if(!istype(src, /turf/closed/wall/r_wall) || d_state != BOLTS)
 						return 1
 					d_state = SUPPORT_RODS
 					update_icon()
@@ -168,9 +151,8 @@
 
 			if(istype(W, /obj/item/crowbar))
 				to_chat(user, "<span class='notice'>You start to pry the cover back into place...</span>")
-				playsound(src, W.usesound, 100, 1)
-				if(do_after(user, 20*W.toolspeed, target = src))
-					if(!istype(src, /turf/closed/wall/r_wall) || !W || d_state != BOLTS)
+				if(W.use_tool(src, user, 20, volume=100))
+					if(!istype(src, /turf/closed/wall/r_wall) || d_state != BOLTS)
 						return 1
 					d_state = CUT_COVER
 					update_icon()
@@ -178,24 +160,12 @@
 				return 1
 
 		if(SUPPORT_RODS)
-			if(istype(W, /obj/item/weldingtool))
-				var/obj/item/weldingtool/WT = W
-				if(WT.remove_fuel(0,user))
-					to_chat(user, "<span class='notice'>You begin slicing through the support rods...</span>")
-					playsound(src, W.usesound, 100, 1)
-					if(do_after(user, 100*W.toolspeed, target = src))
-						if(!istype(src, /turf/closed/wall/r_wall) || !WT || !WT.isOn() || d_state != SUPPORT_RODS)
-							return 1
-						d_state = SHEATH
-						update_icon()
-						to_chat(user, "<span class='notice'>You slice through the support rods.</span>")
-				return 1
-
-			if(istype(W, /obj/item/gun/energy/plasmacutter))
+			if(istype(W, /obj/item/weldingtool) || istype(W, /obj/item/gun/energy/plasmacutter))
+				if(!W.tool_start_check(user, amount=0))
+					return
 				to_chat(user, "<span class='notice'>You begin slicing through the support rods...</span>")
-				playsound(src, 'sound/items/welder.ogg', 100, 1)
-				if(do_after(user, 100*W.toolspeed, target = src))
-					if(!istype(src, /turf/closed/wall/r_wall) || !W || d_state != SUPPORT_RODS)
+				if(W.use_tool(src, user, 100, volume=100))
+					if(!istype(src, /turf/closed/wall/r_wall) || d_state != SUPPORT_RODS)
 						return 1
 					d_state = SHEATH
 					update_icon()
@@ -205,8 +175,8 @@
 			if(istype(W, /obj/item/wrench))
 				to_chat(user, "<span class='notice'>You start tightening the bolts which secure the support rods to their frame...</span>")
 				playsound(src, W.usesound, 100, 1)
-				if(do_after(user, 40*W.toolspeed, target = src))
-					if(!istype(src, /turf/closed/wall/r_wall) || !W || d_state != SUPPORT_RODS)
+				if(W.use_tool(src, user, 40))
+					if(!istype(src, /turf/closed/wall/r_wall) || d_state != SUPPORT_RODS)
 						return 1
 					d_state = BOLTS
 					update_icon()
@@ -216,26 +186,24 @@
 		if(SHEATH)
 			if(istype(W, /obj/item/crowbar))
 				to_chat(user, "<span class='notice'>You struggle to pry off the outer sheath...</span>")
-				playsound(src, W.usesound, 100, 1)
-				if(do_after(user, 100*W.toolspeed, target = src))
-					if(!istype(src, /turf/closed/wall/r_wall) || !W || d_state != SHEATH)
+				if(W.use_tool(src, user, 100, volume=100))
+					if(!istype(src, /turf/closed/wall/r_wall) || d_state != SHEATH)
 						return 1
 					to_chat(user, "<span class='notice'>You pry off the outer sheath.</span>")
 					dismantle_wall()
 				return 1
 
 			if(istype(W, /obj/item/weldingtool))
-				var/obj/item/weldingtool/WT = W
-				if(WT.remove_fuel(0,user))
-					to_chat(user, "<span class='notice'>You begin welding the support rods back together...</span>")
-					playsound(src, WT.usesound, 100, 1)
-					if(do_after(user, 100*WT.toolspeed, target = src))
-						if(!istype(src, /turf/closed/wall/r_wall) || !WT || !WT.isOn() || d_state != SHEATH)
-							return 1
-						d_state = SUPPORT_RODS
-						update_icon()
-						to_chat(user, "<span class='notice'>You weld the support rods back together.</span>")
-					return 1
+				if(!W.tool_start_check(user, amount=0))
+					return
+				to_chat(user, "<span class='notice'>You begin welding the support rods back together...</span>")
+				if(W.use_tool(src, user, 100, volume=100))
+					if(!istype(src, /turf/closed/wall/r_wall) || d_state != SHEATH)
+						return 1
+					d_state = SUPPORT_RODS
+					update_icon()
+					to_chat(user, "<span class='notice'>You weld the support rods back together.</span>")
+				return 1
 	return 0
 
 /turf/closed/wall/r_wall/proc/update_icon()

--- a/code/game/turfs/simulated/wall/reinf_walls.dm
+++ b/code/game/turfs/simulated/wall/reinf_walls.dm
@@ -132,7 +132,7 @@
 				to_chat(user, "<span class='notice'>You begin welding the metal cover back to the frame...</span>")
 				if(W.use_tool(src, user, 60, volume=100))
 					if(!istype(src, /turf/closed/wall/r_wall) || d_state != CUT_COVER)
-						return 1
+						return TRUE
 					d_state = COVER
 					update_icon()
 					to_chat(user, "<span class='notice'>The metal cover has been welded securely to the frame.</span>")
@@ -199,7 +199,7 @@
 				to_chat(user, "<span class='notice'>You begin welding the support rods back together...</span>")
 				if(W.use_tool(src, user, 100, volume=100))
 					if(!istype(src, /turf/closed/wall/r_wall) || d_state != SHEATH)
-						return 1
+						return TRUE
 					d_state = SUPPORT_RODS
 					update_icon()
 					to_chat(user, "<span class='notice'>You weld the support rods back together.</span>")

--- a/code/game/turfs/simulated/walls.dm
+++ b/code/game/turfs/simulated/walls.dm
@@ -190,18 +190,21 @@
 	return ..()
 
 /turf/closed/wall/proc/try_clean(obj/item/W, mob/user, turf/T)
-	if((user.a_intent != INTENT_HELP) || !LAZYLEN(dent_decals) || !istype(W, /obj/item/weldingtool))
+	if((user.a_intent != INTENT_HELP) || !LAZYLEN(dent_decals))
 		return FALSE
-	var/obj/item/weldingtool/WT = W
-	if(WT.remove_fuel(0, user))
+
+	if(istype(W, /obj/item/weldingtool))
+		if(!W.tool_start_check(user, amount=0))
+			return FALSE
+
 		to_chat(user, "<span class='notice'>You begin fixing dents on the wall...</span>")
-		playsound(src, W.usesound, 100, 1)
-		if(do_after(user, slicing_duration * W.toolspeed * 0.1, target = src))
-			if(iswallturf(src) && user && !QDELETED(WT) && WT.isOn() && !QDELETED(T) && (user.loc == T) && (user.get_active_held_item() == WT) && LAZYLEN(dent_decals))
+		if(W.use_tool(src, user, slicing_duration, volume=100))
+			if(iswallturf(src) && LAZYLEN(dent_decals))
 				to_chat(user, "<span class='notice'>You fix some dents on the wall.</span>")
 				cut_overlay(dent_decals)
 				LAZYCLEARLIST(dent_decals)
 			return TRUE
+
 	return FALSE
 
 /turf/closed/wall/proc/try_wallmount(obj/item/W, mob/user, turf/T)
@@ -219,27 +222,17 @@
 	return FALSE
 
 /turf/closed/wall/proc/try_decon(obj/item/W, mob/user, turf/T)
-	if(istype(W, /obj/item/weldingtool))
-		var/obj/item/weldingtool/WT = W
-		if(WT.remove_fuel(0, user))
-			to_chat(user, "<span class='notice'>You begin slicing through the outer plating...</span>")
-			playsound(src, W.usesound, 100, 1)
-			if(do_after(user, slicing_duration * W.toolspeed, target = src))
-				if(iswallturf(src) && user && !QDELETED(WT) && WT.isOn() && !QDELETED(T) && (user.loc == T) && (user.get_active_held_item() == WT))
-					to_chat(user, "<span class='notice'>You remove the outer plating.</span>")
-					dismantle_wall()
-				return TRUE
-	else if(istype(W, /obj/item/gun/energy/plasmacutter))
+	if(istype(W, /obj/item/weldingtool) || istype(W, /obj/item/gun/energy/plasmacutter))
+		if(!W.tool_start_check(user, amount=0))
+			return FALSE
+
 		to_chat(user, "<span class='notice'>You begin slicing through the outer plating...</span>")
-		playsound(src, 'sound/items/welder.ogg', 100, 1)
-		if(do_after(user, slicing_duration * W.toolspeed, target = src))
-			if(!iswallturf(src) || !user || QDELETED(W) || QDELETED(T))
-				return TRUE
-			if((user.loc == T) && (user.get_active_held_item() == W))
+		if(W.use_tool(src, user, slicing_duration, volume=100))
+			if(iswallturf(src))
 				to_chat(user, "<span class='notice'>You remove the outer plating.</span>")
 				dismantle_wall()
-				visible_message("The wall was sliced apart by [user]!", "<span class='italics'>You hear metal being sliced apart.</span>")
-				return TRUE
+			return TRUE
+
 	return FALSE
 
 

--- a/code/modules/antagonists/abductor/equipment/abduction_gear.dm
+++ b/code/modules/antagonists/abductor/equipment/abduction_gear.dm
@@ -683,7 +683,7 @@ Congratulations! You are now trained for invasive xenobiology research!"}
 	if(istype(I, /obj/item/wrench))
 		to_chat(user, "<span class='notice'>You start disassembling [src]...</span>")
 		playsound(src.loc, I.usesound, 50, 1)
-		if(do_after(user, 30*I.toolspeed, target = src))
+		if(I.use_tool(src, user, 30))
 			playsound(src.loc, 'sound/items/deconstruct.ogg', 50, 1)
 			for(var/i = 1, i <= framestackamount, i++)
 				new framestack(get_turf(src))

--- a/code/modules/antagonists/clockcult/clock_structures/wall_gear.dm
+++ b/code/modules/antagonists/clockcult/clock_structures/wall_gear.dm
@@ -31,9 +31,8 @@
 		if(anchored)
 			to_chat(user, "<span class='warning'>[src] needs to be unsecured to disassemble it!</span>")
 		else
-			playsound(src, I.usesound, 100, 1)
 			user.visible_message("<span class='warning'>[user] starts to disassemble [src].</span>", "<span class='notice'>You start to disassemble [src]...</span>")
-			if(do_after(user, 30*I.toolspeed, target = src) && !anchored)
+			if(I.use_tool(src, user, 30, volume=100) && !anchored)
 				to_chat(user, "<span class='notice'>You disassemble [src].</span>")
 				deconstruct(TRUE)
 		return 1

--- a/code/modules/antagonists/nukeop/equipment/nuclearbomb.dm
+++ b/code/modules/antagonists/nukeop/equipment/nuclearbomb.dm
@@ -115,9 +115,8 @@
 	switch(deconstruction_state)
 		if(NUKESTATE_INTACT)
 			if(istype(I, /obj/item/screwdriver/nuke))
-				playsound(loc, I.usesound, 100, 1)
 				to_chat(user, "<span class='notice'>You start removing [src]'s front panel's screws...</span>")
-				if(do_after(user, 60*I.toolspeed,target=src))
+				if(I.use_tool(src, user, 60, volume=100))
 					deconstruction_state = NUKESTATE_UNSCREWED
 					to_chat(user, "<span class='notice'>You remove the screws from [src]'s front panel.</span>")
 					update_icon()
@@ -125,14 +124,13 @@
 
 		if(NUKESTATE_PANEL_REMOVED)
 			if(istype(I, /obj/item/weldingtool))
-				var/obj/item/weldingtool/welder = I
-				playsound(loc, I.usesound, 100, 1)
+				if(!I.tool_start_check(user, amount=1))
+					return
 				to_chat(user, "<span class='notice'>You start cutting [src]'s inner plate...</span>")
-				if(welder.remove_fuel(1,user))
-					if(do_after(user,80*I.toolspeed,target=src))
-						to_chat(user, "<span class='notice'>You cut [src]'s inner plate.</span>")
-						deconstruction_state = NUKESTATE_WELDED
-						update_icon()
+				if(I.use_tool(src, user, 80, volume=100, amount=1))
+					to_chat(user, "<span class='notice'>You cut [src]'s inner plate.</span>")
+					deconstruction_state = NUKESTATE_WELDED
+					update_icon()
 				return
 		if(NUKESTATE_CORE_EXPOSED)
 			if(istype(I, /obj/item/nuke_core_container))
@@ -148,19 +146,15 @@
 						to_chat(user, "<span class='warning'>You fail to load the plutonium core into [core_box]. [core_box] has already been used!</span>")
 				return
 			if(istype(I, /obj/item/stack/sheet/metal))
-				var/obj/item/stack/sheet/metal/M = I
-				if(M.amount >= 20)
-					to_chat(user, "<span class='notice'>You begin repairing [src]'s inner metal plate...</span>")
-					if(do_after(user, 100, target=src))
-						if(M.use(20))
-							to_chat(user, "<span class='notice'>You repair [src]'s inner metal plate. The radiation is contained.</span>")
-							deconstruction_state = NUKESTATE_PANEL_REMOVED
-							STOP_PROCESSING(SSobj, core)
-							update_icon()
-						else
-							to_chat(user, "<span class='warning'>You need more metal to do that!</span>")
-				else
-					to_chat(user, "<span class='warning'>You need more metal to do that!</span>")
+				if(!I.tool_start_check(user, amount=20))
+					return
+
+				to_chat(user, "<span class='notice'>You begin repairing [src]'s inner metal plate...</span>")
+				if(I.use_tool(src, user, 100, amount=20))
+					to_chat(user, "<span class='notice'>You repair [src]'s inner metal plate. The radiation is contained.</span>")
+					deconstruction_state = NUKESTATE_PANEL_REMOVED
+					STOP_PROCESSING(SSobj, core)
+					update_icon()
 				return
 	. = ..()
 
@@ -169,16 +163,14 @@
 	switch(deconstruction_state)
 		if(NUKESTATE_UNSCREWED)
 			to_chat(user, "<span class='notice'>You start removing [src]'s front panel...</span>")
-			playsound(loc, tool.usesound, 100, 1)
-			if(do_after(user, 30 * tool.toolspeed, target = src))
+			if(tool.use_tool(src, user, 30, volume=100))
 				to_chat(user, "<span class='notice'>You remove [src]'s front panel.</span>")
 				deconstruction_state = NUKESTATE_PANEL_REMOVED
 				update_icon()
 			return TRUE
 		if(NUKESTATE_WELDED)
 			to_chat(user, "<span class='notice'>You start prying off [src]'s inner plate...</span>")
-			playsound(loc, tool.usesound, 100, 1)
-			if(do_after(user, 50 * tool.toolspeed, target = src))
+			if(tool.use_tool(src, user, 30, volume=100))
 				to_chat(user, "<span class='notice'>You pry off [src]'s inner plate. You can see the core's green glow!</span>")
 				deconstruction_state = NUKESTATE_CORE_EXPOSED
 				update_icon()

--- a/code/modules/atmospherics/machinery/airalarm.dm
+++ b/code/modules/atmospherics/machinery/airalarm.dm
@@ -675,7 +675,7 @@
 				user.visible_message("[user.name] removes the electronics from [src.name].",\
 									"<span class='notice'>You start prying out the circuit...</span>")
 				playsound(src.loc, W.usesound, 50, 1)
-				if (do_after(user, 20*W.toolspeed, target = src))
+				if (W.use_tool(src, user, 20))
 					if (buildstage == 1)
 						to_chat(user, "<span class='notice'>You remove the air alarm electronics.</span>")
 						new /obj/item/electronics/airalarm( src.loc )

--- a/code/modules/atmospherics/machinery/atmosmachinery.dm
+++ b/code/modules/atmospherics/machinery/atmosmachinery.dm
@@ -183,38 +183,43 @@ Pipelines + Other Objects -> Pipe network
 		if(user.dropItemToGround(pipe))
 			pipe.setPipingLayer(piping_layer) //align it with us
 			return TRUE
-	if(istype(W, /obj/item/wrench))
-		if(can_unwrench(user))
-			var/turf/T = get_turf(src)
-			if (level==1 && isturf(T) && T.intact)
-				to_chat(user, "<span class='warning'>You must remove the plating first!</span>")
-				return TRUE
-			var/datum/gas_mixture/int_air = return_air()
-			var/datum/gas_mixture/env_air = loc.return_air()
-			add_fingerprint(user)
-
-			var/unsafe_wrenching = FALSE
-			var/internal_pressure = int_air.return_pressure()-env_air.return_pressure()
-
-			playsound(src, W.usesound, 50, 1)
-			to_chat(user, "<span class='notice'>You begin to unfasten \the [src]...</span>")
-			if (internal_pressure > 2*ONE_ATMOSPHERE)
-				to_chat(user, "<span class='warning'>As you begin unwrenching \the [src] a gush of air blows in your face... maybe you should reconsider?</span>")
-				unsafe_wrenching = TRUE //Oh dear oh dear
-
-			if (do_after(user, 20*W.toolspeed, target = src) && !QDELETED(src))
-				user.visible_message( \
-					"[user] unfastens \the [src].", \
-					"<span class='notice'>You unfasten \the [src].</span>", \
-					"<span class='italics'>You hear ratchet.</span>")
-				investigate_log("was <span class='warning'>REMOVED</span> by [key_name(usr)]", INVESTIGATE_ATMOS)
-
-				//You unwrenched a pipe full of pressure? Let's splat you into the wall, silly.
-				if(unsafe_wrenching)
-					unsafe_pressure_release(user, internal_pressure)
-				deconstruct(TRUE)
 	else
 		return ..()
+
+/obj/machinery/atmospherics/wrench_act(mob/living/user, obj/item/I)
+	if(!can_unwrench(user))
+		return TRUE
+
+	var/turf/T = get_turf(src)
+	if (level==1 && isturf(T) && T.intact)
+		to_chat(user, "<span class='warning'>You must remove the plating first!</span>")
+		return TRUE
+
+	var/datum/gas_mixture/int_air = return_air()
+	var/datum/gas_mixture/env_air = loc.return_air()
+	add_fingerprint(user)
+
+	var/unsafe_wrenching = FALSE
+	var/internal_pressure = int_air.return_pressure()-env_air.return_pressure()
+
+	to_chat(user, "<span class='notice'>You begin to unfasten \the [src]...</span>")
+
+	if (internal_pressure > 2*ONE_ATMOSPHERE)
+		to_chat(user, "<span class='warning'>As you begin unwrenching \the [src] a gush of air blows in your face... maybe you should reconsider?</span>")
+		unsafe_wrenching = TRUE //Oh dear oh dear
+
+	if(I.use_tool(src, user, 20, volume=50))
+		user.visible_message( \
+			"[user] unfastens \the [src].", \
+			"<span class='notice'>You unfasten \the [src].</span>", \
+			"<span class='italics'>You hear ratchet.</span>")
+		investigate_log("was <span class='warning'>REMOVED</span> by [key_name(usr)]", INVESTIGATE_ATMOS)
+
+		//You unwrenched a pipe full of pressure? Let's splat you into the wall, silly.
+		if(unsafe_wrenching)
+			unsafe_pressure_release(user, internal_pressure)
+		deconstruct(TRUE)
+	return TRUE
 
 /obj/machinery/atmospherics/proc/can_unwrench(mob/user)
 	return can_unwrench
@@ -326,7 +331,7 @@ Pipelines + Other Objects -> Pipe network
 	else if(is_type_in_typecache(src, GLOB.ventcrawl_machinery) && can_crawl_through()) //if we move in a way the pipe can connect, but doesn't - or we're in a vent
 		user.forceMove(loc)
 		user.visible_message("<span class='notice'>You hear something squeezing through the ducts...</span>","<span class='notice'>You climb out the ventilation system.")
-	
+
 	user.canmove = FALSE
 	addtimer(VARSET_CALLBACK(user, canmove, TRUE), 1)
 

--- a/code/modules/atmospherics/machinery/components/unary_devices/vent_pump.dm
+++ b/code/modules/atmospherics/machinery/components/unary_devices/vent_pump.dm
@@ -269,28 +269,23 @@
 	broadcast_status()
 	update_icon()
 
-/obj/machinery/atmospherics/components/unary/vent_pump/attackby(obj/item/W, mob/user, params)
-	if(istype(W, /obj/item/weldingtool))
-		var/obj/item/weldingtool/WT = W
-		if (WT.remove_fuel(0, user))
-			playsound(loc, WT.usesound, 40, 1)
-			to_chat(user, "<span class='notice'>You begin welding the vent...</span>")
-			if(do_after(user, W.toolspeed * 20, target = src))
-				if(!src || !WT.isOn())
-					return
-				playsound(src.loc, 'sound/items/welder2.ogg', 50, 1)
-				if(!welded)
-					user.visible_message("[user] welds the vent shut.", "<span class='notice'>You weld the vent shut.</span>", "<span class='italics'>You hear welding.</span>")
-					welded = TRUE
-				else
-					user.visible_message("[user] unwelds the vent.", "<span class='notice'>You unweld the vent.</span>", "<span class='italics'>You hear welding.</span>")
-					welded = FALSE
-				update_icon()
-				pipe_vision_img = image(src, loc, layer = ABOVE_HUD_LAYER, dir = dir)
-				pipe_vision_img.plane = ABOVE_HUD_PLANE
-			return 0
-	else
-		return ..()
+/obj/machinery/atmospherics/components/unary/vent_pump/welder_act(mob/living/user, obj/item/I)
+	if(!I.tool_start_check(user, amount=0))
+		return TRUE
+	playsound(loc, I.usesound, 40, 1)
+	to_chat(user, "<span class='notice'>You begin welding the vent...</span>")
+	if(I.use_tool(src, user, 20))
+		playsound(src.loc, 'sound/items/welder2.ogg', 50, 1)
+		if(!welded)
+			user.visible_message("[user] welds the vent shut.", "<span class='notice'>You weld the vent shut.</span>", "<span class='italics'>You hear welding.</span>")
+			welded = TRUE
+		else
+			user.visible_message("[user] unwelds the vent.", "<span class='notice'>You unweld the vent.</span>", "<span class='italics'>You hear welding.</span>")
+			welded = FALSE
+		update_icon()
+		pipe_vision_img = image(src, loc, layer = ABOVE_HUD_LAYER, dir = dir)
+		pipe_vision_img.plane = ABOVE_HUD_PLANE
+	return TRUE
 
 /obj/machinery/atmospherics/components/unary/vent_pump/can_unwrench(mob/user)
 	. = ..()

--- a/code/modules/atmospherics/machinery/components/unary_devices/vent_scrubber.dm
+++ b/code/modules/atmospherics/machinery/components/unary_devices/vent_scrubber.dm
@@ -263,28 +263,23 @@
 	..()
 	update_icon_nopipes()
 
-/obj/machinery/atmospherics/components/unary/vent_scrubber/attackby(obj/item/W, mob/user, params)
-	if(istype(W, /obj/item/weldingtool))
-		var/obj/item/weldingtool/WT = W
-		if(WT.remove_fuel(0,user))
-			playsound(loc, WT.usesound, 40, 1)
-			to_chat(user, "<span class='notice'>Now welding the scrubber.</span>")
-			if(do_after(user, 20*W.toolspeed, target = src))
-				if(!src || !WT.isOn())
-					return
-				playsound(src.loc, 'sound/items/welder2.ogg', 50, 1)
-				if(!welded)
-					user.visible_message("[user] welds the scrubber shut.","You weld the scrubber shut.", "You hear welding.")
-					welded = TRUE
-				else
-					user.visible_message("[user] unwelds the scrubber.", "You unweld the scrubber.", "You hear welding.")
-					welded = FALSE
-				update_icon()
-				pipe_vision_img = image(src, loc, layer = ABOVE_HUD_LAYER, dir = dir)
-				pipe_vision_img.plane = ABOVE_HUD_PLANE
-			return 0
-	else
-		return ..()
+/obj/machinery/atmospherics/components/unary/vent_scrubber/welder_act(mob/living/user, obj/item/I)
+	if(!I.tool_start_check(user, amount=0))
+		return TRUE
+	playsound(loc, I.usesound, 40, 1)
+	to_chat(user, "<span class='notice'>Now welding the scrubber.</span>")
+	if(I.use_tool(src, user, 20))
+		playsound(src.loc, 'sound/items/welder2.ogg', 50, 1)
+		if(!welded)
+			user.visible_message("[user] welds the scrubber shut.","You weld the scrubber shut.", "You hear welding.")
+			welded = TRUE
+		else
+			user.visible_message("[user] unwelds the scrubber.", "You unweld the scrubber.", "You hear welding.")
+			welded = FALSE
+		update_icon()
+		pipe_vision_img = image(src, loc, layer = ABOVE_HUD_LAYER, dir = dir)
+		pipe_vision_img.plane = ABOVE_HUD_PLANE
+	return TRUE
 
 /obj/machinery/atmospherics/components/unary/vent_scrubber/can_unwrench(mob/user)
 	. = ..()

--- a/code/modules/atmospherics/machinery/other/meter.dm
+++ b/code/modules/atmospherics/machinery/other/meter.dm
@@ -100,19 +100,20 @@
 	to_chat(user, status())
 
 
-/obj/machinery/meter/attackby(obj/item/W, mob/user, params)
-	if (istype(W, /obj/item/wrench))
-		playsound(src, W.usesound, 50, 1)
-		to_chat(user, "<span class='notice'>You begin to unfasten \the [src]...</span>")
-		if (do_after(user, 40*W.toolspeed, target = src))
-			user.visible_message( \
-				"[user] unfastens \the [src].", \
-				"<span class='notice'>You unfasten \the [src].</span>", \
-				"<span class='italics'>You hear ratchet.</span>")
-			new /obj/item/pipe_meter(loc)
-			qdel(src)
-	else
-		return ..()
+/obj/machinery/meter/wrench_act(mob/user, obj/item/I)
+	to_chat(user, "<span class='notice'>You begin to unfasten \the [src]...</span>")
+	if (I.use_tool(src, user, 40, volume=50))
+		user.visible_message(
+			"[user] unfastens \the [src].",
+			"<span class='notice'>You unfasten \the [src].</span>",
+			"<span class='italics'>You hear ratchet.</span>")
+		deconstruct()
+	return TRUE
+
+/obj/machinery/meter/deconstruct(disassembled = TRUE)
+	if(!(flags_1 & NODECONSTRUCT_1))
+		new /obj/item/pipe_meter(loc)
+	qdel(src)
 
 /obj/machinery/meter/attack_ai(mob/user)
 	return attack_hand(user)
@@ -131,8 +132,7 @@
 /obj/machinery/meter/singularity_pull(S, current_size)
 	..()
 	if(current_size >= STAGE_FIVE)
-		new /obj/item/pipe_meter(loc)
-		qdel(src)
+		deconstruct()
 
 // TURF METER - REPORTS A TILE'S AIR CONTENTS
 //	why are you yelling?

--- a/code/modules/atmospherics/machinery/portable/canister.dm
+++ b/code/modules/atmospherics/machinery/portable/canister.dm
@@ -278,21 +278,20 @@
 			new /obj/item/stack/sheet/metal (loc, 5)
 	qdel(src)
 
-/obj/machinery/portable_atmospherics/canister/attackby(obj/item/W, mob/user, params)
-	if(user.a_intent != INTENT_HARM && istype(W, /obj/item/weldingtool))
-		var/obj/item/weldingtool/WT = W
-		if(stat & BROKEN)
-			if(!WT.remove_fuel(0, user))
-				return
-			playsound(loc, WT.usesound, 40, 1)
-			to_chat(user, "<span class='notice'>You begin cutting [src] apart...</span>")
-			if(do_after(user, 30, target = src))
-				deconstruct(TRUE)
-		else
-			to_chat(user, "<span class='notice'>You cannot slice [src] apart when it isn't broken.</span>")
-		return 1
+/obj/machinery/portable_atmospherics/canister/welder_act(mob/living/user, obj/item/I)
+	if(user.a_intent == INTENT_HARM)
+		return FALSE
+
+	if(stat & BROKEN)
+		if(!I.tool_start_check(user, amount=0))
+			return TRUE
+		to_chat(user, "<span class='notice'>You begin cutting [src] apart...</span>")
+		if(I.use_tool(src, user, 30, volume=50))
+			deconstruct(TRUE)
 	else
-		return ..()
+		to_chat(user, "<span class='notice'>You cannot slice [src] apart when it isn't broken.</span>")
+
+	return TRUE
 
 /obj/machinery/portable_atmospherics/canister/obj_break(damage_flag)
 	if((stat & BROKEN) || (flags_1 & NODECONSTRUCT_1))

--- a/code/modules/food_and_drinks/kitchen_machinery/microwave.dm
+++ b/code/modules/food_and_drinks/kitchen_machinery/microwave.dm
@@ -62,7 +62,7 @@
 				"[user] starts to fix part of the microwave.", \
 				"<span class='notice'>You start to fix part of the microwave...</span>" \
 			)
-			if (do_after(user,20*O.toolspeed, target = src))
+			if (O.use_tool(src, user, 20))
 				user.visible_message( \
 					"[user] fixes part of the microwave.", \
 					"<span class='notice'>You fix part of the microwave.</span>" \
@@ -73,7 +73,7 @@
 				"[user] starts to fix part of the microwave.", \
 				"<span class='notice'>You start to fix part of the microwave...</span>" \
 			)
-			if (do_after(user,20*O.toolspeed, target = src))
+			if (O.use_tool(src, user, 20))
 				user.visible_message( \
 					"[user] fixes the microwave.", \
 					"<span class='notice'>You fix the microwave.</span>" \

--- a/code/modules/hydroponics/hydroponics.dm
+++ b/code/modules/hydroponics/hydroponics.dm
@@ -801,8 +801,7 @@
 		if(!anchored && !isinspace())
 			user.visible_message("[user] begins to wrench [src] into place.", \
 								"<span class='notice'>You begin to wrench [src] in place...</span>")
-			playsound(loc, O.usesound, 50, 1)
-			if (do_after(user, 20*O.toolspeed, target = src))
+			if (O.use_tool(src, user, 20, volume=50))
 				if(anchored)
 					return
 				anchored = TRUE
@@ -811,8 +810,7 @@
 		else if(anchored)
 			user.visible_message("[user] begins to unwrench [src].", \
 								"<span class='notice'>You begin to unwrench [src]...</span>")
-			playsound(loc, O.usesound, 50, 1)
-			if (do_after(user, 20*O.toolspeed, target = src))
+			if (O.use_tool(src, user, 20, volume=50))
 				if(!anchored)
 					return
 				anchored = FALSE

--- a/code/modules/library/lib_items.dm
+++ b/code/modules/library/lib_items.dm
@@ -57,14 +57,12 @@
 	switch(state)
 		if(0)
 			if(istype(I, /obj/item/wrench))
-				playsound(loc, I.usesound, 100, 1)
-				if(do_after(user, 20*I.toolspeed, target = src))
+				if(I.use_tool(src, user, 20, volume=50))
 					to_chat(user, "<span class='notice'>You wrench the frame into place.</span>")
 					anchored = TRUE
 					state = 1
 			if(istype(I, /obj/item/crowbar))
-				playsound(loc, I.usesound, 100, 1)
-				if(do_after(user, 20*I.toolspeed, target = src))
+				if(I.use_tool(src, user, 20, volume=50))
 					to_chat(user, "<span class='notice'>You pry the frame apart.</span>")
 					deconstruct(TRUE)
 
@@ -99,7 +97,7 @@
 				if(!newname)
 					return
 				else
-					name = ("bookcase ([sanitize(newname)])")
+					name = "bookcase ([sanitize(newname)])"
 			else if(istype(I, /obj/item/crowbar))
 				if(contents.len)
 					to_chat(user, "<span class='warning'>You need to remove the books first!</span>")

--- a/code/modules/mining/equipment/survival_pod.dm
+++ b/code/modules/mining/equipment/survival_pod.dm
@@ -138,16 +138,16 @@
 	density = TRUE
 	pixel_y = -32
 
-/obj/item/device/gps/computer/attackby(obj/item/W, mob/user, params)
-	if(istype(W, /obj/item/wrench) && !(flags_1&NODECONSTRUCT_1))
-		playsound(src.loc, W.usesound, 50, 1)
-		user.visible_message("<span class='warning'>[user] disassembles the gps.</span>", \
-						"<span class='notice'>You start to disassemble the gps...</span>", "You hear clanking and banging noises.")
-		if(do_after(user, 20*W.toolspeed, target = src))
-			new /obj/item/device/gps(loc)
-			qdel(src)
-		return
-	return ..()
+/obj/item/device/gps/computer/wrench_act(mob/living/user, obj/item/I)
+	if(flags_1 & NODECONSTRUCT_1)
+		return TRUE
+
+	user.visible_message("<span class='warning'>[user] disassembles [src].</span>",
+		"<span class='notice'>You start to disassemble [src]...</span>", "You hear clanking and banging noises.")
+	if(I.use_tool(src, user, 20, volume=50))
+		new /obj/item/device/gps(loc)
+		qdel(src)
+	return TRUE
 
 /obj/item/device/gps/computer/attack_hand(mob/user)
 	attack_self(user)
@@ -214,14 +214,15 @@
 			new buildstacktype(loc,buildstackamount)
 	qdel(src)
 
-/obj/structure/fans/attackby(obj/item/W, mob/user, params)
-	if(istype(W, /obj/item/wrench) && !(flags_1&NODECONSTRUCT_1))
-		playsound(src.loc, W.usesound, 50, 1)
-		user.visible_message("<span class='warning'>[user] disassembles the fan.</span>", \
-						"<span class='notice'>You start to disassemble the fan...</span>", "You hear clanking and banging noises.")
-		if(do_after(user, 20*W.toolspeed, target = src))
-			deconstruct()
-			return ..()
+/obj/structure/fans/wrench_act(mob/living/user, obj/item/I)
+	if(flags_1 & NODECONSTRUCT_1)
+		return TRUE
+
+	user.visible_message("<span class='warning'>[user] disassembles [src].</span>",
+		"<span class='notice'>You start to disassemble [src]...</span>", "You hear clanking and banging noises.")
+	if(I.use_tool(src, user, 20, volume=50))
+		deconstruct()
+	return TRUE
 
 /obj/structure/fans/tiny
 	name = "tiny fan"

--- a/code/modules/mining/minebot.dm
+++ b/code/modules/mining/minebot.dm
@@ -64,18 +64,21 @@
 
 /mob/living/simple_animal/hostile/mining_drone/attackby(obj/item/I, mob/user, params)
 	if(istype(I, /obj/item/weldingtool))
-		var/obj/item/weldingtool/W = I
-		if(W.welding && !stat)
-			if(AIStatus != AI_OFF && AIStatus != AI_IDLE)
-				to_chat(user, "<span class='info'>[src] is moving around too much to repair!</span>")
-				return
-			if(maxHealth == health)
-				to_chat(user, "<span class='info'>[src] is at full integrity.</span>")
-			else
-				if(W.remove_fuel(0, user))
-					adjustBruteLoss(-10)
-					to_chat(user, "<span class='info'>You repair some of the armor on [src].</span>")
+		if(stat)
 			return
+		if(AIStatus != AI_OFF && AIStatus != AI_IDLE)
+			to_chat(user, "<span class='info'>[src] is moving around too much to repair!</span>")
+			return
+
+		if(maxHealth == health)
+			to_chat(user, "<span class='info'>[src] is at full integrity.</span>")
+			return
+
+		if(I.use_tool(src, user, 0, volume=40))
+			adjustBruteLoss(-10)
+			to_chat(user, "<span class='info'>You repair some of the armor on [src].</span>")
+		return
+
 	if(istype(I, /obj/item/device/mining_scanner) || istype(I, /obj/item/device/t_scanner/adv_mining_scanner))
 		to_chat(user, "<span class='info'>You instruct [src] to drop any collected ore.</span>")
 		DropOre()

--- a/code/modules/mining/ores_coins.dm
+++ b/code/modules/mining/ores_coins.dm
@@ -44,9 +44,8 @@
 		return TRUE
 
 	if(I.use_tool(src, user, 0, volume=50, amount=15))
-		use(1)
 		new refined_type(drop_location())
-		qdel(src)
+		use(1)
 
 	return TRUE
 
@@ -115,13 +114,9 @@ GLOBAL_LIST_INIT(sand_recipes, list(\
 	materials = list(MAT_PLASMA=MINERAL_MATERIAL_AMOUNT)
 	refined_type = /obj/item/stack/sheet/mineral/plasma
 
-/obj/item/stack/ore/plasma/attackby(obj/item/I, mob/user, params)
-	if(istype(I, /obj/item/weldingtool))
-		var/obj/item/weldingtool/W = I
-		if(W.welding)
-			to_chat(user, "<span class='warning'>You can't hit a high enough temperature to smelt [src] properly!</span>")
-	else
-		..()
+/obj/item/stack/ore/plasma/welder_act(mob/living/user, obj/item/I)
+	to_chat(user, "<span class='warning'>You can't hit a high enough temperature to smelt [src] properly!</span>")
+	return TRUE
 
 
 /obj/item/stack/ore/silver

--- a/code/modules/mining/ores_coins.dm
+++ b/code/modules/mining/ores_coins.dm
@@ -39,15 +39,16 @@
 	. = ..()
 	add_overlay(stack_overlays)
 
-/obj/item/stack/ore/attackby(obj/item/I, mob/user, params)
-	if(istype(I, /obj/item/weldingtool))
-		var/obj/item/weldingtool/W = I
-		if(W.remove_fuel(15) && refined_type)
-			new refined_type(get_turf(src.loc))
-			qdel(src)
-		else if(W.isOn())
-			to_chat(user, "<span class='info'>Not enough fuel to smelt [src].</span>")
-	..()
+/obj/item/stack/ore/welder_act(mob/living/user, obj/item/I)
+	if(!refined_type)
+		return TRUE
+
+	if(I.use_tool(src, user, 0, volume=50, amount=15))
+		use(1)
+		new refined_type(drop_location())
+		qdel(src)
+
+	return TRUE
 
 /obj/item/stack/ore/uranium
 	name = "uranium ore"
@@ -423,20 +424,18 @@ GLOBAL_LIST_INIT(sand_recipes, list(\
 		else
 			to_chat(user, "<span class='warning'>You need one length of cable to attach a string to the coin!</span>")
 			return
-
-	else if(istype(W, /obj/item/wirecutters))
-		if(!string_attached)
-			..()
-			return
-
-		var/obj/item/stack/cable_coil/CC = new/obj/item/stack/cable_coil(user.loc)
-		CC.amount = 1
-		CC.update_icon()
-		overlays = list()
-		string_attached = null
-		to_chat(user, "<span class='notice'>You detach the string from the coin.</span>")
 	else
 		..()
+
+/obj/item/coin/wirecutter_act(mob/living/user, obj/item/I)
+	if(!string_attached)
+		return TRUE
+
+	new /obj/item/stack/cable_coil(drop_location(), 1)
+	overlays = list()
+	string_attached = null
+	to_chat(user, "<span class='notice'>You detach the string from the coin.</span>")
+	return TRUE
 
 /obj/item/coin/attack_self(mob/user)
 	if(cooldown < world.time)

--- a/code/modules/mining/satchel_ore_boxdm.dm
+++ b/code/modules/mining/satchel_ore_boxdm.dm
@@ -9,22 +9,24 @@
 	density = TRUE
 	pressure_resistance = 5*ONE_ATMOSPHERE
 
-/obj/structure/ore_box/attackby(obj/item/W, mob/user, params)
-	if (istype(W, /obj/item/stack/ore))
-		user.transferItemToLoc(W, src)
-	else if (istype(W, /obj/item/storage))
-		var/obj/item/storage/S = W
+/obj/structure/ore_box/attackby(obj/item/I, mob/user, params)
+	if(istype(I, /obj/item/ore))
+		user.transferItemToLoc(I, src)
+	else if(istype(I, /obj/item/storage))
+		var/obj/item/storage/S = I
 		for(var/obj/item/stack/ore/O in S.contents)
 			S.remove_from_storage(O, src) //This will move the item to this item's contents
 		to_chat(user, "<span class='notice'>You empty the ore in [S] into \the [src].</span>")
-	else if(istype(W, /obj/item/crowbar))
-		playsound(src, W.usesound, 50, 1)
-		var/obj/item/crowbar/C = W
-		if(do_after(user, 50*C.toolspeed, target = src))
-			user.visible_message("[user] pries \the [src] apart.", "<span class='notice'>You pry apart \the [src].</span>", "<span class='italics'>You hear splitting wood.</span>")
-			deconstruct(TRUE, user)
 	else
 		return ..()
+
+/obj/structure/ore_box/crowbar_act(mob/living/user, obj/item/I)
+	if(I.use_tool(src, user, 50, volume=50))
+		user.visible_message("[user] pries \the [src] apart.",
+			"<span class='notice'>You pry apart \the [src].</span>",
+			"<span class='italics'>You hear splitting wood.</span>")
+		deconstruct(TRUE, user)
+	return TRUE
 
 /obj/structure/ore_box/examine(mob/living/user)
 	if(Adjacent(user) && istype(user))

--- a/code/modules/mob/living/silicon/robot/robot.dm
+++ b/code/modules/mob/living/silicon/robot/robot.dm
@@ -353,24 +353,21 @@
 /mob/living/silicon/robot/attackby(obj/item/W, mob/user, params)
 	if(istype(W, /obj/item/weldingtool) && (user.a_intent != INTENT_HARM || user == src))
 		user.changeNext_move(CLICK_CD_MELEE)
-		var/obj/item/weldingtool/WT = W
 		if (!getBruteLoss())
 			to_chat(user, "<span class='warning'>[src] is already in good condition!</span>")
 			return
-		if (WT.remove_fuel(0, user)) //The welder has 1u of fuel consumed by it's afterattack, so we don't need to worry about taking any away.
-			if(src == user)
-				to_chat(user, "<span class='notice'>You start fixing yourself...</span>")
-				if(!do_after(user, 50, target = src))
-					return
+		if (!W.tool_start_check(user, amount=0)) //The welder has 1u of fuel consumed by it's afterattack, so we don't need to worry about taking any away.
+			return
+		if(src == user)
+			to_chat(user, "<span class='notice'>You start fixing yourself...</span>")
+			if(!W.use_tool(src, user, 50))
+				return
 
-			adjustBruteLoss(-30)
-			updatehealth()
-			add_fingerprint(user)
-			visible_message("<span class='notice'>[user] has fixed some of the dents on [src].</span>")
-			return
-		else
-			to_chat(user, "<span class='warning'>The welder must be on for this task!</span>")
-			return
+		adjustBruteLoss(-30)
+		updatehealth()
+		add_fingerprint(user)
+		visible_message("<span class='notice'>[user] has fixed some of the dents on [src].</span>")
+		return
 
 	else if(istype(W, /obj/item/stack/cable_coil) && wiresexposed)
 		user.changeNext_move(CLICK_CD_MELEE)
@@ -442,9 +439,8 @@
 			spark_system.start()
 			return
 		else
-			playsound(src, W.usesound, 50, 1)
 			to_chat(user, "<span class='notice'>You start to unfasten [src]'s securing bolts...</span>")
-			if(do_after(user, 50*W.toolspeed, target = src) && !cell)
+			if(W.use_tool(src, user, 50, volume=50) && !cell)
 				user.visible_message("[user] deconstructs [src]!", "<span class='notice'>You unfasten the securing bolts, and [src] falls to pieces!</span>")
 				deconstruct()
 

--- a/code/modules/mob/living/simple_animal/bot/bot.dm
+++ b/code/modules/mob/living/simple_animal/bot/bot.dm
@@ -303,12 +303,10 @@
 			if(!open)
 				to_chat(user, "<span class='warning'>Unable to repair with the maintenance panel closed!</span>")
 				return
-			var/obj/item/weldingtool/WT = W
-			if(WT.remove_fuel(0, user))
+
+			if(W.use_tool(src, user, 0, volume=40))
 				adjustHealth(-10)
 				user.visible_message("[user] repairs [src]!","<span class='notice'>You repair [src].</span>")
-			else
-				to_chat(user, "<span class='warning'>The welder must be on for this task!</span>")
 		else
 			if(W.force) //if force is non-zero
 				do_sparks(5, TRUE, src)

--- a/code/modules/mob/living/simple_animal/bot/construction.dm
+++ b/code/modules/mob/living/simple_animal/bot/construction.dm
@@ -101,8 +101,7 @@
 
 		if(ASSEMBLY_FOURTH_STEP)
 			if(istype(W, /obj/item/weldingtool))
-				var/obj/item/weldingtool/WT = W
-				if(WT.remove_fuel(0,user))
+				if(W.use_tool(src, user, 0, volume=40))
 					name = "shielded frame assembly"
 					to_chat(user, "<span class='notice'>You weld the vest to [src].</span>")
 					build_step++
@@ -185,7 +184,7 @@
 			if(istype(W, /obj/item/screwdriver))
 				playsound(loc, W.usesound, 100, 1)
 				to_chat(user, "<span class='notice'>You start attaching the gun to the frame...</span>")
-				if(do_after(user, 40*W.toolspeed, 0, src, 1))
+				if(W.use_tool(src, user, 40))
 					name = "armed [name]"
 					to_chat(user, "<span class='notice'>Taser gun attached.</span>")
 					build_step++
@@ -391,8 +390,7 @@
 	switch(build_step)
 		if(ASSEMBLY_FIRST_STEP)
 			if(istype(I, /obj/item/weldingtool))
-				var/obj/item/weldingtool/WT = I
-				if(WT.remove_fuel(0, user))
+				if(I.use_tool(src, user, 0, volume=40))
 					add_overlay("hs_hole")
 					to_chat(user, "<span class='notice'>You weld a hole in [src]!</span>")
 					build_step++
@@ -414,8 +412,7 @@
 				build_step++
 
 			else if(istype(I, /obj/item/weldingtool)) //deconstruct
-				var/obj/item/weldingtool/WT = I
-				if(WT.remove_fuel(0, user))
+				if(I.use_tool(src, user, 0, volume=40))
 					cut_overlay("hs_hole")
 					to_chat(user, "<span class='notice'>You weld the hole in [src] shut!</span>")
 					build_step--

--- a/code/modules/mob/living/simple_animal/friendly/drone/interaction.dm
+++ b/code/modules/mob/living/simple_animal/friendly/drone/interaction.dm
@@ -80,7 +80,7 @@
 	if(istype(I, /obj/item/screwdriver) && stat != DEAD)
 		if(health < maxHealth)
 			to_chat(user, "<span class='notice'>You start to tighten loose screws on [src]...</span>")
-			if(do_after(user,80*I.toolspeed,target=user))
+			if(I.use_tool(src, user, 80))
 				adjustBruteLoss(-getBruteLoss())
 				visible_message("<span class='notice'>[user] tightens [src == user ? "[user.p_their()]" : "[src]'s"] loose screws!</span>", "<span class='notice'>You tighten [src == user ? "your" : "[src]'s"] loose screws.</span>")
 			else
@@ -91,12 +91,10 @@
 	else if(istype(I, /obj/item/wrench) && user != src) //They aren't required to be hacked, because laws can change in other ways (i.e. admins)
 		user.visible_message("<span class='notice'>[user] starts resetting [src]...</span>", \
 							 "<span class='notice'>You press down on [src]'s factory reset control...</span>")
-		playsound(src, I.usesound, 50, 1)
-		if(!do_after(user, 50*I.toolspeed, target = src))
-			return
-		user.visible_message("<span class='notice'>[user] resets [src]!</span>", \
-							 "<span class='notice'>You reset [src]'s directives to factory defaults!</span>")
-		update_drone_hack(FALSE)
+		if(I.use_tool(src, user, 50, volume=50))
+			user.visible_message("<span class='notice'>[user] resets [src]!</span>", \
+								 "<span class='notice'>You reset [src]'s directives to factory defaults!</span>")
+			update_drone_hack(FALSE)
 		return
 	else
 		..()

--- a/code/modules/modular_computers/computers/item/computer.dm
+++ b/code/modules/modular_computers/computers/item/computer.dm
@@ -393,18 +393,15 @@
 		return
 
 	if(istype(W, /obj/item/weldingtool))
-		var/obj/item/weldingtool/WT = W
-		if(!WT.isOn())
-			to_chat(user, "<span class='warning'>\The [W] is off.</span>")
-			return
-
 		if(obj_integrity == max_integrity)
 			to_chat(user, "<span class='warning'>\The [src] does not require repairs.</span>")
 			return
 
+		if(!W.tool_start_check(user, amount=1))
+			return
+
 		to_chat(user, "<span class='notice'>You begin repairing damage to \the [src]...</span>")
-		var/dmg = round(max_integrity - obj_integrity)
-		if(WT.remove_fuel(round(dmg/75)) && do_after(usr, dmg/10))
+		if(W.use_tool(src, user, 20, volume=50, amount=1))
 			obj_integrity = max_integrity
 			to_chat(user, "<span class='notice'>You repair \the [src].</span>")
 		return

--- a/code/modules/paperwork/photography.dm
+++ b/code/modules/paperwork/photography.dm
@@ -42,9 +42,9 @@
 
 /obj/item/photo/suicide_act(mob/living/carbon/user)
 	user.visible_message("<span class='suicide'>[user] is taking one last look at \the [src]! It looks like [user.p_theyre()] giving in to death!</span>")//when you wanna look at photo of waifu one last time before you die...
-	if (user.gender == MALE) 
+	if (user.gender == MALE)
 		playsound(user, 'sound/voice/human/manlaugh1.ogg', 50, 1)//EVERY TIME I DO IT MAKES ME LAUGH
-	else if (user.gender == FEMALE) 
+	else if (user.gender == FEMALE)
 		playsound(user, 'sound/voice/human/womanlaugh.ogg', 50, 1)
 	return OXYLOSS
 
@@ -581,11 +581,10 @@
 /obj/structure/sign/picture_frame/attackby(obj/item/I, mob/user, params)
 	if(istype(I, /obj/item/screwdriver) || istype(I, /obj/item/wrench))
 		to_chat(user, "<span class='notice'>You start unsecuring [name]...</span>")
-		playsound(loc, I.usesound, 50, 1)
-		if(do_after(user, 30*I.toolspeed, target = src))
+		if(I.use_tool(src, user, 30, volume=50))
 			playsound(loc, 'sound/items/deconstruct.ogg', 50, 1)
 			to_chat(user, "<span class='notice'>You unsecure [name].</span>")
-		deconstruct()
+			deconstruct()
 		return
 
 	else if(istype(I, /obj/item/photo))

--- a/code/modules/power/apc.dm
+++ b/code/modules/power/apc.dm
@@ -385,7 +385,7 @@
 					return
 				playsound(src.loc, W.usesound, 50, 1)
 				to_chat(user, "<span class='notice'>You are trying to remove the power control board...</span>" )
-				if(do_after(user, 50*W.toolspeed, target = src))
+				if(W.use_tool(src, user, 50))
 					if (has_electronics==1)
 						has_electronics = 0
 						if (stat & BROKEN)
@@ -418,12 +418,11 @@
 				user.visible_message("<span class='notice'>[user] starts prying [integration_cog] from [src]...</span>", \
 				"<span class='notice'>You painstakingly start tearing [integration_cog] out of [src]'s guts...</span>")
 				playsound(src, W.usesound, 50, TRUE)
-				if(!do_after(user, 100 * W.toolspeed, target = src))
-					return
-				user.visible_message("<span class='notice'>[user] destroys [integration_cog] in [src]!</span>", \
-				"<span class='notice'>[integration_cog] comes free with a clank and snaps in two as the machinery returns to normal!</span>")
-				playsound(src, 'sound/items/deconstruct.ogg', 50, TRUE)
-				QDEL_NULL(integration_cog)
+				if(W.use_tool(src, user, 100))
+					user.visible_message("<span class='notice'>[user] destroys [integration_cog] in [src]!</span>", \
+					"<span class='notice'>[integration_cog] comes free with a clank and snaps in two as the machinery returns to normal!</span>")
+					playsound(src, 'sound/items/deconstruct.ogg', 50, TRUE)
+					QDEL_NULL(integration_cog)
 				return
 			else if (opened!=2) //cover isn't removed
 				opened = 0
@@ -578,17 +577,12 @@
 			return
 
 	else if (istype(W, /obj/item/weldingtool) && opened && has_electronics==0 && !terminal)
-		var/obj/item/weldingtool/WT = W
-		if (WT.get_fuel() < 3)
-			to_chat(user, "<span class='warning'>You need more welding fuel to complete this task!</span>")
+		if(!W.tool_start_check(user, amount=3))
 			return
 		user.visible_message("[user.name] welds [src].", \
 							"<span class='notice'>You start welding the APC frame...</span>", \
 							"<span class='italics'>You hear welding.</span>")
-		playsound(src.loc, WT.usesound, 50, 1)
-		if(do_after(user, 50*W.toolspeed, target = src))
-			if(!src || !WT.remove_fuel(3, user))
-				return
+		if(W.use_tool(src, user, 50, volume=50, amount=3))
 			if ((stat & BROKEN) || opened==2)
 				new /obj/item/stack/sheet/metal(loc)
 				user.visible_message(\

--- a/code/modules/power/cable.dm
+++ b/code/modules/power/cable.dm
@@ -471,6 +471,7 @@ GLOBAL_LIST_INIT(cable_coil_recipes, list (new/datum/stack_recipe("cable restrai
 	singular_name = "cable piece"
 	full_w_class = WEIGHT_CLASS_SMALL
 	grind_results = list("copper" = 2) //2 copper per cable in the coil
+	usesound = 'sound/items/deconstruct.ogg'
 
 /obj/item/stack/cable_coil/cyborg
 	is_cyborg = 1

--- a/code/modules/power/cell.dm
+++ b/code/modules/power/cell.dm
@@ -70,7 +70,7 @@
 	return 100*charge/maxcharge
 
 // use power from a cell
-/obj/item/stock_parts/cell/proc/use(amount)
+/obj/item/stock_parts/cell/use(amount)
 	if(rigged && amount > 0)
 		explode()
 		return 0

--- a/code/modules/power/gravitygenerator.dm
+++ b/code/modules/power/gravitygenerator.dm
@@ -194,14 +194,11 @@ GLOBAL_LIST_EMPTY(gravity_generators) // We will keep track of this by adding ne
 				return
 		if(GRAV_NEEDS_WELDING)
 			if(istype(I, /obj/item/weldingtool))
-				var/obj/item/weldingtool/WT = I
-				if(WT.remove_fuel(1, user))
+				if(I.use_tool(src, user, 0, amount=1))
 					to_chat(user, "<span class='notice'>You mend the damaged framework.</span>")
-					playsound(src.loc, 'sound/items/welder2.ogg', 50, 1)
+					playsound(src, 'sound/items/welder2.ogg', 50, 1)
 					broken_state++
 					update_icon()
-				else if(WT.isOn())
-					to_chat(user, "<span class='warning'>You don't have enough fuel to mend the damaged framework!</span>")
 				return
 		if(GRAV_NEEDS_PLASTEEL)
 			if(istype(I, /obj/item/stack/sheet/plasteel))

--- a/code/modules/power/lighting.dm
+++ b/code/modules/power/lighting.dm
@@ -109,25 +109,19 @@
 	switch(stage)
 		if(1)
 			if(istype(W, /obj/item/wrench))
-				playsound(src.loc, W.usesound, 75, 1)
 				to_chat(usr, "<span class='notice'>You begin deconstructing [src]...</span>")
-				if (!do_after(usr, 30*W.toolspeed, target = src))
-					return
-				new /obj/item/stack/sheet/metal( get_turf(src.loc), sheets_refunded )
-				user.visible_message("[user.name] deconstructs [src].", \
-					"<span class='notice'>You deconstruct [src].</span>", "<span class='italics'>You hear a ratchet.</span>")
-				playsound(src.loc, 'sound/items/deconstruct.ogg', 75, 1)
-				qdel(src)
+				if (W.use_tool(src, user, 30, volume=50))
+					new /obj/item/stack/sheet/metal(drop_location(), sheets_refunded)
+					user.visible_message("[user.name] deconstructs [src].", \
+						"<span class='notice'>You deconstruct [src].</span>", "<span class='italics'>You hear a ratchet.</span>")
+					playsound(src.loc, 'sound/items/deconstruct.ogg', 75, 1)
+					qdel(src)
 				return
 
 			if(istype(W, /obj/item/stack/cable_coil))
 				var/obj/item/stack/cable_coil/coil = W
 				if(coil.use(1))
-					switch(fixture_type)
-						if ("tube")
-							icon_state = "tube-construct-stage2"
-						if("bulb")
-							icon_state = "bulb-construct-stage2"
+					icon_state = "[fixture_type]-construct-stage2"
 					stage = 2
 					user.visible_message("[user.name] adds wires to [src].", \
 						"<span class='notice'>You add wires to [src].</span>")
@@ -141,12 +135,8 @@
 
 			if(istype(W, /obj/item/wirecutters))
 				stage = 1
-				switch(fixture_type)
-					if ("tube")
-						icon_state = "tube-construct-stage1"
-					if("bulb")
-						icon_state = "bulb-construct-stage1"
-				new /obj/item/stack/cable_coil(get_turf(loc), 1, "red")
+				icon_state = "[fixture_type]-construct-stage1"
+				new /obj/item/stack/cable_coil(drop_location(), 1, "red")
 				user.visible_message("[user.name] removes the wiring from [src].", \
 					"<span class='notice'>You remove the wiring from [src].</span>", "<span class='italics'>You hear clicking.</span>")
 				playsound(loc, W.usesound, 100, 1)
@@ -159,7 +149,7 @@
 				switch(fixture_type)
 					if("tube")
 						newlight = new /obj/machinery/light/built(loc)
-					if ("bulb")
+					if("bulb")
 						newlight = new /obj/machinery/light/small/built(loc)
 				newlight.setDir(dir)
 				transfer_fingerprints_to(newlight)

--- a/code/modules/power/singularity/emitter.dm
+++ b/code/modules/power/singularity/emitter.dm
@@ -221,16 +221,15 @@
 		else
 			state = EM_UNSECURED
 
-/obj/machinery/power/emitter/attackby(obj/item/W, mob/user, params)
-	if(istype(W, /obj/item/wrench))
+/obj/machinery/power/emitter/attackby(obj/item/I, mob/user, params)
+	if(istype(I, /obj/item/wrench))
 		if(active)
 			to_chat(user, "<span class='warning'>Turn \the [src] off first!</span>")
 			return
-		default_unfasten_wrench(user, W, 0)
+		default_unfasten_wrench(user, I, 0)
 		return
 
-	if(istype(W, /obj/item/weldingtool))
-		var/obj/item/weldingtool/WT = W
+	if(istype(I, /obj/item/weldingtool))
 		if(active)
 			to_chat(user, "Turn \the [src] off first.")
 			return
@@ -238,28 +237,28 @@
 			if(EM_UNSECURED)
 				to_chat(user, "<span class='warning'>The [src.name] needs to be wrenched to the floor!</span>")
 			if(EM_SECURED)
-				if(WT.remove_fuel(0,user))
-					playsound(loc, WT.usesound, 50, 1)
-					user.visible_message("[user.name] starts to weld the [name] to the floor.", \
-						"<span class='notice'>You start to weld \the [src] to the floor...</span>", \
-						"<span class='italics'>You hear welding.</span>")
-					if(do_after(user,20*W.toolspeed, target = src) && WT.isOn())
-						state = EM_WELDED
-						to_chat(user, "<span class='notice'>You weld \the [src] to the floor.</span>")
-						connect_to_network()
+				if(!I.tool_start_check(user, amount=0))
+					return
+				user.visible_message("[user.name] starts to weld the [name] to the floor.", \
+					"<span class='notice'>You start to weld \the [src] to the floor...</span>", \
+					"<span class='italics'>You hear welding.</span>")
+				if(I.use_tool(src, user, 20, volume=50))
+					state = EM_WELDED
+					to_chat(user, "<span class='notice'>You weld \the [src] to the floor.</span>")
+					connect_to_network()
 			if(EM_WELDED)
-				if(WT.remove_fuel(0,user))
-					playsound(loc, WT.usesound, 50, 1)
-					user.visible_message("[user.name] starts to cut the [name] free from the floor.", \
-						"<span class='notice'>You start to cut \the [src] free from the floor...</span>", \
-						"<span class='italics'>You hear welding.</span>")
-					if(do_after(user,20*W.toolspeed, target = src) && WT.isOn())
-						state = EM_SECURED
-						to_chat(user, "<span class='notice'>You cut \the [src] free from the floor.</span>")
-						disconnect_from_network()
+				if(!I.tool_start_check(user, amount=0))
+					return
+				user.visible_message("[user.name] starts to cut the [name] free from the floor.", \
+					"<span class='notice'>You start to cut \the [src] free from the floor...</span>", \
+					"<span class='italics'>You hear welding.</span>")
+				if(I.use_tool(src, user, 20, volume=50))
+					state = EM_SECURED
+					to_chat(user, "<span class='notice'>You cut \the [src] free from the floor.</span>")
+					disconnect_from_network()
 		return
 
-	if(W.GetID())
+	if(I.GetID())
 		if(obj_flags & EMAGGED)
 			to_chat(user, "<span class='warning'>The lock seems to be broken!</span>")
 			return
@@ -273,20 +272,20 @@
 			to_chat(user, "<span class='danger'>Access denied.</span>")
 		return
 
-	if(is_wire_tool(W) && panel_open)
+	if(is_wire_tool(I) && panel_open)
 		wires.interact(user)
 		return
 
-	if(default_deconstruction_screwdriver(user, "emitter_open", "emitter", W))
+	if(default_deconstruction_screwdriver(user, "emitter_open", "emitter", I))
 		return
 
-	if(exchange_parts(user, W))
+	if(exchange_parts(user, I))
 		return
 
-	if(default_pry_open(W))
+	if(default_pry_open(I))
 		return
 
-	if(default_deconstruction_crowbar(W))
+	if(default_deconstruction_crowbar(I))
 		return
 
 	return ..()

--- a/code/modules/power/singularity/emitter.dm
+++ b/code/modules/power/singularity/emitter.dm
@@ -207,10 +207,16 @@
 	return P
 
 /obj/machinery/power/emitter/can_be_unfasten_wrench(mob/user, silent)
-	if(state == EM_WELDED)
+	if(active)
+		if(!silent)
+			to_chat(user, "<span class='warning'>Turn \the [src] off first!</span>")
+		return FAILED_UNFASTEN
+
+	else if(state == EM_WELDED)
 		if(!silent)
 			to_chat(user, "<span class='warning'>[src] is welded to the floor!</span>")
 		return FAILED_UNFASTEN
+
 	return ..()
 
 /obj/machinery/power/emitter/default_unfasten_wrench(mob/user, obj/item/wrench/W, time = 20)
@@ -221,43 +227,51 @@
 		else
 			state = EM_UNSECURED
 
+/obj/machinery/power/emitter/wrench_act(mob/living/user, obj/item/I)
+	default_unfasten_wrench(user, I, 0)
+	return TRUE
+
+/obj/machinery/power/emitter/welder_act(mob/living/user, obj/item/I)
+	if(active)
+		to_chat(user, "Turn \the [src] off first.")
+		return TRUE
+
+	switch(state)
+		if(EM_UNSECURED)
+			to_chat(user, "<span class='warning'>The [src.name] needs to be wrenched to the floor!</span>")
+		if(EM_SECURED)
+			if(!I.tool_start_check(user, amount=0))
+				return TRUE
+			user.visible_message("[user.name] starts to weld the [name] to the floor.", \
+				"<span class='notice'>You start to weld \the [src] to the floor...</span>", \
+				"<span class='italics'>You hear welding.</span>")
+			if(I.use_tool(src, user, 20, volume=50))
+				state = EM_WELDED
+				to_chat(user, "<span class='notice'>You weld \the [src] to the floor.</span>")
+				connect_to_network()
+		if(EM_WELDED)
+			if(!I.tool_start_check(user, amount=0))
+				return TRUE
+			user.visible_message("[user.name] starts to cut the [name] free from the floor.", \
+				"<span class='notice'>You start to cut \the [src] free from the floor...</span>", \
+				"<span class='italics'>You hear welding.</span>")
+			if(I.use_tool(src, user, 20, volume=50))
+				state = EM_SECURED
+				to_chat(user, "<span class='notice'>You cut \the [src] free from the floor.</span>")
+				disconnect_from_network()
+
+	return TRUE
+
+/obj/machinery/power/emitter/crowbar_act(mob/living/user, obj/item/I)
+	default_deconstruction_crowbar(I)
+	return TRUE
+
+/obj/machinery/power/emitter/screwdriver_act(mob/living/user, obj/item/I)
+	default_deconstruction_screwdriver(user, "emitter_open", "emitter", I)
+	return TRUE
+
+
 /obj/machinery/power/emitter/attackby(obj/item/I, mob/user, params)
-	if(istype(I, /obj/item/wrench))
-		if(active)
-			to_chat(user, "<span class='warning'>Turn \the [src] off first!</span>")
-			return
-		default_unfasten_wrench(user, I, 0)
-		return
-
-	if(istype(I, /obj/item/weldingtool))
-		if(active)
-			to_chat(user, "Turn \the [src] off first.")
-			return
-		switch(state)
-			if(EM_UNSECURED)
-				to_chat(user, "<span class='warning'>The [src.name] needs to be wrenched to the floor!</span>")
-			if(EM_SECURED)
-				if(!I.tool_start_check(user, amount=0))
-					return
-				user.visible_message("[user.name] starts to weld the [name] to the floor.", \
-					"<span class='notice'>You start to weld \the [src] to the floor...</span>", \
-					"<span class='italics'>You hear welding.</span>")
-				if(I.use_tool(src, user, 20, volume=50))
-					state = EM_WELDED
-					to_chat(user, "<span class='notice'>You weld \the [src] to the floor.</span>")
-					connect_to_network()
-			if(EM_WELDED)
-				if(!I.tool_start_check(user, amount=0))
-					return
-				user.visible_message("[user.name] starts to cut the [name] free from the floor.", \
-					"<span class='notice'>You start to cut \the [src] free from the floor...</span>", \
-					"<span class='italics'>You hear welding.</span>")
-				if(I.use_tool(src, user, 20, volume=50))
-					state = EM_SECURED
-					to_chat(user, "<span class='notice'>You cut \the [src] free from the floor.</span>")
-					disconnect_from_network()
-		return
-
 	if(I.GetID())
 		if(obj_flags & EMAGGED)
 			to_chat(user, "<span class='warning'>The lock seems to be broken!</span>")
@@ -272,20 +286,11 @@
 			to_chat(user, "<span class='danger'>Access denied.</span>")
 		return
 
-	if(is_wire_tool(I) && panel_open)
+	else if(is_wire_tool(I) && panel_open)
 		wires.interact(user)
 		return
 
-	if(default_deconstruction_screwdriver(user, "emitter_open", "emitter", I))
-		return
-
-	if(exchange_parts(user, I))
-		return
-
-	if(default_pry_open(I))
-		return
-
-	if(default_deconstruction_crowbar(I))
+	else if(exchange_parts(user, I))
 		return
 
 	return ..()

--- a/code/modules/power/singularity/field_generator.dm
+++ b/code/modules/power/singularity/field_generator.dm
@@ -77,10 +77,16 @@ field_generator power level display
 		to_chat(user, "<span class='warning'>[src] needs to be firmly secured to the floor first!</span>")
 
 /obj/machinery/field/generator/can_be_unfasten_wrench(mob/user, silent)
-	if(state == FG_WELDED)
+	if(active)
+		if(!silent)
+			to_chat(user, "<span class='warning'>Turn \the [src] off first!</span>")
+		return FAILED_UNFASTEN
+
+	else if(state == FG_WELDED)
 		if(!silent)
 			to_chat(user, "<span class='warning'>[src] is welded to the floor!</span>")
 		return FAILED_UNFASTEN
+
 	return ..()
 
 /obj/machinery/field/generator/default_unfasten_wrench(mob/user, obj/item/wrench/W, time = 20)
@@ -91,40 +97,41 @@ field_generator power level display
 		else
 			state = FG_UNSECURED
 
-/obj/machinery/field/generator/attackby(obj/item/I, mob/user, params)
+/obj/machinery/field/generator/wrench_act(mob/living/user, obj/item/I)
+	default_unfasten_wrench(user, I, 0)
+	return TRUE
+
+/obj/machinery/field/generator/welder_act(mob/living/user, obj/item/I)
 	if(active)
 		to_chat(user, "<span class='warning'>[src] needs to be off!</span>")
-		return
-	else if(istype(I, /obj/item/wrench))
-		default_unfasten_wrench(user, I, 0)
+		return TRUE
 
-	else if(istype(I, /obj/item/weldingtool))
-		switch(state)
-			if(FG_UNSECURED)
-				to_chat(user, "<span class='warning'>[src] needs to be wrenched to the floor!</span>")
+	switch(state)
+		if(FG_UNSECURED)
+			to_chat(user, "<span class='warning'>[src] needs to be wrenched to the floor!</span>")
 
-			if(FG_SECURED)
-				if(!I.tool_start_check(user, amount=0))
-					return
-				user.visible_message("[user] starts to weld [src] to the floor.", \
-					"<span class='notice'>You start to weld \the [src] to the floor...</span>", \
-					"<span class='italics'>You hear welding.</span>")
-				if(I.use_tool(src, user, 20, volume=50) && state == FG_SECURED)
-					state = FG_WELDED
-					to_chat(user, "<span class='notice'>You weld the field generator to the floor.</span>")
+		if(FG_SECURED)
+			if(!I.tool_start_check(user, amount=0))
+				return TRUE
+			user.visible_message("[user] starts to weld [src] to the floor.", \
+				"<span class='notice'>You start to weld \the [src] to the floor...</span>", \
+				"<span class='italics'>You hear welding.</span>")
+			if(I.use_tool(src, user, 20, volume=50) && state == FG_SECURED)
+				state = FG_WELDED
+				to_chat(user, "<span class='notice'>You weld the field generator to the floor.</span>")
 
-			if(FG_WELDED)
-				if(!I.tool_start_check(user, amount=0))
-					return
-				user.visible_message("[user] starts to cut [src] free from the floor.", \
-					"<span class='notice'>You start to cut \the [src] free from the floor...</span>", \
-					"<span class='italics'>You hear welding.</span>")
-				if(I.use_tool(src, user, 20, volume=50) && state == FG_WELDED)
-					state = FG_SECURED
-					to_chat(user, "<span class='notice'>You cut \the [src] free from the floor.</span>")
+		if(FG_WELDED)
+			if(!I.tool_start_check(user, amount=0))
+				return TRUE
+			user.visible_message("[user] starts to cut [src] free from the floor.", \
+				"<span class='notice'>You start to cut \the [src] free from the floor...</span>", \
+				"<span class='italics'>You hear welding.</span>")
+			if(I.use_tool(src, user, 20, volume=50) && state == FG_WELDED)
+				state = FG_SECURED
+				to_chat(user, "<span class='notice'>You cut \the [src] free from the floor.</span>")
 
-	else
-		return ..()
+	return TRUE
+
 
 /obj/machinery/field/generator/attack_animal(mob/living/simple_animal/M)
 	if(M.environment_smash & ENVIRONMENT_SMASH_RWALLS && active == FG_OFFLINE && state != FG_UNSECURED)

--- a/code/modules/power/singularity/field_generator.dm
+++ b/code/modules/power/singularity/field_generator.dm
@@ -91,38 +91,37 @@ field_generator power level display
 		else
 			state = FG_UNSECURED
 
-/obj/machinery/field/generator/attackby(obj/item/W, mob/user, params)
+/obj/machinery/field/generator/attackby(obj/item/I, mob/user, params)
 	if(active)
 		to_chat(user, "<span class='warning'>[src] needs to be off!</span>")
 		return
-	else if(istype(W, /obj/item/wrench))
-		default_unfasten_wrench(user, W, 0)
+	else if(istype(I, /obj/item/wrench))
+		default_unfasten_wrench(user, I, 0)
 
-	else if(istype(W, /obj/item/weldingtool))
-		var/obj/item/weldingtool/WT = W
+	else if(istype(I, /obj/item/weldingtool))
 		switch(state)
 			if(FG_UNSECURED)
 				to_chat(user, "<span class='warning'>[src] needs to be wrenched to the floor!</span>")
 
 			if(FG_SECURED)
-				if (WT.remove_fuel(0,user))
-					playsound(loc, WT.usesound, 50, 1)
-					user.visible_message("[user] starts to weld [src] to the floor.", \
-						"<span class='notice'>You start to weld \the [src] to the floor...</span>", \
-						"<span class='italics'>You hear welding.</span>")
-					if(do_after(user,20*W.toolspeed, target = src) && state == FG_SECURED && WT.isOn())
-						state = FG_WELDED
-						to_chat(user, "<span class='notice'>You weld the field generator to the floor.</span>")
+				if(!I.tool_start_check(user, amount=0))
+					return
+				user.visible_message("[user] starts to weld [src] to the floor.", \
+					"<span class='notice'>You start to weld \the [src] to the floor...</span>", \
+					"<span class='italics'>You hear welding.</span>")
+				if(I.use_tool(src, user, 20, volume=50) && state == FG_SECURED)
+					state = FG_WELDED
+					to_chat(user, "<span class='notice'>You weld the field generator to the floor.</span>")
 
 			if(FG_WELDED)
-				if (WT.remove_fuel(0,user))
-					playsound(loc, WT.usesound, 50, 1)
-					user.visible_message("[user] starts to cut [src] free from the floor.", \
-						"<span class='notice'>You start to cut \the [src] free from the floor...</span>", \
-						"<span class='italics'>You hear welding.</span>")
-					if(do_after(user,20*W.toolspeed, target = src) && state == FG_WELDED && WT.isOn())
-						state = FG_SECURED
-						to_chat(user, "<span class='notice'>You cut \the [src] free from the floor.</span>")
+				if(!I.tool_start_check(user, amount=0))
+					return
+				user.visible_message("[user] starts to cut [src] free from the floor.", \
+					"<span class='notice'>You start to cut \the [src] free from the floor...</span>", \
+					"<span class='italics'>You hear welding.</span>")
+				if(I.use_tool(src, user, 20, volume=50) && state == FG_WELDED)
+					state = FG_SECURED
+					to_chat(user, "<span class='notice'>You cut \the [src] free from the floor.</span>")
 
 	else
 		return ..()

--- a/code/modules/power/solar.dm
+++ b/code/modules/power/solar.dm
@@ -56,16 +56,14 @@
 		obj_integrity = max_integrity
 	update_icon()
 
-/obj/machinery/power/solar/attackby(obj/item/W, mob/user, params)
-	if(istype(W, /obj/item/crowbar))
-		playsound(src.loc, 'sound/machines/click.ogg', 50, 1)
-		user.visible_message("[user] begins to take the glass off the solar panel.", "<span class='notice'>You begin to take the glass off the solar panel...</span>")
-		if(do_after(user, 50*W.toolspeed, target = src))
-			playsound(src.loc, 'sound/items/deconstruct.ogg', 50, 1)
-			user.visible_message("[user] takes the glass off the solar panel.", "<span class='notice'>You take the glass off the solar panel.</span>")
-			deconstruct(TRUE)
-	else
-		return ..()
+/obj/machinery/power/solar/crowbar_act(mob/user, obj/item/I)
+	playsound(src.loc, 'sound/machines/click.ogg', 50, 1)
+	user.visible_message("[user] begins to take the glass off [src].", "<span class='notice'>You begin to take the glass off [src]...</span>")
+	if(I.use_tool(src, user, 50))
+		playsound(src.loc, 'sound/items/deconstruct.ogg', 50, 1)
+		user.visible_message("[user] takes the glass off [src].", "<span class='notice'>You take the glass off [src].</span>")
+		deconstruct(TRUE)
+	return TRUE
 
 /obj/machinery/power/solar/play_attack_sound(damage_amount, damage_type = BRUTE, damage_flag = 0)
 	switch(damage_type)
@@ -407,8 +405,7 @@
 
 /obj/machinery/power/solar_control/attackby(obj/item/I, mob/user, params)
 	if(istype(I, /obj/item/screwdriver))
-		playsound(src.loc, I.usesound, 50, 1)
-		if(do_after(user, 20*I.toolspeed, target = src))
+		if(I.use_tool(src, user, 20, volume=50))
 			if (src.stat & BROKEN)
 				to_chat(user, "<span class='notice'>The broken glass falls out.</span>")
 				var/obj/structure/frame/computer/A = new /obj/structure/frame/computer( src.loc )

--- a/code/modules/power/supermatter/supermatter.dm
+++ b/code/modules/power/supermatter/supermatter.dm
@@ -538,19 +538,11 @@ GLOBAL_DATUM(main_supermatter_engine, /obj/machinery/power/supermatter_shard)
 	if(!istype(W) || (W.flags_1 & ABSTRACT_1) || !istype(user))
 		return
 	if(istype(W, /obj/item/scalpel/supermatter))
-		var/obj/item/scalpel/supermatter/scalpel = W
-		playsound(src, W.usesound, 100, 1)
-		to_chat(user, "<span class='notice'>You carefully begin to scrape [src] with [W]...</span>")
-		if(do_after(user, 60 * W.toolspeed, TRUE, src))
-			if (scalpel.usesLeft)
-				to_chat(user, "<span class='notice'>You extract a sliver from [src]. [src] begins to react violently!</span>")
-				new /obj/item/nuke_core/supermatter_sliver(drop_location())
-				matter_power += 200
-				scalpel.usesLeft--
-				if (!scalpel.usesLeft) 
-					to_chat(user, "<span class='notice'>A tiny piece of [W] falls off, rendering it useless!</span>")
-			else 
-				to_chat(user, "<span class='notice'>You fail to extract a sliver from [src]. [W] isn't sharp enough anymore!</span>")
+		to_chat(user, "<span class='notice'>You carefully begin to scrape \the [src] with \the [W]...</span>")
+		if(W.use_tool(src, user, 60, volume=100))
+			to_chat(user, "<span class='notice'>You extract a sliver from \the [src]. \The [src] begins to react violently!</span>")
+			new /obj/item/nuke_core/supermatter_sliver(drop_location())
+			matter_power += 200
 	else if(user.dropItemToGround(W))
 		user.visible_message("<span class='danger'>As [user] touches \the [src] with \a [W], silence fills the room...</span>",\
 			"<span class='userdanger'>You touch \the [src] with \the [W], and everything suddenly goes silent.</span>\n<span class='notice'>\The [W] flashes into dust as you flinch away from \the [src].</span>",\

--- a/code/modules/power/terminal.dm
+++ b/code/modules/power/terminal.dm
@@ -48,26 +48,31 @@
 		. = 1
 
 
-/obj/machinery/power/terminal/proc/dismantle(mob/living/user, obj/item/W)
+/obj/machinery/power/terminal/proc/dismantle(mob/living/user, obj/item/I)
 	if(isturf(loc))
 		var/turf/T = loc
 		if(T.intact)
 			to_chat(user, "<span class='warning'>You must first expose the power terminal!</span>")
 			return
 
-		if(!master || master.can_terminal_dismantle())
-			user.visible_message("[user.name] dismantles the power terminal from [master].", \
-								"<span class='notice'>You begin to cut the cables...</span>")
+	if(master && !master.can_terminal_dismantle())
+		return
 
-			playsound(src.loc, 'sound/items/deconstruct.ogg', 50, 1)
-			if(do_after(user, 50*W.toolspeed, target = src))
-				if(!master || master.can_terminal_dismantle())
-					if(prob(50) && electrocute_mob(user, powernet, src, 1, TRUE))
-						do_sparks(5, TRUE, master)
-						return
-					new /obj/item/stack/cable_coil(loc, 10)
-					to_chat(user, "<span class='notice'>You cut the cables and dismantle the power terminal.</span>")
-					qdel(src)
+	user.visible_message("[user.name] dismantles the power terminal from [master].",
+		"<span class='notice'>You begin to cut the cables...</span>")
+
+	playsound(src.loc, 'sound/items/deconstruct.ogg', 50, 1)
+	if(I.use_tool(src, user, 50))
+		if(master && !master.can_terminal_dismantle())
+			return
+
+		if(prob(50) && electrocute_mob(user, powernet, src, 1, TRUE))
+			do_sparks(5, TRUE, master)
+			return
+
+		new /obj/item/stack/cable_coil(drop_location(), 10)
+		to_chat(user, "<span class='notice'>You cut the cables and dismantle the power terminal.</span>")
+		qdel(src)
 
 
 /obj/machinery/power/terminal/attackby(obj/item/W, mob/living/user, params)

--- a/code/modules/power/tracker.dm
+++ b/code/modules/power/tracker.dm
@@ -60,17 +60,14 @@
 	if(powernet && (powernet == control.powernet)) //update if we're still in the same powernet
 		control.currentdir = angle
 
-/obj/machinery/power/tracker/attackby(obj/item/W, mob/user, params)
-
-	if(istype(W, /obj/item/crowbar))
-		playsound(src.loc, 'sound/machines/click.ogg', 50, 1)
-		user.visible_message("[user] begins to take the glass off the solar tracker.", "<span class='notice'>You begin to take the glass off the solar tracker...</span>")
-		if(do_after(user, 50*W.toolspeed, target = src))
-			playsound(src.loc, 'sound/items/deconstruct.ogg', 50, 1)
-			user.visible_message("[user] takes the glass off the tracker.", "<span class='notice'>You take the glass off the tracker.</span>")
-			deconstruct(TRUE)
-	else
-		return ..()
+/obj/machinery/power/tracker/crowbar_act(mob/user, obj/item/I)
+	playsound(src.loc, 'sound/machines/click.ogg', 50, 1)
+	user.visible_message("[user] begins to take the glass off [src].", "<span class='notice'>You begin to take the glass off [src]...</span>")
+	if(I.use_tool(src, user, 50))
+		playsound(src.loc, 'sound/items/deconstruct.ogg', 50, 1)
+		user.visible_message("[user] takes the glass off [src].", "<span class='notice'>You take the glass off [src].</span>")
+		deconstruct(TRUE)
+	return TRUE
 
 /obj/machinery/power/tracker/obj_break(damage_flag)
 	if(!(stat & BROKEN) && !(flags_1 & NODECONSTRUCT_1))

--- a/code/modules/projectiles/guns/ballistic/revolver.dm
+++ b/code/modules/projectiles/guns/ballistic/revolver.dm
@@ -107,35 +107,34 @@
 			return 0
 	..()
 
-/obj/item/gun/ballistic/revolver/detective/attackby(obj/item/A, mob/user, params)
-	..()
-	if(istype(A, /obj/item/screwdriver))
-		if(magazine.caliber == "38")
-			to_chat(user, "<span class='notice'>You begin to reinforce the barrel of [src]...</span>")
+/obj/item/gun/ballistic/revolver/detective/screwdriver_act(mob/living/user, obj/item/I)
+	if(magazine.caliber == "38")
+		to_chat(user, "<span class='notice'>You begin to reinforce the barrel of [src]...</span>")
+		if(magazine.ammo_count())
+			afterattack(user, user)	//you know the drill
+			user.visible_message("<span class='danger'>[src] goes off!</span>", "<span class='userdanger'>[src] goes off in your face!</span>")
+			return TRUE
+		if(I.use_tool(src, user, 30))
 			if(magazine.ammo_count())
-				afterattack(user, user)	//you know the drill
-				user.visible_message("<span class='danger'>[src] goes off!</span>", "<span class='userdanger'>[src] goes off in your face!</span>")
-				return
-			if(do_after(user, 30*A.toolspeed, target = src))
-				if(magazine.ammo_count())
-					to_chat(user, "<span class='warning'>You can't modify it!</span>")
-					return
-				magazine.caliber = "357"
-				desc = "The barrel and chamber assembly seems to have been modified."
-				to_chat(user, "<span class='notice'>You reinforce the barrel of [src]. Now it will fire .357 rounds.</span>")
-		else
-			to_chat(user, "<span class='notice'>You begin to revert the modifications to [src]...</span>")
+				to_chat(user, "<span class='warning'>You can't modify it!</span>")
+				return TRUE
+			magazine.caliber = "357"
+			desc = "The barrel and chamber assembly seems to have been modified."
+			to_chat(user, "<span class='notice'>You reinforce the barrel of [src]. Now it will fire .357 rounds.</span>")
+	else
+		to_chat(user, "<span class='notice'>You begin to revert the modifications to [src]...</span>")
+		if(magazine.ammo_count())
+			afterattack(user, user)	//and again
+			user.visible_message("<span class='danger'>[src] goes off!</span>", "<span class='userdanger'>[src] goes off in your face!</span>")
+			return TRUE
+		if(I.use_tool(src, user, 30))
 			if(magazine.ammo_count())
-				afterattack(user, user)	//and again
-				user.visible_message("<span class='danger'>[src] goes off!</span>", "<span class='userdanger'>[src] goes off in your face!</span>")
+				to_chat(user, "<span class='warning'>You can't modify it!</span>")
 				return
-			if(do_after(user, 30*A.toolspeed, target = src))
-				if(magazine.ammo_count())
-					to_chat(user, "<span class='warning'>You can't modify it!</span>")
-					return
-				magazine.caliber = "38"
-				desc = initial(desc)
-				to_chat(user, "<span class='notice'>You remove the modifications on [src]. Now it will fire .38 rounds.</span>")
+			magazine.caliber = "38"
+			desc = initial(desc)
+			to_chat(user, "<span class='notice'>You remove the modifications on [src]. Now it will fire .38 rounds.</span>")
+	return TRUE
 
 
 /obj/item/gun/ballistic/revolver/mateba

--- a/code/modules/projectiles/guns/energy/special.dm
+++ b/code/modules/projectiles/guns/energy/special.dm
@@ -136,19 +136,28 @@
 	if(cell)
 		to_chat(user, "<span class='notice'>[src] is [round(cell.percent())]% charged.</span>")
 
-/obj/item/gun/energy/plasmacutter/attackby(obj/item/A, mob/user)
-	if(istype(A, /obj/item/stack/sheet/mineral/plasma))
-		var/obj/item/stack/sheet/S = A
-		S.use(1)
+/obj/item/gun/energy/plasmacutter/attackby(obj/item/I, mob/user)
+	if(istype(I, /obj/item/stack/sheet/mineral/plasma))
+		I.use(1)
 		cell.give(1000)
-		to_chat(user, "<span class='notice'>You insert [A] in [src], recharging it.</span>")
-	else if(istype(A, /obj/item/stack/ore/plasma))
-		var/obj/item/stack/ore/S = A
-		S.use(1)
+		to_chat(user, "<span class='notice'>You insert [I] in [src], recharging it.</span>")
+	else if(istype(I, /obj/item/stack/ore/plasma))
+		I.use(1)
 		cell.give(500)
-		to_chat(user, "<span class='notice'>You insert [A] in [src], recharging it.</span>")
+		to_chat(user, "<span class='notice'>You insert [I] in [src], recharging it.</span>")
 	else
 		..()
+
+// Tool procs, in case plasma cutter is used as welder
+/obj/item/gun/energy/plasmacutter/tool_use_check(mob/living/user, amount)
+	if(cell.charge >= amount * 100)
+		return TRUE
+
+	to_chat(user, "<span class='warning'>You need more charge to complete this task!</span>")
+	return FALSE
+
+/obj/item/gun/energy/plasmacutter/use(amount)
+	return cell.use(amount * 100)
 
 /obj/item/gun/energy/plasmacutter/update_icon()
 	return

--- a/code/modules/recycling/conveyor2.dm
+++ b/code/modules/recycling/conveyor2.dm
@@ -118,9 +118,7 @@
 	if(istype(I, /obj/item/crowbar))
 		user.visible_message("<span class='notice'>[user] struggles to pry up \the [src] with \the [I].</span>", \
 		"<span class='notice'>You struggle to pry up \the [src] with \the [I].</span>")
-		if(do_after(user, 40*I.toolspeed, target = src))
-			if(QDELETED(src))
-				return //prevent multiple decontructs
+		if(I.use_tool(src, user, 40, volume=40))
 			if(!(stat & BROKEN))
 				var/obj/item/conveyor_construct/C = new/obj/item/conveyor_construct(src.loc)
 				C.id = id

--- a/code/modules/recycling/disposal/bin.dm
+++ b/code/modules/recycling/disposal/bin.dm
@@ -86,15 +86,14 @@
 			to_chat(user, "<span class='notice'>You [panel_open ? "remove":"attach"] the screws around the power connection.</span>")
 			return
 		else if(istype(I, /obj/item/weldingtool) && panel_open)
-			var/obj/item/weldingtool/W = I
-			if(W.remove_fuel(0,user))
-				playsound(src.loc, 'sound/items/welder2.ogg', 100, 1)
-				to_chat(user, "<span class='notice'>You start slicing the floorweld off \the [src]...</span>")
-				if(do_after(user,20*I.toolspeed, target = src) && panel_open)
-					if(!W.isOn())
-						return
-					to_chat(user, "<span class='notice'>You slice the floorweld off \the [src].</span>")
-					deconstruct()
+			if(!I.tool_start_check(user, amount=0))
+				return
+
+			playsound(src.loc, 'sound/items/welder2.ogg', 100, 1)
+			to_chat(user, "<span class='notice'>You start slicing the floorweld off \the [src]...</span>")
+			if(I.use_tool(src, user, 20) && panel_open)
+				to_chat(user, "<span class='notice'>You slice the floorweld off \the [src].</span>")
+				deconstruct()
 			return
 
 	if(user.a_intent != INTENT_HARM)

--- a/code/modules/recycling/disposal/construction.dm
+++ b/code/modules/recycling/disposal/construction.dm
@@ -160,19 +160,16 @@
 
 	else if(istype(I, /obj/item/weldingtool))
 		if(anchored)
-			var/obj/item/weldingtool/W = I
-			if(W.remove_fuel(0,user))
-				playsound(src, I.usesound, 50, 1)
-				to_chat(user, "<span class='notice'>You start welding the [pipename] in place...</span>")
-				if(do_after(user, 8*I.toolspeed, target = src))
-					if(!loc || !W.isOn())
-						return
-					to_chat(user, "<span class='notice'>The [pipename] has been welded in place.</span>")
+			if(!I.tool_start_check(user, amount=0))
+				return
 
-					var/obj/O = new pipe_type(loc, src)
-					transfer_fingerprints_to(O)
+			to_chat(user, "<span class='notice'>You start welding the [pipename] in place...</span>")
+			if(I.use_tool(src, user, 8, volume=50))
+				to_chat(user, "<span class='notice'>The [pipename] has been welded in place.</span>")
+				var/obj/O = new pipe_type(loc, src)
+				transfer_fingerprints_to(O)
 
-					return
+			return
 		else
 			to_chat(user, "<span class='warning'>You need to attach it to the plating first!</span>")
 			return

--- a/code/modules/recycling/disposal/outlet.dm
+++ b/code/modules/recycling/disposal/outlet.dm
@@ -69,21 +69,16 @@
 	H.vent_gas(T)
 	qdel(H)
 
+/obj/structure/disposaloutlet/welder_act(mob/living/user, obj/item/I)
+	if(!I.tool_start_check(user, amount=0))
+		return TRUE
 
-/obj/structure/disposaloutlet/attackby(obj/item/I, mob/user, params)
-	add_fingerprint(user)
-	if(istype(I, /obj/item/weldingtool))
-		var/obj/item/weldingtool/W = I
-		if(W.remove_fuel(0,user))
-			playsound(src, 'sound/items/welder2.ogg', 100, 1)
-			to_chat(user, "<span class='notice'>You start slicing the floorweld off [src]...</span>")
-			if(do_after(user, 20*I.toolspeed, target = src))
-				if(!W.isOn())
-					return
-				to_chat(user, "<span class='notice'>You slice the floorweld off [src].</span>")
-				stored.forceMove(loc)
-				transfer_fingerprints_to(stored)
-				stored = null
-				qdel(src)
-	else
-		return ..()
+	playsound(src, 'sound/items/welder2.ogg', 100, 1)
+	to_chat(user, "<span class='notice'>You start slicing the floorweld off [src]...</span>")
+	if(I.use_tool(src, user, 20))
+		to_chat(user, "<span class='notice'>You slice the floorweld off [src].</span>")
+		stored.forceMove(loc)
+		transfer_fingerprints_to(stored)
+		stored = null
+		qdel(src)
+	return TRUE

--- a/code/modules/recycling/disposal/pipe.dm
+++ b/code/modules/recycling/disposal/pipe.dm
@@ -141,26 +141,19 @@
 	return ..()
 
 
-//attack by item
-//weldingtool: unfasten and convert to obj/disposalconstruct
-/obj/structure/disposalpipe/attackby(obj/item/I, mob/user, params)
-	add_fingerprint(user)
-	if(istype(I, /obj/item/weldingtool))
-		if(!can_be_deconstructed(user))
-			return
+//welding tool: unfasten and convert to obj/disposalconstruct
+/obj/structure/disposalpipe/welder_act(mob/living/user, obj/item/I)
+	if(!can_be_deconstructed(user))
+		return TRUE
 
-		var/obj/item/weldingtool/W = I
-		if(W.remove_fuel(0, user))
-			playsound(src, I.usesound, 50, 1)
-			to_chat(user, "<span class='notice'>You start slicing [src]...</span>")
-			// check if anything changed over 2 seconds
-			if(do_after(user, 30*I.toolspeed, target = src))
-				if(!W.isOn())
-					return
-				deconstruct()
-				to_chat(user, "<span class='notice'>You slice [src].</span>")
-	else
-		return ..()
+	if(!I.tool_start_check(user, amount=0))
+		return TRUE
+
+	to_chat(user, "<span class='notice'>You start slicing [src]...</span>")
+	if(I.use_tool(src, user, 30, volume=50))
+		deconstruct()
+		to_chat(user, "<span class='notice'>You slice [src].</span>")
+	return TRUE
 
 //checks if something is blocking the deconstruction (e.g. trunk with a bin still linked to it)
 /obj/structure/disposalpipe/proc/can_be_deconstructed()

--- a/code/modules/vehicles/scooter.dm
+++ b/code/modules/vehicles/scooter.dm
@@ -12,10 +12,9 @@
 /obj/vehicle/ridden/scooter/attackby(obj/item/I, mob/user, params)
 	if(istype(I, /obj/item/wrench))
 		to_chat(user, "<span class='notice'>You begin to remove the handlebars...</span>")
-		playsound(get_turf(user), 'sound/items/ratchet.ogg', 50, 1)
-		if(do_after(user, 40*I.toolspeed, target = src))
-			var/obj/vehicle/ridden/scooter/skateboard/S = new(loc)
-			new /obj/item/stack/rods(get_turf(src),2)
+		if(I.use_tool(src, user, 40, volume=50))
+			var/obj/vehicle/ridden/scooter/skateboard/S = new(drop_location())
+			new /obj/item/stack/rods(drop_location(), 2)
 			to_chat(user, "<span class='notice'>You remove the handlebars from [src].</span>")
 			if(has_buckled_mobs())
 				var/mob/living/carbon/H = buckled_mobs[1]


### PR DESCRIPTION
This PR replaces most of the `do_after` tool delays and the surrounding checks with just two procs: `tool_start_check` and `use_tool`.

**/obj/item/proc/tool_start_check(user, amount=0)**
Performs checks to determine if a tool is suitable to start an operation. Checks if things like welding tools or stacks have `amount` fuel/sheets in them, also handles tool-specific checks like welding tools being on and displays error messages to the user if any such checks fail. Applies tool-specifc effects such as welding tools blinding people.

It's safe to skip this proc for "dumb" tools (no possible checks) such as screwdrivers.


**/obj/item/proc/use_tool(target, user, delay, amount=0, volume=0, extra_checks)**
Actual tool usage. Handles the `do_after` delay (reduced by tool's `toolspeed`), runs `extra_checks`, amount checks and tool-specific checks on every tick of `do_after`, plays tool sound at `volume` at the beginning and at the end of tool use, uses up tool's fuel/sheets. Also runs `tool_start_check` if input delay is 0, as there is no reason to separate `use_tool` and `tool_start_check` unless you want to display a message between the two.

Example:
```
/obj/item/example/welder_act(mob/living/user, obj/item/I)
	if(!I.tool_start_check(user, amount=1))
		return TRUE

	user.visible_message("[user] is welding [src].",
		"<span class='notice'>You begin welding [src]...</span>",
		"<span class='italics'>You hear welding.</span>")

	if(I.use_tool(src, user, 40, volume=50, amount=1))
		to_chat(user, "<span class='notice'>You weld [src].</span>")
		<actual effect>
	return TRUE
```
Both procs are safe to use on any item, including all the regular tools. Amount checks work on all sheets, welding tools and plasma cutters (plasma cutters being common welder replacements).


This PR also throws in some code improvements I made when I was applying `use_tool`:
* Fixes some logic errors in construction/deconstruction procs.
* Multiple deconstruction procs now use `drop_location()`.
* Multiple deconstruction procs no longer manually set the amount on dropped stacks.
* Some simple `attack_by` procs that only used one tool are ported to `tool_act`.
* Some snowflake fastening/unfastening operations are changed to `default_unfasten_wrench`.

Test merge results:

Closes #35198.