### PR TITLE
Stops qdeleted objects from taking damage.

### DIFF
--- a/code/game/objects/obj_defense.dm
+++ b/code/game/objects/obj_defense.dm
@@ -1,6 +1,8 @@
 
 //the essential proc to call when an obj must receive damage of any kind.
 /obj/proc/take_damage(damage_amount, damage_type = BRUTE, damage_flag = 0, sound_effect = 1, attack_dir, armour_penetration = 0)
+	if(QDELETED(src))
+		return
 	if(sound_effect)
 		play_attack_sound(damage_amount, damage_type, damage_flag)
 	if(!(resistance_flags & INDESTRUCTIBLE) && obj_integrity > 0)

--- a/code/game/objects/obj_defense.dm
+++ b/code/game/objects/obj_defense.dm
@@ -2,6 +2,7 @@
 //the essential proc to call when an obj must receive damage of any kind.
 /obj/proc/take_damage(damage_amount, damage_type = BRUTE, damage_flag = 0, sound_effect = 1, attack_dir, armour_penetration = 0)
 	if(QDELETED(src))
+		stack_trace("[src] taking damage after deletion")
 		return
 	if(sound_effect)
 		play_attack_sound(damage_amount, damage_type, damage_flag)


### PR DESCRIPTION
There's a lot of side-effects to object damage, it makes sense to ignore it when it's not relevant anymore but i'm not sure blanket check like this is good idea since it will make detecting incorrect behaviour harder. Opinions on this ?