### PR TITLE
Gas react is much more efficient

### DIFF
--- a/code/modules/atmospherics/gasmixtures/gas_mixture.dm
+++ b/code/modules/atmospherics/gasmixtures/gas_mixture.dm
@@ -413,7 +413,7 @@ GLOBAL_LIST_INIT(nonreactive_gases, list(/datum/gas/oxygen, /datum/gas/nitrogen,
 /datum/gas_mixture/react(turf/open/dump_location)
 	. = NO_REACTION
 	var/list/cached_gases = gases
-	if(!length(cached_gases-GLOB.nonreactive_gases))) //Uses nitrogen, oxygen, and co2 to quickly check if a reaction is possible
+	if(!length(cached_gases-GLOB.nonreactive_gases)) //Uses nitrogen, oxygen, and co2 to quickly check if a reaction is possible
 		return
 	reaction_results = new
 	var/temp = temperature

--- a/code/modules/atmospherics/gasmixtures/gas_mixture.dm
+++ b/code/modules/atmospherics/gasmixtures/gas_mixture.dm
@@ -465,3 +465,24 @@ GLOBAL_LIST_INIT(gaslist_cache, init_gaslist_cache())
 		garbage_collect()
 		if(temperature < TCMB) //just for safety
 			temperature = TCMB
+
+
+//Takes the amount of the gas you want to PP as an argument
+//So I don't have to do some hacky switches/defines/magic strings
+//eg:
+//Tox_PP = get_partial_pressure(gas_mixture.toxins)
+//O2_PP = get_partial_pressure(gas_mixture.oxygen)
+
+/datum/gas_mixture/proc/get_breath_partial_pressure(gas_pressure)
+	return (gas_pressure * R_IDEAL_GAS_EQUATION * temperature) / BREATH_VOLUME
+//inverse
+/datum/gas_mixture/proc/get_true_breath_pressure(partial_pressure)
+	return (partial_pressure * BREATH_VOLUME) / (R_IDEAL_GAS_EQUATION * temperature)
+
+//Mathematical proofs:
+/*
+get_breath_partial_pressure(gas_pp) --> gas_pp/total_moles()*breath_pp = pp
+get_true_breath_pressure(pp) --> gas_pp = pp/breath_pp*total_moles()
+
+10/20*5 = 2.5
+10 = 2.5/5*20

--- a/code/modules/atmospherics/gasmixtures/gas_mixture.dm
+++ b/code/modules/atmospherics/gasmixtures/gas_mixture.dm
@@ -27,7 +27,6 @@ GLOBAL_LIST_INIT(gaslist_cache, init_gaslist_cache())
 	var/volume = CELL_VOLUME //liters
 	var/last_share = 0
 	var/list/reaction_results
-	var/static/list/nonreactive_gases = list(typecacheof(/datum/gas/oxygen, /datum/gas/nitrogen, /datum/gas/carbon_dioxide)) // These gasses cannot react amongst themselves
 
 /datum/gas_mixture/New(volume)
 	gases = new
@@ -411,13 +410,14 @@ GLOBAL_LIST_INIT(gaslist_cache, init_gaslist_cache())
 	return ""
 
 /datum/gas_mixture/react(turf/open/dump_location)
+	var/static/list/nonreactive_gases = list(typecacheof(/datum/gas/oxygen, /datum/gas/nitrogen, /datum/gas/carbon_dioxide)) // These gases cannot react amongst themselves
 	. = NO_REACTION
-	if(volume == 0)
+	if(!volume)
 		return
 	var/possible
-	for(var/gas in gases)
-		if(is_type_in_typecache(gas,nonreactive_gases))
-			continue
+	for(var/I in gases)
+    	if(nonreactive_gases[I])
+        	continue
 		possible = TRUE
 		break
 	if(!possible)

--- a/code/modules/atmospherics/gasmixtures/gas_mixture.dm
+++ b/code/modules/atmospherics/gasmixtures/gas_mixture.dm
@@ -8,7 +8,7 @@ What are the archived variables for?
 															once gases got hot enough, most procedures wouldnt occur due to the fact that the mole counts would get rounded away. Thus, we lowered it a few orders of magnititude */
 GLOBAL_LIST_INIT(meta_gas_info, meta_gas_list()) //see ATMOSPHERICS/gas_types.dm
 GLOBAL_LIST_INIT(gaslist_cache, init_gaslist_cache())
-GLOBAL_LIST_INIT(nonreactive_gases, list(/datum/gas/oxygen, /datum/gas/nitrogen, /datum/gas/carbon_dioxide)) // These common gases cannot react amongst themselves
+GLOBAL_LIST_INIT(nonreactive_gases, typecacheof(list(/datum/gas/oxygen, /datum/gas/nitrogen, /datum/gas/carbon_dioxide))) // These gasses cannot react amongst themselves
 
 /proc/init_gaslist_cache()
 	. = list()
@@ -413,7 +413,15 @@ GLOBAL_LIST_INIT(nonreactive_gases, list(/datum/gas/oxygen, /datum/gas/nitrogen,
 /datum/gas_mixture/react(turf/open/dump_location)
 	. = NO_REACTION
 	var/list/cached_gases = gases
-	if(!length(cached_gases-GLOB.nonreactive_gases)) //Uses nitrogen, oxygen, and co2 to quickly check if a reaction is possible
+	if(!cached_gases.len)
+		return
+	var/possible
+	for(var/I in cached_gases)
+		if(GLOB.nonreactive_gases[I])
+			continue
+		possible = TRUE
+		break
+	if(!possible)
 		return
 	reaction_results = new
 	var/temp = temperature

--- a/code/modules/atmospherics/gasmixtures/gas_mixture.dm
+++ b/code/modules/atmospherics/gasmixtures/gas_mixture.dm
@@ -418,6 +418,7 @@ GLOBAL_LIST_INIT(gaslist_cache, init_gaslist_cache())
 		if(gas in GLOB.nonreactive_gases)
 			continue
 		possible = TRUE
+		break
 	if(!possible)
 		return
 

--- a/code/modules/atmospherics/gasmixtures/gas_mixture.dm
+++ b/code/modules/atmospherics/gasmixtures/gas_mixture.dm
@@ -27,6 +27,7 @@ GLOBAL_LIST_INIT(gaslist_cache, init_gaslist_cache())
 	var/volume = CELL_VOLUME //liters
 	var/last_share = 0
 	var/list/reaction_results
+	var/static/list/nonreactive_gases = list(typecacheof(/datum/gas/oxygen, /datum/gas/nitrogen, /datum/gas/carbon_dioxide)) // These gasses cannot react amongst themselves
 
 /datum/gas_mixture/New(volume)
 	gases = new
@@ -415,7 +416,7 @@ GLOBAL_LIST_INIT(gaslist_cache, init_gaslist_cache())
 		return
 	var/possible
 	for(var/gas in gases)
-		if(gas in GLOB.nonreactive_gases)
+		if(is_type_in_typecache(gas,nonreactive_gases))
 			continue
 		possible = TRUE
 		break

--- a/code/modules/atmospherics/gasmixtures/gas_mixture.dm
+++ b/code/modules/atmospherics/gasmixtures/gas_mixture.dm
@@ -458,7 +458,7 @@ GLOBAL_LIST_INIT(gaslist_cache, init_gaslist_cache())
 			//at this point, all requirements for the reaction are satisfied. we can now react()
 			*/
 
-			. |= reaction.react(src, null)
+			. |= reaction.react(src, dump_location)
 			if (. & STOP_REACTIONS)
 				break
 	if(.)

--- a/code/modules/atmospherics/gasmixtures/gas_mixture.dm
+++ b/code/modules/atmospherics/gasmixtures/gas_mixture.dm
@@ -8,6 +8,7 @@ What are the archived variables for?
 															once gases got hot enough, most procedures wouldnt occur due to the fact that the mole counts would get rounded away. Thus, we lowered it a few orders of magnititude */
 GLOBAL_LIST_INIT(meta_gas_info, meta_gas_list()) //see ATMOSPHERICS/gas_types.dm
 GLOBAL_LIST_INIT(gaslist_cache, init_gaslist_cache())
+GLOBAL_LIST_INIT(nonreactive_gases, list(/datum/gas/oxygen, /datum/gas/nitrogen, /datum/gas/carbon_dioxide)) // These common gases cannot react amongst themselves
 
 /proc/init_gaslist_cache()
 	. = list()
@@ -410,21 +411,11 @@ GLOBAL_LIST_INIT(gaslist_cache, init_gaslist_cache())
 	return ""
 
 /datum/gas_mixture/react(turf/open/dump_location)
-	var/static/list/nonreactive_gases = list(typecacheof(/datum/gas/oxygen, /datum/gas/nitrogen, /datum/gas/carbon_dioxide)) // These gases cannot react amongst themselves
 	. = NO_REACTION
-	if(gases.len)
-		return
-	var/possible
-	for(var/I in gases)
-		if(nonreactive_gases[I])
-			continue
-		possible = TRUE
-		break
-	if(!possible)
-		return
-
-	reaction_results = new
 	var/list/cached_gases = gases
+	if(!length(cached_gases-GLOB.nonreactive_gases))) //Uses nitrogen, oxygen, and co2 to quickly check if a reaction is possible
+		return
+	reaction_results = new
 	var/temp = temperature
 	var/ener = THERMAL_ENERGY(src)
 
@@ -467,7 +458,6 @@ GLOBAL_LIST_INIT(gaslist_cache, init_gaslist_cache())
 		garbage_collect()
 		if(temperature < TCMB) //just for safety
 			temperature = TCMB
-
 
 //Takes the amount of the gas you want to PP as an argument
 //So I don't have to do some hacky switches/defines/magic strings

--- a/code/modules/atmospherics/gasmixtures/gas_mixture.dm
+++ b/code/modules/atmospherics/gasmixtures/gas_mixture.dm
@@ -486,3 +486,4 @@ get_true_breath_pressure(pp) --> gas_pp = pp/breath_pp*total_moles()
 
 10/20*5 = 2.5
 10 = 2.5/5*20
+*/

--- a/code/modules/atmospherics/gasmixtures/gas_mixture.dm
+++ b/code/modules/atmospherics/gasmixtures/gas_mixture.dm
@@ -411,9 +411,17 @@ GLOBAL_LIST_INIT(gaslist_cache, init_gaslist_cache())
 
 /datum/gas_mixture/react(turf/open/dump_location)
 	. = NO_REACTION
+	if(volume == 0)
+		return
+	var/possible
+	for(var/gas in gases)
+		if(gas in GLOB.nonreactive_gases)
+			continue
+		possible = TRUE
+	if(!possible)
+		return
 
 	reaction_results = new
-
 	var/list/cached_gases = gases
 	var/temp = temperature
 	var/ener = THERMAL_ENERGY(src)
@@ -450,31 +458,10 @@ GLOBAL_LIST_INIT(gaslist_cache, init_gaslist_cache())
 			//at this point, all requirements for the reaction are satisfied. we can now react()
 			*/
 
-			. |= reaction.react(src, dump_location)
+			. |= reaction.react(src, null)
 			if (. & STOP_REACTIONS)
 				break
 	if(.)
 		garbage_collect()
 		if(temperature < TCMB) //just for safety
 			temperature = TCMB
-
-//Takes the amount of the gas you want to PP as an argument
-//So I don't have to do some hacky switches/defines/magic strings
-//eg:
-//Tox_PP = get_partial_pressure(gas_mixture.toxins)
-//O2_PP = get_partial_pressure(gas_mixture.oxygen)
-
-/datum/gas_mixture/proc/get_breath_partial_pressure(gas_pressure)
-	return (gas_pressure * R_IDEAL_GAS_EQUATION * temperature) / BREATH_VOLUME
-//inverse
-/datum/gas_mixture/proc/get_true_breath_pressure(partial_pressure)
-	return (partial_pressure * BREATH_VOLUME) / (R_IDEAL_GAS_EQUATION * temperature)
-
-//Mathematical proofs:
-/*
-get_breath_partial_pressure(gas_pp) --> gas_pp/total_moles()*breath_pp = pp
-get_true_breath_pressure(pp) --> gas_pp = pp/breath_pp*total_moles()
-
-10/20*5 = 2.5
-10 = 2.5/5*20
-*/

--- a/code/modules/atmospherics/gasmixtures/gas_mixture.dm
+++ b/code/modules/atmospherics/gasmixtures/gas_mixture.dm
@@ -412,12 +412,12 @@ GLOBAL_LIST_INIT(gaslist_cache, init_gaslist_cache())
 /datum/gas_mixture/react(turf/open/dump_location)
 	var/static/list/nonreactive_gases = list(typecacheof(/datum/gas/oxygen, /datum/gas/nitrogen, /datum/gas/carbon_dioxide)) // These gases cannot react amongst themselves
 	. = NO_REACTION
-	if(!volume)
+	if(gases.len)
 		return
 	var/possible
 	for(var/I in gases)
-    	if(nonreactive_gases[I])
-        	continue
+		if(nonreactive_gases[I])
+			continue
 		possible = TRUE
 		break
 	if(!possible)

--- a/code/modules/atmospherics/gasmixtures/gas_types.dm
+++ b/code/modules/atmospherics/gasmixtures/gas_types.dm
@@ -1,4 +1,5 @@
 GLOBAL_LIST_INIT(hardcoded_gases, list(/datum/gas/oxygen, /datum/gas/nitrogen, /datum/gas/carbon_dioxide, /datum/gas/plasma)) //the main four gases, which were at one time hardcoded
+GLOBAL_LIST_INIT(nonreactive_gases, list(/datum/gas/oxygen, /datum/gas/nitrogen, /datum/gas/carbon_dioxide)) // These gasses cannot react amongst themselves
 
 /proc/meta_gas_list()
 	. = subtypesof(/datum/gas)

--- a/code/modules/atmospherics/gasmixtures/gas_types.dm
+++ b/code/modules/atmospherics/gasmixtures/gas_types.dm
@@ -1,5 +1,4 @@
 GLOBAL_LIST_INIT(hardcoded_gases, list(/datum/gas/oxygen, /datum/gas/nitrogen, /datum/gas/carbon_dioxide, /datum/gas/plasma)) //the main four gases, which were at one time hardcoded
-GLOBAL_LIST_INIT(nonreactive_gases, list(/datum/gas/oxygen, /datum/gas/nitrogen, /datum/gas/carbon_dioxide)) // These gasses cannot react amongst themselves
 
 /proc/meta_gas_list()
 	. = subtypesof(/datum/gas)


### PR DESCRIPTION
* Most expensive proc on a local server, its still the single most expensive atmos proc in existence on our servers too


Path | SelfCPU | TotalCPU | RealTime | Calls
-- | -- | -- | -- | --
/datum/gas_mixture/OLDreact | 8.137 | 9.006 | 9.149 | 437372
/datum/gas_mixture/NEWreact | 1.147 | 1.222 | 1.276 | 438718



To give you an idea of how wasteful it is. Every pipenet in existence calls React() on its air every time it processes... The first catch is that the most common type of a pipenet is literally a canister valve, which is empty. The second catch is that the other 10% of pipenets (aka the actual pipenets) are typically full of CO2, Nitrogen, or Oxygen for the vast majority of their existence. Those three gases, in any combination, are incapable of any reaction.

So by adding two simple checks: 
1) Is there actually any fucking gas and 
2) Do we actually have a gas capable of reacting 

We make things much easier.

Next PR: Pipenets and the story of "Why are we forcing the entire pipenet to update even when we didn't change any gas?"

Pipenet's react calls actually saw an improvement of 1500% since they're perfect for these conditions:
https://i.imgur.com/LQ40TVe.png

