### PR TITLE
Fix premapped atmos machines turning on automatically when re-wrenched

### DIFF
--- a/_maps/RandomRuins/SpaceRuins/spacehotel.dmm
+++ b/_maps/RandomRuins/SpaceRuins/spacehotel.dmm
@@ -3392,9 +3392,8 @@
 /obj/structure/cable/yellow{
 	icon_state = "2-8"
 	},
-/obj/machinery/atmospherics/components/binary/valve{
-	name = "Air Release Valve";
-	on = 1
+/obj/machinery/atmospherics/components/binary/valve/on{
+	name = "Air Release Valve"
 	},
 /turf/open/floor/plasteel,
 /area/ruin/space/has_grav/hotel/power)

--- a/_maps/RandomRuins/SpaceRuins/spacehotel.dmm
+++ b/_maps/RandomRuins/SpaceRuins/spacehotel.dmm
@@ -3394,7 +3394,7 @@
 	},
 /obj/machinery/atmospherics/components/binary/valve{
 	name = "Air Release Valve";
-	open = 1
+	on = 1
 	},
 /turf/open/floor/plasteel,
 /area/ruin/space/has_grav/hotel/power)

--- a/_maps/map_files/BoxStation/BoxStation.dmm
+++ b/_maps/map_files/BoxStation/BoxStation.dmm
@@ -41396,7 +41396,7 @@
 /turf/closed/wall/r_wall,
 /area/medical/virology)
 "bZQ" = (
-/obj/machinery/atmospherics/components/binary/valve/open{
+/obj/machinery/atmospherics/components/binary/valve/on{
 	dir = 4
 	},
 /obj/effect/turf_decal/stripes/line{
@@ -52262,10 +52262,9 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 6
 	},
-/obj/machinery/atmospherics/components/binary/valve/digital{
+/obj/machinery/atmospherics/components/binary/valve/digital/on{
 	dir = 4;
-	name = "Output Release";
-	on = 1
+	name = "Output Release"
 	},
 /turf/open/floor/engine,
 /area/engine/engineering)

--- a/_maps/map_files/BoxStation/BoxStation.dmm
+++ b/_maps/map_files/BoxStation/BoxStation.dmm
@@ -52265,7 +52265,7 @@
 /obj/machinery/atmospherics/components/binary/valve/digital{
 	dir = 4;
 	name = "Output Release";
-	open = 1
+	on = 1
 	},
 /turf/open/floor/engine,
 /area/engine/engineering)

--- a/_maps/map_files/debug/runtimestation.dmm
+++ b/_maps/map_files/debug/runtimestation.dmm
@@ -445,7 +445,7 @@
 /turf/open/floor/plating,
 /area/engine/atmos)
 "bm" = (
-/obj/machinery/atmospherics/components/binary/valve/open{
+/obj/machinery/atmospherics/components/binary/valve/on{
 	dir = 4
 	},
 /turf/open/floor/plating,

--- a/code/game/machinery/pipe/construction.dm
+++ b/code/game/machinery/pipe/construction.dm
@@ -165,6 +165,11 @@ Buildable meters
 
 	if(pipename)
 		A.name = pipename
+	if("on" in A.vars)
+		// Certain pre-mapped subtypes are on by default, we want to preserve
+		// every other aspect of these subtypes (name, pre-set filters, etc.)
+		// but they shouldn't turn on automatically when wrenched.
+		A.vars["on"] = FALSE
 
 /obj/item/pipe/trinary/flippable/build_pipe(obj/machinery/atmospherics/components/trinary/T)
 	..()

--- a/code/game/machinery/pipe/construction.dm
+++ b/code/game/machinery/pipe/construction.dm
@@ -165,11 +165,11 @@ Buildable meters
 
 	if(pipename)
 		A.name = pipename
-	if("on" in A.vars)
+	if(A.on)
 		// Certain pre-mapped subtypes are on by default, we want to preserve
 		// every other aspect of these subtypes (name, pre-set filters, etc.)
 		// but they shouldn't turn on automatically when wrenched.
-		A.vars["on"] = FALSE
+		A.on = FALSE
 
 /obj/item/pipe/trinary/flippable/build_pipe(obj/machinery/atmospherics/components/trinary/T)
 	..()

--- a/code/modules/atmospherics/machinery/atmosmachinery.dm
+++ b/code/modules/atmospherics/machinery/atmosmachinery.dm
@@ -38,6 +38,7 @@ Pipelines + Other Objects -> Pipe network
 
 	var/construction_type
 	var/pipe_state //icon_state as a pipe item
+	var/on = FALSE
 
 /obj/machinery/atmospherics/examine(mob/user)
 	..()

--- a/code/modules/atmospherics/machinery/components/binary_devices/dp_vent_pump.dm
+++ b/code/modules/atmospherics/machinery/components/binary_devices/dp_vent_pump.dm
@@ -20,7 +20,6 @@ Acts like a normal vent, but has an input AND output.
 	var/id = null
 	var/datum/radio_frequency/radio_connection
 
-	var/on = FALSE
 	var/pump_direction = 1 //0 = siphoning, 1 = releasing
 
 	var/external_pressure_bound = ONE_ATMOSPHERE
@@ -31,12 +30,12 @@ Acts like a normal vent, but has an input AND output.
 	//EXT_BOUND: Do not pass external_pressure_bound
 	//INPUT_MIN: Do not pass input_pressure_min
 	//OUTPUT_MAX: Do not pass output_pressure_max
-	
+
 /obj/machinery/atmospherics/components/binary/dp_vent_pump/layer1
 	piping_layer = PIPING_LAYER_MIN
 	pixel_x = -PIPING_LAYER_P_X
 	pixel_y = -PIPING_LAYER_P_Y
-	
+
 /obj/machinery/atmospherics/components/binary/dp_vent_pump/layer3
 	piping_layer = PIPING_LAYER_MAX
 	pixel_x = PIPING_LAYER_P_X
@@ -45,12 +44,12 @@ Acts like a normal vent, but has an input AND output.
 /obj/machinery/atmospherics/components/binary/dp_vent_pump/on
 	on = TRUE
 	icon_state = "dpvent_map_on"
-	
+
 /obj/machinery/atmospherics/components/binary/dp_vent_pump/on/layer1
 	piping_layer = PIPING_LAYER_MIN
 	pixel_x = -PIPING_LAYER_P_X
 	pixel_y = -PIPING_LAYER_P_Y
-	
+
 /obj/machinery/atmospherics/components/binary/dp_vent_pump/on/layer3
 	piping_layer = PIPING_LAYER_MAX
 	pixel_x = PIPING_LAYER_P_X
@@ -62,12 +61,12 @@ Acts like a normal vent, but has an input AND output.
 
 /obj/machinery/atmospherics/components/binary/dp_vent_pump/high_volume
 	name = "large dual-port air vent"
-	
+
 /obj/machinery/atmospherics/components/binary/dp_vent_pump/high_volume/layer1
 	piping_layer = PIPING_LAYER_MIN
 	pixel_x = -PIPING_LAYER_P_X
 	pixel_y = -PIPING_LAYER_P_Y
-	
+
 /obj/machinery/atmospherics/components/binary/dp_vent_pump/high_volume/layer3
 	piping_layer = PIPING_LAYER_MAX
 	pixel_x = PIPING_LAYER_P_X
@@ -76,12 +75,12 @@ Acts like a normal vent, but has an input AND output.
 /obj/machinery/atmospherics/components/binary/dp_vent_pump/high_volume/on
 	on = TRUE
 	icon_state = "dpvent_map_on"
-	
+
 /obj/machinery/atmospherics/components/binary/dp_vent_pump/high_volume/on/layer1
 	piping_layer = PIPING_LAYER_MIN
 	pixel_x = -PIPING_LAYER_P_X
 	pixel_y = -PIPING_LAYER_P_Y
-	
+
 /obj/machinery/atmospherics/components/binary/dp_vent_pump/high_volume/on/layer3
 	piping_layer = PIPING_LAYER_MAX
 	pixel_x = PIPING_LAYER_P_X

--- a/code/modules/atmospherics/machinery/components/binary_devices/passive_gate.dm
+++ b/code/modules/atmospherics/machinery/components/binary_devices/passive_gate.dm
@@ -16,7 +16,6 @@ Passive gate is similar to the regular pump except:
 
 	interaction_flags_machine = INTERACT_MACHINE_OFFLINE | INTERACT_MACHINE_WIRES_IF_OPEN | INTERACT_MACHINE_ALLOW_SILICON | INTERACT_MACHINE_OPEN_SILICON | INTERACT_MACHINE_SET_MACHINE
 
-	var/on = FALSE
 	var/target_pressure = ONE_ATMOSPHERE
 
 	var/frequency = 0
@@ -25,7 +24,7 @@ Passive gate is similar to the regular pump except:
 
 	construction_type = /obj/item/pipe/directional
 	pipe_state = "passivegate"
-	
+
 /obj/machinery/atmospherics/components/binary/passive_gate/layer1
 	piping_layer = PIPING_LAYER_MIN
 	pixel_x = -PIPING_LAYER_P_X

--- a/code/modules/atmospherics/machinery/components/binary_devices/pump.dm
+++ b/code/modules/atmospherics/machinery/components/binary_devices/pump.dm
@@ -19,7 +19,6 @@ Thus, the two variables affect pump operation are set in New():
 
 	can_unwrench = TRUE
 
-	var/on = FALSE
 	var/target_pressure = ONE_ATMOSPHERE
 
 	var/frequency = 0
@@ -28,7 +27,7 @@ Thus, the two variables affect pump operation are set in New():
 
 	construction_type = /obj/item/pipe/directional
 	pipe_state = "pump"
-	
+
 /obj/machinery/atmospherics/components/binary/pump/layer1
 	piping_layer = PIPING_LAYER_MIN
 	pixel_x = -PIPING_LAYER_P_X
@@ -42,7 +41,7 @@ Thus, the two variables affect pump operation are set in New():
 /obj/machinery/atmospherics/components/binary/pump/on
 	on = TRUE
 	icon_state = "pump_on_map"
-	
+
 /obj/machinery/atmospherics/components/binary/pump/on/layer1
 	piping_layer = PIPING_LAYER_MIN
 	pixel_x = -PIPING_LAYER_P_X
@@ -52,7 +51,7 @@ Thus, the two variables affect pump operation are set in New():
 	piping_layer = PIPING_LAYER_MAX
 	pixel_x = PIPING_LAYER_P_X
 	pixel_y = PIPING_LAYER_P_Y
-	
+
 /obj/machinery/atmospherics/components/binary/pump/Destroy()
 	SSradio.remove_object(src,frequency)
 	if(radio_connection)

--- a/code/modules/atmospherics/machinery/components/binary_devices/valve.dm
+++ b/code/modules/atmospherics/machinery/components/binary_devices/valve.dm
@@ -30,15 +30,15 @@ It's like a regular ol' straight pipe, but you can turn it on and off.
 	pixel_x = PIPING_LAYER_P_X
 	pixel_y = PIPING_LAYER_P_Y
 
-/obj/machinery/atmospherics/components/binary/valve/open
+/obj/machinery/atmospherics/components/binary/valve/on
 	on = TRUE
 
-/obj/machinery/atmospherics/components/binary/valve/open/layer1
+/obj/machinery/atmospherics/components/binary/valve/on/layer1
 	piping_layer = PIPING_LAYER_MIN
 	pixel_x = -PIPING_LAYER_P_X
 	pixel_y = -PIPING_LAYER_P_Y
 
-/obj/machinery/atmospherics/components/binary/valve/open/layer3
+/obj/machinery/atmospherics/components/binary/valve/on/layer3
 	piping_layer = PIPING_LAYER_MAX
 	pixel_x = PIPING_LAYER_P_X
 	pixel_y = PIPING_LAYER_P_Y
@@ -95,6 +95,19 @@ It's like a regular ol' straight pipe, but you can turn it on and off.
 	pixel_y = -PIPING_LAYER_P_Y
 
 /obj/machinery/atmospherics/components/binary/valve/digital/layer3
+	piping_layer = PIPING_LAYER_MAX
+	pixel_x = PIPING_LAYER_P_X
+	pixel_y = PIPING_LAYER_P_Y
+
+/obj/machinery/atmospherics/components/binary/valve/digital/on
+	on = TRUE
+
+/obj/machinery/atmospherics/components/binary/valve/digital/on/layer1
+	piping_layer = PIPING_LAYER_MIN
+	pixel_x = -PIPING_LAYER_P_X
+	pixel_y = -PIPING_LAYER_P_Y
+
+/obj/machinery/atmospherics/components/binary/valve/digital/on/layer3
 	piping_layer = PIPING_LAYER_MAX
 	pixel_x = PIPING_LAYER_P_X
 	pixel_y = PIPING_LAYER_P_Y

--- a/code/modules/atmospherics/machinery/components/binary_devices/valve.dm
+++ b/code/modules/atmospherics/machinery/components/binary_devices/valve.dm
@@ -13,14 +13,13 @@ It's like a regular ol' straight pipe, but you can turn it on and off.
 	var/frequency = 0
 	var/id = null
 
-	var/open = FALSE
 	var/valve_type = "m" //lets us have a nice, clean, OOP update_icon_nopipes()
 
 	construction_type = /obj/item/pipe/binary
 	pipe_state = "mvalve"
 
 	var/switching = FALSE
-	
+
 /obj/machinery/atmospherics/components/binary/valve/layer1
 	piping_layer = PIPING_LAYER_MIN
 	pixel_x = -PIPING_LAYER_P_X
@@ -32,8 +31,8 @@ It's like a regular ol' straight pipe, but you can turn it on and off.
 	pixel_y = PIPING_LAYER_P_Y
 
 /obj/machinery/atmospherics/components/binary/valve/open
-	open = TRUE
-	
+	on = TRUE
+
 /obj/machinery/atmospherics/components/binary/valve/open/layer1
 	piping_layer = PIPING_LAYER_MIN
 	pixel_x = -PIPING_LAYER_P_X
@@ -47,11 +46,11 @@ It's like a regular ol' straight pipe, but you can turn it on and off.
 /obj/machinery/atmospherics/components/binary/valve/update_icon_nopipes(animation = 0)
 	normalize_dir()
 	if(animation)
-		flick("[valve_type]valve_[open][!open]",src)
-	icon_state = "[valve_type]valve_[open?"on":"off"]"
+		flick("[valve_type]valve_[on][!on]",src)
+	icon_state = "[valve_type]valve_[on?"on":"off"]"
 
 /obj/machinery/atmospherics/components/binary/valve/proc/open()
-	open = TRUE
+	on = TRUE
 	update_icon_nopipes()
 	update_parents()
 	var/datum/pipeline/parent1 = parents[1]
@@ -59,7 +58,7 @@ It's like a regular ol' straight pipe, but you can turn it on and off.
 	investigate_log("was opened by [usr ? key_name(usr) : "a remote signal"]", INVESTIGATE_ATMOS)
 
 /obj/machinery/atmospherics/components/binary/valve/proc/close()
-	open = FALSE
+	on = FALSE
 	update_icon_nopipes()
 	investigate_log("was closed by [usr ? key_name(usr) : "a remote signal"]", INVESTIGATE_ATMOS)
 
@@ -76,7 +75,7 @@ It's like a regular ol' straight pipe, but you can turn it on and off.
 		return
 	switching = TRUE
 	sleep(10)
-	if(open)
+	if(on)
 		close()
 	else
 		open()
@@ -89,7 +88,7 @@ It's like a regular ol' straight pipe, but you can turn it on and off.
 	valve_type = "d"
 	pipe_state = "dvalve"
 	interaction_flags_machine = INTERACT_MACHINE_ALLOW_SILICON | INTERACT_MACHINE_OFFLINE | INTERACT_MACHINE_OPEN | INTERACT_MACHINE_OPEN_SILICON
-	
+
 /obj/machinery/atmospherics/components/binary/valve/digital/layer1
 	piping_layer = PIPING_LAYER_MIN
 	pixel_x = -PIPING_LAYER_P_X

--- a/code/modules/atmospherics/machinery/components/binary_devices/volume_pump.dm
+++ b/code/modules/atmospherics/machinery/components/binary_devices/volume_pump.dm
@@ -19,7 +19,6 @@ Thus, the two variables affect pump operation are set in New():
 
 	can_unwrench = TRUE
 
-	var/on = FALSE
 	var/transfer_rate = MAX_TRANSFER_RATE
 
 	var/frequency = 0
@@ -28,7 +27,7 @@ Thus, the two variables affect pump operation are set in New():
 
 	construction_type = /obj/item/pipe/directional
 	pipe_state = "volumepump"
-	
+
 /obj/machinery/atmospherics/components/binary/volume_pump/layer1
 	piping_layer = PIPING_LAYER_MIN
 	pixel_x = -PIPING_LAYER_P_X
@@ -56,7 +55,7 @@ Thus, the two variables affect pump operation are set in New():
 	piping_layer = PIPING_LAYER_MAX
 	pixel_x = PIPING_LAYER_P_X
 	pixel_y = PIPING_LAYER_P_Y
-	
+
 /obj/machinery/atmospherics/components/binary/volume_pump/update_icon_nopipes()
 	if(!is_operational())
 		icon_state = "volpump_off"

--- a/code/modules/atmospherics/machinery/components/trinary_devices/filter.dm
+++ b/code/modules/atmospherics/machinery/components/trinary_devices/filter.dm
@@ -4,7 +4,6 @@
 	desc = "Very useful for filtering gasses."
 	density = FALSE
 	can_unwrench = TRUE
-	var/on = FALSE
 	var/target_pressure = ONE_ATMOSPHERE
 	var/filter_type = null
 	var/frequency = 0
@@ -22,11 +21,11 @@
 	piping_layer = PIPING_LAYER_MAX
 	pixel_x = PIPING_LAYER_P_X
 	pixel_y = PIPING_LAYER_P_Y
-	
+
 /obj/machinery/atmospherics/components/trinary/filter/flipped
 	icon_state = "filter_off_f"
 	flipped = TRUE
-	
+
 /obj/machinery/atmospherics/components/trinary/filter/flipped/layer1
 	piping_layer = PIPING_LAYER_MIN
 	pixel_x = -PIPING_LAYER_P_X
@@ -58,7 +57,7 @@
 /obj/machinery/atmospherics/components/trinary/filter/atmos //Used for atmos waste loops
 	on = TRUE
 	icon_state = "filter_on"
-	
+
 /obj/machinery/atmospherics/components/trinary/filter/atmos/n2
 	name = "nitrogen filter"
 	filter_type = "n2"
@@ -78,7 +77,7 @@
 /obj/machinery/atmospherics/components/trinary/filter/atmos/flipped //This feels wrong, I know
 	icon_state = "filter_on_f"
 	flipped = TRUE
-	
+
 /obj/machinery/atmospherics/components/trinary/filter/atmos/flipped/n2
 	name = "nitrogen filter"
 	filter_type = "n2"
@@ -94,7 +93,7 @@
 /obj/machinery/atmospherics/components/trinary/filter/atmos/flipped/plasma
 	name = "plasma filter"
 	filter_type = "plasma"
-	
+
 /obj/machinery/atmospherics/components/trinary/filter/update_icon()
 	cut_overlays()
 	for(var/direction in GLOB.cardinals)

--- a/code/modules/atmospherics/machinery/components/trinary_devices/mixer.dm
+++ b/code/modules/atmospherics/machinery/components/trinary_devices/mixer.dm
@@ -6,8 +6,6 @@
 	can_unwrench = TRUE
 	desc = "Very useful for mixing gasses."
 
-	var/on = FALSE
-
 	var/target_pressure = ONE_ATMOSPHERE
 	var/node1_concentration = 0.5
 	var/node2_concentration = 0.5
@@ -26,7 +24,7 @@
 	piping_layer = PIPING_LAYER_MAX
 	pixel_x = PIPING_LAYER_P_X
 	pixel_y = PIPING_LAYER_P_Y
-	
+
 /obj/machinery/atmospherics/components/trinary/mixer/flipped
 	icon_state = "mixer_off_f"
 	flipped = TRUE
@@ -40,7 +38,7 @@
 	piping_layer = PIPING_LAYER_MAX
 	pixel_x = PIPING_LAYER_P_X
 	pixel_y = PIPING_LAYER_P_Y
-	
+
 /obj/machinery/atmospherics/components/trinary/mixer/airmix //For standard airmix to distro
 	name = "air mixer"
 	icon_state = "mixer_on"
@@ -48,19 +46,19 @@
 	node2_concentration = O2STANDARD
 	on = TRUE
 	target_pressure = MAX_OUTPUT_PRESSURE
-	
+
 /obj/machinery/atmospherics/components/trinary/mixer/airmix/inverse
 	node1_concentration = O2STANDARD
 	node2_concentration = N2STANDARD
-	
+
 /obj/machinery/atmospherics/components/trinary/mixer/airmix/flipped
 	icon_state = "mixer_on_f"
 	flipped = TRUE
-	
+
 /obj/machinery/atmospherics/components/trinary/mixer/airmix/flipped/inverse
 	node1_concentration = O2STANDARD
 	node2_concentration = N2STANDARD
-	
+
 /obj/machinery/atmospherics/components/trinary/mixer/update_icon()
 	cut_overlays()
 	for(var/direction in GLOB.cardinals)

--- a/code/modules/atmospherics/machinery/components/unary_devices/cryo.dm
+++ b/code/modules/atmospherics/machinery/components/unary_devices/cryo.dm
@@ -14,7 +14,6 @@
 	pipe_flags = PIPING_ONE_PER_TURF | PIPING_DEFAULT_LAYER_ONLY
 	occupant_typecache = list(/mob/living/carbon, /mob/living/simple_animal)
 
-	var/on = FALSE
 	var/autoeject = FALSE
 	var/volume = 100
 

--- a/code/modules/atmospherics/machinery/components/unary_devices/outlet_injector.dm
+++ b/code/modules/atmospherics/machinery/components/unary_devices/outlet_injector.dm
@@ -6,7 +6,6 @@
 	can_unwrench = TRUE
 	resistance_flags = FIRE_PROOF | UNACIDABLE | ACID_PROOF //really helpful in building gas chambers for xenomorphs
 
-	var/on = FALSE
 	var/injecting = 0
 
 	var/volume_rate = 50
@@ -19,7 +18,7 @@
 	layer = GAS_SCRUBBER_LAYER
 
 	pipe_state = "injector"
-	
+
 /obj/machinery/atmospherics/components/unary/outlet_injector/layer1
 	piping_layer = PIPING_LAYER_MIN
 	pixel_x = -PIPING_LAYER_P_X
@@ -75,7 +74,7 @@
 
 /obj/machinery/atmospherics/components/unary/outlet_injector/on
 	on = TRUE
-	
+
 /obj/machinery/atmospherics/components/unary/outlet_injector/on/layer1
 	piping_layer = PIPING_LAYER_MIN
 	pixel_x = -PIPING_LAYER_P_X

--- a/code/modules/atmospherics/machinery/components/unary_devices/thermomachine.dm
+++ b/code/modules/atmospherics/machinery/components/unary_devices/thermomachine.dm
@@ -13,7 +13,6 @@
 	circuit = /obj/item/circuitboard/machine/thermomachine
 	pipe_flags = PIPING_ONE_PER_TURF | PIPING_DEFAULT_LAYER_ONLY
 
-	var/on = FALSE
 	var/min_temperature = 0
 	var/max_temperature = 0
 	var/target_temperature = T20C

--- a/code/modules/atmospherics/machinery/components/unary_devices/vent_pump.dm
+++ b/code/modules/atmospherics/machinery/components/unary_devices/vent_pump.dm
@@ -16,7 +16,6 @@
 	layer = GAS_SCRUBBER_LAYER
 
 	var/id_tag = null
-	var/on = FALSE
 	var/pump_direction = RELEASING
 
 	var/pressure_checks = EXT_BOUND
@@ -32,7 +31,7 @@
 	var/radio_filter_in
 
 	pipe_state = "uvent"
-	
+
 /obj/machinery/atmospherics/components/unary/vent_pump/layer1
 	piping_layer = PIPING_LAYER_MIN
 	pixel_x = -PIPING_LAYER_P_X
@@ -46,7 +45,7 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on
 	on = TRUE
 	icon_state = "vent_map_on"
-	
+
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1
 	piping_layer = PIPING_LAYER_MIN
 	pixel_x = -PIPING_LAYER_P_X
@@ -62,7 +61,7 @@
 	pressure_checks = INT_BOUND
 	internal_pressure_bound = 4000
 	external_pressure_bound = 0
-	
+
 /obj/machinery/atmospherics/components/unary/vent_pump/siphon/layer1
 	piping_layer = PIPING_LAYER_MIN
 	pixel_x = -PIPING_LAYER_P_X
@@ -76,7 +75,7 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/siphon/on
 	on = TRUE
 	icon_state = "vent_map_siphon_on"
-	
+
 /obj/machinery/atmospherics/components/unary/vent_pump/siphon/on/layer1
 	piping_layer = PIPING_LAYER_MIN
 	pixel_x = -PIPING_LAYER_P_X
@@ -136,7 +135,7 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/high_volume
 	name = "large air vent"
 	power_channel = EQUIP
-	
+
 /obj/machinery/atmospherics/components/unary/vent_pump/high_volume/layer1
 	piping_layer = PIPING_LAYER_MIN
 	pixel_x = -PIPING_LAYER_P_X
@@ -150,7 +149,7 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/high_volume/on
 	on = TRUE
 	icon_state = "vent_map_on"
-	
+
 /obj/machinery/atmospherics/components/unary/vent_pump/high_volume/on/layer1
 	piping_layer = PIPING_LAYER_MIN
 	pixel_x = -PIPING_LAYER_P_X
@@ -166,7 +165,7 @@
 	pressure_checks = INT_BOUND
 	internal_pressure_bound = 2000
 	external_pressure_bound = 0
-	
+
 /obj/machinery/atmospherics/components/unary/vent_pump/high_volume/siphon/layer1
 	piping_layer = PIPING_LAYER_MIN
 	pixel_x = -PIPING_LAYER_P_X
@@ -180,7 +179,7 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/high_volume/siphon/on
 	on = TRUE
 	icon_state = "vent_map_siphon_on"
-	
+
 /obj/machinery/atmospherics/components/unary/vent_pump/high_volume/siphon/on/layer1
 	piping_layer = PIPING_LAYER_MIN
 	pixel_x = -PIPING_LAYER_P_X

--- a/code/modules/atmospherics/machinery/components/unary_devices/vent_scrubber.dm
+++ b/code/modules/atmospherics/machinery/components/unary_devices/vent_scrubber.dm
@@ -14,7 +14,6 @@
 	layer = GAS_SCRUBBER_LAYER
 
 	var/id_tag = null
-	var/on = FALSE
 	var/scrubbing = SCRUBBING //0 = siphoning, 1 = scrubbing
 
 	var/filter_types = list(/datum/gas/carbon_dioxide)
@@ -29,7 +28,7 @@
 	var/radio_filter_in
 
 	pipe_state = "scrubber"
-	
+
 /obj/machinery/atmospherics/components/unary/vent_scrubber/layer1
 	piping_layer = PIPING_LAYER_MIN
 	pixel_x = -PIPING_LAYER_P_X
@@ -52,7 +51,7 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on
 	on = TRUE
 	icon_state = "scrub_map_on"
-	
+
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer1
 	piping_layer = PIPING_LAYER_MIN
 	pixel_x = -PIPING_LAYER_P_X

--- a/code/modules/atmospherics/machinery/datum_pipeline.dm
+++ b/code/modules/atmospherics/machinery/datum_pipeline.dm
@@ -219,7 +219,7 @@
 			continue
 		GL += P.return_air()
 		for(var/obj/machinery/atmospherics/components/binary/valve/V in P.other_atmosmch)
-			if(V.open)
+			if(V.on)
 				PL |= V.parents[1]
 				PL |= V.parents[2]
 		for(var/obj/machinery/atmospherics/components/unary/portables_connector/C in P.other_atmosmch)


### PR DESCRIPTION
:cl:
fix: Unwrenching and re-wrenching pre-mapped atmos components no longer turns them on automatically.
/:cl:

Fixes #37062.

Kludgy? Maybe should be a proc, or `var/on` moved up to `/obj/atmospherics/component`?