### PR TITLE
Allow configuring ruin/empty space level count

### DIFF
--- a/code/__DEFINES/maps.dm
+++ b/code/__DEFINES/maps.dm
@@ -26,7 +26,6 @@ require only minor tweaks.
 #define MAP_REMOVE_JOB(jobpath) /datum/job/##jobpath/map_check() { return (SSmapping.config.map_name != JOB_MODIFICATION_MAP_NAME) && ..() }
 
 #define SPACERUIN_MAP_EDGE_PAD 15
-#define ZLEVEL_SPACE_RUIN_COUNT 7
 
 // traits
 // boolean - marks a level as having that property if present

--- a/code/controllers/subsystem/mapping.dm
+++ b/code/controllers/subsystem/mapping.dm
@@ -50,11 +50,13 @@ SUBSYSTEM_DEF(mapping)
 	preloadTemplates()
 #ifndef LOWMEMORYMODE
 	// Create space ruin levels
-	while (space_levels_so_far < ZLEVEL_SPACE_RUIN_COUNT)
+	while (space_levels_so_far < config.space_ruin_levels)
 		++space_levels_so_far
 		add_new_zlevel("Empty Area [space_levels_so_far]", ZTRAITS_SPACE)
 	// and one level with no ruins
-	empty_space = add_new_zlevel("Empty Area [1 + space_levels_so_far]", list(ZTRAIT_LINKAGE = CROSSLINKED))
+	for (var/i in 1 to config.space_empty_levels)
+		++space_levels_so_far
+		empty_space = add_new_zlevel("Empty Area [space_levels_so_far]", list(ZTRAIT_LINKAGE = CROSSLINKED))
 	// and the transit level
 	transit = add_new_zlevel("Transit", list(ZTRAIT_TRANSIT = TRUE))
 
@@ -175,7 +177,7 @@ SUBSYSTEM_DEF(mapping)
 
 #ifndef LOWMEMORYMODE
 	// TODO: remove this when the DB is prepared for the z-levels getting reordered
-	while (world.maxz < (5 - 1) && space_levels_so_far < ZLEVEL_SPACE_RUIN_COUNT)
+	while (world.maxz < (5 - 1) && space_levels_so_far < config.space_ruin_levels)
 		++space_levels_so_far
 		add_new_zlevel("Empty Area [space_levels_so_far]", ZTRAITS_SPACE)
 

--- a/code/datums/map_config.dm
+++ b/code/datums/map_config.dm
@@ -18,6 +18,8 @@
 	var/map_file = "BoxStation.dmm"
 
 	var/traits = null
+	var/space_ruin_levels = 7
+	var/space_empty_levels = 1
 
 	var/minetype = "lavaland"
 
@@ -104,6 +106,20 @@
 	// "traits": null or absent -> default
 	else if (!isnull(traits))
 		log_world("map_config traits is not a list!")
+		return
+
+	var/temp = json["space_ruin_levels"]
+	if (isnum(temp))
+		space_ruin_levels = temp
+	else if (!isnull(temp))
+		log_world("map_config space_ruin_levels is not a number!")
+		return
+
+	temp = json["space_empty_levels"]
+	if (isnum(temp))
+		space_empty_levels = temp
+	else if (!isnull(temp))
+		log_world("map_config space_empty_levels is not a number!")
 		return
 
 	if ("minetype" in json)

--- a/code/modules/events/pirates.dm
+++ b/code/modules/events/pirates.dm
@@ -9,6 +9,12 @@
 	earliest_start = 30 MINUTES
 	gamemode_blacklist = list("nuclear")
 
+/datum/round_event_control/pirates/preRunEvent()
+	if (!SSmapping.empty_space)
+		return EVENT_CANT_RUN
+
+	return ..()
+
 /datum/round_event/pirates
 	startWhen = 60 //2 minutes to answer
 	var/datum/comm_message/threat


### PR DESCRIPTION
Allows map configs to set how many ruin levels (def. 7) and how many empty levels (def. 1) that will be created. Most useful for landlocked stations, event/one-off stations with unusual composition, or testing situations such as RuntimeStation.