### PR TITLE
Some minor pubby shuttle tweaks

### DIFF
--- a/_maps/shuttles/emergency_pubby.dmm
+++ b/_maps/shuttles/emergency_pubby.dmm
@@ -364,7 +364,6 @@
 	},
 /obj/structure/table,
 /obj/item/reagent_containers/food/snacks/beans{
-	step_x = -1;
 	pixel_x = 3;
 	pixel_y = 4
 	},

--- a/_maps/shuttles/emergency_pubby.dmm
+++ b/_maps/shuttles/emergency_pubby.dmm
@@ -339,7 +339,7 @@
 /obj/machinery/light{
 	dir = 1
 	},
-/obj/item/storage/firstaid,
+/obj/item/storage/firstaid/regular,
 /obj/structure/window/reinforced{
 	dir = 4;
 	layer = 2.9
@@ -397,7 +397,7 @@
 	dir = 4
 	},
 /obj/structure/table/glass,
-/obj/item/storage/firstaid,
+/obj/item/storage/firstaid/regular,
 /turf/open/floor/plasteel/cmo,
 /area/shuttle/escape)
 "bj" = (

--- a/_maps/shuttles/emergency_pubby.dmm
+++ b/_maps/shuttles/emergency_pubby.dmm
@@ -388,7 +388,7 @@
 "bh" = (
 /obj/structure/window/reinforced,
 /obj/structure/table/glass,
-/obj/item/defibrillator,
+/obj/item/defibrillator/loaded,
 /turf/open/floor/plasteel/cmo,
 /area/shuttle/escape)
 "bi" = (

--- a/_maps/shuttles/emergency_pubby.dmm
+++ b/_maps/shuttles/emergency_pubby.dmm
@@ -109,7 +109,9 @@
 /area/shuttle/escape)
 "av" = (
 /obj/structure/table/wood/poker,
-/obj/item/toy/cards/deck,
+/obj/item/toy/cards/deck{
+	pixel_y = 5
+	},
 /turf/open/floor/plasteel/dark,
 /area/shuttle/escape)
 "aw" = (
@@ -200,6 +202,14 @@
 /obj/machinery/light{
 	dir = 1
 	},
+/obj/item/reagent_containers/food/snacks/butterdog,
+/obj/item/reagent_containers/food/snacks/cakeslice/apple,
+/obj/item/reagent_containers/food/snacks/cakeslice/brioche,
+/obj/item/reagent_containers/food/snacks/cakeslice/cheese,
+/obj/item/reagent_containers/food/snacks/cakeslice/chocolate,
+/obj/item/reagent_containers/food/snacks/cakeslice/lemon,
+/obj/item/reagent_containers/food/snacks/cakeslice/lime,
+/obj/item/reagent_containers/food/snacks/cakeslice/orange,
 /turf/open/floor/plasteel/cafeteria,
 /area/shuttle/escape)
 "aH" = (
@@ -314,8 +324,7 @@
 /turf/open/floor/plasteel/cafeteria,
 /area/shuttle/escape)
 "aX" = (
-/obj/structure/table/glass,
-/obj/item/clothing/neck/stethoscope,
+/obj/machinery/sleeper,
 /turf/open/floor/plasteel/cmo,
 /area/shuttle/escape)
 "aY" = (
@@ -331,6 +340,10 @@
 	dir = 1
 	},
 /obj/item/storage/firstaid,
+/obj/structure/window/reinforced{
+	dir = 4;
+	layer = 2.9
+	},
 /turf/open/floor/plasteel/cmo,
 /area/shuttle/escape)
 "ba" = (
@@ -350,7 +363,11 @@
 	layer = 2.9
 	},
 /obj/structure/table,
-/obj/item/storage/bag/tray,
+/obj/item/reagent_containers/food/snacks/beans{
+	step_x = -1;
+	pixel_x = 3;
+	pixel_y = 4
+	},
 /turf/open/floor/plasteel/cafeteria,
 /area/shuttle/escape)
 "be" = (
@@ -360,6 +377,7 @@
 "bf" = (
 /obj/structure/window/reinforced,
 /obj/structure/table,
+/obj/item/storage/bag/tray,
 /obj/item/clothing/under/waiter,
 /turf/open/floor/plasteel/cafeteria,
 /area/shuttle/escape)
@@ -445,6 +463,7 @@
 /area/shuttle/escape)
 "bv" = (
 /obj/structure/window/plastitanium,
+/obj/structure/grille,
 /turf/open/floor/plating,
 /area/shuttle/escape)
 "bw" = (

--- a/code/datums/shuttles.dm
+++ b/code/datums/shuttles.dm
@@ -232,7 +232,8 @@
 /datum/map_template/shuttle/emergency/pubby
 	suffix = "pubby"
 	name = "Pubby Station Emergency Shuttle"
-	description = "A small, but feature complete shuttle. It boasts a card table to keep crew members occupied on the long flight home."
+	description = "A train but in space! Complete with a first, second class, brig and storage area."
+	admin_notes = "Choo choo motherfucker!"
 	credit_cost = 1000
 
 /datum/map_template/shuttle/emergency/cere


### PR DESCRIPTION
[Changelogs]: # (Your PR should contain a detailed changelog of notable changes, titled and categorized appropriately. This includes, new features, sprites, sounds, balance changes, admin tools, map edits, removals, big refactors, config changes, hosting changes and important fixes. An example changelog has been provided below for you to edit. If you need additional help, read https://github.com/tgstation/tgstation/wiki/Changelogs)

:cl: Dax Dupont
fix: Fixed missing grilles under brig windows of the pubby shuttle.
add: For the pubby shuttle, added some food in the fridge, mostly pie slices. Also added a sleeper to the minimedbay. 
tweak: Reworded pubby shuttle description to be more inline with the new train shuttle.
/:cl:

[why]: One is a fix and the others added some fluff, the empty fridge was bothering me.
I also updated the description of the shuttle.