### PR TITLE
Removes an unnecessary type check from autolathe attackby

### DIFF
--- a/code/game/machinery/autolathe.dm
+++ b/code/game/machinery/autolathe.dm
@@ -89,18 +89,17 @@
 
 	if(default_deconstruction_screwdriver(user, "autolathe_t", "autolathe", O))
 		updateUsrDialog()
-		return
+		return TRUE
 
 	if(exchange_parts(user, O))
-		return
+		return TRUE
 
-	if(panel_open)
-		if(istype(O, /obj/item/crowbar))
-			default_deconstruction_crowbar(O)
-			return TRUE
-		else if(is_wire_tool(O))
-			wires.interact(user)
-			return TRUE
+	if(default_deconstruction_crowbar(O))
+		return TRUE
+
+	if(panel_open && is_wire_tool(O))
+		wires.interact(user)
+		return TRUE
 
 	if(user.a_intent == INTENT_HARM) //so we can hit the machine
 		return ..()


### PR DESCRIPTION
`default_deconstruction_crowbar` already does both the type check and the panel check, so there's no point in running them twice.