### PR TITLE
Send jquery asset when initializing tooltips

### DIFF
--- a/code/modules/client/asset_cache.dm
+++ b/code/modules/client/asset_cache.dm
@@ -157,9 +157,7 @@ GLOBAL_LIST_EMPTY(asset_datums)
 
 //get an assetdatum or make a new one
 /proc/get_asset_datum(var/type)
-	if (!(type in GLOB.asset_datums))
-		return new type()
-	return GLOB.asset_datums[type]
+	return GLOB.asset_datums[type] || new type()
 
 /datum/asset
 	var/_abstract = /datum/asset
@@ -496,12 +494,21 @@ GLOBAL_LIST_EMPTY(asset_datums)
 	)
 
 /datum/asset/group/goonchat
-	children = list(/datum/asset/simple/goonchat, /datum/asset/spritesheet/goonchat)
+	children = list(
+		/datum/asset/simple/jquery,
+		/datum/asset/simple/goonchat,
+		/datum/asset/spritesheet/goonchat
+	)
+
+/datum/asset/simple/jquery
+	verify = FALSE
+	assets = list(
+		"jquery.min.js"            = 'code/modules/goonchat/browserassets/js/jquery.min.js',
+	)
 
 /datum/asset/simple/goonchat
 	verify = FALSE
 	assets = list(
-		"jquery.min.js"            = 'code/modules/goonchat/browserassets/js/jquery.min.js',
 		"json2.min.js"             = 'code/modules/goonchat/browserassets/js/json2.min.js',
 		"errorHandler.js"          = 'code/modules/goonchat/browserassets/js/errorHandler.js',
 		"browserOutput.js"         = 'code/modules/goonchat/browserassets/js/browserOutput.js',

--- a/code/modules/tooltip/tooltip.dm
+++ b/code/modules/tooltip/tooltip.dm
@@ -42,6 +42,8 @@ Notes:
 /datum/tooltip/New(client/C)
 	if (C)
 		owner = C
+		var/datum/asset/stuff = get_asset_datum(/datum/asset/simple/jquery)
+		stuff.send(owner)
 		owner << browse(file2text('code/modules/tooltip/tooltip.html'), "window=[control]")
 
 	..()


### PR DESCRIPTION
Should fix the `"$" is undefined` errors some have been reporting with tooltips since #37641. Dumb mistake given how much time I've spent in asset code.