### PR TITLE
Three-fifths voter compromise

### DIFF
--- a/code/controllers/subsystem/vote.dm
+++ b/code/controllers/subsystem/vote.dm
@@ -63,7 +63,7 @@ SUBSYSTEM_DEF(vote)
 				non_voters -= non_voter_ckey
 		if(non_voters.len > 0)
 			if(mode == "restart")
-				choices["Continue Playing"] += non_voters.len/2
+				choices["Continue Playing"] += non_voters.len*(3/5) //ITS A COMPROMISE
 				if(choices["Continue Playing"] >= greatest_votes)
 					greatest_votes = choices["Continue Playing"]
 			else if(mode == "gamemode")

--- a/code/controllers/subsystem/vote.dm
+++ b/code/controllers/subsystem/vote.dm
@@ -63,7 +63,7 @@ SUBSYSTEM_DEF(vote)
 				non_voters -= non_voter_ckey
 		if(non_voters.len > 0)
 			if(mode == "restart")
-				choices["Continue Playing"] += non_voters.len
+				choices["Continue Playing"] += non_voters.len/2
 				if(choices["Continue Playing"] >= greatest_votes)
 					greatest_votes = choices["Continue Playing"]
 			else if(mode == "gamemode")


### PR DESCRIPTION
As-is restart votes are a complete joke, I have seen one succeed exactly once. This ought to even the odds a bit more, and besides it doesn't actually restart if a admin is on so this will very, very rarely result in false positives.

:cl:
tweak: It's well-known that non-voters are subhuman, as indicated by the particular shape of their skulls, so they now count for only three-fifths in restart votes.
/:cl: