### PR TITLE
Atmos Pipenets are significantly more efficient

### DIFF
--- a/code/modules/atmospherics/gasmixtures/gas_mixture.dm
+++ b/code/modules/atmospherics/gasmixtures/gas_mixture.dm
@@ -465,3 +465,24 @@ GLOBAL_LIST_INIT(gaslist_cache, init_gaslist_cache())
 		garbage_collect()
 		if(temperature < TCMB) //just for safety
 			temperature = TCMB
+
+
+//Takes the amount of the gas you want to PP as an argument
+//So I don't have to do some hacky switches/defines/magic strings
+//eg:
+//Tox_PP = get_partial_pressure(gas_mixture.toxins)
+//O2_PP = get_partial_pressure(gas_mixture.oxygen)
+
+/datum/gas_mixture/proc/get_breath_partial_pressure(gas_pressure)
+	return (gas_pressure * R_IDEAL_GAS_EQUATION * temperature) / BREATH_VOLUME
+//inverse
+/datum/gas_mixture/proc/get_true_breath_pressure(partial_pressure)
+	return (partial_pressure * BREATH_VOLUME) / (R_IDEAL_GAS_EQUATION * temperature)
+
+//Mathematical proofs:
+/*
+get_breath_partial_pressure(gas_pp) --> gas_pp/total_moles()*breath_pp = pp
+get_true_breath_pressure(pp) --> gas_pp = pp/breath_pp*total_moles()
+
+10/20*5 = 2.5
+10 = 2.5/5*20

--- a/code/modules/atmospherics/gasmixtures/gas_mixture.dm
+++ b/code/modules/atmospherics/gasmixtures/gas_mixture.dm
@@ -418,6 +418,7 @@ GLOBAL_LIST_INIT(gaslist_cache, init_gaslist_cache())
 		if(gas in GLOB.nonreactive_gases)
 			continue
 		possible = TRUE
+		break
 	if(!possible)
 		return
 

--- a/code/modules/atmospherics/gasmixtures/gas_mixture.dm
+++ b/code/modules/atmospherics/gasmixtures/gas_mixture.dm
@@ -27,6 +27,7 @@ GLOBAL_LIST_INIT(gaslist_cache, init_gaslist_cache())
 	var/volume = CELL_VOLUME //liters
 	var/last_share = 0
 	var/list/reaction_results
+	var/static/list/nonreactive_gases = list(typecacheof(/datum/gas/oxygen, /datum/gas/nitrogen, /datum/gas/carbon_dioxide)) // These gasses cannot react amongst themselves
 
 /datum/gas_mixture/New(volume)
 	gases = new
@@ -415,7 +416,7 @@ GLOBAL_LIST_INIT(gaslist_cache, init_gaslist_cache())
 		return
 	var/possible
 	for(var/gas in gases)
-		if(gas in GLOB.nonreactive_gases)
+		if(is_type_in_typecache(gas,nonreactive_gases))
 			continue
 		possible = TRUE
 		break

--- a/code/modules/atmospherics/gasmixtures/gas_mixture.dm
+++ b/code/modules/atmospherics/gasmixtures/gas_mixture.dm
@@ -458,7 +458,7 @@ GLOBAL_LIST_INIT(gaslist_cache, init_gaslist_cache())
 			//at this point, all requirements for the reaction are satisfied. we can now react()
 			*/
 
-			. |= reaction.react(src, null)
+			. |= reaction.react(src, dump_location)
 			if (. & STOP_REACTIONS)
 				break
 	if(.)

--- a/code/modules/atmospherics/gasmixtures/gas_mixture.dm
+++ b/code/modules/atmospherics/gasmixtures/gas_mixture.dm
@@ -486,3 +486,4 @@ get_true_breath_pressure(pp) --> gas_pp = pp/breath_pp*total_moles()
 
 10/20*5 = 2.5
 10 = 2.5/5*20
+*/

--- a/code/modules/atmospherics/gasmixtures/gas_mixture.dm
+++ b/code/modules/atmospherics/gasmixtures/gas_mixture.dm
@@ -411,9 +411,17 @@ GLOBAL_LIST_INIT(gaslist_cache, init_gaslist_cache())
 
 /datum/gas_mixture/react(turf/open/dump_location)
 	. = NO_REACTION
+	if(volume == 0)
+		return
+	var/possible
+	for(var/gas in gases)
+		if(gas in GLOB.nonreactive_gases)
+			continue
+		possible = TRUE
+	if(!possible)
+		return
 
 	reaction_results = new
-
 	var/list/cached_gases = gases
 	var/temp = temperature
 	var/ener = THERMAL_ENERGY(src)
@@ -450,31 +458,10 @@ GLOBAL_LIST_INIT(gaslist_cache, init_gaslist_cache())
 			//at this point, all requirements for the reaction are satisfied. we can now react()
 			*/
 
-			. |= reaction.react(src, dump_location)
+			. |= reaction.react(src, null)
 			if (. & STOP_REACTIONS)
 				break
 	if(.)
 		garbage_collect()
 		if(temperature < TCMB) //just for safety
 			temperature = TCMB
-
-//Takes the amount of the gas you want to PP as an argument
-//So I don't have to do some hacky switches/defines/magic strings
-//eg:
-//Tox_PP = get_partial_pressure(gas_mixture.toxins)
-//O2_PP = get_partial_pressure(gas_mixture.oxygen)
-
-/datum/gas_mixture/proc/get_breath_partial_pressure(gas_pressure)
-	return (gas_pressure * R_IDEAL_GAS_EQUATION * temperature) / BREATH_VOLUME
-//inverse
-/datum/gas_mixture/proc/get_true_breath_pressure(partial_pressure)
-	return (partial_pressure * BREATH_VOLUME) / (R_IDEAL_GAS_EQUATION * temperature)
-
-//Mathematical proofs:
-/*
-get_breath_partial_pressure(gas_pp) --> gas_pp/total_moles()*breath_pp = pp
-get_true_breath_pressure(pp) --> gas_pp = pp/breath_pp*total_moles()
-
-10/20*5 = 2.5
-10 = 2.5/5*20
-*/

--- a/code/modules/atmospherics/gasmixtures/gas_types.dm
+++ b/code/modules/atmospherics/gasmixtures/gas_types.dm
@@ -1,4 +1,5 @@
 GLOBAL_LIST_INIT(hardcoded_gases, list(/datum/gas/oxygen, /datum/gas/nitrogen, /datum/gas/carbon_dioxide, /datum/gas/plasma)) //the main four gases, which were at one time hardcoded
+GLOBAL_LIST_INIT(nonreactive_gases, list(/datum/gas/oxygen, /datum/gas/nitrogen, /datum/gas/carbon_dioxide)) // These gasses cannot react amongst themselves
 
 /proc/meta_gas_list()
 	. = subtypesof(/datum/gas)

--- a/code/modules/atmospherics/gasmixtures/gas_types.dm
+++ b/code/modules/atmospherics/gasmixtures/gas_types.dm
@@ -1,5 +1,4 @@
 GLOBAL_LIST_INIT(hardcoded_gases, list(/datum/gas/oxygen, /datum/gas/nitrogen, /datum/gas/carbon_dioxide, /datum/gas/plasma)) //the main four gases, which were at one time hardcoded
-GLOBAL_LIST_INIT(nonreactive_gases, list(/datum/gas/oxygen, /datum/gas/nitrogen, /datum/gas/carbon_dioxide)) // These gasses cannot react amongst themselves
 
 /proc/meta_gas_list()
 	. = subtypesof(/datum/gas)

--- a/code/modules/atmospherics/machinery/components/binary_devices/circulator.dm
+++ b/code/modules/atmospherics/machinery/components/binary_devices/circulator.dm
@@ -43,8 +43,8 @@
 
 		//Actually transfer the gas
 		var/datum/gas_mixture/removed = air2.remove(transfer_moles)
-
-		update_parents()
+		if(removed.gases.len)
+			update_parents()
 
 		return removed
 

--- a/code/modules/atmospherics/machinery/components/binary_devices/passive_gate.dm
+++ b/code/modules/atmospherics/machinery/components/binary_devices/passive_gate.dm
@@ -61,9 +61,9 @@ Passive gate is similar to the regular pump except:
 
 		//Actually transfer the gas
 		var/datum/gas_mixture/removed = air1.remove(transfer_moles)
-		air2.merge(removed)
-
-		update_parents()
+		if(removed.gases.len)
+			air2.merge(removed)
+			update_parents()
 
 
 //Radio remote control

--- a/code/modules/atmospherics/machinery/components/binary_devices/pump.dm
+++ b/code/modules/atmospherics/machinery/components/binary_devices/pump.dm
@@ -66,9 +66,9 @@ Thus, the two variables affect pump operation are set in New():
 
 		//Actually transfer the gas
 		var/datum/gas_mixture/removed = air1.remove(transfer_moles)
-		air2.merge(removed)
-
-		update_parents()
+		if(transfer_moles)
+			air2.merge(removed)
+			update_parents()
 
 //Radio remote control
 /obj/machinery/atmospherics/components/binary/pump/proc/set_frequency(new_frequency)

--- a/code/modules/atmospherics/machinery/components/binary_devices/valve.dm
+++ b/code/modules/atmospherics/machinery/components/binary_devices/valve.dm
@@ -30,9 +30,7 @@ It's like a regular ol' straight pipe, but you can turn it on and off.
 /obj/machinery/atmospherics/components/binary/valve/proc/open()
 	open = TRUE
 	update_icon_nopipes()
-	update_parents()
-	var/datum/pipeline/parent1 = parents[1]
-	parent1.reconcile_air()
+	reconcile_parents()
 	investigate_log("was opened by [usr ? key_name(usr) : "a remote signal"]", INVESTIGATE_ATMOS)
 
 /obj/machinery/atmospherics/components/binary/valve/proc/close()

--- a/code/modules/atmospherics/machinery/components/binary_devices/volume_pump.dm
+++ b/code/modules/atmospherics/machinery/components/binary_devices/volume_pump.dm
@@ -62,9 +62,7 @@ Thus, the two variables affect pump operation are set in New():
 	var/transfer_ratio = min(1, transfer_rate/air1.volume)
 
 	var/datum/gas_mixture/removed = air1.remove_ratio(transfer_ratio)
-
 	air2.merge(removed)
-
 	update_parents()
 
 /obj/machinery/atmospherics/components/binary/volume_pump/proc/set_frequency(new_frequency)

--- a/code/modules/atmospherics/machinery/components/components_base.dm
+++ b/code/modules/atmospherics/machinery/components/components_base.dm
@@ -134,7 +134,16 @@ Helpers
 		if(!parent)
 			throw EXCEPTION("Component is missing a pipenet! Rebuilding...")
 			build_network()
-		parent.update = 1
+		parent.update = TRUE
+
+/obj/machinery/atmospherics/components/proc/reconcile_parents()
+	for(var/i in 1 to device_type)
+		var/datum/pipeline/parent = parents[i]
+		if(!parent)
+			throw EXCEPTION("Component is missing a pipenet! Rebuilding...")
+			build_network()
+		parent.reconcile = TRUE
+		parent.update = TRUE
 
 /obj/machinery/atmospherics/components/returnPipenets()
 	. = list()

--- a/code/modules/atmospherics/machinery/components/trinary_devices/filter.dm
+++ b/code/modules/atmospherics/machinery/components/trinary_devices/filter.dm
@@ -114,7 +114,7 @@
 
 		air3.merge(removed)
 
-	update_parents()
+		update_parents()
 
 /obj/machinery/atmospherics/components/trinary/filter/atmosinit()
 	set_frequency(frequency)

--- a/code/modules/atmospherics/machinery/components/unary_devices/outlet_injector.dm
+++ b/code/modules/atmospherics/machinery/components/unary_devices/outlet_injector.dm
@@ -98,7 +98,7 @@
 		var/transfer_moles = (air_contents.return_pressure())*volume_rate/(air_contents.temperature * R_IDEAL_GAS_EQUATION)
 
 		var/datum/gas_mixture/removed = air_contents.remove(transfer_moles)
-		if(removed.volume)
+		if(transfer_moles)
 			loc.assume_air(removed)
 			air_update_turf()
 			update_parents()

--- a/code/modules/atmospherics/machinery/components/unary_devices/outlet_injector.dm
+++ b/code/modules/atmospherics/machinery/components/unary_devices/outlet_injector.dm
@@ -59,11 +59,10 @@
 		var/transfer_moles = (air_contents.return_pressure())*volume_rate/(air_contents.temperature * R_IDEAL_GAS_EQUATION)
 
 		var/datum/gas_mixture/removed = air_contents.remove(transfer_moles)
-
-		loc.assume_air(removed)
-		air_update_turf()
-
-		update_parents()
+		if(removed.volume)
+			loc.assume_air(removed)
+			air_update_turf()
+			update_parents()
 
 /obj/machinery/atmospherics/components/unary/outlet_injector/proc/inject()
 

--- a/code/modules/atmospherics/machinery/components/unary_devices/portables_connector.dm
+++ b/code/modules/atmospherics/machinery/components/unary_devices/portables_connector.dm
@@ -23,7 +23,7 @@
 /obj/machinery/atmospherics/components/unary/portables_connector/process_atmos()
 	if(!connected_device)
 		return
-	update_parents()
+	reconcile_parents()
 
 /obj/machinery/atmospherics/components/unary/portables_connector/Destroy()
 	if(connected_device)

--- a/code/modules/atmospherics/machinery/components/unary_devices/vent_pump.dm
+++ b/code/modules/atmospherics/machinery/components/unary_devices/vent_pump.dm
@@ -144,9 +144,9 @@
 				var/transfer_moles = pressure_delta*environment.volume/(air_contents.temperature * R_IDEAL_GAS_EQUATION)
 
 				var/datum/gas_mixture/removed = air_contents.remove(transfer_moles)
-
 				loc.assume_air(removed)
 				air_update_turf()
+				update_parents()
 
 	else // external -> internal
 		var/pressure_delta = 10000
@@ -161,10 +161,9 @@
 			var/datum/gas_mixture/removed = loc.remove_air(transfer_moles)
 			if (isnull(removed)) // in space
 				return
-
 			air_contents.merge(removed)
 			air_update_turf()
-	update_parents()
+			update_parents()
 
 //Radio remote control
 

--- a/code/modules/atmospherics/machinery/components/unary_devices/vent_scrubber.dm
+++ b/code/modules/atmospherics/machinery/components/unary_devices/vent_scrubber.dm
@@ -190,17 +190,16 @@
 
 			tile.assume_air(removed)
 			tile.air_update_turf()
+			update_parents()
 
 	else //Just siphoning all air
 
 		var/transfer_moles = environment.total_moles()*(volume_rate/environment.volume)
 
 		var/datum/gas_mixture/removed = tile.remove_air(transfer_moles)
-
 		air_contents.merge(removed)
 		tile.air_update_turf()
-
-	update_parents()
+		update_parents()
 
 	return TRUE
 
@@ -285,12 +284,6 @@
 			return 0
 	else
 		return ..()
-
-/obj/machinery/atmospherics/components/unary/vent_scrubber/can_unwrench(mob/user)
-	. = ..()
-	if(. && on && is_operational())
-		to_chat(user, "<span class='warning'>You cannot unwrench [src], turn it off first!</span>")
-		return FALSE
 
 /obj/machinery/atmospherics/components/unary/vent_scrubber/can_crawl_through()
 	return !welded

--- a/code/modules/atmospherics/machinery/datum_pipeline.dm
+++ b/code/modules/atmospherics/machinery/datum_pipeline.dm
@@ -7,8 +7,6 @@
 
 	var/update = TRUE
 	var/reconcile = FALSE //If the pipeline contains components that must be reconciled if our gas mix is updated
-	var/static/d1 = 0
-	var/static/d2 = 0
 
 /datum/pipeline/New()
 	other_airs = list()

--- a/code/modules/atmospherics/machinery/datum_pipeline.dm
+++ b/code/modules/atmospherics/machinery/datum_pipeline.dm
@@ -218,8 +218,9 @@
 		var/datum/pipeline/P = PL[i]
 		if(!P)
 			continue
-		if(P != src)
-			GL += P.return_air()
+		GL += P.return_air()
+		if(P == src)
+			GL -= src
 		for(var/obj/machinery/atmospherics/components/binary/valve/V in P.other_atmosmch)
 			if(V.open)
 				PL |= V.parents[1]

--- a/code/modules/atmospherics/machinery/datum_pipeline.dm
+++ b/code/modules/atmospherics/machinery/datum_pipeline.dm
@@ -7,6 +7,8 @@
 
 	var/update = TRUE
 	var/reconcile = FALSE //If the pipeline contains components that must be reconciled if our gas mix is updated
+	var/static/d1 = 0
+	var/static/d2 = 0
 
 /datum/pipeline/New()
 	other_airs = list()
@@ -29,7 +31,7 @@
 		if(reconcile)
 			reconcile_air()
 		else
-			update_air()
+			air.update_pipeair(other_airs)
 		update = air.react()
 
 /datum/pipeline/proc/build_pipeline(obj/machinery/atmospherics/base)
@@ -218,7 +220,8 @@
 		var/datum/pipeline/P = PL[i]
 		if(!P)
 			continue
-		GL += P.return_air()
+		if(P != src)
+			GL += P.return_air()
 		for(var/obj/machinery/atmospherics/components/binary/valve/V in P.other_atmosmch)
 			if(V.open)
 				PL |= V.parents[1]
@@ -226,53 +229,21 @@
 		for(var/obj/machinery/atmospherics/components/unary/portables_connector/C in P.other_atmosmch)
 			if(C.connected_device)
 				GL += C.portableConnectorReturnAir()
-
-	var/total_thermal_energy = 0
-	var/total_heat_capacity = 0
-	var/datum/gas_mixture/total_gas_mixture = new(0)
-
-	for(var/i in GL)
-		var/datum/gas_mixture/G = i
-		total_gas_mixture.volume += G.volume
-
-		total_gas_mixture.merge(G)
-
-		total_thermal_energy += THERMAL_ENERGY(G)
-		total_heat_capacity += G.heat_capacity()
-
-	total_gas_mixture.temperature = total_heat_capacity ? total_thermal_energy/total_heat_capacity : 0
-
-	if(total_gas_mixture.volume > 0)
-		//Update individual gas_mixtures by volume ratio
-		for(var/i in GL)
-			var/datum/gas_mixture/G = i
-			G.copy_from(total_gas_mixture)
-			var/list/G_gases = G.gases
-			for(var/id in G_gases)
-				G_gases[id][MOLES] *= G.volume/total_gas_mixture.volume
 	reconcile = FALSE
+	air.update_pipeair(GL)
 
-/datum/pipeline/proc/update_air()
-	var/list/datum/gas_mixture/GL = list()
-	GL += return_air()
-	var/total_thermal_energy
-	var/total_heat_capacity
-	var/datum/gas_mixture/total_gas_mixture = new(0)
 
-	for(var/i in GL)
+/datum/gas_mixture/proc/update_pipeair(list/other_airs)
+	var/total_volume = volume
+	for(var/i in other_airs)
 		var/datum/gas_mixture/G = i
-		total_gas_mixture.volume += G.volume
-		if(G.gases.len)
-			total_gas_mixture.merge(G)
-			total_thermal_energy += THERMAL_ENERGY(G)
-			total_heat_capacity += G.heat_capacity()
-	total_gas_mixture.temperature = total_heat_capacity ? total_thermal_energy/total_heat_capacity : 0
-
-	if(total_gas_mixture.volume)
-		//Update individual gas_mixtures by volume ratio
-		for(var/i in GL)
+		total_volume += G.volume
+		if(G.gases.len) //Average 0.6-0.8 false results for every proc call
+			merge(G)
+	if(gases.len) //Average 0.15 false results for every proc call
+		for(var/i in other_airs)	//Update individual gas_mixtures by volume ratio
 			var/datum/gas_mixture/G = i
-			G.copy_from(total_gas_mixture)
-			var/list/G_gases = G.gases
-			for(var/id in G_gases)
-				G_gases[id][MOLES] *= G.volume/total_gas_mixture.volume
+			G.ratio_copy_from(src, G.volume/total_volume)
+		var/ratio = volume/total_volume
+		for(var/id in gases)
+			gases[id][MOLES] *= ratio


### PR DESCRIPTION
So pipes and the reconcile_air() proc were right behind react() for hogging processing power (literally the second most expensive proc on an empty server). While my react() improvement was just a shortcut out of a lot of unnecessary work, this is more akin a work of art, whittling the proc down to its most pure essence, RAW SPEED. 

  | Total CPU | Process() Calls
-- | -- | --
NEW Reconciliation per   Process() | 1.157776 | 100000
Reconciliation per Process() | 5.434935 | 100000


Process_Pipenets() | Calls | Total CPU
-- | -- | --
New Pipenet Processing | 1000 | 5.225143
Old Pipenet Processing | 1000 | 21.03587

**For reviewers, this is what this PR contains:**

1) I moved most of the "update_parents" calls in atmos components so that the pipenet would only update if its gas contents changed. Also react was being needlessly called every process for every pipenet, it should be impossible now to reach react() conditions without an update being called so it made no sense to keep testing react().

2) I split reconcile_air into reconcile_air and update_pipeair. Reconcile air was forcing every pipenet to check for binary valves and portable connectors on every update. Instead I simply had these components call a new proc called "reconcile_parents" that would tell the pipenet it needed to "reconcile" before dealing with the air stuff.

3) The heavy-duty air stuff from reconcile_air is now in update_pipeair. It got moved from a pipeline proc to a gas mix proc because once the "reconcile" stuff was out of the picture the proc had nothing to do with the actual pipes beyond the gases that needed to be mixed. The proc also did a huge amount of redundant work like calling heat_capacity three different times on every single air datum (first in merge(), then in THERMAL_ENERGY(), then again in heat_capacity()). Despite Dunc's insistence, I did the math and merge() completely handles thermal mixing so everything past that was just literally duplicated work being done hundreds of times... every second. I also changed the structure of the proc so that its based on the "src" gas and provides the "other gases" via argument in process(), avoiding the silly loop from reconcile() that would only run once in like 99% of cases and just made it way too complicated to get the gas list. The "src" is now also the base gas mix instead of using a "hypothetical" one and the "other gases" are added to the base being they are all redistributed in the 2nd loops

4) Finally, after I opened this PR I just went ahead and incorporated react() into the proc as well. Since this proc already had a reason to do performance checks (i.e. if(gases.len)), it made no sense to immediately follow with react() to run those very same checks on the very same gas mix. I'm still tweaking this part and it has the unfortunate side effect of making the proc long and ugly again, but its still a material boost to pipe performance by combining the two most performance-intensive procs. 


