### PR TITLE
Removes reactive incendiary armor from non-admin methods of obtaining

### DIFF
--- a/code/modules/clothing/suits/reactive_armour.dm
+++ b/code/modules/clothing/suits/reactive_armour.dm
@@ -10,8 +10,8 @@
 	var/static/list/anomaly_armour_types = list(
 		/obj/effect/anomaly/grav	                = /obj/item/clothing/suit/armor/reactive/repulse,
 		/obj/effect/anomaly/flux 	           		= /obj/item/clothing/suit/armor/reactive/tesla,
-		/obj/effect/anomaly/bluespace 	            = /obj/item/clothing/suit/armor/reactive/teleport,
-		/obj/effect/anomaly/pyro	  			    = /obj/item/clothing/suit/armor/reactive/fire)
+		/obj/effect/anomaly/bluespace 	            = /obj/item/clothing/suit/armor/reactive/teleport
+		)
 
 	if(istype(I, /obj/item/assembly/signaler/anomaly))
 		var/obj/item/assembly/signaler/anomaly/A = I


### PR DESCRIPTION
Why: It sets EVERYONE on screen on fire, instantly. No counterplay unless you're in a suit or you're very good at extinguishing yourself instantly and people around you don't just set you on fire. It can purge a shuttle effortlessly. I think this should be reworked before being made acquirable

Also gravity armor is the same thing but this is the worst offender.
Allegedly people also say "it's an accident" to admins when they set the shuttle on fire with this.
This specific piece of armor needs rethinking.
:cl:
experimental: Pending rework, reactive incendiary armor is now adminspawn only. Pyro anomalies will instead give stealth armor.
/:cl: