### PR TITLE
Get_Flat_Human_Icon no longer draws asses that nobody wants

### DIFF
--- a/code/__HELPERS/icons.dm
+++ b/code/__HELPERS/icons.dm
@@ -1041,7 +1041,7 @@ GLOBAL_LIST_EMPTY(friendly_animal_types)
 	return 0
 
 //For creating consistent icons for human looking simple animals
-/proc/get_flat_human_icon(icon_id, datum/job/J, datum/preferences/prefs, dummy_key, showDirs = list(NORTH, SOUTH, EAST, WEST))
+/proc/get_flat_human_icon(icon_id, datum/job/J, datum/preferences/prefs, dummy_key, showDirs = GLOB.cardinal_dirs)
 	var/static/list/humanoid_icon_cache = list()
 	if(!icon_id || !humanoid_icon_cache[icon_id])
 		var/mob/living/carbon/human/dummy/body = generate_or_wait_for_human_dummy(dummy_key)

--- a/code/__HELPERS/icons.dm
+++ b/code/__HELPERS/icons.dm
@@ -1041,7 +1041,7 @@ GLOBAL_LIST_EMPTY(friendly_animal_types)
 	return 0
 
 //For creating consistent icons for human looking simple animals
-/proc/get_flat_human_icon(icon_id, datum/job/J, datum/preferences/prefs, dummy_key)
+/proc/get_flat_human_icon(icon_id, datum/job/J, datum/preferences/prefs, dummy_key, showDirs = list(NORTH, SOUTH, EAST, WEST))
 	var/static/list/humanoid_icon_cache = list()
 	if(!icon_id || !humanoid_icon_cache[icon_id])
 		var/mob/living/carbon/human/dummy/body = generate_or_wait_for_human_dummy(dummy_key)
@@ -1053,26 +1053,11 @@ GLOBAL_LIST_EMPTY(friendly_animal_types)
 
 
 		var/icon/out_icon = icon('icons/effects/effects.dmi', "nothing")
-
-		body.setDir(NORTH)
-		COMPILE_OVERLAYS(body)
-		var/icon/partial = getFlatIcon(body)
-		out_icon.Insert(partial,dir=NORTH)
-
-		body.setDir(SOUTH)
-		COMPILE_OVERLAYS(body)
-		partial = getFlatIcon(body)
-		out_icon.Insert(partial,dir=SOUTH)
-
-		body.setDir(WEST)
-		COMPILE_OVERLAYS(body)
-		partial = getFlatIcon(body)
-		out_icon.Insert(partial,dir=WEST)
-
-		body.setDir(EAST)
-		COMPILE_OVERLAYS(body)
-		partial = getFlatIcon(body)
-		out_icon.Insert(partial,dir=EAST)
+		for(var/D in showDirs)
+			body.setDir(D)
+			COMPILE_OVERLAYS(body)
+			var/icon/partial = getFlatIcon(body)
+			out_icon.Insert(partial,dir=D)
 
 		humanoid_icon_cache[icon_id] = out_icon
 		dummy_key? unset_busy_human_dummy(dummy_key) : qdel(body)

--- a/code/__HELPERS/icons.dm
+++ b/code/__HELPERS/icons.dm
@@ -1041,7 +1041,7 @@ GLOBAL_LIST_EMPTY(friendly_animal_types)
 	return 0
 
 //For creating consistent icons for human looking simple animals
-/proc/get_flat_human_icon(icon_id, datum/job/J, datum/preferences/prefs, dummy_key, showDirs = GLOB.cardinal_dirs)
+/proc/get_flat_human_icon(icon_id, datum/job/J, datum/preferences/prefs, dummy_key, showDirs = GLOB.cardinals)
 	var/static/list/humanoid_icon_cache = list()
 	if(!icon_id || !humanoid_icon_cache[icon_id])
 		var/mob/living/carbon/human/dummy/body = generate_or_wait_for_human_dummy(dummy_key)

--- a/code/datums/datacore.dm
+++ b/code/datums/datacore.dm
@@ -217,7 +217,10 @@
 		var/obj/item/photo/photo_front = new()
 		var/obj/item/photo/photo_side = new()
 		for(var/D in show_directions) 
-			photo_front.photocreate(null, icon(image, dir = D))
+			if(D == SOUTH)
+				photo_front.photocreate(null, icon(image, dir = D))
+			if(D == WEST || D == EAST)
+				photo_side.photocreate(null, icon(image, dir = D))
 
 		//These records should ~really~ be merged or something
 		//General Record

--- a/code/datums/datacore.dm
+++ b/code/datums/datacore.dm
@@ -199,7 +199,7 @@
 
 /datum/datacore/proc/manifest_inject(mob/living/carbon/human/H, client/C)
 	set waitfor = FALSE
-	var/list/show_directions = list(SOUTH, WEST)
+	var/static/list/show_directions = list(SOUTH, WEST)
 	if(H.mind && (H.mind.assigned_role != H.mind.special_role))
 		var/assignment
 		if(H.mind.assigned_role)
@@ -283,7 +283,7 @@
 		locked += L
 	return
 
-/datum/datacore/proc/get_id_photo(mob/living/carbon/human/H, client/C, show_directions = list())
+/datum/datacore/proc/get_id_photo(mob/living/carbon/human/H, client/C, show_directions = list(SOUTH))
 	var/datum/job/J = SSjob.GetJob(H.mind.assigned_role)
 	var/datum/preferences/P
 	if(!C)

--- a/code/datums/datacore.dm
+++ b/code/datums/datacore.dm
@@ -199,6 +199,7 @@
 
 /datum/datacore/proc/manifest_inject(mob/living/carbon/human/H, client/C)
 	set waitfor = FALSE
+	var/list/show_directions = list(SOUTH, WEST)
 	if(H.mind && (H.mind.assigned_role != H.mind.special_role))
 		var/assignment
 		if(H.mind.assigned_role)
@@ -212,11 +213,11 @@
 		var/id = num2hex(record_id_num++,6)
 		if(!C)
 			C = H.client
-		var/image = get_id_photo(H, C)
+		var/image = get_id_photo(H, C, show_directions)
 		var/obj/item/photo/photo_front = new()
 		var/obj/item/photo/photo_side = new()
-		photo_front.photocreate(null, icon(image, dir = SOUTH))
-		photo_side.photocreate(null, icon(image, dir = WEST))
+		for(var/D in show_directions) 
+			photo_front.photocreate(null, icon(image, dir = D))
 
 		//These records should ~really~ be merged or something
 		//General Record
@@ -279,11 +280,11 @@
 		locked += L
 	return
 
-/datum/datacore/proc/get_id_photo(mob/living/carbon/human/H, client/C)
+/datum/datacore/proc/get_id_photo(mob/living/carbon/human/H, client/C, show_directions = list())
 	var/datum/job/J = SSjob.GetJob(H.mind.assigned_role)
 	var/datum/preferences/P
 	if(!C)
 		C = H.client
 	if(C)
 		P = C.prefs
-	return get_flat_human_icon(null, J, P, DUMMY_HUMAN_SLOT_MANIFEST)
+	return get_flat_human_icon(null, J, P, DUMMY_HUMAN_SLOT_MANIFEST, show_directions)

--- a/code/modules/antagonists/cult/cult.dm
+++ b/code/modules/antagonists/cult/cult.dm
@@ -241,7 +241,7 @@
 
 		var/datum/job/sacjob = SSjob.GetJob(sac_objective.target.assigned_role)
 		var/datum/preferences/sacface = sac_objective.target.current.client.prefs
-		var/icon/reshape = get_flat_human_icon(null, sacjob, sacface)
+		var/icon/reshape = get_flat_human_icon(null, sacjob, sacface, list(SOUTH))
 		reshape.Shift(SOUTH, 4)
 		reshape.Shift(EAST, 1)
 		reshape.Crop(7,4,26,31)


### PR DESCRIPTION
Get_Flat_Human_Icon (and manifest inject, which calls it) is probably the most expensive procs per call we have. 

In part because it creates an icon for a real human bean from scratch for all 4 directions.

Only imaginary friends used all 4 directions, manifest inject only needs 2 directions (for player sec records) and cult (sac image) only needs one. 

To give you an idea, each player would use as much processing power as 83,535 gas compare() procs just to create sec record photos. It *should* also significantly reduce roundstart lag. 

Now at least its ~42,000 #progress