### PR TITLE
RPD pipe autowrenching

### DIFF
--- a/code/game/objects/items/RPD.dm
+++ b/code/game/objects/items/RPD.dm
@@ -340,6 +340,8 @@ GLOBAL_LIST_INIT(transit_tube_recipes, list(
 			return
 
 		if(EATING_MODE) //Eating pipes
+			if(istype(A, /obj/machinery/atmospherics))
+				A = A.wrench_act(user, src)
 			if(!(istype(A, /obj/item/pipe) || istype(A, /obj/item/pipe_meter) || istype(A, /obj/structure/disposalconstruct) || istype(A, /obj/structure/c_transit_tube) || istype(A, /obj/structure/c_transit_tube_pod)))
 				return ..()
 			to_chat(user, "<span class='notice'>You start destroying a pipe...</span>")
@@ -358,6 +360,7 @@ GLOBAL_LIST_INIT(transit_tube_recipes, list(
 					activate()
 					var/obj/item/pipe_meter/PM = new /obj/item/pipe_meter(get_turf(A))
 					PM.setAttachLayer(temp_piping_layer)
+					PM.wrench_act(user, src)
 			else
 				to_chat(user, "<span class='notice'>You start building a pipe...</span>")
 				if(do_after(user, 2, target = A))
@@ -374,7 +377,8 @@ GLOBAL_LIST_INIT(transit_tube_recipes, list(
 					P.add_fingerprint(usr)
 					P.setPipingLayer(temp_piping_layer)
 					P.add_atom_colour(GLOB.pipe_paint_colors[paint_color], FIXED_COLOUR_PRIORITY)
-			
+					P.wrench_act(user, src)
+
 		if(DISPOSALS_MODE) //Making disposals pipes
 			if(!can_make_pipe)
 				return ..()

--- a/code/game/objects/items/RPD.dm
+++ b/code/game/objects/items/RPD.dm
@@ -194,6 +194,7 @@ GLOBAL_LIST_INIT(transit_tube_recipes, list(
 	var/static/datum/pipe_info/first_atmos
 	var/static/datum/pipe_info/first_disposal
 	var/static/datum/pipe_info/first_transit
+	var/autowrench = FALSE
 
 /obj/item/pipe_dispenser/New()
 	. = ..()
@@ -340,8 +341,6 @@ GLOBAL_LIST_INIT(transit_tube_recipes, list(
 			return
 
 		if(EATING_MODE) //Eating pipes
-			if(istype(A, /obj/machinery/atmospherics))
-				A = A.wrench_act(user, src)
 			if(!(istype(A, /obj/item/pipe) || istype(A, /obj/item/pipe_meter) || istype(A, /obj/structure/disposalconstruct) || istype(A, /obj/structure/c_transit_tube) || istype(A, /obj/structure/c_transit_tube_pod)))
 				return ..()
 			to_chat(user, "<span class='notice'>You start destroying a pipe...</span>")
@@ -360,7 +359,8 @@ GLOBAL_LIST_INIT(transit_tube_recipes, list(
 					activate()
 					var/obj/item/pipe_meter/PM = new /obj/item/pipe_meter(get_turf(A))
 					PM.setAttachLayer(temp_piping_layer)
-					PM.wrench_act(user, src)
+					if(autowrench)
+						PM.wrench_act(user, src)
 			else
 				to_chat(user, "<span class='notice'>You start building a pipe...</span>")
 				if(do_after(user, 2, target = A))
@@ -377,7 +377,8 @@ GLOBAL_LIST_INIT(transit_tube_recipes, list(
 					P.add_fingerprint(usr)
 					P.setPipingLayer(temp_piping_layer)
 					P.add_atom_colour(GLOB.pipe_paint_colors[paint_color], FIXED_COLOUR_PRIORITY)
-					P.wrench_act(user, src)
+					if(autowrench)
+						P.wrench_act(user, src)
 
 		if(DISPOSALS_MODE) //Making disposals pipes
 			if(!can_make_pipe)
@@ -430,6 +431,11 @@ GLOBAL_LIST_INIT(transit_tube_recipes, list(
 		else
 			return ..()
 
+/obj/item/pipe_dispenser/AltClick(mob/living/user)
+	if(!istype(user) || !user.canUseTopic(src, BE_CLOSE, ismonkey(user)))
+		return
+	autowrench = !autowrench
+	to_chat(user, "<span class='notice'>You [autowrench ? "enable" : "disable"] auto wrenching.</span>")
 
 /obj/item/pipe_dispenser/proc/activate()
 	playsound(get_turf(src), 'sound/items/deconstruct.ogg', 50, 1)

--- a/code/modules/atmospherics/machinery/atmosmachinery.dm
+++ b/code/modules/atmospherics/machinery/atmosmachinery.dm
@@ -218,7 +218,7 @@ Pipelines + Other Objects -> Pipe network
 		//You unwrenched a pipe full of pressure? Let's splat you into the wall, silly.
 		if(unsafe_wrenching)
 			unsafe_pressure_release(user, internal_pressure)
-		return deconstruct(TRUE)
+		deconstruct(TRUE)
 	return TRUE
 
 /obj/machinery/atmospherics/proc/can_unwrench(mob/user)
@@ -251,7 +251,6 @@ Pipelines + Other Objects -> Pipe network
 			if(!disassembled)
 				stored.obj_integrity = stored.max_integrity * 0.5
 			transfer_fingerprints_to(stored)
-			. = stored
 	..()
 
 /obj/machinery/atmospherics/proc/getpipeimage(iconset, iconstate, direction, col=rgb(255,255,255))

--- a/code/modules/atmospherics/machinery/atmosmachinery.dm
+++ b/code/modules/atmospherics/machinery/atmosmachinery.dm
@@ -218,7 +218,7 @@ Pipelines + Other Objects -> Pipe network
 		//You unwrenched a pipe full of pressure? Let's splat you into the wall, silly.
 		if(unsafe_wrenching)
 			unsafe_pressure_release(user, internal_pressure)
-		deconstruct(TRUE)
+		return deconstruct(TRUE)
 	return TRUE
 
 /obj/machinery/atmospherics/proc/can_unwrench(mob/user)
@@ -251,6 +251,7 @@ Pipelines + Other Objects -> Pipe network
 			if(!disassembled)
 				stored.obj_integrity = stored.max_integrity * 0.5
 			transfer_fingerprints_to(stored)
+			. = stored
 	..()
 
 /obj/machinery/atmospherics/proc/getpipeimage(iconset, iconstate, direction, col=rgb(255,255,255))


### PR DESCRIPTION
:cl:
add: RPD can automaticaly wrench printed pipes to floor.
/:cl:

[why]: i like pipes.
helps build with wind and singulo pulls,
removes the need for pipe pixel hunting.

![ezgif com-video-to-gif](https://user-images.githubusercontent.com/7734424/37308648-5ada4c40-2647-11e8-9c1c-f2d44efe4358.gif)
