### PR TITLE
Removes null crates

### DIFF
--- a/code/modules/cargo/packs.dm
+++ b/code/modules/cargo/packs.dm
@@ -180,30 +180,6 @@
 	crate_name = "emergency crate"
 	crate_type = /obj/structure/closet/crate/internals
 
-/datum/supply_pack/emergency/syndicate
-	name = "NULL_ENTRY"
-	hidden = TRUE
-	cost = 20000
-	contains = list()
-	crate_name = "emergency crate"
-	crate_type = /obj/structure/closet/crate/internals
-	dangerous = TRUE
-
-/datum/supply_pack/emergency/syndicate/fill(obj/structure/closet/crate/C)
-	var/crate_value = 30
-	var/list/uplink_items = get_uplink_items(SSticker.mode)
-	while(crate_value)
-		var/category = pick(uplink_items)
-		var/item = pick(uplink_items[category])
-		var/datum/uplink_item/I = uplink_items[category][item]
-
-		if(!I.surplus || prob(100 - I.surplus))
-			continue
-		if(crate_value < I.cost)
-			continue
-		crate_value -= I.cost
-		new I.item(C)
-
 //////////////////////////////////////////////////////////////////////////////
 //////////////////////////// Security ////////////////////////////////////////
 //////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
They're shit, op, and a crutch. Traitor qms can rain rockets of crates on people. More useful.
:cl: Nanotrasen Customs
del: We've tracked down the source of contraband crates heading to your station including highly illegal and lethal gear, and have dispatched a new wave of customs robots to replace the previous faulty ones.
/:cl: