### PR TITLE
Fixes Ghosts not being able to see in containers

### DIFF
--- a/code/datums/components/storage/storage.dm
+++ b/code/datums/components/storage/storage.dm
@@ -86,7 +86,7 @@
 	RegisterSignal(COMSIG_ATOM_ATTACK_HAND, .proc/on_attack_hand)
 	RegisterSignal(COMSIG_ATOM_ATTACK_PAW, .proc/on_attack_hand)
 	RegisterSignal(COMSIG_ATOM_EMP_ACT, .proc/emp_act)
-	RegisterSignal(COMSIG_ATOM_ATTACK_GHOST, .proc/show_to_ghost)
+	RegisterSignal(COMSIG_ATOM_ATTACK_GHOST, .proc/show_to)
 	RegisterSignal(COMSIG_ATOM_EXITED, .proc/_removal_reset)
 
 	RegisterSignal(COMSIG_ITEM_PRE_ATTACK, .proc/preattack_intercept)

--- a/code/datums/components/storage/storage.dm
+++ b/code/datums/components/storage/storage.dm
@@ -614,9 +614,6 @@
 /datum/component/storage/proc/signal_can_insert(obj/item/I, mob/M, silent = FALSE)
 	return can_be_inserted(I, silent, M)
 
-/datum/component/storage/proc/show_to_ghost(mob/dead/observer/M)
-	return user_show_to_mob(M, TRUE)
-
 /datum/component/storage/proc/signal_show_attempt(mob/showto, force = FALSE)
 	return user_show_to_mob(showto, force)
 


### PR DESCRIPTION

:cl: MetroidLover
fix: Ghosts can look in containers again now
/:cl:
 Fixes #37010 