### PR TITLE
[s] Removes some stationloving-related failure surface

### DIFF
--- a/code/datums/components/stationloving.dm
+++ b/code/datums/components/stationloving.dm
@@ -28,13 +28,7 @@
 			CRASH("Unable to find a blobstart landmark")
 
 	var/atom/movable/AM = parent
-	if(ismob(AM.loc))
-		var/mob/M = AM.loc
-		M.transferItemToLoc(AM, targetturf, TRUE)	//nodrops disks when?
-	else if(AM.loc.SendSignal(COMSIG_CONTAINS_STORAGE))
-		AM.loc.SendSignal(COMSIG_TRY_STORAGE_TAKE, src, targetturf, TRUE)
-	else
-		AM.forceMove(targetturf)
+	AM.forceMove(targetturf)
 	// move the disc, so ghosts remain orbiting it even if it's "destroyed"
 	return targetturf
 

--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -758,3 +758,18 @@ GLOBAL_VAR_INIT(rpg_loot_items, FALSE)
 // Returns a numeric value for sorting items used as parts in machines, so they can be replaced by the rped
 /obj/item/proc/get_part_rating()
 	return 0
+
+/obj/item/doMove(atom/destination)
+	if (ismob(loc))
+		var/mob/M = loc
+		var/hand_index = M.get_held_index_of_item(src)
+		if(hand_index)
+			M.held_items[hand_index] = null
+			M.update_inv_hands()
+			if(M.client)
+				M.client.screen -= src
+			layer = initial(layer)
+			plane = initial(plane)
+			appearance_flags &= ~NO_CLIENT_COLOR
+			dropped(M)
+	return ..()

--- a/code/modules/mob/inventory.dm
+++ b/code/modules/mob/inventory.dm
@@ -326,7 +326,10 @@
 		I.plane = initial(I.plane)
 		I.appearance_flags &= ~NO_CLIENT_COLOR
 		if(!no_move && !(I.flags_1 & DROPDEL_1))	//item may be moved/qdel'd immedietely, don't bother moving it
-			I.forceMove(newloc)
+			if (isnull(newloc))
+				I.moveToNullspace()
+			else
+				I.forceMove(newloc)
 		I.dropped(src)
 	return TRUE
 


### PR DESCRIPTION
`COMSIG_TRY_STORAGE_TAKE` fails, leaving the disk out-of-bounds. forceMove **HAS** to be good enough here. 
