### PR TITLE
Reduced shards and shells for the cult

### DIFF
--- a/code/modules/antagonists/cult/cult_structures.dm
+++ b/code/modules/antagonists/cult/cult_structures.dm
@@ -89,13 +89,12 @@
 	if(cooldowntime > world.time)
 		to_chat(user, "<span class='cult italic'>The magic in [src] is weak, it will be ready to use again in [DisplayTimeText(cooldowntime - world.time)].</span>")
 		return
-	var/choice = alert(user,"You study the schematics etched into the altar...",,"Eldritch Whetstone","Construct Shells","Flask of Unholy Water")
+	var/choice = alert(user,"You study the schematics etched into the altar...",,"Eldritch Whetstone","Construct Shell","Flask of Unholy Water")
 	var/list/pickedtype = list()
 	switch(choice)
 		if("Eldritch Whetstone")
 			pickedtype += /obj/item/sharpener/cult
-		if("Construct Shells")
-			pickedtype += /obj/structure/constructshell
+		if("Construct Shell")
 			pickedtype += /obj/structure/constructshell
 		if("Flask of Unholy Water")
 			pickedtype += /obj/item/reagent_containers/glass/beaker/unholywater

--- a/code/modules/antagonists/cult/runes.dm
+++ b/code/modules/antagonists/cult/runes.dm
@@ -316,7 +316,7 @@ structure_check() searches for nearby cultist structures required for the invoca
 				to_chat(M, "<span class='cultlarge'>\"I accept this meager sacrifice.\"</span>")
 
 	var/obj/item/device/soulstone/stone = new /obj/item/device/soulstone(get_turf(src))
-	if(sacrificial.mind)
+	if(sacrificial.mind && !sacrificial.suiciding)
 		stone.invisibility = INVISIBILITY_MAXIMUM //so it's not picked up during transfer_soul()
 		stone.transfer_soul("FORCE", sacrificial, usr)
 		stone.invisibility = 0


### PR DESCRIPTION
:cl: Robustin
balance: The "construct shell" option from the cult archives structure will now only yield one shell instead of two.
balance: Sacrificing suicide victims will now only yield an empty shard. 
/:cl:

With the recent changes its easier than ever for cultists to build structures and as a result the costs for constructs had become a little too easy. Removing suicide victims from the acceptable "full" sacrifice options also seemed like common sense. 