### PR TITLE
Alert players when admins modify their antag reputation

### DIFF
--- a/code/modules/admin/verbs/randomverbs.dm
+++ b/code/modules/admin/verbs/randomverbs.dm
@@ -89,6 +89,7 @@
 
 	log_admin("[key_name(usr)]: Modified [key_name(C)]'s antagonist reputation [log_text]")
 	message_admins("<span class='adminnotice'>[key_name_admin(usr)]: Modified [key_name(C)]'s antagonist reputation ([log_text])</span>")
+	to_chat(C, "<span class='userdanger'>[key_name_admin(usr)]: Modified your antagonist reputation ([log_text])</span>")
 	SSblackbox.record_feedback("tally", "admin_verb", 1, "Modify Antagonist Reputation") //If you are copy-pasting this, ensure the 2nd parameter is unique to the new proc!
 
 /client/proc/cmd_admin_world_narrate()


### PR DESCRIPTION
We get enough people asking if they're shadowbanned from antag despite the code not even existing so hopefully this helps curb the inevitable paranoia from the ability to modify antag reputation
