### PR TITLE
Blacklist projectile effects from chasms

### DIFF
--- a/code/datums/components/chasm.dm
+++ b/code/datums/components/chasm.dm
@@ -11,6 +11,7 @@
 		/obj/structure/lattice,
 		/obj/structure/stone_tile,
 		/obj/item/projectile,
+		/obj/effect/projectile,
 		/obj/effect/portal,
 		/obj/effect/abstract,
 		/obj/effect/hotspot,


### PR DESCRIPTION
:cl:
fix: Beam rifle tracers no longer fall into chasms.
/:cl:

Fixes #37807.