### PR TITLE
You can now mine entire veins of minerals with resonators

### DIFF
--- a/code/modules/mining/equipment/resonator.dm
+++ b/code/modules/mining/equipment/resonator.dm
@@ -114,3 +114,10 @@
 	. = ..()
 	transform = matrix()*1.5
 	animate(src, transform = matrix()*0.1, alpha = 50, time = 4)
+
+/obj/effect/resonance/proc/replicate(turf/M, creator, timetoburst) 
+	for(var/turf/closed/T in orange(1, M))
+		if(istype(T, M))
+			var/turf/closed/mineral/T2 = T
+			if(T2.mineralType) // so we don't end up in the ultimate chain reaction - Super322
+				new /obj/effect/resonance(T, creator, timetoburst)


### PR DESCRIPTION
:cl:
add: Resonance fields replicate onto adjacent minerals of the same variety. 
tweak: Resonators are now more useful for actual mining, you no longer have to regret your choice in 
/:cl:

[why]: # The resonator was simply tedious for mining. It wasn't garbage, but it most certainly wasn't appealing when you obtain better gear, so a QoL change was made and this is it.