### PR TITLE
Tesla coils and grounding rods actually shock buckled mobs.

### DIFF
--- a/code/game/objects/obj_defense.dm
+++ b/code/game/objects/obj_defense.dm
@@ -227,6 +227,14 @@ GLOBAL_DATUM_INIT(acid_overlay, /mutable_appearance, mutable_appearance('icons/e
 	tesla_zap(src, 3, power_bounced)
 	addtimer(CALLBACK(src, .proc/reset_shocked), 10)
 
+//The surgeon general warns that being buckled to certain objects recieving powerful shocks is greatly hazardous to your health
+//Only tesla coils and grounding rods currently call this because mobs are already targeted over all other objects, but this might be useful for more things later.
+/obj/proc/tesla_buckle_check(var/strength)
+	if(has_buckled_mobs())
+		for(var/m in buckled_mobs)
+			var/mob/living/buckled_mob = m
+			buckled_mob.electrocute_act((CLAMP(round(strength/400), 10, 90) + rand(-5, 5)), src, tesla_shock = 1)
+
 /obj/proc/reset_shocked()
 	obj_flags &= ~BEING_SHOCKED
 

--- a/code/modules/power/tesla/coil.dm
+++ b/code/modules/power/tesla/coil.dm
@@ -102,6 +102,10 @@
 	add_load(power)
 	playsound(src.loc, 'sound/magic/lightningshock.ogg', 100, 1, extrarange = 5)
 	tesla_zap(src, 10, power/(coeff/2))
+	if(has_buckled_mobs())
+		for(var/m in buckled_mobs)
+			var/mob/living/buckled_mob = m
+			buckled_mob.electrocute_act((CLAMP(round((power/(coeff/2))/400), 10, 90) + rand(-5, 5)), src, 1, tesla_shock = 1)
 
 // Tesla R&D researcher
 /obj/machinery/power/tesla_coil/research
@@ -122,6 +126,10 @@
 		if(istype(linked_techweb))
 			linked_techweb.research_points += min(power_produced, 3) // x4 coils with a pulse per second or so = ~720/m point bonus for R&D
 		addtimer(CALLBACK(src, .proc/reset_shocked), 10)
+		if(has_buckled_mobs())
+			for(var/m in buckled_mobs)
+				var/mob/living/buckled_mob = m
+				buckled_mob.electrocute_act((CLAMP(round(power/400), 10, 90) + rand(-5, 5)), src, 1, tesla_shock = 1)
 	else
 		..()
 
@@ -185,5 +193,9 @@
 /obj/machinery/power/grounding_rod/tesla_act(var/power)
 	if(anchored && !panel_open)
 		flick("grounding_rodhit", src)
+		if(has_buckled_mobs())
+			for(var/m in buckled_mobs)
+				var/mob/living/buckled_mob = m
+				buckled_mob.electrocute_act((CLAMP(round(power/400), 10, 90) + rand(-5, 5)), src, 1, tesla_shock = 1)
 	else
 		..()

--- a/code/modules/power/tesla/coil.dm
+++ b/code/modules/power/tesla/coil.dm
@@ -89,6 +89,7 @@
 		if(istype(linked_techweb))
 			linked_techweb.research_points += min(power_produced, 1) // x4 coils = ~240/m point bonus for R&D
 		addtimer(CALLBACK(src, .proc/reset_shocked), 10)
+		tesla_buckle_check(power)
 	else
 		..()
 
@@ -102,10 +103,7 @@
 	add_load(power)
 	playsound(src.loc, 'sound/magic/lightningshock.ogg', 100, 1, extrarange = 5)
 	tesla_zap(src, 10, power/(coeff/2))
-	if(has_buckled_mobs())
-		for(var/m in buckled_mobs)
-			var/mob/living/buckled_mob = m
-			buckled_mob.electrocute_act((CLAMP(round((power/(coeff/2))/400), 10, 90) + rand(-5, 5)), src, 1, tesla_shock = 1)
+	tesla_buckle_check(power/(coeff/2))
 
 // Tesla R&D researcher
 /obj/machinery/power/tesla_coil/research
@@ -126,10 +124,7 @@
 		if(istype(linked_techweb))
 			linked_techweb.research_points += min(power_produced, 3) // x4 coils with a pulse per second or so = ~720/m point bonus for R&D
 		addtimer(CALLBACK(src, .proc/reset_shocked), 10)
-		if(has_buckled_mobs())
-			for(var/m in buckled_mobs)
-				var/mob/living/buckled_mob = m
-				buckled_mob.electrocute_act((CLAMP(round(power/400), 10, 90) + rand(-5, 5)), src, 1, tesla_shock = 1)
+		tesla_buckle_check(power)
 	else
 		..()
 
@@ -193,9 +188,6 @@
 /obj/machinery/power/grounding_rod/tesla_act(var/power)
 	if(anchored && !panel_open)
 		flick("grounding_rodhit", src)
-		if(has_buckled_mobs())
-			for(var/m in buckled_mobs)
-				var/mob/living/buckled_mob = m
-				buckled_mob.electrocute_act((CLAMP(round(power/400), 10, 90) + rand(-5, 5)), src, 1, tesla_shock = 1)
+		tesla_buckle_check(power)
 	else
 		..()


### PR DESCRIPTION
:cl: RandomMarine
fix: Did you know that you could buckle guys to grounding rods? Probably not - not that it mattered before, because people buckled to them didn't get shocked when they got zapped. That's fixed now. 
/:cl:

Fixes #nobodyeverreportedthis

Basically, the presence of a grounding rod made it impossible for anyone buckled to the coils/rods to get shocked, even if they were buckled directly to any that were  targeted by a zap chain.

Honestly I don't like how much copypasting was involved there. Anyone have a better idea on how it should be done?