### PR TITLE
Removes the Extend-o-Hand

### DIFF
--- a/code/game/machinery/computer/arcade.dm
+++ b/code/game/machinery/computer/arcade.dm
@@ -47,7 +47,6 @@
 		/obj/item/toy/windupToolbox								= 2,
 		/obj/item/toy/clockwork_watch							= 2,
 		/obj/item/toy/toy_dagger								= 2,
-		/obj/item/extendohand/acme								= 1,
 		/obj/item/hot_potato/harmless/toy						= 1,
 		/obj/item/card/emagfake									= 1)
 

--- a/code/game/objects/items/weaponry.dm
+++ b/code/game/objects/items/weaponry.dm
@@ -614,26 +614,3 @@
 	if(!user.can_use_guns(src))
 		return FALSE
 	return TRUE
-
-/obj/item/extendohand
-	name = "extendo-hand"
-	desc = "Futuristic tech has allowed these classic spring-boxing toys to essentially act as a fully functional hand-operated hand prosthetic."
-	icon = 'icons/obj/items_and_weapons.dmi'
-	icon_state = "extendohand"
-	item_state = "extendohand"
-	lefthand_file = 'icons/mob/inhands/weapons/melee_lefthand.dmi'
-	righthand_file = 'icons/mob/inhands/weapons/melee_righthand.dmi'
-	force = 0
-	throwforce = 5
-	reach = 2
-
-/obj/item/extendohand/acme
-	name = "\improper ACME Extendo-Hand"
-	desc = "A novelty extendo-hand produced by the ACME corporation. Originally designed to knock out roadrunners."
-
-/obj/item/extendohand/attack(atom/M, mob/living/carbon/human/user)
-	var/dist = get_dist(M, user)
-	if(dist < reach)
-		to_chat(user, "<span class='warning'>[M] is too close to use [src] on.</span>")
-		return
-	M.attack_hand(user)

--- a/code/modules/crafting/recipes.dm
+++ b/code/modules/crafting/recipes.dm
@@ -421,12 +421,6 @@
 	result = /obj/structure/curtain
 	category = CAT_MISC
 
-/datum/crafting_recipe/extendohand
-	name = "Extendo-Hand"
-	reqs = list(/obj/item/bodypart/r_arm/robot = 1, /obj/item/clothing/gloves/boxing = 1)
-	result = /obj/item/extendohand
-	category = CAT_MISC
-
 /datum/crafting_recipe/chemical_payload
 	name = "Chemical Payload (C4)"
 	result = /obj/item/bombcore/chemical


### PR DESCRIPTION
1. attack_hand on 90% of objects was designed with "you're next to the machine" in mind
2. this is shit code, doesnt call ..(), and has long range(ha) balance implications and fucks shit up bigtime
3. doesnt even work properly and bypasses all normal shit for calling punches/disarms/etc.
4. we had huge arguments over changeling tentacles and curator whips disarming people and we allowed this?