### PR TITLE
makes the toy emagg look more obvious

### DIFF
--- a/code/game/objects/items/cards_ids.dm
+++ b/code/game/objects/items/cards_ids.dm
@@ -53,7 +53,7 @@
  * ID CARDS
  */
 /obj/item/card/emag
-	desc = "It's a card with a magnetic strip attached to some circuitry, You look at the back and see the letter S"
+	desc = "It's a card with a magnetic strip attached to some circuitry, You look at the back and see the letter S."
 	name = "cryptographic sequencer"
 	icon_state = "emag"
 	item_state = "card-id"
@@ -79,7 +79,7 @@
 	A.emag_act(user)
 
 /obj/item/card/emagfake
-	desc = "It's a card with a magnetic strip attached to some circuitry, You look at the back and see the letter N"
+	desc = "It's a card with a magnetic strip attached to some circuitry, You look at the back and see the letter N."
 	name = "cryptographic sequencer"
 	icon_state = "emag"
 	item_state = "card-id"

--- a/code/game/objects/items/cards_ids.dm
+++ b/code/game/objects/items/cards_ids.dm
@@ -53,7 +53,7 @@
  * ID CARDS
  */
 /obj/item/card/emag
-	desc = "It's a card with a magnetic strip attached to some circuitry."
+	desc = "It's a card with a magnetic strip attached to some circuitry, You look at the back and see the letter S"
 	name = "cryptographic sequencer"
 	icon_state = "emag"
 	item_state = "card-id"
@@ -79,8 +79,8 @@
 	A.emag_act(user)
 
 /obj/item/card/emagfake
-	desc = "It's a card with a magnetic strip attached to some circuitry."
-	name = "toy cryptographic sequencer"
+	desc = "It's a card with a magnetic strip attached to some circuitry, You look at the back and see the letter N"
+	name = "cryptographic sequencer"
 	icon_state = "emag"
 	item_state = "card-id"
 	lefthand_file = 'icons/mob/inhands/equipment/idcards_lefthand.dmi'

--- a/code/game/objects/items/cards_ids.dm
+++ b/code/game/objects/items/cards_ids.dm
@@ -80,7 +80,7 @@
 
 /obj/item/card/emagfake
 	desc = "It's a card with a magnetic strip attached to some circuitry."
-	name = "cryptographic sequencer"
+	name = "toy cryptographic sequencer"
 	icon_state = "emag"
 	item_state = "card-id"
 	lefthand_file = 'icons/mob/inhands/equipment/idcards_lefthand.dmi'


### PR DESCRIPTION
changed the fake emagg you can get from the arcade machine to be more obvious
so you dont have people validing you over a emagg
because >forced to use a joke antag item is bad design because why would you be forced to use against a airlock and ruin the airlock in entirity just to know its real
