### PR TITLE
Topic will no longer be called on deleted objects

### DIFF
--- a/code/modules/client/client_procs.dm
+++ b/code/modules/client/client_procs.dm
@@ -109,6 +109,10 @@ GLOBAL_LIST_INIT(blacklisted_builds, list(
 		if("openLink")
 			src << link(href_list["link"])
 
+	var/datum/real_src = hsrc
+	if(QDELETED(real_src))
+		return
+
 	..()	//redirect to hsrc.Topic()
 
 /client/proc/is_content_unlocked()


### PR DESCRIPTION
Why hasn't this been done already?