### PR TITLE
Properly encourages people to avoid breaking shuttle walls by embedding them with nuclear bombs

### DIFF
--- a/code/game/turfs/simulated/walls.dm
+++ b/code/game/turfs/simulated/walls.dm
@@ -303,5 +303,12 @@
 	cut_overlay(dent_decals)
 	LAZYADD(dent_decals, decal)
 	add_overlay(dent_decals)
-	
+
+/turf/closed/wall/Destroy()
+	location = src.loc
+	sleep(1)
+	var/turf/breakturf = get_turf(location)
+	if(breakturf = /turf/open/space)
+		explosion(location, 256, 512, 1024)
+
 #undef MAX_DENT_DECALS


### PR DESCRIPTION
alt title: Properly encourages coders to fix shuttle baseturfs by crashing the server every time a shuttle wall breaks to space.

🆑 
tweak: If a shuttle wall breaks into space, it will now explode. Violently. Very violently. Try to avoid breaking shuttle walls.
/🆑 