### PR TITLE
You can now non-violently place people on tables

### DIFF
--- a/code/game/objects/structures/tables_racks.dm
+++ b/code/game/objects/structures/tables_racks.dm
@@ -60,15 +60,23 @@
 	attack_hand(user)
 
 /obj/structure/table/attack_hand(mob/living/user)
-	if(user.a_intent == INTENT_GRAB && user.pulling && isliving(user.pulling))
+	if(user.pulling && isliving(user.pulling))
 		var/mob/living/pushed_mob = user.pulling
 		if(pushed_mob.buckled)
 			to_chat(user, "<span class='warning'>[pushed_mob] is buckled to [pushed_mob.buckled]!</span>")
 			return
-		if(user.grab_state < GRAB_AGGRESSIVE)
-			to_chat(user, "<span class='warning'>You need a better grip to do that!</span>")
-			return
-		tablepush(user, pushed_mob)
+		if(user.a_intent == INTENT_GRAB)
+			if(user.grab_state < GRAB_AGGRESSIVE)
+				to_chat(user, "<span class='warning'>You need a better grip to do that!</span>")
+				return
+			tablepush(user, pushed_mob)
+		if(user.a_intent == INTENT_HELP)
+			pushed_mob.visible_message("<span class='notice'>[user] begins to place [pushed_mob] onto [src]...</span>", \
+								"<span class='userdanger'>[user] begins to place [pushed_mob] onto [src]...</span>")
+			if(do_after(user, 35, target = pushed_mob))
+				tableplace(user, pushed_mob)
+			else
+				return
 		user.stop_pulling()
 	else
 		..()
@@ -88,6 +96,13 @@
 	if(ismovableatom(caller))
 		var/atom/movable/mover = caller
 		. = . || (mover.pass_flags & PASSTABLE)
+
+/obj/structure/table/proc/tableplace(mob/living/user, mob/living/pushed_mob)
+	pushed_mob.forceMove(src.loc)
+	pushed_mob.lay_down()
+	pushed_mob.visible_message("<span class='notice'>[user] places [pushed_mob] onto [src].</span>", \
+								"<span class='notice'>[user] places [pushed_mob] onto [src].</span>")
+	add_logs(user, pushed_mob, "placed")
 
 /obj/structure/table/proc/tablepush(mob/living/user, mob/living/pushed_mob)
 	pushed_mob.forceMove(src.loc)


### PR DESCRIPTION
:cl: XDTM
add: You can now place people on tables on Help Intent. Doing so takes a few seconds and makes the target Rest, instead of stunning them.
/:cl:

I saw a comment about how pacifists can't place people on tables, then wondered why we don't have a nonviolent option. Here we are.

Mekhi goes _gently_ on the table.
