### PR TITLE
A reason for cargo to disarm anomaly cores.

### DIFF
--- a/code/modules/cargo/exports/parts.dm
+++ b/code/modules/cargo/exports/parts.dm
@@ -19,3 +19,8 @@
 	cost = 2000
 	unit_name = "deactivated alien deconstruction drone"
 	export_types = list(/obj/item/deactivated_swarmer)
+
+/datum/export/pyroclastic_anomaly
+	cost = 10000
+	unit_name = "A rare disarmed anomaly core"
+	export_types = list(/obj/effect/anomaly/pyro)


### PR DESCRIPTION
This will basically just add price tags to anomaly cores, the more dangerous they are to disarm, the more money they are worth. Just only have one core price set up right now but I'll get the rest done later.

:cl: davethwave
add: You can now sell anomaly cores
/:cl:

