### PR TITLE
BYOND allows us to parent_type /obj and /mob, should we?

### DIFF
--- a/code/game/objects/objs.dm
+++ b/code/game/objects/objs.dm
@@ -1,5 +1,6 @@
 
 /obj
+	parent_type = /objmob
 	var/crit_fail = FALSE
 	animate_movement = 2
 	var/throwforce = 0

--- a/code/game/objmob.dm
+++ b/code/game/objmob.dm
@@ -1,0 +1,2 @@
+/objmob
+	parent_type = /atom/movable

--- a/code/modules/mob/mob_defines.dm
+++ b/code/modules/mob/mob_defines.dm
@@ -1,4 +1,5 @@
 /mob
+	parent_type = /objmob
 	datum_flags = DF_USE_TAG
 	density = TRUE
 	layer = MOB_LAYER

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -452,6 +452,7 @@
 #include "code\game\atoms_movable.dm"
 #include "code\game\communications.dm"
 #include "code\game\data_huds.dm"
+#include "code\game\objmob.dm"
 #include "code\game\say.dm"
 #include "code\game\shuttle_engines.dm"
 #include "code\game\sound.dm"


### PR DESCRIPTION
This is more of a discussion-PR than the real deal.

with parent_type, we can insert a new type between /atom/movable and its native subtypes /mob and /obj. This allows us to move nearly all /atom/movable vars and procs and keep /atom/movable/lighting_object "pure". It would also simplify checks like isobj||ismob of which we have a few. 

It would also quite possibly speed up the initialization of lighting objects quite a bit.

Code included is just for proof that  this compiles, i've also tested it in-game quite a bit to ascertain that inheritance isn't broken in any way.

@MrStonedOne thoughts?