### PR TITLE
Replaces normal revolution with speedy revolution

### DIFF
--- a/code/game/gamemodes/revolution/revolution.dm
+++ b/code/game/gamemodes/revolution/revolution.dm
@@ -29,6 +29,8 @@
 	var/datum/team/revolution/revolution
 	var/list/datum/mind/headrev_candidates = list()
 	var/end_when_heads_dead = TRUE
+	var/endtime = null
+	var/fuckingdone = FALSE
 
 ///////////////////////////
 //Announces the game type//
@@ -59,6 +61,8 @@
 
 	if(headrev_candidates.len < required_enemies)
 		return FALSE
+
+	endtime = world.time + 20 MINUTES
 
 	return TRUE
 
@@ -116,6 +120,13 @@
 		if(!finished)
 			SSticker.mode.check_win()
 		check_counter = 0
+		if (world.time > endtime && !fuckingdone)
+			fuckingdone = TRUE
+			for (var/obj/machinery/nuclearbomb/N in GLOB.nuke_list)
+				if (!N.timing)
+					N.timer_set = 200
+					N.set_safety()
+					N.set_active()
 	return FALSE
 
 //////////////////////////////////////
@@ -196,25 +207,3 @@
 	name = "extended_revolution"
 	config_tag = "extended_revolution"
 	end_when_heads_dead = FALSE
-
-/datum/game_mode/revolution/speedy
-	name = "speedy_revolution"
-	config_tag = "speedy_revolution"
-	end_when_heads_dead = FALSE
-	var/endtime = null
-	var/fuckingdone = FALSE
-
-/datum/game_mode/revolution/speedy/pre_setup()
-	endtime = world.time + 20 MINUTES
-	return ..()
-
-/datum/game_mode/revolution/speedy/process()
-	. = ..()
-	if(check_counter == 0)
-		if (world.time > endtime && !fuckingdone)
-			fuckingdone = TRUE
-			for (var/obj/machinery/nuclearbomb/N in GLOB.nuke_list)
-				if (!N.timing)
-					N.timer_set = 200
-					N.set_safety()
-					N.set_active()


### PR DESCRIPTION
Thank you @vuonojenmustaturska this is EXACTLY what we needed.

:cl:
tweak: Given the recent influx of revolutions, Nanotrasen has taken decisive action; any station with a revolution lasting longer than twenty minutes will have its nuke remotely activated!
/:cl:

For anyone unfamiliar, speedy revolution is normal revs except if no one has won by the 20 minute mark the station nuke is activated.