### PR TITLE
Adds module upgrades for the Janiborg.

### DIFF
--- a/code/game/objects/items/mop.dm
+++ b/code/game/objects/items/mop.dm
@@ -17,6 +17,7 @@
 	var/mopcap = 5
 	var/mopspeed = 30
 	force_string = "robust... against germs"
+	var/insertable = TRUE
 
 /obj/item/mop/New()
 	..()
@@ -62,14 +63,16 @@
 
 
 /obj/item/mop/proc/janicart_insert(mob/user, obj/structure/janitorialcart/J)
-	J.put_in_cart(src, user)
-	J.mymop=src
-	J.update_icon()
+	if(insertable)
+		J.put_in_cart(src, user)
+		J.mymop=src
+		J.update_icon()
+	else
+		to_chat(user, "<span class='warning'>You are unable to fit your [name] into the [J.name].</span>")
+		return
 
 /obj/item/mop/cyborg
-
-/obj/item/mop/cyborg/janicart_insert(mob/user, obj/structure/janitorialcart/J)
-	return
+	insertable = FALSE
 
 /obj/item/mop/advanced
 	desc = "The most advanced tool in a custodian's arsenal, complete with a condenser for self-wetting! Just think of all the viscera you will clean up with this!"
@@ -113,3 +116,6 @@
 	if(refill_enabled)
 		STOP_PROCESSING(SSobj, src)
 	return ..()
+
+/obj/item/mop/advanced/cyborg
+	insertable = FALSE

--- a/code/game/objects/items/robot/robot_upgrades.dm
+++ b/code/game/objects/items/robot/robot_upgrades.dm
@@ -193,6 +193,60 @@
 		R.module.basic_modules += S
 		R.module.add_module(S, FALSE, TRUE)
 
+/obj/item/borg/upgrade/tboh
+	name = "janitor cyborg trash bag of holding"
+	desc = "A trash bag of holding replace for the janiborgs standard trash bag."
+	icon_state = "cyborg_upgrade3"
+	require_module = 1
+	module_type = /obj/item/robot_module/janitor
+
+/obj/item/borg/upgrade/tboh/action(mob/living/silicon/robot/R)
+	. = ..()
+	if(.)
+		for(var/obj/item/storage/bag/trash/cyborg/TB in R.module)
+			R.module.remove_module(TB, TRUE)
+
+		var/obj/item/storage/bag/trash/bluespace/B = new /obj/item/storage/bag/trash/bluespace(R.module)
+		R.module.basic_modules += B
+		R.module.add_module(B, FALSE, TRUE)
+
+/obj/item/borg/upgrade/tboh/deactivate(mob/living/silicon/robot/R, user = usr)
+	. = ..()
+	if(.)
+		for(var/obj/item/storage/bag/trash/bluespace/B in R.module)
+			R.module.remove_module(B, TRUE)
+
+		var/obj/item/storage/bag/trash/cyborg/TB = new (R.module)
+		R.module.basic_modules += TB
+		R.module.add_module(TB, FALSE, TRUE)
+
+/obj/item/borg/upgrade/amop
+	name = "janitor cyborg advanced mop"
+	desc = "An advanced mop replacement from the janiborgs standard mop."
+	icon_state = "cyborg_upgrade3"
+	require_module = 1
+	module_type = /obj/item/robot_module/janitor
+
+/obj/item/borg/upgrade/amop/action(mob/living/silicon/robot/R)
+	. = ..()
+	if(.)
+		for(var/obj/item/mop/cyborg/M in R.module)
+			R.module.remove_module(M, TRUE)
+
+	var/obj/item/mop/advanced/A = new /obj/item/mop/advanced(R.module)
+	R.module.basic_modules += A
+	R.module.add_module(A, FALSE, TRUE)
+
+/obj/item/borg/upgrade/amop/deactivate(mob/living/silicon/robot/R, user = usr)
+	. = ..()
+	if(.)
+		for(var/obj/item/mop/advanced/A in R.module)
+			R.module.remove_module(A, TRUE)
+
+		var/obj/item/mop/cyborg/M = new (R.module)
+		R.module.basic_modules += M
+		R.module.add_module(M, FALSE, TRUE)
+
 /obj/item/borg/upgrade/syndicate
 	name = "illegal equipment module"
 	desc = "Unlocks the hidden, deadlier functions of a cyborg."

--- a/code/game/objects/items/robot/robot_upgrades.dm
+++ b/code/game/objects/items/robot/robot_upgrades.dm
@@ -203,17 +203,17 @@
 /obj/item/borg/upgrade/tboh/action(mob/living/silicon/robot/R)
 	. = ..()
 	if(.)
-		for(var/obj/item/storage/bag/trash/cyborg/TB in R.module)
+		for(var/obj/item/storage/bag/trash/cyborg/TB in R.module.modules)
 			R.module.remove_module(TB, TRUE)
 
-		var/obj/item/storage/bag/trash/bluespace/B = new /obj/item/storage/bag/trash/bluespace(R.module)
+		var/obj/item/storage/bag/trash/bluespace/cyborg/B = new /obj/item/storage/bag/trash/bluespace/cyborg(R.module)
 		R.module.basic_modules += B
 		R.module.add_module(B, FALSE, TRUE)
 
 /obj/item/borg/upgrade/tboh/deactivate(mob/living/silicon/robot/R, user = usr)
 	. = ..()
 	if(.)
-		for(var/obj/item/storage/bag/trash/bluespace/B in R.module)
+		for(var/obj/item/storage/bag/trash/bluespace/cyborg/B in R.module.modules)
 			R.module.remove_module(B, TRUE)
 
 		var/obj/item/storage/bag/trash/cyborg/TB = new (R.module)
@@ -230,17 +230,17 @@
 /obj/item/borg/upgrade/amop/action(mob/living/silicon/robot/R)
 	. = ..()
 	if(.)
-		for(var/obj/item/mop/cyborg/M in R.module)
+		for(var/obj/item/mop/cyborg/M in R.module.modules)
 			R.module.remove_module(M, TRUE)
 
-	var/obj/item/mop/advanced/A = new /obj/item/mop/advanced(R.module)
+	var/obj/item/mop/advanced/cyborg/A = new /obj/item/mop/advanced/cyborg(R.module)
 	R.module.basic_modules += A
 	R.module.add_module(A, FALSE, TRUE)
 
 /obj/item/borg/upgrade/amop/deactivate(mob/living/silicon/robot/R, user = usr)
 	. = ..()
 	if(.)
-		for(var/obj/item/mop/advanced/A in R.module)
+		for(var/obj/item/mop/advanced/cyborg/A in R.module.modules)
 			R.module.remove_module(A, TRUE)
 
 		var/obj/item/mop/cyborg/M = new (R.module)

--- a/code/game/objects/items/storage/bags.dm
+++ b/code/game/objects/items/storage/bags.dm
@@ -40,6 +40,7 @@
 	righthand_file = 'icons/mob/inhands/equipment/custodial_righthand.dmi'
 
 	w_class = WEIGHT_CLASS_BULKY
+	var/insertable = TRUE
 
 /obj/item/storage/bag/trash/ComponentInitialize()
 	. = ..()
@@ -64,14 +65,16 @@
 	else icon_state = "[initial(icon_state)]3"
 
 /obj/item/storage/bag/trash/cyborg
+	insertable = FALSE
 
 /obj/item/storage/bag/trash/proc/janicart_insert(mob/user, obj/structure/janitorialcart/J)
-	J.put_in_cart(src, user)
-	J.mybag=src
-	J.update_icon()
-
-/obj/item/storage/bag/trash/cyborg/janicart_insert(mob/user, obj/structure/janitorialcart/J)
-	return
+	if(insertable)
+		J.put_in_cart(src, user)
+		J.mybag=src
+		J.update_icon()
+	else
+		to_chat(user, "<span class='warning'>You are unable to fit your [name] into the [J.name].</span>")
+		return
 
 /obj/item/storage/bag/trash/bluespace
 	name = "trash bag of holding"
@@ -84,6 +87,9 @@
 	GET_COMPONENT(STR, /datum/component/storage)
 	STR.max_combined_w_class = 60
 	STR.max_items = 60
+
+/obj/item/storage/bag/trash/bluespace/cyborg
+	insertable = FALSE
 
 // -----------------------------
 //        Mining Satchel

--- a/code/modules/research/designs/mechfabricator_designs.dm
+++ b/code/modules/research/designs/mechfabricator_designs.dm
@@ -696,6 +696,24 @@
 	construction_time = 120
 	category = list("Cyborg Upgrade Modules")
 
+/datum/design/borg_upgrade_trashofholding
+	name = "Cyborg Upgrade (Trash Bag of Holding)"
+	id = "borg_upgrade_trashofholding"
+	build_type = MECHFAB
+	build_path = /obj/item/borg/upgrade/tboh
+	materials = list(MAT_METAL=10000, MAT_GOLD=1500, MAT_URANIUM=250, MAT_PLASMA=1500)
+	construction_time = 120
+	category = list("Cyborg Upgrade Modules")
+
+/datum/design/borg_upgrade_advancedmop
+	name = "Cyborg Upgrade (Advanced Mop)"
+	id = "borg_upgrade_advancedmop"
+	build_type = MECHFAB
+	build_path = /obj/item/borg/upgrade/amop
+	materials = list(MAT_METAL=10000, MAT_GLASS=200, MAT_TITANIUM=1000)
+	construction_time = 120
+	category = list("Cyborg Upgrade Modules")
+
 /datum/design/borg_upgrade_expand
 	name = "Cyborg Upgrade (Expand)"
 	id = "borg_upgrade_expand"

--- a/code/modules/research/techweb/all_nodes.dm
+++ b/code/modules/research/techweb/all_nodes.dm
@@ -274,6 +274,15 @@
 	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = 5000)
 	export_price = 5000
 
+/datum/techweb_node/cyborg_upg_janitor
+	id = "cyborg_upg_janitor"
+	display_name = "Cyborg Upgrades: Janitorial"
+	description = "Janitorial upgrades for cyborgs."
+	prereq_ids = list("cyborg", "janitor")
+	design_ids = list("borg_upgrade_trashofholding", "borg_upgrade_advancedmop")
+	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = 2000)
+	export_price = 5000
+
 /datum/techweb_node/ai
 	id = "ai"
 	display_name = "Artificial Intelligence"

--- a/code/modules/research/techweb/all_nodes.dm
+++ b/code/modules/research/techweb/all_nodes.dm
@@ -207,7 +207,7 @@
 	display_name = "Advanced Robotics Research"
 	description = "It can even do the dishes!"
 	prereq_ids = list("robotics")
-	design_ids = list("borg_upgrade_diamonddrill")
+	design_ids = list("borg_upgrade_diamonddrill", "borg_upgrade_trashofholding", "borg_upgrade_advancedmop")
 	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = 2500)
 	export_price = 5000
 
@@ -272,15 +272,6 @@
 	prereq_ids = list("adv_robotics", "adv_engi" , "weaponry")
 	design_ids = list("borg_upgrade_vtec", "borg_upgrade_disablercooler")
 	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = 5000)
-	export_price = 5000
-
-/datum/techweb_node/cyborg_upg_janitor
-	id = "cyborg_upg_janitor"
-	display_name = "Cyborg Upgrades: Janitorial"
-	description = "Janitorial upgrades for cyborgs."
-	prereq_ids = list("cyborg", "janitor")
-	design_ids = list("borg_upgrade_trashofholding", "borg_upgrade_advancedmop")
-	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = 2000)
 	export_price = 5000
 
 /datum/techweb_node/ai


### PR DESCRIPTION
This PR adds two new upgrades for the Janiborg. Well, technically adds their first upgrades since they didn't have any module specific ones. These are the Advanced Mop and the Trash Bag of Holding.

:cl: Firecage
add: The mech fabricator can now print two new janiborg upgrades. Advanced Mop and Trash Bag of holding. These two upgrades uses the advanced robotics node.
/:cl:
