### PR TITLE
Fixes small chem doses

### DIFF
--- a/code/modules/reagents/chemistry/holder.dm
+++ b/code/modules/reagents/chemistry/holder.dm
@@ -567,7 +567,7 @@
 			my_atom.on_reagent_change(ADD_REAGENT)
 		if(!no_react)
 			handle_reactions()
-		if(isliving(my_atom))
+		if(isliving(my_atom)&&!QDELETED(R))
 			R.on_mob_add(my_atom)
 		return TRUE
 

--- a/code/modules/reagents/chemistry/holder.dm
+++ b/code/modules/reagents/chemistry/holder.dm
@@ -464,7 +464,7 @@
 	for(var/_reagent in cached_reagents)
 		var/datum/reagent/R = _reagent
 		if(R.id == reagent)
-			if(my_atom && isliving(my_atom) && R.on_mob_delete)
+			if(my_atom && isliving(my_atom) && R.mobeffectactive)
 				var/mob/living/M = my_atom
 				R.on_mob_delete(M)
 			qdel(R)

--- a/code/modules/reagents/chemistry/holder.dm
+++ b/code/modules/reagents/chemistry/holder.dm
@@ -464,7 +464,7 @@
 	for(var/_reagent in cached_reagents)
 		var/datum/reagent/R = _reagent
 		if(R.id == reagent)
-			if(my_atom && isliving(my_atom))
+			if(my_atom && isliving(my_atom) && R.on_mob_delete)
 				var/mob/living/M = my_atom
 				R.on_mob_delete(M)
 			qdel(R)

--- a/code/modules/reagents/chemistry/holder.dm
+++ b/code/modules/reagents/chemistry/holder.dm
@@ -569,6 +569,7 @@
 			handle_reactions()
 		if(isliving(my_atom)&&!QDELETED(R))
 			R.on_mob_add(my_atom)
+			R.mobeffectactive = TRUE
 		return TRUE
 
 	else

--- a/code/modules/reagents/chemistry/readme.md
+++ b/code/modules/reagents/chemistry/readme.md
@@ -143,6 +143,14 @@ Reagents are all the things you can mix and fille in bottles etc. This can be an
 			If you dont, the chemical will stay in the mob forever -
 			unless you write your own piece of code to slowly remove it.
 			(Should be pretty easy, 1 line of code)
+
+		on_mob_add()
+			Does something to when the reagent datum is first created in a mob(by injection or chem reaction).
+			If you return it make sure to set the reagents mobeffectactive var to TRUE so that on_mob_delete() can run.
+		
+		on_mob_delete()
+			Does something when the reagent datum is deleted from the mob, usualy undoing whatever the reagents on_mob_add() 	did.
+		
 ```
 
 ## Important variables:

--- a/code/modules/reagents/chemistry/reagents.dm
+++ b/code/modules/reagents/chemistry/reagents.dm
@@ -32,6 +32,7 @@
 	var/addiction_stage = 0
 	var/overdosed = 0 // You fucked up and this is now triggering its overdose effects, purge that shit quick.
 	var/self_consuming = FALSE
+	var/mobeffectactive = FALSE
 
 /datum/reagent/Destroy() // This should only be called by the holder, so it's already handled clearing its references
 	. = ..()
@@ -61,6 +62,7 @@
 
 // Called when this reagent is first added to a mob
 /datum/reagent/proc/on_mob_add(mob/M)
+	mobeffectactive = TRUE
 	return
 
 // Called when this reagent is removed while inside a mob

--- a/code/modules/reagents/chemistry/reagents.dm
+++ b/code/modules/reagents/chemistry/reagents.dm
@@ -63,7 +63,6 @@
 // Called when this reagent is first added to a mob
 /datum/reagent/proc/on_mob_add(mob/M)
 	mobeffectactive = TRUE
-	return
 
 // Called when this reagent is removed while inside a mob
 /datum/reagent/proc/on_mob_delete(mob/M)

--- a/code/modules/reagents/chemistry/reagents.dm
+++ b/code/modules/reagents/chemistry/reagents.dm
@@ -62,7 +62,7 @@
 
 // Called when this reagent is first added to a mob
 /datum/reagent/proc/on_mob_add(mob/M)
-	mobeffectactive = TRUE
+	return
 
 // Called when this reagent is removed while inside a mob
 /datum/reagent/proc/on_mob_delete(mob/M)

--- a/code/modules/reagents/chemistry/reagents/alcohol_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/alcohol_reagents.dm
@@ -552,11 +552,13 @@ All effects don't start immediately, but rather get worse over time; the rate is
 	to_chat(M, "<span class='notice'>You feel [tough_text]!</span>")
 	M.maxHealth += 10 //Brave Bull makes you sturdier, and thus capable of withstanding a tiny bit more punishment.
 	M.health += 10
+	..()
 
 /datum/reagent/consumable/ethanol/brave_bull/on_mob_delete(mob/living/M)
 	to_chat(M, "<span class='notice'>You no longer feel [tough_text].</span>")
 	M.maxHealth -= 10
 	M.health = min(M.health - 10, M.maxHealth) //This can indeed crit you if you're alive solely based on alchol ingestion
+	..()
 
 /datum/reagent/consumable/ethanol/tequila_sunrise
 	name = "Tequila Sunrise"
@@ -574,6 +576,7 @@ All effects don't start immediately, but rather get worse over time; the rate is
 	to_chat(M, "<span class='notice'>You feel gentle warmth spread through your body!</span>")
 	light_holder = new(M)
 	light_holder.set_light(3, 0.7, "#FFCC00") //Tequila Sunrise makes you radiate dim light, like a sunrise!
+	..()
 
 /datum/reagent/consumable/ethanol/tequila_sunrise/on_mob_life(mob/living/M)
 	if(QDELETED(light_holder))
@@ -585,6 +588,7 @@ All effects don't start immediately, but rather get worse over time; the rate is
 /datum/reagent/consumable/ethanol/tequila_sunrise/on_mob_delete(mob/living/M)
 	to_chat(M, "<span class='notice'>The warmth in your body fades.</span>")
 	QDEL_NULL(light_holder)
+	..()
 
 /datum/reagent/consumable/ethanol/toxins_special
 	name = "Toxins Special"
@@ -651,6 +655,7 @@ All effects don't start immediately, but rather get worse over time; the rate is
 			to_chat(H, "<span class='notice'>Now THAT is MANLY!</span>")
 			boozepwr = 5 //We've had worse in the mines
 			dorf_mode = TRUE
+	..()
 
 /datum/reagent/consumable/ethanol/manly_dorf/on_mob_life(mob/living/M)
 	if(dorf_mode)
@@ -693,7 +698,7 @@ All effects don't start immediately, but rather get worse over time; the rate is
 	glass_desc = "Kahlua, Irish Cream, and cognac. You will get bombed."
 	shot_glass_icon_state = "b52glass"
 
-/datum/reagent/consumable/ethanol/b52/on_mob_add(mob/living/M)
+/datum/reagent/consumable/ethanol/b52/reaction_mob(mob/living/M)
 	playsound(M, 'sound/effects/explosion_distant.ogg', 100, FALSE)
 
 /datum/reagent/consumable/ethanol/irishcoffee
@@ -1464,7 +1469,7 @@ All effects don't start immediately, but rather get worse over time; the rate is
 	glass_desc = "If you're feeling low, count on the buttery flavor of our own bastion bourbon."
 	shot_glass_icon_state = "shotglassgreen"
 
-/datum/reagent/consumable/ethanol/bastion_bourbon/on_mob_add(mob/living/L)
+/datum/reagent/consumable/ethanol/bastion_bourbon/reaction_mob(mob/living/L)
 	var/heal_points = 10
 	if(L.health <= 0)
 		heal_points = 20 //heal more if we're in softcrit
@@ -1545,5 +1550,6 @@ All effects don't start immediately, but rather get worse over time; the rate is
 	glass_name = "Crevice Spike"
 	glass_desc = "It'll either knock the drunkenness out of you or knock you out cold. Both, probably."
 
-/datum/reagent/consumable/ethanol/crevice_spike/on_mob_add(mob/living/L) //damage only applies when drink first enters system and won't again until drink metabolizes out
+/datum/reagent/consumable/ethanol/crevice_spike/reaction_mob(mob/living/L) //damage only applies when drink first enters system and won't again until drink metabolizes out
+	..()
 	L.adjustBruteLoss(3 * min(5,volume)) //minimum 3 brute damage on ingestion to limit non-drink means of injury - a full 5 unit gulp of the drink trucks you for the full 15

--- a/code/modules/reagents/chemistry/reagents/toxin_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/toxin_reagents.dm
@@ -910,6 +910,8 @@
 
 /datum/reagent/toxin/mimesbane/on_mob_add(mob/living/L)
 	L.add_trait(TRAIT_EMOTEMUTE, id)
+	()..
 
 /datum/reagent/toxin/mimesbane/on_mob_delete(mob/living/L)
 	L.remove_trait(TRAIT_EMOTEMUTE, id)
+	()..

--- a/code/modules/reagents/chemistry/reagents/toxin_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/toxin_reagents.dm
@@ -910,8 +910,8 @@
 
 /datum/reagent/toxin/mimesbane/on_mob_add(mob/living/L)
 	L.add_trait(TRAIT_EMOTEMUTE, id)
-	()..
+	..()
 
 /datum/reagent/toxin/mimesbane/on_mob_delete(mob/living/L)
 	L.remove_trait(TRAIT_EMOTEMUTE, id)
-	()..
+	..()


### PR DESCRIPTION
:cl:
fix: Tiny amounts of chems no longer have unintentional behaviors.
/:cl:

fixes: #36152

This fixes two separate flaws, That traits were added from reagents last, after the reagents removal could have been processed, and that removal of traits or reversions of changes never checked that those changes had been made (so brave bull could make a death vape after the fix for the og bug for example).  

It does this by checking if reagents have been qdeleted before adding the trait and that the trait or change has been added before trying to remove it. It does this without the old stutter-step bug returning. Sorry for the poor form last time.
