### PR TITLE
Fix Snowdin elevators and piping

### DIFF
--- a/_maps/RandomZLevels/VR/snowdin_VR.dmm
+++ b/_maps/RandomZLevels/VR/snowdin_VR.dmm
@@ -2853,7 +2853,6 @@
 /turf/open/floor/plating,
 /area/awaymission/snowdin/post)
 "hk" = (
-/turf/open/floor/plating/asteroid/snow/ice,
 /obj/effect/turf_decal/stripes/corner,
 /obj/machinery/conveyor_switch/oneway{
 	id = "snowdin_belt_mine";
@@ -2893,7 +2892,6 @@
 /turf/open/floor/plasteel,
 /area/awaymission/snowdin/post/gateway)
 "ho" = (
-/turf/open/floor/plating/asteroid/snow/ice,
 /obj/effect/turf_decal/stripes/line,
 /obj/effect/turf_decal/loading_area,
 /turf/open/floor/plating/snowed/cavern,
@@ -3854,13 +3852,6 @@
 /obj/effect/landmark/vr_spawn/snowdin,
 /turf/open/floor/plasteel/floorgrime,
 /area/awaymission/snowdin/post/garage)
-"jv" = (
-/turf/open/floor/plating/asteroid/snow/ice,
-/obj/effect/turf_decal/stripes/corner{
-	dir = 1
-	},
-/turf/open/floor/plating/snowed/cavern,
-/area/awaymission/snowdin/cave/cavern)
 "jw" = (
 /obj/structure/table,
 /obj/item/paper/pamphlet/gateway,
@@ -3940,13 +3931,6 @@
 	},
 /turf/open/floor/plating/snowed/smoothed,
 /area/awaymission/snowdin/outside)
-"jE" = (
-/turf/open/floor/plating/asteroid/snow/ice,
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/turf/open/floor/plating/snowed/cavern,
-/area/awaymission/snowdin/cave/cavern)
 "jF" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating{
@@ -4377,7 +4361,6 @@
 	},
 /area/awaymission/snowdin/post)
 "kK" = (
-/turf/open/floor/plating/asteroid/snow/ice,
 /obj/machinery/conveyor{
 	dir = 2;
 	id = "snowdin_belt_mine"
@@ -9211,23 +9194,10 @@
 /turf/open/floor/plating/snowed,
 /area/awaymission/snowdin/cave)
 "xl" = (
-/obj/effect/baseturf_helper/asteroid/snow,
-/turf/closed/wall/ice,
-/area/shuttle/snowdin/elevator1)
-"xm" = (
-/obj/structure/window/reinforced/fulltile/ice,
-/obj/structure/grille,
-/turf/open/floor/plating,
-/area/shuttle/snowdin/elevator1)
-"xn" = (
-/obj/machinery/door/airlock/public/glass{
-	name = "Elevator Access"
+/turf/open/floor/plasteel/elevatorshaft{
+	initial_gas_mix = "o2=22;n2=82;TEMP=180"
 	},
-/turf/open/floor/plating,
-/area/shuttle/snowdin/elevator1)
-"xo" = (
-/turf/closed/wall/ice,
-/area/shuttle/snowdin/elevator1)
+/area/awaymission/snowdin/cave)
 "xp" = (
 /obj/effect/turf_decal/stripes/white/line{
 	dir = 8
@@ -9278,18 +9248,6 @@
 	},
 /turf/open/floor/engine/cult,
 /area/awaymission/snowdin/post/mining_dock)
-"xv" = (
-/turf/open/floor/engine,
-/area/shuttle/snowdin/elevator1)
-"xw" = (
-/obj/machinery/computer/shuttle/snowdin/mining{
-	dir = 2;
-	name = "Excavation Elevator Console";
-	possible_destinations = "snowdin_excavation_top;snowdin_excavation_down";
-	shuttleId = "snowdin_excavation"
-	},
-/turf/open/floor/engine,
-/area/shuttle/snowdin/elevator1)
 "xx" = (
 /obj/effect/spawner/lootdrop/crate_spawner,
 /turf/open/floor/plasteel/neutral,
@@ -9378,26 +9336,20 @@
 	},
 /area/awaymission/snowdin/post/mining_dock)
 "xK" = (
-/obj/machinery/door/airlock/public/glass{
-	name = "Elevator Access"
-	},
-/obj/docking_port/mobile/elevator{
-	dir = 4;
-	height = 6;
-	id = "snowdin_excavation";
-	name = "excavation elevator";
-	width = 6
-	},
 /obj/docking_port/stationary{
+	area_type = /area/awaymission/snowdin/cave;
 	dir = 4;
 	dwidth = 3;
 	height = 6;
 	id = "snowdin_excavation_top";
 	name = "snowdin excavation top";
+	roundstart_template = /datum/map_template/shuttle/snowdin/excavation;
 	width = 6
 	},
-/turf/open/floor/plating,
-/area/shuttle/snowdin/elevator1)
+/turf/open/floor/plasteel/elevatorshaft{
+	initial_gas_mix = "o2=22;n2=82;TEMP=180"
+	},
+/area/awaymission/snowdin/cave)
 "xL" = (
 /obj/machinery/atmospherics/pipe/manifold/orange/visible{
 	dir = 8
@@ -9424,6 +9376,7 @@
 /area/awaymission/snowdin/post/mining_dock)
 "xP" = (
 /obj/docking_port/stationary{
+	area_type = /area/awaymission/snowdin/post/mining_dock;
 	dir = 4;
 	dwidth = 3;
 	height = 6;
@@ -9431,7 +9384,7 @@
 	name = "snowdin excavation down";
 	width = 6
 	},
-/turf/open/floor/plating,
+/turf/open/floor/plasteel/elevatorshaft,
 /area/awaymission/snowdin/post/mining_dock)
 "xQ" = (
 /obj/effect/turf_decal/stripes/line{
@@ -9860,20 +9813,6 @@
 	name = "toxin out"
 	},
 /turf/open/floor/engine/vacuum,
-/area/awaymission/snowdin/cave)
-"zb" = (
-/obj/structure/window/reinforced/fulltile/ice,
-/obj/structure/grille,
-/obj/machinery/atmospherics/pipe/simple/orange/visible{
-	dir = 8
-	},
-/obj/machinery/atmospherics/components/unary/vent_pump/siphon/on{
-	dir = 4;
-	frequency = 1442;
-	id_tag = "snowdin_toxins_mine_1";
-	name = "toxin out"
-	},
-/turf/open/floor/plating,
 /area/awaymission/snowdin/cave)
 "zc" = (
 /obj/machinery/atmospherics/pipe/simple/orange/visible{
@@ -13339,9 +13278,6 @@
 /turf/open/floor/plating,
 /area/awaymission/snowdin/post/mining_dock)
 "Jl" = (
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 8
-	},
 /obj/machinery/door/airlock/mining/glass{
 	name = "Mining Dock";
 	req_access_txt = "48"
@@ -13384,9 +13320,6 @@
 /turf/open/floor/plating/snowed/cavern,
 /area/awaymission/snowdin/cave/cavern)
 "Jr" = (
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 8
-	},
 /obj/machinery/door/airlock/mining/glass{
 	name = "Mining Dock";
 	req_access_txt = "48"
@@ -13546,20 +13479,6 @@
 	dir = 4
 	},
 /area/awaymission/snowdin/post/mining_main)
-"JR" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/door/firedoor,
-/turf/open/floor/plating,
-/area/shuttle/snowdin/elevator2)
-"JS" = (
-/obj/machinery/door/airlock/public/glass{
-	name = "Elevator Access"
-	},
-/turf/open/floor/plating,
-/area/shuttle/snowdin/elevator2)
-"JT" = (
-/turf/closed/wall,
-/area/shuttle/snowdin/elevator2)
 "JU" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -13622,19 +13541,6 @@
 	dir = 8
 	},
 /area/awaymission/snowdin/post/mining_main)
-"Kd" = (
-/obj/machinery/computer/shuttle/snowdin/mining,
-/turf/open/floor/engine,
-/area/shuttle/snowdin/elevator2)
-"Ke" = (
-/turf/open/floor/engine,
-/area/shuttle/snowdin/elevator2)
-"Kf" = (
-/obj/machinery/light/small{
-	dir = 1
-	},
-/turf/open/floor/engine,
-/area/shuttle/snowdin/elevator2)
 "Kg" = (
 /obj/structure/ore_box,
 /obj/effect/turf_decal/bot,
@@ -13696,27 +13602,18 @@
 	},
 /area/awaymission/snowdin/post/mining_main)
 "Kn" = (
-/obj/machinery/door/airlock/public/glass{
-	name = "Elevator Access"
-	},
-/obj/docking_port/mobile/elevator{
-	dir = 4;
-	dwidth = 2;
-	height = 5;
-	id = "snowdin_mining";
-	name = "mining elevator";
-	width = 5
-	},
 /obj/docking_port/stationary{
+	area_type = /area/awaymission/snowdin/post/mining_main;
 	dir = 4;
 	dwidth = 2;
 	height = 5;
 	id = "snowdin_mining_top";
 	name = "snowdin mining top";
+	roundstart_template = /datum/map_template/shuttle/snowdin/mining;
 	width = 5
 	},
-/turf/open/floor/plating,
-/area/shuttle/snowdin/elevator2)
+/turf/open/floor/plasteel/elevatorshaft,
+/area/awaymission/snowdin/post/mining_main)
 "Ko" = (
 /obj/machinery/light{
 	dir = 4
@@ -13766,7 +13663,7 @@
 	name = "snowdin mining bottom";
 	width = 5
 	},
-/turf/open/floor/plating,
+/turf/open/floor/plasteel/elevatorshaft,
 /area/awaymission/snowdin/post/mining_dock)
 "Ku" = (
 /obj/machinery/light{
@@ -13835,10 +13732,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/awaymission/snowdin/post/mining_main)
-"KC" = (
-/obj/machinery/light/small,
-/turf/open/floor/engine,
-/area/shuttle/snowdin/elevator2)
 "KD" = (
 /obj/structure/ore_box,
 /obj/effect/turf_decal/bot,
@@ -13912,8 +13805,8 @@
 	},
 /area/awaymission/snowdin/post/mining_main)
 "KP" = (
-/turf/closed/wall/rust,
-/area/shuttle/snowdin/elevator2)
+/turf/open/floor/plasteel/elevatorshaft,
+/area/awaymission/snowdin/post/mining_main)
 "KQ" = (
 /obj/machinery/computer/shuttle/snowdin/mining{
 	dir = 8
@@ -14013,6 +13906,9 @@
 	dir = 1
 	},
 /turf/open/floor/plating,
+/area/awaymission/snowdin/post/mining_dock)
+"ND" = (
+/turf/open/floor/plasteel/elevatorshaft,
 /area/awaymission/snowdin/post/mining_dock)
 "OF" = (
 /obj/machinery/door/airlock/external{
@@ -28100,7 +27996,7 @@ wS
 wS
 ai
 yf
-zb
+yt
 ai
 wS
 wS
@@ -28184,10 +28080,10 @@ IY
 Go
 Jx
 KP
-JR
+KP
 Kn
-JR
-JT
+KP
+KP
 KT
 Go
 ac
@@ -28339,7 +28235,7 @@ ii
 yb
 an
 yf
-zb
+yt
 yf
 ai
 ai
@@ -28440,11 +28336,11 @@ Gq
 Gq
 Go
 Jx
-JR
-Kd
-Ke
-KC
-JR
+KP
+KP
+KP
+KP
+KP
 KT
 GP
 ac
@@ -28697,11 +28593,11 @@ Iy
 Iy
 Go
 Jy
-JS
-Ke
-Ke
-Ke
-JS
+KP
+KP
+KP
+KP
+KP
 KU
 GP
 ac
@@ -28954,11 +28850,11 @@ GP
 GP
 GP
 Jx
-JR
-Kf
-Ke
-Ke
-JR
+KP
+KP
+KP
+KP
+KP
 KT
 GP
 ac
@@ -29211,10 +29107,10 @@ ae
 ae
 Go
 Jx
-JT
-JR
-JS
-JR
+KP
+KP
+KP
+KP
 KP
 KT
 GP
@@ -30131,11 +30027,11 @@ ae
 aj
 xa
 xl
-xm
-xn
+xl
+xl
 xK
-xm
-xo
+xl
+xl
 an
 ii
 ii
@@ -30387,12 +30283,12 @@ ae
 ae
 aj
 xa
-xm
-xv
-xv
-xv
-xv
-xm
+xl
+xl
+xl
+xl
+xl
+xl
 yp
 ii
 wS
@@ -30644,12 +30540,12 @@ ae
 wQ
 ai
 xb
-xn
-xv
-xv
-xv
-xv
-xn
+xl
+xl
+xl
+xl
+xl
+xl
 yq
 ii
 wS
@@ -30901,12 +30797,12 @@ ae
 wQ
 ai
 xb
-xn
-xv
-xv
-xv
-xv
-xn
+xl
+xl
+xl
+xl
+xl
+xl
 yq
 an
 ii
@@ -31158,12 +31054,12 @@ ae
 wQ
 wS
 xa
-xm
-xw
-xv
-xv
-xv
-xm
+xl
+xl
+xl
+xl
+xl
+xl
 yr
 an
 ii
@@ -31415,12 +31311,12 @@ ae
 wQ
 wS
 xa
-xo
-xm
-xn
-xn
-xm
-xo
+xl
+xl
+xl
+xl
+xl
+xl
 yp
 an
 an
@@ -62364,11 +62260,11 @@ IO
 wL
 wE
 JH
-wL
-wL
+ND
+ND
 Kt
-wL
-wL
+ND
+ND
 KX
 wE
 bh
@@ -62621,11 +62517,11 @@ IQ
 wL
 wE
 JH
-wL
-wL
-wL
-wL
-wL
+ND
+ND
+ND
+ND
+ND
 KX
 wE
 bh
@@ -62878,11 +62774,11 @@ wL
 wL
 wE
 JI
-wL
-wL
-wL
-wL
-wL
+ND
+ND
+ND
+ND
+ND
 KY
 wE
 bh
@@ -63135,11 +63031,11 @@ wL
 wL
 wE
 JH
-wL
-wL
-wL
-wL
-wL
+ND
+ND
+ND
+ND
+ND
 KX
 wE
 bh
@@ -63392,11 +63288,11 @@ wL
 wL
 wD
 JH
-wL
-wL
-wL
-wL
-wL
+ND
+ND
+ND
+ND
+ND
 KX
 wD
 bh
@@ -64151,7 +64047,7 @@ oZ
 oZ
 oZ
 hk
-jE
+sl
 Gk
 GN
 Hj
@@ -64664,7 +64560,7 @@ oZ
 oZ
 oZ
 oZ
-jv
+By
 xW
 xW
 xW
@@ -65339,12 +65235,12 @@ eJ
 wE
 wV
 xg
-wL
-wL
-wL
+ND
+ND
+ND
 xP
-wL
-wL
+ND
+ND
 yz
 yR
 wD
@@ -65596,12 +65492,12 @@ eJ
 wD
 wW
 xg
-wL
-wL
-wL
-wL
-wL
-wL
+ND
+ND
+ND
+ND
+ND
+ND
 yA
 wM
 zm
@@ -65853,12 +65749,12 @@ wD
 wP
 wX
 xg
-wL
-wL
-wL
-wL
-wL
-wL
+ND
+ND
+ND
+ND
+ND
+ND
 yB
 xy
 zn
@@ -66111,11 +66007,11 @@ wP
 wW
 xh
 wW
-wL
-wL
-wL
-wL
-wL
+ND
+ND
+ND
+ND
+ND
 yB
 xy
 zn
@@ -66369,10 +66265,10 @@ wW
 xh
 wW
 wW
-wW
-wL
-wL
-wL
+ND
+ND
+ND
+ND
 yC
 yS
 zm
@@ -66627,9 +66523,9 @@ xi
 wW
 wW
 wW
-wL
-wL
-wL
+ND
+ND
+ND
 yD
 yT
 wE

--- a/_maps/RandomZLevels/snowdin.dmm
+++ b/_maps/RandomZLevels/snowdin.dmm
@@ -9263,23 +9263,10 @@
 /turf/open/floor/plating/snowed,
 /area/awaymission/snowdin/cave)
 "xl" = (
-/obj/effect/baseturf_helper/asteroid/snow,
-/turf/closed/wall/ice,
-/area/shuttle/snowdin/elevator1)
-"xm" = (
-/obj/structure/window/reinforced/fulltile/ice,
-/obj/structure/grille,
-/turf/open/floor/plating,
-/area/shuttle/snowdin/elevator1)
-"xn" = (
-/obj/machinery/door/airlock/public/glass{
-	name = "Elevator Access"
+/turf/open/floor/plasteel/elevatorshaft{
+	initial_gas_mix = "o2=22;n2=82;TEMP=180"
 	},
-/turf/open/floor/plating,
-/area/shuttle/snowdin/elevator1)
-"xo" = (
-/turf/closed/wall/ice,
-/area/shuttle/snowdin/elevator1)
+/area/awaymission/snowdin/cave)
 "xp" = (
 /obj/effect/turf_decal/stripes/white/line{
 	dir = 8
@@ -9330,18 +9317,6 @@
 	},
 /turf/open/floor/engine/cult,
 /area/awaymission/snowdin/post/mining_dock)
-"xv" = (
-/turf/open/floor/engine,
-/area/shuttle/snowdin/elevator1)
-"xw" = (
-/obj/machinery/computer/shuttle/snowdin/mining{
-	dir = 2;
-	name = "Excavation Elevator Console";
-	possible_destinations = "snowdin_excavation_top;snowdin_excavation_down";
-	shuttleId = "snowdin_excavation"
-	},
-/turf/open/floor/engine,
-/area/shuttle/snowdin/elevator1)
 "xx" = (
 /obj/effect/spawner/lootdrop/crate_spawner,
 /turf/open/floor/plasteel/neutral,
@@ -9430,26 +9405,20 @@
 	},
 /area/awaymission/snowdin/post/mining_dock)
 "xK" = (
-/obj/machinery/door/airlock/public/glass{
-	name = "Elevator Access"
-	},
-/obj/docking_port/mobile/elevator{
-	dir = 4;
-	height = 6;
-	id = "snowdin_excavation";
-	name = "excavation elevator";
-	width = 6
-	},
 /obj/docking_port/stationary{
+	area_type = /area/awaymission/snowdin/cave;
 	dir = 4;
 	dwidth = 3;
 	height = 6;
 	id = "snowdin_excavation_top";
 	name = "snowdin excavation top";
+	roundstart_template = /datum/map_template/shuttle/snowdin/excavation;
 	width = 6
 	},
-/turf/open/floor/plating,
-/area/shuttle/snowdin/elevator1)
+/turf/open/floor/plasteel/elevatorshaft{
+	initial_gas_mix = "o2=22;n2=82;TEMP=180"
+	},
+/area/awaymission/snowdin/cave)
 "xL" = (
 /obj/machinery/atmospherics/pipe/manifold/orange/visible{
 	dir = 8
@@ -9476,6 +9445,7 @@
 /area/awaymission/snowdin/post/mining_dock)
 "xP" = (
 /obj/docking_port/stationary{
+	area_type = /area/awaymission/snowdin/post/mining_dock;
 	dir = 4;
 	dwidth = 3;
 	height = 6;
@@ -9483,7 +9453,7 @@
 	name = "snowdin excavation down";
 	width = 6
 	},
-/turf/open/floor/plating,
+/turf/open/floor/plasteel/elevatorshaft,
 /area/awaymission/snowdin/post/mining_dock)
 "xQ" = (
 /obj/effect/turf_decal/stripes/line{
@@ -9916,20 +9886,6 @@
 	name = "toxin out"
 	},
 /turf/open/floor/engine/vacuum,
-/area/awaymission/snowdin/cave)
-"zb" = (
-/obj/structure/window/reinforced/fulltile/ice,
-/obj/structure/grille,
-/obj/machinery/atmospherics/pipe/simple/orange/visible{
-	dir = 8
-	},
-/obj/machinery/atmospherics/components/unary/vent_pump/siphon/on{
-	dir = 4;
-	frequency = 1442;
-	id_tag = "snowdin_toxins_mine_1";
-	name = "toxin out"
-	},
-/turf/open/floor/plating,
 /area/awaymission/snowdin/cave)
 "zc" = (
 /obj/machinery/atmospherics/pipe/simple/orange/visible{
@@ -12308,13 +12264,6 @@
 /obj/effect/turf_decal/loading_area,
 /turf/open/floor/plating/snowed/cavern,
 /area/awaymission/snowdin/cave/cavern)
-"FP" = (
-/turf/open/floor/plating/asteroid/snow/ice,
-/obj/effect/turf_decal/stripes/corner{
-	dir = 1
-	},
-/turf/open/floor/plating/snowed/cavern,
-/area/awaymission/snowdin/cave/cavern)
 "FQ" = (
 /obj/effect/light_emitter{
 	name = "outdoor light";
@@ -12365,13 +12314,6 @@
 	pixel_y = -32
 	},
 /turf/open/floor/plating/asteroid/snow/ice,
-/area/awaymission/snowdin/cave/cavern)
-"FX" = (
-/turf/open/floor/plating/asteroid/snow/ice,
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/turf/open/floor/plating/snowed/cavern,
 /area/awaymission/snowdin/cave/cavern)
 "FY" = (
 /turf/open/floor/plating/asteroid/snow/ice,
@@ -13442,9 +13384,6 @@
 /turf/open/floor/plating,
 /area/awaymission/snowdin/post/mining_dock)
 "Jl" = (
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 8
-	},
 /obj/machinery/door/airlock/mining/glass{
 	name = "Mining Dock";
 	req_access_txt = "48"
@@ -13487,9 +13426,6 @@
 /turf/open/floor/plating/snowed/cavern,
 /area/awaymission/snowdin/cave/cavern)
 "Jr" = (
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 8
-	},
 /obj/machinery/door/airlock/mining/glass{
 	name = "Mining Dock";
 	req_access_txt = "48"
@@ -13650,23 +13586,8 @@
 	},
 /area/awaymission/snowdin/post/mining_main)
 "JQ" = (
-/obj/effect/baseturf_helper/asteroid/snow,
-/turf/closed/wall/rust,
-/area/shuttle/snowdin/elevator2)
-"JR" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/door/firedoor,
-/turf/open/floor/plating,
-/area/shuttle/snowdin/elevator2)
-"JS" = (
-/obj/machinery/door/airlock/public/glass{
-	name = "Elevator Access"
-	},
-/turf/open/floor/plating,
-/area/shuttle/snowdin/elevator2)
-"JT" = (
-/turf/closed/wall,
-/area/shuttle/snowdin/elevator2)
+/turf/open/floor/plasteel/elevatorshaft,
+/area/awaymission/snowdin/post/mining_main)
 "JU" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -13729,19 +13650,6 @@
 	dir = 8
 	},
 /area/awaymission/snowdin/post/mining_main)
-"Kd" = (
-/obj/machinery/computer/shuttle/snowdin/mining,
-/turf/open/floor/engine,
-/area/shuttle/snowdin/elevator2)
-"Ke" = (
-/turf/open/floor/engine,
-/area/shuttle/snowdin/elevator2)
-"Kf" = (
-/obj/machinery/light/small{
-	dir = 1
-	},
-/turf/open/floor/engine,
-/area/shuttle/snowdin/elevator2)
 "Kg" = (
 /obj/structure/ore_box,
 /obj/effect/turf_decal/bot,
@@ -13803,27 +13711,18 @@
 	},
 /area/awaymission/snowdin/post/mining_main)
 "Kn" = (
-/obj/machinery/door/airlock/public/glass{
-	name = "Elevator Access"
-	},
-/obj/docking_port/mobile/elevator{
-	dir = 4;
-	dwidth = 2;
-	height = 5;
-	id = "snowdin_mining";
-	name = "mining elevator";
-	width = 5
-	},
 /obj/docking_port/stationary{
+	area_type = /area/awaymission/snowdin/post/mining_main;
 	dir = 4;
 	dwidth = 2;
 	height = 5;
 	id = "snowdin_mining_top";
 	name = "snowdin mining top";
+	roundstart_template = /datum/map_template/shuttle/snowdin/mining;
 	width = 5
 	},
-/turf/open/floor/plating,
-/area/shuttle/snowdin/elevator2)
+/turf/open/floor/plasteel/elevatorshaft,
+/area/awaymission/snowdin/post/mining_main)
 "Ko" = (
 /obj/machinery/light{
 	dir = 4
@@ -13873,7 +13772,7 @@
 	name = "snowdin mining bottom";
 	width = 5
 	},
-/turf/open/floor/plating,
+/turf/open/floor/plasteel/elevatorshaft,
 /area/awaymission/snowdin/post/mining_dock)
 "Ku" = (
 /obj/machinery/light{
@@ -13942,10 +13841,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/awaymission/snowdin/post/mining_main)
-"KC" = (
-/obj/machinery/light/small,
-/turf/open/floor/engine,
-/area/shuttle/snowdin/elevator2)
 "KD" = (
 /obj/structure/ore_box,
 /obj/effect/turf_decal/bot,
@@ -14018,9 +13913,6 @@
 	dir = 4
 	},
 /area/awaymission/snowdin/post/mining_main)
-"KP" = (
-/turf/closed/wall/rust,
-/area/shuttle/snowdin/elevator2)
 "KQ" = (
 /obj/machinery/computer/shuttle/snowdin/mining{
 	dir = 8
@@ -14156,6 +14048,20 @@
 /obj/effect/mapping_helpers/airlock/cyclelink_helper,
 /turf/open/floor/plating,
 /area/awaymission/snowdin/post/mining_dock)
+"WK" = (
+/turf/open/floor/plating/asteroid/snow/ice,
+/obj/effect/turf_decal/stripes/corner{
+	dir = 1
+	},
+/turf/open/floor/plating/snowed/cavern,
+/area/awaymission/snowdin/cave/cavern)
+"XO" = (
+/turf/open/floor/plating/asteroid/snow/ice,
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/turf/open/floor/plating/snowed/cavern,
+/area/awaymission/snowdin/cave/cavern)
 "Yn" = (
 /obj/machinery/door/airlock/external/glass,
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
@@ -14163,6 +14069,9 @@
 	},
 /turf/open/floor/plating,
 /area/awaymission/snowdin/post/garage)
+"Ys" = (
+/turf/open/floor/plasteel/elevatorshaft,
+/area/awaymission/snowdin/post/mining_dock)
 
 (1,1,1) = {"
 aa
@@ -28201,7 +28110,7 @@ wS
 wS
 ai
 yf
-zb
+yt
 ai
 wS
 wS
@@ -28285,10 +28194,10 @@ IY
 Go
 Jx
 JQ
-JR
+JQ
 Kn
-JR
-JT
+JQ
+JQ
 KT
 Go
 ac
@@ -28440,7 +28349,7 @@ ii
 yb
 an
 yf
-zb
+yt
 yf
 ai
 ai
@@ -28541,11 +28450,11 @@ Gq
 Gq
 Go
 Jx
-JR
-Kd
-Ke
-KC
-JR
+JQ
+JQ
+JQ
+JQ
+JQ
 KT
 GP
 ac
@@ -28798,11 +28707,11 @@ Iy
 Iy
 Go
 Jy
-JS
-Ke
-Ke
-Ke
-JS
+JQ
+JQ
+JQ
+JQ
+JQ
 KU
 GP
 ac
@@ -29055,11 +28964,11 @@ GP
 GP
 GP
 Jx
-JR
-Kf
-Ke
-Ke
-JR
+JQ
+JQ
+JQ
+JQ
+JQ
 KT
 GP
 ac
@@ -29312,11 +29221,11 @@ ae
 ae
 Go
 Jx
-JT
-JR
-JS
-JR
-KP
+JQ
+JQ
+JQ
+JQ
+JQ
 KT
 GP
 ac
@@ -30232,11 +30141,11 @@ ae
 aj
 xa
 xl
-xm
-xn
+xl
+xl
 xK
-xm
-xo
+xl
+xl
 an
 ii
 ii
@@ -30488,12 +30397,12 @@ ae
 ae
 aj
 xa
-xm
-xv
-xv
-xv
-xv
-xm
+xl
+xl
+xl
+xl
+xl
+xl
 yp
 ii
 wS
@@ -30745,12 +30654,12 @@ ae
 wQ
 ai
 xb
-xn
-xv
-xv
-xv
-xv
-xn
+xl
+xl
+xl
+xl
+xl
+xl
 yq
 ii
 wS
@@ -31002,12 +30911,12 @@ ae
 wQ
 ai
 xb
-xn
-xv
-xv
-xv
-xv
-xn
+xl
+xl
+xl
+xl
+xl
+xl
 yq
 an
 ii
@@ -31259,12 +31168,12 @@ ae
 wQ
 wS
 xa
-xm
-xw
-xv
-xv
-xv
-xm
+xl
+xl
+xl
+xl
+xl
+xl
 yr
 an
 ii
@@ -31516,12 +31425,12 @@ ae
 wQ
 wS
 xa
-xo
-xm
-xn
-xn
-xm
-xo
+xl
+xl
+xl
+xl
+xl
+xl
 yp
 an
 an
@@ -62465,11 +62374,11 @@ IO
 wL
 wE
 JH
-wL
-wL
+Ys
+Ys
 Kt
-wL
-wL
+Ys
+Ys
 KX
 wE
 bh
@@ -62722,11 +62631,11 @@ IQ
 wL
 wE
 JH
-wL
-wL
-wL
-wL
-wL
+Ys
+Ys
+Ys
+Ys
+Ys
 KX
 wE
 bh
@@ -62979,11 +62888,11 @@ wL
 wL
 wE
 JI
-wL
-wL
-wL
-wL
-wL
+Ys
+Ys
+Ys
+Ys
+Ys
 KY
 wE
 bh
@@ -63236,11 +63145,11 @@ wL
 wL
 wE
 JH
-wL
-wL
-wL
-wL
-wL
+Ys
+Ys
+Ys
+Ys
+Ys
 KX
 wE
 bh
@@ -63493,11 +63402,11 @@ wL
 wL
 wD
 JH
-wL
-wL
-wL
-wL
-wL
+Ys
+Ys
+Ys
+Ys
+Ys
 KX
 wD
 bh
@@ -64252,7 +64161,7 @@ oZ
 oZ
 oZ
 FN
-FX
+XO
 Gk
 GN
 Hj
@@ -64765,7 +64674,7 @@ oZ
 oZ
 oZ
 oZ
-FP
+WK
 xW
 xW
 xW
@@ -65440,12 +65349,12 @@ eJ
 wE
 wV
 xg
-wL
-wL
-wL
+Ys
+Ys
+Ys
 xP
-wL
-wL
+Ys
+Ys
 yz
 yR
 wD
@@ -65697,12 +65606,12 @@ eJ
 wD
 wW
 xg
-wL
-wL
-wL
-wL
-wL
-wL
+Ys
+Ys
+Ys
+Ys
+Ys
+Ys
 yA
 wM
 zm
@@ -65954,12 +65863,12 @@ wD
 wP
 wX
 xg
-wL
-wL
-wL
-wL
-wL
-wL
+Ys
+Ys
+Ys
+Ys
+Ys
+Ys
 yB
 xy
 zn
@@ -66212,11 +66121,11 @@ wP
 wW
 xh
 wW
-wL
-wL
-wL
-wL
-wL
+Ys
+Ys
+Ys
+Ys
+Ys
 yB
 xy
 zn
@@ -66470,10 +66379,10 @@ wW
 xh
 wW
 wW
-wW
-wL
-wL
-wL
+Ys
+Ys
+Ys
+Ys
 yC
 yS
 zm
@@ -66728,9 +66637,9 @@ xi
 wW
 wW
 wW
-wL
-wL
-wL
+Ys
+Ys
+Ys
 yD
 yT
 wE

--- a/_maps/RandomZLevels/undergroundoutpost45.dmm
+++ b/_maps/RandomZLevels/undergroundoutpost45.dmm
@@ -7778,10 +7778,7 @@
 	dir = 2;
 	id = "UO45_air_in"
 	},
-/turf/open/floor/engine{
-	name = "air floor";
-	initial_gas_mix = "n2=10580;o2=2644"
-	},
+/turf/open/floor/engine/air,
 /area/awaymission/undergroundoutpost45/engineering)
 "pG" = (
 /obj/structure/cable{
@@ -12603,6 +12600,15 @@
 /obj/effect/mapping_helpers/planet_z,
 /turf/open/space,
 /area/space/nearstation)
+"KE" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on{
+	dir = 4
+	},
+/turf/open/floor/circuit{
+	name = "Server Base";
+	initial_gas_mix = "n2=500,TEMP=80"
+	},
+/area/awaymission/undergroundoutpost45/research)
 
 (1,1,1) = {"
 aa
@@ -37925,7 +37931,7 @@ gz
 gz
 gz
 gz
-qh
+KE
 qP
 qh
 gz

--- a/_maps/shuttles/snowdin_excavation.dmm
+++ b/_maps/shuttles/snowdin_excavation.dmm
@@ -1,0 +1,90 @@
+//MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
+"a" = (
+/obj/machinery/door/airlock/public/glass{
+	name = "Elevator Access"
+	},
+/obj/docking_port/mobile/elevator{
+	dir = 4;
+	height = 6;
+	id = "snowdin_excavation";
+	name = "excavation elevator";
+	timid = 1;
+	width = 6
+	},
+/turf/open/floor/plating,
+/area/shuttle/snowdin/elevator1)
+"b" = (
+/obj/structure/window/reinforced/fulltile/ice,
+/obj/structure/grille,
+/turf/open/floor/plating,
+/area/shuttle/snowdin/elevator1)
+"c" = (
+/obj/machinery/door/airlock/public/glass{
+	name = "Elevator Access"
+	},
+/turf/open/floor/plating,
+/area/shuttle/snowdin/elevator1)
+"d" = (
+/turf/closed/wall/ice,
+/area/shuttle/snowdin/elevator1)
+"e" = (
+/turf/open/floor/engine,
+/area/shuttle/snowdin/elevator1)
+"f" = (
+/obj/machinery/computer/shuttle/snowdin/mining{
+	dir = 2;
+	name = "Excavation Elevator Console";
+	possible_destinations = "snowdin_excavation_top;snowdin_excavation_down";
+	shuttleId = "snowdin_excavation"
+	},
+/turf/open/floor/engine,
+/area/shuttle/snowdin/elevator1)
+
+(1,1,1) = {"
+d
+b
+c
+a
+b
+d
+"}
+(2,1,1) = {"
+b
+e
+e
+e
+e
+b
+"}
+(3,1,1) = {"
+c
+e
+e
+e
+e
+c
+"}
+(4,1,1) = {"
+c
+e
+e
+e
+e
+c
+"}
+(5,1,1) = {"
+b
+f
+e
+e
+e
+b
+"}
+(6,1,1) = {"
+d
+b
+c
+c
+b
+d
+"}

--- a/_maps/shuttles/snowdin_mining.dmm
+++ b/_maps/shuttles/snowdin_mining.dmm
@@ -1,0 +1,86 @@
+//MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
+"a" = (
+/obj/machinery/door/airlock/public/glass{
+	name = "Elevator Access"
+	},
+/obj/docking_port/mobile/elevator{
+	dir = 4;
+	dwidth = 2;
+	height = 5;
+	id = "snowdin_mining";
+	name = "mining elevator";
+	timid = 1;
+	width = 5
+	},
+/turf/open/floor/plating,
+/area/shuttle/snowdin/elevator2)
+"b" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/door/firedoor,
+/turf/open/floor/plating,
+/area/shuttle/snowdin/elevator2)
+"c" = (
+/obj/machinery/door/airlock/public/glass{
+	name = "Elevator Access"
+	},
+/turf/open/floor/plating,
+/area/shuttle/snowdin/elevator2)
+"d" = (
+/turf/closed/wall,
+/area/shuttle/snowdin/elevator2)
+"e" = (
+/obj/machinery/computer/shuttle/snowdin/mining,
+/turf/open/floor/engine,
+/area/shuttle/snowdin/elevator2)
+"f" = (
+/turf/open/floor/engine,
+/area/shuttle/snowdin/elevator2)
+"g" = (
+/obj/machinery/light/small{
+	dir = 1
+	},
+/turf/open/floor/engine,
+/area/shuttle/snowdin/elevator2)
+"i" = (
+/obj/machinery/light/small,
+/turf/open/floor/engine,
+/area/shuttle/snowdin/elevator2)
+"j" = (
+/turf/closed/wall/rust,
+/area/shuttle/snowdin/elevator2)
+
+(1,1,1) = {"
+j
+b
+a
+b
+d
+"}
+(2,1,1) = {"
+b
+e
+f
+i
+b
+"}
+(3,1,1) = {"
+c
+f
+f
+f
+c
+"}
+(4,1,1) = {"
+b
+g
+f
+f
+b
+"}
+(5,1,1) = {"
+d
+b
+c
+b
+j
+"}

--- a/code/datums/shuttles.dm
+++ b/code/datums/shuttles.dm
@@ -94,6 +94,10 @@
 	port_id = "ruin"
 	can_be_bought = FALSE
 
+/datum/map_template/shuttle/snowdin
+	port_id = "snowdin"
+	can_be_bought = FALSE
+
 // Shuttles start here:
 
 /datum/map_template/shuttle/emergency/airless
@@ -431,3 +435,11 @@
 /datum/map_template/shuttle/ruin/syndicate_fighter
 	suffix = "syndicate_fighter"
 	name = "Syndicate Fighter"
+
+/datum/map_template/shuttle/snowdin/mining
+	suffix = "mining"
+	name = "Snowdin Mining Elevator"
+
+/datum/map_template/shuttle/snowdin/excavation
+	suffix = "excavation"
+	name = "Snowdin Excavation Elevator"


### PR DESCRIPTION
:cl:
fix: The elevators in the Snowdin away and VR missions work again.
fix: Minor atmos issues in Snowdin and UO45 have been corrected.
/:cl:

Also fixes a few stacked turfs causing really quite odd overlay issues.

@ninjanomnom Can you double-check me on this? I had some issues with baseturfs once then couldn't reproduce them:

```
[21:19:57] Runtime in change_turf.dm, line 80: Cannot create objects of type /list.
proc name: ChangeTurf (/turf/proc/ChangeTurf)
usr: Joe Bine (spacemaniac) (/mob/dead/observer)
usr.loc: The floor (206,120,4) (/turf/open/floor/plasteel/neutral/side)
src: the plating (201,123,4) (/turf/open/floor/plating)
call stack:
the plating (201,123,4) (/turf/open/floor/plating): ChangeTurf(/list (/list), /turf/open/floor/plating/aster... (/turf/open/floor/plating/asteroid/snow/ice), null)
the plating (201,123,4) (/turf/open/floor/plating): ChangeTurf(/list (/list), /turf/open/floor/plating/aster... (/turf/open/floor/plating/asteroid/snow/ice), null)
the plating (201,123,4) (/turf/open/floor/plating): ScrapeAway(5, null)
the plating (64,123,4) (/turf/open/floor/plating): afterShuttleMove(the plating (201,123,4) (/turf/open/floor/plating), 0)
the excavation elevator (/obj/docking_port/mobile/elevator): cleanup runway(the snowdin excavation top (/obj/docking_port/stationary), /list (/list), /list (/list), /list (/list), /list (/list), 0, 1, Space (/area/space))
the excavation elevator (/obj/docking_port/mobile/elevator): initiate docking(the snowdin excavation top (/obj/docking_port/stationary), 1, 0)
the excavation elevator (/obj/docking_port/mobile/elevator): request(the snowdin excavation top (/obj/docking_port/stationary))
Shuttle (/datum/controller/subsystem/shuttle): moveShuttle("snowdin_excavation", "snowdin_excavation_top", 1)
Excavation Elevator Console (/obj/machinery/computer/shuttle/snowdin/mining): Topic("src=\[0x20213b5];move=snowdin_...", /list (/list))
SpaceManiac (/client): Topic("src=\[0x20213b5];move=snowdin_...", /list (/list), Excavation Elevator Console (/obj/machinery/computer/shuttle/snowdin/mining))
SpaceManiac (/client): Topic("src=\[0x20213b5];move=snowdin_...", /list (/list), Excavation Elevator Console (/obj/machinery/computer/shuttle/snowdin/mining))
```

```
(E) (C) (-) 1 = /turf/open/floor/plating/asteroid/snow 
(E) (C) (-) 2 = /turf/open/floor/plating/asteroid/snow 
(E) (C) (-) 3 = /turf/baseturf_skipover/shuttle 
(E) (C) (-) 4 = /turf/open/floor/plating 
(E) (C) (-) 5 = /turf/baseturf_skipover/shuttle 
(E) (C) (-) 6 = /turf/open/floor/plating 
(E) (C) (-) 7 = /turf/baseturf_skipover/shuttle 
(E) (C) (-) 8 = /turf/open/floor/plating 
(E) (C) (-) 9 = /turf/baseturf_skipover/shuttle 
(E) (C) (-) 10 = /turf/open/floor/plating 
...
(E) (C) (-) 1273 = /turf/baseturf_skipover/shuttle 
(E) (C) (-) 1274 = /turf/open/floor/plating 
(E) (C) (-) 1275 = /turf/baseturf_skipover/shuttle 
(E) (C) (-) 1276 = /turf/open/floor/plating 
(E) (C) (-) 1277 = /turf/baseturf_skipover/shuttle 
(E) (C) (-) 1278 = /turf/open/floor/plating 
(E) (C) (-) 1279 = /turf/baseturf_skipover/shuttle 
(E) (C) (-) 1280 = /turf/open/floor/plating 
(E) (C) (-) 1281 = /turf/baseturf_skipover/shuttle 
```

![image](https://user-images.githubusercontent.com/222630/40761913-a76de726-6452-11e8-9214-975cb3c85b8f.png)