### PR TITLE
Fixes being unable to place a Robotic Factory if it failed to place after the prompt

### DIFF
--- a/code/modules/antagonists/traitor/equipment/Malf_Modules.dm
+++ b/code/modules/antagonists/traitor/equipment/Malf_Modules.dm
@@ -666,6 +666,7 @@ GLOBAL_LIST_INIT(blacklisted_malf_machines, typecacheof(list(
 		active = FALSE
 		return
 	if(!owner_AI.can_place_transformer(src))
+		active = FALSE
 		return
 	var/turf/T = get_turf(owner_AI.eyeobj)
 	var/obj/machinery/transformer/conveyor = new(T)


### PR DESCRIPTION
also catching up on some missing changelogs

:cl: ShizCalev
fix: Fixed traitor AIs being unable to place a robotics factory if they failed to place it after the prompt.
fix: Fixed mobs having no hands if they had prosthetic limbs
fix: Fixed damage overlays disappearing from prosthetic limbs when a mob is husked
fix: Fixed ghosts not being able to see into bags
fix: Fixed a number of chapel and morgue doors being high-security CENTCOM variants. This was also triggering certain phobias.
fix: Fixed the warning message for chameleon projectors when a mob is inside a closet
tweak: Improved the formatting of the round-end report for AI and robotic units
spellcheck: Added a period to the end of point-at messages. 
fix: Fixed ghosts getting spammed by sounds when clicking on a jukebox.
fix: Fixed a duplicate docking port on the aux base template which was causing some errors
fix: Fixed Gr3y.T1d3 virus bolting open the doors to the SM, causing delamination. 
fix: Fixed the cat butcher dropping incorrectly colored tails
fix: Fixed being unable to add a cat tail to someone through surgery.
fix: Fixed mass purrbation & the anime event failing to give people ears and tails in some cases.
fix: Fixed AI units being able to toggle turrets on and off when AI control is disabled.
fix: While it slight increases the cost of production, vanilla ice cream is now actually made with real vanilla!
fix: Fixed AI units being able to see lights through static.
fix: Fixed securitron pathfinding icons being broken.
/:cl: