### PR TITLE
[s] Puts a limit on atoms teleportable by a pad per teleport

### DIFF
--- a/code/game/machinery/launch_pad.dm
+++ b/code/game/machinery/launch_pad.dm
@@ -16,6 +16,7 @@
 	var/power_efficiency = 1
 	var/x_offset = 0
 	var/y_offset = 0
+	var/max_teleportable = 10
 
 /obj/machinery/launchpad/RefreshParts()
 	var/E = -1 //to make default parts have the base value
@@ -88,6 +89,7 @@
 		dest = target
 
 	playsound(get_turf(src), 'sound/weapons/emitter2.ogg', 25, 1)
+	var/teleport_count = 0
 	for(var/atom/movable/ROI in source)
 		if(ROI == src)
 			continue
@@ -125,6 +127,9 @@
 					log_msg += ")"
 			log_msg += ", "
 		do_teleport(ROI, dest)
+		teleport_count++
+		if(teleport_count >= max_teleportable)
+			break
 
 	if (dd_hassuffix(log_msg, ", "))
 		log_msg = dd_limittext(log_msg, length(log_msg) - 2)

--- a/code/game/machinery/launch_pad.dm
+++ b/code/game/machinery/launch_pad.dm
@@ -16,7 +16,7 @@
 	var/power_efficiency = 1
 	var/x_offset = 0
 	var/y_offset = 0
-	var/max_teleportable = 10
+	var/max_teleportable = 20
 
 /obj/machinery/launchpad/RefreshParts()
 	var/E = -1 //to make default parts have the base value

--- a/code/game/machinery/quantum_pad.dm
+++ b/code/game/machinery/quantum_pad.dm
@@ -13,6 +13,7 @@
 	var/last_teleport //to handle the cooldown
 	var/teleporting = 0 //if it's in the process of teleporting
 	var/power_efficiency = 1
+	var/max_teleportable = 10
 	var/obj/machinery/quantumpad/linked_pad
 
 	//mapping
@@ -132,6 +133,7 @@
 			playsound(get_turf(src), 'sound/weapons/emitter2.ogg', 25, 1, extrarange = 3, falloff = 5)
 			flick("qpad-beam", linked_pad)
 			playsound(get_turf(linked_pad), 'sound/weapons/emitter2.ogg', 25, 1, extrarange = 3, falloff = 5)
+			var/teleport_count = 0
 			for(var/atom/movable/ROI in get_turf(src))
 				// if is anchored, don't let through
 				if(ROI.anchored)
@@ -146,6 +148,9 @@
 					else if(!isobserver(ROI))
 						continue
 				do_teleport(ROI, get_turf(linked_pad))
+				teleport_count++
+				if(teleport_count >= max_teleportable)
+					break
 
 /obj/machinery/quantumpad/proc/initMappedLink()
 	. = FALSE

--- a/code/game/machinery/quantum_pad.dm
+++ b/code/game/machinery/quantum_pad.dm
@@ -13,7 +13,7 @@
 	var/last_teleport //to handle the cooldown
 	var/teleporting = 0 //if it's in the process of teleporting
 	var/power_efficiency = 1
-	var/max_teleportable = 10
+	var/max_teleportable = 20
 	var/obj/machinery/quantumpad/linked_pad
 
 	//mapping


### PR DESCRIPTION
[Changelogs]: # (Your PR should contain a detailed changelog of notable changes, titled and categorized appropriately. This includes, new features, sprites, sounds, balance changes, admin tools, map edits, removals, big refactors, config changes, hosting changes and important fixes. An example changelog has been provided below for you to edit. If you need additional help, read https://github.com/tgstation/tgstation/wiki/Changelogs)

:cl: Dax Dupont
fix: Puts a limit on atoms movable at once by telepad.
/:cl:

[why]: Fixes #38399
Seems like the best solution without refactoring do_teleport. Not only that moving a fuckton atoms at once probably has more than one potential downside.

Number negotiable.