### PR TITLE
Adds missing minerals to /everything closet

### DIFF
--- a/code/game/objects/structures/crates_lockers/closets/syndicate.dm
+++ b/code/game/objects/structures/crates_lockers/closets/syndicate.dm
@@ -106,7 +106,9 @@
 	/obj/item/stack/sheet/plasteel,
 	/obj/item/stack/sheet/mineral/titanium,
 	/obj/item/stack/sheet/mineral/plastitanium,
-	/obj/item/stack/rods
+	/obj/item/stack/rods,
+	/obj/item/stack/sheet/bluespace_crystal,
+	/obj/item/stack/sheet/mineral/abductor
 	)
 
 	for(var/i = 0, i<2, i++)

--- a/code/game/objects/structures/crates_lockers/closets/syndicate.dm
+++ b/code/game/objects/structures/crates_lockers/closets/syndicate.dm
@@ -108,7 +108,9 @@
 	/obj/item/stack/sheet/mineral/plastitanium,
 	/obj/item/stack/rods,
 	/obj/item/stack/sheet/bluespace_crystal,
-	/obj/item/stack/sheet/mineral/abductor
+	/obj/item/stack/sheet/mineral/abductor,
+	/obj/item/stack/sheet/plastic,
+	/obj/item/stack/sheet/mineral/wood
 	)
 
 	for(var/i = 0, i<2, i++)


### PR DESCRIPTION
The /everything closet on runtimestation was missing BS crystals and ayy minerals, I added them.