### PR TITLE
Revert "fixes a pacifism kill through crushing firelocks! (#37511)"

### DIFF
--- a/code/game/machinery/doors/firedoor.dm
+++ b/code/game/machinery/doors/firedoor.dm
@@ -142,14 +142,6 @@
 	if(density)
 		open()
 	else
-		if(iscarbon(user))
-			var/mob/living/carbon/C = user
-			if(C.has_trait(TRAIT_PACIFISM))
-				var/T = get_turf(src)
-				for(var/mob/living/L in T)
-					if((L.stat != DEAD) && !L.has_trait(TRAIT_FAKEDEATH))
-						to_chat(user, "<span class='notice'>Closing [src] would hurt [L]!</span>")
-						return
 		close()
 
 /obj/machinery/door/firedoor/interact(mob/user)


### PR DESCRIPTION
This reverts commit 41eb3276fba4d740bcc244971f5720cda70f26ab.

Reverts #37511 

@ShizCalev Shame on you for merging this.

This code is totally unacceptable.

Pacificism is a meme trait and I'm confining it's cancer to gun code only.

@Armhulen do not attempt to snowflake fix all the edge cases like this, there are more than you could possibly imagine and this is the worst code I have seen in some time