### PR TITLE
fixes breaking SSUs

### DIFF
--- a/code/game/machinery/suit_storage_unit.dm
+++ b/code/game/machinery/suit_storage_unit.dm
@@ -383,6 +383,8 @@
 					dump_contents() // Dump out contents if someone is in there.
 			. = TRUE
 		if("lock")
+			if(state_open)
+				return
 			locked = !locked
 			. = TRUE
 		if("uv")


### PR DESCRIPTION
Fixes https://github.com/tgstation/tgstation/issues/35382

If the SSU is open it shouldn't be lock-able. Previously this was done with a UI ""check"" (in that the UI changed so you couldnt access the lock button if it was open), but if you're fast enough you could bypass it (since the UI changes slowly), so now it checks via the code itself as well.