### PR TITLE
Toxin lovers properly take toxin damage from liver failure

### DIFF
--- a/code/modules/mob/living/carbon/life.dm
+++ b/code/modules/mob/living/carbon/life.dm
@@ -435,10 +435,7 @@
 	if(reagents.get_reagent_amount("corazone"))//corazone is processed here an not in the liver because a failing liver can't metabolize reagents
 		reagents.remove_reagent("corazone", 0.4) //corazone slowly deletes itself.
 		return
-	if(TOXINLOVER in dna.species.species_traits)
-		adjustToxLoss(-8)
-	else
-		adjustToxLoss(8)
+	adjustToxLoss(8, TRUE, TRUE)
 	if(prob(30))
 		to_chat(src, "<span class='notice'>You feel confused and nauseous...</span>")//actual symptoms of liver failure
 

--- a/code/modules/mob/living/carbon/life.dm
+++ b/code/modules/mob/living/carbon/life.dm
@@ -435,7 +435,10 @@
 	if(reagents.get_reagent_amount("corazone"))//corazone is processed here an not in the liver because a failing liver can't metabolize reagents
 		reagents.remove_reagent("corazone", 0.4) //corazone slowly deletes itself.
 		return
-	adjustToxLoss(8)
+	if(TOXINLOVER in dna.species.species_traits)
+		adjustToxLoss(-8)
+	else
+		adjustToxLoss(8)
 	if(prob(30))
 		to_chat(src, "<span class='notice'>You feel confused and nauseous...</span>")//actual symptoms of liver failure
 


### PR DESCRIPTION
:cl: Cebutris
tweak: Toxin loving species now properly take toxin damage from liver failiure
/:cl:

[why]: Toxin loving species are immune to toxins, with the downside of being damaged by antitoxin. Removing their livers currently constantly gives them toxin damage, and quite a lot of it, making toxin damage from antitoxins negligible 