### PR TITLE
Admins can now send CentCom messages as an alternative to SMs

### DIFF
--- a/code/modules/admin/admin.dm
+++ b/code/modules/admin/admin.dm
@@ -62,6 +62,8 @@
 		body += "<a href='?_src_=holder;[HrefToken()];borgpanel=[REF(M)]'>BP</a> - "
 	body += "<a href='?priv_msg=[M.ckey]'>PM</a> - "
 	body += "<a href='?_src_=holder;[HrefToken()];subtlemessage=[REF(M)]'>SM</a> - "
+	if (ishuman(M) && M.mind)
+		body += "<a href='?_src_=holder;[HrefToken()];CentComReply=[REF(M)]'>CM</a> - "
 	body += "<a href='?_src_=holder;[HrefToken()];adminplayerobservefollow=[REF(M)]'>FLW</a> - "
 	//Default to client logs if available
 	var/source = LOGSRC_MOB

--- a/code/modules/admin/admin_verbs.dm
+++ b/code/modules/admin/admin_verbs.dm
@@ -40,7 +40,7 @@ GLOBAL_LIST_INIT(admin_verbs_admin, world.AVerbsAdmin())
 	/client/proc/getserverlogs,		/*for accessing server logs*/
 	/client/proc/getcurrentlogs,		/*for accessing server logs for the current round*/
 	/client/proc/cmd_admin_subtle_message,	/*send an message to somebody as a 'voice in their head'*/
-	/client/proc/cmd_admin_centcom_message,	/*send an message to somebody through their headset as CentCom*/
+	/datum/admins/proc/cmd_admin_centcom_message,	/*send an message to somebody through their headset as CentCom*/
 	/client/proc/cmd_admin_delete,		/*delete an instance/object/mob/etc*/
 	/client/proc/cmd_admin_check_contents,	/*displays the contents of an instance*/
 	/client/proc/check_antagonists,		/*shows all antags*/
@@ -181,7 +181,7 @@ GLOBAL_LIST_INIT(admin_verbs_hideable, list(
 	/client/proc/admin_ghost,
 	/client/proc/toggle_view_range,
 	/client/proc/cmd_admin_subtle_message,
-	/client/proc/cmd_admin_centcom_message,
+	/datum/admins/proc/cmd_admin_centcom_message,	
 	/client/proc/cmd_admin_check_contents,
 	/datum/admins/proc/access_news_network,
 	/client/proc/admin_call_shuttle,

--- a/code/modules/admin/admin_verbs.dm
+++ b/code/modules/admin/admin_verbs.dm
@@ -40,6 +40,7 @@ GLOBAL_LIST_INIT(admin_verbs_admin, world.AVerbsAdmin())
 	/client/proc/getserverlogs,		/*for accessing server logs*/
 	/client/proc/getcurrentlogs,		/*for accessing server logs for the current round*/
 	/client/proc/cmd_admin_subtle_message,	/*send an message to somebody as a 'voice in their head'*/
+	/client/proc/cmd_admin_centcom_message,	/*send an message to somebody through their headset as CentCom*/
 	/client/proc/cmd_admin_delete,		/*delete an instance/object/mob/etc*/
 	/client/proc/cmd_admin_check_contents,	/*displays the contents of an instance*/
 	/client/proc/check_antagonists,		/*shows all antags*/
@@ -180,6 +181,7 @@ GLOBAL_LIST_INIT(admin_verbs_hideable, list(
 	/client/proc/admin_ghost,
 	/client/proc/toggle_view_range,
 	/client/proc/cmd_admin_subtle_message,
+	/client/proc/cmd_admin_centcom_message,
 	/client/proc/cmd_admin_check_contents,
 	/datum/admins/proc/access_news_network,
 	/client/proc/admin_call_shuttle,

--- a/code/modules/admin/topic.dm
+++ b/code/modules/admin/topic.dm
@@ -1813,23 +1813,11 @@
 		usr.client.smite(H)
 
 	else if(href_list["CentComReply"])
-		var/mob/living/carbon/human/H = locate(href_list["CentComReply"]) in GLOB.mob_list
-		if(!istype(H))
-			to_chat(usr, "This can only be used on instances of type /mob/living/carbon/human")
-			return
-		if(!istype(H.ears, /obj/item/radio/headset))
-			to_chat(usr, "The person you are trying to contact is not wearing a headset.")
+		if(!check_rights(R_ADMIN))
 			return
 
-		message_admins("[src.owner] has started answering [key_name(H)]'s CentCom request.")
-		var/input = input(src.owner, "Please enter a message to reply to [key_name(H)] via their headset.","Outgoing message from CentCom", "")
-		if(!input)
-			message_admins("[src.owner] decided not to answer [key_name(H)]'s CentCom request.")
-			return
-
-		log_admin("[src.owner] replied to [key_name(H)]'s CentCom message with the message [input].")
-		message_admins("[src.owner] replied to [key_name(H)]'s CentCom message with: \"[input]\"")
-		to_chat(H, "You hear something crackle in your ears for a moment before a voice speaks.  \"Please stand by for a message from Central Command.  Message as follows. [input].  Message ends.\"")
+		var/mob/M = locate(href_list["CentComReply"])
+		usr.client.cmd_admin_centcom_message(M)
 
 	else if(href_list["SyndicateReply"])
 		var/mob/living/carbon/human/H = locate(href_list["SyndicateReply"])

--- a/code/modules/admin/topic.dm
+++ b/code/modules/admin/topic.dm
@@ -1817,7 +1817,7 @@
 			return
 
 		var/mob/M = locate(href_list["CentComReply"])
-		usr.client.cmd_admin_centcom_message(M)
+		cmd_admin_centcom_message(M)
 
 	else if(href_list["SyndicateReply"])
 		var/mob/living/carbon/human/H = locate(href_list["SyndicateReply"])

--- a/code/modules/admin/verbs/randomverbs.dm
+++ b/code/modules/admin/verbs/randomverbs.dm
@@ -45,6 +45,33 @@
 	admin_ticket_log(M, msg)
 	SSblackbox.record_feedback("tally", "admin_verb", 1, "Subtle Message") //If you are copy-pasting this, ensure the 2nd parameter is unique to the new proc!
 
+/client/proc/cmd_admin_centcom_message(mob/M in GLOB.mob_list)
+	set category = "Special Verbs"
+	set name = "CentCom Message"
+	var/mob/living/carbon/human/H = M
+	
+	if(!check_rights(R_ADMIN))
+		return
+
+	if(!istype(H))
+		to_chat(usr, "This can only be used on instances of type /mob/living/carbon/human")
+		return
+	if(!istype(H.ears, /obj/item/radio/headset))
+		to_chat(usr, "The person you are trying to contact is not wearing a headset.")
+		return
+
+	message_admins("[key_name_admin(src)] has started answering [key_name(H)]'s CentCom request.")
+	var/input = input("Please enter a message to reply to [key_name(H)] via their headset.","Outgoing message from CentCom", "") as text|null
+	if(!input)
+		message_admins("[key_name_admin(src)] decided not to answer [key_name(H)]'s CentCom request.")
+		return
+
+	log_admin("[key_name_admin(src)] replied to [key_name(H)]'s CentCom message with the message [input].")
+	message_admins("[key_name_admin(src)] replied to [key_name(H)]'s CentCom message with: \"[input]\"")
+	to_chat(H, "You hear something crackle in your ears for a moment before a voice speaks.  \"Please stand by for a message from Central Command.  Message as follows: <span class='bold'>[input].</span> Message ends.\"")
+
+	SSblackbox.record_feedback("tally", "admin_verb", 1, "CentCom Message") //If you are copy-pasting this, ensure the 2nd parameter is unique to the new proc!
+
 /client/proc/cmd_admin_mod_antag_rep(client/C in GLOB.clients, var/operation)
 	set category = "Special Verbs"
 	set name = "Modify Antagonist Reputation"

--- a/code/modules/admin/verbs/randomverbs.dm
+++ b/code/modules/admin/verbs/randomverbs.dm
@@ -60,14 +60,14 @@
 		to_chat(usr, "The person you are trying to contact is not wearing a headset.")
 		return
 
-	message_admins("[key_name_admin(src)] has started answering [key_name(H)]'s CentCom request.")
+	message_admins("[key_name_admin(src)] has started answering [key_name_admin(H)]'s CentCom request.")
 	var/input = input("Please enter a message to reply to [key_name(H)] via their headset.","Outgoing message from CentCom", "") as text|null
 	if(!input)
-		message_admins("[key_name_admin(src)] decided not to answer [key_name(H)]'s CentCom request.")
+		message_admins("[key_name_admin(src)] decided not to answer [key_name_admin(H)]'s CentCom request.")
 		return
 
-	log_admin("[key_name_admin(src)] replied to [key_name(H)]'s CentCom message with the message [input].")
-	message_admins("[key_name_admin(src)] replied to [key_name(H)]'s CentCom message with: \"[input]\"")
+	log_admin("[key_name(src)] replied to [key_name(H)]'s CentCom message with the message [input].")
+	message_admins("[key_name_admin(src)] replied to [key_name_admin(H)]'s CentCom message with: \"[input]\"")
 	to_chat(H, "You hear something crackle in your ears for a moment before a voice speaks.  \"Please stand by for a message from Central Command.  Message as follows: <span class='bold'>[input].</span> Message ends.\"")
 
 	SSblackbox.record_feedback("tally", "admin_verb", 1, "CentCom Message") //If you are copy-pasting this, ensure the 2nd parameter is unique to the new proc!

--- a/code/modules/admin/verbs/randomverbs.dm
+++ b/code/modules/admin/verbs/randomverbs.dm
@@ -45,7 +45,7 @@
 	admin_ticket_log(M, msg)
 	SSblackbox.record_feedback("tally", "admin_verb", 1, "Subtle Message") //If you are copy-pasting this, ensure the 2nd parameter is unique to the new proc!
 
-/client/proc/cmd_admin_centcom_message(mob/M in GLOB.mob_list)
+/datum/admins/proc/cmd_admin_centcom_message(mob/M in GLOB.mob_list)
 	set category = "Special Verbs"
 	set name = "CentCom Message"
 	var/mob/living/carbon/human/H = M


### PR DESCRIPTION
[Changelogs]: # (Your PR should contain a detailed changelog of notable changes, titled and categorized appropriately. This includes, new features, sprites, sounds, balance changes, admin tools, map edits, removals, big refactors, config changes, hosting changes and important fixes. An example changelog has been provided below for you to edit. If you need additional help, read https://github.com/tgstation/tgstation/wiki/Changelogs)

:cl: Dax Dupont
admin: You can now send messages as CentCom through people's headsets.
/:cl:

[why]: # (Please add a short description [two lines down] of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.)

Someone requested this, but basically this allows admins to send a little more IC messages which is appropriate in certain situations. This also moves CentCom messages to a verb and out of the topic.dm