### PR TITLE
Fixes defibs/backpack watertanks/gatling lasers

### DIFF
--- a/code/game/objects/items/defib.dm
+++ b/code/game/objects/items/defib.dm
@@ -170,7 +170,6 @@
 			to_chat(user, "<span class='warning'>You need a free hand to hold the paddles!</span>")
 			update_icon()
 			return
-		paddles.forceMove(user)
 	else
 		//Remove from their hands and back onto the defib unit
 		paddles.unwield()

--- a/code/game/objects/items/tanks/watertank.dm
+++ b/code/game/objects/items/tanks/watertank.dm
@@ -49,7 +49,6 @@
 			on = FALSE
 			to_chat(user, "<span class='warning'>You need a free hand to hold the mister!</span>")
 			return
-		noz.forceMove(user)
 	else
 		//Remove from their hands and put back "into" the tank
 		remove_noz()

--- a/code/modules/projectiles/guns/ballistic/laser_gatling.dm
+++ b/code/modules/projectiles/guns/ballistic/laser_gatling.dm
@@ -40,7 +40,6 @@
 					to_chat(user, "<span class='warning'>You need a free hand to hold the gun!</span>")
 					return
 				update_icon()
-				gun.forceMove(user)
 				user.update_inv_back()
 		else
 			to_chat(user, "<span class='warning'>You are already holding the gun!</span>")


### PR DESCRIPTION
:cl:
fix:  The paddle/nozzles of defibs, backpack water tanks, and gatling lasers work again
/:cl:
Fixes #37779

https://github.com/tgstation/tgstation/commit/d95c220c3777d52cfeb43916f8f6b145b965c2b7#diff-ac3b89e91ad083b3cb3fdb669006158cR774
Calling forceMove() now removes things from inventories (which moves the paddles/nozzle back into the defib/pack) and put_in_hands already moves it anyways.