### PR TITLE
Syndie lavaland base: adds turret control panel, soap, chemistry supplies

### DIFF
--- a/_maps/RandomRuins/LavaRuins/lavaland_surface_syndicate_base1.dmm
+++ b/_maps/RandomRuins/LavaRuins/lavaland_surface_syndicate_base1.dmm
@@ -1393,10 +1393,10 @@
 /obj/item/stock_parts/micro_laser/quadultra,
 /obj/item/stock_parts/micro_laser/quadultra,
 /obj/item/stock_parts/scanning_module/triphasic{
-	step_x = -4
+	pixel_x = -4
 	},
 /obj/item/stock_parts/scanning_module/triphasic{
-	step_x = -4
+	pixel_x = -4
 	},
 /turf/open/floor/plasteel/dark,
 /area/ruin/unpowered/syndicate_lava_base/cargo)

--- a/_maps/RandomRuins/LavaRuins/lavaland_surface_syndicate_base1.dmm
+++ b/_maps/RandomRuins/LavaRuins/lavaland_surface_syndicate_base1.dmm
@@ -612,6 +612,28 @@
 /obj/item/grenade/chem_grenade,
 /obj/item/grenade/chem_grenade,
 /obj/item/grenade/chem_grenade,
+/obj/item/grenade/chem_grenade/adv_release{
+	pixel_x = 8
+	},
+/obj/item/grenade/chem_grenade/adv_release{
+	pixel_x = 8
+	},
+/obj/item/grenade/chem_grenade/pyro{
+	pixel_x = 4;
+	pixel_y = 6
+	},
+/obj/item/grenade/chem_grenade/pyro{
+	pixel_x = 4;
+	pixel_y = 6
+	},
+/obj/item/grenade/chem_grenade/cryo{
+	pixel_x = -6;
+	pixel_y = 4
+	},
+/obj/item/grenade/chem_grenade/cryo{
+	pixel_x = -6;
+	pixel_y = 4
+	},
 /turf/open/floor/plasteel/vault{
 	dir = 8
 	},
@@ -998,6 +1020,14 @@
 /obj/item/restraints/handcuffs,
 /obj/item/device/taperecorder,
 /obj/effect/decal/cleanable/dirt,
+/obj/item/storage/box/monkeycubes{
+	pixel_x = 4;
+	pixel_y = 4
+	},
+/obj/item/storage/box/monkeycubes{
+	pixel_x = 4;
+	pixel_y = 4
+	},
 /turf/open/floor/plasteel/vault{
 	dir = 8
 	},
@@ -1334,23 +1364,39 @@
 	dir = 8
 	},
 /obj/structure/closet/crate,
-/obj/item/reagent_containers/glass/beaker/waterbottle/large{
-	pixel_x = -3;
-	pixel_y = 3
+/obj/item/stock_parts/capacitor/quadratic,
+/obj/item/stock_parts/capacitor/quadratic,
+/obj/item/stock_parts/cell/bluespace{
+	pixel_x = -2;
+	pixel_y = 2
 	},
-/obj/item/reagent_containers/glass/beaker/waterbottle/large{
-	pixel_x = -3;
-	pixel_y = 3
+/obj/item/stock_parts/cell/bluespace{
+	pixel_x = -2;
+	pixel_y = 2
 	},
-/obj/item/reagent_containers/glass/beaker/waterbottle/large,
-/obj/item/reagent_containers/glass/beaker/waterbottle/large,
-/obj/item/reagent_containers/glass/beaker/waterbottle/large{
-	pixel_x = 3;
-	pixel_y = -3
+/obj/item/stock_parts/manipulator/femto{
+	pixel_x = -4;
+	pixel_y = 4
 	},
-/obj/item/reagent_containers/glass/beaker/waterbottle/large{
-	pixel_x = 3;
-	pixel_y = -3
+/obj/item/stock_parts/manipulator/femto{
+	pixel_x = -4;
+	pixel_y = 4
+	},
+/obj/item/stock_parts/matter_bin/bluespace{
+	pixel_x = -6;
+	pixel_y = 6
+	},
+/obj/item/stock_parts/matter_bin/bluespace{
+	pixel_x = -6;
+	pixel_y = 6
+	},
+/obj/item/stock_parts/micro_laser/quadultra,
+/obj/item/stock_parts/micro_laser/quadultra,
+/obj/item/stock_parts/scanning_module/triphasic{
+	step_x = -4
+	},
+/obj/item/stock_parts/scanning_module/triphasic{
+	step_x = -4
 	},
 /turf/open/floor/plasteel/dark,
 /area/ruin/unpowered/syndicate_lava_base/cargo)
@@ -2744,7 +2790,7 @@
 	dir = 1
 	},
 /obj/machinery/turretid{
-	control_area = /area/ruin/unpowered/syndicate_lava_base;
+	control_area = "/area/ruin/unpowered/syndicate_lava_base/main";
 	dir = 1;
 	icon_state = "control_kill";
 	ailock = 1;
@@ -4101,10 +4147,10 @@
 /area/ruin/unpowered/syndicate_lava_base/bar)
 "kP" = (
 /obj/structure/reagent_dispensers/watertank,
-/obj/item/reagent_containers/glass/bucket,
-/obj/item/mop,
 /obj/effect/decal/cleanable/dirt,
 /obj/item/soap/syndie,
+/obj/item/mop,
+/obj/item/reagent_containers/glass/bucket,
 /turf/open/floor/plating,
 /area/ruin/unpowered/syndicate_lava_base/main)
 "kQ" = (

--- a/_maps/RandomRuins/LavaRuins/lavaland_surface_syndicate_base1.dmm
+++ b/_maps/RandomRuins/LavaRuins/lavaland_surface_syndicate_base1.dmm
@@ -109,6 +109,8 @@
 /obj/structure/table/reinforced,
 /obj/item/book/manual/wiki/chemistry,
 /obj/item/book/manual/wiki/chemistry,
+/obj/item/clothing/glasses/science,
+/obj/item/clothing/glasses/science,
 /turf/open/floor/plasteel/floorgrime,
 /area/ruin/unpowered/syndicate_lava_base/chemistry)
 "cG" = (
@@ -2281,6 +2283,7 @@
 /obj/item/pen/red,
 /obj/item/restraints/handcuffs,
 /obj/effect/decal/cleanable/dirt,
+/obj/item/clothing/glasses/science,
 /turf/open/floor/plasteel/white/side,
 /area/ruin/unpowered/syndicate_lava_base/virology)
 "hu" = (
@@ -2739,6 +2742,17 @@
 "is" = (
 /obj/machinery/light/small{
 	dir = 1
+	},
+/obj/machinery/turretid{
+	control_area = /area/ruin/unpowered/syndicate_lava_base;
+	dir = 1;
+	icon_state = "control_kill";
+	ailock = 1;
+	lethal = 1;
+	name = "Base turret controls";
+	pixel_y = 30;
+	req_access = null;
+	req_access_txt = "150"
 	},
 /turf/open/floor/circuit/red,
 /area/ruin/unpowered/syndicate_lava_base/main)
@@ -4090,6 +4104,7 @@
 /obj/item/reagent_containers/glass/bucket,
 /obj/item/mop,
 /obj/effect/decal/cleanable/dirt,
+/obj/item/soap/syndie,
 /turf/open/floor/plating,
 /area/ruin/unpowered/syndicate_lava_base/main)
 "kQ" = (
@@ -4586,7 +4601,7 @@
 	dir = 9
 	},
 /turf/closed/wall/mineral/plastitanium/nodiagonal,
-/area/ruin/unpowered/syndicate_lava_base/arrivals)
+/area/ruin/unpowered/syndicate_lava_base/main)
 "lT" = (
 /obj/structure/fans/tiny,
 /obj/machinery/door/airlock/external{


### PR DESCRIPTION
:cl: Denton
tweak: The lavaland Syndicate base has been outfitted with a turret control panel as well as more chemistry supplies and one (1) bar of Syndicate brand soap.
/:cl:

I've noticed that people who spawn in this ruin quickly run out of things to do - you only have so many grenades and very few monkeys to test them on. I have added monkey cube boxes and two adv/cryo/pyro grenades each to make up for that.

The crate full of stock parts is so that you can properly test chem macros (the recent nerf makes you unable to with roundstart chem dispensers).

The control panel lets you disable turrets in case they attract fauna and/or you want to kill the fauna yourself. 
Soap lets you clean the microwave so it doesn't explode during long shifts. 
Science goggles for doing science (the bioweapon syndies don't spawn with them).