### PR TITLE
Removes stun gloves

### DIFF
--- a/code/modules/ninja/suit/ninjaDrainAct.dm
+++ b/code/modules/ninja/suit/ninjaDrainAct.dm
@@ -244,21 +244,3 @@ They *could* go in their appropriate files, but this is supposed to be modular
 				. += drain
 			else
 				break
-
-
-//CARBON MOBS//
-/mob/living/carbon/ninjadrain_act(obj/item/clothing/suit/space/space_ninja/S, mob/living/carbon/human/H, obj/item/clothing/gloves/space_ninja/G)
-	if(!S || !H || !G)
-		return INVALID_DRAIN
-
-	. = DRAIN_MOB_SHOCK_FAILED
-
-	//Default cell = 10,000 charge, 10,000/1000 = 10 uses without charging/upgrading
-	if(S.cell && S.cell.charge && S.cell.use(1000))
-		. = DRAIN_MOB_SHOCK
-		//Got that electric touch
-		var/datum/effect_system/spark_spread/spark_system = new /datum/effect_system/spark_spread()
-		spark_system.set_up(5, 0, loc)
-		playsound(src, "sparks", 50, 1)
-		visible_message("<span class='danger'>[H] electrocutes [src] with [H.p_their()] touch!</span>", "<span class='userdanger'>[H] electrocutes you with [H.p_their()] touch!</span>")
-		electrocute_act(25, H)


### PR DESCRIPTION
from ninjas

we must retake the holy code from the stun glove infidels
:cl: Iamgoofball
balance: Removes stun gloves from Ninjas.
/:cl:

ninjas have literal teleports behind u nothin personell kid and free invisibility and are damn near impossible to kill, they do not need stun gloves