### PR TITLE
fixes borgs being able to control the CentCom ferry

### DIFF
--- a/code/modules/shuttle/ferry.dm
+++ b/code/modules/shuttle/ferry.dm
@@ -6,7 +6,7 @@
 	possible_destinations = "ferry_home;ferry_away"
 	req_access = list(ACCESS_CENT_GENERAL)
 
-	var/aiControlDisabled = TRUE
+	var/allow_silicons = FALSE
 	var/allow_emag = FALSE
 
 /obj/machinery/computer/shuttle/ferry/emag_act(mob/user)
@@ -16,7 +16,10 @@
 	return ..()
 
 /obj/machinery/computer/shuttle/ferry/attack_ai()
-	return aiControlDisabled? FALSE : ..()
+	return allow_silicons ? ..() : FALSE
+
+/obj/machinery/computer/shuttle/ferry/attack_robot()
+	return allow_silicons ? ..() : FALSE
 
 /obj/machinery/computer/shuttle/ferry/request
 	name = "ferry console"


### PR DESCRIPTION
Fixes #36799

:cl: Naksu
admin: Station borgs can no longer control the CentCom ferry.
/:cl:
