### PR TITLE
Changes ntnet address assignment from numerical ascending to 16 hexadecimal randomized seeded (in English, everything is now randomized instead of predictable)

### DIFF
--- a/code/controllers/subsystem/processing/networks.dm
+++ b/code/controllers/subsystem/processing/networks.dm
@@ -42,7 +42,7 @@ PROCESSING_SUBSYSTEM_DEF(networks)
 
 /datum/controller/subsystem/processing/networks/proc/make_address(string)
 	if(!string)
-		return resolve_collisions? make_address("[num2text(rand(HID_RESTRICTED_END, 999999999999), 12)]"):.
+		return resolve_collisions? make_address("[num2text(rand(HID_RESTRICTED_END, 999999999999), 12)]"):null
 	var/hex = md5(string)
 	if(!hex)
 		return		//errored

--- a/code/controllers/subsystem/processing/networks.dm
+++ b/code/controllers/subsystem/processing/networks.dm
@@ -9,6 +9,7 @@ PROCESSING_SUBSYSTEM_DEF(networks)
 	var/assignment_hardware_id = HID_RESTRICTED_END
 	var/list/networks_by_id = list()				//id = network
 	var/list/interfaces_by_id = list()				//hardware id = component interface
+	var/resolve_collisions = TRUE
 
 /datum/controller/subsystem/processing/networks/Initialize()
 	station_network = new
@@ -34,3 +35,21 @@ PROCESSING_SUBSYSTEM_DEF(networks)
 /datum/controller/subsystem/processing/networks/proc/unregister_interface(datum/component/ntnet_interface/D)
 	interfaces_by_id -= D.hardware_id
 	return TRUE
+
+/datum/controller/subsystem/processing/networks/proc/get_next_HID()
+	var/string = "[num2text(assignment_hardware_id++, 12)]"
+	return make_address(string)
+
+/datum/controller/subsystem/processing/networks/proc/make_address(string)
+	if(!string)
+		return resolve_collisions? make_address("[num2text(rand(HID_RESTRICTED_END, 999999999999), 12)]"):.
+	var/hex = copytext(md5(string),1,25)
+	if(!hex)
+		return		//errored
+	var/addr_1 = copytext(hex,1,5)
+	var/addr_2 = copytext(hex,5,9)
+	var/addr_3 = copytext(hex,9,13)
+	var/addr_4 = copytext(hex,13,17)
+	. = "fc00:[addr_1]:[addr_2]:[addr_3]:[addr_4]"
+	if(interfaces_by_id[.])
+		return resolve_collisions? make_address("[num2text(rand(HID_RESTRICTED_END, 999999999999), 12)]"):null

--- a/code/controllers/subsystem/processing/networks.dm
+++ b/code/controllers/subsystem/processing/networks.dm
@@ -50,6 +50,6 @@ PROCESSING_SUBSYSTEM_DEF(networks)
 	var/addr_2 = copytext(hex,5,9)
 	var/addr_3 = copytext(hex,9,13)
 	var/addr_4 = copytext(hex,13,17)
-	. = "fc00:[addr_1]:[addr_2]:[addr_3]:[addr_4]"
+	. = "[addr_1]:[addr_2]:[addr_3]:[addr_4]"
 	if(interfaces_by_id[.])
 		return resolve_collisions? make_address("[num2text(rand(HID_RESTRICTED_END, 999999999999), 12)]"):null

--- a/code/controllers/subsystem/processing/networks.dm
+++ b/code/controllers/subsystem/processing/networks.dm
@@ -43,13 +43,9 @@ PROCESSING_SUBSYSTEM_DEF(networks)
 /datum/controller/subsystem/processing/networks/proc/make_address(string)
 	if(!string)
 		return resolve_collisions? make_address("[num2text(rand(HID_RESTRICTED_END, 999999999999), 12)]"):.
-	var/hex = copytext(md5(string),1,25)
+	var/hex = md5(string)
 	if(!hex)
 		return		//errored
-	var/addr_1 = copytext(hex,1,5)
-	var/addr_2 = copytext(hex,5,9)
-	var/addr_3 = copytext(hex,9,13)
-	var/addr_4 = copytext(hex,13,17)
-	. = "[addr_1]:[addr_2]:[addr_3]:[addr_4]"
+	. = "[copytext(hex, 1, 9)]"		//16 ^ 8 possibilities I think.
 	if(interfaces_by_id[.])
 		return resolve_collisions? make_address("[num2text(rand(HID_RESTRICTED_END, 999999999999), 12)]"):null

--- a/code/datums/components/ntnet_interface.dm
+++ b/code/datums/components/ntnet_interface.dm
@@ -13,11 +13,8 @@
 	var/network_name = ""			//text
 	var/list/networks_connected_by_id = list()		//id = datum/ntnet
 
-/datum/component/ntnet_interface/Initialize(force_ID, force_name = "NTNet Device", autoconnect_station_network = TRUE)			//Don't force ID unless you know what you're doing!
-	if(!force_ID)
-		hardware_id = "[SSnetworks.assignment_hardware_id++]"
-	else
-		hardware_id = force_ID
+/datum/component/ntnet_interface/Initialize(force_name = "NTNet Device", autoconnect_station_network = TRUE)			//Don't force ID unless you know what you're doing!
+	hardware_id = "[SSnetworks.get_next_HID()]"
 	network_name = force_name
 	SSnetworks.register_interface(src)
 	if(autoconnect_station_network)


### PR DESCRIPTION
Yes, I know there's a freeze.
This changes how network IDs are assigned
This way it's quite a bit harder (as you'll have to bruteforce 16 ^ 16 addresses instead of pinging ~800) to mass send via NTNet, including being able to with a single click open/close/bolt/unbolt/emergency access/any combination of the above every single door in the game, including those on CentCom Zlevel.
And yes, this will ruin circuitry being able to mass-broadcast to every device for messaging purposes, but the other PR will address it.
:cl:
rscadd: After a severe security breach occurred due to lazily configured Nanotrasen Network DHCP servers where attackers were able to hijack every airlock connected to the Nanotrasen Intranet, the Central Command engineering team reports that they have properly configured network address servers to give out (relatively) secure network IDs again. [NTNet addresses reverted to 16-hex format. they will now be randomized across a ~billion trillion possibilities instead of being 1-1000 every round for doors and stuff.]
/:cl: