### PR TITLE
Removes toolarm prefix from toolarm surgery tools.

### DIFF
--- a/code/modules/surgery/tools.dm
+++ b/code/modules/surgery/tools.dm
@@ -9,7 +9,7 @@
 
 
 /obj/item/retractor/augment
-	name = "toolarm retractor"
+	name = "retractor"
 	desc = "Micro-mechanical manipulator for retracting stuff."
 	icon = 'icons/obj/surgery.dmi'
 	icon_state = "retractor"
@@ -31,7 +31,7 @@
 
 
 /obj/item/hemostat/augment
-	name = "toolarm hemostat"
+	name = "hemostat"
 	desc = "Tiny servos power a pair of pincers to stop bleeding."
 	icon = 'icons/obj/surgery.dmi'
 	icon_state = "hemostat"
@@ -54,7 +54,7 @@
 
 
 /obj/item/cautery/augment
-	name = "toolarm cautery"
+	name = "cautery"
 	desc = "A heated element that cauterizes wounds."
 	icon = 'icons/obj/surgery.dmi'
 	icon_state = "cautery"
@@ -81,7 +81,7 @@
 
 
 /obj/item/surgicaldrill/augment
-	name = "toolarm surgical drill"
+	name = "surgical drill"
 	desc = "Effectively a small power drill contained within your arm, edges dulled to prevent tissue damage. May or may not pierce the heavens."
 	icon = 'icons/obj/surgery.dmi'
 	icon_state = "drill"
@@ -117,7 +117,7 @@
 	AddComponent(/datum/component/butchering, 80 * toolspeed, 100, 0)
 
 /obj/item/scalpel/augment
-	name = "toolarm scalpel"
+	name = "scalpel"
 	desc = "Ultra-sharp blade attached directly to your bone for extra-accuracy."
 	icon = 'icons/obj/surgery.dmi'
 	icon_state = "scalpel"
@@ -162,7 +162,7 @@
 	AddComponent(/datum/component/butchering, 40 * toolspeed, 100, 5, 'sound/weapons/circsawhit.ogg') //saws are very accurate and fast at butchering
 
 /obj/item/circular_saw/augment
-	name = "toolarm circular saw"
+	name = "circular saw"
 	desc = "A small but very fast spinning saw. Edges dulled to prevent accidental cutting inside of the surgeon."
 	icon = 'icons/obj/surgery.dmi'
 	icon_state = "saw"


### PR DESCRIPTION
:cl: 
spellcheck: Toolsarm surgery items no longer have the toolarm prefix.
:cl:
fixes #36538
