### PR TITLE
Fixes Pubby maint boozeomat

### DIFF
--- a/_maps/map_files/PubbyStation/PubbyStation.dmm
+++ b/_maps/map_files/PubbyStation/PubbyStation.dmm
@@ -46986,10 +46986,7 @@
 /turf/open/floor/plasteel/dark,
 /area/library)
 "cBk" = (
-/obj/machinery/vending/boozeomat{
-	products = list(/obj/item/reagent_containers/food/drinks/bottle/whiskey = 1, /obj/item/reagent_containers/food/drinks/bottle/absinthe = 1, /obj/item/reagent_containers/food/drinks/bottle/limejuice = 1, /obj/item/reagent_containers/food/drinks/bottle/cream = 1, /obj/item/reagent_containers/food/drinks/soda_cans/tonic = 1, /obj/item/reagent_containers/food/drinks/drinkingglass = 10, /obj/item/reagent_containers/food/drinks/ice = 3, /obj/item/reagent_containers/food/drinks/drinkingglass/shotglass = 6, /obj/item/reagent_containers/food/drinks/flask = 1);
-	req_access_txt = "0"
-	},
+/obj/machinery/vending/boozeomat/maint,
 /turf/closed/wall,
 /area/maintenance/department/crew_quarters/dorms)
 "cBl" = (

--- a/code/modules/vending/boozeomat.dm
+++ b/code/modules/vending/boozeomat.dm
@@ -38,6 +38,18 @@
 	req_access_txt = "25"
 	refill_canister = /obj/item/vending_refill/boozeomat
 
+/obj/machinery/vending/boozeomat/maint
+	products = list(/obj/item/reagent_containers/food/drinks/bottle/whiskey = 1,
+			/obj/item/reagent_containers/food/drinks/bottle/absinthe = 1,
+			/obj/item/reagent_containers/food/drinks/bottle/limejuice = 1,
+			/obj/item/reagent_containers/food/drinks/bottle/cream = 1,
+			/obj/item/reagent_containers/food/drinks/soda_cans/tonic = 1,
+			/obj/item/reagent_containers/food/drinks/drinkingglass = 10,
+			/obj/item/reagent_containers/food/drinks/ice = 3,
+			/obj/item/reagent_containers/food/drinks/drinkingglass/shotglass = 6,
+			/obj/item/reagent_containers/food/drinks/flask = 1)
+	req_access_txt = "0"
+
 /obj/item/vending_refill/boozeomat
 	machine_name = "Booze-O-Mat"
 	icon_state = "refill_booze"


### PR DESCRIPTION
:cl: Denton
fix: The Pubbystation maint bar Booze-O-Mat now shows its contents correctly.
/:cl:

The Pubby maint boozeomat had its contents defined in the map file. Due to some bug, this would prevent the obj names from displaying.

![adsdaads](https://user-images.githubusercontent.com/32391752/40963972-3307800c-68aa-11e8-9f28-ffc8b0811ffb.PNG)
