### PR TITLE
Cycle-link airlocks on pirate ship

### DIFF
--- a/_maps/templates/pirate_ship.dmm
+++ b/_maps/templates/pirate_ship.dmm
@@ -649,6 +649,7 @@
 /area/shuttle/pirate)
 "bF" = (
 /obj/machinery/door/airlock/external{
+	cyclelinkeddir = 4;
 	id_tag = "pirateportexternal";
 	locked = 1
 	},
@@ -681,7 +682,9 @@
 /turf/open/floor/plating,
 /area/shuttle/pirate)
 "bH" = (
-/obj/machinery/door/airlock/external,
+/obj/machinery/door/airlock/external{
+	cyclelinkeddir = 8
+	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
 /area/shuttle/pirate)
@@ -817,7 +820,9 @@
 /turf/open/floor/plasteel/floorgrime,
 /area/shuttle/pirate)
 "bU" = (
-/obj/machinery/door/airlock/external,
+/obj/machinery/door/airlock/external{
+	cyclelinkeddir = 4
+	},
 /turf/open/floor/plating,
 /area/shuttle/pirate)
 "bV" = (
@@ -826,6 +831,7 @@
 /area/shuttle/pirate)
 "bW" = (
 /obj/machinery/door/airlock/external{
+	cyclelinkeddir = 8;
 	id_tag = "piratestarboardexternal";
 	locked = 1
 	},


### PR DESCRIPTION
:cl:
fix: External airlocks of the pirate shuttle are now cycle-linked.
/:cl:

Port and starboard doors set to link. Makes entering/exiting (in the not-dragging-loot case) easier.