### PR TITLE
Fixes lava burning unconstructed HE-pipes

### DIFF
--- a/code/game/machinery/pipe/construction.dm
+++ b/code/game/machinery/pipe/construction.dm
@@ -83,6 +83,8 @@ Buildable meters
 	var/obj/machinery/atmospherics/fakeA = pipe_type
 	name = "[initial(fakeA.name)] fitting"
 	icon_state = initial(fakeA.pipe_state)
+	if(ispath(pipe_type,/obj/machinery/atmospherics/pipe/heat_exchanging))
+		resistance_flags |= FIRE_PROOF | LAVA_PROOF
 
 /obj/item/pipe/verb/flip()
 	set category = "Object"


### PR DESCRIPTION
:cl: 
fix: fixes lava and fire burning HE-pipes
/:cl:

They don't burn in plasma fires and they don't burn if they're placed on lava. And they exchange heat with the lava. You just can't properly build them on lava. Now you can.
