### PR TITLE
Fix gravity in one of Moon Outpost 19's areas

### DIFF
--- a/code/modules/awaymissions/mission_code/moonoutpost19.dm
+++ b/code/modules/awaymissions/mission_code/moonoutpost19.dm
@@ -29,8 +29,7 @@
 
 /area/awaymission/moonoutpost19/hive
 	name = "The Hive"
-	always_unpowered = FALSE
-	has_gravity = FALSE
+	always_unpowered = TRUE
 	power_environ = FALSE
 	power_equip = FALSE
 	power_light = FALSE


### PR DESCRIPTION
Mistake introduced by #31512 as far as I can tell, this area is supposed to have gravity rather than not have it.