### PR TITLE
Golden apples mutate into poison apples, which have a new chem

### DIFF
--- a/code/modules/hydroponics/grown/apple.dm
+++ b/code/modules/hydroponics/grown/apple.dm
@@ -31,7 +31,7 @@
 /obj/item/seeds/apple/poisoned
 	product = /obj/item/reagent_containers/food/snacks/grown/apple/poisoned
 	mutatelist = list()
-	reagents_add = list("zombiepowder" = 0.5, "vitamin" = 0.04, "nutriment" = 0.1)
+	reagents_add = list("cyanide" = 0.5, "vitamin" = 0.04, "nutriment" = 0.1)
 	rarity = 50 // Source of cyanide, and hard (almost impossible) to obtain normally.
 
 /obj/item/reagent_containers/food/snacks/grown/apple/poisoned

--- a/code/modules/hydroponics/grown/apple.dm
+++ b/code/modules/hydroponics/grown/apple.dm
@@ -48,7 +48,7 @@
 	product = /obj/item/reagent_containers/food/snacks/grown/apple/gold
 	maturation = 10
 	production = 10
-	mutatelist = list()
+	mutatelist = list(/obj/item/seeds/apple/poisoned) //too much greed can poison you or something I dunno
 	reagents_add = list("gold" = 0.2, "vitamin" = 0.04, "nutriment" = 0.1)
 	rarity = 40 // Alchemy!
 

--- a/code/modules/hydroponics/grown/apple.dm
+++ b/code/modules/hydroponics/grown/apple.dm
@@ -31,7 +31,7 @@
 /obj/item/seeds/apple/poisoned
 	product = /obj/item/reagent_containers/food/snacks/grown/apple/poisoned
 	mutatelist = list()
-	reagents_add = list("cyanide" = 0.5, "vitamin" = 0.04, "nutriment" = 0.1)
+	reagents_add = list("kindleium" = 0.5, "vitamin" = 0.04, "nutriment" = 0.1)
 	rarity = 50 // Source of cyanide, and hard (almost impossible) to obtain normally.
 
 /obj/item/reagent_containers/food/snacks/grown/apple/poisoned

--- a/code/modules/reagents/chemistry/reagents/toxin_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/toxin_reagents.dm
@@ -908,3 +908,32 @@
 	color = "#F0F8FF" // rgb: 240, 248, 255
 	toxpwr = 0
 	taste_description = "stillness"
+
+/datum/reagent/kindleium //works like if you get hit by kindle
+	name = "Kindleium"
+	id = "kindleium"
+	description = "Supposedly refined from the remains of a fallen god."
+	color = "#FFFF00" // rgb: 255, 255, 0
+	taste_description = "spinning gears"
+	toxpwr = 0 //NO HURT, ONLY STUN
+
+/datum/reagent/toxin/kindleium/on_mob_add(mob/living/M)
+	kindle(M)
+
+/datum/reagent/toxin/kindleium/on_mob_life(mob/living/M)
+	kindle(M)
+
+/datum/reagent/toxin/kindleium/on_mob_delete(mob/living/M)
+	if(M.has_status_effect(STATUS_EFFECT_KINDLE))
+		M.remove_status_effect(STATUS_EFFECT_KINDLE)
+
+/datum/reagent/toxin/kindleium/kindle(M)
+	if(!(M.has_status_effect(STATUS_EFFECT_KINDLE)) && prob(5))
+	playsound(M, 'sound/magic/fireball.ogg', 50, TRUE, frequency = 1.25)
+	M.visible_message("<span class='warning'>[M]'s eyes blaze with brilliant light!</span>", \
+	"<span class='userdanger'>Your vision suddenly screams with white-hot light!</span>")
+	M.Knockdown(15)
+	M.apply_status_effect(STATUS_EFFECT_KINDLE)
+	M.flash_act(1, 1)
+	if(iscultist(M))
+		M.adjustFireLoss(15)


### PR DESCRIPTION
alternative to #35820
closes #35820

Having a unused item in the game is bad, but I thought I'd make a alternative PR that addresses the other possible solution (remove vs improve).

I have not played botany at all in a very long time this might be insanely overpowered, or not. No clue.

🆑 
tweak: Nanotrasen has... uh... I don't know, whatever. Golden apples can now mutate into poison apples.
IC changelogs are nice but I got 2 hours of sleep so fuck that.
/🆑 

Kindleium is a new reagent. On entering your system (and with a 5% chance every tick you _do not_ have the status effect) it effectively mirrors the effects of getting hit by a kindle bolt. Notable differences are that null rods don't nullify it, and it can effect clock cultists.

I'd turn it into a universal proc instead of copypasting but I don't know where to _put_ it.