### PR TITLE
Fixes windoors dropping extra cable

### DIFF
--- a/code/game/machinery/doors/windowdoor.dm
+++ b/code/game/machinery/doors/windowdoor.dm
@@ -18,7 +18,7 @@
 	var/reinf = 0
 	var/shards = 2
 	var/rods = 2
-	var/cable = 2
+	var/cable = 1
 	var/list/debris = list()
 
 /obj/machinery/door/window/New(loc, set_dir)


### PR DESCRIPTION
No extra cable for you. Hugbox!
Fixes #24231
:cl: Repukan
fix: fixed windoors dropping more cable than what was used to build them.
/:cl:

[why]: But who was cable
