### PR TITLE
Brings certain designs in line with others.

### DIFF
--- a/code/modules/research/designs/comp_board_designs.dm
+++ b/code/modules/research/designs/comp_board_designs.dm
@@ -12,7 +12,6 @@
 	id = "arcade_battle"
 	build_path = /obj/item/circuitboard/computer/arcade/battle
 	category = list("Computer Boards")
-	departmental_flags = DEPARTMENTAL_FLAG_ENGINEERING
 
 /datum/design/board/orion_trail
 	name = "Computer Design (Orion Trail Arcade Machine)"
@@ -20,7 +19,6 @@
 	id = "arcade_orion"
 	build_path = /obj/item/circuitboard/computer/arcade/orion_trail
 	category = list("Computer Boards")
-	departmental_flags = DEPARTMENTAL_FLAG_ENGINEERING
 
 /datum/design/board/seccamera
 	name = "Computer Design (Security Camera)"

--- a/code/modules/research/designs/stock_parts_designs.dm
+++ b/code/modules/research/designs/stock_parts_designs.dm
@@ -275,6 +275,7 @@
 	materials = list(MAT_METAL = 100, MAT_GOLD = 100, MAT_URANIUM = 100)
 	build_path = /obj/item/stock_parts/subspace/amplifier
 	category = list("Stock Parts")
+	departmental_flags = DEPARTMENTAL_FLAG_ENGINEERING | DEPARTMENTAL_FLAG_SCIENCE
 
 /datum/design/subspace_treatment
 	name = "Subspace Treatment Disk"

--- a/code/modules/research/designs/telecomms_designs.dm
+++ b/code/modules/research/designs/telecomms_designs.dm
@@ -8,6 +8,7 @@
 	id = "s-receiver"
 	build_path = /obj/item/circuitboard/machine/telecomms/receiver
 	category = list("Subspace Telecomms")
+	departmental_flags = DEPARTMENTAL_FLAG_ENGINEERING | DEPARTMENTAL_FLAG_SCIENCE
 
 /datum/design/board/telecomms_bus
 	name = "Machine Design (Bus Mainframe)"
@@ -15,6 +16,7 @@
 	id = "s-bus"
 	build_path = /obj/item/circuitboard/machine/telecomms/bus
 	category = list("Subspace Telecomms")
+	departmental_flags = DEPARTMENTAL_FLAG_ENGINEERING | DEPARTMENTAL_FLAG_SCIENCE
 
 /datum/design/board/telecomms_hub
 	name = "Machine Design (Hub Mainframe)"
@@ -22,6 +24,7 @@
 	id = "s-hub"
 	build_path = /obj/item/circuitboard/machine/telecomms/hub
 	category = list("Subspace Telecomms")
+	departmental_flags = DEPARTMENTAL_FLAG_ENGINEERING | DEPARTMENTAL_FLAG_SCIENCE
 
 /datum/design/board/telecomms_relay
 	name = "Machine Design (Relay Mainframe)"
@@ -29,6 +32,7 @@
 	id = "s-relay"
 	build_path = /obj/item/circuitboard/machine/telecomms/relay
 	category = list("Subspace Telecomms")
+	departmental_flags = DEPARTMENTAL_FLAG_ENGINEERING | DEPARTMENTAL_FLAG_SCIENCE
 
 /datum/design/board/telecomms_processor
 	name = "Machine Design (Processor Unit)"
@@ -36,6 +40,7 @@
 	id = "s-processor"
 	build_path = /obj/item/circuitboard/machine/telecomms/processor
 	category = list("Subspace Telecomms")
+	departmental_flags = DEPARTMENTAL_FLAG_ENGINEERING | DEPARTMENTAL_FLAG_SCIENCE
 
 /datum/design/board/telecomms_server
 	name = "Machine Design (Server Mainframe)"
@@ -43,6 +48,7 @@
 	id = "s-server"
 	build_path = /obj/item/circuitboard/machine/telecomms/server
 	category = list("Subspace Telecomms")
+	departmental_flags = DEPARTMENTAL_FLAG_ENGINEERING | DEPARTMENTAL_FLAG_SCIENCE
 
 /datum/design/board/subspace_broadcaster
 	name = "Machine Design (Subspace Broadcaster)"
@@ -50,3 +56,4 @@
 	id = "s-broadcaster"
 	build_path = /obj/item/circuitboard/machine/telecomms/broadcaster
 	category = list("Subspace Telecomms")
+	departmental_flags = DEPARTMENTAL_FLAG_ENGINEERING | DEPARTMENTAL_FLAG_SCIENCE

--- a/code/modules/research/designs/weapon_designs.dm
+++ b/code/modules/research/designs/weapon_designs.dm
@@ -192,6 +192,7 @@
 	id = "mag_oldsmg_ap"
 	materials = list(MAT_METAL = 6000, MAT_SILVER = 600)
 	build_path = /obj/item/ammo_box/magazine/wt550m9/wtap
+	departmental_flags = DEPARTMENTAL_FLAG_SECURITY
 
 /datum/design/mag_oldsmg/ic_mag
 	name = "WT-550 Auto Gun Incendiary Magazine (4.6x30mm IC)"


### PR DESCRIPTION
[Changelogs]: 
:cl: Dax Dupont
fix: Telecom equipment now can only be printed by engineers and scientists as intended.
fix: WT-550 AP can only be printed by sec now.
tweak: Removed engineering requirement for arcade machines to bring it in line with others.
/:cl:

[why]: Fixes #35392