### PR TITLE
Removes duplicate first death log

### DIFF
--- a/code/controllers/subsystem/blackbox.dm
+++ b/code/controllers/subsystem/blackbox.dm
@@ -261,8 +261,6 @@ Versioning
 		return
 	if(!L || !L.key || !L.mind)
 		return
-	var/brute = L.getBruteLoss()
-	var/fire = L.getFireLoss()
 	var/area/placeofdeath = get_area(L)
 	var/sqlname = sanitizeSQL(L.real_name)
 	var/sqlkey = sanitizeSQL(L.ckey)
@@ -271,8 +269,8 @@ Versioning
 	var/sqlpod = sanitizeSQL(placeofdeath.name)
 	var/laname = sanitizeSQL(L.lastattacker)
 	var/lakey = sanitizeSQL(L.lastattackerckey)
-	var/sqlbrute = sanitizeSQL(brute)
-	var/sqlfire = sanitizeSQL(fire)
+	var/sqlbrute = sanitizeSQL(L.getBruteLoss())
+	var/sqlfire = sanitizeSQL(L.getFireLoss())
 	var/sqlbrain = sanitizeSQL(L.getBrainLoss())
 	var/sqloxy = sanitizeSQL(L.getOxyLoss())
 	var/sqltox = sanitizeSQL(L.getToxLoss())
@@ -284,13 +282,13 @@ Versioning
 	var/last_words = sanitizeSQL(L.last_words)
 	var/suicide = sanitizeSQL(L.suiciding)
 	var/map = sanitizeSQL(SSmapping.config.map_name)
-	if(!suicide && !first_death.len) //some of the things in here are not SQL-sanitized because they're only stored locally, and sanitized versions do not appear to show correctly
+	if(!suicide && !first_death.len)
 		first_death["name"] = L.name
 		first_death["role"] = null
 		if(L.mind.assigned_role)
 			first_death["role"] = L.mind.assigned_role
 		first_death["area"] = "[get_area_name(L, TRUE)] [COORD(L)]"
-		first_death["damage"] = "<font color='#FF5555'>[brute]</font>/<font color='orange'>[fire]</font>/<font color='lightgreen'>[L.toxloss]</font>/<font color='lightblue'>[L.oxyloss]</font>/<font color='pink'>[L.cloneloss]</font>"
+		first_death["damage"] = "<font color='#FF5555'>[sqlbrute]</font>/<font color='orange'>[sqlfire]</font>/<font color='lightgreen'>[sqltox]</font>/<font color='lightblue'>[sqloxy]</font>/<font color='pink'>[sqlclone]</font>"
 		first_death["last_words"] = L.last_words
 	var/datum/DBQuery/query_report_death = SSdbcore.NewQuery("INSERT INTO [format_table_name("death")] (pod, x_coord, y_coord, z_coord, mapname, server_ip, server_port, round_id, tod, job, special, name, byondkey, laname, lakey, bruteloss, fireloss, brainloss, oxyloss, toxloss, cloneloss, staminaloss, last_words, suicide) VALUES ('[sqlpod]', '[x_coord]', '[y_coord]', '[z_coord]', '[map]', INET_ATON(IF('[world.internet_address]' LIKE '', '0', '[world.internet_address]')), '[world.port]', [GLOB.round_id], '[SQLtime()]', '[sqljob]', '[sqlspecial]', '[sqlname]', '[sqlkey]', '[laname]', '[lakey]', [sqlbrute], [sqlfire], [sqlbrain], [sqloxy], [sqltox], [sqlclone], [sqlstamina], '[last_words]', [suicide])")
 	query_report_death.Execute()

--- a/code/controllers/subsystem/ticker.dm
+++ b/code/controllers/subsystem/ticker.dm
@@ -32,8 +32,6 @@ SUBSYSTEM_DEF(ticker)
 	SCRIPTURE_SCRIPT = FALSE, \
 	SCRIPTURE_APPLICATION = FALSE) //list of clockcult scripture states for announcements
 
-	var/list/first_death = list()			//contains info about the first player to die; ckey, name, location, and last words
-
 	var/delay_end = 0						//if set true, the round will not restart on it's own
 	var/admin_delay_notice = ""				//a message to display to anyone who tries to restart the world after a delay
 	var/ready_for_reboot = FALSE			//all roundend preparation done with, all that's left is reboot

--- a/code/modules/mob/living/death.dm
+++ b/code/modules/mob/living/death.dm
@@ -74,16 +74,6 @@
 
 	if (client)
 		client.move_delay = initial(client.move_delay)
-		if(!suiciding && !SSticker.first_death.len) //suicides don't clog up the list, only BRUTAL deaths here
-			var/list/L = list()
-			L["name"] = name
-			L["role"] = null
-			if(mind.assigned_role)
-				L["role"] = mind.assigned_role
-			L["area"] = "[get_area_name(src, TRUE)] [COORD(src)]"
-			L["damage"] = "<font color='#FF5555'>[bruteloss]</font>/<font color='orange'>[fireloss]</font>/<font color='lightgreen'>[toxloss]</font>/<font color='lightblue'>[oxyloss]</font>/<font color='pink'>[cloneloss]</font>"
-			L["last_words"] = last_words
-			SSticker.first_death = L
 
 	for(var/s in ownedSoullinks)
 		var/datum/soullink/S = s


### PR DESCRIPTION
Function was moved to SSblackbox, but not actually removed from SSticker.
Changed damage values back to their existing sanitized ones; `sanitizeSQL()` only returns while DB is connected; Xhuis was testing without one.