### PR TITLE
Tidy Processor Overload event code

### DIFF
--- a/code/modules/events/processor_overload.dm
+++ b/code/modules/events/processor_overload.dm
@@ -27,14 +27,12 @@
 
 
 /datum/round_event/processor_overload/start()
-	for(var/obj/machinery/telecomms/T in GLOB.telecomms_list)
-		if(istype(T, /obj/machinery/telecomms/processor))
-			var/obj/machinery/telecomms/processor/P = T
-			if(prob(10))
-				// Damage the surrounding area to indicate that it popped
-				explosion(get_turf(P), 0, 0, 2)
-				// Only a level 1 explosion actually damages the machine
-				// at all
-				P.ex_act(EXPLODE_DEVASTATE)
-			else
-				P.emp_act(EMP_HEAVY)
+	for(var/obj/machinery/telecomms/processor/P in GLOB.telecomms_list)
+		if(prob(10))
+			// Damage the surrounding area to indicate that it popped
+			explosion(get_turf(P), 0, 0, 2)
+			// Only a level 1 explosion actually damages the machine
+			// at all
+			P.ex_act(EXPLODE_DEVASTATE)
+		else
+			P.emp_act(EMP_HEAVY)


### PR DESCRIPTION
Just some minor cleanup. No need to effectively do two `istype` checks, let's just filter the list.