### PR TITLE
Replaces the Roman Shield and Roman Helmets in the autodrobe with fake versions with no block chance nor armour values.

### DIFF
--- a/code/game/objects/items/shields.dm
+++ b/code/game/objects/items/shields.dm
@@ -44,6 +44,7 @@
 	item_state = "roman_shield"
 	lefthand_file = 'icons/mob/inhands/equipment/shields_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/equipment/shields_righthand.dmi'
+	block_chance = 0
 
 /obj/item/shield/riot/buckler
 	name = "wooden buckler"

--- a/code/game/objects/items/shields.dm
+++ b/code/game/objects/items/shields.dm
@@ -45,8 +45,10 @@
 	lefthand_file = 'icons/mob/inhands/equipment/shields_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/equipment/shields_righthand.dmi'
 
-/obj/item/shield/riot/roman/toy
+/obj/item/shield/riot/roman/fake
+	desc = "Bears an inscription on the inside: <i>\"Romanes venio domus\"</i>. It appears to be a bit flimsy."
 	block_chance = 0
+	armor = list("melee" = 0, "bullet" = 0, "laser" = 0, "energy" = 0, "bomb" = 0, "bio" = 0, "rad" = 0, "fire" = 0, "acid" = 0)
 
 /obj/item/shield/riot/buckler
 	name = "wooden buckler"

--- a/code/game/objects/items/shields.dm
+++ b/code/game/objects/items/shields.dm
@@ -44,6 +44,8 @@
 	item_state = "roman_shield"
 	lefthand_file = 'icons/mob/inhands/equipment/shields_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/equipment/shields_righthand.dmi'
+
+/obj/item/shield/riot/roman/toy
 	block_chance = 0
 
 /obj/item/shield/riot/buckler

--- a/code/modules/clothing/head/helmet.dm
+++ b/code/modules/clothing/head/helmet.dm
@@ -161,11 +161,19 @@
 	strip_delay = 100
 	dog_fashion = null
 
+/obj/item/clothing/head/helmet/roman/fake
+	desc = "An ancient helmet made of plastic and leather."
+	armor = list("melee" = 0, "bullet" = 0, "laser" = 0, "energy" = 0, "bomb" = 0, "bio" = 0, "rad" = 0, "fire" = 0, "acid" = 0)
+
 /obj/item/clothing/head/helmet/roman/legionaire
 	name = "roman legionaire helmet"
 	desc = "An ancient helmet made of bronze and leather. Has a red crest on top of it."
 	icon_state = "roman_c"
 	item_state = "roman_c"
+
+/obj/item/clothing/head/helmet/roman/legionaire/fake
+	desc = "An ancient helmet made of plastic and leather. Has a red crest on top of it."
+	armor = list("melee" = 0, "bullet" = 0, "laser" = 0, "energy" = 0, "bomb" = 0, "bio" = 0, "rad" = 0, "fire" = 0, "acid" = 0)
 
 /obj/item/clothing/head/helmet/gladiator
 	name = "gladiator helmet"

--- a/code/modules/vending/autodrobe.dm
+++ b/code/modules/vending/autodrobe.dm
@@ -118,7 +118,7 @@
 		           /obj/item/clothing/head/helmet/roman/legionaire = 1,
 		           /obj/item/clothing/under/roman = 1,
 		           /obj/item/clothing/shoes/roman = 1,
-		           /obj/item/shield/riot/roman = 1,
+		           /obj/item/shield/riot/roman/toy = 1,
 		           /obj/item/skub = 1)
 	refill_canister = /obj/item/vending_refill/autodrobe
 

--- a/code/modules/vending/autodrobe.dm
+++ b/code/modules/vending/autodrobe.dm
@@ -114,11 +114,11 @@
 		              /obj/item/clothing/mask/muzzle = 2)
 	premium = list(/obj/item/clothing/suit/pirate/captain = 2,
 		           /obj/item/clothing/head/pirate/captain = 2,
-		           /obj/item/clothing/head/helmet/roman = 1,
-		           /obj/item/clothing/head/helmet/roman/legionaire = 1,
+		           /obj/item/clothing/head/helmet/roman/fake = 1,
+		           /obj/item/clothing/head/helmet/roman/legionaire/fake = 1,
 		           /obj/item/clothing/under/roman = 1,
 		           /obj/item/clothing/shoes/roman = 1,
-		           /obj/item/shield/riot/roman/toy = 1,
+		           /obj/item/shield/riot/roman/fake = 1,
 		           /obj/item/skub = 1)
 	refill_canister = /obj/item/vending_refill/autodrobe
 


### PR DESCRIPTION
This PR was made on behalf of Bluespace, since it was frankly silly that a vending machine item can block like a riot shield from the armory, and it was often abused by powergamers. This PR also now removes armour values from the fake roman shields, and adds fake roman helmets with no armour values.

Now a message from our sponsors, Bluespace: 

[PR made on behalf of Bluespace because he doesn't know how to into git]
The roman shield is a neat idea in theory, but ultimately it's been repeatedly abused by the same few people to get a free riot shield at roundstart purely to go ahead and powergame. I really don't think this is fun for anyone but the person with the shield, so this PR removes the ability for the roman shield to block stunbaton after stunbaton. Armour values are unchanged, comments welcome.

Note: In case anyone asks. The Roman Armour(jumpsuit) and Roman Sandals already lacks armour values. Only the shield and helmets had it. Funnily enough that might explain why the Skeleton Romans get fucked up so easily during wizard.

:cl: Firecage & Bluespace
balance: Replaces the Roman Shield and Roman helmets in the Autodrobe with fake versions with neither block chance nor armour values.
/:cl:
