### PR TITLE
Empties vis_contents in changeturf

### DIFF
--- a/code/game/turfs/change_turf.dm
+++ b/code/game/turfs/change_turf.dm
@@ -79,6 +79,8 @@ GLOBAL_LIST_INIT(blacklisted_automated_baseturfs, typecacheof(list(
 	qdel(src)	//Just get the side effects and call Destroy
 	var/turf/W = new path(src)
 
+	W.vis_contents.Cut()
+
 	for(var/i in transferring_comps)
 		W.TakeComponent(i)
 


### PR DESCRIPTION
:cl: ninjanomnom
fix: Gas overlays left over in some turf changes should no longer stick around where they shouldn't.
/:cl:

Other air related and overlay related code behaves similarly so I did it this way instead of making it transfer.

fixes #34861