### PR TITLE
Makes Sec Members know Krav Maga at Roundstart

### DIFF
--- a/code/modules/jobs/job_types/security.dm
+++ b/code/modules/jobs/job_types/security.dm
@@ -59,7 +59,7 @@ Head of Security
 	duffelbag = /obj/item/storage/backpack/duffelbag/sec
 	box = /obj/item/storage/box/security
 
-	implants = list(/obj/item/implant/mindshield)
+	implants = list(/obj/item/implant/mindshield, /obj/item/implant/krav_maga)
 
 /*
 Warden
@@ -295,7 +295,7 @@ GLOBAL_LIST_INIT(available_depts, list(SEC_DEPT_ENGINEERING, SEC_DEPT_MEDICAL, S
 	duffelbag = /obj/item/storage/backpack/duffelbag/sec
 	box = /obj/item/storage/box/security
 
-	implants = list(/obj/item/implant/mindshield)
+	implants = list(/obj/item/implant/mindshield, /obj/item/implant/krav_maga)
 
 
 /obj/item/device/radio/headset/headset_sec/alt/department/Initialize()


### PR DESCRIPTION

:cl: optional name here
add: Added Krav Maga implant to list of Sec member's implants.
/:cl:

[why]: # Sec was too easy to shit on, used to know krav maga automatically on (((/tg/))) took it away. Full reasons and autistic arguements here:
https://hippiestation.com/threads/have-all-sec-guards-know-krav-maga.8253/

New and retarded, pls correct.