### PR TITLE
Buckled/pulled cultists cant be teleport summoned

### DIFF
--- a/code/modules/antagonists/cult/runes.dm
+++ b/code/modules/antagonists/cult/runes.dm
@@ -708,6 +708,11 @@ structure_check() searches for nearby cultist structures required for the invoca
 		fail_invoke()
 		log_game("Summon Cultist rune failed - target died")
 		return
+	if(cultist_to_summon.pulledby || cultist_to_summon.buckled)
+		to_chat(user, "<span class='cult italic'>[cultist_to_summon] is being held in place!</span>")
+		fail_invoke()
+		log_game("Summon Cultist rune failed - target restrained")
+		return
 	if(!iscultist(cultist_to_summon))
 		to_chat(user, "<span class='cult italic'>[cultist_to_summon] is not a follower of the Geometer!</span>")
 		fail_invoke()


### PR DESCRIPTION
Having a lengthy deconversion process that requires restraining a cultist for ~a minute of taking them back to the brig and feeding them holy water, but having no way to actually prevent people on another z level from grabbing them away, seems needlessly cruel to loyalist players.