### PR TITLE
fixes pickweight

### DIFF
--- a/code/__HELPERS/_lists.dm
+++ b/code/__HELPERS/_lists.dm
@@ -198,7 +198,7 @@
 	var/total = 0
 	var/item
 	for (item in L)
-		if (!L[item])
+		if(isnull(L[item]))
 			L[item] = 1
 		total += L[item]
 


### PR DESCRIPTION
If a value is set to 0 (random law weights being a good example), pickweight sets it to 1 meaning there's a chance you get stuff like the thermodynamic lawset, or ninjaOS lawset even though it's disabled.

This fixes that, meaning setting a weight to 0 means it actually will have no probability of happening, while preserving the behaviour that they get a weight of 1 if they don't have an assigned weight