### PR TITLE
Fixes SCP being deconstructable

### DIFF
--- a/code/modules/reagents/chemistry/machinery/scp_294.dm
+++ b/code/modules/reagents/chemistry/machinery/scp_294.dm
@@ -16,6 +16,7 @@
 	resistance_flags = INDESTRUCTIBLE | FIRE_PROOF | ACID_PROOF | LAVA_PROOF
 	working_state = null
 	nopower_state = null
+	flags_1 = NODECONSTRUCT_1
 	var/static/list/shortcuts = list(
 		"meth" = "methamphetamine",
 		"tricord" = "tricordrazine"


### PR DESCRIPTION
Fixes #37191

This is a side-effect of the chem dispenser change a month ago

:cl: Naksu
fix: SCP-294 can no longer be deconstructed.
/:cl: