### PR TITLE
Fix pressure damage not taking effect properly

### DIFF
--- a/code/modules/mob/living/carbon/human/species.dm
+++ b/code/modules/mob/living/carbon/human/species.dm
@@ -1456,8 +1456,6 @@ GLOBAL_LIST_EMPTY(roundstart_races)
 	//Body temperature is adjusted in two parts: first there your body tries to naturally preserve homeostasis (shivering/sweating), then it reacts to the surrounding environment
 	//Thermal protection (insulation) has mixed benefits in two situations (hot in hot places, cold in hot places)
 	if(!H.on_fire) //If you're on fire, you do not heat up or cool down based on surrounding gases
-		if((abs(BODYTEMP_NORMAL - H.bodytemperature) <= 5) && (abs(BODYTEMP_NORMAL - loc_temp) <= 25))
-			return //Performance saver
 		var/natural = 0
 		if(H.stat != DEAD)
 			natural = H.natural_bodytemperature_stabilization()


### PR DESCRIPTION
:cl:
fix: Pressure damage now takes effect in certain situations where it should have but did not.
/:cl:

If a human's body and environment were both close enough to body temperature, and the human was not on fire, pressure damage checks did not occur. Note that the Lavaland surface and any siphoned area both fit this bill. Fixes #35357. Caused by #34133.

Travis failure is unrelated and fixed by #35375.