### PR TITLE
Makes lighting cache its generated icons

### DIFF
--- a/code/controllers/subsystem/lighting.dm
+++ b/code/controllers/subsystem/lighting.dm
@@ -8,6 +8,8 @@ SUBSYSTEM_DEF(lighting)
 	init_order = INIT_ORDER_LIGHTING
 	flags = SS_TICKER
 
+	var/list/lighting_appearance_cache = list()
+
 /datum/controller/subsystem/lighting/stat_entry()
 	..("L:[GLOB.lighting_update_lights.len]|C:[GLOB.lighting_update_corners.len]|O:[GLOB.lighting_update_objects.len]")
 
@@ -22,7 +24,7 @@ SUBSYSTEM_DEF(lighting)
 
 		create_all_lighting_objects()
 		initialized = TRUE
-	
+
 	fire(FALSE, TRUE)
 
 	..()

--- a/code/modules/lighting/lighting_object.dm
+++ b/code/modules/lighting/lighting_object.dm
@@ -107,22 +107,23 @@
 	var/set_luminosity = max > 1e-6
 	#endif
 
-	if((rr & gr & br & ar) && (rg + gg + bg + ag + rb + gb + bb + ab == 8))
-	//anything that passes the first case is very likely to pass the second, and addition is a little faster in this case
-		icon_state = "transparent"
-		color = null
-	else if(!set_luminosity)
-		icon_state = "dark"
-		color = null
-	else
-		icon_state = null
-		color = list(
-			rr, rg, rb, 00,
-			gr, gg, gb, 00,
-			br, bg, bb, 00,
-			ar, ag, ab, 00,
-			00, 00, 00, 01
-		)
+	if(!SSlighting.lighting_appearance_cache["[rr]-[rg]-[rb] [gr]-[gg]-[gb] [br]-[bg]-[bb] [ar]-[ag]-[ab]"])
+		var/mutable_appearance/lightappearance = mutable_appearance(LIGHTING_ICON, "transparent", LIGHTING_LAYER)
+		lightappearance.plane = LIGHTING_PLANE
+		if(!set_luminosity)
+			lightappearance.icon_state = "dark"
+		else
+			lightappearance.icon_state = null
+			lightappearance.color = list(
+				rr, rg, rb, 00,
+				gr, gg, gb, 00,
+				br, bg, bb, 00,
+				ar, ag, ab, 00,
+				00, 00, 00, 01
+			)
+		SSlighting.lighting_appearance_cache["[rr]-[rg]-[rb] [gr]-[gg]-[gb] [br]-[bg]-[bb] [ar]-[ag]-[ab]"] = lightappearance
+
+	appearance = SSlighting.lighting_appearance_cache["[rr]-[rg]-[rb] [gr]-[gg]-[gb] [br]-[bg]-[bb] [ar]-[ag]-[ab]"]
 
 	luminosity = set_luminosity
 


### PR DESCRIPTION
Title. Does exactly as it says on the tin.

This should, in theory, reduce the amount of memory used by lighting objects, while also speeding up lighting updates during chaotic rounds.

:cl: deathride58
code: Lighting now makes use of mutable_appearance to cache its generated icons.
/:cl:

Basically, it means features like https://github.com/Citadel-Station-13/Citadel-Station-13/pull/4281 won't make the server burn down faster than usual.