### PR TITLE
Fixes backslot not counting towards assess_threat

### DIFF
--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -571,13 +571,11 @@
 	//Check for weapons
 	if( (judgement_criteria & JUDGE_WEAPONCHECK) && weaponcheck)
 		if(!idcard || !(ACCESS_WEAPONS in idcard.access))
-			for(var/obj/item/I in held_items)
+			for(var/obj/item/I in held_items) //if they're holding a gun
 				if(weaponcheck.Invoke(I))
 					threatcount += 4
-			if(weaponcheck.Invoke(belt))
-				threatcount += 2
-			if(weaponcheck.Invoke(back))
-				threatcount += 2
+			if(weaponcheck.Invoke(belt) || weaponcheck.Invoke(back)) //if a weapon is present in the belt or back slot
+				threatcount += 2 //not enough to trigger look_for_perp() on it's own unless they also have criminal status.
 
 	//Check for arrest warrant
 	if(judgement_criteria & JUDGE_RECORDCHECK)

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -576,6 +576,8 @@
 					threatcount += 4
 			if(weaponcheck.Invoke(belt))
 				threatcount += 2
+			if(weaponcheck.Invoke(back))
+				threatcount += 2
 
 	//Check for arrest warrant
 	if(judgement_criteria & JUDGE_RECORDCHECK)

--- a/code/modules/mob/living/carbon/monkey/monkey.dm
+++ b/code/modules/mob/living/carbon/monkey/monkey.dm
@@ -134,11 +134,11 @@
 
 	//Check for weapons
 	if( (judgement_criteria & JUDGE_WEAPONCHECK) && weaponcheck )
-		for(var/obj/item/I in held_items)
+		for(var/obj/item/I in held_items) //if they're holding a gun
 			if(weaponcheck.Invoke(I))
 				threatcount += 4
-		if(weaponcheck.Invoke(back))
-			threatcount += 2
+		if(weaponcheck.Invoke(back)) //if a weapon is present in the back slot
+			threatcount += 4 //trigger look_for_perp() since they're nonhuman and very likely hostile
 
 	//mindshield implants imply trustworthyness
 	if(isloyal())

--- a/code/modules/mob/living/carbon/monkey/monkey.dm
+++ b/code/modules/mob/living/carbon/monkey/monkey.dm
@@ -137,8 +137,8 @@
 		for(var/obj/item/I in held_items)
 			if(weaponcheck.Invoke(I))
 				threatcount += 4
-			if(weaponcheck.Invoke(back))
-				threatcount += 2
+		if(weaponcheck.Invoke(back))
+			threatcount += 2
 
 	//mindshield implants imply trustworthyness
 	if(isloyal())

--- a/code/modules/mob/living/carbon/monkey/monkey.dm
+++ b/code/modules/mob/living/carbon/monkey/monkey.dm
@@ -137,6 +137,8 @@
 		for(var/obj/item/I in held_items)
 			if(weaponcheck.Invoke(I))
 				threatcount += 4
+			if(weaponcheck.Invoke(back))
+				threatcount += 2
 
 	//mindshield implants imply trustworthyness
 	if(isloyal())

--- a/code/modules/mob/living/simple_animal/bot/secbot.dm
+++ b/code/modules/mob/living/simple_animal/bot/secbot.dm
@@ -391,10 +391,11 @@ Auto Patrol: []"},
 			break
 		else
 			continue
+
 /mob/living/simple_animal/bot/secbot/proc/check_for_weapons(var/obj/item/slot_item)
 	if(slot_item && (slot_item.item_flags & NEEDS_PERMIT))
-		return 1
-	return 0
+		return TRUE
+	return FALSE
 
 /mob/living/simple_animal/bot/secbot/explode()
 


### PR DESCRIPTION
Fixes #38033

🆑 ShizCalev
fix: Weapons slung on one's back will now count towards beepsky's threat assessment.
/🆑