### PR TITLE
removed vapes from vendors

### DIFF
--- a/code/game/machinery/vending.dm
+++ b/code/game/machinery/vending.dm
@@ -831,7 +831,7 @@ IF YOU MODIFY THE PRODUCTS LIST OF A MACHINE, MAKE SURE TO UPDATE ITS RESUPPLY C
 					/obj/item/storage/box/matches = 10,
 					/obj/item/lighter/greyscale = 4,
 					/obj/item/storage/fancy/rollingpapers = 5)
-	contraband = list(/obj/item/lighter = 3, /obj/item/clothing/mask/vape = 5)
+	contraband = list(/obj/item/lighter = 3) // vapes were removed on 31/01/18, never again you'll be allowed to vape touch-based chems 
 	premium = list(/obj/item/storage/fancy/cigarettes/cigpack_robustgold = 3, \
 	/obj/item/storage/fancy/cigarettes/cigars = 1, /obj/item/storage/fancy/cigarettes/cigars/havana = 1, /obj/item/storage/fancy/cigarettes/cigars/cohiba = 1)
 	refill_canister = /obj/item/vending_refill/cigarette

--- a/code/game/objects/items/vending_items.dm
+++ b/code/game/objects/items/vending_items.dm
@@ -60,8 +60,8 @@
 /obj/item/vending_refill/cigarette
 	machine_name = "ShadyCigs Deluxe"
 	icon_state = "refill_smoke"
-	charges = list(12, 3, 2)// of 36 standard, 9 contraband, 6 premium
-	init_charges = list(12, 3, 2)
+	charges = list(12, 1, 2)// of 36 standard, 3 contraband, 6 premium
+	init_charges = list(12, 1, 2)
 
 /obj/item/vending_refill/autodrobe
 	machine_name = "AutoDrobe"


### PR DESCRIPTION
removed vapes from vendors because you could vape touch-based chems like synthflesh and with that new cult update or some shit idk you could vape blood and shoot trillion missiles

:cl: Frozenguy5
del: Removed vapes from vendors.
/:cl: