### PR TITLE
Moved picture-in-picture objects down to the floor plane

### DIFF
--- a/code/_onclick/hud/picture_in_picture.dm
+++ b/code/_onclick/hud/picture_in_picture.dm
@@ -1,7 +1,7 @@
 /obj/screen/movable/pic_in_pic
 	name = "Picture-in-picture"
 	screen_loc = "CENTER"
-	plane = GAME_PLANE
+	plane = FLOOR_PLANE
 	var/atom/center
 	var/width = 0
 	var/height = 0


### PR DESCRIPTION
This makes the background not cover the outside tiles in the window.

:cl:
fix: Picture-in-picture objects now are no longer overlapped by other certain objects
/:cl: