### PR TITLE
Fix nightshift skipping certain maint APCs

### DIFF
--- a/code/controllers/subsystem/nightshift.dm
+++ b/code/controllers/subsystem/nightshift.dm
@@ -8,7 +8,6 @@ SUBSYSTEM_DEF(nightshift)
 	var/nightshift_end_time = 270000		//7:30 AM, station time
 	var/nightshift_first_check = 30 SECONDS
 
-	var/obey_security_level = TRUE
 	var/high_security_mode = FALSE
 
 /datum/controller/subsystem/nightshift/Initialize()
@@ -21,48 +20,38 @@ SUBSYSTEM_DEF(nightshift)
 		return
 	check_nightshift()
 
+/datum/controller/subsystem/nightshift/proc/announce(message)
+	priority_announce(message, sound='sound/misc/notice2.ogg', sender_override="Automated Lighting System Announcement")
+
 /datum/controller/subsystem/nightshift/proc/check_nightshift(force_set = FALSE)
-	var/time = station_time()
-	var/nightshift = time < nightshift_end_time || time > nightshift_start_time
-	var/red_or_delta = GLOB.security_level == SEC_LEVEL_RED || GLOB.security_level == SEC_LEVEL_DELTA
+	var/emergency = GLOB.security_level >= SEC_LEVEL_RED
+	var/nightshift = FALSE
+	if (!emergency)
+		var/time = station_time()
+		nightshift = time < nightshift_end_time || time > nightshift_start_time
+
 	var/announcing = TRUE
-	if(nightshift && red_or_delta)
-		nightshift = FALSE
-	if(high_security_mode && !red_or_delta)
+	if(high_security_mode && !emergency)
 		high_security_mode = FALSE
-		priority_announce("Restoring night lighting configuration to normal operation.", sound='sound/misc/notice2.ogg', sender_override="Automated Lighting System Announcement")
+		announce("Restoring night lighting configuration to normal operation.")
 		announcing = FALSE
-	else if(!high_security_mode && red_or_delta)
+	else if(!high_security_mode && emergency)
 		high_security_mode = TRUE
-		priority_announce("Night lighting disabled: Station is in a state of emergency.", sound='sound/misc/notice2.ogg', sender_override="Automated Lighting System Announcement")
+		announce("Night lighting disabled: Station is in a state of emergency.")
 		announcing = FALSE
 
 	if((nightshift_active != nightshift) || force_set)
-		nightshift? activate_nightshift(announcing) : deactivate_nightshift(announcing)
+		update_nightshift(nightshift, announcing)
 
-/datum/controller/subsystem/nightshift/proc/activate_nightshift(announce = TRUE)
-	if(!nightshift_active)
-		if(announce)
-			priority_announce("Good evening, crew. To reduce power consumption and stimulate the circadian rhythms of some species, all of the lights aboard the station have been dimmed for the night.", sound='sound/misc/notice2.ogg', sender_override="Automated Lighting System Announcement")
-		nightshift_active = TRUE
-	var/list/area/affected = return_nightshift_area_types()
+/datum/controller/subsystem/nightshift/proc/update_nightshift(active, announce = TRUE)
+	nightshift_active = active
+	if(announce)
+		if (active)
+			announce("Good evening, crew. To reduce power consumption and stimulate the circadian rhythms of some species, all of the lights aboard the station have been dimmed for the night.")
+		else
+			announce("Good morning, crew. As it is now day time, all of the lights aboard the station have been restored to their former brightness.")
 	for(var/A in GLOB.apcs_list)
 		var/obj/machinery/power/apc/APC = A
-		if (APC.area.type in affected)
-			APC.set_nightshift(TRUE)
+		if (APC.area && (APC.area.type in GLOB.the_station_areas))
+			APC.set_nightshift(active)
 			CHECK_TICK
-
-/datum/controller/subsystem/nightshift/proc/deactivate_nightshift(announce = TRUE)
-	if(nightshift_active)
-		if(announce)
-			priority_announce("Good morning, crew. As it is now day time, all of the lights aboard the station have been restored to their former brightness.", sound='sound/misc/notice2.ogg', sender_override="Automated Lighting System Announcement")
-		nightshift_active = FALSE
-	var/list/area/affected = return_nightshift_area_types()
-	for(var/A in GLOB.apcs_list)
-		var/obj/machinery/power/apc/APC = A
-		if (APC.area.type in affected)
-			APC.set_nightshift(FALSE)
-			CHECK_TICK
-
-/datum/controller/subsystem/nightshift/proc/return_nightshift_area_types()
-	return GLOB.the_station_areas

--- a/code/controllers/subsystem/nightshift.dm
+++ b/code/controllers/subsystem/nightshift.dm
@@ -46,9 +46,9 @@ SUBSYSTEM_DEF(nightshift)
 			priority_announce("Good evening, crew. To reduce power consumption and stimulate the circadian rhythms of some species, all of the lights aboard the station have been dimmed for the night.", sound='sound/misc/notice2.ogg', sender_override="Automated Lighting System Announcement")
 		nightshift_active = TRUE
 	var/list/area/affected = return_nightshift_area_types()
-	for(var/i in affected)
-		var/area/A = locate(i) in GLOB.sortedAreas
-		for(var/obj/machinery/power/apc/APC in A)
+	for(var/A in GLOB.apcs_list)
+		var/obj/machinery/power/apc/APC = A
+		if (APC.area.type in affected)
 			APC.set_nightshift(TRUE)
 			CHECK_TICK
 
@@ -58,11 +58,11 @@ SUBSYSTEM_DEF(nightshift)
 			priority_announce("Good morning, crew. As it is now day time, all of the lights aboard the station have been restored to their former brightness.", sound='sound/misc/notice2.ogg', sender_override="Automated Lighting System Announcement")
 		nightshift_active = FALSE
 	var/list/area/affected = return_nightshift_area_types()
-	for(var/i in affected)
-		var/area/A = locate(i) in GLOB.sortedAreas
-		for(var/obj/machinery/power/apc/APC in A)
+	for(var/A in GLOB.apcs_list)
+		var/obj/machinery/power/apc/APC = A
+		if (APC.area.type in affected)
 			APC.set_nightshift(FALSE)
 			CHECK_TICK
 
 /datum/controller/subsystem/nightshift/proc/return_nightshift_area_types()
-	return GLOB.the_station_areas.Copy()
+	return GLOB.the_station_areas


### PR DESCRIPTION
:cl:
fix: Night shift no longer ignores rooms whose APCs are in port or starboard central maintenance.
/:cl:

`locate(/area/maintenance/port) in GLOB.sortedAreas` might actually result in the `/area/maintenance/port/aft` instance being returned, thus any areas whose APCs were inside `/area/maintenance/port` would not be updated for nightshift. Instead of looping the contents of every affected area to find APCs, we now loop the APC list and act on any APC whose associated area should be affected.