### PR TITLE
Fixes "ocular wardens don't target buckled mobs"

### DIFF
--- a/code/modules/antagonists/clockcult/clock_helpers/slab_abilities.dm
+++ b/code/modules/antagonists/clockcult/clock_helpers/slab_abilities.dm
@@ -40,7 +40,7 @@
 		else if(L.stat)
 			to_chat(ranged_ability_user, "<span class='neovgre'>\"There is use in shackling the dead, but for examples.\"</span>")
 			return TRUE
-		else if(L.handcuffed)
+		else if (L.handcuffed && istype(L.handcuffed,/obj/item/restraints/handcuffs/clockwork))
 			to_chat(ranged_ability_user, "<span class='neovgre'>\"They are already helpless, no?\"</span>")
 			return TRUE
 

--- a/code/modules/antagonists/clockcult/clock_helpers/slab_abilities.dm
+++ b/code/modules/antagonists/clockcult/clock_helpers/slab_abilities.dm
@@ -40,7 +40,7 @@
 		else if(L.stat)
 			to_chat(ranged_ability_user, "<span class='neovgre'>\"There is use in shackling the dead, but for examples.\"</span>")
 			return TRUE
-		else if (L.handcuffed && istype(L.handcuffed,/obj/item/restraints/handcuffs/clockwork))
+		else if (istype(L.handcuffed,/obj/item/restraints/handcuffs/clockwork))
 			to_chat(ranged_ability_user, "<span class='neovgre'>\"They are already helpless, no?\"</span>")
 			return TRUE
 
@@ -49,7 +49,7 @@
 		"<span class='neovgre_small'>You begin shaping replicant alloy into manacles around [L]'s wrists...</span>")
 		to_chat(L, "<span class='userdanger'>[ranged_ability_user] begins forming manacles around your wrists!</span>")
 		if(do_mob(ranged_ability_user, L, 30))
-			if(!L.handcuffed)
+			if(!(istype(L.handcuffed,/obj/item/restraints/handcuffs/clockwork)))
 				L.handcuffed = new/obj/item/restraints/handcuffs/clockwork(L)
 				L.update_handcuffed()
 				to_chat(ranged_ability_user, "<span class='neovgre_small'>You shackle [L].</span>")

--- a/code/modules/antagonists/clockcult/clock_structures/ocular_warden.dm
+++ b/code/modules/antagonists/clockcult/clock_structures/ocular_warden.dm
@@ -116,7 +116,7 @@
 			continue
 		if (iscarbon(L))
 			var/mob/living/carbon/c = L
-			if (c.handcuffed && istype(c.handcuffed,/obj/item/restraints/handcuffs/clockwork))
+			if (istype(c.handcuffed,/obj/item/restraints/handcuffs/clockwork))
 				continue
 		if(ishostile(L))
 			var/mob/living/simple_animal/hostile/H = L

--- a/code/modules/antagonists/clockcult/clock_structures/ocular_warden.dm
+++ b/code/modules/antagonists/clockcult/clock_structures/ocular_warden.dm
@@ -112,8 +112,12 @@
 			continue
 		if(is_servant_of_ratvar(L) || (L.has_trait(TRAIT_BLIND)) || L.anti_magic_check(TRUE, TRUE))
 			continue
-		if(L.stat || L.restrained() || L.buckled || L.lying)
+		if(L.stat || L.lying)
 			continue
+		if (iscarbon(L))
+			var/mob/living/carbon/c = L
+			if (c.handcuffed && istype(c.handcuffed,/obj/item/restraints/handcuffs/clockwork))
+				continue
 		if(ishostile(L))
 			var/mob/living/simple_animal/hostile/H = L
 			if(("ratvar" in H.faction) || (!H.mind && "neutral" in H.faction))


### PR DESCRIPTION
[Changelogs]:

:cl:
fix: Ocular Wardens now target buckled and cuffed players/mobs, unless they are cuffed by a slab.
tweak: Cuck cultists can cuff already sec-cuffed targets with their slab cuff spell.
/:cl:

[why]:
Fixes #36510
The ocular wardens now target all buckled and cuffed mobs, unless they've been cuffed by specifically the slab.
