### PR TITLE
Lets belts hold additional job-specific items

### DIFF
--- a/code/game/objects/items/storage/belt.dm
+++ b/code/game/objects/items/storage/belt.dm
@@ -46,7 +46,8 @@
 		/obj/item/device/geiger_counter,
 		/obj/item/extinguisher/mini,
 		/obj/item/device/radio,
-		/obj/item/clothing/gloves
+		/obj/item/clothing/gloves,
+		/obj/item/holosign_creator
 		)
 	content_overlays = TRUE
 

--- a/code/game/objects/items/storage/belt.dm
+++ b/code/game/objects/items/storage/belt.dm
@@ -47,7 +47,8 @@
 		/obj/item/extinguisher/mini,
 		/obj/item/device/radio,
 		/obj/item/clothing/gloves,
-		/obj/item/holosign_creator
+		/obj/item/holosign_creator,
+		/obj/item/device/assembly/signaler
 		)
 	content_overlays = TRUE
 

--- a/code/game/objects/items/storage/belt.dm
+++ b/code/game/objects/items/storage/belt.dm
@@ -154,7 +154,11 @@
 		/obj/item/storage/bag/bio,
 		/obj/item/reagent_containers/blood,
 		/obj/item/tank/internals/emergency_oxygen,
-		/obj/item/pinpointer/crew
+		/obj/item/pinpointer/crew, 
+		/obj/item/gun/syringe/syndicate,
+		/obj/item/implantcase,
+		/obj/item/implant,
+		/obj/item/implanter
 		)
 
 
@@ -176,13 +180,13 @@
 		/obj/item/ammo_casing/shotgun,
 		/obj/item/ammo_box,
 		/obj/item/reagent_containers/food/snacks/donut,
-		/obj/item/reagent_containers/food/snacks/donut/jelly,
 		/obj/item/kitchen/knife/combat,
 		/obj/item/device/flashlight/seclite,
 		/obj/item/melee/classic_baton/telescopic,
 		/obj/item/device/radio,
-		/obj/item/clothing/gloves/,
-		/obj/item/restraints/legcuffs/bola
+		/obj/item/clothing/gloves,
+		/obj/item/restraints/legcuffs/bola,
+		/obj/item/holosign_creator/security
 		)
 	content_overlays = TRUE
 
@@ -210,6 +214,7 @@
 		/obj/item/weldingtool,
 		/obj/item/wirecutters,
 		/obj/item/wrench,
+		/obj/item/device/multitool,
 		/obj/item/device/flashlight,
 		/obj/item/stack/cable_coil,
 		/obj/item/device/analyzer,
@@ -403,7 +408,9 @@
 		/obj/item/soap,
 		/obj/item/holosign_creator,
 		/obj/item/key/janitor,
-		/obj/item/clothing/gloves
+		/obj/item/clothing/gloves,
+		/obj/item/melee/flyswatter,
+		/obj/item/device/assembly/mousetrap
 		)
 
 /obj/item/storage/belt/bandolier


### PR DESCRIPTION
:cl: Denton
tweak: Various belts can now hold additional job-specific items.
/:cl:

Janibelt: Flyswatter and mousetraps
Sec belt: Security holosign projector
Toolbelt: Holosign projectors, remote signaling devices
Medical belt: That WEIGHT_CLASS_SMALL traitor dart pistol, implants, implant cases and implanters
Explorer's webbing: Multitool (it can hold all other generic tools already)

/obj/item/reagent_containers/food/snacks/donut/jelly was unneccessary since snacks/donut was already included.