### PR TITLE
Fix errant space area on OmegaStation

### DIFF
--- a/_maps/map_files/OmegaStation/OmegaStation.dmm
+++ b/_maps/map_files/OmegaStation/OmegaStation.dmm
@@ -31519,9 +31519,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
-"fSE" = (
-/turf/closed/wall/r_wall,
-/area/space)
 "fWz" = (
 /obj/machinery/door/airlock/external{
 	name = "External Docking Port";
@@ -69053,7 +69050,7 @@ swZ
 agF
 agF
 agF
-fSE
+agF
 swZ
 agF
 auE


### PR DESCRIPTION
previously:
![image](https://user-images.githubusercontent.com/222630/38451157-d50e58c0-39df-11e8-9dbb-4214b00bdc82.png)
