### PR TITLE
Adds 20% Iron production to Steel Caps

### DIFF
--- a/code/modules/hydroponics/grown/towercap.dm
+++ b/code/modules/hydroponics/grown/towercap.dm
@@ -26,6 +26,7 @@
 	product = /obj/item/grown/log/steel
 	mutatelist = list()
 	rarity = 20
+	reagents_add = list("iron" = 0.2)
 
 
 


### PR DESCRIPTION
Because it's ridiculous that an Iron Rod-producing plant does not produce Iron by itself as a chemical, so....okay, let's be honest. Botany really needed a way to make EMP pulses against things like a Malf AI, rogue Borgs or a Nuke ops Marauder. There's already a lot of things you can make in botany, and it was really lacking on EMP making capabilities. It's infuriating that something as basic as Iron is not produced by any plants, and a "steel cap" mutation is the perfect excuse for a plant to have it.
If a 100 potency Electrical Activity potato battery can have as much charge as a bluespace power cell (40MJ) and you can make atropine rollies or ephedrine gaia then why the fuck not be able to do EMP's like a chemist with a grenade?

**Botanical notes:**
Tested on a private server with Lemons, producing 27 Uranium and 21 Iron on 100 Potency with Densified Chemicals, resulting on an EMP pulse with size (1,3). Potency below 90 to 78 create EMP's of size (1,2).