### PR TITLE
Disables clogged vents until it can be reworked

### DIFF
--- a/code/modules/events/vent_clog.dm
+++ b/code/modules/events/vent_clog.dm
@@ -2,7 +2,7 @@
 	name = "Clogged Vents"
 	typepath = /datum/round_event/vent_clog
 	weight = 25
-	max_occurrences = 1
+	max_occurrences = 0
 	min_players = 50
 
 /datum/round_event/vent_clog


### PR DESCRIPTION
This is ending rounds on Bagil and causing tunguska meteor-tier mayhem often enough to require a rework. @Iamgoofball says they'll get on it after they're done with monk.

:cl: Naksu
tweak: The clogged vents event has been removed for pressing ceremonial reasons
/:cl: