### PR TITLE
White crayons no longer make gloves look latex

### DIFF
--- a/code/modules/clothing/gloves/color.dm
+++ b/code/modules/clothing/gloves/color.dm
@@ -163,7 +163,7 @@
 	item_state = "lgloves"
 	siemens_coefficient = 0.3
 	permeability_coefficient = 0.01
-	item_color="white"
+	item_color="latex"
 	transfer_prints = TRUE
 	resistance_flags = NONE
 
@@ -180,7 +180,7 @@
 	desc = "These look pretty fancy."
 	icon_state = "white"
 	item_state = "wgloves"
-	item_color="mime"
+	item_color="white"
 
 /obj/item/clothing/gloves/color/white/redcoat
 	item_color = "redcoat"		//Exists for washing machines. Is not different from white gloves in any way.

--- a/code/modules/clothing/gloves/color.dm
+++ b/code/modules/clothing/gloves/color.dm
@@ -163,7 +163,7 @@
 	item_state = "lgloves"
 	siemens_coefficient = 0.3
 	permeability_coefficient = 0.01
-	item_color="latex"
+	item_color="mime"
 	transfer_prints = TRUE
 	resistance_flags = NONE
 
@@ -181,9 +181,6 @@
 	icon_state = "white"
 	item_state = "wgloves"
 	item_color="white"
-
-/obj/item/clothing/gloves/color/white/mime
-	item_color= "mime" //Exists for washing machines. Is not different from white gloves in any way.
 
 /obj/item/clothing/gloves/color/white/redcoat
 	item_color = "redcoat"		//Exists for washing machines. Is not different from white gloves in any way.

--- a/code/modules/clothing/gloves/color.dm
+++ b/code/modules/clothing/gloves/color.dm
@@ -182,6 +182,9 @@
 	item_state = "wgloves"
 	item_color="white"
 
+/obj/item/clothing/gloves/color/white/mime
+	item_color= "mime"
+
 /obj/item/clothing/gloves/color/white/redcoat
 	item_color = "redcoat"		//Exists for washing machines. Is not different from white gloves in any way.
 

--- a/code/modules/clothing/gloves/color.dm
+++ b/code/modules/clothing/gloves/color.dm
@@ -183,7 +183,7 @@
 	item_color="white"
 
 /obj/item/clothing/gloves/color/white/mime
-	item_color= "mime"
+	item_color= "mime" //Exists for washing machines. Is not different from white gloves in any way.
 
 /obj/item/clothing/gloves/color/white/redcoat
 	item_color = "redcoat"		//Exists for washing machines. Is not different from white gloves in any way.


### PR DESCRIPTION
:cl: Cebutris
fix: Washing a glove with a white crayon will make it look like a white glove, instead of a latex glove. Instead, mime crayons make gloves look latex
/:cl:

Fixes #34941

It's more sane that white gloves have the item color of "white" rather than latex gloves, anyway