### PR TITLE
Fixes Cyborg Defib units

### DIFF
--- a/code/game/objects/items/defib.dm
+++ b/code/game/objects/items/defib.dm
@@ -307,7 +307,7 @@
 	check_range()
 
 /obj/item/twohanded/shockpaddles/proc/check_range()
-	if(req_defib)
+	if(!req_defib)
 		return
 	if(!in_range(src,defib))
 		var/mob/living/L = loc

--- a/code/game/objects/items/defib.dm
+++ b/code/game/objects/items/defib.dm
@@ -307,6 +307,8 @@
 	check_range()
 
 /obj/item/twohanded/shockpaddles/proc/check_range()
+	if(req_defib)
+		return
 	if(!in_range(src,defib))
 		var/mob/living/L = loc
 		if(istype(L))
@@ -624,9 +626,6 @@
 	icon_state = "defibpaddles0"
 	item_state = "defibpaddles0"
 	req_defib = FALSE
-
-/obj/item/twohanded/shockpaddles/cyborg/check_range() //We don't have a defib unit, remember?
-	return
 	
 /obj/item/twohanded/shockpaddles/cyborg/attack(mob/M, mob/user)
 	if(iscyborg(user))

--- a/code/game/objects/items/defib.dm
+++ b/code/game/objects/items/defib.dm
@@ -625,6 +625,9 @@
 	item_state = "defibpaddles0"
 	req_defib = FALSE
 
+/obj/item/twohanded/shockpaddles/cyborg/check_range() //We don't have a defib unit, remember?
+	return
+	
 /obj/item/twohanded/shockpaddles/cyborg/attack(mob/M, mob/user)
 	if(iscyborg(user))
 		var/mob/living/silicon/robot/R = user


### PR DESCRIPTION
:cl: Poojawa
fix: Cyborg defib units are now actually functional
/:cl:

#35727 fixed mounts, but cyborg defibs don't have a defib unit, so they would just break since, y'know, there's no unit for the paddles to be connected to.

I was wondering why the fuck my medihound defibs were broken, then confirmed mediborgs were broken as well and figured I'd fix it here.