### PR TITLE
Allow running into space diagonally

### DIFF
--- a/code/game/atoms_movable.dm
+++ b/code/game/atoms_movable.dm
@@ -199,8 +199,12 @@
 						first_step_dir = WEST
 						moving_diagonally = SECOND_DIAG_STEP
 						. = step(src, SOUTH)
-			if(!. && moving_diagonally == SECOND_DIAG_STEP)
-				setDir(first_step_dir)
+			if(moving_diagonally == SECOND_DIAG_STEP)
+				if(!.)
+					setDir(first_step_dir)
+				else if (!inertia_moving)
+					inertia_next_move = world.time + inertia_move_delay
+					newtonian_move(direct)
 			moving_diagonally = 0
 			return
 


### PR DESCRIPTION
:cl:
fix: Running diagonally into space now properly continues the diagonal movement in zero-gravity.
/:cl:

Fixes #37862.