### PR TITLE
Adds the jukebox to every active map.

### DIFF
--- a/_maps/map_files/BoxStation/BoxStation.dmm
+++ b/_maps/map_files/BoxStation/BoxStation.dmm
@@ -18360,10 +18360,12 @@
 /turf/open/floor/plasteel/cafeteria,
 /area/crew_quarters/kitchen)
 "aVA" = (
-/obj/structure/table/reinforced,
-/obj/machinery/door/firedoor,
-/obj/item/reagent_containers/food/snacks/pie/cream,
-/turf/open/floor/plasteel/cafeteria,
+/obj/effect/spawner/structure/window,
+/obj/machinery/door/poddoor/preopen{
+	id = "barShutters";
+	name = "privacy shutters"
+	},
+/turf/open/floor/plating,
 /area/crew_quarters/kitchen)
 "aVB" = (
 /obj/structure/table,
@@ -36253,8 +36255,7 @@
 	pixel_y = 24
 	},
 /obj/machinery/atmospherics/components/binary/pump/on{
-	dir = 4;
-	
+	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/engine,
@@ -53747,6 +53748,10 @@
 /obj/structure/lattice,
 /turf/open/space/basic,
 /area/space/nearstation)
+"gYO" = (
+/obj/machinery/jukebox,
+/turf/open/floor/plasteel/bar,
+/area/crew_quarters/bar)
 "gZG" = (
 /obj/structure/closet/crate/freezer/surplus_limbs,
 /obj/item/reagent_containers/glass/beaker/synthflesh,
@@ -91529,9 +91534,9 @@ aND
 aJC
 aab
 aRg
-aQc
 aac
 aQc
+gYO
 aXk
 aQc
 aQc
@@ -91786,8 +91791,8 @@ aJC
 aJC
 aJI
 aJI
-aSI
 aJI
+aSI
 aVA
 aJI
 aYK

--- a/_maps/map_files/Deltastation/DeltaStation2.dmm
+++ b/_maps/map_files/Deltastation/DeltaStation2.dmm
@@ -11783,12 +11783,10 @@
 	},
 /area/crew_quarters/bar)
 "aEY" = (
-/obj/structure/table/wood,
 /obj/machinery/status_display{
 	pixel_y = 32
 	},
-/obj/item/clipboard,
-/obj/item/toy/figure/bartender,
+/obj/machinery/jukebox,
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/bar)
 "aEZ" = (
@@ -11804,6 +11802,7 @@
 	name = "Station Intercom";
 	pixel_y = 26
 	},
+/obj/item/toy/figure/bartender,
 /turf/open/floor/plasteel/vault{
 	dir = 5
 	},

--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -35509,6 +35509,7 @@
 /obj/machinery/newscaster{
 	pixel_y = 32
 	},
+/obj/machinery/jukebox,
 /turf/open/floor/plasteel/bar,
 /area/crew_quarters/bar)
 "bwO" = (

--- a/_maps/map_files/PubbyStation/PubbyStation.dmm
+++ b/_maps/map_files/PubbyStation/PubbyStation.dmm
@@ -45644,7 +45644,7 @@
 	invuln = 1;
 	luminosity = 3;
 	name = "Hardened Bomb-Test Camera";
-	network = list("ss13", "rd", "toxins");
+	network = list("ss13","rd","toxins");
 	use_power = 0
 	},
 /turf/open/floor/plating/asteroid/airless,
@@ -46672,7 +46672,7 @@
 	invuln = 1;
 	luminosity = 3;
 	name = "Hardened Bomb-Test Camera";
-	network = list("ss13", "rd", "toxins");
+	network = list("ss13","rd","toxins");
 	use_power = 0
 	},
 /turf/open/floor/plating/asteroid/airless,
@@ -50143,6 +50143,10 @@
 	},
 /turf/open/floor/carpet,
 /area/library)
+"iyV" = (
+/obj/machinery/jukebox,
+/turf/open/floor/plasteel/dark,
+/area/crew_quarters/bar)
 "izB" = (
 /obj/machinery/door/airlock/external{
 	name = "Escape Pod"
@@ -82604,7 +82608,7 @@ aSS
 aUg
 aVf
 aWi
-bah
+iyV
 aYe
 aZb
 bag


### PR DESCRIPTION
:cl: MMMiracles
add: A jukebox can now be found in the bar of your respective station. Contact Central about song suggestions to be added to the curated list!
/:cl:

[why]: Kor redid the disco machine and added a jukebox variant intended for maps but didn't add it in due to the freeze. I have a PR up that fixes things so I'm gonna use my one free feature PR to get these on the station.

Thaw PR: #36964
Boxstation had a small bit of re-arrangement due to limited space and lost the table between the kitchen/bar to a window since there wasn't a clean way of doing it otherwise that'd keep it behind the bar. I'll map a jukebox into Omegastation once my fix PR for it gets merged.
