### PR TITLE
Cleans up duplicate chem_master power_change() proc

### DIFF
--- a/code/modules/reagents/chemistry/machinery/chem_master.dm
+++ b/code/modules/reagents/chemistry/machinery/chem_master.dm
@@ -75,12 +75,6 @@
 	if (prob(50))
 		qdel(src)
 
-/obj/machinery/chem_master/power_change()
-	if(powered())
-		stat &= ~NOPOWER
-	else
-		stat |= NOPOWER
-
 /obj/machinery/chem_master/attackby(obj/item/I, mob/user, params)
 	if(default_deconstruction_screwdriver(user, "mixer0_nopower", "mixer0", I))
 		return


### PR DESCRIPTION
It's the same as /obj/machinery/proc/power_change()