### PR TITLE
Removes startup message in sql log

### DIFF
--- a/code/game/world.dm
+++ b/code/game/world.dm
@@ -100,7 +100,6 @@ GLOBAL_PROTECT(security_mode)
 	start_log(GLOB.world_pda_log)
 	start_log(GLOB.world_manifest_log)
 	start_log(GLOB.world_href_log)
-	start_log(GLOB.sql_error_log)
 	start_log(GLOB.world_qdel_log)
 	start_log(GLOB.world_runtime_log)
 


### PR DESCRIPTION
To check for sql errors I just search through the month's directory for any `sql.log` files, this interferes with that and is very upsetting. Plus I like seeing that there's no `sql.log` files to be seen.