### PR TITLE
Significantly increases the power of apathy

### DIFF
--- a/code/datums/traits/good.dm
+++ b/code/datums/traits/good.dm
@@ -14,7 +14,7 @@
 /datum/trait/apathetic
 	name = "Apathetic"
 	desc = "You just don't care as much as other people. That's nice to have in a place like this, I guess."
-	value = 1
+	value = 2
 	mood_trait = TRUE
 
 /datum/trait/apathetic/add()

--- a/code/datums/traits/good.dm
+++ b/code/datums/traits/good.dm
@@ -20,7 +20,7 @@
 /datum/trait/apathetic/add()
 	GET_COMPONENT_FROM(mood, /datum/component/mood, trait_holder)
 	if(mood)
-		mood.mood_modifier = 0.8
+		mood.mood_modifier = 0.2
 
 /datum/trait/apathetic/remove()
 	GET_COMPONENT_FROM(mood, /datum/component/mood, trait_holder)


### PR DESCRIPTION
:cl: 
balance: The power of apathy has been greatly increased or something. Whatever.
/:cl:

>Add some sort of opt out trait for this since its so divisive. People who opt out will obviously be at a mechanical advantage over people suffering from bad moodlets, but they won't be able to reap the benefits of increased speed bars etc from good moodlets either. This idea is obviously deranged but the issue seems very divisive to the point a system everyone enjoys seems unlikely in the short term.

This is what I thought the Apathetic trait was intended for.
