### PR TITLE
Fixes trash bin wrenching message

### DIFF
--- a/code/game/objects/structures/crates_lockers/crates/bins.dm
+++ b/code/game/objects/structures/crates_lockers/crates/bins.dm
@@ -31,9 +31,7 @@
 				O.forceMove(T)
 		T.update_icon()
 		do_animate()
-	else if(istype(W, /obj/item/wrench))
-		anchored = !anchored
-		W.play_tool_sound(src, 75)
+		return TRUE
 	else
 		return ..()
 


### PR DESCRIPTION
Fixes #36947

It had a completely superfluous override for no reason. The parent proc already handles wrenches. Tested in-game.

:cl: Naksu
fix: Trash bin anchoring/unanchoring now gives you a small text blip about what happened.
/:cl:
