### PR TITLE
Fixed Ranged Guardian moving when recalled

### DIFF
--- a/code/modules/mob/living/simple_animal/guardian/types/ranged.dm
+++ b/code/modules/mob/living/simple_animal/guardian/types/ranged.dm
@@ -37,7 +37,6 @@
 			environment_smash = initial(environment_smash)
 			alpha = 255
 			range = initial(range)
-			incorporeal_move = FALSE
 			to_chat(src, "<span class='danger'><B>You switch to combat mode.</span></B>")
 			toggle = FALSE
 		else
@@ -48,7 +47,6 @@
 			environment_smash = ENVIRONMENT_SMASH_NONE
 			alpha = 45
 			range = 255
-			incorporeal_move = INCORPOREAL_MOVE_BASIC
 			to_chat(src, "<span class='danger'><B>You switch to scout mode.</span></B>")
 			toggle = TRUE
 	else
@@ -123,3 +121,13 @@
 
 /obj/effect/snare/singularity_pull()
 	return
+
+/mob/living/simple_animal/hostile/guardian/ranged/Manifest(forced)
+	if (toggle)
+		incorporeal_move = INCORPOREAL_MOVE_BASIC
+	. = ..()
+
+/mob/living/simple_animal/hostile/guardian/ranged/Recall(forced)
+	// To stop scout mode from moving when recalled
+	incorporeal_move = FALSE
+	. = ..()


### PR DESCRIPTION
[Changelogs]: # (Your PR should contain a detailed changelog of notable changes, titled and categorized appropriately. This includes, new features, sprites, sounds, balance changes, admin tools, map edits, removals, big refactors, config changes, hosting changes and important fixes. An example changelog has been provided below for you to edit. If you need additional help, read https://github.com/tgstation/tgstation/wiki/Changelogs)

:cl:
fix: Ranged guardians in scout mode no longer are able to move out of their master when recalled.
/:cl:

[why]: # (Please add a short description [two lines down] of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.)
Partially fixes #36368
