### PR TITLE
Fixes mixed blood samples to preserve cloneable if the samples are the same

### DIFF
--- a/code/modules/reagents/chemistry/reagents/other_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/other_reagents.dm
@@ -41,7 +41,8 @@
 
 /datum/reagent/blood/on_merge(list/mix_data)
 	if(data && mix_data)
-		data["cloneable"] = 0 //On mix, consider the genetic sampling unviable for pod cloning, or else we won't know who's even getting cloned, etc
+		if(data["blood_DNA"] != mix_data["blood_DNA"])
+			data["cloneable"] = 0 //On mix, consider the genetic sampling unviable for pod cloning if the DNA sample doesn't match.
 		if(data["viruses"] || mix_data["viruses"])
 
 			var/list/mix1 = data["viruses"]


### PR DESCRIPTION
:cl: SailorDave
fix: Mixed blood samples preserve their cloneability for podpeople if the samples are the same.
/:cl:

[why]:

Currently, blood samples lose their 'cloneable' status if they get mixed with other blood samples. This makes sense if the blood samples differ, like a sample from a different person, but it doesn't make sense for that to change if the mixed blood is the same.

This minor change is mainly for the sake of the use of chemical fuel cells in integrated circuits, where this screws things up a little bit since they rely on the 'cloneable' property from blood, as well as the use of blood samples in replica pods in my as-of-writing open Circuits PR.