### PR TITLE
Removes DEBUG from compile_options.

### DIFF
--- a/code/_compile_options.dm
+++ b/code/_compile_options.dm
@@ -1,5 +1,3 @@
-#define DEBUG					//Enables byond profiling and full runtime logs - note, this may also be defined in your .dme file
-								//Enables in-depth debug messages to runtime log (used for debugging)
 //#define TESTING				//By using the testing("message") proc you can create debug-feedback for people with this
 								//uncommented, but not visible in the release version)
 


### PR DESCRIPTION
byond as of 1413 only lets you define debug inside the dme, so this is pointless.
