### PR TITLE
Cycle links pt.2: the linkening

### DIFF
--- a/_maps/RandomRuins/LavaRuins/lavaland_surface_biodome_winter.dmm
+++ b/_maps/RandomRuins/LavaRuins/lavaland_surface_biodome_winter.dmm
@@ -311,6 +311,9 @@
 "qt" = (
 /obj/machinery/door/airlock/silver,
 /obj/structure/fans/tiny,
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 8
+	},
 /turf/open/floor/pod/dark,
 /area/ruin/powered/snow_biodome)
 "tb" = (
@@ -382,6 +385,9 @@
 "PD" = (
 /obj/machinery/door/airlock/hatch,
 /obj/structure/fans/tiny,
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 4
+	},
 /turf/open/floor/pod/dark,
 /area/ruin/powered/snow_biodome)
 "PK" = (

--- a/_maps/RandomRuins/LavaRuins/lavaland_surface_golem_ship.dmm
+++ b/_maps/RandomRuins/LavaRuins/lavaland_surface_golem_ship.dmm
@@ -205,6 +205,14 @@
 /obj/machinery/light/small,
 /turf/open/floor/plating,
 /area/ruin/powered/golem_ship)
+"K" = (
+/obj/machinery/door/airlock/titanium,
+/obj/structure/fans/tiny,
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 8
+	},
+/turf/open/floor/mineral/titanium/purple,
+/area/ruin/powered/golem_ship)
 "L" = (
 /obj/machinery/light/small{
 	dir = 1
@@ -249,6 +257,13 @@
 	dir = 1
 	},
 /turf/open/floor/plating,
+/area/ruin/powered/golem_ship)
+"Y" = (
+/obj/machinery/door/airlock/titanium,
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 4
+	},
+/turf/open/floor/mineral/titanium/purple,
 /area/ruin/powered/golem_ship)
 
 (1,1,1) = {"
@@ -565,8 +580,8 @@ b
 n
 l
 b
-j
-j
+Y
+Y
 b
 x
 D
@@ -601,8 +616,8 @@ b
 i
 i
 b
-H
-H
+K
+K
 b
 i
 i

--- a/_maps/RandomRuins/LavaRuins/lavaland_surface_seed_vault.dmm
+++ b/_maps/RandomRuins/LavaRuins/lavaland_surface_seed_vault.dmm
@@ -61,6 +61,9 @@
 "m" = (
 /obj/machinery/door/airlock/external,
 /obj/structure/fans/tiny,
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 8
+	},
 /turf/open/floor/plasteel/freezer,
 /area/ruin/powered/seedvault)
 "n" = (
@@ -151,6 +154,9 @@
 /area/ruin/powered/seedvault)
 "z" = (
 /obj/machinery/door/airlock/external,
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 4
+	},
 /turf/open/floor/plasteel/freezer,
 /area/ruin/powered/seedvault)
 "B" = (

--- a/_maps/shuttles/mining_delta.dmm
+++ b/_maps/shuttles/mining_delta.dmm
@@ -80,6 +80,9 @@
 	port_direction = 8;
 	width = 7
 	},
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 4
+	},
 /turf/open/floor/plasteel/white,
 /area/shuttle/mining)
 "j" = (
@@ -108,6 +111,9 @@
 	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 8
 	},
 /turf/open/floor/plasteel/white,
 /area/shuttle/mining)

--- a/_maps/shuttles/whiteship_box.dmm
+++ b/_maps/shuttles/whiteship_box.dmm
@@ -314,20 +314,6 @@
 	},
 /turf/open/floor/mineral/titanium,
 /area/shuttle/abandoned)
-"Ur" = (
-/obj/machinery/door/airlock/titanium,
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 4
-	},
-/turf/open/floor/mineral/titanium,
-/area/shuttle/abandoned)
-"Zp" = (
-/obj/machinery/door/airlock/titanium,
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 8
-	},
-/turf/open/floor/mineral/titanium,
-/area/shuttle/abandoned)
 
 (1,1,1) = {"
 aa
@@ -340,7 +326,7 @@ aa
 aa
 ac
 ac
-Ur
+af
 ac
 ac
 aa
@@ -580,7 +566,7 @@ aa
 aa
 ac
 ac
-Zp
+af
 ac
 ac
 aa

--- a/_maps/shuttles/whiteship_box.dmm
+++ b/_maps/shuttles/whiteship_box.dmm
@@ -314,6 +314,20 @@
 	},
 /turf/open/floor/mineral/titanium,
 /area/shuttle/abandoned)
+"Ur" = (
+/obj/machinery/door/airlock/titanium,
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 4
+	},
+/turf/open/floor/mineral/titanium,
+/area/shuttle/abandoned)
+"Zp" = (
+/obj/machinery/door/airlock/titanium,
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 8
+	},
+/turf/open/floor/mineral/titanium,
+/area/shuttle/abandoned)
 
 (1,1,1) = {"
 aa
@@ -326,7 +340,7 @@ aa
 aa
 ac
 ac
-af
+Ur
 ac
 ac
 aa
@@ -566,7 +580,7 @@ aa
 aa
 ac
 ac
-af
+Zp
 ac
 ac
 aa

--- a/_maps/shuttles/whiteship_meta.dmm
+++ b/_maps/shuttles/whiteship_meta.dmm
@@ -17,6 +17,7 @@
 	desc = "A thin layer of dust coating the floor.";
 	name = "dust"
 	},
+/obj/effect/mapping_helpers/airlock/cyclelink_helper,
 /turf/open/floor/mineral/titanium/blue,
 /area/shuttle/abandoned)
 "ae" = (
@@ -41,6 +42,7 @@
 	preferred_direction = 4;
 	width = 28
 	},
+/obj/effect/mapping_helpers/airlock/cyclelink_helper,
 /turf/open/floor/mineral/titanium/blue,
 /area/shuttle/abandoned)
 "ag" = (
@@ -599,6 +601,9 @@
 	desc = "A thin layer of dust coating the floor.";
 	name = "dust"
 	},
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 1
+	},
 /turf/open/floor/mineral/titanium/blue,
 /area/shuttle/abandoned)
 "aY" = (
@@ -815,6 +820,9 @@
 /obj/effect/decal/cleanable/dirt{
 	desc = "A thin layer of dust coating the floor.";
 	name = "dust"
+	},
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 8
 	},
 /turf/open/floor/mineral/titanium/blue,
 /area/shuttle/abandoned)
@@ -1625,6 +1633,19 @@
 	},
 /turf/open/floor/mineral/titanium,
 /area/shuttle/abandoned)
+"YT" = (
+/obj/machinery/door/airlock/titanium{
+	name = "recovery shuttle external airlock"
+	},
+/obj/effect/decal/cleanable/dirt{
+	desc = "A thin layer of dust coating the floor.";
+	name = "dust"
+	},
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 4
+	},
+/turf/open/floor/mineral/titanium/blue,
+/area/shuttle/abandoned)
 
 (1,1,1) = {"
 aa
@@ -1634,7 +1655,7 @@ aa
 aa
 ab
 ab
-ad
+YT
 ab
 ab
 aa


### PR DESCRIPTION
:cl: Denton
tweak: The outer airlocks of various lavaland ruins and ships now cycle lock.
/:cl:

Continuation of #35870
This cycle links the outer airlocks of: free golem ship, podpeople seed vault, winter biodome, delta mining shuttle, meta white ship and the boxstation white ship.