### PR TITLE
A Nar-Sie Plushie can be used an an extra invoker now!

### DIFF
--- a/code/game/objects/items/plushes.dm
+++ b/code/game/objects/items/plushes.dm
@@ -462,7 +462,7 @@
 
 /obj/item/toy/plush/narplush
 	name = "nar'sie plushie"
-	desc = "A small stuffed doll of the elder god nar'sie. Who thought this was a good children's toy?"
+	desc = "A small stuffed doll of the elder god Nar'Sie. Who thought this was a good children's toy?"
 	icon_state = "narplush"
 	var/clashing
 	var/is_invoker = TRUE
@@ -475,6 +475,7 @@
 		P.clash_of_the_plushies(src)
 
 /obj/item/toy/plush/narplush/hugbox
+	desc = "A small stuffed doll of the elder god Nar'Sie. Who thought this was a good children's toy? <b>It looks sad.</b>"
 	is_invoker = FALSE
 
 /obj/item/toy/plush/lizardplushie

--- a/code/game/objects/items/plushes.dm
+++ b/code/game/objects/items/plushes.dm
@@ -465,6 +465,7 @@
 	desc = "A small stuffed doll of the elder god nar'sie. Who thought this was a good children's toy?"
 	icon_state = "narplush"
 	var/clashing
+	var/is_invoker = TRUE
 	gender = FEMALE	//it's canon if the toy is
 
 /obj/item/toy/plush/narplush/Moved()
@@ -472,6 +473,9 @@
 	var/obj/item/toy/plush/plushvar/P = locate() in range(1, src)
 	if(P && istype(P.loc, /turf/open) && !P.clash_target && !clashing)
 		P.clash_of_the_plushies(src)
+
+/obj/item/toy/plush/narplush/hugbox
+	is_invoker = FALSE
 
 /obj/item/toy/plush/lizardplushie
 	name = "lizard plushie"

--- a/code/modules/antagonists/cult/runes.dm
+++ b/code/modules/antagonists/cult/runes.dm
@@ -113,8 +113,13 @@ structure_check() searches for nearby cultist structures required for the invoca
 	if(user)
 		chanters += user
 		invokers += user
+	
 	if(req_cultists > 1 || allow_excess_invokers)
-		for(var/mob/living/L in range(1, src))
+		var/list/things_in_range = range(1, src)
+		var/obj/item/toy/plush/narplush/plushsie = locate() in things_in_range
+		if(istype(plushsie))
+			invokers += plushsie
+		for(var/mob/living/L in things_in_range)
 			if(iscultist(L))
 				if(L == user)
 					continue
@@ -139,12 +144,15 @@ structure_check() searches for nearby cultist structures required for the invoca
 /obj/effect/rune/proc/invoke(var/list/invokers)
 	//This proc contains the effects of the rune as well as things that happen afterwards. If you want it to spawn an object and then delete itself, have both here.
 	for(var/M in invokers)
-		var/mob/living/L = M
-		if(invocation)
-			L.say(invocation, language = /datum/language/common, ignore_spam = TRUE)
-		if(invoke_damage)
-			L.apply_damage(invoke_damage, BRUTE)
-			to_chat(L, "<span class='cult italic'>[src] saps your strength!</span>")
+		if(isliving(M))
+			var/mob/living/L = M
+			if(invocation)
+				L.say(invocation, language = /datum/language/common, ignore_spam = TRUE)
+			if(invoke_damage)
+				L.apply_damage(invoke_damage, BRUTE)
+				to_chat(L, "<span class='cult italic'>[src] saps your strength!</span>")
+		else if(istype(M, /obj/item/toy/plush/narplush))
+			M.visible_message("<span class='cult italic'>[M] squeaks loudly!</span>")
 	do_invoke_glow()
 
 /obj/effect/rune/proc/do_invoke_glow()

--- a/code/modules/antagonists/cult/runes.dm
+++ b/code/modules/antagonists/cult/runes.dm
@@ -152,7 +152,8 @@ structure_check() searches for nearby cultist structures required for the invoca
 				L.apply_damage(invoke_damage, BRUTE)
 				to_chat(L, "<span class='cult italic'>[src] saps your strength!</span>")
 		else if(istype(M, /obj/item/toy/plush/narplush))
-			M.visible_message("<span class='cult italic'>[M] squeaks loudly!</span>")
+			var/obj/item/toy/plush/narplush/P = M
+			P.visible_message("<span class='cult italic'>[P] squeaks loudly!</span>")
 	do_invoke_glow()
 
 /obj/effect/rune/proc/do_invoke_glow()

--- a/code/modules/antagonists/cult/runes.dm
+++ b/code/modules/antagonists/cult/runes.dm
@@ -117,7 +117,7 @@ structure_check() searches for nearby cultist structures required for the invoca
 	if(req_cultists > 1 || allow_excess_invokers)
 		var/list/things_in_range = range(1, src)
 		var/obj/item/toy/plush/narplush/plushsie = locate() in things_in_range
-		if(istype(plushsie))
+		if(istype(plushsie) && plushsie.is_invoker)
 			invokers += plushsie
 		for(var/mob/living/L in things_in_range)
 			if(iscultist(L))


### PR DESCRIPTION
you can't use 9 nar-sie plushies to invoke a rune, nar-sie plushies are only counted once



:cl: Astral
add: blood cultists can now use a nar nar plushie as an extra invoker for runes!
/:cl:


