### PR TITLE
[WIP] Fusion Rework, Episode IV

### DIFF
--- a/code/modules/atmospherics/gasmixtures/gas_types.dm
+++ b/code/modules/atmospherics/gasmixtures/gas_types.dm
@@ -56,7 +56,7 @@ GLOBAL_LIST_INIT(hardcoded_gases, list(/datum/gas/oxygen, /datum/gas/nitrogen, /
 	id = "co2"
 	specific_heat = 30
 	name = "Carbon Dioxide"
-	fusion_power = 2
+	fusion_power = 3
 
 /datum/gas/plasma
 	id = "plasma"
@@ -72,6 +72,7 @@ GLOBAL_LIST_INIT(hardcoded_gases, list(/datum/gas/oxygen, /datum/gas/nitrogen, /
 	name = "Water Vapor"
 	gas_overlay = "water_vapor"
 	moles_visible = MOLES_GAS_VISIBLE
+	fusion_power = 6
 
 /datum/gas/hypernoblium
 	id = "nob"
@@ -88,7 +89,6 @@ GLOBAL_LIST_INIT(hardcoded_gases, list(/datum/gas/oxygen, /datum/gas/nitrogen, /
 	gas_overlay = "nitrous_oxide"
 	moles_visible = 1
 	dangerous = TRUE
-	fusion_power = 2
 
 /datum/gas/nitryl
 	id = "no2"
@@ -97,7 +97,7 @@ GLOBAL_LIST_INIT(hardcoded_gases, list(/datum/gas/oxygen, /datum/gas/nitrogen, /
 	gas_overlay = "nitryl"
 	moles_visible = MOLES_GAS_VISIBLE
 	dangerous = TRUE
-	fusion_power = 1.5
+	fusion_power = 4
 
 /datum/gas/tritium
 	id = "tritium"
@@ -106,13 +106,15 @@ GLOBAL_LIST_INIT(hardcoded_gases, list(/datum/gas/oxygen, /datum/gas/nitrogen, /
 	gas_overlay = "tritium"
 	moles_visible = MOLES_GAS_VISIBLE
 	dangerous = TRUE
-	fusion_power = 2
+	fusion_power = 1
+
 /datum/gas/bz
 	id = "bz"
 	specific_heat = 20
 	name = "BZ"
 	dangerous = TRUE
-	fusion_power = 2
+	fusion_power = 5
+
 /datum/gas/stimulum
 	id = "stim"
 	specific_heat = 5

--- a/code/modules/atmospherics/gasmixtures/reactions.dm
+++ b/code/modules/atmospherics/gasmixtures/reactions.dm
@@ -232,7 +232,7 @@
 		cached_gases[/datum/gas/tritium][MOLES] += gases_fused
 		if (location && prob(power_ratio)) //You don't really want this to happen
 			radiation_pulse(location, power_ratio * 5)
-			explosion(location,0,0,3,power_ratio / 2,TRUE,TRUE)//A tiny explosion with a large shockwave. People will know you're doing fusion.
+			explosion(location,0,0,3,power_ratio * 0.5,TRUE,TRUE)//A tiny explosion with a large shockwave. People will know you're doing fusion.
 
 	else if (power_ratio > 1) //Mediation is overpowered, fusion reaction starts to break down.
 		reaction_energy += cached_gases[/datum/gas/plasma][MOLES]*PLASMA_BINDING_ENERGY

--- a/code/modules/atmospherics/gasmixtures/reactions.dm
+++ b/code/modules/atmospherics/gasmixtures/reactions.dm
@@ -305,7 +305,7 @@
 
 /datum/gas_reaction/bzformation/init_reqs()
 	min_requirements = list(
-		/datum/gas/tritium = 10,
+		/datum/gas/nitrous_oxide = 10,
 		/datum/gas/plasma = 10
 	)
 

--- a/code/modules/atmospherics/gasmixtures/reactions.dm
+++ b/code/modules/atmospherics/gasmixtures/reactions.dm
@@ -231,7 +231,7 @@
 		air.assert_gas(/datum/gas/tritium)
 		cached_gases[/datum/gas/tritium][MOLES] += gases_fused
 		if (location && prob(power_ratio)) //You don't really want this to happen
-			radiation_pulse(location, power_ratio * 10)
+			radiation_pulse(location, power_ratio * 5)
 			explosion(location,0,0,3,power_ratio / 2,TRUE,TRUE)//A tiny explosion with a large shockwave. People will know you're doing fusion.
 
 	else if (power_ratio > 1) //Mediation is overpowered, fusion reaction starts to break down.
@@ -241,7 +241,7 @@
 		air.assert_gases(/datum/gas/bz,/datum/gas/nitrous_oxide)
 		cached_gases[/datum/gas/bz][MOLES] += gas_power*0.05
 		cached_gases[/datum/gas/nitrous_oxide][MOLES] += gas_power*0.05
-		if (location && prob(power_ratio * 5)) //Fairly high chance of happening
+		if (location && prob(power_ratio * 5)) //Fairly good chances of happening
 			radiation_pulse(location, reaction_energy / (PLASMA_BINDING_ENERGY * 100))
 
 	else

--- a/code/modules/atmospherics/gasmixtures/reactions.dm
+++ b/code/modules/atmospherics/gasmixtures/reactions.dm
@@ -22,17 +22,17 @@
 #define REACTION_OPPRESSION_THRESHOLD		5
 #define NOBLIUM_FORMATION_ENERGY			2e9 //1 Mole of Noblium takes the planck energy to condense.
 //Plasma fusion properties
-#define PLASMA_BINDING_ENERGY				3e9 //Amount of energy it takes to start a fusion reaction
-#define FUSION_RELEASE_ENERGY				4.5e9 //Amount of energy released in the fusion process
-#define FUSION_RADIOACTIVITY_FACTOR			5e11 //Completely arbitrary
-#define FUSION_HIGH_RADIOACTIVITY_FACTOR	2.5e11 //Also arbitrary, but less so
+#define PLASMA_BINDING_ENERGY				3000000000 //Amount of energy it takes to start a fusion reaction
+#define FUSION_RELEASE_ENERGY				4500000000 //Amount of energy released in the fusion process
+#define FUSION_RADIOACTIVITY_FACTOR			500000000000 //Completely arbitrary
+#define FUSION_HIGH_RADIOACTIVITY_FACTOR	250000000000 //Also arbitrary, but less so
 #define FUSION_TEMPERATURE_THRESHOLD		1000
 #define FUSION_MOLE_THRESHOLD				250
 #define FUSION_MEDIATION_FACTOR				80
 #define FUSION_HIGH_REACTION_ENERGY_FACTOR	20
-#define FUSION_GAS_CREATION_FACTOR			0.75 //trit
-#define FUSION_GAS_CREATION_FACTOR			0.45 //BZ and N2O
-#define FUSION_GAS_CREATION_FACTOR			0.48 //O2 and CO2
+#define FUSION_GAS_CREATION_FACTOR_HIGH		0.75 //trit - one gas, so its higher than the other two
+#define FUSION_GAS_CREATION_FACTOR_MID		0.45 //BZ and N2O
+#define FUSION_GAS_CREATION_FACTOR_LOW		0.48 //O2 and CO2
 #define FUSION_EFFICIENCY_BASE				60
 #define FUSION_EFFICIENCY_DIVISOR			0.6
 #define FUSION_LOW_TIER_RAD_PROB_FACTOR		10

--- a/code/modules/atmospherics/gasmixtures/reactions.dm
+++ b/code/modules/atmospherics/gasmixtures/reactions.dm
@@ -4,15 +4,15 @@
 #define PLASMA_MINIMUM_OXYGEN_NEEDED		2
 #define PLASMA_MINIMUM_OXYGEN_PLASMA_RATIO	30
 #define FIRE_CARBON_ENERGY_RELEASED			100000	//Amount of heat released per mole of burnt carbon into the tile
-#define FIRE_HYDROGEN_ENERGY_RELEASED		280000 // Amount of heat released per mole of burnt hydrogen and/or tritium(hydrogen isotope)
+#define FIRE_HYDROGEN_ENERGY_RELEASED		280000  //Amount of heat released per mole of burnt hydrogen and/or tritium(hydrogen isotope)
 #define FIRE_PLASMA_ENERGY_RELEASED			3000000	//Amount of heat released per mole of burnt plasma into the tile
 //General assmos defines.
 #define WATER_VAPOR_FREEZE					200
 #define NITRYL_FORMATION_ENERGY				100000
 #define TRITIUM_BURN_OXY_FACTOR				100
 #define TRITIUM_BURN_TRIT_FACTOR			10
-#define TRITIUM_BURN_RADIOACTIVITY_FACTOR	50000 //The neutrons gotta go somewhere. Completely arbitrary number.
-#define TRITIUM_MINIMUM_RADIATION_ENERGY	0.1 //minimum 0.01 moles trit or 10 moles oxygen to start producing rads
+#define TRITIUM_BURN_RADIOACTIVITY_FACTOR	50000 	//The neutrons gotta go somewhere. Completely arbitrary number.
+#define TRITIUM_MINIMUM_RADIATION_ENERGY	0.1  	//minimum 0.01 moles trit or 10 moles oxygen to start producing rads
 #define SUPER_SATURATION_THRESHOLD			96
 #define STIMULUM_HEAT_SCALE					100000
 #define STIMULUM_FIRST_RISE					0.65
@@ -20,25 +20,28 @@
 #define STIMULUM_SECOND_RISE				0.0009
 #define STIMULUM_ABSOLUTE_DROP				0.00000335
 #define REACTION_OPPRESSION_THRESHOLD		5
-#define NOBLIUM_FORMATION_ENERGY			2e9 //1 Mole of Noblium takes the planck energy to condense.
+#define NOBLIUM_FORMATION_ENERGY			2e9 	//1 Mole of Noblium takes the planck energy to condense.
 //Plasma fusion properties
-#define PLASMA_BINDING_ENERGY				3000000000 //Amount of energy it takes to start a fusion reaction
-#define FUSION_RELEASE_ENERGY				4500000000 //Amount of energy released in the fusion process
-#define FUSION_RADIOACTIVITY_FACTOR			500000000000 //Completely arbitrary
-#define FUSION_HIGH_RADIOACTIVITY_FACTOR	250000000000 //Also arbitrary, but less so
-#define FUSION_TEMPERATURE_THRESHOLD		1000
-#define FUSION_MOLE_THRESHOLD				250
-#define FUSION_MEDIATION_FACTOR				80
-#define FUSION_HIGH_REACTION_ENERGY_FACTOR	20
-#define FUSION_GAS_CREATION_FACTOR_HIGH		0.75 //trit - one gas, so its higher than the other two
-#define FUSION_GAS_CREATION_FACTOR_MID		0.45 //BZ and N2O
-#define FUSION_GAS_CREATION_FACTOR_LOW		0.48 //O2 and CO2
-#define FUSION_EFFICIENCY_BASE				60
-#define FUSION_EFFICIENCY_DIVISOR			0.6
-#define FUSION_LOW_TIER_RAD_PROB_FACTOR		10
+#define FUSION_ENERGY_THRESHOLD				3e9 	//Amount of energy it takes to start a fusion reaction
+#define FUSION_TEMPERATURE_THRESHOLD		1000 	//Temperature required to start a fusion reaction
+#define FUSION_MOLE_THRESHOLD				250 	//Mole count required (tritium/plasma) to start a fusion reaction
+#define FUSION_RELEASE_ENERGY_HIGH			1e10 	//Amount of energy released in the fusion process, high tier
+#define FUSION_RELEASE_ENERGY_MID			8e9 	//Amount of energy released in the fusion process, mid tier
+#define FUSION_RELEASE_ENERGY_LOW			4e9 	//Amount of energy released in the fusion process, low tier
+#define FUSION_RADIOACTIVITY_FACTOR			5e11 	//Completely arbitrary
+#define FUSION_MEDIATION_FACTOR				80 		//Also arbitrary
+#define FUSION_REACTION_ENERGY_FACTOR_HIGH	10
+#define FUSION_REACTION_ENERGY_FACTOR_MID	4
+#define FUSION_REACTION_ENERGY_FACTOR_LOW	2
+#define FUSION_GAS_CREATION_FACTOR_HIGH		0.75 	//trit - one gas, so its higher than the other two
+#define FUSION_GAS_CREATION_FACTOR_MID		0.45 	//BZ and N2O
+#define FUSION_GAS_CREATION_FACTOR_LOW		0.48 	//O2 and CO2
 #define FUSION_MID_TIER_RAD_PROB_FACTOR		5
+#define FUSION_LOW_TIER_RAD_PROB_FACTOR		10
 #define FUSION_HIGH_TIER					10
 #define FUSION_MID_TIER						1
+#define FUSION_EFFICIENCY_BASE				60
+#define FUSION_EFFICIENCY_DIVISOR			0.6
 
 /datum/controller/subsystem/air/var/list/gas_reactions //this is our singleton of all reactions
 
@@ -211,7 +214,7 @@
 /datum/gas_reaction/fusion/init_reqs()
 	min_requirements = list(
 		"TEMP" = FUSION_TEMPERATURE_THRESHOLD,
-		"ENER" = PLASMA_BINDING_ENERGY,
+		"ENER" = FUSION_ENERGY_THRESHOLD,
 		/datum/gas/plasma = FUSION_MOLE_THRESHOLD,
 		/datum/gas/tritium = FUSION_MOLE_THRESHOLD
 	)
@@ -243,16 +246,16 @@
 	var/power_ratio = gas_power/mediation
 
 	if (power_ratio > FUSION_HIGH_TIER) //Super-fusion. Fuses everything into one big atom which then turns to tritium instantly. Very dangerous, but super cool.
-		reaction_energy += gases_fused*FUSION_RELEASE_ENERGY*(power_ratio / FUSION_HIGH_REACTION_ENERGY_FACTOR)
+		reaction_energy += gases_fused * FUSION_RELEASE_ENERGY_HIGH * (power_ratio / FUSION_REACTION_ENERGY_FACTOR_HIGH)
 		for (var/id in cached_gases)
 			cached_gases[id][MOLES] = 0
 		cached_gases[/datum/gas/tritium][MOLES] += gases_fused * FUSION_GAS_CREATION_FACTOR_HIGH //25% of the gas is converted to energy, 75% to tritium
 		if (location && prob(power_ratio)) //You don't really want this to happen
-			radiation_pulse(location, reaction_energy / FUSION_HIGH_RADIOACTIVITY_FACTOR)
+			radiation_pulse(location, reaction_energy / FUSION_RADIOACTIVITY_FACTOR)
 			explosion(location,0,0,3,power_ratio * 0.5,TRUE,TRUE)//A tiny explosion with a large shockwave. People will know you're doing fusion.
 
 	else if (power_ratio > FUSION_MID_TIER) //Mediation is overpowered, fusion reaction starts to break down.
-		reaction_energy += cached_gases[/datum/gas/plasma][MOLES]*FUSION_RELEASE_ENERGY
+		reaction_energy += gases_fused * FUSION_RELEASE_ENERGY_MID * (power_ratio / FUSION_REACTION_ENERGY_FACTOR_MID)
 		for (var/id in cached_gases)
 			cached_gases[id][MOLES] = 0
 		air.assert_gases(/datum/gas/bz,/datum/gas/nitrous_oxide)
@@ -261,8 +264,8 @@
 		if (location && prob(power_ratio * FUSION_MID_TIER_RAD_PROB_FACTOR)) //Fairly good chances of happening
 			radiation_pulse(location, reaction_energy / FUSION_RADIOACTIVITY_FACTOR)
 
-	else
-		reaction_energy += cached_gases[/datum/gas/plasma][MOLES]*FUSION_RELEASE_ENERGY*power_ratio
+	else //Gas power is overpowered. Fusion isn't nearly as powerful.
+		reaction_energy += gases_fused * FUSION_RELEASE_ENERGY_LOW * (power_ratio / FUSION_REACTION_ENERGY_FACTOR_LOW)
 		for (var/gas in cached_gases)
 			cached_gases[gas][MOLES] = 0
 		air.assert_gases(/datum/gas/oxygen, /datum/gas/carbon_dioxide)

--- a/code/modules/atmospherics/gasmixtures/reactions.dm
+++ b/code/modules/atmospherics/gasmixtures/reactions.dm
@@ -22,7 +22,8 @@
 #define REACTION_OPPRESSION_THRESHOLD		5
 #define NOBLIUM_FORMATION_ENERGY			2e9 //1 Mole of Noblium takes the planck energy to condense.
 //Plasma fusion properties
-#define PLASMA_BINDING_ENERGY				3000000
+#define PLASMA_BINDING_ENERGY				3000000000 //Amount of energy it takes to start a fusion reaction
+#define FUSION_RELEASE_ENERGY				4500000 //Amount of energy released in the fusion process
 #define FUSION_RADIOACTIVITY_FACTOR			50000000 //Completely arbitrary
 #define FUSION_HIGH_RADIOACTIVITY_FACTOR	25000000 //Also arbitrary, but less so
 #define FUSION_MEDIATION_FACTOR				100
@@ -202,7 +203,7 @@
 //Since fusion isn't really intended to happen in successive chains, the requirements are very high
 /datum/gas_reaction/fusion/init_reqs()
 	min_requirements = list(
-		"ENER" = PLASMA_BINDING_ENERGY * 1000,
+		"ENER" = PLASMA_BINDING_ENERGY,
 		/datum/gas/plasma = 500,
 		/datum/gas/tritium = 500
 	)
@@ -229,7 +230,7 @@
 
 	if (power_ratio > FUSION_HIGH_TIER) //Super-fusion. Fuses everything into one big atom which then turns to tritium instantly. Very dangerous, but super cool.
 		var/gases_fused = air.total_moles()
-		reaction_energy += gases_fused*PLASMA_BINDING_ENERGY*(gas_power/(mediation*FUSION_MEDIATION_FACTOR))
+		reaction_energy += gases_fused*FUSION_RELEASE_ENERGY*(gas_power/(mediation*FUSION_MEDIATION_FACTOR))
 		for (var/id in cached_gases)
 			cached_gases[id][MOLES] = 0
 		air.assert_gas(/datum/gas/tritium)
@@ -239,7 +240,7 @@
 			explosion(location,0,0,3,power_ratio * 0.5,TRUE,TRUE)//A tiny explosion with a large shockwave. People will know you're doing fusion.
 
 	else if (power_ratio > FUSION_MID_TIER) //Mediation is overpowered, fusion reaction starts to break down.
-		reaction_energy += cached_gases[/datum/gas/plasma][MOLES]*PLASMA_BINDING_ENERGY
+		reaction_energy += cached_gases[/datum/gas/plasma][MOLES]*FUSION_RELEASE_ENERGY
 		cached_gases[/datum/gas/plasma][MOLES] = 0
 		cached_gases[/datum/gas/carbon_dioxide][MOLES] = 0
 		air.assert_gases(/datum/gas/bz,/datum/gas/nitrous_oxide)
@@ -249,7 +250,7 @@
 			radiation_pulse(location, reaction_energy / FUSION_RADIOACTIVITY_FACTOR)
 
 	else
-		reaction_energy += cached_gases[/datum/gas/plasma][MOLES]*PLASMA_BINDING_ENERGY*power_ratio
+		reaction_energy += cached_gases[/datum/gas/plasma][MOLES]*FUSION_RELEASE_ENERGY*power_ratio
 		air.assert_gas(/datum/gas/oxygen)
 		cached_gases[/datum/gas/oxygen][MOLES] += gas_power + cached_gases[/datum/gas/plasma][MOLES]
 		cached_gases[/datum/gas/plasma][MOLES] = 0


### PR DESCRIPTION
in a galaxy far, far away..

:cl: cyclowns
add: Fusion has been re-enabled! It works similarly to before, but with some slight modification.
tweak: Fusion now requires huge amounts of plasma and tritium, as well as a very high thermal energy and temperature to start.
tweak: The fusion power of most gases has been tweaked to allow for more interesting interactions.
tweak: BZ now takes N2O and plasma to create, rather than tritium and plasma.
fix: Fusion no longer delivers server-crashingly large amounts of radiation and stationwide EMPs.
/:cl:

[why]: Fusion is a really interesting reaction at its core and it's a little sad to see it get disabled because of all the dumb broken shit that came along with it. This PR plans to fix those issues and make the interactions a little more interesting, while also gathering player feedback. Here's some explanation for the individual changes I've currently made:

- The EMP pulses are completely removed from fusion

Honestly this is a no-brainer. Not only does it make literally zero sense for a _fusion_ reaction to give off magic EMPs, it was super broken and hard to balance.

- The radiation pulses from fusion are nerfed

Also a no-brainer. I still think radiation is an interesting idea (or anything that makes fusion inherently dangerous to perform), so it's not removed outright, but it is severely nerfed. Who the hell thought 200,000 rads was a good idea???

- The explosion from high tier fusion reactions is fixed* and a lot smaller

The explosion adds another layer of danger to fusion, but having a 50 radius medium devastation explosion is a _liiiiittle_ much. With this change, performing fusion more than twice in the same canister will cause it to burst and spill its contents. Pipes are untested with this change but I can't imagine they would last very long. Not to mention, if you aren't careful its easy to lose an arm or leg. The flash range being large (implying a strong shock wave) just means that the crew will quickly find out that someone is doing fusion---it has no actual destructive capability, it just handles the screen-shake and sound.

*In actuality, the light explosion size is fixed to 3 tiles while the flash range is equal to power_ratio / 2

- power_ratio is now uncapped

Might be a controversial change. My logic for this change is that, since rad pulses and explosions from high tier fusion is at a more normal level, we can reward smarter players by allowing them more freedom. It's not possible to go that high without ridiculously insane dedication, so this doesn't mean the insane rads will come back any time soon.

- Lower tier fusion reactions aren't guaranteed to cause radpulses anymore

Another attempt to cut down on the crazy radiation problem.

- There are higher requirements for fusion now (250 mol plasma, 250 mol tritium)

Maybe another controversial change. A huge issue with old fusion is that starting up the holodeck burn chamber could literally crash the server with fusion and radiation, since fusion only required fairly small amounts of plasma and CO2. The requirements being so high also encourages players to find faster and more efficient ways of producing lots of tritium to be able to do fusion. Also, since AFAIK fusion was intended to really only be done one at a time, not in chain reactions, this change disallows that without removing it altogether.

- fusion_power numbers are mostly higher across the board for gases

This SEEMS like a huge change, but in reality because of how fusion_power interacts with the specific heat of the gas it really isn't. All this change does is make certain gases more interesting to use for fusion, and creates 'tiers' of gases to use for accelerating fusion. Tritium is already present because of requirements, so it has a low fusion_power (bottom tier). CO2 is an easy to acquire gas, and as such accelerates fusion reactions a little, with some effort (low tier). Water vapor is easy to acquire in different ways (stealing, or buying from cargo) and as such is alright at accelerating (low-mid tier). BZ is harder to acquire (can be made with fusion), but it powers fusion a lot more. Nitryl is included in this tier as well as an alternative. (mid tier). Stimulum and pluoxium are a lot harder to get than your average gases, but they're the best for high tier fusion reaction (top tier).

If you have any great ideas for fusion, issues with this PR, or general feedback, hit me up here, discord (cyclowns#1440) or on coderbus if I'm there. The plan currently is to take feedback and new ideas and then iterate fusion based on that feedback, so that we can finally get a balanced and interesting end product that fucking stops the cycle of reworking and removing fusion.

@praisenarsie requested that I fix fusion so blame him if this ends up sucking