### PR TITLE
Fixes master

### DIFF
--- a/_maps/RandomRuins/LavaRuins/lavaland_surface_syndicate_base1.dmm
+++ b/_maps/RandomRuins/LavaRuins/lavaland_surface_syndicate_base1.dmm
@@ -4835,7 +4835,7 @@
 /obj/machinery/atmospherics/components/binary/pump/on{
 	dir = 8;
 	name = "O2 to Incinerator";
-	target_pressure = MAX_OUTPUT_PRESSURE
+	target_pressure = 4500
 	},
 /turf/open/floor/plasteel/floorgrime,
 /area/ruin/unpowered/syndicate_lava_base/engineering)
@@ -5851,7 +5851,7 @@
 	pixel_y = 24
 	},
 /obj/machinery/atmospherics/components/binary/pump/on{
-	target_pressure = MAX_OUTPUT_PRESSURE
+	target_pressure = 4500
 	},
 /turf/open/floor/engine,
 /area/ruin/unpowered/syndicate_lava_base/engineering)

--- a/_maps/templates/pirate_ship.dmm
+++ b/_maps/templates/pirate_ship.dmm
@@ -1058,7 +1058,7 @@
 /obj/machinery/atmospherics/components/binary/pump/on{
 	dir = 4;
 	name = "N2 Out";
-	target_pressure = MAX_OUTPUT_PRESSURE
+	target_pressure = 4500
 	},
 /turf/open/floor/plasteel/floorgrime,
 /area/shuttle/pirate)
@@ -1217,7 +1217,7 @@
 /obj/machinery/atmospherics/components/binary/pump/on{
 	dir = 4;
 	name = "O2 Out";
-	target_pressure = MAX_OUTPUT_PRESSURE
+	target_pressure = 4500
 	},
 /turf/open/floor/plasteel/floorgrime,
 /area/shuttle/pirate)
@@ -1239,7 +1239,7 @@
 /obj/machinery/atmospherics/components/binary/pump{
 	dir = 8;
 	name = "Port Out";
-	target_pressure = MAX_OUTPUT_PRESSURE
+	target_pressure = 4500
 	},
 /turf/open/floor/plasteel/floorgrime,
 /area/shuttle/pirate)
@@ -1362,7 +1362,7 @@
 /obj/machinery/atmospherics/components/binary/pump{
 	dir = 2;
 	name = "O2 to Incinerator";
-	target_pressure = MAX_OUTPUT_PRESSURE
+	target_pressure = 4500
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -1513,7 +1513,7 @@
 /obj/machinery/atmospherics/components/binary/pump{
 	dir = 8;
 	name = "Plasma to Incinerator";
-	target_pressure = MAX_OUTPUT_PRESSURE
+	target_pressure = 4500
 	},
 /turf/open/floor/plasteel/floorgrime,
 /area/shuttle/pirate)
@@ -1590,7 +1590,7 @@
 /obj/effect/turf_decal/stripes/line,
 /obj/machinery/atmospherics/components/binary/pump/on{
 	dir = 2;
-	target_pressure = MAX_OUTPUT_PRESSURE
+	target_pressure = 4500
 	},
 /obj/machinery/button/door{
 	id = "pirateturbinebolt";
@@ -1661,7 +1661,7 @@
 /obj/machinery/atmospherics/components/binary/pump{
 	dir = 8;
 	name = "Port to Incinerator";
-	target_pressure = MAX_OUTPUT_PRESSURE
+	target_pressure = 4500
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/caution,


### PR DESCRIPTION
:cl: Naksu
fix: Removed stray defines from maps, making roundstart atmos functional and runtime-spam free again
/:cl:

#36690 broke things. Defines do not work in maps, travis would've told you except travis doesn't start the round so atmos doesn't tick. 