### PR TITLE
Fix flipping of trinary pipe fittings and related RPD tooltips

### DIFF
--- a/code/game/machinery/pipe/construction.dm
+++ b/code/game/machinery/pipe/construction.dm
@@ -38,7 +38,7 @@ Buildable meters
 
 /obj/item/pipe/ComponentInitialize()
 	//Flipping handled manually due to custom handling for trinary pipes
-	AddComponent(/datum/component/simple_rotation,ROTATION_ALTCLICK | ROTATION_CLOCKWISE ,null,null, CALLBACK(src, .proc/fixdir))
+	AddComponent(/datum/component/simple_rotation, ROTATION_ALTCLICK | ROTATION_CLOCKWISE)
 
 /obj/item/pipe/Initialize(mapload, _pipe_type, _dir, obj/machinery/atmospherics/make_from)
 	if(make_from)
@@ -98,7 +98,6 @@ Buildable meters
 
 /obj/item/pipe/proc/do_a_flip()
 	setDir(turn(dir, -180))
-	fixdir()
 
 /obj/item/pipe/trinary/flippable/do_a_flip()
 	setDir(turn(dir, flipped ? 45 : -45))
@@ -109,31 +108,30 @@ Buildable meters
 	..()
 	setDir(old_dir) //pipes changing direction when moved is just annoying and buggy
 
-//Helper to clean up dir
-/obj/item/pipe/proc/fixdir()
-	return
+// Convert dir of fitting into dir of built component
+/obj/item/pipe/proc/fixed_dir()
+	return dir
 
-/obj/item/pipe/binary/fixdir()
+/obj/item/pipe/binary/fixed_dir()
+	. = dir
 	if(dir == SOUTH)
-		setDir(NORTH)
+		. = NORTH
 	else if(dir == WEST)
-		setDir(EAST)
+		. = EAST
 
-/obj/item/pipe/trinary/flippable/fixdir()
+/obj/item/pipe/trinary/flippable/fixed_dir()
+	. = dir
 	if(dir in GLOB.diagonals)
-		setDir(turn(dir, 45))
+		. = turn(dir, 45)
 
 /obj/item/pipe/attack_self(mob/user)
 	setDir(turn(dir,-90))
-	fixdir()
 
 /obj/item/pipe/wrench_act(mob/living/user, obj/item/wrench/W)
 	if(!isturf(loc))
 		return TRUE
 
 	add_fingerprint(user)
-
-	fixdir()
 
 	var/obj/machinery/atmospherics/fakeA = pipe_type
 	var/flags = initial(fakeA.pipe_flags)
@@ -143,7 +141,7 @@ Buildable meters
 			return TRUE
 		if((M.piping_layer != piping_layer) && !((M.pipe_flags | flags) & PIPING_ALL_LAYER)) //don't continue if either pipe goes across all layers
 			continue
-		if(M.GetInitDirections() & SSair.get_init_dirs(pipe_type, dir))	// matches at least one direction on either type of pipe
+		if(M.GetInitDirections() & SSair.get_init_dirs(pipe_type, fixed_dir()))	// matches at least one direction on either type of pipe
 			to_chat(user, "<span class='warning'>There is already a pipe at that location!</span>")
 			return TRUE
 	// no conflicts found
@@ -162,7 +160,7 @@ Buildable meters
 	qdel(src)
 
 /obj/item/pipe/proc/build_pipe(obj/machinery/atmospherics/A)
-	A.setDir(dir)
+	A.setDir(fixed_dir())
 	A.SetInitDirections()
 
 	if(pipename)

--- a/code/game/objects/items/RPD.dm
+++ b/code/game/objects/items/RPD.dm
@@ -100,12 +100,14 @@ GLOBAL_LIST_INIT(transit_tube_recipes, list(
 			if(dirtype == PIPE_BENDABLE)
 				dirs += list("[NORTHWEST]" = "West to North", "[NORTHEAST]" = "North to East",
 							 "[SOUTHWEST]" = "South to West", "[SOUTHEAST]" = "East to South")
-		if(PIPE_TRINARY, PIPE_TRIN_M)
+		if(PIPE_TRINARY)
 			dirs = list("[NORTH]" = "West South East", "[EAST]" = "North West South",
 						"[SOUTH]" = "East North West", "[WEST]" = "South East North")
-			if(dirtype == PIPE_TRIN_M)
-				dirs += list("[SOUTHEAST]" = "West South East", "[NORTHEAST]" = "North West South",
-							 "[NORTHWEST]" = "East North West", "[SOUTHWEST]" = "South East North")
+		if(PIPE_TRIN_M)
+			dirs = list("[NORTH]" = "North East South", "[EAST]" = "East South West",
+						"[SOUTH]" = "South West North", "[WEST]" = "West North East",
+						"[SOUTHEAST]" = "West South East", "[NORTHEAST]" = "South East North",
+						"[NORTHWEST]" = "East North West", "[SOUTHWEST]" = "North West South")
 		if(PIPE_UNARY)
 			dirs = list("[NORTH]" = "North", "[EAST]" = "East", "[SOUTH]" = "South", "[WEST]" = "West")
 		if(PIPE_ONEDIR)


### PR DESCRIPTION
:cl:
fix: Flipping and then rotating trinary pipe fittings no longer causes their icon to mismatch what they will become when wrenched.
fix: RPD tooltips for flippable trinary components have been corrected.
/:cl:

Fixes #32184.

`fixdir` appears to be meant to turn fitting `dir` into component dir but it's called on a regular basis which messes with the `dir` being used for display. This has been fixed.