### PR TITLE
Thrower Nerf

### DIFF
--- a/code/modules/food_and_drinks/kitchen_machinery/deep_fryer.dm
+++ b/code/modules/food_and_drinks/kitchen_machinery/deep_fryer.dm
@@ -46,6 +46,7 @@ God bless America.
 		/obj/item/reagent_containers/glass,
 		/obj/item/reagent_containers/syringe,
 		/obj/item/reagent_containers/food/condiment,
+		/obj/item/transfer_valve,
 		/obj/item/storage/part_replacer,
 		/obj/item/his_grace))
 	var/datum/looping_sound/deep_fryer/fry_loop

--- a/code/modules/integrated_electronics/subtypes/manipulation.dm
+++ b/code/modules/integrated_electronics/subtypes/manipulation.dm
@@ -459,7 +459,7 @@
 	..()
 
 
-
+/*
 /obj/item/integrated_circuit/manipulation/thrower
 	name = "thrower"
 	desc = "A compact launcher to throw things from inside or nearby tiles."
@@ -516,6 +516,7 @@
 
 	A.forceMove(drop_location())
 	A.throw_at(locate(x_abs, y_abs, T.z), range, 3)
+	*/
 
 /obj/item/integrated_circuit/manipulation/matman
 	name = "material manager"


### PR DESCRIPTION
Temporarily removes throwers in a way that's easy to undo if need be.

:cl:
:del: Removes integrated circuit throwers.
/:cl:

[why]: # (Please add a short description [two lines down] of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.)

Temporarily removes the thrower, as a means of proposing the measure.

Throwers were supposedly intended for use in moving objects between conveyors, into bins, and so on. In practice, they're used as superweapons (chained thrower systems carried in an assembly that kill everything) or as locomotion exploits (circuits can throw themselves, so non-drone circuits can still dart about almost as well, if not better).