### PR TITLE
Omegastation: The spring cleaning DLC

### DIFF
--- a/_maps/map_files/OmegaStation/OmegaStation.dmm
+++ b/_maps/map_files/OmegaStation/OmegaStation.dmm
@@ -2363,7 +2363,6 @@
 /area/crew_quarters/heads/hop)
 "aeO" = (
 /obj/structure/table/wood,
-/obj/machinery/computer/med_data/laptop,
 /obj/machinery/newscaster{
 	pixel_y = 32
 	},
@@ -2376,6 +2375,7 @@
 	pixel_x = 28;
 	pixel_y = 24
 	},
+/obj/machinery/recharger,
 /turf/open/floor/plasteel/vault/corner{
 	dir = 8
 	},
@@ -2518,11 +2518,7 @@
 	},
 /area/crew_quarters/heads/captain/private)
 "afl" = (
-/obj/item/twohanded/required/kirbyplants{
-	icon_state = "plant-15";
-	pixel_x = -6;
-	pixel_y = 12
-	},
+/obj/item/twohanded/required/kirbyplants/random,
 /turf/open/floor/wood,
 /area/crew_quarters/heads/captain/private)
 "afm" = (
@@ -2542,9 +2538,6 @@
 /turf/open/floor/wood,
 /area/crew_quarters/heads/captain/private)
 "afo" = (
-/obj/item/twohanded/required/kirbyplants{
-	icon_state = "plant-21"
-	},
 /obj/item/device/radio/intercom{
 	dir = 8;
 	freerange = 1;
@@ -2557,6 +2550,16 @@
 /obj/machinery/camera{
 	c_tag = "Captain's Office";
 	dir = 8
+	},
+/obj/structure/table/wood,
+/obj/machinery/recharger{
+	pixel_x = 5;
+	pixel_y = 0
+	},
+/obj/item/twohanded/required/kirbyplants{
+	icon_state = "plant-15";
+	pixel_x = -6;
+	pixel_y = 12
 	},
 /turf/open/floor/wood{
 	icon_state = "wood-broken2"
@@ -13955,6 +13958,8 @@
 /obj/machinery/newscaster{
 	pixel_y = 32
 	},
+/obj/item/storage/box/donkpockets,
+/obj/item/storage/box/donkpockets,
 /turf/open/floor/plasteel/vault/side,
 /area/crew_quarters/kitchen)
 "aDa" = (
@@ -21414,6 +21419,8 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 6
 	},
+/obj/item/storage/box/pillbottles,
+/obj/item/storage/box/beakers,
 /turf/open/floor/plasteel,
 /area/medical/chemistry)
 "aTr" = (
@@ -23557,19 +23564,11 @@
 /turf/open/floor/plasteel,
 /area/medical/medbay/zone3)
 "aXW" = (
-/obj/structure/table,
-/obj/item/reagent_containers/glass/beaker/cryoxadone{
-	pixel_x = -6;
-	pixel_y = 6
-	},
-/obj/item/reagent_containers/glass/beaker/cryoxadone{
-	pixel_x = 6;
-	pixel_y = 6
-	},
-/obj/item/storage/pill_bottle/mannitol,
 /obj/effect/turf_decal/stripes/line{
 	dir = 5
 	},
+/obj/machinery/atmospherics/components/unary/portables_connector/visible,
+/obj/machinery/portable_atmospherics/canister/oxygen,
 /turf/open/floor/plasteel,
 /area/medical/medbay/zone3)
 "aXX" = (
@@ -23999,16 +23998,26 @@
 "aYO" = (
 /obj/machinery/atmospherics/pipe/manifold/general/visible,
 /obj/effect/turf_decal/stripes/line,
+/obj/item/wrench/medical,
 /turf/open/floor/plasteel,
 /area/medical/medbay/zone3)
 "aYP" = (
-/obj/machinery/portable_atmospherics/canister/oxygen,
-/obj/machinery/atmospherics/components/unary/portables_connector/visible{
-	dir = 8
-	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 6
 	},
+/obj/machinery/atmospherics/pipe/simple/general/visible{
+	dir = 9
+	},
+/obj/structure/table,
+/obj/item/reagent_containers/glass/beaker/cryoxadone{
+	pixel_x = -6;
+	pixel_y = 6
+	},
+/obj/item/reagent_containers/glass/beaker/cryoxadone{
+	pixel_x = 6;
+	pixel_y = 6
+	},
+/obj/item/storage/pill_bottle/mannitol,
 /turf/open/floor/plasteel,
 /area/medical/medbay/zone3)
 "aYQ" = (
@@ -31457,6 +31466,10 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos)
+"fMP" = (
+/obj/structure/grille,
+/turf/open/space/basic,
+/area/space/nearstation)
 "fMT" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -32425,6 +32438,11 @@
 	},
 /turf/closed/wall/r_wall,
 /area/engine/atmos)
+"pZU" = (
+/obj/structure/lattice,
+/obj/structure/grille,
+/turf/open/space/basic,
+/area/space/nearstation)
 "qdt" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 5
@@ -32642,6 +32660,10 @@
 /obj/machinery/hydroponics/soil,
 /turf/open/floor/plasteel/vault/side,
 /area/maintenance/starboard/aft)
+"sdX" = (
+/obj/structure/lattice,
+/turf/open/space/basic,
+/area/space/nearstation)
 "soC" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -34334,7 +34356,7 @@
 /area/ai_monitored/turret_protected/aisat_interior)
 "sMP" = (
 /obj/machinery/power/smes{
-	charge = 1e+006
+	charge = 5e+006
 	},
 /obj/structure/cable/white{
 	icon_state = "0-8"
@@ -34557,11 +34579,12 @@
 	},
 /area/ai_monitored/turret_protected/aisat_interior)
 "sNm" = (
+/obj/effect/turf_decal/bot,
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden,
 /obj/structure/transit_tube/station/reverse/flipped{
 	dir = 4
 	},
-/obj/effect/turf_decal/bot,
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden,
+/obj/structure/transit_tube_pod,
 /turf/open/floor/plating,
 /area/ai_monitored/turret_protected/aisat_interior)
 "sNn" = (
@@ -34821,7 +34844,7 @@
 /area/space/nearstation)
 "sNP" = (
 /obj/structure/transit_tube,
-/obj/effect/spawner/structure/window/hollow/reinforced/middle,
+/obj/structure/window/reinforced/fulltile,
 /turf/open/floor/plating,
 /area/ai_monitored/turret_protected/aisat_interior)
 "sNQ" = (
@@ -34884,7 +34907,7 @@
 /area/space/nearstation)
 "sOr" = (
 /obj/structure/transit_tube,
-/obj/effect/spawner/structure/window/hollow/reinforced/middle,
+/obj/structure/window/reinforced/fulltile,
 /turf/open/floor/plating,
 /area/bridge)
 "sOs" = (
@@ -34928,7 +34951,6 @@
 "sOw" = (
 /obj/effect/turf_decal/bot,
 /obj/structure/transit_tube/station/reverse{
-	tag = "icon-closed_terminus0 (WEST)";
 	icon_state = "closed_terminus0";
 	dir = 8
 	},
@@ -78287,11 +78309,11 @@ aad
 aac
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+fMP
+pZU
+pZU
+sdX
+sdX
 aaf
 aaa
 aam
@@ -78545,7 +78567,7 @@ aad
 aac
 aac
 aaa
-aaa
+sdX
 aaa
 aaa
 aaa

--- a/_maps/map_files/OmegaStation/OmegaStation.dmm
+++ b/_maps/map_files/OmegaStation/OmegaStation.dmm
@@ -2553,8 +2553,7 @@
 	},
 /obj/structure/table/wood,
 /obj/machinery/recharger{
-	pixel_x = 5;
-	pixel_y = 0
+	pixel_x = 5
 	},
 /obj/item/twohanded/required/kirbyplants{
 	icon_state = "plant-15";

--- a/_maps/map_files/OmegaStation/OmegaStation.dmm
+++ b/_maps/map_files/OmegaStation/OmegaStation.dmm
@@ -7978,28 +7978,10 @@
 	},
 /turf/open/space/basic,
 /area/space)
-"apu" = (
-/obj/machinery/atmospherics/components/unary/outlet_injector/on{
-	dir = 2;
-	frequency = 1441;
-	id = "mix_in";
-	pixel_y = 1
-	},
-/turf/open/floor/engine/vacuum,
-/area/engine/atmos)
 "apv" = (
 /obj/machinery/air_sensor{
 	frequency = 1441;
 	id_tag = "mix_sensor"
-	},
-/turf/open/floor/engine/vacuum,
-/area/engine/atmos)
-"apw" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/siphon/on{
-	dir = 2;
-	frequency = 1441;
-	id_tag = "mix_in";
-	name = "distro vent"
 	},
 /turf/open/floor/engine/vacuum,
 /area/engine/atmos)
@@ -8608,56 +8590,34 @@
 /turf/closed/wall/r_wall,
 /area/engine/atmos)
 "aqA" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 6
-	},
-/turf/closed/wall/r_wall,
-/area/engine/atmos)
-"aqC" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/obj/structure/grille,
-/turf/closed/wall/r_wall,
-/area/engine/atmos)
-"aqD" = (
-/obj/machinery/meter,
-/obj/structure/grille,
-/obj/machinery/atmospherics/pipe/simple/green/visible,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/turf/closed/wall/r_wall,
-/area/engine/atmos)
-"aqE" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
 /obj/effect/spawner/structure/window/plasma/reinforced,
 /turf/open/floor/plating,
 /area/engine/atmos)
-"aqF" = (
+"aqC" = (
 /obj/machinery/meter,
 /obj/structure/grille,
-/obj/machinery/atmospherics/pipe/simple/yellow/visible,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
+/obj/machinery/atmospherics/pipe/simple/green/visible,
+/turf/closed/wall/r_wall,
+/area/engine/atmos)
+"aqE" = (
+/obj/machinery/meter,
+/obj/structure/grille,
+/obj/machinery/atmospherics/pipe/manifold/yellow/visible{
+	dir = 8
+	},
+/turf/closed/wall/r_wall,
+/area/engine/atmos)
+"aqF" = (
+/obj/structure/grille,
+/obj/machinery/atmospherics/pipe/simple/yellow/visible{
+	dir = 10
 	},
 /turf/closed/wall/r_wall,
 /area/engine/atmos)
 "aqG" = (
 /obj/structure/door_assembly/door_assembly_mhatch,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
 /turf/open/floor/plating/astplate,
 /area/maintenance/port/fore)
-"aqH" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 10
-	},
-/turf/closed/wall/r_wall,
-/area/security/brig)
 "aqI" = (
 /obj/structure/closet/secure_closet/security/sec,
 /obj/item/device/radio/intercom{
@@ -8998,112 +8958,45 @@
 	dir = 6
 	},
 /area/quartermaster/miningdock)
-"arq" = (
-/obj/machinery/atmospherics/pipe/simple/cyan/hidden{
-	dir = 6
-	},
-/obj/structure/grille,
-/turf/closed/wall/r_wall,
-/area/engine/atmos)
 "arr" = (
-/obj/machinery/atmospherics/pipe/simple/cyan/visible{
-	dir = 4
+/obj/machinery/atmospherics/components/trinary/filter/flipped{
+	dir = 8;
+	filter_type = "n2o"
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/turf/open/floor/plasteel/vault,
-/area/engine/atmos)
-"ars" = (
-/obj/machinery/atmospherics/pipe/simple/cyan/visible{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/structure/sign/warning/fire{
-	pixel_y = 32
-	},
-/obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel/vault{
-	dir = 8
-	},
-/area/engine/atmos)
-"art" = (
-/obj/machinery/atmospherics/pipe/simple/cyan/visible{
-	dir = 4
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 9
-	},
-/turf/open/floor/plasteel,
-/area/engine/atmos)
-"aru" = (
-/obj/machinery/status_display{
-	pixel_y = 32
-	},
-/obj/machinery/light{
-	dir = 1
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/manifold/cyan/visible{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/engine/atmos)
-"arv" = (
-/obj/machinery/atmospherics/pipe/simple/cyan/visible{
-	dir = 4
-	},
-/obj/effect/turf_decal/stripes/line{
 	dir = 5
 	},
-/turf/open/floor/plasteel,
+/area/engine/atmos)
+"arv" = (
+/obj/machinery/atmospherics/pipe/simple/green/visible{
+	dir = 9
+	},
+/turf/open/floor/plasteel/vault{
+	dir = 5
+	},
 /area/engine/atmos)
 "arw" = (
-/obj/machinery/atmospherics/pipe/simple/green/visible,
-/obj/machinery/atmospherics/pipe/simple/cyan/visible{
-	dir = 4
-	},
-/obj/machinery/camera{
-	c_tag = "Atmospherics Tank 4";
-	pixel_x = 10
-	},
-/turf/open/floor/plasteel/green/side{
-	dir = 9
+/turf/open/floor/plasteel/vault{
+	dir = 5
 	},
 /area/engine/atmos)
 "arx" = (
-/obj/machinery/computer/atmos_control/tank{
-	frequency = 1441;
-	input_tag = "mix_in";
-	name = "Gas Mix Tank Control";
-	output_tag = "mix_in";
-	sensors = list("mix_sensor" = "Tank")
-	},
-/obj/machinery/atmospherics/pipe/simple/cyan/visible{
-	dir = 4
-	},
-/obj/effect/turf_decal/bot,
-/turf/open/floor/plasteel/green/side{
-	dir = 1
+/obj/machinery/atmospherics/pipe/simple/yellow/visible,
+/turf/open/floor/plasteel/vault{
+	dir = 5
 	},
 /area/engine/atmos)
 "ary" = (
-/obj/machinery/atmospherics/pipe/simple/yellow/visible,
-/obj/machinery/atmospherics/pipe/simple/cyan/visible{
-	dir = 4
-	},
-/turf/open/floor/plasteel/green/side{
+/obj/machinery/atmospherics/components/binary/pump,
+/turf/open/floor/plasteel/vault{
 	dir = 5
 	},
 /area/engine/atmos)
 "arz" = (
-/obj/effect/turf_decal/delivery,
-/obj/machinery/atmospherics/pipe/simple/cyan/visible{
-	dir = 10
+/obj/machinery/atmospherics/pipe/simple/cyan/visible,
+/turf/open/floor/plasteel/vault{
+	dir = 5
 	},
-/turf/open/floor/plasteel,
 /area/engine/atmos)
 "arA" = (
 /obj/structure/sign/warning/nosmoking{
@@ -9584,94 +9477,38 @@
 /turf/open/floor/engine/n2,
 /area/engine/atmos)
 "asw" = (
-/obj/machinery/atmospherics/components/unary/outlet_injector/on{
-	dir = 4;
-	frequency = 1441;
-	id = "n2_in"
-	},
-/turf/open/floor/engine/n2,
+/obj/machinery/atmospherics/pipe/manifold/yellow/visible,
+/turf/open/floor/plasteel/neutral,
 /area/engine/atmos)
 "asx" = (
-/obj/machinery/meter,
-/obj/structure/grille,
-/obj/machinery/atmospherics/pipe/simple/cyan/visible,
-/obj/machinery/atmospherics/pipe/simple/general/visible{
-	dir = 4
-	},
-/turf/closed/wall/r_wall,
-/area/engine/atmos)
-"asz" = (
-/obj/machinery/atmospherics/components/trinary/filter{
-	dir = 2;
-	filter_type = "n2";
-	name = "nitrogen filter";
-	on = 1
-	},
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 1
-	},
-/obj/effect/turf_decal/bot,
-/turf/open/floor/plasteel/red/side{
-	dir = 9
-	},
-/area/engine/atmos)
-"asB" = (
-/obj/machinery/atmospherics/components/unary/thermomachine/heater{
+/obj/machinery/atmospherics/pipe/manifold/yellow/visible{
 	dir = 1
 	},
 /turf/open/floor/plasteel/neutral,
 /area/engine/atmos)
 "asC" = (
-/obj/machinery/atmospherics/pipe/simple/green/visible{
-	dir = 6
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/engine/atmos)
-"asD" = (
-/obj/machinery/atmospherics/pipe/simple/green/visible{
-	dir = 4
-	},
-/obj/machinery/atmospherics/components/binary/pump{
-	dir = 1;
-	name = "Unfiltered & Air to Mix";
-	on = 1
-	},
-/turf/open/floor/plasteel/caution{
-	dir = 8
-	},
-/area/engine/atmos)
-"asE" = (
-/obj/machinery/atmospherics/pipe/manifold/green/visible{
-	dir = 1
+/obj/machinery/atmospherics/pipe/simple/yellow/visible{
+	dir = 10
 	},
 /turf/open/floor/plasteel/neutral,
 /area/engine/atmos)
+"asD" = (
+/obj/machinery/computer/atmos_control/tank,
+/turf/open/floor/plasteel/neutral,
+/area/engine/atmos)
 "asF" = (
-/obj/machinery/atmospherics/pipe/simple/yellow/visible,
-/obj/machinery/atmospherics/components/binary/pump{
-	dir = 8;
-	name = "Air to Mix"
+/obj/machinery/atmospherics/pipe/simple/supply/visible{
+	dir = 5
 	},
 /turf/open/floor/plasteel/neutral,
 /area/engine/atmos)
 "asG" = (
-/obj/machinery/atmospherics/pipe/manifold/cyan/visible{
-	dir = 2
+/obj/machinery/atmospherics/pipe/manifold/supply/visible{
+	dir = 4
 	},
-/obj/machinery/meter,
 /turf/open/floor/plasteel/neutral,
 /area/engine/atmos)
 "asH" = (
-/obj/machinery/atmospherics/pipe/simple/cyan/visible{
-	dir = 10
-	},
 /turf/open/floor/plasteel/caution{
 	dir = 4
 	},
@@ -10086,13 +9923,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/maintenance/starboard)
-"atw" = (
-/obj/machinery/portable_atmospherics/canister/nitrogen,
-/obj/machinery/light/small{
-	dir = 8
-	},
-/turf/open/floor/engine/n2,
-/area/engine/atmos)
 "atx" = (
 /obj/machinery/air_sensor{
 	frequency = 1441;
@@ -10101,75 +9931,15 @@
 /turf/open/floor/engine/n2,
 /area/engine/atmos)
 "aty" = (
-/obj/machinery/atmospherics/pipe/simple/cyan/visible,
-/obj/effect/spawner/structure/window/plasma/reinforced,
-/turf/open/floor/plating,
-/area/engine/atmos)
-"atz" = (
-/obj/machinery/camera{
-	c_tag = "Atmospherics Tank 1";
+/obj/machinery/atmospherics/pipe/simple/cyan/visible{
 	dir = 4
 	},
-/turf/open/floor/plasteel/vault{
-	dir = 5
-	},
-/area/engine/atmos)
-"atA" = (
-/obj/machinery/computer/atmos_control/tank{
-	dir = 4;
-	frequency = 1441;
-	input_tag = "n2_in";
-	name = "Nitrogen Supply Control";
-	output_tag = "n2_out";
-	sensors = list("n2_sensor" = "Tank")
-	},
-/obj/machinery/atmospherics/pipe/simple/green/visible,
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/effect/turf_decal/bot,
-/turf/open/floor/plasteel/red/side{
-	dir = 8
-	},
-/area/engine/atmos)
-"atB" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/engine/atmos)
-"atC" = (
-/obj/machinery/holopad,
-/obj/effect/turf_decal/bot,
-/turf/open/floor/plasteel,
-/area/engine/atmos)
-"atE" = (
-/obj/machinery/atmospherics/pipe/simple/green/visible{
-	dir = 5
-	},
-/turf/open/floor/plasteel/caution{
-	dir = 8
-	},
-/area/engine/atmos)
-"atF" = (
-/obj/machinery/atmospherics/pipe/manifold/green/visible{
-	dir = 4
-	},
-/turf/open/floor/plasteel/neutral,
-/area/engine/atmos)
-"atH" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
-	dir = 4
+/obj/machinery/atmospherics/components/binary/pump{
+	dir = 1
 	},
 /turf/open/floor/plasteel/neutral,
 /area/engine/atmos)
 "atI" = (
-/obj/machinery/atmospherics/components/binary/pump{
-	dir = 2;
-	name = "Air to Distro";
-	on = 1;
-	target_pressure = 101
-	},
 /obj/machinery/power/apc{
 	dir = 4;
 	name = "Atmospherics Engine APC";
@@ -10179,23 +9949,13 @@
 /obj/structure/cable/white{
 	icon_state = "0-2"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
+/obj/structure/closet/wardrobe/atmospherics_yellow,
+/obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel/caution{
 	dir = 4
 	},
 /area/engine/atmos)
-"atJ" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/turf/closed/wall/r_wall/rust,
-/area/engine/atmos)
 "atK" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 10
-	},
 /obj/structure/sign/poster/contraband/random{
 	pixel_x = 32
 	},
@@ -10570,47 +10330,8 @@
 /turf/open/floor/plasteel/neutral/corner,
 /area/hallway/primary/starboard/fore)
 "auq" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/siphon/on{
-	dir = 4;
-	frequency = 1441;
-	id_tag = "n2_out";
-	name = "n2 vent"
-	},
-/turf/open/floor/engine/n2,
-/area/engine/atmos)
-"aur" = (
-/obj/machinery/meter,
-/obj/structure/grille,
-/obj/machinery/atmospherics/pipe/simple/cyan/visible,
-/obj/machinery/atmospherics/pipe/simple/cyan/visible{
-	dir = 4
-	},
-/turf/closed/wall/r_wall,
-/area/engine/atmos)
-"aut" = (
-/obj/machinery/atmospherics/pipe/simple/green/visible,
-/obj/machinery/atmospherics/components/binary/pump{
-	dir = 4;
-	name = "N2 to Airmix";
-	on = 1
-	},
-/obj/structure/window/reinforced,
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/effect/turf_decal/bot,
-/turf/open/floor/plasteel/red/side{
-	dir = 10
-	},
-/area/engine/atmos)
-"auu" = (
-/obj/machinery/atmospherics/pipe/simple/cyan/visible{
-	dir = 4
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
+/obj/machinery/atmospherics/pipe/manifold/general/visible,
+/turf/open/floor/plasteel/neutral,
 /area/engine/atmos)
 "auv" = (
 /obj/machinery/atmospherics/pipe/simple/cyan/visible{
@@ -10619,44 +10340,22 @@
 /turf/open/floor/plasteel/neutral,
 /area/engine/atmos)
 "auw" = (
-/obj/machinery/atmospherics/pipe/simple/green/visible,
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/engine/atmos)
-"aux" = (
-/obj/machinery/atmospherics/pipe/simple/green/visible{
-	dir = 6
-	},
-/turf/open/floor/plasteel/caution{
-	dir = 8
-	},
+/obj/machinery/atmospherics/components/binary/pump,
+/turf/open/floor/plasteel/neutral,
 /area/engine/atmos)
 "auy" = (
-/obj/machinery/atmospherics/pipe/simple/green/visible{
+/obj/machinery/atmospherics/pipe/simple/general/visible{
 	dir = 9
 	},
 /turf/open/floor/plasteel/neutral,
 /area/engine/atmos)
-"auz" = (
-/obj/machinery/atmospherics/pipe/manifold/yellow/visible{
+"auA" = (
+/obj/machinery/atmospherics/pipe/manifold/supply/visible{
 	dir = 8
 	},
 /turf/open/floor/plasteel/neutral,
 /area/engine/atmos)
-"auA" = (
-/obj/machinery/atmospherics/components/binary/pump{
-	dir = 4;
-	name = "Mix to Distro";
-	on = 0
-	},
-/turf/open/floor/plasteel/neutral,
-/area/engine/atmos)
 "auB" = (
-/obj/machinery/atmospherics/pipe/manifold/supply/visible{
-	dir = 4
-	},
 /obj/machinery/airalarm{
 	dir = 8;
 	pixel_x = 24
@@ -10664,22 +10363,28 @@
 /obj/structure/cable/white{
 	icon_state = "1-2"
 	},
+/obj/structure/closet/secure_closet/atmospherics,
+/obj/effect/turf_decal/bot,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
 /turf/open/floor/plasteel/caution{
 	dir = 4
 	},
 /area/engine/atmos)
 "auC" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 6
+	dir = 4
 	},
 /turf/closed/wall/r_wall,
 /area/engine/atmos)
 "auD" = (
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
 "auE" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/machinery/space_heater,
 /obj/effect/decal/cleanable/oil,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -11089,82 +10794,26 @@
 /turf/open/floor/plasteel,
 /area/maintenance/starboard)
 "avx" = (
-/obj/structure/grille,
-/obj/machinery/atmospherics/pipe/simple/cyan/visible,
-/turf/closed/wall/r_wall,
-/area/engine/atmos)
-"avy" = (
-/obj/machinery/atmospherics/pipe/simple/general/visible{
-	dir = 5
+/obj/machinery/atmospherics/pipe/simple/yellow/visible,
+/obj/machinery/computer/atmos_control/tank{
+	dir = 1
 	},
-/obj/machinery/light{
-	dir = 8
-	},
-/turf/open/floor/plasteel/vault{
-	dir = 5
-	},
-/area/engine/atmos)
-"avz" = (
-/obj/machinery/atmospherics/pipe/simple/green/visible,
-/obj/machinery/atmospherics/components/binary/pump{
-	dir = 4;
-	name = "N2 to Pure"
-	},
-/obj/effect/turf_decal/bot,
-/turf/open/floor/plasteel/vault{
-	dir = 8
-	},
-/area/engine/atmos)
-"avA" = (
-/obj/machinery/atmospherics/pipe/simple/yellow/visible{
-	dir = 10
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/engine/atmos)
-"avB" = (
-/obj/machinery/atmospherics/pipe/simple/cyan/visible,
-/obj/effect/landmark/start/atmospheric_technician,
 /turf/open/floor/plasteel/neutral,
 /area/engine/atmos)
-"avC" = (
-/obj/machinery/atmospherics/components/binary/pump{
-	dir = 1;
-	name = "Pure to Mix";
-	on = 0
-	},
-/turf/open/floor/plasteel/caution{
-	dir = 8
-	},
-/area/engine/atmos)
-"avD" = (
-/obj/machinery/atmospherics/pipe/simple/yellow/visible{
-	dir = 6
+"avy" = (
+/obj/machinery/atmospherics/components/trinary/filter/flipped{
+	dir = 4;
+	filter_type = "o2"
 	},
 /turf/open/floor/plasteel/neutral,
 /area/engine/atmos)
 "avE" = (
-/obj/machinery/atmospherics/pipe/simple/yellow/visible{
-	dir = 9
-	},
-/turf/open/floor/plasteel/neutral,
-/area/engine/atmos)
-"avF" = (
-/obj/machinery/atmospherics/components/unary/thermomachine/heater{
-	dir = 4;
-	on = 1
+/obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
+	dir = 10
 	},
 /turf/open/floor/plasteel/neutral,
 /area/engine/atmos)
 "avG" = (
-/obj/machinery/atmospherics/pipe/manifold4w/supply/visible,
-/obj/machinery/meter{
-	frequency = 1441;
-	id_tag = "distro_meter";
-	name = "Distribution Loop"
-	},
 /obj/machinery/light{
 	dir = 4
 	},
@@ -11174,21 +10823,17 @@
 /obj/structure/cable/white{
 	icon_state = "1-2"
 	},
+/obj/structure/closet/secure_closet/atmospherics,
+/obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel/caution{
 	dir = 4
 	},
-/area/engine/atmos)
-"avH" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 9
-	},
-/turf/closed/wall/r_wall,
 /area/engine/atmos)
 "avI" = (
 /obj/structure/cable/white{
 	icon_state = "2-4"
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+/obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
 	dir = 6
 	},
 /turf/open/floor/plating{
@@ -11196,7 +10841,6 @@
 	},
 /area/maintenance/port/fore)
 "avJ" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/structure/cable/white{
 	icon_state = "4-8"
 	},
@@ -11664,14 +11308,6 @@
 "awA" = (
 /turf/open/floor/engine/o2,
 /area/engine/atmos)
-"awB" = (
-/obj/machinery/atmospherics/components/unary/outlet_injector/on{
-	dir = 4;
-	frequency = 1441;
-	id = "o2_in"
-	},
-/turf/open/floor/engine/o2,
-/area/engine/atmos)
 "awC" = (
 /obj/machinery/atmospherics/pipe/simple/green/visible{
 	dir = 4
@@ -11680,87 +11316,31 @@
 	dir = 5
 	},
 /area/engine/atmos)
-"awD" = (
-/obj/machinery/atmospherics/components/trinary/filter{
-	dir = 2;
-	filter_type = "o2";
-	name = "oxygen filter";
-	on = 1
-	},
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 1
-	},
-/obj/effect/turf_decal/bot,
-/turf/open/floor/plasteel/blue/side{
-	dir = 9
-	},
-/area/engine/atmos)
-"awE" = (
-/obj/machinery/atmospherics/pipe/simple/yellow/visible,
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/engine/atmos)
 "awF" = (
 /obj/machinery/atmospherics/pipe/simple/cyan/visible,
 /turf/open/floor/plasteel/neutral,
 /area/engine/atmos)
-"awG" = (
-/obj/machinery/atmospherics/pipe/simple/yellow/visible,
-/turf/open/floor/plasteel/caution{
-	dir = 8
-	},
-/area/engine/atmos)
-"awH" = (
-/obj/machinery/atmospherics/components/binary/pump{
-	dir = 2;
-	name = "Mix to Filter";
-	on = 1
-	},
-/turf/open/floor/plasteel/neutral,
-/area/engine/atmos)
 "awI" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
-	dir = 4
+/obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
+	dir = 5
 	},
 /turf/open/floor/plasteel/neutral,
 /area/engine/atmos)
 "awJ" = (
-/obj/machinery/atmospherics/components/unary/thermomachine/freezer{
-	dir = 2;
-	min_temperature = 80;
-	on = 1;
-	target_temperature = 80
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/visible{
 	dir = 4
 	},
 /turf/open/floor/plasteel/neutral,
 /area/engine/atmos)
 "awK" = (
-/obj/machinery/atmospherics/components/binary/pump{
-	dir = 2;
-	name = "Distro to Waste";
-	on = 0
-	},
-/obj/structure/cable/white{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/obj/machinery/camera{
-	c_tag = "Atmospherics East";
-	dir = 8
-	},
-/turf/open/floor/plasteel/caution{
-	dir = 4
-	},
+/obj/structure/table/reinforced,
+/obj/item/clothing/gloves/color/black,
+/obj/item/clothing/suit/hazardvest,
+/obj/item/clothing/mask/gas,
+/obj/item/clothing/gloves/color/black,
+/obj/item/clothing/suit/hazardvest,
+/obj/item/clothing/mask/gas,
+/turf/open/floor/plasteel,
 /area/engine/atmos)
 "awL" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -11776,15 +11356,13 @@
 	name = "Atmospherics Maintenance";
 	req_access_txt = "24"
 	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	dir = 4
-	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 2
 	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/visible,
 /turf/open/floor/plasteel,
 /area/maintenance/port/fore)
 "awN" = (
@@ -11958,13 +11536,6 @@
 /obj/item/wirecutters,
 /turf/open/floor/plasteel,
 /area/maintenance/starboard)
-"axh" = (
-/obj/machinery/portable_atmospherics/canister/oxygen,
-/obj/machinery/light/small{
-	dir = 8
-	},
-/turf/open/floor/engine/o2,
-/area/engine/atmos)
 "axi" = (
 /obj/machinery/air_sensor{
 	frequency = 1441;
@@ -11972,59 +11543,15 @@
 	},
 /turf/open/floor/engine/o2,
 /area/engine/atmos)
-"axj" = (
-/obj/machinery/camera{
-	c_tag = "Atmospherics Tank 2";
-	dir = 4
-	},
-/turf/open/floor/plasteel/vault{
-	dir = 5
-	},
-/area/engine/atmos)
-"axk" = (
-/obj/machinery/computer/atmos_control/tank{
-	dir = 4;
-	frequency = 1441;
-	input_tag = "o2_in";
-	name = "Oxygen Supply Control";
-	output_tag = "o2_out";
-	sensors = list("o2_sensor" = "Tank")
-	},
-/obj/machinery/atmospherics/pipe/simple/green/visible,
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/effect/turf_decal/bot,
-/turf/open/floor/plasteel/blue/side{
-	dir = 8
-	},
-/area/engine/atmos)
 "axm" = (
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/visible{
-	dir = 8;
-	name = "scrubbers pipe"
-	},
-/obj/machinery/meter,
-/turf/open/floor/plasteel/neutral,
-/area/engine/atmos)
-"axn" = (
-/obj/machinery/atmospherics/components/binary/pump{
-	dir = 8;
-	name = "Waste to Filter";
-	on = 1
-	},
+/obj/machinery/atmospherics/components/unary/thermomachine/freezer,
 /turf/open/floor/plasteel/neutral,
 /area/engine/atmos)
 "axo" = (
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/visible{
-	dir = 2
-	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/visible,
 /turf/open/floor/plasteel/neutral,
 /area/engine/atmos)
 "axp" = (
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/visible{
-	dir = 2
-	},
 /obj/structure/cable/white{
 	icon_state = "1-2"
 	},
@@ -12042,9 +11569,6 @@
 /obj/item/twohanded/required/kirbyplants{
 	icon_state = "plant-21"
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
 /obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel,
 /area/engine/atmos)
@@ -12052,14 +11576,11 @@
 /obj/structure/cable/white{
 	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 9
-	},
 /obj/effect/turf_decal/delivery,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/visible,
 /turf/open/floor/plasteel,
 /area/engine/atmos)
 "axs" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/visible,
 /obj/structure/reagent_dispensers/fueltank,
 /obj/machinery/light_switch{
 	pixel_x = 24;
@@ -12357,129 +11878,42 @@
 "axW" = (
 /turf/closed/wall,
 /area/hallway/secondary/exit)
-"aya" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/siphon/on{
-	dir = 4;
-	frequency = 1441;
-	id_tag = "o2_out";
-	name = "oxygen vent"
-	},
-/turf/open/floor/engine/o2,
-/area/engine/atmos)
-"ayb" = (
-/obj/machinery/atmospherics/pipe/manifold/general/visible{
-	dir = 1
-	},
-/turf/open/floor/plasteel/vault{
-	dir = 5
-	},
-/area/engine/atmos)
-"ayc" = (
-/obj/machinery/atmospherics/pipe/simple/green/visible,
-/obj/machinery/atmospherics/components/binary/pump{
-	dir = 4;
-	name = "O2 to Airmix";
-	on = 1
-	},
-/obj/structure/window/reinforced,
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/effect/turf_decal/bot,
-/turf/open/floor/plasteel/blue/side{
-	dir = 10
-	},
-/area/engine/atmos)
-"ayd" = (
-/obj/machinery/atmospherics/pipe/simple/yellow/visible,
-/obj/machinery/atmospherics/pipe/simple/cyan/visible{
-	dir = 4
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/engine/atmos)
-"aye" = (
-/obj/machinery/atmospherics/components/trinary/mixer{
-	dir = 2;
-	name = "air mixer";
-	node1_concentration = 0.8;
-	node2_concentration = 0.2;
-	on = 1;
-	target_pressure = 4500
+"ayh" = (
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/visible{
+	dir = 8;
+	name = "scrubbers pipe"
 	},
 /turf/open/floor/plasteel/neutral,
 /area/engine/atmos)
-"ayf" = (
-/obj/machinery/atmospherics/components/trinary/filter{
-	dir = 1;
-	filter_type = "plasma";
-	name = "waste filter";
-	on = 1
-	},
-/obj/effect/turf_decal/stripes/corner{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/engine/atmos)
-"ayg" = (
-/obj/machinery/atmospherics/pipe/simple/yellow/visible,
-/obj/machinery/atmospherics/components/binary/pump{
-	dir = 4;
-	name = "Waste to Filter";
-	on = 1
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/engine/atmos)
-"ayh" = (
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/visible,
-/obj/machinery/meter,
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/engine/atmos)
 "ayi" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
-	dir = 4
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/visible,
+/turf/open/floor/plasteel/neutral,
 /area/engine/atmos)
 "ayj" = (
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/visible{
-	dir = 1
-	},
 /obj/structure/cable/white{
 	icon_state = "1-2"
 	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
+	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos)
 "ayk" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
-	dir = 4
-	},
 /obj/structure/cable/white{
 	icon_state = "1-2"
 	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/visible{
+	dir = 4
+	},
 /turf/open/floor/plasteel,
 /area/engine/atmos)
 "ayl" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
-	dir = 9
-	},
 /obj/machinery/firealarm{
 	dir = 4;
 	pixel_x = 24
@@ -12841,47 +12275,29 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/hallway/secondary/exit)
-"azj" = (
-/obj/machinery/atmospherics/pipe/simple/green/visible,
-/obj/machinery/atmospherics/components/binary/pump{
-	dir = 4;
-	name = "O2 to Pure"
-	},
-/obj/effect/turf_decal/bot,
-/turf/open/floor/plasteel/vault{
-	dir = 8
-	},
-/area/engine/atmos)
 "azk" = (
-/obj/machinery/atmospherics/pipe/manifold/yellow/visible{
+/obj/machinery/atmospherics/pipe/simple/green/visible{
 	dir = 4
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
+/obj/machinery/atmospherics/components/binary/pump{
+	dir = 1
 	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/neutral,
 /area/engine/atmos)
 "azl" = (
-/obj/machinery/atmospherics/pipe/simple/green/visible,
+/obj/machinery/atmospherics/components/trinary/filter/flipped{
+	dir = 4;
+	filter_type = "n2"
+	},
 /turf/open/floor/plasteel/neutral,
 /area/engine/atmos)
 "azm" = (
 /obj/machinery/atmospherics/pipe/simple/yellow/visible,
 /turf/open/floor/plasteel/neutral,
 /area/engine/atmos)
-"azo" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/turf/open/floor/plasteel/neutral,
-/area/engine/atmos)
 "azp" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/visible,
 /obj/structure/cable/white{
 	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
 	},
 /turf/open/floor/plasteel/neutral,
 /area/engine/atmos)
@@ -12889,17 +12305,15 @@
 /obj/structure/cable/white{
 	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/visible,
 /turf/open/floor/plasteel/neutral,
 /area/engine/atmos)
 "azr" = (
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	dir = 1
-	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 6
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos)
@@ -13223,66 +12637,28 @@
 /turf/open/floor/engine/air,
 /area/engine/atmos)
 "aAh" = (
-/obj/machinery/atmospherics/components/unary/outlet_injector/on{
-	dir = 4;
-	frequency = 1441;
-	id = "air_in"
-	},
-/turf/open/floor/engine/air,
-/area/engine/atmos)
-"aAi" = (
-/obj/machinery/meter{
-	name = "Mixed Air Tank In"
-	},
-/obj/structure/grille,
-/obj/machinery/atmospherics/pipe/simple/cyan/visible,
-/obj/machinery/atmospherics/pipe/simple/cyan/visible{
-	dir = 4
+/obj/machinery/meter,
+/obj/machinery/atmospherics/pipe/manifold/yellow/visible{
+	dir = 8
 	},
 /turf/closed/wall/r_wall,
 /area/engine/atmos)
+"aAi" = (
+/obj/effect/spawner/structure/window/plasma/reinforced,
+/obj/machinery/atmospherics/pipe/simple/yellow/visible{
+	dir = 9
+	},
+/turf/open/floor/plating,
+/area/engine/atmos)
 "aAj" = (
-/obj/machinery/atmospherics/pipe/simple/cyan/visible{
-	dir = 4
-	},
-/turf/open/floor/plasteel/vault{
-	dir = 5
-	},
-/area/engine/atmos)
-"aAk" = (
+/obj/machinery/meter,
 /obj/machinery/atmospherics/pipe/simple/green/visible,
-/obj/machinery/atmospherics/pipe/simple/cyan/visible{
-	dir = 4
-	},
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 1
-	},
-/obj/effect/turf_decal/bot,
-/turf/open/floor/plasteel/arrival{
-	dir = 9
-	},
-/area/engine/atmos)
-"aAm" = (
-/obj/machinery/atmospherics/pipe/simple/cyan/visible{
-	dir = 9
-	},
-/turf/open/floor/plasteel/neutral,
+/turf/closed/wall/r_wall,
 /area/engine/atmos)
 "aAn" = (
 /obj/machinery/atmospherics/pipe/simple/cyan/visible{
 	dir = 6
 	},
-/turf/open/floor/plasteel/neutral,
-/area/engine/atmos)
-"aAo" = (
-/obj/machinery/atmospherics/pipe/manifold/cyan/visible{
-	dir = 1
-	},
-/obj/machinery/meter,
 /turf/open/floor/plasteel/neutral,
 /area/engine/atmos)
 "aAp" = (
@@ -13293,28 +12669,25 @@
 /area/engine/atmos)
 "aAq" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible,
-/obj/machinery/atmospherics/pipe/simple/cyan/visible{
-	dir = 4
-	},
 /obj/effect/landmark/start/atmospheric_technician,
 /obj/structure/cable/white{
 	icon_state = "1-4"
 	},
+/obj/machinery/atmospherics/pipe/manifold/cyan/visible{
+	dir = 1
+	},
 /turf/open/floor/plasteel/neutral,
 /area/engine/atmos)
 "aAr" = (
-/obj/machinery/atmospherics/pipe/simple/cyan/visible{
-	dir = 4
-	},
 /obj/structure/cable/white{
 	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/cyan/visible{
+	dir = 10
 	},
 /turf/open/floor/plasteel/neutral,
 /area/engine/atmos)
 "aAs" = (
-/obj/machinery/atmospherics/pipe/simple/cyan/visible{
-	dir = 10
-	},
 /obj/structure/cable/white{
 	icon_state = "2-8"
 	},
@@ -13330,6 +12703,7 @@
 /obj/structure/cable/white{
 	icon_state = "1-4"
 	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/visible,
 /turf/open/floor/plasteel/neutral,
 /area/engine/atmos)
 "aAt" = (
@@ -13724,113 +13098,46 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit)
-"aBo" = (
-/obj/machinery/portable_atmospherics/canister/air,
-/obj/machinery/light/small{
-	dir = 8
-	},
-/turf/open/floor/engine/air,
-/area/engine/atmos)
 "aBp" = (
-/obj/machinery/air_sensor{
+/obj/machinery/atmospherics/components/unary/vent_pump/siphon/on{
+	dir = 1;
 	frequency = 1441;
-	id_tag = "air_sensor"
+	id_tag = "o2_out";
+	name = "oxygen vent"
 	},
-/turf/open/floor/engine/air,
-/area/engine/atmos)
-"aBq" = (
-/obj/machinery/computer/atmos_control/tank{
-	dir = 4;
-	frequency = 1441;
-	input_tag = "air_in";
-	name = "Mixed Air Supply Control";
-	output_tag = "air_out";
-	sensors = list("air_sensor" = "Tank")
-	},
-/obj/machinery/atmospherics/pipe/simple/green/visible{
-	dir = 5
-	},
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/effect/turf_decal/bot,
-/obj/structure/window/reinforced,
-/turf/open/floor/plasteel/arrival{
-	dir = 8
-	},
+/turf/open/floor/engine/o2,
 /area/engine/atmos)
 "aBr" = (
-/obj/machinery/atmospherics/pipe/simple/green/visible{
-	dir = 4
+/obj/machinery/atmospherics/components/unary/vent_pump/high_volume/siphon/on{
+	dir = 1;
+	frequency = 1441;
+	id_tag = "n2_out";
+	name = "n2 vent"
 	},
-/obj/machinery/atmospherics/pipe/simple/yellow/visible,
-/obj/effect/turf_decal/stripes/line{
-	dir = 10
-	},
-/turf/open/floor/plasteel,
-/area/engine/atmos)
-"aBs" = (
-/obj/machinery/atmospherics/pipe/simple/green/visible{
-	dir = 4
-	},
-/obj/effect/turf_decal/stripes/line,
-/turf/open/floor/plasteel,
+/turf/open/floor/engine/n2,
 /area/engine/atmos)
 "aBt" = (
-/obj/machinery/atmospherics/pipe/simple/green/visible{
-	dir = 9
+/obj/machinery/atmospherics/components/unary/outlet_injector/on{
+	dir = 1;
+	frequency = 1441;
+	id = "n2_in";
+	name = "n2 injector"
 	},
-/obj/effect/turf_decal/stripes/line,
-/turf/open/floor/plasteel,
-/area/engine/atmos)
-"aBu" = (
-/obj/machinery/atmospherics/pipe/simple/yellow/visible,
-/obj/effect/turf_decal/stripes/line,
-/turf/open/floor/plasteel,
-/area/engine/atmos)
-"aBv" = (
-/obj/machinery/atmospherics/pipe/simple/cyan/visible,
-/obj/effect/turf_decal/stripes/line,
-/turf/open/floor/plasteel,
-/area/engine/atmos)
-"aBw" = (
-/obj/machinery/atmospherics/pipe/manifold/cyan/visible{
-	dir = 8
-	},
-/obj/effect/turf_decal/stripes/line,
-/turf/open/floor/plasteel,
-/area/engine/atmos)
-"aBx" = (
-/obj/machinery/atmospherics/pipe/simple/cyan/visible{
-	dir = 10
-	},
-/obj/effect/turf_decal/stripes/line,
-/turf/open/floor/plasteel,
+/turf/open/floor/engine/n2,
 /area/engine/atmos)
 "aBy" = (
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/visible{
-	dir = 8;
-	name = "scrubbers pipe"
-	},
 /obj/effect/turf_decal/stripes/line,
-/turf/open/floor/plasteel,
-/area/engine/atmos)
-"aBz" = (
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/visible{
-	dir = 1
-	},
-/obj/effect/turf_decal/stripes/line,
+/obj/machinery/atmospherics/pipe/simple/cyan/visible,
 /turf/open/floor/plasteel,
 /area/engine/atmos)
 "aBA" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/cyan/visible,
 /obj/structure/cable/white{
 	icon_state = "1-2"
 	},
 /obj/effect/turf_decal/stripes/line,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
+	dir = 5
+	},
 /turf/open/floor/plasteel,
 /area/engine/atmos)
 "aBB" = (
@@ -14245,108 +13552,20 @@
 /obj/structure/sign/warning/vacuum,
 /turf/open/floor/plating,
 /area/hallway/secondary/exit)
-"aCr" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/high_volume/siphon/on{
-	dir = 4;
-	frequency = 1441;
-	id_tag = "air_out";
-	name = "air out"
-	},
-/turf/open/floor/engine/air,
-/area/engine/atmos)
 "aCs" = (
-/obj/machinery/meter{
-	name = "Mixed Air Tank Out"
-	},
-/obj/structure/grille,
-/obj/machinery/atmospherics/pipe/simple/cyan/visible,
-/obj/machinery/atmospherics/pipe/simple/cyan/visible{
-	dir = 4
-	},
-/turf/closed/wall/r_wall,
-/area/engine/atmos)
-"aCt" = (
-/obj/machinery/atmospherics/pipe/manifold/cyan/visible{
-	dir = 1
-	},
-/turf/open/floor/plasteel/vault/side{
-	dir = 1
-	},
-/area/engine/atmos)
-"aCu" = (
-/obj/machinery/atmospherics/components/binary/pump{
-	dir = 4;
-	name = "Air to Pure"
-	},
-/obj/structure/sign/warning/fire{
-	pixel_y = -32
-	},
-/obj/effect/turf_decal/bot,
-/turf/open/floor/plasteel/vault/side{
-	dir = 1
-	},
-/area/engine/atmos)
-"aCv" = (
-/obj/machinery/atmospherics/pipe/manifold/yellow/visible,
-/obj/machinery/meter,
-/turf/open/floor/plasteel/vault/side{
-	dir = 1
-	},
+/obj/machinery/portable_atmospherics/canister/oxygen,
+/turf/open/floor/engine/o2,
 /area/engine/atmos)
 "aCw" = (
-/obj/machinery/atmospherics/pipe/simple/yellow/visible{
-	dir = 4
-	},
-/obj/structure/closet/wardrobe/atmospherics_yellow,
-/obj/machinery/status_display{
-	pixel_y = -32
-	},
-/obj/effect/turf_decal/bot,
-/turf/open/floor/plasteel/vault/side{
-	dir = 1
-	},
-/area/engine/atmos)
-"aCx" = (
-/obj/machinery/atmospherics/pipe/simple/yellow/visible{
-	dir = 4
-	},
-/obj/structure/closet/secure_closet/atmospherics,
-/obj/structure/fireaxecabinet{
-	pixel_y = -28
-	},
-/obj/effect/turf_decal/bot,
-/turf/open/floor/plasteel/vault/side{
-	dir = 1
-	},
-/area/engine/atmos)
-"aCy" = (
-/obj/machinery/atmospherics/pipe/simple/yellow/visible{
-	dir = 9
-	},
-/obj/structure/closet/secure_closet/atmospherics,
-/obj/effect/turf_decal/bot,
-/turf/open/floor/plasteel/vault/side{
-	dir = 1
-	},
+/obj/machinery/portable_atmospherics/canister/nitrogen,
+/turf/open/floor/engine/n2,
 /area/engine/atmos)
 "aCz" = (
-/obj/structure/table/reinforced,
-/obj/item/clothing/gloves/color/black,
-/obj/item/clothing/suit/hazardvest,
-/obj/item/clothing/mask/gas,
-/obj/item/clothing/gloves/color/black,
-/obj/item/clothing/suit/hazardvest,
-/obj/item/clothing/mask/gas,
-/obj/machinery/atmospherics/pipe/simple/cyan/visible,
-/obj/machinery/airalarm{
-	dir = 1;
-	pixel_y = -22
+/obj/machinery/atmospherics/components/unary/portables_connector/visible{
+	dir = 1
 	},
-/obj/machinery/light,
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
+/obj/machinery/portable_atmospherics/scrubber,
+/turf/open/floor/plasteel/arrival,
 /area/engine/atmos)
 "aCA" = (
 /obj/machinery/atmospherics/components/unary/portables_connector/visible{
@@ -14355,45 +13574,34 @@
 /obj/machinery/portable_atmospherics/pump,
 /turf/open/floor/plasteel/arrival,
 /area/engine/atmos)
-"aCB" = (
-/obj/machinery/atmospherics/components/unary/portables_connector/visible{
-	dir = 1
-	},
-/obj/machinery/portable_atmospherics/pump,
-/obj/machinery/newscaster{
-	pixel_y = -32
-	},
-/turf/open/floor/plasteel/arrival,
-/area/engine/atmos)
 "aCC" = (
-/obj/machinery/atmospherics/components/unary/portables_connector/visible{
-	dir = 1
-	},
-/obj/machinery/portable_atmospherics/scrubber,
 /obj/machinery/firealarm{
 	dir = 1;
 	pixel_y = -26
 	},
-/turf/open/floor/plasteel/escape,
-/area/engine/atmos)
-"aCD" = (
 /obj/machinery/atmospherics/components/unary/portables_connector/visible{
 	dir = 1
 	},
-/obj/machinery/portable_atmospherics/scrubber,
+/obj/machinery/portable_atmospherics/pump,
+/turf/open/floor/plasteel/escape,
+/area/engine/atmos)
+"aCD" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/cyan/visible{
+	dir = 8
 	},
 /turf/open/floor/plasteel/escape,
 /area/engine/atmos)
 "aCE" = (
-/obj/machinery/atmospherics/pipe/simple/cyan/visible{
-	dir = 5
-	},
 /obj/structure/cable/white{
 	icon_state = "1-2"
 	},
 /obj/effect/turf_decal/bot,
+/obj/machinery/atmospherics/pipe/simple/cyan/visible{
+	dir = 4
+	},
 /turf/open/floor/plasteel/vault/side{
 	dir = 1
 	},
@@ -14722,34 +13930,18 @@
 	},
 /turf/open/space/basic,
 /area/space)
-"aDn" = (
-/obj/machinery/atmospherics/pipe/simple/cyan/hidden{
-	dir = 5
-	},
-/turf/closed/wall/r_wall,
-/area/engine/atmos)
-"aDo" = (
-/obj/machinery/atmospherics/pipe/manifold/cyan/hidden,
-/turf/closed/wall/r_wall,
-/area/engine/atmos)
-"aDp" = (
-/obj/machinery/atmospherics/pipe/simple/cyan/hidden{
-	dir = 8
-	},
-/turf/closed/wall/r_wall,
-/area/engine/atmos)
-"aDq" = (
-/obj/machinery/atmospherics/pipe/simple/cyan/hidden{
-	dir = 9
-	},
-/turf/closed/wall/r_wall,
-/area/engine/atmos)
 "aDr" = (
 /obj/structure/sign/warning/nosmoking,
+/obj/machinery/atmospherics/pipe/simple/cyan/visible{
+	dir = 4
+	},
 /turf/closed/wall/r_wall,
 /area/engine/atmos)
 "aDs" = (
 /obj/structure/sign/warning/fire,
+/obj/machinery/atmospherics/pipe/simple/cyan/visible{
+	dir = 9
+	},
 /turf/closed/wall/r_wall,
 /area/engine/atmos)
 "aDt" = (
@@ -17015,6 +16207,7 @@
 	pixel_x = -32
 	},
 /obj/effect/turf_decal/bot_white,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plasteel/vault{
 	dir = 8
 	},
@@ -17564,6 +16757,7 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/bot_white/left,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plasteel/vault{
 	dir = 4
 	},
@@ -18105,9 +17299,15 @@
 	dir = 4;
 	pixel_x = -23
 	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 5
+	},
 /turf/open/floor/plasteel/vault,
 /area/engine/gravity_generator)
 "aKq" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
 /turf/open/floor/plasteel/vault,
 /area/engine/gravity_generator)
 "aKs" = (
@@ -18658,12 +17858,10 @@
 /obj/structure/table/reinforced,
 /obj/item/stack/sheet/plasteel/twenty,
 /obj/item/wrench,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 9
 	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden,
 /turf/open/floor/plasteel,
 /area/engine/gravity_generator)
 "aLG" = (
@@ -30165,6 +29363,12 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
+"bko" = (
+/obj/machinery/atmospherics/pipe/simple/cyan/visible{
+	dir = 10
+	},
+/turf/closed/wall/r_wall,
+/area/engine/atmos)
 "bkt" = (
 /obj/item/twohanded/required/kirbyplants{
 	icon_state = "plant-22"
@@ -30322,13 +29526,13 @@
 /turf/open/floor/plasteel/redyellow,
 /area/crew_quarters/bar/atrium)
 "blk" = (
-/obj/machinery/camera{
-	c_tag = "Atmospherics Tank 3";
-	dir = 4
+/obj/machinery/atmospherics/components/unary/outlet_injector/on{
+	dir = 1;
+	frequency = 1441;
+	id = "o2_in";
+	name = "o2 injector"
 	},
-/turf/open/floor/plasteel/vault{
-	dir = 5
-	},
+/turf/open/floor/engine/o2,
 /area/engine/atmos)
 "bll" = (
 /obj/structure/chair{
@@ -30669,6 +29873,12 @@
 	dir = 4
 	},
 /area/hallway/secondary/exit)
+"bpn" = (
+/obj/machinery/atmospherics/pipe/simple/general/visible{
+	dir = 4
+	},
+/turf/closed/wall/r_wall,
+/area/asteroid/nearstation)
 "bsv" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/structure/cable/white{
@@ -31402,13 +30612,6 @@
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/plasteel/neutral,
 /area/engine/atmos)
-"bxI" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/obj/effect/landmark/event_spawn,
-/turf/open/floor/plasteel/neutral,
-/area/engine/atmos)
 "bxJ" = (
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/plasteel/neutral/side{
@@ -31601,6 +30804,21 @@
 /obj/structure/sign/nanotrasen,
 /turf/closed/wall,
 /area/security/checkpoint)
+"bGL" = (
+/obj/machinery/atmospherics/pipe/simple/cyan/visible{
+	dir = 5
+	},
+/turf/open/floor/plasteel/neutral,
+/area/asteroid/nearstation)
+"bGS" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/siphon/on{
+	dir = 2;
+	frequency = 1441;
+	id_tag = "co2_out";
+	name = "co2 vent"
+	},
+/turf/open/floor/engine/co2,
+/area/asteroid/nearstation)
 "bIJ" = (
 /obj/machinery/hydroponics/constructable,
 /obj/effect/turf_decal/stripes/line{
@@ -31609,6 +30827,32 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plasteel,
 /area/hydroponics)
+"bKQ" = (
+/obj/machinery/atmospherics/pipe/simple/yellow/visible{
+	dir = 4
+	},
+/turf/open/floor/plasteel/neutral,
+/area/engine/atmos)
+"bTZ" = (
+/obj/machinery/computer/atmos_control/tank,
+/obj/machinery/atmospherics/pipe/simple/yellow/visible{
+	dir = 4
+	},
+/turf/open/floor/plasteel/neutral,
+/area/engine/atmos)
+"bYE" = (
+/obj/structure/sign/warning/fire,
+/obj/machinery/atmospherics/pipe/simple/general/visible{
+	dir = 4
+	},
+/turf/closed/wall/r_wall,
+/area/asteroid/nearstation)
+"bZq" = (
+/obj/machinery/atmospherics/pipe/manifold/yellow/visible{
+	dir = 8
+	},
+/turf/open/floor/plasteel/neutral,
+/area/asteroid/nearstation)
 "ccy" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
@@ -31624,6 +30868,10 @@
 	},
 /turf/open/floor/plasteel,
 /area/hydroponics)
+"ckn" = (
+/obj/machinery/atmospherics/pipe/simple/cyan/visible,
+/turf/closed/wall/r_wall,
+/area/asteroid/nearstation)
 "cmp" = (
 /obj/machinery/door/airlock/external{
 	name = "External Docking Port"
@@ -31639,6 +30887,13 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
+"coQ" = (
+/obj/machinery/atmospherics/components/unary/outlet_injector/on,
+/obj/effect/turf_decal/stripes/line{
+	dir = 10
+	},
+/turf/open/floor/plating/airless,
+/area/space)
 "csX" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/structure/cable/white{
@@ -31657,6 +30912,30 @@
 /obj/machinery/door/firedoor,
 /turf/open/floor/plasteel,
 /area/hydroponics)
+"cAr" = (
+/obj/structure/grille,
+/turf/closed/wall/r_wall,
+/area/asteroid/nearstation)
+"cBf" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/engine/atmos)
+"cCp" = (
+/obj/machinery/door/poddoor{
+	id = "auxincineratorvent";
+	name = "Incineration Chamber Vent"
+	},
+/turf/open/floor/engine/vacuum,
+/area/asteroid/nearstation)
+"cGz" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/turf/open/floor/plasteel/neutral,
+/area/asteroid/nearstation)
 "cRz" = (
 /obj/machinery/button/door{
 	id = "supplybridge";
@@ -31681,6 +30960,21 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard)
+"cWv" = (
+/obj/machinery/atmospherics/pipe/simple/cyan/visible,
+/turf/closed/wall/r_wall,
+/area/engine/atmos)
+"cWR" = (
+/obj/structure/plasticflaps{
+	opacity = 1
+	},
+/obj/machinery/door/poddoor/preopen{
+	id = "atmoslock";
+	name = "Atmospherics Lockdown Blast door"
+	},
+/obj/effect/turf_decal/delivery,
+/turf/open/floor/plasteel,
+/area/engine/atmos)
 "cXu" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/structure/cable/white{
@@ -31691,6 +30985,13 @@
 	heat_capacity = 1e+006
 	},
 /area/hallway/primary/port)
+"ddI" = (
+/obj/machinery/air_sensor{
+	frequency = 1441;
+	id_tag = "plasma_sensor"
+	},
+/turf/open/floor/engine/plasma,
+/area/asteroid/nearstation)
 "dfP" = (
 /obj/machinery/door/airlock/maintenance_hatch{
 	name = "Maintenance Hatch";
@@ -31733,6 +31034,27 @@
 	dir = 8
 	},
 /area/maintenance/port)
+"dFV" = (
+/obj/machinery/atmospherics/pipe/simple/yellow/visible,
+/obj/machinery/atmospherics/pipe/simple/green/visible{
+	dir = 4
+	},
+/turf/open/floor/plasteel/neutral,
+/area/engine/atmos)
+"dIu" = (
+/obj/structure/grille,
+/obj/machinery/atmospherics/pipe/simple/cyan/visible{
+	dir = 4
+	},
+/turf/closed/wall/r_wall,
+/area/asteroid/nearstation)
+"dMl" = (
+/obj/structure/sign/warning/fire,
+/obj/machinery/atmospherics/pipe/simple/orange/visible{
+	dir = 4
+	},
+/turf/closed/wall/r_wall,
+/area/asteroid/nearstation)
 "dWc" = (
 /turf/closed/mineral/random/labormineral,
 /area/space)
@@ -31744,6 +31066,15 @@
 	dir = 1
 	},
 /area/hallway/primary/fore)
+"eva" = (
+/obj/machinery/computer/atmos_control/tank{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/green/visible{
+	dir = 4
+	},
+/turf/open/floor/plasteel/neutral,
+/area/asteroid/nearstation)
 "ewT" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 8
@@ -31772,6 +31103,29 @@
 	dir = 8
 	},
 /area/science/xenobiology)
+"eyu" = (
+/obj/machinery/atmospherics/components/binary/pump{
+	dir = 8
+	},
+/obj/machinery/light/small,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/turf/open/floor/engine,
+/area/asteroid/nearstation)
+"ezP" = (
+/obj/machinery/atmospherics/pipe/simple/general/visible,
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
+/area/asteroid/nearstation)
+"eCg" = (
+/obj/machinery/atmospherics/pipe/simple/green/visible{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/yellow/visible,
+/obj/machinery/computer/atmos_control/tank{
+	dir = 1
+	},
+/turf/open/floor/plasteel/neutral,
+/area/engine/atmos)
 "eFp" = (
 /obj/effect/turf_decal/stripes/end{
 	dir = 8
@@ -31779,6 +31133,10 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plasteel,
 /area/science/xenobiology)
+"eUr" = (
+/obj/machinery/computer/atmos_control/tank,
+/turf/open/floor/plasteel/neutral,
+/area/asteroid/nearstation)
 "eUz" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -31790,10 +31148,72 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
+"eYe" = (
+/obj/effect/mapping_helpers/airlock/locked,
+/obj/machinery/door/airlock/public/glass{
+	autoclose = 0;
+	frequency = 1449;
+	heat_proof = 1;
+	id_tag = "incinerator_airlock_exterior";
+	name = "Incinerator Exterior Airlock";
+	req_access_txt = "12"
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 4
+	},
+/turf/open/floor/engine,
+/area/asteroid/nearstation)
 "fgG" = (
 /obj/machinery/ai_status_display,
 /turf/closed/wall,
 /area/crew_quarters/lounge)
+"fnp" = (
+/obj/machinery/air_sensor{
+	frequency = 1441;
+	id_tag = "n2o_sensor"
+	},
+/turf/open/floor/engine/n2o,
+/area/asteroid/nearstation)
+"fom" = (
+/obj/structure/lattice/catwalk,
+/obj/item/wrench,
+/turf/open/space,
+/area/space)
+"fsJ" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/components/binary/dp_vent_pump/high_volume{
+	dir = 2;
+	frequency = 1449;
+	id = "incinerator_airlock_pump"
+	},
+/turf/open/floor/engine,
+/area/asteroid/nearstation)
+"fEM" = (
+/obj/machinery/atmospherics/pipe/simple/cyan/visible{
+	dir = 6
+	},
+/turf/closed/wall/r_wall,
+/area/asteroid/nearstation)
+"fFw" = (
+/obj/machinery/atmospherics/components/unary/portables_connector/visible,
+/turf/open/floor/plasteel/neutral,
+/area/engine/atmos)
+"fIe" = (
+/turf/open/floor/engine/air,
+/area/asteroid/nearstation)
+"fIN" = (
+/obj/machinery/atmospherics/pipe/simple/general/visible{
+	dir = 10
+	},
+/turf/open/floor/plasteel/neutral,
+/area/asteroid/nearstation)
 "fMT" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -31810,6 +31230,9 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard/aft)
+"fSE" = (
+/turf/closed/wall/r_wall,
+/area/space)
 "fWz" = (
 /obj/machinery/door/airlock/external{
 	name = "External Docking Port";
@@ -31823,6 +31246,16 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit)
+"gap" = (
+/obj/machinery/portable_atmospherics/canister/nitrous_oxide,
+/turf/open/floor/engine/n2o,
+/area/asteroid/nearstation)
+"gdA" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 6
+	},
+/turf/closed/wall/r_wall,
+/area/asteroid/nearstation)
 "geZ" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plasteel/neutral/corner,
@@ -31847,6 +31280,13 @@
 "glC" = (
 /turf/closed/wall/r_wall,
 /area/maintenance/starboard/aft)
+"guM" = (
+/obj/machinery/atmospherics/pipe/simple/green/visible{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/cyan/visible,
+/turf/open/floor/plasteel/neutral,
+/area/asteroid/nearstation)
 "gyV" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
 	dir = 1
@@ -31858,6 +31298,36 @@
 	dir = 4
 	},
 /area/hallway/primary/starboard/aft)
+"gNH" = (
+/obj/machinery/atmospherics/pipe/simple/general/visible{
+	dir = 4
+	},
+/turf/open/floor/plating/asteroid/airless,
+/area/asteroid/nearstation)
+"gSv" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/orange/visible,
+/turf/open/floor/plasteel/vault{
+	dir = 8
+	},
+/area/asteroid/nearstation)
+"gUJ" = (
+/obj/machinery/atmospherics/pipe/simple/cyan/visible{
+	dir = 4
+	},
+/turf/closed/wall/r_wall,
+/area/asteroid/nearstation)
+"gVX" = (
+/obj/machinery/atmospherics/components/trinary/filter/flipped{
+	dir = 8;
+	filter_type = "co2"
+	},
+/turf/open/floor/plasteel/vault{
+	dir = 5
+	},
+/area/asteroid/nearstation)
 "heQ" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/machinery/navbeacon{
@@ -31883,6 +31353,16 @@
 	},
 /turf/open/floor/plasteel/redyellow,
 /area/crew_quarters/bar/atrium)
+"hNO" = (
+/obj/machinery/atmospherics/pipe/simple/cyan/visible{
+	dir = 5
+	},
+/turf/closed/wall/r_wall,
+/area/asteroid/nearstation)
+"hOh" = (
+/obj/machinery/portable_atmospherics/canister/carbon_dioxide,
+/turf/open/floor/engine/co2,
+/area/asteroid/nearstation)
 "iaa" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/machinery/navbeacon{
@@ -31896,6 +31376,31 @@
 "ibv" = (
 /turf/closed/wall,
 /area/science/xenobiology)
+"iqC" = (
+/obj/machinery/air_sensor{
+	frequency = 1441;
+	id_tag = "co2_sensor"
+	},
+/turf/open/floor/engine/co2,
+/area/asteroid/nearstation)
+"iye" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/siphon/on{
+	dir = 4
+	},
+/turf/open/floor/engine/vacuum,
+/area/asteroid/nearstation)
+"iIj" = (
+/obj/machinery/atmospherics/components/trinary/mixer/flipped{
+	dir = 4
+	},
+/turf/open/floor/plasteel/neutral,
+/area/engine/atmos)
+"iKp" = (
+/obj/machinery/atmospherics/pipe/simple/green/visible{
+	dir = 5
+	},
+/turf/open/floor/plasteel/neutral,
+/area/asteroid/nearstation)
 "iML" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 8
@@ -31911,6 +31416,23 @@
 	dir = 4
 	},
 /area/science/xenobiology)
+"iZQ" = (
+/obj/machinery/atmospherics/components/unary/outlet_injector/on{
+	dir = 2;
+	frequency = 1441;
+	id = "co2_in";
+	name = "co2 injector";
+	pixel_y = 1
+	},
+/turf/open/floor/engine/co2,
+/area/asteroid/nearstation)
+"jbQ" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
+	dir = 5
+	},
+/obj/structure/lattice,
+/turf/open/space/basic,
+/area/space)
 "jcn" = (
 /obj/structure/cable/white{
 	icon_state = "4-8"
@@ -31937,6 +31459,17 @@
 /obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel,
 /area/science/xenobiology)
+"jkl" = (
+/obj/machinery/atmospherics/pipe/simple/general/visible{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/turf/open/floor/plasteel/neutral,
+/area/asteroid/nearstation)
+"jpv" = (
+/obj/machinery/atmospherics/pipe/simple/cyan/visible,
+/turf/open/floor/plasteel/neutral,
+/area/asteroid/nearstation)
 "jqM" = (
 /obj/effect/turf_decal/bot,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -31960,7 +31493,6 @@
 /turf/closed/wall,
 /area/hallway/primary/fore)
 "jBG" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/structure/cable/white{
 	icon_state = "1-2"
 	},
@@ -31970,10 +31502,40 @@
 /obj/structure/cable/white{
 	icon_state = "1-8"
 	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
+	dir = 8
+	},
 /turf/open/floor/plasteel/whitepurple/side{
 	dir = 4
 	},
 /area/science/xenobiology)
+"jCi" = (
+/obj/machinery/atmospherics/pipe/simple/green/visible{
+	dir = 4
+	},
+/turf/open/floor/plasteel/neutral,
+/area/asteroid/nearstation)
+"jDd" = (
+/obj/machinery/atmospherics/pipe/simple/cyan/visible{
+	dir = 4
+	},
+/turf/closed/wall/r_wall/rust,
+/area/engine/atmos)
+"kit" = (
+/obj/machinery/portable_atmospherics/canister/toxins,
+/turf/open/floor/engine/plasma,
+/area/asteroid/nearstation)
+"kiw" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/simple/general/visible,
+/turf/open/floor/plasteel,
+/area/asteroid/nearstation)
+"kqe" = (
+/obj/structure/lattice/catwalk,
+/turf/open/space,
+/area/space)
 "kKd" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/external{
@@ -31991,6 +31553,26 @@
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/miningdock)
+"kTo" = (
+/obj/structure/grille,
+/obj/machinery/meter,
+/obj/machinery/atmospherics/pipe/simple/green/visible,
+/turf/closed/wall/r_wall/rust,
+/area/asteroid/nearstation)
+"kTz" = (
+/obj/machinery/atmospherics/pipe/simple/green/visible,
+/obj/machinery/atmospherics/pipe/simple/cyan/visible{
+	dir = 4
+	},
+/turf/open/floor/plasteel/neutral,
+/area/asteroid/nearstation)
+"lrg" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
+	dir = 4
+	},
+/obj/structure/lattice,
+/turf/open/space/basic,
+/area/asteroid/nearstation)
 "lxq" = (
 /obj/structure/cable/white{
 	icon_state = "1-2"
@@ -32004,6 +31586,15 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on,
 /turf/open/floor/plasteel/greenblue/side,
 /area/hydroponics)
+"lAs" = (
+/turf/open/floor/plasteel/neutral,
+/area/asteroid/nearstation)
+"lBr" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
+	dir = 4
+	},
+/turf/open/floor/plasteel/neutral,
+/area/asteroid/nearstation)
 "lCg" = (
 /obj/machinery/door/airlock/external{
 	name = "Supply Dock Airlock";
@@ -32030,6 +31621,10 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/hallway/primary/starboard/aft)
+"lFw" = (
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/visible,
+/turf/open/floor/plating/asteroid/airless,
+/area/asteroid/nearstation)
 "lIM" = (
 /turf/closed/wall/rust,
 /area/crew_quarters/lounge)
@@ -32046,6 +31641,10 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard/aft)
+"lUu" = (
+/obj/machinery/portable_atmospherics/canister/air,
+/turf/open/floor/engine/air,
+/area/asteroid/nearstation)
 "lXk" = (
 /obj/structure/closet/firecloset,
 /obj/effect/turf_decal/delivery,
@@ -32059,6 +31658,51 @@
 	heat_capacity = 1e+006
 	},
 /area/hallway/primary/fore)
+"mae" = (
+/obj/machinery/atmospherics/pipe/simple/general/visible{
+	dir = 4
+	},
+/turf/open/floor/plasteel/neutral,
+/area/engine/atmos)
+"mgs" = (
+/obj/machinery/atmospherics/components/unary/outlet_injector/on{
+	dir = 1;
+	frequency = 1441;
+	id = "airmix_in";
+	name = "airmix injector"
+	},
+/turf/open/floor/engine/air,
+/area/engine/atmos)
+"mqF" = (
+/obj/machinery/door/poddoor{
+	id = "turbinevent";
+	name = "Turbine Vent"
+	},
+/turf/open/floor/engine/vacuum,
+/area/space)
+"msJ" = (
+/obj/machinery/atmospherics/pipe/simple/cyan/visible,
+/obj/machinery/atmospherics/pipe/simple/orange/visible{
+	dir = 4
+	},
+/turf/open/floor/plasteel/neutral,
+/area/asteroid/nearstation)
+"mIv" = (
+/obj/machinery/atmospherics/pipe/manifold/general/visible,
+/turf/open/floor/plasteel/neutral,
+/area/asteroid/nearstation)
+"mJP" = (
+/obj/machinery/igniter{
+	icon_state = "igniter0";
+	id = "Incinerator";
+	luminosity = 2;
+	on = 0
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/engine/vacuum,
+/area/asteroid/nearstation)
 "mJQ" = (
 /obj/structure/table/glass,
 /obj/effect/turf_decal/delivery,
@@ -32069,6 +31713,21 @@
 "mQi" = (
 /turf/closed/wall/rust,
 /area/maintenance/starboard/central)
+"mTv" = (
+/obj/machinery/atmospherics/pipe/manifold/cyan/visible{
+	dir = 1
+	},
+/turf/open/floor/plasteel/neutral,
+/area/asteroid/nearstation)
+"mTM" = (
+/turf/open/floor/engine/co2,
+/area/asteroid/nearstation)
+"mTT" = (
+/obj/machinery/atmospherics/components/binary/pump{
+	dir = 8
+	},
+/turf/open/floor/plasteel/neutral,
+/area/asteroid/nearstation)
 "mXV" = (
 /obj/structure/cable/white{
 	icon_state = "1-2"
@@ -32081,6 +31740,19 @@
 "ndg" = (
 /turf/open/floor/plasteel/neutral/corner,
 /area/hallway/primary/fore)
+"nhU" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/turf/closed/wall/r_wall,
+/area/asteroid/nearstation)
+"nrv" = (
+/obj/machinery/atmospherics/pipe/simple/cyan/visible,
+/obj/machinery/atmospherics/pipe/simple/green/visible{
+	dir = 4
+	},
+/turf/open/floor/plasteel/neutral,
+/area/asteroid/nearstation)
 "nwY" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
@@ -32114,9 +31786,54 @@
 /obj/structure/sign/warning/biohazard,
 /turf/closed/wall,
 /area/science/xenobiology)
+"nUk" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/simple/general/visible,
+/turf/open/floor/plasteel/caution,
+/area/asteroid/nearstation)
+"oaV" = (
+/obj/structure/grille,
+/obj/machinery/meter,
+/obj/machinery/atmospherics/pipe/simple/yellow/visible,
+/turf/closed/wall/r_wall,
+/area/engine/atmos)
+"oiL" = (
+/turf/open/floor/plasteel/neutral,
+/area/engine/atmos)
+"otn" = (
+/obj/machinery/atmospherics/pipe/simple/green/visible{
+	dir = 6
+	},
+/turf/open/floor/plasteel/vault{
+	dir = 5
+	},
+/area/asteroid/nearstation)
+"oxn" = (
+/obj/machinery/power/compressor{
+	icon_state = "compressor";
+	dir = 4;
+	luminosity = 2;
+	comp_id = "incineratorturbine"
+	},
+/obj/structure/cable{
+	icon_state = "0-4"
+	},
+/obj/structure/cable{
+	icon_state = "0-8"
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/engine/vacuum,
+/area/asteroid/nearstation)
 "oyD" = (
 /turf/closed/wall,
 /area/crew_quarters/toilet/restrooms)
+"oIG" = (
+/obj/structure/sign/warning/fire,
+/turf/closed/wall/r_wall,
+/area/space)
+"oOk" = (
+/turf/open/floor/engine/plasma,
+/area/asteroid/nearstation)
 "oQL" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 1
@@ -32126,6 +31843,21 @@
 	},
 /turf/open/floor/plasteel/neutral/corner,
 /area/hallway/primary/starboard/aft)
+"pbT" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 10
+	},
+/turf/open/floor/plasteel/vault,
+/area/engine/gravity_generator)
+"pcl" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/siphon/on{
+	dir = 2;
+	frequency = 1441;
+	id_tag = "mix_out";
+	name = "distro vent"
+	},
+/turf/open/floor/engine/vacuum,
+/area/engine/atmos)
 "plz" = (
 /obj/effect/turf_decal/stripes/end{
 	dir = 4
@@ -32150,6 +31882,20 @@
 	},
 /turf/open/floor/plasteel,
 /area/science/xenobiology)
+"pqs" = (
+/obj/machinery/power/turbine{
+	icon_state = "turbine";
+	dir = 8;
+	luminosity = 2
+	},
+/obj/structure/sign/warning/vacuum{
+	pixel_y = -32
+	},
+/obj/structure/cable{
+	icon_state = "0-4"
+	},
+/turf/open/floor/engine/vacuum,
+/area/asteroid/nearstation)
 "psq" = (
 /obj/structure/sign/poster/random{
 	pixel_y = 32
@@ -32158,15 +31904,41 @@
 	dir = 5
 	},
 /area/science/xenobiology)
+"pvX" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/simple/orange/visible,
+/obj/machinery/atmospherics/pipe/simple/general/visible{
+	dir = 4
+	},
+/turf/open/floor/plasteel/caution{
+	dir = 10
+	},
+/area/asteroid/nearstation)
+"pBT" = (
+/turf/open/floor/plating/asteroid/airless,
+/area/space)
+"pEH" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/turf/open/floor/plating,
+/area/asteroid/nearstation)
 "pLb" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/structure/cable/white{
 	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
+	dir = 4
 	},
 /turf/open/floor/plasteel/whitepurple/side{
 	dir = 8
 	},
 /area/science/xenobiology)
+"pNE" = (
+/obj/structure/grille,
+/obj/machinery/atmospherics/pipe/simple/cyan/visible{
+	dir = 4
+	},
+/turf/closed/wall/r_wall,
+/area/engine/atmos)
 "qdt" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 5
@@ -32181,6 +31953,75 @@
 /obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel,
 /area/hallway/primary/fore)
+"qgC" = (
+/obj/machinery/atmospherics/components/unary/outlet_injector/on{
+	dir = 4;
+	frequency = 1441;
+	id = "mix_in"
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/engine/vacuum,
+/area/asteroid/nearstation)
+"qoT" = (
+/obj/machinery/atmospherics/components/binary/pump{
+	dir = 1
+	},
+/turf/open/floor/plasteel/neutral,
+/area/engine/atmos)
+"qpG" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/turf/closed/wall/r_wall/rust,
+/area/engine/gravity_generator)
+"qsc" = (
+/obj/machinery/air_sensor{
+	frequency = 1441;
+	id_tag = "airmix_sensor"
+	},
+/turf/open/floor/engine/air,
+/area/asteroid/nearstation)
+"qMr" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/manifold/general/visible{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/space)
+"qTa" = (
+/obj/machinery/atmospherics/pipe/simple/orange/visible{
+	dir = 4
+	},
+/turf/open/floor/plasteel/neutral,
+/area/asteroid/nearstation)
+"qUW" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 5
+	},
+/turf/closed/wall/r_wall,
+/area/asteroid/nearstation)
+"rae" = (
+/obj/machinery/atmospherics/components/binary/pump{
+	dir = 1
+	},
+/turf/open/floor/plasteel/neutral,
+/area/asteroid/nearstation)
+"rjV" = (
+/obj/machinery/atmospherics/components/binary/pump{
+	dir = 4
+	},
+/obj/machinery/light/small{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/machinery/airlock_sensor{
+	id_tag = "incinerator_airlock_sensor";
+	master_tag = "incinerator_airlock_control";
+	pixel_y = 24
+	},
+/turf/open/floor/engine,
+/area/asteroid/nearstation)
 "rlq" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -32199,6 +32040,12 @@
 /obj/machinery/status_display,
 /turf/closed/wall,
 /area/hallway/primary/starboard)
+"rzq" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
+	dir = 6
+	},
+/turf/open/floor/plasteel/neutral,
+/area/asteroid/nearstation)
 "rCw" = (
 /obj/machinery/door/window/brigdoor{
 	dir = 4;
@@ -32215,10 +32062,36 @@
 /obj/structure/cable/white{
 	icon_state = "2-8"
 	},
+/obj/effect/turf_decal/delivery,
 /turf/open/floor/plasteel/vault{
 	dir = 8
 	},
 /area/science/xenobiology)
+"rEx" = (
+/obj/machinery/atmospherics/pipe/simple/cyan/visible{
+	dir = 4
+	},
+/turf/open/floor/plasteel/neutral,
+/area/asteroid/nearstation)
+"rVj" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/siphon/on{
+	dir = 1;
+	frequency = 1441;
+	id_tag = "airmix_out";
+	name = "airmix vent"
+	},
+/turf/open/floor/engine/air,
+/area/asteroid/nearstation)
+"rVs" = (
+/obj/machinery/atmospherics/components/unary/outlet_injector/on{
+	dir = 2;
+	frequency = 1441;
+	id = "mix_in";
+	name = "gas mix injector";
+	pixel_y = 1
+	},
+/turf/open/floor/engine/vacuum,
+/area/engine/atmos)
 "sak" = (
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/plasteel/greenblue/side{
@@ -32230,6 +32103,12 @@
 /obj/machinery/hydroponics/soil,
 /turf/open/floor/plasteel/vault/side,
 /area/maintenance/starboard/aft)
+"skz" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 10
+	},
+/turf/closed/wall/r_wall,
+/area/asteroid/nearstation)
 "soC" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -32245,6 +32124,25 @@
 "sqz" = (
 /turf/closed/wall,
 /area/hallway/primary/starboard)
+"srh" = (
+/obj/machinery/atmospherics/pipe/simple/green/visible{
+	dir = 4
+	},
+/obj/machinery/atmospherics/components/binary/pump,
+/turf/open/floor/plasteel/vault{
+	dir = 5
+	},
+/area/asteroid/nearstation)
+"srR" = (
+/obj/machinery/atmospherics/components/unary/outlet_injector/on{
+	dir = 2;
+	frequency = 1441;
+	id = "n2o_in";
+	name = "n2o injector";
+	pixel_y = 1
+	},
+/turf/open/floor/engine/n2o,
+/area/asteroid/nearstation)
 "sws" = (
 /obj/docking_port/stationary{
 	dheight = 1;
@@ -32366,12 +32264,6 @@
 "sAx" = (
 /turf/closed/wall/r_wall/rust,
 /area/engine/atmos)
-"sAy" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/turf/closed/wall/r_wall/rust,
-/area/engine/atmos)
 "sAz" = (
 /turf/closed/wall/r_wall/rust,
 /area/storage/primary)
@@ -32394,10 +32286,6 @@
 	icon_state = "panelscorched"
 	},
 /area/maintenance/starboard)
-"sBu" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/turf/closed/wall/r_wall/rust,
-/area/security/brig)
 "sBv" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
@@ -32784,12 +32672,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit)
-"sGU" = (
-/obj/machinery/atmospherics/pipe/simple/cyan/hidden{
-	dir = 8
-	},
-/turf/closed/wall/r_wall/rust,
-/area/engine/atmos)
 "sGW" = (
 /obj/structure/cable/white{
 	icon_state = "1-2"
@@ -32968,7 +32850,8 @@
 /area/hallway/secondary/exit)
 "sIA" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/turf/closed/wall/r_wall/rust,
+/obj/structure/barricade/wooden,
+/turf/open/floor/plating/astplate,
 /area/engine/engineering)
 "sIB" = (
 /turf/closed/wall/rust,
@@ -34698,6 +34581,35 @@
 "sPY" = (
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
+"tac" = (
+/obj/structure/grille,
+/obj/machinery/meter,
+/obj/machinery/atmospherics/pipe/simple/green/visible,
+/turf/closed/wall/r_wall/rust,
+/area/engine/atmos)
+"tdN" = (
+/obj/machinery/atmospherics/pipe/simple/green/visible,
+/obj/machinery/atmospherics/pipe/simple/orange/visible{
+	dir = 4
+	},
+/turf/open/floor/plasteel/neutral,
+/area/asteroid/nearstation)
+"tgp" = (
+/obj/machinery/atmospherics/components/unary/portables_connector/visible{
+	dir = 8
+	},
+/turf/open/floor/plasteel/neutral,
+/area/asteroid/nearstation)
+"toY" = (
+/obj/machinery/atmospherics/pipe/simple/yellow/visible{
+	dir = 4
+	},
+/turf/open/floor/plasteel/neutral,
+/area/asteroid/nearstation)
+"ttA" = (
+/obj/machinery/atmospherics/pipe/simple/orange/visible,
+/turf/open/floor/plasteel/neutral,
+/area/asteroid/nearstation)
 "tKM" = (
 /turf/closed/wall,
 /area/hallway/primary/fore)
@@ -34711,12 +34623,61 @@
 "tWh" = (
 /turf/closed/wall,
 /area/crew_quarters/lounge)
+"tWQ" = (
+/obj/machinery/atmospherics/components/unary/thermomachine/heater{
+	dir = 4
+	},
+/turf/open/floor/plasteel/neutral,
+/area/engine/atmos)
+"ueC" = (
+/obj/effect/decal/cleanable/oil,
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/asteroid/nearstation)
+"ueG" = (
+/obj/machinery/atmospherics/pipe/simple/orange/visible{
+	dir = 6
+	},
+/turf/open/floor/plasteel/neutral,
+/area/asteroid/nearstation)
 "ugK" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
 /turf/open/floor/plasteel/neutral/corner,
 /area/hallway/primary/aft)
+"ujg" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/siphon/on{
+	dir = 2;
+	frequency = 1441;
+	id_tag = "n2o_out";
+	name = "n2o vent"
+	},
+/turf/open/floor/engine/n2o,
+/area/asteroid/nearstation)
+"ulC" = (
+/turf/open/space/basic,
+/area/asteroid/nearstation)
+"uok" = (
+/obj/machinery/atmospherics/pipe/simple/cyan/visible{
+	dir = 4
+	},
+/turf/closed/wall/r_wall,
+/area/engine/atmos)
+"uoy" = (
+/obj/machinery/atmospherics/pipe/simple/green/visible{
+	dir = 4
+	},
+/obj/machinery/atmospherics/components/binary/pump,
+/turf/open/floor/plasteel/vault{
+	dir = 5
+	},
+/area/engine/atmos)
 "uqY" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plasteel/neutral/corner{
@@ -34729,6 +34690,10 @@
 /obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel/neutral,
 /area/hydroponics)
+"uuJ" = (
+/obj/machinery/atmospherics/pipe/simple/green/visible,
+/turf/open/floor/plasteel/neutral,
+/area/asteroid/nearstation)
 "uuU" = (
 /obj/machinery/status_display,
 /turf/closed/wall,
@@ -34742,6 +34707,10 @@
 	heat_capacity = 1e+006
 	},
 /area/hallway/primary/aft)
+"uvg" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/visible,
+/turf/closed/wall/r_wall,
+/area/asteroid/nearstation)
 "uxJ" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/public/glass{
@@ -34770,12 +34739,26 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit)
+"uBJ" = (
+/obj/effect/turf_decal/bot_white/right,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/turf/open/floor/plasteel/vault{
+	dir = 1
+	},
+/area/engine/gravity_generator)
 "uGq" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plasteel/red/corner{
 	dir = 1
 	},
 /area/hallway/primary/port)
+"uSs" = (
+/obj/machinery/atmospherics/pipe/simple/cyan/visible,
+/obj/machinery/atmospherics/pipe/simple/green/visible{
+	dir = 4
+	},
+/turf/open/floor/plasteel/neutral,
+/area/engine/atmos)
 "vkK" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/machinery/door/firedoor,
@@ -34797,6 +34780,12 @@
 	},
 /turf/open/floor/plasteel/purple/corner,
 /area/hallway/primary/central)
+"vpz" = (
+/obj/machinery/atmospherics/pipe/manifold/cyan/visible{
+	dir = 4
+	},
+/turf/open/floor/plasteel/neutral,
+/area/asteroid/nearstation)
 "vsf" = (
 /obj/effect/decal/cleanable/xenoblood/xgibs,
 /turf/open/floor/plasteel/vault{
@@ -34814,6 +34803,45 @@
 	dir = 1
 	},
 /area/hallway/primary/port/aft)
+"vtI" = (
+/obj/machinery/atmospherics/pipe/simple/yellow/visible,
+/obj/machinery/atmospherics/pipe/simple/general/visible{
+	dir = 4
+	},
+/turf/open/floor/plasteel/neutral,
+/area/asteroid/nearstation)
+"vuN" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 10
+	},
+/turf/open/floor/plasteel/neutral,
+/area/asteroid/nearstation)
+"vJk" = (
+/obj/machinery/atmospherics/pipe/simple/yellow/visible,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
+	dir = 4
+	},
+/turf/open/floor/plasteel/neutral,
+/area/asteroid/nearstation)
+"vMb" = (
+/turf/open/floor/engine/n2o,
+/area/asteroid/nearstation)
+"vVA" = (
+/obj/machinery/atmospherics/pipe/simple/green/visible{
+	dir = 4
+	},
+/turf/open/floor/plasteel/neutral,
+/area/engine/atmos)
+"vVS" = (
+/obj/machinery/atmospherics/components/unary/outlet_injector/on{
+	dir = 2;
+	frequency = 1441;
+	id = "plasma_in";
+	name = "plasma injector";
+	pixel_y = 1
+	},
+/turf/open/floor/engine/plasma,
+/area/asteroid/nearstation)
 "vWg" = (
 /obj/structure/cable/white{
 	icon_state = "4-8"
@@ -34849,6 +34877,27 @@
 	dir = 8
 	},
 /area/hallway/primary/aft)
+"wev" = (
+/obj/machinery/meter,
+/obj/machinery/atmospherics/pipe/simple/cyan/visible,
+/turf/closed/wall/r_wall,
+/area/asteroid/nearstation)
+"wkG" = (
+/obj/structure/lattice/catwalk,
+/turf/open/floor/plating/airless,
+/area/space)
+"wvE" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
+	dir = 5
+	},
+/turf/open/floor/plasteel/neutral,
+/area/asteroid/nearstation)
+"wMZ" = (
+/obj/structure/grille,
+/obj/machinery/meter,
+/obj/machinery/atmospherics/pipe/simple/yellow/visible,
+/turf/closed/wall/r_wall,
+/area/asteroid/nearstation)
 "wUF" = (
 /obj/machinery/door/airlock/atmos/glass{
 	name = "Supermatter Chamber";
@@ -34859,14 +34908,141 @@
 	},
 /turf/open/floor/engine,
 /area/engine/supermatter)
+"wUL" = (
+/obj/structure/cable/white{
+	icon_state = "4-8"
+	},
+/obj/effect/turf_decal/delivery,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/science/xenobiology)
+"xej" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/siphon/on{
+	dir = 2;
+	frequency = 1441;
+	id_tag = "plasma_out";
+	name = "plasma vent"
+	},
+/turf/open/floor/engine/plasma,
+/area/asteroid/nearstation)
+"xeu" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
+	dir = 4
+	},
+/turf/open/floor/plasteel/neutral,
+/area/engine/atmos)
+"xrf" = (
+/obj/machinery/light{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/orange/visible,
+/turf/open/floor/plasteel/caution{
+	dir = 8
+	},
+/area/asteroid/nearstation)
+"xtL" = (
+/obj/machinery/embedded_controller/radio/airlock_controller{
+	name = "Incinerator Access Console";
+	airpump_tag = "incinerator_airlock_pump";
+	exterior_door_tag = "incinerator_airlock_exterior";
+	id_tag = "incinerator_access_control";
+	interior_door_tag = "incinerator_airlock_interior";
+	pixel_x = 8;
+	pixel_y = -24;
+	sanitize_external = 1;
+	sensor_tag = "incinerator_airlock_sensor";
+	req_access_txt = "12"
+	},
+/obj/machinery/button/ignition{
+	id = "Incinerator";
+	pixel_x = 8;
+	pixel_y = -36
+	},
+/obj/machinery/button/door{
+	id = "turbinevent";
+	name = "Turbine Vent Control";
+	pixel_x = -8;
+	pixel_y = -36;
+	req_access_txt = "12"
+	},
+/obj/machinery/button/door{
+	id = "auxincineratorvent";
+	name = "Auxiliary Vent Control";
+	pixel_x = -8;
+	pixel_y = -24;
+	req_access_txt = "12"
+	},
+/obj/machinery/computer/turbine_computer{
+	dir = 1;
+	id = "incineratorturbine"
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/simple/orange/visible{
+	dir = 9
+	},
+/turf/open/floor/plasteel/caution{
+	dir = 10
+	},
+/area/asteroid/nearstation)
 "xwu" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/engine/break_room)
+"xCL" = (
+/obj/effect/spawner/structure/window/plasma/reinforced,
+/turf/open/floor/plating,
+/area/asteroid/nearstation)
+"xEQ" = (
+/obj/machinery/atmospherics/components/trinary/filter/flipped{
+	dir = 8;
+	filter_type = "plasma"
+	},
+/turf/open/floor/plasteel/vault{
+	dir = 5
+	},
+/area/engine/atmos)
 "xFw" = (
 /obj/structure/sign/departments/xenobio,
 /turf/closed/wall,
 /area/science/xenobiology)
+"xIm" = (
+/obj/machinery/meter,
+/obj/machinery/atmospherics/pipe/simple/cyan/visible,
+/turf/closed/wall/r_wall,
+/area/engine/atmos)
+"xOf" = (
+/obj/structure/lattice,
+/turf/open/space,
+/area/space)
+"xPz" = (
+/obj/machinery/atmospherics/pipe/simple/general/visible{
+	dir = 9
+	},
+/turf/open/floor/plating/asteroid/airless,
+/area/asteroid/nearstation)
+"xZO" = (
+/obj/effect/mapping_helpers/airlock/locked,
+/obj/machinery/door/airlock/public/glass{
+	autoclose = 0;
+	frequency = 1449;
+	heat_proof = 1;
+	id_tag = "incinerator_airlock_interior";
+	name = "Incinerator Interior Airlock";
+	req_access_txt = "12"
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 8
+	},
+/turf/open/floor/engine,
+/area/asteroid/nearstation)
 "yeE" = (
 /obj/machinery/door/window/brigdoor{
 	dir = 4;
@@ -34883,6 +35059,10 @@
 /obj/structure/cable/white{
 	icon_state = "2-8"
 	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on{
+	dir = 8
+	},
+/obj/effect/turf_decal/delivery,
 /turf/open/floor/plasteel/vault{
 	dir = 8
 	},
@@ -34895,6 +35075,14 @@
 	dir = 8
 	},
 /area/hallway/primary/port/aft)
+"ymj" = (
+/obj/machinery/atmospherics/pipe/simple/green/visible{
+	dir = 4
+	},
+/turf/open/floor/plasteel/vault{
+	dir = 5
+	},
+/area/asteroid/nearstation)
 
 (1,1,1) = {"
 aaa
@@ -59417,11 +59605,11 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+kqe
+kqe
+kqe
+kqe
+kqe
 aaa
 aaa
 aaa
@@ -59674,11 +59862,11 @@ aaa
 aaa
 aaa
 aaa
+fom
+xOf
 aaa
-aaa
-aaa
-aaa
-aaa
+xOf
+kqe
 aaa
 aaa
 aaa
@@ -59931,11 +60119,11 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+kqe
+oIG
+mqF
+oIG
+wkG
 aaa
 aaa
 aaa
@@ -60185,15 +60373,15 @@ aaa
 aaa
 aaa
 aaa
-aad
-aad
-aad
-aad
-aad
-aad
-aaa
-aaa
-aaa
+ulC
+ulC
+ulC
+aXc
+ahu
+pqs
+fSE
+coQ
+jbQ
 aaa
 aaa
 aaa
@@ -60437,20 +60625,20 @@ aaa
 aaa
 aaa
 aaa
+pBT
+pBT
+pBT
 aaa
-aaa
-aaa
-aaa
-aad
-aad
-aad
-aad
-aad
-aac
-aac
-aac
-aac
-aac
+ulC
+ulC
+ulC
+ulC
+ahu
+ahu
+oxn
+ahu
+ahu
+lrg
 aaa
 aaa
 aaa
@@ -60692,22 +60880,22 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
+pBT
+pBT
+dWc
+pBT
 aac
+ulC
+ulC
+ulC
+ulC
+ulC
+ahu
+iye
+mJP
+qgC
+cCp
+lrg
 aac
 aac
 aac
@@ -60948,23 +61136,23 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
+pBT
+pBT
+dWc
 aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
+aac
+aac
+ulC
+ulC
+ulC
+ulC
+ulC
+ahu
+bpn
+eYe
+bYE
+ahu
+lrg
 aad
 aad
 aac
@@ -61205,23 +61393,23 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
+pBT
+pBT
 aad
 aad
 aad
 aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
+ulC
+ulC
+ulC
+ulC
+ulC
+gdA
+rjV
+fsJ
+eyu
+uvg
+lFw
 aad
 aac
 aac
@@ -61462,23 +61650,23 @@ aaa
 aaa
 aaa
 aaa
-aaa
+dWc
 aad
 aad
 aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
+ahu
+ahu
+ahu
+ahu
+ahu
+ahu
+ahu
+nhU
+bpn
+xZO
+dMl
+ahu
+gNH
 aad
 aad
 aad
@@ -61717,25 +61905,25 @@ aaa
 aaa
 aaa
 aaa
+ulC
 aac
 aad
 aad
 aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
+ahu
+ahu
+ueG
+ttA
+ttA
+ttA
+ttA
+ttA
+xrf
+pvX
+gSv
+xtL
+ahu
+gNH
 aad
 aad
 aad
@@ -61973,26 +62161,26 @@ aaa
 aaa
 aaa
 aaa
-aac
-aac
-aac
+ulC
 aac
 aad
 aad
 aad
 aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
+ahu
+lAs
+qTa
+lAs
+lAs
+lAs
+lAs
+lAs
+ueC
+qMr
+kiw
+nUk
+ezP
+xPz
 aad
 aad
 aad
@@ -62229,28 +62417,28 @@ aaa
 aaa
 aaa
 aaa
+ulC
 aac
 aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
+fEM
+ckn
+ckn
+ckn
+ckn
+jpv
+msJ
+jpv
+jpv
+jpv
+jpv
+bGL
+vuN
+jkl
+cGz
+cGz
+qUW
+ahu
+ahu
 aGe
 sIu
 aGe
@@ -62485,31 +62673,31 @@ aaa
 aaa
 aaa
 aaa
+ulC
 aac
 aac
 aac
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-sIu
-aHe
+dIu
+cAr
+cAr
+cAr
+otn
+uuJ
+tdN
+uuJ
+uuJ
+uuJ
+uuJ
+kTz
+iKp
+tgp
+lAs
+lAs
+skz
+pEH
+pEH
+qpG
+uBJ
 aIb
 aJh
 aKp
@@ -62746,25 +62934,25 @@ aac
 aad
 aad
 aad
+dIu
+mTM
+iZQ
+kTo
+gVX
+lAs
+qTa
+rzq
+wvE
+lAs
+lAs
+mTv
+guM
+jpv
+jpv
+jpv
+hNO
 aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
+acF
 aGe
 aId
 aIc
@@ -63003,30 +63191,30 @@ aad
 aad
 aad
 aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
+dIu
+hOh
+iqC
+xCL
+ymj
+eUr
+mTT
+mTT
+lBr
+lAs
+lAs
+rEx
+jCi
+ahu
+ahu
+ahu
+gUJ
 aad
 aad
 aGe
 aHg
 aId
 aHe
-aKq
+pbT
 aLF
 bxj
 sJy
@@ -63260,23 +63448,23 @@ aac
 aad
 aad
 aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
+dIu
+mTM
+bGS
+wMZ
+srh
+bZq
+vtI
+vtI
+vJk
+bZq
+rae
+vpz
+nrv
+wev
+rVj
+fIe
+gUJ
 aad
 aad
 aGe
@@ -63517,23 +63705,23 @@ aad
 aad
 aad
 aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
+dIu
+cAr
+cAr
+cAr
+ymj
+toY
+fIN
+mIv
+lBr
+toY
+lAs
+lAs
+eva
+xCL
+qsc
+lUu
+gUJ
 aad
 aad
 afL
@@ -63766,7 +63954,7 @@ aaa
 aaa
 aaa
 aaa
-aac
+ulC
 aad
 aad
 aad
@@ -63774,23 +63962,23 @@ aad
 aad
 aad
 aad
-aad
-aad
-aad
-aad
-anx
-anx
-anx
-anx
-anx
-anx
-anx
-anx
-anx
-anx
-anx
-anx
-anx
+dIu
+oOk
+vVS
+kTo
+xEQ
+bKQ
+oiL
+mae
+xeu
+bKQ
+aAn
+awF
+uSs
+xIm
+mgs
+aAg
+uok
 abi
 aad
 abT
@@ -64022,6 +64210,8 @@ aaa
 aaa
 aaa
 aaa
+ulC
+ulC
 aad
 aad
 aad
@@ -64029,28 +64219,26 @@ aad
 aad
 aad
 aad
+dIu
+kit
+ddI
+xCL
+awC
+bTZ
+oiL
+mae
+xeu
+bKQ
+aAp
+oiL
+vVA
+aqz
+aqz
+aqz
+uok
 aad
 aad
-aad
-aad
-aad
-aad
-anx
-asv
-atw
-asv
-anx
-awA
-axh
-awA
-anx
-aAg
-aBo
-aAg
-anx
-aad
-aad
-aad
+abu
 afL
 sII
 aJm
@@ -64279,6 +64467,8 @@ aaa
 aaa
 aaa
 aaa
+ulC
+ulC
 aad
 aad
 aad
@@ -64286,29 +64476,27 @@ aad
 aad
 aad
 aad
-aad
-aad
-aad
-aad
-aad
-aad
-anx
+dIu
+oOk
+xej
+wMZ
+uoy
 asw
-atx
+fFw
 auq
-anx
-awB
-axi
-aya
-anx
+xeu
+bKQ
+iIj
+qoT
+dFV
 aAh
 aBp
-aCr
-aqz
+awA
+uok
 sxc
 ahu
 ahu
-aaV
+abu
 bwY
 aJn
 aKw
@@ -64535,9 +64723,9 @@ aaa
 aaa
 aaa
 aaa
-aac
-aac
-aad
+ulC
+ulC
+ulC
 aad
 aad
 aad
@@ -64545,23 +64733,23 @@ abj
 aaW
 aad
 aad
-aad
-aad
-abi
-aqz
-arq
+dIu
+cAr
+cAr
+anx
+awC
+bKQ
+fFw
+auq
+xeu
 asx
 aty
-aur
-avx
-asx
-aty
-aur
+azm
 avx
 aAi
-aty
+axi
 aCs
-aDn
+uok
 aEn
 aFq
 aGf
@@ -64792,9 +64980,9 @@ aaa
 aaa
 aaa
 aaa
-aad
-aad
-aad
+ulC
+ulC
+ulC
 aad
 aad
 abi
@@ -64802,23 +64990,23 @@ abj
 abi
 abi
 aad
-aad
-abi
-ajQ
-sAx
+dIu
+vMb
+srR
+tac
 arr
-awC
-atz
-ayb
-avy
-awC
-axj
-ayb
+bKQ
+fFw
+auq
+xeu
+bKQ
+aAp
+oiL
 avy
 aAj
 blk
-aCt
-aDo
+awA
+uok
 aEo
 aFr
 aGg
@@ -65048,10 +65236,10 @@ aad
 aad
 aac
 aaa
-aac
-aad
-aad
-aad
+ulC
+ulC
+ulC
+ulC
 abi
 aik
 aaW
@@ -65059,23 +65247,23 @@ abj
 abj
 abu
 abu
-aad
-aad
-acF
+dIu
+gap
+fnp
 aqA
-ars
-asz
-atA
-aut
-avz
-awD
-axk
-ayc
-azj
-aAk
-aBq
-aCu
-sGU
+awC
+bTZ
+oiL
+mae
+xeu
+bKQ
+aAp
+oiL
+vVA
+aqz
+aqz
+aqz
+uok
 aEp
 aFs
 aGh
@@ -65304,11 +65492,11 @@ aad
 aad
 aad
 aad
-aac
-aac
-aac
-aad
-aad
+ulC
+ulC
+ulC
+ulC
+ulC
 aad
 abj
 abj
@@ -65316,23 +65504,23 @@ abS
 abj
 abj
 acD
-aad
-abi
-abu
-awL
-art
-atB
-atB
-auu
-avA
-awE
-awE
-ayd
+dIu
+vMb
+ujg
+oaV
+uoy
+asw
+oiL
+mae
+xeu
+bKQ
+auv
+awF
 azk
-ayd
+aAh
 aBr
-aCv
-aDp
+asv
+uok
 aEq
 aFt
 aGh
@@ -65561,11 +65749,11 @@ aac
 aad
 aah
 aad
-aac
-aad
-aac
-aad
-aad
+ulC
+ulC
+ulC
+ulC
+ulC
 aaW
 abj
 abu
@@ -65573,23 +65761,23 @@ aaV
 aad
 abS
 aad
-aad
-abi
-aik
-awL
-aru
-asB
-atC
-auv
-avB
-awF
-awF
-aye
-awF
-aAm
-aBs
+dIu
+cAr
+cAr
+anx
+awC
+bKQ
+oiL
+mae
+xeu
+asC
+qoT
+azm
+eCg
+aAi
+atx
 aCw
-aDp
+uok
 aEr
 aFu
 aGi
@@ -65818,11 +66006,11 @@ aaa
 aac
 aac
 aad
-aad
-aad
-aac
-aad
-aad
+ulC
+ulC
+ulC
+ulC
+ulC
 abi
 abu
 abu
@@ -65830,23 +66018,23 @@ aad
 aad
 abj
 abi
-anx
-anx
-anx
+pNE
+aoq
+rVs
 aqC
 arv
 asC
 auw
-auw
-auw
-auw
-auw
-ayf
+auq
+xeu
+oiL
+oiL
+oiL
 azl
-azl
+aAj
 aBt
-aCx
-aDp
+asv
+uok
 aEs
 aFv
 aGj
@@ -66075,11 +66263,11 @@ aaa
 aac
 aac
 aac
-aad
-aad
-aad
-aad
-aad
+ulC
+ulC
+ulC
+ulC
+ulC
 aad
 abu
 abj
@@ -66087,23 +66275,23 @@ aad
 aaV
 abu
 amG
-anx
-aoq
-apu
-aqD
+pNE
+aor
+apv
+aqA
 arw
 asD
-atE
-aux
-avC
-awG
-awG
-ayg
-azm
-azm
-aBu
-aCy
-aDp
+oiL
+mae
+xeu
+oiL
+oiL
+oiL
+xeu
+aqz
+aqz
+aqz
+uok
 aEt
 sHV
 aGg
@@ -66332,11 +66520,11 @@ aaa
 aaa
 aac
 aac
-aac
-aad
-aad
-aad
-aad
+ulC
+ulC
+ulC
+ulC
+ulC
 aad
 adv
 abj
@@ -66344,23 +66532,23 @@ abj
 abu
 abu
 acF
-anx
-aor
-apv
+pNE
+aoq
+pcl
 aqE
 arx
-asE
-atF
+azm
+auw
 auy
-avD
-awH
+xeu
+oiL
 axm
 ayh
-atH
-aAn
-aBv
+awJ
+ayh
+axo
 aCz
-aDq
+uok
 aEu
 aFw
 aGk
@@ -66589,11 +66777,11 @@ aaa
 aaa
 abR
 aac
-aac
-aac
-aad
-aad
-aad
+ulC
+ulC
+ulC
+ulC
+ulC
 abi
 ael
 abj
@@ -66601,22 +66789,22 @@ abu
 abu
 alG
 acF
+pNE
 anx
-aoq
-apw
+anx
 aqF
 ary
 asF
-azm
-auz
+tWQ
+oiL
 avE
 awI
-axn
-ayi
-azo
-aAo
-aBw
-aCA
+oiL
+xeu
+oiL
+avE
+axo
+aCz
 aDr
 aEv
 aFx
@@ -66846,11 +67034,11 @@ aaa
 aaa
 abR
 aac
-aac
-aad
-aad
-aad
-aad
+ulC
+ulC
+ulC
+ulC
+ulC
 abT
 abi
 aaV
@@ -66858,23 +67046,23 @@ ajQ
 abi
 abT
 acG
-anx
-anx
-anx
-aqC
+bko
+cWv
+cWv
+cWv
 arz
 asG
-atH
+asG
 auA
-avF
+auw
 awJ
 axo
 ayi
-bxI
-aAp
-aBx
-aCB
-aqz
+oiL
+aAn
+awF
+aCA
+uok
 aEw
 aFy
 aGg
@@ -67118,7 +67306,7 @@ agE
 abi
 aad
 abi
-sAy
+sAx
 arA
 asH
 atI
@@ -67131,7 +67319,7 @@ azp
 aAq
 aBy
 aCC
-sAx
+jDd
 aEt
 aEt
 aGg
@@ -67375,18 +67563,18 @@ abi
 aad
 aad
 aaV
-awL
 aqz
 aqz
-atJ
+aqz
+sAx
 auC
-avH
+aqz
 awL
 axq
-ayi
-azo
+cBf
+oiL
 aAr
-aBz
+aBy
 aCD
 aDs
 aEx
@@ -67889,13 +68077,13 @@ agF
 swZ
 agF
 agF
-aqH
-arC
-sBu
-arC
+agF
+fSE
+swZ
+agF
 auE
 avJ
-awN
+cWR
 axs
 ayl
 azr
@@ -79247,7 +79435,7 @@ bhb
 bhO
 ibv
 biX
-bhb
+wUL
 bhO
 nTi
 jdD

--- a/_maps/map_files/OmegaStation/OmegaStation.dmm
+++ b/_maps/map_files/OmegaStation/OmegaStation.dmm
@@ -8596,7 +8596,10 @@
 "aqC" = (
 /obj/machinery/meter,
 /obj/structure/grille,
-/obj/machinery/atmospherics/pipe/simple/green/visible,
+/obj/machinery/atmospherics/pipe/manifold/green/hidden{
+	icon_state = "manifold";
+	dir = 4
+	},
 /turf/closed/wall/r_wall,
 /area/engine/atmos)
 "aqE" = (
@@ -8964,6 +8967,7 @@
 	filter_type = "n2o";
 	on = 1
 	},
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/vault{
 	dir = 5
 	},
@@ -8972,6 +8976,7 @@
 /obj/machinery/atmospherics/pipe/simple/green/visible{
 	dir = 9
 	},
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/vault{
 	dir = 5
 	},
@@ -8984,24 +8989,40 @@
 	output_tag = "mix_out";
 	sensors = list("mix_sensor" = "Tank")
 	},
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/vault{
 	dir = 5
 	},
 /area/engine/atmos)
 "arx" = (
 /obj/machinery/atmospherics/pipe/simple/yellow/visible,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/vault{
 	dir = 5
 	},
 /area/engine/atmos)
 "ary" = (
-/obj/machinery/atmospherics/components/binary/pump,
+/obj/machinery/atmospherics/components/binary/pump{
+	name = "Mix to Distro"
+	},
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/vault{
 	dir = 5
 	},
 /area/engine/atmos)
 "arz" = (
-/obj/machinery/atmospherics/pipe/simple/cyan/visible,
+/obj/machinery/atmospherics/components/binary/pump{
+	name = "Air to Distro";
+	on = 1
+	},
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/item/device/radio/intercom{
+	name = "Station Intercom";
+	pixel_y = 24
+	},
 /turf/open/floor/plasteel/vault{
 	dir = 5
 	},
@@ -9012,6 +9033,10 @@
 	},
 /obj/effect/turf_decal/bot,
 /obj/machinery/suit_storage_unit/atmos,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/sign/poster/random{
+	pixel_y = 32
+	},
 /turf/open/floor/plasteel,
 /area/engine/atmos)
 "arB" = (
@@ -9486,35 +9511,50 @@
 /area/engine/atmos)
 "asw" = (
 /obj/machinery/atmospherics/pipe/manifold/yellow/visible,
-/turf/open/floor/plasteel/neutral,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/caution{
+	dir = 1
+	},
 /area/engine/atmos)
 "asx" = (
 /obj/machinery/atmospherics/pipe/manifold/yellow/visible{
 	dir = 1
 	},
-/turf/open/floor/plasteel/neutral,
+/turf/open/floor/plasteel,
 /area/engine/atmos)
 "asC" = (
 /obj/machinery/atmospherics/pipe/simple/yellow/visible{
 	dir = 10
 	},
-/turf/open/floor/plasteel/neutral,
+/obj/machinery/meter,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/caution{
+	dir = 1
+	},
 /area/engine/atmos)
 "asF" = (
 /obj/machinery/atmospherics/pipe/simple/supply/visible{
 	dir = 5
 	},
-/turf/open/floor/plasteel/neutral,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/caution{
+	dir = 1
+	},
 /area/engine/atmos)
 "asG" = (
-/obj/machinery/atmospherics/pipe/manifold/supply/visible{
-	dir = 4
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/manifold4w/supply/visible,
+/turf/open/floor/plasteel/caution{
+	dir = 1
 	},
-/turf/open/floor/plasteel/neutral,
 /area/engine/atmos)
 "asH" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/components/unary/thermomachine/freezer{
+	dir = 8
+	},
 /turf/open/floor/plasteel/caution{
-	dir = 4
+	dir = 5
 	},
 /area/engine/atmos)
 "asI" = (
@@ -9939,9 +9979,10 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/components/binary/pump{
-	dir = 1
+	dir = 1;
+	name = "Oxygen to Pure"
 	},
-/turf/open/floor/plasteel/neutral,
+/turf/open/floor/plasteel,
 /area/engine/atmos)
 "atI" = (
 /obj/structure/cable/white{
@@ -9955,6 +9996,10 @@
 	name = "Atmospherics APC";
 	pixel_x = 26
 	},
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
 /turf/open/floor/plasteel/caution{
 	dir = 4
 	},
@@ -9962,6 +10007,9 @@
 "atK" = (
 /obj/structure/sign/poster/contraband/random{
 	pixel_x = 32
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 10
 	},
 /turf/open/floor/plating{
 	icon_state = "panelscorched"
@@ -10335,21 +10383,36 @@
 /area/hallway/primary/starboard/fore)
 "auq" = (
 /obj/machinery/atmospherics/pipe/manifold/general/visible,
-/turf/open/floor/plasteel/neutral,
+/turf/open/floor/plasteel,
 /area/engine/atmos)
 "auv" = (
 /obj/machinery/atmospherics/pipe/simple/cyan/visible{
 	dir = 10
 	},
-/turf/open/floor/plasteel/neutral,
+/turf/open/floor/plasteel,
 /area/engine/atmos)
 "auw" = (
-/obj/machinery/atmospherics/components/binary/pump,
-/turf/open/floor/plasteel/neutral,
+/obj/machinery/atmospherics/components/binary/pump{
+	name = "Pure to Port"
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
 /area/engine/atmos)
 "auA" = (
-/obj/machinery/atmospherics/pipe/manifold4w/supply/visible,
-/turf/open/floor/plasteel/neutral,
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/visible{
+	icon_state = "manifold";
+	dir = 8
+	},
+/obj/machinery/meter,
+/turf/open/floor/plasteel,
 /area/engine/atmos)
 "auB" = (
 /obj/machinery/airalarm{
@@ -10364,6 +10427,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/caution{
 	dir = 4
 	},
@@ -10378,6 +10442,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
 "auE" = (
@@ -10798,7 +10863,13 @@
 	output_tag = "o2_out";
 	sensors = list("o2_sensor" = "Tank")
 	},
-/turf/open/floor/plasteel/neutral,
+/obj/machinery/atmospherics/pipe/simple/green/visible{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/vault{
+	dir = 5
+	},
 /area/engine/atmos)
 "avy" = (
 /obj/machinery/atmospherics/components/trinary/filter/flipped{
@@ -10806,13 +10877,16 @@
 	filter_type = "o2";
 	on = 1
 	},
-/turf/open/floor/plasteel/neutral,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/vault{
+	dir = 5
+	},
 /area/engine/atmos)
 "avE" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
 	dir = 10
 	},
-/turf/open/floor/plasteel/neutral,
+/turf/open/floor/plasteel,
 /area/engine/atmos)
 "avG" = (
 /obj/machinery/light{
@@ -10826,6 +10900,7 @@
 	},
 /obj/structure/closet/secure_closet/atmospherics,
 /obj/effect/turf_decal/bot,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/caution{
 	dir = 4
 	},
@@ -10834,8 +10909,8 @@
 /obj/structure/cable/white{
 	icon_state = "2-4"
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
-	dir = 6
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
+	dir = 8
 	},
 /turf/open/floor/plating{
 	icon_state = "platingdmg1"
@@ -11313,25 +11388,36 @@
 /obj/machinery/atmospherics/pipe/simple/green/visible{
 	dir = 4
 	},
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/sign/warning/nosmoking{
+	pixel_y = 30
+	},
 /turf/open/floor/plasteel/vault{
 	dir = 5
 	},
 /area/engine/atmos)
 "awF" = (
 /obj/machinery/atmospherics/pipe/simple/cyan/visible,
-/turf/open/floor/plasteel/neutral,
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/plasteel,
 /area/engine/atmos)
 "awI" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
 	dir = 5
 	},
-/turf/open/floor/plasteel/neutral,
+/turf/open/floor/plasteel,
 /area/engine/atmos)
 "awJ" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/visible{
 	dir = 4
 	},
-/turf/open/floor/plasteel/neutral,
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
 /area/engine/atmos)
 "awK" = (
 /obj/structure/table/reinforced,
@@ -11344,7 +11430,10 @@
 /obj/structure/cable/white{
 	icon_state = "1-2"
 	},
-/turf/open/floor/plasteel,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/caution{
+	dir = 4
+	},
 /area/engine/atmos)
 "awL" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -11549,18 +11638,22 @@
 /area/engine/atmos)
 "axm" = (
 /obj/machinery/atmospherics/components/unary/thermomachine/freezer,
-/turf/open/floor/plasteel/neutral,
+/turf/open/floor/plasteel,
 /area/engine/atmos)
 "axo" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible,
-/turf/open/floor/plasteel/neutral,
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
 /area/engine/atmos)
 "axp" = (
 /obj/structure/cable/white{
 	icon_state = "1-2"
 	},
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/caution{
-	dir = 4
+	dir = 5
 	},
 /area/engine/atmos)
 "axq" = (
@@ -11574,6 +11667,7 @@
 	icon_state = "plant-21"
 	},
 /obj/effect/turf_decal/bot,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel,
 /area/engine/atmos)
 "axr" = (
@@ -11582,6 +11676,7 @@
 	},
 /obj/effect/turf_decal/delivery,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel,
 /area/engine/atmos)
 "axs" = (
@@ -11592,6 +11687,7 @@
 	},
 /obj/effect/decal/cleanable/oil,
 /obj/effect/turf_decal/bot,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel,
 /area/engine/atmos)
 "axt" = (
@@ -11887,14 +11983,18 @@
 	dir = 8;
 	name = "scrubbers pipe"
 	},
-/turf/open/floor/plasteel/neutral,
+/obj/effect/decal/cleanable/oil,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/vault{
+	dir = 5
+	},
 /area/engine/atmos)
 "ayi" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/visible,
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/turf/open/floor/plasteel/neutral,
+/turf/open/floor/plasteel,
 /area/engine/atmos)
 "ayj" = (
 /obj/structure/cable/white{
@@ -12291,24 +12391,31 @@
 	filter_type = "n2";
 	on = 1
 	},
-/turf/open/floor/plasteel/neutral,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/vault{
+	dir = 5
+	},
 /area/engine/atmos)
 "azm" = (
 /obj/machinery/atmospherics/pipe/simple/yellow/visible,
-/turf/open/floor/plasteel/neutral,
+/obj/machinery/meter,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/caution{
+	dir = 1
+	},
 /area/engine/atmos)
 "azp" = (
 /obj/structure/cable/white{
 	icon_state = "1-2"
 	},
-/turf/open/floor/plasteel/neutral,
+/turf/open/floor/plasteel,
 /area/engine/atmos)
 "azq" = (
 /obj/structure/cable/white{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible,
-/turf/open/floor/plasteel/neutral,
+/turf/open/floor/plasteel,
 /area/engine/atmos)
 "azr" = (
 /obj/effect/turf_decal/stripes/line{
@@ -12643,6 +12750,7 @@
 /obj/machinery/atmospherics/pipe/manifold/yellow/visible{
 	dir = 8
 	},
+/obj/structure/grille,
 /turf/closed/wall/r_wall,
 /area/engine/atmos)
 "aAi" = (
@@ -12655,19 +12763,21 @@
 "aAj" = (
 /obj/machinery/meter,
 /obj/machinery/atmospherics/pipe/simple/green/visible,
+/obj/structure/grille,
 /turf/closed/wall/r_wall,
 /area/engine/atmos)
 "aAn" = (
 /obj/machinery/atmospherics/pipe/simple/cyan/visible{
 	dir = 6
 	},
-/turf/open/floor/plasteel/neutral,
+/obj/machinery/meter,
+/turf/open/floor/plasteel,
 /area/engine/atmos)
 "aAp" = (
 /obj/machinery/atmospherics/pipe/simple/cyan/visible{
 	dir = 4
 	},
-/turf/open/floor/plasteel/neutral,
+/turf/open/floor/plasteel,
 /area/engine/atmos)
 "aAq" = (
 /obj/effect/landmark/start/atmospheric_technician,
@@ -12677,7 +12787,7 @@
 /obj/machinery/atmospherics/pipe/manifold/cyan/visible{
 	dir = 1
 	},
-/turf/open/floor/plasteel/neutral,
+/turf/open/floor/plasteel,
 /area/engine/atmos)
 "aAr" = (
 /obj/structure/cable/white{
@@ -12686,7 +12796,7 @@
 /obj/machinery/atmospherics/pipe/simple/cyan/visible{
 	dir = 10
 	},
-/turf/open/floor/plasteel/neutral,
+/turf/open/floor/plasteel,
 /area/engine/atmos)
 "aAs" = (
 /obj/structure/cable/white{
@@ -12705,7 +12815,7 @@
 	icon_state = "1-4"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible,
-/turf/open/floor/plasteel/neutral,
+/turf/open/floor/plasteel,
 /area/engine/atmos)
 "aAt" = (
 /obj/structure/cable/white{
@@ -13566,13 +13676,18 @@
 	dir = 1
 	},
 /obj/machinery/portable_atmospherics/scrubber,
-/turf/open/floor/plasteel/arrival,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/escape{
+	dir = 5
+	},
 /area/engine/atmos)
 "aCA" = (
 /obj/machinery/atmospherics/components/unary/portables_connector/visible{
 	dir = 1
 	},
 /obj/machinery/portable_atmospherics/pump,
+/obj/machinery/light,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/arrival,
 /area/engine/atmos)
 "aCC" = (
@@ -13584,16 +13699,20 @@
 	dir = 1
 	},
 /obj/machinery/portable_atmospherics/pump,
-/turf/open/floor/plasteel/escape,
-/area/engine/atmos)
-"aCD" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/arrival,
+/area/engine/atmos)
+"aCD" = (
 /obj/machinery/atmospherics/pipe/manifold/cyan/visible{
 	dir = 8
 	},
-/turf/open/floor/plasteel/escape,
+/obj/effect/turf_decal/bot,
+/turf/open/floor/plasteel/vault/side{
+	dir = 1
+	},
 /area/engine/atmos)
 "aCE" = (
 /obj/structure/cable/white{
@@ -13931,6 +14050,12 @@
 	},
 /turf/open/space/basic,
 /area/space)
+"aDl" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/engine/atmos)
 "aDr" = (
 /obj/structure/sign/warning/nosmoking,
 /obj/machinery/atmospherics/pipe/simple/cyan/hidden{
@@ -20274,6 +20399,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
+/obj/structure/closet/secure_closet/engineering_electrical,
 /turf/open/floor/engine,
 /area/engine/engineering)
 "aQU" = (
@@ -29883,6 +30009,12 @@
 	},
 /turf/closed/wall/r_wall,
 /area/asteroid/nearstation)
+"bpB" = (
+/obj/machinery/atmospherics/pipe/simple/yellow/visible{
+	dir = 10
+	},
+/turf/open/floor/plasteel,
+/area/engine/atmos)
 "bsv" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/structure/cable/white{
@@ -30230,6 +30362,11 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
+"buw" = (
+/obj/machinery/holopad,
+/obj/effect/turf_decal/bot,
+/turf/open/floor/plasteel,
+/area/engine/atmos)
 "buC" = (
 /turf/open/floor/plasteel/grimy,
 /area/tcommsat/server)
@@ -30812,7 +30949,7 @@
 /obj/machinery/atmospherics/pipe/simple/cyan/visible{
 	dir = 5
 	},
-/turf/open/floor/plasteel/neutral,
+/turf/open/floor/plasteel,
 /area/asteroid/nearstation)
 "bGS" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/siphon/on{
@@ -30835,7 +30972,10 @@
 /obj/machinery/atmospherics/pipe/simple/yellow/visible{
 	dir = 4
 	},
-/turf/open/floor/plasteel/neutral,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/caution{
+	dir = 1
+	},
 /area/engine/atmos)
 "bYE" = (
 /obj/structure/sign/warning/fire,
@@ -30848,7 +30988,10 @@
 /obj/machinery/atmospherics/pipe/manifold/yellow/visible{
 	dir = 8
 	},
-/turf/open/floor/plasteel/neutral,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/caution{
+	dir = 1
+	},
 /area/asteroid/nearstation)
 "ccy" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -30865,6 +31008,15 @@
 	},
 /turf/open/floor/plasteel,
 /area/hydroponics)
+"chJ" = (
+/obj/machinery/atmospherics/pipe/simple/orange/visible,
+/obj/effect/turf_decal/bot,
+/obj/machinery/space_heater,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/caution{
+	dir = 8
+	},
+/area/asteroid/nearstation)
 "ckn" = (
 /obj/machinery/atmospherics/pipe/simple/cyan/hidden,
 /turf/closed/wall/r_wall,
@@ -30932,7 +31084,8 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/turf/open/floor/plasteel/neutral,
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/plasteel,
 /area/engine/atmos)
 "cCp" = (
 /obj/machinery/door/poddoor{
@@ -30943,7 +31096,12 @@
 /area/asteroid/nearstation)
 "cGz" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/turf/open/floor/plasteel/neutral,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/firealarm{
+	dir = 1;
+	pixel_y = -26
+	},
+/turf/open/floor/plasteel,
 /area/asteroid/nearstation)
 "cRz" = (
 /obj/machinery/button/door{
@@ -30969,6 +31127,12 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard)
+"cWq" = (
+/obj/machinery/atmospherics/pipe/simple/yellow/visible{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/asteroid/nearstation)
 "cWv" = (
 /obj/machinery/atmospherics/pipe/simple/cyan/hidden,
 /turf/closed/wall/r_wall,
@@ -31023,6 +31187,18 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
+"dgV" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/asteroid/nearstation)
+"diG" = (
+/turf/open/floor/plasteel,
+/area/engine/atmos)
 "doD" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/machinery/door/firedoor,
@@ -31049,9 +31225,13 @@
 	},
 /obj/machinery/atmospherics/components/binary/pump{
 	dir = 1;
+	name = "Oxygen to Airmix";
 	on = 1
 	},
-/turf/open/floor/plasteel/neutral,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/vault{
+	dir = 5
+	},
 /area/engine/atmos)
 "dIu" = (
 /obj/structure/grille,
@@ -31084,14 +31264,15 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/turf/open/floor/plasteel/neutral,
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/plasteel,
 /area/engine/atmos)
 "eew" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/turf/open/floor/plasteel/neutral,
+/turf/open/floor/plasteel,
 /area/asteroid/nearstation)
 "eva" = (
 /obj/machinery/atmospherics/pipe/simple/green/visible{
@@ -31104,7 +31285,10 @@
 	output_tag = "airmix_out";
 	sensors = list("airmix_sensor" = "Tank")
 	},
-/turf/open/floor/plasteel/neutral,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/vault{
+	dir = 5
+	},
 /area/asteroid/nearstation)
 "ewT" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
@@ -31159,7 +31343,10 @@
 	output_tag = "n2_out";
 	sensors = list("n2_sensor" = "Tank")
 	},
-/turf/open/floor/plasteel/neutral,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/vault{
+	dir = 5
+	},
 /area/engine/atmos)
 "eFp" = (
 /obj/effect/turf_decal/stripes/end{
@@ -31168,6 +31355,17 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plasteel,
 /area/science/xenobiology)
+"eOs" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
+	dir = 4
+	},
+/obj/structure/table/reinforced,
+/obj/item/storage/belt/utility,
+/obj/item/storage/belt/utility,
+/obj/item/clothing/glasses/meson/engine/tray,
+/obj/item/clothing/glasses/meson/engine/tray,
+/turf/open/floor/plasteel,
+/area/engine/atmos)
 "eUz" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -31198,10 +31396,36 @@
 	},
 /turf/open/floor/engine,
 /area/asteroid/nearstation)
+"eZd" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/visible,
+/obj/effect/turf_decal/stripes/line{
+	dir = 10
+	},
+/turf/open/floor/plasteel,
+/area/engine/atmos)
+"fbH" = (
+/obj/machinery/atmospherics/pipe/simple/orange/visible,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/fireaxecabinet{
+	pixel_x = -30
+	},
+/turf/open/floor/plasteel/caution{
+	dir = 8
+	},
+/area/asteroid/nearstation)
 "fgG" = (
 /obj/machinery/ai_status_display,
 /turf/closed/wall,
 /area/crew_quarters/lounge)
+"fjs" = (
+/obj/machinery/atmospherics/pipe/simple/green/visible{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/vault{
+	dir = 5
+	},
+/area/engine/atmos)
 "fnp" = (
 /obj/machinery/air_sensor{
 	frequency = 1441;
@@ -31226,6 +31450,17 @@
 	},
 /turf/open/floor/engine,
 /area/asteroid/nearstation)
+"fvd" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/engine/atmos)
+"fEt" = (
+/obj/machinery/atmospherics/pipe/manifold/general/visible,
+/obj/machinery/meter,
+/turf/open/floor/plasteel,
+/area/engine/atmos)
 "fEM" = (
 /obj/machinery/atmospherics/pipe/simple/cyan/hidden{
 	icon_state = "intact";
@@ -31235,7 +31470,11 @@
 /area/asteroid/nearstation)
 "fFw" = (
 /obj/machinery/atmospherics/components/unary/portables_connector/visible,
-/turf/open/floor/plasteel/neutral,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/machinery/portable_atmospherics/canister,
+/turf/open/floor/plasteel,
 /area/engine/atmos)
 "fIe" = (
 /turf/open/floor/engine/air,
@@ -31244,8 +31483,23 @@
 /obj/machinery/atmospherics/pipe/simple/general/visible{
 	dir = 10
 	},
-/turf/open/floor/plasteel/neutral,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
 /area/asteroid/nearstation)
+"fKT" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/caution{
+	dir = 1
+	},
+/area/asteroid/nearstation)
+"fLr" = (
+/obj/machinery/atmospherics/pipe/simple/general/visible{
+	dir = 9
+	},
+/turf/open/floor/plasteel,
+/area/engine/atmos)
 "fMT" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -31278,6 +31532,14 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit)
+"fYx" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/machinery/light,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel,
+/area/asteroid/nearstation)
 "gap" = (
 /obj/machinery/portable_atmospherics/canister/nitrous_oxide,
 /turf/open/floor/engine/n2o,
@@ -31320,7 +31582,10 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/turf/open/floor/plasteel/neutral,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/vault{
+	dir = 5
+	},
 /area/asteroid/nearstation)
 "gyV" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
@@ -31361,6 +31626,7 @@
 	filter_type = "co2";
 	on = 1
 	},
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/vault{
 	dir = 5
 	},
@@ -31380,6 +31646,18 @@
 	},
 /turf/open/floor/plasteel/redyellow,
 /area/crew_quarters/bar/atrium)
+"hqX" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/engine/atmos)
+"hsV" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/turf/closed/wall/r_wall/rust,
+/area/engine/atmos)
 "hDi" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
@@ -31401,6 +31679,25 @@
 /obj/machinery/portable_atmospherics/canister/carbon_dioxide,
 /turf/open/floor/engine/co2,
 /area/asteroid/nearstation)
+"hUG" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/turf/open/floor/plasteel,
+/area/asteroid/nearstation)
+"hUL" = (
+/obj/effect/landmark/start/atmospheric_technician,
+/turf/open/floor/plasteel,
+/area/asteroid/nearstation)
+"hXn" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
+	dir = 4
+	},
+/obj/machinery/pipedispenser,
+/obj/effect/turf_decal/bot,
+/turf/open/floor/plasteel,
+/area/engine/atmos)
 "iaa" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/machinery/navbeacon{
@@ -31414,12 +31711,29 @@
 "ibv" = (
 /turf/closed/wall,
 /area/science/xenobiology)
+"idD" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
+	dir = 4
+	},
+/obj/machinery/light,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/vault{
+	dir = 5
+	},
+/area/engine/atmos)
 "iqC" = (
 /obj/machinery/air_sensor{
 	frequency = 1441;
 	id_tag = "co2_sensor"
 	},
 /turf/open/floor/engine/co2,
+/area/asteroid/nearstation)
+"ixk" = (
+/obj/machinery/atmospherics/pipe/simple/green/visible,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
 /area/asteroid/nearstation)
 "iye" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/siphon/on{
@@ -31431,7 +31745,8 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/turf/open/floor/plasteel/neutral,
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/plasteel,
 /area/asteroid/nearstation)
 "iIj" = (
 /obj/machinery/atmospherics/components/trinary/mixer/flipped{
@@ -31440,20 +31755,24 @@
 	node2_concentration = 0.2;
 	on = 1
 	},
-/turf/open/floor/plasteel/neutral,
+/turf/open/floor/plasteel,
 /area/engine/atmos)
 "iJY" = (
 /obj/machinery/atmospherics/pipe/simple/cyan/visible,
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/turf/open/floor/plasteel/neutral,
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/plasteel,
 /area/engine/atmos)
 "iKp" = (
 /obj/machinery/atmospherics/pipe/simple/green/visible{
 	dir = 5
 	},
-/turf/open/floor/plasteel/neutral,
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
 /area/asteroid/nearstation)
 "iML" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
@@ -31470,6 +31789,16 @@
 	dir = 4
 	},
 /area/science/xenobiology)
+"iVy" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/visible,
+/turf/open/floor/plasteel,
+/area/engine/atmos)
 "iZQ" = (
 /obj/machinery/atmospherics/components/unary/outlet_injector/on{
 	dir = 2;
@@ -31518,11 +31847,20 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/turf/open/floor/plasteel/neutral,
+/turf/open/floor/plasteel,
 /area/asteroid/nearstation)
 "jpv" = (
 /obj/machinery/atmospherics/pipe/simple/cyan/visible,
-/turf/open/floor/plasteel/neutral,
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/sign/poster/random{
+	pixel_y = 32
+	},
+/turf/open/floor/plasteel/caution{
+	dir = 1
+	},
 /area/asteroid/nearstation)
 "jqM" = (
 /obj/effect/turf_decal/bot,
@@ -31533,6 +31871,20 @@
 	dir = 8
 	},
 /area/hallway/primary/starboard)
+"jtZ" = (
+/obj/machinery/atmospherics/pipe/simple/cyan/visible,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/asteroid/nearstation)
+"juT" = (
+/obj/machinery/atmospherics/pipe/simple/yellow/visible,
+/obj/machinery/atmospherics/pipe/simple/general/visible{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/asteroid/nearstation)
 "jwi" = (
 /obj/structure/sign/directions/engineering{
 	dir = 8;
@@ -31546,6 +31898,15 @@
 	},
 /turf/closed/wall,
 /area/hallway/primary/fore)
+"jxc" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/engine/atmos)
 "jBG" = (
 /obj/structure/cable/white{
 	icon_state = "1-2"
@@ -31567,7 +31928,11 @@
 /obj/machinery/atmospherics/pipe/simple/green/visible{
 	dir = 4
 	},
-/turf/open/floor/plasteel/neutral,
+/obj/machinery/light,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/vault{
+	dir = 5
+	},
 /area/asteroid/nearstation)
 "jDd" = (
 /obj/machinery/atmospherics/pipe/simple/cyan/hidden{
@@ -31576,17 +31941,27 @@
 	},
 /turf/closed/wall/r_wall/rust,
 /area/engine/atmos)
+"kaA" = (
+/obj/machinery/atmospherics/components/unary/portables_connector/visible{
+	dir = 1
+	},
+/obj/machinery/portable_atmospherics/scrubber,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/escape{
+	dir = 10
+	},
+/area/engine/atmos)
 "kit" = (
 /obj/machinery/portable_atmospherics/canister/toxins,
 /turf/open/floor/engine/plasma,
 /area/asteroid/nearstation)
 "kiw" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 10
-	},
 /obj/machinery/atmospherics/pipe/simple/general/visible,
 /obj/structure/cable{
 	icon_state = "4-8"
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
 	},
 /turf/open/floor/plasteel,
 /area/asteroid/nearstation)
@@ -31594,6 +31969,30 @@
 /obj/structure/lattice/catwalk,
 /turf/open/space,
 /area/space)
+"kwF" = (
+/obj/machinery/atmospherics/pipe/simple/green/visible{
+	dir = 4
+	},
+/obj/machinery/atmospherics/components/binary/pump{
+	dir = 1;
+	name = "Nitrogen to Airmix";
+	on = 1
+	},
+/obj/machinery/light,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/vault{
+	dir = 5
+	},
+/area/engine/atmos)
+"kCU" = (
+/obj/machinery/atmospherics/pipe/simple/orange/visible{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/asteroid/nearstation)
 "kHA" = (
 /obj/machinery/atmospherics/pipe/simple/green/visible{
 	dir = 4
@@ -31605,6 +32004,7 @@
 	output_tag = "co2_out";
 	sensors = list("co2_sensor" = "Tank")
 	},
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/vault{
 	dir = 5
 	},
@@ -31637,7 +32037,7 @@
 /obj/machinery/atmospherics/pipe/simple/cyan/visible{
 	dir = 4
 	},
-/turf/open/floor/plasteel/neutral,
+/turf/open/floor/plasteel,
 /area/asteroid/nearstation)
 "lrg" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
@@ -31645,6 +32045,13 @@
 	},
 /obj/structure/lattice,
 /turf/open/space/basic,
+/area/asteroid/nearstation)
+"lvw" = (
+/obj/machinery/atmospherics/pipe/simple/orange/visible,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/caution{
+	dir = 8
+	},
 /area/asteroid/nearstation)
 "lxq" = (
 /obj/structure/cable/white{
@@ -31660,13 +32067,20 @@
 /turf/open/floor/plasteel/greenblue/side,
 /area/hydroponics)
 "lAs" = (
-/turf/open/floor/plasteel/neutral,
+/obj/effect/decal/cleanable/dirt,
+/obj/item/device/radio/intercom{
+	name = "Station Intercom";
+	pixel_y = 24
+	},
+/turf/open/floor/plasteel/caution{
+	dir = 9
+	},
 /area/asteroid/nearstation)
 "lBr" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
 	dir = 4
 	},
-/turf/open/floor/plasteel/neutral,
+/turf/open/floor/plasteel,
 /area/asteroid/nearstation)
 "lCg" = (
 /obj/machinery/door/airlock/external{
@@ -31735,7 +32149,7 @@
 /obj/machinery/atmospherics/pipe/simple/general/visible{
 	dir = 4
 	},
-/turf/open/floor/plasteel/neutral,
+/turf/open/floor/plasteel,
 /area/engine/atmos)
 "mgs" = (
 /obj/machinery/atmospherics/components/unary/outlet_injector/on{
@@ -31745,6 +32159,25 @@
 	name = "airmix injector"
 	},
 /turf/open/floor/engine/air,
+/area/engine/atmos)
+"mkF" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
+	dir = 4
+	},
+/obj/structure/table/reinforced,
+/obj/item/clothing/head/welding,
+/obj/item/clothing/head/welding{
+	pixel_y = 5
+	},
+/turf/open/floor/plasteel,
+/area/engine/atmos)
+"mnD" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
+	dir = 4
+	},
+/obj/machinery/pipedispenser/disposal,
+/obj/effect/turf_decal/bot,
+/turf/open/floor/plasteel,
 /area/engine/atmos)
 "mqF" = (
 /obj/machinery/door/poddoor{
@@ -31758,11 +32191,14 @@
 /obj/machinery/atmospherics/pipe/simple/orange/visible{
 	dir = 4
 	},
-/turf/open/floor/plasteel/neutral,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
 /area/asteroid/nearstation)
 "mIv" = (
 /obj/machinery/atmospherics/pipe/manifold/general/visible,
-/turf/open/floor/plasteel/neutral,
+/turf/open/floor/plasteel,
 /area/asteroid/nearstation)
 "mJP" = (
 /obj/machinery/igniter{
@@ -31793,16 +32229,22 @@
 /obj/structure/cable{
 	icon_state = "2-4"
 	},
-/turf/open/floor/plasteel/neutral,
+/obj/effect/turf_decal/stripes/line,
+/obj/machinery/meter,
+/turf/open/floor/plasteel,
 /area/asteroid/nearstation)
 "mTM" = (
 /turf/open/floor/engine/co2,
 /area/asteroid/nearstation)
 "mTT" = (
 /obj/machinery/atmospherics/components/binary/pump{
-	dir = 8
+	dir = 8;
+	name = "Port to Fuel Pipe"
 	},
-/turf/open/floor/plasteel/neutral,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
 /area/asteroid/nearstation)
 "mXV" = (
 /obj/structure/cable/white{
@@ -31827,7 +32269,10 @@
 /obj/machinery/atmospherics/pipe/simple/green/visible{
 	dir = 4
 	},
-/turf/open/floor/plasteel/neutral,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/vault{
+	dir = 5
+	},
 /area/asteroid/nearstation)
 "nwY" = (
 /obj/effect/spawner/structure/window/reinforced,
@@ -31836,6 +32281,13 @@
 "nxA" = (
 /turf/closed/wall,
 /area/hallway/primary/port/aft)
+"nFG" = (
+/obj/machinery/atmospherics/pipe/manifold/yellow/visible{
+	dir = 8
+	},
+/obj/machinery/meter,
+/turf/open/floor/plasteel,
+/area/asteroid/nearstation)
 "nKi" = (
 /obj/machinery/door/airlock/maintenance_hatch{
 	name = "Maintenance Hatch";
@@ -31865,6 +32317,9 @@
 "nUk" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/general/visible,
+/obj/effect/turf_decal/stripes/line{
+	dir = 10
+	},
 /turf/open/floor/plasteel/caution,
 /area/asteroid/nearstation)
 "oaV" = (
@@ -31874,19 +32329,30 @@
 /turf/closed/wall/r_wall,
 /area/engine/atmos)
 "oiL" = (
-/turf/open/floor/plasteel/neutral,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/caution{
+	dir = 1
+	},
 /area/engine/atmos)
+"oql" = (
+/obj/machinery/atmospherics/pipe/simple/green/visible,
+/turf/open/floor/plasteel,
+/area/asteroid/nearstation)
 "orI" = (
 /obj/machinery/atmospherics/pipe/simple/cyan/visible,
 /obj/structure/cable{
 	icon_state = "1-8"
 	},
-/turf/open/floor/plasteel/neutral,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/vault{
+	dir = 5
+	},
 /area/asteroid/nearstation)
 "otn" = (
 /obj/machinery/atmospherics/pipe/simple/green/visible{
 	dir = 6
 	},
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/vault{
 	dir = 5
 	},
@@ -31915,12 +32381,28 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/turf/open/floor/plasteel/neutral,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/vault{
+	dir = 5
+	},
 /area/asteroid/nearstation)
+"oGc" = (
+/obj/machinery/atmospherics/pipe/simple/cyan/visible{
+	dir = 6
+	},
+/turf/open/floor/plasteel,
+/area/engine/atmos)
 "oIG" = (
 /obj/structure/sign/warning/fire,
 /turf/closed/wall/r_wall,
 /area/space)
+"oJp" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on,
+/turf/open/floor/plasteel,
+/area/asteroid/nearstation)
 "oOk" = (
 /turf/open/floor/engine/plasma,
 /area/asteroid/nearstation)
@@ -31947,6 +32429,14 @@
 	name = "distro vent"
 	},
 /turf/open/floor/engine/vacuum,
+/area/engine/atmos)
+"pjU" = (
+/obj/structure/grille,
+/obj/machinery/atmospherics/pipe/simple/yellow/hidden{
+	icon_state = "intact";
+	dir = 6
+	},
+/turf/closed/wall/r_wall,
 /area/engine/atmos)
 "plz" = (
 /obj/effect/turf_decal/stripes/end{
@@ -32055,9 +32545,10 @@
 /area/asteroid/nearstation)
 "qoT" = (
 /obj/machinery/atmospherics/components/binary/pump{
-	dir = 1
+	dir = 1;
+	name = "Nitrogen to Pure"
 	},
-/turf/open/floor/plasteel/neutral,
+/turf/open/floor/plasteel,
 /area/engine/atmos)
 "qpG" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -32070,6 +32561,48 @@
 	},
 /turf/open/floor/engine/air,
 /area/asteroid/nearstation)
+"qui" = (
+/obj/machinery/atmospherics/components/binary/pump{
+	name = "Distro to Waste"
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/engine/atmos)
+"qEl" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
+	dir = 4
+	},
+/obj/machinery/pipedispenser/disposal/transit_tube,
+/obj/effect/turf_decal/bot,
+/turf/open/floor/plasteel,
+/area/engine/atmos)
+"qFw" = (
+/obj/machinery/atmospherics/pipe/simple/green/visible{
+	dir = 4
+	},
+/obj/machinery/atmospherics/components/binary/pump{
+	dir = 1;
+	name = "Pure to Mix"
+	},
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/vault{
+	dir = 5
+	},
+/area/engine/atmos)
+"qIp" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/engine/atmos)
 "qMr" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -32077,13 +32610,17 @@
 /obj/machinery/atmospherics/pipe/manifold/general/visible{
 	dir = 1
 	},
+/obj/machinery/meter,
 /turf/open/floor/plasteel,
 /area/space)
 "qTa" = (
 /obj/machinery/atmospherics/pipe/simple/orange/visible{
 	dir = 4
 	},
-/turf/open/floor/plasteel/neutral,
+/obj/effect/turf_decal/stripes/line{
+	dir = 9
+	},
+/turf/open/floor/plasteel,
 /area/asteroid/nearstation)
 "qUW" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -32093,9 +32630,14 @@
 /area/asteroid/nearstation)
 "rae" = (
 /obj/machinery/atmospherics/components/binary/pump{
-	dir = 1
+	dir = 1;
+	name = "Airmix to Pure"
 	},
-/turf/open/floor/plasteel/neutral,
+/turf/open/floor/plasteel,
+/area/asteroid/nearstation)
+"rjQ" = (
+/obj/machinery/atmospherics/pipe/simple/cyan/visible,
+/turf/open/floor/plasteel,
 /area/asteroid/nearstation)
 "rjV" = (
 /obj/machinery/atmospherics/components/binary/pump{
@@ -32135,7 +32677,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
 	dir = 6
 	},
-/turf/open/floor/plasteel/neutral,
+/turf/open/floor/plasteel,
 /area/asteroid/nearstation)
 "rCw" = (
 /obj/machinery/door/window/brigdoor{
@@ -32165,7 +32707,8 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/turf/open/floor/plasteel/neutral,
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/plasteel,
 /area/asteroid/nearstation)
 "rVj" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/siphon/on{
@@ -32222,7 +32765,10 @@
 /obj/machinery/atmospherics/pipe/simple/green/visible{
 	dir = 4
 	},
-/obj/machinery/atmospherics/components/binary/pump,
+/obj/machinery/atmospherics/components/binary/pump{
+	name = "CO2 to Pure"
+	},
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/vault{
 	dir = 5
 	},
@@ -32597,7 +33143,26 @@
 	},
 /area/maintenance/starboard)
 "sFp" = (
-/obj/machinery/light/small{
+/obj/structure/closet/crate{
+	name = "solar pack crate"
+	},
+/obj/item/solar_assembly,
+/obj/item/solar_assembly,
+/obj/item/solar_assembly,
+/obj/item/solar_assembly,
+/obj/item/solar_assembly,
+/obj/item/solar_assembly,
+/obj/item/solar_assembly,
+/obj/item/solar_assembly,
+/obj/item/solar_assembly,
+/obj/item/solar_assembly,
+/obj/item/solar_assembly,
+/obj/item/solar_assembly,
+/obj/item/solar_assembly,
+/obj/item/circuitboard/computer/solar_control,
+/obj/item/electronics/tracker,
+/obj/item/paper/guides/jobs/engi/solars,
+/obj/effect/turf_decal/bot{
 	dir = 1
 	},
 /turf/open/floor/plasteel/vault/side{
@@ -34686,23 +35251,48 @@
 /obj/machinery/atmospherics/pipe/simple/orange/visible{
 	dir = 4
 	},
-/turf/open/floor/plasteel/neutral,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/asteroid/nearstation)
+"tgm" = (
+/obj/machinery/atmospherics/components/binary/pump{
+	dir = 8;
+	name = "Port to Waste"
+	},
+/turf/open/floor/plasteel,
 /area/asteroid/nearstation)
 "tgp" = (
 /obj/machinery/atmospherics/components/unary/portables_connector/visible{
 	dir = 8
 	},
-/turf/open/floor/plasteel/neutral,
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
 /area/asteroid/nearstation)
 "toY" = (
 /obj/machinery/atmospherics/pipe/simple/yellow/visible{
 	dir = 4
 	},
-/turf/open/floor/plasteel/neutral,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/caution{
+	dir = 1
+	},
 /area/asteroid/nearstation)
 "ttA" = (
 /obj/machinery/atmospherics/pipe/simple/orange/visible,
-/turf/open/floor/plasteel/neutral,
+/obj/effect/turf_decal/bot,
+/obj/machinery/space_heater,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/sign/poster/random{
+	pixel_x = -32;
+	pixel_y = 0
+	},
+/turf/open/floor/plasteel/caution{
+	dir = 8
+	},
 /area/asteroid/nearstation)
 "tKM" = (
 /turf/closed/wall,
@@ -34718,26 +35308,33 @@
 /turf/closed/wall,
 /area/crew_quarters/lounge)
 "tWQ" = (
-/obj/machinery/atmospherics/components/unary/thermomachine/heater{
-	dir = 4
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
 	},
-/turf/open/floor/plasteel/neutral,
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
 /area/engine/atmos)
 "ueC" = (
 /obj/effect/decal/cleanable/oil,
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden,
 /turf/open/floor/plasteel,
 /area/asteroid/nearstation)
 "ueG" = (
 /obj/machinery/atmospherics/pipe/simple/orange/visible{
 	dir = 6
 	},
-/turf/open/floor/plasteel/neutral,
+/obj/machinery/light{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/caution{
+	dir = 9
+	},
 /area/asteroid/nearstation)
 "ugK" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -34768,7 +35365,10 @@
 /obj/machinery/atmospherics/pipe/simple/green/visible{
 	dir = 4
 	},
-/obj/machinery/atmospherics/components/binary/pump,
+/obj/machinery/atmospherics/components/binary/pump{
+	name = "Plasma to Pure"
+	},
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/vault{
 	dir = 5
 	},
@@ -34787,7 +35387,10 @@
 /area/hydroponics)
 "uuJ" = (
 /obj/machinery/atmospherics/pipe/simple/green/visible,
-/turf/open/floor/plasteel/neutral,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/caution{
+	dir = 1
+	},
 /area/asteroid/nearstation)
 "uuU" = (
 /obj/machinery/status_display,
@@ -34835,10 +35438,10 @@
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit)
 "uyJ" = (
-/obj/machinery/atmospherics/components/binary/pump{
-	dir = 4
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
+	dir = 1
 	},
-/turf/open/floor/plasteel/neutral,
+/turf/open/floor/plasteel,
 /area/engine/atmos)
 "uBJ" = (
 /obj/effect/turf_decal/bot_white/right,
@@ -34853,12 +35456,34 @@
 	dir = 1
 	},
 /area/hallway/primary/port)
+"uIm" = (
+/turf/open/floor/plasteel,
+/area/asteroid/nearstation)
 "uSs" = (
 /obj/machinery/atmospherics/pipe/simple/cyan/visible,
 /obj/machinery/atmospherics/pipe/simple/green/visible{
 	dir = 4
 	},
-/turf/open/floor/plasteel/neutral,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/vault{
+	dir = 5
+	},
+/area/engine/atmos)
+"uVJ" = (
+/obj/effect/decal/cleanable/oil,
+/obj/machinery/atmospherics/components/unary/vent_pump/on{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/asteroid/nearstation)
+"ver" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
+	dir = 10
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
 /area/engine/atmos)
 "viy" = (
 /obj/machinery/atmospherics/pipe/simple/green/visible{
@@ -34871,6 +35496,7 @@
 	output_tag = "n2o_out";
 	sensors = list("n2o_sensor" = "Tank")
 	},
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/vault{
 	dir = 5
 	},
@@ -34886,6 +35512,18 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
+"vmq" = (
+/obj/machinery/atmospherics/components/binary/pump{
+	name = "Mix to Port"
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/engine/atmos)
 "vmU" = (
 /obj/machinery/atmospherics/pipe/simple/green/visible{
 	dir = 4
@@ -34897,6 +35535,7 @@
 	output_tag = "plasma_out";
 	sensors = list("plasma_sensor" = "Tank")
 	},
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/vault{
 	dir = 5
 	},
@@ -34918,7 +35557,8 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/turf/open/floor/plasteel/neutral,
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/plasteel,
 /area/asteroid/nearstation)
 "vsf" = (
 /obj/effect/decal/cleanable/xenoblood/xgibs,
@@ -34942,20 +35582,51 @@
 /obj/machinery/atmospherics/pipe/simple/general/visible{
 	dir = 4
 	},
-/turf/open/floor/plasteel/neutral,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
 /area/asteroid/nearstation)
+"vuh" = (
+/obj/machinery/atmospherics/pipe/simple/green/visible{
+	dir = 4
+	},
+/obj/machinery/atmospherics/components/binary/pump{
+	name = "N2O to Pure"
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/vault{
+	dir = 5
+	},
+/area/engine/atmos)
 "vuN" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 10
 	},
-/turf/open/floor/plasteel/neutral,
+/turf/open/floor/plasteel,
 /area/asteroid/nearstation)
 "vJk" = (
 /obj/machinery/atmospherics/pipe/simple/yellow/visible,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
 	dir = 4
 	},
-/turf/open/floor/plasteel/neutral,
+/turf/open/floor/plasteel,
+/area/asteroid/nearstation)
+"vJt" = (
+/obj/machinery/atmospherics/pipe/simple/orange/visible,
+/obj/effect/turf_decal/bot,
+/obj/machinery/space_heater,
+/obj/machinery/light{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/airalarm{
+	dir = 4;
+	pixel_x = -22
+	},
+/turf/open/floor/plasteel/caution{
+	dir = 8
+	},
 /area/asteroid/nearstation)
 "vMb" = (
 /turf/open/floor/engine/n2o,
@@ -34964,7 +35635,14 @@
 /obj/machinery/atmospherics/pipe/simple/green/visible{
 	dir = 4
 	},
-/turf/open/floor/plasteel/neutral,
+/obj/machinery/light,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/sign/warning/nosmoking{
+	pixel_y = -30
+	},
+/turf/open/floor/plasteel/vault{
+	dir = 5
+	},
 /area/engine/atmos)
 "vVS" = (
 /obj/machinery/atmospherics/components/unary/outlet_injector/on{
@@ -35014,17 +35692,24 @@
 "wev" = (
 /obj/machinery/meter,
 /obj/machinery/atmospherics/pipe/simple/cyan/visible,
+/obj/structure/grille,
 /turf/closed/wall/r_wall,
 /area/asteroid/nearstation)
 "wkG" = (
 /obj/structure/lattice/catwalk,
 /turf/open/floor/plating/airless,
 /area/space)
+"wqL" = (
+/obj/machinery/atmospherics/pipe/simple/yellow/visible{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/engine/atmos)
 "wvE" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
 	dir = 5
 	},
-/turf/open/floor/plasteel/neutral,
+/turf/open/floor/plasteel,
 /area/asteroid/nearstation)
 "wMZ" = (
 /obj/structure/grille,
@@ -35052,6 +35737,16 @@
 	},
 /turf/open/floor/plasteel,
 /area/science/xenobiology)
+"wWz" = (
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/visible{
+	dir = 4
+	},
+/obj/machinery/meter,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/vault{
+	dir = 5
+	},
+/area/engine/atmos)
 "xej" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/siphon/on{
 	dir = 2;
@@ -35065,7 +35760,8 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
 	dir = 4
 	},
-/turf/open/floor/plasteel/neutral,
+/obj/effect/landmark/event_spawn,
+/turf/open/floor/plasteel,
 /area/engine/atmos)
 "xrf" = (
 /obj/machinery/light{
@@ -35075,6 +35771,7 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/orange/visible,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/caution{
 	dir = 8
 	},
@@ -35086,7 +35783,7 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/turf/open/floor/plasteel/neutral,
+/turf/open/floor/plasteel,
 /area/engine/atmos)
 "xtL" = (
 /obj/machinery/embedded_controller/radio/airlock_controller{
@@ -35136,6 +35833,20 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/engine/break_room)
+"xyo" = (
+/obj/machinery/atmospherics/pipe/simple/cyan/visible,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/vault{
+	dir = 5
+	},
+/area/asteroid/nearstation)
+"xAj" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/visible,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/vault{
+	dir = 5
+	},
+/area/engine/atmos)
 "xCL" = (
 /obj/effect/spawner/structure/window/plasma/reinforced,
 /turf/open/floor/plating,
@@ -35146,6 +35857,7 @@
 	filter_type = "plasma";
 	on = 1
 	},
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/vault{
 	dir = 5
 	},
@@ -35157,6 +35869,7 @@
 "xIm" = (
 /obj/machinery/meter,
 /obj/machinery/atmospherics/pipe/simple/cyan/visible,
+/obj/structure/grille,
 /turf/closed/wall/r_wall,
 /area/engine/atmos)
 "xOf" = (
@@ -35191,7 +35904,8 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/turf/open/floor/plasteel/neutral,
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/plasteel,
 /area/engine/atmos)
 "yeE" = (
 /obj/machinery/door/window/brigdoor{
@@ -35225,10 +35939,23 @@
 	dir = 8
 	},
 /area/hallway/primary/port/aft)
+"yhg" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/asteroid/nearstation)
 "ymj" = (
 /obj/machinery/atmospherics/pipe/simple/green/visible{
 	dir = 4
 	},
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/vault{
 	dir = 5
 	},
@@ -61035,10 +61762,10 @@ pBT
 dWc
 pBT
 aac
-ulC
-ulC
-ulC
-ulC
+aac
+aac
+aac
+aac
 ulC
 ahu
 iye
@@ -61292,11 +62019,11 @@ dWc
 aad
 aac
 aac
-ulC
-ulC
-ulC
-ulC
-ulC
+aad
+aad
+aad
+aad
+aad
 ahu
 bpn
 eYe
@@ -61549,11 +62276,11 @@ aad
 aad
 aad
 aad
-ulC
-ulC
-ulC
-ulC
-ulC
+aad
+aad
+aad
+aad
+aad
 gdA
 rjV
 fsJ
@@ -62064,10 +62791,10 @@ ahu
 ahu
 ueG
 ttA
-ttA
-ttA
-ttA
-ttA
+chJ
+vJt
+fbH
+lvw
 xrf
 pvX
 gSv
@@ -62320,11 +63047,11 @@ aad
 ahu
 lAs
 qTa
-lAs
-lAs
-lAs
-lAs
-lAs
+oJp
+hUG
+yhg
+hUG
+hUG
 ueC
 qMr
 kiw
@@ -62577,10 +63304,10 @@ ckn
 ckn
 jpv
 msJ
-jpv
-jpv
-jpv
-jpv
+rjQ
+rjQ
+jtZ
+rjQ
 bGL
 vuN
 jkl
@@ -62834,15 +63561,15 @@ cAr
 otn
 uuJ
 tdN
-uuJ
-uuJ
-uuJ
-uuJ
+oql
+oql
+ixk
+oql
 kTz
 iKp
 tgp
-iHo
-lAs
+dgV
+fYx
 skz
 pEH
 pEH
@@ -63089,17 +63816,17 @@ mTM
 iZQ
 kTo
 gVX
-lAs
-qTa
+fKT
+kCU
 rzq
 wvE
-lAs
-lAs
+uVJ
+uIm
 mTv
 guM
 oCy
 orI
-jpv
+xyo
 hNO
 aad
 acF
@@ -63346,17 +64073,17 @@ hOh
 iqC
 xCL
 kHA
-lAs
+fKT
 mTT
-mTT
+tgm
 lBr
-lAs
-lAs
+hUL
+uIm
 rEx
 jCi
-ahu
-ahu
-ahu
+cAr
+cAr
+cAr
 gUJ
 aad
 aad
@@ -63605,9 +64332,9 @@ wMZ
 srh
 bZq
 vtI
-vtI
+juT
 vJk
-bZq
+nFG
 rae
 vpz
 nrv
@@ -63864,8 +64591,8 @@ toY
 fIN
 mIv
 lBr
-toY
-lAs
+cWq
+uIm
 iHo
 eva
 xCL
@@ -64118,10 +64845,10 @@ vVS
 kTo
 xEQ
 bKQ
-oiL
+fvd
 mae
 xeu
-bKQ
+wqL
 aAn
 iJY
 uSs
@@ -64375,16 +65102,16 @@ ddI
 xCL
 vmU
 bKQ
-oiL
+fvd
 mae
-xeu
-bKQ
+mkF
+wqL
 aAp
 yba
 vVA
-aqz
-aqz
-aqz
+anx
+anx
+anx
 uok
 aad
 aad
@@ -64618,7 +65345,7 @@ aaa
 aaa
 aaa
 ulC
-ulC
+aad
 aad
 aad
 aad
@@ -64634,8 +65361,8 @@ uoy
 asw
 fFw
 auq
-xeu
-bKQ
+hXn
+wqL
 iIj
 iJY
 dFV
@@ -64875,7 +65602,7 @@ aaa
 aaa
 ulC
 ulC
-ulC
+aad
 aad
 aad
 aad
@@ -64890,8 +65617,8 @@ anx
 awC
 bKQ
 fFw
-auq
-xeu
+fEt
+mnD
 asx
 aty
 eaf
@@ -65131,8 +65858,8 @@ aaa
 aaa
 aaa
 ulC
-ulC
-ulC
+aad
+aad
 aad
 aad
 abi
@@ -65148,8 +65875,8 @@ arr
 bKQ
 fFw
 auq
-xeu
-bKQ
+qEl
+wqL
 aAp
 yba
 avy
@@ -65386,10 +66113,10 @@ aad
 aad
 aac
 aaa
-ulC
-ulC
-ulC
-ulC
+aac
+aad
+aad
+aad
 abi
 aik
 aaW
@@ -65403,16 +66130,16 @@ fnp
 aqA
 viy
 bKQ
-oiL
+qIp
 mae
-xeu
-bKQ
+eOs
+wqL
 aAp
 yba
-vVA
-aqz
-aqz
-aqz
+fjs
+anx
+anx
+anx
 uok
 aEp
 aFs
@@ -65642,11 +66369,11 @@ aad
 aad
 aad
 aad
-ulC
-ulC
-ulC
-ulC
-ulC
+aad
+aac
+aad
+aad
+aad
 aad
 abj
 abj
@@ -65658,15 +66385,15 @@ dIu
 vMb
 ujg
 oaV
-uoy
+vuh
 asw
-oiL
+jxc
 mae
-xeu
-bKQ
+hqX
+wqL
 auv
 iJY
-dFV
+kwF
 aAh
 aBr
 asv
@@ -65899,11 +66626,11 @@ aac
 aad
 aah
 aad
-ulC
-ulC
-ulC
-ulC
-ulC
+aac
+aac
+aad
+aad
+aad
 aaW
 abj
 abu
@@ -65914,13 +66641,13 @@ aad
 dIu
 cAr
 cAr
-anx
-awC
-bKQ
-oiL
+pjU
+qFw
+asw
+jxc
 mae
-xeu
-asC
+hqX
+bpB
 qoT
 eaf
 eCg
@@ -66156,11 +66883,11 @@ aaa
 aac
 aac
 aad
-ulC
-ulC
-ulC
-ulC
-ulC
+aad
+aad
+aad
+aad
+aad
 abi
 abu
 abu
@@ -66176,9 +66903,9 @@ arv
 asC
 auw
 auq
-xeu
-oiL
-oiL
+hqX
+buw
+diG
 yba
 azl
 aAj
@@ -66413,11 +67140,11 @@ aaa
 aac
 aac
 aac
-ulC
-ulC
-ulC
-ulC
-ulC
+aac
+aad
+aad
+aad
+aad
 aad
 abu
 abj
@@ -66431,16 +67158,16 @@ apv
 aqA
 arw
 oiL
-oiL
+jxc
 mae
-xeu
-oiL
-oiL
+hqX
+diG
+diG
 yba
-xeu
-aqz
-aqz
-aqz
+idD
+anx
+anx
+anx
 uok
 aEt
 sHV
@@ -66670,11 +67397,11 @@ aaa
 aaa
 aac
 aac
-ulC
-ulC
-ulC
-ulC
-ulC
+aac
+aac
+aad
+aad
+aad
 aad
 adv
 abj
@@ -66688,15 +67415,15 @@ pcl
 aqE
 arx
 azm
-auw
-auq
-xeu
-oiL
+vmq
+fLr
+hqX
+diG
 axm
 cBS
-awJ
+wWz
 ayh
-axo
+xAj
 aCz
 uok
 aEu
@@ -66927,11 +67654,11 @@ aaa
 aaa
 abR
 aac
-ulC
-ulC
-ulC
-ulC
-ulC
+aac
+aad
+aad
+aad
+aad
 abi
 ael
 abj
@@ -66949,12 +67676,12 @@ tWQ
 uyJ
 avE
 awI
-oiL
+diG
 xsS
-oiL
-avE
-axo
-aCz
+aDl
+ver
+eZd
+kaA
 aDr
 aEv
 aFx
@@ -67184,11 +67911,11 @@ aaa
 aaa
 abR
 aac
-ulC
-ulC
-ulC
-ulC
-ulC
+aac
+aad
+aad
+aad
+aad
 abT
 abi
 aaV
@@ -67202,14 +67929,14 @@ cWv
 cWv
 arz
 asG
-asG
+iVy
 auA
-auw
+qui
 awJ
 axo
 ayi
-oiL
-aAn
+diG
+oGc
 awF
 aCA
 uok
@@ -67716,13 +68443,13 @@ aaV
 aqz
 aqz
 aqz
-sAx
+hsV
 auC
 aqz
 awL
 axq
 cBf
-oiL
+diG
 aAr
 aBy
 aCD

--- a/_maps/map_files/OmegaStation/OmegaStation.dmm
+++ b/_maps/map_files/OmegaStation/OmegaStation.dmm
@@ -3032,7 +3032,6 @@
 	},
 /obj/item/clothing/neck/stethoscope,
 /obj/item/stack/sheet/mineral/diamond,
-/obj/item/areaeditor/blueprints,
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
@@ -9033,9 +9032,6 @@
 /turf/open/floor/plasteel,
 /area/engine/atmos)
 "aru" = (
-/obj/machinery/atmospherics/pipe/simple/cyan/visible{
-	dir = 4
-	},
 /obj/machinery/status_display{
 	pixel_y = 32
 	},
@@ -9043,6 +9039,9 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/manifold/cyan/visible{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -9095,20 +9094,18 @@
 	},
 /area/engine/atmos)
 "arz" = (
-/obj/machinery/atmospherics/pipe/manifold/cyan/visible{
-	dir = 1
-	},
 /obj/effect/turf_decal/delivery,
+/obj/machinery/atmospherics/pipe/simple/cyan/visible{
+	dir = 10
+	},
 /turf/open/floor/plasteel,
 /area/engine/atmos)
 "arA" = (
-/obj/machinery/atmospherics/components/unary/thermomachine/heater{
-	dir = 8
-	},
 /obj/structure/sign/warning/nosmoking{
 	pixel_x = 32
 	},
 /obj/effect/turf_decal/bot,
+/obj/machinery/suit_storage_unit/atmos,
 /turf/open/floor/plasteel,
 /area/engine/atmos)
 "arB" = (
@@ -9618,6 +9615,9 @@
 	},
 /area/engine/atmos)
 "asB" = (
+/obj/machinery/atmospherics/components/unary/thermomachine/heater{
+	dir = 1
+	},
 /turf/open/floor/plasteel/neutral,
 /area/engine/atmos)
 "asC" = (
@@ -12166,14 +12166,12 @@
 	},
 /area/hallway/primary/central)
 "axD" = (
-/obj/structure/table,
-/obj/item/paper_bin,
-/obj/item/pen,
 /obj/item/device/radio/intercom{
 	name = "Station Intercom";
 	pixel_x = -26
 	},
 /obj/effect/turf_decal/bot,
+/obj/machinery/computer/arcade,
 /turf/open/floor/plasteel/vault{
 	dir = 5
 	},
@@ -14318,6 +14316,7 @@
 	pixel_y = -28
 	},
 /obj/effect/turf_decal/bot,
+/obj/item/pipe_dispenser,
 /turf/open/floor/plasteel/vault/side{
 	dir = 1
 	},
@@ -14328,6 +14327,7 @@
 	},
 /obj/structure/closet/secure_closet/atmospherics,
 /obj/effect/turf_decal/bot,
+/obj/item/pipe_dispenser,
 /turf/open/floor/plasteel/vault/side{
 	dir = 1
 	},
@@ -14522,6 +14522,8 @@
 "aCN" = (
 /obj/structure/table,
 /obj/item/storage/firstaid/regular,
+/obj/item/device/multitool,
+/obj/item/device/multitool,
 /turf/open/floor/plasteel/neutral,
 /area/crew_quarters/dorms)
 "aCO" = (
@@ -15068,10 +15070,10 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "aEb" = (
-/obj/item/twohanded/required/kirbyplants{
-	icon_state = "plant-22"
-	},
 /obj/effect/turf_decal/bot,
+/obj/machinery/computer/arcade{
+	dir = 4
+	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit)
 "aEc" = (
@@ -15204,13 +15206,13 @@
 /area/engine/engineering)
 "aEx" = (
 /obj/structure/closet/radiation,
-/obj/item/clothing/glasses/meson,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 6
 	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 9
 	},
+/obj/item/clothing/glasses/meson/engine,
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "aEy" = (
@@ -15670,6 +15672,7 @@
 	pixel_x = 26
 	},
 /obj/effect/turf_decal/bot,
+/obj/item/areaeditor/blueprints,
 /turf/open/floor/plasteel/vault/side{
 	dir = 8
 	},
@@ -15736,11 +15739,11 @@
 /obj/structure/extinguisher_cabinet{
 	pixel_x = -26
 	},
-/obj/item/clothing/glasses/meson,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/effect/turf_decal/stripes/line{
 	dir = 10
 	},
+/obj/item/clothing/glasses/meson/engine,
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "aFA" = (
@@ -17236,11 +17239,9 @@
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "aIv" = (
-/obj/structure/table/reinforced,
-/obj/item/paper_bin,
-/obj/item/pen,
 /obj/effect/turf_decal/bot,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/machinery/vending/engivend,
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "aIw" = (
@@ -18346,6 +18347,7 @@
 /obj/structure/cable/white{
 	icon_state = "4-8"
 	},
+/obj/item/device/lightreplacer,
 /turf/open/floor/plasteel/yellow/side{
 	dir = 8
 	},
@@ -18369,6 +18371,8 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 5
 	},
+/obj/item/clothing/gloves/color/yellow,
+/obj/item/clothing/gloves/color/yellow,
 /turf/open/floor/plasteel/yellow,
 /area/engine/engineering)
 "aKL" = (
@@ -18393,7 +18397,6 @@
 /area/engine/engineering)
 "aKM" = (
 /obj/structure/table/reinforced,
-/obj/item/folder/yellow,
 /obj/item/device/lightreplacer,
 /obj/structure/cable/white{
 	icon_state = "1-8"
@@ -18770,7 +18773,6 @@
 /area/engine/gravity_generator)
 "aLK" = (
 /obj/structure/closet/radiation,
-/obj/item/clothing/glasses/meson,
 /obj/machinery/airalarm{
 	dir = 1;
 	pixel_y = -22
@@ -18782,6 +18784,7 @@
 /obj/structure/cable{
 	icon_state = "1-8"
 	},
+/obj/item/clothing/glasses/meson/engine,
 /turf/open/floor/plasteel,
 /area/engine/gravity_generator)
 "aLL" = (
@@ -22052,9 +22055,9 @@
 /obj/structure/table/reinforced,
 /obj/item/clothing/suit/radiation,
 /obj/item/clothing/head/radiation,
-/obj/item/clothing/glasses/meson,
 /obj/effect/turf_decal/bot,
 /obj/effect/turf_decal/stripes/line,
+/obj/item/clothing/glasses/meson/engine,
 /turf/open/floor/engine,
 /area/engine/engineering)
 "aTa" = (
@@ -22723,6 +22726,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
+/obj/item/device/multitool,
 /turf/open/floor/plasteel/vault/side,
 /area/science/lab)
 "aUF" = (
@@ -23108,14 +23112,13 @@
 /area/science/lab)
 "aVx" = (
 /obj/structure/table/reinforced,
-/obj/item/folder/white,
-/obj/item/stock_parts/cell/high,
-/obj/item/stack/sheet/glass,
-/obj/item/stack/sheet/glass,
-/obj/item/stack/sheet/glass,
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
+/obj/item/device/integrated_circuit_printer,
+/obj/item/device/integrated_electronics/analyzer,
+/obj/item/device/integrated_electronics/debugger,
+/obj/item/device/integrated_electronics/wirer,
 /turf/open/floor/plasteel/vault/side,
 /area/science/lab)
 "aVy" = (
@@ -23522,6 +23525,8 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 10
 	},
+/obj/item/stock_parts/cell/high,
+/obj/item/stock_parts/cell/high,
 /turf/open/floor/plasteel/vault/side,
 /area/science/lab)
 "aWp" = (
@@ -24271,6 +24276,10 @@
 	},
 /obj/item/storage/backpack/satchel/med,
 /obj/effect/turf_decal/bot,
+/obj/item/storage/belt/medical,
+/obj/item/storage/belt/medical,
+/obj/item/clothing/neck/stethoscope,
+/obj/item/clothing/neck/stethoscope,
 /turf/open/floor/plasteel,
 /area/medical/medbay/zone3)
 "aXQ" = (
@@ -31235,7 +31244,7 @@
 /area/tcommsat/server)
 "buO" = (
 /obj/machinery/telecomms/receiver/preset_left/birdstation,
-/obj/machinery/airalarm{
+/obj/machinery/airalarm/server{
 	dir = 4;
 	pixel_x = -23
 	},
@@ -31832,6 +31841,12 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
+"dEa" = (
+/obj/machinery/computer/arcade,
+/turf/open/floor/plasteel/vault{
+	dir = 8
+	},
+/area/maintenance/port)
 "fWz" = (
 /obj/machinery/door/airlock/external{
 	name = "External Docking Port";
@@ -33605,7 +33620,7 @@
 /area/ai_monitored/turret_protected/aisat_interior)
 "sMP" = (
 /obj/machinery/power/smes{
-	charge = 5e+006
+	charge = 1e+006
 	},
 /obj/structure/cable/white{
 	icon_state = "0-8"
@@ -66972,7 +66987,7 @@ aZp
 bak
 bbc
 bbQ
-bcF
+dEa
 bdD
 beu
 sKE

--- a/_maps/map_files/OmegaStation/OmegaStation.dmm
+++ b/_maps/map_files/OmegaStation/OmegaStation.dmm
@@ -749,7 +749,7 @@
 /area/crew_quarters/heads/hop)
 "abt" = (
 /turf/closed/wall,
-/area/hallway/primary/central)
+/area/hallway/primary/starboard/fore)
 "abu" = (
 /turf/open/floor/plating/astplate,
 /area/asteroid/nearstation)
@@ -1251,7 +1251,7 @@
 	},
 /obj/effect/turf_decal/delivery,
 /turf/open/floor/plasteel,
-/area/hallway/primary/central)
+/area/hallway/primary/starboard/fore)
 "acw" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
 	dir = 1
@@ -4007,22 +4007,22 @@
 /area/bridge)
 "ahY" = (
 /turf/closed/wall/r_wall,
-/area/hallway/primary/central)
+/area/hallway/primary/starboard/fore)
 "ahZ" = (
 /obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel,
-/area/hallway/primary/central)
+/area/hallway/primary/starboard/fore)
 "aia" = (
 /obj/machinery/light{
 	dir = 1
 	},
 /obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel,
-/area/hallway/primary/central)
+/area/hallway/primary/starboard/fore)
 "aib" = (
 /obj/effect/turf_decal/delivery,
 /turf/open/floor/plasteel,
-/area/hallway/primary/central)
+/area/hallway/primary/starboard/fore)
 "aic" = (
 /obj/structure/table,
 /obj/item/paper_bin,
@@ -4033,7 +4033,7 @@
 /turf/open/floor/plasteel/vault{
 	dir = 8
 	},
-/area/hallway/primary/central)
+/area/hallway/primary/starboard/fore)
 "aid" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/mining{
@@ -4334,14 +4334,14 @@
 	dir = 1
 	},
 /turf/open/floor/plasteel,
-/area/hallway/primary/central)
+/area/hallway/primary/starboard/fore)
 "aiE" = (
 /obj/structure/cable/white{
 	icon_state = "0-2"
 	},
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
-/area/hallway/primary/central)
+/area/hallway/primary/starboard/fore)
 "aiF" = (
 /obj/machinery/door/poddoor/shutters/preopen{
 	id = "hopline";
@@ -4349,11 +4349,11 @@
 	},
 /obj/effect/turf_decal/loading_area,
 /turf/open/floor/plasteel,
-/area/hallway/primary/central)
+/area/hallway/primary/starboard/fore)
 "aiG" = (
 /obj/structure/sign/warning/electricshock,
 /turf/closed/wall,
-/area/hallway/primary/central)
+/area/hallway/primary/starboard/fore)
 "aiH" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/machinery/door/airlock/maintenance_hatch{
@@ -4589,7 +4589,7 @@
 /turf/open/floor/plasteel/red/corner{
 	dir = 1
 	},
-/area/hallway/primary/central)
+/area/hallway/primary/port/fore)
 "aje" = (
 /obj/structure/cable/white{
 	icon_state = "1-2"
@@ -4601,13 +4601,13 @@
 /turf/open/floor/plasteel/red/corner{
 	dir = 1
 	},
-/area/hallway/primary/central)
+/area/hallway/primary/port/fore)
 "ajf" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden,
 /turf/open/floor/plasteel/red/corner{
 	dir = 1
 	},
-/area/hallway/primary/central)
+/area/hallway/primary/port/fore)
 "ajg" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
@@ -4616,7 +4616,7 @@
 /turf/open/floor/plasteel/red/corner{
 	dir = 1
 	},
-/area/hallway/primary/central)
+/area/hallway/primary/port/fore)
 "ajh" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
@@ -4624,7 +4624,7 @@
 /turf/open/floor/plasteel/neutral/corner{
 	dir = 1
 	},
-/area/hallway/primary/central)
+/area/hallway/primary/port/fore)
 "aji" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 1
@@ -4632,7 +4632,7 @@
 /turf/open/floor/plasteel/neutral/corner{
 	dir = 1
 	},
-/area/hallway/primary/central)
+/area/hallway/primary/port/fore)
 "ajj" = (
 /obj/structure/cable/white{
 	icon_state = "1-2"
@@ -4644,7 +4644,7 @@
 /turf/open/floor/plasteel/neutral/corner{
 	dir = 1
 	},
-/area/hallway/primary/central)
+/area/hallway/primary/port/fore)
 "ajk" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
@@ -4656,7 +4656,7 @@
 /turf/open/floor/plasteel/neutral/corner{
 	dir = 1
 	},
-/area/hallway/primary/central)
+/area/hallway/primary/port/fore)
 "ajl" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
@@ -4668,7 +4668,7 @@
 /turf/open/floor/plasteel/neutral/corner{
 	dir = 1
 	},
-/area/hallway/primary/central)
+/area/hallway/primary/port/fore)
 "ajm" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
@@ -4682,7 +4682,7 @@
 /turf/open/floor/plasteel/neutral/corner{
 	dir = 1
 	},
-/area/hallway/primary/central)
+/area/hallway/primary/port/fore)
 "ajn" = (
 /obj/structure/sign/nanotrasen{
 	pixel_y = 32
@@ -4698,7 +4698,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel,
-/area/hallway/primary/central)
+/area/hallway/primary/port/fore)
 "ajo" = (
 /obj/structure/cable/white{
 	icon_state = "1-2"
@@ -4710,13 +4710,13 @@
 /turf/open/floor/plasteel/blue/corner{
 	dir = 1
 	},
-/area/hallway/primary/central)
+/area/hallway/primary/fore)
 "ajp" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden,
 /turf/open/floor/plasteel/blue/corner{
 	dir = 1
 	},
-/area/hallway/primary/central)
+/area/hallway/primary/fore)
 "ajq" = (
 /obj/structure/sign/warning/securearea{
 	pixel_y = 32
@@ -4727,7 +4727,7 @@
 /turf/open/floor/plasteel/neutral/corner{
 	dir = 1
 	},
-/area/hallway/primary/central)
+/area/hallway/primary/fore)
 "ajr" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
@@ -4738,7 +4738,7 @@
 /turf/open/floor/plasteel/neutral/corner{
 	dir = 1
 	},
-/area/hallway/primary/central)
+/area/hallway/primary/fore)
 "ajs" = (
 /obj/machinery/atmospherics/pipe/manifold4w/scrubbers/hidden,
 /obj/machinery/camera{
@@ -4749,7 +4749,7 @@
 	dir = 8
 	},
 /turf/open/floor/plasteel,
-/area/hallway/primary/central)
+/area/hallway/primary/fore)
 "ajt" = (
 /obj/structure/cable/white{
 	icon_state = "1-2"
@@ -4761,7 +4761,7 @@
 	dir = 1
 	},
 /turf/open/floor/plasteel,
-/area/hallway/primary/central)
+/area/hallway/primary/fore)
 "aju" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
@@ -4771,7 +4771,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel,
-/area/hallway/primary/central)
+/area/hallway/primary/fore)
 "ajv" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
@@ -4783,7 +4783,7 @@
 /turf/open/floor/plasteel/neutral/corner{
 	dir = 4
 	},
-/area/hallway/primary/central)
+/area/hallway/primary/fore)
 "ajw" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
@@ -4795,7 +4795,7 @@
 /turf/open/floor/plasteel/neutral/corner{
 	dir = 4
 	},
-/area/hallway/primary/central)
+/area/hallway/primary/fore)
 "ajx" = (
 /obj/structure/sign/warning/securearea{
 	pixel_y = 32
@@ -4809,7 +4809,7 @@
 /turf/open/floor/plasteel/neutral/corner{
 	dir = 4
 	},
-/area/hallway/primary/central)
+/area/hallway/primary/fore)
 "ajy" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
@@ -4818,7 +4818,7 @@
 /turf/open/floor/plasteel/blue/corner{
 	dir = 4
 	},
-/area/hallway/primary/central)
+/area/hallway/primary/fore)
 "ajz" = (
 /obj/structure/cable/white{
 	icon_state = "1-2"
@@ -4827,7 +4827,7 @@
 /turf/open/floor/plasteel/blue/corner{
 	dir = 4
 	},
-/area/hallway/primary/central)
+/area/hallway/primary/fore)
 "ajA" = (
 /obj/structure/sign/directions/engineering{
 	desc = "A sign that shows there are doors here. There are doors everywhere!";
@@ -4846,7 +4846,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel,
-/area/hallway/primary/central)
+/area/hallway/primary/starboard/fore)
 "ajB" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
@@ -4854,7 +4854,7 @@
 /turf/open/floor/plasteel/blue/corner{
 	dir = 4
 	},
-/area/hallway/primary/central)
+/area/hallway/primary/starboard/fore)
 "ajC" = (
 /obj/structure/cable/white{
 	icon_state = "1-2"
@@ -4865,7 +4865,7 @@
 /turf/open/floor/plasteel/blue/corner{
 	dir = 4
 	},
-/area/hallway/primary/central)
+/area/hallway/primary/starboard/fore)
 "ajD" = (
 /obj/structure/cable/white{
 	icon_state = "1-2"
@@ -4876,7 +4876,7 @@
 /turf/open/floor/plasteel/blue/corner{
 	dir = 4
 	},
-/area/hallway/primary/central)
+/area/hallway/primary/starboard/fore)
 "ajE" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
@@ -4884,7 +4884,7 @@
 /turf/open/floor/plasteel/neutral/corner{
 	dir = 4
 	},
-/area/hallway/primary/central)
+/area/hallway/primary/starboard/fore)
 "ajF" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 10
@@ -4899,7 +4899,7 @@
 /turf/open/floor/plasteel/neutral/corner{
 	dir = 4
 	},
-/area/hallway/primary/central)
+/area/hallway/primary/starboard/fore)
 "ajH" = (
 /obj/structure/plasticflaps{
 	opacity = 1
@@ -5121,7 +5121,7 @@
 /turf/open/floor/plasteel/red/corner{
 	dir = 1
 	},
-/area/hallway/primary/central)
+/area/hallway/primary/port/fore)
 "akd" = (
 /obj/structure/cable/white{
 	icon_state = "1-2"
@@ -5133,7 +5133,7 @@
 	dir = 8
 	},
 /turf/open/floor/plasteel/neutral/corner,
-/area/hallway/primary/central)
+/area/hallway/primary/port/fore)
 "ake" = (
 /obj/structure/cable/white{
 	icon_state = "4-8"
@@ -5145,7 +5145,7 @@
 	dir = 8;
 	heat_capacity = 1e+006
 	},
-/area/hallway/primary/central)
+/area/hallway/primary/port/fore)
 "akf" = (
 /obj/structure/cable/white{
 	icon_state = "4-8"
@@ -5156,7 +5156,7 @@
 	dir = 8;
 	heat_capacity = 1e+006
 	},
-/area/hallway/primary/central)
+/area/hallway/primary/port/fore)
 "akg" = (
 /obj/structure/cable/white{
 	icon_state = "4-8"
@@ -5168,7 +5168,7 @@
 	dir = 8;
 	heat_capacity = 1e+006
 	},
-/area/hallway/primary/central)
+/area/hallway/primary/port/fore)
 "akh" = (
 /obj/structure/cable/white{
 	icon_state = "4-8"
@@ -5181,7 +5181,7 @@
 	dir = 8;
 	heat_capacity = 1e+006
 	},
-/area/hallway/primary/central)
+/area/hallway/primary/port/fore)
 "aki" = (
 /obj/structure/cable/white{
 	icon_state = "1-8"
@@ -5194,7 +5194,7 @@
 	dir = 8;
 	heat_capacity = 1e+006
 	},
-/area/hallway/primary/central)
+/area/hallway/primary/port/fore)
 "akj" = (
 /obj/structure/cable/white{
 	icon_state = "4-8"
@@ -5210,7 +5210,7 @@
 	dir = 8;
 	heat_capacity = 1e+006
 	},
-/area/hallway/primary/central)
+/area/hallway/primary/port/fore)
 "akk" = (
 /obj/structure/sign/warning/electricshock{
 	pixel_y = -32
@@ -5225,7 +5225,7 @@
 	dir = 8;
 	heat_capacity = 1e+006
 	},
-/area/hallway/primary/central)
+/area/hallway/primary/port/fore)
 "akl" = (
 /obj/structure/cable/white{
 	icon_state = "4-8"
@@ -5238,7 +5238,7 @@
 	},
 /obj/effect/turf_decal/stripes/corner,
 /turf/open/floor/plasteel,
-/area/hallway/primary/central)
+/area/hallway/primary/port/fore)
 "akm" = (
 /obj/structure/cable/white{
 	icon_state = "4-8"
@@ -5249,7 +5249,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plasteel,
-/area/hallway/primary/central)
+/area/hallway/primary/port/fore)
 "akn" = (
 /obj/structure/cable/white{
 	icon_state = "4-8"
@@ -5262,7 +5262,7 @@
 	},
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plasteel,
-/area/hallway/primary/central)
+/area/hallway/primary/port/fore)
 "ako" = (
 /obj/structure/cable/white{
 	icon_state = "4-8"
@@ -5279,7 +5279,7 @@
 	location = "2.1-Teleporter"
 	},
 /turf/open/floor/plasteel,
-/area/hallway/primary/central)
+/area/hallway/primary/port/fore)
 "akp" = (
 /obj/structure/cable/white{
 	icon_state = "4-8"
@@ -5294,7 +5294,7 @@
 	dir = 1
 	},
 /turf/open/floor/plasteel,
-/area/hallway/primary/central)
+/area/hallway/primary/port/fore)
 "akq" = (
 /obj/structure/cable/white{
 	icon_state = "4-8"
@@ -5310,7 +5310,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel,
-/area/hallway/primary/central)
+/area/hallway/primary/port/fore)
 "akr" = (
 /obj/structure/cable/white{
 	icon_state = "2-8"
@@ -5329,7 +5329,7 @@
 	dir = 8;
 	heat_capacity = 1e+006
 	},
-/area/hallway/primary/central)
+/area/hallway/primary/fore)
 "aks" = (
 /obj/structure/cable/white{
 	icon_state = "2-8"
@@ -5344,7 +5344,7 @@
 	dir = 8;
 	heat_capacity = 1e+006
 	},
-/area/hallway/primary/central)
+/area/hallway/primary/fore)
 "akt" = (
 /obj/structure/cable/white{
 	icon_state = "4-8"
@@ -5359,7 +5359,7 @@
 	icon_state = "L1"
 	},
 /turf/open/floor/plasteel,
-/area/hallway/primary/central)
+/area/hallway/primary/fore)
 "aku" = (
 /obj/structure/cable/white{
 	icon_state = "4-8"
@@ -5372,7 +5372,7 @@
 	icon_state = "L3"
 	},
 /turf/open/floor/plasteel,
-/area/hallway/primary/central)
+/area/hallway/primary/fore)
 "akv" = (
 /obj/structure/cable/white{
 	icon_state = "4-8"
@@ -5388,7 +5388,7 @@
 	icon_state = "L5"
 	},
 /turf/open/floor/plasteel,
-/area/hallway/primary/central)
+/area/hallway/primary/fore)
 "akw" = (
 /obj/structure/cable/white{
 	icon_state = "4-8"
@@ -5406,7 +5406,7 @@
 	icon_state = "L7"
 	},
 /turf/open/floor/plasteel,
-/area/hallway/primary/central)
+/area/hallway/primary/fore)
 "akx" = (
 /obj/structure/cable/white{
 	icon_state = "4-8"
@@ -5416,7 +5416,7 @@
 	icon_state = "L9"
 	},
 /turf/open/floor/plasteel,
-/area/hallway/primary/central)
+/area/hallway/primary/fore)
 "aky" = (
 /obj/structure/cable/white{
 	icon_state = "4-8"
@@ -5428,7 +5428,7 @@
 	icon_state = "L11"
 	},
 /turf/open/floor/plasteel,
-/area/hallway/primary/central)
+/area/hallway/primary/fore)
 "akz" = (
 /obj/structure/cable/white{
 	icon_state = "4-8"
@@ -5443,7 +5443,7 @@
 	icon_state = "L13"
 	},
 /turf/open/floor/plasteel,
-/area/hallway/primary/central)
+/area/hallway/primary/fore)
 "akA" = (
 /obj/structure/cable/white{
 	icon_state = "4-8"
@@ -5456,7 +5456,7 @@
 	location = "4.1-BridgeEast"
 	},
 /turf/open/floor/plasteel/neutral/corner,
-/area/hallway/primary/central)
+/area/hallway/primary/fore)
 "akB" = (
 /obj/structure/cable/white{
 	icon_state = "2-8"
@@ -5466,7 +5466,7 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden,
 /turf/open/floor/plasteel/neutral/corner,
-/area/hallway/primary/central)
+/area/hallway/primary/fore)
 "akC" = (
 /obj/structure/cable/white{
 	icon_state = "2-8"
@@ -5484,7 +5484,7 @@
 	icon_state = "1-4"
 	},
 /turf/open/floor/plasteel/neutral/corner,
-/area/hallway/primary/central)
+/area/hallway/primary/fore)
 "akD" = (
 /obj/structure/cable/white{
 	icon_state = "2-8"
@@ -5497,7 +5497,7 @@
 	},
 /obj/effect/turf_decal/stripes/corner,
 /turf/open/floor/plasteel,
-/area/hallway/primary/central)
+/area/hallway/primary/starboard/fore)
 "akE" = (
 /obj/structure/cable/white{
 	icon_state = "2-8"
@@ -5513,7 +5513,7 @@
 	},
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plasteel,
-/area/hallway/primary/central)
+/area/hallway/primary/starboard/fore)
 "akF" = (
 /obj/structure/cable/white{
 	icon_state = "2-8"
@@ -5529,7 +5529,7 @@
 	},
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plasteel,
-/area/hallway/primary/central)
+/area/hallway/primary/starboard/fore)
 "akG" = (
 /obj/structure/cable/white{
 	icon_state = "4-8"
@@ -5543,7 +5543,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plasteel,
-/area/hallway/primary/central)
+/area/hallway/primary/starboard/fore)
 "akH" = (
 /obj/structure/cable/white{
 	icon_state = "2-8"
@@ -5558,7 +5558,7 @@
 	dir = 1
 	},
 /turf/open/floor/plasteel,
-/area/hallway/primary/central)
+/area/hallway/primary/starboard/fore)
 "akI" = (
 /obj/structure/sign/warning/electricshock{
 	pixel_y = -32
@@ -5575,7 +5575,7 @@
 	name = "Billy Herrington memorial navigation beacon"
 	},
 /turf/open/floor/plasteel/neutral/corner,
-/area/hallway/primary/central)
+/area/hallway/primary/starboard/fore)
 "akJ" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -5588,7 +5588,7 @@
 	dir = 8;
 	heat_capacity = 1e+006
 	},
-/area/hallway/primary/central)
+/area/hallway/primary/starboard/fore)
 "akK" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
 	dir = 4
@@ -5601,7 +5601,7 @@
 	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel,
-/area/hallway/primary/central)
+/area/hallway/primary/starboard/fore)
 "akL" = (
 /obj/structure/closet/wardrobe/cargotech,
 /turf/open/floor/plasteel/brown{
@@ -5742,7 +5742,7 @@
 /turf/open/floor/plasteel/red/corner{
 	dir = 1
 	},
-/area/hallway/primary/central)
+/area/hallway/primary/port/fore)
 "alc" = (
 /obj/structure/cable/white{
 	icon_state = "1-2"
@@ -5751,11 +5751,11 @@
 /turf/open/floor/plasteel/neutral/corner{
 	dir = 4
 	},
-/area/hallway/primary/central)
+/area/hallway/primary/port/fore)
 "ald" = (
 /obj/structure/sign/nanotrasen,
 /turf/closed/wall,
-/area/hallway/primary/central)
+/area/crew_quarters/toilet/restrooms)
 "ale" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock{
@@ -5769,11 +5769,11 @@
 	dir = 1
 	},
 /turf/open/floor/plasteel/freezer,
-/area/hallway/primary/central)
+/area/crew_quarters/toilet/restrooms)
 "alf" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/closed/wall,
-/area/hallway/primary/central)
+/area/crew_quarters/toilet/restrooms)
 "alg" = (
 /turf/closed/wall/r_wall,
 /area/teleporter)
@@ -5818,7 +5818,7 @@
 /obj/structure/cable/white,
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
-/area/hallway/primary/central)
+/area/hallway/primary/fore)
 "all" = (
 /obj/structure/sign/directions/engineering{
 	dir = 8;
@@ -5846,7 +5846,7 @@
 	icon_state = "L2"
 	},
 /turf/open/floor/plasteel,
-/area/hallway/primary/central)
+/area/hallway/primary/fore)
 "aln" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 1
@@ -5855,7 +5855,7 @@
 	icon_state = "L4"
 	},
 /turf/open/floor/plasteel,
-/area/hallway/primary/central)
+/area/hallway/primary/fore)
 "alo" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/structure/cable/white{
@@ -5865,20 +5865,20 @@
 	icon_state = "L6"
 	},
 /turf/open/floor/plasteel,
-/area/hallway/primary/central)
+/area/hallway/primary/fore)
 "alp" = (
 /obj/effect/turf_decal/plaque{
 	icon_state = "L8"
 	},
 /turf/open/floor/plasteel,
-/area/hallway/primary/central)
+/area/hallway/primary/fore)
 "alq" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/effect/turf_decal/plaque{
 	icon_state = "L10"
 	},
 /turf/open/floor/plasteel,
-/area/hallway/primary/central)
+/area/hallway/primary/fore)
 "alr" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 1
@@ -5887,7 +5887,7 @@
 	icon_state = "L12"
 	},
 /turf/open/floor/plasteel,
-/area/hallway/primary/central)
+/area/hallway/primary/fore)
 "als" = (
 /obj/item/twohanded/required/kirbyplants{
 	icon_state = "plant-22"
@@ -5902,7 +5902,7 @@
 	icon_state = "L14"
 	},
 /turf/open/floor/plasteel,
-/area/hallway/primary/central)
+/area/hallway/primary/fore)
 "alt" = (
 /obj/structure/sign/directions/engineering{
 	desc = "A direction sign, pointing out which way the Supply department is.";
@@ -5921,7 +5921,7 @@
 	pixel_y = -8
 	},
 /turf/closed/wall,
-/area/hallway/primary/central)
+/area/hallway/primary/fore)
 "alu" = (
 /turf/closed/wall/r_wall,
 /area/ai_monitored/storage/eva)
@@ -5967,7 +5967,7 @@
 /turf/open/floor/plasteel/neutral/corner{
 	dir = 1
 	},
-/area/hallway/primary/central)
+/area/hallway/primary/starboard)
 "alz" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/structure/cable/white{
@@ -5976,7 +5976,7 @@
 /turf/open/floor/plasteel/brown/corner{
 	dir = 4
 	},
-/area/hallway/primary/central)
+/area/hallway/primary/starboard/fore)
 "alA" = (
 /obj/structure/table/reinforced,
 /obj/structure/noticeboard{
@@ -6185,7 +6185,7 @@
 /turf/open/floor/plasteel/red/corner{
 	dir = 1
 	},
-/area/hallway/primary/central)
+/area/hallway/primary/port/fore)
 "alS" = (
 /obj/structure/cable/white{
 	icon_state = "1-2"
@@ -6200,7 +6200,7 @@
 /turf/open/floor/plasteel/neutral/corner{
 	dir = 4
 	},
-/area/hallway/primary/central)
+/area/hallway/primary/port/fore)
 "alT" = (
 /obj/structure/table,
 /obj/item/storage/firstaid/regular,
@@ -6212,12 +6212,12 @@
 	},
 /obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel/freezer,
-/area/hallway/primary/central)
+/area/crew_quarters/toilet/restrooms)
 "alU" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/effect/turf_decal/delivery,
 /turf/open/floor/plasteel/freezer,
-/area/hallway/primary/central)
+/area/crew_quarters/toilet/restrooms)
 "alV" = (
 /obj/structure/urinal{
 	pixel_y = 28
@@ -6227,20 +6227,20 @@
 	},
 /obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel/freezer,
-/area/hallway/primary/central)
+/area/crew_quarters/toilet/restrooms)
 "alW" = (
 /obj/structure/urinal{
 	pixel_y = 28
 	},
 /turf/open/floor/plasteel/freezer,
-/area/hallway/primary/central)
+/area/crew_quarters/toilet/restrooms)
 "alX" = (
 /obj/structure/closet/crate/bin,
 /obj/machinery/light_switch{
 	pixel_y = 24
 	},
 /turf/open/floor/plasteel/freezer,
-/area/hallway/primary/central)
+/area/crew_quarters/toilet/restrooms)
 "alY" = (
 /obj/machinery/shieldwallgen,
 /obj/machinery/button/door{
@@ -6308,7 +6308,7 @@
 	},
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
-/area/hallway/primary/central)
+/area/hallway/primary/fore)
 "amf" = (
 /obj/structure/closet/crate/bin,
 /obj/structure/cable/white{
@@ -6321,7 +6321,7 @@
 /turf/open/floor/plasteel/vault/side{
 	dir = 5
 	},
-/area/hallway/primary/central)
+/area/hallway/primary/fore)
 "amg" = (
 /turf/open/floor/plasteel/neutral/corner{
 	dir = 8;
@@ -6335,7 +6335,7 @@
 	},
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/plasteel/neutral,
-/area/hallway/primary/central)
+/area/hallway/primary/fore)
 "ami" = (
 /obj/machinery/holopad,
 /obj/effect/turf_decal/bot,
@@ -6344,7 +6344,7 @@
 "amj" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plasteel/neutral,
-/area/hallway/primary/central)
+/area/hallway/primary/fore)
 "amk" = (
 /turf/open/floor/plasteel/neutral/corner,
 /area/hallway/primary/central)
@@ -6360,14 +6360,14 @@
 /turf/open/floor/plasteel/vault/side{
 	dir = 9
 	},
-/area/hallway/primary/central)
+/area/hallway/primary/fore)
 "amm" = (
 /obj/structure/cable/white{
 	icon_state = "0-8"
 	},
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
-/area/hallway/primary/central)
+/area/hallway/primary/fore)
 "amn" = (
 /obj/structure/cable/white{
 	icon_state = "0-4"
@@ -6446,7 +6446,7 @@
 /turf/open/floor/plasteel/neutral/corner{
 	dir = 1
 	},
-/area/hallway/primary/central)
+/area/hallway/primary/starboard/fore)
 "amu" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
 	dir = 4
@@ -6457,7 +6457,7 @@
 /turf/open/floor/plasteel/brown/corner{
 	dir = 4
 	},
-/area/hallway/primary/central)
+/area/hallway/primary/starboard/fore)
 "amv" = (
 /obj/machinery/computer/stockexchange,
 /obj/structure/table/reinforced,
@@ -6632,7 +6632,7 @@
 	},
 /obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel/freezer,
-/area/hallway/primary/central)
+/area/crew_quarters/toilet/restrooms)
 "amP" = (
 /obj/machinery/firealarm{
 	dir = 1;
@@ -6643,10 +6643,10 @@
 	dir = 1
 	},
 /turf/open/floor/plasteel/freezer,
-/area/hallway/primary/central)
+/area/crew_quarters/toilet/restrooms)
 "amQ" = (
 /turf/open/floor/plasteel/freezer,
-/area/hallway/primary/central)
+/area/crew_quarters/toilet/restrooms)
 "amR" = (
 /obj/machinery/airalarm{
 	dir = 1;
@@ -6654,14 +6654,14 @@
 	},
 /obj/machinery/light/small,
 /turf/open/floor/plasteel/freezer,
-/area/hallway/primary/central)
+/area/crew_quarters/toilet/restrooms)
 "amS" = (
 /obj/machinery/camera{
 	c_tag = "Locker Room Toilets";
 	dir = 8
 	},
 /turf/open/floor/plasteel/freezer,
-/area/hallway/primary/central)
+/area/crew_quarters/toilet/restrooms)
 "amT" = (
 /obj/structure/table/reinforced,
 /obj/item/stack/cable_coil/white,
@@ -6721,7 +6721,7 @@
 /turf/open/floor/plasteel/vault/side{
 	dir = 4
 	},
-/area/hallway/primary/central)
+/area/hallway/primary/fore)
 "ana" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/structure/cable/white{
@@ -6731,14 +6731,14 @@
 	dir = 8;
 	heat_capacity = 1e+006
 	},
-/area/hallway/primary/central)
+/area/hallway/primary/fore)
 "anb" = (
 /turf/open/floor/plasteel/neutral/side,
-/area/hallway/primary/central)
+/area/hallway/primary/fore)
 "anc" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plasteel/neutral/corner,
-/area/hallway/primary/central)
+/area/hallway/primary/fore)
 "and" = (
 /obj/structure/closet/firecloset,
 /obj/structure/sign/nanotrasen{
@@ -6751,7 +6751,7 @@
 /turf/open/floor/plasteel/vault/side{
 	dir = 8
 	},
-/area/hallway/primary/central)
+/area/hallway/primary/fore)
 "ane" = (
 /obj/structure/sign/warning/electricshock,
 /turf/closed/wall/r_wall,
@@ -6813,7 +6813,7 @@
 	dir = 1
 	},
 /turf/open/floor/plasteel,
-/area/hallway/primary/central)
+/area/hallway/primary/starboard/fore)
 "anl" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/machinery/door/firedoor,
@@ -6827,7 +6827,7 @@
 	dir = 1
 	},
 /turf/open/floor/plasteel,
-/area/hallway/primary/central)
+/area/hallway/primary/starboard/fore)
 "anm" = (
 /obj/structure/table/reinforced,
 /obj/machinery/door/firedoor,
@@ -7050,7 +7050,7 @@
 	dir = 1
 	},
 /turf/open/floor/plasteel,
-/area/hallway/primary/central)
+/area/hallway/primary/port)
 "anI" = (
 /obj/machinery/door/firedoor,
 /obj/structure/cable/white{
@@ -7064,7 +7064,7 @@
 	dir = 1
 	},
 /turf/open/floor/plasteel,
-/area/hallway/primary/central)
+/area/hallway/primary/port/fore)
 "anJ" = (
 /obj/machinery/door/airlock{
 	name = "Toilet Unit"
@@ -7076,7 +7076,7 @@
 	dir = 1
 	},
 /turf/open/floor/plasteel/freezer,
-/area/hallway/primary/central)
+/area/crew_quarters/toilet/restrooms)
 "anL" = (
 /obj/machinery/door/window/northleft{
 	dir = 4;
@@ -7121,7 +7121,7 @@
 "anQ" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
-/area/hallway/primary/central)
+/area/hallway/primary/fore)
 "anR" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/machinery/door/firedoor,
@@ -7139,7 +7139,7 @@
 	},
 /obj/effect/mapping_helpers/airlock/cyclelink_helper,
 /turf/open/floor/plasteel,
-/area/hallway/primary/central)
+/area/hallway/primary/fore)
 "anS" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/public/glass{
@@ -7153,7 +7153,7 @@
 	},
 /obj/effect/mapping_helpers/airlock/cyclelink_helper,
 /turf/open/floor/plasteel,
-/area/hallway/primary/central)
+/area/hallway/primary/fore)
 "anT" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/machinery/door/firedoor,
@@ -7168,7 +7168,7 @@
 	},
 /obj/effect/mapping_helpers/airlock/cyclelink_helper,
 /turf/open/floor/plasteel,
-/area/hallway/primary/central)
+/area/hallway/primary/fore)
 "anU" = (
 /obj/structure/closet/crate/rcd{
 	pixel_y = 4
@@ -7238,7 +7238,7 @@
 /turf/open/floor/plasteel/neutral/corner{
 	dir = 1
 	},
-/area/hallway/primary/central)
+/area/hallway/primary/starboard/fore)
 "aoa" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
 	dir = 8
@@ -7253,7 +7253,7 @@
 /turf/open/floor/plasteel/brown/corner{
 	dir = 4
 	},
-/area/hallway/primary/central)
+/area/hallway/primary/starboard/fore)
 "aob" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -7266,7 +7266,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel,
-/area/hallway/primary/central)
+/area/hallway/primary/starboard/fore)
 "aoc" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -7274,7 +7274,7 @@
 /turf/open/floor/plasteel/brown/corner{
 	dir = 1
 	},
-/area/hallway/primary/central)
+/area/hallway/primary/starboard/fore)
 "aod" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -7283,7 +7283,7 @@
 /turf/open/floor/plasteel/brown/corner{
 	dir = 1
 	},
-/area/hallway/primary/central)
+/area/hallway/primary/starboard/fore)
 "aoe" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -7295,7 +7295,7 @@
 /turf/open/floor/plasteel/brown{
 	dir = 1
 	},
-/area/hallway/primary/central)
+/area/hallway/primary/starboard/fore)
 "aof" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -7304,7 +7304,7 @@
 /turf/open/floor/plasteel/brown/corner{
 	dir = 4
 	},
-/area/hallway/primary/central)
+/area/hallway/primary/starboard/fore)
 "aog" = (
 /obj/machinery/atmospherics/pipe/manifold4w/supply/hidden,
 /obj/structure/cable/white{
@@ -7313,7 +7313,7 @@
 /turf/open/floor/plasteel/brown/corner{
 	dir = 4
 	},
-/area/hallway/primary/central)
+/area/hallway/primary/starboard/fore)
 "aoh" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -7518,7 +7518,7 @@
 /turf/open/floor/plasteel/red/corner{
 	dir = 1
 	},
-/area/hallway/primary/central)
+/area/hallway/primary/port)
 "aoC" = (
 /obj/effect/decal/cleanable/vomit/old,
 /obj/structure/toilet{
@@ -7529,7 +7529,7 @@
 	},
 /obj/machinery/light/small,
 /turf/open/floor/plasteel/freezer,
-/area/hallway/primary/central)
+/area/crew_quarters/toilet/restrooms)
 "aoD" = (
 /obj/structure/toilet{
 	dir = 8
@@ -7541,7 +7541,7 @@
 /obj/effect/landmark/blobstart,
 /obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel/freezer,
-/area/hallway/primary/central)
+/area/crew_quarters/toilet/restrooms)
 "aoE" = (
 /obj/structure/toilet{
 	dir = 8
@@ -7553,7 +7553,7 @@
 /obj/effect/landmark/start/assistant,
 /obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel/freezer,
-/area/hallway/primary/central)
+/area/crew_quarters/toilet/restrooms)
 "aoF" = (
 /obj/structure/table/reinforced,
 /obj/item/stock_parts/cell/high,
@@ -7788,7 +7788,7 @@
 	dir = 8;
 	heat_capacity = 1e+006
 	},
-/area/hallway/primary/central)
+/area/hallway/primary/starboard/fore)
 "apa" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -7808,7 +7808,7 @@
 	location = "5.3-LeavingCargo"
 	},
 /turf/open/floor/plasteel/brown/corner,
-/area/hallway/primary/central)
+/area/hallway/primary/starboard/fore)
 "apb" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -7824,7 +7824,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel,
-/area/hallway/primary/central)
+/area/hallway/primary/starboard/fore)
 "apc" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
@@ -7835,7 +7835,7 @@
 /turf/open/floor/plasteel/brown/corner{
 	dir = 8
 	},
-/area/hallway/primary/central)
+/area/hallway/primary/starboard/fore)
 "apd" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden,
 /obj/structure/cable/white{
@@ -7844,7 +7844,7 @@
 /turf/open/floor/plasteel/brown/corner{
 	dir = 8
 	},
-/area/hallway/primary/central)
+/area/hallway/primary/starboard/fore)
 "ape" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
@@ -7854,7 +7854,7 @@
 	},
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/plasteel/brown,
-/area/hallway/primary/central)
+/area/hallway/primary/starboard/fore)
 "apf" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden,
 /obj/structure/cable/white{
@@ -7865,7 +7865,7 @@
 	location = "5.2-Cargo"
 	},
 /turf/open/floor/plasteel/brown/corner,
-/area/hallway/primary/central)
+/area/hallway/primary/starboard/fore)
 "apg" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
@@ -7880,7 +7880,7 @@
 	icon_state = "1-8"
 	},
 /turf/open/floor/plasteel/brown/corner,
-/area/hallway/primary/central)
+/area/hallway/primary/starboard/fore)
 "aph" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
@@ -7890,7 +7890,7 @@
 	},
 /obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel,
-/area/hallway/primary/central)
+/area/hallway/primary/starboard/fore)
 "api" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/mining{
@@ -8168,7 +8168,7 @@
 /turf/open/floor/plasteel/red/corner{
 	dir = 1
 	},
-/area/hallway/primary/central)
+/area/hallway/primary/port)
 "apH" = (
 /obj/structure/cable/white{
 	icon_state = "1-2"
@@ -8186,7 +8186,7 @@
 /turf/open/floor/plasteel/neutral/corner{
 	dir = 4
 	},
-/area/hallway/primary/central)
+/area/hallway/primary/port)
 "apI" = (
 /turf/closed/wall,
 /area/storage/primary)
@@ -8481,28 +8481,28 @@
 	dir = 8;
 	heat_capacity = 1e+006
 	},
-/area/hallway/primary/central)
+/area/hallway/primary/starboard/fore)
 "aqi" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/structure/cable/white{
 	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel/brown/corner,
-/area/hallway/primary/central)
+/area/hallway/primary/starboard/fore)
 "aqj" = (
 /obj/machinery/computer/cargo/request{
 	dir = 1
 	},
 /obj/effect/turf_decal/delivery,
 /turf/open/floor/plasteel,
-/area/hallway/primary/central)
+/area/hallway/primary/starboard/fore)
 "aqk" = (
 /obj/structure/chair{
 	dir = 1
 	},
 /obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel,
-/area/hallway/primary/central)
+/area/hallway/primary/starboard/fore)
 "aql" = (
 /obj/structure/chair{
 	dir = 1
@@ -8510,7 +8510,7 @@
 /obj/effect/landmark/start/assistant,
 /obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel,
-/area/hallway/primary/central)
+/area/hallway/primary/starboard/fore)
 "aqm" = (
 /obj/structure/table,
 /obj/machinery/light,
@@ -8521,7 +8521,7 @@
 /obj/item/pen,
 /obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel,
-/area/hallway/primary/central)
+/area/hallway/primary/starboard/fore)
 "aqn" = (
 /obj/structure/chair{
 	dir = 1
@@ -8532,7 +8532,7 @@
 	},
 /obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel,
-/area/hallway/primary/central)
+/area/hallway/primary/starboard/fore)
 "aqp" = (
 /obj/machinery/autolathe,
 /obj/structure/extinguisher_cabinet{
@@ -8544,7 +8544,7 @@
 	},
 /obj/effect/turf_decal/delivery,
 /turf/open/floor/plasteel,
-/area/hallway/primary/central)
+/area/hallway/primary/starboard/fore)
 "aqq" = (
 /obj/structure/rack,
 /obj/item/storage/toolbox/emergency{
@@ -8776,7 +8776,7 @@
 /turf/open/floor/plasteel/neutral/corner{
 	dir = 4
 	},
-/area/hallway/primary/central)
+/area/hallway/primary/port)
 "aqT" = (
 /obj/structure/table/reinforced,
 /obj/item/storage/belt/utility,
@@ -8946,14 +8946,14 @@
 	dir = 8;
 	heat_capacity = 1e+006
 	},
-/area/hallway/primary/central)
+/area/hallway/primary/starboard/fore)
 "arj" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/structure/cable/white{
 	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel/neutral/corner,
-/area/hallway/primary/central)
+/area/hallway/primary/starboard/fore)
 "ark" = (
 /obj/structure/table/reinforced,
 /obj/machinery/airalarm{
@@ -9870,7 +9870,7 @@
 /turf/open/floor/plasteel/neutral/corner{
 	dir = 4
 	},
-/area/hallway/primary/central)
+/area/hallway/primary/port)
 "asU" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/engineering/glass{
@@ -10066,7 +10066,7 @@
 	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel/neutral/corner,
-/area/hallway/primary/central)
+/area/hallway/primary/starboard/fore)
 "atq" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -10230,7 +10230,7 @@
 /turf/open/floor/plasteel/neutral/corner{
 	dir = 1
 	},
-/area/hallway/primary/central)
+/area/hallway/primary/port)
 "atN" = (
 /obj/structure/cable/white{
 	icon_state = "1-2"
@@ -10242,7 +10242,7 @@
 /turf/open/floor/plasteel/neutral/corner{
 	dir = 4
 	},
-/area/hallway/primary/central)
+/area/hallway/primary/port)
 "atO" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/engineering/glass{
@@ -10557,7 +10557,7 @@
 	dir = 8;
 	heat_capacity = 1e+006
 	},
-/area/hallway/primary/central)
+/area/hallway/primary/starboard/fore)
 "aup" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/machinery/airalarm{
@@ -10568,7 +10568,7 @@
 	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel/neutral/corner,
-/area/hallway/primary/central)
+/area/hallway/primary/starboard/fore)
 "auq" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/siphon/on{
 	dir = 4;
@@ -10793,7 +10793,7 @@
 /turf/open/floor/plasteel/vault/side{
 	dir = 4
 	},
-/area/hallway/primary/central)
+/area/hallway/primary/port)
 "auO" = (
 /obj/structure/cable/white{
 	icon_state = "4-8"
@@ -10814,7 +10814,7 @@
 /turf/open/floor/plasteel/neutral/corner{
 	dir = 1
 	},
-/area/hallway/primary/central)
+/area/hallway/primary/port)
 "auP" = (
 /obj/structure/cable/white{
 	icon_state = "4-8"
@@ -10825,7 +10825,7 @@
 /turf/open/floor/plasteel/neutral/corner{
 	dir = 1
 	},
-/area/hallway/primary/central)
+/area/hallway/primary/port)
 "auQ" = (
 /obj/structure/cable/white{
 	icon_state = "4-8"
@@ -10836,7 +10836,7 @@
 /turf/open/floor/plasteel/neutral/corner{
 	dir = 1
 	},
-/area/hallway/primary/central)
+/area/hallway/primary/port)
 "auR" = (
 /obj/structure/cable/white{
 	icon_state = "4-8"
@@ -10848,7 +10848,7 @@
 /turf/open/floor/plasteel/neutral/corner{
 	dir = 1
 	},
-/area/hallway/primary/central)
+/area/hallway/primary/port)
 "auS" = (
 /obj/structure/cable/white{
 	icon_state = "1-8"
@@ -10859,7 +10859,7 @@
 /turf/open/floor/plasteel/neutral/corner{
 	dir = 4
 	},
-/area/hallway/primary/central)
+/area/hallway/primary/port)
 "auT" = (
 /turf/open/floor/plasteel/yellow/side{
 	dir = 10
@@ -11063,7 +11063,7 @@
 	dir = 8;
 	heat_capacity = 1e+006
 	},
-/area/hallway/primary/central)
+/area/hallway/primary/starboard/fore)
 "avu" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
@@ -11073,7 +11073,7 @@
 	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel/neutral/corner,
-/area/hallway/primary/central)
+/area/hallway/primary/starboard/fore)
 "avv" = (
 /obj/machinery/shieldgen,
 /obj/effect/turf_decal/stripes/line{
@@ -11332,7 +11332,7 @@
 /turf/open/floor/plasteel/vault/side{
 	dir = 4
 	},
-/area/hallway/primary/central)
+/area/hallway/primary/port)
 "avT" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -11344,7 +11344,7 @@
 /turf/open/floor/plasteel/neutral/corner{
 	dir = 1
 	},
-/area/hallway/primary/central)
+/area/hallway/primary/port)
 "avU" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 1
@@ -11353,13 +11353,13 @@
 	dir = 1
 	},
 /turf/open/floor/plasteel/neutral/corner,
-/area/hallway/primary/central)
+/area/hallway/primary/port)
 "avV" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
 /turf/open/floor/plasteel/neutral/corner,
-/area/hallway/primary/central)
+/area/hallway/primary/port)
 "avW" = (
 /obj/machinery/airalarm{
 	dir = 1;
@@ -11369,7 +11369,7 @@
 	dir = 9
 	},
 /turf/open/floor/plasteel/neutral/corner,
-/area/hallway/primary/central)
+/area/hallway/primary/port)
 "avX" = (
 /obj/machinery/firealarm{
 	dir = 4;
@@ -11379,7 +11379,7 @@
 	icon_state = "plant-21"
 	},
 /turf/open/floor/plasteel/neutral/corner,
-/area/hallway/primary/central)
+/area/hallway/primary/port)
 "avY" = (
 /obj/structure/table/reinforced,
 /obj/item/stock_parts/cell/high,
@@ -11654,7 +11654,7 @@
 	dir = 8;
 	heat_capacity = 1e+006
 	},
-/area/hallway/primary/central)
+/area/hallway/primary/starboard/fore)
 "awz" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -11812,7 +11812,7 @@
 	dir = 1
 	},
 /turf/open/floor/plasteel,
-/area/hallway/primary/central)
+/area/hallway/primary/port)
 "awP" = (
 /obj/structure/sign/nanotrasen,
 /turf/closed/wall,
@@ -12163,13 +12163,13 @@
 /turf/open/floor/plasteel/neutral/corner{
 	dir = 1
 	},
-/area/hallway/primary/central)
+/area/hallway/primary/port)
 "axC" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plasteel/neutral/corner{
 	dir = 4
 	},
-/area/hallway/primary/central)
+/area/hallway/primary/port)
 "axD" = (
 /obj/item/device/radio/intercom{
 	name = "Station Intercom";
@@ -12353,7 +12353,7 @@
 	dir = 8;
 	heat_capacity = 1e+006
 	},
-/area/hallway/primary/central)
+/area/hallway/primary/starboard/fore)
 "axW" = (
 /turf/closed/wall,
 /area/hallway/secondary/exit)
@@ -12554,7 +12554,7 @@
 /turf/open/floor/plasteel/neutral/corner{
 	dir = 1
 	},
-/area/hallway/primary/central)
+/area/hallway/primary/port)
 "ayu" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
@@ -12753,14 +12753,14 @@
 	dir = 8;
 	heat_capacity = 1e+006
 	},
-/area/hallway/primary/central)
+/area/hallway/primary/starboard/fore)
 "ayV" = (
 /obj/structure/closet/firecloset,
 /obj/effect/turf_decal/delivery,
 /turf/open/floor/plasteel/vault/side{
 	dir = 8
 	},
-/area/hallway/primary/central)
+/area/hallway/primary/port)
 "ayW" = (
 /obj/structure/table/reinforced,
 /obj/structure/cable/white{
@@ -13173,7 +13173,7 @@
 	dir = 8;
 	heat_capacity = 1e+006
 	},
-/area/hallway/primary/central)
+/area/hallway/primary/starboard/fore)
 "azU" = (
 /obj/effect/turf_decal/bot,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -13182,7 +13182,7 @@
 /turf/open/floor/plasteel/vault/side{
 	dir = 8
 	},
-/area/hallway/primary/central)
+/area/hallway/primary/starboard/fore)
 "azV" = (
 /obj/structure/table/reinforced,
 /obj/machinery/recharger,
@@ -13427,7 +13427,7 @@
 /turf/open/floor/plasteel/neutral/corner{
 	dir = 4
 	},
-/area/hallway/primary/central)
+/area/hallway/primary/port)
 "aAD" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/public/glass{
@@ -13646,12 +13646,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/central)
-"aAY" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/turf/closed/wall,
-/area/hallway/primary/central)
 "aAZ" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -13661,7 +13655,7 @@
 	dir = 8;
 	heat_capacity = 1e+006
 	},
-/area/hallway/primary/central)
+/area/hallway/primary/starboard/fore)
 "aBa" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
 	dir = 4
@@ -13670,14 +13664,14 @@
 	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel/neutral/corner,
-/area/hallway/primary/central)
+/area/hallway/primary/starboard/fore)
 "aBb" = (
 /obj/machinery/vending/cola/random,
 /obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel/vault/side{
 	dir = 8
 	},
-/area/hallway/primary/central)
+/area/hallway/primary/starboard/fore)
 "aBc" = (
 /obj/machinery/computer/security{
 	dir = 4
@@ -13946,7 +13940,7 @@
 /turf/open/floor/plasteel/neutral/corner{
 	dir = 1
 	},
-/area/hallway/primary/central)
+/area/hallway/primary/port)
 "aBL" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -13960,7 +13954,7 @@
 	location = "9.4-EnteringDorms"
 	},
 /turf/open/floor/plasteel/neutral/corner,
-/area/hallway/primary/central)
+/area/hallway/primary/port)
 "aBM" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/public/glass{
@@ -14161,7 +14155,7 @@
 	dir = 8;
 	heat_capacity = 1e+006
 	},
-/area/hallway/primary/central)
+/area/hallway/primary/starboard/fore)
 "aCh" = (
 /obj/machinery/vending/snack/random,
 /obj/machinery/firealarm{
@@ -14172,7 +14166,7 @@
 /turf/open/floor/plasteel/vault/side{
 	dir = 8
 	},
-/area/hallway/primary/central)
+/area/hallway/primary/starboard/fore)
 "aCi" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable/white{
@@ -14517,7 +14511,7 @@
 /turf/open/floor/plasteel/neutral/corner{
 	dir = 1
 	},
-/area/hallway/primary/central)
+/area/hallway/primary/port)
 "aCM" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plasteel/neutral/corner,
@@ -14664,7 +14658,7 @@
 "aDc" = (
 /obj/machinery/status_display,
 /turf/closed/wall,
-/area/hallway/primary/central)
+/area/hallway/primary/starboard/fore)
 "aDd" = (
 /obj/structure/table,
 /obj/item/paper_bin,
@@ -14784,7 +14778,7 @@
 "aDv" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/closed/wall/r_wall,
-/area/hallway/primary/central)
+/area/engine/break_room)
 "aDw" = (
 /obj/machinery/firealarm{
 	dir = 8;
@@ -14797,7 +14791,7 @@
 /turf/open/floor/plasteel/escape{
 	dir = 8
 	},
-/area/hallway/primary/central)
+/area/engine/break_room)
 "aDx" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 4
@@ -14808,13 +14802,13 @@
 /turf/open/floor/plasteel/caution{
 	dir = 1
 	},
-/area/hallway/primary/central)
+/area/engine/break_room)
 "aDy" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plasteel/caution{
 	dir = 1
 	},
-/area/hallway/primary/central)
+/area/engine/break_room)
 "aDz" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
 	dir = 8
@@ -14822,7 +14816,7 @@
 /turf/open/floor/plasteel/caution{
 	dir = 1
 	},
-/area/hallway/primary/central)
+/area/engine/break_room)
 "aDA" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 8
@@ -14830,7 +14824,7 @@
 /turf/open/floor/plasteel/caution{
 	dir = 1
 	},
-/area/hallway/primary/central)
+/area/engine/break_room)
 "aDB" = (
 /obj/item/twohanded/required/kirbyplants{
 	icon_state = "plant-21"
@@ -14838,13 +14832,13 @@
 /turf/open/floor/plasteel/caution{
 	dir = 5
 	},
-/area/hallway/primary/central)
+/area/engine/break_room)
 "aDC" = (
 /obj/structure/table/reinforced,
 /obj/item/airlock_painter,
 /obj/effect/turf_decal/delivery,
 /turf/open/floor/plasteel,
-/area/hallway/primary/central)
+/area/hallway/primary/port)
 "aDD" = (
 /turf/open/floor/plasteel/neutral/corner{
 	dir = 8;
@@ -15063,13 +15057,13 @@
 /turf/open/floor/plasteel/neutral/corner{
 	dir = 4
 	},
-/area/hallway/primary/central)
+/area/hallway/primary/starboard)
 "aEa" = (
 /obj/structure/table,
 /obj/item/storage/firstaid/regular,
 /obj/effect/turf_decal/delivery,
 /turf/open/floor/plasteel,
-/area/hallway/primary/central)
+/area/hallway/primary/starboard)
 "aEb" = (
 /obj/effect/turf_decal/bot,
 /obj/machinery/computer/arcade{
@@ -15241,7 +15235,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/structure/sign/warning/nosmoking,
 /turf/closed/wall/r_wall,
-/area/hallway/primary/central)
+/area/engine/break_room)
 "aEB" = (
 /obj/machinery/atmospherics/components/unary/portables_connector/visible{
 	dir = 4
@@ -15250,7 +15244,7 @@
 /turf/open/floor/plasteel/escape{
 	dir = 8
 	},
-/area/hallway/primary/central)
+/area/engine/break_room)
 "aEC" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 9
@@ -15259,26 +15253,26 @@
 	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel/neutral,
-/area/hallway/primary/central)
+/area/engine/break_room)
 "aED" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 8
 	},
 /turf/open/floor/plasteel/neutral,
-/area/hallway/primary/central)
+/area/engine/break_room)
 "aEE" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
 /turf/open/floor/plasteel/neutral,
-/area/hallway/primary/central)
+/area/engine/break_room)
 "aEF" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 1
 	},
 /turf/open/floor/plasteel/neutral,
-/area/hallway/primary/central)
+/area/engine/break_room)
 "aEG" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
@@ -15286,7 +15280,7 @@
 /turf/open/floor/plasteel/yellow/corner{
 	dir = 4
 	},
-/area/hallway/primary/central)
+/area/engine/break_room)
 "aEH" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -15302,7 +15296,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel,
-/area/hallway/primary/central)
+/area/engine/break_room)
 "aEI" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
@@ -15314,7 +15308,7 @@
 /turf/open/floor/plasteel/neutral/corner{
 	dir = 1
 	},
-/area/hallway/primary/central)
+/area/hallway/primary/port)
 "aEJ" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 4
@@ -15323,7 +15317,7 @@
 	pixel_x = 24
 	},
 /turf/open/floor/plasteel/neutral/corner,
-/area/hallway/primary/central)
+/area/hallway/primary/port)
 "aEK" = (
 /obj/machinery/vending/clothing,
 /obj/machinery/firealarm{
@@ -15603,7 +15597,7 @@
 	location = "6.1-EnteringDepartures"
 	},
 /turf/open/floor/plasteel,
-/area/hallway/primary/central)
+/area/hallway/primary/starboard)
 "aFk" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -15786,7 +15780,7 @@
 /turf/open/floor/plasteel/arrival{
 	dir = 8
 	},
-/area/hallway/primary/central)
+/area/engine/break_room)
 "aFD" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 10
@@ -15801,7 +15795,7 @@
 	icon_state = "2-4"
 	},
 /turf/open/floor/plasteel/neutral,
-/area/hallway/primary/central)
+/area/engine/break_room)
 "aFE" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/structure/cable/white{
@@ -15812,7 +15806,7 @@
 	location = "9.3-Engi"
 	},
 /turf/open/floor/plasteel/neutral,
-/area/hallway/primary/central)
+/area/engine/break_room)
 "aFF" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
 	dir = 8
@@ -15822,7 +15816,7 @@
 	},
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/plasteel/neutral,
-/area/hallway/primary/central)
+/area/engine/break_room)
 "aFG" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -15832,7 +15826,7 @@
 	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel/neutral,
-/area/hallway/primary/central)
+/area/engine/break_room)
 "aFH" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -15841,7 +15835,7 @@
 	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel/yellow/corner,
-/area/hallway/primary/central)
+/area/engine/break_room)
 "aFI" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -15860,7 +15854,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel,
-/area/hallway/primary/central)
+/area/engine/break_room)
 "aFJ" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -15872,7 +15866,7 @@
 	dir = 8;
 	heat_capacity = 1e+006
 	},
-/area/hallway/primary/central)
+/area/hallway/primary/port)
 "aFK" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
 	dir = 4
@@ -15891,7 +15885,7 @@
 	dir = 8;
 	heat_capacity = 1e+006
 	},
-/area/hallway/primary/central)
+/area/hallway/primary/port)
 "aFL" = (
 /obj/machinery/firealarm{
 	dir = 4;
@@ -15903,7 +15897,7 @@
 	dir = 8
 	},
 /turf/open/floor/plasteel/neutral/corner,
-/area/hallway/primary/central)
+/area/hallway/primary/port)
 "aFN" = (
 /obj/structure/extinguisher_cabinet{
 	pixel_x = -26
@@ -15986,7 +15980,7 @@
 /turf/open/floor/plasteel/neutral/corner{
 	dir = 1
 	},
-/area/hallway/primary/central)
+/area/hallway/primary/starboard)
 "aFY" = (
 /obj/machinery/holopad,
 /obj/structure/cable/white{
@@ -15997,7 +15991,7 @@
 	dir = 8
 	},
 /turf/open/floor/plasteel,
-/area/hallway/primary/central)
+/area/hallway/primary/starboard)
 "aGa" = (
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/plasteel/neutral,
@@ -16145,7 +16139,7 @@
 /turf/open/floor/plasteel/arrival{
 	dir = 8
 	},
-/area/hallway/primary/central)
+/area/engine/break_room)
 "aGq" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
 	dir = 4
@@ -16156,7 +16150,7 @@
 /turf/open/floor/plasteel/yellow/corner{
 	dir = 8
 	},
-/area/hallway/primary/central)
+/area/engine/break_room)
 "aGr" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/machinery/light,
@@ -16167,25 +16161,25 @@
 /turf/open/floor/plasteel/yellow/corner{
 	dir = 8
 	},
-/area/hallway/primary/central)
+/area/engine/break_room)
 "aGs" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plasteel/yellow/corner{
 	dir = 8
 	},
-/area/hallway/primary/central)
+/area/engine/break_room)
 "aGt" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 1
 	},
 /turf/open/floor/plasteel/yellow/corner,
-/area/hallway/primary/central)
+/area/engine/break_room)
 "aGu" = (
 /obj/item/twohanded/required/kirbyplants{
 	icon_state = "plant-22"
 	},
 /turf/open/floor/plasteel/yellow/corner,
-/area/hallway/primary/central)
+/area/engine/break_room)
 "aGv" = (
 /obj/structure/table/reinforced,
 /obj/item/stock_parts/cell/high,
@@ -16193,7 +16187,7 @@
 /obj/machinery/cell_charger,
 /obj/effect/turf_decal/delivery,
 /turf/open/floor/plasteel,
-/area/hallway/primary/central)
+/area/hallway/primary/port)
 "aGw" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
@@ -16206,13 +16200,13 @@
 	dir = 8;
 	heat_capacity = 1e+006
 	},
-/area/hallway/primary/central)
+/area/hallway/primary/port)
 "aGx" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 4
 	},
 /turf/open/floor/plasteel/neutral/corner,
-/area/hallway/primary/central)
+/area/hallway/primary/port)
 "aGy" = (
 /obj/structure/sign/nanotrasen,
 /turf/closed/wall,
@@ -16241,31 +16235,41 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/bot,
-/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/stripes/line{
+	dir = 6
+	},
+/obj/structure/cable/white{
+	icon_state = "2-4"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 6
+	},
 /turf/open/floor/plasteel,
 /area/maintenance/port/central)
-"aGC" = (
-/obj/structure/girder,
-/turf/open/floor/plating,
-/area/maintenance/port/central)
 "aGD" = (
-/obj/structure/cable/white{
-	icon_state = "0-2"
-	},
 /obj/machinery/power/apc/highcap/five_k{
 	dir = 1;
 	name = "Central Port Maintenance APC";
 	areastring = "/area/maintenance/port/central";
 	pixel_y = 25
 	},
+/obj/structure/cable/white{
+	icon_state = "0-8"
+	},
+/obj/structure/cable/white{
+	icon_state = "0-4"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
 /turf/open/floor/plating,
 /area/maintenance/port/central)
 "aGE" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 6
-	},
 /obj/structure/cable/white{
-	icon_state = "2-4"
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
+	dir = 1
 	},
 /turf/open/floor/plating,
 /area/maintenance/port/central)
@@ -16483,7 +16487,7 @@
 /turf/open/floor/plasteel/neutral/corner{
 	dir = 1
 	},
-/area/hallway/primary/central)
+/area/hallway/primary/starboard)
 "aHe" = (
 /obj/effect/turf_decal/bot_white/right,
 /turf/open/floor/plasteel/vault{
@@ -16815,7 +16819,7 @@
 	dir = 8;
 	heat_capacity = 1e+006
 	},
-/area/hallway/primary/central)
+/area/hallway/primary/port)
 "aHD" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -16825,7 +16829,7 @@
 	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel/neutral/corner,
-/area/hallway/primary/central)
+/area/hallway/primary/port)
 "aHE" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -16837,7 +16841,7 @@
 /turf/open/floor/plasteel/vault/side{
 	dir = 8
 	},
-/area/hallway/primary/central)
+/area/hallway/primary/port)
 "aHF" = (
 /obj/machinery/door/airlock/maintenance_hatch{
 	name = "Maintenance Hatch";
@@ -16870,44 +16874,24 @@
 /obj/structure/cable/white{
 	icon_state = "2-8"
 	},
+/obj/effect/landmark/blobstart,
 /turf/open/floor/plating{
 	icon_state = "panelscorched"
 	},
 /area/maintenance/port/central)
 "aHI" = (
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	dir = 1
-	},
-/obj/structure/cable/white{
-	icon_state = "4-8"
-	},
-/turf/open/floor/plating,
-/area/maintenance/port/central)
-"aHK" = (
-/obj/effect/landmark/blobstart,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/obj/structure/cable/white{
-	icon_state = "4-8"
-	},
 /obj/structure/cable/white{
 	icon_state = "1-8"
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
+	dir = 4
 	},
 /turf/open/floor/plating,
 /area/maintenance/port/central)
 "aHL" = (
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	dir = 4
-	},
-/obj/structure/cable/white{
-	icon_state = "2-8"
-	},
-/obj/structure/cable/white{
-	icon_state = "1-8"
-	},
-/turf/open/floor/plating,
-/area/maintenance/port/central)
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/turf/closed/wall,
+/area/hydroponics)
 "aHM" = (
 /turf/closed/wall,
 /area/hydroponics)
@@ -17012,7 +16996,7 @@
 /turf/open/floor/plasteel/vault/side{
 	dir = 8
 	},
-/area/hallway/primary/central)
+/area/hallway/primary/starboard)
 "aHZ" = (
 /obj/item/twohanded/required/kirbyplants{
 	icon_state = "plant-21"
@@ -17307,7 +17291,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plasteel/neutral/corner,
-/area/hallway/primary/central)
+/area/hallway/primary/port)
 "aIB" = (
 /turf/closed/wall,
 /area/janitor)
@@ -17332,27 +17316,6 @@
 /turf/closed/wall,
 /area/janitor)
 "aIE" = (
-/obj/structure/closet,
-/obj/effect/spawner/lootdrop/maintenance{
-	lootcount = 3;
-	name = "3maintenance loot spawner"
-	},
-/obj/effect/turf_decal/bot,
-/obj/effect/turf_decal/stripes/line{
-	dir = 5
-	},
-/turf/open/floor/plasteel,
-/area/maintenance/port/central)
-"aIF" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/structure/cable/white{
-	icon_state = "1-2"
-	},
-/turf/open/floor/plating{
-	icon_state = "platingdmg1"
-	},
-/area/maintenance/port/central)
-"aIG" = (
 /obj/item/crowbar/red,
 /obj/item/cultivator,
 /obj/item/shovel/spade,
@@ -17365,23 +17328,37 @@
 /obj/item/reagent_containers/glass/bucket,
 /obj/structure/closet/crate/hydroponics,
 /obj/effect/turf_decal/delivery,
+/obj/item/wrench,
+/obj/item/wirecutters,
 /turf/open/floor/plasteel/vault/side,
 /area/hydroponics)
-"aIH" = (
-/obj/structure/sink{
-	dir = 4;
-	pixel_x = 12
+"aIF" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/structure/closet/wardrobe/botanist,
+/obj/structure/sign/poster/random{
+	pixel_y = 32
 	},
 /turf/open/floor/plasteel/vault/side,
+/area/hydroponics)
+"aIG" = (
+/obj/machinery/hydroponics/constructable,
+/obj/effect/turf_decal/stripes/line,
+/obj/structure/sign/poster/random{
+	pixel_y = 32
+	},
+/turf/open/floor/plasteel,
+/area/hydroponics)
+"aIH" = (
+/obj/machinery/hydroponics/constructable,
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/plasteel,
 /area/hydroponics)
 "aII" = (
 /obj/machinery/hydroponics/constructable,
 /obj/machinery/airalarm{
 	pixel_y = 23
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 10
-	},
+/obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plasteel,
 /area/hydroponics)
 "aIJ" = (
@@ -17414,9 +17391,6 @@
 /turf/open/floor/plasteel/vault/side,
 /area/hydroponics)
 "aIM" = (
-/obj/machinery/chem_master/condimaster{
-	name = "BrewMaster 3000"
-	},
 /obj/machinery/requests_console{
 	department = "Hydroponics";
 	departmentType = 0;
@@ -17425,6 +17399,9 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/effect/turf_decal/bot,
+/obj/machinery/chem_master/condimaster{
+	name = "BrewMaster 3000"
+	},
 /turf/open/floor/plasteel/vault/side,
 /area/hydroponics)
 "aIN" = (
@@ -17545,7 +17522,7 @@
 /turf/open/floor/plasteel/neutral/corner{
 	dir = 1
 	},
-/area/hallway/primary/central)
+/area/hallway/primary/starboard)
 "aIY" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
@@ -17557,11 +17534,11 @@
 /turf/open/floor/plasteel/neutral/corner{
 	dir = 4
 	},
-/area/hallway/primary/central)
+/area/hallway/primary/starboard)
 "aIZ" = (
 /obj/machinery/ai_status_display,
 /turf/closed/wall,
-/area/hallway/primary/central)
+/area/hallway/primary/starboard)
 "aJa" = (
 /obj/structure/table,
 /obj/item/storage/pill_bottle/dice,
@@ -17929,36 +17906,11 @@
 	},
 /area/janitor)
 "aJM" = (
-/obj/machinery/door/airlock/maintenance_hatch{
-	name = "Maintenance Hatch";
-	req_access_txt = "12"
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
+	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/structure/cable/white{
-	icon_state = "1-2"
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 2
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/obj/effect/mapping_helpers/airlock/cyclelink_helper,
-/turf/open/floor/plating,
-/area/maintenance/port/central)
-"aJN" = (
-/obj/machinery/seed_extractor,
-/obj/machinery/status_display{
-	pixel_x = -32
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 5
-	},
-/turf/open/floor/plasteel,
-/area/hydroponics)
-"aJO" = (
 /turf/open/floor/plasteel/greenblue/side{
-	dir = 9
+	dir = 1
 	},
 /area/hydroponics)
 "aJP" = (
@@ -18122,7 +18074,7 @@
 /turf/open/floor/plasteel/vault/side{
 	dir = 1
 	},
-/area/hallway/primary/central)
+/area/hallway/primary/port/aft)
 "aKh" = (
 /obj/structure/sign/nanotrasen,
 /turf/closed/wall,
@@ -18490,34 +18442,22 @@
 	},
 /area/janitor)
 "aKT" = (
-/obj/machinery/shieldgen,
-/obj/effect/turf_decal/stripes/line{
-	dir = 9
-	},
-/turf/open/floor/plasteel,
-/area/maintenance/port/central)
-"aKU" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/structure/cable/white{
-	icon_state = "1-2"
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 5
-	},
-/turf/open/floor/plasteel,
-/area/maintenance/port/central)
-"aKV" = (
-/obj/machinery/biogenerator,
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
-/turf/open/floor/plasteel,
-/area/hydroponics)
-"aKW" = (
-/obj/effect/landmark/event_spawn,
+/obj/machinery/biogenerator,
 /turf/open/floor/plasteel/greenblue/side{
 	dir = 8
 	},
+/area/hydroponics)
+"aKU" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/turf/open/floor/plasteel/neutral,
+/area/hydroponics)
+"aKW" = (
+/obj/machinery/seed_extractor,
+/obj/effect/turf_decal/bot,
+/turf/open/floor/plasteel/neutral,
 /area/hydroponics)
 "aKX" = (
 /obj/structure/table/glass,
@@ -18690,7 +18630,7 @@
 /turf/open/floor/plasteel/neutral/corner{
 	dir = 1
 	},
-/area/hallway/primary/central)
+/area/hallway/primary/starboard)
 "aLt" = (
 /turf/open/floor/plasteel/brown{
 	dir = 5
@@ -18983,36 +18923,20 @@
 	},
 /area/janitor)
 "aMi" = (
-/obj/machinery/shieldgen,
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/maintenance/port/central)
-"aMj" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/structure/cable/white{
-	icon_state = "1-2"
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/maintenance/port/central)
-"aMk" = (
-/obj/machinery/plantgenes,
-/obj/machinery/status_display{
-	pixel_x = -32
-	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 6
 	},
-/turf/open/floor/plasteel,
-/area/hydroponics)
-"aMl" = (
+/obj/structure/closet/secure_closet/hydroponics,
 /turf/open/floor/plasteel/greenblue/side{
 	dir = 10
 	},
+/area/hydroponics)
+"aMj" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/turf/open/floor/plasteel/greenblue/side,
+/area/hydroponics)
+"aMk" = (
+/turf/open/floor/plasteel/greenblue/side,
 /area/hydroponics)
 "aMm" = (
 /obj/structure/cable/white{
@@ -19109,7 +19033,7 @@
 /turf/open/floor/plasteel/vault/side{
 	dir = 8
 	},
-/area/hallway/primary/central)
+/area/hallway/primary/starboard)
 "aMz" = (
 /obj/item/twohanded/required/kirbyplants{
 	icon_state = "plant-21"
@@ -19376,14 +19300,14 @@
 	dir = 8;
 	heat_capacity = 1e+006
 	},
-/area/hallway/primary/central)
+/area/hallway/primary/port)
 "aNi" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/machinery/newscaster{
 	pixel_x = 32
 	},
 /turf/open/floor/plasteel/neutral/corner,
-/area/hallway/primary/central)
+/area/hallway/primary/port)
 "aNj" = (
 /obj/structure/reagent_dispensers/watertank,
 /obj/item/reagent_containers/glass/bucket,
@@ -19422,35 +19346,8 @@
 	},
 /area/janitor)
 "aNn" = (
-/obj/structure/rack,
-/obj/item/clothing/gloves/color/black,
-/obj/item/crowbar/red,
-/obj/item/wrench,
-/obj/machinery/light/small,
-/obj/effect/turf_decal/stripes/line{
-	dir = 10
-	},
-/turf/open/floor/plasteel,
-/area/maintenance/port/central)
-"aNo" = (
-/obj/effect/decal/cleanable/blood/splatter,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/structure/cable/white{
-	icon_state = "1-2"
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 6
-	},
-/turf/open/floor/plasteel,
-/area/maintenance/port/central)
-"aNp" = (
 /obj/structure/table/glass,
-/obj/structure/extinguisher_cabinet{
-	pixel_x = -26
-	},
-/obj/item/book/manual/hydroponics_pod_people,
 /obj/item/storage/box/syringes,
-/obj/item/paper/guides/jobs/hydroponics,
 /obj/effect/turf_decal/bot,
 /obj/item/storage/box/disks_plantgene,
 /obj/item/toy/figure/botanist,
@@ -19468,7 +19365,7 @@
 	},
 /obj/structure/cable/white,
 /obj/effect/turf_decal/stripes/line{
-	dir = 9
+	dir = 1
 	},
 /turf/open/floor/plasteel,
 /area/hydroponics)
@@ -19521,10 +19418,8 @@
 /turf/open/floor/grass,
 /area/hydroponics)
 "aNx" = (
-/obj/structure/reagent_dispensers/watertank,
-/turf/open/floor/plasteel/vault{
-	dir = 8
-	},
+/obj/structure/sink/puddle,
+/turf/open/floor/grass,
 /area/hydroponics)
 "aNy" = (
 /obj/machinery/door/firedoor,
@@ -19619,7 +19514,7 @@
 	dir = 8;
 	heat_capacity = 1e+006
 	},
-/area/hallway/primary/central)
+/area/hallway/primary/starboard)
 "aNG" = (
 /obj/structure/table/reinforced,
 /obj/item/clipboard,
@@ -20094,7 +19989,7 @@
 /turf/open/floor/plasteel/vault{
 	dir = 5
 	},
-/area/hallway/primary/central)
+/area/hallway/primary/port/aft)
 "aOP" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden,
 /obj/structure/cable/white{
@@ -20107,7 +20002,7 @@
 	dir = 8;
 	heat_capacity = 1e+006
 	},
-/area/hallway/primary/central)
+/area/hallway/primary/port/aft)
 "aOQ" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -20119,7 +20014,7 @@
 /turf/open/floor/plasteel/neutral/corner{
 	dir = 4
 	},
-/area/hallway/primary/central)
+/area/hallway/primary/port/aft)
 "aOR" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
 	dir = 1
@@ -20133,7 +20028,7 @@
 /turf/open/floor/plasteel/neutral/corner{
 	dir = 1
 	},
-/area/hallway/primary/central)
+/area/hallway/primary/port/aft)
 "aOS" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
 	dir = 1
@@ -20144,7 +20039,7 @@
 /turf/open/floor/plasteel/neutral/corner{
 	dir = 1
 	},
-/area/hallway/primary/central)
+/area/hallway/primary/port/aft)
 "aOT" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -20159,7 +20054,7 @@
 /turf/open/floor/plasteel/neutral/corner{
 	dir = 1
 	},
-/area/hallway/primary/central)
+/area/hallway/primary/port/aft)
 "aOU" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden,
@@ -20173,7 +20068,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel,
-/area/hallway/primary/central)
+/area/hallway/primary/port/aft)
 "aOV" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -20190,7 +20085,7 @@
 /turf/open/floor/plasteel/green/corner{
 	dir = 1
 	},
-/area/hallway/primary/central)
+/area/hallway/primary/port/aft)
 "aOW" = (
 /obj/machinery/light{
 	dir = 1
@@ -20211,7 +20106,7 @@
 /turf/open/floor/plasteel/purple/corner{
 	dir = 1
 	},
-/area/hallway/primary/central)
+/area/hallway/primary/port/aft)
 "aOX" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -20232,7 +20127,7 @@
 /turf/open/floor/plasteel/green/corner{
 	dir = 1
 	},
-/area/hallway/primary/central)
+/area/hallway/primary/port/aft)
 "aOY" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden,
 /obj/structure/cable/white{
@@ -20244,21 +20139,19 @@
 /turf/open/floor/plasteel/neutral/corner{
 	dir = 1
 	},
-/area/hallway/primary/central)
+/area/hallway/primary/port/aft)
 "aOZ" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
-/obj/machinery/status_display{
-	pixel_y = 32
-	},
 /obj/structure/cable/white{
 	icon_state = "4-8"
 	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plasteel/neutral/corner{
 	dir = 1
 	},
-/area/hallway/primary/central)
+/area/hallway/primary/port/aft)
 "aPa" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -20273,7 +20166,7 @@
 /turf/open/floor/plasteel/green/corner{
 	dir = 1
 	},
-/area/hallway/primary/central)
+/area/hallway/primary/port/aft)
 "aPb" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -20295,10 +20188,13 @@
 /obj/machinery/camera{
 	c_tag = "Aft Primary Hallway 3"
 	},
+/obj/machinery/status_display{
+	pixel_y = 32
+	},
 /turf/open/floor/plasteel/green/corner{
 	dir = 1
 	},
-/area/hallway/primary/central)
+/area/hallway/primary/port/aft)
 "aPd" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -20314,7 +20210,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel,
-/area/hallway/primary/central)
+/area/hallway/primary/port/aft)
 "aPe" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden,
 /obj/structure/cable/white{
@@ -20522,7 +20418,7 @@
 /turf/open/floor/plasteel/neutral/corner{
 	dir = 4
 	},
-/area/hallway/primary/central)
+/area/hallway/primary/starboard/aft)
 "aPw" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -20534,7 +20430,7 @@
 /turf/open/floor/plasteel/neutral/corner{
 	dir = 1
 	},
-/area/hallway/primary/central)
+/area/hallway/primary/starboard/aft)
 "aPx" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
 	dir = 4
@@ -20546,7 +20442,7 @@
 	icon_state = "2-8"
 	},
 /turf/open/floor/plasteel/neutral/corner,
-/area/hallway/primary/central)
+/area/hallway/primary/starboard/aft)
 "aPy" = (
 /obj/structure/table,
 /obj/item/storage/briefcase,
@@ -20554,7 +20450,7 @@
 /turf/open/floor/plasteel/vault/side{
 	dir = 8
 	},
-/area/hallway/primary/central)
+/area/hallway/primary/starboard/aft)
 "aPz" = (
 /obj/effect/spawner/structure/window/reinforced/tinted,
 /turf/open/floor/plating,
@@ -20753,7 +20649,7 @@
 /turf/open/floor/plasteel/vault{
 	dir = 8
 	},
-/area/hallway/primary/central)
+/area/hallway/primary/port/aft)
 "aPX" = (
 /obj/item/twohanded/required/kirbyplants{
 	icon_state = "plant-21"
@@ -20769,7 +20665,7 @@
 	dir = 8;
 	heat_capacity = 1e+006
 	},
-/area/hallway/primary/central)
+/area/hallway/primary/port/aft)
 "aPY" = (
 /obj/machinery/atmospherics/pipe/manifold4w/scrubbers/hidden,
 /obj/machinery/navbeacon{
@@ -20780,7 +20676,7 @@
 	dir = 8;
 	heat_capacity = 1e+006
 	},
-/area/hallway/primary/central)
+/area/hallway/primary/port/aft)
 "aPZ" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
@@ -20793,7 +20689,7 @@
 	dir = 8;
 	heat_capacity = 1e+006
 	},
-/area/hallway/primary/central)
+/area/hallway/primary/port/aft)
 "aQa" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
@@ -20805,14 +20701,14 @@
 	dir = 8;
 	heat_capacity = 1e+006
 	},
-/area/hallway/primary/central)
+/area/hallway/primary/port/aft)
 "aQb" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden,
 /turf/open/floor/plasteel/neutral/corner{
 	dir = 8;
 	heat_capacity = 1e+006
 	},
-/area/hallway/primary/central)
+/area/hallway/primary/port/aft)
 "aQc" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -20825,7 +20721,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel,
-/area/hallway/primary/central)
+/area/hallway/primary/port/aft)
 "aQd" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
@@ -20834,7 +20730,7 @@
 	dir = 8;
 	heat_capacity = 1e+006
 	},
-/area/hallway/primary/central)
+/area/hallway/primary/port/aft)
 "aQe" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 1
@@ -20843,7 +20739,7 @@
 	dir = 8;
 	heat_capacity = 1e+006
 	},
-/area/hallway/primary/central)
+/area/hallway/primary/port/aft)
 "aQf" = (
 /obj/machinery/firealarm{
 	dir = 1;
@@ -20856,7 +20752,7 @@
 	dir = 8;
 	heat_capacity = 1e+006
 	},
-/area/hallway/primary/central)
+/area/hallway/primary/port/aft)
 "aQg" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
@@ -20985,7 +20881,7 @@
 "aQw" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden,
 /turf/open/floor/plasteel/purple/corner,
-/area/hallway/primary/central)
+/area/hallway/primary/starboard/aft)
 "aQx" = (
 /obj/machinery/firealarm{
 	dir = 1;
@@ -20996,7 +20892,7 @@
 	},
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/plasteel/neutral/corner,
-/area/hallway/primary/central)
+/area/hallway/primary/starboard/aft)
 "aQy" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -21006,7 +20902,7 @@
 	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel/neutral/corner,
-/area/hallway/primary/central)
+/area/hallway/primary/starboard/aft)
 "aQz" = (
 /obj/structure/sign/warning/securearea{
 	pixel_y = -32
@@ -21016,7 +20912,7 @@
 	dir = 9
 	},
 /turf/open/floor/plasteel/neutral/corner,
-/area/hallway/primary/central)
+/area/hallway/primary/starboard/aft)
 "aQA" = (
 /obj/item/twohanded/required/kirbyplants{
 	icon_state = "plant-21"
@@ -21032,7 +20928,7 @@
 /turf/open/floor/plasteel/vault/side{
 	dir = 8
 	},
-/area/hallway/primary/central)
+/area/hallway/primary/starboard/aft)
 "aQB" = (
 /obj/structure/table/wood,
 /obj/item/crowbar/red,
@@ -21303,7 +21199,7 @@
 "aRq" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plasteel/purple/corner,
-/area/hallway/primary/central)
+/area/hallway/primary/aft)
 "aRr" = (
 /turf/closed/wall/r_wall,
 /area/science/lab)
@@ -21767,7 +21663,7 @@
 	dir = 1
 	},
 /turf/open/floor/plasteel,
-/area/hallway/primary/central)
+/area/hallway/primary/aft)
 "aSu" = (
 /obj/structure/cable/white{
 	icon_state = "1-2"
@@ -22230,23 +22126,23 @@
 /turf/open/floor/plasteel/blue/corner{
 	dir = 1
 	},
-/area/hallway/primary/central)
+/area/hallway/primary/aft)
 "aTx" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/structure/cable/white{
 	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel/neutral,
-/area/hallway/primary/central)
+/area/hallway/primary/aft)
 "aTy" = (
 /obj/structure/table/wood,
 /obj/item/device/flashlight/lamp,
 /turf/open/floor/plasteel/grimy,
-/area/hallway/primary/central)
+/area/crew_quarters/lounge)
 "aTz" = (
 /obj/structure/chair/comfy/brown,
 /turf/open/floor/plasteel/grimy,
-/area/hallway/primary/central)
+/area/crew_quarters/lounge)
 "aTA" = (
 /obj/item/twohanded/required/kirbyplants{
 	icon_state = "plant-18"
@@ -22256,27 +22152,27 @@
 	dir = 2
 	},
 /turf/open/floor/plasteel/grimy,
-/area/hallway/primary/central)
+/area/crew_quarters/lounge)
 "aTB" = (
 /obj/structure/chair/comfy/brown,
 /obj/effect/landmark/start/assistant,
 /turf/open/floor/plasteel/grimy,
-/area/hallway/primary/central)
+/area/crew_quarters/lounge)
 "aTC" = (
 /obj/structure/table/wood,
 /obj/item/storage/fancy/donut_box,
 /turf/open/floor/plasteel/grimy,
-/area/hallway/primary/central)
+/area/crew_quarters/lounge)
 "aTD" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plasteel/neutral,
-/area/hallway/primary/central)
+/area/hallway/primary/aft)
 "aTE" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plasteel/purple/corner{
 	dir = 4
 	},
-/area/hallway/primary/central)
+/area/hallway/primary/aft)
 "aTF" = (
 /obj/structure/table/reinforced,
 /obj/machinery/door/firedoor,
@@ -22666,16 +22562,16 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel/grimy,
-/area/hallway/primary/central)
+/area/crew_quarters/lounge)
 "aUy" = (
 /turf/open/floor/carpet,
-/area/hallway/primary/central)
+/area/crew_quarters/lounge)
 "aUz" = (
 /obj/structure/chair/comfy/brown{
 	dir = 8
 	},
 /turf/open/floor/plasteel/grimy,
-/area/hallway/primary/central)
+/area/crew_quarters/lounge)
 "aUA" = (
 /obj/machinery/rnd/destructive_analyzer,
 /obj/effect/turf_decal/stripes/line{
@@ -23045,29 +22941,29 @@
 	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel/neutral,
-/area/hallway/primary/central)
+/area/hallway/primary/aft)
 "aVp" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 8
 	},
 /turf/open/floor/plasteel/grimy,
-/area/hallway/primary/central)
+/area/crew_quarters/lounge)
 "aVq" = (
 /obj/machinery/holopad,
 /turf/open/floor/carpet,
-/area/hallway/primary/central)
+/area/crew_quarters/lounge)
 "aVr" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 4
 	},
 /turf/open/floor/plasteel/grimy,
-/area/hallway/primary/central)
+/area/crew_quarters/lounge)
 "aVs" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 4
 	},
 /turf/open/floor/plasteel/neutral,
-/area/hallway/primary/central)
+/area/hallway/primary/aft)
 "aVt" = (
 /obj/machinery/computer/rdconsole/core{
 	dir = 4
@@ -23739,7 +23635,7 @@
 /obj/structure/table/wood,
 /obj/item/reagent_containers/food/snacks/chips,
 /turf/open/floor/plasteel/grimy,
-/area/hallway/primary/central)
+/area/crew_quarters/lounge)
 "aWQ" = (
 /obj/structure/chair/comfy/brown{
 	buildstackamount = 0;
@@ -23751,7 +23647,7 @@
 	pixel_y = -22
 	},
 /turf/open/floor/plasteel/grimy,
-/area/hallway/primary/central)
+/area/crew_quarters/lounge)
 "aWR" = (
 /obj/item/twohanded/required/kirbyplants{
 	icon_state = "plant-21";
@@ -23763,7 +23659,7 @@
 	pixel_y = -32
 	},
 /turf/open/floor/plasteel/grimy,
-/area/hallway/primary/central)
+/area/crew_quarters/lounge)
 "aWS" = (
 /obj/structure/chair/comfy/brown{
 	buildstackamount = 0;
@@ -23774,13 +23670,13 @@
 	pixel_y = -24
 	},
 /turf/open/floor/plasteel/grimy,
-/area/hallway/primary/central)
+/area/crew_quarters/lounge)
 "aWT" = (
 /obj/structure/table/wood,
 /obj/item/folder,
 /obj/item/pen,
 /turf/open/floor/plasteel/grimy,
-/area/hallway/primary/central)
+/area/crew_quarters/lounge)
 "aWU" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/research{
@@ -24031,7 +23927,7 @@
 /turf/open/floor/plasteel/neutral/side{
 	dir = 4
 	},
-/area/hallway/primary/central)
+/area/hallway/primary/aft)
 "aXx" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/research{
@@ -24380,7 +24276,7 @@
 /turf/open/floor/plasteel/blue/corner{
 	dir = 1
 	},
-/area/hallway/primary/central)
+/area/hallway/primary/aft)
 "aYb" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
@@ -24390,13 +24286,13 @@
 	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel/neutral,
-/area/hallway/primary/central)
+/area/hallway/primary/aft)
 "aYc" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
 /turf/open/floor/plasteel/neutral/side,
-/area/hallway/primary/central)
+/area/hallway/primary/aft)
 "aYd" = (
 /obj/machinery/light{
 	dir = 1
@@ -24405,7 +24301,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel/neutral/side,
-/area/hallway/primary/central)
+/area/hallway/primary/aft)
 "aYe" = (
 /obj/machinery/firealarm{
 	pixel_y = 24
@@ -24414,11 +24310,11 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel/neutral/side,
-/area/hallway/primary/central)
+/area/hallway/primary/aft)
 "aYf" = (
 /obj/machinery/atmospherics/pipe/manifold4w/scrubbers/hidden,
 /turf/open/floor/plasteel/neutral,
-/area/hallway/primary/central)
+/area/hallway/primary/aft)
 "aYg" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -24427,7 +24323,7 @@
 /turf/open/floor/plasteel/neutral/side{
 	dir = 4
 	},
-/area/hallway/primary/central)
+/area/hallway/primary/aft)
 "aYh" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/research{
@@ -24842,14 +24738,14 @@
 /turf/open/floor/plasteel/neutral/side{
 	dir = 8
 	},
-/area/hallway/primary/central)
+/area/hallway/primary/aft)
 "aYV" = (
 /obj/machinery/atmospherics/pipe/manifold4w/supply/hidden,
 /obj/structure/cable/white{
 	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel/neutral,
-/area/hallway/primary/central)
+/area/hallway/primary/aft)
 "aYW" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -24858,14 +24754,14 @@
 	dir = 1;
 	heat_capacity = 1e+006
 	},
-/area/hallway/primary/central)
+/area/hallway/primary/aft)
 "aYY" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plasteel/neutral,
-/area/hallway/primary/central)
+/area/hallway/primary/aft)
 "aYZ" = (
 /obj/structure/sign/warning/securearea{
 	pixel_x = 32
@@ -24874,7 +24770,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel/purple/corner,
-/area/hallway/primary/central)
+/area/hallway/primary/aft)
 "aZa" = (
 /turf/closed/wall/r_wall,
 /area/science/robotics/mechbay)
@@ -25268,7 +25164,7 @@
 /turf/open/floor/plasteel/neutral/side{
 	dir = 8
 	},
-/area/hallway/primary/central)
+/area/hallway/primary/aft)
 "aZR" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/structure/extinguisher_cabinet{
@@ -25284,7 +25180,7 @@
 	icon_state = "2-8"
 	},
 /turf/open/floor/plasteel/neutral,
-/area/hallway/primary/central)
+/area/hallway/primary/aft)
 "aZU" = (
 /obj/machinery/recharge_station,
 /obj/effect/landmark/start/cyborg,
@@ -25654,7 +25550,7 @@
 /turf/open/floor/plasteel/blue/corner{
 	dir = 8
 	},
-/area/hallway/primary/central)
+/area/hallway/primary/aft)
 "baH" = (
 /obj/machinery/light{
 	dir = 4
@@ -25668,7 +25564,7 @@
 	dir = 8
 	},
 /turf/open/floor/plasteel/neutral,
-/area/hallway/primary/central)
+/area/hallway/primary/aft)
 "baI" = (
 /obj/structure/filingcabinet/security,
 /obj/machinery/firealarm{
@@ -25710,12 +25606,12 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plasteel/neutral,
-/area/hallway/primary/central)
+/area/hallway/primary/aft)
 "baM" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/effect/turf_decal/stripes/corner,
 /turf/open/floor/plasteel,
-/area/hallway/primary/central)
+/area/hallway/primary/aft)
 "baN" = (
 /obj/machinery/firealarm{
 	dir = 8;
@@ -26019,7 +25915,7 @@
 /turf/open/floor/plasteel/blue/corner{
 	dir = 8
 	},
-/area/hallway/primary/central)
+/area/hallway/primary/aft)
 "bbw" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -26029,7 +25925,7 @@
 	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel/neutral,
-/area/hallway/primary/central)
+/area/hallway/primary/aft)
 "bbx" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/security/glass{
@@ -26102,7 +25998,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel,
-/area/hallway/primary/central)
+/area/hallway/primary/aft)
 "bbC" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -26443,7 +26339,7 @@
 	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel/neutral,
-/area/hallway/primary/central)
+/area/hallway/primary/aft)
 "bcm" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable/white{
@@ -26482,7 +26378,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel/neutral,
-/area/hallway/primary/central)
+/area/hallway/primary/aft)
 "bcr" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
 	dir = 4
@@ -26494,7 +26390,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel,
-/area/hallway/primary/central)
+/area/hallway/primary/aft)
 "bcs" = (
 /obj/machinery/door/poddoor/shutters{
 	id = "mechbay";
@@ -26860,7 +26756,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel,
-/area/hallway/primary/central)
+/area/hallway/primary/aft)
 "bdk" = (
 /obj/machinery/door/poddoor/shutters{
 	id = "mechbay";
@@ -27351,7 +27247,7 @@
 	dir = 8
 	},
 /turf/open/floor/plasteel,
-/area/hallway/primary/central)
+/area/hallway/primary/aft)
 "beg" = (
 /obj/item/device/radio/intercom{
 	name = "Station Intercom";
@@ -27670,7 +27566,7 @@
 	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel/purple/corner,
-/area/hallway/primary/central)
+/area/hallway/primary/aft)
 "beL" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
@@ -27842,7 +27738,7 @@
 /turf/open/floor/plasteel/blue/corner{
 	dir = 8
 	},
-/area/hallway/primary/central)
+/area/hallway/primary/aft)
 "bff" = (
 /obj/structure/cable/white{
 	icon_state = "1-2"
@@ -27871,7 +27767,7 @@
 	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel/purple/corner,
-/area/hallway/primary/central)
+/area/hallway/primary/aft)
 "bfl" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -28133,7 +28029,7 @@
 /turf/open/floor/plasteel/blue/corner{
 	dir = 8
 	},
-/area/hallway/primary/central)
+/area/hallway/primary/aft)
 "bfJ" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
 	dir = 8
@@ -28148,7 +28044,7 @@
 	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel/neutral,
-/area/hallway/primary/central)
+/area/hallway/primary/aft)
 "bfK" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -28157,7 +28053,7 @@
 	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel/neutral,
-/area/hallway/primary/central)
+/area/hallway/primary/aft)
 "bfL" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden,
 /obj/structure/cable/white{
@@ -28170,7 +28066,7 @@
 	icon_state = "1-4"
 	},
 /turf/open/floor/plasteel/neutral,
-/area/hallway/primary/central)
+/area/hallway/primary/aft)
 "bfO" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
 	dir = 4
@@ -28179,7 +28075,7 @@
 	icon_state = "1-8"
 	},
 /turf/open/floor/plasteel/purple/corner,
-/area/hallway/primary/central)
+/area/hallway/primary/aft)
 "bfP" = (
 /turf/closed/wall/r_wall,
 /area/science/xenobiology)
@@ -28385,7 +28281,7 @@
 	dir = 8;
 	heat_capacity = 1e+006
 	},
-/area/hallway/primary/central)
+/area/hallway/primary/aft)
 "bgf" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -28398,7 +28294,7 @@
 	dir = 8;
 	heat_capacity = 1e+006
 	},
-/area/hallway/primary/central)
+/area/hallway/primary/aft)
 "bgl" = (
 /obj/machinery/vending/cola/random,
 /obj/machinery/newscaster{
@@ -28408,7 +28304,7 @@
 /turf/open/floor/plasteel/vault/side{
 	dir = 8
 	},
-/area/hallway/primary/central)
+/area/hallway/primary/aft)
 "bgm" = (
 /turf/open/floor/plasteel/vault{
 	dir = 5
@@ -30374,7 +30270,7 @@
 /turf/open/floor/plasteel/neutral/corner{
 	dir = 1
 	},
-/area/hallway/primary/central)
+/area/hallway/primary/port/fore)
 "blg" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -30389,7 +30285,7 @@
 	dir = 1
 	},
 /turf/open/floor/plasteel,
-/area/hallway/primary/central)
+/area/hallway/primary/port/fore)
 "blh" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/structure/cable/white{
@@ -30400,7 +30296,7 @@
 	dir = 8
 	},
 /turf/open/floor/plasteel/neutral/corner,
-/area/hallway/primary/central)
+/area/hallway/primary/starboard/fore)
 "bli" = (
 /obj/structure/closet/firecloset,
 /obj/machinery/camera{
@@ -30411,7 +30307,7 @@
 /turf/open/floor/plasteel/vault/side{
 	dir = 8
 	},
-/area/hallway/primary/central)
+/area/hallway/primary/starboard/fore)
 "blj" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -30460,7 +30356,7 @@
 /turf/open/floor/plasteel/vault/side{
 	dir = 8
 	},
-/area/hallway/primary/central)
+/area/hallway/primary/starboard)
 "bln" = (
 /obj/structure/cable/white{
 	icon_state = "1-2"
@@ -30492,7 +30388,7 @@
 /turf/open/floor/plasteel/neutral/corner{
 	dir = 4
 	},
-/area/hallway/primary/central)
+/area/hallway/primary/starboard/aft)
 "blp" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/machinery/camera{
@@ -30538,7 +30434,7 @@
 	dir = 1;
 	heat_capacity = 1e+006
 	},
-/area/hallway/primary/central)
+/area/hallway/primary/aft)
 "blt" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -30825,7 +30721,7 @@
 /turf/open/floor/plasteel/neutral/corner{
 	dir = 4
 	},
-/area/hallway/primary/central)
+/area/hallway/primary/starboard)
 "bsA" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
@@ -30838,7 +30734,7 @@
 	location = "6.4-LeavingDepartures"
 	},
 /turf/open/floor/plasteel,
-/area/hallway/primary/central)
+/area/hallway/primary/starboard)
 "bsB" = (
 /obj/machinery/door/airlock/public/glass{
 	name = "Departure Lounge"
@@ -31444,7 +31340,7 @@
 /turf/open/floor/plasteel/neutral/corner{
 	dir = 1
 	},
-/area/hallway/primary/central)
+/area/hallway/primary/starboard/fore)
 "bxA" = (
 /obj/structure/cable/white{
 	icon_state = "1-4"
@@ -31482,7 +31378,7 @@
 /turf/open/floor/plasteel/red/corner{
 	dir = 1
 	},
-/area/hallway/primary/central)
+/area/hallway/primary/port)
 "bxE" = (
 /obj/structure/cable/white{
 	icon_state = "1-2"
@@ -31552,17 +31448,15 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/plasteel/neutral/corner,
-/area/hallway/primary/central)
+/area/hallway/primary/port)
 "bxQ" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
 /obj/effect/landmark/event_spawn,
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden,
 /turf/open/floor/plasteel/neutral/corner{
 	dir = 8;
 	heat_capacity = 1e+006
 	},
-/area/hallway/primary/central)
+/area/hallway/primary/port/aft)
 "bxR" = (
 /obj/structure/cable/white{
 	icon_state = "1-2"
@@ -31707,6 +31601,29 @@
 /obj/structure/sign/nanotrasen,
 /turf/closed/wall,
 /area/security/checkpoint)
+"bIJ" = (
+/obj/machinery/hydroponics/constructable,
+/obj/effect/turf_decal/stripes/line{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/turf/open/floor/plasteel,
+/area/hydroponics)
+"ccy" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/turf/open/floor/plasteel/neutral/corner{
+	dir = 1
+	},
+/area/hallway/primary/port)
+"cfz" = (
+/obj/machinery/hydroponics/constructable,
+/obj/effect/turf_decal/stripes/line{
+	dir = 10
+	},
+/turf/open/floor/plasteel,
+/area/hydroponics)
 "cmp" = (
 /obj/machinery/door/airlock/external{
 	name = "External Docking Port"
@@ -31723,10 +31640,6 @@
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
 "csX" = (
-/obj/machinery/door/airlock/maintenance_hatch{
-	name = "Maintenance Hatch";
-	req_access_txt = "12"
-	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/structure/cable/white{
 	icon_state = "1-2"
@@ -31737,11 +31650,13 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 1
+/obj/machinery/door/airlock/medical/glass{
+	name = "Hydroponics";
+	req_access_txt = "35"
 	},
-/turf/open/floor/plating,
-/area/maintenance/port/central)
+/obj/machinery/door/firedoor,
+/turf/open/floor/plasteel,
+/area/hydroponics)
 "cRz" = (
 /obj/machinery/button/door{
 	id = "supplybridge";
@@ -31766,6 +31681,16 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard)
+"cXu" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/structure/cable/white{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plasteel/neutral/corner{
+	dir = 8;
+	heat_capacity = 1e+006
+	},
+/area/hallway/primary/port)
 "dfP" = (
 /obj/machinery/door/airlock/maintenance_hatch{
 	name = "Maintenance Hatch";
@@ -31788,6 +31713,20 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
+"doD" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/machinery/door/firedoor,
+/obj/structure/cable/white{
+	icon_state = "1-2"
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 2
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/starboard)
 "dEa" = (
 /obj/machinery/computer/arcade,
 /turf/open/floor/plasteel/vault{
@@ -31797,6 +31736,22 @@
 "dWc" = (
 /turf/closed/mineral/random/labormineral,
 /area/space)
+"dYC" = (
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
+	dir = 1
+	},
+/turf/open/floor/plasteel/neutral/corner{
+	dir = 1
+	},
+/area/hallway/primary/fore)
+"ewT" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on{
+	dir = 8
+	},
+/turf/open/floor/plasteel/greenblue/side{
+	dir = 1
+	},
+/area/hydroponics)
 "exb" = (
 /obj/machinery/door/window/brigdoor{
 	dir = 8;
@@ -31824,6 +31779,37 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plasteel,
 /area/science/xenobiology)
+"eUz" = (
+/obj/machinery/door/firedoor,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/effect/turf_decal/stripes/line{
+	dir = 2
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/aft)
+"fgG" = (
+/obj/machinery/ai_status_display,
+/turf/closed/wall,
+/area/crew_quarters/lounge)
+"fMT" = (
+/obj/machinery/door/firedoor,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/structure/cable/white{
+	icon_state = "4-8"
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/starboard/aft)
 "fWz" = (
 /obj/machinery/door/airlock/external{
 	name = "External Docking Port";
@@ -31837,9 +31823,41 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit)
+"geZ" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/turf/open/floor/plasteel/neutral/corner,
+/area/hallway/primary/port)
+"gii" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/structure/cable/white{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plasteel/neutral,
+/area/hallway/primary/aft)
+"gjW" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/structure/cable/white{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plasteel/neutral/corner,
+/area/hallway/primary/starboard/aft)
 "glC" = (
 /turf/closed/wall/r_wall,
 /area/maintenance/starboard/aft)
+"gyV" = (
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
+	dir = 1
+	},
+/obj/structure/cable/white{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plasteel/neutral/corner{
+	dir = 4
+	},
+/area/hallway/primary/starboard/aft)
 "heQ" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/machinery/navbeacon{
@@ -31847,7 +31865,7 @@
 	location = "8.2-AftSE"
 	},
 /turf/open/floor/plasteel/neutral/corner,
-/area/hallway/primary/central)
+/area/hallway/primary/aft)
 "hpr" = (
 /obj/machinery/navbeacon{
 	codes_txt = "patrol;next_patrol=3.2-AtriumSW";
@@ -31874,10 +31892,16 @@
 /turf/open/floor/plasteel/red/corner{
 	dir = 1
 	},
-/area/hallway/primary/central)
+/area/hallway/primary/port/fore)
 "ibv" = (
 /turf/closed/wall,
 /area/science/xenobiology)
+"iML" = (
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
+	dir = 8
+	},
+/turf/open/floor/plasteel/neutral,
+/area/hallway/primary/aft)
 "iVw" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/structure/cable/white{
@@ -31902,7 +31926,7 @@
 	dir = 8;
 	heat_capacity = 1e+006
 	},
-/area/hallway/primary/central)
+/area/hallway/primary/fore)
 "jdD" = (
 /obj/structure/table/reinforced,
 /obj/machinery/button/door{
@@ -31913,6 +31937,28 @@
 /obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel,
 /area/science/xenobiology)
+"jqM" = (
+/obj/effect/turf_decal/bot,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/turf/open/floor/plasteel/vault/side{
+	dir = 8
+	},
+/area/hallway/primary/starboard)
+"jwi" = (
+/obj/structure/sign/directions/engineering{
+	dir = 8;
+	pixel_y = 8
+	},
+/obj/structure/sign/directions/security{
+	dir = 8
+	},
+/obj/structure/sign/directions/medical{
+	pixel_y = -8
+	},
+/turf/closed/wall,
+/area/hallway/primary/fore)
 "jBG" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/structure/cable/white{
@@ -31945,6 +31991,19 @@
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/miningdock)
+"lxq" = (
+/obj/structure/cable/white{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/turf/open/floor/plasteel/neutral/corner{
+	dir = 4
+	},
+/area/hallway/primary/port)
+"lyp" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on,
+/turf/open/floor/plasteel/greenblue/side,
+/area/hydroponics)
 "lCg" = (
 /obj/machinery/door/airlock/external{
 	name = "Supply Dock Airlock";
@@ -31961,6 +32020,74 @@
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/storage)
+"lEr" = (
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
+	dir = 4
+	},
+/turf/open/floor/plasteel/neutral/corner,
+/area/hallway/primary/aft)
+"lFi" = (
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
+/area/hallway/primary/starboard/aft)
+"lIM" = (
+/turf/closed/wall/rust,
+/area/crew_quarters/lounge)
+"lQs" = (
+/obj/machinery/door/firedoor,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/starboard/aft)
+"lXk" = (
+/obj/structure/closet/firecloset,
+/obj/effect/turf_decal/delivery,
+/turf/open/floor/plasteel/vault/side{
+	dir = 8
+	},
+/area/hallway/primary/aft)
+"lZR" = (
+/turf/open/floor/plasteel/neutral/corner{
+	dir = 8;
+	heat_capacity = 1e+006
+	},
+/area/hallway/primary/fore)
+"mJQ" = (
+/obj/structure/table/glass,
+/obj/effect/turf_decal/delivery,
+/obj/item/book/manual/hydroponics_pod_people,
+/obj/item/paper/guides/jobs/hydroponics,
+/turf/open/floor/plasteel/neutral,
+/area/hydroponics)
+"mQi" = (
+/turf/closed/wall/rust,
+/area/maintenance/starboard/central)
+"mXV" = (
+/obj/structure/cable/white{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/turf/open/floor/plasteel/neutral/corner{
+	dir = 4
+	},
+/area/hallway/primary/starboard)
+"ndg" = (
+/turf/open/floor/plasteel/neutral/corner,
+/area/hallway/primary/fore)
+"nwY" = (
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
+/area/hallway/primary/starboard/fore)
+"nxA" = (
+/turf/closed/wall,
+/area/hallway/primary/port/aft)
 "nKi" = (
 /obj/machinery/door/airlock/maintenance_hatch{
 	name = "Maintenance Hatch";
@@ -31987,6 +32114,18 @@
 /obj/structure/sign/warning/biohazard,
 /turf/closed/wall,
 /area/science/xenobiology)
+"oyD" = (
+/turf/closed/wall,
+/area/crew_quarters/toilet/restrooms)
+"oQL" = (
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
+	dir = 1
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on{
+	dir = 1
+	},
+/turf/open/floor/plasteel/neutral/corner,
+/area/hallway/primary/starboard/aft)
 "plz" = (
 /obj/effect/turf_decal/stripes/end{
 	dir = 4
@@ -32028,6 +32167,38 @@
 	dir = 8
 	},
 /area/science/xenobiology)
+"qdt" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 5
+	},
+/obj/structure/reagent_dispensers/watertank/high,
+/turf/open/floor/plasteel/greenblue/side{
+	dir = 9
+	},
+/area/hydroponics)
+"qdD" = (
+/obj/machinery/holopad,
+/obj/effect/turf_decal/bot,
+/turf/open/floor/plasteel,
+/area/hallway/primary/fore)
+"rlq" = (
+/obj/machinery/door/firedoor,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/structure/cable/white{
+	icon_state = "1-2"
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 2
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/aft)
+"rzn" = (
+/obj/machinery/status_display,
+/turf/closed/wall,
+/area/hallway/primary/starboard)
 "rCw" = (
 /obj/machinery/door/window/brigdoor{
 	dir = 4;
@@ -32048,11 +32219,32 @@
 	dir = 8
 	},
 /area/science/xenobiology)
+"sak" = (
+/obj/effect/landmark/event_spawn,
+/turf/open/floor/plasteel/greenblue/side{
+	dir = 1
+	},
+/area/hydroponics)
 "sdL" = (
 /obj/effect/turf_decal/delivery,
 /obj/machinery/hydroponics/soil,
 /turf/open/floor/plasteel/vault/side,
 /area/maintenance/starboard/aft)
+"soC" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/structure/cable/white{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plasteel/neutral/corner{
+	dir = 4
+	},
+/area/hallway/primary/starboard/aft)
+"sqz" = (
+/turf/closed/wall,
+/area/hallway/primary/starboard)
 "sws" = (
 /obj/docking_port/stationary{
 	dheight = 1;
@@ -32164,7 +32356,7 @@
 /area/quartermaster/miningdock)
 "syS" = (
 /turf/closed/wall/rust,
-/area/hallway/primary/central)
+/area/crew_quarters/toilet/restrooms)
 "syT" = (
 /turf/closed/wall/r_wall/rust,
 /area/ai_monitored/storage/eva)
@@ -32338,6 +32530,10 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard)
+"sEG" = (
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
+/area/crew_quarters/lounge)
 "sEJ" = (
 /obj/structure/cable/white{
 	icon_state = "1-2"
@@ -32346,7 +32542,7 @@
 	dir = 8
 	},
 /turf/open/floor/plasteel/neutral/corner,
-/area/hallway/primary/central)
+/area/hallway/primary/starboard/fore)
 "sEK" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -32476,6 +32672,10 @@
 /obj/item/circuitboard/computer/secure_data{
 	pixel_x = -3;
 	pixel_y = -3
+	},
+/obj/item/circuitboard/machine/smoke_machine{
+	pixel_x = -4;
+	pixel_y = -4
 	},
 /turf/open/floor/plasteel/vault/side{
 	dir = 4
@@ -32650,7 +32850,7 @@
 /turf/open/floor/plasteel/vault/side{
 	dir = 8
 	},
-/area/hallway/primary/central)
+/area/hallway/primary/starboard)
 "sHB" = (
 /turf/open/floor/plasteel/escape{
 	dir = 8
@@ -32865,7 +33065,7 @@
 /turf/open/floor/plasteel/neutral/corner{
 	dir = 4
 	},
-/area/hallway/primary/central)
+/area/hallway/primary/starboard)
 "sJc" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden,
 /turf/open/floor/plating{
@@ -32975,15 +33175,6 @@
 	},
 /turf/closed/wall,
 /area/maintenance/starboard)
-"sJx" = (
-/obj/structure/sink{
-	dir = 4;
-	pixel_x = 12
-	},
-/turf/open/floor/plasteel/vault/side{
-	dir = 1
-	},
-/area/hydroponics)
 "sJy" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/closed/wall/r_wall/rust,
@@ -33013,14 +33204,14 @@
 /turf/open/floor/plasteel/vault/side{
 	dir = 1
 	},
-/area/hallway/primary/central)
+/area/hallway/primary/port/aft)
 "sJK" = (
 /obj/structure/closet/crate/bin,
 /obj/effect/turf_decal/delivery,
 /turf/open/floor/plasteel/vault/side{
 	dir = 1
 	},
-/area/hallway/primary/central)
+/area/hallway/primary/port/aft)
 "sJL" = (
 /turf/closed/wall/r_wall,
 /area/science/research)
@@ -34366,7 +34557,7 @@
 	icon_state = "1-4"
 	},
 /turf/open/floor/plasteel/neutral/corner,
-/area/hallway/primary/central)
+/area/hallway/primary/starboard/fore)
 "sOJ" = (
 /obj/structure/cable/white{
 	icon_state = "0-8"
@@ -34507,6 +34698,50 @@
 "sPY" = (
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
+"tKM" = (
+/turf/closed/wall,
+/area/hallway/primary/fore)
+"tLt" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/structure/cable/white{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plasteel/neutral/corner,
+/area/hallway/primary/starboard)
+"tWh" = (
+/turf/closed/wall,
+/area/crew_quarters/lounge)
+"ugK" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/turf/open/floor/plasteel/neutral/corner,
+/area/hallway/primary/aft)
+"uqY" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/turf/open/floor/plasteel/neutral/corner{
+	dir = 8;
+	heat_capacity = 1e+006
+	},
+/area/hallway/primary/starboard)
+"uuj" = (
+/obj/machinery/plantgenes,
+/obj/effect/turf_decal/bot,
+/turf/open/floor/plasteel/neutral,
+/area/hydroponics)
+"uuU" = (
+/obj/machinery/status_display,
+/turf/closed/wall,
+/area/crew_quarters/lounge)
+"uuX" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/turf/open/floor/plasteel/neutral/corner{
+	dir = 8;
+	heat_capacity = 1e+006
+	},
+/area/hallway/primary/aft)
 "uxJ" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/public/glass{
@@ -34535,6 +34770,23 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit)
+"uGq" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/turf/open/floor/plasteel/red/corner{
+	dir = 1
+	},
+/area/hallway/primary/port)
+"vkK" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/machinery/door/firedoor,
+/obj/effect/turf_decal/stripes/line{
+	dir = 2
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/starboard)
 "voi" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
@@ -34551,6 +34803,33 @@
 	dir = 5
 	},
 /area/science/xenobiology)
+"vsL" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/structure/cable/white{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plasteel/blue/corner{
+	dir = 1
+	},
+/area/hallway/primary/port/aft)
+"vWg" = (
+/obj/structure/cable/white{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/machinery/door/firedoor,
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/starboard/fore)
 "wbV" = (
 /obj/effect/turf_decal/delivery,
 /obj/machinery/hydroponics/soil,
@@ -34558,6 +34837,18 @@
 	dir = 1
 	},
 /area/maintenance/starboard/aft)
+"wdt" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/structure/cable/white{
+	icon_state = "4-8"
+	},
+/obj/effect/turf_decal/bot,
+/turf/open/floor/plasteel/vault/side{
+	dir = 8
+	},
+/area/hallway/primary/aft)
 "wUF" = (
 /obj/machinery/door/airlock/atmos/glass{
 	name = "Supermatter Chamber";
@@ -34568,6 +34859,10 @@
 	},
 /turf/open/floor/engine,
 /area/engine/supermatter)
+"xwu" = (
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
+/area/engine/break_room)
 "xFw" = (
 /obj/structure/sign/departments/xenobio,
 /turf/closed/wall,
@@ -34592,6 +34887,14 @@
 	dir = 8
 	},
 /area/science/xenobiology)
+"yeO" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/turf/open/floor/plasteel/yellow/corner{
+	dir = 8
+	},
+/area/hallway/primary/port/aft)
 
 (1,1,1) = {"
 aaa
@@ -69655,10 +69958,10 @@ azz
 aAB
 aBJ
 aqz
-anQ
+xwu
 aEH
 aFI
-anQ
+xwu
 aEt
 aIy
 aJH
@@ -69913,7 +70216,7 @@ ays
 aqz
 aqz
 aDC
-ajh
+ccy
 aFJ
 aGv
 aHB
@@ -70174,10 +70477,10 @@ aEI
 aFK
 aGw
 aHC
-aIz
-aIz
-aIz
-aIz
+cXu
+cXu
+cXu
+cXu
 aNh
 awO
 aOP
@@ -70425,16 +70728,16 @@ axC
 axC
 aAC
 aBL
-aCM
-aCM
+geZ
+geZ
 aEJ
 aFL
 aGx
 aHD
 aIA
-aCM
+geZ
 bxP
-aCM
+geZ
 aNi
 anH
 aOQ
@@ -70927,8 +71230,8 @@ akc
 blg
 aoB
 apG
-akc
-akc
+uGq
+uGq
 bxD
 atM
 auR
@@ -71182,10 +71485,10 @@ alc
 alS
 alc
 anI
-alc
+lxq
 apH
 aqS
-alc
+lxq
 asT
 atN
 auS
@@ -71436,10 +71739,10 @@ aiw
 ajf
 ake
 ald
-abt
+oyD
 syS
-abt
-abt
+oyD
+oyD
 apI
 apI
 arP
@@ -71692,7 +71995,7 @@ ahE
 aiu
 ajg
 akf
-abt
+oyD
 alT
 amO
 anJ
@@ -71952,8 +72255,8 @@ akg
 ale
 alU
 amP
-abt
-abt
+oyD
+oyD
 sAc
 aqU
 arR
@@ -71971,8 +72274,8 @@ awQ
 awQ
 awQ
 awQ
-aGC
-aGK
+arY
+awe
 sIK
 aIB
 aIB
@@ -72229,13 +72532,13 @@ aDG
 aEO
 sDl
 aGD
-aHK
+aHM
 aIE
-atc
+qdt
 aKT
 aMi
 aNn
-awe
+aHM
 aOX
 aQe
 aRe
@@ -72463,10 +72766,10 @@ ahG
 aix
 ajj
 aki
-abt
+oyD
 alW
 amR
-abt
+oyD
 syS
 apI
 aqW
@@ -72491,11 +72794,11 @@ aIF
 aJM
 aKU
 aMj
-aNo
+aNt
 csX
 aOY
 aQf
-abt
+nxA
 aSh
 aSh
 aUn
@@ -72720,7 +73023,7 @@ swC
 abw
 ajk
 akj
-abt
+oyD
 alX
 amS
 anJ
@@ -72743,13 +73046,13 @@ awQ
 awQ
 awQ
 bxN
-aHM
-aHM
 sIB
-aHM
-aHM
-aHM
-aHM
+cfz
+ewT
+mJQ
+lyp
+bIJ
+aOj
 aOZ
 bxQ
 sJJ
@@ -73002,10 +73305,10 @@ sDl
 arY
 aHM
 aIG
-aJN
-aKV
+aJP
+aKX
 aMk
-aNp
+aNr
 aHM
 aPa
 aQb
@@ -73259,12 +73562,12 @@ awQ
 aGG
 aHM
 aIH
-aJO
+aJP
 aKW
-aMl
-sJx
+aMk
+aNr
 aOh
-aPb
+vsL
 aQd
 sJK
 aSi
@@ -73516,8 +73819,8 @@ awQ
 arY
 sIB
 aII
-aJP
-aKX
+sak
+uuj
 aMm
 aNq
 aHM
@@ -73778,8 +74081,8 @@ aKY
 aMn
 aNr
 aOh
-aPb
-aQg
+vsL
+yeO
 aRg
 aSj
 aTq
@@ -75290,10 +75593,10 @@ aak
 aak
 ajq
 jcn
-all
+jwi
 ame
 ame
-abt
+tKM
 aoL
 arY
 sAA
@@ -75323,7 +75626,7 @@ aOh
 aPb
 aQl
 aRk
-anH
+eUz
 aTw
 aTw
 aTw
@@ -75550,7 +75853,7 @@ akt
 alm
 amf
 amZ
-abt
+tKM
 aoM
 apS
 ara
@@ -75580,7 +75883,7 @@ all
 aPi
 aQm
 aIz
-awO
+rlq
 aTx
 aTx
 aVo
@@ -75802,11 +76105,11 @@ afr
 agY
 agi
 adO
-aji
+dYC
 aku
 aln
-amg
-amg
+lZR
+lZR
 anQ
 aoN
 apT
@@ -75837,13 +76140,13 @@ aOm
 aPj
 aQn
 amg
-aIZ
+fgG
 aTy
 aUx
 aVp
 aUx
 aWP
-aDc
+uuU
 aYc
 aYW
 byo
@@ -75855,7 +76158,7 @@ beb
 byo
 bys
 bfK
-aQd
+uuX
 bgT
 bhG
 bxY
@@ -76094,13 +76397,13 @@ aOn
 aPk
 aQo
 amg
-anQ
+sEG
 aTz
 aUy
 aUy
 aUy
 aWQ
-abt
+tWh
 aYc
 aYW
 sKB
@@ -76112,7 +76415,7 @@ bec
 beH
 byo
 bfK
-aQd
+uuX
 bgU
 bhH
 bix
@@ -76319,7 +76622,7 @@ aiA
 ajt
 akw
 alp
-ami
+qdD
 anb
 anS
 aoP
@@ -76351,13 +76654,13 @@ aOo
 aPl
 aQp
 ami
-anQ
+sEG
 aTA
 aUy
 aVq
 aUy
 aWR
-abt
+tWh
 aYd
 bls
 byq
@@ -76608,13 +76911,13 @@ aOp
 aPm
 aQq
 amk
-anQ
+sEG
 aTB
 aUy
 aUy
 aUy
 aWS
-syS
+lIM
 aYe
 aYW
 byo
@@ -76626,7 +76929,7 @@ bee
 beJ
 byo
 bfK
-avV
+ugK
 bgU
 bhH
 bix
@@ -76833,8 +77136,8 @@ sOD
 ajv
 aky
 alr
-amk
-amk
+ndg
+ndg
 anQ
 aoR
 apX
@@ -76865,13 +77168,13 @@ aOq
 aPn
 aQr
 amk
-aDc
+uuU
 aTC
 aUz
 aVr
 aUz
 aWT
-aIZ
+fgG
 aYc
 aYW
 bys
@@ -76883,7 +77186,7 @@ byo
 sKB
 byo
 bfK
-avV
+ugK
 bgV
 bhG
 biw
@@ -77092,7 +77395,7 @@ akz
 als
 aml
 and
-abt
+tKM
 aoS
 apY
 ara
@@ -77122,7 +77425,7 @@ aOr
 aPo
 aQs
 aCM
-anH
+eUz
 aTD
 aTD
 aVs
@@ -77135,12 +77438,12 @@ aTD
 baL
 aTD
 bcq
-aED
+iML
 aTD
-aED
+iML
 aTD
-aFG
-aGx
+gii
+lEr
 bgR
 bhJ
 biy
@@ -77349,7 +77652,7 @@ akA
 alt
 amm
 amm
-abt
+tKM
 aoT
 apZ
 ara
@@ -77652,8 +77955,8 @@ bcs
 bdk
 aZa
 beL
-aHE
-ayV
+wdt
+lXk
 bgl
 bgX
 bhL
@@ -78116,7 +78419,7 @@ abs
 ahY
 ahY
 ajA
-akq
+vWg
 alu
 amn
 ane
@@ -78661,8 +78964,8 @@ aLj
 aCe
 aNB
 ayP
-aPd
-aQc
+fMT
+lQs
 aRr
 aSx
 aTJ
@@ -78918,7 +79221,7 @@ aLk
 aCf
 aNC
 aOt
-aOQ
+soC
 aQw
 aRs
 aSy
@@ -79666,31 +79969,31 @@ alu
 alu
 alu
 alu
-abt
-abt
-abt
-abt
-syS
-abt
-abt
-abt
+ayP
+ayP
+ayP
+ayP
+mQi
+ayP
+ayP
+ayP
 azS
-aAY
-abt
-abt
-abt
-abt
-abt
-abt
-syS
-abt
-abt
-abt
-abt
-abt
-abt
-aPp
-avU
+apY
+ayP
+ayP
+ayP
+ayP
+ayP
+ayP
+mQi
+ayP
+ayP
+ayP
+ayP
+ayP
+ayP
+gyV
+oQL
 aRv
 aSB
 aTN
@@ -79943,9 +80246,9 @@ aly
 aIX
 aly
 aLm
-aqh
+uqY
 aNF
-ank
+vkK
 aPw
 aQz
 sJL
@@ -80193,18 +80496,18 @@ aBa
 aBa
 anl
 aDZ
-alc
+mXV
 aFY
 bsz
 aDZ
 aIY
 aDZ
 sJa
-arj
-arj
-anl
+tLt
+tLt
+doD
 aPx
-arj
+gjW
 aRx
 sOT
 aTP
@@ -80435,7 +80738,7 @@ ado
 adp
 aob
 apb
-anQ
+nwY
 sOF
 sOG
 atq
@@ -80456,10 +80759,10 @@ bsA
 aHY
 aIZ
 blm
-azU
+jqM
 aMy
 aHY
-aDc
+rzn
 aPy
 aQA
 sOM
@@ -80715,10 +81018,10 @@ aRz
 aRz
 sOL
 aRz
-abt
-abt
-anQ
-anQ
+sqz
+sqz
+lFi
+lFi
 sON
 aSE
 sOV

--- a/_maps/map_files/OmegaStation/OmegaStation.dmm
+++ b/_maps/map_files/OmegaStation/OmegaStation.dmm
@@ -5275,6 +5275,10 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/stripes/line,
+/obj/machinery/navbeacon{
+	codes_txt = "patrol;next_patrol=2.2-BridgeWest";
+	location = "2.1-Teleporter"
+	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "akp" = (
@@ -5448,6 +5452,10 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
+/obj/machinery/navbeacon{
+	codes_txt = "patrol;next_patrol=4.2-HoP";
+	location = "4.1-BridgeEast"
+	},
 /turf/open/floor/plasteel/neutral/corner,
 /area/hallway/primary/central)
 "akB" = (
@@ -5561,6 +5569,11 @@
 	},
 /obj/structure/cable/white{
 	icon_state = "4-8"
+	},
+/obj/machinery/navbeacon{
+	codes_txt = "patrol;next_patrol=5.1-EnteringCargo";
+	location = "4.2-HoP";
+	name = "Billy Herrington memorial navigation beacon"
 	},
 /turf/open/floor/plasteel/neutral/corner,
 /area/hallway/primary/central)
@@ -7234,6 +7247,10 @@
 /obj/structure/cable/white{
 	icon_state = "1-2"
 	},
+/obj/machinery/navbeacon{
+	codes_txt = "patrol;next_patrol=5.2-Cargo";
+	location = "5.1-EnteringCargo"
+	},
 /turf/open/floor/plasteel/brown/corner{
 	dir = 4
 	},
@@ -7787,6 +7804,10 @@
 /obj/structure/cable/white{
 	icon_state = "2-4"
 	},
+/obj/machinery/navbeacon{
+	codes_txt = "patrol;next_patrol=5.3-Starboard";
+	location = "5.3-LeavingCargo"
+	},
 /turf/open/floor/plasteel/brown/corner,
 /area/hallway/primary/central)
 "apb" = (
@@ -7839,6 +7860,10 @@
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden,
 /obj/structure/cable/white{
 	icon_state = "4-8"
+	},
+/obj/machinery/navbeacon{
+	codes_txt = "patrol;next_patrol=5.3-LeavingCargo";
+	location = "5.2-Cargo"
 	},
 /turf/open/floor/plasteel/brown/corner,
 /area/hallway/primary/central)
@@ -13392,6 +13417,10 @@
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 8
 	},
+/obj/machinery/navbeacon{
+	codes_txt = "patrol;next_patrol=1.1-BrigCentral";
+	location = "9.6-LeavingDorms"
+	},
 /turf/open/floor/plasteel/neutral/corner{
 	dir = 4
 	},
@@ -13923,6 +13952,10 @@
 /obj/structure/cable/white{
 	icon_state = "4-8"
 	},
+/obj/machinery/navbeacon{
+	codes_txt = "patrol;next_patrol=9.5-Dorms";
+	location = "9.4-EnteringDorms"
+	},
 /turf/open/floor/plasteel/neutral/corner,
 /area/hallway/primary/central)
 "aBM" = (
@@ -13990,6 +14023,10 @@
 	},
 /obj/structure/cable/white{
 	icon_state = "0-8"
+	},
+/obj/machinery/navbeacon{
+	codes_txt = "patrol;next_patrol=9.6-LeavingDorms";
+	location = "9.5-Dorms"
 	},
 /turf/open/floor/plasteel/neutral/corner,
 /area/crew_quarters/dorms)
@@ -15054,6 +15091,10 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
+/obj/machinery/navbeacon{
+	codes_txt = "patrol;next_patrol=6.3-DeparturesS";
+	location = "6.2-DeparturesN"
+	},
 /turf/open/floor/plasteel/neutral,
 /area/hallway/secondary/exit)
 "aEf" = (
@@ -15554,6 +15595,10 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
+/obj/machinery/navbeacon{
+	codes_txt = "patrol;next_patrol=6.2-DeparturesN";
+	location = "6.1-EnteringDepartures"
+	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "aFk" = (
@@ -15758,6 +15803,10 @@
 /obj/structure/cable/white{
 	icon_state = "4-8"
 	},
+/obj/machinery/navbeacon{
+	codes_txt = "patrol;next_patrol=9.4-EnteringDorms";
+	location = "9.3-Engi"
+	},
 /turf/open/floor/plasteel/neutral,
 /area/hallway/primary/central)
 "aFF" = (
@@ -15829,6 +15878,10 @@
 	},
 /obj/structure/cable/white{
 	icon_state = "2-8"
+	},
+/obj/machinery/navbeacon{
+	codes_txt = "patrol;next_patrol=9.3-Engi";
+	location = "9.2-EnteringEngi"
 	},
 /turf/open/floor/plasteel/neutral/corner{
 	dir = 8;
@@ -18558,6 +18611,10 @@
 	pixel_x = -32;
 	pixel_y = -32
 	},
+/obj/machinery/navbeacon{
+	codes_txt = "patrol;next_patrol=3.3-AtriumSE";
+	location = "3.2-AtriumSW"
+	},
 /turf/open/floor/plasteel/redyellow,
 /area/crew_quarters/bar/atrium)
 "aLg" = (
@@ -20712,6 +20769,10 @@
 /area/hallway/primary/central)
 "aPY" = (
 /obj/machinery/atmospherics/pipe/manifold4w/scrubbers/hidden,
+/obj/machinery/navbeacon{
+	codes_txt = "patrol;next_patrol=9.2-EnteringEngi";
+	location = "9.1-Library"
+	},
 /turf/open/floor/plasteel/neutral/corner{
 	dir = 8;
 	heat_capacity = 1e+006
@@ -21227,6 +21288,10 @@
 /obj/machinery/camera{
 	c_tag = "Aft Primary Hallway 2";
 	dir = 4
+	},
+/obj/machinery/navbeacon{
+	codes_txt = "patrol;next_patrol=9.1-Library";
+	location = "8.4-AftNW"
 	},
 /turf/open/floor/plasteel/yellow/corner{
 	dir = 8
@@ -28303,6 +28368,10 @@
 	name = "Station Intercom";
 	pixel_x = -26
 	},
+/obj/machinery/navbeacon{
+	codes_txt = "patrol;next_patrol=8.4-AftNW";
+	location = "8.3-AftSW"
+	},
 /turf/open/floor/plasteel/neutral/corner{
 	dir = 8;
 	heat_capacity = 1e+006
@@ -30475,6 +30544,10 @@
 	dir = 8;
 	pixel_y = -22
 	},
+/obj/machinery/navbeacon{
+	codes_txt = "patrol;next_patrol=8.2-AftSE";
+	location = "8.1-AftNE"
+	},
 /turf/open/floor/plasteel/purple/corner,
 /area/hallway/primary/central)
 "blq" = (
@@ -30804,6 +30877,10 @@
 /obj/structure/cable/white{
 	icon_state = "4-8"
 	},
+/obj/machinery/navbeacon{
+	codes_txt = "patrol;next_patrol=7.1-StarboardQuarter";
+	location = "6.4-LeavingDepartures"
+	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "bsB" = (
@@ -30946,6 +31023,10 @@
 	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
+	},
+/obj/machinery/navbeacon{
+	codes_txt = "patrol;next_patrol=6.4-LeavingDepartures";
+	location = "6.3-DeparturesS"
 	},
 /turf/open/floor/plasteel/neutral,
 /area/hallway/secondary/exit)
@@ -31242,6 +31323,13 @@
 /obj/item/pickaxe/emergency,
 /turf/open/floor/plating/asteroid/airless,
 /area/asteroid/nearstation)
+"bvV" = (
+/obj/machinery/navbeacon{
+	codes_txt = "patrol;next_patrol=4.1-BridgeEast";
+	location = "3.4-AtriumNE"
+	},
+/turf/open/floor/plasteel/redyellow,
+/area/crew_quarters/bar/atrium)
 "bwz" = (
 /obj/docking_port/stationary{
 	dir = 8;
@@ -31757,14 +31845,55 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit)
+"heQ" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/machinery/navbeacon{
+	codes_txt = "patrol;next_patrol=8.3-AftSW";
+	location = "8.2-AftSE"
+	},
+/turf/open/floor/plasteel/neutral/corner,
+/area/hallway/primary/central)
+"hpr" = (
+/obj/machinery/navbeacon{
+	codes_txt = "patrol;next_patrol=3.2-AtriumSW";
+	location = "3.1-AtriumNW"
+	},
+/turf/open/floor/plasteel/redyellow,
+/area/crew_quarters/bar/atrium)
+"hDi" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/machinery/navbeacon{
+	codes_txt = "patrol;next_patrol=3.4-AtriumNE";
+	location = "3.3-AtriumSE"
+	},
+/turf/open/floor/plasteel/redyellow,
+/area/crew_quarters/bar/atrium)
 "iaa" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/machinery/navbeacon{
-	codes_txt = "patrol;next_patrol=1.1-BrigCentral";
+	codes_txt = "patrol;next_patrol=2.1-Teleporter";
 	location = "1.2-BrigNorth"
 	},
 /turf/open/floor/plasteel/red/corner{
 	dir = 1
+	},
+/area/hallway/primary/central)
+"jcn" = (
+/obj/structure/cable/white{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/machinery/navbeacon{
+	codes_txt = "patrol;next_patrol=3.1-AtriumNW";
+	location = "2.2-BridgeWest"
+	},
+/turf/open/floor/plasteel/neutral/corner{
+	dir = 8;
+	heat_capacity = 1e+006
 	},
 /area/hallway/primary/central)
 "kKd" = (
@@ -34303,6 +34432,16 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit)
+"voi" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/machinery/navbeacon{
+	codes_txt = "patrol;next_patrol=8.1-AftNE";
+	location = "7.1-StarboardQuarter"
+	},
+/turf/open/floor/plasteel/purple/corner,
+/area/hallway/primary/central)
 "wUF" = (
 /obj/machinery/door/airlock/atmos/glass{
 	name = "Supermatter Chamber";
@@ -75010,7 +75149,7 @@ swv
 aak
 aak
 ajq
-ake
+jcn
 all
 ame
 ame
@@ -75533,7 +75672,7 @@ aoN
 apT
 arb
 ase
-asg
+hpr
 asg
 asg
 asg
@@ -76561,7 +76700,7 @@ aoR
 apX
 arf
 asi
-asg
+bvV
 asg
 avi
 awn
@@ -76579,7 +76718,7 @@ asg
 asg
 asg
 ayL
-avi
+hDi
 aAR
 arf
 aOq
@@ -77118,7 +77257,7 @@ bef
 beK
 bfg
 bfO
-anc
+heQ
 bgW
 bhK
 biz
@@ -78126,7 +78265,7 @@ aCe
 asp
 ayP
 aPt
-aQv
+voi
 aRs
 aSw
 aTI

--- a/_maps/map_files/OmegaStation/OmegaStation.dmm
+++ b/_maps/map_files/OmegaStation/OmegaStation.dmm
@@ -9553,6 +9553,10 @@
 /obj/machinery/atmospherics/components/unary/thermomachine/freezer{
 	dir = 8
 	},
+/obj/machinery/camera{
+	c_tag = "Atmospherics North East";
+	dir = 8
+	},
 /turf/open/floor/plasteel/caution{
 	dir = 5
 	},
@@ -11434,12 +11438,6 @@
 /turf/open/floor/plasteel/caution{
 	dir = 4
 	},
-/area/engine/atmos)
-"awL" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/turf/closed/wall/r_wall,
 /area/engine/atmos)
 "awM" = (
 /obj/structure/cable/white{
@@ -15094,8 +15092,9 @@
 	dir = 4
 	},
 /obj/machinery/portable_atmospherics/pump,
-/obj/machinery/newscaster{
-	pixel_x = -32
+/obj/machinery/airalarm/unlocked{
+	dir = 4;
+	pixel_x = -23
 	},
 /turf/open/floor/plasteel/arrival{
 	dir = 8
@@ -19393,6 +19392,9 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
+/obj/machinery/airalarm{
+	pixel_y = 24
+	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/port/aft)
 "aOV" = (
@@ -19513,9 +19515,6 @@
 	},
 /obj/machinery/camera{
 	c_tag = "Aft Primary Hallway 3"
-	},
-/obj/machinery/status_display{
-	pixel_y = 32
 	},
 /turf/open/floor/plasteel/green/corner{
 	dir = 1
@@ -19744,7 +19743,7 @@
 /turf/open/floor/plasteel/neutral/corner{
 	dir = 4
 	},
-/area/hallway/primary/starboard/aft)
+/area/hallway/primary/starboard)
 "aPw" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -19756,7 +19755,7 @@
 /turf/open/floor/plasteel/neutral/corner{
 	dir = 1
 	},
-/area/hallway/primary/starboard/aft)
+/area/hallway/primary/starboard)
 "aPx" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
 	dir = 4
@@ -19768,7 +19767,7 @@
 	icon_state = "2-8"
 	},
 /turf/open/floor/plasteel/neutral/corner,
-/area/hallway/primary/starboard/aft)
+/area/hallway/primary/starboard)
 "aPy" = (
 /obj/structure/table,
 /obj/item/storage/briefcase,
@@ -19776,7 +19775,7 @@
 /turf/open/floor/plasteel/vault/side{
 	dir = 8
 	},
-/area/hallway/primary/starboard/aft)
+/area/hallway/primary/starboard)
 "aPz" = (
 /obj/effect/spawner/structure/window/reinforced/tinted,
 /turf/open/floor/plating,
@@ -20207,7 +20206,7 @@
 "aQw" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden,
 /turf/open/floor/plasteel/purple/corner,
-/area/hallway/primary/starboard/aft)
+/area/hallway/primary/starboard)
 "aQx" = (
 /obj/machinery/firealarm{
 	dir = 1;
@@ -20218,7 +20217,7 @@
 	},
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/plasteel/neutral/corner,
-/area/hallway/primary/starboard/aft)
+/area/hallway/primary/starboard)
 "aQy" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -20228,7 +20227,7 @@
 	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel/neutral/corner,
-/area/hallway/primary/starboard/aft)
+/area/hallway/primary/starboard)
 "aQz" = (
 /obj/structure/sign/warning/securearea{
 	pixel_y = -32
@@ -20238,7 +20237,7 @@
 	dir = 9
 	},
 /turf/open/floor/plasteel/neutral/corner,
-/area/hallway/primary/starboard/aft)
+/area/hallway/primary/starboard)
 "aQA" = (
 /obj/item/twohanded/required/kirbyplants{
 	icon_state = "plant-21"
@@ -20254,7 +20253,7 @@
 /turf/open/floor/plasteel/vault/side{
 	dir = 8
 	},
-/area/hallway/primary/starboard/aft)
+/area/hallway/primary/starboard)
 "aQB" = (
 /obj/structure/table/wood,
 /obj/item/crowbar/red,
@@ -27680,11 +27679,6 @@
 /turf/open/floor/plasteel,
 /area/science/xenobiology)
 "bgt" = (
-/obj/machinery/camera{
-	c_tag = "Xenobiology Test Chamber";
-	dir = 2;
-	network = list("xeno","rd")
-	},
 /turf/open/floor/plasteel/vault{
 	dir = 4
 	},
@@ -28727,6 +28721,11 @@
 /obj/effect/turf_decal/stripes/end{
 	dir = 8
 	},
+/obj/machinery/camera{
+	c_tag = "Xenobiology Central";
+	dir = 4;
+	pixel_y = -5
+	},
 /turf/open/floor/plasteel,
 /area/science/xenobiology)
 "biD" = (
@@ -29346,6 +29345,10 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
+/obj/machinery/camera{
+	c_tag = "Xenobiology South";
+	dir = 1
+	},
 /turf/open/floor/plasteel,
 /area/science/xenobiology)
 "bjR" = (
@@ -29722,7 +29725,7 @@
 /turf/open/floor/plasteel/neutral/corner{
 	dir = 4
 	},
-/area/hallway/primary/starboard/aft)
+/area/hallway/primary/starboard)
 "blp" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/machinery/camera{
@@ -29780,16 +29783,6 @@
 	},
 /turf/open/floor/plasteel/neutral,
 /area/medical/medbay/zone3)
-"blu" = (
-/obj/machinery/camera{
-	c_tag = "Xenobiology Test Chamber";
-	dir = 2;
-	network = list("xeno","rd")
-	},
-/turf/open/floor/plasteel/vault{
-	dir = 5
-	},
-/area/science/xenobiology)
 "blv" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -31006,6 +30999,9 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 10
 	},
+/obj/machinery/light{
+	dir = 1
+	},
 /turf/open/floor/plasteel,
 /area/hydroponics)
 "chJ" = (
@@ -31092,6 +31088,10 @@
 /obj/machinery/firealarm{
 	dir = 1;
 	pixel_y = -26
+	},
+/obj/machinery/camera{
+	c_tag = "Atmospherics South West";
+	dir = 1
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos)
@@ -31331,6 +31331,11 @@
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/machinery/camera{
+	c_tag = "Xenobiology North";
+	dir = 4;
+	pixel_y = -5
+	},
 /turf/open/floor/plasteel,
 /area/science/xenobiology)
 "eOs" = (
@@ -31400,6 +31405,10 @@
 	dir = 4
 	},
 /obj/effect/decal/cleanable/dirt,
+/obj/machinery/camera{
+	c_tag = "Atmospherics Central";
+	dir = 1
+	},
 /turf/open/floor/plasteel/vault{
 	dir = 5
 	},
@@ -31484,7 +31493,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel,
-/area/hallway/primary/starboard/aft)
+/area/hallway/primary/starboard)
 "fSE" = (
 /turf/closed/wall/r_wall,
 /area/space)
@@ -31533,13 +31542,6 @@
 	},
 /turf/open/floor/plasteel/neutral,
 /area/hallway/primary/aft)
-"gjW" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/structure/cable/white{
-	icon_state = "1-2"
-	},
-/turf/open/floor/plasteel/neutral/corner,
-/area/hallway/primary/starboard/aft)
 "glC" = (
 /turf/closed/wall/r_wall,
 /area/maintenance/starboard/aft)
@@ -31566,7 +31568,7 @@
 /turf/open/floor/plasteel/neutral/corner{
 	dir = 4
 	},
-/area/hallway/primary/starboard/aft)
+/area/hallway/primary/starboard)
 "gNH" = (
 /obj/machinery/atmospherics/pipe/simple/general/visible{
 	dir = 4
@@ -32017,6 +32019,10 @@
 	name = "Station Intercom";
 	pixel_y = 24
 	},
+/obj/machinery/camera{
+	c_tag = "Atmospherics North West";
+	dir = 4
+	},
 /turf/open/floor/plasteel/caution{
 	dir = 9
 	},
@@ -32046,7 +32052,7 @@
 "lFi" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
-/area/hallway/primary/starboard/aft)
+/area/hallway/primary/starboard)
 "lFw" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/visible,
 /turf/open/floor/plating/asteroid/airless,
@@ -32066,7 +32072,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel,
-/area/hallway/primary/starboard/aft)
+/area/hallway/primary/starboard)
 "lUu" = (
 /obj/machinery/portable_atmospherics/canister/air,
 /turf/open/floor/engine/air,
@@ -32339,7 +32345,7 @@
 	dir = 1
 	},
 /turf/open/floor/plasteel/neutral/corner,
-/area/hallway/primary/starboard/aft)
+/area/hallway/primary/starboard)
 "pbT" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 10
@@ -32673,7 +32679,7 @@
 /turf/open/floor/plasteel/neutral/corner{
 	dir = 4
 	},
-/area/hallway/primary/starboard/aft)
+/area/hallway/primary/starboard)
 "sqz" = (
 /turf/closed/wall,
 /area/hallway/primary/starboard)
@@ -68324,7 +68330,7 @@ aqz
 hsV
 auC
 aqz
-awL
+aqz
 axq
 cBf
 diG
@@ -79414,15 +79420,15 @@ beh
 sKP
 sOV
 bfP
-blu
+bgm
 bgY
 bgm
 ibv
-blu
+bgm
 bgY
 bgm
 ibv
-blu
+bgm
 bgY
 bgm
 bfP
@@ -81450,7 +81456,7 @@ tLt
 tLt
 doD
 aPx
-gjW
+tLt
 aRx
 sOT
 aTP

--- a/_maps/map_files/OmegaStation/OmegaStation.dmm
+++ b/_maps/map_files/OmegaStation/OmegaStation.dmm
@@ -9944,17 +9944,17 @@
 /turf/open/floor/plasteel/neutral,
 /area/engine/atmos)
 "atI" = (
-/obj/machinery/power/apc{
-	dir = 4;
-	name = "Atmospherics Engine APC";
-	areastring = "/area/engine/atmos";
-	pixel_x = 26
-	},
 /obj/structure/cable/white{
 	icon_state = "0-2"
 	},
 /obj/structure/closet/wardrobe/atmospherics_yellow,
 /obj/effect/turf_decal/bot,
+/obj/machinery/power/apc/highcap/ten_k{
+	areastring = "/area/engine/atmos";
+	dir = 4;
+	name = "Atmospherics APC";
+	pixel_x = 26
+	},
 /turf/open/floor/plasteel/caution{
 	dir = 4
 	},
@@ -11341,6 +11341,9 @@
 /obj/item/clothing/gloves/color/black,
 /obj/item/clothing/suit/hazardvest,
 /obj/item/clothing/mask/gas,
+/obj/structure/cable/white{
+	icon_state = "1-2"
+	},
 /turf/open/floor/plasteel,
 /area/engine/atmos)
 "awL" = (
@@ -12667,7 +12670,6 @@
 /turf/open/floor/plasteel/neutral,
 /area/engine/atmos)
 "aAq" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/visible,
 /obj/effect/landmark/start/atmospheric_technician,
 /obj/structure/cable/white{
 	icon_state = "1-4"
@@ -13931,14 +13933,16 @@
 /area/space)
 "aDr" = (
 /obj/structure/sign/warning/nosmoking,
-/obj/machinery/atmospherics/pipe/simple/cyan/visible{
-	dir = 4
+/obj/machinery/atmospherics/pipe/simple/cyan/hidden{
+	icon_state = "intact";
+	dir = 8
 	},
 /turf/closed/wall/r_wall,
 /area/engine/atmos)
 "aDs" = (
 /obj/structure/sign/warning/fire,
-/obj/machinery/atmospherics/pipe/simple/cyan/visible{
+/obj/machinery/atmospherics/pipe/simple/cyan/hidden{
+	icon_state = "intact";
 	dir = 9
 	},
 /turf/closed/wall/r_wall,
@@ -29363,7 +29367,8 @@
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
 "bko" = (
-/obj/machinery/atmospherics/pipe/simple/cyan/visible{
+/obj/machinery/atmospherics/pipe/simple/cyan/hidden{
+	icon_state = "intact";
 	dir = 10
 	},
 /turf/closed/wall/r_wall,
@@ -30861,7 +30866,7 @@
 /turf/open/floor/plasteel,
 /area/hydroponics)
 "ckn" = (
-/obj/machinery/atmospherics/pipe/simple/cyan/visible,
+/obj/machinery/atmospherics/pipe/simple/cyan/hidden,
 /turf/closed/wall/r_wall,
 /area/asteroid/nearstation)
 "cmp" = (
@@ -30881,7 +30886,7 @@
 /area/hallway/secondary/entry)
 "coQ" = (
 /obj/machinery/atmospherics/components/unary/outlet_injector/on{
-	volume_rate = 200
+	volume_rate = 50
 	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 10
@@ -30965,7 +30970,7 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard)
 "cWv" = (
-/obj/machinery/atmospherics/pipe/simple/cyan/visible,
+/obj/machinery/atmospherics/pipe/simple/cyan/hidden,
 /turf/closed/wall/r_wall,
 /area/engine/atmos)
 "cWR" = (
@@ -31050,8 +31055,9 @@
 /area/engine/atmos)
 "dIu" = (
 /obj/structure/grille,
-/obj/machinery/atmospherics/pipe/simple/cyan/visible{
-	dir = 4
+/obj/machinery/atmospherics/pipe/simple/cyan/hidden{
+	icon_state = "intact";
+	dir = 8
 	},
 /turf/closed/wall/r_wall,
 /area/asteroid/nearstation)
@@ -31221,7 +31227,8 @@
 /turf/open/floor/engine,
 /area/asteroid/nearstation)
 "fEM" = (
-/obj/machinery/atmospherics/pipe/simple/cyan/visible{
+/obj/machinery/atmospherics/pipe/simple/cyan/hidden{
+	icon_state = "intact";
 	dir = 6
 	},
 /turf/closed/wall/r_wall,
@@ -31342,8 +31349,9 @@
 	},
 /area/asteroid/nearstation)
 "gUJ" = (
-/obj/machinery/atmospherics/pipe/simple/cyan/visible{
-	dir = 4
+/obj/machinery/atmospherics/pipe/simple/cyan/hidden{
+	icon_state = "intact";
+	dir = 8
 	},
 /turf/closed/wall/r_wall,
 /area/asteroid/nearstation)
@@ -31383,7 +31391,8 @@
 /turf/open/floor/plasteel/redyellow,
 /area/crew_quarters/bar/atrium)
 "hNO" = (
-/obj/machinery/atmospherics/pipe/simple/cyan/visible{
+/obj/machinery/atmospherics/pipe/simple/cyan/hidden{
+	icon_state = "intact";
 	dir = 5
 	},
 /turf/closed/wall/r_wall,
@@ -31561,8 +31570,9 @@
 /turf/open/floor/plasteel/neutral,
 /area/asteroid/nearstation)
 "jDd" = (
-/obj/machinery/atmospherics/pipe/simple/cyan/visible{
-	dir = 4
+/obj/machinery/atmospherics/pipe/simple/cyan/hidden{
+	icon_state = "intact";
+	dir = 8
 	},
 /turf/closed/wall/r_wall/rust,
 /area/engine/atmos)
@@ -32014,8 +32024,9 @@
 /area/science/xenobiology)
 "pNE" = (
 /obj/structure/grille,
-/obj/machinery/atmospherics/pipe/simple/cyan/visible{
-	dir = 4
+/obj/machinery/atmospherics/pipe/simple/cyan/hidden{
+	icon_state = "intact";
+	dir = 8
 	},
 /turf/closed/wall/r_wall,
 /area/engine/atmos)
@@ -34747,8 +34758,9 @@
 /turf/open/space/basic,
 /area/asteroid/nearstation)
 "uok" = (
-/obj/machinery/atmospherics/pipe/simple/cyan/visible{
-	dir = 4
+/obj/machinery/atmospherics/pipe/simple/cyan/hidden{
+	icon_state = "intact";
+	dir = 8
 	},
 /turf/closed/wall/r_wall,
 /area/engine/atmos)
@@ -34791,7 +34803,7 @@
 	},
 /area/hallway/primary/aft)
 "uvg" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/visible,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/closed/wall/r_wall,
 /area/asteroid/nearstation)
 "uxJ" = (
@@ -34854,10 +34866,10 @@
 	},
 /obj/machinery/computer/atmos_control/tank{
 	dir = 2;
-	input_tag = "no2_in";
+	input_tag = "n2o_in";
 	name = "Nitrogen Dioxide Supply Control";
-	output_tag = "no2_out";
-	sensors = list("no2_sensor" = "Tank")
+	output_tag = "n2o_out";
+	sensors = list("n2o_sensor" = "Tank")
 	},
 /turf/open/floor/plasteel/vault{
 	dir = 5

--- a/_maps/map_files/OmegaStation/OmegaStation.dmm
+++ b/_maps/map_files/OmegaStation/OmegaStation.dmm
@@ -8961,7 +8961,8 @@
 "arr" = (
 /obj/machinery/atmospherics/components/trinary/filter/flipped{
 	dir = 8;
-	filter_type = "n2o"
+	filter_type = "n2o";
+	on = 1
 	},
 /turf/open/floor/plasteel/vault{
 	dir = 5
@@ -8976,6 +8977,13 @@
 	},
 /area/engine/atmos)
 "arw" = (
+/obj/machinery/computer/atmos_control/tank{
+	dir = 2;
+	input_tag = "mix_in";
+	name = "Mix Tank Supply Control";
+	output_tag = "mix_out";
+	sensors = list("mix_sensor" = "Tank")
+	},
 /turf/open/floor/plasteel/vault{
 	dir = 5
 	},
@@ -9490,10 +9498,6 @@
 /obj/machinery/atmospherics/pipe/simple/yellow/visible{
 	dir = 10
 	},
-/turf/open/floor/plasteel/neutral,
-/area/engine/atmos)
-"asD" = (
-/obj/machinery/computer/atmos_control/tank,
 /turf/open/floor/plasteel/neutral,
 /area/engine/atmos)
 "asF" = (
@@ -10343,16 +10347,8 @@
 /obj/machinery/atmospherics/components/binary/pump,
 /turf/open/floor/plasteel/neutral,
 /area/engine/atmos)
-"auy" = (
-/obj/machinery/atmospherics/pipe/simple/general/visible{
-	dir = 9
-	},
-/turf/open/floor/plasteel/neutral,
-/area/engine/atmos)
 "auA" = (
-/obj/machinery/atmospherics/pipe/manifold/supply/visible{
-	dir = 8
-	},
+/obj/machinery/atmospherics/pipe/manifold4w/supply/visible,
 /turf/open/floor/plasteel/neutral,
 /area/engine/atmos)
 "auB" = (
@@ -10796,14 +10792,19 @@
 "avx" = (
 /obj/machinery/atmospherics/pipe/simple/yellow/visible,
 /obj/machinery/computer/atmos_control/tank{
-	dir = 1
+	dir = 1;
+	input_tag = "o2_in";
+	name = "Oxygen Supply Control";
+	output_tag = "o2_out";
+	sensors = list("o2_sensor" = "Tank")
 	},
 /turf/open/floor/plasteel/neutral,
 /area/engine/atmos)
 "avy" = (
 /obj/machinery/atmospherics/components/trinary/filter/flipped{
 	dir = 4;
-	filter_type = "o2"
+	filter_type = "o2";
+	on = 1
 	},
 /turf/open/floor/plasteel/neutral,
 /area/engine/atmos)
@@ -11887,6 +11888,9 @@
 /area/engine/atmos)
 "ayi" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/visible,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
 /turf/open/floor/plasteel/neutral,
 /area/engine/atmos)
 "ayj" = (
@@ -11898,6 +11902,9 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
 	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "2-8"
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos)
@@ -12275,19 +12282,11 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/hallway/secondary/exit)
-"azk" = (
-/obj/machinery/atmospherics/pipe/simple/green/visible{
-	dir = 4
-	},
-/obj/machinery/atmospherics/components/binary/pump{
-	dir = 1
-	},
-/turf/open/floor/plasteel/neutral,
-/area/engine/atmos)
 "azl" = (
 /obj/machinery/atmospherics/components/trinary/filter/flipped{
 	dir = 4;
-	filter_type = "n2"
+	filter_type = "n2";
+	on = 1
 	},
 /turf/open/floor/plasteel/neutral,
 /area/engine/atmos)
@@ -30833,13 +30832,6 @@
 	},
 /turf/open/floor/plasteel/neutral,
 /area/engine/atmos)
-"bTZ" = (
-/obj/machinery/computer/atmos_control/tank,
-/obj/machinery/atmospherics/pipe/simple/yellow/visible{
-	dir = 4
-	},
-/turf/open/floor/plasteel/neutral,
-/area/engine/atmos)
 "bYE" = (
 /obj/structure/sign/warning/fire,
 /obj/machinery/atmospherics/pipe/simple/general/visible{
@@ -30888,7 +30880,9 @@
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
 "coQ" = (
-/obj/machinery/atmospherics/components/unary/outlet_injector/on,
+/obj/machinery/atmospherics/components/unary/outlet_injector/on{
+	volume_rate = 200
+	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 10
 	},
@@ -30924,6 +30918,16 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel,
+/area/engine/atmos)
+"cBS" = (
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/visible{
+	dir = 8;
+	name = "scrubbers pipe"
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plasteel/neutral,
 /area/engine/atmos)
 "cCp" = (
 /obj/machinery/door/poddoor{
@@ -31035,9 +31039,12 @@
 	},
 /area/maintenance/port)
 "dFV" = (
-/obj/machinery/atmospherics/pipe/simple/yellow/visible,
 /obj/machinery/atmospherics/pipe/simple/green/visible{
 	dir = 4
+	},
+/obj/machinery/atmospherics/components/binary/pump{
+	dir = 1;
+	on = 1
 	},
 /turf/open/floor/plasteel/neutral,
 /area/engine/atmos)
@@ -31066,12 +31073,30 @@
 	dir = 1
 	},
 /area/hallway/primary/fore)
-"eva" = (
-/obj/machinery/computer/atmos_control/tank{
-	dir = 1
+"eaf" = (
+/obj/machinery/atmospherics/pipe/simple/yellow/visible,
+/obj/structure/cable{
+	icon_state = "4-8"
 	},
+/turf/open/floor/plasteel/neutral,
+/area/engine/atmos)
+"eew" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plasteel/neutral,
+/area/asteroid/nearstation)
+"eva" = (
 /obj/machinery/atmospherics/pipe/simple/green/visible{
 	dir = 4
+	},
+/obj/machinery/computer/atmos_control/tank{
+	dir = 1;
+	input_tag = "airmix_in";
+	name = "Airmix Supply Control";
+	output_tag = "airmix_out";
+	sensors = list("airmix_sensor" = "Tank")
 	},
 /turf/open/floor/plasteel/neutral,
 /area/asteroid/nearstation)
@@ -31122,7 +31147,11 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/yellow/visible,
 /obj/machinery/computer/atmos_control/tank{
-	dir = 1
+	dir = 1;
+	input_tag = "n2_in";
+	name = "Nitrogen Supply Control";
+	output_tag = "n2_out";
+	sensors = list("n2_sensor" = "Tank")
 	},
 /turf/open/floor/plasteel/neutral,
 /area/engine/atmos)
@@ -31133,10 +31162,6 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plasteel,
 /area/science/xenobiology)
-"eUr" = (
-/obj/machinery/computer/atmos_control/tank,
-/turf/open/floor/plasteel/neutral,
-/area/asteroid/nearstation)
 "eUz" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -31285,6 +31310,9 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/cyan/visible,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
 /turf/open/floor/plasteel/neutral,
 /area/asteroid/nearstation)
 "gyV" = (
@@ -31322,7 +31350,8 @@
 "gVX" = (
 /obj/machinery/atmospherics/components/trinary/filter/flipped{
 	dir = 8;
-	filter_type = "co2"
+	filter_type = "co2";
+	on = 1
 	},
 /turf/open/floor/plasteel/vault{
 	dir = 5
@@ -31389,9 +31418,25 @@
 	},
 /turf/open/floor/engine/vacuum,
 /area/asteroid/nearstation)
+"iHo" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plasteel/neutral,
+/area/asteroid/nearstation)
 "iIj" = (
 /obj/machinery/atmospherics/components/trinary/mixer/flipped{
-	dir = 4
+	dir = 4;
+	node1_concentration = 0.8;
+	node2_concentration = 0.2;
+	on = 1
+	},
+/turf/open/floor/plasteel/neutral,
+/area/engine/atmos)
+"iJY" = (
+/obj/machinery/atmospherics/pipe/simple/cyan/visible,
+/obj/structure/cable{
+	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel/neutral,
 /area/engine/atmos)
@@ -31530,12 +31575,30 @@
 	dir = 10
 	},
 /obj/machinery/atmospherics/pipe/simple/general/visible,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
 /turf/open/floor/plasteel,
 /area/asteroid/nearstation)
 "kqe" = (
 /obj/structure/lattice/catwalk,
 /turf/open/space,
 /area/space)
+"kHA" = (
+/obj/machinery/atmospherics/pipe/simple/green/visible{
+	dir = 4
+	},
+/obj/machinery/computer/atmos_control/tank{
+	dir = 2;
+	input_tag = "co2_in";
+	name = "Carbox Dioxide Supply Control";
+	output_tag = "co2_out";
+	sensors = list("co2_sensor" = "Tank")
+	},
+/turf/open/floor/plasteel/vault{
+	dir = 5
+	},
+/area/asteroid/nearstation)
 "kKd" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/external{
@@ -31717,6 +31780,9 @@
 /obj/machinery/atmospherics/pipe/manifold/cyan/visible{
 	dir = 1
 	},
+/obj/structure/cable{
+	icon_state = "2-4"
+	},
 /turf/open/floor/plasteel/neutral,
 /area/asteroid/nearstation)
 "mTM" = (
@@ -31800,6 +31866,13 @@
 "oiL" = (
 /turf/open/floor/plasteel/neutral,
 /area/engine/atmos)
+"orI" = (
+/obj/machinery/atmospherics/pipe/simple/cyan/visible,
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/turf/open/floor/plasteel/neutral,
+/area/asteroid/nearstation)
 "otn" = (
 /obj/machinery/atmospherics/pipe/simple/green/visible{
 	dir = 6
@@ -31827,6 +31900,13 @@
 "oyD" = (
 /turf/closed/wall,
 /area/crew_quarters/toilet/restrooms)
+"oCy" = (
+/obj/machinery/atmospherics/pipe/simple/cyan/visible,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plasteel/neutral,
+/area/asteroid/nearstation)
 "oIG" = (
 /obj/structure/sign/warning/fire,
 /turf/closed/wall/r_wall,
@@ -32070,6 +32150,9 @@
 "rEx" = (
 /obj/machinery/atmospherics/pipe/simple/cyan/visible{
 	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel/neutral,
 /area/asteroid/nearstation)
@@ -34739,6 +34822,12 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit)
+"uyJ" = (
+/obj/machinery/atmospherics/components/binary/pump{
+	dir = 4
+	},
+/turf/open/floor/plasteel/neutral,
+/area/engine/atmos)
 "uBJ" = (
 /obj/effect/turf_decal/bot_white/right,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -34759,6 +34848,21 @@
 	},
 /turf/open/floor/plasteel/neutral,
 /area/engine/atmos)
+"viy" = (
+/obj/machinery/atmospherics/pipe/simple/green/visible{
+	dir = 4
+	},
+/obj/machinery/computer/atmos_control/tank{
+	dir = 2;
+	input_tag = "no2_in";
+	name = "Nitrogen Dioxide Supply Control";
+	output_tag = "no2_out";
+	sensors = list("no2_sensor" = "Tank")
+	},
+/turf/open/floor/plasteel/vault{
+	dir = 5
+	},
+/area/engine/atmos)
 "vkK" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/machinery/door/firedoor,
@@ -34770,6 +34874,21 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
+"vmU" = (
+/obj/machinery/atmospherics/pipe/simple/green/visible{
+	dir = 4
+	},
+/obj/machinery/computer/atmos_control/tank{
+	dir = 2;
+	input_tag = "plasma_in";
+	name = "Plasma Supply Control";
+	output_tag = "plasma_out";
+	sensors = list("plasma_sensor" = "Tank")
+	},
+/turf/open/floor/plasteel/vault{
+	dir = 5
+	},
+/area/engine/atmos)
 "voi" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
@@ -34783,6 +34902,9 @@
 "vpz" = (
 /obj/machinery/atmospherics/pipe/manifold/cyan/visible{
 	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel/neutral,
 /area/asteroid/nearstation)
@@ -34945,6 +35067,15 @@
 	dir = 8
 	},
 /area/asteroid/nearstation)
+"xsS" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plasteel/neutral,
+/area/engine/atmos)
 "xtL" = (
 /obj/machinery/embedded_controller/radio/airlock_controller{
 	name = "Incinerator Access Console";
@@ -35000,7 +35131,8 @@
 "xEQ" = (
 /obj/machinery/atmospherics/components/trinary/filter/flipped{
 	dir = 8;
-	filter_type = "plasma"
+	filter_type = "plasma";
+	on = 1
 	},
 /turf/open/floor/plasteel/vault{
 	dir = 5
@@ -35043,6 +35175,12 @@
 	},
 /turf/open/floor/engine,
 /area/asteroid/nearstation)
+"yba" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plasteel/neutral,
+/area/engine/atmos)
 "yeE" = (
 /obj/machinery/door/window/brigdoor{
 	dir = 4;
@@ -62434,7 +62572,7 @@ jpv
 bGL
 vuN
 jkl
-cGz
+eew
 cGz
 qUW
 ahu
@@ -62691,7 +62829,7 @@ uuJ
 kTz
 iKp
 tgp
-lAs
+iHo
 lAs
 skz
 pEH
@@ -62947,8 +63085,8 @@ lAs
 lAs
 mTv
 guM
-jpv
-jpv
+oCy
+orI
 jpv
 hNO
 aad
@@ -63195,8 +63333,8 @@ dIu
 hOh
 iqC
 xCL
-ymj
-eUr
+kHA
+lAs
 mTT
 mTT
 lBr
@@ -63716,7 +63854,7 @@ mIv
 lBr
 toY
 lAs
-lAs
+iHo
 eva
 xCL
 qsc
@@ -63973,7 +64111,7 @@ mae
 xeu
 bKQ
 aAn
-awF
+iJY
 uSs
 xIm
 mgs
@@ -64223,14 +64361,14 @@ dIu
 kit
 ddI
 xCL
-awC
-bTZ
+vmU
+bKQ
 oiL
 mae
 xeu
 bKQ
 aAp
-oiL
+yba
 vVA
 aqz
 aqz
@@ -64487,7 +64625,7 @@ auq
 xeu
 bKQ
 iIj
-qoT
+iJY
 dFV
 aAh
 aBp
@@ -64744,7 +64882,7 @@ auq
 xeu
 asx
 aty
-azm
+eaf
 avx
 aAi
 axi
@@ -65001,7 +65139,7 @@ auq
 xeu
 bKQ
 aAp
-oiL
+yba
 avy
 aAj
 blk
@@ -65251,14 +65389,14 @@ dIu
 gap
 fnp
 aqA
-awC
-bTZ
+viy
+bKQ
 oiL
 mae
 xeu
 bKQ
 aAp
-oiL
+yba
 vVA
 aqz
 aqz
@@ -65515,8 +65653,8 @@ mae
 xeu
 bKQ
 auv
-awF
-azk
+iJY
+dFV
 aAh
 aBr
 asv
@@ -65772,7 +65910,7 @@ mae
 xeu
 asC
 qoT
-azm
+eaf
 eCg
 aAi
 atx
@@ -66029,7 +66167,7 @@ auq
 xeu
 oiL
 oiL
-oiL
+yba
 azl
 aAj
 aBt
@@ -66280,13 +66418,13 @@ aor
 apv
 aqA
 arw
-asD
+oiL
 oiL
 mae
 xeu
 oiL
 oiL
-oiL
+yba
 xeu
 aqz
 aqz
@@ -66539,11 +66677,11 @@ aqE
 arx
 azm
 auw
-auy
+auq
 xeu
 oiL
 axm
-ayh
+cBS
 awJ
 ayh
 axo
@@ -66796,11 +66934,11 @@ aqF
 ary
 asF
 tWQ
-oiL
+uyJ
 avE
 awI
 oiL
-xeu
+xsS
 oiL
 avE
 axo

--- a/_maps/map_files/OmegaStation/OmegaStation.dmm
+++ b/_maps/map_files/OmegaStation/OmegaStation.dmm
@@ -7805,7 +7805,7 @@
 	icon_state = "2-4"
 	},
 /obj/machinery/navbeacon{
-	codes_txt = "patrol;next_patrol=5.3-Starboard";
+	codes_txt = "patrol;next_patrol=6.1-EnteringDepartures";
 	location = "5.3-LeavingCargo"
 	},
 /turf/open/floor/plasteel/brown/corner,

--- a/_maps/map_files/OmegaStation/OmegaStation.dmm
+++ b/_maps/map_files/OmegaStation/OmegaStation.dmm
@@ -13659,10 +13659,12 @@
 /area/hallway/secondary/exit)
 "aCs" = (
 /obj/machinery/portable_atmospherics/canister/oxygen,
+/obj/machinery/light/small,
 /turf/open/floor/engine/o2,
 /area/engine/atmos)
 "aCw" = (
 /obj/machinery/portable_atmospherics/canister/nitrogen,
+/obj/machinery/light/small,
 /turf/open/floor/engine/n2,
 /area/engine/atmos)
 "aCz" = (
@@ -31497,6 +31499,9 @@
 /area/engine/atmos)
 "gap" = (
 /obj/machinery/portable_atmospherics/canister/nitrous_oxide,
+/obj/machinery/light/small{
+	dir = 1
+	},
 /turf/open/floor/engine/n2o,
 /area/engine/atmos)
 "gdA" = (
@@ -31618,6 +31623,9 @@
 /area/engine/atmos)
 "hOh" = (
 /obj/machinery/portable_atmospherics/canister/carbon_dioxide,
+/obj/machinery/light/small{
+	dir = 1
+	},
 /turf/open/floor/engine/co2,
 /area/engine/atmos)
 "hUG" = (
@@ -31883,6 +31891,9 @@
 /area/engine/atmos)
 "kit" = (
 /obj/machinery/portable_atmospherics/canister/toxins,
+/obj/machinery/light/small{
+	dir = 1
+	},
 /turf/open/floor/engine/plasma,
 /area/engine/atmos)
 "kiw" = (
@@ -32047,6 +32058,7 @@
 /area/hallway/primary/starboard)
 "lUu" = (
 /obj/machinery/portable_atmospherics/canister/air,
+/obj/machinery/light/small,
 /turf/open/floor/engine/air,
 /area/engine/atmos)
 "lXk" = (

--- a/_maps/map_files/OmegaStation/OmegaStation.dmm
+++ b/_maps/map_files/OmegaStation/OmegaStation.dmm
@@ -17307,8 +17307,7 @@
 	},
 /obj/machinery/camera{
 	c_tag = "Kitchen Coldroom";
-	dir = 4;
-	network = list("mine")
+	dir = 4
 	},
 /turf/open/floor/plasteel/freezer,
 /area/crew_quarters/kitchen)
@@ -27765,8 +27764,7 @@
 	},
 /obj/machinery/camera{
 	c_tag = "Crematorium";
-	dir = 4;
-	network = list("mine")
+	dir = 4
 	},
 /turf/open/floor/plasteel/vault/side{
 	dir = 4
@@ -29663,11 +29661,6 @@
 "bll" = (
 /obj/structure/chair{
 	dir = 8
-	},
-/obj/machinery/camera{
-	c_tag = "Shuttle Docking Foyer";
-	dir = 8;
-	network = list("mine")
 	},
 /obj/machinery/camera{
 	c_tag = "Escape Arm Airlocks";

--- a/_maps/map_files/OmegaStation/OmegaStation.dmm
+++ b/_maps/map_files/OmegaStation/OmegaStation.dmm
@@ -14986,6 +14986,7 @@
 	},
 /obj/effect/turf_decal/bot,
 /obj/item/areaeditor/blueprints,
+/obj/item/tank/jetpack/suit,
 /turf/open/floor/plasteel/vault/side{
 	dir = 8
 	},
@@ -17562,7 +17563,7 @@
 	dir = 1;
 	name = "Gas to Filter"
 	},
-/obj/machinery/airalarm{
+/obj/machinery/airalarm/engine{
 	dir = 4;
 	pixel_x = -23
 	},
@@ -31336,6 +31337,7 @@
 /obj/item/storage/belt/utility,
 /obj/item/clothing/glasses/meson/engine/tray,
 /obj/item/clothing/glasses/meson/engine/tray,
+/obj/item/pipe_dispenser,
 /turf/open/floor/plasteel,
 /area/engine/atmos)
 "eUz" = (

--- a/_maps/map_files/OmegaStation/OmegaStation.dmm
+++ b/_maps/map_files/OmegaStation/OmegaStation.dmm
@@ -35640,11 +35640,12 @@
 	},
 /area/engine/atmos)
 "xsS" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
-	dir = 4
-	},
 /obj/structure/cable{
 	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/components/binary/pump/on{
+	dir = 8;
+	name = "Waste to Filter"
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos)

--- a/_maps/map_files/OmegaStation/OmegaStation.dmm
+++ b/_maps/map_files/OmegaStation/OmegaStation.dmm
@@ -8597,7 +8597,6 @@
 /obj/machinery/meter,
 /obj/structure/grille,
 /obj/machinery/atmospherics/pipe/manifold/green/hidden{
-	icon_state = "manifold";
 	dir = 4
 	},
 /turf/closed/wall/r_wall,
@@ -9011,9 +9010,8 @@
 	},
 /area/engine/atmos)
 "arz" = (
-/obj/machinery/atmospherics/components/binary/pump{
-	name = "Air to Distro";
-	on = 1
+/obj/machinery/atmospherics/components/binary/pump/on{
+	name = "Air to Distro"
 	},
 /obj/machinery/light{
 	dir = 1
@@ -10412,7 +10410,6 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/visible{
-	icon_state = "manifold";
 	dir = 8
 	},
 /obj/machinery/meter,
@@ -11978,8 +11975,7 @@
 /area/hallway/secondary/exit)
 "ayh" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/visible{
-	dir = 8;
-	name = "scrubbers pipe"
+	dir = 8
 	},
 /obj/effect/decal/cleanable/oil,
 /obj/effect/decal/cleanable/dirt,
@@ -14057,7 +14053,6 @@
 "aDr" = (
 /obj/structure/sign/warning/nosmoking,
 /obj/machinery/atmospherics/pipe/simple/cyan/hidden{
-	icon_state = "intact";
 	dir = 8
 	},
 /turf/closed/wall/r_wall,
@@ -14065,7 +14060,6 @@
 "aDs" = (
 /obj/structure/sign/warning/fire,
 /obj/machinery/atmospherics/pipe/simple/cyan/hidden{
-	icon_state = "intact";
 	dir = 9
 	},
 /turf/closed/wall/r_wall,
@@ -29497,7 +29491,6 @@
 /area/hallway/secondary/entry)
 "bko" = (
 /obj/machinery/atmospherics/pipe/simple/cyan/hidden{
-	icon_state = "intact";
 	dir = 10
 	},
 /turf/closed/wall/r_wall,
@@ -31029,9 +31022,7 @@
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
 "coQ" = (
-/obj/machinery/atmospherics/components/unary/outlet_injector/on{
-	volume_rate = 50
-	},
+/obj/machinery/atmospherics/components/unary/outlet_injector/on,
 /obj/effect/turf_decal/stripes/line{
 	dir = 10
 	},
@@ -31066,8 +31057,7 @@
 /area/engine/atmos)
 "cBS" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/visible{
-	dir = 8;
-	name = "scrubbers pipe"
+	dir = 8
 	},
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -31124,9 +31114,7 @@
 /turf/closed/wall/r_wall,
 /area/engine/atmos)
 "cWR" = (
-/obj/structure/plasticflaps{
-	opacity = 1
-	},
+/obj/structure/plasticflaps,
 /obj/machinery/door/poddoor/preopen{
 	id = "atmoslock";
 	name = "Atmospherics Lockdown Blast door"
@@ -31140,8 +31128,7 @@
 	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel/neutral/corner{
-	dir = 8;
-	heat_capacity = 1e+006
+	dir = 8
 	},
 /area/hallway/primary/port)
 "ddI" = (
@@ -31209,10 +31196,9 @@
 /obj/machinery/atmospherics/pipe/simple/green/visible{
 	dir = 4
 	},
-/obj/machinery/atmospherics/components/binary/pump{
+/obj/machinery/atmospherics/components/binary/pump/on{
 	dir = 1;
-	name = "Oxygen to Airmix";
-	on = 1
+	name = "Oxygen to Airmix"
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/vault{
@@ -31364,7 +31350,6 @@
 /obj/effect/mapping_helpers/airlock/locked,
 /obj/machinery/door/airlock/public/glass{
 	autoclose = 0;
-	frequency = 1449;
 	heat_proof = 1;
 	id_tag = "incinerator_airlock_exterior";
 	name = "Incinerator Exterior Airlock";
@@ -31450,7 +31435,6 @@
 /area/engine/atmos)
 "fEM" = (
 /obj/machinery/atmospherics/pipe/simple/cyan/hidden{
-	icon_state = "intact";
 	dir = 6
 	},
 /turf/closed/wall/r_wall,
@@ -31687,7 +31671,6 @@
 /area/engine/atmos)
 "iqC" = (
 /obj/machinery/air_sensor{
-	frequency = 1441;
 	id_tag = "co2_sensor"
 	},
 /turf/open/floor/engine/co2,
@@ -31759,10 +31742,8 @@
 "iZQ" = (
 /obj/machinery/atmospherics/components/unary/outlet_injector/on{
 	dir = 2;
-	frequency = 1441;
 	id = "co2_in";
-	name = "co2 injector";
-	pixel_y = 1
+	name = "co2 injector"
 	},
 /turf/open/floor/engine/co2,
 /area/engine/atmos)
@@ -31893,7 +31874,6 @@
 /area/engine/atmos)
 "jDd" = (
 /obj/machinery/atmospherics/pipe/simple/cyan/hidden{
-	icon_state = "intact";
 	dir = 8
 	},
 /turf/closed/wall/r_wall/rust,
@@ -31926,10 +31906,9 @@
 /obj/machinery/atmospherics/pipe/simple/green/visible{
 	dir = 4
 	},
-/obj/machinery/atmospherics/components/binary/pump{
+/obj/machinery/atmospherics/components/binary/pump/on{
 	dir = 1;
-	name = "Nitrogen to Airmix";
-	on = 1
+	name = "Nitrogen to Airmix"
 	},
 /obj/machinery/light,
 /obj/effect/decal/cleanable/dirt,
@@ -32099,7 +32078,6 @@
 "mgs" = (
 /obj/machinery/atmospherics/components/unary/outlet_injector/on{
 	dir = 1;
-	frequency = 1441;
 	id = "airmix_in";
 	name = "airmix injector"
 	},
@@ -32142,11 +32120,9 @@
 /turf/open/floor/plasteel,
 /area/engine/atmos)
 "mJP" = (
-/obj/machinery/igniter{
-	icon_state = "igniter0";
+/obj/machinery/igniter/off{
 	id = "Incinerator";
-	luminosity = 2;
-	on = 0
+	luminosity = 2
 	},
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -32290,7 +32266,6 @@
 /area/engine/atmos)
 "oxn" = (
 /obj/machinery/power/compressor{
-	icon_state = "compressor";
 	dir = 4;
 	luminosity = 2;
 	comp_id = "incineratorturbine"
@@ -32364,7 +32339,6 @@
 "pjU" = (
 /obj/structure/grille,
 /obj/machinery/atmospherics/pipe/simple/yellow/hidden{
-	icon_state = "intact";
 	dir = 6
 	},
 /turf/closed/wall/r_wall,
@@ -32395,7 +32369,6 @@
 /area/science/xenobiology)
 "pqs" = (
 /obj/machinery/power/turbine{
-	icon_state = "turbine";
 	dir = 8;
 	luminosity = 2
 	},
@@ -32443,7 +32416,6 @@
 "pNE" = (
 /obj/structure/grille,
 /obj/machinery/atmospherics/pipe/simple/cyan/hidden{
-	icon_state = "intact";
 	dir = 8
 	},
 /turf/closed/wall/r_wall,
@@ -32484,7 +32456,6 @@
 /area/engine/gravity_generator)
 "qsc" = (
 /obj/machinery/air_sensor{
-	frequency = 1441;
 	id_tag = "airmix_sensor"
 	},
 /turf/open/floor/engine/air,
@@ -32650,10 +32621,8 @@
 "rVs" = (
 /obj/machinery/atmospherics/components/unary/outlet_injector/on{
 	dir = 2;
-	frequency = 1441;
 	id = "mix_in";
-	name = "gas mix injector";
-	pixel_y = 1
+	name = "gas mix injector"
 	},
 /turf/open/floor/engine/vacuum,
 /area/engine/atmos)
@@ -32698,10 +32667,8 @@
 "srR" = (
 /obj/machinery/atmospherics/components/unary/outlet_injector/on{
 	dir = 2;
-	frequency = 1441;
 	id = "n2o_in";
-	name = "n2o injector";
-	pixel_y = 1
+	name = "n2o injector"
 	},
 /turf/open/floor/engine/n2o,
 /area/engine/atmos)
@@ -35267,7 +35234,6 @@
 /area/engine/atmos)
 "uok" = (
 /obj/machinery/atmospherics/pipe/simple/cyan/hidden{
-	icon_state = "intact";
 	dir = 8
 	},
 /turf/closed/wall/r_wall,
@@ -35558,7 +35524,6 @@
 "vVS" = (
 /obj/machinery/atmospherics/components/unary/outlet_injector/on{
 	dir = 2;
-	frequency = 1441;
 	id = "plasma_in";
 	name = "plasma injector";
 	pixel_y = 1
@@ -35771,7 +35736,6 @@
 /obj/effect/mapping_helpers/airlock/locked,
 /obj/machinery/door/airlock/public/glass{
 	autoclose = 0;
-	frequency = 1449;
 	heat_proof = 1;
 	id_tag = "incinerator_airlock_interior";
 	name = "Incinerator Interior Airlock";

--- a/_maps/map_files/OmegaStation/OmegaStation.dmm
+++ b/_maps/map_files/OmegaStation/OmegaStation.dmm
@@ -8053,6 +8053,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
+/mob/living/simple_animal/bot/secbot/beepsky,
 /turf/open/floor/plasteel/red/corner,
 /area/security/brig)
 "apC" = (
@@ -8132,6 +8133,10 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
+	},
+/obj/machinery/navbeacon{
+	codes_txt = "patrol;next_patrol=1.2-BrigNorth";
+	location = "1.1-BrigCentral"
 	},
 /turf/open/floor/plasteel/red/corner{
 	dir = 1
@@ -31752,6 +31757,16 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit)
+"iaa" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/machinery/navbeacon{
+	codes_txt = "patrol;next_patrol=1.1-BrigCentral";
+	location = "1.2-BrigNorth"
+	},
+/turf/open/floor/plasteel/red/corner{
+	dir = 1
+	},
+/area/hallway/primary/central)
 "kKd" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/external{
@@ -70626,7 +70641,7 @@ agI
 ahB
 aiu
 ajd
-akc
+iaa
 alb
 alR
 akc

--- a/_maps/map_files/OmegaStation/OmegaStation.dmm
+++ b/_maps/map_files/OmegaStation/OmegaStation.dmm
@@ -8078,6 +8078,7 @@
 	dir = 4
 	},
 /mob/living/simple_animal/bot/secbot/beepsky{
+	desc = "It's Officer Beepsky! Powered by a potato and a shot of whiskey.";
 	name = "Officer Beepsky"
 	},
 /turf/open/floor/plasteel/red/corner,
@@ -77919,7 +77920,7 @@ bfP
 bfP
 sKZ
 bfP
-bfP
+bjc
 bfP
 bfP
 dWc
@@ -81516,9 +81517,9 @@ aad
 bvg
 aac
 aad
-aad
-aad
-aad
+aac
+aac
+aac
 aad
 aad
 aac
@@ -81773,9 +81774,9 @@ bvg
 aac
 aaa
 aaa
-aad
-aad
-aad
+aaa
+aaa
+aac
 aad
 aad
 aad
@@ -82031,8 +82032,8 @@ aaa
 aaa
 aaa
 aaa
-aad
-aad
+aaa
+aaa
 aac
 aad
 aad

--- a/_maps/map_files/OmegaStation/OmegaStation.dmm
+++ b/_maps/map_files/OmegaStation/OmegaStation.dmm
@@ -35282,6 +35282,9 @@
 	name = "Plasma to Pure"
 	},
 /obj/effect/decal/cleanable/dirt,
+/obj/machinery/camera{
+	c_tag = "Atmospherics North"
+	},
 /turf/open/floor/plasteel/vault{
 	dir = 5
 	},

--- a/_maps/map_files/OmegaStation/OmegaStation.dmm
+++ b/_maps/map_files/OmegaStation/OmegaStation.dmm
@@ -30008,7 +30008,7 @@
 	dir = 4
 	},
 /turf/closed/wall/r_wall,
-/area/asteroid/nearstation)
+/area/maintenance/disposal/incinerator)
 "bpB" = (
 /obj/machinery/atmospherics/pipe/simple/yellow/visible{
 	dir = 10
@@ -30950,7 +30950,7 @@
 	dir = 5
 	},
 /turf/open/floor/plasteel,
-/area/asteroid/nearstation)
+/area/engine/atmos)
 "bGS" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/siphon/on{
 	dir = 2;
@@ -30959,7 +30959,7 @@
 	name = "co2 vent"
 	},
 /turf/open/floor/engine/co2,
-/area/asteroid/nearstation)
+/area/engine/atmos)
 "bIJ" = (
 /obj/machinery/hydroponics/constructable,
 /obj/effect/turf_decal/stripes/line{
@@ -30983,7 +30983,7 @@
 	dir = 4
 	},
 /turf/closed/wall/r_wall,
-/area/asteroid/nearstation)
+/area/maintenance/disposal/incinerator)
 "bZq" = (
 /obj/machinery/atmospherics/pipe/manifold/yellow/visible{
 	dir = 8
@@ -30992,7 +30992,7 @@
 /turf/open/floor/plasteel/caution{
 	dir = 1
 	},
-/area/asteroid/nearstation)
+/area/engine/atmos)
 "ccy" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
@@ -31016,11 +31016,7 @@
 /turf/open/floor/plasteel/caution{
 	dir = 8
 	},
-/area/asteroid/nearstation)
-"ckn" = (
-/obj/machinery/atmospherics/pipe/simple/cyan/hidden,
-/turf/closed/wall/r_wall,
-/area/asteroid/nearstation)
+/area/engine/atmos)
 "cmp" = (
 /obj/machinery/door/airlock/external{
 	name = "External Docking Port"
@@ -31044,7 +31040,7 @@
 	dir = 10
 	},
 /turf/open/floor/plating/airless,
-/area/space)
+/area/space/nearstation)
 "csX" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/structure/cable/white{
@@ -31063,10 +31059,6 @@
 /obj/machinery/door/firedoor,
 /turf/open/floor/plasteel,
 /area/hydroponics)
-"cAr" = (
-/obj/structure/grille,
-/turf/closed/wall/r_wall,
-/area/asteroid/nearstation)
 "cBf" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -31093,7 +31085,7 @@
 	name = "Incineration Chamber Vent"
 	},
 /turf/open/floor/engine/vacuum,
-/area/asteroid/nearstation)
+/area/maintenance/disposal/incinerator)
 "cGz" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/effect/decal/cleanable/dirt,
@@ -31102,7 +31094,7 @@
 	pixel_y = -26
 	},
 /turf/open/floor/plasteel,
-/area/asteroid/nearstation)
+/area/engine/atmos)
 "cRz" = (
 /obj/machinery/button/door{
 	id = "supplybridge";
@@ -31127,12 +31119,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard)
-"cWq" = (
-/obj/machinery/atmospherics/pipe/simple/yellow/visible{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/asteroid/nearstation)
 "cWv" = (
 /obj/machinery/atmospherics/pipe/simple/cyan/hidden,
 /turf/closed/wall/r_wall,
@@ -31164,7 +31150,7 @@
 	id_tag = "plasma_sensor"
 	},
 /turf/open/floor/engine/plasma,
-/area/asteroid/nearstation)
+/area/engine/atmos)
 "dfP" = (
 /obj/machinery/door/airlock/maintenance_hatch{
 	name = "Maintenance Hatch";
@@ -31195,7 +31181,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel,
-/area/asteroid/nearstation)
+/area/engine/atmos)
 "diG" = (
 /turf/open/floor/plasteel,
 /area/engine/atmos)
@@ -31233,21 +31219,13 @@
 	dir = 5
 	},
 /area/engine/atmos)
-"dIu" = (
-/obj/structure/grille,
-/obj/machinery/atmospherics/pipe/simple/cyan/hidden{
-	icon_state = "intact";
-	dir = 8
-	},
-/turf/closed/wall/r_wall,
-/area/asteroid/nearstation)
 "dMl" = (
 /obj/structure/sign/warning/fire,
 /obj/machinery/atmospherics/pipe/simple/orange/visible{
 	dir = 4
 	},
 /turf/closed/wall/r_wall,
-/area/asteroid/nearstation)
+/area/maintenance/disposal/incinerator)
 "dWc" = (
 /turf/closed/mineral/random/labormineral,
 /area/space)
@@ -31273,7 +31251,7 @@
 	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel,
-/area/asteroid/nearstation)
+/area/engine/atmos)
 "eva" = (
 /obj/machinery/atmospherics/pipe/simple/green/visible{
 	dir = 4
@@ -31289,7 +31267,7 @@
 /turf/open/floor/plasteel/vault{
 	dir = 5
 	},
-/area/asteroid/nearstation)
+/area/engine/atmos)
 "ewT" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 8
@@ -31325,12 +31303,12 @@
 /obj/machinery/light/small,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/engine,
-/area/asteroid/nearstation)
+/area/maintenance/disposal/incinerator)
 "ezP" = (
 /obj/machinery/atmospherics/pipe/simple/general/visible,
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
-/area/asteroid/nearstation)
+/area/engine/atmos)
 "eCg" = (
 /obj/machinery/atmospherics/pipe/simple/green/visible{
 	dir = 4
@@ -31395,7 +31373,7 @@
 	dir = 4
 	},
 /turf/open/floor/engine,
-/area/asteroid/nearstation)
+/area/maintenance/disposal/incinerator)
 "eZd" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible,
 /obj/effect/turf_decal/stripes/line{
@@ -31412,7 +31390,7 @@
 /turf/open/floor/plasteel/caution{
 	dir = 8
 	},
-/area/asteroid/nearstation)
+/area/engine/atmos)
 "fgG" = (
 /obj/machinery/ai_status_display,
 /turf/closed/wall,
@@ -31432,12 +31410,12 @@
 	id_tag = "n2o_sensor"
 	},
 /turf/open/floor/engine/n2o,
-/area/asteroid/nearstation)
+/area/engine/atmos)
 "fom" = (
 /obj/structure/lattice/catwalk,
 /obj/item/wrench,
 /turf/open/space,
-/area/space)
+/area/space/nearstation)
 "fsJ" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -31449,7 +31427,7 @@
 	id = "incinerator_airlock_pump"
 	},
 /turf/open/floor/engine,
-/area/asteroid/nearstation)
+/area/maintenance/disposal/incinerator)
 "fvd" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -31467,7 +31445,7 @@
 	dir = 6
 	},
 /turf/closed/wall/r_wall,
-/area/asteroid/nearstation)
+/area/engine/atmos)
 "fFw" = (
 /obj/machinery/atmospherics/components/unary/portables_connector/visible,
 /obj/effect/turf_decal/stripes/line{
@@ -31476,9 +31454,6 @@
 /obj/machinery/portable_atmospherics/canister,
 /turf/open/floor/plasteel,
 /area/engine/atmos)
-"fIe" = (
-/turf/open/floor/engine/air,
-/area/asteroid/nearstation)
 "fIN" = (
 /obj/machinery/atmospherics/pipe/simple/general/visible{
 	dir = 10
@@ -31487,13 +31462,7 @@
 	dir = 1
 	},
 /turf/open/floor/plasteel,
-/area/asteroid/nearstation)
-"fKT" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/caution{
-	dir = 1
-	},
-/area/asteroid/nearstation)
+/area/engine/atmos)
 "fLr" = (
 /obj/machinery/atmospherics/pipe/simple/general/visible{
 	dir = 9
@@ -31539,17 +31508,17 @@
 /obj/machinery/light,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel,
-/area/asteroid/nearstation)
+/area/engine/atmos)
 "gap" = (
 /obj/machinery/portable_atmospherics/canister/nitrous_oxide,
 /turf/open/floor/engine/n2o,
-/area/asteroid/nearstation)
+/area/engine/atmos)
 "gdA" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 6
 	},
 /turf/closed/wall/r_wall,
-/area/asteroid/nearstation)
+/area/maintenance/disposal/incinerator)
 "geZ" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plasteel/neutral/corner,
@@ -31586,7 +31555,7 @@
 /turf/open/floor/plasteel/vault{
 	dir = 5
 	},
-/area/asteroid/nearstation)
+/area/engine/atmos)
 "gyV" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
 	dir = 1
@@ -31612,14 +31581,7 @@
 /turf/open/floor/plasteel/vault{
 	dir = 8
 	},
-/area/asteroid/nearstation)
-"gUJ" = (
-/obj/machinery/atmospherics/pipe/simple/cyan/hidden{
-	icon_state = "intact";
-	dir = 8
-	},
-/turf/closed/wall/r_wall,
-/area/asteroid/nearstation)
+/area/engine/atmos)
 "gVX" = (
 /obj/machinery/atmospherics/components/trinary/filter/flipped{
 	dir = 8;
@@ -31630,7 +31592,7 @@
 /turf/open/floor/plasteel/vault{
 	dir = 5
 	},
-/area/asteroid/nearstation)
+/area/engine/atmos)
 "heQ" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/machinery/navbeacon{
@@ -31674,22 +31636,22 @@
 	dir = 5
 	},
 /turf/closed/wall/r_wall,
-/area/asteroid/nearstation)
+/area/engine/atmos)
 "hOh" = (
 /obj/machinery/portable_atmospherics/canister/carbon_dioxide,
 /turf/open/floor/engine/co2,
-/area/asteroid/nearstation)
+/area/engine/atmos)
 "hUG" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plasteel,
-/area/asteroid/nearstation)
+/area/engine/atmos)
 "hUL" = (
 /obj/effect/landmark/start/atmospheric_technician,
 /turf/open/floor/plasteel,
-/area/asteroid/nearstation)
+/area/engine/atmos)
 "hXn" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
 	dir = 4
@@ -31727,27 +31689,20 @@
 	id_tag = "co2_sensor"
 	},
 /turf/open/floor/engine/co2,
-/area/asteroid/nearstation)
+/area/engine/atmos)
 "ixk" = (
 /obj/machinery/atmospherics/pipe/simple/green/visible,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
-/area/asteroid/nearstation)
+/area/engine/atmos)
 "iye" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/siphon/on{
 	dir = 4
 	},
 /turf/open/floor/engine/vacuum,
-/area/asteroid/nearstation)
-"iHo" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/effect/turf_decal/stripes/line,
-/turf/open/floor/plasteel,
-/area/asteroid/nearstation)
+/area/maintenance/disposal/incinerator)
 "iIj" = (
 /obj/machinery/atmospherics/components/trinary/mixer/flipped{
 	dir = 4;
@@ -31773,7 +31728,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel,
-/area/asteroid/nearstation)
+/area/engine/atmos)
 "iML" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 8
@@ -31808,14 +31763,14 @@
 	pixel_y = 1
 	},
 /turf/open/floor/engine/co2,
-/area/asteroid/nearstation)
+/area/engine/atmos)
 "jbQ" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
 	dir = 5
 	},
 /obj/structure/lattice,
 /turf/open/space/basic,
-/area/space)
+/area/space/nearstation)
 "jcn" = (
 /obj/structure/cable/white{
 	icon_state = "4-8"
@@ -31848,7 +31803,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plasteel,
-/area/asteroid/nearstation)
+/area/engine/atmos)
 "jpv" = (
 /obj/machinery/atmospherics/pipe/simple/cyan/visible,
 /obj/machinery/light{
@@ -31861,7 +31816,7 @@
 /turf/open/floor/plasteel/caution{
 	dir = 1
 	},
-/area/asteroid/nearstation)
+/area/engine/atmos)
 "jqM" = (
 /obj/effect/turf_decal/bot,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -31877,14 +31832,14 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel,
-/area/asteroid/nearstation)
+/area/engine/atmos)
 "juT" = (
 /obj/machinery/atmospherics/pipe/simple/yellow/visible,
 /obj/machinery/atmospherics/pipe/simple/general/visible{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
-/area/asteroid/nearstation)
+/area/engine/atmos)
 "jwi" = (
 /obj/structure/sign/directions/engineering{
 	dir = 8;
@@ -31933,7 +31888,7 @@
 /turf/open/floor/plasteel/vault{
 	dir = 5
 	},
-/area/asteroid/nearstation)
+/area/engine/atmos)
 "jDd" = (
 /obj/machinery/atmospherics/pipe/simple/cyan/hidden{
 	icon_state = "intact";
@@ -31954,7 +31909,7 @@
 "kit" = (
 /obj/machinery/portable_atmospherics/canister/toxins,
 /turf/open/floor/engine/plasma,
-/area/asteroid/nearstation)
+/area/engine/atmos)
 "kiw" = (
 /obj/machinery/atmospherics/pipe/simple/general/visible,
 /obj/structure/cable{
@@ -31964,11 +31919,7 @@
 	dir = 8
 	},
 /turf/open/floor/plasteel,
-/area/asteroid/nearstation)
-"kqe" = (
-/obj/structure/lattice/catwalk,
-/turf/open/space,
-/area/space)
+/area/engine/atmos)
 "kwF" = (
 /obj/machinery/atmospherics/pipe/simple/green/visible{
 	dir = 4
@@ -31992,7 +31943,7 @@
 	dir = 1
 	},
 /turf/open/floor/plasteel,
-/area/asteroid/nearstation)
+/area/engine/atmos)
 "kHA" = (
 /obj/machinery/atmospherics/pipe/simple/green/visible{
 	dir = 4
@@ -32008,7 +31959,7 @@
 /turf/open/floor/plasteel/vault{
 	dir = 5
 	},
-/area/asteroid/nearstation)
+/area/engine/atmos)
 "kKd" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/external{
@@ -32026,33 +31977,27 @@
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/miningdock)
-"kTo" = (
-/obj/structure/grille,
-/obj/machinery/meter,
-/obj/machinery/atmospherics/pipe/simple/green/visible,
-/turf/closed/wall/r_wall/rust,
-/area/asteroid/nearstation)
 "kTz" = (
 /obj/machinery/atmospherics/pipe/simple/green/visible,
 /obj/machinery/atmospherics/pipe/simple/cyan/visible{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
-/area/asteroid/nearstation)
+/area/engine/atmos)
 "lrg" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
 	dir = 4
 	},
 /obj/structure/lattice,
 /turf/open/space/basic,
-/area/asteroid/nearstation)
+/area/space/nearstation)
 "lvw" = (
 /obj/machinery/atmospherics/pipe/simple/orange/visible,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/caution{
 	dir = 8
 	},
-/area/asteroid/nearstation)
+/area/engine/atmos)
 "lxq" = (
 /obj/structure/cable/white{
 	icon_state = "1-2"
@@ -32075,13 +32020,7 @@
 /turf/open/floor/plasteel/caution{
 	dir = 9
 	},
-/area/asteroid/nearstation)
-"lBr" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/asteroid/nearstation)
+/area/engine/atmos)
 "lCg" = (
 /obj/machinery/door/airlock/external{
 	name = "Supply Dock Airlock";
@@ -32131,7 +32070,7 @@
 "lUu" = (
 /obj/machinery/portable_atmospherics/canister/air,
 /turf/open/floor/engine/air,
-/area/asteroid/nearstation)
+/area/engine/atmos)
 "lXk" = (
 /obj/structure/closet/firecloset,
 /obj/effect/turf_decal/delivery,
@@ -32185,7 +32124,7 @@
 	name = "Turbine Vent"
 	},
 /turf/open/floor/engine/vacuum,
-/area/space)
+/area/maintenance/disposal/incinerator)
 "msJ" = (
 /obj/machinery/atmospherics/pipe/simple/cyan/visible,
 /obj/machinery/atmospherics/pipe/simple/orange/visible{
@@ -32195,11 +32134,7 @@
 	dir = 1
 	},
 /turf/open/floor/plasteel,
-/area/asteroid/nearstation)
-"mIv" = (
-/obj/machinery/atmospherics/pipe/manifold/general/visible,
-/turf/open/floor/plasteel,
-/area/asteroid/nearstation)
+/area/engine/atmos)
 "mJP" = (
 /obj/machinery/igniter{
 	icon_state = "igniter0";
@@ -32211,7 +32146,7 @@
 	icon_state = "4-8"
 	},
 /turf/open/floor/engine/vacuum,
-/area/asteroid/nearstation)
+/area/maintenance/disposal/incinerator)
 "mJQ" = (
 /obj/structure/table/glass,
 /obj/effect/turf_decal/delivery,
@@ -32232,10 +32167,10 @@
 /obj/effect/turf_decal/stripes/line,
 /obj/machinery/meter,
 /turf/open/floor/plasteel,
-/area/asteroid/nearstation)
+/area/engine/atmos)
 "mTM" = (
 /turf/open/floor/engine/co2,
-/area/asteroid/nearstation)
+/area/engine/atmos)
 "mTT" = (
 /obj/machinery/atmospherics/components/binary/pump{
 	dir = 8;
@@ -32245,7 +32180,7 @@
 	dir = 1
 	},
 /turf/open/floor/plasteel,
-/area/asteroid/nearstation)
+/area/engine/atmos)
 "mXV" = (
 /obj/structure/cable/white{
 	icon_state = "1-2"
@@ -32263,17 +32198,7 @@
 	dir = 4
 	},
 /turf/closed/wall/r_wall,
-/area/asteroid/nearstation)
-"nrv" = (
-/obj/machinery/atmospherics/pipe/simple/cyan/visible,
-/obj/machinery/atmospherics/pipe/simple/green/visible{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/vault{
-	dir = 5
-	},
-/area/asteroid/nearstation)
+/area/maintenance/disposal/incinerator)
 "nwY" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
@@ -32287,7 +32212,7 @@
 	},
 /obj/machinery/meter,
 /turf/open/floor/plasteel,
-/area/asteroid/nearstation)
+/area/engine/atmos)
 "nKi" = (
 /obj/machinery/door/airlock/maintenance_hatch{
 	name = "Maintenance Hatch";
@@ -32321,7 +32246,7 @@
 	dir = 10
 	},
 /turf/open/floor/plasteel/caution,
-/area/asteroid/nearstation)
+/area/engine/atmos)
 "oaV" = (
 /obj/structure/grille,
 /obj/machinery/meter,
@@ -32337,7 +32262,7 @@
 "oql" = (
 /obj/machinery/atmospherics/pipe/simple/green/visible,
 /turf/open/floor/plasteel,
-/area/asteroid/nearstation)
+/area/engine/atmos)
 "orI" = (
 /obj/machinery/atmospherics/pipe/simple/cyan/visible,
 /obj/structure/cable{
@@ -32347,7 +32272,7 @@
 /turf/open/floor/plasteel/vault{
 	dir = 5
 	},
-/area/asteroid/nearstation)
+/area/engine/atmos)
 "otn" = (
 /obj/machinery/atmospherics/pipe/simple/green/visible{
 	dir = 6
@@ -32356,7 +32281,7 @@
 /turf/open/floor/plasteel/vault{
 	dir = 5
 	},
-/area/asteroid/nearstation)
+/area/engine/atmos)
 "oxn" = (
 /obj/machinery/power/compressor{
 	icon_state = "compressor";
@@ -32372,7 +32297,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/engine/vacuum,
-/area/asteroid/nearstation)
+/area/maintenance/disposal/incinerator)
 "oyD" = (
 /turf/closed/wall,
 /area/crew_quarters/toilet/restrooms)
@@ -32385,7 +32310,7 @@
 /turf/open/floor/plasteel/vault{
 	dir = 5
 	},
-/area/asteroid/nearstation)
+/area/engine/atmos)
 "oGc" = (
 /obj/machinery/atmospherics/pipe/simple/cyan/visible{
 	dir = 6
@@ -32395,17 +32320,17 @@
 "oIG" = (
 /obj/structure/sign/warning/fire,
 /turf/closed/wall/r_wall,
-/area/space)
+/area/maintenance/disposal/incinerator)
 "oJp" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on,
 /turf/open/floor/plasteel,
-/area/asteroid/nearstation)
+/area/engine/atmos)
 "oOk" = (
 /turf/open/floor/engine/plasma,
-/area/asteroid/nearstation)
+/area/engine/atmos)
 "oQL" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 1
@@ -32475,7 +32400,7 @@
 	icon_state = "0-4"
 	},
 /turf/open/floor/engine/vacuum,
-/area/asteroid/nearstation)
+/area/maintenance/disposal/incinerator)
 "psq" = (
 /obj/structure/sign/poster/random{
 	pixel_y = 32
@@ -32493,10 +32418,7 @@
 /turf/open/floor/plasteel/caution{
 	dir = 10
 	},
-/area/asteroid/nearstation)
-"pBT" = (
-/turf/open/floor/plating/asteroid/airless,
-/area/space)
+/area/engine/atmos)
 "pEH" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plating,
@@ -32542,7 +32464,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/engine/vacuum,
-/area/asteroid/nearstation)
+/area/maintenance/disposal/incinerator)
 "qoT" = (
 /obj/machinery/atmospherics/components/binary/pump{
 	dir = 1;
@@ -32560,7 +32482,7 @@
 	id_tag = "airmix_sensor"
 	},
 /turf/open/floor/engine/air,
-/area/asteroid/nearstation)
+/area/engine/atmos)
 "qui" = (
 /obj/machinery/atmospherics/components/binary/pump{
 	name = "Distro to Waste"
@@ -32612,7 +32534,7 @@
 	},
 /obj/machinery/meter,
 /turf/open/floor/plasteel,
-/area/space)
+/area/engine/atmos)
 "qTa" = (
 /obj/machinery/atmospherics/pipe/simple/orange/visible{
 	dir = 4
@@ -32621,24 +32543,24 @@
 	dir = 9
 	},
 /turf/open/floor/plasteel,
-/area/asteroid/nearstation)
+/area/engine/atmos)
 "qUW" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 5
 	},
 /turf/closed/wall/r_wall,
-/area/asteroid/nearstation)
+/area/engine/atmos)
 "rae" = (
 /obj/machinery/atmospherics/components/binary/pump{
 	dir = 1;
 	name = "Airmix to Pure"
 	},
 /turf/open/floor/plasteel,
-/area/asteroid/nearstation)
+/area/engine/atmos)
 "rjQ" = (
 /obj/machinery/atmospherics/pipe/simple/cyan/visible,
 /turf/open/floor/plasteel,
-/area/asteroid/nearstation)
+/area/engine/atmos)
 "rjV" = (
 /obj/machinery/atmospherics/components/binary/pump{
 	dir = 4
@@ -32654,7 +32576,7 @@
 	pixel_y = 24
 	},
 /turf/open/floor/engine,
-/area/asteroid/nearstation)
+/area/maintenance/disposal/incinerator)
 "rlq" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -32678,7 +32600,7 @@
 	dir = 6
 	},
 /turf/open/floor/plasteel,
-/area/asteroid/nearstation)
+/area/engine/atmos)
 "rCw" = (
 /obj/machinery/door/window/brigdoor{
 	dir = 4;
@@ -32709,7 +32631,7 @@
 	},
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plasteel,
-/area/asteroid/nearstation)
+/area/engine/atmos)
 "rVj" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/siphon/on{
 	dir = 1;
@@ -32718,7 +32640,7 @@
 	name = "airmix vent"
 	},
 /turf/open/floor/engine/air,
-/area/asteroid/nearstation)
+/area/engine/atmos)
 "rVs" = (
 /obj/machinery/atmospherics/components/unary/outlet_injector/on{
 	dir = 2;
@@ -32740,12 +32662,6 @@
 /obj/machinery/hydroponics/soil,
 /turf/open/floor/plasteel/vault/side,
 /area/maintenance/starboard/aft)
-"skz" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 10
-	},
-/turf/closed/wall/r_wall,
-/area/asteroid/nearstation)
 "soC" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -32772,7 +32688,7 @@
 /turf/open/floor/plasteel/vault{
 	dir = 5
 	},
-/area/asteroid/nearstation)
+/area/engine/atmos)
 "srR" = (
 /obj/machinery/atmospherics/components/unary/outlet_injector/on{
 	dir = 2;
@@ -32782,7 +32698,7 @@
 	pixel_y = 1
 	},
 /turf/open/floor/engine/n2o,
-/area/asteroid/nearstation)
+/area/engine/atmos)
 "sws" = (
 /obj/docking_port/stationary{
 	dheight = 1;
@@ -35255,14 +35171,14 @@
 	dir = 1
 	},
 /turf/open/floor/plasteel,
-/area/asteroid/nearstation)
+/area/engine/atmos)
 "tgm" = (
 /obj/machinery/atmospherics/components/binary/pump{
 	dir = 8;
 	name = "Port to Waste"
 	},
 /turf/open/floor/plasteel,
-/area/asteroid/nearstation)
+/area/engine/atmos)
 "tgp" = (
 /obj/machinery/atmospherics/components/unary/portables_connector/visible{
 	dir = 8
@@ -35271,16 +35187,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel,
-/area/asteroid/nearstation)
-"toY" = (
-/obj/machinery/atmospherics/pipe/simple/yellow/visible{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/caution{
-	dir = 1
-	},
-/area/asteroid/nearstation)
+/area/engine/atmos)
 "ttA" = (
 /obj/machinery/atmospherics/pipe/simple/orange/visible,
 /obj/effect/turf_decal/bot,
@@ -35293,7 +35200,7 @@
 /turf/open/floor/plasteel/caution{
 	dir = 8
 	},
-/area/asteroid/nearstation)
+/area/engine/atmos)
 "tKM" = (
 /turf/closed/wall,
 /area/hallway/primary/fore)
@@ -35323,7 +35230,7 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden,
 /turf/open/floor/plasteel,
-/area/asteroid/nearstation)
+/area/engine/atmos)
 "ueG" = (
 /obj/machinery/atmospherics/pipe/simple/orange/visible{
 	dir = 6
@@ -35335,13 +35242,16 @@
 /turf/open/floor/plasteel/caution{
 	dir = 9
 	},
-/area/asteroid/nearstation)
+/area/engine/atmos)
 "ugK" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
 /turf/open/floor/plasteel/neutral/corner,
 /area/hallway/primary/aft)
+"uhz" = (
+/turf/closed/wall/r_wall,
+/area/maintenance/disposal/incinerator)
 "ujg" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/siphon/on{
 	dir = 2;
@@ -35350,10 +35260,7 @@
 	name = "n2o vent"
 	},
 /turf/open/floor/engine/n2o,
-/area/asteroid/nearstation)
-"ulC" = (
-/turf/open/space/basic,
-/area/asteroid/nearstation)
+/area/engine/atmos)
 "uok" = (
 /obj/machinery/atmospherics/pipe/simple/cyan/hidden{
 	icon_state = "intact";
@@ -35391,7 +35298,7 @@
 /turf/open/floor/plasteel/caution{
 	dir = 1
 	},
-/area/asteroid/nearstation)
+/area/engine/atmos)
 "uuU" = (
 /obj/machinery/status_display,
 /turf/closed/wall,
@@ -35408,7 +35315,7 @@
 "uvg" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/closed/wall/r_wall,
-/area/asteroid/nearstation)
+/area/maintenance/disposal/incinerator)
 "uxJ" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/public/glass{
@@ -35456,9 +35363,6 @@
 	dir = 1
 	},
 /area/hallway/primary/port)
-"uIm" = (
-/turf/open/floor/plasteel,
-/area/asteroid/nearstation)
 "uSs" = (
 /obj/machinery/atmospherics/pipe/simple/cyan/visible,
 /obj/machinery/atmospherics/pipe/simple/green/visible{
@@ -35475,7 +35379,7 @@
 	dir = 8
 	},
 /turf/open/floor/plasteel,
-/area/asteroid/nearstation)
+/area/engine/atmos)
 "ver" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
 	dir = 10
@@ -35559,7 +35463,7 @@
 	},
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plasteel,
-/area/asteroid/nearstation)
+/area/engine/atmos)
 "vsf" = (
 /obj/effect/decal/cleanable/xenoblood/xgibs,
 /turf/open/floor/plasteel/vault{
@@ -35586,7 +35490,7 @@
 	dir = 1
 	},
 /turf/open/floor/plasteel,
-/area/asteroid/nearstation)
+/area/engine/atmos)
 "vuh" = (
 /obj/machinery/atmospherics/pipe/simple/green/visible{
 	dir = 4
@@ -35604,14 +35508,14 @@
 	dir = 10
 	},
 /turf/open/floor/plasteel,
-/area/asteroid/nearstation)
+/area/engine/atmos)
 "vJk" = (
 /obj/machinery/atmospherics/pipe/simple/yellow/visible,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
-/area/asteroid/nearstation)
+/area/engine/atmos)
 "vJt" = (
 /obj/machinery/atmospherics/pipe/simple/orange/visible,
 /obj/effect/turf_decal/bot,
@@ -35627,10 +35531,10 @@
 /turf/open/floor/plasteel/caution{
 	dir = 8
 	},
-/area/asteroid/nearstation)
+/area/engine/atmos)
 "vMb" = (
 /turf/open/floor/engine/n2o,
-/area/asteroid/nearstation)
+/area/engine/atmos)
 "vVA" = (
 /obj/machinery/atmospherics/pipe/simple/green/visible{
 	dir = 4
@@ -35653,7 +35557,7 @@
 	pixel_y = 1
 	},
 /turf/open/floor/engine/plasma,
-/area/asteroid/nearstation)
+/area/engine/atmos)
 "vWg" = (
 /obj/structure/cable/white{
 	icon_state = "4-8"
@@ -35689,34 +35593,16 @@
 	dir = 8
 	},
 /area/hallway/primary/aft)
-"wev" = (
-/obj/machinery/meter,
-/obj/machinery/atmospherics/pipe/simple/cyan/visible,
-/obj/structure/grille,
-/turf/closed/wall/r_wall,
-/area/asteroid/nearstation)
 "wkG" = (
 /obj/structure/lattice/catwalk,
 /turf/open/floor/plating/airless,
-/area/space)
+/area/space/nearstation)
 "wqL" = (
 /obj/machinery/atmospherics/pipe/simple/yellow/visible{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos)
-"wvE" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
-	dir = 5
-	},
-/turf/open/floor/plasteel,
-/area/asteroid/nearstation)
-"wMZ" = (
-/obj/structure/grille,
-/obj/machinery/meter,
-/obj/machinery/atmospherics/pipe/simple/yellow/visible,
-/turf/closed/wall/r_wall,
-/area/asteroid/nearstation)
 "wUF" = (
 /obj/machinery/door/airlock/atmos/glass{
 	name = "Supermatter Chamber";
@@ -35755,7 +35641,7 @@
 	name = "plasma vent"
 	},
 /turf/open/floor/engine/plasma,
-/area/asteroid/nearstation)
+/area/engine/atmos)
 "xeu" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
 	dir = 4
@@ -35775,7 +35661,7 @@
 /turf/open/floor/plasteel/caution{
 	dir = 8
 	},
-/area/asteroid/nearstation)
+/area/engine/atmos)
 "xsS" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
 	dir = 4
@@ -35828,7 +35714,7 @@
 /turf/open/floor/plasteel/caution{
 	dir = 10
 	},
-/area/asteroid/nearstation)
+/area/maintenance/disposal/incinerator)
 "xwu" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
@@ -35839,7 +35725,7 @@
 /turf/open/floor/plasteel/vault{
 	dir = 5
 	},
-/area/asteroid/nearstation)
+/area/engine/atmos)
 "xAj" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible,
 /obj/effect/decal/cleanable/dirt,
@@ -35847,10 +35733,6 @@
 	dir = 5
 	},
 /area/engine/atmos)
-"xCL" = (
-/obj/effect/spawner/structure/window/plasma/reinforced,
-/turf/open/floor/plating,
-/area/asteroid/nearstation)
 "xEQ" = (
 /obj/machinery/atmospherics/components/trinary/filter/flipped{
 	dir = 8;
@@ -35872,10 +35754,6 @@
 /obj/structure/grille,
 /turf/closed/wall/r_wall,
 /area/engine/atmos)
-"xOf" = (
-/obj/structure/lattice,
-/turf/open/space,
-/area/space)
 "xPz" = (
 /obj/machinery/atmospherics/pipe/simple/general/visible{
 	dir = 9
@@ -35899,7 +35777,7 @@
 	dir = 8
 	},
 /turf/open/floor/engine,
-/area/asteroid/nearstation)
+/area/maintenance/disposal/incinerator)
 "yba" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -35947,7 +35825,7 @@
 	dir = 8
 	},
 /turf/open/floor/plasteel,
-/area/asteroid/nearstation)
+/area/engine/atmos)
 "ymj" = (
 /obj/machinery/atmospherics/pipe/simple/green/visible{
 	dir = 4
@@ -35959,7 +35837,7 @@
 /turf/open/floor/plasteel/vault{
 	dir = 5
 	},
-/area/asteroid/nearstation)
+/area/engine/atmos)
 
 (1,1,1) = {"
 aaa
@@ -60482,11 +60360,11 @@ aaa
 aaa
 aaa
 aaa
-kqe
-kqe
-kqe
-kqe
-kqe
+sNM
+sNM
+sNM
+sNM
+sNM
 aaa
 aaa
 aaa
@@ -60740,10 +60618,10 @@ aaa
 aaa
 aaa
 fom
-xOf
+aae
 aaa
-xOf
-kqe
+aae
+sNM
 aaa
 aaa
 aaa
@@ -60996,7 +60874,7 @@ aaa
 aaa
 aaa
 aaa
-kqe
+sNM
 oIG
 mqF
 oIG
@@ -61250,13 +61128,13 @@ aaa
 aaa
 aaa
 aaa
-ulC
-ulC
-ulC
-aXc
-ahu
+aaa
+aaa
+aaa
+sNM
+uhz
 pqs
-fSE
+uhz
 coQ
 jbQ
 aaa
@@ -61502,19 +61380,19 @@ aaa
 aaa
 aaa
 aaa
-pBT
-pBT
-pBT
+aac
+aac
+aac
 aaa
-ulC
-ulC
-ulC
-ulC
-ahu
-ahu
+aaa
+aaa
+aaa
+aaa
+uhz
+uhz
 oxn
-ahu
-ahu
+uhz
+uhz
 lrg
 aaa
 aaa
@@ -61757,17 +61635,17 @@ aaa
 aaa
 aaa
 aaa
-pBT
-pBT
-dWc
-pBT
+aac
+aac
+aad
 aac
 aac
 aac
 aac
 aac
-ulC
-ahu
+aac
+aaa
+uhz
 iye
 mJP
 qgC
@@ -62013,9 +61891,9 @@ aaa
 aaa
 aaa
 aaa
-pBT
-pBT
-dWc
+aac
+aac
+aad
 aad
 aac
 aac
@@ -62024,11 +61902,11 @@ aad
 aad
 aad
 aad
-ahu
+uhz
 bpn
 eYe
 bYE
-ahu
+uhz
 lrg
 aad
 aad
@@ -62270,8 +62148,8 @@ aaa
 aaa
 aaa
 aaa
-pBT
-pBT
+aac
+aac
 aad
 aad
 aad
@@ -62527,22 +62405,22 @@ aaa
 aaa
 aaa
 aaa
-dWc
 aad
 aad
 aad
-ahu
-ahu
-ahu
-ahu
-ahu
-ahu
-ahu
+aad
+aqz
+aqz
+aqz
+aqz
+aqz
+aqz
+aqz
 nhU
 bpn
 xZO
 dMl
-ahu
+uhz
 gNH
 aad
 aad
@@ -62782,13 +62660,13 @@ aaa
 aaa
 aaa
 aaa
-ulC
+aaa
 aac
 aad
 aad
 aad
-ahu
-ahu
+aqz
+aqz
 ueG
 ttA
 chJ
@@ -62799,7 +62677,7 @@ xrf
 pvX
 gSv
 xtL
-ahu
+uhz
 gNH
 aad
 aad
@@ -63038,13 +62916,13 @@ aaa
 aaa
 aaa
 aaa
-ulC
+aaa
 aac
 aad
 aad
 aad
 aad
-ahu
+aqz
 lAs
 qTa
 oJp
@@ -63294,14 +63172,14 @@ aaa
 aaa
 aaa
 aaa
-ulC
+aaa
 aac
 aad
 fEM
-ckn
-ckn
-ckn
-ckn
+cWv
+cWv
+cWv
+cWv
 jpv
 msJ
 rjQ
@@ -63314,8 +63192,8 @@ jkl
 eew
 cGz
 qUW
-ahu
-ahu
+aqz
+aqz
 aGe
 sIu
 aGe
@@ -63550,14 +63428,14 @@ aaa
 aaa
 aaa
 aaa
-ulC
+aaa
 aac
 aac
 aac
-dIu
-cAr
-cAr
-cAr
+pNE
+anx
+anx
+anx
 otn
 uuJ
 tdN
@@ -63570,7 +63448,7 @@ iKp
 tgp
 dgV
 fYx
-skz
+aCG
 pEH
 pEH
 qpG
@@ -63811,17 +63689,17 @@ aac
 aad
 aad
 aad
-dIu
+pNE
 mTM
 iZQ
-kTo
+tac
 gVX
-fKT
+oiL
 kCU
 rzq
-wvE
+awI
 uVJ
-uIm
+diG
 mTv
 guM
 oCy
@@ -64068,23 +63946,23 @@ aad
 aad
 aad
 aad
-dIu
+pNE
 hOh
 iqC
-xCL
+aqA
 kHA
-fKT
+oiL
 mTT
 tgm
-lBr
+hqX
 hUL
-uIm
+diG
 rEx
 jCi
-cAr
-cAr
-cAr
-gUJ
+anx
+anx
+anx
+uok
 aad
 aad
 aGe
@@ -64325,10 +64203,10 @@ aac
 aad
 aad
 aad
-dIu
+pNE
 mTM
 bGS
-wMZ
+oaV
 srh
 bZq
 vtI
@@ -64337,11 +64215,11 @@ vJk
 nFG
 rae
 vpz
-nrv
-wev
+uSs
+xIm
 rVj
-fIe
-gUJ
+aAg
+uok
 aad
 aad
 aGe
@@ -64582,23 +64460,23 @@ aad
 aad
 aad
 aad
-dIu
-cAr
-cAr
-cAr
+pNE
+anx
+anx
+anx
 ymj
-toY
+bKQ
 fIN
-mIv
-lBr
-cWq
-uIm
-iHo
+auq
+hqX
+wqL
+diG
+yba
 eva
-xCL
+aqA
 qsc
 lUu
-gUJ
+uok
 aad
 aad
 afL
@@ -64831,7 +64709,7 @@ aaa
 aaa
 aaa
 aaa
-ulC
+aaa
 aad
 aad
 aad
@@ -64839,10 +64717,10 @@ aad
 aad
 aad
 aad
-dIu
+pNE
 oOk
 vVS
-kTo
+tac
 xEQ
 bKQ
 fvd
@@ -65087,8 +64965,8 @@ aaa
 aaa
 aaa
 aaa
-ulC
-ulC
+aaa
+aaa
 aad
 aad
 aad
@@ -65096,10 +64974,10 @@ aad
 aad
 aad
 aad
-dIu
+pNE
 kit
 ddI
-xCL
+aqA
 vmU
 bKQ
 fvd
@@ -65344,7 +65222,7 @@ aaa
 aaa
 aaa
 aaa
-ulC
+aaa
 aad
 aad
 aad
@@ -65353,10 +65231,10 @@ aad
 aad
 aad
 aad
-dIu
+pNE
 oOk
 xej
-wMZ
+oaV
 uoy
 asw
 fFw
@@ -65370,9 +65248,9 @@ aAh
 aBp
 awA
 uok
-sxc
-ahu
-ahu
+sHV
+aEt
+aEt
 abu
 bwY
 aJn
@@ -65600,8 +65478,8 @@ aaa
 aaa
 aaa
 aaa
-ulC
-ulC
+aaa
+aaa
 aad
 aad
 aad
@@ -65610,9 +65488,9 @@ abj
 aaW
 aad
 aad
-dIu
-cAr
-cAr
+pNE
+anx
+anx
 anx
 awC
 bKQ
@@ -65857,7 +65735,7 @@ aaa
 aaa
 aaa
 aaa
-ulC
+aaa
 aad
 aad
 aad
@@ -65867,7 +65745,7 @@ abj
 abi
 abi
 aad
-dIu
+pNE
 vMb
 srR
 tac
@@ -66124,7 +66002,7 @@ abj
 abj
 abu
 abu
-dIu
+pNE
 gap
 fnp
 aqA
@@ -66381,7 +66259,7 @@ abS
 abj
 abj
 acD
-dIu
+pNE
 vMb
 ujg
 oaV
@@ -66638,9 +66516,9 @@ aaV
 aad
 abS
 aad
-dIu
-cAr
-cAr
+pNE
+anx
+anx
 pjU
 qFw
 asw

--- a/_maps/map_files/OmegaStation/OmegaStation.dmm
+++ b/_maps/map_files/OmegaStation/OmegaStation.dmm
@@ -8077,7 +8077,9 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
-/mob/living/simple_animal/bot/secbot/beepsky,
+/mob/living/simple_animal/bot/secbot/beepsky{
+	name = "Officer Beepsky"
+	},
 /turf/open/floor/plasteel/red/corner,
 /area/security/brig)
 "apC" = (
@@ -28426,7 +28428,7 @@
 "bgp" = (
 /obj/structure/table/reinforced,
 /obj/machinery/button/door{
-	id = "xeno2";
+	id = "xeno1";
 	name = "Containment Control";
 	req_access_txt = "55"
 	},
@@ -28451,23 +28453,6 @@
 	icon_state = "1-2"
 	},
 /obj/effect/turf_decal/stripes/line,
-/turf/open/floor/plasteel,
-/area/science/xenobiology)
-"bgs" = (
-/obj/structure/table/reinforced,
-/obj/machinery/button/door{
-	id = "xeno3";
-	name = "Containment Control";
-	req_access_txt = "55"
-	},
-/obj/machinery/light{
-	dir = 1
-	},
-/obj/structure/extinguisher_cabinet{
-	pixel_x = 24;
-	pixel_y = 32
-	},
-/obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel,
 /area/science/xenobiology)
 "bgt" = (
@@ -28794,8 +28779,8 @@
 	req_access_txt = "47"
 	},
 /obj/machinery/door/poddoor/preopen{
-	id = "xeno2";
-	name = "Creature Cell #2"
+	id = "xeno1";
+	name = "Creature Cell #1"
 	},
 /obj/structure/cable/white{
 	icon_state = "2-4"
@@ -28836,26 +28821,6 @@
 	},
 /turf/open/floor/plasteel/whitepurple/side{
 	dir = 5
-	},
-/area/science/xenobiology)
-"bhe" = (
-/obj/machinery/door/window/brigdoor{
-	dir = 4;
-	name = "Creature Pen";
-	req_access_txt = "47"
-	},
-/obj/machinery/door/poddoor/preopen{
-	id = "xeno3";
-	name = "Creature Cell #3"
-	},
-/obj/structure/cable/white{
-	icon_state = "1-8"
-	},
-/obj/structure/cable/white{
-	icon_state = "2-8"
-	},
-/turf/open/floor/plasteel/vault{
-	dir = 8
 	},
 /area/science/xenobiology)
 "bhf" = (
@@ -29172,14 +29137,6 @@
 /turf/open/floor/plasteel/whitepurple/side{
 	dir = 4
 	},
-/area/science/xenobiology)
-"bhR" = (
-/obj/machinery/disposal/bin,
-/obj/structure/disposalpipe/trunk{
-	dir = 4
-	},
-/obj/effect/turf_decal/bot,
-/turf/open/floor/plasteel,
 /area/science/xenobiology)
 "bhS" = (
 /obj/structure/disposalpipe/trunk{
@@ -29537,10 +29494,6 @@
 	dir = 8
 	},
 /area/hallway/secondary/entry)
-"biB" = (
-/obj/structure/sign/warning/biohazard,
-/turf/closed/wall/r_wall,
-/area/science/xenobiology)
 "biC" = (
 /obj/machinery/shower{
 	dir = 4;
@@ -29565,10 +29518,6 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel,
-/area/science/xenobiology)
-"biE" = (
-/obj/structure/sign/departments/xenobio,
-/turf/closed/wall/r_wall,
 /area/science/xenobiology)
 "biF" = (
 /obj/structure/bed,
@@ -29779,7 +29728,7 @@
 "biX" = (
 /obj/structure/table/reinforced,
 /obj/machinery/button/door{
-	id = "xeno1";
+	id = "xeno2";
 	name = "Containment Control";
 	req_access_txt = "55"
 	},
@@ -29924,8 +29873,8 @@
 	req_access_txt = "47"
 	},
 /obj/machinery/door/poddoor/preopen{
-	id = "xeno1";
-	name = "Creature Cell #1"
+	id = "xeno2";
+	name = "Creature Cell #2"
 	},
 /obj/structure/cable/white{
 	icon_state = "1-4"
@@ -31844,6 +31793,36 @@
 	dir = 8
 	},
 /area/maintenance/port)
+"dWc" = (
+/turf/closed/mineral/random/labormineral,
+/area/space)
+"exb" = (
+/obj/machinery/door/window/brigdoor{
+	dir = 8;
+	name = "Creature Pen";
+	req_access_txt = "47"
+	},
+/obj/machinery/door/poddoor/preopen{
+	id = "xeno3";
+	name = "Creature Cell #3"
+	},
+/obj/structure/cable/white{
+	icon_state = "1-4"
+	},
+/obj/structure/cable/white{
+	icon_state = "2-4"
+	},
+/turf/open/floor/plasteel/vault{
+	dir = 8
+	},
+/area/science/xenobiology)
+"eFp" = (
+/obj/effect/turf_decal/stripes/end{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/turf/open/floor/plasteel,
+/area/science/xenobiology)
 "fWz" = (
 /obj/machinery/door/airlock/external{
 	name = "External Docking Port";
@@ -31857,6 +31836,9 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit)
+"glC" = (
+/turf/closed/wall/r_wall,
+/area/maintenance/starboard/aft)
 "heQ" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/machinery/navbeacon{
@@ -31892,6 +31874,18 @@
 	dir = 1
 	},
 /area/hallway/primary/central)
+"ibv" = (
+/turf/closed/wall,
+/area/science/xenobiology)
+"iVw" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/structure/cable/white{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plasteel/whitepurple/side{
+	dir = 4
+	},
+/area/science/xenobiology)
 "jcn" = (
 /obj/structure/cable/white{
 	icon_state = "4-8"
@@ -31908,6 +31902,31 @@
 	heat_capacity = 1e+006
 	},
 /area/hallway/primary/central)
+"jdD" = (
+/obj/structure/table/reinforced,
+/obj/machinery/button/door{
+	id = "xeno3";
+	name = "Containment Control";
+	req_access_txt = "55"
+	},
+/obj/effect/turf_decal/bot,
+/turf/open/floor/plasteel,
+/area/science/xenobiology)
+"jBG" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/structure/cable/white{
+	icon_state = "1-2"
+	},
+/obj/structure/cable/white{
+	icon_state = "1-4"
+	},
+/obj/structure/cable/white{
+	icon_state = "1-8"
+	},
+/turf/open/floor/plasteel/whitepurple/side{
+	dir = 4
+	},
+/area/science/xenobiology)
 "kKd" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/external{
@@ -31962,6 +31981,76 @@
 	dir = 4
 	},
 /turf/open/floor/plating,
+/area/maintenance/starboard/aft)
+"nTi" = (
+/obj/structure/sign/warning/biohazard,
+/turf/closed/wall,
+/area/science/xenobiology)
+"plz" = (
+/obj/effect/turf_decal/stripes/end{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/structure/cable/white{
+	icon_state = "1-2"
+	},
+/obj/machinery/button/door{
+	id = "xeno5";
+	name = "Containment Control";
+	pixel_x = 26;
+	pixel_y = -6;
+	req_access_txt = "55"
+	},
+/obj/machinery/button/door{
+	id = "xeno4";
+	name = "Containment Control";
+	pixel_x = 26;
+	pixel_y = 6;
+	req_access_txt = "55"
+	},
+/turf/open/floor/plasteel,
+/area/science/xenobiology)
+"psq" = (
+/obj/structure/sign/poster/random{
+	pixel_y = 32
+	},
+/turf/open/floor/plasteel/vault{
+	dir = 5
+	},
+/area/science/xenobiology)
+"pLb" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/structure/cable/white{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plasteel/whitepurple/side{
+	dir = 8
+	},
+/area/science/xenobiology)
+"rCw" = (
+/obj/machinery/door/window/brigdoor{
+	dir = 4;
+	name = "Creature Pen";
+	req_access_txt = "47"
+	},
+/obj/machinery/door/poddoor/preopen{
+	id = "xeno4";
+	name = "Creature Cell #4"
+	},
+/obj/structure/cable/white{
+	icon_state = "1-8"
+	},
+/obj/structure/cable/white{
+	icon_state = "2-8"
+	},
+/turf/open/floor/plasteel/vault{
+	dir = 8
+	},
+/area/science/xenobiology)
+"sdL" = (
+/obj/effect/turf_decal/delivery,
+/obj/machinery/hydroponics/soil,
+/turf/open/floor/plasteel/vault/side,
 /area/maintenance/starboard/aft)
 "sws" = (
 /obj/docking_port/stationary{
@@ -34455,6 +34544,19 @@
 	},
 /turf/open/floor/plasteel/purple/corner,
 /area/hallway/primary/central)
+"vsf" = (
+/obj/effect/decal/cleanable/xenoblood/xgibs,
+/turf/open/floor/plasteel/vault{
+	dir = 5
+	},
+/area/science/xenobiology)
+"wbV" = (
+/obj/effect/turf_decal/delivery,
+/obj/machinery/hydroponics/soil,
+/turf/open/floor/plasteel/vault/side{
+	dir = 1
+	},
+/area/maintenance/starboard/aft)
 "wUF" = (
 /obj/machinery/door/airlock/atmos/glass{
 	name = "Supermatter Chamber";
@@ -34465,6 +34567,30 @@
 	},
 /turf/open/floor/engine,
 /area/engine/supermatter)
+"xFw" = (
+/obj/structure/sign/departments/xenobio,
+/turf/closed/wall,
+/area/science/xenobiology)
+"yeE" = (
+/obj/machinery/door/window/brigdoor{
+	dir = 4;
+	name = "Creature Pen";
+	req_access_txt = "47"
+	},
+/obj/machinery/door/poddoor/preopen{
+	id = "xeno5";
+	name = "Creature Cell #5"
+	},
+/obj/structure/cable/white{
+	icon_state = "1-8"
+	},
+/obj/structure/cable/white{
+	icon_state = "2-8"
+	},
+/turf/open/floor/plasteel/vault{
+	dir = 8
+	},
+/area/science/xenobiology)
 
 (1,1,1) = {"
 aaa
@@ -77791,12 +77917,12 @@ sKZ
 bfP
 bfP
 bfP
+sKZ
 bfP
-aad
-aac
-aac
-aaa
-aaa
+bfP
+bfP
+bfP
+dWc
 aaa
 aaa
 aaa
@@ -78044,16 +78170,16 @@ bfP
 blu
 bgY
 bgm
-bfP
+ibv
+blu
+bgY
+bgm
+ibv
 blu
 bgY
 bgm
 bfP
 aad
-aad
-aad
-aac
-aac
 aac
 aac
 aad
@@ -78301,15 +78427,15 @@ sKZ
 bgn
 bgZ
 bhM
-bfP
+ibv
+bgn
+bgZ
+bhM
+ibv
 bgn
 bgZ
 bhM
 sKZ
-aad
-aad
-aad
-aad
 aad
 aac
 aad
@@ -78558,16 +78684,16 @@ bfP
 bgo
 bha
 bhN
-bfP
+ibv
 biW
 bjp
 bhN
+ibv
+biW
+exb
+bhN
 bfP
 bfP
-aad
-aad
-aad
-aad
 aad
 aad
 aad
@@ -78815,16 +78941,16 @@ bfP
 bgp
 bhb
 bhO
-biB
+ibv
 biX
+bhb
+bhO
+nTi
+jdD
 bhb
 bhO
 bjP
 bfP
-aad
-aad
-aad
-aad
 aad
 aad
 aad
@@ -79072,16 +79198,16 @@ bfQ
 bgq
 bhc
 bhP
+eFp
+bhP
+pLb
+bhP
 biC
 bhP
 bjq
 bjD
 bjQ
 bfP
-aad
-aad
-aad
-aad
 aad
 aad
 aad
@@ -79329,16 +79455,16 @@ bfR
 bgr
 bhd
 bhQ
+plz
+iVw
+jBG
+iVw
 biD
 biY
 bjr
 bjE
 bjR
 bfP
-aad
-aad
-aad
-aad
 aad
 aad
 aad
@@ -79583,19 +79709,19 @@ baa
 aZl
 dfP
 bfP
-bgs
-bhb
-bhR
-biB
+bgo
+rCw
+bhN
+ibv
+bgo
+yeE
+bhN
+nTi
 biZ
 bjs
 bjF
 bjS
 bfP
-aad
-aad
-aad
-aad
 aad
 aad
 aad
@@ -79840,19 +79966,19 @@ bem
 beO
 sOV
 bfP
-bgo
-bhe
-bhN
-bfP
+bgt
+bhf
+bhS
+ibv
+bgt
+bhf
+bhS
+ibv
 bja
 bjt
 bjG
 bjT
 bfP
-aad
-aad
-aad
-aad
 aad
 aad
 aad
@@ -80097,19 +80223,19 @@ ben
 beP
 bfn
 bfP
-bgt
-bhf
-bhS
-biE
+vsf
+bhg
+bgm
+ibv
+psq
+bgZ
+bgm
+xFw
 bjb
 bju
 bjH
 bfP
 sKZ
-aad
-aad
-aad
-aad
 aad
 aad
 aad
@@ -80357,15 +80483,15 @@ bfP
 bgm
 bhg
 bgm
+ibv
+bgm
+bhg
+bgm
 bfP
 bjc
 bjv
 bjc
 bfP
-aad
-aad
-aad
-aad
 aad
 aad
 aad
@@ -80612,17 +80738,17 @@ aZl
 sPI
 bfP
 bgm
-bhg
+bhi
+bgm
+ibv
+bgm
+bhi
 bgm
 sKZ
 bjd
 bjw
 bjI
 bfP
-aad
-aad
-aad
-aad
 aad
 aad
 aad
@@ -80868,18 +80994,18 @@ beq
 sKQ
 sOV
 sKZ
-bgm
-bhi
-bgm
+sKZ
+bfP
+bfP
+bfP
+sKZ
+bfP
+bfP
 bfP
 bje
 bjx
 bjI
 sKZ
-aad
-aad
-aad
-aad
 aad
 aad
 aad
@@ -81124,19 +81250,19 @@ bdy
 ber
 aZl
 bxX
-bfP
-sKZ
-bfP
-bfP
+glC
+sdL
+bhj
+wbV
+sOM
+aad
+aad
+aad
 bfP
 bfP
 bjc
 bfP
 bfP
-aad
-aad
-aad
-aad
 aad
 aad
 aad
@@ -81383,7 +81509,7 @@ beQ
 sOV
 sOM
 bgu
-bhj
+sPY
 bhT
 sOM
 aad

--- a/_maps/map_files/OmegaStation/OmegaStation.dmm
+++ b/_maps/map_files/OmegaStation/OmegaStation.dmm
@@ -8802,6 +8802,8 @@
 	pixel_y = 32
 	},
 /obj/effect/turf_decal/bot,
+/obj/item/device/multitool,
+/obj/item/device/multitool,
 /turf/open/floor/plasteel,
 /area/storage/primary)
 "aqV" = (
@@ -14316,7 +14318,6 @@
 	pixel_y = -28
 	},
 /obj/effect/turf_decal/bot,
-/obj/item/pipe_dispenser,
 /turf/open/floor/plasteel/vault/side{
 	dir = 1
 	},
@@ -14327,7 +14328,6 @@
 	},
 /obj/structure/closet/secure_closet/atmospherics,
 /obj/effect/turf_decal/bot,
-/obj/item/pipe_dispenser,
 /turf/open/floor/plasteel/vault/side{
 	dir = 1
 	},
@@ -14522,8 +14522,6 @@
 "aCN" = (
 /obj/structure/table,
 /obj/item/storage/firstaid/regular,
-/obj/item/device/multitool,
-/obj/item/device/multitool,
 /turf/open/floor/plasteel/neutral,
 /area/crew_quarters/dorms)
 "aCO" = (
@@ -18347,7 +18345,6 @@
 /obj/structure/cable/white{
 	icon_state = "4-8"
 	},
-/obj/item/device/lightreplacer,
 /turf/open/floor/plasteel/yellow/side{
 	dir = 8
 	},
@@ -24276,10 +24273,6 @@
 	},
 /obj/item/storage/backpack/satchel/med,
 /obj/effect/turf_decal/bot,
-/obj/item/storage/belt/medical,
-/obj/item/storage/belt/medical,
-/obj/item/clothing/neck/stethoscope,
-/obj/item/clothing/neck/stethoscope,
 /turf/open/floor/plasteel,
 /area/medical/medbay/zone3)
 "aXQ" = (
@@ -24300,6 +24293,10 @@
 /obj/item/storage/box/syringes,
 /obj/item/gun/syringe,
 /obj/item/reagent_containers/hypospray/CMO,
+/obj/item/storage/belt/medical,
+/obj/item/storage/belt/medical,
+/obj/item/clothing/neck/stethoscope,
+/obj/item/clothing/neck/stethoscope,
 /turf/open/floor/plasteel,
 /area/medical/medbay/zone3)
 "aXR" = (
@@ -33866,11 +33863,6 @@
 	},
 /area/ai_monitored/turret_protected/aisat_interior)
 "sNo" = (
-/obj/machinery/turretid{
-	control_area = "/area/ai_monitored/turret_protected/aisat_interior";
-	name = "AI Satellite turret control";
-	pixel_y = -24
-	},
 /obj/machinery/door/airlock/hatch{
 	name = "MiniSat Antechamber";
 	req_one_access_txt = "32;19"
@@ -34014,6 +34006,12 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 1
 	},
+/obj/machinery/turretid{
+	control_area = "/area/ai_monitored/turret_protected/aisat_interior";
+	name = "AI Satellite turret control";
+	pixel_x = 30;
+	pixel_y = 0
+	},
 /turf/open/floor/plasteel/vault/side{
 	dir = 6
 	},
@@ -34116,7 +34114,7 @@
 /area/ai_monitored/turret_protected/aisat_interior)
 "sNS" = (
 /obj/machinery/porta_turret/ai{
-	installation = /obj/item/gun/energy/e_gun
+	installation = /obj/item/gun/energy/e_gun/turret
 	},
 /obj/effect/turf_decal/delivery,
 /obj/machinery/airalarm{
@@ -34146,7 +34144,7 @@
 /area/ai_monitored/turret_protected/aisat_interior)
 "sNU" = (
 /obj/machinery/porta_turret/ai{
-	installation = /obj/item/gun/energy/e_gun
+	installation = /obj/item/gun/energy/e_gun/turret
 	},
 /obj/effect/turf_decal/delivery,
 /obj/machinery/firealarm{

--- a/_maps/map_files/OmegaStation/OmegaStation.dmm
+++ b/_maps/map_files/OmegaStation/OmegaStation.dmm
@@ -34754,8 +34754,7 @@
 /obj/machinery/turretid{
 	control_area = "/area/ai_monitored/turret_protected/aisat_interior";
 	name = "AI Satellite turret control";
-	pixel_x = 30;
-	pixel_y = 0
+	pixel_x = 30
 	},
 /turf/open/floor/plasteel/vault/side{
 	dir = 6
@@ -35200,8 +35199,7 @@
 /obj/machinery/space_heater,
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/sign/poster/random{
-	pixel_x = -32;
-	pixel_y = 0
+	pixel_x = -32
 	},
 /turf/open/floor/plasteel/caution{
 	dir = 8

--- a/code/game/machinery/igniter.dm
+++ b/code/game/machinery/igniter.dm
@@ -12,6 +12,9 @@
 	max_integrity = 300
 	armor = list("melee" = 50, "bullet" = 30, "laser" = 70, "energy" = 50, "bomb" = 20, "bio" = 0, "rad" = 0, "fire" = 100, "acid" = 70)
 	resistance_flags = FIRE_PROOF
+	
+/obj/machinery/igniter/off
+	on = FALSE
 
 /obj/machinery/igniter/attack_ai(mob/user)
 	return src.attack_hand(user)

--- a/code/game/machinery/igniter.dm
+++ b/code/game/machinery/igniter.dm
@@ -15,6 +15,7 @@
 	
 /obj/machinery/igniter/off
 	on = FALSE
+	icon_state = "igniter0"
 
 /obj/machinery/igniter/attack_ai(mob/user)
 	return src.attack_hand(user)


### PR DESCRIPTION
:cl: Denton
add: It's suicide HoPline prevention week at Omegastation! 
add: Navigation beacons and a brand-new Officer Beepsky unit have been installed. This means that crewmembers can now use medibots, janibots and other bots as well.
add: The atmospherics department has been outfitted with all missing gases as well as an incinerator and a hardsuit.
add: The size of the botany and xenobiology departments have been increased in order to increase productivity. The medbay O2 port has been moved so that doctors can access the table next to it.
add: RnD now has circuitry tools; medbay has stethoscopes+wrench+beaker/pill bottle boxes and primary tool storage has multitools. Enginers no longer have to share a single pair of insulated gloves either.
add: Engineers now have access to an Engi-Vend vending machine as well as missing tools like inducers. Circuitry storage has a smoke machine board and a solars crate in case the engine blows up.
tweak: Blueprints have been moved from the vault safe to secure storage in order to speed up construction projects.
fix: The AI sat transit tube now works! Turret controls can now be accessed from the outside. The first two turrets now use the proper type of gun. The telecomms air alarm will no longer report false alarms.
fix: The main hallway's firelocks now no longer all close at once.
/:cl:

[why]: While Omega has a decent size for lowpop, some areas are just too small and too sparsely equipped to allow proper gameplay (6 trays for 2 botanists? no gas mixing/incinerator for atmos techs? come on). 
This often leads to mass self spacing or HoPline suicides at roundstart; I hope this PR fixes that a bit.

[Botany before/after](https://i.imgur.com/IfV7l3M.jpg)
[Xenobiology before/after](https://i.imgur.com/IAbwjqa.jpg)
[Atmospherics before/after](https://i.imgur.com/netIA4q.jpg)
[Cryo before/after](https://i.imgur.com/Jy4wjw2.jpg)

<details><summary>Structural (click here):</summary>
<p>
- Added nav beacons with patrol paths as well as Officer Beepsky (the base model with 25 health).<br>
- Made botanics larger by cutting into the anti-breach storage next to it.<br>
- Increased xenobio's size, adding two slime pens.<br>
- Added missing gases (CO2, Plasma, N2O) as well as an incinerator and a hardsuit to atmospherics.<br>
- Moved the cryo O2 tank around so that docs can reach the table while it's wrenched down.<br>
- Split the "central primary hallway" area into multiple areas. This way, a single fire alarm doesn't shut down half the station.
</p>
</details>

<details><summary>Additions (click here):</summary>
<p>
- Circuitry storage: Smoke machine circuit board and a solars crate, since Omega doesn't come with solars by default.<br>
- Engineering: Insulated gloves (before, all engineers had to share a single pair). An engi-vend machine and a locker with electrical supplies.<br>
- Misc: Stethoscopes+medical wrench+beakers+pill bottles for medbay, multitools for tool storage. Also three arcade machines.
</p>
</details>

<details><summary>Tweaks (click here):</summary>
<p>
- Blueprints have been moved from the vault safe to Engineering secure storage. I've had lots of complaints that construction projects were neigh impossible because A) they were inside the vault safe and B) Omega had no stethoscopes either.<br>
- Replaced meson goggles in engineering with the scanner model.<br>
- <s>Reduced the AI sat SMES starting charge by 80%. The Omega minisat draws so little power that the SMES was at ~90% after a three hour round.</s> There is no power cable running from the AI sat to the station, so I reverted the AI sat SMES nerf.
</p>
</details>

<details><summary>Fixes (click here):</summary>
<p>
- The AI sat transit tube system now works. It was missing a pod and was blocked by two r-window spawners.<br>
- The telecomms air alarm now uses the correct "airalarm/server" subtype and should no longer report false alarms. The SME air alarm now also uses the correct "engine" subtype.<br>
- Fixed the position of the first AI sat turret control panel. Before, you had to stand inside the open door to access it.<br>
- Fixed the gun subtype of the first two turrets (it used to be e_gun instead of e_gun/turret).
</p>
</details>