### PR TITLE
Fixes an heirloom trait-related runtime that gets spammed in the logs

### DIFF
--- a/code/datums/traits/_trait.dm
+++ b/code/datums/traits/_trait.dm
@@ -56,6 +56,7 @@
 
 /datum/trait/process()
 	if(QDELETED(trait_holder))
+		trait_holder = null
 		qdel(src)
 		return
 	if(trait_holder.stat == DEAD)

--- a/code/datums/traits/negative.dm
+++ b/code/datums/traits/negative.dm
@@ -62,6 +62,9 @@
 	heirloom.name = "\improper [family_name[family_name.len]] family [heirloom.name]"
 
 /datum/trait/family_heirloom/process()
+	if (QDELETED(trait_holder))
+		trait_holder = null
+		qdel(src)
 	if(heirloom in trait_holder.GetAllContents())
 		trait_holder.SendSignal(COMSIG_CLEAR_MOOD_EVENT, "family_heirloom_missing")
 		trait_holder.SendSignal(COMSIG_ADD_MOOD_EVENT, "family_heirloom", /datum/mood_event/family_heirloom)

--- a/code/datums/traits/negative.dm
+++ b/code/datums/traits/negative.dm
@@ -65,6 +65,7 @@
 	if (QDELETED(trait_holder))
 		trait_holder = null
 		qdel(src)
+		return
 	if(heirloom in trait_holder.GetAllContents())
 		trait_holder.SendSignal(COMSIG_CLEAR_MOOD_EVENT, "family_heirloom_missing")
 		trait_holder.SendSignal(COMSIG_ADD_MOOD_EVENT, "family_heirloom", /datum/mood_event/family_heirloom)

--- a/code/datums/traits/negative.dm
+++ b/code/datums/traits/negative.dm
@@ -61,11 +61,7 @@
 	var/list/family_name = splittext(trait_holder.real_name, " ")
 	heirloom.name = "\improper [family_name[family_name.len]] family [heirloom.name]"
 
-/datum/trait/family_heirloom/process()
-	if (QDELETED(trait_holder))
-		trait_holder = null
-		qdel(src)
-		return
+/datum/trait/family_heirloom/on_process()
 	if(heirloom in trait_holder.GetAllContents())
 		trait_holder.SendSignal(COMSIG_CLEAR_MOOD_EVENT, "family_heirloom_missing")
 		trait_holder.SendSignal(COMSIG_ADD_MOOD_EVENT, "family_heirloom", /datum/mood_event/family_heirloom)


### PR DESCRIPTION
[19:54:12] Skipped 597 runtimes in negative.dm,63. etc
[19:54:13] Runtime in negative.dm, line 63: Cannot execute null.GetAllContents().
proc name: process (/datum/trait/family_heirloom/process)

:cl: Naksu
code: Fixed an heirloom trait-related runtime
/:cl:

How often does this thing even process?