### PR TITLE
[s] Cameranet fixes

### DIFF
--- a/_maps/RandomRuins/SpaceRuins/deepstorage.dmm
+++ b/_maps/RandomRuins/SpaceRuins/deepstorage.dmm
@@ -1900,7 +1900,7 @@
 /obj/machinery/computer/security/telescreen{
 	dir = 1;
 	name = "Bunker Entrance";
-	network = list("Bunker1");
+	network = list("bunker1");
 	pixel_y = 2
 	},
 /turf/open/floor/plasteel/floorgrime,
@@ -2413,7 +2413,7 @@
 /area/ruin/space/has_grav/deepstorage)
 "fU" = (
 /obj/machinery/camera{
-	network = list("Bunker1")
+	network = list("bunker1")
 	},
 /obj/structure/sign/warning/securearea{
 	pixel_y = 32

--- a/_maps/RandomZLevels/moonoutpost19.dmm
+++ b/_maps/RandomZLevels/moonoutpost19.dmm
@@ -2068,7 +2068,7 @@
 	},
 /obj/machinery/camera{
 	c_tag = "Xenobiology Containment North";
-	network = list("MO19X")
+	network = list("mo19x")
 	},
 /turf/open/floor/engine,
 /area/awaymission/moonoutpost19/research)
@@ -2133,7 +2133,7 @@
 	desc = "Used for watching the contents of the xenobiology containment pen.";
 	dir = 8;
 	name = "xenobiology monitor";
-	network = list("MO19X")
+	network = list("mo19x")
 	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -2209,7 +2209,7 @@
 /obj/machinery/camera{
 	c_tag = "Xenobiology";
 	dir = 4;
-	network = list("MO19","MO19R")
+	network = list("mo19","mo19r")
 	},
 /turf/open/floor/plasteel/white/side{
 	dir = 6;
@@ -2750,7 +2750,7 @@
 /obj/machinery/camera{
 	c_tag = "Xenobiology Containment East";
 	dir = 8;
-	network = list("MO19X")
+	network = list("mo19x")
 	},
 /turf/open/floor/engine,
 /area/awaymission/moonoutpost19/research)
@@ -3326,7 +3326,7 @@
 /obj/machinery/computer/security{
 	desc = "Used to access the various cameras on the outpost.";
 	dir = 4;
-	network = list("MO19R","MO19")
+	network = list("mo19r","mo19")
 	},
 /turf/open/floor/plasteel/red/side{
 	dir = 8;
@@ -3461,7 +3461,7 @@
 /obj/machinery/camera{
 	c_tag = "Xenobiology Containment South";
 	dir = 1;
-	network = list("MO19X")
+	network = list("mo19x")
 	},
 /turf/open/floor/engine,
 /area/awaymission/moonoutpost19/research)
@@ -3759,7 +3759,7 @@
 /obj/machinery/camera{
 	c_tag = "Research Division";
 	dir = 1;
-	network = list("MO19","MO19R")
+	network = list("mo19","mo19r")
 	},
 /turf/open/floor/plasteel/whitepurple/corner{
 	dir = 8;
@@ -3956,7 +3956,7 @@
 /obj/machinery/computer/security/telescreen{
 	desc = "Used for monitoring the research division and the labs within.";
 	name = "research monitor";
-	network = list("MO19X","MO19R")
+	network = list("mo19x","mo19r")
 	},
 /turf/open/floor/plasteel/cafeteria{
 	dir = 5
@@ -4306,7 +4306,7 @@
 /obj/machinery/camera{
 	c_tag = "Research Director's Office";
 	dir = 1;
-	network = list("MO19","MO19R")
+	network = list("mo19","mo19r")
 	},
 /turf/open/floor/plasteel/cafeteria{
 	dir = 5
@@ -5163,7 +5163,7 @@
 /obj/machinery/camera{
 	c_tag = "Arrivals North";
 	dir = 1;
-	network = list("MO19")
+	network = list("mo19")
 	},
 /turf/open/floor/plasteel/arrival{
 	dir = 2;
@@ -5447,7 +5447,7 @@
 /obj/machinery/camera{
 	c_tag = "Kitchen";
 	dir = 8;
-	network = list("MO19")
+	network = list("mo19")
 	},
 /turf/open/floor/plasteel/cafeteria{
 	dir = 5
@@ -5593,7 +5593,7 @@
 /obj/machinery/camera{
 	c_tag = "Bar";
 	dir = 8;
-	network = list("MO19")
+	network = list("mo19")
 	},
 /turf/open/floor/plasteel/bar{
 	heat_capacity = 1e+006
@@ -6136,7 +6136,7 @@
 /obj/machinery/camera{
 	c_tag = "Arrivals South";
 	dir = 8;
-	network = list("MO19")
+	network = list("mo19")
 	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -6379,7 +6379,7 @@
 /obj/machinery/camera{
 	c_tag = "Dormitories";
 	dir = 4;
-	network = list("MO19")
+	network = list("mo19")
 	},
 /turf/open/floor/plasteel{
 	initial_gas_mix = "co2=48.7;n2=13.2;o2=32.4;TEMP=251";

--- a/_maps/RandomZLevels/undergroundoutpost45.dmm
+++ b/_maps/RandomZLevels/undergroundoutpost45.dmm
@@ -552,7 +552,7 @@
 /obj/machinery/camera{
 	c_tag = "Arrivals";
 	dir = 8;
-	network = list("UO45")
+	network = list("uo45")
 	},
 /turf/open/floor/plasteel/neutral/side{
 	dir = 4;
@@ -2216,7 +2216,7 @@
 "eY" = (
 /obj/machinery/computer/security{
 	dir = 1;
-	network = list("UO45")
+	network = list("uo45")
 	},
 /turf/open/floor/plasteel/red/side{
 	dir = 6;
@@ -2280,7 +2280,7 @@
 /obj/machinery/camera{
 	c_tag = "Hydroponics";
 	dir = 1;
-	network = list("UO45")
+	network = list("uo45")
 	},
 /obj/machinery/power/apc/highcap/fifteen_k{
 	dir = 2;
@@ -2667,7 +2667,7 @@
 /obj/machinery/camera{
 	c_tag = "Central Hallway";
 	dir = 1;
-	network = list("UO45")
+	network = list("uo45")
 	},
 /turf/open/floor/plasteel{
 	heat_capacity = 1e+006
@@ -3113,7 +3113,7 @@
 /obj/machinery/camera{
 	c_tag = "Research Lab";
 	dir = 2;
-	network = list("UO45","UO45R")
+	network = list("uo45","uo45r")
 	},
 /turf/open/floor/plasteel/white{
 	heat_capacity = 1e+006
@@ -3299,7 +3299,7 @@
 /obj/machinery/camera{
 	c_tag = "Kitchen";
 	dir = 8;
-	network = list("UO45")
+	network = list("uo45")
 	},
 /obj/structure/table,
 /obj/machinery/microwave{
@@ -4178,7 +4178,7 @@
 /obj/machinery/camera{
 	c_tag = "Gateway Chamber";
 	dir = 4;
-	network = list("UO45","UO45R")
+	network = list("uo45","uo45r")
 	},
 /turf/open/floor/plasteel/floorgrime{
 	dir = 8;
@@ -4348,7 +4348,7 @@
 /obj/machinery/camera{
 	c_tag = "Bar";
 	dir = 8;
-	network = list("UO45")
+	network = list("uo45")
 	},
 /obj/structure/table/reinforced,
 /turf/open/floor/plasteel/bar{
@@ -5363,7 +5363,7 @@
 /obj/machinery/camera{
 	c_tag = "Gateway Ready Room";
 	dir = 2;
-	network = list("UO45","UO45R")
+	network = list("uo45","uo45r")
 	},
 /turf/open/floor/plasteel{
 	heat_capacity = 1e+006
@@ -5480,7 +5480,7 @@
 /obj/machinery/camera{
 	c_tag = "Research Division West";
 	dir = 1;
-	network = list("UO45","UO45R")
+	network = list("uo45","uo45r")
 	},
 /turf/open/floor/plasteel/whitepurple/corner{
 	dir = 2;
@@ -5662,7 +5662,7 @@
 /obj/machinery/camera{
 	c_tag = "Research Division East";
 	dir = 1;
-	network = list("UO45","UO45R")
+	network = list("uo45","uo45r")
 	},
 /turf/open/floor/plasteel/whitepurple/corner{
 	dir = 2;
@@ -5784,7 +5784,7 @@
 /obj/machinery/camera{
 	c_tag = "Engineering Secure Storage";
 	dir = 2;
-	network = list("UO45")
+	network = list("uo45")
 	},
 /turf/open/floor/plating{
 	heat_capacity = 1e+006
@@ -6466,7 +6466,7 @@
 "no" = (
 /obj/machinery/computer/security{
 	dir = 4;
-	network = list("UO45")
+	network = list("uo45")
 	},
 /turf/open/floor/plasteel/red/side{
 	dir = 8;
@@ -6487,7 +6487,7 @@
 	desc = "Used for monitoring the research division and the labs within.";
 	dir = 8;
 	name = "research monitor";
-	network = list("UO45R")
+	network = list("uo45r")
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/red/side{
@@ -6801,7 +6801,7 @@
 	desc = "Used for monitoring the research division and the labs within.";
 	dir = 2;
 	name = "research monitor";
-	network = list("UO45R")
+	network = list("uo45r")
 	},
 /turf/open/floor/plasteel/cafeteria{
 	dir = 5;
@@ -6968,7 +6968,7 @@
 /obj/machinery/camera{
 	c_tag = "Dormitories";
 	dir = 2;
-	network = list("UO45")
+	network = list("uo45")
 	},
 /turf/open/floor/plasteel/neutral/corner{
 	dir = 1;
@@ -8452,7 +8452,7 @@
 /obj/machinery/camera{
 	c_tag = "Atmospherics";
 	dir = 2;
-	network = list("UO45")
+	network = list("uo45")
 	},
 /obj/structure/table,
 /obj/item/clothing/gloves/color/yellow,
@@ -9086,7 +9086,7 @@
 /obj/machinery/camera{
 	c_tag = "Engineering Hallway";
 	dir = 4;
-	network = list("UO45")
+	network = list("uo45")
 	},
 /turf/open/floor/plasteel{
 	heat_capacity = 1e+006
@@ -10114,7 +10114,7 @@
 "tz" = (
 /obj/machinery/computer/security{
 	dir = 1;
-	network = list("UO45")
+	network = list("uo45")
 	},
 /obj/machinery/button/door{
 	desc = "A remote control-switch for the security privacy shutters.";
@@ -11389,7 +11389,7 @@
 /obj/machinery/camera{
 	c_tag = "Engineering Foyer";
 	dir = 1;
-	network = list("UO45")
+	network = list("uo45")
 	},
 /turf/open/floor/plasteel/floorgrime{
 	dir = 8;
@@ -12258,7 +12258,7 @@
 /obj/machinery/camera{
 	c_tag = "Mining";
 	dir = 4;
-	network = list("UO45")
+	network = list("uo45")
 	},
 /turf/open/floor/plasteel/floorgrime{
 	heat_capacity = 1e+006

--- a/_maps/map_files/BoxStation/BoxStation.dmm
+++ b/_maps/map_files/BoxStation/BoxStation.dmm
@@ -84,7 +84,7 @@
 /obj/item/device/plant_analyzer,
 /obj/machinery/camera{
 	c_tag = "Prison Common Room";
-	network = list("SS13","Prison")
+	network = list("ss13","prison")
 	},
 /turf/open/floor/plasteel/green/side{
 	dir = 5
@@ -854,8 +854,7 @@
 	},
 /obj/machinery/camera{
 	c_tag = "Head of Security's Office";
-	dir = 4;
-	network = list("SS13")
+	dir = 4
 	},
 /obj/machinery/recharger{
 	pixel_y = 4
@@ -919,7 +918,7 @@
 /obj/structure/bed,
 /obj/machinery/camera{
 	c_tag = "Prison Cell 3";
-	network = list("SS13","Prison")
+	network = list("ss13","prison")
 	},
 /obj/item/device/radio/intercom{
 	desc = "Talk through this. It looks like it has been modified to not broadcast.";
@@ -950,7 +949,7 @@
 /obj/structure/bed,
 /obj/machinery/camera{
 	c_tag = "Prison Cell 2";
-	network = list("SS13","Prison")
+	network = list("ss13","prison")
 	},
 /obj/item/device/radio/intercom{
 	desc = "Talk through this. It looks like it has been modified to not broadcast.";
@@ -972,7 +971,7 @@
 /obj/structure/bed,
 /obj/machinery/camera{
 	c_tag = "Prison Cell 1";
-	network = list("SS13","Prison")
+	network = list("ss13","prison")
 	},
 /obj/item/device/radio/intercom{
 	desc = "Talk through this. It looks like it has been modified to not broadcast.";
@@ -1709,7 +1708,7 @@
 /obj/machinery/computer/security/telescreen{
 	desc = "Used for watching Prison Wing holding areas.";
 	name = "Prison Monitor";
-	network = list("Prison");
+	network = list("prison");
 	pixel_y = 30
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -1748,7 +1747,7 @@
 /obj/machinery/computer/security/telescreen{
 	desc = "Used for watching Prison Wing holding areas.";
 	name = "Prison Monitor";
-	network = list("Prison");
+	network = list("prison");
 	pixel_y = 30
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -1756,7 +1755,7 @@
 	},
 /obj/machinery/camera{
 	c_tag = "Prison Hallway";
-	network = list("SS13","Prison")
+	network = list("ss13","prison")
 	},
 /turf/open/floor/plasteel/red/side{
 	dir = 1
@@ -1891,8 +1890,7 @@
 "aeC" = (
 /obj/machinery/camera{
 	c_tag = "Security Escape Pod";
-	dir = 4;
-	network = list("SS13")
+	dir = 4
 	},
 /turf/open/floor/plating,
 /area/security/main)
@@ -3586,8 +3584,7 @@
 "aiq" = (
 /obj/machinery/camera{
 	c_tag = "Security Office";
-	dir = 1;
-	network = list("SS13")
+	dir = 1
 	},
 /obj/machinery/computer/secure_data{
 	dir = 1
@@ -4035,7 +4032,7 @@
 	},
 /obj/machinery/computer/security{
 	name = "Labor Camp Monitoring";
-	network = list("Labor")
+	network = list("labor")
 	},
 /turf/open/floor/plasteel,
 /area/security/processing)
@@ -7750,7 +7747,7 @@
 /obj/machinery/camera{
 	c_tag = "Auxillary Mining Base";
 	dir = 8;
-	network = list("SS13","AuxBase")
+	network = list("ss13","auxbase")
 	},
 /turf/open/floor/plating,
 /area/shuttle/auxillary_base)
@@ -8035,8 +8032,7 @@
 /obj/structure/table/wood,
 /obj/machinery/camera{
 	c_tag = "Law Office";
-	dir = 1;
-	network = list("SS13")
+	dir = 1
 	},
 /obj/item/paper_bin{
 	pixel_x = -3;
@@ -8047,7 +8043,7 @@
 	desc = "Used for watching Prison Wing holding areas.";
 	dir = 1;
 	name = "Prison Monitor";
-	network = list("Prison");
+	network = list("prison");
 	pixel_y = -27
 	},
 /turf/open/floor/wood,
@@ -9277,7 +9273,7 @@
 	desc = "Used for the Auxillary Mining Base.";
 	dir = 8;
 	name = "Auxillary Base Monitor";
-	network = list("AuxBase");
+	network = list("auxbase");
 	pixel_x = 28
 	},
 /turf/open/floor/plasteel/yellow/side{
@@ -10863,8 +10859,7 @@
 "aBh" = (
 /obj/machinery/camera{
 	c_tag = "EVA Maintenance";
-	dir = 8;
-	network = list("SS13")
+	dir = 8
 	},
 /obj/machinery/light/small{
 	dir = 4
@@ -11338,8 +11333,7 @@
 "aCp" = (
 /obj/machinery/camera{
 	c_tag = "Arrivals North";
-	dir = 8;
-	network = list("SS13")
+	dir = 8
 	},
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -12336,8 +12330,7 @@
 "aER" = (
 /obj/machinery/camera{
 	c_tag = "Gateway";
-	dir = 4;
-	network = list("SS13")
+	dir = 4
 	},
 /obj/structure/table,
 /obj/structure/sign/warning/biohazard{
@@ -12692,8 +12685,7 @@
 "aFO" = (
 /obj/machinery/camera{
 	c_tag = "Garden";
-	dir = 8;
-	network = list("SS13")
+	dir = 8
 	},
 /obj/machinery/airalarm{
 	dir = 8;
@@ -12808,7 +12800,7 @@
 /obj/machinery/camera/motion{
 	c_tag = "Vault";
 	dir = 1;
-	network = list("MiniSat")
+	network = list("minisat")
 	},
 /obj/machinery/light,
 /turf/open/floor/plasteel/vault/corner{
@@ -13306,8 +13298,7 @@
 	},
 /obj/machinery/camera{
 	c_tag = "Chapel Office";
-	dir = 2;
-	network = list("SS13")
+	dir = 2
 	},
 /turf/open/floor/plasteel/grimy,
 /area/chapel/office)
@@ -13808,8 +13799,7 @@
 /obj/structure/chair/office/dark,
 /obj/machinery/camera{
 	c_tag = "Library North";
-	dir = 2;
-	network = list("SS13")
+	dir = 2
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
@@ -15460,8 +15450,7 @@
 "aMM" = (
 /obj/machinery/camera{
 	c_tag = "Chapel North";
-	dir = 2;
-	network = list("SS13")
+	dir = 2
 	},
 /turf/open/floor/plasteel/dark,
 /area/chapel/main)
@@ -17237,8 +17226,7 @@
 "aRP" = (
 /obj/machinery/camera{
 	c_tag = "Library South";
-	dir = 8;
-	network = list("SS13")
+	dir = 8
 	},
 /turf/open/floor/wood,
 /area/library)
@@ -17353,8 +17341,7 @@
 "aSf" = (
 /obj/machinery/camera{
 	c_tag = "Arrivals Hallway";
-	dir = 8;
-	network = list("SS13")
+	dir = 8
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
@@ -17657,8 +17644,7 @@
 	},
 /obj/machinery/camera{
 	c_tag = "Bar";
-	dir = 8;
-	network = list("SS13")
+	dir = 8
 	},
 /obj/structure/table,
 /obj/machinery/chem_dispenser/drinks,
@@ -17846,8 +17832,7 @@
 	},
 /obj/machinery/camera{
 	c_tag = "Locker Room East";
-	dir = 8;
-	network = list("SS13")
+	dir = 8
 	},
 /obj/machinery/light{
 	dir = 4
@@ -17988,7 +17973,7 @@
 /area/bridge)
 "aUd" = (
 /obj/machinery/computer/security/mining{
-	network = list("MINE","AuxBase")
+	network = list("mine","auxbase")
 	},
 /turf/open/floor/plasteel/brown{
 	dir = 6
@@ -18007,8 +17992,7 @@
 	},
 /obj/machinery/camera{
 	c_tag = "Bar West";
-	dir = 4;
-	network = list("SS13")
+	dir = 4
 	},
 /turf/open/floor/plasteel/bar,
 /area/crew_quarters/bar)
@@ -18137,8 +18121,7 @@
 "aUy" = (
 /obj/machinery/camera{
 	c_tag = "Vacant Office";
-	dir = 4;
-	network = list("SS13")
+	dir = 4
 	},
 /turf/open/floor/wood,
 /area/security/vacantoffice)
@@ -18224,8 +18207,7 @@
 "aUM" = (
 /obj/machinery/camera{
 	c_tag = "Arrivals Bay 2";
-	dir = 8;
-	network = list("SS13")
+	dir = 8
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
@@ -18387,8 +18369,7 @@
 	},
 /obj/machinery/camera{
 	c_tag = "Fore Primary Hallway";
-	dir = 4;
-	network = list("SS13")
+	dir = 4
 	},
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/plasteel/red/corner{
@@ -18717,8 +18698,7 @@
 "aVV" = (
 /obj/machinery/camera{
 	c_tag = "Chapel South";
-	dir = 8;
-	network = list("SS13")
+	dir = 8
 	},
 /turf/open/floor/plasteel/dark,
 /area/chapel/main)
@@ -19994,8 +19974,7 @@
 "aYT" = (
 /obj/machinery/camera{
 	c_tag = "Hydroponics South";
-	dir = 8;
-	network = list("SS13")
+	dir = 8
 	},
 /obj/structure/reagent_dispensers/watertank/high,
 /turf/open/floor/plasteel,
@@ -20120,8 +20099,7 @@
 "aZm" = (
 /obj/machinery/camera{
 	c_tag = "Escape Arm Airlocks";
-	dir = 8;
-	network = list("SS13")
+	dir = 8
 	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -20867,8 +20845,7 @@
 "bbr" = (
 /obj/machinery/camera{
 	c_tag = "Locker Room South";
-	dir = 8;
-	network = list("SS13")
+	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plasteel,
@@ -20935,8 +20912,7 @@
 "bbA" = (
 /obj/machinery/camera{
 	c_tag = "Starboard Primary Hallway 2";
-	dir = 2;
-	network = list("SS13")
+	dir = 2
 	},
 /turf/open/floor/plasteel/white/corner{
 	dir = 1
@@ -21227,8 +21203,7 @@
 "bcr" = (
 /obj/machinery/camera{
 	c_tag = "Starboard Primary Hallway";
-	dir = 2;
-	network = list("SS13")
+	dir = 2
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
@@ -21265,8 +21240,7 @@
 "bcx" = (
 /obj/machinery/camera{
 	c_tag = "Starboard Primary Hallway 5";
-	dir = 2;
-	network = list("SS13")
+	dir = 2
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
@@ -21540,8 +21514,7 @@
 "bdn" = (
 /obj/machinery/camera{
 	c_tag = "Central Hallway East";
-	dir = 4;
-	network = list("SS13")
+	dir = 4
 	},
 /obj/structure/disposalpipe/segment,
 /obj/machinery/status_display{
@@ -22832,8 +22805,7 @@
 	},
 /obj/machinery/camera{
 	c_tag = "Cargo Delivery Office";
-	dir = 4;
-	network = list("SS13")
+	dir = 4
 	},
 /obj/machinery/requests_console{
 	department = "Cargo Bay";
@@ -23017,8 +22989,7 @@
 "bhc" = (
 /obj/machinery/camera{
 	c_tag = "Chemistry";
-	dir = 2;
-	network = list("SS13")
+	dir = 2
 	},
 /obj/machinery/firealarm{
 	dir = 2;
@@ -23057,8 +23028,7 @@
 "bhj" = (
 /obj/machinery/camera{
 	c_tag = "Security Post - Medbay";
-	dir = 2;
-	network = list("SS13")
+	dir = 2
 	},
 /obj/machinery/requests_console{
 	department = "Security";
@@ -23724,7 +23694,7 @@
 /obj/machinery/camera{
 	c_tag = "Robotics Lab";
 	dir = 2;
-	network = list("SS13","RD")
+	network = list("ss13","rd")
 	},
 /obj/machinery/button/door{
 	dir = 2;
@@ -23766,8 +23736,7 @@
 "biS" = (
 /obj/machinery/camera{
 	c_tag = "Research Division Access";
-	dir = 2;
-	network = list("SS13")
+	dir = 2
 	},
 /obj/structure/sink{
 	dir = 4;
@@ -23806,7 +23775,7 @@
 /obj/machinery/camera{
 	c_tag = "Research and Development";
 	dir = 2;
-	network = list("SS13","RD");
+	network = list("ss13","rd");
 	pixel_x = 22
 	},
 /obj/machinery/button/door{
@@ -24046,8 +24015,7 @@
 "bjy" = (
 /obj/machinery/camera{
 	c_tag = "Gravity Generator Room";
-	dir = 8;
-	network = list("SS13")
+	dir = 8
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 4
@@ -24247,8 +24215,7 @@
 "bkb" = (
 /obj/machinery/camera{
 	c_tag = "Medbay Morgue";
-	dir = 8;
-	network = list("SS13")
+	dir = 8
 	},
 /obj/machinery/airalarm{
 	dir = 8;
@@ -24777,8 +24744,7 @@
 /obj/structure/table/reinforced,
 /obj/machinery/camera{
 	c_tag = "Medbay Foyer";
-	dir = 8;
-	network = list("SS13")
+	dir = 8
 	},
 /obj/machinery/cell_charger,
 /turf/open/floor/plasteel/white,
@@ -25879,7 +25845,7 @@
 /obj/machinery/computer/security/telescreen{
 	desc = "Used for watching Prison Wing holding areas.";
 	name = "Prison Monitor";
-	network = list("Prison");
+	network = list("prison");
 	pixel_y = 30
 	},
 /obj/machinery/disposal/bin,
@@ -27176,8 +27142,7 @@
 	},
 /obj/machinery/camera{
 	c_tag = "Medbay West";
-	dir = 2;
-	network = list("SS13")
+	dir = 2
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -27456,7 +27421,7 @@
 /obj/machinery/camera{
 	c_tag = "Experimentor Lab";
 	dir = 2;
-	network = list("SS13","RD")
+	network = list("ss13","rd")
 	},
 /obj/item/hand_labeler,
 /obj/item/stack/packageWrap,
@@ -27585,8 +27550,7 @@
 /obj/item/device/multitool,
 /obj/machinery/camera{
 	c_tag = "Cargo Office";
-	dir = 4;
-	network = list("SS13")
+	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/office)
@@ -27864,7 +27828,6 @@
 /obj/machinery/camera{
 	c_tag = "Medbay East";
 	dir = 8;
-	network = list("SS13");
 	pixel_y = -22
 	},
 /turf/open/floor/plasteel/white,
@@ -28045,7 +28008,7 @@
 /obj/machinery/camera{
 	c_tag = "Robotics Lab - South";
 	dir = 1;
-	network = list("SS13","RD")
+	network = list("ss13","rd")
 	},
 /turf/open/floor/plasteel/white,
 /area/science/robotics/lab)
@@ -28326,8 +28289,7 @@
 "btA" = (
 /obj/machinery/camera{
 	c_tag = "Research Division West";
-	dir = 2;
-	network = list("SS13")
+	dir = 2
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
@@ -29187,7 +29149,7 @@
 /obj/machinery/camera{
 	c_tag = "Genetics Research";
 	dir = 1;
-	network = list("SS13","RD")
+	network = list("ss13","rd")
 	},
 /obj/machinery/firealarm{
 	dir = 1;
@@ -29222,7 +29184,6 @@
 /obj/machinery/camera{
 	c_tag = "Genetics Access";
 	dir = 8;
-	network = list("SS13");
 	pixel_y = -22
 	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
@@ -29456,8 +29417,7 @@
 "bwf" = (
 /obj/machinery/camera{
 	c_tag = "Cargo Bay Entrance";
-	dir = 4;
-	network = list("SS13")
+	dir = 4
 	},
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel/brown/corner{
@@ -29679,8 +29639,7 @@
 /obj/structure/table/glass,
 /obj/machinery/camera{
 	c_tag = "Medbay Cryogenics";
-	dir = 2;
-	network = list("SS13")
+	dir = 2
 	},
 /obj/item/reagent_containers/glass/beaker/cryoxadone,
 /obj/item/reagent_containers/glass/beaker/cryoxadone,
@@ -29698,8 +29657,7 @@
 "bwL" = (
 /obj/machinery/camera{
 	c_tag = "Genetics Cloning";
-	dir = 4;
-	network = list("SS13")
+	dir = 4
 	},
 /obj/structure/table,
 /obj/machinery/firealarm{
@@ -29954,7 +29912,7 @@
 /obj/machinery/computer/security/telescreen{
 	desc = "Used for watching the RD's goons and the AI's satellite from the safety of his office.";
 	name = "Research Monitor";
-	network = list("RD","MiniSat");
+	network = list("rd","minisat");
 	pixel_y = 2
 	},
 /obj/structure/table,
@@ -30597,7 +30555,7 @@
 	},
 /obj/machinery/computer/security/mining{
 	dir = 8;
-	network = list("MINE","AuxBase")
+	network = list("mine","auxbase")
 	},
 /turf/open/floor/plasteel/red/side{
 	dir = 4
@@ -30894,7 +30852,7 @@
 /obj/machinery/camera{
 	c_tag = "Server Room";
 	dir = 2;
-	network = list("SS13","RD");
+	network = list("ss13","rd");
 	pixel_x = 22
 	},
 /obj/machinery/power/apc{
@@ -30949,7 +30907,7 @@
 /obj/machinery/computer/security/telescreen{
 	desc = "Used for watching the RD's goons from the safety of your own office.";
 	name = "Research Monitor";
-	network = list("RD");
+	network = list("rd");
 	pixel_y = 2
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -31270,8 +31228,7 @@
 	},
 /obj/machinery/camera{
 	c_tag = "Medbay Treatment Center";
-	dir = 8;
-	network = list("SS13")
+	dir = 8
 	},
 /turf/open/floor/plasteel,
 /area/medical/sleeper)
@@ -31374,7 +31331,7 @@
 /obj/machinery/camera{
 	c_tag = "Security Post - Science";
 	dir = 4;
-	network = list("SS13","RD")
+	network = list("ss13","rd")
 	},
 /obj/machinery/newscaster{
 	pixel_x = -30
@@ -31491,7 +31448,7 @@
 "bAS" = (
 /obj/machinery/computer/security/mining{
 	dir = 4;
-	network = list("MINE","AuxBase")
+	network = list("mine","auxbase")
 	},
 /obj/machinery/camera{
 	c_tag = "Quartermaster's Office";
@@ -32062,7 +32019,7 @@
 /obj/machinery/camera{
 	c_tag = "Research Director's Office";
 	dir = 1;
-	network = list("SS13","RD")
+	network = list("ss13","rd")
 	},
 /obj/item/device/radio/intercom{
 	name = "Station Intercom (General)";
@@ -32099,7 +32056,7 @@
 /obj/machinery/camera{
 	c_tag = "Experimentor Lab Chamber";
 	dir = 1;
-	network = list("SS13","RD")
+	network = list("ss13","rd")
 	},
 /obj/machinery/light,
 /obj/structure/sign/warning/nosmoking{
@@ -32306,8 +32263,7 @@
 /obj/structure/closet/secure_closet/medical3,
 /obj/machinery/camera{
 	c_tag = "Medbay Storage";
-	dir = 2;
-	network = list("SS13")
+	dir = 2
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/sleeper)
@@ -32389,8 +32345,7 @@
 	},
 /obj/machinery/camera{
 	c_tag = "Medbay South";
-	dir = 4;
-	network = list("SS13")
+	dir = 4
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
@@ -32682,8 +32637,7 @@
 	},
 /obj/machinery/camera{
 	c_tag = "Medbay Recovery Room";
-	dir = 8;
-	network = list("SS13")
+	dir = 8
 	},
 /obj/machinery/iv_drip,
 /turf/open/floor/plasteel/white,
@@ -32929,7 +32883,6 @@
 /obj/machinery/camera{
 	c_tag = "Chief Medical Office";
 	dir = 8;
-	network = list("SS13");
 	pixel_y = -22
 	},
 /turf/open/floor/plasteel/barber,
@@ -32941,7 +32894,7 @@
 /obj/machinery/camera{
 	c_tag = "Xenobiology Test Chamber";
 	dir = 2;
-	network = list("Xeno","RD")
+	network = list("xeno","rd")
 	},
 /obj/machinery/light{
 	dir = 1
@@ -33032,7 +32985,7 @@
 /obj/machinery/camera{
 	c_tag = "Toxins Lab West";
 	dir = 2;
-	network = list("SS13","RD")
+	network = list("ss13","rd")
 	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 2
@@ -33142,12 +33095,11 @@
 /area/maintenance/port/fore)
 "bEK" = (
 /obj/machinery/computer/security/mining{
-	network = list("MINE","AuxBase")
+	network = list("mine","auxbase")
 	},
 /obj/machinery/camera{
 	c_tag = "Mining Dock";
-	dir = 4;
-	network = list("SS13")
+	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/miningdock)
@@ -34128,7 +34080,7 @@
 /obj/machinery/camera{
 	c_tag = "Toxins Storage";
 	dir = 4;
-	network = list("SS13","RD")
+	network = list("ss13","rd")
 	},
 /turf/open/floor/plasteel/floorgrime,
 /area/science/storage)
@@ -34263,7 +34215,7 @@
 	dir = 8;
 	layer = 4;
 	name = "Test Chamber Telescreen";
-	network = list("Toxins");
+	network = list("toxins");
 	pixel_x = 30
 	},
 /obj/effect/turf_decal/stripes/line{
@@ -34382,8 +34334,7 @@
 "bHL" = (
 /obj/machinery/camera{
 	c_tag = "Research Division South";
-	dir = 8;
-	network = list("SS13")
+	dir = 8
 	},
 /obj/machinery/door/firedoor/heavy,
 /turf/open/floor/plasteel/white/side{
@@ -34427,8 +34378,7 @@
 /obj/structure/disposalpipe/segment,
 /obj/machinery/camera{
 	c_tag = "Aft Primary Hallway 2";
-	dir = 4;
-	network = list("SS13")
+	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plasteel/caution/corner{
@@ -34525,7 +34475,6 @@
 /obj/machinery/camera{
 	c_tag = "Surgery Operating";
 	dir = 1;
-	network = list("SS13");
 	pixel_x = 22
 	},
 /obj/machinery/light,
@@ -35913,7 +35862,7 @@
 "bKY" = (
 /obj/machinery/computer/security/telescreen{
 	name = "Test Chamber Monitor";
-	network = list("Xeno");
+	network = list("xeno");
 	pixel_y = 2
 	},
 /obj/structure/table/reinforced,
@@ -36077,7 +36026,7 @@
 	invuln = 1;
 	light = null;
 	name = "Hardened Bomb-Test Camera";
-	network = list("Toxins");
+	network = list("toxins");
 	use_power = 0
 	},
 /obj/item/target/alien/anchored,
@@ -36924,7 +36873,7 @@
 /obj/machinery/camera{
 	c_tag = "Toxins Lab East";
 	dir = 8;
-	network = list("SS13","RD");
+	network = list("ss13","rd");
 	pixel_y = -22
 	},
 /obj/effect/turf_decal/stripes/line{
@@ -37054,8 +37003,7 @@
 	},
 /obj/machinery/camera{
 	c_tag = "Atmospherics Monitoring";
-	dir = 2;
-	network = list("SS13")
+	dir = 2
 	},
 /obj/machinery/light{
 	dir = 4
@@ -37074,8 +37022,7 @@
 "bNT" = (
 /obj/machinery/camera{
 	c_tag = "Atmospherics North West";
-	dir = 4;
-	network = list("SS13")
+	dir = 4
 	},
 /obj/machinery/light{
 	dir = 8
@@ -37224,8 +37171,7 @@
 /obj/structure/closet/emcloset,
 /obj/machinery/camera{
 	c_tag = "Virology Airlock";
-	dir = 2;
-	network = list("SS13")
+	dir = 2
 	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 5
@@ -38141,8 +38087,7 @@
 "bQq" = (
 /obj/machinery/camera{
 	c_tag = "Security Post - Engineering";
-	dir = 8;
-	network = list("SS13")
+	dir = 8
 	},
 /obj/item/device/radio/intercom{
 	dir = 4;
@@ -38315,7 +38260,7 @@
 /obj/machinery/camera{
 	c_tag = "Xenobiology North";
 	dir = 8;
-	network = list("SS13","RD")
+	network = list("ss13","rd")
 	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -38352,7 +38297,7 @@
 /obj/machinery/camera{
 	c_tag = "Testing Lab North";
 	dir = 2;
-	network = list("SS13","RD")
+	network = list("ss13","rd")
 	},
 /turf/open/floor/plasteel,
 /area/science/misc_lab)
@@ -38400,7 +38345,7 @@
 	desc = "Used for watching the RD's goons from the safety of his office.";
 	dir = 2;
 	name = "Research Monitor";
-	network = list("RD");
+	network = list("rd");
 	pixel_y = 28
 	},
 /obj/item/device/integrated_circuit_printer,
@@ -38525,7 +38470,7 @@
 	dir = 8;
 	layer = 4;
 	name = "Engine Monitor";
-	network = list("Engine");
+	network = list("engine");
 	pixel_x = 30
 	},
 /turf/open/floor/plasteel/red/side{
@@ -38951,8 +38896,7 @@
 /obj/structure/closet/emcloset,
 /obj/machinery/camera{
 	c_tag = "Telecomms Monitoring";
-	dir = 8;
-	network = list("SS13")
+	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plasteel,
@@ -39300,7 +39244,7 @@
 /obj/item/crowbar,
 /obj/machinery/computer/security/telescreen{
 	name = "Test Chamber Monitor";
-	network = list("Test");
+	network = list("test");
 	pixel_y = -30
 	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden,
@@ -40341,8 +40285,7 @@
 "bVN" = (
 /obj/machinery/camera{
 	c_tag = "Atmospherics Access";
-	dir = 4;
-	network = list("SS13")
+	dir = 4
 	},
 /obj/machinery/light{
 	dir = 8
@@ -40767,8 +40710,7 @@
 	},
 /obj/machinery/camera{
 	c_tag = "Atmospherics West";
-	dir = 8;
-	network = list("SS13")
+	dir = 8
 	},
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -41228,8 +41170,7 @@
 "bXV" = (
 /obj/machinery/camera{
 	c_tag = "Atmospherics East";
-	dir = 8;
-	network = list("SS13")
+	dir = 8
 	},
 /obj/machinery/atmospherics/components/binary/pump{
 	dir = 8;
@@ -41637,7 +41578,7 @@
 /obj/machinery/camera{
 	c_tag = "Xenobiology South";
 	dir = 4;
-	network = list("SS13","RD")
+	network = list("ss13","rd")
 	},
 /turf/open/floor/plasteel/white,
 /area/science/xenobiology)
@@ -42281,8 +42222,7 @@
 	},
 /obj/machinery/camera{
 	c_tag = "Atmospherics Central";
-	dir = 4;
-	network = list("SS13")
+	dir = 4
 	},
 /obj/machinery/atmospherics/components/binary/pump{
 	dir = 0;
@@ -42584,8 +42524,7 @@
 "cbl" = (
 /obj/machinery/camera{
 	c_tag = "Telecomms Server Room";
-	dir = 4;
-	network = list("SS13")
+	dir = 4
 	},
 /turf/open/floor/plasteel/dark/telecomms/mainframe,
 /area/tcommsat/server)
@@ -42667,7 +42606,6 @@
 /obj/machinery/camera{
 	c_tag = "Aft Primary Hallway 1";
 	dir = 8;
-	network = list("SS13");
 	pixel_y = -22
 	},
 /turf/open/floor/plasteel/yellow/corner{
@@ -42899,7 +42837,7 @@
 /obj/machinery/camera{
 	c_tag = "Testing Chamber";
 	dir = 1;
-	network = list("Test","RD")
+	network = list("test","rd")
 	},
 /obj/machinery/light,
 /turf/open/floor/engine,
@@ -42937,7 +42875,7 @@
 	desc = "Used for watching the RD's goons from the safety of his office.";
 	dir = 1;
 	name = "Research Monitor";
-	network = list("RD");
+	network = list("rd");
 	pixel_y = -28
 	},
 /obj/item/device/integrated_circuit_printer,
@@ -43873,8 +43811,7 @@
 "cex" = (
 /obj/machinery/camera{
 	c_tag = "Atmospherics South West";
-	dir = 4;
-	network = list("SS13")
+	dir = 4
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 8
@@ -44194,7 +44131,7 @@
 /obj/machinery/camera{
 	c_tag = "Xenobiology Kill Room";
 	dir = 4;
-	network = list("SS13","RD")
+	network = list("ss13","rd")
 	},
 /turf/open/floor/circuit/killroom,
 /area/science/xenobiology)
@@ -44725,8 +44662,7 @@
 "cgQ" = (
 /obj/machinery/camera{
 	c_tag = "Engineering East";
-	dir = 8;
-	network = list("SS13")
+	dir = 8
 	},
 /obj/structure/closet/wardrobe/engineering_yellow,
 /turf/open/floor/plasteel/yellow/corner{
@@ -45528,7 +45464,7 @@
 /obj/machinery/camera{
 	c_tag = "Turbine Chamber";
 	dir = 4;
-	network = list("Turbine")
+	network = list("turbine")
 	},
 /turf/open/floor/engine/vacuum,
 /area/maintenance/disposal/incinerator)
@@ -45686,8 +45622,7 @@
 	},
 /obj/machinery/camera{
 	c_tag = "Chief Engineer's Office";
-	dir = 4;
-	network = list("SS13")
+	dir = 4
 	},
 /turf/open/floor/plasteel/vault,
 /area/crew_quarters/heads/chief)
@@ -45735,8 +45670,7 @@
 "cjl" = (
 /obj/machinery/camera{
 	c_tag = "Engineering MiniSat Access";
-	dir = 4;
-	network = list("SS13")
+	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -45919,8 +45853,7 @@
 	},
 /obj/machinery/camera{
 	c_tag = "Engineering Secure Storage";
-	dir = 4;
-	network = list("SS13")
+	dir = 4
 	},
 /turf/open/floor/plating,
 /area/engine/engineering)
@@ -45978,7 +45911,7 @@
 	desc = "Used for watching the RD's goons from the safety of your own office.";
 	dir = 4;
 	name = "Research Monitor";
-	network = list("RD");
+	network = list("rd");
 	pixel_x = -24
 	},
 /turf/open/floor/plasteel/vault,
@@ -46601,8 +46534,7 @@
 /obj/structure/chair/stool,
 /obj/machinery/camera{
 	c_tag = "Aft Starboard Solar Control";
-	dir = 4;
-	network = list("SS13")
+	dir = 4
 	},
 /turf/open/floor/plating,
 /area/maintenance/solars/starboard/aft)
@@ -47158,8 +47090,7 @@
 	},
 /obj/machinery/camera{
 	c_tag = "SMES Room";
-	dir = 8;
-	network = list("SS13")
+	dir = 8
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on,
 /turf/open/floor/plasteel/dark,
@@ -47187,8 +47118,7 @@
 "cnt" = (
 /obj/machinery/camera{
 	c_tag = "Engineering West";
-	dir = 4;
-	network = list("SS13")
+	dir = 4
 	},
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -47398,8 +47328,7 @@
 	},
 /obj/machinery/camera{
 	c_tag = "SMES Access";
-	dir = 8;
-	network = list("SS13")
+	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 1
@@ -48069,8 +47998,7 @@
 "cpV" = (
 /obj/machinery/camera{
 	c_tag = "Engineering Storage";
-	dir = 4;
-	network = list("SS13")
+	dir = 4
 	},
 /obj/machinery/rnd/protolathe/department/engineering,
 /turf/open/floor/plasteel,
@@ -48171,7 +48099,7 @@
 /obj/machinery/camera{
 	c_tag = "Engineering Supermatter Fore";
 	dir = 1;
-	network = list("SS13","Engine");
+	network = list("ss13","engine");
 	pixel_x = 23
 	},
 /obj/machinery/atmospherics/pipe/manifold/green/visible{
@@ -48236,8 +48164,7 @@
 "cqp" = (
 /obj/machinery/camera{
 	c_tag = "Engineering Escape Pod";
-	dir = 4;
-	network = list("SS13")
+	dir = 4
 	},
 /turf/open/floor/plating,
 /area/engine/engineering)
@@ -48872,7 +48799,7 @@
 	desc = "Used for watching the turbine vent.";
 	dir = 1;
 	name = "turbine vent monitor";
-	network = list("Turbine");
+	network = list("turbine");
 	pixel_y = -29
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
@@ -49106,7 +49033,7 @@
 /obj/machinery/camera{
 	c_tag = "MiniSat Pod Access";
 	dir = 1;
-	network = list("MiniSat");
+	network = list("minisat");
 	start_active = 1
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on,
@@ -49388,7 +49315,7 @@
 /obj/machinery/camera{
 	c_tag = "MiniSat Teleporter";
 	dir = 1;
-	network = list("MiniSat");
+	network = list("minisat");
 	start_active = 1
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
@@ -49443,7 +49370,7 @@
 /obj/machinery/camera/motion{
 	c_tag = "MiniSat Foyer";
 	dir = 1;
-	network = list("MiniSat")
+	network = list("minisat")
 	},
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/aisat_interior)
@@ -49623,7 +49550,7 @@
 /obj/machinery/camera{
 	c_tag = "MiniSat Atmospherics";
 	dir = 4;
-	network = list("MiniSat");
+	network = list("minisat");
 	start_active = 1
 	},
 /obj/machinery/airalarm{
@@ -49663,7 +49590,7 @@
 /obj/machinery/camera{
 	c_tag = "MiniSat Antechamber";
 	dir = 4;
-	network = list("MiniSat");
+	network = list("minisat");
 	start_active = 1
 	},
 /obj/machinery/turretid{
@@ -49752,7 +49679,7 @@
 /obj/machinery/camera{
 	c_tag = "MiniSat Service Bay";
 	dir = 8;
-	network = list("MiniSat");
+	network = list("minisat");
 	start_active = 1
 	},
 /obj/machinery/airalarm{
@@ -50182,7 +50109,7 @@
 /obj/machinery/camera{
 	c_tag = "MiniSat External NorthWest";
 	dir = 8;
-	network = list("MiniSat");
+	network = list("minisat");
 	start_active = 1
 	},
 /turf/open/space,
@@ -50229,7 +50156,7 @@
 /obj/machinery/camera{
 	c_tag = "MiniSat External NorthEast";
 	dir = 4;
-	network = list("MiniSat");
+	network = list("minisat");
 	start_active = 1
 	},
 /turf/open/space,
@@ -50245,7 +50172,7 @@
 /obj/machinery/camera/motion{
 	c_tag = "MiniSat Core Hallway";
 	dir = 4;
-	network = list("MiniSat")
+	network = list("minisat")
 	},
 /obj/machinery/firealarm{
 	dir = 8;
@@ -50623,7 +50550,7 @@
 /obj/machinery/camera/motion{
 	c_tag = "MiniSat AI Chamber North";
 	dir = 1;
-	network = list("MiniSat")
+	network = list("minisat")
 	},
 /turf/open/floor/circuit,
 /area/ai_monitored/turret_protected/ai)
@@ -51546,7 +51473,7 @@
 /obj/machinery/camera{
 	c_tag = "MiniSat External SouthWest";
 	dir = 8;
-	network = list("MiniSat");
+	network = list("minisat");
 	start_active = 1
 	},
 /turf/open/space,
@@ -51581,7 +51508,7 @@
 /obj/machinery/camera{
 	c_tag = "MiniSat External SouthEast";
 	dir = 4;
-	network = list("MiniSat");
+	network = list("minisat");
 	start_active = 1
 	},
 /turf/open/space,
@@ -51611,7 +51538,7 @@
 /obj/machinery/camera/motion{
 	c_tag = "MiniSat AI Chamber South";
 	dir = 2;
-	network = list("MiniSat")
+	network = list("minisat")
 	},
 /turf/open/floor/circuit,
 /area/ai_monitored/turret_protected/ai)
@@ -51643,7 +51570,7 @@
 /obj/machinery/camera{
 	c_tag = "MiniSat External South";
 	dir = 2;
-	network = list("MiniSat");
+	network = list("minisat");
 	start_active = 1
 	},
 /turf/open/space,
@@ -51689,8 +51616,7 @@
 "cBn" = (
 /obj/machinery/camera{
 	c_tag = "Locker Room Toilets";
-	dir = 8;
-	network = list("SS13")
+	dir = 8
 	},
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/plasteel/freezer,
@@ -52476,7 +52402,7 @@
 /obj/machinery/camera{
 	c_tag = "Engineering Supermatter Port";
 	dir = 4;
-	network = list("SS13","Engine")
+	network = list("ss13","engine")
 	},
 /turf/open/floor/engine,
 /area/engine/engineering)
@@ -52522,7 +52448,7 @@
 /obj/machinery/camera{
 	c_tag = "Engineering Supermatter Starboard";
 	dir = 8;
-	network = list("SS13","Engine")
+	network = list("ss13","engine")
 	},
 /turf/open/floor/engine,
 /area/engine/engineering)
@@ -52579,7 +52505,7 @@
 /obj/machinery/camera{
 	c_tag = "Supermatter Chamber";
 	dir = 2;
-	network = list("Engine");
+	network = list("engine");
 	pixel_x = 23
 	},
 /obj/structure/cable/yellow{
@@ -52941,7 +52867,7 @@
 /obj/machinery/camera{
 	c_tag = "Engineering Supermatter Aft";
 	dir = 2;
-	network = list("SS13","Engine");
+	network = list("ss13","engine");
 	pixel_x = 23
 	},
 /obj/effect/turf_decal/delivery,
@@ -53591,7 +53517,7 @@
 	dir = 8;
 	layer = 4;
 	name = "Engine Monitor";
-	network = list("Engine");
+	network = list("engine");
 	pixel_x = 30
 	},
 /obj/effect/turf_decal/stripes/line{
@@ -54398,7 +54324,7 @@
 /obj/machinery/camera{
 	c_tag = "Circuitry Lab";
 	dir = 8;
-	network = list("SS13","RD")
+	network = list("ss13","rd")
 	},
 /turf/open/floor/plasteel,
 /area/science/circuit)
@@ -54760,7 +54686,7 @@
 /obj/item/screwdriver,
 /obj/machinery/camera{
 	c_tag = "Circuitry Lab North";
-	network = list("SS13","RD")
+	network = list("ss13","rd")
 	},
 /turf/open/floor/plasteel/white,
 /area/science/circuit)

--- a/_maps/map_files/Deltastation/DeltaStation2.dmm
+++ b/_maps/map_files/Deltastation/DeltaStation2.dmm
@@ -3965,7 +3965,7 @@
 /obj/machinery/camera{
 	c_tag = "Supermatter Engine - Fore";
 	name = "atmospherics camera";
-	network = list("SS13","Engine")
+	network = list("ss13","engine")
 	},
 /turf/open/floor/plasteel/vault{
 	dir = 8
@@ -8665,7 +8665,7 @@
 /obj/machinery/camera{
 	c_tag = "Supermatter Chamber";
 	dir = 2;
-	network = list("Engine")
+	network = list("engine")
 	},
 /turf/open/floor/engine,
 /area/engine/supermatter)
@@ -9244,7 +9244,7 @@
 	c_tag = "Supermatter Engine - Starboard";
 	dir = 8;
 	name = "atmospherics camera";
-	network = list("SS13","Engine")
+	network = list("ss13","engine")
 	},
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -9645,7 +9645,7 @@
 	c_tag = "Supermatter Engine - Port";
 	dir = 4;
 	name = "atmospherics camera";
-	network = list("SS13","Engine")
+	network = list("ss13","engine")
 	},
 /obj/effect/turf_decal/bot,
 /obj/machinery/atmospherics/components/unary/thermomachine/heater{
@@ -11683,7 +11683,7 @@
 /obj/machinery/camera{
 	c_tag = "Supermatter Engine - Aft";
 	name = "atmospherics camera";
-	network = list("SS13","Engine")
+	network = list("ss13","engine")
 	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -12899,7 +12899,7 @@
 	c_tag = "Prison - Garden";
 	dir = 2;
 	name = "prison camera";
-	network = list("SS13","prison")
+	network = list("ss13","prison")
 	},
 /turf/open/floor/plasteel/neutral/side{
 	dir = 1
@@ -17774,7 +17774,7 @@
 	c_tag = "Prison - Relaxation Area";
 	dir = 1;
 	name = "prison camera";
-	network = list("SS13","prison")
+	network = list("ss13","prison")
 	},
 /turf/open/floor/plating,
 /area/security/prison)
@@ -19584,7 +19584,7 @@
 	c_tag = "Prison - Cell 3";
 	dir = 2;
 	name = "prison camera";
-	network = list("SS13","prison")
+	network = list("ss13","prison")
 	},
 /turf/open/floor/plating{
 	icon_state = "panelscorched"
@@ -19624,7 +19624,7 @@
 	c_tag = "Prison - Cell 2";
 	dir = 2;
 	name = "prison camera";
-	network = list("SS13","prison")
+	network = list("ss13","prison")
 	},
 /turf/open/floor/plasteel/red/side{
 	dir = 4
@@ -19656,7 +19656,7 @@
 	c_tag = "Prison - Cell 1";
 	dir = 2;
 	name = "prison camera";
-	network = list("SS13","prison")
+	network = list("ss13","prison")
 	},
 /turf/open/floor/plasteel/red/side{
 	dir = 4
@@ -29372,7 +29372,7 @@
 "bpg" = (
 /obj/machinery/computer/security{
 	name = "Labor Camp Monitoring";
-	network = list("Labor")
+	network = list("labor")
 	},
 /obj/item/device/radio/intercom{
 	name = "Station Intercom";
@@ -29688,7 +29688,7 @@
 	c_tag = "AI Satellite - Fore";
 	dir = 1;
 	name = "ai camera";
-	network = list("Sat");
+	network = list("minisat");
 	start_active = 1
 	},
 /turf/open/floor/plasteel/vault{
@@ -32967,7 +32967,7 @@
 /obj/machinery/camera/motion{
 	c_tag = "AI Chamber - Fore";
 	name = "motion-sensitive ai camera";
-	network = list("AI")
+	network = list("ai")
 	},
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plasteel/dark,
@@ -33456,8 +33456,7 @@
 "bxe" = (
 /obj/machinery/camera/motion{
 	c_tag = "Vault";
-	dir = 4;
-	network = list("SS13")
+	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
@@ -33583,7 +33582,7 @@
 	c_tag = "AI Satellite - Fore Port";
 	dir = 8;
 	name = "ai camera";
-	network = list("Sat");
+	network = list("minisat");
 	start_active = 1
 	},
 /turf/open/floor/plasteel/vault{
@@ -33643,7 +33642,7 @@
 	c_tag = "AI Satellite - Fore Starboard";
 	dir = 4;
 	name = "ai camera";
-	network = list("Sat");
+	network = list("minisat");
 	start_active = 1
 	},
 /turf/open/floor/plasteel/vault{
@@ -35397,7 +35396,7 @@
 	dir = 4;
 	layer = 4;
 	name = "Engine Monitor";
-	network = list("Engine");
+	network = list("engine");
 	pixel_x = -24
 	},
 /turf/open/floor/plasteel/caution{
@@ -35738,7 +35737,7 @@
 /obj/machinery/computer/security/telescreen{
 	desc = "Used for watching the RD's goons and the AI's satellite from the safety of his office.";
 	name = "Research Monitor";
-	network = list("RD","Sat");
+	network = list("rd","minisat");
 	pixel_y = 2
 	},
 /turf/open/floor/plasteel/dark,
@@ -41541,7 +41540,7 @@
 	c_tag = "Telecomms - Monitoring";
 	dir = 2;
 	name = "telecomms camera";
-	network = list("SS13","tcomm")
+	network = list("ss13","tcomm")
 	},
 /turf/open/floor/plasteel/grimy,
 /area/tcommsat/computer)
@@ -42027,7 +42026,7 @@
 	c_tag = "AI Chamber - Aft";
 	dir = 1;
 	name = "motion-sensitive ai camera";
-	network = list("AI")
+	network = list("ai")
 	},
 /turf/open/floor/plasteel/vault,
 /area/ai_monitored/turret_protected/ai)
@@ -42968,7 +42967,7 @@
 	c_tag = "AI Satellite - Port";
 	dir = 8;
 	name = "ai camera";
-	network = list("Sat");
+	network = list("minisat");
 	start_active = 1
 	},
 /turf/open/floor/plasteel/vault{
@@ -43036,7 +43035,7 @@
 	c_tag = "AI Satellite - Starboard";
 	dir = 4;
 	name = "ai camera";
-	network = list("Sat");
+	network = list("minisat");
 	start_active = 1
 	},
 /turf/open/floor/plasteel/vault{
@@ -43948,7 +43947,7 @@
 	c_tag = "AI Satellite - Antechamber";
 	dir = 2;
 	name = "ai camera";
-	network = list("Sat");
+	network = list("minisat");
 	start_active = 1
 	},
 /turf/open/floor/plasteel/vault,
@@ -44792,8 +44791,7 @@
 "bTl" = (
 /obj/machinery/camera/motion{
 	c_tag = "Armoury - Exterior";
-	dir = 4;
-	network = list("SS13")
+	dir = 4
 	},
 /turf/open/space,
 /area/space/nearstation)
@@ -44868,7 +44866,7 @@
 	c_tag = "AI Satellite - Maintenance";
 	dir = 8;
 	name = "ai camera";
-	network = list("Sat");
+	network = list("minisat");
 	start_active = 1
 	},
 /obj/effect/turf_decal/stripes/line,
@@ -44956,7 +44954,7 @@
 	c_tag = "AI Satellite - Teleporter";
 	dir = 4;
 	name = "ai camera";
-	network = list("Sat");
+	network = list("minisat");
 	start_active = 1
 	},
 /turf/open/floor/plasteel/vault{
@@ -45072,7 +45070,7 @@
 	c_tag = "AI Satellite - Transit Tube";
 	dir = 2;
 	name = "ai camera";
-	network = list("Sat");
+	network = list("minisat");
 	start_active = 1
 	},
 /obj/item/clipboard,
@@ -46436,7 +46434,7 @@
 	desc = "Used for watching the AI's satellite.";
 	dir = 4;
 	name = "Research Monitor";
-	network = list("Sat");
+	network = list("minisat");
 	pixel_y = 2
 	},
 /turf/open/floor/plasteel/vault{
@@ -46483,7 +46481,7 @@
 	dir = 4;
 	layer = 4;
 	name = "Engine Monitor";
-	network = list("Engine");
+	network = list("engine");
 	pixel_x = -30
 	},
 /mob/living/simple_animal/parrot/Poly,
@@ -49775,7 +49773,7 @@
 	c_tag = "Telecomms - Chamber Port";
 	dir = 4;
 	name = "telecomms camera";
-	network = list("SS13","tcomm")
+	network = list("ss13","tcomm")
 	},
 /turf/open/floor/plasteel/vault/telecomms{
 	dir = 8
@@ -50219,7 +50217,7 @@
 /obj/machinery/camera/motion{
 	c_tag = "AI - Upload";
 	name = "motion-sensitive ai camera";
-	network = list("Sat")
+	network = list("minisat")
 	},
 /turf/open/floor/plasteel/vault,
 /area/ai_monitored/turret_protected/ai_upload)
@@ -51313,7 +51311,7 @@
 /obj/machinery/camera/emp_proof{
 	c_tag = "Containment - Fore Starboard";
 	dir = 8;
-	network = list("Singularity")
+	network = list("singularity")
 	},
 /turf/open/floor/plating/airless,
 /area/engine/engineering)
@@ -51662,7 +51660,7 @@
 	c_tag = "Telecomms - Chamber Starboard";
 	dir = 8;
 	name = "telecomms camera";
-	network = list("SS13","tcomm")
+	network = list("ss13","tcomm")
 	},
 /turf/open/floor/plasteel/vault/telecomms{
 	dir = 8
@@ -53030,7 +53028,7 @@
 /obj/machinery/camera/emp_proof{
 	c_tag = "Containment - Fore Port";
 	dir = 4;
-	network = list("Singularity")
+	network = list("singularity")
 	},
 /turf/open/space,
 /area/space/nearstation)
@@ -53328,8 +53326,7 @@
 /obj/machinery/camera/motion{
 	c_tag = "Bridge - Captain's Emergency Escape";
 	dir = 4;
-	name = "command camera";
-	network = list("SS13")
+	name = "command camera"
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -55088,7 +55085,7 @@
 	c_tag = "AI Satellite - Aft Port";
 	dir = 8;
 	name = "ai camera";
-	network = list("Sat");
+	network = list("minisat");
 	start_active = 1
 	},
 /turf/open/floor/plasteel/vault{
@@ -55163,7 +55160,7 @@
 	c_tag = "AI Satellite - Aft Starboard";
 	dir = 4;
 	name = "ai camera";
-	network = list("Sat");
+	network = list("minisat");
 	start_active = 1
 	},
 /turf/open/floor/plasteel/vault{
@@ -55467,7 +55464,7 @@
 	c_tag = "Telecomms - Cooling Room";
 	dir = 8;
 	name = "telecomms camera";
-	network = list("SS13","tcomm")
+	network = list("ss13","tcomm")
 	},
 /obj/effect/turf_decal/delivery,
 /turf/open/floor/plasteel,
@@ -57086,7 +57083,7 @@
 	dir = 4;
 	layer = 4;
 	name = "Engine Containment Telescreen";
-	network = list("Singularity");
+	network = list("singularity");
 	pixel_x = -30
 	},
 /obj/effect/turf_decal/stripes/line{
@@ -58641,7 +58638,7 @@
 /obj/machinery/camera/emp_proof{
 	c_tag = "Containment - Particle Accelerator";
 	dir = 1;
-	network = list("Singularity")
+	network = list("singularity")
 	},
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plating,
@@ -61335,7 +61332,7 @@
 /obj/machinery/camera/emp_proof{
 	c_tag = "Containment - Aft Port";
 	dir = 4;
-	network = list("Singularity")
+	network = list("singularity")
 	},
 /turf/open/space,
 /area/space/nearstation)
@@ -62952,7 +62949,7 @@
 /obj/machinery/camera/emp_proof{
 	c_tag = "Containment - Aft Starboard";
 	dir = 8;
-	network = list("Singularity")
+	network = list("singularity")
 	},
 /turf/open/floor/plating/airless,
 /area/engine/engineering)
@@ -67611,7 +67608,7 @@
 /obj/machinery/camera{
 	c_tag = "Xenobiology - Cell 1";
 	name = "xenobiology camera";
-	network = list("SS13","xeno","RD")
+	network = list("ss13","xeno","rd")
 	},
 /turf/open/floor/plasteel/vault{
 	dir = 5
@@ -67624,7 +67621,7 @@
 /obj/machinery/camera{
 	c_tag = "Xenobiology - Cell 2";
 	name = "xenobiology camera";
-	network = list("SS13","xeno","RD")
+	network = list("ss13","xeno","rd")
 	},
 /turf/open/floor/plasteel/vault{
 	dir = 5
@@ -67637,7 +67634,7 @@
 /obj/machinery/camera{
 	c_tag = "Xenobiology - Cell 3";
 	name = "xenobiology camera";
-	network = list("SS13","xeno","RD")
+	network = list("ss13","xeno","rd")
 	},
 /turf/open/floor/plasteel/vault{
 	dir = 5
@@ -67654,7 +67651,7 @@
 	c_tag = "Xenobiology - Killroom Chamber";
 	dir = 2;
 	name = "xenobiology camera";
-	network = list("SS13","xeno","RD")
+	network = list("ss13","xeno","rd")
 	},
 /turf/open/floor/plasteel/vault/killroom,
 /area/science/xenobiology)
@@ -69703,7 +69700,7 @@
 	c_tag = "Xenobiology - Port";
 	dir = 2;
 	name = "xenobiology camera";
-	network = list("SS13","xeno","RD")
+	network = list("ss13","xeno","rd")
 	},
 /obj/effect/turf_decal/delivery,
 /turf/open/floor/plasteel,
@@ -72171,7 +72168,7 @@
 	c_tag = "Xenobiology - Secure Cell";
 	dir = 4;
 	name = "xenobiology camera";
-	network = list("SS13","xeno","RD")
+	network = list("ss13","xeno","rd")
 	},
 /turf/open/floor/plasteel/vault{
 	dir = 5
@@ -72385,7 +72382,7 @@
 	c_tag = "Science - Fore";
 	dir = 8;
 	name = "science camera";
-	network = list("SS13","RD")
+	network = list("ss13","rd")
 	},
 /turf/open/floor/plasteel/whitepurple/corner{
 	dir = 4
@@ -72445,7 +72442,7 @@
 	c_tag = "Security Post - Science";
 	dir = 8;
 	name = "security camera";
-	network = list("SS13","RD")
+	network = list("ss13","rd")
 	},
 /turf/open/floor/plasteel/red/side{
 	dir = 6
@@ -72496,7 +72493,7 @@
 	c_tag = "Science - Waiting Room";
 	dir = 1;
 	name = "science camera";
-	network = list("SS13","RD")
+	network = list("ss13","rd")
 	},
 /turf/open/floor/plasteel/whitepurple/corner{
 	dir = 8
@@ -73192,7 +73189,7 @@
 	c_tag = "Xenobiology - Starboard";
 	dir = 8;
 	name = "xenobiology camera";
-	network = list("SS13","xeno","RD")
+	network = list("ss13","xeno","rd")
 	},
 /obj/effect/turf_decal/delivery,
 /turf/open/floor/plasteel,
@@ -74954,7 +74951,7 @@
 	c_tag = "Science - Research Division Access";
 	dir = 8;
 	name = "science camera";
-	network = list("SS13","RD")
+	network = list("ss13","rd")
 	},
 /obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel,
@@ -76213,7 +76210,7 @@
 	c_tag = "Science - Research and Development";
 	dir = 8;
 	name = "science camera";
-	network = list("SS13","RD")
+	network = list("ss13","rd")
 	},
 /turf/open/floor/plasteel/whitepurple/corner,
 /area/science/lab)
@@ -76281,7 +76278,7 @@
 	c_tag = "Medbay - Chemistry";
 	dir = 8;
 	name = "medbay camera";
-	network = list("SS13","Medbay")
+	network = list("ss13","medbay")
 	},
 /turf/open/floor/plasteel/whiteyellow/corner,
 /area/medical/chemistry)
@@ -76667,7 +76664,7 @@
 	c_tag = "Xenobiology - Cell 4";
 	dir = 1;
 	name = "xenobiology camera";
-	network = list("SS13","xeno","RD")
+	network = list("ss13","xeno","rd")
 	},
 /turf/open/floor/plasteel/vault{
 	dir = 5
@@ -76679,7 +76676,7 @@
 	c_tag = "Xenobiology - Cell 5";
 	dir = 1;
 	name = "xenobiology camera";
-	network = list("SS13","xeno","RD")
+	network = list("ss13","xeno","rd")
 	},
 /turf/open/floor/plasteel/vault{
 	dir = 5
@@ -76691,7 +76688,7 @@
 	c_tag = "Xenobiology - Cell 6";
 	dir = 1;
 	name = "xenobiology camera";
-	network = list("SS13","xeno","RD")
+	network = list("ss13","xeno","rd")
 	},
 /turf/open/floor/plasteel/vault{
 	dir = 5
@@ -76736,7 +76733,7 @@
 	c_tag = "Science - Port";
 	dir = 2;
 	name = "science camera";
-	network = list("SS13","RD")
+	network = list("ss13","rd")
 	},
 /turf/open/floor/plasteel/whitepurple/corner{
 	dir = 1
@@ -76803,7 +76800,7 @@
 	c_tag = "Science - Center";
 	dir = 2;
 	name = "science camera";
-	network = list("SS13","RD")
+	network = list("ss13","rd")
 	},
 /turf/open/floor/plasteel/whitepurple/corner{
 	dir = 1
@@ -77957,7 +77954,7 @@
 	desc = "Used for watching the RD's goons from the safety of his office.";
 	dir = 4;
 	name = "Research Monitor";
-	network = list("RD");
+	network = list("rd");
 	pixel_x = -28
 	},
 /turf/open/floor/plasteel/white/corner,
@@ -78116,7 +78113,7 @@
 	c_tag = "Science - Experimentation Lab";
 	dir = 2;
 	name = "science camera";
-	network = list("SS13","RD")
+	network = list("ss13","rd")
 	},
 /obj/effect/turf_decal/delivery,
 /turf/open/floor/plasteel,
@@ -79517,7 +79514,7 @@
 	c_tag = "Science - Lab Access";
 	dir = 8;
 	name = "science camera";
-	network = list("SS13","RD")
+	network = list("ss13","rd")
 	},
 /obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel,
@@ -81863,7 +81860,7 @@
 	desc = "Used for watching the RD's goons from the safety of his office.";
 	dir = 4;
 	name = "Research Monitor";
-	network = list("RD");
+	network = list("rd");
 	pixel_x = -28
 	},
 /turf/open/floor/plasteel/white/corner{
@@ -82110,7 +82107,7 @@
 	c_tag = "Science - Research Director's Office";
 	dir = 8;
 	name = "science camera";
-	network = list("SS13","RD")
+	network = list("ss13","rd")
 	},
 /obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel,
@@ -83961,7 +83958,7 @@
 	c_tag = "Science - Experimentor";
 	dir = 1;
 	name = "science camera";
-	network = list("SS13","RD")
+	network = list("ss13","rd")
 	},
 /turf/open/floor/plasteel/vault{
 	dir = 5
@@ -83976,7 +83973,7 @@
 	c_tag = "Science - Toxins Mixing Lab Fore";
 	dir = 4;
 	name = "science camera";
-	network = list("SS13","RD")
+	network = list("ss13","rd")
 	},
 /turf/open/floor/plasteel/escape{
 	dir = 8
@@ -84018,7 +84015,7 @@
 	c_tag = "Science - Firing Range";
 	dir = 4;
 	name = "science camera";
-	network = list("SS13","RD")
+	network = list("ss13","rd")
 	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -84115,7 +84112,7 @@
 	c_tag = "Science - Aft Center";
 	dir = 8;
 	name = "science camera";
-	network = list("SS13","RD")
+	network = list("ss13","rd")
 	},
 /turf/open/floor/plasteel/whitepurple/corner,
 /area/science/research)
@@ -84158,7 +84155,7 @@
 	c_tag = "Science - Mech Bay";
 	dir = 1;
 	name = "science camera";
-	network = list("SS13","RD")
+	network = list("ss13","rd")
 	},
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plasteel,
@@ -87072,7 +87069,7 @@
 	c_tag = "Science - Research Director's Quarters";
 	dir = 1;
 	name = "science camera";
-	network = list("SS13","RD")
+	network = list("ss13","rd")
 	},
 /obj/machinery/modular_computer/console/preset/research{
 	dir = 1
@@ -87768,7 +87765,7 @@
 	c_tag = "Science - Robotics Lab";
 	dir = 8;
 	name = "science camera";
-	network = list("SS13","RD")
+	network = list("ss13","rd")
 	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -88606,7 +88603,7 @@
 	c_tag = "Science - Toxins Launch Site";
 	dir = 2;
 	name = "science camera";
-	network = list("SS13","RD")
+	network = list("ss13","rd")
 	},
 /obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel,
@@ -88721,7 +88718,7 @@
 	c_tag = "Science - Toxins Mixing Lab Aft";
 	dir = 8;
 	name = "science camera";
-	network = list("SS13","RD")
+	network = list("ss13","rd")
 	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -89349,7 +89346,7 @@
 	dir = 4;
 	layer = 4;
 	name = "Testing Site Telescreen";
-	network = list("Toxins")
+	network = list("toxins")
 	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -90178,7 +90175,7 @@
 	c_tag = "Science - Server Room";
 	dir = 8;
 	name = "science camera";
-	network = list("SS13","RD")
+	network = list("ss13","rd")
 	},
 /turf/open/floor/circuit/green/telecomms/mainframe,
 /area/science/server)
@@ -90191,7 +90188,7 @@
 	c_tag = "Science - Aft";
 	dir = 4;
 	name = "science camera";
-	network = list("SS13","RD")
+	network = list("ss13","rd")
 	},
 /turf/open/floor/plasteel/whitepurple/corner{
 	dir = 8
@@ -90852,7 +90849,7 @@
 	c_tag = "Science - Toxins Secure Storage";
 	dir = 4;
 	name = "science camera";
-	network = list("SS13","RD")
+	network = list("ss13","rd")
 	},
 /obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel,
@@ -91654,7 +91651,7 @@
 	invuln = 1;
 	light = null;
 	name = "hardened testing camera";
-	network = list("Toxins");
+	network = list("toxins");
 	start_active = 1;
 	use_power = 0
 	},
@@ -92994,7 +92991,7 @@
 	c_tag = "Science - Break Room";
 	dir = 8;
 	name = "science camera";
-	network = list("SS13","RD")
+	network = list("ss13","rd")
 	},
 /turf/open/floor/plasteel/neutral/side{
 	dir = 4
@@ -100879,7 +100876,7 @@
 /obj/machinery/camera{
 	c_tag = "MiniSat Service Bay";
 	dir = 8;
-	network = list("MiniSat");
+	network = list("minisat");
 	start_active = 1
 	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
@@ -101023,7 +101020,7 @@
 	c_tag = "Science - Experimentation Lab";
 	dir = 2;
 	name = "science camera";
-	network = list("SS13","RD")
+	network = list("ss13","rd")
 	},
 /obj/machinery/requests_console{
 	department = "Circuitry Lab";
@@ -101323,7 +101320,7 @@
 	c_tag = "Science - Lab Access";
 	dir = 8;
 	name = "science camera";
-	network = list("SS13","RD")
+	network = list("ss13","rd")
 	},
 /obj/structure/sign/departments/science{
 	pixel_x = 32

--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -188,7 +188,7 @@
 	},
 /obj/machinery/camera{
 	c_tag = "Prison Hydroponics";
-	network = list("SS13","Prison")
+	network = list("ss13","prison")
 	},
 /turf/open/floor/plasteel/floorgrime,
 /area/security/prison)
@@ -1034,7 +1034,7 @@
 /obj/machinery/camera{
 	c_tag = "Prison Chamber";
 	dir = 1;
-	network = list("SS13","Prison")
+	network = list("ss13","prison")
 	},
 /turf/open/floor/plasteel/floorgrime,
 /area/security/prison)
@@ -1119,7 +1119,7 @@
 /obj/machinery/camera{
 	c_tag = "Prison Sanitarium";
 	dir = 2;
-	network = list("SS13","Prison")
+	network = list("ss13","prison")
 	},
 /turf/open/floor/plasteel/whitered/side{
 	dir = 1
@@ -1424,7 +1424,7 @@
 /obj/structure/bed,
 /obj/machinery/camera{
 	c_tag = "Prison Cell 3";
-	network = list("SS13","Prison")
+	network = list("ss13","prison")
 	},
 /turf/open/floor/plasteel/floorgrime,
 /area/security/prison)
@@ -1447,7 +1447,7 @@
 /obj/structure/bed,
 /obj/machinery/camera{
 	c_tag = "Prison Cell 2";
-	network = list("SS13","Prison")
+	network = list("ss13","prison")
 	},
 /turf/open/floor/plasteel/floorgrime,
 /area/security/prison)
@@ -1479,7 +1479,7 @@
 /obj/structure/bed,
 /obj/machinery/camera{
 	c_tag = "Prison Cell 1";
-	network = list("SS13","Prison")
+	network = list("ss13","prison")
 	},
 /turf/open/floor/plasteel/floorgrime,
 /area/security/prison)
@@ -1532,8 +1532,7 @@
 /obj/structure/lattice,
 /obj/machinery/camera/motion{
 	c_tag = "Armory - External";
-	dir = 1;
-	network = list("SS13")
+	dir = 1
 	},
 /turf/open/space,
 /area/space/nearstation)
@@ -2146,12 +2145,12 @@
 /obj/machinery/computer/security/telescreen{
 	desc = "Used for watching Prison Wing holding areas.";
 	name = "Prison Monitor";
-	network = list("Prison");
+	network = list("prison");
 	pixel_y = 30
 	},
 /obj/machinery/camera{
 	c_tag = "Prison Hallway Port";
-	network = list("SS13","Prison")
+	network = list("ss13","prison")
 	},
 /turf/open/floor/plasteel/red/corner{
 	dir = 2
@@ -2217,7 +2216,7 @@
 /obj/machinery/computer/security/telescreen{
 	desc = "Used for watching Prison Wing holding areas.";
 	name = "Prison Monitor";
-	network = list("Prison");
+	network = list("prison");
 	pixel_y = 30
 	},
 /turf/open/floor/plasteel/red/corner{
@@ -2294,7 +2293,7 @@
 /obj/machinery/camera{
 	c_tag = "Prison Hallway Starboard";
 	dir = 2;
-	network = list("SS13","Prison")
+	network = list("ss13","prison")
 	},
 /turf/open/floor/plasteel/red/corner{
 	dir = 2
@@ -2398,8 +2397,7 @@
 	},
 /obj/machinery/camera{
 	c_tag = "Head of Security's Office";
-	dir = 2;
-	network = list("SS13")
+	dir = 2
 	},
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/heads/hos)
@@ -3420,8 +3418,7 @@
 	pixel_y = 8
 	},
 /obj/machinery/camera/autoname{
-	dir = 4;
-	network = list("SS13")
+	dir = 4
 	},
 /turf/open/floor/plating,
 /area/maintenance/solars/port/fore)
@@ -3561,8 +3558,7 @@
 /obj/machinery/light,
 /obj/machinery/camera/motion{
 	c_tag = "Armory - Internal";
-	dir = 1;
-	network = list("SS13")
+	dir = 1
 	},
 /turf/open/floor/plasteel/vault,
 /area/ai_monitored/security/armory)
@@ -3621,7 +3617,7 @@
 	desc = "Used for watching certain areas.";
 	dir = 1;
 	name = "Head of Security's Monitor";
-	network = list("Prison","MiniSat","tcomm");
+	network = list("prison","minisat","tcomm");
 	pixel_y = -30
 	},
 /turf/open/floor/plasteel/vault,
@@ -3924,8 +3920,7 @@
 /obj/machinery/light/small,
 /obj/machinery/camera{
 	c_tag = "Security - EVA Storage";
-	dir = 1;
-	network = list("SS13")
+	dir = 1
 	},
 /turf/open/floor/plasteel/vault{
 	dir = 8
@@ -3990,8 +3985,7 @@
 /obj/effect/landmark/blobstart,
 /obj/machinery/camera{
 	c_tag = "Evidence Storage";
-	dir = 2;
-	network = list("SS13")
+	dir = 2
 	},
 /obj/item/storage/secure/safe{
 	name = "evidence safe";
@@ -4445,7 +4439,7 @@
 /obj/machinery/computer/security/telescreen{
 	desc = "Used for watching Prison Wing holding areas.";
 	name = "Prison Monitor";
-	network = list("Prison");
+	network = list("prison");
 	pixel_y = 30
 	},
 /turf/open/floor/plasteel/vault,
@@ -4921,8 +4915,7 @@
 	},
 /obj/machinery/camera{
 	c_tag = "Security - Secure Gear Storage";
-	dir = 4;
-	network = list("SS13")
+	dir = 4
 	},
 /obj/machinery/flasher/portable,
 /obj/effect/turf_decal/bot,
@@ -5181,8 +5174,7 @@
 	},
 /obj/machinery/camera{
 	c_tag = "Firing Range";
-	dir = 8;
-	network = list("SS13")
+	dir = 8
 	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -6049,8 +6041,7 @@
 "amM" = (
 /obj/machinery/camera{
 	c_tag = "Gravity Generator Room";
-	dir = 8;
-	network = list("SS13")
+	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 10
@@ -6348,8 +6339,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/machinery/camera{
 	c_tag = "Security - Office - Port";
-	dir = 4;
-	network = list("SS13")
+	dir = 4
 	},
 /turf/open/floor/plasteel/red/side{
 	dir = 8
@@ -6748,8 +6738,7 @@
 	},
 /obj/machinery/camera{
 	c_tag = "Brig - Infirmary";
-	dir = 1;
-	network = list("SS13")
+	dir = 1
 	},
 /obj/item/clothing/under/rank/medical/purple{
 	pixel_y = -4
@@ -7463,8 +7452,7 @@
 	},
 /obj/machinery/camera{
 	c_tag = "Warden's Office";
-	dir = 2;
-	network = list("SS13")
+	dir = 2
 	},
 /obj/structure/rack,
 /obj/item/storage/toolbox/mechanical{
@@ -7507,8 +7495,7 @@
 /obj/structure/closet/wardrobe/red,
 /obj/machinery/camera{
 	c_tag = "Security - Gear Room";
-	dir = 8;
-	network = list("SS13")
+	dir = 8
 	},
 /turf/open/floor/plasteel/showroomfloor,
 /area/security/warden)
@@ -7566,8 +7553,7 @@
 	},
 /obj/machinery/camera{
 	c_tag = "Security - Office - Starboard";
-	dir = 8;
-	network = list("SS13")
+	dir = 8
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on,
 /turf/open/floor/plasteel/red/side{
@@ -7775,8 +7761,7 @@
 	pixel_y = 8
 	},
 /obj/machinery/camera/autoname{
-	dir = 4;
-	network = list("SS13")
+	dir = 4
 	},
 /turf/open/floor/plating,
 /area/maintenance/solars/starboard/fore)
@@ -7975,7 +7960,7 @@
 "aqY" = (
 /obj/machinery/computer/security{
 	name = "Labor Camp Monitoring";
-	network = list("Labor")
+	network = list("labor")
 	},
 /turf/open/floor/plasteel/dark,
 /area/security/brig)
@@ -7991,7 +7976,7 @@
 	desc = "Used for watching Prison Wing holding areas.";
 	dir = 2;
 	name = "Prison Monitor";
-	network = list("Prison");
+	network = list("prison");
 	pixel_x = -30
 	},
 /turf/open/floor/plasteel/showroomfloor,
@@ -9946,8 +9931,7 @@
 	},
 /obj/machinery/camera{
 	c_tag = "Brig - Hallway - Entrance";
-	dir = 2;
-	network = list("SS13")
+	dir = 2
 	},
 /turf/open/floor/plasteel/red/corner{
 	dir = 4
@@ -10926,8 +10910,7 @@
 /obj/machinery/light,
 /obj/machinery/camera{
 	c_tag = "Brig - Hallway - Port";
-	dir = 1;
-	network = list("SS13")
+	dir = 1
 	},
 /obj/machinery/door_timer{
 	id = "Cell 1";
@@ -11099,8 +11082,7 @@
 /obj/machinery/light,
 /obj/machinery/camera{
 	c_tag = "Brig - Hallway - Starboard";
-	dir = 1;
-	network = list("SS13")
+	dir = 1
 	},
 /turf/open/floor/plasteel/red/corner{
 	dir = 2
@@ -12230,7 +12212,7 @@
 /obj/machinery/computer/security/telescreen{
 	desc = "Used for watching Prison Wing holding areas.";
 	name = "Prison Monitor";
-	network = list("Prison");
+	network = list("prison");
 	pixel_y = 30
 	},
 /obj/item/device/flashlight/lamp/green{
@@ -12489,8 +12471,7 @@
 	},
 /obj/machinery/camera{
 	c_tag = "Engineering - Fore";
-	dir = 2;
-	network = list("SS13")
+	dir = 2
 	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -12781,8 +12762,7 @@
 	},
 /obj/machinery/camera{
 	c_tag = "Labor Shuttle Dock";
-	dir = 8;
-	network = list("SS13")
+	dir = 8
 	},
 /obj/machinery/flasher{
 	id = "PRelease";
@@ -12893,8 +12873,7 @@
 /obj/effect/landmark/blobstart,
 /obj/machinery/camera{
 	c_tag = "Detective's Office";
-	dir = 4;
-	network = list("SS13")
+	dir = 4
 	},
 /turf/open/floor/plasteel/grimy,
 /area/security/detectives_office)
@@ -13114,8 +13093,7 @@
 "aBG" = (
 /obj/machinery/camera{
 	c_tag = "Engineering - Storage";
-	dir = 2;
-	network = list("SS13")
+	dir = 2
 	},
 /obj/machinery/suit_storage_unit/engine,
 /obj/effect/turf_decal/bot{
@@ -13229,8 +13207,7 @@
 /obj/structure/reagent_dispensers/fueltank,
 /obj/machinery/camera{
 	c_tag = "Mining Dock";
-	dir = 8;
-	network = list("SS13")
+	dir = 8
 	},
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plasteel,
@@ -13258,8 +13235,7 @@
 	},
 /obj/machinery/camera{
 	c_tag = "Mining Office";
-	dir = 8;
-	network = list("SS13")
+	dir = 8
 	},
 /obj/machinery/mineral/equipment_vendor,
 /turf/open/floor/plasteel/brown{
@@ -13335,8 +13311,7 @@
 "aCg" = (
 /obj/machinery/camera/motion{
 	c_tag = "Vault";
-	dir = 1;
-	network = list("SS13")
+	dir = 1
 	},
 /obj/machinery/light,
 /obj/structure/cable/yellow{
@@ -13938,8 +13913,7 @@
 	},
 /obj/machinery/camera{
 	c_tag = "Fore Primary Hallway Cells";
-	dir = 2;
-	network = list("SS13")
+	dir = 2
 	},
 /turf/open/floor/plasteel/red/corner{
 	dir = 1
@@ -14056,8 +14030,7 @@
 	},
 /obj/machinery/camera{
 	c_tag = "Brig - Desk";
-	dir = 8;
-	network = list("SS13")
+	dir = 8
 	},
 /obj/item/device/radio/intercom{
 	freerange = 0;
@@ -14447,7 +14420,7 @@
 "aEv" = (
 /obj/machinery/computer/security/mining{
 	dir = 4;
-	network = list("MINE","AuxBase")
+	network = list("mine","auxbase")
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/miningoffice)
@@ -14776,8 +14749,7 @@
 	},
 /obj/machinery/camera{
 	c_tag = "Restrooms";
-	dir = 4;
-	network = list("SS13")
+	dir = 4
 	},
 /turf/open/floor/plasteel/freezer,
 /area/crew_quarters/toilet/restrooms)
@@ -15214,8 +15186,7 @@
 	},
 /obj/machinery/camera{
 	c_tag = "Storage Wing - Security Access Door";
-	dir = 4;
-	network = list("SS13")
+	dir = 4
 	},
 /obj/machinery/light/small{
 	dir = 8
@@ -15456,7 +15427,7 @@
 	desc = "Used for watching Prison Wing holding areas.";
 	dir = 1;
 	name = "Prison Monitor";
-	network = list("Prison");
+	network = list("prison");
 	pixel_y = -30
 	},
 /obj/item/restraints/handcuffs,
@@ -16351,8 +16322,7 @@
 	},
 /obj/machinery/camera{
 	c_tag = "Cargo Bay - Fore";
-	dir = 2;
-	network = list("SS13")
+	dir = 2
 	},
 /obj/structure/sign/map/right{
 	desc = "A framed picture of the station. Clockwise from security at the top (red), you see engineering (yellow), science (purple), escape (red and white), medbay (green), arrivals (blue and white), and finally cargo (brown).";
@@ -16477,8 +16447,7 @@
 "aIt" = (
 /obj/machinery/camera{
 	c_tag = "Cargo Bay - Storage Wing Entrance";
-	dir = 1;
-	network = list("SS13")
+	dir = 1
 	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 6
@@ -16543,8 +16512,7 @@
 	},
 /obj/machinery/camera{
 	c_tag = "Storage Wing";
-	dir = 1;
-	network = list("SS13")
+	dir = 1
 	},
 /obj/machinery/light,
 /obj/structure/cable/yellow{
@@ -16744,8 +16712,7 @@
 	},
 /obj/machinery/camera{
 	c_tag = "Courtroom";
-	dir = 2;
-	network = list("SS13")
+	dir = 2
 	},
 /turf/open/floor/plasteel/blue/side{
 	dir = 1
@@ -16794,7 +16761,7 @@
 /obj/machinery/computer/security/telescreen{
 	desc = "Used for watching Prison Wing holding areas.";
 	name = "Prison Monitor";
-	network = list("Prison");
+	network = list("prison");
 	pixel_y = 30
 	},
 /turf/open/floor/wood,
@@ -16944,8 +16911,7 @@
 	},
 /obj/machinery/camera{
 	c_tag = "Engineering - Secure Storage";
-	dir = 2;
-	network = list("SS13")
+	dir = 2
 	},
 /turf/open/floor/plating,
 /area/engine/engineering)
@@ -17791,7 +17757,7 @@
 /obj/structure/table,
 /obj/machinery/camera/motion{
 	c_tag = "AI Upload Chamber - Fore";
-	network = list("SS13","RD","AIUpload")
+	network = list("ss13","rd","aiupload")
 	},
 /obj/item/twohanded/required/kirbyplants/photosynthetic{
 	pixel_y = 10
@@ -17890,8 +17856,7 @@
 /obj/machinery/photocopier,
 /obj/machinery/camera{
 	c_tag = "Law Office";
-	dir = 8;
-	network = list("SS13")
+	dir = 8
 	},
 /turf/open/floor/wood,
 /area/lawoffice)
@@ -17961,8 +17926,7 @@
 /obj/structure/disposalpipe/trunk,
 /obj/machinery/camera{
 	c_tag = "Locker Room Starboard";
-	dir = 2;
-	network = list("SS13")
+	dir = 2
 	},
 /obj/structure/sign/warning/pods{
 	pixel_y = 30
@@ -18199,8 +18163,7 @@
 /area/quartermaster/storage)
 "aMA" = (
 /obj/machinery/camera/autoname{
-	dir = 4;
-	network = list("SS13")
+	dir = 4
 	},
 /obj/structure/rack,
 /obj/item/storage/toolbox/electrical{
@@ -18771,8 +18734,7 @@
 /area/quartermaster/qm)
 "aNP" = (
 /obj/machinery/camera/autoname{
-	dir = 2;
-	network = list("SS13")
+	dir = 2
 	},
 /obj/machinery/holopad,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -19244,8 +19206,7 @@
 /obj/machinery/disposal/bin,
 /obj/machinery/camera{
 	c_tag = "Garden";
-	dir = 8;
-	network = list("SS13")
+	dir = 8
 	},
 /obj/structure/disposalpipe/trunk{
 	dir = 8
@@ -19555,8 +19516,7 @@
 	},
 /obj/machinery/camera{
 	c_tag = "Tool Storage";
-	dir = 8;
-	network = list("SS13")
+	dir = 8
 	},
 /turf/open/floor/plasteel/brown{
 	dir = 4
@@ -19636,8 +19596,7 @@
 	},
 /obj/machinery/camera{
 	c_tag = "Fore Primary Hallway Aft";
-	dir = 8;
-	network = list("SS13")
+	dir = 8
 	},
 /turf/open/floor/plasteel/red/corner{
 	dir = 2
@@ -19837,8 +19796,7 @@
 	},
 /obj/machinery/camera{
 	c_tag = "Engineering - Power Monitoring";
-	dir = 2;
-	network = list("SS13")
+	dir = 2
 	},
 /obj/machinery/modular_computer/console/preset/engineering,
 /turf/open/floor/plasteel/vault,
@@ -19978,8 +19936,7 @@
 	},
 /obj/machinery/camera{
 	c_tag = "Cargo Bay - Starboard";
-	dir = 8;
-	network = list("SS13")
+	dir = 8
 	},
 /obj/item/paper_bin{
 	pixel_x = -1;
@@ -19996,7 +19953,7 @@
 "aQq" = (
 /obj/machinery/computer/security/mining{
 	dir = 4;
-	network = list("MINE","AuxBase")
+	network = list("mine","auxbase")
 	},
 /obj/machinery/light_switch{
 	pixel_x = -23
@@ -20110,7 +20067,7 @@
 /obj/machinery/camera/motion{
 	c_tag = "AI Upload Chamber - Port";
 	dir = 1;
-	network = list("SS13","RD","AIUpload")
+	network = list("ss13","rd","aiupload")
 	},
 /turf/open/floor/circuit,
 /area/ai_monitored/turret_protected/ai_upload)
@@ -20133,7 +20090,7 @@
 /obj/machinery/camera/motion{
 	c_tag = "AI Upload Chamber - Starboard";
 	dir = 1;
-	network = list("SS13","RD","AIUpload")
+	network = list("ss13","rd","aiupload")
 	},
 /turf/open/floor/circuit,
 /area/ai_monitored/turret_protected/ai_upload)
@@ -20247,8 +20204,7 @@
 	},
 /obj/machinery/camera{
 	c_tag = "Crew Quarters Entrance";
-	dir = 2;
-	network = list("SS13")
+	dir = 2
 	},
 /turf/open/floor/plasteel/neutral/corner{
 	dir = 1
@@ -21365,8 +21321,7 @@
 /obj/machinery/light,
 /obj/machinery/camera{
 	c_tag = "Courtroom - Gallery";
-	dir = 1;
-	network = list("SS13")
+	dir = 1
 	},
 /turf/open/floor/plasteel/dark,
 /area/security/courtroom)
@@ -21457,8 +21412,7 @@
 	},
 /obj/machinery/camera{
 	c_tag = "Locker Room Port";
-	dir = 1;
-	network = list("SS13")
+	dir = 1
 	},
 /turf/open/floor/plasteel/neutral/corner{
 	dir = 2
@@ -21666,7 +21620,7 @@
 /obj/machinery/camera{
 	c_tag = "MiniSat Exterior - Fore Port";
 	dir = 8;
-	network = list("MiniSat")
+	network = list("minisat")
 	},
 /turf/open/floor/plasteel/dark,
 /area/aisat)
@@ -21718,7 +21672,7 @@
 /obj/machinery/camera{
 	c_tag = "MiniSat Exterior - Fore Starboard";
 	dir = 4;
-	network = list("MiniSat")
+	network = list("minisat")
 	},
 /turf/open/floor/plasteel/dark,
 /area/aisat)
@@ -21768,8 +21722,7 @@
 	},
 /obj/machinery/camera{
 	c_tag = "Cargo Bay - Port";
-	dir = 4;
-	network = list("SS13")
+	dir = 4
 	},
 /obj/machinery/conveyor{
 	dir = 1;
@@ -21968,7 +21921,7 @@
 	desc = "Used for watching the AI Upload.";
 	dir = 4;
 	name = "AI Upload Monitor";
-	network = list("AIUpload");
+	network = list("aiupload");
 	pixel_x = -29
 	},
 /turf/open/floor/plasteel/vault{
@@ -21994,12 +21947,12 @@
 	desc = "Used for watching areas on the MiniSat.";
 	dir = 8;
 	name = "MiniSat Monitor";
-	network = list("MiniSat","tcomm");
+	network = list("minisat","tcomm");
 	pixel_x = 29
 	},
 /obj/machinery/camera/motion{
 	c_tag = "AI Upload Foyer";
-	network = list("SS13","RD","AIUpload")
+	network = list("ss13","rd","aiupload")
 	},
 /obj/machinery/airalarm{
 	pixel_y = 26
@@ -22339,7 +22292,7 @@
 /obj/machinery/camera{
 	c_tag = "AI Chamber - Fore";
 	dir = 2;
-	network = list("RD")
+	network = list("rd")
 	},
 /obj/structure/showcase/cyborg/old{
 	dir = 2;
@@ -22407,8 +22360,7 @@
 /obj/structure/chair,
 /obj/machinery/camera{
 	c_tag = "Arrivals - Fore Arm - Far";
-	dir = 2;
-	network = list("SS13")
+	dir = 2
 	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -22589,7 +22541,7 @@
 	},
 /obj/machinery/computer/security/mining{
 	dir = 8;
-	network = list("MINE","AuxBase")
+	network = list("mine","auxbase")
 	},
 /turf/open/floor/plasteel/red/side{
 	dir = 4
@@ -22693,8 +22645,7 @@
 "aWd" = (
 /obj/machinery/camera{
 	c_tag = "Central Primary Hallway - Fore";
-	dir = 2;
-	network = list("SS13")
+	dir = 2
 	},
 /turf/open/floor/plasteel/red/corner{
 	dir = 1
@@ -23068,8 +23019,7 @@
 	},
 /obj/machinery/camera{
 	c_tag = "Arrivals - Fore Arm";
-	dir = 8;
-	network = list("SS13")
+	dir = 8
 	},
 /obj/machinery/light{
 	dir = 4
@@ -23188,8 +23138,7 @@
 /obj/structure/table/reinforced,
 /obj/machinery/camera{
 	c_tag = "Security Post - Cargo";
-	dir = 1;
-	network = list("SS13")
+	dir = 1
 	},
 /turf/open/floor/plasteel/red/side,
 /area/security/checkpoint/supply)
@@ -23373,8 +23322,7 @@
 	},
 /obj/machinery/camera{
 	c_tag = "Central Primary Hallway - Fore - AI Upload";
-	dir = 2;
-	network = list("SS13")
+	dir = 2
 	},
 /obj/structure/sign/warning/securearea{
 	desc = "A warning sign which reads 'HIGH-POWER TURRETS AHEAD'.";
@@ -23790,8 +23738,7 @@
 	},
 /obj/machinery/camera{
 	c_tag = "Chief Engineer's Office";
-	dir = 2;
-	network = list("SS13")
+	dir = 2
 	},
 /turf/open/floor/plasteel/vault{
 	dir = 5
@@ -23856,7 +23803,7 @@
 /obj/machinery/camera{
 	c_tag = "AI Chamber - Port";
 	dir = 4;
-	network = list("RD")
+	network = list("rd")
 	},
 /obj/structure/showcase/cyborg/old{
 	dir = 4;
@@ -24002,8 +23949,7 @@
 "aYP" = (
 /obj/machinery/camera{
 	c_tag = "Cargo Bay - Aft";
-	dir = 1;
-	network = list("SS13")
+	dir = 1
 	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 2
@@ -24570,7 +24516,7 @@
 /obj/machinery/camera{
 	c_tag = "AI Chamber - Core";
 	dir = 2;
-	network = list("RD")
+	network = list("rd")
 	},
 /turf/open/floor/plasteel/vault{
 	dir = 10
@@ -24973,8 +24919,7 @@
 	},
 /obj/machinery/camera{
 	c_tag = "Central Primary Hallway - Fore - Port Corner";
-	dir = 4;
-	network = list("SS13")
+	dir = 4
 	},
 /turf/open/floor/plasteel/neutral/corner{
 	dir = 1
@@ -25155,8 +25100,7 @@
 	},
 /obj/machinery/camera{
 	c_tag = "Central Primary Hallway - Fore - Courtroom";
-	dir = 1;
-	network = list("SS13")
+	dir = 1
 	},
 /turf/open/floor/plasteel/neutral/corner{
 	dir = 8
@@ -25224,8 +25168,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/machinery/camera{
 	c_tag = "Central Primary Hallway - Fore - Starboard Corner";
-	dir = 8;
-	network = list("SS13")
+	dir = 8
 	},
 /turf/open/floor/plasteel/neutral/corner{
 	dir = 4
@@ -25469,7 +25412,7 @@
 	desc = "Used for monitoring the engine.";
 	dir = 8;
 	name = "Engine Monitor";
-	network = list("Engine");
+	network = list("engine");
 	pixel_x = 32
 	},
 /turf/open/floor/plasteel/vault{
@@ -25508,8 +25451,7 @@
 	},
 /obj/machinery/camera{
 	c_tag = "Engineering - Entrance";
-	dir = 8;
-	network = list("SS13")
+	dir = 8
 	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 6
@@ -25524,7 +25466,7 @@
 /obj/machinery/computer/security/telescreen{
 	dir = 4;
 	name = "MiniSat Monitor";
-	network = list("MiniSat","tcomm");
+	network = list("minisat","tcomm");
 	pixel_x = -29
 	},
 /turf/open/floor/plasteel/red/side{
@@ -25582,7 +25524,7 @@
 /obj/machinery/camera{
 	c_tag = "AI Chamber - Starboard";
 	dir = 8;
-	network = list("RD")
+	network = list("rd")
 	},
 /obj/structure/showcase/cyborg/old{
 	dir = 8;
@@ -25736,8 +25678,7 @@
 	},
 /obj/machinery/camera{
 	c_tag = "Cargo - Foyer";
-	dir = 8;
-	network = list("SS13")
+	dir = 8
 	},
 /turf/open/floor/plasteel/brown{
 	dir = 4
@@ -25847,8 +25788,7 @@
 "bcr" = (
 /obj/machinery/camera{
 	c_tag = "Auxiliary Tool Storage";
-	dir = 8;
-	network = list("SS13")
+	dir = 8
 	},
 /obj/machinery/airalarm{
 	dir = 8;
@@ -26067,7 +26007,7 @@
 	desc = "Used for monitoring the engine.";
 	dir = 8;
 	name = "Engine Monitor";
-	network = list("Engine");
+	network = list("engine");
 	pixel_x = 32
 	},
 /turf/open/floor/plasteel/red/side{
@@ -26171,8 +26111,7 @@
 	},
 /obj/machinery/camera{
 	c_tag = "Customs Checkpoint";
-	dir = 2;
-	network = list("SS13")
+	dir = 2
 	},
 /turf/open/floor/plasteel/red/side{
 	dir = 1
@@ -26692,7 +26631,7 @@
 /obj/machinery/computer/security/telescreen{
 	dir = 1;
 	name = "MiniSat Monitor";
-	network = list("MiniSat","tcomm");
+	network = list("minisat","tcomm");
 	pixel_y = -30
 	},
 /turf/open/floor/plasteel/vault{
@@ -26759,8 +26698,7 @@
 "bem" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on,
 /obj/machinery/camera/autoname{
-	dir = 4;
-	network = list("SS13")
+	dir = 4
 	},
 /obj/machinery/button/door{
 	desc = "A remote control-switch for the engineering security doors.";
@@ -26840,7 +26778,7 @@
 /obj/machinery/camera{
 	c_tag = "MiniSat Exterior - Port Fore";
 	dir = 8;
-	network = list("MiniSat")
+	network = list("minisat")
 	},
 /turf/open/floor/plasteel/dark,
 /area/aisat)
@@ -26881,7 +26819,7 @@
 /obj/machinery/camera{
 	c_tag = "MiniSat Exterior - Starboard Fore";
 	dir = 4;
-	network = list("MiniSat")
+	network = list("minisat")
 	},
 /turf/open/floor/plasteel/dark,
 /area/aisat)
@@ -27051,8 +26989,7 @@
 	},
 /obj/machinery/camera{
 	c_tag = "Cargo - Office";
-	dir = 4;
-	network = list("SS13")
+	dir = 4
 	},
 /turf/open/floor/plasteel/brown{
 	dir = 8
@@ -27122,8 +27059,7 @@
 /obj/item/reagent_containers/spray/cleaner,
 /obj/machinery/camera{
 	c_tag = "Custodial Closet";
-	dir = 4;
-	network = list("SS13")
+	dir = 4
 	},
 /obj/machinery/light/small{
 	dir = 8
@@ -27326,8 +27262,7 @@
 /obj/effect/landmark/start/captain,
 /obj/machinery/camera{
 	c_tag = "Captain's Quarters";
-	dir = 8;
-	network = list("SS13")
+	dir = 8
 	},
 /turf/open/floor/wood,
 /area/crew_quarters/heads/captain/private)
@@ -28110,8 +28045,7 @@
 	},
 /obj/machinery/camera{
 	c_tag = "Bridge - Central";
-	dir = 2;
-	network = list("SS13")
+	dir = 2
 	},
 /obj/structure/table/glass,
 /turf/open/floor/plasteel/darkbrown/side{
@@ -28336,8 +28270,7 @@
 	},
 /obj/machinery/camera{
 	c_tag = "Starboard Primary Hallway - Tech Storage";
-	dir = 2;
-	network = list("SS13")
+	dir = 2
 	},
 /turf/open/floor/plasteel/yellow/corner{
 	dir = 1
@@ -28631,7 +28564,7 @@
 /obj/machinery/camera{
 	c_tag = "MiniSat Exterior - Space Access";
 	dir = 1;
-	network = list("MiniSat")
+	network = list("minisat")
 	},
 /turf/open/floor/plasteel/vault{
 	dir = 8
@@ -28674,7 +28607,7 @@
 /obj/machinery/camera{
 	c_tag = "AI Chamber - Aft";
 	dir = 1;
-	network = list("RD")
+	network = list("rd")
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on,
 /turf/open/floor/plasteel/dark,
@@ -29574,8 +29507,7 @@
 	},
 /obj/machinery/camera{
 	c_tag = "Cargo - Mailroom";
-	dir = 1;
-	network = list("SS13")
+	dir = 1
 	},
 /turf/open/floor/plasteel/arrival{
 	dir = 2
@@ -29861,7 +29793,7 @@
 	icon_state = "2-4"
 	},
 /obj/machinery/computer/security/mining{
-	network = list("MINE","AuxBase")
+	network = list("mine","auxbase")
 	},
 /obj/machinery/keycard_auth{
 	pixel_y = 24
@@ -30076,8 +30008,7 @@
 	},
 /obj/machinery/camera{
 	c_tag = "Starboard Primary Hallway - Auxiliary Tool Storage";
-	dir = 1;
-	network = list("SS13")
+	dir = 1
 	},
 /turf/open/floor/plasteel/caution/corner{
 	dir = 8
@@ -30119,8 +30050,7 @@
 	},
 /obj/machinery/camera{
 	c_tag = "Starboard Primary Hallway - Engineering";
-	dir = 1;
-	network = list("SS13")
+	dir = 1
 	},
 /turf/open/floor/plasteel/caution/corner{
 	dir = 8
@@ -30615,7 +30545,7 @@
 /obj/machinery/computer/security/telescreen{
 	desc = "Used for watching Prison Wing holding areas.";
 	name = "Prison Monitor";
-	network = list("Prison");
+	network = list("prison");
 	pixel_y = 30
 	},
 /turf/open/floor/wood,
@@ -30791,8 +30721,7 @@
 	},
 /obj/machinery/camera{
 	c_tag = "Bridge - Starboard";
-	dir = 8;
-	network = list("SS13")
+	dir = 8
 	},
 /turf/open/floor/plasteel/darkblue/side{
 	dir = 4
@@ -31034,8 +30963,7 @@
 	},
 /obj/machinery/camera{
 	c_tag = "Engineering - Foyer - Starboard";
-	dir = 8;
-	network = list("SS13")
+	dir = 8
 	},
 /turf/open/floor/plasteel,
 /area/engine/break_room)
@@ -31231,7 +31159,7 @@
 /obj/machinery/camera{
 	c_tag = "MiniSat - Antechamber";
 	dir = 4;
-	network = list("MiniSat")
+	network = list("minisat")
 	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 1
@@ -31357,8 +31285,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/machinery/camera{
 	c_tag = "Arrivals - Station Entrance";
-	dir = 4;
-	network = list("SS13")
+	dir = 4
 	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -31480,8 +31407,7 @@
 	},
 /obj/machinery/camera{
 	c_tag = "Port Primary Hallway - Middle";
-	dir = 2;
-	network = list("SS13")
+	dir = 2
 	},
 /turf/open/floor/plasteel/neutral/corner{
 	dir = 1
@@ -31654,8 +31580,7 @@
 /obj/structure/cable/yellow,
 /obj/machinery/camera{
 	c_tag = "Bridge - Port";
-	dir = 4;
-	network = list("SS13")
+	dir = 4
 	},
 /turf/open/floor/plasteel/darkblue/side{
 	dir = 8
@@ -31813,8 +31738,7 @@
 	},
 /obj/machinery/camera{
 	c_tag = "Central Primary Hallway - Starboard - Art Storage";
-	dir = 4;
-	network = list("SS13")
+	dir = 4
 	},
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel/neutral/corner{
@@ -31887,8 +31811,7 @@
 /obj/item/gun/ballistic/revolver/doublebarrel,
 /obj/machinery/camera{
 	c_tag = "Bar - Backroom";
-	dir = 2;
-	network = list("SS13")
+	dir = 2
 	},
 /turf/open/floor/wood,
 /area/crew_quarters/bar)
@@ -32100,7 +32023,7 @@
 /obj/machinery/camera{
 	c_tag = "MiniSat Exterior - Fore";
 	dir = 1;
-	network = list("MiniSat")
+	network = list("minisat")
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plasteel/dark,
@@ -32500,8 +32423,7 @@
 	},
 /obj/machinery/camera{
 	c_tag = "Arrivals - Lounge";
-	dir = 4;
-	network = list("SS13")
+	dir = 4
 	},
 /obj/effect/landmark/start/assistant,
 /turf/open/floor/plasteel/grimy,
@@ -32821,7 +32743,7 @@
 /obj/machinery/computer/security/telescreen{
 	dir = 1;
 	name = "MiniSat Monitor";
-	network = list("MiniSat","tcomm");
+	network = list("minisat","tcomm");
 	pixel_y = -29
 	},
 /turf/open/floor/plasteel/darkblue/side{
@@ -33290,8 +33212,7 @@
 	},
 /obj/machinery/camera{
 	c_tag = "Engineering - Foyer - Port";
-	dir = 1;
-	network = list("SS13")
+	dir = 1
 	},
 /obj/structure/table/glass,
 /turf/open/floor/plasteel/cafeteria{
@@ -33461,7 +33382,7 @@
 /obj/machinery/camera{
 	c_tag = "MiniSat Exterior Access";
 	dir = 1;
-	network = list("MiniSat")
+	network = list("minisat")
 	},
 /obj/machinery/power/apc{
 	aidisabled = 0;
@@ -33555,7 +33476,7 @@
 	desc = "Used for watching the RD's goons from the safety of his office.";
 	dir = 4;
 	name = "Research Monitor";
-	network = list("RD");
+	network = list("rd");
 	pixel_x = -28
 	},
 /turf/open/floor/plasteel/vault{
@@ -33577,7 +33498,7 @@
 /obj/machinery/camera/motion{
 	c_tag = "MiniSat Foyer";
 	dir = 8;
-	network = list("MiniSat")
+	network = list("minisat")
 	},
 /turf/open/floor/plasteel/darkblue/corner{
 	dir = 8
@@ -33635,7 +33556,7 @@
 /obj/machinery/computer/security/telescreen{
 	dir = 8;
 	name = "MiniSat Monitor";
-	network = list("MiniSat","tcomm");
+	network = list("minisat","tcomm");
 	pixel_x = 28
 	},
 /turf/open/floor/plasteel/vault{
@@ -33660,7 +33581,7 @@
 /obj/machinery/computer/security/telescreen{
 	dir = 1;
 	name = "MiniSat Monitor";
-	network = list("MiniSat","tcomm");
+	network = list("minisat","tcomm");
 	pixel_y = -29
 	},
 /turf/open/floor/plasteel/dark,
@@ -33684,7 +33605,7 @@
 /obj/machinery/camera/motion{
 	c_tag = "MiniSat Maintenance";
 	dir = 8;
-	network = list("MiniSat")
+	network = list("minisat")
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 9
@@ -33909,8 +33830,7 @@
 	},
 /obj/machinery/camera{
 	c_tag = "Port Primary Hallway - Starboard";
-	dir = 1;
-	network = list("SS13")
+	dir = 1
 	},
 /turf/open/floor/plasteel/neutral/corner{
 	dir = 8
@@ -34055,8 +33975,7 @@
 	},
 /obj/machinery/camera{
 	c_tag = "Bridge - Command Chair";
-	dir = 1;
-	network = list("SS13")
+	dir = 1
 	},
 /turf/open/floor/carpet,
 /area/bridge)
@@ -34429,7 +34348,7 @@
 /obj/machinery/computer/security/telescreen{
 	dir = 1;
 	name = "MiniSat Monitor";
-	network = list("MiniSat","tcomm");
+	network = list("minisat","tcomm");
 	pixel_y = -28
 	},
 /turf/open/floor/plasteel/darkblue/corner,
@@ -34560,8 +34479,7 @@
 	},
 /obj/machinery/camera{
 	c_tag = "Port Primary Hallway - Port";
-	dir = 4;
-	network = list("SS13")
+	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
 /area/hallway/primary/port)
@@ -34875,8 +34793,7 @@
 "buJ" = (
 /obj/machinery/camera{
 	c_tag = "Captain's Office";
-	dir = 8;
-	network = list("SS13")
+	dir = 8
 	},
 /turf/open/floor/carpet,
 /area/crew_quarters/heads/captain/private)
@@ -34888,8 +34805,7 @@
 	},
 /obj/machinery/camera{
 	c_tag = "Captain's Office - Emergency Escape";
-	dir = 4;
-	network = list("SS13")
+	dir = 4
 	},
 /turf/open/floor/plating{
 	icon_state = "platingdmg2"
@@ -35178,8 +35094,7 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on,
 /obj/machinery/camera{
 	c_tag = "Engineering - Transit Tube Access";
-	dir = 8;
-	network = list("SS13")
+	dir = 8
 	},
 /obj/effect/turf_decal/stripes/corner{
 	dir = 2
@@ -35664,8 +35579,7 @@
 	},
 /obj/machinery/camera{
 	c_tag = "Bridge - Port Access";
-	dir = 8;
-	network = list("SS13")
+	dir = 8
 	},
 /turf/open/floor/plasteel/darkblue/corner{
 	dir = 1
@@ -35704,8 +35618,7 @@
 "bwv" = (
 /obj/machinery/camera{
 	c_tag = "Council Chamber";
-	dir = 2;
-	network = list("SS13")
+	dir = 2
 	},
 /obj/machinery/light{
 	dir = 1
@@ -35742,8 +35655,7 @@
 	},
 /obj/machinery/camera{
 	c_tag = "Bridge - Starboard Access";
-	dir = 4;
-	network = list("SS13")
+	dir = 4
 	},
 /turf/open/floor/plasteel/darkblue/corner,
 /area/bridge)
@@ -35891,8 +35803,7 @@
 "bwM" = (
 /obj/machinery/camera{
 	c_tag = "Bar";
-	dir = 2;
-	network = list("SS13")
+	dir = 2
 	},
 /obj/machinery/requests_console{
 	department = "Bar";
@@ -35990,8 +35901,7 @@
 	},
 /obj/machinery/camera{
 	c_tag = "Club - Fore";
-	dir = 2;
-	network = list("SS13")
+	dir = 2
 	},
 /turf/open/floor/wood,
 /area/crew_quarters/bar)
@@ -36187,8 +36097,7 @@
 "bxu" = (
 /obj/machinery/camera{
 	c_tag = "Arrivals - Middle Arm - Far";
-	dir = 1;
-	network = list("SS13")
+	dir = 1
 	},
 /obj/machinery/status_display{
 	pixel_y = -32
@@ -36234,8 +36143,7 @@
 	},
 /obj/machinery/camera{
 	c_tag = "Arrivals - Middle Arm";
-	dir = 1;
-	network = list("SS13")
+	dir = 1
 	},
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plasteel,
@@ -36890,8 +36798,7 @@
 	pixel_y = 32
 	},
 /obj/machinery/camera{
-	c_tag = "Atmospherics - Control Room";
-	network = list("SS13")
+	c_tag = "Atmospherics - Control Room"
 	},
 /obj/machinery/computer/station_alert,
 /turf/open/floor/plasteel/caution{
@@ -36959,8 +36866,7 @@
 	icon_state = "0-2"
 	},
 /obj/machinery/camera{
-	c_tag = "Atmospherics - Entrance";
-	network = list("SS13")
+	c_tag = "Atmospherics - Entrance"
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos)
@@ -37046,8 +36952,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/machinery/camera{
-	c_tag = "Atmospherics - Distro Loop";
-	network = list("SS13")
+	c_tag = "Atmospherics - Distro Loop"
 	},
 /turf/open/floor/plasteel/caution{
 	dir = 1
@@ -37115,7 +37020,7 @@
 /obj/machinery/camera{
 	c_tag = "MiniSat Exterior - Port Aft";
 	dir = 8;
-	network = list("MiniSat")
+	network = list("minisat")
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 8
@@ -37207,7 +37112,7 @@
 /obj/machinery/camera{
 	c_tag = "MiniSat Exterior - Starboard Aft";
 	dir = 4;
-	network = list("MiniSat")
+	network = list("minisat")
 	},
 /turf/open/floor/plasteel/dark,
 /area/aisat)
@@ -37286,8 +37191,7 @@
 	dir = 4
 	},
 /obj/machinery/camera/autoname{
-	dir = 8;
-	network = list("SS13")
+	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/carpet,
@@ -37498,7 +37402,7 @@
 /obj/machinery/computer/security/telescreen{
 	dir = 1;
 	name = "MiniSat Monitor";
-	network = list("MiniSat","tcomm");
+	network = list("minisat","tcomm");
 	pixel_y = -29
 	},
 /obj/structure/bed/dogbed/renault,
@@ -37645,8 +37549,7 @@
 	},
 /obj/machinery/camera{
 	c_tag = "Starboard Primary Hallway - Atmospherics";
-	dir = 4;
-	network = list("SS13")
+	dir = 4
 	},
 /turf/open/floor/plasteel/arrival{
 	dir = 8
@@ -37864,8 +37767,7 @@
 "bAZ" = (
 /obj/machinery/camera{
 	c_tag = "Head of Personnel's Office";
-	dir = 1;
-	network = list("SS13")
+	dir = 1
 	},
 /obj/structure/table/wood,
 /obj/item/storage/box/PDAs{
@@ -38675,8 +38577,7 @@
 /obj/machinery/light/small,
 /obj/machinery/camera{
 	c_tag = "Auxilary Restrooms";
-	dir = 4;
-	network = list("SS13")
+	dir = 4
 	},
 /turf/open/floor/plating,
 /area/crew_quarters/toilet/auxiliary)
@@ -38953,8 +38854,7 @@
 	},
 /obj/machinery/camera{
 	c_tag = "Command Hallway - Starboard";
-	dir = 2;
-	network = list("SS13")
+	dir = 2
 	},
 /turf/open/floor/plasteel/neutral/corner{
 	dir = 4
@@ -39251,7 +39151,7 @@
 /obj/machinery/camera{
 	c_tag = "Telecomms - Server Room - Fore-Port";
 	dir = 2;
-	network = list("SS13","tcomm")
+	network = list("ss13","tcomm")
 	},
 /turf/open/floor/circuit/green/telecomms/mainframe,
 /area/tcommsat/server)
@@ -39282,7 +39182,7 @@
 /obj/machinery/camera{
 	c_tag = "Telecomms - Server Room - Fore-Starboard";
 	dir = 2;
-	network = list("SS13","tcomm")
+	network = list("ss13","tcomm")
 	},
 /turf/open/floor/circuit/green/telecomms/mainframe,
 /area/tcommsat/server)
@@ -39381,8 +39281,7 @@
 	pixel_x = -32
 	},
 /obj/machinery/camera/autoname{
-	dir = 4;
-	network = list("SS13")
+	dir = 4
 	},
 /obj/structure/displaycase/trophy,
 /turf/open/floor/wood,
@@ -39516,8 +39415,7 @@
 	},
 /obj/machinery/camera{
 	c_tag = "Command Hallway - Port";
-	dir = 1;
-	network = list("SS13")
+	dir = 1
 	},
 /turf/open/floor/plasteel/neutral/corner{
 	dir = 8
@@ -40315,8 +40213,7 @@
 "bGb" = (
 /obj/machinery/camera{
 	c_tag = "Atmospherics Tank - Mix";
-	dir = 8;
-	network = list("SS13")
+	dir = 8
 	},
 /turf/open/floor/engine/vacuum,
 /area/engine/atmos)
@@ -40437,8 +40334,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/machinery/camera{
 	c_tag = "Central Primary Hallway - Port";
-	dir = 8;
-	network = list("SS13")
+	dir = 8
 	},
 /turf/open/floor/plasteel/neutral/corner{
 	dir = 2
@@ -40570,8 +40466,7 @@
 	},
 /obj/machinery/camera{
 	c_tag = "Command Hallway - Central";
-	dir = 8;
-	network = list("SS13")
+	dir = 8
 	},
 /turf/open/floor/plasteel/neutral/corner{
 	dir = 2
@@ -41363,8 +41258,7 @@
 /obj/machinery/light,
 /obj/machinery/camera{
 	c_tag = "Kitchen Hatch";
-	dir = 1;
-	network = list("SS13")
+	dir = 1
 	},
 /turf/open/floor/plasteel/bar,
 /area/crew_quarters/bar)
@@ -41646,7 +41540,7 @@
 /obj/machinery/camera{
 	c_tag = "Telecomms - Control Room";
 	dir = 1;
-	network = list("SS13","tcomm")
+	network = list("ss13","tcomm")
 	},
 /obj/structure/table/wood,
 /obj/item/pen,
@@ -42186,8 +42080,7 @@
 "bKn" = (
 /obj/machinery/camera{
 	c_tag = "Club - Aft";
-	dir = 1;
-	network = list("SS13")
+	dir = 1
 	},
 /obj/machinery/computer/security/telescreen/entertainment{
 	pixel_y = -29
@@ -42409,7 +42302,7 @@
 /obj/machinery/camera{
 	c_tag = "MiniSat Exterior - Aft Starboard";
 	dir = 4;
-	network = list("MiniSat")
+	network = list("minisat")
 	},
 /obj/structure/window/reinforced{
 	dir = 4
@@ -42462,8 +42355,7 @@
 	},
 /obj/machinery/camera{
 	c_tag = "Arrivals - Aft Arm";
-	dir = 8;
-	network = list("SS13")
+	dir = 8
 	},
 /turf/open/floor/plasteel/arrival{
 	dir = 4
@@ -42798,8 +42690,7 @@
 	},
 /obj/machinery/camera{
 	c_tag = "Central Primary Hallway - Starboard - Kitchen";
-	dir = 4;
-	network = list("SS13")
+	dir = 4
 	},
 /turf/open/floor/plasteel/neutral/corner{
 	dir = 1
@@ -42926,8 +42817,7 @@
 	},
 /obj/machinery/camera{
 	c_tag = "Telecomms - Storage";
-	dir = 4;
-	network = list("SS13")
+	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
 /area/storage/tcom)
@@ -43007,8 +42897,7 @@
 	},
 /obj/machinery/camera{
 	c_tag = "Atmospherics - Central";
-	dir = 1;
-	network = list("SS13")
+	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plasteel,
@@ -43078,8 +42967,7 @@
 "bMn" = (
 /obj/machinery/camera{
 	c_tag = "Atmospherics Tank - N2O";
-	dir = 8;
-	network = list("SS13")
+	dir = 8
 	},
 /turf/open/floor/engine/n2o,
 /area/engine/atmos)
@@ -43094,7 +42982,7 @@
 /obj/machinery/camera{
 	c_tag = "Telecomms - Server Room - Aft-Port";
 	dir = 4;
-	network = list("SS13","tcomm")
+	network = list("ss13","tcomm")
 	},
 /turf/open/floor/plasteel/dark/telecomms/mainframe,
 /area/tcommsat/server)
@@ -43132,7 +43020,7 @@
 /obj/machinery/camera{
 	c_tag = "Telecomms - Server Room - Aft-Starboard";
 	dir = 8;
-	network = list("SS13","tcomm")
+	network = list("ss13","tcomm")
 	},
 /obj/structure/cable/yellow{
 	icon_state = "0-8"
@@ -43151,8 +43039,7 @@
 "bMu" = (
 /obj/machinery/camera{
 	c_tag = "Arrivals - Aft Arm - Far";
-	dir = 1;
-	network = list("SS13")
+	dir = 1
 	},
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plasteel,
@@ -43330,8 +43217,7 @@
 /obj/item/folder,
 /obj/item/folder,
 /obj/machinery/camera/autoname{
-	dir = 1;
-	network = list("SS13")
+	dir = 1
 	},
 /obj/structure/table/wood,
 /obj/item/device/taperecorder,
@@ -43440,8 +43326,7 @@
 "bMZ" = (
 /obj/machinery/camera{
 	c_tag = "Teleporter Room";
-	dir = 8;
-	network = list("SS13")
+	dir = 8
 	},
 /obj/structure/rack,
 /obj/structure/window/reinforced{
@@ -43536,8 +43421,7 @@
 /obj/item/clothing/glasses/sunglasses,
 /obj/machinery/camera{
 	c_tag = "Corporate Showroom";
-	dir = 2;
-	network = list("SS13")
+	dir = 2
 	},
 /turf/open/floor/wood,
 /area/bridge/showroom/corporate)
@@ -43596,8 +43480,7 @@
 	},
 /obj/machinery/camera{
 	c_tag = "Gateway - Atrium";
-	dir = 4;
-	network = list("SS13")
+	dir = 4
 	},
 /obj/effect/turf_decal/bot{
 	dir = 1
@@ -43926,7 +43809,7 @@
 /obj/machinery/camera{
 	c_tag = "MiniSat Exterior - Aft Port";
 	dir = 8;
-	network = list("MiniSat")
+	network = list("minisat")
 	},
 /obj/structure/window/reinforced{
 	dir = 8
@@ -43949,7 +43832,7 @@
 /obj/machinery/camera{
 	c_tag = "Telecomms - Server Room - Aft";
 	dir = 1;
-	network = list("SS13","tcomm")
+	network = list("ss13","tcomm")
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/machinery/ntnet_relay,
@@ -45610,8 +45493,7 @@
 	},
 /obj/machinery/camera{
 	c_tag = "Gateway - Access";
-	dir = 8;
-	network = list("SS13")
+	dir = 8
 	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 2
@@ -45691,8 +45573,7 @@
 /obj/item/kitchen/rollingpin,
 /obj/machinery/camera{
 	c_tag = "Kitchen";
-	dir = 1;
-	network = list("SS13")
+	dir = 1
 	},
 /turf/open/floor/plasteel/cafeteria{
 	dir = 2
@@ -45784,8 +45665,7 @@
 	},
 /obj/machinery/camera{
 	c_tag = "Kitchen - Coldroom";
-	dir = 1;
-	network = list("SS13")
+	dir = 1
 	},
 /turf/open/floor/plasteel/showroomfloor,
 /area/crew_quarters/kitchen)
@@ -45848,8 +45728,7 @@
 	},
 /obj/machinery/camera{
 	c_tag = "Atmospherics - Port";
-	dir = 4;
-	network = list("SS13")
+	dir = 4
 	},
 /obj/machinery/light{
 	dir = 8
@@ -45906,8 +45785,7 @@
 "bSl" = (
 /obj/machinery/camera{
 	c_tag = "Atmospherics Tank - Toxins";
-	dir = 8;
-	network = list("SS13")
+	dir = 8
 	},
 /turf/open/floor/engine/plasma,
 /area/engine/atmos)
@@ -46371,8 +46249,7 @@
 	},
 /obj/machinery/camera{
 	c_tag = "Atmospherics - Starboard";
-	dir = 4;
-	network = list("SS13")
+	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos)
@@ -46458,8 +46335,7 @@
 	pixel_y = -24
 	},
 /obj/machinery/camera/autoname{
-	dir = 1;
-	network = list("SS13")
+	dir = 1
 	},
 /obj/structure/table/wood,
 /turf/open/floor/wood,
@@ -47624,8 +47500,7 @@
 	},
 /obj/machinery/camera{
 	c_tag = "Aft Port Solar Maintenance";
-	dir = 4;
-	network = list("SS13")
+	dir = 4
 	},
 /turf/open/floor/plating,
 /area/maintenance/solars/port/aft)
@@ -47806,8 +47681,7 @@
 	},
 /obj/machinery/camera{
 	c_tag = "Central Primary Hallway - Aft-Port Corner";
-	dir = 1;
-	network = list("SS13")
+	dir = 1
 	},
 /turf/open/floor/plasteel/neutral/corner{
 	dir = 8
@@ -48023,8 +47897,7 @@
 	},
 /obj/machinery/camera{
 	c_tag = "Central Primary Hallway - Aft-Starboard Corner";
-	dir = 1;
-	network = list("SS13")
+	dir = 1
 	},
 /turf/open/floor/plasteel/neutral/corner{
 	dir = 2
@@ -48410,8 +48283,7 @@
 "bXs" = (
 /obj/machinery/camera{
 	c_tag = "Atmospherics Tank - CO2";
-	dir = 8;
-	network = list("SS13")
+	dir = 8
 	},
 /turf/open/floor/engine/co2,
 /area/engine/atmos)
@@ -48566,8 +48438,7 @@
 "bXQ" = (
 /obj/machinery/camera{
 	c_tag = "Central Primary Hallway - Aft-Port";
-	dir = 1;
-	network = list("SS13")
+	dir = 1
 	},
 /turf/open/floor/plasteel/blue/corner{
 	dir = 8
@@ -48605,8 +48476,7 @@
 "bXW" = (
 /obj/machinery/camera{
 	c_tag = "Central Primary Hallway - Aft-Starboard";
-	dir = 1;
-	network = list("SS13")
+	dir = 1
 	},
 /turf/open/floor/plasteel/purple/corner{
 	dir = 2
@@ -48674,8 +48544,7 @@
 /area/hallway/primary/central)
 "bYe" = (
 /obj/machinery/camera/autoname{
-	dir = 4;
-	network = list("SS13")
+	dir = 4
 	},
 /obj/item/book/manual/hydroponics_pod_people,
 /obj/item/paper/guides/jobs/hydroponics,
@@ -48742,8 +48611,7 @@
 	dir = 4
 	},
 /obj/machinery/camera/autoname{
-	dir = 8;
-	network = list("SS13")
+	dir = 8
 	},
 /obj/structure/table/glass,
 /obj/effect/turf_decal/stripes/line{
@@ -48848,8 +48716,7 @@
 	},
 /obj/machinery/camera{
 	c_tag = "Atmospherics - Port-Aft";
-	dir = 4;
-	network = list("SS13")
+	dir = 4
 	},
 /turf/open/floor/plasteel/caution{
 	dir = 8
@@ -49130,7 +48997,7 @@
 /obj/machinery/camera{
 	c_tag = "Security Post - Medbay";
 	dir = 2;
-	network = list("SS13","Medbay")
+	network = list("ss13","medbay")
 	},
 /turf/open/floor/plasteel/red/side{
 	dir = 1
@@ -49836,7 +49703,7 @@
 /obj/machinery/camera{
 	c_tag = "Research Division - Lobby";
 	dir = 2;
-	network = list("SS13","RD")
+	network = list("ss13","rd")
 	},
 /turf/open/floor/plasteel/whitepurple/side{
 	dir = 1
@@ -50552,7 +50419,7 @@
 /obj/machinery/camera{
 	c_tag = "Medbay Storage";
 	dir = 8;
-	network = list("SS13","Medbay")
+	network = list("ss13","medbay")
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/structure/closet/crate/freezer/surplus_limbs,
@@ -50578,7 +50445,7 @@
 	desc = "Used for monitoring medbay to ensure patient safety.";
 	dir = 1;
 	name = "Medbay Monitor";
-	network = list("Medbay");
+	network = list("medbay");
 	pixel_y = -29
 	},
 /obj/item/device/radio/intercom{
@@ -50760,7 +50627,7 @@
 	desc = "Used for watching the RD's goons from the safety of his office.";
 	dir = 8;
 	name = "Research Monitor";
-	network = list("RD");
+	network = list("rd");
 	pixel_x = 28;
 	pixel_y = 2
 	},
@@ -50794,8 +50661,7 @@
 /obj/item/paper/guides/jobs/hydroponics,
 /obj/machinery/camera{
 	c_tag = "Hydroponics - Foyer";
-	dir = 1;
-	network = list("SS13")
+	dir = 1
 	},
 /obj/item/device/radio/intercom{
 	pixel_y = -25
@@ -51098,8 +50964,7 @@
 	},
 /obj/machinery/camera{
 	c_tag = "Atmospherics - Starboard Aft";
-	dir = 1;
-	network = list("SS13")
+	dir = 1
 	},
 /turf/open/floor/plasteel/dark,
 /area/engine/atmos)
@@ -51544,7 +51409,7 @@
 /obj/machinery/camera{
 	c_tag = "Security Post - Research Division";
 	dir = 8;
-	network = list("SS13","RD")
+	network = list("ss13","rd")
 	},
 /turf/open/floor/plasteel/red/side{
 	dir = 4
@@ -51913,7 +51778,7 @@
 /obj/machinery/camera{
 	c_tag = "Medbay Foyer";
 	dir = 1;
-	network = list("SS13","Medbay")
+	network = list("ss13","medbay")
 	},
 /turf/open/floor/plasteel/whiteblue/side{
 	dir = 2
@@ -53299,7 +53164,7 @@
 /obj/machinery/camera{
 	c_tag = "Experimentation Lab - Test Chamber";
 	dir = 2;
-	network = list("SS13","RD")
+	network = list("ss13","rd")
 	},
 /obj/machinery/light{
 	dir = 1
@@ -53418,7 +53283,7 @@
 /obj/machinery/camera{
 	c_tag = "MiniSat Exterior - Aft";
 	dir = 2;
-	network = list("MiniSat")
+	network = list("minisat")
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plasteel/dark,
@@ -53667,7 +53532,7 @@
 /obj/machinery/camera{
 	c_tag = "Medbay Hallway Fore";
 	dir = 2;
-	network = list("SS13","Medbay")
+	network = list("ss13","medbay")
 	},
 /turf/open/floor/plasteel/whiteblue/corner{
 	dir = 4
@@ -53895,7 +53760,7 @@
 /obj/machinery/camera{
 	c_tag = "Research Division - Airlock";
 	dir = 2;
-	network = list("SS13","RD")
+	network = list("ss13","rd")
 	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 5
@@ -54046,8 +53911,7 @@
 "cje" = (
 /obj/machinery/camera{
 	c_tag = "Atmospherics Tank - N2";
-	dir = 8;
-	network = list("SS13")
+	dir = 8
 	},
 /turf/open/floor/engine/n2,
 /area/engine/atmos)
@@ -54061,8 +53925,7 @@
 "cjh" = (
 /obj/machinery/camera{
 	c_tag = "Atmospherics Tank - O2";
-	dir = 8;
-	network = list("SS13")
+	dir = 8
 	},
 /turf/open/floor/engine/o2,
 /area/engine/atmos)
@@ -54077,8 +53940,7 @@
 "cjk" = (
 /obj/machinery/camera{
 	c_tag = "Atmospherics Tank - Air";
-	dir = 8;
-	network = list("SS13")
+	dir = 8
 	},
 /turf/open/floor/engine/air,
 /area/engine/atmos)
@@ -54239,7 +54101,7 @@
 /obj/machinery/camera{
 	c_tag = "Medbay Sleepers";
 	dir = 4;
-	network = list("SS13","Medbay")
+	network = list("ss13","medbay")
 	},
 /turf/open/floor/plasteel/whiteblue/side{
 	dir = 10
@@ -55124,8 +54986,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/machinery/camera{
 	c_tag = "Aft Primary Hallway - Fore";
-	dir = 8;
-	network = list("SS13")
+	dir = 8
 	},
 /obj/machinery/firealarm{
 	dir = 4;
@@ -55310,7 +55171,7 @@
 /obj/machinery/camera{
 	c_tag = "Research Division - Break Room";
 	dir = 1;
-	network = list("SS13","RD")
+	network = list("ss13","rd")
 	},
 /turf/open/floor/plasteel/cafeteria{
 	dir = 5
@@ -55672,7 +55533,7 @@
 /obj/machinery/camera{
 	c_tag = "Research and Development";
 	dir = 8;
-	network = list("SS13","RD")
+	network = list("ss13","rd")
 	},
 /obj/machinery/light_switch{
 	pixel_x = 27
@@ -56204,7 +56065,7 @@
 /obj/machinery/camera{
 	c_tag = "Chemistry";
 	dir = 4;
-	network = list("SS13","Medbay")
+	network = list("ss13","medbay")
 	},
 /obj/machinery/light{
 	dir = 8
@@ -56399,7 +56260,7 @@
 /obj/machinery/camera{
 	c_tag = "Research Division Hallway - Central";
 	dir = 2;
-	network = list("SS13","RD")
+	network = list("ss13","rd")
 	},
 /turf/open/floor/plasteel/white,
 /area/science/research)
@@ -56786,7 +56647,7 @@
 /obj/machinery/camera{
 	c_tag = "CMO's Office";
 	dir = 8;
-	network = list("SS13","Medbay")
+	network = list("ss13","medbay")
 	},
 /turf/open/floor/plasteel/barber{
 	dir = 8
@@ -57317,7 +57178,7 @@
 /obj/machinery/camera{
 	c_tag = "Engineering Supermatter Port";
 	dir = 8;
-	network = list("SS13","Engine")
+	network = list("ss13","engine")
 	},
 /obj/machinery/airalarm/engine{
 	dir = 8;
@@ -57821,7 +57682,7 @@
 /obj/machinery/camera{
 	c_tag = "Research Division Hallway - Starboard";
 	dir = 1;
-	network = list("SS13","RD")
+	network = list("ss13","rd")
 	},
 /turf/open/floor/plasteel/white,
 /area/science/research)
@@ -57906,7 +57767,7 @@
 /obj/machinery/camera{
 	c_tag = "Experimentation Lab";
 	dir = 1;
-	network = list("SS13","RD")
+	network = list("ss13","rd")
 	},
 /obj/machinery/light,
 /turf/open/floor/plasteel/white,
@@ -58094,7 +57955,7 @@
 /obj/machinery/camera{
 	c_tag = "Medbay Cryo";
 	dir = 1;
-	network = list("SS13","Medbay")
+	network = list("ss13","medbay")
 	},
 /obj/item/screwdriver{
 	pixel_y = 6
@@ -58529,7 +58390,7 @@
 /obj/machinery/camera{
 	c_tag = "Medbay Surgery";
 	dir = 1;
-	network = list("SS13","Medbay")
+	network = list("ss13","medbay")
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/surgery)
@@ -58592,7 +58453,7 @@
 /obj/machinery/camera{
 	c_tag = "Medbay Recovery Room";
 	dir = 1;
-	network = list("SS13","Medbay")
+	network = list("ss13","medbay")
 	},
 /turf/open/floor/plasteel/whiteblue/side{
 	dir = 2
@@ -58616,7 +58477,7 @@
 /obj/machinery/camera{
 	c_tag = "Medbay Hallway Central";
 	dir = 4;
-	network = list("SS13","Medbay")
+	network = list("ss13","medbay")
 	},
 /turf/open/floor/plasteel/whiteblue/corner{
 	dir = 8
@@ -58740,7 +58601,7 @@
 	desc = "Used for monitoring medbay to ensure patient safety.";
 	dir = 8;
 	name = "Medbay Monitor";
-	network = list("Medbay");
+	network = list("medbay");
 	pixel_x = 29
 	},
 /obj/item/device/radio/intercom{
@@ -59009,7 +58870,7 @@
 /obj/machinery/computer/security/telescreen{
 	desc = "Used for watching the RD's goons from the safety of his office.";
 	name = "Research Monitor";
-	network = list("RD");
+	network = list("rd");
 	pixel_y = 2
 	},
 /obj/structure/table/reinforced,
@@ -59132,7 +58993,7 @@
 	active_power_usage = 0;
 	c_tag = "Turbine Vent";
 	dir = 4;
-	network = list("Turbine");
+	network = list("turbine");
 	use_power = 0
 	},
 /turf/open/space,
@@ -59976,7 +59837,7 @@
 /obj/machinery/camera{
 	c_tag = "Toxins Storage";
 	dir = 8;
-	network = list("SS13","RD")
+	network = list("ss13","rd")
 	},
 /obj/effect/turf_decal/delivery,
 /turf/open/floor/plasteel,
@@ -60182,7 +60043,7 @@
 /obj/machinery/camera{
 	c_tag = "Genetics Lab";
 	dir = 4;
-	network = list("SS13","Medbay")
+	network = list("ss13","medbay")
 	},
 /turf/open/floor/plasteel/whiteblue,
 /area/medical/genetics)
@@ -60722,7 +60583,7 @@
 /obj/machinery/camera{
 	c_tag = "Genetics Desk";
 	dir = 4;
-	network = list("SS13","Medbay")
+	network = list("ss13","medbay")
 	},
 /obj/structure/table/glass,
 /turf/open/floor/plasteel/blue/side{
@@ -60807,7 +60668,7 @@
 /obj/machinery/camera{
 	c_tag = "Research Division Hallway - Mech Bay";
 	dir = 4;
-	network = list("SS13","RD")
+	network = list("ss13","rd")
 	},
 /obj/machinery/airalarm{
 	dir = 4;
@@ -60884,7 +60745,7 @@
 /obj/machinery/camera{
 	c_tag = "Research Director's Office";
 	dir = 1;
-	network = list("SS13","RD")
+	network = list("ss13","rd")
 	},
 /obj/machinery/light,
 /turf/open/floor/plasteel/cafeteria{
@@ -61247,7 +61108,7 @@
 /obj/machinery/camera{
 	c_tag = "Mech Bay";
 	dir = 8;
-	network = list("SS13","RD")
+	network = list("ss13","rd")
 	},
 /turf/open/floor/circuit/green,
 /area/science/robotics/mechbay)
@@ -61258,7 +61119,7 @@
 /obj/machinery/camera{
 	c_tag = "Research Testing Range";
 	dir = 8;
-	network = list("SS13","RD");
+	network = list("ss13","rd");
 	pixel_y = -22
 	},
 /obj/machinery/airalarm{
@@ -61675,7 +61536,7 @@
 /obj/machinery/camera{
 	c_tag = "Toxins - Lab";
 	dir = 2;
-	network = list("SS13","RD")
+	network = list("ss13","rd")
 	},
 /obj/machinery/atmospherics/components/unary/portables_connector/visible,
 /obj/machinery/portable_atmospherics/canister,
@@ -61861,7 +61722,7 @@
 /obj/machinery/camera{
 	c_tag = "Genetics Cloning Lab";
 	dir = 8;
-	network = list("SS13","Medbay")
+	network = list("ss13","medbay")
 	},
 /turf/open/floor/plasteel/whiteblue/side{
 	dir = 6
@@ -62448,8 +62309,7 @@
 	},
 /obj/machinery/camera{
 	c_tag = "Aft Primary Hallway - Middle";
-	dir = 4;
-	network = list("SS13")
+	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
 	dir = 8
@@ -62804,7 +62664,7 @@
 	dir = 8;
 	layer = 4;
 	name = "Test Chamber Telescreen";
-	network = list("Toxins");
+	network = list("toxins");
 	pixel_x = 30
 	},
 /obj/effect/turf_decal/stripes/line{
@@ -63242,7 +63102,7 @@
 	dir = 8;
 	layer = 4;
 	name = "Test Chamber Telescreen";
-	network = list("Toxins");
+	network = list("toxins");
 	pixel_x = 30
 	},
 /obj/effect/turf_decal/stripes/line{
@@ -63333,7 +63193,7 @@
 /obj/machinery/camera{
 	c_tag = "Medbay Break Room";
 	dir = 1;
-	network = list("SS13","Medbay")
+	network = list("ss13","medbay")
 	},
 /turf/open/floor/plasteel/cafeteria{
 	dir = 5
@@ -63720,7 +63580,7 @@
 /obj/machinery/camera{
 	c_tag = "Medbay Hallway Aft";
 	dir = 4;
-	network = list("SS13","Medbay")
+	network = list("ss13","medbay")
 	},
 /turf/open/floor/plasteel/white/side{
 	dir = 5
@@ -63904,7 +63764,7 @@
 /obj/machinery/camera{
 	c_tag = "Robotics - Fore";
 	dir = 2;
-	network = list("SS13","RD")
+	network = list("ss13","rd")
 	},
 /obj/effect/turf_decal/delivery,
 /turf/open/floor/plasteel,
@@ -64065,7 +63925,7 @@
 	light = null;
 	luminosity = 3;
 	name = "Hardened Bomb-Test Camera";
-	network = list("Toxins");
+	network = list("toxins");
 	use_power = 0
 	},
 /obj/item/target/alien/anchored,
@@ -64983,7 +64843,7 @@
 /obj/machinery/camera{
 	c_tag = "Research Division Hallway - Robotics";
 	dir = 4;
-	network = list("SS13","RD")
+	network = list("ss13","rd")
 	},
 /turf/open/floor/plasteel/white,
 /area/science/research)
@@ -65052,7 +64912,7 @@
 /obj/machinery/camera{
 	c_tag = "Toxins - Mixing Area";
 	dir = 8;
-	network = list("SS13","RD")
+	network = list("ss13","rd")
 	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -65112,7 +64972,7 @@
 /obj/machinery/camera{
 	c_tag = "Virology - Cells";
 	dir = 4;
-	network = list("SS13","Medbay")
+	network = list("ss13","medbay")
 	},
 /turf/open/floor/plasteel/whitegreen/side{
 	dir = 9
@@ -66179,7 +66039,7 @@
 /obj/machinery/camera{
 	c_tag = "Virology - Lab";
 	dir = 8;
-	network = list("SS13","Medbay")
+	network = list("ss13","medbay")
 	},
 /obj/structure/sink{
 	dir = 4;
@@ -66206,7 +66066,7 @@
 /obj/machinery/camera{
 	c_tag = "Virology - Airlock";
 	dir = 1;
-	network = list("SS13","Medbay")
+	network = list("ss13","medbay")
 	},
 /obj/machinery/light,
 /obj/structure/closet/l3closet,
@@ -66238,7 +66098,7 @@
 /obj/machinery/camera{
 	c_tag = "Virology - Entrance";
 	dir = 8;
-	network = list("SS13","Medbay")
+	network = list("ss13","medbay")
 	},
 /obj/machinery/light/small{
 	dir = 4
@@ -66536,7 +66396,7 @@
 /obj/machinery/camera{
 	c_tag = "Research Division - Server Room";
 	dir = 2;
-	network = list("SS13","RD");
+	network = list("ss13","rd");
 	pixel_x = 22
 	},
 /obj/machinery/power/apc{
@@ -66831,8 +66691,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/machinery/camera{
 	c_tag = "Aft Primary Hallway - Aft";
-	dir = 8;
-	network = list("SS13")
+	dir = 8
 	},
 /turf/open/floor/plasteel/escape{
 	dir = 2
@@ -67590,7 +67449,7 @@
 /obj/machinery/camera{
 	c_tag = "Virology - Break Room";
 	dir = 2;
-	network = list("SS13","Medbay")
+	network = list("ss13","medbay")
 	},
 /turf/open/floor/plasteel/whitegreen/side{
 	dir = 1
@@ -68285,7 +68144,7 @@
 	desc = "Used for watching the turbine vent.";
 	dir = 8;
 	name = "turbine vent monitor";
-	network = list("Turbine");
+	network = list("turbine");
 	pixel_x = 29
 	},
 /obj/machinery/button/door{
@@ -68570,8 +68429,7 @@
 	},
 /obj/machinery/camera{
 	c_tag = "Departure Lounge - Starboard Fore";
-	dir = 8;
-	network = list("SS13")
+	dir = 8
 	},
 /obj/structure/extinguisher_cabinet{
 	pixel_x = 27
@@ -68645,8 +68503,7 @@
 	},
 /obj/machinery/camera{
 	c_tag = "Aft Starboard Solar Maintenance";
-	dir = 4;
-	network = list("SS13")
+	dir = 4
 	},
 /turf/open/floor/plating,
 /area/maintenance/solars/starboard/aft)
@@ -68816,8 +68673,7 @@
 	},
 /obj/machinery/camera{
 	c_tag = "Chapel - Fore";
-	dir = 2;
-	network = list("SS13")
+	dir = 2
 	},
 /obj/structure/table/wood,
 /turf/open/floor/plasteel/vault,
@@ -68988,7 +68844,6 @@
 /obj/machinery/computer/security/telescreen{
 	desc = "Used for watching output from station security cameras.";
 	name = "Security Camera Monitor";
-	network = list("SS13");
 	pixel_y = 30
 	},
 /turf/open/floor/plasteel/red/side{
@@ -69197,8 +69052,7 @@
 "cNu" = (
 /obj/machinery/camera{
 	c_tag = "Chapel Office - Backroom";
-	dir = 8;
-	network = list("SS13")
+	dir = 8
 	},
 /obj/item/device/radio/intercom{
 	dir = 4;
@@ -69529,8 +69383,7 @@
 	},
 /obj/machinery/camera{
 	c_tag = "Chapel Office";
-	dir = 8;
-	network = list("SS13")
+	dir = 8
 	},
 /turf/open/floor/plasteel/grimy,
 /area/chapel/office)
@@ -69702,8 +69555,7 @@
 	},
 /obj/machinery/camera{
 	c_tag = "Departure Lounge - Security Post";
-	dir = 1;
-	network = list("SS13")
+	dir = 1
 	},
 /obj/item/book/manual/wiki/security_space_law{
 	pixel_x = -4;
@@ -70248,8 +70100,7 @@
 "cPO" = (
 /obj/machinery/camera{
 	c_tag = "Departure Lounge - Port Aft";
-	dir = 4;
-	network = list("SS13")
+	dir = 4
 	},
 /obj/machinery/light{
 	dir = 8
@@ -70314,8 +70165,7 @@
 "cPV" = (
 /obj/machinery/camera{
 	c_tag = "Departure Lounge - Starboard Aft";
-	dir = 8;
-	network = list("SS13")
+	dir = 8
 	},
 /obj/machinery/light{
 	dir = 4
@@ -70519,7 +70369,7 @@
 /obj/machinery/camera{
 	c_tag = "Research Division Hallway - Xenobiology Lab Access";
 	dir = 2;
-	network = list("SS13","RD")
+	network = list("ss13","rd")
 	},
 /turf/open/floor/plasteel/whitepurple/side{
 	dir = 1
@@ -70565,7 +70415,7 @@
 /obj/machinery/camera{
 	c_tag = "Toxins - Launch Area";
 	dir = 2;
-	network = list("SS13","RD")
+	network = list("ss13","rd")
 	},
 /obj/machinery/suit_storage_unit/rd,
 /obj/effect/turf_decal/bot{
@@ -70663,8 +70513,7 @@
 	},
 /obj/machinery/camera{
 	c_tag = "Chapel - Starboard";
-	dir = 8;
-	network = list("SS13")
+	dir = 8
 	},
 /turf/open/floor/plasteel/chapel{
 	dir = 4
@@ -70889,8 +70738,7 @@
 "cRn" = (
 /obj/machinery/camera{
 	c_tag = "Chapel - Port";
-	dir = 4;
-	network = list("SS13")
+	dir = 4
 	},
 /obj/structure/chair/comfy/black{
 	dir = 4
@@ -71339,7 +71187,7 @@
 /obj/machinery/camera{
 	c_tag = "Xenobiology Lab - Pen #1";
 	dir = 4;
-	network = list("SS13","RD","Xeno")
+	network = list("ss13","rd","xeno")
 	},
 /turf/open/floor/engine,
 /area/science/xenobiology)
@@ -71413,7 +71261,7 @@
 /obj/machinery/camera{
 	c_tag = "Xenobiology Lab - Pen #2";
 	dir = 8;
-	network = list("SS13","RD","Xeno")
+	network = list("ss13","rd","xeno")
 	},
 /turf/open/floor/engine,
 /area/science/xenobiology)
@@ -71914,7 +71762,7 @@
 /obj/machinery/computer/security/telescreen{
 	dir = 1;
 	name = "Test Chamber Monitor";
-	network = list("Xeno");
+	network = list("xeno");
 	pixel_y = 2
 	},
 /obj/structure/table/reinforced,
@@ -72302,7 +72150,7 @@
 /obj/machinery/camera{
 	c_tag = "Engineering Supermatter Aft";
 	dir = 1;
-	network = list("SS13","Engine")
+	network = list("ss13","engine")
 	},
 /turf/open/floor/engine,
 /area/engine/engineering)
@@ -72347,7 +72195,7 @@
 /obj/machinery/camera{
 	c_tag = "Robotics - Aft";
 	dir = 1;
-	network = list("SS13","RD")
+	network = list("ss13","rd")
 	},
 /turf/open/floor/plasteel/white/side{
 	dir = 1
@@ -72391,7 +72239,7 @@
 	desc = "Used for the Auxillary Mining Base.";
 	dir = 1;
 	name = "Auxillary Base Monitor";
-	network = list("AuxBase");
+	network = list("auxbase");
 	pixel_y = -28
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on,
@@ -72587,7 +72435,7 @@
 /obj/machinery/camera{
 	c_tag = "Xenobiology Lab - Test Chamber";
 	dir = 1;
-	network = list("SS13","RD","Xeno")
+	network = list("ss13","rd","xeno")
 	},
 /turf/open/floor/engine,
 /area/science/xenobiology)
@@ -72765,7 +72613,7 @@
 /obj/machinery/camera{
 	c_tag = "Xenobiology Lab - Pen #3";
 	dir = 4;
-	network = list("SS13","RD","Xeno")
+	network = list("ss13","rd","xeno")
 	},
 /turf/open/floor/engine,
 /area/science/xenobiology)
@@ -72776,7 +72624,7 @@
 /obj/machinery/camera{
 	c_tag = "Xenobiology Lab - Pen #4";
 	dir = 8;
-	network = list("SS13","RD","Xeno")
+	network = list("ss13","rd","xeno")
 	},
 /turf/open/floor/engine,
 /area/science/xenobiology)
@@ -72789,7 +72637,7 @@
 /obj/machinery/camera{
 	c_tag = "Morgue";
 	dir = 2;
-	network = list("SS13","Medbay")
+	network = list("ss13","medbay")
 	},
 /obj/structure/bodycontainer/morgue{
 	dir = 8
@@ -72803,7 +72651,7 @@
 /obj/machinery/camera{
 	c_tag = "Xenobiology Lab - Pen #5";
 	dir = 4;
-	network = list("SS13","RD","Xeno")
+	network = list("ss13","rd","xeno")
 	},
 /turf/open/floor/engine,
 /area/science/xenobiology)
@@ -72814,7 +72662,7 @@
 /obj/machinery/camera{
 	c_tag = "Xenobiology Lab - Pen #6";
 	dir = 8;
-	network = list("SS13","RD","Xeno")
+	network = list("ss13","rd","xeno")
 	},
 /turf/open/floor/engine,
 /area/science/xenobiology)
@@ -72827,7 +72675,7 @@
 /obj/machinery/camera{
 	c_tag = "Xenobiology Lab - Kill Chamber";
 	dir = 1;
-	network = list("SS13","RD","Xeno");
+	network = list("ss13","rd","xeno");
 	start_active = 1
 	},
 /turf/open/floor/circuit/killroom,
@@ -73064,7 +72912,7 @@
 /obj/machinery/camera{
 	c_tag = "Xenobiology Lab - Fore";
 	dir = 2;
-	network = list("SS13","RD")
+	network = list("ss13","rd")
 	},
 /turf/open/floor/plasteel/whitepurple/side{
 	dir = 1
@@ -73304,7 +73152,7 @@
 /obj/machinery/camera{
 	c_tag = "Xenobiology Lab - Airlock";
 	dir = 4;
-	network = list("SS13","RD")
+	network = list("ss13","rd")
 	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 10
@@ -73497,7 +73345,7 @@
 /obj/machinery/camera{
 	c_tag = "Xenobiology Lab - Central";
 	dir = 8;
-	network = list("SS13","RD")
+	network = list("ss13","rd")
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/effect/turf_decal/stripes/line{
@@ -73692,7 +73540,7 @@
 /obj/machinery/camera{
 	c_tag = "Xenobiology Lab - Aft-Port";
 	dir = 4;
-	network = list("SS13","RD")
+	network = list("ss13","rd")
 	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -73707,7 +73555,7 @@
 /obj/machinery/camera{
 	c_tag = "Xenobiology Lab - Aft-Starboard";
 	dir = 8;
-	network = list("SS13","RD")
+	network = list("ss13","rd")
 	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -73962,7 +73810,7 @@
 /obj/machinery/camera{
 	c_tag = "Engineering Supermatter Fore";
 	dir = 4;
-	network = list("SS13","Engine")
+	network = list("ss13","engine")
 	},
 /obj/machinery/firealarm{
 	dir = 8;
@@ -74323,7 +74171,7 @@
 /obj/machinery/camera{
 	c_tag = "Engineering Supermatter Starboard";
 	dir = 4;
-	network = list("SS13","Engine")
+	network = list("ss13","engine")
 	},
 /obj/machinery/atmospherics/pipe/simple/cyan/visible,
 /turf/open/floor/engine,
@@ -74442,7 +74290,7 @@
 /obj/machinery/camera{
 	c_tag = "Supermatter Chamber";
 	dir = 4;
-	network = list("Engine")
+	network = list("engine")
 	},
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -75381,8 +75229,7 @@
 	},
 /obj/machinery/camera{
 	c_tag = "Theatre - Stage";
-	dir = 8;
-	network = list("SS13")
+	dir = 8
 	},
 /obj/machinery/light/small{
 	dir = 4
@@ -75549,8 +75396,7 @@
 "dir" = (
 /obj/machinery/camera{
 	c_tag = "Theatre - Backstage";
-	dir = 1;
-	network = list("SS13")
+	dir = 1
 	},
 /obj/structure/sign/poster/contraband/random{
 	pixel_y = -32
@@ -75899,8 +75745,7 @@
 	},
 /obj/machinery/camera{
 	c_tag = "Departure Lounge - Port Fore";
-	dir = 4;
-	network = list("SS13")
+	dir = 4
 	},
 /obj/item/twohanded/required/kirbyplants{
 	icon_state = "plant-24"
@@ -75950,8 +75795,7 @@
 	},
 /obj/machinery/camera{
 	c_tag = "Chapel - Funeral Parlour";
-	dir = 8;
-	network = list("SS13")
+	dir = 8
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on,
 /turf/open/floor/plasteel/dark,
@@ -77565,7 +77409,7 @@
 /obj/machinery/computer/security/telescreen{
 	desc = "Used for watching the RD's goons from the safety of your own office.";
 	name = "Research Monitor";
-	network = list("RD");
+	network = list("rd");
 	pixel_y = 32
 	},
 /turf/open/floor/plasteel/white,
@@ -77828,7 +77672,7 @@
 /obj/machinery/computer/security/telescreen{
 	desc = "Used for watching the RD's goons from the safety of your own office.";
 	name = "Research Monitor";
-	network = list("RD");
+	network = list("rd");
 	pixel_y = 32
 	},
 /turf/open/floor/plasteel/white,
@@ -77961,7 +77805,7 @@
 /obj/machinery/camera{
 	c_tag = "Research Division Circuitry Lab";
 	dir = 1;
-	network = list("SS13","RD")
+	network = list("ss13","rd")
 	},
 /turf/open/floor/plasteel/white,
 /area/science/circuit)
@@ -78140,8 +77984,7 @@
 "vhG" = (
 /obj/structure/table/glass,
 /obj/machinery/camera/autoname{
-	dir = 4;
-	network = list("SS13")
+	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/science/misc_lab)

--- a/_maps/map_files/Mining/Lavaland.dmm
+++ b/_maps/map_files/Mining/Lavaland.dmm
@@ -98,7 +98,7 @@
 /obj/machinery/camera{
 	c_tag = "Labor Camp Medical";
 	dir = 8;
-	network = list("Labor")
+	network = list("labor")
 	},
 /turf/open/floor/plasteel/white,
 /area/mine/laborcamp)
@@ -235,7 +235,7 @@
 /obj/machinery/camera{
 	c_tag = "Labor Camp External";
 	dir = 4;
-	network = list("Labor")
+	network = list("labor")
 	},
 /turf/open/floor/plating/asteroid/basalt/lava_land_surface,
 /area/lavaland/surface/outdoors)
@@ -271,7 +271,7 @@
 /area/lavaland/surface/outdoors/explored)
 "aU" = (
 /obj/machinery/flasher{
-	id = "Labor"
+	id = "labor"
 	},
 /turf/closed/wall,
 /area/mine/laborcamp)
@@ -301,7 +301,7 @@
 	dir = 1
 	},
 /obj/machinery/button/door{
-	id = "Labor";
+	id = "labor";
 	name = "Labor Camp Lockdown";
 	pixel_y = 28;
 	req_access_txt = "2"
@@ -310,7 +310,7 @@
 /area/mine/laborcamp)
 "ba" = (
 /obj/machinery/door/poddoor/preopen{
-	id = "Labor";
+	id = "labor";
 	name = "labor camp blast door"
 	},
 /turf/open/floor/plasteel,
@@ -318,7 +318,7 @@
 "bb" = (
 /obj/machinery/camera{
 	c_tag = "Labor Camp Central";
-	network = list("Labor")
+	network = list("labor")
 	},
 /turf/open/floor/plasteel,
 /area/mine/laborcamp)
@@ -417,7 +417,7 @@
 /obj/machinery/camera{
 	c_tag = "EVA";
 	dir = 4;
-	network = list("MINE")
+	network = list("mine")
 	},
 /obj/machinery/airalarm{
 	dir = 4;
@@ -718,7 +718,7 @@
 	},
 /obj/machinery/camera{
 	c_tag = "Labor Camp Monitoring";
-	network = list("Labor")
+	network = list("labor")
 	},
 /obj/structure/cable{
 	icon_state = "0-8"
@@ -847,7 +847,7 @@
 "cx" = (
 /obj/machinery/computer/security{
 	name = "Labor Camp Monitoring";
-	network = list("Labor")
+	network = list("labor")
 	},
 /turf/open/floor/plasteel,
 /area/mine/laborcamp/security)
@@ -1217,7 +1217,7 @@
 /obj/machinery/camera{
 	c_tag = "Communications Relay";
 	dir = 8;
-	network = list("MINE")
+	network = list("mine")
 	},
 /obj/effect/baseturf_helper/picky/lava_land/basalt{
 	whitelist = /turf/open/floor
@@ -1251,7 +1251,7 @@
 /obj/machinery/camera{
 	c_tag = "Sleeper Room";
 	dir = 1;
-	network = list("MINE")
+	network = list("mine")
 	},
 /turf/open/floor/plasteel/white,
 /area/mine/living_quarters)
@@ -1315,7 +1315,7 @@
 /obj/machinery/camera{
 	c_tag = "Shuttle Docking Foyer";
 	dir = 8;
-	network = list("MINE")
+	network = list("mine")
 	},
 /obj/machinery/newscaster{
 	pixel_x = 30;
@@ -1340,7 +1340,7 @@
 /obj/machinery/camera{
 	c_tag = "Processing Area Room";
 	dir = 8;
-	network = list("MINE")
+	network = list("mine")
 	},
 /obj/item/device/radio/intercom{
 	dir = 8;
@@ -1461,7 +1461,7 @@
 "ed" = (
 /obj/machinery/camera{
 	c_tag = "Crew Area Hallway West";
-	network = list("MINE")
+	network = list("mine")
 	},
 /turf/open/floor/plasteel,
 /area/mine/living_quarters)
@@ -1509,7 +1509,7 @@
 "ej" = (
 /obj/machinery/camera{
 	c_tag = "Crew Area Hallway East";
-	network = list("MINE")
+	network = list("mine")
 	},
 /turf/open/floor/plasteel/purple/corner{
 	dir = 1
@@ -1875,7 +1875,7 @@
 /obj/machinery/camera{
 	c_tag = "Storage";
 	dir = 2;
-	network = list("MINE")
+	network = list("mine")
 	},
 /obj/structure/reagent_dispensers/watertank,
 /turf/open/floor/plasteel/brown{
@@ -1990,7 +1990,7 @@
 /obj/machinery/camera{
 	c_tag = "Dormitories";
 	dir = 4;
-	network = list("MINE")
+	network = list("mine")
 	},
 /turf/open/floor/plasteel/purple/corner{
 	dir = 1
@@ -2096,7 +2096,7 @@
 /obj/machinery/camera{
 	c_tag = "Crew Area";
 	dir = 1;
-	network = list("MINE")
+	network = list("mine")
 	},
 /obj/machinery/computer/security/telescreen/entertainment{
 	pixel_y = -32

--- a/_maps/map_files/OmegaStation/OmegaStation.dmm
+++ b/_maps/map_files/OmegaStation/OmegaStation.dmm
@@ -2574,7 +2574,7 @@
 	c_tag = "AI Vault - Port";
 	dir = 4;
 	name = "ai camera";
-	network = list("Sat");
+	network = list("minisat");
 	start_active = 1
 	},
 /obj/effect/turf_decal/stripes/line{
@@ -3515,7 +3515,7 @@
 	c_tag = "AI Vault - Starboard";
 	dir = 8;
 	name = "ai camera";
-	network = list("Sat");
+	network = list("minisat");
 	start_active = 1
 	},
 /obj/effect/turf_decal/stripes/line{
@@ -4081,8 +4081,7 @@
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on,
 /obj/machinery/camera{
-	c_tag = "Armoury - Internal";
-	network = list("Labor")
+	c_tag = "Armoury - Internal"
 	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -4542,8 +4541,7 @@
 	dir = 8
 	},
 /obj/machinery/camera{
-	c_tag = "Security - Cell 1";
-	network = list("MINE")
+	c_tag = "Security - Cell 1"
 	},
 /turf/open/floor/plasteel/red/side{
 	dir = 5
@@ -4569,8 +4567,7 @@
 	},
 /obj/machinery/camera{
 	c_tag = "Fore Primary Hallway";
-	dir = 4;
-	network = list("SS13")
+	dir = 4
 	},
 /turf/open/floor/plasteel/red/corner{
 	dir = 1
@@ -5967,8 +5964,7 @@
 /obj/item/stamp,
 /obj/machinery/camera{
 	c_tag = "Cargo Bay Entrance";
-	dir = 4;
-	network = list("SS13")
+	dir = 4
 	},
 /turf/open/floor/plasteel/brown{
 	dir = 8
@@ -6147,8 +6143,7 @@
 	dir = 8
 	},
 /obj/machinery/camera{
-	c_tag = "Security - Cell 2";
-	network = list("MINE")
+	c_tag = "Security - Cell 2"
 	},
 /turf/open/floor/plasteel/red/side{
 	dir = 5
@@ -6529,8 +6524,7 @@
 	},
 /obj/machinery/camera{
 	c_tag = "Security - Office";
-	dir = 4;
-	network = list("MINE")
+	dir = 4
 	},
 /turf/open/floor/plasteel/red/corner{
 	dir = 1
@@ -6555,8 +6549,7 @@
 "amK" = (
 /obj/machinery/camera{
 	c_tag = "Security - Central";
-	dir = 4;
-	network = list("MINE")
+	dir = 4
 	},
 /turf/open/floor/plasteel/neutral/side{
 	dir = 8
@@ -6637,8 +6630,7 @@
 "amS" = (
 /obj/machinery/camera{
 	c_tag = "Locker Room Toilets";
-	dir = 8;
-	network = list("SS13")
+	dir = 8
 	},
 /turf/open/floor/plasteel/freezer,
 /area/hallway/primary/central)
@@ -8518,8 +8510,7 @@
 /obj/item/shovel,
 /obj/machinery/camera{
 	c_tag = "Mining Dock";
-	dir = 4;
-	network = list("SS13")
+	dir = 4
 	},
 /obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel,
@@ -9028,7 +9019,6 @@
 	},
 /obj/machinery/camera{
 	c_tag = "Atmospherics Tank 4";
-	network = list("thunder");
 	pixel_x = 10
 	},
 /turf/open/floor/plasteel/green/side{
@@ -9431,8 +9421,7 @@
 	},
 /obj/machinery/camera{
 	c_tag = "Central Diner 3";
-	dir = 4;
-	network = list("MINE")
+	dir = 4
 	},
 /turf/open/floor/plasteel/vault/side{
 	dir = 4
@@ -10071,8 +10060,7 @@
 "atz" = (
 /obj/machinery/camera{
 	c_tag = "Atmospherics Tank 1";
-	dir = 4;
-	network = list("SS13")
+	dir = 4
 	},
 /turf/open/floor/plasteel/vault{
 	dir = 5
@@ -10467,8 +10455,7 @@
 	},
 /obj/machinery/camera{
 	c_tag = "Bar";
-	dir = 8;
-	network = list("SS13")
+	dir = 8
 	},
 /turf/open/floor/plasteel/vault{
 	dir = 8
@@ -10486,8 +10473,7 @@
 	},
 /obj/machinery/camera{
 	c_tag = "Bar Backroom";
-	dir = 4;
-	network = list("MINE")
+	dir = 4
 	},
 /turf/open/floor/plasteel/vault,
 /area/crew_quarters/bar/atrium)
@@ -11749,8 +11735,7 @@
 	},
 /obj/machinery/camera{
 	c_tag = "Atmospherics East";
-	dir = 8;
-	network = list("SS13")
+	dir = 8
 	},
 /turf/open/floor/plasteel/caution{
 	dir = 4
@@ -11969,8 +11954,7 @@
 "axj" = (
 /obj/machinery/camera{
 	c_tag = "Atmospherics Tank 2";
-	dir = 4;
-	network = list("SS13")
+	dir = 4
 	},
 /turf/open/floor/plasteel/vault{
 	dir = 5
@@ -12072,8 +12056,7 @@
 /obj/machinery/portable_atmospherics/canister/nitrogen,
 /obj/machinery/camera{
 	c_tag = "Atmospherics Monitoring";
-	dir = 2;
-	network = list("SS13")
+	dir = 2
 	},
 /obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel,
@@ -12647,8 +12630,7 @@
 	},
 /obj/machinery/camera{
 	c_tag = "Central Diner 2";
-	dir = 4;
-	network = list("MINE")
+	dir = 4
 	},
 /turf/open/floor/plasteel/vault/side{
 	dir = 4
@@ -13479,8 +13461,7 @@
 /obj/structure/bedsheetbin,
 /obj/machinery/camera{
 	c_tag = "Locker Room East";
-	dir = 8;
-	network = list("SS13")
+	dir = 8
 	},
 /obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel/arrival{
@@ -14501,8 +14482,7 @@
 	},
 /obj/machinery/camera{
 	c_tag = "Central Hallway East";
-	dir = 4;
-	network = list("SS13")
+	dir = 4
 	},
 /turf/open/floor/plasteel/neutral/corner{
 	dir = 1
@@ -15104,8 +15084,7 @@
 	},
 /obj/machinery/camera{
 	c_tag = "Engineering Secure Storage";
-	dir = 4;
-	network = list("SS13")
+	dir = 4
 	},
 /obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel/vault/side{
@@ -15350,8 +15329,7 @@
 	},
 /obj/machinery/camera{
 	c_tag = "Locker Room South";
-	dir = 8;
-	network = list("SS13")
+	dir = 8
 	},
 /obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel/vault{
@@ -15708,8 +15686,7 @@
 	},
 /obj/machinery/camera{
 	c_tag = "SMES Access";
-	dir = 8;
-	network = list("SS13")
+	dir = 8
 	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 2
@@ -15752,8 +15729,7 @@
 	},
 /obj/machinery/camera{
 	c_tag = "Engineering Access";
-	dir = 8;
-	network = list("Labor")
+	dir = 8
 	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 6
@@ -15890,8 +15866,7 @@
 	},
 /obj/machinery/camera{
 	c_tag = "Central Diner 1";
-	dir = 4;
-	network = list("MINE")
+	dir = 4
 	},
 /turf/open/floor/plasteel/redyellow,
 /area/crew_quarters/bar/atrium)
@@ -16471,8 +16446,7 @@
 "aHg" = (
 /obj/machinery/camera{
 	c_tag = "Gravity Generator Room";
-	dir = 8;
-	network = list("SS13")
+	dir = 8
 	},
 /obj/effect/turf_decal/bot_white/left,
 /turf/open/floor/plasteel/vault{
@@ -16572,7 +16546,7 @@
 /obj/machinery/camera{
 	c_tag = "Engineering Fore";
 	dir = 2;
-	network = list("SS13","Engine");
+	network = list("ss13","engine");
 	pixel_x = 23
 	},
 /turf/open/floor/engine,
@@ -17197,8 +17171,7 @@
 	},
 /obj/machinery/camera{
 	c_tag = "Engineering Monitoring";
-	dir = 2;
-	network = list("SS13")
+	dir = 2
 	},
 /obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel,
@@ -18023,7 +17996,7 @@
 /obj/machinery/camera{
 	c_tag = "Kitchen Coldroom";
 	dir = 4;
-	network = list("MINE")
+	network = list("mine")
 	},
 /turf/open/floor/plasteel/freezer,
 /area/crew_quarters/kitchen)
@@ -19158,7 +19131,7 @@
 /obj/machinery/camera{
 	c_tag = "Engineering Port";
 	dir = 4;
-	network = list("SS13","Engine")
+	network = list("ss13","engine")
 	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -19184,7 +19157,7 @@
 /obj/machinery/camera{
 	c_tag = "Supermatter Chamber";
 	dir = 2;
-	network = list("Engine");
+	network = list("engine");
 	pixel_x = 23
 	},
 /obj/structure/cable{
@@ -19298,7 +19271,7 @@
 	desc = "Used for watching the Engine.";
 	dir = 1;
 	name = "Engine Monitor";
-	network = list("Engine");
+	network = list("engine");
 	pixel_y = -32
 	},
 /obj/machinery/rnd/protolathe/department/engineering,
@@ -19348,8 +19321,7 @@
 	},
 /obj/machinery/camera{
 	c_tag = "Atmospherics South West";
-	dir = 4;
-	network = list("SS13")
+	dir = 4
 	},
 /turf/open/floor/plasteel/neutral/corner{
 	dir = 8;
@@ -19481,8 +19453,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/machinery/camera{
 	c_tag = "Hydroponics South";
-	dir = 8;
-	network = list("SS13")
+	dir = 8
 	},
 /obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel/vault/side{
@@ -20166,8 +20137,7 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/camera{
-	c_tag = "Aft Primary Hallway 4";
-	network = list("SS13","Prison")
+	c_tag = "Aft Primary Hallway 4"
 	},
 /turf/open/floor/plasteel/green/corner{
 	dir = 1
@@ -20275,8 +20245,7 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/camera{
-	c_tag = "Aft Primary Hallway 3";
-	network = list("SS13","Prison")
+	c_tag = "Aft Primary Hallway 3"
 	},
 /turf/open/floor/plasteel/green/corner{
 	dir = 1
@@ -21113,7 +21082,7 @@
 /obj/machinery/camera{
 	c_tag = "Engineering Aft";
 	dir = 2;
-	network = list("SS13","Engine");
+	network = list("ss13","engine");
 	pixel_x = 23
 	},
 /obj/machinery/atmospherics/pipe/simple/orange/visible{
@@ -21270,8 +21239,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/machinery/camera{
 	c_tag = "Aft Primary Hallway 2";
-	dir = 4;
-	network = list("SS13")
+	dir = 4
 	},
 /turf/open/floor/plasteel/yellow/corner{
 	dir = 8
@@ -21548,8 +21516,7 @@
 	},
 /obj/machinery/camera{
 	c_tag = "Library 2";
-	dir = 4;
-	network = list("SS13")
+	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
 /area/library)
@@ -21698,8 +21665,7 @@
 	},
 /obj/machinery/camera{
 	c_tag = "Chemistry";
-	dir = 2;
-	network = list("SS13")
+	dir = 2
 	},
 /turf/open/floor/plasteel/whiteyellow/corner{
 	dir = 1
@@ -22580,8 +22546,7 @@
 "aUo" = (
 /obj/machinery/camera{
 	c_tag = "Genetics Cloning";
-	dir = 4;
-	network = list("SS13")
+	dir = 4
 	},
 /turf/open/floor/plasteel/whiteblue/corner{
 	dir = 1
@@ -23149,7 +23114,7 @@
 /obj/machinery/camera{
 	c_tag = "Server Room";
 	dir = 2;
-	network = list("SS13","RD");
+	network = list("ss13","rd");
 	pixel_x = 22
 	},
 /turf/open/floor/circuit/green/telecomms/mainframe,
@@ -23658,8 +23623,7 @@
 /obj/structure/closet/crate/bin,
 /obj/machinery/camera{
 	c_tag = "Medbay Morgue";
-	dir = 8;
-	network = list("SS13")
+	dir = 8
 	},
 /turf/open/floor/plasteel/vault/side{
 	dir = 8
@@ -23927,8 +23891,7 @@
 	},
 /obj/machinery/camera{
 	c_tag = "Medbay West";
-	dir = 2;
-	network = list("SS13")
+	dir = 2
 	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -24243,8 +24206,7 @@
 	},
 /obj/machinery/camera{
 	c_tag = "Medbay Storage";
-	dir = 2;
-	network = list("SS13")
+	dir = 2
 	},
 /obj/effect/turf_decal/delivery,
 /obj/structure/window/reinforced{
@@ -24508,8 +24470,7 @@
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden,
 /obj/machinery/camera{
 	c_tag = "Research Division South";
-	dir = 8;
-	network = list("SS13")
+	dir = 8
 	},
 /turf/open/floor/plasteel/whitepurple/corner,
 /area/science/research)
@@ -25344,7 +25305,7 @@
 /obj/machinery/camera{
 	c_tag = "Robotics Lab";
 	dir = 2;
-	network = list("SS13","RD")
+	network = list("ss13","rd")
 	},
 /obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel/vault/side,
@@ -25650,8 +25611,7 @@
 	},
 /obj/machinery/camera{
 	c_tag = "Medbay Foyer";
-	dir = 8;
-	network = list("SS13")
+	dir = 8
 	},
 /turf/open/floor/plasteel/neutral,
 /area/hallway/primary/central)
@@ -26721,8 +26681,7 @@
 	},
 /obj/machinery/camera{
 	c_tag = "Medbay South";
-	dir = 4;
-	network = list("SS13")
+	dir = 4
 	},
 /turf/open/floor/plasteel/whiteblue/corner{
 	dir = 8
@@ -27239,8 +27198,7 @@
 	},
 /obj/machinery/camera{
 	c_tag = "Medbay Recovery Room";
-	dir = 8;
-	network = list("SS13")
+	dir = 8
 	},
 /turf/open/floor/plasteel/vault/side{
 	dir = 8
@@ -28464,7 +28422,7 @@
 /obj/machinery/camera{
 	c_tag = "Xenobiology Test Chamber";
 	dir = 2;
-	network = list("Xeno","RD")
+	network = list("xeno","rd")
 	},
 /turf/open/floor/plasteel/vault{
 	dir = 4
@@ -28559,7 +28517,7 @@
 /obj/machinery/camera{
 	c_tag = "Crematorium";
 	dir = 4;
-	network = list("MINE")
+	network = list("mine")
 	},
 /turf/open/floor/plasteel/vault/side{
 	dir = 4
@@ -29244,8 +29202,7 @@
 	},
 /obj/machinery/camera{
 	c_tag = "Chaplain's Quarters";
-	dir = 2;
-	network = list("SS13")
+	dir = 2
 	},
 /turf/open/floor/plasteel/vault{
 	dir = 8
@@ -29291,8 +29248,7 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on,
 /obj/machinery/camera{
 	c_tag = "Chapel Office";
-	dir = 2;
-	network = list("SS13")
+	dir = 2
 	},
 /turf/open/floor/wood,
 /area/chapel/main)
@@ -29727,8 +29683,7 @@
 	},
 /obj/machinery/camera{
 	c_tag = "Chapel South";
-	dir = 8;
-	network = list("SS13")
+	dir = 8
 	},
 /turf/open/floor/plasteel/vault{
 	dir = 5
@@ -29750,8 +29705,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/machinery/camera{
 	c_tag = "Arrivals Hallway 3";
-	dir = 8;
-	network = list("SS13")
+	dir = 8
 	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 2
@@ -29838,7 +29792,7 @@
 	c_tag = "Science - Server Room";
 	dir = 8;
 	name = "science camera";
-	network = list("SS13","RD")
+	network = list("ss13","rd")
 	},
 /turf/open/floor/circuit/green/telecomms/mainframe,
 /area/science/xenobiology)
@@ -30426,8 +30380,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/machinery/camera{
 	c_tag = "Port Primary Hallway";
-	dir = 4;
-	network = list("SS13")
+	dir = 4
 	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 2
@@ -30444,8 +30397,7 @@
 	},
 /obj/machinery/camera{
 	c_tag = "Starboard Primary Hallway 2";
-	dir = 8;
-	network = list("SS13")
+	dir = 8
 	},
 /turf/open/floor/plasteel/neutral/corner,
 /area/hallway/primary/central)
@@ -30453,8 +30405,7 @@
 /obj/structure/closet/firecloset,
 /obj/machinery/camera{
 	c_tag = "Starboard Primary Hallway 2";
-	dir = 2;
-	network = list("SS13")
+	dir = 2
 	},
 /obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel/vault/side{
@@ -30477,8 +30428,7 @@
 "blk" = (
 /obj/machinery/camera{
 	c_tag = "Atmospherics Tank 3";
-	dir = 4;
-	network = list("SS13")
+	dir = 4
 	},
 /turf/open/floor/plasteel/vault{
 	dir = 5
@@ -30491,12 +30441,11 @@
 /obj/machinery/camera{
 	c_tag = "Shuttle Docking Foyer";
 	dir = 8;
-	network = list("MINE")
+	network = list("mine")
 	},
 /obj/machinery/camera{
 	c_tag = "Escape Arm Airlocks";
-	dir = 8;
-	network = list("SS13")
+	dir = 8
 	},
 /obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel,
@@ -30505,8 +30454,7 @@
 /obj/structure/closet/emcloset,
 /obj/machinery/camera{
 	c_tag = "Starboard Primary Hallway";
-	dir = 2;
-	network = list("SS13")
+	dir = 2
 	},
 /obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel/vault/side{
@@ -30520,7 +30468,7 @@
 /obj/machinery/camera{
 	c_tag = "Engineering Starboard";
 	dir = 8;
-	network = list("SS13","Engine")
+	network = list("ss13","engine")
 	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -30536,8 +30484,7 @@
 	},
 /obj/machinery/camera{
 	c_tag = "Research Division Access";
-	dir = 2;
-	network = list("SS13")
+	dir = 2
 	},
 /obj/structure/cable/white{
 	icon_state = "2-8"
@@ -30551,7 +30498,6 @@
 /obj/machinery/camera{
 	c_tag = "Aft Primary Hallway 1";
 	dir = 8;
-	network = list("SS13");
 	pixel_y = -22
 	},
 /turf/open/floor/plasteel/purple/corner,
@@ -30596,7 +30542,6 @@
 /obj/machinery/camera{
 	c_tag = "Surgery Operating";
 	dir = 1;
-	network = list("SS13");
 	pixel_x = 22
 	},
 /turf/open/floor/plasteel/neutral,
@@ -30605,7 +30550,7 @@
 /obj/machinery/camera{
 	c_tag = "Xenobiology Test Chamber";
 	dir = 2;
-	network = list("Xeno","RD")
+	network = list("xeno","rd")
 	},
 /turf/open/floor/plasteel/vault{
 	dir = 5
@@ -30628,8 +30573,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/machinery/camera{
 	c_tag = "Arrivals Hallway";
-	dir = 8;
-	network = list("SS13")
+	dir = 8
 	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -30640,8 +30584,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/machinery/camera{
 	c_tag = "Arrivals Hallway 2";
-	dir = 8;
-	network = list("SS13")
+	dir = 8
 	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -30698,8 +30641,7 @@
 	},
 /obj/machinery/camera{
 	c_tag = "Chapel Mass Driver";
-	dir = 8;
-	network = list("SS13")
+	dir = 8
 	},
 /obj/machinery/light/small,
 /obj/machinery/button/massdriver{
@@ -31277,8 +31219,7 @@
 "buU" = (
 /obj/machinery/camera{
 	c_tag = "Communications Relay";
-	dir = 8;
-	network = list("MINE")
+	dir = 8
 	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -33051,7 +32992,7 @@
 	c_tag = "AI Chamber - Core";
 	dir = 2;
 	name = "core camera";
-	network = list("RD")
+	network = list("rd")
 	},
 /obj/machinery/cell_charger,
 /turf/open/floor/plasteel/vault/side,
@@ -33234,7 +33175,7 @@
 	c_tag = "AI Chamber - Core";
 	dir = 2;
 	name = "core camera";
-	network = list("RD")
+	network = list("rd")
 	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -33371,7 +33312,7 @@
 	c_tag = "AI Chamber - Core";
 	dir = 2;
 	name = "core camera";
-	network = list("RD")
+	network = list("rd")
 	},
 /obj/machinery/light{
 	dir = 1
@@ -33604,7 +33545,7 @@
 	c_tag = "AI Satellite - Access";
 	dir = 4;
 	name = "ai camera";
-	network = list("Sat");
+	network = list("minisat");
 	start_active = 1
 	},
 /turf/open/floor/plasteel/vault/side{
@@ -33892,7 +33833,7 @@
 	c_tag = "AI Satellite - Maintenance";
 	dir = 8;
 	name = "ai camera";
-	network = list("Sat");
+	network = list("minisat");
 	start_active = 1
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
@@ -33964,7 +33905,7 @@
 	c_tag = "AI Satellite - Antechamber";
 	dir = 4;
 	name = "ai camera";
-	network = list("Sat");
+	network = list("minisat");
 	start_active = 1
 	},
 /turf/open/floor/plasteel/vault/side{

--- a/_maps/map_files/PubbyStation/PubbyStation.dmm
+++ b/_maps/map_files/PubbyStation/PubbyStation.dmm
@@ -16,7 +16,7 @@
 /obj/machinery/camera/motion{
 	c_tag = "MiniSat External Fore";
 	dir = 1;
-	network = list("MiniSat")
+	network = list("minisat")
 	},
 /turf/open/space,
 /area/space/nearstation)
@@ -63,7 +63,7 @@
 /obj/machinery/camera/motion{
 	c_tag = "MiniSat AI Chamber North";
 	dir = 1;
-	network = list("MiniSat")
+	network = list("minisat")
 	},
 /obj/machinery/light,
 /obj/machinery/flasher{
@@ -121,7 +121,7 @@
 /obj/machinery/camera/motion{
 	c_tag = "MiniSat AI Chamber Center";
 	dir = 2;
-	network = list("MiniSat")
+	network = list("minisat")
 	},
 /obj/machinery/light/small{
 	dir = 1
@@ -160,7 +160,7 @@
 /obj/machinery/camera/motion{
 	c_tag = "MiniSat External Port";
 	dir = 8;
-	network = list("MiniSat")
+	network = list("minisat")
 	},
 /turf/open/space,
 /area/space/nearstation)
@@ -171,7 +171,7 @@
 /obj/machinery/camera/motion{
 	c_tag = "MiniSat AI Chamber West";
 	dir = 4;
-	network = list("MiniSat")
+	network = list("minisat")
 	},
 /obj/machinery/light{
 	dir = 8
@@ -241,7 +241,7 @@
 /obj/machinery/camera/motion{
 	c_tag = "MiniSat AI Chamber East";
 	dir = 8;
-	network = list("MiniSat")
+	network = list("minisat")
 	},
 /obj/machinery/light{
 	dir = 4
@@ -252,7 +252,7 @@
 /obj/machinery/camera/motion{
 	c_tag = "MiniSat External Starboard";
 	dir = 4;
-	network = list("MiniSat")
+	network = list("minisat")
 	},
 /turf/open/space,
 /area/space/nearstation)
@@ -332,7 +332,7 @@
 /obj/machinery/camera/motion{
 	c_tag = "MiniSat AI Chamber South";
 	dir = 2;
-	network = list("MiniSat")
+	network = list("minisat")
 	},
 /obj/machinery/light{
 	dir = 1
@@ -625,7 +625,7 @@
 /obj/machinery/camera{
 	c_tag = "MiniSat Maintenance Port Fore";
 	dir = 1;
-	network = list("MiniSat")
+	network = list("minisat")
 	},
 /turf/open/floor/plating,
 /area/ai_monitored/turret_protected/AIsatextAP)
@@ -684,7 +684,7 @@
 /obj/machinery/camera/motion{
 	c_tag = "MiniSat AI Chamber Observation";
 	dir = 1;
-	network = list("MiniSat")
+	network = list("minisat")
 	},
 /turf/open/floor/plasteel/grimy,
 /area/ai_monitored/turret_protected/aisat_interior)
@@ -718,7 +718,7 @@
 /obj/machinery/camera{
 	c_tag = "MiniSat Maintenance Starboard Fore";
 	dir = 1;
-	network = list("MiniSat")
+	network = list("minisat")
 	},
 /turf/open/floor/plating,
 /area/ai_monitored/turret_protected/AIsatextAS)
@@ -852,7 +852,7 @@
 /obj/machinery/camera/motion{
 	c_tag = "MiniSat Bridge Port Fore";
 	dir = 2;
-	network = list("MiniSat")
+	network = list("minisat")
 	},
 /turf/open/space,
 /area/ai_monitored/turret_protected/AIsatextAP)
@@ -880,7 +880,7 @@
 /obj/machinery/camera/motion{
 	c_tag = "MiniSat Bridge Starboard Fore";
 	dir = 2;
-	network = list("MiniSat")
+	network = list("minisat")
 	},
 /turf/open/space,
 /area/ai_monitored/turret_protected/AIsatextAS)
@@ -977,7 +977,7 @@
 	},
 /obj/machinery/camera{
 	c_tag = "Permabrig Central";
-	network = list("SS13","Prison")
+	network = list("ss13","prison")
 	},
 /turf/open/floor/plasteel/dark,
 /area/security/prison)
@@ -1039,7 +1039,7 @@
 /obj/machinery/camera/motion{
 	c_tag = "MiniSat Bridge Port Aft";
 	dir = 1;
-	network = list("MiniSat")
+	network = list("minisat")
 	},
 /turf/open/space,
 /area/ai_monitored/turret_protected/AIsatextAP)
@@ -1057,7 +1057,7 @@
 /obj/machinery/camera/motion{
 	c_tag = "MiniSat Bridge Starboard Aft";
 	dir = 1;
-	network = list("MiniSat")
+	network = list("minisat")
 	},
 /turf/open/space,
 /area/ai_monitored/turret_protected/AIsatextAS)
@@ -1239,7 +1239,7 @@
 /obj/machinery/camera{
 	c_tag = "MiniSat Maintenance Port Aft";
 	dir = 2;
-	network = list("MiniSat")
+	network = list("minisat")
 	},
 /turf/open/floor/plating,
 /area/ai_monitored/turret_protected/AIsatextAP)
@@ -1304,7 +1304,7 @@
 /obj/machinery/camera/motion{
 	c_tag = "MiniSat Foyer";
 	dir = 2;
-	network = list("MiniSat")
+	network = list("minisat")
 	},
 /turf/open/floor/plasteel/darkblue/side{
 	dir = 4
@@ -1354,7 +1354,7 @@
 /obj/machinery/camera{
 	c_tag = "MiniSat Maintenance Starboard Aft";
 	dir = 2;
-	network = list("MiniSat")
+	network = list("minisat")
 	},
 /turf/open/floor/plating,
 /area/ai_monitored/turret_protected/AIsatextAS)
@@ -1879,7 +1879,7 @@
 /obj/structure/bed,
 /obj/machinery/camera{
 	c_tag = "Permabrig Cell 2";
-	network = list("SS13","Prison")
+	network = list("ss13","prison")
 	},
 /obj/item/device/radio/intercom{
 	desc = "Talk through this. It looks like it has been modified to not broadcast.";
@@ -1921,7 +1921,7 @@
 /obj/structure/bed,
 /obj/machinery/camera{
 	c_tag = "Permabrig Cell 1";
-	network = list("SS13","Prison")
+	network = list("ss13","prison")
 	},
 /obj/item/device/radio/intercom{
 	desc = "Talk through this. It looks like it has been modified to not broadcast.";
@@ -2174,7 +2174,7 @@
 /obj/machinery/camera/motion{
 	c_tag = "MiniSat Entrance";
 	dir = 2;
-	network = list("MiniSat")
+	network = list("minisat")
 	},
 /turf/open/space,
 /area/space/nearstation)
@@ -2295,12 +2295,12 @@
 "ahF" = (
 /obj/machinery/camera{
 	c_tag = "Brig Prison Hallway";
-	network = list("SS13","Prison")
+	network = list("ss13","prison")
 	},
 /obj/machinery/computer/security/telescreen{
 	desc = "Used for watching Prison Wing holding areas.";
 	name = "Prison Monitor";
-	network = list("Prison");
+	network = list("prison");
 	pixel_y = 30
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -3921,8 +3921,7 @@
 	},
 /obj/machinery/camera{
 	c_tag = "Brig Crematorium";
-	dir = 8;
-	network = list("SS13")
+	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/manifold/cyan/hidden{
 	dir = 8
@@ -4328,8 +4327,7 @@
 	},
 /obj/machinery/camera{
 	c_tag = "Security Office";
-	dir = 4;
-	network = list("SS13")
+	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/manifold/cyan/hidden{
 	dir = 8
@@ -5042,8 +5040,7 @@
 	},
 /obj/machinery/camera{
 	c_tag = "Head of Security's Office";
-	dir = 1;
-	network = list("SS13")
+	dir = 1
 	},
 /obj/item/device/radio/intercom{
 	dir = 4;
@@ -5158,7 +5155,7 @@
 "aok" = (
 /obj/machinery/computer/security{
 	name = "Labor Camp Monitoring";
-	network = list("Labor")
+	network = list("labor")
 	},
 /turf/open/floor/plasteel/dark,
 /area/security/brig)
@@ -6461,8 +6458,7 @@
 /obj/effect/turf_decal/stripes/line,
 /obj/machinery/camera{
 	c_tag = "Bridge MiniSat Access";
-	dir = 4;
-	network = list("SS13")
+	dir = 4
 	},
 /turf/open/floor/plating,
 /area/bridge)
@@ -6556,8 +6552,7 @@
 /obj/machinery/computer/card,
 /obj/machinery/camera{
 	c_tag = "Bridge - Central";
-	dir = 2;
-	network = list("SS13")
+	dir = 2
 	},
 /turf/open/floor/plasteel/darkblue/side{
 	dir = 1
@@ -6651,8 +6646,7 @@
 "arX" = (
 /obj/machinery/camera{
 	c_tag = "Gateway";
-	dir = 4;
-	network = list("SS13")
+	dir = 4
 	},
 /obj/structure/table,
 /obj/structure/sign/warning/biohazard{
@@ -7553,8 +7547,7 @@
 "aud" = (
 /obj/machinery/camera/motion{
 	c_tag = "Vault";
-	dir = 1;
-	network = list("SS13")
+	dir = 1
 	},
 /obj/machinery/light,
 /obj/structure/cable{
@@ -8044,7 +8037,7 @@
 /obj/machinery/computer/security/telescreen{
 	desc = "Used for watching the monastery.";
 	name = "Monastery Monitor";
-	network = list("Monastery");
+	network = list("monastery");
 	pixel_y = 32
 	},
 /turf/open/floor/plasteel/blue/corner{
@@ -8099,8 +8092,7 @@
 	},
 /obj/machinery/camera{
 	c_tag = "Labor Shuttle Dock";
-	dir = 8;
-	network = list("SS13")
+	dir = 8
 	},
 /obj/machinery/gulag_item_reclaimer{
 	pixel_y = 24
@@ -8267,8 +8259,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/machinery/camera{
 	c_tag = "Bridge MiniSat Access Foyer";
-	dir = 1;
-	network = list("SS13")
+	dir = 1
 	},
 /obj/machinery/light/small,
 /turf/open/floor/plasteel/vault,
@@ -9768,8 +9759,7 @@
 /obj/machinery/light,
 /obj/machinery/camera{
 	c_tag = "Bridge External Access";
-	dir = 1;
-	network = list("SS13")
+	dir = 1
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on,
 /turf/open/floor/plasteel/dark,
@@ -10600,7 +10590,7 @@
 /obj/machinery/computer/security/telescreen{
 	desc = "Used for watching the monastery.";
 	name = "Monastery Monitor";
-	network = list("Monastery");
+	network = list("monastery");
 	pixel_y = 32
 	},
 /turf/open/floor/wood,
@@ -10614,8 +10604,7 @@
 	},
 /obj/machinery/camera{
 	c_tag = "Head of Personnel's Office";
-	dir = 2;
-	network = list("SS13")
+	dir = 2
 	},
 /obj/machinery/newscaster{
 	pixel_y = 32
@@ -11061,8 +11050,7 @@
 	},
 /obj/machinery/camera{
 	c_tag = "Captain's Office";
-	dir = 8;
-	network = list("SS13")
+	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
@@ -11988,8 +11976,7 @@
 	},
 /obj/machinery/camera{
 	c_tag = "Bridge Port Entrance";
-	dir = 8;
-	network = list("SS13")
+	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plasteel/darkblue/corner{
@@ -14883,8 +14870,7 @@
 	},
 /obj/machinery/camera{
 	c_tag = "Cargo Security Post";
-	dir = 2;
-	network = list("SS13")
+	dir = 2
 	},
 /obj/machinery/airalarm{
 	pixel_y = 22
@@ -15901,8 +15887,7 @@
 	},
 /obj/machinery/camera{
 	c_tag = "EVA Storage";
-	dir = 4;
-	network = list("SS13")
+	dir = 4
 	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -15932,8 +15917,7 @@
 	},
 /obj/machinery/camera{
 	c_tag = "Teleporter";
-	dir = 4;
-	network = list("SS13")
+	dir = 4
 	},
 /obj/structure/extinguisher_cabinet{
 	pixel_x = -26
@@ -16874,8 +16858,7 @@
 /obj/machinery/vending/coffee,
 /obj/machinery/camera{
 	c_tag = "Bar Backroom";
-	dir = 2;
-	network = list("SS13")
+	dir = 2
 	},
 /turf/open/floor/wood,
 /area/crew_quarters/bar)
@@ -18175,8 +18158,7 @@
 "aTZ" = (
 /obj/machinery/camera{
 	c_tag = "Kitchen Cold Room";
-	dir = 2;
-	network = list("SS13")
+	dir = 2
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 8
@@ -19099,8 +19081,7 @@
 	},
 /obj/machinery/camera{
 	c_tag = "Bar Access";
-	dir = 2;
-	network = list("SS13")
+	dir = 2
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
@@ -20539,8 +20520,7 @@
 	},
 /obj/machinery/camera{
 	c_tag = "Security Checkpoint";
-	dir = 4;
-	network = list("SS13")
+	dir = 4
 	},
 /obj/machinery/airalarm{
 	dir = 4;
@@ -21472,8 +21452,7 @@
 	},
 /obj/machinery/camera{
 	c_tag = "Hydroponics South";
-	dir = 8;
-	network = list("SS13")
+	dir = 8
 	},
 /turf/open/floor/plasteel/neutral/side{
 	dir = 4
@@ -22569,8 +22548,7 @@
 "beY" = (
 /obj/machinery/camera{
 	c_tag = "Arrivals Central";
-	dir = 4;
-	network = list("SS13")
+	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 8
@@ -22822,8 +22800,7 @@
 /obj/machinery/light,
 /obj/machinery/camera{
 	c_tag = "Cargo Quartermaster's Office";
-	dir = 1;
-	network = list("SS13")
+	dir = 1
 	},
 /turf/open/floor/plasteel/brown{
 	dir = 2
@@ -24660,7 +24637,7 @@
 /obj/machinery/camera{
 	c_tag = "Experimentation Lab Chamber";
 	dir = 2;
-	network = list("SS13","RD")
+	network = list("ss13","rd")
 	},
 /turf/open/floor/engine,
 /area/science/explab)
@@ -24829,8 +24806,7 @@
 	},
 /obj/machinery/camera{
 	c_tag = "Genetics Cloning Foyer";
-	dir = 2;
-	network = list("SS13")
+	dir = 2
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on,
 /obj/machinery/airalarm{
@@ -25090,7 +25066,7 @@
 /obj/machinery/camera{
 	c_tag = "Robotics Lab";
 	dir = 2;
-	network = list("SS13","RD")
+	network = list("ss13","rd")
 	},
 /obj/structure/sink/kitchen{
 	name = "utility sink";
@@ -25249,7 +25225,7 @@
 /obj/machinery/camera{
 	c_tag = "Xenobiology Test Chamber";
 	dir = 2;
-	network = list("Xeno","RD")
+	network = list("xeno","rd")
 	},
 /obj/machinery/atmospherics/pipe/simple/general/hidden,
 /obj/machinery/light{
@@ -25427,8 +25403,7 @@
 	},
 /obj/machinery/camera{
 	c_tag = "Medbay Security Post";
-	dir = 4;
-	network = list("SS13")
+	dir = 4
 	},
 /obj/structure/closet/secure_closet/security/med,
 /turf/open/floor/plasteel/red/side{
@@ -25803,8 +25778,7 @@
 	},
 /obj/machinery/camera{
 	c_tag = "Medbay Port Entrance";
-	dir = 4;
-	network = list("SS13")
+	dir = 4
 	},
 /obj/machinery/light{
 	dir = 8
@@ -26432,7 +26406,7 @@
 /obj/machinery/camera{
 	c_tag = "Server Room";
 	dir = 2;
-	network = list("SS13","RD");
+	network = list("ss13","rd");
 	pixel_x = 22
 	},
 /turf/open/floor/plasteel/dark,
@@ -27278,7 +27252,7 @@
 /obj/machinery/camera{
 	c_tag = "Genetics Monkey Pen Fore";
 	dir = 4;
-	network = list("SS13","RD")
+	network = list("ss13","rd")
 	},
 /obj/machinery/light/small{
 	dir = 8
@@ -27753,7 +27727,7 @@
 /obj/machinery/camera{
 	c_tag = "Xenobiology Port";
 	dir = 8;
-	network = list("SS13","RD")
+	network = list("ss13","rd")
 	},
 /obj/effect/turf_decal/stripes/corner{
 	dir = 2
@@ -27774,7 +27748,7 @@
 "brT" = (
 /obj/machinery/computer/security/telescreen{
 	name = "Test Chamber Monitor";
-	network = list("Xeno");
+	network = list("xeno");
 	pixel_y = 2
 	},
 /obj/structure/table/reinforced,
@@ -27978,8 +27952,7 @@
 /obj/machinery/dna_scannernew,
 /obj/machinery/camera{
 	c_tag = "Genetics Cloning";
-	dir = 4;
-	network = list("SS13")
+	dir = 4
 	},
 /obj/machinery/airalarm{
 	dir = 4;
@@ -28299,7 +28272,7 @@
 /obj/machinery/camera{
 	c_tag = "Robotics - Aft";
 	dir = 1;
-	network = list("SS13","RD")
+	network = list("ss13","rd")
 	},
 /turf/open/floor/plasteel/white,
 /area/science/robotics/lab)
@@ -28372,7 +28345,7 @@
 /obj/machinery/camera{
 	c_tag = "Experimentation Lab";
 	dir = 1;
-	network = list("SS13","RD")
+	network = list("ss13","rd")
 	},
 /turf/open/floor/plasteel/white,
 /area/science/explab)
@@ -28486,7 +28459,7 @@
 /obj/machinery/camera{
 	c_tag = "Xenobiology Starboard Fore";
 	dir = 2;
-	network = list("SS13","RD")
+	network = list("ss13","rd")
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
 	dir = 1
@@ -28776,8 +28749,7 @@
 	},
 /obj/machinery/camera{
 	c_tag = "Chemistry";
-	dir = 4;
-	network = list("SS13")
+	dir = 4
 	},
 /turf/open/floor/plasteel/whiteyellow/side{
 	dir = 8
@@ -28852,7 +28824,7 @@
 /obj/machinery/camera{
 	c_tag = "Research and Development Lab";
 	dir = 8;
-	network = list("SS13","RD")
+	network = list("ss13","rd")
 	},
 /obj/machinery/firealarm{
 	dir = 4;
@@ -29167,7 +29139,7 @@
 /obj/machinery/camera{
 	c_tag = "Xenobiology Kill Room";
 	dir = 8;
-	network = list("SS13","RD")
+	network = list("ss13","rd")
 	},
 /turf/open/floor/plating/airless,
 /area/science/xenobiology)
@@ -29205,8 +29177,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/machinery/camera{
 	c_tag = "Medbay Port Hallway";
-	dir = 4;
-	network = list("SS13")
+	dir = 4
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/zone3)
@@ -29320,7 +29291,6 @@
 /obj/machinery/camera{
 	c_tag = "Aft Primary Hallway Chemistry";
 	dir = 4;
-	network = list("SS13");
 	start_active = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -29474,7 +29444,7 @@
 /obj/machinery/camera{
 	c_tag = "Science Access Airlock";
 	dir = 2;
-	network = list("SS13","RD")
+	network = list("ss13","rd")
 	},
 /turf/open/floor/plasteel/white,
 /area/science/research)
@@ -29611,8 +29581,7 @@
 /obj/structure/closet/l3closet,
 /obj/machinery/camera{
 	c_tag = "Xenobiology Access";
-	dir = 2;
-	network = list("SS13")
+	dir = 2
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -29700,7 +29669,7 @@
 /obj/machinery/camera{
 	c_tag = "Xenobiology Central";
 	dir = 1;
-	network = list("SS13","RD")
+	network = list("ss13","rd")
 	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 1
@@ -29719,7 +29688,7 @@
 /obj/machinery/camera{
 	c_tag = "Xenobiology Starboard Aft";
 	dir = 1;
-	network = list("SS13","RD")
+	network = list("ss13","rd")
 	},
 /turf/open/floor/plasteel/darkpurple/side,
 /area/science/xenobiology)
@@ -29945,8 +29914,7 @@
 	},
 /obj/machinery/camera{
 	c_tag = "Medbay Sleepers";
-	dir = 1;
-	network = list("SS13")
+	dir = 1
 	},
 /turf/open/floor/plasteel/whiteblue/side,
 /area/medical/sleeper)
@@ -31451,7 +31419,7 @@
 	desc = "Used for watching the monastery.";
 	dir = 8;
 	name = "Monastery Monitor";
-	network = list("Monastery");
+	network = list("monastery");
 	pixel_x = 28
 	},
 /turf/open/floor/plasteel/dark,
@@ -31482,7 +31450,7 @@
 /obj/machinery/camera{
 	c_tag = "Genetics Monkey Pen Aft";
 	dir = 4;
-	network = list("SS13","RD")
+	network = list("ss13","rd")
 	},
 /obj/structure/flora/ausbushes/grassybush,
 /obj/machinery/light/small{
@@ -32148,8 +32116,7 @@
 /obj/structure/disposalpipe/segment,
 /obj/machinery/camera{
 	c_tag = "Chief Medical Office";
-	dir = 8;
-	network = list("SS13")
+	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 10
@@ -32159,7 +32126,7 @@
 	dir = 8;
 	layer = 4;
 	name = "Surgery Telescreen";
-	network = list("Surgery");
+	network = list("surgery");
 	pixel_x = 30
 	},
 /turf/open/floor/plasteel/cmo,
@@ -32405,7 +32372,7 @@
 /obj/machinery/camera{
 	c_tag = "Toxins Lab Port";
 	dir = 2;
-	network = list("SS13","RD")
+	network = list("ss13","rd")
 	},
 /turf/open/floor/plasteel/dark,
 /area/science/mixing)
@@ -32449,7 +32416,7 @@
 /obj/machinery/camera{
 	c_tag = "Toxins Lab Starboard";
 	dir = 2;
-	network = list("SS13","RD")
+	network = list("ss13","rd")
 	},
 /turf/open/floor/plasteel/vault{
 	dir = 5
@@ -32516,7 +32483,7 @@
 /obj/machinery/camera{
 	c_tag = "Genetics";
 	dir = 1;
-	network = list("SS13","RD")
+	network = list("ss13","rd")
 	},
 /turf/open/floor/plasteel/whitepurple/side,
 /area/medical/genetics)
@@ -32572,8 +32539,7 @@
 /obj/structure/closet/emcloset,
 /obj/machinery/camera{
 	c_tag = "Virology Airlock";
-	dir = 2;
-	network = list("SS13")
+	dir = 2
 	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 5
@@ -32853,7 +32819,7 @@
 /obj/machinery/camera{
 	c_tag = "Science Security Post";
 	dir = 4;
-	network = list("SS13","RD")
+	network = list("ss13","rd")
 	},
 /obj/item/book/manual/wiki/security_space_law,
 /turf/open/floor/plasteel/red/side{
@@ -33825,7 +33791,7 @@
 /obj/machinery/camera{
 	c_tag = "Research Director's Office";
 	dir = 1;
-	network = list("SS13","RD")
+	network = list("ss13","rd")
 	},
 /obj/structure/table/glass,
 /turf/open/floor/plasteel/darkpurple/side,
@@ -33843,7 +33809,7 @@
 /obj/machinery/computer/security/telescreen{
 	desc = "Used for watching the RD's goons and the AI's satellite from the safety of his office.";
 	name = "Research Monitor";
-	network = list("RD","MiniSat");
+	network = list("rd","minisat");
 	pixel_y = -32
 	},
 /obj/structure/table/glass,
@@ -34076,7 +34042,7 @@
 /obj/machinery/camera{
 	c_tag = "Toxins Launch Area";
 	dir = 2;
-	network = list("SS13","RD")
+	network = list("ss13","rd")
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 6
@@ -34363,8 +34329,7 @@
 "bFZ" = (
 /obj/machinery/camera{
 	c_tag = "Aft Primary Hallway Central";
-	dir = 8;
-	network = list("SS13")
+	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plasteel/yellow/corner,
@@ -34436,7 +34401,7 @@
 /obj/machinery/camera{
 	c_tag = "Toxins Storage";
 	dir = 8;
-	network = list("SS13","RD")
+	network = list("ss13","rd")
 	},
 /turf/open/floor/engine,
 /area/science/storage)
@@ -35163,8 +35128,7 @@
 "bHY" = (
 /obj/machinery/camera{
 	c_tag = "Virology";
-	dir = 2;
-	network = list("SS13")
+	dir = 2
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
@@ -35227,8 +35191,7 @@
 /obj/machinery/light,
 /obj/machinery/camera{
 	c_tag = "Medbay Equipment Room";
-	dir = 1;
-	network = list("SS13")
+	dir = 1
 	},
 /turf/open/floor/plasteel/whiteblue/side,
 /area/medical/medbay/central)
@@ -35291,8 +35254,7 @@
 "bIm" = (
 /obj/machinery/camera{
 	c_tag = "Medbay Recovery Room";
-	dir = 8;
-	network = list("SS13")
+	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
@@ -35338,7 +35300,7 @@
 /obj/machinery/camera{
 	c_tag = "Surgery";
 	dir = 2;
-	network = list("SS13","Surgery")
+	network = list("ss13","surgery")
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
@@ -36013,7 +35975,7 @@
 	dir = 2;
 	layer = 4;
 	name = "Test Chamber Telescreen";
-	network = list("Toxins");
+	network = list("toxins");
 	pixel_y = -32
 	},
 /turf/open/floor/plasteel,
@@ -37240,7 +37202,6 @@
 /obj/machinery/camera{
 	c_tag = "Aft Primary Hallway Atmospherics";
 	dir = 2;
-	network = list("SS13");
 	start_active = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -37435,7 +37396,7 @@
 /obj/machinery/camera{
 	c_tag = "Monastery Dock";
 	dir = 1;
-	network = list("SS13","Monastery")
+	network = list("ss13","monastery")
 	},
 /turf/open/floor/plasteel/vault{
 	dir = 4
@@ -37479,7 +37440,7 @@
 /obj/machinery/camera{
 	c_tag = "Monastery Transit";
 	dir = 1;
-	network = list("SS13","Monastery")
+	network = list("ss13","monastery")
 	},
 /turf/open/floor/plating,
 /area/chapel/dock)
@@ -37992,8 +37953,7 @@
 	},
 /obj/machinery/camera{
 	c_tag = "Atmospherics Monitoring";
-	dir = 1;
-	network = list("SS13")
+	dir = 1
 	},
 /obj/machinery/space_heater,
 /turf/open/floor/plasteel/yellow/side,
@@ -38408,7 +38368,7 @@
 /obj/machinery/camera{
 	c_tag = "Monastery Asteroid Dock Port";
 	dir = 4;
-	network = list("SS13","Monastery")
+	network = list("ss13","monastery")
 	},
 /turf/open/floor/plating/asteroid,
 /area/chapel/asteroid/monastery)
@@ -38440,7 +38400,7 @@
 /obj/machinery/camera{
 	c_tag = "Monastery Asteroid Dock Staboard";
 	dir = 8;
-	network = list("SS13","Monastery")
+	network = list("ss13","monastery")
 	},
 /turf/open/floor/plating/asteroid,
 /area/chapel/asteroid/monastery)
@@ -38476,8 +38436,7 @@
 "bQo" = (
 /obj/machinery/camera{
 	c_tag = "Gravity Generator";
-	dir = 2;
-	network = list("SS13")
+	dir = 2
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 4
@@ -38577,8 +38536,7 @@
 	},
 /obj/machinery/camera{
 	c_tag = "Tech Storage";
-	dir = 2;
-	network = list("SS13")
+	dir = 2
 	},
 /obj/item/circuitboard/computer/monastery_shuttle,
 /turf/open/floor/plasteel/darkgreen,
@@ -38866,8 +38824,7 @@
 /obj/structure/closet/radiation,
 /obj/machinery/camera{
 	c_tag = "Gravity Generator Foyer";
-	dir = 2;
-	network = list("SS13")
+	dir = 2
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
@@ -39041,8 +38998,7 @@
 	},
 /obj/machinery/camera{
 	c_tag = "Atmospherics Central";
-	dir = 4;
-	network = list("SS13")
+	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos)
@@ -39346,8 +39302,7 @@
 "bSh" = (
 /obj/machinery/camera{
 	c_tag = "Atmospherics Starboard";
-	dir = 8;
-	network = list("SS13")
+	dir = 8
 	},
 /obj/machinery/atmospherics/components/binary/pump{
 	dir = 8;
@@ -39576,7 +39531,6 @@
 /obj/machinery/camera{
 	c_tag = "Aft Primary Hallway Engineering";
 	dir = 1;
-	network = list("SS13");
 	start_active = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -39999,8 +39953,7 @@
 	},
 /obj/machinery/camera{
 	c_tag = "Atmospherics Entrance";
-	dir = 2;
-	network = list("SS13")
+	dir = 2
 	},
 /turf/open/floor/plasteel/yellow/side{
 	dir = 1
@@ -40062,8 +40015,7 @@
 /obj/structure/reagent_dispensers/fueltank,
 /obj/machinery/camera{
 	c_tag = "Atmospherics Mixing";
-	dir = 2;
-	network = list("SS13")
+	dir = 2
 	},
 /turf/open/floor/plasteel/yellow/side{
 	dir = 1
@@ -40165,8 +40117,7 @@
 /obj/item/book/manual/wiki/security_space_law,
 /obj/machinery/camera{
 	c_tag = "Engineering Security Post";
-	dir = 4;
-	network = list("SS13")
+	dir = 4
 	},
 /obj/machinery/airalarm{
 	dir = 4;
@@ -40391,8 +40342,7 @@
 	},
 /obj/machinery/camera{
 	c_tag = "Chief Engineer's Office";
-	dir = 2;
-	network = list("SS13")
+	dir = 2
 	},
 /turf/open/floor/plasteel/yellow/side{
 	dir = 1
@@ -40459,8 +40409,7 @@
 /obj/machinery/power/smes/engineering,
 /obj/machinery/camera{
 	c_tag = "Engineering Power Storage";
-	dir = 2;
-	network = list("SS13")
+	dir = 2
 	},
 /turf/open/floor/plasteel/darkyellow/side{
 	dir = 1
@@ -41092,7 +41041,7 @@
 /obj/machinery/camera{
 	c_tag = "Monastery Asteroid Primary Entrance";
 	dir = 1;
-	network = list("SS13","Monastery")
+	network = list("ss13","monastery")
 	},
 /turf/open/floor/plating/asteroid,
 /area/chapel/asteroid/monastery)
@@ -41231,7 +41180,7 @@
 	desc = "Used for watching the engine containment area.";
 	dir = 4;
 	name = "Engine Monitor";
-	network = list("Engine");
+	network = list("engine");
 	pixel_x = -32
 	},
 /turf/open/floor/plasteel/darkyellow/side{
@@ -41289,7 +41238,7 @@
 	desc = "Used for watching the engine containment area.";
 	dir = 4;
 	name = "Engine Monitor";
-	network = list("Engine");
+	network = list("engine");
 	pixel_x = -32
 	},
 /turf/open/floor/plasteel/red/side{
@@ -41756,7 +41705,7 @@
 	desc = "Used for the Auxillary Mining Base.";
 	dir = 1;
 	name = "Auxillary Base Monitor";
-	network = list("AuxBase");
+	network = list("auxbase");
 	pixel_y = -28
 	},
 /obj/machinery/computer/shuttle/mining{
@@ -42071,8 +42020,7 @@
 	},
 /obj/machinery/camera{
 	c_tag = "Engineering Port Fore";
-	dir = 2;
-	network = list("SS13")
+	dir = 2
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -42249,8 +42197,7 @@
 	},
 /obj/machinery/camera{
 	c_tag = "Engineering Starboard Fore";
-	dir = 2;
-	network = list("SS13")
+	dir = 2
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -42789,8 +42736,7 @@
 	},
 /obj/machinery/camera{
 	c_tag = "Engineering Central";
-	dir = 1;
-	network = list("SS13")
+	dir = 1
 	},
 /obj/machinery/light,
 /obj/effect/turf_decal/stripes/line,
@@ -42919,14 +42865,13 @@
 	},
 /obj/machinery/camera{
 	c_tag = "Incinerator";
-	dir = 4;
-	network = list("SS13")
+	dir = 4
 	},
 /obj/machinery/computer/security/telescreen{
 	desc = "Used for watching the turbine vent.";
 	dir = 4;
 	name = "turbine vent monitor";
-	network = list("Turbine");
+	network = list("turbine");
 	pixel_x = -29
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
@@ -43017,7 +42962,7 @@
 /obj/machinery/camera{
 	c_tag = "Turbine Chamber";
 	dir = 2;
-	network = list("Turbine")
+	network = list("turbine")
 	},
 /turf/open/floor/engine,
 /area/maintenance/disposal/incinerator)
@@ -43454,7 +43399,7 @@
 /obj/machinery/camera{
 	c_tag = "Engineering Center";
 	dir = 2;
-	network = list("SS13","Engine");
+	network = list("ss13","engine");
 	pixel_x = 23
 	},
 /obj/machinery/light{
@@ -43624,7 +43569,7 @@
 /obj/machinery/camera{
 	c_tag = "Auxillary Mining Base";
 	dir = 1;
-	network = list("SS13","AuxBase")
+	network = list("ss13","auxbase")
 	},
 /turf/open/floor/plating,
 /area/shuttle/auxillary_base)
@@ -43793,7 +43738,7 @@
 /obj/machinery/camera{
 	c_tag = "Chapel Port Access";
 	dir = 2;
-	network = list("SS13","Monastery")
+	network = list("ss13","monastery")
 	},
 /turf/open/floor/plasteel/dark,
 /area/chapel/main/monastery)
@@ -43863,8 +43808,7 @@
 /obj/machinery/field/generator,
 /obj/machinery/camera{
 	c_tag = "Engineering Secure Storage";
-	dir = 4;
-	network = list("SS13")
+	dir = 4
 	},
 /turf/open/floor/plating,
 /area/engine/engineering)
@@ -43902,8 +43846,7 @@
 "cdP" = (
 /obj/machinery/camera{
 	c_tag = "Engineering Port Aft";
-	dir = 1;
-	network = list("SS13")
+	dir = 1
 	},
 /obj/machinery/light,
 /obj/effect/turf_decal/stripes/line,
@@ -43981,8 +43924,7 @@
 "cdY" = (
 /obj/machinery/camera{
 	c_tag = "Engineering Starboard Aft";
-	dir = 1;
-	network = list("SS13")
+	dir = 1
 	},
 /obj/machinery/light,
 /obj/effect/turf_decal/stripes/line,
@@ -44204,7 +44146,7 @@
 /obj/machinery/camera{
 	c_tag = "Chapel Crematorium";
 	dir = 2;
-	network = list("SS13","Monastery")
+	network = list("ss13","monastery")
 	},
 /turf/open/floor/plasteel/dark,
 /area/chapel/office)
@@ -44417,7 +44359,7 @@
 /obj/machinery/camera{
 	c_tag = "Engineering Telecomms Access";
 	dir = 8;
-	network = list("Labor")
+	network = list("tcomm")
 	},
 /obj/machinery/light{
 	dir = 4
@@ -44427,7 +44369,7 @@
 	dir = 8;
 	layer = 4;
 	name = "Telecomms Telescreen";
-	network = list("Telecomms");
+	network = list("tcomm");
 	pixel_x = 30
 	},
 /turf/open/floor/plasteel,
@@ -44561,7 +44503,7 @@
 /obj/machinery/camera{
 	c_tag = "Monastery Asteroid Starboard Aft";
 	dir = 1;
-	network = list("SS13","Monastery")
+	network = list("ss13","monastery")
 	},
 /turf/open/floor/plasteel/asteroid,
 /area/chapel/asteroid/monastery)
@@ -44614,7 +44556,7 @@
 /obj/machinery/camera/emp_proof{
 	c_tag = "Engine Containment Port Fore";
 	dir = 2;
-	network = list("Engine")
+	network = list("engine")
 	},
 /turf/open/floor/plating/airless,
 /area/engine/engineering)
@@ -44636,7 +44578,7 @@
 /obj/machinery/camera/emp_proof{
 	c_tag = "Engine Containment Starboard Fore";
 	dir = 2;
-	network = list("Engine")
+	network = list("engine")
 	},
 /turf/open/floor/plating/airless,
 /area/engine/engineering)
@@ -44700,7 +44642,7 @@
 /obj/machinery/camera{
 	c_tag = "Monastery Garden";
 	dir = 2;
-	network = list("SS13","Monastery")
+	network = list("ss13","monastery")
 	},
 /turf/open/floor/grass,
 /area/hydroponics/garden/monastery)
@@ -44928,7 +44870,7 @@
 /obj/machinery/camera{
 	c_tag = "Monastery Kitchen";
 	dir = 4;
-	network = list("SS13","Monastery")
+	network = list("ss13","monastery")
 	},
 /turf/open/floor/plasteel/hydrofloor,
 /area/chapel/main/monastery)
@@ -45678,7 +45620,7 @@
 	invuln = 1;
 	luminosity = 3;
 	name = "Hardened Bomb-Test Camera";
-	network = list("Toxins");
+	network = list("toxins");
 	use_power = 0
 	},
 /turf/open/floor/plating/asteroid/airless,
@@ -45796,7 +45738,7 @@
 /obj/machinery/camera/emp_proof{
 	c_tag = "Engine Containment Port Aft";
 	dir = 1;
-	network = list("Engine")
+	network = list("engine")
 	},
 /turf/open/floor/plating/airless,
 /area/engine/engineering)
@@ -45804,7 +45746,7 @@
 /obj/machinery/camera/emp_proof{
 	c_tag = "Engine Containment Starboard Aft";
 	dir = 1;
-	network = list("Engine")
+	network = list("engine")
 	},
 /turf/open/floor/plating/airless,
 /area/engine/engineering)
@@ -45964,7 +45906,7 @@
 /obj/machinery/camera{
 	c_tag = "Monastery Library";
 	dir = 4;
-	network = list("SS13","Monastery")
+	network = list("ss13","monastery")
 	},
 /turf/open/floor/plasteel/dark,
 /area/library)
@@ -46066,7 +46008,7 @@
 /obj/machinery/camera{
 	c_tag = "Telecomms External Fore";
 	dir = 1;
-	network = list("SS13, Telecomms");
+	network = list("SS13", "tcomm");
 	start_active = 1
 	},
 /turf/open/space,
@@ -46242,7 +46184,7 @@
 /obj/machinery/camera/motion{
 	c_tag = "Telecomms External Access";
 	dir = 1;
-	network = list("SS13","Telecomms")
+	network = list("ss13","tcomm")
 	},
 /turf/open/floor/plasteel,
 /area/tcommsat/computer)
@@ -46337,7 +46279,7 @@
 /obj/machinery/camera/motion{
 	c_tag = "Telecomms Monitoring";
 	dir = 2;
-	network = list("SS13","Telecomms")
+	network = list("ss13","tcomm")
 	},
 /turf/open/floor/plasteel/yellow/side{
 	dir = 1
@@ -46445,7 +46387,7 @@
 /obj/machinery/camera/motion{
 	c_tag = "Telecomms External Port";
 	dir = 8;
-	network = list("Telecomms")
+	network = list("tcomm")
 	},
 /turf/open/space,
 /area/space/nearstation)
@@ -46507,7 +46449,7 @@
 /obj/machinery/camera/motion{
 	c_tag = "Telecomms External Starboard";
 	dir = 4;
-	network = list("Telecomms")
+	network = list("tcomm")
 	},
 /turf/open/space,
 /area/space/nearstation)
@@ -46700,7 +46642,7 @@
 	invuln = 1;
 	luminosity = 3;
 	name = "Hardened Bomb-Test Camera";
-	network = list("Toxins");
+	network = list("toxins");
 	use_power = 0
 	},
 /turf/open/floor/plating/asteroid/airless,
@@ -46740,7 +46682,7 @@
 /obj/machinery/camera/motion{
 	c_tag = "Telecomms Server Room";
 	dir = 1;
-	network = list("SS13","Telecomms")
+	network = list("ss13","tcomm")
 	},
 /turf/open/floor/plasteel/dark/telecomms,
 /area/tcommsat/server)
@@ -46771,7 +46713,7 @@
 /obj/machinery/camera/motion{
 	c_tag = "Telecomms External Port Aft";
 	dir = 2;
-	network = list("Telecomms")
+	network = list("tcomm")
 	},
 /turf/open/space,
 /area/space/nearstation)
@@ -46780,7 +46722,7 @@
 /obj/machinery/camera/motion{
 	c_tag = "Telecomms External Starboard Aft";
 	dir = 2;
-	network = list("Telecomms")
+	network = list("tcomm")
 	},
 /turf/open/space,
 /area/space/nearstation)
@@ -47245,8 +47187,7 @@
 "cpx" = (
 /obj/machinery/camera{
 	c_tag = "Kitchen";
-	dir = 1;
-	network = list("SS13")
+	dir = 1
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -47764,7 +47705,7 @@
 /obj/machinery/camera{
 	c_tag = "Chapel Port";
 	dir = 4;
-	network = list("SS13","Monastery")
+	network = list("ss13","monastery")
 	},
 /turf/open/floor/plasteel/dark,
 /area/chapel/main/monastery)
@@ -47789,7 +47730,7 @@
 /obj/machinery/camera{
 	c_tag = "Chapel Starboard";
 	dir = 8;
-	network = list("SS13","Monastery")
+	network = list("ss13","monastery")
 	},
 /turf/open/floor/plasteel/dark,
 /area/chapel/main/monastery)
@@ -48015,7 +47956,7 @@
 /obj/machinery/camera{
 	c_tag = "Chapel Office Tunnel";
 	dir = 1;
-	network = list("SS13","Monastery")
+	network = list("ss13","monastery")
 	},
 /turf/open/floor/plasteel/asteroid,
 /area/chapel/office)
@@ -48060,7 +48001,7 @@
 /obj/machinery/camera{
 	c_tag = "Chapel Starboard Access";
 	dir = 2;
-	network = list("SS13","Monastery")
+	network = list("ss13","monastery")
 	},
 /obj/structure/chair/wood/normal,
 /turf/open/floor/plasteel/dark,
@@ -48160,7 +48101,7 @@
 /obj/machinery/camera{
 	c_tag = "Chapel Office";
 	dir = 8;
-	network = list("SS13","Monastery")
+	network = list("ss13","monastery")
 	},
 /turf/open/floor/plasteel/dark,
 /area/chapel/office)
@@ -48211,7 +48152,7 @@
 /obj/machinery/camera{
 	c_tag = "Monastery Cloister Fore";
 	dir = 2;
-	network = list("SS13","Monastery")
+	network = list("ss13","monastery")
 	},
 /turf/open/floor/plasteel/vault{
 	dir = 5
@@ -48410,7 +48351,7 @@
 /obj/machinery/camera{
 	c_tag = "Monastery Cloister Port";
 	dir = 4;
-	network = list("SS13","Monastery")
+	network = list("ss13","monastery")
 	},
 /turf/open/floor/plasteel/dark,
 /area/chapel/main/monastery)
@@ -48456,7 +48397,7 @@
 /obj/machinery/camera{
 	c_tag = "Monastery Dining Room";
 	dir = 8;
-	network = list("SS13","Monastery")
+	network = list("ss13","monastery")
 	},
 /turf/open/floor/plasteel/dark,
 /area/chapel/main/monastery)
@@ -48621,7 +48562,7 @@
 /obj/machinery/camera{
 	c_tag = "Monastery Cloister Starboard";
 	dir = 8;
-	network = list("SS13","Monastery")
+	network = list("ss13","monastery")
 	},
 /turf/open/floor/plasteel/dark,
 /area/chapel/main/monastery)
@@ -48629,7 +48570,7 @@
 /obj/machinery/camera{
 	c_tag = "Monastery Secondary Dock";
 	dir = 8;
-	network = list("SS13","Monastery")
+	network = list("ss13","monastery")
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
@@ -48774,7 +48715,7 @@
 /obj/machinery/camera{
 	c_tag = "Monastery Cloister Aft";
 	dir = 1;
-	network = list("SS13","Monastery")
+	network = list("ss13","monastery")
 	},
 /turf/open/floor/plasteel/vault{
 	dir = 5
@@ -48831,7 +48772,7 @@
 /obj/machinery/camera{
 	c_tag = "Monastery Cemetary";
 	dir = 4;
-	network = list("SS13","Monastery")
+	network = list("ss13","monastery")
 	},
 /turf/open/floor/plasteel/dark,
 /area/chapel/main/monastery)
@@ -49204,7 +49145,7 @@
 /obj/machinery/camera{
 	c_tag = "Monastery Archives Access Tunnel";
 	dir = 4;
-	network = list("SS13","Monastery")
+	network = list("ss13","monastery")
 	},
 /turf/open/floor/plasteel/vault{
 	dir = 4
@@ -49295,7 +49236,7 @@
 /obj/machinery/camera{
 	c_tag = "Monastery Archives Fore";
 	dir = 2;
-	network = list("SS13","Monastery")
+	network = list("ss13","monastery")
 	},
 /turf/open/floor/plasteel/dark,
 /area/library)
@@ -49417,7 +49358,7 @@
 /obj/machinery/camera{
 	c_tag = "Monastery Archives Port";
 	dir = 4;
-	network = list("SS13","Monastery")
+	network = list("ss13","monastery")
 	},
 /turf/open/floor/plasteel/dark,
 /area/library)
@@ -49458,7 +49399,7 @@
 /obj/machinery/camera{
 	c_tag = "Monastery Archives Starboard";
 	dir = 8;
-	network = list("SS13","Monastery")
+	network = list("ss13","monastery")
 	},
 /turf/open/floor/plasteel/dark,
 /area/library)
@@ -49639,7 +49580,7 @@
 /obj/machinery/camera{
 	c_tag = "Monastery Archives Aft";
 	dir = 1;
-	network = list("SS13","Monastery")
+	network = list("ss13","monastery")
 	},
 /turf/open/floor/plasteel/dark,
 /area/library)

--- a/_maps/map_files/generic/CentCom.dmm
+++ b/_maps/map_files/generic/CentCom.dmm
@@ -6277,7 +6277,7 @@
 /obj/machinery/computer/security/telescreen{
 	desc = "Used for watching the RD's goons and the AI's satellite from the safety of his office.";
 	name = "Research Monitor";
-	network = list("RD","Sat");
+	network = list("rd","minisat");
 	pixel_y = 28
 	},
 /turf/open/floor/plasteel/grimy,

--- a/code/game/machinery/camera/camera.dm
+++ b/code/game/machinery/camera/camera.dm
@@ -17,7 +17,7 @@
 	armor = list("melee" = 50, "bullet" = 20, "laser" = 20, "energy" = 20, "bomb" = 0, "bio" = 0, "rad" = 0, "fire" = 90, "acid" = 50)
 	max_integrity = 100
 	integrity_failure = 50
-	var/list/network = list("SS13")
+	var/list/network = list("ss13")
 	var/c_tag = null
 	var/c_tag_order = 999
 	var/status = TRUE
@@ -44,6 +44,9 @@
 
 /obj/machinery/camera/Initialize(mapload, obj/structure/camera_assembly/CA)
 	. = ..()
+	if(LAZYLEN(network))
+		for(var/i in network)
+			i = lowertext(i)
 	if(CA)
 		assembly = CA
 	else

--- a/code/game/machinery/camera/camera.dm
+++ b/code/game/machinery/camera/camera.dm
@@ -44,9 +44,9 @@
 
 /obj/machinery/camera/Initialize(mapload, obj/structure/camera_assembly/CA)
 	. = ..()
-	if(LAZYLEN(network))
-		for(var/i in network)
-			i = lowertext(i)
+	for(var/i in network)
+		network -= i
+		network += lowertext(i)
 	if(CA)
 		assembly = CA
 	else

--- a/code/game/machinery/camera/camera_assembly.dm
+++ b/code/game/machinery/camera/camera_assembly.dm
@@ -99,6 +99,8 @@
 	if(tempnetwork.len < 1)
 		to_chat(user, "<span class='warning'>No network found, please hang up and try your call again!</span>")
 		return
+	for(var/i in tempnetwork)
+		i = lowertext(i)
 	state = 4
 	var/obj/machinery/camera/C = new(loc, src)
 	forceMove(C)

--- a/code/game/machinery/camera/camera_assembly.dm
+++ b/code/game/machinery/camera/camera_assembly.dm
@@ -100,7 +100,8 @@
 		to_chat(user, "<span class='warning'>No network found, please hang up and try your call again!</span>")
 		return
 	for(var/i in tempnetwork)
-		i = lowertext(i)
+		tempnetwork -= i
+		tempnetwork += lowertext(i)
 	state = 4
 	var/obj/machinery/camera/C = new(loc, src)
 	forceMove(C)

--- a/code/game/machinery/computer/camera.dm
+++ b/code/game/machinery/computer/camera.dm
@@ -13,9 +13,9 @@
 
 /obj/machinery/computer/security/Initialize()
 	. = ..()
-	if(LAZYLEN(network))
-		for(var/i in network)
-			i = lowertext(i)
+	for(var/i in network)
+		network -= i
+		network += lowertext(i)
 
 /obj/machinery/computer/security/check_eye(mob/user)
 	if( (stat & (NOPOWER|BROKEN)) || user.incapacitated() || user.eye_blind )

--- a/code/game/machinery/computer/camera.dm
+++ b/code/game/machinery/computer/camera.dm
@@ -5,11 +5,17 @@
 	icon_keyboard = "security_key"
 	circuit = /obj/item/circuitboard/computer/security
 	var/last_pic = 1
-	var/list/network = list("SS13")
+	var/list/network = list("ss13")
 	var/mapping = 0//For the overview file, interesting bit of code.
 	var/list/watchers = list() //who's using the console, associated with the camera they're on.
 
 	light_color = LIGHT_COLOR_RED
+
+/obj/machinery/computer/security/Initialize()
+	. = ..()
+	if(LAZYLEN(network))
+		for(var/i in network)
+			i = lowertext(i)
 
 /obj/machinery/computer/security/check_eye(mob/user)
 	if( (stat & (NOPOWER|BROKEN)) || user.incapacitated() || user.eye_blind )
@@ -185,5 +191,5 @@
 	desc = "Used to access the various cameras on the outpost."
 	icon_screen = "mining"
 	icon_keyboard = "mining_key"
-	network = list("MINE")
+	network = list("mine")
 	circuit = /obj/item/circuitboard/computer/mining

--- a/code/game/machinery/computer/camera_advanced.dm
+++ b/code/game/machinery/computer/camera_advanced.dm
@@ -16,9 +16,9 @@
 
 /obj/machinery/computer/camera_advanced/Initialize()
 	. = ..()
-	if(LAZYLEN(networks))
-		for(var/i in networks)
-			i = lowertext(i)
+	for(var/i in networks)
+		networks -= i
+		networks += lowertext(i)
 	if(lock_override)
 		if(lock_override & CAMERA_LOCK_STATION)
 			z_lock |= SSmapping.levels_by_trait(ZTRAIT_STATION)

--- a/code/game/machinery/computer/camera_advanced.dm
+++ b/code/game/machinery/computer/camera_advanced.dm
@@ -7,7 +7,7 @@
 	var/lock_override = NONE
 	var/mob/camera/aiEye/remote/eyeobj
 	var/mob/living/current_user = null
-	var/list/networks = list("SS13")
+	var/list/networks = list("ss13")
 	var/datum/action/innate/camera_off/off_action = new
 	var/datum/action/innate/camera_jump/jump_action = new
 	var/list/actions = list()
@@ -16,6 +16,9 @@
 
 /obj/machinery/computer/camera_advanced/Initialize()
 	. = ..()
+	if(LAZYLEN(networks))
+		for(var/i in networks)
+			i = lowertext(i)
 	if(lock_override)
 		if(lock_override & CAMERA_LOCK_STATION)
 			z_lock |= SSmapping.levels_by_trait(ZTRAIT_STATION)
@@ -261,7 +264,7 @@
 	name = "ratvarian camera observer"
 	desc = "A console used to snoop on the station's goings-on. A jet of steam occasionally whooshes out from slats on its sides."
 	use_power = FALSE
-	networks = list("SS13", "MiniSat") //:eye:
+	networks = list("ss13", "minisat") //:eye:
 	var/datum/action/innate/servant_warp/warp_action = new
 
 /obj/machinery/computer/camera_advanced/ratvar/Initialize()

--- a/code/game/objects/items/devices/camera_bug.dm
+++ b/code/game/objects/items/devices/camera_bug.dm
@@ -76,7 +76,7 @@
 		for(var/obj/machinery/camera/camera in GLOB.cameranet.cameras)
 			if(camera.stat || !camera.can_use())
 				continue
-			if(length(list("SS13","MINE")&camera.network))
+			if(length(list("ss13","mine")&camera.network))
 				bugged_cameras[camera.c_tag] = camera
 	sortList(bugged_cameras)
 	return bugged_cameras

--- a/code/modules/antagonists/abductor/machinery/camera.dm
+++ b/code/modules/antagonists/abductor/machinery/camera.dm
@@ -1,7 +1,7 @@
 /obj/machinery/computer/camera_advanced/abductor
 	name = "Human Observation Console"
 	var/team_number = 0
-	networks = list("SS13","Abductor")
+	networks = list("ss13", "abductor")
 	var/datum/action/innate/teleport_in/tele_in_action = new
 	var/datum/action/innate/teleport_out/tele_out_action = new
 	var/datum/action/innate/teleport_self/tele_self_action = new

--- a/code/modules/events/camerafailure.dm
+++ b/code/modules/events/camerafailure.dm
@@ -15,7 +15,7 @@
 		var/obj/machinery/camera/C = pick_n_take(cameras)
 		if (!C)
 			break
-		if (!("SS13" in C.network))
+		if (!("ss13" in C.network))
 			continue
 		if(C.status)
 			C.toggle_cam(null, 0)

--- a/code/modules/integrated_electronics/subtypes/output.dm
+++ b/code/modules/integrated_electronics/subtypes/output.dm
@@ -255,7 +255,7 @@
 /obj/item/integrated_circuit/output/video_camera/New()
 	..()
 	camera = new(src)
-	camera.network = list("RD")
+	camera.network = list("rd")
 	on_data_written()
 
 /obj/item/integrated_circuit/output/video_camera/Destroy()

--- a/code/modules/mining/aux_base_camera.dm
+++ b/code/modules/mining/aux_base_camera.dm
@@ -29,7 +29,7 @@
 /obj/machinery/computer/camera_advanced/base_construction
 	name = "base construction console"
 	desc = "An industrial computer integrated with a camera-assisted rapid construction drone."
-	networks = list("SS13")
+	networks = list("ss13")
 	var/obj/item/construction/rcd/internal/RCD //Internal RCD. The computer passes user commands to this in order to avoid massive copypaste.
 	circuit = /obj/item/circuitboard/computer/base_construction
 	off_action = new/datum/action/innate/camera_off/base_construction

--- a/code/modules/mob/living/silicon/ai/ai.dm
+++ b/code/modules/mob/living/silicon/ai/ai.dm
@@ -27,7 +27,7 @@
 	sec_hud = DATA_HUD_SECURITY_BASIC
 	d_hud = DATA_HUD_DIAGNOSTIC_ADVANCED
 	mob_size = MOB_SIZE_LARGE
-	var/list/network = list("SS13")
+	var/list/network = list("ss13")
 	var/obj/machinery/camera/current = null
 	var/list/connected_robots = list()
 	var/aiRestorePowerRoutine = 0
@@ -149,7 +149,7 @@
 	GLOB.shuttle_caller_list += src
 
 	builtInCamera = new (src)
-	builtInCamera.network = list("SS13")
+	builtInCamera.network = list("ss13")
 
 
 /mob/living/silicon/ai/Destroy()
@@ -567,11 +567,13 @@
 	var/mob/living/silicon/ai/U = usr
 
 	for (var/obj/machinery/camera/C in GLOB.cameranet.cameras)
+		var/list/tempnetwork = C.network
+		if(!(is_station_level(C.z) || is_mining_level(C.z) || ("ss13" in tempnetwork)))
+			continue
 		if(!C.can_use())
 			continue
 
-		var/list/tempnetwork = C.network
-		tempnetwork.Remove("CREED", "thunder", "RD", "toxins", "Prison")
+		tempnetwork.Remove("rd", "toxins", "prison")
 		if(tempnetwork.len)
 			for(var/i in C.network)
 				cameralist[i] = i
@@ -591,7 +593,7 @@
 			if(network in C.network)
 				U.eyeobj.setLoc(get_turf(C))
 				break
-	to_chat(src, "<span class='notice'>Switched to [network] camera network.</span>")
+	to_chat(src, "<span class='notice'>Switched to the [capitalize(network)] camera network.</span>")
 //End of code by Mord_Sith
 
 

--- a/code/modules/mob/living/silicon/ai/ai.dm
+++ b/code/modules/mob/living/silicon/ai/ai.dm
@@ -593,7 +593,7 @@
 			if(network in C.network)
 				U.eyeobj.setLoc(get_turf(C))
 				break
-	to_chat(src, "<span class='notice'>Switched to the [capitalize(network)] camera network.</span>")
+	to_chat(src, "<span class='notice'>Switched to the \"[uppertext(network)]\" camera network.</span>")
 //End of code by Mord_Sith
 
 

--- a/code/modules/mob/living/silicon/pai/pai.dm
+++ b/code/modules/mob/living/silicon/pai/pai.dm
@@ -13,7 +13,7 @@
 	layer = BELOW_MOB_LAYER
 	can_be_held = TRUE
 
-	var/network = "SS13"
+	var/network = "ss13"
 	var/obj/machinery/camera/current = null
 
 	var/ram = 100	// Used as currency to purchase different abilities

--- a/code/modules/mob/living/silicon/robot/robot.dm
+++ b/code/modules/mob/living/silicon/robot/robot.dm
@@ -124,7 +124,7 @@
 	if(!scrambledcodes && !builtInCamera)
 		builtInCamera = new (src)
 		builtInCamera.c_tag = real_name
-		builtInCamera.network = list("SS13")
+		builtInCamera.network = list("ss13")
 		builtInCamera.internal_light = FALSE
 		if(wires.is_cut(WIRE_CAMERA))
 			builtInCamera.status = 0

--- a/code/modules/research/xenobiology/xenobio_camera.dm
+++ b/code/modules/research/xenobiology/xenobio_camera.dm
@@ -20,7 +20,7 @@
 /obj/machinery/computer/camera_advanced/xenobio
 	name = "Slime management console"
 	desc = "A computer used for remotely handling slimes."
-	networks = list("SS13")
+	networks = list("ss13")
 	circuit = /obj/item/circuitboard/computer/xenobiology
 	var/datum/action/innate/slime_place/slime_place_action = new
 	var/datum/action/innate/slime_pick_up/slime_up_action = new


### PR DESCRIPTION
Noticed that there were areas of code that were checking for certain camera nets and that they were case sensitive. This presented issues as casing was never really enforced, meaning that these systems would silently fail their checks. This resolves the issue and prevents it going forward by standardizing all camera networks as lowercase. 

Any camera networks assigned through varedits will automatically be lowercased during Init so downstreams (hopefully) won't have to go through and update all their maps for this change as well.

Fixes an exploit where the AI was able to jump to space ruins, away missions, ect at roundstart.

Fixes a number of instances of incorrect camera networks being assigned to cameras on Omega & Pubby.


Fixed incorrect camera network on CENTCOM's telescreen

Cleans up a number of dirty camera network varedits

Fixes #35711
