### PR TITLE
Slight changes to camera network code

### DIFF
--- a/_maps/map_files/BoxStation/BoxStation.dmm
+++ b/_maps/map_files/BoxStation/BoxStation.dmm
@@ -12246,7 +12246,6 @@
 "aFe" = (
 /obj/machinery/camera{
 	c_tag = "Dormitory South";
-	c_tag_order = 999;
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{

--- a/_maps/shuttles/aux_base_default.dmm
+++ b/_maps/shuttles/aux_base_default.dmm
@@ -1,4 +1,4 @@
-//MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE 
+//MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
 "b" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -44,10 +44,6 @@
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plating,
 /area/shuttle/auxillary_base)
-"y" = (
-/obj/effect/turf_decal/stripes/line,
-/turf/open/floor/plating,
-/area/shuttle/auxillary_base)
 "z" = (
 /obj/machinery/light{
 	dir = 8
@@ -82,7 +78,6 @@
 /area/shuttle/auxillary_base)
 "X" = (
 /obj/machinery/camera{
-	c_tag = "Auxillary Mining Base";
 	dir = 1
 	},
 /obj/structure/mining_shuttle_beacon,
@@ -142,7 +137,7 @@ P
 k
 k
 k
-y
+x
 "}
 (6,1,1) = {"
 v

--- a/_maps/shuttles/aux_base_small.dmm
+++ b/_maps/shuttles/aux_base_small.dmm
@@ -35,7 +35,6 @@
 /area/shuttle/auxillary_base)
 "h" = (
 /obj/machinery/camera{
-	c_tag = "Auxillary Mining Base";
 	dir = 1
 	},
 /obj/structure/mining_shuttle_beacon,

--- a/code/game/machinery/camera/camera.dm
+++ b/code/game/machinery/camera/camera.dm
@@ -19,7 +19,6 @@
 	integrity_failure = 50
 	var/list/network = list("ss13")
 	var/c_tag = null
-	var/c_tag_order = 999
 	var/status = TRUE
 	var/start_active = FALSE //If it ignores the random chance to start broken on round start
 	var/invuln = null

--- a/code/game/machinery/camera/tracking.dm
+++ b/code/game/machinery/camera/tracking.dm
@@ -146,10 +146,6 @@
 		for (var/j = 1 to i - 1)
 			a = L[j]
 			b = L[j + 1]
-			if (a.c_tag_order != b.c_tag_order)
-				if (a.c_tag_order > b.c_tag_order)
-					L.Swap(j, j + 1)
-			else
-				if (sorttext(a.c_tag, b.c_tag) < 0)
-					L.Swap(j, j + 1)
+			if (sorttext(a.c_tag, b.c_tag) < 0)
+				L.Swap(j, j + 1)
 	return L

--- a/code/game/machinery/computer/camera.dm
+++ b/code/game/machinery/computer/camera.dm
@@ -196,7 +196,7 @@
 	icon_keyboard = "mining_key"
 	network = list("mine")
 	circuit = /obj/item/circuitboard/computer/mining
-	
+
 /obj/machinery/computer/security/research
 	name = "research camera console"
 	desc = "Used to access the various cameras in science."


### PR DESCRIPTION
Removes a useless var and corrects two cameras to use the automatic naming system to reduce direct var usage.