### PR TITLE
fixes random-weighted AI laws

### DIFF
--- a/code/datums/ai_laws.dm
+++ b/code/datums/ai_laws.dm
@@ -175,7 +175,7 @@
 	id = "ratvar"
 	zeroth = ("Purge all untruths and honor Ratvar.")
 	inherent = list()
-	
+
 /datum/ai_laws/hulkamania
 	name = "H.O.G.A.N."
 	id = "hulkamania"
@@ -249,7 +249,7 @@
 	var/datum/ai_laws/lawtype
 	var/list/law_weights = CONFIG_GET(keyed_number_list/law_weight)
 	while(!lawtype && law_weights.len)
-		var/possible_id = pickweight(law_weights)
+		var/possible_id = pickweightAllowZero(law_weights)
 		lawtype = lawid_to_type(possible_id)
 		if(!lawtype)
 			law_weights -= possible_id


### PR DESCRIPTION
Random-weighted laws now allow you to use a weight of 0, like they do by default in the config, rather than force it to have a chance of 1