### PR TITLE
Removes Syndicate turret EMP immunity

### DIFF
--- a/code/game/machinery/porta_turret/portable_turret.dm
+++ b/code/game/machinery/porta_turret/portable_turret.dm
@@ -636,6 +636,7 @@
 	icon_state = "syndie_off"
 	base_icon_state = "syndie"
 	faction = list(ROLE_SYNDICATE)
+	emp_vunerable = 1
 	desc = "A ballistic machine gun auto-turret."
 
 /obj/machinery/porta_turret/syndicate/energy

--- a/code/game/machinery/porta_turret/portable_turret.dm
+++ b/code/game/machinery/porta_turret/portable_turret.dm
@@ -636,7 +636,6 @@
 	icon_state = "syndie_off"
 	base_icon_state = "syndie"
 	faction = list(ROLE_SYNDICATE)
-	emp_vunerable = 0
 	desc = "A ballistic machine gun auto-turret."
 
 /obj/machinery/porta_turret/syndicate/energy


### PR DESCRIPTION
[Changelogs]: This was sort of mentioned in #36917 and I don't think this was intentional, I'm putting this down as an oversight fix unless a maintainer steps in and says otherwise

:cl: 
fix: Further research has determined that Syndicate turrets are just as vulnerable to EMPs as any other turret
/:cl:
