### PR TITLE
Select Equipment works on observers

### DIFF
--- a/code/modules/admin/verbs/debug.dm
+++ b/code/modules/admin/verbs/debug.dm
@@ -679,10 +679,10 @@ GLOBAL_PROTECT(AdminProcCallSpamPrevention)
 	set name = "Test Areas (ALL)"
 	cmd_admin_areatest(FALSE)
 
-/client/proc/cmd_admin_dress(mob/living/carbon/human/M in GLOB.mob_list)
+/client/proc/cmd_admin_dress(mob/M in GLOB.mob_list)
 	set category = "Fun"
 	set name = "Select equipment"
-	if(!ishuman(M))
+	if(!(ishuman(M) || isobserver(M)))
 		alert("Invalid mob")
 		return
 
@@ -691,16 +691,22 @@ GLOBAL_PROTECT(AdminProcCallSpamPrevention)
 	if(!dresscode)
 		return
 
+	var/mob/living/carbon/human/H
+	if(isobserver(M))
+		H = M.change_mob_type(/mob/living/carbon/human, null, null, TRUE)
+	else
+		H = M
+
 	SSblackbox.record_feedback("tally", "admin_verb", 1, "Select Equipment") //If you are copy-pasting this, ensure the 2nd parameter is unique to the new proc!
-	for (var/obj/item/I in M.get_equipped_items())
+	for (var/obj/item/I in H.get_equipped_items())
 		qdel(I)
 	if(dresscode != "Naked")
-		M.equipOutfit(dresscode)
+		H.equipOutfit(dresscode)
 
-	M.regenerate_icons()
+	H.regenerate_icons()
 
-	log_admin("[key_name(usr)] changed the equipment of [key_name(M)] to [dresscode].")
-	message_admins("<span class='adminnotice'>[key_name_admin(usr)] changed the equipment of [key_name_admin(M)] to [dresscode].</span>")
+	log_admin("[key_name(usr)] changed the equipment of [key_name(H)] to [dresscode].")
+	message_admins("<span class='adminnotice'>[key_name_admin(usr)] changed the equipment of [key_name_admin(H)] to [dresscode].</span>")
 
 /client/proc/robust_dress_shop()
 	var/list/outfits = list("Cancel","Naked","Custom","As Job...")


### PR DESCRIPTION
:cl: coiax
admin: Admins can use the Select Equipment verb on observers. Doing so will
humanise them and then apply the equipment.
/:cl:
- Now when admins are putting on their Centcom Commander outfits, they
can skip the awkward naked stage.