### PR TITLE
refactors overlays to append/remove individual overlays instead of cutting

### DIFF
--- a/code/__DEFINES/subsystems.dm
+++ b/code/__DEFINES/subsystems.dm
@@ -124,16 +124,16 @@
 
 #define COMPILE_OVERLAYS(A)\
 	if (TRUE) {\
-		var/list/a = A.add_overlays;\
-		var/list/r = A.remove_overlays;\
+		var/list/ad = A.add_overlays;\
+		var/list/rm = A.remove_overlays;\
 		var/list/po = A.priority_overlays;\
-		if(LAZYLEN(r)){\
-			A.overlays -= r;\
-			r.Cut();\
+		if(LAZYLEN(rm)){\
+			A.overlays -= rm;\
+			rm.Cut();\
 		}\
-		if(LAZYLEN(a)){\
-			A.overlays |= a;\
-			a.Cut();\
+		if(LAZYLEN(ad)){\
+			A.overlays |= ad;\
+			ad.Cut();\
 		}\
 		if(LAZYLEN(po)){\
 			A.overlays |= po;\

--- a/code/__DEFINES/subsystems.dm
+++ b/code/__DEFINES/subsystems.dm
@@ -124,21 +124,19 @@
 
 #define COMPILE_OVERLAYS(A)\
 	if (TRUE) {\
-		var/list/oo = A.our_overlays;\
+		var/list/a = A.add_overlays;\
+		var/list/r = A.remove_overlays;\
 		var/list/po = A.priority_overlays;\
 		if(LAZYLEN(po)){\
-			if(LAZYLEN(oo)){\
-				A.overlays = oo + po;\
-			}\
-			else{\
-				A.overlays = po;\
-			}\
+			A.overlays = po;\
 		}\
-		else if(LAZYLEN(oo)){\
-			A.overlays = oo;\
+		if(LAZYLEN(r)){\
+			A.overlays -= r;\
+			r.Cut();\
 		}\
-		else{\
-			A.overlays.Cut();\
+		if(LAZYLEN(a)){\
+			A.overlays += a;\
+			a.Cut();\
 		}\
 		A.flags_1 &= ~OVERLAY_QUEUED_1;\
 	}

--- a/code/__DEFINES/subsystems.dm
+++ b/code/__DEFINES/subsystems.dm
@@ -127,16 +127,16 @@
 		var/list/a = A.add_overlays;\
 		var/list/r = A.remove_overlays;\
 		var/list/po = A.priority_overlays;\
-		if(LAZYLEN(po)){\
-			A.overlays = po;\
-		}\
 		if(LAZYLEN(r)){\
 			A.overlays -= r;\
 			r.Cut();\
 		}\
 		if(LAZYLEN(a)){\
-			A.overlays += a;\
+			A.overlays |= a;\
 			a.Cut();\
+		}\
+		if(LAZYLEN(po)){\
+			A.overlays |= po;\
 		}\
 		A.flags_1 &= ~OVERLAY_QUEUED_1;\
 	}

--- a/code/controllers/subsystem/overlays.dm
+++ b/code/controllers/subsystem/overlays.dm
@@ -161,7 +161,7 @@ SUBSYSTEM_DEF(overlays)
 		if(NOT_QUEUED_ALREADY && (init_p_len != cached_priority.len))
 			QUEUE_FOR_COMPILE
 	else
-		add_overlays += overlays
+		add_overlays |= overlays
 		if(NOT_QUEUED_ALREADY)
 			QUEUE_FOR_COMPILE
 
@@ -171,12 +171,11 @@ SUBSYSTEM_DEF(overlays)
 			cut_overlays()
 		return
 
-	var/list/cached_other = other.overlays
+	var/list/cached_other = other.overlays.Copy()
 	if(cached_other)
 		if(cut_old || !LAZYLEN(overlays))
-			add_overlays = cached_other.Copy()
-		else
-			add_overlays = (cached_other - overlays)
+			remove_overlays = overlays
+			add_overlays = cached_other
 		if(NOT_QUEUED_ALREADY)
 			QUEUE_FOR_COMPILE
 	else if(cut_old)
@@ -187,7 +186,7 @@ SUBSYSTEM_DEF(overlays)
 
 //TODO: Better solution for these?
 /image/proc/add_overlay(x)
-	overlays += x
+	overlays |= x
 
 /image/proc/cut_overlay(x)
 	overlays -= x
@@ -205,7 +204,5 @@ SUBSYSTEM_DEF(overlays)
 	if(cached_other)
 		if(cut_old || !overlays.len)
 			overlays = cached_other.Copy()
-		else
-			overlays |= cached_other
 	else if(cut_old)
 		cut_overlays()

--- a/code/controllers/subsystem/overlays.dm
+++ b/code/controllers/subsystem/overlays.dm
@@ -115,20 +115,16 @@ SUBSYSTEM_DEF(overlays)
 #define NOT_QUEUED_ALREADY (!(flags_1 & OVERLAY_QUEUED_1))
 #define QUEUE_FOR_COMPILE flags_1 |= OVERLAY_QUEUED_1; SSoverlays.queue += src;
 /atom/proc/cut_overlays(priority = FALSE)
-	var/list/cached_priority = priority_overlays
+	LAZYINITLIST(priority_overlays)
+	LAZYINITLIST(remove_overlays)
+	LAZYINITLIST(add_overlays)
+	remove_overlays = overlays
+	add_overlays.Cut()
 
-	var/need_compile = FALSE
+	if(priority)
+		priority_overlays.Cut()
 
-	if(LAZYLEN(overlays)) //don't queue empty lists, don't cut priority overlays
-		remove_overlays = overlays
-		add_overlays.Cut()
-		need_compile = TRUE
-
-	if(priority && LAZYLEN(cached_priority))
-		cached_priority.Cut()
-		need_compile = TRUE
-
-	if(NOT_QUEUED_ALREADY && need_compile)
+	if(NOT_QUEUED_ALREADY)
 		QUEUE_FOR_COMPILE
 
 /atom/proc/cut_overlay(list/overlays, priority)
@@ -139,7 +135,7 @@ SUBSYSTEM_DEF(overlays)
 	LAZYINITLIST(priority_overlays)
 	LAZYINITLIST(remove_overlays)
 	remove_overlays += overlays
-	add_overlays -= remove_overlays
+	add_overlays -= overlays
 	var/list/cached_priority = priority_overlays
 
 	if(priority)
@@ -157,16 +153,13 @@ SUBSYSTEM_DEF(overlays)
 	LAZYINITLIST(add_overlays) //always initialized after this point
 	LAZYINITLIST(priority_overlays)
 	LAZYINITLIST(remove_overlays)
-	var/list/cached_priority = priority_overlays
-	var/init_p_len = cached_priority.len  //starter pokemon
 
 	if(priority)
-		cached_priority += overlays  //or in the image. Can we use [image] = image?
-		if(NOT_QUEUED_ALREADY && (init_p_len != cached_priority.len))
+		priority_overlays += overlays  //or in the image. Can we use [image] = image?
+		if(NOT_QUEUED_ALREADY)
 			QUEUE_FOR_COMPILE
 	else
-		add_overlays |= overlays
-		remove_overlays -= overlays
+		add_overlays += overlays
 		if(NOT_QUEUED_ALREADY)
 			QUEUE_FOR_COMPILE
 

--- a/code/controllers/subsystem/overlays.dm
+++ b/code/controllers/subsystem/overlays.dm
@@ -173,7 +173,7 @@ SUBSYSTEM_DEF(overlays)
 	if(cached_other)
 		if(cut_old || !LAZYLEN(overlays))
 			remove_overlays = overlays
-			add_overlays = cached_other
+		add_overlays = cached_other
 		if(NOT_QUEUED_ALREADY)
 			QUEUE_FOR_COMPILE
 	else if(cut_old)
@@ -198,9 +198,11 @@ SUBSYSTEM_DEF(overlays)
 			cut_overlays()
 		return
 
-	var/list/cached_other = other.overlays
+	var/list/cached_other = other.overlays.Copy()
 	if(cached_other)
 		if(cut_old || !overlays.len)
-			overlays = cached_other.Copy()
+			overlays = cached_other
+		else
+			overlays |= cached_other
 	else if(cut_old)
 		cut_overlays()

--- a/code/controllers/subsystem/overlays.dm
+++ b/code/controllers/subsystem/overlays.dm
@@ -121,6 +121,7 @@ SUBSYSTEM_DEF(overlays)
 
 	if(LAZYLEN(overlays)) //don't queue empty lists, don't cut priority overlays
 		remove_overlays = overlays
+		add_overlays.Cut()
 		need_compile = TRUE
 
 	if(priority && LAZYLEN(cached_priority))
@@ -134,8 +135,11 @@ SUBSYSTEM_DEF(overlays)
 	if(!overlays)
 		return
 	overlays = build_appearance_list(overlays)
-	LAZYINITLIST(remove_overlays) //always initialized after this point
+	LAZYINITLIST(add_overlays) //always initialized after this point
+	LAZYINITLIST(priority_overlays)
+	LAZYINITLIST(remove_overlays)
 	remove_overlays += overlays
+	add_overlays -= remove_overlays
 	var/list/cached_priority = priority_overlays
 
 	if(priority)
@@ -152,7 +156,7 @@ SUBSYSTEM_DEF(overlays)
 
 	LAZYINITLIST(add_overlays) //always initialized after this point
 	LAZYINITLIST(priority_overlays)
-
+	LAZYINITLIST(remove_overlays)
 	var/list/cached_priority = priority_overlays
 	var/init_p_len = cached_priority.len  //starter pokemon
 
@@ -162,6 +166,7 @@ SUBSYSTEM_DEF(overlays)
 			QUEUE_FOR_COMPILE
 	else
 		add_overlays |= overlays
+		remove_overlays -= overlays
 		if(NOT_QUEUED_ALREADY)
 			QUEUE_FOR_COMPILE
 

--- a/code/controllers/subsystem/overlays.dm
+++ b/code/controllers/subsystem/overlays.dm
@@ -118,7 +118,7 @@ SUBSYSTEM_DEF(overlays)
 	LAZYINITLIST(priority_overlays)
 	LAZYINITLIST(remove_overlays)
 	LAZYINITLIST(add_overlays)
-	remove_overlays = overlays
+	remove_overlays = overlays.Copy()
 	add_overlays.Cut()
 
 	if(priority)

--- a/code/game/atoms.dm
+++ b/code/game/atoms.dm
@@ -22,8 +22,9 @@
 							//its inherent color, the colored paint applied on it, special color effect etc...
 	var/initialized = FALSE
 
-	var/list/our_overlays	//our local copy of (non-priority) overlays without byond magic. Use procs in SSoverlays to manipulate
 	var/list/priority_overlays	//overlays that should remain on top and not normally removed when using cut_overlay functions, like c4.
+	var/list/remove_overlays // a very temporary list of overlays to remove
+	var/list/add_overlays // a very temporary list of overlays to add
 
 	var/datum/proximity_monitor/proximity_monitor
 	var/buckle_message_cooldown = 0

--- a/code/game/objects/effects/contraband.dm
+++ b/code/game/objects/effects/contraband.dm
@@ -127,7 +127,7 @@
 
 	// Deny placing posters on currently-diagonal walls, although the wall may change in the future.
 	if (smooth & SMOOTH_DIAGONAL)
-		for (var/O in our_overlays)
+		for (var/O in overlays)
 			var/image/I = O
 			if (copytext(I.icon_state, 1, 3) == "d-")
 				return

--- a/code/modules/food_and_drinks/food/customizables.dm
+++ b/code/modules/food_and_drinks/food/customizables.dm
@@ -118,8 +118,8 @@
 		if(INGREDIENTS_STACKPLUSTOP)
 			filling.pixel_x = rand(-1,1)
 			filling.pixel_y = 2 * ingredients.len - 1
-			if(our_overlays)
-				our_overlays.Cut(ingredients.len)	//???, add overlay calls later in this proc will queue the compile if necessary
+			if(overlays)
+				overlays -= overlays[ingredients.len]
 			var/mutable_appearance/TOP = mutable_appearance(icon, "[icon_state]_top")
 			TOP.pixel_y = 2 * ingredients.len + 3
 			add_overlay(filling)

--- a/code/modules/food_and_drinks/food/snacks_pastry.dm
+++ b/code/modules/food_and_drinks/food/snacks_pastry.dm
@@ -406,8 +406,8 @@
 		name = "stack of pancakes"
 	else
 		name = initial(name)
-	if(contents.len < LAZYLEN(our_overlays))
-		cut_overlay(our_overlays[our_overlays.len])
+	if(contents.len < LAZYLEN(overlays))
+		overlays-=overlays[overlays.len]
 
 /obj/item/reagent_containers/food/snacks/pancakes/examine(mob/user)
 	var/ingredients_listed = ""

--- a/code/modules/mob/living/carbon/human/species.dm
+++ b/code/modules/mob/living/carbon/human/species.dm
@@ -301,7 +301,7 @@ GLOBAL_LIST_EMPTY(roundstart_races)
 
 /datum/species/proc/handle_hair(mob/living/carbon/human/H, forced_colour)
 	H.remove_overlay(HAIR_LAYER)
-
+	stack_trace("HAIR CALLED REEEE")
 	var/obj/item/bodypart/head/HD = H.get_bodypart(BODY_ZONE_HEAD)
 	if(!HD) //Decapitated
 		return

--- a/code/modules/mob/living/carbon/human/species.dm
+++ b/code/modules/mob/living/carbon/human/species.dm
@@ -301,7 +301,6 @@ GLOBAL_LIST_EMPTY(roundstart_races)
 
 /datum/species/proc/handle_hair(mob/living/carbon/human/H, forced_colour)
 	H.remove_overlay(HAIR_LAYER)
-	stack_trace("HAIR CALLED REEEE")
 	var/obj/item/bodypart/head/HD = H.get_bodypart(BODY_ZONE_HEAD)
 	if(!HD) //Decapitated
 		return

--- a/code/modules/mob/living/carbon/human/update_icons.dm
+++ b/code/modules/mob/living/carbon/human/update_icons.dm
@@ -538,39 +538,10 @@ generate/load female uniform sprites matching all previously decided variables
 
 	standing = center_image(standing, isinhands ? inhand_x_dimension : worn_x_dimension, isinhands ? inhand_y_dimension : worn_y_dimension)
 
-	//Handle held offsets
-	var/mob/M = loc
-	if(istype(M))
-		var/list/L = get_held_offsets()
-		if(L)
-			standing.pixel_x += L["x"] //+= because of center()ing
-			standing.pixel_y += L["y"]
-
 	standing.alpha = alpha
 	standing.color = color
 
 	return standing
-
-
-/obj/item/proc/get_held_offsets()
-	var/list/L
-	if(ismob(loc))
-		var/mob/M = loc
-		L = M.get_item_offsets_for_index(M.get_held_index_of_item(src))
-	return L
-
-
-//Can't think of a better way to do this, sadly
-/mob/proc/get_item_offsets_for_index(i)
-	switch(i)
-		if(3) //odd = left hands
-			return list("x" = 0, "y" = 16)
-		if(4) //even = right hands
-			return list("x" = 0, "y" = 16)
-		else //No offsets or Unwritten number of hands
-			return list("x" = 0, "y" = 0)
-
-
 
 //produces a key based on the human's limbs
 /mob/living/carbon/human/generate_icon_render_key()

--- a/code/modules/mob/living/carbon/human/update_icons.dm
+++ b/code/modules/mob/living/carbon/human/update_icons.dm
@@ -537,7 +537,7 @@ generate/load female uniform sprites matching all previously decided variables
 		standing.overlays.Add(worn_overlays)
 
 	standing = center_image(standing, isinhands ? inhand_x_dimension : worn_x_dimension, isinhands ? inhand_y_dimension : worn_y_dimension)
-	
+
 	//Handle held offsets
 	var/mob/M = loc
 	if(istype(M))
@@ -546,11 +546,11 @@ generate/load female uniform sprites matching all previously decided variables
 			standing.pixel_x += L["x"] //+= because of center()ing
 			standing.pixel_y += L["y"]
 
- 	standing.alpha = alpha
- 	standing.color = color
- 
- 	return standing
- 
+	standing.alpha = alpha
+	standing.color = color
+
+	return standing
+
 
 /obj/item/proc/get_held_offsets()
 	var/list/L

--- a/code/modules/mob/living/carbon/human/update_icons.dm
+++ b/code/modules/mob/living/carbon/human/update_icons.dm
@@ -537,11 +537,38 @@ generate/load female uniform sprites matching all previously decided variables
 		standing.overlays.Add(worn_overlays)
 
 	standing = center_image(standing, isinhands ? inhand_x_dimension : worn_x_dimension, isinhands ? inhand_y_dimension : worn_y_dimension)
+	
+	//Handle held offsets
+	var/mob/M = loc
+	if(istype(M))
+		var/list/L = get_held_offsets()
+		if(L)
+			standing.pixel_x += L["x"] //+= because of center()ing
+			standing.pixel_y += L["y"]
 
-	standing.alpha = alpha
-	standing.color = color
+ 	standing.alpha = alpha
+ 	standing.color = color
+ 
+ 	return standing
+ 
 
-	return standing
+/obj/item/proc/get_held_offsets()
+	var/list/L
+	if(ismob(loc))
+		var/mob/M = loc
+		L = M.get_item_offsets_for_index(M.get_held_index_of_item(src))
+	return L
+
+
+//Can't think of a better way to do this, sadly
+/mob/proc/get_item_offsets_for_index(i)
+	switch(i)
+		if(3) //odd = left hands
+			return list("x" = 0, "y" = 16)
+		if(4) //even = right hands
+			return list("x" = 0, "y" = 16)
+		else //No offsets or Unwritten number of hands
+			return list("x" = 0, "y" = 0)//Handle held offsets
 
 //produces a key based on the human's limbs
 /mob/living/carbon/human/generate_icon_render_key()

--- a/code/modules/mob/living/carbon/update_icons.dm
+++ b/code/modules/mob/living/carbon/update_icons.dm
@@ -96,7 +96,6 @@
 
 
 /mob/living/carbon/update_damage_overlays()
-	stack_trace("DAMAGE CALLED WITHOUT DAMAGE REEEE")
 	remove_overlay(DAMAGE_LAYER)
 
 	var/mutable_appearance/damage_overlay = mutable_appearance('icons/mob/dam_mob.dmi', "blank", -DAMAGE_LAYER)

--- a/code/modules/mob/living/carbon/update_icons.dm
+++ b/code/modules/mob/living/carbon/update_icons.dm
@@ -96,6 +96,7 @@
 
 
 /mob/living/carbon/update_damage_overlays()
+	stack_trace("DAMAGE CALLED WITHOUT DAMAGE REEEE")
 	remove_overlay(DAMAGE_LAYER)
 
 	var/mutable_appearance/damage_overlay = mutable_appearance('icons/mob/dam_mob.dmi', "blank", -DAMAGE_LAYER)


### PR DESCRIPTION
So after scavenging overhaul code for a few days, after dozens and dozens of tests, the data added up to a horrifying realization.

The very heart of our overlay code, a single line that basically boiled down to overlays = new_overlays, was the cause of so much overlay lag. Human overlay code was by far the biggest culprit. Most objects have 0-2 overlays but humans are marching around with 20+ most of the time and the current system was spending a LOT of effort comparing 20+ image with 20+ other images and then apparently rendering them all anyway. Human overlays are at least 10x the cost of any other overlay process and on a busy server the overlay compiling was 2x the cost of any other system.

I compared the cost of overlay changes by picking up/dropping a PDA in the dorms 250 times, with a 50% chance to use our current overlay compiler and a 50% chance to use a "direct addition/removal (+=, -=) approach:

CURRENT | 1120ms | 133 | (avg:8.4210529327392578)
-- | -- | -- | --
SCRAPS | 6ms | 112 | (avg:0.0535714291036129)

Now this PR makes our whole overlay subsystem use that approach for overlay compiling and the early results look incredible. The best part is this is just the START of improvements. Humans benefits the most because their icon system was already designed for small, incremental overlay updates. By moving other code from "Cut everything, then put it all back" to only updating the necessary overlays (cough, APC's), we can see similar improvements. 

-------------------------------
Edit: Live results from testing, massive improvements but still not perfect. My plate is full now but it wouldn't be too hard to make human's icon building not include null overlays and see what that does for performance - since multi-icon overlay updates for humans are the difference between .05ms and .2-.4ms overlay compiles. 

**BAGIL TESTMERGE:**
/mob/living/carbon/human => 6456ms (21553) (avg:0.29954066872596741)
**BAGIL NO TESTMERGE:**
/mob/living/carbon/human => 146251ms (22649) (avg:6.4572830200195312)

**That's over 2 minutes of processing time cleared out by this PR for a midpop round.** 