### PR TITLE
Fix typo in Python dependencies file

### DIFF
--- a/tools/mapmerge2/requirements.txt
+++ b/tools/mapmerge2/requirements.txt
@@ -1,3 +1,3 @@
 pygit2==0.26.0
 bidict==0.13.1
-Pillow=5.1.0
+Pillow==5.1.0


### PR DESCRIPTION
Messed this up somewhere in copying things from downstream in #37976, noticed when merging back.