### PR TITLE
Hit a teleport beacon with a DRAGnet to set the teleport destination

### DIFF
--- a/code/game/objects/items/devices/beacon.dm
+++ b/code/game/objects/items/devices/beacon.dm
@@ -6,6 +6,7 @@
 	item_state = "beacon"
 	lefthand_file = 'icons/mob/inhands/misc/devices_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/misc/devices_righthand.dmi'
+	anchored = FALSE
 	var/enabled = TRUE
 	var/renamed = FALSE
 
@@ -46,3 +47,25 @@
 		return
 
 	return ..()
+
+/obj/item/device/beacon/examine(mob/user)
+	..()
+	if(!anchored)
+		to_chat(user, "<span class='notice'>It is unsecured from the floor.</span>")
+	else
+		to_chat(user, "<span class='notice'>It is secured to the floor.</span>")
+
+/obj/item/device/beacon/wrench_act(mob/living/user, obj/item/I)
+	var/turf/T = get_turf(src)
+	if(!(T.intact && isfloorturf(T)))
+		to_chat(user, "<span class='notice'>You need a floor to fasten this to!</span>")
+		return
+
+	anchored = !anchored
+	if(anchored)
+		to_chat(user, "<span class='notice'>You fasten [src] to the floor.</span>")
+	else
+		to_chat(user, "<span class='notice'>You unfasten [src] from the floor.</span>")
+	I.play_tool_sound(src, 100)
+
+	return TRUE

--- a/code/game/objects/items/devices/beacon.dm
+++ b/code/game/objects/items/devices/beacon.dm
@@ -13,7 +13,7 @@
 	. = ..()
 	if (enabled)
 		GLOB.teleportbeacons += src
-	else 
+	else
 		icon_state = "beacon-off"
 
 /obj/item/device/beacon/Destroy()
@@ -25,13 +25,17 @@
 	if (enabled)
 		icon_state = "beacon"
 		GLOB.teleportbeacons += src
-	else 
+	else
 		icon_state = "beacon-off"
 		GLOB.teleportbeacons.Remove(src)
 	to_chat(user, "<span class='notice'>You [enabled ? "enable" : "disable"] the beacon.</span>")
 	return
 
 /obj/item/device/beacon/attackby(obj/item/W, mob/user)
+	if(istype(W, /obj/item/gun/energy/e_gun/dragnet))
+		var/obj/item/gun/energy/e_gun/dragnet/D = W
+		D.set_target(src, user)
+
 	if(istype(W, /obj/item/pen)) // needed for things that use custom names like the locator
 		var/new_name = stripped_input(user, "What would you like the name to be?")
 		if(!user.canUseTopic(src, BE_CLOSE))
@@ -40,5 +44,5 @@
 			name = new_name
 			renamed = TRUE
 		return
-	else	
-		return ..()
+
+	return ..()

--- a/code/modules/projectiles/ammunition/energy/special.dm
+++ b/code/modules/projectiles/ammunition/energy/special.dm
@@ -38,6 +38,14 @@
 	select_name = "netting"
 	pellets = 6
 	variance = 40
+	var/obj/item/gun/energy/e_gun/dragnet/drag
+
+/obj/item/ammo_casing/energy/net/Initialize()
+	.=..()
+	drag = loc
+	if(!istype(drag))
+		. = INITIALIZE_HINT_QDEL
+		CRASH("Energy net created outside of dragnet")
 
 /obj/item/ammo_casing/energy/trap
 	projectile_type = /obj/item/projectile/energy/trap

--- a/code/modules/projectiles/ammunition/energy/special.dm
+++ b/code/modules/projectiles/ammunition/energy/special.dm
@@ -38,17 +38,17 @@
 	select_name = "netting"
 	pellets = 6
 	variance = 40
-	var/obj/item/gun/energy/e_gun/dragnet/D
+	var/obj/item/gun/D
 
 /obj/item/ammo_casing/energy/net/Initialize()
 	. = ..()
 	D = loc
 	if(!istype(D))
-		CRASH("net created outside dragnet")
+		D = null
 
 /obj/item/ammo_casing/energy/net/newshot()
 	if(!BB)
-		BB = new projectile_type(src, D.guntarget)
+		BB = new projectile_type(src, D?.guntarget)
 
 /obj/item/ammo_casing/energy/trap
 	projectile_type = /obj/item/projectile/energy/trap

--- a/code/modules/projectiles/ammunition/energy/special.dm
+++ b/code/modules/projectiles/ammunition/energy/special.dm
@@ -38,14 +38,17 @@
 	select_name = "netting"
 	pellets = 6
 	variance = 40
-	var/obj/item/gun/energy/e_gun/dragnet/drag
+	var/obj/item/gun/energy/e_gun/dragnet/D
 
 /obj/item/ammo_casing/energy/net/Initialize()
-	.=..()
-	drag = loc
-	if(!istype(drag))
-		. = INITIALIZE_HINT_QDEL
-		CRASH("Energy net created outside of dragnet")
+	. = ..()
+	D = loc
+	if(!istype(D))
+		CRASH("net created outside dragnet")
+
+/obj/item/ammo_casing/energy/net/newshot()
+	if(!BB)
+		BB = new projectile_type(src, D.guntarget)
 
 /obj/item/ammo_casing/energy/trap
 	projectile_type = /obj/item/projectile/energy/trap

--- a/code/modules/projectiles/gun.dm
+++ b/code/modules/projectiles/gun.dm
@@ -64,6 +64,8 @@
 	var/zoom_out_amt = 0
 	var/datum/action/toggle_scope_zoom/azoom
 
+	var/obj/item/device/beacon/guntarget
+
 /obj/item/gun/Initialize()
 	. = ..()
 	if(pin)

--- a/code/modules/projectiles/guns/energy/energy_gun.dm
+++ b/code/modules/projectiles/guns/energy/energy_gun.dm
@@ -61,7 +61,7 @@
 
 /obj/item/gun/energy/e_gun/dragnet
 	name = "\improper DRAGnet"
-	desc = "The \"Dynamic Rapid-Apprehension of the Guilty\" net is a revolution in law enforcement technology."
+	desc = "The \"Dynamic Rapid-Apprehension of the Guilty\" net is a revolution in law enforcement technology. Hit a teleport beacon with it to set the bluespace net teleport destination."
 	icon_state = "dragnet"
 	item_state = "dragnet"
 	lefthand_file = 'icons/mob/inhands/weapons/guns_lefthand.dmi'
@@ -69,6 +69,20 @@
 	ammo_type = list(/obj/item/ammo_casing/energy/net, /obj/item/ammo_casing/energy/trap)
 	can_flashlight = 0
 	ammo_x_offset = 1
+	var/obj/item/device/radio/beacon/guntarget
+
+/obj/item/gun/energy/e_gun/dragnet/proc/set_target(target, user)//called on beacon's attackby()
+	guntarget = target
+	to_chat(user, "<span class='notice'>[src] has locked onto [guntarget].</span>")
+
+	var/obj/item/projectile/energy/net/MEME = chambered.BB
+
+	MEME.set_projtarget()
+
+/obj/item/gun/energy/e_gun/dragnet/examine(mob/user)
+	..()
+	if(guntarget)
+		to_chat(user, "<span class='notice'>[src] has locked onto [guntarget].</span>")
 
 /obj/item/gun/energy/e_gun/dragnet/snare
 	name = "Energy Snare Launcher"

--- a/code/modules/projectiles/guns/energy/energy_gun.dm
+++ b/code/modules/projectiles/guns/energy/energy_gun.dm
@@ -69,7 +69,6 @@
 	ammo_type = list(/obj/item/ammo_casing/energy/net, /obj/item/ammo_casing/energy/trap)
 	can_flashlight = 0
 	ammo_x_offset = 1
-	var/obj/item/device/beacon/guntarget
 
 /obj/item/gun/energy/e_gun/dragnet/proc/set_target(target, user)//called on beacon's attackby()
 	guntarget = target

--- a/code/modules/projectiles/guns/energy/energy_gun.dm
+++ b/code/modules/projectiles/guns/energy/energy_gun.dm
@@ -61,7 +61,7 @@
 
 /obj/item/gun/energy/e_gun/dragnet
 	name = "\improper DRAGnet"
-	desc = "The \"Dynamic Rapid-Apprehension of the Guilty\" net is a revolution in law enforcement technology. Hit a teleport beacon with it to set the bluespace net teleport destination."
+	desc = "The \"Dynamic Rapid-Apprehension of the Guilty\" net is a revolution in law enforcement technology."
 	icon_state = "dragnet"
 	item_state = "dragnet"
 	lefthand_file = 'icons/mob/inhands/weapons/guns_lefthand.dmi'
@@ -81,6 +81,7 @@
 
 /obj/item/gun/energy/e_gun/dragnet/examine(mob/user)
 	..()
+		to_chat(user, "<span class='notice'>Hit a teleport beacon with it to set the bluespace net teleport destination.</span>")
 	if(guntarget)
 		to_chat(user, "<span class='notice'>[src] has locked onto [guntarget].</span>")
 

--- a/code/modules/projectiles/guns/energy/energy_gun.dm
+++ b/code/modules/projectiles/guns/energy/energy_gun.dm
@@ -69,7 +69,7 @@
 	ammo_type = list(/obj/item/ammo_casing/energy/net, /obj/item/ammo_casing/energy/trap)
 	can_flashlight = 0
 	ammo_x_offset = 1
-	var/obj/item/device/radio/beacon/guntarget
+	var/obj/item/device/beacon/guntarget
 
 /obj/item/gun/energy/e_gun/dragnet/proc/set_target(target, user)//called on beacon's attackby()
 	guntarget = target

--- a/code/modules/projectiles/guns/energy/energy_gun.dm
+++ b/code/modules/projectiles/guns/energy/energy_gun.dm
@@ -81,7 +81,7 @@
 
 /obj/item/gun/energy/e_gun/dragnet/examine(mob/user)
 	..()
-		to_chat(user, "<span class='notice'>Hit a teleport beacon with it to set the bluespace net teleport destination.</span>")
+	to_chat(user, "<span class='notice'>Hit a teleport beacon with it to set the bluespace net teleport destination.</span>")
 	if(guntarget)
 		to_chat(user, "<span class='notice'>[src] has locked onto [guntarget].</span>")
 

--- a/code/modules/projectiles/guns/energy/energy_gun.dm
+++ b/code/modules/projectiles/guns/energy/energy_gun.dm
@@ -77,11 +77,12 @@
 
 	var/obj/item/projectile/energy/net/MEME = chambered.BB
 
-	MEME.set_projtarget()
+	if(istype(MEME))
+		MEME.set_projtarget()
 
 /obj/item/gun/energy/e_gun/dragnet/examine(mob/user)
 	..()
-	to_chat(user, "<span class='notice'>Hit a teleport beacon with it to set the bluespace net teleport destination.</span>")
+	to_chat(user, "<span class='notice'>Hit a teleport beacon with it to set the bluespace netting teleport destination.</span>")
 	if(guntarget)
 		to_chat(user, "<span class='notice'>[src] has locked onto [guntarget].</span>")
 

--- a/code/modules/projectiles/guns/energy/energy_gun.dm
+++ b/code/modules/projectiles/guns/energy/energy_gun.dm
@@ -75,11 +75,6 @@
 	guntarget = target
 	to_chat(user, "<span class='notice'>[src] has locked onto [guntarget].</span>")
 
-	var/obj/item/projectile/energy/net/MEME = chambered.BB
-
-	if(istype(MEME))
-		MEME.set_projtarget()
-
 /obj/item/gun/energy/e_gun/dragnet/examine(mob/user)
 	..()
 	to_chat(user, "<span class='notice'>Hit a teleport beacon with it to set the bluespace netting teleport destination.</span>")

--- a/code/modules/projectiles/projectile/energy/net_snare.dm
+++ b/code/modules/projectiles/projectile/energy/net_snare.dm
@@ -21,7 +21,7 @@
 	if(isliving(target))
 		var/turf/Tloc = get_turf(target)
 		if(!locate(/obj/effect/nettingportal) in Tloc)
-			var/NP = new /obj/effect/nettingportal(Tloc)
+			var/obj/effect/nettingportal/NP = new (Tloc)
 			NP.teletarget = projtarget
 	..()
 

--- a/code/modules/projectiles/projectile/energy/net_snare.dm
+++ b/code/modules/projectiles/projectile/energy/net_snare.dm
@@ -8,8 +8,7 @@
 	var/obj/item/device/beacon/targetbeacon
 
 /obj/item/projectile/energy/net/Initialize(mapload, tbeacon = null)
-	if(tbeacon)
-		targetbeacon = tbeacon
+	targetbeacon = tbeacon
 	. = ..()
 	SpinAnimation()
 

--- a/code/modules/projectiles/projectile/energy/net_snare.dm
+++ b/code/modules/projectiles/projectile/energy/net_snare.dm
@@ -5,16 +5,24 @@
 	damage_type = STAMINA
 	hitsound = 'sound/weapons/taserhit.ogg'
 	range = 10
+	var/obj/item/device/radio/beacon/projtarget
 
 /obj/item/projectile/energy/net/Initialize()
 	. = ..()
 	SpinAnimation()
+	set_projtarget()
+
+/obj/item/projectile/energy/net/proc/set_projtarget()
+	var/obj/item/ammo_casing/energy/net/N = loc
+	if(istype(N))
+		projtarget = N.drag.guntarget
 
 /obj/item/projectile/energy/net/on_hit(atom/target, blocked = FALSE)
 	if(isliving(target))
 		var/turf/Tloc = get_turf(target)
 		if(!locate(/obj/effect/nettingportal) in Tloc)
-			new /obj/effect/nettingportal(Tloc)
+			var/obj/effect/nettingportal/NP = new (Tloc)
+			NP.teletarget = projtarget
 	..()
 
 /obj/item/projectile/energy/net/on_range()
@@ -31,23 +39,20 @@
 
 /obj/effect/nettingportal/Initialize()
 	. = ..()
-	var/obj/item/device/beacon/teletarget = null
-	for(var/obj/machinery/computer/teleporter/com in GLOB.machines)
-		if(com.target)
-			if(com.power_station && com.power_station.teleporter_hub && com.power_station.engaged)
-				teletarget = com.target
 
-	addtimer(CALLBACK(src, .proc/pop, teletarget), 30)
+	addtimer(CALLBACK(src, .proc/pop), 30)
 
-/obj/effect/nettingportal/proc/pop(teletarget)
+/obj/effect/nettingportal/proc/pop()
 	if(teletarget)
+		var/TT = get_turf(teletarget)
 		for(var/mob/living/L in get_turf(src))
-			do_teleport(L, teletarget, 2)//teleport what's in the tile to the beacon
+			do_teleport(L, TT, 1)//teleport what's in the tile to the beacon
 	else
 		for(var/mob/living/L in get_turf(src))
 			do_teleport(L, L, 15) //Otherwise it just warps you off somewhere.
 
 	qdel(src)
+
 
 /obj/effect/nettingportal/singularity_act()
 	return

--- a/code/modules/projectiles/projectile/energy/net_snare.dm
+++ b/code/modules/projectiles/projectile/energy/net_snare.dm
@@ -21,7 +21,7 @@
 	if(isliving(target))
 		var/turf/Tloc = get_turf(target)
 		if(!locate(/obj/effect/nettingportal) in Tloc)
-			var/obj/effect/nettingportal/NP = new (Tloc)
+			var/NP = new /obj/effect/nettingportal(Tloc)
 			NP.teletarget = projtarget
 	..()
 
@@ -44,8 +44,8 @@
 	addtimer(CALLBACK(src, .proc/pop), 30)
 
 /obj/effect/nettingportal/proc/pop()
-	if(teletarget)
-		var/TT = get_turf(teletarget)
+	var/TT = get_turf(teletarget)
+	if(teletarget && loc != TT)
 		for(var/mob/living/L in get_turf(src))
 			do_teleport(L, TT, 1)//teleport what's in the tile to the beacon
 	else

--- a/code/modules/projectiles/projectile/energy/net_snare.dm
+++ b/code/modules/projectiles/projectile/energy/net_snare.dm
@@ -5,7 +5,7 @@
 	damage_type = STAMINA
 	hitsound = 'sound/weapons/taserhit.ogg'
 	range = 10
-	var/obj/item/device/radio/beacon/projtarget
+	var/obj/item/device/beacon/projtarget
 
 /obj/item/projectile/energy/net/Initialize()
 	. = ..()
@@ -36,6 +36,7 @@
 	icon_state = "dragnetfield"
 	light_range = 3
 	anchored = TRUE
+	var/obj/item/device/beacon/teletarget
 
 /obj/effect/nettingportal/Initialize()
 	. = ..()

--- a/code/modules/projectiles/projectile/energy/net_snare.dm
+++ b/code/modules/projectiles/projectile/energy/net_snare.dm
@@ -46,7 +46,7 @@
 	var/TT = get_turf(teletarget)
 	if(teletarget && loc != TT)
 		for(var/mob/living/L in get_turf(src))
-			do_teleport(L, TT, 1)//teleport what's in the tile to the beacon
+			do_teleport(L, TT, 0)//teleport what's in the tile to the beacon
 	else
 		for(var/mob/living/L in get_turf(src))
 			do_teleport(L, L, 15) //Otherwise it just warps you off somewhere.

--- a/code/modules/projectiles/projectile/energy/net_snare.dm
+++ b/code/modules/projectiles/projectile/energy/net_snare.dm
@@ -5,24 +5,23 @@
 	damage_type = STAMINA
 	hitsound = 'sound/weapons/taserhit.ogg'
 	range = 10
-	var/obj/item/device/beacon/projtarget
+	var/obj/item/device/beacon/targetbeacon
 
-/obj/item/projectile/energy/net/Initialize()
+/obj/item/projectile/energy/net/Initialize(mapload, tbeacon = null)
+	if(tbeacon)
+		targetbeacon = tbeacon
 	. = ..()
 	SpinAnimation()
-	set_projtarget()
-
-/obj/item/projectile/energy/net/proc/set_projtarget()
-	var/obj/item/ammo_casing/energy/net/N = loc
-	if(istype(N))
-		projtarget = N.drag.guntarget
 
 /obj/item/projectile/energy/net/on_hit(atom/target, blocked = FALSE)
 	if(isliving(target))
 		var/turf/Tloc = get_turf(target)
 		if(!locate(/obj/effect/nettingportal) in Tloc)
 			var/obj/effect/nettingportal/NP = new (Tloc)
-			NP.teletarget = projtarget
+			if(targetbeacon)
+				NP.teletarget = targetbeacon
+			else
+				NP.teletarget = null
 	..()
 
 /obj/item/projectile/energy/net/on_range()


### PR DESCRIPTION
🆑 Tacolizard Forever
tweak: DRAGnets no longer use teleport stations to determine their teleport destination. Instead, hit a teleport beacon with the DRAGnet.
tweak: DRAGnets now teleport to within 1 tile of a beacon, instead of 2. This allows you to use standard brig cells as teleportation cells so long as the beacon is placed in the center of the room.
experiment: Reminder: teleport beacons can be purchased in cargo and built in Science with pretty low Bluespace levels.
add: You can now wrench teleport beacons to the floor. Now you can safely teleport prisoners to their cells!
/🆑

this is a reopening of an old PR from a deleted branch, so the code was copy-pasted over from the PR's diff page. 