### PR TITLE
Fixes clothes getting damaged twice in explosions.

### DIFF
--- a/code/datums/explosion.dm
+++ b/code/datums/explosion.dm
@@ -201,7 +201,8 @@ GLOBAL_LIST_EMPTY(explosions)
 				items += A.GetAllContents()
 			for(var/O in items)
 				var/atom/A = O
-				A.ex_act(dist)
+				if(!QDELETED(A))
+					A.ex_act(dist)
 
 		if(flame_dist && prob(40) && !isspaceturf(T) && !T.density)
 			new /obj/effect/hotspot(T) //Mostly for ambience!


### PR DESCRIPTION
Clothes could already be damaged in human/ex_act. I'm not sure this is the best fix here but alternatives would need changing how explosions work on humans.