### PR TITLE
Changes event earliest_start to use time helpers

### DIFF
--- a/code/modules/antagonists/revenant/revenant_spawn_event.dm
+++ b/code/modules/antagonists/revenant/revenant_spawn_event.dm
@@ -5,7 +5,6 @@
 	typepath = /datum/round_event/ghost_role/revenant
 	weight = 7
 	max_occurrences = 1
-	earliest_start = 12000 //Meant to mix things up early-game.
 	min_players = 5
 
 

--- a/code/modules/antagonists/slaughter/slaughterevent.dm
+++ b/code/modules/antagonists/slaughter/slaughterevent.dm
@@ -3,7 +3,7 @@
 	typepath = /datum/round_event/ghost_role/slaughter
 	weight = 1 //Very rare
 	max_occurrences = 1
-	earliest_start = 36000 //1 hour
+	earliest_start = 1 HOURS
 	min_players = 20
 
 

--- a/code/modules/antagonists/swarmer/swarmer_event.dm
+++ b/code/modules/antagonists/swarmer/swarmer_event.dm
@@ -3,7 +3,7 @@
 	typepath = /datum/round_event/spawn_swarmer
 	weight = 7
 	max_occurrences = 1 //Only once okay fam
-	earliest_start = 18000 //30 minutes
+	earliest_start = 30 MINUTES
 	min_players = 15
 
 

--- a/code/modules/events/_event.dm
+++ b/code/modules/events/_event.dm
@@ -1,26 +1,26 @@
 //this datum is used by the events controller to dictate how it selects events
 /datum/round_event_control
-	var/name					//The human-readable name of the event
-	var/typepath				//The typepath of the event datum /datum/round_event
+	var/name						//The human-readable name of the event
+	var/typepath					//The typepath of the event datum /datum/round_event
 
-	var/weight = 10				//The weight this event has in the random-selection process.
-								//Higher weights are more likely to be picked.
-								//10 is the default weight. 20 is twice more likely; 5 is half as likely as this default.
-								//0 here does NOT disable the event, it just makes it extremely unlikely
+	var/weight = 10					//The weight this event has in the random-selection process.
+									//Higher weights are more likely to be picked.
+									//10 is the default weight. 20 is twice more likely; 5 is half as likely as this default.
+									//0 here does NOT disable the event, it just makes it extremely unlikely
 
-	var/earliest_start = 12000	//The earliest world.time that an event can start (round-duration in deciseconds) default: 20 mins
-	var/min_players = 0			//The minimum amount of alive, non-AFK human players on server required to start the event.
+	var/earliest_start = 20 MINUTES	//The earliest world.time that an event can start (round-duration in deciseconds) default: 20 mins
+	var/min_players = 0				//The minimum amount of alive, non-AFK human players on server required to start the event.
 
-	var/occurrences = 0			//How many times this event has occured
-	var/max_occurrences = 20	//The maximum number of times this event can occur (naturally), it can still be forced.
-								//By setting this to 0 you can effectively disable an event.
+	var/occurrences = 0				//How many times this event has occured
+	var/max_occurrences = 20		//The maximum number of times this event can occur (naturally), it can still be forced.
+									//By setting this to 0 you can effectively disable an event.
 
-	var/holidayID = ""			//string which should be in the SSeventss.holidays list if you wish this event to be holiday-specific
-								//anything with a (non-null) holidayID which does not match holiday, cannot run.
+	var/holidayID = ""				//string which should be in the SSeventss.holidays list if you wish this event to be holiday-specific
+									//anything with a (non-null) holidayID which does not match holiday, cannot run.
 	var/wizardevent = 0
 
-	var/alertadmins = 1			//should we let the admins know this event is firing
-								//should be disabled on events that fire a lot
+	var/alertadmins = 1				//should we let the admins know this event is firing
+									//should be disabled on events that fire a lot
 
 	var/list/gamemode_blacklist = list() // Event won't happen in these gamemodes
 	var/list/gamemode_whitelist = list() // Event will happen ONLY in these gamemodes if not empty

--- a/code/modules/events/carp_migration.dm
+++ b/code/modules/events/carp_migration.dm
@@ -3,7 +3,7 @@
 	typepath = /datum/round_event/carp_migration
 	weight = 15
 	min_players = 2
-	earliest_start = 6000
+	earliest_start = 10 MINUTES
 	max_occurrences = 6
 
 /datum/round_event/carp_migration

--- a/code/modules/events/dust.dm
+++ b/code/modules/events/dust.dm
@@ -3,7 +3,7 @@
 	typepath = /datum/round_event/space_dust
 	weight = 200
 	max_occurrences = 1000
-	earliest_start = 0
+	earliest_start = 0 MINUTES
 	alertadmins = 0
 
 /datum/round_event/space_dust
@@ -19,7 +19,7 @@
 	typepath = /datum/round_event/sandstorm
 	weight = 0
 	max_occurrences = 0
-	earliest_start = 0
+	earliest_start = 0 MINUTES
 
 /datum/round_event/sandstorm
 	startWhen = 1

--- a/code/modules/events/electrical_storm.dm
+++ b/code/modules/events/electrical_storm.dm
@@ -1,7 +1,7 @@
 /datum/round_event_control/electrical_storm
 	name = "Electrical Storm"
 	typepath = /datum/round_event/electrical_storm
-	earliest_start = 6000
+	earliest_start = 10 MINUTES
 	min_players = 5
 	weight = 40
 	alertadmins = 0

--- a/code/modules/events/heart_attack.dm
+++ b/code/modules/events/heart_attack.dm
@@ -3,7 +3,6 @@
 	typepath = /datum/round_event/heart_attack
 	weight = 20
 	max_occurrences = 2
-	earliest_start = 12000
 	min_players = 40 // To avoid shafting lowpop
 
 /datum/round_event/heart_attack/start()

--- a/code/modules/events/holiday/halloween.dm
+++ b/code/modules/events/holiday/halloween.dm
@@ -4,7 +4,7 @@
 	typepath = /datum/round_event/spooky
 	weight = -1							//forces it to be called, regardless of weight
 	max_occurrences = 1
-	earliest_start = 0
+	earliest_start = 0 MINUTES
 
 /datum/round_event/spooky/start()
 	..()

--- a/code/modules/events/holiday/vday.dm
+++ b/code/modules/events/holiday/vday.dm
@@ -10,7 +10,7 @@
 	typepath = /datum/round_event/valentines
 	weight = -1							//forces it to be called, regardless of weight
 	max_occurrences = 1
-	earliest_start = 0
+	earliest_start = 0 MINUTES
 
 /datum/round_event/valentines/start()
 	..()

--- a/code/modules/events/holiday/xmas.dm
+++ b/code/modules/events/holiday/xmas.dm
@@ -64,7 +64,7 @@
 	typepath = /datum/round_event/santa
 	weight = 20
 	max_occurrences = 1
-	earliest_start = 20000
+	earliest_start = 30 MINUTES
 
 /datum/round_event/santa
 	var/mob/living/carbon/human/santa //who is our santa?

--- a/code/modules/events/portal_storm.dm
+++ b/code/modules/events/portal_storm.dm
@@ -3,7 +3,7 @@
 	typepath = /datum/round_event/portal_storm/syndicate_shocktroop
 	weight = 2
 	min_players = 15
-	earliest_start = 18000
+	earliest_start = 30 MINUTES
 
 /datum/round_event/portal_storm/syndicate_shocktroop
 	boss_types = list(/mob/living/simple_animal/hostile/syndicate/melee/space/stormtrooper = 2)

--- a/code/modules/events/shuttle_loan.dm
+++ b/code/modules/events/shuttle_loan.dm
@@ -10,7 +10,7 @@
 	name = "Shuttle Loan"
 	typepath = /datum/round_event/shuttle_loan
 	max_occurrences = 1
-	earliest_start = 4000
+	earliest_start = 7 MINUTES
 
 /datum/round_event/shuttle_loan
 	announceWhen = 1

--- a/code/modules/events/spontaneous_appendicitis.dm
+++ b/code/modules/events/spontaneous_appendicitis.dm
@@ -3,7 +3,7 @@
 	typepath = /datum/round_event/spontaneous_appendicitis
 	weight = 20
 	max_occurrences = 4
-	earliest_start = 6000
+	earliest_start = 10 MINUTES
 	min_players = 5 // To make your chance of getting help a bit higher.
 
 /datum/round_event/spontaneous_appendicitis

--- a/code/modules/events/wizard/advanced_darkness.dm
+++ b/code/modules/events/wizard/advanced_darkness.dm
@@ -3,7 +3,7 @@
 	weight = 2
 	typepath = /datum/round_event/wizard/darkness
 	max_occurrences = 2
-	earliest_start = 0
+	earliest_start = 0 MINUTES
 
 /datum/round_event/wizard/darkness
 	endWhen = 0

--- a/code/modules/events/wizard/aid.dm
+++ b/code/modules/events/wizard/aid.dm
@@ -5,7 +5,7 @@
 	weight = 2
 	typepath = /datum/round_event/wizard/robelesscasting
 	max_occurrences = 1
-	earliest_start = 0
+	earliest_start = 0 MINUTES
 
 /datum/round_event/wizard/robelesscasting/start()
 
@@ -27,7 +27,7 @@
 	weight = 3
 	typepath = /datum/round_event/wizard/improvedcasting
 	max_occurrences = 4 //because that'd be max level spells
-	earliest_start = 0
+	earliest_start = 0 MINUTES
 
 /datum/round_event/wizard/improvedcasting/start()
 	for(var/i in GLOB.mob_living_list)

--- a/code/modules/events/wizard/blobies.dm
+++ b/code/modules/events/wizard/blobies.dm
@@ -3,7 +3,6 @@
 	weight = 3
 	typepath = /datum/round_event/wizard/blobies
 	max_occurrences = 3
-	earliest_start = 12000 // 20 minutes (gotta get some bodies made!)
 
 /datum/round_event/wizard/blobies/start()
 

--- a/code/modules/events/wizard/curseditems.dm
+++ b/code/modules/events/wizard/curseditems.dm
@@ -3,7 +3,7 @@
 	weight = 3
 	typepath = /datum/round_event/wizard/cursed_items
 	max_occurrences = 3
-	earliest_start = 0
+	earliest_start = 0 MINUTES
 
 //Note about adding items to this: Because of how NODROP_1 works if an item spawned to the hands can also be equiped to a slot
 //it will be able to be put into that slot from the hand, but then get stuck there. To avoid this make a new subtype of any

--- a/code/modules/events/wizard/departmentrevolt.dm
+++ b/code/modules/events/wizard/departmentrevolt.dm
@@ -3,7 +3,7 @@
 	weight = 0 //An order that requires order in a round of chaos was maybe not the best idea. Requiescat in pace departmental uprising August 2014 - March 2015
 	typepath = /datum/round_event/wizard/deprevolt
 	max_occurrences = 1
-	earliest_start = 0
+	earliest_start = 0 MINUTES
 
 /datum/round_event/wizard/deprevolt/start()
 

--- a/code/modules/events/wizard/fakeexplosion.dm
+++ b/code/modules/events/wizard/fakeexplosion.dm
@@ -3,7 +3,7 @@
 	weight = 0 //Badmin exclusive now because once it's expected its not funny
 	typepath = /datum/round_event/wizard/fake_explosion
 	max_occurrences = 1
-	earliest_start = 0
+	earliest_start = 0 MINUTES
 
 /datum/round_event/wizard/fake_explosion/start()
 	sound_to_playing_players('sound/machines/alarm.ogg')

--- a/code/modules/events/wizard/ghost.dm
+++ b/code/modules/events/wizard/ghost.dm
@@ -3,7 +3,7 @@
 	weight = 3
 	typepath = /datum/round_event/wizard/ghost
 	max_occurrences = 1
-	earliest_start = 0
+	earliest_start = 0 MINUTES
 
 /datum/round_event/wizard/ghost/start()
 	var/msg = "<span class='warning'>You suddenly feel extremely obvious...</span>"
@@ -17,7 +17,7 @@
 	weight = 2
 	typepath = /datum/round_event/wizard/possession
 	max_occurrences = 5
-	earliest_start = 0
+	earliest_start = 0 MINUTES
 
 /datum/round_event/wizard/possession/start()
 	for(var/mob/dead/observer/G in GLOB.player_list)

--- a/code/modules/events/wizard/greentext.dm
+++ b/code/modules/events/wizard/greentext.dm
@@ -3,7 +3,7 @@
 	weight = 4
 	typepath = /datum/round_event/wizard/greentext
 	max_occurrences = 1
-	earliest_start = 0
+	earliest_start = 0 MINUTES
 
 /datum/round_event/wizard/greentext/start()
 

--- a/code/modules/events/wizard/imposter.dm
+++ b/code/modules/events/wizard/imposter.dm
@@ -3,7 +3,7 @@
 	weight = 1
 	typepath = /datum/round_event/wizard/imposter
 	max_occurrences = 1
-	earliest_start = 0
+	earliest_start = 0 MINUTES
 
 /datum/round_event/wizard/imposter/start()
 	for(var/datum/mind/M in SSticker.mode.wizards)

--- a/code/modules/events/wizard/invincible.dm
+++ b/code/modules/events/wizard/invincible.dm
@@ -3,7 +3,7 @@
 	weight = 3
 	typepath = /datum/round_event/wizard/invincible
 	max_occurrences = 5
-	earliest_start = 0
+	earliest_start = 0 MINUTES
 
 /datum/round_event/wizard/invincible/start()
 

--- a/code/modules/events/wizard/lava.dm
+++ b/code/modules/events/wizard/lava.dm
@@ -3,7 +3,7 @@
 	weight = 2
 	typepath = /datum/round_event/wizard/lava
 	max_occurrences = 3
-	earliest_start = 0
+	earliest_start = 0 MINUTES
 
 /datum/round_event/wizard/lava
 	endWhen = 0

--- a/code/modules/events/wizard/magicarp.dm
+++ b/code/modules/events/wizard/magicarp.dm
@@ -3,7 +3,7 @@
 	weight = 1
 	typepath = /datum/round_event/wizard/magicarp
 	max_occurrences = 1
-	earliest_start = 0
+	earliest_start = 0 MINUTES
 
 /datum/round_event/wizard/magicarp
 	announceWhen	= 3

--- a/code/modules/events/wizard/petsplosion.dm
+++ b/code/modules/events/wizard/petsplosion.dm
@@ -3,7 +3,7 @@
 	weight = 2
 	typepath = /datum/round_event/wizard/petsplosion
 	max_occurrences = 1 //Exponential growth is nothing to sneeze at!
-	earliest_start = 0
+	earliest_start = 0 MINUTES
 	var/mobs_to_dupe = 0
 
 /datum/round_event_control/wizard/petsplosion/preRunEvent()

--- a/code/modules/events/wizard/race.dm
+++ b/code/modules/events/wizard/race.dm
@@ -3,7 +3,7 @@
 	weight = 2
 	typepath = /datum/round_event/wizard/race
 	max_occurrences = 5
-	earliest_start = 0
+	earliest_start = 0 MINUTES
 
 /datum/round_event/wizard/race/start()
 

--- a/code/modules/events/wizard/rpgloot.dm
+++ b/code/modules/events/wizard/rpgloot.dm
@@ -3,7 +3,7 @@
 	weight = 3
 	typepath = /datum/round_event/wizard/rpgloot
 	max_occurrences = 1
-	earliest_start = 0
+	earliest_start = 0 MINUTES
 
 /datum/round_event/wizard/rpgloot/start()
 	var/upgrade_scroll_chance = 0

--- a/code/modules/events/wizard/shuffle.dm
+++ b/code/modules/events/wizard/shuffle.dm
@@ -6,7 +6,7 @@
 	weight = 2
 	typepath = /datum/round_event/wizard/shuffleloc
 	max_occurrences = 5
-	earliest_start = 0
+	earliest_start = 0 MINUTES
 
 /datum/round_event/wizard/shuffleloc/start()
 	var/list/moblocs = list()
@@ -42,7 +42,7 @@
 	weight = 4
 	typepath = /datum/round_event/wizard/shufflenames
 	max_occurrences = 5
-	earliest_start = 0
+	earliest_start = 0 MINUTES
 
 /datum/round_event/wizard/shufflenames/start()
 	var/list/mobnames = list()
@@ -76,7 +76,7 @@
 	weight = 1
 	typepath = /datum/round_event/wizard/shuffleminds
 	max_occurrences = 3
-	earliest_start = 0
+	earliest_start = 0 MINUTES
 
 /datum/round_event/wizard/shuffleminds/start()
 	var/list/mobs	 = list()

--- a/code/modules/events/wizard/summons.dm
+++ b/code/modules/events/wizard/summons.dm
@@ -3,7 +3,7 @@
 	weight = 1
 	typepath = /datum/round_event/wizard/summonguns
 	max_occurrences = 1
-	earliest_start = 0
+	earliest_start = 0 MINUTES
 
 /datum/round_event_control/wizard/summonguns/New()
 	if(CONFIG_GET(flag/no_summon_guns))
@@ -18,7 +18,7 @@
 	weight = 1
 	typepath = /datum/round_event/wizard/summonmagic
 	max_occurrences = 1
-	earliest_start = 0
+	earliest_start = 0 MINUTES
 
 /datum/round_event_control/wizard/summonmagic/New()
 	if(CONFIG_GET(flag/no_summon_magic))

--- a/code/modules/holiday/easter.dm
+++ b/code/modules/holiday/easter.dm
@@ -4,7 +4,7 @@
 	typepath = /datum/round_event/easter
 	weight = -1
 	max_occurrences = 1
-	earliest_start = 0
+	earliest_start = 0 MINUTES
 
 /datum/round_event/easter/announce(fake)
 	priority_announce(pick("Hip-hop into Easter!","Find some Bunny's stash!","Today is National 'Hunt a Wabbit' Day.","Be kind, give Chocolate Eggs!"))

--- a/code/modules/ninja/ninja_event.dm
+++ b/code/modules/ninja/ninja_event.dm
@@ -13,7 +13,7 @@ Contents:
 	name = "Space Ninja"
 	typepath = /datum/round_event/ghost_role/ninja
 	max_occurrences = 1
-	earliest_start = 30000 // 1 hour
+	earliest_start = 1 HOUR
 	min_players = 15
 
 /datum/round_event/ghost_role/ninja

--- a/code/modules/ninja/ninja_event.dm
+++ b/code/modules/ninja/ninja_event.dm
@@ -13,7 +13,7 @@ Contents:
 	name = "Space Ninja"
 	typepath = /datum/round_event/ghost_role/ninja
 	max_occurrences = 1
-	earliest_start = 1 HOUR
+	earliest_start = 1 HOURS
 	min_players = 15
 
 /datum/round_event/ghost_role/ninja


### PR DESCRIPTION
:cl: Denton
tweak: Changed Santa event earliest start from 33 minutes & 20 seconds to 30 minutes. Changed shuttle loan earliest start from 6 minutes & 40 seconds to 7 minutes.
/:cl:

@vuonojenmustaturska showed me that you can use time helpers instead of deciseconds - this should make event start times readable more easily.

That aside, some events had earliest_start defined as the default 20 minutes. I removed it from the following: heart_attack, revenant, wizard/blobies.

Tweaks:
- Changed Santa event start from 33 minutes & 20 seconds (20.000 deciseconds) to 30 minutes
- Changed shuttle loan event shuttle loan event start from 6 minutes & 40 seconds (4.000 deciseconds) to 7 minutes.