### PR TITLE
Stops silicons looping through world every login looking for flippin runes

### DIFF
--- a/code/modules/mob/living/silicon/ai/login.dm
+++ b/code/modules/mob/living/silicon/ai/login.dm
@@ -1,10 +1,5 @@
 /mob/living/silicon/ai/Login()
 	..()
-	for(var/obj/effect/rune/rune in world)
-		var/image/blood = image(loc = rune)
-		blood.override = 1
-		client.images += blood
-
 	if(stat != DEAD)
 		for(var/obj/machinery/ai_status_display/O in GLOB.ai_status_displays) //change status
 			O.mode = 1


### PR DESCRIPTION
It literally is already done on the rune's initialize (as it should be).

https://github.com/tgstation/tgstation/blob/f300a5c155c6bc69fd2a158bc1f79dca2b7ce6d8/code/modules/antagonists/cult/runes.dm#L41-L47

TY @george99g 