### PR TITLE
Individual Logs now follow the client around automatically

### DIFF
--- a/code/__DEFINES/logging.dm
+++ b/code/__DEFINES/logging.dm
@@ -20,4 +20,7 @@
 #define INDIVIDUAL_SAY_LOG			"Say log"
 #define INDIVIDUAL_EMOTE_LOG		"Emote log"
 #define INDIVIDUAL_OOC_LOG			"OOC log"
+#define INDIVIDUAL_OWNERSHIP_LOG	"Ownership log"
 #define INDIVIDUAL_SHOW_ALL_LOG		"All logs"
+#define LOGSRC_CLIENT "Client"
+#define LOGSRC_MOB "Mob"

--- a/code/_globalvars/logging.dm
+++ b/code/_globalvars/logging.dm
@@ -39,6 +39,4 @@ GLOBAL_PROTECT(OOClog)
 GLOBAL_LIST_EMPTY(adminlog)
 GLOBAL_PROTECT(adminlog)
 
-GLOBAL_LIST_EMPTY(individual_log_list) // Logs each mob individual logs, a global so it doesn't get lost on cloning/changing mobs
-
 GLOBAL_LIST_EMPTY(active_turfs_startlist)

--- a/code/modules/admin/admin.dm
+++ b/code/modules/admin/admin.dm
@@ -63,7 +63,11 @@
 	body += "<a href='?priv_msg=[M.ckey]'>PM</a> - "
 	body += "<a href='?_src_=holder;[HrefToken()];subtlemessage=[REF(M)]'>SM</a> - "
 	body += "<a href='?_src_=holder;[HrefToken()];adminplayerobservefollow=[REF(M)]'>FLW</a> - "
-	body += "<a href='?_src_=holder;[HrefToken()];individuallog=[REF(M)]'>LOGS</a>\] <br>"
+	//Default to client logs if available
+	var/source = LOGSRC_MOB
+	if(M.client)
+		source = LOGSRC_CLIENT
+	body += "<a href='?_src_=holder;[HrefToken()];individuallog=[REF(M)];log_src=[source]'>LOGS</a>\] <br>"
 
 	body += "<b>Mob type</b> = [M.type]<br><br>"
 

--- a/code/modules/admin/topic.dm
+++ b/code/modules/admin/topic.dm
@@ -1903,7 +1903,7 @@
 			to_chat(usr, "This can only be used on instances of type /mob.")
 			return
 
-		show_individual_logging_panel(M, href_list["log_type"])
+		show_individual_logging_panel(M, href_list["log_src"], href_list["log_type"])
 	else if(href_list["languagemenu"])
 		if(!check_rights(R_ADMIN))
 			return

--- a/code/modules/admin/verbs/individual_logging.dm
+++ b/code/modules/admin/verbs/individual_logging.dm
@@ -1,32 +1,52 @@
-/proc/show_individual_logging_panel(mob/M, type = INDIVIDUAL_ATTACK_LOG)
+/proc/show_individual_logging_panel(mob/M, source = LOGSRC_CLIENT, type = INDIVIDUAL_ATTACK_LOG)
 	if(!M || !ismob(M))
 		return
-	var/dat = "<center><a href='?_src_=holder;[HrefToken()];individuallog=[REF(M)];log_type=[INDIVIDUAL_ATTACK_LOG]'>Attack log</a> | "
-	dat += "<a href='?_src_=holder;[HrefToken()];individuallog=[REF(M)];log_type=[INDIVIDUAL_SAY_LOG]'>Say log</a> | "
-	dat += "<a href='?_src_=holder;[HrefToken()];individuallog=[REF(M)];log_type=[INDIVIDUAL_EMOTE_LOG]'>Emote log</a> | "
-	dat += "<a href='?_src_=holder;[HrefToken()];individuallog=[REF(M)];log_type=[INDIVIDUAL_OOC_LOG]'>OOC log</a> | "
-	dat += "<a href='?_src_=holder;[HrefToken()];individuallog=[REF(M)];log_type=[INDIVIDUAL_SHOW_ALL_LOG]'>Show all</a> | "
-	dat += "<a href='?_src_=holder;[HrefToken()];individuallog=[REF(M)];log_type=[type]'>Refresh</a></center>"
+	
+	//Add client links
+	var/dat = ""
+	if(M.client) 
+		dat += "<center><p>Client</p></center>"	
+		dat += "<center><a href='?_src_=holder;[HrefToken()];individuallog=[REF(M)];log_type=[INDIVIDUAL_ATTACK_LOG];log_src=[LOGSRC_CLIENT]'>Attack log</a> | "
+		dat += "<a href='?_src_=holder;[HrefToken()];individuallog=[REF(M)];log_type=[INDIVIDUAL_SAY_LOG];log_src=[LOGSRC_CLIENT]'>Say log</a> | "
+		dat += "<a href='?_src_=holder;[HrefToken()];individuallog=[REF(M)];log_type=[INDIVIDUAL_EMOTE_LOG];log_src=[LOGSRC_CLIENT]'>Emote log</a> | "
+		dat += "<a href='?_src_=holder;[HrefToken()];individuallog=[REF(M)];log_type=[INDIVIDUAL_OOC_LOG];log_src=[LOGSRC_CLIENT]'>OOC log</a> | "
+		dat += "<a href='?_src_=holder;[HrefToken()];individuallog=[REF(M)];log_type=[INDIVIDUAL_SHOW_ALL_LOG];log_src=[LOGSRC_CLIENT]'>Show all</a> | "
+		dat += "<a href='?_src_=holder;[HrefToken()];individuallog=[REF(M)];log_type=[type];log_src=[LOGSRC_CLIENT]'>Refresh</a></center>"
+	else
+		dat += "<p> No client attached to mob </p>"
+
+	dat += "<hr style='background:#000000; border:0; height:1px'>"
+	dat += "<center><p>Mob</p></center>"	
+	//Add the links for the mob specific log
+	dat += "<center><a href='?_src_=holder;[HrefToken()];individuallog=[REF(M)];log_type=[INDIVIDUAL_ATTACK_LOG];log_src=[LOGSRC_MOB]'>Attack log</a> | "
+	dat += "<a href='?_src_=holder;[HrefToken()];individuallog=[REF(M)];log_type=[INDIVIDUAL_SAY_LOG];log_src=[LOGSRC_MOB]'>Say log</a> | "
+	dat += "<a href='?_src_=holder;[HrefToken()];individuallog=[REF(M)];log_type=[INDIVIDUAL_EMOTE_LOG];log_src=[LOGSRC_MOB]'>Emote log</a> | "
+	dat += "<a href='?_src_=holder;[HrefToken()];individuallog=[REF(M)];log_type=[INDIVIDUAL_OOC_LOG];log_src=[LOGSRC_MOB]'>OOC log</a> | "
+	dat += "<a href='?_src_=holder;[HrefToken()];individuallog=[REF(M)];log_type=[INDIVIDUAL_SHOW_ALL_LOG];log_src=[LOGSRC_MOB]'>Show all</a> | "
+	dat += "<a href='?_src_=holder;[HrefToken()];individuallog=[REF(M)];log_type=[type];log_src=[LOGSRC_MOB]'>Refresh</a></center>"
 
 	dat += "<hr style='background:#000000; border:0; height:1px'>"
 
+	var/log_source = M.logging;
+	if(source == LOGSRC_CLIENT && M.client) //if client doesn't exist just fall back to the mob log
+		log_source = M.client.player_details.logging //should exist, if it doesn't that's a bug, don't check for it not existing
 
 	if(type == INDIVIDUAL_SHOW_ALL_LOG)
-		dat += "<center>Displaying all logs of [key_name(M)]</center><br><hr>"
-		for(var/log_type in M.logging)
+		dat += "<center>Displaying all [source] logs of [key_name(M)]</center><br><hr>"
+		for(var/log_type in log_source)
 			dat += "<center><b>[log_type]</b></center><br>"
-			var/list/reversed = M.logging[log_type]
+			var/list/reversed = log_source[log_type]
 			if(islist(reversed))
 				reversed = reverseRange(reversed.Copy())
 				for(var/entry in reversed)
 					dat += "<font size=2px>[entry]: [reversed[entry]]</font><br>"
 			dat += "<hr>"
 	else
-		dat += "<center>[type] of [key_name(M)]</center><br>"
-		var/list/reversed = M.logging[type]
+		dat += "<center>[source] [type] of [key_name(M)]</center><br>"
+		var/list/reversed = log_source[type]
 		if(reversed)
 			reversed = reverseRange(reversed.Copy())
 			for(var/entry in reversed)
 				dat += "<font size=2px>[entry]: [reversed[entry]]</font><hr>"
 
-	usr << browse(dat, "window=invidual_logging_[M];size=600x480")
+	usr << browse(dat, "window=invidual_logging_[key_name(M)];size=600x480")

--- a/code/modules/client/player_details.dm
+++ b/code/modules/client/player_details.dm
@@ -1,2 +1,3 @@
 /datum/player_details
 	var/list/player_actions = list()
+	var/list/logging = list(INDIVIDUAL_ATTACK_LOG, INDIVIDUAL_SAY_LOG, INDIVIDUAL_EMOTE_LOG, INDIVIDUAL_OOC_LOG)

--- a/code/modules/mob/dead/observer/observer.dm
+++ b/code/modules/mob/dead/observer/observer.dm
@@ -79,7 +79,6 @@ GLOBAL_VAR_INIT(observer_default_invisibility, INVISIBILITY_OBSERVER)
 	var/mob/body = loc
 	if(ismob(body))
 		T = get_turf(body)				//Where is the body located?
-		logging = body.logging			//preserve our logs by copying them to our ghost
 
 		gender = body.gender
 		if(body.mind && body.mind.name)

--- a/code/modules/mob/login.dm
+++ b/code/modules/mob/login.dm
@@ -47,7 +47,4 @@
 			for(var/datum/action/A in client.player_details.player_actions)
 				A.Grant(src)
 
-	if(!GLOB.individual_log_list[ckey])
-		GLOB.individual_log_list[ckey] = logging
-	else
-		logging = GLOB.individual_log_list[ckey]
+	log_message("Client [key_name(src)] has taken ownership of mob [src]", INDIVIDUAL_OWNERSHIP_LOG)

--- a/code/modules/mob/logout.dm
+++ b/code/modules/mob/logout.dm
@@ -1,4 +1,5 @@
 /mob/Logout()
+	log_message("[key_name(src)] is no longer owning mob [src]", INDIVIDUAL_OWNERSHIP_LOG)
 	SStgui.on_logout(src)
 	unset_machine()
 	GLOB.player_list -= src

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -772,6 +772,7 @@
 //This will update a mob's name, real_name, mind.name, GLOB.data_core records, pda, id and traitor text
 //Calling this proc without an oldname will only update the mob and skip updating the pda, id and records ~Carn
 /mob/proc/fully_replace_character_name(oldname,newname)
+	log_message("[src] name changed from [oldname] to [newname]", INDIVIDUAL_OWNERSHIP_LOG)
 	if(!newname)
 		return 0
 	real_name = newname

--- a/code/modules/mob/mob_helpers.dm
+++ b/code/modules/mob/mob_helpers.dm
@@ -477,12 +477,18 @@ It's fairly easy to fix if dealing with single letters but not so much with comp
 	if(!LAZYLEN(message) || !message_type)
 		return
 
+	if(client)
+		if(!islist(client.player_details.logging[message_type]))
+			client.player_details.logging[message_type] = list()
+
 	if(!islist(logging[message_type]))
 		logging[message_type] = list()
 
 	var/list/timestamped_message = list("[LAZYLEN(logging[message_type]) + 1]\[[time_stamp()]\] [key_name(src)]" = message)
 
 	logging[message_type] += timestamped_message
+	if(client)
+		client.player_details.logging[message_type] += timestamped_message
 
 /mob/proc/can_hear()
 	. = TRUE

--- a/code/modules/projectiles/projectile/magic.dm
+++ b/code/modules/projectiles/projectile/magic.dm
@@ -231,7 +231,6 @@
 	if(!new_mob)
 		return
 	new_mob.grant_language(/datum/language/common)
-	new_mob.logging = M.logging
 
 	// Some forms can still wear some items
 	for(var/obj/item/W in contents)


### PR DESCRIPTION
The logging is now stored in the persistent client/player_details datum,
that will survive an entire round

The existing mob log is retained and a new admin verb is added to access
it. It will only show logs for the mob in question, across all players
who possibly spent time in that mob

A new log type is added that tracks the mobs the player changes across
into and the times they occured, to better help admins manage complex
situations, this also appears in the mob log as a record of the players
who entered/exited control of the mob


CONS: if the user client is not present, the log can't be easily accessed, I may add something to help deal with this in the near future, but the mob log will still be accessible, more concretely, I am planning on adding an OMNI panel that shows all people that have connected in the last round, with links to easy functions to ban/message/note/see logs etc, since this is a somewhat lacking area where if someone has disconnected admins have a lot of trouble tracking them