### PR TITLE
Reminds assistants not to antagonize people 

### DIFF
--- a/code/modules/jobs/job_types/assistant.dm
+++ b/code/modules/jobs/job_types/assistant.dm
@@ -22,7 +22,7 @@ Assistant
 	else
 		return ..()
 /datum/job/assistant/after_spawn(mob/living/H, mob/M)
-	to_chat(M, "<span class='userdanger'>Note, being a assistant does not give you a license to grief people or antagonize security, Shitty behavior as a assistant (AKA: &quot;Greytide&quot;) Is not tolerated and may lead to a jobban.</span>")
+	to_chat(M, "<span class='userdanger'>Note, being a assistant does not give you a license to grief people or antagonize security, shitty behavior as a assistant (AKA: &quot;Greytide&quot;) Is not tolerated and may lead to a jobban.</span>")
 	
 /datum/job/assistant/config_check()
 	var/ac = CONFIG_GET(number/assistant_cap)

--- a/code/modules/jobs/job_types/assistant.dm
+++ b/code/modules/jobs/job_types/assistant.dm
@@ -22,7 +22,7 @@ Assistant
 	else
 		return ..()
 /datum/job/assistant/after_spawn(mob/living/H, mob/M)
-	to_chat(M, "<span class='userdanger'>Note, being a assistant does not give you a license to grief people or antagonize security, Shitty behavior as a assistant (AKA: "Greytide") Is not tolerated and may lead to a jobban. </span>")
+	to_chat(M, "<span class='userdanger'>Note, being a assistant does not give you a license to grief people or antagonize security, Shitty behavior as a assistant (AKA: &quot;Greytide&quot;) Is not tolerated and may lead to a jobban.</span>")
 	
 /datum/job/assistant/config_check()
 	var/ac = CONFIG_GET(number/assistant_cap)

--- a/code/modules/jobs/job_types/assistant.dm
+++ b/code/modules/jobs/job_types/assistant.dm
@@ -22,7 +22,7 @@ Assistant
 	else
 		return ..()
 /datum/job/assistant/after_spawn(mob/living/H, mob/M)
-	to_chat(M, "<span class='userdanger'>Note, being a assistant does not give you a license to grief people or antagonize security, shitty behavior as a assistant (AKA: &quot;Greytide&quot;) is not tolerated and may lead to a jobban.</span>")
+	to_chat(M, "<span class='userdanger'>Note, being a assistant does not give you a license to grief people or antagonize security, shitty behavior as a assistant (AKA: \"greytide\") is not tolerated and may lead to a jobban.</span>")
 	
 /datum/job/assistant/config_check()
 	var/ac = CONFIG_GET(number/assistant_cap)

--- a/code/modules/jobs/job_types/assistant.dm
+++ b/code/modules/jobs/job_types/assistant.dm
@@ -21,7 +21,9 @@ Assistant
 		. |= list(ACCESS_MAINT_TUNNELS)
 	else
 		return ..()
-
+/datum/job/assistant/after_spawn(mob/living/H, mob/M)
+	to_chat(M, "<span class='userdanger'>Note, being a assistant does not give you a license to grief people or antagonize security, Shitty behavior as a assistant (AKA: "Greytide) Is not tolerated and may lead to a jobban. </span>")
+	
 /datum/job/assistant/config_check()
 	var/ac = CONFIG_GET(number/assistant_cap)
 	if(ac != 0)

--- a/code/modules/jobs/job_types/assistant.dm
+++ b/code/modules/jobs/job_types/assistant.dm
@@ -22,7 +22,7 @@ Assistant
 	else
 		return ..()
 /datum/job/assistant/after_spawn(mob/living/H, mob/M)
-	to_chat(M, "<span class='userdanger'>Note, being a assistant does not give you a license to grief people or antagonize security, shitty behavior as a assistant (AKA: &quot;Greytide&quot;) Is not tolerated and may lead to a jobban.</span>")
+	to_chat(M, "<span class='userdanger'>Note, being a assistant does not give you a license to grief people or antagonize security, shitty behavior as a assistant (AKA: &quot;Greytide&quot;) is not tolerated and may lead to a jobban.</span>")
 	
 /datum/job/assistant/config_check()
 	var/ac = CONFIG_GET(number/assistant_cap)

--- a/code/modules/jobs/job_types/assistant.dm
+++ b/code/modules/jobs/job_types/assistant.dm
@@ -22,7 +22,7 @@ Assistant
 	else
 		return ..()
 /datum/job/assistant/after_spawn(mob/living/H, mob/M)
-	to_chat(M, "<span class='userdanger'>Note, being a assistant does not give you a license to grief people or antagonize security, Shitty behavior as a assistant (AKA: "Greytide) Is not tolerated and may lead to a jobban. </span>")
+	to_chat(M, "<span class='userdanger'>Note, being a assistant does not give you a license to grief people or antagonize security, Shitty behavior as a assistant (AKA: "Greytide") Is not tolerated and may lead to a jobban. </span>")
 	
 /datum/job/assistant/config_check()
 	var/ac = CONFIG_GET(number/assistant_cap)


### PR DESCRIPTION
:cl: 
admin: Assistants now get a warning regarding greytiding when they spawn
/:cl:

[why]: 
Greytide sucks and MSO's solution was bad, i think this is a good way to help without restricting a job meant for new players until they've played sec.

DNM until admins provide feedback on this as it may directly affect server administration.

Note to maintainers, requires squash before merge.