### PR TITLE
Fixes multiserver mining formula

### DIFF
--- a/code/controllers/subsystem/research.dm
+++ b/code/controllers/subsystem/research.dm
@@ -29,8 +29,6 @@ SUBSYSTEM_DEF(research)
 	//[88nodes * 5000points/node] / [1.5hr * 90min/hr * 60s/min]
 	//Around 450000 points max???
 
-	var/bomb_research_point_scaling = 1800
-
 /datum/controller/subsystem/research/Initialize()
 	initialize_all_techweb_designs()
 	initialize_all_techweb_nodes()

--- a/code/modules/research/server.dm
+++ b/code/modules/research/server.dm
@@ -52,7 +52,7 @@
 
 /obj/machinery/rnd/server/proc/mine()
 	. = base_mining_income
-	var/penalty = max((get_env_temp() - temp_tolerance_low), 0) / temp_penalty_coefficient
+	var/penalty = max((get_env_temp() - temp_tolerance_high), 0) * temp_penalty_coefficient
 	. = max(. - penalty, 0)
 
 /obj/machinery/rnd/server/proc/get_env_temp()


### PR DESCRIPTION
:cl:
fix: fixed multiserver mining formula
/:cl:

_Hey hey hey_

This doesn't change anything about the coefficients, it's still sqrt(100 / amt) * amt_per_server and amt_per_server is still 2 diminished by half a point per degree, but it now works correctly according to the comments.
Also removes bomb_research_point_scaling which does... nothing, as usual.