### PR TITLE
Fixes Meta maint chemmaster

### DIFF
--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -54353,8 +54353,7 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
 "cmb" = (
-/obj/machinery/chem_master/condimaster{
-	name = "CondiMaster Neo";
+/obj/machinery/chem_master{
 	pixel_x = -4
 	},
 /turf/open/floor/plating,


### PR DESCRIPTION
Replaces the abandoned medbay condimaster on Metastation with the correct type (chemmaster).

Closes: #38143