### PR TITLE
Removes the smoke machine from roundstart chemistry

### DIFF
--- a/_maps/map_files/BoxStation/BoxStation.dmm
+++ b/_maps/map_files/BoxStation/BoxStation.dmm
@@ -22991,7 +22991,6 @@
 /obj/structure/cable{
 	icon_state = "0-2"
 	},
-/obj/machinery/smoke_machine,
 /turf/open/floor/plasteel/white,
 /area/medical/chemistry)
 "bha" = (

--- a/_maps/map_files/Deltastation/DeltaStation2.dmm
+++ b/_maps/map_files/Deltastation/DeltaStation2.dmm
@@ -76240,7 +76240,6 @@
 	pixel_y = 7;
 	req_access_txt = "33"
 	},
-/obj/machinery/smoke_machine,
 /turf/open/floor/plasteel/whiteyellow/corner{
 	dir = 8
 	},

--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -54263,7 +54263,6 @@
 /turf/open/floor/plasteel/white,
 /area/medical/chemistry)
 "cjV" = (
-/obj/machinery/smoke_machine,
 /turf/open/floor/plasteel/whiteyellow/side{
 	dir = 4
 	},

--- a/_maps/map_files/PubbyStation/PubbyStation.dmm
+++ b/_maps/map_files/PubbyStation/PubbyStation.dmm
@@ -50025,7 +50025,6 @@
 /turf/open/floor/plasteel/dark,
 /area/chapel/office)
 "cBP" = (
-/obj/machinery/smoke_machine,
 /turf/open/floor/plasteel/white,
 /area/medical/chemistry)
 "cBQ" = (


### PR DESCRIPTION
With #36220 making the smoke machine obtainable via techwebs, we don't need to keep smoke machines around in maps in order for them to be usable. Admins have requested for the machine to be removed due to frequent complaints about gamemode and side-antags getting pushed out of mind due to things like infinite holy water smoke and infinite salt smoke.

:cl: Naksu
del: The smoke machine can no longer be found in chemistry departments, instead it must be constructed manually. The board was added to techwebs earlier.
/:cl:

Making smoke not run turf reactions might be a thing worth considering as an alternative.