### PR TITLE
Liver fixes

### DIFF
--- a/code/modules/reagents/chemistry/reagents/other_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/other_reagents.dm
@@ -1817,12 +1817,6 @@
 		L.remove_trait(TRAIT_PACIFISM, id)
 	..()
 
-/datum/reagent/pax/borg
-	name = "synth-pax"
-	id = "synthpax"
-	description = "A colorless liquid that suppresses violence on the subjects. Cheaper to synthetize, but wears out faster than normal Pax."
-	metabolization_rate = 1.5 * REAGENTS_METABOLISM
-
 /datum/reagent/bz_metabolites
 	name = "BZ metabolites"
 	id = "bz_metabolites"
@@ -1845,3 +1839,40 @@
 		if(changeling)
 			changeling.chem_charges = max(changeling.chem_charges-2, 0)
 	return ..()
+
+/datum/reagent/pax/peaceborg
+	name = "synth-pax"
+	id = "synthpax"
+	description = "A colorless liquid that suppresses violence on the subjects. Cheaper to synthetize, but wears out faster than normal Pax."
+	metabolization_rate = 1.5 * REAGENTS_METABOLISM
+
+/datum/reagent/peaceborg/confuse
+	name = "Dizzying Solution"
+	id = "dizzysolution"
+	description = "Makes the target off balance and dizzy"
+	metabolization_rate = 1.5 * REAGENTS_METABOLISM
+	taste_description = "dizziness"
+
+/datum/reagent/peaceborg/confuse/on_mob_life(mob/living/M)
+	if(M.confused < 6)
+		M.confused = CLAMP(M.confused + 3, 0, 5)
+	if(M.dizziness < 6)
+		M.dizziness = CLAMP(M.dizziness + 3, 0, 5)
+	if(prob(20))
+		to_chat(M, "You feel confused and disorientated.")
+	..()
+
+/datum/reagent/peaceborg/tire
+	name = "Tiring Solution"
+	id = "tiresolution"
+	description = "An extremely weak stamina-toxin that tires out the target. Completely harmless."
+	metabolization_rate = 1.5 * REAGENTS_METABOLISM
+	taste_description = "tiredness"
+
+/datum/reagent/peaceborg/tire/on_mob_life(mob/living/M)
+	var/healthcomp = (100 - M.health)	//DOES NOT ACCOUNT FOR ADMINBUS THINGS THAT MAKE YOU HAVE MORE THAN 200/210 HEALTH, OR SOMETHING OTHER THAN A HUMAN PROCESSING THIS.
+	if(M.getStaminaLoss() < (45 - healthcomp))	//At 50 health you would have 200 - 150 health meaning 50 compensation. 60 - 50 = 10, so would only do 10-19 stamina.)
+		M.adjustStaminaLoss(10)
+	if(prob(30))
+		to_chat(M, "You should sit down and take a rest...")
+	..()

--- a/code/modules/reagents/chemistry/reagents/toxin_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/toxin_reagents.dm
@@ -845,39 +845,6 @@
 	. = 1
 	..()
 
-/datum/reagent/toxin/peaceborg/confuse
-	name = "Dizzying Solution"
-	id = "dizzysolution"
-	description = "Makes the target off balance and dizzy"
-	toxpwr = 0
-	metabolization_rate = 1.5 * REAGENTS_METABOLISM
-	taste_description = "dizziness"
-
-/datum/reagent/toxin/peaceborg/confuse/on_mob_life(mob/living/M)
-	if(M.confused < 6)
-		M.confused = CLAMP(M.confused + 3, 0, 5)
-	if(M.dizziness < 6)
-		M.dizziness = CLAMP(M.dizziness + 3, 0, 5)
-	if(prob(20))
-		to_chat(M, "You feel confused and disorientated.")
-	..()
-
-/datum/reagent/toxin/peaceborg/tire
-	name = "Tiring Solution"
-	id = "tiresolution"
-	description = "An extremely weak stamina-toxin that tires out the target. Completely harmless."
-	toxpwr = 0
-	metabolization_rate = 1.5 * REAGENTS_METABOLISM
-	taste_description = "tiredness"
-
-/datum/reagent/toxin/peaceborg/tire/on_mob_life(mob/living/M)
-	var/healthcomp = (100 - M.health)	//DOES NOT ACCOUNT FOR ADMINBUS THINGS THAT MAKE YOU HAVE MORE THAN 200/210 HEALTH, OR SOMETHING OTHER THAN A HUMAN PROCESSING THIS.
-	if(M.getStaminaLoss() < (45 - healthcomp))	//At 50 health you would have 200 - 150 health meaning 50 compensation. 60 - 50 = 10, so would only do 10-19 stamina.)
-		M.adjustStaminaLoss(10)
-	if(prob(30))
-		to_chat(M, "You should sit down and take a rest...")
-	..()
-
 /datum/reagent/toxin/delayed
 	name = "Toxin Microcapsules"
 	id = "delayed_toxin"

--- a/code/modules/surgery/organs/liver.dm
+++ b/code/modules/surgery/organs/liver.dm
@@ -1,6 +1,6 @@
 #define LIVER_DEFAULT_HEALTH 100 //amount of damage required for liver failure
 #define LIVER_DEFAULT_TOX_TOLERANCE 3 //amount of toxins the liver can filter out
-#define LIVER_DEFAULT_TOX_LETHALITY 0.02 //lower values lower how harmful toxins are to the liver
+#define LIVER_DEFAULT_TOX_LETHALITY 0.01 //lower values lower how harmful toxins are to the liver
 
 /obj/item/organ/liver
 	name = "liver"

--- a/code/modules/surgery/organs/liver.dm
+++ b/code/modules/surgery/organs/liver.dm
@@ -27,20 +27,15 @@
 
 			if(filterToxins && !owner.has_trait(TRAIT_TOXINLOVER))
 				//handle liver toxin filtration
-				var/toxamount
 				var/static/list/toxinstypecache = typecacheof(/datum/reagent/toxin)
 				for(var/I in C.reagents.reagent_list)
 					var/datum/reagent/pickedreagent = I
 					if(is_type_in_typecache(pickedreagent, toxinstypecache))
-						toxamount += C.reagents.get_reagent_amount(initial(pickedreagent.id))
-				if(toxamount <= toxTolerance && toxamount > 0)
-					for(var/I in C.reagents.reagent_list)
-						var/datum/reagent/pickedreagent = I
-						if(is_type_in_typecache(pickedreagent, toxinstypecache))
+						var/thisamount = C.reagents.get_reagent_amount(initial(pickedreagent.id))
+						if (thisamount <= toxTolerance && thisamount)
 							C.reagents.remove_reagent(initial(pickedreagent.id), 1)
-				else if(toxamount > toxTolerance)
-					damage += toxamount*toxLethality
-
+						else
+							damage += (thisamount*toxLethality)
 
 			//metabolize reagents
 			C.reagents.metabolize(C, can_overdose=TRUE)
@@ -80,7 +75,7 @@
 	alcohol_tolerance = 0.001
 	maxHealth = 200 //double the health of a normal liver
 	toxTolerance = 15 //can shrug off up to 15u of toxins
-	toxLethality = 0.3 //20% less damage than a normal liver
+	toxLethality = 0.008 //20% less damage than a normal liver
 
 /obj/item/organ/liver/cybernetic/emp_act(severity)
 	switch(severity)

--- a/code/modules/surgery/organs/liver.dm
+++ b/code/modules/surgery/organs/liver.dm
@@ -1,6 +1,6 @@
 #define LIVER_DEFAULT_HEALTH 100 //amount of damage required for liver failure
 #define LIVER_DEFAULT_TOX_TOLERANCE 3 //amount of toxins the liver can filter out
-#define LIVER_DEFAULT_TOX_LETHALITY 0.5 //lower values lower how harmful toxins are to the liver
+#define LIVER_DEFAULT_TOX_LETHALITY 0.02 //lower values lower how harmful toxins are to the liver
 
 /obj/item/organ/liver
 	name = "liver"
@@ -25,7 +25,7 @@
 			//slowly heal liver damage
 			damage = max(0, damage - 0.1)
 
-			if(filterToxins)
+			if(filterToxins && !owner.has_trait(TRAIT_TOXINLOVER))
 				//handle liver toxin filtration
 				var/toxamount
 				var/static/list/toxinstypecache = typecacheof(/datum/reagent/toxin)


### PR DESCRIPTION
[Changelogs]: 
:cl: Dax Dupont & Naksu
fix: Toxin loving species won't take liver damage from toxins.
fix: Liver now gets 0.01 damage per unit of toxin subtype reagent every 2 seconds instead of 0.5. IE 30 units of whatever won't kill you within 10 seconds anymore.
fix: Moved peacekeeper borg reagents to other_reagents so they don't do liver damage and they aren't really toxins
refactor: Renamed borg synthpax path to be more inline and put them next to the other borg reagents.
/:cl:

[why]: These might be balance instead, but I doubt killing people in 10 seconds because they have 30u of mutetoxin was intended.
Fixes #37171
Fixes #37164
Closes #37170