### PR TITLE
Refactored Database Preferences

### DIFF
--- a/SQL/database_changelog.txt
+++ b/SQL/database_changelog.txt
@@ -1,12 +1,27 @@
 Any time you make a change to the schema files, remember to increment the database schema version. Generally increment the minor number, major should be reserved for significant changes to the schema. Both values go up to 255.
 
-The latest database version is 4.0; The query to update the schema revision table is:
+The latest database version is 5.0; The query to update the schema revision table is:
 
-INSERT INTO `schema_revision` (`major`, `minor`) VALUES (4, 0);
+INSERT INTO `schema_revision` (`major`, `minor`) VALUES (5, 0);
 or
-INSERT INTO `SS13_schema_revision` (`major`, `minor`) VALUES (4, 0);
+INSERT INTO `SS13_schema_revision` (`major`, `minor`) VALUES (5, 0);
 
 In any query remember to add a prefix to the table names if you use one.
+
+----------------------------------------------------
+
+29 January 2018, by Cyberboss
+Added table `preferences`. Savefiles will automatically migrate.
+
+You can force them all to migrate at once by manually proc calling /proc/MassConvertPreferenceSavefiles (Requires R_PERMISSIONS)
+
+CREATE TABLE `preferences` (
+  `id` int(11) NOT NULL AUTO_INCREMENT,
+  `ckey` varchar(32) NOT NULL,
+  `json` json NOT NULL,
+  PRIMARY KEY (`id`),
+  KEY `ckey_idx` (`ckey`)
+) ENGINE=InnoDB;
 
 ----------------------------------------------------
 

--- a/SQL/tgstation_schema.sql
+++ b/SQL/tgstation_schema.sql
@@ -392,6 +392,22 @@ CREATE TABLE `poll_vote` (
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
+-- Table structure for table `preferences`
+--
+
+DROP TABLE IF EXISTS `preferences`;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8 */;
+CREATE TABLE `preferences` (
+  `id` int(11) NOT NULL AUTO_INCREMENT,
+  `ckey` varchar(32) NOT NULL,
+  `json` json NOT NULL,
+  PRIMARY KEY (`id`),
+  KEY `ckey_idx` (`ckey`)
+) ENGINE=InnoDB DEFAULT CHARSET=latin1;
+/*!40101 SET character_set_client = @saved_cs_client */;
+
+--
 -- Table structure for table `round`
 --
 DROP TABLE IF EXISTS `round`;

--- a/SQL/tgstation_schema_prefixed.sql
+++ b/SQL/tgstation_schema_prefixed.sql
@@ -392,6 +392,22 @@ CREATE TABLE `SS13_poll_vote` (
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
+-- Table structure for table `SS13_preferences`
+--
+
+DROP TABLE IF EXISTS `SS13_preferences`;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8 */;
+CREATE TABLE `SS13_preferences` (
+  `id` int(11) NOT NULL AUTO_INCREMENT,
+  `ckey` varchar(32) NOT NULL,
+  `json` json NOT NULL,
+  PRIMARY KEY (`id`),
+  KEY `ckey_idx` (`ckey`)
+) ENGINE=InnoDB DEFAULT CHARSET=latin1;
+/*!40101 SET character_set_client = @saved_cs_client */;
+
+--
 -- Table structure for table `SS13_round`
 --
 DROP TABLE IF EXISTS `SS13_round`;

--- a/code/__DEFINES/preferences.dm
+++ b/code/__DEFINES/preferences.dm
@@ -1,3 +1,5 @@
+#define PREFERENCES_SELECTED_SLOT_JSON "data/preference_slots.json"
+
 
 //Preference toggles
 #define SOUND_ADMINHELP	1

--- a/code/__DEFINES/subsystems.dm
+++ b/code/__DEFINES/subsystems.dm
@@ -1,6 +1,6 @@
 //Update this whenever the db schema changes
 //make sure you add an update to the schema_version stable in the db changelog
-#define DB_MAJOR_VERSION 4
+#define DB_MAJOR_VERSION 5
 #define DB_MINOR_VERSION 0
 
 //Timing subsystem

--- a/code/controllers/configuration/entries/general.dm
+++ b/code/controllers/configuration/entries/general.dm
@@ -73,8 +73,6 @@
 
 /datum/config_entry/flag/no_dead_vote	// dead people can't vote
 
-/datum/config_entry/flag/allow_metadata	// Metadata is supported.
-
 /datum/config_entry/flag/popup_admin_pm	// adminPMs to non-admins show in a pop-up 'reply' window when set
 
 /datum/config_entry/number/fps

--- a/code/modules/client/client_procs.dm
+++ b/code/modules/client/client_procs.dm
@@ -188,7 +188,6 @@ GLOBAL_LIST_EMPTY(external_rsc_urls)
 	prefs = GLOB.preferences_datums[ckey]
 	if(!prefs)
 		prefs = new /datum/preferences(src)
-		GLOB.preferences_datums[ckey] = prefs
 	prefs.last_ip = address				//these are gonna be used for banning
 	prefs.last_id = computer_id			//these are gonna be used for banning
 	fps = prefs.clientfps
@@ -366,6 +365,8 @@ GLOBAL_LIST_EMPTY(external_rsc_urls)
 	if(credits)
 		QDEL_LIST(credits)
 	log_access("Logout: [key_name(src)]")
+	if(prefs)
+		prefs.Save(FALSE)
 	if(holder)
 		adminGreet(1)
 		holder.owner = null

--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -17,7 +17,6 @@ GLOBAL_LIST_EMPTY(preferences_datums)
 	var/last_id
 
 	//game-preferences
-	var/lastchangelog = ""				//Saved changlog filesize to detect if there was a change
 	var/ooccolor = null
 	var/enable_tips = TRUE
 	var/tip_delay = 500 //tip delay in milliseconds
@@ -94,9 +93,6 @@ GLOBAL_LIST_EMPTY(preferences_datums)
 
 	// 0 = character settings, 1 = game preferences
 	var/current_tab = 0
-
-		// OOC Metadata:
-	var/metadata = ""
 
 	var/unlock_content = 0
 
@@ -393,8 +389,6 @@ GLOBAL_LIST_EMPTY(preferences_datums)
 			dat += "<b>Ghost pda:</b> <a href='?_src_=prefs;preference=ghost_pda'>[(chat_toggles & CHAT_GHOSTPDA) ? "All Messages" : "Nearest Creatures"]</a><br>"
 			dat += "<b>Pull requests:</b> <a href='?_src_=prefs;preference=pull_requests'>[(chat_toggles & CHAT_PULLR) ? "Yes" : "No"]</a><br>"
 			dat += "<b>Midround Antagonist:</b> <a href='?_src_=prefs;preference=allow_midround_antag'>[(toggles & MIDROUND_ANTAG) ? "Yes" : "No"]</a><br>"
-			if(CONFIG_GET(flag/allow_metadata))
-				dat += "<b>OOC Notes:</b> <a href='?_src_=prefs;preference=metadata;task=input'>Edit </a><br>"
 
 			if(user.client)
 				if(user.client.holder)
@@ -882,11 +876,6 @@ GLOBAL_LIST_EMPTY(preferences_datums)
 					var/new_age = input(user, "Choose your character's age:\n([AGE_MIN]-[AGE_MAX])", "Character Preference") as num|null
 					if(new_age)
 						age = max(min( round(text2num(new_age)), AGE_MAX),AGE_MIN)
-
-				if("metadata")
-					var/new_metadata = input(user, "Enter any information you'd like others to see, such as Roleplay-preferences:", "Game Preference" , metadata)  as message|null
-					if(new_metadata)
-						metadata = sanitize(copytext(new_metadata,1,MAX_MESSAGE_LEN))
 
 				if("hair")
 					var/new_hair = input(user, "Choose your character's hair colour:", "Character Preference","#"+hair_color) as color|null

--- a/code/modules/client/preferences/entries/general_settings.dm
+++ b/code/modules/client/preferences/entries/general_settings.dm
@@ -1,0 +1,1 @@
+/datum/preference_entry/string/ooccolor

--- a/code/modules/client/preferences/entries/hidden_configs.dm
+++ b/code/modules/client/preferences/entries/hidden_configs.dm
@@ -1,0 +1,2 @@
+/datum/preference_entry/string/last_seen_changelog
+

--- a/code/modules/client/preferences/preference_entry.dm
+++ b/code/modules/client/preferences/preference_entry.dm
@@ -1,0 +1,75 @@
+/datum/preference_entry
+	//As it appears to the user
+	//Lack thereof will treat it as unmodifiable by the user
+	var/name
+	//Default value
+	var/value
+
+	var/legacy_root_slot = FALSE
+
+	var/abstract_type = /datum/preference_entry
+	var/default
+	var/version = 0
+
+/datum/preference_entry/New()
+	default = value
+
+/datum/preference_entry/Topic(href, list/href_list)
+	CRASH("TODO")
+
+/datum/preference_entry/proc/ApplyToMob(mob/living/carbon/human/character)
+	return
+
+//Generate the options selection for the preference entry
+/datum/preference_entry/proc/GenerateHTML()
+	CRASH("No GenerateHTML implementation for [type]")
+
+//called version - old_version times, should migrate from one version to the next PER CALL
+/datum/preference_entry/proc/Migrate(old_version)
+	CRASH("No Migrate implementation for [type] from v[old_version]")
+
+//The savefile is already in the correct directory for the slot
+/datum/preference_entry/proc/LegacyLoad(savefile/S)
+	return
+
+/datum/preference_entry/select
+	abstract_type = /datum/preference_entry/select
+
+/datum/preference_entry/select/proc/ListOptions()
+	return list()
+
+/datum/preference_entry/select/multi
+	value = list()
+	abstract_type = /datum/preference_entry/select/multi
+
+/datum/preference_entry/select/multi/GenerateHTML()
+	CRASH("TODO")
+
+/datum/preference_entry/select/single
+	abstract_type = /datum/preference_entry/select/single
+
+/datum/preference_entry/select/single/GenerateHTML()
+	CRASH("TODO")
+
+/datum/preference_entry/number
+	abstract_type = /datum/preference_entry/number
+	var/max_val = INFINITY
+	var/min_val = -INFINITY
+	var/integer = TRUE
+
+/datum/preference_entry/number/GenerateHTML()
+	CRASH("TODO")
+
+/datum/preference_entry/flag
+	value = FALSE
+	abstract_type = /datum/preference_entry/flag
+
+/datum/preference_entry/flag/GenerateHTML()
+	CRASH("TODO")
+
+/datum/preference_entry/string
+	value = ""
+	abstract_type = /datum/preference_entry/string
+
+/datum/preference_entry/flag/GenerateHTML()
+	CRASH("TODO")

--- a/code/modules/client/preferences/preference_slot.dm
+++ b/code/modules/client/preferences/preference_slot.dm
@@ -1,0 +1,80 @@
+/datum/preference_slot
+	var/id
+	var/list/entries
+
+/datum/preference_slot/New(json, _id)
+	var/list/_entries = list()
+	for(var/I in subtypesof(/datum/preference_entry))
+		if(I == /datum/preference_entry)
+			continue
+		var/datum/preference_entry/P = I
+		if(initial(P.abstract_type) == P)
+			continue
+		_entries[I] = new I
+	entries = _entries
+
+/datum/preference_slot/proc/Load(raw_json, row_id)
+	if(!isnum(row_id))
+		CRASH("Invalid row id for preference slot!")
+	id = row_id
+	var/list/json = json_decode(raw_json)
+	if(!json)
+		CRASH("Invalid json for preference slot: [raw_json]")
+	
+	var/list/_entries = entries
+	for(var/I in _entries)
+		var/list/entry_value = json["[I]"]
+		if(!entry_value)
+			continue
+		
+		var/datum/preference_entry/P = _entries[I]
+		var/value = entry_value[1]
+		if(value != P.value)
+			P.modified = TRUE
+			P.value = value
+
+		var/saved_version = entry_value[1] 
+		var/p_version = P.version
+		if(p_version < saved_version)
+			//don't save 
+			P.version = -1
+		else
+			while (p_version > saved_version)
+				P.Migrate(saved_version)
+				++saved_version
+
+/datum/preference_slot/proc/CopyFrom(datum/preference_slot/other)
+	var/list/_entries = entries
+	var/list/other_entries = other.entries
+	for(var/I in _entries)
+		var/datum/preference_entry/target = _entries[I]
+		var/datum/preference_entry/source = other_entries[I]
+		target.value = source.value
+		target.version = source.version
+
+/datum/preference_slot/proc/ToJSON()
+	var/list/_entries = entries
+	var/list/keys_and_values = list()
+	for(var/I in _entries)
+		var/datum/preference_entry/P = _entries[I]
+
+		var/p_value = P.value
+		var/p_version = P.version
+		if(p_version || p_value == P.default)
+			continue
+		
+		keys_and_values[I] = list(p_version, p_version)
+	return json_encode(keys_and_values)
+
+/datum/preference_slot/proc/ApplyToMob(mob/living/carbon/human/character)
+	var/list/_entries = entries
+	for(var/I in _entries)
+		var/datum/preference_entry/P = _entries[I]
+		P.ApplyToMob(character)
+
+/datum/preference_slot/proc/LegacyLoad(savefile/S, slot_number)
+	var/list/_entries = entries
+	for(var/I in _entries)
+		var/datum/preference_entry/P = _entries[I]
+		S.cd = P.legacy_root_slot ? "/" : "character[slot_number]"
+		P.LegacyLoad(S)

--- a/code/modules/client/preferences/preferences.dm
+++ b/code/modules/client/preferences/preferences.dm
@@ -1,0 +1,143 @@
+/datum/preferences
+	var/ckey_owner
+	var/max_slots = 3
+	var/list/slots
+
+	var/static/list/selected_slots
+	var/static/selected_slots_dirty = FALSE
+
+/datum/preferences/New(client/owner)
+	ckey_owner = owner.ckey
+	if(IsGuestKey(ckey_owner))
+		max_slots = 1
+	else if(owner.IsByondMember())
+		max_slots = 8
+	GLOB.preferences_datums[ckey_owner] = prefs
+	if(SSdbcore.initialized)
+		Load()
+
+/datum/preferences/Destroy()
+	QDEL_LIST(slots)
+	GLOB.preferences_datums -= ckey_owner]
+	return ..()
+
+/datum/preferences/proc/Load()
+	if(IsGuestKey(ckey_owner))
+		slots = list(new /datum/preference_slot)
+		return
+
+	if(SSdbcore.Connect())
+		var/datum/DBQuery/Q = SSdbcore.NewQuery("SELECT id, json FROM [format_table_name("preferences")] WHERE owner = '[ckey_owner]'")
+		if(Q.Execute() && Q.NextRow())
+			do
+				var/datum/preference_slot/P = new
+				if(P.Load(Q.items[2], Q.items[1]))
+					LAZYADD(slots, P)
+			while(Q.NextRow())
+	if(LAZYLEN(slots) && !AttemptLegacyLoad())
+		slots = list(new /datum/preference_slot)
+	
+	if(!selected_slots)
+		selected_slots = json_decode(file2text(PREFERENCES_SELECTED_SLOT_JSON))
+		if(!selected_slots)
+			selected_slots = list()
+	
+	if(!selected_slots[ckey_owner])
+		selected_slots[ckey_owner] = 1
+
+/datum/preferences/proc/Save(dry_run = FALSE)
+	//go reg you meme
+	if(IsGuestKey(ckey_owner))
+		return FALSE
+	var/rows = list()
+
+	for(var/I in slots)
+		var/datum/preference_slot/P = I
+		var/json = sanitizeSQL(P.ToJSON())
+		var/list/entry = list("json" = json, "ckey" = sanitizeSQL(ckey_owner))
+		if(P_id != null)
+			entry["id"] = sanitizeSQL(P_id)
+		rows += list(entry)
+
+	if(selected_slots_dirty && text2file(json_encode(selected_slots), PREFERENCES_SELECTED_SLOT_JSON))
+		selected_slots_dirty = FALSE
+
+	if(dry_run)
+		return rows
+	
+	if(!SSdbcore.Connect())
+		return FALSE
+
+	return SSdbcore.MassInsert(format_table_name("preferences"), ., TRUE, TRUE)
+
+/datum/preferences/proc/GetSelectedSlot()
+	return IsGuestKey(ckey_owner) ? 1 : selected_slots[ckey_owner]
+
+/datum/preferences/proc/ApplyToMob(mob/living/carbon/human/character)
+	var/datum/preference_slot/P = slots[GetSelectedSlot()]
+	P.ApplyToMob(character)
+
+/datum/preferences/proc/ShowEditWindow(mob/user)
+	CRASH("TODO")
+
+/datum/preferences/proc/AttemptLegacyLoad()
+	. = FALSE
+
+	var/sfilePath = "data/player_saves/[copytext(ckey_owner, 1, 2)]/[ckey_owner]/preferences.sav"
+	if(!fexists(sfilePath))
+		return
+
+	var/savefile/S = new(sfilePath)
+
+	//forget about the crappy builtin version handling that shit was dumb
+	for(var/I in 1 to max_slots)
+		var/datum/preference_slot/P = new
+		if(P.LegacyLoad(S, I))
+			LAZYADD(slots, P)
+	
+	if(!slots)
+		return
+	
+	. = TRUE
+
+	if(!Save(FALSE))
+		return
+
+	S = null
+	if(fcopy(sfilePath, "data/migrated_player_saves/[sfilePath].migrated"))
+		fdel(sfilePath)
+
+/datum/preferences/proc/SetSelectedSlot(index)
+	if(slots.len < index)
+		CRASH("Attempt to set preference slot to [index] while only having [slots.len] slots!")
+	
+	if(IsGuestKey(ckey_owner) || selected_slots[ckey_owner] == index)
+		return
+
+	selected_slots[ckey_owner] = index
+	selected_slots_dirty = TRUE
+
+/datum/preferences/proc/AddSlot()
+	if(slots.len >= max_slots)
+		return FALSE
+	var/datum/preference_slot/P = new
+	P.CopyFrom(GetSelectedSlot())
+	slots += P
+	return TRUE
+
+/datum/preferences/proc/DeleteSlot(index)
+	if(slots.len < index)
+		CRASH("Attempt to delete non-existent preference slot [index]!")
+	slots -= slots[index]
+	if(!GetSelectedSlot())
+		SetSelectedSlot(1)
+
+/datum/preferences/proc/Get(entry_type)
+	var/datum/preference_slot/P = GetSelectedSlot()
+	var/datum/preference_entry/E = P.entries[entry_type]
+	return E.value
+
+/datum/preferences/proc/Set(entry_type, new_value)
+	var/datum/preference_slot/P = GetSelectedSlot()
+	var/datum/preference_entry/E = P.entries[entry_type]
+	E.value = new_value

--- a/code/modules/client/preferences/preferences.dm
+++ b/code/modules/client/preferences/preferences.dm
@@ -27,7 +27,7 @@
 		return
 
 	if(SSdbcore.Connect())
-		var/datum/DBQuery/Q = SSdbcore.NewQuery("SELECT id, json FROM [format_table_name("preferences")] WHERE owner = '[ckey_owner]'")
+		var/datum/DBQuery/Q = SSdbcore.NewQuery("SELECT id, json FROM [format_table_name("preferences")] WHERE owner = [sanitizeSQL(ckey_owner)]")
 		if(Q.Execute() && Q.NextRow())
 			do
 				var/datum/preference_slot/P = new

--- a/code/modules/client/preferences_savefile.dm
+++ b/code/modules/client/preferences_savefile.dm
@@ -265,7 +265,6 @@ SAVEFILE UPDATING/VERSIONING - 'Simplified', or rather, more coder-friendly ~Car
 		WRITE_FILE(S["features["mcolor"]"]	, "#FFF")
 
 	//Character
-	S["OOC_Notes"]			>> metadata
 	S["real_name"]			>> real_name
 	S["name_is_always_random"] >> be_random_name
 	S["body_is_always_random"] >> be_random_body
@@ -323,7 +322,6 @@ SAVEFILE UPDATING/VERSIONING - 'Simplified', or rather, more coder-friendly ~Car
 		update_character(needs_update, S)		//needs_update == savefile_version if we need an update (positive integer)
 
 	//Sanitize
-	metadata		= sanitize_text(metadata, initial(metadata))
 	real_name		= reject_bad_name(real_name)
 	if(!features["mcolor"] || features["mcolor"] == "#000")
 		features["mcolor"] = pick("FFFFFF","7F7F7F", "7FFF7F", "7F7FFF", "FF7F7F", "7FFFFF", "FF7FFF", "FFFF7F")
@@ -386,7 +384,6 @@ SAVEFILE UPDATING/VERSIONING - 'Simplified', or rather, more coder-friendly ~Car
 	WRITE_FILE(S["version"]			, SAVEFILE_VERSION_MAX)	//load_character will sanitize any bad data, so assume up-to-date.)
 
 	//Character
-	WRITE_FILE(S["OOC_Notes"]			, metadata)
 	WRITE_FILE(S["real_name"]			, real_name)
 	WRITE_FILE(S["name_is_always_random"] , be_random_name)
 	WRITE_FILE(S["body_is_always_random"] , be_random_body)

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -433,21 +433,6 @@
 /mob/living/proc/update_damage_overlays()
 	return
 
-/mob/living/proc/Examine_OOC()
-	set name = "Examine Meta-Info (OOC)"
-	set category = "OOC"
-	set src in view()
-
-	if(CONFIG_GET(flag/allow_metadata))
-		if(client)
-			to_chat(src, "[src]'s Metainfo:<br>[client.prefs.metadata]")
-		else
-			to_chat(src, "[src] does not have any stored information!")
-	else
-		to_chat(src, "OOC Metadata is not supported by this server!")
-
-	return
-
 /mob/living/Move(atom/newloc, direct)
 	if (buckled && buckled.loc != newloc) //not updating position
 		if (!buckled.anchored)

--- a/config/config.txt
+++ b/config/config.txt
@@ -127,9 +127,6 @@ ALLOW_ADMIN_OOCCOLOR
 ## Job slot open/close by identification consoles delay in seconds
 ID_CONSOLE_JOBSLOT_DELAY 30
 
-## If metadata is supported
-ALLOW_METADATA
-
 ## allow players to initiate a restart vote
 #ALLOW_VOTE_RESTART
 


### PR DESCRIPTION
Gonna move these over to an entry system similar to configs with support for loading from (but not saving to) savefiles. It's just a json blob for each slot.

:cl:
code: Modularized character preferences
tweak: Character slots can be created and deleted (Up to the old limits)
tweak: Game settings are now stored per character slot
config: ALLOW_METADATA has been removed
server: Preferences are now stored in the new preferences table
/:cl:

Server crashes will result in unsaved prefs. The alternative is to run the insert/update every time a user clicks "Save"