### PR TITLE
Fixes the AI from being able to magically turn on broken APCs

### DIFF
--- a/code/modules/power/apc.dm
+++ b/code/modules/power/apc.dm
@@ -912,6 +912,8 @@
 	return 1
 
 /obj/machinery/power/apc/proc/toggle_breaker()
+	if((stat & (BROKEN|MAINT)) || failure_timer || shorted)
+		return
 	operating = !operating
 	update()
 	update_icon()

--- a/code/modules/power/apc.dm
+++ b/code/modules/power/apc.dm
@@ -912,7 +912,7 @@
 	return 1
 
 /obj/machinery/power/apc/proc/toggle_breaker()
-	if(!is_operational() || (stat & MAINT) || failure_timer)
+	if(!is_operational() || failure_timer)
 		return
 	operating = !operating
 	update()

--- a/code/modules/power/apc.dm
+++ b/code/modules/power/apc.dm
@@ -912,7 +912,7 @@
 	return 1
 
 /obj/machinery/power/apc/proc/toggle_breaker()
-	if((stat & (BROKEN|MAINT)) || failure_timer || shorted)
+	if((stat & (BROKEN|MAINT)) || failure_timer)
 		return
 	operating = !operating
 	update()

--- a/code/modules/power/apc.dm
+++ b/code/modules/power/apc.dm
@@ -912,7 +912,7 @@
 	return 1
 
 /obj/machinery/power/apc/proc/toggle_breaker()
-	if((stat & (BROKEN|MAINT)) || failure_timer)
+	if(!is_operational() || (stat & MAINT) || failure_timer)
 		return
 	operating = !operating
 	update()


### PR DESCRIPTION
[Changelogs]: 

:cl: Dax Dupont
fix: AIs can no longer turn on broken APCs,
/:cl:

[why]: Fixes #35257
