### PR TITLE
Add support for auto admin when ran in single user mode

### DIFF
--- a/code/modules/client/client_procs.dm
+++ b/code/modules/client/client_procs.dm
@@ -183,7 +183,7 @@ GLOBAL_LIST_EMPTY(external_rsc_urls)
 				new /datum/admins(autorank, ckey)
 	if(CONFIG_GET(flag/enable_localhost_rank) && !connecting_admin)
 		var/localhost_addresses = list("127.0.0.1", "::1")
-		if(address && (address in localhost_addresses))
+		if(isnull(address) || (address in localhost_addresses))
 			var/datum/admin_rank/localhost_rank = new("!localhost!", 65535, 16384, 65535) //+EVERYTHING -DBRANKS *EVERYTHING
 			new /datum/admins(localhost_rank, ckey, 1, 1)
 	//preferences datum - also holds some persistent data for the client (because we may as well keep these datums to a minimum)


### PR DESCRIPTION
address is null in single user mode, but we didn't support that because address has been null because of a byond bug, but now that this is a config we don't have to care since its off in production.
