### PR TITLE
Fixes "humans_need_surnames" config option applying to all races

### DIFF
--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -1520,7 +1520,7 @@ GLOBAL_LIST_EMPTY(preferences_datums)
 	if(be_random_body)
 		random_character(gender)
 
-	if(CONFIG_GET(flag/humans_need_surnames))
+	if(CONFIG_GET(flag/humans_need_surnames) && (pref_species.id == "human"))
 		var/firstspace = findtext(real_name, " ")
 		var/name_length = length(real_name)
 		if(!firstspace)	//we need a surname


### PR DESCRIPTION
"humans_need_surnames" shouldn't apply to non-humans.
:cl:
fix: added a check to see if the preferred race is human when the name doesn't have a space
/:cl:

[why]: fixes #38117 
