### PR TITLE
Lavaland bomb runtime fix

### DIFF
--- a/code/game/objects/effects/decals/cleanable.dm
+++ b/code/game/objects/effects/decals/cleanable.dm
@@ -24,8 +24,6 @@
 		if(LAZYLEN(diseases_to_add))
 			AddComponent(/datum/component/infective, diseases_to_add)
 
-	return//. = ..()//cleanable stuff sometimes needs to be in objs
-
 /obj/effect/decal/cleanable/proc/replace_decal(obj/effect/decal/cleanable/C) // Returns true if we should give up in favor of the pre-existing decal
 	if(mergeable_decal)
 		return TRUE

--- a/code/game/objects/effects/decals/cleanable.dm
+++ b/code/game/objects/effects/decals/cleanable.dm
@@ -7,13 +7,15 @@
 	var/mergeable_decal = TRUE //when two of these are on a same tile or do we need to merge them into just one?
 
 /obj/effect/decal/cleanable/Initialize(mapload, list/datum/disease/diseases)
+	. = ..()
 	if (random_icon_states && length(src.random_icon_states) > 0)
 		src.icon_state = pick(src.random_icon_states)
 	create_reagents(300)
 	if(src.loc && isturf(src.loc))
 		for(var/obj/effect/decal/cleanable/C in src.loc)
-			if(C != src && C.type == src.type)
-				replace_decal(C)
+			if(C != src && C.type == src.type && !QDELETED(C))
+				if (replace_decal(C))
+					return INITIALIZE_HINT_QDEL
 	if(LAZYLEN(diseases))
 		var/list/datum/disease/diseases_to_add = list()
 		for(var/datum/disease/D in diseases)
@@ -24,9 +26,9 @@
 
 	return//. = ..()//cleanable stuff sometimes needs to be in objs
 
-/obj/effect/decal/cleanable/proc/replace_decal(obj/effect/decal/cleanable/C)
+/obj/effect/decal/cleanable/proc/replace_decal(obj/effect/decal/cleanable/C) // Returns true if we should give up in favor of the pre-existing decal
 	if(mergeable_decal)
-		qdel(C)
+		return TRUE
 
 /obj/effect/decal/cleanable/attackby(obj/item/W, mob/user, params)
 	if(istype(W, /obj/item/reagent_containers/glass) || istype(W, /obj/item/reagent_containers/food/drinks))

--- a/code/game/objects/effects/decals/cleanable/humans.dm
+++ b/code/game/objects/effects/decals/cleanable/humans.dm
@@ -8,8 +8,8 @@
 	bloodiness = MAX_SHOE_BLOODINESS
 
 /obj/effect/decal/cleanable/blood/replace_decal(obj/effect/decal/cleanable/blood/C)
-	add_blood_DNA(C.return_blood_DNA())
-	..()
+	C.add_blood_DNA(return_blood_DNA())
+	return ..()
 
 /obj/effect/decal/cleanable/blood/old
 	name = "dried blood"
@@ -17,9 +17,9 @@
 	bloodiness = 0
 
 /obj/effect/decal/cleanable/blood/old/Initialize(mapload, list/datum/disease/diseases)
-	. = ..()
 	icon_state += "-old" //This IS necessary because the parent /blood type uses icon randomization.
-	add_blood_DNA(list("Non-human DNA" = "A+"))
+	add_blood_DNA(list("Non-human DNA" = "A+")) // Needs to happen before ..()
+	return ..()
 
 /obj/effect/decal/cleanable/blood/splatter
 	random_icon_states = list("gibbl1", "gibbl2", "gibbl3", "gibbl4", "gibbl5")
@@ -184,4 +184,3 @@
 	if((blood_state != BLOOD_STATE_OIL) && (blood_state != BLOOD_STATE_NOT_BLOODY))
 		return 1
 	return 0
-

--- a/code/game/turfs/simulated/lava.dm
+++ b/code/game/turfs/simulated/lava.dm
@@ -100,7 +100,7 @@
 				O.resistance_flags |= FLAMMABLE //Even fireproof things burn up in lava
 			if(O.resistance_flags & FIRE_PROOF)
 				O.resistance_flags &= ~FIRE_PROOF
-			if(O.armor.fire > 50) //obj with 100% fire armor still get slowly burned away.
+			if(istype(O.armor, /datum/armor) && O.armor.fire > 50)
 				O.armor = O.armor.setRating(fire = 50)
 			O.fire_act(10000, 1000)
 

--- a/code/game/turfs/simulated/lava.dm
+++ b/code/game/turfs/simulated/lava.dm
@@ -100,7 +100,7 @@
 				O.resistance_flags |= FLAMMABLE //Even fireproof things burn up in lava
 			if(O.resistance_flags & FIRE_PROOF)
 				O.resistance_flags &= ~FIRE_PROOF
-			if(istype(O.armor, /datum/armor) && O.armor.fire > 50)
+			if(O.armor.fire > 50) //obj with 100% fire armor still get slowly burned away.
 				O.armor = O.armor.setRating(fire = 50)
 			O.fire_act(10000, 1000)
 


### PR DESCRIPTION
Fixes #35158

~This seems to be caused by yet-to-be-initialized ores etc getting thrown into/across lava. The nearby code kind of ought to be refactored but that's a job for another PR, currently touching lava permanently alters objects by removing their fireproofness, making them flammable and changing their armor.~

Turns out cleanables were the culprit, they weren't getting initialized because of the changes in #35072 

I also took the opportunity to fix some longstanding issues with their initialization (decal replacing now works by initializing decals deleting themselves in favor of the existing one, instead of an existing decal being deleted, sometimes before its initialization has run)