### PR TITLE
Fixes navbeacon access reqs

### DIFF
--- a/code/game/machinery/navbeacon.dm
+++ b/code/game/machinery/navbeacon.dm
@@ -20,7 +20,7 @@
 	var/list/codes		// assoc. list of transponder codes
 	var/codes_txt = ""	// codes as set on map: "tag1;tag2" or "tag1=value;tag2=value"
 
-	req_access = list(ACCESS_ENGINE, ACCESS_ROBOTICS)
+	req_one_access = list(ACCESS_ENGINE, ACCESS_ROBOTICS)
 
 /obj/machinery/navbeacon/Initialize()
 	. = ..()


### PR DESCRIPTION
:cl: Denton
fix: Navbeacon access requirements have been fixed: Now you need either Engineering or Robotics access, but not both at the same time.
/:cl:

Related: #38064 

