### PR TITLE
Reverts "Changes stormtrooper ammo to 10g slugs"

### DIFF
--- a/code/modules/mob/living/simple_animal/hostile/syndicate.dm
+++ b/code/modules/mob/living/simple_animal/hostile/syndicate.dm
@@ -138,7 +138,7 @@
 	name = "Syndicate Stormtrooper"
 	maxHealth = 200
 	health = 200
-	casingtype = /obj/item/ammo_casing/shotgun/tengauge
+	casingtype = /obj/item/ammo_casing/shotgun/buckshot
 	projectilesound = 'sound/weapons/gunshot.ogg'
 	loot = list(/obj/effect/gibspawner/human)
 

--- a/code/modules/projectiles/ammunition/ballistic/shotgun.dm
+++ b/code/modules/projectiles/ammunition/ballistic/shotgun.dm
@@ -7,11 +7,6 @@
 	caliber = "shotgun"
 	projectile_type = /obj/item/projectile/bullet/shotgun_slug
 	materials = list(MAT_METAL=4000)
-	
-/obj/item/ammo_casing/shotgun/tengauge
-	name = "10g shotgun slug"
-	desc = "A 10 gauge lead slug."
-	projectile_type = /obj/item/projectile/bullet/shotgun_slug/tengauge
 
 /obj/item/ammo_casing/shotgun/beanbag
 	name = "beanbag slug"

--- a/code/modules/projectiles/projectile/bullets/shotgun.dm
+++ b/code/modules/projectiles/projectile/bullets/shotgun.dm
@@ -2,10 +2,6 @@
 	name = "12g shotgun slug"
 	damage = 60
 
-/obj/item/projectile/bullet/shotgun_slug/tengauge
-	name = "10g shotgun slug"
-	damage = 72.5
-
 /obj/item/projectile/bullet/shotgun_beanbag
 	name = "beanbag slug"
 	damage = 5


### PR DESCRIPTION
:cl: Denton
tweak: Syndicate stormtroopers now fire buckshot again.
/:cl:

I've noticed that when simplemobs fire buckshot, the pellets now properly spread instead of being "clumped together" as a single lag-inducing projectile.

This means that #36364 is no longer neccessary and can be reverted.