### PR TITLE
Fixes the tesla coil research screwdrivering

### DIFF
--- a/code/modules/power/tesla/coil.dm
+++ b/code/modules/power/tesla/coil.dm
@@ -134,9 +134,9 @@
 			icon_state = "rpcoil[anchored]"
 
 /obj/machinery/power/tesla_coil/research/attackby(obj/item/W, mob/user, params)
-	. = ..()
 	if(default_deconstruction_screwdriver(user, "rpcoil_open[anchored]", "rpcoil[anchored]", W))
 		return
+	return ..()
 
 /obj/machinery/power/tesla_coil/research/on_construction()
 	if(anchored)


### PR DESCRIPTION
[Changelogs]: 
:cl: Dax Dupont
fix: Edison's ghost no longer interferes with Tesla Corona Coil research device. 
/:cl:

[why]: Fixes #36339
