### PR TITLE
Fixes underlying area grabbing subtypes

### DIFF
--- a/code/modules/shuttle/docking.dm
+++ b/code/modules/shuttle/docking.dm
@@ -46,7 +46,12 @@
 
 	// The underlying old area is the area assumed to be under the shuttle's starting location
 	// If it no longer/has never existed it will be created
-	var/area/underlying_old_area = locate(underlying_area_type) in GLOB.sortedAreas
+	var/area/underlying_old_area
+	for(var/i in GLOB.sortedAreas) // Locate grabs subtypes and we want a particular type
+		var/area/place = i
+		if(place.type == underlying_area_type)
+			underlying_old_area = place
+			break
 	if(!underlying_old_area)
 		underlying_old_area = new underlying_area_type(null)
 


### PR DESCRIPTION
For example the syndicate infiltrator would leave behind a subtype of `/area/syndicate_mothership` instead of the exact area making the zone it left behind have shadows instead of full bright like it should.

This probably fixes a few other oddities that hardly anyone would notice.