### PR TITLE
Fixes SCP 194 not using the amount variable.

### DIFF
--- a/code/modules/reagents/chemistry/machinery/scp_294.dm
+++ b/code/modules/reagents/chemistry/machinery/scp_294.dm
@@ -74,7 +74,7 @@
 					return
 				else if(!beaker.reagents && !QDELETED(beaker))
 					beaker.create_reagents(beaker.volume)
-				beaker.reagents.add_reagent(input_reagent, 10)
+				beaker.reagents.add_reagent(input_reagent, amount)
 		if("makecup")
 			if(beaker)
 				return


### PR DESCRIPTION
:cl: Dax Dupont
fix: SCP 194 now uses it's amount variable instead of a hardcoded number.
/:cl:

[why]: Doesn't really need a changelog, SCP machine didn't use amount and just had a hardcoded value instead, it should use the amount variable as that's what it's there for.