### PR TITLE
Delay smoothing atoms that have not initialized yet

### DIFF
--- a/code/controllers/subsystem/icon_smooth.dm
+++ b/code/controllers/subsystem/icon_smooth.dm
@@ -6,16 +6,26 @@ SUBSYSTEM_DEF(icon_smooth)
 	flags = SS_TICKER
 
 	var/list/smooth_queue = list()
+	var/list/deferred = list()
 
 /datum/controller/subsystem/icon_smooth/fire()
-	while(smooth_queue.len)
-		var/atom/A = smooth_queue[smooth_queue.len]
-		smooth_queue.len--
-		smooth_icon(A)
+	var/list/cached = smooth_queue
+	while(cached.len)
+		var/atom/A = cached[cached.len]
+		cached.len--
+		if (A.flags_1 & INITIALIZED_1)
+			smooth_icon(A)
+		else
+			deferred += A
 		if (MC_TICK_CHECK)
 			return
-	if (!smooth_queue.len)
-		can_fire = 0
+
+	if (!cached.len)
+		if (deferred.len)
+			smooth_queue = deferred
+			deferred = cached
+		else
+			can_fire = 0
 
 /datum/controller/subsystem/icon_smooth/Initialize()
 	smooth_zlevel(1,TRUE)

--- a/code/modules/mapping/map_template.dm
+++ b/code/modules/mapping/map_template.dm
@@ -57,12 +57,12 @@
 	if(!bounds)
 		return FALSE
 
-	smooth_zlevel(world.maxz)
 	repopulate_sorted_areas()
 
 	SSlighting.initialize_lighting_objects(block(locate(bounds[MAP_MINX], bounds[MAP_MINY], bounds[MAP_MINZ]),locate(bounds[MAP_MAXX], bounds[MAP_MAXY], bounds[MAP_MAXZ])))
 	//initialize things that are normally initialized after map load
 	initTemplateBounds(bounds)
+	smooth_zlevel(world.maxz)
 	log_game("Z-level [name] loaded at at [x],[y],[world.maxz]")
 
 	return level


### PR DESCRIPTION
aka partially unruining late-loading snowdin part 1

:cl:
fix: Atom initialization and icon smoothing no longer race, causing late-loading mineral turfs to have no icon.
/:cl: