### PR TITLE
Fix runtimes in corpse code due to mob_spawners becoming null

### DIFF
--- a/code/modules/awaymissions/corpse.dm
+++ b/code/modules/awaymissions/corpse.dm
@@ -56,7 +56,7 @@
 	var/list/spawners = GLOB.mob_spawners[name]
 	LAZYREMOVE(spawners, src)
 	if(!LAZYLEN(spawners))
-		LAZYREMOVE(GLOB.mob_spawners,name)
+		GLOB.mob_spawners -= name
 	return ..()
 
 /obj/effect/mob_spawn/proc/special(mob/M)


### PR DESCRIPTION
```
Runtime in corpse.dm, line 52: bad index
proc name: Initialize (/obj/effect/mob_spawn/Initialize)
src: the broken rejuvenation pod (/obj/effect/mob_spawn/human/doctor/alive/lavaland)
src.loc: the floor (86,78,5) (/turf/open/floor/plasteel/white)
call stack:
the broken rejuvenation pod (/obj/effect/mob_spawn/human/doctor/alive/lavaland): Initialize(1)
the broken rejuvenation pod (/obj/effect/mob_spawn/human/doctor/alive/lavaland): Initialize(1)
Atoms (/datum/controller/subsystem/atoms): InitAtom(the broken rejuvenation pod (/obj/effect/mob_spawn/human/doctor/alive/lavaland), /list (/list))
Atoms (/datum/controller/subsystem/atoms): InitializeAtoms(null)
Atoms (/datum/controller/subsystem/atoms): Initialize(750073)
Master (/datum/controller/master): Initialize(10, 0)
```

```
Runtime in corpse.dm, line 56: bad index
proc name: Destroy (/obj/effect/mob_spawn/Destroy)
src: Clown (/obj/effect/mob_spawn/human/clown)
src.loc: the bananium floor (87,76,4) (/turf/open/floor/mineral/bananium/airless)
call stack:
Clown (/obj/effect/mob_spawn/human/clown): Destroy(0)
qdel(Clown (/obj/effect/mob_spawn/human/clown), 0)
Clown (/obj/effect/mob_spawn/human/clown): create(null, null)
Clown (/obj/effect/mob_spawn/human/clown): Initialize(1)
Clown (/obj/effect/mob_spawn/human/clown): Initialize(1)
Atoms (/datum/controller/subsystem/atoms): InitAtom(Clown (/obj/effect/mob_spawn/human/clown), /list (/list))
Atoms (/datum/controller/subsystem/atoms): InitializeAtoms(null)
Atoms (/datum/controller/subsystem/atoms): Initialize(750073)
Master (/datum/controller/master): Initialize(10, 0)
```