### PR TITLE
Fixed chemical recipe conflicts

### DIFF
--- a/code/modules/food_and_drinks/recipes/drinks_recipes.dm
+++ b/code/modules/food_and_drinks/recipes/drinks_recipes.dm
@@ -441,7 +441,7 @@
 	name = "Chocolate Pudding"
 	id = "chocolatepudding"
 	results = list("chocolatepudding" = 20)
-	required_reagents = list("cocoa" = 5, "milk" = 5, "eggyolk" = 5)
+	required_reagents = list("chocolate_milk" = 10, "eggyolk" = 5)
 
 /datum/chemical_reaction/vanillapudding
 	name = "Vanilla Pudding"

--- a/code/modules/reagents/chemistry/recipes/toxins.dm
+++ b/code/modules/reagents/chemistry/recipes/toxins.dm
@@ -55,7 +55,7 @@
 	name = "Lexorin"
 	id = "lexorin"
 	results = list("lexorin" = 3)
-	required_reagents = list("plasma" = 1, "hydrogen" = 1, "nitrogen" = 1)
+	required_reagents = list("plasma" = 1, "hydrogen" = 1, "oxygen" = 1)
 
 /datum/chemical_reaction/chloralhydrate
 	name = "Chloral Hydrate"


### PR DESCRIPTION
:cl:
balance: Changed the chemical recipe for Lexorin from plasma, hydrogen, and nitrogen to plasma, hydrogen, and oxygen.
fix: These were necessary due to recipe conflicts
/:cl:

Lexorin currently only works if you put the plasma in first (which almost everyone does, because it involves a grinder), and only because "plasma" is earlier than "hydrogen" in GLOB.chemical_reactions_list. Rejigging the order of the recipe datums would break this, so the code should not depend on it.

The chocolate pudding recipe works exactly like it used to, but fixing lexorin in the same way would require making it in batches of 9 instead of batches of 3, because you would have to add ammonia to the recipe and ammonia is always made in batches of 3.
