### PR TITLE
family heirlooms properly open the backpack upon spawning if they're in the backpack

### DIFF
--- a/code/datums/traits/negative.dm
+++ b/code/datums/traits/negative.dm
@@ -65,8 +65,8 @@
 	var/where = H.equip_in_one_of_slots(heirloom, slots)
 	if(!where)
 		where = "at your feet"
-		if(where == "in your backpack")
-			H.back.SendSignal(COMSIG_TRY_STORAGE_SHOW, H)
+	else if(where == "in your backpack")
+		H.back.SendSignal(COMSIG_TRY_STORAGE_SHOW, H)
 	where_text = "<span class='boldnotice'>There is a precious family [heirloom.name] [where], passed down from generation to generation. Keep it safe!</span>"
 
 /datum/quirk/family_heirloom/post_add()


### PR DESCRIPTION
https://github.com/tgstation/tgstation/commit/bd42041c9ccc3a5a98c0ddf75151669b97e1324a#diff-bcdee240f4254f13767fcfd4902927e7R59

:cl: Iamgoofball
fix: Family Heirlooms now properly show you where they are stored if they spawn in a bag.
/:cl: