### PR TITLE
Var cleanup and map fixes

### DIFF
--- a/_maps/RandomRuins/SpaceRuins/bigderelict1.dmm
+++ b/_maps/RandomRuins/SpaceRuins/bigderelict1.dmm
@@ -208,8 +208,7 @@
 /area/ruin/space/has_grav/derelictoutpost/powerstorage)
 "aN" = (
 /obj/structure/closet/crate{
-	icon_state = "crateopen";
-	opened = 1
+	icon_state = "crateopen"
 	},
 /obj/effect/turf_decal/delivery,
 /turf/open/floor/plasteel,
@@ -679,7 +678,6 @@
 	dir = 4
 	},
 /turf/open/floor/plating{
-	icon_plating = "wall_thermite";
 	icon_state = "wall_thermite";
 	name = "melted wall"
 	},
@@ -1054,8 +1052,7 @@
 /area/ruin/space/has_grav/derelictoutpost/cargobay)
 "cH" = (
 /obj/structure/closet/crate{
-	icon_state = "crateopen";
-	opened = 1
+	icon_state = "crateopen"
 	},
 /obj/structure/cable{
 	icon_state = "1-4"
@@ -1712,7 +1709,6 @@
 	dir = 8
 	},
 /turf/open/floor/plating{
-	icon_plating = "wall_thermite";
 	icon_state = "wall_thermite";
 	name = "melted wall"
 	},
@@ -1730,7 +1726,6 @@
 	dir = 8
 	},
 /turf/open/floor/plating{
-	icon_plating = "wall_thermite";
 	icon_state = "wall_thermite";
 	name = "melted wall"
 	},
@@ -1812,8 +1807,7 @@
 /area/ruin/space/has_grav/derelictoutpost/cargostorage)
 "dY" = (
 /obj/structure/closet/crate{
-	icon_state = "crateopen";
-	opened = 1
+	icon_state = "crateopen"
 	},
 /obj/item/stack/sheet/plasteel/twenty,
 /obj/effect/turf_decal/delivery,
@@ -1917,8 +1911,7 @@
 /area/ruin/space/has_grav/derelictoutpost/cargostorage)
 "ek" = (
 /obj/structure/closet/crate{
-	icon_state = "crateopen";
-	opened = 1
+	icon_state = "crateopen"
 	},
 /obj/item/stack/sheet/cardboard/fifty,
 /obj/effect/turf_decal/delivery,
@@ -1964,8 +1957,7 @@
 /area/ruin/space/has_grav/derelictoutpost/cargostorage)
 "eq" = (
 /obj/structure/closet/crate{
-	icon_state = "crateopen";
-	opened = 1
+	icon_state = "crateopen"
 	},
 /obj/item/crowbar,
 /turf/open/floor/plasteel,
@@ -2049,8 +2041,7 @@
 /area/ruin/space/has_grav/derelictoutpost/cargostorage)
 "eB" = (
 /obj/structure/closet/crate{
-	icon_state = "crateopen";
-	opened = 1
+	icon_state = "crateopen"
 	},
 /obj/item/device/paicard,
 /obj/machinery/light,

--- a/_maps/RandomRuins/SpaceRuins/caravanambush.dmm
+++ b/_maps/RandomRuins/SpaceRuins/caravanambush.dmm
@@ -2878,8 +2878,7 @@
 /area/shuttle/caravan/freighter1)
 "jl" = (
 /obj/structure/closet/crate{
-	icon_state = "crateopen";
-	opened = 1
+	icon_state = "crateopen"
 	},
 /obj/item/stack/sheet/metal/fifty,
 /turf/open/floor/plasteel/airless/dark,

--- a/_maps/RandomRuins/SpaceRuins/crashedclownship.dmm
+++ b/_maps/RandomRuins/SpaceRuins/crashedclownship.dmm
@@ -36,8 +36,7 @@
 /area/ruin/unpowered)
 "j" = (
 /obj/structure/closet/crate{
-	icon_state = "crateopen";
-	opened = 1
+	icon_state = "crateopen"
 	},
 /obj/item/stack/ore/bananium,
 /turf/open/floor/mineral/bananium/airless,

--- a/_maps/RandomRuins/SpaceRuins/derelict6.dmm
+++ b/_maps/RandomRuins/SpaceRuins/derelict6.dmm
@@ -17,7 +17,6 @@
 "ad" = (
 /obj/structure/girder,
 /turf/open/floor/plating/airless{
-	icon_plating = "platingdmg2";
 	icon_state = "platingdmg2"
 	},
 /area/ruin/unpowered)
@@ -38,7 +37,6 @@
 /area/ruin/unpowered)
 "ah" = (
 /turf/open/floor/plating/airless{
-	icon_plating = "platingdmg1";
 	icon_state = "platingdmg1"
 	},
 /area/ruin/unpowered)
@@ -55,7 +53,6 @@
 "ak" = (
 /obj/item/stack/rods,
 /turf/open/floor/plating/airless{
-	icon_plating = "platingdmg2";
 	icon_state = "platingdmg2"
 	},
 /area/ruin/unpowered)
@@ -82,20 +79,17 @@
 "ao" = (
 /obj/structure/closet/emcloset,
 /turf/open/floor/plating/airless{
-	icon_plating = "platingdmg3";
 	icon_state = "platingdmg3"
 	},
 /area/ruin/unpowered)
 "ap" = (
 /turf/open/floor/plating/airless{
-	icon_plating = "platingdmg3";
 	icon_state = "platingdmg3"
 	},
 /area/ruin/unpowered)
 "aq" = (
 /obj/structure/girder,
 /turf/open/floor/plating/airless{
-	icon_plating = "platingdmg3";
 	icon_state = "platingdmg3"
 	},
 /area/ruin/unpowered)
@@ -106,7 +100,6 @@
 "as" = (
 /obj/item/stack/sheet/metal,
 /turf/open/floor/plating/airless{
-	icon_plating = "platingdmg2";
 	icon_state = "platingdmg2"
 	},
 /area/ruin/unpowered)
@@ -117,7 +110,6 @@
 "au" = (
 /obj/item/stack/sheet/metal,
 /turf/open/floor/plating/airless{
-	icon_plating = "platingdmg3";
 	icon_state = "platingdmg3"
 	},
 /area/ruin/unpowered)
@@ -136,7 +128,6 @@
 "ay" = (
 /obj/item/stack/tile/plasteel,
 /turf/open/floor/plating/airless{
-	icon_plating = "platingdmg2";
 	icon_state = "platingdmg2"
 	},
 /area/ruin/unpowered)
@@ -159,7 +150,6 @@
 "aB" = (
 /obj/item/stack/tile/plasteel,
 /turf/open/floor/plating/airless{
-	icon_plating = "platingdmg1";
 	icon_state = "platingdmg1"
 	},
 /area/ruin/unpowered)
@@ -176,7 +166,6 @@
 	},
 /obj/item/stack/sheet/metal,
 /turf/open/floor/plating/airless{
-	icon_plating = "platingdmg2";
 	icon_state = "platingdmg2"
 	},
 /area/ruin/unpowered)
@@ -240,7 +229,6 @@
 	status = 2
 	},
 /turf/open/floor/plating/airless{
-	icon_plating = "platingdmg3";
 	icon_state = "platingdmg3"
 	},
 /area/ruin/unpowered)
@@ -263,7 +251,6 @@
 /obj/structure/table/wood,
 /obj/item/shard,
 /turf/open/floor/plating/airless{
-	icon_plating = "platingdmg3";
 	icon_state = "platingdmg3"
 	},
 /area/ruin/unpowered)
@@ -271,7 +258,6 @@
 /obj/structure/table/wood,
 /obj/item/trash/plate,
 /turf/open/floor/plating/airless{
-	icon_plating = "platingdmg3";
 	icon_state = "platingdmg3"
 	},
 /area/ruin/unpowered)
@@ -312,14 +298,12 @@
 /area/ruin/unpowered)
 "be" = (
 /turf/open/floor/plating/airless{
-	icon_plating = "platingdmg2";
 	icon_state = "platingdmg2"
 	},
 /area/ruin/unpowered)
 "bg" = (
 /obj/item/stack/sheet/metal,
 /turf/open/floor/plating/airless{
-	icon_plating = "platingdmg1";
 	icon_state = "platingdmg1"
 	},
 /area/ruin/unpowered)
@@ -336,7 +320,6 @@
 /obj/item/stack/sheet/metal,
 /obj/item/clothing/head/chefhat,
 /turf/open/floor/plating/airless{
-	icon_plating = "platingdmg3";
 	icon_state = "platingdmg3"
 	},
 /area/ruin/unpowered)
@@ -348,21 +331,18 @@
 "bk" = (
 /obj/structure/table_frame/wood,
 /turf/open/floor/plating/airless{
-	icon_plating = "platingdmg3";
 	icon_state = "platingdmg3"
 	},
 /area/ruin/unpowered)
 "bl" = (
 /obj/structure/girder,
 /turf/open/floor/plating/airless{
-	icon_plating = "platingdmg1";
 	icon_state = "platingdmg1"
 	},
 /area/ruin/unpowered)
 "bm" = (
 /obj/item/chair,
 /turf/open/floor/plating/airless{
-	icon_plating = "platingdmg3";
 	icon_state = "platingdmg3"
 	},
 /area/ruin/unpowered)
@@ -374,14 +354,12 @@
 /obj/item/stack/sheet/metal,
 /obj/structure/girder,
 /turf/open/floor/plating/airless{
-	icon_plating = "platingdmg1";
 	icon_state = "platingdmg1"
 	},
 /area/ruin/unpowered)
 "bq" = (
 /obj/item/stack/tile/plasteel,
 /turf/open/floor/plating/airless{
-	icon_plating = "platingdmg3";
 	icon_state = "platingdmg3"
 	},
 /area/ruin/unpowered)
@@ -389,7 +367,6 @@
 /obj/structure/girder,
 /obj/item/stack/sheet/metal,
 /turf/open/floor/plating/airless{
-	icon_plating = "platingdmg1";
 	icon_state = "platingdmg1"
 	},
 /area/ruin/unpowered)

--- a/_maps/RandomZLevels/caves.dmm
+++ b/_maps/RandomZLevels/caves.dmm
@@ -1724,8 +1724,7 @@
 /area/awaymission/caves/listeningpost)
 "fn" = (
 /obj/structure/closet/crate{
-	icon_state = "crateopen";
-	opened = 1
+	icon_state = "crateopen"
 	},
 /obj/item/paper/fluff/awaymissions/caves/shipment_receipt,
 /obj/item/organ/eyes/robotic/thermals,

--- a/_maps/RandomZLevels/moonoutpost19.dmm
+++ b/_maps/RandomZLevels/moonoutpost19.dmm
@@ -4927,9 +4927,7 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/machinery/door/firedoor{
-	density = 1;
-	icon_state = "door_closed";
+/obj/machinery/door/firedoor/closed{
 	opacity = 0
 	},
 /turf/open/floor/plasteel{
@@ -5026,9 +5024,7 @@
 	icon_state = "4-8"
 	},
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/door/firedoor{
-	density = 1;
-	icon_state = "door_closed";
+/obj/machinery/door/firedoor/closed{
 	opacity = 0
 	},
 /turf/open/floor/plasteel/floorgrime{
@@ -5186,9 +5182,7 @@
 /area/awaymission/moonoutpost19/arrivals)
 "kA" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/door/firedoor{
-	density = 1;
-	icon_state = "door_closed";
+/obj/machinery/door/firedoor/closed{
 	opacity = 0
 	},
 /turf/open/floor/plasteel{
@@ -5250,9 +5244,7 @@
 	},
 /area/awaymission/moonoutpost19/arrivals)
 "kH" = (
-/obj/machinery/door/firedoor{
-	density = 1;
-	icon_state = "door_closed";
+/obj/machinery/door/firedoor/closed{
 	opacity = 0
 	},
 /turf/open/floor/plasteel{
@@ -5339,9 +5331,7 @@
 	},
 /area/awaymission/moonoutpost19/arrivals)
 "kR" = (
-/obj/machinery/door/firedoor{
-	density = 1;
-	icon_state = "door_closed";
+/obj/machinery/door/firedoor/closed{
 	opacity = 0
 	},
 /turf/open/floor/plasteel/neutral/corner{
@@ -5350,9 +5340,7 @@
 	},
 /area/awaymission/moonoutpost19/arrivals)
 "kS" = (
-/obj/machinery/door/firedoor{
-	density = 1;
-	icon_state = "door_closed";
+/obj/machinery/door/firedoor/closed{
 	opacity = 0
 	},
 /turf/open/floor/plasteel/neutral/corner{

--- a/_maps/RandomZLevels/research.dmm
+++ b/_maps/RandomZLevels/research.dmm
@@ -2625,8 +2625,7 @@
 /area/awaymission/research/interior/maint)
 "hY" = (
 /obj/structure/closet/crate{
-	icon_state = "crateopen";
-	opened = 1
+	icon_state = "crateopen"
 	},
 /obj/effect/spawner/lootdrop/maintenance,
 /turf/open/floor/plating,

--- a/_maps/RandomZLevels/snowdin.dmm
+++ b/_maps/RandomZLevels/snowdin.dmm
@@ -58,11 +58,7 @@
 /area/awaymission/snowdin/outside)
 "ap" = (
 /obj/effect/turf_decal/weather/snow,
-/turf/open/floor/plasteel/dark{
-	initial_gas_mix = "o2=22;n2=82;TEMP=180";
-	planetary_atmos = 1;
-	temperature = 180
-	},
+/turf/open/floor/plasteel/dark/snowdin,
 /area/awaymission/snowdin/cave)
 "aq" = (
 /obj/effect/baseturf_helper/asteroid/snow,
@@ -76,11 +72,7 @@
 /obj/machinery/light/small{
 	dir = 8
 	},
-/turf/open/floor/plasteel/dark{
-	initial_gas_mix = "o2=22;n2=82;TEMP=180";
-	planetary_atmos = 1;
-	temperature = 180
-	},
+/turf/open/floor/plasteel/dark/snowdin,
 /area/awaymission/snowdin/cave)
 "at" = (
 /obj/item/pickaxe,
@@ -91,11 +83,7 @@
 /obj/machinery/light/small{
 	dir = 4
 	},
-/turf/open/floor/plasteel/dark{
-	initial_gas_mix = "o2=22;n2=82;TEMP=180";
-	planetary_atmos = 1;
-	temperature = 180
-	},
+/turf/open/floor/plasteel/dark/snowdin,
 /area/awaymission/snowdin/cave)
 "av" = (
 /obj/effect/baseturf_helper/asteroid/snow,
@@ -147,7 +135,6 @@
 /area/awaymission/snowdin/post/research)
 "aF" = (
 /obj/structure/chair/office/dark{
-	icon_state = "officechair_dark";
 	dir = 8
 	},
 /turf/open/floor/plasteel/dark,
@@ -207,7 +194,6 @@
 	pixel_y = 5
 	},
 /turf/open/floor/wood{
-	broken = 1;
 	icon_state = "wood-broken"
 	},
 /area/awaymission/snowdin/post/dorm)
@@ -297,7 +283,6 @@
 	pixel_y = 32
 	},
 /turf/open/floor/wood{
-	broken = 1;
 	icon_state = "wood-broken"
 	},
 /area/awaymission/snowdin/post/dorm)
@@ -349,7 +334,6 @@
 	dir = 6
 	},
 /turf/open/floor/wood{
-	broken = 1;
 	icon_state = "wood-broken"
 	},
 /area/awaymission/snowdin/post/dorm)
@@ -359,7 +343,6 @@
 	dir = 8
 	},
 /obj/machinery/light/small/broken{
-	icon_state = "bulb-broken";
 	dir = 4
 	},
 /turf/open/floor/wood,
@@ -405,7 +388,6 @@
 	dir = 4
 	},
 /turf/open/floor/wood{
-	broken = 1;
 	icon_state = "wood-broken"
 	},
 /area/awaymission/snowdin/post/dorm)
@@ -489,7 +471,6 @@
 	id = "snowdindormresearch3";
 	name = "Dorm Bolt Control";
 	normaldoorcontrol = 1;
-	pixel_x = 0;
 	pixel_y = -25;
 	req_access_txt = "0";
 	specialfunctions = 4
@@ -505,7 +486,6 @@
 	id = "snowdindormresearch2";
 	name = "Dorm Bolt Control";
 	normaldoorcontrol = 1;
-	pixel_x = 0;
 	pixel_y = -25;
 	req_access_txt = "0";
 	specialfunctions = 4
@@ -520,7 +500,6 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/wood{
-	broken = 1;
 	icon_state = "wood-broken"
 	},
 /area/awaymission/snowdin/post/dorm)
@@ -531,7 +510,6 @@
 	id = "snowdindormresearch1";
 	name = "Dorm Bolt Control";
 	normaldoorcontrol = 1;
-	pixel_x = 0;
 	pixel_y = -25;
 	req_access_txt = "0";
 	specialfunctions = 4
@@ -544,7 +522,6 @@
 	id = "snowdindormhydro2";
 	name = "Dorm Bolt Control";
 	normaldoorcontrol = 1;
-	pixel_x = 0;
 	pixel_y = -25;
 	req_access_txt = "0";
 	specialfunctions = 4
@@ -559,7 +536,6 @@
 	id = "snowdindormhydro1";
 	name = "Dorm Bolt Control";
 	normaldoorcontrol = 1;
-	pixel_x = 0;
 	pixel_y = -25;
 	req_access_txt = "0";
 	specialfunctions = 4
@@ -712,7 +688,6 @@
 	name = "Rachel Migro's Private Quarters"
 	},
 /turf/open/floor/wood{
-	broken = 1;
 	icon_state = "wood-broken"
 	},
 /area/awaymission/snowdin/post/dorm)
@@ -763,7 +738,6 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/structure/spider/stickyweb,
 /obj/machinery/light/broken{
-	icon_state = "tube-broken";
 	dir = 8
 	},
 /turf/open/floor/plasteel/freezer,
@@ -791,8 +765,7 @@
 	dir = 1
 	},
 /obj/structure/closet/crate{
-	icon_state = "crateopen";
-	opened = 1
+	icon_state = "crateopen"
 	},
 /turf/open/floor/plasteel,
 /area/awaymission/snowdin/post/kitchen)
@@ -876,7 +849,6 @@
 	icon_state = "2-8"
 	},
 /turf/open/floor/plasteel/neutral/side{
-	icon_state = "neutral";
 	dir = 9
 	},
 /area/awaymission/snowdin/post/dorm)
@@ -1165,17 +1137,12 @@
 /obj/effect/turf_decal/weather/snow,
 /obj/structure/closet/crate{
 	icon_state = "crateopen";
-	name = "explosives ordinance";
-	opened = 1
+	name = "explosives ordinance"
 	},
 /obj/machinery/light/small{
 	dir = 4
 	},
-/turf/open/floor/plasteel/dark{
-	initial_gas_mix = "o2=22;n2=82;TEMP=180";
-	planetary_atmos = 1;
-	temperature = 180
-	},
+/turf/open/floor/plasteel/dark/snowdin,
 /area/awaymission/snowdin/cave)
 "cV" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -1446,24 +1413,15 @@
 /obj/structure/closet/crate{
 	name = "explosives ordinance"
 	},
-/turf/open/floor/plasteel/dark{
-	initial_gas_mix = "o2=22;n2=82;TEMP=180";
-	planetary_atmos = 1;
-	temperature = 180
-	},
+/turf/open/floor/plasteel/dark/snowdin,
 /area/awaymission/snowdin/cave)
 "dy" = (
 /obj/effect/turf_decal/weather/snow,
 /obj/structure/closet/crate{
 	icon_state = "crateopen";
-	name = "explosives ordinance";
-	opened = 1
+	name = "explosives ordinance"
 	},
-/turf/open/floor/plasteel/dark{
-	initial_gas_mix = "o2=22;n2=82;TEMP=180";
-	planetary_atmos = 1;
-	temperature = 180
-	},
+/turf/open/floor/plasteel/dark/snowdin,
 /area/awaymission/snowdin/cave)
 "dz" = (
 /obj/machinery/light/small{
@@ -1561,7 +1519,6 @@
 /area/awaymission/snowdin/post/kitchen)
 "dS" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	icon_state = "manifold";
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -1615,7 +1572,6 @@
 /area/awaymission/snowdin/post/dorm)
 "dZ" = (
 /obj/machinery/light/small/broken{
-	icon_state = "bulb-broken";
 	dir = 8
 	},
 /turf/open/floor/carpet,
@@ -1693,7 +1649,6 @@
 /obj/effect/landmark/awaystart,
 /obj/item/bedsheet/red,
 /turf/open/floor/wood{
-	broken = 1;
 	icon_state = "wood-broken"
 	},
 /area/awaymission/snowdin/post/dorm)
@@ -1874,17 +1829,12 @@
 "eF" = (
 /obj/structure/mineral_door/wood,
 /turf/open/floor/wood{
-	broken = 1;
 	icon_state = "wood-broken"
 	},
 /area/awaymission/snowdin/outside)
 "eG" = (
 /obj/structure/barricade/wooden,
-/turf/open/floor/plasteel/dark{
-	initial_gas_mix = "o2=22;n2=82;TEMP=180";
-	planetary_atmos = 1;
-	temperature = 180
-	},
+/turf/open/floor/plasteel/dark/snowdin,
 /area/awaymission/snowdin/cave)
 "eH" = (
 /obj/structure/barricade/wooden,
@@ -1992,7 +1942,6 @@
 	pixel_y = 5
 	},
 /turf/open/floor/wood{
-	broken = 1;
 	icon_state = "wood-broken"
 	},
 /area/awaymission/snowdin/post/dorm)
@@ -2199,7 +2148,6 @@
 	pixel_x = 26
 	},
 /obj/machinery/light/broken{
-	icon_state = "tube-broken";
 	dir = 4
 	},
 /turf/open/floor/plating,
@@ -2349,14 +2297,12 @@
 "fR" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/green/side{
-	icon_state = "green";
 	dir = 1
 	},
 /area/awaymission/snowdin/post/hydro)
 "fS" = (
 /obj/item/kitchen/knife,
 /turf/open/floor/plasteel/green/side{
-	icon_state = "green";
 	dir = 1
 	},
 /area/awaymission/snowdin/post/hydro)
@@ -2366,13 +2312,11 @@
 	pixel_y = 24
 	},
 /turf/open/floor/plasteel/green/side{
-	icon_state = "green";
 	dir = 1
 	},
 /area/awaymission/snowdin/post/hydro)
 "fU" = (
 /obj/machinery/light/broken{
-	icon_state = "tube-broken";
 	dir = 1
 	},
 /turf/open/floor/plating,
@@ -2385,7 +2329,6 @@
 	},
 /obj/effect/decal/cleanable/cobweb/cobweb2,
 /turf/open/floor/plasteel/green/side{
-	icon_state = "green";
 	dir = 5
 	},
 /area/awaymission/snowdin/post/hydro)
@@ -2407,7 +2350,6 @@
 	pixel_y = 4
 	},
 /turf/open/floor/wood{
-	broken = 1;
 	icon_state = "wood-broken"
 	},
 /area/awaymission/snowdin/outside)
@@ -2494,8 +2436,7 @@
 "gk" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on,
 /obj/structure/closet/crate{
-	icon_state = "crateopen";
-	opened = 1
+	icon_state = "crateopen"
 	},
 /obj/item/crowbar,
 /obj/item/crowbar,
@@ -2619,7 +2560,6 @@
 /area/awaymission/snowdin/post/gateway)
 "gz" = (
 /obj/machinery/light/broken{
-	icon_state = "tube-broken";
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -2887,8 +2827,7 @@
 	pixel_y = 5
 	},
 /obj/structure/closet/crate{
-	icon_state = "crateopen";
-	opened = 1
+	icon_state = "crateopen"
 	},
 /obj/item/clothing/shoes/winterboots,
 /obj/item/clothing/shoes/winterboots,
@@ -3002,7 +2941,6 @@
 /obj/structure/table,
 /obj/machinery/reagentgrinder,
 /turf/open/floor/plasteel/green/side{
-	icon_state = "green";
 	dir = 8
 	},
 /area/awaymission/snowdin/post/hydro)
@@ -3129,7 +3067,6 @@
 	pixel_y = 5
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	icon_state = "manifold";
 	dir = 4
 	},
 /obj/structure/cable/yellow{
@@ -3228,7 +3165,6 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/biogenerator,
 /turf/open/floor/plasteel/green/side{
-	icon_state = "green";
 	dir = 8
 	},
 /area/awaymission/snowdin/post/hydro)
@@ -3290,14 +3226,9 @@
 "ih" = (
 /obj/effect/turf_decal/weather/snow,
 /obj/effect/turf_decal/weather/snow/corner{
-	icon_state = "snow_corner";
 	dir = 6
 	},
-/turf/open/floor/plasteel/dark{
-	initial_gas_mix = "o2=22;n2=82;TEMP=180";
-	planetary_atmos = 1;
-	temperature = 180
-	},
+/turf/open/floor/plasteel/dark/snowdin,
 /area/awaymission/snowdin/cave)
 "ii" = (
 /turf/open/floor/plating/snowed/smoothed,
@@ -3309,14 +3240,9 @@
 "ik" = (
 /obj/effect/turf_decal/weather/snow,
 /obj/effect/turf_decal/weather/snow/corner{
-	icon_state = "snow_corner";
 	dir = 10
 	},
-/turf/open/floor/plasteel/dark{
-	initial_gas_mix = "o2=22;n2=82;TEMP=180";
-	planetary_atmos = 1;
-	temperature = 180
-	},
+/turf/open/floor/plasteel/dark/snowdin,
 /area/awaymission/snowdin/cave)
 "il" = (
 /obj/structure/closet/crate/wooden,
@@ -3583,7 +3509,6 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/seed_extractor,
 /turf/open/floor/plasteel/green/side{
-	icon_state = "green";
 	dir = 8
 	},
 /area/awaymission/snowdin/post/hydro)
@@ -3602,7 +3527,6 @@
 	pixel_y = 5
 	},
 /turf/open/floor/plasteel/green/side{
-	icon_state = "green";
 	dir = 4
 	},
 /area/awaymission/snowdin/post/hydro)
@@ -3987,7 +3911,6 @@
 	pixel_x = 11
 	},
 /turf/open/floor/plasteel/green/side{
-	icon_state = "green";
 	dir = 4
 	},
 /area/awaymission/snowdin/post/hydro)
@@ -4202,7 +4125,6 @@
 	pixel_x = -23
 	},
 /turf/open/floor/plasteel/green/side{
-	icon_state = "green";
 	dir = 8
 	},
 /area/awaymission/snowdin/post/hydro)
@@ -4269,8 +4191,7 @@
 	pixel_x = 32
 	},
 /obj/structure/closet/crate{
-	icon_state = "crateopen";
-	opened = 1
+	icon_state = "crateopen"
 	},
 /obj/item/tank/internals/plasma,
 /obj/item/tank/internals/plasma,
@@ -4278,21 +4199,18 @@
 /area/awaymission/snowdin/post/garage)
 "kn" = (
 /obj/structure/fence/corner{
-	icon_state = "corner";
 	dir = 9
 	},
 /turf/open/floor/plating/asteroid/snow,
 /area/awaymission/snowdin/outside)
 "ko" = (
 /obj/structure/fence{
-	icon_state = "straight";
 	dir = 4
 	},
 /turf/open/floor/plating/asteroid/snow,
 /area/awaymission/snowdin/outside)
 "kp" = (
 /obj/structure/fence{
-	icon_state = "straight";
 	dir = 4
 	},
 /obj/structure/sign/nanotrasen,
@@ -4304,7 +4222,6 @@
 /area/awaymission/snowdin/outside)
 "kr" = (
 /obj/structure/fence{
-	icon_state = "straight";
 	dir = 4
 	},
 /turf/open/floor/plating/snowed/smoothed,
@@ -4517,7 +4434,6 @@
 /area/awaymission/snowdin/post/messhall)
 "kQ" = (
 /turf/open/floor/plasteel/green/side{
-	icon_state = "green";
 	dir = 8
 	},
 /area/awaymission/snowdin/post/hydro)
@@ -4643,7 +4559,6 @@
 /area/awaymission/snowdin/post/dorm)
 "lg" = (
 /obj/machinery/light/small/broken{
-	icon_state = "bulb-broken";
 	dir = 4
 	},
 /turf/open/floor/plasteel/showroomfloor,
@@ -5148,7 +5063,6 @@
 /area/awaymission/snowdin/post/garage)
 "lS" = (
 /obj/structure/fence/corner{
-	icon_state = "corner";
 	dir = 10
 	},
 /turf/open/floor/plating/asteroid/snow,
@@ -5289,7 +5203,6 @@
 	pixel_y = 5
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	icon_state = "manifold";
 	dir = 4
 	},
 /obj/structure/cable/yellow{
@@ -5456,7 +5369,6 @@
 /area/awaymission/snowdin/post/garage)
 "mD" = (
 /obj/structure/toilet{
-	icon_state = "toilet00";
 	dir = 1
 	},
 /obj/machinery/light/small,
@@ -6056,7 +5968,6 @@
 	icon_state = "0-4"
 	},
 /turf/open/floor/plasteel/red/side{
-	icon_state = "red";
 	dir = 1
 	},
 /area/awaymission/snowdin/post/secpost)
@@ -6071,14 +5982,12 @@
 	icon_state = "1-8"
 	},
 /turf/open/floor/plasteel/red/side{
-	icon_state = "red";
 	dir = 1
 	},
 /area/awaymission/snowdin/post/secpost)
 "og" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/red/side{
-	icon_state = "red";
 	dir = 1
 	},
 /area/awaymission/snowdin/post/secpost)
@@ -6099,7 +6008,6 @@
 	pixel_y = 23
 	},
 /turf/open/floor/plasteel/red/side{
-	icon_state = "red";
 	dir = 5
 	},
 /area/awaymission/snowdin/post/secpost)
@@ -6152,7 +6060,6 @@
 /area/awaymission/snowdin/post/engineering)
 "oo" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
-	icon_state = "intact";
 	dir = 4;
 	pixel_x = 5;
 	pixel_y = 5;
@@ -6162,7 +6069,6 @@
 /area/awaymission/snowdin/post/engineering)
 "op" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
-	icon_state = "intact";
 	dir = 4;
 	pixel_x = 5;
 	pixel_y = 5;
@@ -6247,7 +6153,6 @@
 	},
 /obj/machinery/holopad,
 /turf/open/floor/plasteel/red/side{
-	icon_state = "red";
 	dir = 8
 	},
 /area/awaymission/snowdin/post/secpost)
@@ -6299,7 +6204,6 @@
 	pixel_y = 5
 	},
 /turf/open/floor/plasteel/red/side{
-	icon_state = "red";
 	dir = 4
 	},
 /area/awaymission/snowdin/post/secpost)
@@ -6310,7 +6214,6 @@
 "oI" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on,
 /turf/open/floor/plasteel/neutral/side{
-	icon_state = "neutral";
 	dir = 9
 	},
 /area/awaymission/snowdin/post)
@@ -6498,7 +6401,6 @@
 	},
 /obj/item/wirecutters,
 /turf/open/floor/plasteel/red/side{
-	icon_state = "red";
 	dir = 10
 	},
 /area/awaymission/snowdin/post/secpost)
@@ -6529,7 +6431,6 @@
 "po" = (
 /obj/structure/table,
 /turf/open/floor/plasteel/red/side{
-	icon_state = "red";
 	dir = 4
 	},
 /area/awaymission/snowdin/post/secpost)
@@ -6544,7 +6445,6 @@
 /area/awaymission/snowdin/post)
 "pq" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	icon_state = "manifold";
 	dir = 4
 	},
 /obj/effect/decal/cleanable/dirt,
@@ -6595,7 +6495,6 @@
 	pixel_y = 5
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/visible{
-	icon_state = "manifold";
 	dir = 8
 	},
 /turf/open/floor/plating{
@@ -6604,14 +6503,12 @@
 /area/awaymission/snowdin/post/engineering)
 "pw" = (
 /obj/machinery/atmospherics/pipe/simple/supply/visible{
-	icon_state = "intact";
 	dir = 8
 	},
 /turf/open/floor/plasteel/floorgrime,
 /area/awaymission/snowdin/post/engineering)
 "px" = (
 /obj/machinery/atmospherics/pipe/simple/supply/visible{
-	icon_state = "intact";
 	dir = 8
 	},
 /turf/open/floor/plating,
@@ -6678,7 +6575,6 @@
 /area/awaymission/snowdin/post/secpost)
 "pK" = (
 /turf/open/floor/plasteel/red/side{
-	icon_state = "red";
 	dir = 10
 	},
 /area/awaymission/snowdin/post/secpost)
@@ -6762,7 +6658,6 @@
 /area/awaymission/snowdin/post/engineering)
 "pU" = (
 /obj/machinery/atmospherics/pipe/simple/supply/visible{
-	icon_state = "intact";
 	dir = 8
 	},
 /obj/machinery/holopad,
@@ -6770,7 +6665,6 @@
 /area/awaymission/snowdin/post/engineering)
 "pV" = (
 /obj/machinery/atmospherics/pipe/simple/supply/visible{
-	icon_state = "intact";
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -6791,7 +6685,6 @@
 /area/awaymission/snowdin/post/engineering)
 "pY" = (
 /obj/machinery/atmospherics/pipe/simple/supply/visible{
-	icon_state = "intact";
 	dir = 8
 	},
 /turf/open/floor/plating{
@@ -6802,7 +6695,6 @@
 /obj/machinery/portable_atmospherics/scrubber,
 /obj/effect/turf_decal/bot,
 /obj/machinery/atmospherics/pipe/simple/supply/visible{
-	icon_state = "intact";
 	dir = 8
 	},
 /turf/open/floor/plating,
@@ -6814,7 +6706,6 @@
 /obj/machinery/portable_atmospherics/pump,
 /obj/effect/turf_decal/bot,
 /obj/machinery/atmospherics/pipe/simple/supply/visible{
-	icon_state = "intact";
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -6823,7 +6714,6 @@
 /obj/machinery/portable_atmospherics/canister,
 /obj/effect/turf_decal/bot,
 /obj/machinery/atmospherics/pipe/simple/supply/visible{
-	icon_state = "intact";
 	dir = 8
 	},
 /turf/open/floor/plasteel/floorgrime,
@@ -6832,7 +6722,6 @@
 /obj/structure/reagent_dispensers/watertank/high,
 /obj/effect/turf_decal/bot,
 /obj/machinery/atmospherics/pipe/simple/supply/visible{
-	icon_state = "intact";
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -6843,14 +6732,12 @@
 /obj/item/weldingtool/largetank,
 /obj/effect/turf_decal/bot,
 /obj/machinery/atmospherics/pipe/simple/supply/visible{
-	icon_state = "intact";
 	dir = 8
 	},
 /turf/open/floor/plasteel,
 /area/awaymission/snowdin/post/engineering)
 "qe" = (
 /obj/machinery/atmospherics/pipe/simple/supply/visible{
-	icon_state = "intact";
 	dir = 8
 	},
 /turf/closed/wall,
@@ -6861,7 +6748,6 @@
 	},
 /obj/structure/grille,
 /obj/machinery/atmospherics/pipe/simple/supply/visible{
-	icon_state = "intact";
 	dir = 9
 	},
 /turf/open/floor/plating,
@@ -6990,21 +6876,18 @@
 /area/awaymission/snowdin/post/engineering)
 "qy" = (
 /obj/machinery/atmospherics/pipe/simple/supplymain/visible{
-	icon_state = "intact";
 	dir = 8
 	},
 /turf/open/floor/plasteel/floorgrime,
 /area/awaymission/snowdin/post/engineering)
 "qz" = (
 /obj/machinery/atmospherics/pipe/simple/supplymain/visible{
-	icon_state = "intact";
 	dir = 8
 	},
 /turf/open/floor/plasteel,
 /area/awaymission/snowdin/post/engineering)
 "qA" = (
 /obj/machinery/atmospherics/pipe/simple/supplymain/visible{
-	icon_state = "intact";
 	dir = 10
 	},
 /turf/open/floor/plating{
@@ -7037,7 +6920,6 @@
 	pixel_x = 32
 	},
 /obj/machinery/light/small/broken{
-	icon_state = "bulb-broken";
 	dir = 4
 	},
 /turf/open/floor/plating/snowed/cavern,
@@ -7204,7 +7086,6 @@
 /area/awaymission/snowdin/post/engineering)
 "qW" = (
 /obj/machinery/atmospherics/pipe/manifold/orange/visible{
-	icon_state = "manifold";
 	dir = 4
 	},
 /obj/structure/cable{
@@ -7438,7 +7319,6 @@
 	pixel_y = 32
 	},
 /obj/machinery/light/broken{
-	icon_state = "tube-broken";
 	dir = 1
 	},
 /turf/open/floor/engine/cult,
@@ -7709,7 +7589,6 @@
 "sm" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/fence/door{
-	icon_state = "door_closed";
 	dir = 4
 	},
 /turf/open/lava/plasma,
@@ -7726,7 +7605,6 @@
 /area/awaymission/snowdin/cave/cavern)
 "sp" = (
 /obj/structure/fence/door{
-	icon_state = "door_closed";
 	dir = 4
 	},
 /obj/effect/turf_decal/stripes/line{
@@ -7773,7 +7651,6 @@
 /area/awaymission/snowdin/post/cavern2)
 "sv" = (
 /obj/machinery/computer/monitor{
-	icon_state = "computer";
 	dir = 8
 	},
 /obj/structure/cable/yellow,
@@ -7785,40 +7662,28 @@
 "sw" = (
 /obj/effect/turf_decal/weather/snow,
 /obj/effect/turf_decal/weather/snow/corner{
-	icon_state = "snow_corner";
 	dir = 9
 	},
-/turf/open/floor/plasteel/vault{
-	dir = 5;
-	initial_gas_mix = "o2=22;n2=82;TEMP=180";
-	planetary_atmos = 1;
-	temperature = 180
+/turf/open/floor/plasteel/vault/snowdin{
+	dir = 5
 	},
 /area/awaymission/snowdin/outside)
 "sx" = (
 /obj/effect/turf_decal/weather/snow,
 /obj/effect/turf_decal/weather/snow/corner{
-	icon_state = "snow_corner";
 	dir = 1
 	},
-/turf/open/floor/plasteel/vault{
-	dir = 5;
-	initial_gas_mix = "o2=22;n2=82;TEMP=180";
-	planetary_atmos = 1;
-	temperature = 180
+/turf/open/floor/plasteel/vault/snowdin{
+	dir = 5
 	},
 /area/awaymission/snowdin/outside)
 "sy" = (
 /obj/effect/turf_decal/weather/snow,
 /obj/effect/turf_decal/weather/snow/corner{
-	icon_state = "snow_corner";
 	dir = 5
 	},
-/turf/open/floor/plasteel/vault{
-	dir = 5;
-	initial_gas_mix = "o2=22;n2=82;TEMP=180";
-	planetary_atmos = 1;
-	temperature = 180
+/turf/open/floor/plasteel/vault/snowdin{
+	dir = 5
 	},
 /area/awaymission/snowdin/outside)
 "sz" = (
@@ -7877,57 +7742,36 @@
 "sH" = (
 /obj/effect/turf_decal/weather/snow,
 /obj/effect/turf_decal/weather/snow/corner{
-	icon_state = "snow_corner";
 	dir = 8
 	},
-/turf/open/floor/plasteel/vault{
-	dir = 5;
-	initial_gas_mix = "o2=22;n2=82;TEMP=180";
-	planetary_atmos = 1;
-	temperature = 180
+/turf/open/floor/plasteel/vault/snowdin{
+	dir = 5
 	},
 /area/awaymission/snowdin/outside)
 "sI" = (
 /obj/effect/turf_decal/weather/snow,
-/turf/open/floor/plasteel/dark{
-	initial_gas_mix = "o2=22;n2=82;TEMP=180";
-	planetary_atmos = 1;
-	temperature = 180
-	},
+/turf/open/floor/plasteel/dark/snowdin,
 /area/awaymission/snowdin/outside)
 "sJ" = (
 /obj/effect/turf_decal/weather/snow,
 /obj/effect/turf_decal/stripes/white/line,
-/turf/open/floor/plasteel/dark{
-	initial_gas_mix = "o2=22;n2=82;TEMP=180";
-	planetary_atmos = 1;
-	temperature = 180
-	},
+/turf/open/floor/plasteel/dark/snowdin,
 /area/awaymission/snowdin/outside)
 "sK" = (
 /obj/effect/turf_decal/weather/snow,
 /obj/effect/turf_decal/stripes/white/line,
 /obj/effect/turf_decal/caution/stand_clear{
-	icon_state = "stand_clear";
 	dir = 1
 	},
-/turf/open/floor/plasteel/dark{
-	initial_gas_mix = "o2=22;n2=82;TEMP=180";
-	planetary_atmos = 1;
-	temperature = 180
-	},
+/turf/open/floor/plasteel/dark/snowdin,
 /area/awaymission/snowdin/outside)
 "sL" = (
 /obj/effect/turf_decal/weather/snow,
 /obj/effect/turf_decal/weather/snow/corner{
-	icon_state = "snow_corner";
 	dir = 4
 	},
-/turf/open/floor/plasteel/vault{
-	dir = 5;
-	initial_gas_mix = "o2=22;n2=82;TEMP=180";
-	planetary_atmos = 1;
-	temperature = 180
+/turf/open/floor/plasteel/vault/snowdin{
+	dir = 5
 	},
 /area/awaymission/snowdin/outside)
 "sM" = (
@@ -7944,14 +7788,12 @@
 /area/awaymission/snowdin/post/engineering)
 "sN" = (
 /obj/structure/fence/corner{
-	icon_state = "corner";
 	dir = 6
 	},
 /turf/open/floor/plating/asteroid/snow,
 /area/awaymission/snowdin/outside)
 "sO" = (
 /obj/structure/fence{
-	icon_state = "straight";
 	dir = 4
 	},
 /obj/effect/turf_decal/stripes/line,
@@ -7980,14 +7822,9 @@
 "sS" = (
 /obj/effect/turf_decal/weather/snow,
 /obj/effect/turf_decal/stripes/white/line{
-	icon_state = "warningline_white";
 	dir = 4
 	},
-/turf/open/floor/plasteel/dark{
-	initial_gas_mix = "o2=22;n2=82;TEMP=180";
-	planetary_atmos = 1;
-	temperature = 180
-	},
+/turf/open/floor/plasteel/dark/snowdin,
 /area/awaymission/snowdin/outside)
 "sT" = (
 /turf/open/floor/plating/snowed/smoothed,
@@ -7996,21 +7833,15 @@
 "sU" = (
 /obj/effect/turf_decal/weather/snow,
 /obj/effect/turf_decal/stripes/white/line{
-	icon_state = "warningline_white";
 	dir = 8
 	},
 /obj/machinery/computer{
 	desc = "A console meant for calling and sending a transit ferry. It seems iced-over and non-functional.";
 	dir = 4;
 	icon_screen = null;
-	icon_state = "computer";
 	name = "Shuttle Transist Console"
 	},
-/turf/open/floor/plasteel/dark{
-	initial_gas_mix = "o2=22;n2=82;TEMP=180";
-	planetary_atmos = 1;
-	temperature = 180
-	},
+/turf/open/floor/plasteel/dark/snowdin,
 /area/awaymission/snowdin/outside)
 "sV" = (
 /obj/structure/statue/snow/snowman{
@@ -8058,18 +7889,12 @@
 "td" = (
 /obj/effect/turf_decal/weather/snow,
 /obj/effect/turf_decal/stripes/white/line{
-	icon_state = "warningline_white";
 	dir = 4
 	},
 /obj/effect/turf_decal/caution/stand_clear{
-	icon_state = "stand_clear";
 	dir = 8
 	},
-/turf/open/floor/plasteel/dark{
-	initial_gas_mix = "o2=22;n2=82;TEMP=180";
-	planetary_atmos = 1;
-	temperature = 180
-	},
+/turf/open/floor/plasteel/dark/snowdin,
 /area/awaymission/snowdin/outside)
 "te" = (
 /turf/open/floor/plating/snowed,
@@ -8077,18 +7902,12 @@
 "tf" = (
 /obj/effect/turf_decal/weather/snow,
 /obj/effect/turf_decal/stripes/white/line{
-	icon_state = "warningline_white";
 	dir = 8
 	},
 /obj/effect/turf_decal/caution/stand_clear{
-	icon_state = "stand_clear";
 	dir = 4
 	},
-/turf/open/floor/plasteel/dark{
-	initial_gas_mix = "o2=22;n2=82;TEMP=180";
-	planetary_atmos = 1;
-	temperature = 180
-	},
+/turf/open/floor/plasteel/dark/snowdin,
 /area/awaymission/snowdin/outside)
 "tg" = (
 /obj/machinery/door/poddoor{
@@ -8117,7 +7936,6 @@
 /area/awaymission/snowdin/post/cavern2)
 "tk" = (
 /obj/structure/toilet{
-	icon_state = "toilet00";
 	dir = 1
 	},
 /turf/open/floor/plasteel/showroomfloor,
@@ -8125,14 +7943,9 @@
 "tl" = (
 /obj/effect/turf_decal/weather/snow,
 /obj/effect/turf_decal/stripes/white/line{
-	icon_state = "warningline_white";
 	dir = 8
 	},
-/turf/open/floor/plasteel/dark{
-	initial_gas_mix = "o2=22;n2=82;TEMP=180";
-	planetary_atmos = 1;
-	temperature = 180
-	},
+/turf/open/floor/plasteel/dark/snowdin,
 /area/awaymission/snowdin/outside)
 "tm" = (
 /mob/living/simple_animal/hostile/asteroid/basilisk,
@@ -8141,27 +7954,19 @@
 "tn" = (
 /obj/effect/turf_decal/weather/snow,
 /obj/effect/turf_decal/weather/snow/corner{
-	icon_state = "snow_corner";
 	dir = 10
 	},
-/turf/open/floor/plasteel/vault{
-	dir = 5;
-	initial_gas_mix = "o2=22;n2=82;TEMP=180";
-	planetary_atmos = 1;
-	temperature = 180
+/turf/open/floor/plasteel/vault/snowdin{
+	dir = 5
 	},
 /area/awaymission/snowdin/outside)
 "to" = (
 /obj/effect/turf_decal/weather/snow,
 /obj/effect/turf_decal/weather/snow/corner{
-	icon_state = "snow_corner";
 	dir = 6
 	},
-/turf/open/floor/plasteel/vault{
-	dir = 5;
-	initial_gas_mix = "o2=22;n2=82;TEMP=180";
-	planetary_atmos = 1;
-	temperature = 180
+/turf/open/floor/plasteel/vault/snowdin{
+	dir = 5
 	},
 /area/awaymission/snowdin/outside)
 "tp" = (
@@ -8266,10 +8071,7 @@
 /area/awaymission/snowdin/cave/cavern)
 "tM" = (
 /turf/open/floor/plating/asteroid/snow/ice,
-/obj/structure/barricade/wooden{
-	desc = "This space is blocked off by a wooden barricade. Has some snow piled on it.";
-	icon_state = "woodenbarricade-snow"
-	},
+/obj/structure/barricade/wooden/snowed,
 /turf/open/floor/plating/snowed/cavern,
 /area/awaymission/snowdin/cave/cavern)
 "tN" = (
@@ -8280,10 +8082,7 @@
 /turf/open/floor/plating/asteroid/snow/ice,
 /area/awaymission/snowdin/cave/cavern)
 "tP" = (
-/obj/structure/barricade/wooden{
-	desc = "This space is blocked off by a wooden barricade. Has some snow piled on it.";
-	icon_state = "woodenbarricade-snow"
-	},
+/obj/structure/barricade/wooden/snowed,
 /turf/open/floor/plating/asteroid/snow/ice,
 /area/awaymission/snowdin/cave/cavern)
 "tQ" = (
@@ -8291,10 +8090,7 @@
 /turf/open/floor/plating/asteroid/snow,
 /area/awaymission/snowdin/cave)
 "tR" = (
-/obj/structure/barricade/wooden{
-	desc = "This space is blocked off by a wooden barricade. Has some snow piled on it.";
-	icon_state = "woodenbarricade-snow"
-	},
+/obj/structure/barricade/wooden/snowed,
 /turf/open/floor/plating/snowed/cavern,
 /area/awaymission/snowdin/cave/cavern)
 "tS" = (
@@ -8345,7 +8141,6 @@
 "ub" = (
 /obj/structure/bed,
 /turf/open/floor/wood{
-	broken = 1;
 	icon_state = "wood-broken"
 	},
 /area/awaymission/snowdin/post/cavern1)
@@ -8366,7 +8161,6 @@
 	},
 /obj/structure/closet/cabinet,
 /turf/open/floor/wood{
-	broken = 1;
 	icon_state = "wood-broken"
 	},
 /area/awaymission/snowdin/post/cavern1)
@@ -8401,7 +8195,6 @@
 /area/awaymission/snowdin/post/cavern1)
 "uk" = (
 /turf/open/floor/wood{
-	broken = 1;
 	icon_state = "wood-broken"
 	},
 /area/awaymission/snowdin/post/cavern1)
@@ -8666,10 +8459,7 @@
 /turf/open/floor/plating/asteroid/snow,
 /area/awaymission/snowdin/outside)
 "uY" = (
-/obj/structure/barricade/wooden{
-	desc = "This space is blocked off by a wooden barricade. Has some snow piled on it.";
-	icon_state = "woodenbarricade-snow"
-	},
+/obj/structure/barricade/wooden/snowed,
 /obj/structure/spider/stickyweb,
 /turf/open/floor/plating/asteroid/snow/ice,
 /area/awaymission/snowdin/cave/cavern)
@@ -8809,7 +8599,6 @@
 /area/awaymission/snowdin/post/cavern1)
 "vq" = (
 /obj/machinery/light/broken{
-	icon_state = "tube-broken";
 	dir = 8
 	},
 /turf/open/floor/plating,
@@ -8867,7 +8656,6 @@
 /area/awaymission/snowdin/post/cavern1)
 "vz" = (
 /obj/machinery/light/small/broken{
-	icon_state = "bulb-broken";
 	dir = 4
 	},
 /turf/open/floor/plating/asteroid/snow/ice,
@@ -8899,7 +8687,6 @@
 /area/awaymission/snowdin/post/cavern1)
 "vE" = (
 /obj/structure/toilet{
-	icon_state = "toilet00";
 	dir = 1
 	},
 /turf/open/floor/plasteel/showroomfloor,
@@ -8994,10 +8781,7 @@
 /turf/open/floor/mineral/titanium/blue,
 /area/awaymission/snowdin/post/broken_shuttle)
 "vV" = (
-/obj/structure/barricade/wooden{
-	desc = "This space is blocked off by a wooden barricade. Has some snow piled on it.";
-	icon_state = "woodenbarricade-snow"
-	},
+/obj/structure/barricade/wooden/snowed,
 /turf/open/floor/plating/asteroid/snow,
 /area/awaymission/snowdin/cave)
 "vW" = (
@@ -9033,7 +8817,6 @@
 /obj/machinery/computer{
 	name = "Shuttle Transist Console";
 	desc = "A console meant for calling and sending a transit ferry. It seems iced-over and non-functional.";
-	icon_state = "computer";
 	dir = 1;
 	icon_screen = null
 	},
@@ -9071,7 +8854,6 @@
 /area/awaymission/snowdin/cave)
 "wg" = (
 /obj/effect/turf_decal/weather/snow/corner{
-	icon_state = "snow_corner";
 	dir = 8
 	},
 /turf/open/floor/plating/asteroid/snow{
@@ -9082,7 +8864,6 @@
 /area/awaymission/snowdin/cave)
 "wh" = (
 /obj/effect/turf_decal/weather/snow/corner{
-	icon_state = "snow_corner";
 	dir = 10
 	},
 /turf/open/floor/plating/asteroid/snow{
@@ -9101,7 +8882,6 @@
 /area/awaymission/snowdin/cave)
 "wj" = (
 /obj/effect/turf_decal/weather/snow/corner{
-	icon_state = "snow_corner";
 	dir = 4
 	},
 /turf/open/floor/plating/asteroid/snow{
@@ -9116,7 +8896,6 @@
 /area/awaymission/snowdin/cave)
 "wl" = (
 /obj/effect/turf_decal/weather/snow/corner{
-	icon_state = "snow_corner";
 	dir = 1
 	},
 /turf/open/floor/plating/asteroid/snow{
@@ -9145,7 +8924,6 @@
 /area/awaymission/snowdin/cave)
 "wo" = (
 /obj/effect/turf_decal/weather/snow/corner{
-	icon_state = "snow_corner";
 	dir = 6
 	},
 /turf/open/floor/plating/asteroid/snow{
@@ -9160,7 +8938,6 @@
 /area/awaymission/snowdin/outside)
 "wq" = (
 /obj/effect/turf_decal/weather/snow/corner{
-	icon_state = "snow_corner";
 	dir = 5
 	},
 /turf/open/floor/plating/asteroid/snow{
@@ -9365,7 +9142,6 @@
 /area/awaymission/snowdin/cave)
 "wT" = (
 /turf/open/floor/plasteel/neutral/side{
-	icon_state = "neutral";
 	dir = 9
 	},
 /area/awaymission/snowdin/post/mining_dock)
@@ -9407,7 +9183,6 @@
 	pixel_y = 32
 	},
 /obj/machinery/light/broken{
-	icon_state = "tube-broken";
 	dir = 1
 	},
 /turf/open/floor/engine/cult,
@@ -9419,7 +9194,6 @@
 "xb" = (
 /obj/effect/turf_decal/stripes/white/line,
 /obj/effect/turf_decal/caution/stand_clear{
-	icon_state = "stand_clear";
 	dir = 1
 	},
 /obj/machinery/light/small{
@@ -9429,8 +9203,7 @@
 /area/awaymission/snowdin/cave)
 "xc" = (
 /obj/structure/closet/crate{
-	icon_state = "crateopen";
-	opened = 1
+	icon_state = "crateopen"
 	},
 /turf/open/floor/plasteel/neutral,
 /area/awaymission/snowdin/post/mining_dock)
@@ -9466,7 +9239,6 @@
 /area/awaymission/snowdin/post/mining_dock)
 "xj" = (
 /obj/effect/turf_decal/stripes/corner{
-	icon_state = "warninglinecorner";
 	dir = 1
 	},
 /obj/structure/cable/yellow{
@@ -9480,7 +9252,6 @@
 /area/awaymission/snowdin/post/mining_dock)
 "xk" = (
 /obj/effect/turf_decal/stripes/white/line{
-	icon_state = "warningline_white";
 	dir = 4
 	},
 /turf/open/floor/plating/snowed,
@@ -9505,14 +9276,12 @@
 /area/shuttle/snowdin/elevator1)
 "xp" = (
 /obj/effect/turf_decal/stripes/white/line{
-	icon_state = "warningline_white";
 	dir = 8
 	},
 /turf/open/floor/plating/snowed,
 /area/awaymission/snowdin/cave)
 "xq" = (
 /obj/machinery/light/broken{
-	icon_state = "tube-broken";
 	dir = 8
 	},
 /obj/effect/spawner/lootdrop/crate_spawner,
@@ -9561,7 +9330,6 @@
 "xw" = (
 /obj/machinery/computer/shuttle/snowdin/mining{
 	dir = 2;
-	icon_state = "computer";
 	name = "Excavation Elevator Console";
 	possible_destinations = "snowdin_excavation_top;snowdin_excavation_down";
 	shuttleId = "snowdin_excavation"
@@ -9600,22 +9368,18 @@
 /area/awaymission/snowdin/post/mining_dock)
 "xC" = (
 /obj/effect/turf_decal/stripes/white/line{
-	icon_state = "warningline_white";
 	dir = 4
 	},
 /obj/effect/turf_decal/caution/stand_clear{
-	icon_state = "stand_clear";
 	dir = 8
 	},
 /turf/open/floor/plating/snowed,
 /area/awaymission/snowdin/cave)
 "xD" = (
 /obj/effect/turf_decal/stripes/white/line{
-	icon_state = "warningline_white";
 	dir = 8
 	},
 /obj/effect/turf_decal/caution/stand_clear{
-	icon_state = "stand_clear";
 	dir = 4
 	},
 /turf/open/floor/plating/snowed,
@@ -9628,7 +9392,6 @@
 /area/awaymission/snowdin/cave)
 "xF" = (
 /obj/machinery/atmospherics/components/unary/portables_connector/visible{
-	icon_state = "connector_map";
 	dir = 8
 	},
 /obj/machinery/portable_atmospherics/canister,
@@ -9685,14 +9448,12 @@
 /area/shuttle/snowdin/elevator1)
 "xL" = (
 /obj/machinery/atmospherics/pipe/manifold/orange/visible{
-	icon_state = "manifold";
 	dir = 8
 	},
 /turf/open/floor/plating/snowed,
 /area/awaymission/snowdin/cave)
 "xM" = (
 /obj/machinery/atmospherics/components/unary/portables_connector/visible{
-	icon_state = "connector_map";
 	dir = 8
 	},
 /obj/machinery/portable_atmospherics/canister/toxins,
@@ -9751,14 +9512,12 @@
 /area/awaymission/snowdin/cave)
 "xT" = (
 /obj/machinery/atmospherics/pipe/simple/orange/visible{
-	icon_state = "intact";
 	dir = 5
 	},
 /turf/open/floor/plating/snowed,
 /area/awaymission/snowdin/cave)
 "xU" = (
 /obj/machinery/atmospherics/pipe/simple/orange/visible{
-	icon_state = "intact";
 	dir = 10
 	},
 /obj/machinery/light/small{
@@ -9812,7 +9571,6 @@
 /area/awaymission/snowdin/cave)
 "yd" = (
 /obj/machinery/atmospherics/components/unary/portables_connector/visible{
-	icon_state = "connector_map";
 	dir = 8
 	},
 /turf/open/floor/plating/snowed/smoothed,
@@ -9868,7 +9626,6 @@
 	},
 /obj/machinery/computer/shuttle/snowdin/mining{
 	dir = 8;
-	icon_state = "computer";
 	name = "Excavation Elevator Console";
 	possible_destinations = "snowdin_excavation_top;snowdin_excavation_down";
 	shuttleId = "snowdin_excavation"
@@ -9879,14 +9636,12 @@
 /area/awaymission/snowdin/post/mining_dock)
 "yn" = (
 /obj/machinery/atmospherics/pipe/manifold/orange/visible{
-	icon_state = "manifold";
 	dir = 8
 	},
 /turf/open/floor/plating/snowed/smoothed,
 /area/awaymission/snowdin/cave)
 "yo" = (
 /obj/machinery/atmospherics/components/unary/portables_connector/visible{
-	icon_state = "connector_map";
 	dir = 8
 	},
 /obj/machinery/portable_atmospherics/canister/toxins,
@@ -9894,14 +9649,12 @@
 /area/awaymission/snowdin/cave)
 "yp" = (
 /obj/effect/turf_decal/stripes/white/line{
-	icon_state = "warningline_white";
 	dir = 1
 	},
 /turf/open/floor/plating/snowed,
 /area/awaymission/snowdin/cave)
 "yq" = (
 /obj/effect/turf_decal/stripes/white/line{
-	icon_state = "warningline_white";
 	dir = 1
 	},
 /obj/effect/turf_decal/caution/stand_clear,
@@ -9909,12 +9662,10 @@
 /area/awaymission/snowdin/cave)
 "yr" = (
 /obj/effect/turf_decal/stripes/white/line{
-	icon_state = "warningline_white";
 	dir = 1
 	},
 /obj/machinery/computer/shuttle/snowdin/mining{
 	dir = 8;
-	icon_state = "computer";
 	name = "Excavation Elevator Console";
 	possible_destinations = "snowdin_excavation_top;snowdin_excavation_down";
 	shuttleId = "snowdin_excavation"
@@ -9936,7 +9687,6 @@
 "yu" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/siphon/on{
 	name = "toxin out";
-	icon_state = "vent_map_siphon_on";
 	dir = 8;
 	id_tag = "snowdin_toxins_mine_1";
 	frequency = 1442
@@ -10037,38 +9787,26 @@
 "yF" = (
 /obj/effect/turf_decal/weather/snow,
 /obj/effect/turf_decal/stripes/white/line{
-	icon_state = "warningline_white";
 	dir = 1
 	},
-/turf/open/floor/plasteel/dark{
-	initial_gas_mix = "o2=22;n2=82;TEMP=180";
-	planetary_atmos = 1;
-	temperature = 180
-	},
+/turf/open/floor/plasteel/dark/snowdin,
 /area/awaymission/snowdin/outside)
 "yG" = (
 /obj/effect/turf_decal/weather/snow,
 /obj/effect/turf_decal/stripes/white/line{
-	icon_state = "warningline_white";
 	dir = 1
 	},
 /obj/effect/turf_decal/caution/stand_clear,
-/turf/open/floor/plasteel/dark{
-	initial_gas_mix = "o2=22;n2=82;TEMP=180";
-	planetary_atmos = 1;
-	temperature = 180
-	},
+/turf/open/floor/plasteel/dark/snowdin,
 /area/awaymission/snowdin/outside)
 "yH" = (
 /obj/machinery/atmospherics/pipe/simple/orange/visible{
-	icon_state = "intact";
 	dir = 5
 	},
 /turf/open/floor/plating/snowed/smoothed,
 /area/awaymission/snowdin/cave)
 "yI" = (
 /obj/machinery/atmospherics/pipe/simple/orange/visible{
-	icon_state = "intact";
 	dir = 10
 	},
 /turf/open/floor/plating/snowed/smoothed,
@@ -10084,7 +9822,6 @@
 /area/awaymission/snowdin/cave)
 "yL" = (
 /obj/machinery/atmospherics/components/unary/portables_connector/visible{
-	icon_state = "connector_map";
 	dir = 1
 	},
 /obj/machinery/portable_atmospherics/canister,
@@ -10092,7 +9829,6 @@
 /area/awaymission/snowdin/cave)
 "yM" = (
 /obj/machinery/atmospherics/components/unary/portables_connector/visible{
-	icon_state = "connector_map";
 	dir = 1
 	},
 /obj/machinery/portable_atmospherics/canister,
@@ -10114,7 +9850,6 @@
 	dir = 4
 	},
 /obj/structure/fence/door{
-	icon_state = "door_closed";
 	dir = 4
 	},
 /obj/effect/decal/cleanable/blood/old,
@@ -10148,11 +9883,8 @@
 "yU" = (
 /obj/effect/turf_decal/weather/snow,
 /obj/effect/turf_decal/weather/snow/corner,
-/turf/open/floor/plasteel/vault{
-	dir = 5;
-	initial_gas_mix = "o2=22;n2=82;TEMP=180";
-	planetary_atmos = 1;
-	temperature = 180
+/turf/open/floor/plasteel/vault/snowdin{
+	dir = 5
 	},
 /area/awaymission/snowdin/outside)
 "yV" = (
@@ -10178,7 +9910,6 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/siphon/on{
 	dir = 4;
 	frequency = 1442;
-	icon_state = "vent_map_siphon_on";
 	id_tag = "snowdin_toxins_mine_1";
 	name = "toxin out"
 	},
@@ -10193,7 +9924,6 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/siphon/on{
 	dir = 4;
 	frequency = 1442;
-	icon_state = "vent_map_siphon_on";
 	id_tag = "snowdin_toxins_mine_1";
 	name = "toxin out"
 	},
@@ -10211,7 +9941,6 @@
 /area/awaymission/snowdin/cave)
 "ze" = (
 /obj/machinery/atmospherics/pipe/simple/orange/visible{
-	icon_state = "intact";
 	dir = 9
 	},
 /turf/open/floor/plating/snowed/smoothed,
@@ -10228,7 +9957,6 @@
 "zg" = (
 /obj/structure/barricade/sandbags,
 /obj/effect/turf_decal/weather/snow/corner{
-	icon_state = "snow_corner";
 	dir = 8
 	},
 /turf/open/floor/plating/asteroid/snow{
@@ -10247,7 +9975,6 @@
 "zi" = (
 /obj/structure/barricade/sandbags,
 /obj/effect/turf_decal/weather/snow/corner{
-	icon_state = "snow_corner";
 	dir = 5
 	},
 /turf/open/floor/plating/asteroid/snow{
@@ -10259,7 +9986,6 @@
 "zj" = (
 /obj/effect/turf_decal/stripes/corner,
 /obj/structure/fence/corner{
-	icon_state = "corner";
 	dir = 9
 	},
 /turf/open/floor/plating/snowed/cavern,
@@ -10309,7 +10035,6 @@
 /area/awaymission/snowdin/post/minipost)
 "zr" = (
 /obj/effect/turf_decal/weather/snow/corner{
-	icon_state = "snow_corner";
 	dir = 10
 	},
 /turf/open/floor/plating/asteroid/snow{
@@ -10373,7 +10098,6 @@
 /area/awaymission/snowdin/cave)
 "zA" = (
 /obj/effect/turf_decal/weather/snow/corner{
-	icon_state = "snow_corner";
 	dir = 8
 	},
 /turf/open/floor/plating/asteroid/snow{
@@ -10384,7 +10108,6 @@
 /area/awaymission/snowdin/outside)
 "zB" = (
 /obj/effect/turf_decal/weather/snow/corner{
-	icon_state = "snow_corner";
 	dir = 4
 	},
 /turf/open/floor/plating/asteroid/snow{
@@ -10450,7 +10173,6 @@
 /area/awaymission/snowdin/post/mining_dock)
 "zJ" = (
 /obj/machinery/atmospherics/components/unary/outlet_injector/on{
-	icon_state = "inje_map";
 	dir = 8
 	},
 /obj/effect/turf_decal/stripes/line{
@@ -10482,7 +10204,6 @@
 /area/awaymission/snowdin/cave)
 "zO" = (
 /obj/effect/turf_decal/weather/snow/corner{
-	icon_state = "snow_corner";
 	dir = 6
 	},
 /turf/open/floor/plating/asteroid/snow{
@@ -10521,7 +10242,6 @@
 	dir = 4
 	},
 /obj/structure/fence/corner{
-	icon_state = "corner";
 	dir = 6
 	},
 /turf/open/floor/plating/snowed/cavern,
@@ -10534,7 +10254,6 @@
 "zV" = (
 /obj/structure/filingcabinet,
 /turf/open/floor/plasteel/neutral/side{
-	icon_state = "neutral";
 	dir = 9
 	},
 /area/awaymission/snowdin/post/minipost)
@@ -10561,11 +10280,9 @@
 /area/awaymission/snowdin/igloo)
 "Ab" = (
 /obj/effect/turf_decal/weather/snow/corner{
-	icon_state = "snow_corner";
 	dir = 8
 	},
 /obj/effect/turf_decal/weather/snow/corner{
-	icon_state = "snow_corner";
 	dir = 4
 	},
 /mob/living/simple_animal/hostile/skeleton/eskimo,
@@ -10588,7 +10305,6 @@
 	dir = 9
 	},
 /obj/structure/fence/corner{
-	icon_state = "corner";
 	dir = 10
 	},
 /turf/open/floor/plating/snowed/cavern,
@@ -10598,7 +10314,6 @@
 	dir = 1
 	},
 /obj/structure/fence{
-	icon_state = "straight";
 	dir = 4
 	},
 /turf/open/floor/plating/snowed/cavern,
@@ -10651,7 +10366,6 @@
 /area/awaymission/snowdin/cave)
 "An" = (
 /obj/effect/turf_decal/weather/snow/corner{
-	icon_state = "snow_corner";
 	dir = 9
 	},
 /turf/open/floor/plating/asteroid/snow{
@@ -10678,7 +10392,6 @@
 "Ar" = (
 /obj/effect/turf_decal/stripes/corner,
 /obj/structure/fence/corner{
-	icon_state = "corner";
 	dir = 10
 	},
 /turf/open/floor/plating/snowed/cavern,
@@ -10691,7 +10404,6 @@
 "At" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/structure/fence{
-	icon_state = "straight";
 	dir = 4
 	},
 /turf/open/floor/plating/snowed/cavern,
@@ -10738,7 +10450,6 @@
 /area/awaymission/snowdin/igloo)
 "AB" = (
 /obj/effect/turf_decal/weather/snow/corner{
-	icon_state = "snow_corner";
 	dir = 1
 	},
 /turf/open/floor/plating/asteroid/snow{
@@ -10811,7 +10522,6 @@
 /area/awaymission/snowdin/cave/cavern)
 "AL" = (
 /obj/effect/turf_decal/stripes/corner{
-	icon_state = "warninglinecorner";
 	dir = 4
 	},
 /obj/structure/fence/corner,
@@ -10883,7 +10593,6 @@
 /obj/structure/closet/emcloset,
 /obj/item/clothing/suit/hooded/wintercoat,
 /turf/open/floor/plasteel/neutral/side{
-	icon_state = "neutral";
 	dir = 9
 	},
 /area/awaymission/snowdin/post/minipost)
@@ -10934,7 +10643,6 @@
 /area/awaymission/snowdin/post/minipost)
 "Bg" = (
 /obj/effect/turf_decal/weather/snow/corner{
-	icon_state = "snow_corner";
 	dir = 4
 	},
 /mob/living/simple_animal/hostile/skeleton/eskimo,
@@ -10978,7 +10686,6 @@
 /area/awaymission/snowdin/post/minipost)
 "Bn" = (
 /obj/effect/turf_decal/weather/snow/corner{
-	icon_state = "snow_corner";
 	dir = 5
 	},
 /turf/open/floor/plating/asteroid/snow{
@@ -10998,7 +10705,6 @@
 	dir = 8
 	},
 /obj/structure/fence/door{
-	icon_state = "door_closed";
 	dir = 4
 	},
 /turf/open/floor/plating/snowed/cavern,
@@ -11053,7 +10759,6 @@
 /area/awaymission/snowdin/cave/cavern)
 "By" = (
 /obj/effect/turf_decal/stripes/corner{
-	icon_state = "warninglinecorner";
 	dir = 1
 	},
 /turf/open/floor/plating/snowed/cavern,
@@ -11094,7 +10799,6 @@
 	dir = 10
 	},
 /obj/structure/fence/corner{
-	icon_state = "corner";
 	dir = 10
 	},
 /turf/open/floor/plating/snowed/cavern,
@@ -11104,7 +10808,6 @@
 	dir = 6
 	},
 /obj/structure/fence{
-	icon_state = "straight";
 	dir = 4
 	},
 /turf/open/floor/plating/snowed/cavern,
@@ -11119,7 +10822,6 @@
 	dir = 10
 	},
 /obj/structure/fence{
-	icon_state = "straight";
 	dir = 4
 	},
 /turf/open/floor/plating/snowed/cavern,
@@ -11130,7 +10832,6 @@
 /area/awaymission/snowdin/cave/cavern)
 "BI" = (
 /obj/machinery/atmospherics/pipe/simple/orange/visible{
-	icon_state = "intact";
 	dir = 9
 	},
 /obj/machinery/light/small{
@@ -11148,7 +10849,6 @@
 /area/awaymission/snowdin/cave)
 "BK" = (
 /obj/machinery/atmospherics/components/unary/portables_connector/visible{
-	icon_state = "connector_map";
 	dir = 8
 	},
 /turf/open/floor/plating/snowed,
@@ -11168,7 +10868,6 @@
 /area/awaymission/snowdin/igloo)
 "BN" = (
 /obj/machinery/atmospherics/pipe/simple/orange/visible{
-	icon_state = "intact";
 	dir = 9
 	},
 /turf/open/floor/plating/snowed,
@@ -11183,7 +10882,6 @@
 "BP" = (
 /obj/structure/lattice/catwalk,
 /obj/effect/turf_decal/stripes/corner{
-	icon_state = "warninglinecorner";
 	dir = 4
 	},
 /turf/open/lava/plasma,
@@ -11200,14 +10898,12 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/stripes/corner{
-	icon_state = "warninglinecorner";
 	dir = 1
 	},
 /turf/open/floor/plating/snowed/cavern,
 /area/awaymission/snowdin/cave/cavern)
 "BS" = (
 /obj/machinery/atmospherics/pipe/simple/orange/visible{
-	icon_state = "intact";
 	dir = 10
 	},
 /turf/open/floor/plating/snowed,
@@ -11217,14 +10913,12 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/stripes/corner{
-	icon_state = "warninglinecorner";
 	dir = 4
 	},
 /turf/open/floor/plating/snowed/cavern,
 /area/awaymission/snowdin/cave/cavern)
 "BU" = (
 /obj/machinery/atmospherics/components/unary/portables_connector/visible{
-	icon_state = "connector_map";
 	dir = 1
 	},
 /obj/machinery/portable_atmospherics/canister/toxins,
@@ -11236,7 +10930,6 @@
 /area/awaymission/snowdin/cave)
 "BV" = (
 /obj/machinery/atmospherics/components/unary/portables_connector/visible{
-	icon_state = "connector_map";
 	dir = 1
 	},
 /turf/open/floor/plating/snowed,
@@ -11264,14 +10957,12 @@
 /obj/effect/turf_decal/bot,
 /obj/structure/closet/crate{
 	icon_state = "crateopen";
-	name = "explosives ordinance";
-	opened = 1
+	name = "explosives ordinance"
 	},
 /turf/open/floor/plating/snowed,
 /area/awaymission/snowdin/cave)
 "Cb" = (
 /obj/structure/fence{
-	icon_state = "straight";
 	dir = 4
 	},
 /turf/open/floor/plating/snowed/cavern,
@@ -11285,7 +10976,6 @@
 	dir = 8
 	},
 /obj/structure/fence{
-	icon_state = "straight";
 	dir = 4
 	},
 /turf/open/floor/plating/snowed/cavern,
@@ -11323,7 +11013,6 @@
 /area/awaymission/snowdin/cave/cavern)
 "Cj" = (
 /obj/structure/fence{
-	icon_state = "straight";
 	dir = 4
 	},
 /obj/structure/sign/mining,
@@ -11451,7 +11140,6 @@
 	list_reagents = null
 	},
 /turf/open/floor/plasteel/vault/side{
-	icon_state = "vault";
 	dir = 4
 	},
 /area/awaymission/snowdin/cave)
@@ -11473,7 +11161,6 @@
 /obj/effect/turf_decal/bot_white,
 /obj/item/gun/ballistic/automatic/pistol,
 /turf/open/floor/plasteel/vault/side{
-	icon_state = "vault";
 	dir = 4
 	},
 /area/awaymission/snowdin/cave)
@@ -11514,7 +11201,6 @@
 /area/awaymission/snowdin/cave)
 "CQ" = (
 /obj/structure/shuttle/engine/propulsion/left{
-	icon_state = "propulsion_l";
 	dir = 4
 	},
 /obj/effect/turf_decal/stripes/line{
@@ -11545,7 +11231,6 @@
 "CT" = (
 /obj/effect/decal/cleanable/blood/old,
 /turf/open/floor/plasteel/vault/side{
-	icon_state = "vault";
 	dir = 4
 	},
 /area/awaymission/snowdin/cave)
@@ -11568,7 +11253,6 @@
 	amount = 1
 	},
 /turf/open/floor/plasteel/vault/side{
-	icon_state = "vault";
 	dir = 4
 	},
 /area/awaymission/snowdin/cave)
@@ -11592,7 +11276,6 @@
 /area/awaymission/snowdin/cave)
 "Da" = (
 /obj/structure/shuttle/engine/propulsion{
-	icon_state = "propulsion";
 	dir = 4
 	},
 /obj/effect/turf_decal/stripes/line{
@@ -11630,7 +11313,6 @@
 	list_reagents = null
 	},
 /turf/open/floor/plasteel/vault/side{
-	icon_state = "vault";
 	dir = 4
 	},
 /area/awaymission/snowdin/cave)
@@ -11652,7 +11334,6 @@
 /area/awaymission/snowdin/cave)
 "Di" = (
 /turf/open/floor/plasteel/vault/side{
-	icon_state = "vault";
 	dir = 4
 	},
 /area/awaymission/snowdin/cave)
@@ -11674,7 +11355,6 @@
 /area/awaymission/snowdin/cave)
 "Dl" = (
 /obj/structure/shuttle/engine/propulsion/right{
-	icon_state = "propulsion_r";
 	dir = 4
 	},
 /obj/effect/turf_decal/stripes/line{
@@ -11690,7 +11370,6 @@
 	set_luminosity = 6
 	},
 /obj/structure/fence/door{
-	icon_state = "door_closed";
 	dir = 4
 	},
 /turf/open/floor/plating/snowed/smoothed,
@@ -11714,11 +11393,8 @@
 /area/awaymission/snowdin/cave)
 "Dp" = (
 /obj/effect/turf_decal/weather/snow,
-/turf/open/floor/plasteel/vault{
-	dir = 5;
-	initial_gas_mix = "o2=22;n2=82;TEMP=180";
-	planetary_atmos = 1;
-	temperature = 180
+/turf/open/floor/plasteel/vault/snowdin{
+	dir = 5
 	},
 /area/awaymission/snowdin/cave)
 "Dq" = (
@@ -11740,7 +11416,6 @@
 "Ds" = (
 /obj/item/grenade/plastic/c4,
 /turf/open/floor/plasteel/vault/side{
-	icon_state = "vault";
 	dir = 4
 	},
 /area/awaymission/snowdin/cave)
@@ -11781,11 +11456,8 @@
 /obj/effect/turf_decal/weather/snow,
 /obj/effect/turf_decal/bot_white,
 /obj/item/chair,
-/turf/open/floor/plasteel/vault{
-	dir = 5;
-	initial_gas_mix = "o2=22;n2=82;TEMP=180";
-	planetary_atmos = 1;
-	temperature = 180
+/turf/open/floor/plasteel/vault/snowdin{
+	dir = 5
 	},
 /area/awaymission/snowdin/cave)
 "Dz" = (
@@ -11794,17 +11466,13 @@
 /obj/structure/chair{
 	dir = 1
 	},
-/turf/open/floor/plasteel/vault{
-	dir = 5;
-	initial_gas_mix = "o2=22;n2=82;TEMP=180";
-	planetary_atmos = 1;
-	temperature = 180
+/turf/open/floor/plasteel/vault/snowdin{
+	dir = 5
 	},
 /area/awaymission/snowdin/cave)
 "DA" = (
 /obj/item/stack/rods,
 /turf/open/floor/plasteel/vault/side{
-	icon_state = "vault";
 	dir = 4
 	},
 /area/awaymission/snowdin/cave)
@@ -11892,21 +11560,15 @@
 "DO" = (
 /obj/item/shard,
 /obj/effect/turf_decal/weather/snow,
-/turf/open/floor/plasteel/vault{
-	dir = 5;
-	initial_gas_mix = "o2=22;n2=82;TEMP=180";
-	planetary_atmos = 1;
-	temperature = 180
+/turf/open/floor/plasteel/vault/snowdin{
+	dir = 5
 	},
 /area/awaymission/snowdin/cave)
 "DP" = (
 /obj/item/stack/rods,
 /obj/effect/turf_decal/weather/snow,
-/turf/open/floor/plasteel/vault{
-	dir = 5;
-	initial_gas_mix = "o2=22;n2=82;TEMP=180";
-	planetary_atmos = 1;
-	temperature = 180
+/turf/open/floor/plasteel/vault/snowdin{
+	dir = 5
 	},
 /area/awaymission/snowdin/cave)
 "DQ" = (
@@ -11944,7 +11606,6 @@
 /area/awaymission/snowdin/cave)
 "DV" = (
 /obj/structure/shuttle/engine/propulsion/left{
-	icon_state = "propulsion_l";
 	dir = 4
 	},
 /obj/effect/turf_decal/stripes/line{
@@ -11973,29 +11634,18 @@
 "DX" = (
 /obj/item/shard,
 /obj/effect/turf_decal/weather/snow,
-/turf/open/floor/plasteel/dark{
-	initial_gas_mix = "o2=22;n2=82;TEMP=180";
-	planetary_atmos = 1;
-	temperature = 180
-	},
+/turf/open/floor/plasteel/dark/snowdin,
 /area/awaymission/snowdin/cave)
 "DY" = (
 /obj/effect/turf_decal/weather/snow,
 /mob/living/simple_animal/hostile/bear/snow,
-/turf/open/floor/plasteel/dark{
-	initial_gas_mix = "o2=22;n2=82;TEMP=180";
-	planetary_atmos = 1;
-	temperature = 180
-	},
+/turf/open/floor/plasteel/dark/snowdin,
 /area/awaymission/snowdin/cave)
 "DZ" = (
 /obj/effect/turf_decal/weather/snow,
 /obj/effect/decal/cleanable/blood/drip,
-/turf/open/floor/plasteel/vault{
-	dir = 5;
-	initial_gas_mix = "o2=22;n2=82;TEMP=180";
-	planetary_atmos = 1;
-	temperature = 180
+/turf/open/floor/plasteel/vault/snowdin{
+	dir = 5
 	},
 /area/awaymission/snowdin/cave)
 "Ea" = (
@@ -12021,7 +11671,6 @@
 /area/awaymission/snowdin/cave)
 "Ee" = (
 /obj/structure/shuttle/engine/propulsion{
-	icon_state = "propulsion";
 	dir = 4
 	},
 /obj/effect/turf_decal/stripes/line{
@@ -12046,7 +11695,6 @@
 /area/awaymission/snowdin/cave)
 "Eh" = (
 /obj/structure/shuttle/engine/propulsion/right{
-	icon_state = "propulsion_r";
 	dir = 4
 	},
 /obj/effect/turf_decal/stripes/line{
@@ -12076,11 +11724,7 @@
 /obj/effect/turf_decal/weather/snow,
 /obj/effect/turf_decal/bot_white,
 /obj/structure/tank_dispenser/oxygen,
-/turf/open/floor/plasteel/dark{
-	initial_gas_mix = "o2=22;n2=82;TEMP=180";
-	planetary_atmos = 1;
-	temperature = 180
-	},
+/turf/open/floor/plasteel/dark/snowdin,
 /area/awaymission/snowdin/cave)
 "Em" = (
 /obj/effect/turf_decal/weather/snow,
@@ -12088,36 +11732,23 @@
 /obj/machinery/light{
 	dir = 1
 	},
-/turf/open/floor/plasteel/dark{
-	initial_gas_mix = "o2=22;n2=82;TEMP=180";
-	planetary_atmos = 1;
-	temperature = 180
-	},
+/turf/open/floor/plasteel/dark/snowdin,
 /area/awaymission/snowdin/cave)
 "En" = (
 /obj/effect/turf_decal/weather/snow,
 /obj/effect/decal/cleanable/blood/old,
-/turf/open/floor/plasteel/dark{
-	initial_gas_mix = "o2=22;n2=82;TEMP=180";
-	planetary_atmos = 1;
-	temperature = 180
-	},
+/turf/open/floor/plasteel/dark/snowdin,
 /area/awaymission/snowdin/cave)
 "Eo" = (
 /obj/effect/turf_decal/weather/snow,
 /obj/item/reagent_containers/food/drinks/beer{
 	list_reagents = null
 	},
-/turf/open/floor/plasteel/dark{
-	initial_gas_mix = "o2=22;n2=82;TEMP=180";
-	planetary_atmos = 1;
-	temperature = 180
-	},
+/turf/open/floor/plasteel/dark/snowdin,
 /area/awaymission/snowdin/cave)
 "Ep" = (
 /obj/item/shard,
 /turf/open/floor/plasteel/vault/side{
-	icon_state = "vault";
 	dir = 4
 	},
 /area/awaymission/snowdin/cave)
@@ -12139,22 +11770,16 @@
 "Es" = (
 /obj/effect/turf_decal/weather/snow,
 /obj/effect/decal/cleanable/blood/old,
-/turf/open/floor/plasteel/vault{
-	dir = 5;
-	initial_gas_mix = "o2=22;n2=82;TEMP=180";
-	planetary_atmos = 1;
-	temperature = 180
+/turf/open/floor/plasteel/vault/snowdin{
+	dir = 5
 	},
 /area/awaymission/snowdin/cave)
 "Et" = (
 /obj/effect/turf_decal/weather/snow,
 /obj/effect/decal/cleanable/blood/old,
 /obj/effect/mob_spawn/human/corpse/syndicatesoldier,
-/turf/open/floor/plasteel/vault{
-	dir = 5;
-	initial_gas_mix = "o2=22;n2=82;TEMP=180";
-	planetary_atmos = 1;
-	temperature = 180
+/turf/open/floor/plasteel/vault/snowdin{
+	dir = 5
 	},
 /area/awaymission/snowdin/cave)
 "Eu" = (
@@ -12177,7 +11802,6 @@
 "Ew" = (
 /obj/machinery/iv_drip,
 /turf/open/floor/plasteel/vault/side{
-	icon_state = "vault";
 	dir = 4
 	},
 /area/awaymission/snowdin/cave)
@@ -12292,7 +11916,6 @@
 "EK" = (
 /obj/structure/bed/roller,
 /turf/open/floor/plasteel/vault/side{
-	icon_state = "vault";
 	dir = 4
 	},
 /area/awaymission/snowdin/cave)
@@ -12335,7 +11958,6 @@
 "EQ" = (
 /obj/structure/table/reinforced,
 /turf/open/floor/plasteel/vault/side{
-	icon_state = "vault";
 	dir = 4
 	},
 /area/awaymission/snowdin/cave)
@@ -12399,14 +12021,12 @@
 /area/awaymission/snowdin/outside)
 "Fb" = (
 /obj/structure/fence{
-	icon_state = "straight";
 	dir = 4
 	},
 /turf/open/floor/plating/asteroid/snow/ice,
 /area/awaymission/snowdin/cave/cavern)
 "Fc" = (
 /obj/structure/fence/corner{
-	icon_state = "corner";
 	dir = 4
 	},
 /turf/open/floor/plating/asteroid/snow/ice,
@@ -12427,7 +12047,6 @@
 /area/awaymission/snowdin/cave/cavern)
 "Ff" = (
 /obj/structure/fence/corner{
-	icon_state = "corner";
 	dir = 10
 	},
 /turf/open/floor/plating/asteroid/snow/ice,
@@ -12463,7 +12082,6 @@
 /area/awaymission/snowdin/cave/cavern)
 "Fl" = (
 /obj/structure/fence{
-	icon_state = "straight";
 	dir = 4
 	},
 /obj/effect/light_emitter{
@@ -12516,7 +12134,6 @@
 /area/awaymission/snowdin/outside)
 "Fs" = (
 /obj/machinery/atmospherics/pipe/manifold/orange/visible{
-	icon_state = "manifold";
 	dir = 8
 	},
 /turf/open/floor/plating/snowed,
@@ -12527,7 +12144,6 @@
 /area/awaymission/snowdin/outside)
 "Fu" = (
 /obj/machinery/atmospherics/pipe/manifold/orange/visible{
-	icon_state = "manifold";
 	dir = 4
 	},
 /turf/open/floor/plating/snowed,
@@ -12549,14 +12165,12 @@
 /area/awaymission/snowdin/outside)
 "Fy" = (
 /obj/machinery/atmospherics/pipe/simple/orange/visible{
-	icon_state = "intact";
 	dir = 5
 	},
 /turf/open/floor/plating/snowed,
 /area/awaymission/snowdin/outside)
 "Fz" = (
 /obj/machinery/atmospherics/pipe/manifold/orange/visible{
-	icon_state = "manifold";
 	dir = 4
 	},
 /obj/machinery/light/small{
@@ -12659,7 +12273,6 @@
 /area/awaymission/snowdin/post/mining_dock)
 "FL" = (
 /obj/machinery/atmospherics/components/unary/outlet_injector/on{
-	icon_state = "inje_map";
 	dir = 8
 	},
 /turf/open/floor/plating/snowed/cavern,
@@ -12693,7 +12306,6 @@
 "FP" = (
 /turf/open/floor/plating/asteroid/snow/ice,
 /obj/effect/turf_decal/stripes/corner{
-	icon_state = "warninglinecorner";
 	dir = 1
 	},
 /turf/open/floor/plating/snowed/cavern,
@@ -12718,7 +12330,6 @@
 /area/awaymission/snowdin/post/mining_main)
 "FS" = (
 /obj/structure/fence/door{
-	icon_state = "door_closed";
 	dir = 4
 	},
 /turf/open/floor/plating/asteroid/snow,
@@ -12897,7 +12508,6 @@
 /area/awaymission/snowdin/outside)
 "Gt" = (
 /obj/machinery/atmospherics/pipe/manifold/orange/visible{
-	icon_state = "manifold";
 	dir = 1
 	},
 /turf/open/floor/plating/snowed,
@@ -13375,7 +12985,6 @@
 /area/awaymission/snowdin/post/mining_main/mechbay)
 "HR" = (
 /obj/effect/turf_decal/stripes/corner{
-	icon_state = "warninglinecorner";
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -13410,7 +13019,6 @@
 "HY" = (
 /obj/structure/closet/emcloset,
 /turf/open/floor/plasteel/neutral/side{
-	icon_state = "neutral";
 	dir = 9
 	},
 /area/awaymission/snowdin/post/mining_main)
@@ -13485,7 +13093,6 @@
 /area/awaymission/snowdin/post/mining_main/mechbay)
 "Ik" = (
 /obj/machinery/computer/mech_bay_power_console{
-	icon_state = "computer";
 	dir = 1
 	},
 /turf/open/floor/plasteel/dark,
@@ -13732,8 +13339,7 @@
 /area/awaymission/snowdin/post/mining_main)
 "IX" = (
 /obj/structure/closet/crate{
-	icon_state = "crateopen";
-	opened = 1
+	icon_state = "crateopen"
 	},
 /obj/item/stack/sheet/mineral/plasma{
 	amount = 10
@@ -13860,8 +13466,7 @@
 /area/awaymission/snowdin/post/mining_dock)
 "Jp" = (
 /obj/structure/closet/crate{
-	icon_state = "crateopen";
-	opened = 1
+	icon_state = "crateopen"
 	},
 /obj/item/storage/toolbox/emergency,
 /obj/item/clothing/suit/hooded/wintercoat,
@@ -13870,7 +13475,6 @@
 /area/awaymission/snowdin/post/mining_dock)
 "Jq" = (
 /obj/effect/turf_decal/stripes/corner{
-	icon_state = "warninglinecorner";
 	dir = 4
 	},
 /turf/open/floor/plating/snowed/cavern,
@@ -13892,8 +13496,7 @@
 /area/awaymission/snowdin/post/mining_main)
 "Jt" = (
 /obj/structure/closet/crate{
-	icon_state = "crateopen";
-	opened = 1
+	icon_state = "crateopen"
 	},
 /obj/item/storage/toolbox/emergency,
 /turf/open/floor/plating,
@@ -13923,14 +13526,12 @@
 "Jy" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/effect/turf_decal/caution/stand_clear{
-	icon_state = "stand_clear";
 	dir = 1
 	},
 /turf/open/floor/plasteel/brown,
 /area/awaymission/snowdin/post/mining_main)
 "Jz" = (
 /obj/effect/turf_decal/stripes/corner{
-	icon_state = "warninglinecorner";
 	dir = 1
 	},
 /turf/open/floor/plasteel/brown{
@@ -13963,8 +13564,7 @@
 /area/awaymission/snowdin/post/mining_dock)
 "JE" = (
 /obj/structure/closet/crate{
-	icon_state = "crateopen";
-	opened = 1
+	icon_state = "crateopen"
 	},
 /obj/item/storage/toolbox/emergency,
 /obj/item/clothing/suit/hooded/wintercoat,
@@ -13988,14 +13588,12 @@
 "JI" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/effect/turf_decal/caution/stand_clear{
-	icon_state = "stand_clear";
 	dir = 1
 	},
 /turf/open/floor/plasteel/brown,
 /area/awaymission/snowdin/post/mining_dock)
 "JJ" = (
 /obj/effect/turf_decal/stripes/corner{
-	icon_state = "warninglinecorner";
 	dir = 1
 	},
 /turf/open/floor/plasteel/brown{
@@ -14020,8 +13618,7 @@
 /area/awaymission/snowdin/post/mining_main)
 "JN" = (
 /obj/structure/closet/crate{
-	icon_state = "crateopen";
-	opened = 1
+	icon_state = "crateopen"
 	},
 /obj/item/clothing/suit/hooded/wintercoat,
 /obj/item/clothing/suit/hooded/wintercoat,
@@ -14190,7 +13787,6 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/caution/stand_clear{
-	icon_state = "stand_clear";
 	dir = 8
 	},
 /turf/open/floor/plasteel/brown{
@@ -14230,7 +13826,6 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/caution/stand_clear{
-	icon_state = "stand_clear";
 	dir = 4
 	},
 /turf/open/floor/plasteel/brown{
@@ -14258,7 +13853,6 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/caution/stand_clear{
-	icon_state = "stand_clear";
 	dir = 8
 	},
 /turf/open/floor/plating,
@@ -14285,7 +13879,6 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/caution/stand_clear{
-	icon_state = "stand_clear";
 	dir = 4
 	},
 /turf/open/floor/plasteel/brown{
@@ -14412,7 +14005,6 @@
 /area/awaymission/snowdin/post/mining_main)
 "KO" = (
 /obj/machinery/computer/shuttle/snowdin/mining{
-	icon_state = "computer";
 	dir = 8
 	},
 /obj/effect/turf_decal/stripes/line{
@@ -14427,7 +14019,6 @@
 /area/shuttle/snowdin/elevator2)
 "KQ" = (
 /obj/machinery/computer/shuttle/snowdin/mining{
-	icon_state = "computer";
 	dir = 8
 	},
 /obj/effect/turf_decal/stripes/line{
@@ -14444,7 +14035,6 @@
 /area/awaymission/snowdin/post/mining_main)
 "KS" = (
 /obj/effect/turf_decal/stripes/corner{
-	icon_state = "warninglinecorner";
 	dir = 8
 	},
 /turf/open/floor/plasteel/brown{
@@ -14470,7 +14060,6 @@
 /area/awaymission/snowdin/post/mining_main)
 "KV" = (
 /obj/effect/turf_decal/stripes/corner{
-	icon_state = "warninglinecorner";
 	dir = 4
 	},
 /turf/open/floor/plasteel/brown{
@@ -14479,7 +14068,6 @@
 /area/awaymission/snowdin/post/mining_main)
 "KW" = (
 /obj/effect/turf_decal/stripes/corner{
-	icon_state = "warninglinecorner";
 	dir = 8
 	},
 /turf/open/floor/plasteel/brown{
@@ -14505,7 +14093,6 @@
 /area/awaymission/snowdin/post/mining_dock)
 "KZ" = (
 /obj/effect/turf_decal/stripes/corner{
-	icon_state = "warninglinecorner";
 	dir = 4
 	},
 /turf/open/floor/plasteel/brown{

--- a/_maps/map_files/BoxStation/BoxStation.dmm
+++ b/_maps/map_files/BoxStation/BoxStation.dmm
@@ -7187,8 +7187,7 @@
 /area/maintenance/port/fore)
 "arM" = (
 /obj/structure/closet/crate{
-	icon_state = "crateopen";
-	opened = 1
+	icon_state = "crateopen"
 	},
 /obj/effect/spawner/lootdrop/maintenance{
 	lootcount = 2;

--- a/_maps/map_files/Deltastation/DeltaStation2.dmm
+++ b/_maps/map_files/Deltastation/DeltaStation2.dmm
@@ -5807,8 +5807,7 @@
 "amD" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/closet/crate{
-	icon_state = "crateopen";
-	opened = 1
+	icon_state = "crateopen"
 	},
 /obj/item/device/flashlight,
 /obj/effect/spawner/lootdrop/maintenance,
@@ -8649,8 +8648,7 @@
 /area/maintenance/port/fore)
 "asU" = (
 /obj/structure/closet/crate{
-	icon_state = "crateopen";
-	opened = 1
+	icon_state = "crateopen"
 	},
 /obj/effect/spawner/lootdrop/maintenance{
 	lootcount = 2;
@@ -9954,8 +9952,7 @@
 /area/maintenance/port/fore)
 "avq" = (
 /obj/structure/closet/crate{
-	icon_state = "crateopen";
-	opened = 1
+	icon_state = "crateopen"
 	},
 /obj/item/crowbar/red,
 /obj/effect/spawner/lootdrop/maintenance,
@@ -10795,8 +10792,7 @@
 "axl" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/closet/crate{
-	icon_state = "crateopen";
-	opened = 1
+	icon_state = "crateopen"
 	},
 /obj/effect/turf_decal/delivery,
 /turf/open/floor/plasteel,
@@ -11852,8 +11848,7 @@
 /area/quartermaster/storage)
 "azA" = (
 /obj/structure/closet/crate{
-	icon_state = "crateopen";
-	opened = 1
+	icon_state = "crateopen"
 	},
 /obj/effect/spawner/lootdrop/maintenance,
 /obj/effect/turf_decal/bot,
@@ -12521,7 +12516,6 @@
 /area/engine/atmospherics_engine)
 "aBd" = (
 /obj/machinery/atmospherics/pipe/simple/orange/hidden{
-	icon_state = "intact";
 	dir = 4
 	},
 /obj/structure/sign/directions/engineering{
@@ -12533,7 +12527,6 @@
 /area/engine/atmospherics_engine)
 "aBe" = (
 /obj/machinery/atmospherics/pipe/simple/orange/hidden{
-	icon_state = "intact";
 	dir = 10
 	},
 /obj/effect/turf_decal/stripes/line{
@@ -12885,8 +12878,7 @@
 /area/quartermaster/warehouse)
 "aBN" = (
 /obj/structure/closet/crate{
-	icon_state = "crateopen";
-	opened = 1
+	icon_state = "crateopen"
 	},
 /obj/effect/spawner/lootdrop/maintenance{
 	lootcount = 2;
@@ -16688,8 +16680,7 @@
 "aJv" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/closet/crate{
-	icon_state = "crateopen";
-	opened = 1
+	icon_state = "crateopen"
 	},
 /obj/effect/spawner/lootdrop/maintenance{
 	lootcount = 2;
@@ -22164,8 +22155,7 @@
 /area/security/execution/education)
 "aUJ" = (
 /obj/structure/closet/crate{
-	icon_state = "crateopen";
-	opened = 1
+	icon_state = "crateopen"
 	},
 /obj/machinery/atmospherics/pipe/manifold/general/visible{
 	dir = 4
@@ -29173,8 +29163,7 @@
 "bjo" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/closet/crate{
-	icon_state = "crateopen";
-	opened = 1
+	icon_state = "crateopen"
 	},
 /obj/item/device/flashlight,
 /obj/effect/spawner/lootdrop/maintenance,
@@ -56882,8 +56871,7 @@
 /area/maintenance/starboard)
 "clv" = (
 /obj/structure/closet/crate{
-	icon_state = "crateopen";
-	opened = 1
+	icon_state = "crateopen"
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/item/device/flashlight,
@@ -61354,8 +61342,7 @@
 /area/maintenance/starboard)
 "cuH" = (
 /obj/structure/closet/crate{
-	icon_state = "crateopen";
-	opened = 1
+	icon_state = "crateopen"
 	},
 /obj/item/clothing/shoes/jackboots,
 /obj/item/device/radio,
@@ -63386,8 +63373,7 @@
 /area/maintenance/starboard)
 "cza" = (
 /obj/structure/closet/crate{
-	icon_state = "crateopen";
-	opened = 1
+	icon_state = "crateopen"
 	},
 /obj/effect/spawner/lootdrop/maintenance{
 	lootcount = 2;
@@ -68671,8 +68657,7 @@
 "cJM" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/closet/crate{
-	icon_state = "crateopen";
-	opened = 1
+	icon_state = "crateopen"
 	},
 /obj/item/device/flashlight,
 /obj/effect/spawner/lootdrop/maintenance,
@@ -70444,8 +70429,7 @@
 /area/science/xenobiology)
 "cNj" = (
 /obj/structure/closet/crate{
-	icon_state = "crateopen";
-	opened = 1
+	icon_state = "crateopen"
 	},
 /obj/item/device/flashlight,
 /obj/effect/spawner/lootdrop/maintenance,
@@ -90134,8 +90118,7 @@
 "dCR" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/closet/crate{
-	icon_state = "crateopen";
-	opened = 1
+	icon_state = "crateopen"
 	},
 /obj/item/device/flashlight,
 /obj/effect/spawner/lootdrop/maintenance,
@@ -94162,8 +94145,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/closet/crate{
-	icon_state = "crateopen";
-	opened = 1
+	icon_state = "crateopen"
 	},
 /obj/effect/spawner/lootdrop/maintenance{
 	lootcount = 2;
@@ -94534,8 +94516,7 @@
 "dLT" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/closet/crate{
-	icon_state = "crateopen";
-	opened = 1
+	icon_state = "crateopen"
 	},
 /obj/item/crowbar/red,
 /obj/effect/spawner/lootdrop/maintenance{
@@ -98791,8 +98772,7 @@
 "dUX" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/closet/crate{
-	icon_state = "crateopen";
-	opened = 1
+	icon_state = "crateopen"
 	},
 /obj/item/device/flashlight,
 /obj/effect/spawner/lootdrop/maintenance,
@@ -102093,7 +102073,6 @@
 /area/shuttle/escape)
 "ecg" = (
 /obj/machinery/atmospherics/components/unary/outlet_injector/on{
-	icon_state = "inje_map";
 	dir = 1
 	},
 /obj/effect/turf_decal/stripes/line,

--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -2034,8 +2034,7 @@
 /obj/item/clothing/mask/gas,
 /obj/item/clothing/mask/gas,
 /obj/structure/closet/crate{
-	icon_state = "crateopen";
-	opened = 1
+	icon_state = "crateopen"
 	},
 /obj/machinery/atmospherics/pipe/manifold/general/visible,
 /obj/item/wrench,
@@ -9684,15 +9683,13 @@
 /area/maintenance/starboard/fore)
 "auC" = (
 /obj/structure/closet/crate{
-	icon_state = "crateopen";
-	opened = 1
+	icon_state = "crateopen"
 	},
 /turf/open/floor/plating/airless,
 /area/space/nearstation)
 "auD" = (
 /obj/structure/closet/crate{
-	icon_state = "crateopen";
-	opened = 1
+	icon_state = "crateopen"
 	},
 /obj/structure/sign/warning/vacuum/external{
 	pixel_y = 32
@@ -10630,8 +10627,7 @@
 /area/security/brig)
 "awA" = (
 /obj/structure/closet/crate{
-	icon_state = "crateopen";
-	opened = 1
+	icon_state = "crateopen"
 	},
 /obj/item/storage/box/donkpockets,
 /turf/open/floor/plating,
@@ -17320,8 +17316,7 @@
 "aKw" = (
 /obj/effect/decal/cleanable/cobweb,
 /obj/structure/closet/crate{
-	icon_state = "crateopen";
-	opened = 1
+	icon_state = "crateopen"
 	},
 /obj/item/wirecutters,
 /obj/item/weldingtool,
@@ -17933,10 +17928,8 @@
 	},
 /area/hydroponics/garden)
 "aLX" = (
-/obj/machinery/door/firedoor/border_only{
-	density = 1;
+/obj/machinery/door/firedoor/border_only/closed{
 	dir = 8;
-	icon_state = "door_closed";
 	name = "Animal Pen A";
 	opacity = 1
 	},
@@ -19846,8 +19839,7 @@
 /area/quartermaster/storage)
 "aQk" = (
 /obj/structure/closet/crate{
-	icon_state = "crateopen";
-	opened = 1
+	icon_state = "crateopen"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/effect/spawner/lootdrop/maintenance{
@@ -19942,8 +19934,7 @@
 /area/quartermaster/qm)
 "aQu" = (
 /obj/structure/closet/crate{
-	icon_state = "crateopen";
-	opened = 1
+	icon_state = "crateopen"
 	},
 /obj/machinery/light{
 	dir = 8
@@ -20327,10 +20318,8 @@
 	},
 /area/hydroponics/garden)
 "aRg" = (
-/obj/machinery/door/firedoor/border_only{
-	density = 1;
+/obj/machinery/door/firedoor/border_only/closed{
 	dir = 8;
-	icon_state = "door_closed";
 	name = "Animal Pen B";
 	opacity = 1
 	},
@@ -21050,8 +21039,7 @@
 /area/maintenance/port)
 "aSP" = (
 /obj/structure/closet/crate{
-	icon_state = "crateopen";
-	opened = 1
+	icon_state = "crateopen"
 	},
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
@@ -29600,8 +29588,7 @@
 /area/quartermaster/office)
 "bks" = (
 /obj/structure/closet/crate{
-	icon_state = "crateopen";
-	opened = 1
+	icon_state = "crateopen"
 	},
 /obj/effect/spawner/lootdrop/maintenance,
 /turf/open/floor/plasteel/brown{
@@ -41146,8 +41133,7 @@
 /area/gateway)
 "bIp" = (
 /obj/structure/closet/crate{
-	icon_state = "crateopen";
-	opened = 1
+	icon_state = "crateopen"
 	},
 /obj/item/stack/sheet/rglass{
 	amount = 50
@@ -42372,8 +42358,7 @@
 /area/maintenance/port)
 "bLc" = (
 /obj/structure/closet/crate{
-	icon_state = "crateopen";
-	opened = 1
+	icon_state = "crateopen"
 	},
 /obj/effect/spawner/lootdrop/maintenance{
 	lootcount = 3;
@@ -43143,8 +43128,7 @@
 /area/maintenance/port)
 "bMG" = (
 /obj/structure/closet/crate{
-	icon_state = "crateopen";
-	opened = 1
+	icon_state = "crateopen"
 	},
 /obj/item/rack_parts,
 /obj/effect/spawner/lootdrop/maintenance,
@@ -48851,8 +48835,7 @@
 /area/maintenance/port/aft)
 "bYP" = (
 /obj/structure/closet/crate{
-	icon_state = "crateopen";
-	opened = 1
+	icon_state = "crateopen"
 	},
 /obj/item/storage/box/donkpockets,
 /obj/effect/spawner/lootdrop/maintenance,
@@ -53191,8 +53174,7 @@
 /area/maintenance/starboard)
 "chD" = (
 /obj/structure/closet/crate{
-	icon_state = "crateopen";
-	opened = 1
+	icon_state = "crateopen"
 	},
 /obj/item/cane,
 /obj/effect/spawner/lootdrop/maintenance,
@@ -55691,8 +55673,7 @@
 /area/aisat)
 "cmY" = (
 /obj/structure/closet/crate{
-	icon_state = "crateopen";
-	opened = 1
+	icon_state = "crateopen"
 	},
 /obj/effect/spawner/lootdrop/maintenance,
 /obj/effect/turf_decal/stripes/line{

--- a/_maps/map_files/Mining/Lavaland.dmm
+++ b/_maps/map_files/Mining/Lavaland.dmm
@@ -1317,8 +1317,7 @@
 /area/mine/production)
 "dL" = (
 /obj/structure/closet/crate{
-	icon_state = "crateopen";
-	opened = 1
+	icon_state = "crateopen"
 	},
 /obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel,
@@ -1772,15 +1771,13 @@
 	pixel_y = -22
 	},
 /obj/structure/closet/crate{
-	icon_state = "crateopen";
-	opened = 1
+	icon_state = "crateopen"
 	},
 /turf/open/floor/plasteel/purple/side,
 /area/mine/production)
 "eT" = (
 /obj/structure/closet/crate{
-	icon_state = "crateopen";
-	opened = 1
+	icon_state = "crateopen"
 	},
 /obj/machinery/light,
 /turf/open/floor/plasteel/brown,
@@ -1791,8 +1788,7 @@
 /area/mine/production)
 "eV" = (
 /obj/structure/closet/crate{
-	icon_state = "crateopen";
-	opened = 1
+	icon_state = "crateopen"
 	},
 /turf/open/floor/plasteel/brown{
 	dir = 6

--- a/_maps/map_files/OmegaStation/OmegaStation.dmm
+++ b/_maps/map_files/OmegaStation/OmegaStation.dmm
@@ -1717,8 +1717,7 @@
 /area/shuttle/supply)
 "adv" = (
 /obj/structure/closet/crate{
-	icon_state = "crateopen";
-	opened = 1
+	icon_state = "crateopen"
 	},
 /obj/effect/spawner/lootdrop/maintenance,
 /turf/open/floor/plating/astplate,
@@ -11620,8 +11619,7 @@
 /area/maintenance/port/fore)
 "avP" = (
 /obj/structure/closet/crate{
-	icon_state = "crateopen";
-	opened = 1
+	icon_state = "crateopen"
 	},
 /obj/item/clothing/shoes/jackboots,
 /obj/item/device/radio,
@@ -33431,8 +33429,7 @@
 /area/maintenance/starboard)
 "sCQ" = (
 /obj/structure/closet/crate{
-	icon_state = "crateopen";
-	opened = 1
+	icon_state = "crateopen"
 	},
 /obj/effect/spawner/lootdrop/maintenance{
 	lootcount = 2;

--- a/_maps/map_files/PubbyStation/PubbyStation.dmm
+++ b/_maps/map_files/PubbyStation/PubbyStation.dmm
@@ -7207,8 +7207,7 @@
 /area/crew_quarters/fitness/recreation)
 "ato" = (
 /obj/structure/closet/crate{
-	icon_state = "crateopen";
-	opened = 1
+	icon_state = "crateopen"
 	},
 /obj/effect/spawner/lootdrop/maintenance{
 	lootcount = 2;
@@ -16450,8 +16449,7 @@
 /area/quartermaster/warehouse)
 "aQf" = (
 /obj/structure/closet/crate{
-	icon_state = "crateopen";
-	opened = 1
+	icon_state = "crateopen"
 	},
 /obj/effect/spawner/lootdrop/maintenance,
 /turf/open/floor/plasteel/floorgrime,
@@ -17262,8 +17260,7 @@
 /area/maintenance/department/crew_quarters/bar)
 "aRY" = (
 /obj/structure/closet/crate{
-	icon_state = "crateopen";
-	opened = 1
+	icon_state = "crateopen"
 	},
 /obj/effect/spawner/lootdrop/maintenance,
 /turf/open/floor/plating,
@@ -19193,8 +19190,7 @@
 /area/quartermaster/storage)
 "aWz" = (
 /obj/structure/closet/crate{
-	icon_state = "crateopen";
-	opened = 1
+	icon_state = "crateopen"
 	},
 /obj/effect/spawner/lootdrop/maintenance{
 	lootcount = 2;
@@ -36440,8 +36436,7 @@
 /area/science/mineral_storeroom)
 "bLj" = (
 /obj/structure/closet/crate{
-	icon_state = "crateopen";
-	opened = 1
+	icon_state = "crateopen"
 	},
 /obj/item/storage/bag/ore,
 /obj/item/storage/bag/ore,
@@ -40161,7 +40156,6 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/purple/visible{
-	icon_state = "intact";
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -40169,14 +40163,12 @@
 "bUx" = (
 /obj/machinery/atmospherics/pipe/simple/green/visible,
 /obj/machinery/atmospherics/pipe/simple/purple/visible{
-	icon_state = "intact";
 	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos)
 "bUy" = (
 /obj/machinery/atmospherics/pipe/simple/purple/visible{
-	icon_state = "intact";
 	dir = 4
 	},
 /turf/open/floor/plasteel/yellow/side{
@@ -40187,7 +40179,6 @@
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/atmospherics/pipe/simple/cyan/visible,
 /obj/machinery/atmospherics/pipe/simple/purple/visible{
-	icon_state = "intact";
 	dir = 4
 	},
 /turf/open/floor/plating,
@@ -40195,7 +40186,6 @@
 "bUA" = (
 /obj/structure/lattice,
 /obj/machinery/atmospherics/pipe/simple/purple/visible{
-	icon_state = "intact";
 	dir = 10
 	},
 /turf/open/space,
@@ -40646,8 +40636,7 @@
 "bVB" = (
 /obj/item/book/manual/barman_recipes,
 /obj/structure/closet/crate{
-	icon_state = "crateopen";
-	opened = 1
+	icon_state = "crateopen"
 	},
 /obj/item/cigbutt,
 /obj/effect/spawner/lootdrop/maintenance,
@@ -42222,7 +42211,6 @@
 /area/maintenance/disposal/incinerator)
 "bZi" = (
 /obj/machinery/atmospherics/pipe/simple/purple/visible{
-	icon_state = "intact";
 	dir = 6
 	},
 /obj/machinery/meter,
@@ -42230,7 +42218,6 @@
 /area/maintenance/disposal/incinerator)
 "bZj" = (
 /obj/machinery/atmospherics/pipe/simple/purple/visible{
-	icon_state = "intact";
 	dir = 9
 	},
 /turf/closed/wall/r_wall,
@@ -42471,7 +42458,6 @@
 /area/maintenance/disposal/incinerator)
 "bZR" = (
 /obj/machinery/atmospherics/pipe/simple/purple/visible{
-	icon_state = "intact";
 	dir = 5
 	},
 /turf/closed/wall/r_wall,

--- a/_maps/map_files/generic/CentCom.dmm
+++ b/_maps/map_files/generic/CentCom.dmm
@@ -1079,8 +1079,7 @@
 /area/holodeck/rec_center/kobayashi)
 "dv" = (
 /obj/structure/closet{
-	density = 0;
-	opened = 1
+	density = 0
 	},
 /obj/item/clothing/suit/judgerobe,
 /obj/item/clothing/head/powdered_wig,
@@ -8981,8 +8980,7 @@
 /area/wizard_station)
 "zp" = (
 /obj/structure/closet/crate{
-	icon_state = "crateopen";
-	opened = 1
+	icon_state = "crateopen"
 	},
 /obj/item/clothing/suit/wizrobe/red,
 /obj/item/clothing/head/wizard/red,

--- a/_maps/shuttles/emergency_cere.dmm
+++ b/_maps/shuttles/emergency_cere.dmm
@@ -790,7 +790,6 @@
 /area/shuttle/escape)
 "cq" = (
 /obj/machinery/atmospherics/pipe/simple/general/visible{
-	icon_state = "intact";
 	dir = 5
 	},
 /turf/open/floor/plasteel/white,
@@ -801,7 +800,6 @@
 /area/shuttle/escape)
 "cs" = (
 /obj/machinery/atmospherics/pipe/simple/general/visible{
-	icon_state = "intact";
 	dir = 9
 	},
 /turf/open/floor/plasteel/white,

--- a/_maps/shuttles/whiteship_cere.dmm
+++ b/_maps/shuttles/whiteship_cere.dmm
@@ -215,8 +215,7 @@
 	},
 /obj/structure/closet/crate{
 	icon_state = "crateopen";
-	name = "spare equipment crate";
-	opened = 1
+	name = "spare equipment crate"
 	},
 /turf/open/floor/mineral/titanium/yellow,
 /area/shuttle/abandoned)
@@ -239,8 +238,7 @@
 	},
 /obj/structure/closet/crate{
 	icon_state = "crateopen";
-	name = "spare equipment crate";
-	opened = 1
+	name = "spare equipment crate"
 	},
 /obj/item/pickaxe,
 /obj/item/pickaxe,
@@ -289,8 +287,7 @@
 	},
 /obj/structure/closet/crate{
 	icon_state = "crateopen";
-	name = "spare equipment crate";
-	opened = 1
+	name = "spare equipment crate"
 	},
 /obj/item/storage/bag/ore,
 /obj/item/pickaxe,
@@ -411,8 +408,7 @@
 	},
 /obj/structure/closet/crate{
 	icon_state = "crateopen";
-	name = "spare equipment crate";
-	opened = 1
+	name = "spare equipment crate"
 	},
 /obj/machinery/light,
 /turf/open/floor/mineral/titanium/yellow,

--- a/_maps/shuttles/whiteship_meta.dmm
+++ b/_maps/shuttles/whiteship_meta.dmm
@@ -215,8 +215,7 @@
 /obj/item/cigbutt,
 /obj/structure/closet/crate{
 	icon_state = "crateopen";
-	name = "spare equipment crate";
-	opened = 1
+	name = "spare equipment crate"
 	},
 /obj/item/tank/internals/oxygen/red,
 /obj/item/tank/internals/air,

--- a/code/game/machinery/deployable.dm
+++ b/code/game/machinery/deployable.dm
@@ -64,12 +64,6 @@
 	material = WOOD
 	var/drop_amount = 3
 
-/obj/structure/barricade/wooden/snowed
-	name = "crude plank barricade"
-	desc = "This space is blocked off by a wooden barricade. It seems to be covered in a layer of snow."
-	icon_state = "woodenbarricade-snow"
-	max_integrity = 125
-
 /obj/structure/barricade/wooden/crude
 	name = "crude plank barricade"
 	desc = "This space is blocked off by a crude assortment of planks."

--- a/code/game/machinery/doors/firedoor.dm
+++ b/code/game/machinery/doors/firedoor.dm
@@ -210,6 +210,11 @@
 	flags_1 = ON_BORDER_1
 	CanAtmosPass = ATMOS_PASS_PROC
 
+/obj/machinery/door/firedoor/border_only/closed
+	icon_state = "door_closed"
+	opacity = TRUE
+	density = TRUE
+
 /obj/machinery/door/firedoor/border_only/CanPass(atom/movable/mover, turf/target)
 	if(istype(mover) && (mover.pass_flags & PASSGLASS))
 		return 1

--- a/code/game/objects/structures/crates_lockers/crates.dm
+++ b/code/game/objects/structures/crates_lockers/crates.dm
@@ -17,6 +17,8 @@
 
 /obj/structure/closet/crate/New()
 	..()
+	if(icon_state == "[initial(icon_state)]open")
+		opened = TRUE
 	update_icon()
 
 /obj/structure/closet/crate/CanPass(atom/movable/mover, turf/target)

--- a/code/game/turfs/simulated/floor/fancy_floor.dm
+++ b/code/game/turfs/simulated/floor/fancy_floor.dm
@@ -182,11 +182,11 @@
 			A.narsie_act()
 
 /turf/open/floor/carpet/break_tile()
-	broken = 1
+	broken = TRUE
 	update_icon()
 
 /turf/open/floor/carpet/burn_tile()
-	burnt = 1
+	burnt = TRUE
 	update_icon()
 
 /turf/open/floor/carpet/get_smooth_underlay_icon(mutable_appearance/underlay_appearance, turf/asking_turf, adjacency_dir)

--- a/code/game/turfs/simulated/floor/plating/asteroid.dm
+++ b/code/game/turfs/simulated/floor/plating/asteroid.dm
@@ -290,16 +290,16 @@
 	flags_1 = NONE
 	planetary_atmos = TRUE
 	archdrops = list(/obj/item/stack/sheet/mineral/snow = 5)
+	burnt_states = list("snow_dug")
 
 /turf/open/floor/plating/asteroid/snow/burn_tile()
-	var/flammened = FALSE
-	if(!flammened)
+	if(!burnt)
 		visible_message("<span class='danger'>[src] melts away!.</span>")
 		slowdown = 0
-		flammened = TRUE
+		burnt = TRUE
 		icon_state = "snow_dug"
-	else
-		return FALSE
+		return TRUE
+	return FALSE
 
 /turf/open/floor/plating/asteroid/snow/ice
 	name = "icey snow"

--- a/code/modules/awaymissions/mission_code/snowdin.dm
+++ b/code/modules/awaymissions/mission_code/snowdin.dm
@@ -149,6 +149,16 @@
 
 //liquid plasma!!!!!!//
 
+/turf/open/floor/plasteel/vault/snowdin
+	initial_gas_mix = "o2=22;n2=82;TEMP=180"
+	planetary_atmos = 1
+	temperature = 180
+
+/turf/open/floor/plasteel/dark/snowdin
+	initial_gas_mix = "o2=22;n2=82;TEMP=180"
+	planetary_atmos = 1
+	temperature = 180
+
 /turf/open/lava/plasma
 	name = "liquid plasma"
 	desc = "A flowing stream of chilled liquid plasma. You probably shouldn't get in."
@@ -539,6 +549,12 @@
 				)
 
 //special items//--
+
+/obj/structure/barricade/wooden/snowed
+	name = "crude plank barricade"
+	desc = "This space is blocked off by a wooden barricade. It seems to be covered in a layer of snow."
+	icon_state = "woodenbarricade-snow"
+	max_integrity = 125
 
 /obj/item/clothing/under/syndicate/coldres
 	name = "insulated tactical turtleneck"


### PR DESCRIPTION
Fixes some icons not representing the actual states of an item on maps (damaged plating, open crates, ect.)
Cleans up some dirty vars

`opened` var for `/obj/structure/closet/crate` will now be generated off the icon_state for maps.