### PR TITLE
Use bundled rather than remote jquery in tooltips

### DIFF
--- a/code/modules/tooltip/tooltip.html
+++ b/code/modules/tooltip/tooltip.html
@@ -93,7 +93,7 @@
 	<div id="wrap" class="wrap">
 		<div id="content" class="content"></div>
 	</div>
-	<script type="text/javascript" src="https://code.jquery.com/jquery-1.11.3.min.js"></script>
+	<script type="text/javascript" src="jquery.min.js"></script>
 	<script type="text/javascript">
 		var tooltip = {
 			'tileSize': 32,


### PR DESCRIPTION
In theory, fixes this message oranges was complaining about on IRC, though I've never seen it myself. Works on my machine:tm:.

`<oranges> https://file.house/Nu_1.png we should do something about this eventually`

![](https://file.house/Nu_1.png)

#30122