### PR TITLE
Sentient diseases get 2 minutes to select their initial host

### DIFF
--- a/code/modules/antagonists/disease/disease_datum.dm
+++ b/code/modules/antagonists/disease/disease_datum.dm
@@ -27,14 +27,13 @@
 /datum/antagonist/disease/apply_innate_effects(mob/living/mob_override)
 	if(!istype(owner.current, /mob/camera/disease))
 		var/turf/T = get_turf(owner.current)
-		T = T ? T : locate(1, 1, 1)
+		T = T ? T : SSmapping.get_station_center()
 		var/mob/camera/disease/D = new /mob/camera/disease(T)
 		owner.transfer_to(D)
 
 /datum/antagonist/disease/admin_add(datum/mind/new_owner,mob/admin)
 	..()
 	var/mob/camera/disease/D = new_owner.current
-	D.infect_patient_zero()
 	D.pick_name()
 
 /datum/antagonist/disease/roundend_report()

--- a/code/modules/antagonists/disease/disease_event.dm
+++ b/code/modules/antagonists/disease/disease_event.dm
@@ -17,11 +17,7 @@
 
 	var/mob/dead/observer/selected = pick_n_take(candidates)
 
-	var/mob/camera/disease/virus = new /mob/camera/disease(locate(1, 1, 1))
-	if(!virus.infect_patient_zero())
-		message_admins("Event attempted to spawn a sentient disease, but infection of patient zero failed.")
-		qdel(virus)
-		return WAITING_FOR_SOMETHING
+	var/mob/camera/disease/virus = new /mob/camera/disease(SSmapping.get_station_center())
 	virus.key = selected.key
 	INVOKE_ASYNC(virus, /mob/camera/disease/proc/pick_name)
 	message_admins("[key_name_admin(virus)] has been made into a sentient disease by an event.")


### PR DESCRIPTION
:cl: 
add: Sentient diseases now get two minutes to select an initial host before being assigned a random one.
/:cl:

Sentient diseases get to fly around the station like blob overminds do to select their initial host. This will prevent people getting screwed because their randomly assigned host is braindead or just stands in their room all round. If they do not make a selection after two minutes, their random host will always be alive and on the station, and non-braindeads will be prioritized.