### PR TITLE
Mime's Bane recipe

### DIFF
--- a/code/__DEFINES/traits.dm
+++ b/code/__DEFINES/traits.dm
@@ -1,6 +1,7 @@
 //mob traits
 #define TRAIT_BLIND 			"blind"
 #define TRAIT_MUTE				"mute"
+#define TRAIT_EMOTEMUTE			"emotemute"
 #define TRAIT_DEAF				"deaf"
 #define TRAIT_NEARSIGHT			"nearsighted"
 #define TRAIT_FAT				"fat"

--- a/code/datums/emotes.dm
+++ b/code/datums/emotes.dm
@@ -107,7 +107,10 @@
 		if(restraint_check && (user.restrained() || user.buckled))
 			to_chat(user, "<span class='notice'>You cannot [key] while restrained.</span>")
 			return FALSE
-		if(user.reagents && user.reagents.has_reagent("mimesbane"))
+
+	if(isliving(user))
+		var/mob/living/L = user
+		if(L.has_trait(TRAIT_EMOTEMUTE))
 			return FALSE
 
 /datum/emote/sound

--- a/code/modules/reagents/chemistry/reagents/toxin_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/toxin_reagents.dm
@@ -908,3 +908,9 @@
 	color = "#F0F8FF" // rgb: 240, 248, 255
 	toxpwr = 0
 	taste_description = "stillness"
+
+/datum/reagent/toxin/mimesbane/on_mob_add(mob/living/L)
+	L.add_trait(TRAIT_EMOTEMUTE, id)
+
+/datum/reagent/toxin/mimesbane/on_mob_delete(mob/living/L)
+	L.remove_trait(TRAIT_EMOTEMUTE, id)

--- a/code/modules/reagents/chemistry/recipes/toxins.dm
+++ b/code/modules/reagents/chemistry/recipes/toxins.dm
@@ -111,5 +111,5 @@
 /datum/chemical_reaction/mimesbane
 	name = "Mime's Bane"
 	id = "mimesbane"
-	results = list("mimesbane" = 2)
-	required_reagents = list("mutetoxin" = 1, "nothing" = 1)
+	results = list("mimesbane" = 3)
+	required_reagents = list("radium" = 1, "mutetoxin" = 1, "nothing" = 1)

--- a/code/modules/reagents/chemistry/recipes/toxins.dm
+++ b/code/modules/reagents/chemistry/recipes/toxins.dm
@@ -64,7 +64,7 @@
 	required_reagents = list("ethanol" = 1, "chlorine" = 3, "water" = 1)
 
 /datum/chemical_reaction/mutetoxin //i'll just fit this in here snugly between other unfun chemicals :v
-	name = "Mute toxin"
+	name = "Mute Toxin"
 	id = "mutetoxin"
 	results = list("mutetoxin" = 2)
 	required_reagents = list("uranium" = 2, "water" = 1, "carbon" = 1)
@@ -107,3 +107,9 @@
 	id = "anacea"
 	results = list("anacea" = 3)
 	required_reagents = list("haloperidol" = 1, "impedrezene" = 1, "radium" = 1)
+
+/datum/chemical_reaction/mimesbane
+	name = "Mime's Bane"
+	id = "mimesbane"
+	results = list("mimesbane" = 2)
+	required_reagents = list("mutetoxin" = 1, "nothing" = 1)


### PR DESCRIPTION
:cl: coiax
add: Mime's Bane, a toxin that prevents people from emoting while it's in their system, can now be created by mixing 1 part Mute Toxin, 1 part Nothing and 1 part Radium.
/:cl:

It randomly occurred to me that I should do this.

Mime's Bane is currently a reagent currently only used in cloning pods
to stop growing clones from gasping from crit/lack of air (since they're
in a pure nitrogen environment).