### PR TITLE
Properly Blacklists Mushroom People

### DIFF
--- a/code/modules/mob/living/carbon/human/species_types/mushpeople.dm
+++ b/code/modules/mob/living/carbon/human/species_types/mushpeople.dm
@@ -25,6 +25,7 @@
 	mutanteyes = /obj/item/organ/eyes/night_vision/mushroom
 	use_skintones = FALSE
 	var/datum/martial_art/mushpunch/mush
+	blacklisted = TRUE //See comment below about locking it out of roundstart. The species is not intended to be available to players yet - and this means wizards, too.
 
 /datum/species/mush/check_roundstart_eligible()
 	return FALSE //hard locked out of roundstart on the order of design lead kor, this can be removed in the future when planetstation is here OR SOMETHING but right now we have a problem with races.


### PR DESCRIPTION
I spoke with @Armhulen about this, and he mentioned that mushroom people weren't supposed to be available *at all*, and this means to Wizards and Xenobiology at the moment. 