### PR TITLE
Fixes transforming weapons runtiming due to no butchering component

### DIFF
--- a/code/game/objects/items/melee/transforming.dm
+++ b/code/game/objects/items/melee/transforming.dm
@@ -22,7 +22,7 @@
 		if(attack_verb_off.len)
 			attack_verb = attack_verb_off
 	if(is_sharp())
-		AddComponent(/datum/component/butchering, 50, 100, 0, hitsound, active)
+		AddComponent(/datum/component/butchering, 50, 100, 0, hitsound, !active)
 
 /obj/item/melee/transforming/attack_self(mob/living/carbon/user)
 	if(transform_weapon(user))
@@ -61,9 +61,13 @@
 			attack_verb = attack_verb_off
 		icon_state = initial(icon_state)
 		w_class = initial(w_class)
-	GET_COMPONENT(butchering, /datum/component/butchering)
-	if(butchering)
-		butchering.butchering_enabled = active
+	if(is_sharp())
+		var/datum/component/butchering/BT = LoadComponent(/datum/component/butchering)
+		BT.butchering_enabled = TRUE
+	else
+		GET_COMPONENT(BT, /datum/component/butchering)
+		if(BT)
+			BT.butchering_enabled = FALSE
 	transform_messages(user, supress_message_text)
 	add_fingerprint(user)
 	return TRUE

--- a/code/game/objects/items/melee/transforming.dm
+++ b/code/game/objects/items/melee/transforming.dm
@@ -61,8 +61,9 @@
 			attack_verb = attack_verb_off
 		icon_state = initial(icon_state)
 		w_class = initial(w_class)
-	GET_COMPONENT_FROM(butchering, /datum/component/butchering, src)
-	butchering.butchering_enabled = active
+	GET_COMPONENT(butchering, /datum/component/butchering)
+	if(butchering)
+		butchering.butchering_enabled = active
 	transform_messages(user, supress_message_text)
 	add_fingerprint(user)
 	return TRUE


### PR DESCRIPTION
GET_COMPONENT to get component from src.
Should always check if a component exists unless you WANT it to crash if it isn't. 
@Xhuis 