### PR TITLE
Removes the action button from chem implants

### DIFF
--- a/code/game/objects/items/implants/implant_chem.dm
+++ b/code/game/objects/items/implants/implant_chem.dm
@@ -38,10 +38,6 @@
 		return 0
 	var/mob/living/carbon/R = imp_in
 	var/injectamount = null
-	if (cause == "action_button")
-		injectamount = reagents.total_volume
-	else
-		injectamount = cause
 	reagents.trans_to(R, injectamount)
 	to_chat(R, "<span class='italics'>You hear a faint beep.</span>")
 	if(!reagents.total_volume)


### PR DESCRIPTION
Sorry i heard you like to powercreep with stuff you can make with one chem macro every round?

:cl: Improvedname
fix: chem implants can no longer be self triggered
/:cl:

