### PR TITLE
Remove revenantspawn landmark from code

### DIFF
--- a/code/game/objects/effects/landmarks.dm
+++ b/code/game/objects/effects/landmarks.dm
@@ -274,11 +274,6 @@ INITIALIZE_IMMEDIATE(/obj/effect/landmark/start/new_player)
 	name = "Observer-Start"
 	icon_state = "observer_start"
 
-// revenant spawn.
-/obj/effect/landmark/revenantspawn
-	name = "revnantspawn"
-	icon_state = "revenant_spawn"
-
 // triple ais.
 /obj/effect/landmark/tripai
 	name = "tripai"


### PR DESCRIPTION
:cl:
code: Removed the now-unused revenant spawn landmark.
/:cl:

Finishing what #34926 started. If it does nothing it should be removed, and should yell at mappers to remove it.