### PR TITLE
Fixes #24231

### DIFF
--- a/code/game/machinery/doors/windowdoor.dm
+++ b/code/game/machinery/doors/windowdoor.dm
@@ -18,7 +18,7 @@
 	var/reinf = 0
 	var/shards = 2
 	var/rods = 2
-	var/cable = 1
+	var/cable = 3
 	var/list/debris = list()
 
 /obj/machinery/door/window/New(loc, set_dir)

--- a/code/game/machinery/doors/windowdoor.dm
+++ b/code/game/machinery/doors/windowdoor.dm
@@ -18,7 +18,7 @@
 	var/reinf = 0
 	var/shards = 2
 	var/rods = 2
-	var/cable = 3
+	var/cable = 1
 	var/list/debris = list()
 
 /obj/machinery/door/window/New(loc, set_dir)

--- a/code/game/machinery/doors/windowdoor.dm
+++ b/code/game/machinery/doors/windowdoor.dm
@@ -18,7 +18,7 @@
 	var/reinf = 0
 	var/shards = 2
 	var/rods = 2
-	var/cable = 2
+	var/cable = 1
 	var/list/debris = list()
 
 /obj/machinery/door/window/New(loc, set_dir)

--- a/code/modules/reagents/chemistry/reagents/alcohol_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/alcohol_reagents.dm
@@ -1119,8 +1119,6 @@ All effects don't start immediately, but rather get worse over time; the rate is
 	if(M.health <= 0)
 		M.adjustBruteLoss(-7, 0)
 		M.adjustFireLoss(-7, 0)
-		M.adjustToxLoss(-7, 0)
-		M.adjustOxyLoss(-7, 0)
 		M.adjustCloneLoss(-7, 0)
 		. = 1
 	return ..() || .


### PR DESCRIPTION
[Changelogs]: Windoors have been fixed to not drop more cable than what was used to build them.

:cl: Repukan
fix: fixed a few things
/:cl:

[why]: Well they're not supposed to drop extra materials if they're broken, aren't they?
