### PR TITLE
Fix caravan ambush ships being unpilotable

### DIFF
--- a/_maps/RandomRuins/SpaceRuins/caravanambush.dmm
+++ b/_maps/RandomRuins/SpaceRuins/caravanambush.dmm
@@ -70,6 +70,7 @@
 	name = "Pirate Cutter";
 	port_direction = 8;
 	preferred_direction = 4;
+	timid = 0;
 	width = 22
 	},
 /turf/open/floor/plating,
@@ -3264,6 +3265,7 @@
 	name = "Syndicate Drop Ship";
 	port_direction = 8;
 	preferred_direction = 4;
+	timid = 0;
 	width = 15
 	},
 /turf/open/floor/plating,
@@ -3429,6 +3431,7 @@
 	name = "Syndicate Fighter";
 	port_direction = 2;
 	preferred_direction = 4;
+	timid = 0;
 	width = 9
 	},
 /turf/open/floor/plating,
@@ -3571,6 +3574,7 @@
 	name = "Syndicate Fighter";
 	port_direction = 2;
 	preferred_direction = 1;
+	timid = 0;
 	width = 9
 	},
 /turf/open/floor/plating,
@@ -3599,6 +3603,7 @@
 	name = "Small Freighter";
 	port_direction = 8;
 	preferred_direction = 4;
+	timid = 0;
 	width = 27
 	},
 /turf/open/floor/plating,


### PR DESCRIPTION
:cl:
fix: The various ships in the caravan ambush space ruin can now fly again.
/:cl:

Fixes #35315. Same reasoning as #35090.
