### PR TITLE
Engie goggles in Meson mode now respect light levels

### DIFF
--- a/code/modules/clothing/glasses/engine_goggles.dm
+++ b/code/modules/clothing/glasses/engine_goggles.dm
@@ -37,7 +37,7 @@
 		if(MODE_MESON)
 			vision_flags = SEE_TURFS
 			darkness_view = 1
-			"lighting_alpha = LIGHTING_PLANE_ALPHA_MOSTLY_VISIBLE"
+			lighting_alpha = LIGHTING_PLANE_ALPHA_MOSTLY_VISIBLE
 
 		if(MODE_TRAY) //undoes the last mode, meson
 			vision_flags = NONE

--- a/code/modules/clothing/glasses/engine_goggles.dm
+++ b/code/modules/clothing/glasses/engine_goggles.dm
@@ -37,7 +37,7 @@
 		if(MODE_MESON)
 			vision_flags = SEE_TURFS
 			darkness_view = 1
-			lighting_alpha = LIGHTING_PLANE_ALPHA_INVISIBLE
+			"lighting_alpha = LIGHTING_PLANE_ALPHA_MOSTLY_VISIBLE"
 
 		if(MODE_TRAY) //undoes the last mode, meson
 			vision_flags = NONE


### PR DESCRIPTION
:cl:Zxaber
tweak:Engineer Goggles now show light levels in Meson mode the same way Meson Glasses do.
/:cl:


Meson glasses show the surrounding terrain, but darken areas beyond line of sight and that are not lit. Engineer goggles set to Meson mode currently show all terrain at max brightness. As a result, it can be hard to even know an area is unlit until objects (or mobs) suddenly start popping in one tile away.

This change makes the Engineer goggles respect light levels like Meson glasses do.

An image for visual aid;
https://i.imgur.com/KdYmkZb.png
Left shows the current Engineer goggles. Right shows the current Meson glasses, and how the Engineer goggles will look with this change.