### PR TITLE
Fixes lye/plastic/charcoal conflicts

### DIFF
--- a/code/modules/reagents/chemistry/recipes/others.dm
+++ b/code/modules/reagents/chemistry/recipes/others.dm
@@ -562,7 +562,7 @@
 	name = "lye"
 	id = "lye"
 	results = list("lye" = 2)
-	required_reagents = list("ash" = 1, "water" = 1)
+	required_reagents = list("ash" = 1, "water" = 1, "carbon" = 1)
 
 /datum/chemical_reaction/royal_bee_jelly
 	name = "royal bee jelly"
@@ -579,7 +579,7 @@
 /datum/chemical_reaction/plastic_polymers
 	name = "plastic polymers"
 	id = "plastic_polymers"
-	required_reagents = list("oil" = 5, "sodiumchloride" = 2, "ash" = 3)
+	required_reagents = list("oil" = 5, "sacid" = 2, "ash" = 3)
 	required_temp = 374 //lazily consistent with soap & other crafted objects generically created with heat.
 
 /datum/chemical_reaction/plastic_polymers/on_reaction(datum/reagents/holder, created_volume)


### PR DESCRIPTION
:cl: Denton
fix: Fixes lye/plastic/charcoal conflicts when mixing.
fix: Lye is now made by combining ash with water and carbon. Plastic sheets by heating ash, sulphuric acid and oil.
/:cl:

Closes: #35490

Charcoal (ash+salt) conflicts with plastic (ash+salt+oil). Lye (ash+water) can conflict with both of them, since water is a component of salt. 

This PR changes their recipes from: 
ash/water + ash/salt/oil
to:
ash/water/carbon + ash/sacid/oil