### PR TITLE
Fix family heirloom being lost on cloning

### DIFF
--- a/code/datums/traits/_quirk.dm
+++ b/code/datums/traits/_quirk.dm
@@ -55,6 +55,9 @@
 /datum/quirk/proc/post_add() //for text, disclaimers etc. given after you spawn in with the trait
 /datum/quirk/proc/on_transfer() //code called when the trait is transferred to a new mob
 
+/datum/quirk/proc/clone_data() //return additional data that should be remembered by cloning
+/datum/quirk/proc/on_clone(data) //create the quirk from clone data
+
 /datum/quirk/process()
 	if(QDELETED(quirk_holder))
 		quirk_holder = null

--- a/code/datums/traits/negative.dm
+++ b/code/datums/traits/negative.dm
@@ -85,7 +85,11 @@
 		quirk_holder.SendSignal(COMSIG_CLEAR_MOOD_EVENT, "family_heirloom")
 		quirk_holder.SendSignal(COMSIG_ADD_MOOD_EVENT, "family_heirloom_missing", /datum/mood_event/family_heirloom_missing)
 
+/datum/quirk/family_heirloom/clone_data()
+	return heirloom
 
+/datum/quirk/family_heirloom/on_clone(data)
+	heirloom = data
 
 /datum/quirk/heavy_sleeper
 	name = "Heavy Sleeper"

--- a/code/game/machinery/cloning.dm
+++ b/code/game/machinery/cloning.dm
@@ -204,7 +204,8 @@
 		H.faction |= factions
 
 		for(var/V in quirks)
-			new V(H)
+			var/datum/quirk/Q = new V(H)
+			Q.on_clone(quirks[V])
 
 		H.set_cloned_appearance()
 

--- a/code/game/machinery/computer/cloning.dm
+++ b/code/game/machinery/computer/cloning.dm
@@ -476,7 +476,7 @@
 	R.fields["quirks"] = list()
 	for(var/V in mob_occupant.roundstart_quirks)
 		var/datum/quirk/T = V
-		R.fields["quirks"] += T.type
+		R.fields["quirks"][T.type] = T.clone_data()
 
 	if (!isnull(mob_occupant.mind)) //Save that mind so traitors can continue traitoring after cloning.
 		R.fields["mind"] = "[REF(mob_occupant.mind)]"


### PR DESCRIPTION
:cl:
fix: Cloning no longer breaks a character's connection to their family heirloom.
/:cl:

Fixes #36940. Maybe should use weakref?