### PR TITLE
Adds comments to access defines, renames power equipment

### DIFF
--- a/code/__DEFINES/access.dm
+++ b/code/__DEFINES/access.dm
@@ -1,22 +1,22 @@
-#define ACCESS_SECURITY 1 // Security equipment
-#define ACCESS_BRIG 2 // Brig timers and permabrig
-#define ACCESS_ARMORY 3
-#define ACCESS_FORENSICS_LOCKERS 4
+#define ACCESS_SECURITY 1 // Security equipment, security records, gulag item storage, secbots
+#define ACCESS_BRIG 2 // Brig cells+timers, permabrig, gulag+gulag shuttle, prisoner management console
+#define ACCESS_ARMORY 3 // Armory, gulag teleporter, execution chamber
+#define ACCESS_FORENSICS_LOCKERS 4 //Detective's office, forensics lockers, security+medical records
 #define ACCESS_MEDICAL 5
 #define ACCESS_MORGUE 6
-#define ACCESS_TOX 7
-#define ACCESS_TOX_STORAGE 8
-#define ACCESS_GENETICS 9
-#define ACCESS_ENGINE 10
-#define ACCESS_ENGINE_EQUIP 11
+#define ACCESS_TOX 7 //R&D department, R&D console, burn chamber on some maps
+#define ACCESS_TOX_STORAGE 8 //Toxins storage, burn chamber on some maps
+#define ACCESS_GENETICS 9 
+#define ACCESS_ENGINE 10 //Engineering area, power monitor, power flow control console
+#define ACCESS_ENGINE_EQUIP 11 //APCs, EngiVend/YouTool, engineering equipment lockers
 #define ACCESS_MAINT_TUNNELS 12
 #define ACCESS_EXTERNAL_AIRLOCKS 13
-#define ACCESS_EMERGENCY_STORAGE 14
+#define ACCESS_EMERGENCY_STORAGE 14 //Not in use
 #define ACCESS_CHANGE_IDS 15
 #define ACCESS_AI_UPLOAD 16
 #define ACCESS_TELEPORTER 17
 #define ACCESS_EVA 18
-#define ACCESS_HEADS 19
+#define ACCESS_HEADS 19 //Bridge, EVA storage windoors, gateway shutters, AI integrity restorer, clone record deletion, comms console
 #define ACCESS_CAPTAIN 20
 #define ACCESS_ALL_PERSONAL_LOCKERS 21
 #define ACCESS_CHAPEL_OFFICE 22
@@ -31,9 +31,9 @@
 #define ACCESS_CARGO 31
 #define ACCESS_CONSTRUCTION 32
 #define ACCESS_CHEMISTRY 33
-#define ACCESS_CARGO_BOT 34
+#define ACCESS_CARGO_BOT 34 //Not in use
 #define ACCESS_HYDROPONICS 35
-#define ACCESS_MANUFACTURING 36
+#define ACCESS_MANUFACTURING 36 //Only used on research.dmm away mission
 #define ACCESS_LIBRARY 37
 #define ACCESS_LAWYER 38
 #define ACCESS_VIROLOGY 39
@@ -44,10 +44,10 @@
 #define ACCESS_THEATRE 46
 #define ACCESS_RESEARCH 47
 #define ACCESS_MINING 48
-#define ACCESS_MINING_OFFICE 49 //not in use
+#define ACCESS_MINING_OFFICE 49 //Not in use
 #define ACCESS_MAILSORTING 50
-#define ACCESS_MINT 51
-#define ACCESS_MINT_VAULT 52
+#define ACCESS_MINT 51 //Not in use
+#define ACCESS_MINT_VAULT 52 //Not in use
 #define ACCESS_VAULT 53
 #define ACCESS_MINING_STATION 54
 #define ACCESS_XENOBIOLOGY 55
@@ -58,19 +58,19 @@
 #define ACCESS_KEYCARD_AUTH 60 //Used for events which require at least two people to confirm them
 #define ACCESS_TCOMSAT 61 // has access to the entire telecomms satellite / machinery
 #define ACCESS_GATEWAY 62
-#define ACCESS_SEC_DOORS 63 // Security front doors
-#define ACCESS_MINERAL_STOREROOM 64
+#define ACCESS_SEC_DOORS 63 // Outer brig doors, department security posts
+#define ACCESS_MINERAL_STOREROOM 64 //For releasing minerals from the ORM
 #define ACCESS_MINISAT 65
 #define ACCESS_WEAPONS 66 //Weapon authorization for secbots
-#define ACCESS_NETWORK 67
-#define ACCESS_CLONING 68 //Cloning room
+#define ACCESS_NETWORK 67 //NTnet diagnostics/monitoring software
+#define ACCESS_CLONING 68 //Cloning room and clone pod ejection
 
 	//BEGIN CENTCOM ACCESS
 	/*Should leave plenty of room if we need to add more access levels.
 	Mostly for admin fun times.*/
-#define ACCESS_CENT_GENERAL 101//General facilities.
+#define ACCESS_CENT_GENERAL 101//General facilities. CentCom ferry.
 #define ACCESS_CENT_THUNDER 102//Thunderdome.
-#define ACCESS_CENT_SPECOPS 103//Special Ops.
+#define ACCESS_CENT_SPECOPS 103//Special Ops. Captain's display case, Marauder and Seraph mechs.
 #define ACCESS_CENT_MEDICAL 104//Medical/Research
 #define ACCESS_CENT_LIVING 105//Living quarters.
 #define ACCESS_CENT_STORAGE 106//Generic storage areas.
@@ -79,7 +79,7 @@
 #define ACCESS_CENT_BAR 110 // The non-existent CentCom Bar
 
 	//The Syndicate
-#define ACCESS_SYNDICATE 150//General Syndicate Access
+#define ACCESS_SYNDICATE 150//General Syndicate Access. Includes Syndicate mechs and ruins.
 #define ACCESS_SYNDICATE_LEADER 151//Nuke Op Leader Access
 
 	//Away Missions or Ruins

--- a/code/modules/jobs/access.dm
+++ b/code/modules/jobs/access.dm
@@ -222,7 +222,7 @@
 		if(ACCESS_ENGINE)
 			return "Engineering"
 		if(ACCESS_ENGINE_EQUIP)
-			return "Power Equipment"
+			return "Power and Engineering Equipment"
 		if(ACCESS_MAINT_TUNNELS)
 			return "Maintenance"
 		if(ACCESS_EXTERNAL_AIRLOCKS)


### PR DESCRIPTION
I added comments to access defines so that it's easier to see what access handles which objects. 

Also renamed Power Equipment to "Power and Engineering Equipment" since it handles APCs as well as engi vending machines and lockers.

I've noticed that access reqs vary wildly from map to map, maybe something for a later PR?