### PR TITLE
Allows passive gates to be interacted with in unpowered areas

### DIFF
--- a/code/modules/atmospherics/machinery/components/binary_devices/passive_gate.dm
+++ b/code/modules/atmospherics/machinery/components/binary_devices/passive_gate.dm
@@ -14,6 +14,8 @@ Passive gate is similar to the regular pump except:
 
 	can_unwrench = TRUE
 
+	interaction_flags_machine = INTERACT_MACHINE_OFFLINE | INTERACT_MACHINE_WIRES_IF_OPEN | INTERACT_MACHINE_ALLOW_SILICON | INTERACT_MACHINE_OPEN_SILICON | INTERACT_MACHINE_SET_MACHINE
+
 	var/on = FALSE
 	var/target_pressure = ONE_ATMOSPHERE
 


### PR DESCRIPTION
Fixes #37219

The effective change to the interaction flags var is the addition of `INTERACT_MACHINE_OFFLINE`

:cl: Naksu
fix: Passive gates can be interacted with in unpowered areas
/:cl:
