### PR TITLE
Improves fuel tank explosion logging

### DIFF
--- a/code/modules/reagents/reagent_dispenser.dm
+++ b/code/modules/reagents/reagent_dispenser.dm
@@ -101,12 +101,15 @@
 			playsound(src, 'sound/effects/refill.ogg', 50, 1)
 			W.update_icon()
 		else
+			var/turf/T = get_turf(src)
+			var/area/A = get_area(T)
 			user.visible_message("<span class='warning'>[user] catastrophically fails at refilling [user.p_their()] [W.name]!</span>", "<span class='userdanger'>That was stupid of you.</span>")
-			var/message_admins = "[key_name_admin(user)] triggered a fueltank explosion via welding tool."
+			var/message_admins = "[key_name_admin(user)] triggered a fueltank explosion via welding tool at [A] [ADMIN_COORDJMP(T)]."
 			GLOB.bombers += message_admins
 			message_admins(message_admins)
-			var/message_log = "triggered a fueltank explosion via welding tool."
+			var/message_log = "triggered a fueltank explosion via welding tool at [A] [COORD(T)]."
 			user.log_message(message_log, INDIVIDUAL_ATTACK_LOG)
+			log_game("[key_name(user)] [message_log]")
 			log_attack("[key_name(user)] [message_log]")
 			boom()
 		return


### PR DESCRIPTION
[Changelogs]:
:cl: Dax Dupont
admin: Fuel tank logging now logs to both game and attack logs so it's more clear from logs what caused the explosion in game log and added coords to the messages as well.
/:cl:

[why]: Explosions get logged to game but not attack, while attacking a fuel tank belongs in attack, I'd argue it should also log to game log so you can contextualize the explosion easier.
