### PR TITLE
Disables emagging Centcom Ferry

### DIFF
--- a/code/modules/shuttle/ferry.dm
+++ b/code/modules/shuttle/ferry.dm
@@ -6,14 +6,14 @@
 	possible_destinations = "ferry_home;ferry_away"
 	req_access = list(ACCESS_CENT_GENERAL)
 
-	var/aiControlDisabled = 1
+	var/aiControlDisabled = TRUE
+	var/allow_emag = FALSE
 
-/obj/machinery/computer/shuttle/ferry/proc/canAIControl(mob/user)
-	return ((aiControlDisabled != 1));
+/obj/machinery/computer/shuttle/ferry/emag_act()
+	return allow_emag? ..() : FALSE
 
-/obj/machinery/computer/shuttle/ferry/attack_ai(mob/user)
-	if(!src.canAIControl(user))
-		return
+/obj/machinery/computer/shuttle/ferry/attack_ai()
+	return aiControlDisabled? FALSE : ..()
 
 /obj/machinery/computer/shuttle/ferry/request
 	name = "ferry console"

--- a/code/modules/shuttle/ferry.dm
+++ b/code/modules/shuttle/ferry.dm
@@ -9,8 +9,11 @@
 	var/aiControlDisabled = TRUE
 	var/allow_emag = FALSE
 
-/obj/machinery/computer/shuttle/ferry/emag_act()
-	return allow_emag? ..() : FALSE
+/obj/machinery/computer/shuttle/ferry/emag_act(mob/user)
+	if(!allow_emag)
+		to_chat(user, "<span class='warning'>[src]'s security firewall is far too powerful for you to bypass.</span>")
+		return FALSE
+	return ..()
 
 /obj/machinery/computer/shuttle/ferry/attack_ai()
 	return aiControlDisabled? FALSE : ..()


### PR DESCRIPTION
It has come to my attention that this has been [rightfully, or otherwise,] treated as an exploit of getting into Central Command.
If we're going to remove people who do it we might as well not have it.
So I'm going to pull a goofball and remove it, because I know that if I see a shiny admin object and I have an emag you bet I'd stick the emag into it for fun and being rewarded with death or removal is not fun so we shouldn't have it at all.
Plus, there's no reason for players to be on Centcom without admins knowing as of right now anyways.