### PR TITLE
Fixes singularity power output

### DIFF
--- a/code/modules/power/singularity/singularity.dm
+++ b/code/modules/power/singularity/singularity.dm
@@ -113,7 +113,7 @@
 /obj/singularity/process()
 	if(current_size >= STAGE_TWO)
 		move()
-		radiation_pulse(src, min(5000, (energy*3)+1000), RAD_DISTANCE_COEFFICIENT*0.5)
+		radiation_pulse(src, min(5000, (energy*4.5)+1000), RAD_DISTANCE_COEFFICIENT*0.5)
 		if(prob(event_chance))//Chance for it to run a special event TODO:Come up with one or two more that fit
 			event()
 	eat()


### PR DESCRIPTION
:cl: Denton
balance: The singularity engine will now output enough energy to power a station again.
/:cl:

Fixes: #36067

I increased the singulo's rad pulse multiplier to 4.5 - a stage 3 singularity with ~500 energy and 6 rad collectors will create about 440kW.
Not much compared to the ~2.4MW you can get from a tesla engine, but enough to power a station at least.
