### PR TITLE
Fixes Omega SM crystal oversight

### DIFF
--- a/_maps/map_files/OmegaStation/OmegaStation.dmm
+++ b/_maps/map_files/OmegaStation/OmegaStation.dmm
@@ -18988,8 +18988,9 @@
 /turf/open/floor/engine,
 /area/engine/engineering)
 "aOa" = (
-/obj/machinery/power/supermatter_crystal/engine{
-	anchored = 1
+/obj/machinery/power/supermatter_crystal/shard/engine{
+	anchored = 1;
+	moveable = 0
 	},
 /turf/open/floor/engine,
 /area/engine/supermatter)


### PR DESCRIPTION
:cl: Denton
tweak: Omegastation's supermatter crystal has been replaced with a smaller shard that doesn't destroy the whole station on explosion.
/:cl:

#36964 meant to replace Omega's SM crystal with a shard, closing the issue #36951. 
It wasn't included in the PR though, I assume that it's an oversight.

This PR replaces the crystal with a non-movable shard (can't unwrench it for obvious reasons).