### PR TITLE
Display cases can now have a list where to randomly spawn items from

### DIFF
--- a/code/controllers/subsystem/persistence.dm
+++ b/code/controllers/subsystem/persistence.dm
@@ -156,6 +156,8 @@ SUBSYSTEM_DEF(persistence)
 /datum/controller/subsystem/persistence/proc/SetUpTrophies(list/trophy_items)
 	for(var/A in GLOB.trophy_cases)
 		var/obj/structure/displaycase/trophy/T = A
+		if (T.showpiece) 
+			continue
 		T.added_roundstart = TRUE
 
 		var/trophy_data = pick_n_take(trophy_items)

--- a/code/game/objects/structures/displaycase.dm
+++ b/code/game/objects/structures/displaycase.dm
@@ -15,17 +15,17 @@
 	var/openable = TRUE
 	var/obj/item/electronics/airlock/electronics
 	var/start_showpiece_type = null //add type for items on display
-	var/list/start_showpieces = list()
+	var/list/start_showpieces = list() //Takes sublists in the form of list("type" = /obj/item/bikehorn, "trophy_message" = "henk")
 	var/trophy_message = ""
 
 /obj/structure/displaycase/Initialize()
 	. = ..()
-	if(start_showpieces.len) 
+	if(start_showpieces.len && !start_showpiece_type) 
 		var/list/showpiece_entry = pick(start_showpieces)
-		if (showpiece_entry && showpiece_entry.len)
-			start_showpiece_type = showpiece_entry[1]
-			if (showpiece_entry.len >= 2)
-				trophy_message = showpiece_entry[2]
+		if (showpiece_entry && showpiece_entry["type"])
+			start_showpiece_type = showpiece_entry["type"]
+			if (showpiece_entry["trophy_message"])
+				trophy_message = showpiece_entry["trophy_message"]
 	if(start_showpiece_type)
 		showpiece = new start_showpiece_type (src)
 	update_icon()

--- a/code/game/objects/structures/displaycase.dm
+++ b/code/game/objects/structures/displaycase.dm
@@ -15,9 +15,17 @@
 	var/openable = TRUE
 	var/obj/item/electronics/airlock/electronics
 	var/start_showpiece_type = null //add type for items on display
+	var/list/start_showpieces = list()
+	var/trophy_message = ""
 
 /obj/structure/displaycase/Initialize()
 	. = ..()
+	if(start_showpieces.len) 
+		var/list/showpiece_entry = pick(start_showpieces)
+		if (showpiece_entry && showpiece_entry.len)
+			start_showpiece_type = showpiece_entry[1]
+			if (showpiece_entry.len >= 2)
+				trophy_message = showpiece_entry[2]
 	if(start_showpiece_type)
 		showpiece = new start_showpiece_type (src)
 	update_icon()
@@ -35,6 +43,9 @@
 		to_chat(user, "<span class='notice'>Hooked up with an anti-theft system.</span>")
 	if(showpiece)
 		to_chat(user, "<span class='notice'>There's [showpiece] inside.</span>")
+	if(trophy_message)
+		to_chat(user, "The plaque reads:")
+		to_chat(user, trophy_message)
 
 
 /obj/structure/displaycase/proc/dump()
@@ -213,7 +224,7 @@
 //The captains display case requiring specops ID access is intentional.
 //The lab cage and captains display case do not spawn with electronics, which is why req_access is needed.
 /obj/structure/displaycase/captain
-	alert = 1
+	alert = TRUE
 	start_showpiece_type = /obj/item/gun/energy/laser/captain
 	req_access = list(ACCESS_CENT_SPECOPS)
 
@@ -223,12 +234,9 @@
 	start_showpiece_type = /obj/item/clothing/mask/facehugger/lamarr
 	req_access = list(ACCESS_RD)
 
-
-
 /obj/structure/displaycase/trophy
 	name = "trophy display case"
 	desc = "Store your trophies of accomplishment in here, and they will stay forever."
-	var/trophy_message = ""
 	var/placer_key = ""
 	var/added_roundstart = TRUE
 	var/is_locked = TRUE
@@ -244,12 +252,6 @@
 /obj/structure/displaycase/trophy/Destroy()
 	GLOB.trophy_cases -= src
 	return ..()
-
-/obj/structure/displaycase/trophy/examine(mob/user)
-	..()
-	if(trophy_message)
-		to_chat(user, "The plaque reads:")
-		to_chat(user, trophy_message)
 
 /obj/structure/displaycase/trophy/attackby(obj/item/W, mob/user, params)
 

--- a/code/game/objects/structures/statues.dm
+++ b/code/game/objects/structures/statues.dm
@@ -16,13 +16,7 @@
 	if(!(flags_1 & NODECONSTRUCT_1))
 		if(default_unfasten_wrench(user, W))
 			return
-		else if(istype(W, /obj/item/pickaxe/drill/jackhammer))
-			user.visible_message("[user] destroys the [name]!",
-								"<span class='notice'>You destroy the [name].</span>")
-			W.play_tool_sound(src)
-			qdel(src)
-			return
-		else if(istype(W, /obj/item/weldingtool) || istype(W, /obj/item/gun/energy/plasmacutter))
+		if(istype(W, /obj/item/weldingtool) || istype(W, /obj/item/gun/energy/plasmacutter))
 			if(!W.tool_start_check(user, amount=0))
 				return FALSE
 

--- a/code/game/objects/structures/statues.dm
+++ b/code/game/objects/structures/statues.dm
@@ -1,6 +1,3 @@
-
-
-
 /obj/structure/statue
 	name = "statue"
 	desc = "Placeholder. Yell at Firecage if you SOMEHOW see this."
@@ -16,47 +13,27 @@
 /obj/structure/statue/attackby(obj/item/W, mob/living/user, params)
 	add_fingerprint(user)
 	user.changeNext_move(CLICK_CD_MELEE)
-	if(istype(W, /obj/item/wrench))
-		if(anchored)
-			user.visible_message("[user] is loosening the [name]'s bolts.", \
-								 "<span class='notice'>You are loosening the [name]'s bolts...</span>")
-			if(W.use_tool(src, user, 40, volume=100))
-				if(!anchored)
-					return
-				user.visible_message("[user] loosened the [name]'s bolts!", \
-									 "<span class='notice'>You loosen the [name]'s bolts!</span>")
-				anchored = FALSE
-		else
-			if(!isfloorturf(src.loc))
-				user.visible_message("<span class='warning'>A floor must be present to secure the [name]!</span>")
-				return
-			user.visible_message("[user] is securing the [name]'s bolts...", \
-								 "<span class='notice'>You are securing the [name]'s bolts...</span>")
-			if(W.use_tool(src, user, 40, volume=100))
-				if(anchored)
-					return
-				user.visible_message("[user] has secured the [name]'s bolts.", \
-									 "<span class='notice'>You have secured the [name]'s bolts.</span>")
-				anchored = TRUE
+	if(!(flags_1 & NODECONSTRUCT_1))
+		if(default_unfasten_wrench(user, W))
+			return
+		else if(istype(W, /obj/item/pickaxe/drill/jackhammer))
+			user.visible_message("[user] destroys the [name]!",
+								"<span class='notice'>You destroy the [name].</span>")
+			W.play_tool_sound(src)
+			qdel(src)
+			return
+		else if(istype(W, /obj/item/weldingtool) || istype(W, /obj/item/gun/energy/plasmacutter))
+			if(!W.tool_start_check(user, amount=0))
+				return FALSE
 
-	else if(istype(W, /obj/item/pickaxe/drill/jackhammer))
-		user.visible_message("[user] destroys the [name]!",
-							 "<span class='notice'>You destroy the [name].</span>")
-		W.play_tool_sound(src)
-		qdel(src)
-
-	else if(istype(W, /obj/item/weldingtool) || istype(W, /obj/item/gun/energy/plasmacutter))
-		if(!W.tool_start_check(user, amount=0))
-			return FALSE
-
-		user.visible_message("[user] is slicing apart the [name].", \
-							 "<span class='notice'>You are slicing apart the [name]...</span>")
-		if(W.use_tool(src, user, 40, volume=50))
-			user.visible_message("[user] slices apart the [name].", \
-								 "<span class='notice'>You slice apart the [name]!</span>")
-			deconstruct(TRUE)
-	else
-		return ..()
+			user.visible_message("[user] is slicing apart the [name].", \
+								"<span class='notice'>You are slicing apart the [name]...</span>")
+			if(W.use_tool(src, user, 40, volume=50))
+				user.visible_message("[user] slices apart the [name].", \
+									"<span class='notice'>You slice apart the [name]!</span>")
+				deconstruct(TRUE)
+			return
+	return ..()
 
 /obj/structure/statue/attack_hand(mob/living/user)
 	user.changeNext_move(CLICK_CD_MELEE)


### PR DESCRIPTION
[Changelogs]: 

:cl: Dax Dupont
add: Display cases can now have a list where to randomly spawn items from.
refactor: Moved plaque code to main type.
refactor: Statues now use default unwrench and the tool interaction is now completely non existent when no deconstruct flag is available.
/:cl:

[why]: Mostly prepwork for away missions and other stuff like VR I have planned.