### PR TITLE
Changeling vs Changeling

### DIFF
--- a/code/game/gamemodes/objective.dm
+++ b/code/game/gamemodes/objective.dm
@@ -630,7 +630,12 @@ GLOBAL_LIST_EMPTY(possible_items_special)
 		var/datum/antagonist/changeling/changeling = M.has_antag_datum(/datum/antagonist/changeling)
 		if(!changeling)
 			continue
-		if(changeling.geneticpoints > initial(changeling.geneticpoints))
+		var/total_genetic_points = changeling.geneticpoints
+
+		for(var/obj/effect/proc_holder/changeling/p in changeling.purchasedpowers)
+			total_genetic_points += p.dna_cost
+
+		if(total_genetic_points > initial(changeling.geneticpoints))
 			return TRUE
 	return FALSE
 

--- a/code/game/gamemodes/objective.dm
+++ b/code/game/gamemodes/objective.dm
@@ -566,6 +566,8 @@ GLOBAL_LIST_EMPTY(possible_items_special)
 	return captured_amount >= target_amount
 
 
+//Changeling Objectives
+
 /datum/objective/absorb
 
 /datum/objective/absorb/proc/gen_amount_goal(lowbound = 4, highbound = 6)
@@ -597,7 +599,42 @@ GLOBAL_LIST_EMPTY(possible_items_special)
 		absorbedcount += changeling.absorbedcount
 	return absorbedcount >= target_amount
 
+/datum/objective/absorb_most
+	explanation_text = "Extract more compatible genomes than any other Changeling."
 
+/datum/objective/absorb_most/check_completion()
+	var/list/datum/mind/owners = get_owners()
+	var/absorbedcount = 0
+	for(var/datum/mind/M in owners)
+		if(!M)
+			continue
+		var/datum/antagonist/changeling/changeling = M.has_antag_datum(/datum/antagonist/changeling)
+		if(!changeling || !changeling.stored_profiles)
+			continue
+		absorbedcount += changeling.absorbedcount
+
+	for(var/datum/antagonist/changeling/changeling2 in GLOB.antagonists)
+		if(!changeling2.owner || !changeling2.stored_profiles || changeling2.absorbedcount < absorbedcount)
+			continue
+		return FALSE
+	return TRUE
+
+/datum/objective/absorb_changeling
+	explanation_text = "Absorb another Changeling."
+
+/datum/objective/absorb_changeling/check_completion()
+	var/list/datum/mind/owners = get_owners()
+	for(var/datum/mind/M in owners)
+		if(!M)
+			continue
+		var/datum/antagonist/changeling/changeling = M.has_antag_datum(/datum/antagonist/changeling)
+		if(!changeling)
+			continue
+		if(changeling.geneticpoints > initial(changeling.geneticpoints))
+			return TRUE
+	return FALSE
+
+//End Changeling Objectives
 
 /datum/objective/destroy
 	martyr_compatible = 1

--- a/code/modules/antagonists/changeling/changeling.dm
+++ b/code/modules/antagonists/changeling/changeling.dm
@@ -367,11 +367,21 @@
 		if(!CTO.escape_objective_compatible)
 			escape_objective_possible = FALSE
 			break
-
-	var/datum/objective/absorb/absorb_objective = new
-	absorb_objective.owner = owner
-	absorb_objective.gen_amount_goal(6, 8)
-	objectives += absorb_objective
+	var/changeling_objective = rand(1,3)
+	switch(changeling_objective)
+		if(1)
+			var/datum/objective/absorb/absorb_objective = new
+			absorb_objective.owner = owner
+			absorb_objective.gen_amount_goal(6, 8)
+			objectives += absorb_objective
+		if(2)
+			var/datum/objective/absorb_changeling/ac = new
+			ac.owner = owner
+			objectives += ac
+		if(3)
+			var/datum/objective/absorb_most/ac = new
+			ac.owner = owner
+			objectives += ac
 
 	if(prob(60))
 		if(prob(85))

--- a/code/modules/antagonists/changeling/powers/absorb.dm
+++ b/code/modules/antagonists/changeling/powers/absorb.dm
@@ -89,9 +89,11 @@
 
 		var/datum/antagonist/changeling/target_ling = target.mind.has_antag_datum(/datum/antagonist/changeling)
 		if(target_ling)//If the target was a changeling, suck out their extra juice and objective points!
+			target_ling.remove_changeling_powers()
+			target_ling.geneticpoints = 0
 			changeling.chem_charges += min(target_ling.chem_charges, changeling.chem_storage)
 			changeling.absorbedcount += (target_ling.absorbedcount)
-
+			changeling.geneticpoints += 4
 			target_ling.stored_profiles.len = 1
 			target_ling.absorbedcount = 0
 

--- a/code/modules/antagonists/changeling/powers/absorb.dm
+++ b/code/modules/antagonists/changeling/powers/absorb.dm
@@ -91,6 +91,7 @@
 		if(target_ling)//If the target was a changeling, suck out their extra juice and objective points!
 			target_ling.remove_changeling_powers()
 			target_ling.geneticpoints = 0
+			target_ling.canrespec = 0
 			changeling.chem_charges += min(target_ling.chem_charges, changeling.chem_storage)
 			changeling.absorbedcount += (target_ling.absorbedcount)
 			changeling.geneticpoints += 4

--- a/code/modules/antagonists/changeling/powers/absorb.dm
+++ b/code/modules/antagonists/changeling/powers/absorb.dm
@@ -89,12 +89,16 @@
 
 		var/datum/antagonist/changeling/target_ling = target.mind.has_antag_datum(/datum/antagonist/changeling)
 		if(target_ling)//If the target was a changeling, suck out their extra juice and objective points!
+			to_chat(user, "<span class='boldnotice'>[target] was one of us. We have absorbed their power.</span>")
 			target_ling.remove_changeling_powers()
+			changeling.geneticpoints += round(target_ling.geneticpoints/2)
 			target_ling.geneticpoints = 0
 			target_ling.canrespec = 0
+			changeling.chem_storage += round(target_ling.chem_storage/2)
 			changeling.chem_charges += min(target_ling.chem_charges, changeling.chem_storage)
+			target_ling.chem_charges = 0
+			target_ling.chem_storage = 0
 			changeling.absorbedcount += (target_ling.absorbedcount)
-			changeling.geneticpoints += 4
 			target_ling.stored_profiles.len = 1
 			target_ling.absorbedcount = 0
 

--- a/code/modules/antagonists/changeling/powers/regenerate.dm
+++ b/code/modules/antagonists/changeling/powers/regenerate.dm
@@ -8,7 +8,6 @@
 	chemical_cost = 10
 	dna_cost = 0
 	req_stat = UNCONSCIOUS
-	always_keep = TRUE
 
 /obj/effect/proc_holder/changeling/regenerate/sting_action(mob/living/user)
 	to_chat(user, "<span class='notice'>You feel an itching, both inside and \

--- a/code/modules/antagonists/changeling/powers/revive.dm
+++ b/code/modules/antagonists/changeling/powers/revive.dm
@@ -29,7 +29,7 @@
 	return TRUE
 
 /obj/effect/proc_holder/changeling/revive/can_be_used_by(mob/living/user)
-	if((user.stat != DEAD) && !(user.has_trait(TRAIT_FAKEDEATH)))
+	if(!(user.has_trait(CHANGELING_DRAIN)) && (user.stat != DEAD) && !(user.has_trait(TRAIT_FAKEDEATH)))
 		var/datum/antagonist/changeling/changeling = user.mind.has_antag_datum(/datum/antagonist/changeling)
 		changeling.purchasedpowers -= src
 		return 0

--- a/code/modules/antagonists/changeling/powers/revive.dm
+++ b/code/modules/antagonists/changeling/powers/revive.dm
@@ -29,7 +29,7 @@
 	return TRUE
 
 /obj/effect/proc_holder/changeling/revive/can_be_used_by(mob/living/user)
-	if(!(user.has_trait(CHANGELING_DRAIN)) && (user.stat != DEAD) && !(user.has_trait(TRAIT_FAKEDEATH)))
+	if(user.has_trait(CHANGELING_DRAIN) || ((user.stat != DEAD) && !(user.has_trait(TRAIT_FAKEDEATH))))
 		var/datum/antagonist/changeling/changeling = user.mind.has_antag_datum(/datum/antagonist/changeling)
 		changeling.purchasedpowers -= src
 		return 0


### PR DESCRIPTION
:cl: Kor
add: Changelings can now have an objective to have more genomes than any other changeling, rather than a set target.
add: Changelings can now have an objective to absorb another changeling.
add: Changelings now get bonus genetic points for buying powers when they absorb another changeling. Their chem storage cap will also be increased.
add: Changelings absorbed by other changelings will lose all their powers, chems, and genetic points, making them unable to revive.
/:cl:

Why: Changelings are way too powerful when they're rolling around in an eight man death squad. This preserves the hive mind, but adds significant risk to to trusting other changelings, and a strong incentive to backstab them. I think a system of uneasy alliances will be much more entertaining than team changeling or forced solo changeling.

Things I'm considering changing:

2/3 chance of an objective explicitly hostile to other lings might be a bit high. Closer to 50/50 might be better.

Letting absorbed lings keep their absorb power so they can kill and absorb a ling for their powers back.
