### PR TITLE
Makes lesser ashdrakes unable to gib and heal from it

### DIFF
--- a/code/modules/mob/living/simple_animal/hostile/megafauna/drake.dm
+++ b/code/modules/mob/living/simple_animal/hostile/megafauna/drake.dm
@@ -388,4 +388,7 @@ Difficulty: Medium
 /mob/living/simple_animal/hostile/megafauna/dragon/lesser/grant_achievement(medaltype,scoretype)
 	return
 
+/mob/living/simple_animal/hostile/megafauna/dragon/lesser/devour(mob/living/L)
+	return
+
 #undef MEDAL_PREFIX


### PR DESCRIPTION
Megafauna are trash. Gibs are intended to be highly limited. They can untransform to heal if they need it.
🆑 
balance: Lesser ash-drakes can no longer gib.
/:cl: