### PR TITLE
Unredden the input bar when the viewport is clicked

### DIFF
--- a/code/modules/client/client_procs.dm
+++ b/code/modules/client/client_procs.dm
@@ -680,6 +680,8 @@ GLOBAL_LIST_EMPTY(external_rsc_urls)
 		if (clicklimiter[SECOND_COUNT] > scl)
 			to_chat(src, "<span class='danger'>Your previous click was ignored because you've done too many in a second</span>")
 			return
+
+	winset(src, null, "input.background-color=[COLOR_INPUT_DISABLED]")
 	..()
 
 /client/proc/add_verbs_from_config()

--- a/code/modules/client/client_procs.dm
+++ b/code/modules/client/client_procs.dm
@@ -681,7 +681,12 @@ GLOBAL_LIST_EMPTY(external_rsc_urls)
 			to_chat(src, "<span class='danger'>Your previous click was ignored because you've done too many in a second</span>")
 			return
 
-	winset(src, null, "input.background-color=[COLOR_INPUT_DISABLED]")
+	if (prefs.hotkeys)
+		// If hotkey mode is enabled, then clicking the map will automatically
+		// unfocus the text bar. This removes the red color from the text bar
+		// so that the visual focus indicator matches reality.
+		winset(src, null, "input.background-color=[COLOR_INPUT_DISABLED]")
+
 	..()
 
 /client/proc/add_verbs_from_config()


### PR DESCRIPTION
:cl:
tweak: Clicking on the viewport to focus it no longer leaves the input bar red.
/:cl:

So, so tired of having to hit tab twice every time I connect to get the red color to go away.

Not 100% sure this proc is where this code belongs though.

~~DNM because I need to make this only happen in hotkey mode but I'm busy; in non-hotkey mode clicking the map actually does not defocus the input bar.~~