### PR TITLE
[s] Prevent unbreakable ladders from being moved by shuttles

### DIFF
--- a/code/game/objects/structures/ladders.dm
+++ b/code/game/objects/structures/ladders.dm
@@ -23,13 +23,7 @@
 /obj/structure/ladder/Destroy(force)
 	if ((resistance_flags & INDESTRUCTIBLE) && !force)
 		return QDEL_HINT_LETMELIVE
-
-	if(up && up.down == src)
-		up.down = null
-		up.update_icon()
-	if(down && down.up == src)
-		down.up = null
-		down.update_icon()
+	disconnect()
 	return ..()
 
 /obj/structure/ladder/LateInitialize()
@@ -51,6 +45,15 @@
 			L.update_icon()
 
 	update_icon()
+
+/obj/structure/ladder/proc/disconnect()
+	if(up && up.down == src)
+		up.down = null
+		up.update_icon()
+	if(down && down.up == src)
+		down.up = null
+		down.update_icon()
+	up = down = null
 
 /obj/structure/ladder/update_icon()
 	if(up && down)

--- a/code/modules/shuttle/on_move.dm
+++ b/code/modules/shuttle/on_move.dm
@@ -331,18 +331,21 @@ All ShuttleMove procs go here
 	if(. & MOVE_AREA)
 		. |= MOVE_CONTENTS
 
+/obj/structure/ladder/beforeShuttleMove(turf/newT, rotation, move_mode, obj/docking_port/mobile/moving_dock)
+	. = ..()
+	if (!(resistance_flags & INDESTRUCTIBLE))
+		disconnect()
+
 /obj/structure/ladder/afterShuttleMove(turf/oldT, list/movement_force, shuttle_dir, shuttle_preferred_direction, move_dir, rotation)
 	. = ..()
-	// be moved, but re-connect at the destination
-	disconnect()
-	LateInitialize()
+	if (!(resistance_flags & INDESTRUCTIBLE))
+		LateInitialize()
 
-/obj/structure/ladder/unbreakable/onShuttleMove(turf/newT, turf/oldT, list/movement_force, move_dir, obj/docking_port/stationary/old_dock, obj/docking_port/mobile/moving_dock)
-	// simply don't be moved
-	return FALSE
-
-/obj/structure/ladder/unbreakable/afterShuttleMove(turf/oldT, list/movement_force, shuttle_dir, shuttle_preferred_direction, move_dir, rotation)
-	// do nothing
+/obj/structure/ladder/onShuttleMove(turf/newT, turf/oldT, list/movement_force, move_dir, obj/docking_port/stationary/old_dock, obj/docking_port/mobile/moving_dock)
+	if (resistance_flags & INDESTRUCTIBLE)
+		// simply don't be moved
+		return FALSE
+	return ..()
 
 /************************************Misc move procs************************************/
 

--- a/code/modules/shuttle/on_move.dm
+++ b/code/modules/shuttle/on_move.dm
@@ -331,6 +331,18 @@ All ShuttleMove procs go here
 	if(. & MOVE_AREA)
 		. |= MOVE_CONTENTS
 
+/obj/structure/ladder/afterShuttleMove(turf/oldT, list/movement_force, shuttle_dir, shuttle_preferred_direction, move_dir, rotation)
+	. = ..()
+	// be moved, but re-connect at the destination
+	disconnect()
+	LateInitialize()
+
+/obj/structure/ladder/unbreakable/onShuttleMove(turf/newT, turf/oldT, list/movement_force, move_dir, obj/docking_port/stationary/old_dock, obj/docking_port/mobile/moving_dock)
+	// simply don't be moved
+	return FALSE
+
+/obj/structure/ladder/unbreakable/afterShuttleMove(turf/oldT, list/movement_force, shuttle_dir, shuttle_preferred_direction, move_dir, rotation)
+	// do nothing
 
 /************************************Misc move procs************************************/
 


### PR DESCRIPTION
:cl:
fix: Unbreakable ladders are now left behind when shuttles move.
/:cl:

Fixes #38475. Also makes *normal* ladders disconnect from their old friends and reconnect at the new location.