### PR TITLE
move enforce_human_authority check before species.before_equip_job()

### DIFF
--- a/code/modules/jobs/job_types/job.dm
+++ b/code/modules/jobs/job_types/job.dm
@@ -67,17 +67,17 @@
 	if(!H)
 		return 0
 
-	//Equip the rest of the gear
-	H.dna.species.before_equip_job(src, H, visualsOnly)
-
-	if(outfit)
-		H.equipOutfit(outfit, visualsOnly)
-
 	if(CONFIG_GET(flag/enforce_human_authority) && (title in GLOB.command_positions))
 		if(H.dna.species.id != "human")
 			H.set_species(/datum/species/human)
 			H.rename_self("human", H.client)
 		purrbation_remove(H, silent=TRUE)
+
+	//Equip the rest of the gear
+	H.dna.species.before_equip_job(src, H, visualsOnly)
+
+	if(outfit)
+		H.equipOutfit(outfit, visualsOnly)
 
 	H.dna.species.after_equip_job(src, H, visualsOnly)
 


### PR DESCRIPTION
Fixes #36968

Plasmemes equip their species gear in before_equip_job(). This is similar to the change done in #34994 which fixed species languages being retained after the species change.

:cl: Naksu
fix: Plasmamen that get converted into humans as a part of spawning as a protected head role no longer retain their plasmaman equipment.
/:cl:
