### PR TITLE
You can no longer print infinite ammunition.

### DIFF
--- a/code/modules/projectiles/ammunition/_ammunition.dm
+++ b/code/modules/projectiles/ammunition/_ammunition.dm
@@ -7,6 +7,7 @@
 	slot_flags = ITEM_SLOT_BELT
 	throwforce = 0
 	w_class = WEIGHT_CLASS_TINY
+	materials = list(MAT_METAL = 500)
 	var/fire_sound = null						//What sound should play when this ammo is fired
 	var/caliber = null							//Which kind of guns it can be loaded into
 	var/projectile_type = null					//The bullet type to create when New() is called

--- a/code/modules/projectiles/ammunition/caseless/foam.dm
+++ b/code/modules/projectiles/ammunition/caseless/foam.dm
@@ -61,3 +61,4 @@
 	desc = "Whose smart idea was it to use toys as crowd control? Ages 18 and up."
 	projectile_type = /obj/item/projectile/bullet/reusable/foam_dart/riot
 	icon_state = "foamdart_riot"
+	materials = list(MAT_METAL = 1000)

--- a/code/modules/projectiles/boxes_magazines/_box_magazine.dm
+++ b/code/modules/projectiles/boxes_magazines/_box_magazine.dm
@@ -21,9 +21,19 @@
 	var/caliber
 	var/multiload = 1
 	var/start_empty = 0
+	var/list/bullet_cost = list() 
+	var/list/base_cost = list() // override this one as well if you override bullet_cost
 
 /obj/item/ammo_box/Initialize()
 	. = ..()
+	if (!bullet_cost.len)
+		for (var/material in materials)
+			var/material_amount = materials[material]
+			base_cost[material] = material_amount * 0.10
+
+			material_amount *= 0.90 // 10% for the container
+			material_amount /= max_ammo
+			bullet_cost[material] = material_amount
 	if(!start_empty)
 		for(var/i = 1, i <= max_ammo, i++)
 			stored_ammo += new ammo_type(src)
@@ -109,6 +119,10 @@
 		if(2)
 			icon_state = "[initial(icon_state)]-[stored_ammo.len ? "[max_ammo]" : "0"]"
 	desc = "[initial(desc)] There are [stored_ammo.len] shell\s left!"
+	for (var/material in bullet_cost)
+		var/material_amount = bullet_cost[material]
+		material_amount = (material_amount*stored_ammo.len) + base_cost[material]
+		materials[material] = material_amount
 
 //Behavior for magazines
 /obj/item/ammo_box/magazine/proc/ammo_count()

--- a/code/modules/projectiles/boxes_magazines/_box_magazine.dm
+++ b/code/modules/projectiles/boxes_magazines/_box_magazine.dm
@@ -9,7 +9,7 @@
 	item_state = "syringe_kit"
 	lefthand_file = 'icons/mob/inhands/equipment/medical_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/equipment/medical_righthand.dmi'
-	materials = list(MAT_METAL=30000)
+	materials = list(MAT_METAL = 30000)
 	throwforce = 2
 	w_class = WEIGHT_CLASS_TINY
 	throw_speed = 3
@@ -21,19 +21,19 @@
 	var/caliber
 	var/multiload = 1
 	var/start_empty = 0
-	var/list/bullet_cost = list() 
-	var/list/base_cost = list() // override this one as well if you override bullet_cost
+	var/list/bullet_cost
+	var/list/base_cost// override this one as well if you override bullet_cost
 
 /obj/item/ammo_box/Initialize()
 	. = ..()
-	if (!bullet_cost.len)
+	if (!bullet_cost)
 		for (var/material in materials)
 			var/material_amount = materials[material]
-			base_cost[material] = material_amount * 0.10
+			LAZYSET(base_cost, material, (material_amount * 0.10))
 
 			material_amount *= 0.90 // 10% for the container
 			material_amount /= max_ammo
-			bullet_cost[material] = material_amount
+			LAZYSET(bullet_cost, material, material_amount)
 	if(!start_empty)
 		for(var/i = 1, i <= max_ammo, i++)
 			stored_ammo += new ammo_type(src)

--- a/code/modules/projectiles/boxes_magazines/ammo_boxes.dm
+++ b/code/modules/projectiles/boxes_magazines/ammo_boxes.dm
@@ -13,6 +13,7 @@
 	ammo_type = /obj/item/ammo_casing/c38
 	max_ammo = 6
 	multiple_sprites = 1
+	materials = list(MAT_METAL = 20000)
 
 /obj/item/ammo_box/c9mm
 	name = "ammo box (9mm)"

--- a/code/modules/research/designs/autolathe_designs.dm
+++ b/code/modules/research/designs/autolathe_designs.dm
@@ -451,7 +451,7 @@
 	name = "Speed Loader (.38)"
 	id = "c38"
 	build_type = AUTOLATHE
-	materials = list(MAT_METAL = 30000)
+	materials = list(MAT_METAL = 20000)
 	build_path = /obj/item/ammo_box/c38
 	category = list("initial", "Security")
 


### PR DESCRIPTION
[Changelogs]: 

:cl: Dax Dupont
balance: After successful lobbying by the Space Ancap Federation ammo is no longer free. Material redemption cost is now determined by the amount of bullets left.
balance: .38 ammo is now cheaper to produce. 
balance: Casings now give a little bit of metal. mostly for immersion sake.
/:cl:

[why]: After seeing ye olde print infinite ammo murderboning I figured this would be a change that people might get behind. 
Things like the .357 are quite powerful, and being able to print and shoot infinite amounts of ammo by reclaiming the full amount on an empty mag seems obscene.
Might tweak the base cost if someone has input.
