### PR TITLE
Optimize runlevel usage in MC

### DIFF
--- a/code/__DEFINES/subsystems.dm
+++ b/code/__DEFINES/subsystems.dm
@@ -119,7 +119,8 @@
 
 #define RUNLEVELS_DEFAULT (RUNLEVEL_SETUP | RUNLEVEL_GAME | RUNLEVEL_POSTGAME)
 
-
+GLOBAL_LIST_INIT(runlevel_flags, list(RUNLEVEL_LOBBY, RUNLEVEL_SETUP, RUNLEVEL_GAME, RUNLEVEL_POSTGAME))
+#define RUNLEVEL_FLAG_TO_INDEX(flag) (log(2, flag) + 1)	// Convert from the runlevel bitfield constants to index in runlevel_flags list
 
 
 #define COMPILE_OVERLAYS(A)\

--- a/code/controllers/master.dm
+++ b/code/controllers/master.dm
@@ -194,7 +194,7 @@ GLOBAL_REAL(Master, /datum/controller/master) = new
 	log_world(msg)
 
 	if (!current_runlevel)
-		SetRunLevel(1)
+		SetRunLevel(RUNLEVEL_LOBBY)
 
 	// Sort subsystems by display setting for easy access.
 	sortTim(subsystems, /proc/cmp_subsystem_display)
@@ -216,7 +216,7 @@ GLOBAL_REAL(Master, /datum/controller/master) = new
 		old_runlevel = "NULL"
 
 	testing("MC: Runlevel changed from [old_runlevel] to [new_runlevel]")
-	current_runlevel = log(2, new_runlevel) + 1
+	current_runlevel = RUNLEVEL_FLAG_TO_INDEX(new_runlevel)
 	if(current_runlevel < 1)
 		CRASH("Attempted to set invalid runlevel: [new_runlevel]")
 
@@ -264,8 +264,8 @@ GLOBAL_REAL(Master, /datum/controller/master) = new
 
 		var/ss_runlevels = SS.runlevels
 		var/added_to_any = FALSE
-		for(var/I in 1 to GLOB.bitflags.len)
-			if(ss_runlevels & GLOB.bitflags[I])
+		for(var/I in 1 to GLOB.runlevel_flags.len)
+			if(ss_runlevels & GLOB.runlevel_flags[I])
 				while(runlevel_sorted_subsystems.len < I)
 					runlevel_sorted_subsystems += list(list())
 				runlevel_sorted_subsystems[I] += SS


### PR DESCRIPTION
Instead of looping over the 16 elements of GLOB.bitfield, if we just create a global list of valid runlevels we can loop only over that, saving 12*subsystems.len iterations. For what its worth.
Also replaced a bare number with its define while I was there.
:cl:
refactor: There are only 4 runlevels, so we don't need to loop from 1 to 16 when populating `runlevel_sorted_subsystems`.  
/:cl: