### PR TITLE
Nerfs Hearty Punch without reducing its healing.

### DIFF
--- a/code/modules/reagents/chemistry/reagents/alcohol_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/alcohol_reagents.dm
@@ -1108,9 +1108,9 @@ All effects don't start immediately, but rather get worse over time; the rate is
 /datum/reagent/consumable/ethanol/hearty_punch
 	name = "Hearty Punch"
 	id = "hearty_punch"
-	description = "Brave bull/syndicate bomb/absinthe mixture resulting in an energizing beverage. Mild alcohol content."
+	description = "Brave bull/syndicate bomb/absinthe mixture resulting in an energizing beverage. A potent, spiced alcohol."
 	color = rgb(140, 0, 0)
-	boozepwr = 10
+	boozepwr = 50
 	metabolization_rate = 0.1 * REAGENTS_METABOLISM
 	taste_description = "bravado in the face of disaster"
 	glass_icon_state = "hearty_punch"
@@ -1124,10 +1124,9 @@ All effects don't start immediately, but rather get worse over time; the rate is
 		M.visible_message("<span class='warning'>[M.name] collapses, but [M.p_they()] look like they're determined to get back up.</span>",
 			"<span class='warning'>You fall over, but hear a soothing, gruff voice urging you back on your feet.</span>")
 	if(active & M.health >= 50)
-		active = FALSE
 		M.visible_message("<span class='warning'>[M.name] starts to get back up and dust [M.p_them()]self off.</span>",
 			"<span class='notice'>You start to get back up and brush yourself off, feeling better.</span>")
-		M.reagents.remove_reagent("hearty_punch",M.reagents.get_reagent_amount("hearty_punch"))
+		M.reagents.del_reagent("hearty_punch")
 
 	if(active)
 		M.Knockdown(60, TRUE, FALSE)

--- a/code/modules/reagents/chemistry/reagents/alcohol_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/alcohol_reagents.dm
@@ -1116,9 +1116,21 @@ All effects don't start immediately, but rather get worse over time; the rate is
 	glass_icon_state = "hearty_punch"
 	glass_name = "Hearty Punch"
 	glass_desc = "Aromatic beverage served piping hot. According to folk tales it can almost wake the dead."
+	var/active = FALSE
 
 /datum/reagent/consumable/ethanol/hearty_punch/on_mob_life(mob/living/M)
-	if(M.health <= 0)
+	if(!active & M.health <= 0)
+		active = TRUE
+		M.visible_message("<span class='warning'>[M.name] collapses, but [M.p_they()] look like they're determined to get back up.</span>",
+			"<span class='warning'>You fall over, but hear a soothing, gruff voice urging you back on your feet.</span>")
+	if(active & M.health >= 50)
+		active = FALSE
+		M.visible_message("<span class='warning'>[M.name] starts to get back up and dust [M.p_them()]self off.</span>",
+			"<span class='notice'>You start to get back up and brush yourself off, feeling better.</span>")
+		M.reagents.remove_reagent("hearty_punch",M.reagents.get_reagent_amount("hearty_punch"))
+
+	if(active)
+		M.Knockdown(60, TRUE, FALSE)
 		M.adjustBruteLoss(-7, 0)
 		M.adjustFireLoss(-7, 0)
 		M.adjustToxLoss(-7, 0)
@@ -1126,6 +1138,11 @@ All effects don't start immediately, but rather get worse over time; the rate is
 		M.adjustCloneLoss(-7, 0)
 		. = 1
 	return ..() || .
+
+/datum/reagent/consumable/ethanol/hearty_punch/on_mob_delete(mob/living/M)
+	if(active)
+		active = FALSE
+	..()
 
 /datum/reagent/consumable/ethanol/bacchus_blessing //An EXTREMELY powerful drink. Smashed in seconds, dead in minutes.
 	name = "Bacchus' Blessing"

--- a/code/modules/reagents/chemistry/reagents/alcohol_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/alcohol_reagents.dm
@@ -1110,7 +1110,7 @@ All effects don't start immediately, but rather get worse over time; the rate is
 	id = "hearty_punch"
 	description = "Brave bull/syndicate bomb/absinthe mixture resulting in an energizing beverage. A potent, spiced alcohol."
 	color = rgb(140, 0, 0)
-	boozepwr = 50
+	boozepwr = 90
 	metabolization_rate = 0.1 * REAGENTS_METABOLISM
 	taste_description = "bravado in the face of disaster"
 	glass_icon_state = "hearty_punch"


### PR DESCRIPTION
:cl: Fel
tweak:Hearty Punch now knocks you down when it is healing you, and makes it obvious what is happening.
add:Hearty Punch now heals until 50% health, but removes itself afterward. It's also better at being alcohol, so enjoy your spiced beverage of choice!
/:cl:

Alternative to #35836.

Hearty Punch now keeps you on the ground while it is healing you, and has an obvious visible message about your healing. It also removes all reagents of it present in you when it finishes healing. In order to ensure it is not kept in large quantities in players as a "backup," its' booze power was increased. This has the added side effect of making it a pretty nice drink even when not tanking bullets.

In exchange for this, it heals up to 50% of maximum health.