### PR TITLE
Bath Salts now induce psychotic rage, but cause much more brain damage

### DIFF
--- a/code/datums/brain_damage/special.dm
+++ b/code/datums/brain_damage/special.dm
@@ -130,3 +130,6 @@
 	..()
 	psychotic_brawling.remove(owner)
 	QDEL_NULL(psychotic_brawling)
+
+/datum/brain_trauma/special/psychotic_brawling/bath_salts
+	name = "Chemical Violent Psychosis"

--- a/code/modules/reagents/chemistry/reagents/drug_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/drug_reagents.dm
@@ -258,12 +258,20 @@
 		var/mob/living/L = M
 		L.add_trait(TRAIT_STUNIMMUNE, id)
 		L.add_trait(TRAIT_SLEEPIMMUNE, id)
+		if(iscarbon(L))
+			var/mob/living/carbon/C = L
+			C.gain_trauma(/datum/brain_trauma/special/psychotic_brawling, TRAUMA_RESILIENCE_LOBOTOMY)
 
 /datum/reagent/drug/bath_salts/on_mob_delete(mob/M)
 	if(isliving(M))
 		var/mob/living/L = M
 		L.remove_trait(TRAIT_STUNIMMUNE, id)
 		L.remove_trait(TRAIT_SLEEPIMMUNE, id)
+		if(iscarbon(L))
+			var/mob/living/carbon/C = L
+			for(var/datum/brain_trauma/special/psychotic_brawling/T in C.get_traumas())
+				if(T.resilience == TRAUMA_RESILIENCE_LOBOTOMY)
+					qdel(T)
 	..()
 
 /datum/reagent/drug/bath_salts/on_mob_life(mob/living/M)
@@ -271,8 +279,7 @@
 	if(prob(5))
 		to_chat(M, "<span class='notice'>[high_message]</span>")
 	M.adjustStaminaLoss(-5, 0)
-	M.adjustBrainLoss(0.5)
-	M.adjustToxLoss(0.1, 0)
+	M.adjustBrainLoss(4)
 	M.hallucination += 10
 	if(M.canmove && !ismovableatom(M.loc))
 		step(M, pick(GLOB.cardinals))

--- a/code/modules/reagents/chemistry/reagents/drug_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/drug_reagents.dm
@@ -260,7 +260,7 @@
 		L.add_trait(TRAIT_SLEEPIMMUNE, id)
 		if(iscarbon(L))
 			var/mob/living/carbon/C = L
-			C.gain_trauma(/datum/brain_trauma/special/psychotic_brawling, TRAUMA_RESILIENCE_LOBOTOMY)
+			C.gain_trauma(/datum/brain_trauma/special/psychotic_brawling/bath_salts, TRAUMA_RESILIENCE_ABSOLUTE)
 
 /datum/reagent/drug/bath_salts/on_mob_delete(mob/M)
 	if(isliving(M))
@@ -269,9 +269,8 @@
 		L.remove_trait(TRAIT_SLEEPIMMUNE, id)
 		if(iscarbon(L))
 			var/mob/living/carbon/C = L
-			for(var/datum/brain_trauma/special/psychotic_brawling/T in C.get_traumas())
-				if(T.resilience == TRAUMA_RESILIENCE_LOBOTOMY)
-					qdel(T)
+			for(var/datum/brain_trauma/special/psychotic_brawling/bath_salts/T in C.get_traumas())
+				qdel(T)
 	..()
 
 /datum/reagent/drug/bath_salts/on_mob_life(mob/living/M)


### PR DESCRIPTION
:cl: XDTM
tweak: Bath Salts now induce psychotic rage, but cause much more brain damage.
/:cl:

To be exact, they now inflict the psychotic brawling special trauma as long as it's in the body.
Brain damage is now 4 per tick (8x the previous value, which was hilariously low for how strong the drug is).
Also removed the 0.1 tox loss which seems pretty much pointless.
