### PR TITLE
Fixes map configuration values for nonexistent maps applying to box

### DIFF
--- a/code/controllers/configuration/configuration.dm
+++ b/code/controllers/configuration/configuration.dm
@@ -239,6 +239,7 @@
 				currentmap = new ("_maps/[data].json")
 				if(currentmap.defaulted)
 					log_config("Failed to load map config for [data]!")
+					currentmap = null
 			if ("minplayers","minplayer")
 				currentmap.config_min_users = text2num(data)
 			if ("maxplayers","maxplayer")


### PR DESCRIPTION
This caused box'es min pop to get set to 50 because all of the servers still had cere defined with that limitation.

@Cyberboss 