### PR TITLE
fixes poddoor examine message

### DIFF
--- a/code/game/machinery/doors/door.dm
+++ b/code/game/machinery/doors/door.dm
@@ -33,6 +33,7 @@
 	var/damage_deflection = 10
 	var/real_explosion_block	//ignore this, just use explosion_block
 	var/red_alert_access = FALSE //if TRUE, this door will always open on red alert
+	var/poddoor = FALSE
 
 /obj/machinery/door/examine(mob/user)
 	..()
@@ -41,7 +42,8 @@
 			to_chat(user, "<span class='notice'>Due to a security threat, its access requirements have been lifted!</span>")
 		else
 			to_chat(user, "<span class='notice'>In the event of a red alert, its access requirements will automatically lift.</span>")
-	to_chat(user, "<span class='notice'>Its maintenance panel is <b>screwed</b> in place.</span>")
+	if(!poddoor)
+		to_chat(user, "<span class='notice'>Its maintenance panel is <b>screwed</b> in place.</span>")
 
 /obj/machinery/door/check_access(access)
 	if(red_alert_access && GLOB.security_level >= SEC_LEVEL_RED)

--- a/code/game/machinery/doors/poddoor.dm
+++ b/code/game/machinery/doors/poddoor.dm
@@ -14,6 +14,7 @@
 	armor = list("melee" = 50, "bullet" = 100, "laser" = 100, "energy" = 100, "bomb" = 50, "bio" = 100, "rad" = 100, "fire" = 100, "acid" = 70)
 	resistance_flags = FIRE_PROOF
 	damage_deflection = 70
+	poddoor = TRUE
 
 /obj/machinery/door/poddoor/preopen
 	icon_state = "open"


### PR DESCRIPTION
[Changelogs]: examining a blast door no longer gives the regular door examination message about the maintenance panel.

:cl: 
fix: removes the maintenance panel examination message on poddoors (blast doors)
/:cl:

Fixes #35723