### PR TITLE
Turret's process() is now 52% more efficient

### DIFF
--- a/code/game/machinery/porta_turret/portable_turret.dm
+++ b/code/game/machinery/porta_turret/portable_turret.dm
@@ -353,8 +353,10 @@
 			if(has_cover)
 				cover = new /obj/machinery/porta_turret_cover(loc)	//if the turret has no cover and is anchored, give it a cover
 				cover.parent_turret = src	//assign the cover its parent_turret, which would be this (src)
-
-	if(stat & (NOPOWER|BROKEN) || !on || manual_control)
+	if(!on)
+		if(!always_up)
+	
+	if(stat & (NOPOWER|BROKEN) || || manual_control)
 		return
 
 	var/list/targets = list()
@@ -557,6 +559,8 @@
 	if(controllock)
 		return
 	src.on = on
+	if(!on)
+		popDown()
 	src.mode = mode
 	power_change()
 

--- a/code/game/machinery/porta_turret/portable_turret.dm
+++ b/code/game/machinery/porta_turret/portable_turret.dm
@@ -353,10 +353,8 @@
 			if(has_cover)
 				cover = new /obj/machinery/porta_turret_cover(loc)	//if the turret has no cover and is anchored, give it a cover
 				cover.parent_turret = src	//assign the cover its parent_turret, which would be this (src)
-	if(!on)
-		if(!always_up)
-	
-	if(stat & (NOPOWER|BROKEN) || || manual_control)
+
+	if(!on || (stat & (NOPOWER|BROKEN)) || manual_control)
 		return
 
 	var/list/targets = list()

--- a/code/game/machinery/porta_turret/portable_turret.dm
+++ b/code/game/machinery/porta_turret/portable_turret.dm
@@ -182,7 +182,7 @@
 				dat += "Assume direct control : <a href='?src=[REF(src)];operation=manual'>Manual Control</a><br>"
 		else
 			dat += "Warning! Remote control protocol enabled.<br>"
-			
+
 
 	var/datum/browser/popup = new(user, "autosec", "Automatic Portable Turret Installation", 300, 300)
 	popup.set_content(dat)
@@ -354,27 +354,12 @@
 				cover = new /obj/machinery/porta_turret_cover(loc)	//if the turret has no cover and is anchored, give it a cover
 				cover.parent_turret = src	//assign the cover its parent_turret, which would be this (src)
 
-	if(stat & (NOPOWER|BROKEN))
-		if(!always_up)
-			//if the turret has no power or is broken, make the turret pop down if it hasn't already
-			popDown()
+	if(stat & (NOPOWER|BROKEN) || !on || manual_control)
 		return
 
-	if(!on)
-		if(!always_up)
-			//if the turret is off, make it pop down
-			popDown()
-		return
-
-	if(manual_control)
-		return
 	var/list/targets = list()
-	var/static/things_to_scan = typecacheof(list(/mob/living, /obj/mecha))
-
-	for(var/A in typecache_filter_list(view(scan_range, base), things_to_scan))
-		var/atom/AA = A
-
-		if(AA.invisibility > SEE_INVISIBLE_LIVING)
+	for(var/mob/A in view(scan_range, base))
+		if(A.invisibility > SEE_INVISIBLE_LIVING)
 			continue
 
 		if(check_anomalies)//if it's set to check for simple animals
@@ -413,17 +398,17 @@
 			else if(check_anomalies) //non humans who are not simple animals (xenos etc)
 				if(!in_faction(C))
 					targets += C
+	for(var/A in GLOB.mechas_list)
+		if((get_dist(A, base) < scan_range) && can_see(base, A, scan_range))
+			var/obj/mecha/Mech = A
+			if(Mech.occupant && !in_faction(Mech.occupant)) //If there is a user and they're not in our faction
+				if(assess_perp(Mech.occupant) >= 4)
+					targets += Mech
 
-		if(ismecha(A))
-			var/obj/mecha/M = A
-			//If there is a user and they're not in our faction
-			if(M.occupant && !in_faction(M.occupant))
-				if(assess_perp(M.occupant) >= 4)
-					targets += M
-
-	if(!tryToShootAt(targets))
-		if(!always_up)
-			popDown() // no valid targets, close the cover
+	if(targets.len)
+		tryToShootAt(targets)
+	else if(!always_up)
+		popDown() // no valid targets, close the cover
 
 /obj/machinery/porta_turret/proc/tryToShootAt(list/atom/movable/targets)
 	while(targets.len > 0)


### PR DESCRIPTION
Turret process() made up almost 2% of CPU load in an empty server.

With help from @vuonojenmustaturska its much more efficient now.



Path | SelfCPU | TotalCPU | RealTime | Calls
-- | -- | -- | -- | --
/obj/machinery/porta_turret/oldprocess | 0.959 | 1.402 | 1.413 | 6594
/obj/machinery/porta_turret/newprocess | 0.673 | 0.696 | 0.697 | 6705






