### PR TITLE
Destructive analyzers no longer work if something has mobs in it

### DIFF
--- a/code/modules/research/destructive_analyzer.dm
+++ b/code/modules/research/destructive_analyzer.dm
@@ -36,6 +36,10 @@ Note: Must be placed within 3 tiles of the R&D Console
 		. = 1
 		if(!is_insertion_ready(user))
 			return
+		var/list/L = typecache_filter_list(O.GetAllContents(), typecacheof(/mob))
+		if(L.len)
+			to_chat(user, "<span class='warning'>[src] rejects [O], having detected biological entities within it.</span>")
+			return
 		if(!user.transferItemToLoc(O, src))
 			to_chat(user, "<span class='warning'>\The [O] is stuck to your hand, you cannot put it in the [src.name]!</span>")
 			return

--- a/code/modules/research/destructive_analyzer.dm
+++ b/code/modules/research/destructive_analyzer.dm
@@ -13,6 +13,7 @@ Note: Must be placed within 3 tiles of the R&D Console
 	icon_state = "d_analyzer"
 	circuit = /obj/item/circuitboard/machine/destructive_analyzer
 	var/decon_mod = 0
+	var/safety = TRUE
 
 /obj/machinery/rnd/destructive_analyzer/RefreshParts()
 	var/T = 0
@@ -36,7 +37,7 @@ Note: Must be placed within 3 tiles of the R&D Console
 		. = 1
 		if(!is_insertion_ready(user))
 			return
-		if(!istype(O, /mob/living/brain) && !istype(O, /obj/item/mmi) && !istype(O, /obj/item/aicard) && !istype(O, /obj/item/organ/brain))
+		if(safety && !istype(O, /mob/living/brain) && !istype(O, /obj/item/mmi) && !istype(O, /obj/item/aicard) && !istype(O, /obj/item/organ/brain))
 			var/list/L = typecache_filter_list(O.GetAllContents(), GLOB.typecache_mob)
 			if(L.len)
 				to_chat(user, "<span class='warning'>[src] rejects [O], having detected biological entities within it.</span>")

--- a/code/modules/research/destructive_analyzer.dm
+++ b/code/modules/research/destructive_analyzer.dm
@@ -36,7 +36,7 @@ Note: Must be placed within 3 tiles of the R&D Console
 		. = 1
 		if(!is_insertion_ready(user))
 			return
-		var/list/L = typecache_filter_list(O.GetAllContents(), typecacheof(/mob))
+		var/list/L = typecache_filter_list(O.GetAllContents(), GLOB.typecache_mob)
 		if(L.len)
 			to_chat(user, "<span class='warning'>[src] rejects [O], having detected biological entities within it.</span>")
 			return

--- a/code/modules/research/destructive_analyzer.dm
+++ b/code/modules/research/destructive_analyzer.dm
@@ -36,10 +36,11 @@ Note: Must be placed within 3 tiles of the R&D Console
 		. = 1
 		if(!is_insertion_ready(user))
 			return
-		var/list/L = typecache_filter_list(O.GetAllContents(), GLOB.typecache_mob)
-		if(L.len)
-			to_chat(user, "<span class='warning'>[src] rejects [O], having detected biological entities within it.</span>")
-			return
+		if(!istype(O, /mob/living/brain) && !istype(O, /obj/item/mmi) && !istype(O, /obj/item/aicard) && !istype(O, /obj/item/organ/brain))
+			var/list/L = typecache_filter_list(O.GetAllContents(), GLOB.typecache_mob)
+			if(L.len)
+				to_chat(user, "<span class='warning'>[src] rejects [O], having detected biological entities within it.</span>")
+				return
 		if(!user.transferItemToLoc(O, src))
 			to_chat(user, "<span class='warning'>\The [O] is stuck to your hand, you cannot put it in the [src.name]!</span>")
 			return


### PR DESCRIPTION
Balancing, due to bluespace body bags being abused for non-escapable instant kills and body destruction via this.