### PR TITLE
Fixed sometimes using items on full storage items

### DIFF
--- a/code/game/objects/items/storage/storage.dm
+++ b/code/game/objects/items/storage/storage.dm
@@ -425,6 +425,15 @@
 	if(!can_be_inserted(W, 0 , user))
 		if(contents.len >= storage_slots) //don't use items on the backpack if they don't fit
 			return 1
+
+		var/sum_w_class = W.w_class
+
+		for(var/obj/item/I in contents)
+			sum_w_class += I.w_class //Adds up the combined w_classes which will be in the storage item if the item is added to it.
+
+		if(sum_w_class > max_combined_w_class)
+			return 1
+		
 		return 0
 
 	handle_item_insertion(W, 0 , user)

--- a/code/game/objects/items/storage/storage.dm
+++ b/code/game/objects/items/storage/storage.dm
@@ -423,18 +423,7 @@
 		return	//Robots can't interact with storage items.
 
 	if(!can_be_inserted(W, 0 , user))
-		if(contents.len >= storage_slots) //don't use items on the backpack if they don't fit
-			return 1
-
-		var/sum_w_class = W.w_class
-
-		for(var/obj/item/I in contents)
-			sum_w_class += I.w_class //Adds up the combined w_classes which will be in the storage item if the item is added to it.
-
-		if(sum_w_class > max_combined_w_class)
-			return 1
-		
-		return 0
+		return 1
 
 	handle_item_insertion(W, 0 , user)
 

--- a/code/game/objects/structures/crates_lockers/closets.dm
+++ b/code/game/objects/structures/crates_lockers/closets.dm
@@ -207,7 +207,9 @@
 /obj/structure/closet/attackby(obj/item/W, mob/user, params)
 	if(user in src)
 		return
-	if(!src.tool_interact(W,user))
+	if(src.tool_interact(W,user))
+		return 1 // No afterattack
+	else
 		return ..()
 
 /obj/structure/closet/proc/tool_interact(obj/item/W, mob/user)//returns TRUE if attackBy call shouldnt be continued (because tool was used/closet was of wrong type), FALSE if otherwise


### PR DESCRIPTION
There was an issue where we were only checking if the number of items was greater than the storage slots, which it's very often. I've changed it so we return 1 (so no afterattack) if the storage item is full

Similarly I return 1 if an item is inserted into a container to stop space cleaner being used when placing it in an open locker

:cl: JohnGinnane
fix: Fixed items sometimes being used on fullpacks when trying to insert
fix: Fixed spray containers being used on open lockers and other containers
/:cl:

Fixes https://github.com/HippieStation/HippieStation/issues/6715
Fixes #34673

Video: https://streamable.com/xp29u
