### PR TITLE
[READY]unapologetic ntnet and circuit buff. adds ntnet service framework, and circuit lists can now be associative

### DIFF
--- a/code/__DEFINES/networks.dm
+++ b/code/__DEFINES/networks.dm
@@ -1,1 +1,3 @@
 #define HID_RESTRICTED_END 101		//the first nonrestricted ID, automatically assigned on connection creation.
+
+#define NETWORK_BROADCAST_ID "ALL"

--- a/code/controllers/subsystem/processing/networks.dm
+++ b/code/controllers/subsystem/processing/networks.dm
@@ -34,3 +34,6 @@ PROCESSING_SUBSYSTEM_DEF(networks)
 /datum/controller/subsystem/processing/networks/proc/unregister_interface(datum/component/ntnet_interface/D)
 	interfaces_by_id -= D.hardware_id
 	return TRUE
+
+/datum/controller/subsystem/processing/networks/proc/get_next_HID()
+	return assignment_hardware_id++		//should never have a collision, up to 1 million.

--- a/code/datums/components/ntnet_interface.dm
+++ b/code/datums/components/ntnet_interface.dm
@@ -2,6 +2,9 @@
 /datum/proc/ntnet_recieve(datum/netdata/data)
 	return
 
+/datum/proc/ntnet_recieve_broadcast(datum/netdata/data)
+	return
+
 /datum/proc/ntnet_send(datum/netdata/data, netid)
 	GET_COMPONENT(NIC, /datum/component/ntnet_interface)
 	if(!NIC)
@@ -9,17 +12,17 @@
 	return NIC.__network_send(data, netid)
 
 /datum/component/ntnet_interface
-	var/hardware_id			//text
+	var/hardware_id			//text. this is the true ID. do not change this. stuff like ID forgery can be done manually.
 	var/network_name = ""			//text
 	var/list/networks_connected_by_id = list()		//id = datum/ntnet
+	var/differentiate_broadcast = TRUE				//If false, broadcasts go to ntnet_recieve. NOT RECOMMENDED.
 
-/datum/component/ntnet_interface/Initialize(force_ID, force_name = "NTNet Device", autoconnect_station_network = TRUE)			//Don't force ID unless you know what you're doing!
-	if(!force_ID)
-		hardware_id = "[SSnetworks.assignment_hardware_id++]"
-	else
-		hardware_id = force_ID
+/datum/component/ntnet_interface/Initialize(force_name = "NTNet Device", autoconnect_station_network = TRUE)			//Don't force ID unless you know what you're doing!
+	hardware_id = "[SSnetworks.get_next_HID()]"
 	network_name = force_name
-	SSnetworks.register_interface(src)
+	if(!SSnetworks.register_interface(src))
+		. = COMPONENT_INCOMPATIBLE
+		CRASH("Unable to register NTNet interface. Interface deleted.")
 	if(autoconnect_station_network)
 		register_connection(SSnetworks.station_network)
 
@@ -30,7 +33,10 @@
 
 /datum/component/ntnet_interface/proc/__network_recieve(datum/netdata/data)			//Do not directly proccall!
 	parent.SendSignal(COMSIG_COMPONENT_NTNET_RECIEVE, data)
-	parent.ntnet_recieve(data)
+	if(differentiate_broadcast && data.broadcast)
+		parent.ntnet_recieve_broadcast(data)
+	else
+		parent.ntnet_recieve(data)
 
 /datum/component/ntnet_interface/proc/__network_send(datum/netdata/data, netid)			//Do not directly proccall!
 	// Process data before sending it

--- a/code/game/machinery/doors/airlock.dm
+++ b/code/game/machinery/doors/airlock.dm
@@ -202,8 +202,8 @@
 		return
 
 	// Handle recieved packet.
-	var/command = lowertext(data.plaintext_data)
-	var/command_value = lowertext(data.plaintext_data_secondary)
+	var/command = lowertext(data.data["data"])
+	var/command_value = lowertext(data.data["data_secondary"])
 	switch(command)
 		if("open")
 			if(command_value == "on" && !density)

--- a/code/game/objects/items/control_wand.dm
+++ b/code/game/objects/items/control_wand.dm
@@ -43,13 +43,13 @@
 
 	switch(mode)
 		if(WAND_OPEN)
-			data.plaintext_data = "open"
+			data.data["data"] = "open"
 		if(WAND_BOLT)
-			data.plaintext_data = "bolt"
+			data.data["data"] = "bolt"
 		if(WAND_EMERGENCY)
-			data.plaintext_data = "emergency"
+			data.data["data"] = "emergency"
 
-	data.plaintext_data_secondary = "toggle"
+	data.data["data_secondary"] = "toggle"
 	data.passkey = access_list
 
 	ntnet_send(data)

--- a/code/modules/NTNet/netdata.dm
+++ b/code/modules/NTNet/netdata.dm
@@ -1,29 +1,44 @@
 /datum/netdata				//this requires some thought later on but for now it's fine.
 	var/network_id
 
+	var/autopasskey = TRUE
+
 	var/list/recipient_ids = list()
 	var/sender_id
+	var/broadcast = FALSE			//Whether this is a broadcast packet.
 
-	var/plaintext_data
-	var/plaintext_data_secondary
-	var/encrypted_passkey
+	var/list/data = list()
 
 	var/list/passkey
 
 // Process data before sending it
 /datum/netdata/proc/pre_send(datum/component/ntnet_interface/interface)
-	// Decrypt the passkey.
-	if(encrypted_passkey && !passkey)
-		passkey = json_decode(XorEncrypt(hextostr(encrypted_passkey, TRUE), SScircuit.cipherkey))
+	if(autopasskey)
+		// Decrypt the passkey.
+		if(data["encrypted_passkey"] && !passkey)
+			passkey = json_decode(XorEncrypt(hextostr(data["encrypted_passkey"], TRUE), SScircuit.cipherkey))
 
-	// Encrypt the passkey.
-	if(!encrypted_passkey && passkey)
-		encrypted_passkey = strtohex(XorEncrypt(json_encode(passkey), SScircuit.cipherkey))
+		// Encrypt the passkey.
+		if(!data["encrypted_passkey"] && passkey)
+			data["encrypted_passkey"] = strtohex(XorEncrypt(json_encode(passkey), SScircuit.cipherkey))
 
 	// If there is no sender ID, set the default one.
 	if(!sender_id && interface)
 		sender_id = interface.hardware_id
 
+/datum/netdata/proc/standard_format_data(primary, secondary, passkey)
+	data["data"] = primary
+	data["data_secondary"] = secondary
+	data["encrypted_passkey"] = passkey
+
+/datum/netdata/proc/json_to_data(json)
+	data = json_decode(json)
+
+/datum/netdata/proc/json_append_to_data(json)
+	data |= json_decode(json)
+
+/datum/netdata/proc/data_to_json()
+	return json_encode(data)
 
 /datum/netdata/proc/json_list_generation_admin()	//for admin logs and such.
 	. = list()
@@ -38,9 +53,7 @@
 	. = list()
 	.["recipient_ids"] = recipient_ids
 	.["sender_id"] = sender_id
-	.["data"] = plaintext_data
-	.["data_secondary"] = plaintext_data_secondary
-	.["passkey"] = encrypted_passkey
+	.["data_list"] = data
 
 /datum/netdata/proc/generate_netlog()
 	return "[json_encode(json_list_generation_netlog())]"

--- a/code/modules/NTNet/network.dm
+++ b/code/modules/NTNet/network.dm
@@ -1,6 +1,11 @@
 /datum/ntnet
 	var/network_id = "Network"
-	var/connected_interfaces_by_id = list()		//id = datum/component/ntnet_interface
+	var/list/connected_interfaces_by_id = list()		//id = datum/component/ntnet_interface
+	var/list/services_by_path = list()					//type = datum/ntnet_service
+	var/list/services_by_id = list()					//id = datum/ntnet_service
+
+	var/list/autoinit_service_paths = list()			//typepaths
+
 
 	var/list/relays = list()
 	var/list/logs = list()
@@ -32,7 +37,18 @@
 		stack_trace("Network [type] with ID [network_id] failed to register and has been deleted.")
 		qdel(src)
 
+/datum/ntnet/Destroy()
+	for(var/i in connected_interfaces_by_id)
+		var/datum/component/ntnet_interface/I = i
+		I.unregister_connection(src)
+	for(var/i in services_by_id)
+		var/datum/ntnet_service/S = i
+		S.disconnect(src, TRUE)
+	return ..()
+
 /datum/ntnet/proc/interface_connect(datum/component/ntnet_interface/I)
+	if(connected_interfaces_by_id[I.hardware_id])
+		return FALSE
 	connected_interfaces_by_id[I.hardware_id] = I
 	return TRUE
 
@@ -43,15 +59,68 @@
 /datum/ntnet/proc/find_interface_id(id)
 	return connected_interfaces_by_id[id]
 
+/datum/ntnet/proc/find_service_id(id)
+	return services_by_id[id]
+
+/datum/ntnet/proc/find_service_path(path)
+	return services_by_path[path]
+
+/datum/ntnet/proc/register_service(datum/ntnet_service/S)
+	if(!istype(S))
+		return FALSE
+	if(services_by_path[S.type] || services_by_id[S.id])
+		return FALSE
+	services_by_path[S.type] = S
+	services_by_id[S.id] = S
+	return TRUE
+
+/datum/ntnet/proc/unregister_service(datum/ntnet_service/S)
+	if(!istype(S))
+		return FALSE
+	services_by_path -= S.type
+	services_by_id -= S.id
+	return TRUE
+
+/datum/ntnet/proc/create_service(type)
+	var/datum/ntnet_service/S = new type
+	if(!istype(S))
+		return FALSE
+	. = S.connect(src)
+	if(!.)
+		qdel(S)
+
+/datum/ntnet/proc/destroy_service(type)
+	var/datum/ntnet_service/S = find_service_path(type)
+	if(!istype(S))
+		return FALSE
+	. = S.disconnect(src)
+	if(.)
+		qdel(src)
+
 /datum/ntnet/proc/process_data_transmit(datum/component/ntnet_interface/sender, datum/netdata/data)
-	data.network_id = src
-	log_data_transfer(data)
 	if(!check_relay_operation())
 		return FALSE
-	for(var/i in data.recipient_ids)
-		var/datum/component/ntnet_interface/reciever = find_interface_id(i)
+	data.network_id = src
+	log_data_transfer(data)
+	var/list/datum/component/ntnet_interface/recieving = list()
+	if((length(data.recipient_ids == 1) && data.recipient_ids[1] == NETWORK_BROADCAST_ID) || data.recipient_ids == NETWORK_BROADCAST_ID)
+		data.broadcast = TRUE
+		for(var/i in connected_interfaces_by_id)
+			recieving |= connected_interfaces_by_id[i]
+	else
+		for(var/i in data.recipient_ids)
+			var/datum/component/ntnet_interface/reciever = find_interface_id(i)
+			recieving |= reciever
+
+	for(var/i in recieving)
+		var/datum/component/ntnet_interface/reciever = i
 		if(reciever)
 			reciever.__network_recieve(data)
+
+	for(var/i in services_by_id)
+		var/datum/ntnet_service/serv = services_by_id[i]
+		serv.ntnet_intercept(data, src, sender)
+
 	return TRUE
 
 /datum/ntnet/proc/check_relay_operation(zlevel)	//can be expanded later but right now it's true/false.

--- a/code/modules/NTNet/services/_service.dm
+++ b/code/modules/NTNet/services/_service.dm
@@ -1,0 +1,38 @@
+/datum/ntnet_service
+	var/name = "Unidentified Network Service"
+	var/id
+	var/list/networks_by_id = list()			//Yes we support multinetwork services!
+
+/datum/ntnet_service/New()
+	var/datum/component/ntnet_interface/N = AddComponent(/datum/component/ntnet_interface, id, name, FALSE)
+	id = N.hardware_id
+
+/datum/ntnet_service/Destroy()
+	for(var/i in networks_by_id)
+		var/datum/ntnet/N = i
+		disconnect(N, TRUE)
+	networks_by_id = null
+	return ..()
+
+/datum/ntnet_service/proc/connect(datum/ntnet/net)
+	if(!istype(net))
+		return FALSE
+	GET_COMPONENT(interface, /datum/component/ntnet_interface)
+	if(!interface.register_connection(net))
+		return FALSE
+	if(!net.register_service(src))
+		interface.unregister_connection(net)
+		return FALSE
+	networks_by_id[net.network_id] = net
+	return TRUE
+
+/datum/ntnet_service/proc/disconnect(datum/ntnet/net, force = FALSE)
+	if(!istype(net) || (!net.unregister_service(src) && !force))
+		return FALSE
+	GET_COMPONENT(interface, /datum/component/ntnet_interface)
+	interface.unregister_connection(net)
+	networks_by_id -= net.network_id
+	return TRUE
+
+/datum/ntnet_service/proc/ntnet_intercept(datum/netdata/data, datum/ntnet/net, datum/component/ntnet_interface/sender)
+	return

--- a/code/modules/integrated_electronics/core/pins.dm
+++ b/code/modules/integrated_electronics/core/pins.dm
@@ -68,7 +68,7 @@ D [1]/  ||
 			result += "<br>"
 			var/pos = 0
 			for(var/line in my_list)
-				result += "[display_data(line)]"
+				result += "[display_data(line)] = [display_data(my_list[line])]"
 				pos++
 				if(pos != my_list.len)
 					result += ",<br>"
@@ -133,7 +133,7 @@ D [1]/  ||
 
 	return FALSE
 
-/datum/integrated_io/proc/write_data_to_pin(new_data)
+/datum/integrated_io/proc/write_data_to_pin(new_data, secondary)
 	if(isnull(new_data) || isnum(new_data) || istext(new_data) || isweakref(new_data))
 		data = new_data
 		holder.on_data_written()

--- a/code/modules/integrated_electronics/core/special_pins/list_pin.dm
+++ b/code/modules/integrated_electronics/core/special_pins/list_pin.dm
@@ -19,24 +19,30 @@
 	var/i = 0
 	for(var/line in my_list)
 		i++
-		t += "#[i] | [display_data(line)]  |  "
+		t += "#[i] | [display_data(line)] | [display_data(my_list[line])]"
 		t += "<a href='?src=[REF(src)];edit=1;pos=[i]'>\[Edit\]</a>  |  "
 		t += "<a href='?src=[REF(src)];remove=1;pos=[i]'>\[Remove\]</a><br>"
 	user << browse(t, "window=list_pin_[REF(src)];size=500x400")
 
-/datum/integrated_io/lists/proc/add_to_list(mob/user, var/new_entry)
+/datum/integrated_io/lists/proc/add_to_list(mob/user, new_entry, new_value)
 	if(!new_entry && user)
 		new_entry = ask_for_data_type(user)
+	if(!holder.check_interactivity(user))
+		return
+	var/yes = input(user, "Do you want to set a value?", "List association", "No") as null|anything in list("Yes", "No")
+	if(yes == "Yes")
+		new_value = ask_for_data_type(user)
 	if(is_valid(new_entry))
 		Add(new_entry)
 
-/datum/integrated_io/lists/proc/Add(var/new_entry)
+/datum/integrated_io/lists/proc/Add(new_entry, new_value)
 	var/list/my_list = data
 	if(my_list.len > IC_MAX_LIST_LENGTH)
 		my_list.Cut(Start=1,End=2)
 	my_list.Add(new_entry)
+	my_list[new_entry] = new_value
 
-/datum/integrated_io/lists/proc/remove_from_list_by_position(mob/user, var/position)
+/datum/integrated_io/lists/proc/remove_from_list_by_position(mob/user, position)
 	var/list/my_list = data
 	if(!my_list.len)
 		to_chat(user, "<span class='warning'>The list is empty, there's nothing to remove.</span>")
@@ -47,7 +53,7 @@
 	if(target_entry)
 		my_list.Remove(target_entry)
 
-/datum/integrated_io/lists/proc/remove_from_list(mob/user, var/target_entry)
+/datum/integrated_io/lists/proc/remove_from_list(mob/user, target_entry)
 	var/list/my_list = data
 	if(!my_list.len)
 		to_chat(user, "<span class='warning'>The list is empty, there's nothing to remove.</span>")
@@ -57,32 +63,48 @@
 	if(holder.check_interactivity(user) && target_entry)
 		my_list.Remove(target_entry)
 
-/datum/integrated_io/lists/proc/edit_in_list(mob/user, var/target_entry)
+/datum/integrated_io/lists/proc/edit_in_list(mob/user, target_entry)
 	var/list/my_list = data
 	if(!my_list.len)
 		to_chat(user, "<span class='warning'>The list is empty, there's nothing to modify.</span>")
 		return
 	if(!target_entry)
 		target_entry = input(user, "Which piece of data do you want to edit?", "Edit") as null|anything in my_list
-	if(holder.check_interactivity(user) && target_entry)
-		var/edited_entry = ask_for_data_type(user, target_entry)
-		if(edited_entry)
-			target_entry = edited_entry
+	if(!holder.check_interactivity(user) || isnull(target_entry))
+		return
+	var/pos = my_list.Find(target_entry)
+	var/mode = input(user, "Key or value?", "List association", "Key") as null|anything in list("Key", "Value")
+	var/edited_entry = ask_for_data_type(user, mode == "Key"? target_entry : my_list[target_entry])
+	if(edited_entry)
+		if(!holder.check_interactivity(user))
+			return
+		if(mode == "Key")
+			my_list[pos] = edited_entry
+		else
+			my_list[target_entry] = edited_entry
 
-/datum/integrated_io/lists/proc/edit_in_list_by_position(mob/user, var/position)
+
+/datum/integrated_io/lists/proc/edit_in_list_by_position(mob/user, position)
 	var/list/my_list = data
 	if(!my_list.len)
 		to_chat(user, "<span class='warning'>The list is empty, there's nothing to modify.</span>")
 		return
 	if(!position)
 		return
-	var/target_entry = my_list.Find(position)
-	if(target_entry)
-		var/edited_entry = ask_for_data_type(user, target_entry)
-		if(edited_entry)
-			target_entry = edited_entry
+	if(!holder.check_interactivity(user))
+		return
+	var/key = my_list.Find(position)
+	var/mode = input(user, "Key or value?", "List association", "Key") as null|anything in list("Key", "Value")
+	var/edited_entry = ask_for_data_type(user, mode == "Key"? key : my_list[key])
+	if(edited_entry)
+		if(!holder.check_interactivity(user))
+			return
+		if(mode == "Key")
+			my_list[position] = edited_entry
+		else
+			my_list[key] = edited_entry
 
-/datum/integrated_io/lists/proc/swap_inside_list(mob/user, var/first_target, var/second_target)
+/datum/integrated_io/lists/proc/swap_inside_list(mob/user, first_target, second_target)
 	var/list/my_list = data
 	if(my_list.len <= 1)
 		to_chat(user, "<span class='warning'>The list is empty, or too small to do any meaningful swapping.</span>")
@@ -108,7 +130,7 @@
 	my_list = shuffle(my_list)
 	push_data()
 
-/datum/integrated_io/lists/write_data_to_pin(var/new_data)
+/datum/integrated_io/lists/write_data_to_pin(new_data)
 	if(islist(new_data))
 		var/list/new_list = new_data
 		data = new_list.Copy(max(1,new_list.len - IC_MAX_LIST_LENGTH+1),0)

--- a/code/modules/integrated_electronics/subtypes/converters.dm
+++ b/code/modules/integrated_electronics/subtypes/converters.dm
@@ -230,7 +230,7 @@
 
 /obj/item/integrated_circuit/converter/exploders
 	name = "string exploder"
-	desc = "This splits a single string into a list of strings."
+	desc = "This splits a single string into a list of strings. Outputs a non-associative list."
 	extended_desc = "This circuit splits a given string into a list of strings based on the string and given delimiter. \
 	For example, 'eat this burger' will be converted to list('eat','this','burger')."
 	icon_state = "split"
@@ -370,5 +370,33 @@
 		result = rgb(red,green,blue)
 
 	set_pin_data(IC_OUTPUT, 1, result)
+	push_data()
+	activate_pin(2)
+
+/obj/item/integrated_circuit/converter/hex2str
+	name = "hex to str"
+	desc = "Converts hexadecimal data to a text string."
+	icon_state = "ref-string"
+	inputs = list("hex" = IC_PINTYPE_STRING)
+	outputs = list("string" = IC_PINTYPE_STRING)
+	spawn_flags = IC_SPAWN_DEFAULT | IC_SPAWN_RESEARCH
+
+/obj/item/integrated_circuit/converter/hex2str/do_work()
+	pull_data()
+	set_pin_data(IC_OUTPUT, 1, hextostr(get_pin_data(IC_INPUT, 1), TRUE))
+	push_data()
+	activate_pin(2)
+
+/obj/item/integrated_circuit/converter/str2hex
+	name = "str to hex"
+	desc = "Converts a text string to hexadecimal data."
+	icon_state = "ref-string"
+	inputs = list("string" = IC_PINTYPE_STRING)
+	outputs = list("hex" = IC_PINTYPE_STRING)
+	spawn_flags = IC_SPAWN_DEFAULT | IC_SPAWN_RESEARCH
+
+/obj/item/integrated_circuit/converter/str2hex/do_work()
+	pull_data()
+	set_pin_data(IC_OUTPUT, 1, strtohex(get_pin_data(IC_INPUT, 1)))
 	push_data()
 	activate_pin(2)

--- a/code/modules/integrated_electronics/subtypes/input.dm
+++ b/code/modules/integrated_electronics/subtypes/input.dm
@@ -150,7 +150,7 @@
 
 /obj/item/integrated_circuit/input/slime_scanner
 	name = "slime_scanner"
-	desc = "A very small version of the xenobio analyser. This allows the machine to know every needed properties of slime."
+	desc = "A very small version of the xenobio analyser. This allows the machine to know every needed properties of slime. Output mutation list is non associative."
 	icon_state = "medscan_adv"
 	complexity = 12
 	inputs = list("\<REF\> target")
@@ -254,7 +254,7 @@
 
 /obj/item/integrated_circuit/input/gene_scanner
 	name = "gene scanner"
-	desc = "This circuit will scan plant for traits and reagent genes."
+	desc = "This circuit will scan plant for traits and reagent genes. Output is non-associative."
 	extended_desc = "This allows the machine to scan plants in trays for reagent and trait genes. \
 			It cannot scan seeds nor fruits, only plants."
 	inputs = list(
@@ -486,7 +486,7 @@
 	complexity = 6
 	name = "list advanced locator"
 	desc = "This is needed for certain devices that demand list of names for a targets to act upon. This type locates something \
-	that is standing in given radius up to 8 meters"
+	that is standing in given radius up to 8 meters. Output is non-associative. Input will only consider keys if associative."
 	extended_desc = "The first pin requires a list of kinds of objects that you want the locator to acquire. It will locate nearby objects by name and description, \
 	and will then provide a list of all found objects which are similar. \
 	The second pin is a radius."
@@ -674,8 +674,8 @@
 	will pulse whatever's connected to it. Pulsing the first activation pin will send a message. Message \
 	can be send to multiple recepients. Addresses must be separated with ; symbol."
 	icon_state = "signal"
-	complexity = 4
-	cooldown_per_use = 5
+	complexity = 2
+	cooldown_per_use = 1
 	inputs = list(
 		"target NTNet addresses"= IC_PINTYPE_STRING,
 		"data to send"			= IC_PINTYPE_STRING,
@@ -686,19 +686,20 @@
 		"address received"			= IC_PINTYPE_STRING,
 		"data received"				= IC_PINTYPE_STRING,
 		"secondary text received"	= IC_PINTYPE_STRING,
-		"passkey"					= IC_PINTYPE_STRING
+		"passkey"					= IC_PINTYPE_STRING,
+		"is_broadcast"				= IC_PINTYPE_BOOLEAN
 		)
 	activators = list("send data" = IC_PINTYPE_PULSE_IN, "on data received" = IC_PINTYPE_PULSE_OUT)
 	spawn_flags = IC_SPAWN_DEFAULT|IC_SPAWN_RESEARCH
 	action_flags = IC_ACTION_LONG_RANGE
 	power_draw_per_use = 50
-	var/datum/ntnet_connection/exonet = null
 	var/address
 
 /obj/item/integrated_circuit/input/ntnet_packet/Initialize()
 	. = ..()
 	var/datum/component/ntnet_interface/net = LoadComponent(/datum/component/ntnet_interface)
 	address = net.hardware_id
+	net.differentiate_broadcast = FALSE
 	desc += "<br>This circuit's NTNet hardware address is: [address]"
 
 /obj/item/integrated_circuit/input/ntnet_packet/do_work()
@@ -709,17 +710,60 @@
 
 	var/datum/netdata/data = new
 	data.recipient_ids = splittext(target_address, ";")
-	data.plaintext_data = message
-	data.plaintext_data_secondary = text
-	data.encrypted_passkey = key
+	data.standard_format_data(message, text, key)
 	ntnet_send(data)
 
 /obj/item/integrated_circuit/input/ntnet_recieve(datum/netdata/data)
 	set_pin_data(IC_OUTPUT, 1, data.sender_id)
-	set_pin_data(IC_OUTPUT, 2, data.plaintext_data)
-	set_pin_data(IC_OUTPUT, 3, data.plaintext_data_secondary)
-	set_pin_data(IC_OUTPUT, 4, data.encrypted_passkey)
+	set_pin_data(IC_OUTPUT, 2, data.data["data"])
+	set_pin_data(IC_OUTPUT, 3, data.data["data_secondary"])
+	set_pin_data(IC_OUTPUT, 4, data.data["encrypted_passkey"])
+	set_pin_data(IC_OUTPUT, 5, data.broadcast)
 
+	push_data()
+	activate_pin(2)
+
+/obj/item/integrated_circuit/input/ntnet_advanced
+	name = "Low level NTNet transreciever"
+	desc = "Enables the sending and receiving of messages on NTNet via packet data protocol. Allows advanced control of message contents and signalling. Must use associative lists. Outputs associative list. Has a slower transmission rate than normal NTNet circuits, due to increased data processing complexity.."
+	extended_desc = "Data can be send or received using the second pin on each side, \
+	with additonal data reserved for the third pin. When a message is received, the second activation pin \
+	will pulse whatever's connected to it. Pulsing the first activation pin will send a message. Message \
+	can be send to multiple recepients. Addresses must be separated with ; symbol."
+	icon_state = "signal"
+	complexity = 4
+	cooldown_per_use = 10
+	inputs = list(
+		"target NTNet addresses"= IC_PINTYPE_STRING,
+		"data"					= IC_PINTYPE_LIST,
+		)
+	outputs = list("recieved data" = IC_PINTYPE_LIST, "is_broadcast" = IC_PINTYPE_BOOLEAN)
+	activators = list("send data" = IC_PINTYPE_PULSE_IN, "on data received" = IC_PINTYPE_PULSE_OUT)
+	spawn_flags = IC_SPAWN_DEFAULT|IC_SPAWN_RESEARCH
+	action_flags = IC_ACTION_LONG_RANGE
+	power_draw_per_use = 50
+	var/address
+
+/obj/item/integrated_circuit/input/ntnet_advanced/Initialize()
+	. = ..()
+	var/datum/component/ntnet_interface/net = LoadComponent(/datum/component/ntnet_interface)
+	address = net.hardware_id
+	net.differentiate_broadcast = FALSE
+	desc += "<br>This circuit's NTNet hardware address is: [address]"
+
+/obj/item/integrated_circuit/input/ntnet_advanced/do_work()
+	var/target_address = get_pin_data(IC_INPUT, 1)
+	var/list/message = get_pin_data(IC_INPUT, 2)
+	if(!islist(message))
+		message = list()
+	var/datum/netdata/data = new
+	data.recipient_ids = splittext(target_address, ";")
+	data.data = message
+	ntnet_send(data)
+
+/obj/item/integrated_circuit/input/ntnet_advanced/ntnet_recieve(datum/netdata/data)
+	set_pin_data(IC_OUTPUT, 1, data.data)
+	set_pin_data(IC_OUTPUT, 2, data.broadcast)
 	push_data()
 	activate_pin(2)
 

--- a/code/modules/integrated_electronics/subtypes/lists.dm
+++ b/code/modules/integrated_electronics/subtypes/lists.dm
@@ -17,11 +17,13 @@
 
 /obj/item/integrated_circuit/lists/pick
 	name = "pick circuit"
-	desc = "This circuit will pick a random element from the input list, and output said element."
+	desc = "This circuit will pick a random element from the input list, and output said element, as well as its index, and value if applicable for associative lists."
 	extended_desc = "Input list is unmodified."
 	icon_state = "addition"
 	outputs = list(
-		"result" = IC_PINTYPE_ANY
+		"result key" = IC_PINTYPE_ANY,
+		"result value" = IC_PINTYPE_ANY,
+		"result index" = IC_PINTYPE_NUMBER
 		)
 	activators = list(
 		"compute" = IC_PINTYPE_PULSE_IN,
@@ -34,7 +36,10 @@
 /obj/item/integrated_circuit/lists/pick/do_work()
 	var/list/input_list = get_pin_data(IC_INPUT, 1) // List pins guarantee that there is a list inside, even if just an empty one.
 	if(input_list.len)
-		set_pin_data(IC_OUTPUT, 1, pick(input_list))
+		var/res = rand(1, input_list.len)
+		set_pin_data(IC_OUTPUT, 1, input_list[res])
+		set_pin_data(IC_OUTPUT, 2, input_list[input_list[res]])
+		set_pin_data(IC_OUTPUT, 3, res)
 		push_data()
 		activate_pin(2)
 	else
@@ -43,11 +48,12 @@
 
 /obj/item/integrated_circuit/lists/append
 	name = "append circuit"
-	desc = "This circuit will add an element to a list."
+	desc = "This circuit will add an element to a list. If input is a string and value is specified, will associate value with input."
 	extended_desc = "The new element will always be at the bottom of the list."
 	inputs = list(
 		"list to append" = IC_PINTYPE_LIST,
-		"input" = IC_PINTYPE_ANY
+		"input" = IC_PINTYPE_ANY,
+		"value" = IC_PINTYPE_ANY
 		)
 	outputs = list(
 		"appended list" = IC_PINTYPE_LIST
@@ -59,24 +65,27 @@
 	var/list/input_list = get_pin_data(IC_INPUT, 1)
 	var/list/output_list = list()
 	var/new_entry = get_pin_data(IC_INPUT, 2)
+	var/value = get_pin_data(IC_INPUT, 3)
 	output_list = input_list.Copy()
 	output_list.Add(new_entry)
+	if(istext(new_entry) && value)
+		output_list[new_entry] = value
 
 	set_pin_data(IC_OUTPUT, 1, output_list)
 	push_data()
 	activate_pin(2)
 
-
 /obj/item/integrated_circuit/lists/search
 	name = "search circuit"
-	desc = "This circuit will get the index location of the desired element in a list."
+	desc = "This circuit will get the index location, and if associative, the value of the desired element in a list."
 	extended_desc = "Search will start at 1 position and will return first matching position."
 	inputs = list(
 		"list" = IC_PINTYPE_LIST,
 		"item" = IC_PINTYPE_ANY
 		)
 	outputs = list(
-		"index" = IC_PINTYPE_NUMBER
+		"index" = IC_PINTYPE_NUMBER,
+		"value" = IC_PINTYPE_ANY
 		)
 	activators = list(
 		"compute" = IC_PINTYPE_PULSE_IN,
@@ -92,6 +101,10 @@
 	var/output = input_list.Find(get_pin_data(IC_INPUT, 2))
 
 	set_pin_data(IC_OUTPUT, 1, output)
+	if(istext(output))
+		set_pin_data(IC_OUTPUT, 2, input_list[output])
+	else
+		set_pin_data(IC_OUTPUT, 2, null)
 	push_data()
 
 	if(output)
@@ -102,14 +115,15 @@
 
 /obj/item/integrated_circuit/lists/at
 	name = "at circuit"
-	desc = "This circuit will pick an element from a list by the input index."
+	desc = "This circuit will pick an element from a list by the input index. Will also output value if item is associated with a value."
 	extended_desc = "If there is no element with such index, result will be null."
 	inputs = list(
 		"list" = IC_PINTYPE_LIST,
 		"index" = IC_PINTYPE_INDEX
 		)
 	outputs = list(
-		"item" = IC_PINTYPE_ANY
+		"item" = IC_PINTYPE_ANY,
+		"value" = IC_PINTYPE_ANY
 		)
 	activators = list(
 		"compute" = IC_PINTYPE_PULSE_IN,
@@ -131,18 +145,22 @@
 		activate_pin(3)
 		return
 
-	set_pin_data(IC_OUTPUT, 1, input_list[index])
+	var/key = input_list[index]
+	set_pin_data(IC_OUTPUT, 1, key)
+	if(istext(key))
+		set_pin_data(IC_OUTPUT, 2, input_list[key])
 	push_data()
 	activate_pin(2)
 
 
 /obj/item/integrated_circuit/lists/delete
 	name = "delete circuit"
-	desc = "This circuit will remove an element from a list by the index."
+	desc = "This circuit will remove an element from a list by the index if specified, and an element from the list with the matching key if specified for associative lists."
 	extended_desc = "If there is no element with such index, result list will be unchanged."
 	inputs = list(
 		"list" = IC_PINTYPE_LIST,
-		"index" = IC_PINTYPE_INDEX
+		"index" = IC_PINTYPE_INDEX,
+		"key" = IC_PINTYPE_STRING
 		)
 	outputs = list(
 		"item" = IC_PINTYPE_LIST
@@ -154,25 +172,27 @@
 	var/list/input_list = get_pin_data(IC_INPUT, 1)
 	var/list/red_list = list()
 	var/index = get_pin_data(IC_INPUT, 2)
+	var/key = get_pin_data(IC_INPUT, 3)
 
 	if(length(input_list))
-		for(var/j in 1 to input_list.len)
-			var/I = input_list[j]
-			if(j != index)
-				red_list.Add(I)
+		red_list = input_list.Copy()
+		if(index)
+			red_list.Cut(index, index+1)
+		if(key)
+			red_list -= key
 	set_pin_data(IC_OUTPUT, 1, red_list)
 	push_data()
 	activate_pin(2)
 
-
 /obj/item/integrated_circuit/lists/write
 	name = "write circuit"
-	desc = "This circuit will write an element to a list at the given index location."
+	desc = "This circuit will write an element to a list at the given index location. If value is specified, it will attempt to set the value of the item written to the value. Associations only work if the itme written is a text string."
 	extended_desc = "If there is no element with such index, it will give the same list as before."
 	inputs = list(
 		"list" = IC_PINTYPE_LIST,
 		"index" = IC_PINTYPE_INDEX,
-		"item" = IC_PINTYPE_ANY
+		"item" = IC_PINTYPE_ANY,
+		"value" = IC_PINTYPE_ANY
 		)
 	outputs = list(
 		"redacted list" = IC_PINTYPE_LIST
@@ -189,6 +209,7 @@
 	var/list/input_list = get_pin_data(IC_INPUT, 1)
 	var/index = get_pin_data(IC_INPUT, 2)
 	var/item = get_pin_data(IC_INPUT, 3)
+	var/value = get_pin_data(IC_INPUT, 4)
 
 	// Check if index is valid
 	if(index > input_list.len)
@@ -200,10 +221,11 @@
 	if(!islist(item))
 		var/list/red_list = input_list.Copy()			//crash proof
 		red_list[index] = item
+		if(istext(item) && value)
+			red_list[item] = value
 		set_pin_data(IC_OUTPUT, 1, red_list)
 		push_data()
 		activate_pin(2)
-
 
 /obj/item/integrated_circuit/lists/len
 	name = "len circuit"
@@ -227,7 +249,7 @@
 
 /obj/item/integrated_circuit/lists/jointext
 	name = "join text circuit"
-	desc = "This circuit will combine two lists into one and output it as a string."
+	desc = "This circuit will combine two lists into one and output it as a string. If list is associative, will only read keys."
 	extended_desc = "Default settings will encode the entire list into a string."
 	icon_state = "join"
 	inputs = list(
@@ -265,7 +287,7 @@
 
 /obj/item/integrated_circuit/lists/constructor
 	name = "large list constructor"
-	desc = "This circuit will build a list out of sixteen input values."
+	desc = "This circuit will build a list out of sixteen input values. Supports list associations. Associations only work if the key is a string."
 	icon_state = "constr8"
 	inputs = list()
 	outputs = list(
@@ -275,19 +297,24 @@
 	var/number_of_pins = 16
 
 /obj/item/integrated_circuit/lists/constructor/Initialize()
-	for(var/i = 1 to number_of_pins)
-		inputs["input [i]"] = IC_PINTYPE_ANY // This is just a string since pins don't get built until ..() is called.
+	for(var/i in 1 to number_of_pins)
+		inputs["key [i]"] = IC_PINTYPE_ANY // This is just a string since pins don't get built until ..() is called.
+	for(var/i in 1 to number_of_pins)
+		inputs["value [i]"] = IC_PINTYPE_ANY
 	complexity = number_of_pins / 2
-	. = ..()
+	return ..()
 
 /obj/item/integrated_circuit/lists/constructor/do_work()
 	var/list/output_list = list()
-	for(var/i = 1 to number_of_pins)
+	for(var/i in 1 to number_of_pins)
 		var/data = get_pin_data(IC_INPUT, i)
+		var/value = get_pin_data(IC_INPUT, i + number_of_pins)
 
 		// No nested lists
 		if(!islist(data))
 			output_list += data
+			if(istext(data) && value)
+				output_list[data] = value
 		else
 			output_list += null
 
@@ -297,20 +324,19 @@
 
 /obj/item/integrated_circuit/lists/constructor/small
 	name = "list constructor"
-	desc = "This circuit will build a list out of four input values."
+	desc = "This circuit will build a list out of four input values. Supports associative lists. List associations only work if the key is a string."
 	icon_state = "constr"
 	number_of_pins = 4
 
 /obj/item/integrated_circuit/lists/constructor/medium
 	name = "medium list constructor"
-	desc = "This circuit will build a list out of eight input values."
+	desc = "This circuit will build a list out of eight input values. Supports associative lists. List associations only work if the key is a string."
 	icon_state = "constr8"
 	number_of_pins = 8
 
-
 /obj/item/integrated_circuit/lists/deconstructor
 	name = "large list deconstructor"
-	desc = "This circuit will write first sixteen entries of input list, starting with index, into the output values."
+	desc = "This circuit will write first sixteen entries of input list, starting with index, into the output values. Supports associative lsits."
 	icon_state = "deconstr8"
 	inputs = list(
 		"input" = IC_PINTYPE_LIST,
@@ -321,8 +347,10 @@
 	var/number_of_pins = 16
 
 /obj/item/integrated_circuit/lists/deconstructor/Initialize()
-	for(var/i = 1 to number_of_pins)
-		outputs["output [i]"] = IC_PINTYPE_ANY // This is just a string since pins don't get built until ..() is called.
+	for(var/i in 1 to number_of_pins)
+		outputs["output key [i]"] = IC_PINTYPE_ANY // This is just a string since pins don't get built until ..() is called.
+	for(var/i in 1 to number_of_pins)
+		outputs["output value [i]"] = IC_PINTYPE_ANY
 	complexity = number_of_pins / 2
 	. = ..()
 
@@ -335,18 +363,66 @@
 		if(list_index > input_list.len)
 			set_pin_data(IC_OUTPUT, i, null)
 		else
-			set_pin_data(IC_OUTPUT, i, input_list[list_index])
+			var/data = input_list[list_index]
+			set_pin_data(IC_OUTPUT, i, data)
+			set_pin_data(IC_OUTPUT, i + number_of_pins, input_list[data])
 
 	push_data()
 	activate_pin(2)
 
 /obj/item/integrated_circuit/lists/deconstructor/small
 	name = "list deconstructor"
-	desc = "This circuit will write first four entries of input list, starting with index, into the output values."
+	desc = "This circuit will write first four entries of input list, starting with index, into the output values. Supports associative lists."
 	icon_state = "deconstr"
 	number_of_pins = 4
 
 /obj/item/integrated_circuit/lists/deconstructor/medium
 	name = "medium list deconstructor"
-	desc = "This circuit will write first eight entries of input list, starting with index, into the output values."
+	desc = "This circuit will write first eight entries of input list, starting with index, into the output values. Supports associative lists."
 	number_of_pins = 8
+
+/obj/item/integrated_circuit/lists/json_encode
+	name = "JSON encoder"
+	desc = "This circuit encodes a list into JSON format. Supports associative lists. Object references must be encoded by a reference encoder first, otherwise they will not encode properly."
+	inputs = list("list" = IC_PINTYPE_LIST)
+	outputs = list("json" = IC_PINTYPE_STRING)
+	spawn_flags = IC_SPAWN_DEFAULT | IC_SPAWN_RESEARCH
+
+/obj/item/integrated_circuit/lists/json_encode/do_work()
+	pull_data()
+	var/list/L = get_pin_data(IC_INPUT, 1)
+	set_pin_data(IC_OUTPUT, 1, json_encode(L))
+	push_data()
+	activate_pin(2)
+
+/obj/item/integrated_circuit/lists/json_decode
+	name = "JSON decoder"
+	desc = "This circuit decodes a JSON formatted string into a list. Supports associative lists."
+	inputs = list("json" = IC_PINTYPE_STRING)
+	outputs = list("list" = IC_PINTYPE_LIST)
+	spawn_flags = IC_SPAWN_DEFAULT | IC_SPAWN_RESEARCH
+
+/obj/item/integrated_circuit/lists/json_decode/do_work()
+	pull_data()
+	var/json = get_pin_data(IC_INPUT, 1)
+	json = html_decode(json)			//Circuits uses stripped_input when getting data from users, and that will mess this up.
+	var/list/L = json_decode(json)
+	if(islist(L))
+		for(var/i in 1 to L.len)
+			var/key = L[i]
+			var/value = L[key]
+			var/changed = FALSE
+			if(islist(key))
+				key = json_encode(key)
+				L[i] = key
+				changed = TRUE
+			if(islist(value))
+				value = json_encode(value)
+				changed = TRUE
+			if(changed)
+				L[key] = value
+		set_pin_data(IC_OUTPUT, 1, L)
+	else
+		set_pin_data(IC_OUTPUT, 1, list())
+	push_data()
+	activate_pin(2)

--- a/code/modules/integrated_electronics/subtypes/manipulation.dm
+++ b/code/modules/integrated_electronics/subtypes/manipulation.dm
@@ -299,7 +299,7 @@
 
 /obj/item/integrated_circuit/manipulation/grabber
 	name = "grabber"
-	desc = "A circuit with it's own inventory for items, used to grab and store things."
+	desc = "A circuit with it's own inventory for items, used to grab and store things. Outputs non-associative list."
 	icon_state = "grabber"
 	extended_desc = "The circuit accepts a reference to an object to be grabbed and can store up to 10 objects. Modes: 1 to grab, 0 to eject the first object, and -1 to eject all objects."
 	w_class = WEIGHT_CLASS_SMALL

--- a/code/modules/integrated_electronics/subtypes/reagents.dm
+++ b/code/modules/integrated_electronics/subtypes/reagents.dm
@@ -427,7 +427,7 @@ obj/item/integrated_circuit/reagent/storage/juicer
 
 /obj/item/integrated_circuit/reagent/storage/scan
 	name = "reagent scanner"
-	desc = "Stores liquid inside the device away from electrical components. It can store up to 60u. On pulse this beaker will send list of contained reagents."
+	desc = "Stores liquid inside the device away from electrical components. It can store up to 60u. On pulse this beaker will send list of contained reagents. Outputs associative list with key being the reagent and value being the amount."
 	icon_state = "reagent_scan"
 	extended_desc = "Mostly useful for reagent filter."
 
@@ -448,7 +448,7 @@ obj/item/integrated_circuit/reagent/storage/juicer
 		if(1)
 			var/cont[0]
 			for(var/datum/reagent/RE in reagents.reagent_list)
-				cont += RE.id
+				cont[RE.id] = RE.volume
 			set_pin_data(IC_OUTPUT, 3, cont)
 			push_data()
 		if(2)
@@ -457,7 +457,7 @@ obj/item/integrated_circuit/reagent/storage/juicer
 
 /obj/item/integrated_circuit/reagent/filter
 	name = "reagent filter"
-	desc = "Filtering liquids by list of desired or unwanted reagents."
+	desc = "Filtering liquids by list of desired or unwanted reagents. If list of reagents is associative, only keys will be considered."
 	icon_state = "reagent_filter"
 	extended_desc = "This is a filter which will move liquids from the source to the target. \
 	It will move all reagents, except those in the unwanted list, given the fourth pin if amount value is positive, \

--- a/code/modules/integrated_electronics/subtypes/smart.dm
+++ b/code/modules/integrated_electronics/subtypes/smart.dm
@@ -117,3 +117,23 @@
 		set_pin_data(IC_OUTPUT, 2, Yn)
 		push_data()
 		activate_pin(2)
+
+/obj/item/integrated_circuit/smart/xorencrypt
+	name = "XOR encrypt"
+	desc = "Cryptographic processor for XOR encryption."
+	icon_state = "numberpad"
+	complexity = 10
+	inputs = list("input" = IC_PINTYPE_STRING, "key" = IC_PINTYPE_STRING)
+	outputs = list("output" = IC_PINTYPE_STRING)
+	activators = list("process" = IC_PINTYPE_PULSE_IN, "on process" = IC_PINTYPE_PULSE_OUT)
+	power_draw_per_use = 20
+	spawn_flags = IC_SPAWN_RESEARCH
+
+/obj/item/integrated_circuit/smart/xorencrypt/do_work()
+	pull_data()
+	var/string = get_pin_data(IC_INPUT, 1)
+	var/key = get_pin_data(IC_INPUT, 2)
+	var/result = XorEncrypt(string, key)
+	set_pin_data(IC_OUTPUT, 1, result)
+	push_data()
+	activate_pin(2)

--- a/code/modules/mob/living/simple_animal/bot/mulebot.dm
+++ b/code/modules/mob/living/simple_animal/bot/mulebot.dm
@@ -61,6 +61,10 @@
 	set_id(suffix || id || "#[mulebot_count]")
 	suffix = null
 
+/mob/living/simple_animal/bot/mulebot/ComponentInitialize()
+	. = ..()
+	AddComponent(/datum/component/ntnet_interface)
+
 /mob/living/simple_animal/bot/mulebot/Destroy()
 	unload(0)
 	qdel(wires)

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -2105,6 +2105,7 @@
 #include "code\modules\NTNet\netdata.dm"
 #include "code\modules\NTNet\network.dm"
 #include "code\modules\NTNet\relays.dm"
+#include "code\modules\NTNet\services\_service.dm"
 #include "code\modules\orbit\orbit.dm"
 #include "code\modules\paperwork\clipboard.dm"
 #include "code\modules\paperwork\contract.dm"


### PR DESCRIPTION
ntnet now allows a custom list of data, current stuff still uses standard argument format.
to make my life easier for techwebs/mineral distribution memes
as for the circuits because i can. circuits can now also convert jsons to list and vice versa, string to hex and vice versa, xor encrypt, and send in the new ntnet packet format allowing for custom lists.

adds ntnet service framework, to be used later for the pda and mulebot services hopefully probably.
they receive all packets on the network, whether they use them is up to them.
they send packets with their own ntnet interface with address.

don't even ask why it's related to techwebs it just is shhh i'll find a use for it

:cl:
rscadd: The str2hex, hex2str, XorEncrypt, json2list, list2json conversion circuits have been added.
code: networks now support network services, what they'll do we don't know yet. netdata now uses a list instead of three variables for their data, and has procs to make their data from a json or turn their data into a json.
rscadd: Circuit ntnet components buffed. Added a new low level ntnet component that can send custom data instead of just the two plaintext and one passkey format, which things will use by default. Ntnet now uses a list for their data instead of three variables. they also have lowered complexity for the now weakened normal network component, and has lower cooldowns.
rscadd: Buckle up, because CIRCUIT LISTS CAN NOW BE ASSOCIATIVE!
/:cl: