### PR TITLE
Optimizes and simplifies glowshroom spreading

### DIFF
--- a/code/game/objects/effects/glowshroom.dm
+++ b/code/game/objects/effects/glowshroom.dm
@@ -64,22 +64,6 @@
 		G = new G
 		myseed.genes += G
 	set_light(G.glow_range(myseed), G.glow_power(myseed), G.glow_color)
-	setDir(CalcDir())
-	var/base_icon_state = initial(icon_state)
-	if(!floor)
-		switch(dir) //offset to make it be on the wall rather than on the floor
-			if(NORTH)
-				pixel_y = 32
-			if(SOUTH)
-				pixel_y = -32
-			if(EAST)
-				pixel_x = 32
-			if(WEST)
-				pixel_x = -32
-		icon_state = "[base_icon_state][rand(1,3)]"
-	else //if on the floor, glowshroom on-floor sprite
-		icon_state = base_icon_state
-
 	addtimer(CALLBACK(src, .proc/Spread), delay)
 
 /obj/structure/glowshroom/proc/Spread()
@@ -87,79 +71,25 @@
 	var/shrooms_planted = 0
 	for(var/i in 1 to myseed.yield)
 		if(prob(1/(generation * generation) * 100))//This formula gives you diminishing returns based on generation. 100% with 1st gen, decreasing to 25%, 11%, 6, 4, 2...
-			var/list/possibleLocs = list()
-			var/spreadsIntoAdjacent = FALSE
-
 			if(prob(spreadIntoAdjacentChance))
-				spreadsIntoAdjacent = TRUE
+				var/list/possibleLocs = list()
+				for(var/turf/T in ownturf.GetAtmosAdjacentTurfs())
+					if(is_type_in_typecache(T, blacklisted_glowshroom_turfs))
+						continue
+					if(!locate(/obj/structure/glowshroom) in T)
+						possibleLocs += earth
+					CHECK_TICK
 
-			for(var/turf/open/floor/earth in view(3,src))
-				if(is_type_in_typecache(earth, blacklisted_glowshroom_turfs))
-					continue
-				if(!ownturf.CanAtmosPass(earth))
-					continue
-				if(spreadsIntoAdjacent || !locate(/obj/structure/glowshroom) in view(1,earth))
-					possibleLocs += earth
-				CHECK_TICK
-
-			if(!possibleLocs.len)
-				break
-
-			var/turf/newLoc = pick(possibleLocs)
-
-			var/shroomCount = 0 //hacky
-			var/placeCount = 1
-			for(var/obj/structure/glowshroom/shroom in newLoc)
-				shroomCount++
-			for(var/wallDir in GLOB.cardinals)
-				var/turf/isWall = get_step(newLoc,wallDir)
-				if(isWall.density)
-					placeCount++
-			if(shroomCount >= placeCount)
-				continue
-
-			var/obj/structure/glowshroom/child = new type(newLoc, myseed, TRUE)
-			child.generation = generation + 1
-			shrooms_planted++
-
-			CHECK_TICK
-		else
-			shrooms_planted++ //if we failed due to generation, don't try to plant one later
+				if(!possibleLocs.len)
+					break
+				var/turf/newLoc = pick(possibleLocs)
+				var/obj/structure/glowshroom/child = new type(newLoc, myseed, TRUE)
+				child.generation = generation + 1
+				shrooms_planted++
+		CHECK_TICK
 	if(shrooms_planted < myseed.yield) //if we didn't get all possible shrooms planted, try again later
 		myseed.yield -= shrooms_planted
 		addtimer(CALLBACK(src, .proc/Spread), delay)
-
-/obj/structure/glowshroom/proc/CalcDir(turf/location = loc)
-	var/direction = 16
-
-	for(var/wallDir in GLOB.cardinals)
-		var/turf/newTurf = get_step(location,wallDir)
-		if(newTurf.density)
-			direction |= wallDir
-
-	for(var/obj/structure/glowshroom/shroom in location)
-		if(shroom == src)
-			continue
-		if(shroom.floor) //special
-			direction &= ~16
-		else
-			direction &= ~shroom.dir
-
-	var/list/dirList = list()
-
-	for(var/i=1,i<=16,i <<= 1)
-		if(direction & i)
-			dirList += i
-
-	if(dirList.len)
-		var/newDir = pick(dirList)
-		if(newDir == 16)
-			floor = 1
-			newDir = 1
-		return newDir
-
-	floor = 1
-	return 1
 
 /obj/structure/glowshroom/play_attack_sound(damage_amount, damage_type = BRUTE, damage_flag = 0)
 	if(damage_type == BURN && damage_amount)


### PR DESCRIPTION
holy shit this was needlessly complex
:cl: Iamgoofball
tweak: Glowshrooms no longer grow onto walls, but should grow faster and properly spread to all nearby open turfs.
del: Removes fancy directional icon work for glowshrooms, they were near impossible to actually notice and only added to overhead.
/:cl: