### PR TITLE
Fixes bikehorn mood event

### DIFF
--- a/code/game/objects/items/clown_items.dm
+++ b/code/game/objects/items/clown_items.dm
@@ -116,7 +116,7 @@
 	. = ..()
 	AddComponent(/datum/component/squeak, list('sound/items/bikehorn.ogg'=1), 50)
 
-/obj/item/weapon/bikehorn/attack(mob/living/carbon/M, mob/living/carbon/user)
+/obj/item/bikehorn/attack(mob/living/carbon/M, mob/living/carbon/user)
 	M.SendSignal(COMSIG_ADD_MOOD_EVENT, "honk", /datum/mood_event/honk)
 
 /obj/item/bikehorn/suicide_act(mob/user)


### PR DESCRIPTION
:cl: ShizCalev
fix: Fixed attacking someone with a bikehorn not triggering the correct mood event.
/:cl: