### PR TITLE
[s] Fixes the fryer shrinking the size of objects

### DIFF
--- a/code/modules/food_and_drinks/food/snacks_bread.dm
+++ b/code/modules/food_and_drinks/food/snacks_bread.dm
@@ -192,6 +192,7 @@
 	overlays = fried.copy_overlays()
 	icon_state = fried.icon_state
 	desc = fried.desc
+	w_class = fried.w_class
 	if(istype(fried, /obj/item/reagent_containers/food/snacks))
 		fried.reagents.trans_to(src, fried.reagents.total_volume)
 		qdel(fried)

--- a/code/modules/food_and_drinks/food/snacks_bread.dm
+++ b/code/modules/food_and_drinks/food/snacks_bread.dm
@@ -193,6 +193,14 @@
 	icon_state = fried.icon_state
 	desc = fried.desc
 	w_class = fried.w_class
+	slowdown = fried.slowdown
+	equip_delay_self = fried.equip_delay_self
+	equip_delay_other = fried.equip_delay_other
+	strip_delay = fried.strip_delay
+	species_exception = fried.species_exception
+	item_flags = fried.item_flags
+	obj_flags = fried.obj_flags
+
 	if(istype(fried, /obj/item/reagent_containers/food/snacks))
 		fried.reagents.trans_to(src, fried.reagents.total_volume)
 		qdel(fried)


### PR DESCRIPTION
🆑 ShizCalev
fix: You can no longer shrink objects using a deep fryer!
/🆑

Alternative fix to #37487. Obviously it also fixes the issue for pretty much everything else as well.

