### PR TITLE
Colossus projectile runtime removal

### DIFF
--- a/code/modules/mob/living/simple_animal/hostile/megafauna/colossus.dm
+++ b/code/modules/mob/living/simple_animal/hostile/megafauna/colossus.dm
@@ -145,6 +145,7 @@ Difficulty: Very Hard
 	INVOKE_ASYNC(src, .proc/spiral_shoot, TRUE)
 
 /mob/living/simple_animal/hostile/megafauna/colossus/proc/spiral_shoot(negative = FALSE, counter_start = 8)
+	var/turf/start_turf = get_step(src, pick(GLOB.alldirs))
 	var/counter = counter_start
 	for(var/i in 1 to 80)
 		if(negative)
@@ -155,7 +156,7 @@ Difficulty: Very Hard
 			counter = 1
 		if(counter < 1)
 			counter = 16
-		shoot_projectile(null, counter * 22.5)
+		shoot_projectile(start_turf, counter * 22.5)
 		playsound(get_turf(src), 'sound/magic/clockwork/invoke_general.ogg', 20, 1)
 		sleep(1)
 
@@ -186,7 +187,7 @@ Difficulty: Very Hard
 		angle_to_target = set_angle
 	var/static/list/colossus_shotgun_shot_angles = list(12.5, 7.5, 2.5, -2.5, -7.5, -12.5)
 	for(var/i in colossus_shotgun_shot_angles)
-		shoot_projectile(null, angle_to_target + i)
+		shoot_projectile(target_turf, angle_to_target + i)
 
 /mob/living/simple_animal/hostile/megafauna/colossus/proc/dir_shots(list/dirs)
 	if(!islist(dirs))


### PR DESCRIPTION
0 hours of testing but this should fix:

The following runtime has occurred 4634 time(s).
runtime error: Cannot read null.y
proc name: preparePixelProjectile (/obj/item/projectile/proc/preparePixelProjectile)
  source file: projectile.dm,452
  usr: null
  src: the death bolt (/obj/item/projectile/colossus)
  src.loc: the volcanic floor (136,174,5) (/turf/open/floor/plating/asteroid/basalt/lava_land_surface)