### PR TITLE
Fixes mutant bodypart assignments

### DIFF
--- a/code/modules/admin/secrets.dm
+++ b/code/modules/admin/secrets.dm
@@ -410,8 +410,10 @@
 
 				if(H.dna.species.id == "human")
 					if(H.dna.features["tail_human"] == "None" || H.dna.features["ears"] == "None")
-						H.dna.features["tail_human"] = "Cat"
-						H.dna.features["ears"] = "Cat"
+						var/obj/item/organ/ears/cat/ears = new
+						var/obj/item/organ/tail/cat/tail = new
+						ears.Insert(H, drop_if_replaced=FALSE)
+						tail.Insert(H, drop_if_replaced=FALSE)
 					var/list/honorifics = list("[MALE]" = list("kun"), "[FEMALE]" = list("chan","tan"), "[NEUTER]" = list("san")) //John Robust -> Robust-kun
 					var/list/names = splittext(H.real_name," ")
 					var/forename = names.len > 1 ? names[2] : names[1]

--- a/code/modules/admin/verbs/randomverbs.dm
+++ b/code/modules/admin/verbs/randomverbs.dm
@@ -1233,9 +1233,6 @@ GLOBAL_LIST_EMPTY(custom_outfits) //Admin created outfits
 		else
 			tail.Remove(H)
 
-	H.dna.features["ears"] = "None"
-	H.dna.features["tail_human"] = "None"
-
 	if(!silent)
 		to_chat(H, "You are no longer a cat.")
 

--- a/code/modules/mob/living/carbon/human/species.dm
+++ b/code/modules/mob/living/carbon/human/species.dm
@@ -37,7 +37,7 @@ GLOBAL_LIST_EMPTY(roundstart_races)
 	var/dangerous_existence //A flag for transformation spells that tells them "hey if you turn a person into one of these without preperation, they'll probably die!"
 	var/say_mod = "says"	// affects the speech message
 	var/list/default_features = list() // Default mutant bodyparts for this species. Don't forget to set one for every mutant bodypart you allow this species to have.
-	var/list/mutant_bodyparts = list() 	// Parts of the body that are diferent enough from the standard human model that they cause clipping with some equipment
+	var/list/mutant_bodyparts = list() 	// Visible CURRENT bodyparts that are unique to a species. DO NOT USE THIS AS A LIST OF ALL POSSIBLE BODYPARTS AS IT WILL FUCK SHIT UP! Changes to this list for non-species specific bodyparts (ie cat ears and tails) should be assigned at organ level if possible. Layer hiding is handled by handle_mutant_bodyparts() below.
 	var/list/mutant_organs = list()		//Internal organs that are unique to this race.
 	var/speedmod = 0	// this affects the race's speed. positive numbers make it move slower, negative numbers make it move faster
 	var/armor = 0		// overall defense for the race... or less defense, if it's negative.

--- a/code/modules/mob/living/carbon/human/species_types/angel.dm
+++ b/code/modules/mob/living/carbon/human/species_types/angel.dm
@@ -3,7 +3,7 @@
 	id = "angel"
 	default_color = "FFFFFF"
 	species_traits = list(SPECIES_ORGANIC,EYECOLOR,HAIR,FACEHAIR,LIPS)
-	mutant_bodyparts = list("tail_human", "ears", "wings")
+	mutant_bodyparts = list("wings")
 	default_features = list("mcolor" = "FFF", "tail_human" = "None", "ears" = "None", "wings" = "Angel")
 	use_skintones = 1
 	no_equip = list(slot_back)
@@ -15,7 +15,9 @@
 
 /datum/species/angel/on_species_gain(mob/living/carbon/human/H, datum/species/old_species)
 	..()
-	if(H.dna && H.dna.species &&((H.dna.features["wings"] != "Angel") && ("wings" in H.dna.species.mutant_bodyparts)))
+	if(H.dna && H.dna.species && (H.dna.features["wings"] != "Angel"))
+		if(!("wings" in H.dna.species.mutant_bodyparts))
+			H.dna.species.mutant_bodyparts |= "wings"
 		H.dna.features["wings"] = "Angel"
 		H.update_body()
 	if(ishuman(H) && !fly)
@@ -29,7 +31,9 @@
 	if(H.movement_type & FLYING)
 		H.movement_type &= ~FLYING
 	ToggleFlight(H,0)
-	if(H.dna && H.dna.species &&((H.dna.features["wings"] != "None") && ("wings" in H.dna.species.mutant_bodyparts)))
+	if(H.dna && H.dna.species && (H.dna.features["wings"] == "Angel"))
+		if("wings" in H.dna.species.mutant_bodyparts)
+			H.dna.species.mutant_bodyparts -= "wings"
 		H.dna.features["wings"] = "None"
 		H.update_body()
 	H.remove_trait(TRAIT_HOLY, SPECIES_TRAIT)

--- a/code/modules/mob/living/carbon/human/species_types/dullahan.dm
+++ b/code/modules/mob/living/carbon/human/species_types/dullahan.dm
@@ -4,7 +4,6 @@
 	default_color = "FFFFFF"
 	species_traits = list(SPECIES_ORGANIC,EYECOLOR,HAIR,FACEHAIR,LIPS)
 	inherent_traits = list(TRAIT_NOHUNGER,TRAIT_NOBREATH)
-	mutant_bodyparts = list("tail_human", "ears", "wings")
 	default_features = list("mcolor" = "FFF", "tail_human" = "None", "ears" = "None", "wings" = "None")
 	use_skintones = TRUE
 	mutant_brain = /obj/item/organ/brain/dullahan

--- a/code/modules/mob/living/carbon/human/species_types/humans.dm
+++ b/code/modules/mob/living/carbon/human/species_types/humans.dm
@@ -3,7 +3,6 @@
 	id = "human"
 	default_color = "FFFFFF"
 	species_traits = list(SPECIES_ORGANIC,EYECOLOR,HAIR,FACEHAIR,LIPS)
-	mutant_bodyparts = list("tail_human", "ears", "wings")
 	default_features = list("mcolor" = "FFF", "tail_human" = "None", "ears" = "None", "wings" = "None")
 	use_skintones = 1
 	skinned_type = /obj/item/stack/sheet/animalhide/human
@@ -29,7 +28,7 @@
 	if(istype(F) && (F.flight) && F.allow_thrust(0.01, src))
 		return TRUE
 
-datum/species/human/on_species_gain(mob/living/carbon/human/H, datum/species/old_species)
+/datum/species/human/on_species_gain(mob/living/carbon/human/H, datum/species/old_species)
 	if(H.dna.features["ears"] == "Cat")
 		mutantears = /obj/item/organ/ears/cat
 	if(H.dna.features["tail_human"] == "Cat")

--- a/code/modules/mob/living/carbon/human/species_types/vampire.dm
+++ b/code/modules/mob/living/carbon/human/species_types/vampire.dm
@@ -4,7 +4,6 @@
 	default_color = "FFFFFF"
 	species_traits = list(SPECIES_UNDEAD,EYECOLOR,HAIR,FACEHAIR,LIPS,DRINKSBLOOD)
 	inherent_traits = list(TRAIT_NOHUNGER,TRAIT_NOBREATH)
-	mutant_bodyparts = list("tail_human", "ears", "wings")
 	default_features = list("mcolor" = "FFF", "tail_human" = "None", "ears" = "None", "wings" = "None")
 	exotic_bloodtype = "U"
 	use_skintones = TRUE

--- a/code/modules/mob/living/simple_animal/hostile/cat_butcher.dm
+++ b/code/modules/mob/living/simple_animal/hostile/cat_butcher.dm
@@ -34,10 +34,10 @@
 	. = ..()
 	if(. && prob(35) && iscarbon(target))
 		var/mob/living/carbon/human/L = target
-		if(L.dna.features["tail_human"] == "Cat")
+		var/obj/item/organ/tail/cat/tail = L.getorgan(/obj/item/organ/tail/cat)
+		if(tail)
 			visible_message("[src] severs [L]'s tail in one swift swipe!", "<span class='notice'>You sever [L]'s tail in one swift swipe.</span>")
-			L.dna.features["tail_human"] -= "Cat"
-			L.dna.species.mutant_bodyparts -= "tail_human"
-			L.update_body()
-			new /obj/item/organ/tail/cat(get_turf(target))
+			tail.Remove(L)
+			var/obj/item/organ/tail/cat/dropped_tail = new(target.drop_location())
+			dropped_tail.color = L.hair_color
 		return 1

--- a/code/modules/mob/living/simple_animal/hostile/cat_butcher.dm
+++ b/code/modules/mob/living/simple_animal/hostile/cat_butcher.dm
@@ -35,7 +35,7 @@
 	if(. && prob(35) && iscarbon(target))
 		var/mob/living/carbon/human/L = target
 		var/obj/item/organ/tail/cat/tail = L.getorgan(/obj/item/organ/tail/cat)
-		if(tail)
+		if(!QDELETED(tail))
 			visible_message("[src] severs [L]'s tail in one swift swipe!", "<span class='notice'>You sever [L]'s tail in one swift swipe.</span>")
 			tail.Remove(L)
 			var/obj/item/organ/tail/cat/dropped_tail = new(target.drop_location())

--- a/code/modules/surgery/organs/ears.dm
+++ b/code/modules/surgery/organs/ears.dm
@@ -96,5 +96,6 @@
 	..()
 	if(istype(H))
 		color = H.hair_color
+		H.dna.features["ears"] = "None"
 		H.dna.species.mutant_bodyparts -= "ears"
 		H.update_body()

--- a/code/modules/surgery/organs/tails.dm
+++ b/code/modules/surgery/organs/tails.dm
@@ -30,11 +30,10 @@
 /obj/item/organ/tail/cat/Remove(mob/living/carbon/human/H,  special = 0)
 	..()
 	if(istype(H))
+		H.dna.features["tail_human"] = "None"
 		H.dna.species.mutant_bodyparts -= "tail_human"
-		tail_type = H.dna.features["tail_human"]
 		color = H.hair_color
 		H.update_body()
-
 
 /obj/item/organ/tail/lizard
 	name = "lizard tail"


### PR DESCRIPTION
Fixes #36802
Fixes #33838

mutant_bodyparts was being used as a list of possible mutations from the looks of it, where in reality is was SUPPOSED to be a list of the mob's current bodyparts, with the mutant_bodyparts list being updated at organ level.

Corrected all relevant instances of it being misused. Also corrected purrbation & cartoon characters incorrectly setting ear & tail vars.

Also fixes the cat butcher dropping incorrectly colored tails.