### PR TITLE
Fixes the stock market having random, spontaneous exponential value spikes.

### DIFF
--- a/code/modules/stock_market/stocks.dm
+++ b/code/modules/stock_market/stocks.dm
@@ -143,7 +143,7 @@
 	var/piece_of_shit_fuck = current_value - 500
 	var/i_hate_this_code = (speculation / rand(25000, 50000) + performance / rand(100, 800)) * current_value
 	if(i_hate_this_code < fucking_stock_spikes || i_hate_this_code > piece_of_shit_fuck)
-		current_value += i_hate_this_code
+		current_value = i_hate_this_code
 	if (current_value < 5)
 		current_value = 5
 


### PR DESCRIPTION
Literally the entire reason the stock market's been having random exponential spikes this entire time is because it's been using a += where a = would've been appropriate. This results in the price of the stock spontaneously doubling when certain conditions are met, and then repeatedly doubling itself indefinitely while it continues to meet those conditions

Fixes #37400 
Closes #37401 (though this can probably be merged into it, since this PR fixes the issue that the PR being reverted by that PR tried to fix)
Closes #37386 
Closes #37414 

:cl: deathride58
fix: Stocks in the stock market no longer have spontaneous exponential spikes.
/:cl:
