### PR TITLE
Changes stunbaton battery examine text to use [src]

### DIFF
--- a/code/game/objects/items/stunbaton.dm
+++ b/code/game/objects/items/stunbaton.dm
@@ -63,9 +63,9 @@
 /obj/item/melee/baton/examine(mob/user)
 	..()
 	if(cell)
-		to_chat(user, "<span class='notice'>The baton is [round(cell.percent())]% charged.</span>")
+		to_chat(user, "<span class='notice'>The [src] is [round(cell.percent())]% charged.</span>")
 	else
-		to_chat(user, "<span class='warning'>The baton does not have a power source installed.</span>")
+		to_chat(user, "<span class='warning'>The [src] does not have a power source installed.</span>")
 
 /obj/item/melee/baton/attackby(obj/item/W, mob/user, params)
 	if(istype(W, /obj/item/stock_parts/cell))

--- a/code/game/objects/items/stunbaton.dm
+++ b/code/game/objects/items/stunbaton.dm
@@ -63,9 +63,9 @@
 /obj/item/melee/baton/examine(mob/user)
 	..()
 	if(cell)
-		to_chat(user, "<span class='notice'>The [src] is [round(cell.percent())]% charged.</span>")
+		to_chat(user, "<span class='notice'>[src] is [round(cell.percent())]% charged.</span>")
 	else
-		to_chat(user, "<span class='warning'>The [src] does not have a power source installed.</span>")
+		to_chat(user, "<span class='warning'>[src] does not have a power source installed.</span>")
 
 /obj/item/melee/baton/attackby(obj/item/W, mob/user, params)
 	if(istype(W, /obj/item/stock_parts/cell))

--- a/code/game/objects/items/stunbaton.dm
+++ b/code/game/objects/items/stunbaton.dm
@@ -63,9 +63,9 @@
 /obj/item/melee/baton/examine(mob/user)
 	..()
 	if(cell)
-		to_chat(user, "<span class='notice'>[src] is [round(cell.percent())]% charged.</span>")
+		to_chat(user, "<span class='notice'>\The [src] is [round(cell.percent())]% charged.</span>")
 	else
-		to_chat(user, "<span class='warning'>[src] does not have a power source installed.</span>")
+		to_chat(user, "<span class='warning'>\The [src] does not have a power source installed.</span>")
 
 /obj/item/melee/baton/attackby(obj/item/W, mob/user, params)
 	if(istype(W, /obj/item/stock_parts/cell))


### PR DESCRIPTION
:cl:
spellcheck: The text you get when you examine a stunbaton to see the battery level now uses the item's name instead of "baton"
/:cl: