### PR TITLE
IC Circuit power relay can now charge guns inside of weapon firing mechanisms

### DIFF
--- a/code/modules/integrated_electronics/subtypes/power.dm
+++ b/code/modules/integrated_electronics/subtypes/power.dm
@@ -40,8 +40,10 @@
 	var/atom/movable/AM = get_pin_data_as_type(IC_INPUT, 1, /atom/movable)
 	if(!AM)
 		return FALSE
-	if(istype(AM, /obj/item/gun/energy) && !istype(AM.loc,/obj/item/integrated_circuit/manipulation/weapon_firing)) // Can only charge guns inside of the assembly's weapon firing mechanism
-		return FALSE
+	if(istype(AM, /obj/item/gun/energy))
+		var/obj/item/gun/energy/E = AM
+		if(!istype(AM.loc,/obj/item/integrated_circuit/manipulation/weapon_firing) || !E.can_charge)  // Can only charge guns that are inside of the assembly's weapon firing mechanism and chargeable
+			return FALSE
 	if(!assembly)
 		return FALSE // Pointless to do everything else if there's no battery to draw from.
 	var/obj/item/stock_parts/cell/cell = AM.get_cell()

--- a/code/modules/integrated_electronics/subtypes/power.dm
+++ b/code/modules/integrated_electronics/subtypes/power.dm
@@ -40,7 +40,7 @@
 	var/atom/movable/AM = get_pin_data_as_type(IC_INPUT, 1, /atom/movable)
 	if(!AM)
 		return FALSE
-	if(istype(AM, /obj/item/gun/energy))
+	if(istype(AM, /obj/item/gun/energy) && !istype(AM.loc,/obj/item/integrated_circuit/manipulation/weapon_firing)) // Can only charge guns inside of the assembly's weapon firing mechanism
 		return FALSE
 	if(!assembly)
 		return FALSE // Pointless to do everything else if there's no battery to draw from.


### PR DESCRIPTION
[Changelogs]: # (Your PR should contain a detailed changelog of notable changes, titled and categorized appropriately. This includes, new features, sprites, sounds, balance changes, admin tools, map edits, removals, big refactors, config changes, hosting changes and important fixes. An example changelog has been provided below for you to edit. If you need additional help, read https://github.com/tgstation/tgstation/wiki/Changelogs)

:cl: Evsey9
add: Integrated Circuit weapon firing mechanisms now have an input port for power relays, and thus give the ability to charge guns inside of them using power relays.
/:cl:

[why]: You can't just make an inducer circuit or make a fully automatic gun recharger with this, but you CAN make gunbots that aren't completely shit because of the fact you have to disassemble them and take out the weapon component out of them simply to recharge their gun
