### PR TITLE
IC weapon mechanism only works when assembly is on turf

### DIFF
--- a/code/modules/integrated_electronics/subtypes/manipulation.dm
+++ b/code/modules/integrated_electronics/subtypes/manipulation.dm
@@ -81,6 +81,8 @@
 /obj/item/integrated_circuit/manipulation/weapon_firing/do_work()
 	if(!installed_gun)
 		return
+	if(!isturf(assembly.loc))
+		return
 	set_pin_data(IC_OUTPUT, 1, WEAKREF(installed_gun))
 	push_data()
 	var/datum/integrated_io/xo = inputs[1]


### PR DESCRIPTION
:cl: Evsey9
balance: Integrated Circuit weapon mechanisms now work only when outside of any containers and hands, due to reports of severe injury caused by activating them while still holding them.
/:cl:

Should make these gun circuits a bit more balanced. I'm open for suggestions for other balance changes to IC weapon mechanisms if needed.
