### PR TITLE
Github bot now auto-sets "Fix" tag if PR name starts with "fixes"

### DIFF
--- a/tools/WebhookProcessor/github_webhook_processor.php
+++ b/tools/WebhookProcessor/github_webhook_processor.php
@@ -209,11 +209,13 @@ function tag_pr($payload, $opened) {
 
 		if(strpos(strtolower($title), 'refactor') !== FALSE)
 			$tags[] = 'Refactor';
-		
+
 		if(strpos(strtolower($title), 'revert') !== FALSE)
 			$tags[] = 'Revert';
 		if(strpos(strtolower($title), 'removes') !== FALSE)
 			$tags[] = 'Removal';
+		if(strpos(strtolower($title), 'fixes') !== FALSE)
+			$tags[] = 'Fix';
 	}
 
 	$remove = array();


### PR DESCRIPTION
It does that for "refactors", "reverts" and "removes" already, so why not?