### PR TITLE
Added a cooldown to being shown hud images

### DIFF
--- a/code/__DEFINES/atom_hud.dm
+++ b/code/__DEFINES/atom_hud.dm
@@ -55,3 +55,5 @@
 #define NOTIFY_JUMP "jump"
 #define NOTIFY_ATTACK "attack"
 #define NOTIFY_ORBIT "orbit"
+
+#define ADD_HUD_TO_COOLDOWN 20 //cooldown for being shown the images for any particular data hud

--- a/code/datums/hud.dm
+++ b/code/datums/hud.dm
@@ -77,8 +77,9 @@ GLOBAL_LIST_INIT(huds, list(
 	if(!hudusers[M])
 		hudusers[M] = 1
 		if(next_time_allowed[M] > world.time)
-			addtimer(CALLBACK(src, .proc/show_hud_images_after_cooldown, M), ADD_HUD_TO_COOLDOWN, TIMER_UNIQUE)
-			queued_to_see[M] = TRUE
+			if(!queued_to_see[M])
+				addtimer(CALLBACK(src, .proc/show_hud_images_after_cooldown, M), next_time_allowed[M] - world.time)
+				queued_to_see[M] = TRUE
 		else
 			next_time_allowed[M] = world.time + ADD_HUD_TO_COOLDOWN
 			for(var/atom/A in hudatoms)

--- a/code/datums/hud.dm
+++ b/code/datums/hud.dm
@@ -32,6 +32,9 @@ GLOBAL_LIST_INIT(huds, list(
 	var/list/mob/hudusers = list() //list with all mobs who can see the hud
 	var/list/hud_icons = list() //these will be the indexes for the atom's hud_list
 
+	var/list/next_time_allowed = list() //mobs associated with the next time this hud can be added to them
+	var/list/queued_to_see = list() //mobs that have triggered the cooldown and are queued to see the hud, but do not yet
+
 /datum/atom_hud/New()
 	GLOB.all_huds += src
 
@@ -48,8 +51,11 @@ GLOBAL_LIST_INIT(huds, list(
 		return
 	if (!--hudusers[M])
 		hudusers -= M
-		for(var/atom/A in hudatoms)
-			remove_from_single_hud(M, A)
+		if(queued_to_see[M])
+			queued_to_see -= M
+		else
+			for(var/atom/A in hudatoms)
+				remove_from_single_hud(M, A)
 
 /datum/atom_hud/proc/remove_from_hud(atom/A)
 	if(!A)
@@ -68,12 +74,24 @@ GLOBAL_LIST_INIT(huds, list(
 /datum/atom_hud/proc/add_hud_to(mob/M)
 	if(!M)
 		return
-	if (!hudusers[M])
+	if(!hudusers[M])
 		hudusers[M] = 1
-		for(var/atom/A in hudatoms)
-			add_to_single_hud(M, A)
+		if(next_time_allowed[M] > world.time)
+			addtimer(CALLBACK(src, .proc/show_hud_images_after_cooldown, M), ADD_HUD_TO_COOLDOWN, TIMER_UNIQUE)
+			queued_to_see[M] = TRUE
+		else
+			next_time_allowed[M] = world.time + ADD_HUD_TO_COOLDOWN
+			for(var/atom/A in hudatoms)
+				add_to_single_hud(M, A)
 	else
 		hudusers[M]++
+
+/datum/atom_hud/proc/show_hud_images_after_cooldown(M)
+	if(queued_to_see[M])
+		queued_to_see -= M
+		next_time_allowed[M] = world.time + ADD_HUD_TO_COOLDOWN
+		for(var/atom/A in hudatoms)
+			add_to_single_hud(M, A)
 
 /datum/atom_hud/proc/add_to_hud(atom/A)
 	if(!A)


### PR DESCRIPTION
Fixes #36086 
Probably fixes #35929 

Added a cooldown to being shown hud images. If you trigger the cooldown by gaining, losing, and regaining the same hud within two seconds, you will still get the hud, but the images are not shown to you until after the 2 seconds have elapsed.