### PR TITLE
cargo bounty/export rebalance

### DIFF
--- a/code/modules/cargo/bounties/assistant.dm
+++ b/code/modules/cargo/bounties/assistant.dm
@@ -26,21 +26,21 @@
 /datum/bounty/item/assistant/soap
 	name = "Soap"
 	description = "Soap has gone missing from CentCom's bathrooms and nobody knows who took it. Replace it and be the hero CentCom needs."
-	reward = 2000
+	reward = 3000
 	required_count = 3
 	wanted_types = list(/obj/item/soap)
 
 /datum/bounty/item/assistant/spear
 	name = "Spears"
 	description = "CentCom's security forces are going through budget cuts. You will be paid if you ship a set of spears."
-	reward = 2000
+	reward = 1500
 	required_count = 5
 	wanted_types = list(/obj/item/twohanded/spear)
 
 /datum/bounty/item/assistant/toolbox
 	name = "Toolboxes"
 	description = "There's an absence of robustness at Central Command. Hurry up and ship some toolboxes as a solution."
-	reward = 2000
+	reward = 1000
 	required_count = 6
 	wanted_types = list(/obj/item/storage/toolbox)
 
@@ -59,7 +59,7 @@
 /datum/bounty/item/assistant/cheesiehonkers
 	name = "Cheesie Honkers"
 	description = "Apparently the company that makes Cheesie Honkers is going out of business soon. CentCom wants to stock up before it happens!"
-	reward = 1200
+	reward = 1000
 	required_count = 3
 	wanted_types = list(/obj/item/reagent_containers/food/snacks/cheesiehonkers)
 
@@ -107,7 +107,7 @@
 /datum/bounty/item/assistant/gondola_hide
 	name = "Gondola Hide"
 	description = "Central Command has recently learned of strange creatures called Gondolas. If you catch one, ship its hide back to CentCom."
-	reward = 5000
+	reward = 10000
 	wanted_types = list(/obj/item/stack/sheet/animalhide/gondola)
 
 /datum/bounty/item/assistant/monkey_hide
@@ -158,19 +158,19 @@
 /datum/bounty/item/assistant/revolver
 	name = "Revolver"
 	description = "Captain Johann of station 12 has challenged Captain Vic of station 11 to a duel. He's asked for help securing an appropriate revolver to use."
-	reward = 2000
+	reward = 6000
 	wanted_types = list(/obj/item/gun/ballistic/revolver)
 
 /datum/bounty/item/assistant/hand_tele
 	name = "Hand Tele"
 	description = "Central Command has come up with a genius idea: Why not teleport cargo rather than ship it? Send over a hand tele, receive payment, then wait 6-8 years while they deliberate."
-	reward = 2000
+	reward = 8000
 	wanted_types = list(/obj/item/hand_tele)
 
 /datum/bounty/item/assistant/geranium
 	name = "Geraniums"
 	description = "Commander Zot has the hots for Commander Zena. Send a shipment of geraniums - her favorite flower - and he'll happily reward you."
-	reward = 4000
+	reward = 3000
 	required_count = 3
 	wanted_types = list(/obj/item/reagent_containers/food/snacks/grown/poppy/geranium)
 
@@ -185,7 +185,7 @@
 /datum/bounty/item/assistant/shadyjims
 	name = "Shady Jim's"
 	description = "There's an irate officer at CentCom demanding that he receive a box of Shady Jim's cigarettes. Please ship one. He's starting to make threats."
-	reward = 500
+	reward = 1000
 	wanted_types = list(/obj/item/storage/fancy/cigarettes/cigpack_shadyjims)
 
 /datum/bounty/item/assistant/potted_plants
@@ -198,7 +198,7 @@
 /datum/bounty/item/assistant/earmuffs
 	name = "Earmuffs"
 	description = "Central Command is getting tired of your station's messages. They've ordered that you ship some earmuffs to lessen the annoyance."
-	reward = 1000
+	reward = 500
 	wanted_types = list(/obj/item/clothing/ears/earmuffs)
 
 /datum/bounty/item/assistant/handcuffs
@@ -243,7 +243,7 @@
 /datum/bounty/item/assistant/plasma_tank
 	name = "Full Tank of Plasma"
 	description = "Station 12 has requested supplies to set up a singularity engine. In particular, they request 28 moles of plasma."
-	reward = 2500
+	reward = 2000
 	wanted_types = list(/obj/item/tank)
 	var/moles_required = 20 // A full tank is 28 moles, but CentCom ignores that fact.
 

--- a/code/modules/cargo/bounties/assistant.dm
+++ b/code/modules/cargo/bounties/assistant.dm
@@ -161,12 +161,6 @@
 	reward = 6000
 	wanted_types = list(/obj/item/gun/ballistic/revolver)
 
-/datum/bounty/item/assistant/hand_tele
-	name = "Hand Tele"
-	description = "Central Command has come up with a genius idea: Why not teleport cargo rather than ship it? Send over a hand tele, receive payment, then wait 6-8 years while they deliberate."
-	reward = 8000
-	wanted_types = list(/obj/item/hand_tele)
-
 /datum/bounty/item/assistant/geranium
 	name = "Geraniums"
 	description = "Commander Zot has the hots for Commander Zena. Send a shipment of geraniums - her favorite flower - and he'll happily reward you."

--- a/code/modules/cargo/bounties/chef.dm
+++ b/code/modules/cargo/bounties/chef.dm
@@ -105,8 +105,8 @@
 
 /datum/bounty/item/chef/chawanmushi
 	name = "Chawanmushi"
-	description = "Nanotrasen wants to improve relations with its sister company, Japanotrasen. Ship Chawanmushi immediately."
-	reward = 8000
+	description = "The Head of External Relationships will meet up with a Spider Clan representative,send asiatic food to make sure the meeting wont be a failure."
+	reward = 6000
 	wanted_types = list(/obj/item/reagent_containers/food/snacks/chawanmushi)
 
 /datum/bounty/item/chef/kebab

--- a/code/modules/cargo/bounties/science.dm
+++ b/code/modules/cargo/bounties/science.dm
@@ -1,72 +1,72 @@
 /datum/bounty/item/science/boh
 	name = "Bag of Holding"
 	description = "Nanotrasen would make good use of high-capacity backpacks. If you have any, please ship them."
-	reward = 10000
+	reward = 5000
 	wanted_types = list(/obj/item/storage/backpack/holding)
 
 /datum/bounty/item/science/tboh
 	name = "Trash Bag of Holding"
 	description = "Nanotrasen would make good use of high-capacity trash bags. If you have any, please ship them."
-	reward = 10000
+	reward = 5000
 	wanted_types = list(/obj/item/storage/backpack/holding)
 
 /datum/bounty/item/science/bluespace_syringe
 	name = "Bluespace Syringe"
 	description = "Nanotrasen would make good use of high-capacity syringes. If you have any, please ship them."
-	reward = 10000
+	reward = 4000
 	wanted_types = list(/obj/item/reagent_containers/syringe/bluespace)
 
 /datum/bounty/item/science/bluespace_body_bag
 	name = "Bluespace Body Bag"
 	description = "Nanotrasen would make good use of high-capacity body bags. If you have any, please ship them."
-	reward = 10000
+	reward = 4000
 	wanted_types = list(/obj/item/bodybag/bluespace)
 
 /datum/bounty/item/science/nightvision_goggles
 	name = "Night Vision Goggles"
 	description = "An electrical storm has busted all the lights at CentCom. While management is waiting for replacements, perhaps some night vision goggles can be shipped?"
-	reward = 10000
+	reward = 3000
 	wanted_types = list(/obj/item/clothing/glasses/night, /obj/item/clothing/glasses/meson/night, /obj/item/clothing/glasses/hud/health/night, /obj/item/clothing/glasses/hud/security/night, /obj/item/clothing/glasses/hud/diagnostic/night)
 
 /datum/bounty/item/science/experimental_welding_tool
 	name = "Experimental Welding Tool"
 	description = "A recent accident has left most of CentCom's welding tools exploded. Ship replacements to be rewarded."
-	reward = 10000
+	reward = 4000
 	required_count = 3
 	wanted_types = list(/obj/item/weldingtool/experimental)
 
 /datum/bounty/item/science/cryostasis_beaker
 	name = "Cryostasis Beaker"
 	description = "Chemists at Central Command have discovered a new chemical that can only be held in cryostasis beakers. The only problem is they don't have any! Rectify this to receive payment."
-	reward = 10000
+	reward = 2000
 	wanted_types = list(/obj/item/reagent_containers/glass/beaker/noreact)
 
 /datum/bounty/item/science/diamond_drill
 	name = "Diamond Mining Drill"
 	description = "Central Command is willing to pay three months salary in exchange for one diamond mining drill."
-	reward = 15000
+	reward = 3000
 	wanted_types = list(/obj/item/mecha_parts/mecha_equipment/drill/diamonddrill)
 
 /datum/bounty/item/science/floor_buffer
 	name = "Floor Buffer Upgrade"
 	description = "One of CentCom's janitors made a small fortune betting on carp races. Now they'd like to commission an upgrade to their floor buffer."
-	reward = 10000
+	reward = 2000
 	wanted_types = list(/obj/item/janiupgrade)
 
 /datum/bounty/item/science/flightsuit
 	name = "Flight Suit"
 	description = "According to all known laws of physics, flight suits are cool. CentCom will pay at a premium for them, so get shipping!"
-	reward = 30000
+	reward = 10000
 	wanted_types = list(/obj/item/clothing/suit/space/hardsuit/flightsuit)
 
 /datum/bounty/item/science/advanced_mop
 	name = "Advanced Mop"
 	description = "Excuse me. I'd like to request $17 for a push broom rebristling. Either that, or an advanced mop."
-	reward = 10000
+	reward = 2000
 	wanted_types = list(/obj/item/mop/advanced)
 
 /datum/bounty/item/science/advanced_egun
 	name = "Advanced Energy Gun"
 	description = "With the price of rechargers on the rise, upper management is interested in purchasing guns that are self-powered. If you ship one, they'll pay."
-	reward = 10000
+	reward = 6000
 	wanted_types = list(/obj/item/gun/energy/e_gun/nuclear)

--- a/code/modules/cargo/bounties/security.dm
+++ b/code/modules/cargo/bounties/security.dm
@@ -7,13 +7,13 @@
 /datum/bounty/item/security/securitybelt
 	name = "Security Belt"
 	description = "CentCom is having difficulties with their security belts. Ship one from the station to receive compensation."
-	reward = 800
+	reward = 1500
 	wanted_types = list(/obj/item/storage/belt/security)
 
 /datum/bounty/item/security/sechuds
 	name = "Security HUDSunglasses"
 	description = "CentCom screwed up and ordered the wrong type of security sunglasses. They request the station ship some of theirs."
-	reward = 800
+	reward = 2000
 	wanted_types = list(/obj/item/clothing/glasses/hud/security/sunglasses)
 
 /datum/bounty/item/security/riotshotgun
@@ -38,7 +38,7 @@
 /datum/bounty/item/security/hardsuit
 	name = "Security Hardsuit"
 	description = "Space pirates are heading towards CentCom! Quick! Ship a security hardsuit to aid the fight!"
-	reward = 2000
+	reward = 3000
 	wanted_types = list(/obj/item/clothing/suit/space/hardsuit/security)
 
 /datum/bounty/item/security/krav_maga

--- a/code/modules/cargo/bounties/security.dm
+++ b/code/modules/cargo/bounties/security.dm
@@ -60,3 +60,9 @@
 	reward = 4000
 	wanted_types = list(/obj/item/melee/sabre)
 
+/datum/bounty/item/security/hand_tele
+	name = "Hand Tele"
+	description = "Central Command has come up with a genius idea: Why not teleport cargo rather than ship it? Send over a hand tele, receive payment, then wait 6-8 years while they deliberate."
+	reward = 6000
+	wanted_types = list(/obj/item/hand_tele)
+

--- a/code/modules/cargo/bounties/security.dm
+++ b/code/modules/cargo/bounties/security.dm
@@ -32,7 +32,7 @@
 /datum/bounty/item/security/captains_spare
 	name = "Captain's Spare"
 	description = "Captain Bart of Station 12 has forgotten his ID! Ship him your station's spare, would you?"
-	reward = 8000
+	reward = 5000
 	wanted_types = list(/obj/item/card/id/captains_spare)
 
 /datum/bounty/item/security/hardsuit

--- a/code/modules/cargo/bounties/security.dm
+++ b/code/modules/cargo/bounties/security.dm
@@ -26,13 +26,13 @@
 /datum/bounty/item/security/pinpointer
 	name = "Nuclear Pinpointer"
 	description = "There's a teeny-tiny itty-bitty chance CentCom may have lost a nuke disk. Can the station spare a pinpointer to help out?"
-	reward = 1500
+	reward = 5000
 	wanted_types = list(/obj/item/pinpointer/nuke)
 
 /datum/bounty/item/security/captains_spare
 	name = "Captain's Spare"
 	description = "Captain Bart of Station 12 has forgotten his ID! Ship him your station's spare, would you?"
-	reward = 1500
+	reward = 8000
 	wanted_types = list(/obj/item/card/id/captains_spare)
 
 /datum/bounty/item/security/hardsuit
@@ -44,7 +44,7 @@
 /datum/bounty/item/security/krav_maga
 	name = "Krav Maga Gloves"
 	description = "Chef Howerwitz of CentCom is trying to take a kung-fu Pizza out of the oven, but his mitts aren't up to the task. Ship them a pair of Krav Maga gloves to do the job right."
-	reward = 2000
+	reward = 5000
 	wanted_types = list(/obj/item/clothing/gloves/krav_maga)
 
 /datum/bounty/item/security/recharger
@@ -57,6 +57,6 @@
 /datum/bounty/item/security/sabre
 	name = "Officer's Sabre"
 	description = "A 3-hour LARP session will be held at CentCom in the upcoming months. A shipped officer's sabre would make a good prop."
-	reward = 2500
+	reward = 4000
 	wanted_types = list(/obj/item/melee/sabre)
 

--- a/code/modules/cargo/bounties/special.dm
+++ b/code/modules/cargo/bounties/special.dm
@@ -1,14 +1,14 @@
 /datum/bounty/item/alien_organs
 	name = "Alien Organs"
 	description = "Nanotrasen is interested in studying Xenomorph biology. Ship a set of organs to be thouroughly compensated."
-	reward = 25000
+	reward = 35000
 	required_count = 3
 	wanted_types = list(/obj/item/organ/brain/alien, /obj/item/organ/alien, /obj/item/organ/body_egg/alien_embryo)
 
 /datum/bounty/item/syndicate_documents
 	name = "Syndicate Documents"
 	description = "Intel regarding the syndicate is highly prized at CentCom. If you find syndicate documents, ship them. You could save lives."
-	reward = 10000
+	reward = 40000
 	wanted_types = list(/obj/item/documents/syndicate, /obj/item/documents/photocopy)
 
 /datum/bounty/item/syndicate_documents/applies_to(obj/O)

--- a/code/modules/cargo/exports/gear.dm
+++ b/code/modules/cargo/exports/gear.dm
@@ -42,12 +42,12 @@
 
 
 /datum/export/gear/space/syndiehelmet
-	cost = 150
+	cost = 2000
 	unit_name = "Syndicate space helmet"
 	export_types = list(/obj/item/clothing/head/helmet/space/syndicate)
 
 /datum/export/gear/space/syndiesuit
-	cost = 300
+	cost = 3000
 	unit_name = "Syndicate space suit"
 	export_types = list(/obj/item/clothing/suit/space/syndicate)
 
@@ -58,26 +58,26 @@
 	export_types = list(/obj/item/clothing/head/radiation)
 
 /datum/export/gear/radsuit
-	cost = 100
+	cost = 50
 	unit_name = "radsuit"
 	export_types = list(/obj/item/clothing/suit/radiation)
 
 /datum/export/gear/biohood
-	cost = 50
+	cost = 150
 	unit_name = "biosuit hood"
 	export_types = list(/obj/item/clothing/head/bio_hood)
 
 /datum/export/gear/biosuit
-	cost = 100
+	cost = 200
 	unit_name = "biosuit"
 	export_types = list(/obj/item/clothing/suit/bio_suit)
 
 /datum/export/gear/bombhelmet
-	cost = 50
+	cost = 200
 	unit_name = "bomb suit hood"
 	export_types = list(/obj/item/clothing/head/bomb_hood)
 
 /datum/export/gear/bombsuit
-	cost = 100
+	cost = 400
 	unit_name = "bomb suit"
 	export_types = list(/obj/item/clothing/suit/bomb_suit)

--- a/code/modules/cargo/exports/large_objects.dm
+++ b/code/modules/cargo/exports/large_objects.dm
@@ -58,22 +58,22 @@
 
 
 /datum/export/large/emitter
-	cost = 200
+	cost = 400
 	unit_name = "emitter"
 	export_types = list(/obj/machinery/power/emitter)
 
 /datum/export/large/field_generator
-	cost = 200
+	cost = 400
 	unit_name = "field generator"
 	export_types = list(/obj/machinery/field/generator)
 
 /datum/export/large/collector
-	cost = 200
+	cost = 400
 	unit_name = "collector"
 	export_types = list(/obj/machinery/power/rad_collector)
 
 /datum/export/large/collector/pa
-	cost = 300
+	cost = 600
 	unit_name = "particle accelerator part"
 	export_types = list(/obj/structure/particle_accelerator)
 
@@ -94,12 +94,12 @@
 
 
 /datum/export/large/iv
-	cost = 50
+	cost = 300
 	unit_name = "iv drip"
 	export_types = list(/obj/machinery/iv_drip)
 
 /datum/export/large/barrier
-	cost = 25
+	cost = 100
 	unit_name = "security barrier"
 	export_types = list(/obj/item/grenade/barrier, /obj/structure/barricade/security)
 

--- a/code/modules/cargo/exports/materials.dm
+++ b/code/modules/cargo/exports/materials.dm
@@ -30,43 +30,43 @@
 // Materials. Nothing but plasma is really worth selling. Better leave it all to RnD and sell some plasma instead.
 
 /datum/export/material/bananium
-	cost = 1000
+	cost = 4000
 	material_id = MAT_BANANIUM
 	message = "cm3 of bananium"
 
 /datum/export/material/diamond
-	cost = 500
+	cost = 2000
 	material_id = MAT_DIAMOND
 	message = "cm3 of diamonds"
 
 /datum/export/material/plasma
-	cost = 200
+	cost = 250
 	k_elasticity = 0
 	material_id = MAT_PLASMA
 	message = "cm3 of plasma"
 
 /datum/export/material/uranium
-	cost = 100
+	cost = 150
 	material_id = MAT_URANIUM
 	message = "cm3 of uranium"
 
 /datum/export/material/gold
-	cost = 125
+	cost = 200
 	material_id = MAT_GOLD
 	message = "cm3 of gold"
 
 /datum/export/material/silver
-	cost = 50
+	cost = 150
 	material_id = MAT_SILVER
 	message = "cm3 of silver"
 
 /datum/export/material/titanium
-	cost = 125
+	cost = 175
 	material_id = MAT_TITANIUM
 	message = "cm3 of titanium"
 
 /datum/export/material/plastitanium
-	cost = 325 // plasma + titanium costs
+	cost = 425 // plasma + titanium costs
 	material_id = MAT_TITANIUM // code can only check for one material_id; plastitanium is half plasma, half titanium
 	message = "cm3 of plastitanium"
 

--- a/code/modules/cargo/exports/materials.dm
+++ b/code/modules/cargo/exports/materials.dm
@@ -46,7 +46,7 @@
 	message = "cm3 of plasma"
 
 /datum/export/material/uranium
-	cost = 150
+	cost = 225
 	material_id = MAT_URANIUM
 	message = "cm3 of uranium"
 

--- a/code/modules/cargo/exports/seeds.dm
+++ b/code/modules/cargo/exports/seeds.dm
@@ -1,5 +1,5 @@
 /datum/export/seed
-	cost = 50 // Gets multiplied by potency
+	cost = 200 // Gets multiplied by potency
 	k_elasticity = 1	//price inelastic/quantity elastic, only need to export a few samples
 	unit_name = "new plant species sample"
 	export_types = list(/obj/item/seeds)

--- a/code/modules/cargo/exports/sheets.dm
+++ b/code/modules/cargo/exports/sheets.dm
@@ -10,46 +10,46 @@
 // Hides
 
 /datum/export/stack/skin/monkey
-	cost = 50
+	cost = 200
 	unit_name = "monkey hide"
 	export_types = list(/obj/item/stack/sheet/animalhide/monkey)
 
 /datum/export/stack/skin/human
-	cost = 100
+	cost = 1500
 	contraband = TRUE
 	unit_name = "piece"
 	message = "of human skin"
 	export_types = list(/obj/item/stack/sheet/animalhide/human)
 
 /datum/export/stack/skin/goliath_hide
-	cost = 200
+	cost = 2000
 	unit_name = "goliath hide"
 	export_types = list(/obj/item/stack/sheet/animalhide/goliath_hide)
 
 /datum/export/stack/skin/cat
-	cost = 150
+	cost = 1250
 	contraband = TRUE
 	unit_name = "cat hide"
 	export_types = list(/obj/item/stack/sheet/animalhide/cat)
 
 /datum/export/stack/skin/corgi
-	cost = 200
+	cost = 2000
 	contraband = TRUE
 	unit_name = "corgi hide"
 	export_types = list(/obj/item/stack/sheet/animalhide/corgi)
 
 /datum/export/stack/skin/lizard
-	cost = 150
+	cost = 1500
 	unit_name = "lizard hide"
 	export_types = list(/obj/item/stack/sheet/animalhide/lizard)
 
 /datum/export/stack/skin/gondola
-	cost = 500
+	cost = 2000
 	unit_name = "gondola hide"
 	export_types = list(/obj/item/stack/sheet/animalhide/gondola)
 
 /datum/export/stack/skin/xeno
-	cost = 500
+	cost = 2000
 	unit_name = "alien hide"
 	export_types = list(/obj/item/stack/sheet/animalhide/xeno)
 
@@ -68,7 +68,7 @@
 	export_types = list(/obj/item/stack/sheet/rglass)
 
 /datum/export/stack/bscrystal
-	cost = 300
+	cost = 500
 	message = "of bluespace crystals"
 	export_types = list(/obj/item/stack/sheet/bluespace_crystal)
 
@@ -96,13 +96,13 @@
 // Weird Stuff
 
 /datum/export/stack/abductor
-	cost = 1000
+	cost = 2000
 	message = "of alien alloy"
 	export_types = list(/obj/item/stack/sheet/mineral/abductor)
 
 /datum/export/stack/adamantine
 	unit_name = "bar"
-	cost = 500
+	cost = 5000
 	message = "of adamantine"
 	export_types = list(/obj/item/stack/sheet/mineral/adamantine)
 

--- a/code/modules/cargo/exports/weapons.dm
+++ b/code/modules/cargo/exports/weapons.dm
@@ -11,61 +11,61 @@
 	include_subtypes = TRUE
 
 /datum/export/weapon/knife
-	cost = 100
+	cost = 500
 	unit_name = "combat knife"
 	export_types = list(/obj/item/kitchen/knife/combat)
 
 
 /datum/export/weapon/taser
-	cost = 200
+	cost = 400
 	unit_name = "advanced taser"
 	export_types = list(/obj/item/gun/energy/e_gun/advtaser)
 
 /datum/export/weapon/laser
-	cost = 200
+	cost = 600
 	unit_name = "laser gun"
 	export_types = list(/obj/item/gun/energy/laser)
 
 /datum/export/weapon/disabler
-	cost = 100
+	cost = 300
 	unit_name = "disabler"
 	export_types = list(/obj/item/gun/energy/disabler)
 
 /datum/export/weapon/energy_gun
-	cost = 300
+	cost = 900
 	unit_name = "energy gun"
 	export_types = list(/obj/item/gun/energy/e_gun)
 
 /datum/export/weapon/wt550
-	cost = 300
+	cost = 800
 	unit_name = "WT-550 automatic rifle"
 	export_types = list(/obj/item/gun/ballistic/automatic/wt550)
 
 /datum/export/weapon/shotgun
-	cost = 300
+	cost = 900
 	unit_name = "combat shotgun"
 	export_types = list(/obj/item/gun/ballistic/shotgun/automatic/combat)
 
 
 /datum/export/weapon/flashbang
-	cost = 5
+	cost = 25
 	unit_name = "flashbang grenade"
 	export_types = list(/obj/item/grenade/flashbang)
 
 /datum/export/weapon/teargas
-	cost = 5
+	cost = 25
 	unit_name = "tear gas grenade"
 	export_types = list(/obj/item/grenade/chem_grenade/teargas)
 
 
 /datum/export/weapon/flash
-	cost = 5
+	cost = 20
 	unit_name = "handheld flash"
 	export_types = list(/obj/item/assembly/flash)
 	include_subtypes = TRUE
 
 /datum/export/weapon/handcuffs
-	cost = 3
+	cost = 10
 	unit_name = "pair"
 	message = "of handcuffs"
 	export_types = list(/obj/item/restraints/handcuffs)

--- a/code/modules/cargo/exports/weapons.dm
+++ b/code/modules/cargo/exports/weapons.dm
@@ -32,7 +32,7 @@
 	export_types = list(/obj/item/gun/energy/disabler)
 
 /datum/export/weapon/energy_gun
-	cost = 900
+	cost = 700
 	unit_name = "energy gun"
 	export_types = list(/obj/item/gun/energy/e_gun)
 


### PR DESCRIPTION
:cl:
balance: export values and bounty have been changed
fix: you were able to buy radsuit crates and sell them back for the same price but now you cant
fix: NT found out that 80% of  the lasers sold were actually laser tag guns so now they have updated their detection software to not accept toy guns
/:cl:

why:
- (1) some of those prices were **refund value** so should be left as they were before the cargo bounties things ((explaination for dummies: these things arent made from the station they can only be imported so if griff mc tide sends back the shuttle or HoP doesnt want guns you get back some money instead of going back to 500 money, still not 100% refund but at least not 10% refund))
-  (2) minerals should keep being worth as they are worth to the station (**economy flexibility takes care of these anyways**) 
- (3) i dont see why nerf production items like skins and adamantite as they require more effort than fetchquesting (bounties) and require actual cooperation they dont have a full value as before bounties but still worth enough (**economy flexibility takes care of these anyways**)
- (4) adapted values of sci stuff bounties to be reasonable (factors: chance of cooperability, actual price and tech cost)
- (5) xeno organs should be worth more and syndi documents which as far i know they only exist in a space ruin inside a safe should give some real money
- (6) lowered bounty rewards of things that were pretty much autolathe printable and increased price of unique items 
- (7) **economy flexibility kills any kind of mass selling after less than a stack its price drops to the ground**