### PR TITLE
Replace area-wide fire overlay with reddening the lights

### DIFF
--- a/code/game/area/areas.dm
+++ b/code/game/area/areas.dm
@@ -18,13 +18,10 @@
 	var/clockwork_warp_allowed = TRUE // Can servants warp into this area from Reebe?
 	var/clockwork_warp_fail = "The structure there is too dense for warping to pierce. (This is normal in high-security areas.)"
 
-	var/eject = null
-
 	var/fire = null
 	var/atmos = TRUE
 	var/atmosalm = FALSE
 	var/poweralm = TRUE
-	var/party = null
 	var/lightswitch = TRUE
 
 	var/requires_power = TRUE
@@ -256,9 +253,7 @@ GLOBAL_LIST_EMPTY(teleportlocs)
 
 /area/proc/firereset(obj/source)
 	if (fire)
-		fire = 0
-		mouse_opacity = MOUSE_OPACITY_TRANSPARENT
-		updateicon()
+		unset_fire_alarm_effects()
 		ModifyFiredoors(TRUE)
 		for(var/item in firealarms)
 			var/obj/machinery/firealarm/F = item
@@ -290,7 +285,7 @@ GLOBAL_LIST_EMPTY(teleportlocs)
 		DOOR.lock()
 
 /area/proc/burglaralert(obj/trigger)
-	if(always_unpowered == 1) //no burglar alarms in space/asteroid
+	if(always_unpowered) //no burglar alarms in space/asteroid
 		return
 
 	//Trigger alarm effect
@@ -306,61 +301,32 @@ GLOBAL_LIST_EMPTY(teleportlocs)
 			addtimer(CALLBACK(SILICON, /mob/living/silicon.proc/cancelAlarm,"Burglar",src,trigger), 600)
 
 /area/proc/set_fire_alarm_effect()
-	fire = 1
-	updateicon()
+	fire = TRUE
 	mouse_opacity = MOUSE_OPACITY_TRANSPARENT
+	for(var/alarm in firealarms)
+		var/obj/machinery/firealarm/F = alarm
+		F.update_fire_light(fire)
+	for(var/obj/machinery/light/L in src)
+		L.update()
 
-/area/proc/readyalert()
-	if(name == "Space")
-		return
-	if(!eject)
-		eject = 1
-		updateicon()
-
-/area/proc/readyreset()
-	if(eject)
-		eject = 0
-		updateicon()
-
-/area/proc/partyalert()
-	if(src.name == "Space") //no parties in space!!!
-		return
-	if (!( src.party ))
-		src.party = 1
-		src.updateicon()
-		src.mouse_opacity = MOUSE_OPACITY_TRANSPARENT
-
-/area/proc/partyreset()
-	if (src.party)
-		src.party = 0
-		src.mouse_opacity = MOUSE_OPACITY_TRANSPARENT
-		src.updateicon()
-		for(var/obj/machinery/door/firedoor/D in src)
-			if(!D.welded)
-				if(D.operating)
-					D.nextstate = OPEN
-				else if(D.density)
-					INVOKE_ASYNC(D, /obj/machinery/door/firedoor.proc/open)
+/area/proc/unset_fire_alarm_effects()
+	fire = FALSE
+	mouse_opacity = MOUSE_OPACITY_TRANSPARENT
+	for(var/alarm in firealarms)
+		var/obj/machinery/firealarm/F = alarm
+		F.update_fire_light(fire)
+	for(var/obj/machinery/light/L in src)
+		L.update()
 
 /area/proc/updateicon()
-	if ((fire || eject || party) && (!requires_power||power_environ))//If it doesn't require power, can still activate this proc.
-		if(fire && !eject && !party)
-			icon_state = "blue"
-		else if(!fire && eject && !party)
-			icon_state = "red"
-		else if(party && !fire && !eject)
-			icon_state = "party"
-		else
-			icon_state = "blue-red"
-	else
-		var/weather_icon
-		for(var/V in SSweather.processing)
-			var/datum/weather/W = V
-			if(W.stage != END_STAGE && (src in W.impacted_areas))
-				W.update_areas()
-				weather_icon = TRUE
-		if(!weather_icon)
-			icon_state = null
+	var/weather_icon
+	for(var/V in SSweather.processing)
+		var/datum/weather/W = V
+		if(W.stage != END_STAGE && (src in W.impacted_areas))
+			W.update_areas()
+			weather_icon = TRUE
+	if(!weather_icon)
+		icon_state = null
 
 /area/space/updateicon()
 	icon_state = null

--- a/code/game/machinery/doors/firedoor.dm
+++ b/code/game/machinery/doors/firedoor.dm
@@ -15,7 +15,6 @@
 	resistance_flags = FIRE_PROOF
 	heat_proof = TRUE
 	glass = TRUE
-	var/nextstate = null
 	sub_door = TRUE
 	explosion_block = 1
 	safe = FALSE
@@ -24,6 +23,7 @@
 	assemblytype = /obj/structure/firelock_frame
 	armor = list("melee" = 30, "bullet" = 30, "laser" = 20, "energy" = 20, "bomb" = 10, "bio" = 100, "rad" = 100, "fire" = 95, "acid" = 70)
 	interaction_flags_machine = INTERACT_MACHINE_WIRES_IF_OPEN | INTERACT_MACHINE_ALLOW_SILICON | INTERACT_MACHINE_OPEN_SILICON | INTERACT_MACHINE_REQUIRES_SILICON | INTERACT_MACHINE_OPEN
+	var/nextstate = null
 	var/boltslocked = TRUE
 	var/list/affecting_areas
 

--- a/code/game/machinery/firealarm.dm
+++ b/code/game/machinery/firealarm.dm
@@ -23,9 +23,14 @@
 	idle_power_usage = 2
 	active_power_usage = 6
 	power_channel = ENVIRON
+	resistance_flags = FIRE_PROOF
+
+	light_power = 0
+	light_range = 7
+	light_color = "#ff3232"
+
 	var/detecting = 1
 	var/buildstage = 2 // 2 = complete, 1 = no wires, 0 = circuit gone
-	resistance_flags = FIRE_PROOF
 	var/last_alarm = 0
 	var/area/myarea = null
 
@@ -273,35 +278,10 @@
 		new /obj/item/stack/cable_coil(loc, 3)
 	qdel(src)
 
-
-/*
- * Party button
- */
-
-/obj/machinery/firealarm/partyalarm
-	name = "\improper PARTY BUTTON"
-	desc = "Cuban Pete is in the house!"
-
-
-/obj/machinery/firealarm/partyalarm/reset()
-	if (stat & (NOPOWER|BROKEN))
-		return
-	var/area/A = src.loc
-	A = A.loc
-	if (!( istype(A, /area) ))
-		return
-	A.partyreset()
-
-/obj/machinery/firealarm/partyalarm/alarm()
-	if (stat & (NOPOWER|BROKEN))
-		return
-	var/area/A = src.loc
-	A = A.loc
-	if (!( istype(A, /area) ))
-		return
-	A.partyalert()
-
-/obj/machinery/firealarm/partyalarm/ui_data(mob/user)
-	. = ..()
-	var/area/A = get_area(src)
-	.["alarm"] = A.party
+/obj/machinery/firealarm/proc/update_fire_light(fire)
+	if(fire == !!light_power)
+		return  // do nothing if we're already active
+	if(fire)
+		set_light(l_power = 0.8)
+	else
+		set_light(l_power = 0)

--- a/code/modules/power/lighting.dm
+++ b/code/modules/power/lighting.dm
@@ -296,7 +296,8 @@
 	cut_overlays()
 	switch(status)		// set icon_states
 		if(LIGHT_OK)
-			if(emergency_mode)
+			var/area/A = get_area(src)
+			if(emergency_mode || (A && A.fire))
 				icon_state = "[base_state]_emergency"
 			else
 				icon_state = "[base_state]"
@@ -319,9 +320,16 @@
 			on = FALSE
 	emergency_mode = FALSE
 	if(on)
-		var/BR = nightshift_enabled? nightshift_brightness : brightness
-		var/PO = nightshift_enabled? nightshift_light_power : bulb_power
-		var/CO = nightshift_enabled? nightshift_light_color : bulb_colour
+		var/BR = brightness
+		var/PO = bulb_power
+		var/CO = bulb_colour
+		var/area/A = get_area(src)
+		if (A && A.fire)
+			CO = bulb_emergency_colour
+		else if (nightshift_enabled)
+			BR = nightshift_brightness
+			PO = nightshift_light_power
+			CO = nightshift_light_color
 		var/matching = light && BR == light.light_range && PO == light.light_power && CO == light.light_color
 		if(!matching)
 			switchcount++


### PR DESCRIPTION
:cl:
tweak: Fire alarms now redden all the room's lights, and emit light themselves, rather than applying an area-wide overlay.
fix: Fire alarms no longer visually conflict with radiation storms.
/:cl:

Fixes #35415.

|**Old Appearance**|**New Appearance**|
|-|-|
| ![space station 13 2018-06-08 141618](https://user-images.githubusercontent.com/222630/41181582-1c886e20-6b27-11e8-8ed8-c494fbacd487.png) | ![ss13 superbox station 13 2018-06-08 141003](https://user-images.githubusercontent.com/222630/41181596-2f1712b2-6b27-11e8-8bfe-a6782d62cb76.png) |
| ![space station 13 2018-06-08 141645](https://user-images.githubusercontent.com/222630/41181583-1dbf7612-6b27-11e8-8316-5df2c9863536.png) | ![ss13 superbox station 13 2018-06-08 141054](https://user-images.githubusercontent.com/222630/41181598-31699e0e-6b27-11e8-913c-ecbd0880523b.png) |
| ![space station 13 2018-06-08 141654](https://user-images.githubusercontent.com/222630/41181585-1f030476-6b27-11e8-89fe-f5f5d2673f1f.png) | ![ss13 superbox station 13 2018-06-08 141103](https://user-images.githubusercontent.com/222630/41181600-33b0359c-6b27-11e8-9d60-9fba233cf38c.png) |
| ![space station 13 2018-06-08 142952](https://user-images.githubusercontent.com/222630/41182012-c5a3b63a-6b28-11e8-82f8-90fb1bab1404.png) | ![ss13 superbox station 13 2018-06-08 143157](https://user-images.githubusercontent.com/222630/41182023-cea0b47c-6b28-11e8-805b-3a861f6c6fcc.png) |

## Originals for reference
![ss13 superbox station 13 2018-06-08 141239](https://user-images.githubusercontent.com/222630/41181529-e83d9884-6b26-11e8-8ee3-7bc4a4d36b9a.png)
![ss13 superbox station 13 2018-06-08 141214](https://user-images.githubusercontent.com/222630/41181541-f3d71bf2-6b26-11e8-8bf5-3f54284d7087.png)



