### PR TITLE
Adds a cooldown to PDA send to all messages.

### DIFF
--- a/code/game/objects/items/devices/PDA/PDA.dm
+++ b/code/game/objects/items/devices/PDA/PDA.dm
@@ -52,6 +52,7 @@ GLOBAL_LIST_EMPTY(PDAs)
 	var/toff = FALSE //If TRUE, messenger disabled
 	var/tnote = null //Current Texts
 	var/last_text //No text spamming
+	var/last_everyone //No text for everyone spamming
 	var/last_noise //Also no honk spamming that's bad too
 	var/ttone = "beep" //The ringtone!
 	var/lock_code = "" // Lockcode to unlock uplink
@@ -609,11 +610,11 @@ GLOBAL_LIST_EMPTY(PDAs)
 		t = Gibberish(t, 100)
 	return t
 
-/obj/item/pda/proc/send_message(mob/living/user, list/obj/item/pda/targets)
+/obj/item/pda/proc/send_message(mob/living/user, list/obj/item/pda/targets, everyone)
 	var/message = msg_input(user)
 	if(!message || !targets.len)
 		return
-	if(last_text && world.time < last_text + 5)
+	if((last_text && world.time < last_text + 10) || (everyone && last_everyone && world.time < last_everyone + 1800))
 		return
 
 	// Send the signal
@@ -658,6 +659,9 @@ GLOBAL_LIST_EMPTY(PDAs)
 	to_chat(user, "<span class='info'>Message sent to [target_text]: \"[message]\"</span>")
 	// Reset the photo
 	photo = null
+	last_text = world.time 
+	if (everyone)
+		last_everyone = world.time
 
 /obj/item/pda/proc/receive_message(datum/signal/subspace/pda/signal)
 	tnote += "<i><b>&larr; From <a href='byond://?src=[REF(src)];choice=Message;target=[REF(signal.source)]'>[signal.data["name"]]</a> ([signal.data["job"]]):</b></i><br>[signal.format_message()]<br>"
@@ -686,7 +690,10 @@ GLOBAL_LIST_EMPTY(PDAs)
 	add_overlay(icon_alert)
 
 /obj/item/pda/proc/send_to_all(mob/living/U)
-	send_message(U,get_viewable_pdas())
+	if (last_everyone && world.time < last_everyone + 1800)
+		to_chat(U,"<span class='warning'>Send To All function is still on cooldown.")
+		return
+	send_message(U,get_viewable_pdas(), TRUE)
 
 /obj/item/pda/proc/create_message(mob/living/U, obj/item/pda/P)
 	send_message(U,list(P))

--- a/code/game/objects/items/devices/PDA/PDA.dm
+++ b/code/game/objects/items/devices/PDA/PDA.dm
@@ -614,7 +614,7 @@ GLOBAL_LIST_EMPTY(PDAs)
 	var/message = msg_input(user)
 	if(!message || !targets.len)
 		return
-	if((last_text && world.time < last_text + 10) || (everyone && last_everyone && world.time < last_everyone + 1800))
+	if((last_text && world.time < last_text + 10) || (everyone && last_everyone && world.time < last_everyone + (2 MINUTES)))
 		return
 
 	// Send the signal

--- a/code/game/objects/items/devices/PDA/PDA.dm
+++ b/code/game/objects/items/devices/PDA/PDA.dm
@@ -9,6 +9,7 @@ GLOBAL_LIST_EMPTY(PDAs)
 #define PDA_SCANNER_REAGENT		3
 #define PDA_SCANNER_HALOGEN		4
 #define PDA_SCANNER_GAS			5
+#define PDA_SPAM_DELAY		    2 MINUTES
 
 /obj/item/pda
 	name = "\improper PDA"
@@ -614,7 +615,7 @@ GLOBAL_LIST_EMPTY(PDAs)
 	var/message = msg_input(user)
 	if(!message || !targets.len)
 		return
-	if((last_text && world.time < last_text + 10) || (everyone && last_everyone && world.time < last_everyone + (2 MINUTES)))
+	if((last_text && world.time < last_text + 10) || (everyone && last_everyone && world.time < last_everyone + PDA_SPAM_DELAY))
 		return
 
 	// Send the signal
@@ -690,7 +691,7 @@ GLOBAL_LIST_EMPTY(PDAs)
 	add_overlay(icon_alert)
 
 /obj/item/pda/proc/send_to_all(mob/living/U)
-	if (last_everyone && world.time < last_everyone + (2 MINUTES))
+	if (last_everyone && world.time < last_everyone + PDA_SPAM_DELAY)
 		to_chat(U,"<span class='warning'>Send To All function is still on cooldown.")
 		return
 	send_message(U,get_viewable_pdas(), TRUE)
@@ -1016,3 +1017,4 @@ GLOBAL_LIST_EMPTY(PDAs)
 #undef PDA_SCANNER_REAGENT
 #undef PDA_SCANNER_HALOGEN
 #undef PDA_SCANNER_GAS
+#undef PDA_SPAM_DELAY

--- a/code/game/objects/items/devices/PDA/PDA.dm
+++ b/code/game/objects/items/devices/PDA/PDA.dm
@@ -690,7 +690,7 @@ GLOBAL_LIST_EMPTY(PDAs)
 	add_overlay(icon_alert)
 
 /obj/item/pda/proc/send_to_all(mob/living/U)
-	if (last_everyone && world.time < last_everyone + 1800)
+	if (last_everyone && world.time < last_everyone + (2 MINUTES))
 		to_chat(U,"<span class='warning'>Send To All function is still on cooldown.")
 		return
 	send_message(U,get_viewable_pdas(), TRUE)


### PR DESCRIPTION
[Changelogs]:

:cl: Dax Dupont
balance: Adds a cooldown to PDA send to all messages.
fix: Last sent message cooldown actually works now.
/:cl:

[why]: People using it to spam is getting annoying, a cooldown seems appropriate considering it sends messages to everyone.
