### PR TITLE
Changes ore-burning math to avoid decimals (and raise RNG)

### DIFF
--- a/code/modules/mining/ores_coins.dm
+++ b/code/modules/mining/ores_coins.dm
@@ -52,17 +52,11 @@
 /obj/item/stack/ore/burn()
 	if(!refined_type)
 		return ..()
-	var/amountrefined = 0
-	for(var/i in 1 to amount)
-		var/probability = rand(30,70)
-		if(prob(probability))
-			amountrefined ++	
+	var/amountrefined = round(rand(0,100)/100*amount, 1)
 	if(amountrefined < 1)
 		return ..()
 	else
-		var/obj/item/stack/sheet/S = new refined_type(drop_location())
-		S.amount = amountrefined
-		S.update_icon()
+		var/obj/item/stack/sheet/S = new refined_type(drop_location(), new_amount = amountrefined)
 		qdel(src)
 
 /obj/item/stack/ore/uranium

--- a/code/modules/mining/ores_coins.dm
+++ b/code/modules/mining/ores_coins.dm
@@ -50,15 +50,20 @@
 	return TRUE
 
 /obj/item/stack/ore/fire_act(exposed_temperature, exposed_volume)
-	if(!refined_type)
-		return ..()
-	var/probability = rand(0,100) / 100
-	var/amountrefined = round(probability*amount, 1)
-	if(amountrefined < 1)
-		return ..()
+	. = ..()
+	if(isnull(refined_type))
+		return
 	else
-		new refined_type(drop_location(), new_amount = amountrefined)
-		qdel(src)
+		var/probability = (rand(0,100))/100
+		var/burn_value = probability*amount
+		var/amountrefined = round(burn_value, 1)
+		if(amountrefined < 1)
+			qdel(src)
+		else
+			var/obj/item/stack/S = new refined_type(drop_location())
+			S.amount = 0
+			S.add(amountrefined)
+			qdel(src)
 
 /obj/item/stack/ore/uranium
 	name = "uranium ore"

--- a/code/modules/mining/ores_coins.dm
+++ b/code/modules/mining/ores_coins.dm
@@ -60,9 +60,7 @@
 		if(amountrefined < 1)
 			qdel(src)
 		else
-			var/obj/item/stack/S = new refined_type(drop_location())
-			S.amount = 0
-			S.add(amountrefined)
+			new refined_type(drop_location(),amountrefined)
 			qdel(src)
 
 /obj/item/stack/ore/uranium

--- a/code/modules/mining/ores_coins.dm
+++ b/code/modules/mining/ores_coins.dm
@@ -49,14 +49,15 @@
 
 	return TRUE
 
-/obj/item/stack/ore/burn()
+/obj/item/stack/ore/fire_act(exposed_temperature, exposed_volume)
 	if(!refined_type)
 		return ..()
-	var/amountrefined = round(rand(0,100)/100*amount, 1)
+	var/probability = rand(0,100) / 100
+	var/amountrefined = round(probability*amount, 1)
 	if(amountrefined < 1)
 		return ..()
 	else
-		var/obj/item/stack/sheet/S = new refined_type(drop_location(), new_amount = amountrefined)
+		new refined_type(drop_location(), new_amount = amountrefined)
 		qdel(src)
 
 /obj/item/stack/ore/uranium

--- a/code/modules/mining/ores_coins.dm
+++ b/code/modules/mining/ores_coins.dm
@@ -52,12 +52,18 @@
 /obj/item/stack/ore/burn()
 	if(!refined_type)
 		return ..()
-	var/obj/item/stack/sheet/S = new refined_type(drop_location())
-	var/percent = rand(0.3,0.7)
-	var/amountrefined = round(amount*percent)
-	S.amount = amountrefined
-	S.update_icon()
-	qdel(src)
+	var/amountrefined = 0
+	for(var/i in 1 to amount)
+		var/probability = rand(30,70)
+		if(prob(probability))
+			amountrefined ++	
+	if(amountrefined < 1)
+		..()
+	else
+		var/obj/item/stack/sheet/S = new refined_type(drop_location())
+		S.amount = amountrefined
+		S.update_icon()
+		qdel(src)
 
 /obj/item/stack/ore/uranium
 	name = "uranium ore"

--- a/code/modules/mining/ores_coins.dm
+++ b/code/modules/mining/ores_coins.dm
@@ -58,7 +58,7 @@
 		if(prob(probability))
 			amountrefined ++	
 	if(amountrefined < 1)
-		..()
+		return ..()
 	else
 		var/obj/item/stack/sheet/S = new refined_type(drop_location())
 		S.amount = amountrefined


### PR DESCRIPTION
5 things of ore.
Previous: Worst: 2, Best: 4, Gives emptystacks.
New: Worst: Nothing, Best: 5, Theoretically Prevents emptystacks.

:cl: Cobby
experiment: Ore burning's math has been edited to be more RNG but also potentially more profitable.
fix: Fixes getting "emptystacks" (a stack with an amount of 0)
/:cl:

(will) fixes #37001 
(will) fixes #37057