### PR TITLE
Supermatter now always spawns a singularity or tesla ball when failing

### DIFF
--- a/code/modules/power/supermatter/supermatter.dm
+++ b/code/modules/power/supermatter/supermatter.dm
@@ -234,20 +234,13 @@ GLOBAL_DATUM(main_supermatter_engine, /obj/machinery/power/supermatter_shard)
 			SEND_SOUND(M, 'sound/magic/charge.ogg')
 			to_chat(M, "<span class='boldannounce'>You feel reality distort for a moment...</span>")
 			M.SendSignal(COMSIG_ADD_MOOD_EVENT, "delam", /datum/mood_event/delam)
-	if(combined_gas > MOLE_PENALTY_THRESHOLD)
-		investigate_log("has collapsed into a singularity.", INVESTIGATE_SUPERMATTER)
-		if(T)
-			var/obj/singularity/S = new(T)
-			S.energy = 800
-			S.consume(src)
-	else
-		investigate_log("has exploded.", INVESTIGATE_SUPERMATTER)
-		explosion(get_turf(T), explosion_power * max(gasmix_power_ratio, 0.205) * 0.5 , explosion_power * max(gasmix_power_ratio, 0.205) + 2, explosion_power * max(gasmix_power_ratio, 0.205) + 4 , explosion_power * max(gasmix_power_ratio, 0.205) + 6, 1, 1)
-		if(power > POWER_PENALTY_THRESHOLD)
-			investigate_log("has spawned additional energy balls.", INVESTIGATE_SUPERMATTER)
-			var/obj/singularity/energy_ball/E = new(T)
-			E.energy = power
-		qdel(src)
+	investigate_log("has collapsed into a singularity.", INVESTIGATE_SUPERMATTER)
+	if(T)
+		explosion(get_turf(T), 0, 4, 12, 15)
+		var/obj/singularity/S = new(T)
+		S.energy = 800
+		S.consume(src)
+
 
 /obj/machinery/power/supermatter_shard/process_atmos()
 	var/turf/T = loc

--- a/code/modules/power/supermatter/supermatter.dm
+++ b/code/modules/power/supermatter/supermatter.dm
@@ -234,12 +234,19 @@ GLOBAL_DATUM(main_supermatter_engine, /obj/machinery/power/supermatter_shard)
 			SEND_SOUND(M, 'sound/magic/charge.ogg')
 			to_chat(M, "<span class='boldannounce'>You feel reality distort for a moment...</span>")
 			M.SendSignal(COMSIG_ADD_MOOD_EVENT, "delam", /datum/mood_event/delam)
-	investigate_log("has collapsed into a singularity.", INVESTIGATE_SUPERMATTER)
-	if(T)
-		explosion(get_turf(T), 0, 4, 12, 15)
-		var/obj/singularity/S = new(T)
-		S.energy = 800
-		S.consume(src)
+	if(power > POWER_PENALTY_THRESHOLD)
+		investigate_log("has exploded and spawned a Tesla ball.", INVESTIGATE_SUPERMATTER)
+		explosion(get_turf(T), explosion_power * max(gasmix_power_ratio, 0.205) * 0.5 , explosion_power * max(gasmix_power_ratio, 0.205) + 2, explosion_power * max(gasmix_power_ratio, 0.205) + 4 , explosion_power * max(gasmix_power_ratio, 0.205) + 6, 1, 1)
+		var/obj/singularity/energy_ball/E = new(T)
+		E.energy = power
+		qdel(src)
+	else
+		investigate_log("has collapsed into a singularity.", INVESTIGATE_SUPERMATTER)
+		if(T)
+			explosion(get_turf(T), 0, 4, 12, 15)
+			var/obj/singularity/S = new(T)
+			S.energy = 800
+			S.consume(src)
 
 
 /obj/machinery/power/supermatter_shard/process_atmos()


### PR DESCRIPTION
The supermatter rarely meets the requirements for spawning a singularity or tesla ball and the standard explosion is kinda boring. This PR makes it so the supermatter failing will always produce a singularity (and a small explosion). 

:cl: 
tweak: Failing supermatter crystals will now always result in a gravitational singularity.
/:cl:

Edit: I put the tesla back, at high power the result is once again a tesla ball (and a huge explosion), at low power the result is a singularity.