### PR TITLE
Clock cult now ends immediately if all clock cultists die

### DIFF
--- a/code/game/gamemodes/clock_cult/clock_cult.dm
+++ b/code/game/gamemodes/clock_cult/clock_cult.dm
@@ -130,6 +130,7 @@ Credit where due:
 	required_enemies = 4
 	recommended_enemies = 4
 	enemy_minimum_age = 14
+	round_ends_with_antag_death = 1
 	protected_jobs = list("AI", "Cyborg", "Security Officer", "Warden", "Detective", "Head of Security", "Captain") //Silicons can eventually be converted
 	restricted_jobs = list("Chaplain", "Captain")
 	announce_span = "brass"

--- a/code/game/gamemodes/clock_cult/clock_cult.dm
+++ b/code/game/gamemodes/clock_cult/clock_cult.dm
@@ -130,7 +130,7 @@ Credit where due:
 	required_enemies = 4
 	recommended_enemies = 4
 	enemy_minimum_age = 14
-	round_ends_with_antag_death = 1
+	round_ends_with_antag_death = TRUE
 	protected_jobs = list("AI", "Cyborg", "Security Officer", "Warden", "Detective", "Head of Security", "Captain") //Silicons can eventually be converted
 	restricted_jobs = list("Chaplain", "Captain")
 	announce_span = "brass"


### PR DESCRIPTION
:cl:
tweak: The round will now end immediately if all clock cultists die.
/:cl:


Clock cult is already a round-interrupting thing. This prevents something like the cultists dying 5 minutes in, and then 30 minutes later suddenly the ark activates and abruptly ends the round even though everyone decimates it.