### PR TITLE
Removes liver unfailure and makes alcohol do the killing thing sometimes

### DIFF
--- a/code/modules/mob/living/carbon/life.dm
+++ b/code/modules/mob/living/carbon/life.dm
@@ -408,7 +408,7 @@
 	if((!dna && !liver) || (NOLIVER in dna.species.species_traits))
 		return
 	if(liver)
-		if(liver.damage >= 100)
+		if(liver.damage >= liver.maxHealth)
 			liver.failing = TRUE
 			liver_failure()
 	else

--- a/code/modules/mob/living/carbon/life.dm
+++ b/code/modules/mob/living/carbon/life.dm
@@ -407,12 +407,9 @@
 	var/obj/item/organ/liver/liver = getorganslot(ORGAN_SLOT_LIVER)
 	if((!dna && !liver) || (NOLIVER in dna.species.species_traits))
 		return
-	if(liver)
-		if(liver.damage >= 100)
-			liver.failing = TRUE
-			liver_failure()
-		else
-			liver.failing = FALSE
+	if(liver && liver.damage >= 100)
+		liver.failing = TRUE
+		liver_failure()
 	else
 		liver_failure()
 

--- a/code/modules/mob/living/carbon/life.dm
+++ b/code/modules/mob/living/carbon/life.dm
@@ -407,9 +407,10 @@
 	var/obj/item/organ/liver/liver = getorganslot(ORGAN_SLOT_LIVER)
 	if((!dna && !liver) || (NOLIVER in dna.species.species_traits))
 		return
-	if(liver && liver.damage >= 100)
-		liver.failing = TRUE
-		liver_failure()
+	if(liver)
+		if(liver.damage >= 100)
+			liver.failing = TRUE
+			liver_failure()
 	else
 		liver_failure()
 

--- a/code/modules/reagents/chemistry/reagents/alcohol_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/alcohol_reagents.dm
@@ -39,7 +39,7 @@ All effects don't start immediately, but rather get worse over time; the rate is
 		if(H.drunkenness < volume * boozepwr * ALCOHOL_THRESHOLD_MODIFIER)
 			H.drunkenness = max((H.drunkenness + (sqrt(volume) * boozepwr * ALCOHOL_RATE)), 0) //Volume, power, and server alcohol rate effect how quickly one gets drunk
 			var/obj/item/organ/liver/L = H.getorganslot(ORGAN_SLOT_LIVER)
-			H.applyLiverDamage((max(sqrt(volume) * boozepwr * L.alcohol_tolerance, 0))/10)
+			H.applyLiverDamage((max(sqrt(volume) * boozepwr * L.alcohol_tolerance, 0)))
 	return ..() || .
 
 /datum/reagent/consumable/ethanol/reaction_obj(obj/O, reac_volume)

--- a/code/modules/reagents/chemistry/reagents/alcohol_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/alcohol_reagents.dm
@@ -39,7 +39,7 @@ All effects don't start immediately, but rather get worse over time; the rate is
 		if(H.drunkenness < volume * boozepwr * ALCOHOL_THRESHOLD_MODIFIER)
 			H.drunkenness = max((H.drunkenness + (sqrt(volume) * boozepwr * ALCOHOL_RATE)), 0) //Volume, power, and server alcohol rate effect how quickly one gets drunk
 			var/obj/item/organ/liver/L = H.getorganslot(ORGAN_SLOT_LIVER)
-			H.applyLiverDamage((max(sqrt(volume) * boozepwr * L.alcohol_tolerance, 0))/5)
+			H.applyLiverDamage((max(sqrt(volume) * boozepwr * L.alcohol_tolerance, 0))/2)
 	return ..() || .
 
 /datum/reagent/consumable/ethanol/reaction_obj(obj/O, reac_volume)

--- a/code/modules/reagents/chemistry/reagents/alcohol_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/alcohol_reagents.dm
@@ -39,7 +39,7 @@ All effects don't start immediately, but rather get worse over time; the rate is
 		if(H.drunkenness < volume * boozepwr * ALCOHOL_THRESHOLD_MODIFIER)
 			H.drunkenness = max((H.drunkenness + (sqrt(volume) * boozepwr * ALCOHOL_RATE)), 0) //Volume, power, and server alcohol rate effect how quickly one gets drunk
 			var/obj/item/organ/liver/L = H.getorganslot(ORGAN_SLOT_LIVER)
-			H.applyLiverDamage((max(sqrt(volume) * boozepwr * L.alcohol_tolerance, 0))/2)
+			H.applyLiverDamage((max(sqrt(volume) * boozepwr * L.alcohol_tolerance, 0))/4)
 	return ..() || .
 
 /datum/reagent/consumable/ethanol/reaction_obj(obj/O, reac_volume)

--- a/code/modules/reagents/chemistry/reagents/alcohol_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/alcohol_reagents.dm
@@ -39,7 +39,7 @@ All effects don't start immediately, but rather get worse over time; the rate is
 		if(H.drunkenness < volume * boozepwr * ALCOHOL_THRESHOLD_MODIFIER)
 			H.drunkenness = max((H.drunkenness + (sqrt(volume) * boozepwr * ALCOHOL_RATE)), 0) //Volume, power, and server alcohol rate effect how quickly one gets drunk
 			var/obj/item/organ/liver/L = H.getorganslot(ORGAN_SLOT_LIVER)
-			H.applyLiverDamage((max(sqrt(volume) * boozepwr * L.alcohol_tolerance, 0)))
+			H.applyLiverDamage((max(sqrt(volume) * boozepwr * L.alcohol_tolerance, 0))/5)
 	return ..() || .
 
 /datum/reagent/consumable/ethanol/reaction_obj(obj/O, reac_volume)

--- a/code/modules/surgery/organs/liver.dm
+++ b/code/modules/surgery/organs/liver.dm
@@ -20,13 +20,11 @@
 /obj/item/organ/liver/on_life()
 	var/mob/living/carbon/C = owner
 
-	//slowly heal liver damage
-	damage = max(0, damage - 0.1)
-	if(damage > maxHealth)//cap liver damage
-		damage = maxHealth
-
 	if(istype(C))
 		if(!failing)//can't process reagents with a failing liver
+			//slowly heal liver damage
+			damage = max(0, damage - 0.1)
+
 			if(filterToxins)
 				//handle liver toxin filtration
 				var/toxamount
@@ -46,6 +44,9 @@
 
 			if(damage > 10 && prob(damage/3))//the higher the damage the higher the probability
 				to_chat(C, "<span class='notice'>You feel [pick("nauseous", "dull pain in your lower body", "confused")].</span>")
+
+	if(damage > maxHealth)//cap liver damage
+		damage = maxHealth
 
 /obj/item/organ/liver/prepare_eat()
 	var/obj/S = ..()


### PR DESCRIPTION
:cl:
balance: livers don't unfail automatically every second life cycle you have to get a new one or get some corazone stat
balance: increased liver damage from alcohol significantly because apparently your liver regenerates faster than you can chug unless you drink 100 liters of bacchus blessing
fix: fixed cyber livers thinking they should fail at half durability
/:cl:

if you take too much liver damage your liver turns into a dieer haha i'm so funny also this will probably kill people from alcohol poisoning
i bet i missed something because i'm touching mobcode two hours after waking up

okay over the span of the last few hours I've learnt many things about being drunk in this game and apparently liver damage and drunkenness is based on how much alcohol is in you at the time. You can likely still safely drink shots of vodka but if you down the whole bottle (100u) you're setting yourself up for coma. Most high volume alcohol decays at regular metabolism speeds (2.5 cycles or ~5 seconds per unit) and isn't that dangerous, the obvious exception is bacchus blessing, which is really bad for your liver even at 30u.

Ideally this change will mean things like antihol and corazone will become more prominent and liver replacements might actually be beneficial especially if hearty punch's boozepwr gets upped to 90.

feedback welcome