### PR TITLE
EMPs no longer pulse internal silicon wires

### DIFF
--- a/code/modules/mob/living/silicon/robot/robot.dm
+++ b/code/modules/mob/living/silicon/robot/robot.dm
@@ -105,6 +105,7 @@
 	spark_system.attach(src)
 
 	wires = new /datum/wires/robot(src)
+	AddComponent(/datum/component/empprotection, EMP_PROTECT_WIRES)
 
 	robot_modules_background = new()
 	robot_modules_background.icon_state = "block"


### PR DESCRIPTION
This restores silicon EMP weakness to normal, before https://github.com/tgstation/tgstation/pull/22676 pr was merged.

Why: It's unfun for one EMP to permanently shut down a cyborg by pulsing the lockdown wire or forcefully sync cyborgs to AIs without someone actually gaining access to its wire panels. For those without code knowledge, EMPs will still stun cyborgs and drain their battery, short out their flash, etc etc.