### PR TITLE
Admin Supplypod tweaks (Behaves like fireballs, also stuns targets)

### DIFF
--- a/code/game/objects/structures/crates_lockers/closets/secure/supplypod.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/supplypod.dm
@@ -104,16 +104,14 @@
 	light_range = 2
 	var/obj/effect/temp_visual/fallingPod
 
-/obj/effect/DPtarget/Initialize(mapload, var/SO, var/podID)
+/obj/effect/DPtarget/Initialize(mapload, var/SO, var/podID, var/target)
 	. = ..()
-	var/delayTime = 0
+	var/delayTime = 30//default time is 30 seconds
 	switch(podID)
-		if(POD_STANDARD)
-			delayTime = 30
 		if(POD_BLUESPACE)
 			delayTime = 15
 		if(POD_CENTCOM)
-			delayTime = 1
+			delayTime = 5//speedy delivery
 
 	addtimer(CALLBACK(src, .proc/beginLaunch, SO, podID), delayTime)//standard pods take 3 seconds to come in, bluespace pods take 1.5
 
@@ -130,8 +128,11 @@
 		new /obj/structure/closet/supplypod/bluespacepod(drop_location(), SO)//pod is created
 		explosion(src,0,0,2, flame_range = 1) //explosion and camshake (shoutout to @cyberboss)
 	else
-		new /obj/structure/closet/supplypod/bluespacepod/centcompod(drop_location(), SO)
-		explosion(src,0,0,2, flame_range = 1)
+		new /obj/structure/closet/supplypod/bluespacepod/centcompod(drop_location(), SO)//CentCom supplypods dont create explosions; instead they directly deal 40 fire damage to people on the turf
+		var/turf/T = get_turf(src)
+		T.hotspot_expose(700, 50, 1)//same as fireball
+		for(var/mob/living/M in T.contents)
+			M.adjustFireLoss(40)
 	qdel(src)
 
 /obj/effect/DPtarget/Destroy()

--- a/code/modules/admin/verbs/randomverbs.dm
+++ b/code/modules/admin/verbs/randomverbs.dm
@@ -1320,7 +1320,7 @@ GLOBAL_LIST_EMPTY(custom_outfits) //Admin created outfits
 					alert("ERROR: Incorrect / improper path given.")
 					return
 			//send the pod
-			target.stun(10)//takes 0.53 seconds for CentCom pod to land
+			target.Stun(10)//takes 0.53 seconds for CentCom pod to land
 			new /obj/effect/DPtarget(get_turf(target), delivery, POD_CENTCOM, target)
 
 	var/msg = "[key_name_admin(usr)] punished [key_name_admin(target)] with [punishment]."

--- a/code/modules/admin/verbs/randomverbs.dm
+++ b/code/modules/admin/verbs/randomverbs.dm
@@ -1310,17 +1310,18 @@ GLOBAL_LIST_EMPTY(custom_outfits) //Admin created outfits
 			var/target_path = input(usr,"Enter typepath of an atom you'd like to send with the pod (type \"empty\" to send an empty pod):" ,"Typepath","/obj/item/reagent_containers/food/snacks/grown/harebell") as null|text
 			if (isnull(target_path))
 				return
-			if (target_path == "empty")//if you type "abort", spawn an empty pod
+			if (target_path == "empty")//if you type "empty", spawn an empty pod
 				new /obj/effect/DPtarget(get_turf(target), null, POD_CENTCOM)
 				return
 			var/delivery = text2path(target_path)
 			if(!ispath(delivery))
 				delivery = pick_closest_path(target_path)
 				if(!delivery)
-					delivery = /obj/item/reagent_containers/food/snacks/grown/harebell
-					alert("That path is not allowed.")
+					alert("ERROR: Incorrect / improper path given.")
+					return
 			//send the pod
-			new /obj/effect/DPtarget(get_turf(target), delivery, POD_CENTCOM)
+			target.stun(10)//takes 0.53 seconds for CentCom pod to land
+			new /obj/effect/DPtarget(get_turf(target), delivery, POD_CENTCOM, target)
 
 	var/msg = "[key_name_admin(usr)] punished [key_name_admin(target)] with [punishment]."
 	message_admins(msg)


### PR DESCRIPTION
Fixes #38286

:cl: MrDoomBringer
admin: CentCom Supplypods now stun their target before landing, and won't damage the station as much
/:cl:

Replaced the explosion with a hotspot_expose (same action as fireball), and now stuns the target. Also, typing an incorrect path will not launch a pod anyways.
