### PR TITLE
Adds a warning to the Readme about harassment and complying with the Github Terms of Service

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,9 +9,9 @@
 **Wiki** https://tgstation13.org/wiki/Main_Page <BR>
 **IRC:** irc://irc.rizon.net/coderbus or if you dont have an IRC client, you can click  [here](https://kiwiirc.com/client/irc.rizon.net:6667/?&theme=cli#coderbus).<BR>
 
-## We have a zero tolerance policy on harassment of contributors and community members on our Github. This is not 4chan, this is not the game server, and this is not the forums. You will follow the Github Terms of Service. Harassment of users on our repository will result in your postings being deleted and reports being filed with Github Support to request a suspension of your account.
+## We have a zero tolerance policy on harassment of contributors and community members on our GitHub. This is not 4chan, this is not the game server, and this is not the forums. You will follow the GitHub Terms of Service. Harassment of users on our repository will result in your postings being deleted and reports being filed with GitHub Support to request a suspension of your account.
 
-### Please consult the Github Terms of Service for further information here: https://help.github.com/articles/github-terms-of-service/
+### Please consult the GitHub Terms of Service for further information here: https://help.github.com/articles/github-terms-of-service/
  
 ## DOWNLOADING
 

--- a/README.md
+++ b/README.md
@@ -9,6 +9,9 @@
 **Wiki** https://tgstation13.org/wiki/Main_Page <BR>
 **IRC:** irc://irc.rizon.net/coderbus or if you dont have an IRC client, you can click  [here](https://kiwiirc.com/client/irc.rizon.net:6667/?&theme=cli#coderbus).<BR>
 
+## We have a zero tolerance policy on harassment of contributors and community members on our Github. This is not 4chan, this is not the game server, and this is not the forums. You will follow the Github Terms of Service. Harassment of users on our repository will result in your postings being deleted and reports being filed with Github Support to request a suspension of your account.
+
+### Please consult the Github Terms of Service for further information here: https://help.github.com/articles/github-terms-of-service/
  
 ## DOWNLOADING
 


### PR DESCRIPTION
I and other contributors have become very fed up with the inappropriate and unprofessional actions of people commenting on pull requests, with the intentions of harassing the contributor because they disagree with their opinions on balance or gameplay or whether they "play the game".

(Note: I'm not talking about people posting hard stats to disprove my or other contributor's arguments, that's fine, but be respectful about it)

This is simply unacceptable behavior and I am getting very tired of having to contact our maintainers to delete 10+ comments every time I make a pull request that is a controversial balance change.

If you cannot argue your point without falling back to below the belt insults and harassment of the person opening a pull request, you will have your rights to this service revoked if you're found to be violating the Terms of Service Github requests we follow.

Github does not do timed bans, and neither does the repository, because Github is a website for **adults** to collaborate on code projects.

This message is added to the readme along with a helpful link to the Terms of Service to hopefully ensure that people will stop their harassing actions and keep their discussions civil.