### PR TITLE
Readds BZ Cannisters for Xenobiology

### DIFF
--- a/_maps/map_files/BoxStation/BoxStation.dmm
+++ b/_maps/map_files/BoxStation/BoxStation.dmm
@@ -2,6 +2,16 @@
 "aaa" = (
 /turf/open/space/basic,
 /area/space)
+"aab" = (
+/obj/machinery/atmospherics/pipe/simple/general/visible{
+	dir = 9
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 9
+	},
+/obj/machinery/portable_atmospherics/canister/bz,
+/turf/open/floor/plasteel,
+/area/science/xenobiology)
 "aae" = (
 /obj/effect/landmark/carpspawn,
 /turf/open/space,
@@ -45836,18 +45846,6 @@
 /obj/item/cigbutt/roach,
 /turf/open/floor/plating,
 /area/maintenance/aft)
-"cjB" = (
-/obj/machinery/atmospherics/pipe/simple/general/visible{
-	dir = 9
-	},
-/obj/structure/table,
-/obj/item/folder/white,
-/obj/item/pen,
-/obj/effect/turf_decal/stripes/line{
-	dir = 9
-	},
-/turf/open/floor/plasteel,
-/area/science/xenobiology)
 "cjC" = (
 /obj/structure/grille,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -99010,7 +99008,7 @@ bMi
 bMi
 cfy
 cgn
-cjB
+aab
 ccQ
 aaf
 cOT

--- a/_maps/map_files/Deltastation/DeltaStation2.dmm
+++ b/_maps/map_files/Deltastation/DeltaStation2.dmm
@@ -112,6 +112,14 @@
 /obj/structure/cable,
 /turf/open/space,
 /area/solar/starboard/fore)
+"aap" = (
+/obj/machinery/newscaster{
+	pixel_y = -32
+	},
+/obj/effect/turf_decal/bot,
+/obj/machinery/portable_atmospherics/canister/bz,
+/turf/open/floor/plasteel,
+/area/science/xenobiology)
 "aas" = (
 /obj/docking_port/stationary/random{
 	id = "pod_lavaland1";
@@ -74671,13 +74679,6 @@
 /obj/effect/turf_decal/delivery,
 /turf/open/floor/plasteel,
 /area/science/xenobiology)
-"dce" = (
-/obj/machinery/newscaster{
-	pixel_y = -32
-	},
-/obj/effect/turf_decal/bot,
-/turf/open/floor/plasteel,
-/area/science/xenobiology)
 "dcf" = (
 /obj/structure/table,
 /obj/item/crowbar,
@@ -128765,7 +128766,7 @@ cVF
 cWZ
 cYN
 dat
-dce
+aap
 cMY
 dfa
 dgp

--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -2,6 +2,21 @@
 "aaa" = (
 /turf/open/space/basic,
 /area/space)
+"aab" = (
+/obj/machinery/atmospherics/components/unary/portables_connector/visible{
+	dir = 4
+	},
+/obj/machinery/camera{
+	c_tag = "Xenobiology Lab - Aft-Port";
+	dir = 4;
+	network = list("SS13","RD")
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/machinery/portable_atmospherics/canister/bz,
+/turf/open/floor/plasteel,
+/area/science/xenobiology)
 "aac" = (
 /obj/effect/landmark/carpspawn,
 /turf/open/space,
@@ -73684,21 +73699,6 @@
 /obj/structure/reagent_dispensers/fueltank,
 /turf/open/floor/plating,
 /area/maintenance/department/science/xenobiology)
-"ddf" = (
-/obj/machinery/portable_atmospherics/canister,
-/obj/machinery/atmospherics/components/unary/portables_connector/visible{
-	dir = 4
-	},
-/obj/machinery/camera{
-	c_tag = "Xenobiology Lab - Aft-Port";
-	dir = 4;
-	network = list("SS13","RD")
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/science/xenobiology)
 "ddg" = (
 /obj/machinery/portable_atmospherics/canister,
 /obj/machinery/atmospherics/components/unary/portables_connector/visible{
@@ -111363,7 +111363,7 @@ dcU
 cTc
 dcX
 cSd
-ddf
+aab
 ddk
 cTj
 cTD

--- a/_maps/map_files/PubbyStation/PubbyStation.dmm
+++ b/_maps/map_files/PubbyStation/PubbyStation.dmm
@@ -2,6 +2,14 @@
 "aaa" = (
 /turf/open/space/basic,
 /area/space)
+"aab" = (
+/obj/machinery/atmospherics/components/unary/portables_connector/visible{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/line,
+/obj/machinery/portable_atmospherics/canister/bz,
+/turf/open/floor/plasteel,
+/area/science/xenobiology)
 "aby" = (
 /obj/structure/lattice,
 /obj/structure/grille,
@@ -27820,13 +27828,6 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 10
 	},
-/turf/open/floor/plasteel,
-/area/science/xenobiology)
-"brX" = (
-/obj/machinery/atmospherics/components/unary/portables_connector/visible{
-	dir = 4
-	},
-/obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plasteel,
 /area/science/xenobiology)
 "brY" = (
@@ -94659,7 +94660,7 @@ blX
 blX
 bpq
 bqD
-brX
+aab
 btt
 buN
 bwe


### PR DESCRIPTION
:cl: YakumoChen
add: Nanotrasen has once again shipped BZ to its nearby stations. Check your local Xenobiology lab for your shipment.
tweak: Nanotrasen would like to remind you that BZ is meant for keeping slimes in stasis. It is not for human use and may lead to hallucinations. Always practice workplace safety when handling dangerous gasses!
/:cl:

[why]: BZ has exactly one beneficial use. When it was created, it replaced Carbon Dioxide as the gas of choice for putting slimes into stasis, which pauses movement and hunger. Unfortunately, it was soon upended by Goof's Meme Freon and the canister you would find in Toxins was removed when Freon was made.
I have added a canister directly to the Xenobio labs on each map (except Omega) to encourage Xenobiologists to use them for their work. Currently, two maps (Meta and Pubby) also conveniently have a gas distribution system for their large chambers and the BZ Canister has been placed on top their respective connector ports, to again, encourage use. Box and Delta Xenoscientists will just have to make do and put on a gas mask to spread gas in their large containment.

And yes, of course, you could just open the canister in the hall and give everyone hallucinations. Nobody's stopping you from doing that either.
