### PR TITLE
Fixed paperbin dropping and fingerprints

### DIFF
--- a/code/modules/paperwork/paperbin.dm
+++ b/code/modules/paperwork/paperbin.dm
@@ -18,6 +18,7 @@
 
 /obj/item/paper_bin/Initialize(mapload)
 	. = ..()
+	interaction_flags_item = interaction_flags_item & ~INTERACT_ITEM_ATTACK_HAND_PICKUP
 	if(!mapload)
 		return
 	var/obj/item/pen/P = locate(/obj/item/pen) in src.loc
@@ -91,7 +92,7 @@
 	else
 		to_chat(user, "<span class='warning'>[src] is empty!</span>")
 	add_fingerprint(user)
-	// return ..() // Breaks the paperbin where the bin drops to the ground from your hand, bag, etc, when taking a paper or pen
+	return ..()
 
 /obj/item/paper_bin/attackby(obj/item/I, mob/user, params)
 	if(istype(I, /obj/item/paper))

--- a/code/modules/paperwork/paperbin.dm
+++ b/code/modules/paperwork/paperbin.dm
@@ -18,7 +18,7 @@
 
 /obj/item/paper_bin/Initialize(mapload)
 	. = ..()
-	interaction_flags_item = interaction_flags_item & ~INTERACT_ITEM_ATTACK_HAND_PICKUP
+	interaction_flags_item &= ~INTERACT_ITEM_ATTACK_HAND_PICKUP
 	if(!mapload)
 		return
 	var/obj/item/pen/P = locate(/obj/item/pen) in src.loc

--- a/code/modules/paperwork/paperbin.dm
+++ b/code/modules/paperwork/paperbin.dm
@@ -91,7 +91,7 @@
 	else
 		to_chat(user, "<span class='warning'>[src] is empty!</span>")
 	add_fingerprint(user)
-	return ..()
+	// return ..() // Breaks the paperbin where the bin drops to the ground from your hand, bag, etc, when taking a paper or pen
 
 /obj/item/paper_bin/attackby(obj/item/I, mob/user, params)
 	if(istype(I, /obj/item/paper))

--- a/code/modules/paperwork/paperbin.dm
+++ b/code/modules/paperwork/paperbin.dm
@@ -53,7 +53,7 @@
 		var/obj/screen/inventory/hand/H = over_object
 		M.putItemFromInventoryInHandIfPossible(src, H.held_index)
 
-	add_fingerprint(M)
+	src.add_fingerprint(M)
 
 /obj/item/paper_bin/attack_paw(mob/user)
 	return attack_hand(user)
@@ -65,6 +65,7 @@
 	user.changeNext_move(CLICK_CD_MELEE)
 	if(bin_pen)
 		var/obj/item/pen/P = bin_pen
+		P.add_fingerprint(user)
 		P.forceMove(user.loc)
 		user.put_in_hands(P)
 		to_chat(user, "<span class='notice'>You take [P] out of \the [src].</span>")
@@ -86,6 +87,7 @@
 					P.rigged = 1
 					P.updateinfolinks()
 
+		P.add_fingerprint(user)
 		P.forceMove(user.loc)
 		user.put_in_hands(P)
 		to_chat(user, "<span class='notice'>You take [P] out of \the [src].</span>")

--- a/code/modules/paperwork/paperbin.dm
+++ b/code/modules/paperwork/paperbin.dm
@@ -53,7 +53,7 @@
 		var/obj/screen/inventory/hand/H = over_object
 		M.putItemFromInventoryInHandIfPossible(src, H.held_index)
 
-	src.add_fingerprint(M)
+	add_fingerprint(M)
 
 /obj/item/paper_bin/attack_paw(mob/user)
 	return attack_hand(user)


### PR DESCRIPTION
[Changelogs]: 

:cl:
fix: Fixed paper bins dropping out of your hand or bag when grabbing a pen or paper.
fix: Paper bins not giving finger prints upon interaction.
/:cl:

Fixes #36724