### PR TITLE
Fixes fried items not staying in your hands once eaten

### DIFF
--- a/code/modules/food_and_drinks/food/snacks_bread.dm
+++ b/code/modules/food_and_drinks/food/snacks_bread.dm
@@ -209,6 +209,7 @@
 		qdel(fried)
 	else
 		fried.forceMove(src)
+		trash = fried
 
 /obj/item/reagent_containers/food/snacks/deepfryholder/proc/fry(cook_time = 30)
 	switch(cook_time)


### PR DESCRIPTION
🆑 ShizCalev
fix: Inedible deepfried items will now properly stay in your hands after you eat them.
/🆑