### PR TITLE
Fixes smugglers satchels being able to refresh items forever

### DIFF
--- a/code/controllers/subsystem/persistence.dm
+++ b/code/controllers/subsystem/persistence.dm
@@ -10,6 +10,7 @@ SUBSYSTEM_DEF(persistence)
 	var/list/saved_messages = list()
 	var/list/saved_modes = list(1,2,3)
 	var/list/saved_trophies = list()
+	var/list/spawned_objects = list()
 
 /datum/controller/subsystem/persistence/Initialize()
 	LoadSatchels()
@@ -62,7 +63,8 @@ SUBSYSTEM_DEF(persistence)
 		if(isfloorturf(F.loc) && !isplatingturf(F.loc))
 			F.hide(1)
 		if(ispath(path))
-			new path(F)
+			var/spawned_item = new path(F)
+			spawned_objects += spawned_item
 		placed_satchel++
 	var/free_satchels = 0
 	for(var/turf/T in shuffle(block(locate(TRANSITIONEDGE,TRANSITIONEDGE,ZLEVEL_STATION_PRIMARY), locate(world.maxx-TRANSITIONEDGE,world.maxy-TRANSITIONEDGE,ZLEVEL_STATION_PRIMARY)))) //Nontrivially expensive but it's roundstart only

--- a/code/controllers/subsystem/persistence.dm
+++ b/code/controllers/subsystem/persistence.dm
@@ -64,7 +64,7 @@ SUBSYSTEM_DEF(persistence)
 			F.hide(1)
 		if(ispath(path))
 			var/spawned_item = new path(F)
-			spawned_objects += spawned_item
+			spawned_objects[spawned_item] = TRUE
 		placed_satchel++
 	var/free_satchels = 0
 	for(var/turf/T in shuffle(block(locate(TRANSITIONEDGE,TRANSITIONEDGE,ZLEVEL_STATION_PRIMARY), locate(world.maxx-TRANSITIONEDGE,world.maxy-TRANSITIONEDGE,ZLEVEL_STATION_PRIMARY)))) //Nontrivially expensive but it's roundstart only

--- a/code/game/objects/items/storage/backpack.dm
+++ b/code/game/objects/items/storage/backpack.dm
@@ -326,6 +326,12 @@
 			new R(src)
 		revealed = 1
 
+/obj/item/storage/backpack/satchel/flat/can_be_inserted(obj/item/W, stop_messages = 0, mob/user)
+	if(W in SSpersistence.spawned_objects)
+		to_chat(user, "<span class='warning'>[W] is unstable after its journey through space and time, it wouldn't survive another trip.</span>")
+		return 0
+	..()
+
 /obj/item/storage/backpack/duffelbag
 	name = "duffel bag"
 	desc = "A large duffel bag for holding extra things."

--- a/code/game/objects/items/storage/backpack.dm
+++ b/code/game/objects/items/storage/backpack.dm
@@ -327,7 +327,7 @@
 		revealed = 1
 
 /obj/item/storage/backpack/satchel/flat/can_be_inserted(obj/item/W, stop_messages = 0, mob/user)
-	if(W in SSpersistence.spawned_objects)
+	if(SSpersistence.spawned_objects[W])
 		to_chat(user, "<span class='warning'>[W] is unstable after its journey through space and time, it wouldn't survive another trip.</span>")
 		return 0
 	..()

--- a/code/game/objects/items/storage/backpack.dm
+++ b/code/game/objects/items/storage/backpack.dm
@@ -329,8 +329,8 @@
 /obj/item/storage/backpack/satchel/flat/can_be_inserted(obj/item/W, stop_messages = 0, mob/user)
 	if(SSpersistence.spawned_objects[W])
 		to_chat(user, "<span class='warning'>[W] is unstable after its journey through space and time, it wouldn't survive another trip.</span>")
-		return 0
-	..()
+		return FALSE
+	return ..()
 
 /obj/item/storage/backpack/duffelbag
 	name = "duffel bag"


### PR DESCRIPTION
Items spawned in satchels may no longer be placed into a satchel once removed.

This means you can't store a used holoparasite injector in round A, have it spawn as a fresh one in round B, then use and replace it again to use in round C (and then in D and E and F and so on forever)