### PR TITLE
Fixes stopsounds

### DIFF
--- a/code/__DEFINES/misc.dm
+++ b/code/__DEFINES/misc.dm
@@ -428,6 +428,8 @@ GLOBAL_LIST_INIT(ghost_others_options, list(GHOST_OTHERS_SIMPLE, GHOST_OTHERS_DE
 #define SUMMON_GUNS "guns"
 #define SUMMON_MAGIC "magic"
 
+#define STOP_SOUNDS_URL "http://"
+
 //Run the world with this parameter to enable a single run though of the game setup and tear down process with unit tests in between
 #define TEST_RUN_PARAMETER "test-run"
 //Force the log directory to be something specific in the data/logs folder

--- a/code/modules/admin/verbs/playsound.dm
+++ b/code/modules/admin/verbs/playsound.dm
@@ -120,10 +120,10 @@
 		else //pressed ok with blank
 			log_admin("[key_name(src)] stopped web sound")
 			message_admins("[key_name(src)] stopped web sound")
-			web_sound_url = " "
+			web_sound_url = STOP_SOUNDS_URL
 
 		if(web_sound_url)
-			if(web_sound_url != " " && !findtext(web_sound_url, GLOB.is_http_protocol))
+			if(!findtext(web_sound_url, GLOB.is_http_protocol))
 				to_chat(src, "<span class='boldwarning'>BLOCKED: Content URL not using http(s) protocol</span>")
 				to_chat(src, "<span class='warning'>The media provider returned a content URL that isn't using the HTTP or HTTPS protocol</span>")
 			for(var/m in GLOB.player_list)
@@ -159,5 +159,5 @@
 			SEND_SOUND(M, sound(null))
 			var/client/C = M.client
 			if(C && C.chatOutput && !C.chatOutput.broken && C.chatOutput.loaded)
-				C.chatOutput.sendMusic(" ")
+				C.chatOutput.sendMusic(STOP_SOUNDS_URL)
 	SSblackbox.record_feedback("tally", "admin_verb", 1, "Stop All Playing Sounds") //If you are copy-pasting this, ensure the 2nd parameter is unique to the new proc!

--- a/code/modules/client/preferences_toggles.dm
+++ b/code/modules/client/preferences_toggles.dm
@@ -235,7 +235,7 @@ TOGGLE_CHECKBOX(/datum/verbs/menu/Settings/Sound, toggleprayersounds)()
 	SEND_SOUND(usr, sound(null))
 	var/client/C = usr.client
 	if(C && C.chatOutput && !C.chatOutput.broken && C.chatOutput.loaded)
-		C.chatOutput.sendMusic(" ")
+		C.chatOutput.sendMusic(STOP_SOUNDS_URL)
 	SSblackbox.record_feedback("nested tally", "preferences_verb", 1, list("Stop Self Sounds")) //If you are copy-pasting this, ensure the 2nd parameter is unique to the new proc!
 
 


### PR DESCRIPTION
web sounds used to send `" "` for playback to stop sounds, it got caught in the sanity check added in #36080

This is a bit saner, but not as good as having a separate goonchat signal for stopping playback. I, however, have absolutely zero interest in touching anything goonchat again as it's undebuggable and i'm not interested in setting up a VM environment for IE8 testing.

:cl: Naksu
fix: internet sounds can be stopped again
/:cl: