### PR TITLE
[s] Fixes altclick exploits

### DIFF
--- a/code/_onclick/ai.dm
+++ b/code/_onclick/ai.dm
@@ -176,6 +176,10 @@
 	toggle_on()
 	add_fingerprint(usr)
 
+/* Holopads */
+/obj/machinery/holopad/AIAltClick(mob/living/silicon/ai/user)
+	hangup_all_calls()
+
 //
 // Override TurfAdjacent for AltClicking
 //

--- a/code/datums/components/material_container.dm
+++ b/code/datums/components/material_container.dm
@@ -78,7 +78,7 @@
 		requested_amount = input(user, "How much do you want to insert?", "Inserting [S.singular_name]s") as num|null
 		if(isnull(requested_amount) || (requested_amount <= 0))
 			return
-		if(QDELETED(I) || QDELETED(user) || QDELETED(src) || parent != current_parent || !user.canUseTopic(current_parent) || !user.is_holding(I) || !user.Adjacent(current_parent))
+		if(QDELETED(I) || QDELETED(user) || QDELETED(src) || parent != current_parent || !user.canUseTopic(current_parent, BE_CLOSE) || !user.is_holding(I))
 			return
 	if(!user.temporarilyRemoveItemFromInventory(I))
 		to_chat(user, "<span class='warning'>[I] is stuck to you and cannot be placed into [parent].</span>")

--- a/code/datums/components/rotation.dm
+++ b/code/datums/components/rotation.dm
@@ -89,7 +89,7 @@
 	after_rotation.Invoke(user,rotation_type)
 
 /datum/component/simple_rotation/proc/default_can_user_rotate(mob/living/user, rotation_type)
-	if(!istype(user) || !user.canUseTopic(src, be_close=TRUE, no_dextery=TRUE))
+	if(!istype(user) || !user.canUseTopic(src, BE_CLOSE, NO_DEXTERY))
 		to_chat(user, "<span class='warning'>You can't do that right now!</span>")
 		return FALSE
 	return TRUE

--- a/code/datums/components/rotation.dm
+++ b/code/datums/components/rotation.dm
@@ -12,11 +12,11 @@
 	
 	var/rotation_flags = NONE
 	var/default_rotation_direction = ROTATION_CLOCKWISE
-	
+
 /datum/component/simple_rotation/Initialize(rotation_flags = NONE ,can_user_rotate,can_be_rotated,after_rotation)
 	if(!ismovableatom(parent))
 		return COMPONENT_INCOMPATIBLE
-	
+
 	//throw if no rotation direction is specificed ?
 
 	src.rotation_flags = rotation_flags
@@ -25,7 +25,7 @@
 		src.can_user_rotate = can_user_rotate
 	else
 		src.can_user_rotate = CALLBACK(src,.proc/default_can_user_rotate)
-	
+
 	if(can_be_rotated)
 		src.can_be_rotated = can_be_rotated
 	else
@@ -89,7 +89,7 @@
 	after_rotation.Invoke(user,rotation_type)
 
 /datum/component/simple_rotation/proc/default_can_user_rotate(mob/living/user, rotation_type)
-	if(!istype(user) || !user.Adjacent(parent) || user.incapacitated())
+	if(!istype(user) || !user.canUseTopic(src, be_close=TRUE, no_dextery=TRUE))
 		to_chat(user, "<span class='warning'>You can't do that right now!</span>")
 		return FALSE
 	return TRUE

--- a/code/datums/components/rotation.dm
+++ b/code/datums/components/rotation.dm
@@ -89,7 +89,7 @@
 	after_rotation.Invoke(user,rotation_type)
 
 /datum/component/simple_rotation/proc/default_can_user_rotate(mob/living/user, rotation_type)
-	if(!istype(user) || !user.canUseTopic(src, BE_CLOSE, NO_DEXTERY))
+	if(!istype(user) || !user.canUseTopic(parent, BE_CLOSE, NO_DEXTERY))
 		to_chat(user, "<span class='warning'>You can't do that right now!</span>")
 		return FALSE
 	return TRUE

--- a/code/game/machinery/computer/apc_control.dm
+++ b/code/game/machinery/computer/apc_control.dm
@@ -94,7 +94,7 @@
 /obj/machinery/computer/apc_control/Topic(href, href_list)
 	if(..())
 		return
-	if(!usr || !usr.canUseTopic(src) || usr.incapacitated() || stat || QDELETED(src))
+	if(!usr || !usr.canUseTopic(src) || stat || QDELETED(src))
 		return
 	if(href_list["authenticate"])
 		var/obj/item/card/id/ID = usr.get_active_held_item()

--- a/code/game/machinery/computer/buildandrepair.dm
+++ b/code/game/machinery/computer/buildandrepair.dm
@@ -134,7 +134,7 @@
 
 /obj/structure/frame/computer/AltClick(mob/user)
 	..()
-	if(!in_range(src, user) || !isliving(user) || user.incapacitated())
+	if(!isliving(user) || !user.canUseTopic(src, be_close=TRUE, no_dextery=TRUE))
 		return
 
 	if(anchored)

--- a/code/game/machinery/computer/buildandrepair.dm
+++ b/code/game/machinery/computer/buildandrepair.dm
@@ -134,7 +134,7 @@
 
 /obj/structure/frame/computer/AltClick(mob/user)
 	..()
-	if(!isliving(user) || !user.canUseTopic(src, be_close=TRUE, no_dextery=TRUE))
+	if(!isliving(user) || !user.canUseTopic(src, BE_CLOSE, NO_DEXTERY))
 		return
 
 	if(anchored)

--- a/code/game/machinery/computer/buildandrepair.dm
+++ b/code/game/machinery/computer/buildandrepair.dm
@@ -134,7 +134,7 @@
 
 /obj/structure/frame/computer/AltClick(mob/user)
 	..()
-	if(!isliving(user) || !user.canUseTopic(src, BE_CLOSE, NO_DEXTERY))
+	if(!isliving(user) || !user.canUseTopic(src, BE_CLOSE, ismonkey(user)))
 		return
 
 	if(anchored)

--- a/code/game/machinery/defibrillator_mount.dm
+++ b/code/game/machinery/defibrillator_mount.dm
@@ -119,7 +119,7 @@
 	return TRUE
 
 /obj/machinery/defibrillator_mount/AltClick(mob/living/user)
-	if(!istype(user) || !user.canUseTopic(src, be_close=TRUE))
+	if(!istype(user) || !user.canUseTopic(src, BE_CLOSE))
 		return
 	if(!defib)
 		to_chat(user, "<span class='warning'>It'd be hard to remove a defib unit from a mount that has none.</span>")

--- a/code/game/machinery/defibrillator_mount.dm
+++ b/code/game/machinery/defibrillator_mount.dm
@@ -118,7 +118,7 @@
 	update_icon()
 	return TRUE
 
-/obj/machinery/defibrillator_mount/AltClick(mob/living/user)
+/obj/machinery/defibrillator_mount/AltClick(mob/living/carbon/user)
 	if(!istype(user) || !user.canUseTopic(src, BE_CLOSE))
 		return
 	if(!defib)

--- a/code/game/machinery/defibrillator_mount.dm
+++ b/code/game/machinery/defibrillator_mount.dm
@@ -119,7 +119,7 @@
 	return TRUE
 
 /obj/machinery/defibrillator_mount/AltClick(mob/living/user)
-	if(!user.Adjacent(src) || !istype(user))
+	if(!istype(user) || !user.canUseTopic(src, be_close=TRUE))
 		return
 	if(!defib)
 		to_chat(user, "<span class='warning'>It'd be hard to remove a defib unit from a mount that has none.</span>")

--- a/code/game/machinery/deployable.dm
+++ b/code/game/machinery/deployable.dm
@@ -142,7 +142,7 @@
 	to_chat(user, "<span class='notice'>Alt-click to toggle modes.</span>")
 
 /obj/item/grenade/barrier/AltClick(mob/living/user)
-	if(!istype(user) || !user.canUseTopic(src, be_close=TRUE))
+	if(!istype(user) || !user.canUseTopic(src, BE_CLOSE))
 		return
 	toggle_mode(user)
 

--- a/code/game/machinery/deployable.dm
+++ b/code/game/machinery/deployable.dm
@@ -141,7 +141,7 @@
 	..()
 	to_chat(user, "<span class='notice'>Alt-click to toggle modes.</span>")
 
-/obj/item/grenade/barrier/AltClick(mob/living/user)
+/obj/item/grenade/barrier/AltClick(mob/living/carbon/user)
 	if(!istype(user) || !user.canUseTopic(src, BE_CLOSE))
 		return
 	toggle_mode(user)

--- a/code/game/machinery/deployable.dm
+++ b/code/game/machinery/deployable.dm
@@ -142,7 +142,7 @@
 	to_chat(user, "<span class='notice'>Alt-click to toggle modes.</span>")
 
 /obj/item/grenade/barrier/AltClick(mob/living/user)
-	if(!istype(user) || user.incapacitated())
+	if(!istype(user) || !user.canUseTopic(src, be_close=TRUE))
 		return
 	toggle_mode(user)
 

--- a/code/game/machinery/hologram.dm
+++ b/code/game/machinery/hologram.dm
@@ -137,10 +137,6 @@ Possible to do for anyone motivated enough:
 
 	return ..()
 
-/obj/machinery/holopad/AltClick(mob/living/carbon/human/user)
-	if(isAI(user) && user.canUseTopic(src))
-		hangup_all_calls()
-		return
 
 /obj/machinery/holopad/interact(mob/living/carbon/human/user) //Carn: Hologram requests.
 	if(!istype(user))

--- a/code/game/machinery/hologram.dm
+++ b/code/game/machinery/hologram.dm
@@ -138,7 +138,7 @@ Possible to do for anyone motivated enough:
 	return ..()
 
 /obj/machinery/holopad/AltClick(mob/living/carbon/human/user)
-	if(isAI(user))
+	if(isAI(user) && user.canUseTopic(src))
 		hangup_all_calls()
 		return
 

--- a/code/game/machinery/launch_pad.dm
+++ b/code/game/machinery/launch_pad.dm
@@ -168,10 +168,10 @@
 
 /obj/machinery/launchpad/briefcase/MouseDrop(over_object, src_location, over_location)
 	. = ..()
-	if(over_object == usr && Adjacent(usr))
+	if(over_object == usr)
 		if(!briefcase || !usr.can_hold_items())
 			return
-		if(usr.incapacitated())
+		if(!usr.canUseTopic(src, BE_CLOSE, ismonkey(usr)))
 			to_chat(usr, "<span class='warning'>You can't do that right now!</span>")
 			return
 		usr.visible_message("<span class='notice'>[usr] starts closing [src]...</span>", "<span class='notice'>You start closing [src]...</span>")

--- a/code/game/mecha/mecha_actions.dm
+++ b/code/game/mecha/mecha_actions.dm
@@ -138,7 +138,7 @@
 	chassis.toggle_strafe()
 
 /obj/mecha/AltClick(mob/living/user)
-	if(user == occupant)
+	if((user == occupant) && user.canUseTopic(src))
 		toggle_strafe()
 
 /obj/mecha/proc/toggle_strafe()

--- a/code/game/objects/items/cards_ids.dm
+++ b/code/game/objects/items/cards_ids.dm
@@ -117,6 +117,7 @@
 		user.visible_message("<span class='notice'>[user] shows you: [icon2html(src, viewers(user))] [src.name].</span>", \
 					"<span class='notice'>You show \the [src.name].</span>")
 		add_fingerprint(user)
+		return
 
 /obj/item/card/id/examine(mob/user)
 	..()

--- a/code/game/objects/items/cards_ids.dm
+++ b/code/game/objects/items/cards_ids.dm
@@ -116,7 +116,7 @@
 	if(Adjacent(user))
 		user.visible_message("<span class='notice'>[user] shows you: [icon2html(src, viewers(user))] [src.name].</span>", \
 					"<span class='notice'>You show \the [src.name].</span>")
-		src.add_fingerprint(user)
+		add_fingerprint(user)
 
 /obj/item/card/id/examine(mob/user)
 	..()

--- a/code/game/objects/items/cards_ids.dm
+++ b/code/game/objects/items/cards_ids.dm
@@ -113,10 +113,10 @@
 				update_label()
 
 /obj/item/card/id/attack_self(mob/user)
-	user.visible_message("<span class='notice'>[user] shows you: [icon2html(src, viewers(user))] [src.name].</span>", \
+	if(Adjacent(user))
+		user.visible_message("<span class='notice'>[user] shows you: [icon2html(src, viewers(user))] [src.name].</span>", \
 					"<span class='notice'>You show \the [src.name].</span>")
-	src.add_fingerprint(user)
-	return
+		src.add_fingerprint(user)
 
 /obj/item/card/id/examine(mob/user)
 	..()

--- a/code/game/objects/items/crayons.dm
+++ b/code/game/objects/items/crayons.dm
@@ -145,7 +145,7 @@
 		ui.open()
 
 /obj/item/toy/crayon/spraycan/AltClick(mob/user)
-	if(user.canUseTopic(src, BE_CLOSE, NO_DEXTERY))
+	if(user.canUseTopic(src, BE_CLOSE, ismonkey(user)))
 		if(has_cap)
 			is_capped = !is_capped
 			to_chat(user, "<span class='notice'>The cap on [src] is now [is_capped ? "on" : "off"].</span>")

--- a/code/game/objects/items/crayons.dm
+++ b/code/game/objects/items/crayons.dm
@@ -145,7 +145,7 @@
 		ui.open()
 
 /obj/item/toy/crayon/spraycan/AltClick(mob/user)
-	if(user.canUseTopic(src, BE_CLOSE))
+	if(user.canUseTopic(src, BE_CLOSE, NO_DEXTERY))
 		if(has_cap)
 			is_capped = !is_capped
 			to_chat(user, "<span class='notice'>The cap on [src] is now [is_capped ? "on" : "off"].</span>")

--- a/code/game/objects/items/crayons.dm
+++ b/code/game/objects/items/crayons.dm
@@ -145,7 +145,7 @@
 		ui.open()
 
 /obj/item/toy/crayon/spraycan/AltClick(mob/user)
-	if(user.canUseTopic(src, be_close=TRUE))
+	if(user.canUseTopic(src, BE_CLOSE))
 		if(has_cap)
 			is_capped = !is_capped
 			to_chat(user, "<span class='notice'>The cap on [src] is now [is_capped ? "on" : "off"].</span>")

--- a/code/game/objects/items/devices/geiger_counter.dm
+++ b/code/game/objects/items/devices/geiger_counter.dm
@@ -183,7 +183,7 @@
 		return ..()
 
 /obj/item/device/geiger_counter/AltClick(mob/living/user)
-	if(!istype(user) || user.incapacitated())
+	if(!istype(user) || !user.canUseTopic(src, be_close=TRUE))
 		return ..()
 	if(!scanning)
 		to_chat(usr, "<span class='warning'>[src] must be on to reset its radiation level!</span>")

--- a/code/game/objects/items/devices/geiger_counter.dm
+++ b/code/game/objects/items/devices/geiger_counter.dm
@@ -183,7 +183,7 @@
 		return ..()
 
 /obj/item/device/geiger_counter/AltClick(mob/living/user)
-	if(!istype(user) || !user.canUseTopic(src, be_close=TRUE))
+	if(!istype(user) || !user.canUseTopic(src, BE_CLOSE))
 		return ..()
 	if(!scanning)
 		to_chat(usr, "<span class='warning'>[src] must be on to reset its radiation level!</span>")

--- a/code/game/objects/items/devices/gps.dm
+++ b/code/game/objects/items/devices/gps.dm
@@ -41,12 +41,12 @@ GLOBAL_LIST_EMPTY(GPS_list)
 	add_overlay("working")
 
 /obj/item/device/gps/AltClick(mob/user)
-	if(!user.canUseTopic(src, be_close=TRUE))
+	if(!user.canUseTopic(src, BE_CLOSE))
 		return
 	toggletracking(user)
 
 /obj/item/device/gps/proc/toggletracking(mob/user)
-	if(!user.canUseTopic(src, be_close=TRUE))
+	if(!user.canUseTopic(src, BE_CLOSE))
 		return //user not valid to use gps
 	if(emped)
 		to_chat(user, "It's busted!")

--- a/code/game/objects/items/devices/gps.dm
+++ b/code/game/objects/items/devices/gps.dm
@@ -41,6 +41,8 @@ GLOBAL_LIST_EMPTY(GPS_list)
 	add_overlay("working")
 
 /obj/item/device/gps/AltClick(mob/user)
+	if(!user.canUseTopic(src, be_close=TRUE))
+		return
 	toggletracking(user)
 
 /obj/item/device/gps/proc/toggletracking(mob/user)

--- a/code/game/objects/items/extinguisher.dm
+++ b/code/game/objects/items/extinguisher.dm
@@ -191,7 +191,7 @@
 		return ..()
 
 /obj/item/extinguisher/AltClick(mob/user)
-	if(!user.canUseTopic(src, BE_CLOSE))
+	if(!user.canUseTopic(src, BE_CLOSE, ismonkey(user)))
 		return
 	EmptyExtinguisher(user)
 

--- a/code/game/objects/items/extinguisher.dm
+++ b/code/game/objects/items/extinguisher.dm
@@ -191,6 +191,8 @@
 		return ..()
 
 /obj/item/extinguisher/AltClick(mob/user)
+	if(!user.canUseTopic(src, be_close=TRUE))
+		return
 	EmptyExtinguisher(user)
 
 /obj/item/extinguisher/proc/EmptyExtinguisher(var/mob/user)

--- a/code/game/objects/items/extinguisher.dm
+++ b/code/game/objects/items/extinguisher.dm
@@ -191,7 +191,7 @@
 		return ..()
 
 /obj/item/extinguisher/AltClick(mob/user)
-	if(!user.canUseTopic(src, be_close=TRUE))
+	if(!user.canUseTopic(src, BE_CLOSE))
 		return
 	EmptyExtinguisher(user)
 

--- a/code/game/objects/items/flamethrower.dm
+++ b/code/game/objects/items/flamethrower.dm
@@ -135,7 +135,7 @@
 	toggle_igniter(user)
 
 /obj/item/flamethrower/AltClick(mob/user)
-	if(ptank && isliving(user) && user.canUseTopic(src, BE_CLOSE))
+	if(ptank && isliving(user) && user.canUseTopic(src, BE_CLOSE, ismonkey(user)))
 		user.put_in_hands(ptank)
 		ptank = null
 		to_chat(user, "<span class='notice'>You remove the plasma tank from [src]!</span>")

--- a/code/game/objects/items/flamethrower.dm
+++ b/code/game/objects/items/flamethrower.dm
@@ -135,7 +135,7 @@
 	toggle_igniter(user)
 
 /obj/item/flamethrower/AltClick(mob/user)
-	if(ptank && isliving(user) && user.canUseTopic(src, be_close=TRUE))
+	if(ptank && isliving(user) && user.canUseTopic(src, BE_CLOSE))
 		user.put_in_hands(ptank)
 		ptank = null
 		to_chat(user, "<span class='notice'>You remove the plasma tank from [src]!</span>")

--- a/code/game/objects/items/flamethrower.dm
+++ b/code/game/objects/items/flamethrower.dm
@@ -135,7 +135,7 @@
 	toggle_igniter(user)
 
 /obj/item/flamethrower/AltClick(mob/user)
-	if(ptank && isliving(user) && !user.incapacitated() && Adjacent(user))
+	if(ptank && isliving(user) && user.canUseTopic(src, be_close=TRUE))
 		user.put_in_hands(ptank)
 		ptank = null
 		to_chat(user, "<span class='notice'>You remove the plasma tank from [src]!</span>")

--- a/code/game/objects/items/pet_carrier.dm
+++ b/code/game/objects/items/pet_carrier.dm
@@ -151,7 +151,7 @@
 		add_overlay("[locked ? "" : "un"]locked")
 
 /obj/item/pet_carrier/MouseDrop(atom/over_atom)
-	if(isopenturf(over_atom) && usr.Adjacent(over_atom) && open && occupants.len)
+	if(isopenturf(over_atom) && usr.canUseTopic(src, BE_CLOSE, ismonkey(usr)) && usr.Adjacent(over_atom) && open && occupants.len)
 		usr.visible_message("<span class='notice'>[usr] unloads [src].</span>", \
 		"<span class='notice'>You unload [src] onto [over_atom].</span>")
 		for(var/V in occupants)

--- a/code/game/objects/items/pet_carrier.dm
+++ b/code/game/objects/items/pet_carrier.dm
@@ -70,7 +70,7 @@
 	update_icon()
 
 /obj/item/pet_carrier/AltClick(mob/living/user)
-	if(open || !user.canUseTopic(src, be_close=TRUE))
+	if(open || !user.canUseTopic(src, BE_CLOSE))
 		return
 	locked = !locked
 	to_chat(user, "<span class='notice'>You flip the lock switch [locked ? "down" : "up"].</span>")

--- a/code/game/objects/items/stacks/stack.dm
+++ b/code/game/objects/items/stacks/stack.dm
@@ -324,9 +324,7 @@
 		..()
 
 /obj/item/stack/AltClick(mob/living/user)
-	if(!istype(user) || !user.canUseTopic(src))
-		return
-	if(!in_range(src, user))
+	if(!istype(user) || !user.canUseTopic(src, BE_CLOSE, NO_DEXTERY))
 		return
 	if(is_cyborg)
 		return
@@ -337,7 +335,7 @@
 		var/min = 0
 		var/max = get_amount()
 		var/stackmaterial = round(input(user,"How many sheets do you wish to take out of this stack? (Maximum  [max])") as num)
-		if(stackmaterial == null || stackmaterial <= min || stackmaterial >= get_amount() || !user.canUseTopic(src))
+		if(stackmaterial == null || stackmaterial <= min || stackmaterial >= get_amount() || !user.canUseTopic(src, BE_CLOSE, NO_DEXTERY))
 			return
 		else
 			change_stack(user,stackmaterial)

--- a/code/game/objects/items/stacks/stack.dm
+++ b/code/game/objects/items/stacks/stack.dm
@@ -325,7 +325,6 @@
 
 /obj/item/stack/AltClick(mob/living/user)
 	if(!istype(user) || !user.canUseTopic(src))
-		to_chat(user, "<span class='warning'>You can't do that right now!</span>")
 		return
 	if(!in_range(src, user))
 		return

--- a/code/game/objects/items/stacks/stack.dm
+++ b/code/game/objects/items/stacks/stack.dm
@@ -324,7 +324,7 @@
 		..()
 
 /obj/item/stack/AltClick(mob/living/user)
-	if(!istype(user) || !user.canUseTopic(src, BE_CLOSE, NO_DEXTERY))
+	if(!istype(user) || !user.canUseTopic(src, BE_CLOSE, ismonkey(user)))
 		return
 	if(is_cyborg)
 		return
@@ -335,7 +335,7 @@
 		var/min = 0
 		var/max = get_amount()
 		var/stackmaterial = round(input(user,"How many sheets do you wish to take out of this stack? (Maximum  [max])") as num)
-		if(stackmaterial == null || stackmaterial <= min || stackmaterial >= get_amount() || !user.canUseTopic(src, BE_CLOSE, NO_DEXTERY))
+		if(stackmaterial == null || stackmaterial <= min || stackmaterial >= get_amount() || !user.canUseTopic(src, BE_CLOSE, ismonkey(user)))
 			return
 		else
 			change_stack(user,stackmaterial)

--- a/code/game/objects/items/storage/belt.dm
+++ b/code/game/objects/items/storage/belt.dm
@@ -509,7 +509,7 @@
 		to_chat(user, "<span class='notice'>Alt-click it to quickly draw the blade.</span>")
 
 /obj/item/storage/belt/sabre/AltClick(mob/user)
-	if(!ishuman(user) || !user.canUseTopic(src, BE_CLOSE))
+	if(!iscarbon(user) || !user.canUseTopic(src, BE_CLOSE, ismonkey(user)))
 		return
 	if(contents.len)
 		var/obj/item/I = contents[1]

--- a/code/game/objects/items/storage/belt.dm
+++ b/code/game/objects/items/storage/belt.dm
@@ -509,7 +509,7 @@
 		to_chat(user, "<span class='notice'>Alt-click it to quickly draw the blade.</span>")
 
 /obj/item/storage/belt/sabre/AltClick(mob/user)
-	if(!ishuman(user) || !user.canUseTopic(src, be_close=TRUE))
+	if(!ishuman(user) || !user.canUseTopic(src, BE_CLOSE))
 		return
 	if(contents.len)
 		var/obj/item/I = contents[1]

--- a/code/game/objects/items/storage/fancy.dm
+++ b/code/game/objects/items/storage/fancy.dm
@@ -130,7 +130,7 @@
 	to_chat(user, "<span class='notice'>Alt-click to extract contents.</span>")
 
 /obj/item/storage/fancy/cigarettes/AltClick(mob/user)
-	if(!user.canUseTopic(src, be_close=TRUE))
+	if(!user.canUseTopic(src, BE_CLOSE))
 		return
 	var/obj/item/clothing/mask/cigarette/W = locate(/obj/item/clothing/mask/cigarette) in contents
 	if(W && contents.len > 0)

--- a/code/game/objects/items/storage/fancy.dm
+++ b/code/game/objects/items/storage/fancy.dm
@@ -130,7 +130,7 @@
 	to_chat(user, "<span class='notice'>Alt-click to extract contents.</span>")
 
 /obj/item/storage/fancy/cigarettes/AltClick(mob/user)
-	if(user.stat || user.restrained())
+	if(!user.canUseTopic(src, be_close=TRUE))
 		return
 	var/obj/item/clothing/mask/cigarette/W = locate(/obj/item/clothing/mask/cigarette) in contents
 	if(W && contents.len > 0)

--- a/code/game/objects/items/storage/fancy.dm
+++ b/code/game/objects/items/storage/fancy.dm
@@ -129,8 +129,8 @@
 	..()
 	to_chat(user, "<span class='notice'>Alt-click to extract contents.</span>")
 
-/obj/item/storage/fancy/cigarettes/AltClick(mob/user)
-	if(!user.canUseTopic(src, BE_CLOSE))
+/obj/item/storage/fancy/cigarettes/AltClick(mob/living/carbon/user)
+	if(!istype(user) || !user.canUseTopic(src, BE_CLOSE, NO_DEXTERY))
 		return
 	var/obj/item/clothing/mask/cigarette/W = locate(/obj/item/clothing/mask/cigarette) in contents
 	if(W && contents.len > 0)

--- a/code/game/objects/items/storage/fancy.dm
+++ b/code/game/objects/items/storage/fancy.dm
@@ -130,7 +130,7 @@
 	to_chat(user, "<span class='notice'>Alt-click to extract contents.</span>")
 
 /obj/item/storage/fancy/cigarettes/AltClick(mob/living/carbon/user)
-	if(!istype(user) || !user.canUseTopic(src, BE_CLOSE, NO_DEXTERY))
+	if(!istype(user) || !user.canUseTopic(src, BE_CLOSE, ismonkey(user)))
 		return
 	var/obj/item/clothing/mask/cigarette/W = locate(/obj/item/clothing/mask/cigarette) in contents
 	if(W && contents.len > 0)

--- a/code/game/objects/items/storage/lockbox.dm
+++ b/code/game/objects/items/storage/lockbox.dm
@@ -129,7 +129,7 @@
 		to_chat(user, "<span class='notice'>Alt-click to [open ? "close":"open"] it.</span>")
 
 /obj/item/storage/lockbox/medal/AltClick(mob/user)
-	if(user.canUseTopic(src, be_close=TRUE))
+	if(user.canUseTopic(src, BE_CLOSE))
 		if(!locked)
 			open = (open ? FALSE : TRUE)
 			update_icon()

--- a/code/game/objects/items/toys.dm
+++ b/code/game/objects/items/toys.dm
@@ -856,7 +856,7 @@
 	set name = "Flip Card"
 	set category = "Object"
 	set src in range(1)
-	if(usr.stat || !ishuman(usr) || !usr.canmove || usr.restrained())
+	if(!ishuman(usr) || !usr.canUseTopic(src, BE_CLOSE))
 		return
 	if(!flipped)
 		src.flipped = 1

--- a/code/game/objects/items/twohanded.dm
+++ b/code/game/objects/items/twohanded.dm
@@ -516,7 +516,7 @@
 			qdel(src)
 
 /obj/item/twohanded/spear/AltClick(mob/user)
-	if(user.canUseTopic(src, be_close=TRUE))
+	if(user.canUseTopic(src, BE_CLOSE))
 		..()
 		if(!explosive)
 			return

--- a/code/game/objects/structures/beds_chairs/bed.dm
+++ b/code/game/objects/structures/beds_chairs/bed.dm
@@ -78,12 +78,9 @@
 /obj/structure/bed/roller/MouseDrop(over_object, src_location, over_location)
 	. = ..()
 	if(over_object == usr && Adjacent(usr))
-		if(!ishuman(usr))
+		if(!ishuman(usr) || !usr.canUseTopic(src, BE_CLOSE))
 			return 0
 		if(has_buckled_mobs())
-			return 0
-		if(usr.incapacitated())
-			to_chat(usr, "<span class='warning'>You can't do that right now!</span>")
 			return 0
 		usr.visible_message("[usr] collapses \the [src.name].", "<span class='notice'>You collapse \the [src.name].</span>")
 		var/obj/structure/bed/roller/B = new foldabletype(get_turf(src))

--- a/code/game/objects/structures/beds_chairs/chair.dm
+++ b/code/game/objects/structures/beds_chairs/chair.dm
@@ -383,7 +383,7 @@
 
 /obj/structure/chair/brass/AltClick(mob/living/user)
 	turns = 0
-	if(!user.canUseTopic(src, be_close = TRUE))
+	if(!istype(user) || !user.canUseTopic(src, BE_CLOSE, NO_DEXTERY))
 		return
 	if(!isprocessing)
 		user.visible_message("<span class='notice'>[user] spins [src] around, and Ratvarian technology keeps it spinning FOREVER.</span>", \

--- a/code/game/objects/structures/beds_chairs/chair.dm
+++ b/code/game/objects/structures/beds_chairs/chair.dm
@@ -36,7 +36,7 @@
 	var/mob/living/L = user
 
 	if(istype(L))
-		if(!user.canUseTopic(src, BE_CLOSE, NO_DEXTERY))
+		if(!user.canUseTopic(src, BE_CLOSE, ismonkey(user)))
 			to_chat(user, "<span class='warning'>You can't do that right now!</span>")
 			return FALSE
 		else
@@ -225,7 +225,7 @@
 	if(over_object == usr && Adjacent(usr))
 		if(!item_chair || !usr.can_hold_items() || has_buckled_mobs() || src.flags_1 & NODECONSTRUCT_1)
 			return
-		if(!usr.canUseTopic(src, BE_CLOSE, NO_DEXTERY))
+		if(!usr.canUseTopic(src, BE_CLOSE, ismonkey(usr)))
 			to_chat(usr, "<span class='warning'>You can't do that right now!</span>")
 			return
 		usr.visible_message("<span class='notice'>[usr] grabs \the [src.name].</span>", "<span class='notice'>You grab \the [src.name].</span>")
@@ -383,7 +383,7 @@
 
 /obj/structure/chair/brass/AltClick(mob/living/user)
 	turns = 0
-	if(!istype(user) || !user.canUseTopic(src, BE_CLOSE, NO_DEXTERY))
+	if(!istype(user) || !user.canUseTopic(src, BE_CLOSE, ismonkey(user)))
 		return
 	if(!isprocessing)
 		user.visible_message("<span class='notice'>[user] spins [src] around, and Ratvarian technology keeps it spinning FOREVER.</span>", \

--- a/code/game/objects/structures/beds_chairs/chair.dm
+++ b/code/game/objects/structures/beds_chairs/chair.dm
@@ -36,7 +36,7 @@
 	var/mob/living/L = user
 
 	if(istype(L))
-		if(!user.Adjacent(src) || user.incapacitated())
+		if(!user.canUseTopic(src, BE_CLOSE, NO_DEXTERY))
 			to_chat(user, "<span class='warning'>You can't do that right now!</span>")
 			return FALSE
 		else
@@ -225,7 +225,7 @@
 	if(over_object == usr && Adjacent(usr))
 		if(!item_chair || !usr.can_hold_items() || has_buckled_mobs() || src.flags_1 & NODECONSTRUCT_1)
 			return
-		if(usr.incapacitated())
+		if(!usr.canUseTopic(src, BE_CLOSE, NO_DEXTERY))
 			to_chat(usr, "<span class='warning'>You can't do that right now!</span>")
 			return
 		usr.visible_message("<span class='notice'>[usr] grabs \the [src.name].</span>", "<span class='notice'>You grab \the [src.name].</span>")

--- a/code/game/objects/structures/crates_lockers/closets.dm
+++ b/code/game/objects/structures/crates_lockers/closets.dm
@@ -391,7 +391,6 @@
 /obj/structure/closet/AltClick(mob/user)
 	..()
 	if(!user.canUseTopic(src, be_close=TRUE) || !isturf(loc))
-		to_chat(user, "<span class='warning'>You can't do that right now!</span>")
 		return
 	if(opened || !secure)
 		return

--- a/code/game/objects/structures/crates_lockers/closets.dm
+++ b/code/game/objects/structures/crates_lockers/closets.dm
@@ -390,7 +390,7 @@
 
 /obj/structure/closet/AltClick(mob/user)
 	..()
-	if(!user.canUseTopic(src, be_close=TRUE) || !isturf(loc))
+	if(!user.canUseTopic(src, BE_CLOSE) || !isturf(loc))
 		return
 	if(opened || !secure)
 		return

--- a/code/game/objects/structures/extinguisher.dm
+++ b/code/game/objects/structures/extinguisher.dm
@@ -98,7 +98,7 @@
 	attack_hand(user)
 
 /obj/structure/extinguisher_cabinet/AltClick(mob/living/user)
-	if(!istype(user) || !user.canUseTopic(src, be_close=TRUE, no_dextery=TRUE))
+	if(!istype(user) || !user.canUseTopic(src, BE_CLOSE, NO_DEXTERY))
 		return
 	toggle_cabinet(user)
 

--- a/code/game/objects/structures/extinguisher.dm
+++ b/code/game/objects/structures/extinguisher.dm
@@ -98,7 +98,7 @@
 	attack_hand(user)
 
 /obj/structure/extinguisher_cabinet/AltClick(mob/living/user)
-	if(!istype(user) || !user.canUseTopic(src, BE_CLOSE, NO_DEXTERY))
+	if(!istype(user) || !user.canUseTopic(src, BE_CLOSE, ismonkey(user)))
 		return
 	toggle_cabinet(user)
 

--- a/code/game/objects/structures/extinguisher.dm
+++ b/code/game/objects/structures/extinguisher.dm
@@ -98,7 +98,7 @@
 	attack_hand(user)
 
 /obj/structure/extinguisher_cabinet/AltClick(mob/living/user)
-	if(user.incapacitated() || !Adjacent(user) || !istype(user))
+	if(!istype(user) || !user.canUseTopic(src, be_close=TRUE, no_dextery=TRUE))
 		return
 	toggle_cabinet(user)
 

--- a/code/game/objects/structures/guncase.dm
+++ b/code/game/objects/structures/guncase.dm
@@ -81,7 +81,7 @@
 		var/obj/item/O = locate(href_list["retrieve"]) in contents
 		if(!O || !istype(O))
 			return
-		if(!usr.canUseTopic(src) || !open)
+		if(!usr.canUseTopic(src, BE_CLOSE) || !open)
 			return
 		if(ishuman(usr))
 			if(!usr.put_in_hands(O))

--- a/code/game/objects/structures/morgue.dm
+++ b/code/game/objects/structures/morgue.dm
@@ -150,7 +150,7 @@ GLOBAL_LIST_EMPTY(bodycontainers) //Let them act as spawnpoints for revenants an
 
 /obj/structure/bodycontainer/morgue/AltClick(mob/user)
 	..()
-	if(user.incapacitated())
+	if(!user.canUseTopic(src, be_close=TRUE))
 		to_chat(user, "<span class='warning'>You can't do that right now!</span>")
 		return
 	beeper = !beeper

--- a/code/game/objects/structures/morgue.dm
+++ b/code/game/objects/structures/morgue.dm
@@ -151,7 +151,6 @@ GLOBAL_LIST_EMPTY(bodycontainers) //Let them act as spawnpoints for revenants an
 /obj/structure/bodycontainer/morgue/AltClick(mob/user)
 	..()
 	if(!user.canUseTopic(src, be_close=TRUE))
-		to_chat(user, "<span class='warning'>You can't do that right now!</span>")
 		return
 	beeper = !beeper
 	to_chat(user, "<span class='notice'>You turn the speaker function [beeper ? "off" : "on"].</span>")

--- a/code/game/objects/structures/morgue.dm
+++ b/code/game/objects/structures/morgue.dm
@@ -150,7 +150,7 @@ GLOBAL_LIST_EMPTY(bodycontainers) //Let them act as spawnpoints for revenants an
 
 /obj/structure/bodycontainer/morgue/AltClick(mob/user)
 	..()
-	if(!user.canUseTopic(src, be_close=TRUE))
+	if(!user.canUseTopic(src, BE_CLOSE))
 		return
 	beeper = !beeper
 	to_chat(user, "<span class='notice'>You turn the speaker function [beeper ? "off" : "on"].</span>")

--- a/code/game/objects/structures/reflector.dm
+++ b/code/game/objects/structures/reflector.dm
@@ -169,7 +169,6 @@
 
 /obj/structure/reflector/AltClick(mob/user)
 	if(!user.canUseTopic(src, be_close=TRUE))
-		to_chat(user, "<span class='warning'>You can't do that right now!</span>")
 		return
 	else if(finished)
 		rotate(user)

--- a/code/game/objects/structures/reflector.dm
+++ b/code/game/objects/structures/reflector.dm
@@ -160,7 +160,7 @@
 		to_chat(user, "<span class='warning'>The rotation is locked!</span>")
 		return FALSE
 	var/new_angle = input(user, "Input a new angle for primary reflection face.", "Reflector Angle", rotation_angle) as null|num
-	if(!user.canUseTopic(src, be_close=TRUE))
+	if(!user.canUseTopic(src, BE_CLOSE))
 		to_chat(user, "<span class='warning'>You can't do that right now!</span>")
 		return
 	if(!isnull(new_angle))
@@ -168,7 +168,7 @@
 	return TRUE
 
 /obj/structure/reflector/AltClick(mob/user)
-	if(!user.canUseTopic(src, be_close=TRUE))
+	if(!user.canUseTopic(src, BE_CLOSE))
 		return
 	else if(finished)
 		rotate(user)

--- a/code/game/objects/structures/reflector.dm
+++ b/code/game/objects/structures/reflector.dm
@@ -160,7 +160,7 @@
 		to_chat(user, "<span class='warning'>The rotation is locked!</span>")
 		return FALSE
 	var/new_angle = input(user, "Input a new angle for primary reflection face.", "Reflector Angle", rotation_angle) as null|num
-	if(!user.canUseTopic(src, BE_CLOSE, NO_DEXTERY))
+	if(!user.canUseTopic(src, BE_CLOSE, ismonkey(user)))
 		to_chat(user, "<span class='warning'>You can't do that right now!</span>")
 		return
 	if(!isnull(new_angle))
@@ -168,7 +168,7 @@
 	return TRUE
 
 /obj/structure/reflector/AltClick(mob/user)
-	if(!user.canUseTopic(src, BE_CLOSE, NO_DEXTERY))
+	if(!user.canUseTopic(src, BE_CLOSE, ismonkey(user)))
 		return
 	else if(finished)
 		rotate(user)

--- a/code/game/objects/structures/reflector.dm
+++ b/code/game/objects/structures/reflector.dm
@@ -160,7 +160,7 @@
 		to_chat(user, "<span class='warning'>The rotation is locked!</span>")
 		return FALSE
 	var/new_angle = input(user, "Input a new angle for primary reflection face.", "Reflector Angle", rotation_angle) as null|num
-	if(!user.canUseTopic(src, BE_CLOSE))
+	if(!user.canUseTopic(src, BE_CLOSE, NO_DEXTERY))
 		to_chat(user, "<span class='warning'>You can't do that right now!</span>")
 		return
 	if(!isnull(new_angle))
@@ -168,7 +168,7 @@
 	return TRUE
 
 /obj/structure/reflector/AltClick(mob/user)
-	if(!user.canUseTopic(src, BE_CLOSE))
+	if(!user.canUseTopic(src, BE_CLOSE, NO_DEXTERY))
 		return
 	else if(finished)
 		rotate(user)

--- a/code/modules/antagonists/clockcult/clock_items/clockwork_slab.dm
+++ b/code/modules/antagonists/clockcult/clock_items/clockwork_slab.dm
@@ -160,7 +160,7 @@
 	access_display(user)
 
 /obj/item/clockwork/slab/AltClick(mob/living/user)
-	if(is_servant_of_ratvar(user) && linking)
+	if(is_servant_of_ratvar(user) && linking && user.canUseTopic(src, be_close=TRUE, no_dextery=TRUE))
 		linking = null
 		to_chat(user, "<span class='notice'>Object link canceled.</span>")
 

--- a/code/modules/antagonists/clockcult/clock_items/clockwork_slab.dm
+++ b/code/modules/antagonists/clockcult/clock_items/clockwork_slab.dm
@@ -160,7 +160,7 @@
 	access_display(user)
 
 /obj/item/clockwork/slab/AltClick(mob/living/user)
-	if(is_servant_of_ratvar(user) && linking && user.canUseTopic(src, BE_CLOSE, NO_DEXTERY))
+	if(is_servant_of_ratvar(user) && linking && user.canUseTopic(src, BE_CLOSE, ismonkey(user)))
 		linking = null
 		to_chat(user, "<span class='notice'>Object link canceled.</span>")
 

--- a/code/modules/antagonists/clockcult/clock_items/clockwork_slab.dm
+++ b/code/modules/antagonists/clockcult/clock_items/clockwork_slab.dm
@@ -160,7 +160,7 @@
 	access_display(user)
 
 /obj/item/clockwork/slab/AltClick(mob/living/user)
-	if(is_servant_of_ratvar(user) && linking && user.canUseTopic(src, be_close=TRUE, no_dextery=TRUE))
+	if(is_servant_of_ratvar(user) && linking && user.canUseTopic(src, BE_CLOSE, NO_DEXTERY))
 		linking = null
 		to_chat(user, "<span class='notice'>Object link canceled.</span>")
 

--- a/code/modules/antagonists/devil/true_devil/_true_devil.dm
+++ b/code/modules/antagonists/devil/true_devil/_true_devil.dm
@@ -94,10 +94,10 @@
 
 /mob/living/carbon/true_devil/canUseTopic(atom/movable/M, be_close=FALSE, no_dextery=FALSE)
 	if(incapacitated())
-		return 0
+		return FALSE
 	if(be_close && !in_range(M, src))
-		return 0
-	return 1
+		return FALSE
+	return TRUE
 
 /mob/living/carbon/true_devil/assess_threat(judgement_criteria, lasercolor = "", datum/callback/weaponcheck=null)
 	return 666

--- a/code/modules/antagonists/wizard/equipment/artefact.dm
+++ b/code/modules/antagonists/wizard/equipment/artefact.dm
@@ -157,7 +157,7 @@
 	if(!istype(M))
 		return ..()
 
-	if(!istype(user) || !user.canUseTopic(M,1))
+	if(!istype(user) || !user.canUseTopic(M, BE_CLOSE))
 		return
 
 	if(M.stat != DEAD)

--- a/code/modules/assembly/infrared.dm
+++ b/code/modules/assembly/infrared.dm
@@ -169,7 +169,6 @@
 /obj/item/device/assembly/infra/AltClick(mob/user)
 	..()
 	if(!user.canUseTopic(src, be_close=TRUE))
-		to_chat(user, "<span class='warning'>You can't do that right now!</span>")
 		return
 	else
 		rotate()

--- a/code/modules/assembly/infrared.dm
+++ b/code/modules/assembly/infrared.dm
@@ -161,7 +161,7 @@
 	set category = "Object"
 	set src in usr
 
-	if(!usr.canUseTopic(src))
+	if(!usr.canUseTopic(src, BE_CLOSE))
 		return
 
 	setDir(turn(dir, -90))

--- a/code/modules/assembly/infrared.dm
+++ b/code/modules/assembly/infrared.dm
@@ -168,7 +168,7 @@
 
 /obj/item/device/assembly/infra/AltClick(mob/user)
 	..()
-	if(!user.canUseTopic(src, be_close=TRUE))
+	if(!user.canUseTopic(src, BE_CLOSE))
 		return
 	else
 		rotate()

--- a/code/modules/assembly/infrared.dm
+++ b/code/modules/assembly/infrared.dm
@@ -161,14 +161,14 @@
 	set category = "Object"
 	set src in usr
 
-	if(!usr.canUseTopic(src, BE_CLOSE))
+	if(!usr.canUseTopic(src, BE_CLOSE, NO_DEXTERY))
 		return
 
 	setDir(turn(dir, -90))
 
 /obj/item/device/assembly/infra/AltClick(mob/user)
 	..()
-	if(!user.canUseTopic(src, BE_CLOSE))
+	if(!user.canUseTopic(src, BE_CLOSE, NO_DEXTERY))
 		return
 	else
 		rotate()

--- a/code/modules/assembly/infrared.dm
+++ b/code/modules/assembly/infrared.dm
@@ -161,17 +161,15 @@
 	set category = "Object"
 	set src in usr
 
-	if(usr.incapacitated())
+	if(!usr.canUseTopic(src))
 		return
 
 	setDir(turn(dir, -90))
 
 /obj/item/device/assembly/infra/AltClick(mob/user)
 	..()
-	if(user.incapacitated())
+	if(!user.canUseTopic(src, be_close=TRUE))
 		to_chat(user, "<span class='warning'>You can't do that right now!</span>")
-		return
-	if(!in_range(src, user))
 		return
 	else
 		rotate()

--- a/code/modules/atmospherics/machinery/airalarm.dm
+++ b/code/modules/atmospherics/machinery/airalarm.dm
@@ -734,7 +734,7 @@
 
 /obj/machinery/airalarm/AltClick(mob/user)
 	..()
-	if(!issilicon(user) && (!user.canUseTopic(src, be_close=TRUE) || !isturf(loc)))
+	if(!issilicon(user) && (!user.canUseTopic(src, BE_CLOSE) || !isturf(loc)))
 		return
 	else
 		togglelock(user)

--- a/code/modules/atmospherics/machinery/airalarm.dm
+++ b/code/modules/atmospherics/machinery/airalarm.dm
@@ -735,7 +735,6 @@
 /obj/machinery/airalarm/AltClick(mob/user)
 	..()
 	if(!issilicon(user) && (!user.canUseTopic(src, be_close=TRUE) || !isturf(loc)))
-		to_chat(user, "<span class='warning'>You can't do that right now!</span>")
 		return
 	else
 		togglelock(user)

--- a/code/modules/atmospherics/machinery/airalarm.dm
+++ b/code/modules/atmospherics/machinery/airalarm.dm
@@ -734,7 +734,7 @@
 
 /obj/machinery/airalarm/AltClick(mob/user)
 	..()
-	if(!issilicon(user) && (!user.canUseTopic(src, BE_CLOSE) || !isturf(loc)))
+	if(!user.canUseTopic(src, !issilicon(user)) || !isturf(loc))
 		return
 	else
 		togglelock(user)

--- a/code/modules/clothing/clothing.dm
+++ b/code/modules/clothing/clothing.dm
@@ -90,7 +90,7 @@
 	return ..()
 
 /obj/item/clothing/AltClick(mob/living/user)
-	if(istype(user) && user.canUseTopic(src, be_close=TRUE, no_dextery=TRUE) && pockets && pockets.quickdraw && pockets.contents.len)
+	if(istype(user) && user.canUseTopic(src, BE_CLOSE, NO_DEXTERY) && pockets && pockets.quickdraw && pockets.contents.len)
 		var/obj/item/I = pockets.contents[1]
 		if(!I)
 			return
@@ -244,7 +244,7 @@ BLIND     // can't see anything
 	if(..())
 		return 1
 
-	if(!istype(user) || !user.canUseTopic(src, be_close=TRUE, no_dextery=TRUE))
+	if(!istype(user) || !user.canUseTopic(src, BE_CLOSE, NO_DEXTERY))
 		to_chat(user, "<span class='warning'>You can't do that right now!</span>")
 		return
 	else

--- a/code/modules/clothing/clothing.dm
+++ b/code/modules/clothing/clothing.dm
@@ -89,8 +89,8 @@
 			return i
 	return ..()
 
-/obj/item/clothing/AltClick(mob/user)
-	if(pockets && pockets.quickdraw && pockets.contents.len && !user.incapacitated())
+/obj/item/clothing/AltClick(mob/living/user)
+	if(istype(user) && user.canUseTopic(src, be_close=TRUE, no_dextery=TRUE) && pockets && pockets.quickdraw && pockets.contents.len)
 		var/obj/item/I = pockets.contents[1]
 		if(!I)
 			return
@@ -244,7 +244,7 @@ BLIND     // can't see anything
 	if(..())
 		return 1
 
-	if(!user.canUseTopic(src, be_close=TRUE))
+	if(!istype(user) || !user.canUseTopic(src, be_close=TRUE, no_dextery=TRUE))
 		to_chat(user, "<span class='warning'>You can't do that right now!</span>")
 		return
 	else

--- a/code/modules/clothing/clothing.dm
+++ b/code/modules/clothing/clothing.dm
@@ -89,8 +89,8 @@
 			return i
 	return ..()
 
-/obj/item/clothing/AltClick(mob/living/user)
-	if(istype(user) && user.canUseTopic(src, BE_CLOSE, NO_DEXTERY) && pockets && pockets.quickdraw && pockets.contents.len)
+/obj/item/clothing/AltClick(mob/user)
+	if(istype(user) && user.canUseTopic(src, BE_CLOSE, ismonkey(user)) && pockets && pockets.quickdraw && pockets.contents.len)
 		var/obj/item/I = pockets.contents[1]
 		if(!I)
 			return
@@ -244,7 +244,7 @@ BLIND     // can't see anything
 	if(..())
 		return 1
 
-	if(!istype(user) || !user.canUseTopic(src, BE_CLOSE, NO_DEXTERY))
+	if(!istype(user) || !user.canUseTopic(src, BE_CLOSE, ismonkey(user)))
 		to_chat(user, "<span class='warning'>You can't do that right now!</span>")
 		return
 	else

--- a/code/modules/clothing/head/jobs.dm
+++ b/code/modules/clothing/head/jobs.dm
@@ -87,7 +87,7 @@
 	to_chat(user, "<span class='notice'>Alt-click to take a candy corn.</span>")
 
 /obj/item/clothing/head/fedora/det_hat/AltClick(mob/user)
-	if(user.canUseTopic(src, be_close=TRUE))
+	if(user.canUseTopic(src, be_close=TRUE, no_dextery=TRUE))
 		..()
 		if(loc == user)
 			if(candy_cooldown < world.time)

--- a/code/modules/clothing/head/jobs.dm
+++ b/code/modules/clothing/head/jobs.dm
@@ -87,7 +87,7 @@
 	to_chat(user, "<span class='notice'>Alt-click to take a candy corn.</span>")
 
 /obj/item/clothing/head/fedora/det_hat/AltClick(mob/user)
-	if(user.canUseTopic(src, be_close=TRUE, no_dextery=TRUE))
+	if(user.canUseTopic(src, BE_CLOSE, NO_DEXTERY))
 		..()
 		if(loc == user)
 			if(candy_cooldown < world.time)

--- a/code/modules/clothing/head/jobs.dm
+++ b/code/modules/clothing/head/jobs.dm
@@ -87,7 +87,7 @@
 	to_chat(user, "<span class='notice'>Alt-click to take a candy corn.</span>")
 
 /obj/item/clothing/head/fedora/det_hat/AltClick(mob/user)
-	if(user.canUseTopic(src, BE_CLOSE, NO_DEXTERY))
+	if(user.canUseTopic(src, BE_CLOSE, ismonkey(user)))
 		..()
 		if(loc == user)
 			if(candy_cooldown < world.time)

--- a/code/modules/clothing/head/soft_caps.dm
+++ b/code/modules/clothing/head/soft_caps.dm
@@ -23,7 +23,7 @@
 
 /obj/item/clothing/head/soft/AltClick(mob/user)
 	..()
-	if(!user.canUseTopic(src, BE_CLOSE, NO_DEXTERY))
+	if(!user.canUseTopic(src, BE_CLOSE, ismonkey(user)))
 		return
 	else
 		flip(user)

--- a/code/modules/clothing/head/soft_caps.dm
+++ b/code/modules/clothing/head/soft_caps.dm
@@ -23,15 +23,14 @@
 
 /obj/item/clothing/head/soft/AltClick(mob/user)
 	..()
-	if(!user.canUseTopic(src, be_close=TRUE))
-		to_chat(user, "<span class='warning'>You can't do that right now!</span>")
+	if(!user.canUseTopic(src, be_close=TRUE, no_dextery=TRUE))
 		return
 	else
 		flip(user)
 
 
 /obj/item/clothing/head/soft/proc/flip(mob/user)
-	if(user.canmove && !user.stat && !user.restrained())
+	if(!user.incapacitated())
 		src.flipped = !src.flipped
 		if(src.flipped)
 			icon_state = "[item_color]soft_flipped"

--- a/code/modules/clothing/head/soft_caps.dm
+++ b/code/modules/clothing/head/soft_caps.dm
@@ -23,7 +23,7 @@
 
 /obj/item/clothing/head/soft/AltClick(mob/user)
 	..()
-	if(!user.canUseTopic(src, be_close=TRUE, no_dextery=TRUE))
+	if(!user.canUseTopic(src, BE_CLOSE, NO_DEXTERY))
 		return
 	else
 		flip(user)

--- a/code/modules/clothing/masks/breath.dm
+++ b/code/modules/clothing/masks/breath.dm
@@ -23,8 +23,7 @@ obj/item/clothing/mask/breath/suicide_act(mob/living/carbon/user)
 
 /obj/item/clothing/mask/breath/AltClick(mob/user)
 	..()
-	if(!user.canUseTopic(src, be_close=TRUE))
-		to_chat(user, "<span class='warning'>You can't do that right now!</span>")
+	if(!user.canUseTopic(src, be_close=TRUE, no_dextery=TRUE))
 		return
 	else
 		adjustmask(user)

--- a/code/modules/clothing/masks/breath.dm
+++ b/code/modules/clothing/masks/breath.dm
@@ -23,7 +23,7 @@ obj/item/clothing/mask/breath/suicide_act(mob/living/carbon/user)
 
 /obj/item/clothing/mask/breath/AltClick(mob/user)
 	..()
-	if(!user.canUseTopic(src, BE_CLOSE, NO_DEXTERY))
+	if(!user.canUseTopic(src, BE_CLOSE, ismonkey(user)))
 		return
 	else
 		adjustmask(user)

--- a/code/modules/clothing/masks/breath.dm
+++ b/code/modules/clothing/masks/breath.dm
@@ -23,7 +23,7 @@ obj/item/clothing/mask/breath/suicide_act(mob/living/carbon/user)
 
 /obj/item/clothing/mask/breath/AltClick(mob/user)
 	..()
-	if(!user.canUseTopic(src, be_close=TRUE, no_dextery=TRUE))
+	if(!user.canUseTopic(src, BE_CLOSE, NO_DEXTERY))
 		return
 	else
 		adjustmask(user)

--- a/code/modules/clothing/suits/toggles.dm
+++ b/code/modules/clothing/suits/toggles.dm
@@ -93,7 +93,7 @@
 
 /obj/item/clothing/suit/toggle/AltClick(mob/user)
 	..()
-	if(!user.canUseTopic(src, BE_CLOSE, NO_DEXTERY))
+	if(!user.canUseTopic(src, BE_CLOSE, ismonkey(user)))
 		return
 	else
 		suit_toggle(user)

--- a/code/modules/clothing/suits/toggles.dm
+++ b/code/modules/clothing/suits/toggles.dm
@@ -93,7 +93,7 @@
 
 /obj/item/clothing/suit/toggle/AltClick(mob/user)
 	..()
-	if(!user.canUseTopic(src, be_close=TRUE, no_dextery=TRUE))
+	if(!user.canUseTopic(src, BE_CLOSE, NO_DEXTERY))
 		return
 	else
 		suit_toggle(user)

--- a/code/modules/clothing/suits/toggles.dm
+++ b/code/modules/clothing/suits/toggles.dm
@@ -93,8 +93,7 @@
 
 /obj/item/clothing/suit/toggle/AltClick(mob/user)
 	..()
-	if(!user.canUseTopic(src, be_close=TRUE))
-		to_chat(user, "<span class='warning'>You can't do that right now!</span>")
+	if(!user.canUseTopic(src, be_close=TRUE, no_dextery=TRUE))
 		return
 	else
 		suit_toggle(user)

--- a/code/modules/clothing/under/accessories.dm
+++ b/code/modules/clothing/under/accessories.dm
@@ -69,7 +69,7 @@
 	return
 
 /obj/item/clothing/accessory/AltClick(mob/user)
-	if(user.canUseTopic(src, be_close=TRUE))
+	if(user.canUseTopic(src, be_close=TRUE, no_dextery=TRUE))
 		if(initial(above_suit))
 			above_suit = !above_suit
 			to_chat(user, "[src] will be worn [above_suit ? "above" : "below"] your suit.")

--- a/code/modules/clothing/under/accessories.dm
+++ b/code/modules/clothing/under/accessories.dm
@@ -68,8 +68,8 @@
 /obj/item/clothing/accessory/proc/on_uniform_dropped(obj/item/clothing/under/U, user)
 	return
 
-/obj/item/clothing/accessory/AltClick(mob/living/carbon/human/user)
-	if(istype(user) && user.canUseTopic(src, BE_CLOSE, NO_DEXTERY))
+/obj/item/clothing/accessory/AltClick(mob/user)
+	if(istype(user) && user.canUseTopic(src, BE_CLOSE, ismonkey(user)))
 		if(initial(above_suit))
 			above_suit = !above_suit
 			to_chat(user, "[src] will be worn [above_suit ? "above" : "below"] your suit.")

--- a/code/modules/clothing/under/accessories.dm
+++ b/code/modules/clothing/under/accessories.dm
@@ -69,7 +69,7 @@
 	return
 
 /obj/item/clothing/accessory/AltClick(mob/user)
-	if(user.canUseTopic(src, be_close=TRUE, no_dextery=TRUE))
+	if(user.canUseTopic(src, BE_CLOSE, NO_DEXTERY))
 		if(initial(above_suit))
 			above_suit = !above_suit
 			to_chat(user, "[src] will be worn [above_suit ? "above" : "below"] your suit.")

--- a/code/modules/clothing/under/accessories.dm
+++ b/code/modules/clothing/under/accessories.dm
@@ -68,8 +68,8 @@
 /obj/item/clothing/accessory/proc/on_uniform_dropped(obj/item/clothing/under/U, user)
 	return
 
-/obj/item/clothing/accessory/AltClick(mob/user)
-	if(user.canUseTopic(src, BE_CLOSE, NO_DEXTERY))
+/obj/item/clothing/accessory/AltClick(mob/living/carbon/human/user)
+	if(istype(user) && user.canUseTopic(src, BE_CLOSE, NO_DEXTERY))
 		if(initial(above_suit))
 			above_suit = !above_suit
 			to_chat(user, "[src] will be worn [above_suit ? "above" : "below"] your suit.")

--- a/code/modules/food_and_drinks/kitchen_machinery/microwave.dm
+++ b/code/modules/food_and_drinks/kitchen_machinery/microwave.dm
@@ -169,7 +169,7 @@
 	interact(user)
 
 /obj/machinery/microwave/AltClick(mob/user)
-	if(user.canUseTopic(src, be_close=TRUE) && !(operating || broken > 0 || panel_open || !anchored || dirty == 100))
+	if(user.canUseTopic(src, BE_CLOSE) && !(operating || broken > 0 || panel_open || !anchored || dirty == 100))
 		cook()
 
 /*******************

--- a/code/modules/games/cas.dm
+++ b/code/modules/games/cas.dm
@@ -117,7 +117,7 @@
 	set name = "Flip Card"
 	set category = "Object"
 	set src in range(1)
-	if(!usr.canUseTopic(src,1))
+	if(!usr.canUseTopic(src, BE_CLOSE))
 		return
 	if(!flipped)
 		name = "CAS card"
@@ -127,7 +127,7 @@
 	update_icon()
 
 /obj/item/toy/cards/singlecard/cas/AltClick(mob/living/user)
-	if(!user.canUseTopic(src,1))
+	if(!user.canUseTopic(src, BE_CLOSE))
 		return
 	Flip()
 

--- a/code/modules/games/cas.dm
+++ b/code/modules/games/cas.dm
@@ -117,7 +117,7 @@
 	set name = "Flip Card"
 	set category = "Object"
 	set src in range(1)
-	if(!usr.canUseTopic(src, BE_CLOSE))
+	if(!ishuman(usr) || !usr.canUseTopic(src, BE_CLOSE))
 		return
 	if(!flipped)
 		name = "CAS card"
@@ -127,7 +127,7 @@
 	update_icon()
 
 /obj/item/toy/cards/singlecard/cas/AltClick(mob/living/user)
-	if(!user.canUseTopic(src, BE_CLOSE))
+	if(!ishuman(user) || !user.canUseTopic(src, BE_CLOSE))
 		return
 	Flip()
 

--- a/code/modules/integrated_electronics/core/assemblies.dm
+++ b/code/modules/integrated_electronics/core/assemblies.dm
@@ -24,7 +24,7 @@
 	armor = list(melee = 50, bullet = 70, laser = 70, energy = 100, bomb = 10, bio = 100, rad = 100, fire = 0, acid = 0)
 
 /obj/item/device/electronic_assembly/proc/check_interactivity(mob/user)
-	return user.canUseTopic(src,be_close = TRUE)
+	return user.canUseTopic(src, BE_CLOSE)
 
 
 /obj/item/device/electronic_assembly/Initialize()

--- a/code/modules/integrated_electronics/core/integrated_circuit.dm
+++ b/code/modules/integrated_electronics/core/integrated_circuit.dm
@@ -68,7 +68,7 @@ a creative player the means to solve many problems.  Circuits are held inside an
 	if(assembly)
 		return assembly.check_interactivity(user)
 	else
-		return user.canUseTopic(src,be_close = TRUE)
+		return user.canUseTopic(src, BE_CLOSE)
 
 /obj/item/integrated_circuit/Initialize()
 	displayed_name = name

--- a/code/modules/integrated_electronics/core/printer.dm
+++ b/code/modules/integrated_electronics/core/printer.dm
@@ -10,7 +10,7 @@
 	var/list/program			// Currently loaded save, in form of list
 
 /obj/item/device/integrated_circuit_printer/proc/check_interactivity(mob/user)
-	return user.canUseTopic(src, be_close = TRUE)
+	return user.canUseTopic(src, BE_CLOSE)
 
 /obj/item/device/integrated_circuit_printer/upgraded
 	upgraded = TRUE

--- a/code/modules/mining/abandoned_crates.dm
+++ b/code/modules/mining/abandoned_crates.dm
@@ -154,7 +154,7 @@
 	if(locked)
 		to_chat(user, "<span class='notice'>The crate is locked with a Deca-code lock.</span>")
 		var/input = input(usr, "Enter [codelen] digits. All digits must be unique.", "Deca-Code Lock", "") as text
-		if(user.canUseTopic(src, 1))
+		if(user.canUseTopic(src, BE_CLOSE))
 			var/list/sanitised = list()
 			var/sanitycheck = 1
 			for(var/i=1,i<=length(input),i++) //put the guess into a list
@@ -180,7 +180,7 @@
 		return ..()
 
 /obj/structure/closet/crate/secure/loot/AltClick(mob/living/user)
-	if(!user.canUseTopic(src))
+	if(!user.canUseTopic(src, BE_CLOSE))
 		return
 	attack_hand(user) //this helps you not blow up so easily by overriding unlocking which results in an immediate boom.
 

--- a/code/modules/mining/equipment/marker_beacons.dm
+++ b/code/modules/mining/equipment/marker_beacons.dm
@@ -57,13 +57,11 @@ GLOBAL_LIST_INIT(marker_beacon_colors, list(
 		transfer_fingerprints_to(M)
 
 /obj/item/stack/marker_beacon/AltClick(mob/living/user)
-	if(user.incapacitated() || !istype(user))
+	if(!istype(user) || !user.canUseTopic(src, be_close=TRUE))
 		to_chat(user, "<span class='warning'>You can't do that right now!</span>")
 		return
-	if(!in_range(src, user))
-		return
 	var/input_color = input(user, "Choose a color.", "Beacon Color") as null|anything in GLOB.marker_beacon_colors
-	if(user.incapacitated() || !istype(user) || !in_range(src, user))
+	if(!istype(user) || !user.canUseTopic(src, be_close=TRUE))
 		return
 	if(input_color)
 		picked_color = input_color
@@ -129,13 +127,11 @@ GLOBAL_LIST_INIT(marker_beacon_colors, list(
 
 /obj/structure/marker_beacon/AltClick(mob/living/user)
 	..()
-	if(user.incapacitated() || !istype(user))
+	if(!istype(user) || !user.canUseTopic(src, be_close=TRUE))
 		to_chat(user, "<span class='warning'>You can't do that right now!</span>")
 		return
-	if(!in_range(src, user))
-		return
 	var/input_color = input(user, "Choose a color.", "Beacon Color") as null|anything in GLOB.marker_beacon_colors
-	if(user.incapacitated() || !istype(user) || !in_range(src, user))
+	if(!istype(user) || !user.canUseTopic(src, be_close=TRUE))
 		return
 	if(input_color)
 		picked_color = input_color

--- a/code/modules/mining/equipment/marker_beacons.dm
+++ b/code/modules/mining/equipment/marker_beacons.dm
@@ -58,7 +58,6 @@ GLOBAL_LIST_INIT(marker_beacon_colors, list(
 
 /obj/item/stack/marker_beacon/AltClick(mob/living/user)
 	if(!istype(user) || !user.canUseTopic(src, be_close=TRUE))
-		to_chat(user, "<span class='warning'>You can't do that right now!</span>")
 		return
 	var/input_color = input(user, "Choose a color.", "Beacon Color") as null|anything in GLOB.marker_beacon_colors
 	if(!istype(user) || !user.canUseTopic(src, be_close=TRUE))
@@ -128,7 +127,6 @@ GLOBAL_LIST_INIT(marker_beacon_colors, list(
 /obj/structure/marker_beacon/AltClick(mob/living/user)
 	..()
 	if(!istype(user) || !user.canUseTopic(src, be_close=TRUE))
-		to_chat(user, "<span class='warning'>You can't do that right now!</span>")
 		return
 	var/input_color = input(user, "Choose a color.", "Beacon Color") as null|anything in GLOB.marker_beacon_colors
 	if(!istype(user) || !user.canUseTopic(src, be_close=TRUE))

--- a/code/modules/mining/equipment/marker_beacons.dm
+++ b/code/modules/mining/equipment/marker_beacons.dm
@@ -57,10 +57,10 @@ GLOBAL_LIST_INIT(marker_beacon_colors, list(
 		transfer_fingerprints_to(M)
 
 /obj/item/stack/marker_beacon/AltClick(mob/living/user)
-	if(!istype(user) || !user.canUseTopic(src, be_close=TRUE))
+	if(!istype(user) || !user.canUseTopic(src, BE_CLOSE))
 		return
 	var/input_color = input(user, "Choose a color.", "Beacon Color") as null|anything in GLOB.marker_beacon_colors
-	if(!istype(user) || !user.canUseTopic(src, be_close=TRUE))
+	if(!istype(user) || !user.canUseTopic(src, BE_CLOSE))
 		return
 	if(input_color)
 		picked_color = input_color
@@ -126,10 +126,10 @@ GLOBAL_LIST_INIT(marker_beacon_colors, list(
 
 /obj/structure/marker_beacon/AltClick(mob/living/user)
 	..()
-	if(!istype(user) || !user.canUseTopic(src, be_close=TRUE))
+	if(!istype(user) || !user.canUseTopic(src, BE_CLOSE))
 		return
 	var/input_color = input(user, "Choose a color.", "Beacon Color") as null|anything in GLOB.marker_beacon_colors
-	if(!istype(user) || !user.canUseTopic(src, be_close=TRUE))
+	if(!istype(user) || !user.canUseTopic(src, BE_CLOSE))
 		return
 	if(input_color)
 		picked_color = input_color

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -719,13 +719,13 @@
 
 /mob/living/carbon/human/canUseTopic(atom/movable/M, be_close=FALSE, no_dextery=FALSE)
 	if(incapacitated() || lying )
-		return
+		return FALSE
 	if(!Adjacent(M) && (M.loc != src))
 		if((be_close == 0) && (dna.check_mutation(TK)))
 			if(tkMaxRangeCheck(src, M))
-				return 1
-		return
-	return 1
+				return TRUE
+		return FALSE
+	return TRUE
 
 /mob/living/carbon/human/resist_restraints()
 	if(wear_suit && wear_suit.breakouttime)

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -784,13 +784,14 @@
 
 /mob/living/canUseTopic(atom/movable/M, be_close=FALSE, no_dextery=FALSE)
 	if(incapacitated())
-		return
+		return FALSE
 	if(no_dextery)
 		if(be_close && in_range(M, src))
-			return 1
+			return TRUE
 	else
 		to_chat(src, "<span class='warning'>You don't have the dexterity to do this!</span>")
-	return
+	return FALSE
+
 /mob/living/proc/can_use_guns(obj/item/G)
 	if(G.trigger_guard != TRIGGER_GUARD_ALLOW_ALL && !IsAdvancedToolUser())
 		to_chat(src, "<span class='warning'>You don't have the dexterity to do this!</span>")

--- a/code/modules/mob/living/silicon/pai/pai.dm
+++ b/code/modules/mob/living/silicon/pai/pai.dm
@@ -185,6 +185,8 @@
 // See software.dm for Topic()
 
 /mob/living/silicon/pai/canUseTopic(atom/movable/M, be_close=FALSE, no_dextery=FALSE)
+	if(be_close && !in_range(M, src))
+		return FALSE
 	return TRUE
 
 /mob/proc/makePAI(delold)

--- a/code/modules/mob/living/silicon/robot/robot.dm
+++ b/code/modules/mob/living/silicon/robot/robot.dm
@@ -849,10 +849,10 @@
 
 /mob/living/silicon/robot/canUseTopic(atom/movable/M, be_close=FALSE, no_dextery=FALSE)
 	if(stat || lockcharge || low_power_mode)
-		return
+		return FALSE
 	if(be_close && !in_range(M, src))
-		return
-	return 1
+		return FALSE
+	return TRUE
 
 /mob/living/silicon/robot/updatehealth()
 	..()

--- a/code/modules/mob/living/simple_animal/simple_animal.dm
+++ b/code/modules/mob/living/simple_animal/simple_animal.dm
@@ -384,13 +384,13 @@
 	return TRUE
 
 /mob/living/simple_animal/stripPanelUnequip(obj/item/what, mob/who, where)
-	if(!canUseTopic(who, TRUE))
+	if(!canUseTopic(who, BE_CLOSE))
 		return
 	else
 		..()
 
 /mob/living/simple_animal/stripPanelEquip(obj/item/what, mob/who, where)
-	if(!canUseTopic(who, TRUE))
+	if(!canUseTopic(who, BE_CLOSE))
 		return
 	else
 		..()

--- a/code/modules/mob/living/simple_animal/simple_animal.dm
+++ b/code/modules/mob/living/simple_animal/simple_animal.dm
@@ -374,14 +374,14 @@
 
 /mob/living/simple_animal/canUseTopic(atom/movable/M, be_close=FALSE, no_dextery=FALSE)
 	if(incapacitated())
-		return 0
+		return FALSE
 	if(no_dextery || dextrous)
 		if(be_close && !in_range(M, src))
-			return 0
+			return FALSE
 	else
 		to_chat(src, "<span class='warning'>You don't have the dexterity to do this!</span>")
-		return 0
-	return 1
+		return FALSE
+	return TRUE
 
 /mob/living/simple_animal/stripPanelUnequip(obj/item/what, mob/who, where)
 	if(!canUseTopic(who, TRUE))

--- a/code/modules/paperwork/paperplane.dm
+++ b/code/modules/paperwork/paperplane.dm
@@ -99,12 +99,9 @@
 		H.emote("scream")
 
 /obj/item/paper/AltClick(mob/living/carbon/user, obj/item/I)
-	if ( istype(user) )
-		if( (!in_range(src, user)) || user.stat || user.restrained() )
-			return
-		to_chat(user, "<span class='notice'>You fold [src] into the shape of a plane!</span>")
-		user.temporarilyRemoveItemFromInventory(src)
-		I = new /obj/item/paperplane(user, src)
-		user.put_in_hands(I)
-	else
-		to_chat(user, "<span class='notice'> You lack the dexterity to fold \the [src]. </span>")
+	if(!istype(user) || !user.canUseTopic(src, be_close=TRUE))
+		return
+	to_chat(user, "<span class='notice'>You fold [src] into the shape of a plane!</span>")
+	user.temporarilyRemoveItemFromInventory(src)
+	I = new /obj/item/paperplane(user, src)
+	user.put_in_hands(I)

--- a/code/modules/paperwork/paperplane.dm
+++ b/code/modules/paperwork/paperplane.dm
@@ -99,7 +99,7 @@
 		H.emote("scream")
 
 /obj/item/paper/AltClick(mob/living/carbon/user, obj/item/I)
-	if(!istype(user) || !user.canUseTopic(src, be_close=TRUE))
+	if(!istype(user) || !user.canUseTopic(src, BE_CLOSE))
 		return
 	to_chat(user, "<span class='notice'>You fold [src] into the shape of a plane!</span>")
 	user.temporarilyRemoveItemFromInventory(src)

--- a/code/modules/paperwork/paperplane.dm
+++ b/code/modules/paperwork/paperplane.dm
@@ -99,7 +99,7 @@
 		H.emote("scream")
 
 /obj/item/paper/AltClick(mob/living/carbon/user, obj/item/I)
-	if(!istype(user) || !user.canUseTopic(src, BE_CLOSE))
+	if(!istype(user) || !user.canUseTopic(src, BE_CLOSE, ismonkey(user)))
 		return
 	to_chat(user, "<span class='notice'>You fold [src] into the shape of a plane!</span>")
 	user.temporarilyRemoveItemFromInventory(src)

--- a/code/modules/paperwork/pen.dm
+++ b/code/modules/paperwork/pen.dm
@@ -128,12 +128,12 @@
 	if(isobj(O) && proximity)
 		if(O.obj_flags & UNIQUE_RENAME)
 			var/penchoice = input(user, "What would you like to edit?", "Rename or change description?") as null|anything in list("Rename","Change description")
-			if(!QDELETED(O) && user.canUseTopic(O, be_close = TRUE))
+			if(!QDELETED(O) && user.canUseTopic(O, BE_CLOSE))
 
 				if(penchoice == "Rename")
 					var/input = stripped_input(user,"What do you want to name \the [O.name]?", ,"", MAX_NAME_LEN)
 					var/oldname = O.name
-					if(!QDELETED(O) && user.canUseTopic(O, be_close = TRUE))
+					if(!QDELETED(O) && user.canUseTopic(O, BE_CLOSE))
 						if(oldname == input)
 							to_chat(user, "You changed \the [O.name] to... well... \the [O.name].")
 							return
@@ -146,7 +146,7 @@
 
 				if(penchoice == "Change description")
 					var/input = stripped_input(user,"Describe \the [O.name] here", ,"", 100)
-					if(!QDELETED(O) && user.canUseTopic(O, be_close = TRUE))
+					if(!QDELETED(O) && user.canUseTopic(O, BE_CLOSE))
 						O.desc = input
 						to_chat(user, "You have successfully changed \the [O.name]'s description.")
 						return

--- a/code/modules/paperwork/photocopier.dm
+++ b/code/modules/paperwork/photocopier.dm
@@ -313,7 +313,7 @@
 
 /obj/machinery/photocopier/MouseDrop_T(mob/target, mob/user)
 	check_ass() //Just to make sure that you can re-drag somebody onto it after they moved off.
-	if (!istype(target) || target.anchored || target.buckled || !Adjacent(user) || !Adjacent(target) || !user.canUseTopic(src, 1) || target == ass || copier_blocked())
+	if (!istype(target) || target.anchored || target.buckled || !Adjacent(user) || !Adjacent(target) || !user.canUseTopic(src, BE_CLOSE) || target == ass || copier_blocked())
 		return
 	src.add_fingerprint(user)
 	if(target == user)

--- a/code/modules/paperwork/photocopier.dm
+++ b/code/modules/paperwork/photocopier.dm
@@ -313,7 +313,7 @@
 
 /obj/machinery/photocopier/MouseDrop_T(mob/target, mob/user)
 	check_ass() //Just to make sure that you can re-drag somebody onto it after they moved off.
-	if (!istype(target) || target.anchored || target.buckled || !Adjacent(user) || !Adjacent(target) || !user.canUseTopic(src, BE_CLOSE) || target == ass || copier_blocked())
+	if (!istype(target) || target.anchored || target.buckled || !Adjacent(target) || !user.canUseTopic(src, BE_CLOSE) || target == ass || copier_blocked())
 		return
 	src.add_fingerprint(user)
 	if(target == user)

--- a/code/modules/power/apc.dm
+++ b/code/modules/power/apc.dm
@@ -656,7 +656,7 @@
 
 /obj/machinery/power/apc/AltClick(mob/user)
 	..()
-	if(!issilicon(user) && (!user.canUseTopic(src, be_close=TRUE) || !isturf(loc)))
+	if(!issilicon(user) && (!user.canUseTopic(src, BE_CLOSE) || !isturf(loc)))
 		return
 	else
 		togglelock(user)

--- a/code/modules/power/apc.dm
+++ b/code/modules/power/apc.dm
@@ -657,7 +657,6 @@
 /obj/machinery/power/apc/AltClick(mob/user)
 	..()
 	if(!issilicon(user) && (!user.canUseTopic(src, be_close=TRUE) || !isturf(loc)))
-		to_chat(user, "<span class='warning'>You can't do that right now!</span>")
 		return
 	else
 		togglelock(user)

--- a/code/modules/power/apc.dm
+++ b/code/modules/power/apc.dm
@@ -656,7 +656,7 @@
 
 /obj/machinery/power/apc/AltClick(mob/user)
 	..()
-	if(!issilicon(user) && (!user.canUseTopic(src, BE_CLOSE) || !isturf(loc)))
+	if(!user.canUseTopic(src, !issilicon(user)) || !isturf(loc))
 		return
 	else
 		togglelock(user)

--- a/code/modules/projectiles/guns/ballistic/shotgun.dm
+++ b/code/modules/projectiles/guns/ballistic/shotgun.dm
@@ -239,8 +239,8 @@
 	else
 		to_chat(user, "You switch to tube A.")
 
-/obj/item/gun/ballistic/shotgun/automatic/dual_tube/AltClick(mob/living/carbon/user)
-	if(!istype(user) || !user.canUseTopic(src, BE_CLOSE, NO_DEXTERY))
+/obj/item/gun/ballistic/shotgun/automatic/dual_tube/AltClick(mob/living/user)
+	if(!istype(user) || !user.canUseTopic(src, BE_CLOSE, ismonkey(user)))
 		return
 	pump()
 

--- a/code/modules/projectiles/guns/ballistic/shotgun.dm
+++ b/code/modules/projectiles/guns/ballistic/shotgun.dm
@@ -240,7 +240,7 @@
 		to_chat(user, "You switch to tube A.")
 
 /obj/item/gun/ballistic/shotgun/automatic/dual_tube/AltClick(mob/living/carbon/user)
-	if(!istype(user) || !user.canUseTopic(src, be_close=TRUE, no_dextery=TRUE))
+	if(!istype(user) || !user.canUseTopic(src, BE_CLOSE, NO_DEXTERY))
 		return
 	pump()
 

--- a/code/modules/projectiles/guns/ballistic/shotgun.dm
+++ b/code/modules/projectiles/guns/ballistic/shotgun.dm
@@ -240,7 +240,7 @@
 		to_chat(user, "You switch to tube A.")
 
 /obj/item/gun/ballistic/shotgun/automatic/dual_tube/AltClick(mob/living/user)
-	if(user.incapacitated() || !Adjacent(user) || !istype(user))
+	if(!istype(user) || !user.canUseTopic(src, be_close=TRUE))
 		return
 	pump()
 

--- a/code/modules/projectiles/guns/ballistic/shotgun.dm
+++ b/code/modules/projectiles/guns/ballistic/shotgun.dm
@@ -239,8 +239,8 @@
 	else
 		to_chat(user, "You switch to tube A.")
 
-/obj/item/gun/ballistic/shotgun/automatic/dual_tube/AltClick(mob/living/user)
-	if(!istype(user) || !user.canUseTopic(src, be_close=TRUE))
+/obj/item/gun/ballistic/shotgun/automatic/dual_tube/AltClick(mob/living/carbon/user)
+	if(!istype(user) || !user.canUseTopic(src, be_close=TRUE, no_dextery=TRUE))
 		return
 	pump()
 

--- a/code/modules/reagents/chemistry/machinery/chem_master.dm
+++ b/code/modules/reagents/chemistry/machinery/chem_master.dm
@@ -223,7 +223,7 @@
 						return
 					vol_each = min(reagents.total_volume / amount, 50)
 				var/name = stripped_input(usr,"Name:","Name your pill!", "[reagents.get_master_reagent_name()] ([vol_each]u)", MAX_NAME_LEN)
-				if(!name || !reagents.total_volume || !src || QDELETED(src) || !usr.canUseTopic(src, be_close=TRUE))
+				if(!name || !reagents.total_volume || !src || QDELETED(src) || !usr.canUseTopic(src, BE_CLOSE))
 					return
 				var/obj/item/reagent_containers/pill/P
 
@@ -237,7 +237,7 @@
 					reagents.trans_to(P,vol_each)
 			else
 				var/name = stripped_input(usr, "Name:", "Name your pack!", reagents.get_master_reagent_name(), MAX_NAME_LEN)
-				if(!name || !reagents.total_volume || !src || QDELETED(src) || !usr.canUseTopic(src, be_close=TRUE))
+				if(!name || !reagents.total_volume || !src || QDELETED(src) || !usr.canUseTopic(src, BE_CLOSE))
 					return
 				var/obj/item/reagent_containers/food/condiment/pack/P = new/obj/item/reagent_containers/food/condiment/pack(drop_location())
 
@@ -259,7 +259,7 @@
 					return
 				vol_each = min(reagents.total_volume / amount, 40)
 			var/name = stripped_input(usr,"Name:","Name your patch!", "[reagents.get_master_reagent_name()] ([vol_each]u)", MAX_NAME_LEN)
-			if(!name || !reagents.total_volume || !src || QDELETED(src) || !usr.canUseTopic(src, be_close=TRUE))
+			if(!name || !reagents.total_volume || !src || QDELETED(src) || !usr.canUseTopic(src, BE_CLOSE))
 				return
 			var/obj/item/reagent_containers/pill/P
 
@@ -277,7 +277,7 @@
 
 			if(condi)
 				var/name = stripped_input(usr, "Name:","Name your bottle!", (reagents.total_volume ? reagents.get_master_reagent_name() : " "), MAX_NAME_LEN)
-				if(!name || !reagents.total_volume || !src || QDELETED(src) || !usr.canUseTopic(src, be_close=TRUE))
+				if(!name || !reagents.total_volume || !src || QDELETED(src) || !usr.canUseTopic(src, BE_CLOSE))
 					return
 				var/obj/item/reagent_containers/food/condiment/P = new(drop_location())
 				P.originalname = name
@@ -290,7 +290,7 @@
 					amount_full = round(reagents.total_volume / 30)
 					vol_part = reagents.total_volume % 30
 				var/name = stripped_input(usr, "Name:","Name your bottle!", (reagents.total_volume ? reagents.get_master_reagent_name() : " "), MAX_NAME_LEN)
-				if(!name || !reagents.total_volume || !src || QDELETED(src) || !usr.canUseTopic(src, be_close=TRUE))
+				if(!name || !reagents.total_volume || !src || QDELETED(src) || !usr.canUseTopic(src, BE_CLOSE))
 					return
 
 				var/obj/item/reagent_containers/glass/bottle/P

--- a/code/modules/vehicles/ridden.dm
+++ b/code/modules/vehicles/ridden.dm
@@ -42,7 +42,7 @@
 	return ..()
 
 /obj/vehicle/ridden/AltClick(mob/user)
-	if(user.canUseTopic(src, BE_CLOSE) && inserted_key)
+	if(inserted_key && user.canUseTopic(src, BE_CLOSE, ismonkey(user)))
 		if(!is_occupant(user))
 			to_chat(user, "<span class='notice'>You must be riding the [src] to remove [src]'s key!</span>")
 			return

--- a/code/modules/vehicles/ridden.dm
+++ b/code/modules/vehicles/ridden.dm
@@ -42,7 +42,7 @@
 	return ..()
 
 /obj/vehicle/ridden/AltClick(mob/user)
-	if(user.Adjacent(src) && inserted_key)
+	if(user.canUseTopic(src, be_close=TRUE) && inserted_key)
 		if(!is_occupant(user))
 			to_chat(user, "<span class='notice'>You must be riding the [src] to remove [src]'s key!</span>")
 			return

--- a/code/modules/vehicles/ridden.dm
+++ b/code/modules/vehicles/ridden.dm
@@ -42,7 +42,7 @@
 	return ..()
 
 /obj/vehicle/ridden/AltClick(mob/user)
-	if(user.canUseTopic(src, be_close=TRUE) && inserted_key)
+	if(user.canUseTopic(src, BE_CLOSE) && inserted_key)
 		if(!is_occupant(user))
 			to_chat(user, "<span class='notice'>You must be riding the [src] to remove [src]'s key!</span>")
 			return


### PR DESCRIPTION
fixes #35450
fixes #35498

Missing adjacency checks, stat checks, ect. This allowed players to teleport items around, open/close things without being near them, ect.

:cl: ShizCalev
fix: Corrected a number of missing checks when using alt-click actions. Please report any strange behavior to a coder.
/:cl: