### PR TITLE
Fix placing boxes in storage implants

### DIFF
--- a/code/datums/components/storage/concrete/implant.dm
+++ b/code/datums/components/storage/concrete/implant.dm
@@ -5,6 +5,7 @@
 	drop_all_on_destroy = TRUE
 	drop_all_on_deconstruct = TRUE
 	silent = TRUE
+	allow_big_nesting = TRUE
 
 /datum/component/storage/concrete/implant/Initialize()
 	. = ..()


### PR DESCRIPTION
:cl:
fix: Boxes now fit inside storage implants again.
/:cl:

Fixes #37555. The implant is supposed to be bluespace so this makes sense.

Removing storage implants still deletes everything inside them, not sure if that's intended?