### PR TITLE
Adds an abandoned kitchen to Metastation

### DIFF
--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -46270,12 +46270,11 @@
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
 "bUT" = (
-/obj/structure/rack,
-/obj/item/weldingtool,
-/obj/item/screwdriver{
-	pixel_y = 16
+/obj/structure/table,
+/obj/item/reagent_containers/food/condiment/enzyme{
+	layer = 5
 	},
-/obj/effect/spawner/lootdrop/maintenance,
+/obj/item/reagent_containers/food/condiment/flour,
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
 "bUU" = (
@@ -46289,20 +46288,16 @@
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
 "bUW" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
+/obj/structure/table,
+/obj/machinery/microwave{
+	pixel_x = -3;
+	pixel_y = 6
 	},
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
 "bUX" = (
-/obj/structure/rack,
-/obj/item/stack/cable_coil{
-	pixel_x = -1;
-	pixel_y = -3
-	},
-/obj/item/stack/cable_coil,
-/obj/item/wirecutters,
-/obj/effect/spawner/lootdrop/maintenance,
+/obj/structure/closet/crate/bin,
+/obj/item/kitchen/knife,
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
 "bUY" = (
@@ -46759,25 +46754,14 @@
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
 "bVW" = (
+/obj/structure/sink{
+	dir = 8;
+	pixel_x = -12;
+	pixel_y = 2
+	},
 /turf/open/floor/plating{
 	icon_state = "platingdmg1"
 	},
-/area/maintenance/port/aft)
-"bVX" = (
-/obj/effect/turf_decal/stripes/corner{
-	dir = 8
-	},
-/turf/open/floor/plating,
-/area/maintenance/port/aft)
-"bVZ" = (
-/obj/effect/turf_decal/stripes/corner{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/maintenance/port/aft)
-"bWa" = (
-/obj/effect/landmark/blobstart,
-/turf/open/floor/plating,
 /area/maintenance/port/aft)
 "bWb" = (
 /obj/structure/cable/yellow{
@@ -47513,17 +47497,15 @@
 	},
 /area/maintenance/port/aft)
 "bXA" = (
-/obj/structure/table,
-/obj/item/flashlight/lamp,
-/turf/open/floor/plating,
-/area/maintenance/port/aft)
-"bXB" = (
-/obj/structure/chair/stool,
+/obj/structure/barricade/wooden,
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
 "bXC" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 4
+	},
+/obj/structure/light_construct{
+	dir = 8
 	},
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
@@ -47957,25 +47939,8 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
-"bYG" = (
-/obj/structure/table,
-/obj/item/folder/white{
-	pixel_x = 4;
-	pixel_y = -3
-	},
-/obj/item/folder/white{
-	pixel_x = 4;
-	pixel_y = -3
-	},
-/obj/item/pen,
-/obj/structure/extinguisher_cabinet{
-	pixel_y = -30
-	},
-/obj/effect/spawner/lootdrop/maintenance,
-/turf/open/floor/plating,
-/area/maintenance/port/aft)
 "bYH" = (
-/obj/structure/light_construct,
+/obj/structure/closet/secure_closet/freezer/kitchen/maintenance,
 /turf/open/floor/plating{
 	icon_state = "panelscorched"
 	},
@@ -50135,8 +50100,6 @@
 /turf/open/space,
 /area/solar/port/aft)
 "cdb" = (
-/obj/structure/girder,
-/obj/structure/grille,
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
 	dir = 8
 	},
@@ -50164,6 +50127,8 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
+/obj/structure/girder,
+/obj/structure/grille,
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
 "cde" = (
@@ -50704,8 +50669,6 @@
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
 "ceo" = (
-/obj/structure/girder,
-/obj/structure/grille,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 9
 	},
@@ -50740,19 +50703,6 @@
 	amount = 23
 	},
 /obj/effect/spawner/lootdrop/maintenance,
-/turf/open/floor/plating,
-/area/maintenance/port/aft)
-"ces" = (
-/obj/structure/table,
-/obj/item/folder/white{
-	pixel_x = 4;
-	pixel_y = -3
-	},
-/obj/item/folder/white{
-	pixel_x = 4;
-	pixel_y = -3
-	},
-/obj/item/pen,
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
 "ceu" = (
@@ -71371,11 +71321,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard)
-"dbk" = (
-/obj/item/hand_labeler_refill,
-/obj/structure/easel,
-/turf/open/floor/plating,
-/area/maintenance/port)
 "dbl" = (
 /obj/structure/easel,
 /turf/open/floor/plating,
@@ -74242,12 +74187,8 @@
 /turf/open/floor/plating,
 /area/maintenance/port)
 "diy" = (
-/obj/structure/table,
-/obj/item/paper_bin{
-	pixel_x = -2;
-	pixel_y = 8
-	},
-/obj/item/poster/random_contraband,
+/obj/structure/kitchenspike,
+/obj/effect/decal/cleanable/blood/gibs/old,
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
 "diz" = (
@@ -76081,6 +76022,19 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/circuit)
+"gqA" = (
+/obj/machinery/button/door{
+	dir = 2;
+	id = "abandoned_kitchen";
+	name = "Shutters Control";
+	pixel_x = 26;
+	pixel_y = 6;
+	req_one_access_txt = null
+	},
+/obj/effect/decal/cleanable/blood/old,
+/obj/item/clothing/suit/apron/chef,
+/turf/open/floor/plating,
+/area/maintenance/port/aft)
 "gra" = (
 /obj/structure/disposalpipe/segment{
 	dir = 5
@@ -76159,6 +76113,13 @@
 	},
 /turf/open/floor/plating,
 /area/security/prison)
+"hIt" = (
+/obj/structure/table/reinforced,
+/obj/machinery/door/poddoor/shutters{
+	id = "abandoned_kitchen"
+	},
+/turf/open/floor/plating,
+/area/maintenance/port/aft)
 "ioI" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
@@ -76186,6 +76147,12 @@
 	},
 /turf/open/floor/plasteel/whitepurple,
 /area/science/lab)
+"iLj" = (
+/obj/structure/table,
+/obj/item/kitchen/rollingpin,
+/obj/item/reagent_containers/glass/beaker,
+/turf/open/floor/plating,
+/area/maintenance/port/aft)
 "jeV" = (
 /obj/machinery/conveyor/inverted{
 	dir = 10;
@@ -76407,6 +76374,13 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/circuit)
+"mWg" = (
+/obj/structure/girder,
+/obj/structure/grille,
+/turf/open/floor/plating{
+	icon_state = "panelscorched"
+	},
+/area/maintenance/port/aft)
 "nnK" = (
 /obj/item/stack/sheet/glass/fifty,
 /obj/item/paper_bin,
@@ -76553,6 +76527,17 @@
 /obj/item/pen,
 /turf/open/floor/plasteel/white,
 /area/science/circuit)
+"oZg" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/obj/structure/girder,
+/obj/structure/grille,
+/turf/open/floor/plating,
+/area/maintenance/port/aft)
 "pmc" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 5
@@ -76911,6 +76896,10 @@
 	},
 /turf/open/floor/plating,
 /area/security/prison)
+"wmt" = (
+/obj/effect/decal/cleanable/flour,
+/turf/open/floor/plating,
+/area/maintenance/port/aft)
 "wxc" = (
 /obj/machinery/door/airlock/external{
 	name = "Atmospherics External Airlock";
@@ -76995,6 +76984,13 @@
 /obj/structure/chair/comfy,
 /turf/open/floor/plasteel,
 /area/science/misc_lab)
+"xEf" = (
+/obj/structure/table,
+/obj/item/flashlight/lamp{
+	on = 0
+	},
+/turf/open/floor/plating,
+/area/maintenance/port/aft)
 "xVl" = (
 /turf/closed/wall,
 /area/hallway/secondary/service)
@@ -77010,6 +77006,16 @@
 /obj/effect/landmark/blobstart,
 /turf/open/floor/engine/cult,
 /area/library)
+"ydn" = (
+/obj/structure/table,
+/obj/item/reagent_containers/food/condiment/saltshaker{
+	pixel_x = -3
+	},
+/obj/item/reagent_containers/food/condiment/peppermill{
+	pixel_x = 3
+	},
+/turf/open/floor/plating,
+/area/maintenance/port/aft)
 "ygk" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -93613,10 +93619,10 @@ bPJ
 alK
 cgH
 dux
-bUU
-bVX
-bXB
-bYG
+iLj
+bXE
+dux
+dux
 dux
 dux
 dux
@@ -93870,8 +93876,8 @@ aqK
 alK
 dit
 dux
-bUV
-duH
+ydn
+wmt
 bXC
 bYH
 dux
@@ -94128,12 +94134,12 @@ alK
 bSu
 dux
 bUW
-bVZ
+bXE
 bXD
 bYI
 bZO
 cbt
-cdc
+oZg
 dux
 dux
 csT
@@ -94385,11 +94391,11 @@ alK
 bSr
 dux
 bUX
-bWa
 bXE
-bYJ
+gqA
+xEf
 dux
-dvt
+mWg
 cdd
 dux
 cfC
@@ -94642,7 +94648,7 @@ bRf
 bSv
 dux
 dux
-dux
+hIt
 dux
 dux
 dux
@@ -94899,7 +94905,7 @@ alK
 bOf
 bOv
 alC
-dbk
+aob
 dux
 bYK
 bZP
@@ -95419,7 +95425,7 @@ bYM
 bZP
 cbx
 cdh
-bXE
+bUV
 dux
 dwc
 cia
@@ -95933,7 +95939,7 @@ bYN
 dux
 cbz
 bXE
-ces
+bYJ
 dux
 dwe
 cic

--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -47495,8 +47495,10 @@
 	},
 /area/maintenance/port/aft)
 "bXA" = (
-/obj/structure/light_construct{
-	dir = 8
+/obj/structure/sink{
+	dir = 8;
+	pixel_x = -12;
+	pixel_y = 2
 	},
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
@@ -47938,9 +47940,6 @@
 /area/maintenance/port/aft)
 "bYH" = (
 /obj/structure/rack,
-/obj/item/stack/cable_coil{
-	amount = 16
-	},
 /obj/item/stack/rods{
 	amount = 4
 	},

--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -46754,11 +46754,9 @@
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
 "bVW" = (
-/obj/structure/sink{
-	dir = 8;
-	pixel_x = -12;
-	pixel_y = 2
-	},
+/obj/structure/table,
+/obj/item/kitchen/rollingpin,
+/obj/item/reagent_containers/glass/beaker,
 /turf/open/floor/plating{
 	icon_state = "platingdmg1"
 	},
@@ -47497,15 +47495,14 @@
 	},
 /area/maintenance/port/aft)
 "bXA" = (
-/obj/structure/barricade/wooden,
+/obj/structure/light_construct{
+	dir = 8
+	},
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
 "bXC" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 4
-	},
-/obj/structure/light_construct{
-	dir = 8
 	},
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
@@ -47940,7 +47937,13 @@
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
 "bYH" = (
-/obj/structure/closet/secure_closet/freezer/kitchen/maintenance,
+/obj/structure/rack,
+/obj/item/stack/cable_coil{
+	amount = 16
+	},
+/obj/item/stack/rods{
+	amount = 4
+	},
 /turf/open/floor/plating{
 	icon_state = "panelscorched"
 	},
@@ -74187,8 +74190,7 @@
 /turf/open/floor/plating,
 /area/maintenance/port)
 "diy" = (
-/obj/structure/kitchenspike,
-/obj/effect/decal/cleanable/blood/gibs/old,
+/obj/structure/closet/secure_closet/freezer/kitchen/maintenance,
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
 "diz" = (
@@ -76104,6 +76106,11 @@
 /obj/machinery/autolathe,
 /turf/open/floor/plasteel/white,
 /area/science/circuit)
+"hvt" = (
+/obj/structure/kitchenspike_frame,
+/obj/effect/decal/cleanable/blood/gibs/old,
+/turf/open/floor/plating,
+/area/maintenance/port/aft)
 "hyP" = (
 /obj/machinery/door/airlock/external{
 	name = "Escape Pod Two"
@@ -76149,8 +76156,6 @@
 /area/science/lab)
 "iLj" = (
 /obj/structure/table,
-/obj/item/kitchen/rollingpin,
-/obj/item/reagent_containers/glass/beaker,
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
 "jeV" = (
@@ -76608,6 +76613,12 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/aft)
+"qhe" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/maintenance/port)
 "qqg" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 6
@@ -93620,9 +93631,9 @@ alK
 cgH
 dux
 iLj
+dvt
 bXE
-dux
-dux
+hvt
 dux
 dux
 dux
@@ -94391,7 +94402,7 @@ alK
 bSr
 dux
 bUX
-bXE
+bUU
 gqA
 xEf
 dux
@@ -94905,7 +94916,7 @@ alK
 bOf
 bOv
 alC
-aob
+qhe
 dux
 bYK
 bZP


### PR DESCRIPTION
:cl: Mickyan
add: Added an abandoned kitchen to Metastation maintenance
/:cl:
Maint gimmicks are fun and Meta was the only map that didn't have a kitchen. Also, there's donk pocket boxes all over the place but no way for an industrious assistant to actually cook them!

This is the room next to the abandoned robotics lab, I moved the borg recharging station and powercell charger into the lab itself since those are pretty important.