### PR TITLE
Sets the default preload_rsc to 2

### DIFF
--- a/code/_compile_options.dm
+++ b/code/_compile_options.dm
@@ -14,7 +14,7 @@
 //#define UNIT_TESTS			//Enables unit tests via TEST_RUN_PARAMETER
 
 #ifndef PRELOAD_RSC				//set to:
-#define PRELOAD_RSC	0			//	0 to allow using external resources or on-demand behaviour;
+#define PRELOAD_RSC	2			//	0 to allow using external resources or on-demand behaviour;
 #endif							//	1 to use the default behaviour;
 								//	2 for preloading absolutely everything;
 


### PR DESCRIPTION
This was supposed to be 1 or 2 (2 preloads uploaded resources) in the repo and set to 0 in [`server_side_modifications.dm`](https://tgstation13.org/parsed-logs/basil/server_side_modifications.dm) but i messed that up when i switched it from a test merging pr to something mergable.
