### PR TITLE
Shuffles Exited() call to after loc is actually changed in forceMove. Fixes storage forcing everything to mouse opacity fulltile

### DIFF
--- a/code/game/atoms_movable.dm
+++ b/code/game/atoms_movable.dm
@@ -310,14 +310,14 @@
 		var/area/old_area = get_area(oldloc)
 		var/area/destarea = get_area(destination)
 
-		if(oldloc && !same_loc)
-			oldloc.Exited(src, destination)
-			if(old_area)
-				old_area.Exited(src, destination)
 
 		loc = destination
 
 		if(!same_loc)
+			if(oldloc)
+				oldloc.Exited(src, destination)
+				if(old_area)
+					old_area.Exited(src, destination)
 			var/turf/oldturf = get_turf(oldloc)
 			var/turf/destturf = get_turf(destination)
 			var/old_z = (oldturf ? oldturf.z : null)
@@ -332,6 +332,7 @@
 				if(AM == src)
 					continue
 				AM.Crossed(src, oldloc)
+
 		Moved(oldloc, NONE, TRUE)
 		. = TRUE
 

--- a/code/game/mecha/mecha.dm
+++ b/code/game/mecha/mecha.dm
@@ -927,9 +927,9 @@
 
 /obj/mecha/Exited(atom/movable/M, atom/newloc)
 	if(occupant && occupant == M) // The occupant exited the mech without calling go_out()
-		go_out(1, newloc)
+		go_out(TRUE, newloc)
 
-/obj/mecha/proc/go_out(var/forced, var/atom/newloc = loc)
+/obj/mecha/proc/go_out(forced, atom/newloc = loc)
 	if(!occupant)
 		return
 	var/atom/movable/mob_container

--- a/code/game/objects/items/storage/wallets.dm
+++ b/code/game/objects/items/storage/wallets.dm
@@ -38,17 +38,13 @@
 
 /obj/item/storage/wallet/Exited(atom/movable/AM)
 	. = ..()
-	// The loc has not actually changed yet when this proc is called, so call
-	// refreshID and have it ignore the outgoing atom.
-	refreshID(AM)
+	refreshID()
 
-/obj/item/storage/wallet/proc/refreshID(atom/movable/removed)
+/obj/item/storage/wallet/proc/refreshID()
 	LAZYCLEARLIST(combined_access)
-	if(!(front_id in src) || front_id == removed)
+	if(!(front_id in src))
 		front_id = null
 	for(var/obj/item/card/id/I in contents)
-		if(I == removed)
-			continue
 		if(!front_id)
 			front_id = I
 		LAZYINITLIST(combined_access)

--- a/code/modules/lighting/lighting_turf.dm
+++ b/code/modules/lighting/lighting_turf.dm
@@ -95,7 +95,7 @@
 				has_opaque_atom = TRUE
 				break
 
-/turf/Exited(var/atom/movable/Obj, var/atom/newloc)
+/turf/Exited(atom/movable/Obj, atom/newloc)
 	. = ..()
 
 	if (Obj && Obj.opacity)


### PR DESCRIPTION
Makes more sense because ExitED() implies the thing already exited, instead of right before it actually exits.
Fixes #38013