### PR TITLE
Adds missing donksoft vendor board to illegal tech node

### DIFF
--- a/code/modules/research/techweb/all_nodes.dm
+++ b/code/modules/research/techweb/all_nodes.dm
@@ -867,7 +867,7 @@
 	display_name = "Illegal Technology"
 	description = "Dangerous research used to create dangerous objects."
 	prereq_ids = list("adv_engi", "adv_weaponry", "explosive_weapons")
-	design_ids = list("decloner", "borg_syndicate_module", "suppressor", "largecrossbow")
+	design_ids = list("decloner", "borg_syndicate_module", "suppressor", "largecrossbow", "donksofttoyvendor")
 	research_cost = 10000
 	export_price = 5000
 	hidden = TRUE


### PR DESCRIPTION
:cl: Denton
fix: The Donksoft vendor board got lost during the techwebs transition and has been re-added under the illegal technology node.
/:cl:

You used to be able to print the donksoft vendor board after deconning illegal tech - now it's back in the 'Illegal Technology' node.