### PR TITLE
Adds the ability for the chaplain to cut trough cult restraints and menacles, removes artifacter construct shell making spell.

### DIFF
--- a/code/game/objects/items/holy_weapons.dm
+++ b/code/game/objects/items/holy_weapons.dm
@@ -445,3 +445,19 @@
 	righthand_file = 'icons/mob/inhands/weapons/staves_righthand.dmi'
 	w_class = WEIGHT_CLASS_NORMAL
 	attack_verb = list("bashes", "smacks", "whacks")
+
+/obj/item/nullrod/attack(mob/living/carbon/C, mob/user)
+	if(istype(C) && C.handcuffed && istype(C.handcuffed, /obj/item/restraints/handcuffs/energy/cult))
+		user.visible_message("<span class='notice'>[user] cuts [C]'s magical restraints with [src]'s holy powers!</span>")
+		qdel(C.handcuffed)
+		return
+	else
+		..()
+
+/obj/item/nullrod/attack(mob/living/carbon/C, mob/user)
+	if(istype(C) && C.handcuffed && istype(C.handcuffed, /obj/item/restraints/handcuffs/clockwork))
+		user.visible_message("<span class='notice'>[user] cuts [C]'s replica menacles with [src]'s holy powers!</span>")
+		qdel(C.handcuffed)
+		return
+	else
+		..()

--- a/code/modules/mob/living/simple_animal/constructs.dm
+++ b/code/modules/mob/living/simple_animal/constructs.dm
@@ -244,7 +244,6 @@
 	construct_spells = list(/obj/effect/proc_holder/spell/aoe_turf/conjure/wall,
 							/obj/effect/proc_holder/spell/aoe_turf/conjure/floor,
 							/obj/effect/proc_holder/spell/aoe_turf/conjure/soulstone,
-							/obj/effect/proc_holder/spell/aoe_turf/conjure/construct/lesser,
 							/obj/effect/proc_holder/spell/targeted/projectile/magic_missile/lesser)
 	runetype = /datum/action/innate/cult/create_rune/revive
 	playstyle_string = "<b>You are an Artificer. You are incredibly weak and fragile, but you are able to construct fortifications, \


### PR DESCRIPTION
Adds the ability for the chaplains holy weapon to cut trough cult cuffs/menacles to give them a little more power mechanic wise considering how strong cult is now

On the other side removes the cult artifacter shell spell which lets you instantly summon a shell.
to make it more troublesome for cult to make constructs and auctally need to play smart with their resources like their metal cyborg shells or their time cooldown on the cult structures

:cl: Improvedname
add: Adds the ability to holy weapons to cut trough cult cuffs
balance: Removes cult artifacter shell making spell
/:cl:
