### PR TITLE
Turf grammar omnibus

### DIFF
--- a/code/game/atoms.dm
+++ b/code/game/atoms.dm
@@ -2,6 +2,7 @@
 	layer = TURF_LAYER
 	plane = GAME_PLANE
 	var/level = 2
+	var/article  // If non-null, overrides a/an/some in all cases
 
 	var/flags_1 = NONE
 	var/interaction_flags_atom = NONE
@@ -241,7 +242,10 @@
 
 /atom/proc/get_examine_name(mob/user)
 	. = "\a [src]"
-	var/list/override = list(gender == PLURAL? "some" : "a" , " ", "[name]")
+	var/list/override = list(gender == PLURAL ? "some" : "a", " ", "[name]")
+	if(article)
+		. = "[article] [src]"
+		override[EXAMINE_POSITION_ARTICLE] = article
 	if(SendSignal(COMSIG_ATOM_GET_EXAMINE_NAME, user, override) & COMPONENT_EXNAME_CHANGED)
 		. = override.Join("")
 

--- a/code/game/turfs/open.dm
+++ b/code/game/turfs/open.dm
@@ -88,7 +88,7 @@
 	baseturfs = /turf/open/indestructible/airblock
 
 /turf/open/indestructible/clock_spawn_room
-	name = "cogmetal"
+	name = "cogmetal floor"
 	desc = "Brass plating that gently radiates heat. For some reason, it reminds you of blood."
 	icon_state = "reebe"
 	baseturfs = /turf/open/indestructible/clock_spawn_room

--- a/code/game/turfs/simulated/floor/fancy_floor.dm
+++ b/code/game/turfs/simulated/floor/fancy_floor.dm
@@ -104,6 +104,7 @@
 	return
 
 /turf/open/floor/grass/snow/basalt //By your powers combined, I am captain planet
+	gender = NEUTER
 	name = "volcanic floor"
 	icon = 'icons/turf/floors.dmi'
 	icon_state = "basalt"

--- a/code/game/turfs/simulated/floor/fancy_floor.dm
+++ b/code/game/turfs/simulated/floor/fancy_floor.dm
@@ -85,6 +85,7 @@
 		return
 
 /turf/open/floor/grass/snow
+	gender = PLURAL
 	name = "snow"
 	icon = 'icons/turf/snow.dmi'
 	desc = "Looks cold."

--- a/code/game/turfs/simulated/floor/mineral_floor.dm
+++ b/code/game/turfs/simulated/floor/mineral_floor.dm
@@ -118,7 +118,7 @@
 	initial_gas_mix = "TEMP=2.7"
 
 /turf/open/floor/mineral/plastitanium/brig
-	name = "Brig floor"
+	name = "brig floor"
 
 //BANANIUM
 

--- a/code/game/turfs/simulated/floor/mineral_floor.dm
+++ b/code/game/turfs/simulated/floor/mineral_floor.dm
@@ -174,6 +174,7 @@
 //URANIUM
 
 /turf/open/floor/mineral/uranium
+	gender = PLURAL // avoid "an uranium floor"
 	name = "uranium floor"
 	icon_state = "uranium"
 	floor_tile = /obj/item/stack/tile/mineral/uranium

--- a/code/game/turfs/simulated/floor/mineral_floor.dm
+++ b/code/game/turfs/simulated/floor/mineral_floor.dm
@@ -174,7 +174,7 @@
 //URANIUM
 
 /turf/open/floor/mineral/uranium
-	gender = PLURAL // avoid "an uranium floor"
+	article = "a"
 	name = "uranium floor"
 	icon_state = "uranium"
 	floor_tile = /obj/item/stack/tile/mineral/uranium

--- a/code/game/turfs/simulated/floor/misc_floor.dm
+++ b/code/game/turfs/simulated/floor/misc_floor.dm
@@ -47,17 +47,17 @@
 	initial_gas_mix = "TEMP=2.7"
 
 /turf/open/floor/circuit/killroom
-	name = "Killroom Floor"
+	name = "killroom Floor"
 	initial_gas_mix = "n2=500;TEMP=80"
 
 /turf/open/floor/circuit/telecomms
 	initial_gas_mix = "n2=100;TEMP=80"
 
 /turf/open/floor/circuit/telecomms/mainframe
-	name = "Mainframe Base"
+	name = "mainframe Base"
 
 /turf/open/floor/circuit/telecomms/server
-	name = "Server Base"
+	name = "server Base"
 
 /turf/open/floor/circuit/green
 	icon_state = "gcircuit"
@@ -81,7 +81,7 @@
 	initial_gas_mix = "n2=100;TEMP=80"
 
 /turf/open/floor/circuit/green/telecomms/mainframe
-	name = "Mainframe Base"
+	name = "mainframe Base"
 
 /turf/open/floor/circuit/red
 	icon_state = "rcircuit"

--- a/code/game/turfs/simulated/floor/plasteel_floor.dm
+++ b/code/game/turfs/simulated/floor/plasteel_floor.dm
@@ -363,7 +363,7 @@
 
 /turf/open/floor/plasteel/goonplaque
 	icon_state = "plaque"
-	name = "Commemorative Plaque"
+	name = "commemorative plaque"
 	desc = "\"This is a plaque in honour of our comrades on the G4407 Stations. Hopefully TG4407 model can live up to your fame and fortune.\" Scratched in beneath that is a crude image of a meteor and a spaceman. The spaceman is laughing. The meteor is exploding."
 
 /turf/open/floor/plasteel/cult/narsie_act()

--- a/code/game/turfs/simulated/floor/plasteel_floor.dm
+++ b/code/game/turfs/simulated/floor/plasteel_floor.dm
@@ -26,11 +26,11 @@
 /turf/open/floor/plasteel/dark/telecomms
 	initial_gas_mix = "n2=100;TEMP=80"
 /turf/open/floor/plasteel/dark/telecomms/mainframe
-	name = "Mainframe Floor"
+	name = "mainframe floor"
 /turf/open/floor/plasteel/dark/telecomms/server
-	name = "Server Base"
+	name = "server base"
 /turf/open/floor/plasteel/dark/telecomms/server/walkway
-	name = "Server Walkway"
+	name = "server walkway"
 /turf/open/floor/plasteel/airless/dark
 	icon_state = "darkfull"
 /turf/open/floor/plasteel/dark/side
@@ -60,7 +60,7 @@
 /turf/open/floor/plasteel/brown/telecomms
 	initial_gas_mix = "n2=100;TEMP=80"
 /turf/open/floor/plasteel/brown/telecomms/mainframe
-	name = "Mainframe Floor"
+	name = "mainframe Floor"
 /turf/open/floor/plasteel/brown/corner
 	icon_state = "browncorner"
 
@@ -349,9 +349,9 @@
 /turf/open/floor/plasteel/vault/telecomms
 	initial_gas_mix = "n2=100;TEMP=80"
 /turf/open/floor/plasteel/vault/telecomms/mainframe
-	name = "Mainframe Floor"
+	name = "mainframe Floor"
 /turf/open/floor/plasteel/vault/killroom
-	name = "Killroom Floor"
+	name = "killroom Floor"
 	initial_gas_mix = "n2=500;TEMP=80"
 
 /turf/open/floor/plasteel/cult

--- a/code/game/turfs/simulated/floor/plating/asteroid.dm
+++ b/code/game/turfs/simulated/floor/plating/asteroid.dm
@@ -2,6 +2,7 @@
 /**********************Asteroid**************************/
 
 /turf/open/floor/plating/asteroid //floor piece
+	gender = PLURAL
 	name = "asteroid sand"
 	baseturfs = /turf/open/floor/plating/asteroid
 	icon = 'icons/turf/floors.dmi'
@@ -266,6 +267,7 @@
 
 
 /turf/open/floor/plating/asteroid/snow
+	gender = PLURAL
 	name = "snow"
 	desc = "Looks cold."
 	icon = 'icons/turf/snow.dmi'

--- a/code/game/turfs/simulated/floor/plating/asteroid.dm
+++ b/code/game/turfs/simulated/floor/plating/asteroid.dm
@@ -294,7 +294,7 @@
 	return FALSE
 
 /turf/open/floor/plating/asteroid/snow/ice
-	name = "icey snow"
+	name = "icy snow"
 	desc = "Looks colder."
 	baseturfs = /turf/open/floor/plating/asteroid/snow/ice
 	initial_gas_mix = "o2=0;n2=82;plasma=24;TEMP=120"

--- a/code/game/turfs/simulated/floor/plating/dirt.dm
+++ b/code/game/turfs/simulated/floor/plating/dirt.dm
@@ -1,4 +1,5 @@
 /turf/open/floor/plating/dirt
+	gender = PLURAL
 	name = "dirt"
 	desc = "Upon closer examination, it's still dirt."
 	icon = 'icons/turf/floors.dmi'

--- a/code/game/turfs/simulated/floor/plating/misc_plating.dm
+++ b/code/game/turfs/simulated/floor/plating/misc_plating.dm
@@ -34,6 +34,7 @@
 
 /turf/open/floor/plating/ashplanet
 	icon = 'icons/turf/mining.dmi'
+	gender = PLURAL
 	name = "ash"
 	icon_state = "ash"
 	smooth = SMOOTH_MORE|SMOOTH_BORDER
@@ -66,6 +67,7 @@
 	slowdown = 1
 
 /turf/open/floor/plating/ashplanet/rocky
+	gender = PLURAL
 	name = "rocky ground"
 	icon_state = "rockyash"
 	smooth_icon = 'icons/turf/floors/rocky_ash.dmi'
@@ -73,6 +75,7 @@
 	canSmoothWith = list(/turf/open/floor/plating/ashplanet/rocky, /turf/closed)
 
 /turf/open/floor/plating/ashplanet/wateryrock
+	gender = PLURAL
 	name = "wet rocky ground"
 	smooth = null
 	icon_state = "wateryrock"
@@ -97,6 +100,7 @@
 	contents_explosion(severity, target)
 
 /turf/open/floor/plating/beach/sand
+	gender = PLURAL
 	name = "sand"
 	desc = "Surf's up."
 	icon_state = "sand"
@@ -114,6 +118,7 @@
 	baseturfs = /turf/open/floor/plating/beach/coastline_b
 
 /turf/open/floor/plating/beach/water
+	gender = PLURAL
 	name = "water"
 	desc = "You get the feeling that nobody's bothered to actually make this water functional..."
 	icon_state = "water"
@@ -124,6 +129,7 @@
 	baseturfs = /turf/open/floor/plating/beach/coastline_t/sandwater_inner
 
 /turf/open/floor/plating/ironsand
+	gender = PLURAL
 	name = "iron sand"
 	desc = "Like sand, but more <i>metal</i>."
 

--- a/code/game/turfs/simulated/floor/reinf_floor.dm
+++ b/code/game/turfs/simulated/floor/reinf_floor.dm
@@ -90,11 +90,12 @@
 //air filled floors; used in atmos pressure chambers
 
 /turf/open/floor/engine/n2o
-	name = "n2o floor"
+	gender = PLURAL // avoid "a N2O floor"
+	name = "\improper N2O floor"
 	initial_gas_mix = "n2o=6000;TEMP=293.15"
 
 /turf/open/floor/engine/co2
-	name = "co2 floor"
+	name = "\improper CO2 floor"
 	initial_gas_mix = "co2=50000;TEMP=293.15"
 
 /turf/open/floor/engine/plasma
@@ -102,11 +103,12 @@
 	initial_gas_mix = "plasma=70000;TEMP=293.15"
 
 /turf/open/floor/engine/o2
-	name = "o2 floor"
+	name = "\improper O2 floor"
 	initial_gas_mix = "o2=100000;TEMP=293.15"
 
 /turf/open/floor/engine/n2
-	name = "n2 floor"
+	gender = PLURAL // avoid "a N2 floor"
+	name = "\improper N2 floor"
 	initial_gas_mix = "n2=100000;TEMP=293.15"
 
 /turf/open/floor/engine/air

--- a/code/game/turfs/simulated/floor/reinf_floor.dm
+++ b/code/game/turfs/simulated/floor/reinf_floor.dm
@@ -90,7 +90,7 @@
 //air filled floors; used in atmos pressure chambers
 
 /turf/open/floor/engine/n2o
-	gender = PLURAL // avoid "a N2O floor"
+	article = "an"
 	name = "\improper N2O floor"
 	initial_gas_mix = "n2o=6000;TEMP=293.15"
 
@@ -107,7 +107,7 @@
 	initial_gas_mix = "o2=100000;TEMP=293.15"
 
 /turf/open/floor/engine/n2
-	gender = PLURAL // avoid "a N2 floor"
+	article = "an"
 	name = "\improper N2 floor"
 	initial_gas_mix = "n2=100000;TEMP=293.15"
 

--- a/code/game/turfs/simulated/wall/mineral_walls.dm
+++ b/code/game/turfs/simulated/wall/mineral_walls.dm
@@ -52,7 +52,7 @@
 	canSmoothWith = list(/turf/closed/wall/mineral/sandstone, /obj/structure/falsewall/sandstone)
 
 /turf/closed/wall/mineral/uranium
-	gender = PLURAL // avoid "an uranium wall"
+	article = "a"
 	name = "uranium wall"
 	desc = "A wall with uranium plating. This is probably a bad idea."
 	icon = 'icons/turf/walls/uranium_wall.dmi'

--- a/code/game/turfs/simulated/wall/mineral_walls.dm
+++ b/code/game/turfs/simulated/wall/mineral_walls.dm
@@ -52,6 +52,7 @@
 	canSmoothWith = list(/turf/closed/wall/mineral/sandstone, /obj/structure/falsewall/sandstone)
 
 /turf/closed/wall/mineral/uranium
+	gender = PLURAL // avoid "an uranium wall"
 	name = "uranium wall"
 	desc = "A wall with uranium plating. This is probably a bad idea."
 	icon = 'icons/turf/walls/uranium_wall.dmi'

--- a/code/game/turfs/simulated/water.dm
+++ b/code/game/turfs/simulated/water.dm
@@ -1,4 +1,5 @@
 /turf/open/water
+	gender = PLURAL
 	name = "water"
 	desc = "Shallow water."
 	icon = 'icons/turf/floors.dmi'

--- a/code/game/turfs/space/transit.dm
+++ b/code/game/turfs/space/transit.dm
@@ -1,4 +1,5 @@
 /turf/open/space/transit
+	name = "\proper hyperspace"
 	icon_state = "black"
 	dir = SOUTH
 	baseturfs = /turf/open/space/transit

--- a/code/modules/holodeck/turfs.dm
+++ b/code/modules/holodeck/turfs.dm
@@ -30,16 +30,19 @@
 	bullet_bounce_sound = null
 
 /turf/open/floor/holofloor/beach
+	gender = PLURAL
 	name = "sand"
 	icon = 'icons/misc/beach.dmi'
 	icon_state = "sand"
 	bullet_bounce_sound = null
 
 /turf/open/floor/holofloor/beach/coast_t
+	gender = NEUTER
 	name = "coastline"
 	icon_state = "sandwater_t"
 
 /turf/open/floor/holofloor/beach/coast_b
+	gender = NEUTER
 	name = "coastline"
 	icon_state = "sandwater_b"
 
@@ -57,6 +60,7 @@
 	. = ..()
 
 /turf/open/floor/holofloor/basalt
+	gender = PLURAL
 	name = "basalt"
 	icon_state = "basalt0"
 
@@ -67,7 +71,7 @@
 		set_basalt_light(src)
 
 /turf/open/floor/holofloor/space
-	name = "Space"
+	name = "\proper space"
 	icon = 'icons/turf/space.dmi'
 	icon_state = "0"
 
@@ -76,7 +80,7 @@
 	. = ..()
 
 /turf/open/floor/holofloor/hyperspace
-	name = "hyperspace"
+	name = "\proper hyperspace"
 	icon = 'icons/turf/space.dmi'
 	icon_state = "speedspace_ns_1"
 	bullet_bounce_sound = null
@@ -110,6 +114,7 @@
 		queue_smooth(src)
 
 /turf/open/floor/holofloor/snow
+	gender = PLURAL
 	name = "snow"
 	desc = "Looks cold."
 	icon = 'icons/turf/snow.dmi'
@@ -122,6 +127,7 @@
 	initial_gas_mix = "nob=7500;TEMP=2.7"
 
 /turf/open/floor/holofloor/asteroid
+	gender = PLURAL
 	name = "asteroid sand"
 	icon = 'icons/turf/floors.dmi'
 	icon_state = "asteroid"


### PR DESCRIPTION
:cl:
spellcheck: Capitalization, propriety, and plurality on turfs have been improved.
/:cl:

A new var `article` on `/atom` has been added to allow overriding a/an so "a uranium floor" will be correct. It's currently only used in `get_examine_name` which is where it's most obvious and will eventually be used elsewhere the `\a` and `\an` macros are used.