### PR TITLE
Fix various bugs with telekinesis

### DIFF
--- a/code/__HELPERS/unsorted.dm
+++ b/code/__HELPERS/unsorted.dm
@@ -922,7 +922,7 @@ GLOBAL_LIST_INIT(WALLITEMS_INVERSE, typecacheof(list(
 		else
 			return "white"
 
-/proc/params2turf(scr_loc, turf/origin)
+/proc/params2turf(scr_loc, turf/origin, client/C)
 	if(!scr_loc)
 		return null
 	var/tX = splittext(scr_loc, ",")
@@ -931,11 +931,12 @@ GLOBAL_LIST_INIT(WALLITEMS_INVERSE, typecacheof(list(
 	tY = tY[1]
 	tX = splittext(tX[1], ":")
 	tX = tX[1]
-	tX = CLAMP(origin.x + text2num(tX) - world.view - 1, 1, world.maxx)
-	tY = CLAMP(origin.y + text2num(tY) - world.view - 1, 1, world.maxy)
+	var/list/actual_view = getviewsize(C ? C.view : world.view)
+	tX = CLAMP(origin.x + text2num(tX) - round(actual_view[1] / 2) - 1, 1, world.maxx)
+	tY = CLAMP(origin.y + text2num(tY) - round(actual_view[2] / 2) - 1, 1, world.maxy)
 	return locate(tX, tY, tZ)
 
-/proc/screen_loc2turf(text, turf/origin)
+/proc/screen_loc2turf(text, turf/origin, client/C)
 	if(!text)
 		return null
 	var/tZ = splittext(text, ",")
@@ -944,8 +945,9 @@ GLOBAL_LIST_INIT(WALLITEMS_INVERSE, typecacheof(list(
 	tX = splittext(tZ[2], "-")
 	tX = text2num(tX[2])
 	tZ = origin.z
-	tX = CLAMP(origin.x + 7 - tX, 1, world.maxx)
-	tY = CLAMP(origin.y + 7 - tY, 1, world.maxy)
+	var/list/actual_view = getviewsize(C ? C.view : world.view)
+	tX = CLAMP(origin.x + round(actual_view[1] / 2) - tX, 1, world.maxx)
+	tY = CLAMP(origin.y + round(actual_view[2] / 2) - tY, 1, world.maxy)
 	return locate(tX, tY, tZ)
 
 /proc/IsValidSrc(datum/D)

--- a/code/_onclick/click.dm
+++ b/code/_onclick/click.dm
@@ -469,7 +469,7 @@
 		var/mob/living/carbon/C = usr
 		C.swap_hand()
 	else
-		var/turf/T = params2turf(modifiers["screen-loc"], get_turf(usr.client ? usr.client.eye : usr))
+		var/turf/T = params2turf(modifiers["screen-loc"], get_turf(usr.client ? usr.client.eye : usr), usr.client)
 		params += "&catcher=1"
 		if(T)
 			T.Click(location, control, params)

--- a/code/_onclick/telekinesis.dm
+++ b/code/_onclick/telekinesis.dm
@@ -104,6 +104,12 @@
 	qdel(src)
 	return
 
+/obj/item/tk_grab/examine(user)
+	if (focus)
+		focus.examine(user)
+	else
+		..()
+
 /obj/item/tk_grab/attack_self(mob/user)
 	if(!focus)
 		return

--- a/code/_onclick/telekinesis.dm
+++ b/code/_onclick/telekinesis.dm
@@ -15,7 +15,7 @@
 /atom/proc/attack_tk(mob/user)
 	if(user.stat || !tkMaxRangeCheck(user, src))
 		return
-	new /obj/effect/temp_visual/telekinesis(loc)
+	new /obj/effect/temp_visual/telekinesis(get_turf(src))
 	user.UnarmedAttack(src,0) // attack_hand, attack_paw, etc
 	add_hiddenprint(user)
 	return

--- a/code/datums/components/material_container.dm
+++ b/code/datums/components/material_container.dm
@@ -77,13 +77,14 @@
 /datum/component/material_container/proc/user_insert(obj/item/I, mob/living/user)
 	set waitfor = FALSE
 	var/requested_amount
+	var/active_held = user.get_active_held_item()  // differs from I when using TK
 	if(istype(I, /obj/item/stack) && precise_insertion)
 		var/atom/current_parent = parent
 		var/obj/item/stack/S = I
 		requested_amount = input(user, "How much do you want to insert?", "Inserting [S.singular_name]s") as num|null
 		if(isnull(requested_amount) || (requested_amount <= 0))
 			return
-		if(QDELETED(I) || QDELETED(user) || QDELETED(src) || parent != current_parent || !user.canUseTopic(current_parent, BE_CLOSE) || !user.is_holding(I))
+		if(QDELETED(I) || QDELETED(user) || QDELETED(src) || parent != current_parent || user.physical_can_use_topic(current_parent) < UI_INTERACTIVE || user.get_active_held_item() != active_held)
 			return
 	if(!user.temporarilyRemoveItemFromInventory(I))
 		to_chat(user, "<span class='warning'>[I] is stuck to you and cannot be placed into [parent].</span>")
@@ -93,16 +94,15 @@
 		if(istype(I, /obj/item/stack))
 			var/obj/item/stack/S = I
 			to_chat(user, "<span class='notice'>You insert [inserted] [S.singular_name][inserted>1 ? "s" : ""] into [parent].</span>")
-			if(!QDELETED(I))
-				if(!user.put_in_hands(I))
-					stack_trace("Warning: User could not put object back in hand during material container insertion, line [__LINE__]! This can lead to issues.")
-					I.forceMove(user.drop_location())
+			if(!QDELETED(I) && I == active_held && !user.put_in_hands(I))
+				stack_trace("Warning: User could not put object back in hand during material container insertion, line [__LINE__]! This can lead to issues.")
+				I.forceMove(user.drop_location())
 		else
 			to_chat(user, "<span class='notice'>You insert a material total of [inserted] into [parent].</span>")
 			qdel(I)
 		if(after_insert)
 			after_insert.Invoke(I.type, last_inserted_id, inserted)
-	else
+	else if(I == active_held)
 		user.put_in_active_hand(I)
 
 //For inserting an amount of material

--- a/code/datums/components/material_container.dm
+++ b/code/datums/components/material_container.dm
@@ -58,6 +58,8 @@
 		return
 	if(user.a_intent != INTENT_HELP)
 		return
+	if(I.flags_1 & ABSTRACT_1)
+		return
 	if((I.flags_1 & HOLOGRAM_1) || (I.item_flags & NO_MAT_REDEMPTION) || (tc && !is_type_in_typecache(I, tc)))
 		to_chat(user, "<span class='warning'>[parent] won't accept [I]!</span>")
 		return

--- a/code/game/objects/items/stacks/sheets/mineral.dm
+++ b/code/game/objects/items/stacks/sheets/mineral.dm
@@ -84,9 +84,10 @@ GLOBAL_LIST_INIT(sandbag_recipes, list ( \
 	if(istype(W, /obj/item/stack/ore/glass))
 		var/obj/item/stack/ore/glass/G = W
 		to_chat(user, "<span class='notice'>You fill the sandbag.</span>")
-		var/obj/item/stack/sheet/mineral/sandbags/I = new /obj/item/stack/sheet/mineral/sandbags
+		var/obj/item/stack/sheet/mineral/sandbags/I = new /obj/item/stack/sheet/mineral/sandbags(drop_location())
 		qdel(src)
-		user.put_in_hands(I)
+		if (Adjacent(user) && !issilicon(user))
+			user.put_in_hands(I)
 		G.use(1)
 	else
 		return ..()

--- a/code/game/objects/items/tools/crowbar.dm
+++ b/code/game/objects/items/tools/crowbar.dm
@@ -82,7 +82,7 @@
 
 /obj/item/crowbar/power/attack_self(mob/user)
 	playsound(get_turf(user), 'sound/items/change_jaws.ogg', 50, 1)
-	var/obj/item/wirecutters/power/cutjaws = new /obj/item/wirecutters/power
+	var/obj/item/wirecutters/power/cutjaws = new /obj/item/wirecutters/power(drop_location())
 	to_chat(user, "<span class='notice'>You attach the cutting jaws to [src].</span>")
 	qdel(src)
 	user.put_in_active_hand(cutjaws)

--- a/code/game/objects/items/tools/screwdriver.dm
+++ b/code/game/objects/items/tools/screwdriver.dm
@@ -123,7 +123,7 @@
 
 /obj/item/screwdriver/power/attack_self(mob/user)
 	playsound(get_turf(user),'sound/items/change_drill.ogg',50,1)
-	var/obj/item/wrench/power/b_drill = new /obj/item/wrench/power
+	var/obj/item/wrench/power/b_drill = new /obj/item/wrench/power(drop_location())
 	to_chat(user, "<span class='notice'>You attach the bolt driver bit to [src].</span>")
 	qdel(src)
 	user.put_in_active_hand(b_drill)

--- a/code/game/objects/items/tools/wirecutters.dm
+++ b/code/game/objects/items/tools/wirecutters.dm
@@ -107,7 +107,7 @@
 
 /obj/item/wirecutters/power/attack_self(mob/user)
 	playsound(get_turf(user), 'sound/items/change_jaws.ogg', 50, 1)
-	var/obj/item/crowbar/power/pryjaws = new /obj/item/crowbar/power
+	var/obj/item/crowbar/power/pryjaws = new /obj/item/crowbar/power(drop_location())
 	to_chat(user, "<span class='notice'>You attach the pry jaws to [src].</span>")
 	qdel(src)
 	user.put_in_active_hand(pryjaws)

--- a/code/game/objects/items/tools/wrench.dm
+++ b/code/game/objects/items/tools/wrench.dm
@@ -62,7 +62,7 @@
 
 /obj/item/wrench/power/attack_self(mob/user)
 	playsound(get_turf(user),'sound/items/change_drill.ogg',50,1)
-	var/obj/item/wirecutters/power/s_drill = new /obj/item/screwdriver/power
+	var/obj/item/wirecutters/power/s_drill = new /obj/item/screwdriver/power(drop_location())
 	to_chat(user, "<span class='notice'>You attach the screw driver bit to [src].</span>")
 	qdel(src)
 	user.put_in_active_hand(s_drill)

--- a/code/modules/food_and_drinks/kitchen_machinery/deep_fryer.dm
+++ b/code/modules/food_and_drinks/kitchen_machinery/deep_fryer.dm
@@ -30,6 +30,7 @@ God bless America.
 	use_power = IDLE_POWER_USE
 	idle_power_usage = 5
 	container_type = OPENCONTAINER
+	layer = BELOW_OBJ_LAYER
 	var/obj/item/reagent_containers/food/snacks/deepfryholder/frying	//What's being fried RIGHT NOW?
 	var/cook_time = 0
 	var/oil_use = 0.05 //How much cooking oil is used per tick
@@ -127,7 +128,9 @@ God bless America.
 			to_chat(user, "<span class='notice'>You eject [frying] from [src].</span>")
 			frying.fry(cook_time)
 			icon_state = "fryer_off"
-			user.put_in_hands(frying)
+			frying.forceMove(drop_location())
+			if(Adjacent(user) && !issilicon(user))
+				user.put_in_hands(frying)
 			frying = null
 			cook_time = 0
 			frying_fried = FALSE


### PR DESCRIPTION
:cl:
fix: Inserting materials into protolathes with telekinesis is now possible.
fix: Telekinesis no longer teleports items removed from deep fryers, constructed sandbags, and leftover materials not inserted into lathes.
fix: Telekinetic sparkles now appear in the correct place when clicking on a turf and when clicking in the fog of war in widescreen.
fix: Telekinetically adjusting power tools no longer causes them to exit the universe.
tweak: Examining a telekinetic grab in-hand will now examine the grabbed object.
/:cl:

Fixes #36404.
Fixes #36894.
Fixes #36895.
Closes #26336. A related unreported bug was fixed but TK already doesn't allow stack crafting anymore.
