### PR TITLE
Stops ninja nets from removing plasmaman suits+internals

### DIFF
--- a/_maps/map_files/generic/CentCom.dmm
+++ b/_maps/map_files/generic/CentCom.dmm
@@ -9160,9 +9160,6 @@
 /obj/structure/closet/secure_closet/freezer/meat{
 	locked = 0
 	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
-	dir = 4
-	},
 /obj/item/reagent_containers/food/snacks/carpmeat,
 /obj/item/reagent_containers/food/snacks/carpmeat,
 /obj/item/reagent_containers/food/snacks/carpmeat,
@@ -9175,6 +9172,7 @@
 /obj/machinery/light{
 	dir = 1
 	},
+/obj/item/soap/deluxe,
 /turf/open/floor/plasteel/cafeteria,
 /area/centcom/holding)
 "Ab" = (
@@ -10920,6 +10918,7 @@
 "Fa" = (
 /obj/structure/table/wood,
 /obj/item/instrument/piano_synth,
+/obj/item/instrument/guitar,
 /turf/open/floor/carpet/black,
 /area/centcom/holding)
 "Fb" = (
@@ -11608,6 +11607,12 @@
 	dir = 4
 	},
 /area/tdome/tdomeobserve)
+"Hj" = (
+/obj/structure/urinal{
+	step_y = 28
+	},
+/turf/open/floor/plasteel/airless/white,
+/area/centcom/holding)
 "Hm" = (
 /obj/structure/flora/ausbushes/fernybush,
 /obj/structure/flora/ausbushes/ppflowers,
@@ -13502,6 +13507,7 @@
 /obj/item/storage/fancy/candle_box,
 /obj/item/storage/fancy/candle_box,
 /obj/item/storage/fancy/candle_box,
+/obj/item/storage/box/lights/mixed,
 /turf/open/floor/wood,
 /area/centcom/holding)
 "Nn" = (
@@ -13555,6 +13561,7 @@
 /obj/structure/table,
 /obj/item/book/manual/hydroponics_pod_people,
 /obj/item/seeds/pumpkin/blumpkin,
+/obj/item/paper/guides/jobs/hydroponics,
 /turf/open/floor/plasteel/whitegreen,
 /area/centcom/holding)
 "NT" = (
@@ -13887,6 +13894,7 @@
 /obj/item/stack/sheet/glass/fifty,
 /obj/item/stack/sheet/metal/fifty,
 /obj/item/storage/toolbox/mechanical,
+/obj/item/multitool,
 /turf/open/floor/wood,
 /area/centcom/holding)
 "Tr" = (
@@ -13929,6 +13937,13 @@
 /area/centcom/holding)
 "Um" = (
 /obj/structure/closet/crate/hydroponics,
+/obj/item/shovel/spade,
+/obj/item/wirecutters,
+/obj/item/wrench,
+/obj/item/watertank,
+/obj/item/cultivator,
+/obj/item/reagent_containers/glass/bucket,
+/obj/item/reagent_containers/glass/bucket,
 /turf/open/floor/plasteel/whitegreen,
 /area/centcom/holding)
 "Un" = (
@@ -38926,7 +38941,7 @@ PY
 PY
 PY
 Nd
-ZW
+Hj
 ZW
 ZW
 Za

--- a/_maps/map_files/generic/CentCom.dmm
+++ b/_maps/map_files/generic/CentCom.dmm
@@ -1,4 +1,4 @@
-//MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE 
+//MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
 "aa" = (
 /turf/open/space/basic,
 /area/space)
@@ -8238,6 +8238,17 @@
 /obj/item/toy/cards/deck,
 /turf/open/floor/carpet,
 /area/wizard_station)
+"wT" = (
+/obj/structure/closet,
+/obj/item/storage/backpack/duffelbag/med/surgery,
+/obj/machinery/iv_drip,
+/obj/item/roller,
+/obj/item/storage/firstaid/regular,
+/obj/item/reagent_containers/medspray/synthflesh,
+/obj/item/reagent_containers/medspray/synthflesh,
+/obj/item/reagent_containers/medspray/synthflesh,
+/turf/open/floor/wood,
+/area/centcom/holding)
 "wV" = (
 /obj/machinery/computer/telecrystals/boss{
 	dir = 1
@@ -9003,6 +9014,12 @@
 /obj/item/reagent_containers/food/snacks/meat/slab/corgi,
 /turf/open/floor/grass,
 /area/wizard_station)
+"zs" = (
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/turf/open/floor/carpet/black,
+/area/centcom/holding)
 "zx" = (
 /obj/structure/closet/syndicate/personal,
 /obj/effect/turf_decal/stripes/line{
@@ -9146,6 +9163,11 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 4
 	},
+/obj/item/reagent_containers/food/snacks/carpmeat,
+/obj/item/reagent_containers/food/snacks/carpmeat,
+/obj/item/reagent_containers/food/snacks/carpmeat,
+/obj/item/reagent_containers/food/snacks/carpmeat,
+/obj/item/reagent_containers/food/snacks/carpmeat,
 /turf/open/floor/plasteel/cafeteria,
 /area/centcom/holding)
 "zX" = (
@@ -9504,6 +9526,25 @@
 /obj/machinery/reagentgrinder,
 /obj/item/reagent_containers/glass/beaker/large,
 /turf/open/floor/plasteel/whitegreen,
+/area/centcom/holding)
+"Br" = (
+/obj/structure/closet{
+	anchored = 1;
+	desc = "A storage unit for plasmaman internals, courtesy of the Spider Clan.";
+	icon_state = "emergency";
+	name = "Plasmaman emergency closet"
+	},
+/obj/item/clothing/mask/breath,
+/obj/item/clothing/mask/breath,
+/obj/item/clothing/mask/breath,
+/obj/item/clothing/mask/breath,
+/obj/item/clothing/mask/breath,
+/obj/item/tank/internals/plasmaman/belt/full,
+/obj/item/tank/internals/plasmaman/belt/full,
+/obj/item/tank/internals/plasmaman/belt/full,
+/obj/item/tank/internals/plasmaman/belt/full,
+/obj/item/tank/internals/plasmaman/belt/full,
+/turf/open/floor/wood,
 /area/centcom/holding)
 "Bs" = (
 /obj/structure/table/wood,
@@ -10894,6 +10935,14 @@
 	},
 /obj/structure/chair/stool,
 /turf/open/floor/carpet/black,
+/area/centcom/holding)
+"Fg" = (
+/obj/item/twohanded/required/kirbyplants{
+	icon_state = "plant-21";
+	pixel_x = -3;
+	pixel_y = 3
+	},
+/turf/open/floor/wood,
 /area/centcom/holding)
 "Fh" = (
 /turf/open/floor/plasteel/cafeteria,
@@ -13461,14 +13510,6 @@
 	},
 /turf/open/floor/plasteel/whitegreen,
 /area/centcom/holding)
-"Nq" = (
-/mob/living/simple_animal/bot/medbot/mysterious{
-	desc = "If you don't accidentally blow yourself up from time to time you're not really a wizard anyway.";
-	faction = list("neutral","silicon","creature");
-	name = "Nobody's Perfect"
-	},
-/turf/open/floor/carpet/black,
-/area/centcom/holding)
 "Nv" = (
 /obj/structure/table,
 /turf/open/floor/plasteel/cafeteria{
@@ -13478,6 +13519,12 @@
 "Nw" = (
 /obj/machinery/recharge_station,
 /turf/open/floor/plasteel/airless/white,
+/area/centcom/holding)
+"Nx" = (
+/obj/structure/extinguisher_cabinet{
+	pixel_y = 32
+	},
+/turf/open/floor/wood,
 /area/centcom/holding)
 "Ny" = (
 /obj/machinery/modular_computer/console/preset/research,
@@ -13543,6 +13590,11 @@
 	},
 /turf/open/floor/plasteel,
 /area/centcom/control)
+"Oo" = (
+/obj/structure/table/wood,
+/obj/item/reagent_containers/food/snacks/chawanmushi,
+/turf/open/floor/wood,
+/area/centcom/holding)
 "Op" = (
 /obj/structure/sink{
 	dir = 8;
@@ -13568,6 +13620,7 @@
 /obj/item/clothing/under/geisha,
 /obj/item/clothing/under/kilt,
 /obj/structure/closet,
+/obj/item/clothing/under/roman,
 /turf/open/floor/wood,
 /area/centcom/holding)
 "Pa" = (
@@ -13612,6 +13665,15 @@
 	},
 /turf/open/floor/wood,
 /area/centcom/holding)
+"PH" = (
+/obj/structure/chair/wood/wings{
+	dir = 4
+	},
+/obj/machinery/defibrillator_mount/loaded{
+	pixel_y = 28
+	},
+/turf/open/floor/wood,
+/area/centcom/holding)
 "PI" = (
 /obj/machinery/biogenerator,
 /turf/open/floor/plasteel/whitegreen,
@@ -13634,6 +13696,12 @@
 "Qe" = (
 /turf/open/ai_visible,
 /area/ai_multicam_room)
+"Qj" = (
+/obj/structure/mineral_door/paperframe{
+	name = "Arcade"
+	},
+/turf/open/floor/wood,
+/area/centcom/holding)
 "Qk" = (
 /obj/structure/flora/ausbushes/fullgrass,
 /obj/structure/flora/ausbushes/ppflowers,
@@ -13723,6 +13791,11 @@
 	},
 /turf/open/floor/wood,
 /area/centcom/holding)
+"Rp" = (
+/obj/structure/table/wood,
+/obj/item/reagent_containers/food/snacks/sashimi,
+/turf/open/floor/wood,
+/area/centcom/holding)
 "RS" = (
 /obj/machinery/light{
 	dir = 8
@@ -13734,8 +13807,18 @@
 	},
 /turf/open/floor/wood,
 /area/centcom/holding)
+"Sa" = (
+/obj/machinery/door/window/westleft,
+/turf/open/floor/carpet/black,
+/area/centcom/holding)
 "Sd" = (
 /turf/open/floor/carpet/black,
+/area/centcom/holding)
+"Sm" = (
+/obj/item/twohanded/required/kirbyplants{
+	icon_state = "plant-10"
+	},
+/turf/open/floor/wood,
 /area/centcom/holding)
 "Sw" = (
 /obj/machinery/hydroponics/constructable,
@@ -13786,8 +13869,7 @@
 /turf/open/floor/plasteel/whitegreen,
 /area/centcom/holding)
 "Tb" = (
-/obj/item/clothing/under/roman,
-/obj/structure/closet,
+/obj/structure/closet/crate/freezer/blood,
 /turf/open/floor/wood,
 /area/centcom/holding)
 "Tn" = (
@@ -13865,12 +13947,6 @@
 /obj/structure/chair/stool/bar,
 /turf/open/floor/wood,
 /area/centcom/holding)
-"UH" = (
-/obj/machinery/door/airlock/wood{
-	req_one_access_txt = "28"
-	},
-/turf/open/floor/wood,
-/area/centcom/holding)
 "UO" = (
 /obj/machinery/door/airlock/centcom{
 	name = "CentCom Security";
@@ -13885,6 +13961,12 @@
 	},
 /turf/open/floor/plasteel,
 /area/centcom/control)
+"UQ" = (
+/obj/structure/mineral_door/paperframe{
+	name = "Dojo"
+	},
+/turf/open/floor/wood,
+/area/centcom/holding)
 "UT" = (
 /obj/structure/chair/wood/wings{
 	dir = 1
@@ -13895,12 +13977,34 @@
 /obj/machinery/computer/arcade,
 /turf/open/floor/wood,
 /area/centcom/holding)
+"UW" = (
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/turf/open/floor/carpet/black,
+/area/centcom/holding)
+"Vf" = (
+/mob/living/simple_animal/bot/medbot{
+	desc = "When engaged in combat, the vanquishing of thine enemy can be the warrior's only concern.";
+	name = "Hattori";
+	radio_key = null;
+	stationary_mode = 1
+	},
+/turf/open/floor/wood,
+/area/centcom/holding)
 "Vm" = (
 /obj/machinery/gibber,
 /obj/machinery/light{
 	dir = 1
 	},
 /turf/open/floor/plasteel/cafeteria,
+/area/centcom/holding)
+"Vq" = (
+/obj/machinery/door/window/eastright,
+/turf/open/floor/carpet/black,
 /area/centcom/holding)
 "Vu" = (
 /obj/structure/flora/ausbushes/fernybush,
@@ -13935,6 +14039,24 @@
 /obj/item/nullrod/scythe/vibro{
 	damtype = "stamina";
 	force = 30
+	},
+/turf/open/floor/wood,
+/area/centcom/holding)
+"VR" = (
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/turf/open/floor/carpet/black,
+/area/centcom/holding)
+"VU" = (
+/obj/structure/chair/wood/wings{
+	dir = 8
+	},
+/obj/machinery/defibrillator_mount/loaded{
+	pixel_y = 28
 	},
 /turf/open/floor/wood,
 /area/centcom/holding)
@@ -14052,7 +14174,7 @@
 /turf/open/floor/wood,
 /area/centcom/holding)
 "Yf" = (
-/obj/structure/table/wood/bar,
+/obj/structure/table/wood,
 /turf/open/floor/wood,
 /area/centcom/holding)
 "Yh" = (
@@ -14143,7 +14265,12 @@
 /turf/open/floor/wood,
 /area/centcom/holding)
 "Zx" = (
-/mob/living/simple_animal/bot/medbot,
+/mob/living/simple_animal/bot/medbot{
+	desc = "A little medical robot. You can make out the word \"sincerity\" on its chassis.";
+	name = "Hijikata";
+	radio_key = null;
+	stationary_mode = 1
+	},
 /turf/open/floor/wood,
 /area/centcom/holding)
 "ZJ" = (
@@ -14160,6 +14287,11 @@
 	},
 /turf/open/floor/plasteel,
 /area/centcom/evac)
+"ZK" = (
+/obj/structure/table/wood,
+/obj/item/reagent_containers/food/drinks/bottle/sake,
+/turf/open/floor/wood,
+/area/centcom/holding)
 "ZT" = (
 /mob/living/simple_animal/cow,
 /turf/open/floor/grass,
@@ -38806,7 +38938,7 @@ Xk
 Xk
 Tn
 NT
-Xk
+Fg
 Xk
 Xk
 NT
@@ -39323,7 +39455,7 @@ Nd
 Gs
 Xk
 Xk
-Re
+Qj
 Xk
 PF
 Xk
@@ -39834,7 +39966,7 @@ Xk
 Xk
 Tn
 NT
-Xk
+Sm
 Xk
 Xk
 NT
@@ -40612,7 +40744,7 @@ NT
 vt
 YV
 OU
-Tb
+OU
 RS
 VF
 Nd
@@ -40865,7 +40997,7 @@ Nd
 Gs
 Zx
 Xk
-Re
+UQ
 Xk
 Xk
 Xk
@@ -41123,7 +41255,7 @@ Xk
 Xk
 Xk
 NT
-XM
+PH
 XM
 Xk
 XM
@@ -41376,13 +41508,13 @@ Xk
 Xk
 HH
 Nd
-Xk
+Nx
 Ud
 Ud
 NT
+UW
 Po
-Po
-Sd
+Sa
 Po
 ZU
 Xk
@@ -41637,7 +41769,7 @@ Xk
 Ud
 Ud
 NT
-Sd
+zs
 Sd
 Sd
 Sd
@@ -41880,7 +42012,7 @@ Fh
 Nv
 ED
 Yo
-Yf
+Oo
 UE
 Xk
 Xk
@@ -41890,16 +42022,16 @@ Xk
 Xk
 Tn
 NT
-Xk
+Br
 Ud
 Ud
 NT
+zs
 Sd
 Sd
-Nq
 Sd
 MM
-Xk
+Vf
 Nd
 aa
 aa
@@ -42151,7 +42283,7 @@ Xk
 Ud
 Ud
 NT
-Sd
+zs
 Sd
 Sd
 Sd
@@ -42394,7 +42526,7 @@ Fh
 Fh
 BV
 Xk
-Yf
+Rp
 UE
 Xk
 Xk
@@ -42408,9 +42540,9 @@ Gs
 Ud
 Ud
 NT
+VR
 PA
-PA
-Sd
+Vq
 PA
 Pl
 Xk
@@ -42665,7 +42797,7 @@ Xk
 Xk
 Xk
 NT
-GY
+VU
 GY
 Xk
 GY
@@ -42906,9 +43038,9 @@ XL
 Fh
 Fh
 Fh
-UH
+XL
 Xk
-Yf
+ZK
 UE
 Xk
 Xk
@@ -42921,7 +43053,7 @@ NT
 Xk
 Xk
 Xk
-Re
+UQ
 Xk
 Xk
 Xk
@@ -43181,7 +43313,7 @@ Xk
 NT
 vt
 Mx
-OU
+wT
 Tb
 Uh
 tW

--- a/_maps/map_files/generic/CentCom.dmm
+++ b/_maps/map_files/generic/CentCom.dmm
@@ -11609,7 +11609,7 @@
 /area/tdome/tdomeobserve)
 "Hj" = (
 /obj/structure/urinal{
-	step_y = 28
+	pixel_y = 28
 	},
 /turf/open/floor/plasteel/airless/white,
 /area/centcom/holding)

--- a/code/modules/ninja/suit/n_suit_verbs/energy_net_nets.dm
+++ b/code/modules/ninja/suit/n_suit_verbs/energy_net_nets.dm
@@ -63,8 +63,6 @@ It is possible to destroy the net by the occupant or someone else.
 				if(istype(W, /obj/item/restraints/)) //No need for restraints once they're inside the weeb jail.
 					W.forceMove(get_turf(H.loc))
 					continue
-				else
-					W.forceMove(get_turf(H.loc))
 
 	playsound(affecting, 'sound/effects/sparks4.ogg', 50, TRUE)
 	new /obj/effect/temp_visual/dir_setting/ninja/phase/out(affecting.drop_location(), affecting.dir)

--- a/code/modules/ninja/suit/n_suit_verbs/energy_net_nets.dm
+++ b/code/modules/ninja/suit/n_suit_verbs/energy_net_nets.dm
@@ -10,13 +10,13 @@ It is possible to destroy the net by the occupant or someone else.
 	icon_state = "energynet"
 
 	density = TRUE //Can't pass through.
-	opacity = 0 //Can see through.
+	opacity = FALSE //Can see through.
 	mouse_opacity = MOUSE_OPACITY_ICON //So you can hit it with stuff.
 	anchored = TRUE //Can't drag/grab the net.
 	layer = ABOVE_ALL_MOB_LAYER
 	max_integrity = 25 //How much health it has.
-	can_buckle = 1
-	buckle_lying = 0
+	can_buckle = TRUE
+	buckle_lying = FALSE
 	buckle_prevents_pull = TRUE
 	var/mob/living/carbon/affecting //Who it is currently affecting, if anyone.
 	var/mob/living/carbon/master //Who shot web. Will let this person know if the net was successful or failed.
@@ -66,7 +66,7 @@ It is possible to destroy the net by the occupant or someone else.
 				else
 					W.forceMove(get_turf(H.loc))
 
-	playsound(affecting, 'sound/effects/sparks4.ogg', 50, 1)
+	playsound(affecting, 'sound/effects/sparks4.ogg', 50, TRUE)
 	new /obj/effect/temp_visual/dir_setting/ninja/phase/out(affecting.drop_location(), affecting.dir)
 
 	visible_message("[affecting] suddenly vanishes!")
@@ -76,8 +76,8 @@ It is possible to destroy the net by the occupant or someone else.
 	if(!QDELETED(master)) //As long as they still exist.
 		to_chat(master, "<span class='notice'><b>SUCCESS</b>: transport procedure of [affecting] complete.</span>")
 	do_sparks(5, FALSE, affecting)
-	playsound(affecting, 'sound/effects/phasein.ogg', 25, 1)
-	playsound(affecting, 'sound/effects/sparks2.ogg', 50, 1)
+	playsound(affecting, 'sound/effects/phasein.ogg', 25, TRUE)
+	playsound(affecting, 'sound/effects/sparks2.ogg', 50, TRUE)
 	new /obj/effect/temp_visual/dir_setting/ninja/phase(affecting.drop_location(), affecting.dir)
 
 /obj/structure/energy_net/attack_paw(mob/user)

--- a/code/modules/ninja/suit/n_suit_verbs/energy_net_nets.dm
+++ b/code/modules/ninja/suit/n_suit_verbs/energy_net_nets.dm
@@ -9,20 +9,26 @@ It is possible to destroy the net by the occupant or someone else.
 	icon = 'icons/effects/effects.dmi'
 	icon_state = "energynet"
 
-	density = TRUE//Can't pass through.
-	opacity = 0//Can see through.
-	mouse_opacity = MOUSE_OPACITY_ICON//So you can hit it with stuff.
-	anchored = TRUE//Can't drag/grab the net.
+	density = TRUE //Can't pass through.
+	opacity = 0 //Can see through.
+	mouse_opacity = MOUSE_OPACITY_ICON //So you can hit it with stuff.
+	anchored = TRUE //Can't drag/grab the net.
 	layer = ABOVE_ALL_MOB_LAYER
 	max_integrity = 25 //How much health it has.
 	can_buckle = 1
 	buckle_lying = 0
 	buckle_prevents_pull = TRUE
-	var/mob/living/carbon/affecting//Who it is currently affecting, if anyone.
-	var/mob/living/carbon/master//Who shot web. Will let this person know if the net was successful or failed.
-	var/check = 15//30 seconds before teleportation. Could be extended I guess.
+	var/mob/living/carbon/affecting //Who it is currently affecting, if anyone.
+	var/mob/living/carbon/master //Who shot web. Will let this person know if the net was successful or failed.
+	var/check = 15 //30 seconds before teleportation. Could be extended I guess.
 	var/success = FALSE
-
+	var/static/list/weeb_jail_essential_items = typecacheof(list( //Ninjas can't catch you when you're on fire
+		/obj/item/clothing/suit/space/eva/plasmaman, //That means you, plasmamen
+		/obj/item/clothing/under/,
+		/obj/item/clothing/head/helmet/space/plasmaman,
+		/obj/item/tank/internals,
+		/obj/item/clothing/mask/breath,
+		/obj/item/clothing/mask/gas))
 
 /obj/structure/energy_net/play_attack_sound(damage, damage_type = BRUTE, damage_flag = 0)
 	switch(damage_type)
@@ -35,13 +41,13 @@ It is possible to destroy the net by the occupant or someone else.
 	if(!success)
 		if(!QDELETED(affecting))
 			affecting.visible_message("[affecting.name] was recovered from the energy net!", "You were recovered from the energy net!", "<span class='italics'>You hear a grunt.</span>")
-		if(!QDELETED(master))//As long as they still exist.
+		if(!QDELETED(master)) //As long as they still exist.
 			to_chat(master, "<span class='userdanger'>ERROR</span>: unable to initiate transport protocol. Procedure terminated.")
 	return ..()
 
 /obj/structure/energy_net/process()
 	if(QDELETED(affecting)||affecting.loc!=loc)
-		qdel(src)//Get rid of the net.
+		qdel(src) //Get rid of the net.
 		return
 
 	if(check>0)
@@ -53,11 +59,12 @@ It is possible to destroy the net by the occupant or someone else.
 	if(ishuman(affecting))
 		var/mob/living/carbon/human/H = affecting
 		for(var/obj/item/W in H)
-			if(W == H.w_uniform)
-				continue//So all they're left with are shoes and uniform.
-			if(W == H.shoes)
-				continue
-			H.dropItemToGround(W)
+			if(!is_type_in_typecache(W, weeb_jail_essential_items) && H.temporarilyRemoveItemFromInventory(W)) //Remove all non-essential items, including implants.
+				if(istype(W, /obj/item/restraints/)) //No need for restraints once they're inside the weeb jail.
+					W.forceMove(get_turf(H.loc))
+					continue
+				else
+					W.forceMove(get_turf(H.loc))
 
 	playsound(affecting, 'sound/effects/sparks4.ogg', 50, 1)
 	new /obj/effect/temp_visual/dir_setting/ninja/phase/out(affecting.drop_location(), affecting.dir)
@@ -66,7 +73,7 @@ It is possible to destroy the net by the occupant or someone else.
 	affecting.forceMove(pick(GLOB.holdingfacility)) //Throw mob in to the holding facility.
 	to_chat(affecting, "<span class='danger'>You appear in a strange place!</span>")
 
-	if(!QDELETED(master))//As long as they still exist.
+	if(!QDELETED(master)) //As long as they still exist.
 		to_chat(master, "<span class='notice'><b>SUCCESS</b>: transport procedure of [affecting] complete.</span>")
 	do_sparks(5, FALSE, affecting)
 	playsound(affecting, 'sound/effects/phasein.ogg', 25, 1)
@@ -77,7 +84,7 @@ It is possible to destroy the net by the occupant or someone else.
 	return attack_hand()
 
 /obj/structure/energy_net/user_buckle_mob(mob/living/M, mob/living/user)
-	return//We only want our target to be buckled
+	return //We only want our target to be buckled
 
 /obj/structure/energy_net/user_unbuckle_mob(mob/living/buckled_mob, mob/living/user)
-	return//The net must be destroyed to free the target
+	return //The net must be destroyed to free the target


### PR DESCRIPTION
:cl: Denton
fix: The Spider Clan has issued an apology for stripping plasmamen of their protective suits and internals, stating that it was "kind of a dick move" and "will never happen again".
tweak: The Spider Clan holding facility has completed minor renovations. The dojo now includes medical and surgical equipment, while the lobby has a fire extinguisher and plasmaman internals. 
/:cl:

Fixes: #37517

I essentially replaced the net TP code with the gulag teleporter's and added plasmaman internals as well as a bunch of fluff to the holding facility.

Also:
Added a plasma internals locker since the TP will still remove plasma tanks if they're stored inside the suit slot (and the suit gets left behind).

Map edits unrelated to plasmamen:
The dojo now has medical items (defibs, synthflesh, surgical equipment, blood bags) so that people can actually fight more than once. Bar table has been replaced with the regular type that doesn't throw players.
Kitchen has a soap bar, box of spare lights and carp meat, hydroponics area has a spade/cultivator/bucket, restroom has a urinal, lathe area has a multitool.