### PR TITLE
Jellypeople (and all subtypes) now can actually speak Slime, as intended

### DIFF
--- a/code/modules/mob/living/carbon/human/species_types/jellypeople.dm
+++ b/code/modules/mob/living/carbon/human/species_types/jellypeople.dm
@@ -17,14 +17,14 @@
 /datum/species/jelly/on_species_loss(mob/living/carbon/C)
 	if(regenerate_limbs)
 		regenerate_limbs.Remove(C)
-	C.remove_language(/datum/language/slime, TRUE)
+	C.remove_language(/datum/language/slime)
 	C.faction -= "slime"
 	..()
 	C.faction -= "slime"
 
 /datum/species/jelly/on_species_gain(mob/living/carbon/C, datum/species/old_species)
 	..()
-	C.grant_language(/datum/language/slime, TRUE)
+	C.grant_language(/datum/language/slime)
 	if(ishuman(C))
 		regenerate_limbs = new
 		regenerate_limbs.Grant(C)


### PR DESCRIPTION
:cl: jakeramsay007
fix: Jellypeople/Slimepeople now are able to speak their Slime language, as intended when it was added.
/:cl:

When the language was added it was intended to be able to be spoken as well. The TRUE flag made it so it could only be understood, so I've removed that and now they can speak the language too.