### PR TITLE
[s] You can no longer buckle anchored mobs to things.

### DIFF
--- a/code/game/objects/buckling.dm
+++ b/code/game/objects/buckling.dm
@@ -107,7 +107,7 @@
 
 //Wrapper procs that handle sanity and user feedback
 /atom/movable/proc/user_buckle_mob(mob/living/M, mob/user, check_loc = TRUE)
-	if(!in_range(user, src) || !isturf(user.loc) || user.incapacitated())
+	if(!in_range(user, src) || !isturf(user.loc) || user.incapacitated() || M.anchored)
 		return FALSE
 
 	add_fingerprint(user)


### PR DESCRIPTION
[Changelogs]:

:cl: Dax Dupont
fix: Fixes an exploit where tendrils/other spawners/anchored mobs in general could be buckled to things and thus moved around.
/:cl:

[why]: Fixes #27109
Fixes #37169
