### PR TITLE
Removes the Kinetic Crusher

### DIFF
--- a/code/modules/mining/machine_vending.dm
+++ b/code/modules/mining/machine_vending.dm
@@ -30,8 +30,7 @@
 		new /datum/data/mining_equipment("Survival Medipen",			/obj/item/reagent_containers/hypospray/medipen/survival,			500),
 		new /datum/data/mining_equipment("Brute First-Aid Kit",			/obj/item/storage/firstaid/brute,									600),
 		new /datum/data/mining_equipment("Tracking Implant Kit", 		/obj/item/storage/box/minertracker,									600),
-		new /datum/data/mining_equipment("Jaunter",						/obj/item/device/wormhole_jaunter,									750),
-		new /datum/data/mining_equipment("Kinetic Crusher",				/obj/item/twohanded/required/kinetic_crusher,						750),
+		new /datum/data/mining_equipment("Jaunter",						/obj/item/device/wormhole_jaunter,									750),					750),
 		new /datum/data/mining_equipment("Kinetic Accelerator",			/obj/item/gun/energy/kinetic_accelerator,							750),
 		new /datum/data/mining_equipment("Resonator",					/obj/item/resonator,												800),
 		new /datum/data/mining_equipment("Fulton Pack",					/obj/item/extraction_pack,											1000),
@@ -166,7 +165,7 @@
 	return ..()
 
 /obj/machinery/mineral/equipment_vendor/proc/RedeemVoucher(obj/item/mining_voucher/voucher, mob/redeemer)
-	var/items = list("Survival Capsule and Explorer's Webbing", "Resonator and Advanced Scanner", "Mining Drone", "Extraction and Rescue Kit", "Crusher Kit", "Mining Conscription Kit")
+	var/items = list("Survival Capsule and Explorer's Webbing", "Resonator and Advanced Scanner", "Mining Drone", "Extraction and Rescue Kit", "Mining Conscription Kit")
 
 	var/selection = input(redeemer, "Pick your equipment", "Mining Voucher Redemption") as null|anything in items
 	if(!selection || !Adjacent(redeemer) || QDELETED(voucher) || voucher.loc != redeemer)
@@ -185,10 +184,6 @@
 			new /obj/item/extraction_pack(loc)
 			new /obj/item/fulton_core(loc)
 			new /obj/item/stack/marker_beacon/thirty(loc)
-		if("Crusher Kit")
-			new /obj/item/twohanded/required/kinetic_crusher(loc)
-			new /obj/item/storage/belt/mining/alt(loc)
-			new /obj/item/extinguisher/mini(loc)
 		if("Mining Conscription Kit")
 			new /obj/item/storage/backpack/duffelbag/mining_conscript(loc)
 


### PR DESCRIPTION
Closes #35588 
Closes #35568 

As I detailed extensively in #35568, its essentially useless as-is. As I've said, I think having unused items sitting around in code is a bad idea, they should either be buffed into usefulness or removed. Since everyone is adamant that this objectively inferior item needs to be nerfed more, I figured we should go with "remove".

Maintainers, let me know if you would prefer that I make it unpurchasable, or completely remove it from the code.

🆑 
rem: Nanotrasen's stock of Proto-Kinetic Crushers has finally been depleted; they are no longer available from vendors.
/🆑 