### PR TITLE
Lets RCDs construct floors on lattices/catwalks

### DIFF
--- a/code/game/objects/structures/lattice.dm
+++ b/code/game/objects/structures/lattice.dm
@@ -55,6 +55,27 @@
 	if(current_size >= STAGE_FOUR)
 		deconstruct()
 
+/obj/structure/lattice/rcd_vals(mob/user, obj/item/construction/rcd/the_rcd)
+	switch(the_rcd.mode)
+		if(RCD_FLOORWALL)
+			return list("mode" = RCD_FLOORWALL, "delay" = 0, "cost" = 1)
+		if(RCD_DECONSTRUCT)
+			return list("mode" = RCD_DECONSTRUCT, "delay" = 0, "cost" = 1)
+	return FALSE
+
+/obj/structure/lattice/rcd_act(mob/user, obj/item/construction/rcd/the_rcd, passed_mode)
+	switch(passed_mode)
+		if(RCD_FLOORWALL)
+			to_chat(user, "<span class='notice'>You build a floor.</span>")
+			var/turf/T = get_turf(src)
+			T.PlaceOnTop(/turf/open/floor/plating)
+			return TRUE
+		if(RCD_DECONSTRUCT)
+			to_chat(user, "<span class='notice'>You deconstruct the lattice.</span>")
+			qdel(src)
+			return TRUE
+	return FALSE
+
 /obj/structure/lattice/clockwork
 	name = "cog lattice"
 	desc = "A lightweight support lattice. These hold the Justicar's station together."

--- a/code/game/objects/structures/lattice.dm
+++ b/code/game/objects/structures/lattice.dm
@@ -64,11 +64,14 @@
 	return FALSE
 
 /obj/structure/lattice/rcd_act(mob/user, obj/item/construction/rcd/the_rcd, passed_mode)
+	var/turf/ST = get_turf(src)
+	if(!istype(ST, /turf/open/space))
+		return FALSE
+
 	switch(passed_mode)
 		if(RCD_FLOORWALL)
 			to_chat(user, "<span class='notice'>You build a floor.</span>")
-			var/turf/T = get_turf(src)
-			T.PlaceOnTop(/turf/open/floor/plating)
+			ST.PlaceOnTop(/turf/open/floor/plating)
 			return TRUE
 		if(RCD_DECONSTRUCT)
 			to_chat(user, "<span class='notice'>You deconstruct the lattice.</span>")


### PR DESCRIPTION
:cl: Denton
fix: RCDs can now construct floors by clicking on lattices and catwalks (same as floor tiles).
/:cl:

Fixes: #38311

It was always pretty annoying that floor tiles can construct floors by clicking on lattices/catwalks, but RCD users had to click on the space turf underneath.