### PR TITLE
Adds spell check for VR

### DIFF
--- a/code/modules/spells/spell.dm
+++ b/code/modules/spells/spell.dm
@@ -145,6 +145,8 @@ GLOBAL_LIST_INIT(spells, typesof(/obj/effect/proc_holder/spell)) //needed for th
 	var/smoke_amt = 0 //cropped at 10
 
 	var/centcom_cancast = 1 //Whether or not the spell should be allowed on z2
+	var/vr_cancast = TRUE 
+	var/static/list/vr_areas = list()
 
 	action_icon = 'icons/mob/actions/actions_spells.dmi'
 	action_icon_state = "spell_default"
@@ -161,7 +163,8 @@ GLOBAL_LIST_INIT(spells, typesof(/obj/effect/proc_holder/spell)) //needed for th
 			return 0
 
 	var/turf/T = get_turf(user)
-	if(is_centcom_level(T.z) && !centcom_cancast) //Certain spells are not allowed on the centcom zlevel
+	var/area/A = get_area(user)
+	if((is_centcom_level(T.z) && !centcom_cancast) || (is_type_in_typecache(A, /area/awaymission/vr) && !vr_cancast)) //Certain spells are not allowed on the centcom zlevel
 		to_chat(user, "<span class='notice'>You can't cast this spell here.</span>")
 		return 0
 
@@ -262,7 +265,7 @@ GLOBAL_LIST_INIT(spells, typesof(/obj/effect/proc_holder/spell)) //needed for th
 /obj/effect/proc_holder/spell/Initialize()
 	. = ..()
 	START_PROCESSING(SSfastprocess, src)
-
+	vr_areas = typecacheof(/area/awaymission/vr)
 	still_recharging_msg = "<span class='notice'>[name] is still recharging.</span>"
 	charge_counter = charge_max
 

--- a/code/modules/spells/spell_types/area_teleport.dm
+++ b/code/modules/spells/spell_types/area_teleport.dm
@@ -2,6 +2,7 @@
 	name = "Area teleport"
 	desc = "This spell teleports you to a type of area of your selection."
 	nonabstract_req = 1
+	vr_cancast = FALSE
 
 	var/randomise_selection = 0 //if it lets the usr choose the teleport loc or picks it from the list
 	var/invocation_area = 1 //if the invocation appends the selected area

--- a/code/modules/spells/spell_types/lichdom.dm
+++ b/code/modules/spells/spell_types/lichdom.dm
@@ -16,6 +16,7 @@
 	level_max = 0 //cannot be improved
 	cooldown_min = 10
 	include_user = 1
+	vr_cancast = FALSE 	
 
 	action_icon = 'icons/mob/actions/actions_spells.dmi'
 	action_icon_state = "skeleton"

--- a/code/modules/spells/spell_types/summonitem.dm
+++ b/code/modules/spells/spell_types/summonitem.dm
@@ -10,6 +10,7 @@
 	level_max = 0 //cannot be improved
 	cooldown_min = 100
 	include_user = 1
+	vr_cancast = FALSE
 
 	var/obj/marked_item
 


### PR DESCRIPTION
[Changelogs]: # (Your PR should contain a detailed changelog of notable changes, titled and categorized appropriately. This includes, new features, sprites, sounds, balance changes, admin tools, map edits, removals, big refactors, config changes, hosting changes and important fixes. An example changelog has been provided below for you to edit. If you need additional help, read https://github.com/tgstation/tgstation/wiki/Changelogs)

:cl: Dax Dupont
fix: Prevents certain spells from being used in VR.
/:cl:

[why]: Whoops apparently things like summon item aren't blacklisted from away missions. Minds get transfered, so that includes spells sadly. While it's cool and very matrix-y, I probably want to prevent people to summon items and lich shit.

Since VR is gonna have several maps, might as well put this in.