### PR TITLE
Distinguishes law types by colour

### DIFF
--- a/code/datums/ai_laws.dm
+++ b/code/datums/ai_laws.dm
@@ -13,7 +13,7 @@
 	var/list/supplied = list()
 	var/list/ion = list()
 	var/mob/living/silicon/owner
-	var/list/devillaws = null
+	var/list/devillaws = list()
 	var/id = DEFAULT_AI_LAWID
 
 /datum/ai_laws/proc/lawid_to_type(lawid)
@@ -403,15 +403,15 @@
 
 	if (include_zeroth && devillaws && devillaws.len)
 		for(var/i in devillaws)
-			data += "[show_numbers ? "666:" : ""] [i]"
+			data += "[show_numbers ? "666:" : ""] <font color='#cc5500'>[i]</font>"
 
 	if (include_zeroth && zeroth)
-		data += "[show_numbers ? "0:" : ""] [zeroth]"
+		data += "[show_numbers ? "0:" : ""] <font color='#ff0000'>[zeroth]</font>"
 
 	for(var/law in ion)
 		if (length(law) > 0)
 			var/num = ionnum()
-			data += "[show_numbers ? "[num]:" : ""] [law]"
+			data += "[show_numbers ? "[num]:" : ""] <font color='#00ffff'>[law]</font>"
 
 	var/number = 1
 	for(var/law in inherent)
@@ -421,6 +421,6 @@
 
 	for(var/law in supplied)
 		if (length(law) > 0)
-			data += "[show_numbers ? "[number]:" : ""] [law]"
+			data += "[show_numbers ? "[number]:" : ""] <font color='#800080'>[law]</font>"
 			number++
 	return data

--- a/code/datums/ai_laws.dm
+++ b/code/datums/ai_laws.dm
@@ -429,15 +429,15 @@
 	if (include_zeroth && zeroth)
 		data += "[show_numbers ? "0:" : ""] <font color='#ff0000'><b>[zeroth]</b></font>"
 
-	for(var/law in ion)
-		if (length(law) > 0)
-			var/num = ionnum()
-			data += "[show_numbers ? "[num]:" : ""] <font color='#00ffff'>[law]</font>"
-
 	for(var/law in hacked)
 		if (length(law) > 0)
 			var/num = ionnum()
 			data += "[show_numbers ? "[num]:" : ""] <font color='#660000'>[law]</font>"
+
+	for(var/law in ion)
+		if (length(law) > 0)
+			var/num = ionnum()
+			data += "[show_numbers ? "[num]:" : ""] <font color='#00ffff'>[law]</font>"
 
 	var/number = 1
 	for(var/law in inherent)

--- a/code/datums/ai_laws.dm
+++ b/code/datums/ai_laws.dm
@@ -3,6 +3,7 @@
 #define LAW_INHERENT "inherent"
 #define LAW_SUPPLIED "supplied"
 #define LAW_ION "ion"
+#define LAW_HACKED "hacked"
 
 
 /datum/ai_laws
@@ -12,6 +13,7 @@
 	var/list/inherent = list()
 	var/list/supplied = list()
 	var/list/ion = list()
+	var/list/hacked = list()
 	var/mob/living/silicon/owner
 	var/list/devillaws = list()
 	var/id = DEFAULT_AI_LAWID
@@ -260,6 +262,8 @@
 		law_amount++
 	if(ion.len && (LAW_ION in groups))
 		law_amount += ion.len
+	if(hacked.len && (LAW_HACKED in groups))
+		law_amount += hacked.len
 	if(inherent.len && (LAW_INHERENT in groups))
 		law_amount += inherent.len
 	if(supplied.len && (LAW_SUPPLIED in groups))
@@ -284,6 +288,9 @@
 /datum/ai_laws/proc/add_ion_law(law)
 	ion += law
 
+/datum/ai_laws/proc/add_hacked_law(law)
+	hacked += law
+
 /datum/ai_laws/proc/clear_inherent_laws()
 	qdel(inherent)
 	inherent = list()
@@ -300,6 +307,8 @@
 		replaceable_groups[LAW_ZEROTH] = 1
 	if(ion.len && (LAW_ION in groups))
 		replaceable_groups[LAW_ION] = ion.len
+	if(hacked.len && (LAW_HACKED in groups))
+		replaceable_groups[LAW_ION] = hacked.len
 	if(inherent.len && (LAW_INHERENT in groups))
 		replaceable_groups[LAW_INHERENT] = inherent.len
 	if(supplied.len && (LAW_SUPPLIED in groups))
@@ -313,6 +322,10 @@
 			var/i = rand(1, ion.len)
 			. = ion[i]
 			ion[i] = law
+		if(LAW_HACKED)
+			var/i = rand(1, hacked.len)
+			. = hacked[i]
+			hacked[i] = law
 		if(LAW_INHERENT)
 			var/i = rand(1, inherent.len)
 			. = inherent[i]
@@ -326,6 +339,8 @@
 	var/list/laws = list()
 	if(ion.len && (LAW_ION in groups))
 		laws += ion
+	if(hacked.len && (LAW_HACKED in groups))
+		laws += hacked
 	if(inherent.len && (LAW_INHERENT in groups))
 		laws += inherent
 	if(supplied.len && (LAW_SUPPLIED in groups))
@@ -336,6 +351,9 @@
 	if(ion.len && (LAW_ION in groups))
 		for(var/i = 1, i <= ion.len, i++)
 			ion[i] = pick_n_take(laws)
+	if(hacked.len && (LAW_HACKED in groups))
+		for(var/i = 1, i <= hacked.len, i++)
+			hacked[i] = pick_n_take(laws)
 	if(inherent.len && (LAW_INHERENT in groups))
 		for(var/i = 1, i <= inherent.len, i++)
 			inherent[i] = pick_n_take(laws)
@@ -372,6 +390,9 @@
 /datum/ai_laws/proc/clear_ion_laws()
 	ion = list()
 
+/datum/ai_laws/proc/clear_hacked_laws()
+	hacked = list()
+
 /datum/ai_laws/proc/show_laws(who)
 	var/list/printable_laws = get_law_list(include_zeroth = TRUE)
 	for(var/law in printable_laws)
@@ -406,12 +427,17 @@
 			data += "[show_numbers ? "666:" : ""] <font color='#cc5500'>[i]</font>"
 
 	if (include_zeroth && zeroth)
-		data += "[show_numbers ? "0:" : ""] <font color='#ff0000'>[zeroth]</font>"
+		data += "[show_numbers ? "0:" : ""] <font color='#ff0000'><b>[zeroth]</b></font>"
 
 	for(var/law in ion)
 		if (length(law) > 0)
 			var/num = ionnum()
 			data += "[show_numbers ? "[num]:" : ""] <font color='#00ffff'>[law]</font>"
+
+	for(var/law in hacked)
+		if (length(law) > 0)
+			var/num = ionnum()
+			data += "[show_numbers ? "[num]:" : ""] <font color='#660000'>[law]</font>"
 
 	var/number = 1
 	for(var/law in inherent)
@@ -421,6 +447,6 @@
 
 	for(var/law in supplied)
 		if (length(law) > 0)
-			data += "[show_numbers ? "[number]:" : ""] <font color='#800080'>[law]</font>"
+			data += "[show_numbers ? "[number]:" : ""] <font color='#990099'>[law]</font>"
 			number++
 	return data

--- a/code/game/machinery/computer/aifixer.dm
+++ b/code/game/machinery/computer/aifixer.dm
@@ -41,6 +41,12 @@
 				var/num = ionnum()
 				laws += "<b>[num]:</b> [law]<BR>"
 
+		for (var/index = 1, index <= src.occupier.laws.hacked.len, index++)
+			var/law = src.occupier.laws.hacked[index]
+			if (length(law) > 0)
+				var/num = ionnum()
+				laws += "<b>[num]:</b> [law]<BR>"
+
 		var/number = 1
 		for (var/index = 1, index <= src.occupier.laws.inherent.len, index++)
 			var/law = src.occupier.laws.inherent[index]

--- a/code/game/machinery/computer/aifixer.dm
+++ b/code/game/machinery/computer/aifixer.dm
@@ -35,14 +35,14 @@
 		if (src.occupier.laws.zeroth)
 			laws += "<b>0:</b> [src.occupier.laws.zeroth]<BR>"
 
-		for (var/index = 1, index <= src.occupier.laws.ion.len, index++)
-			var/law = src.occupier.laws.ion[index]
+		for (var/index = 1, index <= src.occupier.laws.hacked.len, index++)
+			var/law = src.occupier.laws.hacked[index]
 			if (length(law) > 0)
 				var/num = ionnum()
 				laws += "<b>[num]:</b> [law]<BR>"
 
-		for (var/index = 1, index <= src.occupier.laws.hacked.len, index++)
-			var/law = src.occupier.laws.hacked[index]
+		for (var/index = 1, index <= src.occupier.laws.ion.len, index++)
+			var/law = src.occupier.laws.ion[index]
 			if (length(law) > 0)
 				var/num = ionnum()
 				laws += "<b>[num]:</b> [law]<BR>"

--- a/code/game/objects/items/AI_modules.dm
+++ b/code/game/objects/items/AI_modules.dm
@@ -49,7 +49,7 @@ AI MODULES
 	//Handle the lawcap
 	if(law_datum)
 		var/tot_laws = 0
-		for(var/lawlist in list(law_datum.inherent, law_datum.supplied, law_datum.ion, laws))
+		for(var/lawlist in list(law_datum.devillaws, law_datum.inherent, law_datum.supplied, law_datum.ion, law_datum.hacked, laws))
 			for(var/mylaw in lawlist)
 				if(mylaw != "")
 					tot_laws++
@@ -301,9 +301,11 @@ AI MODULES
 	if(law_datum.owner)
 		law_datum.owner.clear_supplied_laws()
 		law_datum.owner.clear_ion_laws()
+		law_datum.owner.clear_hacked_laws()
 	else
 		law_datum.clear_supplied_laws()
 		law_datum.clear_ion_laws()
+		law_datum.clear_hacked_laws()
 
 
 /******************** Purge ********************/
@@ -469,14 +471,14 @@ AI MODULES
 	if(law_datum.owner)
 		to_chat(law_datum.owner, "<span class='warning'>BZZZZT</span>")
 		if(!overflow)
-			law_datum.owner.add_ion_law(laws[1])
+			law_datum.owner.add_hacked_law(laws[1])
 		else
-			law_datum.owner.replace_random_law(laws[1],list(LAW_ION,LAW_INHERENT,LAW_SUPPLIED))
+			law_datum.owner.replace_random_law(laws[1],list(LAW_ION,LAW_HACKED,LAW_INHERENT,LAW_SUPPLIED))
 	else
 		if(!overflow)
-			law_datum.add_ion_law(laws[1])
+			law_datum.add_hacked_law(laws[1])
 		else
-			law_datum.replace_random_law(laws[1],list(LAW_ION,LAW_INHERENT,LAW_SUPPLIED))
+			law_datum.replace_random_law(laws[1],list(LAW_ION,LAW_HACKED,LAW_INHERENT,LAW_SUPPLIED))
 	return laws[1]
 
 /******************* Ion Module *******************/

--- a/code/modules/mob/living/silicon/laws.dm
+++ b/code/modules/mob/living/silicon/laws.dm
@@ -47,6 +47,11 @@
 	laws.add_ion_law(law)
 	post_lawchange(announce)
 
+/mob/living/silicon/proc/add_hacked_law(law, announce = TRUE)
+	laws_sanity_check()
+	laws.add_hacked_law(law)
+	post_lawchange(announce)
+
 /mob/living/silicon/proc/replace_random_law(law, groups, announce = TRUE)
 	laws_sanity_check()
 	. = laws.replace_random_law(law,groups)
@@ -65,6 +70,11 @@
 /mob/living/silicon/proc/clear_ion_laws(announce = TRUE)
 	laws_sanity_check()
 	laws.clear_ion_laws()
+	post_lawchange(announce)
+
+/mob/living/silicon/proc/clear_hacked_laws(announce = TRUE)
+	laws_sanity_check()
+	laws.clear_hacked_laws()
 	post_lawchange(announce)
 
 /mob/living/silicon/proc/make_laws()

--- a/code/modules/mob/living/silicon/robot/laws.dm
+++ b/code/modules/mob/living/silicon/robot/laws.dm
@@ -43,6 +43,12 @@
 	var/datum/ai_laws/master = connected_ai ? connected_ai.laws : null
 	var/temp
 	if (master)
+		laws.devillaws.len = master.devillaws.len
+		for (var/index = 1, index <= master.devillaws.len, index++)
+			temp = master.devillaws[index]
+			if (length(temp) > 0)
+				laws.devillaws[index] = temp
+
 		laws.ion.len = master.ion.len
 		for (var/index = 1, index <= master.ion.len, index++)
 			temp = master.ion[index]

--- a/code/modules/mob/living/silicon/robot/laws.dm
+++ b/code/modules/mob/living/silicon/robot/laws.dm
@@ -55,6 +55,12 @@
 			if (length(temp) > 0)
 				laws.ion[index] = temp
 
+		laws.hacked.len = master.hacked.len
+		for (var/index = 1, index <= master.hacked.len, index++)
+			temp = master.hacked[index]
+			if (length(temp) > 0)
+				laws.hacked[index] = temp
+
 		if(master.zeroth_borg) //If the AI has a defined law zero specifically for its borgs, give it that one, otherwise give it the same one. --NEO
 			temp = master.zeroth_borg
 		else

--- a/code/modules/mob/living/silicon/silicon.dm
+++ b/code/modules/mob/living/silicon/silicon.dm
@@ -255,12 +255,12 @@
 		for(var/index = 1, index <= src.laws.devillaws.len, index++)
 			if (!src.devillawcheck[index])
 				src.devillawcheck[index] = "No"
-			list += {"<A href='byond://?src=[REF(src)];lawdevil=[index]'>[src.devillawcheck[index]] 666:</A> [src.laws.devillaws[index]]<BR>"}
+			list += {"<A href='byond://?src=[REF(src)];lawdevil=[index]'>[src.devillawcheck[index]] 666:</A> <font color='#cc5500'>[src.laws.devillaws[index]]</font><BR>"}
 
 	if (src.laws.zeroth)
 		if (!src.lawcheck[1])
 			src.lawcheck[1] = "No" //Given Law 0's usual nature, it defaults to NOT getting reported. --NeoFite
-		list += {"<A href='byond://?src=[REF(src)];lawc=0'>[src.lawcheck[1]] 0:</A> [src.laws.zeroth]<BR>"}
+		list += {"<A href='byond://?src=[REF(src)];lawc=0'>[src.lawcheck[1]] 0:</A> <font color='#ff0000'>[src.laws.zeroth]</font><BR>"}
 
 	for (var/index = 1, index <= src.laws.ion.len, index++)
 		var/law = src.laws.ion[index]
@@ -268,7 +268,7 @@
 		if (length(law) > 0)
 			if (!src.ioncheck[index])
 				src.ioncheck[index] = "Yes"
-			list += {"<A href='byond://?src=[REF(src)];lawi=[index]'>[src.ioncheck[index]] [ionnum()]:</A> [law]<BR>"}
+			list += {"<A href='byond://?src=[REF(src)];lawi=[index]'>[src.ioncheck[index]] [ionnum()]:</A> <font color='#00ffff'>[law]</font><BR>"}
 			src.ioncheck.len += 1
 
 	var/number = 1
@@ -289,7 +289,7 @@
 			src.lawcheck.len += 1
 			if (!src.lawcheck[number+1])
 				src.lawcheck[number+1] = "Yes"
-			list += {"<A href='byond://?src=[REF(src)];lawc=[number]'>[src.lawcheck[number+1]] [number]:</A> [law]<BR>"}
+			list += {"<A href='byond://?src=[REF(src)];lawc=[number]'>[src.lawcheck[number+1]] [number]:</A> <font color='#800080'>[law]</font><BR>"}
 			number++
 	list += {"<br><br><A href='byond://?src=[REF(src)];laws=1'>State Laws</A>"}
 

--- a/code/modules/mob/living/silicon/silicon.dm
+++ b/code/modules/mob/living/silicon/silicon.dm
@@ -227,6 +227,14 @@
 				src.say("[radiomod] [num]. [law]")
 				sleep(10)
 
+	for (var/index = 1, index <= src.laws.hacked.len, index++)
+		var/law = src.laws.hacked[index]
+		var/num = ionnum()
+		if (length(law) > 0)
+			if (force || src.ioncheck[index] == "Yes")
+				src.say("[radiomod] [num]. [law]")
+				sleep(10)
+
 	for (var/index = 1, index <= src.laws.inherent.len, index++)
 		var/law = src.laws.inherent[index]
 
@@ -260,7 +268,7 @@
 	if (src.laws.zeroth)
 		if (!src.lawcheck[1])
 			src.lawcheck[1] = "No" //Given Law 0's usual nature, it defaults to NOT getting reported. --NeoFite
-		list += {"<A href='byond://?src=[REF(src)];lawc=0'>[src.lawcheck[1]] 0:</A> <font color='#ff0000'>[src.laws.zeroth]</font><BR>"}
+		list += {"<A href='byond://?src=[REF(src)];lawc=0'>[src.lawcheck[1]] 0:</A> <font color='#ff0000'><b>[src.laws.zeroth]</b></font><BR>"}
 
 	for (var/index = 1, index <= src.laws.ion.len, index++)
 		var/law = src.laws.ion[index]
@@ -269,6 +277,15 @@
 			if (!src.ioncheck[index])
 				src.ioncheck[index] = "Yes"
 			list += {"<A href='byond://?src=[REF(src)];lawi=[index]'>[src.ioncheck[index]] [ionnum()]:</A> <font color='#00ffff'>[law]</font><BR>"}
+			src.ioncheck.len += 1
+
+	for (var/index = 1, index <= src.laws.hacked.len, index++)
+		var/law = src.laws.hacked[index]
+
+		if (length(law) > 0)
+			if (!src.ioncheck[index])
+				src.ioncheck[index] = "No"
+			list += {"<A href='byond://?src=[REF(src)];lawi=[index]'>[src.ioncheck[index]] [ionnum()]:</A> <font color='#660000'>[law]</font><BR>"}
 			src.ioncheck.len += 1
 
 	var/number = 1
@@ -289,7 +306,7 @@
 			src.lawcheck.len += 1
 			if (!src.lawcheck[number+1])
 				src.lawcheck[number+1] = "Yes"
-			list += {"<A href='byond://?src=[REF(src)];lawc=[number]'>[src.lawcheck[number+1]] [number]:</A> <font color='#800080'>[law]</font><BR>"}
+			list += {"<A href='byond://?src=[REF(src)];lawc=[number]'>[src.lawcheck[number+1]] [number]:</A> <font color='#990099'>[law]</font><BR>"}
 			number++
 	list += {"<br><br><A href='byond://?src=[REF(src)];laws=1'>State Laws</A>"}
 

--- a/code/modules/mob/living/silicon/silicon.dm
+++ b/code/modules/mob/living/silicon/silicon.dm
@@ -294,7 +294,7 @@
 		if (length(law) > 0)
 			if (!ioncheck[index])
 				ioncheck[index] = "Yes"
-			list += {"<A href='byond://?src=[REF(src)];lawi=[index]'>[ioncheck[index]] [ionnum()]:</A> <font color='#00ffff'>[law]</font><BR>"}
+			list += {"<A href='byond://?src=[REF(src)];lawi=[index]'>[ioncheck[index]] [ionnum()]:</A> <font color='#547DFE'>[law]</font><BR>"}
 			ioncheck.len += 1
 
 	var/number = 1

--- a/code/modules/mob/living/silicon/silicon.dm
+++ b/code/modules/mob/living/silicon/silicon.dm
@@ -229,19 +229,19 @@
 			say("[radiomod] 0. [laws.zeroth]")
 			sleep(10)
 
-	for (var/index = 1, index <= laws.ion.len, index++)
-		var/law = laws.ion[index]
-		var/num = ionnum()
-		if (length(law) > 0)
-			if (force || ioncheck[index] == "Yes")
-				say("[radiomod] [num]. [law]")
-				sleep(10)
-
 	for (var/index = 1, index <= laws.hacked.len, index++)
 		var/law = laws.hacked[index]
 		var/num = ionnum()
 		if (length(law) > 0)
 			if (force || hackedcheck[index] == "Yes")
+				say("[radiomod] [num]. [law]")
+				sleep(10)
+
+	for (var/index = 1, index <= laws.ion.len, index++)
+		var/law = laws.ion[index]
+		var/num = ionnum()
+		if (length(law) > 0)
+			if (force || ioncheck[index] == "Yes")
 				say("[radiomod] [num]. [law]")
 				sleep(10)
 

--- a/code/modules/mob/living/silicon/silicon.dm
+++ b/code/modules/mob/living/silicon/silicon.dm
@@ -184,7 +184,7 @@
 		checklaws()
 
 	if (href_list["lawh"])
-		var/L = text2num(href_list["lawi"])
+		var/L = text2num(href_list["lawh"])
 		switch(hackedcheck[L])
 			if ("Yes")
 				hackedcheck[L] = "No"
@@ -280,6 +280,14 @@
 			lawcheck[1] = "No" //Given Law 0's usual nature, it defaults to NOT getting reported. --NeoFite
 		list += {"<A href='byond://?src=[REF(src)];lawc=0'>[lawcheck[1]] 0:</A> <font color='#ff0000'><b>[laws.zeroth]</b></font><BR>"}
 
+	for (var/index = 1, index <= laws.hacked.len, index++)
+		var/law = laws.hacked[index]
+		if (length(law) > 0)
+			if (!hackedcheck[index])
+				hackedcheck[index] = "No"
+			list += {"<A href='byond://?src=[REF(src)];lawh=[index]'>[hackedcheck[index]] [ionnum()]:</A> <font color='#660000'>[law]</font><BR>"}
+			hackedcheck.len += 1
+
 	for (var/index = 1, index <= laws.ion.len, index++)
 		var/law = laws.ion[index]
 
@@ -287,15 +295,6 @@
 			if (!ioncheck[index])
 				ioncheck[index] = "Yes"
 			list += {"<A href='byond://?src=[REF(src)];lawi=[index]'>[ioncheck[index]] [ionnum()]:</A> <font color='#00ffff'>[law]</font><BR>"}
-			ioncheck.len += 1
-
-	for (var/index = 1, index <= laws.hacked.len, index++)
-		var/law = laws.hacked[index]
-
-		if (length(law) > 0)
-			if (!hackedcheck[index])
-				hackedcheck[index] = "No"
-			list += {"<A href='byond://?src=[REF(src)];lawi=[index]'>[hackedcheck[index]] [ionnum()]:</A> <font color='#660000'>[law]</font><BR>"}
 			ioncheck.len += 1
 
 	var/number = 1

--- a/code/modules/mob/living/silicon/silicon.dm
+++ b/code/modules/mob/living/silicon/silicon.dm
@@ -27,6 +27,7 @@
 
 	var/lawcheck[1]
 	var/ioncheck[1]
+	var/hackedcheck[1]
 	var/devillawcheck[5]
 
 	var/sensors_on = 0
@@ -182,6 +183,15 @@
 				ioncheck[L] = "Yes"
 		checklaws()
 
+	if (href_list["lawh"])
+		var/L = text2num(href_list["lawi"])
+		switch(hackedcheck[L])
+			if ("Yes")
+				hackedcheck[L] = "No"
+			if ("No")
+				hackedcheck[L] = "Yes"
+		checklaws()
+
 	if (href_list["lawdevil"]) // Toggling whether or not a law gets stated by the State Laws verb --NeoFite
 		var/L = text2num(href_list["lawdevil"])
 		switch(devillawcheck[L])
@@ -201,56 +211,56 @@
 /mob/living/silicon/proc/statelaws(force = 0)
 
 	//"radiomod" is inserted before a hardcoded message to change if and how it is handled by an internal radio.
-	src.say("[radiomod] Current Active Laws:")
-	//src.laws_sanity_check()
-	//src.laws.show_laws(world)
+	say("[radiomod] Current Active Laws:")
+	//laws_sanity_check()
+	//laws.show_laws(world)
 	var/number = 1
 	sleep(10)
 
-	if (src.laws.devillaws && src.laws.devillaws.len)
-		for(var/index = 1, index <= src.laws.devillaws.len, index++)
-			if (force || src.devillawcheck[index] == "Yes")
-				src.say("[radiomod] 666. [src.laws.devillaws[index]]")
+	if (laws.devillaws && laws.devillaws.len)
+		for(var/index = 1, index <= laws.devillaws.len, index++)
+			if (force || devillawcheck[index] == "Yes")
+				say("[radiomod] 666. [laws.devillaws[index]]")
 				sleep(10)
 
 
-	if (src.laws.zeroth)
-		if (force || src.lawcheck[1] == "Yes")
-			src.say("[radiomod] 0. [src.laws.zeroth]")
+	if (laws.zeroth)
+		if (force || lawcheck[1] == "Yes")
+			say("[radiomod] 0. [laws.zeroth]")
 			sleep(10)
 
-	for (var/index = 1, index <= src.laws.ion.len, index++)
-		var/law = src.laws.ion[index]
+	for (var/index = 1, index <= laws.ion.len, index++)
+		var/law = laws.ion[index]
 		var/num = ionnum()
 		if (length(law) > 0)
-			if (force || src.ioncheck[index] == "Yes")
-				src.say("[radiomod] [num]. [law]")
+			if (force || ioncheck[index] == "Yes")
+				say("[radiomod] [num]. [law]")
 				sleep(10)
 
-	for (var/index = 1, index <= src.laws.hacked.len, index++)
-		var/law = src.laws.hacked[index]
+	for (var/index = 1, index <= laws.hacked.len, index++)
+		var/law = laws.hacked[index]
 		var/num = ionnum()
 		if (length(law) > 0)
-			if (force || src.ioncheck[index] == "Yes")
-				src.say("[radiomod] [num]. [law]")
+			if (force || hackedcheck[index] == "Yes")
+				say("[radiomod] [num]. [law]")
 				sleep(10)
 
-	for (var/index = 1, index <= src.laws.inherent.len, index++)
-		var/law = src.laws.inherent[index]
+	for (var/index = 1, index <= laws.inherent.len, index++)
+		var/law = laws.inherent[index]
 
 		if (length(law) > 0)
-			if (force || src.lawcheck[index+1] == "Yes")
-				src.say("[radiomod] [number]. [law]")
+			if (force || lawcheck[index+1] == "Yes")
+				say("[radiomod] [number]. [law]")
 				number++
 				sleep(10)
 
-	for (var/index = 1, index <= src.laws.supplied.len, index++)
-		var/law = src.laws.supplied[index]
+	for (var/index = 1, index <= laws.supplied.len, index++)
+		var/law = laws.supplied[index]
 
 		if (length(law) > 0)
-			if(src.lawcheck.len >= number+1)
-				if (force || src.lawcheck[number+1] == "Yes")
-					src.say("[radiomod] [number]. [law]")
+			if(lawcheck.len >= number+1)
+				if (force || lawcheck[number+1] == "Yes")
+					say("[radiomod] [number]. [law]")
 					number++
 					sleep(10)
 
@@ -259,54 +269,54 @@
 
 	var/list = "<b>Which laws do you want to include when stating them for the crew?</b><br><br>"
 
-	if (src.laws.devillaws && src.laws.devillaws.len)
-		for(var/index = 1, index <= src.laws.devillaws.len, index++)
-			if (!src.devillawcheck[index])
-				src.devillawcheck[index] = "No"
-			list += {"<A href='byond://?src=[REF(src)];lawdevil=[index]'>[src.devillawcheck[index]] 666:</A> <font color='#cc5500'>[src.laws.devillaws[index]]</font><BR>"}
+	if (laws.devillaws && laws.devillaws.len)
+		for(var/index = 1, index <= laws.devillaws.len, index++)
+			if (!devillawcheck[index])
+				devillawcheck[index] = "No"
+			list += {"<A href='byond://?src=[REF(src)];lawdevil=[index]'>[devillawcheck[index]] 666:</A> <font color='#cc5500'>[laws.devillaws[index]]</font><BR>"}
 
-	if (src.laws.zeroth)
-		if (!src.lawcheck[1])
-			src.lawcheck[1] = "No" //Given Law 0's usual nature, it defaults to NOT getting reported. --NeoFite
-		list += {"<A href='byond://?src=[REF(src)];lawc=0'>[src.lawcheck[1]] 0:</A> <font color='#ff0000'><b>[src.laws.zeroth]</b></font><BR>"}
+	if (laws.zeroth)
+		if (!lawcheck[1])
+			lawcheck[1] = "No" //Given Law 0's usual nature, it defaults to NOT getting reported. --NeoFite
+		list += {"<A href='byond://?src=[REF(src)];lawc=0'>[lawcheck[1]] 0:</A> <font color='#ff0000'><b>[laws.zeroth]</b></font><BR>"}
 
-	for (var/index = 1, index <= src.laws.ion.len, index++)
-		var/law = src.laws.ion[index]
-
-		if (length(law) > 0)
-			if (!src.ioncheck[index])
-				src.ioncheck[index] = "Yes"
-			list += {"<A href='byond://?src=[REF(src)];lawi=[index]'>[src.ioncheck[index]] [ionnum()]:</A> <font color='#00ffff'>[law]</font><BR>"}
-			src.ioncheck.len += 1
-
-	for (var/index = 1, index <= src.laws.hacked.len, index++)
-		var/law = src.laws.hacked[index]
+	for (var/index = 1, index <= laws.ion.len, index++)
+		var/law = laws.ion[index]
 
 		if (length(law) > 0)
-			if (!src.ioncheck[index])
-				src.ioncheck[index] = "No"
-			list += {"<A href='byond://?src=[REF(src)];lawi=[index]'>[src.ioncheck[index]] [ionnum()]:</A> <font color='#660000'>[law]</font><BR>"}
-			src.ioncheck.len += 1
+			if (!ioncheck[index])
+				ioncheck[index] = "Yes"
+			list += {"<A href='byond://?src=[REF(src)];lawi=[index]'>[ioncheck[index]] [ionnum()]:</A> <font color='#00ffff'>[law]</font><BR>"}
+			ioncheck.len += 1
+
+	for (var/index = 1, index <= laws.hacked.len, index++)
+		var/law = laws.hacked[index]
+
+		if (length(law) > 0)
+			if (!hackedcheck[index])
+				hackedcheck[index] = "No"
+			list += {"<A href='byond://?src=[REF(src)];lawi=[index]'>[hackedcheck[index]] [ionnum()]:</A> <font color='#660000'>[law]</font><BR>"}
+			ioncheck.len += 1
 
 	var/number = 1
-	for (var/index = 1, index <= src.laws.inherent.len, index++)
-		var/law = src.laws.inherent[index]
+	for (var/index = 1, index <= laws.inherent.len, index++)
+		var/law = laws.inherent[index]
 
 		if (length(law) > 0)
-			src.lawcheck.len += 1
+			lawcheck.len += 1
 
-			if (!src.lawcheck[number+1])
-				src.lawcheck[number+1] = "Yes"
-			list += {"<A href='byond://?src=[REF(src)];lawc=[number]'>[src.lawcheck[number+1]] [number]:</A> [law]<BR>"}
+			if (!lawcheck[number+1])
+				lawcheck[number+1] = "Yes"
+			list += {"<A href='byond://?src=[REF(src)];lawc=[number]'>[lawcheck[number+1]] [number]:</A> [law]<BR>"}
 			number++
 
-	for (var/index = 1, index <= src.laws.supplied.len, index++)
-		var/law = src.laws.supplied[index]
+	for (var/index = 1, index <= laws.supplied.len, index++)
+		var/law = laws.supplied[index]
 		if (length(law) > 0)
-			src.lawcheck.len += 1
-			if (!src.lawcheck[number+1])
-				src.lawcheck[number+1] = "Yes"
-			list += {"<A href='byond://?src=[REF(src)];lawc=[number]'>[src.lawcheck[number+1]] [number]:</A> <font color='#990099'>[law]</font><BR>"}
+			lawcheck.len += 1
+			if (!lawcheck[number+1])
+				lawcheck[number+1] = "Yes"
+			list += {"<A href='byond://?src=[REF(src)];lawc=[number]'>[lawcheck[number+1]] [number]:</A> <font color='#990099'>[law]</font><BR>"}
 			number++
 	list += {"<br><br><A href='byond://?src=[REF(src)];laws=1'>State Laws</A>"}
 


### PR DESCRIPTION
When laws are shown to an AI or cyborg they are colored depending on their type.
Devil laws are [burnt orange](https://www.colorhexa.com/cc5500)
Zeroth law is [bold red](https://www.colorhexa.com/ff0000)
Ion laws are [cyan](https://www.colorhexa.com/00ffff)
Hacked laws are [blood red](https://www.colorhexa.com/660000)
Standard laws are unchanged
Freeform laws are [purple](https://www.colorhexa.com/990099)

![capture](https://user-images.githubusercontent.com/4343468/37555358-3dddffaa-2a3a-11e8-8379-ce58ab7a88a0.PNG)

I also added handling for cyborgs inheriting devil laws from AIs, even though it shouldn't happen, because >badmins

For @TribeOfBeavers 