### PR TITLE
Event Earliest Start change

### DIFF
--- a/code/modules/antagonists/slaughter/slaughterevent.dm
+++ b/code/modules/antagonists/slaughter/slaughterevent.dm
@@ -3,7 +3,7 @@
 	typepath = /datum/round_event/ghost_role/slaughter
 	weight = 1 //Very rare
 	max_occurrences = 1
-	earliest_start = 36000 //1 hour
+	earliest_start = 15000 //30mins
 	min_players = 20
 
 

--- a/code/modules/antagonists/slaughter/slaughterevent.dm
+++ b/code/modules/antagonists/slaughter/slaughterevent.dm
@@ -3,7 +3,7 @@
 	typepath = /datum/round_event/ghost_role/slaughter
 	weight = 1 //Very rare
 	max_occurrences = 1
-	earliest_start = 15000 //30mins
+	earliest_start = 30 MINUTES
 	min_players = 20
 
 

--- a/code/modules/events/abductor.dm
+++ b/code/modules/events/abductor.dm
@@ -3,6 +3,7 @@
 	typepath = /datum/round_event/ghost_role/abductor
 	weight = 10
 	max_occurrences = 1
+	earliest_start = 7500 //15mins
 	min_players = 20
 	gamemode_blacklist = list("nuclear","wizard","revolution")
 
@@ -23,7 +24,7 @@
 	var/datum/team/abductor_team/T = new
 	if(T.team_number > ABDUCTOR_MAX_TEAMS)
 		return MAP_ERROR
-	
+
 	log_game("[scientist.mind.key] (ckey) has been selected as [T.name] abductor scientist.")
 	log_game("[agent.mind.key] (ckey) has been selected as [T.name] abductor agent.")
 

--- a/code/modules/events/abductor.dm
+++ b/code/modules/events/abductor.dm
@@ -3,7 +3,7 @@
 	typepath = /datum/round_event/ghost_role/abductor
 	weight = 10
 	max_occurrences = 1
-	earliest_start = 7500 //15mins
+	earliest_start = 15 MINUTES
 	min_players = 20
 	gamemode_blacklist = list("nuclear","wizard","revolution")
 

--- a/code/modules/events/alien_infestation.dm
+++ b/code/modules/events/alien_infestation.dm
@@ -5,7 +5,7 @@
 
 	min_players = 10
 	max_occurrences = 1
-	earliest_start = 7500 //15mins
+	earliest_start = 15 MINUTES
 
 /datum/round_event/ghost_role/alien_infestation
 	announceWhen	= 400

--- a/code/modules/events/alien_infestation.dm
+++ b/code/modules/events/alien_infestation.dm
@@ -5,6 +5,7 @@
 
 	min_players = 10
 	max_occurrences = 1
+	earliest_start = 7500 //15mins
 
 /datum/round_event/ghost_role/alien_infestation
 	announceWhen	= 400

--- a/code/modules/events/blob.dm
+++ b/code/modules/events/blob.dm
@@ -3,7 +3,7 @@
 	typepath = /datum/round_event/ghost_role/blob
 	weight = 10
 	max_occurrences = 1
-
+	earliest_start = 5000
 	min_players = 20
 
 	gamemode_blacklist = list("blob") //Just in case a blob survives that long

--- a/code/modules/events/blob.dm
+++ b/code/modules/events/blob.dm
@@ -3,7 +3,6 @@
 	typepath = /datum/round_event/ghost_role/blob
 	weight = 10
 	max_occurrences = 1
-	earliest_start = 20 MINUTES
 	min_players = 20
 
 	gamemode_blacklist = list("blob") //Just in case a blob survives that long

--- a/code/modules/events/blob.dm
+++ b/code/modules/events/blob.dm
@@ -3,7 +3,7 @@
 	typepath = /datum/round_event/ghost_role/blob
 	weight = 10
 	max_occurrences = 1
-	earliest_start = 25 MINUTES
+	earliest_start = 20 MINUTES
 	min_players = 20
 
 	gamemode_blacklist = list("blob") //Just in case a blob survives that long

--- a/code/modules/events/blob.dm
+++ b/code/modules/events/blob.dm
@@ -3,7 +3,7 @@
 	typepath = /datum/round_event/ghost_role/blob
 	weight = 10
 	max_occurrences = 1
-	earliest_start = 5000
+	earliest_start = 10 MINUTES
 	min_players = 20
 
 	gamemode_blacklist = list("blob") //Just in case a blob survives that long

--- a/code/modules/events/blob.dm
+++ b/code/modules/events/blob.dm
@@ -3,7 +3,7 @@
 	typepath = /datum/round_event/ghost_role/blob
 	weight = 10
 	max_occurrences = 1
-	earliest_start = 10 MINUTES
+	earliest_start = 25 MINUTES
 	min_players = 20
 
 	gamemode_blacklist = list("blob") //Just in case a blob survives that long

--- a/code/modules/events/brand_intelligence.dm
+++ b/code/modules/events/brand_intelligence.dm
@@ -5,6 +5,7 @@
 
 	min_players = 15
 	max_occurrences = 1
+	earliest_start = 7500 //15mins
 
 /datum/round_event/brand_intelligence
 	announceWhen	= 21

--- a/code/modules/events/brand_intelligence.dm
+++ b/code/modules/events/brand_intelligence.dm
@@ -5,7 +5,7 @@
 
 	min_players = 15
 	max_occurrences = 1
-	earliest_start = 7500 //15mins
+	earliest_start = 15 MINUTES
 
 /datum/round_event/brand_intelligence
 	announceWhen	= 21

--- a/code/modules/events/carp_migration.dm
+++ b/code/modules/events/carp_migration.dm
@@ -3,7 +3,7 @@
 	typepath = /datum/round_event/carp_migration
 	weight = 15
 	min_players = 2
-	earliest_start = 6000
+	earliest_start = 12 MINUTES
 	max_occurrences = 6
 
 /datum/round_event/carp_migration

--- a/code/modules/events/electrical_storm.dm
+++ b/code/modules/events/electrical_storm.dm
@@ -1,7 +1,7 @@
 /datum/round_event_control/electrical_storm
 	name = "Electrical Storm"
 	typepath = /datum/round_event/electrical_storm
-	earliest_start = 6000
+	earliest_start = 12 MINUTES
 	min_players = 5
 	weight = 40
 	alertadmins = 0

--- a/code/modules/events/heart_attack.dm
+++ b/code/modules/events/heart_attack.dm
@@ -3,7 +3,7 @@
 	typepath = /datum/round_event/heart_attack
 	weight = 20
 	max_occurrences = 2
-	earliest_start = 12000
+	earliest_start = 24 MINUTES
 	min_players = 40 // To avoid shafting lowpop
 
 /datum/round_event/heart_attack/start()

--- a/code/modules/events/meteor_wave.dm
+++ b/code/modules/events/meteor_wave.dm
@@ -6,7 +6,7 @@
 	weight = 4
 	min_players = 15
 	max_occurrences = 3
-	earliest_start = 12500 //25mins
+	earliest_start = 25 MINUTES
 
 /datum/round_event/meteor_wave
 	startWhen		= 6

--- a/code/modules/events/meteor_wave.dm
+++ b/code/modules/events/meteor_wave.dm
@@ -6,7 +6,7 @@
 	weight = 4
 	min_players = 15
 	max_occurrences = 3
-	earliest_start = 25 MINUTES
+	earliest_start = 12500 //25mins
 
 /datum/round_event/meteor_wave
 	startWhen		= 6

--- a/code/modules/events/pirates.dm
+++ b/code/modules/events/pirates.dm
@@ -6,7 +6,6 @@
 	weight = 8
 	max_occurrences = 1
 	min_players = 10
-	earliest_start = 20 MINUTES
 	gamemode_blacklist = list("nuclear")
 
 /datum/round_event/pirates

--- a/code/modules/events/pirates.dm
+++ b/code/modules/events/pirates.dm
@@ -6,7 +6,7 @@
 	weight = 8
 	max_occurrences = 1
 	min_players = 10
-	earliest_start = 10000 //20mins
+	earliest_start = 20 MINUTES
 	gamemode_blacklist = list("nuclear")
 
 /datum/round_event/pirates

--- a/code/modules/events/pirates.dm
+++ b/code/modules/events/pirates.dm
@@ -6,7 +6,7 @@
 	weight = 8
 	max_occurrences = 1
 	min_players = 10
-	earliest_start = 30 MINUTES
+	earliest_start = 10000 //20mins
 	gamemode_blacklist = list("nuclear")
 
 /datum/round_event/pirates

--- a/code/modules/events/portal_storm.dm
+++ b/code/modules/events/portal_storm.dm
@@ -3,7 +3,7 @@
 	typepath = /datum/round_event/portal_storm/syndicate_shocktroop
 	weight = 2
 	min_players = 15
-	earliest_start = 18000
+	earliest_start = 15000 //30mins
 
 /datum/round_event/portal_storm/syndicate_shocktroop
 	boss_types = list(/mob/living/simple_animal/hostile/syndicate/melee/space/stormtrooper = 2)

--- a/code/modules/events/portal_storm.dm
+++ b/code/modules/events/portal_storm.dm
@@ -3,7 +3,7 @@
 	typepath = /datum/round_event/portal_storm/syndicate_shocktroop
 	weight = 2
 	min_players = 15
-	earliest_start = 15000 //30mins
+	earliest_start = 30 MINUTES
 
 /datum/round_event/portal_storm/syndicate_shocktroop
 	boss_types = list(/mob/living/simple_animal/hostile/syndicate/melee/space/stormtrooper = 2)

--- a/code/modules/events/shuttle_loan.dm
+++ b/code/modules/events/shuttle_loan.dm
@@ -10,7 +10,7 @@
 	name = "Shuttle Loan"
 	typepath = /datum/round_event/shuttle_loan
 	max_occurrences = 1
-	earliest_start = 4000
+	earliest_start = 7500 //15mins
 
 /datum/round_event/shuttle_loan
 	announceWhen = 1

--- a/code/modules/events/shuttle_loan.dm
+++ b/code/modules/events/shuttle_loan.dm
@@ -10,7 +10,7 @@
 	name = "Shuttle Loan"
 	typepath = /datum/round_event/shuttle_loan
 	max_occurrences = 1
-	earliest_start = 7500 //15mins
+	earliest_start = 8 MINUTES
 
 /datum/round_event/shuttle_loan
 	announceWhen = 1

--- a/code/modules/events/spontaneous_appendicitis.dm
+++ b/code/modules/events/spontaneous_appendicitis.dm
@@ -3,7 +3,7 @@
 	typepath = /datum/round_event/spontaneous_appendicitis
 	weight = 20
 	max_occurrences = 4
-	earliest_start = 6000
+	earliest_start = 12 MINUTES
 	min_players = 5 // To make your chance of getting help a bit higher.
 
 /datum/round_event/spontaneous_appendicitis

--- a/code/modules/events/vent_clog.dm
+++ b/code/modules/events/vent_clog.dm
@@ -3,7 +3,7 @@
 	typepath = /datum/round_event/vent_clog
 	weight = 25
 	max_occurrences = 0
-	earliest_start = 5000
+	earliest_start = 10 MINUTES
 	min_players = 50
 
 /datum/round_event/vent_clog

--- a/code/modules/events/vent_clog.dm
+++ b/code/modules/events/vent_clog.dm
@@ -3,6 +3,7 @@
 	typepath = /datum/round_event/vent_clog
 	weight = 25
 	max_occurrences = 0
+	earliest_start = 5000
 	min_players = 50
 
 /datum/round_event/vent_clog

--- a/code/modules/ninja/ninja_event.dm
+++ b/code/modules/ninja/ninja_event.dm
@@ -13,7 +13,7 @@ Contents:
 	name = "Space Ninja"
 	typepath = /datum/round_event/ghost_role/ninja
 	max_occurrences = 1
-	earliest_start = 15000 // 30mins
+	earliest_start = 30 MINUTES
 	min_players = 15
 
 /datum/round_event/ghost_role/ninja

--- a/code/modules/ninja/ninja_event.dm
+++ b/code/modules/ninja/ninja_event.dm
@@ -13,7 +13,7 @@ Contents:
 	name = "Space Ninja"
 	typepath = /datum/round_event/ghost_role/ninja
 	max_occurrences = 1
-	earliest_start = 30000 // 1 hour
+	earliest_start = 15000 // 30mins
 	min_players = 15
 
 /datum/round_event/ghost_role/ninja


### PR DESCRIPTION
[Changelogs]: # (Your PR should contain a detailed changelog of notable changes, titled and categorized appropriately. This includes, new features, sprites, sounds, balance changes, admin tools, map edits, removals, big refactors, config changes, hosting changes and important fixes. An example changelog has been provided below for you to edit. If you need additional help, read https://github.com/tgstation/tgstation/wiki/Changelogs)

:cl: MetroidLover
tweak: tweaked the earliest start time for a few events
/:cl:

 I made this change due to the fact that rounds have been getting shorter and shorter. This change will allow more events to have any chance of firing before the station dies or players get to bored to want to stay. This will also bring players back into the round quicker and more often.
