### PR TITLE
Mining sentience upgrade grants minebots a radio and ID

### DIFF
--- a/code/game/objects/items/implants/implant_misc.dm
+++ b/code/game/objects/items/implants/implant_misc.dm
@@ -80,10 +80,10 @@
 
 /obj/item/implant/radio
 	name = "internal radio implant"
-	desc = "Are you there God? It's me, Syndicate Comms Agent."
 	activated = TRUE
 	var/obj/item/device/radio/radio
-	var/radio_key = /obj/item/device/encryptionkey/syndicate
+	var/radio_key
+	var/subspace_transmission = FALSE
 	icon = 'icons/obj/radio.dmi'
 	icon_state = "walkietalkie"
 
@@ -98,11 +98,19 @@
 	// almost like an internal headset, but without the
 	// "must be in ears to hear" restriction.
 	radio.name = "internal radio"
-	radio.subspace_transmission = TRUE
+	radio.subspace_transmission = subspace_transmission
 	radio.canhear_range = 0
-	radio.keyslot = new radio_key
+	if(radio_key)
+		radio.keyslot = new radio_key
 	radio.recalculateChannels()
 
+/obj/item/implant/radio/mining
+	radio_key = /obj/item/device/encryptionkey/headset_cargo
+
+/obj/item/implant/radio/syndicate
+	desc = "Are you there God? It's me, Syndicate Comms Agent."
+	radio_key = /obj/item/device/encryptionkey/syndicate
+	subspace_transmission = TRUE
 
 /obj/item/implant/radio/get_data()
 	var/dat = {"<b>Implant Specifications:</b><BR>

--- a/code/game/objects/items/implants/implant_misc.dm
+++ b/code/game/objects/items/implants/implant_misc.dm
@@ -122,3 +122,7 @@
 /obj/item/implanter/radio
 	name = "implanter (internal radio)"
 	imp_type = /obj/item/implant/radio
+
+/obj/item/implanter/radio/syndicate
+	name = "implanter (internal syndicate radio)"
+	imp_type = /obj/item/implant/radio/syndicate

--- a/code/game/objects/items/storage/uplink_kits.dm
+++ b/code/game/objects/items/storage/uplink_kits.dm
@@ -307,7 +307,7 @@
 	new /obj/item/spellbook/oneuse/mimery_guns(src)
 
 /obj/item/storage/box/syndie_kit/imp_radio/PopulateContents()
-	new /obj/item/implanter/radio(src)
+	new /obj/item/implanter/radio/syndicate(src)
 
 /obj/item/storage/box/syndie_kit/centcom_costume/PopulateContents()
 	new /obj/item/clothing/under/rank/centcom_officer(src)

--- a/code/modules/mining/minebot.dm
+++ b/code/modules/mining/minebot.dm
@@ -262,5 +262,12 @@
 	icon = 'icons/obj/module.dmi'
 	sentience_type = SENTIENCE_MINEBOT
 
+/obj/item/slimepotion/slime/sentience/mining/after_success(mob/living/user, mob/living/simple_animal/SM)
+	var/obj/item/implant/radio/mining/imp = new(src)
+	imp.implant(SM, user)
+
+	SM.access_card = new /obj/item/card/id/mining(SM)
+	SM.access_card.flags_1 |= NODROP_1
+
 #undef MINEDRONE_COLLECT
 #undef MINEDRONE_ATTACK

--- a/code/modules/research/xenobiology/xenobiology.dm
+++ b/code/modules/research/xenobiology/xenobiology.dm
@@ -617,7 +617,7 @@
 	desc = "A miraculous chemical mix that grants human like intelligence to living beings. It has been modified with Syndicate technology to also grant an internal radio implant to the target and authenticate with identification systems."
 
 /obj/item/slimepotion/slime/sentience/nuclear/after_success(mob/living/user, mob/living/simple_animal/SM)
-	var/obj/item/implant/radio/imp = new(src)
+	var/obj/item/implant/radio/syndicate/imp = new(src)
 	imp.implant(SM, user)
 
 	SM.access_card = new /obj/item/card/id/syndicate(SM)


### PR DESCRIPTION
:cl: Kor
add: Mining sentience upgrades now grant minebots an ID and radio.
/:cl:

I think it will make minebot much less frustrating to play if they can actually communicate with their team mates and move in/out of the base with them.

Thanks @coiax for the original idea with cayenne and leaving the code easy to expand on