### PR TITLE
Removes chefs being automatically genetically italian

### DIFF
--- a/code/modules/jobs/job_types/cargo_service.dm
+++ b/code/modules/jobs/job_types/cargo_service.dm
@@ -216,14 +216,6 @@ Cook
 	var/obj/item/storage/box/I = new chosen_box(src)
 	H.equip_to_slot_or_del(I,slot_in_backpack)
 
-/datum/outfit/job/cook/post_equip(mob/living/carbon/human/H, visualsOnly = FALSE)
-	..()
-	if(visualsOnly)
-		return
-
-	H.dna.add_mutation(ITALIAN)
-
-
 /*
 Botanist
 */


### PR DESCRIPTION
:cl: coiax
del: Chefs are no longer unavoidably italian.
/:cl:


Closes #35416
I'm sorry, but a forced novelty speech impedient isn't actually that
funny for people who regularly play Chef. Make it somehow opt in, with a
mustache, or a minor preference, or some shit. But all chefs that I saw
play after this change reacted in horror when you'd just start randomly
spewing garbage verbally.

- Also, this double-overrided a proc, which is just bad form.