### PR TITLE
Circuit Labels (sorta understanding git edition)

### DIFF
--- a/code/modules/integrated_electronics/core/assemblies.dm
+++ b/code/modules/integrated_electronics/core/assemblies.dm
@@ -3,7 +3,7 @@
 
 /obj/item/electronic_assembly
 	name = "electronic assembly"
-	obj_flags = CAN_BE_HIT
+	obj_flags = CAN_BE_HIT | UNIQUE_RENAME
 	desc = "It's a case, for building small electronics with."
 	w_class = WEIGHT_CLASS_SMALL
 	icon = 'icons/obj/assemblies/electronic_setups.dmi'

--- a/code/modules/integrated_electronics/core/saved_circuits.dm
+++ b/code/modules/integrated_electronics/core/saved_circuits.dm
@@ -146,6 +146,8 @@
 	// Validate name and color
 	if(assembly_params["name"] && !reject_bad_name(assembly_params["name"], TRUE))
 		return "Bad assembly name."
+	if(assembly_params["desc"] && !reject_bad_text(assembly_params["desc"], TRUE))
+		return "Bad assembly description."
 	if(assembly_params["detail_color"] && !(assembly_params["detail_color"] in color_whitelist))
 		return "Bad assembly color."
 

--- a/code/modules/integrated_electronics/core/saved_circuits.dm
+++ b/code/modules/integrated_electronics/core/saved_circuits.dm
@@ -124,6 +124,10 @@
 	// Save modified name
 	if(initial(name) != name)
 		assembly_params["name"] = name
+	
+	// Save modified description
+	if(initial(desc) != desc)
+		assembly_params["desc"] = desc
 
 	// Save panel status
 	if(opened)
@@ -151,6 +155,10 @@
 	// Load modified name, if any.
 	if(assembly_params["name"])
 		name = assembly_params["name"]
+		
+	// Load modified description, if any.
+	if(assembly_params["desc"])
+		desc = assembly_params["desc"]
 
 	// Load panel status
 	if(assembly_params["opened"])


### PR DESCRIPTION
I'm fairly certain this should actually compile this time

As of right now, all this PR should do is let you change the name/desc of assemblies like you would for papers/foods/etc. However, this doesn't touch the way assemblies were previously renamed, which was through the assembly interface, let me know if I should rework that

:cl: resistor
add: Added circuit labels! You can now customize the description of your assemblies.
/:cl:

[why]: 

Complex circuits tend not to be user-friendly, this lets you include instructions or other messages for future users.