### PR TITLE
fixes skateboards giving infinite metal

### DIFF
--- a/code/modules/vehicles/scooter.dm
+++ b/code/modules/vehicles/scooter.dm
@@ -147,6 +147,9 @@
 		qdel(src)
 	return TRUE
 
+/obj/vehicle/ridden/scooter/skateboard/wrench_act(mob/living/user, obj/item/I)
+	return
+
 //Wheelys
 /obj/vehicle/ridden/scooter/wheelys
 	name = "Wheely-Heels"


### PR DESCRIPTION
Fixes #37292 
🆑imsxz
fix: skateboards can no longer be used to get infinite metal rods
/🆑
skateboard deconstruction is already handled by a screwdriver apparently, original skateboard guy never redefined the wrench act though so it was yielding the results of a deconstructed scooter (the results being a NEW skateboard and 2 metal rods)