### PR TITLE
[s]Blacklists the most recent version of byond for basically being a wall hack

### DIFF
--- a/code/modules/client/client_procs.dm
+++ b/code/modules/client/client_procs.dm
@@ -3,6 +3,8 @@
 	////////////
 #define UPLOAD_LIMIT		1048576	//Restricts client uploads to the server to 1MB //Could probably do with being lower.
 
+GLOBAL_LIST_INIT(blacklisted_builds, list(1407 = "bug preventing client display overrides from working leads to clients being able to see things/mobs they shouldn't be able to see"))
+
 #define LIMITER_SIZE	5
 #define CURRENT_SECOND	1
 #define SECOND_COUNT	2
@@ -225,7 +227,18 @@ GLOBAL_LIST_EMPTY(external_rsc_urls)
 
 
 	. = ..()	//calls mob.Login()
-
+	#if DM_VERSION >= 512
+	if (byond_build in blacklisted_builds)
+		log_access("Failed login: blacklisted byond version")
+		to_chat(src, "<span class='userdanger'>Your version of byond is blacklisted.</span>")
+		to_chat(src, "<span class='danger'>Byond build [byond_build] ([byond_version].[byond_build]) has been blacklisted for the following reason: [blacklisted_builds[byond_build]].</span>")
+		to_chat(src, "<span class='danger'>Please download a new version of byond. if [byond_build] is the latest, you can go to http://www.byond.com/download/build/ to download other versions.</span>")
+		if(connecting_admin)
+			to_chat(src, "As an admin, you are being allowed to continue using this version, but please consider changing byond versions"
+		else 
+			qdel(src)
+			return
+	#endif
 	if(SSinput.initialized)
 		set_macros()
 

--- a/code/modules/client/client_procs.dm
+++ b/code/modules/client/client_procs.dm
@@ -234,7 +234,7 @@ GLOBAL_LIST_EMPTY(external_rsc_urls)
 		to_chat(src, "<span class='danger'>Byond build [byond_build] ([byond_version].[byond_build]) has been blacklisted for the following reason: [blacklisted_builds[byond_build]].</span>")
 		to_chat(src, "<span class='danger'>Please download a new version of byond. if [byond_build] is the latest, you can go to http://www.byond.com/download/build/ to download other versions.</span>")
 		if(connecting_admin)
-			to_chat(src, "As an admin, you are being allowed to continue using this version, but please consider changing byond versions"
+			to_chat(src, "As an admin, you are being allowed to continue using this version, but please consider changing byond versions")
 		else 
 			qdel(src)
 			return

--- a/code/modules/client/client_procs.dm
+++ b/code/modules/client/client_procs.dm
@@ -228,10 +228,10 @@ GLOBAL_LIST_EMPTY(external_rsc_urls)
 
 	. = ..()	//calls mob.Login()
 	#if DM_VERSION >= 512
-	if (byond_build in blacklisted_builds)
+	if (byond_build in GLOB.blacklisted_builds)
 		log_access("Failed login: blacklisted byond version")
 		to_chat(src, "<span class='userdanger'>Your version of byond is blacklisted.</span>")
-		to_chat(src, "<span class='danger'>Byond build [byond_build] ([byond_version].[byond_build]) has been blacklisted for the following reason: [blacklisted_builds[byond_build]].</span>")
+		to_chat(src, "<span class='danger'>Byond build [byond_build] ([byond_version].[byond_build]) has been blacklisted for the following reason: [GLOB.blacklisted_builds[byond_build]].</span>")
 		to_chat(src, "<span class='danger'>Please download a new version of byond. if [byond_build] is the latest, you can go to http://www.byond.com/download/build/ to download other versions.</span>")
 		if(connecting_admin)
 			to_chat(src, "As an admin, you are being allowed to continue using this version, but please consider changing byond versions")


### PR DESCRIPTION
1407 breaks client images such that half of them don't even show up, this allows ais to see tiles they shouldn't be able to see, as well as any other hiding we do with image.override. 