### PR TITLE
Fix DisplayTimeText runtimes

### DIFF
--- a/code/__HELPERS/time.dm
+++ b/code/__HELPERS/time.dm
@@ -144,7 +144,7 @@ GLOBAL_VAR_INIT(rollovercheck_last_timeofday, 0)
 			else if(day && (!minute || !second))
 				hour = " and 1 hour"
 			else
-				day = "[truncate ? "hour" : "1 hour"]"
+				hour = "[truncate ? "hour" : "1 hour"]"
 	else
 		hour = null
 


### PR DESCRIPTION
:cl:
fix: The Shift Duration in the round-end report is no longer blank in rounds lasting between one and two hours.
/:cl:

Fixes #36146, introduced in 3ab8b52.