### PR TITLE
Makes it possible to see tiles past z transitions

### DIFF
--- a/code/datums/components/mirage_border.dm
+++ b/code/datums/components/mirage_border.dm
@@ -3,8 +3,7 @@
 
 /datum/component/mirage_border/Initialize(turf/target, direction, range=world.view)
 	if(!isturf(parent))
-		. = COMPONENT_INCOMPATIBLE
-		CRASH("[type] added to a [parent.type]")
+		return COMPONENT_INCOMPATIBLE
 	if(!target || !istype(target) || !direction)
 		. = COMPONENT_INCOMPATIBLE
 		CRASH("[type] improperly instanced with the following args: target=\[[target]\], direction=\[[direction]\], range=\[[range]\]")
@@ -30,8 +29,7 @@
 
 /datum/component/mirage_border/OnTransfer(atom/thing)
 	if(!isturf(thing))
-		stack_trace("[type] added to a [parent.type]")
-		qdel(src)
+		return COMPONENT_INCOMPATIBLE
 	holder.forceMove(thing)
 
 /obj/effect/abstract/mirage_holder

--- a/code/datums/components/mirage_border.dm
+++ b/code/datums/components/mirage_border.dm
@@ -1,0 +1,39 @@
+/datum/component/mirage_border
+	var/obj/effect/abstract/mirage_holder/holder
+
+/datum/component/mirage_border/Initialize(turf/target, direction, range=world.view)
+	if(!isturf(parent))
+		. = COMPONENT_INCOMPATIBLE
+		CRASH("[type] added to a [parent.type]")
+	if(!target || !istype(target) || !direction)
+		. = COMPONENT_INCOMPATIBLE
+		CRASH("[type] improperly instanced with the following args: target=\[[target]\], direction=\[[direction]\], range=\[[range]\]")
+	
+	holder = new(parent)
+
+	var/x = target.x
+	var/y = target.y
+	var/z = target.z
+	var/turf/southwest = locate(CLAMP(x - (direction & WEST ? range : 0), 1, world.maxx), CLAMP(y - (direction & SOUTH ? range : 0), 1, world.maxy), CLAMP(z, 1, world.maxz))
+	var/turf/northeast = locate(CLAMP(x + (direction & EAST ? range : 0), 1, world.maxx), CLAMP(y + (direction & NORTH ? range : 0), 1, world.maxy), CLAMP(z, 1, world.maxz))
+	//holder.vis_contents += block(southwest, northeast) // This doesnt work because of beta bug memes
+	for(var/i in block(southwest, northeast))
+		holder.vis_contents += i
+	if(direction & SOUTH)
+		holder.pixel_y -= world.icon_size * range
+	if(direction & WEST)
+		holder.pixel_x -= world.icon_size * range
+
+/datum/component/mirage_border/Destroy()
+	QDEL_NULL(holder)
+	return ..()
+
+/datum/component/mirage_border/OnTransfer(atom/thing)
+	if(!isturf(thing))
+		stack_trace("[type] added to a [parent.type]")
+		qdel(src)
+	holder.forceMove(thing)
+
+/obj/effect/abstract/mirage_holder
+	name = "Mirage holder"
+	mouse_opacity = MOUSE_OPACITY_TRANSPARENT

--- a/code/modules/mapping/space_management/space_transition.dm
+++ b/code/modules/mapping/space_management/space_transition.dm
@@ -125,3 +125,19 @@
 				S.destination_x = x_pos_transition[side] == 1 ? S.x : x_pos_transition[side]
 				S.destination_y = y_pos_transition[side] == 1 ? S.y : y_pos_transition[side]
 				S.destination_z = zdestination
+				
+				// Mirage border code
+				var/mirage_dir
+				if(S.x == 1 + TRANSITIONEDGE)
+					mirage_dir |= WEST
+				else if(S.x == world.maxx - TRANSITIONEDGE)
+					mirage_dir |= EAST
+				if(S.y == 1 + TRANSITIONEDGE)
+					mirage_dir |= SOUTH
+				else if(S.y == world.maxy - TRANSITIONEDGE)
+					mirage_dir |= NORTH
+				if(!mirage_dir)
+					continue
+
+				var/turf/place = locate(S.destination_x, S.destination_y, S.destination_z)
+				S.AddComponent(/datum/component/mirage_border, place, mirage_dir)

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -321,6 +321,7 @@
 #include "code\datums\components\knockoff.dm"
 #include "code\datums\components\lockon_aiming.dm"
 #include "code\datums\components\material_container.dm"
+#include "code\datums\components\mirage_border.dm"
 #include "code\datums\components\mood.dm"
 #include "code\datums\components\ntnet_interface.dm"
 #include "code\datums\components\paintable.dm"


### PR DESCRIPTION
:cl: ninjanomnom
add: You can now see objects and turfs past the map edge borders.
/:cl:

https://puu.sh/A6EQa/057293c3f3.mp4

It's a little bit rough with the animation there since we need to snowflake the movement glide for the map edge but we can use this to allow for some interesting things. This pr is just to get the visual in.
