### PR TITLE
Makes touching (8)balls take less time

### DIFF
--- a/code/game/objects/items/eightball.dm
+++ b/code/game/objects/items/eightball.dm
@@ -12,7 +12,7 @@
 	var/on_cooldown = FALSE
 
 	var/shake_time = 50
-	var/cooldown_time = 200
+	var/cooldown_time = 100
 
 	var/static/list/possible_answers = list(
 		"It is certain",

--- a/code/game/objects/items/eightball.dm
+++ b/code/game/objects/items/eightball.dm
@@ -11,8 +11,8 @@
 	var/shaking = FALSE
 	var/on_cooldown = FALSE
 
-	var/shake_time = 150
-	var/cooldown_time = 1800
+	var/shake_time = 50
+	var/cooldown_time = 200
 
 	var/static/list/possible_answers = list(
 		"It is certain",
@@ -95,6 +95,8 @@
 // except it actually ASKS THE DEAD (wooooo)
 
 /obj/item/toy/eightball/haunted
+	shake_time = 150
+	cooldown_time = 1800
 	flags_1 = HEAR_1
 	var/last_message
 	var/selected_message


### PR DESCRIPTION
[Changelogs]: 

:cl: Dax Dupont
tweak: 8balls take less time to shake.
/:cl:

[why]: Nobody uses 8balls because it takes for fucking ever to shake and it has a giant cooldown because ???.
I know this will probably give away that the haunted version is haunted but that's a 1% chance to spawn anyways, it's not that big of an issue. Especially since you can just play the chair game with a camera obscura a la @Robustin.
5 seconds with a 10 second cooldown seems fine. Haunted 8balls remain unaffected.