### PR TITLE
Fix the destructive analyzer not revealing nodes

### DIFF
--- a/code/__DEFINES/research.dm
+++ b/code/__DEFINES/research.dm
@@ -29,7 +29,7 @@
 
 #define RDSCREEN_TEXT_NO_PROTOLATHE "<div><h3>No Protolathe Linked!</h3></div><br>"
 #define RDSCREEN_TEXT_NO_IMPRINTER "<div><h3>No Circuit Imprinter Linked!</h3></div><br>"
-#define RDSCREEN_TEXT_NO_DECONSTRUCT "<div><h3>No Deconstructive Analyzer Linked!</h3></div><br>"
+#define RDSCREEN_TEXT_NO_DECONSTRUCT "<div><h3>No Destructive Analyzer Linked!</h3></div><br>"
 #define RDSCREEN_TEXT_NO_TDISK "<div><h3>No Technology Disk Inserted!</h3></div><br>"
 #define RDSCREEN_TEXT_NO_DDISK "<div><h3>No Design Disk Inserted!</h3></div><br>"
 #define RDSCREEN_TEXT_NO_SNODE "<div><h3>No Technology Node Selected!</h3></div><br>"

--- a/code/modules/research/destructive_analyzer.dm
+++ b/code/modules/research/destructive_analyzer.dm
@@ -102,9 +102,6 @@ Note: Must be placed within 3 tiles of the R&D Console
 		var/datum/techweb_node/TN = get_techweb_node_by_id(id)
 		if(!istype(TN))
 			return FALSE
-		var/list/can_boost = techweb_item_boost_check(loaded_item)
-		if(isnull(can_boost[id]))
-			return FALSE
 		var/dpath = loaded_item.type
 		var/list/worths = TN.boost_item_paths[dpath]
 		var/list/differences = list()
@@ -114,7 +111,7 @@ Note: Must be placed within 3 tiles of the R&D Console
 			var/value = min(worths[i], TN.research_costs[i]) - used
 			if(value > 0)
 				differences[i] = value
-		if(!length(differences))
+		if(length(worths) && !length(differences))
 			return FALSE
 		var/choice = input("Are you sure you want to destroy [loaded_item] to [!length(worths) ? "reveal [TN.display_name]" : "boost [TN.display_name] by [json_encode(differences)] point\s"]?") in list("Proceed", "Cancel")
 		if(choice == "Cancel")

--- a/code/modules/research/experimentor.dm
+++ b/code/modules/research/experimentor.dm
@@ -19,7 +19,7 @@
 #define FAIL 8
 /obj/machinery/rnd/experimentor
 	name = "\improper E.X.P.E.R.I-MENTOR"
-	desc = "A \"replacement\" for the deconstructive analyzer with a slight tendency to catastrophically fail."
+	desc = "A \"replacement\" for the destructive analyzer with a slight tendency to catastrophically fail."
 	icon = 'icons/obj/machines/heavy_lathe.dmi'
 	icon_state = "h_lathe"
 	density = TRUE

--- a/code/modules/research/rdconsole.dm
+++ b/code/modules/research/rdconsole.dm
@@ -861,7 +861,7 @@ Nothing else in the console has ID requirements.
 		switch(ls["disconnect"])
 			if("destroy")
 				if(QDELETED(linked_destroy))
-					say("No Deconstructive Analyzer Linked!")
+					say("No Destructive Analyzer Linked!")
 					return
 				linked_destroy.linked_console = null
 				linked_destroy = null
@@ -887,7 +887,7 @@ Nothing else in the console has ID requirements.
 		say("Ejecting Technology Disk")
 	if(ls["deconstruct"])
 		if(QDELETED(linked_destroy))
-			say("No Deconstructive Analyzer Linked!")
+			say("No Destructive Analyzer Linked!")
 			return
 		if(!linked_destroy.user_try_decon_id(ls["deconstruct"], usr))
 			say("Destructive analysis failed!")
@@ -996,7 +996,7 @@ Nothing else in the console has ID requirements.
 		screen = RDSCREEN_DESIGNDISK
 	if(ls["eject_item"]) //Eject the item inside the destructive analyzer.
 		if(QDELETED(linked_destroy))
-			say("No Deconstructive Analyzer Linked!")
+			say("No Destructive Analyzer Linked!")
 			return
 		if(linked_destroy.busy)
 			to_chat(usr, "<span class='danger'>The destructive analyzer is busy at the moment.</span>")

--- a/code/modules/research/rdconsole.dm
+++ b/code/modules/research/rdconsole.dm
@@ -889,7 +889,8 @@ Nothing else in the console has ID requirements.
 		if(QDELETED(linked_destroy))
 			say("No Deconstructive Analyzer Linked!")
 			return
-		linked_destroy.user_try_decon_id(ls["deconstruct"], usr)
+		if(!linked_destroy.user_try_decon_id(ls["deconstruct"], usr))
+			say("Destructive analysis failed!")
 	//Protolathe Materials
 	if(ls["disposeP"])  //Causes the protolathe to dispose of a single reagent (all of it)
 		if(QDELETED(linked_lathe))

--- a/code/modules/research/techweb/__techweb_helpers.dm
+++ b/code/modules/research/techweb/__techweb_helpers.dm
@@ -72,43 +72,44 @@
 		SSresearch.invalid_design_ids[id] = 1
 
 /proc/node_boost_error(id, message)
+	WARNING("Invalid boost information for node \[[id]\]: [message]")
 	SSresearch.invalid_node_boost[id] = message
 
 /proc/verify_techweb_nodes()
 	for(var/n in SSresearch.techweb_nodes)
 		var/datum/techweb_node/N = SSresearch.techweb_nodes[n]
 		if(!istype(N))
-			stack_trace("WARNING: Invalid research node with ID [n] detected and removed.")
+			WARNING("Invalid research node with ID [n] detected and removed.")
 			SSresearch.techweb_nodes -= n
 			research_node_id_error(n)
 		for(var/p in N.prereq_ids)
 			var/datum/techweb_node/P = SSresearch.techweb_nodes[p]
 			if(!istype(P))
-				stack_trace("WARNING: Invalid research prerequisite node with ID [p] detected in node [N.display_name]\[[N.id]\] removed.")
+				WARNING("Invalid research prerequisite node with ID [p] detected in node [N.display_name]\[[N.id]\] removed.")
 				N.prereq_ids  -= p
 				research_node_id_error(p)
 		for(var/d in N.design_ids)
 			var/datum/design/D = SSresearch.techweb_designs[d]
 			if(!istype(D))
-				stack_trace("WARNING: Invalid research design with ID [d] detected in node [N.display_name]\[[N.id]\] removed.")
+				WARNING("Invalid research design with ID [d] detected in node [N.display_name]\[[N.id]\] removed.")
 				N.designs -= d
 				design_id_error(d)
 		for(var/p in N.prerequisites)
 			var/datum/techweb_node/P = N.prerequisites[p]
 			if(!istype(P))
-				stack_trace("WARNING: Invalid research prerequisite node with ID [p] detected in node [N.display_name]\[[N.id]\] removed.")
+				WARNING("Invalid research prerequisite node with ID [p] detected in node [N.display_name]\[[N.id]\] removed.")
 				N.prerequisites -= p
 				research_node_id_error(p)
 		for(var/u in N.unlocks)
 			var/datum/techweb_node/U = N.unlocks[u]
 			if(!istype(U))
-				stack_trace("WARNING: Invalid research unlock node with ID [u] detected in node [N.display_name]\[[N.id]\] removed.")
+				WARNING("Invalid research unlock node with ID [u] detected in node [N.display_name]\[[N.id]\] removed.")
 				N.unlocks -= u
 				research_node_id_error(u)
 		for(var/d in N.designs)
 			var/datum/design/D = N.designs[d]
 			if(!istype(D))
-				stack_trace("WARNING: Invalid research design with ID [d] detected in node [N.display_name]\[[N.id]\] removed.")
+				WARNING("Invalid research design with ID [d] detected in node [N.display_name]\[[N.id]\] removed.")
 				N.designs -= d
 				design_id_error(d)
 		for(var/p in N.boost_item_paths)
@@ -116,15 +117,15 @@
 				N.boost_item_paths -= p
 				node_boost_error(N.id, "[p] is not a valid path.")
 			var/list/points = N.boost_item_paths[p]
-			if(!islist(points))
-				N.boost_item_paths -= p
-				node_boost_error(N.id, "No valid list.")
-			else
+			if(islist(points))
 				for(var/i in points)
 					if(!isnum(points[i]))
 						node_boost_error(N.id, "[points[i]] is not a valid number.")
 					else if(!SSresearch.point_types[i])
 						node_boost_error(N.id, "[i] is not a valid point type.")
+			else if(!isnull(points))
+				N.boost_item_paths -= p
+				node_boost_error(N.id, "No valid list.")
 		CHECK_TICK
 
 /proc/verify_techweb_designs()


### PR DESCRIPTION
:cl:
fix: The destructive analyzer can once again be used to reveal nodes.
spellcheck: Some references to "deconstructive analyzer" have been updated to "destructive".
/:cl:

Fixes #38051.