### PR TITLE
Fixed stacks sometimes having the wrong amount if created on another stack

### DIFF
--- a/code/game/machinery/doors/firedoor.dm
+++ b/code/game/machinery/doors/firedoor.dm
@@ -355,8 +355,7 @@
 					return
 				user.visible_message("<span class='notice'>[user] removes the wires from [src].</span>", \
 									 "<span class='notice'>You remove the wiring from [src], exposing the circuit board.</span>")
-				var/obj/item/stack/cable_coil/B = new(get_turf(src))
-				B.amount = 5
+				new/obj/item/stack/cable_coil(get_turf(src), 5)
 				constructionStep = CONSTRUCTION_GUTTED
 				update_icon()
 				return

--- a/code/game/machinery/washing_machine.dm
+++ b/code/game/machinery/washing_machine.dm
@@ -65,8 +65,7 @@
 	return
 
 /obj/item/stack/sheet/hairlesshide/machine_wash(obj/machinery/washing_machine/WM)
-	var/obj/item/stack/sheet/wetleather/WL = new(loc)
-	WL.amount = amount
+	new /obj/item/stack/sheet/wetleather(drop_location(), amount)
 	qdel(src)
 
 /obj/item/clothing/suit/hooded/ian_costume/machine_wash(obj/machinery/washing_machine/WM)

--- a/code/game/mecha/equipment/tools/other_tools.dm
+++ b/code/game/mecha/equipment/tools/other_tools.dm
@@ -367,8 +367,7 @@
 	return ..()
 
 /obj/item/mecha_parts/mecha_equipment/generator/proc/generator_init()
-	fuel = new /obj/item/stack/sheet/mineral/plasma(src)
-	fuel.amount = 0
+	fuel = new /obj/item/stack/sheet/mineral/plasma(src, 0)
 
 /obj/item/mecha_parts/mecha_equipment/generator/detach()
 	STOP_PROCESSING(SSobj, src)
@@ -472,8 +471,7 @@
 	var/rad_per_cycle = 3
 
 /obj/item/mecha_parts/mecha_equipment/generator/nuclear/generator_init()
-	fuel = new /obj/item/stack/sheet/mineral/uranium(src)
-	fuel.amount = 0
+	fuel = new /obj/item/stack/sheet/mineral/uranium(src, 0)
 
 /obj/item/mecha_parts/mecha_equipment/generator/nuclear/critfail()
 	return

--- a/code/game/mecha/equipment/tools/work_tools.dm
+++ b/code/game/mecha/equipment/tools/work_tools.dm
@@ -301,8 +301,7 @@
 
 /obj/item/mecha_parts/mecha_equipment/cable_layer/Initialize()
 	. = ..()
-	cable = new(src)
-	cable.amount = 0
+	cable = new(src, 0)
 
 /obj/item/mecha_parts/mecha_equipment/cable_layer/can_attach(obj/mecha/working/M)
 	if(..())
@@ -333,8 +332,7 @@
 		if(to_load)
 			to_load = min(target.amount, to_load)
 			if(!cable)
-				cable = new(src)
-				cable.amount = 0
+				cable = new(src, 0)
 			cable.amount += to_load
 			target.use(to_load)
 			occupant_message("<span class='notice'>[to_load] meters of cable successfully loaded.</span>")
@@ -358,8 +356,7 @@
 			m = min(m, cable.amount)
 			if(m)
 				use_cable(m)
-				var/obj/item/stack/cable_coil/CC = new (get_turf(chassis))
-				CC.amount = m
+				new /obj/item/stack/cable_coil(get_turf(chassis), m)
 		else
 			occupant_message("There's no more cable on the reel.")
 	return

--- a/code/game/objects/items/apc_frame.dm
+++ b/code/game/objects/items/apc_frame.dm
@@ -104,8 +104,7 @@
 			to_chat(user, "<span class='warning'>There is another network terminal here!</span>")
 			return
 		else
-			var/obj/item/stack/cable_coil/C = new /obj/item/stack/cable_coil(T)
-			C.amount = 10
+			new /obj/item/stack/cable_coil(T, 10)
 			to_chat(user, "<span class='notice'>You cut the cables and disassemble the unused power terminal.</span>")
 			qdel(E)
 	return TRUE

--- a/code/game/objects/items/stacks/sheets/leather.dm
+++ b/code/game/objects/items/stacks/sheets/leather.dm
@@ -211,10 +211,9 @@ GLOBAL_LIST_INIT(sinew_recipes, list ( \
 	if(W.is_sharp())
 		playsound(loc, 'sound/weapons/slice.ogg', 50, 1, -1)
 		user.visible_message("[user] starts cutting hair off \the [src].", "<span class='notice'>You start cutting the hair off \the [src]...</span>", "<span class='italics'>You hear the sound of a knife rubbing against flesh.</span>")
-		if(do_after(user,50, target = src))
+		if(do_after(user, 50, target = src))
 			to_chat(user, "<span class='notice'>You cut the hair from this [src.singular_name].</span>")
-			var/obj/item/stack/sheet/hairlesshide/HS = new(user.loc)
-			HS.amount = 1
+			new /obj/item/stack/sheet/hairlesshide(user.drop_location(), 1)
 			use(1)
 	else
 		return ..()
@@ -228,21 +227,11 @@ GLOBAL_LIST_INIT(sinew_recipes, list ( \
 	if(exposed_temperature >= drying_threshold_temperature)
 		wetness--
 		if(wetness == 0)
-			//Try locating an exisitng stack on the tile and add to there if possible
-			for(var/obj/item/stack/sheet/leather/HS in src.loc)
-				if(HS.amount < 50)
-					HS.amount++
-					src.use(1)
-					wetness = initial(wetness)
-					break
-			//If it gets to here it means it did not find a suitable stack on the tile.
-			var/obj/item/stack/sheet/leather/HS = new(src.loc)
-			HS.amount = 1
+			new /obj/item/stack/sheet/leather(drop_location(), 1)
 			wetness = initial(wetness)
-			src.use(1)
+			use(1)
 
 /obj/item/stack/sheet/wetleather/microwave_act(obj/machinery/microwave/MW)
 	..()
-	var/obj/item/stack/sheet/leather/L = new(loc)
-	L.amount = amount
+	new /obj/item/stack/sheet/leather(drop_location(), amount)
 	qdel(src)

--- a/code/game/objects/items/stacks/sheets/light.dm
+++ b/code/game/objects/items/stacks/sheets/light.dm
@@ -14,13 +14,12 @@
 	grind_results = list("silicon" = 20, "copper" = 5)
 
 /obj/item/stack/light_w/attackby(obj/item/O, mob/user, params)
-
+	var/atom/Tsec = user.drop_location()
 	if(istype(O, /obj/item/wirecutters))
-		var/obj/item/stack/cable_coil/CC = new (user.loc)
-		CC.amount = 5
+		var/obj/item/stack/cable_coil/CC = new (Tsec, 5)
 		CC.add_fingerprint(user)
 		amount--
-		var/obj/item/stack/sheet/glass/G = new (user.loc)
+		var/obj/item/stack/sheet/glass/G = new (Tsec)
 		G.add_fingerprint(user)
 		if(amount <= 0)
 			qdel(src)
@@ -28,7 +27,6 @@
 	else if(istype(O, /obj/item/stack/sheet/metal))
 		var/obj/item/stack/sheet/metal/M = O
 		if (M.use(1))
-			use(1)
 			var/obj/item/L = new /obj/item/stack/tile/light(user.loc)
 			to_chat(user, "<span class='notice'>You make a light tile.</span>")
 			L.add_fingerprint(user)

--- a/code/game/objects/items/stacks/sheets/sheet_types.dm
+++ b/code/game/objects/items/stacks/sheets/sheet_types.dm
@@ -113,6 +113,9 @@ GLOBAL_LIST_INIT(metal_recipes, list ( \
 /obj/item/stack/sheet/metal/twenty
 	amount = 20
 
+/obj/item/stack/sheet/metal/ten
+	amount = 10
+
 /obj/item/stack/sheet/metal/five
 	amount = 5
 

--- a/code/game/objects/items/stacks/stack.dm
+++ b/code/game/objects/items/stacks/stack.dm
@@ -36,7 +36,11 @@
 /obj/item/stack/Initialize(mapload, new_amount=null , merge = TRUE)
 	. = ..()
 	if(new_amount)
-		amount = new_amount
+		if(new_amount > max_amount)
+			amount = max_amount
+			new type(loc, new_amount - max_amount, merge)
+		else
+			amount = new_amount
 	if(!merge_type)
 		merge_type = type
 	if(merge)

--- a/code/game/objects/items/stacks/stack.dm
+++ b/code/game/objects/items/stacks/stack.dm
@@ -33,14 +33,13 @@
 		return
 	return TRUE
 
-/obj/item/stack/Initialize(mapload, new_amount=null , merge = TRUE)
+/obj/item/stack/Initialize(mapload, new_amount, merge = TRUE)
 	. = ..()
 	if(new_amount)
-		if(new_amount > max_amount)
-			amount = max_amount
-			new type(loc, new_amount - max_amount, merge)
-		else
-			amount = new_amount
+		amount = new_amount
+	while(amount > max_amount)
+		amount -= max_amount
+		new type(loc, max_amount, FALSE)
 	if(!merge_type)
 		merge_type = type
 	if(merge)

--- a/code/game/objects/items/stacks/stack.dm
+++ b/code/game/objects/items/stacks/stack.dm
@@ -35,7 +35,7 @@
 
 /obj/item/stack/Initialize(mapload, new_amount, merge = TRUE)
 	. = ..()
-	if(new_amount)
+	if(new_amount != null)
 		amount = new_amount
 	while(amount > max_amount)
 		amount -= max_amount

--- a/code/game/objects/structures/ai_core.dm
+++ b/code/game/objects/structures/ai_core.dm
@@ -147,8 +147,7 @@
 						to_chat(user, "<span class='notice'>You remove the cables.</span>")
 						state = SCREWED_CORE
 						update_icon()
-						var/obj/item/stack/cable_coil/A = new /obj/item/stack/cable_coil( loc )
-						A.amount = 5
+						new /obj/item/stack/cable_coil(drop_location(), 5)
 					return
 
 				if(istype(P, /obj/item/stack/sheet/rglass))

--- a/code/game/objects/structures/crates_lockers/closets/syndicate.dm
+++ b/code/game/objects/structures/crates_lockers/closets/syndicate.dm
@@ -111,5 +111,5 @@
 
 	for(var/i = 0, i<2, i++)
 		for(var/res in resources)
-			var/obj/item/stack/R = new res(src)
-			R.amount = R.max_amount
+			var/obj/item/stack/R = res
+			new res(src, initial(R.max_amount))

--- a/code/modules/antagonists/swarmer/swarmer.dm
+++ b/code/modules/antagonists/swarmer/swarmer.dm
@@ -493,10 +493,10 @@
 	D.pixel_z = target.pixel_z
 	if(do_mob(src, target, 100))
 		to_chat(src, "<span class='info'>Dismantling complete.</span>")
-		var/obj/item/stack/sheet/metal/M = new /obj/item/stack/sheet/metal(target.loc)
-		M.amount = 5
+		var/atom/Tsec = target.drop_location()
+		new /obj/item/stack/sheet/metal(Tsec, 5)
 		for(var/obj/item/I in target.component_parts)
-			I.forceMove(M.drop_location())
+			I.forceMove(Tsec)
 		var/obj/effect/temp_visual/swarmer/disintegration/N = new /obj/effect/temp_visual/swarmer/disintegration(get_turf(target))
 		N.pixel_x = target.pixel_x
 		N.pixel_y = target.pixel_y
@@ -505,7 +505,7 @@
 		if(istype(target, /obj/machinery/computer))
 			var/obj/machinery/computer/C = target
 			if(C.circuit)
-				C.circuit.forceMove(M.drop_location())
+				C.circuit.forceMove(Tsec)
 		qdel(target)
 
 

--- a/code/modules/food_and_drinks/kitchen_machinery/smartfridge.dm
+++ b/code/modules/food_and_drinks/kitchen_machinery/smartfridge.dm
@@ -299,8 +299,7 @@
 			qdel(S)
 		return TRUE
 	for(var/obj/item/stack/sheet/wetleather/WL in src)
-		var/obj/item/stack/sheet/leather/L = new(drop_location())
-		L.amount = WL.amount
+		new /obj/item/stack/sheet/leather(drop_location(), WL.amount)
 		qdel(WL)
 		return TRUE
 	return FALSE

--- a/code/modules/hydroponics/biogenerator.dm
+++ b/code/modules/hydroponics/biogenerator.dm
@@ -262,8 +262,7 @@
 		if(!check_cost(D.materials, amount))
 			return FALSE
 
-		var/obj/item/stack/product = new D.build_path(loc)
-		product.amount = amount
+		new D.build_path(drop_location(), amount)
 		for(var/R in D.make_reagents)
 			beaker.reagents.add_reagent(R, D.make_reagents[R]*amount)
 	else

--- a/code/modules/hydroponics/grown/grass_carpet.dm
+++ b/code/modules/hydroponics/grown/grass_carpet.dm
@@ -36,19 +36,13 @@
 			continue
 		grassAmt += 1 + round(G.seed.potency * tile_coefficient)
 		qdel(G)
-	var/obj/item/stack/tile/GT = new stacktype(user.loc)
-	while(grassAmt > GT.max_amount)
-		GT.amount = GT.max_amount
-		grassAmt -= GT.max_amount
-		GT = new stacktype(user.loc)
-	GT.amount = grassAmt
-	for(var/obj/item/stack/tile/T in user.loc)
-		if((T.type == stacktype) && (T.amount < T.max_amount))
-			GT.merge(T)
-			if(GT.amount <= 0)
-				break
+	var/obj/item/stack/tile/GT = stacktype
+	var/atom/Tsec = user.drop_location()
+	while(grassAmt > 0)
+		var/amount = min(grassAmt, initial(GT.max_amount))
+		new stacktype(Tsec, amount)
+		grassAmt -= amount
 	qdel(src)
-	return
 
 // Carpet
 /obj/item/seeds/grass/carpet

--- a/code/modules/hydroponics/grown/grass_carpet.dm
+++ b/code/modules/hydroponics/grown/grass_carpet.dm
@@ -36,12 +36,7 @@
 			continue
 		grassAmt += 1 + round(G.seed.potency * tile_coefficient)
 		qdel(G)
-	var/obj/item/stack/tile/GT = stacktype
-	var/atom/Tsec = user.drop_location()
-	while(grassAmt > 0)
-		var/amount = min(grassAmt, initial(GT.max_amount))
-		new stacktype(Tsec, amount)
-		grassAmt -= amount
+	new stacktype(user.drop_location(), grassAmt)
 	qdel(src)
 
 // Carpet

--- a/code/modules/mining/machine_redemption.dm
+++ b/code/modules/mining/machine_redemption.dm
@@ -303,13 +303,12 @@
 					desired = input("How many sheets?", "How many sheets would you like to smelt?", 1) as null|num
 				var/amount = round(min(desired,50,smelt_amount))
 				materials.use_amount(alloy.materials, amount)
-				var/output = new alloy.build_path(src)
-				if(istype(output, /obj/item/stack/sheet))
-					var/obj/item/stack/sheet/produced_alloy = output
-					produced_alloy.amount = amount
-					unload_mineral(produced_alloy)
+				var/output
+				if(ispath(alloy.build_path, /obj/item/stack/sheet))
+					output = new alloy.build_path(src, amount)
 				else
-					unload_mineral(output)
+					output = new alloy.build_path(src)
+				unload_mineral(output)
 			else
 				to_chat(usr, "<span class='warning'>Required access not found.</span>")
 			return TRUE

--- a/code/modules/mining/machine_stacking.dm
+++ b/code/modules/mining/machine_stacking.dm
@@ -44,8 +44,7 @@
 		if(!(text2path(href_list["release"]) in machine.stack_list))
 			return //someone tried to spawn materials by spoofing hrefs
 		var/obj/item/stack/sheet/inp = machine.stack_list[text2path(href_list["release"])]
-		var/obj/item/stack/sheet/out = new inp.type()
-		out.amount = inp.amount
+		var/obj/item/stack/sheet/out = new inp.type(null, inp.amount)
 		inp.amount = 0
 		machine.unload_mineral(out)
 
@@ -81,14 +80,12 @@
 
 /obj/machinery/mineral/stacking_machine/proc/process_sheet(obj/item/stack/sheet/inp)
 	if(!(inp.type in stack_list)) //It's the first of this sheet added
-		var/obj/item/stack/sheet/s = new inp.type(src,0)
-		s.amount = 0
+		var/obj/item/stack/sheet/s = new inp.type(src, 0)
 		stack_list[inp.type] = s
 	var/obj/item/stack/sheet/storage = stack_list[inp.type]
 	storage.amount += inp.amount //Stack the sheets
 	qdel(inp) //Let the old sheet garbage collect
 	while(storage.amount > stack_amt) //Get rid of excessive stackage
-		var/obj/item/stack/sheet/out = new inp.type()
-		out.amount = stack_amt
+		var/obj/item/stack/sheet/out = new inp.type(null, stack_amt)
 		unload_mineral(out)
 		storage.amount -= stack_amt

--- a/code/modules/mob/living/simple_animal/bot/floorbot.dm
+++ b/code/modules/mob/living/simple_animal/bot/floorbot.dm
@@ -164,12 +164,7 @@
 	update_controls()
 
 /mob/living/simple_animal/bot/floorbot/proc/empty_tiles()
-	var/atom/Tsec = drop_location()
-
-	while(specialtiles > initial(tiletype.max_amount))
-		new tiletype(Tsec,initial(tiletype.max_amount))
-		specialtiles -= initial(tiletype.max_amount)
-	new tiletype(Tsec,specialtiles)
+	new tiletype(drop_location(), specialtiles)
 	specialtiles = 0
 	tiletype = null
 

--- a/code/modules/mob/living/simple_animal/bot/floorbot.dm
+++ b/code/modules/mob/living/simple_animal/bot/floorbot.dm
@@ -378,8 +378,7 @@
 	if(prob(50))
 		drop_part(robot_arm, Tsec)
 
-	var/obj/item/stack/tile/plasteel/T = new (Tsec)
-	T.amount = 1
+	new /obj/item/stack/tile/plasteel(Tsec, 1)
 
 	do_sparks(3, TRUE, src)
 	..()

--- a/code/modules/power/port_gen.dm
+++ b/code/modules/power/port_gen.dm
@@ -111,12 +111,12 @@
 
 /obj/machinery/power/port_gen/pacman/DropFuel()
 	if(sheets)
+		var/obj/item/stack/sheet/S = sheet_path
 		var/fail_safe = FALSE
 		while(sheets > 0 && fail_safe < 100)
 			fail_safe += 1
-			var/obj/item/stack/sheet/S = new sheet_path(loc)
-			var/amount = min(sheets, S.max_amount)
-			S.amount = amount
+			var/amount = min(sheets, initial(S.max_amount))
+			new sheet_path(drop_location(), amount)
 			sheets -= amount
 
 /obj/machinery/power/port_gen/pacman/UseFuel()

--- a/code/modules/power/port_gen.dm
+++ b/code/modules/power/port_gen.dm
@@ -111,13 +111,8 @@
 
 /obj/machinery/power/port_gen/pacman/DropFuel()
 	if(sheets)
-		var/obj/item/stack/sheet/S = sheet_path
-		var/fail_safe = FALSE
-		while(sheets > 0 && fail_safe < 100)
-			fail_safe += 1
-			var/amount = min(sheets, initial(S.max_amount))
-			new sheet_path(drop_location(), amount)
-			sheets -= amount
+		new sheet_path(drop_location(), sheets)
+		sheets = 0
 
 /obj/machinery/power/port_gen/pacman/UseFuel()
 	var/needed_sheets = 1 / (time_per_sheet * consumption / power_output)

--- a/code/modules/power/solar.dm
+++ b/code/modules/power/solar.dm
@@ -191,12 +191,12 @@
 
 // Give back the glass type we were supplied with
 /obj/item/solar_assembly/proc/give_glass(device_broken)
+	var/atom/Tsec = drop_location()
 	if(device_broken)
-		new /obj/item/shard(loc)
-		new /obj/item/shard(loc)
+		new /obj/item/shard(Tsec)
+		new /obj/item/shard(Tsec)
 	else if(glass_type)
-		var/obj/item/stack/sheet/S = new glass_type(loc)
-		S.amount = 2
+		new glass_type(Tsec, 2)
 	glass_type = null
 
 

--- a/code/modules/reagents/chemistry/reagents/other_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/other_reagents.dm
@@ -171,8 +171,7 @@
 
 	else if(istype(O, /obj/item/stack/sheet/hairlesshide))
 		var/obj/item/stack/sheet/hairlesshide/HH = O
-		var/obj/item/stack/sheet/wetleather/WL = new(get_turf(HH))
-		WL.amount = HH.amount
+		new /obj/item/stack/sheet/wetleather(get_turf(HH), HH.amount)
 		qdel(HH)
 
 /*

--- a/code/modules/research/xenobiology/crossbreeding/_status_effects.dm
+++ b/code/modules/research/xenobiology/crossbreeding/_status_effects.dm
@@ -448,8 +448,7 @@ datum/status_effect/stabilized/blue/on_remove()
 	else if(istype(O, /obj/item/stack/sheet/hairlesshide))
 		to_chat(owner, "<span class='warning'>[linked_extract] kept your hands wet! It wets [O]!</span>")
 		var/obj/item/stack/sheet/hairlesshide/HH = O
-		var/obj/item/stack/sheet/wetleather/WL = new(get_turf(HH))
-		WL.amount = HH.amount
+		new /obj/item/stack/sheet/wetleather(get_turf(HH), HH.amount)
 		qdel(HH)
 	..()
 

--- a/code/modules/research/xenobiology/crossbreeding/charged.dm
+++ b/code/modules/research/xenobiology/crossbreeding/charged.dm
@@ -66,10 +66,8 @@ Charged extracts:
 	colour = "metal"
 
 /obj/item/slimecross/charged/metal/do_effect(mob/user)
-	var/obj/item/stack/sheet/metal/M = new(get_turf(user))
-	M.amount = 25
-	var/obj/item/stack/sheet/plasteel/P = new(get_turf(user))
-	P.amount = 10
+	new /obj/item/stack/sheet/metal(get_turf(user), 25)
+	new /obj/item/stack/sheet/plasteel(get_turf(user), 10)
 	user.visible_message("<span class='notice'>[src] grows into a plethora of metals!</span>")
 	..()
 
@@ -85,8 +83,7 @@ Charged extracts:
 	colour = "dark purple"
 
 /obj/item/slimecross/charged/darkpurple/do_effect(mob/user)
-	var/obj/item/stack/sheet/mineral/plasma/M = new(get_turf(user))
-	M.amount = 10
+	new /obj/item/stack/sheet/mineral/plasma(get_turf(user), 10)
 	user.visible_message("<span class='notice'>[src] produces a large amount of plasma!</span>")
 	..()
 
@@ -113,8 +110,7 @@ Charged extracts:
 	colour = "bluespace"
 
 /obj/item/slimecross/charged/bluespace/do_effect(mob/user)
-	var/obj/item/stack/sheet/bluespace_crystal/M = new(get_turf(user))
-	M.amount = 10
+	new /obj/item/stack/sheet/bluespace_crystal(get_turf(user), 10)
 	user.visible_message("<span class='notice'>[src] produces several sheets of polycrystal!</span>")
 	..()
 
@@ -138,8 +134,7 @@ Charged extracts:
 	colour = "pyrite"
 
 /obj/item/slimecross/charged/pyrite/do_effect(mob/user)
-	var/obj/item/stack/sheet/mineral/bananium/M = new(get_turf(user))
-	M.amount = 10
+	new /obj/item/stack/sheet/mineral/bananium(get_turf(user), 10)
 	user.visible_message("<span class='warning'>[src] solidifies with a horrifying banana stench!</span>")
 	..()
 

--- a/code/modules/research/xenobiology/crossbreeding/industrial.dm
+++ b/code/modules/research/xenobiology/crossbreeding/industrial.dm
@@ -75,12 +75,7 @@ Industrial extracts:
 /obj/item/slimecross/industrial/metal
 	colour = "metal"
 	plasmarequired = 3
-	itempath = /obj/item/stack/sheet/metal
-
-/obj/item/slimecross/industrial/metal/do_after_spawn(obj/item/spawned)
-	var/obj/item/stack/sheet/metal/M = spawned
-	if(istype(M))
-		M.amount = 10
+	itempath = /obj/item/stack/sheet/metal/ten
 
 /obj/item/slimecross/industrial/yellow
 	colour = "yellow"


### PR DESCRIPTION
:cl:
fix: Fixed items stacks sometimes having the wrong amount if created on another stack
fix: Constructing light tiles no longer uses two sheets of metal
/:cl:
Fixes #37232

Setting the `amount ` after the `new()` call instead of in it creates two problems: the stack will merge with any similar stacks on the same tile with the default amount of 1 instead of the correct amount and the stack will have the 1-item icon if it doesn't get merged.

This PR also replaces some `locs` with `drop_location()` and removes a duplicate `use()` call in light tile construction.