### PR TITLE
adds new changeling var that counts actual absorbs, uses it for Spiders ability

### DIFF
--- a/code/modules/antagonists/changeling/cellular_emporium.dm
+++ b/code/modules/antagonists/changeling/cellular_emporium.dm
@@ -25,6 +25,7 @@
 	var/can_readapt = changeling.canrespec
 	var/genetic_points_remaining = changeling.geneticpoints
 	var/absorbed_dna_count = changeling.absorbedcount
+	var/true_absorbs = changeling.trueabsorbs
 
 	data["can_readapt"] = can_readapt
 	data["genetic_points_remaining"] = genetic_points_remaining
@@ -45,8 +46,9 @@
 		AL["helptext"] = initial(ability.helptext)
 		AL["owned"] = changeling.has_sting(ability)
 		var/req_dna = initial(ability.req_dna)
+		var/req_absorbs = initial(ability.req_absorbs)
 		AL["dna_cost"] = dna_cost
-		AL["can_purchase"] = ((req_dna <= absorbed_dna_count) && (dna_cost <= genetic_points_remaining))
+		AL["can_purchase"] = ((req_absorbs <= true_absorbs) && (req_dna <= absorbed_dna_count) && (dna_cost <= genetic_points_remaining))
 
 		abilities += list(AL)
 

--- a/code/modules/antagonists/changeling/changeling.dm
+++ b/code/modules/antagonists/changeling/changeling.dm
@@ -19,6 +19,7 @@
 	var/datum/changelingprofile/first_prof = null
 	var/dna_max = 6 //How many extra DNA strands the changeling can store for transformation.
 	var/absorbedcount = 0
+	var/trueabsorbs = 0//dna gained using absorb, not dna sting
 	var/chem_charges = 20
 	var/chem_storage = 75
 	var/chem_recharge_rate = 1

--- a/code/modules/antagonists/changeling/changeling_power.dm
+++ b/code/modules/antagonists/changeling/changeling_power.dm
@@ -12,6 +12,7 @@
 	var/dna_cost = -1 //cost of the sting in dna points. 0 = auto-purchase, -1 = cannot be purchased
 	var/req_dna = 0  //amount of dna needed to use this ability. Changelings always have atleast 1
 	var/req_human = 0 //if you need to be human to use this ability
+	var/req_absorbs = 0 //similar to req_dna, but only gained from absorbing, not DNA sting
 	var/req_stat = CONSCIOUS // CONSCIOUS, UNCONSCIOUS or DEAD
 	var/always_keep = 0 // important for abilities like revive that screw you if you lose them.
 	var/ignores_fakedeath = FALSE // usable with the FAKEDEATH flag
@@ -59,6 +60,8 @@
 	if(c.absorbedcount < req_dna)
 		to_chat(user, "<span class='warning'>We require at least [req_dna] sample\s of compatible DNA.</span>")
 		return 0
+	if(c.trueabsorbs < req_absorbs)
+		to_chat(user, "<span class='warning'>We require at least [req_absorbs] sample\s of DNA gained through our Absorb ability.</span>")
 	if(req_stat < user.stat)
 		to_chat(user, "<span class='warning'>We are incapacitated.</span>")
 		return 0

--- a/code/modules/antagonists/changeling/powers/absorb.dm
+++ b/code/modules/antagonists/changeling/powers/absorb.dm
@@ -53,6 +53,7 @@
 
 	if(!changeling.has_dna(target.dna))
 		changeling.add_new_profile(target)
+	changeling.trueabsorbs++
 
 	if(user.nutrition < NUTRITION_LEVEL_WELL_FED)
 		user.nutrition = min((user.nutrition + target.nutrition), NUTRITION_LEVEL_WELL_FED)

--- a/code/modules/antagonists/changeling/powers/absorb.dm
+++ b/code/modules/antagonists/changeling/powers/absorb.dm
@@ -53,7 +53,7 @@
 
 	if(!changeling.has_dna(target.dna))
 		changeling.add_new_profile(target)
-	changeling.trueabsorbs++
+		changeling.trueabsorbs++
 
 	if(user.nutrition < NUTRITION_LEVEL_WELL_FED)
 		user.nutrition = min((user.nutrition + target.nutrition), NUTRITION_LEVEL_WELL_FED)

--- a/code/modules/antagonists/changeling/powers/spiders.dm
+++ b/code/modules/antagonists/changeling/powers/spiders.dm
@@ -1,10 +1,10 @@
 /obj/effect/proc_holder/changeling/spiders
 	name = "Spread Infestation"
 	desc = "Our form divides, creating arachnids which will grow into deadly beasts."
-	helptext = "The spiders are thoughtless creatures, and may attack their creators when fully grown. Requires at least 5 DNA absorptions."
+	helptext = "The spiders are thoughtless creatures, and may attack their creators when fully grown. Requires at least 3 DNA gained through Absorb, and not through DNA sting."
 	chemical_cost = 45
 	dna_cost = 1
-	req_dna = 5
+	req_absorbs = 3
 
 //Makes some spiderlings. Good for setting traps and causing general trouble.
 /obj/effect/proc_holder/changeling/spiders/sting_action(mob/user)


### PR DESCRIPTION
makes spiders power use it and lowers needed absorbs to 3 from 5

:cl: PKPenguin321
balance: The changeling "Spiders" power now requires absorptions gained through the actual Absorb ability, rather than DNA from DNA sting. To compensate, it now only requires 3 absorptions, down from 5. 
/:cl:

Thaw PR: https://github.com/tgstation/tgstation/pull/36581

I promised @improvedname I would do this in https://github.com/tgstation/tgstation/pull/35794 after https://github.com/tgstation/tgstation/pull/35394 got merged but then it died (RIP, somebody please fix it in the future).

Might make more abilities use this after I read through the forum thread that's up for lings right now