### PR TITLE
Make typecache checks twice as fast, stop using single-type typecaches where appropriate

### DIFF
--- a/code/__DEFINES/is_helpers.dm
+++ b/code/__DEFINES/is_helpers.dm
@@ -181,7 +181,7 @@ GLOBAL_LIST_INIT(glass_sheet_types, typecacheof(list(
 
 #define is_glass_sheet(O) (is_type_in_typecache(O, GLOB.glass_sheet_types))
 
-#define iseffect(O) (is_type_in_typecache(O, GLOB.typecache_effect))
+#define iseffect(O) (istype(O, /obj/effect))
 
 #define isblobmonster(O) (istype(O, /mob/living/simple_animal/hostile/blob))
 

--- a/code/__HELPERS/_lists.dm
+++ b/code/__HELPERS/_lists.dm
@@ -73,7 +73,7 @@
 	return FALSE
 
 //Checks for specific types in specifically structured (Assoc "type" = TRUE) lists ('typecaches')
-#define is_type_in_typecache(A, L) (length(L) && L[(ispath(A) ? A : A:type)])
+#define is_type_in_typecache(A, L) (A && length(L) && L[(ispath(A) ? A : A:type)])
 /*
 /proc/is_type_in_typecache(atom/A, list/L)
 	if(!LAZYLEN(L) || !A)

--- a/code/__HELPERS/_lists.dm
+++ b/code/__HELPERS/_lists.dm
@@ -74,16 +74,7 @@
 
 //Checks for specific types in specifically structured (Assoc "type" = TRUE) lists ('typecaches')
 #define is_type_in_typecache(A, L) (A && length(L) && L[(ispath(A) ? A : A:type)])
-/*
-/proc/is_type_in_typecache(atom/A, list/L)
-	if(!LAZYLEN(L) || !A)
 
-		return FALSE
-	if(ispath(A))
-		. = L[A]
-	else
-		. = L[A.type]
-*/
 //Checks for a string in a list
 /proc/is_string_in_list(string, list/L)
 	if(!LAZYLEN(L) || !string)

--- a/code/__HELPERS/_lists.dm
+++ b/code/__HELPERS/_lists.dm
@@ -73,6 +73,8 @@
 	return FALSE
 
 //Checks for specific types in specifically structured (Assoc "type" = TRUE) lists ('typecaches')
+#define is_type_in_typecache(A, L) (length(L) && L[(ispath(A) ? A : A:type)])
+/*
 /proc/is_type_in_typecache(atom/A, list/L)
 	if(!LAZYLEN(L) || !A)
 
@@ -81,7 +83,7 @@
 		. = L[A]
 	else
 		. = L[A.type]
-
+*/
 //Checks for a string in a list
 /proc/is_string_in_list(string, list/L)
 	if(!LAZYLEN(L) || !string)

--- a/code/__HELPERS/areas.dm
+++ b/code/__HELPERS/areas.dm
@@ -15,7 +15,7 @@
 		var/turf/sourceT = found_turfs[1]
 		if(break_if_found[sourceT.type])
 			return FALSE
-		if (is_type_in_typecache(sourceT.loc, GLOB.typecache_shuttle_area))
+		if (istype(sourceT.loc, /area/shuttle))
 			return FALSE
 		found_turfs.Cut(1, 2)
 		var/dir_flags = checked_turfs[sourceT]
@@ -50,7 +50,7 @@
 	var/list/areas = list("New Area" = /area)
 	for(var/i in 1 to turfs.len)
 		var/area/place = get_area(turfs[i])
-		if(blacklisted_areas[place.type] || GLOB.typecache_shuttle_area[place.type])
+		if(blacklisted_areas[place.type] || istype(place, /area/shuttle))
 			continue
 		if(!place.requires_power || place.noteleport || place.hidden)
 			continue // No expanding powerless rooms etc

--- a/code/__HELPERS/mobs.dm
+++ b/code/__HELPERS/mobs.dm
@@ -178,8 +178,8 @@ Proc for attack log creation, because really why not
 /proc/add_logs(mob/user, mob/target, what_done, object=null, addition=null)
 	var/turf/attack_location = get_turf(target)
 
-	var/is_mob_user = user && GLOB.typecache_mob[user.type]
-	var/is_mob_target = target && GLOB.typecache_mob[target.type]
+	var/is_mob_user = user && ismob(user)
+	var/is_mob_target = target && ismob(target)
 
 	var/mob/living/living_target
 

--- a/code/_globalvars/lists/typecache.dm
+++ b/code/_globalvars/lists/typecache.dm
@@ -5,12 +5,4 @@
 
 GLOBAL_LIST_INIT(typecache_mob, typecacheof(/mob))
 
-GLOBAL_LIST_INIT(typecache_living, typecacheof(/mob/living))
-
 GLOBAL_LIST_INIT(typecache_machine_or_structure, typecacheof(list(/obj/machinery, /obj/structure)))
-
-GLOBAL_LIST_INIT(typecache_shuttle_area, typecacheof(/area/shuttle))
-
-GLOBAL_LIST_INIT(typecache_clothing, typecacheof(/obj/item/clothing))
-
-GLOBAL_LIST_INIT(typecache_effect, typecacheof(/obj/effect))

--- a/code/datums/martial/cqc.dm
+++ b/code/datums/martial/cqc.dm
@@ -21,7 +21,8 @@
 	restraining = FALSE
 
 /datum/martial_art/cqc/can_use(mob/living/carbon/human/H)
-	if(just_a_cook && !(is_type_in_typecache(get_area(H), areas_under_siege)))
+	var/area/A = get_area(H)
+	if(just_a_cook && !(is_type_in_typecache(A, areas_under_siege)))
 		return FALSE
 	return ..()
 

--- a/code/game/machinery/_machinery.dm
+++ b/code/game/machinery/_machinery.dm
@@ -180,7 +180,7 @@ Class Procs:
 	density = TRUE
 	if(!target)
 		for(var/am in loc)
-			if(!is_type_in_typecache(am, (occupant_typecache || GLOB.typecache_living)))
+			if (!(occupant_typecache ? is_type_in_typecache(am, occupant_typecache) : isliving(am)))
 				continue
 			var/atom/movable/AM = am
 			if(AM.has_buckled_mobs())

--- a/code/modules/hydroponics/beekeeping/beebox.dm
+++ b/code/modules/hydroponics/beekeeping/beebox.dm
@@ -18,7 +18,7 @@
 /mob/living/carbon/human/bee_friendly()
 	if(dna && dna.species && dna.species.id == "pod") //bees pollinate plants, duh.
 		return 1
-	if (wear_suit && head && istype(wear_suit, /obj/item/clothing) && istype(wear_suit, /obj/item/clothing))
+	if (wear_suit && head && istype(wear_suit, /obj/item/clothing) && istype(head, /obj/item/clothing))
 		var/obj/item/clothing/CS = wear_suit
 		var/obj/item/clothing/CH = head
 		if (CS.clothing_flags & CH.clothing_flags & THICKMATERIAL)

--- a/code/modules/hydroponics/beekeeping/beebox.dm
+++ b/code/modules/hydroponics/beekeeping/beebox.dm
@@ -18,7 +18,7 @@
 /mob/living/carbon/human/bee_friendly()
 	if(dna && dna.species && dna.species.id == "pod") //bees pollinate plants, duh.
 		return 1
-	if (wear_suit && head && is_type_in_typecache(wear_suit, GLOB.typecache_clothing) && is_type_in_typecache(wear_suit, GLOB.typecache_clothing))
+	if (wear_suit && head && istype(wear_suit, /obj/item/clothing) && istype(wear_suit, /obj/item/clothing))
 		var/obj/item/clothing/CS = wear_suit
 		var/obj/item/clothing/CH = head
 		if (CS.clothing_flags & CH.clothing_flags & THICKMATERIAL)

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -496,12 +496,12 @@
 	// If targeting anything else, see if the wear suit is thin enough.
 	if (!penetrate_thick)
 		if(above_neck(target_zone))
-			if(head && is_type_in_typecache(head, GLOB.typecache_clothing))
+			if(head && istype(head, /obj/item/clothing))
 				var/obj/item/clothing/CH = head
 				if (CH.clothing_flags & THICKMATERIAL)
 					. = 0
 		else
-			if(wear_suit && is_type_in_typecache(wear_suit, GLOB.typecache_clothing))
+			if(wear_suit && istype(wear_suit, /obj/item/clothing))
 				var/obj/item/clothing/CS = wear_suit
 				if (CS.clothing_flags & THICKMATERIAL)
 					. = 0

--- a/code/modules/mob/living/carbon/human/human_movement.dm
+++ b/code/modules/mob/living/carbon/human/human_movement.dm
@@ -11,7 +11,7 @@
 	if (!(lube&GALOSHES_DONT_HELP))
 		if(has_trait(TRAIT_NOSLIPWATER))
 			return 0
-		if(shoes && is_type_in_typecache(shoes, GLOB.typecache_clothing))
+		if(shoes && istype(shoes, /obj/item/clothing))
 			var/obj/item/clothing/CS = shoes
 			if (CS.clothing_flags & NOSLIP)
 				return 0
@@ -19,7 +19,7 @@
 
 /mob/living/carbon/human/experience_pressure_difference()
 	playsound(src, 'sound/effects/space_wind.ogg', 50, 1)
-	if(shoes && is_type_in_typecache(shoes, GLOB.typecache_clothing))
+	if(shoes && istype(shoes, /obj/item/clothing))
 		var/obj/item/clothing/S = shoes
 		if (S.clothing_flags & NOSLIP)
 			return 0

--- a/code/modules/mob/living/carbon/human/life.dm
+++ b/code/modules/mob/living/carbon/human/life.dm
@@ -44,7 +44,7 @@
 
 
 /mob/living/carbon/human/calculate_affecting_pressure(pressure)
-	if (wear_suit && head && is_type_in_typecache(wear_suit, GLOB.typecache_clothing) && is_type_in_typecache(head, GLOB.typecache_clothing))
+	if (wear_suit && head && istype(wear_suit, /obj/item/clothing) && istype(head, /obj/item/clothing))
 		var/obj/item/clothing/CS = wear_suit
 		var/obj/item/clothing/CH = head
 		if (CS.clothing_flags & CH.clothing_flags & STOPSPRESSUREDAMAGE)
@@ -274,7 +274,7 @@
 	if(glasses)
 		if(glasses.clothing_flags & BLOCK_GAS_SMOKE_EFFECT)
 			return TRUE
-	if(head && is_type_in_typecache(head, GLOB.typecache_clothing))
+	if(head && istype(head, /obj/item/clothing))
 		var/obj/item/clothing/CH = head
 		if(CH.clothing_flags & BLOCK_GAS_SMOKE_EFFECT)
 			return TRUE

--- a/code/modules/mob/living/carbon/human/species_types/plasmamen.dm
+++ b/code/modules/mob/living/carbon/human/species_types/plasmamen.dm
@@ -25,7 +25,7 @@
 /datum/species/plasmaman/spec_life(mob/living/carbon/human/H)
 	var/datum/gas_mixture/environment = H.loc.return_air()
 	var/atmos_sealed = FALSE
-	if (H.wear_suit && H.head && is_type_in_typecache(H.wear_suit, GLOB.typecache_clothing) && is_type_in_typecache(H.head, GLOB.typecache_clothing))
+	if (H.wear_suit && H.head && istype(H.wear_suit, /obj/item/clothing) && istype(H.head, /obj/item/clothing))
 		var/obj/item/clothing/CS = H.wear_suit
 		var/obj/item/clothing/CH = H.head
 		if (CS.clothing_flags & CH.clothing_flags & STOPSPRESSUREDAMAGE)

--- a/code/modules/mob/living/simple_animal/bot/medbot.dm
+++ b/code/modules/mob/living/simple_animal/bot/medbot.dm
@@ -357,7 +357,7 @@
 
 	if(ishuman(C))
 		var/mob/living/carbon/human/H = C
-		if (H.wear_suit && H.head && is_type_in_typecache(H.wear_suit, GLOB.typecache_clothing) && is_type_in_typecache(H.head, GLOB.typecache_clothing))
+		if (H.wear_suit && H.head && istype(H.wear_suit, /obj/item/clothing) && istype(H.head, /obj/item/clothing))
 			var/obj/item/clothing/CS = H.wear_suit
 			var/obj/item/clothing/CH = H.head
 			if (CS.clothing_flags & CH.clothing_flags & THICKMATERIAL)

--- a/code/modules/surgery/organs/liver.dm
+++ b/code/modules/surgery/organs/liver.dm
@@ -27,10 +27,9 @@
 
 			if(filterToxins && !owner.has_trait(TRAIT_TOXINLOVER))
 				//handle liver toxin filtration
-				var/static/list/toxinstypecache = typecacheof(/datum/reagent/toxin)
 				for(var/I in C.reagents.reagent_list)
 					var/datum/reagent/pickedreagent = I
-					if(is_type_in_typecache(pickedreagent, toxinstypecache))
+					if(istype(pickedreagent, /datum/reagent/toxin))
 						var/thisamount = C.reagents.get_reagent_amount(initial(pickedreagent.id))
 						if (thisamount <= toxTolerance && thisamount)
 							C.reagents.remove_reagent(initial(pickedreagent.id), 1)


### PR DESCRIPTION
one istype() is faster than checking the typecache. The proc call overhead is still more than half the cost of the entire check.

This also has a fairly insignificant but positive effect on memory use.

:cl: Naksu
code: removed some unneeded typecaches
/:cl:
