### PR TITLE
Fix the top menus in the skin not working

### DIFF
--- a/code/datums/verbs.dm
+++ b/code/datums/verbs.dm
@@ -78,7 +78,7 @@
 				if (childname == "[child.type]")
 					var/list/tree = splittext(childname, "/")
 					childname = tree[tree.len]
-				.[child.type] = "parent=[url_encode(type)];name=[url_encode(childname)]"
+				.[child.type] = "parent=[url_encode(type)];name=[childname]"
 				. += childlist
 
 	for (var/thing in verblist)
@@ -92,7 +92,7 @@
 			entry["command"] = copytext(verbpath.name,2)
 		else
 			entry["command"] = replacetext(verbpath.name, " ", "-")
-		
+
 		.[verbpath] = HandleVerb(arglist(list(entry, verbpath) + args))
 
 /world/proc/LoadVerbs(verb_type)

--- a/code/modules/client/client_procs.dm
+++ b/code/modules/client/client_procs.dm
@@ -374,7 +374,7 @@ GLOBAL_LIST_EMPTY(external_rsc_urls)
 		winset(src, "[topmenu.type]", "parent=menu;name=[url_encode(topmenuname)]")
 		var/list/entries = topmenu.Generate_list(src)
 		for (var/child in entries)
-			winset(src, "[url_encode(child)]", "[entries[child]]")
+			winset(src, "[child]", "[entries[child]]")
 			if (!ispath(child, /datum/verbs/menu))
 				var/atom/verb/verbpath = child
 				if (copytext(verbpath.name,1,2) != "@")


### PR DESCRIPTION
:cl:
fix: The top-left menus (icon scaling, ghost preferences, etc.) now work again.
/:cl:

Fixes #37317. Fixes #37563.

Broke in build 512.1420 which changed how `urlencode` works, apparently it percent-encodes `/` now when it didn't before. Works On My Machine:tm: but probably deserves a test merge given how blackmagic this code is.