### PR TITLE
Adds missing GPS signal to caravan ambush ruin

### DIFF
--- a/_maps/RandomRuins/SpaceRuins/caravanambush.dmm
+++ b/_maps/RandomRuins/SpaceRuins/caravanambush.dmm
@@ -1825,6 +1825,9 @@
 /obj/item/folder/yellow{
 	pixel_x = -6
 	},
+/obj/item/device/gps{
+	gpstag = "Distress Signal"
+	},
 /turf/open/floor/plasteel/darkblue/side{
 	dir = 6;
 	initial_gas_mix = "TEMP=2.7"


### PR DESCRIPTION
:cl: Denton
bugfix: Added a missing distress signal to the space ambush ruin.
/:cl:

Old space ruin had a GPS signal that was left out in the remap due to an oversight.

Fixes #34936 