### PR TITLE
[s]Diseases lose scan invisibility if their stealth drops below the threshold

### DIFF
--- a/code/datums/diseases/advance/advance.dm
+++ b/code/datums/diseases/advance/advance.dm
@@ -189,7 +189,9 @@
 
 	if(properties && properties.len)
 		if(properties["stealth"] >= 2)
-			visibility_flags = HIDDEN_SCANNER
+			visibility_flags |= HIDDEN_SCANNER
+		else
+			visibility_flags &= ~HIDDEN_SCANNER
 
 		SetSpread(CLAMP(2 ** (properties["transmittable"] - symptoms.len), DISEASE_SPREAD_BLOOD, DISEASE_SPREAD_AIRBORNE))
 


### PR DESCRIPTION
:cl: XDTM
fix: Diseases now properly lose scan invisibility if their stealth drops below the required threshold.
/:cl:

Fixes #37145