### PR TITLE
Fix for invisible heartboxes

### DIFF
--- a/code/game/objects/items/storage/fancy.dm
+++ b/code/game/objects/items/storage/fancy.dm
@@ -291,7 +291,7 @@
 	desc = "A heart-shaped box for holding tiny chocolates."
 	icon = 'icons/obj/food/containers.dmi'
 	icon_state = "heartbox"
-	icon_type = "chocolate"
+	icon_type = "heart"
 	lefthand_file = 'icons/mob/inhands/misc/food_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/misc/food_righthand.dmi'
 	storage_slots = 8


### PR DESCRIPTION
Accidentally left out a change to fix this in the original PR. Either it didn't save or I didn't add the commit, or both.
This should make heartboxes full of chocolate appear normally when opened again.