### PR TITLE
Removes firing pins from portal and gravity guns.

### DIFF
--- a/code/modules/projectiles/guns/energy/special.dm
+++ b/code/modules/projectiles/guns/energy/special.dm
@@ -176,6 +176,7 @@
 	desc = "A projector that emits high density quantum-coupled bluespace beams."
 	ammo_type = list(/obj/item/ammo_casing/energy/wormhole, /obj/item/ammo_casing/energy/wormhole/orange)
 	item_state = null
+	pin = null
 	icon_state = "wormhole_projector"
 	var/obj/effect/portal/p_blue
 	var/obj/effect/portal/p_orange
@@ -297,4 +298,5 @@
 	ammo_type = list(/obj/item/ammo_casing/energy/gravityrepulse, /obj/item/ammo_casing/energy/gravityattract, /obj/item/ammo_casing/energy/gravitychaos)
 	item_state = "gravity_gun"
 	icon_state = "gravity_gun"
+	pin = null
 	var/power = 4


### PR DESCRIPTION
These things are used almost exclusively to grief, and can be extremely dangerous or disruptive when used right.

Portal guns routinely space people on the shuttle, can get you into almost anywhere you want for free, and are just really fucking annoying.
Shooting a gravity gun into botany can easily crit someone from the sheer amount of items on the ground, and it's always a huge pain in the ass to clean up the mess they cause anyway.

A traitor can simply emag a test range firing pin if they want to use them, so legitimate antag use isn't hindered by removing the pins, only greyshitters. Fuck these things, the gravity gun isn't even useful for anything other than chaos.