### PR TITLE
Linked teleporters now teleport to the hub instead of the power station

### DIFF
--- a/code/game/machinery/computer/teleporter.dm
+++ b/code/game/machinery/computer/teleporter.dm
@@ -174,25 +174,26 @@
 
 	else
 		var/list/S = power_station.linked_stations
-		if(!S.len)
-			to_chat(user, "<span class='alert'>No connected stations located.</span>")
-			return
 		for(var/obj/machinery/teleport/station/R in S)
-			if(is_eligible(R))
+			if(is_eligible(R) && R.teleporter_hub)
 				var/area/A = get_area(R)
 				L[avoid_assoc_duplicate_keys(A.name, areaindex)] = R
+		if(!L.len)
+			to_chat(user, "<span class='alert'>No active connected stations located.</span>")
+			return
 		var/desc = input("Please select a station to lock in.", "Locking Computer") as null|anything in L
-		target = L[desc]
-		if(target)
-			var/obj/machinery/teleport/station/trg = target
-			trg.linked_stations |= power_station
-			trg.stat &= ~NOPOWER
-			if(trg.teleporter_hub)
-				trg.teleporter_hub.stat &= ~NOPOWER
-				trg.teleporter_hub.update_icon()
-			if(trg.teleporter_console)
-				trg.teleporter_console.stat &= ~NOPOWER
-				trg.teleporter_console.update_icon()
+		var/obj/machinery/teleport/station/target_station = L[desc]
+		if(!target_station || !target_station.teleporter_hub)
+			return
+		target = target_station.teleporter_hub
+		target_station.linked_stations |= power_station
+		target_station.stat &= ~NOPOWER
+		if(target_station.teleporter_hub)
+			target_station.teleporter_hub.stat &= ~NOPOWER
+			target_station.teleporter_hub.update_icon()
+		if(target_station.teleporter_console)
+			target_station.teleporter_console.stat &= ~NOPOWER
+			target_station.teleporter_console.update_icon()
 
 /obj/machinery/computer/teleporter/proc/is_eligible(atom/movable/AM)
 	var/turf/T = get_turf(AM)

--- a/code/game/machinery/teleporter.dm
+++ b/code/game/machinery/teleporter.dm
@@ -47,7 +47,6 @@
 		return
 	if(is_ready())
 		teleport(AM)
-		use_power(5000)
 
 /obj/machinery/teleport/hub/attackby(obj/item/W, mob/user, params)
 	if(default_deconstruction_screwdriver(user, "tele-o", "tele0", W))
@@ -61,13 +60,15 @@
 
 /obj/machinery/teleport/hub/proc/teleport(atom/movable/M as mob|obj, turf/T)
 	var/obj/machinery/computer/teleporter/com = power_station.teleporter_console
-	if (!com)
+	if (QDELETED(com))
 		return
-	if (!com.target)
+	if (QDELETED(com.target))
+		com.target = null
 		visible_message("<span class='alert'>Cannot authenticate locked on coordinates. Please reinstate coordinate matrix.</span>")
 		return
 	if (ismovableatom(M))
 		if(do_teleport(M, com.target))
+			use_power(5000)
 			if(!calibrated && prob(30 - ((accurate) * 10))) //oh dear a problem
 				if(ishuman(M))//don't remove people from the round randomly you jerks
 					var/mob/living/carbon/human/human = M


### PR DESCRIPTION
:cl: XDTM
tweak: Teleporters linked to other teleporters now teleport into the other teleporter's hub, instead of the power station.
fix: Teleporters now no longer consume power if teleportation fails.
/:cl:

Always irked me a bit that it didn't target the portal itself. PR also includes minor fixes/code improvements.