### PR TITLE
Removes damage from thrower circuits

### DIFF
--- a/code/modules/integrated_electronics/subtypes/manipulation.dm
+++ b/code/modules/integrated_electronics/subtypes/manipulation.dm
@@ -514,9 +514,11 @@
 	var/y_abs = CLAMP(T.y + target_y_rel, 0, world.maxy)
 	var/range = round(CLAMP(sqrt(target_x_rel*target_x_rel+target_y_rel*target_y_rel),0,8),1)
 	A.throwforce = 0
+	A.embedding = list("embed_chance" = 0)
 	A.forceMove(drop_location())
 	A.throw_at(locate(x_abs, y_abs, T.z), range, 3)
 	A.throwforce = initial(A.throwforce)
+	A.embedding = initial(A.embedding)
 
 /obj/item/integrated_circuit/manipulation/matman
 	name = "material manager"

--- a/code/modules/integrated_electronics/subtypes/manipulation.dm
+++ b/code/modules/integrated_electronics/subtypes/manipulation.dm
@@ -513,9 +513,10 @@
 	var/x_abs = CLAMP(T.x + target_x_rel, 0, world.maxx)
 	var/y_abs = CLAMP(T.y + target_y_rel, 0, world.maxy)
 	var/range = round(CLAMP(sqrt(target_x_rel*target_x_rel+target_y_rel*target_y_rel),0,8),1)
-
+	A.throwforce = 0
 	A.forceMove(drop_location())
 	A.throw_at(locate(x_abs, y_abs, T.z), range, 3)
+	A.throwforce = initial(A.throwforce)
 
 /obj/item/integrated_circuit/manipulation/matman
 	name = "material manager"


### PR DESCRIPTION
:cl: Iamgoofball
balance: Circuits now can't do damage with throwers anymore.

Now they can be used for object movement and locomotion of held objects, but they won't do any damage.
Alternative to #37490

Closes #37490