### PR TITLE
[DNM][DOESNT WORK YET] Headcrab Update (Fix elevated into Feature)

### DIFF
--- a/code/modules/mob/living/simple_animal/hostile/headcrab.dm
+++ b/code/modules/mob/living/simple_animal/hostile/headcrab.dm
@@ -89,7 +89,7 @@
 				Remove(owner)
 				qdel(src)
 		else if(time > cooldown)
-			if(init_origin && init_origin.enslaved_mob)
+			if(init_origin && init_origin.enslaved_to)
 				notify_ghosts("An enslaved changeling is about to burst! Click to become the changeling!", source = src, action=NOTIFY_ATTACK, flashwindow = FALSE)
 			else
 				notify_ghosts("An unbound changeling is about to burst! Click to become the changeling!", source = src, action=NOTIFY_ATTACK, flashwindow = FALSE)
@@ -104,9 +104,9 @@
 
 	if(origin)
 		origin.transfer_to(M)
-		if((init_origin != origin) && init_origin.enslaved_mob) //edge
-			origin.enslave_mind_to_creator(init_origin.enslaved_mob)
-			to_chat(origin.current, "<span class='warning'><b>NOTE:</b> The individual you're filling in for was bound to [origin.enslaved_mob.real_name].</span>")
+		if((init_origin != origin) && init_origin.enslaved_to) //edge
+			origin.enslave_mind_to_creator(init_origin.enslaved_to)
+			to_chat(origin.current, "<span class='warning'><b>NOTE:</b> The individual you're filling in for was bound to [origin.enslaved_to.real_name].</span>")
 		var/datum/antagonist/changeling/C = origin.has_antag_datum(/datum/antagonist/changeling)
 		if(!C)
 			C = origin.add_antag_datum(/datum/antagonist/changeling/xenobio)

--- a/code/modules/mob/living/simple_animal/hostile/headcrab.dm
+++ b/code/modules/mob/living/simple_animal/hostile/headcrab.dm
@@ -72,7 +72,7 @@
 /obj/item/organ/body_egg/changeling_egg/attack_ghost(mob/dead/observer/user)
 	. = ..()
 	if(isnull(origin) && !QDELETED(user) && user.mind) //you managed to be pulled (IE cloning) right as you attacked.
-	 	origin = user.mind
+		origin = user.mind
 		to_chat(user, "<span class='notice'>You will later spawn as a changeling, please remain as a ghost during this time or you may lose your spot!</span>")
 
 /obj/item/organ/body_egg/changeling_egg/egg_process()

--- a/code/modules/mob/living/simple_animal/hostile/headcrab.dm
+++ b/code/modules/mob/living/simple_animal/hostile/headcrab.dm
@@ -80,14 +80,14 @@
 	time++
 	if(time >= true_hatch_time)
 		if(origin)
-			if(!isghost(origin)) //if you're doing something else when it's time to pop then you lose the role.
+			if(!isghost(origin.current)) //if you're doing something else when it's time to pop then you lose the role.
 				origin = null
 			else
 				Pop()
 				Remove(owner)
 				qdel(src)
 		else if(time > cooldown)
-			notify_ghosts("A changeling is about to burst!", source = egg, action=NOTIFY_ATTACK, flashwindow = FALSE)
+			notify_ghosts("A changeling is about to burst!", source = src, action=NOTIFY_ATTACK, flashwindow = FALSE)
 			cooldown = time + cooldown // (x*2cooldown)+cooldown where x is the amount of times the above notification is thrown. tldr it gets longer each time it's thrown.
 
 /obj/item/organ/body_egg/changeling_egg/proc/Pop()

--- a/code/modules/mob/living/simple_animal/hostile/headcrab.dm
+++ b/code/modules/mob/living/simple_animal/hostile/headcrab.dm
@@ -20,22 +20,24 @@
 	environment_smash = ENVIRONMENT_SMASH_NONE
 	speak_emote = list("squeaks")
 	ventcrawler = VENTCRAWLER_ALWAYS
-	var/datum/mind/origin
-	var/egg_lain = 0
+	var/egg_lain = FALSE
 	gold_core_spawnable = HOSTILE_SPAWN //are you sure about this??
+	var/datum/mind/origin
 
 /mob/living/simple_animal/hostile/headcrab/proc/Infect(mob/living/carbon/victim)
 	var/obj/item/organ/body_egg/changeling_egg/egg = new(victim)
 	egg.Insert(victim)
-	if(origin)
-		egg.origin = origin
-	else if(mind) // Let's make this a feature
+	if(mind) // Let's make this a feature //sounds good to me!
 		egg.origin = mind
+	else if(isnull(origin))
+		notify_ghosts("A mindless headslug has implanted a being!", source = egg, action=NOTIFY_ATTACK, flashwindow = FALSE)
+	else
+		egg.origin = origin // admins can rig it without disappointing ghosts
 	for(var/obj/item/organ/I in src)
 		I.forceMove(egg)
 	visible_message("<span class='warning'>[src] plants something in [victim]'s flesh!</span>", \
 					"<span class='danger'>We inject our egg into [victim]'s body!</span>")
-	egg_lain = 1
+	egg_lain = TRUE
 
 /mob/living/simple_animal/hostile/headcrab/AttackingTarget()
 	. = ..()
@@ -50,19 +52,43 @@
 			to_chat(src, "<span class='userdanger'>With our egg laid, our death approaches rapidly...</span>")
 			addtimer(CALLBACK(src, .proc/death), 100)
 
+/mob/living/simple_animal/hostile/headcrab/death()
+	..()
+	ghostize(TRUE) //you need to be a ghost to be the ling. Here, let me help.
+
 /obj/item/organ/body_egg/changeling_egg
 	name = "changeling egg"
 	desc = "Twitching and disgusting."
 	var/datum/mind/origin
-	var/time
+	var/time = 0
+	var/cooldown = 60
+	var/true_hatch_time = EGG_INCUBATION_TIME
+
+/obj/item/organ/body_egg/changeling_egg/Initialize(mapload)
+	. = ..()
+	var/randomization = (rand(80,120)/100) //+- 20%
+	true_hatch_time = CEILING(true_hatch_time*randomization, 1) 
+
+/obj/item/organ/body_egg/changeling_egg/attack_ghost(mob/dead/observer/user)
+	. = ..()
+	if(isnull(origin) && !QDELETED(user) && user.mind) //you managed to be pulled (IE cloning) right as you attacked.
+	 	origin = user.mind
+		to_chat(user, "<span class='notice'>You will later spawn as a changeling, please remain as a ghost during this time or you may lose your spot!</span>")
 
 /obj/item/organ/body_egg/changeling_egg/egg_process()
 	// Changeling eggs grow in dead people
 	time++
-	if(time >= EGG_INCUBATION_TIME)
-		Pop()
-		Remove(owner)
-		qdel(src)
+	if(time >= true_hatch_time)
+		if(origin)
+			if(!isghost(origin)) //if you're doing something else when it's time to pop then you lose the role.
+				origin = null
+			else
+				Pop()
+				Remove(owner)
+				qdel(src)
+		else if(time > cooldown)
+			notify_ghosts("A changeling is about to burst!", source = egg, action=NOTIFY_ATTACK, flashwindow = FALSE)
+			cooldown = time + cooldown // (x*2cooldown)+cooldown where x is the amount of times the above notification is thrown. tldr it gets longer each time it's thrown.
 
 /obj/item/organ/body_egg/changeling_egg/proc/Pop()
 	var/mob/living/carbon/monkey/M = new(owner)
@@ -71,7 +97,7 @@
 	for(var/obj/item/organ/I in src)
 		I.Insert(M, 1)
 
-	if(origin && (origin.current ? (origin.current.stat == DEAD) : origin.get_ghost()))
+	if(origin)
 		origin.transfer_to(M)
 		var/datum/antagonist/changeling/C = origin.has_antag_datum(/datum/antagonist/changeling)
 		if(!C)

--- a/code/modules/mob/living/simple_animal/hostile/headcrab.dm
+++ b/code/modules/mob/living/simple_animal/hostile/headcrab.dm
@@ -80,7 +80,7 @@
 	time++
 	if(time >= true_hatch_time)
 		if(origin)
-			if(!isghost(origin.current)) //if you're doing something else when it's time to pop then you lose the role.
+			if(!isobserver(origin.current)) //if you're doing something else when it's time to pop then you lose the role.
 				origin = null
 			else
 				Pop()

--- a/code/modules/mob/living/simple_animal/hostile/headcrab.dm
+++ b/code/modules/mob/living/simple_animal/hostile/headcrab.dm
@@ -29,6 +29,7 @@
 	egg.Insert(victim)
 	if(mind) // Let's make this a feature //sounds good to me!
 		egg.origin = mind
+		egg.init_origin = mind
 	else if(isnull(origin))
 		notify_ghosts("A mindless headslug has implanted a being!", source = egg, action=NOTIFY_ATTACK, flashwindow = FALSE)
 	else
@@ -59,6 +60,7 @@
 /obj/item/organ/body_egg/changeling_egg
 	name = "changeling egg"
 	desc = "Twitching and disgusting."
+	var/datum/mind/init_origin //only to pull from sentienced slugs in case they leave (we want proper enslavement)
 	var/datum/mind/origin
 	var/time = 0
 	var/cooldown = 60
@@ -87,7 +89,10 @@
 				Remove(owner)
 				qdel(src)
 		else if(time > cooldown)
-			notify_ghosts("A changeling is about to burst! Click to become the changeling!", source = src, action=NOTIFY_ATTACK, flashwindow = FALSE)
+			if(init_origin && init_origin.enslaved_mob)
+				notify_ghosts("An enslaved changeling is about to burst! Click to become the changeling!", source = src, action=NOTIFY_ATTACK, flashwindow = FALSE)
+			else
+				notify_ghosts("An unbound changeling is about to burst! Click to become the changeling!", source = src, action=NOTIFY_ATTACK, flashwindow = FALSE)
 			cooldown = time + cooldown // (x*2cooldown)+cooldown where x is the amount of times the above notification is thrown. tldr it gets longer each time it's thrown.
 
 /obj/item/organ/body_egg/changeling_egg/proc/Pop()
@@ -99,6 +104,9 @@
 
 	if(origin)
 		origin.transfer_to(M)
+		if((init_origin != origin) && init_origin.enslaved_mob) //edge
+			origin.enslave_mind_to_creator(init_origin.enslaved_mob)
+			to_chat(origin.current, "<span class='warning'><b>NOTE:</b> The individual you're filling in for was bound to [origin.enslaved_mob.real_name].</span>")
 		var/datum/antagonist/changeling/C = origin.has_antag_datum(/datum/antagonist/changeling)
 		if(!C)
 			C = origin.add_antag_datum(/datum/antagonist/changeling/xenobio)

--- a/code/modules/mob/living/simple_animal/hostile/headcrab.dm
+++ b/code/modules/mob/living/simple_animal/hostile/headcrab.dm
@@ -87,7 +87,7 @@
 				Remove(owner)
 				qdel(src)
 		else if(time > cooldown)
-			notify_ghosts("A changeling is about to burst!", source = src, action=NOTIFY_ATTACK, flashwindow = FALSE)
+			notify_ghosts("A changeling is about to burst! Click to become the changeling!", source = src, action=NOTIFY_ATTACK, flashwindow = FALSE)
 			cooldown = time + cooldown // (x*2cooldown)+cooldown where x is the amount of times the above notification is thrown. tldr it gets longer each time it's thrown.
 
 /obj/item/organ/body_egg/changeling_egg/proc/Pop()


### PR DESCRIPTION
:cl: Cobby
add: non-sentient headslugs that infect the dead will now prompt ghosts to take the hatched (unbound) changeling role.
code: Mind over matter! A mind in a headslug will take priority during infection (edge cases means admins may set you to get it on the npc slug but the slug gets sentienced so you lose priority).
tweak: Incubation duration has some randomization.
fix: Being anything but an observer will no longer force-pull you into the ling role. Make sure to stay ghosted!
experiment: ^ but don't worry, we give ghosts an opportunity to have fun for you if you chose something else!
/:cl:

Fixes #37274 and provides some potential danger to headslugs who are left unattended (insert flying metal deathtrap buzzphrase here). Tweaks hatchtime to not be as metagame-able

**Also this is webbit af so considered DNM until I test it on my desktop or someone wants to valiantly take the torch.**