### PR TITLE
Adds fire alarm electronics to engivend

### DIFF
--- a/code/modules/vending/engivend.dm
+++ b/code/modules/vending/engivend.dm
@@ -13,7 +13,8 @@
 					/obj/item/stock_parts/cell/high = 10,
 					/obj/item/electronics/airlock = 10, 
 					/obj/item/electronics/apc = 10, 
-					/obj/item/electronics/airalarm = 10)
+					/obj/item/electronics/airalarm = 10,
+					/obj/item/electronics/firealarm = 10)
 	contraband = list(/obj/item/stock_parts/cell/potato = 3)
 	premium = list(/obj/item/storage/belt/utility = 3,
 		           /obj/item/storage/box/smart_metal_foam = 1)


### PR DESCRIPTION
:cl: Denton
tweak: Fire alarm electronics are now available at an Engi-Vend near you.
/:cl:

Those are only available at the autolathe, other than that you have one or two in tech storage depending on the map. 
Bit silly if all other construction related electronics are either available at engivend or engineering locker.