### PR TITLE
[s] Stops infinite food generation by frying the same item repeatedly

### DIFF
--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -106,6 +106,7 @@ GLOBAL_VAR_INIT(rpg_loot_items, FALSE)
 	//Grinder vars
 	var/list/grind_results //A reagent list containing the reagents this item produces when ground up in a grinder - this can be an empty list to allow for reagent transferring only
 	var/list/juice_results //A reagent list containing blah blah... but when JUICED in a grinder!
+	var/was_previously_fried //Prevents the same item from being refried multiple times
 
 /obj/item/Initialize()
 	if (!materials)

--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -223,6 +223,8 @@ GLOBAL_VAR_INIT(rpg_loot_items, FALSE)
 		research_msg += "None"
 	research_msg += "."
 	to_chat(user, research_msg.Join())
+	if(was_previously_fried)
+		to_chat(user, "<span class='info'>[gender == PLURAL ? "They are" : "It's"] covered in an oily residue.</span>")
 
 /obj/item/proc/speechModification(message)			//for message modding by mask slot.
 	return message

--- a/code/modules/food_and_drinks/food/snacks_bread.dm
+++ b/code/modules/food_and_drinks/food/snacks_bread.dm
@@ -209,6 +209,7 @@
 		qdel(fried)
 	else
 		fried.forceMove(src)
+		fried.was_previously_fried = TRUE //prevent psuedo-infinite food generation by refrying the same item forever.
 
 /obj/item/reagent_containers/food/snacks/deepfryholder/proc/fry(cook_time = 30)
 	switch(cook_time)

--- a/code/modules/food_and_drinks/kitchen_machinery/deep_fryer.dm
+++ b/code/modules/food_and_drinks/kitchen_machinery/deep_fryer.dm
@@ -84,6 +84,9 @@ God bless America.
 	if(!reagents.has_reagent("cooking_oil"))
 		to_chat(user, "<span class='warning'>[src] has no cooking oil to fry with!</span>")
 		return
+	if(I.was_previously_fried)
+		to_chat(user, "<span class='warning'>[I] is still a bit soggy, it probably wouldn't taste too good if you tried to fry it again...</span>")
+		return
 	if(istype(I, /obj/item/reagent_containers/food/snacks/deepfryholder))
 		to_chat(user, "<span class='userdanger'>Your cooking skills are not up to the legendary Doublefry technique.</span>")
 		return


### PR DESCRIPTION
Closes #38025
Closes #38054

🆑 ShizCalev
fix: You can now only deepfry a single item once.
/🆑