### PR TITLE
[Ready] Arcade reward: snack rigs

### DIFF
--- a/code/game/machinery/computer/arcade.dm
+++ b/code/game/machinery/computer/arcade.dm
@@ -51,7 +51,9 @@
 		/obj/item/hot_potato/harmless/toy						= 1,
 		/obj/item/card/emagfake									= 1,
 		/obj/item/clothing/shoes/wheelys				= 2,
-		/obj/item/clothing/shoes/kindleKicks				= 2)
+		/obj/item/clothing/shoes/kindleKicks				= 2,
+		/obj/item/storage/belt/military/snack					= 2
+		)
 
 	light_color = LIGHT_COLOR_GREEN
 

--- a/code/game/objects/items/storage/belt.dm
+++ b/code/game/objects/items/storage/belt.dm
@@ -326,6 +326,21 @@
 	GET_COMPONENT(STR, /datum/component/storage)
 	STR.max_w_class = WEIGHT_CLASS_SMALL
 
+/obj/item/storage/belt/military/snack
+	name = "snack rig"
+	desc = "A set of tactical webbing worn by athletes of the DonkCo VR sports division. May contain nuts."
+
+/obj/item/storage/belt/military/snack/ComponentInitialize()
+	. = ..()
+	GET_COMPONENT(STR, /datum/component/storage)
+	STR.max_items = 7
+	STR.max_w_class = WEIGHT_CLASS_SMALL
+	STR.can_hold = typecacheof(list(
+		/obj/item/reagent_containers/food/snacks,
+		/obj/item/reagent_containers/food/drinks/dry_ramen,
+		/obj/item/reagent_containers/food/drinks/soda_cans
+		))
+
 /obj/item/storage/belt/military/abductor
 	name = "agent belt"
 	desc = "A belt used by abductor agents."

--- a/code/game/objects/items/storage/belt.dm
+++ b/code/game/objects/items/storage/belt.dm
@@ -328,7 +328,26 @@
 
 /obj/item/storage/belt/military/snack
 	name = "tactical snack rig"
-	var/list/stop_eating_like_a_noob = list(
+
+/obj/item/storage/belt/military/snack/Initialize()
+	. = ..()
+	var/sponsor = pick("DonkCo", "Waffle Co.", "Roffle Co.", "Gorlax Marauders", "Tiger Cooperative")
+	desc = "A set of snack-tical webbing worn by athletes of the [sponsor] VR sports division."
+
+/obj/item/storage/belt/military/snack/ComponentInitialize()
+	. = ..()
+	GET_COMPONENT(STR, /datum/component/storage)
+	STR.max_items = 6
+	STR.max_w_class = WEIGHT_CLASS_SMALL
+	STR.can_hold = typecacheof(list(
+		/obj/item/reagent_containers/food/snacks,
+		/obj/item/reagent_containers/food/drinks
+		))
+	
+	var/amount = 5
+	var/rig_snacks
+	while(contents.len <= amount)
+		rig_snacks = pick(list(
 		/obj/item/reagent_containers/food/snacks/candy,
 		/obj/item/reagent_containers/food/drinks/dry_ramen,
 		/obj/item/reagent_containers/food/snacks/chips,
@@ -351,25 +370,7 @@
 		/obj/item/reagent_containers/food/drinks/soda_cans/pwr_game,
 		/obj/item/reagent_containers/food/drinks/soda_cans/lemon_lime,
 		/obj/item/reagent_containers/food/drinks/drinkingglass/filled/nuka_cola
-		)
-	var/amount = 6
-
-/obj/item/storage/belt/military/snack/ComponentInitialize()
-	. = ..()
-	var/sponsor = pick("DonkCo", "Waffle Co.", "Roffle Co.", "Gorlax Marauders", "Tiger Cooperative")
-	desc = "A set of snack-tical webbing worn by athletes of the [sponsor] VR sports division."
-
-	GET_COMPONENT(STR, /datum/component/storage)
-	STR.max_items = 6
-	STR.max_w_class = WEIGHT_CLASS_SMALL
-	STR.can_hold = typecacheof(list(
-		/obj/item/reagent_containers/food/snacks,
-		/obj/item/reagent_containers/food/drinks
 		))
-
-	var/rig_snacks
-	while(contents.len <= amount)
-		rig_snacks = pick(stop_eating_like_a_noob)
 		new rig_snacks(src)
 
 /obj/item/storage/belt/military/abductor

--- a/code/game/objects/items/storage/belt.dm
+++ b/code/game/objects/items/storage/belt.dm
@@ -327,19 +327,50 @@
 	STR.max_w_class = WEIGHT_CLASS_SMALL
 
 /obj/item/storage/belt/military/snack
-	name = "snack rig"
-	desc = "A set of tactical webbing worn by athletes of the DonkCo VR sports division. May contain nuts."
+	name = "tactical snack rig"
+	var/list/stop_eating_like_a_noob = list(
+		/obj/item/reagent_containers/food/snacks/candy,
+		/obj/item/reagent_containers/food/drinks/dry_ramen,
+		/obj/item/reagent_containers/food/snacks/chips,
+		/obj/item/reagent_containers/food/snacks/sosjerky,
+		/obj/item/reagent_containers/food/snacks/syndicake,
+		/obj/item/reagent_containers/food/snacks/spacetwinkie,
+		/obj/item/reagent_containers/food/snacks/cheesiehonkers,
+		/obj/item/reagent_containers/food/snacks/nachos,
+		/obj/item/reagent_containers/food/snacks/cheesynachos,
+		/obj/item/reagent_containers/food/snacks/cubannachos,
+		/obj/item/reagent_containers/food/snacks/nugget,
+		/obj/item/reagent_containers/food/snacks/pastatomato,
+		/obj/item/reagent_containers/food/snacks/rofflewaffles,
+		/obj/item/reagent_containers/food/snacks/donkpocket,
+		/obj/item/reagent_containers/food/drinks/soda_cans/cola,
+		/obj/item/reagent_containers/food/drinks/soda_cans/space_mountain_wind,
+		/obj/item/reagent_containers/food/drinks/soda_cans/dr_gibb,
+		/obj/item/reagent_containers/food/drinks/soda_cans/starkist,
+		/obj/item/reagent_containers/food/drinks/soda_cans/space_up,
+		/obj/item/reagent_containers/food/drinks/soda_cans/pwr_game,
+		/obj/item/reagent_containers/food/drinks/soda_cans/lemon_lime,
+		/obj/item/reagent_containers/food/drinks/drinkingglass/filled/nuka_cola
+		)
+	var/amount = 6
 
 /obj/item/storage/belt/military/snack/ComponentInitialize()
 	. = ..()
+	var/sponsor = pick("DonkCo", "Waffle Co.", "Roffle Co.", "Gorlax Marauders", "Tiger Cooperative")
+	desc = "A set of snack-tical webbing worn by athletes of the [sponsor] VR sports division."
+
 	GET_COMPONENT(STR, /datum/component/storage)
-	STR.max_items = 7
+	STR.max_items = 6
 	STR.max_w_class = WEIGHT_CLASS_SMALL
 	STR.can_hold = typecacheof(list(
 		/obj/item/reagent_containers/food/snacks,
-		/obj/item/reagent_containers/food/drinks/dry_ramen,
-		/obj/item/reagent_containers/food/drinks/soda_cans
+		/obj/item/reagent_containers/food/drinks
 		))
+
+	var/rig_snacks
+	while(contents.len <= amount)
+		rig_snacks = pick(stop_eating_like_a_noob)
+		new rig_snacks(src)
 
 /obj/item/storage/belt/military/abductor
 	name = "agent belt"


### PR DESCRIPTION
:cl: Denton
add: Arcades have been stocked with preloaded tactical snack rigs.
/:cl:

I'm a fan of the fake syndie gear you can win at arcades - so I thought, why not add a fake tactical rig?
