### PR TITLE
Fixes radimmune mobs being killed by high bursts of radiation

### DIFF
--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -915,7 +915,7 @@
 /mob/living/rad_act(amount)
 	. = ..()
 
-	if(!amount || amount < RAD_MOB_SKIN_PROTECTION)
+	if(!amount || (amount < RAD_MOB_SKIN_PROTECTION) || has_trait(TRAIT_RADIMMUNE))
 		return
 
 	amount -= RAD_BACKGROUND_RADIATION // This will always be at least 1 because of how skin protection is calculated


### PR DESCRIPTION
Fixes #37739

:cl: ShizCalev
fix: Fixed mobs immune to radiation being killed by HIGH bursts of radiation.
/:cl: