### PR TITLE
Mech drills behave more realistically

### DIFF
--- a/code/game/mecha/equipment/mecha_equipment.dm
+++ b/code/game/mecha/equipment/mecha_equipment.dm
@@ -94,9 +94,16 @@
 	chassis.use_power(energy_drain)
 	. = do_after(chassis.occupant, equip_cooldown, target=target)
 	set_ready_state(1)
-	if(!chassis || 	chassis.loc != C || src != chassis.selected)
+	if(!chassis || 	chassis.loc != C || src != chassis.selected || !(get_dir(chassis, target)&chassis.dir))
 		return 0
 
+/obj/item/mecha_parts/mecha_equipment/proc/do_after_mecha(atom/target, delay)
+	if(!chassis)
+		return
+	var/C = chassis.loc
+	. = do_after(chassis.occupant, delay, target=target)
+	if(!chassis || 	chassis.loc != C || src != chassis.selected || !(get_dir(chassis, target)&chassis.dir))
+		return 0
 
 /obj/item/mecha_parts/mecha_equipment/proc/can_attach(obj/mecha/M)
 	if(M.equipment.len<M.max_equip)

--- a/code/game/mecha/equipment/tools/mining_tools.dm
+++ b/code/game/mecha/equipment/tools/mining_tools.dm
@@ -1,6 +1,9 @@
 
 // Drill, Diamond drill, Mining scanner
 
+#define DRILL_BASIC 1
+#define DRILL_HARDENED 2
+
 
 /obj/item/mecha_parts/mecha_equipment/drill
 	name = "exosuit drill"
@@ -10,6 +13,8 @@
 	energy_drain = 10
 	force = 15
 	pacifist_safe = FALSE
+	var/drill_delay = 7
+	var/drill_level = DRILL_BASIC
 
 /obj/item/mecha_parts/mecha_equipment/drill/Initialize()
 	. = ..()
@@ -29,27 +34,39 @@
 					 "<span class='italics'>You hear drilling.</span>")
 
 	if(do_after_cooldown(target))
+		set_ready_state(FALSE)
+		log_message("Started drilling [target]")
 		if(isturf(target))
 			var/turf/T = target
 			T.drill_act(src)
-		else
-			log_message("Drilled through [target]")
+			set_ready_state(TRUE)
+			return
+		while(do_after_mecha(target, drill_delay))
 			if(isliving(target))
-				if(istype(src , /obj/item/mecha_parts/mecha_equipment/drill/diamonddrill))
-					drill_mob(target, chassis.occupant, 120)
-				else
-					drill_mob(target, chassis.occupant)
+				drill_mob(target, chassis.occupant)
+				playsound(src,'sound/weapons/drill.ogg',40,1)
+			else if(isobj(target))
+				var/obj/O = target
+				O.take_damage(15, BRUTE, 0, FALSE, get_dir(chassis, target))
+				playsound(src,'sound/weapons/drill.ogg',40,1)
 			else
-				target.ex_act(EXPLODE_HEAVY)
+				set_ready_state(TRUE)
+				return
+		set_ready_state(TRUE)
 
 /turf/proc/drill_act(obj/item/mecha_parts/mecha_equipment/drill/drill)
 	return
 
+/turf/closed/wall/drill_act(obj/item/mecha_parts/mecha_equipment/drill/drill)
+	if(drill.do_after_mecha(src, 60 / drill.drill_level))
+		drill.log_message("Drilled through [src]")
+		dismantle_wall(TRUE, FALSE)
+
 /turf/closed/wall/r_wall/drill_act(obj/item/mecha_parts/mecha_equipment/drill/drill)
-	if(istype(drill, /obj/item/mecha_parts/mecha_equipment/drill/diamonddrill))
-		if(drill.do_after_cooldown(src))//To slow down how fast mechs can drill through the station
+	if(drill.drill_level >= DRILL_HARDENED)
+		if(drill.do_after_mecha(src, 120 / drill.drill_level))
 			drill.log_message("Drilled through [src]")
-			ex_act(EXPLODE_LIGHT)
+			dismantle_wall(TRUE, FALSE)
 	else
 		drill.occupant_message("<span class='danger'>[src] is too durable to drill through.</span>")
 
@@ -91,30 +108,40 @@
 	GET_COMPONENT_FROM(butchering, /datum/component/butchering, src)
 	butchering.butchering_enabled = FALSE
 
-/obj/item/mecha_parts/mecha_equipment/drill/proc/drill_mob(mob/living/target, mob/user, var/drill_damage=80)
-	target.visible_message("<span class='danger'>[chassis] drills [target] with [src].</span>", \
-						"<span class='userdanger'>[chassis] drills [target] with [src].</span>")
-	add_logs(user, target, "attacked", "[name]", "(INTENT: [uppertext(user.a_intent)]) (DAMTYPE: [uppertext(damtype)])")
-	if(target.stat == DEAD)
+/obj/item/mecha_parts/mecha_equipment/drill/proc/drill_mob(mob/living/target, mob/user)
+	target.visible_message("<span class='danger'>[chassis] is drilling [target] with [src]!</span>", \
+						"<span class='userdanger'>[chassis] is drilling you with [src]!</span>")
+	add_logs(user, target, "drilled", "[name]", "(INTENT: [uppertext(user.a_intent)]) (DAMTYPE: [uppertext(damtype)])")
+	if(target.stat == DEAD && target.getBruteLoss() >= 200)
 		add_logs(user, target, "gibbed", name)
-		if(target.butcher_results.len || target.guaranteed_butcher_results.len)
+		if(LAZYLEN(target.butcher_results) || LAZYLEN(target.guaranteed_butcher_results))
 			GET_COMPONENT_FROM(butchering, /datum/component/butchering, src)
 			butchering.Butcher(chassis, target)
 		else
 			target.gib()
 	else
-		target.take_bodypart_damage(drill_damage)
+		//drill makes a hole
+		var/obj/item/bodypart/target_part = target.get_bodypart(ran_zone("chest"))
+		target.apply_damage(10, BRUTE, "chest", target.run_armor_check(target_part, "melee"))
 
-	if(target)
-		target.Unconscious(200)
-		target.updatehealth()
+		//blood splatters
+		var/splatter_dir = get_dir(chassis, target)
+		if(isalien(target))
+			new /obj/effect/temp_visual/dir_setting/bloodsplatter/xenosplatter(target.drop_location(), splatter_dir)
+		else
+			new /obj/effect/temp_visual/dir_setting/bloodsplatter(target.drop_location(), splatter_dir)
 
+		//organs go everywhere
+		if(target_part && prob(10 * drill_level))
+			target_part.dismember(BRUTE)
 
 /obj/item/mecha_parts/mecha_equipment/drill/diamonddrill
 	name = "diamond-tipped exosuit drill"
 	desc = "Equipment for engineering and combat exosuits. This is an upgraded version of the drill that'll pierce the heavens!"
 	icon_state = "mecha_diamond_drill"
 	equip_cooldown = 10
+	drill_delay = 4
+	drill_level = DRILL_HARDENED
 	force = 15
 
 
@@ -140,3 +167,6 @@
 			return
 		scanning_time = world.time + equip_cooldown
 		mineral_scan_pulse(get_turf(src))
+
+#undef DRILL_BASIC
+#undef DRILL_HARDENED


### PR DESCRIPTION
:cl: XDTM
add: Changed behaviour of mech drills: now they take some time to start drilling, then they keep drilling until manually stopped or the target is destroyed. Mobs are still gibbed if they have more than 200 brute damage while being drilled.
add: Drilling walls is now consistent; it takes longer, but it will always work instead of only randomly.
tweak: Drills no longer stun mobs, but they can dismember limbs.
fix: Mech drills no longer cause explosion-like effects on mobs inside objects.
/:cl:

Consistency is nicer, and the constant drilling sounds with blood splattering everywhere sounds a lot better than instant drill hits after a delay.
Added a do_after_mecha that is not tied to the equipment cooldown but retains the mech checks.

Removed a few really ugly ex_acts. Probably fixes a few old bugs about people getting drilled in lockers.

Fixes #34426
Fixes #34351
Fixes #10432