### PR TITLE
Pubby: fixes bomb testing site cam networks

### DIFF
--- a/_maps/map_files/PubbyStation/PubbyStation.dmm
+++ b/_maps/map_files/PubbyStation/PubbyStation.dmm
@@ -36215,10 +36215,10 @@
 /area/science/mixing)
 "bJT" = (
 /obj/machinery/computer/security/telescreen{
-	desc = "Used for watching the test chamber.";
+	desc = "Used for watching the bomb testing site.";
 	dir = 2;
 	layer = 4;
-	name = "Test Chamber Telescreen";
+	name = "Testing Site Telescreen";
 	network = list("toxins");
 	pixel_y = -32
 	},
@@ -45825,7 +45825,7 @@
 	invuln = 1;
 	luminosity = 3;
 	name = "Hardened Bomb-Test Camera";
-	network = list("toxins");
+	network = list("ss13", "rd", "toxins");
 	use_power = 0
 	},
 /turf/open/floor/plating/asteroid/airless,
@@ -46856,7 +46856,7 @@
 	invuln = 1;
 	luminosity = 3;
 	name = "Hardened Bomb-Test Camera";
-	network = list("toxins");
+	network = list("ss13", "rd", "toxins");
 	use_power = 0
 	},
 /turf/open/floor/plating/asteroid/airless,


### PR DESCRIPTION
:cl: Denton
fix: Pubbystation: The bomb testing site cameras are now accessible by camera consoles.
/:cl:

The RD/warden/person with camera console were unable to access the bomb site cams, since they were only connected to the telescreen at the launch room.