### PR TITLE
[s] Blacklists TB grenade from experimentor.

### DIFF
--- a/code/modules/research/experimentor.dm
+++ b/code/modules/research/experimentor.dm
@@ -53,6 +53,8 @@
 		if(ispath(I, /obj/item/stock_parts) || ispath(I, /obj/item/grenade/chem_grenade) || ispath(I, /obj/item/kitchen))
 			var/obj/item/tempCheck = I
 			if(initial(tempCheck.icon_state) != null) //check it's an actual usable item, in a hacky way
+				if(istype(I, /obj/item/grenade/chem_grenade/tuberculosis))
+					continue
 				valid_items["[I]"] += 15
 
 		if(ispath(I, /obj/item/reagent_containers/food))


### PR DESCRIPTION
[Changelogs]: # (Your PR should contain a detailed changelog of notable changes, titled and categorized appropriately. This includes, new features, sprites, sounds, balance changes, admin tools, map edits, removals, big refactors, config changes, hosting changes and important fixes. An example changelog has been provided below for you to edit. If you need additional help, read https://github.com/tgstation/tgstation/wiki/Changelogs)

:cl: Dax Dupont
fix: Experimentor no longer shits out primed TB nades.
/:cl:

[why]: Oh my fucking god it occasionally ejects TB grenades and infects the entire station. This is pretty bad.