### PR TITLE
Performance pass on garbage_collect

### DIFF
--- a/code/modules/atmospherics/gasmixtures/gas_mixture.dm
+++ b/code/modules/atmospherics/gasmixtures/gas_mixture.dm
@@ -66,9 +66,10 @@ GLOBAL_LIST_INIT(nonreactive_gases, typecacheof(list(/datum/gas/oxygen, /datum/g
 		//if assert_gas() was called only to read from the gas.
 	//By removing empty gases, processing speed is increased.
 /datum/gas_mixture/proc/garbage_collect(list/tocheck)
-	var/list/cached_gases = gases
-	for(var/id in (tocheck || cached_gases))
-		if(cached_gases[id][MOLES] <= 0 && cached_gases[id][ARCHIVE] <= 0)
+	var/list/cached_gases = tocheck || gases
+	for(var/id in cached_gases)
+		var/current_gas = cached_gases[id]
+		if(QUANTIZE(current_gas[MOLES]) <= 0 && QUANTIZE(current_gas[ARCHIVE]) <= 0)
 			cached_gases -= id
 
 	//PV = nRT


### PR DESCRIPTION
Closes #36899 

Prevents loading `gases` when it's not used
Cuts down a list access on `cached_gases`
the QUANTIZE fix from #36899