### PR TITLE
Prevents docking ports from being thrown away by chasms

### DIFF
--- a/code/datums/components/chasm.dm
+++ b/code/datums/components/chasm.dm
@@ -7,6 +7,7 @@
 	var/static/list/falling_atoms = list() // Atoms currently falling into chasms
 	var/static/list/forbidden_types = typecacheof(list(
 		/obj/singularity,
+		/obj/docking_port,
 		/obj/structure/lattice,
 		/obj/structure/stone_tile,
 		/obj/item/projectile,


### PR DESCRIPTION
:cl: Naksu
fix: Chasms no longer eat shuttle docking ports, rendering them unusable and unresponsive
/:cl:

[why]: 

This actually happened
