### PR TITLE
Adds grind_results to coins and diamonds

### DIFF
--- a/code/game/objects/items/stacks/sheets/mineral.dm
+++ b/code/game/objects/items/stacks/sheets/mineral.dm
@@ -106,6 +106,7 @@ GLOBAL_LIST_INIT(sandbag_recipes, list ( \
 	sheettype = "diamond"
 	materials = list(MAT_DIAMOND=MINERAL_MATERIAL_AMOUNT)
 	novariants = TRUE
+	grind_results = list("carbon" = 20)
 
 GLOBAL_LIST_INIT(diamond_recipes, list ( \
 	new/datum/stack_recipe("diamond door", /obj/structure/mineral_door/transparent/diamond, 10, one_per_turf = 1, on_floor = 1), \

--- a/code/modules/mining/ores_coins.dm
+++ b/code/modules/mining/ores_coins.dm
@@ -359,6 +359,7 @@ GLOBAL_LIST_INIT(sand_recipes, list(\
 	icon_state = "coin_gold_heads"
 	value = 50
 	materials = list(MAT_GOLD = MINERAL_MATERIAL_AMOUNT*0.2)
+	grind_results = list("gold" = 4)
 
 /obj/item/coin/silver
 	name = "silver coin"
@@ -366,13 +367,15 @@ GLOBAL_LIST_INIT(sand_recipes, list(\
 	icon_state = "coin_silver_heads"
 	value = 20
 	materials = list(MAT_SILVER = MINERAL_MATERIAL_AMOUNT*0.2)
-
+	grind_results = list("silver" = 4)
+	
 /obj/item/coin/diamond
 	name = "diamond coin"
 	cmineral = "diamond"
 	icon_state = "coin_diamond_heads"
 	value = 500
 	materials = list(MAT_DIAMOND = MINERAL_MATERIAL_AMOUNT*0.2)
+	grind_results = list("carbon" = 4)
 
 /obj/item/coin/iron
 	name = "iron coin"
@@ -380,6 +383,7 @@ GLOBAL_LIST_INIT(sand_recipes, list(\
 	icon_state = "coin_iron_heads"
 	value = 1
 	materials = list(MAT_METAL = MINERAL_MATERIAL_AMOUNT*0.2)
+	grind_results = list("iron" = 4)
 
 /obj/item/coin/plasma
 	name = "plasma coin"
@@ -387,6 +391,7 @@ GLOBAL_LIST_INIT(sand_recipes, list(\
 	icon_state = "coin_plasma_heads"
 	value = 100
 	materials = list(MAT_PLASMA = MINERAL_MATERIAL_AMOUNT*0.2)
+	grind_results = list("plasma" = 4)
 
 /obj/item/coin/uranium
 	name = "uranium coin"
@@ -394,6 +399,7 @@ GLOBAL_LIST_INIT(sand_recipes, list(\
 	icon_state = "coin_uranium_heads"
 	value = 80
 	materials = list(MAT_URANIUM = MINERAL_MATERIAL_AMOUNT*0.2)
+	grind_results = list("uranium" = 4)
 
 /obj/item/coin/bananium
 	name = "bananium coin"
@@ -401,6 +407,7 @@ GLOBAL_LIST_INIT(sand_recipes, list(\
 	icon_state = "coin_bananium_heads"
 	value = 1000 //makes the clown cry
 	materials = list(MAT_BANANIUM = MINERAL_MATERIAL_AMOUNT*0.2)
+	grind_results = list("banana" = 4)
 
 /obj/item/coin/adamantine
 	name = "adamantine coin"
@@ -421,6 +428,7 @@ GLOBAL_LIST_INIT(sand_recipes, list(\
 	sideslist = list("heads")
 	materials = list(MAT_METAL = MINERAL_MATERIAL_AMOUNT*0.2)
 	value = 1
+	grind_results = list("iron" = 4)
 
 /obj/item/coin/antagtoken
 	name = "antag token"
@@ -429,6 +437,7 @@ GLOBAL_LIST_INIT(sand_recipes, list(\
 	desc = "A novelty coin that helps the heart know what hard evidence cannot prove."
 	sideslist = list("valid", "salad")
 	value = 0
+	grind_results = list("sodiumchloride" = 4)
 
 /obj/item/coin/attackby(obj/item/W, mob/user, params)
 	if(istype(W, /obj/item/stack/cable_coil))


### PR DESCRIPTION
:cl: Denton
tweak: Nanotrasen's materials science division reports: Coins and diamonds DO blend!
/:cl:

I added grind_results to coins and diamonds. The coin press turns a single 20u mineral sheet into five coins -> 4u result per coin.
Adamantium/mythril were left out since they don't have corresponding reagents.