### PR TITLE
Re-enables space runes on Station Z-Level

### DIFF
--- a/code/modules/antagonists/cult/ritual.dm
+++ b/code/modules/antagonists/cult/ritual.dm
@@ -138,21 +138,10 @@ This file contains the cult dagger and rune list code
 	if(isspaceturf(T))
 		to_chat(user, "<span class='warning'>You cannot scribe runes in space!</span>")
 		return FALSE
-
 	if(locate(/obj/effect/rune) in T)
 		to_chat(user, "<span class='cult'>There is already a rune here.</span>")
 		return FALSE
-
-
 	if(!is_station_level(T.z) && !is_mining_level(T.z))
 		to_chat(user, "<span class='warning'>The veil is not weak enough here.</span>")
-
 		return FALSE
-
-	var/area/A = get_area(T)
-	if(A && !A.blob_allowed)
-		to_chat(user, "<span class='warning'>There's a passage in [src] specifically forbidding oyster consumption, triple-frying, and building outside of designated cult zones.</span>")
-		return FALSE
-
-
 	return TRUE


### PR DESCRIPTION
How the fuck did #34734 get merged as a meme title PR with no changelog. 

I spent several hours adjusting off-station balance in my PR, having an off-station base is necessary during highpop (long post below and on forums about it). Cult is at its best when its not MAGICAL REVOLUTION with a conversion rush but playing it slow and low with a cult base is not possible on-station during highpop. You have 20+ assistants online, you have maints that can be fully explored within a couple minutes, then you get the inevitable "CULT IN MEDBAY MAINT" followed by a flurry of flashbang and gunspam down 1x1 hallways that leads to the cult having a <20% winrate during highpop. 

I added new counterplay for space basing in my cult PR, yet its been almost completely untested, so I would really appreciate it if Kor would let me see how my changes go before deciding to remove them after years of existence right as I'm tuning the entire cult mode. 

It's incredibly frustrating putting a lot of time and thought into these changes (that have overall been very popular) and most people reading this PR don't even realize the changes I have already implemented and might think I'm just going to let space basing play out like it has in the past - all because of a ridiculous meme PR that got no discussion and was implemented in the midst of existing changes to the same code after years of being untouched.  