### PR TITLE
Lowers damage cap on breaking hacked apcs

### DIFF
--- a/code/modules/power/apc.dm
+++ b/code/modules/power/apc.dm
@@ -684,7 +684,7 @@
 			to_chat(user, "<span class='warning'>Access denied.</span>")
 
 /obj/machinery/power/apc/run_obj_armor(damage_amount, damage_type, damage_flag = 0, attack_dir)
-	if(damage_flag == "melee" && damage_amount < 15 && (!(stat & BROKEN) || malfai))
+	if(damage_flag == "melee" && damage_amount < 10 && (!(stat & BROKEN) || malfai))
 		return 0
 	. = ..()
 


### PR DESCRIPTION
Now you can actually break APCs with toolboxes and extinguishers instead of needing spears

:cl: 
fix: Malf hacked APCs can be broken with extinguishers and toolboxes again.
/:cl:

I consider this a fix, mainly because I took a look at the blame, and it was originally set to 10, and phil arbitrarily changed it to 15 when he did his damage rework.