### PR TITLE
Changelings are now considered alive as long as they exist.

### DIFF
--- a/code/__HELPERS/game.dm
+++ b/code/__HELPERS/game.dm
@@ -328,6 +328,8 @@
 
 /proc/considered_alive(datum/mind/M, enforce_human = TRUE)
 	if(M && M.current)
+		if(M.has_antag_datum(/datum/antagonist/changeling))
+			return TRUE
 		if(enforce_human)
 			var/mob/living/carbon/human/H
 			if(ishuman(M.current))


### PR DESCRIPTION


:cl: Astral
fix: Changelings should no longer be considered dead if they're not destroyed.
/:cl:
