### PR TITLE
Adds missing traitor obj to Omegastation

### DIFF
--- a/_maps/map_files/OmegaStation/OmegaStation.dmm
+++ b/_maps/map_files/OmegaStation/OmegaStation.dmm
@@ -15004,6 +15004,7 @@
 /obj/effect/turf_decal/bot,
 /obj/item/areaeditor/blueprints,
 /obj/item/tank/jetpack/suit,
+/obj/item/clothing/shoes/magboots/advance,
 /turf/open/floor/plasteel/vault/side{
 	dir = 8
 	},


### PR DESCRIPTION
:cl: Denton
fix: Omegastation: Added advanced magboots to secure storage so that traitors can complete the theft objective.
/:cl:

[why]: Traitors can have the "steal the CE's adv magboots" objective. Those spawn in the CE's hardsuit locker - with no CE, there is no locker on Omega.

This is more of a bandaid fix to one of Omegastation's structural problems - with four out of six head roles missing, you either have to make theft objs available to regular staff or put them in the vault. 