### PR TITLE
Fixes syndicate ruin objects having bugged access requirements

### DIFF
--- a/_maps/RandomRuins/LavaRuins/lavaland_surface_syndicate_base1.dmm
+++ b/_maps/RandomRuins/LavaRuins/lavaland_surface_syndicate_base1.dmm
@@ -44,7 +44,8 @@
 /obj/machinery/airalarm{
 	dir = 4;
 	pixel_x = -24;
-	req_access = list(150)
+	req_access = null;
+	req_access_txt = "150"
 	},
 /turf/open/floor/plasteel/red/side{
 	dir = 8
@@ -166,7 +167,8 @@
 	dir = 8;
 	name = "Chemistry APC";
 	pixel_x = -24;
-	req_access = list(150)
+	req_access = null;
+	req_access_txt = "150"
 	},
 /obj/structure/cable/yellow{
 	icon_state = "0-2"
@@ -263,7 +265,8 @@
 "dL" = (
 /obj/machinery/airalarm{
 	pixel_y = 24;
-	req_access = list(150)
+	req_access = null;
+	req_access_txt = "150"
 	},
 /obj/structure/closet/crate,
 /obj/item/extinguisher{
@@ -413,7 +416,8 @@
 /obj/machinery/airalarm{
 	dir = 8;
 	pixel_x = 24;
-	req_access = list(150)
+	req_access = null;
+	req_access_txt = "150"
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/white/side{
@@ -505,7 +509,8 @@
 	dir = 1;
 	name = "Cargo Bay APC";
 	pixel_y = 24;
-	req_access = list(150)
+	req_access = null;
+	req_access_txt = "150"
 	},
 /obj/structure/closet/emcloset/anchored,
 /obj/effect/decal/cleanable/dirt,
@@ -1168,7 +1173,8 @@
 	dir = 1;
 	name = "Virology APC";
 	pixel_y = 24;
-	req_access = list(150)
+	req_access = null;
+	req_access_txt = "150"
 	},
 /obj/structure/cable/yellow{
 	icon_state = "0-2"
@@ -1201,7 +1207,8 @@
 	dir = 2;
 	name = "Experimentation Lab APC";
 	pixel_y = -24;
-	req_access = list(150)
+	req_access = null;
+	req_access_txt = "150"
 	},
 /obj/structure/cable/yellow{
 	icon_state = "0-4"
@@ -1355,7 +1362,8 @@
 /obj/machinery/airalarm{
 	dir = 4;
 	pixel_x = -24;
-	req_access = list(150)
+	req_access = null;
+	req_access_txt = "150"
 	},
 /obj/structure/table,
 /obj/item/clothing/suit/hazardvest,
@@ -1461,7 +1469,8 @@
 	},
 /obj/machinery/airalarm{
 	pixel_y = 24;
-	req_access = list(150)
+	req_access = null;
+	req_access_txt = "150"
 	},
 /turf/open/floor/plasteel/floorgrime,
 /area/ruin/unpowered/syndicate_lava_base/main)
@@ -2011,7 +2020,8 @@
 /obj/machinery/airalarm{
 	dir = 4;
 	pixel_x = -24;
-	req_access = list(150)
+	req_access = null;
+	req_access_txt = "150"
 	},
 /obj/structure/sink{
 	dir = 8;
@@ -2283,7 +2293,8 @@
 /obj/machinery/airalarm{
 	dir = 4;
 	pixel_x = -24;
-	req_access = list(150)
+	req_access = null;
+	req_access_txt = "150"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -2420,7 +2431,8 @@
 /obj/item/ammo_box/magazine/sniper_rounds,
 /obj/machinery/airalarm{
 	pixel_y = 24;
-	req_access = list(150)
+	req_access = null;
+	req_access_txt = "150"
 	},
 /turf/open/floor/plasteel/grimy,
 /area/ruin/unpowered/syndicate_lava_base/dormitories)
@@ -2454,7 +2466,8 @@
 /obj/item/ammo_box/magazine/m10mm,
 /obj/machinery/airalarm{
 	pixel_y = 24;
-	req_access = list(150)
+	req_access = null;
+	req_access_txt = "150"
 	},
 /turf/open/floor/plasteel/grimy,
 /area/ruin/unpowered/syndicate_lava_base/dormitories)
@@ -2776,7 +2789,8 @@
 "iB" = (
 /obj/machinery/airalarm{
 	pixel_y = 24;
-	req_access = list(150)
+	req_access = null;
+	req_access_txt = "150"
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on,
 /obj/effect/decal/cleanable/dirt,
@@ -2865,7 +2879,8 @@
 /obj/machinery/airalarm{
 	dir = 8;
 	pixel_x = 24;
-	req_access = list(150)
+	req_access = null;
+	req_access_txt = "150"
 	},
 /turf/open/floor/circuit/red,
 /area/ruin/unpowered/syndicate_lava_base/main)
@@ -3002,7 +3017,8 @@
 	dir = 2;
 	name = "Dormitories APC";
 	pixel_y = -24;
-	req_access = list(150)
+	req_access = null;
+	req_access_txt = "150"
 	},
 /obj/structure/cable/yellow{
 	icon_state = "0-8"
@@ -3153,7 +3169,8 @@
 	dir = 8;
 	name = "Primary Hallway APC";
 	pixel_x = -24;
-	req_access = list(150)
+	req_access = null;
+	req_access_txt = "150"
 	},
 /turf/open/floor/plasteel/red/side{
 	dir = 8
@@ -3187,7 +3204,8 @@
 	},
 /obj/machinery/airalarm{
 	pixel_y = 24;
-	req_access = list(150)
+	req_access = null;
+	req_access_txt = "150"
 	},
 /turf/open/floor/plasteel/grimy,
 /area/ruin/unpowered/syndicate_lava_base/dormitories)
@@ -3222,7 +3240,8 @@
 	},
 /obj/machinery/airalarm{
 	pixel_y = 24;
-	req_access = list(150)
+	req_access = null;
+	req_access_txt = "150"
 	},
 /turf/open/floor/plasteel/grimy,
 /area/ruin/unpowered/syndicate_lava_base/dormitories)
@@ -3417,7 +3436,8 @@
 /obj/machinery/airalarm{
 	dir = 8;
 	pixel_x = 24;
-	req_access = list(150)
+	req_access = null;
+	req_access_txt = "150"
 	},
 /obj/structure/cable/yellow{
 	icon_state = "2-8"
@@ -3791,7 +3811,8 @@
 /obj/machinery/airalarm{
 	dir = 8;
 	pixel_x = 24;
-	req_access = list(150)
+	req_access = null;
+	req_access_txt = "150"
 	},
 /obj/machinery/vending/coffee{
 	extended_inventory = 1
@@ -3894,7 +3915,8 @@
 	dir = 1;
 	name = "Engineering APC";
 	pixel_y = 24;
-	req_access = list(150)
+	req_access = null;
+	req_access_txt = "150"
 	},
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
@@ -4459,7 +4481,8 @@
 /obj/machinery/airalarm{
 	dir = 4;
 	pixel_x = -24;
-	req_access = list(150)
+	req_access = null;
+	req_access_txt = "150"
 	},
 /obj/machinery/light/small{
 	dir = 8
@@ -4546,7 +4569,8 @@
 /obj/machinery/airalarm{
 	dir = 4;
 	pixel_x = -24;
-	req_access = list(150)
+	req_access = null;
+	req_access_txt = "150"
 	},
 /obj/structure/chair/stool,
 /turf/open/floor/plasteel/vault{
@@ -4689,7 +4713,8 @@
 /obj/machinery/airalarm{
 	dir = 8;
 	pixel_x = 24;
-	req_access = list(150)
+	req_access = null;
+	req_access_txt = "150"
 	},
 /turf/open/floor/plasteel/floorgrime,
 /area/ruin/unpowered/syndicate_lava_base/medbay)
@@ -4808,7 +4833,8 @@
 	dir = 2;
 	name = "Bar APC";
 	pixel_y = -24;
-	req_access = list(150)
+	req_access = null;
+	req_access_txt = "150"
 	},
 /turf/open/floor/wood,
 /area/ruin/unpowered/syndicate_lava_base/bar)
@@ -5257,7 +5283,8 @@
 	dir = 1;
 	name = "Arrival Hallway APC";
 	pixel_y = 24;
-	req_access = list(150)
+	req_access = null;
+	req_access_txt = "150"
 	},
 /obj/structure/cable/yellow{
 	icon_state = "0-4"
@@ -5430,7 +5457,8 @@
 /obj/machinery/airalarm{
 	dir = 4;
 	pixel_x = -24;
-	req_access = list(150)
+	req_access = null;
+	req_access_txt = "150"
 	},
 /obj/machinery/light/small{
 	dir = 8
@@ -5636,7 +5664,8 @@
 	},
 /obj/machinery/airalarm{
 	pixel_y = 24;
-	req_access = list(150)
+	req_access = null;
+	req_access_txt = "150"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -5706,7 +5735,8 @@
 	dir = 4;
 	name = "Medbay APC";
 	pixel_x = 24;
-	req_access = list(150)
+	req_access = null;
+	req_access_txt = "150"
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/white/side{
@@ -5790,7 +5820,8 @@
 	dir = 2;
 	name = "Telecommunications APC";
 	pixel_y = -24;
-	req_access = list(150)
+	req_access = null;
+	req_access_txt = "150"
 	},
 /turf/open/floor/plasteel/vault{
 	dir = 5

--- a/_maps/RandomRuins/SpaceRuins/caravanambush.dmm
+++ b/_maps/RandomRuins/SpaceRuins/caravanambush.dmm
@@ -1538,7 +1538,8 @@
 	name = "Shuttle turret control";
 	pixel_x = 32;
 	pixel_y = 32;
-	req_access = list(150)
+	req_access = null;
+	req_access_txt = "150"
 	},
 /obj/structure/cable/yellow{
 	icon_state = "0-4"
@@ -3308,7 +3309,8 @@
 	dir = 8;
 	name = "Syndicate Drop Ship APC";
 	pixel_x = -24;
-	req_access = list(150)
+	req_access = null;
+	req_access_txt = "150"
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/pod/dark,
@@ -3317,7 +3319,8 @@
 /obj/structure/chair,
 /obj/machinery/airalarm{
 	pixel_y = 24;
-	req_access = list(150)
+	req_access = null;
+	req_access_txt = "150"
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/pod/dark,
@@ -3444,7 +3447,8 @@
 	dir = 2;
 	name = "Syndicate Fighter APC";
 	pixel_y = -24;
-	req_access = list(150)
+	req_access = null;
+	req_access_txt = "150"
 	},
 /obj/structure/cable/yellow{
 	icon_state = "0-8"
@@ -3498,7 +3502,8 @@
 /obj/machinery/airalarm{
 	dir = 4;
 	pixel_x = -24;
-	req_access = list(150)
+	req_access = null;
+	req_access_txt = "150"
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/dark,
@@ -3516,7 +3521,8 @@
 /obj/machinery/airalarm{
 	dir = 4;
 	pixel_x = -24;
-	req_access = list(150)
+	req_access = null;
+	req_access_txt = "150"
 	},
 /turf/open/floor/plasteel/dark,
 /area/shuttle/caravan/syndicate3)
@@ -3532,7 +3538,8 @@
 	lethal = 1;
 	name = "Shuttle turret control";
 	pixel_y = 34;
-	req_access = list(150)
+	req_access = null;
+	req_access_txt = "150"
 	},
 /turf/open/floor/plasteel/darkred/corner{
 	dir = 4
@@ -3620,7 +3627,8 @@
 	name = "Shuttle turret control";
 	pixel_x = 32;
 	pixel_y = -28;
-	req_access = list(150)
+	req_access = null;
+	req_access_txt = "150"
 	},
 /obj/structure/cable/yellow{
 	icon_state = "0-2"
@@ -3705,7 +3713,8 @@
 	dir = 8;
 	name = "Syndicate Fighter APC";
 	pixel_x = -24;
-	req_access = list(150)
+	req_access = null;
+	req_access_txt = "150"
 	},
 /obj/machinery/computer/security{
 	dir = 1;

--- a/_maps/RandomRuins/SpaceRuins/listeningstation.dmm
+++ b/_maps/RandomRuins/SpaceRuins/listeningstation.dmm
@@ -14,7 +14,8 @@
 	},
 /obj/machinery/airalarm{
 	pixel_y = 24;
-	req_access = list(150)
+	req_access = null;
+	req_access_txt = "150"
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -208,7 +209,8 @@
 /obj/machinery/airalarm{
 	dir = 4;
 	pixel_x = -24;
-	req_access = list(150)
+	req_access = null;
+	req_access_txt = "150"
 	},
 /turf/open/floor/plasteel/dark,
 /area/ruin/space/has_grav/listeningstation)
@@ -513,7 +515,8 @@
 "aU" = (
 /obj/machinery/airalarm{
 	pixel_y = 24;
-	req_access = list(150)
+	req_access = null;
+	req_access_txt = "150"
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
@@ -636,7 +639,8 @@
 /obj/machinery/airalarm{
 	dir = 8;
 	pixel_x = 24;
-	req_access = list(150)
+	req_access = null;
+	req_access_txt = "150"
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -808,7 +812,8 @@
 	dir = 4;
 	name = "Syndicate Listening Post APC";
 	pixel_x = 24;
-	req_access = list(150)
+	req_access = null;
+	req_access_txt = "150"
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,


### PR DESCRIPTION
:cl: Denton
fix: Fixed an issue where syndicate agents were unable to unlock their own APCs, air alarms and turret panels.
/:cl:

Some syndicate objects (APC, air alarm, turret control) had incorrect access reqs that prevented syndicate IDs from being able to lock/unlock them.