### PR TITLE
Removes /related area variable.

### DIFF
--- a/code/__HELPERS/areas.dm
+++ b/code/__HELPERS/areas.dm
@@ -83,15 +83,12 @@
 		newA.contents += thing
 		thing.change_area(old_area, newA)
 
-	var/list/related_areas = oldA.related
-	for(var/i in 1 to related_areas.len)
-		var/area/place = related_areas[i]
-		var/list/firedoors = place.firedoors
-		if(!LAZYLEN(firedoors))
-			continue
-		for(var/k in 1 to firedoors.len)
-			var/obj/machinery/door/firedoor/FD = firedoors[k]
-			FD.CalculateAffectingAreas()
+	var/list/firedoors = oldA.firedoors
+	if(!LAZYLEN(firedoors))
+		continue
+	for(var/k in 1 to firedoors.len)
+		var/obj/machinery/door/firedoor/FD = firedoors[k]
+		FD.CalculateAffectingAreas()
 
 	to_chat(creator, "<span class='notice'>You have created a new area, named [newA.name]. It is now weather proof, and constructing an APC will allow it to be powered.</span>")
 	return TRUE

--- a/code/__HELPERS/areas.dm
+++ b/code/__HELPERS/areas.dm
@@ -84,10 +84,8 @@
 		thing.change_area(old_area, newA)
 
 	var/list/firedoors = oldA.firedoors
-	if(!LAZYLEN(firedoors))
-		continue
-	for(var/k in 1 to firedoors.len)
-		var/obj/machinery/door/firedoor/FD = firedoors[k]
+	for(var/door in firedoors)
+		var/obj/machinery/door/firedoor/FD = door
 		FD.CalculateAffectingAreas()
 
 	to_chat(creator, "<span class='notice'>You have created a new area, named [newA.name]. It is now weather proof, and constructing an APC will allow it to be powered.</span>")

--- a/code/game/area/areas.dm
+++ b/code/game/area/areas.dm
@@ -52,7 +52,6 @@
 	var/safe = FALSE 				//Is the area teleport-safe: no space / radiation / aggresive mobs / other dangers
 
 	var/no_air = null
-	var/list/related			// the other areas of the same type as this
 
 	var/parallax_movedir = 0
 
@@ -88,18 +87,11 @@ GLOBAL_LIST_EMPTY(teleportlocs)
 // ===
 
 
-// Added to fix mech fabs 05/2013 ~Sayu
-// This is necessary due to lighting subareas.  If you were to go in assuming that things in
-// the same logical /area have the parent /area object... well, you would be mistaken.  If you
-// want to find machines, mobs, etc, in the same logical area, you will need to check all the
-// related areas.  This returns a master contents list to assist in that.
+//Not so necessary wrapper.
 /proc/area_contents(area/A)
 	if(!istype(A))
 		return null
-	var/list/contents = list()
-	for(var/area/LSA in A.related)
-		contents += LSA.contents
-	return contents
+	return A.contents
 
 
 
@@ -108,7 +100,6 @@ GLOBAL_LIST_EMPTY(teleportlocs)
 	icon_state = ""
 	layer = AREA_LAYER
 	uid = ++global_uid
-	related = list(src)
 	map_name = name // Save the initial (the name set in the map) name of the area.
 	canSmoothWithAreas = typecacheof(canSmoothWithAreas)
 
@@ -195,11 +186,6 @@ GLOBAL_LIST_EMPTY(teleportlocs)
 /area/proc/atmosalert(danger_level, obj/source)
 	if(danger_level != atmosalm)
 		if (danger_level==2)
-			var/list/cameras = list()
-			for(var/area/RA in related)
-				for (var/item in RA.cameras)
-					var/obj/machinery/camera/C = item
-					cameras += C
 
 			for (var/item in GLOB.silicon_mobs)
 				var/mob/living/silicon/aiPlayer = item
@@ -254,18 +240,12 @@ GLOBAL_LIST_EMPTY(teleportlocs)
 	if(always_unpowered == 1) //no fire alarms in space/asteroid
 		return
 
-	var/list/cameras = list()
-
-	for(var/area/RA in related)
-		if (!( RA.fire ))
-			RA.set_fire_alarm_effect()
-			RA.ModifyFiredoors(FALSE)
-			for(var/item in RA.firealarms)
-				var/obj/machinery/firealarm/F = item
-				F.update_icon()
-		for (var/item in RA.cameras)
-			var/obj/machinery/camera/C = item
-			cameras += C
+	if (!fire)
+		set_fire_alarm_effect()
+		ModifyFiredoors(FALSE)
+		for(var/item in firealarms)
+			var/obj/machinery/firealarm/F = item
+			F.update_icon()
 
 	for (var/item in GLOB.alert_consoles)
 		var/obj/machinery/computer/station_alert/a = item
@@ -283,15 +263,14 @@ GLOBAL_LIST_EMPTY(teleportlocs)
 	START_PROCESSING(SSobj, src)
 
 /area/proc/firereset(obj/source)
-	for(var/area/RA in related)
-		if (RA.fire)
-			RA.fire = 0
-			RA.mouse_opacity = MOUSE_OPACITY_TRANSPARENT
-			RA.updateicon()
-			RA.ModifyFiredoors(TRUE)
-			for(var/item in RA.firealarms)
-				var/obj/machinery/firealarm/F = item
-				F.update_icon()
+	if (fire)
+		fire = 0
+		mouse_opacity = MOUSE_OPACITY_TRANSPARENT
+		updateicon()
+		ModifyFiredoors(TRUE)
+		for(var/item in firealarms)
+			var/obj/machinery/firealarm/F = item
+			F.update_icon()
 
 	for (var/item in GLOB.silicon_mobs)
 		var/mob/living/silicon/aiPlayer = item
@@ -310,8 +289,7 @@ GLOBAL_LIST_EMPTY(teleportlocs)
 
 /area/process()
 	if(firedoors_last_closed_on + 100 < world.time)	//every 10 seconds
-		for(var/area/RA in related)
-			RA.ModifyFiredoors(FALSE)
+		ModifyFiredoors(FALSE)
 
 /area/proc/close_and_lock_door(obj/machinery/door/DOOR)
 	set waitfor = FALSE
@@ -323,17 +301,11 @@ GLOBAL_LIST_EMPTY(teleportlocs)
 	if(always_unpowered == 1) //no burglar alarms in space/asteroid
 		return
 
-	var/list/cameras = list()
-
-	for(var/area/RA in related)
-		//Trigger alarm effect
-		RA.set_fire_alarm_effect()
-		//Lockdown airlocks
-		for(var/obj/machinery/door/DOOR in RA)
-			close_and_lock_door(DOOR)
-		for (var/item in RA.cameras)
-			var/obj/machinery/camera/C = item
-			cameras += C
+	//Trigger alarm effect
+	set_fire_alarm_effect()
+	//Lockdown airlocks
+	for(var/obj/machinery/door/DOOR in src)
+		close_and_lock_door(DOOR)
 
 	for (var/i in GLOB.silicon_mobs)
 		var/mob/living/silicon/SILICON = i
@@ -429,10 +401,9 @@ GLOBAL_LIST_EMPTY(teleportlocs)
 // called when power status changes
 
 /area/proc/power_change()
-	for(var/area/RA in related)
-		for(var/obj/machinery/M in RA)	// for each machine in the area
-			M.power_change()				// reverify power status (to update icons etc.)
-		RA.updateicon()
+	for(var/obj/machinery/M in src)	// for each machine in the area
+		M.power_change()				// reverify power status (to update icons etc.)
+	updateicon()
 
 /area/proc/usage(chan)
 	var/used = 0

--- a/code/game/area/areas.dm
+++ b/code/game/area/areas.dm
@@ -87,15 +87,6 @@ GLOBAL_LIST_EMPTY(teleportlocs)
 // ===
 
 
-//Not so necessary wrapper.
-/proc/area_contents(area/A)
-	if(!istype(A))
-		return null
-	return A.contents
-
-
-
-
 /area/Initialize()
 	icon_state = ""
 	layer = AREA_LAYER

--- a/code/game/machinery/firealarm.dm
+++ b/code/game/machinery/firealarm.dm
@@ -287,9 +287,7 @@
 	A = A.loc
 	if (!( istype(A, /area) ))
 		return
-	for(var/area/RA in A.related)
-		RA.partyreset()
-	return
+	A.partyreset()
 
 /obj/machinery/firealarm/partyalarm/alarm()
 	if (stat & (NOPOWER|BROKEN))
@@ -298,9 +296,7 @@
 	A = A.loc
 	if (!( istype(A, /area) ))
 		return
-	for(var/area/RA in A.related)
-		RA.partyalert()
-	return
+	A.partyalert()
 
 /obj/machinery/firealarm/partyalarm/ui_data(mob/user)
 	. = ..()

--- a/code/game/machinery/hologram.dm
+++ b/code/game/machinery/hologram.dm
@@ -487,7 +487,7 @@ For the other part of the code, check silicon say.dm. Particularly robot talk.*/
 /obj/machinery/holopad/proc/move_hologram(mob/living/user, turf/new_turf)
 	if(LAZYLEN(masters) && masters[user])
 		var/area/holo_area = get_area(src)
-		if(new_turf.loc in holo_area.related)
+		if(new_turf.loc == holo_area)
 			var/obj/effect/overlay/holo_pad_hologram/holo = masters[user]
 			step_to(holo, new_turf)
 			holo.forceMove(new_turf)

--- a/code/game/machinery/lightswitch.dm
+++ b/code/game/machinery/lightswitch.dm
@@ -41,13 +41,12 @@
 	. = ..()
 	on = !on
 
-	for(var/area/A in area.related)
-		A.lightswitch = on
-		A.updateicon()
+	area.lightswitch = on
+	area.updateicon()
 
-		for(var/obj/machinery/light_switch/L in A)
-			L.on = on
-			L.updateicon()
+	for(var/obj/machinery/light_switch/L in area)
+		L.on = on
+		L.updateicon()
 
 	area.power_change()
 

--- a/code/game/objects/items/blueprints.dm
+++ b/code/game/objects/items/blueprints.dm
@@ -193,12 +193,11 @@
 		to_chat(usr, "<span class='warning'>The given name is too long.  The area's name is unchanged.</span>")
 		return
 	set_area_machinery_title(A,str,prevname)
-	for(var/area/RA in A.related)
-		RA.name = str
-		if(RA.firedoors)
-			for(var/D in RA.firedoors)
-				var/obj/machinery/door/firedoor/FD = D
-				FD.CalculateAffectingAreas()
+	A.name = str
+	if(A.firedoors)
+		for(var/D in A.firedoors)
+			var/obj/machinery/door/firedoor/FD = D
+			FD.CalculateAffectingAreas()
 	to_chat(usr, "<span class='notice'>You rename the '[prevname]' to '[str]'.</span>")
 	log_game("[key_name(usr)] has renamed [prevname] to [str]")
 	A.update_areasize()
@@ -209,17 +208,16 @@
 /obj/item/areaeditor/proc/set_area_machinery_title(area/A,title,oldtitle)
 	if(!oldtitle) // or replacetext goes to infinite loop
 		return
-	for(var/area/RA in A.related)
-		for(var/obj/machinery/airalarm/M in RA)
-			M.name = replacetext(M.name,oldtitle,title)
-		for(var/obj/machinery/power/apc/M in RA)
-			M.name = replacetext(M.name,oldtitle,title)
-		for(var/obj/machinery/atmospherics/components/unary/vent_scrubber/M in RA)
-			M.name = replacetext(M.name,oldtitle,title)
-		for(var/obj/machinery/atmospherics/components/unary/vent_pump/M in RA)
-			M.name = replacetext(M.name,oldtitle,title)
-		for(var/obj/machinery/door/M in RA)
-			M.name = replacetext(M.name,oldtitle,title)
+	for(var/obj/machinery/airalarm/M in A)
+		M.name = replacetext(M.name,oldtitle,title)
+	for(var/obj/machinery/power/apc/M in A)
+		M.name = replacetext(M.name,oldtitle,title)
+	for(var/obj/machinery/atmospherics/components/unary/vent_scrubber/M in A)
+		M.name = replacetext(M.name,oldtitle,title)
+	for(var/obj/machinery/atmospherics/components/unary/vent_pump/M in A)
+		M.name = replacetext(M.name,oldtitle,title)
+	for(var/obj/machinery/door/M in A)
+		M.name = replacetext(M.name,oldtitle,title)
 	//TODO: much much more. Unnamed airlocks, cameras, etc.
 
 //Blueprint Subtypes

--- a/code/modules/admin/verbs/adminjump.dm
+++ b/code/modules/admin/verbs/adminjump.dm
@@ -10,11 +10,10 @@
 		return
 
 	var/list/turfs = list()
-	for(var/area/Ar in A.related)
-		for(var/turf/T in Ar)
-			if(T.density)
-				continue
-			turfs.Add(T)
+	for(var/turf/T in A)
+		if(T.density)
+			continue
+		turfs.Add(T)
 
 	var/turf/T = safepick(turfs)
 	if(!T)

--- a/code/modules/atmospherics/machinery/airalarm.dm
+++ b/code/modules/atmospherics/machinery/airalarm.dm
@@ -643,10 +643,9 @@
 	var/area/A = get_area(src)
 
 	var/new_area_danger_level = 0
-	for(var/area/R in A.related)
-		for(var/obj/machinery/airalarm/AA in R)
-			if (!(AA.stat & (NOPOWER|BROKEN)) && !AA.shorted)
-				new_area_danger_level = max(new_area_danger_level,AA.danger_level)
+	for(var/obj/machinery/airalarm/AA in A)
+		if (!(AA.stat & (NOPOWER|BROKEN)) && !AA.shorted)
+			new_area_danger_level = max(new_area_danger_level,AA.danger_level)
 	if(A.atmosalert(new_area_danger_level,src)) //if area was in normal state or if area was in alert state
 		post_alert(new_area_danger_level)
 

--- a/code/modules/lighting/lighting_area.dm
+++ b/code/modules/lighting/lighting_area.dm
@@ -10,13 +10,13 @@
 
 	if (IS_DYNAMIC_LIGHTING(src))
 		cut_overlay(/obj/effect/fullbright)
-		for (var/turf/T in area_contents(src))
+		for (var/turf/T in src)
 			if (IS_DYNAMIC_LIGHTING(T))
 				T.lighting_build_overlay()
 
 	else
 		add_overlay(/obj/effect/fullbright)
-		for (var/turf/T in area_contents(src))
+		for (var/turf/T in src)
 			if (T.lighting_object)
 				T.lighting_clear_overlay()
 

--- a/code/modules/mob/living/silicon/ai/life.dm
+++ b/code/modules/mob/living/silicon/ai/life.dm
@@ -121,11 +121,10 @@
 		T = get_turf(src)
 		AIarea = get_area(src)
 		if(AIarea)
-			for(var/area/A in AIarea.related)
-				for (var/obj/machinery/power/apc/APC in A)
-					if (!(APC.stat & BROKEN))
-						theAPC = APC
-						break
+			for (var/obj/machinery/power/apc/APC in AIarea)
+				if (!(APC.stat & BROKEN))
+					theAPC = APC
+					break
 		if (!theAPC)
 			switch(PRP)
 				if(1)

--- a/code/modules/power/apc.dm
+++ b/code/modules/power/apc.dm
@@ -911,12 +911,11 @@
 			update()
 		if("emergency_lighting")
 			emergency_lights = !emergency_lights
-			for(var/area/A in area.related)
-				for(var/obj/machinery/light/L in A)
-					if(!initial(L.no_emergency)) //If there was an override set on creation, keep that override
-						L.no_emergency = emergency_lights
-						INVOKE_ASYNC(L, /obj/machinery/light/.proc/update, FALSE)
-					CHECK_TICK
+			for(var/obj/machinery/light/L in area)
+				if(!initial(L.no_emergency)) //If there was an override set on creation, keep that override
+					L.no_emergency = emergency_lights
+					INVOKE_ASYNC(L, /obj/machinery/light/.proc/update, FALSE)
+				CHECK_TICK
 	return 1
 
 /obj/machinery/power/apc/proc/toggle_breaker()
@@ -1281,12 +1280,11 @@
 		INVOKE_ASYNC(src, .proc/break_lights)
 
 /obj/machinery/power/apc/proc/break_lights()
-	for(var/area/A in area.related)
-		for(var/obj/machinery/light/L in A)
-			L.on = TRUE
-			L.break_light_tube()
-			L.on = FALSE
-			stoplag()
+	for(var/obj/machinery/light/L in area)
+		L.on = TRUE
+		L.break_light_tube()
+		L.on = FALSE
+		stoplag()
 
 /obj/machinery/power/apc/proc/shock(mob/user, prb)
 	if(!prob(prb))
@@ -1322,12 +1320,11 @@
 /obj/machinery/power/apc/proc/set_nightshift(on)
 	set waitfor = FALSE
 	nightshift_lights = on
-	for(var/area/A in area.related)
-		for(var/obj/machinery/light/L in A)
-			if(L.nightshift_allowed)
-				L.nightshift_enabled = nightshift_lights
-				L.update(FALSE)
-			CHECK_TICK
+	for(var/obj/machinery/light/L in area)
+		if(L.nightshift_allowed)
+			L.nightshift_enabled = nightshift_lights
+			L.update(FALSE)
+		CHECK_TICK
 
 #undef UPSTATE_CELL_IN
 #undef UPSTATE_OPENED1


### PR DESCRIPTION
We're not using multiple area instances for anything (that i know of) right now, and the variable wasn't even tracking properly.