### PR TITLE
Plant icon unit tests

### DIFF
--- a/code/modules/hydroponics/grown/mushrooms.dm
+++ b/code/modules/hydroponics/grown/mushrooms.dm
@@ -323,12 +323,12 @@
 	reagents_add = list("nutriment" = 0.1)
 	resistance_flags = FIRE_PROOF
 	growing_icon = 'icons/obj/hydroponics/growing_mushrooms.dmi'
+	species = "polypore"		//Default to prevent CI failure.
 
 /obj/item/seeds/lavaland/polypore
 	name = "pack of polypore mycelium"
 	desc = "This mycelium grows into bracket mushrooms, also known as polypores. Woody and firm, shaft miners often use them for makeshift crafts."
 	icon_state = "mycelium-polypore"
-	species = "polypore"
 	plantname = "Polypore Mushrooms"
 	product = /obj/item/reagent_containers/food/snacks/grown/ash_flora/shavings
 	genes = list(/datum/plant_gene/trait/plant_type/fungal_metabolism)

--- a/code/modules/hydroponics/grown/mushrooms.dm
+++ b/code/modules/hydroponics/grown/mushrooms.dm
@@ -363,3 +363,5 @@
 	species = "ember"
 	plantname = "Embershroom Mushrooms"
 	product = /obj/item/reagent_containers/food/snacks/grown/ash_flora/mushroom_stem
+	genes = list(/datum/plant_gene/trait/plant_type/fungal_metabolism, /datum/plant_gene/trait/glow)
+	

--- a/code/modules/hydroponics/grown/mushrooms.dm
+++ b/code/modules/hydroponics/grown/mushrooms.dm
@@ -324,6 +324,7 @@
 	resistance_flags = FIRE_PROOF
 	growing_icon = 'icons/obj/hydroponics/growing_mushrooms.dmi'
 	species = "polypore"		//Default to prevent CI failure.
+	icon_harvest = null
 
 /obj/item/seeds/lavaland/polypore
 	name = "pack of polypore mycelium"

--- a/code/modules/hydroponics/grown/mushrooms.dm
+++ b/code/modules/hydroponics/grown/mushrooms.dm
@@ -321,7 +321,8 @@
 	growthstages = 3
 	rarity = 20
 	reagents_add = list("nutriment" = 0.1)
-	resistance_flags = FIRE_PROOF
+	resistance_flags = FIRE_PROOF]
+	growing_icon = 'icons/obj/hydroponics/growing_mushrooms.dmi'
 
 /obj/item/seeds/lavaland/polypore
 	name = "pack of polypore mycelium"
@@ -331,7 +332,6 @@
 	plantname = "Polypore Mushrooms"
 	product = /obj/item/reagent_containers/food/snacks/grown/ash_flora/shavings
 	genes = list(/datum/plant_gene/trait/plant_type/fungal_metabolism)
-	growing_icon = 'icons/obj/hydroponics/growing_mushrooms.dmi'
 
 // Porcini (Leafy mushroom)
 
@@ -343,7 +343,6 @@
 	plantname = "Porcini Mushrooms"
 	product = /obj/item/reagent_containers/food/snacks/grown/ash_flora/mushroom_leaf
 	genes = list(/datum/plant_gene/trait/plant_type/fungal_metabolism)
-	growing_icon = 'icons/obj/hydroponics/growing_mushrooms.dmi'
 
 // Inocybe (Mushroom caps)
 
@@ -355,7 +354,6 @@
 	plantname = "Inocybe Mushrooms"
 	product = /obj/item/reagent_containers/food/snacks/grown/ash_flora/mushroom_cap
 	genes = list(/datum/plant_gene/trait/plant_type/fungal_metabolism)
-	growing_icon = 'icons/obj/hydroponics/growing_mushrooms.dmi'
 
 // Embershroom (Mushroom stem)
 
@@ -367,4 +365,3 @@
 	plantname = "Embershroom Mushrooms"
 	product = /obj/item/reagent_containers/food/snacks/grown/ash_flora/mushroom_stem
 	genes = list(/datum/plant_gene/trait/plant_type/fungal_metabolism, /datum/plant_gene/trait/glow)
-	growing_icon = 'icons/obj/hydroponics/growing_mushrooms.dmi'

--- a/code/modules/hydroponics/grown/mushrooms.dm
+++ b/code/modules/hydroponics/grown/mushrooms.dm
@@ -325,6 +325,7 @@
 	growing_icon = 'icons/obj/hydroponics/growing_mushrooms.dmi'
 	species = "polypore"		//Default to prevent CI failure.
 	icon_harvest = null
+	genes = list(/datum/plant_gene/trait/plant_type/fungal_metabolism)
 
 /obj/item/seeds/lavaland/polypore
 	name = "pack of polypore mycelium"
@@ -332,7 +333,6 @@
 	icon_state = "mycelium-polypore"
 	plantname = "Polypore Mushrooms"
 	product = /obj/item/reagent_containers/food/snacks/grown/ash_flora/shavings
-	genes = list(/datum/plant_gene/trait/plant_type/fungal_metabolism)
 
 // Porcini (Leafy mushroom)
 
@@ -343,7 +343,6 @@
 	species = "porcini"
 	plantname = "Porcini Mushrooms"
 	product = /obj/item/reagent_containers/food/snacks/grown/ash_flora/mushroom_leaf
-	genes = list(/datum/plant_gene/trait/plant_type/fungal_metabolism)
 
 // Inocybe (Mushroom caps)
 
@@ -354,7 +353,6 @@
 	species = "inocybe"
 	plantname = "Inocybe Mushrooms"
 	product = /obj/item/reagent_containers/food/snacks/grown/ash_flora/mushroom_cap
-	genes = list(/datum/plant_gene/trait/plant_type/fungal_metabolism)
 
 // Embershroom (Mushroom stem)
 
@@ -365,4 +363,3 @@
 	species = "ember"
 	plantname = "Embershroom Mushrooms"
 	product = /obj/item/reagent_containers/food/snacks/grown/ash_flora/mushroom_stem
-	genes = list(/datum/plant_gene/trait/plant_type/fungal_metabolism, /datum/plant_gene/trait/glow)

--- a/code/modules/hydroponics/grown/mushrooms.dm
+++ b/code/modules/hydroponics/grown/mushrooms.dm
@@ -321,7 +321,7 @@
 	growthstages = 3
 	rarity = 20
 	reagents_add = list("nutriment" = 0.1)
-	resistance_flags = FIRE_PROOF]
+	resistance_flags = FIRE_PROOF
 	growing_icon = 'icons/obj/hydroponics/growing_mushrooms.dmi'
 
 /obj/item/seeds/lavaland/polypore

--- a/code/modules/hydroponics/seeds.dm
+++ b/code/modules/hydroponics/seeds.dm
@@ -320,37 +320,6 @@
 		return
 	..() // Fallthrough to item/attackby() so that bags can pick seeds up
 
-
-
-
-
-
-
-// Checks plants for broken tray icons. Use Advanced Proc Call to activate.
-// Maybe some day it would be used as unit test.
-/proc/check_plants_growth_stages_icons()
-	var/list/states = icon_states('icons/obj/hydroponics/growing.dmi')
-	states |= icon_states('icons/obj/hydroponics/growing_fruits.dmi')
-	states |= icon_states('icons/obj/hydroponics/growing_flowers.dmi')
-	states |= icon_states('icons/obj/hydroponics/growing_mushrooms.dmi')
-	states |= icon_states('icons/obj/hydroponics/growing_vegetables.dmi')
-	var/list/paths = typesof(/obj/item/seeds) - /obj/item/seeds - typesof(/obj/item/seeds/sample)
-
-	for(var/seedpath in paths)
-		var/obj/item/seeds/seed = new seedpath
-
-		for(var/i in 1 to seed.growthstages)
-			if("[seed.icon_grow][i]" in states)
-				continue
-			to_chat(world, "[seed.name] ([seed.type]) lacks the [seed.icon_grow][i] icon!")
-
-		if(!(seed.icon_dead in states))
-			to_chat(world, "[seed.name] ([seed.type]) lacks the [seed.icon_dead] icon!")
-
-		if(seed.icon_harvest) // mushrooms have no grown sprites, same for items with no product
-			if(!(seed.icon_harvest in states))
-				to_chat(world, "[seed.name] ([seed.type]) lacks the [seed.icon_harvest] icon!")
-
 /obj/item/seeds/proc/randomize_stats()
 	set_lifespan(rand(25, 60))
 	set_endurance(rand(15, 35))

--- a/code/modules/unit_tests/_unit_tests.dm
+++ b/code/modules/unit_tests/_unit_tests.dm
@@ -5,4 +5,5 @@
 #include "reagent_recipe_collisions.dm"
 #include "reagent_id_typos.dm"
 #include "subsystem_init.dm"
+#include "plant_growth_icons.dm"
 #endif

--- a/code/modules/unit_tests/plant_growth_icons.dm
+++ b/code/modules/unit_tests/plant_growth_icons.dm
@@ -20,11 +20,11 @@
 		for(var/i in 1 to seed.growthstages)
 			if("[seed.icon_grow][i]" in states["[seed.growing_icon]"])
 				continue
-			Fail("[seed.name] ([seed.type]) lacks the [seed.icon_grow][i] icon!")
+			Fail("[seed.name] ([seed.type]) lacks the [seed.icon_grow][i] icon! \[ICON_GROW\]")
 
 		if(!(seed.icon_dead in states["[seed.growing_icon]"]))
-			Fail("[seed.name] ([seed.type]) lacks the [seed.icon_dead] icon!")
+			Fail("[seed.name] ([seed.type]) lacks the [seed.icon_dead] icon! \[ICON_DEAD\]")
 
 		if(seed.icon_harvest) // mushrooms have no grown sprites, same for items with no product
 			if(!(seed.icon_harvest in states["[seed.growing_icon]"]))
-				Fail("[seed.name] ([seed.type]) lacks the [seed.icon_harvest] icon!")
+				Fail("[seed.name] ([seed.type]) lacks the [seed.icon_harvest] icon! \[ICON_HARVEST\]")

--- a/code/modules/unit_tests/plant_growth_icons.dm
+++ b/code/modules/unit_tests/plant_growth_icons.dm
@@ -6,6 +6,7 @@
 	states |= icon_states('icons/obj/hydroponics/growing_flowers.dmi')
 	states |= icon_states('icons/obj/hydroponics/growing_mushrooms.dmi')
 	states |= icon_states('icons/obj/hydroponics/growing_vegetables.dmi')
+	states |= icon_states('goon/icons/obj/hydroponics.dmi')
 	var/list/paths = typesof(/obj/item/seeds) - /obj/item/seeds - typesof(/obj/item/seeds/sample)
 
 	for(var/seedpath in paths)

--- a/code/modules/unit_tests/plant_growth_icons.dm
+++ b/code/modules/unit_tests/plant_growth_icons.dm
@@ -18,13 +18,13 @@
 		var/obj/item/seeds/seed = new seedpath
 
 		for(var/i in 1 to seed.growthstages)
-			if("[seed.icon_grow][i]" in states[seed.growing_icon])
+			if("[seed.icon_grow][i]" in states["[seed.growing_icon]"])
 				continue
 			Fail("[seed.name] ([seed.type]) lacks the [seed.icon_grow][i] icon!")
 
-		if(!(seed.icon_dead in states[seed.growing_icon]))
+		if(!(seed.icon_dead in states["[seed.growing_icon]"]))
 			Fail("[seed.name] ([seed.type]) lacks the [seed.icon_dead] icon!")
 
 		if(seed.icon_harvest) // mushrooms have no grown sprites, same for items with no product
-			if(!(seed.icon_harvest in states[seed.growing_icon]))
+			if(!(seed.icon_harvest in states["[seed.growing_icon]"]))
 				Fail("[seed.name] ([seed.type]) lacks the [seed.icon_harvest] icon!")

--- a/code/modules/unit_tests/plant_growth_icons.dm
+++ b/code/modules/unit_tests/plant_growth_icons.dm
@@ -1,0 +1,24 @@
+/datum/unit_test/plant_growth_icons
+
+/datum/unit_test/plant_growth_icons/Run()
+	var/list/states = icon_states('icons/obj/hydroponics/growing.dmi')
+	states |= icon_states('icons/obj/hydroponics/growing_fruits.dmi')
+	states |= icon_states('icons/obj/hydroponics/growing_flowers.dmi')
+	states |= icon_states('icons/obj/hydroponics/growing_mushrooms.dmi')
+	states |= icon_states('icons/obj/hydroponics/growing_vegetables.dmi')
+	var/list/paths = typesof(/obj/item/seeds) - /obj/item/seeds - typesof(/obj/item/seeds/sample)
+
+	for(var/seedpath in paths)
+		var/obj/item/seeds/seed = new seedpath
+
+		for(var/i in 1 to seed.growthstages)
+			if("[seed.icon_grow][i]" in states)
+				continue
+			tFail("[seed.name] ([seed.type]) lacks the [seed.icon_grow][i] icon!")
+
+		if(!(seed.icon_dead in states))
+			Fail("[seed.name] ([seed.type]) lacks the [seed.icon_dead] icon!")
+
+		if(seed.icon_harvest) // mushrooms have no grown sprites, same for items with no product
+			if(!(seed.icon_harvest in states))
+				Fail("[seed.name] ([seed.type]) lacks the [seed.icon_harvest] icon!")

--- a/code/modules/unit_tests/plant_growth_icons.dm
+++ b/code/modules/unit_tests/plant_growth_icons.dm
@@ -14,7 +14,7 @@
 		for(var/i in 1 to seed.growthstages)
 			if("[seed.icon_grow][i]" in states)
 				continue
-			tFail("[seed.name] ([seed.type]) lacks the [seed.icon_grow][i] icon!")
+			Fail("[seed.name] ([seed.type]) lacks the [seed.icon_grow][i] icon!")
 
 		if(!(seed.icon_dead in states))
 			Fail("[seed.name] ([seed.type]) lacks the [seed.icon_dead] icon!")

--- a/code/modules/unit_tests/plant_growth_icons.dm
+++ b/code/modules/unit_tests/plant_growth_icons.dm
@@ -1,25 +1,30 @@
 /datum/unit_test/plant_growth_icons
 
 /datum/unit_test/plant_growth_icons/Run()
-	var/list/states = icon_states('icons/obj/hydroponics/growing.dmi')
-	states |= icon_states('icons/obj/hydroponics/growing_fruits.dmi')
-	states |= icon_states('icons/obj/hydroponics/growing_flowers.dmi')
-	states |= icon_states('icons/obj/hydroponics/growing_mushrooms.dmi')
-	states |= icon_states('icons/obj/hydroponics/growing_vegetables.dmi')
-	states |= icon_states('goon/icons/obj/hydroponics.dmi')
+	var/list/files = list(
+		'icons/obj/hydroponics/growing.dmi',
+		'icons/obj/hydroponics/growing_fruits.dmi',
+		'icons/obj/hydroponics/growing_flowers.dmi',
+		'icons/obj/hydroponics/growing_mushrooms.dmi',
+		'icons/obj/hydroponics/growing_vegetables.dmi',
+		'goon/icons/obj/hydroponics.dmi'
+		)
+	var/list/states = list()
+	for(var/file in files)
+		states["[file]"] = icon_states(file)
 	var/list/paths = typesof(/obj/item/seeds) - /obj/item/seeds - typesof(/obj/item/seeds/sample)
 
 	for(var/seedpath in paths)
 		var/obj/item/seeds/seed = new seedpath
 
 		for(var/i in 1 to seed.growthstages)
-			if("[seed.icon_grow][i]" in states)
+			if("[seed.icon_grow][i]" in states[seed.growing_icon])
 				continue
 			Fail("[seed.name] ([seed.type]) lacks the [seed.icon_grow][i] icon!")
 
-		if(!(seed.icon_dead in states))
+		if(!(seed.icon_dead in states[seed.growing_icon]))
 			Fail("[seed.name] ([seed.type]) lacks the [seed.icon_dead] icon!")
 
 		if(seed.icon_harvest) // mushrooms have no grown sprites, same for items with no product
-			if(!(seed.icon_harvest in states))
+			if(!(seed.icon_harvest in states[seed.growing_icon]))
 				Fail("[seed.name] ([seed.type]) lacks the [seed.icon_harvest] icon!")

--- a/code/modules/unit_tests/reagent_id_typos.dm
+++ b/code/modules/unit_tests/reagent_id_typos.dm
@@ -1,5 +1,3 @@
-
-
 /datum/unit_test/reagent_id_typos
 
 /datum/unit_test/reagent_id_typos/Run()

--- a/code/modules/unit_tests/reagent_recipe_collisions.dm
+++ b/code/modules/unit_tests/reagent_recipe_collisions.dm
@@ -1,5 +1,3 @@
-
-
 /datum/unit_test/reagent_recipe_collisions
 
 /datum/unit_test/reagent_recipe_collisions/Run()

--- a/code/modules/unit_tests/unit_test.dm
+++ b/code/modules/unit_tests/unit_test.dm
@@ -18,7 +18,7 @@ GLOBAL_VAR(test_log)
 /datum/unit_test
 	//Bit of metadata for the future maybe
 	var/list/procs_tested
-	
+
 	//usable vars
 	var/turf/run_loc_bottom_left
 	var/turf/run_loc_top_right


### PR DESCRIPTION
removes the growth icon test from adv proccall as there's basically no reason to use it in game if it's already done in travis when people pr. even though i normally hate removing admeme procs.