### PR TITLE
Fixes hidden node unlocking

### DIFF
--- a/code/modules/research/techweb/_techweb.dm
+++ b/code/modules/research/techweb/_techweb.dm
@@ -158,6 +158,7 @@
 	boosted_nodes[N] = max(boosted_nodes[N], N.boost_item_paths[itempath])
 	if(N.autounlock_by_boost)
 		hidden_nodes -= N.id
+	update_node_status(N)
 	return TRUE
 
 /datum/techweb/proc/update_tiers(datum/techweb_node/base)


### PR DESCRIPTION
Woops, it wasn't forcing a node update so the node was just lost from the techweb datum.
Fixes #33097
