### PR TITLE
Renames various reagent IDs to be more descriptive

### DIFF
--- a/code/game/objects/items/RSF.dm
+++ b/code/game/objects/items/RSF.dm
@@ -178,7 +178,7 @@ RSF
 	to_chat(user, "Fabricating Cookie..")
 	var/obj/item/reagent_containers/food/snacks/cookie/S = new /obj/item/reagent_containers/food/snacks/cookie(T)
 	if(toxin)
-		S.reagents.add_reagent("chloralhydrate2", 10)
+		S.reagents.add_reagent("chloralhydratedelayed", 10)
 	if (iscyborg(user))
 		var/mob/living/silicon/robot/R = user
 		R.cell.charge -= 100

--- a/code/modules/antagonists/changeling/powers/adrenaline.dm
+++ b/code/modules/antagonists/changeling/powers/adrenaline.dm
@@ -14,8 +14,8 @@
 	user.SetUnconscious(0)
 	user.SetStun(0)
 	user.SetKnockdown(0)
-	user.reagents.add_reagent("changelingAdrenaline", 10)
-	user.reagents.add_reagent("changelingHaste", 2) //For a really quick burst of speed
+	user.reagents.add_reagent("changelingadrenaline", 10)
+	user.reagents.add_reagent("changelinghaste", 2) //For a really quick burst of speed
 	user.adjustStaminaLoss(-75)
 	return TRUE
 

--- a/code/modules/antagonists/changeling/powers/adrenaline.dm
+++ b/code/modules/antagonists/changeling/powers/adrenaline.dm
@@ -15,7 +15,7 @@
 	user.SetStun(0)
 	user.SetKnockdown(0)
 	user.reagents.add_reagent("changelingAdrenaline", 10)
-	user.reagents.add_reagent("changelingAdrenaline2", 2) //For a really quick burst of speed
+	user.reagents.add_reagent("changelingHaste", 2) //For a really quick burst of speed
 	user.adjustStaminaLoss(-75)
 	return TRUE
 

--- a/code/modules/paperwork/pen.dm
+++ b/code/modules/paperwork/pen.dm
@@ -167,7 +167,7 @@
 /obj/item/pen/sleepy/Initialize()
 	. = ..()
 	create_reagents(45)
-	reagents.add_reagent("chloralhydrate2", 20)
+	reagents.add_reagent("chloralhydratedelayed", 20)
 	reagents.add_reagent("mutetoxin", 15)
 	reagents.add_reagent("tirizene", 10)
 

--- a/code/modules/reagents/chemistry/reagents/medicine_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/medicine_reagents.dm
@@ -1142,9 +1142,9 @@
 
 //used for changeling's adrenaline power
 /datum/reagent/medicine/changelingAdrenaline
-	name = "Adrenaline"
+	name = "Changeling Adrenaline"
 	id = "changelingAdrenaline"
-	description = "Reduces stun times. Also deals toxin damage at high amounts."
+	description = "Reduces the duration of unconciousness, knockdown and stuns. Restores stamina, but deals toxin damage when overdosed."
 	color = "#C8A5DC"
 	overdose_threshold = 30
 
@@ -1161,26 +1161,26 @@
 	. = 1
 	..()
 
-/datum/reagent/medicine/changelingAdrenaline2
-	name = "Adrenaline"
-	id = "changelingAdrenaline2"
-	description = "Drastically increases movement speed."
+/datum/reagent/medicine/changelingHaste
+	name = "Changeling Haste"
+	id = "changelingHaste"
+	description = "Drastically increases movement speed, but deals toxin damage."
 	color = "#C8A5DC"
 	metabolization_rate = 1
 
-/datum/reagent/medicine/changelingAdrenaline2/on_mob_add(mob/M)
+/datum/reagent/medicine/changelingHaste/on_mob_add(mob/M)
 	..()
 	if(isliving(M))
 		var/mob/living/L = M
 		L.add_trait(TRAIT_GOTTAGOREALLYFAST, id)
 
-/datum/reagent/medicine/changelingAdrenaline2/on_mob_delete(mob/M)
+/datum/reagent/medicine/changelingHaste/on_mob_delete(mob/M)
 	if(isliving(M))
 		var/mob/living/L = M
 		L.remove_trait(TRAIT_GOTTAGOREALLYFAST, id)
 	..()
 
-/datum/reagent/medicine/changelingAdrenaline2/on_mob_life(mob/living/M as mob)
+/datum/reagent/medicine/changelingHaste/on_mob_life(mob/living/M as mob)
 	M.adjustToxLoss(2, 0)
 	. = 1
 	..()

--- a/code/modules/reagents/chemistry/reagents/medicine_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/medicine_reagents.dm
@@ -1141,14 +1141,14 @@
 	. = 1
 
 //used for changeling's adrenaline power
-/datum/reagent/medicine/changelingAdrenaline
+/datum/reagent/medicine/changelingadrenaline
 	name = "Changeling Adrenaline"
-	id = "changelingAdrenaline"
+	id = "changelingadrenaline"
 	description = "Reduces the duration of unconciousness, knockdown and stuns. Restores stamina, but deals toxin damage when overdosed."
 	color = "#C8A5DC"
 	overdose_threshold = 30
 
-/datum/reagent/medicine/changelingAdrenaline/on_mob_life(mob/living/M as mob)
+/datum/reagent/medicine/changelingadrenaline/on_mob_life(mob/living/M as mob)
 	M.AdjustUnconscious(-20, 0)
 	M.AdjustStun(-20, 0)
 	M.AdjustKnockdown(-20, 0)
@@ -1156,31 +1156,31 @@
 	. = 1
 	..()
 
-/datum/reagent/medicine/changelingAdrenaline/overdose_process(mob/living/M as mob)
+/datum/reagent/medicine/changelingadrenaline/overdose_process(mob/living/M as mob)
 	M.adjustToxLoss(1, 0)
 	. = 1
 	..()
 
-/datum/reagent/medicine/changelingHaste
+/datum/reagent/medicine/changelinghaste
 	name = "Changeling Haste"
-	id = "changelingHaste"
+	id = "changelinghaste"
 	description = "Drastically increases movement speed, but deals toxin damage."
 	color = "#C8A5DC"
 	metabolization_rate = 1
 
-/datum/reagent/medicine/changelingHaste/on_mob_add(mob/M)
+/datum/reagent/medicine/changelinghaste/on_mob_add(mob/M)
 	..()
 	if(isliving(M))
 		var/mob/living/L = M
 		L.add_trait(TRAIT_GOTTAGOREALLYFAST, id)
 
-/datum/reagent/medicine/changelingHaste/on_mob_delete(mob/M)
+/datum/reagent/medicine/changelinghaste/on_mob_delete(mob/M)
 	if(isliving(M))
 		var/mob/living/L = M
 		L.remove_trait(TRAIT_GOTTAGOREALLYFAST, id)
 	..()
 
-/datum/reagent/medicine/changelingHaste/on_mob_life(mob/living/M as mob)
+/datum/reagent/medicine/changelinghaste/on_mob_life(mob/living/M as mob)
 	M.adjustToxLoss(2, 0)
 	. = 1
 	..()

--- a/code/modules/reagents/chemistry/reagents/toxin_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/toxin_reagents.dm
@@ -292,9 +292,9 @@
 	..()
 
 /datum/reagent/toxin/chloralhydratedelayed
-	name = "Chloral Hydrate"
-	id = "chloralhydrate2"
-	description = "A powerful sedative that induces confusion and drowsiness before putting its target to sleep."
+	name = "Delayed Chloral Hydrate"
+	id = "chloralhydratedelayed"
+	description = "A slower-acting, non-lethal variant of Chloral Hydrate."
 	reagent_state = SOLID
 	color = "#000067" // rgb: 0, 0, 103
 	toxpwr = 0
@@ -309,9 +309,9 @@
 			M.Sleeping(40, 0)
 	..()
 
-/datum/reagent/toxin/beer2	//disguised as normal beer for use by emagged brobots
+/datum/reagent/toxin/fakebeer	//disguised as normal beer for use by emagged brobots
 	name = "Beer"
-	id = "beer2"
+	id = "fakebeer"
 	description = "A specially-engineered sedative disguised as beer. It induces instant sleep in its target."
 	color = "#664300" // rgb: 102, 67, 0
 	metabolization_rate = 1.5 * REAGENTS_METABOLISM
@@ -320,7 +320,7 @@
 	glass_name = "glass of beer"
 	glass_desc = "A freezing pint of beer."
 
-/datum/reagent/toxin/beer2/on_mob_life(mob/living/M)
+/datum/reagent/toxin/fakebeer/on_mob_life(mob/living/M)
 	switch(current_cycle)
 		if(1 to 50)
 			M.Sleeping(40, 0)

--- a/code/modules/reagents/chemistry/reagents/toxin_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/toxin_reagents.dm
@@ -291,10 +291,10 @@
 			. = 1
 	..()
 
-/datum/reagent/toxin/chloralhydratedelayed
-	name = "Delayed Chloral Hydrate"
+/datum/reagent/toxin/chloralhydratedelayed //sedates half as quickly and does not cause toxloss. same name/desc so it doesn't give away sleepypens
+	name = "Chloral Hydrate"
 	id = "chloralhydratedelayed"
-	description = "A slower-acting, non-lethal variant of Chloral Hydrate."
+	description = "A powerful sedative that induces confusion and drowsiness before putting its target to sleep."
 	reagent_state = SOLID
 	color = "#000067" // rgb: 0, 0, 103
 	toxpwr = 0

--- a/code/modules/reagents/reagent_containers/borghydro.dm
+++ b/code/modules/reagents/reagent_containers/borghydro.dm
@@ -220,7 +220,7 @@ Borg Shaker
 	recharge_time = 3
 	accepts_reagent_upgrades = FALSE
 
-	reagent_ids = list("beer2")
+	reagent_ids = list("fakebeer")
 
 /obj/item/reagent_containers/borghypo/peace
 	name = "Peace Hypospray"


### PR DESCRIPTION
:cl: Denton
code: Renamed the IDs of various reagents to be more descriptive.
spellcheck: Fixed the descriptions of changeling adrenaling reagents.
/:cl:

I changed the reagent IDs of delayed chloral hydrate, KO beer and ling adrenals to be more descriptive. The outward appearance of KO beer and delayed chloral aren't affected by this.

- beer2 -> fakebeer
- changelingAdrenaline2 -> changelingHaste
- chloralhydrate2 -> chloralhydratedelayed