### PR TITLE
[s] Fixes bluespace cookie centcom exploit

### DIFF
--- a/code/modules/research/xenobiology/crossbreeding/consuming.dm
+++ b/code/modules/research/xenobiology/crossbreeding/consuming.dm
@@ -212,18 +212,27 @@ Consuming extracts:
 	taste = "sugar and starlight"
 
 /obj/item/slime_cookie/bluespace/do_effect(mob/living/M, mob/user)
-	var/list/L = list()
-	for(var/turf/T in get_area_turfs(get_area(get_turf(M))))
+	var/list/L = get_area_turfs(get_area(get_turf(M)))
+	var/turf/target
+	while (L.len && !target)
+		var/I = rand(1, L.len)
+		var/turf/T = L[I]
+		if (is_centcom_level(T.z))
+			L.Cut(I,I+1)
+			continue
 		if(!T.density)
-			var/clear = 1
+			var/clear = TRUE
 			for(var/obj/O in T)
 				if(O.density)
-					clear = 0
+					clear = FALSE
 					break
 			if(clear)
-				L+=T
-	if(length(L))
-		do_teleport(M, pick(L), 0, asoundin = 'sound/effects/phasein.ogg')
+				target = T
+		if (!target)
+			L.Cut(I,I+1)
+
+	if(target)
+		do_teleport(M, target, 0, asoundin = 'sound/effects/phasein.ogg')
 		new /obj/effect/particle_effect/sparks(get_turf(M))
 		playsound(get_turf(M), "sparks", 50, 1)
 


### PR DESCRIPTION
Also fixes a potential server griefing exploit, and makes the code in general more performant

:cl: Naksu
fix: Bluespace slime cookies can no longer be used to travel to CentCom
/:cl:

Fixes #37187
