### PR TITLE
Revert "makes tech point gen from rad collectors less useless"

### DIFF
--- a/code/modules/power/singularity/collector.dm
+++ b/code/modules/power/singularity/collector.dm
@@ -2,7 +2,7 @@
 #define RAD_COLLECTOR_EFFICIENCY 80 	// radiation needs to be over this amount to get power
 #define RAD_COLLECTOR_COEFFICIENT 100
 #define RAD_COLLECTOR_STORED_OUT 0.04	// (this*100)% of stored power outputted per tick. Doesn't actualy change output total, lower numbers just means collectors output for longer in absence of a source
-#define RAD_COLLECTOR_MINING_CONVERSION_RATE 0.01 //This is gonna need a lot of tweaking to get right. This is the number used to calculate the conversion of watts to research points per process()
+#define RAD_COLLECTOR_MINING_CONVERSION_RATE 0.00001 //This is gonna need a lot of tweaking to get right. This is the number used to calculate the conversion of watts to research points per process()
 #define RAD_COLLECTOR_OUTPUT min(stored_power, (stored_power*RAD_COLLECTOR_STORED_OUT)+1000) //Produces at least 1000 watts if it has more than that stored
 
 /obj/machinery/power/rad_collector


### PR DESCRIPTION
Reverts tgstation/tgstation#38289

THAT PR LETS YOU HAVE A MINIMUM OF 7K FUCKING RESEARCH POINTS PER *MINUTE* ON ONE SINGLE FUCKING RAD COLLECTOR WITH JUST THE ROUNDSTART SETUP. THAT MEANS IT'S ENTIRELY PLAUSIBLE TO GET RND 100% DONE IN ***ONLY*** TEN FUCKING MINUTES WITH MINIMUM EFFORT OR SETUP REQUIRED.

@Tlaltecuhtli why in the actual ***FUCK*** did you think those values in that PR were a good idea? did you do any testing at all?

The original values were so low to make it so that you have to put active effort into speedrunning RND. I've been able to get RND 100% done in 30 minutes without leaving engineering with the original values. 

And to those that want to abuse the new values the moment live recompiles? Here's a step by step guide

1. Set up the supermatter normally. You don't need to do anything special to 100% RnD with it anymore.
2. Instead of putting more plasma into the plasma tanks, put an equal amount of oxygen in the plasma tank to match the amount of plasma inside, then put the oxy/plasma tanks in the rad collectors
3. Wait for the rad collectors to suck the tanks dry. You'll hear a "ding" when the rad collectors run "dry"
4. The rad collectors now contain tritium and oxygen. Multitool every single rad collector and turn them back on. You are now generating upwards of 42k research points per minute if you're using a standard setup.
5. Have fun! You just completed RND without leaving the supermatter chamber.

:cl: deathride58
balance: Reverted the increased rad collector tech point gain rate.
/:cl: