### PR TITLE
Gold Slime Extract Entity Spawn Reduction

### DIFF
--- a/code/modules/reagents/chemistry/recipes/slime_extracts.dm
+++ b/code/modules/reagents/chemistry/recipes/slime_extracts.dm
@@ -116,7 +116,7 @@
 
 /datum/chemical_reaction/slime/slimemobspawn/proc/summon_mobs(datum/reagents/holder, turf/T)
 	T.visible_message("<span class='danger'>The slime extract begins to vibrate violently!</span>")
-	addtimer(CALLBACK(src, .proc/chemical_mob_spawn, holder, 5, "Gold Slime", HOSTILE_SPAWN), 50)
+	addtimer(CALLBACK(src, .proc/chemical_mob_spawn, holder, 1, "Gold Slime", HOSTILE_SPAWN), 50)
 
 /datum/chemical_reaction/slime/slimemobspawn/lesser
 	name = "Slime Crit Lesser"
@@ -125,7 +125,7 @@
 
 /datum/chemical_reaction/slime/slimemobspawn/lesser/summon_mobs(datum/reagents/holder, turf/T)
 	T.visible_message("<span class='danger'>The slime extract begins to vibrate violently!</span>")
-	addtimer(CALLBACK(src, .proc/chemical_mob_spawn, holder, 3, "Lesser Gold Slime", HOSTILE_SPAWN, "neutral"), 50)
+	addtimer(CALLBACK(src, .proc/chemical_mob_spawn, holder, 1, "Lesser Gold Slime", HOSTILE_SPAWN, "neutral"), 50)
 
 /datum/chemical_reaction/slime/slimemobspawn/friendly
 	name = "Slime Crit Friendly"


### PR DESCRIPTION
Reduced hostile and neutral entity spawns from gold slime blood and plasma to 1 entity per reaction.

:cl: Xenobio Gold Slime Extract Entity Spawn Reduction
balance: Reduced hostile and neutral entity spawns from gold slime blood and plasma to 1 entity per reaction.
/:cl:

This simply reduces the number of mobs spawned from gold slime extracts. Typically by the time gold slimes are being produced, the slime processor has been upgraded to T3 or T4, producing 3 or 4 slime extracts per slime. So you could get up to 12 neutral mobs, or 15 hostile ones per gold slime.