### PR TITLE
Fixes and Upgrades Stabilized Gold Extracts

### DIFF
--- a/code/modules/research/xenobiology/crossbreeding/_status_effects.dm
+++ b/code/modules/research/xenobiology/crossbreeding/_status_effects.dm
@@ -762,7 +762,7 @@ datum/status_effect/stabilized/blue/on_remove()
 
 /datum/status_effect/stabilized/gold/tick()
 	var/obj/item/slimecross/stabilized/gold/linked = linked_extract
-	if(!familiar || QDELETED(familiar))
+	if(QDELETED(familiar))
 		familiar = new linked.mob_type(get_turf(owner.loc))
 		familiar.name = linked.mob_name
 		familiar.del_on_death = TRUE

--- a/code/modules/research/xenobiology/crossbreeding/_status_effects.dm
+++ b/code/modules/research/xenobiology/crossbreeding/_status_effects.dm
@@ -762,9 +762,7 @@ datum/status_effect/stabilized/blue/on_remove()
 
 /datum/status_effect/stabilized/gold/tick()
 	var/obj/item/slimecross/stabilized/gold/linked = linked_extract
-	if(QDELETED(familiar))
-		familiar = null
-	if(!familiar)
+	if(!familiar || QDELETED(familiar))
 		familiar = new linked.mob_type(get_turf(owner.loc))
 		familiar.name = linked.mob_name
 		familiar.del_on_death = TRUE

--- a/code/modules/research/xenobiology/crossbreeding/_status_effects.dm
+++ b/code/modules/research/xenobiology/crossbreeding/_status_effects.dm
@@ -762,9 +762,13 @@ datum/status_effect/stabilized/blue/on_remove()
 
 /datum/status_effect/stabilized/gold/tick()
 	var/obj/item/slimecross/stabilized/gold/linked = linked_extract
+	if(QDELETED(familiar))
+		familiar = null
 	if(!familiar)
 		familiar = new linked.mob_type(get_turf(owner.loc))
+		familiar.name = linked.mob_name
 		familiar.del_on_death = TRUE
+		familiar.copy_known_languages_from(owner, FALSE)
 		if(linked.saved_mind)
 			linked.saved_mind.transfer_to(familiar)
 			familiar.ckey = linked.saved_mind.key

--- a/code/modules/research/xenobiology/crossbreeding/stabilized.dm
+++ b/code/modules/research/xenobiology/crossbreeding/stabilized.dm
@@ -135,9 +135,8 @@ Stabilized extracts:
 		START_PROCESSING(SSobj, src)
 	if(choice == "Familiar Name")
 		var/newname = copytext(sanitize(input(user, "Would you like to change the name of [mob_name]", "Name change", mob_name) as null|text),1,MAX_NAME_LEN)
-		if (!newname)
-			newname = mob_name
-		mob_name = newname
+		if(newname)
+			mob_name = newname
 		to_chat(user, "<span class='notice'>You speak softly into [src], and it shakes slightly in response.</span>")
 		START_PROCESSING(SSobj, src)
 

--- a/code/modules/research/xenobiology/crossbreeding/stabilized.dm
+++ b/code/modules/research/xenobiology/crossbreeding/stabilized.dm
@@ -98,6 +98,7 @@ Stabilized extracts:
 	colour = "gold"
 	var/mob_type
 	var/datum/mind/saved_mind
+	var/mob_name = "Familiar"
 
 /obj/item/slimecross/stabilized/gold/proc/generate_mobtype()
 	var/static/list/mob_spawn_pets = list()
@@ -114,20 +115,31 @@ Stabilized extracts:
 	generate_mobtype()
 
 /obj/item/slimecross/stabilized/gold/attack_self(mob/user)
-	var/choice = input(user, "Which do you want to reset?", "Familiar Adjustment") as null|anything in list("Familiar Species", "Familiar Sentience")
+	var/choice = input(user, "Which do you want to reset?", "Familiar Adjustment") as null|anything in list("Familiar Location", "Familiar Species", "Familiar Sentience", "Familiar Name")
 	if(!user.canUseTopic(src, BE_CLOSE))
 		return
 	if(isliving(user))
 		var/mob/living/L = user
 		if(L.has_status_effect(/datum/status_effect/stabilized/gold))
 			L.remove_status_effect(/datum/status_effect/stabilized/gold)
-			START_PROCESSING(SSobj, src)
+	if(choice == "Familiar Location")
+		to_chat(user, "<span class='notice'>You prod [src], and it shudders slightly.</span>")
+		START_PROCESSING(SSobj, src)
 	if(choice == "Familiar Species")
 		to_chat(user, "<span class='notice'>You squeeze [src], and a shape seems to shift around inside.</span>")
 		generate_mobtype()
+		START_PROCESSING(SSobj, src)
 	if(choice == "Familiar Sentience")
 		to_chat(user, "<span class='notice'>You poke [src], and it lets out a glowing pulse.</span>")
 		saved_mind = null
+		START_PROCESSING(SSobj, src)
+	if(choice == "Familiar Name")
+		var/newname = copytext(sanitize(input(user, "Would you like to change the name of [mob_name]", "Name change", mob_name) as null|text),1,MAX_NAME_LEN)
+		if (!newname)
+			newname = mob_name
+		mob_name = newname
+		to_chat(user, "<span class='notice'>You speak softly into [src], and it shakes slightly in response.</span>")
+		START_PROCESSING(SSobj, src)
 
 /obj/item/slimecross/stabilized/oil
 	colour = "oil"


### PR DESCRIPTION
:cl:fludd12
fix: Stabilized gold extracts now respawn the familiar properly.
fix: Stabilized gold familiars retain the proper languages even after respawning.
tweak: Stabilized gold familiars can be renamed and have their positions reset at will.
/:cl:

A few things I forgot, whoops.