### PR TITLE
Allows the auxbase camera console to place airlocks on fans

### DIFF
--- a/code/modules/mining/aux_base_camera.dm
+++ b/code/modules/mining/aux_base_camera.dm
@@ -174,7 +174,7 @@
 		return
 
 	var/turf/target_turf = get_turf(remote_eye)
-	var/atom/movable/rcd_target = target_turf
+	var/atom/rcd_target = target_turf
 
 	//Find airlocks and other shite
 	for(var/obj/S in target_turf)

--- a/code/modules/mining/aux_base_camera.dm
+++ b/code/modules/mining/aux_base_camera.dm
@@ -173,18 +173,13 @@
 	if(!check_spot())
 		return
 
-
-	var/atom/movable/rcd_target
 	var/turf/target_turf = get_turf(remote_eye)
+	var/atom/movable/rcd_target = target_turf
 
-	//Find airlocks
-	rcd_target = locate(/obj/machinery/door/airlock) in target_turf
-
-	if(!rcd_target)
-		rcd_target = locate (/obj/structure) in target_turf
-
-	if(!rcd_target || !rcd_target.anchored)
-		rcd_target = target_turf
+	//Find airlocks and other shite
+	for(var/obj/S in target_turf)
+		if(LAZYLEN(S.rcd_vals(owner,B.RCD)))
+			rcd_target = S //If we don't break out of this loop we'll get the last placed thing
 
 	owner.changeNext_move(CLICK_CD_RANGE)
 	B.RCD.afterattack(rcd_target, owner, TRUE) //Activate the RCD and force it to work remotely!

--- a/code/modules/mining/equipment/survival_pod.dm
+++ b/code/modules/mining/equipment/survival_pod.dm
@@ -203,7 +203,6 @@
 	desc = "A large machine releasing a constant gust of air."
 	anchored = TRUE
 	density = TRUE
-	var/arbitraryatmosblockingvar = TRUE
 	var/buildstacktype = /obj/item/stack/sheet/metal
 	var/buildstackamount = 5
 	CanAtmosPass = ATMOS_PASS_NO


### PR DESCRIPTION
:cl:
fix: Fixes the auxbase camera console not placing airlocks on fans but doing so vice-versa
/:cl:

One too many times.
This actually doesn't just do that but also lets it commit the same atrocities a handheld RCD would be able to commit, such as, but not limited to, placing airlocks on top of turrets, placing walls on top of fans and other such nonsense. Please give me feedback if I should put more effort into this or if the robustin way of construction is just right.

Also removes a var that, as usual, does nothing.
