### PR TITLE
Cult Fixes and Minor Balance Tweaks

### DIFF
--- a/code/game/gamemodes/cult/cult.dm
+++ b/code/game/gamemodes/cult/cult.dm
@@ -26,8 +26,8 @@
 			return FALSE
 	else
 		return FALSE
-	if(M.isloyal() || issilicon(M) || isbot(M) || isdrone(M) || is_servant_of_ratvar(M))
-		return FALSE //can't convert machines, shielded, or ratvar's dogs
+	if(M.isloyal() || issilicon(M) || isbot(M) || isdrone(M) || is_servant_of_ratvar(M) || !M.client)
+		return FALSE //can't convert machines, shielded, braindead, or ratvar's dogs
 	return TRUE
 
 /datum/game_mode/cult
@@ -80,7 +80,7 @@
 		cultist.special_role = ROLE_CULTIST
 		cultist.restricted_roles = restricted_jobs
 		log_game("[cultist.key] (ckey) has been selected as a cultist")
-	
+
 
 	return (cultists_to_cult.len>=required_enemies)
 

--- a/code/game/machinery/doors/airlock_types.dm
+++ b/code/game/machinery/doors/airlock_types.dm
@@ -418,6 +418,19 @@
 /obj/machinery/door/airlock/cult/canAIControl(mob/user)
 	return (iscultist(user) && !isAllPowerCut())
 
+/obj/machinery/door/airlock/cult/obj_break(damage_flag)
+	if(!(flags_1 & BROKEN) && !(flags_1 & NODECONSTRUCT_1))
+		stat |= BROKEN
+		if(!panel_open)
+			panel_open = TRUE
+		update_icon()
+
+/obj/machinery/door/airlock/cult/isElectrified()
+	return FALSE
+
+/obj/machinery/door/airlock/cult/hasPower()
+	return TRUE
+
 /obj/machinery/door/airlock/cult/allowed(mob/living/L)
 	if(!density)
 		return 1
@@ -487,7 +500,7 @@
 /obj/machinery/door/airlock/cult/weak
 	name = "brittle cult airlock"
 	desc = "An airlock hastily corrupted by blood magic, it is unusually brittle in this state."
-	normal_integrity = 180
+	normal_integrity = 150
 	damage_deflection = 5
 	armor = list("melee" = 0, "bullet" = 0, "laser" = 0,"energy" = 0, "bomb" = 0, "bio" = 0, "rad" = 0, "fire" = 0, "acid" = 0)
 

--- a/code/game/turfs/simulated/floor/reinf_floor.dm
+++ b/code/game/turfs/simulated/floor/reinf_floor.dm
@@ -114,6 +114,7 @@
 	desc = "The air hangs heavy over this sinister flooring."
 	icon_state = "plating"
 	CanAtmosPass = ATMOS_PASS_NO
+	floor_tile = null
 	var/obj/effect/clockwork/overlay/floor/bloodcult/realappearance
 
 

--- a/code/modules/antagonists/cult/blood_magic.dm
+++ b/code/modules/antagonists/cult/blood_magic.dm
@@ -72,10 +72,10 @@
 	else
 		to_chat(owner, "<span class='cultitalic'>You are already invoking blood magic!")
 		return
-	if(do_after(owner, 100 - rune*65, target = owner))
+	if(do_after(owner, 100 - rune*60, target = owner))
 		if(ishuman(owner))
 			var/mob/living/carbon/human/H = owner
-			H.bleed(30 - rune*25)
+			H.bleed(40 - rune*32)
 		var/datum/action/innate/cult/blood_spell/new_spell = new BS(owner)
 		new_spell.Grant(owner, src)
 		spells += new_spell
@@ -177,6 +177,7 @@
 	desc = "<u>A sinister spell used to convert:</u><br>Plasteel into runed metal<br>25 metal into a construct shell<br>Cyborgs directly into constructs<br>Cyborg shells into construct shells<br>Airlocks into runed airlocks (harm intent)"
 	button_icon_state = "transmute"
 	magic_path = "/obj/item/melee/blood_magic/construction"
+	health_cost = 10
 
 /datum/action/innate/cult/blood_spell/equipment
 	name = "Summon Equipment"
@@ -414,7 +415,7 @@
 			target.visible_message("<span class='warning'>[L]'s holy weapon absorbs the light!</span>", \
 								   "<span class='userdanger'>Your holy weapon absorbs the blinding light!</span>")
 		else
-			L.Knockdown(180)
+			L.Knockdown(160)
 			L.flash_act(1,1)
 			if(issilicon(target))
 				var/mob/living/silicon/S = L
@@ -733,11 +734,11 @@
 			to_chat(user, "<span class='cultitalic'>You decide against conducting a greater blood rite.</span>")
 			return
 		switch(choice)
-			if("Blood Spear (200)")
-				if(uses < 200)
+			if("Blood Spear (150)")
+				if(uses < 150)
 					to_chat(user, "<span class='cultitalic'>You need 200 charges to perform this rite.</span>")
 				else
-					uses -= 200
+					uses -= 150
 					var/turf/T = get_turf(user)
 					qdel(src)
 					var/datum/action/innate/cult/spear/S = new(user)
@@ -749,24 +750,24 @@
 					else
 						user.visible_message("<span class='warning'>A [rite.name] appears at [user]'s feet!</span>", \
 							 "<span class='cultitalic'>A [rite.name] materializes at your feet.</span>")
-			if("Blood Bolt Barrage (400)")
-				if(uses < 400)
+			if("Blood Bolt Barrage (300)")
+				if(uses < 300)
 					to_chat(user, "<span class='cultitalic'>You need 400 charges to perform this rite.</span>")
 				else
 					var/obj/rite = new /obj/item/gun/ballistic/shotgun/boltaction/enchanted/arcane_barrage/blood()
-					uses -= 400
+					uses -= 300
 					qdel(src)
 					if(user.put_in_hands(rite))
 						to_chat(user, "<span class='cult'><b>Your hands glow with power!</b></span>")
 					else
 						to_chat(user, "<span class='cultitalic'>You need a free hand for this rite!</span>")
 						qdel(rite)
-			if("Blood Beam (600)")
-				if(uses < 600)
+			if("Blood Beam (500)")
+				if(uses < 500)
 					to_chat(user, "<span class='cultitalic'>You need 600 charges to perform this rite.</span>")
 				else
 					var/obj/rite = new /obj/item/blood_beam()
-					uses -= 600
+					uses -= 500
 					qdel(src)
 					if(user.put_in_hands(rite))
 						to_chat(user, "<span class='cultlarge'><b>Your hands glow with POWER OVERWHELMING!!!</b></span>")

--- a/code/modules/antagonists/cult/runes.dm
+++ b/code/modules/antagonists/cult/runes.dm
@@ -32,8 +32,6 @@ Runes can either be invoked by one's self or with many different cultists. Each 
 
 	var/scribe_delay = 40 //how long the rune takes to create
 	var/scribe_damage = 0.1 //how much damage you take doing it
-
-	var/allow_excess_invokers = FALSE //if we allow excess invokers when being invoked
 	var/invoke_damage = 0 //how much damage invokers take when invoking it
 	var/construct_invoke = TRUE //if constructs can invoke it
 
@@ -109,12 +107,9 @@ structure_check() searches for nearby cultist structures required for the invoca
 /obj/effect/rune/proc/can_invoke(var/mob/living/user=null)
 	//This proc determines if the rune can be invoked at the time. If there are multiple required cultists, it will find all nearby cultists.
 	var/list/invokers = list() //people eligible to invoke the rune
-	var/list/chanters = list() //people who will actually chant the rune when passed to invoke()
 	if(user)
-		chanters += user
 		invokers += user
-	
-	if(req_cultists > 1 || allow_excess_invokers)
+	if(req_cultists > 1 || istype(src, /obj/effect/rune/convert))
 		var/list/things_in_range = range(1, src)
 		var/obj/item/toy/plush/narplush/plushsie = locate() in things_in_range
 		if(istype(plushsie) && plushsie.is_invoker)
@@ -130,17 +125,7 @@ structure_check() searches for nearby cultist structures required for the invoca
 				if(L.stat)
 					continue
 				invokers += L
-			if(allow_excess_invokers)
-				chanters += invokers
-			else
-				shuffle_inplace(invokers)
-				for(var/i in 1 to req_cultists)
-					var/C = pick_n_take(invokers)
-					if(!C)
-						break
-					if(C != user)
-						chanters += C
-	return chanters
+	return invokers
 
 /obj/effect/rune/proc/invoke(var/list/invokers)
 	//This proc contains the effects of the rune as well as things that happen afterwards. If you want it to spawn an object and then delete itself, have both here.
@@ -160,9 +145,9 @@ structure_check() searches for nearby cultist structures required for the invoca
 /obj/effect/rune/proc/do_invoke_glow()
 	set waitfor = FALSE
 	var/oldtransform = transform
-	animate(src, transform = matrix()*2, alpha = 0, time = 5) //fade out
+	animate(src, transform = matrix()*2, alpha = 0, time = 5, flags = ANIMATION_END_NOW) //fade out
 	sleep(5)
-	animate(src, transform = oldtransform, alpha = 255, time = 0)
+	animate(src, transform = oldtransform, alpha = 255, time = 0, flags = ANIMATION_END_NOW)
 
 /obj/effect/rune/proc/fail_invoke()
 	//This proc contains the effects of a rune if it is not invoked correctly, through either invalid wording or not enough cultists. By default, it's just a basic fizzle.
@@ -197,7 +182,6 @@ structure_check() searches for nearby cultist structures required for the invoca
 	icon_state = "3"
 	color = RUNE_COLOR_OFFER
 	req_cultists = 1
-	allow_excess_invokers = TRUE
 	rune_in_use = FALSE
 
 /obj/effect/rune/convert/do_invoke_glow()
@@ -247,7 +231,7 @@ structure_check() searches for nearby cultist structures required for the invoca
 /obj/effect/rune/convert/proc/do_convert(mob/living/convertee, list/invokers)
 	if(invokers.len < 2)
 		for(var/M in invokers)
-			to_chat(M, "<span class='warning'>You need more invokers to convert [convertee]!</span>")
+			to_chat(M, "<span class='danger'>You need at least two invokers to convert [convertee]!</span>")
 		log_game("Offer rune failed - tried conversion with one invoker")
 		return 0
 	if(convertee.anti_magic_check(TRUE, TRUE))
@@ -938,7 +922,6 @@ structure_check() searches for nearby cultist structures required for the invoca
 	icon_state = "apoc"
 	pixel_x = -32
 	pixel_y = -32
-	allow_excess_invokers = TRUE
 	color = RUNE_COLOR_DARKRED
 	req_cultists = 3
 	scribe_delay = 100

--- a/code/modules/mob/living/simple_animal/shade.dm
+++ b/code/modules/mob/living/simple_animal/shade.dm
@@ -6,8 +6,8 @@
 	icon = 'icons/mob/mob.dmi'
 	icon_state = "shade"
 	icon_living = "shade"
-	maxHealth = 50
-	health = 50
+	maxHealth = 40
+	health = 40
 	spacewalk = TRUE
 	healable = 0
 	speak_emote = list("hisses")
@@ -17,12 +17,11 @@
 	response_harm   = "punches"
 	speak_chance = 1
 	melee_damage_lower = 5
-	melee_damage_upper = 15
+	melee_damage_upper = 12
 	attacktext = "metaphysically strikes"
 	minbodytemp = 0
 	maxbodytemp = INFINITY
 	atmos_requirements = list("min_oxy" = 0, "max_oxy" = 0, "min_tox" = 0, "max_tox" = 0, "min_co2" = 0, "max_co2" = 0, "min_n2" = 0, "max_n2" = 0)
-	speed = -1
 	stop_automated_movement = 1
 	status_flags = 0
 	faction = list("cult")

--- a/code/modules/reagents/chemistry/reagents/other_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/other_reagents.dm
@@ -217,13 +217,18 @@
 			to_chat(M, "<span class='cultlarge'>Your blood rites falter as holy water scours your body!</span>")
 			for(var/datum/action/innate/cult/blood_spell/BS in BM.spells)
 				qdel(BS)
-	if(data >= 30)		// 12 units, 54 seconds @ metabolism 0.4 units & tick rate 1.8 sec
+	if(data >= 25)		// 10 units, 45 seconds @ metabolism 0.4 units & tick rate 1.8 sec
 		if(!M.stuttering)
 			M.stuttering = 1
 		M.stuttering = min(M.stuttering+4, 10)
 		M.Dizzy(5)
-		if(iscultist(M) && prob(5))
+		if(iscultist(M) && prob(8))
 			M.say(pick("Av'te Nar'sie","Pa'lid Mors","INO INO ORA ANA","SAT ANA!","Daim'niodeis Arc'iai Le'eones","R'ge Na'sie","Diabo us Vo'iscum","Eld' Mon Nobis"))
+			if(prob(20))
+				M.visible_message("<span class='danger'>[M] starts having a seizure!</span>", "<span class='userdanger'>You have a seizure!</span>")
+				M.Unconscious(120)
+				to_chat(M, "<span class='cultlarge'>[pick("Your blood is your bond - you are nothing without it", "Do not forget your place", \
+				"All that power, and you still fail?", "If you cannot scour this poison, I shall scour your meager life!")].</span>")
 		else if(is_servant_of_ratvar(M) && prob(8))
 			switch(pick("speech", "message", "emote"))
 				if("speech")


### PR DESCRIPTION
:cl: Robustin
fix: One-man conversions are actually fixed this time - excess chanters var removed for a more readable and maintainable rune code. 
fix: Runes should no longer become GIANT if spammed (credit to Joan for this fix).
fix: Pylons are no longer a source of infinite rods. 
tweak: Attempting conversion without 2 cultists present will give a more helpful warning. 
tweak: You can no longer convert braindead individuals. 
balance: Cult doors will no longer lose power but also cannot shock people, brittle cult doors have 30 less integrity. Therefore ordinary crew can now beat cult airlocks open without frying themselves. 
balance: Blood magic now costs slightly more blood and takes slightly more time, the stun spell now stuns for 2 less seconds, twisted construction now costs 10 health, and the blood rite relics (halberd, bolts, beam) are all 50-100 charges cheaper. 
balance: The deconversion time for holy water is slightly reduced, 10 units and 45 seconds (give or take), is all you should need now. Blood cultists can now have seizures while afflicted with holy water. 
balance: Shades are now slower and have a modest reduction to their damage and health.
/:cl:

Closes #35294