### PR TITLE
Makes the thrower IC circuit have a proper cooldown.

### DIFF
--- a/code/modules/integrated_electronics/subtypes/manipulation.dm
+++ b/code/modules/integrated_electronics/subtypes/manipulation.dm
@@ -417,7 +417,7 @@
 	)
 	spawn_flags = IC_SPAWN_RESEARCH
 	power_draw_per_use = 50
-	cooldown_per_use = 50
+	cooldown_per_use = 40
 
 /obj/item/integrated_circuit/manipulation/thrower/do_work()
 	var/max_w_class = assembly.w_class

--- a/code/modules/integrated_electronics/subtypes/manipulation.dm
+++ b/code/modules/integrated_electronics/subtypes/manipulation.dm
@@ -405,7 +405,7 @@
 	projectile need to be inside the machine, or to be on an adjacent tile, and must be medium sized or smaller."
 	complexity = 15
 	w_class = WEIGHT_CLASS_SMALL
-	size = 2
+	size = 3
 	inputs = list(
 		"target X rel" = IC_PINTYPE_NUMBER,
 		"target Y rel" = IC_PINTYPE_NUMBER,

--- a/code/modules/integrated_electronics/subtypes/manipulation.dm
+++ b/code/modules/integrated_electronics/subtypes/manipulation.dm
@@ -417,6 +417,7 @@
 	)
 	spawn_flags = IC_SPAWN_RESEARCH
 	power_draw_per_use = 50
+	cooldown_per_use = 50
 
 /obj/item/integrated_circuit/manipulation/thrower/do_work()
 	var/max_w_class = assembly.w_class


### PR DESCRIPTION
[Changelogs]: 

:cl: Dax Dupont
balance: The IC thrower circuit now has a proper cooldown.
/:cl:

[why]: You can no longer make a device that crits someone by throwing hatchets in under 4 seconds.