### PR TITLE
Removes grind_results from empty soda cans

### DIFF
--- a/code/modules/food_and_drinks/drinks/drinks.dm
+++ b/code/modules/food_and_drinks/drinks/drinks.dm
@@ -394,7 +394,7 @@
 	container_type = NONE
 	spillable = FALSE
 	isGlass = FALSE
-	grind_results = list("aluminum" = 10)
+	grind_results = list("aluminium" = 10)
 	
 /obj/item/reagent_containers/food/drinks/soda_cans/suicide_act(mob/living/carbon/user)
 	user.visible_message("<span class='suicide'>[user] is trying to eat \the [src]! It looks like [user.p_theyre()] trying to commit suicide!</span>")

--- a/code/modules/food_and_drinks/drinks/drinks.dm
+++ b/code/modules/food_and_drinks/drinks/drinks.dm
@@ -394,7 +394,6 @@
 	container_type = NONE
 	spillable = FALSE
 	isGlass = FALSE
-	grind_results = list("aluminium" = 10)
 	
 /obj/item/reagent_containers/food/drinks/soda_cans/suicide_act(mob/living/carbon/user)
 	user.visible_message("<span class='suicide'>[user] is trying to eat \the [src]! It looks like [user.p_theyre()] trying to commit suicide!</span>")


### PR DESCRIPTION
:cl: Denton
code: Removes grind_results from empty soda cans since they can't be ground.
/:cl:

Empty (non-crushed) soda cans count as containers and can't be ground. No reason for them to have grind_results.