### PR TITLE
Fixes a runtime on computer construction

### DIFF
--- a/code/game/machinery/computer/buildandrepair.dm
+++ b/code/game/machinery/computer/buildandrepair.dm
@@ -41,7 +41,7 @@
 					state = 0
 				return
 			if(istype(P, /obj/item/circuitboard/computer) && !circuit)
-				if(!user.transferItemToLoc(P, null))
+				if(!user.transferItemToLoc(P, src))
 					return
 				playsound(src, 'sound/items/deconstruct.ogg', 50, 1)
 				to_chat(user, "<span class='notice'>You place [P] inside the frame.</span>")


### PR DESCRIPTION
Seems like `transferItemToLoc` was changed at some point and `null` is no longer a valid target. Easy fix.