### PR TITLE
READY flash fixes

### DIFF
--- a/code/modules/assembly/flash.dm
+++ b/code/modules/assembly/flash.dm
@@ -81,6 +81,8 @@
 /obj/item/device/assembly/flash/proc/get_flash_targets(atom/target_loc, range = 3, override_vision_checks = FALSE)
 	if(!target_loc)
 		target_loc = loc
+		if(!isturf(target_loc))
+			target_loc = loc.loc
 	if(override_vision_checks)
 		return get_hearers_in_view(range, get_turf(target_loc))
 	if(isturf(target_loc) || (ismob(target_loc) && isturf(target_loc.loc)))
@@ -150,7 +152,7 @@
 		return FALSE
 	if(!AOE_flash(FALSE, 3, 5, FALSE, user))
 		return FALSE
-	to_chat(user, "<span class='danger'>Your [src] emits a blinding light!</span>")
+	to_chat(user, "<span class='danger'>[src] emits a blinding light!</span>")
 
 /obj/item/device/assembly/flash/emp_act(severity)
 	if(!try_use_flash())
@@ -158,6 +160,9 @@
 	AOE_flash()
 	burn_out()
 	. = ..()
+
+/obj/item/device/assembly/flash/activate()
+	AOE_flash(FALSE, 3, 5, FALSE)
 
 /obj/item/device/assembly/flash/proc/terrible_conversion_proc(mob/living/carbon/human/H, mob/user)
 	if(istype(H) && ishuman(user) && H.stat != DEAD)

--- a/code/modules/assembly/flash.dm
+++ b/code/modules/assembly/flash.dm
@@ -80,9 +80,7 @@
 
 /obj/item/device/assembly/flash/proc/get_flash_targets(atom/target_loc, range = 3, override_vision_checks = FALSE)
 	if(!target_loc)
-		target_loc = loc
-		if(!isturf(target_loc))
-			target_loc = loc.loc
+		target_loc = get_turf(src)
 	if(override_vision_checks)
 		return get_hearers_in_view(range, get_turf(target_loc))
 	if(isturf(target_loc) || (ismob(target_loc) && isturf(target_loc.loc)))

--- a/code/modules/assembly/flash.dm
+++ b/code/modules/assembly/flash.dm
@@ -71,7 +71,7 @@
 /obj/item/device/assembly/flash/proc/AOE_flash(bypass_checks = FALSE, range = 3, power = 5, targeted = FALSE, mob/user)
 	if(!bypass_checks && !try_use_flash())
 		return FALSE
-	var/list/mob/targets = get_flash_targets(loc, range, FALSE)
+	var/list/mob/targets = get_flash_targets(get_turf(src), range, FALSE)
 	if(user)
 		targets -= user
 	for(var/mob/living/carbon/C in targets)
@@ -80,7 +80,7 @@
 
 /obj/item/device/assembly/flash/proc/get_flash_targets(atom/target_loc, range = 3, override_vision_checks = FALSE)
 	if(!target_loc)
-		target_loc = get_turf(src)
+		target_loc = loc
 	if(override_vision_checks)
 		return get_hearers_in_view(range, get_turf(target_loc))
 	if(isturf(target_loc) || (ismob(target_loc) && isturf(target_loc.loc)))
@@ -160,7 +160,7 @@
 	. = ..()
 
 /obj/item/device/assembly/flash/activate()
-	AOE_flash(FALSE, 3, 5, FALSE)
+	AOE_flash()
 
 /obj/item/device/assembly/flash/proc/terrible_conversion_proc(mob/living/carbon/human/H, mob/user)
 	if(istype(H) && ishuman(user) && H.stat != DEAD)

--- a/code/modules/assembly/flash.dm
+++ b/code/modules/assembly/flash.dm
@@ -159,7 +159,9 @@
 	burn_out()
 	. = ..()
 
-/obj/item/device/assembly/flash/activate()
+/obj/item/device/assembly/flash/activate()//AOE flash on signal recieved
+	if(!..())
+		return
 	AOE_flash()
 
 /obj/item/device/assembly/flash/proc/terrible_conversion_proc(mob/living/carbon/human/H, mob/user)


### PR DESCRIPTION
:cl:
fix: Restored accidentally cut functionality to flashes. You can once again attach them to a signaller and signal them to trigger an AoE flash remotely.
/:cl:

Fixes https://github.com/tgstation/tgstation/issues/36098

Fixes a message that would incorrectly output "Your the flash emits a blinding light!"