### PR TITLE
Updates .38 ammo to have similar properties as .357

### DIFF
--- a/code/modules/projectiles/projectile/bullets/revolver.dm
+++ b/code/modules/projectiles/projectile/bullets/revolver.dm
@@ -15,7 +15,6 @@
 /obj/item/projectile/bullet/c38
 	name = ".38 bullet"
 	damage = 15
-	knockdown = 60
 	stamina = 50
 
 // .357 (Syndie Revolver)


### PR DESCRIPTION
[Changelogs]:

:cl: imsxz
balance: Updates .357 ammo to have similar properties as .38 special
/:cl:

[why]: Because it makes no sense for a .38 to be in any way stronger than a .357 seeing as it is a strictly weaker cartridge firing the same bullet in the same caliber.