### PR TITLE
Enable Goonchat ping during the lobby

### DIFF
--- a/code/controllers/subsystem/ping.dm
+++ b/code/controllers/subsystem/ping.dm
@@ -3,6 +3,7 @@ SUBSYSTEM_DEF(ping)
 	priority = FIRE_PRIORITY_PING
 	wait = 3 SECONDS
 	flags = SS_NO_INIT
+	runlevels = RUNLEVEL_LOBBY | RUNLEVEL_SETUP | RUNLEVEL_GAME | RUNLEVEL_POSTGAME
 
 	var/list/currentrun = list()
 


### PR DESCRIPTION
Still won't show until other SS finish their initialization but this should fix the ping timer not showing up while in the lobby (and if OOC is quiet, goonchat claiming to be DC'd). From #37934.