### PR TITLE
[s] Fixes TB nades for real now

### DIFF
--- a/code/modules/research/experimentor.dm
+++ b/code/modules/research/experimentor.dm
@@ -45,7 +45,7 @@
 
 /obj/machinery/rnd/experimentor/proc/SetTypeReactions()
 	for(var/I in typesof(/obj/item))
-		if(istype(I, /obj/item/relic))
+		if(ispath(I, /obj/item/relic))
 			item_reactions["[I]"] = SCANTYPE_DISCOVER
 		else
 			item_reactions["[I]"] = pick(SCANTYPE_POKE,SCANTYPE_IRRADIATE,SCANTYPE_GAS,SCANTYPE_HEAT,SCANTYPE_COLD,SCANTYPE_OBLITERATE)
@@ -53,7 +53,7 @@
 		if(ispath(I, /obj/item/stock_parts) || ispath(I, /obj/item/grenade/chem_grenade) || ispath(I, /obj/item/kitchen))
 			var/obj/item/tempCheck = I
 			if(initial(tempCheck.icon_state) != null) //check it's an actual usable item, in a hacky way
-				if(istype(I, /obj/item/grenade/chem_grenade/tuberculosis))
+				if(ispath(I, /obj/item/grenade/chem_grenade/tuberculosis))
 					continue
 				valid_items["[I]"] += 15
 


### PR DESCRIPTION
[Changelogs]: # (Your PR should contain a detailed changelog of notable changes, titled and categorized appropriately. This includes, new features, sprites, sounds, balance changes, admin tools, map edits, removals, big refactors, config changes, hosting changes and important fixes. An example changelog has been provided below for you to edit. If you need additional help, read https://github.com/tgstation/tgstation/wiki/Changelogs)

:cl: Dax Dupont
fix: Did you know istype doesn't work on paths even though they are mostly the same? Yeah I didn't either. Experimentor shouldn't shit out TB nades anymore.
fix: Fixes item reactions for relics as well.
/:cl:

[why]: Fixes the TB exploit/game breaking bug for real now. I assumed istype would work there since other things use istype in the same thing. So that shit has been broken forever as well.