### PR TITLE
Fixes fires breaking indestructible turfs.

### DIFF
--- a/code/datums/components/thermite.dm
+++ b/code/datums/components/thermite.dm
@@ -60,7 +60,7 @@
 
 	if(amount >= 50)
 		var/burning_time = max(100, 100-amount)
-		master = master.ScrapeAway()
+		master = master.Melt()
 		master.burn_tile()
 		if(user)
 			master.add_hiddenprint(user)

--- a/code/game/turfs/closed.dm
+++ b/code/game/turfs/closed.dm
@@ -31,6 +31,10 @@
 /turf/closed/indestructible/acid_act(acidpwr, acid_volume, acid_id)
 	return 0
 
+/turf/closed/indestructible/Melt()
+	to_be_destroyed = FALSE
+	return src
+
 /turf/closed/indestructible/oldshuttle
 	name = "strange shuttle wall"
 	icon = 'icons/turf/shuttleold.dmi'

--- a/code/game/turfs/open.dm
+++ b/code/game/turfs/open.dm
@@ -18,6 +18,10 @@
 	icon = 'icons/turf/floors.dmi'
 	icon_state = "floor"
 
+/turf/open/indestructible/Melt()
+	to_be_destroyed = FALSE
+	return src
+
 /turf/open/indestructible/TerraformTurf(path, defer_change = FALSE, ignore_air = FALSE)
 	return
 

--- a/code/game/turfs/turf.dm
+++ b/code/game/turfs/turf.dm
@@ -457,3 +457,8 @@
 			var/datum/reagent/consumable/nutri_check = R
 			if(nutri_check.nutriment_factor >0)
 				M.reagents.remove_reagent(R.id,R.volume)
+
+//Whatever happens after high temperature fire dies out or thermite reaction works.
+//Should return new turf
+/turf/proc/Melt()
+	return ScrapeAway()

--- a/code/modules/atmospherics/environmental/LINDA_fire.dm
+++ b/code/modules/atmospherics/environmental/LINDA_fire.dm
@@ -231,7 +231,7 @@
 			else
 				chance_of_deletion = 100
 			if(prob(chance_of_deletion))
-				T.ScrapeAway()
+				T.Melt()
 			else
 				T.to_be_destroyed = FALSE
 				T.max_fire_temperature_sustained = 0


### PR DESCRIPTION
Fixes #38167

Not sure if unifying thermite with fires is fine, but it should be pretty much the same effect ?

Alternative fix would be to make indestructible turfs always flatten baseturfs of what's underneath, but not sure that's good idea @ninjanomnom 