### PR TITLE
Gives Omega its own arrivals shuttle

### DIFF
--- a/_maps/map_files/OmegaStation/OmegaStation.dmm
+++ b/_maps/map_files/OmegaStation/OmegaStation.dmm
@@ -30338,18 +30338,6 @@
 /obj/structure/grille,
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
-"btj" = (
-/obj/docking_port/stationary{
-	dir = 2;
-	dwidth = 4;
-	height = 17;
-	id = "arrivals_stationary";
-	name = "omega arrivals";
-	roundstart_template = /datum/map_template/shuttle/arrival/delta;
-	width = 9
-	},
-/turf/open/space/basic,
-/area/space)
 "btk" = (
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 4
@@ -31447,6 +31435,18 @@
 /obj/item/wrench,
 /turf/open/space,
 /area/space/nearstation)
+"fsl" = (
+/obj/docking_port/stationary{
+	dir = 2;
+	dwidth = 2;
+	height = 16;
+	id = "arrivals_stationary";
+	name = "omega arrivals";
+	roundstart_template = /datum/map_template/shuttle/arrival/omega;
+	width = 5
+	},
+/turf/open/space/basic,
+/area/space)
 "fsJ" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -77329,7 +77329,7 @@ bgU
 aaa
 aaa
 aaa
-aaa
+fsl
 aaa
 aaa
 aaa
@@ -77842,7 +77842,7 @@ blv
 bgU
 aaa
 aaa
-btj
+aaa
 aaa
 aaa
 aaa

--- a/_maps/shuttles/arrival_omega.dmm
+++ b/_maps/shuttles/arrival_omega.dmm
@@ -1,0 +1,306 @@
+//MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
+"a" = (
+/turf/template_noop,
+/area/template_noop)
+"b" = (
+/obj/structure/shuttle/engine/propulsion{
+	dir = 1
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel/airless,
+/area/shuttle/arrival)
+"c" = (
+/obj/docking_port/mobile/arrivals{
+	dir = 2;
+	dwidth = 2;
+	height = 16;
+	name = "omega arrivals shuttle";
+	width = 5
+	},
+/turf/closed/wall/mineral/plastitanium/nodiagonal,
+/area/shuttle/arrival)
+"d" = (
+/turf/closed/wall/mineral/titanium/nodiagonal,
+/area/shuttle/arrival)
+"e" = (
+/obj/structure/shuttle/engine/heater{
+	dir = 1
+	},
+/obj/structure/window/reinforced,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel/airless,
+/area/shuttle/arrival)
+"f" = (
+/turf/closed/wall/mineral/titanium,
+/area/shuttle/arrival)
+"g" = (
+/obj/structure/closet/wardrobe/grey,
+/obj/effect/turf_decal/delivery,
+/turf/open/floor/plasteel/neutral/corner,
+/area/shuttle/arrival)
+"h" = (
+/obj/structure/closet/emcloset,
+/obj/machinery/vending/wallmed{
+	pixel_y = 32
+	},
+/obj/item/storage/toolbox/emergency,
+/obj/item/storage/toolbox/emergency,
+/obj/item/clothing/suit/hazardvest,
+/obj/item/clothing/suit/hazardvest,
+/obj/item/clothing/suit/hazardvest,
+/obj/item/clothing/suit/hazardvest,
+/obj/item/clothing/head/hardhat/orange,
+/obj/item/clothing/head/hardhat/orange,
+/obj/item/clothing/head/hardhat/orange,
+/obj/item/clothing/head/hardhat/orange,
+/obj/effect/turf_decal/delivery,
+/turf/open/floor/plasteel/neutral/side,
+/area/shuttle/arrival)
+"i" = (
+/obj/structure/closet/wardrobe/mixed,
+/obj/structure/sign/poster/official/enlist{
+	pixel_x = 32
+	},
+/obj/effect/turf_decal/delivery,
+/turf/open/floor/plasteel/neutral/corner{
+	dir = 8
+	},
+/area/shuttle/arrival)
+"j" = (
+/obj/machinery/door/airlock/shuttle,
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 9
+	},
+/turf/open/floor/plating,
+/area/shuttle/arrival)
+"k" = (
+/obj/effect/turf_decal/caution{
+	icon_state = "caution";
+	dir = 4
+	},
+/turf/open/floor/plasteel/neutral/side{
+	dir = 4
+	},
+/area/shuttle/arrival)
+"l" = (
+/turf/open/floor/plasteel/neutral,
+/area/shuttle/arrival)
+"m" = (
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/open/floor/plasteel/neutral/side{
+	dir = 8
+	},
+/area/shuttle/arrival)
+"n" = (
+/obj/structure/extinguisher_cabinet{
+	pixel_x = -26
+	},
+/turf/open/floor/plasteel/neutral/corner{
+	dir = 4
+	},
+/area/shuttle/arrival)
+"o" = (
+/obj/item/twohanded/required/kirbyplants/random,
+/turf/open/floor/plasteel/neutral/corner{
+	dir = 1
+	},
+/area/shuttle/arrival)
+"p" = (
+/obj/effect/spawner/structure/window/shuttle,
+/turf/open/floor/plating,
+/area/shuttle/arrival)
+"q" = (
+/obj/structure/chair{
+	dir = 4
+	},
+/obj/effect/turf_decal/bot,
+/turf/open/floor/plasteel,
+/area/shuttle/arrival)
+"r" = (
+/obj/structure/chair{
+	dir = 8
+	},
+/obj/effect/turf_decal/bot,
+/turf/open/floor/plasteel,
+/area/shuttle/arrival)
+"s" = (
+/obj/structure/table/reinforced,
+/obj/item/device/radio/intercom{
+	pixel_x = -30
+	},
+/obj/item/paper_bin,
+/obj/item/pen,
+/turf/open/floor/plasteel,
+/area/shuttle/arrival)
+"t" = (
+/obj/structure/table/reinforced,
+/obj/machinery/light{
+	dir = 4
+	},
+/obj/machinery/cell_charger,
+/turf/open/floor/plasteel/neutral/side{
+	dir = 8
+	},
+/area/shuttle/arrival)
+"u" = (
+/turf/open/floor/plasteel/neutral/corner{
+	dir = 4
+	},
+/area/shuttle/arrival)
+"v" = (
+/turf/open/floor/plasteel/neutral/side{
+	dir = 1
+	},
+/area/shuttle/arrival)
+"w" = (
+/obj/structure/closet/crate/internals,
+/obj/item/storage/firstaid/o2,
+/obj/item/tank/internals/emergency_oxygen,
+/obj/item/tank/internals/emergency_oxygen,
+/obj/item/tank/internals/emergency_oxygen,
+/obj/item/tank/internals/emergency_oxygen,
+/obj/item/clothing/mask/breath,
+/obj/item/clothing/mask/breath,
+/obj/item/clothing/mask/breath,
+/obj/item/clothing/mask/breath,
+/obj/effect/turf_decal/delivery,
+/turf/open/floor/plasteel/neutral/corner{
+	dir = 1
+	},
+/area/shuttle/arrival)
+"x" = (
+/obj/machinery/door/airlock/shuttle/glass,
+/turf/open/floor/plasteel,
+/area/shuttle/arrival)
+"y" = (
+/obj/machinery/light/small{
+	dir = 4
+	},
+/obj/structure/chair/office/light,
+/turf/open/floor/plasteel,
+/area/shuttle/arrival)
+"z" = (
+/obj/machinery/computer{
+	dir = 1;
+	name = "Shuttle computer"
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/arrival)
+"C" = (
+/obj/structure/table/reinforced,
+/obj/item/storage/pill_bottle/dice{
+	pixel_x = -2;
+	pixel_y = 8
+	},
+/obj/item/toy/cards/deck,
+/obj/machinery/requests_console{
+	department = "Arrival shuttle";
+	name = "Arrival shuttle requests console";
+	pixel_x = 32
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/arrival)
+"F" = (
+/obj/structure/sign/nanotrasen,
+/turf/closed/wall/mineral/titanium,
+/area/shuttle/arrival)
+
+(1,1,1) = {"
+a
+d
+f
+j
+f
+p
+p
+d
+p
+p
+j
+F
+f
+a
+a
+a
+"}
+(2,1,1) = {"
+b
+e
+g
+k
+n
+q
+q
+s
+q
+q
+k
+u
+f
+f
+p
+p
+"}
+(3,1,1) = {"
+c
+d
+h
+l
+l
+l
+l
+l
+l
+l
+l
+v
+x
+y
+z
+p
+"}
+(4,1,1) = {"
+b
+e
+i
+m
+o
+r
+r
+C
+r
+r
+t
+w
+f
+f
+p
+p
+"}
+(5,1,1) = {"
+a
+d
+f
+f
+f
+p
+p
+d
+p
+p
+f
+F
+f
+a
+a
+a
+"}

--- a/_maps/shuttles/arrival_omega.dmm
+++ b/_maps/shuttles/arrival_omega.dmm
@@ -68,9 +68,6 @@
 /obj/structure/closet/wardrobe/mixed{
 	anchored = 1
 	},
-/obj/structure/sign/poster/official/enlist{
-	pixel_x = 32
-	},
 /obj/effect/turf_decal/delivery,
 /turf/open/floor/plasteel/neutral/corner{
 	dir = 8
@@ -100,6 +97,9 @@
 "m" = (
 /obj/machinery/light{
 	dir = 4
+	},
+/obj/structure/sign/poster/official/enlist{
+	pixel_x = 32
 	},
 /turf/open/floor/plasteel/neutral/side{
 	dir = 8

--- a/_maps/shuttles/arrival_omega.dmm
+++ b/_maps/shuttles/arrival_omega.dmm
@@ -38,12 +38,16 @@
 /turf/closed/wall/mineral/titanium,
 /area/shuttle/arrival)
 "g" = (
-/obj/structure/closet/wardrobe/grey,
+/obj/structure/closet/wardrobe/grey{
+	anchored = 1
+	},
 /obj/effect/turf_decal/delivery,
 /turf/open/floor/plasteel/neutral/corner,
 /area/shuttle/arrival)
 "h" = (
-/obj/structure/closet/emcloset,
+/obj/structure/closet/emcloset{
+	anchored = 1
+	},
 /obj/machinery/vending/wallmed{
 	pixel_y = 32
 	},
@@ -61,7 +65,9 @@
 /turf/open/floor/plasteel/neutral/side,
 /area/shuttle/arrival)
 "i" = (
-/obj/structure/closet/wardrobe/mixed,
+/obj/structure/closet/wardrobe/mixed{
+	anchored = 1
+	},
 /obj/structure/sign/poster/official/enlist{
 	pixel_x = 32
 	},
@@ -82,7 +88,6 @@
 /area/shuttle/arrival)
 "k" = (
 /obj/effect/turf_decal/caution{
-	icon_state = "caution";
 	dir = 4
 	},
 /turf/open/floor/plasteel/neutral/side{

--- a/code/datums/shuttles.dm
+++ b/code/datums/shuttles.dm
@@ -378,6 +378,10 @@
 	suffix = "pubby"
 	name = "arrival shuttle (Pubby)"
 
+/datum/map_template/shuttle/arrival/omega
+	suffix = "omega"
+	name = "arrival shuttle (Omega)"
+	
 /datum/map_template/shuttle/aux_base/default
 	suffix = "default"
 	name = "auxilliary base (Default)"


### PR DESCRIPTION
:cl: Denton
add: Omegastation now has its own arrivals shuttle.
/:cl:

Omega is using the Delta arrivals shuttle, which is way oversized for that small map and forces the docking bay to be huge.

I made a smaller arrivals shuttle for Omega, it looks like this:

![omega shuttle](https://user-images.githubusercontent.com/32391752/38461821-4dc0839c-3ada-11e8-98d8-0892619fb187.JPG)
