### PR TITLE
Fix some nullspacing bugs with antag spawners

### DIFF
--- a/code/modules/antagonists/_common/antag_spawner.dm
+++ b/code/modules/antagonists/_common/antag_spawner.dm
@@ -58,6 +58,8 @@
 				return
 			var/list/candidates = pollCandidatesForMob("Do you want to play as a wizard's [href_list["school"]] apprentice?", ROLE_WIZARD, null, ROLE_WIZARD, 150, src)
 			if(LAZYLEN(candidates))
+				if(QDELETED(src))
+					return
 				if(used)
 					to_chat(H, "You already used this contract!")
 					return
@@ -121,7 +123,7 @@
 	to_chat(user, "<span class='notice'>You activate [src] and wait for confirmation.</span>")
 	var/list/nuke_candidates = pollGhostCandidates("Do you want to play as a syndicate [borg_to_spawn ? "[lowertext(borg_to_spawn)] cyborg":"operative"]?", ROLE_OPERATIVE, null, ROLE_OPERATIVE, 150, POLL_IGNORE_SYNDICATE)
 	if(LAZYLEN(nuke_candidates))
-		if(!(check_usability(user)))
+		if(QDELETED(src) || !check_usability(user))
 			return
 		used = TRUE
 		var/mob/dead/observer/G = pick(nuke_candidates)
@@ -235,7 +237,7 @@
 		return
 	var/list/candidates = pollCandidatesForMob("Do you want to play as a [initial(demon_type.name)]?", ROLE_ALIEN, null, ROLE_ALIEN, 50, src)
 	if(LAZYLEN(candidates))
-		if(used)
+		if(used || QDELETED(src))
 			return
 		used = TRUE
 		var/mob/dead/observer/C = pick(candidates)


### PR DESCRIPTION
:cl:
fix: Refunding nuclear reinforcements while polling ghosts no longer summons the reinforcements into the error room anyways.
/:cl:

Fixes #38057.