### PR TITLE
Removes on_mob_turn, on_mob_move and intercept_user_move, speeding up movement

### DIFF
--- a/code/game/objects/items/RCL.dm
+++ b/code/game/objects/items/RCL.dm
@@ -85,7 +85,7 @@
 /obj/item/twohanded/rcl/Destroy()
 	QDEL_NULL(loaded)
 	last = null
-	setActive(FALSE, null)
+	setActive(FALSE, null) // setactive(FALSE) removes mobhook
 	return ..()
 
 /obj/item/twohanded/rcl/update_icon()

--- a/code/game/objects/items/RCL.dm
+++ b/code/game/objects/items/RCL.dm
@@ -20,6 +20,7 @@
 	var/ghetto = FALSE
 	lefthand_file = 'icons/mob/inhands/equipment/tools_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/equipment/tools_righthand.dmi'
+	var/datum/component/mobhook
 
 /obj/item/twohanded/rcl/attackby(obj/item/W, mob/user)
 	if(istype(W, /obj/item/stack/cable_coil))
@@ -84,7 +85,7 @@
 /obj/item/twohanded/rcl/Destroy()
 	QDEL_NULL(loaded)
 	last = null
-	active = FALSE
+	setActive(FALSE, null)
 	return ..()
 
 /obj/item/twohanded/rcl/update_icon()
@@ -115,18 +116,19 @@
 			QDEL_NULL(loaded)
 			loaded = null
 		unwield(user)
-		active = wielded
+		setActive(wielded, user)
 		return TRUE
 	return FALSE
 
 /obj/item/twohanded/rcl/dropped(mob/wearer)
 	..()
-	active = FALSE
+	if(mobhook)
+		setActive(FALSE, mobhook.parent)
 	last = null
 
 /obj/item/twohanded/rcl/attack_self(mob/user)
 	..()
-	active = wielded
+	setActive(wielded, user)
 	if(!active)
 		last = null
 	else if(!last)
@@ -135,9 +137,15 @@
 				last = C
 				break
 
-/obj/item/twohanded/rcl/on_mob_move(direct, mob/user)
-	if(active)
-		trigger(user)
+/obj/item/twohanded/rcl/proc/setActive(toggle, mob/user)
+	active = toggle
+	if (active && user)
+		if (mobhook && mobhook.parent != user)
+			QDEL_NULL(mobhook)
+		if (!mobhook)
+			mobhook = user.AddComponent(/datum/component/redirect, list(COMSIG_MOVABLE_MOVED), CALLBACK(src, .proc/trigger, user))
+	else
+		QDEL_NULL(mobhook)
 
 /obj/item/twohanded/rcl/proc/trigger(mob/user)
 	if(!isturf(user.loc))
@@ -148,7 +156,7 @@
 
 	if(prob(2) && ghetto) //Give ghetto RCLs a 2% chance to jam, requiring it to be reactviated manually.
 		to_chat(user, "<span class='warning'>[src]'s wires jam!</span>")
-		active = FALSE
+		setActive(FALSE, user)
 		return
 	else
 		if(last)

--- a/code/game/objects/objs.dm
+++ b/code/game/objects/objs.dm
@@ -202,15 +202,6 @@
 /obj/proc/check_uplink_validity()
 	return 1
 
-/obj/proc/on_mob_move(dir, mob, oldLoc, forced)
-	return
-
-/obj/proc/on_mob_turn(dir, mob)
-	return
-
-/obj/proc/intercept_user_move(dir, mob, newLoc, oldLoc)
-	return
-
 /obj/vv_get_dropdown()
 	. = ..()
 	.["Delete all of type"] = "?_src_=vars;[HrefToken()];delall=[REF(src)]"

--- a/code/modules/clothing/spacesuits/flightsuit.dm
+++ b/code/modules/clothing/spacesuits/flightsuit.dm
@@ -97,16 +97,19 @@
 
 	var/atom/movable/cached_pull		//recipe for disaster again.
 	var/afterForceMove = FALSE
+	var/datum/component/mobhook
 
 /obj/item/device/flightpack/proc/changeWearer(mob/changeto)
 	if(wearer)
 		LAZYREMOVE(wearer.user_movement_hooks, src)
 	wearer = null
+	QDEL_NULL(mobhook)
 	cached_pull = null
 	if(istype(changeto))
 		wearer = changeto
 		LAZYADD(wearer.user_movement_hooks, src)
 		cached_pull = changeto.pulling
+		mobhook = changeto.AddComponent(/datum/component/redirect, list(COMSIG_MOVABLE_MOVED), CALLBACK(src, .proc/on_mob_move, changeto))
 
 /obj/item/device/flightpack/Initialize()
 	ion_trail = new
@@ -205,27 +208,6 @@
 	momentum_y = CLAMP(momentum_y + amounty, -momentum_max, momentum_max)
 	calculate_momentum_speed()
 
-/obj/item/device/flightpack/intercept_user_move(dir, mob, newLoc, oldLoc)
-	if(!flight)
-		return
-	var/momentum_increment = momentum_gain
-	if(boost)
-		momentum_increment = boost_power
-	if(brake)
-		momentum_increment = 0
-	if(!gravity && !pressure)
-		momentum_increment -= 10
-	switch(dir)
-		if(NORTH)
-			adjust_momentum(0, momentum_increment)
-		if(SOUTH)
-			adjust_momentum(0, -momentum_increment)
-		if(EAST)
-			adjust_momentum(momentum_increment, 0)
-		if(WEST)
-			adjust_momentum(-momentum_increment, 0)
-	return ..()
-
 //The wearer has momentum left. Move them and take some away, while negating the momentum that moving the wearer would gain. Or force the wearer to lose control if they are incapacitated.
 /obj/item/device/flightpack/proc/momentum_drift()
 	if(!flight || !wearer || (momentum_speed == 0))
@@ -252,7 +234,7 @@
 	if(prob(emp_damage * 15))
 		step(wearer, pick(GLOB.alldirs))
 
-/obj/item/device/flightpack/on_mob_move(dir, mob/mob, turf/oldLoc, forced)
+/obj/item/device/flightpack/proc/on_mob_move(mob/mob, turf/oldLoc, dir, forced)
 	if(forced)
 		if(cached_pull && istype(oldLoc) && (get_dist(oldLoc, loc) <= 1) && !oldLoc.density)
 			cached_pull.forceMove(oldLoc)
@@ -270,7 +252,22 @@
 		afterForceMove = FALSE
 	if(flight)
 		ion_trail.generate_effect()
-	. = ..()
+		var/momentum_increment = momentum_gain
+		if(boost)
+			momentum_increment = boost_power
+		if(brake)
+			momentum_increment = 0
+		if(!gravity && !pressure)
+			momentum_increment -= 10
+		switch(dir)
+			if(NORTH)
+				adjust_momentum(0, momentum_increment)
+			if(SOUTH)
+				adjust_momentum(0, -momentum_increment)
+			if(EAST)
+				adjust_momentum(momentum_increment, 0)
+			if(WEST)
+				adjust_momentum(-momentum_increment, 0)
 
 //Make the wearer lose some momentum.
 /obj/item/device/flightpack/proc/momentum_decay()

--- a/code/modules/clothing/spacesuits/flightsuit.dm
+++ b/code/modules/clothing/spacesuits/flightsuit.dm
@@ -183,6 +183,7 @@
 	QDEL_NULL(part_laser)
 	QDEL_NULL(part_bin)
 	QDEL_NULL(ion_trail)
+	QDEL_NULL(mobhook)
 	STOP_PROCESSING(SSflightpacks, src)
 	. = ..()
 

--- a/code/modules/clothing/spacesuits/hardsuit.dm
+++ b/code/modules/clothing/spacesuits/hardsuit.dm
@@ -585,6 +585,7 @@
 	armor = list("melee" = 30, "bullet" = 5, "laser" = 5, "energy" = 0, "bomb" = 50, "bio" = 100, "rad" = 100, "fire" = 100, "acid" = 75)
 	item_color = "ancient"
 	resistance_flags = FIRE_PROOF
+	var/datum/component/mobhook
 
 /obj/item/clothing/suit/space/hardsuit/ancient
 	name = "prototype RIG hardsuit"
@@ -596,8 +597,9 @@
 	helmettype = /obj/item/clothing/head/helmet/space/hardsuit/ancient
 	resistance_flags = FIRE_PROOF
 	var/footstep = 1
+	var/datum/component/mobhook
 
-/obj/item/clothing/suit/space/hardsuit/ancient/on_mob_move()
+/obj/item/clothing/suit/space/hardsuit/ancient/proc/on_mob_move()
 	var/mob/living/carbon/human/H = loc
 	if(!istype(H) || H.wear_suit != src)
 		return
@@ -606,6 +608,20 @@
 		footstep = 0
 	else
 		footstep++
+
+/obj/item/clothing/suit/space/hardsuit/ancient/equipped(mob/user, slot)
+	. = ..()
+	if (slot == slot_wear_suit)
+		if (mobhook && mobhook.parent != user)
+			QDEL_NULL(mobhook)
+		if (!mobhook)
+			mobhook = user.AddComponent(/datum/component/redirect, list(COMSIG_MOVABLE_MOVED), CALLBACK(src, .proc/on_mob_move))
+	else
+		QDEL_NULL(mobhook)
+
+/obj/item/clothing/suit/space/hardsuit/ancient/dropped()
+	. = ..()
+	QDEL_NULL(mobhook)
 
 /////////////SHIELDED//////////////////////////////////
 

--- a/code/modules/clothing/spacesuits/hardsuit.dm
+++ b/code/modules/clothing/spacesuits/hardsuit.dm
@@ -623,6 +623,10 @@
 	. = ..()
 	QDEL_NULL(mobhook)
 
+/obj/item/clothing/suit/space/hardsuit/ancient/Destroy()
+	QDEL_NULL(mobhook) // mobhook is not our component
+	return ..()
+
 /////////////SHIELDED//////////////////////////////////
 
 /obj/item/clothing/suit/space/hardsuit/shielded

--- a/code/modules/fields/fields.dm
+++ b/code/modules/fields/fields.dm
@@ -292,6 +292,7 @@
 /obj/item/device/multitool/field_debug/Destroy()
 	STOP_PROCESSING(SSobj, src)
 	QDEL_NULL(current)
+	QDEL_NULL(mobhook)
 	return ..()
 
 /obj/item/device/multitool/field_debug/proc/setup_debug_field()

--- a/code/modules/fields/fields.dm
+++ b/code/modules/fields/fields.dm
@@ -283,15 +283,16 @@
 	var/field_type = /datum/proximity_monitor/advanced/debug
 	var/operating = FALSE
 	var/datum/proximity_monitor/advanced/current = null
+	var/datum/component/mobhook
 
-/obj/item/device/multitool/field_debug/New()
+/obj/item/device/multitool/field_debug/Initialize()
+	. = ..()
 	START_PROCESSING(SSobj, src)
-	..()
 
 /obj/item/device/multitool/field_debug/Destroy()
 	STOP_PROCESSING(SSobj, src)
 	QDEL_NULL(current)
-	..()
+	return ..()
 
 /obj/item/device/multitool/field_debug/proc/setup_debug_field()
 	var/list/new_params = field_params.Copy()
@@ -301,12 +302,18 @@
 /obj/item/device/multitool/field_debug/attack_self(mob/user)
 	operating = !operating
 	to_chat(user, "You turn [src] [operating? "on":"off"].")
+	QDEL_NULL(mobhook)
 	if(!istype(current) && operating)
+		mobhook = user.AddComponent(/datum/component/redirect, list(COMSIG_MOVABLE_MOVED), CALLBACK(src, .proc/on_mob_move))
 		setup_debug_field()
 	else if(!operating)
 		QDEL_NULL(current)
 
-/obj/item/device/multitool/field_debug/on_mob_move()
+/obj/item/device/multitool/field_debug/dropped()
+	. = ..()
+	QDEL_NULL(mobhook)
+
+/obj/item/device/multitool/field_debug/proc/on_mob_move()
 	check_turf(get_turf(src))
 
 /obj/item/device/multitool/field_debug/process()

--- a/code/modules/mob/living/carbon/carbon_movement.dm
+++ b/code/modules/mob/living/carbon/carbon_movement.dm
@@ -56,13 +56,3 @@
 			nutrition -= HUNGER_FACTOR/10
 			if(m_intent == MOVE_INTENT_RUN)
 				nutrition -= HUNGER_FACTOR/10
-
-/mob/living/carbon/Moved(oldLoc, Dir)
-	. = ..()
-	for(var/obj/O in internal_organs)
-		O.on_mob_move(dir, src, oldLoc)
-
-/mob/living/carbon/setDir(newdir)
-	. = ..()
-	for(var/obj/O in internal_organs)
-		O.on_mob_turn(newdir, src)

--- a/code/modules/mob/mob_movement.dm
+++ b/code/modules/mob/mob_movement.dm
@@ -111,24 +111,9 @@
 		if(mob.throwing)
 			mob.throwing.finalize(FALSE)
 
-	if(LAZYLEN(mob.user_movement_hooks))
-		for(var/obj/O in mob.user_movement_hooks)
-			O.intercept_user_move(direct, mob, n, oldloc)
-
 	var/atom/movable/P = mob.pulling
 	if(P && !ismob(P) && P.density)
 		mob.dir = turn(mob.dir, 180)
-
-/mob/Moved(oldLoc, dir, Forced = FALSE)
-	. = ..()
-	for(var/obj/O in contents)
-		O.on_mob_move(dir, src, oldLoc, Forced)
-
-/mob/setDir(newDir)
-	. = ..()
-	for(var/obj/O in contents)
-		O.on_mob_turn(newDir, src)
-
 
 ///Process_Grab()
 ///Called by client/Move()

--- a/code/modules/projectiles/guns/beam_rifle.dm
+++ b/code/modules/projectiles/guns/beam_rifle.dm
@@ -75,6 +75,7 @@
 	var/static/image/drained_overlay = image(icon = 'icons/obj/guns/energy.dmi', icon_state = "esniper_empty")
 
 	var/datum/action/item_action/zoom_lock_action/zoom_lock_action
+	var/datum/component/mobhook
 
 /obj/item/gun/energy/beam_rifle/debug
 	delay = 0
@@ -258,7 +259,7 @@
 		delay_penalty(difference * aiming_time_increase_angle_multiplier)
 		lastangle = angle
 
-/obj/item/gun/energy/beam_rifle/on_mob_move()
+/obj/item/gun/energy/beam_rifle/proc/on_mob_move()
 	check_user()
 	if(aiming)
 		delay_penalty(aiming_time_increase_user_movement)
@@ -284,12 +285,14 @@
 	if(user == current_user)
 		return
 	stop_aiming(current_user)
+	QDEL_NULL(mobhook)
 	if(istype(current_user))
 		LAZYREMOVE(current_user.mousemove_intercept_objects, src)
 		current_user = null
 	if(istype(user))
 		current_user = user
 		LAZYADD(current_user.mousemove_intercept_objects, src)
+		mobhook = user.AddComponent(/datum/component/redirect, list(COMSIG_MOVABLE_MOVED), CALLBACK(src, .proc/on_mob_move))
 
 /obj/item/gun/energy/beam_rifle/onMouseDrag(src_object, over_object, src_location, over_location, params, mob)
 	if(aiming)

--- a/code/modules/projectiles/guns/beam_rifle.dm
+++ b/code/modules/projectiles/guns/beam_rifle.dm
@@ -190,6 +190,7 @@
 	STOP_PROCESSING(SSfastprocess, src)
 	set_user(null)
 	QDEL_LIST(current_tracers)
+	QDEL_NULL(mobhook)
 	return ..()
 
 /obj/item/gun/energy/beam_rifle/emp_act(severity)

--- a/code/modules/surgery/organs/eyes.dm
+++ b/code/modules/surgery/organs/eyes.dm
@@ -239,6 +239,10 @@
 	. = ..()
 	QDEL_NULL(mobhook)
 
+/obj/item/organ/eyes/robotic/glow/Destroy()
+	QDEL_NULL(mobhook) // mobhook is not our component
+	return ..()
+
 /obj/item/organ/eyes/robotic/glow/proc/activate(silent = FALSE)
 	start_visuals()
 	if(!silent)

--- a/code/modules/surgery/organs/eyes.dm
+++ b/code/modules/surgery/organs/eyes.dm
@@ -161,6 +161,7 @@
 	var/list/obj/effect/abstract/eye_lighting/eye_lighting
 	var/obj/effect/abstract/eye_lighting/on_mob
 	var/image/mob_overlay
+	var/datum/component/mobhook
 
 /obj/item/organ/eyes/robotic/glow/Initialize()
 	. = ..()
@@ -227,15 +228,16 @@
 	if(active)
 		deactivate(silent = TRUE)
 
-/obj/item/organ/eyes/robotic/glow/on_mob_move()
-	if(QDELETED(owner) || !active)
-		return
-	update_visuals()
+/obj/item/organ/eyes/robotic/glow/Insert(var/mob/living/carbon/M)
+	. = ..()
+	if (mobhook && mobhook.parent != M)
+		QDEL_NULL(mobhook)
+	if (!mobhook)
+		mobhook = M.AddComponent(/datum/component/redirect, list(COMSIG_ATOM_DIR_CHANGE), CALLBACK(src, .proc/update_visuals))
 
-/obj/item/organ/eyes/robotic/glow/on_mob_turn()
-	if(QDELETED(owner) || !active)
-		return
-	update_visuals()
+/obj/item/organ/eyes/robotic/glow/Remove(mob/living/carbon/M)
+	. = ..()
+	QDEL_NULL(mobhook)
 
 /obj/item/organ/eyes/robotic/glow/proc/activate(silent = FALSE)
 	start_visuals()
@@ -251,11 +253,13 @@
 	active = FALSE
 	remove_mob_overlay()
 
-/obj/item/organ/eyes/robotic/glow/proc/update_visuals()
+/obj/item/organ/eyes/robotic/glow/proc/update_visuals(olddir, newdir)
 	if((LAZYLEN(eye_lighting) < light_beam_distance) || !on_mob)
 		regenerate_light_effects()
 	var/turf/scanfrom = get_turf(owner)
 	var/scandir = owner.dir
+	if (newdir && scandir != newdir) // COMSIG_ATOM_DIR_CHANGE happens before the dir change, but with a reference to the new direction.
+		scandir = newdir
 	if(!istype(scanfrom))
 		clear_visuals()
 	var/turf/scanning = scanfrom


### PR DESCRIPTION
@kevinz000 

I've tested flightsuits, RCLs, ancient hardsuits and glowing robot eyes in-game and everything seems to work, I'm not too familiar with how flightsuits are supposed to work but while flying i enjoyed faster than usual movement with momentum effects so that's probably alright?

:cl: Naksu
code: replaced some item-specific movement hooks with components
/:cl:

Currently, every time you move, on_mob_move and on_mob_turn is called on everything in your mob's contents and organs. 
