### PR TITLE
Revert "Nerfs monkey spam"

### DIFF
--- a/code/controllers/subsystem/mobs.dm
+++ b/code/controllers/subsystem/mobs.dm
@@ -6,8 +6,6 @@ SUBSYSTEM_DEF(mobs)
 
 	var/list/currentrun = list()
 	var/static/list/clients_by_zlevel[][]
-	var/static/list/cubemonkeys = list()
-	var/cubemonkeycap = 20
 
 /datum/controller/subsystem/mobs/stat_entry()
 	..("P:[GLOB.mob_living_list.len]")

--- a/code/modules/food_and_drinks/food/snacks_meat.dm
+++ b/code/modules/food_and_drinks/food/snacks_meat.dm
@@ -185,13 +185,10 @@
 	foodtype = MEAT | SUGAR
 
 /obj/item/reagent_containers/food/snacks/monkeycube/proc/Expand()
+	visible_message("<span class='notice'>[src] expands!</span>")
 	var/mob/spammer = get_mob_by_key(fingerprintslast)
-	var/mob/living/carbon/monkey/bananas = new(drop_location(), TRUE, spammer)
-	if (!QDELETED(bananas))
-		visible_message("<span class='notice'>[src] expands!</span>")
-		bananas.log_message("Spawned via [src] at [COORD(src)], Last attached mob: [key_name(spammer)].", INDIVIDUAL_ATTACK_LOG)
-	else if (!spammer) // Visible message in case there are no fingerprints
-		visible_message("<span class='notice'>[src] fails to expand!</span>")
+	var/mob/living/carbon/monkey/bananas = new(drop_location())
+	bananas.log_message("Spawned via [src] at [COORD(src)], Last attached mob: [key_name(spammer)].", INDIVIDUAL_ATTACK_LOG)
 	qdel(src)
 
 /obj/item/reagent_containers/food/snacks/enchiladas

--- a/code/modules/mob/living/carbon/monkey/monkey.dm
+++ b/code/modules/mob/living/carbon/monkey/monkey.dm
@@ -16,7 +16,7 @@
 
 
 
-/mob/living/carbon/monkey/Initialize(mapload, cubespawned=FALSE, mob/spawner)
+/mob/living/carbon/monkey/Initialize()
 	verbs += /mob/living/proc/mob_sleep
 	verbs += /mob/living/proc/lay_down
 
@@ -31,19 +31,8 @@
 
 	. = ..()
 
-	if (cubespawned)
-		if (LAZYLEN(SSmobs.cubemonkeys) > SSmobs.cubemonkeycap)
-			if (spawner)
-				to_chat(spawner, "<span class='warning'>Bluespace harmonics prevent the spawning of more than [SSmobs.cubemonkeycap] monkeys on the station at one time!</span>")
-			return INITIALIZE_HINT_QDEL
-		SSmobs.cubemonkeys += src
-
 	create_dna(src)
 	dna.initialize_dna(random_blood_type())
-
-/mob/living/carbon/monkey/Destroy()
-	SSmobs.cubemonkeys -= src
-	return ..()
 
 /mob/living/carbon/monkey/create_internal_organs()
 	internal_organs += new /obj/item/organ/appendix

--- a/code/modules/research/xenobiology/xenobio_camera.dm
+++ b/code/modules/research/xenobiology/xenobio_camera.dm
@@ -168,11 +168,10 @@
 
 	if(GLOB.cameranet.checkTurfVis(remote_eye.loc))
 		if(X.monkeys >= 1)
-			var/mob/living/carbon/monkey/food = new /mob/living/carbon/monkey(remote_eye.loc, TRUE, owner)
-			if (!QDELETED(food))
-				food.LAssailant = C
-				X.monkeys --
-				to_chat(owner, "[X] now has [X.monkeys] monkeys left.")
+			var/mob/living/carbon/monkey/food = new /mob/living/carbon/monkey(remote_eye.loc)
+			food.LAssailant = C
+			X.monkeys --
+			to_chat(owner, "[X] now has [X.monkeys] monkeys left.")
 	else
 		to_chat(owner, "<span class='notice'>Target is not near a camera. Cannot proceed.</span>")
 


### PR DESCRIPTION
Reverts tgstation/tgstation#36380. 

#36641 greatly improved monkey performance, removing the need for a monkey cap for server stability. The cap now just causes usability issues for xeno, genetics and virology. If you think monkey spam is bad from a gameplay perspective than increase the cost of monkey cubes.

Fixes #36656  




