### PR TITLE
Reverts intercept_user_move change for flightsuits

### DIFF
--- a/code/game/objects/objs.dm
+++ b/code/game/objects/objs.dm
@@ -202,6 +202,9 @@
 /obj/proc/check_uplink_validity()
 	return 1
 
+/obj/proc/intercept_user_move(dir, mob, newLoc, oldLoc)
+	return
+
 /obj/vv_get_dropdown()
 	. = ..()
 	.["Delete all of type"] = "?_src_=vars;[HrefToken()];delall=[REF(src)]"

--- a/code/modules/clothing/spacesuits/flightsuit.dm
+++ b/code/modules/clothing/spacesuits/flightsuit.dm
@@ -253,22 +253,26 @@
 		afterForceMove = FALSE
 	if(flight)
 		ion_trail.generate_effect()
-		var/momentum_increment = momentum_gain
-		if(boost)
-			momentum_increment = boost_power
-		if(brake)
-			momentum_increment = 0
-		if(!gravity && !pressure)
-			momentum_increment -= 10
-		switch(dir)
-			if(NORTH)
-				adjust_momentum(0, momentum_increment)
-			if(SOUTH)
-				adjust_momentum(0, -momentum_increment)
-			if(EAST)
-				adjust_momentum(momentum_increment, 0)
-			if(WEST)
-				adjust_momentum(-momentum_increment, 0)
+
+/obj/item/device/flightpack/intercept_user_move(dir, mob, newLoc, oldLoc)
+	if(!flight)
+		return
+	var/momentum_increment = momentum_gain
+	if(boost)
+		momentum_increment = boost_power
+	if(brake)
+		momentum_increment = 0
+	if(!gravity && !pressure)
+		momentum_increment -= 10
+	switch(dir)
+		if(NORTH)
+			adjust_momentum(0, momentum_increment)
+		if(SOUTH)
+			adjust_momentum(0, -momentum_increment)
+		if(EAST)
+			adjust_momentum(momentum_increment, 0)
+		if(WEST)
+			adjust_momentum(-momentum_increment, 0)
 
 //Make the wearer lose some momentum.
 /obj/item/device/flightpack/proc/momentum_decay()

--- a/code/modules/mob/mob_movement.dm
+++ b/code/modules/mob/mob_movement.dm
@@ -111,6 +111,9 @@
 		if(mob.throwing)
 			mob.throwing.finalize(FALSE)
 
+	for(var/obj/O in mob.user_movement_hooks)
+		O.intercept_user_move(direct, mob, n, oldloc)
+
 	var/atom/movable/P = mob.pulling
 	if(P && !ismob(P) && P.density)
 		mob.dir = turn(mob.dir, 180)


### PR DESCRIPTION
@kevinz000 thinks flightsuits shouldn't become uncontrollable bullets that gain momentum forever from having moved rather than from the client attempting to move.

:cl: Naksu
fix: Flightsuits should be controllable again
/:cl:
