### PR TITLE
Set cult floor effects to be on the floor plane

### DIFF
--- a/code/game/objects/effects/temporary_visuals/cult.dm
+++ b/code/game/objects/effects/temporary_visuals/cult.dm
@@ -47,6 +47,7 @@
 /obj/effect/temp_visual/cult/turf/floor
 	icon_state = "floorglow"
 	duration = 5
+	plane = FLOOR_PLANE
 
 /obj/effect/temp_visual/cult/portal
 	icon_state = "space"

--- a/code/modules/antagonists/clockcult/clock_effects/clock_overlay.dm
+++ b/code/modules/antagonists/clockcult/clock_effects/clock_overlay.dm
@@ -44,6 +44,7 @@
 	icon = 'icons/turf/floors.dmi'
 	icon_state = "clockwork_floor"
 	layer = TURF_LAYER
+	plane = FLOOR_PLANE
 
 /obj/effect/clockwork/overlay/floor/bloodcult //this is used by BLOOD CULT, it shouldn't use such a path...
 	icon_state = "cult"


### PR DESCRIPTION
:cl:
fix: The overlay effects of cult flooring are now on the floor plane, fixing their odd ambient occlusion appearance.
/:cl:

These overlays are used to prevent the floor being visible through mesons; the effects are logically part of the floor and should be on the floor plane, it doesn't make sense for them to have shadows.