### PR TITLE
Assemblies with lighting circuits now properly update light position.

### DIFF
--- a/code/modules/integrated_electronics/core/assemblies.dm
+++ b/code/modules/integrated_electronics/core/assemblies.dm
@@ -90,9 +90,6 @@
 	handle_idle_power()
 	check_pulling()
 
-	if(light) //Update lighting objects (From light circuits) so movement is handled.
-		update_light()
-
 	//updates diagnostic hud
 	diag_hud_set_circuithealth()
 	diag_hud_set_circuitcell()
@@ -505,6 +502,8 @@
 	for(var/I in assembly_components)
 		var/obj/item/integrated_circuit/IC = I
 		IC.ext_moved(oldLoc, dir)
+	if(light) //Update lighting objects (From light circuits).
+		update_light()
 
 /obj/item/device/electronic_assembly/stop_pulling()
 	..()

--- a/code/modules/integrated_electronics/core/assemblies.dm
+++ b/code/modules/integrated_electronics/core/assemblies.dm
@@ -90,6 +90,9 @@
 	handle_idle_power()
 	check_pulling()
 
+	if(light) //Update lighting objects (From light circuits) so movement is handled.
+		update_light()
+
 	//updates diagnostic hud
 	diag_hud_set_circuithealth()
 	diag_hud_set_circuitcell()


### PR DESCRIPTION
The circuit itself doesn't process, so I added it to the assembly process. This actually makes a bit of sense, considering the light itself is in the assembly.

I'm not sure, but I think this also makes the light properly qdel when turned off, if it didn't before, so that's a plus.

Fixes #36706
Fixes #35577