### PR TITLE
Revert the notify command not being admin only

### DIFF
--- a/code/modules/admin/chat_commands.dm
+++ b/code/modules/admin/chat_commands.dm
@@ -75,6 +75,7 @@ GLOBAL_LIST(round_end_notifiees)
 /datum/server_tools_command/notify
 	name = "notify"
 	help_text = "Pings the invoker when the round ends"
+	admin_only = TRUE
 
 /datum/server_tools_command/notify/Run(sender, params)
 	if(!SSticker.IsRoundInProgress() && SSticker.HasRoundStarted())


### PR DESCRIPTION
Reverts #35501

I need to implement an api for sending PMs. right now this works, but the responses only come into #adminbus so it's useless

@Shadowlight213 