### PR TITLE
Adds engineering modular computers to AI satellites.

### DIFF
--- a/_maps/map_files/BoxStation/BoxStation.dmm
+++ b/_maps/map_files/BoxStation/BoxStation.dmm
@@ -49692,14 +49692,8 @@
 /obj/machinery/light/small{
 	dir = 1
 	},
-/obj/structure/table/reinforced,
-/obj/item/paper_bin{
-	pixel_x = -3;
-	pixel_y = 7
-	},
-/obj/item/pen{
-	pixel_x = 4;
-	pixel_y = 4
+/obj/machinery/modular_computer/console/preset/engineering{
+	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/ai)

--- a/_maps/map_files/Deltastation/DeltaStation2.dmm
+++ b/_maps/map_files/Deltastation/DeltaStation2.dmm
@@ -33952,7 +33952,7 @@
 	icon_state = "0-4"
 	},
 /obj/machinery/modular_computer/console/preset/engineering{
-	dir = 4
+	dir = 6
 	},
 /turf/open/floor/plasteel/caution{
 	dir = 8
@@ -43442,7 +43442,7 @@
 	req_access_txt = "39; 19"
 	},
 /obj/machinery/modular_computer/console/preset/engineering{
-	dir = 4
+	dir = 6
 	},
 /turf/open/floor/plasteel/vault{
 	dir = 5
@@ -100171,6 +100171,14 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/closed/wall/r_wall,
 /area/science/circuit)
+"gqA" = (
+/obj/machinery/modular_computer/console/preset/engineering{
+	dir = 8
+	},
+/turf/open/floor/plasteel/vault{
+	dir = 8
+	},
+/area/ai_monitored/turret_protected/ai)
 "gKr" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 1
@@ -110322,7 +110330,7 @@ btH
 btH
 btH
 bzc
-bAG
+gqA
 btH
 bEm
 btH

--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -28141,13 +28141,11 @@
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/ai)
 "bis" = (
-/obj/structure/table/reinforced,
-/obj/item/folder/blue{
-	pixel_y = 2
-	},
-/obj/item/pen,
 /obj/machinery/light/small{
 	dir = 4
+	},
+/obj/machinery/modular_computer/console/preset/engineering{
+	dir = 8
 	},
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/ai)

--- a/_maps/map_files/OmegaStation/OmegaStation.dmm
+++ b/_maps/map_files/OmegaStation/OmegaStation.dmm
@@ -34377,9 +34377,9 @@
 /turf/open/floor/plasteel/vault/side,
 /area/ai_monitored/turret_protected/ai)
 "sMx" = (
-/obj/item/folder/blue,
-/obj/item/assembly/flash/handheld,
-/obj/structure/table,
+/obj/machinery/modular_computer/console/preset/engineering{
+	dir = 1
+	},
 /turf/open/floor/plasteel/vault{
 	dir = 8
 	},

--- a/_maps/map_files/PubbyStation/PubbyStation.dmm
+++ b/_maps/map_files/PubbyStation/PubbyStation.dmm
@@ -602,14 +602,14 @@
 /turf/open/floor/plasteel/grimy,
 /area/ai_monitored/turret_protected/aisat_interior)
 "ado" = (
-/obj/structure/table,
-/obj/item/pen,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/machinery/firealarm{
 	dir = 4;
 	pixel_x = 28
 	},
-/obj/item/paper_bin,
+/obj/machinery/modular_computer/console/preset/engineering{
+	dir = 8
+	},
 /turf/open/floor/plasteel/grimy,
 /area/ai_monitored/turret_protected/aisat_interior)
 "adp" = (


### PR DESCRIPTION
This PR adds engineering modular computers to the AI satellites on all maps. This is largely for easy of life due to the nifty programs on them for the AI to monitor situations. This is so said computers are closer to them and they don't have to bookmark the bridge one.

:cl: Firecage
add: Adds engineering modular computers to the AI satellites on all maps.
/:cl: