### PR TITLE
Fixes escape pods not getting to their default destination

### DIFF
--- a/code/modules/shuttle/emergency.dm
+++ b/code/modules/shuttle/emergency.dm
@@ -428,7 +428,7 @@
 	. = ..()
 	var/static/i = 1
 	if(id == initial(id))
-		id = "[initial(id)] [i]"
+		id = "[initial(id)][i]"
 	if(name == initial(name))
 		name = "[initial(name)] [i]"
 


### PR DESCRIPTION
:cl: ninjanomnom
fix: The escape pods now reach their proper destination at round end
/:cl:

It's one character

fixes #37048 