### PR TITLE
Comms consoles don't update while viewing messages

### DIFF
--- a/code/game/machinery/computer/communications.dm
+++ b/code/game/machinery/computer/communications.dm
@@ -45,7 +45,7 @@
 
 /obj/machinery/computer/communications/process()
 	if(..())
-		if(state != STATE_STATUSDISPLAY && state != STATE_CALLSHUTTLE && state != STATE_PURCHASE)
+		if(state != STATE_STATUSDISPLAY && state != STATE_CALLSHUTTLE && state != STATE_PURCHASE && state != STATE_VIEWMESSAGE)
 			updateDialog()
 
 /obj/machinery/computer/communications/Topic(href, href_list)


### PR DESCRIPTION
:cl: Nichlas0010
fix: Comms consoles won't update while viewing messages
/:cl:

[why]: # They currently update every few seconds, meaning your scrollbar gets reset to the top, so you can't read long messages such as the blue-alert report.
