### PR TITLE
Fixes spider_infestation event

### DIFF
--- a/code/modules/events/spider_infestation.dm
+++ b/code/modules/events/spider_infestation.dm
@@ -21,7 +21,9 @@
 
 /datum/round_event/spider_infestation/start()
 	var/list/vents = list()
-	for(var/obj/machinery/atmospherics/components/unary/vent_pump/temp_vent in world)
+	for(var/obj/machinery/atmospherics/components/unary/vent_pump/temp_vent in GLOB.machines)
+		if(QDELETED(temp_vent))
+			continue
 		if(is_station_level(temp_vent.loc.z) && !temp_vent.welded)
 			var/datum/pipeline/temp_vent_parent = temp_vent.parents[1]
 			if(temp_vent_parent.other_atmosmch.len > 20)


### PR DESCRIPTION
```
runtime error: 
[03:59:52]Cannot read null.z
[03:59:52]proc name: start (/datum/round_event/spider_infestation/start)
[03:59:52]  source file: spider_infestation.dm,25
[03:59:52]  usr: null
[03:59:52]  src: /datum/round_event/spider_infe... (/datum/round_event/spider_infestation)
[03:59:52]  call stack:
[03:59:52]/datum/round_event/spider_infe... (/datum/round_event/spider_infestation): start()
[03:59:52]/datum/round_event/spider_infe... (/datum/round_event/spider_infestation): process()
[03:59:52]Events (/datum/controller/subsystem/events): fire(0)
[03:59:52]Events (/datum/controller/subsystem/events): ignite(0)
[03:59:52]Master (/datum/controller/master): RunQueue()
[03:59:52]Master (/datum/controller/master): Loop()
[03:59:52]Master (/datum/controller/master): StartProcessing(0)
```