### PR TITLE
GC debugging features

### DIFF
--- a/code/__DEFINES/qdel.dm
+++ b/code/__DEFINES/qdel.dm
@@ -8,6 +8,7 @@
 #define QDEL_HINT_HARDDEL_NOW	4 //qdel should assume this object won't gc, and hard del it post haste.
 #define QDEL_HINT_FINDREFERENCE	5 //functionally identical to QDEL_HINT_QUEUE if TESTING is not enabled in _compiler_options.dm.
 								  //if TESTING is enabled, qdel will call this object's find_references() verb.
+#define QDEL_HINT_IFFAIL_FINDREFERENCE 6		//Above but only if gc fails.
 //defines for the gc_destroyed var
 
 #define GC_QUEUE_PREQUEUE 1

--- a/code/controllers/subsystem/garbage.dm
+++ b/code/controllers/subsystem/garbage.dm
@@ -167,12 +167,13 @@ SUBSYSTEM_DEF(garbage)
 		fail_counts[level]++
 		switch (level)
 			if (GC_QUEUE_CHECK)
-				#ifdef GC_FAILURE_HARD_LOOKUP
-				D.find_references()
-				#endif
 				#ifdef TESTING
 				if(reference_find_on_fail[refID])
 					D.find_references()
+				#ifdef GC_FAILURE_HARD_LOOKUP
+				else
+					D.find_references()
+				#endif
 				reference_find_on_fail -= refID
 				#endif
 				var/type = D.type


### PR DESCRIPTION
Not a feature it's a code improvement < : ^ )
:cl:
code: A few code internal debugging features have been added to help debug GC errors. QDEL_HINT_IFFAIL_FINDREFERENCE hint will make the garbage subsystem find references if the build is in TESTING mode, and qdel_and_then_find_ref_if_fail(datum) or calling qdel_then_if_fail_find_references will do the same.
/:cl: