### PR TITLE
Ends the web editor tyranny

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -396,6 +396,7 @@ Regarding sprites & sounds, you must credit the artist and possibly the codebase
 ## Banned content
 Do not add any of the following in a Pull Request or risk getting the PR closed:
 * National Socialist Party of Germany content, National Socialist Party of Germany related content, or National Socialist Party of Germany references
+* Code written solely using the GitHub web editor
 * Code where one line of code is split across mutiple lines (except for multiple, separate strings and comments; in those cases, existing longer lines must not be split up)
 * Code adding, removing, or updating the availability of alien races/species/human mutants without prior approval. Pull requests attempting to add or remove features from said races/species/mutants require prior approval as well.
 

--- a/tools/WebhookProcessor/github_webhook_processor.php
+++ b/tools/WebhookProcessor/github_webhook_processor.php
@@ -359,12 +359,32 @@ function check_dismiss_changelog_review($payload){
 				dismiss_review($payload, $R['id'], 'Changelog added/fixed.');
 }
 
+function check_webeditor($payload){
+	if(is_maintainer($payload, $payload['pull_request']['user']['login']))
+		return;
+	$githubgpgkeyid = '04AEE18F83AFDEB23';
+	$commits = json_decode(apisend($payload['pull_request']['commits_url']), TRUE);
+	foreach($commits as $commit) {
+		if(!$commit['commit']['verification']['verified'])
+			return false;
+		$sig = $commit['commit']['verification']['signature'];
+		$keyid = substr(bin2hex(base64_decode(substr(str_replace('\n', '', $sig),53,12))),0,-1);
+		if(strtoupper($keyid) != $githubgpgkeyid)
+			return false;
+	}
+	create_comment($payload, 'Pull requests made via the GitHub web editor are not accepted.');
+	apisend($payload['url'], 'PATCH', array('state' => 'closed'));
+	return true;
+}
+
 function handle_pr($payload) {
 	global $no_changelog;
 	$action = 'opened';
 	$validated = validate_user($payload);
 	switch ($payload["action"]) {
 		case 'opened':
+			if(check_webeditor($payload))
+				return;
 			list($labels, $remove) = tag_pr($payload, true);
 			set_labels($payload, $labels, $remove);
 			if($no_changelog)


### PR DESCRIPTION
Pull requests OPENED with SOLELY web editor commits will be ~~auto closed (won't be announced to servers)~~ publicly berated and have 3 GBP deducted on merge regardless of other labels. This is an effort to cut back on PRs fired from the hip. They can be reopened at maintainer discretion.

@tgstation/commit-access: debate