### PR TITLE
Adds basic electronics to techwebs

### DIFF
--- a/code/modules/research/designs/autolathe_designs.dm
+++ b/code/modules/research/designs/autolathe_designs.dm
@@ -126,42 +126,47 @@
 /datum/design/apc_board
 	name = "APC Module"
 	id = "power control"
-	build_type = AUTOLATHE
+	build_type = AUTOLATHE | PROTOLATHE
 	materials = list(MAT_METAL = 100, MAT_GLASS = 100)
 	build_path = /obj/item/electronics/apc
 	category = list("initial", "Electronics")
+	departmental_flags = DEPARTMENTAL_FLAG_ENGINEERING
 
 /datum/design/airlock_board
 	name = "Airlock Electronics"
 	id = "airlock_board"
-	build_type = AUTOLATHE
+	build_type = AUTOLATHE | PROTOLATHE
 	materials = list(MAT_METAL = 50, MAT_GLASS = 50)
 	build_path = /obj/item/electronics/airlock
 	category = list("initial", "Electronics")
+	departmental_flags = DEPARTMENTAL_FLAG_ENGINEERING
 
 /datum/design/firelock_board
 	name = "Firelock Circuitry"
 	id = "firelock_board"
-	build_type = AUTOLATHE
+	build_type = AUTOLATHE | PROTOLATHE
 	materials = list(MAT_METAL = 50, MAT_GLASS = 50)
 	build_path = /obj/item/electronics/firelock
 	category = list("initial", "Electronics")
+	departmental_flags = DEPARTMENTAL_FLAG_ENGINEERING
 
 /datum/design/airalarm_electronics
 	name = "Air Alarm Electronics"
 	id = "airalarm_electronics"
-	build_type = AUTOLATHE
+	build_type = AUTOLATHE | PROTOLATHE
 	materials = list(MAT_METAL = 50, MAT_GLASS = 50)
 	build_path = /obj/item/electronics/airalarm
 	category = list("initial", "Electronics")
+	departmental_flags = DEPARTMENTAL_FLAG_ENGINEERING
 
 /datum/design/firealarm_electronics
 	name = "Fire Alarm Electronics"
 	id = "firealarm_electronics"
-	build_type = AUTOLATHE
+	build_type = AUTOLATHE | PROTOLATHE
 	materials = list(MAT_METAL = 50, MAT_GLASS = 50)
 	build_path = /obj/item/electronics/firealarm
 	category = list("initial", "Electronics")
+	departmental_flags = DEPARTMENTAL_FLAG_ENGINEERING
 
 /datum/design/camera
 	name = "Camera"

--- a/code/modules/research/techweb/all_nodes.dm
+++ b/code/modules/research/techweb/all_nodes.dm
@@ -97,6 +97,15 @@
 	research_cost = 7500
 	export_price = 5000
 
+/datum/techweb_node/electronics
+	id = "electronics"
+	display_name = "Basic Electronics"
+	description = "Basic electronics for station construction."
+	prereq_ids = list("base")
+	design_ids = list("power control", "airlock_board", "firelock_board", "airalarm_electronics", "firealarm_electronics")
+	research_cost = 1000 //you can print all of these on a roundstart autolathe already
+	export_price = 5000	
+
 /datum/techweb_node/adv_engi
 	id = "adv_engi"
 	display_name = "Advanced Engineering"

--- a/code/modules/research/techweb/all_nodes.dm
+++ b/code/modules/research/techweb/all_nodes.dm
@@ -93,18 +93,9 @@
 	description = "A refresher course on modern engineering technology."
 	prereq_ids = list("base")
 	design_ids = list("solarcontrol", "recharger", "powermonitor", "rped", "pacman", "adv_capacitor", "adv_scanning", "emitter", "high_cell", "adv_matter_bin",
-	"atmosalerts", "atmos_control", "recycler", "autolathe", "high_micro_laser", "nano_mani", "mesons", "thermomachine", "rad_collector", "tesla_coil", "grounding_rod", "apc_control", "cell_charger")
+	"atmosalerts", "atmos_control", "recycler", "autolathe", "high_micro_laser", "nano_mani", "mesons", "thermomachine", "rad_collector", "tesla_coil", "grounding_rod", "apc_control", "cell_charger", "power control", "airlock_board", "firelock_board", "airalarm_electronics", "firealarm_electronics")
 	research_cost = 7500
 	export_price = 5000
-
-/datum/techweb_node/electronics
-	id = "electronics"
-	display_name = "Basic Electronics"
-	description = "Basic electronics for station construction."
-	prereq_ids = list("base")
-	design_ids = list("power control", "airlock_board", "firelock_board", "airalarm_electronics", "firealarm_electronics")
-	research_cost = 1000 //you can print all of these on a roundstart autolathe already
-	export_price = 5000	
 
 /datum/techweb_node/adv_engi
 	id = "adv_engi"


### PR DESCRIPTION
:cl: Denton
add: APC/air alarm/airlock/fire alarm/firelock electronics are now available once Industrial Engineering is researched..
/:cl:

These electronics are printable at any autolathe roundstart, it would only make sense to add them to a techweb node for the engineering protolathe as well.

Edit: As kevinz000 suggested, I put them in the industrial engineering node instead of giving them their own.