### PR TITLE
Fixes noslip shoes not showing up in nuke ops uplink

### DIFF
--- a/code/modules/research/techweb/all_nodes.dm
+++ b/code/modules/research/techweb/all_nodes.dm
@@ -846,11 +846,11 @@
 /datum/techweb_node/syndicate_basic/New()		//Crappy way of making syndicate gear decon supported until there's another way.
 	. = ..()
 	boost_item_paths = list()
-	for(var/cat in GLOB.uplink_items)
-		var/list/l = cat
-		for(var/i in l)
-			var/datum/uplink_item/UI = i
-			boost_item_paths[UI.item] = 0	//allows deconning to unlock.
+	for(var/path in GLOB.uplink_items)
+		var/datum/uplink_item/UI = new path
+		if(!UI.item)
+			continue
+		boost_item_paths[UI.item] = 0	//allows deconning to unlock.
 
 //HELPERS
 /proc/total_techweb_exports()

--- a/code/modules/uplink/uplink_items.dm
+++ b/code/modules/uplink/uplink_items.dm
@@ -96,11 +96,6 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 	to_chat(user, "[A] materializes onto the floor.")
 	return A
 
-/datum/uplink_item/Destroy()
-	if(src in GLOB.uplink_items)
-		GLOB.uplink_items -= src	//Take us out instead of leaving a null!
-	return ..()
-
 //Discounts (dynamically filled above)
 /datum/uplink_item/discounts
 	category = "Discounted Gear"

--- a/code/modules/uplink/uplink_items.dm
+++ b/code/modules/uplink/uplink_items.dm
@@ -9,12 +9,12 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 		if(!I.item)
 			continue
 		if(I.include_modes.len)
-			if(!gamemode && SSticker && SSticker.mode && !(SSticker.mode.type in I.include_modes))
+			if(!gamemode && SSticker.mode && !(SSticker.mode.type in I.include_modes))
 				continue
 			if(gamemode && !(gamemode in I.include_modes))
 				continue
 		if(I.exclude_modes.len)
-			if(!gamemode && SSticker && SSticker.mode && (SSticker.mode.type in I.exclude_modes))
+			if(!gamemode && SSticker.mode && (SSticker.mode.type in I.exclude_modes))
 				continue
 			if(gamemode && (gamemode in I.exclude_modes))
 				continue


### PR DESCRIPTION
Fixes #35602

Basically this allows uplink_items with the same name to exist so long as only one ends up on a given uplink (i.e. they have different gamemode requirements).