### PR TITLE
[s] prevents pipe dispensers from spawning things that should not be

### DIFF
--- a/code/game/machinery/pipe/pipe_dispenser.dm
+++ b/code/game/machinery/pipe/pipe_dispenser.dm
@@ -72,8 +72,8 @@
 	for(var/category in recipes)
 		var/list/cat_recipes = recipes[category]
 		for(var/i in cat_recipes)
-			var/datum/pipe_info/I = i
-			if (path == I.id)
+			var/datum/pipe_info/info = i
+			if (path == info.id)
 				return TRUE
 	return FALSE
 

--- a/code/game/machinery/pipe/pipe_dispenser.dm
+++ b/code/game/machinery/pipe/pipe_dispenser.dm
@@ -42,6 +42,8 @@
 	if(href_list["makepipe"])
 		if(wait < world.time)
 			var/p_type = text2path(href_list["makepipe"])
+			if (!verify_recipe(GLOB.atmos_pipe_recipes, p_type))
+				return
 			var/p_dir = text2num(href_list["dir"])
 			var/obj/item/pipe/P = new (loc, p_type, p_dir)
 			P.setPipingLayer(piping_layer)
@@ -65,6 +67,15 @@
 		return
 	else
 		return ..()
+
+/obj/machinery/pipedispenser/proc/verify_recipe(recipes, path)
+	for(var/category in recipes)
+		var/list/cat_recipes = recipes[category]
+		for(var/i in cat_recipes)
+			var/datum/pipe_info/I = i
+			if (path == I.id)
+				return TRUE
+	return FALSE
 
 /obj/machinery/pipedispenser/wrench_act(mob/living/user, obj/item/I)
 	if(default_unfasten_wrench(user, I, 40))
@@ -124,6 +135,8 @@
 	if(href_list["dmake"])
 		if(wait < world.time)
 			var/p_type = text2path(href_list["dmake"])
+			if (!verify_recipe(GLOB.disposal_pipe_recipes, p_type))
+				return
 			var/obj/structure/disposalconstruct/C = new (loc, p_type)
 
 			if(!C.can_place())


### PR DESCRIPTION
:cl: Naksu
fix: Pipe dispensers can no longer create pipes containing literally anything
/:cl:

Why critical?
![image](https://user-images.githubusercontent.com/20017308/41384431-5fedcb14-6f7e-11e8-8780-9f7b4f8fae56.png)
![image](https://user-images.githubusercontent.com/20017308/41384435-66e2e292-6f7e-11e8-9a9e-f7e985ccbf31.png)

