### PR TITLE
Morphs now take the entire tile regardless of their current form

### DIFF
--- a/code/modules/antagonists/morph/morph.dm
+++ b/code/modules/antagonists/morph/morph.dm
@@ -105,6 +105,7 @@
 	copy_overlays(target)
 	alpha = max(alpha, 150)	//fucking chameleons
 	transform = initial(transform)
+	mouse_opacity = MOUSE_OPACITY_OPAQUE
 	pixel_y = initial(pixel_y)
 	pixel_x = initial(pixel_x)
 
@@ -126,6 +127,7 @@
 	form = null
 	alpha = initial(alpha)
 	color = initial(color)
+	mouse_opacity = initial(mouse_opacity)
 	maptext = null
 
 	visible_message("<span class='warning'>[src] suddenly collapses in on itself, dissolving into a pile of green flesh!</span>", \


### PR DESCRIPTION
Yeah uh, itś pretty dumb when morphs transform into a very tiny object and youŕe force to either use a gun which not everyone has, or click on the 3 pixels that it is at the moment while itś still able to smash everything and attack you.