### PR TITLE
Pubby: fixes boozeomat and disposals issues

### DIFF
--- a/_maps/map_files/PubbyStation/PubbyStation.dmm
+++ b/_maps/map_files/PubbyStation/PubbyStation.dmm
@@ -12334,10 +12334,7 @@
 /turf/open/floor/plasteel/neutral/side,
 /area/storage/primary)
 "aGk" = (
-/obj/machinery/vending/boozeomat{
-	products = list(/obj/item/reagent_containers/food/drinks/bottle/rum = 1, /obj/item/reagent_containers/food/drinks/bottle/wine = 1, /obj/item/reagent_containers/food/drinks/ale = 1, /obj/item/reagent_containers/food/drinks/drinkingglass = 6, /obj/item/reagent_containers/food/drinks/ice = 1, /obj/item/reagent_containers/food/drinks/drinkingglass/shotglass = 4);
-	req_access_txt = "20"
-	},
+/obj/machinery/vending/boozeomat/pubby_captain,
 /turf/open/floor/plasteel/vault{
 	dir = 5
 	},
@@ -46986,7 +46983,7 @@
 /turf/open/floor/plasteel/dark,
 /area/library)
 "cBk" = (
-/obj/machinery/vending/boozeomat/maint,
+/obj/machinery/vending/boozeomat/pubby_maint,
 /turf/closed/wall,
 /area/maintenance/department/crew_quarters/dorms)
 "cBl" = (

--- a/_maps/map_files/PubbyStation/PubbyStation.dmm
+++ b/_maps/map_files/PubbyStation/PubbyStation.dmm
@@ -27466,6 +27466,7 @@
 /obj/structure/disposalpipe/trunk{
 	dir = 8
 	},
+/obj/machinery/disposal/bin,
 /turf/open/floor/plasteel/white,
 /area/medical/chemistry)
 "bum" = (
@@ -28442,7 +28443,6 @@
 /turf/open/floor/plasteel/white,
 /area/medical/chemistry)
 "bwV" = (
-/obj/machinery/disposal/bin,
 /turf/open/floor/plasteel/whiteyellow/corner,
 /area/medical/chemistry)
 "bwW" = (
@@ -49149,6 +49149,9 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/sleeper)
+"iqc" = (
+/turf/open/floor/plasteel/stairs/right,
+/area/maintenance/department/crew_quarters/dorms)
 "itl" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -91019,7 +91022,7 @@ aaa
 aaa
 aiS
 qPB
-gNv
+iqc
 ngp
 cBr
 cBs

--- a/code/modules/vending/boozeomat.dm
+++ b/code/modules/vending/boozeomat.dm
@@ -38,7 +38,7 @@
 	req_access = list(ACCESS_BAR)
 	refill_canister = /obj/item/vending_refill/boozeomat
 
-/obj/machinery/vending/boozeomat/maint
+/obj/machinery/vending/boozeomat/pubby_maint //abandoned bar on Pubbystation
 	products = list(/obj/item/reagent_containers/food/drinks/bottle/whiskey = 1,
 			/obj/item/reagent_containers/food/drinks/bottle/absinthe = 1,
 			/obj/item/reagent_containers/food/drinks/bottle/limejuice = 1,
@@ -48,7 +48,16 @@
 			/obj/item/reagent_containers/food/drinks/ice = 3,
 			/obj/item/reagent_containers/food/drinks/drinkingglass/shotglass = 6,
 			/obj/item/reagent_containers/food/drinks/flask = 1)
-	req_access_txt = "0"
+	req_access = null
+
+/obj/machinery/vending/boozeomat/pubby_captain //Captain's quarters on Pubbystation
+	products = list(/obj/item/reagent_containers/food/drinks/bottle/rum = 1, 
+					/obj/item/reagent_containers/food/drinks/bottle/wine = 1, 
+					/obj/item/reagent_containers/food/drinks/ale = 1, 
+					/obj/item/reagent_containers/food/drinks/drinkingglass = 6, 
+					/obj/item/reagent_containers/food/drinks/ice = 1, 
+					/obj/item/reagent_containers/food/drinks/drinkingglass/shotglass = 4);
+	req_access = list(ACCESS_CAPTAIN)
 
 /obj/item/vending_refill/boozeomat
 	machine_name = "Booze-O-Mat"


### PR DESCRIPTION
:cl: Denton
fix: Pubbystation: Connected Chemistry disposals to the pipenet and fixed Booze-O-Mat related display/access issues.
/:cl:

- Fixed maint boozeomat access issue and the cap's boozeomat display issue (see #38300)
- Connected Chemistry disposals bin to the disposals pipenet
- Removed duplicate maint bar poster (two on one tile)