### PR TITLE
Fixes hitscans, and this time, properly

### DIFF
--- a/code/modules/projectiles/guns/beam_rifle.dm
+++ b/code/modules/projectiles/guns/beam_rifle.dm
@@ -484,11 +484,9 @@
 	if(!do_pierce)
 		return FALSE
 	if(pierced[target])		//we already pierced them go away
-		forceMove(get_turf(target))
 		return TRUE
 	if(isclosedturf(target))
 		if(wall_pierce++ < wall_pierce_amount)
-			forceMove(target)
 			if(prob(wall_devastate))
 				if(iswallturf(target))
 					var/turf/closed/wall/W = target
@@ -504,7 +502,6 @@
 					var/obj/O = AM
 					O.take_damage((impact_structure_damage + aoe_structure_damage) * structure_bleed_coeff * get_damage_coeff(AM), BURN, "energy", FALSE)
 				pierced[AM] = TRUE
-				forceMove(AM.drop_location())
 				structure_pierce++
 				return TRUE
 	return FALSE
@@ -539,6 +536,9 @@
 /obj/item/projectile/beam/beam_rifle/Collide(atom/target)
 	if(check_pierce(target))
 		permutated += target
+		trajectory_ignore_forcemove = TRUE
+		forceMove(target)
+		trajectory_ignore_forcemove = FALSE
 		return FALSE
 	if(!QDELETED(target))
 		cached = get_turf(target)
@@ -556,7 +556,7 @@
 	tracer_type = /obj/effect/projectile/tracer/tracer/beam_rifle
 	var/constant_tracer = FALSE
 
-/obj/item/projectile/beam/beam_rifle/hitscan/generate_hitscan_tracers(cleanup = TRUE, duration = 5, highlander)
+/obj/item/projectile/beam/beam_rifle/hitscan/generate_hitscan_tracers(cleanup = TRUE, duration = 5, impacting = TRUE, highlander)
 	set waitfor = FALSE
 	if(isnull(highlander))
 		highlander = constant_tracer

--- a/code/modules/projectiles/projectile.dm
+++ b/code/modules/projectiles/projectile.dm
@@ -347,7 +347,9 @@
 		var/matrix/M = new
 		M.Turn(Angle)
 		transform = M
+	trajectory_ignore_forcemove = TRUE
 	forceMove(starting)
+	trajectory_ignore_forcemove = FALSE
 	trajectory = new(starting.x, starting.y, starting.z, 0, 0, Angle, pixel_speed)
 	last_projectile_move = world.time
 	fired = TRUE
@@ -368,17 +370,19 @@
 	return TRUE
 
 /obj/item/projectile/forceMove(atom/target)
-	var/zc = target.z == z
+	if(!isloc(target) || !isloc(loc) || !z)
+		return ..()
+	var/zc = target.z != z
 	var/old = loc
 	if(zc)
 		before_z_change(old, target)
-	if(hitscan)
-		finalize_hitscan_and_generate_tracers(FALSE)
 	. = ..()
 	if(trajectory && !trajectory_ignore_forcemove && isturf(target))
+		if(hitscan)
+			finalize_hitscan_and_generate_tracers(FALSE)
 		trajectory.initialize_location(target.x, target.y, target.z, 0, 0)
-	if(hitscan)
-		record_hitscan_start(RETURN_PRECISE_POINT(src))
+		if(hitscan)
+			record_hitscan_start(RETURN_PRECISE_POINT(src))
 	if(zc)
 		after_z_change(old, target)
 
@@ -445,7 +449,9 @@
 /obj/item/projectile/proc/preparePixelProjectile(atom/target, atom/source, params, spread = 0)
 	var/turf/curloc = get_turf(source)
 	var/turf/targloc = get_turf(target)
+	trajectory_ignore_forcemove = TRUE
 	forceMove(get_turf(source))
+	trajectory_ignore_forcemove = FALSE
 	starting = get_turf(source)
 	original = target
 	if(targloc || !params)
@@ -510,8 +516,8 @@
 	if(hitscan)
 		finalize_hitscan_and_generate_tracers()
 	STOP_PROCESSING(SSprojectiles, src)
-	qdel(trajectory)
 	cleanup_beam_segments()
+	qdel(trajectory)
 	return ..()
 
 /obj/item/projectile/proc/cleanup_beam_segments()

--- a/code/modules/reagents/chemistry/reagents/medicine_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/medicine_reagents.dm
@@ -1272,4 +1272,4 @@
 			M.adjustStaminaLoss(1.5*REM, 0)
 	..()
 	. = 1
-  
+


### PR DESCRIPTION
I made 3-4 webeditor changes to the last one without testing and told @vuonojenmustaturska that it worked and now I feel bad.
This is not webeditor'd and properly tested.
Fixes beam rifles drawing multiple beams when piercing things instead of just one tracer
Fixes hitscans generating a runtime when traversing Zlevels/forcemoving (still moved fined though.)