### PR TITLE
Admin-only extended AND speedy versions of revs

### DIFF
--- a/code/game/gamemodes/revolution/extended_revolution.dm
+++ b/code/game/gamemodes/revolution/extended_revolution.dm
@@ -1,4 +1,0 @@
-/datum/game_mode/revolution/extended
-	name = "extended_revolution"
-	config_tag = "extended_revolution"
-  end_when_heads_dead = FALSE

--- a/code/game/gamemodes/revolution/extended_revolution.dm
+++ b/code/game/gamemodes/revolution/extended_revolution.dm
@@ -1,0 +1,4 @@
+/datum/game_mode/revolution/extended
+	name = "extended_revolution"
+	config_tag = "extended_revolution"
+  end_when_heads_dead = FALSE

--- a/code/game/gamemodes/revolution/revolution.dm
+++ b/code/game/gamemodes/revolution/revolution.dm
@@ -203,7 +203,6 @@
 	end_when_heads_dead = FALSE
 	var/endtime = null
 	var/fuckingdone = FALSE
-	end_when_heads_dead = FALSE
 
 /datum/game_mode/revolution/speedy/pre_setup()
 	endtime = world.time + 20 MINUTES

--- a/code/game/gamemodes/revolution/revolution.dm
+++ b/code/game/gamemodes/revolution/revolution.dm
@@ -28,6 +28,7 @@
 	var/max_headrevs = 3
 	var/datum/team/revolution/revolution
 	var/list/datum/mind/headrev_candidates = list()
+	var/end_when_heads_dead = TRUE
 
 ///////////////////////////
 //Announces the game type//
@@ -135,7 +136,7 @@
 		if(finished)
 			SSshuttle.clearHostileEnvironment(src)
 		return ..()
-	if(finished != 0)
+	if(finished != 0 && end_when_heads_dead)
 		return TRUE
 	else
 		return ..()
@@ -190,3 +191,8 @@
 	return "Employee unrest has spiked in recent weeks, with several attempted mutinies on heads of staff. Some crew have been observed using flashbulb devices to blind their colleagues, \
 		who then follow their orders without question and work towards dethroning departmental leaders. Watch for behavior such as this with caution. If the crew attempts a mutiny, you and \
 		your heads of staff are fully authorized to execute them using lethal weaponry - they will be later cloned and interrogated at Central Command."
+
+/datum/game_mode/revolution/extended
+	name = "extended_revolution"
+	config_tag = "extended_revolution"
+	end_when_heads_dead = FALSE

--- a/code/game/gamemodes/revolution/revolution.dm
+++ b/code/game/gamemodes/revolution/revolution.dm
@@ -196,3 +196,26 @@
 	name = "extended_revolution"
 	config_tag = "extended_revolution"
 	end_when_heads_dead = FALSE
+
+/datum/game_mode/revolution/speedy
+	name = "speedy_revolution"
+	config_tag = "speedy_revolution"
+	end_when_heads_dead = FALSE
+	var/endtime = null
+	var/fuckingdone = FALSE
+	end_when_heads_dead = FALSE
+
+/datum/game_mode/revolution/speedy/pre_setup()
+	endtime = world.time + 20 MINUTES
+	return ..()
+
+/datum/game_mode/revolution/speedy/process()
+	. = ..()
+	if(check_counter == 0)
+		if (world.time > endtime && !fuckingdone)
+			fuckingdone = TRUE
+			for (var/obj/machinery/nuclearbomb/N in GLOB.nuke_list)
+				if (!N.timing)
+					N.timer_set = 200
+					N.set_safety()
+					N.set_active()


### PR DESCRIPTION
:cl: Naksu
admin: Admins can now start the game as extended revs, a version of revs that doesn't end when head(rev)s are dead. Admins can also use the speedy mode, which nukes the station after 20 minutes.
/:cl:

~~Not really 100% on these changes but it's probably close enough, maybe someone who knows more about gamemode code can review it.~~ seems to work? also an existing roudn of revs can be converted into extended revs by means of varediting SSticker.mode

Requested by admins vOv