### PR TITLE
Adds limitations to brain traumas

### DIFF
--- a/code/__DEFINES/mobs.dm
+++ b/code/__DEFINES/mobs.dm
@@ -66,6 +66,13 @@
 #define TRAUMA_RESILIENCE_MAGIC 4      //Curable only with magic
 #define TRAUMA_RESILIENCE_ABSOLUTE 5   //This is here to stay
 
+//Limit of traumas for each resilience tier
+#define TRAUMA_LIMIT_BASIC 3
+#define TRAUMA_LIMIT_SURGERY 2
+#define TRAUMA_LIMIT_LOBOTOMY 3
+#define TRAUMA_LIMIT_MAGIC 3
+#define TRAUMA_LIMIT_ABSOLUTE INFINITY
+
 #define BRAIN_DAMAGE_INTEGRITY_MULTIPLIER 0.5
 
 //Surgery Defines

--- a/code/modules/antagonists/abductor/equipment/gland.dm
+++ b/code/modules/antagonists/abductor/equipment/gland.dm
@@ -219,7 +219,7 @@
 	A.Refresh() //just in case someone already made and named the same disease
 	return A
 
-/obj/item/organ/heart/gland/trauma //TODO : Replace with something more interesting
+/obj/item/organ/heart/gland/trauma
 	cooldown_low = 800
 	cooldown_high = 1200
 	uses = 5
@@ -230,12 +230,12 @@
 /obj/item/organ/heart/gland/trauma/activate()
 	to_chat(owner, "<span class='warning'>You feel a spike of pain in your head.</span>")
 	if(prob(33))
-		owner.gain_trauma_type(BRAIN_TRAUMA_SPECIAL, TRAUMA_RESILIENCE_LOBOTOMY)
+		owner.gain_trauma_type(BRAIN_TRAUMA_SPECIAL, rand(TRAUMA_RESILIENCE_BASIC, TRAUMA_RESILIENCE_LOBOTOMY))
 	else
 		if(prob(20))
-			owner.gain_trauma_type(BRAIN_TRAUMA_SEVERE, TRAUMA_RESILIENCE_LOBOTOMY)
+			owner.gain_trauma_type(BRAIN_TRAUMA_SEVERE, rand(TRAUMA_RESILIENCE_BASIC, TRAUMA_RESILIENCE_LOBOTOMY))
 		else
-			owner.gain_trauma_type(BRAIN_TRAUMA_MILD, TRAUMA_RESILIENCE_LOBOTOMY)
+			owner.gain_trauma_type(BRAIN_TRAUMA_MILD, rand(TRAUMA_RESILIENCE_BASIC, TRAUMA_RESILIENCE_LOBOTOMY))
 
 /obj/item/organ/heart/gland/spiderman
 	cooldown_low = 450

--- a/code/modules/mob/living/carbon/damage_procs.dm
+++ b/code/modules/mob/living/carbon/damage_procs.dm
@@ -212,10 +212,10 @@
 	if(amount <= 0) //cut this early
 		return
 	var/brainloss = getBrainLoss()
-	if(brainloss > BRAIN_DAMAGE_MILD && !has_trauma_type(BRAIN_TRAUMA_MILD))
+	if(brainloss > BRAIN_DAMAGE_MILD)
 		if(prob((amount * 2) + ((brainloss - BRAIN_DAMAGE_MILD) / 5))) //1 damage|50 brain damage = 4% chance
 			gain_trauma_type(BRAIN_TRAUMA_MILD)
-	if(brainloss > BRAIN_DAMAGE_SEVERE && !has_trauma_type(BRAIN_TRAUMA_SEVERE) && !has_trauma_type(BRAIN_TRAUMA_SPECIAL))
+	if(brainloss > BRAIN_DAMAGE_SEVERE)
 		if(prob(amount + ((brainloss - BRAIN_DAMAGE_SEVERE) / 15))) //1 damage|150 brain damage = 3% chance
 			if(prob(20))
 				gain_trauma_type(BRAIN_TRAUMA_SPECIAL)

--- a/code/modules/mob/living/carbon/damage_procs.dm
+++ b/code/modules/mob/living/carbon/damage_procs.dm
@@ -213,10 +213,10 @@
 		return
 	var/brainloss = getBrainLoss()
 	if(brainloss > BRAIN_DAMAGE_MILD)
-		if(prob((amount * 2) + ((brainloss - BRAIN_DAMAGE_MILD - (20 * LAZYLEN(get_traumas())) / 5))) //1 damage|50 brain damage = 4% chance
+		if(prob((amount * 2) + (brainloss - BRAIN_DAMAGE_MILD - (20 * LAZYLEN(get_traumas())) / 5))) //1 damage|50 brain damage = 4% chance
 			gain_trauma_type(BRAIN_TRAUMA_MILD)
 	if(brainloss > BRAIN_DAMAGE_SEVERE)
-		if(prob(amount + ((brainloss - BRAIN_DAMAGE_SEVERE - (20 * LAZYLEN(get_traumas())) / 15))) //1 damage|150 brain damage = 3% chance
+		if(prob(amount + (brainloss - BRAIN_DAMAGE_SEVERE - (20 * LAZYLEN(get_traumas())) / 15))) //1 damage|150 brain damage = 3% chance
 			if(prob(20))
 				gain_trauma_type(BRAIN_TRAUMA_SPECIAL)
 			else

--- a/code/modules/mob/living/carbon/damage_procs.dm
+++ b/code/modules/mob/living/carbon/damage_procs.dm
@@ -213,10 +213,10 @@
 		return
 	var/brainloss = getBrainLoss()
 	if(brainloss > BRAIN_DAMAGE_MILD)
-		if(prob((amount * 2) + ((brainloss - BRAIN_DAMAGE_MILD) / 5))) //1 damage|50 brain damage = 4% chance
+		if(prob((amount * 2) + ((brainloss - BRAIN_DAMAGE_MILD - (20 * LAZYLEN(get_traumas())) / 5))) //1 damage|50 brain damage = 4% chance
 			gain_trauma_type(BRAIN_TRAUMA_MILD)
 	if(brainloss > BRAIN_DAMAGE_SEVERE)
-		if(prob(amount + ((brainloss - BRAIN_DAMAGE_SEVERE) / 15))) //1 damage|150 brain damage = 3% chance
+		if(prob(amount + ((brainloss - BRAIN_DAMAGE_SEVERE - (20 * LAZYLEN(get_traumas())) / 15))) //1 damage|150 brain damage = 3% chance
 			if(prob(20))
 				gain_trauma_type(BRAIN_TRAUMA_SPECIAL)
 			else


### PR DESCRIPTION
:cl: XDTM
balance: You can no longer gain the same trauma more than once.
balance: You can no longer gain more than a certain amount of brain traumas per resilience tier. (Example: You cannot gain 4 mild traumas, but you can gain 3 mild and 1 severe)
tweak: Abductors' trauma gland now gives traumas of random resilience, instead of lobotomy every time.
/:cl:

Some limitations that will prevent bugs with traumas like split personality, and reduces the absurdity of stacking traumas on someone with botched surgery.
