### PR TITLE
Fixes some edge cases with chameleon projectors and sleepers

### DIFF
--- a/code/game/machinery/Sleeper.dm
+++ b/code/game/machinery/Sleeper.dm
@@ -58,8 +58,13 @@
 		"<span class='notice'>You climb out of [src]!</span>")
 	open_machine()
 
+/obj/machinery/sleeper/Exited(atom/movable/user)
+	if (!state_open && user == occupant)
+		container_resist(user)
+
 /obj/machinery/sleeper/relaymove(mob/user)
-	container_resist(user)
+	if (!state_open)
+		container_resist(user)
 
 /obj/machinery/sleeper/open_machine()
 	if(!state_open && !panel_open)

--- a/code/game/objects/items/devices/chameleonproj.dm
+++ b/code/game/objects/items/devices/chameleonproj.dm
@@ -28,7 +28,7 @@
 	disrupt()
 
 /obj/item/device/chameleon/attack_self(mob/user)
-	if (isturf(user.loc) || active_dummy)
+	if (isturf(user.loc) || istype(user.loc, /obj/structure) || active_dummy)
 		toggle(user)
 	else
 		to_chat(user, "<span class='userwarning'>You can't use [src] while inside something.</span>")

--- a/code/game/objects/items/devices/chameleonproj.dm
+++ b/code/game/objects/items/devices/chameleonproj.dm
@@ -28,7 +28,10 @@
 	disrupt()
 
 /obj/item/device/chameleon/attack_self(mob/user)
-	toggle(user)
+	if (isturf(user.loc) || active_dummy)
+		toggle(user)
+	else
+		to_chat(user, "<span class='userwarning'>You can't use [src] while inside something.</span>")
 
 /obj/item/device/chameleon/afterattack(atom/target, mob/user , proximity)
 	if(!proximity)


### PR DESCRIPTION
Fixes #20185

This lets you use chameleon projectors inside structures but not inside mechas or other object effects. It will also reset the sleeper if you exit in any way, such as by being recalled by a cult leader or using rod form inside it.

Everything else in that issue has already been fixed at some point.

:cl: Naksu
del: Chameleon projectors will no longer work from inside transformations, effects, mechas or machines. Effects that cause movement will no longer leave sleepers in a bugged state where they can apply chems to you across distances.
/:cl:
