### PR TITLE
Track admin observer time

### DIFF
--- a/code/__DEFINES/preferences.dm
+++ b/code/__DEFINES/preferences.dm
@@ -63,6 +63,7 @@
 #define EXP_TYPE_ANTAG			"Antag"
 #define EXP_TYPE_SPECIAL		"Special"
 #define EXP_TYPE_GHOST			"Ghost"
+#define EXP_TYPE_ADMIN			"Admin"
 
 //Flags in the players table in the db
 #define DB_FLAG_EXEMPT 1

--- a/code/modules/jobs/job_exp.dm
+++ b/code/modules/jobs/job_exp.dm
@@ -226,9 +226,14 @@ GLOBAL_PROTECT(exp_to_update)
 			if(!rolefound)
 				play_records["Unknown"] += minutes
 		else
-			play_records[EXP_TYPE_GHOST] += minutes
-			if(announce_changes)
-				to_chat(src,"<span class='notice'>You got: [minutes] Ghost EXP!</span>")
+			if(holder && !holder.deadmined)
+				play_records[EXP_TYPE_ADMIN] += minutes
+				if(announce_changes)
+					to_chat(src,"<span class='notice'>You got: [minutes] Admin EXP!</span>")
+			else
+				play_records[EXP_TYPE_GHOST] += minutes
+				if(announce_changes)
+					to_chat(src,"<span class='notice'>You got: [minutes] Ghost EXP!</span>")
 	else if(isobserver(mob))
 		play_records[EXP_TYPE_GHOST] += minutes
 		if(announce_changes)


### PR DESCRIPTION
For the record I hate this idea because I don't want to clock in for my pretend job but a head admin requested it

Someone who is smarter than me (Ned) will still need to make this easily readable from the database on the stat tracking site