### PR TITLE
Chasms no longer drop those buckled to undroppable objects

### DIFF
--- a/code/datums/components/chasm.dm
+++ b/code/datums/components/chasm.dm
@@ -64,8 +64,10 @@
 	if(is_type_in_typecache(AM, forbidden_types) || AM.throwing || AM.floating)
 		return FALSE
 	//Flies right over the chasm
-	if(isliving(AM))
+	if(ismob(AM))
 		var/mob/M = AM
+		if(M.buckled && (M.buckled.buckled != M) && !droppable(M.buckled))		//middle statement to prevent infinite loops just in case!
+			return FALSE
 		if(M.is_flying())
 			return FALSE
 	if(ishuman(AM))

--- a/code/datums/components/chasm.dm
+++ b/code/datums/components/chasm.dm
@@ -70,14 +70,14 @@
 			return FALSE
 		if(M.is_flying())
 			return FALSE
-	if(ishuman(AM))
-		var/mob/living/carbon/human/H = AM
-		if(istype(H.belt, /obj/item/wormhole_jaunter))
-			var/obj/item/wormhole_jaunter/J = H.belt
-			//To freak out any bystanders
-			H.visible_message("<span class='boldwarning'>[H] falls into [parent]!</span>")
-			J.chasm_react(H)
-			return FALSE
+		if(ishuman(AM))
+			var/mob/living/carbon/human/H = AM
+			if(istype(H.belt, /obj/item/wormhole_jaunter))
+				var/obj/item/wormhole_jaunter/J = H.belt
+				//To freak out any bystanders
+				H.visible_message("<span class='boldwarning'>[H] falls into [parent]!</span>")
+				J.chasm_react(H)
+				return FALSE
 	return TRUE
 
 /datum/component/chasm/proc/drop(atom/movable/AM)

--- a/code/datums/components/chasm.dm
+++ b/code/datums/components/chasm.dm
@@ -66,8 +66,10 @@
 	//Flies right over the chasm
 	if(ismob(AM))
 		var/mob/M = AM
-		if(M.buckled && (M.buckled.buckled != M) && !droppable(M.buckled))		//middle statement to prevent infinite loops just in case!
-			return FALSE
+		if(M.buckled)		//middle statement to prevent infinite loops just in case!
+			var/mob/buckled_to = M.buckled
+			if((!ismob(M.buckled) || (buckled_to.buckled != M)) && !droppable(M.buckled))
+				return FALSE
 		if(M.is_flying())
 			return FALSE
 		if(ishuman(AM))


### PR DESCRIPTION
:cl:
fix: Chasms no longer drop mobs buckled to undroppable mobs or objects.
/:cl:

Doesn't make sense.