### PR TITLE
Fixes toolbelts holding everything

### DIFF
--- a/code/game/objects/items/storage/belt.dm
+++ b/code/game/objects/items/storage/belt.dm
@@ -37,7 +37,7 @@
 /obj/item/storage/belt/utility/ComponentInitialize()
 	. = ..()
 	GET_COMPONENT(STR, /datum/component/storage)
-	STR.can_hold = typecacheof(list(
+	var/static/list/can_hold = typecacheof(list(
 		/obj/item/crowbar,
 		/obj/item/screwdriver,
 		/obj/item/weldingtool,
@@ -55,6 +55,7 @@
 		/obj/item/holosign_creator,
 		/obj/item/device/assembly/signaler
 		))
+	STR.can_hold = can_hold
 
 /obj/item/storage/belt/utility/chief
 	name = "\improper Chief Engineer's toolbelt" //"the Chief Engineer's toolbelt", because "Chief Engineer's toolbelt" is not a proper noun

--- a/code/game/objects/items/storage/belt.dm
+++ b/code/game/objects/items/storage/belt.dm
@@ -34,7 +34,7 @@
 	item_state = "utility"
 	content_overlays = TRUE
 
-/obj/item/storage/belt/ulility/ComponentInitialize()
+/obj/item/storage/belt/utility/ComponentInitialize()
 	. = ..()
 	GET_COMPONENT(STR, /datum/component/storage)
 	STR.can_hold = typecacheof(list(


### PR DESCRIPTION
[Changelogs]: 

:cl: Dax Dupont
fix: Fixes toolbelts being able to hold everything.
/:cl:

[why]: Fixes #37186 partially, the rped part is fixed by the rped PR.
>ulility
@kevinz000 
