### PR TITLE
Fix mislabelled and stacked OmegaStation cameras

### DIFF
--- a/_maps/map_files/OmegaStation/OmegaStation.dmm
+++ b/_maps/map_files/OmegaStation/OmegaStation.dmm
@@ -30409,11 +30409,6 @@
 	dir = 8
 	},
 /obj/machinery/camera{
-	c_tag = "Shuttle Docking Foyer";
-	dir = 8;
-	network = list("mine")
-	},
-/obj/machinery/camera{
 	c_tag = "Escape Arm Airlocks";
 	dir = 8
 	},

--- a/_maps/map_files/OmegaStation/OmegaStation.dmm
+++ b/_maps/map_files/OmegaStation/OmegaStation.dmm
@@ -17980,8 +17980,7 @@
 	},
 /obj/machinery/camera{
 	c_tag = "Kitchen Coldroom";
-	dir = 4;
-	network = list("mine")
+	dir = 4
 	},
 /turf/open/floor/plasteel/freezer,
 /area/crew_quarters/kitchen)
@@ -28488,8 +28487,7 @@
 	},
 /obj/machinery/camera{
 	c_tag = "Crematorium";
-	dir = 4;
-	network = list("mine")
+	dir = 4
 	},
 /turf/open/floor/plasteel/vault/side{
 	dir = 4


### PR DESCRIPTION
:cl:
fix: Cameranet issues in OmegaStation's departures wing, crematorium, and freezer have been corrected.
/:cl:

Fixes #36456. Removes one presumably-accidentally copy-pasted mining camera and changes two cameras off the `"mine"` network.