### PR TITLE
Xenobiology Gold Slime Spawn Change & Code Cleanup

### DIFF
--- a/code/__DEFINES/misc.dm
+++ b/code/__DEFINES/misc.dm
@@ -485,6 +485,7 @@ GLOBAL_LIST_INIT(ghost_others_options, list(GHOST_OTHERS_SIMPLE, GHOST_OTHERS_DE
 #define NO_SPAWN 0
 #define HOSTILE_SPAWN 1
 #define FRIENDLY_SPAWN 2
+#define NEUTRAL_SPAWN 3
 
 //slime core activation type
 #define SLIME_ACTIVATE_MINOR 1

--- a/code/__DEFINES/misc.dm
+++ b/code/__DEFINES/misc.dm
@@ -485,7 +485,7 @@ GLOBAL_LIST_INIT(ghost_others_options, list(GHOST_OTHERS_SIMPLE, GHOST_OTHERS_DE
 #define NO_SPAWN 0
 #define HOSTILE_SPAWN 1
 #define FRIENDLY_SPAWN 2
-#define NEUTRAL_SPAWN 3
+#define NEUTRAL_SPAWN 4
 
 //slime core activation type
 #define SLIME_ACTIVATE_MINOR 1

--- a/code/__HELPERS/mobs.dm
+++ b/code/__HELPERS/mobs.dm
@@ -508,6 +508,7 @@ Proc for attack log creation, because really why not
 		mob_spawn_nicecritters = list()
 		mob_spawn_neutralcritters = list()
 		for(var/T in typesof(/mob/living/simple_animal))
+			var/mob/living/simple_animal/SA = T
 			var/goldcorespawns = initial(SA.gold_core_spawnable)
 			if(goldcorespawns & HOSTILE_SPAWN)
 				mob_spawn_meancritters += T

--- a/code/__HELPERS/mobs.dm
+++ b/code/__HELPERS/mobs.dm
@@ -509,12 +509,14 @@ Proc for attack log creation, because really why not
 		mob_spawn_neutralcritters = list()
 		for(var/T in typesof(/mob/living/simple_animal))
 			var/mob/living/simple_animal/SA = T
-			switch(initial(SA.gold_core_spawnable))
-				if(HOSTILE_SPAWN)
+			var/goldcorespawns = initial(SA.gold_core_spawnable)
+				if(goldcorespawns == NO_SPAWN)
+					continue
+				if(goldcorespawns & HOSTILE_SPAWN)
 					mob_spawn_meancritters += T
-				if(FRIENDLY_SPAWN)
+				if(goldcorespawns & FRIENDLY_SPAWN)
 					mob_spawn_nicecritters += T
-				if(NEUTRAL_SPAWN)
+				if(goldcorespawns & NEUTRAL_SPAWN)
 					mob_spawn_neutralcritters += T
 
 	var/chosen

--- a/code/__HELPERS/mobs.dm
+++ b/code/__HELPERS/mobs.dm
@@ -499,10 +499,14 @@ Proc for attack log creation, because really why not
 
 //Used in chemical_mob_spawn. Generates a random mob based on a given gold_core_spawnable value.
 /proc/create_random_mob(spawn_location, mob_class = HOSTILE_SPAWN)
-	var/static/list/mob_spawn_meancritters = list() // list of possible hostile mobs
-	var/static/list/mob_spawn_nicecritters = list() // and possible friendly mobs
+	var/static/list/mob_spawn_meancritters // list of possible hostile mobs
+	var/static/list/mob_spawn_nicecritters // and possible friendly mobs
+	var/static/list/mob_spawn_neutralcritters // list of possible neutral mobs
 
-	if(mob_spawn_meancritters.len <= 0 || mob_spawn_nicecritters.len <= 0)
+	if(!mob_spawn_meancritters)
+		mob_spawn_meancritters = list()
+		mob_spawn_nicecritters = list()
+		mob_spawn_neutralcritters = list()
 		for(var/T in typesof(/mob/living/simple_animal))
 			var/mob/living/simple_animal/SA = T
 			switch(initial(SA.gold_core_spawnable))
@@ -510,11 +514,16 @@ Proc for attack log creation, because really why not
 					mob_spawn_meancritters += T
 				if(FRIENDLY_SPAWN)
 					mob_spawn_nicecritters += T
+				if(NEUTRAL_SPAWN)
+					mob_spawn_neutralcritters += T
 
 	var/chosen
-	if(mob_class == FRIENDLY_SPAWN)
-		chosen = pick(mob_spawn_nicecritters)
-	else
-		chosen = pick(mob_spawn_meancritters)
+	switch(mob_class)
+		if(HOSTILE_SPAWN)
+			chosen = pick(mob_spawn_meancritters)
+		if(FRIENDLY_SPAWN)
+			chosen = pick(mob_spawn_nicecritters)
+		if(NEUTRAL_SPAWN)
+			chosen = pick(mob_spawn_neutralcritters)
 	var/mob/living/simple_animal/C = new chosen(spawn_location)
 	return C

--- a/code/__HELPERS/mobs.dm
+++ b/code/__HELPERS/mobs.dm
@@ -518,6 +518,37 @@ Proc for attack log creation, because really why not
 					mob_spawn_nicecritters += T
 				if(goldcorespawns & NEUTRAL_SPAWN)
 					mob_spawn_neutralcritters += T
+					
+	if(!mob_spawn_nicecritters)
+		mob_spawn_meancritters = list()
+		mob_spawn_nicecritters = list()
+		mob_spawn_neutralcritters = list()
+		for(var/T in typesof(/mob/living/simple_animal))
+			var/mob/living/simple_animal/SA = T
+			var/goldcorespawns = initial(SA.gold_core_spawnable)
+				if(goldcorespawns == NO_SPAWN)
+					continue
+				if(goldcorespawns & HOSTILE_SPAWN)
+					mob_spawn_meancritters += T
+				if(goldcorespawns & FRIENDLY_SPAWN)
+					mob_spawn_nicecritters += T
+				if(goldcorespawns & NEUTRAL_SPAWN)
+					mob_spawn_neutralcritters += T
+	if(!mob_spawn_neutralcritters)
+		mob_spawn_meancritters = list()
+		mob_spawn_nicecritters = list()
+		mob_spawn_neutralcritters = list()
+		for(var/T in typesof(/mob/living/simple_animal))
+			var/mob/living/simple_animal/SA = T
+			var/goldcorespawns = initial(SA.gold_core_spawnable)
+				if(goldcorespawns == NO_SPAWN)
+					continue
+				if(goldcorespawns & HOSTILE_SPAWN)
+					mob_spawn_meancritters += T
+				if(goldcorespawns & FRIENDLY_SPAWN)
+					mob_spawn_nicecritters += T
+				if(goldcorespawns & NEUTRAL_SPAWN)
+					mob_spawn_neutralcritters += T
 
 	var/chosen
 	switch(mob_class)

--- a/code/__HELPERS/mobs.dm
+++ b/code/__HELPERS/mobs.dm
@@ -508,45 +508,13 @@ Proc for attack log creation, because really why not
 		mob_spawn_nicecritters = list()
 		mob_spawn_neutralcritters = list()
 		for(var/T in typesof(/mob/living/simple_animal))
-			var/mob/living/simple_animal/SA = T
-			switch(initial(SA.gold_core_spawnable))
-				if(HOSTILE_SPAWN)
-					mob_spawn_meancritters += T
-				if(FRIENDLY_SPAWN)
-					mob_spawn_nicecritters += T
-				if(NEUTRAL_SPAWN)
-					mob_spawn_neutralcritters += T
-					
-	if(!mob_spawn_nicecritters)
-		mob_spawn_meancritters = list()
-		mob_spawn_nicecritters = list()
-		mob_spawn_neutralcritters = list()
-		for(var/T in typesof(/mob/living/simple_animal))
-			var/mob/living/simple_animal/SA = T
 			var/goldcorespawns = initial(SA.gold_core_spawnable)
-				if(goldcorespawns == NO_SPAWN)
-					continue
-				if(goldcorespawns & HOSTILE_SPAWN)
-					mob_spawn_meancritters += T
-				if(goldcorespawns & FRIENDLY_SPAWN)
-					mob_spawn_nicecritters += T
-				if(goldcorespawns & NEUTRAL_SPAWN)
-					mob_spawn_neutralcritters += T
-	if(!mob_spawn_neutralcritters)
-		mob_spawn_meancritters = list()
-		mob_spawn_nicecritters = list()
-		mob_spawn_neutralcritters = list()
-		for(var/T in typesof(/mob/living/simple_animal))
-			var/mob/living/simple_animal/SA = T
-			var/goldcorespawns = initial(SA.gold_core_spawnable)
-				if(goldcorespawns == NO_SPAWN)
-					continue
-				if(goldcorespawns & HOSTILE_SPAWN)
-					mob_spawn_meancritters += T
-				if(goldcorespawns & FRIENDLY_SPAWN)
-					mob_spawn_nicecritters += T
-				if(goldcorespawns & NEUTRAL_SPAWN)
-					mob_spawn_neutralcritters += T
+			if(goldcorespawns & HOSTILE_SPAWN)
+				mob_spawn_meancritters += T
+			if(goldcorespawns & FRIENDLY_SPAWN)
+				mob_spawn_nicecritters += T
+			if(goldcorespawns & NEUTRAL_SPAWN)
+				mob_spawn_neutralcritters += T
 
 	var/chosen
 	switch(mob_class)

--- a/code/__HELPERS/mobs.dm
+++ b/code/__HELPERS/mobs.dm
@@ -509,14 +509,12 @@ Proc for attack log creation, because really why not
 		mob_spawn_neutralcritters = list()
 		for(var/T in typesof(/mob/living/simple_animal))
 			var/mob/living/simple_animal/SA = T
-			var/goldcorespawns = initial(SA.gold_core_spawnable)
-				if(goldcorespawns == NO_SPAWN)
-					continue
-				if(goldcorespawns & HOSTILE_SPAWN)
+			switch(initial(SA.gold_core_spawnable))
+				if(HOSTILE_SPAWN)
 					mob_spawn_meancritters += T
-				if(goldcorespawns & FRIENDLY_SPAWN)
+				if(FRIENDLY_SPAWN)
 					mob_spawn_nicecritters += T
-				if(goldcorespawns & NEUTRAL_SPAWN)
+				if(NEUTRAL_SPAWN)
 					mob_spawn_neutralcritters += T
 					
 	if(!mob_spawn_nicecritters)

--- a/code/modules/reagents/chemistry/recipes/slime_extracts.dm
+++ b/code/modules/reagents/chemistry/recipes/slime_extracts.dm
@@ -116,7 +116,7 @@
 
 /datum/chemical_reaction/slime/slimemobspawn/proc/summon_mobs(datum/reagents/holder, turf/T)
 	T.visible_message("<span class='danger'>The slime extract begins to vibrate violently!</span>")
-	addtimer(CALLBACK(src, .proc/chemical_mob_spawn, holder, 5, "Gold Slime", HOSTILE_SPAWN), 50)
+	addtimer(CALLBACK(src, .proc/chemical_mob_spawn, holder, 1, "Gold Slime", HOSTILE_SPAWN), 50)
 
 /datum/chemical_reaction/slime/slimemobspawn/lesser
 	name = "Slime Crit Lesser"
@@ -125,7 +125,7 @@
 
 /datum/chemical_reaction/slime/slimemobspawn/lesser/summon_mobs(datum/reagents/holder, turf/T)
 	T.visible_message("<span class='danger'>The slime extract begins to vibrate violently!</span>")
-	addtimer(CALLBACK(src, .proc/chemical_mob_spawn, holder, 3, "Lesser Gold Slime", HOSTILE_SPAWN, "neutral"), 50)
+	addtimer(CALLBACK(src, .proc/chemical_mob_spawn, holder, 1, "Lesser Gold Slime", HOSTILE_SPAWN, "neutral"), 50)
 
 /datum/chemical_reaction/slime/slimemobspawn/friendly
 	name = "Slime Crit Friendly"

--- a/code/modules/reagents/chemistry/recipes/slime_extracts.dm
+++ b/code/modules/reagents/chemistry/recipes/slime_extracts.dm
@@ -116,7 +116,7 @@
 
 /datum/chemical_reaction/slime/slimemobspawn/proc/summon_mobs(datum/reagents/holder, turf/T)
 	T.visible_message("<span class='danger'>The slime extract begins to vibrate violently!</span>")
-	addtimer(CALLBACK(src, .proc/chemical_mob_spawn, holder, 1, "Gold Slime", HOSTILE_SPAWN), 50)
+	addtimer(CALLBACK(src, .proc/chemical_mob_spawn, holder, rand(1,3), "Gold Slime", HOSTILE_SPAWN), 50)
 
 /datum/chemical_reaction/slime/slimemobspawn/lesser
 	name = "Slime Crit Lesser"
@@ -124,8 +124,8 @@
 	required_reagents = list("blood" = 1)
 
 /datum/chemical_reaction/slime/slimemobspawn/lesser/summon_mobs(datum/reagents/holder, turf/T)
-	T.visible_message("<span class='danger'>The slime extract begins to vibrate violently!</span>")
-	addtimer(CALLBACK(src, .proc/chemical_mob_spawn, holder, 1, "Lesser Gold Slime", HOSTILE_SPAWN, "neutral"), 50)
+	T.visible_message("<span class='danger'>The slime extract begins to vibrate!</span>")
+	addtimer(CALLBACK(src, .proc/chemical_mob_spawn, holder, rand(1,3), "Lesser Gold Slime", HOSTILE_SPAWN, "neutral"), 50)
 
 /datum/chemical_reaction/slime/slimemobspawn/friendly
 	name = "Slime Crit Friendly"
@@ -134,7 +134,7 @@
 
 /datum/chemical_reaction/slime/slimemobspawn/friendly/summon_mobs(datum/reagents/holder, turf/T)
 	T.visible_message("<span class='danger'>The slime extract begins to vibrate adorably!</span>")
-	addtimer(CALLBACK(src, .proc/chemical_mob_spawn, holder, 1, "Friendly Gold Slime", FRIENDLY_SPAWN, "neutral"), 50)
+	addtimer(CALLBACK(src, .proc/chemical_mob_spawn, holder, rand(1,3), "Friendly Gold Slime", FRIENDLY_SPAWN, "neutral"), 50)
 
 //Silver
 /datum/chemical_reaction/slime/slimebork


### PR DESCRIPTION
 Gold slime spawn variables no long double the spawn lists each time the proc is run, and code in general cleaned up a bit. Added a new category to gold slime spawns (NEUTRAL_SPAWN). List is currently empty, but will be filled in a future change. All gold slime reactions now randomly spawn 1-3 mobs. (Previously, water spawned 1 mob, blood spawned 3, and plasma spawned 5)
Credit goes to Cruix for helping with coding.

:cl: Xenobio Gold Slime Spawn Balance & Optimization
add: NEUTRAL_SPAWN list for future changes.
balance: All gold slime reactions now produce 1-3 mobs.
code: Optimized code for less RAM usage.
/:cl:

Rebalances gold slime spawn rates to be more manageable for both antagonist and non-antagonists. Friendly critters (Cats, crabs, corgis, etc.) now spawn more abundantly, and neutral and hostile spawns (mimics, trees, space carp, etc.) spawn at a reduced rate. Assuming xenobiology's slime extractor has been upgraded to T4, there is now a minimum of 4 mobs per slime, and a maximum of 12 per slime. This does not change the in any way the number of slimes produced by xenobiology, only the number of mobs spawned per core. Those breeding gold slimes will still end up with more cores than they can use. 
