### PR TITLE
Add team objective support to the centcom antag datum

### DIFF
--- a/code/modules/antagonists/official/official.dm
+++ b/code/modules/antagonists/official/official.dm
@@ -3,10 +3,14 @@
 	show_name_in_check_antagonists = TRUE
 	show_in_antagpanel = FALSE
 	var/datum/objective/mission
+	var/datum/team/ert/ert_team
 
 /datum/antagonist/official/greet()
 	to_chat(owner, "<B><font size=3 color=red>You are a CentCom Official.</font></B>")
-	to_chat(owner, "Central Command is sending you to [station_name()] with the task: [mission.explanation_text]")
+	if (ert_team)
+		to_chat(owner, "Central Command is sending you to [station_name()] with the task: [ert_team.mission.explanation_text]")
+	else
+		to_chat(owner, "Central Command is sending you to [station_name()] with the task: [mission.explanation_text]")
 
 /datum/antagonist/official/proc/equip_official()
 	var/mob/living/carbon/human/H = owner.current
@@ -17,15 +21,22 @@
 	if(CONFIG_GET(flag/enforce_human_authority))
 		H.set_species(/datum/species/human)
 
+/datum/antagonist/official/create_team(datum/team/new_team)
+	if(istype(new_team))
+		ert_team = new_team
+
 /datum/antagonist/official/proc/forge_objectives()
-	if(!mission)
+	if (ert_team)
+		objectives |= ert_team.objectives
+	else if (!mission)
 		var/datum/objective/missionobj = new
 		missionobj.owner = owner
 		missionobj.explanation_text = "Conduct a routine preformance review of [station_name()] and its Captain."
 		missionobj.completed = 1
 		mission = missionobj
-	objectives |= mission
+		objectives |= mission
 	owner.objectives |= objectives
+
 
 /datum/antagonist/official/on_gain()
 	forge_objectives()


### PR DESCRIPTION
Fixes #37226

Bug was caused by centcom antag not caring at all about teams or their objectives

:cl: Naksu
fix: CentCom officials will now properly display the objectives the admin has assigned them.
/:cl:
