### PR TITLE
Fixed cloning pod status not updating when autocloning.

### DIFF
--- a/code/game/machinery/computer/cloning.dm
+++ b/code/game/machinery/computer/cloning.dm
@@ -72,6 +72,7 @@
 			continue	//how though?
 
 		if(pod.growclone(R.fields["ckey"], R.fields["name"], R.fields["UI"], R.fields["SE"], R.fields["mind"], R.fields["mrace"], R.fields["features"], R.fields["factions"]))
+			temp = "[R.fields["name"]] => <font class='good'>Cloning cycle in progress...</font>"
 			records -= R
 
 /obj/machinery/computer/cloning/proc/updatemodules(findfirstcloner)


### PR DESCRIPTION
[Changelogs]:

:cl: Dax Dupont
fix: Cloner UI now properly updates cloning pod status when autocloning starts cloning someone.
/:cl:

[why]: it fixes a bug