### PR TITLE
Removes the throttling sleep from Stat() because it wasn't doing anything.

### DIFF
--- a/code/modules/client/client_procs.dm
+++ b/code/modules/client/client_procs.dm
@@ -656,17 +656,6 @@ GLOBAL_LIST_EMPTY(external_rsc_urls)
 		return inactivity
 	return FALSE
 
-// Byond seemingly calls stat, each tick.
-// Calling things each tick can get expensive real quick.
-// So we slow this down a little.
-// See: http://www.byond.com/docs/ref/info.html#/client/proc/Stat
-/client/Stat()
-	. = ..()
-	if (holder)
-		stoplag(1)
-	else
-		stoplag(5)
-
 //send resources to the client. It's here in its own proc so we can move it around easiliy if need be
 /client/proc/send_resources()
 #if (PRELOAD_RSC == 0)


### PR DESCRIPTION
Byond calls Stat() every 8 ticks with or without this code, this was literally doing nothing. This was pointless and none of the Stat() code is expensive enough to warrant throttling it anyways.


If we had slept for more than 8 ticks sure, in that case byond skips a call and calls it every 16 ticks, but all we were doing was clogging up the sleep queue with useless entries.

I had discovered this fact in host chat some time ago and forgot to pr it here.

This code was originally put in here in #12165 when @Chnkr seemed to think byond called Stat() every byond tick. I don't know what made him think that, I tested on the byond version travis was set to in his commit and the behavior is the same, 8 ticks between calls to Stat(). I also tested it on byond 498, and the behavior is the same.