### PR TITLE
Fixes dizziness on some drinks

### DIFF
--- a/code/modules/reagents/chemistry/reagents/alcohol_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/alcohol_reagents.dm
@@ -1238,7 +1238,7 @@ All effects don't start immediately, but rather get worse over time; the rate is
 	glass_desc = "Like having your brain smashed out by a slice of lemon wrapped around a large gold brick."
 
 /datum/reagent/consumable/ethanol/gargle_blaster/on_mob_life(mob/living/M)
-	M.dizziness +=6
+	M.dizziness +=1.5
 	switch(current_cycle)
 		if(15 to 45)
 			if(!M.slurring)
@@ -1267,7 +1267,7 @@ All effects don't start immediately, but rather get worse over time; the rate is
 
 /datum/reagent/consumable/ethanol/neurotoxin/on_mob_life(mob/living/carbon/M)
 	M.Knockdown(60, 1, 0)
-	M.dizziness +=6
+	M.dizziness +=2
 	switch(current_cycle)
 		if(15 to 45)
 			if(!M.slurring)

--- a/code/modules/reagents/chemistry/reagents/drink_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/drink_reagents.dm
@@ -407,7 +407,7 @@
 /datum/reagent/consumable/nuka_cola/on_mob_life(mob/living/M)
 	M.Jitter(20)
 	M.set_drugginess(30)
-	M.dizziness +=5
+	M.dizziness +=1.5
 	M.drowsyness = 0
 	M.AdjustSleeping(-40, FALSE)
 	M.adjust_bodytemperature(-5 * TEMPERATURE_DAMAGE_COEFFICIENT, BODYTEMP_NORMAL)


### PR DESCRIPTION
:cl: Mickyan
fix: Drinking too much Gargle Blaster, Nuka Cola or Neurotoxin no longer breaks time and space.
/:cl:

Since the dizziness update it didn't even take one full glass of these to make your screen shake so bad you could see the escape dock while standing in front of the bridge on box, causing your client to stutter every time.

I left the value a bit higher on neurotoxin since it's more of a stun poison anyway. Hardly noticeable difference, it just lasts a bit longer in smaller quantities.

The screen shake effect could probably use a cap (or it's way off if it already has one).