### PR TITLE
Remove poisoned apple

### DIFF
--- a/code/modules/hydroponics/grown/apple.dm
+++ b/code/modules/hydroponics/grown/apple.dm
@@ -27,17 +27,6 @@
 	juice_results = list("applejuice" = 0)
 	tastes = list("apple" = 1)
 
-// Posioned Apple
-/obj/item/seeds/apple/poisoned
-	product = /obj/item/reagent_containers/food/snacks/grown/apple/poisoned
-	mutatelist = list()
-	reagents_add = list("zombiepowder" = 0.5, "vitamin" = 0.04, "nutriment" = 0.1)
-	rarity = 50 // Source of cyanide, and hard (almost impossible) to obtain normally.
-
-/obj/item/reagent_containers/food/snacks/grown/apple/poisoned
-	seed = /obj/item/seeds/apple/poisoned
-	foodtype = FRUIT | TOXIC
-
 // Gold Apple
 /obj/item/seeds/apple/gold
 	name = "pack of golden apple seeds"


### PR DESCRIPTION
This thing is unused and unusable in its current state. Completely worthless to keep around, admins can VV it if they need it.

:cl: Naksu
code: removed unused poisoned apple variant
/:cl: