### PR TITLE
Fixed strange bot path icons

### DIFF
--- a/code/modules/mob/living/simple_animal/bot/bot.dm
+++ b/code/modules/mob/living/simple_animal/bot/bot.dm
@@ -1010,5 +1010,5 @@ Pass a positive integer as an argument to override a bot's default speed.
 		return
 	var/image/I = path[path[1]]
 	if(I)
-		I.icon = null
+		I.alpha = 0
 	path.Cut(1, 2)


### PR DESCRIPTION
Fixes #36223 
:cl:
fix: Bot path huds no longer leave strange checkerboard squares behind.
/:cl:
