### PR TITLE
Tells ash walkers to stay on their own turf.

### DIFF
--- a/code/game/objects/structures/ghost_role_spawners.dm
+++ b/code/game/objects/structures/ghost_role_spawners.dm
@@ -44,7 +44,7 @@
 	anchored = FALSE
 	density = FALSE
 	flavour_text = "<span class='big bold'>You are an ash walker.</span><b> Your tribe worships <span class='danger'>the Necropolis</span>. The wastes are sacred ground, its monsters a blessed bounty. \
-	You have seen lights in the distance... they foreshadow the arrival of outsiders that seek to tear apart the Necropolis and its domain. Fresh sacrifices for your nest.</b>"
+	You have seen lights in the distance... they foreshadow the arrival of outsiders that seek to tear apart the Necropolis and its domain. Fresh sacrifices for your nest. Never leave the sacred ashes where you were born.</b>"
 	assignedrole = "Ash Walker"
 
 /obj/effect/mob_spawn/human/ash_walker/special(mob/living/new_spawn)


### PR DESCRIPTION
:cl: Supers saltiest tear
tweak: Ash walkers are now told not to leave the lavaland.
/:cl:

Because a lizard in a miners uniform walking up to you and silently attacking you is disruptive as fuck.  I hate mining's danger-creep and nigh infinite psudo-antags is just a bit far.  The rules give the power for these kinds of tweaks to coderbus for some reason. ¯\_(ツ)_/¯

I feel a soft RP no no is better then salty hard ban from shuttle consoles or something dumb. 