### PR TITLE
Vehiclecode is now far more responsive when their movespeed delays are changed after they move.

### DIFF
--- a/code/datums/components/riding.dm
+++ b/code/datums/components/riding.dm
@@ -1,5 +1,5 @@
 /datum/component/riding
-	var/next_vehicle_move = 0 //used for move delays
+	var/last_vehicle_move = 0 //used for move delays
 	var/vehicle_move_delay = 2 //tick delay between movements, lower = faster, higher = slower
 	var/keytype
 
@@ -146,9 +146,9 @@
 		Unbuckle(user)
 		return
 
-	if(world.time < next_vehicle_move)
+	if(world.time < last_vehicle_move + vehicle_move_delay)
 		return
-	next_vehicle_move = world.time + vehicle_move_delay
+	last_vehicle_move = world.time
 
 	if(keycheck(user))
 		var/turf/next = get_step(AM, direction)


### PR DESCRIPTION
Instead of setting nextmove, now we check if last move and cooldown are more than the current time. This makes changing vehicle movement speed far more responsive.

:cl:
tweak: Vehicle speed changes now happen immediately instead of on the next movement cycle
/:cl: