### PR TITLE
Runtimestation tweaks

### DIFF
--- a/_maps/map_files/debug/runtimestation.dmm
+++ b/_maps/map_files/debug/runtimestation.dmm
@@ -304,7 +304,9 @@
 /obj/structure/cable{
 	icon_state = "2-4"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
+	dir = 8
+	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "aU" = (
@@ -318,6 +320,9 @@
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
 /turf/open/floor/plasteel,
 /area/engine/gravity_generator)
 "aV" = (
@@ -325,6 +330,9 @@
 	icon_state = "4-8"
 	},
 /obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -536,9 +544,6 @@
 /turf/open/floor/plasteel,
 /area/science)
 "bD" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
-	dir = 8
-	},
 /obj/machinery/light{
 	dir = 1
 	},
@@ -570,6 +575,8 @@
 /area/bridge)
 "bI" = (
 /obj/structure/table,
+/obj/item/card/emag,
+/obj/item/flashlight/emp/debug,
 /turf/open/floor/plasteel,
 /area/bridge)
 "bJ" = (
@@ -587,7 +594,7 @@
 /obj/item/rcd_ammo/large,
 /obj/item/rcd_ammo/large,
 /obj/item/rcd_ammo/large,
-/obj/item/construction/rcd,
+/obj/item/construction/rcd/combat,
 /turf/open/floor/plasteel,
 /area/bridge)
 "bM" = (
@@ -665,7 +672,7 @@
 	},
 /area/medical/medbay)
 "bX" = (
-/obj/machinery/sleeper,
+/obj/machinery/sleeper/syndie,
 /turf/open/floor/plasteel/arrival{
 	dir = 1
 	},
@@ -836,6 +843,7 @@
 /turf/open/floor/plasteel,
 /area/medical/medbay)
 "cz" = (
+/obj/structure/fans/tiny,
 /turf/open/floor/plating,
 /area/medical/medbay)
 "cA" = (
@@ -856,8 +864,8 @@
 	},
 /area/hallway/primary/central)
 "cC" = (
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden,
 /obj/machinery/camera/autoname,
+/obj/machinery/atmospherics/pipe/manifold4w/supply/hidden,
 /turf/open/floor/plasteel/blue/side{
 	dir = 1
 	},
@@ -902,7 +910,7 @@
 /area/medical/medbay)
 "cJ" = (
 /obj/item/gun/magic/staff/healing,
-/obj/item/gun/magic/wand/resurrection,
+/obj/item/gun/magic/wand/resurrection/debug,
 /turf/open/floor/plasteel/arrival{
 	dir = 10
 	},
@@ -1282,7 +1290,7 @@
 /obj/machinery/camera/autoname{
 	dir = 1
 	},
-/obj/item/gun/magic/wand/resurrection,
+/obj/item/gun/magic/wand/resurrection/debug,
 /turf/open/floor/plasteel,
 /area/storage/primary)
 "ei" = (
@@ -1361,10 +1369,25 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
+"lg" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/engine/engineering)
 "lK" = (
 /obj/effect/landmark/observer_start,
 /turf/open/floor/plating,
 /area/storage/primary)
+"lX" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
 "ny" = (
 /obj/structure/table,
 /obj/item/storage/toolbox/syndicate,
@@ -1398,6 +1421,12 @@
 "pQ" = (
 /obj/structure/cable{
 	icon_state = "4-8"
+	},
+/turf/open/floor/plasteel,
+/area/medical/chemistry)
+"pT" = (
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
+	dir = 8
 	},
 /turf/open/floor/plasteel,
 /area/medical/chemistry)
@@ -1462,6 +1491,7 @@
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
 	dir = 8
 	},
+/obj/machinery/rnd/production/techfab/department,
 /turf/open/floor/plasteel,
 /area/science)
 "BB" = (
@@ -1526,6 +1556,12 @@
 /obj/machinery/door/airlock,
 /turf/open/floor/plating,
 /area/hallway/primary/central)
+"JF" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/medical/chemistry)
 "Ly" = (
 /obj/machinery/chem_dispenser/chem_synthesizer,
 /turf/open/floor/plasteel/dark,
@@ -1557,6 +1593,7 @@
 /area/science)
 "Ut" = (
 /obj/structure/closet/secure_closet/medical3,
+/obj/item/healthanalyzer/advanced,
 /turf/open/floor/plasteel,
 /area/medical/medbay)
 "Vg" = (
@@ -1567,6 +1604,13 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
+/turf/open/floor/plasteel,
+/area/engine/engineering)
+"VA" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/structure/fans/tiny,
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "WT" = (
@@ -2637,7 +2681,7 @@ ce
 cp
 cv
 cC
-bE
+lX
 bE
 cR
 cY
@@ -2951,7 +2995,7 @@ ae
 ac
 ac
 aj
-Vy
+VA
 aj
 ac
 ac
@@ -3120,7 +3164,7 @@ be
 bx
 CV
 yp
-wT
+pT
 wT
 CK
 bN
@@ -3168,13 +3212,13 @@ af
 aj
 ar
 aF
-Vy
+lg
 bf
 bp
 aj
 bP
 pQ
-Ce
+JF
 Ce
 oV
 bE

--- a/_maps/map_files/debug/runtimestation.dmm
+++ b/_maps/map_files/debug/runtimestation.dmm
@@ -123,6 +123,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 5
 	},
+/obj/structure/cable,
 /turf/open/floor/plasteel,
 /area/engine/gravity_generator)
 "au" = (
@@ -437,7 +438,7 @@
 /obj/structure/table,
 /obj/item/analyzer,
 /obj/item/wrench,
-/turf/open/floor/plating,
+/turf/open/floor/plasteel,
 /area/engine/atmos)
 "bk" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
@@ -1003,7 +1004,8 @@
 	pixel_x = -24
 	},
 /obj/structure/cable,
-/turf/open/floor/plating,
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/plasteel,
 /area/storage/primary)
 "dc" = (
 /obj/effect/turf_decal/stripes/line{
@@ -1307,10 +1309,10 @@
 /turf/open/floor/plating,
 /area/science)
 "gM" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
+	dir = 1
+	},
+/obj/effect/turf_decal/stripes/corner{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -1430,6 +1432,12 @@
 	},
 /turf/open/floor/plasteel,
 /area/medical/chemistry)
+"qn" = (
+/obj/structure/cable{
+	icon_state = "0-2"
+	},
+/turf/open/floor/plating,
+/area/maintenance/department/bridge)
 "sE" = (
 /obj/machinery/power/rtg/advanced,
 /obj/structure/cable,
@@ -1494,6 +1502,12 @@
 /obj/machinery/rnd/production/techfab/department,
 /turf/open/floor/plasteel,
 /area/science)
+"Bl" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/closed/wall/r_wall,
+/area/engine/gravity_generator)
 "BB" = (
 /obj/item/storage/backpack/duffelbag/syndie/surgery,
 /obj/structure/table,
@@ -3116,7 +3130,7 @@ cF
 bE
 bE
 cS
-dl
+dB
 dl
 dl
 dl
@@ -3370,8 +3384,8 @@ aa
 ab
 ac
 ad
-af
-ak
+qn
+Bl
 at
 aH
 aW

--- a/code/game/objects/items/devices/flashlight.dm
+++ b/code/game/objects/items/devices/flashlight.dm
@@ -399,6 +399,11 @@
 		to_chat(user, "<span class='warning'>\The [src] needs time to recharge!</span>")
 	return
 
+/obj/item/flashlight/emp/debug //for testing emp_act()
+	name = "debug EMP flashlight"
+	emp_max_charges = 100
+	emp_cur_charges = 100
+
 // Glowsticks, in the uncomfortable range of similar to flares,
 // but not similar enough to make it worth a refactor
 /obj/item/flashlight/glowstick

--- a/code/modules/projectiles/guns/magic/wand.dm
+++ b/code/modules/projectiles/guns/magic/wand.dm
@@ -96,6 +96,10 @@
 	charges--
 	..()
 
+/obj/item/gun/magic/wand/resurrection/debug //for testing
+	name = "debug wand of healing"
+	max_charges = 500
+
 /////////////////////////////////////
 //WAND OF POLYMORPH
 /////////////////////////////////////


### PR DESCRIPTION
:cl: Denton
fix: Added missing vents to runtimestation.
tweak: Runtimestation: Added /debug EMP flashlight, emag, techfab and tiny fans. Replaced RCD, healing wand and sleeper with more suitable subtypes.
/:cl:

I added a few things to runtimestation that shouldn't affect load/compile times, but will make testing certain things faster than having to go through the admin/debug panel.

* Added a techfab, since every department but RnD/engineering is using them instead of lathe+printer
* Added vents to rooms with air alarms that were missing them
* Added a /debug EMP flashlight (more charges) and emag for testing emp_act(SEVERE) and emag_act()
* Replaced the RCD with the preloaded /combat subtype, sleeper with the syndie one and healing wands with /debug ones (more charges). Added advanced health analyzer for easy reagent metabolization and trauma testing.
* Added two tiny fans so the whole room doesn't get sucked out the airlock once you open it.
* Moved the single exposed wire from the spawn room to maint, so the mouse that spawns through squeak doesn't get in the way anymore.