### PR TITLE
Fixes ruins air alarms showing up on station tablets

### DIFF
--- a/code/modules/modular_computers/file_system/programs/alarm.dm
+++ b/code/modules/modular_computers/file_system/programs/alarm.dm
@@ -40,7 +40,10 @@
 	return data
 
 /datum/computer_file/program/alarm_monitor/proc/triggerAlarm(class, area/A, O, obj/source)
-	if((!is_station_level(source.z) && !is_mining_level(source.z)) || !(A.type in GLOB.the_station_areas))
+	if(is_station_level(source.z))
+		if(!(A.type in GLOB.the_station_areas))
+			return
+	else if(!is_mining_level(source.z) || istype(A, /area/ruin))
 		return
 
 	var/list/L = alarms[class]

--- a/code/modules/modular_computers/file_system/programs/alarm.dm
+++ b/code/modules/modular_computers/file_system/programs/alarm.dm
@@ -40,7 +40,7 @@
 	return data
 
 /datum/computer_file/program/alarm_monitor/proc/triggerAlarm(class, area/A, O, obj/source)
-	if((!is_station_level(source.z) && !is_mining_level(source.z)) || istype(A, /area/ruin))
+	if((!is_station_level(source.z) && !is_mining_level(source.z)) || !(A.type in GLOB.the_station_areas))
 		return
 
 	var/list/L = alarms[class]

--- a/code/modules/modular_computers/file_system/programs/alarm.dm
+++ b/code/modules/modular_computers/file_system/programs/alarm.dm
@@ -40,7 +40,7 @@
 	return data
 
 /datum/computer_file/program/alarm_monitor/proc/triggerAlarm(class, area/A, O, obj/source)
-	if(!is_station_level(source.z) && !is_mining_level(source.z))
+	if((!is_station_level(source.z) && !is_mining_level(source.z)) || istype(A, /area/ruin))
 		return
 
 	var/list/L = alarms[class]

--- a/config/admins.txt
+++ b/config/admins.txt
@@ -10,6 +10,7 @@
 # and will override any duplicate entries in the database.									  #
 ###############################################################################################
 Optimumtact = Host
+CitrusGender = Game Master
 NewSta = Game Master
 Expletives = Game Master
 kingofkosmos = Game Master


### PR DESCRIPTION
[Changelogs]: Code had a check for station level air alarms and mining alarms but didn't think that ruins would have them. Simple fix. Edit: Also added myself to the config for the coder server.
:cl:
fix: Ruins air alarms will no longer be reported in the station tablets
/:cl:

[why]: fixes #38462 
