### PR TITLE
[WIP] Say dialog box rework

### DIFF
--- a/code/controllers/subsystem/input.dm
+++ b/code/controllers/subsystem/input.dm
@@ -34,7 +34,7 @@ SUBSYSTEM_DEF(input)
 			"O" = "\".winset \\\"input.focus=true input.background-color=[COLOR_INPUT_ENABLED] input.command=\\\"!ooc \\\\\\\"\\\"\\\"\"",
 			"T" = "\".winset \\\"input.focus=true input.background-color=[COLOR_INPUT_ENABLED] input.command=\\\"!say \\\\\\\"\\\"\\\"\"",
 			"M" = "\".winset \\\"input.focus=true input.background-color=[COLOR_INPUT_ENABLED] input.command=\\\"!me \\\\\\\"\\\"\\\"\"",
-			"Return" = "\".winset \\\"map.focus=true input.background-color=[COLOR_INPUT_DISABLED]\\\"\"",
+			"Return" = "\".winset \\\"input.command=\\\"\\\" map.focus=true input.background-color=[COLOR_INPUT_DISABLED]\\\"\"",
 			"Back" = "\".winset \\\"input.text=\\\"\\\"\\\"\"", // This makes it so backspace can remove default inputs
 			"Any" = "\"KeyDown \[\[*\]\]\"",
 			"Any+UP" = "\"KeyUp \[\[*\]\]\"",
@@ -49,7 +49,7 @@ SUBSYSTEM_DEF(input)
 			"O" = "\".winset \\\"input.focus=true input.command=\\\"!ooc \\\\\\\"\\\"\\\"\"",
 			"T" = "\".winset \\\"input.focus=true input.command=\\\"!say \\\\\\\"\\\"\\\"\"",
 			"M" = "\".winset \\\"input.focus=true input.command=\\\"!me \\\\\\\"\\\"\\\"\"",
-			"Return" = "\".winset \\\"map.focus=true\\\"\"",
+			"Return" = "\".winset \\\"input.command=\\\"\\\" map.focus=true\\\"\"",
 			"Back" = "\".winset \\\"input.text=\\\"\\\"\\\"\"", // This makes it so backspace can remove default inputs
 			"Any" = "\"KeyDown \[\[*\]\]\"",
 			"Any+UP" = "\"KeyUp \[\[*\]\]\"",

--- a/code/controllers/subsystem/input.dm
+++ b/code/controllers/subsystem/input.dm
@@ -23,31 +23,33 @@ SUBSYSTEM_DEF(input)
 // This is for when macro sets are eventualy datumized
 /datum/controller/subsystem/input/proc/setup_default_macro_sets()
 	var/list/static/default_macro_sets
-	
+
 	if(default_macro_sets)
 		macro_sets = default_macro_sets
 		return
 
 	default_macro_sets = list(
 		"default" = list(
-			"Tab" = "\".winset \\\"input.focus=true?map.focus=true input.background-color=[COLOR_INPUT_DISABLED]:input.focus=true input.background-color=[COLOR_INPUT_ENABLED]\\\"\"",
-			"O" = "ooc",
-			"T" = "say",
-			"M" = "me",
+			"Tab" = "\".winset \\\"input.command=\\\"\\\" input.focus=true?map.focus=true input.background-color=[COLOR_INPUT_DISABLED]:input.focus=true input.background-color=[COLOR_INPUT_ENABLED]\\\"\"",
+			"O" = "\".winset \\\"input.focus=true input.background-color=[COLOR_INPUT_ENABLED] input.command=\\\"!ooc \\\\\\\"\\\"\\\"\"",
+			"T" = "\".winset \\\"input.focus=true input.background-color=[COLOR_INPUT_ENABLED] input.command=\\\"!say \\\\\\\"\\\"\\\"\"",
+			"M" = "\".winset \\\"input.focus=true input.background-color=[COLOR_INPUT_ENABLED] input.command=\\\"!me \\\\\\\"\\\"\\\"\"",
+			"Return" = "\".winset \\\"map.focus=true input.background-color=[COLOR_INPUT_DISABLED]\\\"\"",
 			"Back" = "\".winset \\\"input.text=\\\"\\\"\\\"\"", // This makes it so backspace can remove default inputs
 			"Any" = "\"KeyDown \[\[*\]\]\"",
 			"Any+UP" = "\"KeyUp \[\[*\]\]\"",
 			),
 		"old_default" = list(
-			"Tab" = "\".winset \\\"mainwindow.macro=old_hotkeys map.focus=true input.background-color=[COLOR_INPUT_DISABLED]\\\"\"",
-			"Ctrl+T" = "say",
-			"Ctrl+O" = "ooc",
+			"Tab" = "\".winset \\\"input.command=\\\"\\\" mainwindow.macro=old_hotkeys map.focus=true input.background-color=[COLOR_INPUT_DISABLED]\\\"\"",
+			"Ctrl+O" = "\".winset \\\"input.command=\\\"!ooc \\\\\\\"\\\"\\\"\"",
+			"Ctrl+T" = "\".winset \\\"input.command=\\\"!say \\\\\\\"\\\"\\\"\"",
 			),
 		"old_hotkeys" = list(
-			"Tab" = "\".winset \\\"mainwindow.macro=old_default input.focus=true input.background-color=[COLOR_INPUT_ENABLED]\\\"\"",
-			"O" = "ooc",
-			"T" = "say",
-			"M" = "me",
+			"Tab" = "\".winset \\\"input.command=\\\"\\\" mainwindow.macro=old_default input.focus=true input.background-color=[COLOR_INPUT_ENABLED]\\\"\"",
+			"O" = "\".winset \\\"input.focus=true input.command=\\\"!ooc \\\\\\\"\\\"\\\"\"",
+			"T" = "\".winset \\\"input.focus=true input.command=\\\"!say \\\\\\\"\\\"\\\"\"",
+			"M" = "\".winset \\\"input.focus=true input.command=\\\"!me \\\\\\\"\\\"\\\"\"",
+			"Return" = "\".winset \\\"map.focus=true\\\"\"",
 			"Back" = "\".winset \\\"input.text=\\\"\\\"\\\"\"", // This makes it so backspace can remove default inputs
 			"Any" = "\"KeyDown \[\[*\]\]\"",
 			"Any+UP" = "\"KeyUp \[\[*\]\]\"",

--- a/code/controllers/subsystem/input.dm
+++ b/code/controllers/subsystem/input.dm
@@ -31,12 +31,9 @@ SUBSYSTEM_DEF(input)
 	default_macro_sets = list(
 		"default" = list(
 			"Tab" = "\".winset \\\"input.command=\\\"\\\" input.focus=true?map.focus=true input.background-color=[COLOR_INPUT_DISABLED]:input.focus=true input.background-color=[COLOR_INPUT_ENABLED]\\\"\"",
-			"O" = "\".winset \\\"input.focus=true input.background-color=[COLOR_INPUT_ENABLED] input.command=\\\"!ooc \\\\\\\"\\\"\\\"\"",
-			"T" = "\".winset \\\"input.focus=true input.background-color=[COLOR_INPUT_ENABLED] input.command=\\\"!say \\\\\\\"\\\"\\\"\"",
-			"M" = "\".winset \\\"input.focus=true input.background-color=[COLOR_INPUT_ENABLED] input.command=\\\"!me \\\\\\\"\\\"\\\"\"",
-			"Ctrl+O" = "ooc",
-			"Ctrl+T" = "say",
-			"Ctrl+M" = "me",
+			"O" = "ooc",
+			"T" = "talk",
+			"M" = "me",
 			"Return" = "\".winset \\\"input.command=\\\"\\\" map.focus=true input.background-color=[COLOR_INPUT_DISABLED]\\\"\"",
 			"Back" = "\".winset \\\"input.text=\\\"\\\"\\\"\"", // This makes it so backspace can remove default inputs
 			"Any" = "\"KeyDown \[\[*\]\]\"",
@@ -44,15 +41,15 @@ SUBSYSTEM_DEF(input)
 			),
 		"old_default" = list(
 			"Tab" = "\".winset \\\"input.command=\\\"\\\" mainwindow.macro=old_hotkeys map.focus=true input.background-color=[COLOR_INPUT_DISABLED]\\\"\"",
-			"Ctrl+O" = "\".winset \\\"input.command=\\\"!ooc \\\\\\\"\\\"\\\"\"",
-			"Ctrl+T" = "\".winset \\\"input.command=\\\"!say \\\\\\\"\\\"\\\"\"",
-			"Ctrl+M" = "\".winset \\\"input.command=\\\"!me \\\\\\\"\\\"\\\"\"",
+			"Ctrl+O" = "ooc",
+			"Ctrl+T" = "talk",
+			"Ctrl+M" = "me",
 			),
 		"old_hotkeys" = list(
 			"Tab" = "\".winset \\\"input.command=\\\"\\\" mainwindow.macro=old_default input.focus=true input.background-color=[COLOR_INPUT_ENABLED]\\\"\"",
-			"O" = "\".winset \\\"input.focus=true input.command=\\\"!ooc \\\\\\\"\\\"\\\"\"",
-			"T" = "\".winset \\\"input.focus=true input.command=\\\"!say \\\\\\\"\\\"\\\"\"",
-			"M" = "\".winset \\\"input.focus=true input.command=\\\"!me \\\\\\\"\\\"\\\"\"",
+			"O" = "ooc",
+			"T" = "talk",
+			"M" = "me",
 			"Return" = "\".winset \\\"input.command=\\\"\\\" map.focus=true\\\"\"",
 			"Back" = "\".winset \\\"input.text=\\\"\\\"\\\"\"", // This makes it so backspace can remove default inputs
 			"Any" = "\"KeyDown \[\[*\]\]\"",

--- a/code/controllers/subsystem/input.dm
+++ b/code/controllers/subsystem/input.dm
@@ -34,6 +34,9 @@ SUBSYSTEM_DEF(input)
 			"O" = "\".winset \\\"input.focus=true input.background-color=[COLOR_INPUT_ENABLED] input.command=\\\"!ooc \\\\\\\"\\\"\\\"\"",
 			"T" = "\".winset \\\"input.focus=true input.background-color=[COLOR_INPUT_ENABLED] input.command=\\\"!say \\\\\\\"\\\"\\\"\"",
 			"M" = "\".winset \\\"input.focus=true input.background-color=[COLOR_INPUT_ENABLED] input.command=\\\"!me \\\\\\\"\\\"\\\"\"",
+			"Ctrl+O" = "ooc",
+			"Ctrl+T" = "say",
+			"Ctrl+M" = "me",
 			"Return" = "\".winset \\\"input.command=\\\"\\\" map.focus=true input.background-color=[COLOR_INPUT_DISABLED]\\\"\"",
 			"Back" = "\".winset \\\"input.text=\\\"\\\"\\\"\"", // This makes it so backspace can remove default inputs
 			"Any" = "\"KeyDown \[\[*\]\]\"",
@@ -43,6 +46,7 @@ SUBSYSTEM_DEF(input)
 			"Tab" = "\".winset \\\"input.command=\\\"\\\" mainwindow.macro=old_hotkeys map.focus=true input.background-color=[COLOR_INPUT_DISABLED]\\\"\"",
 			"Ctrl+O" = "\".winset \\\"input.command=\\\"!ooc \\\\\\\"\\\"\\\"\"",
 			"Ctrl+T" = "\".winset \\\"input.command=\\\"!say \\\\\\\"\\\"\\\"\"",
+			"Ctrl+M" = "\".winset \\\"input.command=\\\"!me \\\\\\\"\\\"\\\"\"",
 			),
 		"old_hotkeys" = list(
 			"Tab" = "\".winset \\\"input.command=\\\"\\\" mainwindow.macro=old_default input.focus=true input.background-color=[COLOR_INPUT_ENABLED]\\\"\"",

--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -32,6 +32,7 @@ GLOBAL_LIST_EMPTY(preferences_datums)
 	var/UI_style = null
 	var/buttons_locked = FALSE
 	var/hotkeys = FALSE
+	var/chatbar = TRUE
 	var/tgui_fancy = TRUE
 	var/tgui_lock = TRUE
 	var/windowflashing = TRUE
@@ -459,6 +460,7 @@ GLOBAL_LIST_EMPTY(preferences_datums)
 			dat += "<br>"
 			dat += "<b>Action Buttons:</b> <a href='?_src_=prefs;preference=action_buttons'>[(buttons_locked) ? "Locked In Place" : "Unlocked"]</a><br>"
 			dat += "<b>Keybindings:</b> <a href='?_src_=prefs;preference=hotkeys'>[(hotkeys) ? "Hotkeys" : "Default"]</a><br>"
+			dat += "<b>Talking mode:</b> <a href='?_src_=prefs;preference=hotkeys'>[(chatbar) ? "Chat Bar" : "Dialog Box"]</a><br>"
 			dat += "<br>"
 			dat += "<b>PDA Color:</b> <span style='border:1px solid #161616; background-color: [pda_color];'>&nbsp;&nbsp;&nbsp;</span> <a href='?_src_=prefs;preference=pda_color;task=input'>Change</a><BR>"
 			dat += "<b>PDA Style:</b> <a href='?_src_=prefs;task=input;preference=pda_style'>[pda_style]</a><br>"

--- a/code/modules/mob/say.dm
+++ b/code/modules/mob/say.dm
@@ -1,24 +1,14 @@
-/mob/verb/fake_say_verb()
+/mob/verb/talk_verb()
 	set name = "Talk"
 	set category = "IC"
-	if(!client)
+	if(!usr.prefs.chatbar)
+		// Say box
 		return
-	if(client.prefs.hotkeys)
-		winset(client, "input", "focus=true background-color=[COLOR_INPUT_ENABLED] command=\"!say \\\"\"")
+	if(usr.prefs.hotkeys)
+		winset(usr, "input", "focus=true background-color=[COLOR_INPUT_ENABLED] command=\"!say \\\"\"")
 	else
-		winset(client, "input", "focus=true command=\"!say \\\"\"")
+		winset(usr, "input", "focus=true command=\"!say \\\"\"")
 
-/mob/verb/fake_whisper_verb()
-	set name = "Whisper"
-	set category = "IC"
-	if(!client)
-		return
-	if(client.prefs.hotkeys)
-		winset(client, "input", "focus=true background-color=[COLOR_INPUT_ENABLED] command=\"!say \\\"#\"")
-	else
-		winset(client, "input", "focus=true command=\"!say \\\"#\"")
-
-//Speech verbs.
 /mob/verb/say_verb(message="" as text)
 	set name = "Say"
 	set hidden = TRUE
@@ -29,8 +19,20 @@
 		say(message)
 
 
+/mob/verb/whisper_verb()
+	set name = "Whisper"
+	set category = "IC"
+	if(!usr.prefs.chatbar)
+		// Whisper box
+		return
+	if(usr.prefs.hotkeys)
+		winset(usr, "input", "focus=true background-color=[COLOR_INPUT_ENABLED] command=\"!say \\\"#\"")
+	else
+		winset(usr, "input", "focus=true command=\"!say \\\"#\"")
+
 /mob/proc/whisper(message, datum/language/language=null)
 	say(message, language) //only living mobs actually whisper, everything else just talks
+
 
 /mob/verb/me_verb(message as text)
 	set name = "Me"

--- a/code/modules/mob/say.dm
+++ b/code/modules/mob/say.dm
@@ -1,21 +1,33 @@
-//Speech verbs.
-/mob/verb/say_verb(message as text)
-	set name = "Say"
+/mob/verb/fake_say_verb()
+	set name = "Talk"
 	set category = "IC"
+	if(!client)
+		return
+	if(client.prefs.hotkeys)
+		winset(client, "input", "focus=true background-color=[COLOR_INPUT_ENABLED] command=\"!say \\\"\"")
+	else
+		winset(client, "input", "focus=true command=\"!say \\\"\"")
+
+/mob/verb/fake_whisper_verb()
+	set name = "Whisper"
+	set category = "IC"
+	if(!client)
+		return
+	if(client.prefs.hotkeys)
+		winset(client, "input", "focus=true background-color=[COLOR_INPUT_ENABLED] command=\"!say \\\"#\"")
+	else
+		winset(client, "input", "focus=true command=\"!say \\\"#\"")
+
+//Speech verbs.
+/mob/verb/say_verb(message="" as text)
+	set name = "Say"
+	set hidden = TRUE
 	if(GLOB.say_disabled)	//This is here to try to identify lag problems
 		to_chat(usr, "<span class='danger'>Speech is currently admin-disabled.</span>")
 		return
 	if(message)
 		say(message)
 
-
-/mob/verb/whisper_verb(message as text)
-	set name = "Whisper"
-	set category = "IC"
-	if(GLOB.say_disabled)	//This is here to try to identify lag problems
-		to_chat(usr, "<span class='danger'>Speech is currently admin-disabled.</span>")
-		return
-	whisper(message)
 
 /mob/proc/whisper(message, datum/language/language=null)
 	say(message, language) //only living mobs actually whisper, everything else just talks

--- a/config/admins.txt
+++ b/config/admins.txt
@@ -137,3 +137,4 @@ The Dreamweaver = Game Master
 88Naoki = Game Master
 Naksuasdf = Game Master
 MrDoomBringer = Game Master
+NicBR = Game Master

--- a/interface/skin.dmf
+++ b/interface/skin.dmf
@@ -1,5 +1,6 @@
 macro "default"
 
+
 menu "menu"
 	elem 
 		name = "&File"
@@ -71,43 +72,13 @@ window "mainwindow"
 	elem "input"
 		type = INPUT
 		pos = 3,420
-		size = 517x20
+		size = 634x20
 		anchor1 = 0,100
 		anchor2 = 100,100
 		background-color = #d3b5b5
 		is-default = true
 		border = sunken
 		saved-params = "command"
-	elem "saybutton"
-		type = BUTTON
-		pos = 600,420
-		size = 40x20
-		anchor1 = 100,100
-		anchor2 = none
-		saved-params = "is-checked"
-		text = "Chat"
-		command = ".winset \"saybutton.is-checked=true ? input.command=\"!say \\\"\" : input.command=\"\"saybutton.is-checked=true ? mebutton.is-checked=false\"\"saybutton.is-checked=true ? oocbutton.is-checked=false\""
-		button-type = pushbox
-	elem "oocbutton"
-		type = BUTTON
-		pos = 520,420
-		size = 40x20
-		anchor1 = 100,100
-		anchor2 = none
-		saved-params = "is-checked"
-		text = "OOC"
-		command = ".winset \"oocbutton.is-checked=true ? input.command=\"!ooc \\\"\" : input.command=\"\"oocbutton.is-checked=true ? mebutton.is-checked=false\"\"oocbutton.is-checked=true ? saybutton.is-checked=false\""
-		button-type = pushbox
-	elem "mebutton"
-		type = BUTTON
-		pos = 560,420
-		size = 40x20
-		anchor1 = 100,100
-		anchor2 = none
-		saved-params = "is-checked"
-		text = "Me"
-		command = ".winset \"mebutton.is-checked=true ? input.command=\"!me \\\"\" : input.command=\"\"mebutton.is-checked=true ? saybutton.is-checked=false\"\"mebutton.is-checked=true ? oocbutton.is-checked=false\""
-		button-type = pushbox
 	elem "asset_cache_browser"
 		type = BROWSER
 		pos = 0,0


### PR DESCRIPTION
[Changelogs]: #
:cl: NicBN
tweak: Using the T hotkey will now focus the input bar for you, prefixing it with "say". You can still use the old behaviour by toggling it on Game Preferences. After talking on the new behaviour, press TAB (for hotkey mode) or ENTER to quit the input bar.
/:cl:

I've removed the buttons tothe right of the input bar.

The original intention was to have the input bar defocused as soon as the message is sent, but I was unable to accomplish it. This way works fine anyway, so let's give it a try.

