### PR TITLE
Corrects plasma window armor inconsistency

### DIFF
--- a/code/game/objects/structures/window.dm
+++ b/code/game/objects/structures/window.dm
@@ -417,7 +417,7 @@
 	icon_state = "plasmawindow"
 	reinf = FALSE
 	heat_resistance = 25000
-	armor = list("melee" = 75, "bullet" = 5, "laser" = 0, "energy" = 0, "bomb" = 45, "bio" = 100, "rad" = 100, "fire" = 00, "acid" = 100)
+	armor = list("melee" = 75, "bullet" = 5, "laser" = 0, "energy" = 0, "bomb" = 45, "bio" = 100, "rad" = 100, "fire" = 99, "acid" = 100)
 	max_integrity = 150
 	explosion_block = 1
 	glass_type = /obj/item/stack/sheet/plasmaglass


### PR DESCRIPTION
Fixes #unreported?

\>window fire armor = 80
\>reinforced window fire armor = 80

\>plasma window fire armor = 00
\>reinforced plasma window fire armor = 99

Just stumbled across this, looks like a typo but I could be wrong.