### PR TITLE
Various minor arena shuttle fixes

### DIFF
--- a/_maps/map_files/generic/CentCom.dmm
+++ b/_maps/map_files/generic/CentCom.dmm
@@ -2526,10 +2526,6 @@
 /obj/machinery/capture_the_flag/red,
 /turf/open/floor/circuit/green/anim,
 /area/ctf)
-"hH" = (
-/obj/effect/landmark/shuttle_import,
-/turf/open/space,
-/area/space)
 "hI" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 10
@@ -13506,6 +13502,10 @@
 	},
 /turf/open/floor/plasteel,
 /area/centcom/control)
+"VX" = (
+/obj/effect/landmark/shuttle_import,
+/turf/open/space/basic,
+/area/space)
 "Wc" = (
 /obj/machinery/door/airlock/centcom{
 	name = "CentCom Security";
@@ -36021,7 +36021,7 @@ aa
 aa
 aa
 aa
-aa
+VX
 aa
 aa
 aa
@@ -44564,7 +44564,7 @@ aa
 aa
 aa
 aa
-hH
+ad
 aa
 aa
 aa

--- a/_maps/shuttles/emergency_arena.dmm
+++ b/_maps/shuttles/emergency_arena.dmm
@@ -65,6 +65,10 @@
 /obj/structure/healingfountain,
 /turf/open/indestructible/necropolis/air,
 /area/shuttle/escape/arena)
+"z" = (
+/obj/effect/landmark/shuttle_arena_safe,
+/turf/open/indestructible/necropolis/air,
+/area/shuttle/escape/arena)
 
 (1,1,1) = {"
 a
@@ -309,16 +313,16 @@ h
 h
 j
 j
+z
 j
 j
-j
-j
+z
 j
 h
+z
 j
 j
-j
-j
+z
 j
 j
 j
@@ -465,16 +469,16 @@ h
 h
 j
 j
+z
 j
 j
+z
 j
 j
-j
-j
-j
+z
 j
 h
-j
+z
 j
 j
 j

--- a/code/datums/shuttles.dm
+++ b/code/datums/shuttles.dm
@@ -31,6 +31,8 @@
 		var/turf/place = turfs[i]
 		if(istype(place, /turf/open/space)) // This assumes all shuttles are loaded in a single spot then moved to their real destination.
 			continue
+		if(length(place.baseturfs) < 2) // Some snowflake shuttle shit
+			continue
 		place.baseturfs.Insert(3, /turf/baseturf_skipover/shuttle)
 
 //Whatever special stuff you want

--- a/code/modules/admin/fun_balloon.dm
+++ b/code/modules/admin/fun_balloon.dm
@@ -119,21 +119,13 @@
 
 /obj/effect/forcefield/arena_shuttle
 	name = "portal"
+	timeleft = 0
 	var/list/warp_points
 
 /obj/effect/forcefield/arena_shuttle/Initialize()
 	. = ..()
-	warp_points = get_area_turfs(/area/shuttle/escape)
-	for(var/thing in warp_points)
-		CHECK_TICK
-		var/turf/T = thing
-		if(istype(T.loc, /area/shuttle/escape/backup))
-			warp_points -= T
-			continue
-		for(var/atom/movable/TAM in T)
-			if(TAM.density && TAM.anchored)
-				warp_points -= T
-				break
+	for(var/obj/effect/landmark/shuttle_arena_safe/exit in GLOB.landmarks_list)
+		warp_points += exit
 
 /obj/effect/forcefield/arena_shuttle/CollidedWith(atom/movable/AM)
 	if(!isliving(AM))
@@ -143,7 +135,7 @@
 	if(L.pulling && istype(L.pulling, /obj/item/bodypart/head))
 		to_chat(L, "Your offering is accepted. You may pass.")
 		qdel(L.pulling)
-		var/turf/LA = pick(warp_points)
+		var/turf/LA = get_turf(pick(warp_points))
 		L.forceMove(LA)
 		L.hallucination = 0
 		to_chat(L, "<span class='reallybig redtext'>The battle is won. Your bloodlust subsides.</span>")
@@ -163,6 +155,7 @@
 
 /obj/effect/forcefield/arena_shuttle_entrance
 	name = "portal"
+	timeleft = 0
 	var/list/warp_points = list()
 
 /obj/effect/forcefield/arena_shuttle_entrance/CollidedWith(atom/movable/AM)


### PR DESCRIPTION
:cl: ninjanomnom
fix: The arena shuttle should be working again.
/:cl:

A previous change to forcefields to make them self delete made the teleport fields on the shuttle remove themselves. This was a simple var fix.

Had to do a minor change to shuttle template loading to account for baseturf helpers on shuttles. I should probably handle that a bit better in the future.

The shuttle loading landmark was moved to a bit more open space in centcom.

fixes #36069
fixes #33976
fixes #33975