### PR TITLE
why doesn't nukeops actually check required_enemies

### DIFF
--- a/code/game/gamemodes/nuclear/nuclear.dm
+++ b/code/game/gamemodes/nuclear/nuclear.dm
@@ -22,7 +22,6 @@
 /datum/game_mode/nuclear/pre_setup()
 	var/n_agents = min(round(num_players() / 10), antag_candidates.len, agents_possible)
 	if(n_agents >= required_enemies)
-		message_admins("<span class='notice'> [n_agents] nuclear operative(s) were created!</span>")
 		for(var/i = 0, i < n_agents, ++i)
 			var/datum/mind/new_op = pick_n_take(antag_candidates)
 			pre_nukeops += new_op

--- a/code/game/gamemodes/nuclear/nuclear.dm
+++ b/code/game/gamemodes/nuclear/nuclear.dm
@@ -21,13 +21,17 @@
 
 /datum/game_mode/nuclear/pre_setup()
 	var/n_agents = min(round(num_players() / 10), antag_candidates.len, agents_possible)
-	for(var/i = 0, i < n_agents, ++i)
-		var/datum/mind/new_op = pick_n_take(antag_candidates)
-		pre_nukeops += new_op
-		new_op.assigned_role = "Nuclear Operative"
-		new_op.special_role = "Nuclear Operative"
-		log_game("[new_op.key] (ckey) has been selected as a nuclear operative")
-	return TRUE
+	if(n_agents < required_enemies)
+		message_admins("<span class='notice'> [n_agents] nuclear operative(s) were created!</span>")
+		for(var/i = 0, i < n_agents, ++i)
+			var/datum/mind/new_op = pick_n_take(antag_candidates)
+			pre_nukeops += new_op
+			new_op.assigned_role = "Nuclear Operative"
+			new_op.special_role = "Nuclear Operative"
+			log_game("[new_op.key] (ckey) has been selected as a nuclear operative")
+		return TRUE
+	else
+		return FALSE
 ////////////////////////////////////////////////////////////////////////////////////////
 ////////////////////////////////////////////////////////////////////////////////////////
 

--- a/code/game/gamemodes/nuclear/nuclear.dm
+++ b/code/game/gamemodes/nuclear/nuclear.dm
@@ -21,7 +21,7 @@
 
 /datum/game_mode/nuclear/pre_setup()
 	var/n_agents = min(round(num_players() / 10), antag_candidates.len, agents_possible)
-	if(n_agents < required_enemies)
+	if(n_agents >= required_enemies)
 		message_admins("<span class='notice'> [n_agents] nuclear operative(s) were created!</span>")
 		for(var/i = 0, i < n_agents, ++i)
 			var/datum/mind/new_op = pick_n_take(antag_candidates)


### PR DESCRIPTION
this is causing problems on downstream like hippie (wow loneop every round) because in every other gamemode required_enemies is check in pre_setup, but I guess because nukeops is www.youtube.com/watch?v=yqdDB_tMtgA
it doesn't care

:cl: checkraisefold
fix: Nukeops properly checks the required amount of enemies for the gamemode! This should fix downstream problems.
/:cl:
