### PR TITLE
Adds All-In-One Grinder as an actual buildable machinery

### DIFF
--- a/_maps/map_files/BoxStation/BoxStation.dmm
+++ b/_maps/map_files/BoxStation/BoxStation.dmm
@@ -14354,7 +14354,7 @@
 /area/hydroponics)
 "aJO" = (
 /obj/structure/table,
-/obj/machinery/reagentgrinder,
+/obj/machinery/reagentgrinder/hasbeaker,
 /turf/open/floor/plasteel/hydrofloor,
 /area/hydroponics)
 "aJP" = (
@@ -14728,7 +14728,7 @@
 /turf/open/floor/plasteel/bar,
 /area/crew_quarters/bar)
 "aKQ" = (
-/obj/machinery/reagentgrinder,
+/obj/machinery/reagentgrinder/hasbeaker,
 /obj/structure/table/wood,
 /turf/open/floor/wood,
 /area/crew_quarters/bar)
@@ -19310,7 +19310,7 @@
 /area/crew_quarters/kitchen)
 "aXn" = (
 /obj/structure/table,
-/obj/machinery/reagentgrinder,
+/obj/machinery/reagentgrinder/hasbeaker,
 /obj/machinery/requests_console{
 	department = "Kitchen";
 	departmentType = 2;
@@ -22811,7 +22811,7 @@
 /area/quartermaster/sorting)
 "bgF" = (
 /obj/structure/table/glass,
-/obj/machinery/reagentgrinder,
+/obj/machinery/reagentgrinder/hasbeaker,
 /obj/structure/extinguisher_cabinet{
 	pixel_x = -27
 	},
@@ -36367,7 +36367,7 @@
 	pixel_y = 23
 	},
 /obj/structure/table/glass,
-/obj/machinery/reagentgrinder{
+/obj/machinery/reagentgrinder/hasbeaker{
 	desc = "Used to grind things up into raw materials and liquids.";
 	pixel_y = 5
 	},
@@ -38648,7 +38648,7 @@
 /obj/machinery/light_switch{
 	pixel_x = -23
 	},
-/obj/machinery/reagentgrinder,
+/obj/machinery/reagentgrinder/hasbeaker,
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
 "bRN" = (

--- a/_maps/map_files/Deltastation/DeltaStation2.dmm
+++ b/_maps/map_files/Deltastation/DeltaStation2.dmm
@@ -722,7 +722,7 @@
 /area/shuttle/abandoned)
 "abA" = (
 /obj/structure/table,
-/obj/machinery/reagentgrinder,
+/obj/machinery/reagentgrinder/hasbeaker,
 /obj/effect/decal/cleanable/dirt{
 	desc = "A thin layer of dust coating the floor.";
 	name = "dust"

--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -32088,7 +32088,7 @@
 /turf/open/floor/wood,
 /area/crew_quarters/bar)
 "boQ" = (
-/obj/machinery/reagentgrinder,
+/obj/machinery/reagentgrinder/hasbeaker,
 /obj/structure/table/wood,
 /turf/open/floor/wood,
 /area/crew_quarters/bar)
@@ -45879,7 +45879,7 @@
 	pixel_y = -30
 	},
 /obj/structure/table,
-/obj/machinery/reagentgrinder,
+/obj/machinery/reagentgrinder/hasbeaker,
 /turf/open/floor/plasteel/cafeteria{
 	dir = 5
 	},
@@ -47014,7 +47014,7 @@
 /turf/open/floor/plasteel,
 /area/hydroponics)
 "bUj" = (
-/obj/machinery/reagentgrinder,
+/obj/machinery/reagentgrinder/hasbeaker,
 /obj/structure/table/glass,
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plasteel,
@@ -55741,7 +55741,7 @@
 /turf/open/floor/plating,
 /area/medical/medbay/central)
 "cmz" = (
-/obj/machinery/reagentgrinder,
+/obj/machinery/reagentgrinder/hasbeaker,
 /obj/machinery/requests_console{
 	department = "Chemistry";
 	departmentType = 2;

--- a/_maps/map_files/Mining/Lavaland.dmm
+++ b/_maps/map_files/Mining/Lavaland.dmm
@@ -1997,7 +1997,7 @@
 /area/mine/living_quarters)
 "fv" = (
 /obj/structure/table,
-/obj/machinery/reagentgrinder,
+/obj/machinery/reagentgrinder/hasbeaker,
 /turf/open/floor/plasteel/bar,
 /area/mine/living_quarters)
 "fx" = (

--- a/_maps/map_files/OmegaStation/OmegaStation.dmm
+++ b/_maps/map_files/OmegaStation/OmegaStation.dmm
@@ -12235,7 +12235,7 @@
 /area/crew_quarters/bar/atrium)
 "axb" = (
 /obj/structure/table/wood,
-/obj/machinery/reagentgrinder{
+/obj/machinery/reagentgrinder/hasbeaker{
 	desc = "Used to grind things up into raw materials and liquids.";
 	pixel_y = 5
 	},
@@ -15163,7 +15163,7 @@
 /area/crew_quarters/kitchen)
 "aDa" = (
 /obj/structure/table/reinforced,
-/obj/machinery/reagentgrinder{
+/obj/machinery/reagentgrinder/hasbeaker{
 	desc = "Used to grind things up into raw materials and liquids.";
 	pixel_y = 5
 	},
@@ -19255,7 +19255,7 @@
 /area/hydroponics)
 "aKY" = (
 /obj/structure/table/glass,
-/obj/machinery/reagentgrinder{
+/obj/machinery/reagentgrinder/hasbeaker{
 	desc = "Used to grind things up into raw materials and liquids.";
 	pixel_y = 5
 	},
@@ -23578,7 +23578,7 @@
 /area/medical/chemistry)
 "aUs" = (
 /obj/structure/table/glass,
-/obj/machinery/reagentgrinder{
+/obj/machinery/reagentgrinder/hasbeaker{
 	pixel_y = 5
 	},
 /obj/effect/turf_decal/bot,
@@ -31187,7 +31187,7 @@
 /area/science/xenobiology)
 "bjT" = (
 /obj/structure/table/reinforced,
-/obj/machinery/reagentgrinder{
+/obj/machinery/reagentgrinder/hasbeaker{
 	pixel_y = 5
 	},
 /obj/machinery/power/apc{

--- a/_maps/map_files/PubbyStation/PubbyStation.dmm
+++ b/_maps/map_files/PubbyStation/PubbyStation.dmm
@@ -17197,7 +17197,7 @@
 /turf/open/floor/plating,
 /area/maintenance/department/crew_quarters/bar)
 "aQS" = (
-/obj/machinery/reagentgrinder,
+/obj/machinery/reagentgrinder/hasbeaker,
 /obj/structure/table/wood,
 /turf/open/floor/wood,
 /area/crew_quarters/bar)
@@ -18954,7 +18954,7 @@
 /area/hydroponics)
 "aUW" = (
 /obj/structure/table,
-/obj/machinery/reagentgrinder,
+/obj/machinery/reagentgrinder/hasbeaker,
 /turf/open/floor/plasteel/hydrofloor,
 /area/hydroponics)
 "aUX" = (
@@ -21630,7 +21630,7 @@
 /area/crew_quarters/kitchen)
 "bbi" = (
 /obj/structure/table,
-/obj/machinery/reagentgrinder,
+/obj/machinery/reagentgrinder/hasbeaker,
 /turf/open/floor/plasteel/cafeteria,
 /area/crew_quarters/kitchen)
 "bbl" = (
@@ -26724,7 +26724,7 @@
 /area/science/explab)
 "boe" = (
 /obj/structure/table,
-/obj/machinery/reagentgrinder,
+/obj/machinery/reagentgrinder/hasbeaker,
 /obj/item/device/radio/intercom{
 	dir = 0;
 	name = "Station Intercom (General)";
@@ -32451,7 +32451,7 @@
 /area/medical/chemistry)
 "bAg" = (
 /obj/structure/table/glass,
-/obj/machinery/reagentgrinder,
+/obj/machinery/reagentgrinder/hasbeaker,
 /obj/machinery/light,
 /obj/machinery/airalarm{
 	dir = 1;
@@ -38302,7 +38302,7 @@
 "bNP" = (
 /obj/structure/table,
 /obj/structure/disposalpipe/segment,
-/obj/machinery/reagentgrinder,
+/obj/machinery/reagentgrinder/hasbeaker,
 /turf/open/floor/plasteel/whitegreen/side,
 /area/medical/virology)
 "bNQ" = (
@@ -46001,7 +46001,7 @@
 /area/chapel/main/monastery)
 "chV" = (
 /obj/structure/table,
-/obj/machinery/reagentgrinder,
+/obj/machinery/reagentgrinder/hasbeaker,
 /turf/open/floor/plasteel/hydrofloor,
 /area/chapel/main/monastery)
 "chW" = (

--- a/_maps/map_files/generic/CentCom.dmm
+++ b/_maps/map_files/generic/CentCom.dmm
@@ -656,7 +656,7 @@
 /area/holodeck/rec_center/anthophila)
 "cf" = (
 /obj/structure/table/glass,
-/obj/machinery/reagentgrinder,
+/obj/machinery/reagentgrinder/hasbeaker,
 /turf/open/floor/holofloor{
 	icon_state = "white"
 	},

--- a/code/game/objects/items/circuitboards/machine_circuitboards.dm
+++ b/code/game/objects/items/circuitboards/machine_circuitboards.dm
@@ -588,6 +588,12 @@
 	name = "CondiMaster 3000 (Machine Board)"
 	build_path = /obj/machinery/chem_master/condimaster
 
+/obj/item/circuitboard/machine/reagentgrinder
+	name = "Machine Design (All-In-One Grinder)"
+	build_path = /obj/machinery/reagentgrinder
+	req_components = list(
+		/obj/item/stock_parts/manipulator = 1)
+
 /obj/item/circuitboard/machine/circuit_imprinter
 	name = "Circuit Imprinter (Machine Board)"
 	build_path = /obj/machinery/rnd/circuit_imprinter

--- a/code/modules/reagents/chemistry/machinery/reagentgrinder.dm
+++ b/code/modules/reagents/chemistry/machinery/reagentgrinder.dm
@@ -17,14 +17,12 @@
 	var/operating = FALSE
 	var/obj/item/reagent_containers/beaker = null
 	var/limit = 10
+	var/speed = 1
 	var/list/holdingitems
 
 /obj/machinery/reagentgrinder/Initialize()
 	. = ..()
 	holdingitems = list()
-	//beaker = new /obj/item/reagent_containers/glass/beaker/large(src)
-	//beaker.desc += " May contain blended dust. Don't breathe this in!"
-	//Since grinder can be built now, beaker shouldn't spawn to prevent free beaker exploit
 
 /obj/machinery/reagentgrinder/Destroy()
 	if(beaker)
@@ -35,6 +33,11 @@
 /obj/machinery/reagentgrinder/contents_explosion(severity, target)
 	if(beaker)
 		beaker.ex_act(severity, target)
+
+/obj/machinery/reagentgrinder/RefreshParts()
+	speed = 1
+	for(var/obj/item/stock_parts/manipulator/M in component_parts)
+		speed = M.rating
 
 /obj/machinery/reagentgrinder/handle_atom_del(atom/A)
 	. = ..()
@@ -242,7 +245,7 @@
 	pixel_x = old_px
 
 /obj/machinery/reagentgrinder/proc/operate_for(time, silent = FALSE, juicing = FALSE)
-	shake_for(time)
+	shake_for(time / speed)
 	updateUsrDialog()
 	operating = TRUE
 	if(!silent)
@@ -250,7 +253,7 @@
 			playsound(src, 'sound/machines/blender.ogg', 50, 1)
 		else
 			playsound(src, 'sound/machines/juicer.ogg', 20, 1)
-	addtimer(CALLBACK(src, .proc/stop_operating), time)
+	addtimer(CALLBACK(src, .proc/stop_operating), time / speed)
 
 /obj/machinery/reagentgrinder/proc/stop_operating()
 	operating = FALSE
@@ -316,3 +319,11 @@
 			var/amount = beaker.reagents.get_reagent_amount("eggyolk")
 			beaker.reagents.remove_reagent("eggyolk", amount)
 			beaker.reagents.add_reagent("mayonnaise", amount)
+
+/obj/machinery/reagentgrinder/hasbeaker/Initialize()
+	. = ..()
+	holdingitems = list()
+	beaker = new /obj/item/reagent_containers/glass/beaker/large(src)
+	beaker.desc += " May contain blended dust. Don't breathe this in!"
+	icon_state = "juicer0"
+	update_icon()

--- a/code/modules/research/designs/machine_designs.dm
+++ b/code/modules/research/designs/machine_designs.dm
@@ -153,6 +153,13 @@
 	build_path = /obj/item/circuitboard/machine/smoke_machine
 	category = list ("Medical Machinery")
 
+/datum/design/board/reagentgrinder
+	name = "Machine Design (All-In-One Grinder)"
+	desc = "The circuit board for an All-In-One Grinder."
+	id = "reagentgrinder"
+	build_path = /obj/item/circuitboard/machine/reagentgrinder
+	category = list ("Medical Machinery")
+
 /datum/design/board/clonecontrol
 	name = "Computer Design (Cloning Machine Console)"
 	desc = "Allows for the construction of circuit boards used to build a new Cloning Machine console."

--- a/code/modules/research/techweb/all_nodes.dm
+++ b/code/modules/research/techweb/all_nodes.dm
@@ -35,7 +35,7 @@
 	display_name = "Biological Processing"
 	description = "From slimes to kitchens."
 	prereq_ids = list("biotech")
-	design_ids = list("smartfridge", "gibber", "deepfryer", "monkey_recycler", "processor", "gibber", "microwave")
+	design_ids = list("smartfridge", "gibber", "deepfryer", "monkey_recycler", "processor", "gibber", "microwave", "reagentgrinder")
 	research_cost = 2500
 	export_price = 5000
 


### PR DESCRIPTION
:cl: Mokiros
add: All-In-One Grinder can now be built as an actual machinery using circuit board and micro-manipulator.
/:cl:

Mostly cloned code from other machinery, tested a few times, no errors.
Added roundstart beaker back by adding subtype to all maps
~Had to remove roundstart beaker because it also spawns when you build a new grinder.~