### PR TITLE
fixes a money loop

### DIFF
--- a/code/modules/cargo/exports/large_objects.dm
+++ b/code/modules/cargo/exports/large_objects.dm
@@ -101,7 +101,7 @@
 	export_types = list(/obj/machinery/iv_drip)
 
 /datum/export/large/barrier
-	cost = 325
+	cost = 100
 	unit_name = "security barrier"
 	export_types = list(/obj/item/grenade/barrier, /obj/structure/barricade/security)
 


### PR DESCRIPTION
:cl: 
fix: fixes a possible money exploit
/:cl:

why: if you buy the barrier crate, open it, spam all the grenades in vertical mode u ll get more money that the crate is worth
before: 4 grenades -> 12 barriers * 325 credits -> 3900 + 500 (crate) + 200 (manifest) -> 4600 which is a +2600 net gain
now:  4 grenades -> 12 barriers * 100 credits -> 1200+ 500 (crate) + 200 (manifest) -> 1900 which is a -100 net loss
