### PR TITLE
Sepia floor tiles fly slowly, yet further

### DIFF
--- a/code/modules/research/xenobiology/xenobiology.dm
+++ b/code/modules/research/xenobiology/xenobiology.dm
@@ -870,8 +870,9 @@
 	force = 6
 	materials = list(MAT_METAL=500)
 	throwforce = 10
-	throw_speed = 3
-	throw_range = 7
+	throw_speed = 0.1
+	throw_range = 28
+	glide_size = 2
 	flags_1 = CONDUCT_1
 	max_amount = 60
 	turf_type = /turf/open/floor/sepia


### PR DESCRIPTION
:cl: Denton
tweak: Sepia floor tiles fly really slowly, yet far when thrown. Don't hit yourself!
/:cl:

"Time seems to flow very slowly around these tiles."

Sepia floor tiles now fly so slowly that you can easily run past one after throwing it and even hit yourself. They should also fly four times as far.