### PR TITLE
Adds warning to shuttle purchase menu

### DIFF
--- a/code/game/machinery/computer/communications.dm
+++ b/code/game/machinery/computer/communications.dm
@@ -554,6 +554,9 @@
 
 		if(STATE_PURCHASE)
 			dat += "Budget: [SSshuttle.points] Credits.<BR>"
+			dat += "<BR>"
+			dat += "<b>Caution: Purchasing dangerous shuttles may lead to mutiny and/or death.</b><br>"
+			dat += "<BR>"
 			for(var/shuttle_id in SSmapping.shuttle_templates)
 				var/datum/map_template/shuttle/S = SSmapping.shuttle_templates[shuttle_id]
 				if(S.can_be_bought && S.credit_cost < INFINITY)


### PR DESCRIPTION
:cl: Denton
tweak: Added a warning to the shuttle purchase menu.
/:cl:

Plenty of newer players (me included) didn't know that purchasing dangerous shuttles isn't just a dick move, but also makes you valid.
I added a short warning to let players know that buying that gigashuttle will have consequences.

![adsdasasdads](https://user-images.githubusercontent.com/32391752/40884578-79831b58-6716-11e8-9477-224fdbb3b4f5.PNG)