### PR TITLE
Add halite mining types

### DIFF
--- a/code/game/turfs/simulated/minerals.dm
+++ b/code/game/turfs/simulated/minerals.dm
@@ -370,6 +370,28 @@
 	initial_gas_mix = LAVALAND_DEFAULT_ATMOS
 	defer_change = 1
 
+/turf/closed/mineral/halite
+	mineralType = /obj/effect/decal/cleanable/salt //or /obj/effect/decal/cleanable/ash with salt in. Unsure
+	spreadChance = 0
+	spread = 0
+	scan_state = "rock_Diamond" //salt guaranteed :^)
+
+/turf/closed/mineral/halite/volcanic
+	environment_type = "basalt"
+	turf_type = /turf/open/floor/plating/asteroid/basalt/lava_land_surface
+	baseturfs = /turf/open/floor/plating/asteroid/basalt/lava_land_surface
+	initial_gas_mix = LAVALAND_DEFAULT_ATMOS
+	defer_change = 1
+
+/turf/closed/mineral/halite/ice
+	environment_type = "snow_cavern"
+	icon_state = "icerock_diamond"
+	smooth_icon = 'icons/turf/walls/icerock_wall.dmi'
+	turf_type = /turf/open/floor/plating/asteroid/snow/ice
+	baseturfs = /turf/open/floor/plating/asteroid/snow/ice
+	initial_gas_mix = "o2=22;n2=82;TEMP=180"
+	defer_change = TRUE
+
 
 /turf/closed/mineral/volcanic
 	environment_type = "basalt"


### PR DESCRIPTION
Halite, commonly known as rock salt, is a type of salt, the mineral (natural) form of sodium chloride (NaCl).

:cl:
add: Miners may now find rock salt among other mineral wealth.
/:cl:

Proposing to add rock salt (sodium chloride) types to the mineral turfs. They will yield salt piles and/or white, salt-yielding ash piles.

More is needed but my battery is close to dying.

Also I want to know if anyone truly hates this idea.