### PR TITLE
Fixed diseases getting negative points

### DIFF
--- a/code/modules/antagonists/disease/disease_mob.dm
+++ b/code/modules/antagonists/disease/disease_mob.dm
@@ -225,7 +225,6 @@ the new instance inside the host to be updated to the template's stats.
 		disease_instances -= V
 		hosts -= V.affected_mob
 	else
-		points -= 1
 		to_chat(src, "<span class='notice'>One of your hosts, <b>[V.affected_mob.real_name]</b>, has been purged of your infection.</span>")
 
 		var/datum/atom_hud/my_hud = GLOB.huds[DATA_HUD_SENTIENT_DISEASE]


### PR DESCRIPTION
:cl: 
fix: Sentient diseases will no longer lose points when a host is uninfected.
/:cl:

I always intended for diseases to only lose points for buying things, getting super into debt when lots of people are cured and being unable to buy anything new makes no sense. I probably just added the subtraction by reflex in my tired stupor.

Someone please add PRB:No update or label this as a tweak.