### PR TITLE
Removes some duplicated code

### DIFF
--- a/code/game/turfs/simulated/floor/plating/asteroid.dm
+++ b/code/game/turfs/simulated/floor/plating/asteroid.dm
@@ -47,19 +47,6 @@
 				O.attackby(W,user)
 				return
 
-	if(istype(W, /obj/item/stack/tile))
-		var/obj/item/stack/tile/Z = W
-		if(!Z.use(1))
-			return
-		var/turf/open/floor/T = PlaceOnTop(Z.turf_type)
-		if(istype(Z, /obj/item/stack/tile/light)) //TODO: get rid of this ugly check somehow
-			var/obj/item/stack/tile/light/L = Z
-			var/turf/open/floor/light/F = T
-			F.state = L.state
-		playsound(src, 'sound/weapons/genhit.ogg', 50, 1)
-		return
-
-
 /turf/open/floor/plating/asteroid/singularity_act()
 	if(is_planet_level(z))
 		return ..()


### PR DESCRIPTION
:cl: ninjanomnom
fix: Tiles placed on lavaland turfs should behave properly again.
/:cl:

This exact same code is duplicated up the parent chain.

fixes #37097