### PR TITLE
Fix template preview being invisible on space turfs

### DIFF
--- a/code/modules/admin/verbs/map_template_loadverb.dm
+++ b/code/modules/admin/verbs/map_template_loadverb.dm
@@ -15,7 +15,9 @@
 
 	var/list/preview = list()
 	for(var/S in template.get_affected_turfs(T,centered = TRUE))
-		preview += image('icons/turf/overlays.dmi',S,"greenOverlay")
+		var/image/item = image('icons/turf/overlays.dmi',S,"greenOverlay")
+		item.plane = ABOVE_LIGHTING_PLANE
+		preview += item
 	usr.client.images += preview
 	if(alert(usr,"Confirm location.","Template Confirm","Yes","No") == "Yes")
 		if(template.load(T, centered = TRUE))


### PR DESCRIPTION
:cl:
fix: The green overlay indicating where a map template will be placed is no longer invisible on space turfs.
/:cl:

Fixes #27588. The bug part, anyways. The FR would require deeper map loader changes.