### PR TITLE
Stops cloners from calling process() while autoprocessing is disabled, adds a config option to disable autoprocessing

### DIFF
--- a/code/controllers/configuration/entries/game_options.dm
+++ b/code/controllers/configuration/entries/game_options.dm
@@ -287,3 +287,5 @@
 /datum/config_entry/flag/randomize_shift_time
 
 /datum/config_entry/flag/shift_time_realtime
+
+/datum/config_entry/flag/disable_autocloning

--- a/code/game/machinery/computer/cloning.dm
+++ b/code/game/machinery/computer/cloning.dm
@@ -59,6 +59,7 @@
 	if(!(scanner && LAZYLEN(pods) && autoprocess))
 		return
 
+
 	if(scanner.occupant && scanner.scan_level > 2)
 		scan_occupant(scanner.occupant)
 
@@ -76,9 +77,13 @@
 			records -= R
 
 /obj/machinery/computer/cloning/proc/updatemodules(findfirstcloner)
-	src.scanner = findscanner()
+	scanner = findscanner()
 	if(findfirstcloner && !LAZYLEN(pods))
 		findcloner()
+	if (!isprocessing && autoprocess && !CONFIG_GET(flag/disable_autocloning))
+		START_PROCESSING(SSmachines, src)
+	else if (isprocessing && (!autoprocess || CONFIG_GET(flag/disable_autocloning)))
+		STOP_PROCESSING(SSmachines, src)
 
 /obj/machinery/computer/cloning/proc/findscanner()
 	var/obj/machinery/dna_scannernew/scannerf = null
@@ -151,17 +156,19 @@
 	var/dat = ""
 	dat += "<a href='byond://?src=[REF(src)];refresh=1'>Refresh</a>"
 
-	if(scanner && HasEfficientPod() && scanner.scan_level > 2)
-		if(!autoprocess)
-			dat += "<a href='byond://?src=[REF(src)];task=autoprocess'>Autoprocess</a>"
+	if (!CONFIG_GET(flag/disable_autocloning))
+		if(scanner && HasEfficientPod() && scanner.scan_level > 2)
+			if(!autoprocess)
+				dat += "<a href='byond://?src=[REF(src)];task=autoprocess'>Autoprocess</a>"
+			else
+				dat += "<a href='byond://?src=[REF(src)];task=stopautoprocess'>Stop autoprocess</a>"
 		else
-			dat += "<a href='byond://?src=[REF(src)];task=stopautoprocess'>Stop autoprocess</a>"
-	else
-		dat += "<span class='linkOff'>Autoprocess</span>"
+			dat += "<span class='linkOff'>Autoprocess</span>"
+
 	dat += "<h3>Cloning Pod Status</h3>"
 	dat += "<div class='statusDisplay'>[temp]&nbsp;</div>"
 
-	switch(src.menu)
+	switch(menu)
 		if(1)
 			// Modules
 			if (isnull(src.scanner) || !LAZYLEN(pods))
@@ -273,7 +280,7 @@
 	if(loading)
 		return
 
-	if(href_list["task"])
+	if(href_list["task"] && !CONFIG_GET(flag/disable_autocloning))
 		switch(href_list["task"])
 			if("autoprocess")
 				autoprocess = 1


### PR DESCRIPTION
:cl: Naksu
code: cloners will not waste processing time calling process() for no reason, only when autoprocessing is available and enabled
config: added a new config option to disable autocloning
/:cl:
