### PR TITLE
Circuits can't throw themselves

### DIFF
--- a/code/modules/integrated_electronics/subtypes/manipulation.dm
+++ b/code/modules/integrated_electronics/subtypes/manipulation.dm
@@ -490,7 +490,7 @@
 	var/target_y_rel = round(get_pin_data(IC_INPUT, 2))
 	var/obj/item/A = get_pin_data_as_type(IC_INPUT, 3, /obj/item)
 
-	if(!A || A.anchored || A.throwing)
+	if(!A || A.anchored || A.throwing || A == assembly)
 		return
 
 	if(max_w_class && (A.w_class > max_w_class))


### PR DESCRIPTION
:cl: JJRcop
fix: Integrated circuits can no longer throw themselves.
/:cl:

Here's what I think: If this bug should be in the game as a feature, it should be in a separate "leaper locomotion" circuit that costs more power than throwers.

If this isn't a bug feel free to change my CL and tags to balance change.