### PR TITLE
Adds tesla coil cargo pack

### DIFF
--- a/code/modules/cargo/packs.dm
+++ b/code/modules/cargo/packs.dm
@@ -765,6 +765,17 @@
 	crate_name = "supermatter shard crate"
 	crate_type = /obj/structure/closet/crate/secure/engineering
 	dangerous = TRUE
+	
+/datum/supply_pack/engineering/engine/tesla_coils
+	name = "Tesla Coil Crate"
+	desc = "Whether it's high-voltage executions, creating research points, or just plain old power generation: This pack of four Tesla coils can do it all!"
+	cost = 2500
+	contains = list(/obj/machinery/power/tesla_coil,
+					/obj/machinery/power/tesla_coil,
+					/obj/machinery/power/tesla_coil,
+					/obj/machinery/power/tesla_coil)
+	crate_name = "tesla coil crate"
+	crate_type = /obj/structure/closet/crate/engineering/electrical
 
 /datum/supply_pack/engineering/engine/tesla_gen
 	name = "Tesla Generator Crate"


### PR DESCRIPTION
:cl: Denton
add: Cargo can now order tesla coil crates for 2500 credits.
/:cl:

Closes: #37129

My best guess is that cargo is too busy ordering nullcrates and emitters every round that nobody ever noticed how these are missing