### PR TITLE
harmful var for guns

### DIFF
--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -848,14 +848,19 @@
 		return FALSE
 	return TRUE
 
-/mob/living/proc/can_use_guns(obj/item/G)
+/mob/living/proc/can_use_guns(obj/item/G)//actually used for more than guns!
 	if(G.trigger_guard != TRIGGER_GUARD_ALLOW_ALL && !IsAdvancedToolUser())
 		to_chat(src, "<span class='warning'>You don't have the dexterity to do this!</span>")
 		return FALSE
+	var/obj/item/gun/shooty
+	if(istype(G, /obj/item/gun))
+		shooty = G
 	if(has_trait(TRAIT_PACIFISM))
+		if(shooty && !shooty.harmful)
+			return TRUE
 		to_chat(src, "<span class='notice'>You don't want to risk harming anyone!</span>")
 		return FALSE
-	return TRUE
+return TRUE
 
 /mob/living/carbon/proc/update_stamina()
 	if(staminaloss)

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -860,7 +860,7 @@
 			return TRUE
 		to_chat(src, "<span class='notice'>You don't want to risk harming anyone!</span>")
 		return FALSE
-return TRUE
+	return TRUE
 
 /mob/living/carbon/proc/update_stamina()
 	if(staminaloss)

--- a/code/modules/projectiles/gun.dm
+++ b/code/modules/projectiles/gun.dm
@@ -35,6 +35,7 @@
 	var/weapon_weight = WEAPON_LIGHT
 	var/spread = 0						//Spread induced by the gun itself.
 	var/randomspread = 1				//Set to 0 for shotguns. This is used for weapons that don't fire all their bullets at once.
+	var/harmful = TRUE					//some arent harmful and should have this set to false. used for pacifists with tasers, medibeams, etc
 
 	lefthand_file = 'icons/mob/inhands/weapons/guns_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/weapons/guns_righthand.dmi'

--- a/code/modules/projectiles/guns/ballistic/toy.dm
+++ b/code/modules/projectiles/guns/ballistic/toy.dm
@@ -13,6 +13,7 @@
 	clumsy_check = 0
 	item_flags = NONE
 	casing_ejector = FALSE
+	harmful = FALSE
 
 /obj/item/gun/ballistic/automatic/toy/unrestricted
 	pin = /obj/item/device/firing_pin
@@ -27,6 +28,7 @@
 	burst_size = 1
 	fire_delay = 0
 	actions_types = list()
+	harmful = FALSE
 
 /obj/item/gun/ballistic/automatic/toy/pistol/update_icon()
 	..()
@@ -56,6 +58,7 @@
 	item_flags = NONE
 	casing_ejector = FALSE
 	can_suppress = FALSE
+	harmful = FALSE
 
 /obj/item/gun/ballistic/shotgun/toy/process_chamber(empty_chamber = 0)
 	..()

--- a/code/modules/projectiles/guns/energy/special.dm
+++ b/code/modules/projectiles/guns/energy/special.dm
@@ -49,6 +49,7 @@
 	modifystate = 1
 	ammo_x_offset = 1
 	selfcharge = 1
+	harmful = FALSE
 
 /obj/item/gun/energy/meteorgun
 	name = "meteor gun"

--- a/code/modules/projectiles/guns/energy/stun.dm
+++ b/code/modules/projectiles/guns/energy/stun.dm
@@ -5,6 +5,7 @@
 	item_state = null	//so the human update icon uses the icon_state instead.
 	ammo_type = list(/obj/item/ammo_casing/energy/electrode)
 	ammo_x_offset = 3
+	harmful = FALSE
 
 /obj/item/gun/energy/tesla_revolver
 	name = "tesla gun"
@@ -22,6 +23,7 @@
 	icon_state = "advtaser"
 	ammo_type = list(/obj/item/ammo_casing/energy/electrode, /obj/item/ammo_casing/energy/disabler)
 	ammo_x_offset = 2
+	harmful = FALSE
 
 /obj/item/gun/energy/e_gun/advtaser/cyborg
 	name = "cyborg taser"
@@ -29,6 +31,7 @@
 	can_flashlight = 0
 	can_charge = 0
 	use_cyborg_cell = 1
+	harmful = FALSE
 
 /obj/item/gun/energy/disabler
 	name = "disabler"
@@ -37,10 +40,11 @@
 	item_state = null
 	ammo_type = list(/obj/item/ammo_casing/energy/disabler)
 	ammo_x_offset = 3
+	harmful = FALSE
 
 /obj/item/gun/energy/disabler/cyborg
 	name = "cyborg disabler"
 	desc = "An integrated disabler that draws from a cyborg's power cell. This weapon contains a limiter to prevent the cyborg's power cell from overheating."
 	can_charge = 0
 	use_cyborg_cell = 1
-
+	harmful = FALSE

--- a/code/modules/projectiles/guns/magic/staff.dm
+++ b/code/modules/projectiles/guns/magic/staff.dm
@@ -27,6 +27,7 @@
 	ammo_type = /obj/item/ammo_casing/magic/heal
 	icon_state = "staffofhealing"
 	item_state = "staffofhealing"
+	harmful = FALSE
 
 /obj/item/gun/magic/staff/healing/handle_suicide() //Stops people trying to commit suicide to heal themselves
 	return
@@ -59,6 +60,7 @@
 	max_charges = 10
 	recharge_rate = 2
 	no_den_usage = 1
+	harmful = FALSE
 
 /obj/item/gun/magic/staff/honk
 	name = "staff of the honkmother"
@@ -69,6 +71,7 @@
 	item_state = "honker"
 	max_charges = 4
 	recharge_rate = 8
+	harmful = FALSE
 
 /obj/item/gun/magic/staff/spellblade
 	name = "spellblade"

--- a/code/modules/projectiles/guns/magic/wand.dm
+++ b/code/modules/projectiles/guns/magic/wand.dm
@@ -8,6 +8,7 @@
 	can_charge = 0
 	max_charges = 100 //100, 50, 50, 34 (max charge distribution by 25%ths)
 	var/variable_charges = 1
+	harmful = FALSE
 
 /obj/item/gun/magic/wand/Initialize()
 	if(prob(75) && variable_charges) //25% chance of listed max charges, 50% chance of 1/2 max charges, 25% chance of 1/3 max charges
@@ -85,6 +86,7 @@
 	fire_sound = 'sound/magic/staff_healing.ogg'
 	icon_state = "revivewand"
 	max_charges = 10 //10, 5, 5, 4
+	harmful = FALSE
 
 /obj/item/gun/magic/wand/resurrection/zap_self(mob/living/user)
 	user.revive(full_heal = 1)
@@ -125,6 +127,7 @@
 	icon_state = "telewand"
 	max_charges = 10 //10, 5, 5, 4
 	no_den_usage = 1
+	harmful = FALSE
 
 /obj/item/gun/magic/wand/teleport/zap_self(mob/living/user)
 	if(do_teleport(user, user, 10))
@@ -146,6 +149,7 @@
 	fire_sound = 'sound/magic/staff_door.ogg'
 	max_charges = 20 //20, 10, 10, 7
 	no_den_usage = 1
+	harmful = FALSE
 
 /obj/item/gun/magic/wand/door/zap_self(mob/living/user)
 	to_chat(user, "<span class='notice'>You feel vaguely more open with your feelings.</span>")

--- a/code/modules/projectiles/guns/misc/medbeam.dm
+++ b/code/modules/projectiles/guns/misc/medbeam.dm
@@ -5,6 +5,7 @@
 	icon_state = "chronogun"
 	item_state = "chronogun"
 	w_class = WEIGHT_CLASS_NORMAL
+	harmful = FALSE
 
 	var/mob/living/current_target
 	var/last_check = 0


### PR DESCRIPTION
🆑
fix: Pacifists can now use non-harmful guns, such as tasers, staffs of healing, toy foam dart guns, or medibeams
🆑

support for pacifism to allow firing of non-harmful guns

currently tasers, a few toy foam dart guns, a couple wizard magic wands, and a handful of others (door creation, teleportation, resurrection, floral somatoray, medibeam) are considered non-harmful

Fixes #36224