### PR TITLE
Fixes overlay update for washing bloody hands

### DIFF
--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -703,7 +703,6 @@
 		if(bloody_hands)
 			bloody_hands = 0
 			update_inv_gloves()
-	update_icons()	//apply the now updated overlays to the mob
 
 /mob/living/carbon/human/wash_cream()
 	if(creamed) //clean both to prevent a rare bug

--- a/code/modules/mob/living/carbon/human/update_icons.dm
+++ b/code/modules/mob/living/carbon/human/update_icons.dm
@@ -176,8 +176,7 @@ There are several things that need to be remembered:
 		var/obj/screen/inventory/inv = hud_used.inv_slots[slot_gloves]
 		inv.update_icon()
 
-	GET_COMPONENT(FR, /datum/component/forensics)
-	if(!gloves && FR && length(FR.blood_DNA))
+	if(!gloves && bloody_hands)
 		var/mutable_appearance/bloody_overlay = mutable_appearance('icons/effects/blood.dmi', "bloodyhands", -GLOVES_LAYER)
 		if(get_num_arms() < 2)
 			if(has_left_hand())


### PR DESCRIPTION
:cl:
fix: When you wash your bloody hands they will no longer still look bloody afterwards
/:cl:

On a separate note, the bloody_hands mechanic doesn't seem to be working aside from the zero/not-zero aspect.