### PR TITLE
Sanity check for sentience event

### DIFF
--- a/code/modules/events/sentience.dm
+++ b/code/modules/events/sentience.dm
@@ -31,7 +31,7 @@
 	var/list/potential = list()
 	for(var/mob/living/simple_animal/L in GLOB.alive_mob_list)
 		var/turf/T = get_turf(L)
-		if(!is_station_level(T.z))
+		if(!T || !is_station_level(T.z))
 			continue
 		if(!(L in GLOB.player_list) && !L.mind)
 			potential += L


### PR DESCRIPTION
```
runtime error: 
[02:30:17]Cannot read null.z
[02:30:17]proc name: spawn role (/datum/round_event/ghost_role/sentience/spawn_role)
[02:30:17]  source file: sentience.dm,34
[02:30:17]  usr: null
[02:30:17]  src: /datum/round_event/ghost_role/... (/datum/round_event/ghost_role/sentience)
[02:30:17]  call stack:
[02:30:17]/datum/round_event/ghost_role/... (/datum/round_event/ghost_role/sentience): spawn role()
[02:30:17]/datum/round_event/ghost_role/... (/datum/round_event/ghost_role/sentience): try spawning(0, 0)
[02:30:17]/datum/round_event/ghost_role/... (/datum/round_event/ghost_role/sentience): start()
[02:30:17]/datum/round_event/ghost_role/... (/datum/round_event/ghost_role/sentience): process()
```