### PR TITLE
Fixes a runtime in "reference decoder" circuit

### DIFF
--- a/code/__HELPERS/type2type.dm
+++ b/code/__HELPERS/type2type.dm
@@ -12,7 +12,8 @@
 //Returns an integer given a hex input, supports negative values "-ff"
 //skips preceding invalid characters
 //breaks when hittin invalid characters thereafter
-/proc/hex2num(hex)
+// If safe=TRUE, returns null on incorrect input strings instead of CRASHing
+/proc/hex2num(hex, safe=FALSE)
 	. = 0
 	var/place = 1
 	for(var/i in length(hex) to 1 step -1)
@@ -27,7 +28,10 @@
 			if(45)
 				return . * -1 // -
 			else
-				CRASH("Malformed hex number")
+				if(safe)
+					return null
+				else
+					CRASH("Malformed hex number")
 
 		. += num * place
 		place *= 16
@@ -582,12 +586,16 @@
 		r+= num2hex(c)
 	return r
 
-/proc/hextostr(str)
+// Decodes hex to raw byte string.
+// If safe=TRUE, returns null on incorrect input strings instead of CRASHing
+/proc/hextostr(str, safe=FALSE)
 	if(!istext(str)||!str)
 		return
 	var/r
 	var/c
 	for(var/i = 1 to length(str)/2)
-		c= hex2num(copytext(str,i*2-1,i*2+1))
-		r+= ascii2text(c)
+		c = hex2num(copytext(str,i*2-1,i*2+1), safe)
+		if(isnull(c))
+			return null
+		r += ascii2text(c)
 	return r

--- a/code/modules/integrated_electronics/subtypes/converters.dm
+++ b/code/modules/integrated_electronics/subtypes/converters.dm
@@ -80,7 +80,7 @@
 	pull_data()
 	var/atom/A = get_pin_data(IC_INPUT, 1)
 	if(A && istype(A))
-		result = strtohex(XorEncrypt(REF(A),SScircuit.cipherkey))
+		result = strtohex(XorEncrypt(REF(A), SScircuit.cipherkey))
 
 	set_pin_data(IC_OUTPUT, 1, result)
 	push_data()
@@ -97,8 +97,8 @@
 
 /obj/item/integrated_circuit/converter/refdecode/do_work()
 	pull_data()
-	dec=XorEncrypt(hextostr(get_pin_data(IC_INPUT, 1)),SScircuit.cipherkey)
-	set_pin_data(IC_OUTPUT, 1, WEAKREF(locate( dec )))
+	dec = XorEncrypt(hextostr(get_pin_data(IC_INPUT, 1), TRUE), SScircuit.cipherkey)
+	set_pin_data(IC_OUTPUT, 1, WEAKREF(locate(dec)))
 	push_data()
 	activate_pin(2)
 


### PR DESCRIPTION
"Reference decoder" can accept user-generated strings, but any malformed strings would cause runtime errors. This PR adds two new helpers to fix that.