### PR TITLE
Removes the ability for RD's to steal hand teles

### DIFF
--- a/code/game/gamemodes/objective_items.dm
+++ b/code/game/gamemodes/objective_items.dm
@@ -41,7 +41,7 @@
 	name = "a hand teleporter."
 	targetitem = /obj/item/hand_tele
 	difficulty = 5
-	excludefromjob = list("Captain")
+	excludefromjob = list("Captain", "Research Director")
 
 /datum/objective_item/steal/jetpack
 	name = "the Captain's jetpack."


### PR DESCRIPTION
:cl: Nichlas0010
tweak: Reseach Director Traitors can no longer receive an objective to steal the Hand Teleporter
/:cl:

The RD has access to the teleporter in which a hand teleporter lies, this objective **literally** consists of walking in and taking it.
