### PR TITLE
Toxinloving species don't have livers

### DIFF
--- a/code/modules/mob/living/carbon/human/species.dm
+++ b/code/modules/mob/living/carbon/human/species.dm
@@ -150,7 +150,7 @@ GLOBAL_LIST_EMPTY(roundstart_races)
 	var/should_have_eyes = TRUE
 	var/should_have_ears = TRUE
 	var/should_have_tongue = TRUE
-	var/should_have_liver = !(NOLIVER in species_traits)
+	var/should_have_liver = (!(NOLIVER in species_traits) || !(TOXINLOVER in species_traits))
 	var/should_have_stomach = !(NOSTOMACH in species_traits)
 	var/should_have_tail = mutanttail
 

--- a/code/modules/mob/living/carbon/life.dm
+++ b/code/modules/mob/living/carbon/life.dm
@@ -405,7 +405,7 @@
 
 /mob/living/carbon/proc/handle_liver()
 	var/obj/item/organ/liver/liver = getorganslot(ORGAN_SLOT_LIVER)
-	if((!dna && !liver) || (NOLIVER in dna.species.species_traits))
+	if((!dna && !liver) || (NOLIVER in dna.species.species_traits) || (TOXINLOVER in dna.species.species_traits))
 		return
 	if(liver)
 		if(liver.damage >= 100)

--- a/code/modules/surgery/organs/organ_internal.dm
+++ b/code/modules/surgery/organs/organ_internal.dm
@@ -114,7 +114,7 @@
 			breathes = FALSE
 		if(NOBLOOD in dna.species.species_traits)
 			blooded = FALSE
-		var/has_liver = (!(NOLIVER in dna.species.species_traits))
+		var/has_liver = (!(NOLIVER in dna.species.species_traits) || !(TOXINLOVER in dna.species.species_traits))
 		var/has_stomach = (!(NOSTOMACH in dna.species.species_traits))
 
 		if(has_liver && !getorganslot(ORGAN_SLOT_LIVER))


### PR DESCRIPTION
:cl: Cebutris
tweak: Toxin loving species should no longer have livers
/:cl:

[why]: Toxin loving species get healed from toxin and hurt from antitoxin. They also have livers, which, when removed, deals constant toxin damage, giving them passive toxin damage regeneration. 

This PR makes checks for TOXINLOVER in addition to NOLIVER. An alternative would just be to give NOLIVER to species with TOXINLOVER but this futureproofs it a little
