### PR TITLE
Fix cycle-linked airlocks on shuttles

### DIFF
--- a/code/modules/shuttle/on_move.dm
+++ b/code/modules/shuttle/on_move.dm
@@ -157,17 +157,17 @@ All ShuttleMove procs go here
 
 /obj/machinery/door/airlock/beforeShuttleMove(turf/newT, rotation, move_mode, obj/docking_port/mobile/moving_dock)
 	. = ..()
-	shuttledocked = 0
-	for(var/obj/machinery/door/airlock/A in range(1, src))
-		A.shuttledocked = 0
+	for(var/obj/machinery/door/airlock/A in range(1, src))  // includes src
+		A.shuttledocked = FALSE
 		A.air_tight = TRUE
 		INVOKE_ASYNC(A, /obj/machinery/door/.proc/close)
 
 /obj/machinery/door/airlock/afterShuttleMove(turf/oldT, list/movement_force, shuttle_dir, shuttle_preferred_direction, move_dir, rotation)
 	. = ..()
-	shuttledocked =  1
-	for(var/obj/machinery/door/airlock/A in range(1, src))
-		A.shuttledocked = 1
+	for(var/obj/machinery/door/airlock/A in orange(1, src))  // does not include src
+		// Cycle linking is only disabled if we are actually adjacent to another airlock
+		shuttledocked = TRUE
+		A.shuttledocked = TRUE
 
 /obj/machinery/camera/beforeShuttleMove(turf/newT, rotation, move_mode, obj/docking_port/mobile/moving_dock)
 	. = ..()


### PR DESCRIPTION
:cl:
fix: Cycle-linking is no longer permanently disabled for airlocks on shuttles.
/:cl:

Right now, every single airlock on a shuttle is considered to be `shuttledocked` at all times, meaning cycle-linking doesn't work. Cycle-linking is now only inhibited for airlocks which are directly adjacent to another airlock (i.e. actually docked).