### PR TITLE
Fixes Tequila Sunrise naming

### DIFF
--- a/code/modules/food_and_drinks/recipes/drinks_recipes.dm
+++ b/code/modules/food_and_drinks/recipes/drinks_recipes.dm
@@ -139,7 +139,7 @@
 	required_reagents = list("tequila" = 2, "kahlua" = 1)
 
 /datum/chemical_reaction/tequila_sunrise
-	name = "tequila Sunrise"
+	name = "Tequila Sunrise"
 	id = "tequilasunrise"
 	results = list("tequilasunrise" = 5)
 	required_reagents = list("tequila" = 2, "orangejuice" = 2, "grenadine" = 1)


### PR DESCRIPTION
[Changelogs]:  Fixes #37652 - Changes Tequila Sunrise spelling to corrected value based on Issue #37652
(https://github.com/tgstation/tgstation/issues/37652)

:cl: Poetic_Iron
spellcheck: Fixed 'Tequila Sunrise' naming from 'tequila Sunrise'.
/:cl:

[why]: Proper use of English language concepts.
