### PR TITLE
Blood Cult Conversion Fixes

### DIFF
--- a/code/modules/antagonists/cult/blood_magic.dm
+++ b/code/modules/antagonists/cult/blood_magic.dm
@@ -525,7 +525,7 @@
 	. = ..()
 
 
-//Construction: Creates a construct shell out of 25 metal sheets, or converts plasteel into runed metal
+//Construction: Creates a construct shell out of 50 metal sheets, or converts plasteel into runed metal
 /obj/item/melee/blood_magic/construction
 	name = "Corrupting Aura"
 	desc = "Corrupts metal and plasteel into more sinister forms."
@@ -546,12 +546,13 @@
 				to_chat(user, "<span class='warning'>You need 50 metal to produce a construct shell!</span>")
 		else if(istype(target, /obj/item/stack/sheet/plasteel))
 			var/obj/item/stack/sheet/plasteel/candidate = target
-			var/quantity = min(candidate.amount, uses)
-			uses -= quantity
-			new /obj/item/stack/sheet/runed_metal(T,quantity)
-			candidate.use(quantity)
-			to_chat(user, "<span class='warning'>A dark cloud eminates from you hand and swirls around the plasteel, transforming it into runed metal!</span>")
-			SEND_SOUND(user, sound('sound/effects/magic.ogg',0,1,25))
+			var/quantity = candidate.amount
+			if(candidate.use(quantity))
+				uses --
+				new /obj/item/stack/sheet/runed_metal(T,quantity)
+				candidate.use(quantity)
+				to_chat(user, "<span class='warning'>A dark cloud eminates from you hand and swirls around the plasteel, transforming it into runed metal!</span>")
+				SEND_SOUND(user, sound('sound/effects/magic.ogg',0,1,25))
 		else if(istype(target,/mob/living/silicon/robot))
 			var/mob/living/silicon/robot/candidate = target
 			if(candidate.mmi)

--- a/code/modules/antagonists/cult/blood_magic.dm
+++ b/code/modules/antagonists/cult/blood_magic.dm
@@ -550,7 +550,6 @@
 			if(candidate.use(quantity))
 				uses --
 				new /obj/item/stack/sheet/runed_metal(T,quantity)
-				candidate.use(quantity)
 				to_chat(user, "<span class='warning'>A dark cloud eminates from you hand and swirls around the plasteel, transforming it into runed metal!</span>")
 				SEND_SOUND(user, sound('sound/effects/magic.ogg',0,1,25))
 		else if(istype(target,/mob/living/silicon/robot))

--- a/code/modules/antagonists/cult/runes.dm
+++ b/code/modules/antagonists/cult/runes.dm
@@ -133,7 +133,8 @@ structure_check() searches for nearby cultist structures required for the invoca
 					var/C = pick_n_take(invokers)
 					if(!C)
 						break
-					chanters += C
+					if(C != user)
+						chanters += C
 	return chanters
 
 /obj/effect/rune/proc/invoke(var/list/invokers)

--- a/code/modules/spells/spell_types/construct_spells.dm
+++ b/code/modules/spells/spell_types/construct_spells.dm
@@ -297,6 +297,7 @@
 
 /obj/effect/proc_holder/spell/targeted/inflict_handler/juggernaut
 	name = "Gauntlet Echo"
+	alpha = 180
 	amt_dam_brute = 30
 	amt_knockdown = 50
 	sound = 'sound/weapons/punch3.ogg'


### PR DESCRIPTION
:cl: Robustin
fix: Twisted Construction will now consume ALL available plasteel in a stack.
fix: Runes will no longer count the original invoker more than once. 
/:cl: