### PR TITLE
Fix some issues with family heirloom spawning

### DIFF
--- a/code/datums/traits/negative.dm
+++ b/code/datums/traits/negative.dm
@@ -27,11 +27,11 @@
 
 /datum/quirk/family_heirloom
 	name = "Family Heirloom"
-	desc = "You are the current owner of an heirloom. passed down for generations. You have to keep it safe!"
+	desc = "You are the current owner of an heirloom, passed down for generations. You have to keep it safe!"
 	value = -1
 	mood_quirk = TRUE
 	var/obj/item/heirloom
-	var/where_text
+	var/where
 
 /datum/quirk/family_heirloom/on_spawn()
 	var/mob/living/carbon/human/H = quirk_holder
@@ -58,19 +58,18 @@
 		/obj/item/dice/d20)
 	heirloom = new heirloom_type(get_turf(quirk_holder))
 	var/list/slots = list(
-		"in your backpack" = SLOT_IN_BACKPACK,
 		"in your left pocket" = SLOT_L_STORE,
-		"in your right pocket" = SLOT_R_STORE
+		"in your right pocket" = SLOT_R_STORE,
+		"in your backpack" = SLOT_IN_BACKPACK
 	)
-	var/where = H.equip_in_one_of_slots(heirloom, slots)
-	if(!where)
-		where = "at your feet"
-	else if(where == "in your backpack")
-		H.back.SendSignal(COMSIG_TRY_STORAGE_SHOW, H)
-	where_text = "<span class='boldnotice'>There is a precious family [heirloom.name] [where], passed down from generation to generation. Keep it safe!</span>"
+	where = H.equip_in_one_of_slots(heirloom, slots, FALSE) || "at your feet"
 
 /datum/quirk/family_heirloom/post_add()
-	to_chat(quirk_holder, where_text)
+	if(where == "in your backpack")
+		var/mob/living/carbon/human/H = quirk_holder
+		H.back.SendSignal(COMSIG_TRY_STORAGE_SHOW, H)
+
+	to_chat(quirk_holder, "<span class='boldnotice'>There is a precious family [heirloom.name] [where], passed down from generation to generation. Keep it safe!</span>")
 	var/list/family_name = splittext(quirk_holder.real_name, " ")
 	heirloom.name = "\improper [family_name[family_name.len]] family [heirloom.name]"
 


### PR DESCRIPTION
:cl:
fix: Family heirlooms which can fit in pockets will now spawn there.
fix: Family heirlooms which only fit in the backpack now show the backpack at roundstart.
fix: Family heirlooms which do not fit in the backpack are no longer gone forever.
/:cl:

Part two of #37754. Fixes item two on #36940.