### PR TITLE
Fixes Guardian Spirits not being able to move in stopped time along with their user.

### DIFF
--- a/code/modules/fields/timestop.dm
+++ b/code/modules/fields/timestop.dm
@@ -27,6 +27,9 @@
 	for(var/mob/living/L in GLOB.player_list)
 		if(locate(/obj/effect/proc_holder/spell/aoe_turf/conjure/timestop) in L.mind.spell_list) //People who can stop time are immune to its effects
 			immune[L] = TRUE
+	for(var/mob/living/simple_animal/hostile/guardian in GLOB.parasites)
+		if(locate(/obj/effect/proc_holder/spell/aoe_turf/conjure/timestop) in summoner.mind.spell_list) //It would only make sense that a person's stand would also be immune.
+			immune[guardian] = TRUE
 	if(start)
 		timestop()
 

--- a/code/modules/fields/timestop.dm
+++ b/code/modules/fields/timestop.dm
@@ -27,9 +27,9 @@
 	for(var/mob/living/L in GLOB.player_list)
 		if(locate(/obj/effect/proc_holder/spell/aoe_turf/conjure/timestop) in L.mind.spell_list) //People who can stop time are immune to its effects
 			immune[L] = TRUE
-	for(var/mob/living/simple_animal/hostile/guardian in GLOB.parasites)
+	for(var/mob/living/simple_animal/hostile/guardian/G in GLOB.parasites)
 		if(locate(/obj/effect/proc_holder/spell/aoe_turf/conjure/timestop) in summoner.mind.spell_list) //It would only make sense that a person's stand would also be immune.
-			immune[guardian] = TRUE
+			immune[G] = TRUE
 	if(start)
 		timestop()
 

--- a/code/modules/fields/timestop.dm
+++ b/code/modules/fields/timestop.dm
@@ -28,7 +28,7 @@
 		if(locate(/obj/effect/proc_holder/spell/aoe_turf/conjure/timestop) in L.mind.spell_list) //People who can stop time are immune to its effects
 			immune[L] = TRUE
 	for(var/mob/living/simple_animal/hostile/guardian/G in GLOB.parasites)
-		if(locate(/obj/effect/proc_holder/spell/aoe_turf/conjure/timestop) in summoner.mind.spell_list) //It would only make sense that a person's stand would also be immune.
+		if(locate(/obj/effect/proc_holder/spell/aoe_turf/conjure/timestop) in var/mob/living/summoner.mind.spell_list) //It would only make sense that a person's stand would also be immune.
 			immune[G] = TRUE
 	if(start)
 		timestop()

--- a/code/modules/fields/timestop.dm
+++ b/code/modules/fields/timestop.dm
@@ -28,7 +28,7 @@
 		if(locate(/obj/effect/proc_holder/spell/aoe_turf/conjure/timestop) in L.mind.spell_list) //People who can stop time are immune to its effects
 			immune[L] = TRUE
 	for(var/mob/living/simple_animal/hostile/guardian/G in GLOB.parasites)
-		if(locate(/obj/effect/proc_holder/spell/aoe_turf/conjure/timestop) in var/mob/living/summoner.mind.spell_list) //It would only make sense that a person's stand would also be immune.
+		if(G.summoner && locate(/obj/effect/proc_holder/spell/aoe_turf/conjure/timestop) in G.summoner.mind.spell_list) //It would only make sense that a person's stand would also be immune.
 			immune[G] = TRUE
 	if(start)
 		timestop()


### PR DESCRIPTION
First PR, hooray for shit code. 

**I think this works, but I have no way of testing locally due to Guardian's two-player interaction.**

**EDIT: It did not work.**
**EDIT 2: It now does.**

:cl: Potato Masher
fix: The Wizard Federation has finally modified their production method for pre-packaged magic tarot cards for better compatibility with time-stopping spells. Guardians Spirits are no longer frozen by their user's time-stops.
/:cl:

![6e59f0e0017f8ae6eed32d8507ef75b0](https://user-images.githubusercontent.com/33107541/36523210-7ec3d168-176e-11e8-944e-dd34db054191.jpg)

**Why:** This fix would make guardians be a little bit more in line with the whole "whatever affects the guardian affects the user" thing for consistency sake and make them just a little more useful.
On the topic of balance, this shouldn't be too bad. Just compare it to other options a wizard could deploy during a time-stop: 

>Disintegrate

Please note that attacking a time stop wizard with your own guardian (looking at you, miners) is still going to have both you and your guardian frozen as usual. You have to have the time stop spell learned to avoid it.



