### PR TITLE
Fix some inconsistencies relating to resting

### DIFF
--- a/code/game/machinery/dance_machine.dm
+++ b/code/game/machinery/dance_machine.dm
@@ -376,8 +376,10 @@
 		sleep(speed)
 		for(var/i in 1 to speed)
 			M.setDir(pick(GLOB.cardinals))
+			// update resting manually to avoid chat spam
 			for(var/mob/living/carbon/NS in rangers)
-				NS.lay_down(TRUE)		//specifically excludes silicons to prevent pAI chat spam
+				NS.resting = !NS.resting
+				NS.update_canmove()
 		 time--
 
 /obj/machinery/jukebox/disco/proc/dance5(var/mob/living/M)

--- a/code/game/objects/structures/tables_racks.dm
+++ b/code/game/objects/structures/tables_racks.dm
@@ -101,7 +101,8 @@
 
 /obj/structure/table/proc/tableplace(mob/living/user, mob/living/pushed_mob)
 	pushed_mob.forceMove(src.loc)
-	pushed_mob.lay_down()
+	pushed_mob.resting = TRUE
+	pushed_mob.update_canmove()
 	pushed_mob.visible_message("<span class='notice'>[user] places [pushed_mob] onto [src].</span>", \
 								"<span class='notice'>[user] places [pushed_mob] onto [src].</span>")
 	add_logs(user, pushed_mob, "placed")


### PR DESCRIPTION
:cl:
fix: Non-harmfully placing someone who is resting on a table no longer makes them get up.
fix: The disco machine no longer lags the chat by spamming "You are now resting!" messages.
/:cl:

Fixes #37068.