### PR TITLE
Fix ventcrawl breathing and visuals

### DIFF
--- a/code/modules/atmospherics/machinery/components/components_base.dm
+++ b/code/modules/atmospherics/machinery/components/components_base.dm
@@ -54,10 +54,10 @@ Pipenet stuff; housekeeping
 */
 
 /obj/machinery/atmospherics/components/nullifyNode(i)
-	..()
 	if(nodes[i])
 		nullifyPipenet(parents[i])
 		QDEL_NULL(airs[i])
+	..()
 
 /obj/machinery/atmospherics/components/on_construction()
 	..()

--- a/code/modules/atmospherics/machinery/pipes/pipes.dm
+++ b/code/modules/atmospherics/machinery/pipes/pipes.dm
@@ -59,6 +59,9 @@
 /obj/machinery/atmospherics/pipe/return_air()
 	return parent.air
 
+/obj/machinery/atmospherics/pipe/remove_air(amount)
+	return parent.air.remove(amount)
+
 /obj/machinery/atmospherics/pipe/attackby(obj/item/W, mob/user, params)
 	if(istype(W, /obj/item/device/analyzer))
 		atmosanalyzer_scan(parent.air, user)


### PR DESCRIPTION
:cl:
fix: Ventcrawlers in pipes now breathe from that pipe.
fix: Deconstructing atmos components no longer breaks ventcrawl visuals.
/:cl:

Fixes #36559 (thanks Antur for knowing the problem) and another issue found while testing that fix. Parent proc of `nullifyNode` would set `nodes[i]` to null so `nullifyPipenet` was never called and qdel'd objects (eventually `null`s) would be left in the pipenet's `other_atmosmch`, breaking visuals.