### PR TITLE
Fixes regression with pulled objects and space transitions

### DIFF
--- a/code/game/turfs/space/space.dm
+++ b/code/game/turfs/space/space.dm
@@ -151,16 +151,12 @@
 				ty--
 			DT = locate(tx, ty, destination_z)
 
-		if(isliving(A))
-			var/mob/living/L = A
-			var/atom/movable/AM = L.pulling
-			L.forceMove(DT)
-			if(AM)
-				var/turf/T = get_step(L.loc,turn(A.dir, 180))
-				AM.forceMove(T)
-				L.start_pulling(AM)
-		else
-			A.forceMove(DT)
+		var/atom/movable/AM = A.pulling
+		A.forceMove(DT)
+		if(AM)
+			var/turf/T = get_step(A.loc,turn(A.dir, 180))
+			AM.forceMove(T)
+			A.start_pulling(AM)
 
 		//now we're on the new z_level, proceed the space drifting
 		stoplag()//Let a diagonal move finish, if necessary

--- a/code/game/turfs/space/space.dm
+++ b/code/game/turfs/space/space.dm
@@ -150,15 +150,17 @@
 			else
 				ty--
 			DT = locate(tx, ty, destination_z)
-		A.forceMove(DT)
 
 		if(isliving(A))
 			var/mob/living/L = A
 			var/atom/movable/AM = L.pulling
+			L.forceMove(DT)
 			if(AM)
 				var/turf/T = get_step(L.loc,turn(A.dir, 180))
 				AM.forceMove(T)
 				L.start_pulling(AM)
+		else
+			A.forceMove(DT)
 
 		//now we're on the new z_level, proceed the space drifting
 		stoplag()//Let a diagonal move finish, if necessary


### PR DESCRIPTION
This was already fixed once but regressed recently. Basically when you're pulling stuff in spess, whatever you're pulling gets left behind unless it makes the transition on its own.

:cl: Naksu
fix: Pulled objects will now follow their puller across space transitions again
/:cl: