### PR TITLE
Fixes jugg spell object damage

### DIFF
--- a/code/modules/spells/spell_types/construct_spells.dm
+++ b/code/modules/spells/spell_types/construct_spells.dm
@@ -307,6 +307,6 @@
 	new /obj/effect/temp_visual/cult/sac(T)
 	for(var/obj/O in range(src,1))
 		if(O.density && !istype(O, /obj/structure/destructible/cult))
-			O.take_damage(90, BRUTE, "gauntlet echo", 0)
+			O.take_damage(90, BRUTE, "melee", 0)
 			new /obj/effect/temp_visual/cult/turf/floor
 	..()


### PR DESCRIPTION
Things that need to be done later:

Changing all damage_flag uses into defines. (or maybe make damages typed)
Change damage_flag name to something that  does not imply it's a flag.