### PR TITLE
Make admin heals also max out mood

### DIFF
--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -472,6 +472,11 @@
 	ExtinguishMob()
 	fire_stacks = 0
 	update_canmove()
+	GET_COMPONENT(mood, /datum/component/mood)
+	if (mood)
+		QDEL_LIST(mood.mood_events)
+		mood.sanity = SANITY_GREAT
+		mood.update_mood()
 
 
 //proc called by revive(), to check if we can actually ressuscitate the mob (we don't want to revive him and have him instantly die again)


### PR DESCRIPTION
:cl:
admin: Admin-healing someone will now rejuvenate their mood as well.
/:cl:

Mostly for when I leave the game open in the background during testing and don't want to be slow.
