### PR TITLE
Nerfs techwebs to 90 minute passive gen completion again - Alright okay I'll hold off until I have something better to do with techwebs and point gen

### DIFF
--- a/code/controllers/subsystem/research.dm
+++ b/code/controllers/subsystem/research.dm
@@ -19,7 +19,7 @@ SUBSYSTEM_DEF(research)
 	var/list/techweb_point_items = list()		//path = value
 	var/list/errored_datums = list()
 	//----------------------------------------------
-	var/single_server_income = 54.3
+	var/single_server_income = 36.2
 	var/multiserver_calculation = FALSE
 	var/last_income = 0
 	//^^^^^^^^ ALL OF THESE ARE PER SECOND! ^^^^^^^^


### PR DESCRIPTION
Why: we have a few carried varied methods of generation now and if you want to be lazy you should have to keep the round going long enough to get all of it without boosting the process. The way I see it you either spend time stabilizing the station to last longer, or spend time speeding along research to get your toys, and the end result is the same.