### PR TITLE
Adds the saltmine shuttle.

### DIFF
--- a/_maps/shuttles/emergency_saltmine.dmm
+++ b/_maps/shuttles/emergency_saltmine.dmm
@@ -554,7 +554,7 @@
 "jz" = (
 /obj/effect/decal/cleanable/salt,
 /obj/structure/statue/plasma/scientist{
-	desc = "This statue is suitably made from Armhulen's tears.";
+	desc = "This statue is suitably made from tears of a certain man, you can still hear him crying to this day.";
 	oreAmount = 0
 	},
 /turf/open/floor/fakespace,

--- a/_maps/shuttles/emergency_saltmine.dmm
+++ b/_maps/shuttles/emergency_saltmine.dmm
@@ -593,6 +593,23 @@
 /mob/living/simple_animal/bot/honkbot,
 /turf/open/floor/fakespace,
 /area/shuttle/escape)
+"Ho" = (
+/obj/effect/decal/cleanable/salt,
+/obj/structure/window/plasma/reinforced{
+	dir = 1
+	},
+/obj/structure/table/reinforced,
+/obj/item/clothing/neck/petcollar,
+/obj/item/restraints/handcuffs,
+/turf/open/floor/fakespace,
+/area/shuttle/escape)
+"HA" = (
+/obj/effect/decal/cleanable/salt,
+/obj/structure/table/reinforced,
+/obj/item/clothing/under/schoolgirl,
+/obj/item/clothing/head/kitty,
+/turf/open/floor/fakespace,
+/area/shuttle/escape)
 "Iq" = (
 /obj/effect/decal/cleanable/salt,
 /obj/structure/bed/dogbed/ian,
@@ -794,10 +811,10 @@ ae
 aP
 ba
 bm
-bt
+Ho
 aK
 aK
-aK
+HA
 ac
 "}
 (13,1,1) = {"

--- a/_maps/shuttles/emergency_saltmine.dmm
+++ b/_maps/shuttles/emergency_saltmine.dmm
@@ -512,7 +512,6 @@
 /turf/open/floor/fakespace,
 /area/shuttle/escape)
 "bI" = (
-/obj/effect/decal/cleanable/salt,
 /turf/open/chasm,
 /area/shuttle/escape)
 "bJ" = (
@@ -521,6 +520,7 @@
 	dir = 4
 	},
 /obj/effect/decal/cleanable/salt,
+/obj/item/clothing/mask/frog,
 /obj/item/storage/box/hug/medical,
 /turf/open/floor/fakepit,
 /area/shuttle/escape)
@@ -553,7 +553,10 @@
 /area/shuttle/escape)
 "jz" = (
 /obj/effect/decal/cleanable/salt,
-/obj/structure/statue/plasma/scientist,
+/obj/structure/statue/plasma/scientist{
+	desc = "This statue is suitably made from Armhulen's tears.";
+	oreAmount = 0
+	},
 /turf/open/floor/fakespace,
 /area/shuttle/escape)
 "oC" = (

--- a/_maps/shuttles/emergency_saltmine.dmm
+++ b/_maps/shuttles/emergency_saltmine.dmm
@@ -41,6 +41,9 @@
 /obj/effect/decal/cleanable/salt,
 /obj/structure/table/reinforced,
 /obj/item/card/emag/fake,
+/obj/machinery/light{
+	dir = 1
+	},
 /turf/open/floor/fakespace,
 /area/shuttle/escape)
 "ak" = (
@@ -176,7 +179,9 @@
 /area/shuttle/escape)
 "aG" = (
 /obj/effect/decal/cleanable/salt,
-/obj/machinery/door/airlock/clockwork,
+/obj/machinery/door/airlock/clockwork{
+	req_access = null
+	},
 /turf/open/indestructible/clock_spawn_room,
 /area/shuttle/escape)
 "aH" = (
@@ -251,6 +256,7 @@
 /area/shuttle/escape)
 "aT" = (
 /obj/machinery/door/airlock/titanium,
+/obj/item/soap/deluxe,
 /turf/open/floor/fakespace,
 /area/shuttle/escape)
 "aU" = (
@@ -307,6 +313,7 @@
 	timid = 1;
 	width = 14
 	},
+/obj/item/soap/deluxe,
 /turf/open/floor/fakespace,
 /area/shuttle/escape)
 "be" = (
@@ -551,6 +558,10 @@
 /area/shuttle/escape)
 "oC" = (
 /obj/effect/decal/cleanable/salt,
+/obj/structure/window,
+/obj/structure/window{
+	dir = 4
+	},
 /mob/living/simple_animal/hostile/retaliate/clown{
 	health = 200;
 	maxHealth = 200
@@ -593,6 +604,17 @@
 /mob/living/simple_animal/bot/honkbot,
 /turf/open/floor/fakespace,
 /area/shuttle/escape)
+"CB" = (
+/obj/effect/decal/cleanable/salt,
+/obj/structure/window{
+	dir = 4
+	},
+/mob/living/simple_animal/hostile/retaliate/clown{
+	health = 200;
+	maxHealth = 200
+	},
+/turf/open/floor/fakespace,
+/area/shuttle/escape)
 "Ho" = (
 /obj/effect/decal/cleanable/salt,
 /obj/structure/window/plasma/reinforced{
@@ -624,6 +646,13 @@
 	},
 /turf/open/floor/fakespace,
 /area/shuttle/escape)
+"Uc" = (
+/obj/effect/decal/cleanable/salt,
+/obj/item/grown/bananapeel,
+/obj/structure/table/reinforced,
+/obj/item/clothing/suit/armor/reactive/table,
+/turf/open/floor/fakespace,
+/area/shuttle/escape)
 
 (1,1,1) = {"
 aa
@@ -646,7 +675,7 @@ aa
 ac
 ah
 LR
-oC
+CB
 vf
 jz
 aU
@@ -813,7 +842,7 @@ ba
 bm
 Ho
 aK
-aK
+Uc
 HA
 ac
 "}

--- a/_maps/shuttles/emergency_saltmine.dmm
+++ b/_maps/shuttles/emergency_saltmine.dmm
@@ -258,12 +258,6 @@
 /obj/item/toy/syndicateballoon,
 /turf/open/floor/fakespace,
 /area/shuttle/escape)
-"aV" = (
-/obj/effect/decal/cleanable/salt,
-/obj/item/grown/bananapeel,
-/mob/living/simple_animal/bot/honkbot,
-/turf/open/floor/fakespace,
-/area/shuttle/escape)
 "aW" = (
 /obj/structure/table/reinforced,
 /obj/effect/decal/cleanable/salt,
@@ -281,13 +275,6 @@
 /obj/structure/table/reinforced,
 /obj/item/reagent_containers/food/snacks/salad/validsalad,
 /obj/item/toy/figure/hos,
-/turf/open/floor/fakespace,
-/area/shuttle/escape)
-"aZ" = (
-/obj/item/grown/bananapeel,
-/obj/item/storage/backpack,
-/obj/effect/decal/cleanable/salt,
-/mob/living/simple_animal/bot/honkbot,
 /turf/open/floor/fakespace,
 /area/shuttle/escape)
 "ba" = (
@@ -345,6 +332,7 @@
 /obj/effect/decal/cleanable/salt,
 /obj/effect/decal/cleanable/salt,
 /obj/item/clothing/mask/vape,
+/obj/structure/window/plasma/reinforced,
 /turf/open/floor/fakespace,
 /area/shuttle/escape)
 "bi" = (
@@ -484,6 +472,7 @@
 /obj/structure/table/reinforced,
 /obj/effect/decal/cleanable/salt,
 /obj/item/bikehorn,
+/obj/item/organ/eyes/moth,
 /turf/open/floor/fakespace,
 /area/shuttle/escape)
 "bD" = (
@@ -562,7 +551,16 @@
 /area/shuttle/escape)
 "oC" = (
 /obj/effect/decal/cleanable/salt,
-/mob/living/simple_animal/hostile/retaliate/clown,
+/mob/living/simple_animal/hostile/retaliate/clown{
+	health = 200;
+	maxHealth = 200
+	},
+/turf/open/floor/fakespace,
+/area/shuttle/escape)
+"rH" = (
+/obj/effect/decal/cleanable/salt,
+/obj/item/mecha_parts/mecha_equipment/weapon/honker,
+/obj/structure/table/reinforced,
 /turf/open/floor/fakespace,
 /area/shuttle/escape)
 "vf" = (
@@ -578,10 +576,35 @@
 /obj/item/device/radio/beacon,
 /turf/open/indestructible/clock_spawn_room,
 /area/shuttle/escape)
+"xd" = (
+/obj/effect/decal/cleanable/salt,
+/obj/structure/table/reinforced,
+/obj/item/codespeak_manual/unlimited,
+/turf/open/floor/plasteel/cult,
+/area/shuttle/escape)
 "xi" = (
 /obj/effect/decal/cleanable/salt,
 /obj/structure/table/reinforced,
 /obj/item/reagent_containers/food/snacks/grown/citrus/orange,
+/turf/open/floor/fakespace,
+/area/shuttle/escape)
+"Ac" = (
+/obj/effect/decal/cleanable/salt,
+/mob/living/simple_animal/bot/honkbot,
+/turf/open/floor/fakespace,
+/area/shuttle/escape)
+"Iq" = (
+/obj/effect/decal/cleanable/salt,
+/obj/structure/bed/dogbed/ian,
+/obj/item/stack/sheet/animalhide/corgi,
+/obj/item/reagent_containers/food/snacks/meat/slab/corgi,
+/turf/open/floor/fakespace,
+/area/shuttle/escape)
+"LR" = (
+/obj/effect/decal/cleanable/salt,
+/obj/mecha/combat/honker{
+	max_integrity = 60
+	},
 /turf/open/floor/fakespace,
 /area/shuttle/escape)
 
@@ -590,7 +613,7 @@ aa
 aa
 ac
 ac
-ad
+ac
 ac
 ad
 ad
@@ -605,8 +628,8 @@ aa
 aa
 ac
 ah
-ak
-ak
+LR
+oC
 vf
 jz
 aU
@@ -624,20 +647,20 @@ ai
 oC
 xi
 av
-ak
+Ac
 ak
 be
 ak
-ak
+Ac
 ak
 ac
 aa
 "}
 (4,1,1) = {"
 aa
-ad
+ac
 aj
-ak
+rH
 ay
 ac
 aJ
@@ -651,16 +674,16 @@ aa
 "}
 (5,1,1) = {"
 aa
-ad
+ac
 ak
 at
 ak
 ac
 aK
-aV
+aK
 bg
 bt
-aV
+aK
 aK
 ac
 aa
@@ -668,7 +691,7 @@ aa
 (6,1,1) = {"
 aa
 ac
-ak
+Iq
 au
 ak
 ac
@@ -689,10 +712,10 @@ av
 az
 ae
 aK
-aV
+aK
 bg
 bt
-aV
+aK
 aK
 aK
 ac
@@ -721,10 +744,10 @@ al
 aA
 aD
 aK
-aV
+aK
 bj
 bw
-aV
+aK
 aK
 aK
 ad
@@ -753,10 +776,10 @@ al
 al
 ae
 aO
-aZ
+aO
 bl
 bt
-aV
+aK
 aK
 aK
 ad
@@ -765,7 +788,7 @@ ad
 aa
 ae
 ao
-al
+xd
 aB
 ae
 aP

--- a/_maps/shuttles/emergency_saltmine.dmm
+++ b/_maps/shuttles/emergency_saltmine.dmm
@@ -142,12 +142,15 @@
 "aA" = (
 /obj/effect/decal/cleanable/salt,
 /obj/structure/table/reinforced,
+/obj/item/twohanded/spear,
+/obj/item/device/assembly/flash/handheld,
 /turf/open/floor/plasteel/cult,
 /area/shuttle/escape)
 "aB" = (
 /obj/structure/table/reinforced,
 /obj/effect/decal/cleanable/salt,
 /obj/item/greentext,
+/obj/item/banhammer,
 /turf/open/floor/plasteel/cult,
 /area/shuttle/escape)
 "aC" = (
@@ -290,7 +293,7 @@
 "ba" = (
 /obj/structure/table/reinforced,
 /obj/effect/decal/cleanable/salt,
-/obj/item/gun/ballistic/revolver/russian,
+/obj/item/gun/ballistic/revolver/reverse,
 /turf/open/floor/fakespace,
 /area/shuttle/escape)
 "bb" = (
@@ -328,13 +331,13 @@
 /obj/effect/decal/cleanable/salt,
 /obj/structure/table/reinforced,
 /obj/item/reagent_containers/glass/beaker/waterbottle/large,
-/obj/structure/window/reinforced,
+/obj/structure/window/plasma/reinforced,
 /turf/open/floor/fakespace,
 /area/shuttle/escape)
 "bg" = (
 /obj/effect/decal/cleanable/salt,
 /obj/item/grown/bananapeel,
-/obj/structure/window/reinforced,
+/obj/structure/window/plasma/reinforced,
 /turf/open/floor/fakespace,
 /area/shuttle/escape)
 "bh" = (
@@ -346,19 +349,19 @@
 /area/shuttle/escape)
 "bi" = (
 /obj/effect/decal/cleanable/salt,
-/obj/structure/window/reinforced,
+/obj/structure/window/plasma/reinforced,
 /obj/structure/table/glass,
 /obj/item/toy/plush/nukeplushie,
 /turf/open/floor/fakespace,
 /area/shuttle/escape)
 "bj" = (
-/obj/structure/window/reinforced,
+/obj/structure/window/plasma/reinforced,
 /obj/effect/decal/cleanable/salt,
 /obj/item/grown/bananapeel,
 /turf/open/floor/fakespace,
 /area/shuttle/escape)
 "bk" = (
-/obj/structure/window/reinforced,
+/obj/structure/window/plasma/reinforced,
 /obj/effect/decal/cleanable/salt,
 /obj/structure/table/reinforced,
 /obj/item/reagent_containers/food/snacks/salad/validsalad,
@@ -366,14 +369,14 @@
 /turf/open/floor/fakespace,
 /area/shuttle/escape)
 "bl" = (
-/obj/structure/window/reinforced,
+/obj/structure/window/plasma/reinforced,
 /obj/effect/decal/cleanable/salt,
 /obj/item/grown/bananapeel,
 /obj/item/storage/backpack,
 /turf/open/floor/fakespace,
 /area/shuttle/escape)
 "bm" = (
-/obj/structure/window/reinforced,
+/obj/structure/window/plasma/reinforced,
 /obj/machinery/light{
 	dir = 4
 	},
@@ -406,57 +409,52 @@
 /obj/effect/decal/cleanable/salt,
 /obj/structure/table/reinforced,
 /obj/item/reagent_containers/glass/beaker/waterbottle/large,
-/obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 2
+/obj/structure/window/plasma/reinforced{
+	dir = 1
 	},
 /turf/open/floor/fakespace,
 /area/shuttle/escape)
 "bt" = (
 /obj/effect/decal/cleanable/salt,
 /obj/item/grown/bananapeel,
-/obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 2
+/obj/structure/window/plasma/reinforced{
+	dir = 1
 	},
 /turf/open/floor/fakespace,
 /area/shuttle/escape)
 "bu" = (
 /obj/effect/decal/cleanable/salt,
 /obj/structure/table/reinforced,
-/obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 2
-	},
 /obj/item/clothing/head/collectable/wizard,
+/obj/structure/window/plasma/reinforced{
+	dir = 1
+	},
 /turf/open/floor/fakespace,
 /area/shuttle/escape)
 "bv" = (
 /obj/effect/decal/cleanable/salt,
-/obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 2
-	},
 /obj/structure/table/glass,
 /obj/item/clothing/head/kitty/genuine,
+/obj/structure/window/plasma/reinforced{
+	dir = 1
+	},
 /turf/open/floor/fakespace,
 /area/shuttle/escape)
 "bw" = (
-/obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 2
-	},
 /obj/effect/decal/cleanable/salt,
 /obj/item/grown/bananapeel,
+/obj/structure/window/plasma/reinforced{
+	dir = 1
+	},
+/obj/item/device/assembly/flash,
 /turf/open/floor/fakespace,
 /area/shuttle/escape)
 "bx" = (
-/obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 2
-	},
 /obj/effect/decal/cleanable/salt,
 /obj/structure/table/reinforced,
+/obj/structure/window/plasma/reinforced{
+	dir = 1
+	},
 /obj/item/toy/plush/lizardplushie,
 /turf/open/floor/fakespace,
 /area/shuttle/escape)
@@ -494,12 +492,8 @@
 /area/shuttle/escape)
 "bE" = (
 /obj/structure/table/glass,
-/obj/item/storage/firstaid/fire{
-	pixel_x = 5;
-	pixel_y = 5
-	},
-/obj/item/storage/firstaid/toxin,
 /obj/effect/decal/cleanable/salt,
+/obj/item/storage/firstaid/fire,
 /turf/open/floor/fakepit,
 /area/shuttle/escape)
 "bF" = (
@@ -527,15 +521,11 @@
 /area/shuttle/escape)
 "bJ" = (
 /obj/structure/table/glass,
-/obj/item/storage/firstaid/brute{
-	pixel_x = 5;
-	pixel_y = 5
-	},
-/obj/item/storage/firstaid/brute,
 /obj/machinery/light{
 	dir = 4
 	},
 /obj/effect/decal/cleanable/salt,
+/obj/item/storage/box/hug/medical,
 /turf/open/floor/fakepit,
 /area/shuttle/escape)
 "bK" = (
@@ -565,6 +555,35 @@
 /obj/item/grenade/flashbang,
 /turf/open/floor/fakepit,
 /area/shuttle/escape)
+"jz" = (
+/obj/effect/decal/cleanable/salt,
+/obj/structure/statue/plasma/scientist,
+/turf/open/floor/fakespace,
+/area/shuttle/escape)
+"oC" = (
+/obj/effect/decal/cleanable/salt,
+/mob/living/simple_animal/hostile/retaliate/clown,
+/turf/open/floor/fakespace,
+/area/shuttle/escape)
+"vf" = (
+/obj/effect/spawner/structure/window/shuttle,
+/obj/effect/decal/cleanable/salt,
+/obj/structure/table/reinforced,
+/turf/open/floor/fakespace,
+/area/shuttle/escape)
+"wp" = (
+/obj/effect/decal/cleanable/salt,
+/obj/structure/destructible/clockwork/trap/trigger/pressure_sensor,
+/obj/structure/destructible/clockwork/trap/brass_skewer,
+/obj/item/device/radio/beacon,
+/turf/open/indestructible/clock_spawn_room,
+/area/shuttle/escape)
+"xi" = (
+/obj/effect/decal/cleanable/salt,
+/obj/structure/table/reinforced,
+/obj/item/reagent_containers/food/snacks/grown/citrus/orange,
+/turf/open/floor/fakespace,
+/area/shuttle/escape)
 
 (1,1,1) = {"
 aa
@@ -588,12 +607,12 @@ ac
 ah
 ak
 ak
-ad
-ak
+vf
+jz
 aU
 aU
 aU
-ak
+jz
 ah
 ac
 aa
@@ -602,8 +621,8 @@ aa
 aa
 ac
 ai
-at
-au
+oC
+xi
 av
 ak
 ak
@@ -634,7 +653,7 @@ aa
 aa
 ad
 ak
-ak
+at
 ak
 ac
 aK
@@ -736,7 +755,7 @@ ae
 aO
 aZ
 bl
-bw
+bt
 aV
 aK
 aK
@@ -752,7 +771,7 @@ ae
 aP
 ba
 bm
-bw
+bt
 aK
 aK
 aK
@@ -776,7 +795,7 @@ ac
 "}
 (14,1,1) = {"
 ab
-af
+wp
 ap
 af
 af
@@ -792,7 +811,7 @@ ac
 "}
 (15,1,1) = {"
 ab
-af
+wp
 aq
 af
 af
@@ -808,7 +827,7 @@ ac
 "}
 (16,1,1) = {"
 ab
-af
+wp
 ar
 aw
 aC

--- a/_maps/shuttles/emergency_saltmine.dmm
+++ b/_maps/shuttles/emergency_saltmine.dmm
@@ -1,0 +1,856 @@
+//MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
+"aa" = (
+/turf/template_noop,
+/area/template_noop)
+"ab" = (
+/turf/closed/wall/clockwork,
+/area/shuttle/escape)
+"ac" = (
+/turf/closed/wall/mineral/titanium,
+/area/shuttle/escape)
+"ad" = (
+/obj/effect/spawner/structure/window/shuttle,
+/obj/effect/decal/cleanable/salt,
+/turf/open/floor/fakespace,
+/area/shuttle/escape)
+"ae" = (
+/turf/closed/wall/mineral/titanium,
+/turf/closed/wall/mineral/cult,
+/area/shuttle/escape)
+"af" = (
+/obj/effect/decal/cleanable/salt,
+/obj/structure/destructible/clockwork/trap/trigger/pressure_sensor,
+/obj/structure/destructible/clockwork/trap/brass_skewer,
+/turf/open/indestructible/clock_spawn_room,
+/area/shuttle/escape)
+"ag" = (
+/obj/structure/shuttle/engine/propulsion/right{
+	dir = 4
+	},
+/turf/open/floor/plating/airless,
+/area/shuttle/escape)
+"ah" = (
+/turf/closed/wall/mineral/titanium/nodiagonal,
+/area/shuttle/escape)
+"ai" = (
+/obj/machinery/computer/emergency_shuttle,
+/obj/effect/decal/cleanable/salt,
+/turf/open/floor/fakespace,
+/area/shuttle/escape)
+"aj" = (
+/obj/effect/decal/cleanable/salt,
+/obj/structure/table/reinforced,
+/obj/item/card/emag/fake,
+/turf/open/floor/fakespace,
+/area/shuttle/escape)
+"ak" = (
+/obj/effect/decal/cleanable/salt,
+/turf/open/floor/fakespace,
+/area/shuttle/escape)
+"al" = (
+/obj/effect/decal/cleanable/salt,
+/turf/open/floor/plasteel/cult,
+/area/shuttle/escape)
+"am" = (
+/obj/effect/decal/cleanable/salt,
+/obj/effect/decal/cleanable/crayon,
+/turf/open/floor/plasteel/cult,
+/area/shuttle/escape)
+"an" = (
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/salt,
+/turf/open/floor/plasteel/cult,
+/area/shuttle/escape)
+"ao" = (
+/obj/effect/decal/cleanable/salt,
+/obj/item/tome,
+/obj/structure/table/reinforced,
+/turf/open/floor/plasteel/cult,
+/area/shuttle/escape)
+"ap" = (
+/obj/effect/decal/cleanable/salt,
+/obj/item/clothing/gloves/clockwork,
+/obj/structure/destructible/clockwork/trap/trigger/pressure_sensor,
+/obj/structure/destructible/clockwork/trap/brass_skewer,
+/turf/open/indestructible/clock_spawn_room,
+/area/shuttle/escape)
+"aq" = (
+/obj/effect/decal/cleanable/salt,
+/obj/item/clothing/suit/armor/clockwork,
+/obj/structure/destructible/clockwork/trap/trigger/pressure_sensor,
+/obj/structure/destructible/clockwork/trap/brass_skewer,
+/turf/open/indestructible/clock_spawn_room,
+/area/shuttle/escape)
+"ar" = (
+/obj/machinery/light{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/salt,
+/obj/item/clothing/shoes/clockwork,
+/obj/structure/destructible/clockwork/trap/trigger/pressure_sensor,
+/obj/structure/destructible/clockwork/trap/brass_skewer,
+/turf/open/indestructible/clock_spawn_room,
+/area/shuttle/escape)
+"as" = (
+/obj/structure/shuttle/engine/propulsion{
+	dir = 4
+	},
+/turf/open/floor/plating/airless,
+/area/shuttle/escape)
+"at" = (
+/obj/effect/decal/cleanable/salt,
+/obj/machinery/portable_atmospherics/canister/water_vapor,
+/turf/open/floor/fakespace,
+/area/shuttle/escape)
+"au" = (
+/obj/effect/decal/cleanable/salt,
+/obj/structure/table/reinforced,
+/obj/structure/holosign/wetsign,
+/turf/open/floor/fakespace,
+/area/shuttle/escape)
+"av" = (
+/obj/machinery/door/airlock/command/glass{
+	name = "bridge door";
+	req_access_txt = "19";
+	secondsElectrified = -1
+	},
+/obj/effect/decal/cleanable/salt,
+/turf/open/floor/fakespace,
+/area/shuttle/escape)
+"aw" = (
+/obj/effect/decal/cleanable/salt,
+/obj/structure/destructible/clockwork/trap/trigger/pressure_sensor,
+/turf/open/indestructible/clock_spawn_room,
+/area/shuttle/escape)
+"ax" = (
+/obj/structure/shuttle/engine/propulsion/left{
+	dir = 4
+	},
+/turf/open/floor/plating/airless,
+/area/shuttle/escape)
+"ay" = (
+/obj/machinery/light,
+/obj/effect/decal/cleanable/salt,
+/turf/open/floor/fakespace,
+/area/shuttle/escape)
+"az" = (
+/turf/open/floor/plasteel/cult,
+/turf/closed/wall/mineral/cult,
+/area/shuttle/escape)
+"aA" = (
+/obj/effect/decal/cleanable/salt,
+/obj/structure/table/reinforced,
+/turf/open/floor/plasteel/cult,
+/area/shuttle/escape)
+"aB" = (
+/obj/structure/table/reinforced,
+/obj/effect/decal/cleanable/salt,
+/obj/item/greentext,
+/turf/open/floor/plasteel/cult,
+/area/shuttle/escape)
+"aC" = (
+/obj/effect/decal/cleanable/salt,
+/turf/open/indestructible/clock_spawn_room,
+/area/shuttle/escape)
+"aD" = (
+/obj/machinery/door/airlock/security/glass{
+	name = "security airlock";
+	req_access_txt = "63";
+	secondsElectrified = -1
+	},
+/obj/effect/decal/cleanable/salt,
+/turf/open/floor/plasteel/cult,
+/area/shuttle/escape)
+"aE" = (
+/obj/structure/sign/poster/contraband/energy_swords,
+/turf/closed/wall/clockwork,
+/area/shuttle/escape)
+"aF" = (
+/obj/structure/sign/poster/contraband/revolver,
+/turf/closed/wall/clockwork,
+/area/shuttle/escape)
+"aG" = (
+/obj/effect/decal/cleanable/salt,
+/obj/machinery/door/airlock/clockwork,
+/turf/open/indestructible/clock_spawn_room,
+/area/shuttle/escape)
+"aH" = (
+/obj/structure/sign/poster/contraband/kudzu,
+/turf/closed/wall/clockwork,
+/area/shuttle/escape)
+"aI" = (
+/obj/structure/sign/poster/contraband/busty_backdoor_xeno_babes_6,
+/turf/closed/wall/clockwork,
+/area/shuttle/escape)
+"aJ" = (
+/obj/effect/decal/cleanable/salt,
+/obj/structure/table/reinforced,
+/obj/item/reagent_containers/glass/beaker/waterbottle/large,
+/turf/open/floor/fakespace,
+/area/shuttle/escape)
+"aK" = (
+/obj/effect/decal/cleanable/salt,
+/obj/item/grown/bananapeel,
+/turf/open/floor/fakespace,
+/area/shuttle/escape)
+"aL" = (
+/obj/structure/table/reinforced,
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/salt,
+/obj/item/clothing/mask/vape,
+/turf/open/floor/fakespace,
+/area/shuttle/escape)
+"aM" = (
+/obj/effect/decal/cleanable/salt,
+/obj/structure/table/glass,
+/obj/item/toy/plush/plushvar,
+/turf/open/floor/fakespace,
+/area/shuttle/escape)
+"aN" = (
+/obj/effect/decal/cleanable/salt,
+/obj/structure/table/reinforced,
+/obj/item/reagent_containers/food/snacks/salad/validsalad,
+/obj/item/toy/figure/warden,
+/turf/open/floor/fakespace,
+/area/shuttle/escape)
+"aO" = (
+/obj/item/grown/bananapeel,
+/obj/item/storage/backpack,
+/obj/effect/decal/cleanable/salt,
+/turf/open/floor/fakespace,
+/area/shuttle/escape)
+"aP" = (
+/obj/structure/table/reinforced,
+/obj/effect/decal/cleanable/salt,
+/obj/item/gun/ballistic/automatic/c20r/toy/unrestricted,
+/turf/open/floor/fakespace,
+/area/shuttle/escape)
+"aQ" = (
+/obj/item/soap/deluxe,
+/obj/effect/decal/cleanable/salt,
+/turf/open/floor/fakespace,
+/area/shuttle/escape)
+"aR" = (
+/obj/effect/decal/cleanable/salt,
+/obj/structure/table/glass,
+/obj/item/toy/spinningtoy,
+/turf/open/floor/fakespace,
+/area/shuttle/escape)
+"aS" = (
+/obj/structure/table/reinforced,
+/obj/effect/decal/cleanable/salt,
+/obj/item/toy/katana,
+/turf/open/floor/fakespace,
+/area/shuttle/escape)
+"aT" = (
+/obj/machinery/door/airlock/titanium,
+/turf/open/floor/fakespace,
+/area/shuttle/escape)
+"aU" = (
+/obj/effect/decal/cleanable/salt,
+/obj/item/toy/syndicateballoon,
+/turf/open/floor/fakespace,
+/area/shuttle/escape)
+"aV" = (
+/obj/effect/decal/cleanable/salt,
+/obj/item/grown/bananapeel,
+/mob/living/simple_animal/bot/honkbot,
+/turf/open/floor/fakespace,
+/area/shuttle/escape)
+"aW" = (
+/obj/structure/table/reinforced,
+/obj/effect/decal/cleanable/salt,
+/obj/item/clothing/mask/vape,
+/turf/open/floor/fakespace,
+/area/shuttle/escape)
+"aX" = (
+/obj/effect/decal/cleanable/salt,
+/obj/structure/table/glass,
+/obj/item/toy/plush/narplush,
+/turf/open/floor/fakespace,
+/area/shuttle/escape)
+"aY" = (
+/obj/effect/decal/cleanable/salt,
+/obj/structure/table/reinforced,
+/obj/item/reagent_containers/food/snacks/salad/validsalad,
+/obj/item/toy/figure/hos,
+/turf/open/floor/fakespace,
+/area/shuttle/escape)
+"aZ" = (
+/obj/item/grown/bananapeel,
+/obj/item/storage/backpack,
+/obj/effect/decal/cleanable/salt,
+/mob/living/simple_animal/bot/honkbot,
+/turf/open/floor/fakespace,
+/area/shuttle/escape)
+"ba" = (
+/obj/structure/table/reinforced,
+/obj/effect/decal/cleanable/salt,
+/obj/item/gun/ballistic/revolver/russian,
+/turf/open/floor/fakespace,
+/area/shuttle/escape)
+"bb" = (
+/obj/structure/table/reinforced,
+/obj/effect/decal/cleanable/salt,
+/obj/item/toy/sword,
+/turf/open/floor/fakespace,
+/area/shuttle/escape)
+"bc" = (
+/obj/machinery/light/small,
+/obj/item/soap/deluxe,
+/obj/effect/decal/cleanable/salt,
+/turf/open/floor/fakespace,
+/area/shuttle/escape)
+"bd" = (
+/obj/machinery/door/airlock/titanium,
+/obj/docking_port/mobile/emergency{
+	dheight = 0;
+	dir = 8;
+	dwidth = 6;
+	height = 18;
+	name = "Saltmine";
+	port_direction = 4;
+	timid = 1;
+	width = 14
+	},
+/turf/open/floor/fakespace,
+/area/shuttle/escape)
+"be" = (
+/obj/effect/decal/cleanable/salt,
+/mob/living/simple_animal/bot/secbot/beepsky,
+/turf/open/floor/fakespace,
+/area/shuttle/escape)
+"bf" = (
+/obj/effect/decal/cleanable/salt,
+/obj/structure/table/reinforced,
+/obj/item/reagent_containers/glass/beaker/waterbottle/large,
+/obj/structure/window/reinforced,
+/turf/open/floor/fakespace,
+/area/shuttle/escape)
+"bg" = (
+/obj/effect/decal/cleanable/salt,
+/obj/item/grown/bananapeel,
+/obj/structure/window/reinforced,
+/turf/open/floor/fakespace,
+/area/shuttle/escape)
+"bh" = (
+/obj/structure/table/reinforced,
+/obj/effect/decal/cleanable/salt,
+/obj/effect/decal/cleanable/salt,
+/obj/item/clothing/mask/vape,
+/turf/open/floor/fakespace,
+/area/shuttle/escape)
+"bi" = (
+/obj/effect/decal/cleanable/salt,
+/obj/structure/window/reinforced,
+/obj/structure/table/glass,
+/obj/item/toy/plush/nukeplushie,
+/turf/open/floor/fakespace,
+/area/shuttle/escape)
+"bj" = (
+/obj/structure/window/reinforced,
+/obj/effect/decal/cleanable/salt,
+/obj/item/grown/bananapeel,
+/turf/open/floor/fakespace,
+/area/shuttle/escape)
+"bk" = (
+/obj/structure/window/reinforced,
+/obj/effect/decal/cleanable/salt,
+/obj/structure/table/reinforced,
+/obj/item/reagent_containers/food/snacks/salad/validsalad,
+/obj/item/toy/figure/secofficer,
+/turf/open/floor/fakespace,
+/area/shuttle/escape)
+"bl" = (
+/obj/structure/window/reinforced,
+/obj/effect/decal/cleanable/salt,
+/obj/item/grown/bananapeel,
+/obj/item/storage/backpack,
+/turf/open/floor/fakespace,
+/area/shuttle/escape)
+"bm" = (
+/obj/structure/window/reinforced,
+/obj/machinery/light{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/salt,
+/obj/structure/table/reinforced,
+/obj/item/gun/ballistic/automatic/l6_saw/toy/unrestricted,
+/turf/open/floor/fakespace,
+/area/shuttle/escape)
+"bn" = (
+/obj/structure/sign/poster/contraband/lizard,
+/turf/closed/wall/mineral/titanium/nodiagonal,
+/area/shuttle/escape)
+"bo" = (
+/obj/structure/sign/poster/contraband/lusty_xenomorph,
+/turf/closed/wall/mineral/titanium/nodiagonal,
+/area/shuttle/escape)
+"bp" = (
+/obj/structure/sign/poster/contraband/grey_tide,
+/turf/closed/wall/mineral/titanium/nodiagonal,
+/area/shuttle/escape)
+"bq" = (
+/obj/structure/sign/poster/contraband/fun_police,
+/turf/closed/wall/mineral/titanium,
+/area/shuttle/escape)
+"br" = (
+/obj/structure/sign/poster/official/wtf_is_co2,
+/turf/closed/wall/mineral/titanium,
+/area/shuttle/escape)
+"bs" = (
+/obj/effect/decal/cleanable/salt,
+/obj/structure/table/reinforced,
+/obj/item/reagent_containers/glass/beaker/waterbottle/large,
+/obj/structure/window/reinforced{
+	dir = 1;
+	pixel_y = 2
+	},
+/turf/open/floor/fakespace,
+/area/shuttle/escape)
+"bt" = (
+/obj/effect/decal/cleanable/salt,
+/obj/item/grown/bananapeel,
+/obj/structure/window/reinforced{
+	dir = 1;
+	pixel_y = 2
+	},
+/turf/open/floor/fakespace,
+/area/shuttle/escape)
+"bu" = (
+/obj/effect/decal/cleanable/salt,
+/obj/structure/table/reinforced,
+/obj/structure/window/reinforced{
+	dir = 1;
+	pixel_y = 2
+	},
+/obj/item/clothing/head/collectable/wizard,
+/turf/open/floor/fakespace,
+/area/shuttle/escape)
+"bv" = (
+/obj/effect/decal/cleanable/salt,
+/obj/structure/window/reinforced{
+	dir = 1;
+	pixel_y = 2
+	},
+/obj/structure/table/glass,
+/obj/item/clothing/head/kitty/genuine,
+/turf/open/floor/fakespace,
+/area/shuttle/escape)
+"bw" = (
+/obj/structure/window/reinforced{
+	dir = 1;
+	pixel_y = 2
+	},
+/obj/effect/decal/cleanable/salt,
+/obj/item/grown/bananapeel,
+/turf/open/floor/fakespace,
+/area/shuttle/escape)
+"bx" = (
+/obj/structure/window/reinforced{
+	dir = 1;
+	pixel_y = 2
+	},
+/obj/effect/decal/cleanable/salt,
+/obj/structure/table/reinforced,
+/obj/item/toy/plush/lizardplushie,
+/turf/open/floor/fakespace,
+/area/shuttle/escape)
+"by" = (
+/obj/effect/decal/cleanable/salt,
+/turf/closed/wall/mineral/titanium,
+/area/shuttle/escape)
+"bz" = (
+/obj/effect/decal/cleanable/salt,
+/obj/structure/table/reinforced,
+/obj/item/clothing/suit/wizrobe,
+/turf/open/floor/fakespace,
+/area/shuttle/escape)
+"bA" = (
+/obj/structure/table/glass,
+/obj/effect/decal/cleanable/salt,
+/obj/item/clothing/head/rabbitears,
+/turf/open/floor/fakespace,
+/area/shuttle/escape)
+"bB" = (
+/obj/effect/decal/cleanable/salt,
+/obj/structure/table/reinforced,
+/obj/item/stack/sheet/animalhide/lizard,
+/turf/open/floor/fakespace,
+/area/shuttle/escape)
+"bC" = (
+/obj/structure/table/reinforced,
+/obj/effect/decal/cleanable/salt,
+/obj/item/bikehorn,
+/turf/open/floor/fakespace,
+/area/shuttle/escape)
+"bD" = (
+/obj/effect/decal/cleanable/salt,
+/turf/open/floor/fakepit,
+/area/shuttle/escape)
+"bE" = (
+/obj/structure/table/glass,
+/obj/item/storage/firstaid/fire{
+	pixel_x = 5;
+	pixel_y = 5
+	},
+/obj/item/storage/firstaid/toxin,
+/obj/effect/decal/cleanable/salt,
+/turf/open/floor/fakepit,
+/area/shuttle/escape)
+"bF" = (
+/obj/machinery/light,
+/obj/effect/decal/cleanable/salt,
+/obj/structure/table/reinforced,
+/obj/item/gun/magic/wand/resurrection/inert,
+/turf/open/floor/fakespace,
+/area/shuttle/escape)
+"bG" = (
+/obj/effect/decal/cleanable/salt,
+/obj/structure/table/glass,
+/obj/item/clothing/head/rabbitears,
+/turf/open/floor/fakespace,
+/area/shuttle/escape)
+"bH" = (
+/obj/effect/decal/cleanable/salt,
+/obj/structure/table/reinforced,
+/obj/item/reagent_containers/food/drinks/bottle/lizardwine,
+/turf/open/floor/fakespace,
+/area/shuttle/escape)
+"bI" = (
+/obj/effect/decal/cleanable/salt,
+/turf/open/chasm,
+/area/shuttle/escape)
+"bJ" = (
+/obj/structure/table/glass,
+/obj/item/storage/firstaid/brute{
+	pixel_x = 5;
+	pixel_y = 5
+	},
+/obj/item/storage/firstaid/brute,
+/obj/machinery/light{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/salt,
+/turf/open/floor/fakepit,
+/area/shuttle/escape)
+"bK" = (
+/obj/effect/decal/cleanable/salt,
+/obj/structure/table/glass,
+/obj/item/clothing/head/kitty/genuine,
+/turf/open/floor/fakespace,
+/area/shuttle/escape)
+"bL" = (
+/obj/effect/decal/cleanable/salt,
+/obj/structure/table/reinforced,
+/obj/item/toy/plush/lizardplushie,
+/turf/open/floor/fakespace,
+/area/shuttle/escape)
+"bM" = (
+/obj/effect/decal/cleanable/salt,
+/obj/machinery/sleeper/syndie,
+/turf/open/floor/fakepit,
+/area/shuttle/escape)
+"bN" = (
+/obj/structure/table/glass,
+/obj/effect/decal/cleanable/salt,
+/obj/item/grenade/flashbang,
+/obj/item/grenade/flashbang,
+/obj/item/grenade/flashbang,
+/obj/item/grenade/flashbang,
+/obj/item/grenade/flashbang,
+/turf/open/floor/fakepit,
+/area/shuttle/escape)
+
+(1,1,1) = {"
+aa
+aa
+ac
+ac
+ad
+ac
+ad
+ad
+ad
+ad
+ad
+ac
+aa
+aa
+"}
+(2,1,1) = {"
+aa
+ac
+ah
+ak
+ak
+ad
+ak
+aU
+aU
+aU
+ak
+ah
+ac
+aa
+"}
+(3,1,1) = {"
+aa
+ac
+ai
+at
+au
+av
+ak
+ak
+be
+ak
+ak
+ak
+ac
+aa
+"}
+(4,1,1) = {"
+aa
+ad
+aj
+ak
+ay
+ac
+aJ
+aJ
+bf
+bs
+aJ
+aJ
+ac
+aa
+"}
+(5,1,1) = {"
+aa
+ad
+ak
+ak
+ak
+ac
+aK
+aV
+bg
+bt
+aV
+aK
+ac
+aa
+"}
+(6,1,1) = {"
+aa
+ac
+ak
+au
+ak
+ac
+aL
+aW
+bh
+bu
+bz
+bF
+ah
+ac
+"}
+(7,1,1) = {"
+aa
+ae
+ae
+av
+az
+ae
+aK
+aV
+bg
+bt
+aV
+aK
+aK
+ac
+"}
+(8,1,1) = {"
+aa
+ae
+al
+al
+al
+az
+aM
+aX
+bi
+bv
+bA
+bG
+bK
+ac
+"}
+(9,1,1) = {"
+aa
+ae
+am
+al
+aA
+aD
+aK
+aV
+bj
+bw
+aV
+aK
+aK
+ad
+"}
+(10,1,1) = {"
+aa
+ae
+an
+al
+al
+az
+aN
+aY
+bk
+bx
+bB
+bH
+bL
+ad
+"}
+(11,1,1) = {"
+aa
+ae
+al
+al
+al
+ae
+aO
+aZ
+bl
+bw
+aV
+aK
+aK
+ad
+"}
+(12,1,1) = {"
+aa
+ae
+ao
+al
+aB
+ae
+aP
+ba
+bm
+bw
+aK
+aK
+aK
+ac
+"}
+(13,1,1) = {"
+ab
+ab
+ab
+ab
+ab
+aE
+aQ
+aQ
+bn
+ah
+bC
+ad
+ac
+ac
+"}
+(14,1,1) = {"
+ab
+af
+ap
+af
+af
+aF
+aR
+aR
+bo
+by
+bD
+bD
+bM
+ac
+"}
+(15,1,1) = {"
+ab
+af
+aq
+af
+af
+aG
+aQ
+aQ
+bp
+by
+bD
+bI
+bD
+ac
+"}
+(16,1,1) = {"
+ab
+af
+ar
+aw
+aC
+aH
+aS
+bb
+bq
+ac
+bE
+bJ
+bN
+ac
+"}
+(17,1,1) = {"
+ab
+ab
+ab
+ab
+ab
+aI
+aQ
+bc
+br
+ac
+ac
+ac
+ac
+ac
+"}
+(18,1,1) = {"
+ac
+ag
+as
+ax
+ac
+ac
+aT
+bd
+ac
+ah
+ag
+as
+ax
+ac
+"}

--- a/code/datums/shuttles.dm
+++ b/code/datums/shuttles.dm
@@ -103,18 +103,19 @@
 	admin_notes = "Includes a small variety of weapons. And bears. Only captain-access can release the bears. Bears won't smash the windows themselves, but they can escape if someone lets them."
 	credit_cost = 5000 // While the shuttle is rusted and poorly maintained, trained bears are costly.
 
-/datum/map_template/shuttle/emergency/saltmine
-	suffix = "saltmine"
-	name = "The Saltmine"
-	description = "Contains everything that upsets you."
-	credit_cost = 5000
-
 /datum/map_template/shuttle/emergency/meteor
 	suffix = "meteor"
 	name = "Asteroid With Engines Strapped To It"
 	description = "A hollowed out asteroid with engines strapped to it. Due to its size and difficulty in steering it, this shuttle may damage the docking area."
 	admin_notes = "This shuttle will likely crush escape, killing anyone there."
 	credit_cost = -5000
+
+/datum/map_template/shuttle/emergency/saltmine
+	suffix = "saltmine"
+	name = "The Saltmine"
+	description = "Contains everything that upsets you."
+	admin_notes = "Don't forget: You're here forever."
+	credit_cost = 10000
 
 /datum/map_template/shuttle/emergency/luxury
 	suffix = "luxury"

--- a/code/datums/shuttles.dm
+++ b/code/datums/shuttles.dm
@@ -107,7 +107,7 @@
 	suffix = "saltmine"
 	name = "The Saltmine"
 	description = "Contains everything that upsets you."
-	credit_cost = 3000
+	credit_cost = 5000
 
 /datum/map_template/shuttle/emergency/meteor
 	suffix = "meteor"

--- a/code/datums/shuttles.dm
+++ b/code/datums/shuttles.dm
@@ -115,7 +115,12 @@
 	name = "The Saltmine"
 	description = "Contains everything that upsets you."
 	admin_notes = "Don't forget: You're here forever."
-	credit_cost = 10000
+	credit_cost = 5000
+
+/datum/map_template/shuttle/emergency/saltmine/prerequisites_met()
+	if("revenant" in SSshuttle.shuttle_purchase_requirements_met)
+		return TRUE
+	return FALSE
 
 /datum/map_template/shuttle/emergency/luxury
 	suffix = "luxury"

--- a/code/datums/shuttles.dm
+++ b/code/datums/shuttles.dm
@@ -87,6 +87,7 @@
 	description = "A respectable mid-sized shuttle that first saw service shuttling Nanotrasen crew to and from their asteroid belt embedded facilities."
 	credit_cost = 3000
 
+
 /datum/map_template/shuttle/emergency/bar
 	suffix = "bar"
 	name = "The Emergency Escape Bar"
@@ -101,6 +102,12 @@
 	description = "Dis is a high-quality shuttle, da. Many seats, lots of space, all equipment! Even includes entertainment! Such as lots to drink, and a fighting arena for drunk crew to have fun! If arena not fun enough, simply press button of releasing bears. Do not worry, bears trained not to break out of fighting pit, so totally safe so long as nobody stupid or drunk enough to leave door open. Try not to let asimov babycons ruin fun!"
 	admin_notes = "Includes a small variety of weapons. And bears. Only captain-access can release the bears. Bears won't smash the windows themselves, but they can escape if someone lets them."
 	credit_cost = 5000 // While the shuttle is rusted and poorly maintained, trained bears are costly.
+
+/datum/map_template/shuttle/emergency/saltmine
+	suffix = "saltmine"
+	name = "The Saltmine"
+	description = "Contains everything that upsets you."
+	credit_cost = 3000
 
 /datum/map_template/shuttle/emergency/meteor
 	suffix = "meteor"

--- a/code/game/objects/items/cards_ids.dm
+++ b/code/game/objects/items/cards_ids.dm
@@ -78,6 +78,9 @@
 		return
 	A.emag_act(user)
 
+/obj/item/card/emag/fake/afterattack()
+	return
+
 /obj/item/card/id
 	name = "identification card"
 	desc = "A card used to provide ID and determine access across the station."

--- a/code/game/objects/items/cards_ids.dm
+++ b/code/game/objects/items/cards_ids.dm
@@ -79,6 +79,7 @@
 	A.emag_act(user)
 
 /obj/item/card/emag/fake/afterattack()
+	playsound(src.loc, 'sound/items/bikehorn.ogg', 50, 1)
 	return
 
 /obj/item/card/id

--- a/code/modules/antagonists/revenant/revenant.dm
+++ b/code/modules/antagonists/revenant/revenant.dm
@@ -224,6 +224,7 @@
 	invisibility = INVISIBILITY_ABSTRACT
 	revealed = FALSE
 	ghostize(0)//Don't re-enter invisible corpse
+	SSshuttle.shuttle_purchase_requirements_met |= "revenant"
 
 
 //reveal, stun, icon updates, cast checks, and essence changing


### PR DESCRIPTION
[Changelogs]: 

:cl: Dax Dupont
add: Killing a revenant will now result in an unique shuttle to be able to be bought. You probably won't like it though.
add: Fake emag now available.
/:cl:

[why]: Inspired by a lot of salt lately, I have made a shuttle that contains more or less everything that makes people angry. Nothing that actually functions though, well except the clock cult room that's just unending skewers.

One of the chasms may be real.

Its based on the birdboat shuttle and flies sideways for memes
![dreamseeker_2018-02-06_13-43-53](https://user-images.githubusercontent.com/17237624/35860295-d0312adc-0b43-11e8-8e9b-caaa0cafdf31.png)
