### PR TITLE
Readjusts doppler array formula for thermonuclear explosions

### DIFF
--- a/code/game/machinery/doppler_array.dm
+++ b/code/game/machinery/doppler_array.dm
@@ -110,23 +110,21 @@ GLOBAL_LIST_EMPTY(doppler_arrays)
 	if(!istype(linked_techweb))
 		say("Warning: No linked research system!")
 		return
-	var/adjusted = orig_light - 10 - linked_techweb.max_bomb_value
+	var/adjusted = orig_light - 10
 	if(adjusted <= 0)
 		say("Explosion not large enough for research calculations.")
 		return
-	var/point_gain = techweb_scale_bomb(adjusted)
+	var/point_gain = techweb_scale_bomb(adjusted) - techweb_scale_bomb(linked_techweb.max_bomb_value)
 	if(point_gain <= 0)
 		say("Explosion not large enough for research calculations.")
 		return
-	linked_techweb.max_bomb_value = orig_light - 10
+	linked_techweb.max_bomb_value = adjusted
 	linked_techweb.research_points += point_gain
 	say("Gained [point_gain] points from explosion dataset.")
-
-/obj/machinery/doppler_array/research/science
 
 /obj/machinery/doppler_array/research/science/Initialize()
 	. = ..()
 	linked_techweb = SSresearch.science_tech
 
 /proc/techweb_scale_bomb(lightradius)
-	return (lightradius ** 0.5) * 5000
+	return (lightradius ** 0.5) * 3000


### PR DESCRIPTION
:cl:
tweak: The last scientists have reported that thermonuclear blasts triggered by so called 'power gamers' have shorted the doppler array. We've readjusted the ALU and are confident that this will not happen again.
/:cl:

![bombs](https://user-images.githubusercontent.com/9559216/36567746-d04228be-1827-11e8-8b85-13f45f022b1d.png)

The formula now returns the delta between the total points generated and the points that would be generated by the bomb. aka the above graph now statically applies whether you detonate the smaller bomb first or last, the downside being that improving your bomb will still reward you but with significantly less points than before. 

I've also adjusted the multiplier so ash proton can't max research by detonating one of his thermonuclear bombs, I've marked a maxcap bomb, and a 700 and 1000 radius bomb on the graph with horizontal lines. I'm sure you can figure it out yourself.

Feedback welcome.

fixes #35909 