### PR TITLE
Squashes silicon HUDs together

### DIFF
--- a/code/_onclick/hud/ai.dm
+++ b/code/_onclick/hud/ai.dm
@@ -162,7 +162,7 @@
 	if(..())
 		return
 	var/mob/living/silicon/S = usr
-	S.sensor_mode()
+	S.toggle_sensors()
 
 
 /datum/hud/ai

--- a/code/modules/mob/living/silicon/pai/software.dm
+++ b/code/modules/mob/living/silicon/pai/software.dm
@@ -235,8 +235,7 @@
 			if(href_list["toggle"])
 				secHUD = !secHUD
 				if(secHUD)
-					var/datum/atom_hud/sec = GLOB.huds[sec_hud]
-					secsensor.add_hud_to(src)
+					add_sec_hud()
 				else
 					var/datum/atom_hud/sec = GLOB.huds[sec_hud]
 					sec.remove_hud_from(src)
@@ -244,8 +243,7 @@
 			if(href_list["toggle"])
 				medHUD = !medHUD
 				if(medHUD)
-					var/datum/atom_hud/med = GLOB.huds[med_hud]
-					medsensor.add_hud_to(src)
+					add_med_hud()
 				else
 					var/datum/atom_hud/med = GLOB.huds[med_hud]
 					med.remove_hud_from(src)

--- a/code/modules/mob/living/silicon/pai/software.dm
+++ b/code/modules/mob/living/silicon/pai/software.dm
@@ -235,7 +235,8 @@
 			if(href_list["toggle"])
 				secHUD = !secHUD
 				if(secHUD)
-					add_sec_hud()
+					var/datum/atom_hud/sec = GLOB.huds[sec_hud]
+					sec.add_hud_to(src)
 				else
 					var/datum/atom_hud/sec = GLOB.huds[sec_hud]
 					sec.remove_hud_from(src)
@@ -243,7 +244,8 @@
 			if(href_list["toggle"])
 				medHUD = !medHUD
 				if(medHUD)
-					add_med_hud()
+					var/datum/atom_hud/med = GLOB.huds[med_hud]
+					med.add_hud_to(src)
 				else
 					var/datum/atom_hud/med = GLOB.huds[med_hud]
 					med.remove_hud_from(src)

--- a/code/modules/mob/living/silicon/pai/software.dm
+++ b/code/modules/mob/living/silicon/pai/software.dm
@@ -235,7 +235,8 @@
 			if(href_list["toggle"])
 				secHUD = !secHUD
 				if(secHUD)
-					add_sec_hud()
+					var/datum/atom_hud/sec = GLOB.huds[sec_hud]
+					secsensor.add_hud_to(src)
 				else
 					var/datum/atom_hud/sec = GLOB.huds[sec_hud]
 					sec.remove_hud_from(src)
@@ -243,8 +244,8 @@
 			if(href_list["toggle"])
 				medHUD = !medHUD
 				if(medHUD)
-					add_med_hud()
-
+					var/datum/atom_hud/med = GLOB.huds[med_hud]
+					medsensor.add_hud_to(src)
 				else
 					var/datum/atom_hud/med = GLOB.huds[med_hud]
 					med.remove_hud_from(src)

--- a/code/modules/mob/living/silicon/silicon.dm
+++ b/code/modules/mob/living/silicon/silicon.dm
@@ -351,9 +351,9 @@
 	sensors_on = !sensors_on
 	if (!sensors_on)
 		to_chat(src, "Sensors deactivated.")
-		remove_huds()
+		remove_sensors()
 		return
-	add_huds()
+	add_sensors()
 	to_chat(src, "Sensors activated.")
 
 /mob/living/silicon/proc/GetPhoto()

--- a/code/modules/mob/living/silicon/silicon.dm
+++ b/code/modules/mob/living/silicon/silicon.dm
@@ -30,6 +30,7 @@
 	var/ioncheck[1]
 	var/devillawcheck[5]
 
+	var/sensors_on = 0
 	var/med_hud = DATA_HUD_MEDICAL_ADVANCED //Determines the med hud to use
 	var/sec_hud = DATA_HUD_SECURITY_ADVANCED //Determines the sec hud to use
 	var/d_hud = DATA_HUD_DIAGNOSTIC_BASIC //Determines the diag hud to use
@@ -328,7 +329,7 @@
 /mob/living/silicon/assess_threat(judgement_criteria, lasercolor = "", datum/callback/weaponcheck=null) //Secbots won't hunt silicon units
 	return -10
 
-/mob/living/silicon/proc/remove_med_sec_hud()
+/mob/living/silicon/proc/remove_sensors()
 	var/datum/atom_hud/secsensor = GLOB.huds[sec_hud]
 	var/datum/atom_hud/medsensor = GLOB.huds[med_hud]
 	var/datum/atom_hud/diagsensor = GLOB.huds[d_hud]
@@ -336,36 +337,24 @@
 	medsensor.remove_hud_from(src)
 	diagsensor.remove_hud_from(src)
 
-/mob/living/silicon/proc/add_sec_hud()
+/mob/living/silicon/proc/add_sensors()
 	var/datum/atom_hud/secsensor = GLOB.huds[sec_hud]
-	secsensor.add_hud_to(src)
-
-/mob/living/silicon/proc/add_med_hud()
 	var/datum/atom_hud/medsensor = GLOB.huds[med_hud]
-	medsensor.add_hud_to(src)
-
-/mob/living/silicon/proc/add_diag_hud()
 	var/datum/atom_hud/diagsensor = GLOB.huds[d_hud]
+	secsensor.add_hud_to(src)
+	medsensor.add_hud_to(src)
 	diagsensor.add_hud_to(src)
 
-/mob/living/silicon/proc/sensor_mode()
+/mob/living/silicon/proc/toggle_sensors()
 	if(incapacitated())
 		return
-	var/sensor_type = input("Please select sensor type.", "Sensor Integration", null) in list("Security", "Medical","Diagnostic","Disable")
-	remove_med_sec_hud()
-	switch(sensor_type)
-		if ("Security")
-			add_sec_hud()
-			to_chat(src, "<span class='notice'>Security records overlay enabled.</span>")
-		if ("Medical")
-			add_med_hud()
-			to_chat(src, "<span class='notice'>Life signs monitor overlay enabled.</span>")
-		if ("Diagnostic")
-			add_diag_hud()
-			to_chat(src, "<span class='notice'>Robotics diagnostic overlay enabled.</span>")
-		if ("Disable")
-			to_chat(src, "Sensor augmentations disabled.")
-
+	sensors_on = !sensors_on
+	if (!sensors_on)
+		to_chat(src, "Sensors deactivated.")
+		remove_huds()
+		return
+	add_huds()
+	to_chat(src, "Sensors activated.")
 
 /mob/living/silicon/proc/GetPhoto()
 	if (aicamera)

--- a/code/modules/mob/living/silicon/silicon.dm
+++ b/code/modules/mob/living/silicon/silicon.dm
@@ -350,11 +350,11 @@
 		return
 	sensors_on = !sensors_on
 	if (!sensors_on)
-		to_chat(src, "Sensors deactivated.")
+		to_chat(src, "Sensor overlay deactivated.")
 		remove_sensors()
 		return
 	add_sensors()
-	to_chat(src, "Sensors activated.")
+	to_chat(src, "Sensor overlay activated.")
 
 /mob/living/silicon/proc/GetPhoto()
 	if (aicamera)

--- a/code/modules/mob/living/silicon/silicon.dm
+++ b/code/modules/mob/living/silicon/silicon.dm
@@ -329,6 +329,14 @@
 /mob/living/silicon/assess_threat(judgement_criteria, lasercolor = "", datum/callback/weaponcheck=null) //Secbots won't hunt silicon units
 	return -10
 
+/mob/living/silicon/proc/add_sec_hud()
+	var/datum/atom_hud/secsensor = GLOB.huds[sec_hud]
+	secsensor.add_hud_to(src)
+
+/mob/living/silicon/proc/add_med_hud()
+	var/datum/atom_hud/medsensor = GLOB.huds[med_hud]
+	medsensor.add_hud_to(src)
+
 /mob/living/silicon/proc/remove_sensors()
 	var/datum/atom_hud/secsensor = GLOB.huds[sec_hud]
 	var/datum/atom_hud/medsensor = GLOB.huds[med_hud]

--- a/code/modules/mob/living/silicon/silicon.dm
+++ b/code/modules/mob/living/silicon/silicon.dm
@@ -329,14 +329,6 @@
 /mob/living/silicon/assess_threat(judgement_criteria, lasercolor = "", datum/callback/weaponcheck=null) //Secbots won't hunt silicon units
 	return -10
 
-/mob/living/silicon/proc/add_sec_hud()
-	var/datum/atom_hud/secsensor = GLOB.huds[sec_hud]
-	secsensor.add_hud_to(src)
-
-/mob/living/silicon/proc/add_med_hud()
-	var/datum/atom_hud/medsensor = GLOB.huds[med_hud]
-	medsensor.add_hud_to(src)
-
 /mob/living/silicon/proc/remove_sensors()
 	var/datum/atom_hud/secsensor = GLOB.huds[sec_hud]
 	var/datum/atom_hud/medsensor = GLOB.huds[med_hud]


### PR DESCRIPTION
This always seemed like a leftover from the days when the HUDs weren't compatible with eachother. Silicons are now able to use the HUD icon to toggle their sensors, which displays results from the three sensor types available to them.

Comes with the added bonus of extra human harm awareness.