### PR TITLE
Keeps SM shuttle shards from being unwrenched

### DIFF
--- a/code/modules/power/supermatter/supermatter.dm
+++ b/code/modules/power/supermatter/supermatter.dm
@@ -623,6 +623,7 @@ GLOBAL_DATUM(main_supermatter_engine, /obj/machinery/power/supermatter_crystal)
 /obj/machinery/power/supermatter_crystal/shard/hugbox
 	takes_damage = FALSE
 	produces_gas = FALSE
+	moveable = FALSE
 
 /obj/machinery/power/supermatter_crystal/proc/supermatter_pull(turf/center, pull_range = 10)
 	playsound(src.loc, 'sound/weapons/marauder.ogg', 100, 1, extrarange = 7)


### PR DESCRIPTION
An unintended side effect of #36991 is that you can unwrench the SM shuttle's hugbox shards (the big one in the middle is just a reskinned shard as well)

This lets you go on a merry dusting spree oof