### PR TITLE
Fixes banhammer grammar

### DIFF
--- a/code/game/objects/items/weaponry.dm
+++ b/code/game/objects/items/weaponry.dm
@@ -20,7 +20,7 @@
 
 /obj/item/banhammer/attack(mob/M, mob/user)
 	if(user.zone_selected == BODY_ZONE_HEAD)
-		M.visible_message("<span class='danger'>[user] are stroking the head of [M] with a bangammer</span>", "<span class='userdanger'>[user] are stroking the head with a bangammer</span>", "you hear a bangammer stroking a head");
+		M.visible_message("<span class='danger'>[user] is stroking the head of [M] with a banhammer</span>", "<span class='userdanger'>[user] is stroking the head with a banhammer</span>", "you hear a bangammer stroking a head");
 	else
 		M.visible_message("<span class='danger'>[M] has been banned FOR NO REISIN by [user]</span>", "<span class='userdanger'>You have been banned FOR NO REISIN by [user]</span>", "you hear a banhammer banning someone")
 	playsound(loc, 'sound/effects/adminhelp.ogg', 15) //keep it at 15% volume so people don't jump out of their skin too much

--- a/code/game/objects/items/weaponry.dm
+++ b/code/game/objects/items/weaponry.dm
@@ -20,7 +20,7 @@
 
 /obj/item/banhammer/attack(mob/M, mob/user)
 	if(user.zone_selected == BODY_ZONE_HEAD)
-		M.visible_message("<span class='danger'>[user] is stroking the head of [M] with a banhammer</span>", "<span class='userdanger'>[user] is stroking the head with a banhammer</span>", "you hear a bangammer stroking a head");
+		M.visible_message("<span class='danger'>[user] is stroking the head of [M] with a banhammer</span>", "<span class='userdanger'>[user] is stroking the head with a banhammer</span>", "you hear a banhammer stroking a head");
 	else
 		M.visible_message("<span class='danger'>[M] has been banned FOR NO REISIN by [user]</span>", "<span class='userdanger'>You have been banned FOR NO REISIN by [user]</span>", "you hear a banhammer banning someone")
 	playsound(loc, 'sound/effects/adminhelp.ogg', 15) //keep it at 15% volume so people don't jump out of their skin too much


### PR DESCRIPTION
[Changelogs]: # Fixed grammar on the banhammer item when used on players heads.
Converts:
"[user] are stroking the head of [M] with a bangammer"
To:
"[user] is stroking the head of [M] with a banhammer"
Fixes and additional "Bangammer" to its correct spelling.

:cl: Mickyy5
spellcheck: Fixed grammar on the banhammer
/:cl:

[why]: # The banhammer item had incorrect grammar and spelling when being targeted on the head.
