### PR TITLE
Beefs up door security

### DIFF
--- a/_maps/RandomRuins/LavaRuins/lavaland_surface_syndicate_base1.dmm
+++ b/_maps/RandomRuins/LavaRuins/lavaland_surface_syndicate_base1.dmm
@@ -5149,7 +5149,7 @@
 	},
 /area/ruin/unpowered/syndicate_lava_base/telecomms)
 "nj" = (
-/obj/machinery/door/airlock/hatch{
+/obj/machinery/door/airlock/hatch/high_sec{
 	name = "Telecommunications Control";
 	req_access_txt = "150"
 	},
@@ -5478,7 +5478,7 @@
 	},
 /area/ruin/unpowered/syndicate_lava_base/telecomms)
 "nL" = (
-/obj/machinery/door/airlock/hatch{
+/obj/machinery/door/airlock/hatch/high_sec{
 	name = "Telecommunications";
 	req_access_txt = "150"
 	},

--- a/_maps/map_files/BoxStation/BoxStation.dmm
+++ b/_maps/map_files/BoxStation/BoxStation.dmm
@@ -1447,14 +1447,14 @@
 /turf/closed/wall,
 /area/security/prison)
 "adH" = (
-/obj/machinery/door/airlock/security/glass{
+/obj/machinery/door/airlock/security/glass/high_sec{
 	name = "Long-Term Cell 3";
 	req_access_txt = "2"
 	},
 /turf/open/floor/plasteel/floorgrime,
 /area/security/prison)
 "adI" = (
-/obj/machinery/door/airlock/security/glass{
+/obj/machinery/door/airlock/security/glass/high_sec{
 	name = "Long-Term Cell 2";
 	req_access_txt = "2"
 	},
@@ -1462,7 +1462,7 @@
 /turf/open/floor/plasteel/floorgrime,
 /area/security/prison)
 "adJ" = (
-/obj/machinery/door/airlock/security/glass{
+/obj/machinery/door/airlock/security/glass/high_sec{
 	name = "Long-Term Cell 1";
 	req_access_txt = "2"
 	},

--- a/_maps/map_files/BoxStation/BoxStation.dmm
+++ b/_maps/map_files/BoxStation/BoxStation.dmm
@@ -869,6 +869,9 @@
 /area/crew_quarters/heads/hos)
 "acv" = (
 /obj/structure/closet/secure_closet/contraband/armory,
+/obj/machinery/light/small{
+	dir = 8
+	},
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/security/armory)
 "acw" = (
@@ -1811,6 +1814,9 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/suit_storage_unit/security,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
 /turf/open/floor/plasteel/red/side,
 /area/ai_monitored/security/armory)
 "aet" = (
@@ -1824,6 +1830,12 @@
 	icon_state = "1-8"
 	},
 /obj/machinery/suit_storage_unit/security,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/machinery/light{
+	dir = 4
+	},
 /turf/open/floor/plasteel/red/side,
 /area/ai_monitored/security/armory)
 "aev" = (
@@ -2104,13 +2116,9 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/machinery/door/window/southleft{
+/obj/machinery/door/airlock/security/glass/high_sec{
 	name = "Armory";
 	req_access_txt = "3"
-	},
-/obj/machinery/door/firedoor,
-/obj/effect/turf_decal/stripes/line{
-	dir = 10
 	},
 /turf/open/floor/plasteel,
 /area/ai_monitored/security/armory)
@@ -2311,7 +2319,7 @@
 	base_state = "right";
 	dir = 4;
 	icon_state = "right";
-	name = "Armory";
+	name = "Transfer Centre Atmos Control";
 	req_access_txt = "2"
 	},
 /obj/effect/turf_decal/stripes/line,
@@ -2637,10 +2645,7 @@
 /turf/open/floor/plasteel/showroomfloor,
 /area/security/warden)
 "agq" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/door/window/southleft{
-	base_state = "right";
-	icon_state = "right";
+/obj/machinery/door/airlock/security/glass/high_sec{
 	name = "Armory";
 	req_access_txt = "3"
 	},
@@ -2650,21 +2655,18 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/machinery/light{
-	dir = 4
-	},
 /obj/structure/cable{
 	icon_state = "2-4"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/effect/turf_decal/stripes/line{
-	dir = 2
-	},
 /turf/open/floor/plasteel,
 /area/ai_monitored/security/armory)
 "agr" = (
 /obj/machinery/computer/secure_data,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/effect/turf_decal/stripes/corner{
+	dir = 8
+	},
 /turf/open/floor/plasteel/showroomfloor,
 /area/security/warden)
 "ags" = (
@@ -2682,6 +2684,9 @@
 /obj/machinery/airalarm{
 	dir = 8;
 	pixel_x = 24
+	},
+/obj/machinery/light{
+	dir = 4
 	},
 /turf/open/floor/plasteel/showroomfloor,
 /area/security/warden)
@@ -5354,6 +5359,9 @@
 /obj/item/clothing/ears/earmuffs{
 	pixel_x = -3;
 	pixel_y = -2
+	},
+/obj/effect/turf_decal/stripes/corner{
+	dir = 4
 	},
 /turf/open/floor/plasteel/showroomfloor,
 /area/security/warden)
@@ -25018,6 +25026,9 @@
 	icon_state = "2-4"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/effect/turf_decal/stripes/line{
+	dir = 6
+	},
 /turf/open/floor/plasteel,
 /area/ai_monitored/security/armory)
 "blU" = (
@@ -25865,7 +25876,7 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/machinery/door/airlock/engineering/glass{
+/obj/machinery/door/airlock/engineering/glass/high_sec{
 	name = "Gravity Generator";
 	req_access_txt = "11";
 	req_one_access_txt = "0"
@@ -28324,7 +28335,7 @@
 /area/crew_quarters/heads/hop)
 "btF" = (
 /obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/engineering{
+/obj/machinery/door/airlock/engineering/high_sec{
 	name = "Gravity Generator";
 	req_access_txt = "11"
 	},
@@ -30291,7 +30302,7 @@
 /area/quartermaster/qm)
 "byh" = (
 /obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/command{
+/obj/machinery/door/airlock/command/high_sec{
 	name = "Server Room";
 	req_access = null;
 	req_access_txt = "30"
@@ -31302,7 +31313,7 @@
 /area/science/server)
 "bAB" = (
 /obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/command/glass{
+/obj/machinery/door/airlock/command/glass/high_sec{
 	name = "Server Room";
 	req_access_txt = "30"
 	},
@@ -38227,7 +38238,7 @@
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
 "bQK" = (
-/obj/machinery/door/airlock/command/glass{
+/obj/machinery/door/airlock/command/glass/high_sec{
 	name = "Control Room";
 	req_access_txt = "19; 61"
 	},
@@ -40544,7 +40555,7 @@
 /turf/open/floor/plasteel,
 /area/tcommsat/computer)
 "bWu" = (
-/obj/machinery/door/airlock/engineering{
+/obj/machinery/door/airlock/engineering/high_sec{
 	name = "Telecommunications";
 	req_access_txt = "61"
 	},
@@ -42059,7 +42070,7 @@
 	},
 /area/tcommsat/server)
 "cal" = (
-/obj/machinery/door/airlock/engineering/glass{
+/obj/machinery/door/airlock/engineering/glass/high_sec{
 	cyclelinkeddir = 4;
 	name = "Server Room";
 	req_access_txt = "61"
@@ -42072,7 +42083,7 @@
 	},
 /area/tcommsat/computer)
 "can" = (
-/obj/machinery/door/airlock/engineering/glass{
+/obj/machinery/door/airlock/engineering/glass/high_sec{
 	cyclelinkeddir = 8;
 	name = "Server Room";
 	req_access_txt = "61"
@@ -44648,7 +44659,7 @@
 /area/engine/engineering)
 "cgL" = (
 /obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/engineering/glass{
+/obj/machinery/door/airlock/engineering/glass/high_sec{
 	name = "Supermatter Engine Room";
 	req_access_txt = "10"
 	},
@@ -46756,6 +46767,9 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
 /turf/open/floor/plasteel/showroomfloor,
 /area/security/warden)
 "cmn" = (
@@ -47416,7 +47430,7 @@
 "coc" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden,
 /obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/engineering/glass{
+/obj/machinery/door/airlock/engineering/glass/high_sec{
 	name = "Supermatter Engine Room";
 	req_access_txt = "10"
 	},
@@ -47804,7 +47818,7 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/engineering/glass{
+/obj/machinery/door/airlock/engineering/glass/high_sec{
 	name = "Supermatter Engine Room";
 	req_access_txt = "10"
 	},
@@ -48279,7 +48293,7 @@
 /area/engine/supermatter)
 "cqE" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/door/airlock/engineering/glass{
+/obj/machinery/door/airlock/engineering/glass/high_sec{
 	heat_proof = 1;
 	name = "Supermatter Chamber";
 	req_access_txt = "10"
@@ -48437,7 +48451,7 @@
 /area/engine/engineering)
 "crd" = (
 /obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/engineering/glass{
+/obj/machinery/door/airlock/engineering/glass/high_sec{
 	name = "Supermatter Engine Room";
 	req_access_txt = "10"
 	},
@@ -48510,7 +48524,7 @@
 /turf/closed/wall/r_wall,
 /area/engine/supermatter)
 "crt" = (
-/obj/machinery/door/airlock/engineering/glass{
+/obj/machinery/door/airlock/engineering/glass/high_sec{
 	heat_proof = 1;
 	name = "Supermatter Chamber";
 	req_access_txt = "10"
@@ -49040,7 +49054,7 @@
 /turf/closed/wall,
 /area/ai_monitored/turret_protected/aisat_interior)
 "cto" = (
-/obj/machinery/door/airlock/hatch{
+/obj/machinery/door/airlock/hatch/high_sec{
 	name = "MiniSat Foyer";
 	req_one_access_txt = "65"
 	},
@@ -49208,7 +49222,7 @@
 /turf/open/floor/plasteel/grimy,
 /area/ai_monitored/turret_protected/aisat_interior)
 "ctK" = (
-/obj/machinery/door/airlock/hatch{
+/obj/machinery/door/airlock/hatch/high_sec{
 	name = "MiniSat Teleporter";
 	req_access_txt = "17;65"
 	},
@@ -49410,7 +49424,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/hatch{
+/obj/machinery/door/airlock/hatch/high_sec{
 	name = "MiniSat Antechamber";
 	req_one_access_txt = "65"
 	},
@@ -49749,7 +49763,7 @@
 	dir = 4
 	},
 /obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/hatch{
+/obj/machinery/door/airlock/hatch/high_sec{
 	name = "MiniSat Atmospherics";
 	req_one_access_txt = "65"
 	},
@@ -49799,7 +49813,7 @@
 	dir = 4
 	},
 /obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/hatch{
+/obj/machinery/door/airlock/hatch/high_sec{
 	name = "MiniSat Service Bay";
 	req_one_access_txt = "65"
 	},
@@ -49947,7 +49961,7 @@
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/ai)
 "cvm" = (
-/obj/machinery/door/airlock/maintenance_hatch{
+/obj/machinery/door/airlock/maintenance_hatch/high_sec{
 	name = "MiniSat Maintenance";
 	req_access_txt = "65"
 	},
@@ -49964,7 +49978,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/hatch{
+/obj/machinery/door/airlock/hatch/high_sec{
 	name = "MiniSat Chamber Hallway";
 	req_one_access_txt = "65"
 	},
@@ -49974,7 +49988,7 @@
 /turf/open/floor/circuit,
 /area/ai_monitored/turret_protected/ai)
 "cvq" = (
-/obj/machinery/door/airlock/maintenance_hatch{
+/obj/machinery/door/airlock/maintenance_hatch/high_sec{
 	name = "MiniSat Maintenance";
 	req_access_txt = "65"
 	},
@@ -50185,7 +50199,7 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
 "cvP" = (
-/obj/machinery/door/airlock/maintenance_hatch{
+/obj/machinery/door/airlock/maintenance_hatch/high_sec{
 	name = "MiniSat Maintenance";
 	req_access_txt = "65"
 	},
@@ -50222,7 +50236,7 @@
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/aisat/hallway)
 "cvU" = (
-/obj/machinery/door/airlock/maintenance_hatch{
+/obj/machinery/door/airlock/maintenance_hatch/high_sec{
 	name = "MiniSat Maintenance";
 	req_access_txt = "65"
 	},
@@ -50311,7 +50325,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/hatch{
+/obj/machinery/door/airlock/hatch/high_sec{
 	name = "MiniSat Chamber Observation";
 	req_one_access_txt = "65"
 	},
@@ -50892,7 +50906,7 @@
 /turf/open/floor/plating,
 /area/engine/engineering)
 "czk" = (
-/obj/machinery/door/airlock/external{
+/obj/machinery/door/airlock/external/high_sec{
 	cyclelinkeddir = 8;
 	name = "MiniSat External Access";
 	req_access = null;
@@ -54607,6 +54621,12 @@
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/plasteel,
 /area/science/circuit)
+"Qqw" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel/showroomfloor,
+/area/security/warden)
 
 (1,1,1) = {"
 aaa
@@ -83984,9 +84004,9 @@ abI
 ack
 coS
 aet
-cxA
+acL
 aeY
-agt
+Qqw
 agt
 ahz
 aie
@@ -97172,7 +97192,7 @@ bIP
 bPA
 bJN
 bRU
-bSZ
+bEm
 bEm
 bJN
 bRU
@@ -97180,7 +97200,7 @@ bXe
 bEm
 bJN
 bRU
-bSZ
+bEm
 bEm
 bDb
 cgi
@@ -99742,7 +99762,7 @@ bOx
 bPJ
 bJN
 bEm
-bSZ
+bEm
 bRU
 bJN
 bEm
@@ -99750,7 +99770,7 @@ bXe
 bRU
 bJN
 bEm
-bSZ
+bEm
 bRU
 bDb
 aaf

--- a/_maps/map_files/Deltastation/DeltaStation2.dmm
+++ b/_maps/map_files/Deltastation/DeltaStation2.dmm
@@ -7845,7 +7845,7 @@
 /area/engine/atmospherics_engine)
 "arm" = (
 /obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/atmos{
+/obj/machinery/door/airlock/atmos/glass/high_sec{
 	name = "Reflector Access";
 	req_access_txt = "0";
 	req_one_access_txt = "24;10"
@@ -7871,7 +7871,7 @@
 /area/engine/atmospherics_engine)
 "aro" = (
 /obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/atmos{
+/obj/machinery/door/airlock/atmos/glass/high_sec{
 	name = "Reflector Access";
 	req_access_txt = "0";
 	req_one_access_txt = "24;10"
@@ -12455,7 +12455,7 @@
 /turf/closed/wall/r_wall,
 /area/engine/supermatter)
 "aAW" = (
-/obj/machinery/door/airlock/atmos/glass{
+/obj/machinery/door/airlock/atmos/glass/high_sec{
 	heat_proof = 1;
 	name = "Supermatter Chamber";
 	req_access_txt = "0";
@@ -16269,8 +16269,8 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 2
 	},
-/obj/machinery/door/airlock/atmos{
-	name = "Atmospherics Access";
+/obj/machinery/door/airlock/atmos/high_sec{
+	name = "Atmospherics Engine Access";
 	req_access_txt = "0";
 	req_one_access_txt = "24;10"
 	},
@@ -16293,7 +16293,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 2
 	},
-/obj/machinery/door/airlock/atmos{
+/obj/machinery/door/airlock/atmos/high_sec{
 	name = "Atmospherics Engine Access";
 	req_access_txt = "0";
 	req_one_access_txt = "24;10"
@@ -18194,8 +18194,8 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 2
 	},
-/obj/machinery/door/airlock/atmos{
-	name = "Atmospherics Access";
+/obj/machinery/door/airlock/atmos/high_sec{
+	name = "Atmospherics Engine Access";
 	req_access_txt = "0";
 	req_one_access_txt = "24;10"
 	},
@@ -18217,7 +18217,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 2
 	},
-/obj/machinery/door/airlock/atmos{
+/obj/machinery/door/airlock/atmos/high_sec{
 	name = "Atmospherics Engine Access";
 	req_access_txt = "0";
 	req_one_access_txt = "24;10"
@@ -35803,8 +35803,8 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 2
 	},
-/obj/machinery/door/airlock/atmos{
-	name = "Atmospherics Access";
+/obj/machinery/door/airlock/atmos/high_sec{
+	name = "Atmospherics Engine Access";
 	req_access_txt = "0";
 	req_one_access_txt = "24;10"
 	},
@@ -40166,7 +40166,7 @@
 /area/engine/gravity_generator)
 "bEp" = (
 /obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/command/glass{
+/obj/machinery/door/airlock/command/glass/high_sec{
 	name = "Gravity Generator Chamber";
 	req_access_txt = "19; 61"
 	},
@@ -42992,7 +42992,7 @@
 /obj/structure/cable/white{
 	icon_state = "1-2"
 	},
-/obj/machinery/door/airlock/hatch{
+/obj/machinery/door/airlock/hatch/high_sec{
 	name = "MiniSat Transit Tube Access";
 	req_one_access_txt = "32;19"
 	},
@@ -43423,7 +43423,7 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/command{
+/obj/machinery/door/airlock/command/high_sec{
 	name = "Telecomms Control Room";
 	req_access = null;
 	req_access_txt = "19; 61"
@@ -44920,7 +44920,7 @@
 /obj/structure/cable/white{
 	icon_state = "4-8"
 	},
-/obj/machinery/door/airlock/hatch{
+/obj/machinery/door/airlock/hatch/high_sec{
 	name = "MiniSat Exterior Access";
 	req_one_access_txt = "32;19"
 	},
@@ -44965,7 +44965,7 @@
 /obj/structure/cable/white{
 	icon_state = "4-8"
 	},
-/obj/machinery/door/airlock/hatch{
+/obj/machinery/door/airlock/hatch/high_sec{
 	cyclelinkeddir = 4;
 	name = "MiniSat Exterior Access";
 	req_one_access_txt = "32;19"
@@ -44992,7 +44992,7 @@
 /obj/structure/cable/white{
 	icon_state = "4-8"
 	},
-/obj/machinery/door/airlock/hatch{
+/obj/machinery/door/airlock/hatch/high_sec{
 	cyclelinkeddir = 8;
 	name = "MiniSat Exterior Access";
 	req_one_access_txt = "32;19"
@@ -46892,7 +46892,7 @@
 /turf/open/floor/plating,
 /area/engine/transit_tube)
 "bRW" = (
-/obj/machinery/door/airlock/hatch{
+/obj/machinery/door/airlock/hatch/high_sec{
 	name = "MiniSat Transit Tube Access";
 	req_one_access_txt = "32;19"
 	},
@@ -48468,7 +48468,7 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/command{
+/obj/machinery/door/airlock/command/high_sec{
 	cyclelinkeddir = 2;
 	name = "Telecomms Server Room";
 	req_access = null;
@@ -48899,7 +48899,7 @@
 /area/aisat)
 "bVu" = (
 /obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/maintenance_hatch{
+/obj/machinery/door/airlock/maintenance_hatch/high_sec{
 	name = "MiniSat Maintenance";
 	req_access_txt = "16"
 	},
@@ -48972,7 +48972,7 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/maintenance_hatch{
+/obj/machinery/door/airlock/maintenance_hatch/high_sec{
 	name = "MiniSat Antechamber";
 	req_access_txt = "16"
 	},
@@ -49054,7 +49054,7 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/hatch{
+/obj/machinery/door/airlock/hatch/high_sec{
 	name = "MiniSat Antechamber";
 	req_one_access_txt = "32;19"
 	},
@@ -49098,7 +49098,7 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/hatch{
+/obj/machinery/door/airlock/hatch/high_sec{
 	name = "MiniSat Access";
 	req_one_access_txt = "32;19"
 	},
@@ -50133,7 +50133,7 @@
 /obj/structure/cable/white{
 	icon_state = "4-8"
 	},
-/obj/machinery/door/airlock/security{
+/obj/machinery/door/airlock/security/high_sec{
 	name = "Armoury";
 	req_access_txt = "3"
 	},
@@ -50883,7 +50883,7 @@
 /obj/structure/cable/white{
 	icon_state = "1-2"
 	},
-/obj/machinery/door/airlock/command{
+/obj/machinery/door/airlock/command/high_sec{
 	cyclelinkeddir = 1;
 	name = "Telecomms Server Room";
 	req_access = null;
@@ -51295,7 +51295,7 @@
 /obj/structure/cable/white{
 	icon_state = "1-2"
 	},
-/obj/machinery/door/airlock/security{
+/obj/machinery/door/airlock/security/high_sec{
 	name = "Armoury";
 	req_access_txt = "3"
 	},
@@ -56093,7 +56093,7 @@
 /obj/structure/cable/white{
 	icon_state = "1-2"
 	},
-/obj/machinery/door/airlock/command{
+/obj/machinery/door/airlock/command/high_sec{
 	cyclelinkeddir = 2;
 	name = "Telecomms Server Room";
 	req_access = null;
@@ -57426,7 +57426,7 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/command{
+/obj/machinery/door/airlock/command/high_sec{
 	cyclelinkeddir = 1;
 	name = "Telecomms Server Room";
 	req_access = null;
@@ -59529,7 +59529,7 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/command{
+/obj/machinery/door/airlock/command/high_sec{
 	cyclelinkeddir = 0;
 	name = "Telecomms Foyer";
 	req_access = null;

--- a/_maps/map_files/Deltastation/DeltaStation2.dmm
+++ b/_maps/map_files/Deltastation/DeltaStation2.dmm
@@ -23708,7 +23708,7 @@
 /turf/closed/wall,
 /area/security/prison)
 "aXN" = (
-/obj/machinery/door/airlock/security/glass{
+/obj/machinery/door/airlock/security/glass/high_sec{
 	name = "Long-Term Cell 3";
 	req_access_txt = "2"
 	},
@@ -23720,7 +23720,7 @@
 /turf/closed/wall,
 /area/security/prison)
 "aXP" = (
-/obj/machinery/door/airlock/security/glass{
+/obj/machinery/door/airlock/security/glass/high_sec{
 	name = "Long-Term Cell 2";
 	req_access_txt = "2"
 	},
@@ -23730,7 +23730,7 @@
 /turf/open/floor/plasteel/floorgrime,
 /area/security/prison)
 "aXQ" = (
-/obj/machinery/door/airlock/security/glass{
+/obj/machinery/door/airlock/security/glass/high_sec{
 	name = "Long-Term Cell 1";
 	req_access_txt = "2"
 	},
@@ -91580,7 +91580,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
-/obj/machinery/door/airlock/command{
+/obj/machinery/door/airlock/command/high_sec{
 	name = "Research Division Server Room";
 	req_access = null;
 	req_access_txt = "30"
@@ -92258,7 +92258,7 @@
 /obj/machinery/atmospherics/pipe/simple/general/hidden{
 	dir = 6
 	},
-/obj/machinery/door/airlock/command/glass{
+/obj/machinery/door/airlock/command/glass/high_sec{
 	name = "Server Access";
 	req_access_txt = "30"
 	},

--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -3657,9 +3657,8 @@
 /area/crew_quarters/heads/hos)
 "ahP" = (
 /obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/security{
+/obj/machinery/door/airlock/security/high_sec{
 	name = "Armory";
-	req_access = null;
 	req_access_txt = "3"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -7149,7 +7148,7 @@
 /turf/open/floor/plating,
 /area/engine/gravity_generator)
 "apj" = (
-/obj/machinery/door/airlock/command/glass{
+/obj/machinery/door/airlock/command/glass/high_sec{
 	name = "Gravity Generator Area";
 	req_access_txt = "19; 61"
 	},
@@ -27681,7 +27680,7 @@
 /turf/closed/wall/mineral/titanium,
 /area/shuttle/pod_4)
 "bgc" = (
-/obj/machinery/door/airlock/hatch{
+/obj/machinery/door/airlock/hatch/high_sec{
 	name = "MiniSat Space Access Airlock";
 	req_one_access_txt = "32;19"
 	},
@@ -32491,7 +32490,7 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/hatch{
+/obj/machinery/door/airlock/hatch/high_sec{
 	name = "MiniSat Foyer";
 	req_one_access_txt = "32;19"
 	},
@@ -32529,7 +32528,7 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/hatch{
+/obj/machinery/door/airlock/hatch/high_sec{
 	name = "MiniSat Antechamber";
 	req_one_access_txt = "32;19"
 	},
@@ -32591,7 +32590,7 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/maintenance_hatch{
+/obj/machinery/door/airlock/maintenance_hatch/high_sec{
 	name = "MiniSat Maintenance";
 	req_access_txt = "32"
 	},
@@ -32633,7 +32632,7 @@
 /area/ai_monitored/storage/satellite)
 "bpX" = (
 /obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/maintenance_hatch{
+/obj/machinery/door/airlock/maintenance_hatch/high_sec{
 	name = "MiniSat Maintenance";
 	req_access_txt = "32"
 	},
@@ -33594,7 +33593,7 @@
 /area/engine/break_room)
 "brK" = (
 /obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/hatch{
+/obj/machinery/door/airlock/hatch/high_sec{
 	name = "MiniSat Access";
 	req_one_access_txt = "32;19"
 	},
@@ -34685,7 +34684,7 @@
 /turf/closed/wall/r_wall,
 /area/tcommsat/computer)
 "btN" = (
-/obj/machinery/door/airlock/hatch{
+/obj/machinery/door/airlock/hatch/high_sec{
 	name = "Telecomms Control Room";
 	req_one_access_txt = "19; 61"
 	},
@@ -35414,7 +35413,7 @@
 /turf/open/floor/plasteel/dark,
 /area/engine/break_room)
 "bvs" = (
-/obj/machinery/door/airlock/hatch{
+/obj/machinery/door/airlock/hatch/high_sec{
 	name = "MiniSat Space Access Airlock";
 	req_one_access_txt = "32;19"
 	},
@@ -35788,7 +35787,7 @@
 /turf/open/floor/wood,
 /area/crew_quarters/heads/hop)
 "bwl" = (
-/obj/machinery/door/airlock/hatch{
+/obj/machinery/door/airlock/hatch/high_sec{
 	name = "MiniSat Space Access Airlock";
 	req_one_access_txt = "32;19"
 	},
@@ -38804,7 +38803,7 @@
 /turf/open/floor/plating,
 /area/tcommsat/server)
 "bCF" = (
-/obj/machinery/door/airlock/hatch{
+/obj/machinery/door/airlock/hatch/high_sec{
 	name = "Telecomms Server Room"
 	},
 /obj/structure/cable/yellow{
@@ -42422,7 +42421,7 @@
 "bKt" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/machinery/door/airlock/engineering{
+/obj/machinery/door/airlock/engineering/high_sec{
 	name = "Telecomms Storage";
 	req_access_txt = "61"
 	},

--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -1857,14 +1857,14 @@
 /turf/closed/wall,
 /area/security/prison)
 "aem" = (
-/obj/machinery/door/airlock/security/glass{
+/obj/machinery/door/airlock/security/glass/high_sec{
 	name = "Long-Term Cell 3";
 	req_access_txt = "2"
 	},
 /turf/open/floor/plasteel/floorgrime,
 /area/security/prison)
 "aen" = (
-/obj/machinery/door/airlock/security/glass{
+/obj/machinery/door/airlock/security/glass/high_sec{
 	name = "Long-Term Cell 2";
 	req_access_txt = "2"
 	},
@@ -1875,7 +1875,7 @@
 /turf/open/floor/plasteel/floorgrime,
 /area/security/prison)
 "aeo" = (
-/obj/machinery/door/airlock/security/glass{
+/obj/machinery/door/airlock/security/glass/high_sec{
 	name = "Long-Term Cell 1";
 	req_access_txt = "2"
 	},
@@ -66682,7 +66682,7 @@
 /area/science/research)
 "cHZ" = (
 /obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/command{
+/obj/machinery/door/airlock/command/high_sec{
 	name = "Research Division Server Room";
 	req_access = null;
 	req_access_txt = "30"
@@ -67148,7 +67148,7 @@
 /area/science/server)
 "cIX" = (
 /obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/command/glass{
+/obj/machinery/door/airlock/command/glass/high_sec{
 	name = "Server Access";
 	req_access_txt = "30"
 	},

--- a/_maps/map_files/OmegaStation/OmegaStation.dmm
+++ b/_maps/map_files/OmegaStation/OmegaStation.dmm
@@ -24789,7 +24789,7 @@
 	name = "Xenobiology Containment Door"
 	},
 /obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/command/glass{
+/obj/machinery/door/airlock/command/glass/high_sec{
 	name = "Server Access";
 	req_access_txt = "30"
 	},
@@ -25085,7 +25085,7 @@
 	},
 /area/science/research)
 "aXF" = (
-/obj/machinery/door/airlock/command{
+/obj/machinery/door/airlock/command/high_sec{
 	name = "Research Division Server Room";
 	req_access = null;
 	req_access_txt = "30"

--- a/_maps/map_files/OmegaStation/OmegaStation.dmm
+++ b/_maps/map_files/OmegaStation/OmegaStation.dmm
@@ -5757,7 +5757,7 @@
 /obj/structure/cable/white{
 	icon_state = "1-4"
 	},
-/obj/machinery/door/airlock/security{
+/obj/machinery/door/airlock/security/high_sec{
 	name = "Armoury";
 	req_access_txt = "3"
 	},
@@ -18886,7 +18886,7 @@
 /area/engine/gravity_generator)
 "aKs" = (
 /obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/command/glass{
+/obj/machinery/door/airlock/command/glass/high_sec{
 	name = "Gravity Generator Chamber";
 	req_access_txt = "19; 61"
 	},
@@ -19622,7 +19622,7 @@
 /turf/closed/wall/r_wall/rust,
 /area/engine/supermatter)
 "aLR" = (
-/obj/machinery/door/airlock/atmos/glass{
+/obj/machinery/door/airlock/atmos/glass/high_sec{
 	name = "Supermatter Chamber";
 	req_access_txt = "24"
 	},
@@ -19993,7 +19993,7 @@
 /area/tcommsat/server)
 "aML" = (
 /obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/command{
+/obj/machinery/door/airlock/command/high_sec{
 	name = "Telecomms Control Room";
 	req_access = null;
 	req_access_txt = "19; 61"
@@ -22028,7 +22028,7 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/machinery/door/airlock/command{
+/obj/machinery/door/airlock/command/high_sec{
 	cyclelinkeddir = 2;
 	name = "Telecomms Server Room";
 	req_access = null;
@@ -22879,7 +22879,7 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
 "aSM" = (
-/obj/machinery/door/airlock/command{
+/obj/machinery/door/airlock/command/high_sec{
 	cyclelinkeddir = 2;
 	name = "Telecomms Server Room";
 	req_access = null;
@@ -35064,7 +35064,7 @@
 /turf/open/floor/plasteel/vault,
 /area/ai_monitored/turret_protected/aisat_interior)
 "sNk" = (
-/obj/machinery/door/airlock/external{
+/obj/machinery/door/airlock/external/high_sec{
 	cyclelinkeddir = 1;
 	name = "MiniSat External Access";
 	req_access = null;
@@ -35163,7 +35163,7 @@
 	},
 /area/ai_monitored/turret_protected/aisat_interior)
 "sNs" = (
-/obj/machinery/door/airlock/hatch{
+/obj/machinery/door/airlock/hatch/high_sec{
 	name = "MiniSat Antechamber";
 	req_one_access_txt = "32;19"
 	},
@@ -35218,7 +35218,7 @@
 /turf/closed/wall,
 /area/ai_monitored/turret_protected/aisat_interior)
 "sNy" = (
-/obj/machinery/door/airlock/external{
+/obj/machinery/door/airlock/external/high_sec{
 	cyclelinkeddir = 1;
 	name = "MiniSat External Access";
 	req_access = null;

--- a/_maps/map_files/PubbyStation/PubbyStation.dmm
+++ b/_maps/map_files/PubbyStation/PubbyStation.dmm
@@ -2127,7 +2127,7 @@
 /turf/open/floor/plasteel/dark,
 /area/security/execution/transfer)
 "ahm" = (
-/obj/machinery/door/airlock/security/glass{
+/obj/machinery/door/airlock/security/glass/high_sec{
 	name = "Long-Term Cell 2";
 	req_access_txt = "2"
 	},
@@ -2147,7 +2147,7 @@
 /turf/closed/wall,
 /area/security/prison)
 "ahp" = (
-/obj/machinery/door/airlock/security/glass{
+/obj/machinery/door/airlock/security/glass/high_sec{
 	name = "Long-Term Cell 1";
 	req_access_txt = "2"
 	},

--- a/_maps/map_files/PubbyStation/PubbyStation.dmm
+++ b/_maps/map_files/PubbyStation/PubbyStation.dmm
@@ -649,7 +649,7 @@
 /turf/open/floor/plating,
 /area/ai_monitored/turret_protected/AIsatextAP)
 "adv" = (
-/obj/machinery/door/airlock/maintenance_hatch{
+/obj/machinery/door/airlock/maintenance_hatch/high_sec{
 	name = "MiniSat Maintenance";
 	req_access_txt = "65"
 	},
@@ -703,7 +703,7 @@
 /turf/open/floor/plasteel/grimy,
 /area/ai_monitored/turret_protected/aisat_interior)
 "adB" = (
-/obj/machinery/door/airlock/maintenance_hatch{
+/obj/machinery/door/airlock/maintenance_hatch/high_sec{
 	name = "MiniSat Maintenance";
 	req_access_txt = "65"
 	},
@@ -749,7 +749,7 @@
 /turf/closed/wall/r_wall,
 /area/ai_monitored/turret_protected/AIsatextAP)
 "adH" = (
-/obj/machinery/door/airlock/maintenance_hatch{
+/obj/machinery/door/airlock/maintenance_hatch/high_sec{
 	name = "MiniSat Maintenance";
 	req_access_txt = "65"
 	},
@@ -782,7 +782,7 @@
 /area/ai_monitored/turret_protected/aisat_interior)
 "adM" = (
 /obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/hatch{
+/obj/machinery/door/airlock/hatch/high_sec{
 	name = "MiniSat Chamber Observation";
 	req_one_access_txt = "65"
 	},
@@ -814,7 +814,7 @@
 /turf/closed/wall/r_wall,
 /area/ai_monitored/turret_protected/AIsatextAS)
 "adQ" = (
-/obj/machinery/door/airlock/maintenance_hatch{
+/obj/machinery/door/airlock/maintenance_hatch/high_sec{
 	name = "MiniSat Maintenance";
 	req_access_txt = "65"
 	},
@@ -1146,7 +1146,7 @@
 /area/ai_monitored/turret_protected/aisat_interior)
 "aeO" = (
 /obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/hatch{
+/obj/machinery/door/airlock/hatch/high_sec{
 	name = "MiniSat Chamber Hallway";
 	req_one_access_txt = "65"
 	},
@@ -1173,7 +1173,7 @@
 /turf/closed/wall/r_wall,
 /area/ai_monitored/turret_protected/AIsatextAS)
 "aeS" = (
-/obj/machinery/door/airlock/maintenance_hatch{
+/obj/machinery/door/airlock/maintenance_hatch/high_sec{
 	name = "MiniSat Maintenance";
 	req_access_txt = "65"
 	},
@@ -1251,7 +1251,7 @@
 /turf/open/floor/plating,
 /area/ai_monitored/turret_protected/AIsatextAP)
 "afc" = (
-/obj/machinery/door/airlock/maintenance_hatch{
+/obj/machinery/door/airlock/maintenance_hatch/high_sec{
 	name = "MiniSat Maintenance";
 	req_access_txt = "65"
 	},
@@ -1318,7 +1318,7 @@
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/aisat_interior)
 "afi" = (
-/obj/machinery/door/airlock/maintenance_hatch{
+/obj/machinery/door/airlock/maintenance_hatch/high_sec{
 	name = "MiniSat Maintenance";
 	req_access_txt = "65"
 	},
@@ -1756,7 +1756,7 @@
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/aisat_interior)
 "agt" = (
-/obj/machinery/door/airlock/external{
+/obj/machinery/door/airlock/external/high_sec{
 	cyclelinkeddir = 2;
 	name = "MiniSat External Access";
 	req_access = null;
@@ -1977,7 +1977,7 @@
 /turf/open/floor/plating,
 /area/security/main)
 "agR" = (
-/obj/machinery/door/airlock/external{
+/obj/machinery/door/airlock/external/high_sec{
 	cyclelinkeddir = 1;
 	name = "MiniSat External Access";
 	req_access = null;
@@ -2666,14 +2666,13 @@
 /area/security/execution/transfer)
 "aiw" = (
 /obj/machinery/atmospherics/components/binary/pump{
-	dir = 4;
-	layer = 2.4
+	dir = 4
 	},
 /obj/machinery/door/window/southleft{
 	base_state = "right";
 	dir = 4;
 	icon_state = "right";
-	name = "Armory";
+	name = "Transfer Centre Atmos Control";
 	req_access_txt = "2"
 	},
 /obj/effect/turf_decal/stripes/line,
@@ -4258,10 +4257,7 @@
 /turf/open/floor/plating,
 /area/security/warden)
 "ami" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/door/window/southleft{
-	base_state = "right";
-	icon_state = "right";
+/obj/machinery/door/airlock/security/glass/high_sec{
 	name = "Armory";
 	req_access_txt = "3"
 	},
@@ -4282,10 +4278,7 @@
 /turf/open/floor/plating,
 /area/security/warden)
 "amk" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/door/window/southleft{
-	base_state = "right";
-	icon_state = "right";
+/obj/machinery/door/airlock/security/glass/high_sec{
 	name = "Armory";
 	req_access_txt = "3"
 	},
@@ -26662,7 +26655,7 @@
 /area/science/server)
 "bnU" = (
 /obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/command/glass{
+/obj/machinery/door/airlock/command/glass/high_sec{
 	name = "Server Room";
 	req_access_txt = "30"
 	},
@@ -29043,7 +29036,7 @@
 /area/science/server)
 "btf" = (
 /obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/command{
+/obj/machinery/door/airlock/command/high_sec{
 	name = "Server Room";
 	req_access = null;
 	req_access_txt = "30"
@@ -39853,7 +39846,7 @@
 /area/engine/gravity_generator)
 "bRH" = (
 /obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/engineering{
+/obj/machinery/door/airlock/engineering/high_sec{
 	name = "Gravity Generator";
 	req_access_txt = "11"
 	},
@@ -39878,7 +39871,7 @@
 /area/engine/gravity_generator)
 "bRK" = (
 /obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/engineering{
+/obj/machinery/door/airlock/engineering/high_sec{
 	name = "Gravity Generator";
 	req_access_txt = "11"
 	},
@@ -44900,7 +44893,7 @@
 /turf/open/floor/plating,
 /area/engine/engineering)
 "cer" = (
-/obj/machinery/door/airlock/engineering{
+/obj/machinery/door/airlock/engineering/high_sec{
 	name = "Telecommunications Transit Tube";
 	req_access_txt = "10; 61"
 	},
@@ -47017,7 +47010,7 @@
 /turf/open/space,
 /area/space/nearstation)
 "clz" = (
-/obj/machinery/door/airlock/external{
+/obj/machinery/door/airlock/external/high_sec{
 	cyclelinkeddir = 2;
 	name = "Telecommunications External Access";
 	req_access = null;
@@ -47042,7 +47035,7 @@
 /turf/open/floor/plating,
 /area/tcommsat/computer)
 "clD" = (
-/obj/machinery/door/airlock/external{
+/obj/machinery/door/airlock/external/high_sec{
 	cyclelinkeddir = 1;
 	name = "Telecommunications External Access";
 	req_access = null;
@@ -47130,7 +47123,7 @@
 /turf/open/floor/plasteel,
 /area/tcommsat/computer)
 "clT" = (
-/obj/machinery/door/airlock/maintenance_hatch{
+/obj/machinery/door/airlock/maintenance_hatch/high_sec{
 	name = "Telecommunications Maintenance";
 	req_access_txt = "61"
 	},
@@ -47202,7 +47195,7 @@
 /turf/open/floor/plating,
 /area/tcommsat/computer)
 "cmd" = (
-/obj/machinery/door/airlock/engineering{
+/obj/machinery/door/airlock/engineering/high_sec{
 	name = "Telecommunications Chamber";
 	req_access_txt = "61"
 	},
@@ -47268,7 +47261,7 @@
 	},
 /area/tcommsat/computer)
 "cmj" = (
-/obj/machinery/door/airlock/command/glass{
+/obj/machinery/door/airlock/command/glass/high_sec{
 	name = "Control Room";
 	req_access_txt = "19; 61"
 	},
@@ -47397,7 +47390,7 @@
 	},
 /area/tcommsat/computer)
 "cmw" = (
-/obj/machinery/door/airlock/engineering/glass{
+/obj/machinery/door/airlock/engineering/glass/high_sec{
 	cyclelinkeddir = 2;
 	name = "Server Room";
 	req_access_txt = "61"
@@ -47472,7 +47465,7 @@
 /turf/open/floor/plating,
 /area/tcommsat/computer)
 "cmF" = (
-/obj/machinery/door/airlock/engineering/glass{
+/obj/machinery/door/airlock/engineering/glass/high_sec{
 	cyclelinkeddir = 1;
 	name = "Server Room";
 	req_access_txt = "61"

--- a/_maps/map_files/debug/runtimestation.dmm
+++ b/_maps/map_files/debug/runtimestation.dmm
@@ -304,7 +304,7 @@
 /turf/open/floor/plating,
 /area/engine/engineering)
 "aU" = (
-/obj/machinery/door/airlock/engineering/glass{
+/obj/machinery/door/airlock/engineering/glass/high_sec{
 	name = "Gravity Generator";
 	req_access_txt = "11";
 	req_one_access_txt = "0"
@@ -333,7 +333,7 @@
 /turf/open/floor/plasteel,
 /area/engine/gravity_generator)
 "aX" = (
-/obj/machinery/door/airlock/engineering/glass{
+/obj/machinery/door/airlock/engineering/glass/high_sec{
 	name = "Gravity Generator";
 	req_access_txt = "11";
 	req_one_access_txt = "0"

--- a/code/game/machinery/doors/airlock.dm
+++ b/code/game/machinery/doors/airlock.dm
@@ -801,7 +801,7 @@
 					var/obj/item/crowbar/W = C
 					to_chat(user, "<span class='notice'>You start removing the inner layer of shielding...</span>")
 					playsound(src, W.usesound, 100, 1)
-					if(do_after(user, 40*W.toolspeed, 1, target = src))
+					if(do_after(user, 20*W.toolspeed, 1, target = src))
 						if(!panel_open)
 							return
 						if(security_level != AIRLOCK_SECURITY_PLASTEEL_I_S)
@@ -835,7 +835,7 @@
 					var/obj/item/crowbar/W = C
 					to_chat(user, "<span class='notice'>You start removing outer layer of shielding...</span>")
 					playsound(src, W.usesound, 100, 1)
-					if(do_after(user, 40*W.toolspeed, 1, target = src))
+					if(do_after(user, 20*W.toolspeed, 1, target = src))
 						if(!panel_open)
 							return
 						if(security_level != AIRLOCK_SECURITY_PLASTEEL_O_S)

--- a/code/game/machinery/doors/airlock.dm
+++ b/code/game/machinery/doors/airlock.dm
@@ -51,7 +51,7 @@
 	damage_deflection = AIRLOCK_DAMAGE_DEFLECTION_N
 	interact_open = TRUE
 
-	var/security_level = 0 //How much are wires secured
+	var/security_level = AIRLOCK_SECURITY_NONE //How much are wires secured
 	var/aiControlDisabled = 0 //If 1, AI control is disabled until the AI hacks back in and disables the lock. If 2, the AI has bypassed the lock. If -1, the control is enabled but the AI had bypassed it earlier, so if it is disabled again the AI would have no trouble getting back in.
 	var/hackProof = FALSE // if true, this door can't be hacked by the AI
 	var/secondsMainPowerLost = 0 //The number of seconds until power is restored.
@@ -100,7 +100,6 @@
 
 /obj/machinery/door/airlock/Initialize()
 	. = ..()
-	wires = new /datum/wires/airlock(src)
 	if (cyclelinkeddir)
 		cyclelinkairlock()
 	if(frequency)
@@ -111,9 +110,11 @@
 	if(glass)
 		airlock_material = "glass"
 	if(security_level > AIRLOCK_SECURITY_METAL)
+		wires = new /datum/wires/airlock/secure(src)
 		obj_integrity = normal_integrity * AIRLOCK_INTEGRITY_MULTIPLIER
 		max_integrity = normal_integrity * AIRLOCK_INTEGRITY_MULTIPLIER
 	else
+		wires = new /datum/wires/airlock(src)
 		obj_integrity = normal_integrity
 		max_integrity = normal_integrity
 	if(damage_deflection == AIRLOCK_DAMAGE_DEFLECTION_N && security_level > AIRLOCK_SECURITY_METAL)
@@ -1610,14 +1611,6 @@
 #undef AIRLOCK_OPENING
 #undef AIRLOCK_DENY
 #undef AIRLOCK_EMAG
-
-#undef AIRLOCK_SECURITY_NONE
-#undef AIRLOCK_SECURITY_METAL
-#undef AIRLOCK_SECURITY_PLASTEEL_I_S
-#undef AIRLOCK_SECURITY_PLASTEEL_I
-#undef AIRLOCK_SECURITY_PLASTEEL_O_S
-#undef AIRLOCK_SECURITY_PLASTEEL_O
-#undef AIRLOCK_SECURITY_PLASTEEL
 
 #undef AIRLOCK_INTEGRITY_N
 #undef AIRLOCK_INTEGRITY_MULTIPLIER

--- a/code/game/machinery/doors/airlock_types.dm
+++ b/code/game/machinery/doors/airlock_types.dm
@@ -9,15 +9,27 @@
 	icon = 'icons/obj/doors/airlocks/station/command.dmi'
 	assemblytype = /obj/structure/door_assembly/door_assembly_com
 	normal_integrity = 450
+	security_level = AIRLOCK_SECURITY_PLASTEEL_I
+
+/obj/machinery/door/airlock/command/high_sec
+	security_level = AIRLOCK_SECURITY_PLASTEEL
 
 /obj/machinery/door/airlock/security
 	icon = 'icons/obj/doors/airlocks/station/security.dmi'
 	assemblytype = /obj/structure/door_assembly/door_assembly_sec
 	normal_integrity = 450
+	security_level = AIRLOCK_SECURITY_PLASTEEL_O
+
+/obj/machinery/door/airlock/security/high_sec
+	security_level = AIRLOCK_SECURITY_PLASTEEL
 
 /obj/machinery/door/airlock/engineering
 	icon = 'icons/obj/doors/airlocks/station/engineering.dmi'
 	assemblytype = /obj/structure/door_assembly/door_assembly_eng
+	security_level = AIRLOCK_SECURITY_METAL
+
+/obj/machinery/door/airlock/engineering/high_sec
+	security_level = AIRLOCK_SECURITY_PLASTEEL
 
 /obj/machinery/door/airlock/engineering/abandoned
 	abandoned = TRUE
@@ -49,6 +61,10 @@
 	name = "atmospherics airlock"
 	icon = 'icons/obj/doors/airlocks/station/atmos.dmi'
 	assemblytype = /obj/structure/door_assembly/door_assembly_atmo
+	security_level = AIRLOCK_SECURITY_METAL
+
+/obj/machinery/door/airlock/atmos/high_sec
+	security_level = AIRLOCK_SECURITY_PLASTEEL
 
 /obj/machinery/door/airlock/atmos/abandoned
 	abandoned = TRUE
@@ -67,6 +83,7 @@
 	assemblytype = /obj/structure/door_assembly/door_assembly_science
 
 /obj/machinery/door/airlock/virology
+	security_level = AIRLOCK_SECURITY_PLASTEEL_I
 	icon = 'icons/obj/doors/airlocks/station/virology.dmi'
 	assemblytype = /obj/structure/door_assembly/door_assembly_viro
 
@@ -84,14 +101,23 @@
 	glass = TRUE
 	normal_integrity = 400
 
+/obj/machinery/door/airlock/command/glass/high_sec
+	security_level = AIRLOCK_SECURITY_PLASTEEL
+
 /obj/machinery/door/airlock/engineering/glass
 	opacity = 0
 	glass = TRUE
+
+/obj/machinery/door/airlock/engineering/glass/high_sec
+	security_level = AIRLOCK_SECURITY_PLASTEEL
 
 /obj/machinery/door/airlock/security/glass
 	opacity = 0
 	glass = TRUE
 	normal_integrity = 400
+
+/obj/machinery/door/airlock/security/glass/high_sec
+	security_level = AIRLOCK_SECURITY_PLASTEEL
 
 /obj/machinery/door/airlock/security/glass/abandoned
 	abandoned = TRUE
@@ -111,6 +137,9 @@
 /obj/machinery/door/airlock/atmos/glass
 	opacity = 0
 	glass = TRUE
+
+/obj/machinery/door/airlock/atmos/glass/high_sec
+	security_level = AIRLOCK_SECURITY_PLASTEEL
 
 /obj/machinery/door/airlock/science/glass
 	opacity = 0
@@ -293,6 +322,9 @@
 	note_overlay_file = 'icons/obj/doors/airlocks/external/overlays.dmi'
 	assemblytype = /obj/structure/door_assembly/door_assembly_ext
 
+/obj/machinery/door/airlock/external/high_sec
+	security_level = AIRLOCK_SECURITY_PLASTEEL
+
 /obj/machinery/door/airlock/external/glass
 	opacity = 0
 	glass = TRUE
@@ -307,7 +339,7 @@
 	overlays_file = 'icons/obj/doors/airlocks/centcom/overlays.dmi'
 	assemblytype = /obj/structure/door_assembly/door_assembly_centcom
 	normal_integrity = 1000
-	security_level = 6
+	security_level = AIRLOCK_SECURITY_PLASTEEL
 	explosion_block = 2
 
 /obj/machinery/door/airlock/centcom/abandoned
@@ -325,7 +357,7 @@
 	assemblytype = /obj/structure/door_assembly/door_assembly_vault
 	explosion_block = 2
 	normal_integrity = 400 // reverse engieneerd: 400 * 1.5 (sec lvl 6) = 600 = original
-	security_level = 6
+	security_level = AIRLOCK_SECURITY_PLASTEEL
 
 //////////////////////////////////
 /*
@@ -339,12 +371,18 @@
 	note_overlay_file = 'icons/obj/doors/airlocks/hatch/overlays.dmi'
 	assemblytype = /obj/structure/door_assembly/door_assembly_hatch
 
+/obj/machinery/door/airlock/hatch/high_sec
+	security_level = AIRLOCK_SECURITY_PLASTEEL
+
 /obj/machinery/door/airlock/maintenance_hatch
 	name = "maintenance hatch"
 	icon = 'icons/obj/doors/airlocks/hatch/maintenance.dmi'
 	overlays_file = 'icons/obj/doors/airlocks/hatch/overlays.dmi'
 	note_overlay_file = 'icons/obj/doors/airlocks/hatch/overlays.dmi'
 	assemblytype = /obj/structure/door_assembly/door_assembly_mhatch
+
+/obj/machinery/door/airlock/maintenance_hatch/high_sec
+	security_level = AIRLOCK_SECURITY_PLASTEEL
 
 /obj/machinery/door/airlock/maintenance_hatch/abandoned
 	abandoned = TRUE
@@ -361,7 +399,7 @@
 	assemblytype = /obj/structure/door_assembly/door_assembly_highsecurity
 	explosion_block = 2
 	normal_integrity = 500
-	security_level = 1
+	security_level = AIRLOCK_SECURITY_PLASTEEL
 	damage_deflection = 30
 
 //////////////////////////////////
@@ -374,6 +412,7 @@
 	icon = 'icons/obj/doors/airlocks/shuttle/shuttle.dmi'
 	overlays_file = 'icons/obj/doors/airlocks/shuttle/overlays.dmi'
 	assemblytype = /obj/structure/door_assembly/door_assembly_shuttle
+	security_level = AIRLOCK_SECURITY_METAL
 
 /obj/machinery/door/airlock/shuttle/glass
 	opacity = 0
@@ -391,7 +430,7 @@
 	hackProof = TRUE
 	aiControlDisabled = 1
 	normal_integrity = 700
-	security_level = 1
+	security_level = AIRLOCK_SECURITY_PLASTEEL
 
 //////////////////////////////////
 /*
@@ -402,6 +441,7 @@
 	name = "cult airlock"
 	icon = 'icons/obj/doors/airlocks/cult/runed/cult.dmi'
 	overlays_file = 'icons/obj/doors/airlocks/cult/runed/overlays.dmi'
+	security_level = AIRLOCK_SECURITY_PLASTEEL
 	assemblytype = /obj/structure/door_assembly/door_assembly_cult
 	hackProof = TRUE
 	aiControlDisabled = TRUE
@@ -467,6 +507,7 @@
 	desc = "A massive cogwheel set into two heavy slabs of brass."
 	icon = 'icons/obj/doors/airlocks/clockwork/pinion_airlock.dmi'
 	overlays_file = 'icons/obj/doors/airlocks/clockwork/overlays.dmi'
+	security_level = AIRLOCK_SECURITY_PLASTEEL
 	hackProof = TRUE
 	aiControlDisabled = TRUE
 	req_access = list(ACCESS_CLOCKCULT)

--- a/code/game/machinery/doors/airlock_types.dm
+++ b/code/game/machinery/doors/airlock_types.dm
@@ -9,19 +9,19 @@
 	icon = 'icons/obj/doors/airlocks/station/command.dmi'
 	assemblytype = /obj/structure/door_assembly/door_assembly_com
 	normal_integrity = 450
-	security_level = AIRLOCK_SECURITY_PLASTEEL_I
+	security_level = AIRLOCK_SECURITY_METAL
 
 /obj/machinery/door/airlock/command/high_sec
-	security_level = AIRLOCK_SECURITY_PLASTEEL
+	security_level = AIRLOCK_SECURITY_PLASTEEL_I
 
 /obj/machinery/door/airlock/security
 	icon = 'icons/obj/doors/airlocks/station/security.dmi'
 	assemblytype = /obj/structure/door_assembly/door_assembly_sec
 	normal_integrity = 450
-	security_level = AIRLOCK_SECURITY_PLASTEEL_O
+	security_level = AIRLOCK_SECURITY_METAL
 
 /obj/machinery/door/airlock/security/high_sec
-	security_level = AIRLOCK_SECURITY_PLASTEEL
+	security_level = AIRLOCK_SECURITY_PLASTEEL_I
 
 /obj/machinery/door/airlock/engineering
 	icon = 'icons/obj/doors/airlocks/station/engineering.dmi'
@@ -29,7 +29,7 @@
 	security_level = AIRLOCK_SECURITY_METAL
 
 /obj/machinery/door/airlock/engineering/high_sec
-	security_level = AIRLOCK_SECURITY_PLASTEEL
+	security_level = AIRLOCK_SECURITY_PLASTEEL_I
 
 /obj/machinery/door/airlock/engineering/abandoned
 	abandoned = TRUE
@@ -64,7 +64,7 @@
 	security_level = AIRLOCK_SECURITY_METAL
 
 /obj/machinery/door/airlock/atmos/high_sec
-	security_level = AIRLOCK_SECURITY_PLASTEEL
+	security_level = AIRLOCK_SECURITY_PLASTEEL_I
 
 /obj/machinery/door/airlock/atmos/abandoned
 	abandoned = TRUE
@@ -102,14 +102,14 @@
 	normal_integrity = 400
 
 /obj/machinery/door/airlock/command/glass/high_sec
-	security_level = AIRLOCK_SECURITY_PLASTEEL
+	security_level = AIRLOCK_SECURITY_PLASTEEL_I
 
 /obj/machinery/door/airlock/engineering/glass
 	opacity = 0
 	glass = TRUE
 
 /obj/machinery/door/airlock/engineering/glass/high_sec
-	security_level = AIRLOCK_SECURITY_PLASTEEL
+	security_level = AIRLOCK_SECURITY_PLASTEEL_I
 
 /obj/machinery/door/airlock/security/glass
 	opacity = 0
@@ -117,7 +117,7 @@
 	normal_integrity = 400
 
 /obj/machinery/door/airlock/security/glass/high_sec
-	security_level = AIRLOCK_SECURITY_PLASTEEL
+	security_level = AIRLOCK_SECURITY_PLASTEEL_I
 
 /obj/machinery/door/airlock/security/glass/abandoned
 	abandoned = TRUE
@@ -139,7 +139,7 @@
 	glass = TRUE
 
 /obj/machinery/door/airlock/atmos/glass/high_sec
-	security_level = AIRLOCK_SECURITY_PLASTEEL
+	security_level = AIRLOCK_SECURITY_PLASTEEL_I
 
 /obj/machinery/door/airlock/science/glass
 	opacity = 0
@@ -372,7 +372,7 @@
 	assemblytype = /obj/structure/door_assembly/door_assembly_hatch
 
 /obj/machinery/door/airlock/hatch/high_sec
-	security_level = AIRLOCK_SECURITY_PLASTEEL
+	security_level = AIRLOCK_SECURITY_PLASTEEL_I
 
 /obj/machinery/door/airlock/maintenance_hatch
 	name = "maintenance hatch"
@@ -382,7 +382,7 @@
 	assemblytype = /obj/structure/door_assembly/door_assembly_mhatch
 
 /obj/machinery/door/airlock/maintenance_hatch/high_sec
-	security_level = AIRLOCK_SECURITY_PLASTEEL
+	security_level = AIRLOCK_SECURITY_PLASTEEL_I
 
 /obj/machinery/door/airlock/maintenance_hatch/abandoned
 	abandoned = TRUE
@@ -399,7 +399,7 @@
 	assemblytype = /obj/structure/door_assembly/door_assembly_highsecurity
 	explosion_block = 2
 	normal_integrity = 500
-	security_level = AIRLOCK_SECURITY_PLASTEEL
+	security_level = AIRLOCK_SECURITY_PLASTEEL_O
 	damage_deflection = 30
 
 //////////////////////////////////


### PR DESCRIPTION
Implements better door security across the station.

Doors with access to sensitive equipment, such as the Gravity Generator, the Supermatter Engine, the Armory, and Telecomms, will all now take a few extra steps to hack into.

Doors with security protection levels beyond AIRLOCK_SECURITY_METAL will now also have their wiring randomized.


Adjusted the time it takes to hack into a higher security airlock (delay is decreased by toolspeed);

**OLD**
AIRLOCK_SECURITY_METAL = 4 seconds
AIRLOCK_SECURITY_PLASTEEL_I = 12 seconds
AIRLOCK_SECURITY_PLASTEEL_O = 20 seconds
AIRLOCK_SECURITY_PLASTEEL = 21 seconds _(only used by CENTCOM zlevel & vault doors)_

**NEW**
AIRLOCK_SECURITY_METAL = 4 seconds
AIRLOCK_SECURITY_PLASTEEL_I = 10 seconds
AIRLOCK_SECURITY_PLASTEEL_O = 16 seconds
AIRLOCK_SECURITY_PLASTEEL = 17 seconds _(only used by CENTCOM zlevel & vault doors)_


:cl: ShizCalev
balance: Due to an increased threat of hostile presence across Nanotrasen stations, the security levels of doors onboard all stations has been increased. In some cases, internal wiring of such doors will also now be randomized to further heighten their security.
/:cl:


Also corrected a few incorrectly named airlocks / windoors in a couple locations.