### PR TITLE
Fixes a radiation runtime related to going off the map edge

### DIFF
--- a/code/datums/radiation_wave.dm
+++ b/code/datums/radiation_wave.dm
@@ -29,6 +29,9 @@
 
 /datum/radiation_wave/process()
 	master_turf = get_step(master_turf, move_dir)
+	if(!master_turf)
+		qdel(src)
+		return
 	steps++
 	var/list/atoms = get_rad_atoms()
 


### PR DESCRIPTION
I have no clue how this wasn't caught for so long, I fixed this during original solo testing but the code got lost somewhere and we apparently never had a major source of radiation near the map edge.