### PR TITLE
You can now grow poison apples.

### DIFF
--- a/code/modules/hydroponics/grown/apple.dm
+++ b/code/modules/hydroponics/grown/apple.dm
@@ -13,7 +13,7 @@
 	icon_grow = "apple-grow"
 	icon_dead = "apple-dead"
 	genes = list(/datum/plant_gene/trait/repeated_harvest)
-	mutatelist = list(/obj/item/seeds/apple/gold)
+	mutatelist = list(/obj/item/seeds/apple/gold, /obj/item/seeds/apple/poisoned)
 	reagents_add = list("vitamin" = 0.04, "nutriment" = 0.1)
 
 /obj/item/reagent_containers/food/snacks/grown/apple
@@ -31,8 +31,8 @@
 /obj/item/seeds/apple/poisoned
 	product = /obj/item/reagent_containers/food/snacks/grown/apple/poisoned
 	mutatelist = list()
-	reagents_add = list("zombiepowder" = 0.5, "vitamin" = 0.04, "nutriment" = 0.1)
-	rarity = 50 // Source of cyanide, and hard (almost impossible) to obtain normally.
+	reagents_add = list("zombiepowder" = 0.1, "vitamin" = 0.04, "nutriment" = 0.1)
+	rarity = 50 // Source of zombie powder, and hard (almost impossible) to obtain normally.
 
 /obj/item/reagent_containers/food/snacks/grown/apple/poisoned
 	seed = /obj/item/seeds/apple/poisoned


### PR DESCRIPTION
:cl:
tweak: A freak mutation has appeared in standard-issue Nanotrasen Brand Apples. They can now mutate into dangerous poison apples.
/:cl:

closes #35820

New pr because #35821 got a bit crazy.

They still have zombie powder in them but its 1/5th as much as before so just eating a normal apple will put you down for a second at most, and botany will have to work a little to get a large amount.

Justification: They can already get it anyway. Koibeans provide carpotoxin, Reishi have morphine, and cable coils can be ground into copper. A few people in #35821 pointed this out.