### PR TITLE
SYMBOLICALLY replaces revolution with speedy revolution

### DIFF
--- a/code/game/gamemodes/revolution/revolution.dm
+++ b/code/game/gamemodes/revolution/revolution.dm
@@ -197,7 +197,7 @@
 	config_tag = "extended_revolution"
 	end_when_heads_dead = FALSE
 
-/datum/game_mode/revolution/speedy
+/datum/game_mode/revolution/speedy //Revs except if no one wins by the 20 minute mark the station explodes
 	name = "speedy_revolution"
 	config_tag = "speedy_revolution"
 	end_when_heads_dead = FALSE


### PR DESCRIPTION
Turns out to do this MSO has to edit the [config](https://tgstation13.org/parsed-logs/basil/config/game_options.txt)

So lets pretend this is the change. Voice your opinion, etc.

:cl:
tweak: Given the recent influx of revolutions, Nanotrasen has taken decisive action; any station with a revolution lasting longer than twenty minutes will have its nuke remotely activated!
/:cl:

For anyone unfamiliar, speedy revolution is normal revs except if no one has won by the 20 minute mark the station nuke is activated.