### PR TITLE
Gives admins the D(say) hotkey + fixes buildmode permissions

### DIFF
--- a/code/modules/admin/admin_verbs.dm
+++ b/code/modules/admin/admin_verbs.dm
@@ -597,6 +597,8 @@ GLOBAL_LIST_INIT(admin_verbs_hideable, list(
 /client/proc/togglebuildmodeself()
 	set name = "Toggle Build Mode Self"
 	set category = "Special Verbs"
+	if (!(holder.rank.rights & R_BUILDMODE))
+		return
 	if(src.mob)
 		togglebuildmode(src.mob)
 	SSblackbox.record_feedback("tally", "admin_verb", 1, "Toggle Build Mode") //If you are copy-pasting this, ensure the 2nd parameter is unique to the new proc!

--- a/code/modules/admin/verbs/deadsay.dm
+++ b/code/modules/admin/verbs/deadsay.dm
@@ -30,3 +30,7 @@
 			M.show_message(rendered, 2)
 
 	SSblackbox.record_feedback("tally", "admin_verb", 1, "Dsay") //If you are copy-pasting this, ensure the 2nd parameter is unique to the new proc!
+
+/client/proc/get_dead_say()
+	var/msg = input(src, null, "dsay \"text\"") as text
+	dsay(msg)

--- a/code/modules/keybindings/bindings_admin.dm
+++ b/code/modules/keybindings/bindings_admin.dm
@@ -18,4 +18,7 @@
 			else
 				user.invisimin()
 			return
+		if("F10")
+			user.get_dead_say()
+			return
 	..()


### PR DESCRIPTION
[Changelogs]: 

:cl: Dax Dupont
fix: Buildmode toggle now checks for permissions so the hotkey can't bypass it.
admin: Press F10 for dsay prompt.
/:cl:

[why]: Makes using dsay less pain, also I chose F10 because its on the opposite side of the asay button. Didn't want to put it next to it and having it on the opposite side makes it easy to remember.
