### PR TITLE
Fixes crushed sodacans not giving aluminium

### DIFF
--- a/code/game/objects/items/trash.dm
+++ b/code/game/objects/items/trash.dm
@@ -66,7 +66,7 @@
 	name = "crushed can"
 	icon_state = "cola"
 	resistance_flags = NONE
-	grind_results = list("aluminum" = 10)
+	grind_results = list("aluminium" = 10)
 
 /obj/item/trash/attack(mob/M, mob/living/user)
 	return


### PR DESCRIPTION

fix: (hopefully) fixed crushed soda cans not being ground into aluminum in a grinder

why: Ghetto Chemistry has been in the code for a while, and its a shame that it doesn't work because of spelling mistakes.

(this is my first PR, so please tell me if I messed something up)