### PR TITLE
[s] You can no longer unequip your own chained shoes

### DIFF
--- a/code/modules/clothing/clothing.dm
+++ b/code/modules/clothing/clothing.dm
@@ -23,6 +23,7 @@
 	var/obj/item/device/flashlight/F = null
 	var/can_flashlight = 0
 	var/scan_reagents = 0 //Can the wearer see reagents while it's equipped?
+	var/mouse_unequippable = TRUE //can this item be unequipped by dragging it into a hand slot?
 
 	//Var modification - PLEASE be careful with this I know who you are and where you live
 	var/list/user_vars_to_edit = list() //VARNAME = VARVALUE eg: "name" = "butts"
@@ -53,8 +54,9 @@
 
 	if(!M.incapacitated() && loc == M && istype(over_object, /obj/screen/inventory/hand))
 		var/obj/screen/inventory/hand/H = over_object
-		if(M.putItemFromInventoryInHandIfPossible(src, H.held_index))
-			add_fingerprint(usr)
+		if(mouse_unequippable)
+			if(M.putItemFromInventoryInHandIfPossible(src, H.held_index))
+				add_fingerprint(usr)
 
 /obj/item/clothing/throw_at(atom/target, range, speed, mob/thrower, spin=1, diagonals_first = 0, datum/callback/callback)
 	if(pockets)

--- a/code/modules/clothing/clothing.dm
+++ b/code/modules/clothing/clothing.dm
@@ -54,9 +54,8 @@
 
 	if(!M.incapacitated() && loc == M && istype(over_object, /obj/screen/inventory/hand))
 		var/obj/screen/inventory/hand/H = over_object
-		if(mouse_unequippable)
-			if(M.putItemFromInventoryInHandIfPossible(src, H.held_index))
-				add_fingerprint(usr)
+		if(mouse_unequippable && M.putItemFromInventoryInHandIfPossible(src, H.held_index))
+			add_fingerprint(usr)
 
 /obj/item/clothing/throw_at(atom/target, range, speed, mob/thrower, spin=1, diagonals_first = 0, datum/callback/callback)
 	if(pockets)

--- a/code/modules/clothing/masks/miscellaneous.dm
+++ b/code/modules/clothing/masks/miscellaneous.dm
@@ -7,15 +7,6 @@
 	w_class = WEIGHT_CLASS_SMALL
 	gas_transfer_coefficient = 0.9
 	equip_delay_other = 20
-	mouse_unequippable = FALSE
-
-/obj/item/clothing/mask/muzzle/attack_hand(mob/user)
-	if(iscarbon(user))
-		var/mob/living/carbon/C = user
-		if(src == C.wear_mask)
-			to_chat(user, "<span class='warning'>You need help taking this off!</span>")
-			return
-	..()
 
 /obj/item/clothing/mask/surgical
 	name = "sterile mask"

--- a/code/modules/clothing/masks/miscellaneous.dm
+++ b/code/modules/clothing/masks/miscellaneous.dm
@@ -7,8 +7,9 @@
 	w_class = WEIGHT_CLASS_SMALL
 	gas_transfer_coefficient = 0.9
 	equip_delay_other = 20
+	mouse_unequippable = FALSE
 
-/obj/item/clothing/mask/muzzle/attack_paw(mob/user)
+/obj/item/clothing/mask/muzzle/attack_hand(mob/user)
 	if(iscarbon(user))
 		var/mob/living/carbon/C = user
 		if(src == C.wear_mask)

--- a/code/modules/clothing/shoes/colour.dm
+++ b/code/modules/clothing/shoes/colour.dm
@@ -87,11 +87,13 @@
 	item_color = "orange"
 
 /obj/item/clothing/shoes/sneakers/orange/attack_self(mob/user)
-	if (src.chained)
-		src.chained = null
-		src.slowdown = SHOES_SLOWDOWN
-		new /obj/item/restraints/handcuffs( user.loc )
-		src.icon_state = "orange"
+	if (chained)
+		chained = FALSE
+		slowdown = SHOES_SLOWDOWN
+		mouse_unequippable = TRUE
+		var/H = new /obj/item/restraints/handcuffs()
+		user.put_in_hands(H)
+		icon_state = "orange"
 	return
 
 /obj/item/clothing/shoes/sneakers/orange/attackby(obj/H, loc, params)
@@ -99,15 +101,16 @@
 	// Note: not using istype here because we want to ignore all subtypes
 	if (H.type == /obj/item/restraints/handcuffs && !chained)
 		qdel(H)
-		src.chained = 1
-		src.slowdown = 15
-		src.icon_state = "orange1"
+		chained = TRUE
+		slowdown = 15
+		mouse_unequippable = FALSE
+		icon_state = "orange1"
 	return
 
 /obj/item/clothing/shoes/sneakers/orange/attack_hand(mob/user)
 	if(ishuman(user))
 		var/mob/living/carbon/human/C = user
-		if(C.shoes == src && src.chained == 1)
+		if(C.shoes == src && chained)
 			to_chat(user, "<span class='warning'>You need help taking these off!</span>")
 			return
 	..()


### PR DESCRIPTION
:cl: Tacolizard Forever
fix: Fixed an exploit that allowed users to take off their chained shoes
/:cl:

Fixes #36318
Removed extraneous `src` from chained shoe code
Made chained shoe code use `TRUE` and `FALSE`
removed broken code from muzzles because apparently people should be able to unequip them

adds a new var `mouse_unequippable` to `/obj/item/clothing`. the var defaults to `TRUE`. when set to `FALSE`, prevents click-drag unequipping.
