### PR TITLE
Fixed item attack overlays being in the hud plane

### DIFF
--- a/code/game/atoms_movable.dm
+++ b/code/game/atoms_movable.dm
@@ -564,6 +564,7 @@
 		I = image('icons/effects/effects.dmi', A, visual_effect_icon, A.layer + 0.1)
 	else if(used_item)
 		I = image(icon = used_item, loc = A, layer = A.layer + 0.1)
+		I.plane = GAME_PLANE
 
 		// Scale the icon.
 		I.transform *= 0.75


### PR DESCRIPTION
Fixes #38449

:cl: Cruix
fix: Item attack animations can no longer be seen over darkness or camera static.
/:cl:

Nothing to do with multicamera mode. Item attack animations were recently changed from copying the sprite of the item to copying the entire appearance of the item, which includes the plane, but any object that is currently being held is in the HUD plane, putting it above almost everything.