### PR TITLE
Removes Headcrabs and Magicarp from Xenobio

### DIFF
--- a/code/modules/events/wizard/magicarp.dm
+++ b/code/modules/events/wizard/magicarp.dm
@@ -36,10 +36,11 @@
 	projectilesound = 'sound/weapons/emitter.ogg'
 	maxHealth = 50
 	health = 50
+	gold_core_spawnable = NO_SPAWN
 	var/allowed_projectile_types = list(/obj/item/projectile/magic/change, /obj/item/projectile/magic/animate, /obj/item/projectile/magic/resurrection,
 	/obj/item/projectile/magic/death, /obj/item/projectile/magic/teleport, /obj/item/projectile/magic/door, /obj/item/projectile/magic/aoe/fireball,
 	/obj/item/projectile/magic/spellblade, /obj/item/projectile/magic/arcane_barrage)
-	
+
 /mob/living/simple_animal/hostile/carp/ranged/Initialize()
 	projectiletype = pick(allowed_projectile_types)
 	. = ..()

--- a/code/modules/mob/living/simple_animal/hostile/headcrab.dm
+++ b/code/modules/mob/living/simple_animal/hostile/headcrab.dm
@@ -20,9 +20,9 @@
 	environment_smash = ENVIRONMENT_SMASH_NONE
 	speak_emote = list("squeaks")
 	ventcrawler = VENTCRAWLER_ALWAYS
+	gold_core_spawnable = NO_SPAWN
 	var/datum/mind/origin
 	var/egg_lain = 0
-	gold_core_spawnable = HOSTILE_SPAWN //are you sure about this??
 
 /mob/living/simple_animal/hostile/headcrab/proc/Infect(mob/living/carbon/victim)
 	var/obj/item/organ/body_egg/changeling_egg/egg = new(victim)


### PR DESCRIPTION
Magicarp and headcrabs are problematic as a Xenobiology mob.

Magicarp give free access to minerals, syndiborgs (and therefore emags), which is problematic, to say the least; it also gives access to headcrabs, which is basically a way to turn yourself into a changeling.

Headcrabs are also problematic because they allow you to become a changeling, especially in combination with the sentience transference potion.

Both give an unprecedented amount of power to science not to mention blur the lines between crew and antags.

:cl: Fox McCloud
tweak: Can no longer produce magicarp and headcrabs in Xenobiology
/:cl: