### PR TITLE
Prevents overriding shuttle areas

### DIFF
--- a/code/__HELPERS/areas.dm
+++ b/code/__HELPERS/areas.dm
@@ -36,7 +36,10 @@
 
 /proc/create_area(mob/creator)
 	var/static/blacklisted_turfs = typecacheof(/turf/open/space)
-	var/static/blacklisted_areas = typecacheof(/area/space)
+	var/static/blacklisted_areas = typecacheof(list(
+		/area/space,
+		/area/shuttle,
+		))
 	var/list/turfs = detect_room(get_turf(creator), blacklisted_turfs)
 	if(!turfs)
 		to_chat(creator, "<span class='warning'>The new area must be completely airtight and not a part of a shuttle.</span>")


### PR DESCRIPTION
:cl: ninjanomnom
fix: You can no longer override shuttle areas with new or expanded areas from elsewhere.
/:cl:

fixes #35222
