### PR TITLE
Blacklist ion trails from chasms

### DIFF
--- a/code/datums/components/chasm.dm
+++ b/code/datums/components/chasm.dm
@@ -18,7 +18,9 @@
 		/obj/effect/landmark,
 		/obj/effect/temp_visual,
 		/obj/effect/light_emitter/tendril,
-		/obj/effect/collapse))
+		/obj/effect/collapse,
+		/obj/effect/particle_effect/ion_trails
+		))
 
 /datum/component/chasm/Initialize(turf/target)
 	RegisterSignal(list(COMSIG_MOVABLE_CROSSED, COMSIG_ATOM_ENTERED), .proc/Entered)


### PR DESCRIPTION
[why]: Flying a flightsuit across a tear/chasm results in this wonderful spam:

<img width="233" alt="ion reeee" src="https://user-images.githubusercontent.com/32391752/40914676-6a0126c8-67f9-11e8-8e6b-0020e2e26509.PNG">
