### PR TITLE
Cycle links space ruin airlocks

### DIFF
--- a/_maps/RandomRuins/SpaceRuins/DJstation.dmm
+++ b/_maps/RandomRuins/SpaceRuins/DJstation.dmm
@@ -341,6 +341,7 @@
 	req_access = null;
 	req_access_txt = "0"
 	},
+/obj/effect/mapping_helpers/airlock/cyclelink_helper,
 /turf/open/floor/plating,
 /area/ruin/space/djstation)
 "bj" = (
@@ -350,6 +351,17 @@
 /obj/structure/disposaloutlet,
 /turf/open/floor/plating/airless,
 /area/space/nearstation)
+"Co" = (
+/obj/machinery/door/airlock/external{
+	name = "Ruskie DJ Station";
+	req_access = null;
+	req_access_txt = "0"
+	},
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/ruin/space/djstation)
 
 (1,1,1) = {"
 aa
@@ -624,7 +636,7 @@ bd
 aw
 bi
 ah
-bi
+Co
 "}
 (12,1,1) = {"
 ab

--- a/_maps/RandomRuins/SpaceRuins/abandonedteleporter.dmm
+++ b/_maps/RandomRuins/SpaceRuins/abandonedteleporter.dmm
@@ -65,6 +65,9 @@
 /area/ruin/space/abandoned_tele)
 "p" = (
 /obj/machinery/door/airlock/external,
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 4
+	},
 /turf/open/floor/plating/airless,
 /area/ruin/space/abandoned_tele)
 "q" = (
@@ -120,6 +123,13 @@
 /area/ruin/space/abandoned_tele)
 "B" = (
 /obj/structure/girder,
+/turf/open/floor/plating/airless,
+/area/ruin/space/abandoned_tele)
+"O" = (
+/obj/machinery/door/airlock/external,
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 8
+	},
 /turf/open/floor/plating/airless,
 /area/ruin/space/abandoned_tele)
 
@@ -184,7 +194,7 @@ a
 c
 b
 b
-p
+O
 b
 b
 c

--- a/_maps/RandomRuins/SpaceRuins/abandonedzoo.dmm
+++ b/_maps/RandomRuins/SpaceRuins/abandonedzoo.dmm
@@ -652,6 +652,7 @@
 /area/ruin/space/has_grav/abandonedzoo)
 "bG" = (
 /obj/machinery/door/airlock/external,
+/obj/effect/mapping_helpers/airlock/cyclelink_helper,
 /turf/open/floor/plasteel/darkgreen,
 /area/ruin/space/has_grav/abandonedzoo)
 "bH" = (
@@ -747,6 +748,13 @@
 /area/template_noop)
 "bX" = (
 /turf/open/floor/plating/airless,
+/area/ruin/space/has_grav/abandonedzoo)
+"lo" = (
+/obj/machinery/door/airlock/external,
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 1
+	},
+/turf/open/floor/plasteel/darkgreen,
 /area/ruin/space/has_grav/abandonedzoo)
 "KN" = (
 /turf/template_noop,
@@ -937,7 +945,7 @@ aH
 ay
 bG
 bL
-bG
+lo
 aa
 aa
 "}
@@ -958,7 +966,7 @@ bq
 ay
 bG
 bM
-bG
+lo
 aa
 aa
 "}

--- a/_maps/RandomRuins/SpaceRuins/bigderelict1.dmm
+++ b/_maps/RandomRuins/SpaceRuins/bigderelict1.dmm
@@ -152,6 +152,7 @@
 /area/ruin/space/has_grav/derelictoutpost/powerstorage)
 "aB" = (
 /obj/machinery/door/airlock/external,
+/obj/effect/mapping_helpers/airlock/cyclelink_helper,
 /turf/open/floor/plating,
 /area/ruin/space/has_grav/derelictoutpost/powerstorage)
 "aC" = (
@@ -201,6 +202,7 @@
 /area/ruin/space/has_grav/derelictoutpost)
 "aL" = (
 /obj/machinery/door/airlock/external,
+/obj/effect/mapping_helpers/airlock/cyclelink_helper,
 /turf/open/floor/plating,
 /area/ruin/space/has_grav/derelictoutpost)
 "aM" = (
@@ -2126,6 +2128,20 @@
 /obj/machinery/door/airlock/maintenance,
 /turf/open/floor/plating,
 /area/ruin/space/has_grav/derelictoutpost/cargobay)
+"uV" = (
+/obj/machinery/door/airlock/external,
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/ruin/space/has_grav/derelictoutpost/powerstorage)
+"LB" = (
+/obj/machinery/door/airlock/external,
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/ruin/space/has_grav/derelictoutpost)
 
 (1,1,1) = {"
 aa
@@ -2209,7 +2225,7 @@ aa
 aa
 aB
 aM
-aB
+uV
 ba
 bq
 bH
@@ -3181,7 +3197,7 @@ aa
 aa
 aL
 aR
-aL
+LB
 bj
 bl
 bn
@@ -3397,7 +3413,7 @@ aa
 aa
 aL
 aR
-aL
+LB
 bn
 bF
 bl

--- a/_maps/RandomRuins/SpaceRuins/deepstorage.dmm
+++ b/_maps/RandomRuins/SpaceRuins/deepstorage.dmm
@@ -2655,6 +2655,7 @@
 	name = "Inconspicuous Airlock";
 	req_access_txt = "200"
 	},
+/obj/effect/mapping_helpers/airlock/cyclelink_helper,
 /turf/open/floor/plating,
 /area/ruin/space/has_grav/deepstorage)
 "gA" = (
@@ -2778,6 +2779,9 @@
 	req_access_txt = "200"
 	},
 /obj/structure/fans/tiny,
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 1
+	},
 /turf/open/floor/plating,
 /area/ruin/space/has_grav/deepstorage)
 "gR" = (

--- a/_maps/RandomRuins/SpaceRuins/gasthelizards.dmm
+++ b/_maps/RandomRuins/SpaceRuins/gasthelizards.dmm
@@ -352,9 +352,17 @@
 /area/ruin/space/has_grav/gasthelizard)
 "V" = (
 /obj/machinery/door/airlock/external,
+/obj/effect/mapping_helpers/airlock/cyclelink_helper,
 /turf/open/floor/plating,
 /area/ruin/space/has_grav/gasthelizard)
 "W" = (
+/turf/open/floor/plating,
+/area/ruin/space/has_grav/gasthelizard)
+"Z" = (
+/obj/machinery/door/airlock/external,
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 1
+	},
 /turf/open/floor/plating,
 /area/ruin/space/has_grav/gasthelizard)
 
@@ -452,7 +460,7 @@ B
 B
 V
 W
-V
+Z
 "}
 (7,1,1) = {"
 b

--- a/_maps/RandomRuins/SpaceRuins/gondolaasteroid.dmm
+++ b/_maps/RandomRuins/SpaceRuins/gondolaasteroid.dmm
@@ -79,6 +79,16 @@
 /obj/machinery/door/airlock/survival_pod/glass{
 	dir = 4
 	},
+/obj/effect/mapping_helpers/airlock/cyclelink_helper,
+/turf/open/floor/plating/asteroid/airless,
+/area/ruin/space/has_grav)
+"T" = (
+/obj/machinery/door/airlock/survival_pod/glass{
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 1
+	},
 /turf/open/floor/plating/asteroid/airless,
 /area/ruin/space/has_grav)
 
@@ -783,7 +793,7 @@ c
 c
 u
 c
-u
+T
 "}
 (20,1,1) = {"
 a

--- a/_maps/RandomRuins/SpaceRuins/mrow_thats_right.dmm
+++ b/_maps/RandomRuins/SpaceRuins/mrow_thats_right.dmm
@@ -104,6 +104,9 @@
 /area/ruin/space/has_grav/powered/cat_man)
 "au" = (
 /obj/machinery/door/airlock/external,
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 4
+	},
 /turf/open/floor/plating,
 /area/ruin/space/has_grav/powered/cat_man)
 "av" = (
@@ -856,6 +859,25 @@
 /obj/item/organ/tail/cat,
 /turf/open/floor/plasteel/freezer,
 /area/ruin/space/has_grav/powered/cat_man)
+"Bl" = (
+/obj/machinery/door/airlock/external,
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/ruin/space/has_grav/powered/cat_man)
+"RT" = (
+/obj/machinery/door/airlock/external,
+/obj/effect/mapping_helpers/airlock/cyclelink_helper,
+/turf/open/floor/plating,
+/area/ruin/space/has_grav/powered/cat_man)
+"Sl" = (
+/obj/machinery/door/airlock/external,
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/ruin/space/has_grav/powered/cat_man)
 
 (1,1,1) = {"
 aa
@@ -1090,7 +1112,7 @@ ad
 ad
 ad
 ad
-au
+Sl
 ad
 ad
 ad
@@ -1133,9 +1155,9 @@ ad
 bK
 aI
 aG
-au
+RT
 ah
-au
+Bl
 ac
 ac
 ac

--- a/_maps/RandomRuins/SpaceRuins/originalcontent.dmm
+++ b/_maps/RandomRuins/SpaceRuins/originalcontent.dmm
@@ -55,6 +55,7 @@
 /obj/structure/fluff/paper{
 	dir = 4
 	},
+/obj/effect/mapping_helpers/airlock/cyclelink_helper,
 /turf/open/indestructible/paper,
 /area/ruin/powered)
 "ak" = (
@@ -893,6 +894,22 @@
 	dir = 1
 	},
 /mob/living/simple_animal/hostile/stickman/ranged,
+/turf/open/indestructible/paper,
+/area/ruin/powered)
+"wr" = (
+/obj/machinery/door/airlock/freezer{
+	name = "airlock";
+	opacity = 0
+	},
+/obj/structure/fluff/paper{
+	dir = 8
+	},
+/obj/structure/fluff/paper{
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 1
+	},
 /turf/open/indestructible/paper,
 /area/ruin/powered)
 
@@ -2521,7 +2538,7 @@ aa
 ah
 aj
 an
-aj
+wr
 av
 ap
 ap

--- a/_maps/RandomRuins/SpaceRuins/spacehotel.dmm
+++ b/_maps/RandomRuins/SpaceRuins/spacehotel.dmm
@@ -3589,6 +3589,7 @@
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
+/obj/effect/mapping_helpers/airlock/cyclelink_helper,
 /turf/open/floor/plating,
 /area/ruin/space/has_grav/hotel/power)
 "kK" = (
@@ -4345,6 +4346,16 @@
 /obj/effect/baseturf_helper/space,
 /turf/closed/wall,
 /area/ruin/space/has_grav/hotel/pool)
+"sN" = (
+/obj/machinery/door/airlock/external/glass,
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/ruin/space/has_grav/hotel/power)
 
 (1,1,1) = {"
 aa
@@ -5376,7 +5387,7 @@ kg
 kw
 kJ
 la
-kJ
+sN
 aj
 aj
 al

--- a/_maps/RandomRuins/SpaceRuins/turretedoutpost.dmm
+++ b/_maps/RandomRuins/SpaceRuins/turretedoutpost.dmm
@@ -33,6 +33,9 @@
 /area/ruin/space/has_grav/turretedoutpost)
 "ai" = (
 /obj/machinery/door/airlock/external,
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 4
+	},
 /turf/open/floor/plating,
 /area/ruin/space/has_grav/turretedoutpost)
 "aj" = (
@@ -283,6 +286,13 @@
 	dir = 8
 	},
 /turf/open/floor/plasteel,
+/area/ruin/space/has_grav/turretedoutpost)
+"Nu" = (
+/obj/machinery/door/airlock/external,
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 8
+	},
+/turf/open/floor/plating,
 /area/ruin/space/has_grav/turretedoutpost)
 
 (1,1,1) = {"
@@ -710,8 +720,8 @@ ab
 ab
 ac
 ad
-ai
-ai
+Nu
+Nu
 ad
 ac
 ac

--- a/_maps/RandomRuins/SpaceRuins/whiteshipruin_box.dmm
+++ b/_maps/RandomRuins/SpaceRuins/whiteshipruin_box.dmm
@@ -294,6 +294,20 @@
 /obj/structure/light_construct,
 /turf/open/floor/mineral/titanium,
 /area/ruin/space/has_grav/whiteship/box)
+"Bc" = (
+/obj/machinery/door/airlock/titanium,
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 4
+	},
+/turf/open/floor/mineral/titanium,
+/area/ruin/space/has_grav/whiteship/box)
+"ML" = (
+/obj/machinery/door/airlock/titanium,
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 8
+	},
+/turf/open/floor/mineral/titanium,
+/area/ruin/space/has_grav/whiteship/box)
 
 (1,1,1) = {"
 aa
@@ -306,7 +320,7 @@ aa
 aa
 ab
 ab
-ac
+Bc
 ab
 ab
 aa
@@ -536,7 +550,7 @@ aa
 aa
 ab
 ab
-ac
+ML
 ab
 ab
 aa

--- a/_maps/RandomRuins/SpaceRuins/whiteshipruin_box.dmm
+++ b/_maps/RandomRuins/SpaceRuins/whiteshipruin_box.dmm
@@ -294,20 +294,6 @@
 /obj/structure/light_construct,
 /turf/open/floor/mineral/titanium,
 /area/ruin/space/has_grav/whiteship/box)
-"Bc" = (
-/obj/machinery/door/airlock/titanium,
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 4
-	},
-/turf/open/floor/mineral/titanium,
-/area/ruin/space/has_grav/whiteship/box)
-"ML" = (
-/obj/machinery/door/airlock/titanium,
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 8
-	},
-/turf/open/floor/mineral/titanium,
-/area/ruin/space/has_grav/whiteship/box)
 
 (1,1,1) = {"
 aa
@@ -320,7 +306,7 @@ aa
 aa
 ab
 ab
-Bc
+ac
 ab
 ab
 aa
@@ -550,7 +536,7 @@ aa
 aa
 ab
 ab
-ML
+ac
 ab
 ab
 aa


### PR DESCRIPTION
:cl: Denton
tweak: The outer airlocks of most space ruin airlocks are now cycle linked.
/:cl:

Cycle linking is wildly inconsistent; I linked most outer space ruin airlocks to fix that (except in places where it wouldn't make sense because airlocks are busted up/barricaded etc). 
The cyclelink mapping helper from #35674 made this pretty comfortable.
I'll give lavaland ruins a shot later.
