### PR TITLE
Expands ORM accepted accesses

### DIFF
--- a/code/modules/mining/machine_redemption.dm
+++ b/code/modules/mining/machine_redemption.dm
@@ -10,7 +10,7 @@
 	anchored = TRUE
 	input_dir = NORTH
 	output_dir = SOUTH
-	req_access = list(ACCESS_MINERAL_STOREROOM)
+	req_access = list(ACCESS_MINERAL_STOREROOM, ACCESS_MEDICAL, ACCESS_ARMORY, ACCESS_CONSTRUCTION)
 	speed_process = TRUE
 	circuit = /obj/item/circuitboard/machine/ore_redemption
 	var/req_access_reclaim = ACCESS_MINING_STATION

--- a/code/modules/mining/machine_redemption.dm
+++ b/code/modules/mining/machine_redemption.dm
@@ -10,7 +10,7 @@
 	anchored = TRUE
 	input_dir = NORTH
 	output_dir = SOUTH
-	req_access = list(ACCESS_MINERAL_STOREROOM, ACCESS_MEDICAL, ACCESS_ARMORY, ACCESS_CONSTRUCTION)
+	req_one_access = list(ACCESS_MINERAL_STOREROOM, ACCESS_MEDICAL, ACCESS_ARMORY, ACCESS_CONSTRUCTION)
 	speed_process = TRUE
 	circuit = /obj/item/circuitboard/machine/ore_redemption
 	var/req_access_reclaim = ACCESS_MINING_STATION
@@ -257,7 +257,7 @@
 		if("Release")
 
 			if(check_access(inserted_id) || allowed(usr)) //Check the ID inside, otherwise check the user
-				if(params["id"] == "all")
+				if(params["id"] == "any")
 					materials.retrieve_all(get_step(src, output_dir))
 				else
 					var/mat_id = params["id"]


### PR DESCRIPTION
[Changelogs]: The ORM machine will now accept accesses from other departments, meaning you don't have to pester cargo or break the machine to fill your department lathes any more. Most access requirements are generic - bar security's, considering their lathe's the one with the weaponry.

:cl:
balance: The ORM is now accessible to a wider range of people
/:cl:

[why]: Honestly I was just going to remove the access altogether since the machine only needs a screwdriver and a crowbar to deconstruct and get at the materials but this is a comprimise.