### PR TITLE
Deactivate prescans on suicide

### DIFF
--- a/code/datums/mind.dm
+++ b/code/datums/mind.dm
@@ -782,6 +782,17 @@
 		var/mob/living/carbon/human/H = user
 		log_game("[key_name(user)] (job: [H.job ? "[H.job]" : "None"]) committed suicide at [get_area(user)][COORD(T)].")
 
+		//Go through all cloning computers and mark their records as suicided
+		for(var/obj/machinery/computer/cloning/C in world)
+			var/datum/data/record/R = find_record("ckey", user.ckey, C.records)
+			if(R)
+				R.fields["suiciding"] = TRUE
+
+		//Do the same for diskettes
+		for(var/obj/item/disk/data/D in world)
+			if(D.fields["ckey"] && D.fields["ckey"] == user.ckey)
+				D.fields["suiciding"] = TRUE
+
 		return
 
 	log_game("[key_name(user)] committed suicide at [get_area(user)][COORD(T)] as [user.type].")

--- a/code/datums/mind.dm
+++ b/code/datums/mind.dm
@@ -774,6 +774,17 @@
 	if(G)
 		G.reenter_corpse()
 
+//user: The mob that is suiciding
+/datum/mind/proc/suicide_log(mob/user)
+	var/turf/T = get_turf(user)
+
+	if(ishuman(user))
+		var/mob/living/carbon/human/H = user
+		log_game("[key_name(user)] (job: [H.job ? "[H.job]" : "None"]) committed suicide at [get_area(user)][COORD(T)].")
+
+		return
+
+	log_game("[key_name(user)] committed suicide at [get_area(user)][COORD(T)] as [user.type].")
 
 /datum/mind/proc/has_objective(objective_type)
 	for(var/datum/antagonist/A in antag_datums)

--- a/code/game/machinery/computer/cloning.dm
+++ b/code/game/machinery/computer/cloning.dm
@@ -71,6 +71,9 @@
 		if(pod.occupant)
 			continue	//how though?
 
+		if(R.fields["suiciding"])
+			continue
+
 		if(pod.growclone(R.fields["ckey"], R.fields["name"], R.fields["UI"], R.fields["SE"], R.fields["mind"], R.fields["mrace"], R.fields["features"], R.fields["factions"], R.fields["traits"]))
 			temp = "[R.fields["name"]] => <font class='good'>Cloning cycle in progress...</font>"
 			records -= R
@@ -220,7 +223,13 @@
 				dat += "<font class='bad'>Record not found.</font>"
 			else
 				dat += "<h4>[src.active_record.fields["name"]]</h4>"
-				dat += "Scan ID [src.active_record.fields["id"]] <a href='byond://?src=[REF(src)];clone=[active_record.fields["id"]]'>Clone</a><br>"
+				dat += "Scan ID [src.active_record.fields["id"]] "
+
+				if(src.active_record.fields["suiciding"])
+					dat += "<span class='linkOff'>Clone</span><br>"
+					dat += "<font class='bad'>Subject's brain data is malformed.</font><br>"
+				else
+					dat += "<a href='byond://?src=[REF(src)];clone=[active_record.fields["id"]]'>Clone</a><br>"
 
 				var/obj/item/implant/health/H = locate(src.active_record.fields["imp"])
 
@@ -244,6 +253,10 @@
 					if(diskette.fields["SE"])
 						L += "Structural Enzymes"
 					dat += english_list(L, "Empty", " + ", " + ")
+
+					if(diskette.fields["suiciding"])
+						dat += "<br><font class='bad'>Subject's brain data is malformed.</font>"
+
 					dat += "<br /><a href='byond://?src=[REF(src)];disk=load'>Load from Disk</a>"
 
 					dat += "<br /><a href='byond://?src=[REF(src)];disk=save'>Save to Disk</a>"
@@ -400,6 +413,9 @@
 			else if(pod.occupant)
 				temp = "<font class='bad'>Cloning cycle already in progress.</font>"
 				playsound(src, 'sound/machines/terminal_prompt_deny.ogg', 50, 0)
+			else if(C.fields["suiciding"])
+				temp = "[C.fields["name"]] => <font class='bad'>Subject's brain data is malformed.</font>"
+				playsound(src, 'sound/machines/terminal_prompt_deny.ogg', 50, 0)
 			else if(pod.growclone(C.fields["ckey"], C.fields["name"], C.fields["UI"], C.fields["SE"], C.fields["mind"], C.fields["mrace"], C.fields["features"], C.fields["factions"], C.fields["traits"]))
 				temp = "[C.fields["name"]] => <font class='good'>Cloning cycle in progress...</font>"
 				playsound(src, 'sound/machines/terminal_prompt_confirm.ogg', 50, 0)
@@ -474,6 +490,7 @@
 	R.fields["features"] = dna.features
 	R.fields["factions"] = mob_occupant.faction
 	R.fields["traits"] = list()
+	R.fields["suiciding"] = FALSE
 	for(var/V in mob_occupant.roundstart_traits)
 		var/datum/trait/T = V
 		R.fields["traits"] += T.type

--- a/code/modules/client/verbs/suicide.dm
+++ b/code/modules/client/verbs/suicide.dm
@@ -12,7 +12,6 @@
 		return
 	if(confirm == "Yes")
 		suiciding = TRUE
-		log_game("[key_name(src)] (job: [job ? "[job]" : "None"]) committed suicide at [get_area(src)].")
 		var/obj/item/held_item = get_active_held_item()
 		if(held_item)
 			var/damagetype = held_item.suicide_act(src)
@@ -22,6 +21,9 @@
 					suiciding = FALSE
 					SendSignal(COMSIG_ADD_MOOD_EVENT, "shameful_suicide", /datum/mood_event/shameful_suicide)
 					return
+
+				mind.suicide_log(src)
+
 				var/damage_mod = 0
 				for(var/T in list(BRUTELOSS, FIRELOSS, TOXLOSS, OXYLOSS))
 					damage_mod += (T & damagetype) ? 1 : 0
@@ -48,6 +50,7 @@
 					adjustOxyLoss(max(200 - getToxLoss() - getFireLoss() - getBruteLoss() - getOxyLoss(), 0))
 
 				death(FALSE)
+
 				return
 
 		var/suicide_message
@@ -72,6 +75,8 @@
 
 		visible_message("<span class='danger'>[suicide_message]</span>", "<span class='userdanger'>[suicide_message]</span>")
 
+		mind.suicide_log(src)
+
 		adjustOxyLoss(max(200 - getToxLoss() - getFireLoss() - getBruteLoss() - getOxyLoss(), 0))
 		death(0)
 
@@ -86,6 +91,9 @@
 		suiciding = 1
 		visible_message("<span class='danger'>[src]'s brain is growing dull and lifeless. [p_they(TRUE)] look[p_s()] like [p_theyve()] lost the will to live.</span>", \
 						"<span class='userdanger'>[src]'s brain is growing dull and lifeless. [p_they(TRUE)] look[p_s()] like [p_theyve()] lost the will to live.</span>")
+
+		mind.suicide_log(src)
+
 		death(0)
 
 /mob/living/carbon/monkey/verb/suicide()
@@ -99,6 +107,9 @@
 		suiciding = 1
 		visible_message("<span class='danger'>[src] is attempting to bite [p_their()] tongue. It looks like [p_theyre()] trying to commit suicide.</span>", \
 				"<span class='userdanger'>[src] is attempting to bite [p_their()] tongue. It looks like [p_theyre()] trying to commit suicide.</span>")
+
+		mind.suicide_log(src)
+
 		adjustOxyLoss(max(200- getToxLoss() - getFireLoss() - getBruteLoss() - getOxyLoss(), 0))
 		death(0)
 
@@ -113,6 +124,9 @@
 		suiciding = 1
 		visible_message("<span class='danger'>[src] is powering down. It looks like [p_theyre()] trying to commit suicide.</span>", \
 				"<span class='userdanger'>[src] is powering down. It looks like [p_theyre()] trying to commit suicide.</span>")
+
+		mind.suicide_log(src)
+
 		//put em at -175
 		adjustOxyLoss(max(maxHealth * 2 - getToxLoss() - getFireLoss() - getBruteLoss() - getOxyLoss(), 0))
 		death(0)
@@ -128,6 +142,9 @@
 		suiciding = 1
 		visible_message("<span class='danger'>[src] is powering down. It looks like [p_theyre()] trying to commit suicide.</span>", \
 				"<span class='userdanger'>[src] is powering down. It looks like [p_theyre()] trying to commit suicide.</span>")
+
+		mind.suicide_log(src)
+
 		//put em at -175
 		adjustOxyLoss(max(maxHealth * 2 - getToxLoss() - getFireLoss() - getBruteLoss() - getOxyLoss(), 0))
 		death(0)
@@ -139,6 +156,9 @@
 		var/turf/T = get_turf(src.loc)
 		T.visible_message("<span class='notice'>[src] flashes a message across its screen, \"Wiping core files. Please acquire a new personality to continue using pAI device functions.\"</span>", null, \
 		 "<span class='notice'>[src] bleeps electronically.</span>")
+
+		mind.suicide_log(src)
+
 		death(0)
 	else
 		to_chat(src, "Aborting suicide attempt.")
@@ -155,6 +175,9 @@
 		visible_message("<span class='danger'>[src] is thrashing wildly! It looks like [p_theyre()] trying to commit suicide.</span>", \
 				"<span class='userdanger'>[src] is thrashing wildly! It looks like [p_theyre()] trying to commit suicide.</span>", \
 				"<span class='italics'>You hear thrashing.</span>")
+
+		mind.suicide_log(src)
+
 		//put em at -175
 		adjustOxyLoss(max(200 - getFireLoss() - getBruteLoss() - getOxyLoss(), 0))
 		death(0)
@@ -170,6 +193,9 @@
 		suiciding = 1
 		visible_message("<span class='danger'>[src] begins to fall down. It looks like [p_theyve()] lost the will to live.</span>", \
 						"<span class='userdanger'>[src] begins to fall down. It looks like [p_theyve()] lost the will to live.</span>")
+
+		mind.suicide_log(src)
+
 		death(0)
 
 


### PR DESCRIPTION
This will just give all of your records a flag on suicide, preventing them from being used to create a clone.

Created `suicide_act` on `/datum/mind` to log animal suicides and handle the record deactivation without cluttering up the mob verbs.

Screenshot:
![screenshot at 2018-03-27 15-48-14](https://user-images.githubusercontent.com/12787230/37968262-5254f792-31d6-11e8-9f33-3d98f373e88f.png)

Fixes #36205 
Alternative to and closes #36839

:cl:
fix: Suiciding will now deactivate all your genetics prescans.
/:cl: