### PR TITLE
Removes the Central Command report list because it's bad

### DIFF
--- a/code/game/gamemodes/game_mode.dm
+++ b/code/game/gamemodes/game_mode.dm
@@ -251,25 +251,10 @@
 
 /datum/game_mode/proc/send_intercept()
 	var/intercepttext = "<b><i>Central Command Status Summary</i></b><hr>"
-	intercepttext += "<b>Central Command has intercepted and partially decoded a Syndicate transmission with vital information regarding their movements. The following report outlines the most \
+	intercepttext += "<b>Central Command intelligence assets have intercepted and partially decoded a Syndicate transmission with vital information regarding their movements. The following report outlines the most \
 	likely threats to appear in your sector.</b>"
-	var/list/report_weights = config.mode_false_report_weight.Copy()
-	report_weights[config_tag] = 0 //Prevent the current mode from being falsely selected.
-	var/list/reports = list()
-	var/Count = 0 //To compensate for missing correct report
-	if(prob(65)) // 65% chance the actual mode will appear on the list
-		reports += config.mode_reports[config_tag]
-		Count++
-	for(var/i in Count to rand(3,5)) //Between three and five wrong entries on the list.
-		var/false_report_type = pickweightAllowZero(report_weights)
-		report_weights[false_report_type] = 0 //Make it so the same false report won't be selected twice
-		reports += config.mode_reports[false_report_type]
 
-	reports = shuffle(reports) //Randomize the order, so the real one is at a random position.
-
-	for(var/report in reports)
-		intercepttext += "<hr>"
-		intercepttext += report
+	intercepttext += "<em>[This information has been redacted in the interest of preserving our intelligence assets]<br>We apologize for any inconvenience.</em>"
 
 	if(station_goals.len)
 		intercepttext += "<hr><b>Special Orders for [station_name()]:</b>"

--- a/code/game/gamemodes/game_mode.dm
+++ b/code/game/gamemodes/game_mode.dm
@@ -254,7 +254,7 @@
 	intercepttext += "<b>Central Command intelligence assets have intercepted and partially decoded a Syndicate transmission with vital information regarding their movements. The following report outlines the most \
 	likely threats to appear in your sector.</b>"
 
-	intercepttext += "<em>[This information has been redacted in the interest of preserving our intelligence assets]<br>We apologize for any inconvenience.</em>"
+	intercepttext += "<em>\[This information has been redacted in the interest of preserving our intelligence assets]<br>We apologize for any inconvenience.</em>"
 
 	if(station_goals.len)
 		intercepttext += "<hr><b>Special Orders for [station_name()]:</b>"


### PR DESCRIPTION
:cl: Atlanta-Ned
del: Central Command intelligence assets have been dying at an alarming rate. Until further notice, intelligence reports will not contain detailed information in order to protect these assets.
/:cl:

[why]: I'm proposing an alternate solution to the command report issue. 
