### PR TITLE
Equalizes thresholds on being fat

### DIFF
--- a/code/modules/mob/living/carbon/human/species.dm
+++ b/code/modules/mob/living/carbon/human/species.dm
@@ -951,7 +951,7 @@ GLOBAL_LIST_EMPTY(roundstart_races)
 			H.update_inv_w_uniform()
 			H.update_inv_wear_suit()
 	else
-		if(H.overeatduration > 500)
+		if(H.overeatduration >= 100)
 			to_chat(H, "<span class='danger'>You suddenly feel blubbery!</span>")
 			H.add_trait(TRAIT_FAT, OBESITY)
 			H.update_inv_w_uniform()


### PR DESCRIPTION
[Changelogs]: # (Your PR should contain a detailed changelog of notable changes, titled and categorized appropriately. This includes, new features, sprites, sounds, balance changes, admin tools, map edits, removals, big refactors, config changes, hosting changes and important fixes. An example changelog has been provided below for you to edit. If you need additional help, read https://github.com/tgstation/tgstation/wiki/Changelogs)

:cl: Dax Dupont
balance: It's now easier to become fat. Don't eat so much.
/:cl:

[why]: It was nigh impossible to get the threshold of 500.
You still need to eat a lot, but now it's at least attainable. Also I used 100 because from testing it's seems sane and also the other check uses 100. https://github.com/DaxDupont/tgstation/blob/824c7551e12da4959fba6d235e9137dcb521763a/code/modules/mob/living/carbon/human/species.dm#L948