### PR TITLE
Meteor shield emag feedback and typo fix

### DIFF
--- a/code/modules/research/server.dm
+++ b/code/modules/research/server.dm
@@ -167,4 +167,4 @@
 		return
 	playsound(src, "sparks", 75, 1)
 	obj_flags |= EMAGGED
-	to_chat(user, "<span class='notice'>You you disable the security protocols.</span>")
+	to_chat(user, "<span class='notice'>You disable the security protocols.</span>")

--- a/code/modules/station_goals/shield.dm
+++ b/code/modules/station_goals/shield.dm
@@ -170,9 +170,10 @@
 	if(active && (obj_flags & EMAGGED))
 		change_meteor_chance(0.5)
 
-/obj/machinery/satellite/meteor_shield/emag_act()
+/obj/machinery/satellite/meteor_shield/emag_act(mob/user)
 	if(obj_flags & EMAGGED)
 		return
 	obj_flags |= EMAGGED
+	to_chat(user, "<span class='notice'>You scramble the satellite's controller, increasing the chance of meteor strikes.</span>")
 	if(active)
 		change_meteor_chance(2)


### PR DESCRIPTION
:cl: Denton
tweak: Emagging meteor shield satellites now shows you a message.
spellcheck: Fixed a typo when emagging RnD servers.
/:cl:

I added a feedback message to when players emag meteor shield sats and removed a "you" in the RnD server emag message.

Closes: #35628