### PR TITLE
VR fix

### DIFF
--- a/code/modules/VR/vr_human.dm
+++ b/code/modules/VR/vr_human.dm
@@ -36,12 +36,13 @@
 /mob/living/carbon/human/virtual_reality/proc/revert_to_reality(deathchecks = TRUE)
 	if(real_mind && mind)
 		real_mind.current.ckey = ckey
-		if(deathchecks)
-			if(vr_sleeper)
-				if(vr_sleeper.you_die_in_the_game_you_die_for_real)
-					real_mind.current.death(0)
-				vr_sleeper.vr_human = null
-			vr_sleeper = null
+		real_mind.current.stop_sound_channel(CHANNEL_HEARTBEAT)
+		if(deathchecks && vr_sleeper)
+			if(vr_sleeper.you_die_in_the_game_you_die_for_real)
+				real_mind.current.death(0)
+	if(deathchecks && vr_sleeper)
+		vr_sleeper.vr_human = null
+		vr_sleeper = null
 	real_mind = null
 
 /datum/action/quit_vr


### PR DESCRIPTION
[Changelogs]: # (Your PR should contain a detailed changelog of notable changes, titled and categorized appropriately. This includes, new features, sprites, sounds, balance changes, admin tools, map edits, removals, big refactors, config changes, hosting changes and important fixes. An example changelog has been provided below for you to edit. If you need additional help, read https://github.com/tgstation/tgstation/wiki/Changelogs)

:cl: Dax Dupont
fix: Fixes race condition caused by exiting the body while dying in VR.
/:cl:

[why]: Dying with no active mind in VR would cause a lack of clean up, allowing people to connect to bodies which are dead and thus ghost out when they move.