### PR TITLE
Fixes limbgrower having max volume of 0

### DIFF
--- a/code/game/machinery/limbgrower.dm
+++ b/code/game/machinery/limbgrower.dm
@@ -34,7 +34,7 @@
 
 /obj/machinery/limbgrower/Initialize()
 	. = ..()
-	create_reagents(0)
+	create_reagents(100)
 	stored_research = new /datum/techweb/specialized/autounlocking/limbgrower
 
 /obj/machinery/limbgrower/interact(mob/user)

--- a/code/game/machinery/limbgrower.dm
+++ b/code/game/machinery/limbgrower.dm
@@ -33,9 +33,9 @@
 							)
 
 /obj/machinery/limbgrower/Initialize()
-	. = ..()
 	create_reagents(100)
 	stored_research = new /datum/techweb/specialized/autounlocking/limbgrower
+	. = ..()
 
 /obj/machinery/limbgrower/interact(mob/user)
 	if(!is_operational())


### PR DESCRIPTION
:cl: Robustin
fix: Fixed the limb grower having a max volume of 0.
/:cl:
