### PR TITLE
Blacklists His Grace from the deep fryer

### DIFF
--- a/code/modules/food_and_drinks/kitchen_machinery/deep_fryer.dm
+++ b/code/modules/food_and_drinks/kitchen_machinery/deep_fryer.dm
@@ -46,7 +46,8 @@ God bless America.
 		/obj/item/reagent_containers/glass,
 		/obj/item/reagent_containers/syringe,
 		/obj/item/reagent_containers/food/condiment,
-		/obj/item/storage/part_replacer))
+		/obj/item/storage/part_replacer,
+		/obj/item/his_grace))
 	var/datum/looping_sound/deep_fryer/fry_loop
 
 /obj/machinery/deepfryer/Initialize()


### PR DESCRIPTION
Fixes #36385

Alternative solution would be to render His Grace dormant if deep-fried, that way it won't pop out of the deepfryholder object. That would however make the item much safer to use and have balance considerations.

:cl: Naksu
tweak: His Grace can no longer be deep-fried
/:cl: