### PR TITLE
Foam Darts get deleted when sprayed with space cleaner.

### DIFF
--- a/code/modules/reagents/chemistry/reagents/other_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/other_reagents.dm
@@ -1005,7 +1005,7 @@
 	taste_description = "sourness"
 
 /datum/reagent/space_cleaner/reaction_obj(obj/O, reac_volume)
-	if(istype(O, /obj/effect/decal/cleanable) || istype(O, /obj/item/ammo_casing/caseless/foam_dart)
+	if(istype(O, /obj/effect/decal/cleanable) || istype(O, /obj/item/ammo_casing/caseless/foam_dart))
 		qdel(O)
 	else
 		if(O)

--- a/code/modules/reagents/chemistry/reagents/other_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/other_reagents.dm
@@ -1005,7 +1005,7 @@
 	taste_description = "sourness"
 
 /datum/reagent/space_cleaner/reaction_obj(obj/O, reac_volume)
-	if(istype(O, /obj/effect/decal/cleanable))
+	if(istype(O, /obj/effect/decal/cleanable) || istype(O, /obj/item/ammo_casing/caseless/foam_dart)
 		qdel(O)
 	else
 		if(O)


### PR DESCRIPTION
Exactly what it says on the tin.

[Changelogs]: When sprayed with Space Cleaner, Foam darts and Foam Riot darts will now be removed like blood, oil, and most other stuff that can be cleaned.
:cl: ZeroNetAlpha
tweak: Foam Darts and Riot Darts will now be qdel'd when sprayed with space cleaner.
/:cl:

[why]: Originally this was just going to be a change for Citadel, but I was told that this might be of interest upstream so here I am. It doesn't do much but it should help with any lag associated with 200+ foam darts being shot.
https://gyazo.com/a98ed04fb60ae7fcd58f4a8d4aa13d71