### PR TITLE
Cleans up end of round robo report

### DIFF
--- a/code/__HELPERS/roundend.dm
+++ b/code/__HELPERS/roundend.dm
@@ -285,7 +285,7 @@
 			var/list/ded = SSblackbox.first_death
 			if(ded.len)
 				parts += "[GLOB.TAB]First Death: <b>[ded["name"]], [ded["role"]], at [ded["area"]]. Damage taken: [ded["damage"]].[ded["last_words"] ? " Their last words were: \"[ded["last_words"]]\"" : ""]</b>"
-			//fukken syntax parsing memes"
+			//ignore this comment, it fixes the broken sytax parsing caused by the " above
 			else
 				parts += "[GLOB.TAB]<i>Nobody died this shift!</i>"
 	return parts.Join("<br>")

--- a/code/__HELPERS/roundend.dm
+++ b/code/__HELPERS/roundend.dm
@@ -285,6 +285,7 @@
 			var/list/ded = SSblackbox.first_death
 			if(ded.len)
 				parts += "[GLOB.TAB]First Death: <b>[ded["name"]], [ded["role"]], at [ded["area"]]. Damage taken: [ded["damage"]].[ded["last_words"] ? " Their last words were: \"[ded["last_words"]]\"" : ""]</b>"
+			//fukken syntax parsing memes"
 			else
 				parts += "[GLOB.TAB]<i>Nobody died this shift!</i>"
 	return parts.Join("<br>")
@@ -342,31 +343,37 @@
 
 /datum/controller/subsystem/ticker/proc/law_report()
 	var/list/parts = list()
+	var/borg_spacer = FALSE //inserts an extra linebreak to seperate AIs from independent borgs, and then multiple independent borgs.
 	//Silicon laws report
 	for (var/i in GLOB.ai_list)
 		var/mob/living/silicon/ai/aiPlayer = i
 		if(aiPlayer.mind)
-			parts += "<b>[aiPlayer.name] (Played by: [aiPlayer.mind.key])'s laws [aiPlayer.stat != DEAD ? "at the end of the round" : "when it was deactivated"] were:</b>"
+			parts += "<b>[aiPlayer.name]</b> (Played by: <b>[aiPlayer.mind.key]</b>)'s laws [aiPlayer.stat != DEAD ? "at the end of the round" : "when it was <span class='redtext'>deactivated</span>"] were:"
 			parts += aiPlayer.laws.get_law_list(include_zeroth=TRUE)
 
 		parts += "<b>Total law changes: [aiPlayer.law_change_counter]</b>"
 
 		if (aiPlayer.connected_robots.len)
-			var/robolist = "<b>[aiPlayer.real_name]'s minions were:</b> "
+			var/borg_num = aiPlayer.connected_robots.len
+			var/robolist = "<br><b>[aiPlayer.real_name]</b>'s minions were: "
 			for(var/mob/living/silicon/robot/robo in aiPlayer.connected_robots)
+				borg_num--
 				if(robo.mind)
-					robolist += "[robo.name][robo.stat?" (Deactivated) (Played by: [robo.mind.key]), ":" (Played by: [robo.mind.key]), "]"
+					robolist += "<b>[robo.name]</b> (Played by: <b>[robo.mind.key]</b>)[robo.stat ? " <span class='redtext'>(Deactivated)</span>" : ""][borg_num ?", ":""]<br>"
 			parts += "[robolist]"
+		if(!borg_spacer)
+			borg_spacer = TRUE
 
 	for (var/mob/living/silicon/robot/robo in GLOB.silicon_mobs)
 		if (!robo.connected_ai && robo.mind)
-			if (robo.stat != DEAD)
-				parts += "<b>[robo.name] (Played by: [robo.mind.key]) survived as an AI-less borg! Its laws were:</b>"
-			else
-				parts += "<b>[robo.name] (Played by: [robo.mind.key]) was unable to survive the rigors of being a cyborg without an AI. Its laws were:</b>"
+			parts += "[borg_spacer?"<br>":""]<b>[robo.name]</b> (Played by: <b>[robo.mind.key]</b>) [(robo.stat != DEAD)? "<span class='greentext'>survived</span> as an AI-less borg!" : "was <span class='redtext'>unable to survive</span> the rigors of being a cyborg without an AI."] Its laws were:"
 
 			if(robo) //How the hell do we lose robo between here and the world messages directly above this?
 				parts += robo.laws.get_law_list(include_zeroth=TRUE)
+
+			if(!borg_spacer)
+				borg_spacer = TRUE
+
 	if(parts.len)
 		return "<div class='panel stationborder'>[parts.Join("<br>")]</div>"
 	else


### PR DESCRIPTION
Making it a little easier to read by inserting some linebreaks and bolding player names/ckeys instead of entire lines. Also cleaned up some rogue spacing and commas.

Old:
![old](https://user-images.githubusercontent.com/6209658/38638286-d2926f9a-3d9b-11e8-9af2-f97615189473.png)

new:
![new 2](https://user-images.githubusercontent.com/6209658/38638298-d5b1a63c-3d9b-11e8-93ec-0c277914f8cb.png)
![new 3](https://user-images.githubusercontent.com/6209658/38638299-d5bc9826-3d9b-11e8-9e1c-1945fc3aaa14.png)
![new 1](https://user-images.githubusercontent.com/6209658/38638300-d5cbf19a-3d9b-11e8-90ef-d077eb23474e.png)


also if anyone has any suggestions on how to indent the laws, that'd be cool too tbh.