### PR TITLE
Fixed mutate not removing its effects when refunded

### DIFF
--- a/code/modules/spells/spell_types/genetic.dm
+++ b/code/modules/spells/spell_types/genetic.dm
@@ -2,6 +2,7 @@
 	name = "Genetic"
 	desc = "This spell inflicts a set of mutations and disabilities upon the target."
 
+	var/list/active_on = list()
 	var/list/traits = list() //disabilities
 	var/list/mutations = list() //mutation strings
 	var/duration = 100 //deciseconds
@@ -24,9 +25,16 @@
 			target.dna.add_mutation(A)
 		for(var/A in traits)
 			target.add_trait(A, GENETICS_SPELL)
+		active_on += target
 		addtimer(CALLBACK(src, .proc/remove, target), duration)
 
+/obj/effect/proc_holder/spell/targeted/genetic/Destroy()
+	. = ..()
+	for(var/V in active_on)
+		remove(V)
+
 /obj/effect/proc_holder/spell/targeted/genetic/proc/remove(mob/living/carbon/target)
+	active_on -= target
 	if(!QDELETED(target))
 		for(var/A in mutations)
 			target.dna.remove_mutation(A)


### PR DESCRIPTION
Fixes #35758 

I would have loved to use /obj/effect/proc_holder/proc/on_lose(), but it is a relic that is not called anywhere.