### PR TITLE
Burning ores (from either fire or lava) now yields materials at a decreased rate.

### DIFF
--- a/code/modules/mining/ores_coins.dm
+++ b/code/modules/mining/ores_coins.dm
@@ -53,7 +53,8 @@
 	if(!refined_type)
 		return ..()
 	var/obj/item/stack/sheet/S = new refined_type(drop_location())
-	var/amountrefined = round(amount/2)
+	var/percent = rand(0.3,0.7)
+	var/amountrefined = round(amount*percent)
 	S.amount = amountrefined
 	S.update_icon()
 	qdel(src)

--- a/code/modules/mining/ores_coins.dm
+++ b/code/modules/mining/ores_coins.dm
@@ -49,6 +49,15 @@
 
 	return TRUE
 
+/obj/item/stack/ore/burn()
+	if(!refined_type)
+		return ..()
+	var/obj/item/stack/sheet/S = new refined_type(drop_location())
+	var/amountrefined = round(amount/2)
+	S.amount = amountrefined
+	S.update_icon()
+	qdel(src)
+
 /obj/item/stack/ore/uranium
 	name = "uranium ore"
 	icon_state = "Uranium ore"


### PR DESCRIPTION
:cl: Fludd12
add: Burning ores now yields materials at a very reduced ratio! Lavaland roles will now be able to construct things with enough effort.
/:cl:

There's really no reason why this shouldn't be a thing, in my mind. Lavaland roles (outside of golems, at least) don't have many methods of easily obtaining metal, which at the very least makes for a useful building material.

Notably, if they're not quick about pulling the ore off of the lava or fire, it'll set the material on fire, too - most lavaland roles have access to water, but this does make things at least a bit harder.