### PR TITLE
Tritium now produces water vapor when combusting.

### DIFF
--- a/code/modules/atmospherics/gasmixtures/reactions.dm
+++ b/code/modules/atmospherics/gasmixtures/reactions.dm
@@ -6,6 +6,7 @@
 #define PLASMA_MINIMUM_OXYGEN_PLASMA_RATIO	30
 #define PLASMA_OXYGEN_FULLBURN				10
 #define FIRE_CARBON_ENERGY_RELEASED			100000	//Amount of heat released per mole of burnt carbon into the tile
+#define FIRE_HYDROGEN_ENERGY_RELEASED		280000 // Amount of heat released per mole of burnt hydrogen and/or tritium(hydrogen isotope)
 #define FIRE_PLASMA_ENERGY_RELEASED			3000000	//Amount of heat released per mole of burnt plasma into the tile
 //General assmos defines.
 #define WATER_VAPOR_FREEZE					200
@@ -120,10 +121,10 @@
 			cached_gases[/datum/gas/oxygen][MOLES] -= cached_gases[/datum/gas/tritium][MOLES]
 
 		if(burned_fuel)
-			energy_released += FIRE_CARBON_ENERGY_RELEASED * burned_fuel
+			energy_released += FIRE_HYDROGEN_ENERGY_RELEASED * burned_fuel
 
-			ASSERT_GAS(/datum/gas/carbon_dioxide, air)
-			cached_gases[/datum/gas/carbon_dioxide][MOLES] += burned_fuel/TRITIUM_BURN_OXY_FACTOR
+			ASSERT_GAS(/datum/gas/water_vapor, air) //oxygen+more-or-less hydrogen=H2O
+			cached_gases[/datum/gas/water_vapor][MOLES] += burned_fuel/TRITIUM_BURN_OXY_FACTOR
 
 			cached_results[id] += burned_fuel
 

--- a/code/modules/atmospherics/gasmixtures/reactions.dm
+++ b/code/modules/atmospherics/gasmixtures/reactions.dm
@@ -13,6 +13,7 @@
 #define NITRYL_FORMATION_ENERGY				100000
 #define TRITIUM_BURN_OXY_FACTOR				100
 #define TRITIUM_BURN_TRIT_FACTOR			10
+#define TRITIUM_BURN_RADIOACTIVITY_FACTOR	1000 //The neutrons gotta go somewhere. Completely arbitrary number.
 #define SUPER_SATURATION_THRESHOLD			96
 #define STIMULUM_HEAT_SCALE					100000
 #define STIMULUM_FIRST_RISE					0.65
@@ -122,6 +123,9 @@
 
 		if(burned_fuel)
 			energy_released += FIRE_HYDROGEN_ENERGY_RELEASED * burned_fuel
+
+		if (location)
+			radiation_pulse(location, energy_released/TRITIUM_BURN_RADIOACTIVITY_FACTOR)
 
 			ASSERT_GAS(/datum/gas/water_vapor, air) //oxygen+more-or-less hydrogen=H2O
 			cached_gases[/datum/gas/water_vapor][MOLES] += burned_fuel/TRITIUM_BURN_OXY_FACTOR

--- a/code/modules/atmospherics/gasmixtures/reactions.dm
+++ b/code/modules/atmospherics/gasmixtures/reactions.dm
@@ -123,9 +123,8 @@
 
 		if(burned_fuel)
 			energy_released += FIRE_HYDROGEN_ENERGY_RELEASED * burned_fuel
-
-		if (location)
-			radiation_pulse(location, energy_released/TRITIUM_BURN_RADIOACTIVITY_FACTOR)
+			if(location)
+				radiation_pulse(location, energy_released/TRITIUM_BURN_RADIOACTIVITY_FACTOR)
 
 			ASSERT_GAS(/datum/gas/water_vapor, air) //oxygen+more-or-less hydrogen=H2O
 			cached_gases[/datum/gas/water_vapor][MOLES] += burned_fuel/TRITIUM_BURN_OXY_FACTOR

--- a/code/modules/atmospherics/gasmixtures/reactions.dm
+++ b/code/modules/atmospherics/gasmixtures/reactions.dm
@@ -13,7 +13,7 @@
 #define NITRYL_FORMATION_ENERGY				100000
 #define TRITIUM_BURN_OXY_FACTOR				100
 #define TRITIUM_BURN_TRIT_FACTOR			10
-#define TRITIUM_BURN_RADIOACTIVITY_FACTOR	1000 //The neutrons gotta go somewhere. Completely arbitrary number.
+#define TRITIUM_BURN_RADIOACTIVITY_FACTOR	1000000 //The neutrons gotta go somewhere. Completely arbitrary number.
 #define SUPER_SATURATION_THRESHOLD			96
 #define STIMULUM_HEAT_SCALE					100000
 #define STIMULUM_FIRST_RISE					0.65


### PR DESCRIPTION
![](https://imgur.com/8xxYKwT.jpg)

![](https://imgur.com/4VK7bcQ.jpg)

Tritum is a fucking isotope of hydrogen it does not produce **CARBON DIOXIDE** when burning. H+O does not equal CO2. Technically it makes Tritiated Water but I'm not adding a radioactive form of water vapor unless a maintainer wants it so plain water it is.

Also we need a way to produce water vapor anyway so here you go.

🆑 
tweak: After consulting with their in-house physicists, Nanotrasen has updated their worst-case disaster training simulation "Space Station 13". The combustion of hydrogen isotopes now produces water vapor instead of carbon dioxide.
/🆑

Might conflict a little with #35348 as it adds a define used by it. Could eventually be expanded so that tritium mimics the behavior of hydrogen if desired.