### PR TITLE
[s] Fix observers being able to manipulate their target's screens

### DIFF
--- a/code/_onclick/hud/action_button.dm
+++ b/code/_onclick/hud/action_button.dm
@@ -11,7 +11,24 @@
 	var/id
 	var/ordered = TRUE //If the button gets placed into the default bar
 
+/obj/screen/movable/action_button/proc/can_use(mob/user)
+	if (linked_action)
+		return linked_action.owner == user
+	else if (isobserver(user))
+		var/mob/dead/observer/O = user
+		return !O.observetarget
+	else
+		return TRUE
+
+/obj/screen/movable/action_button/MouseDrop()
+	if (!can_use(usr))
+		return
+	return ..()
+
 /obj/screen/movable/action_button/Click(location,control,params)
+	if (!can_use(usr))
+		return
+
 	var/list/modifiers = params2list(params)
 	if(modifiers["shift"])
 		if(locked)
@@ -44,6 +61,9 @@
 	var/show_state = "show"
 
 /obj/screen/movable/action_button/hide_toggle/Click(location,control,params)
+	if (!can_use(usr))
+		return
+
 	var/list/modifiers = params2list(params)
 	if(modifiers["shift"])
 		if(locked)

--- a/code/_onclick/hud/ghost.dm
+++ b/code/_onclick/hud/ghost.dm
@@ -73,6 +73,12 @@
 	static_inventory += using
 
 /datum/hud/ghost/show_hud(version = 0, mob/viewmob)
+	// don't show this HUD if observing; show the HUD of the observee
+	var/mob/dead/observer/O = mymob
+	if (istype(O) && O.observetarget)
+		plane_masters_update()
+		return FALSE
+
 	. = ..()
 	if(!.)
 		return


### PR DESCRIPTION
:cl:
fix: Observers can no longer move the action button toggle or change the ambient occlusion setting of their targets.
/:cl:

Fixes #34816.