### PR TITLE
hotspot_expose() will now heat the turf's air if it fails to create a hotspot

### DIFF
--- a/code/modules/atmospherics/environmental/LINDA_fire.dm
+++ b/code/modules/atmospherics/environmental/LINDA_fire.dm
@@ -42,6 +42,11 @@
 		active_hotspot.just_spawned = (current_cycle < SSair.times_fired)
 			//remove just_spawned protection if no longer processing this cell
 		SSair.add_to_active(src, 0)
+	else
+		var/datum/gas_mixture/heating = air_contents.remove_ratio(exposed_volume/air_contents.volume)
+		heating.temperature = exposed_temperature
+		heating.react()
+		assume_air(heating)
 	return igniting
 
 //This is the icon for fire on turfs, also helps for nurturing small fires until they are full tile


### PR DESCRIPTION
In layman's terms, this means welding tools, bonfires, igniters, etc, will now actually generate heat. Attempting to build a bonfire inside the station without taking precautions is now a very bad idea.

:cl: deathride58
add: Things that are capable of igniting plasma fires will now generate heat if there's no plasma to ignite. Building a bonfire inside the station without taking safety precautions is now a bad idea.
/:cl:
