### PR TITLE
Fixes anomalies not listening on the correct frequency

### DIFF
--- a/code/game/objects/effects/anomalies.dm
+++ b/code/game/objects/effects/anomalies.dm
@@ -8,7 +8,7 @@
 	anchored = TRUE
 	light_range = 3
 	var/movechance = 70
-	var/obj/item/assembly/signaler/anomaly/aSignal = null
+	var/obj/item/assembly/signaler/anomaly/aSignal
 	var/area/impact_area
 
 	var/lifespan = 990
@@ -27,9 +27,10 @@
 	aSignal.name = "[name] core"
 	aSignal.code = rand(1,100)
 
-	aSignal.frequency = rand(MIN_FREE_FREQ, MAX_FREE_FREQ)
-	if(ISMULTIPLE(aSignal.frequency, 2))//signaller frequencies are always uneven!
-		aSignal.frequency++
+	var/frequency = rand(MIN_FREE_FREQ, MAX_FREE_FREQ)
+	if(ISMULTIPLE(frequency, 2))//signaller frequencies are always uneven!
+		frequency++
+	aSignal.set_frequency(frequency)
 
 	if(new_lifespan)
 		lifespan = new_lifespan

--- a/code/modules/assembly/signaler.dm
+++ b/code/modules/assembly/signaler.dm
@@ -111,7 +111,7 @@ Code:
 		var/obj/item/assembly/signaler/signaler2 = W
 		if(secured && signaler2.secured)
 			code = signaler2.code
-			frequency = signaler2.frequency
+			set_frequency(signaler2.frequency)
 			to_chat(user, "You transfer the frequency and code of \the [signaler2.name] to \the [name]")
 	..()
 


### PR DESCRIPTION
:cl:
fix: Anomalies can be disabled with signalers again
/:cl:

Fixes #37766

This used to not be necessary thanks to a dirty hack
https://github.com/tgstation/tgstation/commit/b4d11c6eab775b1f0ac5c3e9c40104f282bdcf9a#diff-360b24ed4c639982bc7944909c1e2e26L32

This also fixes frequency changes when copying another signaller's frequency.