### PR TITLE
Fixes power cell name and makes borgs use a standard high capacity cell.

### DIFF
--- a/code/modules/mob/living/silicon/robot/robot.dm
+++ b/code/modules/mob/living/silicon/robot/robot.dm
@@ -113,7 +113,7 @@
 	ident = rand(1, 999)
 
 	if(!cell)
-		cell = new /obj/item/stock_parts/cell/high(src, 7500)
+		cell = new /obj/item/stock_parts/cell/high(src)
 
 	if(lawupdate)
 		make_laws()

--- a/code/modules/mob/transform_procs.dm
+++ b/code/modules/mob/transform_procs.dm
@@ -374,9 +374,6 @@
 
 	var/mob/living/silicon/robot/R = new /mob/living/silicon/robot(loc)
 
-	// cyborgs produced by Robotize get an automatic power cell
-	R.cell = new /obj/item/stock_parts/cell/high(R, 7500)
-
 	R.gender = gender
 	R.invisibility = 0
 

--- a/code/modules/power/cell.dm
+++ b/code/modules/power/cell.dm
@@ -174,7 +174,7 @@
 	charge = 0
 
 /obj/item/stock_parts/cell/upgraded
-	name = "high-capacity power cell"
+	name = "upgraded power cell"
 	desc = "A power cell with a slightly higher capacity than normal!"
 	maxcharge = 2500
 	materials = list(MAT_GLASS=50)


### PR DESCRIPTION
[Changelogs]: 

:cl: Dax Dupont
balance: Regular cyborgs now start with a normal high capacity cell instead of a snowflake cell. Resulting in less confusing and 2.5MJ more electric charge.
fix: Fixed name of the upgraded power cell
refactor: Removed duplicate cell giving code in transformation proc.
/:cl:

[why]: The custom cell on robots have resulted in many a discussions of "why do you want to swap this cell it's already high capacity". Since normal high capacity is 10MJ instead of 7.5MJ. 
This gives a borg slightly more power on roundstart, but is less snowflake-y and more consistent.
It's still lower than the high capacity+ 15MJ that spawn on all maps so roboticists will still have plenty of work and opportunity to emag.

Also the transformation proc was assigning the same kinda cell to the borg. However, the borg code already put in a cell if there is non on initialize with the same properties.

All of this does NOT affect the transform machine, that still has a var for badmin usage.