### PR TITLE
Fixes process_dead diseases not processing at all

### DIFF
--- a/code/modules/mob/living/carbon/life.dm
+++ b/code/modules/mob/living/carbon/life.dm
@@ -250,7 +250,7 @@
 		if(prob(D.infectivity))
 			D.spread()
 
-		if(stat != DEAD && !D.process_dead)
+		if(stat != DEAD || D.process_dead)
 			D.stage_act()
 
 //todo generalize this and move hud out


### PR DESCRIPTION
Fixes first half of #34311

~~process_dead diseases are supposed to work in both corpses and living mobs, not just corpses.~~
They weren't being processed at all.