### PR TITLE
Fixes temperature guns to respect armor/dodge

### DIFF
--- a/code/modules/projectiles/projectile/special/temperature.dm
+++ b/code/modules/projectiles/projectile/special/temperature.dm
@@ -8,11 +8,10 @@
 	var/temperature = 100
 
 /obj/item/projectile/temp/on_hit(atom/target, blocked = 0)
-	..()
+	. = ..()
 	if(isliving(target))
 		var/mob/living/L = target
 		L.adjust_bodytemperature(L.bodytemperature + (((100-blocked)/100)*(temperature - L.bodytemperature))) // the new body temperature is adjusted by 100-blocked % of the delta between body temperature and the bullet's effect temperature
-	return TRUE
 
 /obj/item/projectile/temp/hot
 	name = "heat beam"

--- a/code/modules/projectiles/projectile/special/temperature.dm
+++ b/code/modules/projectiles/projectile/special/temperature.dm
@@ -7,11 +7,11 @@
 	flag = "energy"
 	var/temperature = 100
 
-/obj/item/projectile/temp/on_hit(atom/target, blocked = FALSE)//These two could likely check temp protection on the mob
+/obj/item/projectile/temp/on_hit(atom/target, blocked = 0)
 	..()
 	if(isliving(target))
-		var/mob/M = target
-		M.bodytemperature = temperature
+		var/mob/living/L = target
+		L.adjust_bodytemperature(L.bodytemperature + (((100-blocked)/100)*(temperature - L.bodytemperature))) // the new body temperature is adjusted by 100-blocked % of the delta between body temperature and the bullet's effect temperature
 	return TRUE
 
 /obj/item/projectile/temp/hot


### PR DESCRIPTION
The temperature values will likely have to be adjusted to account for small baseline armor, though I have in mind to revisit these and make them more juicy if I can source some sprites for my small security special weapons refactor/redesign.

In my mind this PR is a fix as it doesn't make sense that a bullet that didn't hit you still affects you, but it's been that way for at least 7 years so a balance tag is warranted on those grounds alone. But I am also adjusting the effect based on armor as well, so it would not be a pure fix even if you accept my logic.

:cl: Naksu
balance: Temperature gun projectiles now respect armor/dodge, and will no longer freeze you if they don't hit you.
/:cl:
