### PR TITLE
Changes techweb bomb scaling to use point difference and not radius difference

### DIFF
--- a/code/game/machinery/doppler_array.dm
+++ b/code/game/machinery/doppler_array.dm
@@ -114,11 +114,12 @@ GLOBAL_LIST_EMPTY(doppler_arrays)
 	if(adjusted <= 0)
 		say("Explosion not large enough for research calculations.")
 		return
-	var/point_gain = techweb_scale_bomb(adjusted) - techweb_scale_bomb(linked_techweb.max_bomb_value)
+	var/points = techweb_scale_bomb(adjusted)
+	var/point_gain = points - linked_techweb.max_bomb_value
 	if(point_gain <= 0)
 		say("Explosion not large enough for research calculations.")
 		return
-	linked_techweb.max_bomb_value = adjusted
+	linked_techweb.max_bomb_value = points
 	linked_techweb.research_points += point_gain
 	say("Gained [point_gain] points from explosion dataset.")
 
@@ -127,4 +128,4 @@ GLOBAL_LIST_EMPTY(doppler_arrays)
 	linked_techweb = SSresearch.science_tech
 
 /proc/techweb_scale_bomb(lightradius)
-	return (lightradius ** 0.5) * 3000
+	return (lightradius ** 0.5) * 6000


### PR DESCRIPTION
Removes using incremental bombs to get maximum points instead of going as big as you can immediately.
To compensate, doubles point gains. 250/500/1000 gains you 120k points out of 288k total.