### PR TITLE
get_reagent_amount will return 0 for negative amounts.

### DIFF
--- a/code/modules/reagents/chemistry/holder.dm
+++ b/code/modules/reagents/chemistry/holder.dm
@@ -630,8 +630,8 @@
 	var/list/cached_reagents = reagent_list
 	for(var/_reagent in cached_reagents)
 		var/datum/reagent/R = _reagent
-		if (R.id == reagent && R.volume > 0)
-			return R.volume
+		if (R.id == reagent)
+			return max(R.volume,0)
 
 	return 0
 

--- a/code/modules/reagents/chemistry/holder.dm
+++ b/code/modules/reagents/chemistry/holder.dm
@@ -630,7 +630,7 @@
 	var/list/cached_reagents = reagent_list
 	for(var/_reagent in cached_reagents)
 		var/datum/reagent/R = _reagent
-		if (R.id == reagent)
+		if (R.id == reagent && R.volume > 0)
 			return R.volume
 
 	return 0


### PR DESCRIPTION
Supposedly there can be brief moments where one can receive negative amounts of reagents which is probably fine for the processes that check for such as cues to delete it. However, get_reagent_amount should not. In the instant that the proc is called right before the reagent is being deleted (cued by the negative amount), get_reagents_amount should return 0 as it will now do.

This should prevent localized checks such as the one in #37175
