### PR TITLE
Adds lights to the bridge on Omega

### DIFF
--- a/_maps/map_files/OmegaStation/OmegaStation.dmm
+++ b/_maps/map_files/OmegaStation/OmegaStation.dmm
@@ -517,6 +517,7 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden,
+/obj/machinery/light,
 /turf/open/floor/plasteel/vault/side{
 	dir = 1
 	},
@@ -581,6 +582,7 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 1
 	},
+/obj/machinery/light,
 /turf/open/floor/plasteel/vault/side{
 	dir = 1
 	},


### PR DESCRIPTION
Spots by the airlocks had no lighting when night shift is enabled. This alleviates it.