### PR TITLE
Limits gold core magicarps to wizard rounds

### DIFF
--- a/code/modules/events/wizard/magicarp.dm
+++ b/code/modules/events/wizard/magicarp.dm
@@ -36,12 +36,17 @@
 	projectilesound = 'sound/weapons/emitter.ogg'
 	maxHealth = 50
 	health = 50
+	gold_core_spawnable = NO_SPAWN
 	var/allowed_projectile_types = list(/obj/item/projectile/magic/change, /obj/item/projectile/magic/animate, /obj/item/projectile/magic/resurrection,
 	/obj/item/projectile/magic/death, /obj/item/projectile/magic/teleport, /obj/item/projectile/magic/door, /obj/item/projectile/magic/aoe/fireball,
 	/obj/item/projectile/magic/spellblade, /obj/item/projectile/magic/arcane_barrage)
-	
+
 /mob/living/simple_animal/hostile/carp/ranged/Initialize()
 	projectiletype = pick(allowed_projectile_types)
+
+	if(SSticker.mode.config_tag == "wizard")
+		gold_core_spawnable = HOSTILE_SPAWN
+
 	. = ..()
 
 /mob/living/simple_animal/hostile/carp/ranged/chaos


### PR DESCRIPTION
:cl:
tweak: After a series of litigations, the Space Wizard Federation has managed to successfully patent troll Nanotrasen. Nanotrasen now has a legal agreement with the Space Wizard Federation to not engage in magicarp research.
/:cl:

Let's keep magical shenanigans to wizard rounds please.
