### PR TITLE
Removes gold requirement of Positronic brains.

### DIFF
--- a/code/modules/research/designs/medical_designs.dm
+++ b/code/modules/research/designs/medical_designs.dm
@@ -18,7 +18,7 @@
 	desc = "The latest in Artificial Intelligences."
 	id = "mmi_posi"
 	build_type = PROTOLATHE | MECHFAB
-	materials = list(MAT_METAL = 1700, MAT_GLASS = 1350, MAT_GOLD = 500) //Gold, because SWAG.
+	materials = list(MAT_METAL = 2000, MAT_GLASS = 2000)
 	construction_time = 75
 	build_path = /obj/item/mmi/posibrain
 	category = list("Misc", "Medical Designs")


### PR DESCRIPTION
This PR removes the gold requirement of building positronic brains, and increases the metal and glass requirement. This is because they are already quite a bit up the tech tree, and aren't build to often. Only really build some rounds.

:cl: Firecage
tweak: Removes gold cost from Positronic brains.
/:cl:
