### PR TITLE
Fixes large crates (Issue #36516)

### DIFF
--- a/code/game/objects/structures/crates_lockers/crates/large.dm
+++ b/code/game/objects/structures/crates_lockers/crates/large.dm
@@ -4,12 +4,11 @@
 	icon_state = "largecrate"
 	density = TRUE
 	material_drop = /obj/item/stack/sheet/mineral/wood
+	material_drop_amount = 4
 	delivery_icon = "deliverybox"
+	integrity_failure = 0 //Makes the crate break when integrity reaches 0, instead of opening and becoming an invisible sprite.
 
 /obj/structure/closet/crate/large/attack_hand(mob/user)
-	. = ..()
-	if(.)
-		return
 	add_fingerprint(user)
 	if(manifest)
 		tear_manifest(user)
@@ -18,7 +17,7 @@
 
 /obj/structure/closet/crate/large/attackby(obj/item/W, mob/user, params)
 	if(istype(W, /obj/item/crowbar))
-		var/turf/T = get_turf(src)
+		//var/turf/T = get_turf(src)
 		if(manifest)
 			tear_manifest(user)
 
@@ -27,11 +26,18 @@
 							 "<span class='italics'>You hear splitting wood.</span>")
 		playsound(src.loc, 'sound/weapons/slashmiss.ogg', 75, 1)
 
-		for(var/i in 1 to rand(2, 5))
-			new material_drop(src)
+		var/turf/T = get_turf(src)
+		for(var/i in 1 to 4)
+			new material_drop(src) //Drop 4 planks, same as the material_drop_amount if destroyed
 		for(var/atom/movable/AM in contents)
 			AM.forceMove(T)
 
 		qdel(src)
+
 	else
-		return ..()
+		if(user.a_intent == INTENT_HARM)	//Only return  ..() if intent is harm, otherwise return 0 or just end it.
+			return ..()						//Stops it from opening and turning invisible when items are used on it.
+
+		else
+			return 0 //Just stop. Do nothing. Don't turn into an invisible sprite. Don't open like a locker.
+					//The large crate has no non-attack interactions other than the crowbar, anyway.

--- a/code/game/objects/structures/crates_lockers/crates/large.dm
+++ b/code/game/objects/structures/crates_lockers/crates/large.dm
@@ -17,7 +17,6 @@
 
 /obj/structure/closet/crate/large/attackby(obj/item/W, mob/user, params)
 	if(istype(W, /obj/item/crowbar))
-		//var/turf/T = get_turf(src)
 		if(manifest)
 			tear_manifest(user)
 

--- a/code/game/objects/structures/crates_lockers/crates/large.dm
+++ b/code/game/objects/structures/crates_lockers/crates/large.dm
@@ -1,6 +1,6 @@
 /obj/structure/closet/crate/large
 	name = "large crate"
-	desc = "A hefty wooden crate."
+	desc = "A hefty wooden crate. You'll need a crowbar to get it open."
 	icon_state = "largecrate"
 	density = TRUE
 	material_drop = /obj/item/stack/sheet/mineral/wood
@@ -26,8 +26,8 @@
 		playsound(src.loc, 'sound/weapons/slashmiss.ogg', 75, 1)
 
 		var/turf/T = get_turf(src)
-		for(var/i in 1 to 4)
-			new material_drop(src) //Drop 4 planks, same as the material_drop_amount if destroyed
+		for(var/i in 1 to material_drop_amount)
+			new material_drop(src)
 		for(var/atom/movable/AM in contents)
 			AM.forceMove(T)
 
@@ -38,5 +38,6 @@
 			return ..()						//Stops it from opening and turning invisible when items are used on it.
 
 		else
-			return 0 //Just stop. Do nothing. Don't turn into an invisible sprite. Don't open like a locker.
+			to_chat(user, "<span class='warning'>You need a crowbar to pry this open!</span>")
+			return FALSE //Just stop. Do nothing. Don't turn into an invisible sprite. Don't open like a locker.
 					//The large crate has no non-attack interactions other than the crowbar, anyway.


### PR DESCRIPTION
[Changelogs]: # (Your PR should contain a detailed changelog of notable changes, titled and categorized appropriately. This includes, new features, sprites, sounds, balance changes, admin tools, map edits, removals, big refactors, config changes, hosting changes and important fixes. An example changelog has been provided below for you to edit. If you need additional help, read https://github.com/tgstation/tgstation/wiki/Changelogs)

:cl: Alexch2
fix: Large crates no longer behave like lockers. They no longer open into invisible sprites when damaged, interacted with, when "toggle open" is used, or when non-crowbar items are used on them.
/:cl:

[why]: # (Please add a short description [two lines down] of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.)

Fixes #36516, and removes an exploit where you can use these invisible boxes to block off areas.