### PR TITLE
Removes the ability for inducers and circuits to charge energy weapons.

### DIFF
--- a/code/game/objects/items/inducer.dm
+++ b/code/game/objects/items/inducer.dm
@@ -105,7 +105,7 @@
 	var/obj/O
 	var/coefficient = 1
 	if(istype(A, /obj/item/gun/energy))
-		to_chat(user,"Error unable to interface with device"
+		to_chat(user,"Error unable to interface with device")
 		return FALSE
 	if(istype(A, /obj))
 		O = A

--- a/code/game/objects/items/inducer.dm
+++ b/code/game/objects/items/inducer.dm
@@ -102,12 +102,11 @@
 	else
 		recharging = TRUE
 	var/obj/item/stock_parts/cell/C = A.get_cell()
-	var/obj/item/gun/energy/E
 	var/obj/O
 	var/coefficient = 1
 	if(istype(A, /obj/item/gun/energy))
-		coefficient = 0.075 // 14 loops to recharge an egun from 0-1000
-		E = A
+		to_chat(user,"Error unable to interface with device"
+		return FALSE
 	if(istype(A, /obj))
 		O = A
 	if(C)
@@ -118,8 +117,6 @@
 			return TRUE
 		user.visible_message("[user] starts recharging [A] with [src].","<span class='notice'>You start recharging [A] with [src].</span>")
 		while(C.charge < C.maxcharge)
-			if(E)
-				E.semicd = TRUE  // Prevents someone from firing continuously while recharging the gun.
 			if(do_after(user, 10, target = user) && cell.charge)
 				done_any = TRUE
 				induce(C, coefficient)
@@ -128,8 +125,6 @@
 					O.update_icon()
 			else
 				break
-		if(E)
-			E.reset_semicd() //We're done charging, so we'll let someone fire it now.
 		if(done_any) // Only show a message if we succeeded at least once
 			user.visible_message("[user] recharged [A]!","<span class='notice'>You recharged [A]!</span>")
 		recharging = FALSE

--- a/code/modules/integrated_electronics/subtypes/power.dm
+++ b/code/modules/integrated_electronics/subtypes/power.dm
@@ -40,7 +40,7 @@
 	var/atom/movable/AM = get_pin_data_as_type(IC_INPUT, 1, /atom/movable)
 	if(!AM)
 		return FALSE
-	if(istype(AM, /obj/item/gun/energy)
+	if(istype(AM, /obj/item/gun/energy))
 		return FALSE
 	if(!assembly)
 		return FALSE // Pointless to do everything else if there's no battery to draw from.

--- a/code/modules/integrated_electronics/subtypes/power.dm
+++ b/code/modules/integrated_electronics/subtypes/power.dm
@@ -40,6 +40,8 @@
 	var/atom/movable/AM = get_pin_data_as_type(IC_INPUT, 1, /atom/movable)
 	if(!AM)
 		return FALSE
+	if(istype(AM, /obj/item/gun/energy)
+		return FALSE
 	if(!assembly)
 		return FALSE // Pointless to do everything else if there's no battery to draw from.
 	var/obj/item/stock_parts/cell/cell = AM.get_cell()


### PR DESCRIPTION
Fixes a power creep that occurred with two objects that weren't known to @KorPhaeron at the time they were merged and now needs reverting.

Fixes #37109 

:cl: Spoilsport
del: Inducers and integrated circuits can no longer charge energised weapons.
/:cl:
