### PR TITLE
Those footprints are... moving? [Chameleon Proj will let you scan decals]

### DIFF
--- a/code/game/objects/items/devices/chameleonproj.dm
+++ b/code/game/objects/items/devices/chameleonproj.dm
@@ -39,23 +39,24 @@
 		return
 	if(!check_sprite(target))
 		return
-	if(!active_dummy) //I now present you the blackli(f)st
-		if(isturf(target))
-			return
-		if(ismob(target))
-			return
-		if(istype(target, /obj/structure/falsewall))
-			return
-		if(iseffect(target))
-			if(!(istype(target, /obj/effect/decal))) //be a footprint
-				return	
-		playsound(get_turf(src), 'sound/weapons/flash.ogg', 100, 1, -6)
-		to_chat(user, "<span class='notice'>Scanned [target].</span>")
-		var/obj/temp = new/obj()
-		temp.appearance = target.appearance
-		temp.layer = initial(target.layer) // scanning things in your inventory
-		temp.plane = initial(target.plane)
-		saved_appearance = temp.appearance
+	if(active_dummy)//I now present you the blackli(f)st
+		return
+	if(isturf(target))
+		return
+	if(ismob(target))
+		return
+	if(istype(target, /obj/structure/falsewall))
+		return
+	if(iseffect(target))
+		if(!(istype(target, /obj/effect/decal))) //be a footprint
+			return	
+	playsound(get_turf(src), 'sound/weapons/flash.ogg', 100, 1, -6)
+	to_chat(user, "<span class='notice'>Scanned [target].</span>")
+	var/obj/temp = new/obj()
+	temp.appearance = target.appearance
+	temp.layer = initial(target.layer) // scanning things in your inventory
+	temp.plane = initial(target.plane)
+	saved_appearance = temp.appearance
 
 /obj/item/chameleon/proc/check_sprite(atom/target)
 	if(target.icon_state in icon_states(target.icon))

--- a/code/game/objects/items/devices/chameleonproj.dm
+++ b/code/game/objects/items/devices/chameleonproj.dm
@@ -39,15 +39,23 @@
 		return
 	if(!check_sprite(target))
 		return
-	if(!active_dummy)
-		if(!(isturf(target) || ismob(target) || istype(target, /obj/structure/falsewall) || istype(target, /obj/effect))) //NOT any of these
-			playsound(get_turf(src), 'sound/weapons/flash.ogg', 100, 1, -6)
-			to_chat(user, "<span class='notice'>Scanned [target].</span>")
-			var/obj/temp = new/obj()
-			temp.appearance = target.appearance
-			temp.layer = initial(target.layer) // scanning things in your inventory
-			temp.plane = initial(target.plane)
-			saved_appearance = temp.appearance
+	if(!active_dummy) //I now present you the blackli(f)st
+		if(isturf(target))
+			return
+		if(ismob(target))
+			return
+		if(istype(target, /obj/structure/falsewall))
+			return
+		if(iseffect(target))
+			if(!(istype(target, /obj/effect/decal))) //be a footprint
+				return	
+		playsound(get_turf(src), 'sound/weapons/flash.ogg', 100, 1, -6)
+		to_chat(user, "<span class='notice'>Scanned [target].</span>")
+		var/obj/temp = new/obj()
+		temp.appearance = target.appearance
+		temp.layer = initial(target.layer) // scanning things in your inventory
+		temp.plane = initial(target.plane)
+		saved_appearance = temp.appearance
 
 /obj/item/chameleon/proc/check_sprite(atom/target)
 	if(target.icon_state in icon_states(target.icon))


### PR DESCRIPTION
:cl: Cobby
tweak: Decals are the exception to the recent removal of effects in Chameleon Projectors.
/:cl:

I was never told decals would be problematic when asked in the previous PR and didn't like that it just gutted a large possibility of items to scan. When I asked if these would ever be a problem, I was ignored. I could probably just change it to only exclude temp effects like Naksu said previously but I don't want to play gotcha with a rogue one and have my PR closed over it.

I'm not looking for major balance discussion, I'm ensuring that the "fix" pr remains just that or at least the decal question gets properly addressed. If there were/are actual balance issues, it should have been PR'd separately from a legitimate bug or at least called out in the PR rather than throwing it under the bugfix umbrella.

Again, for those seeking balance discussion (preferably not on my PR),

# The default option is a common, two pixel item.

Oh and I expanded the centipede-if into readable items.