### PR TITLE
Some circuitry fixes and qol

### DIFF
--- a/code/modules/integrated_electronics/core/assemblies.dm
+++ b/code/modules/integrated_electronics/core/assemblies.dm
@@ -402,7 +402,7 @@
 
 /obj/item/electronic_assembly/attackby(obj/item/I, mob/living/user)
 	if(can_anchor && default_unfasten_wrench(user, I, 20))
-		return
+		return TRUE
 	if(istype(I, /obj/item/integrated_circuit))
 		if(!user.canUnEquip(I))
 			return FALSE
@@ -451,6 +451,7 @@
 			S.attackby_react(I,user,user.a_intent)
 		if(user.a_intent != INTENT_HELP)
 			return ..()
+		return TRUE
 
 
 /obj/item/electronic_assembly/attack_self(mob/user)

--- a/code/modules/integrated_electronics/core/assemblies.dm
+++ b/code/modules/integrated_electronics/core/assemblies.dm
@@ -402,7 +402,7 @@
 
 /obj/item/electronic_assembly/attackby(obj/item/I, mob/living/user)
 	if(can_anchor && default_unfasten_wrench(user, I, 20))
-		return TRUE
+		return
 	if(istype(I, /obj/item/integrated_circuit))
 		if(!user.canUnEquip(I))
 			return FALSE
@@ -451,7 +451,6 @@
 			S.attackby_react(I,user,user.a_intent)
 		if(user.a_intent != INTENT_HELP)
 			return ..()
-		return TRUE
 
 
 /obj/item/electronic_assembly/attack_self(mob/user)

--- a/code/modules/integrated_electronics/core/assemblies.dm
+++ b/code/modules/integrated_electronics/core/assemblies.dm
@@ -13,7 +13,7 @@
 	var/list/assembly_components = list()
 	var/max_components = IC_MAX_SIZE_BASE
 	var/max_complexity = IC_COMPLEXITY_BASE
-	var/opened = FALSE
+	var/opened = TRUE
 	var/obj/item/stock_parts/cell/battery // Internal cell which most circuits need to work.
 	var/cell_type = /obj/item/stock_parts/cell
 	var/can_charge = TRUE //Can it be charged in a recharger?
@@ -449,7 +449,8 @@
 	else
 		for(var/obj/item/integrated_circuit/input/S in assembly_components)
 			S.attackby_react(I,user,user.a_intent)
-		return ..()
+		if(user.a_intent != INTENT_HELP)
+			return ..()
 
 
 /obj/item/electronic_assembly/attack_self(mob/user)

--- a/code/modules/integrated_electronics/core/printer.dm
+++ b/code/modules/integrated_electronics/core/printer.dm
@@ -259,8 +259,10 @@
 
 				if(program["requires_upgrades"] && !upgraded && !debug)
 					to_chat(usr, "<span class='warning'>This program uses unknown component designs. Printer upgrade is required to proceed.</span>")
+					return
 				if(program["unsupported_circuit"] && !debug)
 					to_chat(usr, "<span class='warning'>This program uses components not supported by the specified assembly. Please change the assembly type in the save file to a supported one.</span>")
+					return
 				else if(fast_clone || debug)
 					var/datum/component/material_container/materials = GetComponent(/datum/component/material_container)
 					if(debug || materials.use_amount_type(program["metal_cost"], MAT_METAL))

--- a/code/modules/integrated_electronics/core/saved_circuits.dm
+++ b/code/modules/integrated_electronics/core/saved_circuits.dm
@@ -125,10 +125,6 @@
 	if(initial(name) != name)
 		assembly_params["name"] = name
 
-	// Save panel status
-	if(opened)
-		assembly_params["opened"] = TRUE
-
 	// Save modified color
 	if(initial(detail_color) != detail_color)
 		assembly_params["detail_color"] = detail_color
@@ -151,10 +147,6 @@
 	// Load modified name, if any.
 	if(assembly_params["name"])
 		name = assembly_params["name"]
-
-	// Load panel status
-	if(assembly_params["opened"])
-		opened = TRUE
 
 	if(assembly_params["detail_color"])
 		detail_color = assembly_params["detail_color"]

--- a/code/modules/integrated_electronics/subtypes/input.dm
+++ b/code/modules/integrated_electronics/subtypes/input.dm
@@ -878,6 +878,7 @@
 			return FALSE
 	set_pin_data(IC_OUTPUT, 1, WEAKREF(A))
 	push_data()
+	to_chat(usr, "<span class='notice'>You scan [A] with [assembly].</span>")
 	activate_pin(1)
 	return TRUE
 
@@ -910,6 +911,7 @@
 			return FALSE
 	set_pin_data(IC_OUTPUT, 1, WEAKREF(A))
 	push_data()
+	to_chat(usr, "<span class='notice'>You scan [A] with [assembly].</span>")
 	activate_pin(1)
 	return TRUE
 
@@ -936,6 +938,7 @@
 		user.transferItemToLoc(A,drop_location())
 	set_pin_data(IC_OUTPUT, 1, WEAKREF(A))
 	push_data()
+	to_chat(user, "<span class='notice'>You let [assembly] scan [A].</span>")
 	activate_pin(1)
 	return TRUE
 

--- a/code/modules/integrated_electronics/subtypes/input.dm
+++ b/code/modules/integrated_electronics/subtypes/input.dm
@@ -878,7 +878,7 @@
 			return FALSE
 	set_pin_data(IC_OUTPUT, 1, WEAKREF(A))
 	push_data()
-	to_chat(usr, "<span class='notice'>You scan [A] with [assembly].</span>")
+	to_chat(user, "<span class='notice'>You scan [A] with [assembly].</span>")
 	activate_pin(1)
 	return TRUE
 
@@ -911,7 +911,7 @@
 			return FALSE
 	set_pin_data(IC_OUTPUT, 1, WEAKREF(A))
 	push_data()
-	to_chat(usr, "<span class='notice'>You scan [A] with [assembly].</span>")
+	to_chat(user, "<span class='notice'>You scan [A] with [assembly].</span>")
 	activate_pin(1)
 	return TRUE
 


### PR DESCRIPTION
Fixes #36498

[Changelogs]: # (Your PR should contain a detailed changelog of notable changes, titled and categorized appropriately. This includes, new features, sprites, sounds, balance changes, admin tools, map edits, removals, big refactors, config changes, hosting changes and important fixes. An example changelog has been provided below for you to edit. If you need additional help, read https://github.com/tgstation/tgstation/wiki/Changelogs)

:cl: Garen
del: Removed circuitry save files saving whether or not the assembly is open.
add: Adds messages for when you successfully use a sensor or scanner circuit.
fix: Fixed circuit printers printing advanced assemblies from save files despite not being upgraded.
fix: Fixed circuit printers printing circuits into assemblies that wouldn't normally be able to hold them.
fix: Fixed circuit assemblies taking damage when using objects with the help intent.
/:cl:

[why]: # (Please add a short description [two lines down] of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.)

I removed the ability for you to save whether or not an assembly is open since you always want the assembly to be open when its printed so you can put a battery in. I added messages when the sensor and scanner circuits are used since it is sometimes unclear if it worked(such as how using a sensor with harm intent doesn't work but there was nothing to tell the user if it did or didn't scan). I fixed the other three issues because they were bugs.