### PR TITLE
Plastic flaps are now airtight

### DIFF
--- a/_maps/RandomZLevels/snowdin.dmm
+++ b/_maps/RandomZLevels/snowdin.dmm
@@ -12494,7 +12494,7 @@
 /turf/open/floor/plasteel,
 /area/awaymission/snowdin/post/mining_main/mechbay)
 "Gn" = (
-/obj/structure/plasticflaps/mining,
+/obj/structure/plasticflaps,
 /obj/machinery/conveyor{
 	dir = 2;
 	id = "snowdin_belt_mine"
@@ -13415,7 +13415,7 @@
 /turf/open/floor/plating,
 /area/awaymission/snowdin/post/mining_dock)
 "Jf" = (
-/obj/structure/plasticflaps/mining,
+/obj/structure/plasticflaps,
 /obj/machinery/conveyor{
 	dir = 8;
 	id = "snowdin_belt_mine"

--- a/code/game/objects/structures/plasticflaps.dm
+++ b/code/game/objects/structures/plasticflaps.dm
@@ -7,8 +7,8 @@
 	density = FALSE
 	anchored = TRUE
 	layer = ABOVE_MOB_LAYER
-	var/state = PLASTIC_FLAPS_NORMAL
 	CanAtmosPass = ATMOS_PASS_NO
+	var/state = PLASTIC_FLAPS_NORMAL
 
 /obj/structure/plasticflaps/examine(mob/user)
 	. = ..()
@@ -77,7 +77,6 @@
 	if(ismecha(A))
 		return 0
 
-
 	else if(isliving(A)) // You Shall Not Pass!
 		var/mob/living/M = A
 		if(isbot(A)) //Bots understand the secrets
@@ -93,9 +92,9 @@
 		new /obj/item/stack/sheet/plastic/five(loc)
 	qdel(src)
 
-/obj/structure/plasticflaps/New()
-	air_update_turf(1)
-	. = ..()
+/obj/structure/plasticflaps/Initialize()
+ 	. = ..()
+ 	air_update_turf(TRUE)
 
 /obj/structure/plasticflaps/Destroy()
 	var/atom/oldloc = loc

--- a/code/game/objects/structures/plasticflaps.dm
+++ b/code/game/objects/structures/plasticflaps.dm
@@ -1,6 +1,6 @@
 /obj/structure/plasticflaps
-	name = "plastic flaps"
-	desc = "Definitely can't get past those. No way."
+	name = "airtight plastic flaps"
+	desc = "Heavy duty, airtight, plastic flaps. Definitely can't get past those. No way."
 	icon = 'icons/obj/stationobjs.dmi'
 	icon_state = "plasticflaps"
 	armor = list("melee" = 100, "bullet" = 80, "laser" = 80, "energy" = 100, "bomb" = 50, "bio" = 100, "rad" = 100, "fire" = 50, "acid" = 50)
@@ -8,6 +8,7 @@
 	anchored = TRUE
 	layer = ABOVE_MOB_LAYER
 	var/state = PLASTIC_FLAPS_NORMAL
+	CanAtmosPass = ATMOS_PASS_NO
 
 /obj/structure/plasticflaps/examine(mob/user)
 	. = ..()
@@ -92,17 +93,13 @@
 		new /obj/item/stack/sheet/plastic/five(loc)
 	qdel(src)
 
-/obj/structure/plasticflaps/mining //A specific type for mining that doesn't allow airflow because of them damn crates
-	name = "airtight plastic flaps"
-	desc = "Heavy duty, airtight, plastic flaps."
-	CanAtmosPass = ATMOS_PASS_NO
-
-/obj/structure/plasticflaps/mining/New()
+/obj/structure/plasticflaps/New()
 	air_update_turf(1)
 	. = ..()
 
-/obj/structure/plasticflaps/mining/Destroy()
+/obj/structure/plasticflaps/Destroy()
 	var/atom/oldloc = loc
 	. = ..()
 	if (oldloc)
 		oldloc.air_update_turf(1)
+		


### PR DESCRIPTION
:cl: Denton
tweak: Plastic flaps are now airtight.
/:cl:

Right now, some maps (for example Delta) atmos connect huge areas through plastic flaps. 
You break a window in room A and can basically hear the CPU screech as it updates room A, corridors B, C, and D as well as the connected rooms.

An alternative solution would be adding windoors in front of plastic flaps, like how it's done on Boxstation.

What do you prefer?