### PR TITLE
Fixes wet floor scaling

### DIFF
--- a/code/__DEFINES/misc.dm
+++ b/code/__DEFINES/misc.dm
@@ -190,7 +190,7 @@ GLOBAL_LIST_EMPTY(bloody_footprints_cache)
 #define IS_WET_OPEN_TURF(O) O.GetComponent(/datum/component/wet_floor)
 
 //Maximum amount of time, (in deciseconds) a tile can be wet for.
-#define MAXIMUM_WET_TIME 3000
+#define MAXIMUM_WET_TIME 5 MINUTES
 
 //unmagic-strings for types of polls
 #define POLLTYPE_OPTION		"OPTION"

--- a/code/controllers/subsystem/processing/wet_floors.dm
+++ b/code/controllers/subsystem/processing/wet_floors.dm
@@ -1,5 +1,7 @@
 PROCESSING_SUBSYSTEM_DEF(wet_floors)
 	name = "Wet floors"
 	priority = FIRE_PRIORITY_WET_FLOORS
-	wait = 15
+	wait = 10
 	stat_tag = "WFP" //Used for logging
+	var/temperature_coeff = 2
+	var/time_ratio = 1.5 SECONDS

--- a/code/modules/reagents/chemistry/reagents/other_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/other_reagents.dm
@@ -135,7 +135,7 @@
 	var/CT = cooling_temperature
 
 	if(reac_volume >= 5)
-		T.MakeSlippery(TURF_WET_WATER, min_wet_time = 10 SECONDS, wet_time_to_add = min(reac_volume*1.5 SECONDS, 60 SECONDS))
+		T.MakeSlippery(TURF_WET_WATER, 10 SECONDS, min(reac_volume*1.5 SECONDS, 60 SECONDS))
 
 	for(var/mob/living/simple_animal/slime/M in T)
 		M.apply_water()


### PR DESCRIPTION
@Arianya 
Wet floors are now scaled to the time of their last process (more accuracy), and the dry time at room temperature is no longer doubled.
However, this also means that the drying effect of ALL temperatures ranging from 0 to 100C on wet floors has been cut by half, because I don't want the old inconsistent switch statement back so slap a balance tag on this too I guess?
Fixes #36661 