### PR TITLE
Fixes some edge cases in sstimer that could cause a timer to run before it was expecting to.

### DIFF
--- a/code/controllers/subsystem/timer.dm
+++ b/code/controllers/subsystem/timer.dm
@@ -452,13 +452,13 @@ SUBSYSTEM_DEF(timer)
 		CRASH("addtimer called without a callback")
 
 	if (wait < 0)
-		stack_trace("addtimer called with a negative wait. Converting to 0")
+		stack_trace("addtimer called with a negative wait. Converting to [world.tick_lag]")
 
 	//alot of things add short timers on themselves in their destroy, we ignore those cases
 	if (wait >= 1 && callback && callback.object && callback.object != GLOBAL_PROC && QDELETED(callback.object))
 		stack_trace("addtimer called with a callback assigned to a qdeleted object")
 
-	wait = max(wait, 0)
+	wait = max(CEILING(wait, world.tick_lag), world.tick_lag)
 
 	if(wait >= INFINITY)
 		CRASH("Attempted to create timer with INFINITY delay")


### PR DESCRIPTION
Because sstimer tracks timers internally in the terms of what "byond tick" they are suppose to run at; float wait values are now rounded *up* to the next Byond Tick rather then have byond round the resulting list index *down* at access time.

`0` wait timers are now rounded *up* to `world.tick_lag` to avoid incompatibilities with editing the current tick's bucket while it was being processed. This also matches how byond treats spawn(0) and sleep(0)