### PR TITLE
Fix reagents being lost when vomit piles combine

### DIFF
--- a/code/game/atoms.dm
+++ b/code/game/atoms.dm
@@ -426,23 +426,6 @@
 /atom/proc/update_remote_sight(mob/living/user)
 	return
 
-/atom/proc/add_vomit_floor(mob/living/carbon/M, toxvomit = 0)
-	if(isturf(src))
-		var/obj/effect/decal/cleanable/vomit/V = new /obj/effect/decal/cleanable/vomit(src, M.get_static_viruses())
-		// Make toxins vomit look different
-		if(toxvomit)
-			V.icon_state = "vomittox_[pick(1,4)]"
-		if(M.reagents)
-			clear_reagents_to_vomit_pool(M,V)
-
-/atom/proc/clear_reagents_to_vomit_pool(mob/living/carbon/M, obj/effect/decal/cleanable/vomit/V)
-	M.reagents.trans_to(V, M.reagents.total_volume / 10)
-	for(var/datum/reagent/R in M.reagents.reagent_list)                //clears the stomach of anything that might be digested as food
-		if(istype(R, /datum/reagent/consumable))
-			var/datum/reagent/consumable/nutri_check = R
-			if(nutri_check.nutriment_factor >0)
-				M.reagents.remove_reagent(R.id,R.volume)
-
 
 //Hook for running code when a dir change occurs
 /atom/proc/setDir(newdir)

--- a/code/game/turfs/turf.dm
+++ b/code/game/turfs/turf.dm
@@ -438,3 +438,22 @@
 
 /turf/AllowDrop()
 	return TRUE
+
+/turf/proc/add_vomit_floor(mob/living/carbon/M, toxvomit = 0)
+	var/obj/effect/decal/cleanable/vomit/V = new /obj/effect/decal/cleanable/vomit(src, M.get_static_viruses())
+	// If the vomit combined, apply toxicity and reagents to the old vomit
+	if (QDELETED(V))
+		V = locate() in src
+	// Make toxins vomit look different
+	if(toxvomit)
+		V.icon_state = "vomittox_[pick(1,4)]"
+	if(M.reagents)
+		clear_reagents_to_vomit_pool(M,V)
+
+/proc/clear_reagents_to_vomit_pool(mob/living/carbon/M, obj/effect/decal/cleanable/vomit/V)
+	M.reagents.trans_to(V, M.reagents.total_volume / 10)
+	for(var/datum/reagent/R in M.reagents.reagent_list)                //clears the stomach of anything that might be digested as food
+		if(istype(R, /datum/reagent/consumable))
+			var/datum/reagent/consumable/nutri_check = R
+			if(nutri_check.nutriment_factor >0)
+				M.reagents.remove_reagent(R.id,R.volume)


### PR DESCRIPTION
:cl:
fix: Vomiting on the same tile a second time no deletes the vomited reagents.
/:cl:

Fixes #15879.