### PR TITLE
Fix nullspace error room not working correctly

### DIFF
--- a/code/modules/awaymissions/signpost.dm
+++ b/code/modules/awaymissions/signpost.dm
@@ -7,33 +7,55 @@
 	var/question = "Travel back?"
 	var/list/zlevels
 
-/obj/structure/signpost/New()
+/obj/structure/signpost/Initialize()
 	. = ..()
 	set_light(2)
 	zlevels = SSmapping.levels_by_trait(ZTRAIT_STATION)
 
-/obj/structure/signpost/attackby(obj/item/W, mob/user, params)
-	return attack_hand(user)
-
-/obj/structure/signpost/attack_hand(mob/user)
+/obj/structure/signpost/interact(mob/user)
 	. = ..()
 	if(.)
 		return
-	switch(alert(question,name,"Yes","No"))
-		if("Yes")
-			var/turf/T = find_safe_turf(zlevels=zlevels)
+	if(alert(question,name,"Yes","No") == "Yes" && Adjacent(user))
+		var/turf/T = find_safe_turf(zlevels=zlevels)
 
-			if(T)
-				user.forceMove(T)
-				to_chat(user, "<span class='notice'>You blink and find yourself in [get_area_name(T)].</span>")
-			else
-				to_chat(user, "Nothing happens. You feel that this is a bad sign.")
-		if("No")
-			return
+		if(T)
+			var/atom/movable/AM = user.pulling
+			if(AM)
+				AM.forceMove(T)
+			user.forceMove(T)
+			if(AM)
+				user.start_pulling(AM)
+			to_chat(user, "<span class='notice'>You blink and find yourself in [get_area_name(T)].</span>")
+		else
+			to_chat(user, "Nothing happens. You feel that this is a bad sign.")
+
+/obj/structure/signpost/attackby(obj/item/W, mob/user, params)
+	return interact(user)
+
+/obj/structure/signpost/attack_paw(mob/user)
+	return interact(user)
+
+/obj/structure/signpost/attack_hulk(mob/user, does_attack_animation = 0)
+	return interact(user)
+
+/obj/structure/signpost/attack_larva(mob/user)
+	return interact(user)
+
+/obj/structure/signpost/attack_robot(mob/user)
+	if (Adjacent(user))
+		return interact(user)
+
+/obj/structure/signpost/attack_slime(mob/user)
+	return interact(user)
+
+/obj/structure/signpost/attack_animal(mob/user)
+	return interact(user)
 
 /obj/structure/signpost/salvation
 	name = "\proper salvation"
 	desc = "In the darkest times, we will find our way home."
+	resistance_flags = INDESTRUCTIBLE
 
 /obj/structure/signpost/exit
 	name = "exit"
@@ -41,7 +63,7 @@
 		exit the area."
 	question = "Leave? You might never come back."
 
-/obj/structure/signpost/exit/New()
+/obj/structure/signpost/exit/Initialize()
 	. = ..()
 	zlevels = list()
 	for(var/i in 1 to world.maxz)

--- a/code/modules/awaymissions/super_secret_room.dm
+++ b/code/modules/awaymissions/super_secret_room.dm
@@ -5,6 +5,7 @@
 	icon = 'icons/obj/structures.dmi'
 	icon_state = "speaking_tile"
 	layer = 5
+	resistance_flags = INDESTRUCTIBLE
 	var/speaking = FALSE
 	var/times_spoken_to = 0
 	var/list/shenanigans = list()
@@ -87,6 +88,27 @@
 			y += 2
 	speaking = FALSE
 	times_spoken_to++
+
+/obj/structure/speaking_tile/attackby(obj/item/W, mob/user, params)
+	return interact(user)
+
+/obj/structure/speaking_tile/attack_paw(mob/user)
+	return interact(user)
+
+/obj/structure/speaking_tile/attack_hulk(mob/user, does_attack_animation = 0)
+	return interact(user)
+
+/obj/structure/speaking_tile/attack_larva(mob/user)
+	return interact(user)
+
+/obj/structure/speaking_tile/attack_ai(mob/user)
+	return interact(user)
+
+/obj/structure/speaking_tile/attack_slime(mob/user)
+	return interact(user)
+
+/obj/structure/speaking_tile/attack_animal(mob/user)
+	return interact(user)
 
 /obj/structure/speaking_tile/proc/SpeakPeace(list/statements)
 	for(var/i in 1 to statements.len)

--- a/code/modules/mob/living/life.dm
+++ b/code/modules/mob/living/life.dm
@@ -7,31 +7,32 @@
 	if((movement_type & FLYING) && !floating)	//TODO: Better floating
 		float(on = TRUE)
 
-	if (client || registered_z) // This is a temporary error tracker to make sure we've caught everything
+	if (client)
 		var/turf/T = get_turf(src)
-		if (client && registered_z != T.z)
+		if(!T)
+			for(var/obj/effect/landmark/error/E in GLOB.landmarks_list)
+				forceMove(E.loc)
+				break
+			var/msg = "[key_name_admin(src)] [ADMIN_JMP(src)] was found to have no .loc with an attached client, if the cause is unknown it would be wise to ask how this was accomplished."
+			message_admins(msg)
+			send2irc_adminless_only("Mob", msg, R_ADMIN)
+			log_game("[key_name(src)] was found to have no .loc with an attached client.")
+
+		// This is a temporary error tracker to make sure we've caught everything
+		else if (registered_z != T.z)
 #ifdef TESTING
 			message_admins("[src] [ADMIN_FLW(src)] has somehow ended up in Z-level [T.z] despite being registered in Z-level [registered_z]. If you could ask them how that happened and notify coderbus, it would be appreciated.")
 #endif
 			log_game("Z-TRACKING: [src] has somehow ended up in Z-level [T.z] despite being registered in Z-level [registered_z].")
 			update_z(T.z)
-		else if (!client && registered_z)
-			log_game("Z-TRACKING: [src] of type [src.type] has a Z-registration despite not having a client.")
-			update_z(null)
+	else if (registered_z)
+		log_game("Z-TRACKING: [src] of type [src.type] has a Z-registration despite not having a client.")
+		update_z(null)
 
 	if (notransform)
 		return
 	if(!loc)
-		if(client)
-			for(var/obj/effect/landmark/error/E in GLOB.landmarks_list)
-				forceMove(E.loc)
-				break
-			var/msg = "[key_name_admin(src)] was found to have no .loc with an attached client, if the cause is unknown it would be wise to ask how this was accomplished."
-			message_admins(msg)
-			send2irc_adminless_only("Mob", msg, R_ADMIN)
-			log_game("[key_name(src)] was found to have no .loc with an attached client.")
-		else
-			return
+		return
 	var/datum/gas_mixture/environment = loc.return_air()
 
 	if(stat != DEAD)


### PR DESCRIPTION
:cl:
fix: The robustness of the Super Secret Room has been increased.
/:cl:

* Fixes logic ordering in Life so the room actually activates rather than runtiming
* Fixes signposts not getting their z-level lists due to still using New
* Allows silicons and animals to activate the talking tile and ladder
* Marks the two objects indestructible
* Allows pulling things through signposts
* Fixes clicking signposts multiple times for multiple teleports

Inspired by #38057.