### PR TITLE
Blacklists some stacktypes from stabilized metal

### DIFF
--- a/code/modules/research/xenobiology/crossbreeding/_status_effects.dm
+++ b/code/modules/research/xenobiology/crossbreeding/_status_effects.dm
@@ -348,9 +348,7 @@ datum/status_effect/stabilized/blue/on_remove()
 	colour = "metal"
 	var/cooldown = 30
 	var/max_cooldown = 30
-	var/list/blacklisted_stacks = list(
-		/obj/item/stack/telecrystal, /obj/item/stack/sheet/runed_metal, /obj/item/stack/tile/brass
-	)
+	var/list/blacklisted_stacks = list(/obj/item/stack/sheet/runed_metal)
 
 /datum/status_effect/stabilized/metal/New()
 	blacklisted_stacks = typecacheof(blacklisted_stacks)

--- a/code/modules/research/xenobiology/crossbreeding/_status_effects.dm
+++ b/code/modules/research/xenobiology/crossbreeding/_status_effects.dm
@@ -348,6 +348,13 @@ datum/status_effect/stabilized/blue/on_remove()
 	colour = "metal"
 	var/cooldown = 30
 	var/max_cooldown = 30
+	var/list/blacklisted_stacks = list(
+		/obj/item/stack/telecrystal, /obj/item/stack/sheet/runed_metal, /obj/item/stack/tile/brass
+	)
+
+/datum/status_effect/stabilized/metal/New()
+	blacklisted_stacks = typecacheof(blacklisted_stacks)
+	return ..()
 
 /datum/status_effect/stabilized/metal/tick()
 	if(cooldown > 0)
@@ -356,7 +363,7 @@ datum/status_effect/stabilized/blue/on_remove()
 		cooldown = max_cooldown
 		var/list/sheets = list()
 		for(var/obj/item/stack/sheet/S in owner.GetAllContents())
-			if(S.amount < S.max_amount)
+			if(S.amount < S.max_amount && !is_type_in_typecache(S, blacklisted_stacks))
 				sheets += S
 
 		if(sheets.len > 0)

--- a/code/modules/research/xenobiology/crossbreeding/_status_effects.dm
+++ b/code/modules/research/xenobiology/crossbreeding/_status_effects.dm
@@ -348,11 +348,6 @@ datum/status_effect/stabilized/blue/on_remove()
 	colour = "metal"
 	var/cooldown = 30
 	var/max_cooldown = 30
-	var/list/blacklisted_stacks = list(/obj/item/stack/sheet/runed_metal)
-
-/datum/status_effect/stabilized/metal/New()
-	blacklisted_stacks = typecacheof(blacklisted_stacks)
-	return ..()
 
 /datum/status_effect/stabilized/metal/tick()
 	if(cooldown > 0)
@@ -361,7 +356,7 @@ datum/status_effect/stabilized/blue/on_remove()
 		cooldown = max_cooldown
 		var/list/sheets = list()
 		for(var/obj/item/stack/sheet/S in owner.GetAllContents())
-			if(S.amount < S.max_amount && !is_type_in_typecache(S, blacklisted_stacks))
+			if(S.amount < S.max_amount && !istype(S, /obj/item/stack/sheet/runed_metal))
 				sheets += S
 
 		if(sheets.len > 0)


### PR DESCRIPTION
[Changelogs]: 

:cl: Dax Dupont
balance: Stabilized metal can no longer add to stacks of runed metal.
/:cl:

[why]: Passively farming cult shit is _probably_ a bad idea.
