### PR TITLE
Removes can_synth=0 from mining nanites

### DIFF
--- a/code/modules/reagents/chemistry/reagents/medicine_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/medicine_reagents.dm
@@ -1128,7 +1128,6 @@
 	description = "It's mining magic. We don't have to explain it."
 	color = "#C8A5DC" // rgb: 200, 165, 220
 	overdose_threshold = 3 //To prevent people stacking massive amounts of a very strong healing reagent
-	can_synth = 0
 
 /datum/reagent/medicine/miningnanites/on_mob_life(mob/living/M)
 	M.heal_bodypart_damage(5,5, 0)


### PR DESCRIPTION
Reasoning: can_synth=0 is intended to prohibit Odysseuses and other sources such as vent foam, etc from creating extremely powerful or purely technical(blob) chemicals. Mining nanites is neither of these:

 - It has a astoundingly small overdose limit, one of the smallest of all reagents.
 - As a medicine, it heals at a rate equal to Ketrazine, which also gives near-immunity to stuns and sleep, has a higher negative effects dose threshold, speeds you up, and can be produced directly in chemistry.
 - Poison wise, it is decent but _also_ inferior to Ketrazine.
 - It cannot be synthisized normally, with this PR obtaining and using it as a medicine reagent nonetheless _requires_ a abnormal source such as a Odysseus.
 - Currently speaking, with this change, obtaining it requires gibbing a monkey which contains it, grinding the flesh, and then scanning it with a properly equipped Odysseus, which then can only produce it by shooting syringes filled with it, which would OD people if used directly and thus must be manually emptied and processed into pills/patches. Quite convoluted and involved.
 - Using it to heal requires careful dose management to avoid overdose. The amount of time it lasts is also quite short compared to the OD threshold.

🆑 
tweak: Methods of reagent replication can now produce mining nanites.
/🆑 
