### PR TITLE
Removes sound from the laugh emote.

### DIFF
--- a/code/modules/mob/living/emote.dm
+++ b/code/modules/mob/living/emote.dm
@@ -202,16 +202,6 @@
 		var/mob/living/carbon/C = user
 		return !C.silent
 
-/datum/emote/living/laugh/run_emote(mob/user, params)
-	. = ..()
-	if(. && ishuman(user))
-		var/mob/living/carbon/human/H = user
-		if(H.dna.species.id == "human" && (!H.mind || !H.mind.miming))
-			if(user.gender == FEMALE)
-				playsound(H, 'sound/voice/human/womanlaugh.ogg', 50, 1)
-			else
-				playsound(H, pick('sound/voice/human/manlaugh1.ogg', 'sound/voice/human/manlaugh2.ogg'), 50, 1)
-
 /datum/emote/living/look
 	key = "look"
 	key_third_person = "looks"


### PR DESCRIPTION
Having everyone's laughs sound the same is bad. This game gives you plenty of ways of making a unique character, and having everyone's laughs being identical is just bad for roleplay.