### PR TITLE
Smoke Machine re-added to the map, no longer affects turfs

### DIFF
--- a/_maps/map_files/BoxStation/BoxStation.dmm
+++ b/_maps/map_files/BoxStation/BoxStation.dmm
@@ -22989,6 +22989,7 @@
 /obj/structure/cable{
 	icon_state = "0-2"
 	},
+/obj/machinery/smoke_machine,
 /turf/open/floor/plasteel/white,
 /area/medical/chemistry)
 "bha" = (

--- a/_maps/map_files/Deltastation/DeltaStation2.dmm
+++ b/_maps/map_files/Deltastation/DeltaStation2.dmm
@@ -76240,6 +76240,7 @@
 	pixel_y = 7;
 	req_access_txt = "33"
 	},
+/obj/machinery/smoke_machine,
 /turf/open/floor/plasteel/whiteyellow/corner{
 	dir = 8
 	},

--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -54266,6 +54266,7 @@
 /turf/open/floor/plasteel/white,
 /area/medical/chemistry)
 "cjV" = (
+/obj/machinery/smoke_machine,
 /turf/open/floor/plasteel/whiteyellow/side{
 	dir = 4
 	},

--- a/_maps/map_files/PubbyStation/PubbyStation.dmm
+++ b/_maps/map_files/PubbyStation/PubbyStation.dmm
@@ -50047,9 +50047,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/chapel/office)
-"cBP" = (
-/turf/open/floor/plasteel/white,
-/area/medical/chemistry)
 "cBQ" = (
 /obj/machinery/power/rad_collector,
 /turf/open/floor/plating,
@@ -50601,6 +50598,10 @@
 	dir = 4
 	},
 /area/science/circuit)
+"osE" = (
+/obj/machinery/smoke_machine,
+/turf/open/floor/plasteel/white,
+/area/medical/chemistry)
 "oEG" = (
 /obj/machinery/bookbinder,
 /turf/open/floor/plasteel/purple/side{
@@ -82182,7 +82183,7 @@ brl
 bsL
 bul
 bwU
-cBP
+osE
 bsK
 bAg
 bpY

--- a/code/game/objects/effects/effect_system/effects_smoke.dm
+++ b/code/game/objects/effects/effect_system/effects_smoke.dm
@@ -218,6 +218,7 @@
 
 /obj/effect/particle_effect/smoke/chem
 	lifetime = 10
+	var/residue = TRUE // whether the smoke will affect Turf
 
 
 /obj/effect/particle_effect/smoke/chem/process()
@@ -230,8 +231,8 @@
 			if(T.intact && AM.level == 1) //hidden under the floor
 				continue
 			reagents.reaction(AM, TOUCH, fraction)
-
-		reagents.reaction(T, TOUCH, fraction)
+		if(residue)
+			reagents.reaction(T, TOUCH, fraction)
 		return 1
 
 /obj/effect/particle_effect/smoke/chem/smoke_mob(mob/living/carbon/M)

--- a/code/modules/reagents/chemistry/machinery/smoke_machine.dm
+++ b/code/modules/reagents/chemistry/machinery/smoke_machine.dm
@@ -28,6 +28,7 @@
 /obj/effect/particle_effect/smoke/chem/smoke_machine
 	opaque = FALSE
 	alpha = 100
+	residue = FALSE
 
 /obj/machinery/smoke_machine/Initialize()
 	. = ..()


### PR DESCRIPTION
:cl: Robustin
add: The smoke machine is in chemistry again, again
tweak: Artificial smoke (smoke machine, ecig) will no longer affect Tur
/:cl:

MFW controversial removal gets speedmerged because of Revenant salt

The smoke machine is used in <10% of rounds, with macros its now possible to make smoke grenades that are MUCH more potent in <10 seconds. There was absolutely 0 coherence behind the excuse for removing it but when Kevinz starts campaigning for a removal - logic isn't really part of the picture. 

We already reached the consensus that putting the board in tech storage was a death sentence, locking it behind a tech node thinking it will ever see the light of day is even further delusional.

This addresses apparently the only controversial aspect of the machine, its ability to affect turf via slipping, blessing, and yes, salting. It also has the side bonus of removing these abuses from the vape pen.

Makes me sad we have to strip more utility out of the machine because of a small number of whiners but when the negatively voted removal PR gets speedmerged what choice do I get? 
