### PR TITLE
Removes a whole bunch of nuclear emergency memes

### DIFF
--- a/code/__HELPERS/areas.dm
+++ b/code/__HELPERS/areas.dm
@@ -15,6 +15,8 @@
 		var/turf/sourceT = found_turfs[1]
 		if(break_if_found[sourceT.type])
 			return FALSE
+		if (is_type_in_typecache(sourceT.loc, GLOB.typecache_shuttle_area))
+			return FALSE
 		found_turfs.Cut(1, 2)
 		var/dir_flags = checked_turfs[sourceT]
 		for(var/dir in GLOB.alldirs)
@@ -37,7 +39,7 @@
 	var/static/blacklisted_areas = typecacheof(/area/space)
 	var/list/turfs = detect_room(get_turf(creator), blacklisted_turfs)
 	if(!turfs)
-		to_chat(creator, "<span class='warning'>The new area must be completely airtight.</span>")
+		to_chat(creator, "<span class='warning'>The new area must be completely airtight and not a part of a shuttle.</span>")
 		return
 	if(turfs.len > BP_MAX_ROOM_SIZE)
 		to_chat(creator, "<span class='warning'>The room you're in is too big. It is [((turfs.len / BP_MAX_ROOM_SIZE)-1)*100]% larger than allowed.</span>")
@@ -45,7 +47,7 @@
 	var/list/areas = list("New Area" = /area)
 	for(var/i in 1 to turfs.len)
 		var/area/place = get_area(turfs[i])
-		if(blacklisted_areas[place.type])
+		if(blacklisted_areas[place.type] || GLOB.typecache_shuttle_area[place.type])
 			continue
 		if(!place.requires_power || place.noteleport || place.hidden)
 			continue // No expanding powerless rooms etc

--- a/code/_globalvars/lists/typecache.dm
+++ b/code/_globalvars/lists/typecache.dm
@@ -9,3 +9,4 @@ GLOBAL_LIST_INIT(typecache_living, typecacheof(/mob/living))
 
 GLOBAL_LIST_INIT(typecache_machine_or_structure, typecacheof(list(/obj/machinery, /obj/structure)))
 
+GLOBAL_LIST_INIT(typecache_shuttle_area, typecacheof(/area/shuttle))

--- a/code/game/atoms_movable.dm
+++ b/code/game/atoms_movable.dm
@@ -698,8 +698,6 @@
 		return TRUE
 	if (is_transit_level(T.z))
 		var/area/A = T.loc
-		if (!istype(A, /area/shuttle)) // To pre-empt the next meme
-			return FALSE
 		if (is_type_in_typecache(A, allowed_shuttles))
 			return TRUE
 

--- a/code/game/atoms_movable.dm
+++ b/code/game/atoms_movable.dm
@@ -690,10 +690,20 @@
 			message_admins("[src] has been moved out of bounds in [ADMIN_COORDJMP(currentturf)]. Moving it to [ADMIN_COORDJMP(targetturf)].")
 
 /atom/movable/proc/in_bounds()
-	. = FALSE
+	var/static/list/allowed_shuttles = typecacheof(list(/area/shuttle/syndicate, /area/shuttle/escape, /area/shuttle/pod_1, /area/shuttle/pod_2, /area/shuttle/pod_3, /area/shuttle/pod_4))
 	var/turf/T = get_turf(src)
-	if (T && (is_centcom_level(T.z) || is_station_level(T.z) || is_transit_level(T.z)))
-		. = TRUE
+	if (!T)
+		return FALSE
+	if (is_station_level(T.z) || is_centcom_level(T.z))
+		return TRUE
+	if (is_transit_level(T.z))
+		var/area/A = T.loc
+		if (!istype(A, /area/shuttle)) // To pre-empt the next meme
+			return FALSE
+		if (is_type_in_typecache(A, allowed_shuttles))
+			return TRUE
+
+	return FALSE
 
 
 /* Language procs */

--- a/code/game/turfs/space/space.dm
+++ b/code/game/turfs/space/space.dm
@@ -130,7 +130,24 @@
 		return
 
 	if(destination_z && destination_x && destination_y)
-		A.forceMove(locate(destination_x, destination_y, destination_z))
+		var/tx = destination_x
+		var/ty = destination_y
+		var/turf/DT = locate(tx, ty, destination_z)
+		var/itercount = 0
+		while(DT.density || istype(DT.loc,/area/shuttle)) // Extend towards the center of the map, trying to look for a better place to arrive
+			if (itercount++ >= 100)
+				log_game("SPACE Z-TRANSIT ERROR: Could not not find a safe place to land [A] within 100 iterations.")
+				break
+			if (tx < 128)
+				tx++
+			else
+				tx--
+			if (ty < 128)
+				ty++
+			else
+				ty--
+			DT = locate(tx, ty, destination_z)
+		A.forceMove(DT)
 
 		if(isliving(A))
 			var/mob/living/L = A

--- a/code/modules/antagonists/nukeop/equipment/nuclear_challenge.dm
+++ b/code/modules/antagonists/nukeop/equipment/nuclear_challenge.dm
@@ -3,8 +3,6 @@
 #define CHALLENGE_MIN_PLAYERS 50
 #define CHALLENGE_SHUTTLE_DELAY 15000 // 25 minutes, so the ops have at least 5 minutes before the shuttle is callable.
 
-GLOBAL_LIST_EMPTY(del_on_wardec)
-
 /obj/item/device/nuclear_challenge
 	name = "Declaration of War (Challenge Mode)"
 	icon_state = "gangtool-red"
@@ -55,9 +53,6 @@ GLOBAL_LIST_EMPTY(del_on_wardec)
 	for(var/V in GLOB.syndicate_shuttle_boards)
 		var/obj/item/circuitboard/computer/syndicate_shuttle/board = V
 		board.challenge = TRUE
-
-	for(var/atom/A in GLOB.del_on_wardec)
-		qdel(A)
 
 	new /obj/item/device/radio/uplink/nuclear(get_turf(user), user.key, CHALLENGE_TELECRYSTALS)
 	CONFIG_SET(number/shuttle_refuel_delay, max(CONFIG_GET(number/shuttle_refuel_delay), CHALLENGE_SHUTTLE_DELAY))

--- a/code/modules/antagonists/nukeop/equipment/nuclear_challenge.dm
+++ b/code/modules/antagonists/nukeop/equipment/nuclear_challenge.dm
@@ -3,6 +3,8 @@
 #define CHALLENGE_MIN_PLAYERS 50
 #define CHALLENGE_SHUTTLE_DELAY 15000 // 25 minutes, so the ops have at least 5 minutes before the shuttle is callable.
 
+GLOBAL_LIST_EMPTY(del_on_wardec)
+
 /obj/item/device/nuclear_challenge
 	name = "Declaration of War (Challenge Mode)"
 	icon_state = "gangtool-red"
@@ -54,6 +56,9 @@
 		var/obj/item/circuitboard/computer/syndicate_shuttle/board = V
 		board.challenge = TRUE
 
+	for(var/atom/A in GLOB.del_on_wardec)
+		qdel(A)
+
 	new /obj/item/device/radio/uplink/nuclear(get_turf(user), user.key, CHALLENGE_TELECRYSTALS)
 	CONFIG_SET(number/shuttle_refuel_delay, max(CONFIG_GET(number/shuttle_refuel_delay), CHALLENGE_SHUTTLE_DELAY))
 	SSblackbox.record_feedback("amount", "nuclear_challenge_mode", 1)
@@ -81,5 +86,6 @@
 	return TRUE
 
 #undef CHALLENGE_TELECRYSTALS
+#undef CHALLENGE_TIME_LIMIT
 #undef CHALLENGE_MIN_PLAYERS
 #undef CHALLENGE_SHUTTLE_DELAY

--- a/code/modules/ruins/spaceruin_code/caravanambush.dm
+++ b/code/modules/ruins/spaceruin_code/caravanambush.dm
@@ -53,14 +53,6 @@
 	shuttleId = "caravantrade1"
 	possible_destinations = "whiteship_away;whiteship_home;whiteship_z4;whiteship_lavaland;caravantrade1_custom;caravantrade1_ambush"
 
-/obj/machinery/computer/camera_advanced/shuttle_docker/caravan/Initialize()
-	. = ..()
-	GLOB.del_on_wardec += src
-
-/obj/machinery/computer/camera_advanced/shuttle_docker/caravan/Destroy()
-	GLOB.del_on_wardec -= src
-	return ..()
-
 /obj/machinery/computer/camera_advanced/shuttle_docker/caravan/trade1
 	name = "Small Freighter Navigation Computer"
 	desc = "Used to designate a precise transit location for the Small Freighter."

--- a/code/modules/ruins/spaceruin_code/caravanambush.dm
+++ b/code/modules/ruins/spaceruin_code/caravanambush.dm
@@ -53,6 +53,14 @@
 	shuttleId = "caravantrade1"
 	possible_destinations = "whiteship_away;whiteship_home;whiteship_z4;whiteship_lavaland;caravantrade1_custom;caravantrade1_ambush"
 
+/obj/machinery/computer/camera_advanced/shuttle_docker/caravan/Initialize()
+	. = ..()
+	GLOB.del_on_wardec += src
+
+/obj/machinery/computer/camera_advanced/shuttle_docker/caravan/Destroy()
+	GLOB.del_on_wardec -= src
+	return ..()
+
 /obj/machinery/computer/camera_advanced/shuttle_docker/caravan/trade1
 	name = "Small Freighter Navigation Computer"
 	desc = "Used to designate a precise transit location for the Small Freighter."

--- a/code/modules/shuttle/white_ship.dm
+++ b/code/modules/shuttle/white_ship.dm
@@ -17,11 +17,3 @@
 	x_offset = -6
 	y_offset = -10
 	designate_time = 100
-
-/obj/machinery/computer/camera_advanced/shuttle_docker/whiteship/Initialize()
-	. = ..()
-	GLOB.del_on_wardec += src
-
-/obj/machinery/computer/camera_advanced/shuttle_docker/whiteship/Destroy()
-	GLOB.del_on_wardec -= src
-	return ..()

--- a/code/modules/shuttle/white_ship.dm
+++ b/code/modules/shuttle/white_ship.dm
@@ -18,3 +18,10 @@
 	y_offset = -10
 	designate_time = 100
 
+/obj/machinery/computer/camera_advanced/shuttle_docker/whiteship/Initialize()
+	. = ..()
+	GLOB.del_on_wardec += src
+
+/obj/machinery/computer/camera_advanced/shuttle_docker/whiteship/Destroy()
+	GLOB.del_on_wardec -= src
+	return ..()


### PR DESCRIPTION
:cl: Naksu
balance: The nuclear authentication disk no longer treats the transit space as a whole as being "in bounds", but instead checks whether it is in an approved shuttle type (syndicate shuttles, escape shuttles, pubbiestation's monastery shuttle, escape pods are allowed)
fix: Blueprints can no longer be used to create areas inside shuttles. This fixes various exploits involving shuttles and areas.
fix: Moving across a space z-level border can no longer place you inside a shuttle or a dense turf such as an asteroid.
/:cl:

Overall this removes a few ways players may use to find and trivially board the ops' shuttle, and also several ways the disk can be rendered inaccessible to the ops. 