### PR TITLE
Adjust antag rep values to remove chain-of-command -based bonuses

### DIFF
--- a/code/modules/jobs/job_types/assistant.dm
+++ b/code/modules/jobs/job_types/assistant.dm
@@ -13,7 +13,7 @@ Assistant
 	access = list()			//See /datum/job/assistant/get_access()
 	minimal_access = list()	//See /datum/job/assistant/get_access()
 	outfit = /datum/outfit/job/assistant
-	antag_rep = 10
+	antag_rep = 7
 
 
 /datum/job/assistant/get_access()

--- a/code/modules/jobs/job_types/captain.dm
+++ b/code/modules/jobs/job_types/captain.dm
@@ -15,7 +15,6 @@ Captain
 	minimal_player_age = 14
 	exp_requirements = 180
 	exp_type = EXP_TYPE_CREW
-	antag_rep = 20
 
 	outfit = /datum/outfit/job/captain
 
@@ -70,7 +69,6 @@ Head of Personnel
 	exp_requirements = 180
 	exp_type = EXP_TYPE_CREW
 	exp_type_department = EXP_TYPE_SUPPLY
-	antag_rep = 20
 
 	outfit = /datum/outfit/job/hop
 

--- a/code/modules/jobs/job_types/cargo_service.dm
+++ b/code/modules/jobs/job_types/cargo_service.dm
@@ -11,7 +11,6 @@ Quartermaster
 	spawn_positions = 1
 	supervisors = "the head of personnel"
 	selection_color = "#d7b088"
-	antag_rep = 17
 
 	outfit = /datum/outfit/job/quartermaster
 
@@ -42,7 +41,6 @@ Cargo Technician
 	spawn_positions = 2
 	supervisors = "the quartermaster and the head of personnel"
 	selection_color = "#dcba97"
-	antag_rep = 14
 
 	outfit = /datum/outfit/job/cargo_tech
 
@@ -71,7 +69,6 @@ Shaft Miner
 	spawn_positions = 3
 	supervisors = "the quartermaster and the head of personnel"
 	selection_color = "#dcba97"
-	antag_rep = 17
 
 	outfit = /datum/outfit/job/miner
 
@@ -150,7 +147,6 @@ Bartender
 	spawn_positions = 1
 	supervisors = "the head of personnel"
 	selection_color = "#bbe291"
-	antag_rep = 14
 
 	outfit = /datum/outfit/job/bartender
 
@@ -184,7 +180,6 @@ Cook
 	supervisors = "the head of personnel"
 	selection_color = "#bbe291"
 	var/cooks = 0 //Counts cooks amount
-	antag_rep = 17
 
 	outfit = /datum/outfit/job/cook
 
@@ -237,7 +232,6 @@ Botanist
 	spawn_positions = 2
 	supervisors = "the head of personnel"
 	selection_color = "#bbe291"
-	antag_rep = 17
 
 	outfit = /datum/outfit/job/botanist
 
@@ -277,7 +271,6 @@ Janitor
 	supervisors = "the head of personnel"
 	selection_color = "#bbe291"
 	var/global/janitors = 0
-	antag_rep = 17
 
 	outfit = /datum/outfit/job/janitor
 

--- a/code/modules/jobs/job_types/civilian.dm
+++ b/code/modules/jobs/job_types/civilian.dm
@@ -11,7 +11,6 @@ Clown
 	spawn_positions = 1
 	supervisors = "the head of personnel"
 	selection_color = "#dddddd"
-	antag_rep = 14
 
 	outfit = /datum/outfit/job/clown
 
@@ -73,7 +72,6 @@ Mime
 	spawn_positions = 1
 	supervisors = "the head of personnel"
 	selection_color = "#dddddd"
-	antag_rep = 14
 
 	outfit = /datum/outfit/job/mime
 
@@ -124,7 +122,6 @@ Curator
 	spawn_positions = 1
 	supervisors = "the head of personnel"
 	selection_color = "#dddddd"
-	antag_rep = 14
 
 	outfit = /datum/outfit/job/curator
 
@@ -170,7 +167,6 @@ Lawyer
 	supervisors = "the head of personnel"
 	selection_color = "#dddddd"
 	var/lawyers = 0 //Counts lawyer amount
-	antag_rep = 17
 
 	outfit = /datum/outfit/job/lawyer
 

--- a/code/modules/jobs/job_types/civilian_chaplain.dm
+++ b/code/modules/jobs/job_types/civilian_chaplain.dm
@@ -12,7 +12,6 @@ Chaplain
 	spawn_positions = 1
 	supervisors = "the head of personnel"
 	selection_color = "#dddddd"
-	antag_rep = 14
 
 	outfit = /datum/outfit/job/chaplain
 

--- a/code/modules/jobs/job_types/engineering.dm
+++ b/code/modules/jobs/job_types/engineering.dm
@@ -17,7 +17,6 @@ Chief Engineer
 	exp_requirements = 180
 	exp_type = EXP_TYPE_CREW
 	exp_type_department = EXP_TYPE_ENGINEERING
-	antag_rep = 20
 
 	outfit = /datum/outfit/job/ce
 
@@ -77,7 +76,6 @@ Station Engineer
 	selection_color = "#fff5cc"
 	exp_requirements = 60
 	exp_type = EXP_TYPE_CREW
-	antag_rep = 17
 
 	outfit = /datum/outfit/job/engineer
 
@@ -134,7 +132,6 @@ Atmospheric Technician
 	selection_color = "#fff5cc"
 	exp_requirements = 60
 	exp_type = EXP_TYPE_CREW
-	antag_rep = 17
 
 	outfit = /datum/outfit/job/atmos
 

--- a/code/modules/jobs/job_types/job.dm
+++ b/code/modules/jobs/job_types/job.dm
@@ -49,7 +49,7 @@
 	var/exp_type_department = ""
 
 	//The amount of good boy points playing this role will earn you towards a higher chance to roll antagonist next round
-	var/antag_rep = 0
+	var/antag_rep = 10
 
 //Only override this proc
 //H is usually a human unless an /equip override transformed it

--- a/code/modules/jobs/job_types/medical.dm
+++ b/code/modules/jobs/job_types/medical.dm
@@ -17,7 +17,6 @@ Chief Medical Officer
 	exp_requirements = 180
 	exp_type = EXP_TYPE_CREW
 	exp_type_department = EXP_TYPE_MEDICAL
-	antag_rep = 20
 
 	outfit = /datum/outfit/job/cmo
 
@@ -60,7 +59,6 @@ Medical Doctor
 	spawn_positions = 3
 	supervisors = "the chief medical officer"
 	selection_color = "#ffeef0"
-	antag_rep = 17
 
 	outfit = /datum/outfit/job/doctor
 
@@ -98,7 +96,6 @@ Chemist
 	selection_color = "#ffeef0"
 	exp_type = EXP_TYPE_CREW
 	exp_requirements = 60
-	antag_rep = 17
 
 	outfit = /datum/outfit/job/chemist
 
@@ -134,7 +131,6 @@ Geneticist
 	selection_color = "#ffeef0"
 	exp_type = EXP_TYPE_CREW
 	exp_requirements = 60
-	antag_rep = 17
 
 	outfit = /datum/outfit/job/geneticist
 
@@ -171,7 +167,6 @@ Virologist
 	selection_color = "#ffeef0"
 	exp_type = EXP_TYPE_CREW
 	exp_requirements = 60
-	antag_rep = 17
 
 	outfit = /datum/outfit/job/virologist
 

--- a/code/modules/jobs/job_types/science.dm
+++ b/code/modules/jobs/job_types/science.dm
@@ -17,7 +17,6 @@ Research Director
 	exp_type_department = EXP_TYPE_SCIENCE
 	exp_requirements = 180
 	exp_type = EXP_TYPE_CREW
-	antag_rep = 20
 
 	outfit = /datum/outfit/job/rd
 
@@ -73,7 +72,7 @@ Scientist
 	selection_color = "#ffeeff"
 	exp_requirements = 60
 	exp_type = EXP_TYPE_CREW
-	antag_rep = 17
+
 
 	outfit = /datum/outfit/job/scientist
 
@@ -108,7 +107,6 @@ Roboticist
 	selection_color = "#ffeeff"
 	exp_requirements = 60
 	exp_type = EXP_TYPE_CREW
-	antag_rep = 17
 
 	outfit = /datum/outfit/job/roboticist
 

--- a/code/modules/jobs/job_types/security.dm
+++ b/code/modules/jobs/job_types/security.dm
@@ -23,7 +23,6 @@ Head of Security
 	exp_requirements = 300
 	exp_type = EXP_TYPE_CREW
 	exp_type_department = EXP_TYPE_SECURITY
-	antag_rep = 20
 
 	outfit = /datum/outfit/job/hos
 
@@ -77,7 +76,6 @@ Warden
 	minimal_player_age = 7
 	exp_requirements = 300
 	exp_type = EXP_TYPE_CREW
-	antag_rep = 20
 
 	outfit = /datum/outfit/job/warden
 
@@ -130,7 +128,6 @@ Detective
 	minimal_player_age = 7
 	exp_requirements = 300
 	exp_type = EXP_TYPE_CREW
-	antag_rep = 20
 
 	outfit = /datum/outfit/job/detective
 
@@ -181,7 +178,6 @@ Security Officer
 	minimal_player_age = 7
 	exp_requirements = 300
 	exp_type = EXP_TYPE_CREW
-	antag_rep = 20
 
 	outfit = /datum/outfit/job/security
 

--- a/code/modules/jobs/job_types/silicon.dm
+++ b/code/modules/jobs/job_types/silicon.dm
@@ -15,7 +15,6 @@ AI
 	exp_requirements = 180
 	exp_type = EXP_TYPE_CREW
 	exp_type_department = EXP_TYPE_SILICON
-	antag_rep = 20
 	var/do_special_check = TRUE
 
 /datum/job/ai/equip(mob/living/carbon/human/H, visualsOnly, announce, latejoin)


### PR DESCRIPTION
This eliminates the system's bias towards players in headroles, and also awards the roundstart borg points (previously they got zero)

:cl: Naksu
balance: adjusted default antag rep points to grant every job the same amount of points per round, except for assistant which gets 30% less
/:cl: