### PR TITLE
Makes the detective's flask more noir-noire-noided

### DIFF
--- a/code/modules/food_and_drinks/drinks/drinks.dm
+++ b/code/modules/food_and_drinks/drinks/drinks.dm
@@ -317,7 +317,7 @@
 	name = "detective's flask"
 	desc = "The detective's only true friend."
 	icon_state = "detflask"
-	list_reagents = list("hearty_punch" = 30)
+	list_reagents = list("whiskey" = 30)
 
 /obj/item/reagent_containers/food/drinks/britcup
 	name = "cup"


### PR DESCRIPTION
Changes detective contents from hearty punch to a more appropriately noire drink

:cl: Repukan
add: Whiskey to the flask
del: Hearty Punch from the flask
/:cl:

This could make you drunk enough to console you from the nerf it is.