### PR TITLE
allows changing the rank of players in the playerpanel

### DIFF
--- a/code/modules/admin/admin.dm
+++ b/code/modules/admin/admin.dm
@@ -29,7 +29,7 @@
 	body += "<body>Options panel for <b>[M]</b>"
 	if(M.client)
 		body += " played by <b>[M.client]</b> "
-		body += "\[<A href='?_src_=holder;[HrefToken()];editrights=rank;ckey=[M.ckey]'>[M.client.holder ? M.client.holder.rank : "Player"]</A>\]"
+		body += "\[<A href='?_src_=holder;[HrefToken()];editrights=[(GLOB.admin_datums[M.client.ckey] || GLOB.deadmins[M.client.ckey]) ? "rank" : "add"];ckey=[M.ckey]'>[M.client.holder ? M.client.holder.rank : "Player"]</A>\]"
 		if(CONFIG_GET(flag/use_exp_tracking))
 			body += "\[<A href='?_src_=holder;[HrefToken()];getplaytimewindow=[REF(M)]'>" + M.client.get_exp_living() + "</a>\]"
 

--- a/code/modules/admin/permissionedit.dm
+++ b/code/modules/admin/permissionedit.dm
@@ -165,7 +165,7 @@
 			return
 	switch(task)
 		if("add")
-			add_admin(admin_ckey, use_db)
+			admin_ckey = add_admin(admin_ckey, use_db)
 			if(!admin_ckey)
 				return
 			change_admin_rank(admin_ckey, use_db)

--- a/code/modules/admin/permissionedit.dm
+++ b/code/modules/admin/permissionedit.dm
@@ -165,7 +165,10 @@
 			return
 	switch(task)
 		if("add")
-			admin_ckey = add_admin(null, use_db)
+			if(admin_ckey)
+				add_admin(admin_ckey, use_db)
+			else
+				admin_ckey = add_admin(null, use_db)
 			if(!admin_ckey)
 				return
 			change_admin_rank(admin_ckey, use_db)

--- a/code/modules/admin/permissionedit.dm
+++ b/code/modules/admin/permissionedit.dm
@@ -165,10 +165,7 @@
 			return
 	switch(task)
 		if("add")
-			if(admin_ckey)
-				add_admin(admin_ckey, use_db)
-			else
-				admin_ckey = add_admin(null, use_db)
+			add_admin(admin_ckey, use_db)
 			if(!admin_ckey)
 				return
 			change_admin_rank(admin_ckey, use_db)


### PR DESCRIPTION
Allows admins (who have the right permissions, ofc) to give players admin-ranks through the playerpanel like they would edit an admins rank, since right now it just asks you whether you want a temporary or permanent change, then returns and does nothing.

I'd call it a fix, but eh, i don't really care about GBP since I don't do balance and features