### PR TITLE
Removes synths and androids from magic mirror

### DIFF
--- a/code/game/objects/structures/mirror.dm
+++ b/code/game/objects/structures/mirror.dm
@@ -89,7 +89,7 @@
 	name = "magic mirror"
 	desc = "Turn and face the strange... face."
 	icon_state = "magic_mirror"
-	var/list/races_blacklist = list("skeleton", "agent", "angel", "military_synth", "memezombies", "clockwork golem servant")
+	var/list/races_blacklist = list("skeleton", "agent", "angel", "military_synth", "memezombies", "clockwork golem servant", "android", "synth")
 	var/list/choosable_races = list()
 
 /obj/structure/mirror/magic/New()


### PR DESCRIPTION
:cl: Robustin
balance: Synths and Androids are no longer available species at the magic mirror. 
/:cl:

This is the future you chose. Anyone who thinks wizards being able to chill in space with no cost or downsides, and wants to promote that sort of wizard gameplay, needs a mental health checkup.

Android traits:

**species_traits = list(SPECIES_ROBOTIC,NOBREATH,RESISTHOT,RESISTCOLD,RESISTPRESSURE,NOFIRE,NOBLOOD,PIERCEIMMUNE,NOHUNGER,EASYLIMBATTACHMENT)**