### PR TITLE
Removes abstract shotgun from Summon Guns list

### DIFF
--- a/code/modules/spells/spell_types/rightandwrong.dm
+++ b/code/modules/spells/spell_types/rightandwrong.dm
@@ -25,7 +25,6 @@ GLOBAL_LIST_INIT(summoned_guns, list(
 	/obj/item/gun/energy/kinetic_accelerator/crossbow/large,
 	/obj/item/gun/energy/e_gun/nuclear,
 	/obj/item/gun/ballistic/automatic/proto,
-	/obj/item/gun/ballistic/automatic/shotgun/bulldog,
 	/obj/item/gun/ballistic/automatic/c20r,
 	/obj/item/gun/ballistic/automatic/l6_saw,
 	/obj/item/gun/ballistic/automatic/m90,

--- a/code/modules/spells/spell_types/rightandwrong.dm
+++ b/code/modules/spells/spell_types/rightandwrong.dm
@@ -39,7 +39,7 @@ GLOBAL_LIST_INIT(summoned_guns, list(
 	/obj/item/gun/energy/plasmacutter/adv,
 	/obj/item/gun/energy/wormhole_projector,
 	/obj/item/gun/ballistic/automatic/wt550,
-	/obj/item/gun/ballistic/automatic/shotgun,
+	/obj/item/gun/ballistic/automatic/shotgun/bulldog,
 	/obj/item/gun/ballistic/revolver/grenadelauncher,
 	/obj/item/gun/ballistic/revolver/golden,
 	/obj/item/gun/ballistic/automatic/sniper_rifle,


### PR DESCRIPTION
Fixes #34962.

Looking at the old summon gun list, the comment says this
typepath was supposed to be a Bulldog.