### PR TITLE
Fix mecha mouse pointer issues

### DIFF
--- a/code/game/mecha/combat/combat.dm
+++ b/code/game/mecha/combat/combat.dm
@@ -2,27 +2,4 @@
 	force = 30
 	internal_damage_threshold = 50
 	armor = list("melee" = 30, "bullet" = 30, "laser" = 15, "energy" = 20, "bomb" = 20, "bio" = 0, "rad" = 0, "fire" = 100, "acid" = 100)
-
-/obj/mecha/combat/moved_inside(mob/living/carbon/human/H)
-	if(..())
-		if(H.client && H.client.mouse_pointer_icon == initial(H.client.mouse_pointer_icon))
-			H.client.mouse_pointer_icon = 'icons/mecha/mecha_mouse.dmi'
-		return 1
-	else
-		return 0
-
-/obj/mecha/combat/mmi_moved_inside(obj/item/mmi/mmi_as_oc,mob/user)
-	if(..())
-		if(occupant.client && occupant.client.mouse_pointer_icon == initial(occupant.client.mouse_pointer_icon))
-			occupant.client.mouse_pointer_icon = 'icons/mecha/mecha_mouse.dmi'
-		return 1
-	else
-		return 0
-
-
-/obj/mecha/combat/go_out()
-	if(occupant && occupant.client && occupant.client.mouse_pointer_icon == 'icons/mecha/mecha_mouse.dmi')
-		occupant.client.mouse_pointer_icon = initial(occupant.client.mouse_pointer_icon)
-	..()
-
-
+	mouse_pointer = 'icons/mecha/mecha_mouse.dmi'

--- a/code/game/mecha/mecha.dm
+++ b/code/game/mecha/mecha.dm
@@ -115,6 +115,7 @@
 	var/smashcooldown = 3	//deciseconds
 
 	var/occupant_sight_flags = 0 //sight flags to give to the occupant (e.g. mech mining scanner gives meson-like vision)
+	var/mouse_pointer
 
 	hud_possible = list (DIAG_STAT_HUD, DIAG_BATT_HUD, DIAG_MECH_HUD, DIAG_TRACK_HUD)
 
@@ -855,6 +856,7 @@
 	if(H && H.client && H in range(1))
 		occupant = H
 		H.forceMove(src)
+		H.update_mouse_pointer()
 		add_fingerprint(H)
 		GrantActions(H, human_occupant=1)
 		forceMove(loc)
@@ -912,6 +914,7 @@
 	brainmob.reset_perspective(src)
 	brainmob.remote_control = src
 	brainmob.update_canmove()
+	brainmob.update_mouse_pointer()
 	icon_state = initial(icon_state)
 	update_icon()
 	setDir(dir_in)
@@ -981,6 +984,7 @@
 		setDir(dir_in)
 
 	if(L && L.client)
+		L.update_mouse_pointer()
 		L.client.change_view(CONFIG_GET(string/default_view))
 		zoom_mode = 0
 

--- a/code/modules/antagonists/cult/blood_magic.dm
+++ b/code/modules/antagonists/cult/blood_magic.dm
@@ -271,7 +271,6 @@
 		attached_action.desc += "<br><b><u>Has [attached_action.charges] use\s remaining</u></b>."
 		attached_action.UpdateButtonIcon()
 		if(attached_action.charges <= 0)
-			remove_mousepointer(ranged_ability_user.client)
 			remove_ranged_ability("<span class='cult'>You have exhausted the spell's power!</span>")
 			qdel(src)
 

--- a/code/modules/antagonists/cult/cult_comms.dm
+++ b/code/modules/antagonists/cult/cult_comms.dm
@@ -457,7 +457,6 @@
 			new /obj/effect/temp_visual/cult/sparks(get_turf(target), ranged_ability_user.dir)
 			attached_action.throwing = FALSE
 			attached_action.cooldown = world.time + attached_action.base_cooldown
-			remove_mousepointer(ranged_ability_user.client)
 			remove_ranged_ability("<span class='cult'>A pulse of blood magic surges through you as you shift [attached_action.throwee] through time and space.</span>")
 			caller.update_action_buttons_icon()
 			addtimer(CALLBACK(caller, /mob.proc/update_action_buttons_icon), attached_action.base_cooldown)

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -35,14 +35,6 @@
 	QDEL_LIST(diseases)
 	return ..()
 
-/mob/living/ghostize(can_reenter_corpse = 1)
-	var/prev_client = client
-	. = ..()
-	if(.)
-		if(ranged_ability && prev_client)
-			ranged_ability.remove_mousepointer(prev_client)
-
-
 /mob/living/proc/OpenCraftingMenu()
 	return
 
@@ -1113,6 +1105,11 @@
 		else
 			clear_fullscreen("remote_view", 0)
 		update_pipe_vision()
+
+/mob/living/update_mouse_pointer()
+	..()
+	if (client && ranged_ability && ranged_ability.ranged_mousepointer)
+		client.mouse_pointer_icon = ranged_ability.ranged_mousepointer
 
 /mob/living/vv_edit_var(var_name, var_value)
 	switch(var_name)

--- a/code/modules/mob/living/logout.dm
+++ b/code/modules/mob/living/logout.dm
@@ -1,7 +1,5 @@
 /mob/living/Logout()
 	update_z(null)
-	if(ranged_ability && client)
-		ranged_ability.remove_mousepointer(client)
 	..()
 	if(!key && mind)	//key and mind have become separated.
 		mind.active = 0	//This is to stop say, a mind.transfer_to call on a corpse causing a ghost to re-enter its body.

--- a/code/modules/mob/login.dm
+++ b/code/modules/mob/login.dm
@@ -39,6 +39,7 @@
 		AA.onNewMob(src)
 
 	update_client_colour()
+	update_mouse_pointer()
 	if(client)
 		client.click_intercept = null
 

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -836,6 +836,15 @@
 		if (L)
 			L.alpha = lighting_alpha
 
+/mob/proc/update_mouse_pointer()
+	if (!client)
+		return
+	client.mouse_pointer_icon = initial(client.mouse_pointer_icon)
+	if (ismecha(loc))
+		var/obj/mecha/M = loc
+		if(M.mouse_pointer)
+			client.mouse_pointer_icon = M.mouse_pointer
+
 /mob/proc/is_literate()
 	return 0
 

--- a/code/modules/spells/spell.dm
+++ b/code/modules/spells/spell.dm
@@ -68,27 +68,19 @@ GLOBAL_LIST_INIT(spells, typesof(/obj/effect/proc_holder/spell)) //needed for th
 			return
 	user.ranged_ability = src
 	user.click_intercept = src
-	add_mousepointer(user.client)
+	user.update_mouse_pointer()
 	ranged_ability_user = user
 	if(msg)
 		to_chat(ranged_ability_user, msg)
 	active = TRUE
 	update_icon()
 
-/obj/effect/proc_holder/proc/add_mousepointer(client/C)
-	if(C && ranged_mousepointer && C.mouse_pointer_icon == initial(C.mouse_pointer_icon))
-		C.mouse_pointer_icon = ranged_mousepointer
-
-/obj/effect/proc_holder/proc/remove_mousepointer(client/C)
-	if(C && ranged_mousepointer && C.mouse_pointer_icon == ranged_mousepointer)
-		C.mouse_pointer_icon = initial(C.mouse_pointer_icon)
-
 /obj/effect/proc_holder/proc/remove_ranged_ability(msg)
 	if(!ranged_ability_user || !ranged_ability_user.client || (ranged_ability_user.ranged_ability && ranged_ability_user.ranged_ability != src)) //To avoid removing the wrong ability
 		return
 	ranged_ability_user.ranged_ability = null
 	ranged_ability_user.click_intercept = null
-	remove_mousepointer(ranged_ability_user.client)
+	ranged_ability_user.update_mouse_pointer()
 	if(msg)
 		to_chat(ranged_ability_user, msg)
 	ranged_ability_user = null


### PR DESCRIPTION
:cl:
fix: Switching mobs into/out of a mech (by VR, ghosting, or mindswap) no longer improperly applies the mech's cursor.
/:cl:

Fixes #38204. Also makes it easier to apply cursors to other mechs if anyone ever wants to do that.