### PR TITLE
Updates .357 ammo to have similar properties as .38 special

### DIFF
--- a/code/modules/projectiles/projectile/bullets/revolver.dm
+++ b/code/modules/projectiles/projectile/bullets/revolver.dm
@@ -23,3 +23,5 @@
 /obj/item/projectile/bullet/a357
 	name = ".357 bullet"
 	damage = 60
+	knockdown = 60
+	stamina = 50


### PR DESCRIPTION

[Changelogs]: 

:cl: yorii
balance: Updates .357 ammo to have similar properties as .38 special
/:cl:

[why]: Because it makes no sense for a .357 to be in any way weaker than a .38 Special seeing as it is a strictly stronger cartridge firing the same bullet in the same caliber.
