### PR TITLE
fixes a locate and adds job checks to download objective

### DIFF
--- a/code/modules/antagonists/traitor/datum_traitor.dm
+++ b/code/modules/antagonists/traitor/datum_traitor.dm
@@ -164,7 +164,7 @@
 			kill_objective.find_target()
 			add_objective(kill_objective)
 	else
-		if(prob(15) && !(locate(/datum/objective/download in owner.objectives)))
+		if(prob(15) && !(locate(/datum/objective/download) in owner.objectives) && !(owner.assigned_role in list("Research Director", "Scientist", "Roboticist")))
 			var/datum/objective/download/download_objective = new
 			download_objective.owner = owner
 			download_objective.gen_amount_goal()


### PR DESCRIPTION
Fixes #38183

:cl: Nichlas0010
fix: You now can't get multiple download objectives!
tweak: RDs, Scientists and Roboticists can no longer get download objectives!
/:cl:

[why]: # @SpaceManiac 
