### PR TITLE
Fixes a lack of feedback when entering too many points for the gulag.

### DIFF
--- a/code/game/machinery/computer/gulag_teleporter.dm
+++ b/code/game/machinery/computer/gulag_teleporter.dm
@@ -106,6 +106,8 @@
 				return
 			if(!new_goal)
 				new_goal = default_goal
+			if (new_goal > 1000)
+				to_chat(usr, "The entered amount of points is too large. Points have instead been set to the maximum allowed amount.")
 			id.goal = CLAMP(new_goal, 0, 1000) //maximum 1000 points
 		if("toggle_open")
 			if(teleporter.locked)


### PR DESCRIPTION
[Changelogs]:

:cl: Dax Dupont
fix: Fixed a lack of feedback when entering too many points for the gulag.
/:cl:

[why]: Since we're clamping to 1k max we should probably notify the user that their chosen amount overrides that. This will also help with people who mistype the amount of points, or at least prevent people from using it as an excuse as much.