### PR TITLE
Makes transit tubes take half as long to secure/unsecure

### DIFF
--- a/code/game/objects/structures/transit_tubes/transit_tube.dm
+++ b/code/game/objects/structures/transit_tubes/transit_tube.dm
@@ -12,7 +12,7 @@
 	var/list/tube_dirs //list of directions this tube section can connect to.
 	var/exit_delay = 1
 	var/enter_delay = 0
-	var/time_to_unwrench = 20 //deciseconds
+	var/const/time_to_unwrench = 2 SECONDS
 
 /obj/structure/transit_tube/CanPass(atom/movable/mover, turf/target)
 	if(istype(mover) && (mover.pass_flags & PASSGLASS))

--- a/code/game/objects/structures/transit_tubes/transit_tube.dm
+++ b/code/game/objects/structures/transit_tubes/transit_tube.dm
@@ -12,6 +12,7 @@
 	var/list/tube_dirs //list of directions this tube section can connect to.
 	var/exit_delay = 1
 	var/enter_delay = 0
+	var/time_to_unwrench = 20 //deciseconds
 
 /obj/structure/transit_tube/CanPass(atom/movable/mover, turf/target)
 	if(istype(mover) && (mover.pass_flags & PASSGLASS))
@@ -42,7 +43,7 @@
 				to_chat(user, "<span class='warning'>Remove the pod first!</span>")
 				return
 			user.visible_message("[user] starts to deattach \the [src].", "<span class='notice'>You start to deattach the [name]...</span>")
-			if(W.use_tool(src, user, 40, volume=50))
+			if(W.use_tool(src, user, time_to_unwrench, volume=50))
 				to_chat(user, "<span class='notice'>You deattach the [name].</span>")
 				var/obj/structure/c_transit_tube/R = new tube_construction(loc)
 				R.setDir(dir)

--- a/code/game/objects/structures/transit_tubes/transit_tube_construction.dm
+++ b/code/game/objects/structures/transit_tubes/transit_tube_construction.dm
@@ -9,7 +9,7 @@
 	density = FALSE
 	layer = LOW_ITEM_LAYER //same as the built tube
 	anchored = FALSE
-	var/time_to_unwrench = 20 //deciseconds
+	var/const/time_to_unwrench = 2 SECONDS
 	var/flipped = 0
 	var/build_type = /obj/structure/transit_tube
 	var/flipped_build_type

--- a/code/game/objects/structures/transit_tubes/transit_tube_construction.dm
+++ b/code/game/objects/structures/transit_tubes/transit_tube_construction.dm
@@ -9,6 +9,7 @@
 	density = FALSE
 	layer = LOW_ITEM_LAYER //same as the built tube
 	anchored = FALSE
+	var/time_to_unwrench = 20 //deciseconds
 	var/flipped = 0
 	var/build_type = /obj/structure/transit_tube
 	var/flipped_build_type
@@ -33,7 +34,7 @@
 /obj/structure/c_transit_tube/wrench_act(mob/living/user, obj/item/I)
 	to_chat(user, "<span class='notice'>You start attaching the [name]...</span>")
 	add_fingerprint(user)
-	if(I.use_tool(src, user, 40, volume=50))
+	if(I.use_tool(src, user, time_to_unwrench, volume=50))
 		to_chat(user, "<span class='notice'>You attach the [name].</span>")
 		var/obj/structure/transit_tube/R = new build_type(loc, dir)
 		transfer_fingerprints_to(R)


### PR DESCRIPTION
:cl: cacogen
tweak: Transit tubes take half as long to secure/unsecure
/:cl:

[why]: # (Please add a short description [two lines down] of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.)
Takes ages to build anything meaningful when each pipe takes four seconds to fasten to the floor.