### PR TITLE
Fix cyborg HUD not unhighlighting when dropping a module

### DIFF
--- a/code/modules/mob/living/silicon/robot/inventory.dm
+++ b/code/modules/mob/living/silicon/robot/inventory.dm
@@ -33,10 +33,10 @@
 		inv3.icon_state = "inv3"
 		held_items[3] = null
 
-	O.forceMove(module) //Return item to module so it appears in its contents, so it can be taken out again.
-
 	if(O.flags_1 & DROPDEL_1)
 		O.flags_1 &= ~DROPDEL_1 //we shouldn't HAVE things with DROPDEL_1 in our modules, but better safe than runtiming horribly
+
+	O.forceMove(module) //Return item to module so it appears in its contents, so it can be taken out again.
 
 	hud_used.update_robot_modules_display()
 	return 1

--- a/code/modules/mob/living/silicon/robot/inventory.dm
+++ b/code/modules/mob/living/silicon/robot/inventory.dm
@@ -38,7 +38,6 @@
 	if(O.flags_1 & DROPDEL_1)
 		O.flags_1 &= ~DROPDEL_1 //we shouldn't HAVE things with DROPDEL_1 in our modules, but better safe than runtiming horribly
 
-	O.dropped(src)
 	hud_used.update_robot_modules_display()
 	return 1
 

--- a/code/modules/mob/living/silicon/robot/inventory.dm
+++ b/code/modules/mob/living/silicon/robot/inventory.dm
@@ -20,12 +20,6 @@
 	if(client)
 		client.screen -= O
 	observer_screen_update(O,FALSE)
-	O.forceMove(module) //Return item to module so it appears in its contents, so it can be taken out again.
-
-	if(O.flags_1 & DROPDEL_1)
-		O.flags_1 &= ~DROPDEL_1 //we shouldn't HAVE things with DROPDEL_1 in our modules, but better safe than runtiming horribly
-
-	O.dropped(src)
 
 	if(module_active == O)
 		module_active = null
@@ -38,6 +32,13 @@
 	else if(held_items[3] == O)
 		inv3.icon_state = "inv3"
 		held_items[3] = null
+
+	O.forceMove(module) //Return item to module so it appears in its contents, so it can be taken out again.
+
+	if(O.flags_1 & DROPDEL_1)
+		O.flags_1 &= ~DROPDEL_1 //we shouldn't HAVE things with DROPDEL_1 in our modules, but better safe than runtiming horribly
+
+	O.dropped(src)
 	hud_used.update_robot_modules_display()
 	return 1
 


### PR DESCRIPTION
:cl:
fix: Cyborg inventory slots once again unhighlight when a module is stowed.
/:cl:

Fixes #37783