### PR TITLE
Scrubbers now start OFF, will activate when the air alarm triggers

### DIFF
--- a/code/modules/atmospherics/machinery/components/unary_devices/vent_scrubber.dm
+++ b/code/modules/atmospherics/machinery/components/unary_devices/vent_scrubber.dm
@@ -40,8 +40,7 @@
 			filter_types += gas_id2path(f)
 
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on
-	on = TRUE
-	icon_state = "scrub_map_on"
+	desc = "This scrubbers seem particularly eager to help!"
 
 /obj/machinery/atmospherics/components/unary/vent_scrubber/Destroy()
 	var/area/A = get_area(src)


### PR DESCRIPTION
:cl: Robustin
tweak: Scrubbers are now off by default, but will turn on (with the current default settings) if the air alarm is tripped. 
/:cl:

Episode 2 of "Naksu told me about the profile tool and now I want to make all the numbers smaller".

Scrubbers are probably the easiest, lowest-hanging fruit for atmos efficiency without sacrificing realism. In a 20m window the scrubber vents had called scrub() and process_atmos() over 1,000,000 times - and those aren't cheap procs either, the cumulative processing cost of the scrubbers doing nothing for 20 minutes is costly and surpassed other major procs like mob/life(). It's probably the single-most "expensive" object in the game. Having scrubbers relax a little also brought material benefits to other machinery procs like process_atmos_machinery and auto_use_power.

This should have minimal effect on gameplay and most important it offers a performance boost without dumbing down or simplifying our atmos system. 