### PR TITLE
Removes the ghost chair config

### DIFF
--- a/code/_onclick/observer.dm
+++ b/code/_onclick/observer.dm
@@ -42,8 +42,6 @@
 
 	if(world.time <= next_move)
 		return
-	// You are responsible for checking config.ghost_interaction when you override this function
-	// Not all of them require checking, see below
 	A.attack_ghost(src)
 
 // Oh by the way this didn't work with old click code which is why clicking shit didn't spam you

--- a/code/controllers/configuration/entries/game_options.dm
+++ b/code/controllers/configuration/entries/game_options.dm
@@ -203,8 +203,6 @@
 	config_entry_value = 18000
 	min_val = 0
 
-/datum/config_entry/flag/ghost_interaction
-
 /datum/config_entry/flag/silent_ai
 /datum/config_entry/flag/silent_borg
 

--- a/code/game/objects/structures/beds_chairs/chair.dm
+++ b/code/game/objects/structures/beds_chairs/chair.dm
@@ -40,8 +40,6 @@
 			return FALSE
 		else
 			return TRUE
-	else if(isobserver(user) && CONFIG_GET(flag/ghost_interaction))
-		return TRUE
 	return FALSE
 
 /obj/structure/chair/Destroy()

--- a/config/game_options.txt
+++ b/config/game_options.txt
@@ -300,11 +300,6 @@ MINIMAL_ACCESS_THRESHOLD 20
 ## Comment this out this to make security officers spawn in departmental security posts
 SEC_START_BRIG
 
-
-## GHOST INTERACTION ###
-## Uncomment to let ghosts spin chairs. You may be wondering why this is a config option. Don't ask.
-#GHOST_INTERACTION
-
 ## NON-VOCAL SILICONS ###
 ## Uncomment these to stop the AI, or cyborgs, from having vocal communication.
 #SILENT_AI


### PR DESCRIPTION
An outdated config from I think 2012 which believe it or not was a compromise to stop massive community drama and a downstream revolt.

/tg/ hasn't had this on for 6 years now, it's a silly thing to still keep around.