### PR TITLE
You can see what other people eat or drink

### DIFF
--- a/code/game/objects/objs.dm
+++ b/code/game/objects/objs.dm
@@ -27,6 +27,8 @@
 	var/req_access_txt = "0"
 	var/list/req_one_access
 	var/req_one_access_txt = "0"
+	
+	var/renamedByPlayer = FALSE //set when a player uses a pen on a renamable object
 
 /obj/vv_edit_var(vname, vval)
 	switch(vname)

--- a/code/modules/food_and_drinks/drinks/drinks.dm
+++ b/code/modules/food_and_drinks/drinks/drinks.dm
@@ -35,7 +35,7 @@
 		return 0
 
 	if(M == user)
-		to_chat(M, "<span class='notice'>You swallow a gulp of [src].</span>")
+		user.visible_message("[user] swallows a gulp of [src].", "<span class='notice'>You swallow a gulp of [src].</span>")
 		if(M.has_trait(TRAIT_VORACIOUS))
 			M.changeNext_move(CLICK_CD_MELEE * 0.5) //chug! chug! chug!
 

--- a/code/modules/food_and_drinks/drinks/drinks.dm
+++ b/code/modules/food_and_drinks/drinks/drinks.dm
@@ -35,7 +35,7 @@
 		return 0
 
 	if(M == user)
-		user.visible_message("[user] swallows a gulp of [src].", "<span class='notice'>You swallow a gulp of [src].</span>")
+		user.visible_message("<span class='notice'>[user] swallows a gulp of [src].</span>", "<span class='notice'>You swallow a gulp of [src].</span>")
 		if(M.has_trait(TRAIT_VORACIOUS))
 			M.changeNext_move(CLICK_CD_MELEE * 0.5) //chug! chug! chug!
 

--- a/code/modules/food_and_drinks/drinks/drinks/drinkingglass.dm
+++ b/code/modules/food_and_drinks/drinks/drinks/drinkingglass.dm
@@ -27,7 +27,7 @@
 			add_overlay(reagent_overlay)
 	else
 		name = "empty glass of [name]"
-		desc = "A sad sight to behold."
+		desc = "Why is the rum always gone?"
 
 //Shot glasses!//
 //  This lets us add shots in here instead of lumping them in with drinks because >logic  //

--- a/code/modules/food_and_drinks/drinks/drinks/drinkingglass.dm
+++ b/code/modules/food_and_drinks/drinks/drinks/drinkingglass.dm
@@ -27,8 +27,6 @@
 			add_overlay(reagent_overlay)
 	else
 		icon_state = "glass_empty"
-		name = "empty glass of [name]"
-		desc = "Why is the rum always gone?"
 
 //Shot glasses!//
 //  This lets us add shots in here instead of lumping them in with drinks because >logic  //

--- a/code/modules/food_and_drinks/drinks/drinks/drinkingglass.dm
+++ b/code/modules/food_and_drinks/drinks/drinks/drinkingglass.dm
@@ -16,8 +16,9 @@
 	cut_overlays()
 	if(reagents.reagent_list.len)
 		var/datum/reagent/R = reagents.get_master_reagent()
-		name = R.glass_name
-		desc = R.glass_desc
+		if(!renamedByPlayer)
+			name = R.glass_name
+			desc = R.glass_desc
 		if(R.glass_icon_state)
 			icon_state = R.glass_icon_state
 		else
@@ -25,9 +26,8 @@
 			reagent_overlay.color = mix_color_from_reagents(reagents.reagent_list)
 			add_overlay(reagent_overlay)
 	else
-		icon_state = "glass_empty"
-		name = "drinking glass"
-		desc = "Your standard drinking glass."
+		name = "empty glass of [name]"
+		desc = "A sad sight to behold."
 
 //Shot glasses!//
 //  This lets us add shots in here instead of lumping them in with drinks because >logic  //

--- a/code/modules/food_and_drinks/drinks/drinks/drinkingglass.dm
+++ b/code/modules/food_and_drinks/drinks/drinks/drinkingglass.dm
@@ -27,6 +27,7 @@
 			add_overlay(reagent_overlay)
 	else
 		icon_state = "glass_empty"
+		O.renamedByPlayer = FALSE //so new drinks can rename the glass
 
 //Shot glasses!//
 //  This lets us add shots in here instead of lumping them in with drinks because >logic  //

--- a/code/modules/food_and_drinks/drinks/drinks/drinkingglass.dm
+++ b/code/modules/food_and_drinks/drinks/drinks/drinkingglass.dm
@@ -26,6 +26,7 @@
 			reagent_overlay.color = mix_color_from_reagents(reagents.reagent_list)
 			add_overlay(reagent_overlay)
 	else
+		icon_state = "glass_empty"
 		name = "empty glass of [name]"
 		desc = "Why is the rum always gone?"
 

--- a/code/modules/food_and_drinks/drinks/drinks/drinkingglass.dm
+++ b/code/modules/food_and_drinks/drinks/drinks/drinkingglass.dm
@@ -27,7 +27,7 @@
 			add_overlay(reagent_overlay)
 	else
 		icon_state = "glass_empty"
-		O.renamedByPlayer = FALSE //so new drinks can rename the glass
+		renamedByPlayer = FALSE //so new drinks can rename the glass
 
 //Shot glasses!//
 //  This lets us add shots in here instead of lumping them in with drinks because >logic  //

--- a/code/modules/food_and_drinks/food/condiment.dm
+++ b/code/modules/food_and_drinks/food/condiment.dm
@@ -41,7 +41,7 @@
 		return 0
 
 	if(M == user)
-		user.visible_message("[user] swallows some of contents of \the [src].", "<span class='notice'>You swallow some of contents of \the [src].</span>")
+		user.visible_message("<span class='notice'>[user] swallows some of contents of \the [src].</span>", "<span class='notice'>You swallow some of contents of \the [src].</span>")
 	else
 		user.visible_message("<span class='warning'>[user] attempts to feed [M] from [src].</span>")
 		if(!do_mob(user, M))

--- a/code/modules/food_and_drinks/food/condiment.dm
+++ b/code/modules/food_and_drinks/food/condiment.dm
@@ -41,7 +41,7 @@
 		return 0
 
 	if(M == user)
-		to_chat(M, "<span class='notice'>You swallow some of contents of \the [src].</span>")
+		user.visible_message("[user] swallows some of contents of \the [src].", "<span class='notice'>You swallow some of contents of \the [src].</span>")
 	else
 		user.visible_message("<span class='warning'>[user] attempts to feed [M] from [src].</span>")
 		if(!do_mob(user, M))

--- a/code/modules/food_and_drinks/food/snacks.dm
+++ b/code/modules/food_and_drinks/food/snacks.dm
@@ -72,15 +72,15 @@
 				to_chat(M, "<span class='notice'>You don't feel like eating any more junk food at the moment.</span>")
 				return 0
 			else if(fullness <= 50)
-				to_chat(M, "<span class='notice'>You hungrily [eatverb] some of \the [src] and gobble it down!</span>")
+				user.visible_message("[user] hungrily [eatverb]s some of \the [src] and gobbles it down!", "<span class='notice'>You hungrily [eatverb] some of \the [src] and gobble it down!</span>")
 			else if(fullness > 50 && fullness < 150)
-				to_chat(M, "<span class='notice'>You hungrily begin to [eatverb] \the [src].</span>")
+				user.visible_message("[user] hungrily begins to [eatverb] \the [src].", "<span class='notice'>You hungrily begin to [eatverb] \the [src].</span>")
 			else if(fullness > 150 && fullness < 500)
-				to_chat(M, "<span class='notice'>You [eatverb] \the [src].</span>")
+				user.visible_message("[user] [eatverb]s \the [src].", "<span class='notice'>You [eatverb] \the [src].</span>")		
 			else if(fullness > 500 && fullness < 600)
-				to_chat(M, "<span class='notice'>You unwillingly [eatverb] a bit of \the [src].</span>")
+				user.visible_message("[user] unwillingly [eatverb]s a bit of \the [src].", "<span class='notice'>You unwillingly [eatverb] a bit of \the [src].</span>")
 			else if(fullness > (600 * (1 + M.overeatduration / 2000)))	// The more you eat - the more you can eat
-				to_chat(M, "<span class='warning'>You cannot force any more of \the [src] to go down your throat!</span>")
+				user.visible_message("[user] cannot force any more of \the [src] to go down [user.p_they()] throat!</span>", "<span class='warning'>You cannot force any more of \the [src] to go down your throat!</span>")	
 				return 0
 			if(M.has_trait(TRAIT_VORACIOUS))
 				M.changeNext_move(CLICK_CD_MELEE * 0.5) //nom nom nom

--- a/code/modules/food_and_drinks/food/snacks.dm
+++ b/code/modules/food_and_drinks/food/snacks.dm
@@ -80,7 +80,7 @@
 			else if(fullness > 500 && fullness < 600)
 				user.visible_message("[user] unwillingly [eatverb]s a bit of \the [src].", "<span class='notice'>You unwillingly [eatverb] a bit of \the [src].</span>")
 			else if(fullness > (600 * (1 + M.overeatduration / 2000)))	// The more you eat - the more you can eat
-				user.visible_message("[user] cannot force any more of \the [src] to go down [user.p_they()] throat!</span>", "<span class='warning'>You cannot force any more of \the [src] to go down your throat!</span>")	
+				user.visible_message("[user] cannot force any more of \the [src] to go down [user.p_their()] throat!</span>", "<span class='warning'>You cannot force any more of \the [src] to go down your throat!</span>")	
 				return 0
 			if(M.has_trait(TRAIT_VORACIOUS))
 				M.changeNext_move(CLICK_CD_MELEE * 0.5) //nom nom nom

--- a/code/modules/food_and_drinks/food/snacks.dm
+++ b/code/modules/food_and_drinks/food/snacks.dm
@@ -72,13 +72,13 @@
 				to_chat(M, "<span class='notice'>You don't feel like eating any more junk food at the moment.</span>")
 				return 0
 			else if(fullness <= 50)
-				user.visible_message("[user] hungrily [eatverb]s some of \the [src] and gobbles it down!", "<span class='notice'>You hungrily [eatverb] some of \the [src] and gobble it down!</span>")
+				user.visible_message("[user] hungrily takes a [eatverb] from \the [src], gobbling it down!", "<span class='notice'>You hungrily take a [eatverb] from \the [src], gobbling it down!</span>")
 			else if(fullness > 50 && fullness < 150)
-				user.visible_message("[user] hungrily begins to [eatverb] \the [src].", "<span class='notice'>You hungrily begin to [eatverb] \the [src].</span>")
+				user.visible_message("[user] hungrily takes a [eatverb] from \the [src].", "<span class='notice'>You hungrily take a [eatverb] from \the [src].</span>")
 			else if(fullness > 150 && fullness < 500)
-				user.visible_message("[user] [eatverb]s \the [src].", "<span class='notice'>You [eatverb] \the [src].</span>")		
+				user.visible_message("[user] takes a [eatverb] from \the [src].", "<span class='notice'>You take a [eatverb] from \the [src].</span>")		
 			else if(fullness > 500 && fullness < 600)
-				user.visible_message("[user] unwillingly [eatverb]s a bit of \the [src].", "<span class='notice'>You unwillingly [eatverb] a bit of \the [src].</span>")
+				user.visible_message("[user] unwillingly takes a [eatverb] of a bit of \the [src].", "<span class='notice'>You unwillingly take a [eatverb] of a bit of \the [src].</span>")
 			else if(fullness > (600 * (1 + M.overeatduration / 2000)))	// The more you eat - the more you can eat
 				user.visible_message("[user] cannot force any more of \the [src] to go down [user.p_their()] throat!</span>", "<span class='warning'>You cannot force any more of \the [src] to go down your throat!</span>")	
 				return 0

--- a/code/modules/food_and_drinks/food/snacks.dm
+++ b/code/modules/food_and_drinks/food/snacks.dm
@@ -72,15 +72,15 @@
 				to_chat(M, "<span class='notice'>You don't feel like eating any more junk food at the moment.</span>")
 				return 0
 			else if(fullness <= 50)
-				user.visible_message("[user] hungrily takes a [eatverb] from \the [src], gobbling it down!", "<span class='notice'>You hungrily take a [eatverb] from \the [src], gobbling it down!</span>")
+				user.visible_message("<span class='notice'>[user] hungrily takes a [eatverb] from \the [src], gobbling it down!</span>", "<span class='notice'>You hungrily take a [eatverb] from \the [src], gobbling it down!</span>")
 			else if(fullness > 50 && fullness < 150)
-				user.visible_message("[user] hungrily takes a [eatverb] from \the [src].", "<span class='notice'>You hungrily take a [eatverb] from \the [src].</span>")
+				user.visible_message("<span class='notice'>[user] hungrily takes a [eatverb] from \the [src].</span>", "<span class='notice'>You hungrily take a [eatverb] from \the [src].</span>")
 			else if(fullness > 150 && fullness < 500)
-				user.visible_message("[user] takes a [eatverb] from \the [src].", "<span class='notice'>You take a [eatverb] from \the [src].</span>")		
+				user.visible_message("<span class='notice'>[user] takes a [eatverb] from \the [src].</span>", "<span class='notice'>You take a [eatverb] from \the [src].</span>")		
 			else if(fullness > 500 && fullness < 600)
-				user.visible_message("[user] unwillingly takes a [eatverb] of a bit of \the [src].", "<span class='notice'>You unwillingly take a [eatverb] of a bit of \the [src].</span>")
+				user.visible_message("<span class='notice'>[user] unwillingly takes a [eatverb] of a bit of \the [src].</span>", "<span class='notice'>You unwillingly take a [eatverb] of a bit of \the [src].</span>")
 			else if(fullness > (600 * (1 + M.overeatduration / 2000)))	// The more you eat - the more you can eat
-				user.visible_message("[user] cannot force any more of \the [src] to go down [user.p_their()] throat!</span>", "<span class='warning'>You cannot force any more of \the [src] to go down your throat!</span>")	
+				user.visible_message("<span class='warning'>[user] cannot force any more of \the [src] to go down [user.p_their()] throat!</span>", "<span class='warning'>You cannot force any more of \the [src] to go down your throat!</span>")	
 				return 0
 			if(M.has_trait(TRAIT_VORACIOUS))
 				M.changeNext_move(CLICK_CD_MELEE * 0.5) //nom nom nom

--- a/code/modules/paperwork/pen.dm
+++ b/code/modules/paperwork/pen.dm
@@ -143,6 +143,7 @@
 			else
 				O.name = input
 				to_chat(user, "\The [oldname] has been successfully been renamed to \the [input].")
+				O.renamedByPlayer = TRUE
 
 		if(penchoice == "Change description")
 			var/input = stripped_input(user,"Describe \the [O.name] here", ,"", 100)

--- a/code/modules/reagents/reagent_containers/borghydro.dm
+++ b/code/modules/reagents/reagent_containers/borghydro.dm
@@ -180,7 +180,7 @@ Borg Shaker
 	recharge_time = 3
 	accepts_reagent_upgrades = FALSE
 
-	reagent_ids = list("beer", "orangejuice", "grenadine", "limejuice", "tomatojuice", "cola", "tonic", "sodawater", "ice", "cream", "whiskey", "vodka", "rum", "gin", "tequila", "vermouth", "wine", "kahlua", "cognac", "ale", "fernet", "milk", "coffee", "banana", "lemonjuice", "blood")
+	reagent_ids = list("beer", "orangejuice", "grenadine", "limejuice", "tomatojuice", "cola", "tonic", "sodawater", "ice", "cream", "whiskey", "vodka", "rum", "gin", "tequila", "vermouth", "wine", "kahlua", "cognac", "ale", "fernet", "milk", "coffee", "banana", "lemonjuice")
 
 /obj/item/reagent_containers/borghypo/borgshaker/attack(mob/M, mob/user)
 	return //Can't inject stuff with a shaker, can we? //not with that attitude

--- a/code/modules/reagents/reagent_containers/borghydro.dm
+++ b/code/modules/reagents/reagent_containers/borghydro.dm
@@ -180,7 +180,7 @@ Borg Shaker
 	recharge_time = 3
 	accepts_reagent_upgrades = FALSE
 
-	reagent_ids = list("beer", "orangejuice", "grenadine" ,"limejuice", "tomatojuice", "cola", "tonic", "sodawater", "ice", "cream", "whiskey", "vodka", "rum", "gin", "tequila", "vermouth", "wine", "kahlua", "cognac", "ale", "fernet")
+	reagent_ids = list("beer", "orangejuice", "grenadine", "limejuice", "tomatojuice", "cola", "tonic", "sodawater", "ice", "cream", "whiskey", "vodka", "rum", "gin", "tequila", "vermouth", "wine", "kahlua", "cognac", "ale", "fernet", "milk", "coffee", "banana", "lemonjuice", "blood")
 
 /obj/item/reagent_containers/borghypo/borgshaker/attack(mob/M, mob/user)
 	return //Can't inject stuff with a shaker, can we? //not with that attitude


### PR DESCRIPTION
[Changelogs]: # (Your PR should contain a detailed changelog of notable changes, titled and categorized appropriately. This includes, new features, sprites, sounds, balance changes, admin tools, map edits, removals, big refactors, config changes, hosting changes and important fixes. An example changelog has been provided below for you to edit. If you need additional help, read https://github.com/tgstation/tgstation/wiki/Changelogs)

:cl: cacogen
add: You can now see what other people are eating or drinking.
add: Borg shaker can now synthesise milk, lemon juice, banana juice and coffee
fix: Renamed drinks no longer revert to their original name when their reagents change
/:cl:

[why]: # (Please add a short description [two lines down] of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.)

I like renaming food and drinks but it's not very satisfying when you can't see other people eat them.
