### PR TITLE
Making sparks not heat up the air.

### DIFF
--- a/code/game/objects/effects/effect_system/effects_sparks.dm
+++ b/code/game/objects/effects/effect_system/effects_sparks.dm
@@ -28,20 +28,20 @@
 	playsound(src.loc, "sparks", 100, 1)
 	var/turf/T = loc
 	if(isturf(T))
-		T.hotspot_expose(1000,100,0,1)
+		T.hotspot_expose(1000,100,FALSE,TRUE)
 	QDEL_IN(src, 20)
 
 /obj/effect/particle_effect/sparks/Destroy()
 	var/turf/T = loc
 	if(isturf(T))
-		T.hotspot_expose(1000,100,0,1)
+		T.hotspot_expose(1000,100,FALSE,TRUE)
 	return ..()
 
 /obj/effect/particle_effect/sparks/Move()
 	..()
 	var/turf/T = loc
 	if(isturf(T))
-		T.hotspot_expose(1000,100,0,1)
+		T.hotspot_expose(1000,100,FALSE,TRUE)
 
 /datum/effect_system/spark_spread
 	effect_type = /obj/effect/particle_effect/sparks

--- a/code/game/objects/effects/effect_system/effects_sparks.dm
+++ b/code/game/objects/effects/effect_system/effects_sparks.dm
@@ -28,20 +28,20 @@
 	playsound(src.loc, "sparks", 100, 1)
 	var/turf/T = loc
 	if(isturf(T))
-		T.hotspot_expose(1000,100)
+		T.hotspot_expose(1000,100,0,1)
 	QDEL_IN(src, 20)
 
 /obj/effect/particle_effect/sparks/Destroy()
 	var/turf/T = loc
 	if(isturf(T))
-		T.hotspot_expose(1000,100)
+		T.hotspot_expose(1000,100,0,1)
 	return ..()
 
 /obj/effect/particle_effect/sparks/Move()
 	..()
 	var/turf/T = loc
 	if(isturf(T))
-		T.hotspot_expose(1000,100)
+		T.hotspot_expose(1000,100,0,1)
 
 /datum/effect_system/spark_spread
 	effect_type = /obj/effect/particle_effect/sparks

--- a/code/modules/atmospherics/environmental/LINDA_fire.dm
+++ b/code/modules/atmospherics/environmental/LINDA_fire.dm
@@ -5,11 +5,11 @@
 
 
 
-/turf/proc/hotspot_expose(exposed_temperature, exposed_volume, soh = 0, heatless = 0)
+/turf/proc/hotspot_expose(exposed_temperature, exposed_volume, soh, noheat)
 	return
 
 
-/turf/open/hotspot_expose(exposed_temperature, exposed_volume, soh, heatless)
+/turf/open/hotspot_expose(exposed_temperature, exposed_volume, soh, noheat)
 	var/datum/gas_mixture/air_contents = return_air()
 	if(!air_contents)
 		return 0
@@ -43,7 +43,7 @@
 			//remove just_spawned protection if no longer processing this cell
 		SSair.add_to_active(src, 0)
 	else
-		if(heatless == 1)
+		if(noheat)
 			return
 		var/datum/gas_mixture/heating = air_contents.remove_ratio(exposed_volume/air_contents.volume)
 		heating.temperature = exposed_temperature

--- a/code/modules/atmospherics/environmental/LINDA_fire.dm
+++ b/code/modules/atmospherics/environmental/LINDA_fire.dm
@@ -264,3 +264,4 @@
 	if(!isliving(loc))
 		return INITIALIZE_HINT_QDEL
 #undef INSUFFICIENT
+

--- a/code/modules/atmospherics/environmental/LINDA_fire.dm
+++ b/code/modules/atmospherics/environmental/LINDA_fire.dm
@@ -5,11 +5,11 @@
 
 
 
-/turf/proc/hotspot_expose(exposed_temperature, exposed_volume, soh = 0)
+/turf/proc/hotspot_expose(exposed_temperature, exposed_volume, soh = 0, heatless = 0)
 	return
 
 
-/turf/open/hotspot_expose(exposed_temperature, exposed_volume, soh)
+/turf/open/hotspot_expose(exposed_temperature, exposed_volume, soh, heatless)
 	var/datum/gas_mixture/air_contents = return_air()
 	if(!air_contents)
 		return 0
@@ -43,6 +43,8 @@
 			//remove just_spawned protection if no longer processing this cell
 		SSair.add_to_active(src, 0)
 	else
+		if(heatless == 1)
+			return
 		var/datum/gas_mixture/heating = air_contents.remove_ratio(exposed_volume/air_contents.volume)
 		heating.temperature = exposed_temperature
 		heating.react()


### PR DESCRIPTION
Pretty sure this should affect nothing except sparks, and prevent them from heating the air. The code for the air heating is a bit jank though, looking at it; seems like if there's enough plasma or tritium in the air to ignite, regardless of whether or not there's any oxygen to burn with, open flames will never heat the air?

That seems wrong, maybe we should change that.