### PR TITLE
Fixes gulag teleporter runtime, now automatically sets the default goal of an ID

### DIFF
--- a/code/game/machinery/computer/gulag_teleporter.dm
+++ b/code/game/machinery/computer/gulag_teleporter.dm
@@ -140,14 +140,22 @@
 	return locate(/obj/structure/gulag_beacon)
 
 /obj/machinery/computer/gulag_teleporter_computer/proc/teleport(mob/user)
-	log_game("[user]([user.ckey] teleported [prisoner]([prisoner.ckey]) to the Labor Camp ([beacon.x], [beacon.y], [beacon.z]) for [id.goal] points.")
+	if(!id) //incase the ID was removed after the transfer timer was set.
+		say("Warning: Unable to transfer prisoner without a valid Prisoner ID inserted!")
+		return
+	var/id_goal_not_set
+	if(!id.goal)
+		id_goal_not_set = TRUE
+		id.goal = default_goal
+		say("[id]'s ID card goal defaulting to [id.goal] points.")
+	log_game("[user]([user.ckey] teleported [prisoner]([prisoner.ckey]) to the Labor Camp ([beacon.x], [beacon.y], [beacon.z]) for [id_goal_not_set ? "default goal of ":""][id.goal] points.")
 	teleporter.handle_prisoner(id, temporary_record)
-	playsound(loc, 'sound/weapons/emitter.ogg', 50, 1)
+	playsound(src, 'sound/weapons/emitter.ogg', 50, 1)
 	prisoner.forceMove(get_turf(beacon))
 	prisoner.Knockdown(40) // small travel dizziness
 	to_chat(prisoner, "<span class='warning'>The teleportation makes you a little dizzy.</span>")
-	new /obj/effect/particle_effect/sparks(prisoner.loc)
-	playsound(src.loc, "sparks", 50, 1)
+	new /obj/effect/particle_effect/sparks(get_turf(prisoner))
+	playsound(src, "sparks", 50, 1)
 	if(teleporter.locked)
 		teleporter.locked = FALSE
 	teleporter.toggle_open()


### PR DESCRIPTION
There was a brief window after initiating the transfer where the computer operator was capable of removing the ID, resulting in the process runtiming.

Also made it so that if the inserted ID doesn't have a goal set during teleport, it will default to... the default goal! 

:cl: ShizCalev
fix: Fixed a runtime with the gulag teleporter that could cause the process to fail if you removed the ID.
tweak: Not setting the goal of a prisoner's ID when teleporting them will now set the ID's goal to the default value (200 points at the time of this change.)
/:cl: