### PR TITLE
Changes stormtrooper ammo to 10g slugs

### DIFF
--- a/code/modules/mob/living/simple_animal/hostile/syndicate.dm
+++ b/code/modules/mob/living/simple_animal/hostile/syndicate.dm
@@ -137,8 +137,8 @@
 	name = "Syndicate Stormtrooper"
 	maxHealth = 200
 	health = 200
+	casingtype = /obj/item/ammo_casing/shotgun/tengauge
 	projectilesound = 'sound/weapons/gunshot.ogg'
-	casingtype = /obj/item/ammo_casing/shotgun/pulseslug
 	loot = list(/obj/effect/gibspawner/human)
 
 ///////////////Misc////////////

--- a/code/modules/mob/living/simple_animal/hostile/syndicate.dm
+++ b/code/modules/mob/living/simple_animal/hostile/syndicate.dm
@@ -138,7 +138,7 @@
 	maxHealth = 200
 	health = 200
 	projectilesound = 'sound/weapons/gunshot.ogg'
-	casingtype = /obj/item/ammo_casing/shotgun/buckshot
+	casingtype = /obj/item/ammo_casing/shotgun/pulseslug
 	loot = list(/obj/effect/gibspawner/human)
 
 ///////////////Misc////////////

--- a/code/modules/projectiles/ammunition/ballistic/shotgun.dm
+++ b/code/modules/projectiles/ammunition/ballistic/shotgun.dm
@@ -9,7 +9,7 @@
 	materials = list(MAT_METAL=4000)
 	
 /obj/item/ammo_casing/shotgun/tengauge
-	name = "shotgun slug"
+	name = "10g shotgun slug"
 	desc = "A 10 gauge lead slug."
 	projectile_type = /obj/item/projectile/bullet/shotgun_slug/tengauge
 

--- a/code/modules/projectiles/ammunition/ballistic/shotgun.dm
+++ b/code/modules/projectiles/ammunition/ballistic/shotgun.dm
@@ -7,6 +7,11 @@
 	caliber = "shotgun"
 	projectile_type = /obj/item/projectile/bullet/shotgun_slug
 	materials = list(MAT_METAL=4000)
+	
+/obj/item/ammo_casing/shotgun/tengauge
+	name = "shotgun slug"
+	desc = "A 10 gauge lead slug."
+	projectile_type = /obj/item/projectile/bullet/shotgun_slug/tengauge
 
 /obj/item/ammo_casing/shotgun/beanbag
 	name = "beanbag slug"

--- a/code/modules/projectiles/projectile/bullets/shotgun.dm
+++ b/code/modules/projectiles/projectile/bullets/shotgun.dm
@@ -1,6 +1,10 @@
 /obj/item/projectile/bullet/shotgun_slug
 	name = "12g shotgun slug"
 	damage = 60
+	
+/obj/item/projectile/bullet/shotgun_slug/tengauge
+	name = "10g shotgun slug"
+	damage = 72.5
 
 /obj/item/projectile/bullet/shotgun_beanbag
 	name = "beanbag slug"


### PR DESCRIPTION
:cl: Denton
tweak: Syndicate stormtroopers now rapid fire 10g slugs instead of buckshot. This deals the same damage, but makes getting hit less laggy.
/:cl:

Right now, syndie stormtroopers rapid fire buckshot shells with zero spread. Getting hit with a salvo of 18 pellets will spam your screen and lag your client to hell (up to 36 messages at once).

I changed them to use 10g slugs instead - this will still kill you dead in record time, but in a less spammy/laggy fashion.
Unless armor calculations change it, the damage should be the same (six 12.5 brute buckshot pellets vs. a single 72.5 brute slug).

**tl;dr if you get hit by a full salvo while wearing armor, your client will only have to process 6 instead of 36 messages. Damage is the same as before.**