### PR TITLE
Adds desc to chemmaster circ board

### DIFF
--- a/code/game/objects/items/circuitboards/machine_circuitboards.dm
+++ b/code/game/objects/items/circuitboards/machine_circuitboards.dm
@@ -204,7 +204,7 @@
 
 /obj/item/circuitboard/machine/vendor
 	name = "Booze-O-Mat Vendor (Machine Board)"
-	desc = "You could turn the \"brand selection\" dial using a screwdriver."
+	desc = "You can turn the \"brand selection\" dial using a screwdriver."
 	build_path = /obj/machinery/vending/boozeomat
 	req_components = list(
 							/obj/item/vending_refill/boozeomat = 3)

--- a/code/game/objects/items/circuitboards/machine_circuitboards.dm
+++ b/code/game/objects/items/circuitboards/machine_circuitboards.dm
@@ -651,7 +651,7 @@
 /obj/item/circuitboard/machine/chem_master
 	name = "ChemMaster 3000 (Machine Board)"
 	build_path = /obj/machinery/chem_master
-	desc = "You could turn the \"mode selection\" dial using a screwdriver."
+	desc = "You can turn the \"mode selection\" dial using a screwdriver."
 	req_components = list(
 		/obj/item/reagent_containers/glass/beaker = 2,
 		/obj/item/stock_parts/manipulator = 1,

--- a/code/game/objects/items/circuitboards/machine_circuitboards.dm
+++ b/code/game/objects/items/circuitboards/machine_circuitboards.dm
@@ -651,6 +651,7 @@
 /obj/item/circuitboard/machine/chem_master
 	name = "ChemMaster 3000 (Machine Board)"
 	build_path = /obj/machinery/chem_master
+	desc = "You could turn the \"mode selection\" dial using a screwdriver."
 	req_components = list(
 		/obj/item/reagent_containers/glass/beaker = 2,
 		/obj/item/stock_parts/manipulator = 1,


### PR DESCRIPTION
:cl: Denton
spellcheck: Did you know that you can use a screwdriver on the ChemMaster board? Now you do.
/:cl:

/tg/station, where comments and object descs are for the weak