### PR TITLE
Fix 512-only code in recent conveyor belt fix

### DIFF
--- a/code/__HELPERS/_lists.dm
+++ b/code/__HELPERS/_lists.dm
@@ -10,12 +10,12 @@
  */
 
 #define LAZYINITLIST(L) if (!L) L = list()
-#define UNSETEMPTY(L) if (L && !L.len) L = null
-#define LAZYREMOVE(L, I) if(L) { L -= I; if(!L.len) { L = null; } }
+#define UNSETEMPTY(L) if (L && !length(L)) L = null
+#define LAZYREMOVE(L, I) if(L) { L -= I; if(!length(L)) { L = null; } }
 #define LAZYADD(L, I) if(!L) { L = list(); } L += I;
 #define LAZYOR(L, I) if(!L) { L = list(); } L |= I;
 #define LAZYFIND(L, V) L ? L.Find(V) : 0
-#define LAZYACCESS(L, I) (L ? (isnum(I) ? (I > 0 && I <= L.len ? L[I] : null) : L[I]) : null)
+#define LAZYACCESS(L, I) (L ? (isnum(I) ? (I > 0 && I <= length(L) ? L[I] : null) : L[I]) : null)
 #define LAZYSET(L, K, V) if(!L) { L = list(); } L[K] = V;
 #define LAZYLEN(L) length(L)
 #define LAZYCLEARLIST(L) if(L) L.Cut()

--- a/code/modules/recycling/conveyor2.dm
+++ b/code/modules/recycling/conveyor2.dm
@@ -56,15 +56,13 @@ GLOBAL_LIST_EMPTY(conveyors_by_id)
 	LAZYADD(GLOB.conveyors_by_id[id], src)
 
 /obj/machinery/conveyor/Destroy()
-	var/list/L = GLOB.conveyors_by_id[id]
-	LAZYREMOVE(L, src)
+	LAZYREMOVE(GLOB.conveyors_by_id[id], src)
 	. = ..()
 
 /obj/machinery/conveyor/vv_edit_var(var_name, var_value)
 	if (var_name == "id")
 		// if "id" is varedited, update our list membership
-		var/list/L = GLOB.conveyors_by_id[id]
-		LAZYREMOVE(L, src)
+		LAZYREMOVE(GLOB.conveyors_by_id[id], src)
 		. = ..()
 		LAZYADD(GLOB.conveyors_by_id[id], src)
 	else
@@ -233,15 +231,13 @@ GLOBAL_LIST_EMPTY(conveyors_by_id)
 	LAZYADD(GLOB.conveyors_by_id[id], src)
 
 /obj/machinery/conveyor_switch/Destroy()
-	var/list/L = GLOB.conveyors_by_id[id]
-	LAZYREMOVE(L, src)
+	LAZYREMOVE(GLOB.conveyors_by_id[id], src)
 	. = ..()
 
 /obj/machinery/conveyor_switch/vv_edit_var(var_name, var_value)
 	if (var_name == "id")
 		// if "id" is varedited, update our list membership
-		var/list/L = GLOB.conveyors_by_id[id]
-		LAZYREMOVE(L, src)
+		LAZYREMOVE(GLOB.conveyors_by_id[id], src)
 		. = ..()
 		LAZYADD(GLOB.conveyors_by_id[id], src)
 	else

--- a/code/modules/recycling/conveyor2.dm
+++ b/code/modules/recycling/conveyor2.dm
@@ -56,13 +56,15 @@ GLOBAL_LIST_EMPTY(conveyors_by_id)
 	LAZYADD(GLOB.conveyors_by_id[id], src)
 
 /obj/machinery/conveyor/Destroy()
-	LAZYREMOVE(GLOB.conveyors_by_id[id], src)
+	var/list/L = GLOB.conveyors_by_id[id]
+	LAZYREMOVE(L, src)
 	. = ..()
 
 /obj/machinery/conveyor/vv_edit_var(var_name, var_value)
 	if (var_name == "id")
 		// if "id" is varedited, update our list membership
-		LAZYREMOVE(GLOB.conveyors_by_id[id], src)
+		var/list/L = GLOB.conveyors_by_id[id]
+		LAZYREMOVE(L, src)
 		. = ..()
 		LAZYADD(GLOB.conveyors_by_id[id], src)
 	else
@@ -231,13 +233,15 @@ GLOBAL_LIST_EMPTY(conveyors_by_id)
 	LAZYADD(GLOB.conveyors_by_id[id], src)
 
 /obj/machinery/conveyor_switch/Destroy()
-	LAZYREMOVE(GLOB.conveyors_by_id[id], src)
+	var/list/L = GLOB.conveyors_by_id[id]
+	LAZYREMOVE(L, src)
 	. = ..()
 
 /obj/machinery/conveyor_switch/vv_edit_var(var_name, var_value)
 	if (var_name == "id")
 		// if "id" is varedited, update our list membership
-		LAZYREMOVE(GLOB.conveyors_by_id[id], src)
+		var/list/L = GLOB.conveyors_by_id[id]
+		LAZYREMOVE(L, src)
 		. = ..()
 		LAZYADD(GLOB.conveyors_by_id[id], src)
 	else


### PR DESCRIPTION
`LAZYREMOVE` expansion includes `GLOB.conveyors_by_id[id].len` which is 512-only.