### PR TITLE
Deactivate suicide prescans via ghost var

### DIFF
--- a/code/game/machinery/cloning.dm
+++ b/code/game/machinery/cloning.dm
@@ -134,8 +134,11 @@
 	clonemind = locate(mindref) in SSticker.minds
 	if(!istype(clonemind))	//not a mind
 		return FALSE
-	if( clonemind.current && clonemind.current.stat != DEAD )	//mind is associated with a non-dead body
-		return FALSE
+	if(clonemind.current)
+		if(clonemind.current.stat != DEAD)	//mind is associated with a non-dead body
+			return FALSE
+		if(clonemind.current.suiciding) // Mind is associated with a body that is suiciding.
+			return FALSE
 	if(clonemind.active)	//somebody is using that mind
 		if( ckey(clonemind.key)!=ckey )
 			return FALSE
@@ -143,6 +146,8 @@
 		// get_ghost() will fail if they're unable to reenter their body
 		var/mob/dead/observer/G = clonemind.get_ghost()
 		if(!G)
+			return FALSE
+		if(G.suiciding) // The ghost came from a body that is suiciding.
 			return FALSE
 	if(clonemind.damnation_type) //Can't clone the damned.
 		INVOKE_ASYNC(src, .proc/horrifyingsound)

--- a/code/modules/client/verbs/suicide.dm
+++ b/code/modules/client/verbs/suicide.dm
@@ -12,7 +12,6 @@
 		return
 	if(confirm == "Yes")
 		suiciding = TRUE
-		log_game("[key_name(src)] (job: [job ? "[job]" : "None"]) committed suicide at [get_area(src)].")
 		var/obj/item/held_item = get_active_held_item()
 		if(held_item)
 			var/damagetype = held_item.suicide_act(src)
@@ -22,6 +21,9 @@
 					suiciding = FALSE
 					SendSignal(COMSIG_ADD_MOOD_EVENT, "shameful_suicide", /datum/mood_event/shameful_suicide)
 					return
+
+				suicide_log()
+
 				var/damage_mod = 0
 				for(var/T in list(BRUTELOSS, FIRELOSS, TOXLOSS, OXYLOSS))
 					damage_mod += (T & damagetype) ? 1 : 0
@@ -48,6 +50,7 @@
 					adjustOxyLoss(max(200 - getToxLoss() - getFireLoss() - getBruteLoss() - getOxyLoss(), 0))
 
 				death(FALSE)
+
 				return
 
 		var/suicide_message
@@ -72,6 +75,8 @@
 
 		visible_message("<span class='danger'>[suicide_message]</span>", "<span class='userdanger'>[suicide_message]</span>")
 
+		suicide_log()
+
 		adjustOxyLoss(max(200 - getToxLoss() - getFireLoss() - getBruteLoss() - getOxyLoss(), 0))
 		death(0)
 
@@ -86,6 +91,9 @@
 		suiciding = 1
 		visible_message("<span class='danger'>[src]'s brain is growing dull and lifeless. [p_they(TRUE)] look[p_s()] like [p_theyve()] lost the will to live.</span>", \
 						"<span class='userdanger'>[src]'s brain is growing dull and lifeless. [p_they(TRUE)] look[p_s()] like [p_theyve()] lost the will to live.</span>")
+
+		suicide_log()
+
 		death(0)
 
 /mob/living/carbon/monkey/verb/suicide()
@@ -99,6 +107,9 @@
 		suiciding = 1
 		visible_message("<span class='danger'>[src] is attempting to bite [p_their()] tongue. It looks like [p_theyre()] trying to commit suicide.</span>", \
 				"<span class='userdanger'>[src] is attempting to bite [p_their()] tongue. It looks like [p_theyre()] trying to commit suicide.</span>")
+
+		suicide_log()
+
 		adjustOxyLoss(max(200- getToxLoss() - getFireLoss() - getBruteLoss() - getOxyLoss(), 0))
 		death(0)
 
@@ -113,6 +124,9 @@
 		suiciding = 1
 		visible_message("<span class='danger'>[src] is powering down. It looks like [p_theyre()] trying to commit suicide.</span>", \
 				"<span class='userdanger'>[src] is powering down. It looks like [p_theyre()] trying to commit suicide.</span>")
+
+		suicide_log()
+
 		//put em at -175
 		adjustOxyLoss(max(maxHealth * 2 - getToxLoss() - getFireLoss() - getBruteLoss() - getOxyLoss(), 0))
 		death(0)
@@ -128,6 +142,9 @@
 		suiciding = 1
 		visible_message("<span class='danger'>[src] is powering down. It looks like [p_theyre()] trying to commit suicide.</span>", \
 				"<span class='userdanger'>[src] is powering down. It looks like [p_theyre()] trying to commit suicide.</span>")
+
+		suicide_log()
+
 		//put em at -175
 		adjustOxyLoss(max(maxHealth * 2 - getToxLoss() - getFireLoss() - getBruteLoss() - getOxyLoss(), 0))
 		death(0)
@@ -139,6 +156,9 @@
 		var/turf/T = get_turf(src.loc)
 		T.visible_message("<span class='notice'>[src] flashes a message across its screen, \"Wiping core files. Please acquire a new personality to continue using pAI device functions.\"</span>", null, \
 		 "<span class='notice'>[src] bleeps electronically.</span>")
+
+		suicide_log()
+
 		death(0)
 	else
 		to_chat(src, "Aborting suicide attempt.")
@@ -155,6 +175,9 @@
 		visible_message("<span class='danger'>[src] is thrashing wildly! It looks like [p_theyre()] trying to commit suicide.</span>", \
 				"<span class='userdanger'>[src] is thrashing wildly! It looks like [p_theyre()] trying to commit suicide.</span>", \
 				"<span class='italics'>You hear thrashing.</span>")
+
+		suicide_log()
+
 		//put em at -175
 		adjustOxyLoss(max(200 - getFireLoss() - getBruteLoss() - getOxyLoss(), 0))
 		death(0)
@@ -170,8 +193,20 @@
 		suiciding = 1
 		visible_message("<span class='danger'>[src] begins to fall down. It looks like [p_theyve()] lost the will to live.</span>", \
 						"<span class='userdanger'>[src] begins to fall down. It looks like [p_theyve()] lost the will to live.</span>")
+
+		suicide_log()
+
 		death(0)
 
+/mob/living/proc/suicide_log()
+	var/turf/T = get_turf(src)
+
+	log_game("[key_name(src)] committed suicide at [get_area(src)][COORD(T)] as [src.type].")
+
+/mob/living/carbon/human/suicide_log()
+	var/turf/T = get_turf(src)
+
+	log_game("[key_name(src)] (job: [src.job ? "[src.job]" : "None"]) committed suicide at [get_area(src)][COORD(T)].")
 
 /mob/living/proc/canSuicide()
 	if(stat == CONSCIOUS)

--- a/code/modules/mob/dead/observer/observer.dm
+++ b/code/modules/mob/dead/observer/observer.dm
@@ -91,6 +91,9 @@ GLOBAL_VAR_INIT(observer_default_invisibility, INVISIBILITY_OBSERVER)
 				name = random_unique_name(gender)
 
 		mind = body.mind	//we don't transfer the mind but we keep a reference to it.
+
+		suiciding = body.suiciding // Transfer whether they committed suicide.
+
 		if(ishuman(body))
 			var/mob/living/carbon/human/body_human = body
 			if(HAIR in body_human.dna.species.species_traits)


### PR DESCRIPTION
This will transfer the `suiciding` var to ghosts and disallow suicide cloning in the cloning pod's `growclone` proc.

Created `suicide_log` on `/mob/living` to log suicides in a central location. Did this in the other PR to avoid cluttering the suicide verb, but it seems useful to keep around. I'll remove it from the PR if it's a problem.

Fixes #36205
Alternative to and closes #36741

:cl:
fix: Committing suicide will now stop you from being cloned via prescans.
/:cl: