### PR TITLE
fixes revenant deadchat

### DIFF
--- a/code/modules/antagonists/revenant/revenant.dm
+++ b/code/modules/antagonists/revenant/revenant.dm
@@ -7,7 +7,7 @@
 #define REVENANT_NAME_FILE "revenant_names.json"
 
 /mob/living/simple_animal/revenant
-	name = "\a Revenant"
+	name = "revenant"
 	desc = "A malevolent spirit."
 	icon = 'icons/mob/mob.dmi'
 	icon_state = "revenant_idle"


### PR DESCRIPTION
Fixes #36944 
Fixes #33744


For whatever reason, the \a macro here translates into %ff%06 in url_encode() which makes browserOutput.js throw a "The URI to be decoded is not a valid encoding" error. it was superfluous anyways. While revenants are alive, they use their fluffy name like "spirit of abysmal hellfire" which is why this bug only triggered in death.

:cl: Naksu
fix: Fixed (dead) revenants being unable to deadchat or ahelp
/:cl:

```
22:30 <%Naksu> !dm url_encode("\a Revenant")
22:30 <+Bot32> Naksu: %ff%06Revenant
```