### PR TITLE
Removes Dragon Blood from the Ash Drake Necropolis chest loot

### DIFF
--- a/code/modules/mining/lavaland/necropolis_chests.dm
+++ b/code/modules/mining/lavaland/necropolis_chests.dm
@@ -701,7 +701,7 @@
 	name = "dragon chest"
 
 /obj/structure/closet/crate/necropolis/dragon/PopulateContents()
-	var/loot = rand(1,4)
+	var/loot = rand(1,3)
 	switch(loot)
 		if(1)
 			new /obj/item/melee/ghost_sword(src)
@@ -710,8 +710,6 @@
 		if(3)
 			new /obj/item/book/granter/spell/sacredflame(src)
 			new /obj/item/gun/magic/wand/fireball(src)
-		if(4)
-			new /obj/item/dragons_blood(src)
 
 /obj/structure/closet/crate/necropolis/dragon/crusher
 	name = "firey dragon chest"


### PR DESCRIPTION
This PR removes the Dragon Blood from the loot chest gotten from Ash Drakes. Frankly, killing one of the weaker Megafauna on Lavaland should not give you a potion which turns you into a Megafauna. 

Now, while weaker than an actual Ash Drake, the simple fact that they are player controlled makes them far, far deadlier and harder to deal with. It gets fairly stale and highly unbalanced each time a murderboning lesser ash drake is onstation. It gets even worse when it is a lowpop round where a Lesser Ash Drake is even harder to deal with.

If anyone has a better idea how to deal with a major balance issue like this, then by all means I will change the PR to that instead. An alternative would be to make the transformation to and from the Drake form be longer, or make it so they either can't devour corpses, or devouring corpses doesn't heal them.

:cl: Firecage
balance: Removes the Dragon Blood from the Ash Drake Necropolis chest loot.
/:cl:
