### PR TITLE
Morgue and Crematorium Repositions

### DIFF
--- a/_maps/map_files/BoxStation/BoxStation.dmm
+++ b/_maps/map_files/BoxStation/BoxStation.dmm
@@ -13849,8 +13849,11 @@
 /turf/open/floor/plasteel/grimy,
 /area/chapel/office)
 "aIB" = (
-/obj/structure/bodycontainer/crematorium,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/structure/bodycontainer/crematorium{
+	icon_state = "crema1";
+	dir = 4
+	},
 /turf/open/floor/plasteel/dark,
 /area/chapel/office)
 "aIC" = (
@@ -23075,6 +23078,10 @@
 /area/medical/morgue)
 "bho" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/structure/bodycontainer/morgue{
+	icon_state = "morgue1";
+	dir = 8
+	},
 /turf/open/floor/plasteel/dark,
 /area/medical/morgue)
 "bhp" = (
@@ -93546,9 +93553,9 @@ bdp
 bdc
 bfL
 beY
-biz
-biz
-biz
+bhm
+bhm
+bhm
 bkR
 bfL
 boo
@@ -97172,7 +97179,7 @@ bIP
 bPA
 bJN
 bRU
-bSZ
+bEm
 bEm
 bJN
 bRU
@@ -97180,7 +97187,7 @@ bXe
 bEm
 bJN
 bRU
-bSZ
+bEm
 bEm
 bDb
 cgi
@@ -99742,7 +99749,7 @@ bOx
 bPJ
 bJN
 bEm
-bSZ
+bEm
 bRU
 bJN
 bEm
@@ -99750,7 +99757,7 @@ bXe
 bRU
 bJN
 bEm
-bSZ
+bEm
 bRU
 bDb
 aaf

--- a/_maps/map_files/BoxStation/BoxStation.dmm
+++ b/_maps/map_files/BoxStation/BoxStation.dmm
@@ -13850,10 +13850,7 @@
 /area/chapel/office)
 "aIB" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/structure/bodycontainer/crematorium{
-	icon_state = "crema1";
-	dir = 4
-	},
+/obj/structure/bodycontainer/crematorium,
 /turf/open/floor/plasteel/dark,
 /area/chapel/office)
 "aIC" = (

--- a/_maps/map_files/BoxStation/BoxStation.dmm
+++ b/_maps/map_files/BoxStation/BoxStation.dmm
@@ -23076,7 +23076,6 @@
 "bho" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/structure/bodycontainer/morgue{
-	icon_state = "morgue1";
 	dir = 8
 	},
 /turf/open/floor/plasteel/dark,

--- a/_maps/map_files/Deltastation/DeltaStation2.dmm
+++ b/_maps/map_files/Deltastation/DeltaStation2.dmm
@@ -90598,14 +90598,12 @@
 /area/medical/morgue)
 "dDM" = (
 /obj/structure/bodycontainer/morgue{
-	icon_state = "morgue1";
 	dir = 2
 	},
 /turf/open/floor/plating,
 /area/medical/morgue)
 "dDN" = (
 /obj/structure/bodycontainer/morgue{
-	icon_state = "morgue1";
 	dir = 2
 	},
 /turf/open/floor/plasteel/vault{
@@ -90615,7 +90613,6 @@
 "dDO" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/bodycontainer/morgue{
-	icon_state = "morgue1";
 	dir = 2
 	},
 /turf/open/floor/plasteel/vault{
@@ -90628,7 +90625,6 @@
 	dir = 1
 	},
 /obj/structure/bodycontainer/morgue{
-	icon_state = "morgue1";
 	dir = 2
 	},
 /turf/open/floor/plating,
@@ -93106,7 +93102,6 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/light/small,
 /obj/structure/bodycontainer/morgue{
-	icon_state = "morgue1";
 	dir = 1
 	},
 /turf/open/floor/plasteel/vault{
@@ -93124,7 +93119,6 @@
 	pixel_y = -32
 	},
 /obj/structure/bodycontainer/morgue{
-	icon_state = "morgue1";
 	dir = 1
 	},
 /turf/open/floor/plasteel/vault{
@@ -93146,7 +93140,6 @@
 "dIZ" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/bodycontainer/morgue{
-	icon_state = "morgue1";
 	dir = 1
 	},
 /turf/open/floor/plating,
@@ -93155,7 +93148,6 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/light_construct/small,
 /obj/structure/bodycontainer/morgue{
-	icon_state = "morgue1";
 	dir = 1
 	},
 /turf/open/floor/plating,
@@ -100985,8 +100977,8 @@
 "dZO" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/structure/bodycontainer/crematorium{
-	icon_state = "crema1";
-	dir = 4
+	dir = 4;
+	id = "cremawheat"
 	},
 /turf/open/floor/plasteel/vault{
 	dir = 8
@@ -105057,7 +105049,6 @@
 "QOn" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/bodycontainer/morgue{
-	icon_state = "morgue1";
 	dir = 2
 	},
 /turf/open/floor/plasteel/vault{
@@ -105080,7 +105071,6 @@
 /area/medical/morgue)
 "QOq" = (
 /obj/structure/bodycontainer/morgue{
-	icon_state = "morgue1";
 	dir = 1
 	},
 /turf/open/floor/plasteel/vault{
@@ -105090,7 +105080,6 @@
 "QOr" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/bodycontainer/morgue{
-	icon_state = "morgue1";
 	dir = 1
 	},
 /turf/open/floor/plasteel/vault{
@@ -146655,7 +146644,7 @@ dyo
 dzU
 dAX
 dCB
-QOo
+QOn
 dEW
 dGn
 dHI

--- a/_maps/map_files/Deltastation/DeltaStation2.dmm
+++ b/_maps/map_files/Deltastation/DeltaStation2.dmm
@@ -105058,7 +105058,6 @@
 "QOo" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/bodycontainer/morgue{
-	icon_state = "morgue1";
 	dir = 2
 	},
 /turf/open/floor/plasteel/vault{
@@ -170622,3 +170621,4 @@ aaa
 aaa
 aaa
 "}
+

--- a/_maps/map_files/Deltastation/DeltaStation2.dmm
+++ b/_maps/map_files/Deltastation/DeltaStation2.dmm
@@ -90597,18 +90597,27 @@
 	},
 /area/medical/morgue)
 "dDM" = (
-/obj/structure/bodycontainer/morgue,
+/obj/structure/bodycontainer/morgue{
+	icon_state = "morgue1";
+	dir = 2
+	},
 /turf/open/floor/plating,
 /area/medical/morgue)
 "dDN" = (
-/obj/structure/bodycontainer/morgue,
+/obj/structure/bodycontainer/morgue{
+	icon_state = "morgue1";
+	dir = 2
+	},
 /turf/open/floor/plasteel/vault{
 	dir = 8
 	},
 /area/medical/morgue)
 "dDO" = (
-/obj/structure/bodycontainer/morgue,
 /obj/effect/decal/cleanable/dirt,
+/obj/structure/bodycontainer/morgue{
+	icon_state = "morgue1";
+	dir = 2
+	},
 /turf/open/floor/plasteel/vault{
 	dir = 8
 	},
@@ -90617,6 +90626,10 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/light/small{
 	dir = 1
+	},
+/obj/structure/bodycontainer/morgue{
+	icon_state = "morgue1";
+	dir = 2
 	},
 /turf/open/floor/plating,
 /area/medical/morgue)
@@ -91109,7 +91122,7 @@
 "dEV" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating,
+/turf/open/floor/plasteel/neutral,
 /area/medical/morgue)
 "dEW" = (
 /turf/open/floor/plasteel/neutral,
@@ -92435,6 +92448,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
+/obj/effect/landmark/event_spawn,
 /turf/open/floor/plasteel/neutral,
 /area/medical/morgue)
 "dHK" = (
@@ -93091,6 +93105,10 @@
 "dIW" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/light/small,
+/obj/structure/bodycontainer/morgue{
+	icon_state = "morgue1";
+	dir = 1
+	},
 /turf/open/floor/plasteel/vault{
 	dir = 5
 	},
@@ -93104,6 +93122,10 @@
 	},
 /obj/structure/sign/poster/official/bless_this_spess{
 	pixel_y = -32
+	},
+/obj/structure/bodycontainer/morgue{
+	icon_state = "morgue1";
+	dir = 1
 	},
 /turf/open/floor/plasteel/vault{
 	dir = 5
@@ -93122,14 +93144,20 @@
 	},
 /area/medical/morgue)
 "dIZ" = (
-/obj/structure/bodycontainer/morgue,
 /obj/effect/decal/cleanable/dirt,
+/obj/structure/bodycontainer/morgue{
+	icon_state = "morgue1";
+	dir = 1
+	},
 /turf/open/floor/plating,
 /area/medical/morgue)
 "dJa" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/light_construct/small,
-/obj/effect/landmark/event_spawn,
+/obj/structure/bodycontainer/morgue{
+	icon_state = "morgue1";
+	dir = 1
+	},
 /turf/open/floor/plating,
 /area/medical/morgue)
 "dJb" = (
@@ -100955,10 +100983,11 @@
 /turf/closed/wall/r_wall,
 /area/chapel/office)
 "dZO" = (
-/obj/structure/bodycontainer/crematorium{
-	id = "cremawheat"
-	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/structure/bodycontainer/crematorium{
+	icon_state = "crema1";
+	dir = 4
+	},
 /turf/open/floor/plasteel/vault{
 	dir = 8
 	},
@@ -105025,6 +105054,49 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/port)
+"QOn" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/bodycontainer/morgue{
+	icon_state = "morgue1";
+	dir = 2
+	},
+/turf/open/floor/plasteel/vault{
+	dir = 5
+	},
+/area/medical/morgue)
+"QOo" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/bodycontainer/morgue{
+	icon_state = "morgue1";
+	dir = 2
+	},
+/turf/open/floor/plasteel/vault{
+	dir = 5
+	},
+/area/medical/morgue)
+"QOp" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/neutral,
+/area/medical/morgue)
+"QOq" = (
+/obj/structure/bodycontainer/morgue{
+	icon_state = "morgue1";
+	dir = 1
+	},
+/turf/open/floor/plasteel/vault{
+	dir = 8
+	},
+/area/medical/morgue)
+"QOr" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/bodycontainer/morgue{
+	icon_state = "morgue1";
+	dir = 1
+	},
+/turf/open/floor/plasteel/vault{
+	dir = 8
+	},
+/area/medical/morgue)
 
 (1,1,1) = {"
 aaa
@@ -126533,7 +126605,7 @@ dml
 dsX
 djb
 dvU
-dxC
+drv
 dru
 dhD
 aad
@@ -135012,7 +135084,7 @@ doy
 dqo
 drM
 dtf
-duB
+duz
 dwd
 djA
 dzp
@@ -135921,7 +135993,7 @@ aaa
 aaa
 aaa
 aaa
-aci
+aaa
 aaa
 aaa
 aaa
@@ -139521,7 +139593,7 @@ aaa
 aaa
 aaa
 aaa
-aeu
+aaa
 aaa
 aid
 aiA
@@ -143879,7 +143951,7 @@ aad
 aaa
 acF
 aaa
-adu
+aaa
 aaa
 aaa
 aaa
@@ -145813,10 +145885,10 @@ dzR
 dAU
 dCA
 dDM
-dDO
+QOp
 dGl
-dHG
-dDN
+dHH
+QOq
 dCy
 dKZ
 dMy
@@ -146069,7 +146141,7 @@ dym
 dzS
 dAV
 dCB
-dDJ
+QOn
 dEV
 dGm
 dHH
@@ -146327,10 +146399,10 @@ dzT
 dAW
 dCB
 dDN
-dDN
+dEW
 dGl
-dHG
-dDO
+dHH
+QOr
 dCy
 dKX
 dMA
@@ -146349,7 +146421,7 @@ aaa
 aaa
 aaa
 aaa
-dUD
+aaa
 aaa
 aaa
 aaa
@@ -146583,7 +146655,7 @@ dyo
 dzU
 dAX
 dCB
-dDJ
+QOo
 dEW
 dGn
 dHI
@@ -146841,9 +146913,9 @@ dzV
 dAY
 dCB
 dDO
-dDN
+dEW
 dGl
-dHG
+dHH
 dIZ
 dCy
 dKZ
@@ -152139,7 +152211,7 @@ aaa
 aaa
 aaa
 aaa
-aAM
+aaa
 aaa
 aaa
 aaa
@@ -152685,7 +152757,7 @@ aaa
 aaa
 aaa
 aaa
-bAa
+aaa
 aaa
 aaa
 aaa
@@ -152930,7 +153002,7 @@ aad
 aaa
 aaa
 aaa
-bgW
+aaa
 aaa
 aaa
 aaa

--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -65518,6 +65518,10 @@
 /area/medical/medbay/aft)
 "cFU" = (
 /obj/machinery/light/small,
+/obj/structure/bodycontainer/morgue{
+	icon_state = "morgue1";
+	dir = 8
+	},
 /turf/open/floor/plasteel/dark,
 /area/medical/morgue)
 "cFV" = (
@@ -68608,8 +68612,11 @@
 	},
 /area/medical/virology)
 "cLT" = (
-/obj/structure/bodycontainer/crematorium,
 /obj/effect/decal/cleanable/cobweb,
+/obj/structure/bodycontainer/crematorium{
+	icon_state = "crema1";
+	dir = 4
+	},
 /turf/open/floor/plasteel/dark,
 /area/chapel/office)
 "cLU" = (
@@ -75231,6 +75238,10 @@
 	dir = 2;
 	network = list("SS13","Medbay")
 	},
+/obj/structure/bodycontainer/morgue{
+	icon_state = "morgue1";
+	dir = 8
+	},
 /turf/open/floor/plasteel/dark,
 /area/medical/morgue)
 "dbs" = (
@@ -80644,6 +80655,20 @@
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/plasteel/white,
 /area/science/circuit)
+"QuX" = (
+/obj/structure/bodycontainer/morgue{
+	icon_state = "morgue1";
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
+/area/medical/morgue)
+"QuY" = (
+/obj/structure/bodycontainer/morgue{
+	icon_state = "morgue1";
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
+/area/medical/morgue)
 
 (1,1,1) = {"
 aaa
@@ -90552,7 +90577,7 @@ aZZ
 bOd
 EDi
 aaa
-cWp
+aaa
 aaa
 aaa
 aaa
@@ -92083,7 +92108,7 @@ bxw
 aVs
 aaa
 aaa
-cVv
+aaa
 aaa
 aaa
 aVs
@@ -93099,7 +93124,7 @@ djC
 aaa
 aaa
 aaa
-beC
+aaa
 aaa
 aaa
 aaa
@@ -94373,7 +94398,7 @@ auG
 dnd
 dhK
 dnk
-aRG
+dnH
 aSP
 dne
 dhM
@@ -95645,7 +95670,7 @@ aaa
 aaa
 aaa
 aaa
-azh
+aaa
 aaa
 aaa
 aaa
@@ -96170,7 +96195,7 @@ aaa
 aaa
 aaa
 aaa
-cUV
+aaa
 aaa
 aaa
 aaa
@@ -103869,7 +103894,7 @@ aaa
 aaa
 aaa
 aaa
-ayt
+aaa
 aaa
 aaa
 azC
@@ -105743,11 +105768,11 @@ cyf
 cyZ
 cAc
 ctA
-cCf
-cCf
+cCj
+cCj
 cDY
-cCf
-cCf
+cCj
+cCj
 cCe
 cHJ
 bTs
@@ -106001,9 +106026,9 @@ cyZ
 cAd
 ctA
 dbr
-cCj
+QuX
 dDC
-cCj
+QuY
 cFU
 cCe
 ctK
@@ -107824,7 +107849,7 @@ cQK
 cQY
 cYJ
 aaa
-cYO
+aaa
 aaa
 aaa
 aaa
@@ -113224,15 +113249,15 @@ cRi
 cRe
 cRi
 cSg
-cSo
+cSn
 cSn
 cSd
 cSg
-cSo
+cSn
 cSn
 cSd
 cSg
-cSo
+cSn
 cSn
 cRi
 cTA
@@ -113466,8 +113491,8 @@ cIg
 dDF
 dvY
 cNj
-dwN
-dwN
+ciL
+ciL
 cPg
 dvY
 aaa
@@ -113723,8 +113748,8 @@ cIg
 dxQ
 dvY
 cNk
-dwN
-dwN
+ciL
+ciL
 cPh
 dvY
 aaa
@@ -114526,7 +114551,7 @@ cTt
 daA
 cSn
 cSn
-cSo
+cSn
 daL
 cRi
 daQ
@@ -115794,15 +115819,15 @@ dcC
 dcM
 cSd
 cSn
-cSo
+cSn
 cSg
 cSd
 cSn
-cSo
+cSn
 cSg
 cSd
 cSn
-cSo
+cSn
 cSg
 cRi
 ddh
@@ -118320,7 +118345,7 @@ alq
 alq
 dvY
 ckx
-dwN
+ciL
 dwQ
 cot
 cnb
@@ -118577,10 +118602,10 @@ apc
 chE
 dvY
 cky
-dwN
+ciL
 dwX
-dwN
-dwN
+ciL
+ciL
 cou
 csb
 dvY
@@ -118834,10 +118859,10 @@ avr
 chF
 dvY
 ckz
-dwN
+ciL
 dwY
-dwN
-dwN
+ciL
+ciL
 cgs
 csc
 dvY
@@ -119095,7 +119120,7 @@ dwQ
 cnb
 cou
 cpK
-dwN
+ciL
 csc
 dvY
 Qtj
@@ -120324,7 +120349,7 @@ aFs
 aGT
 axY
 aJm
-aKy
+aJu
 aMb
 EDE
 axY

--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -68613,9 +68613,9 @@
 /area/medical/virology)
 "cLT" = (
 /obj/effect/decal/cleanable/cobweb,
-/obj/structure/bodycontainer/crematorium{
-	icon_state = "crema1";
-	dir = 4
+/obj/structure/bodycontainer/morgue{
+	icon_state = "morgue1";
+	dir = 2
 	},
 /turf/open/floor/plasteel/dark,
 /area/chapel/office)
@@ -68927,9 +68927,6 @@
 "cMC" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 4
-	},
-/obj/machinery/button/crematorium{
-	pixel_x = -25
 	},
 /turf/open/floor/plasteel/dark,
 /area/chapel/office)
@@ -69371,7 +69368,11 @@
 /turf/open/floor/plating/airless,
 /area/medical/virology)
 "cNt" = (
-/obj/structure/bodycontainer/morgue,
+/obj/machinery/button/crematorium{
+	id = "cremawheat";
+	pixel_x = -26;
+	req_access_txt = "27"
+	},
 /turf/open/floor/plasteel/dark,
 /area/chapel/office)
 "cNu" = (
@@ -69936,6 +69937,11 @@
 /obj/machinery/airalarm{
 	dir = 1;
 	pixel_y = -22
+	},
+/obj/structure/table,
+/obj/item/storage/box/bodybags{
+	pixel_x = 2;
+	pixel_y = 2
 	},
 /turf/open/floor/plasteel/dark,
 /area/chapel/office)
@@ -71970,17 +71976,12 @@
 /turf/open/floor/plasteel,
 /area/science/xenobiology)
 "cTf" = (
-/obj/structure/table,
 /obj/machinery/light/small{
 	dir = 8
 	},
 /obj/machinery/airalarm{
 	dir = 4;
 	pixel_x = -22
-	},
-/obj/item/storage/box/bodybags{
-	pixel_x = 2;
-	pixel_y = 2
 	},
 /turf/open/floor/plasteel/dark,
 /area/chapel/office)
@@ -80669,6 +80670,13 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/medical/morgue)
+"QuZ" = (
+/obj/structure/bodycontainer/crematorium{
+	icon_state = "crema1";
+	dir = 1
+	},
+/turf/open/floor/plasteel/dark,
+/area/chapel/office)
 
 (1,1,1) = {"
 aaa
@@ -100900,7 +100908,7 @@ cLT
 cMC
 cNt
 cTf
-cNt
+QuZ
 cMI
 cPC
 djX
@@ -106028,7 +106036,7 @@ ctA
 dbr
 QuX
 dDC
-QuY
+QuX
 cFU
 cCe
 ctK

--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -80661,7 +80661,6 @@
 /area/medical/morgue)
 "QuY" = (
 /obj/structure/bodycontainer/morgue{
-	icon_state = "morgue1";
 	dir = 8
 	},
 /turf/open/floor/plasteel/dark,
@@ -146208,3 +146207,4 @@ aaa
 aaa
 aaa
 "}
+

--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -65519,7 +65519,6 @@
 "cFU" = (
 /obj/machinery/light/small,
 /obj/structure/bodycontainer/morgue{
-	icon_state = "morgue1";
 	dir = 8
 	},
 /turf/open/floor/plasteel/dark,
@@ -68614,7 +68613,6 @@
 "cLT" = (
 /obj/effect/decal/cleanable/cobweb,
 /obj/structure/bodycontainer/morgue{
-	icon_state = "morgue1";
 	dir = 2
 	},
 /turf/open/floor/plasteel/dark,
@@ -75240,7 +75238,6 @@
 	network = list("SS13","Medbay")
 	},
 /obj/structure/bodycontainer/morgue{
-	icon_state = "morgue1";
 	dir = 8
 	},
 /turf/open/floor/plasteel/dark,
@@ -80658,7 +80655,6 @@
 /area/science/circuit)
 "QuX" = (
 /obj/structure/bodycontainer/morgue{
-	icon_state = "morgue1";
 	dir = 8
 	},
 /turf/open/floor/plasteel/dark,
@@ -80672,7 +80668,6 @@
 /area/medical/morgue)
 "QuZ" = (
 /obj/structure/bodycontainer/crematorium{
-	icon_state = "crema1";
 	dir = 1
 	},
 /turf/open/floor/plasteel/dark,


### PR DESCRIPTION
[Changelogs]: 
:cl: Jittai
tweak: Some of the Morgue Trays and Crematoriums on Box, Delta, and Meta have been re-positioned to make use of their new directional states.
/:cl:

Very minor re-positions, some are just turned, adds no extra trays.

Box:
![3](https://user-images.githubusercontent.com/6071161/35525279-0a95304a-04f2-11e8-989e-9f35badafdd0.png) 

Meta:
![1](https://user-images.githubusercontent.com/6071161/35525277-0a7a28d6-04f2-11e8-8e55-b9b67b693f36.png)

Delta:
Note: Moved a random-event-spawner up 1 tile and some of the flooring changed to match pattern.
![22](https://user-images.githubusercontent.com/6071161/35531426-f8100f4a-0504-11e8-8d50-11371d0a7627.png)

Chapel Backroom Respectively:
Box Meta Delta
![box](https://user-images.githubusercontent.com/6071161/35535624-29426b8c-0512-11e8-90e7-2b110eab71c9.png) ![meta](https://user-images.githubusercontent.com/6071161/35535630-2a88a862-0512-11e8-808c-9769bddedbe7.png) ![delta](https://user-images.githubusercontent.com/6071161/35535631-2b7560c6-0512-11e8-8794-64e8a418c3ab.png)


[why]: To make use of the new directional states, gives a bit more space in the rooms, and arguably looks better.

redo of: #35110