### PR TITLE
Added chemical reaction unit tests

### DIFF
--- a/code/modules/reagents/chemistry/holder.dm
+++ b/code/modules/reagents/chemistry/holder.dm
@@ -1,4 +1,45 @@
 
+/proc/build_chemical_reagent_list()
+	//Chemical Reagents - Initialises all /datum/reagent into a list indexed by reagent id
+
+	if(GLOB.chemical_reagents_list)
+		return
+
+	var/paths = subtypesof(/datum/reagent)
+	GLOB.chemical_reagents_list = list()
+
+	for(var/path in paths)
+		var/datum/reagent/D = new path()
+		GLOB.chemical_reagents_list[D.id] = D
+
+/proc/build_chemical_reactions_list()
+	//Chemical Reactions - Initialises all /datum/chemical_reaction into a list
+	// It is filtered into multiple lists within a list.
+	// For example:
+	// chemical_reaction_list["plasma"] is a list of all reactions relating to plasma
+
+	if(GLOB.chemical_reactions_list)
+		return
+
+	var/paths = subtypesof(/datum/chemical_reaction)
+	GLOB.chemical_reactions_list = list()
+
+	for(var/path in paths)
+
+		var/datum/chemical_reaction/D = new path()
+		var/list/reaction_ids = list()
+
+		if(D.required_reagents && D.required_reagents.len)
+			for(var/reaction in D.required_reagents)
+				reaction_ids += reaction
+
+		// Create filters based on each reagent id in the required reagents list
+		for(var/id in reaction_ids)
+			if(!GLOB.chemical_reactions_list[id])
+				GLOB.chemical_reactions_list[id] = list()
+			GLOB.chemical_reactions_list[id] += D
+			break // Don't bother adding ourselves to other reagent ids, it is redundant
+.
 ///////////////////////////////////////////////////////////////////////////////////
 
 /datum/reagents
@@ -15,39 +56,11 @@
 /datum/reagents/New(maximum=100)
 	maximum_volume = maximum
 
-
 	//I dislike having these here but map-objects are initialised before world/New() is called. >_>
 	if(!GLOB.chemical_reagents_list)
-		//Chemical Reagents - Initialises all /datum/reagent into a list indexed by reagent id
-		var/paths = subtypesof(/datum/reagent)
-		GLOB.chemical_reagents_list = list()
-		for(var/path in paths)
-			var/datum/reagent/D = new path()
-			GLOB.chemical_reagents_list[D.id] = D
+		build_chemical_reagent_list()
 	if(!GLOB.chemical_reactions_list)
-		//Chemical Reactions - Initialises all /datum/chemical_reaction into a list
-		// It is filtered into multiple lists within a list.
-		// For example:
-		// chemical_reaction_list["plasma"] is a list of all reactions relating to plasma
-
-		var/paths = subtypesof(/datum/chemical_reaction)
-		GLOB.chemical_reactions_list = list()
-
-		for(var/path in paths)
-
-			var/datum/chemical_reaction/D = new path()
-			var/list/reaction_ids = list()
-
-			if(D.required_reagents && D.required_reagents.len)
-				for(var/reaction in D.required_reagents)
-					reaction_ids += reaction
-
-			// Create filters based on each reagent id in the required reagents list
-			for(var/id in reaction_ids)
-				if(!GLOB.chemical_reactions_list[id])
-					GLOB.chemical_reactions_list[id] = list()
-				GLOB.chemical_reactions_list[id] += D
-				break // Don't bother adding ourselves to other reagent ids, it is redundant.
+		build_chemical_reactions_list()
 
 /datum/reagents/Destroy()
 	. = ..()

--- a/code/modules/reagents/chemistry/recipes.dm
+++ b/code/modules/reagents/chemistry/recipes.dm
@@ -6,7 +6,7 @@
 	var/list/required_catalysts = new/list()
 
 	// Both of these variables are mostly going to be used with slime cores - but if you want to, you can use them for other things
-	var/atom/required_container = null // the container required for the reaction to happen
+	var/required_container = null // the exact container path required for the reaction to happen
 	var/required_other = 0 // an integer required for the reaction to happen
 
 	var/secondary = 0 // set to nonzero if secondary reaction

--- a/code/modules/unit_tests/_unit_tests.dm
+++ b/code/modules/unit_tests/_unit_tests.dm
@@ -2,4 +2,6 @@
 
 #ifdef UNIT_TESTS
 #include "unit_test.dm"
+#include "recipe_collisions.dm"
+#include "reagent_id_typos.dm"
 #endif

--- a/code/modules/unit_tests/_unit_tests.dm
+++ b/code/modules/unit_tests/_unit_tests.dm
@@ -2,6 +2,6 @@
 
 #ifdef UNIT_TESTS
 #include "unit_test.dm"
-#include "recipe_collisions.dm"
+#include "reagent_recipe_collisions.dm"
 #include "reagent_id_typos.dm"
 #endif

--- a/code/modules/unit_tests/reagent_id_typos.dm
+++ b/code/modules/unit_tests/reagent_id_typos.dm
@@ -1,0 +1,14 @@
+
+
+/datum/unit_test/reagent_id_typos
+
+/datum/unit_test/reagent_id_typos/Run()
+	build_chemical_reactions_list()
+	build_chemical_reagent_list()
+
+	for(var/I in GLOB.chemical_reactions_list)
+		for(var/V in GLOB.chemical_reactions_list[I])
+			var/datum/chemical_reaction/R = V
+			for(var/id in (R.required_reagents + R.required_catalysts))
+				if(!GLOB.chemical_reagents_list[id])
+					Fail("Unknown chemical id \"[id]\" in recipe [R.type]")

--- a/code/modules/unit_tests/reagent_recipe_collisions.dm
+++ b/code/modules/unit_tests/reagent_recipe_collisions.dm
@@ -1,8 +1,8 @@
 
 
-/datum/unit_test/recipe_collisions
+/datum/unit_test/reagent_recipe_collisions
 
-/datum/unit_test/recipe_collisions/Run()
+/datum/unit_test/reagent_recipe_collisions/Run()
 	build_chemical_reactions_list()
 	var/list/reactions = list()
 	for(var/V in GLOB.chemical_reactions_list)
@@ -14,7 +14,7 @@
 			if(recipes_do_conflict(r1, r2))
 				Fail("Chemical recipe conflict between [r1.type] and [r2.type]")
 
-/datum/unit_test/recipe_collisions/proc/recipes_do_conflict(datum/chemical_reaction/r1, datum/chemical_reaction/r2)
+/datum/unit_test/reagent_recipe_collisions/proc/recipes_do_conflict(datum/chemical_reaction/r1, datum/chemical_reaction/r2)
 	//do the non-list tests first, because they are cheaper
 	if(r1.required_temp != r2.required_temp)
 		return FALSE

--- a/code/modules/unit_tests/reagent_recipe_collisions.dm
+++ b/code/modules/unit_tests/reagent_recipe_collisions.dm
@@ -18,7 +18,11 @@
 	//do the non-list tests first, because they are cheaper
 	if(r1.required_container != r2.required_container)
 		return FALSE
-	if(r1.is_cold_recipe != r2.is_cold_recipe)
+	if(r1.is_cold_recipe == r2.is_cold_recipe)
+		if(r1.required_temp != r2.required_temp)
+			//one reaction requires a more extreme temperature than the other, so there is no conflict
+			return FALSE
+	else
 		var/datum/chemical_reaction/cold_one = r1.is_cold_recipe ? r1 : r2
 		var/datum/chemical_reaction/warm_one = r1.is_cold_recipe ? r2 : r1
 		if(cold_one.required_temp < warm_one.required_temp)

--- a/code/modules/unit_tests/reagent_recipe_collisions.dm
+++ b/code/modules/unit_tests/reagent_recipe_collisions.dm
@@ -16,12 +16,14 @@
 
 /datum/unit_test/reagent_recipe_collisions/proc/recipes_do_conflict(datum/chemical_reaction/r1, datum/chemical_reaction/r2)
 	//do the non-list tests first, because they are cheaper
-	if(r1.required_temp != r2.required_temp)
-		return FALSE
-	if(r1.is_cold_recipe != r2.is_cold_recipe)
-		return FALSE
 	if(r1.required_container != r2.required_container)
 		return FALSE
+	if(r1.is_cold_recipe != r2.is_cold_recipe)
+		var/datum/chemical_reaction/cold_one = r1.is_cold_recipe ? r1 : r2
+		var/datum/chemical_reaction/warm_one = r1.is_cold_recipe ? r2 : r1
+		if(cold_one.required_temp < warm_one.required_temp)
+			//the range of temperatures does not overlap, so there is no conflict
+			return FALSE
 
 	//find the reactions with the shorter and longer required_reagents list
 	var/datum/chemical_reaction/long_req

--- a/code/modules/unit_tests/recipe_collisions.dm
+++ b/code/modules/unit_tests/recipe_collisions.dm
@@ -1,0 +1,61 @@
+
+
+/datum/unit_test/recipe_collisions
+
+/datum/unit_test/recipe_collisions/Run()
+	build_chemical_reactions_list()
+	var/list/reactions = list()
+	for(var/V in GLOB.chemical_reactions_list)
+		reactions += GLOB.chemical_reactions_list[V]
+	for(var/i in 1 to (reactions.len-1))
+		for(var/i2 in (i+1) to reactions.len)
+			var/datum/chemical_reaction/r1 = reactions[i]
+			var/datum/chemical_reaction/r2 = reactions[i2]
+			if(recipes_do_conflict(r1, r2))
+				Fail("Chemical recipe conflict between [r1.type] and [r2.type]")
+
+/datum/unit_test/recipe_collisions/proc/recipes_do_conflict(datum/chemical_reaction/r1, datum/chemical_reaction/r2)
+	//do the non-list tests first, because they are cheaper
+	if(r1.required_temp != r2.required_temp)
+		return FALSE
+	if(r1.is_cold_recipe != r2.is_cold_recipe)
+		return FALSE
+	if(r1.required_container != r2.required_container)
+		return FALSE
+
+	//find the reactions with the shorter and longer required_reagents list
+	var/datum/chemical_reaction/long_req
+	var/datum/chemical_reaction/short_req
+	if(r1.required_reagents.len > r2.required_reagents.len)
+		long_req = r1
+		short_req = r2
+	else if(r1.required_reagents.len < r2.required_reagents.len)
+		long_req = r2
+		short_req = r1
+	else
+		//if they are the same length, sort instead by the length of the catalyst list
+		//this is important if the required_reagents lists are the same
+		if(r1.required_catalysts.len > r2.required_catalysts.len)
+			long_req = r1
+			short_req = r2
+		else
+			long_req = r2
+			short_req = r1
+
+
+	//check if the shorter reaction list is a subset of the longer one
+	var/list/overlap = r1.required_reagents & r2.required_reagents
+	if(overlap.len != short_req.required_reagents.len)
+		//there is at least one reagent in the short list that is not in the long list, so there is no conflict
+		return FALSE
+
+	//check to see if the shorter reaction's catalyst list is also a subset of the longer reaction's catalyst list
+	//if the longer reaction's catalyst list is a subset of the shorter ones, that is fine
+	//if the reaction lists are the same, the short reaction will have the shorter required_catalysts list, so it will register as a conflict
+	var/list/short_minus_long_catalysts = short_req.required_catalysts - long_req.required_catalysts
+	if(short_minus_long_catalysts.len)
+		//there is at least one unique catalyst for the short reaction, so there is no conflict
+		return FALSE
+
+	//if we got this far, the longer reaction will be impossible to create if the shorter one is earlier in GLOB.chemical_reactions_list, and will require the reagents to be added in a particular order otherwise
+	return TRUE


### PR DESCRIPTION
Added a unit test for misspelt chemical IDs in chemical reaction datums, and a unit test for chemical reaction conflicts. Travis will fail because there will be two recipe conflicts until #35479 or a similar PR is merged.

To avoid having to redo a very large number of recipes, possible reactions that require a more extreme temperature will now be chosen over reactions that require a less extreme temperature. For example:

The recipe for carbon dioxide requires carbon and oxygen, and a temperature of at least 777.
The recipe for bicaridine requires carbon, oxygen and sugar, and a temperature of at least 0.
If you add carbon to a reagent container that contains sugar and oxygen, if the reagent temperature of the mixture is 777 or above, the carbon dioxide recipe will always be chosen, because the carbon dioxide recipe has a more extreme temperature requirement.

No mixture should ever have some possible reactions that require cold and some that require heat. If there are ever a combination of reactions that this could happen for, the unit test will catch it.