### PR TITLE
Fixes attackby in expressconsole.dm, moves bluespace pod upgrade further down the line in techwebs

### DIFF
--- a/code/modules/cargo/expressconsole.dm
+++ b/code/modules/cargo/expressconsole.dm
@@ -23,14 +23,13 @@
 	if((istype(W, /obj/item/card/id) || istype(W, /obj/item/device/pda)) && allowed(user))
 		locked = !locked
 		to_chat(user, "<span class='notice'>You [locked ? "lock" : "unlock"] the interface.</span>")
-
+		return
 	else if(istype(W, /obj/item/disk/cargo/bluespace_pod))
 		podID = 1//doesnt effect circuit board, so that reversal is possible
 		to_chat(user, "<span class='notice'>You insert the disk into [src], allowing for advanced supply delivery vehicles.</span>")
 		qdel(W)
 		return TRUE
-	else
-		..()
+	..()
 
 /obj/machinery/computer/cargo/express/emag_act(mob/living/user)
 	if(obj_flags & EMAGGED)

--- a/code/modules/cargo/expressconsole.dm
+++ b/code/modules/cargo/expressconsole.dm
@@ -20,7 +20,6 @@
 
 
 /obj/machinery/computer/cargo/express/attackby(obj/item/W, mob/living/user, params)
-	..()
 	if((istype(W, /obj/item/card/id) || istype(W, /obj/item/device/pda)) && allowed(user))
 		locked = !locked
 		to_chat(user, "<span class='notice'>You [locked ? "lock" : "unlock"] the interface.</span>")
@@ -30,6 +29,8 @@
 		to_chat(user, "<span class='notice'>You insert the disk into [src], allowing for advanced supply delivery vehicles.</span>")
 		qdel(W)
 		return TRUE
+	else
+		..()
 
 /obj/machinery/computer/cargo/express/emag_act(mob/living/user)
 	if(obj_flags & EMAGGED)

--- a/code/modules/research/techweb/all_nodes.dm
+++ b/code/modules/research/techweb/all_nodes.dm
@@ -111,7 +111,7 @@
 	description = "Deeper understanding of how the Bluespace dimension works"
 	prereq_ids = list("practical_bluespace", "high_efficiency")
 	design_ids = list("bluespace_matter_bin", "femto_mani", "triphasic_scanning", "tele_station", "tele_hub", "quantumpad", "launchpad", "launchpad_console",
-	"teleconsole", "bag_holding", "bluespace_crystal", "wormholeprojector")
+	"teleconsole", "bag_holding", "bluespace_crystal", "wormholeprojector", "bluespace_pod")
 	research_cost = 2500
 	export_price = 5000
 
@@ -432,7 +432,7 @@
 	display_name = "Advanced Mining Technology"
 	description = "Efficiency Level 127"	//dumb mc references
 	prereq_ids = list("basic_mining", "adv_engi", "adv_power", "adv_plasma")
-	design_ids = list("drill_diamond", "jackhammer", "hypermod", "plasmacutter", "plasmacutter_adv", "bluespace_pod")
+	design_ids = list("drill_diamond", "jackhammer", "hypermod", "plasmacutter", "plasmacutter_adv")
 	research_cost = 2500
 	export_price = 5000
 


### PR DESCRIPTION
Fixes expressconsole getting hit by your ID when you swipe it

:cl: MrDoomBringer
add: Due to complicated quantum-bluespace-entanglement shenanigans, the Bluespace Drop Pod upgrade for the express supply console is now slightly more difficult to research.
/:cl:

moves the bluespace pod upgrade further down techwebs because:
- bluespace pod upgrade fits advanced bluespace research category better
- bluespace pod upgrade got researched too early 

