### PR TITLE
Adds logging for PDA explosions

### DIFF
--- a/code/game/objects/items/devices/PDA/virus_cart.dm
+++ b/code/game/objects/items/devices/PDA/virus_cart.dm
@@ -77,7 +77,7 @@
 		else
 			var/turf/T = get_turf(target)
 			var/area/A = get_area(T)
-			message_admins("[key_name_admin(U)][ADMIN_FLW(U)] triggered a PDA explosion on [target.name] at [A] [ADMIN_COORDJMP(T)].")
+			message_admins("[!is_special_character(U) ? "Non-antag " : ""][key_name_admin(U)][ADMIN_FLW(U)] triggered a PDA explosion on [target.name] at [A] [ADMIN_COORDJMP(T)].")
 			var/message_log = "triggered a PDA explosion on [target.name] at at [A] [COORD(T)]."
 			U.log_message(message_log, INDIVIDUAL_ATTACK_LOG)
 			log_game("[key_name(U)] [message_log]")

--- a/code/game/objects/items/devices/PDA/virus_cart.dm
+++ b/code/game/objects/items/devices/PDA/virus_cart.dm
@@ -75,6 +75,13 @@
 		if(!target.detonatable || prob(difficulty * 15) || (hidden_uplink))
 			U.show_message("<span class='danger'>An error flashes on your [src].</span>", 1)
 		else
+			var/turf/T = get_turf(target)
+			var/area/A = get_area(T)
+			message_admins("[key_name_admin(U)][ADMIN_FLW(U)] triggered a PDA explosion on [target.name] at [A] [ADMIN_COORDJMP(T)].")
+			var/message_log = "triggered a PDA explosion on [target.name] at at [A] [COORD(T)]."
+			U.log_message(message_log, INDIVIDUAL_ATTACK_LOG)
+			log_game("[key_name(U)] [message_log]")
+			log_attack("[key_name(U)] [message_log]")
 			U.show_message("<span class='notice'>Success!</span>", 1)
 			target.explode()
 	else


### PR DESCRIPTION
[Changelogs]: 

:cl: Dax Dupont
admin: PDA explosions now have logging.
/:cl:

[why]: Because digging through hrefs is annoying to find out something that happens relatively common.
Especially when there's null crates about things get foggy as to owners of detomax cartridges being tots or not.
