### PR TITLE
Provides a link to round specific logs/stats on statbus when the round reboots.

### DIFF
--- a/code/controllers/configuration/entries/general.dm
+++ b/code/controllers/configuration/entries/general.dm
@@ -177,6 +177,10 @@
 /datum/config_entry/string/githuburl
 	config_entry_value = "https://www.github.com/tgstation/-tg-station"
 
+/datum/config_entry/string/roundstatsurl
+
+/datum/config_entry/string/gamelogurl
+
 /datum/config_entry/number/githubrepoid
 	config_entry_value = null
 	min_val = 0

--- a/code/controllers/subsystem/ticker.dm
+++ b/code/controllers/subsystem/ticker.dm
@@ -612,6 +612,13 @@ SUBSYSTEM_DEF(ticker)
 	if(end_string)
 		end_state = end_string
 
+	var/statspage = CONFIG_GET(string/roundstatsurl)
+	var/gamelogloc = CONFIG_GET(string/gamelogurl)
+	if(statspage)
+		to_chat(world, "<span class='info'>Round statistics and logs can be viewed at [statspage][GLOB.round_id]</span>")
+	else if(gamelogloc)
+		to_chat(world, "<span class='info'>Round logs can be located at [gamelogloc]</span>")
+
 	log_game("<span class='boldannounce'>Rebooting World. [reason]</span>")
 
 	world.Reboot()

--- a/code/controllers/subsystem/ticker.dm
+++ b/code/controllers/subsystem/ticker.dm
@@ -615,9 +615,9 @@ SUBSYSTEM_DEF(ticker)
 	var/statspage = CONFIG_GET(string/roundstatsurl)
 	var/gamelogloc = CONFIG_GET(string/gamelogurl)
 	if(statspage)
-		to_chat(world, "<span class='info'>Round statistics and logs can be viewed at [statspage][GLOB.round_id]</span>")
+		to_chat(world, "<span class='info'>Round statistics and logs can be viewed <a href=\"[statspage][GLOB.round_id]\">at this website!</a></span>")
 	else if(gamelogloc)
-		to_chat(world, "<span class='info'>Round logs can be located at [gamelogloc]</span>")
+		to_chat(world, "<span class='info'>Round logs can be located <a href=\"[gamelogloc]\">at this website!</a></span>")
 
 	log_game("<span class='boldannounce'>Rebooting World. [reason]</span>")
 

--- a/config/config.txt
+++ b/config/config.txt
@@ -220,13 +220,15 @@ CHECK_RANDOMIZER
 # GITHUBURL https://www.github.com/tgstation/tgstation
 
 ## Round specific stats address
-## Link to round specific logs parsed IE statbus. RoundID is filled in automatically by ticker/Reboot()
+## Link to round specific parsed logs; IE statbus. It is appended with the RoundID automatically by ticker/Reboot()
 ## This will take priority over the game logs address during reboot.
-# ROUNDSTATSURL https://atlantaned.space/statbus/round.php?round=
+## Example: https://atlantaned.space/statbus/round.php?round=
+# ROUNDSTATSURL
 
 ## Game Logs address
-## Incase you don't have a fancy parsing system, but still want players to be able to find where you keep logs.
-# GAMELOGURL https://tgstation13.org/parsed-logs/basil/data/logs/
+## Incase you don't have a fancy parsing system, but still want players to be able to find where you keep your server's logs.
+## Example: https://tgstation13.org/parsed-logs/basil/data/logs/
+# GAMELOGURL
 
 ## Github repo id
 ##This can be found by going to https://api.github.com/users/<user name here>/repos

--- a/config/config.txt
+++ b/config/config.txt
@@ -219,6 +219,15 @@ CHECK_RANDOMIZER
 ## Github address
 # GITHUBURL https://www.github.com/tgstation/tgstation
 
+## Round specific stats address
+## Link to round specific logs parsed IE statbus. RoundID is filled in automatically by ticker/Reboot()
+## This will take priority over the game logs address during reboot.
+# ROUNDSTATSURL https://atlantaned.space/statbus/round.php?round=
+
+## Game Logs address
+## Incase you don't have a fancy parsing system, but still want players to be able to find where you keep logs.
+# GAMELOGURL https://tgstation13.org/parsed-logs/basil/data/logs/
+
 ## Github repo id
 ##This can be found by going to https://api.github.com/users/<user name here>/repos
 ##Or https://api.github.com/orgs/<org name here>/repos if the repo owner is an organization


### PR DESCRIPTION
or if a downstream doesn't have a fancy statbus system, they can insert a URL link to their own log location so folks can find them. 

Closes #37873

@MrStonedOne
