### PR TITLE
Adds departmental wardrobe vendors to all maps

### DIFF
--- a/_maps/map_files/Deltastation/DeltaStation2.dmm
+++ b/_maps/map_files/Deltastation/DeltaStation2.dmm
@@ -4866,7 +4866,7 @@
 /turf/open/floor/plasteel/grimy,
 /area/hallway/secondary/entry)
 "aqr" = (
-/obj/structure/closet/wardrobe/red,
+/obj/machinery/vending/wardrobe/sec_wardrobe,
 /obj/machinery/newscaster{
 	pixel_x = -32
 	},
@@ -7545,18 +7545,15 @@
 /turf/open/floor/plasteel/neutral,
 /area/janitor)
 "avA" = (
-/obj/vehicle/ridden/janicart,
 /obj/machinery/status_display{
 	pixel_y = 32
 	},
 /obj/effect/decal/cleanable/dirt,
-/obj/item/storage/bag/trash,
-/obj/item/key/janitor,
 /obj/effect/turf_decal/bot,
+/obj/machinery/vending/wardrobe/jani_wardrobe,
 /turf/open/floor/plasteel/neutral,
 /area/janitor)
 "avB" = (
-/obj/structure/closet/jcloset,
 /obj/machinery/power/apc{
 	dir = 1;
 	name = "Custodial Closet APC";
@@ -7566,9 +7563,10 @@
 /obj/structure/cable/white{
 	icon_state = "0-2"
 	},
-/obj/item/clothing/under/maid,
-/obj/item/clothing/shoes/laceup,
 /obj/effect/turf_decal/bot,
+/obj/vehicle/ridden/janicart,
+/obj/item/storage/bag/trash,
+/obj/item/key/janitor,
 /turf/open/floor/plasteel/neutral,
 /area/janitor)
 "avC" = (
@@ -11706,6 +11704,7 @@
 	pixel_y = 32
 	},
 /obj/item/storage/box/beanbag,
+/obj/item/gun/ballistic/revolver/doublebarrel,
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/bar)
 "aET" = (
@@ -14478,14 +14477,12 @@
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/bar)
 "aKv" = (
-/obj/structure/table/wood,
-/obj/item/gun/ballistic/revolver/doublebarrel,
+/obj/machinery/vending/wardrobe/bar_wardrobe,
 /turf/open/floor/plasteel/vault{
 	dir = 5
 	},
 /area/crew_quarters/bar)
 "aKw" = (
-/obj/structure/closet/gmcloset,
 /obj/item/wrench,
 /obj/item/stack/sheet/glass{
 	amount = 30
@@ -14496,6 +14493,7 @@
 /obj/item/stack/cable_coil/random,
 /obj/item/stack/cable_coil/random,
 /obj/machinery/light,
+/obj/structure/closet,
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/bar)
 "aKx" = (
@@ -21532,6 +21530,10 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
+/obj/machinery/airalarm{
+	dir = 1;
+	pixel_y = -22
+	},
 /turf/open/floor/plasteel/brown{
 	dir = 10
 	},
@@ -21555,11 +21557,7 @@
 /turf/open/floor/plasteel/brown,
 /area/quartermaster/storage)
 "aYV" = (
-/obj/structure/closet/wardrobe/cargotech,
-/obj/machinery/airalarm{
-	dir = 1;
-	pixel_y = -22
-	},
+/obj/machinery/vending/wardrobe/cargo_wardrobe,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
@@ -21567,7 +21565,6 @@
 /turf/open/floor/plasteel,
 /area/quartermaster/storage)
 "aYW" = (
-/obj/structure/closet/wardrobe/cargotech,
 /obj/machinery/ai_status_display{
 	pixel_y = -32
 	},
@@ -21575,6 +21572,7 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/bot,
+/obj/machinery/vending/wardrobe/cargo_wardrobe,
 /turf/open/floor/plasteel,
 /area/quartermaster/storage)
 "aYX" = (
@@ -22467,10 +22465,6 @@
 "baQ" = (
 /turf/closed/wall,
 /area/quartermaster/miningoffice)
-"baR" = (
-/obj/machinery/status_display,
-/turf/closed/wall,
-/area/quartermaster/miningoffice)
 "baS" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -22959,11 +22953,7 @@
 /turf/open/floor/plasteel,
 /area/hydroponics)
 "bbX" = (
-/obj/structure/closet/wardrobe/botanist,
-/obj/item/radio/intercom{
-	name = "Station Intercom";
-	pixel_y = 26
-	},
+/obj/machinery/vending/wardrobe/hydro_wardrobe,
 /obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel,
 /area/hydroponics)
@@ -22972,6 +22962,10 @@
 /obj/item/wrench,
 /obj/item/clothing/suit/apron,
 /obj/effect/turf_decal/bot,
+/obj/item/radio/intercom{
+	name = "Station Intercom";
+	pixel_y = 26
+	},
 /turf/open/floor/plasteel,
 /area/hydroponics)
 "bbZ" = (
@@ -23775,7 +23769,7 @@
 /turf/open/floor/plasteel/freezer,
 /area/crew_quarters/kitchen)
 "bdG" = (
-/obj/structure/closet/chefcloset,
+/obj/machinery/vending/wardrobe/chef_wardrobe,
 /obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel,
 /area/crew_quarters/kitchen)
@@ -24136,15 +24130,12 @@
 /turf/open/floor/plasteel,
 /area/engine/atmos)
 "beD" = (
-/obj/structure/closet/wardrobe/atmospherics_yellow,
+/obj/machinery/vending/wardrobe/atmos_wardrobe,
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/light{
 	dir = 4
 	},
-/obj/item/storage/backpack/satchel/eng,
 /obj/effect/turf_decal/bot,
-/obj/item/clothing/suit/hooded/wintercoat/engineering/atmos,
-/obj/item/clothing/suit/hooded/wintercoat/engineering/atmos,
 /turf/open/floor/plasteel,
 /area/engine/atmos)
 "beE" = (
@@ -49388,7 +49379,7 @@
 /turf/open/floor/wood,
 /area/lawoffice)
 "cdk" = (
-/obj/structure/closet/lawcloset,
+/obj/machinery/vending/wardrobe/law_wardrobe,
 /obj/machinery/firealarm{
 	dir = 4;
 	pixel_x = 24
@@ -52219,19 +52210,13 @@
 	},
 /area/security/brig)
 "ciK" = (
-/obj/structure/closet/wardrobe/red,
-/obj/item/clothing/under/rank/security/grey,
-/obj/item/clothing/under/rank/security/grey,
-/obj/item/clothing/under/rank/security/grey,
+/obj/machinery/vending/wardrobe/sec_wardrobe,
 /obj/structure/cable/white{
 	icon_state = "1-4"
 	},
-/obj/item/storage/backpack/satchel/sec,
 /obj/structure/sign/poster/official/do_not_question{
 	pixel_y = -32
 	},
-/obj/item/clothing/suit/hooded/wintercoat/security,
-/obj/item/clothing/suit/hooded/wintercoat/security,
 /turf/open/floor/plasteel/red,
 /area/security/brig)
 "ciL" = (
@@ -53688,11 +53673,8 @@
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "cmb" = (
-/obj/structure/closet/wardrobe/engineering_yellow,
-/obj/item/storage/backpack/satchel/eng,
+/obj/machinery/vending/wardrobe/engi_wardrobe,
 /obj/effect/turf_decal/delivery,
-/obj/item/clothing/suit/hooded/wintercoat/engineering,
-/obj/item/clothing/suit/hooded/wintercoat/engineering,
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "cmc" = (
@@ -58671,7 +58653,7 @@
 /turf/open/floor/plasteel/dark,
 /area/library)
 "cwv" = (
-/obj/structure/closet/wardrobe/curator,
+/obj/machinery/vending/wardrobe/curator_wardrobe,
 /turf/open/floor/plasteel/dark,
 /area/library)
 "cww" = (
@@ -67178,11 +67160,7 @@
 /turf/open/floor/plasteel/neutral/side,
 /area/medical/storage)
 "cNO" = (
-/obj/structure/closet/wardrobe/white/medical,
-/obj/structure/extinguisher_cabinet{
-	pixel_y = 32
-	},
-/obj/item/storage/backpack/satchel/med,
+/obj/machinery/vending/wardrobe/medi_wardrobe,
 /turf/open/floor/plasteel/neutral/side,
 /area/medical/storage)
 "cNP" = (
@@ -68452,11 +68430,10 @@
 /turf/open/floor/plasteel/vault/killroom,
 /area/science/xenobiology)
 "cQz" = (
-/obj/structure/closet/wardrobe/science_white,
+/obj/machinery/vending/wardrobe/science_wardrobe,
 /obj/machinery/light/small{
 	dir = 8
 	},
-/obj/item/storage/backpack/satchel/tox,
 /obj/effect/turf_decal/delivery,
 /turf/open/floor/plasteel,
 /area/science/research)
@@ -77682,14 +77659,10 @@
 /obj/structure/cable/white{
 	icon_state = "1-4"
 	},
-/obj/item/radio/intercom{
-	name = "Station Intercom";
-	pixel_y = -26
-	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
-/obj/structure/closet/secure_closet/chemical,
+/obj/machinery/vending/wardrobe/chem_wardrobe,
 /turf/open/floor/plasteel/whiteyellow/corner,
 /area/medical/chemistry)
 "dkl" = (
@@ -77697,11 +77670,16 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/light_switch{
-	pixel_x = 7;
+	pixel_x = 10;
 	pixel_y = -26
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
+	},
+/obj/item/radio/intercom{
+	name = "Station Intercom";
+	pixel_x = -6;
+	pixel_y = -26
 	},
 /turf/open/floor/plasteel/whiteyellow/corner,
 /area/medical/chemistry)
@@ -85652,7 +85630,7 @@
 /turf/open/floor/plasteel/whitepurple/corner,
 /area/medical/genetics)
 "dAU" = (
-/obj/structure/closet/wardrobe/genetics_white,
+/obj/machinery/vending/wardrobe/gene_wardrobe,
 /turf/open/floor/plasteel/whitepurple/corner,
 /area/medical/genetics)
 "dAV" = (
@@ -89518,7 +89496,7 @@
 /turf/open/floor/plasteel,
 /area/science/robotics/lab)
 "dIN" = (
-/obj/structure/closet/wardrobe/robotics_black,
+/obj/machinery/vending/wardrobe/robo_wardrobe,
 /obj/structure/window/reinforced{
 	dir = 4
 	},
@@ -89666,7 +89644,7 @@
 /turf/open/floor/plating,
 /area/maintenance/department/medical/morgue)
 "dJd" = (
-/obj/structure/closet/wardrobe/white/medical,
+/obj/machinery/vending/wardrobe/medi_wardrobe,
 /turf/open/floor/plating,
 /area/maintenance/department/medical/morgue)
 "dJe" = (
@@ -94736,8 +94714,7 @@
 	},
 /area/medical/virology)
 "dUb" = (
-/obj/structure/closet/wardrobe/virology_white,
-/obj/item/storage/backpack/satchel/vir,
+/obj/machinery/vending/wardrobe/viro_wardrobe,
 /turf/open/floor/plasteel/vault{
 	dir = 5
 	},
@@ -99112,6 +99089,10 @@
 	name = "Station Intercom";
 	pixel_x = -26
 	},
+/obj/machinery/airalarm{
+	dir = 2;
+	pixel_y = 22
+	},
 /turf/open/floor/plasteel/vault{
 	dir = 8
 	},
@@ -99135,6 +99116,12 @@
 /obj/structure/cable/white{
 	icon_state = "0-8"
 	},
+/obj/structure/table/wood,
+/obj/item/grown/log,
+/obj/item/grown/log,
+/obj/item/grown/log,
+/obj/item/grown/log,
+/obj/item/grown/log,
 /turf/open/floor/plasteel/grimy,
 /area/chapel/office)
 "eey" = (
@@ -99282,7 +99269,7 @@
 	},
 /area/security/checkpoint/escape)
 "eeM" = (
-/obj/structure/closet/wardrobe/red,
+/obj/machinery/vending/wardrobe/sec_wardrobe,
 /turf/open/floor/plasteel/red/side{
 	dir = 5
 	},
@@ -99745,16 +99732,7 @@
 /turf/open/floor/plasteel/grimy,
 /area/chapel/office)
 "ega" = (
-/obj/structure/closet/wardrobe/chaplain_black,
-/obj/machinery/airalarm{
-	dir = 1;
-	pixel_y = -22
-	},
-/obj/item/grown/log,
-/obj/item/grown/log,
-/obj/item/grown/log,
-/obj/item/grown/log,
-/obj/item/grown/log,
+/obj/machinery/vending/wardrobe/chap_wardrobe,
 /turf/open/floor/plasteel/vault{
 	dir = 8
 	},
@@ -143201,7 +143179,7 @@ aTZ
 aVH
 aXr
 aYR
-baR
+baQ
 bct
 bdW
 bfr

--- a/_maps/map_files/Deltastation/DeltaStation2.dmm
+++ b/_maps/map_files/Deltastation/DeltaStation2.dmm
@@ -135973,7 +135973,7 @@ aEP
 aGd
 aHu
 aIV
-aKv
+aKw
 aDL
 aNb
 aNd
@@ -136230,7 +136230,7 @@ aEQ
 aGe
 aHv
 aIW
-aKw
+aKv
 aDL
 aNc
 aOE

--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -7384,11 +7384,11 @@
 /obj/structure/reagent_dispensers/peppertank{
 	pixel_x = 32
 	},
-/obj/structure/closet/wardrobe/red,
 /obj/machinery/camera{
 	c_tag = "Security - Gear Room";
 	dir = 8
 	},
+/obj/machinery/vending/wardrobe/sec_wardrobe,
 /turf/open/floor/plasteel/showroomfloor,
 /area/security/warden)
 "apR" = (
@@ -18727,10 +18727,10 @@
 /turf/open/floor/wood,
 /area/lawoffice)
 "aOr" = (
-/obj/structure/closet/lawcloset,
 /obj/machinery/light_switch{
 	pixel_y = -28
 	},
+/obj/machinery/vending/wardrobe/law_wardrobe,
 /turf/open/floor/wood,
 /area/lawoffice)
 "aOs" = (
@@ -21826,7 +21826,7 @@
 /area/crew_quarters/dorms)
 "aUY" = (
 /obj/effect/turf_decal/delivery,
-/obj/structure/closet/wardrobe/engineering_yellow,
+/obj/machinery/vending/wardrobe/engi_wardrobe,
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "aUZ" = (
@@ -24389,18 +24389,18 @@
 /turf/open/floor/plasteel,
 /area/quartermaster/storage)
 "bar" = (
-/obj/structure/closet/wardrobe/cargotech,
 /obj/effect/turf_decal/stripes/line{
 	dir = 2
 	},
+/obj/machinery/vending/wardrobe/cargo_wardrobe,
 /turf/open/floor/plasteel,
 /area/quartermaster/storage)
 "bas" = (
-/obj/structure/closet/wardrobe/cargotech,
 /obj/structure/disposalpipe/segment,
 /obj/effect/turf_decal/stripes/line{
 	dir = 6
 	},
+/obj/machinery/vending/wardrobe/cargo_wardrobe,
 /turf/open/floor/plasteel,
 /area/quartermaster/storage)
 "bat" = (
@@ -25626,6 +25626,9 @@
 	pixel_x = -3;
 	pixel_y = 5
 	},
+/obj/machinery/light_switch{
+	pixel_y = 26
+	},
 /turf/open/floor/plasteel/red/side{
 	dir = 9
 	},
@@ -25693,6 +25696,10 @@
 	pixel_y = 30
 	},
 /obj/structure/closet/secure_closet/security,
+/obj/machinery/firealarm{
+	dir = 4;
+	pixel_x = 24
+	},
 /turf/open/floor/plasteel/red/side{
 	dir = 5
 	},
@@ -25922,10 +25929,10 @@
 /turf/open/floor/plasteel/floorgrime,
 /area/janitor)
 "bdD" = (
-/obj/structure/closet/jcloset,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 9
 	},
+/obj/machinery/vending/wardrobe/jani_wardrobe,
 /turf/open/floor/plasteel/floorgrime,
 /area/janitor)
 "bdE" = (
@@ -31279,6 +31286,9 @@
 	c_tag = "Bar - Backroom";
 	dir = 2
 	},
+/obj/structure/sink/kitchen{
+	pixel_y = 28
+	},
 /turf/open/floor/wood,
 /area/crew_quarters/bar)
 "boS" = (
@@ -31493,11 +31503,7 @@
 /turf/open/floor/plasteel/dark,
 /area/aisat)
 "bpt" = (
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = 24
-	},
-/obj/structure/closet/wardrobe/red,
+/obj/machinery/vending/wardrobe/sec_wardrobe,
 /turf/open/floor/plasteel/red/side{
 	dir = 6
 	},
@@ -32433,7 +32439,6 @@
 /obj/machinery/light/small{
 	dir = 8
 	},
-/obj/item/vending_refill/cigarette,
 /turf/open/floor/wood,
 /area/crew_quarters/bar)
 "brh" = (
@@ -33640,7 +33645,6 @@
 /obj/structure/disposalpipe/segment{
 	dir = 9
 	},
-/obj/structure/closet/gmcloset,
 /obj/item/wrench,
 /obj/item/stack/sheet/glass{
 	amount = 30
@@ -33650,6 +33654,8 @@
 	},
 /obj/item/stack/cable_coil/random,
 /obj/item/stack/cable_coil/random,
+/obj/structure/closet,
+/obj/item/vending_refill/cigarette,
 /turf/open/floor/wood,
 /area/crew_quarters/bar)
 "btr" = (
@@ -43930,17 +43936,17 @@
 /area/library)
 "bPW" = (
 /obj/structure/chair/comfy/brown,
+/obj/effect/landmark/blobstart,
 /turf/open/floor/engine/cult,
 /area/library)
 "bPX" = (
-/obj/effect/landmark/blobstart,
 /obj/machinery/light/small{
 	dir = 1
 	},
 /obj/machinery/computer/security/telescreen/entertainment{
 	pixel_x = 30
 	},
-/obj/structure/closet/wardrobe/curator,
+/obj/machinery/vending/wardrobe/curator_wardrobe,
 /turf/open/floor/engine/cult,
 /area/library)
 "bPY" = (
@@ -44309,7 +44315,7 @@
 	},
 /area/crew_quarters/kitchen)
 "bQI" = (
-/obj/structure/closet/chefcloset,
+/obj/machinery/vending/wardrobe/chef_wardrobe,
 /turf/open/floor/plasteel/showroomfloor,
 /area/crew_quarters/kitchen)
 "bQJ" = (
@@ -45487,7 +45493,7 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard)
 "bTi" = (
-/obj/structure/closet/wardrobe/atmospherics_yellow,
+/obj/machinery/vending/wardrobe/atmos_wardrobe,
 /turf/open/floor/plasteel/dark,
 /area/engine/atmos)
 "bTj" = (
@@ -47285,10 +47291,7 @@
 /turf/open/floor/plasteel,
 /area/hydroponics)
 "bWV" = (
-/obj/structure/extinguisher_cabinet{
-	pixel_x = -27
-	},
-/obj/structure/closet/wardrobe/botanist,
+/obj/machinery/vending/wardrobe/hydro_wardrobe,
 /turf/open/floor/plasteel/hydrofloor,
 /area/hydroponics)
 "bWX" = (
@@ -47857,6 +47860,9 @@
 /area/hydroponics)
 "bYm" = (
 /obj/structure/closet/secure_closet/hydroponics,
+/obj/structure/extinguisher_cabinet{
+	pixel_x = -27
+	},
 /turf/open/floor/plasteel/hydrofloor,
 /area/hydroponics)
 "bYn" = (
@@ -48136,7 +48142,16 @@
 /obj/item/screwdriver{
 	pixel_y = 6
 	},
-/obj/structure/sign/warning/nosmoking{
+/obj/item/storage/belt/medical{
+	pixel_y = 2
+	},
+/obj/item/clothing/neck/stethoscope,
+/obj/item/radio/intercom{
+	broadcasting = 1;
+	freerange = 0;
+	frequency = 1485;
+	listening = 0;
+	name = "Station Intercom (Medbay)";
 	pixel_y = 30
 	},
 /turf/open/floor/plasteel/whiteblue/side{
@@ -48154,32 +48169,19 @@
 /obj/item/screwdriver{
 	pixel_y = 6
 	},
+/obj/item/storage/belt/medical{
+	pixel_y = 2
+	},
+/obj/item/clothing/neck/stethoscope,
 /turf/open/floor/plasteel/whiteblue/side{
 	dir = 1
 	},
 /area/medical/storage)
 "bYV" = (
-/obj/item/radio/intercom{
-	broadcasting = 1;
-	freerange = 0;
-	frequency = 1485;
-	listening = 0;
-	name = "Station Intercom (Medbay)";
+/obj/machinery/vending/wardrobe/medi_wardrobe,
+/obj/structure/sign/warning/nosmoking{
 	pixel_y = 30
 	},
-/obj/structure/closet/wardrobe/white/medical,
-/obj/item/clothing/suit/hooded/wintercoat/medical,
-/obj/item/storage/belt/medical{
-	pixel_y = 2
-	},
-/obj/item/storage/belt/medical{
-	pixel_y = 2
-	},
-/obj/item/storage/belt/medical{
-	pixel_y = 2
-	},
-/obj/item/clothing/neck/stethoscope,
-/obj/item/clothing/neck/stethoscope,
 /turf/open/floor/plasteel/whiteblue/side{
 	dir = 1
 	},
@@ -55030,6 +55032,9 @@
 /obj/item/clothing/glasses/eyepatch,
 /obj/item/clothing/glasses/sunglasses/blindfold,
 /obj/item/clothing/ears/earmuffs,
+/obj/item/storage/belt/medical{
+	pixel_y = 2
+	},
 /turf/open/floor/plasteel/white/side{
 	dir = 2
 	},
@@ -55803,14 +55808,6 @@
 	},
 /area/crew_quarters/heads/cmo)
 "coT" = (
-/obj/structure/closet/wardrobe/chemistry_white{
-	pixel_x = -3
-	},
-/obj/item/storage/backpack/satchel/chem,
-/obj/machinery/airalarm{
-	dir = 4;
-	pixel_x = -22
-	},
 /obj/structure/window/reinforced{
 	dir = 1;
 	pixel_y = 1
@@ -55818,6 +55815,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 5
 	},
+/obj/machinery/vending/wardrobe/chem_wardrobe,
 /turf/open/floor/plasteel/white,
 /area/medical/chemistry)
 "coU" = (
@@ -56606,6 +56604,10 @@
 	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
+	},
+/obj/machinery/airalarm{
+	dir = 1;
+	pixel_y = -22
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/chemistry)
@@ -57425,10 +57427,10 @@
 /turf/open/floor/plasteel,
 /area/science/explab)
 "crX" = (
-/obj/structure/closet/wardrobe/science_white,
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
+/obj/machinery/vending/wardrobe/science_wardrobe,
 /turf/open/floor/plasteel,
 /area/science/explab)
 "crY" = (
@@ -61357,7 +61359,7 @@
 	dir = 1;
 	pixel_y = -22
 	},
-/obj/structure/closet/wardrobe/genetics_white,
+/obj/machinery/vending/wardrobe/gene_wardrobe,
 /turf/open/floor/plasteel/vault,
 /area/medical/genetics)
 "cAb" = (
@@ -65669,8 +65671,6 @@
 /turf/closed/wall,
 /area/medical/virology)
 "cIt" = (
-/obj/structure/closet/wardrobe/virology_white,
-/obj/item/storage/backpack/satchel/vir,
 /obj/structure/disposalpipe/segment{
 	dir = 9
 	},
@@ -65678,6 +65678,7 @@
 	dir = 8;
 	pixel_x = -26
 	},
+/obj/machinery/vending/wardrobe/viro_wardrobe,
 /turf/open/floor/plasteel/vault,
 /area/medical/virology)
 "cIu" = (
@@ -66302,13 +66303,11 @@
 /turf/open/floor/plasteel,
 /area/science/robotics/lab)
 "cJM" = (
-/obj/structure/closet/wardrobe/robotics_black{
-	pixel_x = 2
-	},
 /obj/structure/window/reinforced{
 	dir = 8
 	},
 /obj/effect/turf_decal/delivery,
+/obj/machinery/vending/wardrobe/robo_wardrobe,
 /turf/open/floor/plasteel,
 /area/science/robotics/lab)
 "cJN" = (
@@ -67681,6 +67680,11 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 4
 	},
+/obj/item/radio/intercom{
+	dir = 4;
+	name = "Station Intercom (General)";
+	pixel_x = -27
+	},
 /turf/open/floor/plasteel/dark,
 /area/chapel/office)
 "cMD" = (
@@ -68131,11 +68135,6 @@
 	c_tag = "Chapel Office - Backroom";
 	dir = 8
 	},
-/obj/item/radio/intercom{
-	dir = 4;
-	name = "Station Intercom (General)";
-	pixel_x = 27
-	},
 /turf/open/floor/plasteel/dark,
 /area/chapel/office)
 "cNv" = (
@@ -68144,6 +68143,10 @@
 	dir = 8
 	},
 /obj/structure/table/wood,
+/obj/machinery/airalarm{
+	dir = 4;
+	pixel_x = -23
+	},
 /turf/open/floor/plasteel/grimy,
 /area/chapel/office)
 "cNw" = (
@@ -68689,11 +68692,7 @@
 /turf/open/floor/plasteel/dark,
 /area/chapel/office)
 "cOG" = (
-/obj/structure/closet/wardrobe/chaplain_black,
-/obj/machinery/airalarm{
-	dir = 4;
-	pixel_x = -23
-	},
+/obj/machinery/vending/wardrobe/chap_wardrobe,
 /turf/open/floor/plasteel/grimy,
 /area/chapel/office)
 "cOH" = (
@@ -71487,9 +71486,7 @@
 /turf/open/floor/engine,
 /area/engine/supermatter)
 "dbd" = (
-/obj/structure/sink/kitchen{
-	pixel_y = 28
-	},
+/obj/machinery/vending/wardrobe/bar_wardrobe,
 /turf/open/floor/wood,
 /area/crew_quarters/bar)
 "dbe" = (

--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -9095,13 +9095,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
-"atw" = (
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/plating,
-/area/maintenance/port)
 "atx" = (
 /obj/structure/cable/yellow{
 	icon_state = "2-4"
@@ -44472,12 +44465,7 @@
 /turf/open/floor/engine/cult,
 /area/library)
 "bRm" = (
-/obj/item/taperecorder,
-/obj/item/camera,
-/obj/item/radio/intercom{
-	pixel_y = -25
-	},
-/obj/structure/table/wood,
+/obj/structure/chair/comfy/brown,
 /turf/open/floor/engine/cult,
 /area/library)
 "bRn" = (
@@ -45622,39 +45610,12 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 8
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 5
-	},
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
-/turf/open/floor/wood,
-/area/library)
-"bTB" = (
-/obj/machinery/door/airlock/maintenance{
-	name = "Library Maintenance";
-	req_one_access_txt = "12;37"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
-/turf/open/floor/plating,
-/area/maintenance/port)
-"bTC" = (
+/obj/structure/disposalpipe/segment,
 /obj/structure/cable/yellow{
 	icon_state = "2-8"
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 10
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/turf/open/floor/plating,
-/area/maintenance/port)
+/turf/open/floor/wood,
+/area/library)
 "bTD" = (
 /obj/machinery/vending/snack/random,
 /obj/machinery/newscaster{
@@ -46860,22 +46821,6 @@
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
-	},
-/turf/open/floor/plating,
-/area/maintenance/port)
-"bWe" = (
-/obj/structure/disposalpipe/sorting/mail/flip{
-	dir = 4;
-	sortType = 16
-	},
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/obj/structure/cable/yellow{
-	icon_state = "1-4"
 	},
 /turf/open/floor/plating,
 /area/maintenance/port)
@@ -76122,6 +76067,21 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard)
+"dOf" = (
+/obj/structure/table/wood,
+/obj/item/storage/photo_album,
+/turf/open/floor/engine/cult,
+/area/library)
+"dTg" = (
+/obj/item/taperecorder,
+/obj/item/camera,
+/obj/structure/table/wood,
+/obj/item/radio/intercom{
+	name = "Station Intercom (General)";
+	pixel_y = -29
+	},
+/turf/open/floor/engine/cult,
+/area/library)
 "dYu" = (
 /obj/machinery/door/airlock/external{
 	name = "Auxiliary Airlock"
@@ -76213,6 +76173,15 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/circuit)
+"fGq" = (
+/obj/structure/rack{
+	icon = 'icons/obj/stationobjs.dmi';
+	icon_state = "minibar";
+	name = "skeletal minibar"
+	},
+/obj/item/storage/fancy/candle_box,
+/turf/open/floor/engine/cult,
+/area/library)
 "gfh" = (
 /obj/machinery/libraryscanner,
 /turf/open/floor/plasteel/white,
@@ -76235,6 +76204,17 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/circuit)
+"gDX" = (
+/obj/machinery/door/airlock/maintenance{
+	name = "Library Maintenance";
+	req_one_access_txt = "12;37"
+	},
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plating,
+/area/library)
 "gEk" = (
 /obj/structure/cable/yellow{
 	icon_state = "2-8"
@@ -76423,6 +76403,25 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
+"kMc" = (
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/structure/disposalpipe/sorting/mail/flip{
+	dir = 4;
+	sortType = 16
+	},
+/obj/structure/cable/yellow{
+	icon_state = "1-4"
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/maintenance/port)
 "kOt" = (
 /obj/item/multitool,
 /obj/item/screwdriver,
@@ -76454,6 +76453,15 @@
 /obj/item/integrated_circuit_printer,
 /turf/open/floor/plasteel/white,
 /area/science/circuit)
+"lmV" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 5
+	},
+/obj/structure/cable/yellow{
+	icon_state = "1-4"
+	},
+/turf/open/floor/wood,
+/area/library)
 "lsv" = (
 /obj/machinery/power/apc{
 	areastring = "/area/science/circuit";
@@ -97527,7 +97535,7 @@ bue
 bzE
 bRj
 bSB
-bPR
+lmV
 bue
 div
 bXI
@@ -97785,8 +97793,8 @@ bPU
 bRk
 bSC
 bTA
-bue
-bWd
+gDX
+kMc
 alC
 dux
 dvq
@@ -98041,7 +98049,7 @@ bue
 bue
 bue
 bue
-bTB
+bue
 bue
 bWd
 aqK
@@ -98296,11 +98304,11 @@ bzE
 bMO
 bue
 bPV
+dOf
 bRl
 bue
-bTC
-atw
-bWe
+alC
+bWd
 bXJ
 dux
 bZV
@@ -98554,9 +98562,9 @@ cVi
 bOm
 bPW
 bRm
+dTg
 bue
 auF
-alC
 aXt
 aqO
 dux
@@ -98810,9 +98818,9 @@ bue
 bue
 bue
 bPX
+fGq
 bRn
 bue
-alK
 alK
 bWf
 bXK

--- a/_maps/map_files/OmegaStation/OmegaStation.dmm
+++ b/_maps/map_files/OmegaStation/OmegaStation.dmm
@@ -22084,7 +22084,7 @@
 /obj/structure/extinguisher_cabinet{
 	pixel_x = -26
 	},
-/obj/structure/closet/crate/bin,
+/obj/machinery/libraryscanner,
 /turf/open/floor/plasteel/vault{
 	dir = 5
 	},
@@ -22808,9 +22808,13 @@
 /turf/open/space,
 /area/asteroid/nearstation)
 "aWA" = (
-/obj/machinery/libraryscanner,
 /obj/machinery/newscaster{
 	pixel_x = -32
+	},
+/obj/structure/table/wood,
+/obj/machinery/computer/libraryconsole/bookmanagement,
+/obj/machinery/light_switch{
+	pixel_y = -24
 	},
 /turf/open/floor/plasteel/vault{
 	dir = 5
@@ -23078,28 +23082,9 @@
 /obj/structure/lattice/catwalk,
 /turf/open/space,
 /area/asteroid/nearstation)
-"aXe" = (
-/obj/structure/table/wood,
-/obj/machinery/computer/libraryconsole/bookmanagement,
-/obj/machinery/light_switch{
-	pixel_y = -24
-	},
-/obj/machinery/airalarm{
-	dir = 4;
-	pixel_x = -23
-	},
-/turf/open/floor/plasteel/dark,
-/area/library)
 "aXf" = (
-/obj/structure/table/wood,
-/obj/item/folder,
-/obj/item/pen/blue{
-	pixel_x = 3;
-	pixel_y = 3
-	},
-/obj/item/pen/red,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/turf/open/floor/plasteel/dark,
+/turf/closed/wall,
 /area/library)
 "aXg" = (
 /obj/structure/bookcase/random/nonfiction,
@@ -23117,6 +23102,7 @@
 	dir = 1;
 	pixel_y = -22
 	},
+/obj/structure/closet/crate/bin,
 /turf/open/floor/plasteel/dark,
 /area/library)
 "aXj" = (
@@ -23410,19 +23396,18 @@
 /turf/open/floor/plasteel,
 /area/maintenance/starboard)
 "aXL" = (
-/obj/machinery/door/morgue{
-	name = "Curator's Study";
-	req_access_txt = "37"
+/obj/effect/landmark/start/librarian,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
+	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/turf/open/floor/plasteel/vault{
-	dir = 8
+/turf/open/floor/wood{
+	icon_state = "wood-broken2"
 	},
 /area/library)
 "aXM" = (
-/obj/machinery/status_display,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/turf/closed/wall,
+/obj/machinery/vending/wardrobe/curator_wardrobe,
+/turf/open/floor/wood,
 /area/library)
 "aXN" = (
 /obj/machinery/door/airlock/maintenance_hatch{
@@ -23811,37 +23796,30 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
 "aYw" = (
-/obj/structure/destructible/cult/tome,
-/obj/item/book/codex_gigas,
 /obj/machinery/light/small{
-	dir = 1
+	dir = 8
 	},
-/obj/machinery/light_switch{
-	pixel_y = 24
-	},
+/obj/structure/table/wood,
+/obj/item/taperecorder,
 /turf/open/floor/wood{
 	icon_state = "wood-broken6"
 	},
 /area/library)
 "aYx" = (
-/obj/effect/landmark/start/librarian,
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
-	dir = 1
-	},
+/obj/structure/chair/comfy/brown,
 /turf/open/floor/wood,
 /area/library)
 "aYy" = (
-/obj/structure/bookcase{
-	name = "Forbidden Knowledge"
-	},
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = 24
-	},
-/obj/machinery/light/small{
-	dir = 1
-	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/structure/rack{
+	icon = 'icons/obj/stationobjs.dmi';
+	icon_state = "minibar";
+	name = "skeletal minibar"
+	},
+/obj/item/storage/fancy/candle_box,
+/obj/machinery/computer/security/telescreen/entertainment{
+	pixel_x = 32
+	},
 /turf/open/floor/wood,
 /area/library)
 "aYz" = (
@@ -24207,7 +24185,9 @@
 /obj/machinery/newscaster{
 	pixel_x = -32
 	},
-/obj/machinery/vending/wardrobe/curator_wardrobe,
+/obj/structure/table/wood,
+/obj/item/storage/photo_album,
+/obj/item/camera,
 /turf/open/floor/wood,
 /area/library)
 "aZv" = (
@@ -24227,17 +24207,14 @@
 	},
 /area/library)
 "aZw" = (
-/obj/structure/table/wood,
-/obj/item/taperecorder,
-/obj/item/camera,
 /obj/machinery/ai_status_display{
 	pixel_y = -32
 	},
-/obj/machinery/computer/security/telescreen/entertainment{
-	pixel_x = 32
-	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 1
+	},
+/obj/structure/bookcase{
+	name = "Forbidden Knowledge"
 	},
 /turf/open/floor/wood,
 /area/library)
@@ -32238,6 +32215,14 @@
 /obj/item/paper/guides/jobs/hydroponics,
 /turf/open/floor/plasteel/neutral,
 /area/hydroponics)
+"mLL" = (
+/obj/machinery/light_switch{
+	pixel_y = 24
+	},
+/obj/structure/destructible/cult/tome,
+/obj/item/book/codex_gigas,
+/turf/open/floor/wood,
+/area/library)
 "mQi" = (
 /turf/closed/wall/rust,
 /area/maintenance/starboard/central)
@@ -32297,6 +32282,16 @@
 /obj/machinery/meter,
 /turf/open/floor/plasteel,
 /area/engine/atmos)
+"nJb" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/machinery/door/morgue{
+	name = "Curator's Study";
+	req_access_txt = "37"
+	},
+/turf/open/floor/plasteel/vault{
+	dir = 5
+	},
+/area/library)
 "nKi" = (
 /obj/machinery/door/airlock/maintenance_hatch{
 	name = "Maintenance Hatch";
@@ -35934,6 +35929,10 @@
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plasteel,
 /area/engine/atmos)
+"yde" = (
+/obj/machinery/status_display,
+/turf/closed/wall,
+/area/library)
 "yeE" = (
 /obj/machinery/door/window/brigdoor{
 	dir = 4;
@@ -69786,7 +69785,7 @@ aQW
 aQW
 aQW
 aQW
-aQW
+sJI
 aQW
 sJI
 aQW
@@ -70042,8 +70041,8 @@ aUc
 aUV
 aVN
 aWA
-aXe
 aQW
+mLL
 aYw
 aZu
 aQW
@@ -70299,7 +70298,7 @@ aUd
 sKd
 aVO
 aWB
-aVO
+nJb
 aXL
 aYx
 aZv
@@ -70813,7 +70812,7 @@ aUf
 aUX
 aVQ
 aWD
-aVQ
+yde
 aQW
 aQW
 aQW

--- a/_maps/map_files/OmegaStation/OmegaStation.dmm
+++ b/_maps/map_files/OmegaStation/OmegaStation.dmm
@@ -5618,7 +5618,7 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard/fore)
 "akL" = (
-/obj/structure/closet/wardrobe/cargotech,
+/obj/machinery/vending/wardrobe/cargo_wardrobe,
 /turf/open/floor/plasteel/brown{
 	dir = 8
 	},
@@ -8673,11 +8673,11 @@
 	},
 /area/security/brig)
 "aqK" = (
-/obj/structure/closet/secure_closet/security/sec,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
+/obj/machinery/vending/wardrobe/sec_wardrobe,
 /turf/open/floor/plasteel/vault{
 	dir = 8
 	},
@@ -9589,17 +9589,13 @@
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
 "asJ" = (
-/obj/structure/closet/wardrobe/red,
-/obj/item/clothing/under/rank/security/grey,
-/obj/item/clothing/under/rank/security/grey,
-/obj/item/clothing/under/rank/security/grey,
-/obj/item/storage/backpack/satchel/sec,
 /obj/structure/extinguisher_cabinet{
 	pixel_x = -26
 	},
 /obj/structure/reagent_dispensers/peppertank{
 	pixel_y = -32
 	},
+/obj/structure/closet/secure_closet/security/sec,
 /turf/open/floor/plasteel/vault/corner{
 	dir = 4
 	},
@@ -10008,7 +10004,6 @@
 /obj/structure/cable/white{
 	icon_state = "0-2"
 	},
-/obj/structure/closet/wardrobe/atmospherics_yellow,
 /obj/effect/turf_decal/bot,
 /obj/machinery/power/apc/highcap/ten_k{
 	areastring = "/area/engine/atmos";
@@ -10020,6 +10015,13 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
+/obj/structure/table/reinforced,
+/obj/item/clothing/gloves/color/black,
+/obj/item/clothing/gloves/color/black,
+/obj/item/clothing/suit/hazardvest,
+/obj/item/clothing/suit/hazardvest,
+/obj/item/clothing/mask/gas,
+/obj/item/clothing/mask/gas,
 /turf/open/floor/plasteel/caution{
 	dir = 4
 	},
@@ -10348,7 +10350,6 @@
 /turf/open/floor/plasteel/vault,
 /area/crew_quarters/bar/atrium)
 "aul" = (
-/obj/structure/closet/gmcloset,
 /obj/item/wrench,
 /obj/item/stack/sheet/glass{
 	amount = 30
@@ -10362,6 +10363,7 @@
 	name = "Station Intercom";
 	pixel_x = 26
 	},
+/obj/structure/closet,
 /turf/open/floor/plasteel/vault,
 /area/crew_quarters/bar/atrium)
 "aum" = (
@@ -11432,17 +11434,11 @@
 /turf/open/floor/plasteel,
 /area/engine/atmos)
 "awK" = (
-/obj/structure/table/reinforced,
-/obj/item/clothing/gloves/color/black,
-/obj/item/clothing/suit/hazardvest,
-/obj/item/clothing/mask/gas,
-/obj/item/clothing/gloves/color/black,
-/obj/item/clothing/suit/hazardvest,
-/obj/item/clothing/mask/gas,
 /obj/structure/cable/white{
 	icon_state = "1-2"
 	},
 /obj/effect/decal/cleanable/dirt,
+/obj/machinery/vending/wardrobe/atmos_wardrobe,
 /turf/open/floor/plasteel/caution{
 	dir = 4
 	},
@@ -11585,17 +11581,8 @@
 	},
 /area/crew_quarters/bar/atrium)
 "axc" = (
-/obj/structure/closet/gmcloset,
-/obj/item/wrench,
-/obj/item/stack/sheet/glass{
-	amount = 30
-	},
-/obj/item/stack/sheet/metal{
-	amount = 30
-	},
-/obj/item/stack/cable_coil/random,
-/obj/item/stack/cable_coil/random,
 /obj/machinery/light,
+/obj/machinery/vending/wardrobe/bar_wardrobe,
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/bar/atrium)
 "axd" = (
@@ -16661,10 +16648,10 @@
 /area/hydroponics)
 "aIF" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/structure/closet/wardrobe/botanist,
 /obj/structure/sign/poster/random{
 	pixel_y = 32
 	},
+/obj/structure/closet/secure_closet/hydroponics,
 /turf/open/floor/plasteel/vault/side,
 /area/hydroponics)
 "aIG" = (
@@ -16782,9 +16769,9 @@
 /turf/open/floor/plasteel/freezer,
 /area/crew_quarters/kitchen)
 "aIS" = (
-/obj/structure/closet/chefcloset,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/effect/turf_decal/bot,
+/obj/machinery/vending/wardrobe/chef_wardrobe,
 /turf/open/floor/plasteel/freezer,
 /area/crew_quarters/kitchen)
 "aIT" = (
@@ -18256,7 +18243,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 6
 	},
-/obj/structure/closet/secure_closet/hydroponics,
+/obj/machinery/vending/wardrobe/hydro_wardrobe,
 /turf/open/floor/plasteel/greenblue/side{
 	dir = 10
 	},
@@ -18657,18 +18644,17 @@
 /turf/open/floor/plasteel,
 /area/janitor)
 "aNl" = (
-/obj/structure/closet/jcloset,
 /obj/machinery/light_switch{
 	pixel_y = -24
 	},
-/obj/item/flashlight,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/effect/turf_decal/bot,
+/obj/structure/closet/l3closet/janitor,
 /turf/open/floor/plasteel,
 /area/janitor)
 "aNm" = (
-/obj/structure/closet/l3closet/janitor,
 /obj/effect/turf_decal/bot,
+/obj/machinery/vending/wardrobe/jani_wardrobe,
 /turf/open/floor/plasteel/vault/side{
 	dir = 8
 	},
@@ -20906,7 +20892,6 @@
 /turf/closed/wall,
 /area/medical/medbay/zone3)
 "aSj" = (
-/obj/structure/closet/wardrobe/chemistry_white,
 /obj/machinery/airalarm{
 	dir = 4;
 	pixel_x = -22
@@ -20919,6 +20904,9 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 5
 	},
+/obj/structure/closet/secure_closet/medical1,
+/obj/item/storage/box/beakers,
+/obj/item/storage/box/pillbottles,
 /turf/open/floor/plasteel,
 /area/medical/chemistry)
 "aSk" = (
@@ -21178,10 +21166,10 @@
 /turf/closed/wall/r_wall,
 /area/tcommsat/server)
 "aSP" = (
-/obj/structure/closet/wardrobe/engineering_yellow,
 /obj/effect/turf_decal/stripes/line{
 	dir = 10
 	},
+/obj/machinery/vending/wardrobe/engi_wardrobe,
 /turf/open/floor/engine,
 /area/engine/engineering)
 "aSR" = (
@@ -21407,13 +21395,11 @@
 /turf/open/floor/plating,
 /area/medical/chemistry)
 "aTq" = (
-/obj/structure/closet/secure_closet/medical1,
 /obj/structure/window/reinforced,
 /obj/effect/turf_decal/stripes/line{
 	dir = 6
 	},
-/obj/item/storage/box/pillbottles,
-/obj/item/storage/box/beakers,
+/obj/machinery/vending/wardrobe/chem_wardrobe,
 /turf/open/floor/plasteel,
 /area/medical/chemistry)
 "aTr" = (
@@ -23491,12 +23477,11 @@
 /turf/open/floor/plasteel,
 /area/medical/medbay/zone3)
 "aXP" = (
-/obj/structure/closet/wardrobe/white/medical,
 /obj/structure/extinguisher_cabinet{
 	pixel_y = 32
 	},
-/obj/item/storage/backpack/satchel/med,
 /obj/effect/turf_decal/bot,
+/obj/machinery/vending/wardrobe/medi_wardrobe,
 /turf/open/floor/plasteel,
 /area/medical/medbay/zone3)
 "aXQ" = (
@@ -23731,9 +23716,6 @@
 /turf/open/floor/plasteel/whitepurple/corner,
 /area/science/research)
 "aYp" = (
-/obj/item/twohanded/required/kirbyplants{
-	icon_state = "plant-21"
-	},
 /obj/structure/extinguisher_cabinet{
 	pixel_x = 24
 	},
@@ -23742,6 +23724,7 @@
 	c_tag = "Research Division South";
 	dir = 8
 	},
+/obj/machinery/vending/wardrobe/science_wardrobe,
 /turf/open/floor/plasteel/whitepurple/corner,
 /area/science/research)
 "aYq" = (
@@ -24218,15 +24201,13 @@
 /turf/closed/wall,
 /area/maintenance/port)
 "aZu" = (
-/obj/structure/table/wood,
-/obj/item/paper_bin,
-/obj/item/pen,
 /obj/machinery/status_display{
 	pixel_y = -32
 	},
 /obj/machinery/newscaster{
 	pixel_x = -32
 	},
+/obj/machinery/vending/wardrobe/curator_wardrobe,
 /turf/open/floor/wood,
 /area/library)
 "aZv" = (
@@ -24239,6 +24220,8 @@
 	name = "Station Intercom";
 	pixel_y = -26
 	},
+/obj/item/paper_bin,
+/obj/item/pen,
 /turf/open/floor/wood{
 	icon_state = "wood-broken"
 	},
@@ -25766,7 +25749,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 10
 	},
-/obj/structure/closet/crate/bin,
+/obj/machinery/vending/wardrobe/robo_wardrobe,
 /turf/open/floor/plasteel,
 /area/science/robotics/lab)
 "bcz" = (
@@ -26171,7 +26154,6 @@
 /turf/closed/wall/rust,
 /area/science/robotics/lab)
 "bdt" = (
-/obj/structure/closet/wardrobe/robotics_black,
 /obj/machinery/power/apc{
 	dir = 8;
 	name = "Robotics Lab APC";
@@ -26183,6 +26165,7 @@
 	icon_state = "0-4"
 	},
 /obj/effect/turf_decal/bot,
+/obj/structure/closet/crate/bin,
 /turf/open/floor/plasteel/vault,
 /area/science/robotics/lab)
 "bdu" = (
@@ -26852,14 +26835,10 @@
 /turf/closed/wall,
 /area/medical/medbay/zone3)
 "beH" = (
-/obj/structure/closet/wardrobe/red,
 /obj/machinery/newscaster{
 	pixel_x = -32
 	},
-/obj/item/radio/intercom{
-	name = "Station Intercom";
-	pixel_y = -24
-	},
+/obj/machinery/vending/wardrobe/sec_wardrobe,
 /turf/open/floor/plasteel/red/side{
 	dir = 10
 	},
@@ -26880,6 +26859,10 @@
 /obj/machinery/camera{
 	c_tag = "Security Checkpoint";
 	dir = 1
+	},
+/obj/item/radio/intercom{
+	name = "Station Intercom";
+	pixel_y = -24
 	},
 /turf/open/floor/plasteel/red/side{
 	dir = 6
@@ -28422,7 +28405,6 @@
 	},
 /area/maintenance/starboard/aft)
 "bhZ" = (
-/obj/structure/closet/wardrobe/chaplain_black,
 /obj/machinery/light_switch{
 	pixel_y = 24
 	},
@@ -28433,6 +28415,7 @@
 	c_tag = "Chaplain's Quarters";
 	dir = 2
 	},
+/obj/machinery/vending/wardrobe/chap_wardrobe,
 /turf/open/floor/plasteel/vault{
 	dir = 8
 	},

--- a/_maps/map_files/PubbyStation/PubbyStation.dmm
+++ b/_maps/map_files/PubbyStation/PubbyStation.dmm
@@ -10507,7 +10507,7 @@
 /turf/open/floor/wood,
 /area/lawoffice)
 "aCf" = (
-/obj/structure/closet/lawcloset,
+/obj/machinery/vending/wardrobe/law_wardrobe,
 /turf/open/floor/wood,
 /area/lawoffice)
 "aCg" = (
@@ -16230,6 +16230,9 @@
 /obj/structure/closet/secure_closet/bar{
 	req_access_txt = "25"
 	},
+/obj/item/stack/cable_coil,
+/obj/item/stack/sheet/glass/fifty,
+/obj/item/stack/sheet/metal/fifty,
 /turf/open/floor/wood,
 /area/crew_quarters/bar)
 "aQW" = (
@@ -16981,6 +16984,7 @@
 /area/maintenance/department/crew_quarters/bar)
 "aSN" = (
 /obj/item/assembly/mousetrap,
+/obj/item/storage/box/mousetraps,
 /turf/open/floor/wood{
 	icon_state = "wood-broken6"
 	},
@@ -17522,6 +17526,8 @@
 /obj/structure/extinguisher_cabinet{
 	pixel_x = 26
 	},
+/obj/item/crowbar,
+/obj/item/wrench,
 /turf/open/floor/plasteel/showroomfloor,
 /area/crew_quarters/kitchen)
 "aUb" = (
@@ -17542,11 +17548,7 @@
 /turf/open/floor/wood,
 /area/crew_quarters/bar)
 "aUe" = (
-/obj/structure/closet/gmcloset,
-/obj/item/stack/sheet/metal/fifty,
-/obj/item/stack/sheet/glass/fifty,
-/obj/item/stack/cable_coil,
-/obj/item/storage/box/mousetraps,
+/obj/machinery/vending/wardrobe/bar_wardrobe,
 /turf/open/floor/wood{
 	icon_state = "wood-broken5"
 	},
@@ -17886,10 +17888,10 @@
 /turf/open/floor/plasteel/hydrofloor,
 /area/hydroponics)
 "aUT" = (
-/obj/structure/closet/wardrobe/botanist,
 /obj/structure/cable{
 	icon_state = "1-4"
 	},
+/obj/machinery/vending/wardrobe/hydro_wardrobe,
 /turf/open/floor/plasteel/hydrofloor,
 /area/hydroponics)
 "aUU" = (
@@ -18341,9 +18343,7 @@
 /turf/open/floor/plasteel,
 /area/hydroponics)
 "aVW" = (
-/obj/structure/closet/chefcloset,
-/obj/item/wrench,
-/obj/item/crowbar,
+/obj/machinery/vending/wardrobe/chef_wardrobe,
 /turf/open/floor/plasteel/showroomfloor,
 /area/crew_quarters/kitchen)
 "aVX" = (
@@ -19405,7 +19405,7 @@
 	},
 /area/security/checkpoint/customs)
 "aYJ" = (
-/obj/structure/closet/wardrobe/red,
+/obj/machinery/vending/wardrobe/sec_wardrobe,
 /turf/open/floor/plasteel/red/side{
 	dir = 1
 	},
@@ -20535,6 +20535,8 @@
 	pixel_x = 6;
 	pixel_y = -5
 	},
+/obj/item/clothing/under/rank/mailman,
+/obj/item/clothing/head/mailman,
 /turf/open/floor/plasteel,
 /area/quartermaster/office)
 "bbC" = (
@@ -20545,9 +20547,7 @@
 /turf/open/floor/plasteel,
 /area/quartermaster/office)
 "bbD" = (
-/obj/structure/closet/wardrobe/cargotech,
-/obj/item/clothing/head/mailman,
-/obj/item/clothing/under/rank/mailman,
+/obj/machinery/vending/wardrobe/cargo_wardrobe,
 /turf/open/floor/plasteel,
 /area/quartermaster/office)
 "bbE" = (
@@ -20693,15 +20693,11 @@
 /turf/open/floor/plasteel/floorgrime,
 /area/janitor)
 "bbY" = (
-/obj/structure/closet/jcloset,
-/obj/item/clothing/head/crown,
 /obj/machinery/camera{
 	c_tag = "Custodial Closet";
 	dir = 8
 	},
-/obj/structure/extinguisher_cabinet{
-	pixel_x = 24
-	},
+/obj/machinery/vending/wardrobe/jani_wardrobe,
 /turf/open/floor/plasteel/floorgrime,
 /area/janitor)
 "bbZ" = (
@@ -21433,6 +21429,10 @@
 	pixel_y = 3
 	},
 /obj/item/storage/box/mousetraps,
+/obj/structure/extinguisher_cabinet{
+	pixel_x = 24
+	},
+/obj/item/clothing/head/crown,
 /turf/open/floor/plasteel/floorgrime,
 /area/janitor)
 "bef" = (
@@ -25817,6 +25817,9 @@
 	name = "Station Intercom (General)";
 	pixel_x = -27
 	},
+/obj/item/radio/headset/headset_sci{
+	pixel_x = -3
+	},
 /turf/open/floor/plasteel/vault{
 	dir = 8
 	},
@@ -26400,10 +26403,7 @@
 	},
 /area/hallway/primary/aft)
 "brw" = (
-/obj/structure/closet/wardrobe/robotics_black,
-/obj/item/radio/headset/headset_sci{
-	pixel_x = -3
-	},
+/obj/machinery/vending/wardrobe/robo_wardrobe,
 /turf/open/floor/plasteel/vault{
 	dir = 8
 	},
@@ -29153,6 +29153,7 @@
 	icon_state = "0-4"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/item/radio/headset/headset_med,
 /turf/open/floor/plasteel/whiteyellow/side{
 	dir = 8
 	},
@@ -29868,11 +29869,10 @@
 /turf/open/floor/plasteel/cmo,
 /area/crew_quarters/heads/cmo)
 "bAe" = (
-/obj/structure/closet/wardrobe/chemistry_white,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 5
 	},
-/obj/item/radio/headset/headset_med,
+/obj/machinery/vending/wardrobe/chem_wardrobe,
 /turf/open/floor/plasteel/whiteyellow/side{
 	dir = 10
 	},
@@ -31228,7 +31228,7 @@
 /turf/open/floor/plasteel/whitepurple/side,
 /area/medical/genetics)
 "bDn" = (
-/obj/structure/closet/wardrobe/genetics_white,
+/obj/machinery/vending/wardrobe/gene_wardrobe,
 /turf/open/floor/plasteel/whitepurple/side{
 	dir = 6
 	},
@@ -32535,7 +32535,7 @@
 /turf/open/floor/plasteel/whitepurple/side,
 /area/science/mixing)
 "bGn" = (
-/obj/structure/closet/wardrobe/science_white,
+/obj/machinery/vending/wardrobe/science_wardrobe,
 /turf/open/floor/plasteel/whitepurple/side,
 /area/science/mixing)
 "bGo" = (
@@ -33261,7 +33261,7 @@
 /turf/open/floor/plasteel/whiteblue/side,
 /area/medical/medbay/central)
 "bIf" = (
-/obj/structure/closet/wardrobe/white/medical,
+/obj/machinery/vending/wardrobe/medi_wardrobe,
 /turf/open/floor/plasteel/whiteblue/side,
 /area/medical/medbay/central)
 "bIg" = (
@@ -34644,7 +34644,10 @@
 	pixel_x = 32;
 	receive_ore_updates = 1
 	},
-/obj/item/reagent_containers/dropper,
+/obj/item/paper_bin{
+	layer = 2.9
+	},
+/obj/item/pen/red,
 /turf/open/floor/plasteel/whitegreen/side{
 	dir = 4
 	},
@@ -35081,6 +35084,7 @@
 	},
 /obj/item/clothing/gloves/color/latex,
 /obj/item/clothing/glasses/hud/health,
+/obj/item/reagent_containers/dropper,
 /turf/open/floor/plasteel/whitegreen/side{
 	dir = 6
 	},
@@ -35494,11 +35498,7 @@
 "bNQ" = (
 /obj/machinery/light,
 /obj/machinery/atmospherics/pipe/simple/cyan/hidden,
-/obj/structure/table,
-/obj/item/paper_bin{
-	layer = 2.9
-	},
-/obj/item/pen/red,
+/obj/machinery/vending/wardrobe/viro_wardrobe,
 /turf/open/floor/plasteel/whitegreen/side,
 /area/medical/virology)
 "bNR" = (
@@ -37907,7 +37907,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
 	dir = 4
 	},
-/obj/structure/closet/wardrobe/atmospherics_yellow,
+/obj/machinery/vending/wardrobe/atmos_wardrobe,
 /turf/open/floor/plasteel/yellow/side{
 	dir = 1
 	},
@@ -44225,8 +44225,8 @@
 /turf/open/space/basic,
 /area/ai_monitored/turret_protected/AIsatextAS)
 "cnJ" = (
-/obj/structure/closet/wardrobe/red,
 /obj/effect/turf_decal/delivery,
+/obj/machinery/vending/wardrobe/sec_wardrobe,
 /turf/open/floor/plasteel/showroomfloor,
 /area/security/main)
 "cnN" = (
@@ -45272,7 +45272,11 @@
 	departmentType = 2;
 	pixel_x = -32
 	},
-/obj/structure/closet/wardrobe/chaplain_black,
+/obj/structure/closet,
+/obj/item/storage/backpack/cultpack,
+/obj/item/clothing/head/nun_hood,
+/obj/item/clothing/suit/nun,
+/obj/item/clothing/suit/holidaypriest,
 /turf/open/floor/plasteel/vault{
 	dir = 8
 	},
@@ -45592,11 +45596,7 @@
 /turf/open/floor/plating/airless,
 /area/space/nearstation)
 "ctX" = (
-/obj/structure/closet,
-/obj/item/clothing/suit/holidaypriest,
-/obj/item/clothing/suit/nun,
-/obj/item/clothing/head/nun_hood,
-/obj/item/storage/backpack/cultpack,
+/obj/machinery/vending/wardrobe/chap_wardrobe,
 /turf/open/floor/carpet,
 /area/chapel/office)
 "cua" = (
@@ -47010,7 +47010,7 @@
 /turf/open/floor/plasteel/dark,
 /area/library)
 "cAS" = (
-/obj/structure/closet/wardrobe/curator,
+/obj/machinery/vending/wardrobe/curator_wardrobe,
 /turf/open/floor/plasteel/dark,
 /area/library)
 "cAT" = (
@@ -50413,10 +50413,10 @@
 	},
 /area/maintenance/department/science)
 "mbe" = (
-/obj/structure/closet/wardrobe/engineering_yellow,
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
+/obj/machinery/vending/wardrobe/engi_wardrobe,
 /turf/open/floor/plasteel/yellow/side{
 	dir = 1
 	},

--- a/code/modules/cargo/packs.dm
+++ b/code/modules/cargo/packs.dm
@@ -37,6 +37,7 @@
 		for(var/item in contains)
 			new item(C)
 
+// If you add something to this list, please group it by type and sort it alphabetically instead of just jamming it in like an animal
 
 //////////////////////////////////////////////////////////////////////////////
 //////////////////////////// Emergency ///////////////////////////////////////
@@ -1706,73 +1707,6 @@
 /datum/supply_pack/costumes_toys
 	group = "Costumes & Toys"
 
-/datum/supply_pack/costumes_toys/autodrobe
-	name = "Autodrobe Supply Crate"
-	desc = "Autodrobe missing your favorite dress? Solve that issue today with these two autodrobe refills."
-	cost = 1500
-	contains = list(/obj/item/vending_refill/autodrobe,
-					/obj/item/vending_refill/autodrobe)
-	crate_name = "autodrobe supply crate"
-
-/datum/supply_pack/costumes_toys/wardrobes/general
-	name = "General Wardrobes Supply Crate"
-	desc = "This crate contains refills for the CuraDrobe, BarDrobe, ChefDrobe, JaniDrobe, ChapDrobe."
-	cost = 3750
-	contains = list(/obj/item/vending_refill/wardrobe/curator_wardrobe,
-					/obj/item/vending_refill/wardrobe/bar_wardrobe,
-					/obj/item/vending_refill/wardrobe/chef_wardrobe,
-					/obj/item/vending_refill/wardrobe/jani_wardrobe,
-					/obj/item/vending_refill/wardrobe/chap_wardrobe)
-	crate_name = "general wardrobes vendor refills"
-
-/datum/supply_pack/costumes_toys/wardrobes/cargo
-	name = "Cargo Department Supply Crate"
-	desc = "This crate contains a refill for the CargoDrobe."
-	cost = 750
-	contains = list(/obj/item/vending_refill/wardrobe/cargo_wardrobe)
-	crate_name = "cargo department supply crate"
-
-/datum/supply_pack/costumes_toys/wardrobes/security
-	name = "Security Department Supply Crate"
-	desc = "This crate contains refills for the SecDrobe and LawDrobe."
-	cost = 1500
-	contains = list(/obj/item/vending_refill/wardrobe/sec_wardrobe,
-					/obj/item/vending_refill/wardrobe/law_wardrobe)
-	crate_name = "security department supply crate"
-
-/datum/supply_pack/costumes_toys/wardrobes/medical
-	name = "Medical Department Wardrobe Supply Crate"
-	desc = "This crate contains refills for the MediDrobe, ChemDrobe, GeneDrobe, and ViroDrobe."
-	cost = 3000
-	contains = list(/obj/item/vending_refill/wardrobe/medi_wardrobe,
-					/obj/item/vending_refill/wardrobe/chem_wardrobe,
-					/obj/item/vending_refill/wardrobe/gene_wardrobe,
-					/obj/item/vending_refill/wardrobe/viro_wardrobe)
-	crate_name = "medical department wardrobe supply crate"
-
-/datum/supply_pack/costumes_toys/wardrobes/engineering
-	name = "Engineering Department Wardrobe Supply Crate"
-	desc = "This crate contains refills for the EngiDrobe and AtmosDrobe."
-	cost = 1500
-	contains = list(/obj/item/vending_refill/wardrobe/engi_wardrobe,
-					/obj/item/vending_refill/wardrobe/atmos_wardrobe)
-	crate_name = "engineering department wardrobe supply crate"
-
-/datum/supply_pack/costumes_toys/wardrobes/science
-	name = "Science Department Wardrobe Supply Crate"
-	desc = "This crate contains refills for the SciDrobe and RoboDrobe."
-	cost = 1500
-	contains = list(/obj/item/vending_refill/wardrobe/robo_wardrobe,
-					/obj/item/vending_refill/wardrobe/science_wardrobe)
-	crate_name = "science department wardrobe supply crate"
-
-/datum/supply_pack/costumes_toys/wardrobes/hydroponics
-	name = "Hydrobe Supply Crate"
-	desc = "This crate contains a refill for the Hydrobe."
-	cost = 750
-	contains = list(/obj/item/vending_refill/wardrobe/hydro_wardrobe)
-	crate_name = "hydrobe supply crate"
-
 /datum/supply_pack/costumes_toys/randomised
 	name = "Collectable Hats Crate"
 	desc = "Flaunt your status with three unique, highly-collectable hats!"
@@ -2000,6 +1934,73 @@
 	for(var/i in 1 to num_contained)
 		var/item = pick_n_take(L)
 		new item(C)
+
+/datum/supply_pack/costumes_toys/wardrobes/autodrobe
+	name = "Autodrobe Supply Crate"
+	desc = "Autodrobe missing your favorite dress? Solve that issue today with these two autodrobe refills."
+	cost = 1500
+	contains = list(/obj/item/vending_refill/autodrobe,
+					/obj/item/vending_refill/autodrobe)
+	crate_name = "autodrobe supply crate"
+
+/datum/supply_pack/costumes_toys/wardrobes/cargo
+	name = "Cargo Department Supply Crate"
+	desc = "This crate contains a refill for the CargoDrobe."
+	cost = 750
+	contains = list(/obj/item/vending_refill/wardrobe/cargo_wardrobe)
+	crate_name = "cargo department supply crate"
+
+/datum/supply_pack/costumes_toys/wardrobes/engineering
+	name = "Engineering Department Wardrobe Supply Crate"
+	desc = "This crate contains refills for the EngiDrobe and AtmosDrobe."
+	cost = 1500
+	contains = list(/obj/item/vending_refill/wardrobe/engi_wardrobe,
+					/obj/item/vending_refill/wardrobe/atmos_wardrobe)
+	crate_name = "engineering department wardrobe supply crate"
+
+/datum/supply_pack/costumes_toys/wardrobes/general
+	name = "General Wardrobes Supply Crate"
+	desc = "This crate contains refills for the CuraDrobe, BarDrobe, ChefDrobe, JaniDrobe, ChapDrobe."
+	cost = 3750
+	contains = list(/obj/item/vending_refill/wardrobe/curator_wardrobe,
+					/obj/item/vending_refill/wardrobe/bar_wardrobe,
+					/obj/item/vending_refill/wardrobe/chef_wardrobe,
+					/obj/item/vending_refill/wardrobe/jani_wardrobe,
+					/obj/item/vending_refill/wardrobe/chap_wardrobe)
+	crate_name = "general wardrobes vendor refills"
+
+/datum/supply_pack/costumes_toys/wardrobes/hydroponics
+	name = "Hydrobe Supply Crate"
+	desc = "This crate contains a refill for the Hydrobe."
+	cost = 750
+	contains = list(/obj/item/vending_refill/wardrobe/hydro_wardrobe)
+	crate_name = "hydrobe supply crate"
+
+/datum/supply_pack/costumes_toys/wardrobes/medical
+	name = "Medical Department Wardrobe Supply Crate"
+	desc = "This crate contains refills for the MediDrobe, ChemDrobe, GeneDrobe, and ViroDrobe."
+	cost = 3000
+	contains = list(/obj/item/vending_refill/wardrobe/medi_wardrobe,
+					/obj/item/vending_refill/wardrobe/chem_wardrobe,
+					/obj/item/vending_refill/wardrobe/gene_wardrobe,
+					/obj/item/vending_refill/wardrobe/viro_wardrobe)
+	crate_name = "medical department wardrobe supply crate"
+
+/datum/supply_pack/costumes_toys/wardrobes/science
+	name = "Science Department Wardrobe Supply Crate"
+	desc = "This crate contains refills for the SciDrobe and RoboDrobe."
+	cost = 1500
+	contains = list(/obj/item/vending_refill/wardrobe/robo_wardrobe,
+					/obj/item/vending_refill/wardrobe/science_wardrobe)
+	crate_name = "science department wardrobe supply crate"
+
+/datum/supply_pack/costumes_toys/wardrobes/security
+	name = "Security Department Supply Crate"
+	desc = "This crate contains refills for the SecDrobe and LawDrobe."
+	cost = 1500
+	contains = list(/obj/item/vending_refill/wardrobe/sec_wardrobe,
+					/obj/item/vending_refill/wardrobe/law_wardrobe)
+	crate_name = "security department supply crate"
 
 //////////////////////////////////////////////////////////////////////////////
 //////////////////////////// Miscellaneous ///////////////////////////////////

--- a/code/modules/mining/machine_vending.dm
+++ b/code/modules/mining/machine_vending.dm
@@ -10,7 +10,7 @@
 	circuit = /obj/item/circuitboard/machine/mining_equipment_vendor
 	var/icon_deny = "mining-deny"
 	var/obj/item/card/id/inserted_id
-	var/list/prize_list = list( //if you add something to this, please, for the love of god, use tabs and not spaces.
+	var/list/prize_list = list( //if you add something to this, please, for the love of god, sort it by price/type. use tabs and not spaces.
 		new /datum/data/mining_equipment("1 Marker Beacon",				/obj/item/stack/marker_beacon,										10),
 		new /datum/data/mining_equipment("10 Marker Beacons",			/obj/item/stack/marker_beacon/ten,									100),
 		new /datum/data/mining_equipment("30 Marker Beacons",			/obj/item/stack/marker_beacon/thirty,								300),
@@ -18,9 +18,8 @@
 		new /datum/data/mining_equipment("Absinthe",					/obj/item/reagent_containers/food/drinks/bottle/absinthe/premium,	100),
 		new /datum/data/mining_equipment("Cigar",						/obj/item/clothing/mask/cigarette/cigar/havana,						150),
 		new /datum/data/mining_equipment("Soap",						/obj/item/soap/nanotrasen,											200),
-		new /datum/data/mining_equipment("Laser Pointer",				/obj/item/laser_pointer,										300),
+		new /datum/data/mining_equipment("Laser Pointer",				/obj/item/laser_pointer,											300),
 		new /datum/data/mining_equipment("Alien Toy",					/obj/item/clothing/mask/facehugger/toy,								300),
-		new /datum/data/mining_equipment("Advanced Scanner",			/obj/item/t_scanner/adv_mining_scanner,						800),
 		new /datum/data/mining_equipment("Stabilizing Serum",			/obj/item/hivelordstabilizer,										400),
 		new /datum/data/mining_equipment("Fulton Beacon",				/obj/item/fulton_core,												400),
 		new /datum/data/mining_equipment("Shelter Capsule",				/obj/item/survivalcapsule,											400),
@@ -30,9 +29,10 @@
 		new /datum/data/mining_equipment("Survival Medipen",			/obj/item/reagent_containers/hypospray/medipen/survival,			500),
 		new /datum/data/mining_equipment("Brute First-Aid Kit",			/obj/item/storage/firstaid/brute,									600),
 		new /datum/data/mining_equipment("Tracking Implant Kit", 		/obj/item/storage/box/minertracker,									600),
-		new /datum/data/mining_equipment("Jaunter",						/obj/item/wormhole_jaunter,									750),
+		new /datum/data/mining_equipment("Jaunter",						/obj/item/wormhole_jaunter,											750),
 		new /datum/data/mining_equipment("Kinetic Crusher",				/obj/item/twohanded/required/kinetic_crusher,						750),
 		new /datum/data/mining_equipment("Kinetic Accelerator",			/obj/item/gun/energy/kinetic_accelerator,							750),
+		new /datum/data/mining_equipment("Advanced Scanner",			/obj/item/t_scanner/adv_mining_scanner,								800),
 		new /datum/data/mining_equipment("Resonator",					/obj/item/resonator,												800),
 		new /datum/data/mining_equipment("Fulton Pack",					/obj/item/extraction_pack,											1000),
 		new /datum/data/mining_equipment("Lazarus Injector",			/obj/item/lazarus_injector,											1000),
@@ -46,8 +46,8 @@
 		new /datum/data/mining_equipment("Jump Boots",					/obj/item/clothing/shoes/bhop,										2500),
 		new /datum/data/mining_equipment("Luxury Shelter Capsule",		/obj/item/survivalcapsule/luxury,									3000),
 		new /datum/data/mining_equipment("Nanotrasen Minebot",			/mob/living/simple_animal/hostile/mining_drone,						800),
-		new /datum/data/mining_equipment("Minebot Melee Upgrade",		/obj/item/mine_bot_upgrade,									400),
-		new /datum/data/mining_equipment("Minebot Armor Upgrade",		/obj/item/mine_bot_upgrade/health,							400),
+		new /datum/data/mining_equipment("Minebot Melee Upgrade",		/obj/item/mine_bot_upgrade,											400),
+		new /datum/data/mining_equipment("Minebot Armor Upgrade",		/obj/item/mine_bot_upgrade/health,									400),
 		new /datum/data/mining_equipment("Minebot Cooldown Upgrade",	/obj/item/borg/upgrade/modkit/cooldown/minebot,						600),
 		new /datum/data/mining_equipment("Minebot AI Upgrade",			/obj/item/slimepotion/slime/sentience/mining,						1000),
 		new /datum/data/mining_equipment("KA Minebot Passthrough",		/obj/item/borg/upgrade/modkit/minebot_passthrough,					100),


### PR DESCRIPTION
:cl: Denton
add: Departmental wardrobe vendors have been added to all maps.
spellcheck: Sorted cargo packs (wardrobe refills//alphabetically) and mining vendor items (by price), again.
/:cl:

This PR adds the departmental wardrobe vendors from #37859 to all maps, replacing the closets.

Everything else is essentially the same - in a bunch of spots I had to move air alarms/intercoms so they wouldn't be blocked by the vendor.
Whenever closets had extra items in them, I put them in nearby closets/on tables (stethoscopes, medical belts etc.). Extra winter jackets/satchels were removed, since they're included in the vendor anyway.

Also, I grouped the cargo refill packs and put them at the bottom of the toys/costumes section for better visibility.