### PR TITLE
[READY AND TESTED]Projectiles now properly delete themselves if they try to move and their trajectory is at an invalid turf

### DIFF
--- a/code/modules/projectiles/projectile.dm
+++ b/code/modules/projectiles/projectile.dm
@@ -419,6 +419,9 @@
 		transform = M
 	trajectory.increment(trajectory_multiplier)
 	var/turf/T = trajectory.return_turf()
+	if(!istype(T))
+		qdel(src)
+		return
 	if(T.z != loc.z)
 		var/old = loc
 		before_z_change(loc, T)


### PR DESCRIPTION
title
Fixes #35890