### PR TITLE
Ghosts can now clap.

### DIFF
--- a/code/game/sound.dm
+++ b/code/game/sound.dm
@@ -1,8 +1,7 @@
-/proc/playsound(atom/source, soundin, vol as num, vary, extrarange as num, falloff, frequency = null, channel = 0, pressure_affected = TRUE, ignore_walls = TRUE)
+/proc/playsound(atom/source, soundin, vol as num, vary, extrarange as num, falloff, frequency = null, channel = 0, pressure_affected = TRUE, ignore_walls = TRUE, only_dead_mobs)
 	if(isarea(source))
 		throw EXCEPTION("playsound(): source is an area")
 		return
-
 	var/turf/turf_source = get_turf(source)
 
 	//allocate a channel if necessary now so its the same for everyone
@@ -11,9 +10,13 @@
  	// Looping through the player list has the added bonus of working for mobs inside containers
 	var/sound/S = sound(get_sfx(soundin))
 	var/maxdistance = (world.view + extrarange)
-	var/list/listeners = GLOB.player_list
-	if(!ignore_walls) //these sounds don't carry through walls
-		listeners = listeners & hearers(maxdistance,turf_source)
+	var/list/listeners
+	if (only_dead_mobs)
+		listeners = GLOB.dead_mob_list
+	else
+		listeners = GLOB.player_list
+		if(!ignore_walls) //these sounds don't carry through walls
+			listeners = listeners & hearers(maxdistance,turf_source)
 	for(var/P in listeners)
 		var/mob/M = P
 		if(!M || !M.client)

--- a/code/modules/mob/emote.dm
+++ b/code/modules/mob/emote.dm
@@ -46,3 +46,28 @@
 					riding_datum.force_dismount(M)
 			else
 				R.unbuckle_all_mobs()
+
+/datum/emote/clap
+	key = "clap"
+	key_third_person = "claps"
+	message = "claps."
+	muzzle_ignore = TRUE
+	restraint_check = TRUE
+	mob_type_allowed_typecache = list(/mob/living/carbon/human, /mob/dead/observer)
+	mob_type_ignore_stat_typecache = list(/mob/dead/observer)
+
+/datum/emote/clap/run_emote(mob/user, params)
+	. = ..()
+	if (.)
+		var/clap = pick('sound/misc/clap1.ogg',
+				        'sound/misc/clap2.ogg',
+				        'sound/misc/clap3.ogg',
+				        'sound/misc/clap4.ogg')
+		if (ishuman(user))
+			// Need hands to clap
+			var/mob/living/carbon/human/H = user
+			if (!H.get_bodypart("l_arm") || !H.get_bodypart("r_arm"))
+				return
+			playsound(H, clap, 50, 1, -1)
+		else if (isobserver(user))
+			playsound(user, clap, 50, 1, -1, 0, null, 0, FALSE, TRUE, TRUE)

--- a/code/modules/mob/living/carbon/emote.dm
+++ b/code/modules/mob/living/carbon/emote.dm
@@ -15,27 +15,6 @@
 	key = "blink_r"
 	message = "blinks rapidly."
 
-/datum/emote/living/carbon/clap
-	key = "clap"
-	key_third_person = "claps"
-	message = "claps."
-	muzzle_ignore = TRUE
-	restraint_check = TRUE
-	emote_type = EMOTE_AUDIBLE
-
-/datum/emote/living/carbon/clap/run_emote(mob/living/user, params)
-	. = ..()
-	if (.)
-		if (ishuman(user))
-			// Need hands to clap
-			if (!user.get_bodypart("l_arm") || !user.get_bodypart("r_arm"))
-				return
-			var/clap = pick('sound/misc/clap1.ogg',
-				            'sound/misc/clap2.ogg',
-				            'sound/misc/clap3.ogg',
-				            'sound/misc/clap4.ogg')
-			playsound(user, clap, 50, 1, -1)
-
 /datum/emote/living/carbon/gnarl
 	key = "gnarl"
 	key_third_person = "gnarls"


### PR DESCRIPTION
[Changelogs]: 
:cl: Dax Dupont
add: Ghosts can now clap. Please clap.
code: playsound now has an argument to only play to dead mobs.
/:cl:

[why]: This has been requested ingame so many times I've lost count.
Clapping fits the peanut gallery that is deadchat.
