### PR TITLE
Readds actual fun to admins throwing around drop pods

### DIFF
--- a/code/game/objects/structures/crates_lockers/closets/secure/supplypod.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/supplypod.dm
@@ -106,11 +106,13 @@
 
 /obj/effect/DPtarget/Initialize(mapload, var/SO, var/podID, var/target)
 	. = ..()
-	var/delayTime = 30//default time is 3 seconds
+	var/delayTime = 17			//We're forcefully adminspawned, make it faster
 	switch(podID)
+		if(POD_STANDARD)
+			delayTime = 30
 		if(POD_BLUESPACE)
 			delayTime = 15
-		if(POD_CENTCOM)
+		if(POD_CENTCOM)			//Admin smite, even faster.
 			delayTime = 5//speedy delivery
 
 	addtimer(CALLBACK(src, .proc/beginLaunch, SO, podID), delayTime)//standard pods take 3 seconds to come in, bluespace pods take 1.5

--- a/code/game/objects/structures/crates_lockers/closets/secure/supplypod.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/supplypod.dm
@@ -106,7 +106,7 @@
 
 /obj/effect/DPtarget/Initialize(mapload, var/SO, var/podID, var/target)
 	. = ..()
-	var/delayTime = 30//default time is 30 seconds
+	var/delayTime = 30//default time is 3 seconds
 	switch(podID)
 		if(POD_BLUESPACE)
 			delayTime = 15
@@ -121,18 +121,21 @@
 	addtimer(CALLBACK(src, .proc/endLaunch, SO, podID), 3, TIMER_CLIENT_TIME)//fall 0.3seconds
 
 /obj/effect/DPtarget/proc/endLaunch(var/SO, var/podID)
-	if (podID == POD_STANDARD)
+	if(podID == POD_STANDARD)
 		new /obj/structure/closet/supplypod(drop_location(), SO)//pod is created
 		explosion(src,0,0,2, flame_range = 3) //less advanced equipment than bluespace pod, so larger explosion when landing
-	else if (podID == POD_BLUESPACE)
+	else if(podID == POD_BLUESPACE)
 		new /obj/structure/closet/supplypod/bluespacepod(drop_location(), SO)//pod is created
 		explosion(src,0,0,2, flame_range = 1) //explosion and camshake (shoutout to @cyberboss)
-	else
+	else if(podID == POD_CENTCOM)
 		new /obj/structure/closet/supplypod/bluespacepod/centcompod(drop_location(), SO)//CentCom supplypods dont create explosions; instead they directly deal 40 fire damage to people on the turf
 		var/turf/T = get_turf(src)
 		T.hotspot_expose(700, 50, 1)//same as fireball
 		for(var/mob/living/M in T.contents)
 			M.adjustFireLoss(40)
+	else			//We're buildmoded or directly spawned, blow them up damnit.
+		new /obj/structure/closet/supplypod/bluespacepod/centcompod(drop_location(), SO)
+		explosion(src, 0, 0, 2, flame_range = 3)
 	qdel(src)
 
 /obj/effect/DPtarget/Destroy()


### PR DESCRIPTION
Why didn't I notice this earlier. Admins can now blow people up with pods if spawned via buildmode/spawn/gamepanel instead of smite, as it should be.