### PR TITLE
Fix a runtime when clicking the splash screen fadeout

### DIFF
--- a/code/_onclick/click.dm
+++ b/code/_onclick/click.dm
@@ -190,6 +190,8 @@
 				if(Adjacent(target) || (tool && CheckToolReach(src, target, tool.reach))) //Adjacent or reaching attacks
 					return TRUE
 
+			if (!target.loc)
+				continue
 			GET_COMPONENT_FROM(storage, /datum/component/storage, target.loc)
 			if (storage)
 				var/datum/component/storage/concrete/master = storage.master()


### PR DESCRIPTION
```
[23:17:11] Runtime in click.dm,193: Cannot execute null.GetComponent().
  proc name: CanReach (/atom/movable/proc/CanReach)
  usr:  (spacemaniac) (/mob/living/carbon/human)
  usr.loc: The floor (33,20,2) (/turf/open/floor/plasteel)
  src:  (/mob/living/carbon/human)
  src.loc: the floor (33,20,2) (/turf/open/floor/plasteel)
  call stack:
   (/mob/living/carbon/human): CanReach( (/obj/screen/splash), null, 0)
   (/mob/living/carbon/human): ClickOn( (/obj/screen/splash), "icon-x=261;icon-y=184;left=1;s...")
   (/obj/screen/splash): Click(null, "mapwindow.map", "icon-x=261;icon-y=184;left=1;s...")
  SpaceManiac (/client): Click( (/obj/screen/splash), null, "mapwindow.map", "icon-x=261;icon-y=184;left=1;s...")
```