### PR TITLE
Sender of PDA messages is told when their message is sent

### DIFF
--- a/code/game/objects/items/devices/PDA/PDA.dm
+++ b/code/game/objects/items/devices/PDA/PDA.dm
@@ -655,6 +655,7 @@ GLOBAL_LIST_EMPTY(PDAs)
 			to_chat(M, "[FOLLOW_LINK(M, user)] [ghost_message]")
 	// Log in the talk log
 	log_talk(user, "[key_name(user)] (PDA: [initial(name)]) sent \"[message]\" to [target_text]", LOGPDA)
+	to_chat(user, "Message sent to [target_text]: \"[message]\"")
 	// Reset the photo
 	photo = null
 

--- a/code/game/objects/items/devices/PDA/PDA.dm
+++ b/code/game/objects/items/devices/PDA/PDA.dm
@@ -655,7 +655,7 @@ GLOBAL_LIST_EMPTY(PDAs)
 			to_chat(M, "[FOLLOW_LINK(M, user)] [ghost_message]")
 	// Log in the talk log
 	log_talk(user, "[key_name(user)] (PDA: [initial(name)]) sent \"[message]\" to [target_text]", LOGPDA)
-	to_chat(user, "Message sent to [target_text]: \"[message]\"")
+	to_chat(user, "<span class='info'>Message sent to [target_text]: \"[message]\"</span>")
 	// Reset the photo
 	photo = null
 


### PR DESCRIPTION
Mostly a quality of life thing. I wasn't sure of sending messages from the backpack worked

Screenshot:
![image](https://user-images.githubusercontent.com/3355198/38772541-ee9037ee-4030-11e8-97e5-8fd357380d10.png)

:cl: JohnGinnane
add: PDA messages you send are now displayed in the chat for your confirmation
/:cl:

Fixes https://github.com/HippieStation/HippieStation/issues/7503
