### PR TITLE
Add whiteship dock to space ruin code

### DIFF
--- a/code/datums/ruins/space.dm
+++ b/code/datums/ruins/space.dm
@@ -262,3 +262,9 @@
 	name = "NT Medical Ship"
 	description = "An ancient ship, said to be among the first discovered derelicts near Space Station 13 that was still in working order. \
 	Aged and deprecated by time, this relic of a vessel is now broken beyond repair."
+
+/datum/map_template/ruin/space/whiteshipdock
+	id = "whiteshipdock"
+	suffix = "whiteshipdock.dmm"
+	name = "Whiteship Dock"
+	description = "An abandoned but functional vessel parked in deep space, ripe for the taking."

--- a/config/spaceruinblacklist.txt
+++ b/config/spaceruinblacklist.txt
@@ -42,3 +42,4 @@
 #_maps/RandomRuins/SpaceRuins/bus.dmm
 #_maps/RandomRuins/SpaceRuins/miracle.dmm
 #_maps/RandomRuins/SpaceRuins/oldstation.dmm
+#_maps/RandomRuins/SpaceRuins/whiteshipdock.dmm


### PR DESCRIPTION
First time doing space ruins and I just realized I forgot a step in #35128. Tested prim & proper this time. The whiteship *does* spawn and flies fine, though the ruin landmark gets deleted in the process.