### PR TITLE
Revert "Unmaps the smoke machine (#36260)"

### DIFF
--- a/_maps/map_files/BoxStation/BoxStation.dmm
+++ b/_maps/map_files/BoxStation/BoxStation.dmm
@@ -22989,6 +22989,7 @@
 /obj/structure/cable{
 	icon_state = "0-2"
 	},
+/obj/machinery/smoke_machine,
 /turf/open/floor/plasteel/white,
 /area/medical/chemistry)
 "bha" = (

--- a/_maps/map_files/Deltastation/DeltaStation2.dmm
+++ b/_maps/map_files/Deltastation/DeltaStation2.dmm
@@ -76240,6 +76240,7 @@
 	pixel_y = 7;
 	req_access_txt = "33"
 	},
+/obj/machinery/smoke_machine,
 /turf/open/floor/plasteel/whiteyellow/corner{
 	dir = 8
 	},

--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -54266,6 +54266,7 @@
 /turf/open/floor/plasteel/white,
 /area/medical/chemistry)
 "cjV" = (
+/obj/machinery/smoke_machine,
 /turf/open/floor/plasteel/whiteyellow/side{
 	dir = 4
 	},

--- a/_maps/map_files/PubbyStation/PubbyStation.dmm
+++ b/_maps/map_files/PubbyStation/PubbyStation.dmm
@@ -50048,6 +50048,7 @@
 /turf/open/floor/plasteel/dark,
 /area/chapel/office)
 "cBP" = (
+/obj/machinery/smoke_machine,
 /turf/open/floor/plasteel/white,
 /area/medical/chemistry)
 "cBQ" = (


### PR DESCRIPTION
1: It was a highly controversial change that got speedmerged
2: PRs that revert it with minor changes such as #36322 have gotten unanimous support.
3: As Robustin said in his PR:

>The smoke machine is used in <10% of rounds, with macros its now possible to make smoke grenades that are MUCH more potent in <10 seconds. There was absolutely 0 coherence behind the excuse for removing it but when Kevinz starts campaigning for a removal - logic isn't really part of the picture.

>We already reached the consensus that putting the board in tech storage was a death sentence, locking it behind a tech node thinking it will ever see the light of day is even further delusional.

>Makes me sad we have to strip more utility out of the machine because of a small number of whiners but when the negatively voted removal PR gets speedmerged what choice do I get?

This flat out reverts it. Puts the smoke machine back. No changes, no nuthin. If plasmaman transformation toxin smoke is a big deal then nerf SCP-294 because that's where everyone gets it anyway.

:cl: 
revert: Nanotrasen has backpedalled on their hasty policy change, and is once-again shipping smoke machines as part of the default chemistry sub-department.
/:cl: