### PR TITLE
Increases Kinetic Crusher trophy drop chance

### DIFF
--- a/code/modules/mob/living/simple_animal/hostile/mining_mobs/mining_mobs.dm
+++ b/code/modules/mob/living/simple_animal/hostile/mining_mobs/mining_mobs.dm
@@ -20,7 +20,7 @@
 	lighting_alpha = LIGHTING_PLANE_ALPHA_MOSTLY_INVISIBLE
 	mob_size = MOB_SIZE_LARGE
 	var/icon_aggro = null
-	var/crusher_drop_mod = 10
+	var/crusher_drop_mod = 20
 
 /mob/living/simple_animal/hostile/asteroid/Initialize(mapload)
 	. = ..()

--- a/code/modules/mob/living/simple_animal/hostile/mining_mobs/mining_mobs.dm
+++ b/code/modules/mob/living/simple_animal/hostile/mining_mobs/mining_mobs.dm
@@ -20,7 +20,7 @@
 	lighting_alpha = LIGHTING_PLANE_ALPHA_MOSTLY_INVISIBLE
 	mob_size = MOB_SIZE_LARGE
 	var/icon_aggro = null
-	var/crusher_drop_mod = 5
+	var/crusher_drop_mod = 2.5
 
 /mob/living/simple_animal/hostile/asteroid/Initialize(mapload)
 	. = ..()

--- a/code/modules/mob/living/simple_animal/hostile/mining_mobs/mining_mobs.dm
+++ b/code/modules/mob/living/simple_animal/hostile/mining_mobs/mining_mobs.dm
@@ -20,7 +20,7 @@
 	lighting_alpha = LIGHTING_PLANE_ALPHA_MOSTLY_INVISIBLE
 	mob_size = MOB_SIZE_LARGE
 	var/icon_aggro = null
-	var/crusher_drop_mod = 2.5
+	var/crusher_drop_mod = 10
 
 /mob/living/simple_animal/hostile/asteroid/Initialize(mapload)
 	. = ..()


### PR DESCRIPTION
This PR quadruples the drop chance for Kinetic Crusher trophies.

Reasoning:
The Kinetic Crusher is a_very_ high skill ceiling weapon. It is hard to use well and even harder to use without  constantly getting hit. And, once you get the right trophies, its also quite powerful.

Unfortunately, the trophy drop chance is shit. I've had to farm goliath tendrils for 30 minutes to get a single trophy. Your chances of getting them _without_ a tendril are essentially nill.

So, we're left with this extremely high skill weapon that, theoretically, _should_ reward players for using it (if they can). In actuality, we get a weapon which is almost entirely dependent on shitty RNG.

If I want to kill shit, I don't use this, because it can take 40 minutes to get to the point where it can kill megafauna effectively. Instead, I wait 5 minutes, by which point research has unlocked Advanced Plasma Cutters >90% of the time. Then, I print 2 of those with shit I mined in those 5 minutes, and bam, I'm killing megas _without_ the risk involved in meleeing them to death.

Oh, and did I forget to mention that its also two-handed and can't fit in bags, and its also worse at mining than both a upgraded KA and _especially_ Adv Plasmas?

:cl: 
tweak: Centcom has sharpened all Kinetic Crushers. Unfortunately, this doesn't make them more effective as weapons, but you'll have better luck cutting off trophies while using them.
/:cl: 