### PR TITLE
Removes Acid from Remaining Circuits

### DIFF
--- a/code/game/objects/items/circuitboards/circuitboard.dm
+++ b/code/game/objects/items/circuitboards/circuitboard.dm
@@ -12,7 +12,7 @@
 	righthand_file = 'icons/mob/inhands/misc/devices_righthand.dmi'
 	materials = list(MAT_GLASS=1000)
 	w_class = WEIGHT_CLASS_SMALL
-	grind_results = list("silicon" = 20, "sacid" = 0.5) //Retrieving acid this way is extremely inefficient
+	grind_results = list("silicon" = 20)
 	var/build_path = null
 
 /obj/item/circuitboard/proc/apply_default_parts(obj/machinery/M)

--- a/code/modules/research/designs/computer_part_designs.dm
+++ b/code/modules/research/designs/computer_part_designs.dm
@@ -62,7 +62,6 @@
 	id = "netcard_basic"
 	build_type = IMPRINTER
 	materials = list(MAT_METAL = 250, MAT_GLASS = 100)
-	reagents_list = list("sacid" = 20)
 	build_path = /obj/item/computer_hardware/network_card
 	category = list("Computer Parts")
 	departmental_flags = DEPARTMENTAL_FLAG_SCIENCE | DEPARTMENTAL_FLAG_ENGINEERING
@@ -91,7 +90,6 @@
 	id = "portadrive_basic"
 	build_type = IMPRINTER
 	materials = list(MAT_GLASS = 800)
-	reagents_list = list("sacid" = 20)
 	build_path = /obj/item/computer_hardware/hard_drive/portable
 	category = list("Computer Parts")
 	departmental_flags = DEPARTMENTAL_FLAG_SCIENCE | DEPARTMENTAL_FLAG_ENGINEERING


### PR DESCRIPTION
For the purpose of consistency, sulfuric acid has been removed from the remaining research designs; the basic network card and basic data disk both required acid, despite their more advanced versions not having it.

Along the way, acid was removed from all circuit designs, as it was pointless busywork. This just brings things into consistency.

Also removed acid from grinding circuitboards, as none of them utilize acid anymore.

:cl: Fox McCloud
tweak: Removed acid requirement from basic network card and basic data disk
tweak: grinding circuitboards no longer generates acid
/:cl: