### PR TITLE
Couple of fixes for situations involving mechas and the clock cult gamemode

### DIFF
--- a/code/game/atoms_movable.dm
+++ b/code/game/atoms_movable.dm
@@ -383,7 +383,7 @@
 
 	if(throwing)
 		return 1
-	
+
 	if(!isturf(loc))
 		return 1
 
@@ -414,6 +414,9 @@
 	if(!anchored && hitpush)
 		step(src, AM.dir)
 	..()
+
+/atom/movable/proc/safe_throw_at(atom/target, range, speed, mob/thrower, spin=TRUE, diagonals_first = FALSE, var/datum/callback/callback)
+	return throw_at(target, range, speed, thrower, spin, diagonals_first, callback)
 
 /atom/movable/proc/throw_at(atom/target, range, speed, mob/thrower, spin=TRUE, diagonals_first = FALSE, var/datum/callback/callback) //If this returns FALSE then callback will not be called.
 	. = FALSE

--- a/code/game/mecha/equipment/weapons/weapons.dm
+++ b/code/game/mecha/equipment/weapons/weapons.dm
@@ -426,9 +426,7 @@
 
 /obj/item/punching_glove/throw_impact(atom/hit_atom)
 	if(!..())
-		if(ismovableatom(hit_atom) && !istype(hit_atom, /obj/effect/clockwork/servant_blocker))
-			warning("Oingo hit [hit_atom] [hit_atom.type]")
+		if(ismovableatom(hit_atom))
 			var/atom/movable/AM = hit_atom
-			if (!(istype(AM, /obj/machinery/nuclearbomb) && AM.anchored))
-				AM.throw_at(get_edge_target_turf(AM,get_dir(src, AM)), 7, 2)
+			AM.safe_throw_at(get_edge_target_turf(AM,get_dir(src, AM)), 7, 2)
 		qdel(src)

--- a/code/game/mecha/equipment/weapons/weapons.dm
+++ b/code/game/mecha/equipment/weapons/weapons.dm
@@ -50,7 +50,7 @@
 		playsound(chassis, fire_sound, 50, 1)
 
 		sleep(max(0, projectile_delay))
-	
+
 	if(kickback)
 		chassis.newtonian_move(turn(chassis.dir,180))
 	chassis.log_message("Fired from [src.name], targeting [target].")
@@ -426,8 +426,9 @@
 
 /obj/item/punching_glove/throw_impact(atom/hit_atom)
 	if(!..())
-		if(ismovableatom(hit_atom))
+		if(ismovableatom(hit_atom) && !istype(hit_atom, /obj/effect/clockwork/servant_blocker))
+			warning("Oingo hit [hit_atom] [hit_atom.type]")
 			var/atom/movable/AM = hit_atom
-			AM.throw_at(get_edge_target_turf(AM,get_dir(src, AM)), 7, 2)
+			if (!(istype(AM, /obj/machinery/nuclearbomb) && AM.anchored))
+				AM.throw_at(get_edge_target_turf(AM,get_dir(src, AM)), 7, 2)
 		qdel(src)
-

--- a/code/modules/antagonists/clockcult/clock_effects/city_of_cogs_rift.dm
+++ b/code/modules/antagonists/clockcult/clock_effects/city_of_cogs_rift.dm
@@ -54,8 +54,14 @@
 
 /obj/effect/clockwork/city_of_cogs_rift/proc/beckon(atom/movable/AM)
 	var/turf/T = get_turf(pick(GLOB.city_of_cogs_spawns))
-	if(is_servant_of_ratvar(AM))
+	if(ismob(AM) && is_servant_of_ratvar(AM))
 		T = GLOB.ark_of_the_clockwork_justiciar ? get_step(GLOB.ark_of_the_clockwork_justiciar, SOUTH) : get_turf(pick(GLOB.servant_spawns))
+	else // Handle mechas and such
+		var/list/target_contents = AM.GetAllContents() + AM
+		for(var/mob/living/L in target_contents)
+			if(is_servant_of_ratvar(L) && L.stat != DEAD) // Having a living cultist in your inventory sends you to the cultist spawn
+				T = GLOB.ark_of_the_clockwork_justiciar ? get_step(GLOB.ark_of_the_clockwork_justiciar, SOUTH) : get_turf(pick(GLOB.servant_spawns))
+				break
 	AM.visible_message("<span class='danger'>[AM] passes through [src]!</span>", null, null, null, AM)
 	AM.forceMove(T)
 	AM.visible_message("<span class='danger'>[AM] materializes from the air!</span>", \

--- a/code/modules/antagonists/clockcult/clock_effects/servant_blocker.dm
+++ b/code/modules/antagonists/clockcult/clock_effects/servant_blocker.dm
@@ -42,3 +42,6 @@
 
 /obj/effect/clockwork/servant_blocker/ex_act(severity, target)
 	return
+
+/obj/effect/clockwork/servant_blocker/safe_throw_at()
+	return

--- a/code/modules/antagonists/nukeop/equipment/nuclearbomb.dm
+++ b/code/modules/antagonists/nukeop/equipment/nuclearbomb.dm
@@ -400,11 +400,6 @@
 	if(explosive)
 		qdel(src)//like the singulo, tesla deletes it. stops it from exploding over and over
 
-/obj/machinery/nuclearbomb/safe_throw_at(atom/target, range, speed, mob/thrower, spin=TRUE, diagonals_first = FALSE, var/datum/callback/callback)
-	if (!anchored)
-		return ..()
-	return
-
 #define NUKERANGE 127
 /obj/machinery/nuclearbomb/proc/explode()
 	if(safety)

--- a/code/modules/antagonists/nukeop/equipment/nuclearbomb.dm
+++ b/code/modules/antagonists/nukeop/equipment/nuclearbomb.dm
@@ -400,6 +400,11 @@
 	if(explosive)
 		qdel(src)//like the singulo, tesla deletes it. stops it from exploding over and over
 
+/obj/machinery/nuclearbomb/safe_throw_at(atom/target, range, speed, mob/thrower, spin=TRUE, diagonals_first = FALSE, var/datum/callback/callback)
+	if (!anchored)
+		return ..()
+	return
+
 #define NUKERANGE 127
 /obj/machinery/nuclearbomb/proc/explode()
 	if(safety)

--- a/code/modules/awaymissions/gateway.dm
+++ b/code/modules/awaymissions/gateway.dm
@@ -74,6 +74,9 @@ GLOBAL_DATUM(the_gateway, /obj/machinery/gateway/centerstation)
 /obj/machinery/gateway/proc/toggleon(mob/user)
 	return FALSE
 
+/obj/machinery/gateway/safe_throw_at()
+	return
+
 /obj/machinery/gateway/centerstation/Initialize()
 	. = ..()
 	if(!GLOB.the_gateway)

--- a/code/modules/power/gravitygenerator.dm
+++ b/code/modules/power/gravitygenerator.dm
@@ -28,7 +28,7 @@ GLOBAL_LIST_EMPTY(gravity_generators) // We will keep track of this by adding ne
 	resistance_flags = INDESTRUCTIBLE | LAVA_PROOF | FIRE_PROOF | UNACIDABLE | ACID_PROOF
 	var/sprite_number = 0
 
-/obj/machinery/gravity_generator/throw_at()
+/obj/machinery/gravity_generator/safe_throw_at()
 	return FALSE
 
 /obj/machinery/gravity_generator/ex_act(severity, target)

--- a/code/modules/projectiles/projectile/bullets/shotgun.dm
+++ b/code/modules/projectiles/projectile/bullets/shotgun.dm
@@ -1,7 +1,7 @@
 /obj/item/projectile/bullet/shotgun_slug
 	name = "12g shotgun slug"
 	damage = 60
-	
+
 /obj/item/projectile/bullet/shotgun_slug/tengauge
 	name = "10g shotgun slug"
 	damage = 72.5
@@ -42,7 +42,7 @@
 	if(ismovableatom(target))
 		var/atom/movable/M = target
 		var/atom/throw_target = get_edge_target_turf(M, get_dir(src, get_step_away(M, src)))
-		M.throw_at(throw_target, 3, 2)
+		M.safe_throw_at(throw_target, 3, 2)
 
 /obj/item/projectile/bullet/shotgun_meteorslug/Initialize()
 	. = ..()


### PR DESCRIPTION
Fixes #33300
Closes #36681

I'm not really sold on removing the ability to move the nuke, but the fix for that is contained in this PR for discussion. I think having your op get wrecked by a clown is what nuke ops is about, though that's somewhat related to the issue where ops pretty much lose if the nuke ever leaves the station z-level after arriving there.

:cl: Naksu
fix: Oingo-boingo punch-face and meteor shot can no longer move gateways or Reebe servant blocker effects
fix: Mechas piloted by servants of Ratvar now teleport to the servant side of Reebe when entering a rift
admin: Gravity generators can now be thrown in buildmode
/:cl:

![image](https://user-images.githubusercontent.com/20017308/38778009-7b58a72c-40ba-11e8-9c83-009d148b7e1c.png)
![image](https://user-images.githubusercontent.com/20017308/38778012-82b21a12-40ba-11e8-920c-10826cce3d1a.png)

I wasn't even looking for this bug
