### PR TITLE
Fix construction behavior of hydroponics trays

### DIFF
--- a/code/game/machinery/constructable_frame.dm
+++ b/code/game/machinery/constructable_frame.dm
@@ -4,7 +4,7 @@
 	icon_state = "box_0"
 	density = TRUE
 	max_integrity = 250
-	var/obj/item/circuitboard/circuit = null
+	var/obj/item/circuitboard/machine/circuit = null
 	var/state = 1
 
 /obj/structure/frame/examine(user)
@@ -163,6 +163,13 @@
 				req_components = null
 				components = null
 				icon_state = "box_1"
+				return
+
+			if(istype(P, /obj/item/wrench) && !circuit.needs_anchored)
+				to_chat(user, "<span class='notice'>You start [anchored ? "un" : ""]securing [name]...</span>")
+				if(P.use_tool(src, user, 40, volume=75))
+					to_chat(user, "<span class='notice'>You [anchored ? "un" : ""]secure [name].</span>")
+					anchored = !anchored
 				return
 
 			if(istype(P, /obj/item/screwdriver))


### PR DESCRIPTION
:cl:
fix: Hydroponics trays can no longer be deconstructed with their panels closed or unanchored while irrigated.
tweak: Frames for machines which do not require being anchored can now be un/anchored after the circuit has been added.
/:cl:

Fixes #37931.