### PR TITLE
Revert "Forcing the human liver to actually do its job v2"

### DIFF
--- a/code/modules/surgery/organs/liver.dm
+++ b/code/modules/surgery/organs/liver.dm
@@ -28,16 +28,13 @@
 			if(filterToxins)
 				//handle liver toxin filtration
 				var/toxamount
-				var/static/list/toxinstypecache = typecacheof(/datum/reagent/toxin)
-				for(var/I in C.reagents.reagent_list)
-					var/datum/reagent/pickedreagent = I
-					if(is_type_in_typecache(pickedreagent, toxinstypecache))
-						toxamount += C.reagents.get_reagent_amount(initial(pickedreagent.id))
+				var/static/list/listOfToxinsInThisBitch = typesof(/datum/reagent/toxin)
+				for(var/datum/reagent/toxin/toxin in listOfToxinsInThisBitch)
+					toxamount += C.reagents.get_reagent_amount(initial(toxin.id))
+
 				if(toxamount <= toxTolerance && toxamount > 0)
-					for(var/I in C.reagents.reagent_list)
-						var/datum/reagent/pickedreagent = I
-						if(is_type_in_typecache(pickedreagent, toxinstypecache))
-							C.reagents.remove_reagent(initial(pickedreagent.id), 1)
+					for(var/datum/reagent/toxin/toxin in listOfToxinsInThisBitch)
+						C.reagents.remove_reagent(initial(toxin.id), 1)
 				else if(toxamount > toxTolerance)
 					damage += toxamount*toxLethality
 


### PR DESCRIPTION
#37032 makes toxins cause liver failure. 
I assume it hasn't been tested, since ANY toxins, even the non-damaging or super low potency ones, will cause it now.

Examples:
1) Sleepypens straight up murder people
2) Peacekeeper borg dizzying/tiring solution quickly give people liver failure and kill them
3) TOXINLOVER species receive liver failure the same way, even though they're supposed to be immune to toxin damage
4) Another example: Mindbreaker toxin also causes liver failure.

This needs to be done differently, maybe go by ToxLoss received instead of just having toxins in your system.

Closes: #37164