### PR TITLE
Transference potions rename the mob to just your name

### DIFF
--- a/code/modules/research/xenobiology/xenobiology.dm
+++ b/code/modules/research/xenobiology/xenobiology.dm
@@ -661,7 +661,7 @@
 	user.death()
 	to_chat(SM, "<span class='notice'>In a quick flash, you feel your consciousness flow into [SM]!</span>")
 	to_chat(SM, "<span class='warning'>You are now [SM]. Your allegiances, alliances, and role is still the same as it was prior to consciousness transfer!</span>")
-	SM.name = "[SM.name] as [user.real_name]"
+	SM.name = "[user.real_name]"
 	qdel(src)
 
 /obj/item/slimepotion/slime/steroid


### PR DESCRIPTION
:cl: coiax
add: Transference potions now just rename the mob that you are transferring into with your name, rather than your name plus the old name of the mob.
/:cl:

So instead of "Braxton Cherry as parrot", it'll just be "Braxton Cherry"
now. Polymorphing keeps your name, this has always bugged me as ugly and
unneeded.