### PR TITLE
Megafauna can now be transported via fulton pack

### DIFF
--- a/code/modules/mining/fulton.dm
+++ b/code/modules/mining/fulton.dm
@@ -56,7 +56,7 @@ GLOBAL_LIST_EMPTY(total_extraction_beacons)
 			return
 		if(!isturf(A.loc)) // no extracting stuff inside other stuff
 			return
-		if(A.anchored)
+		if(A.anchored && !istype(A, /mob/living/simple_animal/hostile/megafauna))
 			return
 		to_chat(user, "<span class='notice'>You start attaching the pack to [A]...</span>")
 		if(do_after(user,50,target=A))


### PR DESCRIPTION
I've been trying to think of a intermediate between the old method, where you could transport megafauna to the station via jaunter (bit too easy), and the current one, where you have to get them onto the shuttle (essentially impossible for some without exploits, merely suicidal for others). If you want to know WHY this should be possible see the argument in #34164.

This is a intermediate I think. You can now fulton them to locations. This is more precise than jaunting and more flexible than shuttles. You can put them in a precise location BUT you have to get to that location and put down a (mildly expensive, rather obvious) fulton beacon first. And... you have to FULTON them. That is, you have to sit directly next to them without moving for about 5 seconds.

**While they're hitting you.**

This is easier said than done, I actually need to double check to make sure its possible but at MINIMUM you need good armor and probably gotta load up on healing chems beforehand and even then its iffy.

:cl:
Add: Nanotrasen has upgraded the balloons used to produce standard-issue fulton packs. They can now lift significantly more massive objects.
/:cl: 