### PR TITLE
Adds multilayer pipe subtypes for mapping

### DIFF
--- a/code/modules/atmospherics/machinery/components/binary_devices/dp_vent_pump.dm
+++ b/code/modules/atmospherics/machinery/components/binary_devices/dp_vent_pump.dm
@@ -31,10 +31,30 @@ Acts like a normal vent, but has an input AND output.
 	//EXT_BOUND: Do not pass external_pressure_bound
 	//INPUT_MIN: Do not pass input_pressure_min
 	//OUTPUT_MAX: Do not pass output_pressure_max
+	
+/obj/machinery/atmospherics/components/binary/dp_vent_pump/layer1
+	piping_layer = 1
+	pixel_x = -5
+	pixel_y = -5
+	
+/obj/machinery/atmospherics/components/binary/dp_vent_pump/layer3
+	piping_layer = 3
+	pixel_x = 5
+	pixel_y = 5
 
 /obj/machinery/atmospherics/components/binary/dp_vent_pump/on
 	on = TRUE
 	icon_state = "dpvent_map_on"
+	
+/obj/machinery/atmospherics/components/binary/dp_vent_pump/on/layer1
+	piping_layer = 1
+	pixel_x = -5
+	pixel_y = -5
+	
+/obj/machinery/atmospherics/components/binary/dp_vent_pump/on/layer3
+	piping_layer = 3
+	pixel_x = 5
+	pixel_y = 5
 
 /obj/machinery/atmospherics/components/binary/dp_vent_pump/Destroy()
 	SSradio.remove_object(src, frequency)
@@ -42,10 +62,30 @@ Acts like a normal vent, but has an input AND output.
 
 /obj/machinery/atmospherics/components/binary/dp_vent_pump/high_volume
 	name = "large dual-port air vent"
+	
+/obj/machinery/atmospherics/components/binary/dp_vent_pump/high_volume/layer1
+	piping_layer = 1
+	pixel_x = -5
+	pixel_y = -5
+	
+/obj/machinery/atmospherics/components/binary/dp_vent_pump/high_volume/layer3
+	piping_layer = 3
+	pixel_x = 5
+	pixel_y = 5
 
 /obj/machinery/atmospherics/components/binary/dp_vent_pump/high_volume/on
 	on = TRUE
 	icon_state = "dpvent_map_on"
+	
+/obj/machinery/atmospherics/components/binary/dp_vent_pump/high_volume/on/layer1
+	piping_layer = 1
+	pixel_x = -5
+	pixel_y = -5
+	
+/obj/machinery/atmospherics/components/binary/dp_vent_pump/high_volume/on/layer3
+	piping_layer = 3
+	pixel_x = 5
+	pixel_y = 5
 
 /obj/machinery/atmospherics/components/binary/dp_vent_pump/high_volume/New()
 	..()

--- a/code/modules/atmospherics/machinery/components/binary_devices/dp_vent_pump.dm
+++ b/code/modules/atmospherics/machinery/components/binary_devices/dp_vent_pump.dm
@@ -33,28 +33,28 @@ Acts like a normal vent, but has an input AND output.
 	//OUTPUT_MAX: Do not pass output_pressure_max
 	
 /obj/machinery/atmospherics/components/binary/dp_vent_pump/layer1
-	piping_layer = 1
-	pixel_x = -5
-	pixel_y = -5
+	piping_layer = PIPING_LAYER_MIN
+	pixel_x = -PIPING_LAYER_P_X
+	pixel_y = -PIPING_LAYER_P_Y
 	
 /obj/machinery/atmospherics/components/binary/dp_vent_pump/layer3
-	piping_layer = 3
-	pixel_x = 5
-	pixel_y = 5
+	piping_layer = PIPING_LAYER_MAX
+	pixel_x = PIPING_LAYER_P_X
+	pixel_y = PIPING_LAYER_P_Y
 
 /obj/machinery/atmospherics/components/binary/dp_vent_pump/on
 	on = TRUE
 	icon_state = "dpvent_map_on"
 	
 /obj/machinery/atmospherics/components/binary/dp_vent_pump/on/layer1
-	piping_layer = 1
-	pixel_x = -5
-	pixel_y = -5
+	piping_layer = PIPING_LAYER_MIN
+	pixel_x = -PIPING_LAYER_P_X
+	pixel_y = -PIPING_LAYER_P_Y
 	
 /obj/machinery/atmospherics/components/binary/dp_vent_pump/on/layer3
-	piping_layer = 3
-	pixel_x = 5
-	pixel_y = 5
+	piping_layer = PIPING_LAYER_MAX
+	pixel_x = PIPING_LAYER_P_X
+	pixel_y = PIPING_LAYER_P_Y
 
 /obj/machinery/atmospherics/components/binary/dp_vent_pump/Destroy()
 	SSradio.remove_object(src, frequency)
@@ -64,28 +64,28 @@ Acts like a normal vent, but has an input AND output.
 	name = "large dual-port air vent"
 	
 /obj/machinery/atmospherics/components/binary/dp_vent_pump/high_volume/layer1
-	piping_layer = 1
-	pixel_x = -5
-	pixel_y = -5
+	piping_layer = PIPING_LAYER_MIN
+	pixel_x = -PIPING_LAYER_P_X
+	pixel_y = -PIPING_LAYER_P_Y
 	
 /obj/machinery/atmospherics/components/binary/dp_vent_pump/high_volume/layer3
-	piping_layer = 3
-	pixel_x = 5
-	pixel_y = 5
+	piping_layer = PIPING_LAYER_MAX
+	pixel_x = PIPING_LAYER_P_X
+	pixel_y = PIPING_LAYER_P_Y
 
 /obj/machinery/atmospherics/components/binary/dp_vent_pump/high_volume/on
 	on = TRUE
 	icon_state = "dpvent_map_on"
 	
 /obj/machinery/atmospherics/components/binary/dp_vent_pump/high_volume/on/layer1
-	piping_layer = 1
-	pixel_x = -5
-	pixel_y = -5
+	piping_layer = PIPING_LAYER_MIN
+	pixel_x = -PIPING_LAYER_P_X
+	pixel_y = -PIPING_LAYER_P_Y
 	
 /obj/machinery/atmospherics/components/binary/dp_vent_pump/high_volume/on/layer3
-	piping_layer = 3
-	pixel_x = 5
-	pixel_y = 5
+	piping_layer = PIPING_LAYER_MAX
+	pixel_x = PIPING_LAYER_P_X
+	pixel_y = PIPING_LAYER_P_Y
 
 /obj/machinery/atmospherics/components/binary/dp_vent_pump/high_volume/New()
 	..()

--- a/code/modules/atmospherics/machinery/components/binary_devices/passive_gate.dm
+++ b/code/modules/atmospherics/machinery/components/binary_devices/passive_gate.dm
@@ -27,14 +27,14 @@ Passive gate is similar to the regular pump except:
 	pipe_state = "passivegate"
 	
 /obj/machinery/atmospherics/components/binary/passive_gate/layer1
-	piping_layer = 1
-	pixel_x = -5
-	pixel_y = -5
+	piping_layer = PIPING_LAYER_MIN
+	pixel_x = -PIPING_LAYER_P_X
+	pixel_y = -PIPING_LAYER_P_Y
 
 /obj/machinery/atmospherics/components/binary/passive_gate/layer3
-	piping_layer = 3
-	pixel_x = 5
-	pixel_y = 5
+	piping_layer = PIPING_LAYER_MAX
+	pixel_x = PIPING_LAYER_P_X
+	pixel_y = PIPING_LAYER_P_Y
 
 /obj/machinery/atmospherics/components/binary/passive_gate/Destroy()
 	SSradio.remove_object(src,frequency)

--- a/code/modules/atmospherics/machinery/components/binary_devices/passive_gate.dm
+++ b/code/modules/atmospherics/machinery/components/binary_devices/passive_gate.dm
@@ -25,6 +25,16 @@ Passive gate is similar to the regular pump except:
 
 	construction_type = /obj/item/pipe/directional
 	pipe_state = "passivegate"
+	
+/obj/machinery/atmospherics/components/binary/passive_gate/layer1
+	piping_layer = 1
+	pixel_x = -5
+	pixel_y = -5
+
+/obj/machinery/atmospherics/components/binary/passive_gate/layer3
+	piping_layer = 3
+	pixel_x = 5
+	pixel_y = 5
 
 /obj/machinery/atmospherics/components/binary/passive_gate/Destroy()
 	SSradio.remove_object(src,frequency)

--- a/code/modules/atmospherics/machinery/components/binary_devices/pump.dm
+++ b/code/modules/atmospherics/machinery/components/binary_devices/pump.dm
@@ -28,10 +28,30 @@ Thus, the two variables affect pump operation are set in New():
 
 	construction_type = /obj/item/pipe/directional
 	pipe_state = "pump"
+	
+/obj/machinery/atmospherics/components/binary/pump/layer1
+	piping_layer = 1
+	pixel_x = -5
+	pixel_y = -5
+
+/obj/machinery/atmospherics/components/binary/pump/layer3
+	piping_layer = 3
+	pixel_x = 5
+	pixel_y = 5
 
 /obj/machinery/atmospherics/components/binary/pump/on
 	on = TRUE
 	icon_state = "pump_on_map"
+	
+/obj/machinery/atmospherics/components/binary/pump/on/layer1
+	piping_layer = 1
+	pixel_x = -5
+	pixel_y = -5
+
+/obj/machinery/atmospherics/components/binary/pump/on/layer3
+	piping_layer = 3
+	pixel_x = 5
+	pixel_y = 5
 	
 /obj/machinery/atmospherics/components/binary/pump/Destroy()
 	SSradio.remove_object(src,frequency)

--- a/code/modules/atmospherics/machinery/components/binary_devices/pump.dm
+++ b/code/modules/atmospherics/machinery/components/binary_devices/pump.dm
@@ -30,28 +30,28 @@ Thus, the two variables affect pump operation are set in New():
 	pipe_state = "pump"
 	
 /obj/machinery/atmospherics/components/binary/pump/layer1
-	piping_layer = 1
-	pixel_x = -5
-	pixel_y = -5
+	piping_layer = PIPING_LAYER_MIN
+	pixel_x = -PIPING_LAYER_P_X
+	pixel_y = -PIPING_LAYER_P_Y
 
 /obj/machinery/atmospherics/components/binary/pump/layer3
-	piping_layer = 3
-	pixel_x = 5
-	pixel_y = 5
+	piping_layer = PIPING_LAYER_MAX
+	pixel_x = PIPING_LAYER_P_X
+	pixel_y = PIPING_LAYER_P_Y
 
 /obj/machinery/atmospherics/components/binary/pump/on
 	on = TRUE
 	icon_state = "pump_on_map"
 	
 /obj/machinery/atmospherics/components/binary/pump/on/layer1
-	piping_layer = 1
-	pixel_x = -5
-	pixel_y = -5
+	piping_layer = PIPING_LAYER_MIN
+	pixel_x = -PIPING_LAYER_P_X
+	pixel_y = -PIPING_LAYER_P_Y
 
 /obj/machinery/atmospherics/components/binary/pump/on/layer3
-	piping_layer = 3
-	pixel_x = 5
-	pixel_y = 5
+	piping_layer = PIPING_LAYER_MAX
+	pixel_x = PIPING_LAYER_P_X
+	pixel_y = PIPING_LAYER_P_Y
 	
 /obj/machinery/atmospherics/components/binary/pump/Destroy()
 	SSradio.remove_object(src,frequency)

--- a/code/modules/atmospherics/machinery/components/binary_devices/valve.dm
+++ b/code/modules/atmospherics/machinery/components/binary_devices/valve.dm
@@ -21,27 +21,27 @@ It's like a regular ol' straight pipe, but you can turn it on and off.
 	var/switching = FALSE
 	
 /obj/machinery/atmospherics/components/binary/valve/layer1
-	piping_layer = 1
-	pixel_x = -5
-	pixel_y = -5
+	piping_layer = PIPING_LAYER_MIN
+	pixel_x = -PIPING_LAYER_P_X
+	pixel_y = -PIPING_LAYER_P_Y
 
 /obj/machinery/atmospherics/components/binary/valve/layer3
-	piping_layer = 3
-	pixel_x = 5
-	pixel_y = 5
+	piping_layer = PIPING_LAYER_MAX
+	pixel_x = PIPING_LAYER_P_X
+	pixel_y = PIPING_LAYER_P_Y
 
 /obj/machinery/atmospherics/components/binary/valve/open
 	open = TRUE
 	
 /obj/machinery/atmospherics/components/binary/valve/open/layer1
-	piping_layer = 1
-	pixel_x = -5
-	pixel_y = -5
+	piping_layer = PIPING_LAYER_MIN
+	pixel_x = -PIPING_LAYER_P_X
+	pixel_y = -PIPING_LAYER_P_Y
 
 /obj/machinery/atmospherics/components/binary/valve/open/layer3
-	piping_layer = 3
-	pixel_x = 5
-	pixel_y = 5
+	piping_layer = PIPING_LAYER_MAX
+	pixel_x = PIPING_LAYER_P_X
+	pixel_y = PIPING_LAYER_P_Y
 
 /obj/machinery/atmospherics/components/binary/valve/update_icon_nopipes(animation = 0)
 	normalize_dir()
@@ -95,14 +95,14 @@ It's like a regular ol' straight pipe, but you can turn it on and off.
 	pipe_state = "dvalve"
 	
 /obj/machinery/atmospherics/components/binary/valve/digital/layer1
-	piping_layer = 1
-	pixel_x = -5
-	pixel_y = -5
+	piping_layer = PIPING_LAYER_MIN
+	pixel_x = -PIPING_LAYER_P_X
+	pixel_y = -PIPING_LAYER_P_Y
 
 /obj/machinery/atmospherics/components/binary/valve/digital/layer3
-	piping_layer = 3
-	pixel_x = 5
-	pixel_y = 5
+	piping_layer = PIPING_LAYER_MAX
+	pixel_x = PIPING_LAYER_P_X
+	pixel_y = PIPING_LAYER_P_Y
 
 /obj/machinery/atmospherics/components/binary/valve/digital/attack_ai(mob/user)
 	return attack_hand(user)

--- a/code/modules/atmospherics/machinery/components/binary_devices/valve.dm
+++ b/code/modules/atmospherics/machinery/components/binary_devices/valve.dm
@@ -19,9 +19,29 @@ It's like a regular ol' straight pipe, but you can turn it on and off.
 	pipe_state = "mvalve"
 
 	var/switching = FALSE
+	
+/obj/machinery/atmospherics/components/binary/valve/layer1
+	piping_layer = 1
+	pixel_x = -5
+	pixel_y = -5
+
+/obj/machinery/atmospherics/components/binary/valve/layer3
+	piping_layer = 3
+	pixel_x = 5
+	pixel_y = 5
 
 /obj/machinery/atmospherics/components/binary/valve/open
 	open = TRUE
+	
+/obj/machinery/atmospherics/components/binary/valve/open/layer1
+	piping_layer = 1
+	pixel_x = -5
+	pixel_y = -5
+
+/obj/machinery/atmospherics/components/binary/valve/open/layer3
+	piping_layer = 3
+	pixel_x = 5
+	pixel_y = 5
 
 /obj/machinery/atmospherics/components/binary/valve/update_icon_nopipes(animation = 0)
 	normalize_dir()
@@ -73,6 +93,16 @@ It's like a regular ol' straight pipe, but you can turn it on and off.
 	icon_state = "dvalve_map"
 	valve_type = "d"
 	pipe_state = "dvalve"
+	
+/obj/machinery/atmospherics/components/binary/valve/digital/layer1
+	piping_layer = 1
+	pixel_x = -5
+	pixel_y = -5
+
+/obj/machinery/atmospherics/components/binary/valve/digital/layer3
+	piping_layer = 3
+	pixel_x = 5
+	pixel_y = 5
 
 /obj/machinery/atmospherics/components/binary/valve/digital/attack_ai(mob/user)
 	return attack_hand(user)

--- a/code/modules/atmospherics/machinery/components/binary_devices/volume_pump.dm
+++ b/code/modules/atmospherics/machinery/components/binary_devices/volume_pump.dm
@@ -30,14 +30,14 @@ Thus, the two variables affect pump operation are set in New():
 	pipe_state = "volumepump"
 	
 /obj/machinery/atmospherics/components/binary/volume_pump/layer1
-	piping_layer = 1
-	pixel_x = -5
-	pixel_y = -5
+	piping_layer = PIPING_LAYER_MIN
+	pixel_x = -PIPING_LAYER_P_X
+	pixel_y = -PIPING_LAYER_P_Y
 
 /obj/machinery/atmospherics/components/binary/volume_pump/layer3
-	piping_layer = 3
-	pixel_x = 5
-	pixel_y = 5
+	piping_layer = PIPING_LAYER_MAX
+	pixel_x = PIPING_LAYER_P_X
+	pixel_y = PIPING_LAYER_P_Y
 
 /obj/machinery/atmospherics/components/binary/volume_pump/Destroy()
 	SSradio.remove_object(src,frequency)
@@ -48,14 +48,14 @@ Thus, the two variables affect pump operation are set in New():
 	icon_state = "volpump_on_map"
 
 /obj/machinery/atmospherics/components/binary/volume_pump/on/layer1
-	piping_layer = 1
-	pixel_x = -5
-	pixel_y = -5
+	piping_layer = PIPING_LAYER_MIN
+	pixel_x = -PIPING_LAYER_P_X
+	pixel_y = -PIPING_LAYER_P_Y
 
 /obj/machinery/atmospherics/components/binary/volume_pump/on/layer3
-	piping_layer = 3
-	pixel_x = 5
-	pixel_y = 5
+	piping_layer = PIPING_LAYER_MAX
+	pixel_x = PIPING_LAYER_P_X
+	pixel_y = PIPING_LAYER_P_Y
 	
 /obj/machinery/atmospherics/components/binary/volume_pump/update_icon_nopipes()
 	if(!is_operational())

--- a/code/modules/atmospherics/machinery/components/binary_devices/volume_pump.dm
+++ b/code/modules/atmospherics/machinery/components/binary_devices/volume_pump.dm
@@ -28,6 +28,16 @@ Thus, the two variables affect pump operation are set in New():
 
 	construction_type = /obj/item/pipe/directional
 	pipe_state = "volumepump"
+	
+/obj/machinery/atmospherics/components/binary/volume_pump/layer1
+	piping_layer = 1
+	pixel_x = -5
+	pixel_y = -5
+
+/obj/machinery/atmospherics/components/binary/volume_pump/layer3
+	piping_layer = 3
+	pixel_x = 5
+	pixel_y = 5
 
 /obj/machinery/atmospherics/components/binary/volume_pump/Destroy()
 	SSradio.remove_object(src,frequency)
@@ -37,6 +47,16 @@ Thus, the two variables affect pump operation are set in New():
 	on = TRUE
 	icon_state = "volpump_on_map"
 
+/obj/machinery/atmospherics/components/binary/volume_pump/on/layer1
+	piping_layer = 1
+	pixel_x = -5
+	pixel_y = -5
+
+/obj/machinery/atmospherics/components/binary/volume_pump/on/layer3
+	piping_layer = 3
+	pixel_x = 5
+	pixel_y = 5
+	
 /obj/machinery/atmospherics/components/binary/volume_pump/update_icon_nopipes()
 	if(!is_operational())
 		icon_state = "volpump_off"

--- a/code/modules/atmospherics/machinery/components/trinary_devices/filter.dm
+++ b/code/modules/atmospherics/machinery/components/trinary_devices/filter.dm
@@ -14,28 +14,28 @@
 	pipe_state = "filter"
 
 /obj/machinery/atmospherics/components/trinary/filter/layer1
-	piping_layer = 1
-	pixel_x = -5
-	pixel_y = -5
+	piping_layer = PIPING_LAYER_MIN
+	pixel_x = -PIPING_LAYER_P_X
+	pixel_y = -PIPING_LAYER_P_Y
 
 /obj/machinery/atmospherics/components/trinary/filter/layer3
-	piping_layer = 3
-	pixel_x = 5
-	pixel_y = 5
+	piping_layer = PIPING_LAYER_MAX
+	pixel_x = PIPING_LAYER_P_X
+	pixel_y = PIPING_LAYER_P_Y
 	
 /obj/machinery/atmospherics/components/trinary/filter/flipped
 	icon_state = "filter_off_f"
 	flipped = TRUE
 	
 /obj/machinery/atmospherics/components/trinary/filter/flipped/layer1
-	piping_layer = 1
-	pixel_x = -5
-	pixel_y = -5
+	piping_layer = PIPING_LAYER_MIN
+	pixel_x = -PIPING_LAYER_P_X
+	pixel_y = -PIPING_LAYER_P_Y
 
 /obj/machinery/atmospherics/components/trinary/filter/flipped/layer3
-	piping_layer = 3
-	pixel_x = 5
-	pixel_y = 5
+	piping_layer = PIPING_LAYER_MAX
+	pixel_x = PIPING_LAYER_P_X
+	pixel_y = PIPING_LAYER_P_Y
 
 // These two filter types have critical_machine flagged to on and thus causes the area they are in to be exempt from the Grid Check event.
 

--- a/code/modules/atmospherics/machinery/components/trinary_devices/filter.dm
+++ b/code/modules/atmospherics/machinery/components/trinary_devices/filter.dm
@@ -13,9 +13,29 @@
 	construction_type = /obj/item/pipe/trinary/flippable
 	pipe_state = "filter"
 
+/obj/machinery/atmospherics/components/trinary/filter/layer1
+	piping_layer = 1
+	pixel_x = -5
+	pixel_y = -5
+
+/obj/machinery/atmospherics/components/trinary/filter/layer3
+	piping_layer = 3
+	pixel_x = 5
+	pixel_y = 5
+	
 /obj/machinery/atmospherics/components/trinary/filter/flipped
 	icon_state = "filter_off_f"
 	flipped = TRUE
+	
+/obj/machinery/atmospherics/components/trinary/filter/flipped/layer1
+	piping_layer = 1
+	pixel_x = -5
+	pixel_y = -5
+
+/obj/machinery/atmospherics/components/trinary/filter/flipped/layer3
+	piping_layer = 3
+	pixel_x = 5
+	pixel_y = 5
 
 // These two filter types have critical_machine flagged to on and thus causes the area they are in to be exempt from the Grid Check event.
 

--- a/code/modules/atmospherics/machinery/components/trinary_devices/mixer.dm
+++ b/code/modules/atmospherics/machinery/components/trinary_devices/mixer.dm
@@ -18,28 +18,28 @@
 	//node 3 is the outlet, nodes 1 & 2 are intakes
 
 /obj/machinery/atmospherics/components/trinary/mixer/layer1
-	piping_layer = 1
-	pixel_x = -5
-	pixel_y = -5
+	piping_layer = PIPING_LAYER_MIN
+	pixel_x = -PIPING_LAYER_P_X
+	pixel_y = -PIPING_LAYER_P_Y
 
 /obj/machinery/atmospherics/components/trinary/mixer/layer3
-	piping_layer = 3
-	pixel_x = 5
-	pixel_y = 5
+	piping_layer = PIPING_LAYER_MAX
+	pixel_x = PIPING_LAYER_P_X
+	pixel_y = PIPING_LAYER_P_Y
 	
 /obj/machinery/atmospherics/components/trinary/mixer/flipped
 	icon_state = "mixer_off_f"
 	flipped = TRUE
 
 /obj/machinery/atmospherics/components/trinary/mixer/flipped/layer1
-	piping_layer = 1
-	pixel_x = -5
-	pixel_y = -5
+	piping_layer = PIPING_LAYER_MIN
+	pixel_x = -PIPING_LAYER_P_X
+	pixel_y = -PIPING_LAYER_P_Y
 
 /obj/machinery/atmospherics/components/trinary/mixer/flipped/layer3
-	piping_layer = 3
-	pixel_x = 5
-	pixel_y = 5
+	piping_layer = PIPING_LAYER_MAX
+	pixel_x = PIPING_LAYER_P_X
+	pixel_y = PIPING_LAYER_P_Y
 	
 /obj/machinery/atmospherics/components/trinary/mixer/airmix //For standard airmix to distro
 	name = "air mixer"

--- a/code/modules/atmospherics/machinery/components/trinary_devices/mixer.dm
+++ b/code/modules/atmospherics/machinery/components/trinary_devices/mixer.dm
@@ -17,10 +17,30 @@
 
 	//node 3 is the outlet, nodes 1 & 2 are intakes
 
+/obj/machinery/atmospherics/components/trinary/mixer/layer1
+	piping_layer = 1
+	pixel_x = -5
+	pixel_y = -5
+
+/obj/machinery/atmospherics/components/trinary/mixer/layer3
+	piping_layer = 3
+	pixel_x = 5
+	pixel_y = 5
+	
 /obj/machinery/atmospherics/components/trinary/mixer/flipped
 	icon_state = "mixer_off_f"
 	flipped = TRUE
 
+/obj/machinery/atmospherics/components/trinary/mixer/flipped/layer1
+	piping_layer = 1
+	pixel_x = -5
+	pixel_y = -5
+
+/obj/machinery/atmospherics/components/trinary/mixer/flipped/layer3
+	piping_layer = 3
+	pixel_x = 5
+	pixel_y = 5
+	
 /obj/machinery/atmospherics/components/trinary/mixer/airmix //For standard airmix to distro
 	name = "air mixer"
 	icon_state = "mixer_on"

--- a/code/modules/atmospherics/machinery/components/unary_devices/heat_exchanger.dm
+++ b/code/modules/atmospherics/machinery/components/unary_devices/heat_exchanger.dm
@@ -15,14 +15,14 @@
 	pipe_state = "heunary"
 	
 /obj/machinery/atmospherics/components/unary/heat_exchanger/layer1
-	piping_layer = 1
-	pixel_x = -5
-	pixel_y = -5
+	piping_layer = PIPING_LAYER_MIN
+	pixel_x = -PIPING_LAYER_P_X
+	pixel_y = -PIPING_LAYER_P_Y
 
 /obj/machinery/atmospherics/components/unary/heat_exchanger/layer3
-	piping_layer = 3
-	pixel_x = 5
-	pixel_y = 5
+	piping_layer = PIPING_LAYER_MAX
+	pixel_x = PIPING_LAYER_P_X
+	pixel_y = PIPING_LAYER_P_Y
 
 /obj/machinery/atmospherics/components/unary/heat_exchanger/update_icon()
 	if(nodes[1])

--- a/code/modules/atmospherics/machinery/components/unary_devices/heat_exchanger.dm
+++ b/code/modules/atmospherics/machinery/components/unary_devices/heat_exchanger.dm
@@ -13,6 +13,16 @@
 	var/update_cycle
 
 	pipe_state = "heunary"
+	
+/obj/machinery/atmospherics/components/unary/heat_exchanger/layer1
+	piping_layer = 1
+	pixel_x = -5
+	pixel_y = -5
+
+/obj/machinery/atmospherics/components/unary/heat_exchanger/layer3
+	piping_layer = 3
+	pixel_x = 5
+	pixel_y = 5
 
 /obj/machinery/atmospherics/components/unary/heat_exchanger/update_icon()
 	if(nodes[1])

--- a/code/modules/atmospherics/machinery/components/unary_devices/outlet_injector.dm
+++ b/code/modules/atmospherics/machinery/components/unary_devices/outlet_injector.dm
@@ -19,6 +19,16 @@
 	layer = GAS_SCRUBBER_LAYER
 
 	pipe_state = "injector"
+	
+/obj/machinery/atmospherics/components/unary/outlet_injector/layer1
+	piping_layer = 1
+	pixel_x = -5
+	pixel_y = -5
+
+/obj/machinery/atmospherics/components/unary/outlet_injector/layer3
+	piping_layer = 3
+	pixel_x = 5
+	pixel_y = 5
 
 /obj/machinery/atmospherics/components/unary/outlet_injector/Destroy()
 	SSradio.remove_object(src,frequency)
@@ -65,6 +75,16 @@
 
 /obj/machinery/atmospherics/components/unary/outlet_injector/on
 	on = TRUE
+	
+/obj/machinery/atmospherics/components/unary/outlet_injector/on/layer1
+	piping_layer = 1
+	pixel_x = -5
+	pixel_y = -5
+
+/obj/machinery/atmospherics/components/unary/outlet_injector/on/layer3
+	piping_layer = 3
+	pixel_x = 5
+	pixel_y = 5
 
 /obj/machinery/atmospherics/components/unary/outlet_injector/update_icon_nopipes()
 	cut_overlays()

--- a/code/modules/atmospherics/machinery/components/unary_devices/outlet_injector.dm
+++ b/code/modules/atmospherics/machinery/components/unary_devices/outlet_injector.dm
@@ -21,14 +21,14 @@
 	pipe_state = "injector"
 	
 /obj/machinery/atmospherics/components/unary/outlet_injector/layer1
-	piping_layer = 1
-	pixel_x = -5
-	pixel_y = -5
+	piping_layer = PIPING_LAYER_MIN
+	pixel_x = -PIPING_LAYER_P_X
+	pixel_y = -PIPING_LAYER_P_Y
 
 /obj/machinery/atmospherics/components/unary/outlet_injector/layer3
-	piping_layer = 3
-	pixel_x = 5
-	pixel_y = 5
+	piping_layer = PIPING_LAYER_MAX
+	pixel_x = PIPING_LAYER_P_X
+	pixel_y = PIPING_LAYER_P_Y
 
 /obj/machinery/atmospherics/components/unary/outlet_injector/Destroy()
 	SSradio.remove_object(src,frequency)
@@ -77,14 +77,14 @@
 	on = TRUE
 	
 /obj/machinery/atmospherics/components/unary/outlet_injector/on/layer1
-	piping_layer = 1
-	pixel_x = -5
-	pixel_y = -5
+	piping_layer = PIPING_LAYER_MIN
+	pixel_x = -PIPING_LAYER_P_X
+	pixel_y = -PIPING_LAYER_P_Y
 
 /obj/machinery/atmospherics/components/unary/outlet_injector/on/layer3
-	piping_layer = 3
-	pixel_x = 5
-	pixel_y = 5
+	piping_layer = PIPING_LAYER_MAX
+	pixel_x = PIPING_LAYER_P_X
+	pixel_y = PIPING_LAYER_P_Y
 
 /obj/machinery/atmospherics/components/unary/outlet_injector/update_icon_nopipes()
 	cut_overlays()

--- a/code/modules/atmospherics/machinery/components/unary_devices/portables_connector.dm
+++ b/code/modules/atmospherics/machinery/components/unary_devices/portables_connector.dm
@@ -12,14 +12,14 @@
 	pipe_state = "connector"
 	
 /obj/machinery/atmospherics/components/unary/portables_connector/layer1
-	piping_layer = 1
-	pixel_x = -5
-	pixel_y = -5
+	piping_layer = PIPING_LAYER_MIN
+	pixel_x = -PIPING_LAYER_P_X
+	pixel_y = -PIPING_LAYER_P_Y
 
 /obj/machinery/atmospherics/components/unary/portables_connector/layer3
-	piping_layer = 3
-	pixel_x = 5
-	pixel_y = 5
+	piping_layer = PIPING_LAYER_MAX
+	pixel_x = PIPING_LAYER_P_X
+	pixel_y = PIPING_LAYER_P_Y
 
 /obj/machinery/atmospherics/components/unary/portables_connector/New()
 	..()
@@ -31,14 +31,14 @@
 	level = 2
 
 /obj/machinery/atmospherics/components/unary/portables_connector/visible/layer1
-	piping_layer = 1
-	pixel_x = -5
-	pixel_y = -5
+	piping_layer = PIPING_LAYER_MIN
+	pixel_x = -PIPING_LAYER_P_X
+	pixel_y = -PIPING_LAYER_P_Y
 
 /obj/machinery/atmospherics/components/unary/portables_connector/visible/layer3
-	piping_layer = 3
-	pixel_x = 5
-	pixel_y = 5
+	piping_layer = PIPING_LAYER_MAX
+	pixel_x = PIPING_LAYER_P_X
+	pixel_y = PIPING_LAYER_P_Y
 	
 /obj/machinery/atmospherics/components/unary/portables_connector/process_atmos()
 	if(!connected_device)

--- a/code/modules/atmospherics/machinery/components/unary_devices/portables_connector.dm
+++ b/code/modules/atmospherics/machinery/components/unary_devices/portables_connector.dm
@@ -10,6 +10,16 @@
 	layer = GAS_FILTER_LAYER
 	pipe_flags = PIPING_ONE_PER_TURF
 	pipe_state = "connector"
+	
+/obj/machinery/atmospherics/components/unary/portables_connector/layer1
+	piping_layer = 1
+	pixel_x = -5
+	pixel_y = -5
+
+/obj/machinery/atmospherics/components/unary/portables_connector/layer3
+	piping_layer = 3
+	pixel_x = 5
+	pixel_y = 5
 
 /obj/machinery/atmospherics/components/unary/portables_connector/New()
 	..()
@@ -20,6 +30,16 @@
 /obj/machinery/atmospherics/components/unary/portables_connector/visible
 	level = 2
 
+/obj/machinery/atmospherics/components/unary/portables_connector/visible/layer1
+	piping_layer = 1
+	pixel_x = -5
+	pixel_y = -5
+
+/obj/machinery/atmospherics/components/unary/portables_connector/visible/layer3
+	piping_layer = 3
+	pixel_x = 5
+	pixel_y = 5
+	
 /obj/machinery/atmospherics/components/unary/portables_connector/process_atmos()
 	if(!connected_device)
 		return

--- a/code/modules/atmospherics/machinery/components/unary_devices/vent_pump.dm
+++ b/code/modules/atmospherics/machinery/components/unary_devices/vent_pump.dm
@@ -32,20 +32,60 @@
 	var/radio_filter_in
 
 	pipe_state = "uvent"
+	
+/obj/machinery/atmospherics/components/unary/vent_pump/layer1
+	piping_layer = 1
+	pixel_x = -5
+	pixel_y = -5
+
+/obj/machinery/atmospherics/components/unary/vent_pump/layer3
+	piping_layer = 3
+	pixel_x = 5
+	pixel_y = 5
 
 /obj/machinery/atmospherics/components/unary/vent_pump/on
 	on = TRUE
 	icon_state = "vent_map_on"
+	
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1
+	piping_layer = 1
+	pixel_x = -5
+	pixel_y = -5
+
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer3
+	piping_layer = 3
+	pixel_x = 5
+	pixel_y = 5
 
 /obj/machinery/atmospherics/components/unary/vent_pump/siphon
 	pump_direction = SIPHONING
 	pressure_checks = INT_BOUND
 	internal_pressure_bound = 4000
 	external_pressure_bound = 0
+	
+/obj/machinery/atmospherics/components/unary/vent_pump/siphon/layer1
+	piping_layer = 1
+	pixel_x = -5
+	pixel_y = -5
+
+/obj/machinery/atmospherics/components/unary/vent_pump/siphon/layer3
+	piping_layer = 3
+	pixel_x = 5
+	pixel_y = 5
 
 /obj/machinery/atmospherics/components/unary/vent_pump/siphon/on
 	on = TRUE
 	icon_state = "vent_map_siphon_on"
+	
+/obj/machinery/atmospherics/components/unary/vent_pump/siphon/on/layer1
+	piping_layer = 1
+	pixel_x = -5
+	pixel_y = -5
+
+/obj/machinery/atmospherics/components/unary/vent_pump/siphon/on/layer3
+	piping_layer = 3
+	pixel_x = 5
+	pixel_y = 5
 
 /obj/machinery/atmospherics/components/unary/vent_pump/siphon/atmos
 	frequency = FREQ_ATMOS_STORAGE
@@ -96,20 +136,60 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/high_volume
 	name = "large air vent"
 	power_channel = EQUIP
+	
+/obj/machinery/atmospherics/components/unary/vent_pump/high_volume/layer1
+	piping_layer = 1
+	pixel_x = -5
+	pixel_y = -5
+
+/obj/machinery/atmospherics/components/unary/vent_pump/high_volume/layer3
+	piping_layer = 3
+	pixel_x = 5
+	pixel_y = 5
 
 /obj/machinery/atmospherics/components/unary/vent_pump/high_volume/on
 	on = TRUE
 	icon_state = "vent_map_on"
+	
+/obj/machinery/atmospherics/components/unary/vent_pump/high_volume/on/layer1
+	piping_layer = 1
+	pixel_x = -5
+	pixel_y = -5
+
+/obj/machinery/atmospherics/components/unary/vent_pump/high_volume/on/layer3
+	piping_layer = 3
+	pixel_x = 5
+	pixel_y = 5
 
 /obj/machinery/atmospherics/components/unary/vent_pump/high_volume/siphon
 	pump_direction = SIPHONING
 	pressure_checks = INT_BOUND
 	internal_pressure_bound = 2000
 	external_pressure_bound = 0
+	
+/obj/machinery/atmospherics/components/unary/vent_pump/high_volume/siphon/layer1
+	piping_layer = 1
+	pixel_x = -5
+	pixel_y = -5
+
+/obj/machinery/atmospherics/components/unary/vent_pump/high_volume/siphon/layer3
+	piping_layer = 3
+	pixel_x = 5
+	pixel_y = 5
 
 /obj/machinery/atmospherics/components/unary/vent_pump/high_volume/siphon/on
 	on = TRUE
 	icon_state = "vent_map_siphon_on"
+	
+/obj/machinery/atmospherics/components/unary/vent_pump/high_volume/siphon/on/layer1
+	piping_layer = 1
+	pixel_x = -5
+	pixel_y = -5
+
+/obj/machinery/atmospherics/components/unary/vent_pump/high_volume/siphon/on/layer3
+	piping_layer = 3
+	pixel_x = 5
+	pixel_y = 5
 
 /obj/machinery/atmospherics/components/unary/vent_pump/high_volume/siphon/atmos
 	frequency = FREQ_ATMOS_STORAGE

--- a/code/modules/atmospherics/machinery/components/unary_devices/vent_pump.dm
+++ b/code/modules/atmospherics/machinery/components/unary_devices/vent_pump.dm
@@ -34,28 +34,28 @@
 	pipe_state = "uvent"
 	
 /obj/machinery/atmospherics/components/unary/vent_pump/layer1
-	piping_layer = 1
-	pixel_x = -5
-	pixel_y = -5
+	piping_layer = PIPING_LAYER_MIN
+	pixel_x = -PIPING_LAYER_P_X
+	pixel_y = -PIPING_LAYER_P_Y
 
 /obj/machinery/atmospherics/components/unary/vent_pump/layer3
-	piping_layer = 3
-	pixel_x = 5
-	pixel_y = 5
+	piping_layer = PIPING_LAYER_MAX
+	pixel_x = PIPING_LAYER_P_X
+	pixel_y = PIPING_LAYER_P_Y
 
 /obj/machinery/atmospherics/components/unary/vent_pump/on
 	on = TRUE
 	icon_state = "vent_map_on"
 	
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1
-	piping_layer = 1
-	pixel_x = -5
-	pixel_y = -5
+	piping_layer = PIPING_LAYER_MIN
+	pixel_x = -PIPING_LAYER_P_X
+	pixel_y = -PIPING_LAYER_P_Y
 
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer3
-	piping_layer = 3
-	pixel_x = 5
-	pixel_y = 5
+	piping_layer = PIPING_LAYER_MAX
+	pixel_x = PIPING_LAYER_P_X
+	pixel_y = PIPING_LAYER_P_Y
 
 /obj/machinery/atmospherics/components/unary/vent_pump/siphon
 	pump_direction = SIPHONING
@@ -64,28 +64,28 @@
 	external_pressure_bound = 0
 	
 /obj/machinery/atmospherics/components/unary/vent_pump/siphon/layer1
-	piping_layer = 1
-	pixel_x = -5
-	pixel_y = -5
+	piping_layer = PIPING_LAYER_MIN
+	pixel_x = -PIPING_LAYER_P_X
+	pixel_y = -PIPING_LAYER_P_Y
 
 /obj/machinery/atmospherics/components/unary/vent_pump/siphon/layer3
-	piping_layer = 3
-	pixel_x = 5
-	pixel_y = 5
+	piping_layer = PIPING_LAYER_MAX
+	pixel_x = PIPING_LAYER_P_X
+	pixel_y = PIPING_LAYER_P_Y
 
 /obj/machinery/atmospherics/components/unary/vent_pump/siphon/on
 	on = TRUE
 	icon_state = "vent_map_siphon_on"
 	
 /obj/machinery/atmospherics/components/unary/vent_pump/siphon/on/layer1
-	piping_layer = 1
-	pixel_x = -5
-	pixel_y = -5
+	piping_layer = PIPING_LAYER_MIN
+	pixel_x = -PIPING_LAYER_P_X
+	pixel_y = -PIPING_LAYER_P_Y
 
 /obj/machinery/atmospherics/components/unary/vent_pump/siphon/on/layer3
-	piping_layer = 3
-	pixel_x = 5
-	pixel_y = 5
+	piping_layer = PIPING_LAYER_MAX
+	pixel_x = PIPING_LAYER_P_X
+	pixel_y = PIPING_LAYER_P_Y
 
 /obj/machinery/atmospherics/components/unary/vent_pump/siphon/atmos
 	frequency = FREQ_ATMOS_STORAGE
@@ -138,28 +138,28 @@
 	power_channel = EQUIP
 	
 /obj/machinery/atmospherics/components/unary/vent_pump/high_volume/layer1
-	piping_layer = 1
-	pixel_x = -5
-	pixel_y = -5
+	piping_layer = PIPING_LAYER_MIN
+	pixel_x = -PIPING_LAYER_P_X
+	pixel_y = -PIPING_LAYER_P_Y
 
 /obj/machinery/atmospherics/components/unary/vent_pump/high_volume/layer3
-	piping_layer = 3
-	pixel_x = 5
-	pixel_y = 5
+	piping_layer = PIPING_LAYER_MAX
+	pixel_x = PIPING_LAYER_P_X
+	pixel_y = PIPING_LAYER_P_Y
 
 /obj/machinery/atmospherics/components/unary/vent_pump/high_volume/on
 	on = TRUE
 	icon_state = "vent_map_on"
 	
 /obj/machinery/atmospherics/components/unary/vent_pump/high_volume/on/layer1
-	piping_layer = 1
-	pixel_x = -5
-	pixel_y = -5
+	piping_layer = PIPING_LAYER_MIN
+	pixel_x = -PIPING_LAYER_P_X
+	pixel_y = -PIPING_LAYER_P_Y
 
 /obj/machinery/atmospherics/components/unary/vent_pump/high_volume/on/layer3
-	piping_layer = 3
-	pixel_x = 5
-	pixel_y = 5
+	piping_layer = PIPING_LAYER_MAX
+	pixel_x = PIPING_LAYER_P_X
+	pixel_y = PIPING_LAYER_P_Y
 
 /obj/machinery/atmospherics/components/unary/vent_pump/high_volume/siphon
 	pump_direction = SIPHONING
@@ -168,28 +168,28 @@
 	external_pressure_bound = 0
 	
 /obj/machinery/atmospherics/components/unary/vent_pump/high_volume/siphon/layer1
-	piping_layer = 1
-	pixel_x = -5
-	pixel_y = -5
+	piping_layer = PIPING_LAYER_MIN
+	pixel_x = -PIPING_LAYER_P_X
+	pixel_y = -PIPING_LAYER_P_Y
 
 /obj/machinery/atmospherics/components/unary/vent_pump/high_volume/siphon/layer3
-	piping_layer = 3
-	pixel_x = 5
-	pixel_y = 5
+	piping_layer = PIPING_LAYER_MAX
+	pixel_x = PIPING_LAYER_P_X
+	pixel_y = PIPING_LAYER_P_Y
 
 /obj/machinery/atmospherics/components/unary/vent_pump/high_volume/siphon/on
 	on = TRUE
 	icon_state = "vent_map_siphon_on"
 	
 /obj/machinery/atmospherics/components/unary/vent_pump/high_volume/siphon/on/layer1
-	piping_layer = 1
-	pixel_x = -5
-	pixel_y = -5
+	piping_layer = PIPING_LAYER_MIN
+	pixel_x = -PIPING_LAYER_P_X
+	pixel_y = -PIPING_LAYER_P_Y
 
 /obj/machinery/atmospherics/components/unary/vent_pump/high_volume/siphon/on/layer3
-	piping_layer = 3
-	pixel_x = 5
-	pixel_y = 5
+	piping_layer = PIPING_LAYER_MAX
+	pixel_x = PIPING_LAYER_P_X
+	pixel_y = PIPING_LAYER_P_Y
 
 /obj/machinery/atmospherics/components/unary/vent_pump/high_volume/siphon/atmos
 	frequency = FREQ_ATMOS_STORAGE

--- a/code/modules/atmospherics/machinery/components/unary_devices/vent_scrubber.dm
+++ b/code/modules/atmospherics/machinery/components/unary_devices/vent_scrubber.dm
@@ -29,6 +29,16 @@
 	var/radio_filter_in
 
 	pipe_state = "scrubber"
+	
+/obj/machinery/atmospherics/components/unary/vent_scrubber/layer1
+	piping_layer = 1
+	pixel_x = -5
+	pixel_y = -5
+
+/obj/machinery/atmospherics/components/unary/vent_scrubber/layer3
+	piping_layer = 3
+	pixel_x = 5
+	pixel_y = 5
 
 /obj/machinery/atmospherics/components/unary/vent_scrubber/New()
 	..()
@@ -42,6 +52,16 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on
 	on = TRUE
 	icon_state = "scrub_map_on"
+	
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer1
+	piping_layer = 1
+	pixel_x = -5
+	pixel_y = -5
+
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3
+	piping_layer = 3
+	pixel_x = 5
+	pixel_y = 5
 
 /obj/machinery/atmospherics/components/unary/vent_scrubber/Destroy()
 	var/area/A = get_area(src)

--- a/code/modules/atmospherics/machinery/components/unary_devices/vent_scrubber.dm
+++ b/code/modules/atmospherics/machinery/components/unary_devices/vent_scrubber.dm
@@ -31,14 +31,14 @@
 	pipe_state = "scrubber"
 	
 /obj/machinery/atmospherics/components/unary/vent_scrubber/layer1
-	piping_layer = 1
-	pixel_x = -5
-	pixel_y = -5
+	piping_layer = PIPING_LAYER_MIN
+	pixel_x = -PIPING_LAYER_P_X
+	pixel_y = -PIPING_LAYER_P_Y
 
 /obj/machinery/atmospherics/components/unary/vent_scrubber/layer3
-	piping_layer = 3
-	pixel_x = 5
-	pixel_y = 5
+	piping_layer = PIPING_LAYER_MAX
+	pixel_x = PIPING_LAYER_P_X
+	pixel_y = PIPING_LAYER_P_Y
 
 /obj/machinery/atmospherics/components/unary/vent_scrubber/New()
 	..()
@@ -54,14 +54,14 @@
 	icon_state = "scrub_map_on"
 	
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer1
-	piping_layer = 1
-	pixel_x = -5
-	pixel_y = -5
+	piping_layer = PIPING_LAYER_MIN
+	pixel_x = -PIPING_LAYER_P_X
+	pixel_y = -PIPING_LAYER_P_Y
 
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3
-	piping_layer = 3
-	pixel_x = 5
-	pixel_y = 5
+	piping_layer = PIPING_LAYER_MAX
+	pixel_x = PIPING_LAYER_P_X
+	pixel_y = PIPING_LAYER_P_Y
 
 /obj/machinery/atmospherics/components/unary/vent_scrubber/Destroy()
 	var/area/A = get_area(src)

--- a/code/modules/atmospherics/machinery/pipes/heat_exchange/junction.dm
+++ b/code/modules/atmospherics/machinery/pipes/heat_exchange/junction.dm
@@ -17,6 +17,16 @@
 	construction_type = /obj/item/pipe/directional
 	pipe_state = "junction"
 
+/obj/machinery/atmospherics/pipe/heat_exchanging/junction/layer1
+	piping_layer = 1
+	pixel_x = -5
+	pixel_y = -5
+
+/obj/machinery/atmospherics/pipe/heat_exchanging/junction/layer3
+	piping_layer = 3
+	pixel_x = 5
+	pixel_y = 5
+	
 /obj/machinery/atmospherics/pipe/heat_exchanging/junction/SetInitDirections()
 	switch(dir)
 		if(SOUTH)

--- a/code/modules/atmospherics/machinery/pipes/heat_exchange/junction.dm
+++ b/code/modules/atmospherics/machinery/pipes/heat_exchange/junction.dm
@@ -18,14 +18,14 @@
 	pipe_state = "junction"
 
 /obj/machinery/atmospherics/pipe/heat_exchanging/junction/layer1
-	piping_layer = 1
-	pixel_x = -5
-	pixel_y = -5
+	piping_layer = PIPING_LAYER_MIN
+	pixel_x = -PIPING_LAYER_P_X
+	pixel_y = -PIPING_LAYER_P_Y
 
 /obj/machinery/atmospherics/pipe/heat_exchanging/junction/layer3
-	piping_layer = 3
-	pixel_x = 5
-	pixel_y = 5
+	piping_layer = PIPING_LAYER_MAX
+	pixel_x = PIPING_LAYER_P_X
+	pixel_y = PIPING_LAYER_P_Y
 	
 /obj/machinery/atmospherics/pipe/heat_exchanging/junction/SetInitDirections()
 	switch(dir)

--- a/code/modules/atmospherics/machinery/pipes/heat_exchange/manifold.dm
+++ b/code/modules/atmospherics/machinery/pipes/heat_exchange/manifold.dm
@@ -12,6 +12,16 @@
 
 	construction_type = /obj/item/pipe/trinary
 	pipe_state = "he_manifold"
+	
+/obj/machinery/atmospherics/pipe/heat_exchanging/manifold/layer1
+	piping_layer = 1
+	pixel_x = -5
+	pixel_y = -5
+
+/obj/machinery/atmospherics/pipe/heat_exchanging/manifold/layer3
+	piping_layer = 3
+	pixel_x = 5
+	pixel_y = 5
 
 /obj/machinery/atmospherics/pipe/heat_exchanging/manifold/SetInitDirections()
 	switch(dir)
@@ -49,6 +59,16 @@
 
 	construction_type = /obj/item/pipe/quaternary
 	pipe_state = "he_manifold4w"
+	
+/obj/machinery/atmospherics/pipe/heat_exchanging/manifold4w/layer1
+	piping_layer = 1
+	pixel_x = -5
+	pixel_y = -5
+
+/obj/machinery/atmospherics/pipe/heat_exchanging/manifold4w/layer3
+	piping_layer = 3
+	pixel_x = 5
+	pixel_y = 5
 
 /obj/machinery/atmospherics/pipe/heat_exchanging/manifold4w/SetInitDirections()
 	initialize_directions_he = initial(initialize_directions_he)

--- a/code/modules/atmospherics/machinery/pipes/heat_exchange/manifold.dm
+++ b/code/modules/atmospherics/machinery/pipes/heat_exchange/manifold.dm
@@ -14,14 +14,14 @@
 	pipe_state = "he_manifold"
 	
 /obj/machinery/atmospherics/pipe/heat_exchanging/manifold/layer1
-	piping_layer = 1
-	pixel_x = -5
-	pixel_y = -5
+	piping_layer = PIPING_LAYER_MIN
+	pixel_x = -PIPING_LAYER_P_X
+	pixel_y = -PIPING_LAYER_P_Y
 
 /obj/machinery/atmospherics/pipe/heat_exchanging/manifold/layer3
-	piping_layer = 3
-	pixel_x = 5
-	pixel_y = 5
+	piping_layer = PIPING_LAYER_MAX
+	pixel_x = PIPING_LAYER_P_X
+	pixel_y = PIPING_LAYER_P_Y
 
 /obj/machinery/atmospherics/pipe/heat_exchanging/manifold/SetInitDirections()
 	switch(dir)
@@ -61,14 +61,14 @@
 	pipe_state = "he_manifold4w"
 	
 /obj/machinery/atmospherics/pipe/heat_exchanging/manifold4w/layer1
-	piping_layer = 1
-	pixel_x = -5
-	pixel_y = -5
+	piping_layer = PIPING_LAYER_MIN
+	pixel_x = -PIPING_LAYER_P_X
+	pixel_y = -PIPING_LAYER_P_Y
 
 /obj/machinery/atmospherics/pipe/heat_exchanging/manifold4w/layer3
-	piping_layer = 3
-	pixel_x = 5
-	pixel_y = 5
+	piping_layer = PIPING_LAYER_MAX
+	pixel_x = PIPING_LAYER_P_X
+	pixel_y = PIPING_LAYER_P_Y
 
 /obj/machinery/atmospherics/pipe/heat_exchanging/manifold4w/SetInitDirections()
 	initialize_directions_he = initial(initialize_directions_he)

--- a/code/modules/atmospherics/machinery/pipes/heat_exchange/simple.dm
+++ b/code/modules/atmospherics/machinery/pipes/heat_exchange/simple.dm
@@ -11,6 +11,16 @@
 
 	construction_type = /obj/item/pipe/binary/bendable
 	pipe_state = "he"
+	
+/obj/machinery/atmospherics/pipe/heat_exchanging/simple/layer1
+	piping_layer = 1
+	pixel_x = -5
+	pixel_y = -5
+
+/obj/machinery/atmospherics/pipe/heat_exchanging/simple/layer3
+	piping_layer = 3
+	pixel_x = 5
+	pixel_y = 5
 
 /obj/machinery/atmospherics/pipe/heat_exchanging/simple/SetInitDirections()
 	if(dir in GLOB.diagonals)

--- a/code/modules/atmospherics/machinery/pipes/heat_exchange/simple.dm
+++ b/code/modules/atmospherics/machinery/pipes/heat_exchange/simple.dm
@@ -13,14 +13,14 @@
 	pipe_state = "he"
 	
 /obj/machinery/atmospherics/pipe/heat_exchanging/simple/layer1
-	piping_layer = 1
-	pixel_x = -5
-	pixel_y = -5
+	piping_layer = PIPING_LAYER_MIN
+	pixel_x = -PIPING_LAYER_P_X
+	pixel_y = -PIPING_LAYER_P_Y
 
 /obj/machinery/atmospherics/pipe/heat_exchanging/simple/layer3
-	piping_layer = 3
-	pixel_x = 5
-	pixel_y = 5
+	piping_layer = PIPING_LAYER_MAX
+	pixel_x = PIPING_LAYER_P_X
+	pixel_y = PIPING_LAYER_P_Y
 
 /obj/machinery/atmospherics/pipe/heat_exchanging/simple/SetInitDirections()
 	if(dir in GLOB.diagonals)

--- a/code/modules/atmospherics/machinery/pipes/manifold.dm
+++ b/code/modules/atmospherics/machinery/pipes/manifold.dm
@@ -47,27 +47,27 @@
 	layer = GAS_PIPE_VISIBLE_LAYER
 	
 /obj/machinery/atmospherics/pipe/manifold/general/visible/layer1
-	piping_layer = 1
-	pixel_x = -5
-	pixel_y = -5
+	piping_layer = PIPING_LAYER_MIN
+	pixel_x = -PIPING_LAYER_P_X
+	pixel_y = -PIPING_LAYER_P_Y
 
 /obj/machinery/atmospherics/pipe/manifold/general/visible/layer3
-	piping_layer = 3
-	pixel_x = 5
-	pixel_y = 5
+	piping_layer = PIPING_LAYER_MAX
+	pixel_x = PIPING_LAYER_P_X
+	pixel_y = PIPING_LAYER_P_Y
 
 /obj/machinery/atmospherics/pipe/manifold/general/hidden
 	level = PIPE_HIDDEN_LEVEL
 	
 /obj/machinery/atmospherics/pipe/manifold/general/hidden/layer1
-	piping_layer = 1
-	pixel_x = -5
-	pixel_y = -5
+	piping_layer = PIPING_LAYER_MIN
+	pixel_x = -PIPING_LAYER_P_X
+	pixel_y = -PIPING_LAYER_P_Y
 
 /obj/machinery/atmospherics/pipe/manifold/general/hidden/layer3
-	piping_layer = 3
-	pixel_x = 5
-	pixel_y = 5
+	piping_layer = PIPING_LAYER_MAX
+	pixel_x = PIPING_LAYER_P_X
+	pixel_y = PIPING_LAYER_P_Y
 
 /obj/machinery/atmospherics/pipe/manifold/scrubbers
 	name="scrubbers pipe"
@@ -79,27 +79,27 @@
 	layer = GAS_PIPE_VISIBLE_LAYER
 
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/visible/layer1
-	piping_layer = 1
-	pixel_x = -5
-	pixel_y = -5
+	piping_layer = PIPING_LAYER_MIN
+	pixel_x = -PIPING_LAYER_P_X
+	pixel_y = -PIPING_LAYER_P_Y
 
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/visible/layer3
-	piping_layer = 3
-	pixel_x = 5
-	pixel_y = 5
+	piping_layer = PIPING_LAYER_MAX
+	pixel_x = PIPING_LAYER_P_X
+	pixel_y = PIPING_LAYER_P_Y
 
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden
 	level = PIPE_HIDDEN_LEVEL
 	
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer1
-	piping_layer = 1
-	pixel_x = -5
-	pixel_y = -5
+	piping_layer = PIPING_LAYER_MIN
+	pixel_x = -PIPING_LAYER_P_X
+	pixel_y = -PIPING_LAYER_P_Y
 
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3
-	piping_layer = 3
-	pixel_x = 5
-	pixel_y = 5
+	piping_layer = PIPING_LAYER_MAX
+	pixel_x = PIPING_LAYER_P_X
+	pixel_y = PIPING_LAYER_P_Y
 
 /obj/machinery/atmospherics/pipe/manifold/supply
 	name="air supply pipe"
@@ -111,27 +111,27 @@
 	layer = GAS_PIPE_VISIBLE_LAYER
 	
 /obj/machinery/atmospherics/pipe/manifold/supply/visible/layer1
-	piping_layer = 1
-	pixel_x = -5
-	pixel_y = -5
+	piping_layer = PIPING_LAYER_MIN
+	pixel_x = -PIPING_LAYER_P_X
+	pixel_y = -PIPING_LAYER_P_Y
 
 /obj/machinery/atmospherics/pipe/manifold/supply/visible/layer3
-	piping_layer = 3
-	pixel_x = 5
-	pixel_y = 5
+	piping_layer = PIPING_LAYER_MAX
+	pixel_x = PIPING_LAYER_P_X
+	pixel_y = PIPING_LAYER_P_Y
 
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden
 	level = PIPE_HIDDEN_LEVEL
 
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1
-	piping_layer = 1
-	pixel_x = -5
-	pixel_y = -5
+	piping_layer = PIPING_LAYER_MIN
+	pixel_x = -PIPING_LAYER_P_X
+	pixel_y = -PIPING_LAYER_P_Y
 
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer3
-	piping_layer = 3
-	pixel_x = 5
-	pixel_y = 5
+	piping_layer = PIPING_LAYER_MAX
+	pixel_x = PIPING_LAYER_P_X
+	pixel_y = PIPING_LAYER_P_Y
 	
 /obj/machinery/atmospherics/pipe/manifold/supplymain
 	name="main air supply pipe"
@@ -143,27 +143,27 @@
 	layer = GAS_PIPE_VISIBLE_LAYER
 	
 /obj/machinery/atmospherics/pipe/manifold/supplymain/visible/layer1
-	piping_layer = 1
-	pixel_x = -5
-	pixel_y = -5
+	piping_layer = PIPING_LAYER_MIN
+	pixel_x = -PIPING_LAYER_P_X
+	pixel_y = -PIPING_LAYER_P_Y
 
 /obj/machinery/atmospherics/pipe/manifold/supplymain/visible/layer3
-	piping_layer = 3
-	pixel_x = 5
-	pixel_y = 5
+	piping_layer = PIPING_LAYER_MAX
+	pixel_x = PIPING_LAYER_P_X
+	pixel_y = PIPING_LAYER_P_Y
 
 /obj/machinery/atmospherics/pipe/manifold/supplymain/hidden
 	level = PIPE_HIDDEN_LEVEL
 	
 /obj/machinery/atmospherics/pipe/manifold/supplymain/hidden/layer1
-	piping_layer = 1
-	pixel_x = -5
-	pixel_y = -5
+	piping_layer = PIPING_LAYER_MIN
+	pixel_x = -PIPING_LAYER_P_X
+	pixel_y = -PIPING_LAYER_P_Y
 
 /obj/machinery/atmospherics/pipe/manifold/supplymain/hidden/layer3
-	piping_layer = 3
-	pixel_x = 5
-	pixel_y = 5
+	piping_layer = PIPING_LAYER_MAX
+	pixel_x = PIPING_LAYER_P_X
+	pixel_y = PIPING_LAYER_P_Y
 
 /obj/machinery/atmospherics/pipe/manifold/yellow
 	pipe_color=rgb(255,198,0)
@@ -174,27 +174,27 @@
 	layer = GAS_PIPE_VISIBLE_LAYER
 	
 /obj/machinery/atmospherics/pipe/manifold/yellow/visible/layer1
-	piping_layer = 1
-	pixel_x = -5
-	pixel_y = -5
+	piping_layer = PIPING_LAYER_MIN
+	pixel_x = -PIPING_LAYER_P_X
+	pixel_y = -PIPING_LAYER_P_Y
 
 /obj/machinery/atmospherics/pipe/manifold/yellow/visible/layer3
-	piping_layer = 3
-	pixel_x = 5
-	pixel_y = 5
+	piping_layer = PIPING_LAYER_MAX
+	pixel_x = PIPING_LAYER_P_X
+	pixel_y = PIPING_LAYER_P_Y
 
 /obj/machinery/atmospherics/pipe/manifold/yellow/hidden
 	level = PIPE_HIDDEN_LEVEL
 	
 /obj/machinery/atmospherics/pipe/manifold/yellow/hidden/layer1
-	piping_layer = 1
-	pixel_x = -5
-	pixel_y = -5
+	piping_layer = PIPING_LAYER_MIN
+	pixel_x = -PIPING_LAYER_P_X
+	pixel_y = -PIPING_LAYER_P_Y
 
 /obj/machinery/atmospherics/pipe/manifold/yellow/hidden/layer3
-	piping_layer = 3
-	pixel_x = 5
-	pixel_y = 5
+	piping_layer = PIPING_LAYER_MAX
+	pixel_x = PIPING_LAYER_P_X
+	pixel_y = PIPING_LAYER_P_Y
 
 /obj/machinery/atmospherics/pipe/manifold/cyan
 	pipe_color=rgb(0,255,249)
@@ -205,27 +205,27 @@
 	layer = GAS_PIPE_VISIBLE_LAYER
 	
 /obj/machinery/atmospherics/pipe/manifold/cyan/visible/layer1
-	piping_layer = 1
-	pixel_x = -5
-	pixel_y = -5
+	piping_layer = PIPING_LAYER_MIN
+	pixel_x = -PIPING_LAYER_P_X
+	pixel_y = -PIPING_LAYER_P_Y
 
 /obj/machinery/atmospherics/pipe/manifold/cyan/visible/layer3
-	piping_layer = 3
-	pixel_x = 5
-	pixel_y = 5
+	piping_layer = PIPING_LAYER_MAX
+	pixel_x = PIPING_LAYER_P_X
+	pixel_y = PIPING_LAYER_P_Y
 
 /obj/machinery/atmospherics/pipe/manifold/cyan/hidden
 	level = PIPE_HIDDEN_LEVEL
 	
 /obj/machinery/atmospherics/pipe/manifold/cyan/hidden/layer1
-	piping_layer = 1
-	pixel_x = -5
-	pixel_y = -5
+	piping_layer = PIPING_LAYER_MIN
+	pixel_x = -PIPING_LAYER_P_X
+	pixel_y = -PIPING_LAYER_P_Y
 
 /obj/machinery/atmospherics/pipe/manifold/cyan/hidden/layer3
-	piping_layer = 3
-	pixel_x = 5
-	pixel_y = 5
+	piping_layer = PIPING_LAYER_MAX
+	pixel_x = PIPING_LAYER_P_X
+	pixel_y = PIPING_LAYER_P_Y
 
 /obj/machinery/atmospherics/pipe/manifold/green
 	pipe_color=rgb(30,255,0)
@@ -236,27 +236,27 @@
 	layer = GAS_PIPE_VISIBLE_LAYER
 	
 /obj/machinery/atmospherics/pipe/manifold/green/visible/layer1
-	piping_layer = 1
-	pixel_x = -5
-	pixel_y = -5
+	piping_layer = PIPING_LAYER_MIN
+	pixel_x = -PIPING_LAYER_P_X
+	pixel_y = -PIPING_LAYER_P_Y
 
 /obj/machinery/atmospherics/pipe/manifold/green/visible/layer3
-	piping_layer = 3
-	pixel_x = 5
-	pixel_y = 5
+	piping_layer = PIPING_LAYER_MAX
+	pixel_x = PIPING_LAYER_P_X
+	pixel_y = PIPING_LAYER_P_Y
 
 /obj/machinery/atmospherics/pipe/manifold/green/hidden
 	level = PIPE_HIDDEN_LEVEL
 	
 /obj/machinery/atmospherics/pipe/manifold/green/hidden/layer1
-	piping_layer = 1
-	pixel_x = -5
-	pixel_y = -5
+	piping_layer = PIPING_LAYER_MIN
+	pixel_x = -PIPING_LAYER_P_X
+	pixel_y = -PIPING_LAYER_P_Y
 
 /obj/machinery/atmospherics/pipe/manifold/green/hidden/layer3
-	piping_layer = 3
-	pixel_x = 5
-	pixel_y = 5
+	piping_layer = PIPING_LAYER_MAX
+	pixel_x = PIPING_LAYER_P_X
+	pixel_y = PIPING_LAYER_P_Y
 
 /obj/machinery/atmospherics/pipe/manifold/orange
 	pipe_color=rgb(255,129,25)
@@ -267,27 +267,27 @@
 	layer = GAS_PIPE_VISIBLE_LAYER
 	
 /obj/machinery/atmospherics/pipe/manifold/orange/visible/layer1
-	piping_layer = 1
-	pixel_x = -5
-	pixel_y = -5
+	piping_layer = PIPING_LAYER_MIN
+	pixel_x = -PIPING_LAYER_P_X
+	pixel_y = -PIPING_LAYER_P_Y
 
 /obj/machinery/atmospherics/pipe/manifold/orange/visible/layer3
-	piping_layer = 3
-	pixel_x = 5
-	pixel_y = 5
+	piping_layer = PIPING_LAYER_MAX
+	pixel_x = PIPING_LAYER_P_X
+	pixel_y = PIPING_LAYER_P_Y
 
 /obj/machinery/atmospherics/pipe/manifold/orange/hidden
 	level = PIPE_HIDDEN_LEVEL
 	
 /obj/machinery/atmospherics/pipe/manifold/orange/hidden/layer1
-	piping_layer = 1
-	pixel_x = -5
-	pixel_y = -5
+	piping_layer = PIPING_LAYER_MIN
+	pixel_x = -PIPING_LAYER_P_X
+	pixel_y = -PIPING_LAYER_P_Y
 
 /obj/machinery/atmospherics/pipe/manifold/orange/hidden/layer3
-	piping_layer = 3
-	pixel_x = 5
-	pixel_y = 5
+	piping_layer = PIPING_LAYER_MAX
+	pixel_x = PIPING_LAYER_P_X
+	pixel_y = PIPING_LAYER_P_Y
 
 /obj/machinery/atmospherics/pipe/manifold/purple
 	pipe_color=rgb(128,0,182)
@@ -298,27 +298,27 @@
 	layer = GAS_PIPE_VISIBLE_LAYER
 	
 /obj/machinery/atmospherics/pipe/manifold/purple/visible/layer1
-	piping_layer = 1
-	pixel_x = -5
-	pixel_y = -5
+	piping_layer = PIPING_LAYER_MIN
+	pixel_x = -PIPING_LAYER_P_X
+	pixel_y = -PIPING_LAYER_P_Y
 
 /obj/machinery/atmospherics/pipe/manifold/purple/visible/layer3
-	piping_layer = 3
-	pixel_x = 5
-	pixel_y = 5
+	piping_layer = PIPING_LAYER_MAX
+	pixel_x = PIPING_LAYER_P_X
+	pixel_y = PIPING_LAYER_P_Y
 
 /obj/machinery/atmospherics/pipe/manifold/purple/hidden
 	level = PIPE_HIDDEN_LEVEL
 	
 /obj/machinery/atmospherics/pipe/manifold/purple/hidden/layer1
-	piping_layer = 1
-	pixel_x = -5
-	pixel_y = -5
+	piping_layer = PIPING_LAYER_MIN
+	pixel_x = -PIPING_LAYER_P_X
+	pixel_y = -PIPING_LAYER_P_Y
 
 /obj/machinery/atmospherics/pipe/manifold/purple/hidden/layer3
-	piping_layer = 3
-	pixel_x = 5
-	pixel_y = 5
+	piping_layer = PIPING_LAYER_MAX
+	pixel_x = PIPING_LAYER_P_X
+	pixel_y = PIPING_LAYER_P_Y
 
 /obj/machinery/atmospherics/pipe/manifold/dark
 	pipe_color=rgb(69,69,69)
@@ -329,27 +329,27 @@
 	layer = GAS_PIPE_VISIBLE_LAYER
 	
 /obj/machinery/atmospherics/pipe/manifold/dark/visible/layer1
-	piping_layer = 1
-	pixel_x = -5
-	pixel_y = -5
+	piping_layer = PIPING_LAYER_MIN
+	pixel_x = -PIPING_LAYER_P_X
+	pixel_y = -PIPING_LAYER_P_Y
 
 /obj/machinery/atmospherics/pipe/manifold/dark/visible/layer3
-	piping_layer = 3
-	pixel_x = 5
-	pixel_y = 5
+	piping_layer = PIPING_LAYER_MAX
+	pixel_x = PIPING_LAYER_P_X
+	pixel_y = PIPING_LAYER_P_Y
 
 /obj/machinery/atmospherics/pipe/manifold/dark/hidden
 	level = PIPE_HIDDEN_LEVEL
 	
 /obj/machinery/atmospherics/pipe/manifold/dark/hidden/layer1
-	piping_layer = 1
-	pixel_x = -5
-	pixel_y = -5
+	piping_layer = PIPING_LAYER_MIN
+	pixel_x = -PIPING_LAYER_P_X
+	pixel_y = -PIPING_LAYER_P_Y
 
 /obj/machinery/atmospherics/pipe/manifold/dark/hidden/layer3
-	piping_layer = 3
-	pixel_x = 5
-	pixel_y = 5
+	piping_layer = PIPING_LAYER_MAX
+	pixel_x = PIPING_LAYER_P_X
+	pixel_y = PIPING_LAYER_P_Y
 
 /obj/machinery/atmospherics/pipe/manifold/violet
 	pipe_color=rgb(64,0,128)
@@ -360,27 +360,27 @@
 	layer = GAS_PIPE_VISIBLE_LAYER
 	
 /obj/machinery/atmospherics/pipe/manifold/violet/visible/layer1
-	piping_layer = 1
-	pixel_x = -5
-	pixel_y = -5
+	piping_layer = PIPING_LAYER_MIN
+	pixel_x = -PIPING_LAYER_P_X
+	pixel_y = -PIPING_LAYER_P_Y
 
 /obj/machinery/atmospherics/pipe/manifold/violet/visible/layer3
-	piping_layer = 3
-	pixel_x = 5
-	pixel_y = 5
+	piping_layer = PIPING_LAYER_MAX
+	pixel_x = PIPING_LAYER_P_X
+	pixel_y = PIPING_LAYER_P_Y
 
 /obj/machinery/atmospherics/pipe/manifold/violet/hidden
 	level = PIPE_HIDDEN_LEVEL
 	
 /obj/machinery/atmospherics/pipe/manifold/violet/hidden/layer1
-	piping_layer = 1
-	pixel_x = -5
-	pixel_y = -5
+	piping_layer = PIPING_LAYER_MIN
+	pixel_x = -PIPING_LAYER_P_X
+	pixel_y = -PIPING_LAYER_P_Y
 
 /obj/machinery/atmospherics/pipe/manifold/violet/hidden/layer3
-	piping_layer = 3
-	pixel_x = 5
-	pixel_y = 5
+	piping_layer = PIPING_LAYER_MAX
+	pixel_x = PIPING_LAYER_P_X
+	pixel_y = PIPING_LAYER_P_Y
 
 /obj/machinery/atmospherics/pipe/manifold/brown
 	pipe_color=rgb(178,100,56)
@@ -391,24 +391,24 @@
 	layer = GAS_PIPE_VISIBLE_LAYER
 	
 /obj/machinery/atmospherics/pipe/manifold/brown/visible/layer1
-	piping_layer = 1
-	pixel_x = -5
-	pixel_y = -5
+	piping_layer = PIPING_LAYER_MIN
+	pixel_x = -PIPING_LAYER_P_X
+	pixel_y = -PIPING_LAYER_P_Y
 
 /obj/machinery/atmospherics/pipe/manifold/brown/visible/layer3
-	piping_layer = 3
-	pixel_x = 5
-	pixel_y = 5
+	piping_layer = PIPING_LAYER_MAX
+	pixel_x = PIPING_LAYER_P_X
+	pixel_y = PIPING_LAYER_P_Y
 
 /obj/machinery/atmospherics/pipe/manifold/brown/hidden
 	level = PIPE_HIDDEN_LEVEL
 	
 /obj/machinery/atmospherics/pipe/manifold/brown/hidden/layer1
-	piping_layer = 1
-	pixel_x = -5
-	pixel_y = -5
+	piping_layer = PIPING_LAYER_MIN
+	pixel_x = -PIPING_LAYER_P_X
+	pixel_y = -PIPING_LAYER_P_Y
 
 /obj/machinery/atmospherics/pipe/manifold/brown/hidden/layer3
-	piping_layer = 3
-	pixel_x = 5
-	pixel_y = 5
+	piping_layer = PIPING_LAYER_MAX
+	pixel_x = PIPING_LAYER_P_X
+	pixel_y = PIPING_LAYER_P_Y

--- a/code/modules/atmospherics/machinery/pipes/manifold.dm
+++ b/code/modules/atmospherics/machinery/pipes/manifold.dm
@@ -45,9 +45,29 @@
 /obj/machinery/atmospherics/pipe/manifold/general/visible
 	level = PIPE_VISIBLE_LEVEL
 	layer = GAS_PIPE_VISIBLE_LAYER
+	
+/obj/machinery/atmospherics/pipe/manifold/general/visible/layer1
+	piping_layer = 1
+	pixel_x = -5
+	pixel_y = -5
+
+/obj/machinery/atmospherics/pipe/manifold/general/visible/layer3
+	piping_layer = 3
+	pixel_x = 5
+	pixel_y = 5
 
 /obj/machinery/atmospherics/pipe/manifold/general/hidden
 	level = PIPE_HIDDEN_LEVEL
+	
+/obj/machinery/atmospherics/pipe/manifold/general/hidden/layer1
+	piping_layer = 1
+	pixel_x = -5
+	pixel_y = -5
+
+/obj/machinery/atmospherics/pipe/manifold/general/hidden/layer3
+	piping_layer = 3
+	pixel_x = 5
+	pixel_y = 5
 
 /obj/machinery/atmospherics/pipe/manifold/scrubbers
 	name="scrubbers pipe"
@@ -58,8 +78,28 @@
 	level = PIPE_VISIBLE_LEVEL
 	layer = GAS_PIPE_VISIBLE_LAYER
 
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/visible/layer1
+	piping_layer = 1
+	pixel_x = -5
+	pixel_y = -5
+
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/visible/layer3
+	piping_layer = 3
+	pixel_x = 5
+	pixel_y = 5
+
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden
 	level = PIPE_HIDDEN_LEVEL
+	
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer1
+	piping_layer = 1
+	pixel_x = -5
+	pixel_y = -5
+
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3
+	piping_layer = 3
+	pixel_x = 5
+	pixel_y = 5
 
 /obj/machinery/atmospherics/pipe/manifold/supply
 	name="air supply pipe"
@@ -69,10 +109,30 @@
 /obj/machinery/atmospherics/pipe/manifold/supply/visible
 	level = PIPE_VISIBLE_LEVEL
 	layer = GAS_PIPE_VISIBLE_LAYER
+	
+/obj/machinery/atmospherics/pipe/manifold/supply/visible/layer1
+	piping_layer = 1
+	pixel_x = -5
+	pixel_y = -5
+
+/obj/machinery/atmospherics/pipe/manifold/supply/visible/layer3
+	piping_layer = 3
+	pixel_x = 5
+	pixel_y = 5
 
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden
 	level = PIPE_HIDDEN_LEVEL
 
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1
+	piping_layer = 1
+	pixel_x = -5
+	pixel_y = -5
+
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer3
+	piping_layer = 3
+	pixel_x = 5
+	pixel_y = 5
+	
 /obj/machinery/atmospherics/pipe/manifold/supplymain
 	name="main air supply pipe"
 	pipe_color=rgb(130,43,255)
@@ -81,9 +141,29 @@
 /obj/machinery/atmospherics/pipe/manifold/supplymain/visible
 	level = PIPE_VISIBLE_LEVEL
 	layer = GAS_PIPE_VISIBLE_LAYER
+	
+/obj/machinery/atmospherics/pipe/manifold/supplymain/visible/layer1
+	piping_layer = 1
+	pixel_x = -5
+	pixel_y = -5
+
+/obj/machinery/atmospherics/pipe/manifold/supplymain/visible/layer3
+	piping_layer = 3
+	pixel_x = 5
+	pixel_y = 5
 
 /obj/machinery/atmospherics/pipe/manifold/supplymain/hidden
 	level = PIPE_HIDDEN_LEVEL
+	
+/obj/machinery/atmospherics/pipe/manifold/supplymain/hidden/layer1
+	piping_layer = 1
+	pixel_x = -5
+	pixel_y = -5
+
+/obj/machinery/atmospherics/pipe/manifold/supplymain/hidden/layer3
+	piping_layer = 3
+	pixel_x = 5
+	pixel_y = 5
 
 /obj/machinery/atmospherics/pipe/manifold/yellow
 	pipe_color=rgb(255,198,0)
@@ -92,9 +172,29 @@
 /obj/machinery/atmospherics/pipe/manifold/yellow/visible
 	level = PIPE_VISIBLE_LEVEL
 	layer = GAS_PIPE_VISIBLE_LAYER
+	
+/obj/machinery/atmospherics/pipe/manifold/yellow/visible/layer1
+	piping_layer = 1
+	pixel_x = -5
+	pixel_y = -5
+
+/obj/machinery/atmospherics/pipe/manifold/yellow/visible/layer3
+	piping_layer = 3
+	pixel_x = 5
+	pixel_y = 5
 
 /obj/machinery/atmospherics/pipe/manifold/yellow/hidden
 	level = PIPE_HIDDEN_LEVEL
+	
+/obj/machinery/atmospherics/pipe/manifold/yellow/hidden/layer1
+	piping_layer = 1
+	pixel_x = -5
+	pixel_y = -5
+
+/obj/machinery/atmospherics/pipe/manifold/yellow/hidden/layer3
+	piping_layer = 3
+	pixel_x = 5
+	pixel_y = 5
 
 /obj/machinery/atmospherics/pipe/manifold/cyan
 	pipe_color=rgb(0,255,249)
@@ -103,9 +203,29 @@
 /obj/machinery/atmospherics/pipe/manifold/cyan/visible
 	level = PIPE_VISIBLE_LEVEL
 	layer = GAS_PIPE_VISIBLE_LAYER
+	
+/obj/machinery/atmospherics/pipe/manifold/cyan/visible/layer1
+	piping_layer = 1
+	pixel_x = -5
+	pixel_y = -5
+
+/obj/machinery/atmospherics/pipe/manifold/cyan/visible/layer3
+	piping_layer = 3
+	pixel_x = 5
+	pixel_y = 5
 
 /obj/machinery/atmospherics/pipe/manifold/cyan/hidden
 	level = PIPE_HIDDEN_LEVEL
+	
+/obj/machinery/atmospherics/pipe/manifold/cyan/hidden/layer1
+	piping_layer = 1
+	pixel_x = -5
+	pixel_y = -5
+
+/obj/machinery/atmospherics/pipe/manifold/cyan/hidden/layer3
+	piping_layer = 3
+	pixel_x = 5
+	pixel_y = 5
 
 /obj/machinery/atmospherics/pipe/manifold/green
 	pipe_color=rgb(30,255,0)
@@ -114,9 +234,29 @@
 /obj/machinery/atmospherics/pipe/manifold/green/visible
 	level = PIPE_VISIBLE_LEVEL
 	layer = GAS_PIPE_VISIBLE_LAYER
+	
+/obj/machinery/atmospherics/pipe/manifold/green/visible/layer1
+	piping_layer = 1
+	pixel_x = -5
+	pixel_y = -5
+
+/obj/machinery/atmospherics/pipe/manifold/green/visible/layer3
+	piping_layer = 3
+	pixel_x = 5
+	pixel_y = 5
 
 /obj/machinery/atmospherics/pipe/manifold/green/hidden
 	level = PIPE_HIDDEN_LEVEL
+	
+/obj/machinery/atmospherics/pipe/manifold/green/hidden/layer1
+	piping_layer = 1
+	pixel_x = -5
+	pixel_y = -5
+
+/obj/machinery/atmospherics/pipe/manifold/green/hidden/layer3
+	piping_layer = 3
+	pixel_x = 5
+	pixel_y = 5
 
 /obj/machinery/atmospherics/pipe/manifold/orange
 	pipe_color=rgb(255,129,25)
@@ -125,9 +265,29 @@
 /obj/machinery/atmospherics/pipe/manifold/orange/visible
 	level = PIPE_VISIBLE_LEVEL
 	layer = GAS_PIPE_VISIBLE_LAYER
+	
+/obj/machinery/atmospherics/pipe/manifold/orange/visible/layer1
+	piping_layer = 1
+	pixel_x = -5
+	pixel_y = -5
+
+/obj/machinery/atmospherics/pipe/manifold/orange/visible/layer3
+	piping_layer = 3
+	pixel_x = 5
+	pixel_y = 5
 
 /obj/machinery/atmospherics/pipe/manifold/orange/hidden
 	level = PIPE_HIDDEN_LEVEL
+	
+/obj/machinery/atmospherics/pipe/manifold/orange/hidden/layer1
+	piping_layer = 1
+	pixel_x = -5
+	pixel_y = -5
+
+/obj/machinery/atmospherics/pipe/manifold/orange/hidden/layer3
+	piping_layer = 3
+	pixel_x = 5
+	pixel_y = 5
 
 /obj/machinery/atmospherics/pipe/manifold/purple
 	pipe_color=rgb(128,0,182)
@@ -136,9 +296,29 @@
 /obj/machinery/atmospherics/pipe/manifold/purple/visible
 	level = PIPE_VISIBLE_LEVEL
 	layer = GAS_PIPE_VISIBLE_LAYER
+	
+/obj/machinery/atmospherics/pipe/manifold/purple/visible/layer1
+	piping_layer = 1
+	pixel_x = -5
+	pixel_y = -5
+
+/obj/machinery/atmospherics/pipe/manifold/purple/visible/layer3
+	piping_layer = 3
+	pixel_x = 5
+	pixel_y = 5
 
 /obj/machinery/atmospherics/pipe/manifold/purple/hidden
 	level = PIPE_HIDDEN_LEVEL
+	
+/obj/machinery/atmospherics/pipe/manifold/purple/hidden/layer1
+	piping_layer = 1
+	pixel_x = -5
+	pixel_y = -5
+
+/obj/machinery/atmospherics/pipe/manifold/purple/hidden/layer3
+	piping_layer = 3
+	pixel_x = 5
+	pixel_y = 5
 
 /obj/machinery/atmospherics/pipe/manifold/dark
 	pipe_color=rgb(69,69,69)
@@ -147,9 +327,29 @@
 /obj/machinery/atmospherics/pipe/manifold/dark/visible
 	level = PIPE_VISIBLE_LEVEL
 	layer = GAS_PIPE_VISIBLE_LAYER
+	
+/obj/machinery/atmospherics/pipe/manifold/dark/visible/layer1
+	piping_layer = 1
+	pixel_x = -5
+	pixel_y = -5
+
+/obj/machinery/atmospherics/pipe/manifold/dark/visible/layer3
+	piping_layer = 3
+	pixel_x = 5
+	pixel_y = 5
 
 /obj/machinery/atmospherics/pipe/manifold/dark/hidden
 	level = PIPE_HIDDEN_LEVEL
+	
+/obj/machinery/atmospherics/pipe/manifold/dark/hidden/layer1
+	piping_layer = 1
+	pixel_x = -5
+	pixel_y = -5
+
+/obj/machinery/atmospherics/pipe/manifold/dark/hidden/layer3
+	piping_layer = 3
+	pixel_x = 5
+	pixel_y = 5
 
 /obj/machinery/atmospherics/pipe/manifold/violet
 	pipe_color=rgb(64,0,128)
@@ -158,9 +358,29 @@
 /obj/machinery/atmospherics/pipe/manifold/violet/visible
 	level = PIPE_VISIBLE_LEVEL
 	layer = GAS_PIPE_VISIBLE_LAYER
+	
+/obj/machinery/atmospherics/pipe/manifold/violet/visible/layer1
+	piping_layer = 1
+	pixel_x = -5
+	pixel_y = -5
+
+/obj/machinery/atmospherics/pipe/manifold/violet/visible/layer3
+	piping_layer = 3
+	pixel_x = 5
+	pixel_y = 5
 
 /obj/machinery/atmospherics/pipe/manifold/violet/hidden
 	level = PIPE_HIDDEN_LEVEL
+	
+/obj/machinery/atmospherics/pipe/manifold/violet/hidden/layer1
+	piping_layer = 1
+	pixel_x = -5
+	pixel_y = -5
+
+/obj/machinery/atmospherics/pipe/manifold/violet/hidden/layer3
+	piping_layer = 3
+	pixel_x = 5
+	pixel_y = 5
 
 /obj/machinery/atmospherics/pipe/manifold/brown
 	pipe_color=rgb(178,100,56)
@@ -169,6 +389,26 @@
 /obj/machinery/atmospherics/pipe/manifold/brown/visible
 	level = PIPE_VISIBLE_LEVEL
 	layer = GAS_PIPE_VISIBLE_LAYER
+	
+/obj/machinery/atmospherics/pipe/manifold/brown/visible/layer1
+	piping_layer = 1
+	pixel_x = -5
+	pixel_y = -5
+
+/obj/machinery/atmospherics/pipe/manifold/brown/visible/layer3
+	piping_layer = 3
+	pixel_x = 5
+	pixel_y = 5
 
 /obj/machinery/atmospherics/pipe/manifold/brown/hidden
 	level = PIPE_HIDDEN_LEVEL
+	
+/obj/machinery/atmospherics/pipe/manifold/brown/hidden/layer1
+	piping_layer = 1
+	pixel_x = -5
+	pixel_y = -5
+
+/obj/machinery/atmospherics/pipe/manifold/brown/hidden/layer3
+	piping_layer = 3
+	pixel_x = 5
+	pixel_y = 5

--- a/code/modules/atmospherics/machinery/pipes/manifold4w.dm
+++ b/code/modules/atmospherics/machinery/pipes/manifold4w.dm
@@ -36,9 +36,29 @@
 /obj/machinery/atmospherics/pipe/manifold4w/general/visible
 	level = PIPE_VISIBLE_LEVEL
 	layer = GAS_PIPE_VISIBLE_LAYER
+	
+/obj/machinery/atmospherics/pipe/manifold4w/general/visible/layer1
+	piping_layer = 1
+	pixel_x = -5
+	pixel_y = -5
+
+/obj/machinery/atmospherics/pipe/manifold4w/general/visible/layer3
+	piping_layer = 3
+	pixel_x = 5
+	pixel_y = 5
 
 /obj/machinery/atmospherics/pipe/manifold4w/general/hidden
 	level = PIPE_HIDDEN_LEVEL
+	
+/obj/machinery/atmospherics/pipe/manifold4w/general/hidden/layer1
+	piping_layer = 1
+	pixel_x = -5
+	pixel_y = -5
+
+/obj/machinery/atmospherics/pipe/manifold4w/general/hidden/layer3
+	piping_layer = 3
+	pixel_x = 5
+	pixel_y = 5
 
 /obj/machinery/atmospherics/pipe/manifold4w/scrubbers
 	name="scrubbers pipe"
@@ -49,9 +69,28 @@
 	level = PIPE_VISIBLE_LEVEL
 	layer = GAS_PIPE_VISIBLE_LAYER
 
+/obj/machinery/atmospherics/pipe/manifold4w/scrubbers/visible/layer1
+	piping_layer = 1
+	pixel_x = -5
+	pixel_y = -5
+
+/obj/machinery/atmospherics/pipe/manifold4w/scrubbers/visible/layer3
+	piping_layer = 3
+	pixel_x = 5
+	pixel_y = 5
 
 /obj/machinery/atmospherics/pipe/manifold4w/scrubbers/hidden
 	level = PIPE_HIDDEN_LEVEL
+	
+/obj/machinery/atmospherics/pipe/manifold4w/scrubbers/hidden/layer1
+	piping_layer = 1
+	pixel_x = -5
+	pixel_y = -5
+
+/obj/machinery/atmospherics/pipe/manifold4w/scrubbers/hidden/layer3
+	piping_layer = 3
+	pixel_x = 5
+	pixel_y = 5
 
 /obj/machinery/atmospherics/pipe/manifold4w/supply
 	name="air supply pipe"
@@ -61,10 +100,30 @@
 /obj/machinery/atmospherics/pipe/manifold4w/supply/visible
 	level = PIPE_VISIBLE_LEVEL
 	layer = GAS_PIPE_VISIBLE_LAYER
+	
+/obj/machinery/atmospherics/pipe/manifold4w/supply/visible/layer1
+	piping_layer = 1
+	pixel_x = -5
+	pixel_y = -5
+
+/obj/machinery/atmospherics/pipe/manifold4w/supply/visible/layer3
+	piping_layer = 3
+	pixel_x = 5
+	pixel_y = 5
 
 /obj/machinery/atmospherics/pipe/manifold4w/supply/hidden
 	level = PIPE_HIDDEN_LEVEL
 
+/obj/machinery/atmospherics/pipe/manifold4w/supply/hidden/layer1
+	piping_layer = 1
+	pixel_x = -5
+	pixel_y = -5
+
+/obj/machinery/atmospherics/pipe/manifold4w/supply/hidden/layer3
+	piping_layer = 3
+	pixel_x = 5
+	pixel_y = 5
+	
 /obj/machinery/atmospherics/pipe/manifold4w/supplymain
 	name="main air supply pipe"
 	pipe_color=rgb(130,43,255)
@@ -73,9 +132,29 @@
 /obj/machinery/atmospherics/pipe/manifold4w/supplymain/visible
 	level = PIPE_VISIBLE_LEVEL
 	layer = GAS_PIPE_VISIBLE_LAYER
+	
+/obj/machinery/atmospherics/pipe/manifold4w/supplymain/visible/layer1
+	piping_layer = 1
+	pixel_x = -5
+	pixel_y = -5
+
+/obj/machinery/atmospherics/pipe/manifold4w/supplymain/visible/layer3
+	piping_layer = 3
+	pixel_x = 5
+	pixel_y = 5
 
 /obj/machinery/atmospherics/pipe/manifold4w/supplymain/hidden
 	level = PIPE_HIDDEN_LEVEL
+	
+/obj/machinery/atmospherics/pipe/manifold4w/supplymain/hidden/layer1
+	piping_layer = 1
+	pixel_x = -5
+	pixel_y = -5
+
+/obj/machinery/atmospherics/pipe/manifold4w/supplymain/hidden/layer3
+	piping_layer = 3
+	pixel_x = 5
+	pixel_y = 5
 
 /obj/machinery/atmospherics/pipe/manifold4w/yellow
 	pipe_color=rgb(255,198,0)
@@ -84,9 +163,29 @@
 /obj/machinery/atmospherics/pipe/manifold4w/yellow/visible
 	level = PIPE_VISIBLE_LEVEL
 	layer = GAS_PIPE_VISIBLE_LAYER
+	
+/obj/machinery/atmospherics/pipe/manifold4w/yellow/visible/layer1
+	piping_layer = 1
+	pixel_x = -5
+	pixel_y = -5
+
+/obj/machinery/atmospherics/pipe/manifold4w/yellow/visible/layer3
+	piping_layer = 3
+	pixel_x = 5
+	pixel_y = 5
 
 /obj/machinery/atmospherics/pipe/manifold4w/yellow/hidden
 	level = PIPE_HIDDEN_LEVEL
+	
+/obj/machinery/atmospherics/pipe/manifold4w/yellow/hidden/layer1
+	piping_layer = 1
+	pixel_x = -5
+	pixel_y = -5
+
+/obj/machinery/atmospherics/pipe/manifold4w/yellow/hidden/layer3
+	piping_layer = 3
+	pixel_x = 5
+	pixel_y = 5
 
 /obj/machinery/atmospherics/pipe/manifold4w/cyan
 	pipe_color=rgb(0,255,249)
@@ -95,9 +194,29 @@
 /obj/machinery/atmospherics/pipe/manifold4w/cyan/visible
 	level = PIPE_VISIBLE_LEVEL
 	layer = GAS_PIPE_VISIBLE_LAYER
+	
+/obj/machinery/atmospherics/pipe/manifold4w/cyan/visible/layer1
+	piping_layer = 1
+	pixel_x = -5
+	pixel_y = -5
+
+/obj/machinery/atmospherics/pipe/manifold4w/cyan/visible/layer3
+	piping_layer = 3
+	pixel_x = 5
+	pixel_y = 5
 
 /obj/machinery/atmospherics/pipe/manifold4w/cyan/hidden
 	level = PIPE_HIDDEN_LEVEL
+	
+/obj/machinery/atmospherics/pipe/manifold4w/cyan/hidden/layer1
+	piping_layer = 1
+	pixel_x = -5
+	pixel_y = -5
+
+/obj/machinery/atmospherics/pipe/manifold4w/cyan/hidden/layer3
+	piping_layer = 3
+	pixel_x = 5
+	pixel_y = 5
 
 /obj/machinery/atmospherics/pipe/manifold4w/green
 	pipe_color=rgb(30,255,0)
@@ -106,9 +225,29 @@
 /obj/machinery/atmospherics/pipe/manifold4w/green/visible
 	level = PIPE_VISIBLE_LEVEL
 	layer = GAS_PIPE_VISIBLE_LAYER
+	
+/obj/machinery/atmospherics/pipe/manifold4w/green/visible/layer1
+	piping_layer = 1
+	pixel_x = -5
+	pixel_y = -5
+
+/obj/machinery/atmospherics/pipe/manifold4w/green/visible/layer3
+	piping_layer = 3
+	pixel_x = 5
+	pixel_y = 5
 
 /obj/machinery/atmospherics/pipe/manifold4w/green/hidden
 	level = PIPE_HIDDEN_LEVEL
+	
+/obj/machinery/atmospherics/pipe/manifold4w/green/hidden/layer1
+	piping_layer = 1
+	pixel_x = -5
+	pixel_y = -5
+
+/obj/machinery/atmospherics/pipe/manifold4w/green/hidden/layer3
+	piping_layer = 3
+	pixel_x = 5
+	pixel_y = 5
 
 /obj/machinery/atmospherics/pipe/manifold4w/orange
 	pipe_color=rgb(255,129,25)
@@ -117,9 +256,29 @@
 /obj/machinery/atmospherics/pipe/manifold4w/orange/visible
 	level = PIPE_VISIBLE_LEVEL
 	layer = GAS_PIPE_VISIBLE_LAYER
+	
+/obj/machinery/atmospherics/pipe/manifold4w/orange/visible/layer1
+	piping_layer = 1
+	pixel_x = -5
+	pixel_y = -5
+
+/obj/machinery/atmospherics/pipe/manifold4w/orange/visible/layer3
+	piping_layer = 3
+	pixel_x = 5
+	pixel_y = 5
 
 /obj/machinery/atmospherics/pipe/manifold4w/orange/hidden
 	level = PIPE_HIDDEN_LEVEL
+	
+/obj/machinery/atmospherics/pipe/manifold4w/orange/hidden/layer1
+	piping_layer = 1
+	pixel_x = -5
+	pixel_y = -5
+
+/obj/machinery/atmospherics/pipe/manifold4w/orange/hidden/layer3
+	piping_layer = 3
+	pixel_x = 5
+	pixel_y = 5
 
 /obj/machinery/atmospherics/pipe/manifold4w/purple
 	pipe_color=rgb(128,0,182)
@@ -128,9 +287,29 @@
 /obj/machinery/atmospherics/pipe/manifold4w/purple/visible
 	level = PIPE_VISIBLE_LEVEL
 	layer = GAS_PIPE_VISIBLE_LAYER
+	
+/obj/machinery/atmospherics/pipe/manifold4w/purple/visible/layer1
+	piping_layer = 1
+	pixel_x = -5
+	pixel_y = -5
+
+/obj/machinery/atmospherics/pipe/manifold4w/purple/visible/layer3
+	piping_layer = 3
+	pixel_x = 5
+	pixel_y = 5
 
 /obj/machinery/atmospherics/pipe/manifold4w/purple/hidden
 	level = PIPE_HIDDEN_LEVEL
+	
+/obj/machinery/atmospherics/pipe/manifold4w/purple/hidden/layer1
+	piping_layer = 1
+	pixel_x = -5
+	pixel_y = -5
+
+/obj/machinery/atmospherics/pipe/manifold4w/purple/hidden/layer3
+	piping_layer = 3
+	pixel_x = 5
+	pixel_y = 5
 
 /obj/machinery/atmospherics/pipe/manifold4w/dark
 	pipe_color=rgb(69,69,69)
@@ -139,9 +318,29 @@
 /obj/machinery/atmospherics/pipe/manifold4w/dark/visible
 	level = PIPE_VISIBLE_LEVEL
 	layer = GAS_PIPE_VISIBLE_LAYER
+	
+/obj/machinery/atmospherics/pipe/manifold4w/dark/visible/layer1
+	piping_layer = 1
+	pixel_x = -5
+	pixel_y = -5
+
+/obj/machinery/atmospherics/pipe/manifold4w/dark/visible/layer3
+	piping_layer = 3
+	pixel_x = 5
+	pixel_y = 5
 
 /obj/machinery/atmospherics/pipe/manifold4w/dark/hidden
 	level = PIPE_HIDDEN_LEVEL
+	
+/obj/machinery/atmospherics/pipe/manifold4w/dark/hidden/layer1
+	piping_layer = 1
+	pixel_x = -5
+	pixel_y = -5
+
+/obj/machinery/atmospherics/pipe/manifold4w/dark/hidden/layer3
+	piping_layer = 3
+	pixel_x = 5
+	pixel_y = 5
 
 /obj/machinery/atmospherics/pipe/manifold4w/violet
 	pipe_color=rgb(64,0,128)
@@ -150,9 +349,29 @@
 /obj/machinery/atmospherics/pipe/manifold4w/violet/visible
 	level = PIPE_VISIBLE_LEVEL
 	layer = GAS_PIPE_VISIBLE_LAYER
+	
+/obj/machinery/atmospherics/pipe/manifold4w/violet/visible/layer1
+	piping_layer = 1
+	pixel_x = -5
+	pixel_y = -5
+
+/obj/machinery/atmospherics/pipe/manifold4w/violet/visible/layer3
+	piping_layer = 3
+	pixel_x = 5
+	pixel_y = 5
 
 /obj/machinery/atmospherics/pipe/manifold4w/violet/hidden
 	level = PIPE_HIDDEN_LEVEL
+	
+/obj/machinery/atmospherics/pipe/manifold4w/violet/hidden/layer1
+	piping_layer = 1
+	pixel_x = -5
+	pixel_y = -5
+
+/obj/machinery/atmospherics/pipe/manifold4w/violet/hidden/layer3
+	piping_layer = 3
+	pixel_x = 5
+	pixel_y = 5
 
 /obj/machinery/atmospherics/pipe/manifold4w/brown
 	pipe_color=rgb(178,100,56)
@@ -161,6 +380,26 @@
 /obj/machinery/atmospherics/pipe/manifold4w/brown/visible
 	level = PIPE_VISIBLE_LEVEL
 	layer = GAS_PIPE_VISIBLE_LAYER
+	
+/obj/machinery/atmospherics/pipe/manifold4w/brown/visible/layer1
+	piping_layer = 1
+	pixel_x = -5
+	pixel_y = -5
+
+/obj/machinery/atmospherics/pipe/manifold4w/brown/visible/layer3
+	piping_layer = 3
+	pixel_x = 5
+	pixel_y = 5
 
 /obj/machinery/atmospherics/pipe/manifold4w/brown/hidden
 	level = PIPE_HIDDEN_LEVEL
+	
+/obj/machinery/atmospherics/pipe/manifold4w/brown/hidden/layer1
+	piping_layer = 1
+	pixel_x = -5
+	pixel_y = -5
+
+/obj/machinery/atmospherics/pipe/manifold4w/brown/hidden/layer3
+	piping_layer = 3
+	pixel_x = 5
+	pixel_y = 5

--- a/code/modules/atmospherics/machinery/pipes/manifold4w.dm
+++ b/code/modules/atmospherics/machinery/pipes/manifold4w.dm
@@ -38,27 +38,27 @@
 	layer = GAS_PIPE_VISIBLE_LAYER
 	
 /obj/machinery/atmospherics/pipe/manifold4w/general/visible/layer1
-	piping_layer = 1
-	pixel_x = -5
-	pixel_y = -5
+	piping_layer = PIPING_LAYER_MIN
+	pixel_x = -PIPING_LAYER_P_X
+	pixel_y = -PIPING_LAYER_P_Y
 
 /obj/machinery/atmospherics/pipe/manifold4w/general/visible/layer3
-	piping_layer = 3
-	pixel_x = 5
-	pixel_y = 5
+	piping_layer = PIPING_LAYER_MAX
+	pixel_x = PIPING_LAYER_P_X
+	pixel_y = PIPING_LAYER_P_Y
 
 /obj/machinery/atmospherics/pipe/manifold4w/general/hidden
 	level = PIPE_HIDDEN_LEVEL
 	
 /obj/machinery/atmospherics/pipe/manifold4w/general/hidden/layer1
-	piping_layer = 1
-	pixel_x = -5
-	pixel_y = -5
+	piping_layer = PIPING_LAYER_MIN
+	pixel_x = -PIPING_LAYER_P_X
+	pixel_y = -PIPING_LAYER_P_Y
 
 /obj/machinery/atmospherics/pipe/manifold4w/general/hidden/layer3
-	piping_layer = 3
-	pixel_x = 5
-	pixel_y = 5
+	piping_layer = PIPING_LAYER_MAX
+	pixel_x = PIPING_LAYER_P_X
+	pixel_y = PIPING_LAYER_P_Y
 
 /obj/machinery/atmospherics/pipe/manifold4w/scrubbers
 	name="scrubbers pipe"
@@ -70,27 +70,27 @@
 	layer = GAS_PIPE_VISIBLE_LAYER
 
 /obj/machinery/atmospherics/pipe/manifold4w/scrubbers/visible/layer1
-	piping_layer = 1
-	pixel_x = -5
-	pixel_y = -5
+	piping_layer = PIPING_LAYER_MIN
+	pixel_x = -PIPING_LAYER_P_X
+	pixel_y = -PIPING_LAYER_P_Y
 
 /obj/machinery/atmospherics/pipe/manifold4w/scrubbers/visible/layer3
-	piping_layer = 3
-	pixel_x = 5
-	pixel_y = 5
+	piping_layer = PIPING_LAYER_MAX
+	pixel_x = PIPING_LAYER_P_X
+	pixel_y = PIPING_LAYER_P_Y
 
 /obj/machinery/atmospherics/pipe/manifold4w/scrubbers/hidden
 	level = PIPE_HIDDEN_LEVEL
 	
 /obj/machinery/atmospherics/pipe/manifold4w/scrubbers/hidden/layer1
-	piping_layer = 1
-	pixel_x = -5
-	pixel_y = -5
+	piping_layer = PIPING_LAYER_MIN
+	pixel_x = -PIPING_LAYER_P_X
+	pixel_y = -PIPING_LAYER_P_Y
 
 /obj/machinery/atmospherics/pipe/manifold4w/scrubbers/hidden/layer3
-	piping_layer = 3
-	pixel_x = 5
-	pixel_y = 5
+	piping_layer = PIPING_LAYER_MAX
+	pixel_x = PIPING_LAYER_P_X
+	pixel_y = PIPING_LAYER_P_Y
 
 /obj/machinery/atmospherics/pipe/manifold4w/supply
 	name="air supply pipe"
@@ -102,27 +102,27 @@
 	layer = GAS_PIPE_VISIBLE_LAYER
 	
 /obj/machinery/atmospherics/pipe/manifold4w/supply/visible/layer1
-	piping_layer = 1
-	pixel_x = -5
-	pixel_y = -5
+	piping_layer = PIPING_LAYER_MIN
+	pixel_x = -PIPING_LAYER_P_X
+	pixel_y = -PIPING_LAYER_P_Y
 
 /obj/machinery/atmospherics/pipe/manifold4w/supply/visible/layer3
-	piping_layer = 3
-	pixel_x = 5
-	pixel_y = 5
+	piping_layer = PIPING_LAYER_MAX
+	pixel_x = PIPING_LAYER_P_X
+	pixel_y = PIPING_LAYER_P_Y
 
 /obj/machinery/atmospherics/pipe/manifold4w/supply/hidden
 	level = PIPE_HIDDEN_LEVEL
 
 /obj/machinery/atmospherics/pipe/manifold4w/supply/hidden/layer1
-	piping_layer = 1
-	pixel_x = -5
-	pixel_y = -5
+	piping_layer = PIPING_LAYER_MIN
+	pixel_x = -PIPING_LAYER_P_X
+	pixel_y = -PIPING_LAYER_P_Y
 
 /obj/machinery/atmospherics/pipe/manifold4w/supply/hidden/layer3
-	piping_layer = 3
-	pixel_x = 5
-	pixel_y = 5
+	piping_layer = PIPING_LAYER_MAX
+	pixel_x = PIPING_LAYER_P_X
+	pixel_y = PIPING_LAYER_P_Y
 	
 /obj/machinery/atmospherics/pipe/manifold4w/supplymain
 	name="main air supply pipe"
@@ -134,27 +134,27 @@
 	layer = GAS_PIPE_VISIBLE_LAYER
 	
 /obj/machinery/atmospherics/pipe/manifold4w/supplymain/visible/layer1
-	piping_layer = 1
-	pixel_x = -5
-	pixel_y = -5
+	piping_layer = PIPING_LAYER_MIN
+	pixel_x = -PIPING_LAYER_P_X
+	pixel_y = -PIPING_LAYER_P_Y
 
 /obj/machinery/atmospherics/pipe/manifold4w/supplymain/visible/layer3
-	piping_layer = 3
-	pixel_x = 5
-	pixel_y = 5
+	piping_layer = PIPING_LAYER_MAX
+	pixel_x = PIPING_LAYER_P_X
+	pixel_y = PIPING_LAYER_P_Y
 
 /obj/machinery/atmospherics/pipe/manifold4w/supplymain/hidden
 	level = PIPE_HIDDEN_LEVEL
 	
 /obj/machinery/atmospherics/pipe/manifold4w/supplymain/hidden/layer1
-	piping_layer = 1
-	pixel_x = -5
-	pixel_y = -5
+	piping_layer = PIPING_LAYER_MIN
+	pixel_x = -PIPING_LAYER_P_X
+	pixel_y = -PIPING_LAYER_P_Y
 
 /obj/machinery/atmospherics/pipe/manifold4w/supplymain/hidden/layer3
-	piping_layer = 3
-	pixel_x = 5
-	pixel_y = 5
+	piping_layer = PIPING_LAYER_MAX
+	pixel_x = PIPING_LAYER_P_X
+	pixel_y = PIPING_LAYER_P_Y
 
 /obj/machinery/atmospherics/pipe/manifold4w/yellow
 	pipe_color=rgb(255,198,0)
@@ -165,27 +165,27 @@
 	layer = GAS_PIPE_VISIBLE_LAYER
 	
 /obj/machinery/atmospherics/pipe/manifold4w/yellow/visible/layer1
-	piping_layer = 1
-	pixel_x = -5
-	pixel_y = -5
+	piping_layer = PIPING_LAYER_MIN
+	pixel_x = -PIPING_LAYER_P_X
+	pixel_y = -PIPING_LAYER_P_Y
 
 /obj/machinery/atmospherics/pipe/manifold4w/yellow/visible/layer3
-	piping_layer = 3
-	pixel_x = 5
-	pixel_y = 5
+	piping_layer = PIPING_LAYER_MAX
+	pixel_x = PIPING_LAYER_P_X
+	pixel_y = PIPING_LAYER_P_Y
 
 /obj/machinery/atmospherics/pipe/manifold4w/yellow/hidden
 	level = PIPE_HIDDEN_LEVEL
 	
 /obj/machinery/atmospherics/pipe/manifold4w/yellow/hidden/layer1
-	piping_layer = 1
-	pixel_x = -5
-	pixel_y = -5
+	piping_layer = PIPING_LAYER_MIN
+	pixel_x = -PIPING_LAYER_P_X
+	pixel_y = -PIPING_LAYER_P_Y
 
 /obj/machinery/atmospherics/pipe/manifold4w/yellow/hidden/layer3
-	piping_layer = 3
-	pixel_x = 5
-	pixel_y = 5
+	piping_layer = PIPING_LAYER_MAX
+	pixel_x = PIPING_LAYER_P_X
+	pixel_y = PIPING_LAYER_P_Y
 
 /obj/machinery/atmospherics/pipe/manifold4w/cyan
 	pipe_color=rgb(0,255,249)
@@ -196,27 +196,27 @@
 	layer = GAS_PIPE_VISIBLE_LAYER
 	
 /obj/machinery/atmospherics/pipe/manifold4w/cyan/visible/layer1
-	piping_layer = 1
-	pixel_x = -5
-	pixel_y = -5
+	piping_layer = PIPING_LAYER_MIN
+	pixel_x = -PIPING_LAYER_P_X
+	pixel_y = -PIPING_LAYER_P_Y
 
 /obj/machinery/atmospherics/pipe/manifold4w/cyan/visible/layer3
-	piping_layer = 3
-	pixel_x = 5
-	pixel_y = 5
+	piping_layer = PIPING_LAYER_MAX
+	pixel_x = PIPING_LAYER_P_X
+	pixel_y = PIPING_LAYER_P_Y
 
 /obj/machinery/atmospherics/pipe/manifold4w/cyan/hidden
 	level = PIPE_HIDDEN_LEVEL
 	
 /obj/machinery/atmospherics/pipe/manifold4w/cyan/hidden/layer1
-	piping_layer = 1
-	pixel_x = -5
-	pixel_y = -5
+	piping_layer = PIPING_LAYER_MIN
+	pixel_x = -PIPING_LAYER_P_X
+	pixel_y = -PIPING_LAYER_P_Y
 
 /obj/machinery/atmospherics/pipe/manifold4w/cyan/hidden/layer3
-	piping_layer = 3
-	pixel_x = 5
-	pixel_y = 5
+	piping_layer = PIPING_LAYER_MAX
+	pixel_x = PIPING_LAYER_P_X
+	pixel_y = PIPING_LAYER_P_Y
 
 /obj/machinery/atmospherics/pipe/manifold4w/green
 	pipe_color=rgb(30,255,0)
@@ -227,27 +227,27 @@
 	layer = GAS_PIPE_VISIBLE_LAYER
 	
 /obj/machinery/atmospherics/pipe/manifold4w/green/visible/layer1
-	piping_layer = 1
-	pixel_x = -5
-	pixel_y = -5
+	piping_layer = PIPING_LAYER_MIN
+	pixel_x = -PIPING_LAYER_P_X
+	pixel_y = -PIPING_LAYER_P_Y
 
 /obj/machinery/atmospherics/pipe/manifold4w/green/visible/layer3
-	piping_layer = 3
-	pixel_x = 5
-	pixel_y = 5
+	piping_layer = PIPING_LAYER_MAX
+	pixel_x = PIPING_LAYER_P_X
+	pixel_y = PIPING_LAYER_P_Y
 
 /obj/machinery/atmospherics/pipe/manifold4w/green/hidden
 	level = PIPE_HIDDEN_LEVEL
 	
 /obj/machinery/atmospherics/pipe/manifold4w/green/hidden/layer1
-	piping_layer = 1
-	pixel_x = -5
-	pixel_y = -5
+	piping_layer = PIPING_LAYER_MIN
+	pixel_x = -PIPING_LAYER_P_X
+	pixel_y = -PIPING_LAYER_P_Y
 
 /obj/machinery/atmospherics/pipe/manifold4w/green/hidden/layer3
-	piping_layer = 3
-	pixel_x = 5
-	pixel_y = 5
+	piping_layer = PIPING_LAYER_MAX
+	pixel_x = PIPING_LAYER_P_X
+	pixel_y = PIPING_LAYER_P_Y
 
 /obj/machinery/atmospherics/pipe/manifold4w/orange
 	pipe_color=rgb(255,129,25)
@@ -258,27 +258,27 @@
 	layer = GAS_PIPE_VISIBLE_LAYER
 	
 /obj/machinery/atmospherics/pipe/manifold4w/orange/visible/layer1
-	piping_layer = 1
-	pixel_x = -5
-	pixel_y = -5
+	piping_layer = PIPING_LAYER_MIN
+	pixel_x = -PIPING_LAYER_P_X
+	pixel_y = -PIPING_LAYER_P_Y
 
 /obj/machinery/atmospherics/pipe/manifold4w/orange/visible/layer3
-	piping_layer = 3
-	pixel_x = 5
-	pixel_y = 5
+	piping_layer = PIPING_LAYER_MAX
+	pixel_x = PIPING_LAYER_P_X
+	pixel_y = PIPING_LAYER_P_Y
 
 /obj/machinery/atmospherics/pipe/manifold4w/orange/hidden
 	level = PIPE_HIDDEN_LEVEL
 	
 /obj/machinery/atmospherics/pipe/manifold4w/orange/hidden/layer1
-	piping_layer = 1
-	pixel_x = -5
-	pixel_y = -5
+	piping_layer = PIPING_LAYER_MIN
+	pixel_x = -PIPING_LAYER_P_X
+	pixel_y = -PIPING_LAYER_P_Y
 
 /obj/machinery/atmospherics/pipe/manifold4w/orange/hidden/layer3
-	piping_layer = 3
-	pixel_x = 5
-	pixel_y = 5
+	piping_layer = PIPING_LAYER_MAX
+	pixel_x = PIPING_LAYER_P_X
+	pixel_y = PIPING_LAYER_P_Y
 
 /obj/machinery/atmospherics/pipe/manifold4w/purple
 	pipe_color=rgb(128,0,182)
@@ -289,27 +289,27 @@
 	layer = GAS_PIPE_VISIBLE_LAYER
 	
 /obj/machinery/atmospherics/pipe/manifold4w/purple/visible/layer1
-	piping_layer = 1
-	pixel_x = -5
-	pixel_y = -5
+	piping_layer = PIPING_LAYER_MIN
+	pixel_x = -PIPING_LAYER_P_X
+	pixel_y = -PIPING_LAYER_P_Y
 
 /obj/machinery/atmospherics/pipe/manifold4w/purple/visible/layer3
-	piping_layer = 3
-	pixel_x = 5
-	pixel_y = 5
+	piping_layer = PIPING_LAYER_MAX
+	pixel_x = PIPING_LAYER_P_X
+	pixel_y = PIPING_LAYER_P_Y
 
 /obj/machinery/atmospherics/pipe/manifold4w/purple/hidden
 	level = PIPE_HIDDEN_LEVEL
 	
 /obj/machinery/atmospherics/pipe/manifold4w/purple/hidden/layer1
-	piping_layer = 1
-	pixel_x = -5
-	pixel_y = -5
+	piping_layer = PIPING_LAYER_MIN
+	pixel_x = -PIPING_LAYER_P_X
+	pixel_y = -PIPING_LAYER_P_Y
 
 /obj/machinery/atmospherics/pipe/manifold4w/purple/hidden/layer3
-	piping_layer = 3
-	pixel_x = 5
-	pixel_y = 5
+	piping_layer = PIPING_LAYER_MAX
+	pixel_x = PIPING_LAYER_P_X
+	pixel_y = PIPING_LAYER_P_Y
 
 /obj/machinery/atmospherics/pipe/manifold4w/dark
 	pipe_color=rgb(69,69,69)
@@ -320,27 +320,27 @@
 	layer = GAS_PIPE_VISIBLE_LAYER
 	
 /obj/machinery/atmospherics/pipe/manifold4w/dark/visible/layer1
-	piping_layer = 1
-	pixel_x = -5
-	pixel_y = -5
+	piping_layer = PIPING_LAYER_MIN
+	pixel_x = -PIPING_LAYER_P_X
+	pixel_y = -PIPING_LAYER_P_Y
 
 /obj/machinery/atmospherics/pipe/manifold4w/dark/visible/layer3
-	piping_layer = 3
-	pixel_x = 5
-	pixel_y = 5
+	piping_layer = PIPING_LAYER_MAX
+	pixel_x = PIPING_LAYER_P_X
+	pixel_y = PIPING_LAYER_P_Y
 
 /obj/machinery/atmospherics/pipe/manifold4w/dark/hidden
 	level = PIPE_HIDDEN_LEVEL
 	
 /obj/machinery/atmospherics/pipe/manifold4w/dark/hidden/layer1
-	piping_layer = 1
-	pixel_x = -5
-	pixel_y = -5
+	piping_layer = PIPING_LAYER_MIN
+	pixel_x = -PIPING_LAYER_P_X
+	pixel_y = -PIPING_LAYER_P_Y
 
 /obj/machinery/atmospherics/pipe/manifold4w/dark/hidden/layer3
-	piping_layer = 3
-	pixel_x = 5
-	pixel_y = 5
+	piping_layer = PIPING_LAYER_MAX
+	pixel_x = PIPING_LAYER_P_X
+	pixel_y = PIPING_LAYER_P_Y
 
 /obj/machinery/atmospherics/pipe/manifold4w/violet
 	pipe_color=rgb(64,0,128)
@@ -351,27 +351,27 @@
 	layer = GAS_PIPE_VISIBLE_LAYER
 	
 /obj/machinery/atmospherics/pipe/manifold4w/violet/visible/layer1
-	piping_layer = 1
-	pixel_x = -5
-	pixel_y = -5
+	piping_layer = PIPING_LAYER_MIN
+	pixel_x = -PIPING_LAYER_P_X
+	pixel_y = -PIPING_LAYER_P_Y
 
 /obj/machinery/atmospherics/pipe/manifold4w/violet/visible/layer3
-	piping_layer = 3
-	pixel_x = 5
-	pixel_y = 5
+	piping_layer = PIPING_LAYER_MAX
+	pixel_x = PIPING_LAYER_P_X
+	pixel_y = PIPING_LAYER_P_Y
 
 /obj/machinery/atmospherics/pipe/manifold4w/violet/hidden
 	level = PIPE_HIDDEN_LEVEL
 	
 /obj/machinery/atmospherics/pipe/manifold4w/violet/hidden/layer1
-	piping_layer = 1
-	pixel_x = -5
-	pixel_y = -5
+	piping_layer = PIPING_LAYER_MIN
+	pixel_x = -PIPING_LAYER_P_X
+	pixel_y = -PIPING_LAYER_P_Y
 
 /obj/machinery/atmospherics/pipe/manifold4w/violet/hidden/layer3
-	piping_layer = 3
-	pixel_x = 5
-	pixel_y = 5
+	piping_layer = PIPING_LAYER_MAX
+	pixel_x = PIPING_LAYER_P_X
+	pixel_y = PIPING_LAYER_P_Y
 
 /obj/machinery/atmospherics/pipe/manifold4w/brown
 	pipe_color=rgb(178,100,56)
@@ -382,24 +382,24 @@
 	layer = GAS_PIPE_VISIBLE_LAYER
 	
 /obj/machinery/atmospherics/pipe/manifold4w/brown/visible/layer1
-	piping_layer = 1
-	pixel_x = -5
-	pixel_y = -5
+	piping_layer = PIPING_LAYER_MIN
+	pixel_x = -PIPING_LAYER_P_X
+	pixel_y = -PIPING_LAYER_P_Y
 
 /obj/machinery/atmospherics/pipe/manifold4w/brown/visible/layer3
-	piping_layer = 3
-	pixel_x = 5
-	pixel_y = 5
+	piping_layer = PIPING_LAYER_MAX
+	pixel_x = PIPING_LAYER_P_X
+	pixel_y = PIPING_LAYER_P_Y
 
 /obj/machinery/atmospherics/pipe/manifold4w/brown/hidden
 	level = PIPE_HIDDEN_LEVEL
 	
 /obj/machinery/atmospherics/pipe/manifold4w/brown/hidden/layer1
-	piping_layer = 1
-	pixel_x = -5
-	pixel_y = -5
+	piping_layer = PIPING_LAYER_MIN
+	pixel_x = -PIPING_LAYER_P_X
+	pixel_y = -PIPING_LAYER_P_Y
 
 /obj/machinery/atmospherics/pipe/manifold4w/brown/hidden/layer3
-	piping_layer = 3
-	pixel_x = 5
-	pixel_y = 5
+	piping_layer = PIPING_LAYER_MAX
+	pixel_x = PIPING_LAYER_P_X
+	pixel_y = PIPING_LAYER_P_Y

--- a/code/modules/atmospherics/machinery/pipes/simple.dm
+++ b/code/modules/atmospherics/machinery/pipes/simple.dm
@@ -35,10 +35,30 @@ The regular pipe you see everywhere, including bent ones.
 /obj/machinery/atmospherics/pipe/simple/general/visible
 	level = PIPE_VISIBLE_LEVEL
 	layer = GAS_PIPE_VISIBLE_LAYER
+	
+/obj/machinery/atmospherics/pipe/simple/general/visible/layer1
+	piping_layer = 1
+	pixel_x = -5
+	pixel_y = -5
+
+/obj/machinery/atmospherics/pipe/simple/general/visible/layer3
+	piping_layer = 3
+	pixel_x = 5
+	pixel_y = 5
 
 /obj/machinery/atmospherics/pipe/simple/general/hidden
 	level = PIPE_HIDDEN_LEVEL
 
+/obj/machinery/atmospherics/pipe/simple/general/hidden/layer1
+	piping_layer = 1
+	pixel_x = -5
+	pixel_y = -5
+
+/obj/machinery/atmospherics/pipe/simple/general/hidden/layer3
+	piping_layer = 3
+	pixel_x = 5
+	pixel_y = 5
+	
 /obj/machinery/atmospherics/pipe/simple/scrubbers
 	name="scrubbers pipe"
 	pipe_color=rgb(255,0,0)
@@ -48,9 +68,29 @@ The regular pipe you see everywhere, including bent ones.
 	level = PIPE_VISIBLE_LEVEL
 	layer = GAS_PIPE_VISIBLE_LAYER
 
+/obj/machinery/atmospherics/pipe/simple/scrubbers/visible/layer1
+	piping_layer = 1
+	pixel_x = -5
+	pixel_y = -5
+
+/obj/machinery/atmospherics/pipe/simple/scrubbers/visible/layer3
+	piping_layer = 3
+	pixel_x = 5
+	pixel_y = 5
+	
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden
 	level = PIPE_HIDDEN_LEVEL
 
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1
+	piping_layer = 1
+	pixel_x = -5
+	pixel_y = -5
+
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3
+	piping_layer = 3
+	pixel_x = 5
+	pixel_y = 5
+	
 /obj/machinery/atmospherics/pipe/simple/supply
 	name="air supply pipe"
 	pipe_color=rgb(0,0,255)
@@ -59,10 +99,30 @@ The regular pipe you see everywhere, including bent ones.
 /obj/machinery/atmospherics/pipe/simple/supply/visible
 	level = PIPE_VISIBLE_LEVEL
 	layer = GAS_PIPE_VISIBLE_LAYER
+	
+/obj/machinery/atmospherics/pipe/simple/supply/visible/layer1
+	piping_layer = 1
+	pixel_x = -5
+	pixel_y = -5
+
+/obj/machinery/atmospherics/pipe/simple/supply/visible/layer3
+	piping_layer = 3
+	pixel_x = 5
+	pixel_y = 5
 
 /obj/machinery/atmospherics/pipe/simple/supply/hidden
 	level = PIPE_HIDDEN_LEVEL
 
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1
+	piping_layer = 1
+	pixel_x = -5
+	pixel_y = -5
+
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3
+	piping_layer = 3
+	pixel_x = 5
+	pixel_y = 5
+	
 /obj/machinery/atmospherics/pipe/simple/supplymain
 	name="main air supply pipe"
 	pipe_color=rgb(130,43,255)
@@ -72,9 +132,29 @@ The regular pipe you see everywhere, including bent ones.
 	level = PIPE_VISIBLE_LEVEL
 	layer = GAS_PIPE_VISIBLE_LAYER
 
+/obj/machinery/atmospherics/pipe/simple/supplymain/visible/layer1
+	piping_layer = 1
+	pixel_x = -5
+	pixel_y = -5
+
+/obj/machinery/atmospherics/pipe/simple/supplymain/visible/layer3
+	piping_layer = 3
+	pixel_x = 5
+	pixel_y = 5
+	
 /obj/machinery/atmospherics/pipe/simple/supplymain/hidden
 	level = PIPE_HIDDEN_LEVEL
 
+/obj/machinery/atmospherics/pipe/simple/supplymain/hidden/layer1
+	piping_layer = 1
+	pixel_x = -5
+	pixel_y = -5
+
+/obj/machinery/atmospherics/pipe/simple/supplymain/hidden/layer3
+	piping_layer = 3
+	pixel_x = 5
+	pixel_y = 5
+	
 /obj/machinery/atmospherics/pipe/simple/yellow
 	pipe_color=rgb(255,198,0)
 	color=rgb(255,198,0)
@@ -83,9 +163,29 @@ The regular pipe you see everywhere, including bent ones.
 	level = PIPE_VISIBLE_LEVEL
 	layer = GAS_PIPE_VISIBLE_LAYER
 
+/obj/machinery/atmospherics/pipe/simple/yellow/visible/layer1
+	piping_layer = 1
+	pixel_x = -5
+	pixel_y = -5
+
+/obj/machinery/atmospherics/pipe/simple/yellow/visible/layer3
+	piping_layer = 3
+	pixel_x = 5
+	pixel_y = 5
+	
 /obj/machinery/atmospherics/pipe/simple/yellow/hidden
 	level = PIPE_HIDDEN_LEVEL
 
+/obj/machinery/atmospherics/pipe/simple/yellow/hidden/layer1
+	piping_layer = 1
+	pixel_x = -5
+	pixel_y = -5
+
+/obj/machinery/atmospherics/pipe/simple/yellow/hidden/layer3
+	piping_layer = 3
+	pixel_x = 5
+	pixel_y = 5
+	
 /obj/machinery/atmospherics/pipe/simple/cyan
 	pipe_color=rgb(0,255,249)
 	color=rgb(0,255,249)
@@ -93,9 +193,29 @@ The regular pipe you see everywhere, including bent ones.
 /obj/machinery/atmospherics/pipe/simple/cyan/visible
 	level = PIPE_VISIBLE_LEVEL
 	layer = GAS_PIPE_VISIBLE_LAYER
+	
+/obj/machinery/atmospherics/pipe/simple/cyan/visible/layer1
+	piping_layer = 1
+	pixel_x = -5
+	pixel_y = -5
+
+/obj/machinery/atmospherics/pipe/simple/cyan/visible/layer3
+	piping_layer = 3
+	pixel_x = 5
+	pixel_y = 5
 
 /obj/machinery/atmospherics/pipe/simple/cyan/hidden
 	level = PIPE_HIDDEN_LEVEL
+	
+/obj/machinery/atmospherics/pipe/simple/cyan/hidden/layer1
+	piping_layer = 1
+	pixel_x = -5
+	pixel_y = -5
+
+/obj/machinery/atmospherics/pipe/simple/cyan/hidden/layer3
+	piping_layer = 3
+	pixel_x = 5
+	pixel_y = 5
 
 /obj/machinery/atmospherics/pipe/simple/green
 	pipe_color=rgb(30,255,0)
@@ -104,9 +224,29 @@ The regular pipe you see everywhere, including bent ones.
 /obj/machinery/atmospherics/pipe/simple/green/visible
 	level = PIPE_VISIBLE_LEVEL
 	layer = GAS_PIPE_VISIBLE_LAYER
+	
+/obj/machinery/atmospherics/pipe/simple/green/visible/layer1
+	piping_layer = 1
+	pixel_x = -5
+	pixel_y = -5
+
+/obj/machinery/atmospherics/pipe/simple/green/visible/layer3
+	piping_layer = 3
+	pixel_x = 5
+	pixel_y = 5
 
 /obj/machinery/atmospherics/pipe/simple/green/hidden
 	level = PIPE_HIDDEN_LEVEL
+	
+/obj/machinery/atmospherics/pipe/simple/green/hidden/layer1
+	piping_layer = 1
+	pixel_x = -5
+	pixel_y = -5
+
+/obj/machinery/atmospherics/pipe/simple/green/hidden/layer3
+	piping_layer = 3
+	pixel_x = 5
+	pixel_y = 5
 
 /obj/machinery/atmospherics/pipe/simple/orange
 	pipe_color=rgb(255,129,25)
@@ -115,9 +255,29 @@ The regular pipe you see everywhere, including bent ones.
 /obj/machinery/atmospherics/pipe/simple/orange/visible
 	level = PIPE_VISIBLE_LEVEL
 	layer = GAS_PIPE_VISIBLE_LAYER
+	
+/obj/machinery/atmospherics/pipe/simple/orange/visible/layer1
+	piping_layer = 1
+	pixel_x = -5
+	pixel_y = -5
+
+/obj/machinery/atmospherics/pipe/simple/orange/visible/layer3
+	piping_layer = 3
+	pixel_x = 5
+	pixel_y = 5
 
 /obj/machinery/atmospherics/pipe/simple/orange/hidden
 	level = PIPE_HIDDEN_LEVEL
+	
+/obj/machinery/atmospherics/pipe/simple/orange/hidden/layer1
+	piping_layer = 1
+	pixel_x = -5
+	pixel_y = -5
+
+/obj/machinery/atmospherics/pipe/simple/orange/hidden/layer3
+	piping_layer = 3
+	pixel_x = 5
+	pixel_y = 5
 
 /obj/machinery/atmospherics/pipe/simple/purple
 	pipe_color=rgb(128,0,182)
@@ -126,10 +286,30 @@ The regular pipe you see everywhere, including bent ones.
 /obj/machinery/atmospherics/pipe/simple/purple/visible
 	level = PIPE_VISIBLE_LEVEL
 	layer = GAS_PIPE_VISIBLE_LAYER
+	
+/obj/machinery/atmospherics/pipe/simple/purple/visible/layer1
+	piping_layer = 1
+	pixel_x = -5
+	pixel_y = -5
+
+/obj/machinery/atmospherics/pipe/simple/purple/visible/layer3
+	piping_layer = 3
+	pixel_x = 5
+	pixel_y = 5
 
 /obj/machinery/atmospherics/pipe/simple/purple/hidden
 	level = PIPE_HIDDEN_LEVEL
 
+/obj/machinery/atmospherics/pipe/simple/purple/hidden/layer1
+	piping_layer = 1
+	pixel_x = -5
+	pixel_y = -5
+
+/obj/machinery/atmospherics/pipe/simple/purple/hidden/layer3
+	piping_layer = 3
+	pixel_x = 5
+	pixel_y = 5
+	
 /obj/machinery/atmospherics/pipe/simple/dark
 	pipe_color=rgb(69,69,69)
 	color=rgb(69,69,69)
@@ -137,10 +317,30 @@ The regular pipe you see everywhere, including bent ones.
 /obj/machinery/atmospherics/pipe/simple/dark/visible
 	level = PIPE_VISIBLE_LEVEL
 	layer = GAS_PIPE_VISIBLE_LAYER
+	
+/obj/machinery/atmospherics/pipe/simple/dark/visible/layer1
+	piping_layer = 1
+	pixel_x = -5
+	pixel_y = -5
+
+/obj/machinery/atmospherics/pipe/simple/dark/visible/layer3
+	piping_layer = 3
+	pixel_x = 5
+	pixel_y = 5
 
 /obj/machinery/atmospherics/pipe/simple/dark/hidden
 	level = PIPE_HIDDEN_LEVEL
 
+/obj/machinery/atmospherics/pipe/simple/dark/hidden/layer1
+	piping_layer = 1
+	pixel_x = -5
+	pixel_y = -5
+
+/obj/machinery/atmospherics/pipe/simple/dark/hidden/layer3
+	piping_layer = 3
+	pixel_x = 5
+	pixel_y = 5
+	
 /obj/machinery/atmospherics/pipe/simple/violet
 	pipe_color=rgb(64,0,128)
 	color=rgb(64,0,128)
@@ -148,10 +348,30 @@ The regular pipe you see everywhere, including bent ones.
 /obj/machinery/atmospherics/pipe/simple/violet/visible
 	level = PIPE_VISIBLE_LEVEL
 	layer = GAS_PIPE_VISIBLE_LAYER
+	
+/obj/machinery/atmospherics/pipe/simple/violet/visible/layer1
+	piping_layer = 1
+	pixel_x = -5
+	pixel_y = -5
+
+/obj/machinery/atmospherics/pipe/simple/violet/visible/layer3
+	piping_layer = 3
+	pixel_x = 5
+	pixel_y = 5
 
 /obj/machinery/atmospherics/pipe/simple/violet/hidden
 	level = PIPE_HIDDEN_LEVEL
 
+/obj/machinery/atmospherics/pipe/simple/violet/hidden/layer1
+	piping_layer = 1
+	pixel_x = -5
+	pixel_y = -5
+
+/obj/machinery/atmospherics/pipe/simple/violet/hidden/layer3
+	piping_layer = 3
+	pixel_x = 5
+	pixel_y = 5
+	
 /obj/machinery/atmospherics/pipe/simple/brown
 	pipe_color=rgb(178,100,56)
 	color=rgb(178,100,56)
@@ -159,6 +379,26 @@ The regular pipe you see everywhere, including bent ones.
 /obj/machinery/atmospherics/pipe/simple/brown/visible
 	level = PIPE_VISIBLE_LEVEL
 	layer = GAS_PIPE_VISIBLE_LAYER
+	
+/obj/machinery/atmospherics/pipe/simple/brown/visible/layer1
+	piping_layer = 1
+	pixel_x = -5
+	pixel_y = -5
+
+/obj/machinery/atmospherics/pipe/simple/brown/visible/layer3
+	piping_layer = 3
+	pixel_x = 5
+	pixel_y = 5
 
 /obj/machinery/atmospherics/pipe/simple/brown/hidden
 	level = PIPE_HIDDEN_LEVEL
+
+/obj/machinery/atmospherics/pipe/simple/brown/hidden/layer1
+	piping_layer = 1
+	pixel_x = -5
+	pixel_y = -5
+
+/obj/machinery/atmospherics/pipe/simple/brown/hidden/layer3
+	piping_layer = 3
+	pixel_x = 5
+	pixel_y = 5

--- a/code/modules/atmospherics/machinery/pipes/simple.dm
+++ b/code/modules/atmospherics/machinery/pipes/simple.dm
@@ -37,27 +37,27 @@ The regular pipe you see everywhere, including bent ones.
 	layer = GAS_PIPE_VISIBLE_LAYER
 	
 /obj/machinery/atmospherics/pipe/simple/general/visible/layer1
-	piping_layer = 1
-	pixel_x = -5
-	pixel_y = -5
+	piping_layer = PIPING_LAYER_MIN
+	pixel_x = -PIPING_LAYER_P_X
+	pixel_y = -PIPING_LAYER_P_Y
 
 /obj/machinery/atmospherics/pipe/simple/general/visible/layer3
-	piping_layer = 3
-	pixel_x = 5
-	pixel_y = 5
+	piping_layer = PIPING_LAYER_MAX
+	pixel_x = PIPING_LAYER_P_X
+	pixel_y = PIPING_LAYER_P_Y
 
 /obj/machinery/atmospherics/pipe/simple/general/hidden
 	level = PIPE_HIDDEN_LEVEL
 
 /obj/machinery/atmospherics/pipe/simple/general/hidden/layer1
-	piping_layer = 1
-	pixel_x = -5
-	pixel_y = -5
+	piping_layer = PIPING_LAYER_MIN
+	pixel_x = -PIPING_LAYER_P_X
+	pixel_y = -PIPING_LAYER_P_Y
 
 /obj/machinery/atmospherics/pipe/simple/general/hidden/layer3
-	piping_layer = 3
-	pixel_x = 5
-	pixel_y = 5
+	piping_layer = PIPING_LAYER_MAX
+	pixel_x = PIPING_LAYER_P_X
+	pixel_y = PIPING_LAYER_P_Y
 	
 /obj/machinery/atmospherics/pipe/simple/scrubbers
 	name="scrubbers pipe"
@@ -69,27 +69,27 @@ The regular pipe you see everywhere, including bent ones.
 	layer = GAS_PIPE_VISIBLE_LAYER
 
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible/layer1
-	piping_layer = 1
-	pixel_x = -5
-	pixel_y = -5
+	piping_layer = PIPING_LAYER_MIN
+	pixel_x = -PIPING_LAYER_P_X
+	pixel_y = -PIPING_LAYER_P_Y
 
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible/layer3
-	piping_layer = 3
-	pixel_x = 5
-	pixel_y = 5
+	piping_layer = PIPING_LAYER_MAX
+	pixel_x = PIPING_LAYER_P_X
+	pixel_y = PIPING_LAYER_P_Y
 	
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden
 	level = PIPE_HIDDEN_LEVEL
 
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1
-	piping_layer = 1
-	pixel_x = -5
-	pixel_y = -5
+	piping_layer = PIPING_LAYER_MIN
+	pixel_x = -PIPING_LAYER_P_X
+	pixel_y = -PIPING_LAYER_P_Y
 
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3
-	piping_layer = 3
-	pixel_x = 5
-	pixel_y = 5
+	piping_layer = PIPING_LAYER_MAX
+	pixel_x = PIPING_LAYER_P_X
+	pixel_y = PIPING_LAYER_P_Y
 	
 /obj/machinery/atmospherics/pipe/simple/supply
 	name="air supply pipe"
@@ -101,27 +101,27 @@ The regular pipe you see everywhere, including bent ones.
 	layer = GAS_PIPE_VISIBLE_LAYER
 	
 /obj/machinery/atmospherics/pipe/simple/supply/visible/layer1
-	piping_layer = 1
-	pixel_x = -5
-	pixel_y = -5
+	piping_layer = PIPING_LAYER_MIN
+	pixel_x = -PIPING_LAYER_P_X
+	pixel_y = -PIPING_LAYER_P_Y
 
 /obj/machinery/atmospherics/pipe/simple/supply/visible/layer3
-	piping_layer = 3
-	pixel_x = 5
-	pixel_y = 5
+	piping_layer = PIPING_LAYER_MAX
+	pixel_x = PIPING_LAYER_P_X
+	pixel_y = PIPING_LAYER_P_Y
 
 /obj/machinery/atmospherics/pipe/simple/supply/hidden
 	level = PIPE_HIDDEN_LEVEL
 
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1
-	piping_layer = 1
-	pixel_x = -5
-	pixel_y = -5
+	piping_layer = PIPING_LAYER_MIN
+	pixel_x = -PIPING_LAYER_P_X
+	pixel_y = -PIPING_LAYER_P_Y
 
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3
-	piping_layer = 3
-	pixel_x = 5
-	pixel_y = 5
+	piping_layer = PIPING_LAYER_MAX
+	pixel_x = PIPING_LAYER_P_X
+	pixel_y = PIPING_LAYER_P_Y
 	
 /obj/machinery/atmospherics/pipe/simple/supplymain
 	name="main air supply pipe"
@@ -133,27 +133,27 @@ The regular pipe you see everywhere, including bent ones.
 	layer = GAS_PIPE_VISIBLE_LAYER
 
 /obj/machinery/atmospherics/pipe/simple/supplymain/visible/layer1
-	piping_layer = 1
-	pixel_x = -5
-	pixel_y = -5
+	piping_layer = PIPING_LAYER_MIN
+	pixel_x = -PIPING_LAYER_P_X
+	pixel_y = -PIPING_LAYER_P_Y
 
 /obj/machinery/atmospherics/pipe/simple/supplymain/visible/layer3
-	piping_layer = 3
-	pixel_x = 5
-	pixel_y = 5
+	piping_layer = PIPING_LAYER_MAX
+	pixel_x = PIPING_LAYER_P_X
+	pixel_y = PIPING_LAYER_P_Y
 	
 /obj/machinery/atmospherics/pipe/simple/supplymain/hidden
 	level = PIPE_HIDDEN_LEVEL
 
 /obj/machinery/atmospherics/pipe/simple/supplymain/hidden/layer1
-	piping_layer = 1
-	pixel_x = -5
-	pixel_y = -5
+	piping_layer = PIPING_LAYER_MIN
+	pixel_x = -PIPING_LAYER_P_X
+	pixel_y = -PIPING_LAYER_P_Y
 
 /obj/machinery/atmospherics/pipe/simple/supplymain/hidden/layer3
-	piping_layer = 3
-	pixel_x = 5
-	pixel_y = 5
+	piping_layer = PIPING_LAYER_MAX
+	pixel_x = PIPING_LAYER_P_X
+	pixel_y = PIPING_LAYER_P_Y
 	
 /obj/machinery/atmospherics/pipe/simple/yellow
 	pipe_color=rgb(255,198,0)
@@ -164,27 +164,27 @@ The regular pipe you see everywhere, including bent ones.
 	layer = GAS_PIPE_VISIBLE_LAYER
 
 /obj/machinery/atmospherics/pipe/simple/yellow/visible/layer1
-	piping_layer = 1
-	pixel_x = -5
-	pixel_y = -5
+	piping_layer = PIPING_LAYER_MIN
+	pixel_x = -PIPING_LAYER_P_X
+	pixel_y = -PIPING_LAYER_P_Y
 
 /obj/machinery/atmospherics/pipe/simple/yellow/visible/layer3
-	piping_layer = 3
-	pixel_x = 5
-	pixel_y = 5
+	piping_layer = PIPING_LAYER_MAX
+	pixel_x = PIPING_LAYER_P_X
+	pixel_y = PIPING_LAYER_P_Y
 	
 /obj/machinery/atmospherics/pipe/simple/yellow/hidden
 	level = PIPE_HIDDEN_LEVEL
 
 /obj/machinery/atmospherics/pipe/simple/yellow/hidden/layer1
-	piping_layer = 1
-	pixel_x = -5
-	pixel_y = -5
+	piping_layer = PIPING_LAYER_MIN
+	pixel_x = -PIPING_LAYER_P_X
+	pixel_y = -PIPING_LAYER_P_Y
 
 /obj/machinery/atmospherics/pipe/simple/yellow/hidden/layer3
-	piping_layer = 3
-	pixel_x = 5
-	pixel_y = 5
+	piping_layer = PIPING_LAYER_MAX
+	pixel_x = PIPING_LAYER_P_X
+	pixel_y = PIPING_LAYER_P_Y
 	
 /obj/machinery/atmospherics/pipe/simple/cyan
 	pipe_color=rgb(0,255,249)
@@ -195,27 +195,27 @@ The regular pipe you see everywhere, including bent ones.
 	layer = GAS_PIPE_VISIBLE_LAYER
 	
 /obj/machinery/atmospherics/pipe/simple/cyan/visible/layer1
-	piping_layer = 1
-	pixel_x = -5
-	pixel_y = -5
+	piping_layer = PIPING_LAYER_MIN
+	pixel_x = -PIPING_LAYER_P_X
+	pixel_y = -PIPING_LAYER_P_Y
 
 /obj/machinery/atmospherics/pipe/simple/cyan/visible/layer3
-	piping_layer = 3
-	pixel_x = 5
-	pixel_y = 5
+	piping_layer = PIPING_LAYER_MAX
+	pixel_x = PIPING_LAYER_P_X
+	pixel_y = PIPING_LAYER_P_Y
 
 /obj/machinery/atmospherics/pipe/simple/cyan/hidden
 	level = PIPE_HIDDEN_LEVEL
 	
 /obj/machinery/atmospherics/pipe/simple/cyan/hidden/layer1
-	piping_layer = 1
-	pixel_x = -5
-	pixel_y = -5
+	piping_layer = PIPING_LAYER_MIN
+	pixel_x = -PIPING_LAYER_P_X
+	pixel_y = -PIPING_LAYER_P_Y
 
 /obj/machinery/atmospherics/pipe/simple/cyan/hidden/layer3
-	piping_layer = 3
-	pixel_x = 5
-	pixel_y = 5
+	piping_layer = PIPING_LAYER_MAX
+	pixel_x = PIPING_LAYER_P_X
+	pixel_y = PIPING_LAYER_P_Y
 
 /obj/machinery/atmospherics/pipe/simple/green
 	pipe_color=rgb(30,255,0)
@@ -226,27 +226,27 @@ The regular pipe you see everywhere, including bent ones.
 	layer = GAS_PIPE_VISIBLE_LAYER
 	
 /obj/machinery/atmospherics/pipe/simple/green/visible/layer1
-	piping_layer = 1
-	pixel_x = -5
-	pixel_y = -5
+	piping_layer = PIPING_LAYER_MIN
+	pixel_x = -PIPING_LAYER_P_X
+	pixel_y = -PIPING_LAYER_P_Y
 
 /obj/machinery/atmospherics/pipe/simple/green/visible/layer3
-	piping_layer = 3
-	pixel_x = 5
-	pixel_y = 5
+	piping_layer = PIPING_LAYER_MAX
+	pixel_x = PIPING_LAYER_P_X
+	pixel_y = PIPING_LAYER_P_Y
 
 /obj/machinery/atmospherics/pipe/simple/green/hidden
 	level = PIPE_HIDDEN_LEVEL
 	
 /obj/machinery/atmospherics/pipe/simple/green/hidden/layer1
-	piping_layer = 1
-	pixel_x = -5
-	pixel_y = -5
+	piping_layer = PIPING_LAYER_MIN
+	pixel_x = -PIPING_LAYER_P_X
+	pixel_y = -PIPING_LAYER_P_Y
 
 /obj/machinery/atmospherics/pipe/simple/green/hidden/layer3
-	piping_layer = 3
-	pixel_x = 5
-	pixel_y = 5
+	piping_layer = PIPING_LAYER_MAX
+	pixel_x = PIPING_LAYER_P_X
+	pixel_y = PIPING_LAYER_P_Y
 
 /obj/machinery/atmospherics/pipe/simple/orange
 	pipe_color=rgb(255,129,25)
@@ -257,27 +257,27 @@ The regular pipe you see everywhere, including bent ones.
 	layer = GAS_PIPE_VISIBLE_LAYER
 	
 /obj/machinery/atmospherics/pipe/simple/orange/visible/layer1
-	piping_layer = 1
-	pixel_x = -5
-	pixel_y = -5
+	piping_layer = PIPING_LAYER_MIN
+	pixel_x = -PIPING_LAYER_P_X
+	pixel_y = -PIPING_LAYER_P_Y
 
 /obj/machinery/atmospherics/pipe/simple/orange/visible/layer3
-	piping_layer = 3
-	pixel_x = 5
-	pixel_y = 5
+	piping_layer = PIPING_LAYER_MAX
+	pixel_x = PIPING_LAYER_P_X
+	pixel_y = PIPING_LAYER_P_Y
 
 /obj/machinery/atmospherics/pipe/simple/orange/hidden
 	level = PIPE_HIDDEN_LEVEL
 	
 /obj/machinery/atmospherics/pipe/simple/orange/hidden/layer1
-	piping_layer = 1
-	pixel_x = -5
-	pixel_y = -5
+	piping_layer = PIPING_LAYER_MIN
+	pixel_x = -PIPING_LAYER_P_X
+	pixel_y = -PIPING_LAYER_P_Y
 
 /obj/machinery/atmospherics/pipe/simple/orange/hidden/layer3
-	piping_layer = 3
-	pixel_x = 5
-	pixel_y = 5
+	piping_layer = PIPING_LAYER_MAX
+	pixel_x = PIPING_LAYER_P_X
+	pixel_y = PIPING_LAYER_P_Y
 
 /obj/machinery/atmospherics/pipe/simple/purple
 	pipe_color=rgb(128,0,182)
@@ -288,27 +288,27 @@ The regular pipe you see everywhere, including bent ones.
 	layer = GAS_PIPE_VISIBLE_LAYER
 	
 /obj/machinery/atmospherics/pipe/simple/purple/visible/layer1
-	piping_layer = 1
-	pixel_x = -5
-	pixel_y = -5
+	piping_layer = PIPING_LAYER_MIN
+	pixel_x = -PIPING_LAYER_P_X
+	pixel_y = -PIPING_LAYER_P_Y
 
 /obj/machinery/atmospherics/pipe/simple/purple/visible/layer3
-	piping_layer = 3
-	pixel_x = 5
-	pixel_y = 5
+	piping_layer = PIPING_LAYER_MAX
+	pixel_x = PIPING_LAYER_P_X
+	pixel_y = PIPING_LAYER_P_Y
 
 /obj/machinery/atmospherics/pipe/simple/purple/hidden
 	level = PIPE_HIDDEN_LEVEL
 
 /obj/machinery/atmospherics/pipe/simple/purple/hidden/layer1
-	piping_layer = 1
-	pixel_x = -5
-	pixel_y = -5
+	piping_layer = PIPING_LAYER_MIN
+	pixel_x = -PIPING_LAYER_P_X
+	pixel_y = -PIPING_LAYER_P_Y
 
 /obj/machinery/atmospherics/pipe/simple/purple/hidden/layer3
-	piping_layer = 3
-	pixel_x = 5
-	pixel_y = 5
+	piping_layer = PIPING_LAYER_MAX
+	pixel_x = PIPING_LAYER_P_X
+	pixel_y = PIPING_LAYER_P_Y
 	
 /obj/machinery/atmospherics/pipe/simple/dark
 	pipe_color=rgb(69,69,69)
@@ -319,27 +319,27 @@ The regular pipe you see everywhere, including bent ones.
 	layer = GAS_PIPE_VISIBLE_LAYER
 	
 /obj/machinery/atmospherics/pipe/simple/dark/visible/layer1
-	piping_layer = 1
-	pixel_x = -5
-	pixel_y = -5
+	piping_layer = PIPING_LAYER_MIN
+	pixel_x = -PIPING_LAYER_P_X
+	pixel_y = -PIPING_LAYER_P_Y
 
 /obj/machinery/atmospherics/pipe/simple/dark/visible/layer3
-	piping_layer = 3
-	pixel_x = 5
-	pixel_y = 5
+	piping_layer = PIPING_LAYER_MAX
+	pixel_x = PIPING_LAYER_P_X
+	pixel_y = PIPING_LAYER_P_Y
 
 /obj/machinery/atmospherics/pipe/simple/dark/hidden
 	level = PIPE_HIDDEN_LEVEL
 
 /obj/machinery/atmospherics/pipe/simple/dark/hidden/layer1
-	piping_layer = 1
-	pixel_x = -5
-	pixel_y = -5
+	piping_layer = PIPING_LAYER_MIN
+	pixel_x = -PIPING_LAYER_P_X
+	pixel_y = -PIPING_LAYER_P_Y
 
 /obj/machinery/atmospherics/pipe/simple/dark/hidden/layer3
-	piping_layer = 3
-	pixel_x = 5
-	pixel_y = 5
+	piping_layer = PIPING_LAYER_MAX
+	pixel_x = PIPING_LAYER_P_X
+	pixel_y = PIPING_LAYER_P_Y
 	
 /obj/machinery/atmospherics/pipe/simple/violet
 	pipe_color=rgb(64,0,128)
@@ -350,27 +350,27 @@ The regular pipe you see everywhere, including bent ones.
 	layer = GAS_PIPE_VISIBLE_LAYER
 	
 /obj/machinery/atmospherics/pipe/simple/violet/visible/layer1
-	piping_layer = 1
-	pixel_x = -5
-	pixel_y = -5
+	piping_layer = PIPING_LAYER_MIN
+	pixel_x = -PIPING_LAYER_P_X
+	pixel_y = -PIPING_LAYER_P_Y
 
 /obj/machinery/atmospherics/pipe/simple/violet/visible/layer3
-	piping_layer = 3
-	pixel_x = 5
-	pixel_y = 5
+	piping_layer = PIPING_LAYER_MAX
+	pixel_x = PIPING_LAYER_P_X
+	pixel_y = PIPING_LAYER_P_Y
 
 /obj/machinery/atmospherics/pipe/simple/violet/hidden
 	level = PIPE_HIDDEN_LEVEL
 
 /obj/machinery/atmospherics/pipe/simple/violet/hidden/layer1
-	piping_layer = 1
-	pixel_x = -5
-	pixel_y = -5
+	piping_layer = PIPING_LAYER_MIN
+	pixel_x = -PIPING_LAYER_P_X
+	pixel_y = -PIPING_LAYER_P_Y
 
 /obj/machinery/atmospherics/pipe/simple/violet/hidden/layer3
-	piping_layer = 3
-	pixel_x = 5
-	pixel_y = 5
+	piping_layer = PIPING_LAYER_MAX
+	pixel_x = PIPING_LAYER_P_X
+	pixel_y = PIPING_LAYER_P_Y
 	
 /obj/machinery/atmospherics/pipe/simple/brown
 	pipe_color=rgb(178,100,56)
@@ -381,24 +381,24 @@ The regular pipe you see everywhere, including bent ones.
 	layer = GAS_PIPE_VISIBLE_LAYER
 	
 /obj/machinery/atmospherics/pipe/simple/brown/visible/layer1
-	piping_layer = 1
-	pixel_x = -5
-	pixel_y = -5
+	piping_layer = PIPING_LAYER_MIN
+	pixel_x = -PIPING_LAYER_P_X
+	pixel_y = -PIPING_LAYER_P_Y
 
 /obj/machinery/atmospherics/pipe/simple/brown/visible/layer3
-	piping_layer = 3
-	pixel_x = 5
-	pixel_y = 5
+	piping_layer = PIPING_LAYER_MAX
+	pixel_x = PIPING_LAYER_P_X
+	pixel_y = PIPING_LAYER_P_Y
 
 /obj/machinery/atmospherics/pipe/simple/brown/hidden
 	level = PIPE_HIDDEN_LEVEL
 
 /obj/machinery/atmospherics/pipe/simple/brown/hidden/layer1
-	piping_layer = 1
-	pixel_x = -5
-	pixel_y = -5
+	piping_layer = PIPING_LAYER_MIN
+	pixel_x = -PIPING_LAYER_P_X
+	pixel_y = -PIPING_LAYER_P_Y
 
 /obj/machinery/atmospherics/pipe/simple/brown/hidden/layer3
-	piping_layer = 3
-	pixel_x = 5
-	pixel_y = 5
+	piping_layer = PIPING_LAYER_MAX
+	pixel_x = PIPING_LAYER_P_X
+	pixel_y = PIPING_LAYER_P_Y


### PR DESCRIPTION
:cl: Denton
code: Added multilayer subtypes for mapping.
/:cl:

[why]: It's a pain in the dong to map multilayer piping. This PR takes the var editing work out of it and should make it easy to do multilayer atmos setups.