### PR TITLE
Include item overlays in attack animations (shows the proper color of screwdrivers etc)

### DIFF
--- a/code/game/atoms_movable.dm
+++ b/code/game/atoms_movable.dm
@@ -562,13 +562,14 @@
 	if(visual_effect_icon)
 		I = image('icons/effects/effects.dmi', A, visual_effect_icon, A.layer + 0.1)
 	else if(used_item)
-		I = image(used_item.icon, A, used_item.icon_state, A.layer + 0.1)
-
+		var/mutable_appearance/MA = new(used_item)
 		// Scale the icon.
-		I.transform *= 0.75
+		MA.transform *= 0.75
+
+		I = image(icon = MA, loc = A, layer = A.layer + 0.1)
+
 		// The icon should not rotate.
 		I.appearance_flags = APPEARANCE_UI_IGNORE_ALPHA
-
 		// Set the direction of the icon animation.
 		var/direction = get_dir(src, A)
 		if(direction & NORTH)

--- a/code/game/atoms_movable.dm
+++ b/code/game/atoms_movable.dm
@@ -562,14 +562,13 @@
 	if(visual_effect_icon)
 		I = image('icons/effects/effects.dmi', A, visual_effect_icon, A.layer + 0.1)
 	else if(used_item)
-		var/mutable_appearance/MA = new(used_item)
+		I = image(icon = used_item, loc = A, layer = A.layer + 0.1)
+
 		// Scale the icon.
-		MA.transform *= 0.75
-
-		I = image(icon = MA, loc = A, layer = A.layer + 0.1)
-
+		I.transform *= 0.75
 		// The icon should not rotate.
 		I.appearance_flags = APPEARANCE_UI_IGNORE_ALPHA
+
 		// Set the direction of the icon animation.
 		var/direction = get_dir(src, A)
 		if(direction & NORTH)

--- a/code/game/objects/items/storage/bags.dm
+++ b/code/game/objects/items/storage/bags.dm
@@ -316,7 +316,7 @@
 /obj/item/storage/bag/tray/update_icon()
 	cut_overlays()
 	for(var/obj/item/I in contents)
-		add_overlay(mutable_appearance(I.icon, I.icon_state))
+		add_overlay(new /mutable_appearance(I))
 
 /obj/item/storage/bag/tray/Entered()
 	. = ..()


### PR DESCRIPTION
Fixes #31871

:cl: Naksu
fix: Screwdrivers and other items with overlays now show the proper appearance of the item when attacking something with them, or when put on a tray.
/:cl:
![image](https://user-images.githubusercontent.com/20017308/40859571-eb1b2e0e-65ea-11e8-9de9-d9b6d51b6357.png)
