### PR TITLE
Adds swapping disks to the plantmanipulator

### DIFF
--- a/code/modules/hydroponics/gene_modder.dm
+++ b/code/modules/hydroponics/gene_modder.dm
@@ -363,9 +363,11 @@
 
 /obj/machinery/plantgenes/proc/eject_disk()
 	if (disk && !operation)
-		disk.forceMove(drop_location())
 		if(Adjacent(usr) && !issilicon(usr))
-			usr.put_in_hands(disk)
+			if (!usr.put_in_hands(disk))
+				disk.forceMove(drop_location())
+		else
+			disk.forceMove(drop_location())
 		disk = null
 		update_genes()
 

--- a/code/modules/hydroponics/gene_modder.dm
+++ b/code/modules/hydroponics/gene_modder.dm
@@ -85,14 +85,15 @@
 			interact(user)
 		return
 	else if(istype(I, /obj/item/disk/plantgene))
-		if(disk)
-			to_chat(user, "<span class='warning'>A data disk is already loaded into the machine!</span>")
-		else
-			if(!user.transferItemToLoc(I, src))
-				return
-			disk = I
-			to_chat(user, "<span class='notice'>You add [I] to the machine.</span>")
-			interact(user)
+		if (operation)
+			to_chat(user, "<span class='notice'>Please complete current operation.</span>")
+			return
+		eject_disk()
+		if(!user.transferItemToLoc(I, src))
+			return
+		disk = I
+		to_chat(user, "<span class='notice'>You add [I] to the machine.</span>")
+		interact(user)
 	else
 		..()
 
@@ -266,18 +267,13 @@
 				to_chat(usr, "<span class='notice'>You add [I] to the machine.</span>")
 		update_icon()
 	else if(href_list["eject_disk"] && !operation)
-		if (disk)
-			disk.forceMove(drop_location())
-			disk.verb_pickup()
-			disk = null
-			update_genes()
-		else
-			var/obj/item/I = usr.get_active_held_item()
-			if(istype(I, /obj/item/disk/plantgene))
-				if(!usr.transferItemToLoc(I, src))
-					return
-				disk = I
-				to_chat(usr, "<span class='notice'>You add [I] to the machine.</span>")
+		var/obj/item/I = usr.get_active_held_item()
+		eject_disk()
+		if(istype(I, /obj/item/disk/plantgene))
+			if(!usr.transferItemToLoc(I, src))
+				return
+			disk = I
+			to_chat(usr, "<span class='notice'>You add [I] to the machine.</span>")
 	else if(href_list["op"] == "insert" && disk && disk.gene && seed)
 		if(!operation) // Wait for confirmation
 			operation = "insert"
@@ -364,6 +360,14 @@
 	seed = S
 	update_genes()
 	update_icon()
+
+/obj/machinery/plantgenes/proc/eject_disk()
+	if (disk && !operation)
+		disk.forceMove(drop_location())
+		if(Adjacent(usr) && !issilicon(usr))
+			usr.put_in_hands(disk)
+		disk = null
+		update_genes()
 
 /obj/machinery/plantgenes/proc/update_genes()
 	core_genes = list()


### PR DESCRIPTION
[Changelogs]:  

:cl: Dax Dupont
add: You can now swap disks in the plant manipulator.
/:cl:

[why]: Small QoL improvement, allows you to swap disks way faster.
