### PR TITLE
Fix Pubby auxiliary mining base

### DIFF
--- a/_maps/map_files/PubbyStation/PubbyStation.dmm
+++ b/_maps/map_files/PubbyStation/PubbyStation.dmm
@@ -47956,7 +47956,6 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/simple/general/hidden,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plating,
 /area/maintenance/department/cargo)
@@ -52381,7 +52380,7 @@
 	width = 9
 	},
 /turf/open/floor/plating,
-/area/shuttle/auxillary_base)
+/area/construction/mining/aux_base)
 "rKr" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -53162,7 +53161,7 @@
 /area/construction/mining/aux_base)
 "uoS" = (
 /turf/open/floor/plating,
-/area/shuttle/auxillary_base)
+/area/construction/mining/aux_base)
 "uqJ" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable,

--- a/_maps/shuttles/aux_base_small.dmm
+++ b/_maps/shuttles/aux_base_small.dmm
@@ -1,0 +1,150 @@
+//MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
+"b" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 9
+	},
+/obj/structure/ore_box,
+/turf/open/floor/plating,
+/area/shuttle/auxillary_base)
+"c" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/shuttle/auxillary_base)
+"d" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 5
+	},
+/turf/open/floor/plating,
+/area/shuttle/auxillary_base)
+"e" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/shuttle/auxillary_base)
+"f" = (
+/turf/open/floor/plating,
+/area/shuttle/auxillary_base)
+"g" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/shuttle/auxillary_base)
+"h" = (
+/obj/machinery/camera{
+	c_tag = "Auxillary Mining Base";
+	dir = 1
+	},
+/obj/structure/mining_shuttle_beacon,
+/turf/open/floor/plating,
+/area/shuttle/auxillary_base)
+"i" = (
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/shuttle/auxillary_base)
+"j" = (
+/obj/docking_port/mobile/auxillary_base{
+	dheight = 4;
+	dir = 2;
+	dwidth = 4;
+	height = 9;
+	width = 9;
+	timid = 1
+	},
+/obj/machinery/bluespace_beacon,
+/obj/machinery/computer/auxillary_base,
+/turf/closed/wall,
+/area/shuttle/auxillary_base)
+"k" = (
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/shuttle/auxillary_base)
+"l" = (
+/obj/machinery/portable_atmospherics/canister/air,
+/obj/effect/turf_decal/stripes/line{
+	dir = 10
+	},
+/turf/open/floor/plating,
+/area/shuttle/auxillary_base)
+"m" = (
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/plating,
+/area/shuttle/auxillary_base)
+"n" = (
+/obj/structure/closet/secure_closet/miner/unlocked,
+/obj/effect/turf_decal/stripes/line{
+	dir = 6
+	},
+/turf/open/floor/plating,
+/area/shuttle/auxillary_base)
+
+(1,1,1) = {"
+b
+e
+e
+e
+e
+e
+l
+"}
+(2,1,1) = {"
+c
+f
+f
+f
+f
+f
+m
+"}
+(3,1,1) = {"
+c
+f
+f
+i
+f
+f
+m
+"}
+(4,1,1) = {"
+c
+f
+h
+j
+f
+f
+m
+"}
+(5,1,1) = {"
+c
+f
+f
+k
+f
+f
+m
+"}
+(6,1,1) = {"
+c
+f
+f
+f
+f
+f
+m
+"}
+(7,1,1) = {"
+d
+g
+g
+g
+g
+g
+n
+"}

--- a/code/modules/shuttle/manipulator.dm
+++ b/code/modules/shuttle/manipulator.dm
@@ -279,7 +279,7 @@
 			if(istype(P, /obj/docking_port/stationary))
 				log_world("Map warning: Shuttle Template [S.mappath] has a stationary docking port.")
 	if(!found)
-		var/msg = "load_template(): Shuttle Template [S.mappath] has no	mobile docking port. Aborting import."
+		var/msg = "load_template(): Shuttle Template [S.mappath] has no mobile docking port. Aborting import."
 		for(var/T in affected)
 			var/turf/T0 = T
 			T0.empty()


### PR DESCRIPTION
:cl:
fix: Pubby's auxiliary mining base now works again.
/:cl:

The file just didn't exist. Fixes #38188.

Also removes a stray double pipe near Xenobio and fixes a stray tab in the relevant warning message which must have been ignored for some time.