### PR TITLE
Fix inconsistent energy gun suicide

### DIFF
--- a/code/modules/projectiles/guns/energy.dm
+++ b/code/modules/projectiles/guns/energy.dm
@@ -166,8 +166,8 @@
 /obj/item/gun/energy/ui_action_click()
 	toggle_gunlight()
 
-/obj/item/gun/energy/suicide_act(mob/user)
-	if (can_shoot() && can_trigger_gun(user))
+/obj/item/gun/energy/suicide_act(mob/living/user)
+	if (istype(user) && can_shoot() && can_trigger_gun(user) && user.get_bodypart(BODY_ZONE_HEAD))
 		user.visible_message("<span class='suicide'>[user] is putting the barrel of [src] in [user.p_their()] mouth.  It looks like [user.p_theyre()] trying to commit suicide!</span>")
 		sleep(25)
 		if(user.is_holding(src))
@@ -181,7 +181,7 @@
 			user.visible_message("<span class='suicide'>[user] panics and starts choking to death!</span>")
 			return(OXYLOSS)
 	else
-		user.visible_message("<span class='suicide'>[user] is pretending to blow [user.p_their()] brains out with [src]! It looks like [user.p_theyre()] trying to commit suicide!</b></span>")
+		user.visible_message("<span class='suicide'>[user] is pretending to melt [user.p_their()] face off with [src]! It looks like [user.p_theyre()] trying to commit suicide!</b></span>")
 		playsound(src, "gun_dry_fire", 30, 1)
 		return (OXYLOSS)
 


### PR DESCRIPTION
:cl:
spellcheck: Faceless persons no longer "melt their face off" in energy gun suicides.
/:cl:

Closes #36853.