### PR TITLE
Removes duplicate air alarm on meta.

### DIFF
--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -69550,10 +69550,6 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
 "cOF" = (
-/obj/machinery/airalarm{
-	dir = 1;
-	pixel_y = -22
-	},
 /obj/structure/table,
 /obj/item/storage/box/bodybags{
 	pixel_x = 2;


### PR DESCRIPTION
[Changelogs]: 

:cl: Dax Dupont 
fix: Fixes duplicate air alarm on meta.
/:cl:

[why]:  fixes #35500