### PR TITLE
Fixes has_trait() handling of non-list args

### DIFF
--- a/code/modules/mob/living/status_procs.dm
+++ b/code/modules/mob/living/status_procs.dm
@@ -173,15 +173,14 @@
 
 	. = FALSE
 
+	if(sources && !islist(sources))
+		sources = list(sources)
 	if(LAZYLEN(sources))
-		if(!islist(sources))
-			sources = list(sources)
 		for(var/S in sources)
 			if(S in status_traits[trait])
 				return TRUE
-	else
-		if(LAZYLEN(status_traits[trait]))
-			return TRUE
+	else if(LAZYLEN(status_traits[trait]))
+		return TRUE
 
 /mob/living/proc/remove_all_traits()
 	status_traits = list()

--- a/code/modules/mob/living/status_procs.dm
+++ b/code/modules/mob/living/status_procs.dm
@@ -174,6 +174,8 @@
 	. = FALSE
 
 	if(LAZYLEN(sources))
+		if(!islist(sources))
+			sources = list(sources)
 		for(var/S in sources)
 			if(S in status_traits[trait])
 				return TRUE


### PR DESCRIPTION
The in iterator won't work for single objects, it seems.

This broke NOBREATH species' speech and a few other minor features
https://github.com/tgstation/tgstation/blob/b49798c48368ed4bdc528e1c79214ce7f44d6767/code/modules/mob/living/carbon/human/say.dm#L52