### PR TITLE
If a player somehow picks up a NODROP item, the item is deleted

### DIFF
--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -412,6 +412,7 @@ GLOBAL_VAR_INIT(rpg_loot_items, FALSE)
 
 // called just as an item is picked up (loc is not yet changed)
 /obj/item/proc/pickup(mob/user)
+	flags_1 &= ~NODROP_1
 	item_flags |= IN_INVENTORY
 	return
 

--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -412,7 +412,8 @@ GLOBAL_VAR_INIT(rpg_loot_items, FALSE)
 
 // called just as an item is picked up (loc is not yet changed)
 /obj/item/proc/pickup(mob/user)
-	flags_1 &= ~NODROP_1
+	if(NODROP_1 & flags_1)
+		qdel(src)
 	item_flags |= IN_INVENTORY
 	return
 


### PR DESCRIPTION
:cl: Tacolizard Forever
fix: Items that aren't supposed to be dropped will no longer stick in your inventory if you somehow pick them up.
/:cl:

fixes #35826

