### PR TITLE
Disables roundstart xenomorphs

### DIFF
--- a/code/game/objects/effects/spawners/lootdrop.dm
+++ b/code/game/objects/effects/spawners/lootdrop.dm
@@ -128,10 +128,8 @@
 	lootcount = 3
 
 /obj/effect/spawner/lootdrop/two_percent_xeno_egg_spawner
-	name = "2% chance xeno egg spawner"
-	loot = list(
-		/obj/effect/decal/remains/xeno = 49,
-		/obj/effect/spawner/xeno_egg_delivery = 1)
+	name = "xeno gibs"
+	loot = list(/obj/effect/decal/remains/xeno = 1)
 
 /obj/effect/spawner/lootdrop/costume
 	name = "random costume spawner"


### PR DESCRIPTION
1. admins always delete the fuckers
2. if admins dont delete the fuckers, it's now going to turn into 30 minutes of people bitching because someone killed the xeno after getting trapped in the pit with it
3. if it doesnt get killed, it's time for an hour of xeno round gameplay where nothing interesting happens
