### PR TITLE
Reflectors now reset the range of a projectile like before!

### DIFF
--- a/code/game/objects/structures/reflector.dm
+++ b/code/game/objects/structures/reflector.dm
@@ -72,7 +72,8 @@
 
 /obj/structure/reflector/proc/auto_reflect(obj/item/projectile/P, pdir, turf/ploc, pangle)
 	P.ignore_source_check = TRUE
-	P.range = initial(P.range)
+	P.range = P.decayedRange
+	P.decayedRange = max(P.decayedRange--, 0)
 	return -1
 
 /obj/structure/reflector/attackby(obj/item/W, mob/user, params)

--- a/code/game/objects/structures/reflector.dm
+++ b/code/game/objects/structures/reflector.dm
@@ -72,6 +72,7 @@
 
 /obj/structure/reflector/proc/auto_reflect(obj/item/projectile/P, pdir, turf/ploc, pangle)
 	P.ignore_source_check = TRUE
+	P.range = initial(P.range)
 	return -1
 
 /obj/structure/reflector/attackby(obj/item/W, mob/user, params)

--- a/code/modules/projectiles/projectile.dm
+++ b/code/modules/projectiles/projectile.dm
@@ -65,6 +65,7 @@
 	var/flag = "bullet" //Defines what armor to use when it hits things.  Must be set to bullet, laser, energy,or bomb
 	var/projectile_type = /obj/item/projectile
 	var/range = 50 //This will de-increment every step. When 0, it will deletze the projectile.
+	var/decayedRange
 	var/is_reflectable = FALSE // Can it be reflected or not?
 		//Effects
 	var/stun = 0
@@ -85,6 +86,7 @@
 /obj/item/projectile/Initialize()
 	. = ..()
 	permutated = list()
+	decayedRange = range
 
 /obj/item/projectile/proc/Range()
 	range--


### PR DESCRIPTION
[Changelogs]: 

:cl: Dax Dupont
add: Nanotrasen has invested in better reflective materials for it's reflectors. You can now make complex laser shows again.
/:cl:

[why]: Due to @kevinz000's refactor long ago, the resetting of range on reflectors disappeared. I readded it because it got in the way of making complex laser shows and laser mazes and what not, since it would kill the range on them.
