### PR TITLE
Deletes a redundant double proc definition in paper bins

### DIFF
--- a/code/modules/paperwork/paperbin.dm
+++ b/code/modules/paperwork/paperbin.dm
@@ -26,11 +26,6 @@
 		bin_pen = P
 		update_icon()
 
-/obj/item/paper_bin/fire_act(exposed_temperature, exposed_volume)
-	if(!total_paper)
-		return
-	..()
-
 /obj/item/paper_bin/Destroy()
 	if(papers)
 		for(var/i in papers)


### PR DESCRIPTION
:cl:
fix: Fixed paper bins not catching fire properly
/:cl: