### PR TITLE
Gives the colossus voice of god, adds language support to voice of god

### DIFF
--- a/code/modules/mob/living/silicon/ai/say.dm
+++ b/code/modules/mob/living/silicon/ai/say.dm
@@ -1,8 +1,7 @@
-/mob/living/silicon/ai/say(message, language)
+/mob/living/silicon/ai/say(message, bubble_type, var/list/spans = list(), sanitize = TRUE, datum/language/language = null)
 	if(parent && istype(parent) && parent.stat != DEAD) //If there is a defined "parent" AI, it is actually an AI, and it is alive, anything the AI tries to say is said by the parent instead.
-		parent.say(message, language)
-		return
-	..(message)
+		return parent.say(message, bubble_type, spans, sanitize, language)
+	return ..()
 
 /mob/living/silicon/ai/compose_track_href(atom/movable/speaker, namepart)
 	var/mob/M = speaker.GetSource()

--- a/code/modules/mob/living/simple_animal/hostile/megafauna/colossus.dm
+++ b/code/modules/mob/living/simple_animal/hostile/megafauna/colossus.dm
@@ -115,7 +115,7 @@ Difficulty: Very Hard
 /mob/living/simple_animal/hostile/megafauna/colossus/say(message, bubble_type, var/list/spans = list(), sanitize = TRUE, datum/language/language = null)
 	if(!using_voice) //to prevent infinite loops when voice of god calls say()
 		using_voice = TRUE
-		playsound(get_turf(owner), 'sound/magic/clockwork/invoke_general.ogg', 50, 1, 5)
+		playsound(get_turf(src), 'sound/magic/clockwork/invoke_general.ogg', 50, 1, 5)
 		voice_of_god(message, src, list("colossus","yell"), 1, FALSE, FALSE, language)
 	else
 		using_voice = FALSE

--- a/code/modules/mob/living/simple_animal/hostile/megafauna/colossus.dm
+++ b/code/modules/mob/living/simple_animal/hostile/megafauna/colossus.dm
@@ -51,6 +51,7 @@ Difficulty: Very Hard
 	butcher_results = list(/obj/item/ore/diamond = 5, /obj/item/stack/sheet/sinew = 5, /obj/item/stack/sheet/animalhide/ashdrake = 10, /obj/item/stack/sheet/bone = 30)
 	deathmessage = "disintegrates, leaving a glowing core in its wake."
 	death_sound = 'sound/magic/demon_dies.ogg'
+	var/using_voice = FALSE
 
 /mob/living/simple_animal/hostile/megafauna/colossus/devour(mob/living/L)
 	visible_message("<span class='colossus'>[src] disintegrates [L]!</span>")
@@ -110,6 +111,15 @@ Difficulty: Very Hard
 	. = ..()
 	target = new_target
 	INVOKE_ASYNC(src, /atom/movable/proc/orbit, target, 0, FALSE, 0, 0, FALSE, TRUE)
+
+/mob/living/simple_animal/hostile/megafauna/colossus/say(message, bubble_type, var/list/spans = list(), sanitize = TRUE, datum/language/language = null)
+	if(!using_voice) //to prevent infinite loops when voice of god calls say()
+		using_voice = TRUE
+		playsound(get_turf(owner), 'sound/magic/clockwork/invoke_general.ogg', 50, 1, 5)
+		voice_of_god(message, src, list("colossus","yell"), 1, FALSE, FALSE, language)
+	else
+		using_voice = FALSE
+		return ..()
 
 /mob/living/simple_animal/hostile/megafauna/colossus/bullet_act(obj/item/projectile/P)
 	if(!stat)

--- a/code/modules/surgery/organs/vocal_cords.dm
+++ b/code/modules/surgery/organs/vocal_cords.dm
@@ -119,11 +119,18 @@
 ///////////VOICE OF GOD///////////////
 //////////////////////////////////////
 
-/proc/voice_of_god(message, mob/living/user, list/span_list, base_multiplier = 1, include_speaker = FALSE, message_admins = TRUE)
+/proc/voice_of_god(message, mob/living/user, list/span_list, base_multiplier = 1, include_speaker = FALSE, message_admins = TRUE, datum/language/_language = null)
 	var/cooldown = 0
+	message = uppertext(message)
 
-	if(!user || !user.can_speak() || user.stat)
+	if(!user || user.stat)
 		return 0 //no cooldown
+
+	if(!_language)
+		_language = user.get_default_language()
+
+	if(!user.say(message, spans = span_list, sanitize = FALSE, language = _language))
+		return 0
 
 	var/log_message = uppertext(message)
 	if(!span_list || !span_list.len)
@@ -133,8 +140,6 @@
 			span_list = list("ratvar")
 		else
 			span_list = list()
-
-	user.say(message, spans = span_list, sanitize = FALSE)
 
 	message = lowertext(message)
 	var/mob/living/list/listeners = list()


### PR DESCRIPTION
:cl: XDTM
fix: If a colossus is somehow able to gain sentience, they'll speak with the Voice of God instead of a wimpy, human voice.
tweak: Voice of God now uses your default language. The effect is the same regardless of language, but it can be made incomprehensible to listeners.
fix: AIs can now properly use the voice of god spell. It still does not work over radio, but better than nothing.
/:cl:

I found this in my closed PR list, for some reason. I don't think it had anything wrong so i'm reopening it

Fixes #33650
