### PR TITLE
Grabbers can now only contain things smaller than the assembly.

### DIFF
--- a/code/modules/integrated_electronics/subtypes/manipulation.dm
+++ b/code/modules/integrated_electronics/subtypes/manipulation.dm
@@ -399,7 +399,7 @@
 	projectile need to be inside the machine, or to be on an adjacent tile, and must be medium sized or smaller."
 	complexity = 15
 	w_class = WEIGHT_CLASS_SMALL
-	size = 3
+	size = 2
 	inputs = list(
 		"target X rel" = IC_PINTYPE_NUMBER,
 		"target Y rel" = IC_PINTYPE_NUMBER,
@@ -421,7 +421,7 @@
 	if(!A || A.anchored || A.throwing)
 		return
 
-	if(max_w_class && (A.w_class >= max_w_class))
+	if(max_w_class && (A.w_class > max_w_class))
 		return
 
 	// Is the target inside the assembly or close to it?

--- a/code/modules/integrated_electronics/subtypes/manipulation.dm
+++ b/code/modules/integrated_electronics/subtypes/manipulation.dm
@@ -399,7 +399,7 @@
 	projectile need to be inside the machine, or to be on an adjacent tile, and must be medium sized or smaller."
 	complexity = 15
 	w_class = WEIGHT_CLASS_SMALL
-	size = 2
+	size = 3
 	inputs = list(
 		"target X rel" = IC_PINTYPE_NUMBER,
 		"target Y rel" = IC_PINTYPE_NUMBER,
@@ -421,7 +421,7 @@
 	if(!A || A.anchored || A.throwing)
 		return
 
-	if(max_w_class && (A.w_class > max_w_class))
+	if(max_w_class && (A.w_class >= max_w_class))
 		return
 
 	// Is the target inside the assembly or close to it?

--- a/code/modules/integrated_electronics/subtypes/manipulation.dm
+++ b/code/modules/integrated_electronics/subtypes/manipulation.dm
@@ -315,16 +315,10 @@
 		if(mode == 1)
 			if(check_target(AM))
 				var/weightcheck = FALSE
-				if ((!istype(AM,/obj/item/device/electronic_assembly/)) && (!istype(AM,/obj/item/device/transfer_valve)))
-					if (AM.w_class <= max_w_class)
-						weightcheck = TRUE
-					else
-						weightcheck = FALSE
+				if (AM.w_class < max_w_class)
+					weightcheck = TRUE
 				else
-					if (AM.w_class < max_w_class)
-						weightcheck = TRUE
-					else
-						weightcheck = FALSE
+					weightcheck = FALSE
 				if((contents.len < max_items) && (weightcheck))
 					AM.forceMove(src)
 		if(mode == 0)


### PR DESCRIPTION
[Changelogs]: 

:cl: Dax Dupont
balance: Grabbers/throwers no longer can contain/throw things equal to the assembly size. 
/:cl:

[why]: I think this was a logic error.
Grabbers can hold 10 items, so arguably the objects shouldn't be the same weight class as the assembly holding the object.
