### PR TITLE
Nuclear Emergency now ends if the operatives die

### DIFF
--- a/code/game/gamemodes/nuclear/nuclear.dm
+++ b/code/game/gamemodes/nuclear/nuclear.dm
@@ -7,6 +7,7 @@
 	recommended_enemies = 5
 	antag_flag = ROLE_OPERATIVE
 	enemy_minimum_age = 14
+	round_ends_with_antag_death = 1
 
 	announce_span = "danger"
 	announce_text = "Syndicate forces are approaching the station in an attempt to destroy it!\n\


### PR DESCRIPTION
See title.

:cl:
tweak: The round will now end immediately if all nuclear operatives die during nuke ops.
/:cl:

:man_shrugging: It just makes sense, they can't be cloned unless for some reason you scan them in a autocloner, and no one else can nuke the station at that point anyway. Plus even if the OPS are immediately decimated people will almost always call the shuttle and leave anyway so...