### PR TITLE
Pubbystation: Tweaks/fixes v4

### DIFF
--- a/_maps/map_files/PubbyStation/PubbyStation.dmm
+++ b/_maps/map_files/PubbyStation/PubbyStation.dmm
@@ -1806,6 +1806,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/effect/mapping_helpers/airlock/cyclelink_helper,
+/obj/effect/turf_decal/delivery,
 /turf/open/floor/plasteel/vault,
 /area/security/prison)
 "agA" = (
@@ -1825,6 +1826,7 @@
 	name = "Cell 1"
 	},
 /obj/effect/mapping_helpers/airlock/cyclelink_helper,
+/obj/effect/turf_decal/delivery,
 /turf/open/floor/plasteel/vault,
 /area/security/prison)
 "agC" = (
@@ -2625,6 +2627,10 @@
 /area/security/armory)
 "ain" = (
 /obj/machinery/atmospherics/pipe/simple/cyan/hidden,
+/obj/machinery/light_switch{
+	dir = 9;
+	pixel_x = -22
+	},
 /turf/open/floor/plasteel/showroomfloor,
 /area/security/main)
 "aio" = (
@@ -3076,7 +3082,7 @@
 /turf/open/floor/plasteel/red,
 /area/security/main)
 "ajr" = (
-/obj/item/reagent_containers/food/snacks/donut,
+/obj/item/reagent_containers/food/snacks/donut/chaos,
 /turf/open/floor/plating,
 /area/crew_quarters/heads/hos)
 "ajs" = (
@@ -3401,6 +3407,12 @@
 	departmentType = 5;
 	name = "Head of Security RC";
 	pixel_y = 30
+	},
+/obj/machinery/button/door{
+	id = "hos_spess_shutters";
+	name = "Space shutters";
+	pixel_x = 24;
+	req_access_txt = "1"
 	},
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/heads/hos)
@@ -3803,13 +3815,6 @@
 /turf/open/floor/plasteel/darkred/side,
 /area/crew_quarters/heads/hos)
 "akX" = (
-/turf/open/floor/plasteel/darkred/side,
-/area/crew_quarters/heads/hos)
-"akY" = (
-/obj/machinery/keycard_auth{
-	pixel_x = 28;
-	pixel_y = 28
-	},
 /turf/open/floor/plasteel/darkred/side,
 /area/crew_quarters/heads/hos)
 "akZ" = (
@@ -4699,6 +4704,10 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/cyan/hidden,
+/obj/machinery/light_switch{
+	dir = 9;
+	pixel_x = -22
+	},
 /turf/open/floor/plasteel/red/side{
 	dir = 8
 	},
@@ -5022,10 +5031,8 @@
 /obj/structure/cable{
 	icon_state = "1-4"
 	},
-/obj/machinery/button/door{
-	id = "hos_spess_shutters";
-	pixel_y = -26;
-	req_access_txt = "1"
+/obj/machinery/keycard_auth{
+	pixel_y = -24
 	},
 /turf/open/floor/plasteel/darkred/side{
 	dir = 1
@@ -5478,6 +5485,9 @@
 /area/security/warden)
 "aoY" = (
 /obj/structure/filingcabinet/chestdrawer,
+/obj/machinery/light_switch{
+	pixel_y = -22
+	},
 /turf/open/floor/plasteel/showroomfloor,
 /area/security/warden)
 "aoZ" = (
@@ -7017,13 +7027,13 @@
 	icon_state = "2-8"
 	},
 /obj/machinery/keycard_auth{
-	pixel_x = -28;
-	pixel_y = 9
+	pixel_x = -24;
+	pixel_y = 10
 	},
 /obj/machinery/button/door{
-	id = "bridge blast";
-	name = "Bridge Entrance Lockdown";
-	pixel_x = -28;
+	id = "bridgespace";
+	name = "Bridge Space Lockdown";
+	pixel_x = -24;
 	pixel_y = -2;
 	req_access_txt = "19"
 	},
@@ -7050,14 +7060,7 @@
 /obj/machinery/button/door{
 	id = "bridgespace";
 	name = "Bridge Space Lockdown";
-	pixel_x = 28;
-	pixel_y = 8;
-	req_access_txt = "19"
-	},
-/obj/machinery/button/door{
-	id = "bridge blast";
-	name = "Bridge Entrance Lockdown";
-	pixel_x = 28;
+	pixel_x = 24;
 	pixel_y = -2;
 	req_access_txt = "19"
 	},
@@ -7819,6 +7822,7 @@
 	id = "bridgespace";
 	name = "bridge external shutters"
 	},
+/obj/effect/turf_decal/delivery,
 /turf/open/floor/plasteel/dark,
 /area/bridge)
 "auL" = (
@@ -7827,6 +7831,7 @@
 	name = "bridge external shutters"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/effect/turf_decal/delivery,
 /turf/open/floor/plasteel/dark,
 /area/bridge)
 "auM" = (
@@ -9226,6 +9231,7 @@
 	id = "bridgespace";
 	name = "bridge external shutters"
 	},
+/obj/effect/turf_decal/delivery,
 /turf/open/floor/plasteel/vault{
 	dir = 8
 	},
@@ -9585,6 +9591,10 @@
 	icon_state = "2-4"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/machinery/light_switch{
+	dir = 9;
+	pixel_x = -22
+	},
 /turf/open/floor/plasteel/darkblue/side{
 	dir = 8
 	},
@@ -10134,6 +10144,10 @@
 "aAp" = (
 /obj/structure/table/wood,
 /obj/item/device/flashlight/lamp/green,
+/obj/machinery/light_switch{
+	dir = 9;
+	pixel_x = -22
+	},
 /turf/open/floor/plasteel/grimy,
 /area/crew_quarters/heads/captain)
 "aAq" = (
@@ -10200,6 +10214,13 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/machinery/button/door{
+	id = "bridge blast";
+	name = "Bridge Entrance Lockdown";
+	pixel_x = -24;
+	pixel_y = -2;
+	req_access_txt = "19"
+	},
 /turf/open/floor/plasteel/darkblue/side{
 	dir = 8
 	},
@@ -10239,6 +10260,13 @@
 	},
 /obj/structure/cable{
 	icon_state = "2-8"
+	},
+/obj/machinery/button/door{
+	id = "bridge blast";
+	name = "Bridge Entrance Lockdown";
+	pixel_x = 24;
+	pixel_y = -2;
+	req_access_txt = "19"
 	},
 /turf/open/floor/plasteel/darkblue/side{
 	dir = 4
@@ -10845,6 +10873,10 @@
 /obj/item/twohanded/required/kirbyplants{
 	icon_state = "plant-18";
 	pixel_y = 12
+	},
+/obj/machinery/light_switch{
+	dir = 9;
+	pixel_x = -22
 	},
 /turf/open/floor/plasteel/grimy,
 /area/security/detectives_office)
@@ -12941,6 +12973,7 @@
 	name = "Bridge";
 	req_access_txt = "19"
 	},
+/obj/effect/turf_decal/delivery,
 /turf/open/floor/plasteel/vault,
 /area/bridge)
 "aHe" = (
@@ -12957,6 +12990,7 @@
 	name = "Bridge";
 	req_access_txt = "19"
 	},
+/obj/effect/turf_decal/delivery,
 /turf/open/floor/plasteel/vault,
 /area/bridge)
 "aHf" = (
@@ -12981,6 +13015,7 @@
 	name = "Bridge";
 	req_access_txt = "19"
 	},
+/obj/effect/turf_decal/delivery,
 /turf/open/floor/plasteel/vault,
 /area/bridge)
 "aHh" = (
@@ -15248,6 +15283,10 @@
 /obj/item/storage/toolbox/artistic{
 	pixel_x = -3
 	},
+/obj/machinery/light_switch{
+	dir = 9;
+	pixel_x = -22
+	},
 /turf/open/floor/plasteel/redblue,
 /area/storage/art)
 "aMW" = (
@@ -15275,6 +15314,10 @@
 "aMY" = (
 /obj/structure/chair{
 	dir = 1
+	},
+/obj/machinery/light_switch{
+	dir = 9;
+	pixel_x = -22
 	},
 /turf/open/floor/plasteel/cafeteria,
 /area/crew_quarters/cafeteria/lunchroom)
@@ -16112,6 +16155,10 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on,
 /obj/structure/cable{
 	icon_state = "1-2"
+	},
+/obj/machinery/light_switch{
+	dir = 9;
+	pixel_x = -22
 	},
 /turf/open/floor/plasteel/floorgrime,
 /area/quartermaster/warehouse)
@@ -18667,6 +18714,9 @@
 	pixel_x = 2;
 	pixel_y = 4
 	},
+/obj/machinery/light_switch{
+	pixel_y = 22
+	},
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/bar)
 "aVi" = (
@@ -19418,8 +19468,7 @@
 	dir = 8
 	},
 /obj/machinery/light_switch{
-	pixel_x = -4;
-	pixel_y = 30
+	pixel_y = 22
 	},
 /turf/open/floor/plasteel/green/corner{
 	dir = 4
@@ -21923,6 +21972,10 @@
 	dir = 4;
 	pixel_x = 11
 	},
+/obj/machinery/light_switch{
+	dir = 9;
+	pixel_x = 22
+	},
 /turf/open/floor/plasteel/floorgrime,
 /area/janitor)
 "bdj" = (
@@ -24371,7 +24424,7 @@
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/machinery/door/airlock{
-	name = "Port Emergency Storage";
+	name = "Port Emergency Storage"
 	},
 /turf/open/floor/plasteel/freezer,
 /area/storage/emergency/port)
@@ -25822,6 +25875,9 @@
 /obj/item/folder/white,
 /obj/item/clothing/gloves/color/latex,
 /obj/item/storage/fancy/candle_box,
+/obj/machinery/light_switch{
+	pixel_x = 22
+	},
 /turf/open/floor/plasteel/dark,
 /area/medical/morgue)
 "bnA" = (
@@ -26003,6 +26059,7 @@
 	},
 /obj/machinery/door/firedoor/heavy,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/effect/turf_decal/delivery,
 /turf/open/floor/engine,
 /area/science/explab)
 "bnY" = (
@@ -27542,7 +27599,7 @@
 /obj/item/storage/toolbox/mechanical,
 /obj/machinery/holopad,
 /obj/machinery/light_switch{
-	pixel_x = 25
+	pixel_x = 22
 	},
 /turf/open/floor/plasteel/whitepurple/side{
 	dir = 1
@@ -27651,6 +27708,9 @@
 /area/science/robotics/lab)
 "brD" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on,
+/obj/machinery/light_switch{
+	pixel_x = -22
+	},
 /turf/open/floor/plasteel/dark,
 /area/science/server)
 "brE" = (
@@ -27672,7 +27732,7 @@
 	name = "Connector Port (Air Supply)"
 	},
 /obj/machinery/light_switch{
-	pixel_x = -25
+	pixel_x = -22
 	},
 /turf/open/floor/plasteel/white,
 /area/science/explab)
@@ -28937,6 +28997,9 @@
 	},
 /obj/item/twohanded/required/kirbyplants{
 	icon_state = "plant-14"
+	},
+/obj/machinery/light_switch{
+	pixel_x = -22
 	},
 /turf/open/floor/plasteel/white,
 /area/science/xenobiology)
@@ -30756,6 +30819,9 @@
 /obj/machinery/light{
 	dir = 4
 	},
+/obj/machinery/light_switch{
+	pixel_x = 22
+	},
 /turf/open/floor/plasteel/whitepurple/side{
 	dir = 4
 	},
@@ -30846,6 +30912,9 @@
 /obj/machinery/door/poddoor/preopen{
 	id = "cmoshutters";
 	name = "Privacy shutters"
+	},
+/obj/structure/cable{
+	icon_state = "0-2"
 	},
 /turf/open/floor/plating,
 /area/crew_quarters/heads/cmo)
@@ -31654,6 +31723,9 @@
 /area/crew_quarters/heads/cmo)
 "bzZ" = (
 /obj/machinery/suit_storage_unit/cmo,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
 /turf/open/floor/plasteel/cmo,
 /area/crew_quarters/heads/cmo)
 "bAa" = (
@@ -31672,6 +31744,9 @@
 /area/crew_quarters/heads/cmo)
 "bAb" = (
 /obj/machinery/computer/med_data,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
 /turf/open/floor/plasteel/cmo,
 /area/crew_quarters/heads/cmo)
 "bAc" = (
@@ -31694,12 +31769,18 @@
 	pixel_x = 38;
 	req_access_txt = "40"
 	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
 /turf/open/floor/plasteel/cmo,
 /area/crew_quarters/heads/cmo)
 "bAe" = (
 /obj/structure/closet/wardrobe/chemistry_white,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 5
+	},
+/obj/machinery/light_switch{
+	pixel_y = -22
 	},
 /turf/open/floor/plasteel/whiteyellow/side{
 	dir = 10
@@ -31802,10 +31883,10 @@
 	id = "rdprivacy";
 	name = "Privacy shutters"
 	},
-/turf/open/floor/plasteel/darkpurple/side{
-	icon_state = "darkpurple";
-	dir = 9
+/obj/structure/cable{
+	icon_state = "0-4"
 	},
+/turf/open/floor/plating,
 /area/crew_quarters/heads/hor)
 "bAp" = (
 /obj/structure/cable{
@@ -31819,6 +31900,12 @@
 	name = "Research Director's Office";
 	req_access_txt = "30"
 	},
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
 /turf/open/floor/plasteel/darkpurple/side{
 	dir = 1
 	},
@@ -31829,9 +31916,13 @@
 	id = "rdprivacy";
 	name = "Privacy shutters"
 	},
-/turf/open/floor/plasteel/darkpurple/side{
-	dir = 1
+/obj/structure/cable{
+	icon_state = "0-8"
 	},
+/obj/structure/cable{
+	icon_state = "0-4"
+	},
+/turf/open/floor/plating,
 /area/crew_quarters/heads/hor)
 "bAr" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -31840,20 +31931,13 @@
 	id = "rdprivacy";
 	name = "Privacy shutters"
 	},
-/turf/open/floor/plasteel/darkpurple/side{
-	dir = 1
+/obj/structure/cable{
+	icon_state = "0-8"
 	},
-/area/crew_quarters/heads/hor)
-"bAs" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/door/poddoor/shutters/preopen{
-	id = "rdprivacy";
-	name = "Privacy shutters"
+/obj/structure/cable{
+	icon_state = "0-4"
 	},
-/turf/open/floor/plasteel/darkpurple/side{
-	icon_state = "darkpurple";
-	dir = 5
-	},
+/turf/open/floor/plating,
 /area/crew_quarters/heads/hor)
 "bAt" = (
 /obj/effect/spawner/structure/window/reinforced,
@@ -32129,9 +32213,21 @@
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "bBg" = (
+/obj/structure/cable{
+	icon_state = "2-4"
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
 /turf/open/floor/plasteel/cmo,
 /area/crew_quarters/heads/cmo)
 "bBh" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
 /mob/living/simple_animal/pet/cat/Runtime,
 /turf/open/floor/plasteel/cmo,
 /area/crew_quarters/heads/cmo)
@@ -32143,11 +32239,20 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 4
 	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
 /turf/open/floor/plasteel/cmo,
 /area/crew_quarters/heads/cmo)
 "bBj" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel/cmo,
 /area/crew_quarters/heads/cmo)
@@ -32167,6 +32272,12 @@
 	name = "Surgery Telescreen";
 	network = list("surgery");
 	pixel_x = 30
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/structure/cable{
+	icon_state = "2-8"
 	},
 /turf/open/floor/plasteel/cmo,
 /area/crew_quarters/heads/cmo)
@@ -32262,13 +32373,13 @@
 	pixel_y = -5;
 	req_access_txt = "47"
 	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
 /turf/open/floor/plasteel/darkpurple/side{
 	icon_state = "darkpurple";
 	dir = 4
 	},
-/area/crew_quarters/heads/hor)
-"bBv" = (
-/turf/closed/wall,
 /area/crew_quarters/heads/hor)
 "bBw" = (
 /obj/machinery/computer/security,
@@ -32673,6 +32784,9 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 10
 	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
 /turf/open/floor/plasteel/cmo,
 /area/crew_quarters/heads/cmo)
 "bCs" = (
@@ -32717,6 +32831,9 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 5
+	},
+/obj/structure/cable{
+	icon_state = "1-4"
 	},
 /turf/open/floor/plasteel/cmo,
 /area/crew_quarters/heads/cmo)
@@ -32849,6 +32966,9 @@
 	dir = 4;
 	light_color = "#c1caff"
 	},
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
 /turf/open/floor/plasteel/darkpurple/side{
 	icon_state = "darkpurple";
 	dir = 4
@@ -32859,6 +32979,12 @@
 /obj/machinery/door/poddoor/shutters/preopen{
 	id = "rdprivacy";
 	name = "Privacy shutters"
+	},
+/obj/structure/cable{
+	icon_state = "0-8"
+	},
+/obj/structure/cable{
+	icon_state = "0-2"
 	},
 /turf/open/floor/plating,
 /area/crew_quarters/heads/hor)
@@ -33109,6 +33235,9 @@
 "bDt" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 5
+	},
+/obj/structure/cable{
+	icon_state = "1-8"
 	},
 /turf/open/floor/plasteel/cmo,
 /area/crew_quarters/heads/cmo)
@@ -33681,6 +33810,9 @@
 /obj/item/twohanded/required/kirbyplants{
 	icon_state = "plant-16"
 	},
+/obj/machinery/light_switch{
+	pixel_y = -22
+	},
 /turf/open/floor/plasteel/cmo,
 /area/crew_quarters/heads/cmo)
 "bEI" = (
@@ -33799,6 +33931,9 @@
 	dir = 0;
 	name = "Station Intercom (General)";
 	pixel_y = -26
+	},
+/obj/machinery/light_switch{
+	pixel_x = -22
 	},
 /turf/open/floor/plasteel/darkpurple/side{
 	icon_state = "darkpurple";
@@ -34034,6 +34169,9 @@
 	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
+	},
+/obj/machinery/light_switch{
+	pixel_x = 22
 	},
 /turf/open/floor/plasteel/vault{
 	dir = 5
@@ -34401,6 +34539,9 @@
 /obj/effect/decal/cleanable/blood/drip,
 /obj/item/restraints/handcuffs,
 /obj/item/clothing/mask/muzzle,
+/obj/machinery/light_switch{
+	pixel_y = -22
+	},
 /turf/open/floor/plasteel/dark,
 /area/medical/exam_room)
 "bFY" = (
@@ -34778,6 +34919,9 @@
 	icon_state = "0-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/cyan/hidden,
+/obj/machinery/light_switch{
+	pixel_x = 22
+	},
 /turf/open/floor/plasteel/whitegreen/side{
 	dir = 5
 	},
@@ -35101,7 +35245,7 @@
 	},
 /obj/machinery/light_switch{
 	dir = 8;
-	pixel_x = -20
+	pixel_x = -22
 	},
 /turf/open/floor/plasteel,
 /area/science/mixing)
@@ -35285,6 +35429,9 @@
 /area/medical/medbay/central)
 "bIf" = (
 /obj/structure/closet/wardrobe/white/medical,
+/obj/machinery/light_switch{
+	pixel_y = -22
+	},
 /turf/open/floor/plasteel/whiteblue/side,
 /area/medical/medbay/central)
 "bIg" = (
@@ -35567,6 +35714,9 @@
 "bIJ" = (
 /obj/structure/cable{
 	icon_state = "1-8"
+	},
+/obj/machinery/light_switch{
+	pixel_y = -22
 	},
 /turf/open/floor/engine,
 /area/science/storage)
@@ -36057,7 +36207,7 @@
 /obj/machinery/light/small{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
 /turf/open/floor/engine,
@@ -36779,6 +36929,9 @@
 /obj/item/clothing/neck/stethoscope{
 	layer = 3.2
 	},
+/obj/machinery/light_switch{
+	pixel_x = -22
+	},
 /turf/open/floor/plasteel/freezer,
 /area/medical/medbay/central)
 "bLG" = (
@@ -36834,6 +36987,9 @@
 /obj/item/clothing/gloves/color/latex,
 /obj/item/clothing/mask/surgical,
 /obj/item/clothing/suit/apron/surgical,
+/obj/machinery/light_switch{
+	pixel_x = -22
+	},
 /turf/open/floor/plasteel/whiteblue/side{
 	dir = 8
 	},
@@ -41180,8 +41336,7 @@
 	},
 /area/maintenance/department/engine)
 "bWn" = (
-/obj/structure/closet/secure_closet/engineering_chief{
-	},
+/obj/structure/closet/secure_closet/engineering_chief,
 /obj/structure/extinguisher_cabinet{
 	pixel_x = -27
 	},
@@ -41212,6 +41367,10 @@
 "bWr" = (
 /obj/machinery/modular_computer/console/preset/engineering{
 	dir = 8
+	},
+/obj/machinery/light_switch{
+	dir = 2;
+	pixel_x = 22
 	},
 /turf/open/floor/plasteel/yellow/side{
 	dir = 4
@@ -41583,6 +41742,13 @@
 /obj/machinery/light_switch{
 	pixel_x = 25
 	},
+/obj/machinery/button/door{
+	desc = "A remote control-switch for secure storage.";
+	id = "ce_privacy";
+	name = "Privacy Shutters";
+	pixel_x = 24;
+	req_access_txt = "11"
+	},
 /turf/open/floor/plasteel/yellow/side{
 	dir = 6
 	},
@@ -41855,11 +42021,28 @@
 /area/maintenance/department/engine)
 "bXY" = (
 /obj/effect/spawner/structure/window/reinforced,
+/obj/structure/cable{
+	icon_state = "0-4"
+	},
+/obj/machinery/door/poddoor/preopen{
+	id = "ce_privacy";
+	name = "Privacy shutters"
+	},
 /turf/open/floor/plating,
 /area/crew_quarters/heads/chief)
 "bXZ" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/structure/cable{
+	icon_state = "0-8"
+	},
+/obj/structure/cable{
+	icon_state = "0-4"
+	},
+/obj/machinery/door/poddoor/preopen{
+	id = "ce_privacy";
+	name = "Privacy shutters"
+	},
 /turf/open/floor/plating,
 /area/crew_quarters/heads/chief)
 "bYa" = (
@@ -41872,6 +42055,12 @@
 	},
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
+/obj/structure/cable{
+	icon_state = "2-4"
+	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/heads/chief)
 "bYb" = (
@@ -46580,6 +46769,10 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
+/obj/structure/sign/warning{
+	name = "\improper DANGER: NITROGEN ATMOSPHERE";
+	pixel_x = 32
+	},
 /turf/open/floor/plasteel/vault{
 	dir = 5
 	},
@@ -47317,12 +47510,12 @@
 	id = "kitchenshutters";
 	name = "Kitchen Shutters Control";
 	pixel_x = 5;
-	pixel_y = -26;
+	pixel_y = -24;
 	req_access_txt = "28"
 	},
 /obj/machinery/light_switch{
 	pixel_x = -6;
-	pixel_y = -25
+	pixel_y = -24
 	},
 /turf/open/floor/plasteel/cafeteria,
 /area/crew_quarters/kitchen)
@@ -49941,9 +50134,6 @@
 "cCt" = (
 /turf/open/floor/plasteel/white,
 /area/science/lab)
-"cCA" = (
-/turf/closed/wall,
-/area/science/lab)
 "cCB" = (
 /obj/effect/turf_decal/loading_area{
 	dir = 8
@@ -50057,7 +50247,7 @@
 /turf/open/floor/plasteel,
 /area/quartermaster/sorting)
 "dAF" = (
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/visible{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -50114,6 +50304,15 @@
 	dir = 1
 	},
 /area/science/circuit)
+"eQR" = (
+/obj/effect/spawner/lootdrop/two_percent_xeno_egg_spawner,
+/turf/open/floor/engine,
+/area/science/xenobiology)
+"fon" = (
+/obj/structure/lattice,
+/obj/structure/grille,
+/turf/open/space/basic,
+/area/space/nearstation)
 "fvG" = (
 /turf/open/floor/plasteel/whitepurple/side{
 	dir = 6
@@ -50142,6 +50341,15 @@
 /obj/machinery/door/firedoor/heavy,
 /turf/open/floor/plasteel,
 /area/science/mixing)
+"fIW" = (
+/obj/machinery/light_switch{
+	dir = 9;
+	pixel_x = -22
+	},
+/turf/open/floor/plating{
+	icon_state = "platingdmg3"
+	},
+/area/maintenance/department/crew_quarters/dorms)
 "fKj" = (
 /turf/closed/wall,
 /area/science/circuit)
@@ -50177,6 +50385,10 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/closed/wall/r_wall,
 /area/science/mixing)
+"gYo" = (
+/obj/structure/grille,
+/turf/open/space/basic,
+/area/space/nearstation)
 "htU" = (
 /obj/machinery/rnd/production/protolathe/department/science,
 /turf/open/floor/plasteel/purple/side{
@@ -50406,10 +50618,16 @@
 	id = "bridgespace";
 	name = "bridge external shutters"
 	},
+/obj/effect/turf_decal/delivery,
 /turf/open/floor/plasteel/vault{
 	dir = 8
 	},
 /area/bridge)
+"mau" = (
+/obj/structure/lattice,
+/obj/structure/grille/broken,
+/turf/open/space/basic,
+/area/space/nearstation)
 "mdL" = (
 /obj/structure/table,
 /obj/item/stock_parts/matter_bin,
@@ -50572,6 +50790,17 @@
 	dir = 8
 	},
 /area/science/circuit)
+"qGZ" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/cable{
+	icon_state = "0-8"
+	},
+/obj/machinery/door/poddoor/preopen{
+	id = "ce_privacy";
+	name = "Privacy shutters"
+	},
+/turf/open/floor/plating,
+/area/crew_quarters/heads/chief)
 "qKm" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
@@ -50664,7 +50893,7 @@
 /turf/closed/wall/r_wall,
 /area/maintenance/disposal/incinerator)
 "tYg" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
 /turf/closed/wall/r_wall,
@@ -50705,6 +50934,15 @@
 	dir = 1
 	},
 /area/science/circuit)
+"upI" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "rdprivacy";
+	name = "Privacy shutters"
+	},
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/crew_quarters/heads/hor)
 "uyY" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 8
@@ -50750,7 +50988,7 @@
 	},
 /obj/machinery/light_switch{
 	dir = 8;
-	pixel_x = -20
+	pixel_x = -22
 	},
 /turf/open/floor/plasteel,
 /area/science/circuit)
@@ -50804,6 +51042,17 @@
 	},
 /turf/open/space,
 /area/space/nearstation)
+"wLo" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/door/poddoor/preopen{
+	id = "cmoshutters";
+	name = "Privacy shutters"
+	},
+/obj/structure/cable{
+	icon_state = "0-4"
+	},
+/turf/open/floor/plating,
+/area/crew_quarters/heads/cmo)
 "wTO" = (
 /obj/machinery/vending/assist,
 /turf/open/floor/plasteel/purple/corner{
@@ -78430,7 +78679,7 @@ aaa
 abI
 ajs
 ake
-akY
+akX
 alM
 amz
 ank
@@ -79781,9 +80030,9 @@ bvo
 bwN
 byu
 bzY
-byv
+wLo
 bCq
-byv
+wLo
 bzY
 bFU
 bFU
@@ -80062,7 +80311,7 @@ bUM
 bVH
 bWr
 bXj
-bXY
+qGZ
 bYM
 bZB
 caj
@@ -85434,7 +85683,7 @@ bus
 bvz
 bxg
 mdL
-bAs
+bCJ
 bBu
 bCI
 bDF
@@ -85691,11 +85940,11 @@ cCl
 bqb
 bxh
 bqb
-cCA
-bBv
+cCl
+bBp
 bCJ
-bCJ
-bBv
+upI
+bBp
 bBp
 bHm
 bIy
@@ -87933,7 +88182,7 @@ aaa
 aaa
 aiT
 cBk
-aju
+fIW
 cBo
 alQ
 alb
@@ -89838,7 +90087,7 @@ cdj
 bYw
 bYw
 aaa
-aaa
+gYo
 aaa
 aaa
 aaa
@@ -90094,8 +90343,8 @@ thA
 cdk
 ced
 bYw
-aaa
-aaa
+aht
+fon
 aaa
 aaa
 aaa
@@ -90352,7 +90601,7 @@ cdl
 bYw
 bYw
 aaa
-aaa
+mau
 aaa
 aaa
 aaa
@@ -90608,8 +90857,8 @@ ccs
 cdm
 cdm
 bYw
-aaa
-aaa
+aht
+fon
 aaa
 aaa
 aaa
@@ -94161,7 +94410,7 @@ aaa
 aEj
 aTx
 bkF
-blX
+eQR
 bne
 blX
 bkF
@@ -95469,10 +95718,10 @@ vMX
 bLj
 bIS
 lJr
-aaa
-aaa
-aaa
-aaa
+aht
+aht
+aht
+fon
 aaa
 aaa
 aaa
@@ -95726,10 +95975,10 @@ bJW
 bLk
 xfc
 lJr
+aht
 aaa
 aaa
-aaa
-aaa
+fon
 aaa
 aaa
 aaa
@@ -95983,10 +96232,10 @@ bJX
 bLl
 xfc
 lJr
-aaa
-aaa
-aaa
-aaa
+aht
+aht
+aht
+fon
 aaa
 aaa
 aaa
@@ -96241,9 +96490,9 @@ bLm
 lpS
 gxK
 gxK
+aht
 aaa
-aaa
-aaa
+gYo
 aaa
 aaa
 aaa
@@ -96755,10 +97004,10 @@ yeS
 mES
 qnT
 lJr
-aaa
-aaa
-aaa
-aaa
+aht
+aht
+aht
+fon
 aaa
 aaa
 aaa
@@ -97012,10 +97261,10 @@ lQn
 mES
 htU
 lJr
+aht
 aaa
 aaa
-aaa
-aaa
+fon
 aaa
 aaa
 aaa
@@ -97269,10 +97518,10 @@ lQn
 mES
 dMI
 lJr
+aht
 aaa
 aaa
-aaa
-aaa
+fon
 aaa
 aaa
 aaa
@@ -97526,10 +97775,10 @@ tYI
 kmh
 oEG
 gxK
-aaa
-aaa
-aaa
-aaa
+aht
+aht
+aht
+mau
 aaa
 aaa
 aaa
@@ -97786,7 +98035,7 @@ gxK
 aaa
 aaa
 aaa
-aaa
+gYo
 aaa
 aaa
 aaa
@@ -98040,9 +98289,9 @@ lQn
 lQn
 dWy
 gxK
-aaa
-aaa
-aaa
+aht
+fon
+aht
 aaa
 aaa
 aaa
@@ -98298,7 +98547,7 @@ fvG
 rtE
 lJr
 aaa
-aaa
+fon
 aaa
 aaa
 aaa
@@ -98554,8 +98803,8 @@ gAj
 rtE
 lJr
 lJr
-aaa
-aaa
+aht
+fon
 aaa
 aaa
 aaa
@@ -98800,19 +99049,19 @@ aEj
 aEj
 abI
 aaa
+aht
 aaa
 aaa
-aaa
-aaa
+aht
 gxK
 gxK
 gxK
 lJr
 lJr
 lJr
+aht
 aaa
-aaa
-aaa
+fon
 aaa
 aaa
 aaa
@@ -99061,13 +99310,13 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+aht
+aht
+aht
+aht
+aht
+aht
+aht
 aaa
 aaa
 aaa
@@ -99320,11 +99569,11 @@ aaa
 aaa
 aaa
 aaa
+aht
 aaa
+aht
 aaa
-aaa
-aaa
-aaa
+aht
 aaa
 aaa
 aaa
@@ -99577,12 +99826,12 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+fon
+gYo
+fon
+mau
+gYo
+fon
 aaa
 aaa
 aaa


### PR DESCRIPTION
:cl: Denton
add: Pubbystation: Added protective grilles outside the circuitry lab. The one with the big glass windows, right next to the bomb test site. Oops.
add: Pubby: Added electrified grilles to the windows of the CMO/RD/CE offices, as well as missing privacy shutters to the CE office.
add: Pubby: There is now a very rare chance for a Xenomorph egg to appear in the Xeno containment chamber at roundstart.
fix: Pubby: Fixed the name of the HoS space shutter button.
/:cl:

A bunch of tweaks/additions and two bugfixes for Pubbystation. This time hopefully without dirty vars?

Fixes: 
- Gave the HoS space shutter button the correct name.
- Fixed the visibility of toxins launch chamber scrubber pipes: See [before/after](https://i.imgur.com/YMDAVB8.jpg)

Tweaks:
- Tweaked the positions of the bridge and HoS shutter buttons as well as keycard devices. Door shutters are closer to the doors, space shutters close to you know, space.

Additions:
- Added protective grilles to the exterior of the circuitry lab and incinerator. When I made the lab, I gave it big windows and overlooked that it's next to a god damn bomb test site that launches shrapnel in all directions. Oops. [Screenshot of the grilles](https://i.imgur.com/ODeKzZj.jpg)
- Added missing light switches to rooms all over the station.
- Added electrified grilles to the windows of RD/CMO/CE offices.
- Added missing privacy shutters to the CE office.
- Added turf decals to tiles with blast doors/shutters, plus an atmos warning sign to the tcomms server room.
- Added that spicy 2% spawn rate xeno egg to xenobio containment.
- Added three missing r-wall tiles to the RnD division.


