### PR TITLE
Fix pAI suicide while in holoform deleting the card

### DIFF
--- a/code/game/objects/items/devices/paicard.dm
+++ b/code/game/objects/items/devices/paicard.dm
@@ -22,7 +22,8 @@
 /obj/item/paicard/Destroy()
 	//Will stop people throwing friend pAIs into the singularity so they can respawn
 	SSpai.pai_card_list -= src
-	QDEL_NULL(pai)
+	if (!QDELETED(pai))
+		QDEL_NULL(pai)
 	return ..()
 
 /obj/item/paicard/attack_self(mob/user)
@@ -90,7 +91,7 @@
 					to_chat(pai, "<span class='danger'>Byte by byte you lose your sense of self.</span>")
 					to_chat(pai, "<span class='userdanger'>Your mental faculties leave you.</span>")
 					to_chat(pai, "<span class='rose'>oblivion... </span>")
-					removePersonality()
+					qdel(pai)
 		if(href_list["wires"])
 			var/wire = text2num(href_list["wires"])
 			if(pai.radio)
@@ -121,11 +122,6 @@
 
 	playsound(loc, 'sound/effects/pai_boot.ogg', 50, 1, -1)
 	audible_message("\The [src] plays a cheerful startup noise!")
-
-/obj/item/paicard/proc/removePersonality()
-	QDEL_NULL(pai)
-	cut_overlays()
-	add_overlay("pai-off")
 
 /obj/item/paicard/proc/setEmotion(emotion)
 	if(pai)

--- a/code/modules/mob/living/silicon/pai/death.dm
+++ b/code/modules/mob/living/silicon/pai/death.dm
@@ -3,8 +3,6 @@
 		return
 	stat = DEAD
 	canmove = 0
-	card.removePersonality()
-	card.forceMove(loc)
 	update_sight()
 	clear_fullscreens()
 

--- a/code/modules/mob/living/silicon/pai/pai.dm
+++ b/code/modules/mob/living/silicon/pai/pai.dm
@@ -90,6 +90,11 @@
 	return FALSE
 
 /mob/living/silicon/pai/Destroy()
+	if (loc != card)
+		card.forceMove(drop_location())
+	card.pai = null
+	card.cut_overlays()
+	card.add_overlay("pai-off")
 	GLOB.pai_list -= src
 	return ..()
 

--- a/code/modules/mob/living/silicon/pai/pai_shell.dm
+++ b/code/modules/mob/living/silicon/pai/pai_shell.dm
@@ -57,7 +57,7 @@
 	if(client)
 		client.perspective = EYE_PERSPECTIVE
 		client.eye = card
-	var/turf/T = get_turf(src)
+	var/turf/T = drop_location()
 	card.forceMove(T)
 	forceMove(card)
 	canmove = FALSE


### PR DESCRIPTION
:cl:
fix: A pAI dying while in holoform no longer deletes the card, instead merely emptying it.
/:cl:

Fixes #28707.