### PR TITLE
Fixes nuke exploding instantly.

### DIFF
--- a/code/modules/antagonists/nukeop/equipment/nuclearbomb.dm
+++ b/code/modules/antagonists/nukeop/equipment/nuclearbomb.dm
@@ -371,11 +371,11 @@
 	if(timing)
 		previous_level = get_security_level()
 		bomb_set = TRUE
-		set_security_level("delta")
 		detonation_timer = world.time + (timer_set * 10)
 		for(var/obj/item/pinpointer/nuke/syndicate/S in GLOB.pinpointer_list)
 			S.switch_mode_to(TRACK_INFILTRATOR)
 		countdown.start()
+		set_security_level("delta")
 	else
 		bomb_set = FALSE
 		detonation_timer = null


### PR DESCRIPTION
Fixes #38408 

Setting security level updates night shift which is check ticked, so next machinery process could hit while timing is set but timer wasn't set yet