### PR TITLE
Fixes communications console runtime

### DIFF
--- a/code/game/machinery/computer/communications.dm
+++ b/code/game/machinery/computer/communications.dm
@@ -366,7 +366,7 @@
 			if(!aicurrmsg || !answer || aicurrmsg.possible_answers.len < answer)
 				aistate = STATE_MESSAGELIST
 			aicurrmsg.answered = answer
-			log_game("[key_name(usr)] answered [currmsg.title] comm message. Answer : [currmsg.answered]")
+			log_game("[key_name(usr)] answered [aicurrmsg.title] comm message. Answer : [aicurrmsg.answered]")
 			if(aicurrmsg.answer_callback)
 				aicurrmsg.answer_callback.Invoke()
 			aistate = STATE_VIEWMESSAGE


### PR DESCRIPTION
Wrong message was being sent to log_game

```
runtime error: 
[14:41:45]Cannot read null.title
[14:41:45]proc name: Topic (/obj/machinery/computer/communications/Topic)
[14:41:45]  source file: communications.dm,370
[14:41:45]  usr: AI-Zwei-C (/mob/living/silicon/ai)
[14:41:45]  src: the communications console (/obj/machinery/computer/communications)
[14:41:45]  usr.loc: the floor (147,125,2) (/turf/open/floor/plasteel)
[14:41:45]  src.loc: the floor (120,174,2) (/turf/open/floor/plasteel/darkblue/side)
[14:41:45]  call stack:
[14:41:45]the communications console (/obj/machinery/computer/communications): Topic("src=\[0x2004a3f];operation=ai-...", /list (/list))
[14:41:45]GreyGanon (/client): Topic("src=\[0x2004a3f];operation=ai-...", /list (/list), the communications console (/obj/machinery/computer/communications))
[14:41:45]GreyGanon (/client): Topic("src=\[0x2004a3f];operation=ai-...", /list (/list), the communications console (/obj/machinery/computer/communications))
```