### PR TITLE
Fixes a bug where mirage_holders could be pulled

### DIFF
--- a/code/datums/components/mirage_border.dm
+++ b/code/datums/components/mirage_border.dm
@@ -38,3 +38,6 @@
 /obj/effect/abstract/mirage_holder
 	name = "Mirage holder"
 	mouse_opacity = MOUSE_OPACITY_TRANSPARENT
+	
+/obj/effect/abstract/mirage_holder/can_be_pulled(user)
+	return FALSE

--- a/code/game/objects/effects/effect_system/effect_system.dm
+++ b/code/game/objects/effects/effect_system/effect_system.dm
@@ -10,7 +10,10 @@ would spawn and follow the beaker, even if it is carried or thrown.
 	name = "particle effect"
 	mouse_opacity = MOUSE_OPACITY_TRANSPARENT
 	pass_flags = PASSTABLE | PASSGRILLE
-
+	
+/obj/effect/particle_effect/can_be_pulled(user)
+	return FALSE
+	
 /obj/effect/particle_effect/New()
 	..()
 	GLOB.cameranet.updateVisibility(src)

--- a/code/game/objects/effects/effect_system/effect_system.dm
+++ b/code/game/objects/effects/effect_system/effect_system.dm
@@ -11,13 +11,13 @@ would spawn and follow the beaker, even if it is carried or thrown.
 	mouse_opacity = MOUSE_OPACITY_TRANSPARENT
 	pass_flags = PASSTABLE | PASSGRILLE
 	
-/obj/effect/particle_effect/can_be_pulled(user)
-	return FALSE
-	
 /obj/effect/particle_effect/New()
 	..()
 	GLOB.cameranet.updateVisibility(src)
-
+	
+/obj/effect/particle_effect/can_be_pulled(user)
+	return FALSE
+	
 /obj/effect/particle_effect/Destroy()
 	GLOB.cameranet.updateVisibility(src)
 	. = ..()

--- a/code/game/objects/effects/effect_system/effects_water.dm
+++ b/code/game/objects/effects/effect_system/effects_water.dm
@@ -10,7 +10,10 @@
 /obj/effect/particle_effect/water/New()
 	..()
 	QDEL_IN(src, 70)
-
+	
+/obj/effect/particle_effect/water/can_be_pulled(user)
+	return FALSE
+	
 /obj/effect/particle_effect/water/Move(turf/newloc)
 	if (--src.life < 1)
 		qdel(src)

--- a/code/game/objects/effects/effect_system/effects_water.dm
+++ b/code/game/objects/effects/effect_system/effects_water.dm
@@ -49,5 +49,8 @@ steam.start() -- spawns the effect
 	..()
 	QDEL_IN(src, 20)
 
+/obj/effect/particle_effect/steam/can_be_pulled(user)
+	return FALSE
+	
 /datum/effect_system/steam_spread
 	effect_type = /obj/effect/particle_effect/steam

--- a/code/game/objects/items/tanks/watertank.dm
+++ b/code/game/objects/items/tanks/watertank.dm
@@ -326,6 +326,9 @@
 	mouse_opacity = MOUSE_OPACITY_TRANSPARENT
 	pass_flags = PASSTABLE
 
+/obj/effect/resin_container/can_be_pulled(user)
+	return FALSE
+	
 /obj/effect/resin_container/proc/Smoke()
 	var/obj/effect/particle_effect/foam/metal/resin/S = new /obj/effect/particle_effect/foam/metal/resin(get_turf(loc))
 	S.amount = 4

--- a/code/modules/mining/lavaland/necropolis_chests.dm
+++ b/code/modules/mining/lavaland/necropolis_chests.dm
@@ -367,7 +367,10 @@
 
 /obj/effect/warp_cube
 	mouse_opacity = MOUSE_OPACITY_TRANSPARENT
-
+	
+/obj/effect/warp_cube/can_be_pulled(user)
+	return FALSE
+	
 /obj/effect/warp_cube/ex_act(severity, target)
 	return
 

--- a/code/modules/ruins/objects_and_mobs/necropolis_gate.dm
+++ b/code/modules/ruins/objects_and_mobs/necropolis_gate.dm
@@ -74,7 +74,10 @@
 	pixel_y = -32
 	mouse_opacity = MOUSE_OPACITY_TRANSPARENT
 	opacity = TRUE
-
+	
+/obj/structure/opacity_blocker/can_be_pulled(user)
+	return FALSE
+	
 /obj/structure/opacity_blocker/singularity_pull()
 	return 0
 


### PR DESCRIPTION
:cl: Nervere
fix: Mirage-holders can no longer be pulled.
/:cl:
See #38137 for why mirage-holders being pulled is a bad idea.
Mirage-holder is an abstract object at the edge of a z-level. Its purpose is to create visual continuity between z-levels. However, it could be pulled away from the z-level, bringing the image it was creating with it.

fixes #38137 