### PR TITLE
Fixes overflow role latejoin

### DIFF
--- a/code/controllers/configuration/entries/game_options.dm
+++ b/code/controllers/configuration/entries/game_options.dm
@@ -226,9 +226,12 @@
 /datum/config_entry/keyed_number_list/law_weight
 	splitter = ","
 
-/datum/config_entry/number/assistant_cap
+/datum/config_entry/number/overflow_cap
 	config_entry_value = -1
 	min_val = -1
+
+/datum/config_entry/string/overflow_job
+	config_entry_value = "Assistant"
 
 /datum/config_entry/flag/starlight
 /datum/config_entry/flag/grey_assistants

--- a/code/controllers/subsystem/job.dm
+++ b/code/controllers/subsystem/job.dm
@@ -21,8 +21,21 @@ SUBSYSTEM_DEF(job)
 	if(CONFIG_GET(flag/load_jobs_from_txt))
 		LoadJobs()
 	generate_selectable_species()
+	set_overflow_role(CONFIG_GET(string/overflow_job))
 	..()
 
+/datum/controller/subsystem/job/proc/set_overflow_role(new_overflow_role)
+	var/datum/job/new_overflow = GetJob(new_overflow_role)
+	var/cap = CONFIG_GET(number/overflow_cap)
+
+	new_overflow.spawn_positions = cap
+	new_overflow.total_positions = cap
+
+	if(new_overflow_role != overflow_role)
+		var/datum/job/old_overflow = GetJob(overflow_role)
+		old_overflow.spawn_positions = initial(old_overflow.spawn_positions)
+		old_overflow.total_positions = initial(old_overflow.total_positions)
+		overflow_role = new_overflow_role
 
 /datum/controller/subsystem/job/proc/SetupOccupations(faction = "Station")
 	occupations = list()

--- a/code/modules/holiday/holidays.dm
+++ b/code/modules/holiday/holidays.dm
@@ -153,7 +153,7 @@
 	begin_month = APRIL
 
 /datum/holiday/april_fools/celebrate()
-	SSjob.overflow_role = "Clown"
+	SSjob.set_overflow_role("Clown")
 	SSticker.login_music = 'sound/ambience/clown.ogg'
 	for(var/mob/dead/new_player/P in GLOB.mob_list)
 		if(P.client)

--- a/code/modules/jobs/job_types/assistant.dm
+++ b/code/modules/jobs/job_types/assistant.dm
@@ -6,8 +6,8 @@ Assistant
 	flag = ASSISTANT
 	department_flag = CIVILIAN
 	faction = "Station"
-	total_positions = -1
-	spawn_positions = -1
+	total_positions = 5
+	spawn_positions = 5
 	supervisors = "absolutely everyone"
 	selection_color = "#dddddd"
 	access = list()			//See /datum/job/assistant/get_access()
@@ -22,15 +22,6 @@ Assistant
 		. |= list(ACCESS_MAINT_TUNNELS)
 	else
 		return ..()
-
-/datum/job/assistant/config_check()
-	var/ac = CONFIG_GET(number/assistant_cap)
-	if(ac != 0)
-		total_positions = ac
-		spawn_positions = ac
-		return 1
-	return 0
-
 
 /datum/outfit/job/assistant
 	name = "Assistant"

--- a/config/game_options.txt
+++ b/config/game_options.txt
@@ -434,8 +434,11 @@ ROUNDSTART_RACES plasmaman
 ## Uncomment to give players the choice of joining as a human with mutant bodyparts before they join the game
 #JOIN_WITH_MUTANT_HUMANS
 
-## Assistant slot cap. Set to -1 for unlimited.
-ASSISTANT_CAP -1
+##Overflow job. Default is assistant
+OVERFLOW_JOB Assistant
+
+## Overflow slot cap. Set to -1 for unlimited. If limited, it will still open up if every other job is full.
+OVERFLOW_CAP -1
 
 ## Starlight for exterior walls and breaches. Uncomment for starlight!
 ## This is disabled by default to make testing quicker, should be enabled on production servers or testing servers messing with lighting


### PR DESCRIPTION
The overflow role thing worked in character setup, but never actually became available because the assistant slot was never full.

This fixes setting the overflow role properly for latejoin.

Also adds a proc for setting the overflow job so admins can ruin the game.