### PR TITLE
Traitors can now get an objective to steal a specific slime extract.

### DIFF
--- a/code/game/gamemodes/objective_items.dm
+++ b/code/game/gamemodes/objective_items.dm
@@ -156,7 +156,7 @@
 	return 0
 
 /datum/objective_item/steal/slime
-	name = "an unused sample of slime extract."
+	name = "an unused sample of any slime extract."
 	targetitem = /obj/item/slime_extract
 	difficulty = 3
 	excludefromjob = list("Research Director","Scientist")
@@ -165,6 +165,15 @@
 	if(E.Uses > 0)
 		return 1
 	return 0
+
+/datum/objective_item/steal/specific
+	difficulty = 5
+
+/datum/objective_item/steal/specific/New()
+	..()
+	var/obj/target = pick(subtypesof(/obj/item/slime_extract))
+	name = initial(target.name)
+	targetitem = "an unused sample of [target]."
 
 //Unique Objectives
 /datum/objective_item/unique/docs_red


### PR DESCRIPTION
Changelogs]: # (Your PR should contain a detailed changelog of notable changes, titled and categorized appropriately. This includes, new features, sprites, sounds, balance changes, admin tools, map edits, removals, big refactors, config changes, hosting changes and important fixes. An example changelog has been provided below for you to edit. If you need additional help, read https://github.com/tgstation/tgstation/wiki/Changelogs)

:cl: 
tweak: NT has received reports that the Syndicate is fucking tired of getting gray slime extract every single time, and that agents are attempting to steal more powerful slime byproducts.
/:cl:

Why: Because the slime extract traitor objective is a total joke, and this at least adds some minor-to-major amount of challenge to it. This asks traitors to retrieve a specific extract. 

I didn't remove the regular objective because I don't know if people still want easy-ass objectives as a possibility, but if people would prefer it removed (I would honestly) then I can do that as well.

**HALP:** When manually adding a traitor objective, the randomization only happens once, i.e. if you go to add an objective manually it always is "steal a green extract" or whatever. I don't know how to fix this.