### PR TITLE
respawn_character runtime fix

### DIFF
--- a/code/modules/admin/verbs/randomverbs.dm
+++ b/code/modules/admin/verbs/randomverbs.dm
@@ -344,7 +344,7 @@ Traitors and the like can also be revived with the previous role mostly intact.
 		new_character.real_name = record_found.fields["name"]
 		new_character.gender = record_found.fields["sex"]
 		new_character.age = record_found.fields["age"]
-		new_character.hardset_dna(record_found.fields["identity"], record_found.fields["enzymes"], record_found.fields["name"], record_found.fields["blood_type"], new record_found.fields["species"], record_found.fields["features"])
+		new_character.hardset_dna(record_found.fields["identity"], record_found.fields["enzymes"], record_found.fields["name"], record_found.fields["blood_type"], record_found.fields["species"], record_found.fields["features"])
 	else
 		var/datum/preferences/A = new()
 		A.copy_to(new_character)


### PR DESCRIPTION
Looks like a bad copypasta

```
runtime error: 
[09:06:20]Cannot create objects of type /list.
[09:06:20]proc name: Respawn Character (/client/proc/respawn_character)
[09:06:20]  source file: randomverbs.dm,347
[09:06:20]  usr: Skylar Lineman (/mob/dead/observer)
[09:06:20]  src: Kevinz000 (/client)
[09:06:20]  usr.loc: the wall (164,132,2) (/turf/closed/wall)
[09:06:20]  call stack:
[09:06:20]Kevinz000 (/client): Respawn Character()
Initialized 652 atoms
```