### PR TITLE
Reorganizes cargo's big "miscellaneous supplies" category

### DIFF
--- a/code/modules/cargo/packs.dm
+++ b/code/modules/cargo/packs.dm
@@ -1332,7 +1332,7 @@
 					/obj/item/flashlight/glowstick/pink)
 	crate_name = "party equipment crate"
 
-/datum/supply_pack/service/janitor/lightbulbs
+/datum/supply_pack/service/lightbulbs
 	name = "Replacement Lights"
 	desc = "May the light of Aether shine upon this station! Or at least, the light of forty two light tubes and twenty one light bulbs."
 	cost = 1000
@@ -1356,7 +1356,7 @@
 	crate_name = "shaft miner starter kit"
 	crate_type = /obj/structure/closet/crate/secure
 
-/datum/supply_pack/service/vending
+/datum/supply_pack/service/vending/bartending
 	name = "Bartending Supply Crate"
 	desc = "Bring on the booze with six vending machine refills, as well as a free book containing the well-kept secrets to the bartending trade!"
 	cost = 2000
@@ -1541,7 +1541,7 @@
 	crate_name = "potted plants crate"
 	crate_type = /obj/structure/closet/crate/hydroponics
 
-/datum/supply_pack/organic/hydroponics/seeds
+/datum/supply_pack/organic/seeds
 	name = "Seeds Crate"
 	desc = "Big things have small beginnings. Contains thirteen different seeds."
 	cost = 1000
@@ -1561,7 +1561,7 @@
 	crate_name = "seeds crate"
 	crate_type = /obj/structure/closet/crate/hydroponics
 
-/datum/supply_pack/organic/hydroponics/exoticseeds
+/datum/supply_pack/organic/exoticseeds
 	name = "Exotic Seeds Crate"
 	desc = "Any entrepreneuring botanist's dream. Contains twelve different seeds, including three replica-pod seeds and two mystery seeds!"
 	cost = 1500

--- a/code/modules/cargo/packs.dm
+++ b/code/modules/cargo/packs.dm
@@ -554,6 +554,20 @@
 					/obj/machinery/shieldgen)
 	crate_name = "anti-breach shield projector crate"
 
+/datum/supply_pack/engineering/conveyor
+	name = "Conveyor Assembly Crate"
+	desc = "Keep production moving along with six conveyor belts. Conveyor switch included. If you have any questions, check out the enclosed instruction book."
+	cost = 1500
+	contains = list(/obj/item/conveyor_construct,
+					/obj/item/conveyor_construct,
+					/obj/item/conveyor_construct,
+					/obj/item/conveyor_construct,
+					/obj/item/conveyor_construct,
+					/obj/item/conveyor_construct,
+					/obj/item/conveyor_switch_construct,
+					/obj/item/paper/guides/conveyor)
+	crate_name = "conveyor assembly crate"
+
 /datum/supply_pack/engineering/engiequipment
 	name = "Engineering Gear Crate"
 	desc = "Gear up with three toolbelts, high-visibility vests, welding helmets, hardhats, and two pairs of meson goggles!"
@@ -582,8 +596,9 @@
 					/obj/item/clothing/gloves/color/yellow,
 					/obj/item/clothing/gloves/color/yellow)
 	crate_name = "insulated gloves crate"
+	crate_type = /obj/structure/closet/crate/engineering/electrical
 
-/obj/item/stock_parts/cell/inducer_supply//what is this doing here
+/obj/item/stock_parts/cell/inducer_supply
 	maxcharge = 5000
 	charge = 5000
 
@@ -634,155 +649,6 @@
 					/obj/item/storage/toolbox/mechanical)
 	cost = 1000
 	crate_name = "toolbox crate"
-
-/datum/supply_pack/engineering/engine/am_jar
-	name = "Antimatter Containment Jar Crate"
-	desc = "Two Antimatter containment jars stuffed into a single crate."
-	cost = 2000
-	contains = list(/obj/item/am_containment,
-					/obj/item/am_containment)
-	crate_name = "antimatter jar crate"
-
-/datum/supply_pack/engineering/engine/am_core
-	name = "Antimatter Control Crate"
-	desc = "The brains of the Antimatter engine, this device is sure to teach the station's powergrid the true meaning of real power."
-	cost = 5000
-	contains = list(/obj/machinery/power/am_control_unit)
-	crate_name = "antimatter control crate"
-
-/datum/supply_pack/engineering/engine/am_shielding
-	name = "Antimatter Shielding Crate"
-	desc = "Contains ten Antimatter shields, somehow crammed into a crate."
-	cost = 2000
-	contains = list(/obj/item/am_shielding_container,
-					/obj/item/am_shielding_container,
-					/obj/item/am_shielding_container,
-					/obj/item/am_shielding_container,
-					/obj/item/am_shielding_container,
-					/obj/item/am_shielding_container,
-					/obj/item/am_shielding_container,
-					/obj/item/am_shielding_container,
-					/obj/item/am_shielding_container,
-					/obj/item/am_shielding_container) //10 shields: 3x3 containment and a core
-	crate_name = "antimatter shielding crate"
-
-/datum/supply_pack/engineering/engine
-	name = "Emitter Crate"
-	desc = "Useful for powering forcefield generators while destroying locked crates and intruders alike. Contains two high-powered energy emitters. Requires CE access to open."
-	cost = 1500
-	access = ACCESS_CE
-	contains = list(/obj/machinery/power/emitter,
-					/obj/machinery/power/emitter)
-	crate_name = "emitter crate"
-	crate_type = /obj/structure/closet/crate/secure/engineering
-	dangerous = TRUE
-
-/datum/supply_pack/engineering/engine/field_gen
-	name = "Field Generator Crate"
-	desc = "Typically the only thing standing between the station and a messy death. Powered by emitters. Contains two field generators."
-	cost = 1500
-	contains = list(/obj/machinery/field/generator,
-					/obj/machinery/field/generator)
-	crate_name = "field generator crate"
-
-/datum/supply_pack/engineering/grounding_rods
-	name = "Grounding Rod Crate"
-	desc = "Four grounding rods guaranteed to keep any uppity tesla's lightning under control."
-	cost = 1700
-	contains = list(/obj/machinery/power/grounding_rod,
-					/obj/machinery/power/grounding_rod,
-					/obj/machinery/power/grounding_rod,
-					/obj/machinery/power/grounding_rod)
-	crate_name = "grounding rod crate"
-	crate_type = /obj/structure/closet/crate/engineering/electrical
-
-/datum/supply_pack/engineering/engine/PA
-	name = "Particle Accelerator Crate"
-	desc = "A supermassive black hole or hyper-powered teslaball are the perfect way to spice up any party! This \"My First Apocalypse\" kit contains everything you need to build your own Particle Accelerator! Ages 10 and up."
-	cost = 3000
-	contains = list(/obj/structure/particle_accelerator/fuel_chamber,
-					/obj/machinery/particle_accelerator/control_box,
-					/obj/structure/particle_accelerator/particle_emitter/center,
-					/obj/structure/particle_accelerator/particle_emitter/left,
-					/obj/structure/particle_accelerator/particle_emitter/right,
-					/obj/structure/particle_accelerator/power_box,
-					/obj/structure/particle_accelerator/end_cap)
-	crate_name = "particle accelerator crate"
-
-/datum/supply_pack/engineering/engine/collector
-	name = "Radiation Collector Crate"
-	desc = "Contains three radiation collectors. Useful for collecting energy off nearby Supermatter Crystals, Singularities or Teslas!"
-	cost = 2500
-	contains = list(/obj/machinery/power/rad_collector,
-					/obj/machinery/power/rad_collector,
-					/obj/machinery/power/rad_collector)
-	crate_name = "collector crate"
-
-/datum/supply_pack/engineering/engine/sing_gen
-	name = "Singularity Generator Crate"
-	desc = "The key to unlocking the power of Lord Singuloth. Particle Accelerator not included."
-	cost = 5000
-	contains = list(/obj/machinery/the_singularitygen)
-	crate_name = "singularity generator crate"
-
-/datum/supply_pack/engineering/solar
-	name = "Solar Panel Crate"
-	desc = "Go green with this DIY advanced solar array. Contains twenty one solar assemblies, a solar-control circuit board, and tracker. If you have any questions, please check out the enclosed instruction book."
-	cost = 2000
-	contains  = list(/obj/item/solar_assembly,
-					/obj/item/solar_assembly,
-					/obj/item/solar_assembly,
-					/obj/item/solar_assembly,
-					/obj/item/solar_assembly,
-					/obj/item/solar_assembly,
-					/obj/item/solar_assembly,
-					/obj/item/solar_assembly,
-					/obj/item/solar_assembly,
-					/obj/item/solar_assembly,
-					/obj/item/solar_assembly,
-					/obj/item/solar_assembly,
-					/obj/item/solar_assembly,
-					/obj/item/solar_assembly,
-					/obj/item/solar_assembly,
-					/obj/item/solar_assembly,
-					/obj/item/solar_assembly,
-					/obj/item/solar_assembly,
-					/obj/item/solar_assembly,
-					/obj/item/solar_assembly,
-					/obj/item/solar_assembly,
-					/obj/item/circuitboard/computer/solar_control,
-					/obj/item/electronics/tracker,
-					/obj/item/paper/guides/jobs/engi/solars)
-	crate_name = "solar panel crate"
-	crate_type = /obj/structure/closet/crate/engineering/electrical
-
-/datum/supply_pack/engineering/engine/supermatter_crystal
-	name = "Supermatter Shard Crate"
-	desc = "The power of the heavens condensed into a single crystal. Requires CE access to open."
-	cost = 10000
-	access = ACCESS_CE
-	contains = list(/obj/machinery/power/supermatter_crystal/shard)
-	crate_name = "supermatter shard crate"
-	crate_type = /obj/structure/closet/crate/secure/engineering
-	dangerous = TRUE
-	
-/datum/supply_pack/engineering/engine/tesla_coils
-	name = "Tesla Coil Crate"
-	desc = "Whether it's high-voltage executions, creating research points, or just plain old power generation: This pack of four Tesla coils can do it all!"
-	cost = 2500
-	contains = list(/obj/machinery/power/tesla_coil,
-					/obj/machinery/power/tesla_coil,
-					/obj/machinery/power/tesla_coil,
-					/obj/machinery/power/tesla_coil)
-	crate_name = "tesla coil crate"
-	crate_type = /obj/structure/closet/crate/engineering/electrical
-
-/datum/supply_pack/engineering/engine/tesla_gen
-	name = "Tesla Generator Crate"
-	desc = "The key to unlocking the power of the Tesla energy ball. Particle Accelerator not included."
-	cost = 5000
-	contains = list(/obj/machinery/the_singularitygen/tesla)
-	crate_name = "tesla generator crate"
 
 /datum/supply_pack/engineering/bsa
 	name = "Bluespace Artillery Parts"
@@ -846,8 +712,166 @@
 	contains = list(/obj/item/circuitboard/computer/sat_control)
 	crate_name= "shield control board crate"
 
+
 //////////////////////////////////////////////////////////////////////////////
-//////////////////////// Canisters & Materials////////////////////////////////
+//////////////////////// Engine Construction /////////////////////////////////
+//////////////////////////////////////////////////////////////////////////////	
+
+/datum/supply_pack/engine
+	group = "Engine Construction"
+	crate_type = /obj/structure/closet/crate/engineering
+
+/datum/supply_pack/engine/am_jar
+	name = "Antimatter Containment Jar Crate"
+	desc = "Two Antimatter containment jars stuffed into a single crate."
+	cost = 2000
+	contains = list(/obj/item/am_containment,
+					/obj/item/am_containment)
+	crate_name = "antimatter jar crate"
+
+/datum/supply_pack/engine/am_core
+	name = "Antimatter Control Crate"
+	desc = "The brains of the Antimatter engine, this device is sure to teach the station's powergrid the true meaning of real power."
+	cost = 5000
+	contains = list(/obj/machinery/power/am_control_unit)
+	crate_name = "antimatter control crate"
+
+/datum/supply_pack/engine/am_shielding
+	name = "Antimatter Shielding Crate"
+	desc = "Contains ten Antimatter shields, somehow crammed into a crate."
+	cost = 2000
+	contains = list(/obj/item/am_shielding_container,
+					/obj/item/am_shielding_container,
+					/obj/item/am_shielding_container,
+					/obj/item/am_shielding_container,
+					/obj/item/am_shielding_container,
+					/obj/item/am_shielding_container,
+					/obj/item/am_shielding_container,
+					/obj/item/am_shielding_container,
+					/obj/item/am_shielding_container,
+					/obj/item/am_shielding_container) //10 shields: 3x3 containment and a core
+	crate_name = "antimatter shielding crate"
+
+/datum/supply_pack/engine/emitter
+	name = "Emitter Crate"
+	desc = "Useful for powering forcefield generators while destroying locked crates and intruders alike. Contains two high-powered energy emitters. Requires CE access to open."
+	cost = 1500
+	access = ACCESS_CE
+	contains = list(/obj/machinery/power/emitter,
+					/obj/machinery/power/emitter)
+	crate_name = "emitter crate"
+	crate_type = /obj/structure/closet/crate/secure/engineering
+	dangerous = TRUE
+
+/datum/supply_pack/engine/field_gen
+	name = "Field Generator Crate"
+	desc = "Typically the only thing standing between the station and a messy death. Powered by emitters. Contains two field generators."
+	cost = 1500
+	contains = list(/obj/machinery/field/generator,
+					/obj/machinery/field/generator)
+	crate_name = "field generator crate"
+
+/datum/supply_pack/engine/grounding_rods
+	name = "Grounding Rod Crate"
+	desc = "Four grounding rods guaranteed to keep any uppity tesla's lightning under control."
+	cost = 1700
+	contains = list(/obj/machinery/power/grounding_rod,
+					/obj/machinery/power/grounding_rod,
+					/obj/machinery/power/grounding_rod,
+					/obj/machinery/power/grounding_rod)
+	crate_name = "grounding rod crate"
+	crate_type = /obj/structure/closet/crate/engineering/electrical
+
+/datum/supply_pack/engine/PA
+	name = "Particle Accelerator Crate"
+	desc = "A supermassive black hole or hyper-powered teslaball are the perfect way to spice up any party! This \"My First Apocalypse\" kit contains everything you need to build your own Particle Accelerator! Ages 10 and up."
+	cost = 3000
+	contains = list(/obj/structure/particle_accelerator/fuel_chamber,
+					/obj/machinery/particle_accelerator/control_box,
+					/obj/structure/particle_accelerator/particle_emitter/center,
+					/obj/structure/particle_accelerator/particle_emitter/left,
+					/obj/structure/particle_accelerator/particle_emitter/right,
+					/obj/structure/particle_accelerator/power_box,
+					/obj/structure/particle_accelerator/end_cap)
+	crate_name = "particle accelerator crate"
+
+/datum/supply_pack/engine/collector
+	name = "Radiation Collector Crate"
+	desc = "Contains three radiation collectors. Useful for collecting energy off nearby Supermatter Crystals, Singularities or Teslas!"
+	cost = 2500
+	contains = list(/obj/machinery/power/rad_collector,
+					/obj/machinery/power/rad_collector,
+					/obj/machinery/power/rad_collector)
+	crate_name = "collector crate"
+
+/datum/supply_pack/engine/sing_gen
+	name = "Singularity Generator Crate"
+	desc = "The key to unlocking the power of Lord Singuloth. Particle Accelerator not included."
+	cost = 5000
+	contains = list(/obj/machinery/the_singularitygen)
+	crate_name = "singularity generator crate"
+
+/datum/supply_pack/engine/solar
+	name = "Solar Panel Crate"
+	desc = "Go green with this DIY advanced solar array. Contains twenty one solar assemblies, a solar-control circuit board, and tracker. If you have any questions, please check out the enclosed instruction book."
+	cost = 2000
+	contains  = list(/obj/item/solar_assembly,
+					/obj/item/solar_assembly,
+					/obj/item/solar_assembly,
+					/obj/item/solar_assembly,
+					/obj/item/solar_assembly,
+					/obj/item/solar_assembly,
+					/obj/item/solar_assembly,
+					/obj/item/solar_assembly,
+					/obj/item/solar_assembly,
+					/obj/item/solar_assembly,
+					/obj/item/solar_assembly,
+					/obj/item/solar_assembly,
+					/obj/item/solar_assembly,
+					/obj/item/solar_assembly,
+					/obj/item/solar_assembly,
+					/obj/item/solar_assembly,
+					/obj/item/solar_assembly,
+					/obj/item/solar_assembly,
+					/obj/item/solar_assembly,
+					/obj/item/solar_assembly,
+					/obj/item/solar_assembly,
+					/obj/item/circuitboard/computer/solar_control,
+					/obj/item/electronics/tracker,
+					/obj/item/paper/guides/jobs/engi/solars)
+	crate_name = "solar panel crate"
+	crate_type = /obj/structure/closet/crate/engineering/electrical
+
+/datum/supply_pack/engine/supermatter_shard
+	name = "Supermatter Shard Crate"
+	desc = "The power of the heavens condensed into a single crystal. Requires CE access to open."
+	cost = 10000
+	access = ACCESS_CE
+	contains = list(/obj/machinery/power/supermatter_crystal/shard)
+	crate_name = "supermatter shard crate"
+	crate_type = /obj/structure/closet/crate/secure/engineering
+	dangerous = TRUE
+	
+/datum/supply_pack/engine/tesla_coils
+	name = "Tesla Coil Crate"
+	desc = "Whether it's high-voltage executions, creating research points, or just plain old power generation: This pack of four Tesla coils can do it all!"
+	cost = 2500
+	contains = list(/obj/machinery/power/tesla_coil,
+					/obj/machinery/power/tesla_coil,
+					/obj/machinery/power/tesla_coil,
+					/obj/machinery/power/tesla_coil)
+	crate_name = "tesla coil crate"
+	crate_type = /obj/structure/closet/crate/engineering/electrical
+
+/datum/supply_pack/engine/tesla_gen
+	name = "Tesla Generator Crate"
+	desc = "The key to unlocking the power of the Tesla energy ball. Particle Accelerator not included."
+	cost = 5000
+	contains = list(/obj/machinery/the_singularitygen/tesla)
+	crate_name = "tesla generator crate"
+
+//////////////////////////////////////////////////////////////////////////////
+/////////////////////// Canisters & Materials ////////////////////////////////
 //////////////////////////////////////////////////////////////////////////////
 
 /datum/supply_pack/materials
@@ -990,7 +1014,6 @@
 /datum/supply_pack/medical
 	group = "Medical"
 	crate_type = /obj/structure/closet/crate/medical
-
 
 /datum/supply_pack/medical/firstaidbruises
 	name = "Bruise Treatment Kit Crate"
@@ -1228,11 +1251,168 @@
 	dangerous = TRUE
 
 //////////////////////////////////////////////////////////////////////////////
+/////////////////////////////// Service //////////////////////////////////////
+//////////////////////////////////////////////////////////////////////////////
+
+/datum/supply_pack/service
+	group = "Service"
+
+/datum/supply_pack/service/noslipfloor
+	name = "High-traction Floor Tiles"
+	desc = "Make slipping a thing of the past with thirty industrial-grade anti-slip floortiles!"
+	cost = 2000
+	contains = list(/obj/item/stack/tile/noslip/thirty)
+	crate_name = "high-traction floor tiles crate"
+
+/datum/supply_pack/service/janitor
+	name = "Janitorial Supplies Crate"
+	desc = "Fight back against dirt and grime with Nanotrasen's Janitorial Essentials(tm)! Contains three buckets, caution signs, and cleaner grenades. Also has a single mop, spray cleaner, rag, and trash bag."
+	cost = 1000
+	contains = list(/obj/item/reagent_containers/glass/bucket,
+					/obj/item/reagent_containers/glass/bucket,
+					/obj/item/reagent_containers/glass/bucket,
+					/obj/item/mop,
+					/obj/item/caution,
+					/obj/item/caution,
+					/obj/item/caution,
+					/obj/item/storage/bag/trash,
+					/obj/item/reagent_containers/spray/cleaner,
+					/obj/item/reagent_containers/glass/rag,
+					/obj/item/grenade/chem_grenade/cleaner,
+					/obj/item/grenade/chem_grenade/cleaner,
+					/obj/item/grenade/chem_grenade/cleaner)
+	crate_name = "janitorial supplies crate"
+
+/datum/supply_pack/service/janitor/janicart
+	name = "Janitorial Cart and Galoshes Crate"
+	desc = "The keystone to any successful janitor. As long as you have feet, this pair of galoshes will keep them firmly planted on the ground. Also contains a janitorial cart."
+	cost = 2000
+	contains = list(/obj/structure/janitorialcart,
+					/obj/item/clothing/shoes/galoshes)
+	crate_name = "janitorial cart crate"
+	crate_type = /obj/structure/closet/crate/large
+
+/datum/supply_pack/service/janitor/janitank
+	name = "Janitor Backpack Crate"
+	desc = "Call forth divine judgement upon dirt and grime with this high capacity janitor backpack. Contains 500 units of station-cleansing cleaner. Requires janitor access to open."
+	cost = 1000
+	access = ACCESS_JANITOR
+	contains = list(/obj/item/watertank/janitor)
+	crate_name = "janitor backpack crate"
+	crate_type = /obj/structure/closet/crate/secure
+
+/datum/supply_pack/service/mule
+	name = "MULEbot Crate"
+	desc = "Pink-haired Quartermaster not doing her job? Replace her with this tireless worker, today!"
+	cost = 2000
+	contains = list(/mob/living/simple_animal/bot/mulebot)
+	crate_name = "\improper MULEbot Crate"
+	crate_type = /obj/structure/closet/crate/large
+
+/datum/supply_pack/service/party
+	name = "Party Equipment"
+	desc = "Celebrate both life and death on the station with Nanotrasen's Party Essentials(tm)! Contains seven colored glowsticks, four beers, two ales, and a bottle of patron, goldschlager, and shaker!"
+	cost = 2000
+	contains = list(/obj/item/storage/box/drinkingglasses,
+					/obj/item/reagent_containers/food/drinks/shaker,
+					/obj/item/reagent_containers/food/drinks/bottle/patron,
+					/obj/item/reagent_containers/food/drinks/bottle/goldschlager,
+					/obj/item/reagent_containers/food/drinks/ale,
+					/obj/item/reagent_containers/food/drinks/ale,
+					/obj/item/reagent_containers/food/drinks/beer,
+					/obj/item/reagent_containers/food/drinks/beer,
+					/obj/item/reagent_containers/food/drinks/beer,
+					/obj/item/reagent_containers/food/drinks/beer,
+					/obj/item/flashlight/glowstick,
+					/obj/item/flashlight/glowstick/red,
+					/obj/item/flashlight/glowstick/blue,
+					/obj/item/flashlight/glowstick/cyan,
+					/obj/item/flashlight/glowstick/orange,
+					/obj/item/flashlight/glowstick/yellow,
+					/obj/item/flashlight/glowstick/pink)
+	crate_name = "party equipment crate"
+
+/datum/supply_pack/service/janitor/lightbulbs
+	name = "Replacement Lights"
+	desc = "May the light of Aether shine upon this station! Or at least, the light of forty two light tubes and twenty one light bulbs."
+	cost = 1000
+	contains = list(/obj/item/storage/box/lights/mixed,
+					/obj/item/storage/box/lights/mixed,
+					/obj/item/storage/box/lights/mixed)
+	crate_name = "replacement lights"
+
+/datum/supply_pack/service/minerkit
+	name = "Shaft Miner Starter Kit"
+	desc = "All the miners died too fast? Assistant wants to get a taste of life off-station? Either way, this kit is the best way to turn a regular crewman into an ore-producing, monster-slaying machine. Contains meson goggles, a pickaxe, advanced mining scanner, cargo headset, ore bag, gasmask, and explorer suit. Requires QM access to open."
+	cost = 2500
+	access = ACCESS_QM
+	contains = list(/obj/item/pickaxe/mini,
+			/obj/item/clothing/glasses/meson,
+			/obj/item/t_scanner/adv_mining_scanner/lesser,
+			/obj/item/radio/headset/headset_cargo/mining,
+			/obj/item/storage/bag/ore,
+			/obj/item/clothing/suit/hooded/explorer,
+			/obj/item/clothing/mask/gas/explorer)
+	crate_name = "shaft miner starter kit"
+	crate_type = /obj/structure/closet/crate/secure
+
+/datum/supply_pack/service/vending
+	name = "Bartending Supply Crate"
+	desc = "Bring on the booze with six vending machine refills, as well as a free book containing the well-kept secrets to the bartending trade!"
+	cost = 2000
+	contains = list(/obj/item/vending_refill/boozeomat,
+					/obj/item/vending_refill/boozeomat,
+					/obj/item/vending_refill/boozeomat,
+					/obj/item/vending_refill/coffee,
+					/obj/item/vending_refill/coffee,
+					/obj/item/vending_refill/coffee,
+					/obj/item/book/granter/action/drink_fling)
+	crate_name = "bartending supply crate"
+
+/datum/supply_pack/service/vending/cigarette
+	name = "Cigarette Supply Crate"
+	desc = "Don't believe the reports - smoke today! Contains cigarette vending machine refills."
+	cost = 1500
+	contains = list(/obj/item/vending_refill/cigarette,
+					/obj/item/vending_refill/cigarette,
+					/obj/item/vending_refill/cigarette)
+	crate_name = "cigarette supply crate"
+	crate_type = /obj/structure/closet/crate
+
+/datum/supply_pack/service/vending/games
+	name = "Games Supply Crate"
+	desc = "Get your game on with these three game vending machine refills."
+	cost = 1000
+	contains = list(/obj/item/vending_refill/games,
+					/obj/item/vending_refill/games,
+					/obj/item/vending_refill/games)
+	crate_name = "games supply crate"
+	crate_type = /obj/structure/closet/crate
+
+/datum/supply_pack/service/vending/snack
+	name = "Snack Supply Crate"
+	desc = "Three vending machine refills of cavity-bringin' goodness! The number one dentist recommended order!"
+	cost = 1500
+	contains = list(/obj/item/vending_refill/snack,
+					/obj/item/vending_refill/snack,
+					/obj/item/vending_refill/snack)
+	crate_name = "snacks supply crate"
+
+/datum/supply_pack/service/vending/cola
+	name = "Softdrinks Supply Crate"
+	desc = "Got whacked by a toolbox, but you still have those pesky teeth? Get rid of those pearly whites with these three soda machine refills, today!"
+	cost = 1500
+	contains = list(/obj/item/vending_refill/cola,
+					/obj/item/vending_refill/cola,
+					/obj/item/vending_refill/cola)
+	crate_name = "soft drinks supply crate"
+	
+//////////////////////////////////////////////////////////////////////////////
 //////////////////////////// Organic /////////////////////////////////////////
 //////////////////////////////////////////////////////////////////////////////
 
 /datum/supply_pack/organic
-	group = "Food & Livestock"
+	group = "Food & Hydroponics"
 	crate_type = /obj/structure/closet/crate/freezer
 
 /datum/supply_pack/organic/hydroponics/beekeeping_suits
@@ -1244,6 +1424,22 @@
 					/obj/item/clothing/head/beekeeper_head,
 					/obj/item/clothing/suit/beekeeper_suit)
 	crate_name = "beekeeper suits"
+	crate_type = /obj/structure/closet/crate/hydroponics
+
+/datum/supply_pack/organic/hydroponics/beekeeping_fullkit
+	name = "Beekeeping Starter Crate"
+	desc = "BEES BEES BEES. Contains three honey frames, a beekeeper suit and helmet, flyswatter, bee house, and, of course, a pure-bred Nanotrasen-Standardized Queen Bee!"
+	cost = 1500
+	contains = list(/obj/structure/beebox,
+					/obj/item/honey_frame,
+					/obj/item/honey_frame,
+					/obj/item/honey_frame,
+					/obj/item/queen_bee/bought,
+					/obj/item/clothing/head/beekeeper_head,
+					/obj/item/clothing/suit/beekeeper_suit,
+					/obj/item/melee/flyswatter)
+	crate_name = "beekeeping starter crate"
+	crate_type = /obj/structure/closet/crate/hydroponics
 
 /datum/supply_pack/organic/food
 	name = "Food Crate"
@@ -1263,20 +1459,6 @@
 					/obj/item/reagent_containers/food/snacks/grown/banana,
 					/obj/item/reagent_containers/food/snacks/grown/banana)
 	crate_name = "food crate"
-
-/datum/supply_pack/organic/hydroponics/beekeeping_fullkit
-	name = "Beekeeping Starter Crate"
-	desc = "BEES BEES BEES. Contains three honey frames, a beekeeper suit and helmet, flyswatter, bee house, and, of course, a pure-bred Nanotrasen-Standardized Queen Bee!"
-	cost = 1500
-	contains = list(/obj/structure/beebox,
-					/obj/item/honey_frame,
-					/obj/item/honey_frame,
-					/obj/item/honey_frame,
-					/obj/item/queen_bee/bought,
-					/obj/item/clothing/head/beekeeper_head,
-					/obj/item/clothing/suit/beekeeper_suit,
-					/obj/item/melee/flyswatter)
-	crate_name = "beekeeping starter crate"
 
 /datum/supply_pack/organic/cream_piee
 	name = "High-yield Clown-grade Cream Pie Crate"
@@ -1312,36 +1494,6 @@
 	contains = list(/obj/item/watertank)
 	crate_name = "hydroponics backpack crate"
 	crate_type = /obj/structure/closet/crate/secure
-
-/datum/supply_pack/organic/monkey
-	name = "Monkey Cube Crate"
-	desc = "Stop monkeying around! Contains seven monkey cubes. Just add water!"
-	cost = 2000
-	contains = list (/obj/item/storage/box/monkeycubes)
-	crate_name = "monkey cube crate"
-
-/datum/supply_pack/organic/party
-	name = "Party Equipment"
-	desc = "Celebrate both life and death on the station with Nanotrasen's Party Essentials(tm)! Contains seven colored glowsticks, four beers, two ales, and a bottle of patron, goldschlager, and shaker!"
-	cost = 2000
-	contains = list(/obj/item/storage/box/drinkingglasses,
-					/obj/item/reagent_containers/food/drinks/shaker,
-					/obj/item/reagent_containers/food/drinks/bottle/patron,
-					/obj/item/reagent_containers/food/drinks/bottle/goldschlager,
-					/obj/item/reagent_containers/food/drinks/ale,
-					/obj/item/reagent_containers/food/drinks/ale,
-					/obj/item/reagent_containers/food/drinks/beer,
-					/obj/item/reagent_containers/food/drinks/beer,
-					/obj/item/reagent_containers/food/drinks/beer,
-					/obj/item/reagent_containers/food/drinks/beer,
-					/obj/item/flashlight/glowstick,
-					/obj/item/flashlight/glowstick/red,
-					/obj/item/flashlight/glowstick/blue,
-					/obj/item/flashlight/glowstick/cyan,
-					/obj/item/flashlight/glowstick/orange,
-					/obj/item/flashlight/glowstick/yellow,
-					/obj/item/flashlight/glowstick/pink)
-	crate_name = "party equipment crate"
 
 /datum/supply_pack/organic/pizza
 	name = "Pizza Crate"
@@ -1407,6 +1559,7 @@
 					/obj/item/seeds/potato,
 					/obj/item/seeds/sugarcane)
 	crate_name = "seeds crate"
+	crate_type = /obj/structure/closet/crate/hydroponics
 
 /datum/supply_pack/organic/hydroponics/exoticseeds
 	name = "Exotic Seeds Crate"
@@ -1425,11 +1578,17 @@
 					/obj/item/seeds/random,
 					/obj/item/seeds/random)
 	crate_name = "exotic seeds crate"
+	crate_type = /obj/structure/closet/crate/hydroponics
 
-/datum/supply_pack/organic/critter
+//////////////////////////////////////////////////////////////////////////////
+////////////////////////////// Livestock /////////////////////////////////////
+//////////////////////////////////////////////////////////////////////////////
+
+/datum/supply_pack/critter
+	group = "Livestock"
 	crate_type = /obj/structure/closet/crate/critter
 
-/datum/supply_pack/organic/critter/butterfly
+/datum/supply_pack/critter/butterfly
 	name = "Butterflies Crate"
 	desc = "Not a very dangerous insect, but they do give off a better image than, say, flies or cockroaches."//is that a motherfucking worm reference
 	contraband = TRUE
@@ -1437,12 +1596,12 @@
 	contains = list(/mob/living/simple_animal/butterfly)
 	crate_name = "entomology samples crate"
 
-/datum/supply_pack/organic/critter/butterfly/generate()
+/datum/supply_pack/critter/butterfly/generate()
 	. = ..()
 	for(var/i in 1 to 49)
 		new /mob/living/simple_animal/butterfly(.)
 
-/datum/supply_pack/organic/critter/cat
+/datum/supply_pack/critter/cat
 	name = "Cat Crate"
 	desc = "The cat goes meow! Comes with a collar and a nice cat toy! Cheeseburger not included."//i can't believe im making this reference
 	cost = 5000 //Cats are worth as much as corgis.
@@ -1451,21 +1610,21 @@
                     /obj/item/toy/cattoy)
 	crate_name = "cat crate"
 
-/datum/supply_pack/organic/critter/cat/generate()
+/datum/supply_pack/critter/cat/generate()
 	. = ..()
 	if(prob(50))
 		var/mob/living/simple_animal/pet/cat/C = locate() in .
 		qdel(C)
 		new /mob/living/simple_animal/pet/cat/Proc(.)
 
-/datum/supply_pack/organic/critter/chick
+/datum/supply_pack/critter/chick
 	name = "Chicken Crate"
 	desc = "The chicken goes bwaak!"
 	cost = 2000
 	contains = list( /mob/living/simple_animal/chick)
 	crate_name = "chicken crate"
 
-/datum/supply_pack/organic/critter/crab
+/datum/supply_pack/critter/crab
 	name = "Crab Rocket"
 	desc = "CRAAAAAAB ROCKET. CRAB ROCKET. CRAB ROCKET. CRAB CRAB CRAB CRAB CRAB CRAB CRAB CRAB CRAB CRAB CRAB CRAB CRAB CRAB CRAB CRAB CRAB CRAB CRAB CRAB CRAB CRAB CRAB CRAB CRAB CRAB CRAB CRAB CRAB CRAB CRAB CRAB CRAB CRAB CRAB CRAB CRAB CRAB CRAB CRAB CRAB CRAB CRAB CRAB CRAB CRAB CRAB ROCKET. CRAFT. ROCKET. BUY. CRAFT ROCKET. CRAB ROOOCKET. CRAB ROOOOCKET. CRAB CRAB CRAB CRAB CRAB CRAB CRAB CRAB ROOOOOOOOOOOOOOOOOOOOOOCK EEEEEEEEEEEEEEEEEEEEEEEEE EEEETTTTTTTTTTTTAAAAAAAAA AAAHHHHHHHHHHHHH. CRAB ROCKET. CRAAAB ROCKEEEEEEEEEGGGGHHHHTT CRAB CRAB CRAABROCKET CRAB ROCKEEEET."//fun fact: i actually spent like 10 minutes and transcribed the entire video.
 	cost = 5000
@@ -1473,12 +1632,12 @@
 	crate_name = "look sir free crabs"
 	DropPodOnly = TRUE
 
-/datum/supply_pack/organic/critter/crab/generate()
+/datum/supply_pack/critter/crab/generate()
 	. = ..()
 	for(var/i in 1 to 49)
 		new /mob/living/simple_animal/crab(.)
 
-/datum/supply_pack/organic/critter/corgi
+/datum/supply_pack/critter/corgi
 	name = "Corgi Crate"
 	desc = "Considered the optimal dog breed by thousands of research scientists, this Corgi is but one dog from the millions of Ian's noble bloodline. Comes with a cute collar!"
 	cost = 5000
@@ -1486,21 +1645,21 @@
 					/obj/item/clothing/neck/petcollar)
 	crate_name = "corgi crate"
 
-/datum/supply_pack/organic/critter/corgi/generate()
+/datum/supply_pack/critter/corgi/generate()
 	. = ..()
 	if(prob(50))
 		var/mob/living/simple_animal/pet/dog/corgi/D = locate() in .
 		qdel(D)
 		new /mob/living/simple_animal/pet/dog/corgi/Lisa(.)
 
-/datum/supply_pack/organic/critter/cow
+/datum/supply_pack/critter/cow
 	name = "Cow Crate"
 	desc = "The cow goes moo!"
 	cost = 3000
 	contains = list(/mob/living/simple_animal/cow)
 	crate_name = "cow crate"
 
-/datum/supply_pack/organic/critter/fox
+/datum/supply_pack/critter/fox
 	name = "Fox Crate"
 	desc = "The fox goes...? Comes with a collar!"//what does the fox say
 	cost = 5000
@@ -1508,14 +1667,21 @@
 					/obj/item/clothing/neck/petcollar)
 	crate_name = "fox crate"
 
-/datum/supply_pack/organic/critter/goat
+/datum/supply_pack/critter/goat
 	name = "Goat Crate"
 	desc = "The goat goes baa! Warranty void if used as a replacement for Pete."
 	cost = 2500
 	contains = list(/mob/living/simple_animal/hostile/retaliate/goat)
 	crate_name = "goat crate"
 
-/datum/supply_pack/organic/critter/pug
+/datum/supply_pack/critter/monkey
+	name = "Monkey Cube Crate"
+	desc = "Stop monkeying around! Contains seven monkey cubes. Just add water!"
+	cost = 2000
+	contains = list (/obj/item/storage/box/monkeycubes)
+	crate_name = "monkey cube crate"
+
+/datum/supply_pack/critter/pug
 	name = "Pug Crate"
 	desc = "Like a normal dog, but... squished. Comes with a nice collar!"
 	cost = 5000
@@ -1523,7 +1689,7 @@
 					/obj/item/clothing/neck/petcollar)
 	crate_name = "pug crate"
 
-/datum/supply_pack/organic/critter/snake
+/datum/supply_pack/critter/snake
 	name = "Snake Crate"
 	desc = "Tired of these MOTHER FUCKING snakes on this MOTHER FUCKING space station? Then this isn't the crate for you. Contains three poisonous snakes."
 	cost = 3000
@@ -1532,144 +1698,51 @@
 					/mob/living/simple_animal/hostile/retaliate/poison/snake)
 	crate_name = "snake crate"
 
-/datum/supply_pack/organic/vending
-	name = "Bartending Supply Crate"
-	desc = "Bring on the booze with six vending machine refills, as well as a free book containing the well-kept secrets to the bartending trade!"
-	cost = 2000
-	contains = list(/obj/item/vending_refill/boozeomat,
-					/obj/item/vending_refill/boozeomat,
-					/obj/item/vending_refill/boozeomat,
-					/obj/item/vending_refill/coffee,
-					/obj/item/vending_refill/coffee,
-					/obj/item/vending_refill/coffee,
-					/obj/item/book/granter/action/drink_fling)
-	crate_name = "bartending supply crate"
-
-/datum/supply_pack/organic/vending/cigarette
-	name = "Cigarette Supply Crate"
-	desc = "Don't believe the reports - smoke today! Contains cigarette vending machine refills."
-	cost = 1500
-	contains = list(/obj/item/vending_refill/cigarette,
-					/obj/item/vending_refill/cigarette,
-					/obj/item/vending_refill/cigarette)
-	crate_name = "cigarette supply crate"
-
-/datum/supply_pack/organic/vending/games
-	name = "Games Supply Crate"
-	desc = "Get your game on with these three game vending machine refills."
-	cost = 1000
-	contains = list(/obj/item/vending_refill/games,
-					/obj/item/vending_refill/games,
-					/obj/item/vending_refill/games)
-	crate_name = "games supply crate"
-
-/datum/supply_pack/organic/vending/snack
-	name = "Snack Supply Crate"
-	desc = "Three vending machine refills of cavity-bringin' goodness! The number one dentist recommended order!"
-	cost = 1500
-	contains = list(/obj/item/vending_refill/snack,
-					/obj/item/vending_refill/snack,
-					/obj/item/vending_refill/snack)
-	crate_name = "snacks supply crate"
-
-/datum/supply_pack/organic/vending/cola
-	name = "Softdrinks Supply Crate"
-	desc = "Got whacked by a toolbox, but you still have those pesky teeth? Get rid of those pearly whites with these three soda machine refills, today!"
-	cost = 1500
-	contains = list(/obj/item/vending_refill/cola,
-					/obj/item/vending_refill/cola,
-					/obj/item/vending_refill/cola)
-	crate_name = "soft drinks supply crate"
-
 //////////////////////////////////////////////////////////////////////////////
-//////////////////////////// Miscellaneous ///////////////////////////////////
+//////////////////////////// Costumes & Toys /////////////////////////////////
 //////////////////////////////////////////////////////////////////////////////
 
-/datum/supply_pack/misc
-	group = "Miscellaneous Supplies"
+/datum/supply_pack/costumes_toys
+	group = "Costumes & Toys"
 
-/datum/supply_pack/misc/artsupply
-	name = "Art Supplies"
-	desc = "Make some happy little accidents with six canvasses, two easels, and two rainbow crayons!"
-	cost = 800
-	contains = list(/obj/structure/easel,
-					/obj/structure/easel,
-					/obj/item/canvas/nineteenXnineteen,
-					/obj/item/canvas/nineteenXnineteen,
-					/obj/item/canvas/twentythreeXnineteen,
-					/obj/item/canvas/twentythreeXnineteen,
-					/obj/item/canvas/twentythreeXtwentythree,
-					/obj/item/canvas/twentythreeXtwentythree,
-					/obj/item/toy/crayon/rainbow,
-					/obj/item/toy/crayon/rainbow)
-	crate_name = "art supply crate"
-
-/datum/supply_pack/misc/bicycle
-	name = "Bicycle"
-	desc = "Nanotrasen reminds all employees to never toy with powers outside their control."
-	cost = 1000000
-	contains = list(/obj/vehicle/ridden/bicycle)
-	crate_name = "Bicycle Crate"
-	crate_type = /obj/structure/closet/crate/large
-
-/datum/supply_pack/misc/bigband
-	name = "Big Band Instrument Collection"
-	desc = "Get your sad station movin' and groovin' with this fine collection! Contains nine different instruments!"
-	cost = 5000
-	crate_name = "Big band musical instruments collection"
-	contains = list(/obj/item/instrument/violin,
-					/obj/item/instrument/guitar,
-					/obj/item/instrument/glockenspiel,
-					/obj/item/instrument/accordion,
-					/obj/item/instrument/saxophone,
-					/obj/item/instrument/trombone,
-					/obj/item/instrument/recorder,
-					/obj/item/instrument/harmonica,
-					/obj/structure/piano/unanchored)
-
-/datum/supply_pack/misc/book_crate
-	name = "Book Crate"
-	desc = "Surplus from the Nanotrasen Archives, these five books are sure to be good reads."
+/datum/supply_pack/costumes_toys/autodrobe
+	name = "Autodrobe Supply Crate"
+	desc = "Autodrobe missing your favorite dress? Solve that issue today with these two autodrobe refills."
 	cost = 1500
-	contains = list(/obj/item/book/codex_gigas,
-					/obj/item/book/manual/random/,
-					/obj/item/book/manual/random/,
-					/obj/item/book/manual/random/,
-					/obj/item/book/random/triple)
+	contains = list(/obj/item/vending_refill/autodrobe,
+					/obj/item/vending_refill/autodrobe)
+	crate_name = "autodrobe supply crate"
 
-/datum/supply_pack/misc/paper
-	name = "Bureaucracy Crate"
-	desc = "High stacks of papers on your desk Are a big problem - make it Pea-sized with these bureacratic supplies! Contains six pens, some camera film, hand labeler supplies, a paper bin, three folders, two clipboards and two stamps."//that was too forced
-	cost = 1500
-	contains = list(/obj/structure/filingcabinet/chestdrawer/wheeled,
-					/obj/item/camera_film,
-					/obj/item/hand_labeler,
-					/obj/item/hand_labeler_refill,
-					/obj/item/hand_labeler_refill,
-					/obj/item/paper_bin,
-					/obj/item/pen/fourcolor,
-					/obj/item/pen/fourcolor,
-					/obj/item/pen,
-					/obj/item/pen/fountain,
-					/obj/item/pen/blue,
-					/obj/item/pen/red,
-					/obj/item/folder/blue,
-					/obj/item/folder/red,
-					/obj/item/folder/yellow,
-					/obj/item/clipboard,
-					/obj/item/clipboard,
-					/obj/item/stamp,
-					/obj/item/stamp/denied)
-	crate_name = "bureaucracy crate"
-
-/datum/supply_pack/misc/fountainpens
-	name = "Calligraphy Crate"
-	desc = "Sign death warrents in style with these seven executive fountain pens."
-	cost = 700
-	contains = list(/obj/item/storage/box/fountainpens)
+/datum/supply_pack/costumes_toys/randomised
+	name = "Collectable Hats Crate"
+	desc = "Flaunt your status with three unique, highly-collectable hats!"
+	cost = 20000
+	var/num_contained = 3 //number of items picked to be contained in a randomised crate
+	contains = list(/obj/item/clothing/head/collectable/chef,
+					/obj/item/clothing/head/collectable/paper,
+					/obj/item/clothing/head/collectable/tophat,
+					/obj/item/clothing/head/collectable/captain,
+					/obj/item/clothing/head/collectable/beret,
+					/obj/item/clothing/head/collectable/welding,
+					/obj/item/clothing/head/collectable/flatcap,
+					/obj/item/clothing/head/collectable/pirate,
+					/obj/item/clothing/head/collectable/kitty,
+					/obj/item/clothing/head/collectable/rabbitears,
+					/obj/item/clothing/head/collectable/wizard,
+					/obj/item/clothing/head/collectable/hardhat,
+					/obj/item/clothing/head/collectable/HoS,
+					/obj/item/clothing/head/collectable/HoP,
+					/obj/item/clothing/head/collectable/thunderdome,
+					/obj/item/clothing/head/collectable/swat,
+					/obj/item/clothing/head/collectable/slime,
+					/obj/item/clothing/head/collectable/police,
+					/obj/item/clothing/head/collectable/slime,
+					/obj/item/clothing/head/collectable/xenom,
+					/obj/item/clothing/head/collectable/petehat)
+	crate_name = "collectable hats crate"
 	crate_type = /obj/structure/closet/crate/wooden
 
-/datum/supply_pack/misc/randomised/contraband
+/datum/supply_pack/costumes_toys/randomised/contraband
 	name = "Contraband Crate"
 	desc = "Psst.. bud... want some contraband? I can get you a poster, some nice cigs, bling, even some ambrosia deus...you know, the good stuff. Just keep it away from the cops, kay?"
 	contraband = TRUE
@@ -1682,21 +1755,7 @@
 					/obj/item/clothing/neck/necklace/dope)
 	crate_name = "crate"
 
-/datum/supply_pack/misc/conveyor
-	name = "Conveyor Assembly Crate"
-	desc = "Keep production moving along with six conveyor belts. Conveyor switch included. If you have any questions, check out the enclosed instruction book."
-	cost = 1500
-	contains = list(/obj/item/conveyor_construct,
-					/obj/item/conveyor_construct,
-					/obj/item/conveyor_construct,
-					/obj/item/conveyor_construct,
-					/obj/item/conveyor_construct,
-					/obj/item/conveyor_construct,
-					/obj/item/conveyor_switch_construct,
-					/obj/item/paper/guides/conveyor)
-	crate_name = "conveyor assembly crate"
-
-/datum/supply_pack/misc/foamforce
+/datum/supply_pack/costumes_toys/foamforce
 	name = "Foam Force Crate"
 	desc = "Break out the big guns with eight Foam Force shotguns!"
 	cost = 1000
@@ -1710,7 +1769,7 @@
 					/obj/item/gun/ballistic/shotgun/toy)
 	crate_name = "foam force crate"
 
-/datum/supply_pack/misc/foamforce/bonus
+/datum/supply_pack/costumes_toys/foamforce/bonus
 	name = "Foam Force Pistols Crate"
 	desc = "Psst.. hey bud... remember those old foam force pistols that got discontinued for being too cool? Well I got two of those right here with your name on em. I'll even throw in a spare mag for each, waddya say?"
 	contraband = TRUE
@@ -1721,198 +1780,7 @@
 					/obj/item/ammo_box/magazine/toy/pistol)
 	crate_name = "foam force crate"
 
-/datum/supply_pack/misc/noslipfloor
-	name = "High-traction Floor Tiles"
-	desc = "Make slipping a thing of the past with thirty industrial-grade anti-slip floortiles!"
-	cost = 2000
-	contains = list(/obj/item/stack/tile/noslip/thirty)
-	crate_name = "high-traction floor tiles crate"
-
-/datum/supply_pack/misc/clownpin
-	name = "Hilarious Firing Pin Crate"
-	desc = "i uh... im not really sure what this does. wanna buy it?"
-	cost = 5000
-	contraband = TRUE
-	contains = list(/obj/item/firing_pin/clown)
-	// It's /technically/ a toy. For the clown, at least.
-	crate_name = "toy crate"
-
-/datum/supply_pack/misc/janitor
-	name = "Janitorial Supplies Crate"
-	desc = "Fight back against dirt and grime with Nanotrasen's Janitorial Essentials(tm)! Contains three buckets, caution signs, and cleaner grenades. Also has a single mop, spray cleaner, rag, and trash bag."
-	cost = 1000
-	contains = list(/obj/item/reagent_containers/glass/bucket,
-					/obj/item/reagent_containers/glass/bucket,
-					/obj/item/reagent_containers/glass/bucket,
-					/obj/item/mop,
-					/obj/item/caution,
-					/obj/item/caution,
-					/obj/item/caution,
-					/obj/item/storage/bag/trash,
-					/obj/item/reagent_containers/spray/cleaner,
-					/obj/item/reagent_containers/glass/rag,
-					/obj/item/grenade/chem_grenade/cleaner,
-					/obj/item/grenade/chem_grenade/cleaner,
-					/obj/item/grenade/chem_grenade/cleaner)
-	crate_name = "janitorial supplies crate"
-
-/datum/supply_pack/misc/janitor/janicart
-	name = "Janitorial Cart and Galoshes Crate"
-	desc = "The keystone to any successful janitor. As long as you have feet, this pair of galoshes will keep them firmly planted on the ground. Also contains a janitorial cart."
-	cost = 2000
-	contains = list(/obj/structure/janitorialcart,
-					/obj/item/clothing/shoes/galoshes)
-	crate_name = "janitorial cart crate"
-	crate_type = /obj/structure/closet/crate/large
-
-/datum/supply_pack/misc/janitor/janitank
-	name = "Janitor Backpack Crate"
-	desc = "Call forth divine judgement upon dirt and grime with this high capacity janitor backpack. Contains 500 units of station-cleansing cleaner. Requires janitor access to open."
-	cost = 1000
-	access = ACCESS_JANITOR
-	contains = list(/obj/item/watertank/janitor)
-	crate_name = "janitor backpack crate"
-	crate_type = /obj/structure/closet/crate/secure
-
-/datum/supply_pack/misc/lasertag
-	name = "Laser Tag Crate"
-	desc = "Foam Force is for boys. Laser Tag is for men. Contains three sets of red suits, blue suits, matching helmets, and matching laser tag guns."
-	cost = 1500
-	contains = list(/obj/item/gun/energy/laser/redtag,
-					/obj/item/gun/energy/laser/redtag,
-					/obj/item/gun/energy/laser/redtag,
-					/obj/item/gun/energy/laser/bluetag,
-					/obj/item/gun/energy/laser/bluetag,
-					/obj/item/gun/energy/laser/bluetag,
-					/obj/item/clothing/suit/redtag,
-					/obj/item/clothing/suit/redtag,
-					/obj/item/clothing/suit/redtag,
-					/obj/item/clothing/suit/bluetag,
-					/obj/item/clothing/suit/bluetag,
-					/obj/item/clothing/suit/bluetag,
-					/obj/item/clothing/head/helmet/redtaghelm,
-					/obj/item/clothing/head/helmet/redtaghelm,
-					/obj/item/clothing/head/helmet/redtaghelm,
-					/obj/item/clothing/head/helmet/bluetaghelm,
-					/obj/item/clothing/head/helmet/bluetaghelm,
-					/obj/item/clothing/head/helmet/bluetaghelm)
-	crate_name = "laser tag crate"
-
-/datum/supply_pack/misc/lasertag/pins
-	name = "Laser Tag Firing Pins Crate"
-	desc = "Three laser tag firing pins used in laser-tag units to ensure users are wearing their vests."
-	cost = 3000
-	contraband = TRUE
-	contains = list(/obj/item/storage/box/lasertagpins)
-	crate_name = "laser tag crate"
-
-/datum/supply_pack/misc/mule
-	name = "MULEbot Crate"
-	desc = "Pink-haired Quartermaster not doing her job? Replace her with this tireless worker, today!"
-	cost = 2000
-	contains = list(/mob/living/simple_animal/bot/mulebot)
-	crate_name = "\improper MULEbot Crate"
-	crate_type = /obj/structure/closet/crate/large
-
-/datum/supply_pack/misc/religious_supplies
-	name = "Religious Supplies Crate"
-	desc = "Keep your local chaplain happy and well-supplied, lest they call down judgement upon your cargo bay. Contains two bottles of holywater, bibles, chaplain robes, and burial garmets."
-	cost = 4000	// it costs so much because the Space Church is ran by Space Jews
-	contains = list(/obj/item/reagent_containers/food/drinks/bottle/holywater,
-					/obj/item/reagent_containers/food/drinks/bottle/holywater,
-					/obj/item/storage/book/bible/booze,
-					/obj/item/storage/book/bible/booze,
-					/obj/item/clothing/suit/hooded/chaplain_hoodie,
-					/obj/item/clothing/suit/hooded/chaplain_hoodie,
-					/obj/item/clothing/under/burial,
-					/obj/item/clothing/under/burial)
-	crate_name = "religious supplies crate"
-
-/datum/supply_pack/misc/janitor/lightbulbs
-	name = "Replacement Lights"
-	desc = "May the light of Aether shine upon this station! Or at least, the light of forty two light tubes and twenty one light bulbs."
-	cost = 1000
-	contains = list(/obj/item/storage/box/lights/mixed,
-					/obj/item/storage/box/lights/mixed,
-					/obj/item/storage/box/lights/mixed)
-	crate_name = "replacement lights"
-
-/datum/supply_pack/misc/minerkit
-	name = "Shaft Miner Starter Kit"
-	desc = "All the miners died too fast? Assistant wants to get a taste of life off-station? Either way, this kit is the best way to turn a regular crewman into an ore-producing, monster-slaying machine. Contains meson goggles, a pickaxe, advanced mining scanner, cargo headset, ore bag, gasmask, and explorer suit. Requires QM access to open."
-	cost = 2500
-	access = ACCESS_QM
-	contains = list(/obj/item/pickaxe/mini,
-			/obj/item/clothing/glasses/meson,
-			/obj/item/t_scanner/adv_mining_scanner/lesser,
-			/obj/item/radio/headset/headset_cargo/mining,
-			/obj/item/storage/bag/ore,
-			/obj/item/clothing/suit/hooded/explorer,
-			/obj/item/clothing/mask/gas/explorer)
-	crate_name = "shaft miner starter kit"
-	crate_type = /obj/structure/closet/crate/secure
-
-/datum/supply_pack/misc/toner
-	name = "Toner Crate"
-	desc = "Spent too much ink printing butt pictures? Fret not, with these six toner refills, you'll be printing butts 'till the cows come home!'"
-	cost = 1000
-	contains = list(/obj/item/toner,
-					/obj/item/toner,
-					/obj/item/toner,
-					/obj/item/toner,
-					/obj/item/toner,
-					/obj/item/toner)
-	crate_name = "toner crate"
-
-/datum/supply_pack/misc/autodrobe
-	name = "Autodrobe Supply Crate"
-	desc = "Autodrobe missing your favorite dress? Solve that issue today with these two autodrobe refills."
-	cost = 1500
-	contains = list(/obj/item/vending_refill/autodrobe,
-					/obj/item/vending_refill/autodrobe)
-	crate_name = "autodrobe supply crate"
-
-/datum/supply_pack/misc/costume
-	name = "Standard Costume Crate"
-	desc = "Supply the station's entertainers with the equipment of their trade with these Nanotrasen-approved costumes! Contains a full clown and mime outfit, along with a bike horn and a bottle of nothing."
-	cost = 1000
-	access = ACCESS_THEATRE
-	contains = list(/obj/item/storage/backpack/clown,
-					/obj/item/clothing/shoes/clown_shoes,
-					/obj/item/clothing/mask/gas/clown_hat,
-					/obj/item/clothing/under/rank/clown,
-					/obj/item/bikehorn,
-					/obj/item/clothing/under/rank/mime,
-					/obj/item/clothing/shoes/sneakers/black,
-					/obj/item/clothing/gloves/color/white,
-					/obj/item/clothing/mask/gas/mime,
-					/obj/item/clothing/head/beret,
-					/obj/item/clothing/suit/suspenders,
-					/obj/item/reagent_containers/food/drinks/bottle/bottleofnothing,
-					/obj/item/storage/backpack/mime)
-	crate_name = "standard costume crate"
-	crate_type = /obj/structure/closet/crate/secure
-
-/datum/supply_pack/misc/costume_original
-	name = "Original Costume Crate"
-	desc = "Reenact Shakespearean plays with this assortment of outfits. Contains eight different costumes!"
-	cost = 1000
-	contains = list(/obj/item/clothing/head/snowman,
-					/obj/item/clothing/suit/snowman,
-					/obj/item/clothing/head/chicken,
-					/obj/item/clothing/suit/chickensuit,
-					/obj/item/clothing/mask/gas/monkeymask,
-					/obj/item/clothing/suit/monkeysuit,
-					/obj/item/clothing/head/cardborg,
-					/obj/item/clothing/suit/cardborg,
-					/obj/item/clothing/head/xenos,
-					/obj/item/clothing/suit/xenos,
-					/obj/item/clothing/suit/hooded/ian_costume,
-					/obj/item/clothing/suit/hooded/carp_costume,
-					/obj/item/clothing/suit/hooded/bee_costume)
-	crate_name = "original costume crate"
-
-/datum/supply_pack/misc/formalwear
+/datum/supply_pack/costumes_toys/formalwear
 	name = "Formalwear Crate"
 	desc = "You're gonna like the way you look, I guaranteed it. Contains an asston of fancy clothing."
 	cost = 3000 //Lots of very expensive items. You gotta pay up to look good!
@@ -1944,52 +1812,91 @@
 					/obj/item/clothing/under/suit_jacket/tan,
 					/obj/item/lipstick/random)
 	crate_name = "formalwear crate"
+	crate_type = /obj/structure/closet/crate/wooden
 
-/datum/supply_pack/misc/wizard
-	name = "Wizard Costume Crate"
-	desc = "Pretend to join the Wizard Federation with this full wizard outfit! Nanotrasen would like to remind its employees that actually joining the Wizard Federation is subject to termination of job and life."
-	cost = 2000
-	contains = list(/obj/item/staff,
-					/obj/item/clothing/suit/wizrobe/fake,
-					/obj/item/clothing/shoes/sandal,
-					/obj/item/clothing/head/wizard/fake)
-	crate_name = "wizard costume crate"
+/datum/supply_pack/costumes_toys/clownpin
+	name = "Hilarious Firing Pin Crate"
+	desc = "I uh... I'm not really sure what this does. Wanna buy it?"
+	cost = 5000
+	contraband = TRUE
+	contains = list(/obj/item/firing_pin/clown)
+	crate_name = "toy crate" // It's /technically/ a toy. For the clown, at least.
+	crate_type = /obj/structure/closet/crate/wooden
 
-/datum/supply_pack/misc/randomised/fill(obj/structure/closet/crate/C)
-	var/list/L = contains.Copy()
-	for(var/i in 1 to num_contained)
-		var/item = pick_n_take(L)
-		new item(C)
+/datum/supply_pack/costumes_toys/lasertag
+	name = "Laser Tag Crate"
+	desc = "Foam Force is for boys. Laser Tag is for men. Contains three sets of red suits, blue suits, matching helmets, and matching laser tag guns."
+	cost = 1500
+	contains = list(/obj/item/gun/energy/laser/redtag,
+					/obj/item/gun/energy/laser/redtag,
+					/obj/item/gun/energy/laser/redtag,
+					/obj/item/gun/energy/laser/bluetag,
+					/obj/item/gun/energy/laser/bluetag,
+					/obj/item/gun/energy/laser/bluetag,
+					/obj/item/clothing/suit/redtag,
+					/obj/item/clothing/suit/redtag,
+					/obj/item/clothing/suit/redtag,
+					/obj/item/clothing/suit/bluetag,
+					/obj/item/clothing/suit/bluetag,
+					/obj/item/clothing/suit/bluetag,
+					/obj/item/clothing/head/helmet/redtaghelm,
+					/obj/item/clothing/head/helmet/redtaghelm,
+					/obj/item/clothing/head/helmet/redtaghelm,
+					/obj/item/clothing/head/helmet/bluetaghelm,
+					/obj/item/clothing/head/helmet/bluetaghelm,
+					/obj/item/clothing/head/helmet/bluetaghelm)
+	crate_name = "laser tag crate"
 
-/datum/supply_pack/misc/randomised
-	name = "Collectable Hats Crate"
-	desc = "Flaunt your status with three unique, highly-collectable hats!"
-	cost = 20000
-	var/num_contained = 3 //number of items picked to be contained in a randomised crate
-	contains = list(/obj/item/clothing/head/collectable/chef,
-					/obj/item/clothing/head/collectable/paper,
-					/obj/item/clothing/head/collectable/tophat,
-					/obj/item/clothing/head/collectable/captain,
-					/obj/item/clothing/head/collectable/beret,
-					/obj/item/clothing/head/collectable/welding,
-					/obj/item/clothing/head/collectable/flatcap,
-					/obj/item/clothing/head/collectable/pirate,
-					/obj/item/clothing/head/collectable/kitty,
-					/obj/item/clothing/head/collectable/rabbitears,
-					/obj/item/clothing/head/collectable/wizard,
-					/obj/item/clothing/head/collectable/hardhat,
-					/obj/item/clothing/head/collectable/HoS,
-					/obj/item/clothing/head/collectable/HoP,
-					/obj/item/clothing/head/collectable/thunderdome,
-					/obj/item/clothing/head/collectable/swat,
-					/obj/item/clothing/head/collectable/slime,
-					/obj/item/clothing/head/collectable/police,
-					/obj/item/clothing/head/collectable/slime,
-					/obj/item/clothing/head/collectable/xenom,
-					/obj/item/clothing/head/collectable/petehat)
-	crate_name = "collectable hats crate"
+/datum/supply_pack/costumes_toys/lasertag/pins
+	name = "Laser Tag Firing Pins Crate"
+	desc = "Three laser tag firing pins used in laser-tag units to ensure users are wearing their vests."
+	cost = 3000
+	contraband = TRUE
+	contains = list(/obj/item/storage/box/lasertagpins)
+	crate_name = "laser tag crate"
 
-/datum/supply_pack/misc/randomised/toys
+/datum/supply_pack/costumes_toys/costume_original
+	name = "Original Costume Crate"
+	desc = "Reenact Shakespearean plays with this assortment of outfits. Contains eight different costumes!"
+	cost = 1000
+	contains = list(/obj/item/clothing/head/snowman,
+					/obj/item/clothing/suit/snowman,
+					/obj/item/clothing/head/chicken,
+					/obj/item/clothing/suit/chickensuit,
+					/obj/item/clothing/mask/gas/monkeymask,
+					/obj/item/clothing/suit/monkeysuit,
+					/obj/item/clothing/head/cardborg,
+					/obj/item/clothing/suit/cardborg,
+					/obj/item/clothing/head/xenos,
+					/obj/item/clothing/suit/xenos,
+					/obj/item/clothing/suit/hooded/ian_costume,
+					/obj/item/clothing/suit/hooded/carp_costume,
+					/obj/item/clothing/suit/hooded/bee_costume)
+	crate_name = "original costume crate"
+	crate_type = /obj/structure/closet/crate/wooden
+
+/datum/supply_pack/costumes_toys/costume
+	name = "Standard Costume Crate"
+	desc = "Supply the station's entertainers with the equipment of their trade with these Nanotrasen-approved costumes! Contains a full clown and mime outfit, along with a bike horn and a bottle of nothing."
+	cost = 1000
+	access = ACCESS_THEATRE
+	contains = list(/obj/item/storage/backpack/clown,
+					/obj/item/clothing/shoes/clown_shoes,
+					/obj/item/clothing/mask/gas/clown_hat,
+					/obj/item/clothing/under/rank/clown,
+					/obj/item/bikehorn,
+					/obj/item/clothing/under/rank/mime,
+					/obj/item/clothing/shoes/sneakers/black,
+					/obj/item/clothing/gloves/color/white,
+					/obj/item/clothing/mask/gas/mime,
+					/obj/item/clothing/head/beret,
+					/obj/item/clothing/suit/suspenders,
+					/obj/item/reagent_containers/food/drinks/bottle/bottleofnothing,
+					/obj/item/storage/backpack/mime)
+	crate_name = "standard costume crate"
+	crate_type = /obj/structure/closet/crate/wooden
+
+/datum/supply_pack/costumes_toys/randomised/toys
 	name = "Toy Crate"
 	desc = "Who cares about pride and accomplishment? Skip the gaming and get straight to the sweet rewards with this product! Contains five random toys. Warranty void if used to prank research directors."
 	cost = 5000 // or play the arcade machines ya lazy bum
@@ -2015,3 +1922,138 @@
 					/obj/item/toy/eightball,
 					/obj/item/vending_refill/donksoft)
 	crate_name = "toy crate"
+	crate_type = /obj/structure/closet/crate/wooden
+
+/datum/supply_pack/costumes_toys/wizard
+	name = "Wizard Costume Crate"
+	desc = "Pretend to join the Wizard Federation with this full wizard outfit! Nanotrasen would like to remind its employees that actually joining the Wizard Federation is subject to termination of job and life."
+	cost = 2000
+	contains = list(/obj/item/staff,
+					/obj/item/clothing/suit/wizrobe/fake,
+					/obj/item/clothing/shoes/sandal,
+					/obj/item/clothing/head/wizard/fake)
+	crate_name = "wizard costume crate"
+	crate_type = /obj/structure/closet/crate/wooden
+
+/datum/supply_pack/costumes_toys/randomised/fill(obj/structure/closet/crate/C)
+	var/list/L = contains.Copy()
+	for(var/i in 1 to num_contained)
+		var/item = pick_n_take(L)
+		new item(C)
+
+//////////////////////////////////////////////////////////////////////////////
+//////////////////////////// Miscellaneous ///////////////////////////////////
+//////////////////////////////////////////////////////////////////////////////
+
+/datum/supply_pack/misc
+	group = "Miscellaneous Supplies"
+
+/datum/supply_pack/misc/artsupply
+	name = "Art Supplies"
+	desc = "Make some happy little accidents with six canvasses, two easels, and two rainbow crayons!"
+	cost = 800
+	contains = list(/obj/structure/easel,
+					/obj/structure/easel,
+					/obj/item/canvas/nineteenXnineteen,
+					/obj/item/canvas/nineteenXnineteen,
+					/obj/item/canvas/twentythreeXnineteen,
+					/obj/item/canvas/twentythreeXnineteen,
+					/obj/item/canvas/twentythreeXtwentythree,
+					/obj/item/canvas/twentythreeXtwentythree,
+					/obj/item/toy/crayon/rainbow,
+					/obj/item/toy/crayon/rainbow)
+	crate_name = "art supply crate"
+	crate_type = /obj/structure/closet/crate/wooden
+
+/datum/supply_pack/misc/bicycle
+	name = "Bicycle"
+	desc = "Nanotrasen reminds all employees to never toy with powers outside their control."
+	cost = 1000000
+	contains = list(/obj/vehicle/ridden/bicycle)
+	crate_name = "Bicycle Crate"
+	crate_type = /obj/structure/closet/crate/large
+
+/datum/supply_pack/misc/bigband
+	name = "Big Band Instrument Collection"
+	desc = "Get your sad station movin' and groovin' with this fine collection! Contains nine different instruments!"
+	cost = 5000
+	crate_name = "Big band musical instruments collection"
+	contains = list(/obj/item/instrument/violin,
+					/obj/item/instrument/guitar,
+					/obj/item/instrument/glockenspiel,
+					/obj/item/instrument/accordion,
+					/obj/item/instrument/saxophone,
+					/obj/item/instrument/trombone,
+					/obj/item/instrument/recorder,
+					/obj/item/instrument/harmonica,
+					/obj/structure/piano/unanchored)
+	crate_type = /obj/structure/closet/crate/wooden
+
+/datum/supply_pack/misc/book_crate
+	name = "Book Crate"
+	desc = "Surplus from the Nanotrasen Archives, these five books are sure to be good reads."
+	cost = 1500
+	contains = list(/obj/item/book/codex_gigas,
+					/obj/item/book/manual/random/,
+					/obj/item/book/manual/random/,
+					/obj/item/book/manual/random/,
+					/obj/item/book/random/triple)
+	crate_type = /obj/structure/closet/crate/wooden
+
+/datum/supply_pack/misc/paper
+	name = "Bureaucracy Crate"
+	desc = "High stacks of papers on your desk Are a big problem - make it Pea-sized with these bureacratic supplies! Contains six pens, some camera film, hand labeler supplies, a paper bin, three folders, two clipboards and two stamps."//that was too forced
+	cost = 1500
+	contains = list(/obj/structure/filingcabinet/chestdrawer/wheeled,
+					/obj/item/camera_film,
+					/obj/item/hand_labeler,
+					/obj/item/hand_labeler_refill,
+					/obj/item/hand_labeler_refill,
+					/obj/item/paper_bin,
+					/obj/item/pen/fourcolor,
+					/obj/item/pen/fourcolor,
+					/obj/item/pen,
+					/obj/item/pen/fountain,
+					/obj/item/pen/blue,
+					/obj/item/pen/red,
+					/obj/item/folder/blue,
+					/obj/item/folder/red,
+					/obj/item/folder/yellow,
+					/obj/item/clipboard,
+					/obj/item/clipboard,
+					/obj/item/stamp,
+					/obj/item/stamp/denied)
+	crate_name = "bureaucracy crate"
+
+/datum/supply_pack/misc/fountainpens
+	name = "Calligraphy Crate"
+	desc = "Sign death warrants in style with these seven executive fountain pens."
+	cost = 700
+	contains = list(/obj/item/storage/box/fountainpens)
+	crate_type = /obj/structure/closet/crate/wooden
+
+/datum/supply_pack/misc/religious_supplies
+	name = "Religious Supplies Crate"
+	desc = "Keep your local chaplain happy and well-supplied, lest they call down judgement upon your cargo bay. Contains two bottles of holywater, bibles, chaplain robes, and burial garmets."
+	cost = 4000	// it costs so much because the Space Church is ran by Space Jews
+	contains = list(/obj/item/reagent_containers/food/drinks/bottle/holywater,
+					/obj/item/reagent_containers/food/drinks/bottle/holywater,
+					/obj/item/storage/book/bible/booze,
+					/obj/item/storage/book/bible/booze,
+					/obj/item/clothing/suit/hooded/chaplain_hoodie,
+					/obj/item/clothing/suit/hooded/chaplain_hoodie,
+					/obj/item/clothing/under/burial,
+					/obj/item/clothing/under/burial)
+	crate_name = "religious supplies crate"
+
+/datum/supply_pack/misc/toner
+	name = "Toner Crate"
+	desc = "Spent too much ink printing butt pictures? Fret not, with these six toner refills, you'll be printing butts 'till the cows come home!'"
+	cost = 1000
+	contains = list(/obj/item/toner,
+					/obj/item/toner,
+					/obj/item/toner,
+					/obj/item/toner,
+					/obj/item/toner,
+					/obj/item/toner)
+	crate_name = "toner crate"

--- a/code/modules/events/shuttle_loan.dm
+++ b/code/modules/events/shuttle_loan.dm
@@ -103,7 +103,7 @@
 					shuttle_spawns.Add(/mob/living/simple_animal/hostile/syndicate)
 
 			if(RUSKY_PARTY)
-				var/datum/supply_pack/pack = SSshuttle.supply_packs[/datum/supply_pack/organic/party]
+				var/datum/supply_pack/pack = SSshuttle.supply_packs[/datum/supply_pack/service/party]
 				pack.generate(pick_n_take(empty_shuttle_turfs))
 
 				shuttle_spawns.Add(/mob/living/simple_animal/hostile/russian)


### PR DESCRIPTION
:cl: Denton
tweak: Cargo packs have been reorganized to shrink the big engineering, food&livestock and misc categories.
/:cl:

This PR moves most packs from the "Miscellaneous Supplies" category into more appropriate ones - conveyor belts go into "Engineering", janitorial supplies into "Service" and so on.
I also split up Engineering into Engineering + Engine Construction and Food&Livestock into Food&Hydroponics + Livestock.

All changes:
- Engineering -> Engineering + Engine Construction
- Food&Livestock -> Food & Hydroponics + Livestock
- New category: Service (janitor+cargo+shaft miner and vending machine resupply packs)
- New category: Costumes & Toys