### PR TITLE
Makes welding tools (attempt to) flash you during progress

### DIFF
--- a/code/game/objects/items/tools/weldingtool.dm
+++ b/code/game/objects/items/tools/weldingtool.dm
@@ -237,7 +237,7 @@
 
 // Flash the user during welding progress
 /obj/item/weldingtool/tool_check_callback(mob/living/user, amount, datum/callback/extra_checks)
-	. = tool_use_check(user, amount) && (!extra_checks || extra_checks.Invoke())
+	. = ..()
 	if(. && user)
 		if (progress_flash_divisor == 0)
 			user.flash_act(min(light_intensity,1))

--- a/code/game/objects/items/tools/weldingtool.dm
+++ b/code/game/objects/items/tools/weldingtool.dm
@@ -28,6 +28,7 @@
 	var/change_icons = 1
 	var/can_off_process = 0
 	var/light_intensity = 2 //how powerful the emitted light is when used.
+	var/progress_flash_divisor = 10
 	var/burned_fuel_for = 0	//when fuel was last removed
 	heat = 3800
 	tool_behaviour = TOOL_WELDER
@@ -233,6 +234,16 @@
 	. = tool_use_check(user, amount)
 	if(. && user)
 		user.flash_act(light_intensity)
+
+// Flash the user during welding progress
+/obj/item/weldingtool/tool_check_callback(mob/living/user, amount, datum/callback/extra_checks)
+	. = tool_use_check(user, amount) && (!extra_checks || extra_checks.Invoke())
+	if(. && user)
+		if (progress_flash_divisor == 0)
+			user.flash_act(min(light_intensity,1))
+			progress_flash_divisor = initial(progress_flash_divisor)
+		else
+			progress_flash_divisor--
 
 // If welding tool ran out of fuel during a construction task, construction fails.
 /obj/item/weldingtool/tool_use_check(mob/living/user, amount)


### PR DESCRIPTION
Fixes #15472

Balance change: you take more damage from welding shit without protection. Tested by welding walls, after slicing two walls you get sand-eye that goes away almost right away, but if you continue to a third or fourth weld you probably go blind.

:cl: Naksu
balance: Welding tools now flash the user as the weld progresses, not just when the welding is started.
/:cl: