### PR TITLE
Adds singular_name to BS polycrystals

### DIFF
--- a/code/game/objects/items/stacks/bscrystal.dm
+++ b/code/game/objects/items/stacks/bscrystal.dm
@@ -61,6 +61,7 @@
 	icon = 'icons/obj/telescience.dmi'
 	icon_state = "polycrystal"
 	item_state = "sheet-polycrystal"
+	singular_name = "bluespace polycrystal"
 	desc = "A stable polycrystal, made of fused-together bluespace crystals. You could probably break one off."
 	materials = list(MAT_BLUESPACE=MINERAL_MATERIAL_AMOUNT)
 	attack_verb = list("bluespace polybashed", "bluespace polybattered", "bluespace polybludgeoned", "bluespace polythrashed", "bluespace polysmashed")


### PR DESCRIPTION
:cl: Denton
spellcheck: Bluespace polycrystals now show their name when inserted into machinery.
/:cl:

In #36716 I missed giving polycrystals a singular_name as well, now they'll show their name when inserted into protolathes etc.
