### PR TITLE
Adds salt to chips and jerky

### DIFF
--- a/code/modules/food_and_drinks/food/snacks_vend.dm
+++ b/code/modules/food_and_drinks/food/snacks_vend.dm
@@ -40,7 +40,7 @@
 	junkiness = 20
 	filling_color = "#FFD700"
 	tastes = list("salt" = 1, "crisps" = 1)
-	foodtype = JUNKFOOD | VEGETABLES | FRIED
+	foodtype = JUNKFOOD | FRIED
 
 /obj/item/reagent_containers/food/snacks/no_raisin
 	name = "4no raisins"

--- a/code/modules/food_and_drinks/food/snacks_vend.dm
+++ b/code/modules/food_and_drinks/food/snacks_vend.dm
@@ -18,7 +18,7 @@
 	icon_state = "sosjerky"
 	desc = "Beef jerky made from the finest space cows."
 	trash = /obj/item/trash/sosjerky
-	list_reagents = list("nutriment" = 1, "sugar" = 3)
+	list_reagents = list("nutriment" = 1, "sugar" = 3, "sodiumchloride" = 2)
 	junkiness = 25
 	filling_color = "#8B0000"
 	tastes = list("dried meat" = 1)
@@ -36,11 +36,11 @@
 	icon_state = "chips"
 	trash = /obj/item/trash/chips
 	bitesize = 1
-	list_reagents = list("nutriment" = 1, "sugar" = 3)
+	list_reagents = list("nutriment" = 1, "sugar" = 3, "sodiumchloride" = 1)
 	junkiness = 20
 	filling_color = "#FFD700"
 	tastes = list("salt" = 1, "crisps" = 1)
-	foodtype = JUNKFOOD | FRIED
+	foodtype = JUNKFOOD | VEGETABLES | FRIED
 
 /obj/item/reagent_containers/food/snacks/no_raisin
 	name = "4no raisins"


### PR DESCRIPTION
Chips and jerky from food vendors now contain salt

This is my first PR pls no bully

:cl: Mickyan
tweak: Potato Chips and Beef Jerky from food vendors now contain salt.
/:cl:

[why]: despite being lower than sugar on the resistance scale for virus cures, it's nearly impossible to acquire salt without access to either the kitchen (with its limited supply) or chemistry. This helps balance it out just a little bit.
