### PR TITLE
Updates RuntimeStation to make testing faster

### DIFF
--- a/_maps/map_files/debug/runtimestation.dmm
+++ b/_maps/map_files/debug/runtimestation.dmm
@@ -8,7 +8,7 @@
 /area/space/nearstation)
 "ac" = (
 /turf/open/space,
-/area/space)
+/area/space/nearstation)
 "ad" = (
 /turf/closed/wall/r_wall,
 /area/maintenance/department/bridge)
@@ -85,6 +85,9 @@
 	icon_state = "2-8"
 	},
 /obj/machinery/camera/autoname,
+/obj/machinery/light{
+	dir = 1
+	},
 /turf/open/floor/plating,
 /area/engine/engineering)
 "ar" = (
@@ -176,13 +179,13 @@
 /turf/open/space,
 /area/space/nearstation)
 "aC" = (
-/obj/machinery/door/airlock,
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 4
 	},
+/obj/machinery/door/airlock/external/glass,
 /turf/open/floor/plating,
 /area/engine/engineering)
 "aD" = (
@@ -294,7 +297,8 @@
 /obj/item/device/flashlight{
 	pixel_y = 5
 	},
-/obj/item/airlock_painter,
+/obj/item/storage/toolbox/syndicate,
+/obj/item/stock_parts/cell/infinite,
 /turf/open/floor/plating,
 /area/engine/engineering)
 "aT" = (
@@ -387,6 +391,7 @@
 "bd" = (
 /obj/structure/table,
 /obj/item/weldingtool/experimental,
+/obj/item/inducer,
 /turf/open/floor/plating,
 /area/engine/engineering)
 "be" = (
@@ -396,7 +401,7 @@
 /turf/open/floor/plating,
 /area/engine/engineering)
 "bf" = (
-/obj/structure/closet/secure_closet/engineering_chief,
+/obj/machinery/suit_storage_unit/captain,
 /turf/open/floor/plating,
 /area/engine/engineering)
 "bg" = (
@@ -466,14 +471,14 @@
 /area/engine/engineering)
 "bp" = (
 /obj/machinery/light,
-/obj/item/storage/box/lights/mixed,
-/obj/item/device/lightreplacer,
+/obj/structure/tank_dispenser,
 /turf/open/floor/plating,
 /area/engine/engineering)
 "bq" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 10
 	},
+/obj/machinery/light,
 /turf/open/floor/plasteel,
 /area/engine/gravity_generator)
 "br" = (
@@ -514,7 +519,7 @@
 /area/engine/engineering)
 "by" = (
 /turf/closed/wall/r_wall,
-/area/hallway/secondary/entry)
+/area/medical/medbay)
 "bz" = (
 /obj/machinery/light{
 	dir = 8
@@ -523,7 +528,7 @@
 /area/maintenance/department/bridge)
 "bA" = (
 /turf/closed/wall/r_wall,
-/area/hallway/primary/central)
+/area/science)
 "bB" = (
 /obj/machinery/power/apc{
 	dir = 8;
@@ -538,28 +543,32 @@
 	locked = 0;
 	pixel_y = 23
 	},
-/obj/structure/closet/jcloset,
+/obj/machinery/autolathe/hacked,
 /turf/open/floor/plasteel,
-/area/hallway/primary/central)
+/area/science)
 "bC" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
-/area/hallway/primary/central)
+/area/science)
 "bD" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 8
 	},
+/obj/machinery/robotic_fabricator,
+/obj/machinery/light{
+	dir = 1
+	},
 /turf/open/floor/plasteel,
-/area/hallway/primary/central)
+/area/science)
 "bE" = (
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "bF" = (
-/obj/structure/closet/secure_closet/CMO,
+/obj/machinery/computer/rdconsole/core,
 /turf/open/floor/plasteel,
-/area/hallway/primary/central)
+/area/science)
 "bG" = (
 /obj/machinery/airalarm{
 	frequency = 1439;
@@ -577,12 +586,6 @@
 /turf/open/floor/plasteel/blue/side{
 	dir = 8
 	},
-/area/bridge)
-"bH" = (
-/obj/structure/table,
-/obj/item/ammo_box/c10mm,
-/obj/item/gun/ballistic,
-/turf/open/floor/plasteel,
 /area/bridge)
 "bI" = (
 /obj/structure/table,
@@ -624,26 +627,36 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "bP" = (
-/obj/machinery/vending/cigarette,
+/obj/item/storage/box/beakers,
+/obj/item/storage/box/syringes,
+/obj/structure/table,
+/obj/item/reagent_containers/glass/beaker/bluespace,
+/obj/item/reagent_containers/glass/beaker/bluespace,
+/obj/item/reagent_containers/syringe,
+/obj/machinery/airalarm{
+	frequency = 1439;
+	locked = 0;
+	pixel_y = 23
+	},
 /turf/open/floor/plasteel/dark,
-/area/hallway/primary/central)
+/area/medical/chemistry)
 "bQ" = (
-/obj/machinery/vending/coffee,
+/obj/machinery/chem_master,
 /turf/open/floor/plasteel/dark,
-/area/hallway/primary/central)
+/area/medical/chemistry)
 "bR" = (
-/obj/machinery/vending/cola,
 /obj/machinery/camera/autoname,
+/obj/machinery/chem_heater,
 /turf/open/floor/plasteel/dark,
-/area/hallway/primary/central)
+/area/medical/chemistry)
 "bS" = (
-/obj/machinery/vending/snack,
+/obj/machinery/chem_dispenser,
 /turf/open/floor/plasteel/dark,
-/area/hallway/primary/central)
+/area/medical/chemistry)
 "bT" = (
-/obj/machinery/computer/arcade,
+/obj/machinery/chem_dispenser/scp_294,
 /turf/open/floor/plasteel/dark,
-/area/hallway/primary/central)
+/area/medical/chemistry)
 "bU" = (
 /obj/machinery/airalarm{
 	frequency = 1439;
@@ -657,33 +670,33 @@
 /obj/structure/cable{
 	icon_state = "0-2"
 	},
-/obj/structure/closet/firecloset/full,
+/mob/living/carbon/human,
 /turf/open/floor/plasteel/arrival{
 	dir = 9
 	},
-/area/hallway/secondary/entry)
+/area/medical/medbay)
 "bV" = (
 /obj/machinery/light{
 	dir = 1
 	},
-/obj/structure/closet/emcloset,
+/mob/living/carbon/human,
 /turf/open/floor/plasteel/arrival{
 	dir = 1
 	},
-/area/hallway/secondary/entry)
+/area/medical/medbay)
 "bW" = (
-/obj/structure/closet/secure_closet/hos,
 /obj/machinery/camera/autoname,
+/mob/living/carbon/human,
 /turf/open/floor/plasteel/arrival{
 	dir = 1
 	},
-/area/hallway/secondary/entry)
+/area/medical/medbay)
 "bX" = (
-/obj/structure/closet/emcloset,
+/obj/machinery/sleeper,
 /turf/open/floor/plasteel/arrival{
 	dir = 1
 	},
-/area/hallway/secondary/entry)
+/area/medical/medbay)
 "bY" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
@@ -700,25 +713,25 @@
 	icon_state = "2-4"
 	},
 /turf/open/floor/plasteel,
-/area/hallway/primary/central)
+/area/science)
 "cb" = (
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plasteel,
-/area/hallway/primary/central)
+/area/science)
 "cc" = (
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel,
-/area/hallway/primary/central)
+/area/science)
 "cd" = (
-/obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
+/obj/machinery/door/airlock,
 /turf/open/floor/plating,
 /area/bridge)
 "ce" = (
@@ -747,13 +760,13 @@
 	},
 /area/bridge)
 "ch" = (
-/obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
 /obj/structure/cable{
 	icon_state = "2-4"
 	},
+/obj/machinery/door/airlock,
 /turf/open/floor/plating,
 /area/bridge)
 "ci" = (
@@ -761,8 +774,11 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
 /turf/open/floor/plasteel,
-/area/hallway/primary/central)
+/area/medical/chemistry)
 "cj" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -771,13 +787,14 @@
 	icon_state = "1-8"
 	},
 /turf/open/floor/plasteel,
-/area/hallway/primary/central)
+/area/medical/chemistry)
 "ck" = (
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/turf/closed/wall/r_wall,
-/area/hallway/secondary/entry)
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
+/area/medical/medbay)
 "cl" = (
 /obj/structure/cable{
 	icon_state = "1-8"
@@ -785,23 +802,25 @@
 /turf/open/floor/plasteel/arrival{
 	dir = 8
 	},
-/area/hallway/secondary/entry)
+/area/medical/medbay)
 "cm" = (
 /turf/open/floor/plasteel,
-/area/hallway/secondary/entry)
+/area/medical/medbay)
 "cn" = (
 /obj/machinery/door/airlock,
 /turf/open/floor/plating,
-/area/hallway/secondary/entry)
+/area/medical/medbay)
 "co" = (
 /obj/machinery/light{
 	dir = 4
 	},
+/obj/structure/closet/syndicate/resources/everything,
 /turf/open/floor/plasteel,
-/area/hallway/primary/central)
+/area/science)
 "cp" = (
 /obj/machinery/light,
 /obj/machinery/atmospherics/components/unary/vent_pump/on,
+/obj/structure/closet/secure_closet/engineering_chief,
 /turf/open/floor/plasteel/blue/side{
 	dir = 10
 	},
@@ -811,6 +830,7 @@
 /area/bridge)
 "cr" = (
 /obj/machinery/light,
+/obj/structure/closet/secure_closet/hos,
 /turf/open/floor/plasteel/blue/side{
 	dir = 6
 	},
@@ -827,12 +847,12 @@
 	dir = 8
 	},
 /turf/open/floor/plasteel,
-/area/hallway/primary/central)
+/area/medical/chemistry)
 "cu" = (
 /turf/open/floor/plasteel/arrival{
 	dir = 8
 	},
-/area/hallway/secondary/entry)
+/area/medical/medbay)
 "cv" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/closed/wall/r_wall,
@@ -844,16 +864,16 @@
 "cx" = (
 /obj/machinery/door/airlock/public/glass,
 /turf/open/floor/plasteel,
-/area/hallway/secondary/entry)
+/area/medical/medbay)
 "cy" = (
 /obj/effect/turf_decal/loading_area{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
-/area/hallway/secondary/entry)
+/area/medical/medbay)
 "cz" = (
 /turf/open/floor/plating,
-/area/hallway/secondary/entry)
+/area/medical/medbay)
 "cA" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -893,23 +913,19 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
-/obj/machinery/light{
-	dir = 1
-	},
-/turf/open/floor/plasteel/blue/corner{
-	dir = 1
-	},
-/area/hallway/primary/central)
+/turf/closed/wall/r_wall,
+/area/medical/chemistry)
 "cF" = (
 /obj/machinery/atmospherics/pipe/manifold4w/supply/hidden,
+/obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plasteel,
-/area/hallway/primary/central)
+/area/medical/chemistry)
 "cG" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
 /turf/closed/wall/r_wall,
-/area/hallway/secondary/entry)
+/area/medical/medbay)
 "cH" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 8
@@ -917,43 +933,26 @@
 /turf/open/floor/plasteel/arrival{
 	dir = 8
 	},
-/area/hallway/secondary/entry)
-"cI" = (
-/obj/structure/table,
-/obj/item/storage/fancy/donut_box,
-/turf/open/floor/plasteel/arrival{
-	dir = 8
-	},
-/area/hallway/secondary/entry)
+/area/medical/medbay)
 "cJ" = (
-/obj/structure/table,
-/obj/item/storage/fancy/donut_box,
+/obj/item/gun/magic/staff/healing,
+/obj/item/gun/magic/wand/resurrection,
 /turf/open/floor/plasteel/arrival{
 	dir = 10
 	},
-/area/hallway/secondary/entry)
+/area/medical/medbay)
 "cK" = (
-/obj/structure/table,
-/obj/item/stack/sheet/glass/fifty,
-/obj/item/stack/rods/fifty,
-/obj/machinery/light,
+/obj/machinery/dna_scannernew,
 /turf/open/floor/plasteel/arrival,
-/area/hallway/secondary/entry)
+/area/medical/medbay)
 "cL" = (
-/obj/structure/table,
-/obj/item/paper_bin{
-	pixel_x = -3;
-	pixel_y = 7
-	},
+/obj/machinery/computer/cloning,
 /turf/open/floor/plasteel/arrival,
-/area/hallway/secondary/entry)
+/area/medical/medbay)
 "cM" = (
-/obj/structure/table,
-/obj/item/storage/firstaid/regular,
-/obj/item/storage/firstaid/regular,
-/obj/item/device/healthanalyzer,
+/obj/machinery/clonepod,
 /turf/open/floor/plasteel/arrival,
-/area/hallway/secondary/entry)
+/area/medical/medbay)
 "cN" = (
 /turf/closed/wall/r_wall,
 /area/construction)
@@ -1267,27 +1266,12 @@
 "dO" = (
 /obj/structure/table,
 /obj/machinery/light,
-/obj/item/twohanded/fireaxe,
-/obj/item/extinguisher,
-/turf/open/floor/plasteel,
-/area/storage/primary)
-"dP" = (
-/obj/structure/table,
-/obj/item/device/lightreplacer,
+/obj/item/storage/firstaid,
 /turf/open/floor/plasteel,
 /area/storage/primary)
 "dQ" = (
 /obj/structure/table,
-/obj/item/storage/box/lights/mixed,
-/obj/item/storage/box/lights/tubes,
 /obj/machinery/light,
-/turf/open/floor/plasteel,
-/area/storage/primary)
-"dR" = (
-/obj/structure/table,
-/obj/item/device/flashlight{
-	pixel_y = 5
-	},
 /turf/open/floor/plasteel,
 /area/storage/primary)
 "dS" = (
@@ -1342,32 +1326,228 @@
 /obj/machinery/camera/autoname{
 	dir = 1
 	},
+/obj/item/gun/magic/wand/resurrection,
 /turf/open/floor/plasteel,
 /area/storage/primary)
-"pI" = (
+"ei" = (
+/obj/machinery/light,
+/obj/machinery/computer/operating,
+/turf/open/floor/plasteel,
+/area/maintenance/department/bridge)
+"fT" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/turf/open/floor/plasteel,
+/area/science)
+"gd" = (
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
+/area/science)
+"gY" = (
+/turf/open/floor/plasteel,
+/area/science)
+"hD" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/machinery/power/apc{
+	dir = 1;
+	pixel_y = 25
+	},
+/obj/structure/cable{
+	icon_state = "0-2"
+	},
+/turf/open/floor/plasteel,
+/area/medical/chemistry)
+"jb" = (
 /obj/machinery/door/airlock,
+/turf/open/floor/plasteel,
+/area/science)
+"jU" = (
+/obj/structure/table,
+/obj/item/melee/transforming/energy/axe,
+/turf/open/floor/plasteel,
+/area/storage/primary)
+"kk" = (
+/obj/structure/table/optable,
+/turf/open/floor/plasteel,
+/area/maintenance/department/bridge)
+"kn" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
+"kQ" = (
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
+	dir = 8
+	},
+/obj/structure/cable{
+	icon_state = "0-8"
+	},
+/obj/machinery/power/apc{
+	dir = 1;
+	pixel_y = 25
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
+"lK" = (
+/obj/effect/landmark/observer_start,
+/turf/open/floor/plating,
+/area/storage/primary)
+"ny" = (
+/obj/structure/table,
+/obj/item/storage/toolbox/syndicate,
+/turf/open/floor/plasteel,
+/area/storage/primary)
+"oV" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plasteel,
+/area/medical/chemistry)
+"pA" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/turf/closed/wall/r_wall,
+/area/science)
+"pI" = (
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 8
 	},
+/obj/machinery/door/airlock/external/glass,
 /turf/open/floor/plating,
-/area/hallway/secondary/entry)
-"Qt" = (
+/area/medical/medbay)
+"pQ" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plasteel,
+/area/medical/chemistry)
+"vv" = (
 /obj/machinery/door/airlock,
+/turf/open/floor/plating,
+/area/storage/primary)
+"vP" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/machinery/door/airlock/public/glass,
+/turf/open/floor/plasteel,
+/area/medical/chemistry)
+"wb" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/open/floor/plasteel/blue/side{
+	dir = 1
+	},
+/area/hallway/primary/central)
+"wS" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/machinery/airalarm{
+	frequency = 1439;
+	locked = 0;
+	pixel_y = 23
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
+"wT" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/turf/open/floor/plasteel,
+/area/medical/chemistry)
+"BB" = (
+/obj/item/storage/backpack/duffelbag/syndie/surgery,
+/obj/structure/table,
+/obj/item/disk/surgery/debug,
+/turf/open/floor/plasteel,
+/area/medical/medbay)
+"BD" = (
+/obj/structure/closet/secure_closet/CMO,
+/turf/open/floor/plasteel/blue/side,
+/area/bridge)
+"BG" = (
+/obj/structure/table,
+/obj/item/ammo_box/c10mm,
+/obj/item/gun/ballistic/automatic/pistol,
+/turf/open/floor/plasteel,
+/area/bridge)
+"Ce" = (
+/turf/open/floor/plasteel,
+/area/medical/chemistry)
+"Ct" = (
+/obj/item/disk/tech_disk/debug,
+/turf/open/floor/plasteel,
+/area/science)
+"CV" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plasteel,
+/area/medical/chemistry)
+"If" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plasteel,
+/area/science)
+"In" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/closed/wall/r_wall,
+/area/science)
+"Iy" = (
+/obj/structure/closet/secure_closet/RD,
+/turf/open/floor/plasteel/blue/side,
+/area/bridge)
+"JE" = (
+/obj/machinery/door/airlock,
+/turf/open/floor/plating,
+/area/hallway/primary/central)
+"NZ" = (
+/obj/machinery/rnd/protolathe,
+/turf/open/floor/plasteel,
+/area/science)
+"Qt" = (
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 4
 	},
+/obj/machinery/door/airlock/external/glass,
 /turf/open/floor/plating,
-/area/hallway/secondary/entry)
+/area/medical/medbay)
+"Ut" = (
+/obj/structure/closet/secure_closet/medical3,
+/turf/open/floor/plasteel,
+/area/medical/medbay)
+"Vg" = (
+/obj/machinery/light,
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
 "WT" = (
-/obj/machinery/door/airlock,
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 8
 	},
+/obj/machinery/door/airlock/external/glass,
 /turf/open/floor/plating,
 /area/engine/engineering)
+"Xg" = (
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/medical/chemistry)
 
 (1,1,1) = {"
 aa
@@ -2038,12 +2218,12 @@ ah
 ah
 ah
 bA
-bZ
-bZ
-bZ
-bZ
-bZ
+gd
+gd
 bA
+bZ
+bZ
+JE
 cN
 cN
 cN
@@ -2093,9 +2273,9 @@ bj
 bs
 bB
 ca
-bO
-bO
-bO
+If
+In
+kn
 bO
 bO
 cO
@@ -2147,9 +2327,9 @@ bk
 bt
 bC
 cb
-bN
-bN
-bC
+fT
+pA
+kQ
 bN
 bN
 cP
@@ -2201,8 +2381,8 @@ bl
 ah
 bD
 cc
-bE
-bE
+gY
+jb
 cA
 bE
 bE
@@ -2253,10 +2433,10 @@ aO
 bc
 bm
 ah
-bE
+NZ
 cc
-bE
-bE
+Ct
+gd
 cA
 bE
 bE
@@ -2310,8 +2490,8 @@ ah
 bF
 cc
 co
-bE
-cA
+bA
+wS
 bE
 bE
 cN
@@ -2353,7 +2533,7 @@ aa
 ab
 ac
 ad
-ad
+bY
 ah
 ah
 ah
@@ -2437,7 +2617,7 @@ dn
 dZ
 cN
 af
-ad
+bY
 ac
 ab
 aa
@@ -2469,7 +2649,7 @@ aQ
 ai
 ab
 bv
-bH
+bI
 cf
 cq
 bv
@@ -2491,7 +2671,7 @@ dn
 dL
 cN
 af
-ad
+bY
 ac
 ab
 aa
@@ -2523,9 +2703,9 @@ aR
 ai
 ab
 bv
-bI
+BG
 cf
-cq
+BD
 bu
 dU
 bE
@@ -2545,7 +2725,7 @@ dn
 dL
 cN
 af
-ad
+bY
 ac
 ab
 aa
@@ -2599,7 +2779,7 @@ dn
 dL
 cN
 af
-ad
+bY
 ac
 ab
 aa
@@ -2633,7 +2813,7 @@ ac
 bv
 bK
 cf
-cq
+Iy
 bu
 cD
 bE
@@ -2653,7 +2833,7 @@ dn
 dL
 cN
 af
-ad
+bY
 ac
 ab
 aa
@@ -2707,7 +2887,7 @@ do
 dM
 cN
 af
-ad
+bY
 ac
 ab
 aa
@@ -2743,7 +2923,7 @@ bM
 cg
 cr
 bu
-cD
+wb
 bE
 bE
 cS
@@ -2761,7 +2941,7 @@ cS
 cS
 cS
 af
-ad
+bY
 ac
 ab
 aa
@@ -2785,7 +2965,7 @@ aa
 ab
 ac
 ad
-ad
+bY
 aj
 aj
 WT
@@ -2815,7 +2995,7 @@ dp
 dl
 cS
 af
-ad
+bY
 ac
 ab
 aa
@@ -2847,10 +3027,10 @@ aS
 bd
 bo
 bw
-bN
+hD
 ci
 ct
-bN
+wT
 cF
 bN
 bN
@@ -2869,7 +3049,7 @@ dl
 dl
 cS
 af
-ad
+bY
 ac
 ab
 aa
@@ -2901,11 +3081,11 @@ aT
 be
 be
 bx
-bO
+CV
 cj
-bE
-bE
-cA
+Ce
+Ce
+oV
 bE
 bE
 cS
@@ -2923,7 +3103,7 @@ dc
 dc
 cS
 af
-ad
+bY
 ac
 ab
 aa
@@ -2956,10 +3136,10 @@ bf
 bp
 aj
 bP
-cc
-bE
-bE
-cA
+pQ
+Ce
+Ce
+oV
 bE
 bE
 cS
@@ -2974,10 +3154,10 @@ dB
 dl
 dE
 dJ
-dN
+ny
 cS
 af
-ad
+bY
 ac
 ab
 aa
@@ -3010,12 +3190,12 @@ ak
 ak
 ak
 bQ
-cc
+pQ
+Ce
+Ce
+vP
 bE
-bE
-cA
-bE
-bE
+Vg
 cS
 de
 dr
@@ -3031,7 +3211,7 @@ dJ
 dO
 cS
 af
-ad
+bY
 ac
 ab
 aa
@@ -3064,10 +3244,10 @@ bg
 bq
 ak
 bR
-cc
-bE
-bE
-cA
+pQ
+Ce
+Ce
+oV
 bE
 bE
 cV
@@ -3082,10 +3262,10 @@ dB
 dl
 dE
 dJ
-dN
+jU
 cS
 af
-ad
+bY
 ac
 ab
 aa
@@ -3118,17 +3298,17 @@ bh
 br
 ak
 bS
-cc
-bE
-bE
-cA
+pQ
+Ce
+Ce
+oV
 bE
 bE
 cV
 dg
 dt
 dB
-dl
+lK
 dE
 dH
 dI
@@ -3172,10 +3352,10 @@ aI
 aI
 ak
 bT
-cc
-co
-bE
-cA
+pQ
+Xg
+Ce
+oV
 bE
 bE
 cV
@@ -3190,7 +3370,7 @@ dB
 dl
 dE
 dJ
-dP
+dN
 cS
 af
 ad
@@ -3230,7 +3410,7 @@ ck
 by
 cx
 cG
-by
+cx
 by
 by
 di
@@ -3284,7 +3464,7 @@ cl
 cu
 cu
 cH
-cI
+cu
 cJ
 by
 dj
@@ -3298,7 +3478,7 @@ dB
 dl
 dE
 dJ
-dR
+dN
 cS
 af
 ad
@@ -3445,7 +3625,7 @@ bX
 cm
 cm
 cy
-cm
+Ut
 cm
 cM
 by
@@ -3500,16 +3680,16 @@ cn
 by
 Qt
 by
-cn
+cm
+BB
 by
-by
 cS
 cS
 cS
 cS
 cS
 cS
-cS
+vv
 cS
 cS
 cS
@@ -3554,9 +3734,9 @@ af
 by
 cz
 by
-af
-af
-af
+kk
+ei
+ad
 af
 af
 af


### PR DESCRIPTION
- Removed pointless clutter like the lightbulb boxes
- Added an energy axe and healing wands to the main room for quick healing/killing when testing mobs.
- Added a room with three humans, a sleeper, a cloning setup, a surgery setup, and a staff of healing.
- Added a room with a chemistry setup, along with the vending machine scp to test new chems.
- Added a room with an R&D setup, along with a debug tech disk. Contains universal protolathe, exofab, and an autolathe, along with a full material closet.
- Moved all the head lockers into the room with the captain's id.
- External airlocks now _look_ like external airlocks.
- Added a syndicate toolbox, an infinite battery and an inducer in the engineering room, along with a captain's spacesuit and oxygen tanks.
- Changed the layout a bit to make moving between rooms/maint a bit faster. The bottom maint now has some windows to space.
- Added an observer landmark so the game finally stops complaining when observing.

Map:
![map](https://user-images.githubusercontent.com/18611020/36938761-c6966e00-1f26-11e8-80ed-3e365f505eb2.png)

