### PR TITLE
Removes unused optimization from SendSignal

### DIFF
--- a/code/datums/components/_component.dm
+++ b/code/datums/components/_component.dm
@@ -118,17 +118,8 @@
 	if(!comps)
 		return NONE
 	var/list/arguments = args.Copy(2)
-	var/target = comps[/datum/component]
-	if(!length(target))
-		var/datum/component/C = target
-		if(!C.enabled)
-			return NONE
-		var/datum/callback/CB = C.signal_procs[sigtype]
-		if(!CB)
-			return NONE
-		return CB.InvokeAsync(arglist(arguments))
 	. = NONE
-	for(var/I in target)
+	for(var/I in comps[/datum/component])
 		var/datum/component/C = I
 		if(!C.enabled)
 			continue


### PR DESCRIPTION
When components we're initially made, if a datum only had one it'd be assigned directly to the `datum_components` var without lists. That was lost somewhere along the way so this isn't needed anymore