### PR TITLE
Fixes machines not updating power when changing areas

### DIFF
--- a/code/game/machinery/_machinery.dm
+++ b/code/game/machinery/_machinery.dm
@@ -127,13 +127,10 @@ Class Procs:
 	else
 		START_PROCESSING(SSfastprocess, src)
 	power_change()
+	AddComponent(/datum/component/redirect, list(COMSIG_ENTER_AREA), CALLBACK(src, .proc/power_change))
 
 	if (occupant_typecache)
 		occupant_typecache = typecacheof(occupant_typecache)
-
-/obj/machinery/ComponentInitialize()
-	. = ..()
-	AddComponent(/datum/component/redirect, list(COMSIG_ENTER_AREA), CALLBACK(src, .proc/power_change))
 
 /obj/machinery/Destroy()
 	GLOB.machines.Remove(src)

--- a/code/game/machinery/_machinery.dm
+++ b/code/game/machinery/_machinery.dm
@@ -131,6 +131,10 @@ Class Procs:
 	if (occupant_typecache)
 		occupant_typecache = typecacheof(occupant_typecache)
 
+/obj/machinery/ComponentInitialize()
+	. = ..()
+	AddComponent(/datum/component/redirect, list(COMSIG_ENTER_AREA), CALLBACK(src, .proc/power_change))
+
 /obj/machinery/Destroy()
 	GLOB.machines.Remove(src)
 	if(!speed_process)


### PR DESCRIPTION
:cl:
fix: Machine power will now update when moving from powered to unpowered areas and vice versa.
/:cl:

Fixes #9146
Fixes #26824