### PR TITLE
Explosive holoparasites must now be adjacent to turn objects into bombs

### DIFF
--- a/code/modules/mob/living/simple_animal/guardian/types/explosive.dm
+++ b/code/modules/mob/living/simple_animal/guardian/types/explosive.dm
@@ -33,10 +33,10 @@
 /mob/living/simple_animal/hostile/guardian/bomb/AltClickOn(atom/movable/A)
 	if(!istype(A))
 		return
-	if(src.loc == summoner)
+	if(loc == summoner)
 		to_chat(src, "<span class='danger'><B>You must be manifested to create bombs!</span></B>")
 		return
-	if(isobj(A))
+	if(isobj(A) && Adjacent(A))
 		if(bomb_cooldown <= world.time && !stat)
 			var/obj/guardian_bomb/B = new /obj/guardian_bomb(get_turf(A))
 			to_chat(src, "<span class='danger'><B>Success! Bomb armed!</span></B>")


### PR DESCRIPTION
:cl:
balance: Explosive holoparasites must now be adjacent to turn objects into bombs, instead of being able to do so from any range.
/:cl:
Whew!