### PR TITLE
Adds indestructible sandstone wall

### DIFF
--- a/code/game/turfs/closed.dm
+++ b/code/game/turfs/closed.dm
@@ -68,6 +68,12 @@
 	icon = 'icons/turf/walls/uranium_wall.dmi'
 	icon_state = "uranium"
 
+/turf/closed/indestructible/riveted/sandstone
+	name = "sandstone wall"
+	desc = "A wall with sandstone plating. Rough."
+	icon = 'icons/turf/walls/sandstone_wall.dmi'
+	icon_state = "sandstone"
+
 /turf/closed/indestructible/abductor
 	icon_state = "alien1"
 

--- a/code/game/turfs/closed.dm
+++ b/code/game/turfs/closed.dm
@@ -36,6 +36,14 @@
 	icon = 'icons/turf/shuttleold.dmi'
 	icon_state = "block"
 
+/turf/closed/indestructible/riveted/sandstone
+	name = "sandstone wall"
+	desc = "A wall with sandstone plating. Rough."
+	icon = 'icons/turf/walls/sandstone_wall.dmi'
+	icon_state = "sandstone"
+	baseturfs = /turf/closed/indestructible/riveted/sandstone
+	smooth = SMOOTH_TRUE
+
 /turf/closed/indestructible/oldshuttle/corner
 	icon_state = "corner"
 
@@ -67,13 +75,6 @@
 /turf/closed/indestructible/riveted/uranium
 	icon = 'icons/turf/walls/uranium_wall.dmi'
 	icon_state = "uranium"
-
-/turf/closed/indestructible/riveted/sandstone
-	name = "sandstone wall"
-	desc = "A wall with sandstone plating. Rough."
-	icon = 'icons/turf/walls/sandstone_wall.dmi'
-	icon_state = "sandstone"
-	baseturfs = /turf/closed/indestructible/riveted/sandstone
 
 /turf/closed/indestructible/abductor
 	icon_state = "alien1"

--- a/code/game/turfs/closed.dm
+++ b/code/game/turfs/closed.dm
@@ -36,12 +36,12 @@
 	icon = 'icons/turf/shuttleold.dmi'
 	icon_state = "block"
 
-/turf/closed/indestructible/riveted/sandstone
+/turf/closed/indestructible/sandstone
 	name = "sandstone wall"
 	desc = "A wall with sandstone plating. Rough."
 	icon = 'icons/turf/walls/sandstone_wall.dmi'
 	icon_state = "sandstone"
-	baseturfs = /turf/closed/indestructible/riveted/sandstone
+	baseturfs = /turf/closed/indestructible/sandstone
 	smooth = SMOOTH_TRUE
 
 /turf/closed/indestructible/oldshuttle/corner

--- a/code/game/turfs/closed.dm
+++ b/code/game/turfs/closed.dm
@@ -36,6 +36,13 @@
 	icon = 'icons/turf/shuttleold.dmi'
 	icon_state = "block"
 
+/turf/closed/indestructible/sandstone
+	name = "sandstone wall"
+	desc = "A wall with sandstone plating. Rough."
+	icon = 'icons/turf/walls/sandstone_wall.dmi'
+	icon_state = "sandstone"
+	baseturfs = /turf/closed/indestructible/sandstone
+
 /turf/closed/indestructible/oldshuttle/corner
 	icon_state = "corner"
 
@@ -67,12 +74,6 @@
 /turf/closed/indestructible/riveted/uranium
 	icon = 'icons/turf/walls/uranium_wall.dmi'
 	icon_state = "uranium"
-
-/turf/closed/indestructible/riveted/sandstone
-	name = "sandstone wall"
-	desc = "A wall with sandstone plating. Rough."
-	icon = 'icons/turf/walls/sandstone_wall.dmi'
-	icon_state = "sandstone"
 
 /turf/closed/indestructible/abductor
 	icon_state = "alien1"

--- a/code/game/turfs/closed.dm
+++ b/code/game/turfs/closed.dm
@@ -36,13 +36,6 @@
 	icon = 'icons/turf/shuttleold.dmi'
 	icon_state = "block"
 
-/turf/closed/indestructible/sandstone
-	name = "sandstone wall"
-	desc = "A wall with sandstone plating. Rough."
-	icon = 'icons/turf/walls/sandstone_wall.dmi'
-	icon_state = "sandstone"
-	baseturfs = /turf/closed/indestructible/sandstone
-
 /turf/closed/indestructible/oldshuttle/corner
 	icon_state = "corner"
 
@@ -74,6 +67,13 @@
 /turf/closed/indestructible/riveted/uranium
 	icon = 'icons/turf/walls/uranium_wall.dmi'
 	icon_state = "uranium"
+
+/turf/closed/indestructible/riveted/sandstone
+	name = "sandstone wall"
+	desc = "A wall with sandstone plating. Rough."
+	icon = 'icons/turf/walls/sandstone_wall.dmi'
+	icon_state = "sandstone"
+	baseturfs = /turf/closed/indestructible/riveted/sandstone
 
 /turf/closed/indestructible/abductor
 	icon_state = "alien1"


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/31262308/41137422-12b306ea-6aa9-11e8-9813-81df0eb4fd69.png)


:cl:
imageadd: sandstone wall sprite for indestructible object
/:cl:

[why]: # I needed an indestructible sandstone wall for the Ball. It doesn't add any sprites so I can't imagine this should be too difficult. I was gonna make them with normal sandstone walls but then I realized that's a horrible idea.
