### PR TITLE
Improved plastic surgery; pick the target name

### DIFF
--- a/code/modules/surgery/plastic_surgery.dm
+++ b/code/modules/surgery/plastic_surgery.dm
@@ -8,20 +8,29 @@
 	name = "reshape face"
 	implements = list(/obj/item/scalpel = 100, /obj/item/kitchen/knife = 50, TOOL_WIRECUTTER = 35)
 	time = 64
+	var/chosen_name
 
 /datum/surgery_step/reshape_face/preop(mob/user, mob/living/carbon/target, target_zone, obj/item/tool, datum/surgery/surgery)
+	chosen_name = stripped_input(user, "Enter the name that [target] will have, post-surgery.", "Input a name", target.real_name, MAX_NAME_LEN)
+
+	if(QDELETED(tool) || QDELETED(target) || QDELETED(user) || !chosen_name)
+		return -1 // FAILURE
+
 	user.visible_message("[user] begins to alter [target]'s appearance.", "<span class='notice'>You begin to alter [target]'s appearance...</span>")
 
 /datum/surgery_step/reshape_face/success(mob/user, mob/living/carbon/target, target_zone, obj/item/tool, datum/surgery/surgery)
-	if(target.has_trait(TRAIT_DISFIGURED, TRAIT_GENERIC))
-		target.remove_trait(TRAIT_DISFIGURED, TRAIT_GENERIC)
-		user.visible_message("[user] successfully restores [target]'s appearance!", "<span class='notice'>You successfully restore [target]'s appearance.</span>")
-	else
-		var/oldname = target.real_name
-		target.real_name = target.dna.species.random_name(target.gender,1)
-		var/newname = target.real_name	//something about how the code handles names required that I use this instead of target.real_name
-		user.visible_message("[user] alters [oldname]'s appearance completely, [target.p_they()] is now [newname]!", "<span class='notice'>You alter [oldname]'s appearance completely, [target.p_they()] is now [newname].</span>")
+	var/oldname = target.real_name
+	user.visible_message("[user] alters [oldname]'s appearance completely, [target.p_they()] is now [chosen_name]!", "<span class='notice'>You alter [oldname]'s appearance completely, [target.p_they()] is now [chosen_name].</span>")
+
+	target.fully_replace_character_name(null, chosen_name)
+
 	if(ishuman(target))
 		var/mob/living/carbon/human/H = target
 		H.sec_hud_set_ID()
 	return 1
+
+/datum/surgery_step/reshape_face/failure(mob/user, mob/living/carbon/target, target_zone, obj/item/tool, datum/surgery/surgery)
+	..()
+	// Screw up, and they get a random name instead.
+	chosen_name = target.dna.species.random_name(target.gender,1)
+	. = success(user, target, target_zone, tool, surgery)


### PR DESCRIPTION
:cl: coiax
add: During the "reshape face" step of plastic surgery, the surgeon can
pick the new name that the person undergoing surgery will gain. Screwing
up will give them a random name instead.
del: Plastic surgery will no longer fix disfigurement.
/:cl:

What horrors will unscrupulous surgeons do to people? Will Abductors
just start renaming all of their subjects to "Subject Y", "Subject Z", "Subject Ran-out-of-letters"