### PR TITLE
Fixes SCP ruin turret faction, fixes hostile mobs attacking turrets in the same faction

### DIFF
--- a/_maps/RandomRuins/SpaceRuins/scp_294.dmm
+++ b/_maps/RandomRuins/SpaceRuins/scp_294.dmm
@@ -45,14 +45,12 @@
 "aj" = (
 /obj/machinery/porta_turret/syndicate/energy/heavy{
 	desc = "An energy blaster auto-turret designed to contain and terminate in case of a breach in security.";
-	faction = "scp";
+	faction = list("scp");
 	mode = 1;
 	name = "emergency containment breach turret"
 	},
 /obj/effect/turf_decal/box,
-/turf/open/floor/plasteel/dark{
-	initial_gas_mix = "TEMP=2.7"
-	},
+/turf/open/floor/plasteel/dark/airless,
 /area/ruin/space/has_grav/powered/scp_294)
 "ak" = (
 /obj/effect/turf_decal/tile/beige/corner{

--- a/code/game/turfs/simulated/floor/plasteel_floor.dm
+++ b/code/game/turfs/simulated/floor/plasteel_floor.dm
@@ -21,6 +21,8 @@
 
 /turf/open/floor/plasteel/dark
 	icon_state = "darkfull"
+/turf/open/floor/plasteel/dark/airless
+	initial_gas_mix = "TEMP=2.7"
 /turf/open/floor/plasteel/dark/telecomms
 	initial_gas_mix = "n2=100;TEMP=80"
 /turf/open/floor/plasteel/dark/telecomms/mainframe

--- a/code/modules/mob/living/simple_animal/hostile/hostile.dm
+++ b/code/modules/mob/living/simple_animal/hostile/hostile.dm
@@ -188,8 +188,9 @@
 
 		if(istype(the_target, /obj/machinery/porta_turret))
 			var/obj/machinery/porta_turret/P = the_target
-			if(P.faction in faction)
-				return FALSE
+			for(var/turret_faction in P.faction)
+				if(turret_faction in faction)
+					return FALSE
 			if(P.has_cover &&!P.raised) //Don't attack invincible turrets
 				return FALSE
 			if(P.stat & BROKEN) //Or turrets that are already broken

--- a/code/modules/mob/living/simple_animal/hostile/hostile.dm
+++ b/code/modules/mob/living/simple_animal/hostile/hostile.dm
@@ -188,9 +188,8 @@
 
 		if(istype(the_target, /obj/machinery/porta_turret))
 			var/obj/machinery/porta_turret/P = the_target
-			for(var/turret_faction in P.faction)
-				if(turret_faction in faction)
-					return FALSE
+			if(P.in_faction(src)) //Don't attack if the turret is in the same faction
+				return FALSE
 			if(P.has_cover &&!P.raised) //Don't attack invincible turrets
 				return FALSE
 			if(P.stat & BROKEN) //Or turrets that are already broken

--- a/config/lavaruinblacklist.txt
+++ b/config/lavaruinblacklist.txt
@@ -1,6 +1,6 @@
 #Listing maps here will blacklist them from generating in lavaland.
 #Maps must be the full path to them
-#A list of maps valid to blacklist can be found at _maps\RandomRuins\LavaRuins\_maplisting.txt
+#A list of maps valid to blacklist can be found in _maps\RandomRuins\LavaRuins
 #SPECIFYING AN INVALID MAP WILL RESULT IN RUNTIMES ON GAME START
 
 ##BIODOMES

--- a/config/spaceruinblacklist.txt
+++ b/config/spaceruinblacklist.txt
@@ -1,45 +1,48 @@
 #Listing maps here will blacklist them from generating in space.
 #Maps must be the full path to them
-#A list of maps valid to blacklist can be found at _maps\RandomRuins\SpaceRuins\_maplisting.txt
+#A list of maps valid to blacklist can be found in _maps\RandomRuins\SpaceRuins
 #SPECIFYING AN INVALID MAP WILL RESULT IN RUNTIMES ON GAME START
 
-#_maps/RandomRuins/SpaceRuins/way_home.dmm
+#_maps/RandomRuins/SpaceRuins/abandonedteleporter.dmm
+#_maps/RandomRuins/SpaceRuins/abandonedzoo.dmm
 #_maps/RandomRuins/SpaceRuins/asteroid1.dmm
 #_maps/RandomRuins/SpaceRuins/asteroid2.dmm
 #_maps/RandomRuins/SpaceRuins/asteroid3.dmm
 #_maps/RandomRuins/SpaceRuins/asteroid4.dmm
 #_maps/RandomRuins/SpaceRuins/asteroid5.dmm
 #_maps/RandomRuins/SpaceRuins/bigderelict1.dmm
+#_maps/RandomRuins/SpaceRuins/bus.dmm
+#_maps/RandomRuins/SpaceRuins/caravanambush.dmm
+#_maps/RandomRuins/SpaceRuins/cloning_facility.dmm
+#_maps/RandomRuins/SpaceRuins/crashedclownship.dmm
+#_maps/RandomRuins/SpaceRuins/crashedship.dmm
+#_maps/RandomRuins/SpaceRuins/deepstorage.dmm
 #_maps/RandomRuins/SpaceRuins/derelict1.dmm
 #_maps/RandomRuins/SpaceRuins/derelict2.dmm
 #_maps/RandomRuins/SpaceRuins/derelict3.dmm
 #_maps/RandomRuins/SpaceRuins/derelict4.dmm
 #_maps/RandomRuins/SpaceRuins/derelict5.dmm
 #_maps/RandomRuins/SpaceRuins/derelict6.dmm
-#_maps/RandomRuins/SpaceRuins/spacebar.dmm
-#_maps/RandomRuins/SpaceRuins/abandonedzoo.dmm
-#_maps/RandomRuins/SpaceRuins/deepstorage.dmm
+#_maps/RandomRuins/SpaceRuins/djstation.dmm
 #_maps/RandomRuins/SpaceRuins/emptyshell.dmm
 #_maps/RandomRuins/SpaceRuins/gasthelizards.dmm
+#_maps/RandomRuins/SpaceRuins/gondolaasteroid.dmm
 #_maps/RandomRuins/SpaceRuins/intactemptyship.dmm
-#_maps/RandomRuins/SpaceRuins/mechtransport.dmm
-#_maps/RandomRuins/SpaceRuins/turretedoutpost.dmm
-#_maps/RandomRuins/SpaceRuins/caravanambush.dmm
-#_maps/RandomRuins/SpaceRuins/originalcontent.dmm
-#_maps/RandomRuins/SpaceRuins/onehalf.dmm
-#_maps/RandomRuins/SpaceRuins/spacehotel.dmm
-#_maps/RandomRuins/SpaceRuins/turretedoutpost.dmm
-#_maps/RandomRuins/SpaceRuins/shuttlerelic.dmm
-#_maps/RandomRuins/SpaceRuins/djstation.dmm
-#_maps/RandomRuins/SpaceRuins/thederelict.dmm
-#_maps/RandomRuins/SpaceRuins/abandonedteleporter.dmm
-#_maps/RandomRuins/SpaceRuins/crashedclownship.dmm
-#_maps/RandomRuins/SpaceRuins/crashedship.dmm
 #_maps/RandomRuins/SpaceRuins/listeningstation.dmm
-#_maps/RandomRuins/SpaceRuins/oldAIsat.dmm
-#_maps/RandomRuins/SpaceRuins/oldteleporter.dmm
-#_maps/RandomRuins/SpaceRuins/vaporwave.dmm
-#_maps/RandomRuins/SpaceRuins/bus.dmm
+#_maps/RandomRuins/SpaceRuins/mechtransport.dmm
 #_maps/RandomRuins/SpaceRuins/miracle.dmm
+#_maps/RandomRuins/SpaceRuins/mrow_thats_right
+#_maps/RandomRuins/SpaceRuins/oldAIsat.dmm
 #_maps/RandomRuins/SpaceRuins/oldstation.dmm
+#_maps/RandomRuins/SpaceRuins/oldteleporter.dmm
+#_maps/RandomRuins/SpaceRuins/onehalf.dmm
+#_maps/RandomRuins/SpaceRuins/originalcontent.dmm
+#_maps/RandomRuins/SpaceRuins/scp_294.dmm
+#_maps/RandomRuins/SpaceRuins/shuttlerelic.dmm
+#_maps/RandomRuins/SpaceRuins/spacehotel.dmm
+#_maps/RandomRuins/SpaceRuins/thederelict.dmm
+#_maps/RandomRuins/SpaceRuins/turretedoutpost.dmm
+#_maps/RandomRuins/SpaceRuins/vaporwave.dmm
+#_maps/RandomRuins/SpaceRuins/way_home.dmm
 #_maps/RandomRuins/SpaceRuins/whiteshipdock.dmm
+#_maps/RandomRuins/SpaceRuins/whiteshipruin_box.dmm


### PR DESCRIPTION
🆑 ShizCalev
fix: Fixed the SCP ruin killing itself.
/🆑

Fixes #37253
Closes #37265

another leftover from changing turret factions to lists
also sorted and added missing ruins to the spaceruins blacklist, as well as cleaned up references to the remove _maplisting.txt files.