### PR TITLE
Makes it more apparent that >>>>>>>YOU CAN ALT CLICK TO DISABLE MORGUE TRAY BEEPING<<<<<<

### DIFF
--- a/code/game/objects/structures/morgue.dm
+++ b/code/game/objects/structures/morgue.dm
@@ -153,7 +153,7 @@ GLOBAL_LIST_EMPTY(bodycontainers) //Let them act as spawnpoints for revenants an
 
 /obj/structure/bodycontainer/morgue/examine(mob/user)
 	..()
-	to_chat(user, "<span class='notice'>You can Alt-click the tray to deactivate the alarm.</span>")
+	to_chat(user, "<span class='notice'>Alt-click [src] to [beeper ? "disable" : "enable"] the alarm.</span>")
 
 /obj/structure/bodycontainer/morgue/AltClick(mob/user)
 	..()

--- a/code/game/objects/structures/morgue.dm
+++ b/code/game/objects/structures/morgue.dm
@@ -141,7 +141,7 @@ GLOBAL_LIST_EMPTY(bodycontainers) //Let them act as spawnpoints for revenants an
  */
 /obj/structure/bodycontainer/morgue
 	name = "morgue"
-	desc = "Used to keep bodies in until someone fetches them."
+	desc = "Used to keep bodies in until someone fetches them. Now includes a high-tech alert system."
 	icon_state = "morgue1"
 	dir = EAST
 	var/beeper = TRUE
@@ -150,6 +150,10 @@ GLOBAL_LIST_EMPTY(bodycontainers) //Let them act as spawnpoints for revenants an
 	connected = new/obj/structure/tray/m_tray(src)
 	connected.connected = src
 	..()
+
+/obj/structure/bodycontainer/morgue/examine(mob/user)
+	..()
+	to_chat(user, "<span class='notice'>You can Alt-click the tray to deactivate the alarm.</span>")
 
 /obj/structure/bodycontainer/morgue/AltClick(mob/user)
 	..()


### PR DESCRIPTION
🆑 
tweak: Nanotrasen has begun a campaign to inform their employees that you can alt-click to disable morgue tray beeping.
/🆑 

If its annoying you literally just alt-click to disable it. There's basically no situation where you would be able to hear it without being able to turn it off, except maybe the one morgue tray in the brig if you don't have access to the windoor (but just fucking ask sec to disable it).
