### PR TITLE
[s] Power monitor tweaks and fixes

### DIFF
--- a/_maps/RandomRuins/LavaRuins/lavaland_surface_biodome_winter.dmm
+++ b/_maps/RandomRuins/LavaRuins/lavaland_surface_biodome_winter.dmm
@@ -422,7 +422,7 @@
 /turf/open/floor/pod/dark,
 /area/ruin/powered/snow_biodome)
 "UM" = (
-/obj/machinery/computer/monitor{
+/obj/machinery/computer/monitor/secret{
 	dir = 1
 	},
 /turf/open/floor/pod/dark,

--- a/_maps/RandomRuins/LavaRuins/lavaland_surface_syndicate_base1.dmm
+++ b/_maps/RandomRuins/LavaRuins/lavaland_surface_syndicate_base1.dmm
@@ -3438,7 +3438,7 @@
 /obj/structure/cable/yellow{
 	icon_state = "0-2"
 	},
-/obj/machinery/computer/monitor,
+/obj/machinery/computer/monitor/secret,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/floorgrime,

--- a/_maps/RandomRuins/SpaceRuins/TheDerelict.dmm
+++ b/_maps/RandomRuins/SpaceRuins/TheDerelict.dmm
@@ -328,7 +328,7 @@
 /turf/closed/wall/r_wall,
 /area/ruin/unpowered/no_grav)
 "aZ" = (
-/obj/machinery/computer/monitor{
+/obj/machinery/computer/monitor/secret{
 	dir = 4
 	},
 /obj/structure/cable{

--- a/_maps/RandomZLevels/moonoutpost19.dmm
+++ b/_maps/RandomZLevels/moonoutpost19.dmm
@@ -728,7 +728,7 @@
 /obj/structure/cable{
 	icon_state = "0-4"
 	},
-/obj/machinery/computer/monitor,
+/obj/machinery/computer/monitor/secret,
 /obj/effect/turf_decal/stripes/line{
 	dir = 5
 	},
@@ -3124,7 +3124,7 @@
 	},
 /area/awaymission/moonoutpost19/research)
 "gA" = (
-/obj/machinery/computer/monitor{
+/obj/machinery/computer/monitor/secret{
 	dir = 1
 	},
 /obj/structure/cable,

--- a/_maps/RandomZLevels/snowdin.dmm
+++ b/_maps/RandomZLevels/snowdin.dmm
@@ -5713,7 +5713,7 @@
 /turf/open/floor/plasteel,
 /area/awaymission/snowdin/post/engineering)
 "ns" = (
-/obj/machinery/computer/monitor,
+/obj/machinery/computer/monitor/secret,
 /obj/structure/cable/yellow{
 	icon_state = "0-8"
 	},
@@ -7654,7 +7654,7 @@
 /turf/open/floor/plating,
 /area/awaymission/snowdin/post/cavern2)
 "sv" = (
-/obj/machinery/computer/monitor{
+/obj/machinery/computer/monitor/secret{
 	dir = 8
 	},
 /obj/structure/cable/yellow,
@@ -8295,7 +8295,7 @@
 	},
 /area/awaymission/snowdin/post/cavern1)
 "uA" = (
-/obj/machinery/computer/monitor{
+/obj/machinery/computer/monitor/secret{
 	dir = 1
 	},
 /obj/structure/cable/yellow{
@@ -9090,7 +9090,7 @@
 /turf/open/floor/plating,
 /area/awaymission/snowdin/post/mining_dock)
 "wJ" = (
-/obj/machinery/computer/monitor,
+/obj/machinery/computer/monitor/secret,
 /obj/structure/cable/yellow{
 	icon_state = "2-8"
 	},
@@ -10729,7 +10729,7 @@
 /turf/open/floor/plating,
 /area/awaymission/snowdin/post/minipost)
 "Br" = (
-/obj/machinery/computer/monitor,
+/obj/machinery/computer/monitor/secret,
 /turf/open/floor/plating,
 /area/awaymission/snowdin/post/minipost)
 "Bs" = (
@@ -13358,7 +13358,7 @@
 	},
 /area/awaymission/snowdin/post/mining_main)
 "IZ" = (
-/obj/machinery/computer/monitor,
+/obj/machinery/computer/monitor/secret,
 /obj/structure/cable/yellow{
 	icon_state = "0-4"
 	},
@@ -13777,7 +13777,7 @@
 /obj/structure/cable/yellow{
 	icon_state = "2-8"
 	},
-/obj/machinery/computer/monitor,
+/obj/machinery/computer/monitor/secret,
 /obj/structure/cable/yellow{
 	icon_state = "0-8"
 	},

--- a/_maps/RandomZLevels/undergroundoutpost45.dmm
+++ b/_maps/RandomZLevels/undergroundoutpost45.dmm
@@ -8236,7 +8236,7 @@
 /obj/structure/cable{
 	icon_state = "0-4"
 	},
-/obj/machinery/computer/monitor{
+/obj/machinery/computer/monitor/secret{
 	name = "primary power monitoring console"
 	},
 /obj/structure/sign/warning/nosmoking{
@@ -11911,7 +11911,7 @@
 	},
 /area/awaymission/undergroundoutpost45/engineering)
 "xk" = (
-/obj/machinery/computer/monitor{
+/obj/machinery/computer/monitor/secret{
 	dir = 1;
 	name = "primary power monitoring console"
 	},

--- a/_maps/map_files/generic/CentCom.dmm
+++ b/_maps/map_files/generic/CentCom.dmm
@@ -7087,7 +7087,7 @@
 /turf/open/floor/plasteel,
 /area/centcom/ferry)
 "tE" = (
-/obj/machinery/computer/monitor{
+/obj/machinery/computer/monitor/secret{
 	dir = 1
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on{

--- a/_maps/shuttles/emergency_cere.dmm
+++ b/_maps/shuttles/emergency_cere.dmm
@@ -1022,7 +1022,7 @@
 /obj/machinery/light{
 	dir = 1
 	},
-/obj/machinery/computer/monitor,
+/obj/machinery/computer/monitor/secret,
 /turf/open/floor/plasteel/yellow/side{
 	dir = 1
 	},

--- a/_maps/shuttles/pirate_default.dmm
+++ b/_maps/shuttles/pirate_default.dmm
@@ -47,7 +47,7 @@
 "ah" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/computer/monitor{
+/obj/machinery/computer/monitor/secret{
 	dir = 8
 	},
 /turf/open/floor/plasteel/dark,
@@ -1189,7 +1189,7 @@
 	},
 /area/shuttle/pirate)
 "cI" = (
-/obj/machinery/computer/monitor{
+/obj/machinery/computer/monitor/secret{
 	dir = 8
 	},
 /obj/structure/cable/yellow{

--- a/code/game/objects/items/circuitboards/computer_circuitboards.dm
+++ b/code/game/objects/items/circuitboards/computer_circuitboards.dm
@@ -135,6 +135,10 @@
 	name = "Power Monitor (Computer Board)"  //name fixed 250810
 	build_path = /obj/machinery/computer/monitor
 
+/obj/item/circuitboard/computer/powermonitor/secret
+	name = "Outdated Power Monitor (Computer Board)" //Variant used on ruins to prevent them from showing up on PDA's.
+	build_path = /obj/machinery/computer/monitor/secret
+
 /obj/item/circuitboard/computer/olddoor
 	name = "DoorMex (Computer Board)"
 	build_path = /obj/machinery/computer/pod/old

--- a/code/game/objects/items/devices/PDA/cart.dm
+++ b/code/game/objects/items/devices/PDA/cart.dm
@@ -266,7 +266,7 @@ Code:
 					continue
 				if(pda_turf.z != pMon.z) //and that we're on the same zlevel as the computer (lore: limited signal strength)
 					continue
-				if(!is_station_level(pMon.z)) //and it isn't located on centcom / off in space, allowing people to metagame ruins
+				if(pMon.is_secret_monitor) //make sure it isn't a secret one (ie located on a ruin), allowing people to metagame ruins
 					continue
 				powercount++
 				powermonitors += pMon

--- a/code/game/objects/items/devices/PDA/cart.dm
+++ b/code/game/objects/items/devices/PDA/cart.dm
@@ -266,7 +266,7 @@ Code:
 					continue
 				if(pda_turf.z != pMon.z) //and that we're on the same zlevel as the computer (lore: limited signal strength)
 					continue
-				if(pMon.is_secret_monitor) //make sure it isn't a secret one (ie located on a ruin), allowing people to metagame ruins
+				if(pMon.is_secret_monitor) //make sure it isn't a secret one (ie located on a ruin), allowing people to metagame that the location exists
 					continue
 				powercount++
 				powermonitors += pMon

--- a/code/game/objects/items/devices/PDA/cart.dm
+++ b/code/game/objects/items/devices/PDA/cart.dm
@@ -260,10 +260,16 @@ Code:
 
 
 
+			var/turf/pda_turf = get_turf(src)
 			for(var/obj/machinery/computer/monitor/pMon in GLOB.machines)
-				if(!(pMon.stat & (NOPOWER | BROKEN)) )
-					powercount++
-					powermonitors += pMon
+				if(pMon.stat & (NOPOWER | BROKEN)) //check to make sure the computer is functional
+					continue
+				if(pda_turf.z != pMon.z) //and that we're on the same zlevel as the computer (lore: limited signal strength)
+					continue
+				if(!is_station_level(pMon.z)) //and it isn't located on centcom / off in space, allowing people to metagame ruins
+					continue
+				powercount++
+				powermonitors += pMon
 
 
 			if(!powercount)
@@ -274,22 +280,23 @@ Code:
 				var/count = 0
 				for(var/obj/machinery/computer/monitor/pMon in powermonitors)
 					count++
-					menu += "<a href='byond://?src=[REF(src)];choice=Power Select;target=[count]'>[pMon] </a><BR>"
+					menu += "<a href='byond://?src=[REF(src)];choice=Power Select;target=[count]'>[pMon] - [get_area_name(pMon, TRUE)] </a><BR>"
 
 				menu += "</FONT>"
 
 		if (433)
 			menu = "<h4>[PDAIMG(power)] Power Monitor </h4><BR>"
-			if(!powmonitor)
+			if(!powmonitor || !powmonitor.get_powernet())
 				menu += "<span class='danger'>No connection<BR></span>"
 			else
 				var/list/L = list()
-				for(var/obj/machinery/power/terminal/term in powmonitor.attached.powernet.nodes)
+				var/datum/powernet/connected_powernet = powmonitor.get_powernet()
+				for(var/obj/machinery/power/terminal/term in connected_powernet.nodes)
 					if(istype(term.master, /obj/machinery/power/apc))
 						var/obj/machinery/power/apc/A = term.master
 						L += A
 
-				menu += "<PRE>Total power: [DisplayPower(powmonitor.attached.powernet.viewavail)]<BR>Total load:  [DisplayPower(powmonitor.attached.powernet.viewload)]<BR>"
+				menu += "<PRE>Location: [get_area_name(powmonitor, TRUE)]<BR>Total power: [DisplayPower(connected_powernet.viewavail)]<BR>Total load:  [DisplayPower(connected_powernet.viewload)]<BR>"
 
 				menu += "<FONT SIZE=-1>"
 

--- a/code/modules/modular_computers/file_system/programs/powermonitor.dm
+++ b/code/modules/modular_computers/file_system/programs/powermonitor.dm
@@ -1,3 +1,5 @@
+//normal computer version is located in code\modules\power\monitor.dm, /obj/machinery/computer/monitor
+
 /datum/computer_file/program/power_monitor
 	filename = "powermonitor"
 	filedesc = "Power Monitor"
@@ -14,7 +16,8 @@
 	ui_y = 1000
 
 	var/has_alert = 0
-	var/obj/structure/cable/attached
+	var/obj/structure/cable/attached_wire
+	var/obj/machinery/power/apc/local_apc
 	var/list/history = list()
 	var/record_size = 60
 	var/record_interval = 50
@@ -29,42 +32,62 @@
 
 
 /datum/computer_file/program/power_monitor/process_tick()
-	if(!attached)
+	if(!get_powernet())
 		search()
 	else
 		record()
 
-/datum/computer_file/program/power_monitor/proc/search()
+/datum/computer_file/program/power_monitor/proc/search() //keep in sync with /obj/machinery/computer/monitor's version
 	var/turf/T = get_turf(computer)
-	attached = locate() in T
+	attached_wire = locate(/obj/structure/cable) in T
+	if(attached_wire)
+		return
+	var/area/A = get_area(computer) //if the computer isn't directly connected to a wire, attempt to find the APC powering it to pull it's powernet instead
+	if(!A)
+		return
+	local_apc = A.get_apc()
+	if(!local_apc)
+		return
+	if(!local_apc.terminal) //this really shouldn't happen without badminnery.
+		local_apc = null
 
-/datum/computer_file/program/power_monitor/proc/record()
+/datum/computer_file/program/power_monitor/proc/get_powernet() //keep in sync with /obj/machinery/computer/monitor's version
+	if(attached_wire || (local_apc && local_apc.terminal))
+		return attached_wire ? attached_wire.powernet : local_apc.terminal.powernet
+	return FALSE
+
+/datum/computer_file/program/power_monitor/proc/record() //keep in sync with /obj/machinery/computer/monitor's version
 	if(world.time >= next_record)
 		next_record = world.time + record_interval
 
+		var/datum/powernet/connected_powernet = get_powernet()
+
 		var/list/supply = history["supply"]
-		supply += attached.powernet.viewavail
+		if(connected_powernet)
+			supply += connected_powernet.viewavail
 		if(supply.len > record_size)
 			supply.Cut(1, 2)
 
 		var/list/demand = history["demand"]
-		demand += attached.powernet.viewload
+		if(connected_powernet)
+			demand += connected_powernet.viewload
 		if(demand.len > record_size)
 			demand.Cut(1, 2)
 
 /datum/computer_file/program/power_monitor/ui_data()
+	var/datum/powernet/connected_powernet = get_powernet()
 	var/list/data = get_header_data()
 	data["stored"] = record_size
 	data["interval"] = record_interval / 10
-	data["attached"] = attached ? TRUE : FALSE
-	if(attached)
-		data["supply"] = DisplayPower(attached.powernet.viewavail)
-		data["demand"] = DisplayPower(attached.powernet.viewload)
+	data["attached"] = connected_powernet ? TRUE : FALSE
+	if(connected_powernet)
+		data["supply"] = DisplayPower(connected_powernet.viewavail)
+		data["demand"] = DisplayPower(connected_powernet.viewload)
 	data["history"] = history
 
 	data["areas"] = list()
-	if(attached)
-		for(var/obj/machinery/power/terminal/term in attached.powernet.nodes)
+	if(connected_powernet)
+		for(var/obj/machinery/power/terminal/term in connected_powernet.nodes)
 			var/obj/machinery/power/apc/A = term.master
 			if(istype(A))
 				data["areas"] += list(list(

--- a/code/modules/power/monitor.dm
+++ b/code/modules/power/monitor.dm
@@ -21,7 +21,14 @@
 	var/is_secret_monitor = FALSE
 
 /obj/machinery/computer/monitor/secret //Hides the power monitor (such as ones on ruins & CentCom) from PDA's to prevent metagaming.
+	name = "outdated power monitoring console"
+	desc = "It monitors power levels across the local powernet."
+	circuit = /obj/item/circuitboard/computer/powermonitor/secret
 	is_secret_monitor = TRUE
+
+/obj/machinery/computer/monitor/secret/examine(mob/user)
+	..()
+	to_chat(user, "<span class='notice'>It's operating system seems quite outdated... It doesn't seem like it'd be compatible with the latest remote NTOS monitoring systems.</span>")
 
 /obj/machinery/computer/monitor/Initialize()
 	. = ..()

--- a/code/modules/power/monitor.dm
+++ b/code/modules/power/monitor.dm
@@ -18,6 +18,10 @@
 	var/record_size = 60
 	var/record_interval = 50
 	var/next_record = 0
+	var/is_secret_monitor = FALSE
+
+/obj/machinery/computer/monitor/secret //Hides the power monitor (such as ones on ruins & CentCom) from PDA's to prevent metagaming.
+	is_secret_monitor = TRUE
 
 /obj/machinery/computer/monitor/Initialize()
 	. = ..()

--- a/code/modules/power/monitor.dm
+++ b/code/modules/power/monitor.dm
@@ -1,3 +1,5 @@
+//modular computer program version is located in code\modules\modular_computers\file_system\programs\powermonitor.dm, /datum/computer_file/program/power_monitor
+
 /obj/machinery/computer/monitor
 	name = "power monitoring console"
 	desc = "It monitors power levels across the station."
@@ -9,7 +11,8 @@
 	active_power_usage = 100
 	circuit = /obj/item/circuitboard/computer/powermonitor
 
-	var/obj/structure/cable/attached
+	var/obj/structure/cable/attached_wire
+	var/obj/machinery/power/apc/local_apc
 
 	var/list/history = list()
 	var/record_size = 60
@@ -23,30 +26,47 @@
 	history["demand"] = list()
 
 /obj/machinery/computer/monitor/process()
-	if(!attached)
+	if(!get_powernet())
 		use_power = IDLE_POWER_USE
 		search()
 	else
 		use_power = ACTIVE_POWER_USE
 		record()
 
-/obj/machinery/computer/monitor/proc/search()
+/obj/machinery/computer/monitor/proc/search() //keep in sync with /datum/computer_file/program/power_monitor's version
 	var/turf/T = get_turf(src)
-	attached = locate() in T
+	attached_wire = locate(/obj/structure/cable) in T
+	if(attached_wire)
+		return
+	var/area/A = get_area(src) //if the computer isn't directly connected to a wire, attempt to find the APC powering it to pull it's powernet instead
+	if(!A)
+		return
+	local_apc = A.get_apc()
+	if(!local_apc)
+		return
+	if(!local_apc.terminal) //this really shouldn't happen without badminnery.
+		local_apc = null
 
-/obj/machinery/computer/monitor/proc/record()
+/obj/machinery/computer/monitor/proc/get_powernet() //keep in sync with /datum/computer_file/program/power_monitor's version
+	if(attached_wire || (local_apc && local_apc.terminal))
+		return attached_wire ? attached_wire.powernet : local_apc.terminal.powernet
+	return FALSE
+
+/obj/machinery/computer/monitor/proc/record() //keep in sync with /datum/computer_file/program/power_monitor's version
 	if(world.time >= next_record)
 		next_record = world.time + record_interval
 
+		var/datum/powernet/connected_powernet = get_powernet()
+
 		var/list/supply = history["supply"]
-		if(attached.powernet)
-			supply += attached.powernet.viewavail
+		if(connected_powernet)
+			supply += connected_powernet.viewavail
 		if(supply.len > record_size)
 			supply.Cut(1, 2)
 
 		var/list/demand = history["demand"]
-		if(attached.powernet)
-			demand += attached.powernet.viewload
+		if(connected_powernet)
+			demand += connected_powernet.viewload
 		if(demand.len > record_size)
 			demand.Cut(1, 2)
 
@@ -58,17 +78,18 @@
 		ui.open()
 
 /obj/machinery/computer/monitor/ui_data()
+	var/datum/powernet/connected_powernet = get_powernet()
 	var/list/data = list()
 	data["stored"] = record_size
 	data["interval"] = record_interval / 10
-	data["attached"] = attached ? TRUE : FALSE
+	data["attached"] = connected_powernet ? TRUE : FALSE
 	data["history"] = history
 	data["areas"] = list()
 
-	if(attached)
-		data["supply"] = DisplayPower(attached.powernet.viewavail)
-		data["demand"] = DisplayPower(attached.powernet.viewload)
-		for(var/obj/machinery/power/terminal/term in attached.powernet.nodes)
+	if(connected_powernet)
+		data["supply"] = DisplayPower(connected_powernet.viewavail)
+		data["demand"] = DisplayPower(connected_powernet.viewload)
+		for(var/obj/machinery/power/terminal/term in connected_powernet.nodes)
 			var/obj/machinery/power/apc/A = term.master
 			if(istype(A))
 				var/cell_charge


### PR DESCRIPTION
🆑 ShizCalev
fix: Fixed exploit allowing you to view what lavaland & space ruins spawned via the PDA power monitor program.
fix: Fixed exploit allowing you to view CentCom's power status.
tweak: PDA power monitor program will now tell you the area that the monitor is located in.
tweak: Power monitor computers & modular computers will now pull the powernet of their local APC if they aren't directly wired into a powernet.
/🆑
