### PR TITLE
Meth is not good for your brain

### DIFF
--- a/code/modules/reagents/chemistry/reagents/drug_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/drug_reagents.dm
@@ -187,7 +187,7 @@
 	M.AdjustUnconscious(-40, 0)
 	M.adjustStaminaLoss(-2, 0)
 	M.Jitter(2)
-	M.adjustBrainLoss(0.25)
+	M.adjustBrainLoss(rand(1,4))
 	if(prob(5))
 		M.emote(pick("twitch", "shiver"))
 	..()


### PR DESCRIPTION
:cl: Robustin
balance: Meth now deals 1-4 brain damage while active, up from 0.25
/:cl:

People using meth as potent combat stim is a fun tactic but it really needs an actual downside outside of "dont use more than 10 of it at a time". 

Plus we have all these fun new brain traumas, I'd love to see more of them. You need 20 brain damage to even start seeing side-effects and the minor ones are all pretty... minor and can be cured by mannitol.

Honestly might even need to address that aspect too (its not exactly hard to add mannitol to your combat pillz) but making the brain damage number actually relevant is a start.