### PR TITLE
Reverts #34939

### DIFF
--- a/code/modules/mob/living/simple_animal/friendly/drone/_drone.dm
+++ b/code/modules/mob/living/simple_animal/friendly/drone/_drone.dm
@@ -27,7 +27,7 @@
 	maxHealth = 30
 	unsuitable_atmos_damage = 0
 	wander = 0
-	speed = -1
+	speed = 0
 	ventcrawler = VENTCRAWLER_ALWAYS
 	healable = 0
 	density = FALSE


### PR DESCRIPTION
Perma max speed for a mob that bullets pass over is awful

Free Drones are easily obtainable in normal play, and slaved drones don't need adrenals to do their jobs anyway