### PR TITLE
Fixes Rainbow Extracts

### DIFF
--- a/code/game/objects/items/grenades/clusterbuster.dm
+++ b/code/game/objects/items/grenades/clusterbuster.dm
@@ -57,7 +57,7 @@
 	var/steps = rand(1,4)
 	for(var/i in 1 to steps)
 		step_away(src,loc)
-		addtimer(CALLBACK(src, .proc/prime), rand(15,60))
+	addtimer(CALLBACK(src, .proc/prime), rand(15,60))
 
 /obj/item/grenade/clusterbuster/segment/prime()
 	new payload_spawner(drop_location(), payload, rand(min_spawned,max_spawned))

--- a/code/game/objects/items/grenades/clusterbuster.dm
+++ b/code/game/objects/items/grenades/clusterbuster.dm
@@ -54,8 +54,10 @@
 		max_spawned = base.max_spawned
 	icon_state = "[base_state]_active"
 	active = TRUE
-	walk_away(src,loc,rand(1,4))
-	addtimer(CALLBACK(src, .proc/prime), rand(15,60))
+	var/steps = rand(1,4)
+	for(var/i in 1 to steps)
+		step_away(src,loc)
+		addtimer(CALLBACK(src, .proc/prime), rand(15,60))
 
 /obj/item/grenade/clusterbuster/segment/prime()
 	new payload_spawner(drop_location(), payload, rand(min_spawned,max_spawned))
@@ -76,7 +78,9 @@
 		if(istype(P))
 			P.active = TRUE
 			addtimer(CALLBACK(P, /obj/item/grenade/proc/prime), rand(15,60))
-		walk_away(P,loc,rand(1,4))
+		var/steps = rand(1,4)
+		for(var/i in 1 to steps)
+			step_away(src,loc)
 
 /obj/effect/payload_spawner/random_slime
 	var/volatile = FALSE
@@ -86,17 +90,16 @@
 
 /obj/item/slime_extract/proc/activate_slime()
 	var/list/slime_chems = src.activate_reagents
-	for(var/i in 1 to slime_chems.len)
-		if(!QDELETED(src))
-			var/chem = pick_n_take(slime_chems)
-			var/amount = 5
-			if(chem == "lesser plasma") //In the rare case we get another rainbow.
-				chem = "plasma"
-				amount = 4
-			if(chem == "holy water and uranium")
-				chem = "uranium"
-				reagents.add_reagent("holywater")
-			reagents.add_reagent(chem,amount) //Add them in random order so we get all effects
+	if(!QDELETED(src))
+		var/chem = pick(slime_chems)
+		var/amount = 5
+		if(chem == "lesser plasma") //In the rare case we get another rainbow.
+			chem = "plasma"
+			amount = 4
+		if(chem == "holy water and uranium")
+			chem = "uranium"
+			reagents.add_reagent("holywater")
+		reagents.add_reagent(chem,amount) //Add them in random order so we get all effects
 
 /obj/effect/payload_spawner/random_slime/spawn_payload(type, numspawned)
 	for(var/loop = numspawned ,loop > 0, loop--)
@@ -104,7 +107,9 @@
 		var/obj/item/slime_extract/P = new chosen(loc)
 		if(volatile)
 			addtimer(CALLBACK(P, /obj/item/slime_extract/proc/activate_slime), rand(15,60))
-		walk_away(P,loc,rand(1,4))
+		var/steps = rand(1,4)
+		for(var/i in 1 to steps)
+			step_away(src,loc)
 
 //////////////////////////////////
 //Custom payload clusterbusters

--- a/code/game/objects/items/grenades/clusterbuster.dm
+++ b/code/game/objects/items/grenades/clusterbuster.dm
@@ -99,7 +99,7 @@
 		if(chem == "holy water and uranium")
 			chem = "uranium"
 			reagents.add_reagent("holywater")
-		reagents.add_reagent(chem,amount) //Add them in random order so we get all effects
+		reagents.add_reagent(chem,amount)
 
 /obj/effect/payload_spawner/random_slime/spawn_payload(type, numspawned)
 	for(var/loop = numspawned ,loop > 0, loop--)

--- a/code/modules/reagents/chemistry/recipes/slime_extracts.dm
+++ b/code/modules/reagents/chemistry/recipes/slime_extracts.dm
@@ -618,7 +618,7 @@
 		addtimer(CALLBACK(S, /obj/item/grenade.proc/prime), rand(15,60))
 		qdel(holder.my_atom) //deleto
 	else
-		var/mob/living/simple_animal/slime/random/S = new (holder.my_atom.loc)
+		var/mob/living/simple_animal/slime/random/S = new (get_turf(holder.my_atom.loc))
 		S.visible_message("<span class='danger'>Infused with plasma, the core begins to quiver and grow, and a new baby slime emerges from it!</span>")
 	..()
 

--- a/code/modules/reagents/chemistry/recipes/slime_extracts.dm
+++ b/code/modules/reagents/chemistry/recipes/slime_extracts.dm
@@ -611,14 +611,14 @@
 
 /datum/chemical_reaction/slime/slimeRNG/on_reaction(datum/reagents/holder, created_volume)
 	if(created_volume >= 5)
-		var/obj/item/grenade/clusterbuster/slime/S = new (holder.my_atom.loc)
+		var/obj/item/grenade/clusterbuster/slime/S = new (get_turf(holder.my_atom))
 		S.visible_message("<span class='danger'>Infused with plasma, the core begins to expand uncontrollably!</span>")
 		S.icon_state = "[S.base_state]_active"
 		S.active = TRUE
 		addtimer(CALLBACK(S, /obj/item/grenade.proc/prime), rand(15,60))
 		qdel(holder.my_atom) //deleto
 	else
-		var/mob/living/simple_animal/slime/random/S = new (get_turf(holder.my_atom.loc))
+		var/mob/living/simple_animal/slime/random/S = new (get_turf(holder.my_atom))
 		S.visible_message("<span class='danger'>Infused with plasma, the core begins to quiver and grow, and a new baby slime emerges from it!</span>")
 	..()
 


### PR DESCRIPTION
Rainbow extracts were basically completely broken, so this fixes a lot of the issues. They would spawn slimes inside of the user if you tried to do the lesser plasma reaction while holding them, and the clusterblorble effect had extremely weird effects for a long time after ocurring.

It turns out, the latter case was because clusterbangs as a whole were using an *extremely* gross byond-level proc that returned, but continued to process afterwards. Thank @optimumtact for figuring that one out.

Fixes #36342
Fixes #35908