### PR TITLE
Allow accessing RND machine wires, show feedback when they are cut

### DIFF
--- a/code/modules/research/rdmachines.dm
+++ b/code/modules/research/rdmachines.dm
@@ -44,6 +44,9 @@
 		return
 	if(default_deconstruction_crowbar(O))
 		return
+	if(panel_open && is_wire_tool(O))
+		wires.interact(user)
+		return TRUE
 	if(is_refillable() && O.is_drainable())
 		return FALSE //inserting reagents into the machine
 	if(Insert_Item(O, user))
@@ -65,6 +68,7 @@
 		to_chat(user, "<span class='warning'>You can't load [src] while it's opened!</span>")
 		return FALSE
 	if(disabled)
+		to_chat(user, "<span class='warning'>The insertion belts of [src] won't engage!</span>")
 		return FALSE
 	if(requires_console && !linked_console)
 		to_chat(user, "<span class='warning'>[src] must be linked to an R&D console first!</span>")


### PR DESCRIPTION
:cl:
fix: It is now possible to access the wires of RND machines in order to repair them if they have been EMP'd.
/:cl:

Fixes #37060.