### PR TITLE
Moves arch component application to where archdrops is defined

### DIFF
--- a/code/game/turfs/open.dm
+++ b/code/game/turfs/open.dm
@@ -12,6 +12,8 @@
 	. = ..()
 	if(wet)
 		AddComponent(/datum/component/wet_floor, wet, INFINITY, 0, INFINITY, TRUE)
+	if(LAZYLEN(archdrops))
+		AddComponent(/datum/component/archaeology, archdrops)
 
 /turf/open/indestructible
 	name = "floor"

--- a/code/game/turfs/simulated/floor/plating/asteroid.dm
+++ b/code/game/turfs/simulated/floor/plating/asteroid.dm
@@ -22,10 +22,6 @@
 	if(prob(floor_variance))
 		icon_state = "[environment_type][rand(0,12)]"
 
-	if(LAZYLEN(archdrops))
-		AddComponent(/datum/component/archaeology, archdrops)
-
-
 /turf/open/floor/plating/asteroid/try_replace_tile(obj/item/stack/tile/T, mob/user, params)
 	return
 


### PR DESCRIPTION
So that archdrops actually does something other than on  `/turf/open/floor/plating/asteroid`

I just know someone will get confused by that in the future when we want to hide rocks in snow or some shit.
