### PR TITLE
Guide to Advanced Mimery spellbooks will grant the vow of silence spell if the user doesn't have it already.

### DIFF
--- a/code/modules/spells/spell_types/mime.dm
+++ b/code/modules/spells/spell_types/mime.dm
@@ -139,7 +139,8 @@
 
 /obj/item/book/granter/spell/mimery_blockade/attack_self(mob/user)
 	..()
-	user.mind.AddSpell(new /obj/effect/proc_holder/spell/targeted/mime/speak)
+	if(!locate(/obj/effect/proc_holder/spell/targeted/mime/speak) in user.mind.spell_list)
+		user.mind.AddSpell(new /obj/effect/proc_holder/spell/targeted/mime/speak)
 
 /obj/item/book/granter/spell/mimery_guns
 	spell = /obj/effect/proc_holder/spell/aimed/finger_guns
@@ -151,4 +152,5 @@
 
 /obj/item/book/granter/spell/mimery_guns/attack_self(mob/user)
 	..()
-	user.mind.AddSpell(new /obj/effect/proc_holder/spell/targeted/mime/speak)
+	if(!locate(/obj/effect/proc_holder/spell/targeted/mime/speak) in user.mind.spell_list)
+		user.mind.AddSpell(new /obj/effect/proc_holder/spell/targeted/mime/speak)

--- a/code/modules/spells/spell_types/mime.dm
+++ b/code/modules/spells/spell_types/mime.dm
@@ -131,17 +131,24 @@
 
 /obj/item/book/granter/spell/mimery_blockade
 	spell = /obj/effect/proc_holder/spell/targeted/forcewall/mime
-	spellname = ""
+	spellname = "Invisible Blockade"
 	name = "Guide to Advanced Mimery Vol 1"
 	desc = "The pages don't make any sound when turned."
 	icon_state ="bookmime"
 	remarks = list("...")
 
+/obj/item/book/granter/spell/mimery_blockade/attack_self(mob/user)
+	..()
+	user.mind.AddSpell(new /obj/effect/proc_holder/spell/targeted/mime/speak)
 
 /obj/item/book/granter/spell/mimery_guns
 	spell = /obj/effect/proc_holder/spell/aimed/finger_guns
-	spellname = ""
+	spellname = "Finger Guns"
 	name = "Guide to Advanced Mimery Vol 2"
 	desc = "There aren't any words written..."
 	icon_state ="bookmime"
 	remarks = list("...")
+
+/obj/item/book/granter/spell/mimery_guns/attack_self(mob/user)
+	..()
+	user.mind.AddSpell(new /obj/effect/proc_holder/spell/targeted/mime/speak)


### PR DESCRIPTION
You can't use the spells the mime spellbooks grant you unless you have a vow of silence going. But the game still allows you to read the spellbooks and get the spells, you just can't use them, which seems silly and overly restrictive. If a mime traitor wants to give his spellbooks to someone else, I don't see why he shouldn't be able to. (The other day I was the clown and the mime and I were traitors, and we did a gimmick of trading each other's tator items, except I had to ahelp to actually use the spells. Massively disappointing.) Vow of silence is useless on its own so I don't think this will affect balance.

Also added the spell names to the messages you get so it wouldn't show up blank ("You have learned how to cast !"), idk if this was some kind of mime joke but if it was it was more confusing than funny