### PR TITLE
Fixes geiger counters on engiborgs

### DIFF
--- a/code/datums/components/_component.dm
+++ b/code/datums/components/_component.dm
@@ -95,7 +95,7 @@
 		if(!istype(proc_or_callback, /datum/callback)) //if it wasnt a callback before, it is now
 			proc_or_callback = CALLBACK(src, proc_or_callback)
 		procs[sig_type] = proc_or_callback
-	
+
 	enabled = TRUE
 
 /datum/component/proc/InheritComponent(datum/component/C, i_am_original)
@@ -180,7 +180,7 @@
 
 	var/datum/component/old_comp
 	var/datum/component/new_comp
-	
+
 	if(ispath(nt))
 		if(nt == /datum/component)
 			CRASH("[nt] attempted instantiation!")

--- a/code/game/atoms.dm
+++ b/code/game/atoms.dm
@@ -370,7 +370,7 @@
 	SendSignal(COMSIG_ATOM_EMAG_ACT)
 
 /atom/proc/rad_act(strength)
-	SendSignal(COMSIG_ATOM_RAD_ACT)
+	SendSignal(COMSIG_ATOM_RAD_ACT, strength)
 
 /atom/proc/narsie_act()
 	SendSignal(COMSIG_ATOM_NARSIE_ACT)

--- a/code/game/objects/items/devices/geiger_counter.dm
+++ b/code/game/objects/items/devices/geiger_counter.dm
@@ -213,8 +213,7 @@
 
 /obj/item/device/geiger_counter/cyborg/dropped()
 	. = ..()
-	if (mobhook)
-		QDEL_NULL(mobhook)
+	QDEL_NULL(mobhook)
 
 #undef RAD_LEVEL_NORMAL
 #undef RAD_LEVEL_MODERATE

--- a/code/game/objects/items/devices/geiger_counter.dm
+++ b/code/game/objects/items/devices/geiger_counter.dm
@@ -201,6 +201,21 @@
 	to_chat(user, "<span class='warning'>You override [src]'s radiation storing protocols. It will now generate small doses of radiation, and stored rads are now projected into creatures you scan.</span>")
 	obj_flags |= EMAGGED
 
+/obj/item/device/geiger_counter/cyborg
+	var/datum/component/mobhook
+
+/obj/item/device/geiger_counter/cyborg/equipped(mob/user)
+	. = ..()
+	if (mobhook && mobhook.parent != user)
+		QDEL_NULL(mobhook)
+	if (!mobhook)
+		mobhook = user.AddComponent(/datum/component/redirect, list(COMSIG_ATOM_RAD_ACT), CALLBACK(src, /atom.proc/rad_act))
+
+/obj/item/device/geiger_counter/cyborg/dropped()
+	. = ..()
+	if (mobhook)
+		QDEL_NULL(mobhook)
+
 #undef RAD_LEVEL_NORMAL
 #undef RAD_LEVEL_MODERATE
 #undef RAD_LEVEL_HIGH

--- a/code/modules/mob/living/silicon/robot/robot_modules.dm
+++ b/code/modules/mob/living/silicon/robot/robot_modules.dm
@@ -301,7 +301,7 @@
 		/obj/item/device/multitool/cyborg,
 		/obj/item/device/t_scanner,
 		/obj/item/device/analyzer,
-		/obj/item/device/geiger_counter,
+		/obj/item/device/geiger_counter/cyborg,
 		/obj/item/device/assembly/signaler/cyborg,
 		/obj/item/areaeditor/blueprints/cyborg,
 		/obj/item/device/electroadaptive_pseudocircuit,


### PR DESCRIPTION
Fixes #32866

also fixes COMSIG_ATOM_RAD_ACT to include the rad_act strength

:cl: Naksu
fix: Cyborg engineering module geiger counters now work properly again
/:cl:
