### PR TITLE
Remove rusty from tgs3.json

### DIFF
--- a/TGS3.json
+++ b/TGS3.json
@@ -17,7 +17,6 @@
       "data"
     ],
     "dlls": [
-      "libmariadb.dll",
-      "rust_g.dll"
+      "libmariadb.dll"
     ]
   }


### PR DESCRIPTION
Because rusty is in this file, the dll does not auto-update and I can't update the dll without taking down the server.

If it was not in here, both of those issues would not exist.

@Cyberboss tgs2 doing it for the mysql/mariadb dll was special because byond does not close the handle to the dll between world/reboots, this is not the case for call()() dlls