### PR TITLE
Fixes ninja objectives remaining when ninja antag removed

### DIFF
--- a/code/modules/antagonists/_common/antag_datum.dm
+++ b/code/modules/antagonists/_common/antag_datum.dm
@@ -95,6 +95,7 @@ GLOBAL_LIST_EMPTY(antagonists)
 		LAZYREMOVE(owner.antag_datums, src)
 		if(!silent && owner.current)
 			farewell()
+		owner.objectives -= objectives
 	var/datum/team/team = get_team()
 	if(team)
 		team.remove_member(owner)

--- a/code/modules/antagonists/brainwashing/brainwashing.dm
+++ b/code/modules/antagonists/brainwashing/brainwashing.dm
@@ -36,10 +36,6 @@
 	owner.objectives |= objectives
 	. = ..()
 
-/datum/antagonist/brainwashed/on_removal()
-	owner.objectives -= objectives
-	. = ..()
-
 /datum/antagonist/brainwashed/greet()
 	to_chat(owner, "<span class='warning'>Your mind reels as it begins focusing on a single purpose...</span>")
 	to_chat(owner, "<big><span class='warning'><b>Follow the Directives, at any cost!</b></span></big>")

--- a/code/modules/antagonists/brother/brother.dm
+++ b/code/modules/antagonists/brother/brother.dm
@@ -26,7 +26,6 @@
 
 /datum/antagonist/brother/on_removal()
 	SSticker.mode.brothers -= owner
-	owner.objectives -= objectives
 	if(owner.current)
 		to_chat(owner.current,"<span class='userdanger'>You are no longer the [special_role]!</span>")
 	owner.special_role = null

--- a/code/modules/antagonists/changeling/changeling.dm
+++ b/code/modules/antagonists/changeling/changeling.dm
@@ -85,7 +85,6 @@
 			B.vital = TRUE
 			B.decoy_override = FALSE
 	remove_changeling_powers()
-	owner.objectives -= objectives
 	. = ..()
 
 /datum/antagonist/changeling/proc/remove_clownmut()

--- a/code/modules/antagonists/cult/cult.dm
+++ b/code/modules/antagonists/cult/cult.dm
@@ -37,9 +37,6 @@
 	objectives |= cult_team.objectives
 	owner.objectives |= objectives
 
-/datum/antagonist/cult/proc/remove_objectives()
-	owner.objectives -= objectives
-
 /datum/antagonist/cult/Destroy()
 	QDEL_NULL(communion)
 	QDEL_NULL(vote)
@@ -130,7 +127,6 @@
 	current.clear_alert("bloodsense")
 
 /datum/antagonist/cult/on_removal()
-	remove_objectives()
 	SSticker.mode.cult -= owner
 	SSticker.mode.update_cult_icons_removed(owner)
 	if(!silent)

--- a/code/modules/antagonists/greentext/greentext.dm
+++ b/code/modules/antagonists/greentext/greentext.dm
@@ -13,7 +13,3 @@
 /datum/antagonist/greentext/on_gain()
 	forge_objectives()
 	. = ..()
-
-/datum/antagonist/greentext/on_removal()
-	owner.objectives -= objectives
-	. = ..()

--- a/code/modules/antagonists/highlander/highlander.dm
+++ b/code/modules/antagonists/highlander/highlander.dm
@@ -12,10 +12,6 @@
 	var/mob/living/L = owner.current || mob_override
 	L.remove_trait(TRAIT_NOGUNS, "highlander")
 
-/datum/antagonist/highlander/on_removal()
-	owner.objectives -= objectives
-	. = ..()
-
 /datum/antagonist/highlander/proc/forge_objectives()
 	var/datum/objective/steal/steal_objective = new
 	steal_objective.owner = owner

--- a/code/modules/antagonists/ninja/ninja.dm
+++ b/code/modules/antagonists/ninja/ninja.dm
@@ -90,8 +90,8 @@
 				break
 	var/datum/objective/O = new /datum/objective/survive()
 	O.owner = owner
+	objectives += O
 	owner.objectives |= objectives
-
 
 /proc/remove_ninja(mob/living/L)
 	if(!L || !L.mind)
@@ -109,6 +109,7 @@
 	to_chat(owner.current, "I am an elite mercenary assassin of the mighty Spider Clan. A <font color='red'><B>SPACE NINJA</B></font>!")
 	to_chat(owner.current, "Surprise is my weapon. Shadows are my armor. Without them, I am nothing. (//initialize your suit by right clicking on it, to use abilities like stealth)!")
 	to_chat(owner.current, "Officially, [helping_station?"Nanotrasen":"The Syndicate"] are my employer.")
+	owner.announce_objectives()
 	return
 
 /datum/antagonist/ninja/on_gain()

--- a/code/modules/antagonists/official/official.dm
+++ b/code/modules/antagonists/official/official.dm
@@ -26,7 +26,7 @@
 		mission = missionobj
 	objectives |= mission
 	owner.objectives |= objectives
-	
+
 /datum/antagonist/official/on_gain()
 	forge_objectives()
 	. = ..()

--- a/code/modules/antagonists/revenant/revenant_antag.dm
+++ b/code/modules/antagonists/revenant/revenant_antag.dm
@@ -17,5 +17,5 @@
 	owner.objectives |= objectives
 
 /datum/antagonist/revenant/on_gain()
-		forge_objectives()
-		. = ..()
+	forge_objectives()
+	. = ..()

--- a/code/modules/antagonists/traitor/IAA/internal_affairs.dm
+++ b/code/modules/antagonists/traitor/IAA/internal_affairs.dm
@@ -1,4 +1,4 @@
-#define PINPOINTER_MINIMUM_RANGE 15 
+#define PINPOINTER_MINIMUM_RANGE 15
 #define PINPOINTER_EXTRA_RANDOM_RANGE 10
 #define PINPOINTER_PING_TIME 40
 #define PROB_ACTUAL_TRAITOR 20
@@ -18,7 +18,7 @@
 	var/syndicate = FALSE
 	var/last_man_standing = FALSE
 	var/list/datum/mind/targets_stolen
-	
+
 
 /datum/antagonist/traitor/human/internal_affairs
 	name = "Internal Affairs Agent"
@@ -28,12 +28,12 @@
 	var/syndicate = FALSE
 	var/last_man_standing = FALSE
 	var/list/datum/mind/targets_stolen
-	
-	
+
+
 /datum/antagonist/traitor/human/internal_affairs/proc/give_pinpointer()
 	if(owner && owner.current)
 		owner.current.apply_status_effect(/datum/status_effect/agent_pinpointer)
-	
+
 /datum/antagonist/traitor/human/internal_affairs/apply_innate_effects()
 	.=..() //in case the base is used in future
 	if(owner && owner.current)
@@ -129,7 +129,7 @@
 		if(!(istype(objective_, /datum/objective/escape)||istype(objective_, /datum/objective/survive)))
 			continue
 		remove_objective(objective_)
-		
+
 	var/datum/objective/martyr/martyr_objective = new
 	martyr_objective.owner = owner
 	add_objective(martyr_objective)
@@ -156,8 +156,8 @@
 
 /datum/antagonist/traitor/proc/steal_targets(datum/mind/victim)
 	var/datum/antagonist/traitor/human/internal_affairs/this = src //Should only use this if IAA
-	
-	if(!owner.current||owner.current.stat==DEAD) 
+
+	if(!owner.current||owner.current.stat==DEAD)
 		return
 	to_chat(owner.current, "<span class='userdanger'> Target eliminated: [victim.name]</span>")
 	for(var/objective_ in victim.objectives)
@@ -254,7 +254,7 @@
 			owner.special_role = TRAITOR_AGENT_ROLE
 			special_role = TRAITOR_AGENT_ROLE
 			this.syndicate = TRUE
-			forge_single_objective()	
+			forge_single_objective()
 
 	else
 		..() // Give them standard objectives.

--- a/code/modules/antagonists/traitor/datum_traitor.dm
+++ b/code/modules/antagonists/traitor/datum_traitor.dm
@@ -57,9 +57,6 @@
 
 /datum/antagonist/traitor/on_removal()
 	SSticker.mode.traitors -= owner
-	for(var/O in objectives)
-		owner.objectives -= O
-	objectives = list()
 	if(!silent && owner.current)
 		to_chat(owner.current,"<span class='userdanger'> You are no longer the [special_role]! </span>")
 	owner.special_role = null
@@ -227,7 +224,7 @@
 	var/mob/living/silicon/ai/A = mob_override || owner.current
 	if(istype(A))
 		A.hack_software = TRUE
-	
+
 /datum/antagonist/traitor/AI/remove_innate_effects(mob/living/mob_override)
 	. = ..()
 	var/mob/living/silicon/ai/A = mob_override || owner.current

--- a/code/modules/antagonists/valentines/heartbreaker.dm
+++ b/code/modules/antagonists/valentines/heartbreaker.dm
@@ -15,10 +15,6 @@
 	forge_objectives()
 	. = ..()
 
-/datum/antagonist/heartbreaker/on_removal()
-	owner.objectives -= objectives
-	. = ..()
-
 /datum/antagonist/heartbreaker/greet()
 	to_chat(owner, "<span class='warning'><B>You didn't get a date! They're all having fun without you! you'll show them though...</B></span>")
 	owner.announce_objectives()

--- a/code/modules/antagonists/valentines/valentine.dm
+++ b/code/modules/antagonists/valentines/valentine.dm
@@ -18,9 +18,6 @@
 	forge_objectives()
 	. = ..()
 
-/datum/antagonist/valentine/on_removal()
-	owner.objectives -= objectives
-
 /datum/antagonist/valentine/greet()
 	to_chat(owner, "<span class='warning'><B>You're on a date with [date.name]! Protect them at all costs. This takes priority over all other loyalties.</B></span>")
 

--- a/code/modules/antagonists/wizard/wizard.dm
+++ b/code/modules/antagonists/wizard/wizard.dm
@@ -109,8 +109,6 @@
 
 /datum/antagonist/wizard/on_removal()
 	unregister()
-	for(var/objective in objectives)
-		owner.objectives -= objective
 	owner.RemoveAllSpells() // TODO keep track which spells are wizard spells which innate stuff
 	return ..()
 


### PR DESCRIPTION
Fixes #32467
I went ahead and made objectives always get removed upon antag removal regardless of antag type.
This also fixes ninjas not getting their survive objective and ninja objectives not automatically being announced.