### PR TITLE
Fixes dupe and runtime issues with Rod of Asclepius

### DIFF
--- a/code/datums/status_effects/buffs.dm
+++ b/code/datums/status_effects/buffs.dm
@@ -501,19 +501,15 @@
 					if(((hand % 2) == 0))
 						var/obj/item/bodypart/L = itemUser.newBodyPart("r_arm", FALSE, FALSE)
 						L.attach_limb(itemUser)
-						itemUser.put_in_r_hand(newRod)
+						itemUser.force_put_in_hand(newRod, hand)
 					else
 						var/obj/item/bodypart/L = itemUser.newBodyPart("l_arm", FALSE, FALSE)
 						L.attach_limb(itemUser)
-						itemUser.put_in_l_hand(newRod)
+						itemUser.force_put_in_hand(newRod, hand)
 					to_chat(itemUser, "<span class='notice'>Your arm suddenly grows back with the Rod of Asclepius still attached!</span>")
 				else
 					//Otherwise get rid of whatever else is in their hand and return the rod to said hand
-					itemUser.dropItemToGround(itemUser.get_item_for_held_index(hand))
-					if(((hand % 2) == 0))
-						itemUser.put_in_r_hand(newRod)
-					else
-						itemUser.put_in_l_hand(newRod)
+					itemUser.force_put_in_hand(newRod, hand)
 					to_chat(itemUser, "<span class='notice'>The Rod of Asclepius suddenly grows back out of your arm!</span>")
 			//Because a servant of medicines stops at nothing to help others, lets keep them on their toes and give them an additional boost.
 			if(itemUser.health < itemUser.maxHealth)

--- a/code/datums/status_effects/buffs.dm
+++ b/code/datums/status_effects/buffs.dm
@@ -501,15 +501,15 @@
 					if(((hand % 2) == 0))
 						var/obj/item/bodypart/L = itemUser.newBodyPart("r_arm", FALSE, FALSE)
 						L.attach_limb(itemUser)
-						itemUser.force_put_in_hand(newRod, hand)
+						itemUser.put_in_hand(newRod, hand, forced = TRUE)
 					else
 						var/obj/item/bodypart/L = itemUser.newBodyPart("l_arm", FALSE, FALSE)
 						L.attach_limb(itemUser)
-						itemUser.force_put_in_hand(newRod, hand)
+						itemUser.put_in_hand(newRod, hand, forced = TRUE)
 					to_chat(itemUser, "<span class='notice'>Your arm suddenly grows back with the Rod of Asclepius still attached!</span>")
 				else
 					//Otherwise get rid of whatever else is in their hand and return the rod to said hand
-					itemUser.force_put_in_hand(newRod, hand)
+					itemUser.put_in_hand(newRod, hand, forced = TRUE)
 					to_chat(itemUser, "<span class='notice'>The Rod of Asclepius suddenly grows back out of your arm!</span>")
 			//Because a servant of medicines stops at nothing to help others, lets keep them on their toes and give them an additional boost.
 			if(itemUser.health < itemUser.maxHealth)

--- a/code/modules/mining/lavaland/necropolis_chests.dm
+++ b/code/modules/mining/lavaland/necropolis_chests.dm
@@ -146,7 +146,7 @@
 	icon = 'icons/obj/lavaland/artefacts.dmi'
 	icon_state = "asclepius_dormant"
 	var/activated = FALSE
-	var/usedHand = null
+	var/usedHand
 
 /obj/item/rod_of_asclepius/attack_self(mob/user)
 	if(activated)

--- a/code/modules/mining/lavaland/necropolis_chests.dm
+++ b/code/modules/mining/lavaland/necropolis_chests.dm
@@ -146,6 +146,7 @@
 	icon = 'icons/obj/lavaland/artefacts.dmi'
 	icon_state = "asclepius_dormant"
 	var/activated = FALSE
+	var/usedHand = null
 
 /obj/item/rod_of_asclepius/attack_self(mob/user)
 	if(activated)
@@ -154,6 +155,10 @@
 		to_chat(user, "<span class='warning'>The snake carving seems to come alive, if only for a moment, before returning to it's dormant state, almost as if it finds you incapable of holding it's oath.</span>")
 		return
 	var/mob/living/carbon/itemUser = user
+	usedHand = itemUser.get_held_index_of_item(src)
+	if(itemUser.has_status_effect(STATUS_EFFECT_HIPPOCRATIC_OATH))
+		to_chat(user, "<span class='warning'>You can't possibly handle the responsibility of more than one rod!</span>")
+		return
 	var/failText = "<span class='warning'>The snake seems unsatisfied with your incomplete oath and returns to it's previous place on the rod, returning to its dormant, wooden state. You must stand still while completing your oath!</span>"
 	to_chat(itemUser, "<span class='notice'>The wooden snake that was carved into the rod seems to suddenly come alive and begins to slither down your arm! The compulsion to help others grows abnormally strong...</span>")
 	if(do_after(itemUser, 40, target = itemUser))
@@ -178,7 +183,7 @@
 		return
 	to_chat(itemUser, "<span class='notice'>The snake, satisfied with your oath, attaches itself and the rod to your forearm with an inseparable grip. Your thoughts seem to only revolve around the core idea of helping others, and harm is nothing more than a distant, wicked memory...</span>")
 	var/datum/status_effect/hippocraticOath/effect = itemUser.apply_status_effect(STATUS_EFFECT_HIPPOCRATIC_OATH)
-	effect.hand = itemUser.get_held_index_of_item(src)
+	effect.hand = usedHand
 	activated()
 
 /obj/item/rod_of_asclepius/proc/activated()

--- a/code/modules/mob/inventory.dm
+++ b/code/modules/mob/inventory.dm
@@ -170,8 +170,12 @@
 		return FALSE
 	return !held_items[hand_index]
 
-/mob/proc/put_in_hand(obj/item/I, hand_index)
-	if(can_put_in_hand(I, hand_index))
+/mob/proc/put_in_hand(obj/item/I, hand_index, forced = FALSE)
+	if(forced || can_put_in_hand(I, hand_index))
+		if(hand_index == null)
+			return FALSE
+		if(get_item_for_held_index(hand_index) != null)
+			dropItemToGround(get_item_for_held_index(hand_index), force = TRUE)
 		I.forceMove(src)
 		held_items[hand_index] = I
 		I.layer = ABOVE_HUD_LAYER
@@ -184,23 +188,6 @@
 		I.pixel_y = initial(I.pixel_y)
 		return hand_index || TRUE
 	return FALSE
-
-/mob/proc/force_put_in_hand(obj/item/I, hand_index)
-	if(hand_index == null)
-		return FALSE
-	if(get_item_for_held_index(hand_index) != null)
-		dropItemToGround(get_item_for_held_index(hand_index), force = TRUE)
-	I.forceMove(src)
-	held_items[hand_index] = I
-	I.layer = ABOVE_HUD_LAYER
-	I.plane = ABOVE_HUD_PLANE
-	I.equipped(src, slot_hands)
-	if(I.pulledby)
-		I.pulledby.stop_pulling()
-	update_inv_hands()
-	I.pixel_x = initial(I.pixel_x)
-	I.pixel_y = initial(I.pixel_y)
-	return hand_index || TRUE
 
 //Puts the item into the first available left hand if possible and calls all necessary triggers/updates. returns 1 on success.
 /mob/proc/put_in_l_hand(obj/item/I)

--- a/code/modules/mob/inventory.dm
+++ b/code/modules/mob/inventory.dm
@@ -185,6 +185,22 @@
 		return hand_index || TRUE
 	return FALSE
 
+/mob/proc/force_put_in_hand(obj/item/I, hand_index)
+	if(hand_index == null)
+		return FALSE
+	if(get_item_for_held_index(hand_index) != null)
+		dropItemToGround(get_item_for_held_index(hand_index), force = TRUE)
+	I.forceMove(src)
+	held_items[hand_index] = I
+	I.layer = ABOVE_HUD_LAYER
+	I.plane = ABOVE_HUD_PLANE
+	I.equipped(src, slot_hands)
+	if(I.pulledby)
+		I.pulledby.stop_pulling()
+	update_inv_hands()
+	I.pixel_x = initial(I.pixel_x)
+	I.pixel_y = initial(I.pixel_y)
+	return hand_index || TRUE
 
 //Puts the item into the first available left hand if possible and calls all necessary triggers/updates. returns 1 on success.
 /mob/proc/put_in_l_hand(obj/item/I)


### PR DESCRIPTION
:cl: The Dreamweaver
fix: Fixes duplication issue when the Rod of Asclepius is removed while lying down, as well as fixing a runtime when attempting to use multiple rods.
/:cl:

Changelog pretty much explains it all. Modified put_in_hand proc to make this work.

Closes #36408 

