### PR TITLE
Changes default button for BoH confirmation prompt

### DIFF
--- a/code/datums/components/storage/concrete/bag_of_holding.dm
+++ b/code/datums/components/storage/concrete/bag_of_holding.dm
@@ -6,7 +6,7 @@
 			user.visible_message("<span class='warning'>An unseen force knocks [user] to the ground!</span>", "<span class='big_brass'>\"I think not!\"</span>")
 			user.Knockdown(60)
 			return
-		var/safety = alert(user, "Doing this will have extremely dire consequences for the station and its crew. Be sure you know what you're doing.", "Put in [A.name]?", "Proceed", "Abort")
+		var/safety = alert(user, "Doing this will have extremely dire consequences for the station and its crew. Be sure you know what you're doing.", "Put in [A.name]?", "Abort", "Proceed")
 		if(safety == "Abort" || !in_range(A, user) || !A || !W || user.incapacitated())
 			return
 		A.investigate_log("has become a singularity. Caused by [user.key]", INVESTIGATE_SINGULO)


### PR DESCRIPTION
Everything must burn.

:cl: Dax Dupont
tweak: The BoH dialog now has Abort instead of Proceed as an default option.
/:cl:

[why]: Should prevent accidental activations.
