### PR TITLE
Removes skewium from saferChems

### DIFF
--- a/code/modules/events/vent_clog.dm
+++ b/code/modules/events/vent_clog.dm
@@ -14,7 +14,7 @@
 	var/randomProbability = 1
 	var/reagentsAmount = 100
 	var/list/saferChems = list("water","carbon","flour","cleaner","nutriment","condensedcapsaicin","mushroomhallucinogen","lube","pink_glitter",
-						 "plantbgone","blood","charcoal","space_drugs","morphine","holywater","ethanol","hot_coco","sacid","mindbreaker","rotatium","skewium",
+						 "plantbgone","blood","charcoal","space_drugs","morphine","holywater","ethanol","hot_coco","sacid","mindbreaker","rotatium",
 						 "pax","laughter","concentrated_barbers_aid","colorful_reagent","dizzysolution","tiresolution","sodiumchloride","beer","hair_dye","sugar","white_glitter","growthserum")
 	//needs to be chemid unit checked at some point
 


### PR DESCRIPTION
:cl: Denton
balance: Skewium is much less likely to appear during the Clogged Vents event.
/:cl:

Everything else in saferChems is an annoyance at best, but nothing that disables you with absolute screen-flipping misery.
People on ~~Sybil~~ Bagil have told me that it can lag/freeze clients as well, but I don't have any data on that.