### PR TITLE
Refactors mech construction datums

### DIFF
--- a/code/datums/helper_datums/construction_datum.dm
+++ b/code/datums/helper_datums/construction_datum.dm
@@ -1,44 +1,50 @@
-#define FORWARD -1
-#define BACKWARD 1
+#define FORWARD 1
+#define BACKWARD -1
+
+#define ITEM_DELETE "delete"
+#define ITEM_MOVE_INSIDE "move_inside"
+
 
 /datum/construction
 	var/list/steps
 	var/atom/holder
 	var/result
-	var/list/steps_desc
+	var/index = 1
 
 /datum/construction/New(atom)
 	..()
 	holder = atom
 	if(!holder) //don't want this without a holder
 		qdel(src)
-	set_desc(steps.len)
-	return
+	update_holder(index)
 
-/datum/construction/proc/next_step()
-	steps.len--
-	if(!steps.len)
+/datum/construction/proc/on_step()
+	if(index > steps.len)
 		spawn_result()
 	else
-		set_desc(steps.len)
-	return
+		update_holder(index)
 
-/datum/construction/proc/action(obj/item/I, mob/user)
-	return
+/datum/construction/proc/action(obj/item/I, mob/living/user)
+	return check_step(I, user)
 
-/datum/construction/proc/check_step(obj/item/I, mob/user) //check last step only
-	var/valid_step = is_right_key(I)
-	if(valid_step)
-		if(custom_action(valid_step, I, user))
-			next_step()
-			return 1
-	return 0
+/datum/construction/proc/update_index(diff)
+	index += diff
+	on_step()
 
-/datum/construction/proc/is_right_key(obj/item/I) // returns current step num if I is of the right type.
-	var/list/L = steps[steps.len]
+/datum/construction/proc/check_step(obj/item/I, mob/living/user)
+	var/diff = is_right_key(I)
+	if(diff && custom_action(I, user, diff))
+		update_index(diff)
+		return TRUE
+	return FALSE
+
+/datum/construction/proc/is_right_key(obj/item/I) // returns index step
+	var/list/L = steps[index]
 	if(check_used_item(I, L["key"]))
-		return steps.len
-	return 0
+		return FORWARD //to the first step -> forward
+	else if(check_used_item(I, L["back_key"]))
+		return BACKWARD //to the last step -> backwards
+	return FALSE
 
 /datum/construction/proc/check_used_item(obj/item/I, key)
 	if(!key)
@@ -52,77 +58,47 @@
 
 	return FALSE
 
-
-/datum/construction/proc/custom_action(step, obj/item/I, user)
-	return 1
-
-/datum/construction/proc/check_all_steps(obj/item/I, mob/user) //check all steps, remove matching one.
-	for(var/i=1;i<=steps.len;i++)
-		var/list/L = steps[i]
-		if(check_used_item(I, L["key"]))
-			if(custom_action(i, I, user))
-				steps[i] = null//stupid byond list from list removal...
-				listclearnulls(steps)
-				if(!steps.len)
-					spawn_result()
-				return 1
-	return 0
-
+/datum/construction/proc/custom_action(obj/item/I, mob/living/user, diff)
+	return TRUE
 
 /datum/construction/proc/spawn_result()
 	if(result)
-		new result(get_turf(holder))
+		new result(drop_location())
 		qdel(holder)
-	return
 
-/datum/construction/proc/spawn_mecha_result()
-	if(result)
-		var/obj/mecha/m = new result(get_turf(holder))
-		var/obj/item/oldcell = locate (/obj/item/stock_parts/cell) in m
-		QDEL_NULL(oldcell)
-		m.CheckParts(holder.contents)
-		SSblackbox.record_feedback("tally", "mechas_created", 1, m.name)
-		QDEL_NULL(holder)
+/datum/construction/proc/update_holder(step_index)
+	var/list/step = steps[step_index]
 
-/datum/construction/proc/set_desc(index as num)
-	var/list/step = steps[index]
-	holder.desc = step["desc"]
-	return
+	if(step["desc"])
+		holder.desc = step["desc"]
+
+	if(step["icon_state"])
+		holder.icon_state = step["icon_state"]
 
 /datum/construction/proc/drop_location()
 	return holder.drop_location()
 
-/datum/construction/reversible
-	var/index
 
-/datum/construction/reversible/New(atom)
-	..()
-	index = steps.len
-	return
 
-/datum/construction/reversible/proc/update_index(diff as num)
-	index+=diff
-	if(index==0)
-		spawn_result()
-	else
-		set_desc(index)
-	return
-
-/datum/construction/reversible/is_right_key(obj/item/I) // returns index step
-	var/list/L = steps[index]
-	if(check_used_item(I, L["key"]))
-		return FORWARD //to the first step -> forward
-	else if(check_used_item(I, L["backkey"]))
-		return BACKWARD //to the last step -> backwards
+// Unordered construction.
+// Takes a list of part types, to be added in any order, as steps.
+// Calls spawn_result() when every type has been added.
+/datum/construction/unordered/check_step(obj/item/I, mob/living/user)
+	for(var/typepath in steps)
+		if(istype(I, typepath) && custom_action(I, user, typepath))
+			steps -= typepath
+			on_step()
+			return TRUE
 	return FALSE
 
-/datum/construction/reversible/check_step(obj/item/I, mob/user)
-	var/diff = is_right_key(I)
-	if(diff)
-		if(custom_action(index, diff, I, user))
-			update_index(diff)
-			return 1
-	return 0
+/datum/construction/unordered/on_step()
+	if(!steps.len)
+		spawn_result()
+	else
+		update_holder(steps.len)
 
-/datum/construction/reversible/custom_action(index, diff, obj/item/I, user)
-	return 1
+/datum/construction/unordered/update_holder(steps_left)
+	return
+
+/datum/construction/unordered/custom_action(obj/item/I, mob/living/user, typepath)
+	return TRUE

--- a/code/game/mecha/mecha.dm
+++ b/code/game/mecha/mecha.dm
@@ -206,8 +206,7 @@
 
 /obj/mecha/CheckParts(list/parts_list)
 	..()
-	var/obj/item/C = locate(/obj/item/stock_parts/cell) in contents
-	cell = C
+	cell = locate(/obj/item/stock_parts/cell) in contents
 	var/obj/item/stock_parts/scanning_module/SM = locate() in contents
 	var/obj/item/stock_parts/capacitor/CP = locate() in contents
 	if(SM)

--- a/code/game/mecha/mecha_construction_paths.dm
+++ b/code/game/mecha/mecha_construction_paths.dm
@@ -1,1788 +1,1816 @@
 ////////////////////////////////
 ///// Construction datums //////
 ////////////////////////////////
+/datum/construction/mecha
+	var/base_icon
 
-/datum/construction/mecha/custom_action(step, obj/item/I, mob/user)
-	if(I.tool_behaviour == TOOL_WELDER)
-		if(I.use_tool(holder, user, 0))
-			playsound(holder, 'sound/items/welder2.ogg', 50, 1)
-		else
-			return FALSE
+/datum/construction/mecha/custom_action(obj/item/I, mob/living/user, diff)
+	var/target_index = index + diff
+	var/list/current_step = steps[index]
+	var/list/target_step
 
-	else if(I.tool_behaviour)
-		return I.use_tool(holder, user, 0, volume=50)
+	if(target_index > 0 && target_index <= steps.len)
+		target_step = steps[target_index]
 
-	else if(istype(I, /obj/item/stack))
-		return I.use_tool(holder, user, 0, volume=50, amount=5)
+	. = TRUE
 
-	return TRUE
+	if(I.tool_behaviour)
+		. = I.use_tool(holder, user, 0, volume=50)
 
-/datum/construction/reversible/mecha/custom_action(index as num, diff as num, obj/item/I, mob/user)
-	if(I.tool_behaviour == TOOL_WELDER)
-		if(I.use_tool(holder, user, 0))
-			playsound(holder, 'sound/items/welder2.ogg', 50, 1)
-		else
-			return FALSE
+	else if(diff == FORWARD)
+		switch(current_step["action"])
+			if(ITEM_DELETE)
+				. = user.transferItemToLoc(I, holder)
+				if(.)
+					qdel(I)
 
-	else if(I.tool_behaviour)
-		return I.use_tool(holder, user, 0, volume=50)
+			if(ITEM_MOVE_INSIDE)
+				. = user.transferItemToLoc(I, holder)
 
-	else if(istype(I, /obj/item/stack))
-		return I.use_tool(holder, user, 0, volume=50, amount=5)
-
-	return TRUE
+			else if(istype(I, /obj/item/stack))
+				. = I.use_tool(holder, user, 0, volume=50, amount=current_step["amount"])
 
 
-/datum/construction/mecha/ripley_chassis
-	steps = list(list("key"=/obj/item/mecha_parts/part/ripley_torso), //1
-					 list("key"=/obj/item/mecha_parts/part/ripley_left_arm), //2
-					 list("key"=/obj/item/mecha_parts/part/ripley_right_arm), //3
-					 list("key"=/obj/item/mecha_parts/part/ripley_left_leg), //4
-					 list("key"=/obj/item/mecha_parts/part/ripley_right_leg)//5
-					)
+	// Going backwards? Undo the last action. Drop/respawn the items used in last action, if any.
+	if(. && diff == BACKWARD && target_step && !target_step["no_refund"])
+		var/target_step_key = target_step["key"]
 
-/datum/construction/mecha/ripley_chassis/custom_action(step, atom/used_atom, mob/user)
-	user.visible_message("[user] has connected [used_atom] to the [holder].", "<span class='notice'>You connect [used_atom] to the [holder].</span>")
-	holder.add_overlay(used_atom.icon_state+"+o")
-	qdel(used_atom)
-	return TRUE
+		switch(target_step["action"])
+			if(ITEM_DELETE)
+				new target_step_key(drop_location())
 
-/datum/construction/mecha/ripley_chassis/action(atom/used_atom,mob/user)
-	return check_all_steps(used_atom,user)
+			if(ITEM_MOVE_INSIDE)
+				var/obj/item/located_item = locate(target_step_key) in holder
+				if(located_item)
+					located_item.forceMove(drop_location())
 
-/datum/construction/mecha/ripley_chassis/spawn_result()
-	var/obj/item/mecha_parts/chassis/const_holder = holder
-	const_holder.construct = new /datum/construction/reversible/mecha/ripley(const_holder)
-	const_holder.icon = 'icons/mecha/mech_construction.dmi'
-	const_holder.icon_state = "ripley0"
-	const_holder.density = TRUE
-	const_holder.cut_overlays(TRUE)
+			else if(ispath(target_step_key, /obj/item/stack))
+				new target_step_key(drop_location(), target_step["amount"])
+
+
+/datum/construction/mecha/spawn_result()
+	if(!result)
+		return
+
+	// Remove default mech power cell, as we replace it with a new one.
+	var/obj/mecha/M = new result(drop_location())
+	QDEL_NULL(M.cell)
+
+	M.CheckParts(holder.contents)
+
+	SSblackbox.record_feedback("tally", "mechas_created", 1, M.name)
+	QDEL_NULL(holder)
+
+/datum/construction/mecha/update_holder(step_index)
+	..()
+	// By default, each step in mech construction has a single icon_state:
+	// "[base_icon][index - 1]"
+	// For example, Ripley's step 1 icon_state is "ripley0".
+	if(!steps[index]["icon_state"] && base_icon)
+		holder.icon_state = "[base_icon][index - 1]"
+
+/datum/construction/unordered/mecha_chassis/custom_action(obj/item/I, mob/living/user, typepath)
+	. = user.transferItemToLoc(I, holder)
+	if(.)
+		user.visible_message("[user] has connected [I] to [holder].", "<span class='notice'>You connect [I] to [holder].</span>")
+		holder.add_overlay(I.icon_state+"+o")
+		qdel(I)
+
+/datum/construction/unordered/mecha_chassis/spawn_result()
+	holder.icon = 'icons/mecha/mech_construction.dmi'
+	holder.density = TRUE
+	holder.cut_overlays()
+
+	var/obj/item/mecha_parts/chassis/chassis = holder
+	chassis.construct = new result(holder)
 	qdel(src)
 
-/datum/construction/reversible/mecha/ripley
-	result = /obj/mecha/working/ripley
+
+
+/datum/construction/unordered/mecha_chassis/ripley
+	result = /datum/construction/mecha/ripley
 	steps = list(
-					 //0, dummy step used to stop the steps from finishing and spawn_result() being called automatically.
-					 list("desc"="You shouldn't be able to see this."),
+		/obj/item/mecha_parts/part/ripley_torso,
+		/obj/item/mecha_parts/part/ripley_left_arm,
+		/obj/item/mecha_parts/part/ripley_right_arm,
+		/obj/item/mecha_parts/part/ripley_left_leg,
+		/obj/item/mecha_parts/part/ripley_right_leg
+	)
 
-					//1
-					list("key"=/obj/item/weldingtool,
-							"backkey"=/obj/item/wrench,
-							"desc"="External armor is wrenched."),
-					//2
-					 list("key"=/obj/item/wrench,
-					 		"backkey"=/obj/item/crowbar,
-					 		"desc"="External armor is installed."),
-					 //3
-					 list("key"=/obj/item/stack/sheet/plasteel,
-					 		"backkey"=/obj/item/weldingtool,
-					 		"desc"="Internal armor is welded."),
-					 //4
-					 list("key"=/obj/item/weldingtool,
-					 		"backkey"=/obj/item/wrench,
-					 		"desc"="Internal armor is wrenched."),
-					 //5
-					 list("key"=/obj/item/wrench,
-					 		"backkey"=/obj/item/crowbar,
-					 		"desc"="Internal armor is installed."),
-					 //6
-					 list("key"=/obj/item/stack/sheet/metal,
-					 		"backkey"=/obj/item/screwdriver,
-					 		"desc"="The power cell is secured."),
-					 //7
-					 list("key"=/obj/item/screwdriver,
-					 		"backkey"=/obj/item/crowbar,
-					 		"desc"="The power cell is installed."),
-					 //8
-					 list("key"=/obj/item/stock_parts/cell,
-					 		"backkey"=/obj/item/screwdriver,
-					 		"desc"="Peripherals control module is secured."),
-					 //9
-					 list("key"=/obj/item/screwdriver,
-					 		"backkey"=/obj/item/crowbar,
-					 		"desc"="Peripherals control module is installed."),
-					 //10
-					 list("key"=/obj/item/circuitboard/mecha/ripley/peripherals,
-					 		"backkey"=/obj/item/screwdriver,
-					 		"desc"="Central control module is secured."),
-					 //11
-					 list("key"=/obj/item/screwdriver,
-					 		"backkey"=/obj/item/crowbar,
-					 		"desc"="Central control module is installed."),
-					 //12
-					 list("key"=/obj/item/circuitboard/mecha/ripley/main,
-					 		"backkey"=/obj/item/screwdriver,
-					 		"desc"="The wiring is adjusted."),
-					 //13
-					 list("key"=/obj/item/wirecutters,
-					 		"backkey"=/obj/item/screwdriver,
-					 		"desc"="The wiring is added."),
-					 //14
-					 list("key"=/obj/item/stack/cable_coil,
-					 		"backkey"=/obj/item/screwdriver,
-					 		"desc"="The hydraulic systems are active."),
-					 //15
-					 list("key"=/obj/item/screwdriver,
-					 		"backkey"=/obj/item/wrench,
-					 		"desc"="The hydraulic systems are connected."),
-					 //16
-					 list("key"=/obj/item/wrench,
-					 		"desc"="The hydraulic systems are disconnected.")
+/datum/construction/mecha/ripley
+	result = /obj/mecha/working/ripley
+	base_icon = "ripley"
+	steps = list(
+		//1
+		list(
+			"key" = TOOL_WRENCH,
+			"desc" = "The hydraulic systems are disconnected."
+		),
 
-					)
+		//2
+		list(
+			"key" = TOOL_SCREWDRIVER,
+			"back_key" = TOOL_WRENCH,
+			"desc" = "The hydraulic systems are connected."
+		),
 
-/datum/construction/reversible/mecha/ripley/action(atom/used_atom,mob/user)
-	return check_step(used_atom,user)
+		//3
+		list(
+			"key" = /obj/item/stack/cable_coil,
+			"amount" = 5,
+			"back_key" = TOOL_SCREWDRIVER,
+			"desc" = "The hydraulic systems are active."
+		),
 
-/datum/construction/reversible/mecha/ripley/custom_action(index, diff, atom/used_atom, mob/user)
+		//4
+		list(
+			"key" = TOOL_WIRECUTTER,
+			"back_key" = TOOL_SCREWDRIVER,
+			"desc" = "The wiring is added."
+		),
+
+		//5
+		list(
+			"key" = /obj/item/circuitboard/mecha/ripley/main,
+			"action" = ITEM_DELETE,
+			"back_key" = TOOL_SCREWDRIVER,
+			"desc" = "The wiring is adjusted."
+		),
+
+		//6
+		list(
+			"key" = TOOL_SCREWDRIVER,
+			"back_key" = TOOL_CROWBAR,
+			"desc" = "Central control module is installed."
+		),
+
+		//7
+		list(
+			"key" = /obj/item/circuitboard/mecha/ripley/peripherals,
+			"action" = ITEM_DELETE,
+			"back_key" = TOOL_SCREWDRIVER,
+			"desc" = "Central control module is secured."
+		),
+
+		//8
+		list(
+			"key" = TOOL_SCREWDRIVER,
+			"back_key" = TOOL_CROWBAR,
+			"desc" = "Peripherals control module is installed."
+		),
+
+		//9
+		list(
+			"key" = /obj/item/stock_parts/cell,
+			"action" = ITEM_MOVE_INSIDE,
+			"back_key" = TOOL_SCREWDRIVER,
+			"desc" = "Peripherals control module is secured."
+		),
+
+		//10
+		list(
+			"key" = TOOL_SCREWDRIVER,
+			"back_key" = TOOL_CROWBAR,
+			"desc" = "The power cell is installed."
+		),
+
+		//11
+		list(
+			"key" = /obj/item/stack/sheet/metal,
+			"amount" = 5,
+			"back_key" = TOOL_SCREWDRIVER,
+			"desc" = "The power cell is secured."
+		),
+
+		//12
+		list(
+			"key" = TOOL_WRENCH,
+			"back_key" = TOOL_CROWBAR,
+			"desc" = "Internal armor is installed."
+		),
+
+		//13
+		list(
+			"key" = TOOL_WELDER,
+			"back_key" = TOOL_WRENCH,
+			"desc" = "Internal armor is wrenched."
+		),
+
+		//14
+		list(
+			"key" = /obj/item/stack/sheet/plasteel,
+			"amount" = 5,
+			"back_key" = TOOL_WELDER,
+			"desc" = "Internal armor is welded."
+		),
+
+		//15
+		list(
+			"key" = TOOL_WRENCH,
+			"back_key" = TOOL_CROWBAR,
+			"desc" = "External armor is installed."
+		),
+
+		//16
+		list(
+			"key" = TOOL_WELDER,
+			"back_key" = TOOL_WRENCH,
+			"desc" = "External armor is wrenched."
+		),
+	)
+
+/datum/construction/mecha/ripley/custom_action(obj/item/I, mob/living/user, diff)
 	if(!..())
 		return FALSE
 
-	//TODO: better messages.
 	switch(index)
-		if(17)
-			user.visible_message("[user] connects the [holder] hydraulic systems", "<span class='notice'>You connect the [holder] hydraulic systems.</span>")
-			holder.icon_state = "ripley1"
-		if(16)
-			if(diff==FORWARD)
-				user.visible_message("[user] activates the [holder] hydraulic systems.", "<span class='notice'>You activate the [holder] hydraulic systems.</span>")
-				holder.icon_state = "ripley2"
-			else
-				user.visible_message("[user] disconnects the [holder] hydraulic systems", "<span class='notice'>You disconnect the [holder] hydraulic systems.</span>")
-				holder.icon_state = "ripley0"
-		if(15)
-			if(diff==FORWARD)
-				user.visible_message("[user] adds the wiring to the [holder].", "<span class='notice'>You add the wiring to the [holder].</span>")
-				holder.icon_state = "ripley3"
-			else
-				user.visible_message("[user] deactivates the [holder] hydraulic systems.", "<span class='notice'>You deactivate the [holder] hydraulic systems.</span>")
-				holder.icon_state = "ripley1"
-		if(14)
-			if(diff==FORWARD)
-				user.visible_message("[user] adjusts the wiring of the [holder].", "<span class='notice'>You adjust the wiring of the [holder].</span>")
-				holder.icon_state = "ripley4"
-			else
-				user.visible_message("[user] removes the wiring from the [holder].", "<span class='notice'>You remove the wiring from the [holder].</span>")
-				var/obj/item/stack/cable_coil/coil = new /obj/item/stack/cable_coil(get_turf(holder))
-				coil.amount = 4
-				holder.icon_state = "ripley2"
-		if(13)
-			if(diff==FORWARD)
-				user.visible_message("[user] installs the central control module into the [holder].", "<span class='notice'>You install the central computer mainboard into the [holder].</span>")
-				qdel(used_atom)
-				holder.icon_state = "ripley5"
-			else
-				user.visible_message("[user] disconnects the wiring of the [holder].", "<span class='notice'>You disconnect the wiring of the [holder].</span>")
-				holder.icon_state = "ripley3"
-		if(12)
-			if(diff==FORWARD)
-				user.visible_message("[user] secures the mainboard.", "<span class='notice'>You secure the mainboard.</span>")
-				holder.icon_state = "ripley6"
-			else
-				user.visible_message("[user] removes the central control module from the [holder].", "<span class='notice'>You remove the central computer mainboard from the [holder].</span>")
-				new /obj/item/circuitboard/mecha/ripley/main(get_turf(holder))
-				holder.icon_state = "ripley4"
-		if(11)
-			if(diff==FORWARD)
-				user.visible_message("[user] installs the peripherals control module into the [holder].", "<span class='notice'>You install the peripherals control module into the [holder].</span>")
-				qdel(used_atom)
-				holder.icon_state = "ripley7"
-			else
-				user.visible_message("[user] unfastens the mainboard.", "<span class='notice'>You unfasten the mainboard.</span>")
-				holder.icon_state = "ripley5"
-		if(10)
-			if(diff==FORWARD)
-				user.visible_message("[user] secures the peripherals control module.", "<span class='notice'>You secure the peripherals control module.</span>")
-				holder.icon_state = "ripley8"
-			else
-				user.visible_message("[user] removes the peripherals control module from the [holder].", "<span class='notice'>You remove the peripherals control module from the [holder].</span>")
-				new /obj/item/circuitboard/mecha/ripley/peripherals(get_turf(holder))
-				holder.icon_state = "ripley6"
-		if(9)
-			if(diff==FORWARD)
-				user.visible_message("[user] installs the power cell into the [holder].", "<span class='notice'>You install the power cell into the [holder].</span>")
-				var/obj/item/I = used_atom
-				user.transferItemToLoc(I, holder, TRUE)
-				holder.icon_state = "ripley9"
-			else
-				user.visible_message("[user] unfastens the peripherals control module.", "<span class='notice'>You unfasten the peripherals control module.</span>")
-				holder.icon_state = "ripley7"
-		if(8)
-			if(diff==FORWARD)
-				user.visible_message("[user] secures the power cell.", "<span class='notice'>You secure the power cell.</span>")
-				holder.icon_state = "ripley10"
-			else
-				user.visible_message("[user] prys the power cell from [holder].", "<span class='notice'>You pry the power cell from [holder].</span>")
-				var/obj/item/I = locate(/obj/item/stock_parts/cell) in holder
-				I.forceMove(holder.drop_location())
-				holder.icon_state = "ripley8"
-		if(7)
-			if(diff==FORWARD)
-				user.visible_message("[user] installs the internal armor layer to the [holder].", "<span class='notice'>You install the internal armor layer to the [holder].</span>")
-				holder.icon_state = "ripley11"
-			else
-				user.visible_message("[user] unfastens the power cell.", "<span class='notice'>You unfasten the power cell.</span>")
-				holder.icon_state = "ripley9"
-		if(6)
-			if(diff==FORWARD)
-				user.visible_message("[user] secures the internal armor layer.", "<span class='notice'>You secure the internal armor layer.</span>")
-				holder.icon_state = "ripley12"
-			else
-				user.visible_message("[user] pries internal armor layer from the [holder].", "<span class='notice'>You pry internal armor layer from the [holder].</span>")
-				var/obj/item/stack/sheet/metal/MS = new /obj/item/stack/sheet/metal(get_turf(holder))
-				MS.amount = 5
-				holder.icon_state = "ripley10"
-		if(5)
-			if(diff==FORWARD)
-				user.visible_message("[user] welds the internal armor layer to the [holder].", "<span class='notice'>You weld the internal armor layer to the [holder].</span>")
-				holder.icon_state = "ripley13"
-			else
-				user.visible_message("[user] unfastens the internal armor layer.", "<span class='notice'>You unfasten the internal armor layer.</span>")
-				holder.icon_state = "ripley11"
-		if(4)
-			if(diff==FORWARD)
-				user.visible_message("[user] installs the external reinforced armor layer to the [holder].", "<span class='notice'>You install the external reinforced armor layer to the [holder].</span>")
-				holder.icon_state = "ripley14"
-			else
-				user.visible_message("[user] cuts the internal armor layer from the [holder].", "<span class='notice'>You cut the internal armor layer from the [holder].</span>")
-				holder.icon_state = "ripley12"
-		if(3)
-			if(diff==FORWARD)
-				user.visible_message("[user] secures the external armor layer.", "<span class='notice'>You secure the external reinforced armor layer.</span>")
-				holder.icon_state = "ripley15"
-			else
-				user.visible_message("[user] pries external armor layer from the [holder].", "<span class='notice'>You pry external armor layer from the [holder].</span>")
-				var/obj/item/stack/sheet/plasteel/MS = new /obj/item/stack/sheet/plasteel(get_turf(holder))
-				MS.amount = 5
-				holder.icon_state = "ripley13"
+		if(1)
+			user.visible_message("[user] connects [holder] hydraulic systems", "<span class='notice'>You connect [holder] hydraulic systems.</span>")
 		if(2)
 			if(diff==FORWARD)
-				user.visible_message("[user] welds the external armor layer to the [holder].", "<span class='notice'>You weld the external armor layer to the [holder].</span>")
-				spawn_mecha_result()
+				user.visible_message("[user] activates [holder] hydraulic systems.", "<span class='notice'>You activate [holder] hydraulic systems.</span>")
+			else
+				user.visible_message("[user] disconnects [holder] hydraulic systems", "<span class='notice'>You disconnect [holder] hydraulic systems.</span>")
+		if(3)
+			if(diff==FORWARD)
+				user.visible_message("[user] adds the wiring to [holder].", "<span class='notice'>You add the wiring to [holder].</span>")
+			else
+				user.visible_message("[user] deactivates [holder] hydraulic systems.", "<span class='notice'>You deactivate [holder] hydraulic systems.</span>")
+		if(4)
+			if(diff==FORWARD)
+				user.visible_message("[user] adjusts the wiring of [holder].", "<span class='notice'>You adjust the wiring of [holder].</span>")
+			else
+				user.visible_message("[user] removes the wiring from [holder].", "<span class='notice'>You remove the wiring from [holder].</span>")
+		if(5)
+			if(diff==FORWARD)
+				user.visible_message("[user] installs the central control module into [holder].", "<span class='notice'>You install the central computer mainboard into [holder].</span>")
+			else
+				user.visible_message("[user] disconnects the wiring of [holder].", "<span class='notice'>You disconnect the wiring of [holder].</span>")
+		if(6)
+			if(diff==FORWARD)
+				user.visible_message("[user] secures the mainboard.", "<span class='notice'>You secure the mainboard.</span>")
+			else
+				user.visible_message("[user] removes the central control module from [holder].", "<span class='notice'>You remove the central computer mainboard from [holder].</span>")
+		if(7)
+			if(diff==FORWARD)
+				user.visible_message("[user] installs the peripherals control module into [holder].", "<span class='notice'>You install the peripherals control module into [holder].</span>")
+			else
+				user.visible_message("[user] unfastens the mainboard.", "<span class='notice'>You unfasten the mainboard.</span>")
+		if(8)
+			if(diff==FORWARD)
+				user.visible_message("[user] secures the peripherals control module.", "<span class='notice'>You secure the peripherals control module.</span>")
+			else
+				user.visible_message("[user] removes the peripherals control module from [holder].", "<span class='notice'>You remove the peripherals control module from [holder].</span>")
+		if(9)
+			if(diff==FORWARD)
+				user.visible_message("[user] installs the power cell into [holder].", "<span class='notice'>You install the power cell into [holder].</span>")
+			else
+				user.visible_message("[user] unfastens the peripherals control module.", "<span class='notice'>You unfasten the peripherals control module.</span>")
+		if(10)
+			if(diff==FORWARD)
+				user.visible_message("[user] secures the power cell.", "<span class='notice'>You secure the power cell.</span>")
+			else
+				user.visible_message("[user] prys the power cell from [holder].", "<span class='notice'>You pry the power cell from [holder].</span>")
+		if(11)
+			if(diff==FORWARD)
+				user.visible_message("[user] installs the internal armor layer to [holder].", "<span class='notice'>You install the internal armor layer to [holder].</span>")
+			else
+				user.visible_message("[user] unfastens the power cell.", "<span class='notice'>You unfasten the power cell.</span>")
+		if(12)
+			if(diff==FORWARD)
+				user.visible_message("[user] secures the internal armor layer.", "<span class='notice'>You secure the internal armor layer.</span>")
+			else
+				user.visible_message("[user] pries internal armor layer from [holder].", "<span class='notice'>You pry internal armor layer from [holder].</span>")
+		if(13)
+			if(diff==FORWARD)
+				user.visible_message("[user] welds the internal armor layer to [holder].", "<span class='notice'>You weld the internal armor layer to [holder].</span>")
+			else
+				user.visible_message("[user] unfastens the internal armor layer.", "<span class='notice'>You unfasten the internal armor layer.</span>")
+		if(14)
+			if(diff==FORWARD)
+				user.visible_message("[user] installs the external reinforced armor layer to [holder].", "<span class='notice'>You install the external reinforced armor layer to [holder].</span>")
+			else
+				user.visible_message("[user] cuts the internal armor layer from [holder].", "<span class='notice'>You cut the internal armor layer from [holder].</span>")
+		if(15)
+			if(diff==FORWARD)
+				user.visible_message("[user] secures the external armor layer.", "<span class='notice'>You secure the external reinforced armor layer.</span>")
+			else
+				user.visible_message("[user] pries external armor layer from [holder].", "<span class='notice'>You pry external armor layer from [holder].</span>")
+		if(16)
+			if(diff==FORWARD)
+				user.visible_message("[user] welds the external armor layer to [holder].", "<span class='notice'>You weld the external armor layer to [holder].</span>")
 			else
 				user.visible_message("[user] unfastens the external armor layer.", "<span class='notice'>You unfasten the external armor layer.</span>")
-				holder.icon_state = "ripley14"
 	return TRUE
 
-/datum/construction/mecha/gygax_chassis
-	steps = list(list("key"=/obj/item/mecha_parts/part/gygax_torso), //1
-					 list("key"=/obj/item/mecha_parts/part/gygax_left_arm), //2
-					 list("key"=/obj/item/mecha_parts/part/gygax_right_arm), //3
-					 list("key"=/obj/item/mecha_parts/part/gygax_left_leg), //4
-					 list("key"=/obj/item/mecha_parts/part/gygax_right_leg), //5
-					 list("key"=/obj/item/mecha_parts/part/gygax_head)
-					)
-
-/datum/construction/mecha/gygax_chassis/custom_action(step, atom/used_atom, mob/user)
-	user.visible_message("[user] has connected [used_atom] to the [holder].", "<span class='notice'>You connect [used_atom] to the [holder].</span>")
-	holder.add_overlay(used_atom.icon_state+"+o")
-	qdel(used_atom)
-	return TRUE
-
-/datum/construction/mecha/gygax_chassis/action(atom/used_atom,mob/user)
-	return check_all_steps(used_atom,user)
-
-/datum/construction/mecha/gygax_chassis/spawn_result()
-	var/obj/item/mecha_parts/chassis/const_holder = holder
-	const_holder.construct = new /datum/construction/reversible/mecha/gygax(const_holder)
-	const_holder.icon = 'icons/mecha/mech_construction.dmi'
-	const_holder.icon_state = "gygax0"
-	const_holder.density = TRUE
-	qdel(src)
-
-/datum/construction/reversible/mecha/gygax
-	result = /obj/mecha/combat/gygax
+/datum/construction/unordered/mecha_chassis/gygax
+	result = /datum/construction/mecha/gygax
 	steps = list(
-					//0, dummy step used to stop the steps from finishing and spawn_result() being called automatically.
-					 list("desc"="You shouldn't be able to see this."),
+		/obj/item/mecha_parts/part/gygax_torso,
+		/obj/item/mecha_parts/part/gygax_left_arm,
+		/obj/item/mecha_parts/part/gygax_right_arm,
+		/obj/item/mecha_parts/part/gygax_left_leg,
+		/obj/item/mecha_parts/part/gygax_right_leg,
+		/obj/item/mecha_parts/part/gygax_head
+	)
 
-					//1
-					list("key"=/obj/item/weldingtool,
-							"backkey"=/obj/item/wrench,
-							"desc"="External armor is wrenched."),
-					 //2
-					 list("key"=/obj/item/wrench,
-					 		"backkey"=/obj/item/crowbar,
-					 		"desc"="External armor is installed."),
-					 //3
-					 list("key"=/obj/item/mecha_parts/part/gygax_armor,
-					 		"backkey"=/obj/item/weldingtool,
-					 		"desc"="Internal armor is welded."),
-					 //4
-					 list("key"=/obj/item/weldingtool,
-					 		"backkey"=/obj/item/wrench,
-					 		"desc"="Internal armor is wrenched."),
-					 //5
-					 list("key"=/obj/item/wrench,
-					 		"backkey"=/obj/item/crowbar,
-					 		"desc"="Internal armor is installed."),
-					 //6
-					 list("key"=/obj/item/stack/sheet/metal,
-					 		"backkey"=/obj/item/screwdriver,
-					 		"desc"="The power cell is secured."),
-					 //7
-					 list("key"=/obj/item/screwdriver,
-					 		"backkey"=/obj/item/crowbar,
-					 		"desc"="The power cell is installed."),
-					 //8
-					 list("key"=/obj/item/stock_parts/cell,
-					 		"backkey"=/obj/item/screwdriver,
-					 		"desc"="Advanced capacitor is secured."),
-					 //9
-					 list("key"=/obj/item/screwdriver,
-					 		"backkey"=/obj/item/crowbar,
-					 		"desc"="Advanced capacitor is installed."),
-					 //10
-					 list("key"=/obj/item/stock_parts/capacitor,
-					 		"backkey"=/obj/item/screwdriver,
-					 		"desc"="Advanced scanner module is secured."),
-					 //11
-					 list("key"=/obj/item/screwdriver,
-					 		"backkey"=/obj/item/crowbar,
-					 		"desc"="Advanced scanner module is installed."),
-					 //12
-					 list("key"=/obj/item/stock_parts/scanning_module,
-					 		"backkey"=/obj/item/screwdriver,
-					 		"desc"="Weapon control module is secured."),
-					 //13
-					 list("key"=/obj/item/screwdriver,
-					 		"backkey"=/obj/item/crowbar,
-					 		"desc"="Weapon control module is installed."),
-					 //14
-					 list("key"=/obj/item/circuitboard/mecha/gygax/targeting,
-					 		"backkey"=/obj/item/screwdriver,
-					 		"desc"="Peripherals control module is secured."),
-					 //15
-					 list("key"=/obj/item/screwdriver,
-					 		"backkey"=/obj/item/crowbar,
-					 		"desc"="Peripherals control module is installed."),
-					 //16
-					 list("key"=/obj/item/circuitboard/mecha/gygax/peripherals,
-					 		"backkey"=/obj/item/screwdriver,
-					 		"desc"="Central control module is secured."),
-					 //17
-					 list("key"=/obj/item/screwdriver,
-					 		"backkey"=/obj/item/crowbar,
-					 		"desc"="Central control module is installed."),
-					 //18
-					 list("key"=/obj/item/circuitboard/mecha/gygax/main,
-					 		"backkey"=/obj/item/screwdriver,
-					 		"desc"="The wiring is adjusted."),
-					 //19
-					 list("key"=/obj/item/wirecutters,
-					 		"backkey"=/obj/item/screwdriver,
-					 		"desc"="The wiring is added."),
-					 //20
-					 list("key"=/obj/item/stack/cable_coil,
-					 		"backkey"=/obj/item/screwdriver,
-					 		"desc"="The hydraulic systems are active."),
-					 //21
-					 list("key"=/obj/item/screwdriver,
-					 		"backkey"=/obj/item/wrench,
-					 		"desc"="The hydraulic systems are connected."),
-					 //22
-					 list("key"=/obj/item/wrench,
-					 		"desc"="The hydraulic systems are disconnected.")
-					)
+/datum/construction/mecha/gygax
+	result = /obj/mecha/combat/gygax
+	base_icon = "gygax"
+	steps = list(
+		//1
+		list(
+			"key" = TOOL_WRENCH,
+			"desc" = "The hydraulic systems are disconnected."
+		),
 
-/datum/construction/reversible/mecha/gygax/action(atom/used_atom,mob/user)
+		//2
+		list(
+			"key" = TOOL_SCREWDRIVER,
+			"back_key" = TOOL_WRENCH,
+			"desc" = "The hydraulic systems are connected."
+		),
+
+		//3
+		list(
+			"key" = /obj/item/stack/cable_coil,
+			"amount" = 5,
+			"back_key" = TOOL_SCREWDRIVER,
+			"desc" = "The hydraulic systems are active."
+		),
+
+		//4
+		list(
+			"key" = TOOL_WIRECUTTER,
+			"back_key" = TOOL_SCREWDRIVER,
+			"desc" = "The wiring is added."
+		),
+
+		//5
+		list(
+			"key" = /obj/item/circuitboard/mecha/gygax/main,
+			"action" = ITEM_DELETE,
+			"back_key" = TOOL_SCREWDRIVER,
+			"desc" = "The wiring is adjusted."
+		),
+
+		//6
+		list(
+			"key" = TOOL_SCREWDRIVER,
+			"back_key" = TOOL_CROWBAR,
+			"desc" = "Central control module is installed."
+		),
+
+		//7
+		list(
+			"key" = /obj/item/circuitboard/mecha/gygax/peripherals,
+			"action" = ITEM_DELETE,
+			"back_key" = TOOL_SCREWDRIVER,
+			"desc" = "Central control module is secured."
+		),
+
+		//8
+		list(
+			"key" = TOOL_SCREWDRIVER,
+			"back_key" = TOOL_CROWBAR,
+			"desc" = "Peripherals control module is installed."
+		),
+
+		//9
+		list(
+			"key" = /obj/item/circuitboard/mecha/gygax/targeting,
+			"action" = ITEM_DELETE,
+			"back_key" = TOOL_SCREWDRIVER,
+			"desc" = "Peripherals control module is secured."
+		),
+
+		//10
+		list(
+			"key" = TOOL_SCREWDRIVER,
+			"back_key" = TOOL_CROWBAR,
+			"desc" = "Weapon control module is installed."
+		),
+
+		//11
+		list(
+			"key" = /obj/item/stock_parts/scanning_module,
+			"action" = ITEM_MOVE_INSIDE,
+			"back_key" = TOOL_SCREWDRIVER,
+			"desc" = "Weapon control module is secured."
+		),
+
+		//12
+		list(
+			"key" = TOOL_SCREWDRIVER,
+			"back_key" = TOOL_CROWBAR,
+			"desc" = "Advanced scanner module is installed."
+		),
+
+		//13
+		list(
+			"key" = /obj/item/stock_parts/capacitor,
+			"back_key" = TOOL_SCREWDRIVER,
+			"desc" = "Advanced scanner module is secured."
+		),
+
+		//14
+		list(
+			"key" = TOOL_SCREWDRIVER,
+			"back_key" = TOOL_CROWBAR,
+			"desc" = "Advanced capacitor is installed."
+		),
+
+		//15
+		list(
+			"key" = /obj/item/stock_parts/cell,
+			"action" = ITEM_MOVE_INSIDE,
+			"back_key" = TOOL_SCREWDRIVER,
+			"desc" = "Advanced capacitor is secured."
+		),
+
+		//16
+		list(
+			"key" = TOOL_SCREWDRIVER,
+			"back_key" = TOOL_CROWBAR,
+			"desc" = "The power cell is installed."
+		),
+
+		//17
+		list(
+			"key" = /obj/item/stack/sheet/metal,
+			"amount" = 5,
+			"back_key" = TOOL_SCREWDRIVER,
+			"desc" = "The power cell is secured."
+		),
+
+		//18
+		list(
+			"key" = TOOL_WRENCH,
+			"back_key" = TOOL_CROWBAR,
+			"desc" = "Internal armor is installed."
+		),
+
+		//19
+		list(
+			"key" = TOOL_WELDER,
+			"back_key" = TOOL_WRENCH,
+			"desc" = "Internal armor is wrenched."
+		),
+
+		//20
+		list(
+			"key" = /obj/item/mecha_parts/part/gygax_armor,
+			"action" = ITEM_DELETE,
+			"back_key" = TOOL_WELDER,
+			"desc" = "Internal armor is welded."
+		),
+
+		//21
+		list(
+			"key" = TOOL_WRENCH,
+			"back_key" = TOOL_CROWBAR,
+			"desc" = "External armor is installed."
+		),
+
+		//22
+		list(
+			"key" = TOOL_WELDER,
+			"back_key" = TOOL_WRENCH,
+			"desc" = "External armor is wrenched."
+		),
+
+	)
+
+/datum/construction/mecha/gygax/action(atom/used_atom,mob/user)
 	return check_step(used_atom,user)
 
-/datum/construction/reversible/mecha/gygax/custom_action(index, diff, atom/used_atom, mob/user)
+/datum/construction/mecha/gygax/custom_action(obj/item/I, mob/living/user, diff)
 	if(!..())
 		return FALSE
 
-	//TODO: better messages.
 	switch(index)
-		if(23)
-			user.visible_message("[user] connects the [holder] hydraulic systems", "<span class='notice'>You connect the [holder] hydraulic systems.</span>")
-			holder.icon_state = "gygax1"
-		if(22)
+		if(1)
+			user.visible_message("[user] connects [holder] hydraulic systems", "<span class='notice'>You connect [holder] hydraulic systems.</span>")
+		if(2)
 			if(diff==FORWARD)
-				user.visible_message("[user] activates the [holder] hydraulic systems.", "<span class='notice'>You activate the [holder] hydraulic systems.</span>")
-				holder.icon_state = "gygax2"
+				user.visible_message("[user] activates [holder] hydraulic systems.", "<span class='notice'>You activate [holder] hydraulic systems.</span>")
 			else
-				user.visible_message("[user] disconnects the [holder] hydraulic systems", "<span class='notice'>You disconnect the [holder] hydraulic systems.</span>")
-				holder.icon_state = "gygax0"
-		if(21)
+				user.visible_message("[user] disconnects [holder] hydraulic systems", "<span class='notice'>You disconnect [holder] hydraulic systems.</span>")
+		if(3)
 			if(diff==FORWARD)
-				user.visible_message("[user] adds the wiring to the [holder].", "<span class='notice'>You add the wiring to the [holder].</span>")
-				holder.icon_state = "gygax3"
+				user.visible_message("[user] adds the wiring to [holder].", "<span class='notice'>You add the wiring to [holder].</span>")
 			else
-				user.visible_message("[user] deactivates the [holder] hydraulic systems.", "<span class='notice'>You deactivate the [holder] hydraulic systems.</span>")
-				holder.icon_state = "gygax1"
-		if(20)
+				user.visible_message("[user] deactivates [holder] hydraulic systems.", "<span class='notice'>You deactivate [holder] hydraulic systems.</span>")
+		if(4)
 			if(diff==FORWARD)
-				user.visible_message("[user] adjusts the wiring of the [holder].", "<span class='notice'>You adjust the wiring of the [holder].</span>")
-				holder.icon_state = "gygax4"
+				user.visible_message("[user] adjusts the wiring of [holder].", "<span class='notice'>You adjust the wiring of [holder].</span>")
 			else
-				user.visible_message("[user] removes the wiring from the [holder].", "<span class='notice'>You remove the wiring from the [holder].</span>")
-				var/obj/item/stack/cable_coil/coil = new /obj/item/stack/cable_coil(get_turf(holder))
-				coil.amount = 4
-				holder.icon_state = "gygax2"
-		if(19)
+				user.visible_message("[user] removes the wiring from [holder].", "<span class='notice'>You remove the wiring from [holder].</span>")
+		if(5)
 			if(diff==FORWARD)
-				user.visible_message("[user] installs the central control module into the [holder].", "<span class='notice'>You install the central computer mainboard into the [holder].</span>")
-				qdel(used_atom)
-				holder.icon_state = "gygax5"
+				user.visible_message("[user] installs the central control module into [holder].", "<span class='notice'>You install the central computer mainboard into [holder].</span>")
 			else
-				user.visible_message("[user] disconnects the wiring of the [holder].", "<span class='notice'>You disconnect the wiring of the [holder].</span>")
-				holder.icon_state = "gygax3"
-		if(18)
+				user.visible_message("[user] disconnects the wiring of [holder].", "<span class='notice'>You disconnect the wiring of [holder].</span>")
+		if(6)
 			if(diff==FORWARD)
 				user.visible_message("[user] secures the mainboard.", "<span class='notice'>You secure the mainboard.</span>")
-				holder.icon_state = "gygax6"
 			else
-				user.visible_message("[user] removes the central control module from the [holder].", "<span class='notice'>You remove the central computer mainboard from the [holder].</span>")
-				new /obj/item/circuitboard/mecha/gygax/main(get_turf(holder))
-				holder.icon_state = "gygax4"
-		if(17)
+				user.visible_message("[user] removes the central control module from [holder].", "<span class='notice'>You remove the central computer mainboard from [holder].</span>")
+		if(7)
 			if(diff==FORWARD)
-				user.visible_message("[user] installs the peripherals control module into the [holder].", "<span class='notice'>You install the peripherals control module into the [holder].</span>")
-				qdel(used_atom)
-				holder.icon_state = "gygax7"
+				user.visible_message("[user] installs the peripherals control module into [holder].", "<span class='notice'>You install the peripherals control module into [holder].</span>")
 			else
 				user.visible_message("[user] unfastens the mainboard.", "<span class='notice'>You unfasten the mainboard.</span>")
-				holder.icon_state = "gygax5"
-		if(16)
+		if(8)
 			if(diff==FORWARD)
 				user.visible_message("[user] secures the peripherals control module.", "<span class='notice'>You secure the peripherals control module.</span>")
-				holder.icon_state = "gygax8"
 			else
-				user.visible_message("[user] removes the peripherals control module from the [holder].", "<span class='notice'>You remove the peripherals control module from the [holder].</span>")
-				new /obj/item/circuitboard/mecha/gygax/peripherals(get_turf(holder))
-				holder.icon_state = "gygax6"
-		if(15)
+				user.visible_message("[user] removes the peripherals control module from [holder].", "<span class='notice'>You remove the peripherals control module from [holder].</span>")
+		if(9)
 			if(diff==FORWARD)
-				user.visible_message("[user] installs the weapon control module into the [holder].", "<span class='notice'>You install the weapon control module into the [holder].</span>")
-				qdel(used_atom)
-				holder.icon_state = "gygax9"
+				user.visible_message("[user] installs the weapon control module into [holder].", "<span class='notice'>You install the weapon control module into [holder].</span>")
 			else
 				user.visible_message("[user] unfastens the peripherals control module.", "<span class='notice'>You unfasten the peripherals control module.</span>")
-				holder.icon_state = "gygax7"
-		if(14)
+		if(10)
 			if(diff==FORWARD)
 				user.visible_message("[user] secures the weapon control module.", "<span class='notice'>You secure the weapon control module.</span>")
-				holder.icon_state = "gygax10"
 			else
-				user.visible_message("[user] removes the weapon control module from the [holder].", "<span class='notice'>You remove the weapon control module from the [holder].</span>")
-				new /obj/item/circuitboard/mecha/gygax/targeting(get_turf(holder))
-				holder.icon_state = "gygax8"
-		if(13)
+				user.visible_message("[user] removes the weapon control module from [holder].", "<span class='notice'>You remove the weapon control module from [holder].</span>")
+		if(11)
 			if(diff==FORWARD)
-				user.visible_message("[user] installs scanner module to the [holder].", "<span class='notice'>You install scanner module to the [holder].</span>")
-				var/obj/item/I = used_atom
-				user.transferItemToLoc(I, holder, TRUE)
-				holder.icon_state = "gygax11"
+				user.visible_message("[user] installs scanner module to [holder].", "<span class='notice'>You install scanner module to [holder].</span>")
 			else
 				user.visible_message("[user] unfastens the weapon control module.", "<span class='notice'>You unfasten the weapon control module.</span>")
-				holder.icon_state = "gygax9"
 		if(12)
 			if(diff==FORWARD)
 				user.visible_message("[user] secures the advanced scanner module.", "<span class='notice'>You secure the scanner module.</span>")
-				holder.icon_state = "gygax12"
 			else
-				user.visible_message("[user] removes the advanced scanner module from the [holder].", "<span class='notice'>You remove the scanner module from the [holder].</span>")
-				var/obj/item/I = locate(/obj/item/stock_parts/scanning_module) in holder
-				I.forceMove(get_turf(holder))
-				holder.icon_state = "gygax10"
-		if(11)
+				user.visible_message("[user] removes the advanced scanner module from [holder].", "<span class='notice'>You remove the scanner module from [holder].</span>")
+		if(13)
 			if(diff==FORWARD)
-				user.visible_message("[user] installs capacitor to the [holder].", "<span class='notice'>You install capacitor to the [holder].</span>")
-				var/obj/item/I = used_atom
-				user.transferItemToLoc(I, holder, TRUE)
-				holder.icon_state = "gygax13"
+				user.visible_message("[user] installs capacitor to [holder].", "<span class='notice'>You install capacitor to [holder].</span>")
 			else
 				user.visible_message("[user] unfastens the  scanner module.", "<span class='notice'>You unfasten the scanner module.</span>")
-				holder.icon_state = "gygax11"
-		if(10)
+		if(14)
 			if(diff==FORWARD)
-				user.visible_message("[user] secures the  capacitor.", "<span class='notice'>You secure the capacitor.</span>")
-				holder.icon_state = "gygax14"
+				user.visible_message("[user] secures the capacitor.", "<span class='notice'>You secure the capacitor.</span>")
 			else
-				user.visible_message("[user] removes the  capacitor from the [holder].", "<span class='notice'>You remove the capacitor from the [holder].</span>")
-				var/obj/item/I = locate(/obj/item/stock_parts/capacitor) in holder
-				I.forceMove(holder.drop_location())
-				holder.icon_state = "gygax12"
-		if(9)
+				user.visible_message("[user] removes the capacitor from [holder].", "<span class='notice'>You remove the capacitor from [holder].</span>")
+		if(15)
 			if(diff==FORWARD)
-				user.visible_message("[user] installs the power cell into the [holder].", "<span class='notice'>You install the power cell into the [holder].</span>")
-				var/obj/item/I = used_atom
-				user.transferItemToLoc(I, holder, TRUE)
-				holder.icon_state = "gygax15"
+				user.visible_message("[user] installs the power cell into [holder].", "<span class='notice'>You install the power cell into [holder].</span>")
 			else
 				user.visible_message("[user] unfastens the capacitor.", "<span class='notice'>You unfasten the capacitor.</span>")
-				holder.icon_state = "gygax13"
-		if(8)
+		if(16)
 			if(diff==FORWARD)
 				user.visible_message("[user] secures the power cell.", "<span class='notice'>You secure the power cell.</span>")
-				holder.icon_state = "gygax16"
 			else
 				user.visible_message("[user] prys the power cell from [holder].", "<span class='notice'>You pry the power cell from [holder].</span>")
-				var/obj/item/I = locate(/obj/item/stock_parts/cell) in holder
-				I.forceMove(holder.drop_location())
-				holder.icon_state = "gygax14"
-		if(7)
+		if(17)
 			if(diff==FORWARD)
-				user.visible_message("[user] installs the internal armor layer to the [holder].", "<span class='notice'>You install the internal armor layer to the [holder].</span>")
-				holder.icon_state = "gygax17"
+				user.visible_message("[user] installs the internal armor layer to [holder].", "<span class='notice'>You install the internal armor layer to [holder].</span>")
 			else
 				user.visible_message("[user] unfastens the power cell.", "<span class='notice'>You unfasten the power cell.</span>")
-				holder.icon_state = "gygax15"
-		if(6)
+		if(18)
 			if(diff==FORWARD)
 				user.visible_message("[user] secures the internal armor layer.", "<span class='notice'>You secure the internal armor layer.</span>")
-				holder.icon_state = "gygax18"
 			else
-				user.visible_message("[user] pries internal armor layer from the [holder].", "<span class='notice'>You pry internal armor layer from the [holder].</span>")
-				var/obj/item/stack/sheet/metal/MS = new /obj/item/stack/sheet/metal(get_turf(holder))
-				MS.amount = 5
-				holder.icon_state = "gygax16"
-		if(5)
+				user.visible_message("[user] pries internal armor layer from [holder].", "<span class='notice'>You pry internal armor layer from [holder].</span>")
+		if(19)
 			if(diff==FORWARD)
-				user.visible_message("[user] welds the internal armor layer to the [holder].", "<span class='notice'>You weld the internal armor layer to the [holder].</span>")
-				holder.icon_state = "gygax19"
+				user.visible_message("[user] welds the internal armor layer to [holder].", "<span class='notice'>You weld the internal armor layer to [holder].</span>")
 			else
 				user.visible_message("[user] unfastens the internal armor layer.", "<span class='notice'>You unfasten the internal armor layer.</span>")
-				holder.icon_state = "gygax17"
-		if(4)
+		if(20)
 			if(diff==FORWARD)
-				user.visible_message("[user] installs Gygax Armor Plates to the [holder].", "<span class='notice'>You install Gygax Armor Plates to the [holder].</span>")
-				qdel(used_atom)
-				holder.icon_state = "gygax20"
+				user.visible_message("[user] installs Gygax Armor Plates to [holder].", "<span class='notice'>You install Gygax Armor Plates to [holder].</span>")
 			else
-				user.visible_message("[user] cuts the internal armor layer from the [holder].", "<span class='notice'>You cut the internal armor layer from the [holder].</span>")
-				holder.icon_state = "gygax18"
-		if(3)
+				user.visible_message("[user] cuts the internal armor layer from [holder].", "<span class='notice'>You cut the internal armor layer from [holder].</span>")
+		if(21)
 			if(diff==FORWARD)
 				user.visible_message("[user] secures Gygax Armor Plates.", "<span class='notice'>You secure Gygax Armor Plates.</span>")
-				holder.icon_state = "gygax21"
 			else
-				user.visible_message("[user] pries Gygax Armor Plates from the [holder].", "<span class='notice'>You pry Gygax Armor Plates from the [holder].</span>")
-				new /obj/item/mecha_parts/part/gygax_armor(get_turf(holder))
-				holder.icon_state = "gygax19"
-		if(2)
+				user.visible_message("[user] pries Gygax Armor Plates from [holder].", "<span class='notice'>You pry Gygax Armor Plates from [holder].</span>")
+		if(22)
 			if(diff==FORWARD)
-				user.visible_message("[user] welds Gygax Armor Plates to the [holder].", "<span class='notice'>You weld Gygax Armor Plates to the [holder].</span>")
-				spawn_mecha_result()
+				user.visible_message("[user] welds Gygax Armor Plates to [holder].", "<span class='notice'>You weld Gygax Armor Plates to [holder].</span>")
 			else
 				user.visible_message("[user] unfastens Gygax Armor Plates.", "<span class='notice'>You unfasten Gygax Armor Plates.</span>")
-				holder.icon_state = "gygax20"
 	return TRUE
 
-/datum/construction/mecha/firefighter_chassis
-	steps = list(list("key"=/obj/item/mecha_parts/part/ripley_torso), //1
-					 list("key"=/obj/item/mecha_parts/part/ripley_left_arm), //2
-					 list("key"=/obj/item/mecha_parts/part/ripley_right_arm), //3
-					 list("key"=/obj/item/mecha_parts/part/ripley_left_leg), //4
-					 list("key"=/obj/item/mecha_parts/part/ripley_right_leg), //5
-					 list("key"=/obj/item/clothing/suit/fire)//6
-					)
-
-/datum/construction/mecha/firefighter_chassis/custom_action(step, atom/used_atom, mob/user)
-	user.visible_message("[user] has connected [used_atom] to the [holder].", "<span class='notice'>You connect [used_atom] to the [holder].</span>")
-	holder.add_overlay(used_atom.icon_state+"+o")
-	qdel(used_atom)
-	return TRUE
-
-/datum/construction/mecha/firefighter_chassis/action(atom/used_atom,mob/user)
-	return check_all_steps(used_atom,user)
-
-/datum/construction/mecha/firefighter_chassis/spawn_result()
-	var/obj/item/mecha_parts/chassis/const_holder = holder
-	const_holder.construct = new /datum/construction/reversible/mecha/firefighter(const_holder)
-	const_holder.icon = 'icons/mecha/mech_construction.dmi'
-	const_holder.icon_state = "fireripley0"
-	const_holder.density = TRUE
-	qdel(src)
-
-
-/datum/construction/reversible/mecha/firefighter
-	result = /obj/mecha/working/ripley/firefighter
+/datum/construction/unordered/mecha_chassis/firefighter
+	result = /datum/construction/mecha/firefighter
 	steps = list(
-					 //0, dummy step used to stop the steps from finishing and spawn_result() being called automatically.
-					 list("desc"="You shouldn't be able to see this."),
+		/obj/item/mecha_parts/part/ripley_torso,
+		/obj/item/mecha_parts/part/ripley_left_arm,
+		/obj/item/mecha_parts/part/ripley_right_arm,
+		/obj/item/mecha_parts/part/ripley_left_leg,
+		/obj/item/mecha_parts/part/ripley_right_leg,
+		/obj/item/clothing/suit/fire
+	)
 
-					 //1
-					 list("key"=/obj/item/weldingtool,
-							"backkey"=/obj/item/wrench,
-							"desc"="External armor is wrenched."),
-					 //2
-					 list("key"=/obj/item/wrench,
-					 		"backkey"=/obj/item/crowbar,
-					 		"desc"="External armor is installed."),
-					 //3
-					 list("key"=/obj/item/stack/sheet/plasteel,
-					 		"backkey"=/obj/item/crowbar,
-					 		"desc"="External armor is being installed."),
-					 //4
-					 list("key"=/obj/item/stack/sheet/plasteel,
-					 		"backkey"=/obj/item/weldingtool,
-					 		"desc"="Internal armor is welded."),
-					 //5
-					 list("key"=/obj/item/weldingtool,
-					 		"backkey"=/obj/item/wrench,
-					 		"desc"="Internal armor is wrenched."),
-					 //6
-					 list("key"=/obj/item/wrench,
-					 		"backkey"=/obj/item/crowbar,
-					 		"desc"="Internal armor is installed."),
-					 //7
-					 list("key"=/obj/item/stack/sheet/plasteel,
-					 		"backkey"=/obj/item/screwdriver,
-					 		"desc"="The power cell is secured."),
-					 //8
-					 list("key"=/obj/item/screwdriver,
-					 		"backkey"=/obj/item/crowbar,
-					 		"desc"="The power cell is installed."),
-					 //9
-					 list("key"=/obj/item/stock_parts/cell,
-					 		"backkey"=/obj/item/screwdriver,
-					 		"desc"="Peripherals control module is secured."),
-					 //10
-					 list("key"=/obj/item/screwdriver,
-					 		"backkey"=/obj/item/crowbar,
-					 		"desc"="Peripherals control module is installed."),
-					 //11
-					 list("key"=/obj/item/circuitboard/mecha/ripley/peripherals,
-					 		"backkey"=/obj/item/screwdriver,
-					 		"desc"="Central control module is secured."),
-					 //12
-					 list("key"=/obj/item/screwdriver,
-					 		"backkey"=/obj/item/crowbar,
-					 		"desc"="Central control module is installed."),
-					 //13
-					 list("key"=/obj/item/circuitboard/mecha/ripley/main,
-					 		"backkey"=/obj/item/screwdriver,
-					 		"desc"="The wiring is adjusted."),
-					 //14
-					 list("key"=/obj/item/wirecutters,
-					 		"backkey"=/obj/item/screwdriver,
-					 		"desc"="The wiring is added."),
-					 //15
-					 list("key"=/obj/item/stack/cable_coil,
-					 		"backkey"=/obj/item/screwdriver,
-					 		"desc"="The hydraulic systems are active."),
-					 //16
-					 list("key"=/obj/item/screwdriver,
-					 		"backkey"=/obj/item/wrench,
-					 		"desc"="The hydraulic systems are connected."),
-					 //17
-					 list("key"=/obj/item/wrench,
-					 		"desc"="The hydraulic systems are disconnected.")
-					)
+/datum/construction/mecha/firefighter
+	result = /obj/mecha/working/ripley/firefighter
+	base_icon = "fireripley"
+	steps = list(
+		//1
+		list(
+			"key" = TOOL_WRENCH,
+			"desc" = "The hydraulic systems are disconnected."
+		),
 
-/datum/construction/reversible/mecha/firefighter/action(atom/used_atom,mob/user)
-	return check_step(used_atom,user)
+		//2
+		list(
+			"key" = TOOL_SCREWDRIVER,
+			"back_key" = TOOL_WRENCH,
+			"desc" = "The hydraulic systems are connected."
+		),
 
-/datum/construction/reversible/mecha/firefighter/custom_action(index, diff, atom/used_atom, mob/user)
+		//3
+		list(
+			"key" = /obj/item/stack/cable_coil,
+			"amount" = 5,
+			"back_key" = TOOL_SCREWDRIVER,
+			"desc" = "The hydraulic systems are active."
+		),
+
+		//4
+		list(
+			"key" = TOOL_WIRECUTTER,
+			"back_key" = TOOL_SCREWDRIVER,
+			"desc" = "The wiring is added."
+		),
+
+		//5
+		list(
+			"key" = /obj/item/circuitboard/mecha/ripley/main,
+			"action" = ITEM_DELETE,
+			"back_key" = TOOL_SCREWDRIVER,
+			"desc" = "The wiring is adjusted."
+		),
+
+		//6
+		list(
+			"key" = TOOL_SCREWDRIVER,
+			"back_key" = TOOL_CROWBAR,
+			"desc" = "Central control module is installed."
+		),
+
+		//7
+		list(
+			"key" = /obj/item/circuitboard/mecha/ripley/peripherals,
+			"action" = ITEM_DELETE,
+			"back_key" = TOOL_SCREWDRIVER,
+			"desc" = "Central control module is secured."
+		),
+
+		//8
+		list(
+			"key" = TOOL_SCREWDRIVER,
+			"back_key" = TOOL_CROWBAR,
+			"desc" = "Peripherals control module is installed."
+		),
+
+		//9
+		list(
+			"key" = /obj/item/stock_parts/cell,
+			"action" = ITEM_MOVE_INSIDE,
+			"back_key" = TOOL_SCREWDRIVER,
+			"desc" = "Peripherals control module is secured."
+		),
+
+		//10
+		list(
+			"key" = TOOL_SCREWDRIVER,
+			"back_key" = TOOL_CROWBAR,
+			"desc" = "The power cell is installed."
+		),
+
+		//11
+		list(
+			"key" = /obj/item/stack/sheet/plasteel,
+			"amount" = 5,
+			"back_key" = TOOL_SCREWDRIVER,
+			"desc" = "The power cell is secured."
+		),
+
+		//12
+		list(
+			"key" = TOOL_WRENCH,
+			"back_key" = TOOL_CROWBAR,
+			"desc" = "Internal armor is installed."
+		),
+
+		//13
+		list(
+			"key" = TOOL_WELDER,
+			"back_key" = TOOL_WRENCH,
+			"desc" = "Internal armor is wrenched."
+		),
+
+		//14
+		list(
+			"key" = /obj/item/stack/sheet/plasteel,
+			"amount" = 5,
+			"back_key" = TOOL_WELDER,
+			"desc" = "Internal armor is welded."
+		),
+
+		//15
+		list(
+			"key" = /obj/item/stack/sheet/plasteel,
+			"amount" = 5,
+			"back_key" = TOOL_CROWBAR,
+			"desc" = "External armor is being installed."
+		),
+
+		//16
+		list(
+			"key" = TOOL_WRENCH,
+			"back_key" = TOOL_CROWBAR,
+			"desc" = "External armor is installed."
+		),
+
+		//17
+		list(
+			"key" = TOOL_WELDER,
+			"back_key" = TOOL_WRENCH,
+			"desc" = "External armor is wrenched."
+		),
+	)
+
+/datum/construction/mecha/firefighter/custom_action(obj/item/I, mob/living/user, diff)
 	if(!..())
 		return FALSE
 
 	//TODO: better messages.
 	switch(index)
-		if(18)
-			user.visible_message("[user] connects the [holder] hydraulic systems", "<span class='notice'>You connect the [holder] hydraulic systems.</span>")
-			holder.icon_state = "fireripley1"
-		if(17)
-			if(diff==FORWARD)
-				user.visible_message("[user] activates the [holder] hydraulic systems.", "<span class='notice'>You activate the [holder] hydraulic systems.</span>")
-				holder.icon_state = "fireripley2"
-			else
-				user.visible_message("[user] disconnects the [holder] hydraulic systems", "<span class='notice'>You disconnect the [holder] hydraulic systems.</span>")
-				holder.icon_state = "fireripley0"
-		if(16)
-			if(diff==FORWARD)
-				user.visible_message("[user] adds the wiring to the [holder].", "<span class='notice'>You add the wiring to the [holder].</span>")
-				holder.icon_state = "fireripley3"
-			else
-				user.visible_message("[user] deactivates the [holder] hydraulic systems.", "<span class='notice'>You deactivate the [holder] hydraulic systems.</span>")
-				holder.icon_state = "fireripley1"
-		if(15)
-			if(diff==FORWARD)
-				user.visible_message("[user] adjusts the wiring of the [holder].", "<span class='notice'>You adjust the wiring of the [holder].</span>")
-				holder.icon_state = "fireripley4"
-			else
-				user.visible_message("[user] removes the wiring from the [holder].", "<span class='notice'>You remove the wiring from the [holder].</span>")
-				var/obj/item/stack/cable_coil/coil = new /obj/item/stack/cable_coil(get_turf(holder))
-				coil.amount = 4
-				holder.icon_state = "fireripley2"
-		if(14)
-			if(diff==FORWARD)
-				user.visible_message("[user] installs the central control module into the [holder].", "<span class='notice'>You install the central computer mainboard into the [holder].</span>")
-				qdel(used_atom)
-				holder.icon_state = "fireripley5"
-			else
-				user.visible_message("[user] disconnects the wiring of the [holder].", "<span class='notice'>You disconnect the wiring of the [holder].</span>")
-				holder.icon_state = "fireripley3"
-		if(13)
-			if(diff==FORWARD)
-				user.visible_message("[user] secures the mainboard.", "<span class='notice'>You secure the mainboard.</span>")
-				holder.icon_state = "fireripley6"
-			else
-				user.visible_message("[user] removes the central control module from the [holder].", "<span class='notice'>You remove the central computer mainboard from the [holder].</span>")
-				new /obj/item/circuitboard/mecha/ripley/main(get_turf(holder))
-				holder.icon_state = "fireripley4"
-		if(12)
-			if(diff==FORWARD)
-				user.visible_message("[user] installs the peripherals control module into the [holder].", "<span class='notice'>You install the peripherals control module into the [holder].</span>")
-				qdel(used_atom)
-				holder.icon_state = "fireripley7"
-			else
-				user.visible_message("[user] unfastens the mainboard.", "<span class='notice'>You unfasten the mainboard.</span>")
-				holder.icon_state = "fireripley5"
-		if(11)
-			if(diff==FORWARD)
-				user.visible_message("[user] secures the peripherals control module.", "<span class='notice'>You secure the peripherals control module.</span>")
-				holder.icon_state = "fireripley8"
-			else
-				user.visible_message("[user] removes the peripherals control module from the [holder].", "<span class='notice'>You remove the peripherals control module from the [holder].</span>")
-				new /obj/item/circuitboard/mecha/ripley/peripherals(get_turf(holder))
-				holder.icon_state = "fireripley6"
-		if(10)
-			if(diff==FORWARD)
-				user.visible_message("[user] installs the power cell into the [holder].", "<span class='notice'>You install the power cell into the [holder].</span>")
-				var/obj/item/I = used_atom
-				user.transferItemToLoc(I, holder, TRUE)
-				holder.icon_state = "fireripley9"
-			else
-				user.visible_message("[user] unfastens the peripherals control module.", "<span class='notice'>You unfasten the peripherals control module.</span>")
-				holder.icon_state = "fireripley7"
-		if(9)
-			if(diff==FORWARD)
-				user.visible_message("[user] secures the power cell.", "<span class='notice'>You secure the power cell.</span>")
-				holder.icon_state = "fireripley10"
-			else
-				user.visible_message("[user] prys the power cell from [holder].", "<span class='notice'>You pry the power cell from [holder].</span>")
-				var/obj/item/I = locate(/obj/item/stock_parts/cell) in holder
-				I.forceMove(holder.drop_location())
-				holder.icon_state = "fireripley8"
-		if(8)
-			if(diff==FORWARD)
-				user.visible_message("[user] installs the internal armor layer to the [holder].", "<span class='notice'>You install the internal armor layer to the [holder].</span>")
-				holder.icon_state = "fireripley11"
-			else
-				user.visible_message("[user] unfastens the power cell.", "<span class='notice'>You unfasten the power cell.</span>")
-				holder.icon_state = "fireripley9"
-		if(7)
-			if(diff==FORWARD)
-				user.visible_message("[user] secures the internal armor layer.", "<span class='notice'>You secure the internal armor layer.</span>")
-				holder.icon_state = "fireripley12"
-			else
-				user.visible_message("[user] pries internal armor layer from the [holder].", "<span class='notice'>You pry internal armor layer from the [holder].</span>")
-				var/obj/item/stack/sheet/plasteel/MS = new /obj/item/stack/sheet/plasteel(get_turf(holder))
-				MS.amount = 5
-				holder.icon_state = "fireripley10"
-		if(6)
-			if(diff==FORWARD)
-				user.visible_message("[user] welds the internal armor layer to the [holder].", "<span class='notice'>You weld the internal armor layer to the [holder].</span>")
-				holder.icon_state = "fireripley13"
-			else
-				user.visible_message("[user] unfastens the internal armor layer.", "<span class='notice'>You unfasten the internal armor layer.</span>")
-				holder.icon_state = "fireripley11"
-		if(5)
-			if(diff==FORWARD)
-				user.visible_message("[user] starts to install the external armor layer to the [holder].", "<span class='notice'>You install the external armor layer to the [holder].</span>")
-				holder.icon_state = "fireripley14"
-			else
-				user.visible_message("[user] cuts the internal armor layer from the [holder].", "<span class='notice'>You cut the internal armor layer from the [holder].</span>")
-				holder.icon_state = "fireripley12"
-		if(4)
-			if(diff==FORWARD)
-				user.visible_message("[user] installs the external reinforced armor layer to the [holder].", "<span class='notice'>You install the external reinforced armor layer to the [holder].</span>")
-				holder.icon_state = "fireripley15"
-			else
-				user.visible_message("[user] removes the external armor from the [holder].", "<span class='notice'>You remove the external armor from the [holder].</span>")
-				var/obj/item/stack/sheet/plasteel/MS = new /obj/item/stack/sheet/plasteel(get_turf(holder))
-				MS.amount = 5
-				holder.icon_state = "fireripley13"
-		if(3)
-			if(diff==FORWARD)
-				user.visible_message("[user] secures the external armor layer.", "<span class='notice'>You secure the external reinforced armor layer.</span>")
-				holder.icon_state = "fireripley16"
-			else
-				user.visible_message("[user] pries external armor layer from the [holder].", "<span class='notice'>You pry external armor layer from the [holder].</span>")
-				var/obj/item/stack/sheet/plasteel/MS = new /obj/item/stack/sheet/plasteel(get_turf(holder))
-				MS.amount = 5
-				holder.icon_state = "fireripley14"
+		if(1)
+			user.visible_message("[user] connects [holder] hydraulic systems", "<span class='notice'>You connect [holder] hydraulic systems.</span>")
 		if(2)
 			if(diff==FORWARD)
-				user.visible_message("[user] welds the external armor layer to the [holder].", "<span class='notice'>You weld the external armor layer to the [holder].</span>")
-				spawn_mecha_result()
+				user.visible_message("[user] activates [holder] hydraulic systems.", "<span class='notice'>You activate [holder] hydraulic systems.</span>")
+			else
+				user.visible_message("[user] disconnects [holder] hydraulic systems", "<span class='notice'>You disconnect [holder] hydraulic systems.</span>")
+		if(3)
+			if(diff==FORWARD)
+				user.visible_message("[user] adds the wiring to [holder].", "<span class='notice'>You add the wiring to [holder].</span>")
+			else
+				user.visible_message("[user] deactivates [holder] hydraulic systems.", "<span class='notice'>You deactivate [holder] hydraulic systems.</span>")
+		if(4)
+			if(diff==FORWARD)
+				user.visible_message("[user] adjusts the wiring of [holder].", "<span class='notice'>You adjust the wiring of [holder].</span>")
+			else
+				user.visible_message("[user] removes the wiring from [holder].", "<span class='notice'>You remove the wiring from [holder].</span>")
+		if(5)
+			if(diff==FORWARD)
+				user.visible_message("[user] installs the central control module into [holder].", "<span class='notice'>You install the central computer mainboard into [holder].</span>")
+			else
+				user.visible_message("[user] disconnects the wiring of [holder].", "<span class='notice'>You disconnect the wiring of [holder].</span>")
+		if(6)
+			if(diff==FORWARD)
+				user.visible_message("[user] secures the mainboard.", "<span class='notice'>You secure the mainboard.</span>")
+			else
+				user.visible_message("[user] removes the central control module from [holder].", "<span class='notice'>You remove the central computer mainboard from [holder].</span>")
+		if(7)
+			if(diff==FORWARD)
+				user.visible_message("[user] installs the peripherals control module into [holder].", "<span class='notice'>You install the peripherals control module into [holder].</span>")
+			else
+				user.visible_message("[user] unfastens the mainboard.", "<span class='notice'>You unfasten the mainboard.</span>")
+		if(8)
+			if(diff==FORWARD)
+				user.visible_message("[user] secures the peripherals control module.", "<span class='notice'>You secure the peripherals control module.</span>")
+			else
+				user.visible_message("[user] removes the peripherals control module from [holder].", "<span class='notice'>You remove the peripherals control module from [holder].</span>")
+		if(9)
+			if(diff==FORWARD)
+				user.visible_message("[user] installs the power cell into [holder].", "<span class='notice'>You install the power cell into [holder].</span>")
+			else
+				user.visible_message("[user] unfastens the peripherals control module.", "<span class='notice'>You unfasten the peripherals control module.</span>")
+		if(10)
+			if(diff==FORWARD)
+				user.visible_message("[user] secures the power cell.", "<span class='notice'>You secure the power cell.</span>")
+			else
+				user.visible_message("[user] prys the power cell from [holder].", "<span class='notice'>You pry the power cell from [holder].</span>")
+		if(11)
+			if(diff==FORWARD)
+				user.visible_message("[user] installs the internal armor layer to [holder].", "<span class='notice'>You install the internal armor layer to [holder].</span>")
+			else
+				user.visible_message("[user] unfastens the power cell.", "<span class='notice'>You unfasten the power cell.</span>")
+		if(12)
+			if(diff==FORWARD)
+				user.visible_message("[user] secures the internal armor layer.", "<span class='notice'>You secure the internal armor layer.</span>")
+			else
+				user.visible_message("[user] pries internal armor layer from [holder].", "<span class='notice'>You pry internal armor layer from [holder].</span>")
+		if(13)
+			if(diff==FORWARD)
+				user.visible_message("[user] welds the internal armor layer to [holder].", "<span class='notice'>You weld the internal armor layer to [holder].</span>")
+			else
+				user.visible_message("[user] unfastens the internal armor layer.", "<span class='notice'>You unfasten the internal armor layer.</span>")
+		if(14)
+			if(diff==FORWARD)
+				user.visible_message("[user] starts to install the external armor layer to [holder].", "<span class='notice'>You install the external armor layer to [holder].</span>")
+			else
+				user.visible_message("[user] cuts the internal armor layer from [holder].", "<span class='notice'>You cut the internal armor layer from [holder].</span>")
+		if(15)
+			if(diff==FORWARD)
+				user.visible_message("[user] installs the external reinforced armor layer to [holder].", "<span class='notice'>You install the external reinforced armor layer to [holder].</span>")
+			else
+				user.visible_message("[user] removes the external armor from [holder].", "<span class='notice'>You remove the external armor from [holder].</span>")
+		if(16)
+			if(diff==FORWARD)
+				user.visible_message("[user] secures the external armor layer.", "<span class='notice'>You secure the external reinforced armor layer.</span>")
+			else
+				user.visible_message("[user] pries external armor layer from [holder].", "<span class='notice'>You pry external armor layer from [holder].</span>")
+		if(17)
+			if(diff==FORWARD)
+				user.visible_message("[user] welds the external armor layer to [holder].", "<span class='notice'>You weld the external armor layer to [holder].</span>")
 			else
 				user.visible_message("[user] unfastens the external armor layer.", "<span class='notice'>You unfasten the external armor layer.</span>")
-				holder.icon_state = "fireripley15"
 	return TRUE
 
-/datum/construction/mecha/honker_chassis
-	steps = list(list("key"=/obj/item/mecha_parts/part/honker_torso), //1
-					 list("key"=/obj/item/mecha_parts/part/honker_left_arm), //2
-					 list("key"=/obj/item/mecha_parts/part/honker_right_arm), //3
-					 list("key"=/obj/item/mecha_parts/part/honker_left_leg), //4
-					 list("key"=/obj/item/mecha_parts/part/honker_right_leg), //5
-					 list("key"=/obj/item/mecha_parts/part/honker_head)
-					)
-
-/datum/construction/mecha/honker_chassis/action(atom/used_atom,mob/user)
-	return check_all_steps(used_atom,user)
-
-/datum/construction/mecha/honker_chassis/custom_action(step, atom/used_atom, mob/user)
-	user.visible_message("[user] has connected [used_atom] to the [holder].", "<span class='notice'>You connect [used_atom] to the [holder].</span>")
-	holder.add_overlay(used_atom.icon_state+"+o")
-	qdel(used_atom)
-	return TRUE
-
-/datum/construction/mecha/honker_chassis/spawn_result()
-	var/obj/item/mecha_parts/chassis/const_holder = holder
-	const_holder.construct = new /datum/construction/mecha/honker(const_holder)
-	const_holder.density = TRUE
-	qdel(src)
+/datum/construction/unordered/mecha_chassis/honker
+	result = /datum/construction/mecha/honker
+	steps = list(
+		/obj/item/mecha_parts/part/honker_torso,
+		/obj/item/mecha_parts/part/honker_left_arm,
+		/obj/item/mecha_parts/part/honker_right_arm,
+		/obj/item/mecha_parts/part/honker_left_leg,
+		/obj/item/mecha_parts/part/honker_right_leg,
+		/obj/item/mecha_parts/part/honker_head
+	)
 
 /datum/construction/mecha/honker
 	result = /obj/mecha/combat/honker
 	steps = list(
-					 list("desc"="You shouldn't be able to see this."), //0, note steps in the construction path are +1 to the ones here
-					 list("key"=/obj/item/bikehorn), //1
-					 list("key"=/obj/item/clothing/shoes/clown_shoes), //2
-					 list("key"=/obj/item/bikehorn), //3
-					 list("key"=/obj/item/clothing/mask/gas/clown_hat), //4
-					 list("key"=/obj/item/bikehorn), //5
-					 list("key"=/obj/item/stock_parts/cell), //6
-					 list("key"=/obj/item/bikehorn), //7
-					 list("key"=/obj/item/circuitboard/mecha/honker/targeting), //8
-					 list("key"=/obj/item/bikehorn), //9
-					 list("key"=/obj/item/circuitboard/mecha/honker/peripherals), //10
-					 list("key"=/obj/item/bikehorn), //11
-					 list("key"=/obj/item/circuitboard/mecha/honker/main), //12
-					 list("key"=/obj/item/bikehorn), //13
-				)
+		//1
+		list(
+			"key" = /obj/item/bikehorn
+		),
 
-/datum/construction/mecha/honker/action(atom/used_atom,mob/user)
-	return check_step(used_atom,user)
+		//2
+		list(
+			"key" = /obj/item/circuitboard/mecha/honker/main,
+			"action" = ITEM_DELETE
+		),
 
-/datum/construction/mecha/honker/custom_action(step, atom/used_atom, mob/user)
+		//3
+		list(
+			"key" = /obj/item/bikehorn
+		),
+
+		//4
+		list(
+			"key" = /obj/item/circuitboard/mecha/honker/peripherals,
+			"action" = ITEM_DELETE
+		),
+
+		//5
+		list(
+			"key" = /obj/item/bikehorn
+		),
+
+		//6
+		list(
+			"key" = /obj/item/circuitboard/mecha/honker/targeting,
+			"action" = ITEM_DELETE
+		),
+
+		//7
+		list(
+			"key" = /obj/item/bikehorn
+		),
+
+		//8
+		list(
+			"key" = /obj/item/stock_parts/cell,
+			"action" = ITEM_MOVE_INSIDE
+		),
+
+		//9
+		list(
+			"key" = /obj/item/bikehorn
+		),
+
+		//10
+		list(
+			"key" = /obj/item/clothing/mask/gas/clown_hat,
+			"action" = ITEM_DELETE
+		),
+
+		//11
+		list(
+			"key" = /obj/item/bikehorn
+		),
+
+		//12
+		list(
+			"key" = /obj/item/clothing/shoes/clown_shoes,
+			"action" = ITEM_DELETE
+		),
+
+		//13
+		list(
+			"key" = /obj/item/bikehorn
+		),
+	)
+
+// HONK doesn't have any construction step icons, so we just set an icon once.
+/datum/construction/mecha/honker/update_holder(step_index)
+	if(step_index == 1)
+		holder.icon = 'icons/mecha/mech_construct.dmi'
+		holder.icon_state = "honker_chassis"
+	..()
+
+/datum/construction/mecha/honker/custom_action(obj/item/I, mob/living/user, diff)
 	if(!..())
 		return FALSE
 
-	if(istype(used_atom, /obj/item/bikehorn))
+	if(istype(I, /obj/item/bikehorn))
 		playsound(holder, 'sound/items/bikehorn.ogg', 50, 1)
 		user.visible_message("HONK!")
-		if(step==2)
-			spawn_mecha_result()
-
 
 	//TODO: better messages.
-	switch(step)
-		if(13)
-			user.visible_message("[user] installs the central control module into the [holder].", "<span class='notice'>You install the central control module into the [holder].</span>")
-			qdel(used_atom)
-		if(11)
-			user.visible_message("[user] installs the peripherals control module into the [holder].", "<span class='notice'>You install the peripherals control module into the [holder].</span>")
-			qdel(used_atom)
-		if(9)
-			user.visible_message("[user] installs the weapon control module into the [holder].", "<span class='notice'>You install the weapon control module into the [holder].</span>")
-			qdel(used_atom)
-		if(7)
-			user.visible_message("[user] installs the power cell into the [holder].", "<span class='notice'>You install the power cell into the [holder].</span>")
-			var/obj/item/I = used_atom
-			user.transferItemToLoc(I, holder, TRUE)
-		if(5)
-			user.visible_message("[user] puts clown wig and mask on the [holder].", "<span class='notice'>You put clown wig and mask on the [holder].</span>")
-			qdel(used_atom)
-		if(3)
-			user.visible_message("[user] puts clown boots on the [holder].", "<span class='notice'>You put clown boots on the [holder].</span>")
-			qdel(used_atom)
+	switch(index)
+		if(2)
+			user.visible_message("[user] installs the central control module into [holder].", "<span class='notice'>You install the central control module into [holder].</span>")
+		if(4)
+			user.visible_message("[user] installs the peripherals control module into [holder].", "<span class='notice'>You install the peripherals control module into [holder].</span>")
+		if(6)
+			user.visible_message("[user] installs the weapon control module into [holder].", "<span class='notice'>You install the weapon control module into [holder].</span>")
+		if(8)
+			user.visible_message("[user] installs the power cell into [holder].", "<span class='notice'>You install the power cell into [holder].</span>")
+		if(10)
+			user.visible_message("[user] puts clown wig and mask on [holder].", "<span class='notice'>You put clown wig and mask on [holder].</span>")
+		if(12)
+			user.visible_message("[user] puts clown boots on [holder].", "<span class='notice'>You put clown boots on [holder].</span>")
 	return TRUE
 
-/datum/construction/mecha/durand_chassis
-	steps = list(list("key"=/obj/item/mecha_parts/part/durand_torso), //1
-					 list("key"=/obj/item/mecha_parts/part/durand_left_arm), //2
-					 list("key"=/obj/item/mecha_parts/part/durand_right_arm), //3
-					 list("key"=/obj/item/mecha_parts/part/durand_left_leg), //4
-					 list("key"=/obj/item/mecha_parts/part/durand_right_leg), //5
-					 list("key"=/obj/item/mecha_parts/part/durand_head)
-					)
-
-/datum/construction/mecha/durand_chassis/custom_action(step, atom/used_atom, mob/user)
-	user.visible_message("[user] has connected [used_atom] to the [holder].", "You connect [used_atom] to the [holder]")
-	holder.add_overlay(used_atom.icon_state+"+o")
-	qdel(used_atom)
-	return TRUE
-
-/datum/construction/mecha/durand_chassis/action(atom/used_atom,mob/user)
-	return check_all_steps(used_atom,user)
-
-/datum/construction/mecha/durand_chassis/spawn_result()
-	var/obj/item/mecha_parts/chassis/const_holder = holder
-	const_holder.construct = new /datum/construction/reversible/mecha/durand(const_holder)
-	const_holder.icon = 'icons/mecha/mech_construction.dmi'
-	const_holder.icon_state = "durand0"
-	const_holder.density = TRUE
-	qdel(src)
-
-/datum/construction/reversible/mecha/durand
-	result = /obj/mecha/combat/durand
+/datum/construction/unordered/mecha_chassis/durand
+	result = /datum/construction/mecha/durand
 	steps = list(
-					 //0, dummy step used to stop the steps from finishing and spawn_result() being called automatically.
-					 list("desc"="You shouldn't be able to see this."),
+		/obj/item/mecha_parts/part/durand_torso,
+		/obj/item/mecha_parts/part/durand_left_arm,
+		/obj/item/mecha_parts/part/durand_right_arm,
+		/obj/item/mecha_parts/part/durand_left_leg,
+		/obj/item/mecha_parts/part/durand_right_leg,
+		/obj/item/mecha_parts/part/durand_head
+	)
 
-					 //1
-					 list("key"=/obj/item/weldingtool,
-							"backkey"=/obj/item/wrench,
-							"desc"="External armor is wrenched."),
-					 //2
-					 list("key"=/obj/item/wrench,
-					 		"backkey"=/obj/item/crowbar,
-					 		"desc"="External armor is installed."),
-					 //3
-					 list("key"=/obj/item/mecha_parts/part/durand_armor,
-					 		"backkey"=/obj/item/weldingtool,
-					 		"desc"="Internal armor is welded."),
-					 //4
-					 list("key"=/obj/item/weldingtool,
-					 		"backkey"=/obj/item/wrench,
-					 		"desc"="Internal armor is wrenched."),
-					 //5
-					 list("key"=/obj/item/wrench,
-					 		"backkey"=/obj/item/crowbar,
-					 		"desc"="Internal armor is installed."),
-					 //6
-					 list("key"=/obj/item/stack/sheet/metal,
-					 		"backkey"=/obj/item/screwdriver,
-					 		"desc"="The power cell is secured."),
-					 //7
-					 list("key"=/obj/item/screwdriver,
-					 		"backkey"=/obj/item/crowbar,
-					 		"desc"="The power cell is installed."),
-					 //8
-					 list("key"=/obj/item/stock_parts/cell,
-					 		"backkey"=/obj/item/screwdriver,
-					 		"desc"="Super capacitor is secured."),
-					 //9
-					 list("key"=/obj/item/screwdriver,
-					 		"backkey"=/obj/item/crowbar,
-					 		"desc"="Super capacitor is installed."),
-					 //10
-					 list("key"=/obj/item/stock_parts/capacitor,
-					 		"backkey"=/obj/item/screwdriver,
-					 		"desc"="Phasic scanner module is secured."),
-					 //11
-					 list("key"=/obj/item/screwdriver,
-					 		"backkey"=/obj/item/crowbar,
-					 		"desc"="Phasic scanner module is installed."),
-					 //12
-					 list("key"=/obj/item/stock_parts/scanning_module,
-					 		"backkey"=/obj/item/screwdriver,
-					 		"desc"="Weapon control module is secured."),
-					 //13
-					 list("key"=/obj/item/screwdriver,
-					 		"backkey"=/obj/item/crowbar,
-					 		"desc"="Weapon control module is installed."),
-					 //14
-					 list("key"=/obj/item/circuitboard/mecha/durand/targeting,
-					 		"backkey"=/obj/item/screwdriver,
-					 		"desc"="Peripherals control module is secured."),
-					 //15
-					 list("key"=/obj/item/screwdriver,
-					 		"backkey"=/obj/item/crowbar,
-					 		"desc"="Peripherals control module is installed."),
-					 //16
-					 list("key"=/obj/item/circuitboard/mecha/durand/peripherals,
-					 		"backkey"=/obj/item/screwdriver,
-					 		"desc"="Central control module is secured."),
-					 //17
-					 list("key"=/obj/item/screwdriver,
-					 		"backkey"=/obj/item/crowbar,
-					 		"desc"="Central control module is installed."),
-					 //18
-					 list("key"=/obj/item/circuitboard/mecha/durand/main,
-					 		"backkey"=/obj/item/screwdriver,
-					 		"desc"="The wiring is adjusted."),
-					 //19
-					 list("key"=/obj/item/wirecutters,
-					 		"backkey"=/obj/item/screwdriver,
-					 		"desc"="The wiring is added."),
-					 //20
-					 list("key"=/obj/item/stack/cable_coil,
-					 		"backkey"=/obj/item/screwdriver,
-					 		"desc"="The hydraulic systems are active."),
-					 //21
-					 list("key"=/obj/item/screwdriver,
-					 		"backkey"=/obj/item/wrench,
-					 		"desc"="The hydraulic systems are connected."),
-					 //22
-					 list("key"=/obj/item/wrench,
-					 		"desc"="The hydraulic systems are disconnected.")
-					)
+/datum/construction/mecha/durand
+	result = /obj/mecha/combat/durand
+	base_icon = "durand"
+	steps = list(
+		//1
+		list(
+			"key" = TOOL_WRENCH,
+			"desc" = "The hydraulic systems are disconnected."
+		),
+
+		//2
+		list(
+			"key" = TOOL_SCREWDRIVER,
+			"back_key" = TOOL_WRENCH,
+			"desc" = "The hydraulic systems are connected."
+		),
+
+		//3
+		list(
+			"key" = /obj/item/stack/cable_coil,
+			"amount" = 5,
+			"back_key" = TOOL_SCREWDRIVER,
+			"desc" = "The hydraulic systems are active."
+		),
+
+		//4
+		list(
+			"key" = TOOL_WIRECUTTER,
+			"back_key" = TOOL_SCREWDRIVER,
+			"desc" = "The wiring is added."
+		),
+
+		//5
+		list(
+			"key" = /obj/item/circuitboard/mecha/durand/main,
+			"action" = ITEM_DELETE,
+			"back_key" = TOOL_SCREWDRIVER,
+			"desc" = "The wiring is adjusted."
+		),
+
+		//6
+		list(
+			"key" = TOOL_SCREWDRIVER,
+			"back_key" = TOOL_CROWBAR,
+			"desc" = "Central control module is installed."
+		),
+
+		//7
+		list(
+			"key" = /obj/item/circuitboard/mecha/durand/peripherals,
+			"action" = ITEM_DELETE,
+			"back_key" = TOOL_SCREWDRIVER,
+			"desc" = "Central control module is secured."
+		),
+
+		//8
+		list(
+			"key" = TOOL_SCREWDRIVER,
+			"back_key" = TOOL_CROWBAR,
+			"desc" = "Peripherals control module is installed."
+		),
+
+		//9
+		list(
+			"key" = /obj/item/circuitboard/mecha/durand/targeting,
+			"action" = ITEM_DELETE,
+			"back_key" = TOOL_SCREWDRIVER,
+			"desc" = "Peripherals control module is secured."
+		),
+
+		//10
+		list(
+			"key" = TOOL_SCREWDRIVER,
+			"back_key" = TOOL_CROWBAR,
+			"desc" = "Weapon control module is installed."
+		),
+
+		//11
+		list(
+			"key" = /obj/item/stock_parts/scanning_module,
+			"action" = ITEM_MOVE_INSIDE,
+			"back_key" = TOOL_SCREWDRIVER,
+			"desc" = "Weapon control module is secured."
+		),
+
+		//12
+		list(
+			"key" = TOOL_SCREWDRIVER,
+			"back_key" = TOOL_CROWBAR,
+			"desc" = "Phasic scanner module is installed."
+		),
+
+		//13
+		list(
+			"key" = /obj/item/stock_parts/capacitor,
+			"action" = ITEM_MOVE_INSIDE,
+			"back_key" = TOOL_SCREWDRIVER,
+			"desc" = "Phasic scanner module is secured."
+		),
+
+		//14
+		list(
+			"key" = TOOL_SCREWDRIVER,
+			"back_key" = TOOL_CROWBAR,
+			"desc" = "Super capacitor is installed."
+		),
+
+		//15
+		list(
+			"key" = /obj/item/stock_parts/cell,
+			"action" = ITEM_MOVE_INSIDE,
+			"back_key" = TOOL_SCREWDRIVER,
+			"desc" = "Super capacitor is secured."
+		),
+
+		//16
+		list(
+			"key" = TOOL_SCREWDRIVER,
+			"back_key" = TOOL_CROWBAR,
+			"desc" = "The power cell is installed."
+		),
+
+		//17
+		list(
+			"key" = /obj/item/stack/sheet/metal,
+			"amount" = 5,
+			"back_key" = TOOL_SCREWDRIVER,
+			"desc" = "The power cell is secured."
+		),
+
+		//18
+		list(
+			"key" = TOOL_WRENCH,
+			"back_key" = TOOL_CROWBAR,
+			"desc" = "Internal armor is installed."
+		),
+
+		//19
+		list(
+			"key" = TOOL_WELDER,
+			"back_key" = TOOL_WRENCH,
+			"desc" = "Internal armor is wrenched."
+		),
+
+		//20
+		list(
+			"key" = /obj/item/mecha_parts/part/durand_armor,
+			"action" = ITEM_DELETE,
+			"back_key" = TOOL_WELDER,
+			"desc" = "Internal armor is welded."
+		),
+
+		//21
+		list(
+			"key" = TOOL_WRENCH,
+			"back_key" = TOOL_CROWBAR,
+			"desc" = "External armor is installed."
+		),
+
+		//22
+		list(
+			"key" = TOOL_WELDER,
+			"back_key" = TOOL_WRENCH,
+			"desc" = "External armor is wrenched."
+		),
+	)
 
 
-/datum/construction/reversible/mecha/durand/action(atom/used_atom,mob/user)
-	return check_step(used_atom,user)
-
-/datum/construction/reversible/mecha/durand/custom_action(index, diff, atom/used_atom, mob/user)
+/datum/construction/mecha/durand/custom_action(obj/item/I, mob/living/user, diff)
 	if(!..())
 		return FALSE
 
 	//TODO: better messages.
 	switch(index)
-		if(23)
-			user.visible_message("[user] connects the [holder] hydraulic systems", "<span class='notice'>You connect the [holder] hydraulic systems.</span>")
-			holder.icon_state = "durand1"
-		if(22)
+		if(1)
+			user.visible_message("[user] connects [holder] hydraulic systems", "<span class='notice'>You connect [holder] hydraulic systems.</span>")
+		if(2)
 			if(diff==FORWARD)
-				user.visible_message("[user] activates the [holder] hydraulic systems.", "<span class='notice'>You activate the [holder] hydraulic systems.</span>")
-				holder.icon_state = "durand2"
+				user.visible_message("[user] activates [holder] hydraulic systems.", "<span class='notice'>You activate [holder] hydraulic systems.</span>")
 			else
-				user.visible_message("[user] disconnects the [holder] hydraulic systems", "<span class='notice'>You disconnect the [holder] hydraulic systems.</span>")
-				holder.icon_state = "durand0"
-		if(21)
+				user.visible_message("[user] disconnects [holder] hydraulic systems", "<span class='notice'>You disconnect [holder] hydraulic systems.</span>")
+		if(3)
 			if(diff==FORWARD)
-				user.visible_message("[user] adds the wiring to the [holder].", "<span class='notice'>You add the wiring to the [holder].</span>")
-				holder.icon_state = "durand3"
+				user.visible_message("[user] adds the wiring to [holder].", "<span class='notice'>You add the wiring to [holder].</span>")
 			else
-				user.visible_message("[user] deactivates the [holder] hydraulic systems.", "<span class='notice'>You deactivate the [holder] hydraulic systems.</span>")
-				holder.icon_state = "durand1"
-		if(20)
+				user.visible_message("[user] deactivates [holder] hydraulic systems.", "<span class='notice'>You deactivate [holder] hydraulic systems.</span>")
+		if(4)
 			if(diff==FORWARD)
-				user.visible_message("[user] adjusts the wiring of the [holder].", "<span class='notice'>You adjust the wiring of the [holder].</span>")
-				holder.icon_state = "durand4"
+				user.visible_message("[user] adjusts the wiring of [holder].", "<span class='notice'>You adjust the wiring of [holder].</span>")
 			else
-				user.visible_message("[user] removes the wiring from the [holder].", "<span class='notice'>You remove the wiring from the [holder].</span>")
-				var/obj/item/stack/cable_coil/coil = new /obj/item/stack/cable_coil(get_turf(holder))
-				coil.amount = 4
-				holder.icon_state = "durand2"
-		if(19)
+				user.visible_message("[user] removes the wiring from [holder].", "<span class='notice'>You remove the wiring from [holder].</span>")
+		if(5)
 			if(diff==FORWARD)
-				user.visible_message("[user] installs the central control module into the [holder].", "<span class='notice'>You install the central computer mainboard into the [holder].</span>")
-				qdel(used_atom)
-				holder.icon_state = "durand5"
+				user.visible_message("[user] installs the central control module into [holder].", "<span class='notice'>You install the central computer mainboard into [holder].</span>")
 			else
-				user.visible_message("[user] disconnects the wiring of the [holder].", "<span class='notice'>You disconnect the wiring of the [holder].</span>")
-				holder.icon_state = "durand3"
-		if(18)
+				user.visible_message("[user] disconnects the wiring of [holder].", "<span class='notice'>You disconnect the wiring of [holder].</span>")
+		if(6)
 			if(diff==FORWARD)
 				user.visible_message("[user] secures the mainboard.", "<span class='notice'>You secure the mainboard.</span>")
-				holder.icon_state = "durand6"
 			else
-				user.visible_message("[user] removes the central control module from the [holder].", "<span class='notice'>You remove the central computer mainboard from the [holder].</span>")
-				new /obj/item/circuitboard/mecha/durand/main(get_turf(holder))
-				holder.icon_state = "durand4"
-		if(17)
+				user.visible_message("[user] removes the central control module from [holder].", "<span class='notice'>You remove the central computer mainboard from [holder].</span>")
+		if(7)
 			if(diff==FORWARD)
-				user.visible_message("[user] installs the peripherals control module into the [holder].", "<span class='notice'>You install the peripherals control module into the [holder].</span>")
-				qdel(used_atom)
-				holder.icon_state = "durand7"
+				user.visible_message("[user] installs the peripherals control module into [holder].", "<span class='notice'>You install the peripherals control module into [holder].</span>")
 			else
 				user.visible_message("[user] unfastens the mainboard.", "<span class='notice'>You unfasten the mainboard.</span>")
-				holder.icon_state = "durand5"
-		if(16)
+		if(8)
 			if(diff==FORWARD)
 				user.visible_message("[user] secures the peripherals control module.", "<span class='notice'>You secure the peripherals control module.</span>")
-				holder.icon_state = "durand8"
 			else
-				user.visible_message("[user] removes the peripherals control module from the [holder].", "<span class='notice'>You remove the peripherals control module from the [holder].</span>")
-				new /obj/item/circuitboard/mecha/durand/peripherals(get_turf(holder))
-				holder.icon_state = "durand6"
-		if(15)
+				user.visible_message("[user] removes the peripherals control module from [holder].", "<span class='notice'>You remove the peripherals control module from [holder].</span>")
+		if(9)
 			if(diff==FORWARD)
-				user.visible_message("[user] installs the weapon control module into the [holder].", "<span class='notice'>You install the weapon control module into the [holder].</span>")
-				qdel(used_atom)
-				holder.icon_state = "durand9"
+				user.visible_message("[user] installs the weapon control module into [holder].", "<span class='notice'>You install the weapon control module into [holder].</span>")
 			else
 				user.visible_message("[user] unfastens the peripherals control module.", "<span class='notice'>You unfasten the peripherals control module.</span>")
-				holder.icon_state = "durand7"
-		if(14)
+		if(10)
 			if(diff==FORWARD)
 				user.visible_message("[user] secures the weapon control module.", "<span class='notice'>You secure the weapon control module.</span>")
-				holder.icon_state = "durand10"
 			else
-				user.visible_message("[user] removes the weapon control module from the [holder].", "<span class='notice'>You remove the weapon control module from the [holder].</span>")
-				new /obj/item/circuitboard/mecha/durand/targeting(get_turf(holder))
-				holder.icon_state = "durand8"
-		if(13)
+				user.visible_message("[user] removes the weapon control module from [holder].", "<span class='notice'>You remove the weapon control module from [holder].</span>")
+		if(11)
 			if(diff==FORWARD)
-				user.visible_message("[user] installs scanner module to the [holder].", "<span class='notice'>You install phasic scanner module to the [holder].</span>")
-				var/obj/item/I = used_atom
-				user.transferItemToLoc(I, holder, TRUE)
-				holder.icon_state = "durand11"
+				user.visible_message("[user] installs scanner module to [holder].", "<span class='notice'>You install phasic scanner module to [holder].</span>")
 			else
 				user.visible_message("[user] unfastens the weapon control module.", "<span class='notice'>You unfasten the weapon control module.</span>")
-				holder.icon_state = "durand9"
 		if(12)
 			if(diff==FORWARD)
 				user.visible_message("[user] secures the scanner module.", "<span class='notice'>You secure the scanner module.</span>")
-				holder.icon_state = "durand12"
 			else
-				user.visible_message("[user] removes the scanner module from the [holder].", "<span class='notice'>You remove the scanner module from the [holder].</span>")
-				var/obj/item/I = locate(/obj/item/stock_parts/scanning_module) in holder
-				I.forceMove(holder.drop_location())
-				holder.icon_state = "durand10"
-		if(11)
+				user.visible_message("[user] removes the scanner module from [holder].", "<span class='notice'>You remove the scanner module from [holder].</span>")
+		if(13)
 			if(diff==FORWARD)
-				user.visible_message("[user] installs capacitor to the [holder].", "<span class='notice'>You install capacitor to the [holder].</span>")
-				var/obj/item/I = used_atom
-				user.transferItemToLoc(I, holder, TRUE)
-				holder.icon_state = "durand13"
+				user.visible_message("[user] installs capacitor to [holder].", "<span class='notice'>You install capacitor to [holder].</span>")
 			else
 				user.visible_message("[user] unfastens the scanner module.", "<span class='notice'>You unfasten the scanner module.</span>")
-				holder.icon_state = "durand11"
-		if(10)
+		if(14)
 			if(diff==FORWARD)
 				user.visible_message("[user] secures the capacitor.", "<span class='notice'>You secure the capacitor.</span>")
-				holder.icon_state = "durand14"
 			else
-				user.visible_message("[user] removes the super capacitor from the [holder].", "<span class='notice'>You remove the capacitor from the [holder].</span>")
-				var/obj/item/I = locate(/obj/item/stock_parts/capacitor) in holder
-				I.forceMove(holder.drop_location())
-				holder.icon_state = "durand12"
-		if(9)
+				user.visible_message("[user] removes the super capacitor from [holder].", "<span class='notice'>You remove the capacitor from [holder].</span>")
+		if(15)
 			if(diff==FORWARD)
-				user.visible_message("[user] installs the power cell into the [holder].", "<span class='notice'>You install the power cell into the [holder].</span>")
-				var/obj/item/I = used_atom
-				user.transferItemToLoc(I, holder, TRUE)
-				holder.icon_state = "durand15"
+				user.visible_message("[user] installs the power cell into [holder].", "<span class='notice'>You install the power cell into [holder].</span>")
 			else
 				user.visible_message("[user] unfastens the capacitor.", "<span class='notice'>You unfasten the capacitor.</span>")
-				holder.icon_state = "durand13"
-		if(8)
+		if(16)
 			if(diff==FORWARD)
 				user.visible_message("[user] secures the power cell.", "<span class='notice'>You secure the power cell.</span>")
-				holder.icon_state = "durand16"
 			else
 				user.visible_message("[user] prys the power cell from [holder].", "<span class='notice'>You pry the power cell from [holder].</span>")
-				var/obj/item/I = locate(/obj/item/stock_parts/cell) in holder
-				I.forceMove(holder.drop_location())
-				holder.icon_state = "durand14"
-		if(7)
+		if(17)
 			if(diff==FORWARD)
-				user.visible_message("[user] installs the internal armor layer to the [holder].", "<span class='notice'>You install the internal armor layer to the [holder].</span>")
-				holder.icon_state = "durand17"
+				user.visible_message("[user] installs the internal armor layer to [holder].", "<span class='notice'>You install the internal armor layer to [holder].</span>")
 			else
 				user.visible_message("[user] unfastens the power cell.", "<span class='notice'>You unfasten the power cell.</span>")
-				holder.icon_state = "durand15"
-		if(6)
+		if(18)
 			if(diff==FORWARD)
 				user.visible_message("[user] secures the internal armor layer.", "<span class='notice'>You secure the internal armor layer.</span>")
-				holder.icon_state = "durand18"
 			else
-				user.visible_message("[user] pries internal armor layer from the [holder].", "<span class='notice'>You pry internal armor layer from the [holder].</span>")
-				var/obj/item/stack/sheet/metal/MS = new /obj/item/stack/sheet/metal(get_turf(holder))
-				MS.amount = 5
-				holder.icon_state = "durand16"
-		if(5)
+				user.visible_message("[user] pries internal armor layer from [holder].", "<span class='notice'>You pry internal armor layer from [holder].</span>")
+		if(19)
 			if(diff==FORWARD)
-				user.visible_message("[user] welds the internal armor layer to the [holder].", "<span class='notice'>You weld the internal armor layer to the [holder].</span>")
-				holder.icon_state = "durand19"
+				user.visible_message("[user] welds the internal armor layer to [holder].", "<span class='notice'>You weld the internal armor layer to [holder].</span>")
 			else
 				user.visible_message("[user] unfastens the internal armor layer.", "<span class='notice'>You unfasten the internal armor layer.</span>")
-				holder.icon_state = "durand17"
-		if(4)
+		if(20)
 			if(diff==FORWARD)
-				user.visible_message("[user] installs Durand Armor Plates to the [holder].", "<span class='notice'>You install Durand Armor Plates to the [holder].</span>")
-				qdel(used_atom)
-				holder.icon_state = "durand20"
+				user.visible_message("[user] installs Durand Armor Plates to [holder].", "<span class='notice'>You install Durand Armor Plates to [holder].</span>")
 			else
-				user.visible_message("[user] cuts the internal armor layer from the [holder].", "<span class='notice'>You cut the internal armor layer from the [holder].</span>")
-				holder.icon_state = "durand18"
-		if(3)
+				user.visible_message("[user] cuts the internal armor layer from [holder].", "<span class='notice'>You cut the internal armor layer from [holder].</span>")
+		if(21)
 			if(diff==FORWARD)
 				user.visible_message("[user] secures Durand Armor Plates.", "<span class='notice'>You secure Durand Armor Plates.</span>")
-				holder.icon_state = "durand21"
 			else
-				user.visible_message("[user] pries Durand Armor Plates from the [holder].", "<span class='notice'>You pry Durand Armor Plates from the [holder].</span>")
-				new /obj/item/mecha_parts/part/durand_armor(get_turf(holder))
-				holder.icon_state = "durand19"
-		if(2)
+				user.visible_message("[user] pries Durand Armor Plates from [holder].", "<span class='notice'>You pry Durand Armor Plates from [holder].</span>")
+		if(22)
 			if(diff==FORWARD)
-				user.visible_message("[user] welds Durand Armor Plates to the [holder].", "<span class='notice'>You weld Durand Armor Plates to the [holder].</span>")
-				spawn_mecha_result()
+				user.visible_message("[user] welds Durand Armor Plates to [holder].", "<span class='notice'>You weld Durand Armor Plates to [holder].</span>")
 			else
 				user.visible_message("[user] unfastens Durand Armor Plates.", "<span class='notice'>You unfasten Durand Armor Plates.</span>")
-				holder.icon_state = "durand20"
 	return TRUE
 
 //PHAZON
 
-/datum/construction/mecha/phazon_chassis
-	steps = list(list("key"=/obj/item/mecha_parts/part/phazon_torso), //1
-					 list("key"=/obj/item/mecha_parts/part/phazon_left_arm), //2
-					 list("key"=/obj/item/mecha_parts/part/phazon_right_arm), //3
-					 list("key"=/obj/item/mecha_parts/part/phazon_left_leg), //4
-					 list("key"=/obj/item/mecha_parts/part/phazon_right_leg), //5
-					 list("key"=/obj/item/mecha_parts/part/phazon_head)
-					)
-
-/datum/construction/mecha/phazon_chassis/custom_action(step, atom/used_atom, mob/user)
-	user.visible_message("[user] has connected [used_atom] to the [holder].", "<span class='notice'>You connect [used_atom] to the [holder].</span>")
-	holder.add_overlay(used_atom.icon_state+"+o")
-	qdel(used_atom)
-	return TRUE
-
-/datum/construction/mecha/phazon_chassis/action(atom/used_atom,mob/user)
-	return check_all_steps(used_atom,user)
-
-/datum/construction/mecha/phazon_chassis/spawn_result()
-	var/obj/item/mecha_parts/chassis/const_holder = holder
-	const_holder.construct = new /datum/construction/reversible/mecha/phazon(const_holder)
-	const_holder.icon = 'icons/mecha/mech_construction.dmi'
-	const_holder.icon_state = "phazon0"
-	const_holder.density = TRUE
-	qdel(src)
-
-/datum/construction/reversible/mecha/phazon
-	result = /obj/mecha/combat/phazon
+/datum/construction/unordered/mecha_chassis/phazon
+	result = /datum/construction/mecha/phazon
 	steps = list(
-					 //0, dummy step used to stop the steps from finishing and spawn_result() being called automatically.
-					 list("desc"="You shouldn't be able to see this."),
+		/obj/item/mecha_parts/part/phazon_torso,
+		/obj/item/mecha_parts/part/phazon_left_arm,
+		/obj/item/mecha_parts/part/phazon_right_arm,
+		/obj/item/mecha_parts/part/phazon_left_leg,
+		/obj/item/mecha_parts/part/phazon_right_leg,
+		/obj/item/mecha_parts/part/phazon_head
+	)
 
-					 //1
-					 list("key"=/obj/item/device/assembly/signaler/anomaly,
-						 "backkey"=null, //Cannot remove the anomaly core once it's in
-						 "desc"="Anomaly core socket is open and awaiting connection."),
-					 //2
-					 list("key"=/obj/item/weldingtool,
-							"backkey"=/obj/item/wrench,
-							"desc"="External armor is wrenched."),
-					 //3
-					 list("key"=/obj/item/wrench,
-					 		"backkey"=/obj/item/crowbar,
-					 		"desc"="External armor is installed."),
-					 //4
-					 list("key"=/obj/item/mecha_parts/part/phazon_armor,
-					 		"backkey"=/obj/item/weldingtool,
-					 		"desc"="Phase armor is welded."),
-					 //5
-					 list("key"=/obj/item/weldingtool,
-					 		"backkey"=/obj/item/wrench,
-					 		"desc"="Phase armor is wrenched."),
-					 //6
-					 list("key"=/obj/item/wrench,
-					 		"backkey"=/obj/item/crowbar,
-					 		"desc"="Phase armor is installed."),
-					 //7
-					 list("key"=/obj/item/stack/sheet/plasteel,
-					 		"backkey"=/obj/item/screwdriver,
-					 		"desc"="The power cell is secured."),
-					 //8
-					 list("key"=/obj/item/screwdriver,
-					 		"backkey"=/obj/item/crowbar,
-					 		"desc"="The power cell is installed."),
-					 //9
-					 list("key"=/obj/item/stock_parts/cell,
-					 		"backkey"=/obj/item/screwdriver,
-					 		"desc"="The bluespace crystal is engaged."),
-					 //10
-					 list("key"=/obj/item/screwdriver,
-					 		"backkey"=/obj/item/wirecutters,
-					 		"desc"="The bluespace crystal is connected."),
-					 //11
-					 list("key"=/obj/item/stack/cable_coil,
-					 		"backkey"=/obj/item/crowbar,
-					 		"desc"="The bluespace crystal is installed."),
-					 //12
-					 list("key"=/obj/item/stack/ore/bluespace_crystal,
-					 		"backkey"=/obj/item/screwdriver,
-					 		"desc"="Super capacitor is secured."),
-					 //13
-					 list("key"=/obj/item/screwdriver,
-					 		"backkey"=/obj/item/crowbar,
-					 		"desc"="Super capacitor is installed."),
-					 //14
-					 list("key"=/obj/item/stock_parts/capacitor,
-					 		"backkey"=/obj/item/screwdriver,
-					 		"desc"="Phasic scanner module is secured."),
-					 //15
-					 list("key"=/obj/item/screwdriver,
-					 		"backkey"=/obj/item/crowbar,
-					 		"desc"="Phasic scanner module is installed."),
-					 //16
-					 list("key"=/obj/item/stock_parts/scanning_module,
-					 		"backkey"=/obj/item/screwdriver,
-					 		"desc"="Weapon control module is secured."),
-					 //17
-					 list("key"=/obj/item/screwdriver,
-					 		"backkey"=/obj/item/crowbar,
-					 		"desc"="Weapon control is installed."),
-					 //18
-					 list("key"=/obj/item/circuitboard/mecha/phazon/targeting,
-					 		"backkey"=/obj/item/screwdriver,
-					 		"desc"="Peripherals control module is secured."),
-					 //19
-					 list("key"=/obj/item/screwdriver,
-					 		"backkey"=/obj/item/crowbar,
-					 		"desc"="Peripherals control module is installed"),
-					 //20
-					 list("key"=/obj/item/circuitboard/mecha/phazon/peripherals,
-					 		"backkey"=/obj/item/screwdriver,
-					 		"desc"="Central control module is secured."),
-					 //21
-					 list("key"=/obj/item/screwdriver,
-					 		"backkey"=/obj/item/crowbar,
-					 		"desc"="Central control module is installed."),
-					 //22
-					 list("key"=/obj/item/circuitboard/mecha/phazon/main,
-					 		"backkey"=/obj/item/screwdriver,
-					 		"desc"="The wiring is adjusted."),
-					 //23
-					 list("key"=/obj/item/wirecutters,
-					 		"backkey"=/obj/item/screwdriver,
-					 		"desc"="The wiring is added."),
-					 //24
-					 list("key"=/obj/item/stack/cable_coil,
-					 		"backkey"=/obj/item/screwdriver,
-					 		"desc"="The hydraulic systems are active."),
-					 //25
-					 list("key"=/obj/item/screwdriver,
-					 		"backkey"=/obj/item/wrench,
-					 		"desc"="The hydraulic systems are connected."),
-					 //26
-					 list("key"=/obj/item/wrench,
-					 		"desc"="The hydraulic systems are disconnected.")
-					)
+/datum/construction/mecha/phazon
+	result = /obj/mecha/combat/phazon
+	base_icon = "phazon"
+	steps = list(
+		//1
+		list(
+			"key" = TOOL_WRENCH,
+			"desc" = "The hydraulic systems are disconnected."
+		),
+
+		//2
+		list(
+			"key" = TOOL_SCREWDRIVER,
+			"back_key" = TOOL_WRENCH,
+			"desc" = "The hydraulic systems are connected."
+		),
+
+		//3
+		list(
+			"key" = /obj/item/stack/cable_coil,
+			"amount" = 5,
+			"back_key" = TOOL_SCREWDRIVER,
+			"desc" = "The hydraulic systems are active."
+		),
+
+		//4
+		list(
+			"key" = TOOL_WIRECUTTER,
+			"back_key" = TOOL_SCREWDRIVER,
+			"desc" = "The wiring is added."
+		),
+
+		//5
+		list(
+			"key" = /obj/item/circuitboard/mecha/phazon/main,
+			"action" = ITEM_DELETE,
+			"back_key" = TOOL_SCREWDRIVER,
+			"desc" = "The wiring is adjusted."
+		),
+
+		//6
+		list(
+			"key" = TOOL_SCREWDRIVER,
+			"back_key" = TOOL_CROWBAR,
+			"desc" = "Central control module is installed."
+		),
+
+		//7
+		list(
+			"key" = /obj/item/circuitboard/mecha/phazon/peripherals,
+			"action" = ITEM_DELETE,
+			"back_key" = TOOL_SCREWDRIVER,
+			"desc" = "Central control module is secured."
+		),
+
+		//8
+		list(
+			"key" = TOOL_SCREWDRIVER,
+			"back_key" = TOOL_CROWBAR,
+			"desc" = "Peripherals control module is installed"
+		),
+
+		//9
+		list(
+			"key" = /obj/item/circuitboard/mecha/phazon/targeting,
+			"action" = ITEM_DELETE,
+			"back_key" = TOOL_SCREWDRIVER,
+			"desc" = "Peripherals control module is secured."
+		),
+
+		//10
+		list(
+			"key" = TOOL_SCREWDRIVER,
+			"back_key" = TOOL_CROWBAR,
+			"desc" = "Weapon control is installed."
+		),
+
+		//11
+		list(
+			"key" = /obj/item/stock_parts/scanning_module,
+			"action" = ITEM_MOVE_INSIDE,
+			"back_key" = TOOL_SCREWDRIVER,
+			"desc" = "Weapon control module is secured."
+		),
+
+		//12
+		list(
+			"key" = TOOL_SCREWDRIVER,
+			"back_key" = TOOL_CROWBAR,
+			"desc" = "Phasic scanner module is installed."
+		),
+
+		//13
+		list(
+			"key" = /obj/item/stock_parts/capacitor,
+			"action" = ITEM_MOVE_INSIDE,
+			"back_key" = TOOL_SCREWDRIVER,
+			"desc" = "Phasic scanner module is secured."
+		),
+
+		//14
+		list(
+			"key" = TOOL_SCREWDRIVER,
+			"back_key" = TOOL_CROWBAR,
+			"desc" = "Super capacitor is installed."
+		),
+
+		//15
+		list(
+			"key" = /obj/item/stack/ore/bluespace_crystal,
+			"amount" = 1,
+			"back_key" = TOOL_SCREWDRIVER,
+			"desc" = "Super capacitor is secured."
+		),
+
+		//16
+		list(
+			"key" = /obj/item/stack/cable_coil,
+			"amount" = 5,
+			"back_key" = TOOL_CROWBAR,
+			"desc" = "The bluespace crystal is installed."
+		),
+
+		//17
+		list(
+			"key" = TOOL_SCREWDRIVER,
+			"back_key" = TOOL_WIRECUTTER,
+			"desc" = "The bluespace crystal is connected."
+		),
+
+		//18
+		list(
+			"key" = /obj/item/stock_parts/cell,
+			"action" = ITEM_MOVE_INSIDE,
+			"back_key" = TOOL_SCREWDRIVER,
+			"desc" = "The bluespace crystal is engaged."
+		),
+
+		//19
+		list(
+			"key" = TOOL_SCREWDRIVER,
+			"back_key" = TOOL_CROWBAR,
+			"desc" = "The power cell is installed.",
+			"icon_state" = "phazon17"
+			// This is the point where a step icon is skipped, so "icon_state" had to be set manually starting from here.
+		),
+
+		//20
+		list(
+			"key" = /obj/item/stack/sheet/plasteel,
+			"amount" = 5,
+			"back_key" = TOOL_SCREWDRIVER,
+			"desc" = "The power cell is secured.",
+			"icon_state" = "phazon18"
+		),
+
+		//21
+		list(
+			"key" = TOOL_WRENCH,
+			"back_key" = TOOL_CROWBAR,
+			"desc" = "Phase armor is installed.",
+			"icon_state" = "phazon19"
+		),
+
+		//22
+		list(
+			"key" = TOOL_WELDER,
+			"back_key" = TOOL_WRENCH,
+			"desc" = "Phase armor is wrenched.",
+			"icon_state" = "phazon20"
+		),
+
+		//23
+		list(
+			"key" = /obj/item/mecha_parts/part/phazon_armor,
+			"action" = ITEM_DELETE,
+			"back_key" = TOOL_WELDER,
+			"desc" = "Phase armor is welded.",
+			"icon_state" = "phazon21"
+		),
+
+		//24
+		list(
+			"key" = TOOL_WRENCH,
+			"back_key" = TOOL_CROWBAR,
+			"desc" = "External armor is installed.",
+			"icon_state" = "phazon22"
+		),
+
+		//25
+		list(
+			"key" = TOOL_WELDER,
+			"back_key" = TOOL_WRENCH,
+			"desc" = "External armor is wrenched.",
+			"icon_state" = "phazon23"
+		),
+
+		//26
+		list(
+			"key" = /obj/item/device/assembly/signaler/anomaly,
+			"action" = ITEM_DELETE,
+			"back_key" = TOOL_WELDER,
+			"desc" = "Anomaly core socket is open.",
+			"icon_state" = "phazon24"
+		),
+	)
 
 
-/datum/construction/reversible/mecha/phazon/action(atom/used_atom,mob/user)
-	return check_step(used_atom,user)
-
-/datum/construction/reversible/mecha/phazon/custom_action(index, diff, atom/used_atom, mob/user)
+/datum/construction/mecha/phazon/custom_action(obj/item/I, mob/living/user, diff)
 	if(!..())
 		return FALSE
 
 	//TODO: better messages.
 	switch(index)
-		if(27)
-			user.visible_message("[user] connects the [holder] hydraulic systems", "<span class='notice'>You connect the [holder] hydraulic systems.</span>")
-			holder.icon_state = "phazon1"
-		if(26)
+		if(1)
+			user.visible_message("[user] connects [holder] hydraulic systems", "<span class='notice'>You connect [holder] hydraulic systems.</span>")
+		if(2)
 			if(diff==FORWARD)
-				user.visible_message("[user] activates the [holder] hydraulic systems.", "<span class='notice'>You activate the [holder] hydraulic systems.</span>")
-				holder.icon_state = "phazon2"
+				user.visible_message("[user] activates [holder] hydraulic systems.", "<span class='notice'>You activate [holder] hydraulic systems.</span>")
 			else
-				user.visible_message("[user] disconnects the [holder] hydraulic systems", "<span class='notice'>You disconnect the [holder] hydraulic systems.</span>")
-				holder.icon_state = "phazon0"
-		if(25)
+				user.visible_message("[user] disconnects [holder] hydraulic systems", "<span class='notice'>You disconnect [holder] hydraulic systems.</span>")
+		if(3)
 			if(diff==FORWARD)
-				user.visible_message("[user] adds the wiring to the [holder].", "<span class='notice'>You add the wiring to the [holder].</span>")
-				holder.icon_state = "phazon3"
+				user.visible_message("[user] adds the wiring to [holder].", "<span class='notice'>You add the wiring to [holder].</span>")
 			else
-				user.visible_message("[user] deactivates the [holder] hydraulic systems.", "<span class='notice'>You deactivate the [holder] hydraulic systems.</span>")
-				holder.icon_state = "phazon1"
-		if(24)
+				user.visible_message("[user] deactivates [holder] hydraulic systems.", "<span class='notice'>You deactivate [holder] hydraulic systems.</span>")
+		if(4)
 			if(diff==FORWARD)
-				user.visible_message("[user] adjusts the wiring of the [holder].", "<span class='notice'>You adjust the wiring of the [holder].</span>")
-				holder.icon_state = "phazon4"
+				user.visible_message("[user] adjusts the wiring of [holder].", "<span class='notice'>You adjust the wiring of [holder].</span>")
 			else
-				user.visible_message("[user] removes the wiring from the [holder].", "<span class='notice'>You remove the wiring from the [holder].</span>")
-				var/obj/item/stack/cable_coil/coil = new /obj/item/stack/cable_coil(get_turf(holder))
-				coil.amount = 4
-				holder.icon_state = "phazon2"
-		if(23)
+				user.visible_message("[user] removes the wiring from [holder].", "<span class='notice'>You remove the wiring from [holder].</span>")
+		if(5)
 			if(diff==FORWARD)
-				user.visible_message("[user] installs the central control module into the [holder].", "<span class='notice'>You install the central computer mainboard into the [holder].</span>")
-				qdel(used_atom)
-				holder.icon_state = "phazon5"
+				user.visible_message("[user] installs the central control module into [holder].", "<span class='notice'>You install the central computer mainboard into [holder].</span>")
 			else
-				user.visible_message("[user] disconnects the wiring of the [holder].", "<span class='notice'>You disconnect the wiring of the [holder].</span>")
-				holder.icon_state = "phazon3"
-		if(22)
+				user.visible_message("[user] disconnects the wiring of [holder].", "<span class='notice'>You disconnect the wiring of [holder].</span>")
+		if(6)
 			if(diff==FORWARD)
 				user.visible_message("[user] secures the mainboard.", "<span class='notice'>You secure the mainboard.</span>")
-				holder.icon_state = "phazon6"
 			else
-				user.visible_message("[user] removes the central control module from the [holder].", "<span class='notice'>You remove the central computer mainboard from the [holder].</span>")
-				new /obj/item/circuitboard/mecha/phazon/main(get_turf(holder))
-				holder.icon_state = "phazon4"
-		if(21)
+				user.visible_message("[user] removes the central control module from [holder].", "<span class='notice'>You remove the central computer mainboard from [holder].</span>")
+		if(7)
 			if(diff==FORWARD)
-				user.visible_message("[user] installs the peripherals control module into the [holder].", "<span class='notice'>You install the peripherals control module into the [holder].</span>")
-				qdel(used_atom)
-				holder.icon_state = "phazon7"
+				user.visible_message("[user] installs the peripherals control module into [holder].", "<span class='notice'>You install the peripherals control module into [holder].</span>")
 			else
 				user.visible_message("[user] unfastens the mainboard.", "<span class='notice'>You unfasten the mainboard.</span>")
-				holder.icon_state = "phazon5"
-		if(20)
+		if(8)
 			if(diff==FORWARD)
 				user.visible_message("[user] secures the peripherals control module.", "<span class='notice'>You secure the peripherals control module.</span>")
-				holder.icon_state = "phazon8"
 			else
-				user.visible_message("[user] removes the peripherals control module from the [holder].", "<span class='notice'>You remove the peripherals control module from the [holder].</span>")
-				new /obj/item/circuitboard/mecha/phazon/peripherals(get_turf(holder))
-				holder.icon_state = "phazon6"
-		if(19)
+				user.visible_message("[user] removes the peripherals control module from [holder].", "<span class='notice'>You remove the peripherals control module from [holder].</span>")
+		if(9)
 			if(diff==FORWARD)
-				user.visible_message("[user] installs the weapon control module into the [holder].", "<span class='notice'>You install the weapon control module into the [holder].</span>")
-				qdel(used_atom)
-				holder.icon_state = "phazon9"
+				user.visible_message("[user] installs the weapon control module into [holder].", "<span class='notice'>You install the weapon control module into [holder].</span>")
 			else
 				user.visible_message("[user] unfastens the peripherals control module.", "<span class='notice'>You unfasten the peripherals control module.</span>")
-				holder.icon_state = "phazon7"
-		if(18)
+		if(10)
 			if(diff==FORWARD)
 				user.visible_message("[user] secures the weapon control module.", "<span class='notice'>You secure the weapon control module.</span>")
-				holder.icon_state = "phazon10"
 			else
-				user.visible_message("[user] removes the weapon control module from the [holder].", "<span class='notice'>You remove the weapon control module from the [holder].</span>")
-				new /obj/item/circuitboard/mecha/phazon/targeting(get_turf(holder))
-				holder.icon_state = "phazon8"
-		if(17)
+				user.visible_message("[user] removes the weapon control module from [holder].", "<span class='notice'>You remove the weapon control module from [holder].</span>")
+		if(11)
 			if(diff==FORWARD)
-				user.visible_message("[user] installs phasic scanner module to the [holder].", "<span class='notice'>You install scanner module to the [holder].</span>")
-				var/obj/item/I = used_atom
-				user.transferItemToLoc(I, holder, TRUE)
-				holder.icon_state = "phazon11"
+				user.visible_message("[user] installs phasic scanner module to [holder].", "<span class='notice'>You install scanner module to [holder].</span>")
 			else
 				user.visible_message("[user] unfastens the weapon control module.", "<span class='notice'>You unfasten the weapon control module.</span>")
-				holder.icon_state = "phazon9"
-		if(16)
+		if(12)
 			if(diff==FORWARD)
 				user.visible_message("[user] secures the phasic scanner module.", "<span class='notice'>You secure the scanner module.</span>")
-				holder.icon_state = "phazon12"
 			else
-				user.visible_message("[user] removes the phasic scanner module from the [holder].", "<span class='notice'>You remove the scanner module from the [holder].</span>")
-				var/obj/item/I = locate(/obj/item/stock_parts/scanning_module) in holder
-				I.forceMove(holder.drop_location())
-				holder.icon_state = "phazon10"
-		if(15)
+				user.visible_message("[user] removes the phasic scanner module from [holder].", "<span class='notice'>You remove the scanner module from [holder].</span>")
+		if(13)
 			if(diff==FORWARD)
-				user.visible_message("[user] installs super capacitor to the [holder].", "<span class='notice'>You install capacitor to the [holder].</span>")
-				var/obj/item/I = used_atom
-				user.transferItemToLoc(I, holder, TRUE)
-				holder.icon_state = "phazon13"
+				user.visible_message("[user] installs super capacitor to [holder].", "<span class='notice'>You install capacitor to [holder].</span>")
 			else
 				user.visible_message("[user] unfastens the phasic scanner module.", "<span class='notice'>You unfasten the scanner module.</span>")
-				holder.icon_state = "phazon11"
 		if(14)
 			if(diff==FORWARD)
 				user.visible_message("[user] secures the super capacitor.", "<span class='notice'>You secure the capacitor.</span>")
-				holder.icon_state = "phazon14"
 			else
-				user.visible_message("[user] removes the super capacitor from the [holder].", "<span class='notice'>You remove the capacitor from the [holder].</span>")
-				var/obj/item/I = locate(/obj/item/stock_parts/capacitor) in holder
-				I.forceMove(holder.drop_location())
-				holder.icon_state = "phazon12"
-		if(13)
+				user.visible_message("[user] removes the super capacitor from [holder].", "<span class='notice'>You remove the capacitor from [holder].</span>")
+		if(15)
 			if(diff==FORWARD)
 				user.visible_message("[user] installs the bluespace crystal.", "<span class='notice'>You install the bluespace crystal.</span>")
-				qdel(used_atom)
-				holder.icon_state = "phazon15"
 			else
-				user.visible_message("[user] unsecures the super capacitor from the [holder].", "<span class='notice'>You unsecure the capacitor from the [holder].</span>")
-				holder.icon_state = "phazon13"
-		if(12)
+				user.visible_message("[user] unsecures the super capacitor from [holder].", "<span class='notice'>You unsecure the capacitor from [holder].</span>")
+		if(16)
 			if(diff==FORWARD)
 				user.visible_message("[user] connects the bluespace crystal.", "<span class='notice'>You connect the bluespace crystal.</span>")
-				holder.icon_state = "phazon16"
 			else
-				user.visible_message("[user] removes the bluespace crystal from the [holder].", "<span class='notice'>You remove the bluespace crystal from the [holder].</span>")
-				new /obj/item/stack/ore/bluespace_crystal(get_turf(holder))
-				holder.icon_state = "phazon14"
-		if(11)
+				user.visible_message("[user] removes the bluespace crystal from [holder].", "<span class='notice'>You remove the bluespace crystal from [holder].</span>")
+		if(17)
 			if(diff==FORWARD)
 				user.visible_message("[user] engages the bluespace crystal.", "<span class='notice'>You engage the bluespace crystal.</span>")
-				holder.icon_state = "phazon17"
 			else
-				user.visible_message("[user] disconnects the bluespace crystal from the [holder].", "<span class='notice'>You disconnect the bluespace crystal from the [holder].</span>")
-				holder.icon_state = "phazon15"
-		if(10)
+				user.visible_message("[user] disconnects the bluespace crystal from [holder].", "<span class='notice'>You disconnect the bluespace crystal from [holder].</span>")
+		if(18)
 			if(diff==FORWARD)
-				user.visible_message("[user] installs the power cell into the [holder].", "<span class='notice'>You install the power cell into the [holder].</span>")
-				var/obj/item/I = used_atom
-				user.transferItemToLoc(I, holder, TRUE)
-				holder.icon_state = "phazon18"
+				user.visible_message("[user] installs the power cell into [holder].", "<span class='notice'>You install the power cell into [holder].</span>")
 			else
 				user.visible_message("[user] disengages the bluespace crystal.", "<span class='notice'>You disengage the bluespace crystal.</span>")
-				holder.icon_state = "phazon16"
-		if(9)
+		if(19)
 			if(diff==FORWARD)
 				user.visible_message("[user] secures the power cell.", "<span class='notice'>You secure the power cell.</span>")
-				holder.icon_state = "phazon19"
 			else
 				user.visible_message("[user] prys the power cell from [holder].", "<span class='notice'>You pry the power cell from [holder].</span>")
-				var/obj/item/I = locate(/obj/item/stock_parts/cell) in holder
-				I.forceMove(holder.drop_location())
-				holder.icon_state = "phazon17"
-		if(8)
+		if(20)
 			if(diff==FORWARD)
-				user.visible_message("[user] installs the phase armor layer to the [holder].", "<span class='notice'>You install the phase armor layer to the [holder].</span>")
-				holder.icon_state = "phazon20"
+				user.visible_message("[user] installs the phase armor layer to [holder].", "<span class='notice'>You install the phase armor layer to [holder].</span>")
 			else
 				user.visible_message("[user] unfastens the power cell.", "<span class='notice'>You unfasten the power cell.</span>")
-				holder.icon_state = "durand18"
-		if(7)
+		if(21)
 			if(diff==FORWARD)
 				user.visible_message("[user] secures the phase armor layer.", "<span class='notice'>You secure the phase armor layer.</span>")
-				holder.icon_state = "phazon21"
 			else
-				user.visible_message("[user] pries the phase armor layer from the [holder].", "<span class='notice'>You pry the phase armor layer from the [holder].</span>")
-				var/obj/item/stack/sheet/plasteel/MS = new /obj/item/stack/sheet/plasteel(get_turf(holder))
-				MS.amount = 5
-				holder.icon_state = "phazon19"
-		if(6)
+				user.visible_message("[user] pries the phase armor layer from [holder].", "<span class='notice'>You pry the phase armor layer from [holder].</span>")
+		if(22)
 			if(diff==FORWARD)
-				user.visible_message("[user] welds the phase armor layer to the [holder].", "<span class='notice'>You weld the phase armor layer to the [holder].</span>")
-				holder.icon_state = "phazon22"
+				user.visible_message("[user] welds the phase armor layer to [holder].", "<span class='notice'>You weld the phase armor layer to [holder].</span>")
 			else
 				user.visible_message("[user] unfastens the phase armor layer.", "<span class='notice'>You unfasten the phase armor layer.</span>")
-				holder.icon_state = "phazon20"
-		if(5)
+		if(23)
 			if(diff==FORWARD)
-				user.visible_message("[user] installs Phazon Armor Plates to the [holder].", "<span class='notice'>You install Phazon Armor Plates to the [holder].</span>")
-				qdel(used_atom)
-				holder.icon_state = "phazon23"
+				user.visible_message("[user] installs Phazon Armor Plates to [holder].", "<span class='notice'>You install Phazon Armor Plates to [holder].</span>")
 			else
-				user.visible_message("[user] cuts phase armor layer from the [holder].", "<span class='notice'>You cut the phase armor layer from the [holder].</span>")
-				holder.icon_state = "phazon21"
-		if(4)
+				user.visible_message("[user] cuts phase armor layer from [holder].", "<span class='notice'>You cut the phase armor layer from [holder].</span>")
+		if(24)
 			if(diff==FORWARD)
 				user.visible_message("[user] secures Phazon Armor Plates.", "<span class='notice'>You secure Phazon Armor Plates.</span>")
-				holder.icon_state = "phazon24"
 			else
-				user.visible_message("[user] pries Phazon Armor Plates from the [holder].", "<span class='notice'>You pry Phazon Armor Plates from the [holder].</span>")
-				new /obj/item/mecha_parts/part/phazon_armor(get_turf(holder))
-				holder.icon_state = "phazon22"
-		if(3)
+				user.visible_message("[user] pries Phazon Armor Plates from [holder].", "<span class='notice'>You pry Phazon Armor Plates from [holder].</span>")
+		if(25)
 			if(diff==FORWARD)
-				user.visible_message("[user] welds Phazon Armor Plates to the [holder].", "<span class='notice'>You weld Phazon Armor Plates to the [holder].</span>")
+				user.visible_message("[user] welds Phazon Armor Plates to [holder].", "<span class='notice'>You weld Phazon Armor Plates to [holder].</span>")
 			else
 				user.visible_message("[user] unfastens Phazon Armor Plates.", "<span class='notice'>You unfasten Phazon Armor Plates.</span>")
-				holder.icon_state = "phazon23"
-		if(2)
+		if(26)
 			if(diff==FORWARD)
-				user.visible_message("[user] carefully inserts the anomaly core into \the [holder] and secures it.", "<span class='notice'>You slowly place the anomaly core into its socket and close its chamber.</span>")
-				qdel(used_atom)
-				spawn_mecha_result()
+				user.visible_message("[user] carefully inserts the anomaly core into [holder] and secures it.",
+					"<span class='notice'>You slowly place the anomaly core into its socket and close its chamber.</span>")
 	return TRUE
 
 //ODYSSEUS
 
-/datum/construction/mecha/odysseus_chassis
-	steps = list(list("key"=/obj/item/mecha_parts/part/odysseus_torso), //1
-					 list("key"=/obj/item/mecha_parts/part/odysseus_head), //2
-					 list("key"=/obj/item/mecha_parts/part/odysseus_left_arm), //3
-					 list("key"=/obj/item/mecha_parts/part/odysseus_right_arm), //4
-					 list("key"=/obj/item/mecha_parts/part/odysseus_left_leg), //5
-					 list("key"=/obj/item/mecha_parts/part/odysseus_right_leg)//6
-					)
-
-/datum/construction/mecha/odysseus_chassis/custom_action(step, atom/used_atom, mob/user)
-	user.visible_message("[user] has connected [used_atom] to the [holder].", "<span class='notice'>You connect [used_atom] to the [holder].</span>")
-	holder.add_overlay(used_atom.icon_state+"+o")
-	qdel(used_atom)
-	return TRUE
-
-/datum/construction/mecha/odysseus_chassis/action(atom/used_atom,mob/user)
-	return check_all_steps(used_atom,user)
-
-/datum/construction/mecha/odysseus_chassis/spawn_result()
-	var/obj/item/mecha_parts/chassis/const_holder = holder
-	const_holder.construct = new /datum/construction/reversible/mecha/odysseus(const_holder)
-	const_holder.icon = 'icons/mecha/mech_construction.dmi'
-	const_holder.icon_state = "odysseus0"
-	const_holder.density = TRUE
-	qdel(src)
-
-
-/datum/construction/reversible/mecha/odysseus
-	result = /obj/mecha/medical/odysseus
+/datum/construction/unordered/mecha_chassis/odysseus
+	result = /datum/construction/mecha/odysseus
 	steps = list(
-					 //0, dummy step used to stop the steps from finishing and spawn_result() being called automatically.
-					 list("desc"="You shouldn't be able to see this."),
+		/obj/item/mecha_parts/part/odysseus_torso,
+		/obj/item/mecha_parts/part/odysseus_head,
+		/obj/item/mecha_parts/part/odysseus_left_arm,
+		/obj/item/mecha_parts/part/odysseus_right_arm,
+		/obj/item/mecha_parts/part/odysseus_left_leg,
+		/obj/item/mecha_parts/part/odysseus_right_leg
+	)
 
-					 //1
-					 list("key"=/obj/item/weldingtool,
-							"backkey"=/obj/item/wrench,
-							"desc"="External armor is wrenched."),
-					 //2
-					 list("key"=/obj/item/wrench,
-					 		"backkey"=/obj/item/crowbar,
-					 		"desc"="External armor is installed."),
-					 //3
-					 list("key"=/obj/item/stack/sheet/plasteel,
-					 		"backkey"=/obj/item/weldingtool,
-					 		"desc"="Internal armor is welded."),
-					 //4
-					 list("key"=/obj/item/weldingtool,
-					 		"backkey"=/obj/item/wrench,
-					 		"desc"="Internal armor is wrenched."),
-					 //5
-					 list("key"=/obj/item/wrench,
-					 		"backkey"=/obj/item/crowbar,
-					 		"desc"="Internal armor is installed."),
-					 //6
-					 list("key"=/obj/item/stack/sheet/metal,
-					 		"backkey"=/obj/item/screwdriver,
-					 		"desc"="The power cell is secured."),
-					 //7
-					 list("key"=/obj/item/screwdriver,
-					 		"backkey"=/obj/item/crowbar,
-					 		"desc"="The power cell is installed."),
-					 //8
-					 list("key"=/obj/item/stock_parts/cell,
-					 		"backkey"=/obj/item/screwdriver,
-					 		"desc"="Peripherals control module is secured."),
-					 //9
-					 list("key"=/obj/item/screwdriver,
-					 		"backkey"=/obj/item/crowbar,
-					 		"desc"="Peripherals control module is installed."),
-					 //10
-					 list("key"=/obj/item/circuitboard/mecha/odysseus/peripherals,
-					 		"backkey"=/obj/item/screwdriver,
-					 		"desc"="Central control module is secured."),
-					 //11
-					 list("key"=/obj/item/screwdriver,
-					 		"backkey"=/obj/item/crowbar,
-					 		"desc"="Central control module is installed."),
-					 //12
-					 list("key"=/obj/item/circuitboard/mecha/odysseus/main,
-					 		"backkey"=/obj/item/screwdriver,
-					 		"desc"="The wiring is adjusted."),
-					 //13
-					 list("key"=/obj/item/wirecutters,
-					 		"backkey"=/obj/item/screwdriver,
-					 		"desc"="The wiring is added."),
-					 //14
-					 list("key"=/obj/item/stack/cable_coil,
-					 		"backkey"=/obj/item/screwdriver,
-					 		"desc"="The hydraulic systems are active."),
-					 //15
-					 list("key"=/obj/item/screwdriver,
-					 		"backkey"=/obj/item/wrench,
-					 		"desc"="The hydraulic systems are connected."),
-					 //16
-					 list("key"=/obj/item/wrench,
-					 		"desc"="The hydraulic systems are disconnected.")
-					)
+/datum/construction/mecha/odysseus
+	result = /obj/mecha/medical/odysseus
+	base_icon = "odysseus"
+	steps = list(
+		//1
+		list(
+			"key" = TOOL_WRENCH,
+			"desc" = "The hydraulic systems are disconnected."
+		),
 
-/datum/construction/reversible/mecha/odysseus/action(atom/used_atom,mob/user)
-	return check_step(used_atom,user)
+		//2
+		list(
+			"key" = TOOL_SCREWDRIVER,
+			"back_key" = TOOL_WRENCH,
+			"desc" = "The hydraulic systems are connected."
+		),
 
-/datum/construction/reversible/mecha/odysseus/custom_action(index, diff, atom/used_atom, mob/user)
+		//3
+		list(
+			"key" = /obj/item/stack/cable_coil,
+			"amount" = 5,
+			"back_key" = TOOL_SCREWDRIVER,
+			"desc" = "The hydraulic systems are active."
+		),
+
+		//4
+		list(
+			"key" = TOOL_WIRECUTTER,
+			"back_key" = TOOL_SCREWDRIVER,
+			"desc" = "The wiring is added."
+		),
+
+		//5
+		list(
+			"key" = /obj/item/circuitboard/mecha/odysseus/main,
+			"action" = ITEM_DELETE,
+			"back_key" = TOOL_SCREWDRIVER,
+			"desc" = "The wiring is adjusted."
+		),
+
+		//6
+		list(
+			"key" = TOOL_SCREWDRIVER,
+			"back_key" = TOOL_CROWBAR,
+			"desc" = "Central control module is installed."
+		),
+
+		//7
+		list(
+			"key" = /obj/item/circuitboard/mecha/odysseus/peripherals,
+			"action" = ITEM_DELETE,
+			"back_key" = TOOL_SCREWDRIVER,
+			"desc" = "Central control module is secured."
+		),
+
+		//8
+		list(
+			"key" = TOOL_SCREWDRIVER,
+			"back_key" = TOOL_CROWBAR,
+			"desc" = "Peripherals control module is installed."
+		),
+
+		//9
+		list(
+			"key" = /obj/item/stock_parts/cell,
+			"action" = ITEM_MOVE_INSIDE,
+			"back_key" = TOOL_SCREWDRIVER,
+			"desc" = "Peripherals control module is secured."
+		),
+
+		//10
+		list(
+			"key" = TOOL_SCREWDRIVER,
+			"back_key" = TOOL_CROWBAR,
+			"desc" = "The power cell is installed."
+		),
+
+		//11
+		list(
+			"key" = /obj/item/stack/sheet/metal,
+			"amount" = 5,
+			"back_key" = TOOL_SCREWDRIVER,
+			"desc" = "The power cell is secured."
+		),
+
+		//12
+		list(
+			"key" = TOOL_WRENCH,
+			"back_key" = TOOL_CROWBAR,
+			"desc" = "Internal armor is installed."
+		),
+
+		//13
+		list(
+			"key" = TOOL_WELDER,
+			"back_key" = TOOL_WRENCH,
+			"desc" = "Internal armor is wrenched."
+		),
+
+		//14
+		list(
+			"key" = /obj/item/stack/sheet/plasteel,
+			"amount" = 5,
+			"back_key" = TOOL_WELDER,
+			"desc" = "Internal armor is welded."
+		),
+
+		//15
+		list(
+			"key" = TOOL_WRENCH,
+			"back_key" = TOOL_CROWBAR,
+			"desc" = "External armor is installed."
+		),
+
+		//16
+		list(
+			"key" = TOOL_WELDER,
+			"back_key" = TOOL_WRENCH,
+			"desc" = "External armor is wrenched."
+		),
+	)
+
+/datum/construction/mecha/odysseus/custom_action(obj/item/I, mob/living/user, diff)
 	if(!..())
 		return FALSE
 
 	//TODO: better messages.
 	switch(index)
-		if(17)
-			user.visible_message("[user] connects the [holder] hydraulic systems", "<span class='notice'>You connect the [holder] hydraulic systems.</span>")
-			holder.icon_state = "odysseus1"
-		if(16)
-			if(diff==FORWARD)
-				user.visible_message("[user] activates the [holder] hydraulic systems.", "<span class='notice'>You activate the [holder] hydraulic systems.</span>")
-				holder.icon_state = "odysseus2"
-			else
-				user.visible_message("[user] disconnects the [holder] hydraulic systems", "<span class='notice'>You disconnect the [holder] hydraulic systems.</span>")
-				holder.icon_state = "odysseus0"
-		if(15)
-			if(diff==FORWARD)
-				user.visible_message("[user] adds the wiring to the [holder].", "<span class='notice'>You add the wiring to the [holder].</span>")
-				holder.icon_state = "odysseus3"
-			else
-				user.visible_message("[user] deactivates the [holder] hydraulic systems.", "<span class='notice'>You deactivate the [holder] hydraulic systems.</span>")
-				holder.icon_state = "odysseus1"
-		if(14)
-			if(diff==FORWARD)
-				user.visible_message("[user] adjusts the wiring of the [holder].", "<span class='notice'>You adjust the wiring of the [holder].</span>")
-				holder.icon_state = "odysseus4"
-			else
-				user.visible_message("[user] removes the wiring from the [holder].", "<span class='notice'>You remove the wiring from the [holder].</span>")
-				var/obj/item/stack/cable_coil/coil = new /obj/item/stack/cable_coil(get_turf(holder))
-				coil.amount = 4
-				holder.icon_state = "odysseus2"
-		if(13)
-			if(diff==FORWARD)
-				user.visible_message("[user] installs the central control module into the [holder].", "<span class='notice'>You install the central computer mainboard into the [holder].</span>")
-				qdel(used_atom)
-				holder.icon_state = "odysseus5"
-			else
-				user.visible_message("[user] disconnects the wiring of the [holder].", "<span class='notice'>You disconnect the wiring of the [holder].</span>")
-				holder.icon_state = "odysseus3"
-		if(12)
-			if(diff==FORWARD)
-				user.visible_message("[user] secures the mainboard.", "<span class='notice'>You secure the mainboard.</span>")
-				holder.icon_state = "odysseus6"
-			else
-				user.visible_message("[user] removes the central control module from the [holder].", "<span class='notice'>You remove the central computer mainboard from the [holder].</span>")
-				new /obj/item/circuitboard/mecha/odysseus/main(get_turf(holder))
-				holder.icon_state = "odysseus4"
-		if(11)
-			if(diff==FORWARD)
-				user.visible_message("[user] installs the peripherals control module into the [holder].", "<span class='notice'>You install the peripherals control module into the [holder].</span>")
-				qdel(used_atom)
-				holder.icon_state = "odysseus7"
-			else
-				user.visible_message("[user] unfastens the mainboard.", "<span class='notice'>You unfasten the mainboard.</span>")
-				holder.icon_state = "odysseus5"
-		if(10)
-			if(diff==FORWARD)
-				user.visible_message("[user] secures the peripherals control module.", "<span class='notice'>You secure the peripherals control module.</span>")
-				holder.icon_state = "odysseus8"
-			else
-				user.visible_message("[user] removes the peripherals control module from the [holder].", "<span class='notice'>You remove the peripherals control module from the [holder].</span>")
-				new /obj/item/circuitboard/mecha/odysseus/peripherals(get_turf(holder))
-				holder.icon_state = "odysseus6"
-		if(9)
-			if(diff==FORWARD)
-				user.visible_message("[user] installs the power cell into the [holder].", "<span class='notice'>You install the power cell into the [holder].</span>")
-				var/obj/item/I = used_atom
-				user.transferItemToLoc(I, holder, TRUE)
-				holder.icon_state = "odysseus9"
-			else
-				user.visible_message("[user] unfastens the peripherals control module.", "<span class='notice'>You unfasten the peripherals control module.</span>")
-				holder.icon_state = "odysseus7"
-		if(8)
-			if(diff==FORWARD)
-				user.visible_message("[user] secures the power cell.", "<span class='notice'>You secure the power cell.</span>")
-				holder.icon_state = "odysseus10"
-			else
-				user.visible_message("[user] prys the power cell from [holder].", "<span class='notice'>You pry the power cell from [holder].</span>")
-				var/obj/item/I = locate(/obj/item/stock_parts/cell) in holder
-				I.forceMove(holder.drop_location())
-				holder.icon_state = "odysseus8"
-		if(7)
-			if(diff==FORWARD)
-				user.visible_message("[user] installs the internal armor layer to the [holder].", "<span class='notice'>You install the internal armor layer to the [holder].</span>")
-				holder.icon_state = "odysseus11"
-			else
-				user.visible_message("[user] unfastens the power cell.", "<span class='notice'>You unfasten the power cell.</span>")
-				holder.icon_state = "odysseus9"
-		if(6)
-			if(diff==FORWARD)
-				user.visible_message("[user] secures the internal armor layer.", "<span class='notice'>You secure the internal armor layer.</span>")
-				holder.icon_state = "odysseus12"
-			else
-				user.visible_message("[user] pries internal armor layer from the [holder].", "<span class='notice'>You pry internal armor layer from the [holder].</span>")
-				var/obj/item/stack/sheet/metal/MS = new /obj/item/stack/sheet/metal(get_turf(holder))
-				MS.amount = 5
-				holder.icon_state = "odysseus10"
-		if(5)
-			if(diff==FORWARD)
-				user.visible_message("[user] welds the internal armor layer to the [holder].", "<span class='notice'>You weld the internal armor layer to the [holder].</span>")
-				holder.icon_state = "odysseus13"
-			else
-				user.visible_message("[user] unfastens the internal armor layer.", "<span class='notice'>You unfasten the internal armor layer.</span>")
-				holder.icon_state = "odysseus11"
-		if(4)
-			if(diff==FORWARD)
-				user.visible_message("[user] installs [used_atom] layer to the [holder].", "<span class='notice'>You install the external reinforced armor layer to the [holder].</span>")
-
-				holder.icon_state = "odysseus14"
-			else
-				user.visible_message("[user] cuts the internal armor layer from the [holder].", "<span class='notice'>You cut the internal armor layer from the [holder].</span>")
-				holder.icon_state = "odysseus12"
-		if(3)
-			if(diff==FORWARD)
-				user.visible_message("[user] secures the external armor layer.", "<span class='notice'>You secure the external reinforced armor layer.</span>")
-				holder.icon_state = "odysseus15"
-			else
-				var/obj/item/stack/sheet/plasteel/MS = new /obj/item/stack/sheet/plasteel(get_turf(holder))
-				MS.amount = 5
-				user.visible_message("[user] pries [MS] from the [holder].", "<span class='notice'>You pry [MS] from the [holder].</span>")
-				holder.icon_state = "odysseus13"
+		if(1)
+			user.visible_message("[user] connects [holder] hydraulic systems", "<span class='notice'>You connect [holder] hydraulic systems.</span>")
 		if(2)
 			if(diff==FORWARD)
-				user.visible_message("[user] welds the external armor layer to the [holder].", "<span class='notice'>You weld the external armor layer to the [holder].</span>")
-				spawn_mecha_result()
+				user.visible_message("[user] activates [holder] hydraulic systems.", "<span class='notice'>You activate [holder] hydraulic systems.</span>")
+			else
+				user.visible_message("[user] disconnects [holder] hydraulic systems", "<span class='notice'>You disconnect [holder] hydraulic systems.</span>")
+		if(3)
+			if(diff==FORWARD)
+				user.visible_message("[user] adds the wiring to [holder].", "<span class='notice'>You add the wiring to [holder].</span>")
+			else
+				user.visible_message("[user] deactivates [holder] hydraulic systems.", "<span class='notice'>You deactivate [holder] hydraulic systems.</span>")
+		if(4)
+			if(diff==FORWARD)
+				user.visible_message("[user] adjusts the wiring of [holder].", "<span class='notice'>You adjust the wiring of [holder].</span>")
+			else
+				user.visible_message("[user] removes the wiring from [holder].", "<span class='notice'>You remove the wiring from [holder].</span>")
+		if(5)
+			if(diff==FORWARD)
+				user.visible_message("[user] installs the central control module into [holder].", "<span class='notice'>You install the central computer mainboard into [holder].</span>")
+			else
+				user.visible_message("[user] disconnects the wiring of [holder].", "<span class='notice'>You disconnect the wiring of [holder].</span>")
+		if(6)
+			if(diff==FORWARD)
+				user.visible_message("[user] secures the mainboard.", "<span class='notice'>You secure the mainboard.</span>")
+			else
+				user.visible_message("[user] removes the central control module from [holder].", "<span class='notice'>You remove the central computer mainboard from [holder].</span>")
+		if(7)
+			if(diff==FORWARD)
+				user.visible_message("[user] installs the peripherals control module into [holder].", "<span class='notice'>You install the peripherals control module into [holder].</span>")
+			else
+				user.visible_message("[user] unfastens the mainboard.", "<span class='notice'>You unfasten the mainboard.</span>")
+		if(8)
+			if(diff==FORWARD)
+				user.visible_message("[user] secures the peripherals control module.", "<span class='notice'>You secure the peripherals control module.</span>")
+			else
+				user.visible_message("[user] removes the peripherals control module from [holder].", "<span class='notice'>You remove the peripherals control module from [holder].</span>")
+		if(9)
+			if(diff==FORWARD)
+				user.visible_message("[user] installs the power cell into [holder].", "<span class='notice'>You install the power cell into [holder].</span>")
+			else
+				user.visible_message("[user] unfastens the peripherals control module.", "<span class='notice'>You unfasten the peripherals control module.</span>")
+		if(10)
+			if(diff==FORWARD)
+				user.visible_message("[user] secures the power cell.", "<span class='notice'>You secure the power cell.</span>")
+			else
+				user.visible_message("[user] prys the power cell from [holder].", "<span class='notice'>You pry the power cell from [holder].</span>")
+		if(11)
+			if(diff==FORWARD)
+				user.visible_message("[user] installs the internal armor layer to [holder].", "<span class='notice'>You install the internal armor layer to [holder].</span>")
+			else
+				user.visible_message("[user] unfastens the power cell.", "<span class='notice'>You unfasten the power cell.</span>")
+		if(12)
+			if(diff==FORWARD)
+				user.visible_message("[user] secures the internal armor layer.", "<span class='notice'>You secure the internal armor layer.</span>")
+			else
+				user.visible_message("[user] pries internal armor layer from [holder].", "<span class='notice'>You pry internal armor layer from [holder].</span>")
+		if(13)
+			if(diff==FORWARD)
+				user.visible_message("[user] welds the internal armor layer to [holder].", "<span class='notice'>You weld the internal armor layer to [holder].</span>")
+			else
+				user.visible_message("[user] unfastens the internal armor layer.", "<span class='notice'>You unfasten the internal armor layer.</span>")
+		if(14)
+			if(diff==FORWARD)
+				user.visible_message("[user] installs the external armor layer to [holder].", "<span class='notice'>You install the external reinforced armor layer to [holder].</span>")
+			else
+				user.visible_message("[user] cuts the internal armor layer from [holder].", "<span class='notice'>You cut the internal armor layer from [holder].</span>")
+		if(15)
+			if(diff==FORWARD)
+				user.visible_message("[user] secures the external armor layer.", "<span class='notice'>You secure the external reinforced armor layer.</span>")
+			else
+				user.visible_message("[user] pries the external armor layer from [holder].", "<span class='notice'>You pry the external armor layer from [holder].</span>")
+		if(16)
+			if(diff==FORWARD)
+				user.visible_message("[user] welds the external armor layer to [holder].", "<span class='notice'>You weld the external armor layer to [holder].</span>")
 			else
 				user.visible_message("[user] unfastens the external armor layer.", "<span class='notice'>You unfasten the external armor layer.</span>")
-				holder.icon_state = "odysseus14"
 	return TRUE

--- a/code/game/mecha/mecha_parts.dm
+++ b/code/game/mecha/mecha_parts.dm
@@ -10,9 +10,15 @@
 	flags_1 = CONDUCT_1
 
 /obj/item/mecha_parts/chassis
-	name="Mecha Chassis"
+	name = "Mecha Chassis"
 	icon_state = "backbone"
 	var/datum/construction/construct
+	var/construct_type
+
+/obj/item/mecha_parts/chassis/Initialize()
+	. = ..()
+	if(construct_type)
+		construct = new construct_type(src)
 
 /obj/item/mecha_parts/chassis/attackby(obj/item/W, mob/user, params)
 	if(!construct || !construct.action(W, user))
@@ -25,10 +31,7 @@
 
 /obj/item/mecha_parts/chassis/ripley
 	name = "\improper Ripley chassis"
-
-/obj/item/mecha_parts/chassis/ripley/Initialize()
-	. = ..()
-	construct = new /datum/construction/mecha/ripley_chassis(src)
+	construct_type = /datum/construction/unordered/mecha_chassis/ripley
 
 /obj/item/mecha_parts/part/ripley_torso
 	name = "\improper Ripley torso"
@@ -59,10 +62,7 @@
 
 /obj/item/mecha_parts/chassis/odysseus
 	name = "\improper Odysseus chassis"
-
-/obj/item/mecha_parts/chassis/odysseus/Initialize()
-	. = ..()
-	construct = new /datum/construction/mecha/odysseus_chassis(src)
+	construct_type = /datum/construction/unordered/mecha_chassis/odysseus
 
 /obj/item/mecha_parts/part/odysseus_head
 	name = "\improper Odysseus head"
@@ -98,10 +98,7 @@
 
 /obj/item/mecha_parts/chassis/gygax
 	name = "\improper Gygax chassis"
-
-/obj/item/mecha_parts/chassis/gygax/Initialize()
-	. = ..()
-	construct = new /datum/construction/mecha/gygax_chassis(src)
+	construct_type = /datum/construction/unordered/mecha_chassis/gygax
 
 /obj/item/mecha_parts/part/gygax_torso
 	name = "\improper Gygax torso"
@@ -144,10 +141,7 @@
 
 /obj/item/mecha_parts/chassis/durand
 	name = "\improper Durand chassis"
-
-/obj/item/mecha_parts/chassis/durand/Initialize()
-	. = ..()
-	construct = new /datum/construction/mecha/durand_chassis(src)
+	construct_type = /datum/construction/unordered/mecha_chassis/durand
 
 /obj/item/mecha_parts/part/durand_torso
 	name = "\improper Durand torso"
@@ -188,21 +182,15 @@
 ////////// Firefighter
 
 /obj/item/mecha_parts/chassis/firefighter
-	name = "Firefighter chassis"
-
-/obj/item/mecha_parts/chassis/firefighter/Initialize()
-	. = ..()
-	construct = new /datum/construction/mecha/firefighter_chassis(src)
+	name = "\improper Firefighter chassis"
+	construct_type = /datum/construction/unordered/mecha_chassis/firefighter
 
 
 ////////// HONK
 
 /obj/item/mecha_parts/chassis/honker
 	name = "\improper H.O.N.K chassis"
-
-/obj/item/mecha_parts/chassis/honker/Initialize()
-	. = ..()
-	construct = new /datum/construction/mecha/honker_chassis(src)
+	construct_type = /datum/construction/unordered/mecha_chassis/honker
 
 /obj/item/mecha_parts/part/honker_torso
 	name = "\improper H.O.N.K torso"
@@ -239,10 +227,7 @@
 
 /obj/item/mecha_parts/chassis/phazon
 	name = "\improper Phazon chassis"
-
-/obj/item/mecha_parts/chassis/phazon/Initialize()
-	. = ..()
-	construct = new /datum/construction/mecha/phazon_chassis(src)
+	construct_type = /datum/construction/unordered/mecha_chassis/phazon
 
 /obj/item/mecha_parts/part/phazon_torso
 	name="\improper Phazon torso"


### PR DESCRIPTION
I don't know _why_, but I refactored mech construction datums.

The tools are now checked by qualities instead of typepaths, the steps are no longer hardcoded, the amount of copypaste is greatly reduced and the code is less batshit insane.

This also fixes a bug with Phason construction consuming an entire stack, no matter how large or small, instead of just one bluespace crystal.