### PR TITLE
Fixed insufficient cultists warning

### DIFF
--- a/code/game/gamemodes/cult/runes.dm
+++ b/code/game/gamemodes/cult/runes.dm
@@ -120,8 +120,6 @@ structure_check() searches for nearby cultist structures required for the invoca
 				if(L.stat)
 					continue
 				invokers += L
-		if(invokers.len >= req_cultists)
-			invokers -= user
 			if(allow_excess_invokers)
 				chanters += invokers
 			else
@@ -130,6 +128,8 @@ structure_check() searches for nearby cultist structures required for the invoca
 					var/L = pick_n_take(invokers)
 					if(L)
 						chanters += L
+					else
+						break
 	return chanters
 
 /obj/effect/rune/proc/invoke(var/list/invokers)

--- a/code/modules/antagonists/cult/runes.dm
+++ b/code/modules/antagonists/cult/runes.dm
@@ -131,10 +131,9 @@ structure_check() searches for nearby cultist structures required for the invoca
 				shuffle_inplace(invokers)
 				for(var/i in 1 to req_cultists)
 					var/C = pick_n_take(invokers)
-					if(C)
-						chanters += C
-					else
+					if(!C)
 						break
+					chanters += C
 	return chanters
 
 /obj/effect/rune/proc/invoke(var/list/invokers)

--- a/code/modules/antagonists/cult/runes.dm
+++ b/code/modules/antagonists/cult/runes.dm
@@ -125,8 +125,6 @@ structure_check() searches for nearby cultist structures required for the invoca
 				if(L.stat)
 					continue
 				invokers += L
-		if(invokers.len >= req_cultists)
-			invokers -= user
 			if(allow_excess_invokers)
 				chanters += invokers
 			else
@@ -135,6 +133,8 @@ structure_check() searches for nearby cultist structures required for the invoca
 					var/L = pick_n_take(invokers)
 					if(L)
 						chanters += L
+					else
+						break
 	return chanters
 
 /obj/effect/rune/proc/invoke(var/list/invokers)

--- a/code/modules/antagonists/cult/runes.dm
+++ b/code/modules/antagonists/cult/runes.dm
@@ -130,9 +130,9 @@ structure_check() searches for nearby cultist structures required for the invoca
 			else
 				shuffle_inplace(invokers)
 				for(var/i in 1 to req_cultists)
-					var/L = pick_n_take(invokers)
-					if(L)
-						chanters += L
+					var/C = pick_n_take(invokers)
+					if(C)
+						chanters += C
 					else
 						break
 	return chanters


### PR DESCRIPTION
Fixes #35287

The can_invoke proc was returning chanters, not available invokers, and if you had insufficient invokers the only chanter would be the user.