### PR TITLE
Black Fedora opens its inventory on-click like the Detective's Fedora

### DIFF
--- a/code/game/objects/items/storage/internal.dm
+++ b/code/game/objects/items/storage/internal.dm
@@ -34,7 +34,7 @@
 
 /obj/item/storage/internal/pocket/small
 	storage_slots = 1
-	priority = FALSE
+	priority = TRUE
 
 /obj/item/storage/internal/pocket/tiny
 	storage_slots = 1

--- a/code/game/objects/items/storage/internal.dm
+++ b/code/game/objects/items/storage/internal.dm
@@ -34,7 +34,6 @@
 
 /obj/item/storage/internal/pocket/small
 	storage_slots = 1
-	priority = TRUE
 
 /obj/item/storage/internal/pocket/tiny
 	storage_slots = 1


### PR DESCRIPTION
**Tweak:** 
Instead of having to drag the sprite to your character to access its inventory, behaves the same as the Detective's Fedora opening its container on click. Considering some dets prefer the black variation for noir flavour rather than the brown standard one they just have to pass his flask from one hat to another and keep the same functionality. They cannot either draw candy corn from it nor alt click to quickly remove contents though, considering the Black Fedora also spawns on the bar on Metastation.
I had either this in mind or creating a new black detective's fedora variant on the det's cabinet that also had the flask inside it.

:cl:
tweak: Tweaked the inventory management of the black fedora to be more like the detective's
/:cl: