### PR TITLE
Adds a line to Contributing.md to stop all these damn command report PRs that keep springing up like weeds

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -398,6 +398,7 @@ Do not add any of the following in a Pull Request or risk getting the PR closed:
 * National Socialist Party of Germany content, National Socialist Party of Germany related content, or National Socialist Party of Germany references
 * Code where one line of code is split across mutiple lines (except for multiple, separate strings and comments; in those cases, existing longer lines must not be split up)
 * Code adding, removing, or updating the availability of alien races/species/human mutants without prior approval. Pull requests attempting to add or remove features from said races/species/mutants require prior approval as well.
+* Code attempting to alter the contents or existence of a command report in any way, such as the probability that the current gamemode will appear on the report, or that non-rotation gamemdoes can appear on the report. There is an exception for adding newly-created gamemodes to the possible contents of the report, but they must behave in a identical manner to how all other gamemodes behave in regards to the report. Any of these changes require prior approval.
 
 Just because something isn't on this list doesn't mean that it's acceptable. Use common sense above all else.
 


### PR DESCRIPTION
See title.

![image](https://user-images.githubusercontent.com/16315400/35780552-1a062fb2-09ab-11e8-90c7-3297a97d1f3b.png)


>Code attempting to alter the contents or existence of a command report in any way, such as the probability that the current gamemode will appear on the report, or that non-rotation gamemdoes can appear on the report. There is an exception for adding newly-created gamemodes to the possible contents of the report, but they must behave in a identical manner to how all other gamemodes behave in regards to the report. Any of these changes require prior approval.