### PR TITLE
Storage Objects Overlay Improvement

### DIFF
--- a/code/game/objects/items/storage/bags.dm
+++ b/code/game/objects/items/storage/bags.dm
@@ -47,6 +47,16 @@
 	playsound(loc, 'sound/items/eatfood.ogg', 50, 1, -1)
 	return (TOXLOSS)
 
+/obj/item/storage/bag/trash/remove_from_storage()
+	. = ..()
+	if(.)
+		update_icon()
+
+/obj/item/storage/bag/trash/handle_item_insertion()
+	. = ..()
+	if(.)
+		update_icon()
+
 /obj/item/storage/bag/trash/update_icon()
 	if(contents.len == 0)
 		icon_state = "[initial(icon_state)]"

--- a/code/game/objects/items/storage/belt.dm
+++ b/code/game/objects/items/storage/belt.dm
@@ -39,9 +39,9 @@
 	. = ..()
 	if(content_overlays.len)
 		content_overlays = typecacheof(content_overlays)
-		for(var/obj/O in contents)
-			if(is_type_in_typecache(O, content_overlays))
-				update_icon(O, TRUE)
+		for(var/I in contents)
+			if(is_type_in_typecache(I, content_overlays))
+				update_icon(I, TRUE)
 
 /obj/item/storage/belt/utility
 	name = "toolbelt" //Carn: utility belt is nicer, but it bamboozles the text parsing.

--- a/code/game/objects/items/storage/boxes.dm
+++ b/code/game/objects/items/storage/boxes.dm
@@ -34,7 +34,8 @@
 
 /obj/item/storage/box/Initialize(mapload)
 	. = ..()
-	update_icon()
+	if(illustration)
+		add_overlay(illustration)
 
 /obj/item/storage/box/suicide_act(mob/living/carbon/user)
 	var/obj/item/bodypart/head/myhead = user.get_bodypart(BODY_ZONE_HEAD)
@@ -46,12 +47,6 @@
 		return BRUTELOSS
 	user.visible_message("<span class='suicide'>[user] beating [user.p_them()]self with \the [src]! It looks like [user.p_theyre()] trying to commit suicide!</span>")
 	return BRUTELOSS
-
-/obj/item/storage/box/update_icon()
-	. = ..()
-	if(illustration)
-		cut_overlays()
-		add_overlay(illustration)
 
 /obj/item/storage/box/attack_self(mob/user)
 	..()
@@ -714,6 +709,16 @@ obj/item/storage/box/clown
 	resistance_flags = FLAMMABLE
 	foldable = null
 	var/design = NODESIGN
+
+/obj/item/storage/box/papersack/remove_from_storage()
+	. = ..()
+	if(.)
+		update_icon()
+
+/obj/item/storage/box/papersack/handle_item_insertion()
+	. = ..()
+	if(.)
+		update_icon()
 
 /obj/item/storage/box/papersack/update_icon()
 	if(contents.len == 0)

--- a/code/game/objects/items/storage/fancy.dm
+++ b/code/game/objects/items/storage/fancy.dm
@@ -53,13 +53,16 @@
 		update_icon()
 
 /obj/item/storage/fancy/handle_item_insertion(obj/item/W, prevent_warning = 0, mob/user)
-	fancy_open = TRUE
-	return ..()
+	. = ..()
+	if(.)
+		fancy_open = TRUE
+		update_icon()
 
 /obj/item/storage/fancy/remove_from_storage(obj/item/W, atom/new_location, burn = 0)
-	fancy_open = TRUE
-	return ..()
-
+	. = ..()
+	if(.)
+		fancy_open = TRUE
+		update_icon()
 /*
  * Donut Box
  */

--- a/code/game/objects/items/storage/lockbox.dm
+++ b/code/game/objects/items/storage/lockbox.dm
@@ -79,15 +79,6 @@
 		return 0
 	return ..()
 
-/obj/item/storage/lockbox/handle_item_insertion(obj/item/W, prevent_warning = 0, mob/user)
-	open = TRUE
-	update_icon()
-	return ..()
-/obj/item/storage/lockbox/remove_from_storage(obj/item/W, atom/new_location, burn = 0)
-	open = TRUE
-	update_icon()
-	return ..()
-
 /obj/item/storage/lockbox/loyalty
 	name = "lockbox of mindshield implants"
 	req_access = list(ACCESS_SECURITY)
@@ -146,28 +137,47 @@
 	for(var/i in 1 to 3)
 		new /obj/item/clothing/accessory/medal/conduct(src)
 
-/obj/item/storage/lockbox/medal/update_icon()
-	cut_overlays()
-	if(locked)
-		icon_state = "medalbox+l"
-		open = FALSE
-	else
-		icon_state = "medalbox"
+/obj/item/storage/lockbox/medal/remove_from_storage()
+	. = ..()
+	if(.)
 		if(open)
-			icon_state += "open"
-		if(broken)
-			icon_state += "+b"
-		if(contents && open)
-			for (var/i in 1 to contents.len)
-				var/obj/item/clothing/accessory/medal/M = contents[i]
-				var/mutable_appearance/medalicon = mutable_appearance(initial(icon), M.medaltype)
-				if(i > 1 && i <= 5)
-					medalicon.pixel_x += ((i-1)*3)
-				else if(i > 5)
-					medalicon.pixel_y -= 7
-					medalicon.pixel_x -= 2
-					medalicon.pixel_x += ((i-6)*3)
-				add_overlay(medalicon)
+			update_icon(TRUE)
+		else
+			open = TRUE
+			update_icon(FALSE) //We dont need to specify a medal to remove since we aren't showing them until now
+
+/obj/item/storage/lockbox/medal/handle_item_insertion()
+	. = ..()
+	if(.)
+		if(open)
+			update_icon(TRUE)
+		else
+			open = TRUE
+			update_icon(FALSE)
+
+/obj/item/storage/lockbox/medal/update_icon(medal_change = FALSE)
+	if(medal_change) //We're moving a medal and the case is already open
+		cut_overlays()
+	if(broken)
+		icon_state = icon_broken
+	else if(open)
+		icon_state = "medalboxopen"
+		for (var/i in 1 to contents.len)
+			var/obj/item/clothing/accessory/medal/M = contents[i]
+			var/mutable_appearance/medalicon = mutable_appearance(initial(icon), M.medaltype)
+			if(i > 1 && i <= 5)
+				medalicon.pixel_x += ((i-1)*3)
+			else if(i > 5)
+				medalicon.pixel_y -= 7
+				medalicon.pixel_x -= 2
+				medalicon.pixel_x += ((i-6)*3)
+			add_overlay(medalicon)
+	else if(!locked)
+		icon_state = icon_closed
+		cut_overlays()
+	else
+		icon_state = icon_locked
+
 
 /obj/item/storage/lockbox/medal/sec
 	name = "security medal box"

--- a/code/game/objects/items/storage/storage.dm
+++ b/code/game/objects/items/storage/storage.dm
@@ -585,5 +585,3 @@
 //Cyberboss says: "USE THIS TO FILL IT, NOT INITIALIZE OR NEW"
 
 /obj/item/storage/proc/PopulateContents()
-
-/obj/item/storage/update_icon(obj/item/I, added = TRUE)

--- a/code/game/objects/items/storage/storage.dm
+++ b/code/game/objects/items/storage/storage.dm
@@ -360,7 +360,6 @@
 		for(var/mob/M in can_see_contents())
 			show_to(M)
 	W.mouse_opacity = MOUSE_OPACITY_OPAQUE //So you can click on the area around the item to equip it, instead of having to pixel hunt
-	update_icon()
 	return 1
 
 
@@ -378,7 +377,7 @@
 	if(ismob(loc))
 		var/mob/M = loc
 		W.dropped(M)
-	
+
 
 	if(new_location)
 		W.forceMove(new_location)
@@ -399,8 +398,6 @@
 	for(var/mob/M in seeing_mobs)
 		orient2hud(M)
 		show_to(M)
-
-	update_icon()
 	return 1
 
 /obj/item/storage/deconstruct(disassembled = TRUE)
@@ -588,3 +585,5 @@
 //Cyberboss says: "USE THIS TO FILL IT, NOT INITIALIZE OR NEW"
 
 /obj/item/storage/proc/PopulateContents()
+
+/obj/item/storage/update_icon(obj/item/I, added = TRUE)

--- a/code/game/objects/items/storage/toolbox.dm
+++ b/code/game/objects/items/storage/toolbox.dm
@@ -24,14 +24,7 @@
 			latches = "double_latch"
 			if(prob(1))
 				latches = "triple_latch"
-	update_icon()
-
-/obj/item/storage/toolbox/update_icon()
-	..()
-	cut_overlays()
-	if(has_latches)
 		add_overlay(latches)
-
 
 /obj/item/storage/toolbox/suicide_act(mob/user)
 	user.visible_message("<span class='suicide'>[user] robusts [user.p_them()]self with [src]! It looks like [user.p_theyre()] trying to commit suicide!</span>")

--- a/code/game/objects/items/storage/wallets.dm
+++ b/code/game/objects/items/storage/wallets.dm
@@ -40,7 +40,6 @@
 			if(W == front_id)
 				front_id = null
 			refreshID()
-			update_icon()
 
 /obj/item/storage/wallet/proc/refreshID()
 	combined_access.Cut()
@@ -57,9 +56,10 @@
 			refreshID()
 
 /obj/item/storage/wallet/update_icon()
-	icon_state = "wallet"
 	if(front_id)
 		icon_state = "wallet_[front_id.icon_state]"
+	else
+		icon_state = "wallet"
 
 
 


### PR DESCRIPTION
Still stretching my legs at this overlay stuff/icon stuff.

Storage objects would call update_icon whenever an item was added or removed despite 95% of them having icons that don't give a shit about their contents - so its no longer the default.

The 5% now call icon_update only when appropriate and the belts with overlays (aka what started all this) will only add or remove the overlay specific to what was added/removed and use a typecache to determine if the item even has an overlay. This is far more efficient than the current approach where the belt removes and re-adds an overlay for every item when you put in a cable coil that doesn't even have an overlay.