### PR TITLE
(NOT TESTED YET) Fixes Bedbuckling to avoid Floor is Lava

### DIFF
--- a/code/datums/weather/weather_types/floor_is_lava.dm
+++ b/code/datums/weather/weather_types/floor_is_lava.dm
@@ -26,7 +26,9 @@
 	if(issilicon(L))
 		return
 	for(var/obj/structure/O in L.loc)
-		if(O.density || (L in O.buckled_mobs && istype(O, /obj/structure/bed)))
+		if(O.density)
+			return
+		if((L.buckled == O) && istype(O, /obj/structure/bed))
 			return
 	if(L.loc.density)
 		return

--- a/code/datums/weather/weather_types/floor_is_lava.dm
+++ b/code/datums/weather/weather_types/floor_is_lava.dm
@@ -25,10 +25,10 @@
 /datum/weather/floor_is_lava/weather_act(mob/living/L)
 	if(issilicon(L))
 		return
+	if(istype(L.buckled, /obj/structure/bed))
+		return
 	for(var/obj/structure/O in L.loc)
 		if(O.density)
-			return
-		if((L.buckled == O) && istype(O, /obj/structure/bed))
 			return
 	if(L.loc.density)
 		return


### PR DESCRIPTION
:cl: Cobby
fix: Beds will now properly save you from floor is lava, but only if you buckle to them
/:cl:

I'm assuming it's something dumb with not wrapping L in O.buckled_mobs in parenthesis but just in case I based it off the mob instead :^) 

Fixes #37738