### PR TITLE
Makes solar assemblies craftable

### DIFF
--- a/code/game/objects/items/stacks/sheets/sheet_types.dm
+++ b/code/game/objects/items/stacks/sheets/sheet_types.dm
@@ -41,6 +41,8 @@ GLOBAL_LIST_INIT(metal_recipes, list ( \
 	new/datum/stack_recipe("floor tile", /obj/item/stack/tile/plasteel, 1, 4, 20), \
 	new/datum/stack_recipe("metal rod", /obj/item/stack/rods, 1, 2, 60), \
 	null, \
+	new/datum/stack_recipe("solar assembly", /obj/item/solar_assembly, 2), \
+	null, \
 	new/datum/stack_recipe("wall girders", /obj/structure/girder, 2, time = 40, one_per_turf = TRUE, on_floor = TRUE), \
 	null, \
 	new/datum/stack_recipe("computer frame", /obj/structure/frame/computer, 5, time = 25, one_per_turf = TRUE, on_floor = TRUE), \


### PR DESCRIPTION
:cl: Denton
add: Solar panel assemblies are now craftable from two metal sheets each.
/:cl:

Does exactly what it says on the tin. This is for the few engineers that actually build things, ghost roles, etc.