### PR TITLE
Fix defibrillator mount runtiming continously while empty

### DIFF
--- a/code/game/machinery/defibrillator_mount.dm
+++ b/code/game/machinery/defibrillator_mount.dm
@@ -38,7 +38,7 @@
 	if(defib && defib.cell && defib.cell.charge < defib.cell.maxcharge)
 		use_power(20)
 		defib.cell.give(18) //90% efficiency, slightly better than the cell charger's 87.5%
-	if(isliving(defib.paddles.loc))
+	if(defib && defib.paddles && isliving(defib.paddles.loc))
 		var/mob/living/L = defib.paddles.loc
 		if(!L.Adjacent(src))
 			to_chat(L, "<span class='warning'>[defib]'s paddles overextend and come out of your hands!</span>")


### PR DESCRIPTION
:cl:
fix: Defibrillator mounts no longer spam the error log while empty.
/:cl:

```
Runtime in defibrillator_mount.dm, line 41: Cannot read null.paddles
proc name: process (/obj/machinery/defibrillator_mount/process)
src: the defibrillator mount (/obj/machinery/defibrillator_mount)
src.loc: the floor (88,105,2) (/turf/open/floor/plasteel/whiteblue/side)
call stack:
the defibrillator mount (/obj/machinery/defibrillator_mount): process(2)
Fast Processing (/datum/controller/subsystem/processing/fastprocess): fire(0)
Fast Processing (/datum/controller/subsystem/processing/fastprocess): ignite(0)
Master (/datum/controller/master): RunQueue()
Master (/datum/controller/master): Loop()
Master (/datum/controller/master): StartProcessing(0)
```