### PR TITLE
Refactors use_sound and changes the way tools play sounds

### DIFF
--- a/code/datums/wires/wires.dm
+++ b/code/datums/wires/wires.dm
@@ -248,14 +248,16 @@
 	switch(action)
 		if("cut")
 			if(istype(I, /obj/item/wirecutters) || IsAdminGhost(usr))
-				playsound(holder, I.usesound, 20, 1)
+				if(I)
+					I.play_tool_sound(src, 20)
 				cut_color(target_wire)
 				. = TRUE
 			else
 				to_chat(L, "<span class='warning'>You need wirecutters!</span>")
 		if("pulse")
 			if(istype(I, /obj/item/device/multitool) || IsAdminGhost(usr))
-				playsound(holder, 'sound/weapons/empty.ogg', 20, 1)
+				if(I)
+					I.play_tool_sound(src, 20)
 				pulse_color(target_wire, L)
 				. = TRUE
 			else

--- a/code/game/machinery/PDApainter.dm
+++ b/code/game/machinery/PDApainter.dm
@@ -86,12 +86,10 @@
 			user.visible_message("[user] is repairing [src].", \
 							"<span class='notice'>You begin repairing [src]...</span>", \
 							"<span class='italics'>You hear welding.</span>")
-			playsound(loc, O.usesound, 40, 1)
-			if(O.use_tool(src, user, 40))
+			if(O.use_tool(src, user, 40, volume=50))
 				if(!(stat & BROKEN))
 					return
 				to_chat(user, "<span class='notice'>You repair [src].</span>")
-				playsound(loc, 'sound/items/welder2.ogg', 50, 1)
 				stat &= ~BROKEN
 				obj_integrity = max_integrity
 				update_icon()

--- a/code/game/machinery/announcement_system.dm
+++ b/code/game/machinery/announcement_system.dm
@@ -61,7 +61,7 @@ GLOBAL_LIST_EMPTY(announcement_systems)
 
 /obj/machinery/announcement_system/attackby(obj/item/P, mob/user, params)
 	if(istype(P, /obj/item/screwdriver))
-		playsound(src.loc, P.usesound, 50, 1)
+		P.play_tool_sound(src)
 		panel_open = !panel_open
 		to_chat(user, "<span class='notice'>You [panel_open ? "open" : "close"] the maintenance hatch of [src].</span>")
 		update_icon()

--- a/code/game/machinery/aug_manipulator.dm
+++ b/code/game/machinery/aug_manipulator.dm
@@ -82,12 +82,10 @@
 				"<span class='notice'>You begin repairing [src]...</span>", \
 				"<span class='italics'>You hear welding.</span>")
 
-			playsound(src, O.usesound, 40, 1)
-			if(O.use_tool(src, user, 40))
+			if(O.use_tool(src, user, 40, volume=50))
 				if(!(stat & BROKEN))
 					return
 				to_chat(user, "<span class='notice'>You repair [src].</span>")
-				playsound(src, 'sound/items/welder2.ogg', 50, 1)
 				stat &= ~BROKEN
 				obj_integrity = max(obj_integrity, max_integrity)
 				update_icon()

--- a/code/game/machinery/buttons.dm
+++ b/code/game/machinery/buttons.dm
@@ -87,7 +87,7 @@
 
 		if(!device && !board && istype(W, /obj/item/wrench))
 			to_chat(user, "<span class='notice'>You start unsecuring the button frame...</span>")
-			playsound(loc, W.usesound, 50, 1)
+			W.play_tool_sound(src)
 			if(W.use_tool(src, user, 40))
 				to_chat(user, "<span class='notice'>You unsecure the button frame.</span>")
 				transfer_fingerprints_to(new /obj/item/wallframe/button(get_turf(src)))

--- a/code/game/machinery/camera/camera.dm
+++ b/code/game/machinery/camera/camera.dm
@@ -139,7 +139,7 @@
 	if(istype(W, /obj/item/screwdriver))
 		panel_open = !panel_open
 		to_chat(user, "<span class='notice'>You screw the camera's panel [panel_open ? "open" : "closed"].</span>")
-		playsound(src.loc, W.usesound, 50, 1)
+		W.play_tool_sound(src)
 		return
 
 	if(panel_open)

--- a/code/game/machinery/camera/camera_assembly.dm
+++ b/code/game/machinery/camera/camera_assembly.dm
@@ -81,7 +81,7 @@
 	var/obj/U = locate(/obj) in upgrades
 	if(U)
 		to_chat(user, "<span class='notice'>You unattach an upgrade from the assembly.</span>")
-		playsound(src, tool.usesound, 50, 1)
+		tool.play_tool_sound(src)
 		U.forceMove(drop_location())
 		upgrades -= U
 	return TRUE
@@ -90,7 +90,7 @@
 	if(state != 3)
 		return FALSE
 
-	playsound(src, tool.usesound, 50, 1)
+	tool.play_tool_sound(src)
 	var/input = stripped_input(user, "Which networks would you like to connect this camera to? Separate networks with a comma. No Spaces!\nFor example: SS13,Security,Secret ", "Set Network", "SS13")
 	if(!input)
 		to_chat(user, "<span class='warning'>No input found, please hang up and try your call again!</span>")
@@ -109,22 +109,22 @@
 	C.c_tag = "[A.name] ([rand(1, 999)])"
 	return TRUE
 
-/obj/structure/camera_assembly/wirecutter_act(mob/user, obj/item/tool)
+/obj/structure/camera_assembly/wirecutter_act(mob/user, obj/item/I)
 	if(state != 3)
 		return FALSE
 
-	new /obj/item/stack/cable_coil(get_turf(src), 2)
-	playsound(src, tool.usesound, 50, 1)
+	new /obj/item/stack/cable_coil(drop_location(), 2)
+	I.play_tool_sound(src)
 	to_chat(user, "<span class='notice'>You cut the wires from the circuits.</span>")
 	state = 2
 	return TRUE
 
-/obj/structure/camera_assembly/wrench_act(mob/user, obj/item/tool)
+/obj/structure/camera_assembly/wrench_act(mob/user, obj/item/I)
 	if(state != 1)
 		return FALSE
-	playsound(src, tool.usesound, 50, 1)
+	I.play_tool_sound(src)
 	to_chat(user, "<span class='notice'>You unattach the assembly from its place.</span>")
-	new /obj/item/wallframe/camera(get_turf(src))
+	new /obj/item/wallframe/camera(drop_location())
 	qdel(src)
 	return TRUE
 
@@ -132,9 +132,7 @@
 	if(!W.tool_start_check(user, amount=0))
 		return FALSE
 	to_chat(user, "<span class='notice'>You start to weld \the [src]...</span>")
-	playsound(src.loc, W.usesound, 50, 1)
-	if(W.use_tool(src, user, 20))
-		playsound(loc, 'sound/items/welder2.ogg', 50, 1)
+	if(W.use_tool(src, user, 20, volume=50))
 		return TRUE
 	return FALSE
 

--- a/code/game/machinery/cell_charger.dm
+++ b/code/game/machinery/cell_charger.dm
@@ -59,7 +59,7 @@
 
 		anchored = !anchored
 		to_chat(user, "<span class='notice'>You [anchored ? "attach" : "detach"] [src] [anchored ? "to" : "from"] the ground</span>")
-		playsound(src.loc, W.usesound, 75, 1)
+		W.play_tool_sound(src, 75)
 	else
 		return ..()
 

--- a/code/game/machinery/computer/buildandrepair.dm
+++ b/code/game/machinery/computer/buildandrepair.dm
@@ -47,13 +47,13 @@
 				to_chat(user, "<span class='warning'>This frame does not accept circuit boards of this type!</span>")
 				return
 			if(istype(P, /obj/item/screwdriver) && circuit)
-				playsound(src, P.usesound, 50, 1)
+				P.play_tool_sound(src)
 				to_chat(user, "<span class='notice'>You screw [circuit] into place.</span>")
 				state = 2
 				icon_state = "2"
 				return
 			if(istype(P, /obj/item/crowbar) && circuit)
-				playsound(src, P.usesound, 50, 1)
+				P.play_tool_sound(src)
 				to_chat(user, "<span class='notice'>You remove [circuit].</span>")
 				state = 1
 				icon_state = "0"
@@ -63,7 +63,7 @@
 				return
 		if(2)
 			if(istype(P, /obj/item/screwdriver) && circuit)
-				playsound(src, P.usesound, 50, 1)
+				P.play_tool_sound(src)
 				to_chat(user, "<span class='notice'>You unfasten the circuit board.</span>")
 				state = 1
 				icon_state = "1"
@@ -71,9 +71,8 @@
 			if(istype(P, /obj/item/stack/cable_coil))
 				if(!P.tool_start_check(user, amount=5))
 					return
-				playsound(src, 'sound/items/deconstruct.ogg', 50, 1)
 				to_chat(user, "<span class='notice'>You start adding cables to the frame...</span>")
-				if(P.use_tool(src, user, 20, amount=5))
+				if(P.use_tool(src, user, 20, volume=50, amount=5))
 					if(state != 2)
 						return
 					to_chat(user, "<span class='notice'>You add cables to the frame.</span>")
@@ -82,7 +81,7 @@
 				return
 		if(3)
 			if(istype(P, /obj/item/wirecutters))
-				playsound(src, P.usesound, 50, 1)
+				P.play_tool_sound(src)
 				to_chat(user, "<span class='notice'>You remove the cables.</span>")
 				state = 2
 				icon_state = "2"
@@ -104,7 +103,7 @@
 				return
 		if(4)
 			if(istype(P, /obj/item/crowbar))
-				playsound(src, P.usesound, 50, 1)
+				P.play_tool_sound(src)
 				to_chat(user, "<span class='notice'>You remove the glass panel.</span>")
 				state = 3
 				icon_state = "3"
@@ -112,7 +111,7 @@
 				G.add_fingerprint(user)
 				return
 			if(istype(P, /obj/item/screwdriver))
-				playsound(src, P.usesound, 50, 1)
+				P.play_tool_sound(src)
 				to_chat(user, "<span class='notice'>You connect the monitor.</span>")
 				var/obj/B = new circuit.build_path (loc, circuit)
 				B.dir = dir

--- a/code/game/machinery/constructable_frame.dm
+++ b/code/game/machinery/constructable_frame.dm
@@ -139,7 +139,7 @@
 				return
 
 			if(istype(P, /obj/item/wirecutters))
-				playsound(src.loc, P.usesound, 50, 1)
+				P.play_tool_sound(src)
 				to_chat(user, "<span class='notice'>You remove the cables.</span>")
 				state = 1
 				icon_state = "box_0"
@@ -148,7 +148,7 @@
 
 		if(3)
 			if(istype(P, /obj/item/crowbar))
-				playsound(src.loc, P.usesound, 50, 1)
+				P.play_tool_sound(src)
 				state = 2
 				circuit.forceMove(drop_location())
 				components.Remove(circuit)
@@ -172,7 +172,7 @@
 						component_check = 0
 						break
 				if(component_check)
-					playsound(src.loc, P.usesound, 50, 1)
+					P.play_tool_sound(src)
 					var/obj/machinery/new_machine = new src.circuit.build_path(src.loc, 1)
 					new_machine.on_construction()
 					for(var/obj/O in new_machine.component_parts)

--- a/code/game/machinery/doors/airlock.dm
+++ b/code/game/machinery/doors/airlock.dm
@@ -869,11 +869,11 @@
 			return
 		panel_open = !panel_open
 		to_chat(user, "<span class='notice'>You [panel_open ? "open":"close"] the maintenance panel of the airlock.</span>")
-		playsound(src.loc, C.usesound, 50, 1)
+		C.play_tool_sound(src)
 		src.update_icon()
 	else if(istype(C, /obj/item/wirecutters) && note)
 		user.visible_message("<span class='notice'>[user] cuts down [note] from [src].</span>", "<span class='notice'>You remove [note] from [src].</span>")
-		playsound(src, 'sound/items/Wirecutter.ogg', 50, 1)
+		C.play_tool_sound(src)
 		note.forceMove(get_turf(user))
 		note = null
 		update_icon()
@@ -923,9 +923,7 @@
 			user.visible_message("[user] is [welded ? "unwelding":"welding"] the airlock.", \
 							"<span class='notice'>You begin [welded ? "unwelding":"welding"] the airlock...</span>", \
 							"<span class='italics'>You hear welding.</span>")
-			playsound(loc, W.usesound, 40, 1)
-			if(W.use_tool(src, user, 40, extra_checks = CALLBACK(src, .proc/weld_checks, W, user)))
-				playsound(loc, 'sound/items/welder2.ogg', 50, 1)
+			if(W.use_tool(src, user, 40, volume=50, extra_checks = CALLBACK(src, .proc/weld_checks, W, user)))
 				welded = !welded
 				user.visible_message("[user.name] has [welded? "welded shut":"unwelded"] [src].", \
 									"<span class='notice'>You [welded ? "weld the airlock shut":"unweld the airlock"].</span>")
@@ -937,9 +935,7 @@
 				user.visible_message("[user] is welding the airlock.", \
 								"<span class='notice'>You begin repairing the airlock...</span>", \
 								"<span class='italics'>You hear welding.</span>")
-				playsound(loc, W.usesound, 40, 1)
-				if(W.use_tool(src, user, 40, extra_checks = CALLBACK(src, .proc/weld_checks, W, user)))
-					playsound(loc, 'sound/items/welder2.ogg', 50, 1)
+				if(W.use_tool(src, user, 40, volume=50, extra_checks = CALLBACK(src, .proc/weld_checks, W, user)))
 					obj_integrity = max_integrity
 					stat &= ~BROKEN
 					user.visible_message("[user.name] has repaired [src].", \
@@ -959,8 +955,7 @@
 		beingcrowbarred = 0
 	if(panel_open && charge)
 		to_chat(user, "<span class='notice'>You carefully start removing [charge] from [src]...</span>")
-		playsound(get_turf(src), I.usesound, 50, 1)
-		if(!I.use_tool(src, user, 150))
+		if(!I.use_tool(src, user, 150, volume=50))
 			to_chat(user, "<span class='warning'>You slip and [charge] detonates!</span>")
 			charge.ex_act(EXPLODE_DEVASTATE)
 			user.Knockdown(60)
@@ -971,10 +966,9 @@
 		charge = null
 		return
 	if(beingcrowbarred && panel_open && ((obj_flags & EMAGGED) || (density && welded && !operating && !hasPower() && !locked)))
-		playsound(src.loc, I.usesound, 100, 1)
 		user.visible_message("[user] removes the electronics from the airlock assembly.", \
 							 "<span class='notice'>You start to remove electronics from the airlock assembly...</span>")
-		if(I.use_tool(src, user, 40))
+		if(I.use_tool(src, user, 40, volume=100))
 			deconstruct(TRUE, user)
 			return
 	else if(hasPower())

--- a/code/game/machinery/doors/firedoor.dm
+++ b/code/game/machinery/doors/firedoor.dm
@@ -100,7 +100,7 @@
 			if(boltslocked)
 				to_chat(user, "<span class='notice'>There are screws locking the bolts in place!</span>")
 				return
-			playsound(get_turf(src), C.usesound, 50, 1)
+			C.play_tool_sound(src)
 			user.visible_message("<span class='notice'>[user] starts undoing [src]'s bolts...</span>", \
 								 "<span class='notice'>You start unfastening [src]'s floor bolts...</span>")
 			if(!C.use_tool(src, user, 50))
@@ -113,7 +113,7 @@
 		if(istype(C, /obj/item/screwdriver))
 			user.visible_message("<span class='notice'>[user] [boltslocked ? "unlocks" : "locks"] [src]'s bolts.</span>", \
 								 "<span class='notice'>You [boltslocked ? "unlock" : "lock"] [src]'s floor bolts.</span>")
-			playsound(get_turf(src), C.usesound, 50, 1)
+			C.play_tool_sound(src)
 			boltslocked = !boltslocked
 			return
 
@@ -278,7 +278,7 @@
 	switch(constructionStep)
 		if(CONSTRUCTION_PANEL_OPEN)
 			if(istype(C, /obj/item/crowbar))
-				playsound(get_turf(src), C.usesound, 50, 1)
+				C.play_tool_sound(src)
 				user.visible_message("<span class='notice'>[user] starts prying something out from [src]...</span>", \
 									 "<span class='notice'>You begin prying out the wire cover...</span>")
 				if(!C.use_tool(src, user, 50))
@@ -295,7 +295,7 @@
 				if(locate(/obj/machinery/door/firedoor) in get_turf(src))
 					to_chat(user, "<span class='warning'>There's already a firelock there.</span>")
 					return
-				playsound(get_turf(src), C.usesound, 50, 1)
+				C.play_tool_sound(src)
 				user.visible_message("<span class='notice'>[user] starts bolting down [src]...</span>", \
 									 "<span class='notice'>You begin bolting [src]...</span>")
 				if(!C.use_tool(src, user, 30))
@@ -334,7 +334,7 @@
 
 		if(CONSTRUCTION_WIRES_EXPOSED)
 			if(istype(C, /obj/item/wirecutters))
-				playsound(get_turf(src), C.usesound, 50, 1)
+				C.play_tool_sound(src)
 				user.visible_message("<span class='notice'>[user] starts cutting the wires from [src]...</span>", \
 									 "<span class='notice'>You begin removing [src]'s wires...</span>")
 				if(!C.use_tool(src, user, 60))
@@ -349,7 +349,7 @@
 				update_icon()
 				return
 			if(istype(C, /obj/item/crowbar))
-				playsound(get_turf(src), C.usesound, 50, 1)
+				C.play_tool_sound(src)
 				user.visible_message("<span class='notice'>[user] starts prying a metal plate into [src]...</span>", \
 									 "<span class='notice'>You begin prying the cover plate back onto [src]...</span>")
 				if(!C.use_tool(src, user, 80))
@@ -366,15 +366,13 @@
 			if(istype(C, /obj/item/crowbar))
 				user.visible_message("<span class='notice'>[user] begins removing the circuit board from [src]...</span>", \
 									 "<span class='notice'>You begin prying out the circuit board from [src]...</span>")
-				playsound(get_turf(src), C.usesound, 50, 1)
-				if(!C.use_tool(src, user, 50))
+				if(!C.use_tool(src, user, 50, volume=50))
 					return
 				if(constructionStep != CONSTRUCTION_GUTTED)
 					return
 				user.visible_message("<span class='notice'>[user] removes [src]'s circuit board.</span>", \
 									 "<span class='notice'>You remove the circuit board from [src].</span>")
-				new /obj/item/electronics/firelock(get_turf(src))
-				playsound(get_turf(src), C.usesound, 50, 1)
+				new /obj/item/electronics/firelock(drop_location())
 				constructionStep = CONSTRUCTION_NOCIRCUIT
 				update_icon()
 				return
@@ -400,17 +398,15 @@
 			if(istype(C, /obj/item/weldingtool))
 				if(!C.tool_start_check(user, amount=1))
 					return
-				playsound(get_turf(src), C.usesound, 50, 1)
 				user.visible_message("<span class='notice'>[user] begins cutting apart [src]'s frame...</span>", \
 									 "<span class='notice'>You begin slicing [src] apart...</span>")
 
-				if(C.use_tool(src, user, 40, amount=1))
+				if(C.use_tool(src, user, 40, volume=50, amount=1))
 					return
 					if(constructionStep != CONSTRUCTION_NOCIRCUIT)
 						return
 					user.visible_message("<span class='notice'>[user] cuts apart [src]!</span>", \
 										 "<span class='notice'>You cut [src] into metal.</span>")
-					playsound(get_turf(src), 'sound/items/welder2.ogg', 50, 1)
 					var/turf/T = get_turf(src)
 					new /obj/item/stack/sheet/metal(T, 3)
 					if(reinforced)

--- a/code/game/machinery/doors/windowdoor.dm
+++ b/code/game/machinery/doors/windowdoor.dm
@@ -227,7 +227,7 @@
 			if(density || operating)
 				to_chat(user, "<span class='warning'>You need to open the door to access the maintenance panel!</span>")
 				return
-			playsound(src.loc, I.usesound, 50, 1)
+			I.play_tool_sound(src)
 			panel_open = !panel_open
 			to_chat(user, "<span class='notice'>You [panel_open ? "open":"close"] the maintenance panel of the [src.name].</span>")
 			return

--- a/code/game/machinery/doppler_array.dm
+++ b/code/game/machinery/doppler_array.dm
@@ -29,8 +29,8 @@ GLOBAL_LIST_EMPTY(doppler_arrays)
 /obj/machinery/doppler_array/process()
 	return PROCESS_KILL
 
-/obj/machinery/doppler_array/attackby(obj/item/O, mob/user, params)
-	if(istype(O, /obj/item/wrench))
+/obj/machinery/doppler_array/attackby(obj/item/I, mob/user, params)
+	if(istype(I, /obj/item/wrench))
 		if(!anchored && !isinspace())
 			anchored = TRUE
 			power_change()
@@ -39,7 +39,7 @@ GLOBAL_LIST_EMPTY(doppler_arrays)
 			anchored = FALSE
 			power_change()
 			to_chat(user, "<span class='notice'>You unfasten [src].</span>")
-		playsound(loc, O.usesound, 50, 1)
+		I.play_tool_sound(src)
 	else
 		return ..()
 

--- a/code/game/machinery/droneDispenser.dm
+++ b/code/game/machinery/droneDispenser.dm
@@ -214,7 +214,7 @@
 	if(istype(I, /obj/item/crowbar))
 		GET_COMPONENT(materials, /datum/component/material_container)
 		materials.retrieve_all()
-		playsound(loc, I.usesound, 50, 1)
+		I.play_tool_sound(src)
 		to_chat(user, "<span class='notice'>You retrieve the materials from [src].</span>")
 
 	else if(istype(I, /obj/item/weldingtool))

--- a/code/game/machinery/firealarm.dm
+++ b/code/game/machinery/firealarm.dm
@@ -149,7 +149,7 @@
 	add_fingerprint(user)
 
 	if(istype(W, /obj/item/screwdriver) && buildstage == 2)
-		playsound(src.loc, W.usesound, 50, 1)
+		W.play_tool_sound(src)
 		panel_open = !panel_open
 		to_chat(user, "<span class='notice'>The wires have been [panel_open ? "exposed" : "unexposed"].</span>")
 		update_icon()
@@ -163,10 +163,8 @@
 					return
 
 				to_chat(user, "<span class='notice'>You begin repairing [src]...</span>")
-				playsound(loc, W.usesound, 40, 1)
-				if(W.use_tool(src, user, 40))
+				if(W.use_tool(src, user, 40, volume=50))
 					obj_integrity = max_integrity
-					playsound(loc, 'sound/items/welder2.ogg', 50, 1)
 					to_chat(user, "<span class='notice'>You repair [src].</span>")
 			else
 				to_chat(user, "<span class='warning'>[src] is already in good condition!</span>")
@@ -184,7 +182,7 @@
 
 				else if (istype(W, /obj/item/wirecutters))
 					buildstage = 1
-					playsound(src.loc, W.usesound, 50, 1)
+					W.play_tool_sound(src)
 					new /obj/item/stack/cable_coil(user.loc, 5)
 					to_chat(user, "<span class='notice'>You cut the wires from \the [src].</span>")
 					update_icon()
@@ -238,7 +236,7 @@
 										 "<span class='notice'>You remove the fire alarm assembly from the wall.</span>")
 					var/obj/item/wallframe/firealarm/frame = new /obj/item/wallframe/firealarm()
 					frame.forceMove(user.drop_location())
-					playsound(src.loc, W.usesound, 50, 1)
+					W.play_tool_sound(src)
 					qdel(src)
 					return
 	return ..()

--- a/code/game/machinery/flasher.dm
+++ b/code/game/machinery/flasher.dm
@@ -163,7 +163,7 @@
 
 /obj/machinery/flasher/portable/attackby(obj/item/W, mob/user, params)
 	if (istype(W, /obj/item/wrench))
-		playsound(src.loc, W.usesound, 100, 1)
+		W.play_tool_sound(src, 100)
 
 		if (!anchored && !isinspace())
 			to_chat(user, "<span class='notice'>[src] is now secured.</span>")

--- a/code/game/machinery/newscaster.dm
+++ b/code/game/machinery/newscaster.dm
@@ -724,7 +724,7 @@ GLOBAL_LIST_EMPTY(allCasters)
 /obj/machinery/newscaster/attackby(obj/item/I, mob/living/user, params)
 	if(istype(I, /obj/item/wrench))
 		to_chat(user, "<span class='notice'>You start [anchored ? "un" : ""]securing [name]...</span>")
-		playsound(loc, I.usesound, 50, 1)
+		I.play_tool_sound(src)
 		if(I.use_tool(src, user, 60))
 			playsound(loc, 'sound/items/deconstruct.ogg', 50, 1)
 			if(stat & BROKEN)
@@ -743,12 +743,10 @@ GLOBAL_LIST_EMPTY(allCasters)
 			user.visible_message("[user] is repairing [src].", \
 							"<span class='notice'>You begin repairing [src]...</span>", \
 							"<span class='italics'>You hear welding.</span>")
-			playsound(loc, I.usesound, 40, 1)
-			if(I.use_tool(src, user, 40))
+			if(I.use_tool(src, user, 40, volume=50))
 				if(!(stat & BROKEN))
 					return
 				to_chat(user, "<span class='notice'>You repair [src].</span>")
-				playsound(loc, 'sound/items/welder2.ogg', 50, 1)
 				obj_integrity = max_integrity
 				stat &= ~BROKEN
 				update_icon()

--- a/code/game/machinery/pipe/construction.dm
+++ b/code/game/machinery/pipe/construction.dm
@@ -151,7 +151,7 @@ Buildable meters
 	A.on_construction(color, piping_layer)
 	transfer_fingerprints_to(A)
 
-	playsound(src, W.usesound, 50, 1)
+	W.play_tool_sound(src)
 	user.visible_message( \
 		"[user] fastens \the [src].", \
 		"<span class='notice'>You fasten \the [src].</span>", \
@@ -205,7 +205,7 @@ Buildable meters
 		to_chat(user, "<span class='warning'>You need to fasten it to a pipe!</span>")
 		return TRUE
 	new /obj/machinery/meter(loc, piping_layer)
-	playsound(src, I.usesound, 50, 1)
+	I.play_tool_sound(src)
 	to_chat(user, "<span class='notice'>You fasten the meter to the pipe.</span>")
 	qdel(src)
 

--- a/code/game/machinery/porta_turret/portable_turret_construct.dm
+++ b/code/game/machinery/porta_turret/portable_turret_construct.dm
@@ -23,14 +23,14 @@
 	switch(build_step)
 		if(PTURRET_UNSECURED)	//first step
 			if(istype(I, /obj/item/wrench) && !anchored)
-				playsound(loc, I.usesound, 100, 1)
+				I.play_tool_sound(src, 100)
 				to_chat(user, "<span class='notice'>You secure the external bolts.</span>")
 				anchored = TRUE
 				build_step = PTURRET_BOLTED
 				return
 
 			else if(istype(I, /obj/item/crowbar) && !anchored)
-				playsound(loc, I.usesound, 75, 1)
+				I.play_tool_sound(src, 75)
 				to_chat(user, "<span class='notice'>You dismantle the turret construction.</span>")
 				new /obj/item/stack/sheet/metal( loc, 5)
 				qdel(src)
@@ -48,7 +48,7 @@
 				return
 
 			else if(istype(I, /obj/item/wrench))
-				playsound(loc, I.usesound, 75, 1)
+				I.play_tool_sound(src, 75)
 				to_chat(user, "<span class='notice'>You unfasten the external bolts.</span>")
 				anchored = FALSE
 				build_step = PTURRET_UNSECURED
@@ -57,7 +57,7 @@
 
 		if(PTURRET_START_INTERNAL_ARMOUR)
 			if(istype(I, /obj/item/wrench))
-				playsound(loc, I.usesound, 100, 1)
+				I.play_tool_sound(src, 100)
 				to_chat(user, "<span class='notice'>You bolt the metal armor into place.</span>")
 				build_step = PTURRET_INTERNAL_ARMOUR_ON
 				return
@@ -86,7 +86,7 @@
 				return
 
 			else if(istype(I, /obj/item/wrench))
-				playsound(loc, I.usesound, 100, 1)
+				I.play_tool_sound(src, 100)
 				to_chat(user, "<span class='notice'>You remove the turret's metal armor bolts.</span>")
 				build_step = PTURRET_START_INTERNAL_ARMOUR
 				return
@@ -103,7 +103,7 @@
 
 		if(PTURRET_SENSORS_ON)
 			if(istype(I, /obj/item/screwdriver))
-				playsound(loc, I.usesound, 100, 1)
+				I.play_tool_sound(src, 100)
 				build_step = PTURRET_CLOSED
 				to_chat(user, "<span class='notice'>You close the internal access hatch.</span>")
 				return
@@ -120,7 +120,7 @@
 				return
 
 			else if(istype(I, /obj/item/screwdriver))
-				playsound(loc, I.usesound, 100, 1)
+				I.play_tool_sound(src, 100)
 				build_step = PTURRET_SENSORS_ON
 				to_chat(user, "<span class='notice'>You open the internal access hatch.</span>")
 				return
@@ -149,7 +149,7 @@
 					qdel(src)
 
 			else if(istype(I, /obj/item/crowbar))
-				playsound(loc, I.usesound, 75, 1)
+				I.play_tool_sound(src, 75)
 				to_chat(user, "<span class='notice'>You pry off the turret's exterior armor.</span>")
 				new /obj/item/stack/sheet/metal(loc, 2)
 				build_step = PTURRET_CLOSED

--- a/code/game/machinery/recharger.dm
+++ b/code/game/machinery/recharger.dm
@@ -29,7 +29,7 @@
 		anchored = !anchored
 		power_change()
 		to_chat(user, "<span class='notice'>You [anchored ? "attached" : "detached"] [src].</span>")
-		playsound(loc, G.usesound, 75, 1)
+		G.play_tool_sound(src)
 		return
 
 	var/allowed = is_type_in_typecache(G, allowed_devices)

--- a/code/game/machinery/shieldgen.dm
+++ b/code/game/machinery/shieldgen.dm
@@ -144,7 +144,7 @@
 
 /obj/machinery/shieldgen/attackby(obj/item/W, mob/user, params)
 	if(istype(W, /obj/item/screwdriver))
-		playsound(src.loc, W.usesound, 100, 1)
+		W.play_tool_sound(src, 100)
 		panel_open = !panel_open
 		if(panel_open)
 			to_chat(user, "<span class='notice'>You open the panel and expose the wiring.</span>")
@@ -170,11 +170,11 @@
 			to_chat(user, "<span class='warning'>The bolts are covered! Unlocking this would retract the covers.</span>")
 			return
 		if(!anchored && !isinspace())
-			playsound(src.loc, W.usesound, 100, 1)
+			W.play_tool_sound(src, 100)
 			to_chat(user, "<span class='notice'>You secure \the [src] to the floor!</span>")
 			anchored = TRUE
 		else if(anchored)
-			playsound(src.loc, W.usesound, 100, 1)
+			W.play_tool_sound(src, 100)
 			to_chat(user, "<span class='notice'>You unsecure \the [src] from the floor!</span>")
 			if(active)
 				to_chat(user, "<span class='notice'>\The [src] shuts off!</span>")

--- a/code/game/machinery/syndicatebomb.dm
+++ b/code/game/machinery/syndicatebomb.dm
@@ -116,14 +116,14 @@
 				to_chat(user, "<span class='notice'>The bomb must be placed on solid ground to attach it.</span>")
 			else
 				to_chat(user, "<span class='notice'>You firmly wrench the bomb to the floor.</span>")
-				playsound(loc, I.usesound, 50, 1)
+				I.play_tool_sound(src)
 				anchored = TRUE
 				if(active)
 					to_chat(user, "<span class='notice'>The bolts lock in place.</span>")
 		else
 			if(!active)
 				to_chat(user, "<span class='notice'>You wrench the bomb from the floor.</span>")
-				playsound(loc, I.usesound, 50, 1)
+				I.play_tool_sound(src)
 				anchored = FALSE
 			else
 				to_chat(user, "<span class='warning'>The bolts are locked down!</span>")
@@ -442,7 +442,7 @@
 
 /obj/item/bombcore/chemical/attackby(obj/item/I, mob/user, params)
 	if(istype(I, /obj/item/crowbar) && beakers.len > 0)
-		playsound(loc, I.usesound, 50, 1)
+		I.play_tool_sound(src)
 		for (var/obj/item/B in beakers)
 			B.forceMove(drop_location())
 			beakers -= B

--- a/code/game/machinery/vending.dm
+++ b/code/game/machinery/vending.dm
@@ -260,7 +260,7 @@
 			cut_overlays()
 			if(panel_open)
 				add_overlay("[initial(icon_state)]-panel")
-			playsound(src, W.usesound, 50, 1)
+			W.play_tool_sound(src)
 			updateUsrDialog()
 		else
 			to_chat(user, "<span class='warning'>You must first secure [src].</span>")

--- a/code/game/objects/effects/contraband.dm
+++ b/code/game/objects/effects/contraband.dm
@@ -88,7 +88,7 @@
 
 /obj/structure/sign/poster/attackby(obj/item/I, mob/user, params)
 	if(istype(I, /obj/item/wirecutters))
-		playsound(loc, I.usesound, 100, 1)
+		I.play_tool_sound(src, 100)
 		if(ruined)
 			to_chat(user, "<span class='notice'>You remove the remnants of the poster.</span>")
 			qdel(src)

--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -799,9 +799,14 @@ GLOBAL_VAR_INIT(rpg_loot_items, FALSE)
 	return !used
 
 // Plays item's usesound, if any.
-/obj/item/proc/play_tool_sound(atom/target, volume)
+/obj/item/proc/play_tool_sound(atom/target, volume=50)
 	if(target && usesound && volume)
-		playsound(target, usesound, volume, 1)
+		var/played_sound = usesound
+
+		if(islist(usesound))
+			played_sound = pick(usesound)
+
+		playsound(target, played_sound, volume, 1)
 
 // Used in a callback that is passed by use_tool into do_after call. Do not override, do not call manually.
 /obj/item/proc/tool_check_callback(mob/living/user, amount, datum/callback/extra_checks)

--- a/code/game/objects/items/circuitboards/machine_circuitboards.dm
+++ b/code/game/objects/items/circuitboards/machine_circuitboards.dm
@@ -287,7 +287,7 @@
 				new_setting = "Freezer"
 		name = initial(new_type.name)
 		build_path = initial(new_type.build_path)
-		playsound(user, I.usesound, 50, 1)
+		I.play_tool_sound(src)
 		to_chat(user, "<span class='notice'>You change the circuitboard setting to \"[new_setting]\".</span>")
 	else
 		return ..()

--- a/code/game/objects/items/devices/geiger_counter.dm
+++ b/code/game/objects/items/devices/geiger_counter.dm
@@ -169,11 +169,9 @@
 			to_chat(user, "<span class='warning'>Turn off [src] before you perform this action!</span>")
 			return 0
 		user.visible_message("<span class='notice'>[user] unscrews [src]'s maintenance panel and begins fiddling with its innards...</span>", "<span class='notice'>You begin resetting [src]...</span>")
-		playsound(user, I.usesound, 50, 1)
-		if(!I.use_tool(src, user, 40))
+		if(!I.use_tool(src, user, 40, volume=50))
 			return 0
 		user.visible_message("<span class='notice'>[user] refastens [src]'s maintenance panel!</span>", "<span class='notice'>You reset [src] to its factory settings!</span>")
-		playsound(user, 'sound/items/screwdriver2.ogg', 50, 1)
 		obj_flags &= ~EMAGGED
 		radiation_count = 0
 		update_icon()

--- a/code/game/objects/items/devices/multitool.dm
+++ b/code/game/objects/items/devices/multitool.dm
@@ -27,6 +27,7 @@
 	hitsound = 'sound/weapons/tap.ogg'
 	toolspeed = 1
 	tool_behaviour = TOOL_MULTITOOL
+	usesound = 'sound/weapons/empty.ogg'
 	var/datum/integrated_io/selected_io = null  //functional for integrated circuits.
 	var/mode = 0
 

--- a/code/game/objects/items/devices/radio/intercom.dm
+++ b/code/game/objects/items/devices/radio/intercom.dm
@@ -59,17 +59,13 @@
 	if(istype(I, /obj/item/screwdriver))
 		if(unfastened)
 			user.visible_message("<span class='notice'>[user] starts tightening [src]'s screws...</span>", "<span class='notice'>You start screwing in [src]...</span>")
-			playsound(src, I.usesound, 50, 1)
-			if(I.use_tool(src, user, 30))
+			if(I.use_tool(src, user, 30, volume=50))
 				user.visible_message("<span class='notice'>[user] tightens [src]'s screws!</span>", "<span class='notice'>You tighten [src]'s screws.</span>")
-				playsound(src, 'sound/items/screwdriver2.ogg', 50, 1)
 				unfastened = FALSE
 		else
 			user.visible_message("<span class='notice'>[user] starts loosening [src]'s screws...</span>", "<span class='notice'>You start unscrewing [src]...</span>")
-			playsound(src, I.usesound, 50, 1)
-			if(I.use_tool(src, user, 40))
+			if(I.use_tool(src, user, 40, volume=50))
 				user.visible_message("<span class='notice'>[user] loosens [src]'s screws!</span>", "<span class='notice'>You unscrew [src], loosening it from the wall.</span>")
-				playsound(src, 'sound/items/screwdriver2.ogg', 50, 1)
 				unfastened = TRUE
 		return
 	else if(istype(I, /obj/item/wrench))
@@ -77,7 +73,7 @@
 			to_chat(user, "<span class='warning'>You need to unscrew [src] from the wall first!</span>")
 			return
 		user.visible_message("<span class='notice'>[user] starts unsecuring [src]...</span>", "<span class='notice'>You start unsecuring [src]...</span>")
-		playsound(src, I.usesound, 50, 1)
+		I.play_tool_sound(src)
 		if(I.use_tool(src, user, 80))
 			user.visible_message("<span class='notice'>[user] unsecures [src]!</span>", "<span class='notice'>You detach [src] from the wall.</span>")
 			playsound(src, 'sound/items/deconstruct.ogg', 50, 1)

--- a/code/game/objects/items/grenades/chem_grenade.dm
+++ b/code/game/objects/items/grenades/chem_grenade.dm
@@ -55,7 +55,7 @@
 			if(beakers.len)
 				stage_change(READY)
 				to_chat(user, "<span class='notice'>You lock the [initial(name)] assembly.</span>")
-				playsound(loc, I.usesound, 25, -3)
+				I.play_tool_sound(src, 25)
 			else
 				to_chat(user, "<span class='warning'>You need to add at least one beaker before locking the [initial(name)] assembly!</span>")
 		else if(stage == READY && !nadeassembly)

--- a/code/game/objects/items/grenades/plastic.dm
+++ b/code/game/objects/items/grenades/plastic.dm
@@ -43,7 +43,7 @@
 		update_icon()
 		return
 	if(nadeassembly && istype(I, /obj/item/wirecutters))
-		playsound(src, I.usesound, 20, 1)
+		I.play_tool_sound(src, 20)
 		nadeassembly.forceMove(get_turf(src))
 		nadeassembly.master = null
 		nadeassembly = null

--- a/code/game/objects/items/inducer.dm
+++ b/code/game/objects/items/inducer.dm
@@ -62,7 +62,7 @@
 
 /obj/item/inducer/attackby(obj/item/W, mob/user)
 	if(istype(W, /obj/item/screwdriver))
-		playsound(src, W.usesound, 50, 1)
+		W.play_tool_sound(src)
 		if(!opened)
 			to_chat(user, "<span class='notice'>You unscrew the battery compartment.</span>")
 			opened = TRUE

--- a/code/game/objects/items/plushes.dm
+++ b/code/game/objects/items/plushes.dm
@@ -122,7 +122,7 @@
 				to_chat(user, "<span class='warning'>You already murdered it!</span>")
 				return
 			user.visible_message("<span class='notice'>[user] tears out the stuffing from [src]!</span>", "<span class='notice'>You rip a bunch of the stuffing from [src]. Murderer.</span>")
-			playsound(I, I.usesound, 50, TRUE)
+			I.play_tool_sound(src)
 			stuffed = FALSE
 		else
 			to_chat(user, "<span class='notice'>You remove the grenade from [src].</span>")

--- a/code/game/objects/items/powerfist.dm
+++ b/code/game/objects/items/powerfist.dm
@@ -44,7 +44,7 @@
 				fisto_setting = 3
 			if(3)
 				fisto_setting = 1
-		playsound(loc, W.usesound, 50, 1)
+		W.play_tool_sound(src)
 		to_chat(user, "<span class='notice'>You tweak \the [src]'s piston valve to [fisto_setting].</span>")
 	else if(istype(W, /obj/item/screwdriver))
 		if(tank)

--- a/code/game/objects/items/tools/screwdriver.dm
+++ b/code/game/objects/items/tools/screwdriver.dm
@@ -16,7 +16,7 @@
 	materials = list(MAT_METAL=75)
 	attack_verb = list("stabbed")
 	hitsound = 'sound/weapons/bladeslice.ogg'
-	usesound = 'sound/items/screwdriver.ogg'
+	usesound = list('sound/items/screwdriver.ogg', 'sound/items/screwdriver2.ogg')
 	tool_behaviour = TOOL_SCREWDRIVER
 	toolspeed = 1
 	armor = list(melee = 0, bullet = 0, laser = 0, energy = 0, bomb = 0, bio = 0, rad = 0, fire = 50, acid = 30)

--- a/code/game/objects/items/tools/weldingtool.dm
+++ b/code/game/objects/items/tools/weldingtool.dm
@@ -12,7 +12,7 @@
 	force = 3
 	throwforce = 5
 	hitsound = "swing_hit"
-	usesound = 'sound/items/welder.ogg'
+	usesound = list('sound/items/welder.ogg', 'sound/items/welder2.ogg')
 	var/acti_sound = 'sound/items/welderactivate.ogg'
 	var/deac_sound = 'sound/items/welderdeactivate.ogg'
 	throw_speed = 3

--- a/code/game/objects/structures/ai_core.dm
+++ b/code/game/objects/structures/ai_core.dm
@@ -55,13 +55,13 @@
 					return
 			if(CIRCUIT_CORE)
 				if(istype(P, /obj/item/screwdriver))
-					playsound(loc, P.usesound, 50, 1)
+					P.play_tool_sound(src)
 					to_chat(user, "<span class='notice'>You screw the circuit board into place.</span>")
 					state = SCREWED_CORE
 					update_icon()
 					return
 				if(istype(P, /obj/item/crowbar))
-					playsound(loc, P.usesound, 50, 1)
+					P.play_tool_sound(src)
 					to_chat(user, "<span class='notice'>You remove the circuit board.</span>")
 					state = EMPTY_CORE
 					update_icon()
@@ -70,7 +70,7 @@
 					return
 			if(SCREWED_CORE)
 				if(istype(P, /obj/item/screwdriver) && circuit)
-					playsound(loc, P.usesound, 50, 1)
+					P.play_tool_sound(src)
 					to_chat(user, "<span class='notice'>You unfasten the circuit board.</span>")
 					state = CIRCUIT_CORE
 					update_icon()
@@ -92,7 +92,7 @@
 					if(brain)
 						to_chat(user, "<span class='warning'>Get that [brain.name] out of there first!</span>")
 					else
-						playsound(loc, P.usesound, 50, 1)
+						P.play_tool_sound(src)
 						to_chat(user, "<span class='notice'>You remove the cables.</span>")
 						state = SCREWED_CORE
 						update_icon()
@@ -151,7 +151,7 @@
 					return
 
 				if(istype(P, /obj/item/crowbar) && brain)
-					playsound(loc, P.usesound, 50, 1)
+					P.play_tool_sound(src)
 					to_chat(user, "<span class='notice'>You remove the brain.</span>")
 					brain.forceMove(loc)
 					brain = null
@@ -160,7 +160,7 @@
 
 			if(GLASS_CORE)
 				if(istype(P, /obj/item/crowbar))
-					playsound(loc, P.usesound, 50, 1)
+					P.play_tool_sound(src)
 					to_chat(user, "<span class='notice'>You remove the glass panel.</span>")
 					state = CABLED_CORE
 					update_icon()
@@ -168,7 +168,7 @@
 					return
 
 				if(istype(P, /obj/item/screwdriver))
-					playsound(loc, P.usesound, 50, 1)
+					P.play_tool_sound(src)
 					to_chat(user, "<span class='notice'>You connect the monitor.</span>")
 					if(brain)
 						SSticker.mode.remove_antag_for_borging(brain.brainmob.mind)
@@ -197,7 +197,7 @@
 					return
 
 				if(istype(P, /obj/item/screwdriver))
-					playsound(loc, P.usesound, 50, 1)
+					P.play_tool_sound(src)
 					to_chat(user, "<span class='notice'>You disconnect the monitor.</span>")
 					state = GLASS_CORE
 					update_icon()

--- a/code/game/objects/structures/beds_chairs/bed.dm
+++ b/code/game/objects/structures/beds_chairs/bed.dm
@@ -38,7 +38,7 @@
 
 /obj/structure/bed/attackby(obj/item/W, mob/user, params)
 	if(istype(W, /obj/item/wrench) && !(flags_1&NODECONSTRUCT_1))
-		playsound(src.loc, W.usesound, 50, 1)
+		W.play_tool_sound(src)
 		deconstruct(TRUE)
 	else
 		return ..()

--- a/code/game/objects/structures/beds_chairs/chair.dm
+++ b/code/game/objects/structures/beds_chairs/chair.dm
@@ -73,7 +73,7 @@
 
 /obj/structure/chair/attackby(obj/item/W, mob/user, params)
 	if(istype(W, /obj/item/wrench) && !(flags_1&NODECONSTRUCT_1))
-		playsound(src.loc, W.usesound, 50, 1)
+		W.play_tool_sound(src)
 		deconstruct()
 	else if(istype(W, /obj/item/assembly/shock_kit))
 		if(!user.temporarilyRemoveItemFromInventory(W))

--- a/code/game/objects/structures/crates_lockers/closets.dm
+++ b/code/game/objects/structures/crates_lockers/closets.dm
@@ -251,7 +251,7 @@
 		if(isinspace() && !anchored)
 			return
 		anchored = !anchored
-		playsound(src.loc, W.usesound, 75, 1)
+		W.play_tool_sound(src, 75)
 		user.visible_message("<span class='notice'>[user] [anchored ? "anchored" : "unanchored"] \the [src] [anchored ? "to" : "from"] the ground.</span>", \
 						"<span class='notice'>You [anchored ? "anchored" : "unanchored"] \the [src] [anchored ? "to" : "from"] the ground.</span>", \
 						"<span class='italics'>You hear a ratchet.</span>")

--- a/code/game/objects/structures/crates_lockers/crates/bins.dm
+++ b/code/game/objects/structures/crates_lockers/crates/bins.dm
@@ -33,7 +33,7 @@
 		do_animate()
 	else if(istype(W, /obj/item/wrench))
 		anchored = !anchored
-		playsound(src.loc, W.usesound, 75, 1)
+		W.play_tool_sound(src, 75)
 	else
 		return ..()
 

--- a/code/game/objects/structures/displaycase.dm
+++ b/code/game/objects/structures/displaycase.dm
@@ -101,10 +101,8 @@
 				return
 
 			to_chat(user, "<span class='notice'>You begin repairing [src].</span>")
-			playsound(loc, W.usesound, 40, 1)
-			if(W.use_tool(src, user, 40, amount=5))
+			if(W.use_tool(src, user, 40, amount=5, volume=50))
 				obj_integrity = max_integrity
-				playsound(loc, 'sound/items/welder2.ogg', 50, 1)
 				update_icon()
 				to_chat(user, "<span class='notice'>You repair [src].</span>")
 		else
@@ -179,7 +177,7 @@
 /obj/structure/displaycase_chassis/attackby(obj/item/I, mob/user, params)
 	if(istype(I, /obj/item/wrench)) //The player can only deconstruct the wooden frame
 		to_chat(user, "<span class='notice'>You start disassembling [src]...</span>")
-		playsound(src.loc, I.usesound, 50, 1)
+		I.play_tool_sound(src)
 		if(I.use_tool(src, user, 30))
 			playsound(src.loc, 'sound/items/deconstruct.ogg', 50, 1)
 			new /obj/item/stack/sheet/mineral/wood(get_turf(src), 5)
@@ -187,7 +185,7 @@
 
 	else if(istype(I, /obj/item/electronics/airlock))
 		to_chat(user, "<span class='notice'>You start installing the electronics into [src]...</span>")
-		playsound(src.loc, I.usesound, 50, 1)
+		I.play_tool_sound(src)
 		if(do_after(user, 30, target = src) && user.transferItemToLoc(I,src))
 			electronics = I
 			to_chat(user, "<span class='notice'>You install the airlock electronics.</span>")

--- a/code/game/objects/structures/door_assembly.dm
+++ b/code/game/objects/structures/door_assembly.dm
@@ -62,11 +62,10 @@
 		if(!W.tool_start_check(user, amount=0))
 			return
 
-		playsound(src, 'sound/items/welder2.ogg', 50, 1)
 		if(mineral)
 			var/obj/item/stack/sheet/mineral/mineral_path = text2path("/obj/item/stack/sheet/mineral/[mineral]")
 			user.visible_message("[user] welds the [mineral] plating off the airlock assembly.", "You start to weld the [mineral] plating off the airlock assembly...")
-			if(W.use_tool(src, user, 40))
+			if(W.use_tool(src, user, 40, volume=50))
 				to_chat(user, "<span class='notice'>You weld the [mineral] plating off.</span>")
 				new mineral_path(loc, 2)
 				var/obj/structure/door_assembly/PA = new previous_assembly(loc)
@@ -74,7 +73,7 @@
 
 		else if(glass)
 			user.visible_message("[user] welds the glass panel out of the airlock assembly.", "You start to weld the glass panel out of the airlock assembly...")
-			if(W.use_tool(src, user, 40))
+			if(W.use_tool(src, user, 40, volume=50))
 				to_chat(user, "<span class='notice'>You weld the glass panel out.</span>")
 				if(heat_proof_finished)
 					new /obj/item/stack/sheet/rglass(get_turf(src))
@@ -85,7 +84,7 @@
 		else if(!anchored)
 			user.visible_message("<span class='warning'>[user] disassembles the airlock assembly.</span>", \
 								"You start to disassemble the airlock assembly...")
-			if(W.use_tool(src, user, 40))
+			if(W.use_tool(src, user, 40, volume=50))
 				to_chat(user, "<span class='notice'>You disassemble the airlock assembly.</span>")
 				deconstruct(TRUE)
 
@@ -148,7 +147,7 @@
 			name = "secured airlock assembly"
 
 	else if(istype(W, /obj/item/electronics/airlock) && state == AIRLOCK_ASSEMBLY_NEEDS_ELECTRONICS )
-		playsound(src, W.usesound, 100, 1)
+		W.play_tool_sound(src, 100)
 		user.visible_message("[user] installs the electronics into the airlock assembly.", \
 							"<span class='notice'>You start to install electronics into the airlock assembly...</span>")
 		if(do_after(user, 40, target = src))

--- a/code/game/objects/structures/dresser.dm
+++ b/code/game/objects/structures/dresser.dm
@@ -6,8 +6,8 @@
 	density = TRUE
 	anchored = TRUE
 
-/obj/structure/dresser/attackby(obj/item/P, mob/user, params)
-	if(istype(P, /obj/item/wrench))
+/obj/structure/dresser/attackby(obj/item/I, mob/user, params)
+	if(istype(I, /obj/item/wrench))
 		to_chat(user, "<span class='notice'>You begin to [anchored ? "unwrench" : "wrench"] [src].</span>")
 		if(I.use_tool(src, user, 20, volume=50))
 			to_chat(user, "<span class='notice'>You successfully [anchored ? "unwrench" : "wrench"] [src].</span>")

--- a/code/game/objects/structures/dresser.dm
+++ b/code/game/objects/structures/dresser.dm
@@ -9,15 +9,14 @@
 /obj/structure/dresser/attackby(obj/item/P, mob/user, params)
 	if(istype(P, /obj/item/wrench))
 		to_chat(user, "<span class='notice'>You begin to [anchored ? "unwrench" : "wrench"] [src].</span>")
-		playsound(src, P.usesound, 50, 1)
-		if(do_after(user, 20, target = src))
+		if(I.use_tool(src, user, 20, volume=50))
 			to_chat(user, "<span class='notice'>You successfully [anchored ? "unwrench" : "wrench"] [src].</span>")
 			anchored = !anchored
 	else
 		return ..()
 
 /obj/structure/dresser/deconstruct(disassembled = TRUE)
-	new /obj/item/stack/sheet/mineral/wood (get_turf(src), 10)
+	new /obj/item/stack/sheet/mineral/wood(drop_location(), 10)
 	qdel(src)
 
 /obj/structure/dresser/attack_hand(mob/user)

--- a/code/game/objects/structures/electricchair.dm
+++ b/code/game/objects/structures/electricchair.dm
@@ -13,7 +13,7 @@
 /obj/structure/chair/e_chair/attackby(obj/item/W, mob/user, params)
 	if(istype(W, /obj/item/wrench))
 		var/obj/structure/chair/C = new /obj/structure/chair(loc)
-		playsound(loc, W.usesound, 50, 1)
+		W.play_tool_sound(src)
 		C.setDir(dir)
 		part.forceMove(loc)
 		part.master = null

--- a/code/game/objects/structures/extinguisher.dm
+++ b/code/game/objects/structures/extinguisher.dm
@@ -43,7 +43,7 @@
 /obj/structure/extinguisher_cabinet/attackby(obj/item/I, mob/user, params)
 	if(istype(I, /obj/item/wrench) && !stored_extinguisher)
 		to_chat(user, "<span class='notice'>You start unsecuring [name]...</span>")
-		playsound(loc, I.usesound, 50, 1)
+		I.play_tool_sound(src)
 		if(I.use_tool(src, user, 60))
 			playsound(loc, 'sound/items/deconstruct.ogg', 50, 1)
 			to_chat(user, "<span class='notice'>You unsecure [name].</span>")

--- a/code/game/objects/structures/false_walls.dm
+++ b/code/game/objects/structures/false_walls.dm
@@ -113,8 +113,7 @@
 		if(W.use_tool(src, user, 0, volume=50))
 			dismantle(user, TRUE)
 	else if(istype(W, /obj/item/pickaxe/drill/jackhammer))
-		var/obj/item/pickaxe/drill/jackhammer/D = W
-		D.playDigSound()
+		W.play_tool_sound(src)
 		dismantle(user, TRUE)
 	else
 		return ..()
@@ -122,7 +121,7 @@
 /obj/structure/falsewall/proc/dismantle(mob/user, disassembled=TRUE, obj/item/tool = null)
 	user.visible_message("[user] dismantles the false wall.", "<span class='notice'>You dismantle the false wall.</span>")
 	if(tool)
-		playsound(src, tool.usesound, 100, 1)
+		tool.play_tool_sound(src, 100)
 	else
 		playsound(src, 'sound/items/welder.ogg', 100, 1)
 	deconstruct(disassembled)

--- a/code/game/objects/structures/fireaxe.dm
+++ b/code/game/objects/structures/fireaxe.dm
@@ -30,10 +30,8 @@
 				return
 
 			to_chat(user, "<span class='notice'>You begin repairing [src].</span>")
-			playsound(loc, I.usesound, 40, 1)
-			if(I.use_tool(src, user, 40, amount=2))
+			if(I.use_tool(src, user, 40, volume=50, amount=2))
 				obj_integrity = max_integrity
-				playsound(loc, 'sound/items/welder2.ogg', 50, 1)
 				update_icon()
 				to_chat(user, "<span class='notice'>You repair [src].</span>")
 		else

--- a/code/game/objects/structures/fluff.dm
+++ b/code/game/objects/structures/fluff.dm
@@ -13,13 +13,12 @@
 /obj/structure/fluff/attackby(obj/item/I, mob/living/user, params)
 	if(istype(I, /obj/item/wrench) && deconstructible)
 		user.visible_message("<span class='notice'>[user] starts disassembling [src]...</span>", "<span class='notice'>You start disassembling [src]...</span>")
-		playsound(user, I.usesound, 50, 1)
-		if(!do_after(user, 50, target = src))
-			return 0
-		user.visible_message("<span class='notice'>[user] disassembles [src]!</span>", "<span class='notice'>You break down [src] into scrap metal.</span>")
-		playsound(user, 'sound/items/deconstruct.ogg', 50, 1)
-		new/obj/item/stack/sheet/metal(get_turf(src))
-		qdel(src)
+		I.play_tool_sound(src)
+		if(I.use_tool(src, user, 50))
+			user.visible_message("<span class='notice'>[user] disassembles [src]!</span>", "<span class='notice'>You break down [src] into scrap metal.</span>")
+			playsound(user, 'sound/items/deconstruct.ogg', 50, 1)
+			new/obj/item/stack/sheet/metal(drop_location())
+			qdel(src)
 		return
 	..()
 

--- a/code/game/objects/structures/girders.dm
+++ b/code/game/objects/structures/girders.dm
@@ -41,10 +41,9 @@
 			qdel(src)
 
 	else if(istype(W, /obj/item/pickaxe/drill/jackhammer))
-		var/obj/item/pickaxe/drill/jackhammer/D = W
 		to_chat(user, "<span class='notice'>You smash through the girder!</span>")
 		new /obj/item/stack/sheet/metal(get_turf(src))
-		D.playDigSound()
+		W.play_tool_sound(src)
 		qdel(src)
 
 
@@ -356,11 +355,10 @@
 			qdel(src)
 
 	else if(istype(W, /obj/item/pickaxe/drill/jackhammer))
-		var/obj/item/pickaxe/drill/jackhammer/D = W
 		to_chat(user, "<span class='notice'>Your jackhammer smashes through the girder!</span>")
 		var/obj/item/stack/sheet/runed_metal/R = new(drop_location(), 2)
 		transfer_fingerprints_to(R)
-		D.playDigSound()
+		W.play_tool_sound(src)
 		qdel(src)
 
 	else if(istype(W, /obj/item/stack/sheet/runed_metal))

--- a/code/game/objects/structures/grille.dm
+++ b/code/game/objects/structures/grille.dm
@@ -137,11 +137,11 @@
 	add_fingerprint(user)
 	if(istype(W, /obj/item/wirecutters))
 		if(!shock(user, 100))
-			playsound(src, W.usesound, 100, 1)
+			W.play_tool_sound(src, 100)
 			deconstruct()
 	else if((istype(W, /obj/item/screwdriver)) && (isturf(loc) || anchored))
 		if(!shock(user, 90))
-			playsound(src, W.usesound, 100, 1)
+			W.play_tool_sound(src, 100)
 			anchored = !anchored
 			user.visible_message("<span class='notice'>[user] [anchored ? "fastens" : "unfastens"] [src].</span>", \
 								 "<span class='notice'>You [anchored ? "fasten [src] to" : "unfasten [src] from"] the floor.</span>")

--- a/code/game/objects/structures/reflector.dm
+++ b/code/game/objects/structures/reflector.dm
@@ -81,7 +81,7 @@
 	if(istype(W, /obj/item/screwdriver))
 		can_rotate = !can_rotate
 		to_chat(user, "<span class='notice'>You [can_rotate ? "unlock" : "lock"] [src]'s rotation.</span>")
-		playsound(src, W.usesound, 50, 1)
+		W.play_tool_sound(src)
 		return
 
 	if(istype(W, /obj/item/wrench))

--- a/code/game/objects/structures/showcase.dm
+++ b/code/game/objects/structures/showcase.dm
@@ -112,11 +112,11 @@
 	if(istype(W, /obj/item/screwdriver) && !anchored)
 		if(deconstruction_state == SHOWCASE_SCREWDRIVERED)
 			to_chat(user, "<span class='notice'>You screw the screws back into the showcase.</span>")
-			playsound(loc, W.usesound, 100, 1)
+			W.play_tool_sound(src, 100)
 			deconstruction_state = SHOWCASE_CONSTRUCTED
 		else if (deconstruction_state == SHOWCASE_CONSTRUCTED)
 			to_chat(user, "<span class='notice'>You unscrew the screws.</span>")
-			playsound(loc, W.usesound, 100, 1)
+			W.play_tool_sound(src, 100)
 			deconstruction_state = SHOWCASE_SCREWDRIVERED
 
 	if(istype(W, /obj/item/crowbar) && deconstruction_state == SHOWCASE_SCREWDRIVERED)

--- a/code/game/objects/structures/signs/_signs.dm
+++ b/code/game/objects/structures/signs/_signs.dm
@@ -31,7 +31,7 @@
 	if(istype(I, /obj/item/wrench) && buildable_sign)
 		user.visible_message("<span class='notice'>[user] starts removing [src]...</span>", \
 							 "<span class='notice'>You start unfastening [src].</span>")
-		playsound(src, I.usesound, 50, 1)
+		I.play_tool_sound(src)
 		if(I.use_tool(src, user, 40))
 			playsound(src, 'sound/items/deconstruct.ogg', 50, 1)
 			user.visible_message("<span class='notice'>[user] unfastens [src].</span>", \

--- a/code/game/objects/structures/statues.dm
+++ b/code/game/objects/structures/statues.dm
@@ -40,12 +40,9 @@
 				anchored = TRUE
 
 	else if(istype(W, /obj/item/pickaxe/drill/jackhammer))
-		var/obj/item/pickaxe/drill/jackhammer/D = W
-		if(!src.loc)
-			return
-		user.visible_message("[user] destroys the [name]!", \
+		user.visible_message("[user] destroys the [name]!",
 							 "<span class='notice'>You destroy the [name].</span>")
-		D.playDigSound()
+		W.play_tool_sound(src)
 		qdel(src)
 
 	else if(istype(W, /obj/item/weldingtool) || istype(W, /obj/item/gun/energy/plasmacutter))

--- a/code/game/objects/structures/statues.dm
+++ b/code/game/objects/structures/statues.dm
@@ -49,11 +49,9 @@
 		if(!W.tool_start_check(user, amount=0))
 			return FALSE
 
-		playsound(loc, W.usesound, 40, 1)
 		user.visible_message("[user] is slicing apart the [name].", \
 							 "<span class='notice'>You are slicing apart the [name]...</span>")
-		if(W.use_tool(src, user, 40))
-			playsound(loc, 'sound/items/welder2.ogg', 50, 1)
+		if(W.use_tool(src, user, 40, volume=50))
 			user.visible_message("[user] slices apart the [name].", \
 								 "<span class='notice'>You slice apart the [name]!</span>")
 			deconstruct(TRUE)

--- a/code/game/objects/structures/table_frames.dm
+++ b/code/game/objects/structures/table_frames.dm
@@ -24,7 +24,7 @@
 /obj/structure/table_frame/attackby(obj/item/I, mob/user, params)
 	if(istype(I, /obj/item/wrench))
 		to_chat(user, "<span class='notice'>You start disassembling [src]...</span>")
-		playsound(src.loc, I.usesound, 50, 1)
+		I.play_tool_sound(src)
 		if(I.use_tool(src, user, 30))
 			playsound(src.loc, 'sound/items/deconstruct.ogg', 50, 1)
 			deconstruct(TRUE)

--- a/code/game/objects/structures/tables_racks.dm
+++ b/code/game/objects/structures/tables_racks.dm
@@ -441,7 +441,7 @@
 
 /obj/structure/rack/attackby(obj/item/W, mob/user, params)
 	if (istype(W, /obj/item/wrench) && !(flags_1&NODECONSTRUCT_1))
-		playsound(src.loc, W.usesound, 50, 1)
+		W.play_tool_sound(src)
 		deconstruct(TRUE)
 		return
 	if(user.a_intent == INTENT_HARM)

--- a/code/game/objects/structures/transit_tubes/transit_tube_pod.dm
+++ b/code/game/objects/structures/transit_tubes/transit_tube_pod.dm
@@ -30,7 +30,7 @@
 /obj/structure/transit_tube_pod/attackby(obj/item/I, mob/user, params)
 	if(istype(I, /obj/item/crowbar))
 		if(!moving)
-			playsound(src.loc, I.usesound, 50, 1)
+			I.play_tool_sound(src)
 			if(contents.len)
 				user.visible_message("[user] empties \the [src].", "<span class='notice'>You empty \the [src].</span>")
 				empty_pod()

--- a/code/game/objects/structures/windoor_assembly.dm
+++ b/code/game/objects/structures/windoor_assembly.dm
@@ -93,9 +93,8 @@
 
 				user.visible_message("[user] disassembles the windoor assembly.",
 					"<span class='notice'>You start to disassemble the windoor assembly...</span>")
-				playsound(loc, 'sound/items/welder2.ogg', 50, 1)
 
-				if(W.use_tool(src, user, 40))
+				if(W.use_tool(src, user, 40, volume=50))
 					to_chat(user, "<span class='notice'>You disassemble the windoor assembly.</span>")
 					var/obj/item/stack/sheet/rglass/RG = new (get_turf(src), 5)
 					RG.add_fingerprint(user)
@@ -205,7 +204,7 @@
 			else if(istype(W, /obj/item/electronics/airlock))
 				if(!user.transferItemToLoc(W, src))
 					return
-				playsound(loc, W.usesound, 100, 1)
+				W.play_tool_sound(src, 100)
 				user.visible_message("[user] installs the electronics into the airlock assembly.",
 					"<span class='notice'>You start to install electronics into the airlock assembly...</span>")
 

--- a/code/game/objects/structures/window.dm
+++ b/code/game/objects/structures/window.dm
@@ -185,10 +185,8 @@
 				return
 
 			to_chat(user, "<span class='notice'>You begin repairing [src]...</span>")
-			playsound(src, I.usesound, 40, 1)
-			if(I.use_tool(src, user, 40))
+			if(I.use_tool(src, user, 40, volume=50))
 				obj_integrity = max_integrity
-				playsound(src, 'sound/items/Welder2.ogg', 50, 1)
 				update_nearby_icons()
 				to_chat(user, "<span class='notice'>You repair [src].</span>")
 		else
@@ -197,7 +195,7 @@
 
 	if(!(flags_1&NODECONSTRUCT_1))
 		if(istype(I, /obj/item/screwdriver))
-			playsound(src, I.usesound, 75, 1)
+			I.play_tool_sound(src, 75)
 			if(reinf)
 				if(state == WINDOW_SCREWED_TO_FRAME || state == WINDOW_IN_FRAME)
 					to_chat(user, "<span class='notice'>You begin to [state == WINDOW_SCREWED_TO_FRAME ? "unscrew the window from":"screw the window to"] the frame...</span>")
@@ -222,14 +220,14 @@
 
 		else if (istype(I, /obj/item/crowbar) && reinf && (state == WINDOW_OUT_OF_FRAME || state == WINDOW_IN_FRAME))
 			to_chat(user, "<span class='notice'>You begin to lever the window [state == WINDOW_OUT_OF_FRAME ? "into":"out of"] the frame...</span>")
-			playsound(src, I.usesound, 75, 1)
+			I.play_tool_sound(src, 75)
 			if(I.use_tool(src, user, decon_speed, extra_checks = CALLBACK(src, .proc/check_state_and_anchored, state, anchored)))
 				state = (state == WINDOW_OUT_OF_FRAME ? WINDOW_IN_FRAME : WINDOW_OUT_OF_FRAME)
 				to_chat(user, "<span class='notice'>You pry the window [state == WINDOW_IN_FRAME ? "into":"out of"] the frame.</span>")
 			return
 
 		else if(istype(I, /obj/item/wrench) && !anchored)
-			playsound(src, I.usesound, 75, 1)
+			I.play_tool_sound(src, 75)
 			to_chat(user, "<span class='notice'> You begin to disassemble [src]...</span>")
 			if(I.use_tool(src, user, decon_speed, extra_checks = CALLBACK(src, .proc/check_state_and_anchored, state, anchored)))
 				var/obj/item/stack/sheet/G = new glass_type(user.loc, glass_amount)

--- a/code/game/turfs/simulated/floor.dm
+++ b/code/game/turfs/simulated/floor.dm
@@ -156,8 +156,8 @@
 		return
 	P.attackby(T, user, params)
 
-/turf/open/floor/proc/pry_tile(obj/item/C, mob/user, silent = FALSE)
-	playsound(src, C.usesound, 80, 1)
+/turf/open/floor/proc/pry_tile(obj/item/I, mob/user, silent = FALSE)
+	I.play_tool_sound(src, 80)
 	return remove_tile(user, silent)
 
 /turf/open/floor/proc/remove_tile(mob/user, silent = FALSE, make_tile = TRUE)

--- a/code/game/turfs/simulated/floor/fancy_floor.dm
+++ b/code/game/turfs/simulated/floor/fancy_floor.dm
@@ -39,7 +39,7 @@
 
 /turf/open/floor/wood/pry_tile(obj/item/C, mob/user, silent = FALSE)
 	var/is_screwdriver = istype(C, /obj/item/screwdriver)
-	playsound(src, C.usesound, 80, 1)
+	C.play_tool_sound(src, 80)
 	return remove_tile(user, silent, make_tile = is_screwdriver)
 
 /turf/open/floor/wood/remove_tile(mob/user, silent = FALSE, make_tile = TRUE)

--- a/code/game/turfs/simulated/minerals.dm
+++ b/code/game/turfs/simulated/minerals.dm
@@ -60,7 +60,6 @@
 			return
 		last_act = world.time
 		to_chat(user, "<span class='notice'>You start picking...</span>")
-		P.playDigSound()
 
 		if(do_after(user,P.digspeed, target = src))
 			if(ismineralturf(src))

--- a/code/game/turfs/simulated/wall/reinf_walls.dm
+++ b/code/game/turfs/simulated/wall/reinf_walls.dm
@@ -67,7 +67,7 @@
 	switch(d_state)
 		if(INTACT)
 			if(istype(W, /obj/item/wirecutters))
-				playsound(src, W.usesound, 100, 1)
+				W.play_tool_sound(src, 100)
 				d_state = SUPPORT_LINES
 				update_icon()
 				to_chat(user, "<span class='notice'>You cut the outer grille.</span>")
@@ -85,7 +85,7 @@
 				return 1
 
 			else if(istype(W, /obj/item/wirecutters))
-				playsound(src, W.usesound, 100, 1)
+				W.play_tool_sound(src, 100)
 				d_state = INTACT
 				update_icon()
 				to_chat(user, "<span class='notice'>You repair the outer grille.</span>")
@@ -173,7 +173,7 @@
 
 			if(istype(W, /obj/item/wrench))
 				to_chat(user, "<span class='notice'>You start tightening the bolts which secure the support rods to their frame...</span>")
-				playsound(src, W.usesound, 100, 1)
+				W.play_tool_sound(src, 100)
 				if(W.use_tool(src, user, 40))
 					if(!istype(src, /turf/closed/wall/r_wall) || d_state != SUPPORT_RODS)
 						return 1

--- a/code/game/turfs/simulated/wall/reinf_walls.dm
+++ b/code/game/turfs/simulated/wall/reinf_walls.dm
@@ -50,18 +50,17 @@
 		playsound(src, 'sound/effects/bang.ogg', 50, 1)
 		to_chat(M, "<span class='warning'>This wall is far too strong for you to destroy.</span>")
 
-/turf/closed/wall/r_wall/try_destroy(obj/item/W, mob/user, turf/T)
-	if(istype(W, /obj/item/pickaxe/drill/jackhammer))
-		var/obj/item/pickaxe/drill/jackhammer/D = W
-		to_chat(user, "<span class='notice'>You begin to smash though the [name]...</span>")
+/turf/closed/wall/r_wall/try_destroy(obj/item/I, mob/user, turf/T)
+	if(istype(I, /obj/item/pickaxe/drill/jackhammer))
+		to_chat(user, "<span class='notice'>You begin to smash though [src]...</span>")
 		if(do_after(user, 50, target = src))
-			if(!istype(src, /turf/closed/wall/r_wall) || !W)
-				return 1
-			D.playDigSound()
-			visible_message("<span class='warning'>[user] smashes through the [name] with the [D.name]!</span>", "<span class='italics'>You hear the grinding of metal.</span>")
+			if(!istype(src, /turf/closed/wall/r_wall))
+				return TRUE
+			I.play_tool_sound(src)
+			visible_message("<span class='warning'>[user] smashes through [src] with [I]!</span>", "<span class='italics'>You hear the grinding of metal.</span>")
 			dismantle_wall()
-			return 1
-	return 0
+			return TRUE
+	return FALSE
 
 /turf/closed/wall/r_wall/try_decon(obj/item/W, mob/user, turf/T)
 	//DECONSTRUCTION

--- a/code/game/turfs/simulated/walls.dm
+++ b/code/game/turfs/simulated/walls.dm
@@ -221,13 +221,13 @@
 
 	return FALSE
 
-/turf/closed/wall/proc/try_decon(obj/item/W, mob/user, turf/T)
-	if(istype(W, /obj/item/weldingtool) || istype(W, /obj/item/gun/energy/plasmacutter))
-		if(!W.tool_start_check(user, amount=0))
+/turf/closed/wall/proc/try_decon(obj/item/I, mob/user, turf/T)
+	if(istype(I, /obj/item/weldingtool) || istype(I, /obj/item/gun/energy/plasmacutter))
+		if(!I.tool_start_check(user, amount=0))
 			return FALSE
 
 		to_chat(user, "<span class='notice'>You begin slicing through the outer plating...</span>")
-		if(W.use_tool(src, user, slicing_duration, volume=100))
+		if(I.use_tool(src, user, slicing_duration, volume=100))
 			if(iswallturf(src))
 				to_chat(user, "<span class='notice'>You remove the outer plating.</span>")
 				dismantle_wall()
@@ -236,15 +236,14 @@
 	return FALSE
 
 
-/turf/closed/wall/proc/try_destroy(obj/item/W, mob/user, turf/T)
-	if(istype(W, /obj/item/pickaxe/drill/jackhammer))
-		var/obj/item/pickaxe/drill/jackhammer/D = W
-		if(!iswallturf(src) || !user || !W || !T)
+/turf/closed/wall/proc/try_destroy(obj/item/I, mob/user, turf/T)
+	if(istype(I, /obj/item/pickaxe/drill/jackhammer))
+		if(!iswallturf(src))
 			return TRUE
-		if( user.loc == T && user.get_active_held_item() == W )
-			D.playDigSound()
+		if(user.loc == T)
+			I.play_tool_sound(src)
 			dismantle_wall()
-			visible_message("<span class='warning'>[user] smashes through the [name] with the [W.name]!</span>", "<span class='italics'>You hear the grinding of metal.</span>")
+			visible_message("<span class='warning'>[user] smashes through [src] with [I]!</span>", "<span class='italics'>You hear the grinding of metal.</span>")
 			return TRUE
 	return FALSE
 

--- a/code/modules/antagonists/abductor/equipment/abduction_gear.dm
+++ b/code/modules/antagonists/abductor/equipment/abduction_gear.dm
@@ -682,7 +682,7 @@ Congratulations! You are now trained for invasive xenobiology research!"}
 /obj/structure/table_frame/abductor/attackby(obj/item/I, mob/user, params)
 	if(istype(I, /obj/item/wrench))
 		to_chat(user, "<span class='notice'>You start disassembling [src]...</span>")
-		playsound(src.loc, I.usesound, 50, 1)
+		I.play_tool_sound(src)
 		if(I.use_tool(src, user, 30))
 			playsound(src.loc, 'sound/items/deconstruct.ogg', 50, 1)
 			for(var/i = 1, i <= framestackamount, i++)

--- a/code/modules/antagonists/clockcult/clock_structures/_trap_object.dm
+++ b/code/modules/antagonists/clockcult/clock_structures/_trap_object.dm
@@ -27,11 +27,11 @@
 				var/distance = get_dist(src, O)
 				to_chat(user, "[O] ([distance == 0 ? "same tile" : "[distance] tiles [dir2text(get_dir(src, O))]"])")
 
-/obj/structure/destructible/clockwork/trap/wrench_act(mob/living/user, obj/item/wrench)
+/obj/structure/destructible/clockwork/trap/wrench_act(mob/living/user, obj/item/I)
 	if(!is_servant_of_ratvar(user))
 		return ..()
 	to_chat(user, "<span class='notice'>You break down the delicate components of [src] into brass.</span>")
-	playsound(src, wrench.usesound, 50, TRUE)
+	I.play_tool_sound(src)
 	new/obj/item/stack/tile/brass(get_turf(src))
 	qdel(src)
 	return TRUE
@@ -56,14 +56,14 @@
 		return
 	..()
 
-/obj/structure/destructible/clockwork/trap/wirecutter_act(mob/living/user, obj/item/wirecutters)
+/obj/structure/destructible/clockwork/trap/wirecutter_act(mob/living/user, obj/item/I)
 	if(!is_servant_of_ratvar(user))
 		return
 	if(!wired_to.len)
 		to_chat(user, "<span class='warning'>[src] has no connections!</span>")
 		return
 	to_chat(user, "<span class='notice'>You sever all connections to [src].</span>")
-	playsound(src, wirecutters.usesound, 50, TRUE)
+	I.play_tool_sound(src)
 	for(var/V in wired_to)
 		var/obj/structure/destructible/clockwork/trap/T = V
 		T.wired_to -= src

--- a/code/modules/atmospherics/machinery/airalarm.dm
+++ b/code/modules/atmospherics/machinery/airalarm.dm
@@ -653,14 +653,14 @@
 	switch(buildstage)
 		if(2)
 			if(istype(W, /obj/item/wirecutters) && panel_open && wires.is_all_cut())
-				playsound(src.loc, W.usesound, 50, 1)
+				W.play_tool_sound(src)
 				to_chat(user, "<span class='notice'>You cut the final wires.</span>")
 				new /obj/item/stack/cable_coil(loc, 5)
 				buildstage = 1
 				update_icon()
 				return
 			else if(istype(W, /obj/item/screwdriver))  // Opening that Air Alarm up.
-				playsound(src.loc, W.usesound, 50, 1)
+				W.play_tool_sound(src)
 				panel_open = !panel_open
 				to_chat(user, "<span class='notice'>The wires have been [panel_open ? "exposed" : "unexposed"].</span>")
 				update_icon()
@@ -674,7 +674,7 @@
 			if(istype(W, /obj/item/crowbar))
 				user.visible_message("[user.name] removes the electronics from [src.name].",\
 									"<span class='notice'>You start prying out the circuit...</span>")
-				playsound(src.loc, W.usesound, 50, 1)
+				W.play_tool_sound(src)
 				if (W.use_tool(src, user, 20))
 					if (buildstage == 1)
 						to_chat(user, "<span class='notice'>You remove the air alarm electronics.</span>")
@@ -725,7 +725,7 @@
 
 			if(istype(W, /obj/item/wrench))
 				to_chat(user, "<span class='notice'>You detach \the [src] from the wall.</span>")
-				playsound(src.loc, W.usesound, 50, 1)
+				W.play_tool_sound(src)
 				new /obj/item/wallframe/airalarm( user.loc )
 				qdel(src)
 				return

--- a/code/modules/atmospherics/machinery/components/unary_devices/vent_pump.dm
+++ b/code/modules/atmospherics/machinery/components/unary_devices/vent_pump.dm
@@ -272,10 +272,8 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/welder_act(mob/living/user, obj/item/I)
 	if(!I.tool_start_check(user, amount=0))
 		return TRUE
-	playsound(loc, I.usesound, 40, 1)
 	to_chat(user, "<span class='notice'>You begin welding the vent...</span>")
-	if(I.use_tool(src, user, 20))
-		playsound(src.loc, 'sound/items/welder2.ogg', 50, 1)
+	if(I.use_tool(src, user, 20, volume=50))
 		if(!welded)
 			user.visible_message("[user] welds the vent shut.", "<span class='notice'>You weld the vent shut.</span>", "<span class='italics'>You hear welding.</span>")
 			welded = TRUE

--- a/code/modules/atmospherics/machinery/components/unary_devices/vent_scrubber.dm
+++ b/code/modules/atmospherics/machinery/components/unary_devices/vent_scrubber.dm
@@ -266,10 +266,8 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/welder_act(mob/living/user, obj/item/I)
 	if(!I.tool_start_check(user, amount=0))
 		return TRUE
-	playsound(loc, I.usesound, 40, 1)
 	to_chat(user, "<span class='notice'>Now welding the scrubber.</span>")
-	if(I.use_tool(src, user, 20))
-		playsound(src.loc, 'sound/items/welder2.ogg', 50, 1)
+	if(I.use_tool(src, user, 20, volume=50))
 		if(!welded)
 			user.visible_message("[user] welds the scrubber shut.","You weld the scrubber shut.", "You hear welding.")
 			welded = TRUE

--- a/code/modules/atmospherics/machinery/portable/portable_atmospherics.dm
+++ b/code/modules/atmospherics/machinery/portable/portable_atmospherics.dm
@@ -92,7 +92,7 @@
 		if(!(stat & BROKEN))
 			if(connected_port)
 				disconnect()
-				playsound(src.loc, W.usesound, 50, 1)
+				W.play_tool_sound(src)
 				user.visible_message( \
 					"[user] disconnects [src].", \
 					"<span class='notice'>You unfasten [src] from the port.</span>", \
@@ -107,7 +107,7 @@
 				if(!connect(possible_port))
 					to_chat(user, "<span class='notice'>[name] failed to connect to the port.</span>")
 					return
-				playsound(src.loc, W.usesound, 50, 1)
+				W.play_tool_sound(src)
 				user.visible_message( \
 					"[user] connects [src].", \
 					"<span class='notice'>You fasten [src] to the port.</span>", \

--- a/code/modules/clothing/gloves/color.dm
+++ b/code/modules/clothing/gloves/color.dm
@@ -49,12 +49,12 @@
 /obj/item/clothing/gloves/color/black/ce
 	item_color = "chief"		//Exists for washing machines. Is not different from black gloves in any way.
 
-/obj/item/clothing/gloves/color/black/attackby(obj/item/W as obj, mob/user as mob, params)
-	if(istype(W, /obj/item/wirecutters))
+/obj/item/clothing/gloves/color/black/attackby(obj/item/I, mob/user, params)
+	if(istype(I, /obj/item/wirecutters))
 		if(can_be_cut && icon_state == initial(icon_state))//only if not dyed
 			to_chat(user, "<span class='notice'>You snip the fingertips off of [src].</span>")
-			playsound(user.loc, W.usesound, rand(10,50), 1)
-			new /obj/item/clothing/gloves/fingerless(user.loc)
+			I.play_tool_sound(src)
+			new /obj/item/clothing/gloves/fingerless(drop_location())
 			qdel(src)
 	..()
 

--- a/code/modules/hydroponics/hydroponics.dm
+++ b/code/modules/hydroponics/hydroponics.dm
@@ -819,7 +819,7 @@
 
 	else if(istype(O, /obj/item/wirecutters) && unwrenchable)
 		using_irrigation = !using_irrigation
-		playsound(src, O.usesound, 50, 1)
+		O.play_tool_sound(src)
 		user.visible_message("<span class='notice'>[user] [using_irrigation ? "" : "dis"]connects [src]'s irrigation hoses.</span>", \
 		"<span class='notice'>You [using_irrigation ? "" : "dis"]connect [src]'s irrigation hoses.</span>")
 		for(var/obj/machinery/hydroponics/h in range(1,src))
@@ -830,11 +830,11 @@
 			to_chat(user, "<span class='warning'>[src] doesn't have any plants or weeds!</span>")
 			return
 		user.visible_message("<span class='notice'>[user] starts digging out [src]'s plants...</span>", "<span class='notice'>You start digging out [src]'s plants...</span>")
-		playsound(src, 'sound/effects/shovel_dig.ogg', 50, 1)
+		O.play_tool_sound(src)
 		if(!do_after(user, 50, target = src) || (!myseed && !weedlevel))
 			return
 		user.visible_message("<span class='notice'>[user] digs out the plants in [src]!</span>", "<span class='notice'>You dig out all of [src]'s plants!</span>")
-		playsound(src, 'sound/effects/shovel_dig.ogg', 50, 1)
+		O.play_tool_sound(src)
 		if(myseed) //Could be that they're just using it as a de-weeder
 			age = 0
 			plant_health = 0

--- a/code/modules/integrated_electronics/core/assemblies.dm
+++ b/code/modules/integrated_electronics/core/assemblies.dm
@@ -279,8 +279,8 @@
 			visible_message("<span class='notice'> [user] waves [src] around [target].</span>")
 
 
-/obj/item/device/electronic_assembly/screwdriver_act(mob/living/user, obj/item/S)
-	playsound(src, S.usesound, 50, 1)
+/obj/item/device/electronic_assembly/screwdriver_act(mob/living/user, obj/item/I)
+	I.play_tool_sound(src)
 	opened = !opened
 	to_chat(user, "<span class='notice'>You [opened ? "open" : "close"] the maintenance hatch of [src].</span>")
 	update_icon()

--- a/code/modules/library/lib_items.dm
+++ b/code/modules/library/lib_items.dm
@@ -75,7 +75,7 @@
 					state = 2
 					icon_state = "book-0"
 			if(istype(I, /obj/item/wrench))
-				playsound(loc, I.usesound, 100, 1)
+				I.play_tool_sound(src, 100)
 				to_chat(user, "<span class='notice'>You unwrench the frame.</span>")
 				anchored = FALSE
 				state = 0
@@ -102,9 +102,9 @@
 				if(contents.len)
 					to_chat(user, "<span class='warning'>You need to remove the books first!</span>")
 				else
-					playsound(loc, I.usesound, 100, 1)
+					I.play_tool_sound(src, 100)
 					to_chat(user, "<span class='notice'>You pry the shelf out.</span>")
-					new /obj/item/stack/sheet/mineral/wood(loc, 2)
+					new /obj/item/stack/sheet/mineral/wood(drop_location(), 2)
 					state = 1
 					icon_state = "bookempty"
 			else

--- a/code/modules/mining/equipment/kinetic_crusher.dm
+++ b/code/modules/mining/equipment/kinetic_crusher.dm
@@ -38,18 +38,18 @@
 		var/obj/item/crusher_trophy/T = t
 		to_chat(user, "<span class='notice'>It has \a [T] attached, which causes [T.effect_desc()].</span>")
 
-/obj/item/twohanded/required/kinetic_crusher/attackby(obj/item/A, mob/living/user)
-	if(istype(A, /obj/item/crowbar))
+/obj/item/twohanded/required/kinetic_crusher/attackby(obj/item/I, mob/living/user)
+	if(istype(I, /obj/item/crowbar))
 		if(LAZYLEN(trophies))
 			to_chat(user, "<span class='notice'>You remove [src]'s trophies.</span>")
-			playsound(loc, A.usesound, 100, 1)
+			I.play_tool_sound(src)
 			for(var/t in trophies)
 				var/obj/item/crusher_trophy/T = t
 				T.remove_from(src, user)
 		else
 			to_chat(user, "<span class='warning'>There are no trophies on [src].</span>")
-	else if(istype(A, /obj/item/crusher_trophy))
-		var/obj/item/crusher_trophy/T = A
+	else if(istype(I, /obj/item/crusher_trophy))
+		var/obj/item/crusher_trophy/T = I
 		T.add_to(src, user)
 	else
 		return ..()

--- a/code/modules/mining/equipment/mining_tools.dm
+++ b/code/modules/mining/equipment/mining_tools.dm
@@ -13,13 +13,13 @@
 	w_class = WEIGHT_CLASS_BULKY
 	materials = list(MAT_METAL=2000) //one sheet, but where can you make them?
 	var/digspeed = 40
-	var/list/digsound = list('sound/effects/picaxe1.ogg','sound/effects/picaxe2.ogg','sound/effects/picaxe3.ogg')
+	usesound = list('sound/effects/picaxe1.ogg', 'sound/effects/picaxe2.ogg', 'sound/effects/picaxe3.ogg')
 	attack_verb = list("hit", "pierced", "sliced", "attacked")
 
 /obj/item/pickaxe/suicide_act(mob/living/user)
 	user.visible_message("<span class='suicide'>[user] begins digging into their chest!  It looks like [user.p_theyre()] trying to commit suicide!</span>")
 	if(do_after(user,30, target = user))
-		playDigSound()
+		play_tool_sound(user)
 		return BRUTELOSS
 	user.visible_message("<span class='suicide'>[user] couldn't do it!</span>")	
 	return SHAME
@@ -33,9 +33,6 @@
 	slot_flags = SLOT_BELT
 	w_class = WEIGHT_CLASS_NORMAL
 	materials = list(MAT_METAL=1000)
-
-/obj/item/pickaxe/proc/playDigSound()
-	playsound(src, pick(digsound),50,1)
 
 /obj/item/pickaxe/silver
 	name = "silver-plated pickaxe"
@@ -59,7 +56,7 @@
 	item_state = "jackhammer"
 	slot_flags = SLOT_BELT
 	digspeed = 25 //available from roundstart, faster than a pickaxe.
-	digsound = list('sound/weapons/drill.ogg')
+	usesound = 'sound/weapons/drill.ogg'
 	hitsound = 'sound/weapons/drill.ogg'
 	desc = "An electric mining drill for the especially scrawny."
 
@@ -84,7 +81,7 @@
 	icon_state = "jackhammer"
 	item_state = "jackhammer"
 	digspeed = 5 //the epitome of powertools. extremely fast mining, laughs at puny walls
-	digsound = list('sound/weapons/sonic_jackhammer.ogg')
+	usesound = 'sound/weapons/sonic_jackhammer.ogg'
 	hitsound = 'sound/weapons/sonic_jackhammer.ogg'
 	desc = "Cracks rocks with sonic blasts, and doubles as a demolition power tool for smashing walls."
 
@@ -99,6 +96,7 @@
 	slot_flags = SLOT_BELT
 	force = 8
 	var/digspeed = 20
+	usesound = 'sound/effects/shovel_dig.ogg'
 	throwforce = 4
 	item_state = "shovel"
 	w_class = WEIGHT_CLASS_NORMAL
@@ -109,7 +107,7 @@
 /obj/item/shovel/suicide_act(mob/living/user)
 	user.visible_message("<span class='suicide'>[user] begins digging their own grave!  It looks like [user.p_theyre()] trying to commit suicide!</span>")
 	if(do_after(user,30, target = user))
-		playsound(src, 'sound/effects/shovel_dig.ogg', 50, 1)
+		play_tool_sound(user)
 		return BRUTELOSS
 	user.visible_message("<span class='suicide'>[user] couldn't do it!</span>")	
 	return SHAME

--- a/code/modules/mob/living/simple_animal/bot/construction.dm
+++ b/code/modules/mob/living/simple_animal/bot/construction.dm
@@ -182,9 +182,8 @@
 
 		if(8)
 			if(istype(W, /obj/item/screwdriver))
-				playsound(loc, W.usesound, 100, 1)
 				to_chat(user, "<span class='notice'>You start attaching the gun to the frame...</span>")
-				if(W.use_tool(src, user, 40))
+				if(W.use_tool(src, user, 40, volume=100))
 					name = "armed [name]"
 					to_chat(user, "<span class='notice'>Taser gun attached.</span>")
 					build_step++

--- a/code/modules/paperwork/filingcabinet.dm
+++ b/code/modules/paperwork/filingcabinet.dm
@@ -56,8 +56,7 @@
 		updateUsrDialog()
 	else if(istype(P, /obj/item/wrench))
 		to_chat(user, "<span class='notice'>You begin to [anchored ? "unwrench" : "wrench"] [src].</span>")
-		playsound(loc, P.usesound, 50, 1)
-		if(do_after(user, 20, target = src))
+		if(P.use_tool(src, user, 20, volume=50))
 			to_chat(user, "<span class='notice'>You successfully [anchored ? "unwrench" : "wrench"] [src].</span>")
 			anchored = !anchored
 	else if(user.a_intent != INTENT_HARM)

--- a/code/modules/paperwork/paper_cutter.dm
+++ b/code/modules/paperwork/paper_cutter.dm
@@ -60,7 +60,7 @@
 		update_icon()
 		return
 	if(istype(P, /obj/item/screwdriver) && storedcutter)
-		playsound(src, P.usesound, 50, 1)
+		P.play_tool_sound(src)
 		to_chat(user, "<span class='notice'>[storedcutter] has been [cuttersecured ? "unsecured" : "secured"].</span>")
 		cuttersecured = !cuttersecured
 		return

--- a/code/modules/power/antimatter/control.dm
+++ b/code/modules/power/antimatter/control.dm
@@ -159,14 +159,14 @@
 /obj/machinery/power/am_control_unit/attackby(obj/item/W, mob/user, params)
 	if(istype(W, /obj/item/wrench))
 		if(!anchored)
-			playsound(src.loc, W.usesound, 75, 1)
+			W.play_tool_sound(src, 75)
 			user.visible_message("[user.name] secures the [src.name] to the floor.", \
 				"<span class='notice'>You secure the anchor bolts to the floor.</span>", \
 				"<span class='italics'>You hear a ratchet.</span>")
 			src.anchored = TRUE
 			connect_to_network()
 		else if(!linked_shielding.len > 0)
-			playsound(src.loc, W.usesound, 75, 1)
+			W.play_tool_sound(src, 75)
 			user.visible_message("[user.name] unsecures the [src.name].", \
 				"<span class='notice'>You remove the anchor bolts.</span>", \
 				"<span class='italics'>You hear a ratchet.</span>")

--- a/code/modules/power/apc.dm
+++ b/code/modules/power/apc.dm
@@ -383,7 +383,7 @@
 				if (terminal)
 					to_chat(user, "<span class='warning'>Disconnect the wires first!</span>")
 					return
-				playsound(src.loc, W.usesound, 50, 1)
+				W.play_tool_sound(src)
 				to_chat(user, "<span class='notice'>You are trying to remove the power control board...</span>" )
 				if(W.use_tool(src, user, 50))
 					if (has_electronics==1)
@@ -417,7 +417,7 @@
 			else if(integration_cog)
 				user.visible_message("<span class='notice'>[user] starts prying [integration_cog] from [src]...</span>", \
 				"<span class='notice'>You painstakingly start tearing [integration_cog] out of [src]'s guts...</span>")
-				playsound(src, W.usesound, 50, TRUE)
+				W.play_tool_sound(src)
 				if(W.use_tool(src, user, 100))
 					user.visible_message("<span class='notice'>[user] destroys [integration_cog] in [src]!</span>", \
 					"<span class='notice'>[integration_cog] comes free with a clank and snaps in two as the machinery returns to normal!</span>")
@@ -467,12 +467,12 @@
 				if (has_electronics==1)
 					has_electronics = 2
 					stat &= ~MAINT
-					playsound(src.loc, W.usesound, 50, 1)
+					W.play_tool_sound(src)
 					to_chat(user, "<span class='notice'>You screw the circuit electronics into place.</span>")
 				else if (has_electronics==2)
 					has_electronics = 1
 					stat |= MAINT
-					playsound(src.loc, W.usesound, 50, 1)
+					W.play_tool_sound(src)
 					to_chat(user, "<span class='notice'>You unfasten the electronics.</span>")
 				else /* has_electronics==0 */
 					to_chat(user, "<span class='warning'>There is nothing to secure!</span>")

--- a/code/modules/power/gravitygenerator.dm
+++ b/code/modules/power/gravitygenerator.dm
@@ -188,15 +188,14 @@ GLOBAL_LIST_EMPTY(gravity_generators) // We will keep track of this by adding ne
 		if(GRAV_NEEDS_SCREWDRIVER)
 			if(istype(I, /obj/item/screwdriver))
 				to_chat(user, "<span class='notice'>You secure the screws of the framework.</span>")
-				playsound(src.loc, I.usesound, 50, 1)
+				I.play_tool_sound(src)
 				broken_state++
 				update_icon()
 				return
 		if(GRAV_NEEDS_WELDING)
 			if(istype(I, /obj/item/weldingtool))
-				if(I.use_tool(src, user, 0, amount=1))
+				if(I.use_tool(src, user, 0, volume=50, amount=1))
 					to_chat(user, "<span class='notice'>You mend the damaged framework.</span>")
-					playsound(src, 'sound/items/welder2.ogg', 50, 1)
 					broken_state++
 					update_icon()
 				return
@@ -215,7 +214,7 @@ GLOBAL_LIST_EMPTY(gravity_generators) // We will keep track of this by adding ne
 		if(GRAV_NEEDS_WRENCH)
 			if(istype(I, /obj/item/wrench))
 				to_chat(user, "<span class='notice'>You secure the plating to the framework.</span>")
-				playsound(src.loc, I.usesound, 75, 1)
+				I.play_tool_sound(src)
 				set_fix()
 				return
 	return ..()

--- a/code/modules/power/lighting.dm
+++ b/code/modules/power/lighting.dm
@@ -139,13 +139,13 @@
 				new /obj/item/stack/cable_coil(drop_location(), 1, "red")
 				user.visible_message("[user.name] removes the wiring from [src].", \
 					"<span class='notice'>You remove the wiring from [src].</span>", "<span class='italics'>You hear clicking.</span>")
-				playsound(loc, W.usesound, 100, 1)
+				W.play_tool_sound(src, 100)
 				return
 
 			if(istype(W, /obj/item/screwdriver))
 				user.visible_message("[user.name] closes [src]'s casing.", \
 					"<span class='notice'>You close [src]'s casing.</span>", "<span class='italics'>You hear screwing.</span>")
-				playsound(loc, W.usesound, 75, 1)
+				W.play_tool_sound(src, 75)
 				switch(fixture_type)
 					if("tube")
 						newlight = new /obj/machinery/light/built(loc)
@@ -418,7 +418,7 @@
 	// attempt to stick weapon into light socket
 	else if(status == LIGHT_EMPTY)
 		if(istype(W, /obj/item/screwdriver)) //If it's a screwdriver open it.
-			playsound(src.loc, W.usesound, 75, 1)
+			W.play_tool_sound(src, 75)
 			user.visible_message("[user.name] opens [src]'s casing.", \
 				"<span class='notice'>You open [src]'s casing.</span>", "<span class='italics'>You hear a noise.</span>")
 			deconstruct()

--- a/code/modules/power/port_gen.dm
+++ b/code/modules/power/port_gen.dm
@@ -195,7 +195,7 @@
 			return
 		else if(istype(O, /obj/item/screwdriver))
 			panel_open = !panel_open
-			playsound(src.loc, O.usesound, 50, 1)
+			O.play_tool_sound(src)
 			if(panel_open)
 				to_chat(user, "<span class='notice'>You open the access panel.</span>")
 			else

--- a/code/modules/power/singularity/particle_accelerator/particle_accelerator.dm
+++ b/code/modules/power/singularity/particle_accelerator/particle_accelerator.dm
@@ -65,7 +65,7 @@
 	switch(construction_state)
 		if(PA_CONSTRUCTION_UNSECURED)
 			if(istype(W, /obj/item/wrench) && !isinspace())
-				playsound(loc, W.usesound, 75, 1)
+				W.play_tool_sound(src, 75)
 				anchored = TRUE
 				user.visible_message("[user.name] secures the [name] to the floor.", \
 					"You secure the external bolts.")
@@ -73,7 +73,7 @@
 				did_something = TRUE
 		if(PA_CONSTRUCTION_UNWIRED)
 			if(istype(W, /obj/item/wrench))
-				playsound(loc, W.usesound, 75, 1)
+				W.play_tool_sound(src, 75)
 				anchored = FALSE
 				user.visible_message("[user.name] detaches the [name] from the floor.", \
 					"You remove the external bolts.")

--- a/code/modules/power/singularity/particle_accelerator/particle_control.dm
+++ b/code/modules/power/singularity/particle_accelerator/particle_control.dm
@@ -270,7 +270,7 @@
 	switch(construction_state)
 		if(PA_CONSTRUCTION_UNSECURED)
 			if(istype(W, /obj/item/wrench) && !isinspace())
-				playsound(loc, W.usesound, 75, 1)
+				W.play_tool_sound(src, 75)
 				anchored = TRUE
 				user.visible_message("[user.name] secures the [name] to the floor.", \
 					"You secure the external bolts.")
@@ -278,7 +278,7 @@
 				did_something = TRUE
 		if(PA_CONSTRUCTION_UNWIRED)
 			if(istype(W, /obj/item/wrench))
-				playsound(loc, W.usesound, 75, 1)
+				W.play_tool_sound(src, 75)
 				anchored = FALSE
 				user.visible_message("[user.name] detaches the [name] from the floor.", \
 					"You remove the external bolts.")

--- a/code/modules/power/solar.dm
+++ b/code/modules/power/solar.dm
@@ -212,10 +212,10 @@
 		anchored = !anchored
 		if(anchored)
 			user.visible_message("[user] wrenches the solar assembly into place.", "<span class='notice'>You wrench the solar assembly into place.</span>")
-			playsound(src.loc, W.usesound, 75, 1)
+			W.play_tool_sound(src, 75)
 		else
 			user.visible_message("[user] unwrenches the solar assembly from its place.", "<span class='notice'>You unwrench the solar assembly from its place.</span>")
-			playsound(src.loc, W.usesound, 75, 1)
+			W.play_tool_sound(src, 75)
 		return 1
 
 	if(istype(W, /obj/item/stack/sheet/glass) || istype(W, /obj/item/stack/sheet/rglass))

--- a/code/modules/projectiles/guns/energy/kinetic_accelerator.dm
+++ b/code/modules/projectiles/guns/energy/kinetic_accelerator.dm
@@ -33,17 +33,17 @@
 			var/obj/item/borg/upgrade/modkit/M = A
 			to_chat(user, "<span class='notice'>There is \a [M] installed, using <b>[M.cost]%</b> capacity.</span>")
 
-/obj/item/gun/energy/kinetic_accelerator/attackby(obj/item/A, mob/user)
-	if(istype(A, /obj/item/crowbar))
+/obj/item/gun/energy/kinetic_accelerator/attackby(obj/item/I, mob/user)
+	if(istype(I, /obj/item/crowbar))
 		if(modkits.len)
 			to_chat(user, "<span class='notice'>You pry the modifications out.</span>")
-			playsound(loc, A.usesound, 100, 1)
+			I.play_tool_sound(src, 100)
 			for(var/obj/item/borg/upgrade/modkit/M in modkits)
 				M.uninstall(src)
 		else
 			to_chat(user, "<span class='notice'>There are no modifications currently installed.</span>")
-	else if(istype(A, /obj/item/borg/upgrade/modkit))
-		var/obj/item/borg/upgrade/modkit/MK = A
+	else if(istype(I, /obj/item/borg/upgrade/modkit))
+		var/obj/item/borg/upgrade/modkit/MK = I
 		MK.install(src, user)
 	else
 		..()

--- a/code/modules/projectiles/guns/energy/special.dm
+++ b/code/modules/projectiles/guns/energy/special.dm
@@ -127,7 +127,7 @@
 	can_charge = 0
 
 	heat = 3800
-	usesound = 'sound/items/welder.ogg'
+	usesound = list('sound/items/welder.ogg', 'sound/items/welder2.ogg')
 	tool_behaviour = TOOL_WELDER
 	toolspeed = 0.7 //plasmacutters can be used as welders, and are faster than standard welders
 

--- a/code/modules/recycling/conveyor2.dm
+++ b/code/modules/recycling/conveyor2.dm
@@ -128,7 +128,7 @@
 
 	else if(istype(I, /obj/item/wrench))
 		if(!(stat & BROKEN))
-			playsound(loc, I.usesound, 50, 1)
+			I.play_tool_sound(src)
 			setDir(turn(dir,-45))
 			update_move_direction()
 			to_chat(user, "<span class='notice'>You rotate [src].</span>")

--- a/code/modules/recycling/disposal/bin.dm
+++ b/code/modules/recycling/disposal/bin.dm
@@ -82,16 +82,15 @@
 	if(!pressure_charging && !full_pressure && !flush)
 		if(istype(I, /obj/item/screwdriver))
 			panel_open = !panel_open
-			playsound(get_turf(src), I.usesound, 50, 1)
+			I.play_tool_sound(src)
 			to_chat(user, "<span class='notice'>You [panel_open ? "remove":"attach"] the screws around the power connection.</span>")
 			return
 		else if(istype(I, /obj/item/weldingtool) && panel_open)
 			if(!I.tool_start_check(user, amount=0))
 				return
 
-			playsound(src.loc, 'sound/items/welder2.ogg', 100, 1)
 			to_chat(user, "<span class='notice'>You start slicing the floorweld off \the [src]...</span>")
-			if(I.use_tool(src, user, 20) && panel_open)
+			if(I.use_tool(src, user, 20, volume=100) && panel_open)
 				to_chat(user, "<span class='notice'>You slice the floorweld off \the [src].</span>")
 				deconstruct()
 			return

--- a/code/modules/recycling/disposal/construction.dm
+++ b/code/modules/recycling/disposal/construction.dm
@@ -155,7 +155,7 @@
 			anchored = TRUE
 			density = initial(pipe_type.density)
 			to_chat(user, "<span class='notice'>You attach the [pipename] to the underfloor.</span>")
-		playsound(src, I.usesound, 100, 1)
+		I.play_tool_sound(src, 100)
 		update_icon()
 
 	else if(istype(I, /obj/item/weldingtool))

--- a/code/modules/surgery/bodyparts/robot_bodyparts.dm
+++ b/code/modules/surgery/bodyparts/robot_bodyparts.dm
@@ -126,7 +126,7 @@
 			to_chat(user, "<span class='notice'>You insert the flash into the eye socket.</span>")
 	else if(istype(W, /obj/item/crowbar))
 		if(flash1 || flash2)
-			playsound(src.loc, W.usesound, 50, 1)
+			W.play_tool_sound(src)
 			to_chat(user, "<span class='notice'>You remove the flash from [src].</span>")
 			if(flash1)
 				flash1.forceMove(user.loc)

--- a/code/modules/surgery/organs/autosurgeon.dm
+++ b/code/modules/surgery/organs/autosurgeon.dm
@@ -60,7 +60,7 @@
 			var/turf/open/floorloc = get_turf(user)
 			floorloc.contents += contents
 			to_chat(user, "<span class='notice'>You remove the [storedorgan] from [src].</span>")
-			playsound(get_turf(user), I.usesound, 50, 1)
+			I.play_tool_sound(src)
 			storedorgan = null
 			if(uses != INFINITE)
 				uses--

--- a/code/modules/vehicles/scooter.dm
+++ b/code/modules/vehicles/scooter.dm
@@ -101,21 +101,16 @@
 /obj/item/scooter_frame/attackby(obj/item/I, mob/user, params)
 	if(istype(I, /obj/item/wrench))
 		to_chat(user, "<span class='notice'>You deconstruct [src].</span>")
-		new /obj/item/stack/rods(get_turf(src),10)
-		playsound(get_turf(user), 'sound/items/ratchet.ogg', 50, 1)
+		new /obj/item/stack/rods(drop_location(), 10)
+		I.play_tool_sound(src)
 		qdel(src)
 		return
 
 	else if(istype(I, /obj/item/stack/sheet/metal))
-		var/obj/item/stack/sheet/metal/M = I
-		if(M.get_amount() < 5)
-			to_chat(user, "<span class='warning'>You need at least five metal sheets to make proper wheels!</span>")
+		if(!I.tool_start_check(user, amount=5))
 			return
 		to_chat(user, "<span class='notice'>You begin to add wheels to [src].</span>")
-		if(do_after(user, 80, target = src))
-			if(!M || M.get_amount() < 5)
-				return
-			M.use(5)
+		if(I.use_tool(src, user, 80, volume=50, amount=5))
 			to_chat(user, "<span class='notice'>You finish making wheels for [src].</span>")
 			new /obj/vehicle/ridden/scooter/skateboard(user.loc)
 			qdel(src)
@@ -123,27 +118,21 @@
 /obj/vehicle/ridden/scooter/skateboard/attackby(obj/item/I, mob/user, params)
 	if(istype(I, /obj/item/screwdriver))
 		to_chat(user, "<span class='notice'>You begin to deconstruct and remove the wheels on [src]...</span>")
-		playsound(get_turf(user), I.usesound, 50, 1)
-		if(do_after(user, 20, target = src))
+		if(I.use_tool(src, user, 20, volume=50))
 			to_chat(user, "<span class='notice'>You deconstruct the wheels on [src].</span>")
-			new /obj/item/stack/sheet/metal(get_turf(src),5)
-			new /obj/item/scooter_frame(get_turf(src))
+			new /obj/item/stack/sheet/metal(drop_location(), 5)
+			new /obj/item/scooter_frame(drop_location())
 			if(has_buckled_mobs())
 				var/mob/living/carbon/H = buckled_mobs[1]
 				unbuckle_mob(H)
 			qdel(src)
 
 	else if(istype(I, /obj/item/stack/rods))
-		var/obj/item/stack/rods/C = I
-		if(C.get_amount() < 2)
-			to_chat(user, "<span class='warning'>You need at least two rods to make proper handlebars!</span>")
+		if(!I.tool_start_check(user, amount=2))
 			return
 		to_chat(user, "<span class='notice'>You begin making handlebars for [src].</span>")
-		if(do_after(user, 25, target = src))
-			if(!C || C.get_amount() < 2)
-				return
+		if(I.use_tool(src, user, 25, volume=50, amount=2))
 			to_chat(user, "<span class='notice'>You add the rods to [src], creating handlebars.</span>")
-			C.use(2)
 			var/obj/vehicle/ridden/scooter/S = new(loc)
 			if(has_buckled_mobs())
 				var/mob/living/carbon/H = buckled_mobs[1]


### PR DESCRIPTION
Tools now use `play_tool_sound` instead of calling `playsound` on `usesound`.

The new proc, `play_tool_sound`, supports lists in `usesound`, so it's now possible for tools to have more than one sound. So now the largely unused `'sound/items/welder2.ogg'` and `'sound/items/screwdriver2.ogg'` are actually used.

This PR also adds tool sounds to some tools, and makes mining tools use `usesound` and `play_tool_sound` instead of a snowflake system they had.