### PR TITLE
Rounded the last digit of pi correctly

### DIFF
--- a/code/__DEFINES/maths.dm
+++ b/code/__DEFINES/maths.dm
@@ -4,7 +4,7 @@
 
 #define NUM_E 2.71828183
 
-#define PI						3.1415
+#define PI						3.1416
 #define INFINITY				1e31	//closer then enough
 
 #define SHORT_REAL_LIMIT 16777216


### PR DESCRIPTION
:cl: Putnam
tweak: rounded pi correctly
/:cl:

[why]: 

Pi being more accurate should help circles and related phenomena behave in ways more keeping with verisimilitude, aiding in the enjoyment of the game. 