### PR TITLE
stops logic circuit runtime spam

### DIFF
--- a/code/modules/integrated_electronics/subtypes/logic.dm
+++ b/code/modules/integrated_electronics/subtypes/logic.dm
@@ -163,6 +163,8 @@
 	spawn_flags = IC_SPAWN_DEFAULT|IC_SPAWN_RESEARCH
 
 /obj/item/integrated_circuit/logic/binary/and/do_compare(var/datum/integrated_io/A, var/datum/integrated_io/B)
+	if(!isnum(A.data) || !isnum(B.data))
+		return FALSE
 	return A.data && B.data
 
 /obj/item/integrated_circuit/logic/binary/or
@@ -172,6 +174,8 @@
 	spawn_flags = IC_SPAWN_DEFAULT|IC_SPAWN_RESEARCH
 
 /obj/item/integrated_circuit/logic/binary/or/do_compare(var/datum/integrated_io/A, var/datum/integrated_io/B)
+	if(!isnum(A.data) || !isnum(B.data))
+		return FALSE
 	return A.data || B.data
 
 /obj/item/integrated_circuit/logic/binary/less_than
@@ -181,6 +185,8 @@
 	spawn_flags = IC_SPAWN_DEFAULT|IC_SPAWN_RESEARCH
 
 /obj/item/integrated_circuit/logic/binary/less_than/do_compare(var/datum/integrated_io/A, var/datum/integrated_io/B)
+	if(!isnum(A.data) || !isnum(B.data))
+		return FALSE
 	return A.data < B.data
 
 /obj/item/integrated_circuit/logic/binary/less_than_or_equal
@@ -190,6 +196,8 @@
 	spawn_flags = IC_SPAWN_DEFAULT|IC_SPAWN_RESEARCH
 
 /obj/item/integrated_circuit/logic/binary/less_than_or_equal/do_compare(var/datum/integrated_io/A, var/datum/integrated_io/B)
+	if(!isnum(A.data) || !isnum(B.data))
+		return FALSE
 	return A.data <= B.data
 
 /obj/item/integrated_circuit/logic/binary/greater_than
@@ -199,6 +207,8 @@
 	spawn_flags = IC_SPAWN_DEFAULT|IC_SPAWN_RESEARCH
 
 /obj/item/integrated_circuit/logic/binary/greater_than/do_compare(var/datum/integrated_io/A, var/datum/integrated_io/B)
+	if(!isnum(A.data) || !isnum(B.data))
+		return FALSE
 	return A.data > B.data
 
 /obj/item/integrated_circuit/logic/binary/greater_than_or_equal
@@ -208,6 +218,8 @@
 	spawn_flags = IC_SPAWN_DEFAULT|IC_SPAWN_RESEARCH
 
 /obj/item/integrated_circuit/logic/binary/greater_than_or_equal/do_compare(var/datum/integrated_io/A, var/datum/integrated_io/B)
+	if(!isnum(A.data) || !isnum(B.data))
+		return FALSE
 	return A.data >= B.data
 
 /obj/item/integrated_circuit/logic/unary/not


### PR DESCRIPTION
no reason to spam the runtime log if someone was dumb and didn't use a text2num converter circuit.

```
The following runtime has occurred 22 time(s).
runtime error: type mismatch: cannot compare -100 to "10"
proc name: do compare (/obj/item/integrated_circuit/logic/binary/less_than/do_compare)
  source file: logic.dm,184
  usr: Brick Carr (/mob/living/carbon/human)
  src: the less than gate (/obj/item/integrated_circuit/logic/binary/less_than)
```

```
The following runtime has occurred 6 time(s).
runtime error: type mismatch: cannot compare /datum/weakref (/datum/weakref) to 100
proc name: do compare (/obj/item/integrated_circuit/logic/binary/less_than/do_compare)
  source file: logic.dm,184
  usr: Incomprehensible Joanne (/mob/living/carbon/human)
  src: the less than gate (/obj/item/integrated_circuit/logic/binary/less_than)
```

```
The following runtime has occurred 1 time(s).
runtime error: type mismatch: cannot compare 83 to ""
proc name: do compare (/obj/item/integrated_circuit/logic/binary/less_than/do_compare)
  source file: logic.dm,184
  usr: Floof NoBeard (/mob/living/carbon/human)
  src: the less than gate (/obj/item/integrated_circuit/logic/binary/less_than)
```

```
The following runtime has occurred 32 time(s).
runtime error: type mismatch: cannot compare 98 to "10"
proc name: do compare (/obj/item/integrated_circuit/logic/binary/less_than/do_compare)
  source file: logic.dm,184
  usr: Brick Carr (/mob/living/carbon/human)
  src: the less than gate (/obj/item/integrated_circuit/logic/binary/less_than)
```