### PR TITLE
Fixes ghost role spawners still showing up in the spawner menu even if they're deleted

### DIFF
--- a/code/modules/awaymissions/corpse.dm
+++ b/code/modules/awaymissions/corpse.dm
@@ -54,6 +54,8 @@
 	GLOB.poi_list -= src
 	var/list/spawners = GLOB.mob_spawners[name]
 	LAZYREMOVE(spawners, src)
+	if(!LAZYLEN(spawners))
+		LAZYREMOVE(GLOB.mob_spawners,name)
 	return ..()
 
 /obj/effect/mob_spawn/proc/special(mob/M)

--- a/code/modules/ruins/lavaland_ruin_code.dm
+++ b/code/modules/ruins/lavaland_ruin_code.dm
@@ -130,6 +130,8 @@
 	. = ..()
 	if(prob(90)) //only has a 10% chance of existing, otherwise it'll just be a NPC syndie.
 		new /mob/living/simple_animal/hostile/syndicate/ranged(get_turf(src))
+		GLOB.poi_list -= src
+		LAZYREMOVE(GLOB.mob_spawners[name], src)
 		return INITIALIZE_HINT_QDEL
 
 /datum/outfit/lavaland_syndicate/comms

--- a/code/modules/ruins/lavaland_ruin_code.dm
+++ b/code/modules/ruins/lavaland_ruin_code.dm
@@ -130,8 +130,6 @@
 	. = ..()
 	if(prob(90)) //only has a 10% chance of existing, otherwise it'll just be a NPC syndie.
 		new /mob/living/simple_animal/hostile/syndicate/ranged(get_turf(src))
-		GLOB.poi_list -= src
-		LAZYREMOVE(GLOB.mob_spawners[name], src)
 		return INITIALIZE_HINT_QDEL
 
 /datum/outfit/lavaland_syndicate/comms


### PR DESCRIPTION
:cl: 
fix: fixed ghost spawners showing up in the spawner menu when you can't use them
/:cl:
