### PR TITLE
Makes admin loaded shuttles work again

### DIFF
--- a/code/modules/admin/verbs/map_template_loadverb.dm
+++ b/code/modules/admin/verbs/map_template_loadverb.dm
@@ -34,8 +34,14 @@
 	if(copytext("[map]",-4) != ".dmm")
 		to_chat(usr, "Bad map file: [map]")
 		return
-
-	var/datum/map_template/M = new(map, "[map]")
+	var/datum/map_template/M
+	switch(alert(usr, "What kind of map is this?", "Map type", "Normal", "Shuttle", "Cancel"))
+		if("Normal")
+			M = new /datum/map_template(map, "[map]")
+		if("Shuttle")
+			M = new /datum/map_template/shuttle(map, "[map]")
+		else
+			return
 	if(M.preload_size(map))
 		to_chat(usr, "Map template '[map]' ready to place ([M.width]x[M.height])")
 		SSmapping.map_templates[M.name] = M


### PR DESCRIPTION
:cl: ninjanomnom
fix: Admin loaded map templates can be designated as shuttles during the upload process. Make sure to load them on space first.
/:cl:

Loading on non space can eventually work but I still need to figure out a best way of handling that bit of related code. Not in this pr at least.