### PR TITLE
slighty upgrades the medbeam

### DIFF
--- a/code/modules/projectiles/guns/misc/medbeam.dm
+++ b/code/modules/projectiles/guns/misc/medbeam.dm
@@ -116,6 +116,8 @@
 		new /obj/effect/temp_visual/heal(get_turf(target), "#80F5FF")
 	target.adjustBruteLoss(-4)
 	target.adjustFireLoss(-4)
+	target.adjustToxLoss(-1)
+	target.adjustOxyLoss(-1)
 	return
 
 /obj/item/gun/medbeam/proc/on_beam_release(var/mob/living/target)


### PR DESCRIPTION
:cl:
tweak: medbeams heal tox and oxy slighty
/:cl:
why: because some dude having 1 tox damage and not being able to heal is really frustating
