### PR TITLE
Tile_Graphics now has some early exit conditions

### DIFF
--- a/code/modules/atmospherics/environmental/LINDA_turf_tile.dm
+++ b/code/modules/atmospherics/environmental/LINDA_turf_tile.dm
@@ -103,22 +103,16 @@
 	#endif
 
 	#if DM_VERSION >= 512
-	if (atmos_overlay_types)
-		for(var/overlay in atmos_overlay_types-new_overlay_types) //doesn't remove overlays that would only be added
-			vars["vis_contents"] -= overlay
-
 	if (new_overlay_types.len)
 		if (atmos_overlay_types)
+			vars["vis_contents"] -= atmos_overlay_types - new_overlay_types
 			vars["vis_contents"] += new_overlay_types - atmos_overlay_types //don't add overlays that already exist
 		else
 			vars["vis_contents"] += new_overlay_types
 	#else
-	if (atmos_overlay_types)
-		for(var/overlay in atmos_overlay_types-new_overlay_types) //doesn't remove overlays that would only be added
-			cut_overlay(overlay)
-
 	if (new_overlay_types.len)
 		if (atmos_overlay_types)
+			cut_overlay(atmos_overlay_types - new_overlay_types)
 			add_overlay(new_overlay_types - atmos_overlay_types) //don't add overlays that already exist
 		else
 			add_overlay(new_overlay_types)

--- a/code/modules/atmospherics/environmental/LINDA_turf_tile.dm
+++ b/code/modules/atmospherics/environmental/LINDA_turf_tile.dm
@@ -97,25 +97,20 @@
 /turf/open/proc/update_visuals()
 	var/list/new_overlay_types = tile_graphic()
 	var/list/atmos_overlay_types = src.atmos_overlay_types // Cache for free performance
-
+	var/list/diff = new_overlay_types^atmos_overlay_types
 	#if DM_VERSION >= 513
 	#warning 512 is stable now for sure, remove the old code
 	#endif
 
 	#if DM_VERSION >= 512
-	if (new_overlay_types.len)
-		if (atmos_overlay_types)
-			vars["vis_contents"] -= atmos_overlay_types - new_overlay_types
-			vars["vis_contents"] += new_overlay_types - atmos_overlay_types //don't add overlays that already exist
-		else
-			vars["vis_contents"] += new_overlay_types
+	if (diff)
+		vars["vis_contents"] -= atmos_overlay_types - new_overlay_types
+		vars["vis_contents"] += new_overlay_types - atmos_overlay_types //don't add overlays that already exist
+
 	#else
-	if (new_overlay_types.len)
-		if (atmos_overlay_types)
-			cut_overlay(atmos_overlay_types - new_overlay_types)
-			add_overlay(new_overlay_types - atmos_overlay_types) //don't add overlays that already exist
-		else
-			add_overlay(new_overlay_types)
+	if (diff)
+		cut_overlay(atmos_overlay_types - new_overlay_types)
+		add_overlay(new_overlay_types - atmos_overlay_types) //don't add overlays that already exist
 	#endif
 
 	UNSETEMPTY(new_overlay_types)
@@ -123,9 +118,11 @@
 
 /turf/open/proc/tile_graphic()
 	. = new /list
-	if(air)
+	if(air && air.gases)
 		var/list/gases = air.gases
 		for(var/id in gases)
+			if(GLOB.nonreactive_gases[id])
+				continue
 			var/gas = gases[id]
 			var/gas_meta = gas[GAS_META]
 			var/gas_overlay = gas_meta[META_GAS_OVERLAY]

--- a/code/modules/atmospherics/environmental/LINDA_turf_tile.dm
+++ b/code/modules/atmospherics/environmental/LINDA_turf_tile.dm
@@ -131,12 +131,15 @@
 	. = new /list
 	if(air)
 		var/list/gases = air.gases
-		for(var/id in gases)
-			var/gas = gases[id]
-			var/gas_meta = gas[GAS_META]
-			var/gas_overlay = gas_meta[META_GAS_OVERLAY]
-			if(gas_overlay && gas[MOLES] > gas_meta[META_GAS_MOLES_VISIBLE])
-				. += gas_overlay
+		if(gases)
+			for(var/id in gases)
+				if(GLOB.nonreactive_gases[id])
+					continue
+				var/gas = gases[id]
+				var/gas_meta = gas[GAS_META]
+				var/gas_overlay = gas_meta[META_GAS_OVERLAY]
+				if(gas_overlay && gas[MOLES] > gas_meta[META_GAS_MOLES_VISIBLE])
+					. += gas_overlay
 
 /////////////////////////////SIMULATION///////////////////////////////////
 

--- a/code/modules/atmospherics/environmental/LINDA_turf_tile.dm
+++ b/code/modules/atmospherics/environmental/LINDA_turf_tile.dm
@@ -131,15 +131,14 @@
 	. = new /list
 	if(air)
 		var/list/gases = air.gases
-		if(gases)
-			for(var/id in gases)
-				if(GLOB.nonreactive_gases[id])
-					continue
-				var/gas = gases[id]
-				var/gas_meta = gas[GAS_META]
-				var/gas_overlay = gas_meta[META_GAS_OVERLAY]
-				if(gas_overlay && gas[MOLES] > gas_meta[META_GAS_MOLES_VISIBLE])
-					. += gas_overlay
+		for(var/id in gases)
+			if(GLOB.nonoverlay_gases[id])
+				continue
+			var/gas = gases[id]
+			var/gas_meta = gas[GAS_META]
+			var/gas_overlay = gas_meta[META_GAS_OVERLAY]
+			if(gas_overlay && gas[MOLES] > gas_meta[META_GAS_MOLES_VISIBLE])
+				. += gas_overlay
 
 /////////////////////////////SIMULATION///////////////////////////////////
 

--- a/code/modules/atmospherics/gasmixtures/gas_types.dm
+++ b/code/modules/atmospherics/gasmixtures/gas_types.dm
@@ -1,5 +1,5 @@
 GLOBAL_LIST_INIT(hardcoded_gases, list(/datum/gas/oxygen, /datum/gas/nitrogen, /datum/gas/carbon_dioxide, /datum/gas/plasma)) //the main four gases, which were at one time hardcoded
-
+GLOBAL_LIST_INIT(nonoverlay_gases, typecacheof(list(/datum/gas/oxygen, /datum/gas/nitrogen, /datum/gas/carbon_dioxide, /datum/gas/hypernoblium, /datum/gas/pluoxium, /datum/gas/bz, /datum/gas/stimulum))) 
 /proc/meta_gas_list()
 	. = subtypesof(/datum/gas)
 	for(var/gas_path in .)


### PR DESCRIPTION
This proc got called 10,000,000 times in a round, lets make it faster.

Edit: I opened a canister of no2 (overlay) and co2 (no overlay) just to get the proc fired up:


/turf/open/proc/tile_graphic | 0.103 | 0.103 | 0.107 | 34637
-- | -- | -- | -- | --

/turf/open/proc/new_graphic | 0.067 | 0.067 | 0.069 | 35277
-- | -- | -- | -- | --

Since it never makes sense to run this proc for a gas with no visual, its a modest but sure-fire improvement, this run has the proc going 35k each but when you've run it 10m times you end up saving more process time than entire subsystems use. 

