### PR TITLE
Make the delete verb check for SPAWN|DEBUG

### DIFF
--- a/code/modules/admin/verbs/randomverbs.dm
+++ b/code/modules/admin/verbs/randomverbs.dm
@@ -553,7 +553,7 @@ Traitors and the like can also be revived with the previous role mostly intact.
 	set category = "Admin"
 	set name = "Delete"
 
-	if(!check_rights(R_ADMIN))
+	if(!check_rights(R_SPAWN|R_DEBUG))
 		return
 
 	admin_delete(A)


### PR DESCRIPTION
:cl:
admin: Re-juggled delete verb permissions
/:cl:

It doesn't make sense to have +SPAWN but not the delete verb, especially because delete in the VV panel works. Hence, we give +SPAWN and +DEBUG delete.