### PR TITLE
lets admins see dsay if they're in-game and unconscious

### DIFF
--- a/code/modules/admin/verbs/deadsay.dm
+++ b/code/modules/admin/verbs/deadsay.dm
@@ -27,7 +27,7 @@
 		if(isnewplayer(M))
 			continue
 		if (M.stat == DEAD || (M.client && M.client.holder && (M.client.prefs.chat_toggles & CHAT_DEAD))) //admins can toggle deadchat on and off. This is a proc in admin.dm and is only give to Administrators and above
-			M.show_message(rendered, 2)
+			to_chat(M, rendered)
 
 	SSblackbox.record_feedback("tally", "admin_verb", 1, "Dsay") //If you are copy-pasting this, ensure the 2nd parameter is unique to the new proc!
 


### PR DESCRIPTION
Consider this either a fix or a tweak, idc about the GBP anyways



[why]: # I hate it when i'm in cryo or unconscious for any other reason and suddenly can't see either my own or any other admins' deadchat messages. It doesn't even need show_message since this only impacts people who can't hear or are unconscious, and the only people who get sent the message are either admins or dead anyways,
