### PR TITLE
Custom dockers must be greater than 10 tiles from map edge

### DIFF
--- a/code/modules/shuttle/navigation_computer.dm
+++ b/code/modules/shuttle/navigation_computer.dm
@@ -199,7 +199,7 @@
 
 /obj/machinery/computer/camera_advanced/shuttle_docker/proc/checkLandingTurf(turf/T, list/overlappers)
 	// Too close to the map edge is never allowed
-	if(!T || T.x == 1 || T.y == 1 || T.x == world.maxx || T.y == world.maxy)
+	if(!T || T.x <= 10 || T.y <= 10 || T.x >= world.maxx - 10 || T.y >= world.maxy - 10)
 		return SHUTTLE_DOCKER_BLOCKED
 	// If it's one of our shuttle areas assume it's ok to be there
 	if(shuttle_port.shuttle_areas[T.loc])


### PR DESCRIPTION
:cl: ninjanomnom
fix: Custom shuttles being too close to the map edge was causing problems, you must now be at least 10 tiles away.
/:cl:
