### PR TITLE
Detective Scanner Fixes

### DIFF
--- a/code/modules/detectivework/scanner.dm
+++ b/code/modules/detectivework/scanner.dm
@@ -181,3 +181,14 @@
 		return
 	to_chat(user, "<span class='notice'>The scanner logs are cleared.</span>")
 	log = list()
+
+/obj/item/device/detective_scanner/verb/displayResults()
+	set name = "Display Scanner Results"
+	set category = "Object"
+	if(!can_use(usr))
+		return
+	if(!LAZYLEN(log) || scanning)
+		to_chat(usr, "<span class='notice'>The scanner has no logs or is in use.</span>")
+	to_chat(usr, "<span class='notice'><B>Scanner Report</B></span>")
+	for(var/iterLog in log)
+		to_chat(usr, iterLog)

--- a/code/modules/detectivework/scanner.dm
+++ b/code/modules/detectivework/scanner.dm
@@ -166,3 +166,18 @@
 
 /proc/get_timestamp()
 	return time2text(world.time + 432000, ":ss")
+
+/obj/item/device/detective_scanner/proc/can_use(mob/user)
+	if(user && ismob(user))
+		if(!user.incapacitated())
+			return TRUE
+	return FALSE
+	
+/obj/item/device/detective_scanner/AltClick(mob/living/user)
+	if(!can_use(user))
+		return
+	if(!LAZYLEN(log) || scanning)
+		to_chat(user, "<span class='notice'>Cannot clear logs, the scanner has no logs or is in use.</span>")
+		return
+	to_chat(user, "<span class='notice'>The scanner logs are cleared.</span>")
+	log = list()

--- a/code/modules/detectivework/scanner.dm
+++ b/code/modules/detectivework/scanner.dm
@@ -36,6 +36,7 @@
 	P.info += jointext(log, "<BR>")
 	P.info += "<HR><B>Notes:</B><BR>"
 	P.info_links = P.info
+	P.updateinfolinks()
 
 	if(ismob(loc))
 		var/mob/M = loc

--- a/code/modules/detectivework/scanner.dm
+++ b/code/modules/detectivework/scanner.dm
@@ -175,14 +175,10 @@
 
 /proc/get_timestamp()
 	return time2text(world.time + 432000, ":ss")
-
-/obj/item/device/detective_scanner/proc/can_use(mob/user)
-	if(isliving(user) && !user.incapacitated())
-		return TRUE
-	return FALSE
 	
 /obj/item/device/detective_scanner/AltClick(mob/living/user)
-	if(!can_use(user))
+	// Best way for checking if a player can use while not incapacitated, etc
+	if(!user.canUseTopic(src, be_close=TRUE))
 		return
 	if(!LAZYLEN(log))
 		to_chat(user, "<span class='notice'>Cannot clear logs, the scanner has no logs.</span>")
@@ -194,13 +190,12 @@
 	log = list()
 
 /obj/item/device/detective_scanner/proc/displayDetectiveScanResults(mob/living/user)
-	if(!can_use(user))
-		return
+	// No need for can-use checks since the action button should do proper checks
 	if(!LAZYLEN(log))
-		to_chat(user, "<span class='notice'>Cannot clear logs, the scanner has no logs.</span>")
+		to_chat(user, "<span class='notice'>Cannot display logs, the scanner has no logs.</span>")
 		return
 	if(scanning)
-		to_chat(user, "<span class='notice'>Cannot clear logs, the scanner is in use.</span>")
+		to_chat(user, "<span class='notice'>Cannot display logs, the scanner is in use.</span>")
 		return
 	to_chat(user, "<span class='notice'><B>Scanner Report</B></span>")
 	for(var/iterLog in log)

--- a/code/modules/detectivework/scanner.dm
+++ b/code/modules/detectivework/scanner.dm
@@ -16,6 +16,15 @@
 	var/list/log = list()
 	var/range = 8
 	var/view_check = TRUE
+	actions_types = list(/datum/action/item_action/displayDetectiveScanResults)
+
+/datum/action/item_action/displayDetectiveScanResults
+	name = "Display Forensic Scanner Results"
+
+/datum/action/item_action/displayDetectiveScanResults/Trigger()
+	var/obj/item/device/detective_scanner/scanner = target
+	if(istype(scanner))
+		scanner.displayDetectiveScanResults()
 
 /obj/item/device/detective_scanner/attack_self(mob/user)
 	if(log.len && !scanning)
@@ -168,7 +177,7 @@
 	return time2text(world.time + 432000, ":ss")
 
 /obj/item/device/detective_scanner/proc/can_use(mob/user)
-	if(user && ismob(user))
+	if(isliving(user))
 		if(!user.incapacitated())
 			return TRUE
 	return FALSE
@@ -182,13 +191,12 @@
 	to_chat(user, "<span class='notice'>The scanner logs are cleared.</span>")
 	log = list()
 
-/obj/item/device/detective_scanner/verb/displayResults()
-	set name = "Display Scanner Results"
-	set category = "Object"
+/obj/item/device/detective_scanner/proc/displayDetectiveScanResults()
 	if(!can_use(usr))
 		return
 	if(!LAZYLEN(log) || scanning)
 		to_chat(usr, "<span class='notice'>The scanner has no logs or is in use.</span>")
+		return
 	to_chat(usr, "<span class='notice'><B>Scanner Report</B></span>")
 	for(var/iterLog in log)
 		to_chat(usr, iterLog)

--- a/code/modules/detectivework/scanner.dm
+++ b/code/modules/detectivework/scanner.dm
@@ -184,8 +184,11 @@
 /obj/item/device/detective_scanner/AltClick(mob/living/user)
 	if(!can_use(user))
 		return
-	if(!LAZYLEN(log) || scanning)
-		to_chat(user, "<span class='notice'>Cannot clear logs, the scanner has no logs or is in use.</span>")
+	if(!LAZYLEN(log))
+		to_chat(user, "<span class='notice'>Cannot clear logs, the scanner has no logs.</span>")
+		return
+	if(scanning)
+		to_chat(user, "<span class='notice'>Cannot clear logs, the scanner is in use.</span>")
 		return
 	to_chat(user, "<span class='notice'>The scanner logs are cleared.</span>")
 	log = list()
@@ -193,8 +196,11 @@
 /obj/item/device/detective_scanner/proc/displayDetectiveScanResults(mob/living/user)
 	if(!can_use(user))
 		return
-	if(!LAZYLEN(log) || scanning)
-		to_chat(user, "<span class='notice'>The scanner has no logs or is in use.</span>")
+	if(!LAZYLEN(log))
+		to_chat(user, "<span class='notice'>Cannot clear logs, the scanner has no logs.</span>")
+		return
+	if(scanning)
+		to_chat(user, "<span class='notice'>Cannot clear logs, the scanner is in use.</span>")
 		return
 	to_chat(user, "<span class='notice'><B>Scanner Report</B></span>")
 	for(var/iterLog in log)

--- a/code/modules/detectivework/scanner.dm
+++ b/code/modules/detectivework/scanner.dm
@@ -24,7 +24,7 @@
 /datum/action/item_action/displayDetectiveScanResults/Trigger()
 	var/obj/item/device/detective_scanner/scanner = target
 	if(istype(scanner))
-		scanner.displayDetectiveScanResults()
+		scanner.displayDetectiveScanResults(usr)
 
 /obj/item/device/detective_scanner/attack_self(mob/user)
 	if(log.len && !scanning)
@@ -177,9 +177,8 @@
 	return time2text(world.time + 432000, ":ss")
 
 /obj/item/device/detective_scanner/proc/can_use(mob/user)
-	if(isliving(user))
-		if(!user.incapacitated())
-			return TRUE
+	if(isliving(user) && !user.incapacitated())
+		return TRUE
 	return FALSE
 	
 /obj/item/device/detective_scanner/AltClick(mob/living/user)
@@ -191,12 +190,12 @@
 	to_chat(user, "<span class='notice'>The scanner logs are cleared.</span>")
 	log = list()
 
-/obj/item/device/detective_scanner/proc/displayDetectiveScanResults()
-	if(!can_use(usr))
+/obj/item/device/detective_scanner/proc/displayDetectiveScanResults(mob/living/user)
+	if(!can_use(user))
 		return
 	if(!LAZYLEN(log) || scanning)
-		to_chat(usr, "<span class='notice'>The scanner has no logs or is in use.</span>")
+		to_chat(user, "<span class='notice'>The scanner has no logs or is in use.</span>")
 		return
-	to_chat(usr, "<span class='notice'><B>Scanner Report</B></span>")
+	to_chat(user, "<span class='notice'><B>Scanner Report</B></span>")
 	for(var/iterLog in log)
-		to_chat(usr, iterLog)
+		to_chat(user, iterLog)


### PR DESCRIPTION
[Changelogs]:

:cl:
fix: Detective can now write notes onto his printed scanner reports.
tweak: Detective scanner can have its logs erased via alt-click.
tweak: Detective scanner can display logs via the action button.
/:cl:

[why]:
Fixes #18315 and tweaks some functionality that is needed for the detective scanner.
