### PR TITLE
Allow entering radio frequencies in friendly form

### DIFF
--- a/code/game/objects/items/devices/radio/radio.dm
+++ b/code/game/objects/items/devices/radio/radio.dm
@@ -144,6 +144,9 @@
 				var/max = format_frequency(freerange ? MAX_FREE_FREQ : MAX_FREQ)
 				tune = input("Tune frequency ([min]-[max]):", name, format_frequency(frequency)) as null|num
 				if(!isnull(tune) && !..())
+					if (tune < MIN_FREE_FREQ && tune <= MAX_FREE_FREQ / 10)
+						// allow typing 144.7 to get 1447
+						tune *= 10
 					. = TRUE
 			else if(adjust)
 				tune = frequency + adjust * 10


### PR DESCRIPTION
:cl:
fix: Entering a frequency like 145.7 into a radio will now work, where 1457 was previously required.
/:cl:

Fixes #32014.