### PR TITLE
Actually fixes broken accesses

### DIFF
--- a/_maps/RandomRuins/LavaRuins/lavaland_surface_syndicate_base1.dmm
+++ b/_maps/RandomRuins/LavaRuins/lavaland_surface_syndicate_base1.dmm
@@ -44,7 +44,8 @@
 /obj/machinery/airalarm{
 	dir = 4;
 	pixel_x = -24;
-	req_access = list(150)
+	req_access = null;
+	req_access_txt = "150"
 	},
 /turf/open/floor/plasteel/red/side{
 	dir = 8
@@ -166,7 +167,8 @@
 	dir = 8;
 	name = "Chemistry APC";
 	pixel_x = -24;
-	req_access = list(150)
+	req_access = null;
+	req_access_txt = "150"
 	},
 /obj/structure/cable/yellow{
 	icon_state = "0-2"
@@ -263,7 +265,8 @@
 "dL" = (
 /obj/machinery/airalarm{
 	pixel_y = 24;
-	req_access = list(150)
+	req_access = null;
+	req_access_txt = "150"
 	},
 /obj/structure/closet/crate,
 /obj/item/extinguisher{
@@ -413,7 +416,8 @@
 /obj/machinery/airalarm{
 	dir = 8;
 	pixel_x = 24;
-	req_access = list(150)
+	req_access = null;
+	req_access_txt = "150"
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/white/side{
@@ -505,7 +509,8 @@
 	dir = 1;
 	name = "Cargo Bay APC";
 	pixel_y = 24;
-	req_access = list(150)
+	req_access = null;
+	req_access_txt = "150"
 	},
 /obj/structure/closet/emcloset/anchored,
 /obj/effect/decal/cleanable/dirt,
@@ -1168,7 +1173,8 @@
 	dir = 1;
 	name = "Virology APC";
 	pixel_y = 24;
-	req_access = list(150)
+	req_access = null;
+	req_access_txt = "150"
 	},
 /obj/structure/cable/yellow{
 	icon_state = "0-2"
@@ -1201,7 +1207,8 @@
 	dir = 2;
 	name = "Experimentation Lab APC";
 	pixel_y = -24;
-	req_access = list(150)
+	req_access = null;
+	req_access_txt = "150"
 	},
 /obj/structure/cable/yellow{
 	icon_state = "0-4"
@@ -1355,7 +1362,8 @@
 /obj/machinery/airalarm{
 	dir = 4;
 	pixel_x = -24;
-	req_access = list(150)
+	req_access = null;
+	req_access_txt = "150"
 	},
 /obj/structure/table,
 /obj/item/clothing/suit/hazardvest,
@@ -1461,7 +1469,8 @@
 	},
 /obj/machinery/airalarm{
 	pixel_y = 24;
-	req_access = list(150)
+	req_access = null;
+	req_access_txt = "150"
 	},
 /turf/open/floor/plasteel/floorgrime,
 /area/ruin/unpowered/syndicate_lava_base/main)
@@ -2011,7 +2020,8 @@
 /obj/machinery/airalarm{
 	dir = 4;
 	pixel_x = -24;
-	req_access = list(150)
+	req_access = null;
+	req_access_txt = "150"
 	},
 /obj/structure/sink{
 	dir = 8;
@@ -2283,7 +2293,8 @@
 /obj/machinery/airalarm{
 	dir = 4;
 	pixel_x = -24;
-	req_access = list(150)
+	req_access = null;
+	req_access_txt = "150"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -2420,7 +2431,8 @@
 /obj/item/ammo_box/magazine/sniper_rounds,
 /obj/machinery/airalarm{
 	pixel_y = 24;
-	req_access = list(150)
+	req_access = null;
+	req_access_txt = "150"
 	},
 /turf/open/floor/plasteel/grimy,
 /area/ruin/unpowered/syndicate_lava_base/dormitories)
@@ -2454,7 +2466,8 @@
 /obj/item/ammo_box/magazine/m10mm,
 /obj/machinery/airalarm{
 	pixel_y = 24;
-	req_access = list(150)
+	req_access = null;
+	req_access_txt = "150"
 	},
 /turf/open/floor/plasteel/grimy,
 /area/ruin/unpowered/syndicate_lava_base/dormitories)
@@ -2776,7 +2789,8 @@
 "iB" = (
 /obj/machinery/airalarm{
 	pixel_y = 24;
-	req_access = list(150)
+	req_access = null;
+	req_access_txt = "150"
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on,
 /obj/effect/decal/cleanable/dirt,
@@ -2865,7 +2879,8 @@
 /obj/machinery/airalarm{
 	dir = 8;
 	pixel_x = 24;
-	req_access = list(150)
+	req_access = null;
+	req_access_txt = "150"
 	},
 /turf/open/floor/circuit/red,
 /area/ruin/unpowered/syndicate_lava_base/main)
@@ -3002,7 +3017,8 @@
 	dir = 2;
 	name = "Dormitories APC";
 	pixel_y = -24;
-	req_access = list(150)
+	req_access = null;
+	req_access_txt = "150"
 	},
 /obj/structure/cable/yellow{
 	icon_state = "0-8"
@@ -3153,7 +3169,8 @@
 	dir = 8;
 	name = "Primary Hallway APC";
 	pixel_x = -24;
-	req_access = list(150)
+	req_access = null;
+	req_access_txt = "150"
 	},
 /turf/open/floor/plasteel/red/side{
 	dir = 8
@@ -3187,7 +3204,8 @@
 	},
 /obj/machinery/airalarm{
 	pixel_y = 24;
-	req_access = list(150)
+	req_access = null;
+	req_access_txt = "150"
 	},
 /turf/open/floor/plasteel/grimy,
 /area/ruin/unpowered/syndicate_lava_base/dormitories)
@@ -3222,7 +3240,8 @@
 	},
 /obj/machinery/airalarm{
 	pixel_y = 24;
-	req_access = list(150)
+	req_access = null;
+	req_access_txt = "150"
 	},
 /turf/open/floor/plasteel/grimy,
 /area/ruin/unpowered/syndicate_lava_base/dormitories)
@@ -3417,7 +3436,8 @@
 /obj/machinery/airalarm{
 	dir = 8;
 	pixel_x = 24;
-	req_access = list(150)
+	req_access = null;
+	req_access_txt = "150"
 	},
 /obj/structure/cable/yellow{
 	icon_state = "2-8"
@@ -3791,7 +3811,8 @@
 /obj/machinery/airalarm{
 	dir = 8;
 	pixel_x = 24;
-	req_access = list(150)
+	req_access = null;
+	req_access_txt = "150"
 	},
 /obj/machinery/vending/coffee{
 	extended_inventory = 1
@@ -3894,7 +3915,8 @@
 	dir = 1;
 	name = "Engineering APC";
 	pixel_y = 24;
-	req_access = list(150)
+	req_access = null;
+	req_access_txt = "150"
 	},
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
@@ -4459,7 +4481,8 @@
 /obj/machinery/airalarm{
 	dir = 4;
 	pixel_x = -24;
-	req_access = list(150)
+	req_access = null;
+	req_access_txt = "150"
 	},
 /obj/machinery/light/small{
 	dir = 8
@@ -4546,7 +4569,8 @@
 /obj/machinery/airalarm{
 	dir = 4;
 	pixel_x = -24;
-	req_access = list(150)
+	req_access = null;
+	req_access_txt = "150"
 	},
 /obj/structure/chair/stool,
 /turf/open/floor/plasteel/vault{
@@ -4689,7 +4713,8 @@
 /obj/machinery/airalarm{
 	dir = 8;
 	pixel_x = 24;
-	req_access = list(150)
+	req_access = null;
+	req_access_txt = "150"
 	},
 /turf/open/floor/plasteel/floorgrime,
 /area/ruin/unpowered/syndicate_lava_base/medbay)
@@ -4808,7 +4833,8 @@
 	dir = 2;
 	name = "Bar APC";
 	pixel_y = -24;
-	req_access = list(150)
+	req_access = null;
+	req_access_txt = "150"
 	},
 /turf/open/floor/wood,
 /area/ruin/unpowered/syndicate_lava_base/bar)
@@ -5257,7 +5283,8 @@
 	dir = 1;
 	name = "Arrival Hallway APC";
 	pixel_y = 24;
-	req_access = list(150)
+	req_access = null;
+	req_access_txt = "150"
 	},
 /obj/structure/cable/yellow{
 	icon_state = "0-4"
@@ -5430,7 +5457,8 @@
 /obj/machinery/airalarm{
 	dir = 4;
 	pixel_x = -24;
-	req_access = list(150)
+	req_access = null;
+	req_access_txt = "150"
 	},
 /obj/machinery/light/small{
 	dir = 8
@@ -5636,7 +5664,8 @@
 	},
 /obj/machinery/airalarm{
 	pixel_y = 24;
-	req_access = list(150)
+	req_access = null;
+	req_access_txt = "150"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -5706,7 +5735,8 @@
 	dir = 4;
 	name = "Medbay APC";
 	pixel_x = 24;
-	req_access = list(150)
+	req_access = null;
+	req_access_txt = "150"
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/white/side{
@@ -5790,7 +5820,8 @@
 	dir = 2;
 	name = "Telecommunications APC";
 	pixel_y = -24;
-	req_access = list(150)
+	req_access = null;
+	req_access_txt = "150"
 	},
 /turf/open/floor/plasteel/vault{
 	dir = 5

--- a/_maps/RandomRuins/SpaceRuins/caravanambush.dmm
+++ b/_maps/RandomRuins/SpaceRuins/caravanambush.dmm
@@ -1538,7 +1538,8 @@
 	name = "Shuttle turret control";
 	pixel_x = 32;
 	pixel_y = 32;
-	req_access = list(150)
+	req_access = null;
+	req_access_txt = "150"
 	},
 /obj/structure/cable/yellow{
 	icon_state = "0-4"
@@ -3308,7 +3309,8 @@
 	dir = 8;
 	name = "Syndicate Drop Ship APC";
 	pixel_x = -24;
-	req_access = list(150)
+	req_access = null;
+	req_access_txt = "150"
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/pod/dark,
@@ -3317,7 +3319,8 @@
 /obj/structure/chair,
 /obj/machinery/airalarm{
 	pixel_y = 24;
-	req_access = list(150)
+	req_access = null;
+	req_access_txt = "150"
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/pod/dark,
@@ -3444,7 +3447,8 @@
 	dir = 2;
 	name = "Syndicate Fighter APC";
 	pixel_y = -24;
-	req_access = list(150)
+	req_access = null;
+	req_access_txt = "150"
 	},
 /obj/structure/cable/yellow{
 	icon_state = "0-8"
@@ -3498,7 +3502,8 @@
 /obj/machinery/airalarm{
 	dir = 4;
 	pixel_x = -24;
-	req_access = list(150)
+	req_access = null;
+	req_access_txt = "150"
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/dark,
@@ -3516,7 +3521,8 @@
 /obj/machinery/airalarm{
 	dir = 4;
 	pixel_x = -24;
-	req_access = list(150)
+	req_access = null;
+	req_access_txt = "150"
 	},
 /turf/open/floor/plasteel/dark,
 /area/shuttle/caravan/syndicate3)
@@ -3532,7 +3538,8 @@
 	lethal = 1;
 	name = "Shuttle turret control";
 	pixel_y = 34;
-	req_access = list(150)
+	req_access = null;
+	req_access_txt = "150"
 	},
 /turf/open/floor/plasteel/darkred/corner{
 	dir = 4
@@ -3620,7 +3627,8 @@
 	name = "Shuttle turret control";
 	pixel_x = 32;
 	pixel_y = -28;
-	req_access = list(150)
+	req_access = null;
+	req_access_txt = "150"
 	},
 /obj/structure/cable/yellow{
 	icon_state = "0-2"
@@ -3705,7 +3713,8 @@
 	dir = 8;
 	name = "Syndicate Fighter APC";
 	pixel_x = -24;
-	req_access = list(150)
+	req_access = null;
+	req_access_txt = "150"
 	},
 /obj/machinery/computer/security{
 	dir = 1;

--- a/_maps/RandomRuins/SpaceRuins/listeningstation.dmm
+++ b/_maps/RandomRuins/SpaceRuins/listeningstation.dmm
@@ -14,7 +14,8 @@
 	},
 /obj/machinery/airalarm{
 	pixel_y = 24;
-	req_access = list(150)
+	req_access = null;
+	req_access_txt = "150"
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -208,7 +209,8 @@
 /obj/machinery/airalarm{
 	dir = 4;
 	pixel_x = -24;
-	req_access = list(150)
+	req_access = null;
+	req_access_txt = "150"
 	},
 /turf/open/floor/plasteel/dark,
 /area/ruin/space/has_grav/listeningstation)
@@ -513,7 +515,8 @@
 "aU" = (
 /obj/machinery/airalarm{
 	pixel_y = 24;
-	req_access = list(150)
+	req_access = null;
+	req_access_txt = "150"
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
@@ -636,7 +639,8 @@
 /obj/machinery/airalarm{
 	dir = 8;
 	pixel_x = 24;
-	req_access = list(150)
+	req_access = null;
+	req_access_txt = "150"
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -808,7 +812,8 @@
 	dir = 4;
 	name = "Syndicate Listening Post APC";
 	pixel_x = 24;
-	req_access = list(150)
+	req_access = null;
+	req_access_txt = "150"
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,

--- a/_maps/RandomZLevels/moonoutpost19.dmm
+++ b/_maps/RandomZLevels/moonoutpost19.dmm
@@ -431,7 +431,8 @@
 	frequency = 1439;
 	locked = 1;
 	pixel_y = 23;
-	req_access = list(150)
+	req_access = null;
+	req_access_txt = "150"
 	},
 /turf/open/floor/plasteel/bar{
 	heat_capacity = 1e+006
@@ -611,7 +612,8 @@
 	frequency = 1439;
 	locked = 1;
 	pixel_x = 23;
-	req_access = list(150)
+	req_access = null;
+	req_access_txt = "150"
 	},
 /turf/open/floor/plasteel/floorgrime{
 	dir = 8;
@@ -761,7 +763,8 @@
 	frequency = 1439;
 	locked = 1;
 	pixel_y = 23;
-	req_access = list(150)
+	req_access = null;
+	req_access_txt = "150"
 	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 9
@@ -860,7 +863,8 @@
 	frequency = 1439;
 	locked = 0;
 	pixel_y = 23;
-	req_access = list(150)
+	req_access = null;
+	req_access_txt = "150"
 	},
 /turf/open/floor/plasteel{
 	initial_gas_mix = "co2=48.7;n2=13.2;o2=32.4;TEMP=251";
@@ -1220,7 +1224,8 @@
 	locked = 1;
 	name = "Worn-out APC";
 	pixel_y = -25;
-	req_access = list(150);
+	req_access = null;
+	req_access_txt = "150";
 	start_charge = 0
 	},
 /turf/open/floor/plasteel/red/side{
@@ -1314,7 +1319,8 @@
 	frequency = 1439;
 	locked = 1;
 	pixel_x = 23;
-	req_access = list(150)
+	req_access = null;
+	req_access_txt = "150"
 	},
 /obj/machinery/light{
 	active_power_usage = 0;
@@ -1497,7 +1503,8 @@
 	frequency = 1439;
 	locked = 1;
 	pixel_x = -23;
-	req_access = list(150)
+	req_access = null;
+	req_access_txt = "150"
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/wood{
@@ -1528,7 +1535,8 @@
 	frequency = 1439;
 	locked = 1;
 	pixel_x = 23;
-	req_access = list(150)
+	req_access = null;
+	req_access_txt = "150"
 	},
 /turf/open/floor/wood{
 	heat_capacity = 1e+006

--- a/_maps/RandomZLevels/undergroundoutpost45.dmm
+++ b/_maps/RandomZLevels/undergroundoutpost45.dmm
@@ -8433,7 +8433,8 @@
 	layer = 2.9
 	},
 /obj/structure/closet/secure_closet/engineering_personal{
-	req_access = list(201)
+	req_access = null;
+	req_access_txt = "201"
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/yellow/side{
@@ -8822,7 +8823,8 @@
 	locked = 1;
 	name = "UO45 Engineering APC";
 	pixel_x = -25;
-	req_access = list(201);
+	req_access = null;
+	req_access_txt = "201";
 	start_charge = 100
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
@@ -9418,7 +9420,8 @@
 	icon_state = "mining";
 	locked = 0;
 	name = "miner's equipment";
-	req_access = list(201)
+	req_access = null;
+	req_access_txt = "201"
 	},
 /obj/item/storage/backpack/satchel/eng,
 /obj/item/clothing/gloves/fingerless,
@@ -11959,7 +11962,8 @@
 	pixel_y = -24
 	},
 /obj/structure/closet/secure_closet/miner{
-	req_access = list(201)
+	req_access = null;
+	req_access_txt = "201"
 	},
 /turf/open/floor/plasteel/floorgrime{
 	dir = 8;

--- a/_maps/map_files/BoxStation/BoxStation.dmm
+++ b/_maps/map_files/BoxStation/BoxStation.dmm
@@ -49336,7 +49336,8 @@
 	icon_state = "control_standby";
 	name = "Antechamber Turret Control";
 	pixel_y = -24;
-	req_access = list(65)
+	req_access = null;
+	req_access_txt = "65"
 	},
 /obj/machinery/light/small,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -49572,7 +49573,8 @@
 	icon_state = "control_standby";
 	name = "Atmospherics Turret Control";
 	pixel_x = -27;
-	req_access = list(65)
+	req_access = null;
+	req_access_txt = "65"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
@@ -49597,7 +49599,8 @@
 	icon_state = "control_standby";
 	name = "Service Bay Turret Control";
 	pixel_x = 27;
-	req_access = list(65)
+	req_access = null;
+	req_access_txt = "65"
 	},
 /obj/machinery/atmospherics/pipe/manifold4w/scrubbers,
 /turf/open/floor/plasteel/darkblue/corner{
@@ -49887,7 +49890,8 @@
 	name = "Chamber Hallway Turret Control";
 	pixel_x = 32;
 	pixel_y = -24;
-	req_access = list(65)
+	req_access = null;
+	req_access_txt = "65"
 	},
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/aisat_interior)

--- a/_maps/map_files/Deltastation/DeltaStation2.dmm
+++ b/_maps/map_files/Deltastation/DeltaStation2.dmm
@@ -47768,7 +47768,8 @@
 	icon_state = "control_standby";
 	name = "Antechamber Turret Control";
 	pixel_x = -32;
-	req_access = list(65)
+	req_access = null;
+	req_access_txt = "65"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4

--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -13270,12 +13270,7 @@
 	contents = newlist(/obj/item/clothing/suit/armor/vest,/obj/item/gun/ballistic/automatic/pistol,/obj/item/suppressor,/obj/item/melee/classic_baton/telescopic,/obj/item/clothing/mask/balaclava,/obj/item/bodybag,/obj/item/soap/nanotrasen)
 	},
 /obj/item/storage/backpack/duffelbag/syndie/hitman,
-/obj/item/card/id/silver{
-	access = list(12);
-	assignment = "Reaper";
-	name = "Thirteen's ID Card (Reaper)";
-	registered_name = "Thirteen"
-	},
+/obj/item/card/id/silver/reaper,
 /obj/item/lazarus_injector,
 /obj/item/gun/energy/e_gun/advtaser,
 /obj/item/gun/ballistic/revolver/russian,

--- a/_maps/map_files/PubbyStation/PubbyStation.dmm
+++ b/_maps/map_files/PubbyStation/PubbyStation.dmm
@@ -47575,7 +47575,8 @@
 /obj/machinery/door/airlock/centcom{
 	name = "Crematorium";
 	opacity = 1;
-	req_access = list(27)
+	req_access = null;
+	req_access_txt = "27"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plasteel/dark,

--- a/_maps/shuttles/ferry_meat.dmm
+++ b/_maps/shuttles/ferry_meat.dmm
@@ -127,7 +127,8 @@
 "v" = (
 /obj/machinery/door/airlock/freezer{
 	name = "Meat Tradeship Backroom";
-	req_access = list(28)
+	req_access = null;
+	req_access_txt = "28"
 	},
 /turf/open/floor/plasteel/freezer,
 /area/shuttle/transport)

--- a/_maps/templates/pirate_ship.dmm
+++ b/_maps/templates/pirate_ship.dmm
@@ -707,7 +707,8 @@
 /obj/machinery/airalarm{
 	dir = 8;
 	pixel_x = 24;
-	req_access = list(152)
+	req_access = null;
+	req_access_txt = "152"
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/rack{

--- a/_maps/templates/shelter_2.dmm
+++ b/_maps/templates/shelter_2.dmm
@@ -151,7 +151,8 @@
 	alert = 0;
 	desc = "A display case containing an expensive forgery, probably.";
 	pixel_y = -4;
-	req_access = list(48);
+	req_access = null;
+	req_access_txt = "48";
 	start_showpiece_type = /obj/item/fakeartefact
 	},
 /turf/open/floor/carpet/black,

--- a/code/game/objects/items/cards_ids.dm
+++ b/code/game/objects/items/cards_ids.dm
@@ -148,6 +148,12 @@ update_label("John Doe", "Clowny")
 	lefthand_file = 'icons/mob/inhands/equipment/idcards_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/equipment/idcards_righthand.dmi'
 
+/obj/item/card/id/silver/reaper
+	name = "Thirteen's ID Card (Reaper)"
+	access = list(ACCESS_MAINT_TUNNELS)
+	assignment = "Reaper"
+	registered_name = "Thirteen"
+
 /obj/item/card/id/gold
 	name = "gold identification card"
 	desc = "A golden card which shows power and might."


### PR DESCRIPTION
Closes #35513

Originally tried to fix these in #35234. Didn't realize DMMs don't support number values in lists (they're always converted to text), so they went from being all-access (because they were broken from the start) to no access since it was trying to compare nums to text.