### PR TITLE
The alternative morph nerf

### DIFF
--- a/code/modules/antagonists/morph/morph.dm
+++ b/code/modules/antagonists/morph/morph.dm
@@ -109,8 +109,8 @@
 	pixel_x = initial(pixel_x)
 
 	//Morphed is weaker
-	melee_damage_lower = 5
-	melee_damage_upper = 5
+	melee_damage_lower = 0
+	melee_damage_upper = 0
 	speed = 0
 
 	morph_time = world.time + MORPH_COOLDOWN


### PR DESCRIPTION
This is an alternative fix to the complaint in #37588. It sets the speedy morph forms damage to 0. The reason why I made this fix because I was told that instead of complaining I should make an alternative fix. This is the alternative fix, It makes shapeshifted morphs nuzzle anyone they're attacking in the shapeshifted form. 

Edit: I also tested it, I'm a science man. Also, it only edits two lines of code, if PK penguin does the even better version of this, where it swaps into the tank form with the cooldown. Then that'd be great as well!