### PR TITLE
Minor refactor of sheet code, things constructed by stacks can now selectively get the mob that constructed them.

### DIFF
--- a/code/game/objects/items/stacks/stack.dm
+++ b/code/game/objects/items/stacks/stack.dm
@@ -187,16 +187,9 @@
 		else
 			O = new R.result_type(usr.drop_location())
 		O.setDir(usr.dir)
+		if(O.constructor)
+			O.constructor = usr
 		use(R.req_amount * multiplier)
-
-		//START: oh fuck i'm so sorry
-		if(istype(O, /obj/structure/windoor_assembly))
-			var/obj/structure/windoor_assembly/W = O
-			W.ini_dir = W.dir
-		else if(istype(O, /obj/structure/window))
-			var/obj/structure/window/W = O
-			W.ini_dir = W.dir
-		//END: oh fuck i'm so sorry
 
 		else if(istype(O, /obj/item/restraints/handcuffs/cable))
 			var/obj/item/cuffs = O

--- a/code/game/objects/structures/windoor_assembly.dm
+++ b/code/game/objects/structures/windoor_assembly.dm
@@ -22,6 +22,7 @@
 	var/ini_dir
 	var/obj/item/electronics/airlock/electronics = null
 	var/created_name = null
+	var/constructor = null
 
 	//Vars to help with the icon's name
 	var/facing = "l"	//Does the windoor open to the left or right?
@@ -31,6 +32,8 @@
 
 /obj/structure/windoor_assembly/New(loc, set_dir)
 	..()
+	if(constructor)
+		ini_dir = constructor.dir
 	if(set_dir)
 		dir = set_dir
 	ini_dir = dir

--- a/code/game/objects/structures/window.dm
+++ b/code/game/objects/structures/window.dm
@@ -30,8 +30,8 @@
 	var/spawn_cleanable_shards = TRUE
 	var/constructor = null
 
-/obf/structure/window/new()
-	..()
+/obj/structure/window/Initialize()
+	. = ..()
 	if(constructor)
 		ini_dir = constructor.dir
 

--- a/code/game/objects/structures/window.dm
+++ b/code/game/objects/structures/window.dm
@@ -30,7 +30,7 @@
 	var/spawn_cleanable_shards = TRUE
 	var/constructor = null
 
-/ojb/structure/window/new()
+/obf/structure/window/new()
 	..()
 	if(constructor)
 		ini_dir = constructor.dir

--- a/code/game/objects/structures/window.dm
+++ b/code/game/objects/structures/window.dm
@@ -28,6 +28,12 @@
 	var/hitsound = 'sound/effects/Glasshit.ogg'
 	var/rad_insulation = RAD_VERY_LIGHT_INSULATION
 	var/spawn_cleanable_shards = TRUE
+	var/constructor = null
+
+/ojb/structure/window/new()
+	..()
+	if(constructor)
+		ini_dir = constructor.dir
 
 /obj/structure/window/examine(mob/user)
 	..()


### PR DESCRIPTION
This is either a brilliant and flawless solution or mind-numbingly retarded and completely nonfunctional and I can't tell which.

Stacks now check if a constructed object has a "constructor" var, if it does it sets it to that mob that constructed it, and then the constructed object can do whatever it wants with it. As-is I use it to fix a bit of snowflake code that was hiding in stacks.dm.