### PR TITLE
Debate: Autoclose inactive issues after X days

### DIFF
--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -29,3 +29,6 @@ markComment: >
   This issue has been automatically marked as stale because it has not had
   recent activity. It will be closed if no further activity occurs. Please
   comment if this issue is still relevent/reproducable
+
+#action limit per hour
+limitPerRun: 1

--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -1,0 +1,31 @@
+# Configuration for probot-stale - https://github.com/probot/stale
+
+# Number of days of inactivity before an Issue or Pull Request becomes stale
+daysUntilStale: 365
+
+# Number of days of inactivity before a stale Issue or Pull Request is closed.
+# Set to false to disable. If disabled, issues still need to be closed manually, but will remain marked as stale.
+daysUntilClose: 3
+
+# Issues or Pull Requests with these labels will never be considered stale. Set to `[]` to disable
+exemptLabels:
+  - BYOND Issue
+  - Priority: High
+  - Priority: Critical
+  - Maintainability/Hinders improvements 
+  - Performance
+
+# Set to true to ignore issues in a project (defaults to false)
+exemptProjects: true
+
+# Set to true to ignore issues in a milestone (defaults to false)
+exemptMilestones: true
+
+# Label to use when marking as stale
+staleLabel: Stale
+
+# Comment to post when marking as stale. Set to `false` to disable
+markComment: >
+  This issue has been automatically marked as stale because it has not had
+  recent activity. It will be closed if no further activity occurs. Please
+  comment if this issue is still relevent/reproducable


### PR DESCRIPTION
Currently set to a year, up for debate. Any activity will prevent closure (that means any user comment). This is mainly to help trim down the issues list of the crap that no one will ever bother to look at again. If people care enough, they can comment to prevent a closure. Currently limited to actioning on 1 issue per hour to prevent the massive influx of closure notifications it'll cause.

@tgstation/commit-access 

If we decide to do this @KorPhaeron has to install it here: https://github.com/apps/stale