### PR TITLE
Reverts #34291 (sacid for boards)

### DIFF
--- a/code/modules/research/designs/comp_board_designs.dm
+++ b/code/modules/research/designs/comp_board_designs.dm
@@ -5,6 +5,7 @@
 	desc = "I promise this doesn't give you syndicate goodies!"
 	build_type = IMPRINTER
 	materials = list(MAT_GLASS = 1000)
+	reagents_list = list("sacid" = 20)
 
 /datum/design/board/arcade_battle
 	name = "Computer Design (Battle Arcade Machine)"


### PR DESCRIPTION
:cl: yorii
balance: circuit boards now again require sulphuric acid to make
/:cl:

[why]: Why remove inter-departmental cooperation for no reason whatsoever?

Reverts #34291