### PR TITLE
Adds techweb doppler arrays and fixes their name/desc

### DIFF
--- a/_maps/map_files/BoxStation/BoxStation.dmm
+++ b/_maps/map_files/BoxStation/BoxStation.dmm
@@ -33684,7 +33684,7 @@
 /turf/open/floor/plating,
 /area/science/mixing)
 "bGd" = (
-/obj/machinery/doppler_array{
+/obj/machinery/doppler_array/research/science{
 	dir = 4
 	},
 /obj/effect/turf_decal/bot{

--- a/_maps/map_files/Deltastation/DeltaStation2.dmm
+++ b/_maps/map_files/Deltastation/DeltaStation2.dmm
@@ -90664,7 +90664,7 @@
 /turf/open/floor/plating/airless,
 /area/science/test_area)
 "dJJ" = (
-/obj/machinery/doppler_array{
+/obj/machinery/doppler_array/research/science{
 	dir = 8
 	},
 /obj/structure/extinguisher_cabinet{

--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -70582,7 +70582,7 @@
 /turf/open/floor/plasteel/vault,
 /area/chapel/main)
 "cQB" = (
-/obj/machinery/doppler_array{
+/obj/machinery/doppler_array/research/science{
 	dir = 4
 	},
 /obj/item/device/radio/intercom{

--- a/_maps/map_files/PubbyStation/PubbyStation.dmm
+++ b/_maps/map_files/PubbyStation/PubbyStation.dmm
@@ -35550,7 +35550,7 @@
 /area/science/mineral_storeroom)
 "bIO" = (
 /obj/structure/window/reinforced,
-/obj/machinery/doppler_array{
+/obj/machinery/doppler_array/research/science{
 	dir = 2
 	},
 /obj/effect/turf_decal/bot{

--- a/code/game/machinery/doppler_array.dm
+++ b/code/game/machinery/doppler_array.dm
@@ -101,8 +101,8 @@ GLOBAL_LIST_EMPTY(doppler_arrays)
 	use_power = NO_POWER_USE
 
 /obj/machinery/doppler_array/research
-	name = "tachyon-dopplar research array"
-	desc = "A specialized tacyhon-dopplar bomb detection array that uses the results of the highest yield of explosions for research."
+	name = "tachyon-doppler research array"
+	desc = "A specialized tachyon-doppler bomb detection array that uses the results of the highest yield of explosions for research."
 	var/datum/techweb/linked_techweb
 
 /obj/machinery/doppler_array/research/sense_explosion(turf/epicenter, dev, heavy, light, time, orig_dev, orig_heavy, orig_light)	//probably needs a way to ignore admin explosives later on


### PR DESCRIPTION
:cl: kevinz000, Denton
add: Nanotrasen's RnD division has integrated all stationary tachyon doppler arrays into the techweb system. Record increasingly large explosions with them and you will generate research points!
spellcheck: Fixed a few typos in the RnD doppler array name/description.
/:cl:

@kevinz000 The doppler_aray/research/science version was just sitting around without being used in maps. Is that intentional or an oversight? 
If it's intentional I'll close this PR.