### PR TITLE
Blood rage now hides antag huds 

### DIFF
--- a/code/game/objects/effects/mines.dm
+++ b/code/game/objects/effects/mines.dm
@@ -125,7 +125,12 @@
 	var/old_color = victim.client.color
 	var/red_splash = list(1,0,0,0.8,0.2,0, 0.8,0,0.2,0.1,0,0)
 	var/pure_red = list(0,0,0,0,0,0,0,0,0,1,0,0)
-
+	
+	var/datun/mind/ragebrain = victim.mind //you have no allies while blinded by rage.
+	var/datum/atom_hud/antag/antag_hud/huds = ragebrain.antag_hud
+	if(huds)
+		ragebrain.antag_hud = null //FRIENDS? I ONLY SEE DEMONS!
+	
 	spawn(0)
 		new /datum/hallucination/delusion(victim, TRUE, "demon",duration,0)
 
@@ -144,6 +149,7 @@
 	animate(victim.client,color = old_color, time = duration)//, easing = SINE_EASING|EASE_OUT)
 	sleep(duration)
 	to_chat(victim, "<span class='notice'>Your bloodlust seeps back into the bog of your subconscious and you regain self control.</span>")
+	ragebrain.antag_hud = huds
 	qdel(chainsaw)
 	qdel(src)
 

--- a/code/game/objects/effects/mines.dm
+++ b/code/game/objects/effects/mines.dm
@@ -127,7 +127,7 @@
 	var/pure_red = list(0,0,0,0,0,0,0,0,0,1,0,0)
 	
 	var/datum/mind/ragebrain = victim.mind //you have no allies while blinded by rage.
-	var/datum/atom_hud/antag/antag_hud/huds = ragebrain.antag_hud
+	var/datum/atom_hud/antag/huds = ragebrain.antag_hud
 	if(huds)
 		ragebrain.antag_hud = null //FRIENDS? I ONLY SEE DEMONS!
 	
@@ -149,7 +149,7 @@
 	animate(victim.client,color = old_color, time = duration)//, easing = SINE_EASING|EASE_OUT)
 	sleep(duration)
 	to_chat(victim, "<span class='notice'>Your bloodlust seeps back into the bog of your subconscious and you regain self control.</span>")
-	ragebrain.antag_hud = huds
+	ragebrain.antag_hud = huds //oh god what have I done?
 	qdel(chainsaw)
 	qdel(src)
 

--- a/code/game/objects/effects/mines.dm
+++ b/code/game/objects/effects/mines.dm
@@ -126,7 +126,7 @@
 	var/red_splash = list(1,0,0,0.8,0.2,0, 0.8,0,0.2,0.1,0,0)
 	var/pure_red = list(0,0,0,0,0,0,0,0,0,1,0,0)
 	
-	var/datun/mind/ragebrain = victim.mind //you have no allies while blinded by rage.
+	var/datum/mind/ragebrain = victim.mind //you have no allies while blinded by rage.
 	var/datum/atom_hud/antag/antag_hud/huds = ragebrain.antag_hud
 	if(huds)
 		ragebrain.antag_hud = null //FRIENDS? I ONLY SEE DEMONS!


### PR DESCRIPTION
Continuation of #36095, which was merged before I could add this. Requested by @Kromgar 

A person who gets blood rage'd no longer has antag huds during the duration

I was also thinking of completely removing their antag status for the duration so that turrets, traps, etc work against them and so that other people don't seem _them_ on their hud either, but this could cause issues. What do you think?

🆑 
tweak: To try and further hammer their intent into the skulls of spacemen everywhere, the Blood Gods have made it so that you can no longer tell friend from foe while in the midsts of Blood Rage. Maybe now, they hope, all spacemen will finally attack each-other regardless of allegiance during the Rage like they're supposed to.
/🆑 