### PR TITLE
DV Cleanup part 20

### DIFF
--- a/_maps/RandomRuins/LavaRuins/lavaland_surface_animal_hospital.dmm
+++ b/_maps/RandomRuins/LavaRuins/lavaland_surface_animal_hospital.dmm
@@ -211,9 +211,7 @@
 	},
 /area/ruin/powered/animal_hospital)
 "aP" = (
-/turf/open/floor/plasteel/blue/side{
-	dir = 0
-	},
+/turf/open/floor/plasteel/blue/side,
 /area/ruin/powered/animal_hospital)
 "aQ" = (
 /turf/open/floor/plasteel/blue/corner{
@@ -721,9 +719,7 @@
 /area/ruin/powered/animal_hospital)
 "cw" = (
 /obj/machinery/light/small,
-/turf/open/floor/plasteel/blue/side{
-	dir = 0
-	},
+/turf/open/floor/plasteel/blue/side,
 /area/ruin/powered/animal_hospital)
 "cx" = (
 /obj/machinery/light{
@@ -782,9 +778,7 @@
 /area/ruin/powered/animal_hospital)
 "cH" = (
 /mob/living/simple_animal/bot/cleanbot,
-/turf/open/floor/plasteel/blue/side{
-	dir = 0
-	},
+/turf/open/floor/plasteel/blue/side,
 /area/ruin/powered/animal_hospital)
 "cI" = (
 /obj/structure/table/glass,

--- a/_maps/RandomRuins/LavaRuins/lavaland_surface_pizzaparty.dmm
+++ b/_maps/RandomRuins/LavaRuins/lavaland_surface_pizzaparty.dmm
@@ -195,7 +195,6 @@
 /area/ruin/unpowered)
 "C" = (
 /obj/structure/chair/wood/wings{
-	icon_state = "wooden_chair_wings";
 	dir = 4
 	},
 /obj/effect/decal/cleanable/dirt,
@@ -253,7 +252,6 @@
 /area/ruin/unpowered)
 "K" = (
 /obj/structure/chair/wood/wings{
-	icon_state = "wooden_chair_wings";
 	dir = 1
 	},
 /obj/effect/decal/remains/human,

--- a/_maps/RandomRuins/SpaceRuins/DJstation.dmm
+++ b/_maps/RandomRuins/SpaceRuins/DJstation.dmm
@@ -74,7 +74,6 @@
 	icon_state = "0-4"
 	},
 /obj/machinery/power/apc{
-	dir = 0;
 	name = "Worn-out APC";
 	pixel_y = -24
 	},

--- a/_maps/RandomRuins/SpaceRuins/TheDerelict.dmm
+++ b/_maps/RandomRuins/SpaceRuins/TheDerelict.dmm
@@ -848,7 +848,6 @@
 "cQ" = (
 /obj/structure/cable,
 /obj/machinery/power/apc{
-	dir = 0;
 	name = "Worn-out APC";
 	pixel_y = -24
 	},
@@ -1560,7 +1559,6 @@
 "fg" = (
 /obj/structure/table,
 /obj/machinery/power/apc{
-	dir = 0;
 	name = "Worn-out APC";
 	pixel_y = -24
 	},
@@ -2001,7 +1999,6 @@
 "gB" = (
 /obj/structure/cable,
 /obj/machinery/power/apc{
-	dir = 0;
 	name = "Worn-out APC";
 	pixel_y = -24
 	},
@@ -2855,7 +2852,6 @@
 /area/ruin/space/derelict/medical/chapel)
 "jz" = (
 /obj/machinery/power/apc{
-	dir = 0;
 	name = "Worn-out APC";
 	pixel_y = -24
 	},
@@ -3130,7 +3126,6 @@
 "kr" = (
 /obj/structure/cable,
 /obj/machinery/power/apc{
-	dir = 0;
 	name = "Worn-out APC";
 	pixel_y = -24
 	},
@@ -3314,7 +3309,6 @@
 "la" = (
 /obj/structure/cable,
 /obj/machinery/power/apc{
-	dir = 0;
 	name = "Worn-out APC";
 	pixel_y = -24
 	},

--- a/_maps/RandomRuins/SpaceRuins/oldstation.dmm
+++ b/_maps/RandomRuins/SpaceRuins/oldstation.dmm
@@ -1218,10 +1218,7 @@
 /obj/structure/cable{
 	icon_state = "0-8"
 	},
-/turf/open/floor/plating/airless{
-	tag = "icon-floor";
-	icon_state = "floor"
-	},
+/turf/open/floor/plating/airless,
 /area/template_noop)
 "dM" = (
 /obj/structure/table,
@@ -1542,19 +1539,13 @@
 	icon_state = "0-4"
 	},
 /obj/machinery/power/solar,
-/turf/open/floor/plating/airless{
-	tag = "icon-floor";
-	icon_state = "floor"
-	},
+/turf/open/floor/plating/airless,
 /area/template_noop)
 "eJ" = (
 /obj/structure/cable{
 	icon_state = "0-8"
 	},
-/turf/open/floor/plating/airless{
-	tag = "icon-floor";
-	icon_state = "floor"
-	},
+/turf/open/floor/plating/airless,
 /area/template_noop)
 "eK" = (
 /obj/effect/decal/cleanable/dirt,
@@ -2823,8 +2814,6 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/orange/side{
-	tag = "icon-orange (NORTHWEST)";
-	icon_state = "orange";
 	dir = 9
 	},
 /area/ruin/space/has_grav/ancientstation/rnd)
@@ -2838,8 +2827,6 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/orange/side{
-	tag = "icon-orange (NORTH)";
-	icon_state = "orange";
 	dir = 1
 	},
 /area/ruin/space/has_grav/ancientstation/rnd)
@@ -2853,8 +2840,6 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/orange/side{
-	tag = "icon-orange (NORTHEAST)";
-	icon_state = "orange";
 	dir = 5
 	},
 /area/ruin/space/has_grav/ancientstation/rnd)
@@ -2886,10 +2871,7 @@
 /obj/structure/cable{
 	icon_state = "0-4"
 	},
-/turf/open/floor/plating/airless{
-	tag = "icon-floor";
-	icon_state = "floor"
-	},
+/turf/open/floor/plating/airless,
 /area/template_noop)
 "hN" = (
 /obj/structure/lattice/catwalk,
@@ -3002,8 +2984,6 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/orange/side{
-	tag = "icon-orange (EAST)";
-	icon_state = "orange";
 	dir = 4
 	},
 /area/ruin/space/has_grav/ancientstation/rnd)
@@ -3129,8 +3109,6 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel/orange/side{
-	tag = "icon-orange (EAST)";
-	icon_state = "orange";
 	dir = 4
 	},
 /area/ruin/space/has_grav/ancientstation/rnd)
@@ -3181,8 +3159,6 @@
 	pixel_x = 24
 	},
 /turf/open/floor/plasteel/orange/side{
-	tag = "icon-orange (EAST)";
-	icon_state = "orange";
 	dir = 4
 	},
 /area/ruin/space/has_grav/ancientstation/rnd)
@@ -3297,8 +3273,6 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/orange/side{
-	tag = "icon-orange (EAST)";
-	icon_state = "orange";
 	dir = 4
 	},
 /area/ruin/space/has_grav/ancientstation/rnd)
@@ -3387,8 +3361,6 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/orange/side{
-	tag = "icon-orange (SOUTHWEST)";
-	icon_state = "orange";
 	dir = 10
 	},
 /area/ruin/space/has_grav/ancientstation/rnd)
@@ -3413,8 +3385,6 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/orange/side{
-	tag = "icon-orange (SOUTHEAST)";
-	icon_state = "orange";
 	dir = 6
 	},
 /area/ruin/space/has_grav/ancientstation/rnd)
@@ -4338,10 +4308,7 @@
 /turf/open/floor/plating,
 /area/ruin/space/has_grav/ancientstation/hivebot)
 "lz" = (
-/turf/open/floor/plating/airless{
-	tag = "icon-floor";
-	icon_state = "floor"
-	},
+/turf/open/floor/plating/airless,
 /area/template_noop)
 "lL" = (
 /obj/effect/decal/cleanable/dirt,
@@ -4351,8 +4318,6 @@
 "lM" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/orange/side{
-	tag = "icon-orange (WEST)";
-	icon_state = "orange";
 	dir = 8
 	},
 /area/ruin/space/has_grav/ancientstation/rnd)
@@ -4360,8 +4325,6 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plasteel/orange/corner{
-	tag = "icon-orangecorner (EAST)";
-	icon_state = "orangecorner";
 	dir = 4
 	},
 /area/ruin/space/has_grav/ancientstation/rnd)

--- a/_maps/RandomRuins/SpaceRuins/oldteleporter.dmm
+++ b/_maps/RandomRuins/SpaceRuins/oldteleporter.dmm
@@ -63,7 +63,6 @@
 /area/ruin/space/oldteleporter)
 "n" = (
 /obj/machinery/power/apc{
-	dir = 0;
 	name = "Worn-out APC";
 	pixel_y = -24
 	},

--- a/_maps/RandomRuins/SpaceRuins/turretedoutpost.dmm
+++ b/_maps/RandomRuins/SpaceRuins/turretedoutpost.dmm
@@ -76,7 +76,6 @@
 /area/ruin/space/has_grav/turretedoutpost)
 "ar" = (
 /obj/machinery/power/apc{
-	dir = 0;
 	name = "Worn-out APC";
 	pixel_y = -24
 	},

--- a/_maps/RandomZLevels/challenge.dmm
+++ b/_maps/RandomZLevels/challenge.dmm
@@ -37,7 +37,6 @@
 "ai" = (
 /obj/item/flashlight{
 	icon_state = "flashlight-on";
-	item_state = "flashlight";
 	on = 1
 	},
 /turf/open/floor/plasteel/airless,
@@ -656,7 +655,6 @@
 	dir = 1
 	},
 /obj/item/radio/intercom{
-	dir = 0;
 	name = "Station Intercom (General)";
 	pixel_y = 28
 	},
@@ -681,7 +679,6 @@
 /area/awaymission/challenge/end)
 "cg" = (
 /obj/item/radio/intercom{
-	dir = 0;
 	name = "Station Intercom (General)";
 	pixel_x = -27
 	},

--- a/_maps/RandomZLevels/moonoutpost19.dmm
+++ b/_maps/RandomZLevels/moonoutpost19.dmm
@@ -2707,12 +2707,10 @@
 /turf/open/floor/engine,
 /area/awaymission/moonoutpost19/research)
 "fJ" = (
-/obj/machinery/atmospherics/components/unary/outlet_injector{
+/obj/machinery/atmospherics/components/unary/outlet_injector/on{
 	desc = "Has a valve and pump attached to it. This one has been applied with an acid-proof coating.";
 	dir = 8;
-	icon_state = "on";
-	name = "Acid-Proof Air Injector";
-	on = 1
+	name = "Acid-Proof Air Injector"
 	},
 /obj/structure/alien/weeds,
 /turf/open/floor/engine,
@@ -3973,7 +3971,6 @@
 /area/awaymission/moonoutpost19/research)
 "ie" = (
 /obj/machinery/door/airlock/medical{
-	id_tag = "";
 	name = "Research Division";
 	req_access_txt = "201"
 	},
@@ -5348,7 +5345,6 @@
 "kW" = (
 /obj/structure/closet/emcloset,
 /turf/open/floor/plasteel/blue/side{
-	dir = 0;
 	heat_capacity = 1e+006
 	},
 /area/awaymission/moonoutpost19/arrivals)
@@ -5360,7 +5356,6 @@
 	},
 /obj/item/multitool,
 /turf/open/floor/plasteel/blue/side{
-	dir = 0;
 	heat_capacity = 1e+006
 	},
 /area/awaymission/moonoutpost19/arrivals)
@@ -5372,14 +5367,12 @@
 	maxcharge = 15000
 	},
 /turf/open/floor/plasteel/blue/side{
-	dir = 0;
 	heat_capacity = 1e+006
 	},
 /area/awaymission/moonoutpost19/arrivals)
 "kZ" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/blue/side{
-	dir = 0;
 	heat_capacity = 1e+006
 	},
 /area/awaymission/moonoutpost19/arrivals)
@@ -6776,7 +6769,6 @@
 /area/awaymission/moonoutpost19/arrivals)
 "Mm" = (
 /obj/machinery/door/airlock/medical{
-	id_tag = "";
 	name = "Research Division";
 	req_access_txt = "201"
 	},

--- a/_maps/RandomZLevels/research.dmm
+++ b/_maps/RandomZLevels/research.dmm
@@ -3106,19 +3106,16 @@
 "jr" = (
 /obj/structure/sign/directions/security{
 	dir = 1;
-	icon_state = "direction_sec";
 	pixel_x = 32;
 	pixel_y = 40
 	},
 /obj/structure/sign/directions/engineering{
 	dir = 1;
-	icon_state = "direction_eng";
 	pixel_x = 32;
 	pixel_y = 33
 	},
 /obj/structure/sign/directions/science{
 	dir = 1;
-	icon_state = "direction_sci";
 	pixel_x = 32;
 	pixel_y = 26
 	},

--- a/_maps/RandomZLevels/snowdin.dmm
+++ b/_maps/RandomZLevels/snowdin.dmm
@@ -10881,7 +10881,6 @@
 /area/awaymission/snowdin/cave)
 "BO" = (
 /obj/effect/turf_decal/stripes/end{
-	icon_state = "warn_end";
 	dir = 1
 	},
 /turf/open/floor/plating/snowed/cavern,
@@ -10895,7 +10894,6 @@
 /area/awaymission/snowdin/cave/cavern)
 "BQ" = (
 /obj/effect/turf_decal/stripes/end{
-	icon_state = "warn_end";
 	dir = 8
 	},
 /turf/open/floor/plating/snowed/cavern,

--- a/_maps/RandomZLevels/spacebattle.dmm
+++ b/_maps/RandomZLevels/spacebattle.dmm
@@ -1388,16 +1388,12 @@
 	},
 /area/awaymission/spacebattle/cruiser)
 "fJ" = (
-/turf/open/floor/plasteel/blue/side{
-	dir = 0
-	},
+/turf/open/floor/plasteel/blue/side,
 /area/awaymission/spacebattle/cruiser)
 "fK" = (
 /obj/item/ammo_casing/c10mm,
 /obj/item/ammo_casing/c10mm,
-/turf/open/floor/plasteel/blue/side{
-	dir = 0
-	},
+/turf/open/floor/plasteel/blue/side,
 /area/awaymission/spacebattle/cruiser)
 "fL" = (
 /obj/item/stack/sheet/metal,
@@ -1407,9 +1403,7 @@
 /area/awaymission/spacebattle/cruiser)
 "fM" = (
 /obj/item/ammo_casing/shotgun,
-/turf/open/floor/plasteel/blue/side{
-	dir = 0
-	},
+/turf/open/floor/plasteel/blue/side,
 /area/awaymission/spacebattle/cruiser)
 "fN" = (
 /obj/effect/mob_spawn/human/syndicatesoldier,
@@ -1417,9 +1411,7 @@
 /obj/item/ammo_casing/c10mm,
 /obj/item/ammo_casing/c10mm,
 /obj/effect/decal/cleanable/blood,
-/turf/open/floor/plasteel/blue/side{
-	dir = 0
-	},
+/turf/open/floor/plasteel/blue/side,
 /area/awaymission/spacebattle/cruiser)
 "fO" = (
 /obj/item/ammo_casing/c10mm,
@@ -1773,9 +1765,7 @@
 /area/awaymission/spacebattle/cruiser)
 "gZ" = (
 /obj/structure/table/reinforced,
-/turf/open/floor/plasteel/blue/side{
-	dir = 0
-	},
+/turf/open/floor/plasteel/blue/side,
 /area/awaymission/spacebattle/cruiser)
 "ha" = (
 /obj/effect/spawner/structure/window/hollow/reinforced/end,
@@ -2471,9 +2461,7 @@
 /obj/item/ammo_casing/c10mm,
 /obj/item/ammo_casing/c10mm,
 /obj/item/stack/sheet/metal,
-/turf/open/floor/plasteel/blue/side{
-	dir = 0
-	},
+/turf/open/floor/plasteel/blue/side,
 /area/awaymission/spacebattle/cruiser)
 "jP" = (
 /obj/structure/closet/crate/internals,

--- a/_maps/RandomZLevels/undergroundoutpost45.dmm
+++ b/_maps/RandomZLevels/undergroundoutpost45.dmm
@@ -458,8 +458,7 @@
 /area/awaymission/undergroundoutpost45/central)
 "bm" = (
 /obj/structure/chair/comfy/beige{
-	dir = 1;
-	icon_state = "comfychair"
+	dir = 1
 	},
 /turf/open/floor/plasteel/grimy{
 	heat_capacity = 1e+006
@@ -6238,10 +6237,9 @@
 /area/awaymission/undergroundoutpost45/crew_quarters)
 "mZ" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/components/binary/pump{
+/obj/machinery/atmospherics/components/binary/pump/on{
 	dir = 8;
-	name = "Air to Distro";
-	on = 1
+	name = "Air to Distro"
 	},
 /turf/open/floor/plasteel{
 	heat_capacity = 1e+006
@@ -8749,10 +8747,9 @@
 /obj/machinery/atmospherics/pipe/simple/cyan/visible{
 	dir = 4
 	},
-/obj/machinery/atmospherics/components/binary/pump{
+/obj/machinery/atmospherics/components/binary/pump/on{
 	dir = 1;
-	name = "Mix to Exterior";
-	on = 1
+	name = "Mix to Exterior"
 	},
 /turf/open/floor/plasteel{
 	heat_capacity = 1e+006
@@ -9649,10 +9646,9 @@
 	},
 /area/awaymission/undergroundoutpost45/engineering)
 "sU" = (
-/obj/machinery/atmospherics/components/binary/pump{
+/obj/machinery/atmospherics/components/binary/pump/on{
 	dir = 4;
-	name = "Waste In";
-	on = 1
+	name = "Waste In"
 	},
 /turf/open/floor/plasteel/floorgrime{
 	dir = 8;
@@ -9688,10 +9684,8 @@
 	},
 /area/awaymission/undergroundoutpost45/engineering)
 "sY" = (
-/obj/machinery/atmospherics/components/binary/pump{
-	dir = 0;
-	name = "Mix to Filter";
-	on = 1
+/obj/machinery/atmospherics/components/binary/pump/on{
+	name = "Mix to Filter"
 	},
 /turf/open/floor/plasteel{
 	heat_capacity = 1e+006
@@ -10043,20 +10037,18 @@
 	},
 /area/awaymission/undergroundoutpost45/engineering)
 "tH" = (
-/obj/machinery/atmospherics/components/binary/pump{
+/obj/machinery/atmospherics/components/binary/pump/on{
 	dir = 1;
-	name = "N2 Outlet Pump";
-	on = 1
+	name = "N2 Outlet Pump"
 	},
 /turf/open/floor/plasteel{
 	heat_capacity = 1e+006
 	},
 /area/awaymission/undergroundoutpost45/engineering)
 "tI" = (
-/obj/machinery/atmospherics/components/binary/pump{
+/obj/machinery/atmospherics/components/binary/pump/on{
 	dir = 1;
-	name = "O2 Outlet Pump";
-	on = 1
+	name = "O2 Outlet Pump"
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel{
@@ -10064,10 +10056,9 @@
 	},
 /area/awaymission/undergroundoutpost45/engineering)
 "tJ" = (
-/obj/machinery/atmospherics/components/binary/pump{
+/obj/machinery/atmospherics/components/binary/pump/on{
 	dir = 1;
-	name = "Unfiltered to Mix";
-	on = 1
+	name = "Unfiltered to Mix"
 	},
 /obj/structure/sign/warning/nosmoking{
 	pixel_x = 32
@@ -10336,20 +10327,17 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/components/binary/pump{
+/obj/machinery/atmospherics/components/binary/pump/on{
 	dir = 1;
-	name = "External to Filter";
-	on = 1
+	name = "External to Filter"
 	},
 /turf/open/floor/plasteel{
 	heat_capacity = 1e+006
 	},
 /area/awaymission/undergroundoutpost45/engineering)
 "uk" = (
-/obj/machinery/atmospherics/components/binary/pump{
-	dir = 0;
-	name = "Air to External";
-	on = 1
+/obj/machinery/atmospherics/components/binary/pump/on{
+	name = "Air to External"
 	},
 /turf/open/floor/plasteel{
 	heat_capacity = 1e+006

--- a/_maps/RandomZLevels/wildwest.dmm
+++ b/_maps/RandomZLevels/wildwest.dmm
@@ -1076,8 +1076,7 @@
 /area/awaymission/wildwest/mines)
 "dO" = (
 /obj/structure/chair/comfy/beige{
-	dir = 1;
-	icon_state = "comfychair"
+	dir = 1
 	},
 /turf/open/floor/carpet,
 /area/awaymission/wildwest/mines)

--- a/_maps/map_files/BoxStation/BoxStation.dmm
+++ b/_maps/map_files/BoxStation/BoxStation.dmm
@@ -3008,9 +3008,7 @@
 	freq = 1400;
 	location = "Security"
 	},
-/obj/structure/plasticflaps{
-	opacity = 1
-	},
+/obj/structure/plasticflaps/opaque,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
@@ -13535,9 +13533,7 @@
 	freq = 1400;
 	location = "Bar"
 	},
-/obj/structure/plasticflaps{
-	opacity = 1
-	},
+/obj/structure/plasticflaps/opaque,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
@@ -14040,19 +14036,16 @@
 "aJt" = (
 /obj/structure/sign/directions/security{
 	dir = 1;
-	icon_state = "direction_sec";
 	pixel_x = 32;
 	pixel_y = 40
 	},
 /obj/structure/sign/directions/medical{
 	dir = 4;
-	icon_state = "direction_med";
 	pixel_x = 32;
 	pixel_y = 32
 	},
 /obj/structure/sign/directions/evac{
 	dir = 4;
-	icon_state = "direction_evac";
 	pixel_x = 32;
 	pixel_y = 24
 	},
@@ -14178,9 +14171,7 @@
 	freq = 1400;
 	location = "Kitchen"
 	},
-/obj/structure/plasticflaps{
-	opacity = 1
-	},
+/obj/structure/plasticflaps/opaque,
 /obj/effect/turf_decal/bot{
 	dir = 2
 	},
@@ -14194,9 +14185,7 @@
 	freq = 1400;
 	location = "Hydroponics"
 	},
-/obj/structure/plasticflaps{
-	opacity = 1
-	},
+/obj/structure/plasticflaps/opaque,
 /obj/effect/turf_decal/bot{
 	dir = 2
 	},
@@ -15927,13 +15916,11 @@
 "aOz" = (
 /obj/structure/sign/directions/security{
 	dir = 4;
-	icon_state = "direction_sec";
 	pixel_x = 32;
 	pixel_y = -24
 	},
 /obj/structure/sign/directions/evac{
 	dir = 4;
-	icon_state = "direction_evac";
 	pixel_x = 32;
 	pixel_y = -32
 	},
@@ -16109,8 +16096,7 @@
 /area/hydroponics)
 "aOY" = (
 /obj/structure/chair/comfy/beige{
-	dir = 1;
-	icon_state = "comfychair"
+	dir = 1
 	},
 /obj/effect/landmark/start/assistant,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -16125,8 +16111,7 @@
 /area/hydroponics)
 "aPa" = (
 /obj/structure/chair/comfy/beige{
-	dir = 1;
-	icon_state = "comfychair"
+	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plasteel/grimy,
@@ -16285,8 +16270,7 @@
 /area/crew_quarters/bar)
 "aPx" = (
 /obj/structure/chair/comfy/beige{
-	dir = 1;
-	icon_state = "comfychair"
+	dir = 1
 	},
 /turf/open/floor/plasteel/grimy,
 /area/hallway/secondary/entry)
@@ -16860,9 +16844,7 @@
 /area/bridge)
 "aRm" = (
 /obj/machinery/computer/communications,
-/turf/open/floor/plasteel/blue/side{
-	dir = 0
-	},
+/turf/open/floor/plasteel/blue/side,
 /area/bridge)
 "aRn" = (
 /obj/machinery/computer/shuttle/labor,
@@ -17183,7 +17165,6 @@
 "aSh" = (
 /obj/structure/closet/wardrobe/mixed,
 /obj/item/radio/intercom{
-	dir = 0;
 	name = "Station Intercom (General)";
 	pixel_x = -27
 	},
@@ -18884,9 +18865,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
-/turf/open/floor/plasteel/blue/side{
-	dir = 0
-	},
+/turf/open/floor/plasteel/blue/side,
 /area/bridge)
 "aWP" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -18902,9 +18881,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
-/turf/open/floor/plasteel/blue/side{
-	dir = 0
-	},
+/turf/open/floor/plasteel/blue/side,
 /area/bridge)
 "aWR" = (
 /obj/structure/fireaxecabinet{
@@ -18913,9 +18890,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
-/turf/open/floor/plasteel/blue/side{
-	dir = 0
-	},
+/turf/open/floor/plasteel/blue/side,
 /area/bridge)
 "aWS" = (
 /obj/structure/cable{
@@ -18924,9 +18899,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
-/turf/open/floor/plasteel/blue/side{
-	dir = 0
-	},
+/turf/open/floor/plasteel/blue/side,
 /area/bridge)
 "aWT" = (
 /obj/machinery/requests_console{
@@ -18940,17 +18913,13 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
-/turf/open/floor/plasteel/blue/side{
-	dir = 0
-	},
+/turf/open/floor/plasteel/blue/side,
 /area/bridge)
 "aWU" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
-/turf/open/floor/plasteel/blue/side{
-	dir = 0
-	},
+/turf/open/floor/plasteel/blue/side,
 /area/bridge)
 "aWV" = (
 /obj/machinery/turretid{
@@ -18965,9 +18934,7 @@
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
 	dir = 1
 	},
-/turf/open/floor/plasteel/blue/side{
-	dir = 0
-	},
+/turf/open/floor/plasteel/blue/side,
 /area/bridge)
 "aWW" = (
 /obj/machinery/power/apc/highcap/five_k{
@@ -18979,9 +18946,7 @@
 /obj/structure/cable,
 /obj/machinery/light,
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden,
-/turf/open/floor/plasteel/blue/side{
-	dir = 0
-	},
+/turf/open/floor/plasteel/blue/side,
 /area/bridge)
 "aWX" = (
 /obj/machinery/newscaster{
@@ -18990,9 +18955,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
-/turf/open/floor/plasteel/blue/side{
-	dir = 0
-	},
+/turf/open/floor/plasteel/blue/side,
 /area/bridge)
 "aWY" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -19523,9 +19486,7 @@
 /area/security/detectives_office)
 "aYk" = (
 /obj/machinery/light,
-/turf/open/floor/plasteel/blue/side{
-	dir = 0
-	},
+/turf/open/floor/plasteel/blue/side,
 /area/hallway/primary/central)
 "aYl" = (
 /turf/open/floor/plasteel/blue/corner,
@@ -19541,9 +19502,7 @@
 	c_tag = "Bridge West Entrance";
 	dir = 1
 	},
-/turf/open/floor/plasteel/blue/side{
-	dir = 0
-	},
+/turf/open/floor/plasteel/blue/side,
 /area/hallway/primary/central)
 "aYo" = (
 /obj/machinery/door/firedoor,
@@ -19562,27 +19521,21 @@
 "aYq" = (
 /obj/structure/closet/emcloset,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/turf/open/floor/plasteel/blue/side{
-	dir = 0
-	},
+/turf/open/floor/plasteel/blue/side,
 /area/bridge)
 "aYr" = (
 /obj/item/radio/intercom{
 	name = "Station Intercom (General)";
 	pixel_y = -29
 	},
-/turf/open/floor/plasteel/blue/side{
-	dir = 0
-	},
+/turf/open/floor/plasteel/blue/side,
 /area/bridge)
 "aYs" = (
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/turf/open/floor/plasteel/blue/side{
-	dir = 0
-	},
+/turf/open/floor/plasteel/blue/side,
 /area/bridge)
 "aYt" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -19669,9 +19622,7 @@
 	},
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/turf/open/floor/plasteel/blue/side{
-	dir = 0
-	},
+/turf/open/floor/plasteel/blue/side,
 /area/bridge)
 "aYE" = (
 /obj/machinery/door/firedoor,
@@ -19687,9 +19638,7 @@
 	pixel_y = -24
 	},
 /obj/structure/cable,
-/turf/open/floor/plasteel/blue/side{
-	dir = 0
-	},
+/turf/open/floor/plasteel/blue/side,
 /area/hallway/primary/central)
 "aYG" = (
 /obj/structure/disposalpipe/segment,
@@ -20994,13 +20943,11 @@
 "bcp" = (
 /obj/structure/sign/directions/evac{
 	dir = 4;
-	icon_state = "direction_evac";
 	pixel_x = 32;
 	pixel_y = 28
 	},
 /obj/structure/sign/directions/security{
 	dir = 1;
-	icon_state = "direction_sec";
 	pixel_x = 32;
 	pixel_y = 36
 	},
@@ -21774,13 +21721,11 @@
 "beq" = (
 /obj/structure/sign/directions/medical{
 	dir = 4;
-	icon_state = "direction_med";
 	pixel_x = 32;
 	pixel_y = -24
 	},
 /obj/structure/sign/directions/science{
 	dir = 4;
-	icon_state = "direction_sci";
 	pixel_x = 32;
 	pixel_y = -32
 	},
@@ -21801,15 +21746,11 @@
 /turf/open/floor/plasteel/blue/corner,
 /area/hallway/primary/starboard)
 "bet" = (
-/turf/open/floor/plasteel/blue/side{
-	dir = 0
-	},
+/turf/open/floor/plasteel/blue/side,
 /area/hallway/primary/starboard)
 "beu" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/turf/open/floor/plasteel/blue/side{
-	dir = 0
-	},
+/turf/open/floor/plasteel/blue/side,
 /area/hallway/primary/starboard)
 "bev" = (
 /obj/machinery/light,
@@ -23244,9 +23185,7 @@
 	freq = 1400;
 	location = "Bridge"
 	},
-/obj/structure/plasticflaps{
-	opacity = 1
-	},
+/obj/structure/plasticflaps/opaque,
 /obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel,
 /area/bridge/meeting_room)
@@ -25409,9 +25348,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 5
 	},
-/obj/structure/plasticflaps{
-	opacity = 1
-	},
+/obj/structure/plasticflaps/opaque,
 /turf/open/floor/plating,
 /area/science/lab)
 "bns" = (
@@ -29335,9 +29272,7 @@
 	freq = 1400;
 	location = "Medbay"
 	},
-/obj/structure/plasticflaps{
-	opacity = 1
-	},
+/obj/structure/plasticflaps/opaque,
 /obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel,
 /area/medical/medbay/central)
@@ -31448,13 +31383,11 @@
 	},
 /obj/structure/sign/directions/medical{
 	dir = 4;
-	icon_state = "direction_med";
 	pixel_x = -32;
 	pixel_y = -24
 	},
 /obj/structure/sign/directions/evac{
 	dir = 4;
-	icon_state = "direction_evac";
 	pixel_x = -32;
 	pixel_y = -32
 	},
@@ -32495,9 +32428,7 @@
 	freq = 1400;
 	location = "Janitor"
 	},
-/obj/structure/plasticflaps{
-	opacity = 1
-	},
+/obj/structure/plasticflaps/opaque,
 /obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel,
 /area/janitor)
@@ -37134,9 +37065,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/structure/plasticflaps{
-	opacity = 1
-	},
+/obj/structure/plasticflaps/opaque,
 /obj/machinery/navbeacon{
 	codes_txt = "delivery;dir=4";
 	dir = 4;
@@ -37228,7 +37157,6 @@
 /area/engine/atmos)
 "bPd" = (
 /obj/machinery/atmospherics/components/binary/pump/on{
-	dir = 0;
 	name = "Waste In"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -37242,7 +37170,6 @@
 /area/engine/atmos)
 "bPf" = (
 /obj/machinery/atmospherics/components/binary/pump{
-	dir = 0;
 	name = "Air to Mix"
 	},
 /obj/machinery/atmospherics/pipe/simple/yellow/visible{
@@ -39598,21 +39525,18 @@
 /area/engine/atmos)
 "bUO" = (
 /obj/machinery/atmospherics/components/binary/pump{
-	dir = 0;
 	name = "Mix to Port"
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos)
 "bUP" = (
 /obj/machinery/atmospherics/components/binary/pump{
-	dir = 0;
 	name = "Air to Port"
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos)
 "bUQ" = (
 /obj/machinery/atmospherics/components/binary/pump{
-	dir = 0;
 	name = "Pure to Port"
 	},
 /turf/open/floor/plasteel,
@@ -40370,7 +40294,6 @@
 	pixel_x = -27
 	},
 /obj/machinery/atmospherics/components/binary/pump{
-	dir = 0;
 	name = "Air to Port"
 	},
 /obj/machinery/light{
@@ -41843,7 +41766,6 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/components/binary/pump{
-	dir = 0;
 	name = "Port to Filter"
 	},
 /turf/open/floor/plasteel,
@@ -44317,9 +44239,7 @@
 /obj/machinery/computer/atmos_control/tank/oxygen_tank{
 	dir = 1
 	},
-/turf/open/floor/plasteel/blue/side{
-	dir = 0
-	},
+/turf/open/floor/plasteel/blue/side,
 /area/engine/atmos)
 "cha" = (
 /obj/machinery/atmospherics/pipe/simple/green/visible,
@@ -46443,9 +46363,7 @@
 	freq = 1400;
 	location = "Engineering"
 	},
-/obj/structure/plasticflaps{
-	opacity = 1
-	},
+/obj/structure/plasticflaps/opaque,
 /obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel,
 /area/engine/engineering)
@@ -48953,7 +48871,6 @@
 /area/ai_monitored/turret_protected/aisat/atmos)
 "cuq" = (
 /obj/machinery/atmospherics/components/binary/pump{
-	dir = 0;
 	name = "Air Out"
 	},
 /obj/effect/turf_decal/stripes/line,

--- a/_maps/map_files/Deltastation/DeltaStation2.dmm
+++ b/_maps/map_files/Deltastation/DeltaStation2.dmm
@@ -10334,9 +10334,7 @@
 /turf/open/floor/plasteel,
 /area/quartermaster/warehouse)
 "aBQ" = (
-/obj/structure/plasticflaps{
-	opacity = 1
-	},
+/obj/structure/plasticflaps/opaque,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/delivery,
 /turf/open/floor/plasteel,
@@ -12196,9 +12194,7 @@
 /turf/open/floor/plasteel,
 /area/hallway/secondary/service)
 "aGb" = (
-/obj/structure/plasticflaps{
-	opacity = 1
-	},
+/obj/structure/plasticflaps/opaque,
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
@@ -12337,9 +12333,7 @@
 	id = "cargodeliver"
 	},
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/plasticflaps{
-	opacity = 1
-	},
+/obj/structure/plasticflaps/opaque,
 /turf/open/floor/plating,
 /area/quartermaster/sorting)
 "aGo" = (
@@ -17116,9 +17110,7 @@
 /turf/open/floor/plasteel,
 /area/crew_quarters/theatre)
 "aQi" = (
-/obj/structure/plasticflaps{
-	opacity = 1
-	},
+/obj/structure/plasticflaps/opaque,
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/navbeacon{
 	codes_txt = "delivery;dir=8";
@@ -20693,9 +20685,7 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/fore)
 "aXf" = (
-/obj/structure/plasticflaps{
-	opacity = 1
-	},
+/obj/structure/plasticflaps/opaque,
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -22502,9 +22492,7 @@
 /turf/open/floor/plating,
 /area/quartermaster/miningoffice)
 "baV" = (
-/obj/structure/plasticflaps{
-	opacity = 1
-	},
+/obj/structure/plasticflaps/opaque,
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/effect/turf_decal/delivery,
@@ -23017,9 +23005,7 @@
 /turf/open/floor/plasteel,
 /area/hallway/secondary/service)
 "bcc" = (
-/obj/structure/plasticflaps{
-	opacity = 1
-	},
+/obj/structure/plasticflaps/opaque,
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
@@ -24294,9 +24280,7 @@
 /turf/open/floor/plasteel,
 /area/hydroponics)
 "beV" = (
-/obj/structure/plasticflaps{
-	opacity = 1
-	},
+/obj/structure/plasticflaps/opaque,
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/navbeacon{
 	codes_txt = "delivery;dir=8";
@@ -28066,11 +28050,8 @@
 	dir = 4;
 	pixel_y = 8
 	},
-/obj/structure/sign/directions/engineering{
-	desc = "A direction sign, pointing out which way the Supply department is.";
-	dir = 4;
-	icon_state = "direction_supply";
-	name = "supply department"
+/obj/structure/sign/directions/supply{
+	dir = 4
 	},
 /obj/structure/sign/directions/medical{
 	pixel_y = -8
@@ -28127,9 +28108,7 @@
 /turf/open/floor/plasteel,
 /area/quartermaster/miningoffice)
 "bnA" = (
-/obj/structure/plasticflaps{
-	opacity = 1
-	},
+/obj/structure/plasticflaps/opaque,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/delivery,
 /turf/open/floor/plasteel,
@@ -32525,8 +32504,7 @@
 "bwt" = (
 /obj/machinery/atmospherics/components/binary/pump/on{
 	dir = 4;
-	name = "Air to Distro";
-	target_pressure = 101
+	name = "Air to Distro"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plasteel/caution,
@@ -32663,9 +32641,7 @@
 /area/engine/atmos)
 "bwG" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/plasticflaps{
-	opacity = 1
-	},
+/obj/structure/plasticflaps/opaque,
 /obj/structure/cable/white{
 	icon_state = "1-8"
 	},
@@ -35052,9 +35028,7 @@
 /area/maintenance/port/fore)
 "bBt" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/plasticflaps{
-	opacity = 1
-	},
+/obj/structure/plasticflaps/opaque,
 /obj/structure/cable/white{
 	icon_state = "1-2"
 	},
@@ -41889,9 +41863,7 @@
 /area/bridge/meeting_room/council)
 "bOy" = (
 /obj/structure/chair/comfy/brown{
-	color = "#c45c57";
-	dir = 4;
-	icon_state = "comfychair"
+	dir = 4
 	},
 /obj/structure/cable/white{
 	icon_state = "4-8"
@@ -43723,11 +43695,8 @@
 	dir = 8;
 	pixel_y = 8
 	},
-/obj/structure/sign/directions/engineering{
-	desc = "A direction sign, pointing out which way the Command department is.";
+/obj/structure/sign/directions/command{
 	dir = 4;
-	icon_state = "direction_bridge";
-	name = "command department";
 	pixel_y = -8
 	},
 /turf/closed/wall,
@@ -43937,17 +43906,11 @@
 	dir = 2;
 	pixel_y = -8
 	},
-/obj/structure/sign/directions/engineering{
-	desc = "A direction sign, pointing out which way the Command department is.";
-	dir = 1;
-	icon_state = "direction_bridge";
-	name = "command department"
+/obj/structure/sign/directions/command{
+	dir = 1
 	},
-/obj/structure/sign/directions/engineering{
-	desc = "A direction sign, pointing out which way the Supply department is.";
+/obj/structure/sign/directions/supply{
 	dir = 1;
-	icon_state = "direction_supply";
-	name = "supply department";
 	pixel_y = 8
 	},
 /turf/closed/wall,
@@ -50191,9 +50154,7 @@
 /area/crew_quarters/heads/captain/private)
 "ceF" = (
 /obj/structure/chair/comfy/brown{
-	color = "#c45c57";
-	dir = 8;
-	icon_state = "comfychair"
+	dir = 8
 	},
 /obj/structure/cable/white{
 	icon_state = "1-4"
@@ -55739,9 +55700,7 @@
 /turf/open/floor/plasteel,
 /area/maintenance/starboard)
 "cqg" = (
-/obj/structure/plasticflaps{
-	opacity = 1
-	},
+/obj/structure/plasticflaps/opaque,
 /obj/machinery/navbeacon{
 	codes_txt = "delivery;dir=1";
 	dir = 1;
@@ -58196,11 +58155,8 @@
 	},
 /area/library)
 "cvn" = (
-/obj/structure/sign/directions/engineering{
-	desc = "A direction sign, pointing out which way the Command department is.";
-	dir = 1;
-	icon_state = "direction_bridge";
-	name = "command department"
+/obj/structure/sign/directions/command{
+	dir = 1
 	},
 /turf/closed/wall/r_wall,
 /area/ai_monitored/storage/eva)
@@ -58347,11 +58303,8 @@
 /turf/open/floor/plasteel,
 /area/hallway/secondary/command)
 "cvF" = (
-/obj/structure/sign/directions/engineering{
-	desc = "A direction sign, pointing out which way the Command department is.";
-	dir = 1;
-	icon_state = "direction_bridge";
-	name = "command department"
+/obj/structure/sign/directions/command{
+	dir = 1
 	},
 /turf/closed/wall/r_wall,
 /area/gateway)
@@ -64499,9 +64452,7 @@
 /area/maintenance/port)
 "cIq" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/plasticflaps{
-	opacity = 1
-	},
+/obj/structure/plasticflaps/opaque,
 /obj/machinery/navbeacon{
 	codes_txt = "delivery;dir=1";
 	dir = 1;
@@ -68771,9 +68722,7 @@
 /turf/open/floor/plasteel,
 /area/medical/storage)
 "cRk" = (
-/obj/structure/plasticflaps{
-	opacity = 1
-	},
+/obj/structure/plasticflaps/opaque,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
@@ -90292,9 +90241,7 @@
 /turf/open/floor/plasteel,
 /area/maintenance/port/aft)
 "dKk" = (
-/obj/structure/plasticflaps{
-	opacity = 1
-	},
+/obj/structure/plasticflaps/opaque,
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/machinery/navbeacon{

--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -6826,9 +6826,7 @@
 	freq = 1400;
 	location = "Security"
 	},
-/obj/structure/plasticflaps{
-	opacity = 1
-	},
+/obj/structure/plasticflaps/opaque,
 /obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel,
 /area/security/main)
@@ -11197,9 +11195,7 @@
 	freq = 1400;
 	location = "Engineering"
 	},
-/obj/structure/plasticflaps{
-	opacity = 1
-	},
+/obj/structure/plasticflaps/opaque,
 /obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel,
 /area/engine/engineering)
@@ -15859,9 +15855,7 @@
 /area/hallway/primary/fore)
 "aHC" = (
 /obj/structure/sign/directions/security{
-	desc = "A direction sign, pointing out which way the security department is.";
 	dir = 1;
-	icon_state = "direction_sec";
 	pixel_y = 8
 	},
 /turf/closed/wall,
@@ -17371,9 +17365,7 @@
 	name = "MuleBot Supply Access";
 	req_access_txt = "50"
 	},
-/obj/structure/plasticflaps{
-	opacity = 1
-	},
+/obj/structure/plasticflaps/opaque,
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
 "aLa" = (
@@ -19220,9 +19212,7 @@
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
 "aPm" = (
-/obj/structure/plasticflaps{
-	opacity = 1
-	},
+/obj/structure/plasticflaps/opaque,
 /obj/machinery/navbeacon{
 	codes_txt = "delivery;dir=4";
 	dir = 4;
@@ -21687,21 +21677,14 @@
 /area/ai_monitored/turret_protected/ai_upload_foyer)
 "aUB" = (
 /obj/structure/sign/directions/security{
-	desc = "A direction sign, pointing out which way the security department is.";
 	dir = 1;
-	icon_state = "direction_sec";
 	pixel_y = 8
 	},
 /obj/structure/sign/directions/engineering{
-	desc = "A direction sign, pointing out which way the engineering department is.";
-	dir = 4;
-	icon_state = "direction_eng"
+	dir = 4
 	},
-/obj/structure/sign/directions/engineering{
-	desc = "A direction sign, pointing out which way the bridge is.";
+/obj/structure/sign/directions/command{
 	dir = 2;
-	icon_state = "direction_bridge";
-	name = "bridge";
 	pixel_y = -8
 	},
 /turf/closed/wall/r_wall,
@@ -21737,21 +21720,11 @@
 	},
 /area/hallway/primary/fore)
 "aUF" = (
-/obj/structure/sign/directions/engineering{
-	desc = "A direction sign, pointing out which way the escape arm is.";
-	icon_state = "direction_evac";
-	name = "escape arm"
-	},
-/obj/structure/sign/directions/engineering{
-	desc = "A direction sign, pointing out which way the medical department is.";
-	icon_state = "direction_med";
-	name = "medical department";
+/obj/structure/sign/directions/evac,
+/obj/structure/sign/directions/medical{
 	pixel_y = 8
 	},
-/obj/structure/sign/directions/engineering{
-	desc = "A direction sign, pointing out which way the research department is.";
-	icon_state = "direction_sci";
-	name = "research department";
+/obj/structure/sign/directions/science{
 	pixel_y = -8
 	},
 /turf/closed/wall,
@@ -24543,10 +24516,7 @@
 	},
 /area/quartermaster/office)
 "bay" = (
-/obj/structure/sign/directions/engineering{
-	desc = "A direction sign, pointing out which way the Cargo department is.";
-	icon_state = "direction_supply";
-	name = "cargo department";
+/obj/structure/sign/directions/supply{
 	pixel_y = -5
 	},
 /turf/closed/wall,
@@ -25235,9 +25205,7 @@
 /turf/open/floor/plating,
 /area/quartermaster/office)
 "bbO" = (
-/obj/structure/plasticflaps{
-	opacity = 1
-	},
+/obj/structure/plasticflaps/opaque,
 /obj/machinery/conveyor{
 	backwards = 1;
 	dir = 2;
@@ -26040,7 +26008,6 @@
 	pixel_y = 5
 	},
 /obj/item/radio/intercom{
-	dir = 0;
 	name = "Station Intercom (General)";
 	pixel_x = -27
 	},
@@ -26929,21 +26896,14 @@
 /area/hallway/primary/central)
 "bfG" = (
 /obj/structure/sign/directions/security{
-	desc = "A direction sign, pointing out which way the security department is.";
 	dir = 1;
-	icon_state = "direction_sec";
 	pixel_y = 8
 	},
 /obj/structure/sign/directions/engineering{
-	desc = "A direction sign, pointing out which way the engineering department is.";
-	dir = 4;
-	icon_state = "direction_eng"
+	dir = 4
 	},
-/obj/structure/sign/directions/engineering{
-	desc = "A direction sign, pointing out which way the bridge is.";
+/obj/structure/sign/directions/command{
 	dir = 2;
-	icon_state = "direction_bridge";
-	name = "bridge";
 	pixel_y = -8
 	},
 /turf/closed/wall/r_wall,
@@ -28462,7 +28422,6 @@
 	},
 /obj/machinery/light/small,
 /obj/item/radio/intercom{
-	dir = 0;
 	name = "Station Intercom (General)";
 	pixel_y = -28
 	},
@@ -29056,9 +29015,7 @@
 	dir = 1;
 	id = "packageExternal"
 	},
-/obj/structure/plasticflaps{
-	opacity = 1
-	},
+/obj/structure/plasticflaps/opaque,
 /obj/structure/window/reinforced{
 	dir = 4
 	},
@@ -29338,7 +29295,6 @@
 /area/bridge)
 "bkD" = (
 /obj/item/radio/intercom{
-	dir = 0;
 	name = "Station Intercom (General)";
 	pixel_y = 29
 	},
@@ -30054,11 +30010,8 @@
 /turf/open/floor/plating,
 /area/quartermaster/office)
 "bmj" = (
-/obj/structure/sign/directions/engineering{
-	desc = "A direction sign, pointing out which way the Supply department is.";
+/obj/structure/sign/directions/supply{
 	dir = 1;
-	icon_state = "direction_supply";
-	name = "cargo department";
 	pixel_y = 8
 	},
 /turf/closed/wall,
@@ -30083,21 +30036,14 @@
 /area/hallway/primary/port)
 "bmm" = (
 /obj/structure/sign/directions/security{
-	desc = "A direction sign, pointing out which way the security department is.";
 	dir = 1;
-	icon_state = "direction_sec";
 	pixel_y = 8
 	},
 /obj/structure/sign/directions/engineering{
-	desc = "A direction sign, pointing out which way the engineering department is.";
-	dir = 4;
-	icon_state = "direction_eng"
+	dir = 4
 	},
-/obj/structure/sign/directions/engineering{
-	desc = "A direction sign, pointing out which way the bridge is.";
+/obj/structure/sign/directions/command{
 	dir = 2;
-	icon_state = "direction_bridge";
-	name = "bridge";
 	pixel_y = -8
 	},
 /turf/closed/wall/r_wall,
@@ -30176,9 +30122,7 @@
 	freq = 1400;
 	location = "Bridge"
 	},
-/obj/structure/plasticflaps{
-	opacity = 1
-	},
+/obj/structure/plasticflaps/opaque,
 /obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel,
 /area/maintenance/central)
@@ -30350,21 +30294,11 @@
 	},
 /area/hallway/primary/central)
 "bmL" = (
-/obj/structure/sign/directions/engineering{
-	desc = "A direction sign, pointing out which way the escape arm is.";
-	icon_state = "direction_evac";
-	name = "escape arm"
-	},
-/obj/structure/sign/directions/engineering{
-	desc = "A direction sign, pointing out which way the medical department is.";
-	icon_state = "direction_med";
-	name = "medical department";
+/obj/structure/sign/directions/evac,
+/obj/structure/sign/directions/medical{
 	pixel_y = 8
 	},
-/obj/structure/sign/directions/engineering{
-	desc = "A direction sign, pointing out which way the research department is.";
-	icon_state = "direction_sci";
-	name = "research department";
+/obj/structure/sign/directions/science{
 	pixel_y = -8
 	},
 /turf/closed/wall,
@@ -30420,9 +30354,7 @@
 /area/maintenance/starboard)
 "bmU" = (
 /obj/structure/sign/directions/engineering{
-	desc = "A direction sign, pointing out which way the engineering department is.";
 	dir = 4;
-	icon_state = "direction_eng";
 	pixel_y = 8
 	},
 /turf/closed/wall,
@@ -31428,9 +31360,7 @@
 	freq = 1400;
 	location = "Bar"
 	},
-/obj/structure/plasticflaps{
-	opacity = 1
-	},
+/obj/structure/plasticflaps/opaque,
 /obj/effect/turf_decal/bot{
 	dir = 1
 	},
@@ -33665,7 +33595,6 @@
 /obj/item/hand_tele,
 /obj/structure/window/reinforced,
 /obj/item/radio/intercom{
-	dir = 0;
 	name = "Station Intercom (General)";
 	pixel_x = 27
 	},
@@ -34129,21 +34058,11 @@
 /turf/open/floor/wood,
 /area/library)
 "bui" = (
-/obj/structure/sign/directions/engineering{
-	desc = "A direction sign, pointing out which way the escape arm is.";
-	icon_state = "direction_evac";
-	name = "escape arm"
-	},
-/obj/structure/sign/directions/engineering{
-	desc = "A direction sign, pointing out which way the medical department is.";
-	icon_state = "direction_med";
-	name = "medical department";
+/obj/structure/sign/directions/evac,
+/obj/structure/sign/directions/medical{
 	pixel_y = 8
 	},
-/obj/structure/sign/directions/engineering{
-	desc = "A direction sign, pointing out which way the research department is.";
-	icon_state = "direction_sci";
-	name = "research department";
+/obj/structure/sign/directions/science{
 	pixel_y = -8
 	},
 /turf/closed/wall,
@@ -34330,7 +34249,6 @@
 	icon_state = "1-2"
 	},
 /obj/item/radio/intercom{
-	dir = 0;
 	name = "Station Intercom (General)";
 	pixel_x = -26
 	},
@@ -35173,7 +35091,6 @@
 	pixel_y = 3
 	},
 /obj/item/radio/intercom{
-	dir = 0;
 	name = "Station Intercom (General)";
 	pixel_y = 28
 	},
@@ -36013,7 +35930,6 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/item/radio/intercom{
-	dir = 0;
 	name = "Station Intercom (General)";
 	pixel_x = -26
 	},
@@ -36962,7 +36878,6 @@
 /area/crew_quarters/heads/captain/private)
 "bAf" = (
 /obj/item/radio/intercom{
-	dir = 0;
 	name = "Station Intercom (General)";
 	pixel_y = -26
 	},
@@ -37505,23 +37420,16 @@
 /turf/open/floor/wood,
 /area/library)
 "bBy" = (
-/obj/structure/sign/directions/engineering{
-	desc = "A direction sign, pointing out which way the bridge is.";
+/obj/structure/sign/directions/command{
 	dir = 4;
-	icon_state = "direction_bridge";
-	name = "bridge";
 	pixel_y = -8
 	},
 /obj/structure/sign/directions/security{
-	desc = "A direction sign, pointing out which way the security department is.";
 	dir = 1;
-	icon_state = "direction_sec";
 	pixel_y = 8
 	},
 /obj/structure/sign/directions/engineering{
-	desc = "A direction sign, pointing out which way the engineering department is.";
-	dir = 4;
-	icon_state = "direction_eng"
+	dir = 4
 	},
 /turf/closed/wall,
 /area/hallway/secondary/command)
@@ -37570,11 +37478,8 @@
 /turf/open/floor/plasteel,
 /area/hallway/secondary/command)
 "bBD" = (
-/obj/structure/sign/directions/engineering{
-	desc = "A direction sign, pointing out which way the bridge is.";
+/obj/structure/sign/directions/command{
 	dir = 1;
-	icon_state = "direction_bridge";
-	name = "bridge";
 	pixel_y = -8
 	},
 /turf/closed/wall/r_wall,
@@ -37708,11 +37613,8 @@
 /turf/open/floor/plasteel/vault,
 /area/bridge)
 "bBN" = (
-/obj/structure/sign/directions/engineering{
-	desc = "A direction sign, pointing out which way the bridge is.";
+/obj/structure/sign/directions/command{
 	dir = 1;
-	icon_state = "direction_bridge";
-	name = "bridge";
 	pixel_y = -8
 	},
 /turf/closed/wall/r_wall,
@@ -37730,21 +37632,14 @@
 /area/maintenance/central)
 "bBP" = (
 /obj/structure/sign/directions/engineering{
-	desc = "A direction sign, pointing out which way the engineering department is.";
-	dir = 4;
-	icon_state = "direction_eng"
+	dir = 4
 	},
 /obj/structure/sign/directions/security{
-	desc = "A direction sign, pointing out which way the security department is.";
 	dir = 1;
-	icon_state = "direction_sec";
 	pixel_y = 8
 	},
-/obj/structure/sign/directions/engineering{
-	desc = "A direction sign, pointing out which way the bridge is.";
+/obj/structure/sign/directions/command{
 	dir = 8;
-	icon_state = "direction_bridge";
-	name = "bridge";
 	pixel_y = -8
 	},
 /turf/closed/wall,
@@ -37964,7 +37859,6 @@
 /area/engine/atmos)
 "bCr" = (
 /obj/machinery/atmospherics/components/binary/pump/on{
-	dir = 0;
 	name = "Waste to Filter"
 	},
 /turf/open/floor/plasteel,
@@ -37988,7 +37882,6 @@
 /area/engine/atmos)
 "bCw" = (
 /obj/machinery/atmospherics/components/binary/pump{
-	dir = 0;
 	name = "Air to Mix"
 	},
 /obj/machinery/atmospherics/pipe/simple/purple/visible{
@@ -39554,9 +39447,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/structure/plasticflaps{
-	opacity = 1
-	},
+/obj/structure/plasticflaps/opaque,
 /obj/machinery/navbeacon{
 	codes_txt = "delivery;dir=4";
 	dir = 4;
@@ -39865,23 +39756,13 @@
 	},
 /area/hallway/primary/central)
 "bGx" = (
-/obj/structure/sign/directions/engineering{
-	desc = "A direction sign, pointing out which way the research department is.";
-	icon_state = "direction_sci";
-	name = "research department";
+/obj/structure/sign/directions/science{
 	pixel_y = -8
 	},
-/obj/structure/sign/directions/engineering{
-	desc = "A direction sign, pointing out which way the medical department is.";
-	icon_state = "direction_med";
-	name = "medical department";
+/obj/structure/sign/directions/medical{
 	pixel_y = 8
 	},
-/obj/structure/sign/directions/engineering{
-	desc = "A direction sign, pointing out which way the escape arm is.";
-	icon_state = "direction_evac";
-	name = "escape arm"
-	},
+/obj/structure/sign/directions/evac,
 /turf/closed/wall/r_wall,
 /area/ai_monitored/storage/eva)
 "bGy" = (
@@ -40044,21 +39925,11 @@
 /turf/open/floor/plating,
 /area/maintenance/central)
 "bGU" = (
-/obj/structure/sign/directions/engineering{
-	desc = "A direction sign, pointing out which way the escape arm is.";
-	icon_state = "direction_evac";
-	name = "escape arm"
-	},
-/obj/structure/sign/directions/engineering{
-	desc = "A direction sign, pointing out which way the medical department is.";
-	icon_state = "direction_med";
-	name = "medical department";
+/obj/structure/sign/directions/evac,
+/obj/structure/sign/directions/medical{
 	pixel_y = 8
 	},
-/obj/structure/sign/directions/engineering{
-	desc = "A direction sign, pointing out which way the research department is.";
-	icon_state = "direction_sci";
-	name = "research department";
+/obj/structure/sign/directions/science{
 	pixel_y = -8
 	},
 /turf/closed/wall,
@@ -41688,21 +41559,18 @@
 /area/engine/atmos)
 "bKA" = (
 /obj/machinery/atmospherics/components/binary/pump{
-	dir = 0;
 	name = "Air to Ports"
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos)
 "bKB" = (
 /obj/machinery/atmospherics/components/binary/pump{
-	dir = 0;
 	name = "Mix to Ports"
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos)
 "bKC" = (
 /obj/machinery/atmospherics/components/binary/pump{
-	dir = 0;
 	name = "Pure to Ports"
 	},
 /turf/open/floor/plasteel,
@@ -42999,7 +42867,6 @@
 	dir = 4
 	},
 /obj/item/radio/intercom{
-	dir = 0;
 	name = "Station Intercom (General)";
 	pixel_x = 29
 	},
@@ -43263,7 +43130,6 @@
 	pixel_x = -27
 	},
 /obj/machinery/atmospherics/components/binary/pump{
-	dir = 0;
 	name = "Port Mix to West Ports"
 	},
 /obj/machinery/light/small{
@@ -43273,7 +43139,6 @@
 /area/engine/atmos)
 "bNU" = (
 /obj/machinery/atmospherics/components/binary/pump{
-	dir = 0;
 	name = "Port Mix to East Ports"
 	},
 /obj/item/crowbar,
@@ -45705,7 +45570,6 @@
 /area/engine/atmos)
 "bTk" = (
 /obj/machinery/atmospherics/components/binary/pump{
-	dir = 0;
 	name = "Port to Filter"
 	},
 /obj/machinery/light/small{
@@ -46248,9 +46112,7 @@
 	freq = 1400;
 	location = "Kitchen"
 	},
-/obj/structure/plasticflaps{
-	opacity = 1
-	},
+/obj/structure/plasticflaps/opaque,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
@@ -46910,7 +46772,6 @@
 /area/engine/atmos)
 "bVL" = (
 /obj/machinery/atmospherics/components/binary/pump{
-	dir = 0;
 	name = "Port to Fuel Pipe"
 	},
 /turf/open/floor/plasteel,
@@ -48099,7 +47960,6 @@
 /obj/item/radio/off,
 /obj/item/radio/off,
 /obj/item/radio/intercom{
-	dir = 0;
 	name = "Station Intercom (General)";
 	pixel_x = 27
 	},
@@ -48481,21 +48341,14 @@
 /area/medical/medbay/central)
 "bZe" = (
 /obj/structure/sign/directions/security{
-	desc = "A direction sign, pointing out which way the security department is.";
 	dir = 1;
-	icon_state = "direction_sec";
 	pixel_y = 8
 	},
 /obj/structure/sign/directions/engineering{
-	desc = "A direction sign, pointing out which way the engineering department is.";
-	dir = 4;
-	icon_state = "direction_eng"
+	dir = 4
 	},
-/obj/structure/sign/directions/engineering{
-	desc = "A direction sign, pointing out which way the bridge is.";
+/obj/structure/sign/directions/command{
 	dir = 1;
-	icon_state = "direction_bridge";
-	name = "bridge";
 	pixel_y = -8
 	},
 /turf/closed/wall,
@@ -48531,23 +48384,13 @@
 	},
 /area/hallway/primary/aft)
 "bZi" = (
-/obj/structure/sign/directions/engineering{
-	desc = "A direction sign, pointing out which way the medical department is.";
+/obj/structure/sign/directions/medical{
 	dir = 8;
-	icon_state = "direction_med";
-	name = "medical department";
 	pixel_y = 8
 	},
-/obj/structure/sign/directions/engineering{
-	desc = "A direction sign, pointing out which way the escape arm is.";
-	icon_state = "direction_evac";
-	name = "escape arm"
-	},
-/obj/structure/sign/directions/engineering{
-	desc = "A direction sign, pointing out which way the research department is.";
+/obj/structure/sign/directions/evac,
+/obj/structure/sign/directions/science{
 	dir = 4;
-	icon_state = "direction_sci";
-	name = "research department";
 	pixel_y = -8
 	},
 /turf/closed/wall,
@@ -48838,9 +48681,7 @@
 	freq = 1400;
 	location = "Medbay"
 	},
-/obj/structure/plasticflaps{
-	opacity = 1
-	},
+/obj/structure/plasticflaps/opaque,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
@@ -49859,7 +49700,6 @@
 	pixel_y = -29
 	},
 /obj/item/radio/intercom{
-	dir = 0;
 	name = "Station Intercom (General)";
 	pixel_x = -27;
 	pixel_y = -10
@@ -50211,9 +50051,7 @@
 	freq = 1400;
 	location = "Hydroponics"
 	},
-/obj/structure/plasticflaps{
-	opacity = 1
-	},
+/obj/structure/plasticflaps/opaque,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
@@ -54477,9 +54315,7 @@
 /turf/open/floor/plasteel,
 /area/science/research)
 "clJ" = (
-/obj/structure/plasticflaps{
-	opacity = 1
-	},
+/obj/structure/plasticflaps/opaque,
 /obj/machinery/navbeacon{
 	codes_txt = "delivery;dir=2";
 	freq = 1400;
@@ -57516,9 +57352,7 @@
 	},
 /area/hallway/primary/aft)
 "crI" = (
-/obj/structure/plasticflaps{
-	opacity = 1
-	},
+/obj/structure/plasticflaps/opaque,
 /obj/machinery/navbeacon{
 	codes_txt = "delivery;dir=1";
 	dir = 1;
@@ -61113,9 +60947,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
-/turf/open/floor/plasteel/blue/side{
-	dir = 0
-	},
+/turf/open/floor/plasteel/blue/side,
 /area/medical/genetics)
 "czd" = (
 /obj/machinery/light_switch{
@@ -66980,9 +66812,7 @@
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit/departure_lounge)
 "cKG" = (
-/obj/structure/plasticflaps{
-	opacity = 1
-	},
+/obj/structure/plasticflaps/opaque,
 /obj/machinery/navbeacon{
 	codes_txt = "delivery;dir=1";
 	dir = 1;

--- a/_maps/map_files/OmegaStation/OmegaStation.dmm
+++ b/_maps/map_files/OmegaStation/OmegaStation.dmm
@@ -1505,9 +1505,7 @@
 /area/bridge)
 "acZ" = (
 /obj/structure/chair/comfy/brown{
-	color = "#c45c57";
-	dir = 4;
-	icon_state = "comfychair"
+	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
@@ -3352,9 +3350,7 @@
 /area/crew_quarters/heads/captain/private)
 "agQ" = (
 /obj/structure/chair/comfy/brown{
-	color = "#c45c57";
-	dir = 4;
-	icon_state = "comfychair"
+	dir = 4
 	},
 /obj/structure/cable/white{
 	icon_state = "4-8"
@@ -4912,9 +4908,7 @@
 	},
 /area/hallway/primary/starboard/fore)
 "ajH" = (
-/obj/structure/plasticflaps{
-	opacity = 1
-	},
+/obj/structure/plasticflaps/opaque,
 /obj/effect/turf_decal/delivery,
 /turf/open/floor/plasteel,
 /area/quartermaster/storage)
@@ -5926,17 +5920,11 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/fore)
 "alt" = (
-/obj/structure/sign/directions/engineering{
-	desc = "A direction sign, pointing out which way the Supply department is.";
-	dir = 4;
-	icon_state = "direction_supply";
-	name = "supply department"
+/obj/structure/sign/directions/supply{
+	dir = 4
 	},
-/obj/structure/sign/directions/engineering{
-	desc = "A direction sign, pointing out which way the Command department is.";
+/obj/structure/sign/directions/command{
 	dir = 1;
-	icon_state = "direction_bridge";
-	name = "command department";
 	pixel_y = 8
 	},
 /obj/structure/sign/directions/science{
@@ -7073,11 +7061,8 @@
 /obj/structure/sign/directions/security{
 	dir = 8
 	},
-/obj/structure/sign/directions/engineering{
-	desc = "A direction sign, pointing out which way the Command department is.";
+/obj/structure/sign/directions/command{
 	dir = 1;
-	icon_state = "direction_bridge";
-	name = "command department";
 	pixel_y = 8
 	},
 /turf/closed/wall,
@@ -10220,9 +10205,7 @@
 /turf/open/floor/plasteel,
 /area/storage/primary)
 "atU" = (
-/obj/structure/plasticflaps{
-	opacity = 1
-	},
+/obj/structure/plasticflaps/opaque,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
@@ -11478,9 +11461,7 @@
 /turf/open/floor/plasteel,
 /area/maintenance/port/fore)
 "awN" = (
-/obj/structure/plasticflaps{
-	opacity = 1
-	},
+/obj/structure/plasticflaps/opaque,
 /obj/machinery/door/poddoor/preopen{
 	id = "atmoslock";
 	name = "Atmospherics Lockdown Blast door"
@@ -17435,9 +17416,7 @@
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit)
 "aKj" = (
-/obj/structure/plasticflaps{
-	opacity = 1
-	},
+/obj/structure/plasticflaps/opaque,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/effect/turf_decal/delivery,
 /turf/open/floor/plasteel,
@@ -19105,11 +19084,8 @@
 	},
 /area/hallway/primary/central)
 "aOr" = (
-/obj/structure/sign/directions/engineering{
-	desc = "A direction sign, pointing out which way the Supply department is.";
-	dir = 4;
-	icon_state = "direction_supply";
-	name = "supply department"
+/obj/structure/sign/directions/supply{
+	dir = 4
 	},
 /obj/structure/sign/directions/science{
 	pixel_y = -8
@@ -27990,11 +27966,8 @@
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
 "bgX" = (
-/obj/structure/sign/directions/engineering{
-	desc = "A direction sign, pointing out which way the Supply department is.";
-	dir = 1;
-	icon_state = "direction_supply";
-	name = "supply department"
+/obj/structure/sign/directions/supply{
+	dir = 1
 	},
 /obj/structure/sign/directions/science{
 	dir = 1;
@@ -34366,8 +34339,6 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plasteel/vault/corner{
-	tag = "icon-vaultcorner (NORTH)";
-	icon_state = "vaultcorner";
 	dir = 1
 	},
 /area/ai_monitored/turret_protected/ai)
@@ -35146,17 +35117,11 @@
 /turf/closed/wall/r_wall/rust,
 /area/ai_monitored/nuke_storage)
 "sOF" = (
-/obj/structure/sign/directions/engineering{
-	desc = "A direction sign, pointing out which way the Supply department is.";
-	dir = 4;
-	icon_state = "direction_supply";
-	name = "supply department"
+/obj/structure/sign/directions/supply{
+	dir = 4
 	},
-/obj/structure/sign/directions/engineering{
-	desc = "A direction sign, pointing out which way the Command department is.";
+/obj/structure/sign/directions/command{
 	dir = 1;
-	icon_state = "direction_bridge";
-	name = "command department";
 	pixel_y = 8
 	},
 /obj/structure/sign/directions/science{

--- a/_maps/map_files/PubbyStation/PubbyStation.dmm
+++ b/_maps/map_files/PubbyStation/PubbyStation.dmm
@@ -2524,8 +2524,7 @@
 /obj/structure/closet/secure_closet/lethalshots,
 /obj/machinery/camera/motion{
 	c_tag = "Armory Motion Sensor";
-	dir = 2;
-	name = "motion-sensitive security camera"
+	dir = 2
 	},
 /turf/open/floor/plasteel/dark,
 /area/security/armory)
@@ -3496,7 +3495,6 @@
 "akx" = (
 /obj/structure/bodycontainer/crematorium,
 /obj/item/radio/intercom{
-	dir = 0;
 	name = "Station Intercom (General)";
 	pixel_x = -27
 	},
@@ -4061,8 +4059,7 @@
 "alU" = (
 /obj/machinery/atmospherics/components/binary/pump{
 	dir = 8;
-	name = "Supply to Security";
-	on = 0
+	name = "Supply to Security"
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/security/brig)
@@ -4747,9 +4744,7 @@
 /turf/closed/wall,
 /area/security/processing/cremation)
 "anw" = (
-/obj/structure/plasticflaps{
-	opacity = 1
-	},
+/obj/structure/plasticflaps/opaque,
 /turf/open/floor/plasteel/vault{
 	dir = 8
 	},
@@ -8070,7 +8065,6 @@
 	dir = 4
 	},
 /obj/item/radio/intercom{
-	dir = 0;
 	name = "Station Intercom (General)";
 	pixel_y = -28
 	},
@@ -8932,7 +8926,6 @@
 "axU" = (
 /obj/machinery/computer/card,
 /obj/item/radio/intercom{
-	dir = 0;
 	name = "Station Intercom (General)";
 	pixel_y = 26
 	},
@@ -9100,7 +9093,6 @@
 /area/crew_quarters/dorms)
 "ayn" = (
 /obj/structure/chair/comfy{
-	icon_state = "comfychair";
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
@@ -9411,7 +9403,6 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden,
 /obj/item/radio/intercom{
-	dir = 0;
 	name = "Station Intercom (General)";
 	pixel_y = -28
 	},
@@ -9508,7 +9499,6 @@
 	dir = 4
 	},
 /obj/item/radio/intercom{
-	dir = 0;
 	name = "Station Intercom (General)";
 	pixel_y = -28
 	},
@@ -9592,7 +9582,6 @@
 /area/crew_quarters/dorms)
 "azv" = (
 /obj/structure/chair/comfy{
-	icon_state = "comfychair";
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
@@ -10152,7 +10141,6 @@
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/security{
 	name = "Detective's Office";
-	req_access = null;
 	req_access_txt = "4"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -10524,7 +10512,6 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/item/radio/intercom{
-	dir = 0;
 	name = "Station Intercom (General)";
 	pixel_x = 28
 	},
@@ -10680,7 +10667,6 @@
 /obj/machinery/cell_charger,
 /obj/item/stock_parts/cell/high/plus,
 /obj/item/radio/intercom{
-	dir = 0;
 	name = "Station Intercom (General)";
 	pixel_y = 26
 	},
@@ -11068,7 +11054,6 @@
 	dir = 4
 	},
 /obj/item/radio/intercom{
-	dir = 0;
 	name = "Station Intercom (General)";
 	pixel_y = -26
 	},
@@ -11856,7 +11841,6 @@
 	pixel_y = 4
 	},
 /obj/item/radio/intercom{
-	dir = 0;
 	name = "Station Intercom (General)";
 	pixel_x = 27
 	},
@@ -11872,7 +11856,6 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/item/radio/intercom{
-	dir = 0;
 	name = "Station Intercom (General)";
 	pixel_x = -27
 	},
@@ -12518,8 +12501,7 @@
 	},
 /obj/structure/disposalpipe/segment,
 /obj/structure/sign/warning/vacuum/external{
-	pixel_x = -32;
-	pixel_y = 0
+	pixel_x = -32
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
@@ -13655,7 +13637,6 @@
 	},
 /obj/structure/sign/directions/security{
 	dir = 1;
-	icon_state = "direction_sec";
 	pixel_x = 32;
 	pixel_y = -24
 	},
@@ -13812,13 +13793,11 @@
 "aJX" = (
 /obj/structure/sign/directions/security{
 	dir = 8;
-	icon_state = "direction_sec";
 	pixel_x = -32;
 	pixel_y = -24
 	},
 /obj/structure/sign/directions/evac{
 	dir = 1;
-	icon_state = "direction_evac";
 	pixel_x = -32;
 	pixel_y = -32
 	},
@@ -14472,7 +14451,6 @@
 "aMf" = (
 /obj/machinery/computer/secure_data,
 /obj/item/radio/intercom{
-	dir = 0;
 	name = "Station Intercom (General)";
 	pixel_y = 26
 	},
@@ -14957,7 +14935,6 @@
 	},
 /obj/item/clothing/shoes/magboots,
 /obj/item/radio/intercom{
-	dir = 0;
 	name = "Station Intercom (General)";
 	pixel_x = -27
 	},
@@ -15007,7 +14984,6 @@
 /obj/structure/closet/crate,
 /obj/item/melee/flyswatter,
 /obj/item/radio/intercom{
-	dir = 0;
 	name = "Station Intercom (General)";
 	pixel_x = -27
 	},
@@ -15702,7 +15678,6 @@
 	dir = 4
 	},
 /obj/item/radio/intercom{
-	dir = 0;
 	name = "Station Intercom (General)";
 	pixel_x = 27
 	},
@@ -15727,7 +15702,6 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/structure/sign/directions/evac{
 	dir = 1;
-	icon_state = "direction_evac";
 	pixel_x = 32
 	},
 /turf/open/floor/plasteel/neutral/corner,
@@ -16670,9 +16644,7 @@
 /turf/open/floor/plating,
 /area/crew_quarters/kitchen)
 "aRP" = (
-/obj/structure/plasticflaps{
-	opacity = 1
-	},
+/obj/structure/plasticflaps/opaque,
 /turf/open/floor/plating{
 	icon_state = "platingdmg3"
 	},
@@ -17589,9 +17561,7 @@
 /turf/open/floor/plasteel/showroomfloor,
 /area/crew_quarters/kitchen)
 "aUb" = (
-/obj/structure/plasticflaps{
-	opacity = 1
-	},
+/obj/structure/plasticflaps/opaque,
 /turf/open/floor/plasteel/vault{
 	dir = 8
 	},
@@ -17823,8 +17793,6 @@
 	},
 /obj/structure/sign/directions/evac{
 	dir = 1;
-	icon_state = "direction_evac";
-	pixel_x = 0;
 	pixel_y = 32
 	},
 /obj/structure/cable{
@@ -17925,9 +17893,7 @@
 /turf/open/floor/plating,
 /area/maintenance/department/crew_quarters/bar)
 "aUQ" = (
-/obj/structure/plasticflaps{
-	opacity = 1
-	},
+/obj/structure/plasticflaps/opaque,
 /turf/open/floor/plasteel/vault{
 	dir = 8
 	},
@@ -18126,7 +18092,6 @@
 	req_access_txt = "25"
 	},
 /obj/item/radio/intercom{
-	dir = 0;
 	name = "Station Intercom (General)";
 	pixel_y = 26
 	},
@@ -18204,9 +18169,7 @@
 /turf/open/floor/plasteel,
 /area/quartermaster/office)
 "aVs" = (
-/obj/structure/plasticflaps{
-	opacity = 1
-	},
+/obj/structure/plasticflaps/opaque,
 /obj/machinery/conveyor{
 	dir = 4;
 	id = "cargodeliver"
@@ -18511,7 +18474,6 @@
 	icon_state = "2-8"
 	},
 /obj/item/radio/intercom{
-	dir = 0;
 	name = "Station Intercom (General)";
 	pixel_y = 26
 	},
@@ -18579,7 +18541,6 @@
 	dir = 4
 	},
 /obj/item/radio/intercom{
-	dir = 0;
 	name = "Station Intercom (General)";
 	pixel_y = 26
 	},
@@ -18727,7 +18688,6 @@
 	dir = 1
 	},
 /obj/item/radio/intercom{
-	dir = 0;
 	name = "Station Intercom (General)";
 	pixel_y = 26
 	},
@@ -19167,7 +19127,6 @@
 "aXX" = (
 /obj/machinery/hydroponics/constructable,
 /obj/item/radio/intercom{
-	dir = 0;
 	name = "Station Intercom (General)";
 	pixel_y = 26
 	},
@@ -19490,7 +19449,6 @@
 "aYK" = (
 /obj/structure/closet/secure_closet/security,
 /obj/item/radio/intercom{
-	dir = 0;
 	name = "Station Intercom (General)";
 	pixel_y = 26
 	},
@@ -19557,7 +19515,6 @@
 "aYU" = (
 /obj/machinery/processor,
 /obj/item/radio/intercom{
-	dir = 0;
 	name = "Station Intercom (General)";
 	pixel_y = 26
 	},
@@ -19848,7 +19805,6 @@
 	dir = 4
 	},
 /obj/item/radio/intercom{
-	dir = 0;
 	name = "Station Intercom (General)";
 	pixel_y = 26
 	},
@@ -20103,7 +20059,6 @@
 "bao" = (
 /obj/machinery/computer/slot_machine,
 /obj/item/radio/intercom{
-	dir = 0;
 	name = "Station Intercom (General)";
 	pixel_y = 26
 	},
@@ -20142,7 +20097,6 @@
 /obj/structure/table,
 /obj/item/pen,
 /obj/item/radio/intercom{
-	dir = 0;
 	name = "Station Intercom (General)";
 	pixel_y = -26
 	},
@@ -20248,7 +20202,6 @@
 	dir = 4
 	},
 /obj/item/radio/intercom{
-	dir = 0;
 	name = "Station Intercom (General)";
 	pixel_y = -26
 	},
@@ -20704,7 +20657,6 @@
 	},
 /obj/machinery/door/airlock/external{
 	name = "Solar Maintenance";
-	req_access = null;
 	req_access_txt = "10; 13"
 	},
 /turf/open/floor/plating,
@@ -21702,7 +21654,6 @@
 /obj/machinery/button/door{
 	id = "barshutters";
 	name = "Bar Lockdown";
-	pixel_x = 0;
 	pixel_y = -28;
 	req_access_txt = "25"
 	},
@@ -21722,7 +21673,6 @@
 /obj/machinery/button/door{
 	id = "barshutters";
 	name = "Bar Lockdown";
-	pixel_x = 0;
 	pixel_y = -28;
 	req_access_txt = "25"
 	},
@@ -21936,7 +21886,6 @@
 	},
 /obj/structure/sign/directions/evac{
 	dir = 8;
-	icon_state = "direction_evac";
 	pixel_y = -32
 	},
 /turf/open/floor/plasteel,
@@ -22181,7 +22130,6 @@
 "bfI" = (
 /obj/machinery/door/airlock/external{
 	name = "Mining Dock Airlock";
-	req_access = null;
 	req_access_txt = "48"
 	},
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
@@ -22264,13 +22212,11 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/structure/sign/directions/security{
 	dir = 1;
-	icon_state = "direction_sec";
 	pixel_x = 32;
 	pixel_y = 40
 	},
 /obj/structure/sign/directions/science{
 	dir = 4;
-	icon_state = "direction_sci";
 	pixel_x = 32;
 	pixel_y = 32
 	},
@@ -22302,7 +22248,6 @@
 	name = "Throne of Custodia"
 	},
 /obj/item/radio/intercom{
-	dir = 0;
 	name = "Station Intercom (General)";
 	pixel_y = 26
 	},
@@ -22456,13 +22401,11 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/structure/sign/directions/evac{
 	dir = 1;
-	icon_state = "direction_evac";
 	pixel_x = -32;
 	pixel_y = 40
 	},
 /obj/structure/sign/directions/medical{
 	dir = 8;
-	icon_state = "direction_med";
 	pixel_x = -32;
 	pixel_y = 32
 	},
@@ -22679,7 +22622,6 @@
 	},
 /obj/structure/sign/directions/evac{
 	dir = 1;
-	icon_state = "direction_evac";
 	pixel_x = 32;
 	pixel_y = 38
 	},
@@ -23565,9 +23507,7 @@
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/zone3)
 "bjR" = (
-/obj/structure/plasticflaps{
-	opacity = 1
-	},
+/obj/structure/plasticflaps/opaque,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plating,
 /area/storage/emergency/port)
@@ -23636,7 +23576,6 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/item/radio/intercom{
-	dir = 0;
 	name = "Station Intercom (General)";
 	pixel_y = 26
 	},
@@ -23837,9 +23776,7 @@
 /turf/open/floor/engine,
 /area/science/explab)
 "bkD" = (
-/obj/structure/plasticflaps{
-	opacity = 1
-	},
+/obj/structure/plasticflaps/opaque,
 /obj/effect/turf_decal/delivery,
 /turf/open/floor/plasteel,
 /area/science/explab)
@@ -24696,9 +24633,7 @@
 /turf/open/floor/circuit/telecomms/server,
 /area/science/server)
 "bmV" = (
-/obj/machinery/atmospherics/components/unary/outlet_injector{
-	on = 1
-	},
+/obj/machinery/atmospherics/components/unary/outlet_injector/on,
 /turf/open/floor/engine,
 /area/science/explab)
 "bmW" = (
@@ -24842,7 +24777,6 @@
 "bnw" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/medical/glass{
-	id_tag = null;
 	name = "Cloning";
 	req_access_txt = "0";
 	req_one_access_txt = "5;9"
@@ -25430,10 +25364,8 @@
 /turf/open/floor/plasteel/dark,
 /area/science/robotics/lab)
 "bpa" = (
-/obj/machinery/atmospherics/components/unary/thermomachine/freezer{
-	dir = 4;
-	on = 1;
-	target_temperature = 80
+/obj/machinery/atmospherics/components/unary/thermomachine/freezer/on{
+	dir = 4
 	},
 /obj/machinery/airalarm{
 	dir = 4;
@@ -25917,7 +25849,6 @@
 /obj/item/storage/belt/utility,
 /obj/item/reagent_containers/glass/beaker/large,
 /obj/item/radio/intercom{
-	dir = 0;
 	name = "Station Intercom (General)";
 	pixel_x = -27
 	},
@@ -26430,9 +26361,7 @@
 	},
 /area/medical/chemistry)
 "bro" = (
-/obj/structure/plasticflaps{
-	opacity = 1
-	},
+/obj/structure/plasticflaps/opaque,
 /obj/effect/turf_decal/delivery,
 /turf/open/floor/plasteel,
 /area/maintenance/department/engine)
@@ -26461,9 +26390,7 @@
 /obj/structure/disposalpipe/trunk{
 	dir = 4
 	},
-/obj/machinery/airalarm{
-	frequency = 1439;
-	locked = 0;
+/obj/machinery/airalarm/unlocked{
 	pixel_y = 23
 	},
 /turf/open/floor/plasteel/whitepurple/side{
@@ -26499,9 +26426,8 @@
 /area/science/lab)
 "brv" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/machinery/airalarm{
+/obj/machinery/airalarm/unlocked{
 	dir = 4;
-	locked = 0;
 	pixel_x = -23
 	},
 /turf/open/floor/plasteel/purple/side{
@@ -26790,7 +26716,6 @@
 	network = list("ss13","rd")
 	},
 /obj/structure/sign/departments/xenobio{
-	pixel_x = 0;
 	pixel_y = 32
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -26844,9 +26769,8 @@
 	c_tag = "Genetics Cloning";
 	dir = 4
 	},
-/obj/machinery/airalarm{
+/obj/machinery/airalarm/unlocked{
 	dir = 4;
-	locked = 0;
 	pixel_x = -23
 	},
 /turf/open/floor/plasteel/blue,
@@ -27031,7 +26955,6 @@
 	layer = 2.7
 	},
 /obj/item/radio/intercom{
-	dir = 0;
 	name = "Station Intercom (General)";
 	pixel_x = 29
 	},
@@ -27163,7 +27086,6 @@
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/command{
 	name = "Server Room";
-	req_access = null;
 	req_access_txt = "30"
 	},
 /obj/structure/cable{
@@ -27365,7 +27287,6 @@
 	dir = 4
 	},
 /obj/machinery/door/airlock/external{
-	id_tag = null;
 	name = "Port Docking Bay 2";
 	req_access_txt = "0"
 	},
@@ -27376,7 +27297,6 @@
 	dir = 8
 	},
 /obj/machinery/door/airlock/external{
-	id_tag = null;
 	name = "Port Docking Bay 2";
 	req_access_txt = "0"
 	},
@@ -27973,7 +27893,6 @@
 /area/medical/medbay/central)
 "bvq" = (
 /obj/machinery/door/airlock/medical/glass{
-	id_tag = null;
 	name = "Chemistry Lab";
 	req_access_txt = "5; 33"
 	},
@@ -29496,7 +29415,6 @@
 /area/science/explab)
 "byU" = (
 /obj/structure/chair/comfy{
-	icon_state = "comfychair";
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden,
@@ -30699,7 +30617,6 @@
 /area/science/mixing)
 "bBP" = (
 /obj/item/radio/intercom{
-	dir = 0;
 	name = "Station Intercom (General)";
 	pixel_y = 26
 	},
@@ -30786,7 +30703,6 @@
 /obj/structure/table,
 /obj/item/pen,
 /obj/item/radio/intercom{
-	dir = 0;
 	name = "Station Intercom (General)";
 	pixel_x = -27
 	},
@@ -31449,9 +31365,8 @@
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
 "bDB" = (
-/obj/machinery/airalarm{
+/obj/machinery/airalarm/unlocked{
 	dir = 4;
-	locked = 0;
 	pixel_x = -23
 	},
 /obj/machinery/computer/rdconsole{
@@ -32067,7 +31982,6 @@
 	dir = 4
 	},
 /obj/item/radio/intercom{
-	dir = 0;
 	name = "Station Intercom (General)";
 	pixel_y = -26
 	},
@@ -32318,8 +32232,7 @@
 /obj/machinery/button/massdriver{
 	dir = 4;
 	id = "toxinsdriver";
-	pixel_x = 28;
-	pixel_y = 0
+	pixel_x = 28
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 9
@@ -32481,7 +32394,6 @@
 /area/medical/medbay/central)
 "bFR" = (
 /obj/machinery/door/airlock/medical/glass{
-	id_tag = null;
 	name = "Medbay Storage";
 	req_access_txt = "5"
 	},
@@ -32949,7 +32861,6 @@
 	dir = 4
 	},
 /obj/machinery/door/airlock/medical/glass{
-	id_tag = null;
 	name = "Medbay Storage";
 	req_access_txt = "5"
 	},
@@ -33225,8 +33136,7 @@
 "bHC" = (
 /obj/machinery/atmospherics/components/binary/pump{
 	dir = 2;
-	name = "Incinerator Output Pump";
-	on = 0
+	name = "Incinerator Output Pump"
 	},
 /turf/open/floor/plasteel,
 /area/science/mixing)
@@ -33328,9 +33238,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
-/obj/machinery/airalarm{
-	frequency = 1439;
-	locked = 0;
+/obj/machinery/airalarm/unlocked{
 	pixel_y = 23
 	},
 /turf/open/floor/plasteel/whitegreen/side{
@@ -33704,8 +33612,7 @@
 	layer = 4;
 	name = "Test Chamber Telescreen";
 	network = list("toxins");
-	pixel_x = -32;
-	pixel_y = 0
+	pixel_x = -32
 	},
 /turf/open/floor/plasteel/purple/side,
 /area/science/mixing)
@@ -34118,10 +34025,8 @@
 /turf/closed/wall/r_wall,
 /area/engine/atmos)
 "bJQ" = (
-/obj/machinery/atmospherics/components/binary/pump{
-	dir = 2;
-	on = 1;
-	target_pressure = 101.325
+/obj/machinery/atmospherics/components/binary/pump/on{
+	dir = 2
 	},
 /obj/machinery/doorButtons/access_button{
 	idDoor = "tox_airlock_exterior";
@@ -34141,9 +34046,7 @@
 /area/science/mixing)
 "bJS" = (
 /obj/machinery/atmospherics/components/binary/pump{
-	dir = 1;
-	on = 0;
-	target_pressure = 101.325
+	dir = 1
 	},
 /obj/machinery/doorButtons/access_button{
 	idDoor = "tox_airlock_interior";
@@ -34554,7 +34457,6 @@
 	dir = 4
 	},
 /obj/item/radio/intercom{
-	dir = 0;
 	name = "Station Intercom (General)";
 	pixel_y = 26
 	},
@@ -34591,8 +34493,7 @@
 "bKY" = (
 /obj/machinery/atmospherics/components/binary/pump{
 	dir = 8;
-	name = "Mix Outlet Pump";
-	on = 0
+	name = "Mix Outlet Pump"
 	},
 /turf/open/floor/plasteel/yellow/side{
 	dir = 5
@@ -34994,8 +34895,7 @@
 "bMd" = (
 /obj/machinery/atmospherics/components/binary/pump{
 	dir = 8;
-	name = "Mix to Distro";
-	on = 0
+	name = "Mix to Distro"
 	},
 /turf/open/floor/plasteel/yellow/side{
 	dir = 1
@@ -35059,10 +34959,8 @@
 /area/science/mixing)
 "bMm" = (
 /obj/machinery/igniter{
-	icon_state = "igniter0";
 	id = "toxigniter";
-	luminosity = 2;
-	on = 0
+	luminosity = 2
 	},
 /turf/open/floor/engine/vacuum,
 /area/science/mixing)
@@ -35507,7 +35405,6 @@
 	dir = 1
 	},
 /obj/item/radio/intercom{
-	dir = 0;
 	name = "Station Intercom (General)";
 	pixel_x = 27
 	},
@@ -35818,9 +35715,7 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/components/binary/pump{
-	dir = 0;
-	name = "Mix to Port";
-	on = 0
+	name = "Mix to Port"
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos)
@@ -35830,8 +35725,7 @@
 	},
 /obj/machinery/atmospherics/components/binary/pump{
 	dir = 1;
-	name = "Pure to Mix";
-	on = 0
+	name = "Pure to Mix"
 	},
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -35842,10 +35736,9 @@
 /obj/machinery/atmospherics/pipe/simple/cyan/visible{
 	dir = 4
 	},
-/obj/machinery/atmospherics/components/binary/pump{
+/obj/machinery/atmospherics/components/binary/pump/on{
 	dir = 1;
-	name = "Unfiltered to Mix";
-	on = 1
+	name = "Unfiltered to Mix"
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos)
@@ -36141,8 +36034,7 @@
 "bPe" = (
 /obj/machinery/atmospherics/components/binary/pump{
 	dir = 8;
-	name = "N2O Outlet Pump";
-	on = 0
+	name = "N2O Outlet Pump"
 	},
 /turf/open/floor/plasteel/yellow/side{
 	dir = 4
@@ -36368,7 +36260,6 @@
 /area/engine/atmos)
 "bPR" = (
 /obj/machinery/atmospherics/components/binary/pump/on{
-	dir = 0;
 	name = "Waste In"
 	},
 /turf/open/floor/plasteel,
@@ -36379,9 +36270,7 @@
 /area/engine/atmos)
 "bPT" = (
 /obj/machinery/atmospherics/components/binary/pump{
-	dir = 0;
-	name = "Air to Port";
-	on = 0
+	name = "Air to Port"
 	},
 /obj/machinery/light{
 	dir = 8
@@ -36393,9 +36282,7 @@
 /area/engine/atmos)
 "bPU" = (
 /obj/machinery/atmospherics/components/binary/pump{
-	dir = 0;
-	name = "Mix to Port";
-	on = 0
+	name = "Mix to Port"
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos)
@@ -36460,6 +36347,7 @@
 /area/chapel/asteroid/monastery)
 "bQe" = (
 /obj/item/flashlight/lantern{
+	icon_state = "lantern-on";
 	on = 1
 	},
 /turf/open/floor/plating/asteroid,
@@ -36732,9 +36620,8 @@
 	},
 /area/engine/atmos)
 "bQN" = (
-/obj/machinery/atmospherics/components/trinary/filter{
+/obj/machinery/atmospherics/components/trinary/filter/atmos/n2o{
 	dir = 1;
-	filter_type = "n2o";
 	on = 1
 	},
 /turf/open/floor/plasteel,
@@ -36888,7 +36775,6 @@
 	dir = 4
 	},
 /obj/item/radio/intercom{
-	dir = 0;
 	name = "Station Intercom (General)";
 	pixel_y = 26
 	},
@@ -37311,9 +37197,7 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
 "bSa" = (
-/obj/structure/plasticflaps{
-	opacity = 1
-	},
+/obj/structure/plasticflaps/opaque,
 /obj/effect/turf_decal/delivery,
 /obj/machinery/conveyor{
 	dir = 4;
@@ -37378,8 +37262,7 @@
 	},
 /obj/machinery/atmospherics/components/binary/pump{
 	dir = 8;
-	name = "Plasma Outlet Pump";
-	on = 0
+	name = "Plasma Outlet Pump"
 	},
 /turf/open/floor/plasteel/yellow/side{
 	dir = 4
@@ -37663,9 +37546,7 @@
 	dir = 8
 	},
 /obj/machinery/atmospherics/components/binary/pump{
-	dir = 0;
-	name = "Port to Filter";
-	on = 0
+	name = "Port to Filter"
 	},
 /obj/structure/extinguisher_cabinet{
 	pixel_x = -27
@@ -37757,10 +37638,9 @@
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
 "bTf" = (
-/obj/machinery/atmospherics/components/binary/pump{
+/obj/machinery/atmospherics/components/binary/pump/on{
 	dir = 2;
-	name = "Virology Waste to Space";
-	on = 1
+	name = "Virology Waste to Space"
 	},
 /turf/open/floor/plating{
 	icon_state = "platingdmg1"
@@ -37769,16 +37649,14 @@
 "bTg" = (
 /obj/machinery/atmospherics/components/binary/pump{
 	dir = 2;
-	name = "Virology Waste to Atmospherics";
-	on = 0
+	name = "Virology Waste to Atmospherics"
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
 "bTh" = (
-/obj/machinery/atmospherics/components/binary/pump{
+/obj/machinery/atmospherics/components/binary/pump/on{
 	dir = 1;
-	name = "Air Out";
-	on = 1
+	name = "Air Out"
 	},
 /turf/open/floor/plating{
 	icon_state = "platingdmg3"
@@ -38072,7 +37950,6 @@
 	dir = 4
 	},
 /obj/item/radio/intercom{
-	dir = 0;
 	name = "Station Intercom (General)";
 	pixel_x = 30;
 	pixel_y = 26
@@ -38116,8 +37993,7 @@
 "bTR" = (
 /obj/machinery/atmospherics/components/binary/pump{
 	dir = 8;
-	name = "Port to Filter";
-	on = 0
+	name = "Port to Filter"
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos)
@@ -38133,9 +38009,8 @@
 /turf/open/floor/plasteel,
 /area/engine/atmos)
 "bTU" = (
-/obj/machinery/atmospherics/components/trinary/filter{
+/obj/machinery/atmospherics/components/trinary/filter/atmos/plasma{
 	dir = 1;
-	filter_type = "plasma";
 	on = 1
 	},
 /turf/open/floor/plasteel,
@@ -38272,7 +38147,6 @@
 	dir = 6
 	},
 /obj/item/radio/intercom{
-	dir = 0;
 	name = "Station Intercom (General)";
 	pixel_y = 24
 	},
@@ -38994,7 +38868,6 @@
 /area/engine/break_room)
 "bVV" = (
 /obj/machinery/atmospherics/components/binary/pump{
-	dir = 0;
 	name = "Waste to Space"
 	},
 /turf/open/floor/plasteel,
@@ -40203,7 +40076,6 @@
 	dir = 4
 	},
 /obj/item/radio/intercom{
-	dir = 0;
 	name = "Station Intercom (General)";
 	pixel_y = 26
 	},
@@ -40375,7 +40247,6 @@
 	dir = 1
 	},
 /obj/item/radio/intercom{
-	dir = 0;
 	name = "Station Intercom (General)";
 	pixel_y = 26
 	},
@@ -41456,6 +41327,7 @@
 /area/chapel/main/monastery)
 "ccL" = (
 /obj/item/flashlight/lantern{
+	icon_state = "lantern-on";
 	on = 1
 	},
 /turf/open/floor/plasteel/asteroid{
@@ -42122,7 +41994,6 @@
 	layer = 4;
 	name = "Telecomms Telescreen";
 	network = list("tcomm");
-	pixel_x = 0;
 	pixel_y = 28
 	},
 /obj/structure/disposalpipe/segment{
@@ -42550,7 +42421,6 @@
 /obj/effect/mapping_helpers/airlock/cyclelink_helper,
 /obj/machinery/door/airlock/external{
 	name = "Engineering External Access";
-	req_access = null;
 	req_access_txt = "61"
 	},
 /obj/structure/cable{
@@ -42800,7 +42670,6 @@
 	},
 /obj/machinery/door/airlock/external{
 	name = "Engineering External Access";
-	req_access = null;
 	req_access_txt = "61"
 	},
 /obj/structure/cable{
@@ -42843,7 +42712,6 @@
 	},
 /obj/effect/decal/cleanable/cobweb,
 /obj/item/radio/intercom{
-	dir = 0;
 	name = "Station Intercom (General)";
 	pixel_y = 26
 	},
@@ -43024,7 +42892,6 @@
 /area/engine/engineering)
 "civ" = (
 /obj/effect/turf_decal/stripes/end{
-	icon_state = "warn_end";
 	dir = 4
 	},
 /obj/machinery/light{
@@ -43320,7 +43187,6 @@
 	icon_state = "plant-22"
 	},
 /obj/item/radio/intercom{
-	dir = 0;
 	name = "Station Intercom (General)";
 	pixel_y = 26
 	},
@@ -43706,6 +43572,7 @@
 /area/library)
 "clj" = (
 /obj/item/flashlight/lantern{
+	icon_state = "lantern-on";
 	on = 1
 	},
 /turf/open/floor/plating/asteroid/airless,
@@ -43750,7 +43617,6 @@
 /obj/effect/mapping_helpers/airlock/cyclelink_helper,
 /obj/machinery/door/airlock/external{
 	name = "Telecommunications External Access";
-	req_access = null;
 	req_access_txt = "61"
 	},
 /obj/structure/cable{
@@ -43804,7 +43670,6 @@
 	},
 /obj/machinery/door/airlock/external{
 	name = "Telecommunications External Access";
-	req_access = null;
 	req_access_txt = "61"
 	},
 /obj/structure/cable{
@@ -43816,10 +43681,9 @@
 /turf/closed/wall,
 /area/tcommsat/computer)
 "clM" = (
-/obj/machinery/atmospherics/components/binary/pump{
+/obj/machinery/atmospherics/components/binary/pump/on{
 	dir = 1;
-	name = "Waste to Space";
-	on = 1
+	name = "Waste to Space"
 	},
 /turf/open/floor/plating,
 /area/tcommsat/computer)
@@ -45453,7 +45317,6 @@
 /area/chapel/main/monastery)
 "csn" = (
 /obj/item/radio/intercom{
-	dir = 0;
 	name = "Station Intercom (General)";
 	pixel_y = 26
 	},
@@ -45663,7 +45526,6 @@
 /area/chapel/main/monastery)
 "ctr" = (
 /turf/open/floor/plasteel/darkyellow/corner{
-	icon_state = "darkyellowcorners";
 	dir = 4
 	},
 /area/chapel/office)
@@ -45672,7 +45534,6 @@
 	dir = 1
 	},
 /turf/open/floor/plasteel/darkyellow/corner{
-	icon_state = "darkyellowcorners";
 	dir = 4
 	},
 /area/chapel/office)
@@ -45681,7 +45542,6 @@
 	dir = 2
 	},
 /turf/open/floor/plasteel/darkyellow/corner{
-	icon_state = "darkyellowcorners";
 	dir = 4
 	},
 /area/chapel/office)
@@ -46982,6 +46842,7 @@
 /obj/structure/table/wood/fancy,
 /obj/item/flashlight/lantern{
 	on = 1;
+	icon_state = "lantern-on";
 	pixel_y = 8
 	},
 /turf/open/floor/carpet,
@@ -47163,7 +47024,6 @@
 "cAC" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/structure/chair/wood/wings{
-	icon_state = "wooden_chair_wings";
 	dir = 1
 	},
 /turf/open/floor/plasteel/dark,
@@ -47171,7 +47031,6 @@
 "cAD" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/structure/chair/wood/wings{
-	icon_state = "wooden_chair_wings";
 	dir = 1
 	},
 /obj/effect/landmark/start/librarian,
@@ -47264,7 +47123,6 @@
 /obj/structure/table,
 /obj/item/lighter,
 /obj/structure/light_construct/small{
-	icon_state = "bulb-construct-stage1";
 	dir = 8
 	},
 /turf/open/floor/plating,
@@ -47756,8 +47614,6 @@
 	},
 /obj/structure/sign/directions/evac{
 	dir = 1;
-	icon_state = "direction_evac";
-	pixel_x = 0;
 	pixel_y = 32
 	},
 /obj/structure/cable{
@@ -48079,7 +47935,6 @@
 /area/space/nearstation)
 "epJ" = (
 /obj/structure/sign/poster/contraband/random{
-	pixel_x = 0;
 	pixel_y = 32
 	},
 /turf/open/floor/carpet,
@@ -48741,7 +48596,6 @@
 /area/maintenance/department/crew_quarters/dorms)
 "gnq" = (
 /obj/item/radio/intercom{
-	dir = 0;
 	name = "Station Intercom (General)";
 	pixel_x = -27
 	},
@@ -48804,7 +48658,6 @@
 	pixel_x = -32
 	},
 /obj/structure/light_construct/small{
-	icon_state = "bulb-construct-stage1";
 	dir = 8
 	},
 /obj/structure/chair/comfy/black{
@@ -48850,7 +48703,6 @@
 /obj/structure/window/reinforced,
 /obj/structure/table/glass,
 /obj/item/radio/intercom{
-	dir = 0;
 	name = "Station Intercom (General)";
 	pixel_x = -28;
 	pixel_y = 3
@@ -48954,9 +48806,7 @@
 /turf/closed/wall,
 /area/science/mixing)
 "gMO" = (
-/obj/structure/plasticflaps{
-	opacity = 1
-	},
+/obj/structure/plasticflaps/opaque,
 /obj/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
@@ -48976,7 +48826,6 @@
 /obj/machinery/button/door{
 	id = "assistantshutters";
 	name = "Tool Storage Shutters Control";
-	pixel_x = 0;
 	pixel_y = 24;
 	req_access_txt = "10"
 	},
@@ -49080,8 +48929,7 @@
 	req_access_txt = "38"
 	},
 /obj/machinery/light_switch{
-	pixel_x = 24;
-	pixel_y = 0
+	pixel_x = 24
 	},
 /turf/open/floor/wood,
 /area/lawoffice)
@@ -49092,7 +48940,6 @@
 /obj/machinery/button/door{
 	id = "assistantshutters";
 	name = "Tool Storage Shutters Control";
-	pixel_x = 0;
 	pixel_y = 24;
 	req_access_txt = "10"
 	},
@@ -49161,7 +49008,6 @@
 	},
 /obj/machinery/door/airlock/external{
 	name = "Solar Maintenance";
-	req_access = null;
 	req_access_txt = "10; 13"
 	},
 /turf/open/floor/plating,
@@ -49233,7 +49079,6 @@
 	id = "xenobiomain";
 	name = "Containment Blast Doors";
 	pixel_x = 28;
-	pixel_y = 0;
 	req_access_txt = "55"
 	},
 /turf/open/floor/plasteel,
@@ -49275,8 +49120,7 @@
 	},
 /obj/structure/mirror{
 	icon_state = "mirror_broke";
-	pixel_y = 28;
-	broken = 1
+	pixel_y = 28
 	},
 /obj/machinery/light/small{
 	dir = 1;
@@ -49422,7 +49266,6 @@
 	dir = 4
 	},
 /obj/structure/sign/departments/xenobio{
-	pixel_x = 0;
 	pixel_y = 32
 	},
 /turf/open/floor/plasteel/darkpurple/side{
@@ -49563,10 +49406,8 @@
 /area/science/xenobiology)
 "iPj" = (
 /obj/machinery/igniter{
-	icon_state = "igniter0";
 	id = "xenoigniter";
-	luminosity = 2;
-	on = 0
+	luminosity = 2
 	},
 /turf/open/floor/engine,
 /area/science/xenobiology)
@@ -49980,8 +49821,7 @@
 "jYh" = (
 /obj/machinery/atmospherics/components/binary/pump{
 	dir = 4;
-	name = "Supply to Virology";
-	on = 0
+	name = "Supply to Virology"
 	},
 /turf/open/floor/plating{
 	icon_state = "platingdmg3"
@@ -50130,9 +49970,7 @@
 	},
 /area/hallway/secondary/exit/departure_lounge)
 "kCc" = (
-/obj/structure/plasticflaps{
-	opacity = 1
-	},
+/obj/structure/plasticflaps/opaque,
 /obj/machinery/conveyor{
 	dir = 8;
 	id = "EngLoad"
@@ -50582,7 +50420,6 @@
 /area/maintenance/department/science)
 "lWH" = (
 /obj/item/radio/intercom{
-	dir = 0;
 	name = "Station Intercom (General)";
 	pixel_x = -28
 	},
@@ -50940,8 +50777,6 @@
 "nfi" = (
 /obj/structure/sign/directions/evac{
 	dir = 1;
-	icon_state = "direction_evac";
-	pixel_x = 0;
 	pixel_y = 32
 	},
 /turf/open/floor/plasteel/escape{
@@ -50983,7 +50818,6 @@
 /obj/machinery/door/airlock/centcom{
 	name = "Crematorium";
 	opacity = 1;
-	req_access = null;
 	req_access_txt = "27"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -51092,7 +50926,6 @@
 	},
 /obj/machinery/door/airlock/external{
 	name = "Engineering External Access";
-	req_access = null;
 	req_access_txt = "10;13"
 	},
 /turf/open/floor/plating,
@@ -51428,7 +51261,6 @@
 	desc = "A remote control-switch for secure storage.";
 	id = "Secure Storage";
 	name = "Engineering Secure Storage";
-	pixel_x = 0;
 	pixel_y = -24;
 	req_access_txt = "11"
 	},
@@ -51498,7 +51330,6 @@
 	},
 /obj/machinery/door/airlock/external{
 	name = "Solar Maintenance";
-	req_access = null;
 	req_access_txt = "10; 13"
 	},
 /turf/open/floor/plating,
@@ -51514,8 +51345,7 @@
 "oEG" = (
 /obj/structure/mirror{
 	icon_state = "mirror_broke";
-	pixel_y = 28;
-	broken = 1
+	pixel_y = 28
 	},
 /obj/item/shard{
 	icon_state = "medium"
@@ -51539,7 +51369,6 @@
 	},
 /obj/machinery/button/ignition{
 	id = "xenoigniter";
-	pixel_x = 0;
 	pixel_y = 7
 	},
 /turf/open/floor/plasteel,
@@ -51622,7 +51451,6 @@
 "oPy" = (
 /obj/machinery/door/airlock/external{
 	name = "Mining Dock Airlock";
-	req_access = null;
 	req_access_txt = "48"
 	},
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
@@ -51757,9 +51585,7 @@
 /turf/open/floor/engine,
 /area/science/xenobiology)
 "pdq" = (
-/obj/effect/decal/cleanable/oil{
-	icon_state = "floor5"
-	},
+/obj/effect/decal/cleanable/oil,
 /turf/open/floor/plating,
 /area/maintenance/department/security/brig)
 "pdW" = (
@@ -52037,8 +51863,7 @@
 	areastring = "/area/lawoffice";
 	dir = 8;
 	name = "Law Office APC";
-	pixel_x = -24;
-	pixel_y = 0
+	pixel_x = -24
 	},
 /obj/structure/cable,
 /turf/open/floor/wood,
@@ -52156,10 +51981,8 @@
 /turf/open/floor/plasteel/yellow/side,
 /area/engine/engineering)
 "qxq" = (
-/obj/machinery/atmospherics/components/binary/pump{
-	dir = 0;
-	name = "Air Out";
-	on = 1
+/obj/machinery/atmospherics/components/binary/pump/on{
+	name = "Air Out"
 	},
 /obj/machinery/light/small{
 	dir = 4
@@ -52626,7 +52449,6 @@
 	},
 /obj/machinery/door/airlock/external{
 	name = "Solar Maintenance";
-	req_access = null;
 	req_access_txt = "10; 13"
 	},
 /turf/open/floor/plating,
@@ -52642,7 +52464,6 @@
 	id = "shootshut";
 	name = "shutters control";
 	pixel_x = 28;
-	pixel_y = 0;
 	req_access_txt = "0"
 	},
 /obj/item/ammo_casing/shotgun/improvised,
@@ -52708,7 +52529,6 @@
 /obj/effect/mapping_helpers/airlock/cyclelink_helper,
 /obj/machinery/door/airlock/external{
 	name = "Engineering External Access";
-	req_access = null;
 	req_access_txt = "10;13"
 	},
 /turf/open/floor/plating,
@@ -52740,8 +52560,7 @@
 /obj/machinery/power/apc/highcap/fifteen_k{
 	dir = 8;
 	name = "Engineering APC";
-	pixel_x = -28;
-	pixel_y = 0
+	pixel_x = -28
 	},
 /obj/structure/cable{
 	icon_state = "0-2"
@@ -53002,11 +52821,9 @@
 /turf/open/floor/plasteel/dark,
 /area/science/xenobiology)
 "taT" = (
-/obj/machinery/atmospherics/components/unary/thermomachine/freezer{
+/obj/machinery/atmospherics/components/unary/thermomachine/freezer/on{
 	dir = 4;
-	name = "euthanization chamber freezer";
-	on = 1;
-	target_temperature = 80
+	name = "euthanization chamber freezer"
 	},
 /turf/open/floor/plasteel,
 /area/science/xenobiology)
@@ -53310,7 +53127,6 @@
 	id = "xenobiomain";
 	name = "Containment Blast Doors";
 	pixel_x = 28;
-	pixel_y = 0;
 	req_access_txt = "55"
 	},
 /turf/open/floor/plasteel,
@@ -53689,7 +53505,6 @@
 	icon_state = "floor5"
 	},
 /obj/structure/light_construct/small{
-	icon_state = "bulb-construct-stage1";
 	dir = 8
 	},
 /turf/open/floor/plasteel/dark,
@@ -54271,7 +54086,6 @@
 /obj/item/folder/red,
 /obj/item/clothing/glasses/sunglasses,
 /obj/item/radio/intercom{
-	dir = 0;
 	name = "Station Intercom (General)";
 	pixel_x = 27
 	},
@@ -54417,7 +54231,6 @@
 /area/maintenance/department/engine)
 "xjK" = (
 /obj/item/radio/intercom{
-	dir = 0;
 	name = "Station Intercom (General)";
 	pixel_x = -27
 	},
@@ -54624,7 +54437,6 @@
 "xOC" = (
 /obj/machinery/door/airlock/external{
 	name = "Construction Zone";
-	req_access = null;
 	req_access_txt = "0";
 	req_one_access_txt = "0"
 	},
@@ -54652,9 +54464,7 @@
 /turf/open/floor/plasteel/freezer,
 /area/storage/emergency/port)
 "xSX" = (
-/obj/machinery/airalarm{
-	frequency = 1439;
-	locked = 0;
+/obj/machinery/airalarm/unlocked{
 	pixel_y = 23
 	},
 /turf/open/floor/plasteel/dark,

--- a/_maps/map_files/generic/CentCom.dmm
+++ b/_maps/map_files/generic/CentCom.dmm
@@ -4635,9 +4635,7 @@
 /turf/open/floor/plasteel/brown,
 /area/centcom/supply)
 "no" = (
-/obj/structure/plasticflaps{
-	opacity = 1
-	},
+/obj/structure/plasticflaps/opaque,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/delivery,
 /turf/open/floor/plasteel,
@@ -5171,9 +5169,7 @@
 /area/centcom/ferry)
 "oC" = (
 /obj/structure/chair/comfy/brown{
-	color = "#c45c57";
-	dir = 4;
-	icon_state = "comfychair"
+	dir = 4
 	},
 /turf/open/floor/plasteel/grimy,
 /area/centcom/ferry)
@@ -5205,9 +5201,7 @@
 /area/centcom/ferry)
 "oH" = (
 /obj/structure/chair/comfy/brown{
-	color = "#c45c57";
-	dir = 8;
-	icon_state = "comfychair"
+	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 6
@@ -5380,9 +5374,7 @@
 /area/centcom/ferry)
 "pb" = (
 /obj/structure/chair/comfy/brown{
-	color = "#c45c57";
-	dir = 8;
-	icon_state = "comfychair"
+	dir = 8
 	},
 /turf/open/floor/plasteel/grimy,
 /area/centcom/ferry)
@@ -7697,14 +7689,12 @@
 /area/wizard_station)
 "vk" = (
 /obj/structure/chair/wood/wings{
-	icon_state = "wooden_chair_wings";
 	dir = 1
 	},
 /turf/open/floor/wood,
 /area/wizard_station)
 "vl" = (
 /obj/structure/chair/wood/wings{
-	icon_state = "wooden_chair_wings";
 	dir = 4
 	},
 /turf/open/floor/carpet,
@@ -7716,7 +7706,6 @@
 /area/wizard_station)
 "vn" = (
 /obj/structure/chair/wood/wings{
-	icon_state = "wooden_chair_wings";
 	dir = 8
 	},
 /turf/open/floor/carpet,
@@ -8009,7 +7998,6 @@
 /area/wizard_station)
 "wd" = (
 /obj/structure/chair/wood/wings{
-	icon_state = "wooden_chair_wings";
 	dir = 1
 	},
 /turf/open/floor/carpet,
@@ -8217,7 +8205,6 @@
 /area/centcom/evac)
 "wM" = (
 /obj/structure/chair/wood/wings{
-	icon_state = "wooden_chair_wings";
 	dir = 8
 	},
 /turf/open/floor/wood,
@@ -8972,11 +8959,8 @@
 /area/centcom/ferry)
 "zj" = (
 /obj/structure/closet/secure_closet/ertCom,
-/obj/structure/sign/directions/engineering{
-	desc = "A direction sign, pointing out which way the Command department is.";
+/obj/structure/sign/directions/command{
 	dir = 2;
-	icon_state = "direction_bridge";
-	name = "command department";
 	pixel_y = 24
 	},
 /obj/effect/turf_decal/stripes/line,
@@ -9478,7 +9462,6 @@
 /area/abductor_ship)
 "Bf" = (
 /obj/structure/chair/wood/wings{
-	icon_state = "wooden_chair_wings";
 	dir = 1
 	},
 /turf/open/floor/engine/cult,

--- a/_maps/shuttles/emergency_raven.dmm
+++ b/_maps/shuttles/emergency_raven.dmm
@@ -621,8 +621,7 @@
 /area/shuttle/escape)
 "bF" = (
 /turf/open/floor/plasteel/darkgreen/side{
-	dir = 9;
-	icon_state = "darkgreen"
+	dir = 9
 	},
 /area/shuttle/escape)
 "bG" = (
@@ -642,8 +641,7 @@
 	pixel_y = -6
 	},
 /turf/open/floor/plasteel/darkgreen/side{
-	dir = 9;
-	icon_state = "darkgreen"
+	dir = 9
 	},
 /area/shuttle/escape)
 "bI" = (
@@ -791,8 +789,7 @@
 "bT" = (
 /obj/machinery/recharge_station,
 /turf/open/floor/plasteel/darkgreen/side{
-	dir = 9;
-	icon_state = "darkgreen"
+	dir = 9
 	},
 /area/shuttle/escape)
 "bU" = (
@@ -806,8 +803,7 @@
 	icon_state = "plant-22"
 	},
 /turf/open/floor/plasteel/darkgreen/side{
-	dir = 9;
-	icon_state = "darkgreen"
+	dir = 9
 	},
 /area/shuttle/escape)
 "bW" = (
@@ -884,8 +880,7 @@
 	dir = 8
 	},
 /turf/open/floor/plasteel/darkgreen/side{
-	dir = 9;
-	icon_state = "darkgreen"
+	dir = 9
 	},
 /area/shuttle/escape)
 "ci" = (

--- a/_maps/shuttles/pirate_default.dmm
+++ b/_maps/shuttles/pirate_default.dmm
@@ -72,8 +72,6 @@
 	req_access = null
 	},
 /obj/structure/chair{
-	tag = "icon-chair (WEST)";
-	icon_state = "chair";
 	dir = 8
 	},
 /obj/effect/decal/cleanable/dirt,
@@ -416,8 +414,6 @@
 	req_access = null
 	},
 /obj/structure/chair{
-	tag = "icon-chair (WEST)";
-	icon_state = "chair";
 	dir = 8
 	},
 /obj/effect/decal/cleanable/dirt,
@@ -1552,8 +1548,6 @@
 /obj/effect/turf_decal/stripes/corner,
 /obj/machinery/light/small,
 /turf/open/floor/plasteel/yellow/corner{
-	tag = "icon-yellowcorner (WEST)";
-	icon_state = "yellowcorner";
 	dir = 8
 	},
 /area/shuttle/pirate)

--- a/code/game/objects/effects/decals/cleanable.dm
+++ b/code/game/objects/effects/decals/cleanable.dm
@@ -9,7 +9,7 @@
 
 /obj/effect/decal/cleanable/Initialize(mapload, list/datum/disease/diseases)
 	. = ..()
-	if (random_icon_states && length(random_icon_states) > 0)
+	if (random_icon_states && (icon_state == initial(icon_state)) && length(random_icon_states) > 0)
 		icon_state = pick(random_icon_states)
 	create_reagents(300)
 	if(loc && isturf(loc))

--- a/code/game/objects/structures/plasticflaps.dm
+++ b/code/game/objects/structures/plasticflaps.dm
@@ -10,6 +10,9 @@
 	CanAtmosPass = ATMOS_PASS_NO
 	var/state = PLASTIC_FLAPS_NORMAL
 
+/obj/structure/plasticflaps/opaque
+	opacity = TRUE
+
 /obj/structure/plasticflaps/examine(mob/user)
 	. = ..()
 	switch(state)
@@ -103,4 +106,3 @@
 	. = ..()
 	if (oldloc)
 		oldloc.air_update_turf(1)
-		

--- a/code/modules/atmospherics/machinery/components/unary_devices/thermomachine.dm
+++ b/code/modules/atmospherics/machinery/components/unary_devices/thermomachine.dm
@@ -164,11 +164,11 @@
 	max_temperature = T20C
 	min_temperature = 170 //actual minimum temperature is defined by RefreshParts()
 	circuit = /obj/item/circuitboard/machine/thermomachine/freezer
-	
+
 /obj/machinery/atmospherics/components/unary/thermomachine/freezer/on
 	on = TRUE
 	icon_state = "freezer_1"
-	
+
 /obj/machinery/atmospherics/components/unary/thermomachine/freezer/on/Initialize()
 	. = ..()
 	if(target_temperature == initial(target_temperature))
@@ -193,7 +193,7 @@
 /obj/machinery/atmospherics/components/unary/thermomachine/heater/on
 	on = TRUE
 	icon_state = "heater_1"
-	
+
 /obj/machinery/atmospherics/components/unary/thermomachine/heater/RefreshParts()
 	..()
 	var/L


### PR DESCRIPTION
Fixes some travis warnings that were recently introduced.

Also fixed cleanable decals with custom set icons reverting during Initialize()

