### PR TITLE
Pocket Maxcap Fix

### DIFF
--- a/code/modules/food_and_drinks/kitchen_machinery/deep_fryer.dm
+++ b/code/modules/food_and_drinks/kitchen_machinery/deep_fryer.dm
@@ -46,6 +46,7 @@ God bless America.
 		/obj/item/reagent_containers/glass,
 		/obj/item/reagent_containers/syringe,
 		/obj/item/reagent_containers/food/condiment,
+		/obj/item/transfer_valve,
 		/obj/item/storage/part_replacer,
 		/obj/item/his_grace))
 	var/datum/looping_sound/deep_fryer/fry_loop


### PR DESCRIPTION
Fixes an exploit that allowed TTVs to be shrunk to pocket sizes, while retaining the ability to detonate if signalled.

:cl: BlueNothing
fix: You are no able to deepfry bombs to shrink them to fit in your pocket!
/:cl:

[why]: # (Please add a short description [two lines down] of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.)


 We've been trying to stop pocket bombs and other such compactness for a while, that was the whole reason bombs were made bulky in the first place.