### PR TITLE
[s] Fixes an admin unprotected var read/write exploit

### DIFF
--- a/code/modules/clothing/clothing.dm
+++ b/code/modules/clothing/clothing.dm
@@ -83,13 +83,14 @@
 
 /obj/item/clothing/equipped(mob/user, slot)
 	..()
-
+	if (!istype(user))
+		return
 	if(slot_flags & slotdefine2slotbit(slot)) //Was equipped to a valid slot for this item?
 		if (LAZYLEN(user_vars_to_edit))
 			for(var/variable in user_vars_to_edit)
 				if(variable in user.vars)
 					LAZYSET(user_vars_remembered, variable, user.vars[variable])
-					user.vars[variable] = user_vars_to_edit[variable]
+					user.vv_edit_var(variable, user_vars_to_edit[variable])
 
 /obj/item/clothing/examine(mob/user)
 	..()


### PR DESCRIPTION
so yeah you can call `equipped()` on non-mobs, such as datums, and it does unguarded var edits while saving the previous value to a list. 