### PR TITLE
Adds missing cables to Omega

### DIFF
--- a/_maps/map_files/OmegaStation/OmegaStation.dmm
+++ b/_maps/map_files/OmegaStation/OmegaStation.dmm
@@ -15110,6 +15110,9 @@
 	codes_txt = "patrol;next_patrol=9.4-EnteringDorms";
 	location = "9.3-Engi"
 	},
+/obj/structure/cable/white{
+	icon_state = "2-4"
+	},
 /turf/open/floor/plasteel/neutral,
 /area/engine/break_room)
 "aFF" = (
@@ -15470,6 +15473,7 @@
 	name = "Engineering Foyer APC";
 	pixel_y = -26
 	},
+/obj/structure/cable/white,
 /turf/open/floor/plasteel/yellow/corner{
 	dir = 8
 	},


### PR DESCRIPTION
:cl: Denton
fix: Omegastation: Connected the Engineering Foyer APC to the powernet.
/:cl:

this map gives me headaches