### PR TITLE
Fixes a naughty dot

### DIFF
--- a/code/modules/client/verbs/ooc.dm
+++ b/code/modules/client/verbs/ooc.dm
@@ -247,7 +247,7 @@ GLOBAL_VAR_INIT(normal_ooc_colour, OOC_COLOR)
 	browse_messages(null, usr.ckey, null, TRUE)
 
 /client/proc/self_playtime()
-	set name = "View tracked playtime."
+	set name = "View tracked playtime"
 	set category = "OOC"
 	set desc = "View the amount of playtime for roles the server has tracked."
 


### PR DESCRIPTION
Does this need a changelog?
It just removes a dot from a verb that shouldn't be there