### PR TITLE
Pipenet fix

### DIFF
--- a/code/modules/atmospherics/machinery/components/components_base.dm
+++ b/code/modules/atmospherics/machinery/components/components_base.dm
@@ -88,8 +88,6 @@ Pipenet stuff; housekeeping
 	parents[nodes.Find(A)] = reference
 
 /obj/machinery/atmospherics/components/returnPipenet(obj/machinery/atmospherics/A = nodes[1]) //returns parents[1] if called without argument
-	if(QDELETED(src))
-		warning(" returnPipenet called on QDELETED [src]  Nearby: ([x], [y], [z])")
 	return parents[nodes.Find(A)]
 
 /obj/machinery/atmospherics/components/replacePipenet(datum/pipeline/Old, datum/pipeline/New)

--- a/code/modules/atmospherics/machinery/components/components_base.dm
+++ b/code/modules/atmospherics/machinery/components/components_base.dm
@@ -88,6 +88,8 @@ Pipenet stuff; housekeeping
 	parents[nodes.Find(A)] = reference
 
 /obj/machinery/atmospherics/components/returnPipenet(obj/machinery/atmospherics/A = nodes[1]) //returns parents[1] if called without argument
+	if(QDELETED(src))
+		warning(" returnPipenet called on QDELETED [src]  Nearby: ([x], [y], [z])")
 	return parents[nodes.Find(A)]
 
 /obj/machinery/atmospherics/components/replacePipenet(datum/pipeline/Old, datum/pipeline/New)

--- a/code/modules/atmospherics/machinery/datum_pipeline.dm
+++ b/code/modules/atmospherics/machinery/datum_pipeline.dm
@@ -90,7 +90,8 @@
 		var/obj/machinery/atmospherics/pipe/P = A
 		if(P.parent)
 			merge(P.parent)
-		P.parent = src
+		else
+			P.parent = src
 		var/list/adjacent = P.pipeline_expansion()
 		for(var/obj/machinery/atmospherics/pipe/I in adjacent)
 			if(I.parent == src)
@@ -105,6 +106,8 @@
 		addMachineryMember(A)
 
 /datum/pipeline/proc/merge(datum/pipeline/E)
+	if(E == src)
+		return
 	air.volume += E.air.volume
 	members.Add(E.members)
 	for(var/obj/machinery/atmospherics/pipe/S in E.members)

--- a/code/modules/atmospherics/machinery/datum_pipeline.dm
+++ b/code/modules/atmospherics/machinery/datum_pipeline.dm
@@ -90,8 +90,7 @@
 		var/obj/machinery/atmospherics/pipe/P = A
 		if(P.parent)
 			merge(P.parent)
-		else
-			P.parent = src
+		P.parent = src
 		var/list/adjacent = P.pipeline_expansion()
 		for(var/obj/machinery/atmospherics/pipe/I in adjacent)
 			if(I.parent == src)

--- a/code/modules/atmospherics/machinery/pipes/pipes.dm
+++ b/code/modules/atmospherics/machinery/pipes/pipes.dm
@@ -76,9 +76,10 @@
 	parent = P
 
 /obj/machinery/atmospherics/pipe/Destroy()
+	QDEL_NULL(parent)
+
 	releaseAirToTurf()
-	qdel(air_temporary)
-	air_temporary = null
+	QDEL_NULL(air_temporary)
 
 	var/turf/T = loc
 	for(var/obj/machinery/meter/meter in T)
@@ -87,8 +88,6 @@
 			meter.transfer_fingerprints_to(PM)
 			qdel(meter)
 	. = ..()
-
-	QDEL_NULL(parent)
 
 /obj/machinery/atmospherics/pipe/proc/update_node_icon()
 	for(var/i in 1 to device_type)


### PR DESCRIPTION
#Fix of Runtime in components_base.dm,91: Cannot read null.parents  proc name: returnPipenet
Return working releaseAirToTurf() on pipe Destroy()
Block of self merge what cause pipeline annihilation. Pipes don't lose air on connecting more than to one pipe

:cl: Pipe fixes
fix: Runtime in components_base.dm,91 what cause atmos machinery connection problems.
fix: Pipes release air in turf on Destroy(), again.
fix: Pipeline now cant be annihilated by merge(src). Pipes don't lose air on connecting more than to one pipe.
/:cl:

[why]: # (Please add a short description [two lines down] of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.)

Fixes #36298
Fixes #18354