### PR TITLE
Cleans up earliest_start for pirate/meteor events

### DIFF
--- a/code/modules/events/meteor_wave.dm
+++ b/code/modules/events/meteor_wave.dm
@@ -6,7 +6,7 @@
 	weight = 4
 	min_players = 15
 	max_occurrences = 3
-	earliest_start = 25 MINUTES
+	earliest_start = 15000 //25 minutes
 
 /datum/round_event/meteor_wave
 	startWhen		= 6
@@ -58,7 +58,7 @@
 	weight = 5
 	min_players = 20
 	max_occurrences = 3
-	earliest_start = 35 MINUTES
+	earliest_start = 21000 //35 minutes
 
 /datum/round_event/meteor_wave/threatening
 	wave_name = "threatening"
@@ -69,7 +69,7 @@
 	weight = 7
 	min_players = 25
 	max_occurrences = 3
-	earliest_start = 45 MINUTES
+	earliest_start = 27000 //45 minutes
 
 /datum/round_event/meteor_wave/catastrophic
 	wave_name = "catastrophic"

--- a/code/modules/events/pirates.dm
+++ b/code/modules/events/pirates.dm
@@ -6,7 +6,7 @@
 	weight = 8
 	max_occurrences = 1
 	min_players = 10
-	earliest_start = 30 MINUTES
+	earliest_start = 18000 //30 minutes
 	gamemode_blacklist = list("nuclear")
 
 /datum/round_event/pirates
@@ -199,7 +199,7 @@
 	name = "pirate shuttle"
 	id = "pirateship"
 	var/engines_cooling = FALSE
-	var/engine_cooldown = 3 MINUTES
+	var/engine_cooldown = 1800 //3 minutes
 
 /obj/docking_port/mobile/pirate/getStatusText()
 	. = ..()


### PR DESCRIPTION
:cl: Denton
code: Cleans up earliest_start for pirate/meteor events.
/:cl:

For some reason, the pirate and meteor wave events were using "XY MINUTES" instead of deciseconds for earliest_start.