### PR TITLE
[s] Fix wallets acting as though they still contain removed IDs

### DIFF
--- a/code/game/objects/items/storage/wallets.dm
+++ b/code/game/objects/items/storage/wallets.dm
@@ -38,16 +38,20 @@
 
 /obj/item/storage/wallet/Exited(atom/movable/AM)
 	. = ..()
-	refreshID()
+	// The loc has not actually changed yet when this proc is called, so call
+	// refreshID and have it ignore the outgoing atom.
+	refreshID(AM)
 
-/obj/item/storage/wallet/proc/refreshID()
-	if(!(front_id in src))
+/obj/item/storage/wallet/proc/refreshID(atom/movable/removed)
+	LAZYCLEARLIST(combined_access)
+	if(!(front_id in src) || front_id == removed)
 		front_id = null
 	for(var/obj/item/card/id/I in contents)
-		LAZYINITLIST(combined_access)
-		LAZYCLEARLIST(combined_access)
+		if(I == removed)
+			continue
 		if(!front_id)
 			front_id = I
+		LAZYINITLIST(combined_access)
 		combined_access |= I.access
 	update_icon()
 


### PR DESCRIPTION
:cl:
fix: Removing an ID card from a wallet now properly removes its visual and accesses.
/:cl:

Fixes #37675.