### PR TITLE
Fix: Cyborgs can now use defibs with other modules equipped

### DIFF
--- a/code/game/objects/items/twohanded.dm
+++ b/code/game/objects/items/twohanded.dm
@@ -63,7 +63,7 @@
 	if(ismonkey(user))
 		to_chat(user, "<span class='warning'>It's too heavy for you to wield fully.</span>")
 		return
-	if(user.get_inactive_held_item())
+	if(user.get_inactive_held_item() && !(iscyborg(usr)))
 		to_chat(user, "<span class='warning'>You need your other hand to be empty!</span>")
 		return
 	if(user.get_num_arms() < 2)

--- a/code/game/objects/items/twohanded.dm
+++ b/code/game/objects/items/twohanded.dm
@@ -63,11 +63,7 @@
 	if(ismonkey(user))
 		to_chat(user, "<span class='warning'>It's too heavy for you to wield fully.</span>")
 		return
-<<<<<<< HEAD
-	if(user.get_inactive_held_item())
-=======
 	if(user.get_inactive_held_item() && !(iscyborg(user)))
->>>>>>> 7ca223918efe8525c28bdedcc8768a714d562d61
 		to_chat(user, "<span class='warning'>You need your other hand to be empty!</span>")
 		return
 	if(user.get_num_arms() < 2)

--- a/code/game/objects/items/twohanded.dm
+++ b/code/game/objects/items/twohanded.dm
@@ -63,7 +63,7 @@
 	if(ismonkey(user))
 		to_chat(user, "<span class='warning'>It's too heavy for you to wield fully.</span>")
 		return
-	if(user.get_inactive_held_item() && !(iscyborg(usr)))
+	if(user.get_inactive_held_item())
 		to_chat(user, "<span class='warning'>You need your other hand to be empty!</span>")
 		return
 	if(user.get_num_arms() < 2)

--- a/code/game/objects/items/twohanded.dm
+++ b/code/game/objects/items/twohanded.dm
@@ -63,7 +63,7 @@
 	if(ismonkey(user))
 		to_chat(user, "<span class='warning'>It's too heavy for you to wield fully.</span>")
 		return
-	if(user.get_inactive_held_item() && !(iscyborg(user)))
+	if(user.get_inactive_held_item())
 		to_chat(user, "<span class='warning'>You need your other hand to be empty!</span>")
 		return
 	if(user.get_num_arms() < 2)

--- a/code/game/objects/items/twohanded.dm
+++ b/code/game/objects/items/twohanded.dm
@@ -63,7 +63,7 @@
 	if(ismonkey(user))
 		to_chat(user, "<span class='warning'>It's too heavy for you to wield fully.</span>")
 		return
-	if(user.get_inactive_held_item() && !(iscyborg(usr)))
+	if(user.get_inactive_held_item() && !(iscyborg(user)))
 		to_chat(user, "<span class='warning'>You need your other hand to be empty!</span>")
 		return
 	if(user.get_num_arms() < 2)

--- a/code/modules/mob/living/silicon/silicon.dm
+++ b/code/modules/mob/living/silicon/silicon.dm
@@ -403,3 +403,6 @@
 
 /mob/living/silicon/is_literate()
 	return 1
+
+/mob/living/silicon/get_inactive_held_item()
+	return FALSE


### PR DESCRIPTION
The if(user.get_inactive_held_item()) check isn't very useful to cyborgs since all that does is return the item in the second module (and if there is nothing there, it returns null.) 

Ingame picture of the bug:
![image](https://user-images.githubusercontent.com/31262308/40696801-5f5d6cda-6395-11e8-8bd2-a0d9d3c77c9b.png)


:cl:
fix: Fixes cyborgs not being able to use two-handed modules while other modules are equipped.
/:cl:

[why]: fixes #38142 
