### PR TITLE
Some dbadmin fixes

### DIFF
--- a/SQL/admin_import_2018-02-03.py
+++ b/SQL/admin_import_2018-02-03.py
@@ -18,6 +18,7 @@ import MySQLdb
 import argparse
 import re
 import sys
+import string
 
 def parse_text_flags(text, previous):
     flag_values = {"BUILDMODE":1, "BUILD":1, "ADMIN":2, "REJUVINATE":2, "REJUV":2, "BAN":4, "FUN":8, "SERVER":16, "DEBUG":32, "POSSESS":64, "PERMISSIONS":128, "RIGHTS":128, "STEALTH":256, "POLL":512, "VAREDIT":1024, "SOUNDS":2048, "SOUND":2048, "SPAWN":4096, "CREATE":4096, "AUTOLOGIN":8192, "AUTOADMIN":8192, "DBRANKS":16384}
@@ -70,6 +71,7 @@ db=MySQLdb.connect(host=args.address, user=args.username, passwd=args.password, 
 cursor=db.cursor()
 ranks_table = args.rankstable
 admin_table = args.admintable
+ckeyExformat = re.sub("@|-|_", " ", string.punctuation)
 with open("..\\config\\admin_ranks.txt") as rank_file:
     previous = 0
     for line in rank_file:
@@ -77,17 +79,21 @@ with open("..\\config\\admin_ranks.txt") as rank_file:
             if line.startswith("#"):
                 continue
             matches = re.match("(.+)\\b\\s+=\\s*(.*)", line)
+            rank = "".join((c for c in matches.group(1) if c not in ckeyExformat))
             flags = parse_text_flags(matches.group(2), previous)
             previous = flags
-            cursor.execute("INSERT INTO {0} (rank, flags, exclude_flags, can_edit_flags) VALUES ('{1}', {2}, {3}, {4})".format(ranks_table, matches.group(1), flags[0], flags[1], flags[2]))
+            cursor.execute("INSERT INTO {0} (rank, flags, exclude_flags, can_edit_flags) VALUES ('{1}', {2}, {3}, {4})".format(ranks_table, rank, flags[0], flags[1], flags[2]))
 with open("..\\config\\admins.txt") as admins_file:
     previous = 0
+    ckeyformat = string.punctuation.replace("@", " ")
     for line in admins_file:
         if line.strip():
             if line.startswith("#"):
                 continue
             matches = re.match("(.+)\\b\\s+=\\s+(.+)", line)
-        cursor.execute("INSERT INTO {0} (ckey, rank) VALUES ('{1}', '{2}')".format(admin_table, matches.group(1).lower(), matches.group(2)))
+            ckey = "".join((c for c in matches.group(1) if c not in ckeyformat)).lower()
+            rank = "".join((c for c in matches.group(2) if c not in ckeyExformat))
+        cursor.execute("INSERT INTO {0} (ckey, rank) VALUES ('{1}', '{2}')".format(admin_table, ckey, rank))
 db.commit()
 cursor.close()
 print("Import complete.")

--- a/code/modules/admin/admin_ranks.dm
+++ b/code/modules/admin/admin_ranks.dm
@@ -156,7 +156,7 @@ GLOBAL_PROTECT(protected_ranks)
 			else
 				while(query_load_admin_ranks.NextRow())
 					var/skip
-					var/rank_name = query_load_admin_ranks.item[1]
+					var/rank_name = ckeyEx(query_load_admin_ranks.item[1])
 					for(var/datum/admin_rank/R in GLOB.admin_ranks)
 						if(R.name == rank_name) //this rank was already loaded from txt override
 							skip = 1

--- a/code/modules/admin/permissionedit.dm
+++ b/code/modules/admin/permissionedit.dm
@@ -64,13 +64,16 @@
 			output += "[admin_ckey] has non-existant rank [admin_rank] | <a href='?_src_=holder;[HrefToken()];editrightsbrowsermanage=1;editrightschange=[admin_ckey]'>\[Change Rank\]</a> | <a href='?_src_=holder;[HrefToken()];editrightsbrowsermanage=1;editrightsremove=[admin_ckey]'>\[Remove\]</a>"
 			output += "<hr style='background:#000000; border:0; height:1px'>"
 		output += "<h3>Unused ranks</h3>"
-		var/datum/DBQuery/query_check_unused_rank = SSdbcore.NewQuery("SELECT [format_table_name("admin_ranks")].rank FROM [format_table_name("admin_ranks")] LEFT JOIN [format_table_name("admin")] ON [format_table_name("admin")].rank = [format_table_name("admin_ranks")].rank WHERE [format_table_name("admin")].rank IS NULL")
+		var/datum/DBQuery/query_check_unused_rank = SSdbcore.NewQuery("SELECT [format_table_name("admin_ranks")].rank, flags, exclude_flags, can_edit_flags FROM [format_table_name("admin_ranks")] LEFT JOIN [format_table_name("admin")] ON [format_table_name("admin")].rank = [format_table_name("admin_ranks")].rank WHERE [format_table_name("admin")].rank IS NULL")
 		if(!query_check_unused_rank.warn_execute())
 			return
 		while(query_check_unused_rank.NextRow())
 			var/admin_rank = query_check_unused_rank.item[1]
-			output += "Rank [admin_rank] is not held by any admin | <a href='?_src_=holder;[HrefToken()];editrightsbrowsermanage=1;editrightsremoverank=[admin_rank]'>\[Remove\]</a>"
-			output += "<hr style='background:#000000; border:0; height:1px'>"
+			output += {"Rank [admin_rank] is not held by any admin | <a href='?_src_=holder;[HrefToken()];editrightsbrowsermanage=1;editrightsremoverank=[admin_rank]'>\[Remove\]</a>
+			<br>Permissions: [rights2text(text2num(query_check_unused_rank.item[2])," ")]
+			<br>Denied: [rights2text(text2num(query_check_unused_rank.item[3])," ", "-")]
+			<br>Allowed to edit: [rights2text(text2num(query_check_unused_rank.item[4])," ", "*")]
+			<hr style='background:#000000; border:0; height:1px'>"}
 	else if(!action)
 		output += {"<head>
 		<title>Permissions Panel</title>
@@ -193,7 +196,7 @@
 	if(use_db)
 		. = sanitizeSQL(.)
 		//if an admin exists without a datum they won't be caught by the above
-		var/datum/DBQuery/query_admin_in_db = SSdbcore.NewQuery("SELECT 1 FROM [format_table_name("admin_ranks")] WHERE ckey = '[.]'")
+		var/datum/DBQuery/query_admin_in_db = SSdbcore.NewQuery("SELECT 1 FROM [format_table_name("admin")] WHERE ckey = '[.]'")
 		if(!query_admin_in_db.warn_execute())
 			return FALSE
 		if(query_admin_in_db.NextRow())

--- a/code/modules/admin/topic.dm
+++ b/code/modules/admin/topic.dm
@@ -834,8 +834,8 @@
 		var/isbanned_dept = jobban_isbanned(M, ROLE_SYNDICATE)
 		dat += "<table cellpadding='1' cellspacing='0' width='100%'>"
 		dat += "<tr bgcolor='ffeeaa'><th colspan='10'><a href='?src=[REF(src)];[HrefToken()];jobban3=Syndicate;jobban4=[REF(M)]'>Antagonist Positions</a> | "
-		dat += "<a href='?src=[REF(src)];[HrefToken()];jobban3=teamantags;jobban4=[REF(M)]'>Team Antagonists</a></th>"
-		dat += "<a href='?src=[REF(src)];[HrefToken()];jobban3=convertantags;jobban4=[REF(M)]'>Conversion Antagonists</a></th></tr><tr align='center'>"
+		dat += "<a href='?src=[REF(src)];[HrefToken()];jobban3=teamantags;jobban4=[REF(M)]'>Team Antagonists</a> | "
+		dat += "<a href='?src=[REF(src)];[HrefToken()];jobban3=convertantags;jobban4=[REF(M)]'>Conversion Antagonists</a></th></tr><tr align='center'></th>"
 
 		//Traitor
 		if(jobban_isbanned(M, ROLE_TRAITOR) || isbanned_dept)


### PR DESCRIPTION
Makes admin import script strip punctuation like `ckey` and `ckeyEx` do on admin ckeys and rank names
Fixes `load_admin_ranks()` not running `ckeyEx` on rank names loaded from db
Adds readout of permissions held by a rank in list of unused ranks
Fixes query in `add_admin` not using right table
Fixes formatting of `Conversion Antags` in jobban panel