### PR TITLE
Fixes Blast Cannon

### DIFF
--- a/code/modules/projectiles/guns/misc/blastcannon.dm
+++ b/code/modules/projectiles/guns/misc/blastcannon.dm
@@ -19,9 +19,7 @@
 		pin = new
 
 /obj/item/gun/blastcannon/Destroy()
-	if(bomb)
-		qdel(bomb)
-		bomb = null
+	QDEL_NULL(bomb)
 	return ..()
 
 /obj/item/gun/blastcannon/attack_self(mob/user)
@@ -49,17 +47,17 @@
 		if(!T.tank_one || !T.tank_two)
 			to_chat(user, "<span class='warning'>What good would an incomplete bomb do?</span>")
 			return FALSE
-		if(!user.transferItemToLoc(O, src))
-			to_chat(user, "<span class='warning'>[O] seems to be stuck to your hand!</span>")
+		if(!user.transferItemToLoc(T, src))
+			to_chat(user, "<span class='warning'>[T] seems to be stuck to your hand!</span>")
 			return FALSE
-		user.visible_message("<span class='warning'>[user] attaches [O] to [src]!</span>")
-		bomb = O
+		user.visible_message("<span class='warning'>[user] attaches [T] to [src]!</span>")
+		bomb = T
 		update_icon()
 		return TRUE
 	return ..()
 
 /obj/item/gun/blastcannon/proc/calculate_bomb()
-	if(!istype(bomb)||!istype(bomb.tank_one)||!istype(bomb.tank_two))
+	if(!istype(bomb) || !istype(bomb.tank_one) || !istype(bomb.tank_two))
 		return 0
 	var/datum/gas_mixture/temp = new(60)	//directional buff.
 	temp.merge(bomb.tank_one.air_contents.remove_ratio(1))
@@ -70,18 +68,18 @@
 	qdel(temp)
 	if(pressure < TANK_FRAGMENT_PRESSURE)
 		return 0
-	return (pressure/TANK_FRAGMENT_SCALE)
+	return (pressure / TANK_FRAGMENT_SCALE)
 
 /obj/item/gun/blastcannon/afterattack(atom/target, mob/user, flag, params)
 	if((!bomb) || (!target) || (get_dist(get_turf(target), get_turf(user)) <= 2))
 		return ..()
 	var/power = calculate_bomb()
-	qdel(bomb)
+	QDEL_NULL(bomb)
 	update_icon()
 	var/heavy = power * 0.2
 	var/medium = power * 0.5
 	var/light = power
-	user.visible_message("<span class='danger'>[user] opens \the [bomb] on \his [name] and fires a blast wave at \the [target]!</span>","<span class='danger'>You open \the [bomb] on your [name] and fire a blast wave at \the [target]!</span>")
+	user.visible_message("<span class='danger'>[user] opens [bomb] on \his [name] and fires a blast wave at [target]!</span>","<span class='danger'>You open [bomb] on your [name] and fire a blast wave at [target]!</span>")
 	playsound(user, "explosion", 100, 1)
 	var/turf/starting = get_turf(user)
 	var/turf/targturf = get_turf(target)
@@ -111,17 +109,21 @@
 
 /obj/item/projectile/blastwave/Range()
 	..()
+	var/amount_destruction = 0
 	if(heavyr)
-		loc.ex_act(EXPLODE_DEVASTATE)
+		amount_destruction = EXPLODE_DEVASTATE
 	else if(mediumr)
-		loc.ex_act(EXPLODE_HEAVY)
+		amount_destruction = EXPLODE_HEAVY
 	else if(lightr)
-		loc.ex_act(EXPLODE_LIGHT)
+		amount_destruction = EXPLODE_LIGHT
+	if(amount_destruction)
+		loc.ex_act(amount_destruction)
 	else
 		qdel(src)
-	heavyr--
-	mediumr--
-	lightr--
+
+	heavyr = max(heavyr - 1, 0)
+	mediumr = max(mediumr - 1, 0)
+	lightr = max(lightr - 1, 0)
 
 /obj/item/projectile/blastwave/ex_act()
 	return

--- a/code/modules/projectiles/guns/misc/blastcannon.dm
+++ b/code/modules/projectiles/guns/misc/blastcannon.dm
@@ -109,7 +109,7 @@
 
 /obj/item/projectile/blastwave/Range()
 	..()
-	var/amount_destruction = 0
+	var/amount_destruction = EXPLODE_NONE
 	if(heavyr)
 		amount_destruction = EXPLODE_DEVASTATE
 	else if(mediumr)

--- a/code/modules/projectiles/guns/misc/blastcannon.dm
+++ b/code/modules/projectiles/guns/misc/blastcannon.dm
@@ -79,7 +79,7 @@
 	var/heavy = power * 0.2
 	var/medium = power * 0.5
 	var/light = power
-	user.visible_message("<span class='danger'>[user] opens [bomb] on \his [name] and fires a blast wave at [target]!</span>","<span class='danger'>You open [bomb] on your [name] and fire a blast wave at [target]!</span>")
+	user.visible_message("<span class='danger'>[user] opens [bomb] on [user.p_their()] [name] and fires a blast wave at [target]!</span>","<span class='danger'>You open [bomb] on your [name] and fire a blast wave at [target]!</span>")
 	playsound(user, "explosion", 100, 1)
 	var/turf/starting = get_turf(user)
 	var/turf/targturf = get_turf(target)


### PR DESCRIPTION
@kevinz000 

Fixes the blast cannon being a weapon of mass destruction.

Basically, due to the logic of how the bullet would deal its damage, every time it would complete `Range`, it would reduce its `heavyr/mediumr/lightr` by 1, indiscriminately. This works out fine if your'e dealing with nice round numbers, but...usually you're not, so if it goes negative, `if(heavyr)` will always return true, and it will continue to call `loc.ex_act(EXPLODE_DEVASTATE)` on everything it hits, until it deletes 150 turfs later. This can be resolved by ensuring the value never goes below `0`.

Also cleans up some code so it's cleaner/less redundant.

Lastly, @kevinz000, do you still have plans for this gun? It's pretty interesting and unique and gives a hair more depth to Toxins.

