### PR TITLE
Paperwork Error Event

### DIFF
--- a/code/modules/events/bureaucratic_error.dm
+++ b/code/modules/events/bureaucratic_error.dm
@@ -11,4 +11,4 @@
 	priority_announce("A recent bureaucratic error in the Organic Resources Department may result in personnel shortages in some departments and redundant staffing in others.", "Paperwork Mishap Alert")
 
 /datum/round_event/bureaucratic_error/start()
-	set_overflow_role(pick(get_all_jobs()))
+	SSjob.set_overflow_role(pick(get_all_jobs()))

--- a/code/modules/events/bureaucratic_error.dm
+++ b/code/modules/events/bureaucratic_error.dm
@@ -1,0 +1,16 @@
+/datum/round_event_control/bureaucratic_error
+	name = "Bureaucratic Error"
+	typepath = /datum/round_event/bureaucratic_error
+	max_occurrences = 1
+	weight = 5
+
+/datum/round_event/bureaucratic_error
+	announceWhen = 1
+
+/datum/round_event/bureaucratic_error/announce(fake)
+	priority_announce("A recent bureaucratic error in the Organic Resources Department may result in personnel shortages in some departments and redundant staffing in others.", "Paperwork Mishap Alert")
+
+/datum/round_event/bureaucratic_error/start()
+	var/list/all_jobs = get_all_jobs()
+	picked_job = pick(all_jobs)
+	SSjob.set_overflow_role(picked_job)

--- a/code/modules/events/bureaucratic_error.dm
+++ b/code/modules/events/bureaucratic_error.dm
@@ -11,6 +11,4 @@
 	priority_announce("A recent bureaucratic error in the Organic Resources Department may result in personnel shortages in some departments and redundant staffing in others.", "Paperwork Mishap Alert")
 
 /datum/round_event/bureaucratic_error/start()
-	var/list/all_jobs = get_all_jobs()
-	picked_job = pick(all_jobs)
-	SSjob.set_overflow_role(picked_job)
+	set_overflow_role(pick(get_all_jobs()))

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -1440,6 +1440,7 @@
 #include "code\modules\events\aurora_caelus.dm"
 #include "code\modules\events\blob.dm"
 #include "code\modules\events\brand_intelligence.dm"
+#include "code\modules\events\bureaucratic_error.dm"
 #include "code\modules\events\camerafailure.dm"
 #include "code\modules\events\carp_migration.dm"
 #include "code\modules\events\communications_blackout.dm"


### PR DESCRIPTION
:cl: Kor
add: Added the Bureaucratic Error event, which replaces the overflow role with a random job.
/:cl:

Randomly sets the overflow role (the infinite slot one, default is Assistant) to any job in the game.

Why: I think rare events that disrupt the round without directly killing people or blowing things up have strong potential for EMERGENT stories and gameplay.

The one time I ran this manually about 9 chaplains held elaborated rituals in the chapel, then declared alchohol sinful and wrecked the bar before being shotgunned to death by cargo.