### PR TITLE
Field generators are now workable by silicons again... but not wirelessly

### DIFF
--- a/code/modules/power/singularity/field_generator.dm
+++ b/code/modules/power/singularity/field_generator.dm
@@ -64,10 +64,7 @@ field_generator power level display
 	if(active == FG_ONLINE)
 		calc_power()
 
-/obj/machinery/field/generator/attack_hand(mob/user)
-	. = ..()
-	if(.)
-		return
+/obj/machinery/field/generator/interact(mob/user)
 	if(state == FG_WELDED)
 		if(get_dist(src, user) <= 1)//Need to actually touch the thing to turn it on
 			if(active >= FG_CHARGING)


### PR DESCRIPTION
Why? Because there was an existing comment in the code that says it is specifically distance checked so you have to be next to it. If you don't want that there, we can argue balance on another PR, but this just fixes it not working at all.

---

:cl:
fix: Field generators are once again operable by adjacent cyborgs.
/:cl:

Fixes #37740.