### PR TITLE
Simple mobs can no longer attack themselves

### DIFF
--- a/code/modules/mob/living/living_defense.dm
+++ b/code/modules/mob/living/living_defense.dm
@@ -214,6 +214,9 @@
 			to_chat(M, "<span class='notice'>You don't want to hurt anyone!</span>")
 			return FALSE
 
+		if(M == src)
+			return FALSE
+
 		if(M.attack_sound)
 			playsound(loc, M.attack_sound, 50, 1, 1)
 		M.do_attack_animation(src)


### PR DESCRIPTION
A mob that has no way of healing itself really shouldn't indefinitely drain its limited health pool by mistakenly clicking on its own sprite.

If you wish to suicide as a simple mob, you can do so by using the Suicide verb.