### PR TITLE
Fixes ai transform being picky

### DIFF
--- a/code/modules/mob/transform_procs.dm
+++ b/code/modules/mob/transform_procs.dm
@@ -344,8 +344,8 @@
 			landmark_loc += sloc.loc
 
 	if(!landmark_loc.len)
-		message_admins("[src] cannot be made an AI as there are no valid spawn points. Yell at a mapper!")
-		return
+		message_admins("Could not find ai landmark for [src]. Yell at a mapper! We are spawning them at their current location.")
+		landmark_loc += loc
 
 	if(client)
 		stop_sound_channel(CHANNEL_LOBBYMUSIC)


### PR DESCRIPTION
The fact ai transform even forces them to an ai loc is iffy as the admin might want them to be an ai at their current location, but this is more sane.

This stupid bullshit has been getting in the way of fixing the byond image hang bugs.