### PR TITLE
removes inaccurate comment for item/proc/equipped

### DIFF
--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -428,7 +428,7 @@ GLOBAL_VAR_INIT(rpg_loot_items, FALSE)
 /obj/item/proc/on_found(mob/finder)
 	return
 
-// called after an item is placed in an equipment slot //NOPE, for example, if you put a helmet in slot_head, it is NOT in user's head variable yet, how stupid.
+// called after an item is placed in an equipment slot
 // user is mob that equipped it
 // slot uses the slot_X defines found in setup.dm
 // for items that can be placed in multiple slots


### PR DESCRIPTION
As you can see below, equipped is called after the slot vars are assigned, where applicable

https://github.com/tgstation/tgstation/blob/e666bc63e13580260d2342009a97f383c77c9dff/code/modules/mob/inventory.dm#L176-L179
https://github.com/tgstation/tgstation/blob/e666bc63e13580260d2342009a97f383c77c9dff/code/modules/mob/living/carbon/inventory.dm#L52-L87
https://github.com/tgstation/tgstation/blob/e666bc63e13580260d2342009a97f383c77c9dff/code/modules/mob/living/carbon/human/inventory.dm#L86-L142