### PR TITLE
Fixes cyborg related cuffing issues

### DIFF
--- a/code/game/objects/items/handcuffs.dm
+++ b/code/game/objects/items/handcuffs.dm
@@ -40,10 +40,11 @@
 	var/cuffsound = 'sound/weapons/handcuffs.ogg'
 	var/trashtype = null //for disposable cuffs
 
-/obj/item/restraints/handcuffs/attack(mob/living/carbon/C, mob/living/carbon/human/user)
+/obj/item/restraints/handcuffs/attack(mob/living/carbon/C, mob/living/user)
 	if(!istype(C))
 		return
-	if(user.has_trait(TRAIT_CLUMSY) && prob(50))
+
+	if(iscarbon(user) && (user.has_trait(TRAIT_CLUMSY) && prob(50)))
 		to_chat(user, "<span class='warning'>Uh... how do those things work?!</span>")
 		apply_cuffs(user,user)
 		return
@@ -61,7 +62,10 @@
 
 			playsound(loc, cuffsound, 30, 1, -2)
 			if(do_mob(user, C, 30) && (C.get_num_arms() >= 2 || C.get_arm_ignore()))
-				apply_cuffs(C,user)
+				if(iscyborg(user))
+					apply_cuffs(C, user, TRUE)
+				else
+					apply_cuffs(C, user)
 				to_chat(user, "<span class='notice'>You handcuff [C].</span>")
 				SSblackbox.record_feedback("tally", "handcuffs", 1, type)
 
@@ -113,7 +117,6 @@
 	materials = list(MAT_METAL=150, MAT_GLASS=75)
 	breakouttime = 300 //Deciseconds = 30s
 	cuffsound = 'sound/weapons/cablecuff.ogg'
-	var/datum/robot_energy_storage/wirestorage = null
 
 /obj/item/restraints/handcuffs/cable/Initialize(mapload, param_color)
 	. = ..()
@@ -127,23 +130,6 @@
 /obj/item/restraints/handcuffs/cable/update_icon()
 	color = null
 	add_atom_colour(item_color, FIXED_COLOUR_PRIORITY)
-
-/obj/item/restraints/handcuffs/cable/attack(mob/living/carbon/C, mob/living/carbon/human/user)
-	if(!istype(C))
-		return
-	if(wirestorage && wirestorage.energy < 15)
-		to_chat(user, "<span class='warning'>You need at least 15 wire to restrain [C]!</span>")
-		return
-	return ..()
-
-/obj/item/restraints/handcuffs/cable/apply_cuffs(mob/living/carbon/target, mob/user, var/dispense = 0)
-	if(wirestorage)
-		if(!wirestorage.use_charge(15))
-			to_chat(user, "<span class='warning'>You need at least 15 wire to restrain [target]!</span>")
-			return
-		return ..(target, user, 1)
-
-	return ..()
 
 /obj/item/restraints/handcuffs/cable/red
 	item_color = "red"
@@ -215,21 +201,6 @@
 	else
 		return ..()
 
-/obj/item/restraints/handcuffs/cable/zipties/cyborg/attack(mob/living/carbon/C, mob/user)
-	if(iscyborg(user))
-		if(!C.handcuffed)
-			playsound(loc, 'sound/weapons/cablecuff.ogg', 30, 1, -2)
-			C.visible_message("<span class='danger'>[user] is trying to put zipties on [C]!</span>", \
-								"<span class='userdanger'>[user] is trying to put zipties on [C]!</span>")
-			if(do_mob(user, C, 30))
-				if(!C.handcuffed)
-					C.handcuffed = new /obj/item/restraints/handcuffs/cable/zipties/used(C)
-					C.update_handcuffed()
-					to_chat(user, "<span class='notice'>You handcuff [C].</span>")
-					add_logs(user, C, "handcuffed")
-			else
-				to_chat(user, "<span class='warning'>You fail to handcuff [C]!</span>")
-
 /obj/item/restraints/handcuffs/cable/zipties
 	name = "zipties"
 	desc = "Plastic, disposable zipties that can be used to restrain temporarily but are destroyed after use."
@@ -248,7 +219,6 @@
 
 /obj/item/restraints/handcuffs/cable/zipties/used/attack()
 	return
-
 
 //Legcuffs
 

--- a/code/modules/mob/living/silicon/robot/robot_modules.dm
+++ b/code/modules/mob/living/silicon/robot/robot_modules.dm
@@ -113,10 +113,6 @@
 			S.materials = list()
 			S.is_cyborg = 1
 
-	if(istype(I, /obj/item/restraints/handcuffs/cable))
-		var/obj/item/restraints/handcuffs/cable/C = I
-		C.wirestorage = get_or_create_estorage(/datum/robot_energy_storage/wire)
-
 	if(I.loc != src)
 		I.forceMove(src)
 	modules += I
@@ -243,7 +239,7 @@
 		/obj/item/extinguisher,
 		/obj/item/pickaxe,
 		/obj/item/device/t_scanner/adv_mining_scanner,
-		/obj/item/restraints/handcuffs/cable/zipties/cyborg,
+		/obj/item/restraints/handcuffs/cable/zipties,
 		/obj/item/soap/nanotrasen,
 		/obj/item/borg/cyborghug)
 	emag_modules = list(/obj/item/melee/transforming/energy/sword/cyborg)
@@ -324,7 +320,7 @@
 	name = "Security"
 	basic_modules = list(
 		/obj/item/device/assembly/flash/cyborg,
-		/obj/item/restraints/handcuffs/cable/zipties/cyborg,
+		/obj/item/restraints/handcuffs/cable/zipties,
 		/obj/item/melee/baton/loaded,
 		/obj/item/gun/energy/disabler/cyborg,
 		/obj/item/clothing/mask/gas/sechailer/cyborg)


### PR DESCRIPTION
[Changelogs]: 
:cl: Dax Dupont
fix: Fixed borgs applying cuffs on people without the right number of arms.
refactor: Handcuff code has been rejiggled and snowflake code has been removed.
del: Removed unused cable cuffs module stuff for borgs.
/:cl:

[why]: Cyborg cuffs were mostly a duplication of the regular handcuff code without it taking dismemberment in account.
I removed the cablecuffs for the borgs since they weren't used and only made it harder to have a nice clean solution. They were replaced by zipties long ago anyways.
