### PR TITLE
Syndicate bundles now spawn with dufflebags instead of boxes

### DIFF
--- a/code/game/objects/items/storage/uplink_kits.dm
+++ b/code/game/objects/items/storage/uplink_kits.dm
@@ -1,6 +1,6 @@
 /obj/item/storage/box/syndicate
 
-/obj/item/storage/box/syndicate/PopulateContents()
+/obj/item/storage/backpack/duffelbag/syndie/PopulateContents()
 	switch (pickweight(list("bloodyspai" = 3, "stealth" = 2, "bond" = 2, "screwed" = 2, "sabotage" = 3, "guns" = 2, "murder" = 2, "implant" = 1, "hacker" = 3, "darklord" = 1, "sniper" = 1, "metaops" = 1, "ninja" = 1)))
 		if("bloodyspai") // 27 tc now this is more right
 			new /obj/item/clothing/under/chameleon(src) // 2 tc since it's not the full set

--- a/code/modules/uplink/uplink_items.dm
+++ b/code/modules/uplink/uplink_items.dm
@@ -1355,10 +1355,10 @@ GLOBAL_LIST_EMPTY(uplink_items) // Global list so we only initialize this once.
 
 /datum/uplink_item/badass/bundle
 	name = "Syndicate Bundle"
-	desc = "Syndicate Bundles are specialized groups of items that arrive in a plain box. \
+	desc = "Syndicate Bundles are specialized groups of items that arrive in a Syndicate dufflebag. \
 			These items are collectively worth more than 20 telecrystals, but you do not know which specialization \
 			you will receive."
-	item = /obj/item/storage/box/syndicate
+	item = /obj/item/storage/backpack/duffelbag/syndie
 	cost = 20
 	exclude_modes = list(/datum/game_mode/nuclear)
 	cant_discount = TRUE


### PR DESCRIPTION
Syndicate bundles now spawn in dufflebags instead of an box

closes #23127

:cl: Improvedname
balance: syndicate bundles now spawn in dufflebags
/:cl:

[why]: # (Please add a short description [two lines down] of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.)
