### PR TITLE
Fixes missing wire on boxstation

### DIFF
--- a/_maps/map_files/BoxStation/BoxStation.dmm
+++ b/_maps/map_files/BoxStation/BoxStation.dmm
@@ -40982,11 +40982,6 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plasteel,
 /area/science/circuit)
-"bXu" = (
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/turf/open/floor/plating,
-/area/maintenance/starboard/aft)
 "bXv" = (
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 4
@@ -105096,7 +105091,7 @@ bTr
 bTr
 bTr
 bTr
-bXu
+bTr
 bTr
 bTr
 bTr


### PR DESCRIPTION
Was really annoying since this meant the R&D/departures APC wasn't being charged.

Before:
![before](https://user-images.githubusercontent.com/30683121/36718583-8a05c29e-1b5f-11e8-8ee3-0ffea61b6b2f.PNG)
After:
![after](https://user-images.githubusercontent.com/30683121/36718590-94fe6336-1b5f-11e8-99da-c07317bc8168.PNG)
