### PR TITLE
April Fools Day replaces the overflow role with Clowns

### DIFF
--- a/code/__DEFINES/role_preferences.dm
+++ b/code/__DEFINES/role_preferences.dm
@@ -51,6 +51,6 @@ GLOBAL_LIST_INIT(special_roles, list(
 ))
 
 //Job defines for what happens when you fail to qualify for any job during job selection
-#define BEASSISTANT 	1
+#define BEOVERFLOW 	1
 #define BERANDOMJOB 	2
 #define RETURNTOLOBBY 	3

--- a/code/controllers/subsystem/job.dm
+++ b/code/controllers/subsystem/job.dm
@@ -13,6 +13,8 @@ SUBSYSTEM_DEF(job)
 	var/list/prioritized_jobs = list()
 	var/list/latejoin_trackers = list()	//Don't read this list, use GetLateJoinTurfs() instead
 
+	var/overflow_role = "Assistant"
+
 /datum/controller/subsystem/job/Initialize(timeofday)
 	if(!occupations.len)
 		SetupOccupations()
@@ -119,7 +121,7 @@ SUBSYSTEM_DEF(job)
 		if(!job)
 			continue
 
-		if(istype(job, GetJob("Assistant"))) // We don't want to give him assistant, that's boring!
+		if(istype(job, GetJob(SSjob.overflow_role))) // We don't want to give him assistant, that's boring!
 			continue
 
 		if(job.title in GLOB.command_positions) //If you want a command position, select it!
@@ -250,15 +252,15 @@ SUBSYSTEM_DEF(job)
 
 	HandleFeedbackGathering()
 
-	//People who wants to be assistants, sure, go on.
-	Debug("DO, Running Assistant Check 1")
-	var/datum/job/assist = new /datum/job/assistant()
-	var/list/assistant_candidates = FindOccupationCandidates(assist, 3)
-	Debug("AC1, Candidates: [assistant_candidates.len]")
-	for(var/mob/dead/new_player/player in assistant_candidates)
+	//People who wants to be the overflow role, sure, go on.
+	Debug("DO, Running Overflow Check 1")
+	var/datum/job/overflow = GetJob(SSjob.overflow_role)
+	var/list/overflow_candidates = FindOccupationCandidates(overflow, 3)
+	Debug("AC1, Candidates: [overflow_candidates.len]")
+	for(var/mob/dead/new_player/player in overflow_candidates)
 		Debug("AC1 pass, Player: [player]")
-		AssignRole(player, "Assistant")
-		assistant_candidates -= player
+		AssignRole(player, SSjob.overflow_role)
+		overflow_candidates -= player
 	Debug("DO, AC1 end")
 
 	//Select one head
@@ -327,8 +329,8 @@ SUBSYSTEM_DEF(job)
 	for(var/mob/dead/new_player/player in unassigned)
 		if(PopcapReached())
 			RejectPlayer(player)
-		else if(jobban_isbanned(player, "Assistant"))
-			GiveRandomJob(player) //you get to roll for random before everyone else just to be sure you don't get assistant. you're so speshul
+		else if(jobban_isbanned(player, SSjob.overflow_role))
+			GiveRandomJob(player) //you get to roll for random before everyone else just to be sure you don't get overflow. you're so speshul
 
 	for(var/mob/dead/new_player/player in unassigned)
 		if(PopcapReached())
@@ -344,15 +346,15 @@ SUBSYSTEM_DEF(job)
 	for(var/mob/dead/new_player/player in unassigned)
 		if(PopcapReached())
 			RejectPlayer(player)
-		if(player.client.prefs.joblessrole == BEASSISTANT)
+		if(player.client.prefs.joblessrole == BEOVERFLOW)
 			Debug("AC2 Assistant located, Player: [player]")
-			AssignRole(player, "Assistant")
+			AssignRole(player, SSjob.overflow_role)
 		else // For those who don't want to play if their preference were filled, back you go.
 			RejectPlayer(player)
 
 	for(var/mob/dead/new_player/player in unassigned) //Players that wanted to back out but couldn't because they're antags (can you feel the edge case?)
 		if(!GiveRandomJob(player))
-			AssignRole(player, "Assistant") //If everything is already filled, make them an assistant
+			AssignRole(player, SSjob.overflow_role) //If everything is already filled, make them an assistant
 
 	return 1
 

--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -569,7 +569,7 @@ GLOBAL_LIST_EMPTY(preferences_datums)
 				var/available_in_days = job.available_in_days(user.client)
 				HTML += "<font color=red>[rank]</font></td><td><font color=red> \[IN [(available_in_days)] DAYS\]</font></td></tr>"
 				continue
-			if((job_civilian_low & ASSISTANT) && (rank != "Assistant") && !jobban_isbanned(user, "Assistant"))
+			if((job_civilian_low) && (rank != SSjob.overflow_role) && !jobban_isbanned(user, SSjob.overflow_role))
 				HTML += "<font color=orange>[rank]</font></td><td></td></tr>"
 				continue
 			if((rank in GLOB.command_positions) || (rank == "AI"))//Bold head jobs
@@ -608,8 +608,8 @@ GLOBAL_LIST_EMPTY(preferences_datums)
 
 			HTML += "<a class='white' href='?_src_=prefs;preference=job;task=setJobLevel;level=[prefUpperLevel];text=[rank]' oncontextmenu='javascript:return setJobPrefRedirect([prefLowerLevel], \"[rank]\");'>"
 
-			if(rank == "Assistant")//Assistant is special
-				if(job_civilian_low & ASSISTANT)
+			if(rank == SSjob.overflow_role)//Overflow is special
+				if(job_civilian_low)
 					HTML += "<font color=green>Yes</font>"
 				else
 					HTML += "<font color=red>No</font>"
@@ -625,7 +625,7 @@ GLOBAL_LIST_EMPTY(preferences_datums)
 		HTML += "</td'></tr></table>"
 		HTML += "</center></table>"
 
-		var/message = "Be an Assistant if preferences unavailable"
+		var/message = "Be an [SSjob.overflow_role] if preferences unavailable"
 		if(joblessrole == BERANDOMJOB)
 			message = "Get random job if preferences unavailable"
 		else if(joblessrole == RETURNTOLOBBY)
@@ -713,7 +713,7 @@ GLOBAL_LIST_EMPTY(preferences_datums)
 		ShowChoices(user)
 		return
 
-	if(role == "Assistant")
+	if(role == SSjob.overflow_role)
 		if(job_civilian_low & job.flag)
 			job_civilian_low &= ~job.flag
 		else
@@ -863,11 +863,11 @@ GLOBAL_LIST_EMPTY(preferences_datums)
 			if("random")
 				switch(joblessrole)
 					if(RETURNTOLOBBY)
-						if(jobban_isbanned(user, "Assistant"))
+						if(jobban_isbanned(user, SSjob.overflow_role))
 							joblessrole = BERANDOMJOB
 						else
-							joblessrole = BEASSISTANT
-					if(BEASSISTANT)
+							joblessrole = BEOVERFLOW
+					if(BEOVERFLOW)
 						joblessrole = BERANDOMJOB
 					if(BERANDOMJOB)
 						joblessrole = RETURNTOLOBBY

--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -542,6 +542,8 @@ GLOBAL_LIST_EMPTY(preferences_datums)
 		//The job before the current job. I only use this to get the previous jobs color when I'm filling in blank rows.
 		var/datum/job/lastJob
 
+		var/datum/job/overflow = SSjob.GetJob(SSjob.overflow_role)
+
 		for(var/datum/job/job in SSjob.occupations)
 
 			index += 1
@@ -569,7 +571,7 @@ GLOBAL_LIST_EMPTY(preferences_datums)
 				var/available_in_days = job.available_in_days(user.client)
 				HTML += "<font color=red>[rank]</font></td><td><font color=red> \[IN [(available_in_days)] DAYS\]</font></td></tr>"
 				continue
-			if((job_civilian_low) && (rank != SSjob.overflow_role) && !jobban_isbanned(user, SSjob.overflow_role))
+			if((job_civilian_low & overflow.flag) && (rank != SSjob.overflow_role) && !jobban_isbanned(user, SSjob.overflow_role))
 				HTML += "<font color=orange>[rank]</font></td><td></td></tr>"
 				continue
 			if((rank in GLOB.command_positions) || (rank == "AI"))//Bold head jobs
@@ -609,7 +611,7 @@ GLOBAL_LIST_EMPTY(preferences_datums)
 			HTML += "<a class='white' href='?_src_=prefs;preference=job;task=setJobLevel;level=[prefUpperLevel];text=[rank]' oncontextmenu='javascript:return setJobPrefRedirect([prefLowerLevel], \"[rank]\");'>"
 
 			if(rank == SSjob.overflow_role)//Overflow is special
-				if(job_civilian_low)
+				if(job_civilian_low & overflow.flag)
 					HTML += "<font color=green>Yes</font>"
 				else
 					HTML += "<font color=red>No</font>"

--- a/code/modules/holiday/holidays.dm
+++ b/code/modules/holiday/holidays.dm
@@ -149,10 +149,11 @@
 /datum/holiday/april_fools
 	name = APRIL_FOOLS
 	begin_day = 1
-	end_day = 2
+	end_day = 5
 	begin_month = APRIL
 
 /datum/holiday/april_fools/celebrate()
+	SSjob.overflow_role = "Clown"
 	SSticker.login_music = 'sound/ambience/clown.ogg'
 	for(var/mob/dead/new_player/P in GLOB.mob_list)
 		if(P.client)

--- a/code/modules/mob/dead/new_player/new_player.dm
+++ b/code/modules/mob/dead/new_player/new_player.dm
@@ -430,9 +430,9 @@
 			if (job.title in GLOB.command_positions)
 				position_class = "commandPosition"
 			dat += "<a class='[position_class]' href='byond://?src=[REF(src)];SelectedJob=[job.title]'>[job.title] ([job.current_positions])</a><br>"
-	if(!job_count) //if there's nowhere to go, assistant opens up.
+	if(!job_count) //if there's nowhere to go, overflow opens up.
 		for(var/datum/job/job in SSjob.occupations)
-			if(job.title != "Assistant")
+			if(job.title != SSjob.overflow_role)
 				continue
 			dat += "<a class='otherPosition' href='byond://?src=[REF(src)];SelectedJob=[job.title]'>[job.title] ([job.current_positions])</a><br>"
 			break


### PR DESCRIPTION
:cl: Kor
code: Jobs other than Assistant may now be assigned by admins or events as the overflow role
add: April Fools now sets the overflow role as Clown.
/:cl:

Changed the overflow role stuff to use a var instead of always Assistant, meaning admins or coders can pick whatever job they want as the overflow.

April fools now lasts the 1st to the 5th, and sets clown as the overflow role.
