### PR TITLE
Moves quick equip hotkey up to /mob

### DIFF
--- a/code/modules/keybindings/bindings_human.dm
+++ b/code/modules/keybindings/bindings_human.dm
@@ -30,7 +30,7 @@
 					return
 				stored.attack_hand(src) // take out thing from belt
 				return
-			
+
 			if("B") // Put held thing in backpack or take out most recent thing from backpack
 				var/obj/item/thing = get_active_held_item()
 				var/obj/item/storage/equipped_backpack = get_item_by_slot(slot_back)
@@ -60,10 +60,4 @@
 					return
 				stored.attack_hand(src) // take out thing from backpack
 				return
-
-	switch(_key)
-		if("E")
-			quick_equip()
-			return
-
 	return ..()

--- a/code/modules/keybindings/bindings_mob.dm
+++ b/code/modules/keybindings/bindings_mob.dm
@@ -29,6 +29,9 @@
 			else
 				dropItemToGround(I)
 			return
+		if("E")
+			quick_equip()
+			return
 		if("Alt")
 			toggle_move_intent()
 			return


### PR DESCRIPTION
:cl: RandomMarine
fix: The quick equip hotkey (e) now works for drones again.
/:cl:

Fixes #34821
