### PR TITLE
Crayons and spraycans can no longer infinitely draw large graffiti

### DIFF
--- a/code/game/objects/items/crayons.dm
+++ b/code/game/objects/items/crayons.dm
@@ -244,8 +244,13 @@
 	if(!proximity || !check_allowed_items(target))
 		return
 
-	if(check_empty(user))
+	var/cost = 1
+	if(paint_mode == PAINT_LARGE_HORIZONTAL)
+		cost = 5
+	var/charges_used = use_charges(user, cost)
+	if(!charges_used)
 		return
+	. = charges_used
 
 	if(istype(target, /obj/effect/decal/cleanable))
 		target = target.loc
@@ -353,10 +358,6 @@
 		audible_message("<span class='notice'>You hear spraying.</span>")
 		playsound(user.loc, 'sound/effects/spray.ogg', 5, 1, 5)
 
-	var/cost = 1
-	if(paint_mode == PAINT_LARGE_HORIZONTAL)
-		cost = 5
-	. = use_charges(user, cost)
 	var/fraction = min(1, . / reagents.maximum_volume)
 	if(affected_turfs.len)
 		fraction /= affected_turfs.len


### PR DESCRIPTION
:cl: SailorDave
fix: Crayons and spraycans can no longer draw an unlimited amount of large graffiti regardless of uses left.
/:cl:

Fixes https://github.com/tgstation/tgstation/issues/35833

The check_empty() at the top of the afterattack() was only checking if the can was empty, not if the amount of uses left was less than the spray amount. This is tested and fixed.