### PR TITLE
Fixes comms consoles thinking the transit is on centcom

### DIFF
--- a/code/game/machinery/computer/communications.dm
+++ b/code/game/machinery/computer/communications.dm
@@ -51,7 +51,7 @@
 /obj/machinery/computer/communications/Topic(href, href_list)
 	if(..())
 		return
-	if(!is_station_level(z) && !is_centcom_level(z)) //Can only use on centcom and SS13
+	if(!is_station_level(z) && !is_transit_level(z)) //Can only use in transit and on SS13
 		to_chat(usr, "<span class='boldannounce'>Unable to establish a connection</span>: \black You're too far away from the station!")
 		return
 	usr.set_machine(src)


### PR DESCRIPTION
As per @KorPhaeron , comms consoles were intended to only work on station but were then expanded to work in transit for announcements, back when transit was on centcom's Z-level.

:cl: Naksu
fix: comms consoles now work in transit again, and no longer work in centcom
/:cl:


