### PR TITLE
Removes april fools from heirlooms

### DIFF
--- a/code/datums/traits/negative.dm
+++ b/code/datums/traits/negative.dm
@@ -21,29 +21,21 @@
 /datum/trait/family_heirloom/on_spawn()
 	var/mob/living/carbon/human/H = trait_holder
 	var/obj/item/heirloom_type
-	if(SSevents.holidays && SSevents.holidays[APRIL_FOOLS]) //on april fools, pick from any item in the game
-		var/list/heirlooms = subtypesof(/obj/item)
-		for(var/V in heirlooms)
-			var/obj/item/I = V
-			if((!initial(I.icon_state)) || (!initial(I.item_state)) || (initial(I.flags_1) & ABSTRACT_1))
-				heirlooms -= V
-		heirloom_type = pick(heirlooms)
-	else
-		switch(trait_holder.mind.assigned_role)
-			if("Clown")
-				heirloom_type = /obj/item/bikehorn/golden
-			if("Mime")
-				heirloom_type = /obj/item/reagent_containers/food/snacks/baguette
-			if("Lawyer")
-				heirloom_type = /obj/item/gavelhammer
-			if("Janitor")
-				heirloom_type = /obj/item/mop
-			if("Security Officer")
-				heirloom_type = /obj/item/book/manual/wiki/security_space_law
-			if("Scientist")
-				heirloom_type = /obj/item/toy/plush/slimeplushie
-			if("Assistant")
-				heirloom_type = /obj/item/storage/toolbox/mechanical/old/heirloom
+	switch(trait_holder.mind.assigned_role)
+		if("Clown")
+			heirloom_type = /obj/item/bikehorn/golden
+		if("Mime")
+			heirloom_type = /obj/item/reagent_containers/food/snacks/baguette
+		if("Lawyer")
+			heirloom_type = /obj/item/gavelhammer
+		if("Janitor")
+			heirloom_type = /obj/item/mop
+		if("Security Officer")
+			heirloom_type = /obj/item/book/manual/wiki/security_space_law
+		if("Scientist")
+			heirloom_type = /obj/item/toy/plush/slimeplushie
+		if("Assistant")
+			heirloom_type = /obj/item/storage/toolbox/mechanical/old/heirloom
 	if(!heirloom_type)
 		heirloom_type = pick(
 		/obj/item/toy/cards/deck,


### PR DESCRIPTION
Why: It's bugged, it has no thematic relation to april fools, there is nothing indicating how this works ingame, and I think the holidays should be kept distinct from one another when possible

Closes https://github.com/tgstation/tgstation/issues/36918