### PR TITLE
Fixes some issues with pacifism by disabling intent auto-switch

### DIFF
--- a/code/modules/mob/living/carbon/human/life.dm
+++ b/code/modules/mob/living/carbon/human/life.dm
@@ -61,10 +61,6 @@
 	else if(eye_blurry)			//blurry eyes heal slowly
 		adjust_blurriness(-1)
 
-	if(has_trait(TRAIT_PACIFISM) && a_intent == INTENT_HARM)
-		to_chat(src, "<span class='notice'>You don't feel like harming anybody.</span>")
-		a_intent_change(INTENT_HELP)
-
 	if (getBrainLoss() >= 60 && !incapacitated(TRUE))
 		SendSignal(COMSIG_ADD_MOOD_EVENT, "brain_damage", /datum/mood_event/brain_damage)
 		if(prob(3))

--- a/code/modules/mob/living/life.dm
+++ b/code/modules/mob/living/life.dm
@@ -133,9 +133,6 @@
 		eye_blurry = max(eye_blurry-1, 0)
 		if(client && !eye_blurry)
 			clear_fullscreen("blurry")
-	if(has_trait(TRAIT_PACIFISM) && a_intent == INTENT_HARM)
-		to_chat(src, "<span class='notice'>You don't feel like harming anybody.</span>")
-		a_intent_change(INTENT_HELP)
 
 /mob/living/proc/update_damage_hud()
 	return


### PR DESCRIPTION
:cl: Mickyan
fix: Pacifists can now use harm intent for actions that require it (but still can't harm!)
/:cl:

I checked with XDTM who made the code for this and he agreed this could be removed on the basis that:

1. It's redundant, there's already checks for harmful actions and this was more of a safety net
2. Can be bypassed by spamming intent switch anyway
3. Causes some issues (chat spam for zombies #36669) and makes some actions that require harm intent impossible (breaking tables, splashing containers on the ground)