### PR TITLE
Machinery can now also be anchored on any /turf/open/indestructible, instead of only /turf/open/plating

### DIFF
--- a/code/game/machinery/_machinery.dm
+++ b/code/game/machinery/_machinery.dm
@@ -359,7 +359,7 @@ Class Procs:
 	return 0
 
 /obj/proc/can_be_unfasten_wrench(mob/user, silent) //if we can unwrench this object; returns SUCCESSFUL_UNFASTEN and FAILED_UNFASTEN, which are both TRUE, or CANT_UNFASTEN, which isn't.
-	if(!isfloorturf(loc) && !anchored)
+	if(!(isfloorturf(loc) || istype(loc, /turf/open/indestructible)) && !anchored)
 		to_chat(user, "<span class='warning'>[src] needs to be on the floor to be secured!</span>")
 		return FAILED_UNFASTEN
 	return SUCCESSFUL_UNFASTEN


### PR DESCRIPTION
Previously they couldn't be anchored on /turf/open/indestructible, e.g. things like the area the crew teleport into in the City of Cogs.

:cl: 
tweak: The Clockwork Justicar has decided to be merciful, and allow nonbelievers to anchor their petty machines in his city. It's only fair for them to have a fighting chance, after all.
/:cl: