### PR TITLE
Fixes constants chips getting scrambled by EMPs

### DIFF
--- a/code/modules/integrated_electronics/subtypes/memory.dm
+++ b/code/modules/integrated_electronics/subtypes/memory.dm
@@ -84,6 +84,11 @@
 	var/datum/integrated_io/O = outputs[1]
 	O.push_data()
 
+/obj/item/integrated_circuit/memory/constant/emp_act()
+	for(var/i in 1 to activators.len)
+		var/datum/integrated_io/activate/A = activators[i]
+		A.scramble()
+
 /obj/item/integrated_circuit/memory/constant/save_special()
 	var/datum/integrated_io/O = outputs[1]
 	if(istext(O.data) || isnum(O.data))


### PR DESCRIPTION
This is supposed to be the primary advantage of using constants and not rewritable memory...