### PR TITLE
[s] Adds a centcom level check to launchpad.

### DIFF
--- a/code/game/machinery/launch_pad.dm
+++ b/code/game/machinery/launch_pad.dm
@@ -56,6 +56,9 @@
 	if(teleporting)
 		to_chat(user, "<span class='warning'>ERROR: Launchpad busy.</span>")
 		return
+	if(is_centcom_level(loc.z))
+		to_chat(user, "<span class='warning'>ERROR: Launchpad not operative. Heavy area shielding makes teleporting impossible.</span>")
+		return
 
 	var/target_x = x + x_offset
 	var/target_y = y + y_offset

--- a/code/game/machinery/launch_pad.dm
+++ b/code/game/machinery/launch_pad.dm
@@ -56,7 +56,10 @@
 	if(teleporting)
 		to_chat(user, "<span class='warning'>ERROR: Launchpad busy.</span>")
 		return
-	if(is_centcom_level(loc.z))
+	
+	var/turf/dest = get_turf(src)
+
+	if(dest && is_centcom_level(dest.z))
 		to_chat(user, "<span class='warning'>ERROR: Launchpad not operative. Heavy area shielding makes teleporting impossible.</span>")
 		return
 
@@ -81,7 +84,6 @@
 	use_power(1000)
 
 	var/turf/source = target
-	var/turf/dest = get_turf(src)
 	var/list/log_msg = list()
 	log_msg += ": [key_name(user)] has teleported "
 


### PR DESCRIPTION
[Changelogs]: 
:cl: Dax Dupont
fix: Briefcase bluespace launch pads no longer work on the centcom Z level.
/:cl:

[why]: Fixes #37111
