### PR TITLE
Gives the toy emag a description showing that it is a toy.

### DIFF
--- a/code/game/objects/items/cards_ids.dm
+++ b/code/game/objects/items/cards_ids.dm
@@ -78,7 +78,7 @@
 	A.emag_act(user)
 
 /obj/item/card/emagfake
-	desc = "It's a card with a magnetic strip attached to some circuitry. Closer inspection shows that this card is a poorly made replica, with a "DonkCo" logo stamped on the back."
+	desc = "It's a card with a magnetic strip attached to some circuitry. Closer inspection shows that this card is a poorly made replica, with a /"DonkCo/" logo stamped on the back."
 	name = "cryptographic sequencer"
 	icon_state = "emag"
 	item_state = "card-id"

--- a/code/game/objects/items/cards_ids.dm
+++ b/code/game/objects/items/cards_ids.dm
@@ -78,7 +78,7 @@
 	A.emag_act(user)
 
 /obj/item/card/emagfake
-	desc = "It's a card with a magnetic strip attached to some circuitry."
+	desc = "It's a card with a magnetic strip attached to some circuitry. Closer inspection shows that this card is a poorly made replica, with a "DonkCo" logo stamped on the back."
 	name = "cryptographic sequencer"
 	icon_state = "emag"
 	item_state = "card-id"

--- a/code/game/objects/items/cards_ids.dm
+++ b/code/game/objects/items/cards_ids.dm
@@ -78,7 +78,7 @@
 	A.emag_act(user)
 
 /obj/item/card/emagfake
-	desc = "It's a card with a magnetic strip attached to some circuitry. Closer inspection shows that this card is a poorly made replica, with a /"DonkCo/" logo stamped on the back."
+	desc = "It's a card with a magnetic strip attached to some circuitry. Closer inspection shows that this card is a poorly made replica, with a \"DonkCo\" logo stamped on the back."
 	name = "cryptographic sequencer"
 	icon_state = "emag"
 	item_state = "card-id"


### PR DESCRIPTION
[Changelogs]: # (Your PR should contain a detailed changelog of notable changes, titled and categorized appropriately. This includes, new features, sprites, sounds, balance changes, admin tools, map edits, removals, big refactors, config changes, hosting changes and important fixes. An example changelog has been provided below for you to edit. If you need additional help, read https://github.com/tgstation/tgstation/wiki/Changelogs)

Keeps the toy emag consistent with other toys in the game. Players shouldn't be forced to risk damaging equipment to test if an emag is real or not.

:cl: MrDoomBringer
tweak: Due to DonkCo's recent budget cuts, their line of toy emags are now noticably less realistic. As such, you can now examine an emag to determine if it is a toy or not.
/:cl:

@improvedname was doing something like this but he closed his pr and I think deleted his branch so I guess I'll give it a go.
