### PR TITLE
Client topics only check for deleted objects when an object was actually passed

### DIFF
--- a/code/modules/client/client_procs.dm
+++ b/code/modules/client/client_procs.dm
@@ -108,10 +108,10 @@ GLOBAL_LIST_INIT(blacklisted_builds, list(
 	switch(href_list["action"])
 		if("openLink")
 			src << link(href_list["link"])
-
-	var/datum/real_src = hsrc
-	if(QDELETED(real_src))
-		return
+	if (hsrc)
+		var/datum/real_src = hsrc
+		if(QDELETED(real_src))
+			return
 
 	..()	//redirect to hsrc.Topic()
 


### PR DESCRIPTION
I need this for a thing I'm doing.