### PR TITLE
Lets silicons disable morguetray alarms at a distance

### DIFF
--- a/code/game/objects/structures/morgue.dm
+++ b/code/game/objects/structures/morgue.dm
@@ -153,7 +153,7 @@ GLOBAL_LIST_EMPTY(bodycontainers) //Let them act as spawnpoints for revenants an
 
 /obj/structure/bodycontainer/morgue/AltClick(mob/user)
 	..()
-	if(!user.canUseTopic(src, BE_CLOSE))
+	if(!user.canUseTopic(src, !issilicon(user)))
 		return
 	beeper = !beeper
 	to_chat(user, "<span class='notice'>You turn the speaker function [beeper ? "off" : "on"].</span>")


### PR DESCRIPTION
Minor tweak

:cl: ShizCalev
tweak: Silicons no longer have to be adjacent to morguetrays to disable the alarms on then.
/:cl: