### PR TITLE
Adds links to a standalone prepackaged database server to the readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,6 +118,8 @@ To enable an away mission open `config/awaymissionconfig.txt` and uncomment one 
 
 The SQL backend requires a Mariadb server running 10.2 or later. Mysql is not supported but Mariadb is a drop in replacement for mysql. SQL is required for the library, stats tracking, admin notes, and job-only bans, among other features, mostly related to server administration. Your server details go in /config/dbconfig.txt, and the SQL schema is in /SQL/tgstation_schema.sql and /SQL/tgstation_schema_prefix.sql depending on if you want table prefixes.  More detailed setup instructions are located here: https://www.tgstation13.org/wiki/Downloading_the_source_code#Setting_up_the_database
 
+If you are hosting a testing server on windows you can use a standalone version of MariaDB pre load with a blank (but initialized) tgdb database. Find them here: https://tgstation13.download/database/ Just unzip and run for a working (but insecure) database server. Includes a zipped copy of the data folder for easy resetting back to square one.
+
 ## WEB/CDN RESOURCE DELIVERY 
 
 Web delivery of game resources makes it quicker for players to join and reduces some of the stress on the game server.


### PR DESCRIPTION
Download https://tgstation13.download/database/mariadb-v10.2.10-x86-trimmed-preprimed%28v4.1%29.zip, Extract, and run a batch script for an instant mariadb server pre-loaded with /tg/'s schema as well as a user account that uses the default database credentials. 

40mb extracts out to 150mb. 

The schema is also kept as a seperate .zip (https://tgstation13.download/database/tgstation13%20database%20primer%20v4.1.zip (<1mb)) with the idea that you can "prime" any mariadb version by downloading the .zip from their website (its much larger because it includes debugging symbols) and just extracting the primer zip on top, as well as update any existing standalone folder by just re-priming it with a new database primer.

