### PR TITLE
AIFixer no longer updates overlays on every process()

### DIFF
--- a/code/game/machinery/computer/aifixer.dm
+++ b/code/game/machinery/computer/aifixer.dm
@@ -80,7 +80,6 @@
 	occupier.adjustToxLoss(-1, 0)
 	occupier.adjustBruteLoss(-1, 0)
 	occupier.updatehealth()
-	occupier.updatehealth()
 	if(occupier.health >= 0 && occupier.stat == DEAD)
 		occupier.revive()
 	return occupier.health < 100
@@ -88,9 +87,11 @@
 /obj/machinery/computer/aifixer/process()
 	if(..())
 		if(active)
+			var/oldstat = occupier.stat
 			active = Fix()
+			if(oldstat != occupier.stat)
+				update_icon()
 		updateDialog()
-		update_icon()
 
 /obj/machinery/computer/aifixer/Topic(href, href_list)
 	if(..())


### PR DESCRIPTION
Interesting case of how much processing power gets put into overlay compiling that does absolutely nothing though. 

From a round on Sybil:

/obj/machinery/computer/aifixer => 3819ms (4569) (avg:0.8358502984046936)