### PR TITLE
Fixes near_camera runtime

### DIFF
--- a/code/game/machinery/camera/tracking.dm
+++ b/code/game/machinery/camera/tracking.dm
@@ -118,14 +118,14 @@
 
 /proc/near_camera(mob/living/M)
 	if (!isturf(M.loc))
-		return 0
+		return FALSE
 	if(issilicon(M))
 		var/mob/living/silicon/S = M
-		if((!QDELETED(S.builtInCamera) || !S.builtInCamera.can_use()) && !GLOB.cameranet.checkCameraVis(M))
-			return 0
+		if((QDELETED(S.builtInCamera) || !S.builtInCamera.can_use()) && !GLOB.cameranet.checkCameraVis(M))
+			return FALSE
 	else if(!GLOB.cameranet.checkCameraVis(M))
-		return 0
-	return 1
+		return FALSE
+	return TRUE
 
 /obj/machinery/camera/attack_ai(mob/living/silicon/ai/user)
 	if (!istype(user))


### PR DESCRIPTION
```
runtime error: 
[01:58:36]Cannot execute null.can use().
[01:58:36]proc name: near camera (/proc/near_camera)
[01:58:36]  source file: tracking.dm,124
[01:58:36]  usr: LegendBot27 (/mob/living/silicon/ai)
[01:58:36]  src: null
[01:58:36]  usr.loc: the floor (150,32,2) (/turf/open/floor/circuit)
[01:58:36]  call stack:
[01:58:36]near camera(Bo Bubutron (/mob/living/silicon/robot))
[01:58:36]Bo Bubutron (/mob/living/silicon/robot): can track(LegendBot27 (/mob/living/silicon/ai))
[01:58:36]LegendBot27 (/mob/living/silicon/ai): trackable mobs()
[01:58:36]LegendBot27 (/mob/living/silicon/ai): Topic("src=\[mob_561];track=Jack%20Da...", /list (/list))
[01:58:36]Shark-sie (/client): Topic("src=\[mob_561];track=Jack%20Da...", /list (/list), LegendBot27 (/mob/living/silicon/ai))
[01:58:36]Shark-sie (/client): Topic("src=\[mob_561];track=Jack%20Da...", /list (/list), LegendBot27 (/mob/living/silicon/ai))
```