### PR TITLE
Fixes tinfoil hats and lengthens the time for someone else to put it on

### DIFF
--- a/code/modules/clothing/head/misc_special.dm
+++ b/code/modules/clothing/head/misc_special.dm
@@ -225,9 +225,17 @@
 	icon_state = "foilhat"
 	item_state = "foilhat"
 	armor = list("melee" = 0, "bullet" = 0, "laser" = -5,"energy" = 0, "bomb" = 0, "bio" = 0, "rad" = -5, "fire" = 0, "acid" = 0)
+	equip_delay_other = 140
 
 /obj/item/clothing/head/foilhat/equipped(mob/living/carbon/human/user, slot)
 	if(slot == slot_head)
 		user.gain_trauma(/datum/brain_trauma/mild/phobia, FALSE, "conspiracies")
 		to_chat(user, "<span class='warning'>As you don the foiled hat, an entire world of conspiracy theories and seemingly insane ideas suddenly rush into your mind. What you once thought unbelievable suddenly seems.. undeniable. Everything is connected and nothing happens just by accident. You know too much and now they're out to get you. </span>")
-		flags_1 |= NODROP_1
+
+/obj/item/clothing/head/foilhat/attack_hand(mob/user)
+	if(iscarbon(user))
+		var/mob/living/carbon/C = user
+		if(src == C.head)
+			to_chat(user, "<span class='warning'>You need help taking this off!</span>")
+			return
+	..()

--- a/code/modules/clothing/head/misc_special.dm
+++ b/code/modules/clothing/head/misc_special.dm
@@ -236,6 +236,6 @@
 	if(iscarbon(user))
 		var/mob/living/carbon/C = user
 		if(src == C.head)
-			to_chat(user, "<span class='warning'>You need help taking this off!</span>")
+			to_chat(user, "<span class='userdanger'>Why would you want to take this off? Do you want them to get into your mind?!</span>") 
 			return
 	..()


### PR DESCRIPTION
[Changelogs]: 

:cl: Dax Dupont
balance: Others can now take off your tinfoil hat as seemingly originally intended.
balance: Due to the nature of tinfoil hats, the delay of putting a tinfoil hat on unwilling participants has been increased.
/:cl:

[why]: While someone flashing everyone and giving them a tinfoil hat they cannot take off seems funny, it's rather annoying since it gives everyone traumas which completely makes people unable to function. That's why there's a larger delay now for OTHERS to put it on you.

Also replaced NO_DROP1 with the way found with the electropack. NO_DROP1 prevents others from taking it off too while the PR states others should be able to take it off.
