### PR TITLE
Fixes drones being able to magically sense invisible revenants

### DIFF
--- a/code/modules/antagonists/revenant/revenant.dm
+++ b/code/modules/antagonists/revenant/revenant.dm
@@ -109,6 +109,12 @@
 		revealed = FALSE
 		incorporeal_move = INCORPOREAL_MOVE_JAUNT
 		invisibility = INVISIBILITY_REVENANT
+		if(staticOverlays.len)
+			for(var/mob/living/simple_animal/drone/D in GLOB.drones_list)
+				if(D && D.client && D.seeStatic)
+					for(var/image/I in staticOverlays)
+						D.staticOverlays.Remove(I)
+						D.client.images.Remove(I)
 		to_chat(src, "<span class='revenboldnotice'>You are once more concealed.</span>")
 	if(unstun_time && world.time >= unstun_time)
 		unstun_time = 0
@@ -245,6 +251,15 @@
 	else
 		to_chat(src, "<span class='revenwarning'>You have been revealed!</span>")
 		unreveal_time = unreveal_time + time
+	if(staticOverlays.len)
+		for(var/mob/living/simple_animal/drone/D in GLOB.drones_list)
+			if(D && D.client && D.seeStatic)
+				if(D.staticChoice in staticOverlays)
+					D.staticOverlays |= staticOverlays[D.staticChoice]
+					D.client.images |= staticOverlays[D.staticChoice]
+				else
+					D.staticOverlays |= staticOverlays["static"]
+					D.client.images |= staticOverlays["static"]
 	update_spooky_icon()
 
 /mob/living/simple_animal/revenant/proc/stun(time)

--- a/code/modules/antagonists/revenant/revenant.dm
+++ b/code/modules/antagonists/revenant/revenant.dm
@@ -112,9 +112,8 @@
 		if(staticOverlays.len)
 			for(var/mob/living/simple_animal/drone/D in GLOB.drones_list)
 				if(D && D.client && D.seeStatic)
-					for(var/image/I in staticOverlays)
-						D.staticOverlays.Remove(I)
-						D.client.images.Remove(I)
+					D.staticOverlays.Remove(staticOverlays)
+					D.client.images.Remove(staticOverlays)
 		to_chat(src, "<span class='revenboldnotice'>You are once more concealed.</span>")
 	if(unstun_time && world.time >= unstun_time)
 		unstun_time = 0

--- a/code/modules/mob/living/simple_animal/friendly/drone/visuals_icons.dm
+++ b/code/modules/mob/living/simple_animal/friendly/drone/visuals_icons.dm
@@ -154,6 +154,10 @@
 			var/mob/living/L = i
 			if(isdrone(L) || !L.staticOverlays.len)
 				continue
+			if(isrevenant(L))
+				var/mob/living/simple_animal/revenant/R = L
+				if (!R.revealed)
+					continue
 			var/image/chosen
 			if(staticChoice in L.staticOverlays)
 				chosen = L.staticOverlays[staticChoice]


### PR DESCRIPTION
Fixes #38016

:cl: Naksu
fix: Drones can no longer see a static overlay over invisible revenants
/:cl:
