### PR TITLE
Fixes duplicate logic causing doors to be perma stuck on shock mode.

### DIFF
--- a/code/datums/wires/airlock.dm
+++ b/code/datums/wires/airlock.dm
@@ -81,13 +81,6 @@
 				if(usr)
 					A.shockedby += text("\[[time_stamp()]\][usr](ckey:[usr.ckey])")
 				add_logs(usr, A, "electrified")
-				sleep(10)
-				if(A)
-					while (A.secondsElectrified > 0)
-						A.secondsElectrified -= 1
-						if(A.secondsElectrified < 0)
-							A.set_electrified(0)
-						sleep(10)
 		if(WIRE_SAFETY)
 			A.safe = !A.safe
 			if(!A.density)


### PR DESCRIPTION
:cl: Dax Dupont
fix: Doors don't turn into Mike Pence when the shock wire is pulsed, only why it's cut.
/:cl:

[why]: Fixes #37374 
The airlock maincode already handled the timing.
