### PR TITLE
Mining hardsuit now has no slowdown in low pressure

### DIFF
--- a/code/modules/clothing/spacesuits/hardsuit.dm
+++ b/code/modules/clothing/spacesuits/hardsuit.dm
@@ -249,6 +249,32 @@
 	allowed = list(/obj/item/device/flashlight, /obj/item/tank/internals, /obj/item/storage/bag/ore, /obj/item/pickaxe)
 	helmettype = /obj/item/clothing/head/helmet/space/hardsuit/mining
 	heat_protection = CHEST|GROIN|LEGS|FEET|ARMS|HANDS
+	var/datum/component/mobhook
+
+/obj/item/clothing/suit/space/hardsuit/mining/proc/on_mob_move()
+	var/turf/T = get_turf(loc)
+	if(lavaland_equipment_pressure_check(T))
+		slowdown = 0
+	else
+		slowdown = 1
+		
+/obj/item/clothing/suit/space/hardsuit/mining/equipped(mob/user, slot)
+	. = ..()
+	if (slot == slot_wear_suit)
+		if (mobhook && mobhook.parent != user)
+			QDEL_NULL(mobhook)
+		if (!mobhook)
+			mobhook = user.AddComponent(/datum/component/redirect, list(COMSIG_MOVABLE_MOVED), CALLBACK(src, .proc/on_mob_move))
+	else
+		QDEL_NULL(mobhook)
+
+/obj/item/clothing/suit/space/hardsuit/mining/dropped()
+	. = ..()
+	QDEL_NULL(mobhook)
+
+/obj/item/clothing/suit/space/hardsuit/mining/Destroy()
+	QDEL_NULL(mobhook) // mobhook is not our component
+	return ..()
 
 	//Syndicate hardsuit
 /obj/item/clothing/head/helmet/space/hardsuit/syndi


### PR DESCRIPTION
:cl:Zxaber
balance:Mining hardsuit no longer has a slowdown in low pressure enviroments
/:cl:

Movement speed is important for miners to avoid death by fauna. As such, the mining hardsuit is useful for trips to the ORM, if the station has breaches, but offer only a disadvantage when actually mining. This change give the hardsuit full movement speed in low pressure areas, granting it better use for the task it's specifically stocked for.

The atmosphere check code was specifically stolen from the Ripley mech, which has the same feature. If the Ripley gets it's bonus movement speed in a given area, the mining hardsuit will as well.

