### PR TITLE
Adds disk fridges to meta/box/pubby.

### DIFF
--- a/_maps/map_files/BoxStation/BoxStation.dmm
+++ b/_maps/map_files/BoxStation/BoxStation.dmm
@@ -14550,8 +14550,8 @@
 /turf/open/floor/wood,
 /area/crew_quarters/theatre)
 "aKK" = (
-/obj/structure/closet/wardrobe/botanist,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/structure/closet/secure_closet/hydroponics,
 /turf/open/floor/plasteel/hydrofloor,
 /area/hydroponics)
 "aKL" = (
@@ -15272,6 +15272,7 @@
 /area/library)
 "aMI" = (
 /obj/machinery/light/small,
+/obj/structure/closet/wardrobe/botanist,
 /turf/open/floor/plasteel/hydrofloor,
 /area/hydroponics)
 "aMJ" = (
@@ -53670,6 +53671,10 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plasteel/dark,
 /area/engine/engineering)
+"fGf" = (
+/obj/machinery/smartfridge/disks,
+/turf/open/floor/plasteel/hydrofloor,
+/area/hydroponics)
 "fKl" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/effect/landmark/event_spawn,
@@ -95368,7 +95373,7 @@ aFp
 aGW
 anf
 aIp
-aKI
+fGf
 aMA
 aIp
 aOX

--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -50254,13 +50254,10 @@
 /turf/open/floor/plasteel,
 /area/hydroponics)
 "ccz" = (
-/obj/item/wrench,
-/obj/item/clothing/suit/apron,
-/obj/item/clothing/accessory/armband/hydro,
-/obj/structure/table/glass,
 /obj/effect/turf_decal/stripes/line{
-	dir = 9
+	dir = 1
 	},
+/obj/machinery/smartfridge/disks,
 /turf/open/floor/plasteel,
 /area/hydroponics)
 "ccA" = (
@@ -71958,7 +71955,7 @@
 "dbE" = (
 /obj/machinery/plantgenes,
 /obj/effect/turf_decal/stripes/line{
-	dir = 9
+	dir = 1
 	},
 /turf/open/floor/plasteel,
 /area/hydroponics)
@@ -76713,6 +76710,14 @@
 "krD" = (
 /turf/closed/wall,
 /area/science/circuit)
+"kwI" = (
+/obj/item/wrench,
+/obj/item/clothing/suit/apron,
+/obj/item/clothing/accessory/armband/hydro,
+/obj/structure/table/glass,
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/plasteel,
+/area/hydroponics)
 "kys" = (
 /obj/structure/cable/yellow{
 	icon_state = "0-8"
@@ -112498,7 +112503,7 @@ bOW
 bQH
 bRV
 bST
-bUh
+kwI
 bVx
 bWS
 bYi

--- a/_maps/map_files/PubbyStation/PubbyStation.dmm
+++ b/_maps/map_files/PubbyStation/PubbyStation.dmm
@@ -17551,10 +17551,10 @@
 /turf/open/floor/plasteel/hydrofloor,
 /area/hydroponics)
 "aSF" = (
-/obj/machinery/chem_master/condimaster,
 /obj/machinery/light/small{
 	dir = 1
 	},
+/obj/machinery/smartfridge/disks,
 /turf/open/floor/plasteel/hydrofloor,
 /area/hydroponics)
 "aSG" = (
@@ -49990,6 +49990,10 @@
 	dir = 1
 	},
 /area/science/circuit)
+"eIh" = (
+/obj/machinery/chem_master/condimaster,
+/turf/open/floor/plasteel/hydrofloor,
+/area/hydroponics)
 "eQR" = (
 /obj/effect/spawner/lootdrop/two_percent_xeno_egg_spawner,
 /turf/open/floor/engine,
@@ -77467,7 +77471,7 @@ aQJ
 aRL
 aSD
 aTT
-aTV
+eIh
 aRL
 aWR
 aXT


### PR DESCRIPTION
[Changelogs]: 

:cl: Dax Dupont
add: More stations have been outfitted with disk compartmentalizers.
/:cl:

[why]: Currently only delta has one, and it's pretty handy vs juggling plant dna disks for everything. It was requested by a few players.
Freeze is officially over so features are a go!
