### PR TITLE
Disables advanced shuttle navigation consoles during nuclear war ops

### DIFF
--- a/code/modules/antagonists/nukeop/equipment/nuclear_challenge.dm
+++ b/code/modules/antagonists/nukeop/equipment/nuclear_challenge.dm
@@ -3,6 +3,8 @@
 #define CHALLENGE_MIN_PLAYERS 50
 #define CHALLENGE_SHUTTLE_DELAY 15000 // 25 minutes, so the ops have at least 5 minutes before the shuttle is callable.
 
+GLOBAL_LIST_EMPTY(jam_on_wardec)
+
 /obj/item/device/nuclear_challenge
 	name = "Declaration of War (Challenge Mode)"
 	icon_state = "gangtool-red"
@@ -53,6 +55,9 @@
 	for(var/V in GLOB.syndicate_shuttle_boards)
 		var/obj/item/circuitboard/computer/syndicate_shuttle/board = V
 		board.challenge = TRUE
+
+	for(var/obj/machinery/computer/camera_advanced/shuttle_docker/D in GLOB.jam_on_wardec)
+		D.jammed = TRUE
 
 	new /obj/item/device/radio/uplink/nuclear(get_turf(user), user.key, CHALLENGE_TELECRYSTALS)
 	CONFIG_SET(number/shuttle_refuel_delay, max(CONFIG_GET(number/shuttle_refuel_delay), CHALLENGE_SHUTTLE_DELAY))

--- a/code/modules/ruins/spaceruin_code/caravanambush.dm
+++ b/code/modules/ruins/spaceruin_code/caravanambush.dm
@@ -53,6 +53,14 @@
 	shuttleId = "caravantrade1"
 	possible_destinations = "whiteship_away;whiteship_home;whiteship_z4;whiteship_lavaland;caravantrade1_custom;caravantrade1_ambush"
 
+/obj/machinery/computer/camera_advanced/shuttle_docker/caravan/Initialize()
+	. = ..()
+	GLOB.jam_on_wardec += src
+
+/obj/machinery/computer/camera_advanced/shuttle_docker/caravan/Destroy()
+	GLOB.jam_on_wardec -= src
+	return ..()
+
 /obj/machinery/computer/camera_advanced/shuttle_docker/caravan/trade1
 	name = "Small Freighter Navigation Computer"
 	desc = "Used to designate a precise transit location for the Small Freighter."

--- a/code/modules/shuttle/navigation_computer.dm
+++ b/code/modules/shuttle/navigation_computer.dm
@@ -29,7 +29,7 @@
 
 /obj/machinery/computer/camera_advanced/shuttle_docker/attack_hand(mob/user)
 	if(jammed)
-		to_chat(user, "<span class='warning'>The Syndicate are jamming the console!</span>")
+		to_chat(user, "<span class='warning'>The Syndicate is jamming the console!</span>")
 		return
 	return ..()
 

--- a/code/modules/shuttle/navigation_computer.dm
+++ b/code/modules/shuttle/navigation_computer.dm
@@ -17,6 +17,7 @@
 	var/see_hidden = FALSE
 	var/designate_time = 0
 	var/turf/designating_target_loc
+	var/jammed = FALSE
 
 /obj/machinery/computer/camera_advanced/shuttle_docker/Initialize()
 	. = ..()
@@ -25,6 +26,12 @@
 /obj/machinery/computer/camera_advanced/shuttle_docker/Destroy()
 	. = ..()
 	GLOB.navigation_computers -= src
+
+/obj/machinery/computer/camera_advanced/shuttle_docker/attack_hand()
+	if(jammed)
+		to_chat(user, "<span class='warning'>The Syndicate are jamming the console!</span>")
+		return
+	return ..()
 
 /obj/machinery/computer/camera_advanced/shuttle_docker/GrantActions(mob/living/user)
 	if(jumpto_ports.len)

--- a/code/modules/shuttle/navigation_computer.dm
+++ b/code/modules/shuttle/navigation_computer.dm
@@ -27,7 +27,7 @@
 	. = ..()
 	GLOB.navigation_computers -= src
 
-/obj/machinery/computer/camera_advanced/shuttle_docker/attack_hand()
+/obj/machinery/computer/camera_advanced/shuttle_docker/attack_hand(mob/user)
 	if(jammed)
 		to_chat(user, "<span class='warning'>The Syndicate are jamming the console!</span>")
 		return

--- a/code/modules/shuttle/white_ship.dm
+++ b/code/modules/shuttle/white_ship.dm
@@ -17,3 +17,11 @@
 	x_offset = -6
 	y_offset = -10
 	designate_time = 100
+
+/obj/machinery/computer/camera_advanced/shuttle_docker/whiteship/Initialize()
+	. = ..()
+	GLOB.jam_on_wardec += src
+
+/obj/machinery/computer/camera_advanced/shuttle_docker/whiteship/Destroy()
+	GLOB.jam_on_wardec -= src
+	return ..()


### PR DESCRIPTION
:cl: Naksu
balance: The white ship and miscellaneous caravan ships lose their advanced place-anywhere shuttle movement during war ops.
/:cl:


