### PR TITLE
Keep only the most recent airlock autoclose timer

### DIFF
--- a/code/game/machinery/doors/airlock.dm
+++ b/code/game/machinery/doors/airlock.dm
@@ -1070,10 +1070,8 @@
 	else
 		playsound(src.loc, 'sound/machines/airlockforced.ogg', 30, 1)
 
-	if(autoclose && normalspeed)
-		addtimer(CALLBACK(src, .proc/autoclose), 150)
-	else if(autoclose && !normalspeed)
-		addtimer(CALLBACK(src, .proc/autoclose), 15)
+	if(autoclose)
+		autoclose_in(normalspeed ? 150 : 15)
 
 	if(!density)
 		return TRUE
@@ -1106,7 +1104,7 @@
 	if(safe)
 		for(var/atom/movable/M in get_turf(src))
 			if(M.density && M != src) //something is blocking the door
-				addtimer(CALLBACK(src, .proc/autoclose), 60)
+				autoclose_in(60)
 				return
 
 	if(forced < 2)

--- a/code/game/machinery/doors/door.dm
+++ b/code/game/machinery/doors/door.dm
@@ -27,6 +27,7 @@
 	var/sub_door = FALSE // true if it's meant to go under another door.
 	var/closingLayer = CLOSED_DOOR_LAYER
 	var/autoclose = FALSE //does it automatically close after some time
+	var/autoclose_timer // ID of timer to prevent multiple queued autocloses
 	var/safe = TRUE //whether the door detects things and mobs in its way and reopen or crushes them.
 	var/locked = FALSE //whether the door is bolted or not.
 	var/assemblytype //the type of door frame to drop during deconstruction
@@ -274,7 +275,7 @@
 		for(var/atom/movable/M in get_turf(src))
 			if(M.density && M != src) //something is blocking the door
 				if(autoclose)
-					addtimer(CALLBACK(src, .proc/autoclose), 60)
+					autoclose_in(60)
 				return
 
 	operating = TRUE
@@ -325,6 +326,10 @@
 /obj/machinery/door/proc/autoclose()
 	if(!QDELETED(src) && !density && !operating && !locked && !welded && autoclose)
 		close()
+
+/obj/machinery/door/proc/autoclose_in(wait)
+	deltimer(autoclose_timer)
+	autoclose_timer = addtimer(CALLBACK(src, .proc/autoclose), wait, TIMER_STOPPABLE)
 
 /obj/machinery/door/proc/requiresID()
 	return 1

--- a/code/game/machinery/doors/door.dm
+++ b/code/game/machinery/doors/door.dm
@@ -27,7 +27,6 @@
 	var/sub_door = FALSE // true if it's meant to go under another door.
 	var/closingLayer = CLOSED_DOOR_LAYER
 	var/autoclose = FALSE //does it automatically close after some time
-	var/autoclose_timer // ID of timer to prevent multiple queued autocloses
 	var/safe = TRUE //whether the door detects things and mobs in its way and reopen or crushes them.
 	var/locked = FALSE //whether the door is bolted or not.
 	var/assemblytype //the type of door frame to drop during deconstruction
@@ -328,8 +327,7 @@
 		close()
 
 /obj/machinery/door/proc/autoclose_in(wait)
-	deltimer(autoclose_timer)
-	autoclose_timer = addtimer(CALLBACK(src, .proc/autoclose), wait, TIMER_STOPPABLE)
+	addtimer(CALLBACK(src, .proc/autoclose), wait, TIMER_UNIQUE | TIMER_NO_HASH_WAIT | TIMER_OVERRIDE)
 
 /obj/machinery/door/proc/requiresID()
 	return 1


### PR DESCRIPTION
:cl:
fix: Opening and closing airlocks repeatedly no longer stacks queued autocloses.
/:cl:

This has been bothering me for weeks.