### PR TITLE
Hijack objectives will only be given out if there are 30 or more players.

### DIFF
--- a/code/modules/antagonists/traitor/datum_traitor.dm
+++ b/code/modules/antagonists/traitor/datum_traitor.dm
@@ -86,7 +86,7 @@
 
 /datum/antagonist/traitor/human/forge_traitor_objectives()
 	var/is_hijacker = FALSE
-	if (GLOB.joined_player_list.len > 30) // Less murderboning on lowpop thanks
+	if (GLOB.joined_player_list.len >= 30) // Less murderboning on lowpop thanks
 		is_hijacker = prob(10)
 	var/martyr_chance = prob(20)
 	var/objective_count = is_hijacker 			//Hijacking counts towards number of objectives

--- a/code/modules/antagonists/traitor/datum_traitor.dm
+++ b/code/modules/antagonists/traitor/datum_traitor.dm
@@ -85,7 +85,9 @@
 	return
 
 /datum/antagonist/traitor/human/forge_traitor_objectives()
-	var/is_hijacker = prob(10)
+	var/is_hijacker = FALSE
+	if (GLOB.player_list.len > 30) // Less murderboning on lowpop thanks
+		is_hijacker = prob(10)
 	var/martyr_chance = prob(20)
 	var/objective_count = is_hijacker 			//Hijacking counts towards number of objectives
 	if(!SSticker.mode.exchange_blue && SSticker.mode.traitors.len >= 8) 	//Set up an exchange if there are enough traitors

--- a/code/modules/antagonists/traitor/datum_traitor.dm
+++ b/code/modules/antagonists/traitor/datum_traitor.dm
@@ -86,7 +86,7 @@
 
 /datum/antagonist/traitor/human/forge_traitor_objectives()
 	var/is_hijacker = FALSE
-	if (GLOB.player_list.len > 30) // Less murderboning on lowpop thanks
+	if (GLOB.joined_player_list.len > 30) // Less murderboning on lowpop thanks
 		is_hijacker = prob(10)
 	var/martyr_chance = prob(20)
 	var/objective_count = is_hijacker 			//Hijacking counts towards number of objectives


### PR DESCRIPTION
[Changelogs]: 
:cl: Dax Dupont
tweak: Hijack objectives will only be given out if there are 30 or more players.
/:cl:

[why]: From Beesting: It's pretty dumb to encourage murderboning when there's not enough people to fight off the traitor.

I did it this way since it seems to consider hijacking an objective that needs to be counted before all others, that's why it's sensible to do it there instead of when adding the objective itself.

Closes #35186