### PR TITLE
Makes the monkeycap part of the config

### DIFF
--- a/code/controllers/configuration/entries/game_options.dm
+++ b/code/controllers/configuration/entries/game_options.dm
@@ -287,3 +287,8 @@
 /datum/config_entry/flag/randomize_shift_time
 
 /datum/config_entry/flag/shift_time_realtime
+
+/datum/config_entry/number/monkeycap
+	config_entry_value = 64
+	integer = FALSE
+	min_val = 0

--- a/code/controllers/subsystem/mobs.dm
+++ b/code/controllers/subsystem/mobs.dm
@@ -7,7 +7,7 @@ SUBSYSTEM_DEF(mobs)
 	var/list/currentrun = list()
 	var/static/list/clients_by_zlevel[][]
 	var/static/list/cubemonkeys = list()
-	var/cubemonkeycap = 64
+	var/cubemonkeycap = CONFIG_GET(number/monkeycap)
 
 /datum/controller/subsystem/mobs/stat_entry()
 	..("P:[GLOB.mob_living_list.len]")

--- a/code/controllers/subsystem/mobs.dm
+++ b/code/controllers/subsystem/mobs.dm
@@ -7,6 +7,8 @@ SUBSYSTEM_DEF(mobs)
 	var/list/currentrun = list()
 	var/static/list/clients_by_zlevel[][]
 	var/static/list/cubemonkeys = list()
+
+/datum/controller/subsystem/mobs/PreInit()
 	var/cubemonkeycap = CONFIG_GET(number/monkeycap)
 
 /datum/controller/subsystem/mobs/stat_entry()

--- a/config/game_options.txt
+++ b/config/game_options.txt
@@ -481,7 +481,6 @@ BOMBCAP 20
 ## LagHell (7, 14, 28)
 #BOMBCAP 28
 
-
 ## Lavaland "Budget"
 ## Lavaland ruin spawning has an imaginary budget to spend on ruins, where
 ## a less lootfilled or smaller or less round effecting ruin costs less to
@@ -527,3 +526,6 @@ ROUNDSTART_TRAITS
 
 ## Sets shift time to server time at roundstart. Overridden by RANDOMIZE_SHIFT_TIME ##
 #SHIFT_TIME_REALTIME
+
+## A cap on how much monkeys are allowed, can't be an integer.
+MONKEYCAP 64


### PR DESCRIPTION
MONKEYCAP ROUND 3

Someone at hippie made a PR to change the monkeycap (for some reason) so I just decided to make this a config since at the time when I changed the monkeycap to 64, I was a bit clueless on how to do configs but then I realised it's easy so I made this PR.

:cl: FrozenGuy5
config: The monkeycap is now part of the config. Note, it's still 64 unless a remote holder changes it.
/:cl: