### PR TITLE
Stops ghosts from being able to start plasma fires

### DIFF
--- a/code/datums/helper_datums/teleport.dm
+++ b/code/datums/helper_datums/teleport.dm
@@ -79,7 +79,7 @@
 	return 1
 
 /datum/teleport/proc/playSpecials(atom/location,datum/effect_system/effect,sound)
-	if(location)
+	if(location && !isobserver(teleatom))
 		if(effect)
 			INVOKE_ASYNC(src, .proc/do_effect, location, effect)
 		if(sound)


### PR DESCRIPTION
Fixes #36742

Observer-mobs no longer trigger teleport datum effects

:cl: Naksu
fix: Ghosts can no longer interact with the round via teleporter effects of any kind
/:cl: