### PR TITLE
Heart Attack Event Actually Works Now

### DIFF
--- a/code/datums/diseases/heart_failure.dm
+++ b/code/datums/diseases/heart_failure.dm
@@ -5,7 +5,7 @@
 	stage_prob = 2
 	cure_text = "Heart replacement surgery to cure. Defibrillation (or as a last resort, uncontrolled electric shocking) may also be effective after the onset of cardiac arrest. Corazone can also mitigate cardiac arrest."
 	agent = "Shitty Heart"
-	viable_mobtypes = list(/mob/living/carbon)
+	viable_mobtypes = list(/mob/living/carbon/human)
 	permeability_mod = 1
 	desc = "If left untreated the subject will die!"
 	severity = "Dangerous!"
@@ -13,6 +13,7 @@
 	spread_flags = VIRUS_SPREAD_NON_CONTAGIOUS
 	visibility_flags = HIDDEN_PANDEMIC
 	required_organs = list(/obj/item/organ/heart)
+	bypasses_immunity = TRUE // Immunity is based on not having an appendix; this isn't a virus
 	var/sound = FALSE
 
 /datum/disease/heart_failure/stage_act()

--- a/code/modules/events/heart_attack.dm
+++ b/code/modules/events/heart_attack.dm
@@ -7,16 +7,16 @@
 
 /datum/round_event/heart_attack/start()
 	var/list/heart_attack_contestants = list()
-	for(var/mob/living/carbon/H in shuffle(GLOB.player_list))
+	for(var/mob/living/carbon/human/H in shuffle(GLOB.player_list))
 		if(!H.client || H.stat == DEAD || H.InCritical() || !H.can_heartattack() || H.has_status_effect(STATUS_EFFECT_EXERCISED) || (/datum/disease/heart_failure in H.viruses) || H.undergoing_cardiac_arrest())
 			continue
-		if(H.satiety <= -100)
-			heart_attack_contestants[H] = 1.15
+		if(H.satiety <= -60) //Multiple junk food items recently
+			heart_attack_contestants[H] = 3
 		else
 			heart_attack_contestants[H] = 1
 
 	if(LAZYLEN(heart_attack_contestants))
-		var/mob/living/carbon/C = pickweight(heart_attack_contestants)
+		var/mob/living/carbon/human/winner = pickweight(heart_attack_contestants)
 		var/datum/disease/D = new /datum/disease/heart_failure
-		C.ForceContractDisease(D)
-		notify_ghosts("[C] is beginning to have a heart attack!", enter_link="<a href=?src=[REF(C)];orbit=1>(Click to orbit)</a>", source=C, action=NOTIFY_ORBIT)
+		winner.ForceContractDisease(D)
+		notify_ghosts("[winner] is beginning to have a heart attack!", enter_link="<a href=?src=[REF(src)];orbit=1>(Click to orbit)</a>", source=winner, action=NOTIFY_ORBIT)


### PR DESCRIPTION
:cl: Robustin
fix: The heart attack event will now actually make the victim acquire the heart disease
fix: Clicking the chatbox link will let you orbit the victim
tweak: The event is now significantly more sensitive to junk food. Recent consumption of multiple junk food items will triple your chances of having a heart attack (exercise will still block it). 
/:cl:

Someone else can explain why humans couldn't get a disease with mobtype 'carbon', all I know is that it fixed the ForceContractDisease returning FALSE on humans. 

Fixes #35615
Closes #35889 