### PR TITLE
Disentangles Command Reports from Metagame

### DIFF
--- a/code/controllers/configuration/configuration.dm
+++ b/code/controllers/configuration/configuration.dm
@@ -168,7 +168,7 @@ GLOBAL_PROTECT(config_dir)
 				mode_names[M.config_tag] = M.name
 				probabilities[M.config_tag] = M.probability
 				mode_reports[M.config_tag] = M.generate_report()
-				if(M.probability)
+				if(probabilities[M.config_tag]>0)
 					mode_false_report_weight[M.config_tag] = M.false_report_weight
 				else
 					mode_false_report_weight[M.config_tag] = 1

--- a/code/game/gamemodes/game_mode.dm
+++ b/code/game/gamemodes/game_mode.dm
@@ -297,11 +297,15 @@
 	var/list/report_weights = config.mode_false_report_weight.Copy()
 	report_weights[config_tag] = 0 //Prevent the current mode from being falsely selected.
 	var/list/reports = list()
-	for(var/i in 1 to rand(3,5)) //Between three and five wrong entries on the list.
+	var/Count = 0 //To compensate for missing correct report
+	if(prob(65)) // 65% chance the actual mode will appear on the list
+		reports += config.mode_reports[config_tag]
+		Count++
+	for(var/i in Count to rand(3,5)) //Between three and five wrong entries on the list.
 		var/false_report_type = pickweightAllowZero(report_weights)
 		report_weights[false_report_type] = 0 //Make it so the same false report won't be selected twice
 		reports += config.mode_reports[false_report_type]
-	reports += config.mode_reports[config_tag]
+
 	reports = shuffle(reports) //Randomize the order, so the real one is at a random position.
 
 	for(var/report in reports)


### PR DESCRIPTION
:cl: Robustin
fix: Command reports should now properly weight the appearance of modes based on their existence in our actual game rotation.
balance: The current mode now has a 35% chance of not appearing in the report.
/:cl:

Again not 100% sure the fix will work because I can't test that shit locally, but the 35% failure rate alone should do a good job of preventing metagaming. 