### PR TITLE
Fixes immersion, fried eggs now no longer requires boiled eggs

### DIFF
--- a/code/modules/food_and_drinks/recipes/tablecraft/recipes_egg.dm
+++ b/code/modules/food_and_drinks/recipes/tablecraft/recipes_egg.dm
@@ -8,7 +8,7 @@
 	reqs = list(
 		/datum/reagent/consumable/sodiumchloride = 1,
 		/datum/reagent/consumable/blackpepper = 1,
-		/obj/item/reagent_containers/food/snacks/boiledegg = 1
+		/obj/item/reagent_containers/food/snacks/egg = 1
 	)
 	result = /obj/item/reagent_containers/food/snacks/friedegg
 	subcategory = CAT_EGG
@@ -16,7 +16,7 @@
 /datum/crafting_recipe/food/omelette
 	name = "omelette"
 	reqs = list(
-		/obj/item/reagent_containers/food/snacks/boiledegg = 2,
+		/obj/item/reagent_containers/food/snacks/egg = 2,
 		/obj/item/reagent_containers/food/snacks/cheesewedge = 2
 	)
 	result = /obj/item/reagent_containers/food/snacks/omelette


### PR DESCRIPTION
EVER TRIED TO MAKE FRIED EGG WITH A BOILED EGG

:cl: Improvedname
fix: Fried eggs don't require boiled eggs anymore and just normal eggs
/:cl:

[why]: # (Please add a short description [two lines down] of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.)
