### PR TITLE
Fixes tile analyzer

### DIFF
--- a/code/modules/integrated_electronics/subtypes/input.dm
+++ b/code/modules/integrated_electronics/subtypes/input.dm
@@ -396,21 +396,18 @@
 	cooldown_per_use = 10
 
 /obj/item/integrated_circuit/input/turfscan/do_work()
-	var/atom/movable/H = get_pin_data_as_type(IC_INPUT, 1, /atom)
+	var/turf/H = get_pin_data_as_type(IC_INPUT, 1, /turf)
 	var/turf/T = get_turf(src)
-	var/turf/E = get_turf(H)
 	if(!istype(H)) //Invalid input
 		return
 
 	if(H in view(T)) // This is a camera. It can't examine thngs,that it can't see.
 		var/list/cont = new()
-		if(E.contents.len)
-			for(var/i = 1 to E.contents.len)
-				var/atom/U = E.contents[i]
-				cont += WEAKREF(U)
+		for(var/atom/U in H.contents)
+			cont += WEAKREF(U)
 		set_pin_data(IC_OUTPUT, 1, cont)
 		var/list/St = new()
-		for(var/obj/effect/decal/cleanable/crayon/I in E.contents)
+		for(var/obj/effect/decal/cleanable/crayon/I in H.contents)
 			St.Add(I.icon_state)
 		if(St.len)
 			set_pin_data(IC_OUTPUT, 2, jointext(St, ",", 1, 0))

--- a/code/modules/integrated_electronics/subtypes/input.dm
+++ b/code/modules/integrated_electronics/subtypes/input.dm
@@ -405,6 +405,8 @@
 		var/list/cont = new()
 		for(var/obj/U in H)
 			cont += WEAKREF(U)
+		for(var/mob/U in H)
+			cont += WEAKREF(U)
 		set_pin_data(IC_OUTPUT, 1, cont)
 		var/list/St = new()
 		for(var/obj/effect/decal/cleanable/crayon/I in H)

--- a/code/modules/integrated_electronics/subtypes/input.dm
+++ b/code/modules/integrated_electronics/subtypes/input.dm
@@ -403,11 +403,11 @@
 
 	if(H in view(T)) // This is a camera. It can't examine thngs,that it can't see.
 		var/list/cont = new()
-		for(var/atom/U in H.contents)
+		for(var/U in H)
 			cont += WEAKREF(U)
 		set_pin_data(IC_OUTPUT, 1, cont)
 		var/list/St = new()
-		for(var/obj/effect/decal/cleanable/crayon/I in H.contents)
+		for(var/obj/effect/decal/cleanable/crayon/I in H)
 			St.Add(I.icon_state)
 		if(St.len)
 			set_pin_data(IC_OUTPUT, 2, jointext(St, ",", 1, 0))

--- a/code/modules/integrated_electronics/subtypes/input.dm
+++ b/code/modules/integrated_electronics/subtypes/input.dm
@@ -403,7 +403,7 @@
 
 	if(H in view(T)) // This is a camera. It can't examine thngs,that it can't see.
 		var/list/cont = new()
-		for(var/U in H)
+		for(var/obj/U in H)
 			cont += WEAKREF(U)
 		set_pin_data(IC_OUTPUT, 1, cont)
 		var/list/St = new()


### PR DESCRIPTION
[Changelogs]: #
The tile analyzer circuit was not working, and by looking at the code, would've never worked.
It was type checking against movable atoms where it needed to check against turfs, which are mutually exclusive IIRC. TBH, I don't know how this got added. A simple test would've shown its failure.

:cl: robbym
fix: Fixes tile analyzer circuit
refactor: Cleaned up tile analyzer code
/:cl:

[why]: # (Please add a short description [two lines down] of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.)
