### PR TITLE
Singularities created with Bags of Holding have a limited lifetime

### DIFF
--- a/code/game/objects/items/storage/backpack.dm
+++ b/code/game/objects/items/storage/backpack.dm
@@ -42,8 +42,14 @@
 	flags_2 = NO_MAT_REDEMPTION_2
 	var/pshoom = 'sound/items/pshoom.ogg'
 	var/alt_sound = 'sound/items/pshoom_2.ogg'
+	var/emagged = FALSE
+	var/obj/singularity/boh/singulo
 	armor = list("melee" = 0, "bullet" = 0, "laser" = 0, "energy" = 0, "bomb" = 0, "bio" = 0, "rad" = 0, "fire" = 60, "acid" = 50)
 
+/obj/item/storage/backpack/holding/examine(mob/user)
+	..()
+	if(emagged)
+		to_chat(user, "A black scorch mark covers the bluespace transceiver")
 
 /obj/item/storage/backpack/holding/suicide_act(mob/living/user)
 	user.visible_message("<span class='suicide'>[user] is jumping into [src]! It looks like [user.p_theyre()] trying to commit suicide.</span>")
@@ -82,7 +88,12 @@
 		investigate_log("has become a singularity. Caused by [user.key]", INVESTIGATE_SINGULO)
 		to_chat(user, "<span class='danger'>The Bluespace interfaces of the two devices catastrophically malfunction!</span>")
 		qdel(W)
-		var/obj/singularity/boh/singulo = new /obj/singularity/boh (get_turf(src))
+
+		if(emagged)
+			singulo = new /obj/singularity/boh/emagged (get_turf(src))
+		else
+			singulo = new /obj/singularity/boh (get_turf(src))
+
 		singulo.energy = 300 //should make it a bit bigger~
 		message_admins("[key_name_admin(user)] detonated a bag of holding")
 		log_game("[key_name(user)] detonated a bag of holding")
@@ -90,6 +101,10 @@
 		singulo.process()
 		return
 	. = ..()
+
+/obj/item/storage/backpack/holding/emag_act(mob/user)
+	emagged = TRUE
+	to_chat(user, "<span class='notice'>You overload the bluespace transceiver.</span>")
 
 /obj/item/storage/backpack/holding/singularity_act(current_size)
 	var/dist = max((current_size - 2),1)

--- a/code/game/objects/items/storage/backpack.dm
+++ b/code/game/objects/items/storage/backpack.dm
@@ -49,7 +49,7 @@
 /obj/item/storage/backpack/holding/examine(mob/user)
 	..()
 	if(emagged)
-		to_chat(user, "A black scorch mark covers the bluespace transceiver")
+		to_chat(user, "A black scorch mark covers the bluespace transceiver.")
 
 /obj/item/storage/backpack/holding/suicide_act(mob/living/user)
 	user.visible_message("<span class='suicide'>[user] is jumping into [src]! It looks like [user.p_theyre()] trying to commit suicide.</span>")
@@ -96,7 +96,7 @@
 		else
 			singulo = new /obj/singularity/boh (get_turf(src))
 
-		singulo.energy = 300 //should make it a bit bigger~
+		singulo.energy = 500 //should make it a bit bigger~
 		message_admins("[key_name_admin(user)] detonated a bag of holding")
 		log_game("[key_name(user)] detonated a bag of holding")
 		qdel(src)

--- a/code/game/objects/items/storage/backpack.dm
+++ b/code/game/objects/items/storage/backpack.dm
@@ -84,6 +84,8 @@
 		qdel(W)
 		var/obj/singularity/singulo = new /obj/singularity (get_turf(src))
 		singulo.energy = 300 //should make it a bit bigger~
+		singulo.dissipate_delay = 1 //make the singularity last less
+		singulo.dissipate_strength = 50
 		message_admins("[key_name_admin(user)] detonated a bag of holding")
 		log_game("[key_name(user)] detonated a bag of holding")
 		qdel(src)

--- a/code/game/objects/items/storage/backpack.dm
+++ b/code/game/objects/items/storage/backpack.dm
@@ -76,6 +76,8 @@
 	return 0
 
 /obj/item/storage/backpack/holding/handle_item_insertion(obj/item/W, prevent_warning = 0, mob/living/user)
+	if(istype(W, /obj/item/card/emag))
+		emag_act(user)
 	if((istype(W, /obj/item/storage/backpack/holding) || count_by_type(W.GetAllContents(), /obj/item/storage/backpack/holding)))
 		var/turf/loccheck = get_turf(src)
 		if(is_reebe(loccheck.z))

--- a/code/game/objects/items/storage/backpack.dm
+++ b/code/game/objects/items/storage/backpack.dm
@@ -82,10 +82,8 @@
 		investigate_log("has become a singularity. Caused by [user.key]", INVESTIGATE_SINGULO)
 		to_chat(user, "<span class='danger'>The Bluespace interfaces of the two devices catastrophically malfunction!</span>")
 		qdel(W)
-		var/obj/singularity/singulo = new /obj/singularity (get_turf(src))
+		var/obj/singularity/boh/singulo = new /obj/singularity/boh (get_turf(src))
 		singulo.energy = 300 //should make it a bit bigger~
-		singulo.dissipate_delay = 1 //make the singularity last less
-		singulo.dissipate_strength = 50
 		message_admins("[key_name_admin(user)] detonated a bag of holding")
 		log_game("[key_name(user)] detonated a bag of holding")
 		qdel(src)

--- a/code/modules/power/singularity/singularity.dm
+++ b/code/modules/power/singularity/singularity.dm
@@ -47,11 +47,8 @@
 		addtimer(CALLBACK(src, .proc/timeOut), lifetime)
 	return
 
-/obj/singularity/proc/timeOut()
-	expand(STAGE_ONE) //called when lifetime expires
-	energy = 1 //this makes sure the sing stays at stage one
-	src.visible_message("<span class='danger'>[src] destabilizes and begins to collapse in on itself!</span>")
-	QDEL_IN(src, 20)
+/obj/singularity/proc/timeOut() //proc called when lifetime expires
+	qdel(src)
 
 /obj/singularity/Destroy()
 	STOP_PROCESSING(SSobj, src)
@@ -442,6 +439,12 @@
 
 /obj/singularity/boh //singulo created by putting on Bag of Holding in another
 	lifetime = 200
+	
+/obj/singularity/boh/timeOut()
+	expand(STAGE_ONE)
+	energy = 1 //this makes sure the sing stays at stage one
+	src.visible_message("<span class='danger'>[src] destabilizes and begins to collapse in on itself!</span>")
+	QDEL_IN(src, 20)
 
 /obj/singularity/boh/emagged //singulo created by emagged BoH
 	lifetime = 600

--- a/code/modules/power/singularity/singularity.dm
+++ b/code/modules/power/singularity/singularity.dm
@@ -49,6 +49,7 @@
 
 /obj/singularity/proc/timeOut()
 	expand(STAGE_ONE) //called when lifetime expires
+	energy = 1 //this makes sure the sing stays at stage one
 	src.visible_message("<span class='danger'>[src] destabilizes and begins to collapse in on itself!</span>")
 	QDEL_IN(src, 20)
 

--- a/code/modules/power/singularity/singularity.dm
+++ b/code/modules/power/singularity/singularity.dm
@@ -27,6 +27,7 @@
 	var/last_failed_movement = 0//Will not move in the same dir if it couldnt before, will help with the getting stuck on fields thing
 	var/last_warning
 	var/consumedSupermatter = 0 //If the singularity has eaten a supermatter shard and can go to stage six
+	var/timerid
 	resistance_flags = INDESTRUCTIBLE | LAVA_PROOF | FIRE_PROOF | UNACIDABLE | ACID_PROOF | FREEZE_PROOF
 	obj_flags = CAN_BE_HIT | DANGEROUS_POSSESSION
 
@@ -44,7 +45,7 @@
 			target = singubeacon
 			break
 	if(lifetime > 0)
-		addtimer(CALLBACK(src, .proc/timeOut), lifetime)
+		timerid = addtimer(CALLBACK(src, .proc/timeOut), lifetime, TIMER_STOPPABLE)
 	return
 
 /obj/singularity/proc/timeOut() //proc called when lifetime expires
@@ -439,7 +440,18 @@
 
 /obj/singularity/boh //singulo created by putting on Bag of Holding in another
 	lifetime = 200
-	
+
+/obj/singularity/boh/consume(atom/A)
+	var/gain = A.singularity_act(current_size, src)
+	src.energy += gain
+	if(istype(A, /obj/machinery/power/supermatter_shard) && !consumedSupermatter)
+		desc = "[initial(desc)] It glows fiercely with inner fire."
+		name = "supermatter-charged [initial(name)]"
+		consumedSupermatter = 1
+		set_light(10)
+		deltimer(timerid)
+	return ..()
+
 /obj/singularity/boh/timeOut()
 	expand(STAGE_ONE)
 	energy = 1 //this makes sure the sing stays at stage one

--- a/code/modules/power/singularity/singularity.dm
+++ b/code/modules/power/singularity/singularity.dm
@@ -441,4 +441,7 @@
 	return(gain)
 
 /obj/singularity/boh //singulo created by putting on Bag of Holding in another
-	lifetime = 300
+	lifetime = 200
+
+/obj/singularity/boh/emagged //singulo created by emagged BoH
+	lifetime = 600

--- a/code/modules/power/singularity/singularity.dm
+++ b/code/modules/power/singularity/singularity.dm
@@ -10,6 +10,7 @@
 	layer = MASSIVE_OBJ_LAYER
 	light_range = 6
 	appearance_flags = 0
+	var/lifetime = 0 //how many deciseconds until the singularity destroys itself. Set to 0 for infinite.
 	var/current_size = 1
 	var/allowed_size = 1
 	var/contained = 1 //Are we going to move around?
@@ -42,7 +43,14 @@
 		if(singubeacon.active)
 			target = singubeacon
 			break
+	if(lifetime > 0)
+		addtimer(CALLBACK(src, .proc/timeOut), lifetime)
 	return
+
+/obj/singularity/proc/timeOut()
+	expand(STAGE_ONE) //called when lifetime expires
+	src.visible_message("<span class='danger'>[src] destabilizes and begins to collapse in on itself!</span>")
+	QDEL_IN(src, 20)
 
 /obj/singularity/Destroy()
 	STOP_PROCESSING(SSobj, src)
@@ -430,3 +438,6 @@
 	explosion(src.loc,(dist),(dist*2),(dist*4))
 	qdel(src)
 	return(gain)
+
+/obj/singularity/boh //singulo created by putting on Bag of Holding in another
+	lifetime = 300


### PR DESCRIPTION
:cl: Tacolizard Forever
tweak: Singularities created by bluespace interference now have a limited lifetime.
add: Coders can now create subtypes of singularity that self-destruct after a time.
/:cl:

Idea from this forum post, read here for more reasoning: https://tgstation13.org/phpBB/viewtopic.php?f=9&t=30&start=3150#p375882

Singularities created by BoH last for 20 seconds before collapsing. the BoH is emagged, they last a minute.

As for the exact length of the sing lifetime, I am open to debate. 

**If the BoH sing eats the SM it will delete its lifetime timer, making its lifetime uncapped.**
this is to discourage BoH bombing a delaminating SM, as the resulting singularity will do more damage than the SM could by just exploding.
