### PR TITLE
Fix N2 filter in deep storage ruin

### DIFF
--- a/_maps/RandomRuins/SpaceRuins/deepstorage.dmm
+++ b/_maps/RandomRuins/SpaceRuins/deepstorage.dmm
@@ -2749,7 +2749,7 @@
 "gO" = (
 /obj/machinery/atmospherics/components/trinary/filter{
 	dir = 1;
-	filter_type = "n2o";
+	filter_type = "n2";
 	on = 1
 	},
 /turf/open/floor/plasteel/floorgrime,


### PR DESCRIPTION
Imagine my surprise when I go to dump the N2O canister to waste and it filters into the N2 chamber instead.