### PR TITLE
Prevents fungal TB spores from being synthesized

### DIFF
--- a/code/modules/reagents/chemistry/reagents/other_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/other_reagents.dm
@@ -1104,7 +1104,7 @@
 	id = "fungalspores"
 	description = "Active fungal spores."
 	color = "#92D17D" // rgb: 146, 209, 125
-	can_synth = 0
+	can_synth = FALSE
 	taste_description = "slime"
 
 /datum/reagent/fungalspores/reaction_mob(mob/M, method=TOUCH, reac_volume, show_message = 1, touch_protection = 0)

--- a/code/modules/reagents/chemistry/reagents/other_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/other_reagents.dm
@@ -1104,6 +1104,7 @@
 	id = "fungalspores"
 	description = "Active fungal spores."
 	color = "#92D17D" // rgb: 146, 209, 125
+	can_synth = 0
 	taste_description = "slime"
 
 /datum/reagent/fungalspores/reaction_mob(mob/M, method=TOUCH, reac_volume, show_message = 1, touch_protection = 0)


### PR DESCRIPTION
:cl: Denton
tweak: Fungal tuberculosis spores can no longer be synthesized by machinery. 
/:cl:

I've noticed that most "special" round ending chems like xenomicrobes have the can_synth 0 flag, but fungal TB juice doesn't.

This is mostly to prevent people from getting a nice warm cup of fungal TB from the #35188 SCP-294 ruin.