### PR TITLE
Gun Overlays are now ∞²% more efficient 

### DIFF
--- a/code/modules/projectiles/gun.dm
+++ b/code/modules/projectiles/gun.dm
@@ -339,7 +339,8 @@
 			var/state = "bayonet"							//Generic state.
 			if(bayonet.icon_state in icon_states('icons/obj/guns/bayonets.dmi'))		//Snowflake state?
 				state = bayonet.icon_state
-			knife_overlay = mutable_appearance('icons/obj/guns/bayonets.dmi', state)
+			var/icon/bayonet_icons = 'icons/obj/guns/bayonets.dmi' 
+			knife_overlay = mutable_appearance(bayonet_icons, state)
 			knife_overlay.pixel_x = knife_x_offset
 			knife_overlay.pixel_y = knife_y_offset
 			add_overlay(knife_overlay, TRUE)

--- a/code/modules/projectiles/gun.dm
+++ b/code/modules/projectiles/gun.dm
@@ -45,8 +45,10 @@
 	var/obj/item/device/flashlight/gun_light
 	var/can_flashlight = 0
 	var/obj/item/kitchen/knife/bayonet
+	var/mutable_appearance/knife_overlay
 	var/can_bayonet = FALSE
 	var/datum/action/item_action/toggle_gunlight/alight
+	var/mutable_appearance/flashlight_overlay
 
 	var/list/upgrades = list()
 
@@ -282,17 +284,6 @@
 /obj/item/gun/proc/reset_semicd()
 	semicd = FALSE
 
-/obj/item/gun/update_icon()
-	..()
-	cut_overlays()
-	if(gun_light && can_flashlight)
-		var/state = "flight[gun_light.on? "_on":""]"	//Generic state.
-		if(gun_light.icon_state in icon_states('icons/obj/guns/flashlights.dmi'))	//Snowflake state?
-			state = gun_light.icon_state
-		var/mutable_appearance/flashlight_overlay = mutable_appearance('icons/obj/guns/flashlights.dmi', state)
-		flashlight_overlay.pixel_x = flight_x_offset
-		flashlight_overlay.pixel_y = flight_y_offset
-		add_overlay(flashlight_overlay)
 	if(bayonet && can_bayonet)
 		var/state = "bayonet"							//Generic state.
 		if(bayonet.icon_state in icon_states('icons/obj/guns/bayonets.dmi'))		//Snowflake state?
@@ -332,7 +323,6 @@
 			if(S.on)
 				set_light(0)
 			gun_light = S
-			update_icon()
 			update_gunlight(user)
 			alight = new /datum/action/item_action/toggle_gunlight(src)
 			if(loc == user)
@@ -346,7 +336,13 @@
 				return
 			to_chat(user, "<span class='notice'>You attach \the [K] to the front of \the [src].</span>")
 			bayonet = K
-			update_icon()
+			var/state = "bayonet"							//Generic state.
+			if(bayonet.icon_state in icon_states('icons/obj/guns/bayonets.dmi'))		//Snowflake state?
+				state = bayonet.icon_state
+			knife_overlay = mutable_appearance('icons/obj/guns/bayonets.dmi', state)
+			knife_overlay.pixel_x = knife_x_offset
+			knife_overlay.pixel_y = knife_y_offset
+			add_overlay(knife_overlay, TRUE)
 	else if(istype(I, /obj/item/screwdriver))
 		if(gun_light)
 			var/obj/item/device/flashlight/seclite/S = gun_light
@@ -355,13 +351,14 @@
 			S.forceMove(get_turf(user))
 			update_gunlight(user)
 			S.update_brightness(user)
-			update_icon()
 			QDEL_NULL(alight)
 		if(bayonet)
+			to_chat(user, "<span class='notice'>You unscrew the bayonet from \the [src].</span>")
 			var/obj/item/kitchen/knife/K = bayonet
 			K.forceMove(get_turf(user))
 			bayonet = null
-			update_icon()
+			cut_overlay(knife_overlay, TRUE)
+			knife_overlay = null
 	else
 		return ..()
 
@@ -383,9 +380,18 @@
 			set_light(gun_light.brightness_on)
 		else
 			set_light(0)
-		update_icon()
+		cut_overlays(flashlight_overlay, TRUE)
+		var/state = "flight[gun_light.on? "_on":""]"	//Generic state.
+		if(gun_light.icon_state in icon_states('icons/obj/guns/flashlights.dmi'))	//Snowflake state?
+			state = gun_light.icon_state
+		flashlight_overlay = mutable_appearance('icons/obj/guns/flashlights.dmi', state)
+		flashlight_overlay.pixel_x = flight_x_offset
+		flashlight_overlay.pixel_y = flight_y_offset
+		add_overlay(flashlight_overlay, TRUE)
 	else
 		set_light(0)
+		cut_overlays(flashlight_overlay, TRUE)
+		flashlight_overlay = null
 	for(var/X in actions)
 		var/datum/action/A = X
 		A.UpdateButtonIcon()

--- a/code/modules/projectiles/gun.dm
+++ b/code/modules/projectiles/gun.dm
@@ -288,15 +288,6 @@
 /obj/item/gun/proc/reset_semicd()
 	semicd = FALSE
 
-	if(bayonet && can_bayonet)
-		var/state = "bayonet"							//Generic state.
-		if(bayonet.icon_state in icon_states('icons/obj/guns/bayonets.dmi'))		//Snowflake state?
-			state = bayonet.icon_state
-		var/mutable_appearance/knife_overlay = mutable_appearance('icons/obj/guns/bayonets.dmi', state)
-		knife_overlay.pixel_x = knife_x_offset
-		knife_overlay.pixel_y = knife_y_offset
-		add_overlay(knife_overlay)
-
 /obj/item/gun/attack(mob/M as mob, mob/user)
 	if(user.a_intent == INTENT_HARM) //Flogging
 		if(bayonet)

--- a/code/modules/projectiles/gun.dm
+++ b/code/modules/projectiles/gun.dm
@@ -281,6 +281,10 @@
 	SSblackbox.record_feedback("tally", "gun_fired", 1, type)
 	return TRUE
 
+/obj/item/gun/update_icon()
+	..()
+
+
 /obj/item/gun/proc/reset_semicd()
 	semicd = FALSE
 

--- a/code/modules/projectiles/guns/energy.dm
+++ b/code/modules/projectiles/guns/energy.dm
@@ -60,7 +60,7 @@
 	return ..()
 
 /obj/item/gun/energy/process()
-	if(selfcharge && cell && cell.percent < 100)
+	if(selfcharge && cell && cell.percent() < 100)
 		charge_tick++
 		if(charge_tick < charge_delay)
 			return

--- a/code/modules/projectiles/guns/energy.dm
+++ b/code/modules/projectiles/guns/energy.dm
@@ -59,13 +59,11 @@
 	return ..()
 
 /obj/item/gun/energy/process()
-	if(selfcharge)
+	if(selfcharge && cell && cell.percent < 100))
 		charge_tick++
 		if(charge_tick < charge_delay)
 			return
 		charge_tick = 0
-		if(!cell)
-			return
 		cell.give(100)
 		if(!chambered) //if empty chamber we try to charge a new shot
 			recharge_newshot(1)

--- a/code/modules/projectiles/guns/energy.dm
+++ b/code/modules/projectiles/guns/energy.dm
@@ -13,7 +13,8 @@
 	var/automatic_charge_overlays = TRUE	//Do we handle overlays with base update_icon()?
 	var/charge_sections = 4
 	ammo_x_offset = 2
-	var/shaded_charge = 0 //if this gun uses a stateful charge bar for more detail
+	var/shaded_charge = FALSE //if this gun uses a stateful charge bar for more detail
+	var/old_ratio = 0 // stores the gun's previous ammo "ratio" to see if it needs an updated icon
 	var/selfcharge = 0
 	var/charge_tick = 0
 	var/charge_delay = 4
@@ -59,7 +60,7 @@
 	return ..()
 
 /obj/item/gun/energy/process()
-	if(selfcharge && cell && cell.percent < 100))
+	if(selfcharge && cell && cell.percent < 100)
 		charge_tick++
 		if(charge_tick < charge_delay)
 			return
@@ -131,6 +132,9 @@
 	if(!automatic_charge_overlays)
 		return
 	var/ratio = CEILING((cell.charge / cell.maxcharge) * charge_sections, 1)
+	if(ratio == old_ratio)
+		return
+	old_ratio = ratio
 	var/obj/item/ammo_casing/energy/shot = ammo_type[select]
 	var/iconState = "[icon_state]_charge"
 	var/itemState = null

--- a/code/modules/projectiles/guns/energy.dm
+++ b/code/modules/projectiles/guns/energy.dm
@@ -128,13 +128,13 @@
 	return
 
 /obj/item/gun/energy/update_icon()
-	..()
 	if(!automatic_charge_overlays)
 		return
 	var/ratio = CEILING((cell.charge / cell.maxcharge) * charge_sections, 1)
 	if(ratio == old_ratio)
 		return
 	old_ratio = ratio
+	cut_overlays()
 	var/obj/item/ammo_casing/energy/shot = ammo_type[select]
 	var/iconState = "[icon_state]_charge"
 	var/itemState = null

--- a/code/modules/projectiles/guns/energy.dm
+++ b/code/modules/projectiles/guns/energy.dm
@@ -128,6 +128,7 @@
 	return
 
 /obj/item/gun/energy/update_icon()
+	..()
 	if(!automatic_charge_overlays)
 		return
 	var/ratio = CEILING((cell.charge / cell.maxcharge) * charge_sections, 1)

--- a/code/modules/projectiles/guns/energy/kinetic_accelerator.dm
+++ b/code/modules/projectiles/guns/energy/kinetic_accelerator.dm
@@ -144,10 +144,10 @@
 	overheat = FALSE
 
 /obj/item/gun/energy/kinetic_accelerator/update_icon()
-	..()
-
 	if(empty_state && !can_shoot())
 		add_overlay(empty_state)
+	else
+		cut_overlays()
 
 //Casing
 /obj/item/ammo_casing/energy/kinetic

--- a/code/modules/projectiles/guns/energy/kinetic_accelerator.dm
+++ b/code/modules/projectiles/guns/energy/kinetic_accelerator.dm
@@ -143,6 +143,7 @@
 	overheat = FALSE
 
 /obj/item/gun/energy/kinetic_accelerator/update_icon()
+	..()
 	if(!can_shoot())
 		add_overlay("[icon_state]_empty")
 	else

--- a/code/modules/projectiles/guns/energy/kinetic_accelerator.dm
+++ b/code/modules/projectiles/guns/energy/kinetic_accelerator.dm
@@ -21,8 +21,7 @@
 
 	var/max_mod_capacity = 100
 	var/list/modkits = list()
-
-	var/empty_state = "kineticgun_empty"
+	
 	var/recharge_timerid
 
 /obj/item/gun/energy/kinetic_accelerator/examine(mob/user)
@@ -145,7 +144,7 @@
 
 /obj/item/gun/energy/kinetic_accelerator/update_icon()
 	if(!can_shoot())
-		add_overlay(empty_state)
+		add_overlay("[icon_state]_empty")
 	else
 		cut_overlays()
 

--- a/code/modules/projectiles/guns/energy/kinetic_accelerator.dm
+++ b/code/modules/projectiles/guns/energy/kinetic_accelerator.dm
@@ -144,7 +144,7 @@
 	overheat = FALSE
 
 /obj/item/gun/energy/kinetic_accelerator/update_icon()
-	if(empty_state && !can_shoot())
+	if(!can_shoot())
 		add_overlay(empty_state)
 	else
 		cut_overlays()

--- a/code/modules/projectiles/guns/energy/kinetic_accelerator.dm
+++ b/code/modules/projectiles/guns/energy/kinetic_accelerator.dm
@@ -11,6 +11,7 @@
 	can_flashlight = 1
 	flight_x_offset = 15
 	flight_y_offset = 9
+	automatic_charge_overlays = FALSE
 	var/overheat_time = 16
 	var/holds_charge = FALSE
 	var/unique_frequency = FALSE // modified by KA modkits

--- a/code/modules/projectiles/guns/energy/special.dm
+++ b/code/modules/projectiles/guns/energy/special.dm
@@ -98,6 +98,13 @@
 	max_mod_capacity = 0
 	empty_state = null
 
+/obj/item/gun/energy/kinetic_accelerator/crossbow/update_icon()
+	if(!can_shoot())
+		add_overlay("[icon_state]_empty")
+	else
+		cut_overlays()
+
+
 /obj/item/gun/energy/kinetic_accelerator/crossbow/halloween
 	name = "candy corn crossbow"
 	desc = "A weapon favored by Syndicate trick-or-treaters."

--- a/code/modules/projectiles/guns/energy/special.dm
+++ b/code/modules/projectiles/guns/energy/special.dm
@@ -96,7 +96,6 @@
 	unique_frequency = TRUE
 	can_flashlight = 0
 	max_mod_capacity = 0
-	empty_state = null
 
 /obj/item/gun/energy/kinetic_accelerator/crossbow/halloween
 	name = "candy corn crossbow"

--- a/code/modules/projectiles/guns/energy/special.dm
+++ b/code/modules/projectiles/guns/energy/special.dm
@@ -98,13 +98,6 @@
 	max_mod_capacity = 0
 	empty_state = null
 
-/obj/item/gun/energy/kinetic_accelerator/crossbow/update_icon()
-	if(!can_shoot())
-		add_overlay("[icon_state]_empty")
-	else
-		cut_overlays()
-
-
 /obj/item/gun/energy/kinetic_accelerator/crossbow/halloween
 	name = "candy corn crossbow"
 	desc = "A weapon favored by Syndicate trick-or-treaters."


### PR DESCRIPTION
Nerds: "Sure Robustin, you improved atmos, but thats nothing compared to overlay shit hitting the fan on a populated server"

Me: Hold my scraps

------------

Self-charging guns were doing a shitload of work refreshing their overlay every few seconds of their entire existence. Turns out the floral somatoray doesn't need to be sitting there redrawing its overlay thousands of times per round as it sits on a table. 

Also guns only change overlays if their "ratio" of current energy/max energy hits a certain breakpoint (i.e. eguns hold 10 "shots" but only 4 bars to show your ammo). By simply storing the ratio from the previous update_icon() we can decide if we want to go to all the trouble of redrawing the overlay from scratch.

Lastly KA's are a meme and use a totally different ammo/icon system, yet for some baffling reason they still called their parent (egun) update_icon which would do a bunch of complex but meaningless overlay calculations before jumping to the KA proc and going "lol JK here's the actual overlay". 

**Edit: Oh god I figured out why KA's called eguns update, because it needed eguns to call guns... and it needed guns because EVERY FUCKING TIME ANY WEAPON WITH AN ATTACHMENT FIRED, RECHARGED, OR GOT BREATHED ON IT WOULD DELETE AND REBUILD THE ATTACHMENT OVERLAY FROM SCRATCH AHHHHHH... so I fixed that and now guns are ∞² more efficient, see the new table:**


  | Spawned 5 Floral Somatorays and   left on ground for 10m
-- | --
Current | 1817ms
Box of Scraps | 9ms


  | Shot a KA w/attachments 20 times
-- | --
Current | 139ms
Box of Scraps | 3ms