### PR TITLE
Fixes and optimises apc_control.dm a tad.

### DIFF
--- a/code/game/machinery/computer/apc_control.dm
+++ b/code/game/machinery/computer/apc_control.dm
@@ -6,7 +6,6 @@
 	req_access = list(ACCESS_ENGINE)
 	circuit = /obj/item/circuitboard/computer/apc_control
 	light_color = LIGHT_COLOR_YELLOW
-	var/list/apcs //APCs the computer has access to
 	var/mob/living/operator //Who's operating the computer right now
 	var/obj/machinery/power/apc/active_apc //The APC we're using right now
 	var/list/result_filters //For sorting the results
@@ -17,15 +16,9 @@
 
 /obj/machinery/computer/apc_control/Initialize()
 	. = ..()
-	apcs = list() //To avoid BYOND making the list run through a ton of procs
 	result_filters = list("Name" = null, "Charge Above" = null, "Charge Below" = null, "Responsive" = null)
 
 /obj/machinery/computer/apc_control/process()
-	apcs = list() //Clear the list every tick
-	for(var/V in GLOB.apcs_list)
-		var/obj/machinery/power/apc/APC = V
-		if(check_apc(APC))
-			apcs[APC.name] = APC
 	if(operator && (!operator.Adjacent(src) || stat))
 		operator = null
 		if(active_apc)
@@ -56,20 +49,21 @@
 			dat += "<b>Name:</b> <a href='?src=[REF(src)];name_filter=1'>[result_filters["Name"] ? result_filters["Name"] : "None set"]</a><br>"
 			dat += "<b>Charge:</b> <a href='?src=[REF(src)];above_filter=1'>\>[result_filters["Charge Above"] ? result_filters["Charge Above"] : "NaN"]%</a> and <a href='?src=[REF(src)];below_filter=1'>\<[result_filters["Charge Below"] ? result_filters["Charge Below"] : "NaN"]%</a><br>"
 			dat += "<b>Accessible:</b> <a href='?src=[REF(src)];access_filter=1'>[result_filters["Responsive"] ? "Non-Responsive Only" : "All"]</a><br><br>"
-			for(var/A in apcs)
-				var/obj/machinery/power/apc/APC = apcs[A]
-				if(result_filters["Name"] && !findtext(APC.name, result_filters["Name"]) && !findtext(APC.area.name, result_filters["Name"]))
-					continue
-				if(result_filters["Charge Above"] && (!APC.cell || (APC.cell && (APC.cell.charge / APC.cell.maxcharge) < result_filters["Charge Above"] / 100)))
-					continue
-				if(result_filters["Charge Below"] && APC.cell && (APC.cell.charge / APC.cell.maxcharge) > result_filters["Charge Below"] / 100)
-					continue
-				if(result_filters["Responsive"] && !APC.aidisabled)
-					continue
-				dat += "<a href='?src=[REF(src)];access_apc=[REF(APC)]'>[A]</a><br>\
-				<b>Charge:</b> [APC.cell ? "[DisplayEnergy(APC.cell.charge)] / [DisplayEnergy(APC.cell.maxcharge)] ([round((APC.cell.charge / APC.cell.maxcharge) * 100)]%)" : "No Powercell Installed"]<br>\
-				<b>Area:</b> [APC.area]<br>\
-				[APC.aidisabled || APC.panel_open ? "<font color='#FF0000'>APC does not respond to interface query.</font>" : "<font color='#00FF00'>APC responds to interface query.</font>"]<br><br>"
+			for(var/A in GLOB.apcs_list)
+				if(check_apc(A))
+					var/obj/machinery/power/apc/APC = A
+					if(result_filters["Name"] && !findtext(APC.name, result_filters["Name"]) && !findtext(APC.area.name, result_filters["Name"]))
+						continue
+					if(result_filters["Charge Above"] && (!APC.cell || (APC.cell && (APC.cell.charge / APC.cell.maxcharge) < result_filters["Charge Above"] / 100)))
+						continue
+					if(result_filters["Charge Below"] && APC.cell && (APC.cell.charge / APC.cell.maxcharge) > result_filters["Charge Below"] / 100)
+						continue
+					if(result_filters["Responsive"] && !APC.aidisabled)
+						continue
+					dat += "<a href='?src=[REF(src)];access_apc=[REF(APC)]'>[A]</a><br>\
+					<b>Charge:</b> [APC.cell ? "[DisplayEnergy(APC.cell.charge)] / [DisplayEnergy(APC.cell.maxcharge)] ([round((APC.cell.charge / APC.cell.maxcharge) * 100)]%)" : "No Powercell Installed"]<br>\
+					<b>Area:</b> [APC.area]<br>\
+					[APC.aidisabled || APC.panel_open ? "<font color='#FF0000'>APC does not respond to interface query.</font>" : "<font color='#00FF00'>APC responds to interface query.</font>"]<br><br>"
 			dat += "<a href='?src=[REF(src)];check_logs=1'>Check Logs</a><br>"
 			dat += "<a href='?src=[REF(src)];log_out=1'>Log Out</a><br>"
 			if(obj_flags & EMAGGED)
@@ -130,7 +124,7 @@
 			active_apc = null
 		to_chat(usr, "<span class='robot notice'>[icon2html(src, usr)] Connected to APC in [APC.area]. Interface request sent.</span>")
 		log_activity("remotely accessed APC in [APC.area]")
-		APC.interact(usr, GLOB.not_incapacitated_state)
+		APC.ui_interact(usr, state = GLOB.not_incapacitated_state)
 		playsound(src, 'sound/machines/terminal_prompt_confirm.ogg', 50, 0)
 		message_admins("[key_name_admin(usr)] remotely accessed [APC] from [src] at [get_area(src)].")
 		log_game("[key_name(usr)] remotely accessed [APC] from [src] at [get_area(src)].")


### PR DESCRIPTION
it can probably be fixed up further.

Fixes #37211

:cl: Power Control Support
fix: What do you mean we accidentally routed the interaction back to the apc control conso- oh for fleeps sake STEVE WHAT DID YOU DO!!
/:cl:

I also removed a list inside the computer for this object type since it literally wasnt nessecary and getting it from the GLOB list when you interact with the computer is a much saner and more suitable route.