### PR TITLE
Fix fullscreens added to clientless mobs not stretching properly

### DIFF
--- a/code/_onclick/hud/fullscreen.dm
+++ b/code/_onclick/hud/fullscreen.dm
@@ -15,11 +15,8 @@
 	screen.icon_state = "[initial(screen.icon_state)][severity]"
 	screen.severity = severity
 	if (client && screen.should_show_to(src))
+		screen.update_for_view(client.view)
 		client.screen += screen
-		if (screen.screen_loc == "CENTER-7,CENTER-7" && screen.view != client.view)
-			var/list/actualview = getviewsize(client.view)
-			screen.view = client.view
-			screen.transform = matrix(actualview[1]/FULLSCREEN_OVERLAY_RESOLUTION_X, 0, 0, 0, actualview[2]/FULLSCREEN_OVERLAY_RESOLUTION_Y, 0)
 
 	return screen
 
@@ -58,6 +55,7 @@
 		for(var/category in screens)
 			screen = screens[category]
 			if(screen.should_show_to(src))
+				screen.update_for_view(client.view)
 				client.screen |= screen
 			else
 				client.screen -= screen
@@ -72,6 +70,12 @@
 	var/view = 7
 	var/severity = 0
 	var/show_when_dead = FALSE
+
+/obj/screen/fullscreen/proc/update_for_view(client_view)
+	if (screen_loc == "CENTER-7,CENTER-7" && view != client_view)
+		var/list/actualview = getviewsize(client_view)
+		view = client_view
+		transform = matrix(actualview[1]/FULLSCREEN_OVERLAY_RESOLUTION_X, 0, 0, 0, actualview[2]/FULLSCREEN_OVERLAY_RESOLUTION_Y, 0)
 
 /obj/screen/fullscreen/proc/should_show_to(mob/mymob)
 	if(!show_when_dead && mymob.stat == DEAD)

--- a/code/modules/client/client_procs.dm
+++ b/code/modules/client/client_procs.dm
@@ -610,7 +610,7 @@ GLOBAL_LIST_EMPTY(external_rsc_urls)
 
 /client/proc/note_randomizer_user()
 	add_system_note("CID-Error", "Detected as using a cid randomizer.")
-	
+
 /client/proc/add_system_note(system_ckey, message)
 	var/sql_system_ckey = sanitizeSQL(system_ckey)
 	var/sql_ckey = sanitizeSQL(ckey)
@@ -759,6 +759,7 @@ GLOBAL_LIST_EMPTY(external_rsc_urls)
 
 	view = new_size
 	apply_clickcatcher()
+	mob.reload_fullscreen()
 	if (isliving(mob))
 		var/mob/living/M = mob
 		M.update_damage_hud()


### PR DESCRIPTION
:cl:
fix: The blindness overlay applied during cloning now properly stretches for widescreen views.
/:cl:

Fixes #35620.