### PR TITLE
Hotfix for #36688 - Excludes non-carbon-based life from the disco machine's dance4 proc to fix pAI "resting/getting up" chat spam

### DIFF
--- a/code/game/machinery/dance_machine.dm
+++ b/code/game/machinery/dance_machine.dm
@@ -407,7 +407,8 @@
 		sleep(speed)
 		for(var/i in 1 to speed)
 			M.setDir(pick(GLOB.cardinals))
-			M.lay_down(TRUE)
+			for(var/mob/living/carbon/NS in rangers)
+				NS.lay_down(TRUE)		//specifically excludes silicons to prevent pAI chat spam
 		 time--
 
 /obj/machinery/disco/proc/dance5(var/mob/living/M)


### PR DESCRIPTION
:cl: EvilJackCarver
fix: Edited a certain part of the disco machine's dance to only target carbon-based (mob/living/carbon) lifeforms. pAI units will no longer spam chat with rest notifications when in range of the disco machine.
/:cl:

Hotfix for #36688. I'm sure there's a better way to do it, but I haven't touched byond in a *long* time.

Tested on two songs, didn't get any sort of rest notification as pAI but did as expected as a carbon-based lifeform. 

