### PR TITLE
Correct some pixel_z issues

### DIFF
--- a/_maps/shuttles/pirate_default.dmm
+++ b/_maps/shuttles/pirate_default.dmm
@@ -961,8 +961,7 @@
 	},
 /obj/item/melee/transforming/energy/sword/pirate{
 	pixel_x = 12;
-	pixel_y = 7;
-	pixel_z = 0
+	pixel_y = 7
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,

--- a/_maps/shuttles/whiteship_delta.dmm
+++ b/_maps/shuttles/whiteship_delta.dmm
@@ -243,7 +243,7 @@
 /area/shuttle/abandoned)
 "az" = (
 /obj/structure/sink/kitchen{
-	pixel_z = 30
+	pixel_y = 30
 	},
 /obj/effect/decal/cleanable/dirt{
 	desc = "A thin layer of dust coating the floor.";

--- a/code/modules/hydroponics/hydroponics.dm
+++ b/code/modules/hydroponics/hydroponics.dm
@@ -4,7 +4,7 @@
 	icon_state = "hydrotray"
 	density = TRUE
 	anchored = TRUE
-	pixel_y = 8
+	pixel_z = 8
 	obj_flags = CAN_BE_HIT | UNIQUE_RENAME
 	circuit = /obj/item/circuitboard/machine/hydroponics
 	var/waterlevel = 100	//The amount of water in the tray (max 100)


### PR DESCRIPTION
Hydroponics trays look off when they get rotated by shuttles:
![image](https://user-images.githubusercontent.com/222630/38774603-b2162cf6-4021-11e8-88e6-518d9602505d.png)

And the sink doesn't get rotated properly:
![image](https://user-images.githubusercontent.com/222630/38774624-4c02b636-4022-11e8-897c-97e6f59df6cd.png)


