### PR TITLE
Fix the escape pod safes always being unlocked

### DIFF
--- a/code/modules/shuttle/emergency.dm
+++ b/code/modules/shuttle/emergency.dm
@@ -536,13 +536,24 @@
 	new /obj/item/storage/toolbox/emergency(src)
 
 /obj/item/storage/pod/attackby(obj/item/W, mob/user, params)
-	return
+	if (can_interact(user))
+		return ..()
+
+/obj/item/storage/pod/attack_hand(mob/user)
+	if (can_interact(user))
+		SendSignal(COMSIG_TRY_STORAGE_SHOW, user)
+	return TRUE
 
 /obj/item/storage/pod/MouseDrop(over_object, src_location, over_location)
+	if(can_interact(usr))
+		return ..()
+
+/obj/item/storage/pod/can_interact(mob/user)
+	if(!..())
+		return FALSE
 	if(GLOB.security_level == SEC_LEVEL_RED || GLOB.security_level == SEC_LEVEL_DELTA || unlocked)
-		. = ..()
-	else
-		to_chat(usr, "The storage unit will only unlock during a Red or Delta security alert.")
+		return TRUE
+	to_chat(user, "The storage unit will only unlock during a Red or Delta security alert.")
 
 /obj/docking_port/mobile/emergency/backup
 	name = "backup shuttle"

--- a/code/modules/shuttle/on_move.dm
+++ b/code/modules/shuttle/on_move.dm
@@ -270,8 +270,11 @@ All ShuttleMove procs go here
 
 /obj/item/storage/pod/afterShuttleMove(turf/oldT, list/movement_force, shuttle_dir, shuttle_preferred_direction, move_dir, rotation)
 	. = ..()
-	unlocked = TRUE
-	// If the pod was launched, the storage will always open.
+	// If the pod was launched, the storage will always open. The CentCom check
+	// ignores the movement of the shuttle from the staging area on CentCom to
+	// the station as it is loaded in.
+	if (oldT && !is_centcom_level(oldT.z))
+		unlocked = TRUE
 
 /************************************Mob move procs************************************/
 


### PR DESCRIPTION
:cl:
fix: The emergency space suit safes in escape pods are no longer always unlocked.
/:cl:

Fixes #37996. Also makes the interaction on them a little more natural.