### PR TITLE
Cleans up single frame get flat icon.

### DIFF
--- a/code/__HELPERS/icons.dm
+++ b/code/__HELPERS/icons.dm
@@ -890,7 +890,10 @@ The _flatIcons list is a cache for generated icon files.
 		flat.Blend(rgb(255, 255, 255, A.alpha), ICON_MULTIPLY)
 
 	if(no_anim)
-		return icon(flat, "", SOUTH, frame=1)
+		//Clean up repeated frames
+		var/icon/cleaned = new /icon()
+		cleaned.Insert(flat, "", SOUTH, 1, 0)
+		return cleaned
 	else
 		return icon(flat, "", SOUTH)
 

--- a/code/game/machinery/newscaster.dm
+++ b/code/game/machinery/newscaster.dm
@@ -164,8 +164,10 @@ GLOBAL_LIST_EMPTY(allCasters)
 /datum/newscaster/feed_network/proc/save_photo(icon/photo)
 	var/photo_file = copytext(md5("\icon[photo]"), 1, 6)
 	if(!fexists("[GLOB.log_directory]/photos/[photo_file].png"))
-		var/icon/p = icon(photo, frame = 1)
-		fcopy(p, "[GLOB.log_directory]/photos/[photo_file].png")
+		//Clean up repeated frames
+		var/icon/clean = new /icon()
+		clean.Insert(photo, "", SOUTH, 1, 0)
+		fcopy(clean, "[GLOB.log_directory]/photos/[photo_file].png")
 	return photo_file
 
 /obj/item/wallframe/newscaster


### PR DESCRIPTION
Turns out icon(frame = 1) doesn't do what's advertised.