### PR TITLE
Adds OOC verb to show the last round end report you've viewed

### DIFF
--- a/code/__HELPERS/roundend.dm
+++ b/code/__HELPERS/roundend.dm
@@ -290,19 +290,25 @@
 				parts += "[GLOB.TAB]<i>Nobody died this shift!</i>"
 	return parts.Join("<br>")
 
-/datum/controller/subsystem/ticker/proc/show_roundend_report(client/C,common_report, popcount)
-	var/list/report_parts = list()
+/client/proc/roundend_report_file()
+	return "data/roundend_reports/[ckey].html"
 
-	report_parts += personal_report(C, popcount)
-	report_parts += common_report
-
+/datum/controller/subsystem/ticker/proc/show_roundend_report(client/C, previous = FALSE)
 	var/datum/browser/roundend_report = new(C, "roundend")
 	roundend_report.width = 800
 	roundend_report.height = 600
-	roundend_report.set_content(report_parts.Join())
+	var/content
+	var/filename = C.roundend_report_file()
+	if(!previous)
+		var/list/report_parts = personal_report(C) + GLOB.common_report
+		content = report_parts.Join()
+		C.verbs -= /client/proc/show_previous_roundend_report
+		text2file(content, filename)
+	else
+		content = file2text(filename)
+	roundend_report.set_content(content)
 	roundend_report.stylesheets = list()
-	roundend_report.add_stylesheet("roundend",'html/browser/roundend.css')
-
+	roundend_report.add_stylesheet("roundend", 'html/browser/roundend.css')
 	roundend_report.open(0)
 
 /datum/controller/subsystem/ticker/proc/personal_report(client/C, popcount)
@@ -327,8 +333,6 @@
 	else
 		parts += "<div class='panel stationborder'>"
 	parts += "<br>"
-	if(!GLOB.survivor_report)
-		GLOB.survivor_report = survivor_report(popcount)
 	parts += GLOB.survivor_report
 	parts += "</div>"
 
@@ -336,8 +340,9 @@
 
 /datum/controller/subsystem/ticker/proc/display_report(popcount)
 	GLOB.common_report = build_roundend_report()
+	GLOB.survivor_report = survivor_report(popcount)
 	for(var/client/C in GLOB.clients)
-		show_roundend_report(C,GLOB.common_report, popcount)
+		show_roundend_report(C, FALSE)
 		give_show_report_button(C)
 		CHECK_TICK
 
@@ -458,7 +463,7 @@
 
 /datum/action/report/Trigger()
 	if(owner && GLOB.common_report && SSticker.current_state == GAME_STATE_FINISHED)
-		SSticker.show_roundend_report(owner.client,GLOB.common_report)
+		SSticker.show_roundend_report(owner.client, FALSE)
 
 /datum/action/report/IsAvailable()
 	return 1

--- a/code/__HELPERS/roundend.dm
+++ b/code/__HELPERS/roundend.dm
@@ -300,9 +300,10 @@
 	var/content
 	var/filename = C.roundend_report_file()
 	if(!previous)
-		var/list/report_parts = personal_report(C) + GLOB.common_report
+		var/list/report_parts = list(personal_report(C), GLOB.common_report)
 		content = report_parts.Join()
 		C.verbs -= /client/proc/show_previous_roundend_report
+		fdel(filename)
 		text2file(content, filename)
 	else
 		content = file2text(filename)

--- a/code/modules/client/client_procs.dm
+++ b/code/modules/client/client_procs.dm
@@ -204,6 +204,9 @@ GLOBAL_LIST_EMPTY(external_rsc_urls)
 	prefs.last_id = computer_id			//these are gonna be used for banning
 	fps = prefs.clientfps
 
+	if(fexists(roundend_report_file()))
+		verbs += /client/proc/show_previous_roundend_report
+
 	log_access("Login: [key_name(src)] from [address ? address : "localhost"]-[computer_id] || BYOND v[byond_version]")
 	var/alert_mob_dupe_login = FALSE
 	if(CONFIG_GET(flag/log_access))

--- a/code/modules/client/verbs/ooc.dm
+++ b/code/modules/client/verbs/ooc.dm
@@ -291,3 +291,10 @@ GLOBAL_VAR_INIT(normal_ooc_colour, OOC_COLOR)
 		to_chat(src, "You can't ignore yourself.")
 		return
 	ignore_key(selection)
+
+/client/proc/show_previous_roundend_report()
+	set name = "Your last round"
+	set category = "OOC"
+	set desc = "View the last round end report you've seen"
+
+	SSticker.show_roundend_report(src, TRUE)

--- a/code/modules/client/verbs/ooc.dm
+++ b/code/modules/client/verbs/ooc.dm
@@ -293,7 +293,7 @@ GLOBAL_VAR_INIT(normal_ooc_colour, OOC_COLOR)
 	ignore_key(selection)
 
 /client/proc/show_previous_roundend_report()
-	set name = "Your last round"
+	set name = "Your Last Round"
 	set category = "OOC"
 	set desc = "View the last round end report you've seen"
 


### PR DESCRIPTION
Works just by storing the html in a data file. Too lazy to do it any other way

:cl:
add: You can now view your last round end report window with the "Your last round" verb in the OOC tab
/:cl:

Closes #37873