### PR TITLE
Fixes NTNet scanner component

### DIFF
--- a/code/modules/integrated_electronics/subtypes/input.dm
+++ b/code/modules/integrated_electronics/subtypes/input.dm
@@ -884,9 +884,9 @@
 
 	if(net)
 		set_pin_data(IC_OUTPUT, 1, net.hardware_id)
+		push_data()
 		activate_pin(2)
 	else
 		set_pin_data(IC_OUTPUT, 1, null)
+		push_data()
 		activate_pin(3)
-	push_data()
-	return


### PR DESCRIPTION
NTNet scanner was pushing data _after_ triggering a pin, preventing user from attaching anything that uses its data to its output pins. This PR fixes that.