### PR TITLE
Removed admin requirement for the notify chat command

### DIFF
--- a/code/modules/admin/chat_commands.dm
+++ b/code/modules/admin/chat_commands.dm
@@ -75,7 +75,6 @@ GLOBAL_LIST(round_end_notifiees)
 /datum/server_tools_command/notify
 	name = "notify"
 	help_text = "Pings the invoker when the round ends"
-	admin_only = TRUE
 
 /datum/server_tools_command/notify/Run(sender, params)
 	if(!SSticker.IsRoundInProgress() && SSticker.HasRoundStarted())


### PR DESCRIPTION
There's no real reason to keep this locked to admins

:cl:
admin: The notify irc/discord bot chat command no longer requires admin privileges.
/:cl:
