### PR TITLE
Wrench Supermatter Shard to the ground

### DIFF
--- a/code/modules/power/supermatter/supermatter.dm
+++ b/code/modules/power/supermatter/supermatter.dm
@@ -137,6 +137,8 @@ GLOBAL_DATUM(main_supermatter_engine, /obj/machinery/power/supermatter_shard)
 
 	var/datum/looping_sound/supermatter/soundloop
 
+	var/moveable = TRUE
+
 /obj/machinery/power/supermatter_shard/Initialize()
 	. = ..()
 	uid = gl_uid++
@@ -542,13 +544,6 @@ GLOBAL_DATUM(main_supermatter_engine, /obj/machinery/power/supermatter_shard)
 			to_chat(user, "<span class='notice'>You extract a sliver from \the [src]. \The [src] begins to react violently!</span>")
 			new /obj/item/nuke_core/supermatter_sliver(drop_location())
 			matter_power += 200
-	else if (istype(W, /obj/item/wrench))
-		if (anchored == FALSE)
-			user.visible_message("<span class='notice'>You secure the shard to the ground</span>")
-			anchored = TRUE
-		else
-			user.visible_message("<span class='notice'>You unsecure the shard from the ground</span>")
-			anchored = FALSE
 	else if(user.dropItemToGround(W))
 		user.visible_message("<span class='danger'>As [user] touches \the [src] with \a [W], silence fills the room...</span>",\
 			"<span class='userdanger'>You touch \the [src] with \the [W], and everything suddenly goes silent.</span>\n<span class='notice'>\The [W] flashes into dust as you flinch away from \the [src].</span>",\
@@ -559,6 +554,10 @@ GLOBAL_DATUM(main_supermatter_engine, /obj/machinery/power/supermatter_shard)
 
 		radiation_pulse(src, 150, 4)
 
+/obj/machinery/power/supermatter_shard/wrench_act(mob/user, obj/item/tool)
+	if (moveable)
+		default_unfasten_wrench(user, tool, time = 20)
+	return TRUE
 
 /obj/machinery/power/supermatter_shard/CollidedWith(atom/movable/AM)
 	if(isliving(AM))
@@ -620,6 +619,7 @@ GLOBAL_DATUM(main_supermatter_engine, /obj/machinery/power/supermatter_shard)
 	anchored = TRUE
 	gasefficency = 0.15
 	explosion_power = 35
+	moveable = FALSE
 
 /obj/machinery/power/supermatter_shard/crystal/engine
 	is_main_engine = TRUE

--- a/code/modules/power/supermatter/supermatter.dm
+++ b/code/modules/power/supermatter/supermatter.dm
@@ -542,6 +542,13 @@ GLOBAL_DATUM(main_supermatter_engine, /obj/machinery/power/supermatter_shard)
 			to_chat(user, "<span class='notice'>You extract a sliver from \the [src]. \The [src] begins to react violently!</span>")
 			new /obj/item/nuke_core/supermatter_sliver(drop_location())
 			matter_power += 200
+	else if (istype(W, /obj/item/wrench))
+		if (anchored == FALSE)
+			user.visible_message("<span class='notice'>You secure the shard to the ground</span>")
+			anchored = TRUE
+		else
+			user.visible_message("<span class='notice'>You unsecure the shard from the ground</span>")
+			anchored = FALSE
 	else if(user.dropItemToGround(W))
 		user.visible_message("<span class='danger'>As [user] touches \the [src] with \a [W], silence fills the room...</span>",\
 			"<span class='userdanger'>You touch \the [src] with \the [W], and everything suddenly goes silent.</span>\n<span class='notice'>\The [W] flashes into dust as you flinch away from \the [src].</span>",\


### PR DESCRIPTION
I doubt this code is the standard method of doing things, but trying to understand this code is a bit AIDS

[Changelogs]: # (Your PR should contain a detailed changelog of notable changes, titled and categorized appropriately. This includes, new features, sprites, sounds, balance changes, admin tools, map edits, removals, big refactors, config changes, hosting changes and important fixes. An example changelog has been provided below for you to edit. If you need additional help, read https://github.com/tgstation/tgstation/wiki/Changelogs)

:cl: SpironoZeppeli
add: You can now wrench the supermatter shard
/:cl:

[why]: # (Please add a short description [two lines down] of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.)

The supermatter shard is nearly impossible to work with due to it moving about in changing atmospheres. As such, the ability to secure it to the ground is necessary.