### PR TITLE
Refactors and fixes RPEDs

### DIFF
--- a/code/datums/components/storage/concrete/rped.dm
+++ b/code/datums/components/storage/concrete/rped.dm
@@ -10,8 +10,9 @@
 
 /datum/component/storage/concrete/rped/can_be_inserted(obj/item/I, stop_messages, mob/M)
 	. = ..()
-	if(!I.get_part_rating() && !stop_messages)
-		to_chat(M, "<span class='warning'>[parent] only accepts machine parts!</span>")
+	if(!I.get_part_rating())
+		if (!stop_messages)
+			to_chat(M, "<span class='warning'>[parent] only accepts machine parts!</span>")
 		return FALSE
 
 /datum/component/storage/concrete/bluespace/rped
@@ -26,6 +27,7 @@
 
 /datum/component/storage/concrete/bluespace/rped/can_be_inserted(obj/item/I, stop_messages, mob/M)
 	. = ..()
-	if(!I.get_part_rating() && !stop_messages)
-		to_chat(M, "<span class='warning'>[parent] only accepts machine parts!</span>")
+	if(!I.get_part_rating())
+		if (!stop_messages)
+			to_chat(M, "<span class='warning'>[parent] only accepts machine par	ts!</span>")
 		return FALSE

--- a/code/game/machinery/Sleeper.dm
+++ b/code/game/machinery/Sleeper.dm
@@ -93,8 +93,6 @@
 			return
 	if(default_change_direction_wrench(user, I))
 		return
-	if(exchange_parts(user, I))
-		return
 	if(default_pry_open(I))
 		return
 	if(default_deconstruction_crowbar(I))

--- a/code/game/machinery/autolathe.dm
+++ b/code/game/machinery/autolathe.dm
@@ -93,9 +93,6 @@
 		updateUsrDialog()
 		return TRUE
 
-	if(exchange_parts(user, O))
-		return TRUE
-
 	if(default_deconstruction_crowbar(O))
 		return TRUE
 

--- a/code/game/machinery/cloning.dm
+++ b/code/game/machinery/cloning.dm
@@ -279,9 +279,6 @@
 		if(default_deconstruction_screwdriver(user, "[icon_state]_maintenance", "[initial(icon_state)]",W))
 			return
 
-	if(exchange_parts(user, W))
-		return
-
 	if(default_deconstruction_crowbar(W))
 		return
 

--- a/code/game/machinery/dna_scanner.dm
+++ b/code/game/machinery/dna_scanner.dm
@@ -133,9 +133,6 @@
 		update_icon()//..since we're updating the icon here, since the scanner can be unpowered when opened/closed
 		return
 
-	if(exchange_parts(user, I))
-		return
-
 	if(default_pry_open(I))
 		return
 

--- a/code/game/machinery/hologram.dm
+++ b/code/game/machinery/hologram.dm
@@ -146,9 +146,6 @@ Possible to do for anyone motivated enough:
 	if(default_deconstruction_screwdriver(user, "holopad_open", "holopad0", P))
 		return
 
-	if(exchange_parts(user, P))
-		return
-
 	if(default_pry_open(P))
 		return
 

--- a/code/game/machinery/launch_pad.dm
+++ b/code/game/machinery/launch_pad.dm
@@ -37,9 +37,6 @@
 				to_chat(user, "<span class='notice'>You save the data in the [I.name]'s buffer.</span>")
 				return 1
 
-		if(exchange_parts(user, I))
-			return
-
 		if(default_deconstruction_crowbar(I))
 			return
 

--- a/code/game/machinery/limbgrower.dm
+++ b/code/game/machinery/limbgrower.dm
@@ -70,9 +70,6 @@
 		updateUsrDialog()
 		return
 
-	if(exchange_parts(user, O))
-		return
-
 	if(panel_open && default_deconstruction_crowbar(O))
 		return
 

--- a/code/game/machinery/quantum_pad.dm
+++ b/code/game/machinery/quantum_pad.dm
@@ -60,9 +60,6 @@
 			to_chat(user, "<span class='notice'>You link [src] to the one in [I]'s buffer.</span>")
 			return 1
 
-	if(exchange_parts(user, I))
-		return
-
 	if(default_deconstruction_crowbar(I))
 		return
 

--- a/code/game/machinery/recharger.dm
+++ b/code/game/machinery/recharger.dm
@@ -68,8 +68,6 @@
 			default_deconstruction_crowbar(G)
 			return
 
-		if(exchange_parts(user, G))
-			return
 	return ..()
 
 /obj/machinery/recharger/attack_hand(mob/user)

--- a/code/game/machinery/rechargestation.dm
+++ b/code/game/machinery/rechargestation.dm
@@ -53,9 +53,6 @@
 		if(default_deconstruction_screwdriver(user, "borgdecon2", "borgcharger0", P))
 			return
 
-	if(exchange_parts(user, P))
-		return
-
 	if(default_pry_open(P))
 		return
 

--- a/code/game/machinery/recycler.dm
+++ b/code/game/machinery/recycler.dm
@@ -55,9 +55,6 @@
 	if(default_deconstruction_screwdriver(user, "grinder-oOpen", "grinder-o0", I))
 		return
 
-	if(exchange_parts(user, I))
-		return
-
 	if(default_pry_open(I))
 		return
 

--- a/code/game/machinery/spaceheater.dm
+++ b/code/game/machinery/spaceheater.dm
@@ -156,7 +156,7 @@
 		update_icon()
 		if(panel_open)
 			interact(user)
-	else if(exchange_parts(user, I) || default_deconstruction_crowbar(I))
+	else if(default_deconstruction_crowbar(I))
 		return
 	else
 		return ..()

--- a/code/game/machinery/telecomms/machine_interactions.dm
+++ b/code/game/machinery/telecomms/machine_interactions.dm
@@ -18,10 +18,6 @@
 
 	if(default_deconstruction_screwdriver(user, icon_open, icon_closed, P))
 		return
-
-	else if(exchange_parts(user, P))
-		return
-
 	// Using a multitool lets you access the receiver's interface
 	else if(istype(P, /obj/item/device/multitool))
 		attack_hand(user)

--- a/code/game/machinery/teleporter.dm
+++ b/code/game/machinery/teleporter.dm
@@ -55,8 +55,6 @@
 			power_station.engaged = 0 //hub with panel open is off, so the station must be informed.
 			update_icon()
 		return
-	if(exchange_parts(user, W))
-		return
 	if(default_deconstruction_crowbar(W))
 		return
 	return ..()
@@ -167,9 +165,6 @@
 		return
 	else if(default_deconstruction_screwdriver(user, "controller-o", "controller", W))
 		update_icon()
-		return
-
-	else if(exchange_parts(user, W))
 		return
 
 	else if(default_deconstruction_crowbar(W))

--- a/code/game/mecha/mech_bay.dm
+++ b/code/game/mecha/mech_bay.dm
@@ -62,9 +62,6 @@
 		recharging_turf = get_step(loc, dir)
 		return
 
-	if(exchange_parts(user, I))
-		return
-
 	if(default_deconstruction_crowbar(I))
 		return
 	return ..()

--- a/code/game/mecha/mech_fabricator.dm
+++ b/code/game/mecha/mech_fabricator.dm
@@ -401,9 +401,6 @@
 	if(default_deconstruction_screwdriver(user, "fab-o", "fab-idle", W))
 		return TRUE
 
-	if(exchange_parts(user, W))
-		return TRUE
-
 	if(default_deconstruction_crowbar(W))
 		return TRUE
 

--- a/code/modules/atmospherics/machinery/components/unary_devices/cryo.dm
+++ b/code/modules/atmospherics/machinery/components/unary_devices/cryo.dm
@@ -298,7 +298,7 @@
 		var/reagentlist = pretty_string_from_reagent_list(I.reagents.reagent_list)
 		log_game("[key_name(user)] added an [I] to cyro containing [reagentlist]")
 		return
-	if(!on && !occupant && !state_open && (default_deconstruction_screwdriver(user, "pod-off", "pod-off", I) || exchange_parts(user, I)) \
+	if(!on && !occupant && !state_open && (default_deconstruction_screwdriver(user, "pod-off", "pod-off", I)) \
 		|| default_change_direction_wrench(user, I) \
 		|| default_pry_open(I) \
 		|| default_deconstruction_crowbar(I))

--- a/code/modules/atmospherics/machinery/components/unary_devices/thermomachine.dm
+++ b/code/modules/atmospherics/machinery/components/unary_devices/thermomachine.dm
@@ -80,8 +80,6 @@
 		return
 	if(default_deconstruction_crowbar(I))
 		return
-	if(exchange_parts(user, I))
-		return
 	return ..()
 
 /obj/machinery/atmospherics/components/unary/thermomachine/default_change_direction_wrench(mob/user, obj/item/I)

--- a/code/modules/food_and_drinks/kitchen_machinery/deep_fryer.dm
+++ b/code/modules/food_and_drinks/kitchen_machinery/deep_fryer.dm
@@ -89,8 +89,6 @@ God bless America.
 		return
 	if(default_unfasten_wrench(user, I))
 		return
-	else if(exchange_parts(user, I))
-		return
 	else if(default_deconstruction_screwdriver(user, "fryer_off", "fryer_off" ,I))	//where's the open maint panel icon?!
 		return
 	else

--- a/code/modules/food_and_drinks/kitchen_machinery/gibber.dm
+++ b/code/modules/food_and_drinks/kitchen_machinery/gibber.dm
@@ -99,10 +99,7 @@
 /obj/machinery/gibber/attackby(obj/item/P, mob/user, params)
 	if(default_deconstruction_screwdriver(user, "grinder_open", "grinder", P))
 		return
-
-	else if(exchange_parts(user, P))
-		return
-
+		
 	else if(default_pry_open(P))
 		return
 

--- a/code/modules/food_and_drinks/kitchen_machinery/microwave.dm
+++ b/code/modules/food_and_drinks/kitchen_machinery/microwave.dm
@@ -50,8 +50,6 @@
 			return
 		if(default_unfasten_wrench(user, O))
 			return
-		if(exchange_parts(user, O))
-			return
 
 	if(default_deconstruction_crowbar(O))
 		return

--- a/code/modules/food_and_drinks/kitchen_machinery/monkeyrecycler.dm
+++ b/code/modules/food_and_drinks/kitchen_machinery/monkeyrecycler.dm
@@ -29,9 +29,6 @@
 	if(default_deconstruction_screwdriver(user, "grinder_open", "grinder", O))
 		return
 
-	if(exchange_parts(user, O))
-		return
-
 	if(default_pry_open(O))
 		return
 

--- a/code/modules/food_and_drinks/kitchen_machinery/processor.dm
+++ b/code/modules/food_and_drinks/kitchen_machinery/processor.dm
@@ -46,9 +46,6 @@
 	if(default_deconstruction_screwdriver(user, "processor", "processor1", O))
 		return
 
-	if(exchange_parts(user, O))
-		return
-
 	if(default_pry_open(O))
 		return
 

--- a/code/modules/food_and_drinks/kitchen_machinery/smartfridge.dm
+++ b/code/modules/food_and_drinks/kitchen_machinery/smartfridge.dm
@@ -55,9 +55,6 @@
 	if(default_deconstruction_screwdriver(user, "smartfridge_open", "smartfridge", O))
 		return
 
-	if(exchange_parts(user, O))
-		return
-
 	if(default_pry_open(O))
 		return
 

--- a/code/modules/hydroponics/biogenerator.dm
+++ b/code/modules/hydroponics/biogenerator.dm
@@ -83,9 +83,6 @@
 		update_icon()
 		return
 
-	if(exchange_parts(user, O))
-		return
-
 	if(default_deconstruction_crowbar(O))
 		return
 

--- a/code/modules/hydroponics/gene_modder.dm
+++ b/code/modules/hydroponics/gene_modder.dm
@@ -69,8 +69,6 @@
 	if(default_deconstruction_screwdriver(user, "dnamod", "dnamod", I))
 		update_icon()
 		return
-	if(exchange_parts(user, I))
-		return
 	if(default_deconstruction_crowbar(I))
 		return
 	if(iscyborg(user))

--- a/code/modules/hydroponics/hydroponics.dm
+++ b/code/modules/hydroponics/hydroponics.dm
@@ -59,9 +59,6 @@
 	if(default_deconstruction_screwdriver(user, "hydrotray3", "hydrotray3", I))
 		return
 
-	if(exchange_parts(user, I))
-		return
-
 	if(default_pry_open(I))
 		return
 

--- a/code/modules/hydroponics/seed_extractor.dm
+++ b/code/modules/hydroponics/seed_extractor.dm
@@ -62,9 +62,6 @@
 	if(default_deconstruction_screwdriver(user, "sextractor_open", "sextractor", O))
 		return
 
-	if(exchange_parts(user, O))
-		return
-
 	if(default_pry_open(O))
 		return
 

--- a/code/modules/mining/machine_redemption.dm
+++ b/code/modules/mining/machine_redemption.dm
@@ -148,8 +148,6 @@
 		send_console_message()
 
 /obj/machinery/mineral/ore_redemption/attackby(obj/item/W, mob/user, params)
-	if(exchange_parts(user, W))
-		return
 	GET_COMPONENT(materials, /datum/component/material_container)
 	if(default_pry_open(W))
 		materials.retrieve_all()

--- a/code/modules/power/port_gen.dm
+++ b/code/modules/power/port_gen.dm
@@ -173,9 +173,6 @@
 		return
 	else if(!active)
 
-		if(exchange_parts(user, O))
-			return
-
 		if(istype(O, /obj/item/wrench))
 
 			if(!anchored && !isinspace())

--- a/code/modules/power/rtg.dm
+++ b/code/modules/power/rtg.dm
@@ -38,9 +38,7 @@
 	power_gen = initial(power_gen) * part_level
 
 /obj/machinery/power/rtg/attackby(obj/item/I, mob/user, params)
-	if(exchange_parts(user, I))
-		return
-	else if(default_deconstruction_screwdriver(user, "[initial(icon_state)]-open", initial(icon_state), I))
+	if(default_deconstruction_screwdriver(user, "[initial(icon_state)]-open", initial(icon_state), I))
 		return
 	else if(default_deconstruction_crowbar(I))
 		return

--- a/code/modules/power/singularity/emitter.dm
+++ b/code/modules/power/singularity/emitter.dm
@@ -291,9 +291,6 @@
 		wires.interact(user)
 		return
 
-	else if(exchange_parts(user, I))
-		return
-
 	return ..()
 
 /obj/machinery/power/emitter/emag_act(mob/user)

--- a/code/modules/power/smes.dm
+++ b/code/modules/power/smes.dm
@@ -98,10 +98,6 @@
 		update_icon()
 		return
 
-	//exchanging parts using the RPE
-	if(exchange_parts(user, I))
-		return
-
 	//building and linking a terminal
 	if(istype(I, /obj/item/stack/cable_coil))
 		var/dir = get_dir(user,src)

--- a/code/modules/power/tesla/coil.dm
+++ b/code/modules/power/tesla/coil.dm
@@ -56,9 +56,6 @@
 	if(default_deconstruction_screwdriver(user, "coil_open[anchored]", "coil[anchored]", W))
 		return
 
-	if(exchange_parts(user, W))
-		return
-
 	if(default_unfasten_wrench(user, W))
 		return
 
@@ -167,9 +164,6 @@
 
 /obj/machinery/power/grounding_rod/attackby(obj/item/W, mob/user, params)
 	if(default_deconstruction_screwdriver(user, "grounding_rod_open[anchored]", "grounding_rod[anchored]", W))
-		return
-
-	if(exchange_parts(user, W))
 		return
 
 	if(default_unfasten_wrench(user, W))

--- a/code/modules/power/turbine.dm
+++ b/code/modules/power/turbine.dm
@@ -112,9 +112,6 @@
 			stat |= BROKEN
 		return
 
-	if(exchange_parts(user, I))
-		return
-
 	default_deconstruction_crowbar(I)
 
 /obj/machinery/power/compressor/process()
@@ -241,9 +238,6 @@
 		else
 			to_chat(user, "<span class='alert'>Compressor not connected.</span>")
 			stat |= BROKEN
-		return
-
-	if(exchange_parts(user, I))
 		return
 
 	default_deconstruction_crowbar(I)

--- a/code/modules/reagents/chemistry/machinery/chem_dispenser.dm
+++ b/code/modules/reagents/chemistry/machinery/chem_dispenser.dm
@@ -292,9 +292,6 @@ obj/machinery/chem_dispenser/proc/work_animation()
 		update_icon()
 		return
 
-	if(exchange_parts(user, I))
-		return
-
 	if(default_deconstruction_crowbar(I))
 		return
 	if(istype(I, /obj/item/reagent_containers) && !(I.flags_1 & ABSTRACT_1) && I.is_open_container())

--- a/code/modules/reagents/chemistry/machinery/chem_heater.dm
+++ b/code/modules/reagents/chemistry/machinery/chem_heater.dm
@@ -60,9 +60,6 @@
 	if(default_deconstruction_screwdriver(user, "mixer0b", "mixer0b", I))
 		return
 
-	if(exchange_parts(user, I))
-		return
-
 	if(default_deconstruction_crowbar(I))
 		return
 

--- a/code/modules/reagents/chemistry/machinery/chem_master.dm
+++ b/code/modules/reagents/chemistry/machinery/chem_master.dm
@@ -79,8 +79,6 @@
 	if(default_deconstruction_screwdriver(user, "mixer0_nopower", "mixer0", I))
 		return
 
-	else if(exchange_parts(user, I))
-		return
 	else if(default_deconstruction_crowbar(I))
 		return
 

--- a/code/modules/research/rdmachines.dm
+++ b/code/modules/research/rdmachines.dm
@@ -43,8 +43,6 @@
 		if(linked_console)
 			disconnect_console()
 		return
-	if(exchange_parts(user, O))
-		return
 	if(default_deconstruction_crowbar(O))
 		return
 	if(is_refillable() && O.is_drainable())

--- a/code/modules/research/stock_parts.dm
+++ b/code/modules/research/stock_parts.dm
@@ -18,6 +18,8 @@ If you create T5+ please take a pass at gene_modder.dm [L40]. Max_values MUST fi
 	if(!istype(T) || !T.component_parts)
 		return ..()
 	if(user.Adjacent(T)) // no TK upgrading.
+		if(works_from_distance)
+			user.Beam(T, icon_state = "rped_upgrade", time = 5)
 		T.exchange_parts(user, src)
 		return FALSE
 	return ..()

--- a/code/modules/research/stock_parts.dm
+++ b/code/modules/research/stock_parts.dm
@@ -14,13 +14,22 @@ If you create T5+ please take a pass at gene_modder.dm [L40]. Max_values MUST fi
 	var/pshoom_or_beepboopblorpzingshadashwoosh = 'sound/items/rped.ogg'
 	var/alt_sound = null
 
-/obj/item/storage/part_replacer/afterattack(obj/machinery/T, mob/living/carbon/human/user, flag, params)
+/obj/item/storage/part_replacer/pre_attack(obj/machinery/T, mob/living/user, params)
 	if(!istype(T) || !T.component_parts)
 		return ..()
-	if(works_from_distance || user.Adjacent(T))
+	if(user.Adjacent(T)) // no TK upgrading.
 		T.exchange_parts(user, src)
+		return FALSE
+	return ..()
+
+/obj/item/storage/part_replacer/afterattack(obj/machinery/T, mob/living/user, adjacent, params)
+	if(adjacent || !istype(T) || !T.component_parts)
+		return ..()
 	if(works_from_distance)
 		user.Beam(T, icon_state = "rped_upgrade", time = 5)
+		T.exchange_parts(user, src)
+		return
+	return ..()
 
 /obj/item/storage/part_replacer/proc/play_rped_sound()
 	//Plays the sound for RPED exhanging or installing parts.


### PR DESCRIPTION
[Changelogs]: 

:cl: Dax Dupont
fix: RPEDs will no longer display machine contents twice.
fix: RPED can no longer hold everything.
refactor: Moves all the logic for exchanging parts into the RPEDs instead of having checks in every attack_by.
/:cl:

[why]: Fixes #37367
This also removes the need to check exchange parts on every attack_by.
Fixes #36378
Fixes #37030
