### PR TITLE
Constructed turbines now properly connect_to_network()

### DIFF
--- a/code/modules/power/turbine.dm
+++ b/code/modules/power/turbine.dm
@@ -173,6 +173,7 @@
 	locate_machinery()
 	if(!compressor)
 		stat |= BROKEN
+	connect_to_network()
 
 /obj/machinery/power/turbine/RefreshParts()
 	var/P = 0


### PR DESCRIPTION
Fixes #35899

:cl: Astral
fix: Constructed turbines will now properly connect to the powernet
/:cl:

ok so i was browsing engineering autism and I saw this easy to fix issue mentioned.

