### PR TITLE
Adds used variants of the oneuse spellbooks and guardian creators for quick access by admins

### DIFF
--- a/code/game/gamemodes/wizard/spellbook.dm
+++ b/code/game/gamemodes/wizard/spellbook.dm
@@ -717,7 +717,7 @@
 /obj/item/spellbook/oneuse
 	var/spell = /obj/effect/proc_holder/spell/targeted/projectile/magic_missile //just a placeholder to avoid runtimes if someone spawned the generic
 	var/spellname = "sandbox"
-	var/used = 0
+	var/used = FALSE
 	name = "spellbook of "
 	uses = 1
 	desc = "This template spellbook was never meant for the eyes of man..."
@@ -765,6 +765,9 @@
 	explosion(user.loc, -1, 0, 2, 3, 0, flame_range = 2)
 	qdel(src)
 
+/obj/item/spellbook/oneuse/fireball/used
+	used = TRUE
+
 /obj/item/spellbook/oneuse/smoke
 	spell = /obj/effect/proc_holder/spell/targeted/smoke
 	spellname = "smoke"
@@ -782,6 +785,9 @@
 		if(user.nutrition <= 0)
 			user.nutrition = 0
 
+/obj/item/spellbook/oneuse/smoke/used
+	used = TRUE
+
 
 /obj/item/spellbook/oneuse/blind
 	spell = /obj/effect/proc_holder/spell/targeted/trigger/blind
@@ -793,6 +799,9 @@
 	..()
 	to_chat(user,"<span class='warning'>You go blind!</span>")
 	user.blind_eyes(10)
+
+/obj/item/spellbook/oneuse/blind/used
+	used = TRUE
 
 /obj/item/spellbook/oneuse/mindswap
 	spell = /obj/effect/proc_holder/spell/targeted/mind_transfer
@@ -826,6 +835,9 @@
 	to_chat(user,"<span class='warning'>Suddenly you're staring at [src] again... where are you, who are you?!</span>")
 	stored_swap = null
 
+/obj/item/spellbook/oneuse/mindswap/used
+	used = TRUE
+
 /obj/item/spellbook/oneuse/forcewall
 	spell = /obj/effect/proc_holder/spell/targeted/forcewall
 	spellname = "forcewall"
@@ -838,6 +850,9 @@
 	user.Stun(40, ignore_canstun = TRUE)
 	user.petrify(30)
 
+/obj/item/spellbook/oneuse/forcewall/used
+	used = TRUE
+
 /obj/item/spellbook/oneuse/knock
 	spell = /obj/effect/proc_holder/spell/aoe_turf/knock
 	spellname = "knock"
@@ -848,6 +863,9 @@
 	..()
 	to_chat(user,"<span class='warning'>You're knocked down!</span>")
 	user.Knockdown(40)
+
+/obj/item/spellbook/oneuse/knock/used
+	used = TRUE
 
 /obj/item/spellbook/oneuse/barnyard
 	spell = /obj/effect/proc_holder/spell/targeted/barnyardcurse
@@ -869,6 +887,9 @@
 	else
 		to_chat(user,"<span class='notice'>I say thee neigh</span>") //It still lives here
 
+/obj/item/spellbook/oneuse/barnyard/used
+	used = TRUE
+
 /obj/item/spellbook/oneuse/charge
 	spell = /obj/effect/proc_holder/spell/targeted/charge
 	spellname = "charging"
@@ -880,6 +901,9 @@
 	to_chat(user,"<span class='warning'>[src] suddenly feels very warm!</span>")
 	empulse(src, 1, 1)
 
+/obj/item/spellbook/oneuse/charge/used
+	used = TRUE
+
 /obj/item/spellbook/oneuse/summonitem
 	spell = /obj/effect/proc_holder/spell/targeted/summonitem
 	spellname = "instant summons"
@@ -890,6 +914,9 @@
 	..()
 	to_chat(user,"<span class='warning'>[src] suddenly vanishes!</span>")
 	qdel(src)
+
+/obj/item/spellbook/oneuse/summonitem/used
+	used = TRUE
 
 /obj/item/spellbook/oneuse/random
 	icon_state = "random_book"

--- a/code/modules/mob/living/simple_animal/guardian/guardian.dm
+++ b/code/modules/mob/living/simple_animal/guardian/guardian.dm
@@ -581,6 +581,9 @@ GLOBAL_LIST_EMPTY(parasites) //all currently existing/living guardians
 	possible_guardians = list("Assassin", "Chaos", "Charger", "Dextrous", "Explosive", "Lightning", "Protector", "Ranged", "Standard")
 	allowmultiple = TRUE
 
+/obj/item/guardiancreator/used
+	used = TRUE
+
 /obj/item/guardiancreator/tech
 	name = "holoparasite injector"
 	desc = "It contains an alien nanoswarm of unknown origin. Though capable of near sorcerous feats via use of hardlight holograms and nanomachines, it requires an organic host as a home base and source of fuel."
@@ -592,6 +595,9 @@ GLOBAL_LIST_EMPTY(parasites) //all currently existing/living guardians
 	used_message = "<span class='holoparasite'>The injector has already been used.</span>"
 	failure_message = "<span class='holoparasite bold'>...ERROR. BOOT SEQUENCE ABORTED. AI FAILED TO INTIALIZE. PLEASE CONTACT SUPPORT OR TRY AGAIN LATER.</span>"
 	ling_failure = "<span class='holoparasite bold'>The holoparasites recoil in horror. They want nothing to do with a creature like you.</span>"
+
+/obj/item/guardiancreator/tech/used
+	used = TRUE
 
 /obj/item/guardiancreator/tech/choose/traitor
 	possible_guardians = list("Assassin", "Chaos", "Charger", "Explosive", "Lightning", "Protector", "Ranged", "Standard", "Support")


### PR DESCRIPTION
Just some stuff

also if somebody cares enough they can use this subtype for smuggler satchels kek

:cl: Improvedname
add: Used variants of the oneuse spellbooks
/:cl:

[why]: # (Please add a short description [two lines down] of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.) I dont have to open a whole variable menu to spawn a used book
