### PR TITLE
Fix bloodpack-related Travis failures

### DIFF
--- a/_maps/RandomZLevels/snowdin.dmm
+++ b/_maps/RandomZLevels/snowdin.dmm
@@ -2022,8 +2022,8 @@
 "eX" = (
 /obj/structure/closet/crate/freezer,
 /obj/item/reagent_containers/blood/random,
-/obj/item/reagent_containers/blood/empty,
-/obj/item/reagent_containers/blood/empty,
+/obj/item/reagent_containers/blood,
+/obj/item/reagent_containers/blood,
 /turf/open/floor/plasteel/cmo,
 /area/awaymission/snowdin/post)
 "eY" = (
@@ -2212,7 +2212,7 @@
 /turf/open/floor/plasteel/cmo,
 /area/awaymission/snowdin/post)
 "fx" = (
-/obj/item/reagent_containers/blood/empty,
+/obj/item/reagent_containers/blood,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	piping_layer = 3;
 	pixel_x = 5;


### PR DESCRIPTION
Caused by #35288 + #35000 together:

```
loading RandomZLevels\snowdin.dmm
_maps\RandomZLevels\snowdin.dmm:2025:error: undefined type: /obj/item/reagent_containers/blood/empty
_maps\RandomZLevels\snowdin.dmm:2026:error: undefined type: /obj/item/reagent_containers/blood/empty
_maps\RandomZLevels\snowdin.dmm:2028:error: unknown type
_maps\RandomZLevels\snowdin.dmm:2028:error: unknown type
_maps\RandomZLevels\snowdin.dmm:2215:error: undefined type: /obj/item/reagent_containers/blood/empty
_maps\RandomZLevels\snowdin.dmm:2223:error: unknown type
```