### PR TITLE
Disables night shifts and random shift times in the config

### DIFF
--- a/config/game_options.txt
+++ b/config/game_options.txt
@@ -507,10 +507,10 @@ MICE_ROUNDSTART 10
 ROUNDSTART_TRAITS
 
 ## Enable night shifts ##
-ENABLE_NIGHT_SHIFTS
+#ENABLE_NIGHT_SHIFTS
 
 ## Enable randomized shift start times##
-RANDOMIZE_SHIFT_TIME
+#RANDOMIZE_SHIFT_TIME
 
 ## Sets shift time to server time at roundstart. Overridden by RANDOMIZE_SHIFT_TIME ##
 #SHIFT_TIME_REALTIME


### PR DESCRIPTION
Both of these are rather disruptive when you are debugging/testing.

The Config *file* should default to debugging best defaults, and the config *code* should default to production best defaults.

One day we will make a seperate production default config file
