### PR TITLE
Fixes imps all having the same name

### DIFF
--- a/code/modules/antagonists/devil/imp/imp.dm
+++ b/code/modules/antagonists/devil/imp/imp.dm
@@ -3,6 +3,7 @@
 /mob/living/simple_animal/imp
 	name = "imp"
 	real_name = "imp"
+	unique_name = 1
 	desc = "A large, menacing creature covered in armored black scales."
 	speak_emote = list("cackles")
 	emote_hear = list("cackles","screeches")

--- a/code/modules/antagonists/devil/imp/imp.dm
+++ b/code/modules/antagonists/devil/imp/imp.dm
@@ -3,7 +3,7 @@
 /mob/living/simple_animal/imp
 	name = "imp"
 	real_name = "imp"
-	unique_name = 1
+	unique_name = TRUE
 	desc = "A large, menacing creature covered in armored black scales."
 	speak_emote = list("cackles")
 	emote_hear = list("cackles","screeches")


### PR DESCRIPTION
Fixes #37045 
Gives imps unique identifiers (eg. "imp (123)" as opposed to "imp")