### PR TITLE
Fixes some tooltip runtimes

### DIFF
--- a/code/_onclick/hud/action_button.dm
+++ b/code/_onclick/hud/action_button.dm
@@ -108,7 +108,8 @@
 
 
 /obj/screen/movable/action_button/MouseEntered(location,control,params)
-	openToolTip(usr,src,params,title = name,content = desc,theme = actiontooltipstyle)
+	if(!QDELETED(src))
+		openToolTip(usr,src,params,title = name,content = desc,theme = actiontooltipstyle)
 
 
 /obj/screen/movable/action_button/MouseExited()

--- a/code/_onclick/hud/alert.dm
+++ b/code/_onclick/hud/alert.dm
@@ -101,7 +101,8 @@
 
 
 /obj/screen/alert/MouseEntered(location,control,params)
-	openToolTip(usr,src,params,title = name,content = desc,theme = alerttooltipstyle)
+	if(!QDELETED(src))
+		openToolTip(usr,src,params,title = name,content = desc,theme = alerttooltipstyle)
 
 
 /obj/screen/alert/MouseExited()

--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -734,7 +734,7 @@ GLOBAL_VAR_INIT(rpg_loot_items, FALSE)
 		openToolTip(user,src,params,title = name,content = "[desc]<br><b>Force:</b> [force_string]",theme = "")
 
 /obj/item/MouseEntered(location, control, params)
-	if((item_flags & IN_INVENTORY) && usr.client.prefs.enable_tips)
+	if((item_flags & IN_INVENTORY) && usr.client.prefs.enable_tips && !QDELETED(src))
 		var/timedelay = usr.client.prefs.tip_delay/100
 		var/user = usr
 		tip_timer = addtimer(CALLBACK(src, .proc/openTip, location, control, params, user), timedelay, TIMER_STOPPABLE)//timer takes delay in deciseconds, but the pref is in milliseconds. dividing by 100 converts it.


### PR DESCRIPTION
Just some sanity.

```
[12:15:52] Runtime in unsorted.dm, line 1246: addtimer called with a callback assigned to a qdeleted object
proc name: stack trace (/proc/stack_trace)
usr: Gish-Bokeeus (damous) (/mob/living/carbon/human)
usr.loc: The volcanic floor (114,37,5) (/turf/open/floor/plating/asteroid/basalt/lava_land_surface)
src: null
call stack:
stack trace("addtimer called with a callbac...")
addtimer(/datum/callback (/datum/callback), 5, 8)
the spear (Wielded) - offhand (/obj/item/twohanded/offhand): MouseEntered(null, "mapwindow.map", "icon-x=7;icon-y=16;screen-loc=...")
```