### PR TITLE
Refactors flight into trait based procs

### DIFF
--- a/code/__DEFINES/traits.dm
+++ b/code/__DEFINES/traits.dm
@@ -40,11 +40,12 @@
 #define TRAIT_NOBREATH			"no_breath"
 #define TRAIT_ANTIMAGIC			"anti_magic"
 #define TRAIT_HOLY				"holy"
-#define TRAIT_DEPRESSION			"depression"
+#define TRAIT_DEPRESSION		"depression"
 #define TRAIT_JOLLY				"jolly"
 #define TRAIT_NOCRITDAMAGE		"no_crit"
 #define TRAIT_NOSLIPWATER		"noslip_water"
 #define TRAIT_NOSLIPALL			"noslip_all"
+#define TRAIT_FLIGHT			"flight"
 
 
 #define TRAIT_ALCOHOL_TOLERANCE	"alcohol_tolerance"
@@ -61,16 +62,17 @@
 #define TRAIT_PROSOPAGNOSIA		"prosopagnosia"
 
 // common trait sources
-#define TRAIT_GENERIC "generic"
-#define EYE_DAMAGE "eye_damage"
-#define GENETIC_MUTATION "genetic"
-#define OBESITY "obesity"
-#define MAGIC_TRAIT "magic"
-#define TRAUMA_TRAIT "trauma"
-#define SPECIES_TRAIT "species"
-#define ROUNDSTART_TRAIT "roundstart" //cannot be removed without admin intervention
+#define TRAIT_INNATE 			"innate"		//spawned with it
+#define TRAIT_GENERIC 			"generic"		//in case a trait should always have the same source
+#define EYE_DAMAGE 				"eye_damage"	//for physical eye damage
+#define GENETIC_MUTATION 		"genetic"		//Genetic Mutations
+#define MAGIC_TRAIT 			"magic"			//Generic Magic
+#define TRAUMA_TRAIT 			"trauma"		//Brain Traumas
+#define SPECIES_TRAIT 			"species"		//Added by species on gain
+#define ROUNDSTART_TRAIT 		"roundstart" 	//cannot be removed without admin intervention
 
 // unique trait sources, still defines
+#define OBESITY "obesity"
 #define STATUE_MUTE "statue"
 #define CHANGELING_DRAIN "drain"
 #define CHANGELING_HIVEMIND_MUTE "ling_mute"

--- a/code/datums/components/caltrop.dm
+++ b/code/datums/components/caltrop.dm
@@ -42,7 +42,7 @@
 		if(!(flags & CALTROP_BYPASS_SHOES) && (H.shoes || feetCover))
 			return
 
-		if((H.movement_type & FLYING) || H.buckled)
+		if((H.is_flying()) || H.buckled)
 			return
 
 		var/damage = rand(min_damage, max_damage)

--- a/code/game/objects/effects/alien_acid.dm
+++ b/code/game/objects/effects/alien_acid.dm
@@ -55,7 +55,7 @@
 /obj/effect/acid/Crossed(AM as mob|obj)
 	if(isliving(AM))
 		var/mob/living/L = AM
-		if(L.movement_type & FLYING)
+		if(L.is_flying())
 			return
 		if(L.m_intent != MOVE_INTENT_WALK && prob(40))
 			var/acid_used = min(acid_level*0.05, 20)

--- a/code/game/objects/effects/mines.dm
+++ b/code/game/objects/effects/mines.dm
@@ -14,7 +14,7 @@
 	if(isturf(loc))
 		if(ismob(AM))
 			var/mob/MM = AM
-			if(!(MM.movement_type & FLYING))
+			if(!(MM.is_flying()))
 				triggermine(AM)
 		else
 			triggermine(AM)

--- a/code/game/objects/items/handcuffs.dm
+++ b/code/game/objects/items/handcuffs.dm
@@ -281,7 +281,7 @@
 				var/mob/living/simple_animal/SA = L
 				if(SA.mob_size > MOB_SIZE_TINY)
 					snap = 1
-			if(L.movement_type & FLYING)
+			if(L.is_flying())
 				snap = 0
 			if(snap)
 				armed = 0

--- a/code/game/objects/structures/tables_racks.dm
+++ b/code/game/objects/structures/tables_racks.dm
@@ -211,7 +211,7 @@
 		check_break(M)
 
 /obj/structure/table/glass/proc/check_break(mob/living/M)
-	if(M.has_gravity() && M.mob_size > MOB_SIZE_SMALL && !(M.movement_type & FLYING))
+	if(M.has_gravity() && M.mob_size > MOB_SIZE_SMALL && !(M.is_flying()))
 		table_shatter(M)
 
 /obj/structure/table/glass/proc/table_shatter(mob/living/L)

--- a/code/game/turfs/open.dm
+++ b/code/game/turfs/open.dm
@@ -184,8 +184,8 @@
 	return TRUE
 
 /turf/open/handle_slip(mob/living/carbon/C, knockdown_amount, obj/O, lube)
-	if(C.movement_type & FLYING)
-		return 0
+	if(C.is_flying())
+		return FALSE
 	if(has_gravity(src))
 		var/obj/buckled_obj
 		if(C.buckled)

--- a/code/game/turfs/simulated/lava.dm
+++ b/code/game/turfs/simulated/lava.dm
@@ -110,7 +110,7 @@
 		else if (isliving(thing))
 			. = 1
 			var/mob/living/L = thing
-			if(L.movement_type & FLYING)
+			if(L.is_flying())
 				continue	//YOU'RE FLYING OVER IT
 			if("lava" in L.weather_immunities)
 				continue

--- a/code/modules/antagonists/blob/blob/blobs/blob_mobs.dm
+++ b/code/modules/antagonists/blob/blob/blobs/blob_mobs.dm
@@ -122,7 +122,7 @@
 	desc = "A shambling corpse animated by the blob."
 	melee_damage_lower += 8
 	melee_damage_upper += 11
-	movement_type = GROUND
+	set_flight(TRAIT_INNATE, FALSE)
 	death_cloud_size = 0
 	icon = H.icon
 	icon_state = "zombie"

--- a/code/modules/assembly/mousetrap.dm
+++ b/code/modules/assembly/mousetrap.dm
@@ -108,7 +108,7 @@
 	if(armed)
 		if(ismob(AM))
 			var/mob/MM = AM
-			if(!(MM.movement_type & FLYING))
+			if(!(MM.is_flying()))
 				if(ishuman(AM))
 					var/mob/living/carbon/H = AM
 					if(H.m_intent == MOVE_INTENT_RUN)

--- a/code/modules/awaymissions/mission_code/snowdin.dm
+++ b/code/modules/awaymissions/mission_code/snowdin.dm
@@ -197,7 +197,7 @@
 		else if (isliving(thing))
 			. = 1
 			var/mob/living/L = thing
-			if(L.movement_type & FLYING)
+			if(L.is_flying())
 				continue	//YOU'RE FLYING OVER IT
 			if("snow" in L.weather_immunities)
 				continue

--- a/code/modules/clothing/spacesuits/flightsuit.dm
+++ b/code/modules/clothing/spacesuits/flightsuit.dm
@@ -496,8 +496,7 @@
 		else if(!requires_suit)
 			usermessage("Warning: Flightpack not linked to compatible flight-suit mount!", "boldwarning")
 			return FALSE
-	wearer.movement_type |= FLYING
-	wearer.pass_flags |= flight_passflags
+	wearer.set_flight("flightpack", TRUE)
 	usermessage("ENGAGING FLIGHT ENGINES.")
 	wearer.visible_message("<font color='blue' size='2'>[wearer]'s flight engines activate as they lift into the air!</font>")
 	flight = TRUE
@@ -516,8 +515,7 @@
 		calculate_momentum_speed()
 		usermessage("DISENGAGING FLIGHT ENGINES.")
 		wearer.visible_message("<font color='blue' size='2'>[wearer] drops to the ground as their flight engines cut out!</font>")
-		wearer.movement_type &= ~FLYING
-		wearer.pass_flags &= ~flight_passflags
+		wearer.set_flight("flightpack", FALSE)
 		flight = FALSE
 		update_slowdown()
 		update_icon()

--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -105,7 +105,7 @@
 			take_bodypart_damage(10)
 	if(iscarbon(hit_atom) && hit_atom != src)
 		var/mob/living/carbon/victim = hit_atom
-		if(victim.movement_type & FLYING)
+		if(victim.is_flying())
 			return
 		if(hurt)
 			victim.take_bodypart_damage(10)

--- a/code/modules/mob/living/carbon/carbon_movement.dm
+++ b/code/modules/mob/living/carbon/carbon_movement.dm
@@ -21,8 +21,8 @@
 		. += SOFTCRIT_ADD_SLOWDOWN
 
 /mob/living/carbon/slip(knockdown_amount, obj/O, lube)
-	if(movement_type & FLYING)
-		return 0
+	if(is_flying())
+		return FALSE
 	if(!(lube&SLIDE_ICE))
 		add_logs(src,, "slipped",, "on [O ? O.name : "floor"]")
 	return loc.handle_slip(src, knockdown_amount, O, lube)

--- a/code/modules/mob/living/carbon/human/species.dm
+++ b/code/modules/mob/living/carbon/human/species.dm
@@ -1078,7 +1078,7 @@ GLOBAL_LIST_EMPTY(roundstart_races)
 	var/obj/item/device/flightpack/F = H.get_flightpack()
 	if(istype(F) && F.flight)
 		flightpack = 1
-	if(H.movement_type & FLYING)
+	if(H.is_flying())
 		flight = 1
 
 	if(H.has_gravity())

--- a/code/modules/mob/living/carbon/human/species_types/angel.dm
+++ b/code/modules/mob/living/carbon/human/species_types/angel.dm
@@ -26,8 +26,7 @@
 /datum/species/angel/on_species_loss(mob/living/carbon/human/H)
 	if(fly)
 		fly.Remove(H)
-	if(H.movement_type & FLYING)
-		H.movement_type &= ~FLYING
+	H.set_flight(SPECIES_TRAIT, FALSE)
 	ToggleFlight(H,0)
 	if(H.dna && H.dna.species &&((H.dna.features["wings"] != "None") && ("wings" in H.dna.species.mutant_bodyparts)))
 		H.dna.features["wings"] = "None"
@@ -39,7 +38,7 @@
 	HandleFlight(H)
 
 /datum/species/angel/proc/HandleFlight(mob/living/carbon/human/H)
-	if(H.movement_type & FLYING)
+	if(H.is_flying(SPECIES_TRAIT))
 		if(!CanFly(H))
 			ToggleFlight(H,0)
 			return 0
@@ -74,7 +73,7 @@
 	var/mob/living/carbon/human/H = owner
 	var/datum/species/angel/A = H.dna.species
 	if(A.CanFly(H))
-		if(H.movement_type & FLYING)
+		if(H.is_flying(SPECIES_TRAIT))
 			to_chat(H, "<span class='notice'>You settle gently back onto the ground...</span>")
 			A.ToggleFlight(H,0)
 			H.update_canmove()
@@ -111,31 +110,29 @@
 
 
 /datum/species/angel/spec_stun(mob/living/carbon/human/H,amount)
-	if(H.movement_type & FLYING)
+	if(H.is_flying(SPECIES_TRAIT))
 		ToggleFlight(H,0)
 		flyslip(H)
 	. = ..()
 
 /datum/species/angel/negates_gravity(mob/living/carbon/human/H)
-	if(H.movement_type & FLYING)
-		return 1
+	if(H.is_flying(SPECIES_TRAIT))
+		return TRUE
 
 /datum/species/angel/space_move(mob/living/carbon/human/H)
-	if(H.movement_type & FLYING)
-		return 1
+	if(H.is_flying(SPECIES_TRAIT))
+		return TRUE
 
 /datum/species/angel/proc/ToggleFlight(mob/living/carbon/human/H,flight)
 	if(flight && CanFly(H))
 		stunmod = 2
 		speedmod = -0.35
-		H.movement_type |= FLYING
+		H.set_flight(SPECIES_TRAIT, TRUE)
 		override_float = TRUE
-		H.pass_flags |= PASSTABLE
 		H.OpenWings()
 	else
 		stunmod = 1
 		speedmod = 0
-		H.movement_type &= ~FLYING
+		H.set_flight(SPECIES_TRAIT, FALSE)
 		override_float = FALSE
-		H.pass_flags &= ~PASSTABLE
 		H.CloseWings()

--- a/code/modules/mob/living/life.dm
+++ b/code/modules/mob/living/life.dm
@@ -4,7 +4,7 @@
 	if(digitalinvis)
 		handle_diginvis() //AI becomes unable to see mob
 
-	if((movement_type & FLYING) && !floating)	//TODO: Better floating
+	if(is_flying() && !floating)	//TODO: Better floating
 		float(on = TRUE)
 
 	if (client || registered_z) // This is a temporary error tracker to make sure we've caught everything

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -17,6 +17,8 @@
 	medhud.add_to_hud(src)
 	faction += "[REF(src)]"
 	GLOB.mob_living_list += src
+	if(movement_type & FLYING)
+		set_flight(TRAIT_INNATE, TRUE)
 
 
 /mob/living/prepare_huds()
@@ -553,6 +555,26 @@
 			if(MOVE_INTENT_WALK)
 				. += config_walk_delay.value_cache
 
+/mob/living/is_flying(source)
+	if(has_trait(TRAIT_FLIGHT, source))
+		return TRUE
+	else
+		return FALSE
+
+/mob/living/set_flight(source, flight = TRUE)
+	if(flight)
+		add_trait(TRAIT_FLIGHT, source)
+	else
+		remove_trait(TRAIT_FLIGHT, source)
+
+	if(has_trait(TRAIT_FLIGHT))
+		movement_type |= FLYING
+		pass_flags |= PASSTABLE
+	else
+		movement_type &= ~FLYING
+		if(!(initial(pass_flags) & PASSTABLE))
+			pass_flags &= ~PASSTABLE
+
 /mob/living/proc/makeTrail(turf/target_turf, turf/start, direction)
 	if(!has_gravity())
 		return
@@ -1010,7 +1032,7 @@
 	C.Knockdown(40)
 
 /mob/living/ConveyorMove()
-	if((movement_type & FLYING) && !stat)
+	if(is_flying() && !stat)
 		return
 	..()
 

--- a/code/modules/mob/living/simple_animal/friendly/cockroach.dm
+++ b/code/modules/mob/living/simple_animal/friendly/cockroach.dm
@@ -35,7 +35,7 @@
 	if(ismob(AM))
 		if(isliving(AM))
 			var/mob/living/A = AM
-			if(A.mob_size > MOB_SIZE_SMALL && !(A.movement_type & FLYING))
+			if(A.mob_size > MOB_SIZE_SMALL && !(A.is_flying()))
 				if(prob(squish_chance))
 					A.visible_message("<span class='notice'>[A] squashed [src].</span>", "<span class='notice'>You squashed [src].</span>")
 					adjustBruteLoss(1) //kills a normal cockroach

--- a/code/modules/mob/living/simple_animal/simple_animal.dm
+++ b/code/modules/mob/living/simple_animal/simple_animal.dm
@@ -283,7 +283,7 @@
 		return 1
 
 /mob/living/simple_animal/death(gibbed)
-	movement_type &= ~FLYING
+	set_flight(TRAIT_INNATE, FALSE)
 	if(nest)
 		nest.spawned_mobs -= src
 		nest = null
@@ -343,7 +343,8 @@
 		density = initial(density)
 		lying = 0
 		. = 1
-		movement_type = initial(movement_type)
+		if(initial(movement_type) & FLYING)
+			set_flight(TRAIT_INNATE, TRUE)
 
 /mob/living/simple_animal/proc/make_babies() // <3 <3 <3
 	if(gender != FEMALE || stat || next_scan_time > world.time || !childtype || !animal_species || !SSticker.IsRoundInProgress())

--- a/code/modules/mob/mob_helpers.dm
+++ b/code/modules/mob/mob_helpers.dm
@@ -458,11 +458,11 @@ It's fairly easy to fix if dealing with single letters but not so much with comp
 		message_admins("No ghosts were willing to take control of [key_name_admin(M)])")
 		return FALSE
 
-/mob/proc/is_flying(mob/M = src)
-	if(M.movement_type & FLYING)
-		return 1
+/mob/proc/is_flying(source)
+	if(movement_type & FLYING)
+		return TRUE
 	else
-		return 0
+		return FALSE
 
 /mob/proc/click_random_mob()
 	var/list/nearby_mobs = list()
@@ -486,3 +486,12 @@ It's fairly easy to fix if dealing with single letters but not so much with comp
 
 /mob/proc/can_hear()
 	. = TRUE
+
+/mob/proc/set_flight(source, flight = TRUE)
+	if(flight)
+		movement_type |= FLYING
+		pass_flags |= PASSTABLE
+	else
+		movement_type &= ~FLYING
+		if(!(initial(pass_flags) & PASSTABLE))
+			pass_flags &= ~PASSTABLE

--- a/code/modules/ruins/objects_and_mobs/necropolis_gate.dm
+++ b/code/modules/ruins/objects_and_mobs/necropolis_gate.dm
@@ -276,7 +276,7 @@ GLOBAL_DATUM(necropolis_gate, /obj/structure/necropolis_gate/legion_gate)
 		L = AM
 	switch(fall_on_cross)
 		if(COLLAPSE_ON_CROSS, DESTROY_ON_CROSS)
-			if((I && I.w_class >= WEIGHT_CLASS_BULKY) || (L && !(L.movement_type & FLYING) && L.mob_size >= MOB_SIZE_HUMAN)) //too heavy! too big! aaah!
+			if((I && I.w_class >= WEIGHT_CLASS_BULKY) || (L && !(L.is_flying()) && L.mob_size >= MOB_SIZE_HUMAN)) //too heavy! too big! aaah!
 				collapse()
 		if(UNIQUE_EFFECT)
 			crossed_effect(AM)

--- a/code/modules/surgery/bodyparts/helpers.dm
+++ b/code/modules/surgery/bodyparts/helpers.dm
@@ -89,7 +89,7 @@
 	return TRUE
 
 /mob/living/carbon/human/get_leg_ignore()
-	if((movement_type & FLYING) || floating)
+	if((is_flying()) || floating)
 		return TRUE
 	return FALSE
 


### PR DESCRIPTION
Really useful if you want to add items/powers that give flight.

Usage: 
`set_flight(source, flight)`
source: the flight source.
flight: TRUE/FALSE. TRUE will add the given flight source, FALSE will remove it.

If you have no flight sources left, you'll stop flying.

`is_flying(source)`
Without a source, returns TRUE if the mob is flying in any way. If a source is specified, it will only return TRUE if the mob is flying because of that source.


I might be able to merge lack of gravity with this, but i'd have to check for side effects.