### PR TITLE
Fix being able to examine out-of-view turfs

### DIFF
--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -293,6 +293,10 @@
 	set name = "Examine"
 	set category = "IC"
 
+	if(isturf(A) && !(sight & SEE_TURFS) && !(A in view(src)))
+		// shift-click catcher may issue examinate() calls for out-of-sight turfs
+		return
+
 	if(is_blind(src))
 		to_chat(src, "<span class='notice'>Something is there but you can't see it.</span>")
 		return

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -293,7 +293,7 @@
 	set name = "Examine"
 	set category = "IC"
 
-	if(isturf(A) && !(sight & SEE_TURFS) && !(A in view(src)))
+	if(isturf(A) && !(sight & SEE_TURFS) && !(A in view(client ? client.view : world.view, src)))
 		// shift-click catcher may issue examinate() calls for out-of-sight turfs
 		return
 


### PR DESCRIPTION
:cl:
fix: Shift-clicking turfs obscured by fog of war no longer lets you examine them.
/:cl:

Fixes #38063. Based on https://github.com/yogstation13/yogstation/pull/3070.