### PR TITLE
Bag of holding singularities no longer move around.

### DIFF
--- a/code/datums/components/storage/concrete/bag_of_holding.dm
+++ b/code/datums/components/storage/concrete/bag_of_holding.dm
@@ -13,7 +13,8 @@
 		to_chat(user, "<span class='danger'>The Bluespace interfaces of the two devices catastrophically malfunction!</span>")
 		qdel(W)
 		var/obj/singularity/singulo = new /obj/singularity (get_turf(A))
-		singulo.energy = 300 //should make it a bit bigger~
+		singulo.energy = 600 //Puts it at stage 3 initially, since it doesn't move anymore.
+		singulo.move_self = 0
 		message_admins("[key_name_admin(user)] detonated a bag of holding")
 		log_game("[key_name(user)] detonated a bag of holding")
 		qdel(A)


### PR DESCRIPTION
[Changelogs]: # (Your PR should contain a detailed changelog of notable changes, titled and categorized appropriately. This includes, new features, sprites, sounds, balance changes, admin tools, map edits, removals, big refactors, config changes, hosting changes and important fixes. An example changelog has been provided below for you to edit. If you need additional help, read https://github.com/tgstation/tgstation/wiki/Changelogs)

:cl: Alexch2
balance: Singularities created from the bag of holding no longer move around.
/:cl:

[why]: # (Please add a short description [two lines down] of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.)

BoH bombs are still the actual least interesting mechanic ever, and it's never fun for a round to just end because some guy printed two backpacks from RnD. Singularities created from the bag of holding are now stationary, actually acting like, y'know, bags. To compensate for them not moving around anymore, they now start at stage 3, rather than stage 2 like previously.
