### PR TITLE
Fixes client version config not working

### DIFF
--- a/code/controllers/configuration/entries/general.dm
+++ b/code/controllers/configuration/entries/general.dm
@@ -320,7 +320,6 @@
 /datum/config_entry/number/client_warn_version
 	config_entry_value = null
 	min_val = 500
-	max_val = DM_VERSION - 1
 
 /datum/config_entry/string/client_warn_message
 	config_entry_value = "Your version of byond may have issues or be blocked from accessing this server in the future."
@@ -330,7 +329,6 @@
 /datum/config_entry/number/client_error_version
 	config_entry_value = null
 	min_val = 500
-	max_val = DM_VERSION - 1
 
 /datum/config_entry/string/client_error_message
 	config_entry_value = "Your version of byond is too old, may have issues, and is blocked from accessing this server."


### PR DESCRIPTION
1, the number is non-inclusive, so if you want to show a message to 511 and lower, you set it to 512 meaning this should have been `DM_VERSION - 0`, and 2, if i want to limit it to a version higher then the server's version that is something that should be allowed.

@Cyberboss 
