### PR TITLE
Pubbystation: Firelocks, shutters, fixes

### DIFF
--- a/_maps/map_files/PubbyStation/PubbyStation.dmm
+++ b/_maps/map_files/PubbyStation/PubbyStation.dmm
@@ -2388,6 +2388,10 @@
 /obj/machinery/atmospherics/pipe/simple/cyan/hidden{
 	dir = 6
 	},
+/obj/machinery/firealarm{
+	dir = 8;
+	pixel_x = -27
+	},
 /turf/open/floor/plasteel/showroomfloor,
 /area/security/main)
 "ahN" = (
@@ -3259,6 +3263,10 @@
 	pixel_y = -3
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on,
+/obj/machinery/firealarm{
+	dir = 8;
+	pixel_x = -27
+	},
 /turf/open/floor/plasteel/dark,
 /area/security/armory)
 "ajQ" = (
@@ -3826,6 +3834,10 @@
 /obj/structure/cable{
 	icon_state = "0-2"
 	},
+/obj/machinery/door/poddoor/preopen{
+	id = "hos_spess_shutters";
+	name = "Space shutters"
+	},
 /turf/open/floor/plating,
 /area/crew_quarters/heads/hos)
 "ala" = (
@@ -4114,6 +4126,10 @@
 	icon_state = "0-2"
 	},
 /obj/structure/cable,
+/obj/machinery/door/poddoor/preopen{
+	id = "hos_spess_shutters";
+	name = "Space shutters"
+	},
 /turf/open/floor/plating,
 /area/crew_quarters/heads/hos)
 "alO" = (
@@ -4418,6 +4434,7 @@
 /obj/machinery/atmospherics/pipe/simple/cyan/hidden{
 	dir = 4
 	},
+/obj/machinery/door/firedoor,
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/heads/hos)
 "amu" = (
@@ -4684,6 +4701,10 @@
 /obj/machinery/recharger,
 /obj/machinery/light/small{
 	dir = 4
+	},
+/obj/machinery/firealarm{
+	dir = 4;
+	pixel_x = 28
 	},
 /turf/open/floor/plasteel/showroomfloor,
 /area/security/warden)
@@ -5022,6 +5043,11 @@
 /obj/structure/cable{
 	icon_state = "1-4"
 	},
+/obj/machinery/button/door{
+	id = "hos_spess_shutters";
+	pixel_y = -26;
+	req_access_txt = "1"
+	},
 /turf/open/floor/plasteel/darkred/side{
 	dir = 1
 	},
@@ -5073,6 +5099,10 @@
 	icon_state = "0-8"
 	},
 /obj/structure/cable,
+/obj/machinery/door/poddoor/preopen{
+	id = "hos_spess_shutters";
+	name = "Space shutters"
+	},
 /turf/open/floor/plating,
 /area/crew_quarters/heads/hos)
 "anX" = (
@@ -5213,6 +5243,7 @@
 /obj/structure/cable{
 	icon_state = "1-4"
 	},
+/obj/machinery/door/firedoor,
 /turf/open/floor/plasteel/showroomfloor,
 /area/security/warden)
 "aot" = (
@@ -5802,6 +5833,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/cyan/hidden,
 /obj/structure/disposalpipe/segment,
+/obj/machinery/door/firedoor,
 /turf/open/floor/plasteel/showroomfloor,
 /area/security/warden)
 "apN" = (
@@ -7261,9 +7293,6 @@
 "atq" = (
 /turf/open/floor/circuit/green,
 /area/maintenance/department/security/brig)
-"atu" = (
-/turf/open/space,
-/area/security/brig)
 "atv" = (
 /obj/structure/cable{
 	icon_state = "0-4"
@@ -7361,6 +7390,7 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/machinery/door/firedoor,
 /turf/open/floor/plasteel/red/side{
 	dir = 8
 	},
@@ -7383,6 +7413,7 @@
 	req_access_txt = "63"
 	},
 /obj/structure/disposalpipe/segment,
+/obj/machinery/door/firedoor,
 /turf/open/floor/plasteel/red/side{
 	dir = 4
 	},
@@ -7393,6 +7424,7 @@
 	req_access_txt = "1"
 	},
 /obj/machinery/atmospherics/pipe/simple/cyan/hidden,
+/obj/machinery/door/firedoor,
 /turf/open/floor/plasteel/dark,
 /area/security/brig)
 "atI" = (
@@ -8284,6 +8316,7 @@
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 8
 	},
+/obj/machinery/door/firedoor,
 /turf/open/floor/plasteel/vault{
 	dir = 5
 	},
@@ -8743,6 +8776,7 @@
 	name = "brig shutters"
 	},
 /obj/item/device/radio,
+/obj/machinery/door/firedoor,
 /turf/open/floor/plasteel/dark,
 /area/security/brig)
 "awP" = (
@@ -8764,6 +8798,7 @@
 /obj/item/folder/red{
 	layer = 2.9
 	},
+/obj/machinery/door/firedoor,
 /turf/open/floor/plasteel/dark,
 /area/security/brig)
 "awQ" = (
@@ -8782,6 +8817,7 @@
 	name = "Brig Desk";
 	req_access_txt = "1"
 	},
+/obj/machinery/door/firedoor,
 /turf/open/floor/plasteel/dark,
 /area/security/brig)
 "awR" = (
@@ -8809,7 +8845,7 @@
 	dir = 1
 	},
 /turf/open/floor/plating,
-/area/maintenance/fore)
+/area/crew_quarters/heads/captain)
 "awU" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 5
@@ -9043,7 +9079,7 @@
 	},
 /obj/effect/turf_decal/delivery,
 /turf/open/floor/plasteel,
-/area/security/brig)
+/area/hallway/primary/fore)
 "axF" = (
 /obj/item/twohanded/required/kirbyplants{
 	icon_state = "plant-10"
@@ -9228,10 +9264,10 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
+/obj/machinery/door/firedoor,
 /turf/open/floor/plasteel/dark,
 /area/bridge)
 "ayf" = (
-/obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
@@ -9548,6 +9584,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
+/obj/machinery/door/firedoor,
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/heads/captain)
 "ayX" = (
@@ -10583,6 +10620,10 @@
 /area/crew_quarters/heads/hop)
 "aBB" = (
 /obj/machinery/computer/cargo/request,
+/obj/machinery/firealarm{
+	dir = 1;
+	pixel_y = 29
+	},
 /turf/open/floor/wood,
 /area/crew_quarters/heads/hop)
 "aBC" = (
@@ -12898,11 +12939,6 @@
 /obj/machinery/door/firedoor,
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
-"aGW" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/turf/open/floor/plasteel,
-/area/hallway/primary/central)
 "aGX" = (
 /obj/effect/spawner/structure/window,
 /turf/open/floor/plating,
@@ -14425,6 +14461,7 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
+/obj/machinery/door/firedoor,
 /turf/open/floor/plasteel,
 /area/storage/art)
 "aKM" = (
@@ -14463,6 +14500,7 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/machinery/door/firedoor,
 /turf/open/floor/plasteel/freezer,
 /area/crew_quarters/toilet/auxiliary)
 "aKS" = (
@@ -14899,7 +14937,7 @@
 	},
 /obj/structure/disposalpipe/trunk,
 /turf/open/floor/plating,
-/area/quartermaster/office)
+/area/quartermaster/sorting)
 "aMh" = (
 /obj/machinery/conveyor{
 	dir = 4;
@@ -14907,7 +14945,7 @@
 	},
 /obj/effect/spawner/lootdrop/maintenance,
 /turf/open/floor/plating,
-/area/quartermaster/office)
+/area/quartermaster/sorting)
 "aMi" = (
 /obj/machinery/conveyor{
 	dir = 4;
@@ -14919,7 +14957,7 @@
 	supply_display = 1
 	},
 /turf/open/floor/plating,
-/area/quartermaster/office)
+/area/quartermaster/sorting)
 "aMj" = (
 /obj/machinery/conveyor{
 	dir = 4;
@@ -14933,7 +14971,7 @@
 	pixel_y = 32
 	},
 /turf/open/floor/plating,
-/area/quartermaster/office)
+/area/quartermaster/sorting)
 "aMk" = (
 /obj/machinery/conveyor{
 	dir = 4;
@@ -14944,14 +14982,14 @@
 	pixel_y = 32
 	},
 /turf/open/floor/plating,
-/area/quartermaster/office)
+/area/quartermaster/sorting)
 "aMl" = (
 /obj/machinery/conveyor{
 	dir = 4;
 	id = "packageSort2"
 	},
 /turf/open/floor/plating,
-/area/quartermaster/office)
+/area/quartermaster/sorting)
 "aMm" = (
 /obj/machinery/conveyor{
 	dir = 4;
@@ -14962,7 +15000,7 @@
 	dir = 1
 	},
 /turf/open/floor/plating,
-/area/quartermaster/office)
+/area/quartermaster/sorting)
 "aMn" = (
 /obj/machinery/disposal/deliveryChute{
 	dir = 8
@@ -14974,7 +15012,7 @@
 	dir = 4
 	},
 /turf/open/floor/plating,
-/area/quartermaster/office)
+/area/quartermaster/sorting)
 "aMo" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -15540,20 +15578,20 @@
 	dir = 1
 	},
 /turf/open/floor/plating,
-/area/quartermaster/office)
+/area/quartermaster/sorting)
 "aNH" = (
 /obj/structure/disposalpipe/segment,
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
-/area/quartermaster/office)
+/area/quartermaster/sorting)
 "aNI" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
-/area/quartermaster/office)
+/area/quartermaster/sorting)
 "aNJ" = (
 /obj/machinery/conveyor_switch/oneway{
 	id = "packageSort2"
@@ -15562,7 +15600,7 @@
 	dir = 1
 	},
 /turf/open/floor/plasteel,
-/area/quartermaster/office)
+/area/quartermaster/sorting)
 "aNK" = (
 /obj/structure/table,
 /obj/item/device/destTagger,
@@ -15570,7 +15608,7 @@
 	dir = 1
 	},
 /turf/open/floor/plasteel,
-/area/quartermaster/office)
+/area/quartermaster/sorting)
 "aNL" = (
 /obj/item/stack/wrapping_paper{
 	pixel_x = 3;
@@ -15585,7 +15623,7 @@
 	dir = 1
 	},
 /turf/open/floor/plasteel,
-/area/quartermaster/office)
+/area/quartermaster/sorting)
 "aNM" = (
 /obj/item/storage/box,
 /obj/item/storage/box,
@@ -15602,7 +15640,7 @@
 	dir = 1
 	},
 /turf/open/floor/plasteel,
-/area/quartermaster/office)
+/area/quartermaster/sorting)
 "aNN" = (
 /obj/structure/closet/crate/freezer,
 /obj/structure/sign/poster/official/random{
@@ -16058,14 +16096,14 @@
 /turf/open/floor/plasteel/red/side{
 	dir = 8
 	},
-/area/quartermaster/office)
+/area/quartermaster/sorting)
 "aOS" = (
 /obj/structure/disposalpipe/segment{
 	dir = 5
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on,
 /turf/open/floor/plasteel,
-/area/quartermaster/office)
+/area/quartermaster/sorting)
 "aOT" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -16079,7 +16117,7 @@
 	},
 /obj/effect/landmark/start/cargo_technician,
 /turf/open/floor/plasteel,
-/area/quartermaster/office)
+/area/quartermaster/sorting)
 "aOV" = (
 /obj/structure/disposalpipe/segment{
 	dir = 6
@@ -16098,7 +16136,7 @@
 	},
 /obj/machinery/light/small,
 /turf/open/floor/plating,
-/area/quartermaster/office)
+/area/quartermaster/sorting)
 "aOX" = (
 /obj/structure/disposalpipe/trunk{
 	dir = 8
@@ -16110,7 +16148,7 @@
 	dir = 4
 	},
 /turf/open/floor/plating,
-/area/quartermaster/office)
+/area/quartermaster/sorting)
 "aOY" = (
 /obj/effect/spawner/lootdrop/maintenance,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on,
@@ -16459,14 +16497,14 @@
 "aPX" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plasteel,
-/area/quartermaster/office)
+/area/quartermaster/sorting)
 "aPY" = (
 /turf/open/floor/plasteel,
 /area/quartermaster/office)
 "aPZ" = (
 /obj/machinery/holopad,
 /turf/open/floor/plasteel,
-/area/quartermaster/office)
+/area/quartermaster/sorting)
 "aQa" = (
 /obj/structure/disposalpipe/sorting/wrap{
 	dir = 1
@@ -16475,7 +16513,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel,
-/area/quartermaster/office)
+/area/quartermaster/sorting)
 "aQb" = (
 /obj/structure/disposalpipe/segment{
 	dir = 9
@@ -16487,8 +16525,12 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 10
 	},
+/obj/machinery/firealarm{
+	dir = 4;
+	pixel_x = 28
+	},
 /turf/open/floor/plasteel,
-/area/quartermaster/office)
+/area/quartermaster/sorting)
 "aQc" = (
 /obj/machinery/button/door{
 	id = "qm_warehouse";
@@ -16975,11 +17017,11 @@
 /obj/structure/chair/stool,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plasteel,
-/area/quartermaster/office)
+/area/quartermaster/sorting)
 "aRi" = (
 /obj/structure/chair/stool,
 /turf/open/floor/plasteel,
-/area/quartermaster/office)
+/area/quartermaster/sorting)
 "aRj" = (
 /obj/structure/table/reinforced,
 /obj/item/folder/yellow,
@@ -16988,15 +17030,15 @@
 	layer = 2.9
 	},
 /turf/open/floor/plasteel,
-/area/quartermaster/office)
+/area/quartermaster/sorting)
 "aRk" = (
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel,
-/area/quartermaster/office)
+/area/quartermaster/sorting)
 "aRl" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plasteel,
-/area/quartermaster/office)
+/area/quartermaster/sorting)
 "aRm" = (
 /obj/structure/closet/crate,
 /obj/item/reagent_containers/food/snacks/donut,
@@ -17004,7 +17046,7 @@
 /obj/item/reagent_containers/food/snacks/donut,
 /obj/item/reagent_containers/food/snacks/donut,
 /turf/open/floor/plating,
-/area/quartermaster/office)
+/area/quartermaster/sorting)
 "aRn" = (
 /obj/machinery/door/poddoor/shutters{
 	id = "qm_warehouse";
@@ -17364,7 +17406,7 @@
 	},
 /obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel,
-/area/quartermaster/office)
+/area/quartermaster/sorting)
 "aSf" = (
 /obj/machinery/door/firedoor,
 /obj/structure/table/reinforced,
@@ -17375,7 +17417,7 @@
 	},
 /obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel,
-/area/quartermaster/office)
+/area/quartermaster/sorting)
 "aSg" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/door/airlock/mining/glass{
@@ -17383,13 +17425,14 @@
 	req_access_txt = "0";
 	req_one_access_txt = "48;50"
 	},
+/obj/machinery/door/firedoor,
 /turf/open/floor/plasteel,
-/area/quartermaster/office)
+/area/quartermaster/sorting)
 "aSh" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plating,
-/area/quartermaster/office)
+/area/quartermaster/sorting)
 "aSi" = (
 /obj/machinery/button/door{
 	id = "qm_warehouse";
@@ -18279,6 +18322,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
+/obj/machinery/door/firedoor,
 /turf/open/floor/plasteel,
 /area/quartermaster/office)
 "aUp" = (
@@ -18774,6 +18818,7 @@
 	id = "cargodeliver"
 	},
 /obj/effect/turf_decal/delivery,
+/obj/machinery/door/firedoor,
 /turf/open/floor/plasteel,
 /area/quartermaster/office)
 "aVt" = (
@@ -19914,9 +19959,7 @@
 	},
 /area/crew_quarters/theatre)
 "aYn" = (
-/obj/machinery/computer/cargo{
-	dir = 4
-	},
+/obj/machinery/computer/cargo,
 /obj/machinery/requests_console{
 	department = "Cargo Bay";
 	departmentType = 2;
@@ -20212,6 +20255,7 @@
 	pixel_x = 5;
 	pixel_y = -2
 	},
+/obj/machinery/door/firedoor,
 /turf/open/floor/plasteel/darkred/side{
 	dir = 8
 	},
@@ -20633,6 +20677,10 @@
 /obj/machinery/light{
 	dir = 8
 	},
+/obj/machinery/firealarm{
+	dir = 8;
+	pixel_x = -28
+	},
 /turf/open/floor/plasteel/green/side{
 	dir = 8
 	},
@@ -20706,6 +20754,7 @@
 	name = "kitchen shutters"
 	},
 /obj/item/storage/fancy/donut_box,
+/obj/machinery/door/firedoor,
 /turf/open/floor/plasteel/darkred/side{
 	dir = 8
 	},
@@ -21159,6 +21208,7 @@
 	id = "kitchenshutters";
 	name = "kitchen shutters"
 	},
+/obj/machinery/door/firedoor,
 /turf/open/floor/plasteel/darkred/side{
 	dir = 8
 	},
@@ -21304,6 +21354,7 @@
 	},
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/machinery/door/firedoor,
 /turf/open/floor/plasteel/brown,
 /area/quartermaster/qm)
 "bbH" = (
@@ -22695,10 +22746,6 @@
 	req_access_txt = "28"
 	},
 /turf/open/floor/plasteel/cafeteria,
-/area/crew_quarters/kitchen)
-"bfq" = (
-/obj/effect/spawner/structure/window,
-/turf/open/floor/plating,
 /area/crew_quarters/kitchen)
 "bfr" = (
 /obj/structure/sign/barsign,
@@ -24612,7 +24659,6 @@
 /turf/open/floor/plating,
 /area/science/robotics/lab)
 "bkw" = (
-/obj/machinery/door/firedoor,
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
@@ -27525,6 +27571,9 @@
 "bru" = (
 /obj/item/storage/toolbox/mechanical,
 /obj/machinery/holopad,
+/obj/machinery/light_switch{
+	pixel_x = 25
+	},
 /turf/open/floor/plasteel/whitepurple/side{
 	dir = 1
 	},
@@ -28829,6 +28878,9 @@
 	dir = 4;
 	pixel_x = 28
 	},
+/obj/machinery/light{
+	dir = 4
+	},
 /turf/open/floor/plasteel/white,
 /area/science/lab)
 "but" = (
@@ -28862,6 +28914,7 @@
 	req_one_access_txt = "0"
 	},
 /obj/effect/turf_decal/delivery,
+/obj/machinery/door/firedoor,
 /turf/open/floor/plasteel,
 /area/science/robotics/lab)
 "buw" = (
@@ -28872,14 +28925,14 @@
 /turf/open/floor/plasteel/darkpurple/side{
 	dir = 8
 	},
-/area/science/server)
+/area/science/research)
 "bux" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel/dark,
-/area/science/server)
+/area/science/research)
 "buy" = (
 /obj/item/twohanded/required/kirbyplants/photosynthetic{
 	pixel_y = 10
@@ -28888,7 +28941,7 @@
 	icon_state = "darkpurple";
 	dir = 4
 	},
-/area/science/server)
+/area/science/research)
 "buz" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
@@ -29260,6 +29313,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
+/obj/machinery/door/firedoor,
 /turf/open/floor/plasteel/white,
 /area/medical/chemistry)
 "bvr" = (
@@ -29310,7 +29364,7 @@
 	name = "Shutters Control Button";
 	pixel_x = -28;
 	pixel_y = -7;
-	req_access_txt = "7; 29"
+	req_access_txt = "47"
 	},
 /turf/open/floor/plasteel/white,
 /area/science/lab)
@@ -29424,13 +29478,13 @@
 	},
 /obj/effect/turf_decal/delivery,
 /turf/open/floor/plasteel/dark,
-/area/science/research/lobby)
+/area/science/research)
 "bvH" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
 /turf/closed/wall/r_wall,
-/area/science/research/lobby)
+/area/science/research)
 "bvI" = (
 /obj/structure/closet/emcloset,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -30240,7 +30294,7 @@
 	},
 /obj/effect/turf_decal/delivery,
 /turf/open/floor/plasteel/dark,
-/area/science/research/lobby)
+/area/science/research)
 "bxq" = (
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 4
@@ -30256,7 +30310,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
-/area/science/research/lobby)
+/area/science/research)
 "bxr" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -30833,6 +30887,10 @@
 /area/crew_quarters/heads/cmo)
 "byv" = (
 /obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/door/poddoor/preopen{
+	id = "cmoshutters";
+	name = "Privacy shutters"
+	},
 /turf/open/floor/plating,
 /area/crew_quarters/heads/cmo)
 "byw" = (
@@ -30952,13 +31010,25 @@
 /turf/open/floor/plasteel/white,
 /area/science/lab)
 "byH" = (
-/obj/structure/chair/stool,
-/turf/open/floor/plasteel/white,
+/obj/structure/table,
+/obj/item/stack/sheet/glass,
+/obj/item/stack/sheet/glass,
+/obj/item/stock_parts/capacitor,
+/obj/item/stock_parts/capacitor,
+/obj/item/stock_parts/manipulator,
+/obj/item/stock_parts/manipulator,
+/obj/item/stock_parts/scanning_module,
+/obj/item/stock_parts/scanning_module,
+/obj/item/device/multitool,
+/turf/open/floor/plasteel/whitepurple/side,
 /area/science/lab)
 "byI" = (
-/obj/structure/chair/stool,
+/obj/structure/table,
+/obj/machinery/cell_charger,
+/obj/item/stock_parts/cell/high/plus,
+/obj/item/stock_parts/cell/high/plus,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/turf/open/floor/plasteel/white,
+/turf/open/floor/plasteel/whitepurple/side,
 /area/science/lab)
 "byJ" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -31026,13 +31096,13 @@
 	},
 /obj/effect/turf_decal/delivery,
 /turf/open/floor/plasteel/dark,
-/area/science/research/lobby)
+/area/science/research)
 "byP" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
 /turf/closed/wall/r_wall,
-/area/science/research/lobby)
+/area/science/research)
 "byQ" = (
 /obj/structure/sink{
 	dir = 8;
@@ -31655,6 +31725,13 @@
 /obj/machinery/keycard_auth{
 	pixel_x = 26
 	},
+/obj/machinery/button/door{
+	dir = 4;
+	id = "cmoshutters";
+	name = "Privacy shutters";
+	pixel_x = 38;
+	req_access_txt = "40"
+	},
 /turf/open/floor/plasteel/cmo,
 /area/crew_quarters/heads/cmo)
 "bAe" = (
@@ -31758,63 +31835,65 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
-/obj/structure/window/reinforced,
-/turf/open/floor/plasteel/whitepurple/side,
-/area/science/lab)
+/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "rdprivacy";
+	name = "Privacy shutters"
+	},
+/turf/open/floor/plasteel/darkpurple/side{
+	icon_state = "darkpurple";
+	dir = 9
+	},
+/area/crew_quarters/heads/hor)
 "bAp" = (
 /obj/structure/cable{
 	icon_state = "1-2"
-	},
-/obj/machinery/door/window{
-	name = "Research Director's Office";
-	req_access_txt = "30"
 	},
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
 	dir = 4
 	},
-/turf/open/floor/plasteel/whitepurple/side,
-/area/science/lab)
+/obj/machinery/door/airlock/research{
+	name = "Research Director's Office";
+	req_access_txt = "30";
+	req_one_access_txt = "0"
+	},
+/turf/open/floor/plasteel/darkpurple/side{
+	dir = 1
+	},
+/area/crew_quarters/heads/hor)
 "bAq" = (
-/obj/structure/table,
-/obj/item/stack/sheet/glass,
-/obj/item/stack/sheet/glass,
-/obj/item/stock_parts/capacitor,
-/obj/item/stock_parts/capacitor,
-/obj/item/stock_parts/manipulator,
-/obj/item/stock_parts/manipulator,
-/obj/item/stock_parts/scanning_module,
-/obj/item/stock_parts/scanning_module,
-/obj/item/device/multitool,
-/obj/structure/window/reinforced,
-/turf/open/floor/plasteel/whitepurple/side,
-/area/science/lab)
+/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "rdprivacy";
+	name = "Privacy shutters"
+	},
+/turf/open/floor/plasteel/darkpurple/side{
+	dir = 1
+	},
+/area/crew_quarters/heads/hor)
 "bAr" = (
-/obj/structure/table,
-/obj/machinery/cell_charger,
-/obj/item/stock_parts/cell/high/plus,
-/obj/item/stock_parts/cell/high/plus,
-/obj/structure/window/reinforced,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/turf/open/floor/plasteel/whitepurple/side,
-/area/science/lab)
+/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "rdprivacy";
+	name = "Privacy shutters"
+	},
+/turf/open/floor/plasteel/darkpurple/side{
+	dir = 1
+	},
+/area/crew_quarters/heads/hor)
 "bAs" = (
-/obj/structure/table,
-/obj/item/stock_parts/matter_bin,
-/obj/item/stock_parts/matter_bin,
-/obj/item/stock_parts/micro_laser,
-/obj/item/stock_parts/micro_laser,
-/obj/item/stack/cable_coil,
-/obj/item/stack/cable_coil,
-/obj/machinery/light_switch{
-	pixel_x = 25
+/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "rdprivacy";
+	name = "Privacy shutters"
 	},
-/obj/machinery/light{
-	dir = 4
+/turf/open/floor/plasteel/darkpurple/side{
+	icon_state = "darkpurple";
+	dir = 5
 	},
-/obj/structure/window/reinforced,
-/turf/open/floor/plasteel/whitepurple/side,
-/area/science/lab)
+/area/crew_quarters/heads/hor)
 "bAt" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
@@ -32172,8 +32251,7 @@
 	icon_state = "0-4"
 	},
 /turf/open/floor/plasteel/darkpurple/side{
-	icon_state = "darkpurple";
-	dir = 9
+	dir = 8
 	},
 /area/crew_quarters/heads/hor)
 "bBr" = (
@@ -32184,26 +32262,20 @@
 	dir = 5
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/turf/open/floor/plasteel/darkpurple/side{
-	dir = 1
-	},
+/turf/open/floor/plasteel/dark,
 /area/crew_quarters/heads/hor)
 "bBs" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/turf/open/floor/plasteel/darkpurple/side{
-	dir = 1
-	},
+/turf/open/floor/plasteel/dark,
 /area/crew_quarters/heads/hor)
 "bBt" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/turf/open/floor/plasteel/darkpurple/side{
-	dir = 1
-	},
+/turf/open/floor/plasteel/dark,
 /area/crew_quarters/heads/hor)
 "bBu" = (
 /obj/item/twohanded/required/kirbyplants/dead,
@@ -32211,19 +32283,27 @@
 	dir = 10
 	},
 /obj/machinery/button/door{
-	id = "rndshutters";
-	name = "Research Lockdown";
-	pixel_x = 28;
+	desc = "A switch that controls privacy shutters.";
+	id = "rdprivacy";
+	name = "Privacy Shutters";
+	pixel_x = 40;
 	pixel_y = -5;
-	req_access_txt = "47"
+	req_access_txt = "30"
 	},
 /obj/machinery/keycard_auth{
 	pixel_x = 28;
 	pixel_y = 6
 	},
+/obj/machinery/button/door{
+	id = "research_shutters_2";
+	name = "Research Lockdown";
+	pixel_x = 28;
+	pixel_y = -5;
+	req_access_txt = "47"
+	},
 /turf/open/floor/plasteel/darkpurple/side{
 	icon_state = "darkpurple";
-	dir = 5
+	dir = 4
 	},
 /area/crew_quarters/heads/hor)
 "bBv" = (
@@ -32619,6 +32699,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
+/obj/machinery/door/firedoor,
 /turf/open/floor/plasteel/barber,
 /area/crew_quarters/heads/cmo)
 "bCr" = (
@@ -32773,6 +32854,10 @@
 /obj/machinery/computer/robotics{
 	dir = 4
 	},
+/obj/machinery/firealarm{
+	dir = 4;
+	pixel_x = -28
+	},
 /turf/open/floor/plasteel/darkpurple/side{
 	dir = 8
 	},
@@ -32808,8 +32893,8 @@
 "bCJ" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/door/poddoor/shutters/preopen{
-	id = "research_shutters_2";
-	name = "research shutters"
+	id = "rdprivacy";
+	name = "Privacy shutters"
 	},
 /turf/open/floor/plating,
 /area/crew_quarters/heads/hor)
@@ -33628,6 +33713,10 @@
 /obj/item/folder/blue,
 /obj/item/stamp/cmo,
 /obj/structure/table,
+/obj/machinery/firealarm{
+	dir = 1;
+	pixel_y = -26
+	},
 /turf/open/floor/plasteel/cmo,
 /area/crew_quarters/heads/cmo)
 "bEH" = (
@@ -34401,6 +34490,10 @@
 	c_tag = "Toxins Storage";
 	dir = 8;
 	network = list("ss13","rd")
+	},
+/obj/machinery/firealarm{
+	dir = 4;
+	pixel_x = 28
 	},
 /turf/open/floor/engine,
 /area/science/storage)
@@ -35682,6 +35775,10 @@
 /obj/machinery/atmospherics/pipe/manifold/cyan/hidden{
 	dir = 4
 	},
+/obj/machinery/firealarm{
+	dir = 8;
+	pixel_x = 28
+	},
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
 "bJo" = (
@@ -35717,6 +35814,7 @@
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 4
 	},
+/obj/machinery/door/firedoor,
 /turf/open/floor/plasteel/freezer,
 /area/medical/surgery)
 "bJr" = (
@@ -36258,6 +36356,10 @@
 "bKE" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 1
+	},
+/obj/machinery/firealarm{
+	dir = 8;
+	pixel_x = -26
 	},
 /turf/open/floor/plasteel/whiteblue/side{
 	dir = 8
@@ -38441,6 +38543,10 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/stripes/line,
+/obj/machinery/firealarm{
+	dir = 1;
+	pixel_y = 29
+	},
 /turf/open/floor/plasteel/dark,
 /area/engine/gravity_generator)
 "bQp" = (
@@ -38497,6 +38603,10 @@
 	pixel_y = 5
 	},
 /obj/item/stock_parts/cell/high/plus,
+/obj/machinery/firealarm{
+	dir = 1;
+	pixel_y = 29
+	},
 /turf/open/floor/plasteel/darkgreen,
 /area/storage/tech)
 "bQv" = (
@@ -39077,6 +39187,7 @@
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 4
 	},
+/obj/machinery/door/firedoor,
 /turf/open/floor/plasteel,
 /area/engine/gravity_generator)
 "bRI" = (
@@ -39105,6 +39216,7 @@
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 8
 	},
+/obj/machinery/door/firedoor,
 /turf/open/floor/plasteel,
 /area/storage/tech)
 "bRL" = (
@@ -39199,6 +39311,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
+/obj/machinery/door/firedoor,
 /turf/open/floor/plasteel/dark,
 /area/storage/tech)
 "bRV" = (
@@ -40109,6 +40222,7 @@
 	req_access_txt = "19;23"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/machinery/door/firedoor,
 /turf/open/floor/plasteel/dark,
 /area/storage/tech)
 "bUh" = (
@@ -45609,7 +45723,7 @@
 	pixel_y = 26
 	},
 /turf/open/floor/plasteel/dark,
-/area/library)
+/area/library/lounge)
 "cjQ" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/carpet,
@@ -45619,8 +45733,11 @@
 	icon_state = "1-4"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
 /turf/open/floor/carpet,
-/area/library)
+/area/library/lounge)
 "cjT" = (
 /obj/structure/grille,
 /obj/structure/cable{
@@ -45737,7 +45854,7 @@
 	},
 /obj/machinery/photocopier,
 /turf/open/floor/plasteel/dark,
-/area/library)
+/area/library/lounge)
 "ckm" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/carpet,
@@ -45752,7 +45869,7 @@
 	icon_state = "cobweb2"
 	},
 /turf/open/floor/plasteel/dark,
-/area/library)
+/area/library/lounge)
 "ckq" = (
 /obj/structure/grille,
 /turf/open/floor/plating/airless,
@@ -45839,8 +45956,12 @@
 /area/maintenance/department/chapel/monastery)
 "ckD" = (
 /obj/structure/chair/wood/normal,
+/obj/machinery/firealarm{
+	dir = 8;
+	pixel_x = -28
+	},
 /turf/open/floor/plasteel/dark,
-/area/library)
+/area/library/lounge)
 "ckE" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
 	dir = 1
@@ -45857,14 +45978,17 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
 /turf/open/floor/carpet,
-/area/library)
+/area/library/lounge)
 "ckG" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 8
 	},
 /turf/open/floor/plasteel/dark,
-/area/library)
+/area/library/lounge)
 "ckH" = (
 /turf/open/floor/plasteel/dark,
 /area/library)
@@ -45873,7 +45997,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
-/area/library)
+/area/library/lounge)
 "ckJ" = (
 /obj/structure/sign/warning/securearea,
 /turf/closed/wall/r_wall,
@@ -45932,22 +46056,23 @@
 	network = list("ss13","monastery")
 	},
 /turf/open/floor/plasteel/dark,
-/area/library)
+/area/library/lounge)
 "ckT" = (
 /obj/machinery/door/airlock/centcom{
 	name = "Library"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/machinery/door/firedoor,
 /turf/open/floor/plasteel/dark,
-/area/library)
+/area/library/lounge)
 "ckU" = (
 /obj/machinery/bookbinder,
 /turf/open/floor/plasteel/dark,
-/area/library)
+/area/library/lounge)
 "ckV" = (
 /obj/structure/bookcase/random/reference,
 /turf/open/floor/plasteel/dark,
-/area/library)
+/area/library/lounge)
 "ckW" = (
 /obj/structure/bookcase/random/nonfiction,
 /turf/open/floor/plasteel/dark,
@@ -45955,7 +46080,7 @@
 "ckX" = (
 /obj/structure/bookcase/random/fiction,
 /turf/open/floor/plasteel/dark,
-/area/library)
+/area/library/lounge)
 "clb" = (
 /obj/machinery/door/poddoor{
 	id = "chapelgun";
@@ -45990,7 +46115,7 @@
 	dir = 1
 	},
 /turf/open/floor/plasteel/dark,
-/area/library)
+/area/library/lounge)
 "cli" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 8
@@ -46009,15 +46134,15 @@
 	},
 /obj/machinery/libraryscanner,
 /turf/open/floor/plasteel/dark,
-/area/library)
+/area/library/lounge)
 "clm" = (
 /obj/structure/closet/crate/bin,
 /turf/open/floor/plasteel/dark,
-/area/library)
+/area/library/lounge)
 "cln" = (
 /obj/structure/bookcase/random/adult,
 /turf/open/floor/plasteel/dark,
-/area/library)
+/area/library/lounge)
 "clp" = (
 /obj/structure/table/wood,
 /obj/machinery/computer/libraryconsole/bookmanagement,
@@ -48848,7 +48973,7 @@
 /area/maintenance/department/chapel/monastery)
 "cwe" = (
 /turf/closed/wall/mineral/iron,
-/area/library)
+/area/library/lounge)
 "cwg" = (
 /obj/machinery/door/airlock/centcom{
 	name = "Library"
@@ -48857,8 +48982,9 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/machinery/door/firedoor,
 /turf/open/floor/plasteel/dark,
-/area/library)
+/area/library/lounge)
 "cwj" = (
 /obj/item/storage/box/matches{
 	pixel_x = -3;
@@ -48940,14 +49066,14 @@
 	},
 /obj/machinery/power/apc{
 	dir = 4;
-	name = "Library APC";
+	name = "Library Lounge APC";
 	pixel_x = 24
 	},
 /obj/machinery/airalarm{
 	pixel_y = 22
 	},
 /turf/open/floor/plasteel/dark,
-/area/library)
+/area/library/lounge)
 "cww" = (
 /obj/structure/table/wood,
 /obj/item/reagent_containers/food/snacks/grown/poppy,
@@ -49019,7 +49145,7 @@
 	dir = 8
 	},
 /turf/open/floor/carpet,
-/area/library)
+/area/library/lounge)
 "cwM" = (
 /obj/structure/window/reinforced{
 	dir = 4;
@@ -49046,13 +49172,16 @@
 /obj/structure/table/wood,
 /obj/machinery/computer/libraryconsole,
 /turf/open/floor/plasteel/dark,
-/area/library)
+/area/library/lounge)
 "cxe" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 8
 	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
 /turf/open/floor/carpet,
-/area/library)
+/area/library/lounge)
 "cxg" = (
 /obj/structure/window/reinforced{
 	dir = 1;
@@ -49089,21 +49218,25 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/carpet,
-/area/library)
+/area/library/lounge)
 "cxz" = (
 /obj/machinery/door/airlock/centcom{
 	name = "Library"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/effect/mapping_helpers/airlock/cyclelink_helper,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/door/firedoor,
 /turf/open/floor/plasteel/dark,
-/area/library)
+/area/library/lounge)
 "cxB" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 6
 	},
 /turf/closed/wall,
-/area/library)
+/area/library/lounge)
 "cxC" = (
 /obj/effect/turf_decal/stripes/corner{
 	dir = 1
@@ -49114,7 +49247,7 @@
 /turf/open/floor/plasteel/vault{
 	dir = 4
 	},
-/area/library)
+/area/library/lounge)
 "cxD" = (
 /obj/effect/turf_decal/stripes/corner{
 	dir = 2
@@ -49122,21 +49255,24 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 5
 	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
 /turf/open/floor/plasteel/vault{
 	dir = 1
 	},
-/area/library)
+/area/library/lounge)
 "cxE" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 10
 	},
 /turf/closed/wall,
-/area/library)
+/area/library/lounge)
 "cxJ" = (
 /obj/structure/window/reinforced/fulltile,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plating,
-/area/library)
+/area/library/lounge)
 "cxK" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -49147,20 +49283,23 @@
 /turf/open/floor/plasteel/vault{
 	dir = 4
 	},
-/area/library)
+/area/library/lounge)
 "cxL" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
 /turf/open/floor/plasteel/vault{
 	dir = 1
 	},
-/area/library)
+/area/library/lounge)
 "cxM" = (
 /obj/structure/window/reinforced/fulltile,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plating,
-/area/library)
+/area/library/lounge)
 "cxX" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -49173,7 +49312,7 @@
 /turf/open/floor/plasteel/vault{
 	dir = 4
 	},
-/area/library)
+/area/library/lounge)
 "cxY" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -49181,10 +49320,13 @@
 /obj/machinery/light/small{
 	dir = 4
 	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
 /turf/open/floor/plasteel/vault{
 	dir = 1
 	},
-/area/library)
+/area/library/lounge)
 "cyl" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -49192,22 +49334,25 @@
 /turf/open/floor/plasteel/vault{
 	dir = 4
 	},
-/area/library)
+/area/library/lounge)
 "cym" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
 /turf/open/floor/plasteel/vault{
 	dir = 1
 	},
-/area/library)
+/area/library/lounge)
 "cyy" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 5
 	},
 /turf/closed/wall,
-/area/library)
+/area/library/lounge)
 "cyz" = (
 /obj/effect/turf_decal/stripes/corner{
 	dir = 4
@@ -49218,7 +49363,7 @@
 /turf/open/floor/plasteel/vault{
 	dir = 4
 	},
-/area/library)
+/area/library/lounge)
 "cyA" = (
 /obj/effect/turf_decal/stripes/corner{
 	dir = 8
@@ -49226,16 +49371,19 @@
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 8
 	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
 /turf/open/floor/plasteel/vault{
 	dir = 1
 	},
-/area/library)
+/area/library/lounge)
 "cyB" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 9
 	},
 /turf/closed/wall,
-/area/library)
+/area/library/lounge)
 "cyL" = (
 /obj/structure/lattice,
 /obj/structure/lattice,
@@ -49260,6 +49408,10 @@
 	c_tag = "Monastery Archives Fore";
 	dir = 2;
 	network = list("ss13","monastery")
+	},
+/obj/machinery/firealarm{
+	dir = 1;
+	pixel_y = 29
 	},
 /turf/open/floor/plasteel/dark,
 /area/library)
@@ -49939,6 +50091,38 @@
 "cDa" = (
 /turf/closed/wall,
 /area/quartermaster/warehouse)
+"dse" = (
+/obj/structure/disposalpipe/segment{
+	dir = 6
+	},
+/turf/open/floor/plasteel,
+/area/quartermaster/sorting)
+"dMB" = (
+/turf/open/floor/plasteel,
+/area/quartermaster/sorting)
+"fwl" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/quartermaster/sorting)
+"fWv" = (
+/obj/structure/bookcase/random/religion,
+/turf/open/floor/plasteel/dark,
+/area/library/lounge)
+"ick" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plasteel/dark,
+/area/library)
+"ijF" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/carpet,
+/area/library)
 "izB" = (
 /obj/machinery/door/airlock/external{
 	name = "Escape Pod"
@@ -49948,6 +50132,10 @@
 	},
 /turf/open/floor/plating,
 /area/crew_quarters/dorms)
+"iKb" = (
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
+/area/quartermaster/sorting)
 "jgr" = (
 /obj/machinery/door/airlock/centcom{
 	name = "Library"
@@ -49956,8 +50144,34 @@
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 1
 	},
+/obj/machinery/door/firedoor,
 /turf/open/floor/plasteel/dark,
 /area/library)
+"jvi" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/firealarm{
+	dir = 1;
+	pixel_y = -26
+	},
+/turf/open/floor/plasteel/darkred/side{
+	dir = 1
+	},
+/area/crew_quarters/heads/hos)
+"jFO" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/carpet,
+/area/library/lounge)
+"jXh" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
+/area/library/lounge)
 "kjK" = (
 /obj/machinery/door/airlock/maintenance_hatch{
 	name = "MiniSat Maintenance";
@@ -49977,8 +50191,43 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/effect/mapping_helpers/airlock/cyclelink_helper,
+/obj/machinery/door/firedoor,
 /turf/open/floor/plasteel/dark,
-/area/library)
+/area/library/lounge)
+"lAs" = (
+/turf/closed/wall,
+/area/quartermaster/sorting)
+"lQQ" = (
+/obj/machinery/door/poddoor/preopen{
+	id = "bridgespace";
+	name = "bridge external shutters"
+	},
+/turf/open/floor/plasteel/vault{
+	dir = 8
+	},
+/area/bridge)
+"mdL" = (
+/obj/structure/table,
+/obj/item/stock_parts/matter_bin,
+/obj/item/stock_parts/matter_bin,
+/obj/item/stock_parts/micro_laser,
+/obj/item/stock_parts/micro_laser,
+/obj/item/stack/cable_coil,
+/obj/item/stack/cable_coil,
+/turf/open/floor/plasteel/whitepurple/side,
+/area/science/lab)
+"mCe" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/door/poddoor/preopen{
+	id = "Engineering";
+	name = "engineering security door"
+	},
+/turf/open/floor/plating,
+/area/security/checkpoint/engineering)
+"mKc" = (
+/obj/structure/bookcase/random/nonfiction,
+/turf/open/floor/plasteel/dark,
+/area/library/lounge)
 "oPy" = (
 /obj/machinery/door/airlock/external{
 	name = "Mining Dock Airlock";
@@ -50002,6 +50251,40 @@
 "pps" = (
 /turf/closed/wall,
 /area/engine/break_room)
+"pXc" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
+/turf/open/floor/carpet,
+/area/library)
+"qOE" = (
+/turf/open/floor/plasteel/dark,
+/area/library/lounge)
+"rxV" = (
+/obj/structure/table,
+/obj/machinery/microwave{
+	pixel_x = -3;
+	pixel_y = 6
+	},
+/obj/machinery/firealarm{
+	dir = 1;
+	pixel_y = 27
+	},
+/turf/open/floor/plasteel/cafeteria,
+/area/crew_quarters/kitchen)
+"sBA" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/machinery/firealarm{
+	dir = 1;
+	pixel_y = 29
+	},
+/turf/open/floor/plasteel/red/side{
+	dir = 1
+	},
+/area/security/brig)
 "sQt" = (
 /obj/machinery/door/airlock/external{
 	name = "Supply Dock Airlock";
@@ -50029,6 +50312,40 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 1
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/door/firedoor,
+/turf/open/floor/plasteel/dark,
+/area/library)
+"wxJ" = (
+/obj/effect/turf_decal/delivery,
+/obj/machinery/door/poddoor/preopen{
+	id = "prison release";
+	name = "prisoner processing blast door"
+	},
+/turf/open/floor/plasteel/dark,
+/area/security/brig)
+"xhj" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/turf/open/floor/carpet,
+/area/library/lounge)
+"xja" = (
+/obj/machinery/light/small{
+	dir = 4
+	},
+/obj/machinery/power/apc{
+	dir = 4;
+	name = "Library APC";
+	pixel_x = 24
+	},
+/obj/structure/cable,
+/turf/open/floor/plasteel/dark,
+/area/library)
+"xjc" = (
+/obj/structure/cable{
+	icon_state = "2-8"
 	},
 /turf/open/floor/plasteel/dark,
 /area/library)
@@ -67697,13 +68014,13 @@ cgG
 cfn
 ckE
 ckT
-cjQ
-cjQ
+xhj
+xhj
 cwK
-cjQ
-cjQ
+xhj
+xhj
 cxn
-cjQ
+xhj
 lqy
 cxC
 cxK
@@ -67955,12 +68272,12 @@ cvw
 cvK
 cwg
 cjR
-ckm
+jFO
 ckF
-ckm
+jFO
 cxe
-ckm
-ckm
+jFO
+jFO
 cxz
 cxD
 cxL
@@ -67968,8 +68285,8 @@ cxY
 cym
 cyA
 vOw
-ckm
-ckm
+ijF
+pXc
 ckm
 ckm
 ckm
@@ -68215,7 +68532,7 @@ cwr
 clm
 ckG
 cwU
-cli
+jXh
 ckU
 cwe
 cwe
@@ -68226,7 +68543,7 @@ cxM
 cyB
 cjp
 cyR
-ckH
+ick
 ckH
 ckH
 ckH
@@ -68469,10 +68786,10 @@ cvy
 cvL
 cwe
 cwe
-cko
-ckH
+fWv
+qOE
 ckV
-ckH
+qOE
 cln
 cwe
 cfN
@@ -68483,7 +68800,7 @@ aaa
 aaa
 cjp
 cyS
-ckH
+ick
 cyZ
 ckH
 czo
@@ -68726,10 +69043,10 @@ cvc
 cvM
 cfm
 cwe
-cko
-ckH
-ckW
-ckH
+fWv
+qOE
+mKc
+qOE
 cln
 cwe
 caS
@@ -68740,7 +69057,7 @@ aht
 aht
 cjp
 cko
-ckH
+ick
 ckH
 ckH
 clp
@@ -68997,7 +69314,7 @@ aaa
 aaa
 cjp
 cyT
-ckH
+ick
 cyZ
 ckH
 czp
@@ -69254,8 +69571,8 @@ aht
 aht
 cjp
 cjp
-ckH
-ckI
+xjc
+xja
 ckH
 czq
 czw
@@ -69906,7 +70223,7 @@ apE
 apE
 ari
 apE
-atu
+bBW
 apE
 avq
 apE
@@ -70161,9 +70478,9 @@ aok
 aoO
 apF
 apE
-aqC
+wxJ
 apE
-atu
+bBW
 ajM
 avr
 awH
@@ -73501,7 +73818,7 @@ anJ
 amX
 aoY
 apN
-aqp
+sBA
 arp
 asB
 atB
@@ -74288,7 +74605,7 @@ aDv
 aBh
 aBh
 aGd
-aGW
+aEY
 aHG
 aIM
 aJG
@@ -76838,7 +77155,7 @@ akW
 alK
 amw
 ani
-anT
+jvi
 aiR
 aph
 ajM
@@ -79445,7 +79762,7 @@ aRN
 aWa
 aRN
 aRN
-bce
+rxV
 aYS
 cpn
 bch
@@ -80222,7 +80539,7 @@ baa
 baa
 baa
 beu
-bfq
+bgk
 bgn
 aJI
 aDZ
@@ -82320,7 +82637,7 @@ bUi
 bUV
 bVO
 bWA
-bTC
+mCe
 bYj
 bYQ
 bZA
@@ -82577,7 +82894,7 @@ bUj
 bUW
 bVP
 bWB
-bTC
+mCe
 bYk
 bYQ
 bZA
@@ -82759,7 +83076,7 @@ ahi
 atY
 auU
 atY
-axf
+lQQ
 ayf
 axf
 aAF
@@ -82834,7 +83151,7 @@ bUk
 bUX
 bVQ
 bWC
-bTC
+mCe
 bYl
 bYO
 bZC
@@ -84608,7 +84925,7 @@ bsT
 bus
 bvz
 bxg
-byH
+mdL
 bAs
 bBu
 bCI
@@ -85339,7 +85656,7 @@ aBI
 aES
 aBI
 aBI
-aGW
+aEY
 aHG
 aBI
 aJX
@@ -85362,7 +85679,7 @@ aMb
 aSX
 aMb
 aBI
-aGW
+aEY
 bgA
 bhe
 aDZ
@@ -87142,13 +87459,13 @@ aAN
 aHN
 aIU
 aJI
-aLf
-aLf
+lAs
+lAs
 aNG
 aOR
-aPW
-aLf
-aLf
+iKb
+lAs
+lAs
 aTb
 aOT
 aVp
@@ -87399,7 +87716,7 @@ aET
 aHN
 aIU
 aJI
-aLf
+lAs
 aMg
 aNH
 aOS
@@ -87656,11 +87973,11 @@ aET
 aHN
 aJh
 bhe
-aLf
+lAs
 aMh
 aNI
-aOT
-aPY
+fwl
+dMB
 aRi
 aSf
 aTd
@@ -87913,13 +88230,13 @@ aHn
 aIi
 aJi
 aKe
-aLf
+lAs
 aMi
 aNJ
-aOT
+fwl
 aPZ
 aRj
-aLf
+lAs
 aTe
 aUo
 aVs
@@ -88170,13 +88487,13 @@ aET
 aHN
 aIU
 aJI
-aLf
+lAs
 aMj
 aNK
-aOT
-aPY
-aPY
-aPW
+fwl
+dMB
+dMB
+iKb
 aTf
 aUp
 aVt
@@ -88427,7 +88744,7 @@ aET
 aHN
 aIU
 aJI
-aLf
+lAs
 aMk
 aNL
 aOU
@@ -88684,10 +89001,10 @@ cos
 coy
 aJj
 aJI
-aLf
+lAs
 aMl
 aNM
-aOV
+dse
 aQb
 aRl
 aSh
@@ -88941,13 +89258,13 @@ aDZ
 aDZ
 aJk
 aJH
-aLf
+lAs
 aMm
-aLf
+lAs
 aOW
-aLf
-aLf
-aLf
+lAs
+lAs
+lAs
 aSY
 aUs
 aLf
@@ -89198,11 +89515,11 @@ aBI
 aBI
 aJl
 aKf
-aLf
+lAs
 aMn
-aLf
+lAs
 aOX
-aLf
+lAs
 aRm
 aLg
 aTi


### PR DESCRIPTION
:cl: Denton
fix: Burglar alarms in the Pubbystation library and RD office can now be disabled properly.
fix: Fixed Pubbystation's RD office shutters.
add: Added missing engineering and kitchen lockdown shutters on Pubbystation.
add: Pubbystation: Added privacy shutters to the CMO and RD offices. Added space shutters to the HoS office. Replaced the RD office's directional windows with fulltile ones.
add: Added a second blast door to the Pubbystation gulag shuttle lockdown.
tweak: Due to pressure from the space OSHA, Pubbystation has installed missing fire alarms and firelocks.
tweak: Split the Pubbystation library into two areas with their own APCs.
/:cl:

This PR covers a bunch of Pubbystation bugfixes (mostly missing firelocks and alarms) and additions (privacy shutters).

If it's a huge pain in the ass to review I can atomize this.
		
**Firelocks/alarms:**
- Added missing firelocks and fire alarms in almost all statíon areas minus the monastery - there, I only added them to the library to fix #35957.
- Half the station either had missing fire alarms, firelocks or both.

**Changes:**
- Replaced the RD office's directional r-windows and windoor with fulltile r-windows and an airlock. Even though the original design was pretty, this had to be done to fix #35957.
- Added privacy shutters to the CMO and RD offices. Added space shutters to the HoS office.
- Split the library into two areas - lounge and main area. Added an APC to the main area. This is partially to fix #35957, but also because it is one large area that was "magically" powered by a single APC.
- Changed the mail delivery room's area type to quartermaster/sorting.
Added a second blast door to the gulag shuttle entrance.

**Fixes:**
- Deleted duplicate fire lock at Robotics.
- Fixed defunct RD office shutters/buttons and their req_ids.
- Fixed a couple of area issues. For example: the burglar alarm would not affect all doors in the captain's office. RnD fire alarm would not trigger the server room firelock, etc.
- Placed missing shutters (kitchen and engineering).

Closes: #35957