### PR TITLE
Timers on qdeleted objects is no longer supported.

### DIFF
--- a/code/controllers/subsystem/timer.dm
+++ b/code/controllers/subsystem/timer.dm
@@ -326,7 +326,7 @@ SUBSYSTEM_DEF(timer)
 	if ((timeToRun < world.time || timeToRun < SStimer.head_offset) && !(flags & TIMER_CLIENT_TIME))
 		CRASH("Invalid timer state: Timer created that would require a backtrack to run (addtimer would never let this happen): [SStimer.get_timer_debug_string(src)]")
 
-	if (callBack.object != GLOBAL_PROC)
+	if (callBack.object != GLOBAL_PROC && !QDESTROYING(callBack.object))
 		LAZYADD(callBack.object.active_timers, src)
 
 
@@ -454,9 +454,8 @@ SUBSYSTEM_DEF(timer)
 	if (wait < 0)
 		stack_trace("addtimer called with a negative wait. Converting to 0")
 
-	//alot of things add short timers on themselves in their destroy, we ignore those cases
-	if (wait >= 1 && callback && callback.object && callback.object != GLOBAL_PROC && QDELETED(callback.object))
-		stack_trace("addtimer called with a callback assigned to a qdeleted object")
+	if (callback.object != GLOBAL_PROC && QDELETED(callback.object) && !QDESTROYING(callback.object))
+		stack_trace("addtimer called with a callback assigned to a qdeleted object. In the future such timers will not be supported and may refuse to run or run with a 0 wait")
 
 	wait = max(wait, 0)
 


### PR DESCRIPTION
Before we only warned if the wait was 1 or higher to solve issues with objects settings timers on themselves while getting qdeleted, a common enough usecase to support (even if it is annoying), but then I remembered we could check for qdestroying directly.

Also fixes it so such `destory()` time timers actually run consistently. before they would only work if called after the `..()` in `destroy()`.

After dealing with the cases that come up, we can look at changing this to a `crash()`