### PR TITLE
Delta ORM position

### DIFF
--- a/_maps/map_files/Deltastation/DeltaStation2.dmm
+++ b/_maps/map_files/Deltastation/DeltaStation2.dmm
@@ -27358,6 +27358,7 @@
 /obj/structure/cable/white{
 	icon_state = "1-4"
 	},
+/obj/effect/turf_decal/loading_area,
 /turf/open/floor/plasteel,
 /area/quartermaster/miningoffice)
 "blS" = (

--- a/_maps/map_files/Deltastation/DeltaStation2.dmm
+++ b/_maps/map_files/Deltastation/DeltaStation2.dmm
@@ -100216,15 +100216,6 @@
 /obj/machinery/rnd/production/techfab/department/cargo,
 /turf/open/floor/plasteel/brown,
 /area/quartermaster/office)
-"ehK" = (
-/obj/machinery/mineral/ore_redemption{
-	input_dir = 4;
-	output_dir = 8
-	},
-/obj/machinery/door/firedoor,
-/obj/effect/turf_decal/stripes/box,
-/turf/open/floor/plasteel/neutral,
-/area/quartermaster/miningoffice)
 "ehL" = (
 /obj/structure/cable/white{
 	icon_state = "1-2"
@@ -100656,6 +100647,12 @@
 	dir = 6
 	},
 /area/science/circuit)
+"rUL" = (
+/obj/machinery/mineral/ore_redemption,
+/obj/machinery/door/firedoor,
+/obj/effect/turf_decal/stripes/box,
+/turf/open/floor/plasteel/neutral,
+/area/quartermaster/miningoffice)
 "saw" = (
 /turf/closed/wall,
 /area/science/circuit)
@@ -144088,7 +144085,7 @@ bgK
 bii
 bjU
 blR
-baU
+rUL
 boO
 bqZ
 bsT
@@ -144600,7 +144597,7 @@ baU
 bfw
 bgG
 bik
-ehK
+baU
 baQ
 baQ
 boW


### PR DESCRIPTION
:cl: Denton
tweak: Moved Deltastation's ORM so that all crew can access it.
/:cl:

With #36387 getting merged, it doesn't make sense to keep the ORM in the mining office. Instead, I put it two tiles SW so that crew can access it.

![37684242-af733b1a-2c8f-11e8-91a5-cdaf21bc71f1](https://user-images.githubusercontent.com/32391752/39086629-bc95d0dc-4594-11e8-9ad2-36417303b162.JPG)
