### PR TITLE
Raises the cid check disconnect time out

### DIFF
--- a/code/modules/client/client_procs.dm
+++ b/code/modules/client/client_procs.dm
@@ -519,7 +519,11 @@ GLOBAL_LIST_EMPTY(external_rsc_urls)
 			cidcheck[ckey] = computer_id
 			tokens[ckey] = cid_check_reconnect()
 
-			sleep(10) //browse is queued, we don't want them to disconnect before getting the browse() command.
+			sleep(15 SECONDS) //Longer sleep here since this would trigger if a client tries to reconnect manually because the inital reconnect failed
+			
+			 //we sleep after telling the client to reconnect, so if we still exist something is up
+			log_access("Forced disconnect: [key] [computer_id] [address] - CID randomizer check")
+			
 			qdel(src)
 			return TRUE
 
@@ -561,7 +565,11 @@ GLOBAL_LIST_EMPTY(external_rsc_urls)
 			cidcheck[ckey] = computer_id
 			tokens[ckey] = cid_check_reconnect()
 
-			sleep(10) //browse is queued, we don't want them to disconnect before getting the browse() command.
+			sleep(5 SECONDS) //browse is queued, we don't want them to disconnect before getting the browse() command.
+			
+			//we sleep after telling the client to reconnect, so if we still exist something is up
+			log_access("Forced disconnect: [key] [computer_id] [address] - CID randomizer check")
+			
 			qdel(src)
 			return TRUE
 


### PR DESCRIPTION
Disconnects from deleting the client are immediate, where are other commands are queued to some degree or another, browse is the worst one of all since it has to queue behind after-connection resource sends as well as asset cache or browse_rsc calls.

I'm finding hints that clients on lagger connections are getting disconnected before getting the reconnect command, and I was able to reproduce this myself on a cell phone connection while connecting to terry
