### PR TITLE
Megafauna doesn't go in machines

### DIFF
--- a/code/game/machinery/_machinery.dm
+++ b/code/game/machinery/_machinery.dm
@@ -184,7 +184,7 @@ Class Procs:
 				continue
 			if(isliving(AM))
 				var/mob/living/L = am
-				if(L.buckled)
+				if(L.buckled || L.mob_size >= MOB_SIZE_LARGE)
 					continue
 			target = am
 


### PR DESCRIPTION
:cl:
fix: Prevents megafauna (and other large things like spiders and mulebots) from going into machines
/:cl:

The flight plan I just filed with the Agency lists me, my men, and Dr. Pavel here. But only one of you.