### PR TITLE
Fix wormhole jaunter grammar

### DIFF
--- a/code/modules/mining/equipment/wormhole_jaunter.dm
+++ b/code/modules/mining/equipment/wormhole_jaunter.dm
@@ -66,7 +66,7 @@
 
 /obj/item/wormhole_jaunter/proc/chasm_react(mob/user)
 	if(user.get_item_by_slot(SLOT_BELT) == src)
-		to_chat(user, "Your [src] activates, saving you from the chasm!</span>")
+		to_chat(user, "Your [name] activates, saving you from the chasm!</span>")
 		SSblackbox.record_feedback("tally", "jaunter", 1, "Chasm") // chasm automatic activation
 		activate(user, FALSE)
 	else


### PR DESCRIPTION
:cl:
spellcheck: Fix "Your the wormhole jaunter" when a wormhole jaunter saves you from a chasm.
/:cl: