### PR TITLE
Refresh mob views when atoms enter/exit storage

### DIFF
--- a/code/datums/components/storage/storage.dm
+++ b/code/datums/components/storage/storage.dm
@@ -87,7 +87,8 @@
 	RegisterSignal(COMSIG_ATOM_ATTACK_PAW, .proc/on_attack_hand)
 	RegisterSignal(COMSIG_ATOM_EMP_ACT, .proc/emp_act)
 	RegisterSignal(COMSIG_ATOM_ATTACK_GHOST, .proc/show_to_ghost)
-	RegisterSignal(COMSIG_ATOM_EXITED, .proc/_removal_reset)
+	RegisterSignal(COMSIG_ATOM_ENTERED, .proc/refresh_mob_views)
+	RegisterSignal(COMSIG_ATOM_EXITED, .proc/_remove_and_refresh)
 
 	RegisterSignal(COMSIG_ITEM_PRE_ATTACK, .proc/preattack_intercept)
 	RegisterSignal(COMSIG_ITEM_ATTACK_SELF, .proc/attack_self)
@@ -401,6 +402,10 @@
 	if(!istype(master))
 		return FALSE
 	return master._removal_reset(thing)
+
+/datum/component/storage/proc/_remove_and_refresh(atom/movable/thing)
+	_removal_reset(thing)
+	refresh_mob_views()
 
 //Call this proc to handle the removal of an item from the storage item. The item will be moved to the new_location target, if that is null it's being deleted
 /datum/component/storage/proc/remove_from_storage(atom/movable/AM, atom/new_location)

--- a/code/game/objects/items/devices/PDA/PDA.dm
+++ b/code/game/objects/items/devices/PDA/PDA.dm
@@ -743,7 +743,7 @@ GLOBAL_LIST_EMPTY(PDAs)
 			var/mob/M = loc
 			M.put_in_hands(inserted_item)
 		else
-			inserted_item.forceMove(get_turf(src))
+			inserted_item.forceMove(drop_location())
 		to_chat(usr, "<span class='notice'>You remove \the [inserted_item] from \the [src].</span>")
 		inserted_item = null
 		update_icon()


### PR DESCRIPTION
:cl:
fix: Removing an ID from a PDA in a backpack no longer hides the ID until something else updates.
/:cl:

Fixes #37893. Fixes #33388. @kevinz000 