### PR TITLE
Fixes players killing themselves by whispering inside clone pods

### DIFF
--- a/code/game/machinery/cloning.dm
+++ b/code/game/machinery/cloning.dm
@@ -44,8 +44,8 @@
 		"salbutamol", // anti-oxyloss
 		"bicaridine", // NOBREATHE species take brute in crit
 		"corazone", // prevents cardiac arrest and liver failure damage
-		"mimesbane") // stops them gasping from lack of air.
-
+		"mimesbane", // stops them gasping from lack of air.
+		"mutetoxin") // stops them from killing themselves BY DEATHWHISPERING INSIDE A CLONE POD NICE JOB BREAKING IT HERO
 /obj/machinery/clonepod/Initialize()
 	. = ..()
 


### PR DESCRIPTION
:cl: Denton
fix: Players can no longer kill themselves by whispering inside clone pods.
/:cl:

Ok that was almost too funny to fix.
Keep in mind that this is kind of a bandaid fix since I couldn't code my way out of a paper bag.

Closes: #35851