### PR TITLE
Fix runtime when shaking camera with duration between 0 and 1

### DIFF
--- a/code/modules/mob/mob_helpers.dm
+++ b/code/modules/mob/mob_helpers.dm
@@ -254,7 +254,7 @@ It's fairly easy to fix if dealing with single letters but not so much with comp
 
 
 /proc/shake_camera(mob/M, duration, strength=1)
-	if(!M || !M.client || duration <= 0)
+	if(!M || !M.client || duration < 1)
 		return
 	var/client/C = M.client
 	var/oldx = C.pixel_x


### PR DESCRIPTION
```
[13:25:21] Runtime in mob_helpers.dm,270: nothing to animate
  proc name: shake camera (/proc/shake_camera)
  src: null
  call stack:
  shake camera(Eugenia Waldron (/mob/living/carbon/human), 0.75, 1)
  Eugenia Waldron (/mob/living/carbon/human): afterShuttleMove(hyperspace (19,17,13) (/turf/open/space/transit/west), /list (/list), 8, 8, 8, 0)
  Eugenia Waldron (/mob/living/carbon/human): afterShuttleMove(hyperspace (19,17,13) (/turf/open/space/transit/west), /list (/list), 8, 8, 8, 0)
  Eugenia Waldron (/mob/living/carbon/human): afterShuttleMove(hyperspace (19,17,13) (/turf/open/space/transit/west), /list (/list), 8, 8, 8, 0)
  the boz arrivals shuttle (/obj/docking_port/mobile/arrivals): cleanup runway(the arrivals bay (/obj/docking_port/stationary), /list (/list), /list (/list), /list (/list), /list (/list), 0, 8, Space (/area/space), /turf/open/space/transit/west (/turf/open/space/transit/west), /turf/open/space (/turf/open/space))
  the boz arrivals shuttle (/obj/docking_port/mobile/arrivals): initiate docking(the arrivals bay (/obj/docking_port/stationary), 8, 0)
  the boz arrivals shuttle (/obj/docking_port/mobile/arrivals): initiate docking(the arrivals bay (/obj/docking_port/stationary), 8)
  the boz arrivals shuttle (/obj/docking_port/mobile/arrivals): check()
  the boz arrivals shuttle (/obj/docking_port/mobile/arrivals): check()
  Shuttle (/datum/controller/subsystem/shuttle): fire(0)
  Shuttle (/datum/controller/subsystem/shuttle): ignite(0)
```