### PR TITLE
Adds singular_name to BS crystals

### DIFF
--- a/code/game/objects/items/stacks/bscrystal.dm
+++ b/code/game/objects/items/stacks/bscrystal.dm
@@ -4,6 +4,7 @@
 	desc = "A glowing bluespace crystal, not much is known about how they work. It looks very delicate."
 	icon = 'icons/obj/telescience.dmi'
 	icon_state = "bluespace_crystal"
+	singular_name = "bluespace crystal"
 	w_class = WEIGHT_CLASS_TINY
 	materials = list(MAT_BLUESPACE=MINERAL_MATERIAL_AMOUNT)
 	points = 50


### PR DESCRIPTION
:cl: Denton
spellcheck: Bluespace crystals now show their proper name during machine construction.
/:cl:

BS crystals were missing a singular_name and showed up like "It requires 1 ore chunk" during machine construction.
