### PR TITLE
Tweaks meteor shield emag text

### DIFF
--- a/code/modules/station_goals/shield.dm
+++ b/code/modules/station_goals/shield.dm
@@ -174,6 +174,6 @@
 	if(obj_flags & EMAGGED)
 		return
 	obj_flags |= EMAGGED
-	to_chat(user, "<span class='notice'>You enable the satellite's debug mode, increasing the chance of meteor strikes.</span>")
+	to_chat(user, "<span class='notice'>You access the satellite's debug mode, increasing the chance of meteor strikes.</span>")
 	if(active)
 		change_meteor_chance(2)

--- a/code/modules/station_goals/shield.dm
+++ b/code/modules/station_goals/shield.dm
@@ -174,6 +174,6 @@
 	if(obj_flags & EMAGGED)
 		return
 	obj_flags |= EMAGGED
-	to_chat(user, "<span class='notice'>You scramble the satellite's controller, increasing the chance of meteor strikes.</span>")
+	to_chat(user, "<span class='notice'>You enable the satellite's debug mode, increasing the chance of meteor strikes.</span>")
 	if(active)
 		change_meteor_chance(2)


### PR DESCRIPTION
:cl: Denton
spellcheck: Tweaked the message you see when emagging meteor shield satellites.
/:cl:

"Debug mode" is more in line with the message you see when using a multitool on an emagged shield sat.