### PR TITLE
Makes the posibrain play a ping sound on success.

### DIFF
--- a/code/modules/mob/living/brain/posibrain.dm
+++ b/code/modules/mob/living/brain/posibrain.dm
@@ -64,6 +64,7 @@ GLOBAL_VAR(posibrain_notify_cooldown)
 		return
 	if(brainmob.client)
 		visible_message(success_message)
+		playsound(src, 'sound/machines/ping.ogg', 15, TRUE)
 	else
 		visible_message(fail_message)
 


### PR DESCRIPTION
[Changelogs]: 

:cl: Dax Dupont
add: Posibrains have gotten a small firmware update, they will now play a sound on successful activation.
/:cl:

[why]: Makes it more noticeable when a posibrain jumps to life when you're busy fiddling with the research console.