### PR TITLE
[wip]Database backed stickybans

### DIFF
--- a/SQL/database_changelog.txt
+++ b/SQL/database_changelog.txt
@@ -1,12 +1,34 @@
 Any time you make a change to the schema files, remember to increment the database schema version. Generally increment the minor number, major should be reserved for significant changes to the schema. Both values go up to 255.
 
-The latest database version is 4.1; The query to update the schema revision table is:
+The latest database version is 4.2; The query to update the schema revision table is:
 
-INSERT INTO `schema_revision` (`major`, `minor`) VALUES (4, 1);
+INSERT INTO `schema_revision` (`major`, `minor`) VALUES (4, 2);
 or
-INSERT INTO `SS13_schema_revision` (`major`, `minor`) VALUES (4, 1);
+INSERT INTO `SS13_schema_revision` (`major`, `minor`) VALUES (4, 2);
 
 In any query remember to add a prefix to the table names if you use one.
+
+----------------------------------------------------
+
+Version 4.2, 20 March 2018, by MrStonedOne
+Added two tables to enable storing of stickybans in the database since byond can lose them, and to enable disabling stickybans for a round without depending on a crash free round.
+
+CREATE TABLE `stickyban` (
+	`ckey` VARCHAR(32) NOT NULL,
+	`reason` VARCHAR(2048) NOT NULL,
+	`banning_admin` VARCHAR(32) NOT NULL,
+	`datetime` DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+	PRIMARY KEY (`ckey`)
+) ENGINE=InnoDB;
+
+CREATE TABLE `stickyban_matched_ckey` (
+	`stickyban` VARCHAR(32) NOT NULL,
+	`matched_ckey` VARCHAR(32) NOT NULL,
+	`first_matched` TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+	`exempt` TINYINT(1) NOT NULL DEFAULT '0',
+	PRIMARY KEY (`stickyban`, `matched_ckey`)
+) ENGINE=InnoDB;
+
 
 ----------------------------------------------------
 

--- a/SQL/tgstation_schema.sql
+++ b/SQL/tgstation_schema.sql
@@ -424,6 +424,30 @@ CREATE TABLE `schema_revision` (
   PRIMARY KEY (`major`, `minor`)
 ) ENGINE=InnoDB DEFAULT CHARSET=latin1;
 
+--
+-- Table structure for table `stickyban`
+--
+DROP TABLE IF EXISTS `stickyban`;
+CREATE TABLE `stickyban` (
+	`ckey` VARCHAR(32) NOT NULL,
+	`reason` VARCHAR(2048) NOT NULL,
+	`banning_admin` VARCHAR(32) NOT NULL,
+	`datetime` DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+	PRIMARY KEY (`ckey`)
+) ENGINE=InnoDB;
+
+--
+-- Table structure for table `stickyban_matched_ckey`
+--
+DROP TABLE IF EXISTS `stickyban_matched_ckey`;
+CREATE TABLE `stickyban_matched_ckey` (
+	`stickyban` VARCHAR(32) NOT NULL,
+	`matched_ckey` VARCHAR(32) NOT NULL,
+	`first_matched` TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+	`exempt` TINYINT(1) NOT NULL DEFAULT '0',
+	PRIMARY KEY (`stickyban`, `matched_ckey`)
+) ENGINE=InnoDB;
+
 /*!40101 SET SQL_MODE=@OLD_SQL_MODE */;
 /*!40014 SET FOREIGN_KEY_CHECKS=@OLD_FOREIGN_KEY_CHECKS */;
 /*!40014 SET UNIQUE_CHECKS=@OLD_UNIQUE_CHECKS */;

--- a/SQL/tgstation_schema_prefixed.sql
+++ b/SQL/tgstation_schema_prefixed.sql
@@ -424,6 +424,30 @@ CREATE TABLE `SS13_schema_revision` (
   PRIMARY KEY (`major`,`minor`)
 ) ENGINE=InnoDB DEFAULT CHARSET=latin1;
 
+--
+-- Table structure for table `SS13_stickyban`
+--
+DROP TABLE IF EXISTS `SS13_stickyban`;
+CREATE TABLE `SS13_stickyban` (
+	`ckey` VARCHAR(32) NOT NULL,
+	`reason` VARCHAR(2048) NOT NULL,
+	`banning_admin` VARCHAR(32) NOT NULL,
+	`datetime` DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+	PRIMARY KEY (`ckey`)
+) ENGINE=InnoDB;
+
+--
+-- Table structure for table `ss13_stickyban_matched_ckey`
+--
+DROP TABLE IF EXISTS `ss13_stickyban_matched_ckey`;
+CREATE TABLE `ss13_stickyban_matched_ckey` (
+	`stickyban` VARCHAR(32) NOT NULL,
+	`matched_ckey` VARCHAR(32) NOT NULL,
+	`first_matched` TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+	`exempt` TINYINT(1) NOT NULL DEFAULT '0',
+	PRIMARY KEY (`stickyban`, `matched_ckey`)
+) ENGINE=InnoDB;
+
 /*!40101 SET SQL_MODE=@OLD_SQL_MODE */;
 /*!40014 SET FOREIGN_KEY_CHECKS=@OLD_FOREIGN_KEY_CHECKS */;
 /*!40014 SET UNIQUE_CHECKS=@OLD_UNIQUE_CHECKS */;

--- a/code/__DEFINES/admin.dm
+++ b/code/__DEFINES/admin.dm
@@ -76,3 +76,6 @@
 
 #define SPAM_TRIGGER_WARNING	5	//Number of identical messages required before the spam-prevention will warn you to stfu
 #define SPAM_TRIGGER_AUTOMUTE	10	//Number of identical messages required before the spam-prevention will automute you
+
+#define STICKYBAN_DB_CACHE_TIME 10 SECONDS
+#define STICKYBAN_ROGUE_CHECK_TIME 5 SECONDS

--- a/code/__DEFINES/subsystems.dm
+++ b/code/__DEFINES/subsystems.dm
@@ -1,7 +1,7 @@
 //Update this whenever the db schema changes
 //make sure you add an update to the schema_version stable in the db changelog
 #define DB_MAJOR_VERSION 4
-#define DB_MINOR_VERSION 1
+#define DB_MINOR_VERSION 2
 
 //Timing subsystem
 //Don't run if there is an identical unique timer active

--- a/code/controllers/subsystem/server_maint.dm
+++ b/code/controllers/subsystem/server_maint.dm
@@ -9,6 +9,9 @@ SUBSYSTEM_DEF(server_maint)
 	runlevels = RUNLEVEL_LOBBY | RUNLEVELS_DEFAULT
 	var/list/currentrun
 
+/datum/controller/subsystem/server_maint/PreInit()
+	world.hub_password = "" //quickly! before the hubbies see us.
+
 /datum/controller/subsystem/server_maint/Initialize(timeofday)
 	if (CONFIG_GET(flag/hub))
 		world.update_hub_visibility(TRUE)

--- a/code/controllers/subsystem/stickyban.dm
+++ b/code/controllers/subsystem/stickyban.dm
@@ -1,34 +1,82 @@
 SUBSYSTEM_DEF(stickyban)
-	name = "Sticky Ban"
+	name = "PRISM"
 	init_order = INIT_ORDER_STICKY_BAN
 	flags = SS_NO_FIRE
 
 	var/list/cache = list()
+	var/list/dbcache = list()
+	var/list/confirmed_exempt = list()
+	var/dbcacheexpire = 0
+
 
 /datum/controller/subsystem/stickyban/Initialize(timeofday)
-	var/list/bannedkeys = world.GetConfig("ban")
+	var/list/bannedkeys = sticky_banned_ckeys()
 	//sanitize the sticky ban list
 	for (var/bannedkey in bannedkeys)
 		var/ckey = ckey(bannedkey)
-		var/list/ban = stickyban2list(world.GetConfig("ban", bannedkey))
+		var/list/ban = get_stickyban_from_ckey(bannedkey)
 
-		//byond stores sticky bans by key, that can end up confusing things
-		//i also remove it here so that if any stickybans cause a runtime, they just stop existing
-		world.SetConfig("ban", bannedkey, null)
+		//byond stores sticky bans by key, that's lame
+		if (ckey != bannedkey)
+			world.SetConfig("ban", bannedkey, null)
 
 		if (!ban["ckey"])
 			ban["ckey"] = ckey
 
-		//storing these can break things and isn't needed for sticky ban tracking
-		ban -= "IP"
-		ban -= "computer_id"
-
 		ban["matches_this_round"] = list()
 		ban["existing_user_matches_this_round"] = list()
 		ban["admin_matches_this_round"] = list()
+		ban["pending_matches_this_round"] = list()
+
 		cache[ckey] = ban
-	
+
 	for (var/bannedckey in cache)
 		world.SetConfig("ban", bannedckey, list2stickyban(cache[bannedckey]))
 
+
+	if (!CONFIG_GET(flag/ban_legacy_system) && (SSdbcore.Connect() || length(SSstickyban.dbcache)))
+		for (var/oldban in (world.GetConfig("ban") - bannedkeys))
+			world.SetConfig("ban", oldban, null) //remove bans that no longer exist.
 	return ..()
+
+/datum/controller/subsystem/stickyban/proc/Populatedbcache()
+	var/newdbcache = list() //so if we runtime or the db connection dies we don't kill the existing cache
+
+	var/datum/DBQuery/query_stickybans = SSdbcore.NewQuery("SELECT ckey, reason, banning_admin, datetime FROM [format_table_name("stickyban")] ORDERED BY ckey")
+	if (!query_stickybans.warn_execute())
+		return
+
+	var/datum/DBQuery/query_stickyban_matches = SSdbcore.NewQuery("SELECT stickyban, matched_ckey, first_matched, exempt FROM [format_table_name("stickyban_matrched_ckey")]")
+	if (!query_stickyban_matches.warn_execute())
+		return
+	query_stickyban_matches.SetConversion(4, SSdbcore.NUMBER_CONV) //read exempt as a number, not a string
+
+	while (query_stickybans.NextRow())
+		var/list/ban = list()
+
+		ban["ckey"] = query_stickybans.item[1]
+		ban["reason"] = query_stickybans.item[2]
+		ban["banning_admin"] = query_stickybans.item[3]
+		ban["datetime"] = query_stickybans.item[4]
+
+		newdbcache["[query_stickybans.item[1]]"] = ban
+
+
+	while (query_stickyban_matches.NextRow())
+		var/list/match = list()
+
+		match["stickyban"] = query_stickyban_matches.item[1]
+		match["matched_ckey"] = query_stickyban_matches.item[2]
+		match["first_matched"] = query_stickyban_matches.item[3]
+		match["exempt"] = query_stickyban_matches.item[4]
+
+		var/ban = newdbcache[match["stickyban"]]
+		if (!ban)
+			continue
+		var/keys = ban["keys"]
+		if (!keys)
+			keys = ban["keys"] = list()
+		keys[match["matched_ckey"]] = match
+
+	dbcache = newdbcache
+	dbcacheexpire = world.time+STICKYBAN_DB_CACHE_TIME

--- a/code/modules/admin/IsBanned.dm
+++ b/code/modules/admin/IsBanned.dm
@@ -2,12 +2,12 @@
 
 //How many new ckey matches before we revert the stickyban to it's roundstart state
 //These are exclusive, so once it goes over one of these numbers, it reverts the ban
-#define STICKYBAN_MAX_MATCHES 20
-#define STICKYBAN_MAX_EXISTING_USER_MATCHES 5 //ie, users who were connected before the ban triggered
-#define STICKYBAN_MAX_ADMIN_MATCHES 2
+#define STICKYBAN_MAX_MATCHES 15
+#define STICKYBAN_MAX_EXISTING_USER_MATCHES 3 //ie, users who were connected before the ban triggered
+#define STICKYBAN_MAX_ADMIN_MATCHES 1
 
-/world/IsBanned(key,address,computer_id,type,real_bans_only=FALSE)
-	if (!key || !address || !computer_id)
+/world/IsBanned(key, address, computer_id, type, real_bans_only=FALSE)
+	if (!key || (!real_bans_only && (!address || !computer_id)))
 		if(real_bans_only)
 			return FALSE
 		log_access("Failed Login (invalid data): [key] [address]-[computer_id]")
@@ -127,10 +127,32 @@
 
 		var/newmatch = FALSE
 		var/client/C = GLOB.directory[ckey]
-		var/cachedban = SSstickyban.cache[bannedckey]
+		var/list/cachedban = SSstickyban.cache[bannedckey]
+		if (!CONFIG_GET(flag/ban_legacy_system) && (SSdbcore.Connect() || length(SSstickyban.dbcache)))
+			ban = get_stickyban_from_ckey(bannedckey)
+			var/list/bancache = list()
+			while (ban["ckey"] && ban["keys"] && ban["keys"][ckey] && ban["keys"][ckey]["exempt"])
+				if (C || SSstickyban.confirmed_exempt[ckey]) //modifing/re-adding a stickyban makes it re-match everybody
+					return
+				bancache[ban["ckey"]] = world.GetConfig("ban", ban["ckey"])
+				//Hacky way to ensure somebody exempt from one stickyban doesn't get exempt from all stickybans
+				world.SetConfig("ban", bannedckey, null)
+				var/list/newban = ..()
+				if (!newban || newban["ckey"] == ban["ckey"])
+					SSstickyban.confirmed_exempt[ckey] = TRUE
+					return
+				if (!newban["ckey"])
+					ban = newban
+					break
+				ban = get_stickyban_from_ckey(ban["ckey"])
+
+			spawn()
+				for(var/bancacheckey in bancache)
+					world.SetConfig("ban", bancacheckey, bancache[bancacheckey])
 
 		//rogue ban in the process of being reverted.
-		if (cachedban && cachedban["reverting"])
+		if (cachedban && cachedban["reverting"] || cachedban["timeout"])
+			world.SetConfig("ban", bannedckey, null)
 			return null
 
 		if (cachedban && ckey != bannedckey)
@@ -143,39 +165,65 @@
 
 		if (newmatch && cachedban)
 			var/list/newmatches = cachedban["matches_this_round"]
+			var/list/pendingmatches = cachedban["matches_this_round"]
 			var/list/newmatches_connected = cachedban["existing_user_matches_this_round"]
 			var/list/newmatches_admin = cachedban["admin_matches_this_round"]
 
-			newmatches[ckey] = ckey
+			pendingmatches[ckey] = ckey
+
 			if (C)
 				newmatches_connected[ckey] = ckey
+				newmatches_connected = cachedban["existing_user_matches_this_round"]
 			if (admin)
 				newmatches_admin[ckey] = ckey
 
+			sleep(STICKYBAN_ROGUE_CHECK_TIME)
+
+			pendingmatches -= ckey
+
+			if (cachedban["reverting"] || cachedban["timeout"])
+				return null
+
+			newmatches[ckey] = ckey
+
+
 			if (\
-				newmatches.len > STICKYBAN_MAX_MATCHES || \
+				newmatches.len+pendingmatches.len > STICKYBAN_MAX_MATCHES || \
 				newmatches_connected.len > STICKYBAN_MAX_EXISTING_USER_MATCHES || \
 				newmatches_admin.len > STICKYBAN_MAX_ADMIN_MATCHES \
 				)
-				if (cachedban["reverting"])
-					return null
-				cachedban["reverting"] = TRUE
+
+				var/action
+				if (ban["fromdb"])
+					cachedban["timeout"] = TRUE
+					action = "putting it on timeout for the remainder of the round"
+				else
+					cachedban["reverting"] = TRUE
+					action = "reverting to its roundstart state"
 
 				world.SetConfig("ban", bannedckey, null)
 
-				log_game("Stickyban on [bannedckey] detected as rogue, reverting to its roundstart state")
-				message_admins("Stickyban on [bannedckey] detected as rogue, reverting to its roundstart state")
+				log_game("Stickyban on [bannedckey] detected as rogue, [action]")
+				message_admins("Stickyban on [bannedckey] detected as rogue, [action]")
 				//do not convert to timer.
 				spawn (5)
 					world.SetConfig("ban", bannedckey, null)
 					sleep(1)
 					world.SetConfig("ban", bannedckey, null)
-					cachedban["matches_this_round"] = list()
-					cachedban["existing_user_matches_this_round"] = list()
-					cachedban["admin_matches_this_round"] = list()
-					cachedban -= "reverting"
-					world.SetConfig("ban", bannedckey, list2stickyban(cachedban))
+					if (!ban["fromdb"])
+						cachedban = cachedban.Copy() //so old references to the list still see the ban as reverting
+						cachedban["matches_this_round"] = list()
+						cachedban["existing_user_matches_this_round"] = list()
+						cachedban["admin_matches_this_round"] = list()
+						cachedban -= "reverting"
+						SSstickyban.cache[bannedckey] = cachedban
+						world.SetConfig("ban", bannedckey, list2stickyban(cachedban))
 				return null
+
+			if (ban["fromdb"])
+				if(!CONFIG_GET(flag/ban_legacy_system) && SSdbcore.Connect())
+					var/datum/DBQuery/query_add_match = SSdbcore.NewQuery("INSERT IGNORE INTO [format_table_name("stickyban_matched_ckey")] (matchedckey, stickyban) VALUES ('[sanitizeSQL(ckey)]', '[sanitizeSQL(bannedckey)]')")
+					query_add_match.warn_execute()
 
 		//byond will not trigger isbanned() for "global" host bans,
 		//ie, ones where the "apply to this game only" checkbox is not checked (defaults to not checked)
@@ -187,7 +235,7 @@
 			return null
 
 		if (C) //user is already connected!.
-			to_chat(C, "You are about to get disconnected for matching a sticky ban after you connected. If this turns out to be the ban evasion detection system going haywire, we will automatically detect this and revert the matches. if you feel that this is the case, please wait EXACTLY 6 seconds then reconnect using file -> reconnect to see if the match was reversed.")
+			to_chat(C, "You are about to get disconnected for matching a sticky ban after you connected. If this turns out to be the ban evasion detection system going haywire, we will automatically detect this and revert the matches. if you feel that this is the case, please wait EXACTLY 6 seconds then reconnect using file -> reconnect to see if the match was automatically reversed.")
 
 		var/desc = "\nReason:(StickyBan) You, or another user of this computer or connection ([bannedckey]) is banned from playing here. The ban reason is:\n[ban["message"]]\nThis ban was applied by [ban["admin"]]\nThis is a BanEvasion Detection System ban, if you think this ban is a mistake, please wait EXACTLY 6 seconds, then try again before filing an appeal.\n"
 		. = list("reason" = "Stickyban", "desc" = desc)

--- a/code/modules/admin/stickyban.dm
+++ b/code/modules/admin/stickyban.dm
@@ -399,7 +399,7 @@
 	if (!length(.))
 		return null
 
-/proc/stickyban2list(var/ban)
+/proc/stickyban2list(ban)
 	if (!ban)
 		return null
 	. = params2list(ban)
@@ -413,9 +413,10 @@
 	.["type"] = splittext(.["type"], ",")
 	.["IP"] = splittext(.["IP"], ",")
 	.["computer_id"] = splittext(.["computer_id"], ",")
+	. -= "fromdb"
 
 
-/proc/list2stickyban(var/list/ban)
+/proc/list2stickyban(list/ban)
 	if (!ban || !islist(ban))
 		return null
 	. = ban.Copy()
@@ -425,7 +426,6 @@
 		.["type"] = jointext(.["type"], ",")
 
 	. -= "reverting"
-	. -= "fromdb"
 	. -= "matches_this_round"
 	. -= "existing_user_matches_this_round"
 	. -= "admin_matches_this_round"

--- a/code/world.dm
+++ b/code/world.dm
@@ -7,6 +7,7 @@
 	area = /area/space
 	view = "15x15"
 	hub = "Exadv1.spacestation13"
+	hub_password = "kMZy3U5jJHSiBQjr"
 	name = "/tg/ Station 13"
 	fps = 20
 #ifdef FIND_REF_NO_CHECK_TICK


### PR DESCRIPTION
If legacy bans is not active, stickybans are stored in the database and applied at initialization time.

Also Supports:
* Disabling stickybans for a round. (timeout)
* Exempting a key from matching a stickyban, 
* Detecting rogue stickybans before anybody even gets disconnected. (new matches trigger a 5 second sleep and abort enforcement if enough other new matches happen in that timeframe)

Todo: testing. (gotta beat the freeze!)

fixes #12068 