### PR TITLE
Fixes null reference not pulsing the 'not scanned' output

### DIFF
--- a/code/modules/integrated_electronics/subtypes/input.dm
+++ b/code/modules/integrated_electronics/subtypes/input.dm
@@ -321,10 +321,10 @@
 /obj/item/integrated_circuit/input/examiner/do_work()
 	var/atom/movable/H = get_pin_data_as_type(IC_INPUT, 1, /atom/movable)
 	var/turf/T = get_turf(src)
-	if(!istype(H)) //Invalid input
-		return
 
-	if(H in view(T)) // This is a camera. It can't examine thngs,that it can't see.
+	if(!istype(H) || !(H in view(T)))
+		activate_pin(3)
+	else
 		set_pin_data(IC_OUTPUT, 1, H.name)
 		set_pin_data(IC_OUTPUT, 2, H.desc)
 		set_pin_data(IC_OUTPUT, 3, H.x-T.x)
@@ -341,8 +341,6 @@
 		set_pin_data(IC_OUTPUT, 9, H.opacity)
 		push_data()
 		activate_pin(2)
-	else
-		activate_pin(3)
 
 /obj/item/integrated_circuit/input/turfpoint
 	name = "tile pointer"


### PR DESCRIPTION
fixes #36881 


:cl: robbym
fix: Fixes examiner circuit failing to pulse 'not scanned' when reference is null  (#36881)
/:cl:

[why]: # (Please add a short description [two lines down] of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.)
