### PR TITLE
Pacifists can no longer cause harm using mech equipment

### DIFF
--- a/code/game/mecha/equipment/mecha_equipment.dm
+++ b/code/game/mecha/equipment/mecha_equipment.dm
@@ -14,7 +14,7 @@
 	var/range = MELEE //bitflags
 	var/salvageable = 1
 	var/selectable = 1	// Set to 0 for passive equipment such as mining scanner or armor plates
-	var/pacifist_safe = 1 //Controls if equipment can be used to attack by a pacifist.
+	var/pacifist_safe = true //Controls if equipment can be used to attack by a pacifist.
 
 /obj/item/mecha_parts/mecha_equipment/proc/update_chassis_page()
 	if(chassis)

--- a/code/game/mecha/equipment/mecha_equipment.dm
+++ b/code/game/mecha/equipment/mecha_equipment.dm
@@ -14,6 +14,7 @@
 	var/range = MELEE //bitflags
 	var/salvageable = 1
 	var/selectable = 1	// Set to 0 for passive equipment such as mining scanner or armor plates
+	var/pacifist_safe = 1 //Controls if equipment can be used to attack by a pacifist.
 
 /obj/item/mecha_parts/mecha_equipment/proc/update_chassis_page()
 	if(chassis)

--- a/code/game/mecha/equipment/mecha_equipment.dm
+++ b/code/game/mecha/equipment/mecha_equipment.dm
@@ -14,7 +14,7 @@
 	var/range = MELEE //bitflags
 	var/salvageable = 1
 	var/selectable = 1	// Set to 0 for passive equipment such as mining scanner or armor plates
-	var/pacifist_safe = true //Controls if equipment can be used to attack by a pacifist.
+	var/pacifist_safe = TRUE //Controls if equipment can be used to attack by a pacifist.
 
 /obj/item/mecha_parts/mecha_equipment/proc/update_chassis_page()
 	if(chassis)

--- a/code/game/mecha/equipment/tools/mining_tools.dm
+++ b/code/game/mecha/equipment/tools/mining_tools.dm
@@ -9,7 +9,7 @@
 	equip_cooldown = 15
 	energy_drain = 10
 	force = 15
-	pacifist_safe = 0
+	pacifist_safe = false
 
 /obj/item/mecha_parts/mecha_equipment/drill/Initialize()
 	. = ..()

--- a/code/game/mecha/equipment/tools/mining_tools.dm
+++ b/code/game/mecha/equipment/tools/mining_tools.dm
@@ -9,6 +9,7 @@
 	equip_cooldown = 15
 	energy_drain = 10
 	force = 15
+	pacifist_safe = 0
 
 /obj/item/mecha_parts/mecha_equipment/drill/Initialize()
 	. = ..()

--- a/code/game/mecha/equipment/tools/mining_tools.dm
+++ b/code/game/mecha/equipment/tools/mining_tools.dm
@@ -9,7 +9,7 @@
 	equip_cooldown = 15
 	energy_drain = 10
 	force = 15
-	pacifist_safe = false
+	pacifist_safe = FALSE
 
 /obj/item/mecha_parts/mecha_equipment/drill/Initialize()
 	. = ..()

--- a/code/game/mecha/equipment/tools/work_tools.dm
+++ b/code/game/mecha/equipment/tools/work_tools.dm
@@ -10,7 +10,7 @@
 	energy_drain = 10
 	var/dam_force = 20
 	var/obj/mecha/working/ripley/cargo_holder
-	pacifist_safe = false
+	pacifist_safe = FALSE
 
 /obj/item/mecha_parts/mecha_equipment/hydraulic_clamp/can_attach(obj/mecha/working/ripley/M as obj)
 	if(..())

--- a/code/game/mecha/equipment/tools/work_tools.dm
+++ b/code/game/mecha/equipment/tools/work_tools.dm
@@ -10,7 +10,7 @@
 	energy_drain = 10
 	var/dam_force = 20
 	var/obj/mecha/working/ripley/cargo_holder
-	pacifist_safe = 0
+	pacifist_safe = false
 
 /obj/item/mecha_parts/mecha_equipment/hydraulic_clamp/can_attach(obj/mecha/working/ripley/M as obj)
 	if(..())

--- a/code/game/mecha/equipment/tools/work_tools.dm
+++ b/code/game/mecha/equipment/tools/work_tools.dm
@@ -78,7 +78,6 @@
 	name = "\improper KILL CLAMP"
 	desc = "They won't know what clamped them!"
 	energy_drain = 0
-	pacifist_safe = 0
 
 /obj/item/mecha_parts/mecha_equipment/hydraulic_clamp/kill/action(atom/target)
 	if(!action_checks(target))

--- a/code/game/mecha/equipment/tools/work_tools.dm
+++ b/code/game/mecha/equipment/tools/work_tools.dm
@@ -10,6 +10,7 @@
 	energy_drain = 10
 	var/dam_force = 20
 	var/obj/mecha/working/ripley/cargo_holder
+	pacifist_safe = 0
 
 /obj/item/mecha_parts/mecha_equipment/hydraulic_clamp/can_attach(obj/mecha/working/ripley/M as obj)
 	if(..())
@@ -77,6 +78,7 @@
 	name = "\improper KILL CLAMP"
 	desc = "They won't know what clamped them!"
 	energy_drain = 0
+	pacifist_safe = 0
 
 /obj/item/mecha_parts/mecha_equipment/hydraulic_clamp/kill/action(atom/target)
 	if(!action_checks(target))

--- a/code/game/mecha/equipment/weapons/weapons.dm
+++ b/code/game/mecha/equipment/weapons/weapons.dm
@@ -75,6 +75,7 @@
 	energy_drain = 30
 	projectile = /obj/item/projectile/beam/laser
 	fire_sound = 'sound/weapons/laser.ogg'
+	pacifist_safe = 0
 
 /obj/item/mecha_parts/mecha_equipment/weapon/energy/laser/heavy
 	equip_cooldown = 15
@@ -102,7 +103,7 @@
 	energy_drain = 500
 	projectile = /obj/item/projectile/energy/tesla/cannon
 	fire_sound = 'sound/magic/lightningbolt.ogg'
-
+	pacifist_safe = 0
 
 /obj/item/mecha_parts/mecha_equipment/weapon/energy/pulse
 	equip_cooldown = 30
@@ -112,6 +113,7 @@
 	energy_drain = 120
 	projectile = /obj/item/projectile/beam/pulse/heavy
 	fire_sound = 'sound/weapons/marauder.ogg'
+	pacifist_safe = 0
 
 /obj/item/mecha_parts/mecha_equipment/weapon/energy/plasma
 	equip_cooldown = 10
@@ -124,6 +126,7 @@
 	energy_drain = 30
 	projectile = /obj/item/projectile/plasma/adv/mech
 	fire_sound = 'sound/weapons/plasma_cutter.ogg'
+	pacifist_safe = 0
 
 /obj/item/mecha_parts/mecha_equipment/weapon/energy/plasma/can_attach(obj/mecha/working/M)
 	if(..()) //combat mech
@@ -243,6 +246,7 @@
 	projectile = /obj/item/projectile/bullet/incendiary/fnx99
 	projectiles = 24
 	projectile_energy_cost = 15
+	pacifist_safe = 0
 
 /obj/item/mecha_parts/mecha_equipment/weapon/ballistic/silenced
 	name = "\improper S.H.H. \"Quietus\" Carbine"
@@ -253,6 +257,7 @@
 	projectile = /obj/item/projectile/bullet/mime
 	projectiles = 6
 	projectile_energy_cost = 50
+	pacifist_safe = 0
 
 /obj/item/mecha_parts/mecha_equipment/weapon/ballistic/scattershot
 	name = "\improper LBX AC 10 \"Scattershot\""
@@ -264,6 +269,7 @@
 	projectile_energy_cost = 25
 	projectiles_per_shot = 4
 	variance = 25
+	pacifist_safe = 0
 
 /obj/item/mecha_parts/mecha_equipment/weapon/ballistic/lmg
 	name = "\improper Ultra AC 2"
@@ -277,6 +283,7 @@
 	variance = 6
 	randomspread = 1
 	projectile_delay = 2
+	pacifist_safe = 0
 
 /obj/item/mecha_parts/mecha_equipment/weapon/ballistic/missile_rack
 	name = "\improper SRM-8 missile rack"
@@ -287,6 +294,7 @@
 	projectiles = 8
 	projectile_energy_cost = 1000
 	equip_cooldown = 60
+	pacifist_safe = 0
 
 
 /obj/item/mecha_parts/mecha_equipment/weapon/ballistic/launcher
@@ -388,6 +396,7 @@
 	projectiles = 10
 	projectile_energy_cost = 500
 	diags_first = TRUE
+	pacifist_safe = 0 //Does this even do damage? need to test.
 
 /obj/item/mecha_parts/mecha_equipment/weapon/ballistic/launcher/punching_glove/can_attach(obj/mecha/combat/honker/M)
 	if(..())

--- a/code/game/mecha/equipment/weapons/weapons.dm
+++ b/code/game/mecha/equipment/weapons/weapons.dm
@@ -396,7 +396,6 @@
 	projectiles = 10
 	projectile_energy_cost = 500
 	diags_first = TRUE
-	pacifist_safe = 0 //Does this even do damage? need to test.
 
 /obj/item/mecha_parts/mecha_equipment/weapon/ballistic/launcher/punching_glove/can_attach(obj/mecha/combat/honker/M)
 	if(..())

--- a/code/game/mecha/equipment/weapons/weapons.dm
+++ b/code/game/mecha/equipment/weapons/weapons.dm
@@ -75,7 +75,7 @@
 	energy_drain = 30
 	projectile = /obj/item/projectile/beam/laser
 	fire_sound = 'sound/weapons/laser.ogg'
-	pacifist_safe = 0
+	pacifist_safe = false
 
 /obj/item/mecha_parts/mecha_equipment/weapon/energy/laser/heavy
 	equip_cooldown = 15
@@ -103,7 +103,7 @@
 	energy_drain = 500
 	projectile = /obj/item/projectile/energy/tesla/cannon
 	fire_sound = 'sound/magic/lightningbolt.ogg'
-	pacifist_safe = 0
+	pacifist_safe = false
 
 /obj/item/mecha_parts/mecha_equipment/weapon/energy/pulse
 	equip_cooldown = 30
@@ -113,7 +113,7 @@
 	energy_drain = 120
 	projectile = /obj/item/projectile/beam/pulse/heavy
 	fire_sound = 'sound/weapons/marauder.ogg'
-	pacifist_safe = 0
+	pacifist_safe = false
 
 /obj/item/mecha_parts/mecha_equipment/weapon/energy/plasma
 	equip_cooldown = 10
@@ -126,7 +126,7 @@
 	energy_drain = 30
 	projectile = /obj/item/projectile/plasma/adv/mech
 	fire_sound = 'sound/weapons/plasma_cutter.ogg'
-	pacifist_safe = 0
+	pacifist_safe = false
 
 /obj/item/mecha_parts/mecha_equipment/weapon/energy/plasma/can_attach(obj/mecha/working/M)
 	if(..()) //combat mech
@@ -246,7 +246,7 @@
 	projectile = /obj/item/projectile/bullet/incendiary/fnx99
 	projectiles = 24
 	projectile_energy_cost = 15
-	pacifist_safe = 0
+	pacifist_safe = false
 
 /obj/item/mecha_parts/mecha_equipment/weapon/ballistic/silenced
 	name = "\improper S.H.H. \"Quietus\" Carbine"
@@ -257,7 +257,7 @@
 	projectile = /obj/item/projectile/bullet/mime
 	projectiles = 6
 	projectile_energy_cost = 50
-	pacifist_safe = 0
+	pacifist_safe = false
 
 /obj/item/mecha_parts/mecha_equipment/weapon/ballistic/scattershot
 	name = "\improper LBX AC 10 \"Scattershot\""
@@ -269,7 +269,7 @@
 	projectile_energy_cost = 25
 	projectiles_per_shot = 4
 	variance = 25
-	pacifist_safe = 0
+	pacifist_safe = false
 
 /obj/item/mecha_parts/mecha_equipment/weapon/ballistic/lmg
 	name = "\improper Ultra AC 2"
@@ -283,7 +283,7 @@
 	variance = 6
 	randomspread = 1
 	projectile_delay = 2
-	pacifist_safe = 0
+	pacifist_safe = false
 
 /obj/item/mecha_parts/mecha_equipment/weapon/ballistic/missile_rack
 	name = "\improper SRM-8 missile rack"
@@ -294,7 +294,7 @@
 	projectiles = 8
 	projectile_energy_cost = 1000
 	equip_cooldown = 60
-	pacifist_safe = 0
+	pacifist_safe = false
 
 
 /obj/item/mecha_parts/mecha_equipment/weapon/ballistic/launcher

--- a/code/game/mecha/equipment/weapons/weapons.dm
+++ b/code/game/mecha/equipment/weapons/weapons.dm
@@ -75,7 +75,7 @@
 	energy_drain = 30
 	projectile = /obj/item/projectile/beam/laser
 	fire_sound = 'sound/weapons/laser.ogg'
-	pacifist_safe = false
+	pacifist_safe = FALSE
 
 /obj/item/mecha_parts/mecha_equipment/weapon/energy/laser/heavy
 	equip_cooldown = 15
@@ -103,7 +103,7 @@
 	energy_drain = 500
 	projectile = /obj/item/projectile/energy/tesla/cannon
 	fire_sound = 'sound/magic/lightningbolt.ogg'
-	pacifist_safe = false
+	pacifist_safe = FALSE
 
 /obj/item/mecha_parts/mecha_equipment/weapon/energy/pulse
 	equip_cooldown = 30
@@ -113,7 +113,7 @@
 	energy_drain = 120
 	projectile = /obj/item/projectile/beam/pulse/heavy
 	fire_sound = 'sound/weapons/marauder.ogg'
-	pacifist_safe = false
+	pacifist_safe = FALSE
 
 /obj/item/mecha_parts/mecha_equipment/weapon/energy/plasma
 	equip_cooldown = 10
@@ -126,7 +126,7 @@
 	energy_drain = 30
 	projectile = /obj/item/projectile/plasma/adv/mech
 	fire_sound = 'sound/weapons/plasma_cutter.ogg'
-	pacifist_safe = false
+	pacifist_safe = FALSE
 
 /obj/item/mecha_parts/mecha_equipment/weapon/energy/plasma/can_attach(obj/mecha/working/M)
 	if(..()) //combat mech
@@ -246,7 +246,7 @@
 	projectile = /obj/item/projectile/bullet/incendiary/fnx99
 	projectiles = 24
 	projectile_energy_cost = 15
-	pacifist_safe = false
+	pacifist_safe = FALSE
 
 /obj/item/mecha_parts/mecha_equipment/weapon/ballistic/silenced
 	name = "\improper S.H.H. \"Quietus\" Carbine"
@@ -257,7 +257,7 @@
 	projectile = /obj/item/projectile/bullet/mime
 	projectiles = 6
 	projectile_energy_cost = 50
-	pacifist_safe = false
+	pacifist_safe = FALSE
 
 /obj/item/mecha_parts/mecha_equipment/weapon/ballistic/scattershot
 	name = "\improper LBX AC 10 \"Scattershot\""
@@ -269,7 +269,7 @@
 	projectile_energy_cost = 25
 	projectiles_per_shot = 4
 	variance = 25
-	pacifist_safe = false
+	pacifist_safe = FALSE
 
 /obj/item/mecha_parts/mecha_equipment/weapon/ballistic/lmg
 	name = "\improper Ultra AC 2"
@@ -283,7 +283,7 @@
 	variance = 6
 	randomspread = 1
 	projectile_delay = 2
-	pacifist_safe = false
+	pacifist_safe = FALSE
 
 /obj/item/mecha_parts/mecha_equipment/weapon/ballistic/missile_rack
 	name = "\improper SRM-8 missile rack"
@@ -294,7 +294,7 @@
 	projectiles = 8
 	projectile_energy_cost = 1000
 	equip_cooldown = 60
-	pacifist_safe = false
+	pacifist_safe = FALSE
 
 
 /obj/item/mecha_parts/mecha_equipment/weapon/ballistic/launcher

--- a/code/game/mecha/mecha.dm
+++ b/code/game/mecha/mecha.dm
@@ -454,9 +454,10 @@
 		if(isliving(target) && !selected.pacifist_safe && L.has_trait(TRAIT_PACIFISM))
 			to_chat(user, "<span class='warning'>You don't want to harm other living beings!</span>")
 			return
-		if(istype(C) && !C.opened && !selected.pacifist_safe && L.has_trait(TRAIT_PACIFISM))
-			to_chat(user, "<span class='warning'> It's closed. Better make sure no one is in it first.</span>")
-			return
+		if(istype(C) && L.has_trait(TRAIT_PACIFISM) && !selected.pacifist_safe)
+			for(var/mob/living/M in C.contents)
+				to_chat(user, "<span class='warning'>There's someone in there! I don't want to hurt them.</span>")
+				return
 		if(selected.action(target,params))
 			selected.start_cooldown()
 	else

--- a/code/game/mecha/mecha.dm
+++ b/code/game/mecha/mecha.dm
@@ -73,7 +73,6 @@
 	var/obj/item/mecha_parts/mecha_equipment/selected
 	var/max_equip = 3
 	var/datum/events/events
-	var/list = list("tase_cannon"=0)
 
 	var/stepsound = 'sound/mecha/mechstep.ogg'
 	var/turnsound = 'sound/mecha/mechturn.ogg'
@@ -443,15 +442,17 @@
 			return
 
 	var/mob/living/L = user
-	if(L.has_trait(TRAIT_PACIFISM) && !selected.pacifist_safe)
-		to_chat(user, "<span class='warning'>You don't want to harm other living beings!</span>")
-		return
-
 	if(!Adjacent(target))
 		if(selected && selected.is_ranged())
+			if(L.has_trait(TRAIT_PACIFISM) && !selected.pacifist_safe)
+				to_chat(user, "<span class='warning'>You don't want to harm other living beings!</span>")
+				return
 			if(selected.action(target,params))
 				selected.start_cooldown()
 	else if(selected && selected.is_melee())
+		if(isliving(target) && !selected.pacifist_safe && L.has_trait(TRAIT_PACIFISM))
+			to_chat(user, "<span class='warning'>You don't want to harm other living beings!</span>")
+			return
 		if(selected.action(target,params))
 			selected.start_cooldown()
 	else

--- a/code/game/mecha/mecha.dm
+++ b/code/game/mecha/mecha.dm
@@ -442,6 +442,7 @@
 			return
 
 	var/mob/living/L = user
+	var/obj/structure/closet/C = target
 	if(!Adjacent(target))
 		if(selected && selected.is_ranged())
 			if(L.has_trait(TRAIT_PACIFISM) && !selected.pacifist_safe)
@@ -452,6 +453,9 @@
 	else if(selected && selected.is_melee())
 		if(isliving(target) && !selected.pacifist_safe && L.has_trait(TRAIT_PACIFISM))
 			to_chat(user, "<span class='warning'>You don't want to harm other living beings!</span>")
+			return
+		if(istype(C) && !C.opened && !selected.pacifist_safe && L.has_trait(TRAIT_PACIFISM))
+			to_chat(user, "<span class='warning'> It's closed. Better make sure no one is in it first.</span>")
 			return
 		if(selected.action(target,params))
 			selected.start_cooldown()

--- a/code/game/mecha/mecha.dm
+++ b/code/game/mecha/mecha.dm
@@ -454,7 +454,7 @@
 		if(isliving(target) && !selected.pacifist_safe && L.has_trait(TRAIT_PACIFISM))
 			to_chat(user, "<span class='warning'>You don't want to harm other living beings!</span>")
 			return
-		if(istype(C) && L.has_trait(TRAIT_PACIFISM) && !selected.pacifist_safe)
+		if(istype(C) && L.has_trait(TRAIT_PACIFISM) && !selected.pacifist_safe && !istype(selected,/obj/item/mecha_parts/mecha_equipment/hydraulic_clamp/))
 			for(var/mob/living/M in C)
 				to_chat(user, "<span class='warning'>There's someone in there! I don't want to hurt them.</span>")
 				return

--- a/code/game/mecha/mecha.dm
+++ b/code/game/mecha/mecha.dm
@@ -455,7 +455,7 @@
 			to_chat(user, "<span class='warning'>You don't want to harm other living beings!</span>")
 			return
 		if(istype(C) && L.has_trait(TRAIT_PACIFISM) && !selected.pacifist_safe)
-			for(var/mob/living/M in C.contents)
+			for(var/mob/living/M in C)
 				to_chat(user, "<span class='warning'>There's someone in there! I don't want to hurt them.</span>")
 				return
 		if(selected.action(target,params))

--- a/code/game/mecha/mecha.dm
+++ b/code/game/mecha/mecha.dm
@@ -73,6 +73,7 @@
 	var/obj/item/mecha_parts/mecha_equipment/selected
 	var/max_equip = 3
 	var/datum/events/events
+	var/list = list("tase_cannon"=0)
 
 	var/stepsound = 'sound/mecha/mechstep.ogg'
 	var/turnsound = 'sound/mecha/mechturn.ogg'
@@ -440,6 +441,12 @@
 		target = safepick(view(3,target))
 		if(!target)
 			return
+
+	var/mob/living/L = user
+	if(L.has_trait(TRAIT_PACIFISM) && !selected.pacifist_safe)
+		to_chat(user, "<span class='warning'>You don't want to harm other living beings!</span>")
+		return
+
 	if(!Adjacent(target))
 		if(selected && selected.is_ranged())
 			if(selected.action(target,params))


### PR DESCRIPTION
_Pacifists have learned that the missiles, bullets and lasers that mechs fire cause injury._

adds new variable to mech equipment  called pacifist_safe. A pacifist can only use this equipment when this is set to true. 

:cl: 
fix: Fixed pacifists from being able to fire mech weapons
/:cl:

Fixes issue #36276 