### PR TITLE
Fixes invalid shuttle vars

### DIFF
--- a/_maps/map_files/BoxStation/BoxStation.dmm
+++ b/_maps/map_files/BoxStation/BoxStation.dmm
@@ -5746,7 +5746,7 @@
 	height = 5;
 	id = "laborcamp_home";
 	name = "fore bay 1";
-	roundstart_template = /datum/map_template/shuttle/labour/box;
+	roundstart_template = "/datum/map_template/shuttle/labour/box";
 	width = 9
 	},
 /turf/open/space/basic,
@@ -34953,7 +34953,7 @@
 	height = 5;
 	id = "mining_home";
 	name = "mining shuttle bay";
-	roundstart_template = /datum/map_template/shuttle/mining/box;
+	roundstart_template = "/datum/map_template/shuttle/mining/box";
 	width = 7
 	},
 /turf/open/space/basic,
@@ -53423,7 +53423,7 @@
 	height = 15;
 	id = "arrivals_stationary";
 	name = "arrivals";
-	roundstart_template = /datum/map_template/shuttle/arrival/box;
+	roundstart_template = "/datum/map_template/shuttle/arrival/box";
 	width = 7
 	},
 /turf/open/space/basic,

--- a/_maps/map_files/Deltastation/DeltaStation2.dmm
+++ b/_maps/map_files/Deltastation/DeltaStation2.dmm
@@ -1261,7 +1261,7 @@
 	id = "arrivals_stationary";
 	name = "delta arrivals";
 	width = 9;
-	roundstart_template = /datum/map_template/shuttle/arrival/delta
+	roundstart_template = "/datum/map_template/shuttle/arrival/delta";
 	},
 /turf/open/space/basic,
 /area/space)
@@ -28029,7 +28029,7 @@
 	id = "mining_home";
 	name = "mining shuttle bay";
 	width = 7;
-	roundstart_template = /datum/map_template/shuttle/mining/delta
+	roundstart_template = "/datum/map_template/shuttle/mining/delta";
 	},
 /turf/open/space/basic,
 /area/space)
@@ -37733,7 +37733,7 @@
 	id = "laborcamp_home";
 	name = "fore bay 1";
 	width = 9;
-	roundstart_template = /datum/map_template/shuttle/labour/delta
+	roundstart_template = "/datum/map_template/shuttle/labour/delta";
 	},
 /turf/open/space/basic,
 /area/space)

--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -12606,7 +12606,7 @@
 	id = "mining_home";
 	name = "mining shuttle bay";
 	width = 7;
-	roundstart_template = /datum/map_template/shuttle/mining/box
+	roundstart_template = "/datum/map_template/shuttle/mining/box";
 	},
 /turf/open/space/basic,
 /area/space)
@@ -12807,7 +12807,7 @@
 	id = "laborcamp_home";
 	name = "fore bay 1";
 	width = 9;
-	roundstart_template = /datum/map_template/shuttle/labour/box
+	roundstart_template = "/datum/map_template/shuttle/labour/box";
 	},
 /turf/open/space/basic,
 /area/space)
@@ -78478,7 +78478,7 @@
 	id = "arrivals_stationary";
 	name = "arrivals";
 	width = 7;
-	roundstart_template = /datum/map_template/shuttle/arrival/box
+	roundstart_template = "/datum/map_template/shuttle/arrival/box";
 	},
 /turf/open/space/basic,
 /area/space)

--- a/_maps/map_files/OmegaStation/OmegaStation.dmm
+++ b/_maps/map_files/OmegaStation/OmegaStation.dmm
@@ -8118,7 +8118,7 @@
 	height = 5;
 	id = "mining_home";
 	name = "mining shuttle bay";
-	roundstart_template = /datum/map_template/shuttle/mining/delta;
+	roundstart_template = "/datum/map_template/shuttle/mining/delta";
 	width = 7
 	},
 /turf/open/space/basic,
@@ -32462,7 +32462,7 @@
 	height = 17;
 	id = "arrivals_stationary";
 	name = "omega arrivals";
-	roundstart_template = /datum/map_template/shuttle/arrival/delta;
+	roundstart_template = "/datum/map_template/shuttle/arrival/delta";
 	width = 9
 	},
 /turf/open/space/basic,

--- a/_maps/map_files/PubbyStation/PubbyStation.dmm
+++ b/_maps/map_files/PubbyStation/PubbyStation.dmm
@@ -8166,7 +8166,7 @@
 	height = 5;
 	id = "laborcamp_home";
 	name = "fore bay 1";
-	roundstart_template = /datum/map_template/shuttle/labour/box;
+	roundstart_template = "/datum/map_template/shuttle/labour/box";
 	width = 9
 	},
 /turf/open/space/basic,
@@ -23385,7 +23385,7 @@
 	height = 5;
 	id = "mining_home";
 	name = "mining shuttle bay";
-	roundstart_template = /datum/map_template/shuttle/mining/delta;
+	roundstart_template = "/datum/map_template/shuttle/mining/delta";
 	width = 7
 	},
 /turf/open/space/basic,
@@ -23867,7 +23867,7 @@
 	height = 13;
 	id = "arrivals_stationary";
 	name = "pubby arrivals";
-	roundstart_template = /datum/map_template/shuttle/arrival/pubby;
+	roundstart_template = "/datum/map_template/shuttle/arrival/pubby";
 	width = 6
 	},
 /turf/open/space/basic,

--- a/_maps/map_files/generic/CentCom.dmm
+++ b/_maps/map_files/generic/CentCom.dmm
@@ -13433,7 +13433,7 @@
 	height = 17;
 	id = "syndicate_away";
 	name = "syndicate recon outpost";
-	roundstart_template = /datum/map_template/shuttle/infiltrator/basic;
+	roundstart_template = "/datum/map_template/shuttle/infiltrator/basic";
 	turf_type = /turf/open/floor/plating/asteroid/snow;
 	width = 23
 	},

--- a/code/modules/shuttle/shuttle.dm
+++ b/code/modules/shuttle/shuttle.dm
@@ -167,7 +167,7 @@
 
 	var/last_dock_time
 
-	var/datum/map_template/shuttle/roundstart_template
+	var/roundstart_template
 	var/json_key
 
 /obj/docking_port/stationary/Initialize(mapload)
@@ -188,20 +188,21 @@
 	#endif
 
 /obj/docking_port/stationary/proc/load_roundstart()
-	if(json_key)
+	var/datum/map_template/shuttle/roundstart_template_parsed
+	if(json_key)		
 		var/sid = SSmapping.config.shuttles[json_key]
-		roundstart_template = SSmapping.shuttle_templates[sid]
-		if(!roundstart_template)
+		roundstart_template_parsed = SSmapping.shuttle_templates[sid]
+		if(!roundstart_template_parsed)
 			CRASH("json_key:[json_key] value \[[sid]\] resulted in a null shuttle template for [src]")
 	else if(roundstart_template) // passed a PATH
-		var/sid = "[initial(roundstart_template.port_id)]_[initial(roundstart_template.suffix)]"
+		roundstart_template_parsed = text2path(roundstart_template)
+		var/sid = "[initial(roundstart_template_parsed.port_id)]_[initial(roundstart_template_parsed.suffix)]"
+		roundstart_template_parsed = SSmapping.shuttle_templates[sid]
+		if(!roundstart_template_parsed)
+			CRASH("Invalid path ([roundstart_template_parsed]) passed to docking port.")
 
-		roundstart_template = SSmapping.shuttle_templates[sid]
-		if(!roundstart_template)
-			CRASH("Invalid path ([roundstart_template]) passed to docking port.")
-
-	if(roundstart_template)
-		SSshuttle.manipulator.action_load(roundstart_template, src)
+	if(roundstart_template_parsed)
+		SSshuttle.manipulator.action_load(roundstart_template_parsed, src)
 
 //returns first-found touching shuttleport
 /obj/docking_port/stationary/get_docked()


### PR DESCRIPTION
[Changelogs]: 

:cl: Dax Dupont
fix: Shuttle roundstart templates are no longer invalid.
/:cl:

[why]: Fixes #35226
