### PR TITLE
Fix being able to pull mirage borders, others

### DIFF
--- a/code/datums/components/mirage_border.dm
+++ b/code/datums/components/mirage_border.dm
@@ -7,7 +7,7 @@
 	if(!target || !istype(target) || !direction)
 		. = COMPONENT_INCOMPATIBLE
 		CRASH("[type] improperly instanced with the following args: target=\[[target]\], direction=\[[direction]\], range=\[[range]\]")
-	
+
 	holder = new(parent)
 
 	var/x = target.x
@@ -37,4 +37,5 @@
 
 /obj/effect/abstract/mirage_holder
 	name = "Mirage holder"
+	anchored = TRUE
 	mouse_opacity = MOUSE_OPACITY_TRANSPARENT

--- a/code/game/objects/effects/effect_system/effect_system.dm
+++ b/code/game/objects/effects/effect_system/effect_system.dm
@@ -10,6 +10,7 @@ would spawn and follow the beaker, even if it is carried or thrown.
 	name = "particle effect"
 	mouse_opacity = MOUSE_OPACITY_TRANSPARENT
 	pass_flags = PASSTABLE | PASSGRILLE
+	anchored = TRUE
 
 /obj/effect/particle_effect/New()
 	..()

--- a/code/game/objects/effects/overlays.dm
+++ b/code/game/objects/effects/overlays.dm
@@ -1,6 +1,5 @@
 /obj/effect/overlay
 	name = "overlay"
-	var/i_attached//Added for possible image attachments to objects. For hallucinations and the like.
 
 /obj/effect/overlay/singularity_act()
 	return
@@ -19,7 +18,7 @@
 	QDEL_IN(src, 10)
 
 /obj/effect/overlay/palmtree_r
-	name = "Palm tree"
+	name = "palm tree"
 	icon = 'icons/misc/beach2.dmi'
 	icon_state = "palm1"
 	density = TRUE
@@ -27,7 +26,7 @@
 	anchored = TRUE
 
 /obj/effect/overlay/palmtree_l
-	name = "Palm tree"
+	name = "palm tree"
 	icon = 'icons/misc/beach2.dmi'
 	icon_state = "palm2"
 	density = TRUE
@@ -35,11 +34,14 @@
 	anchored = TRUE
 
 /obj/effect/overlay/coconut
-	name = "Coconuts"
+	gender = PLURAL
+	name = "coconuts"
 	icon = 'icons/misc/beach.dmi'
 	icon_state = "coconuts"
 
 /obj/effect/overlay/sparkles
+	gender = PLURAL
 	name = "sparkles"
 	icon = 'icons/effects/effects.dmi'
 	icon_state = "shieldsparkles"
+	anchored = TRUE

--- a/code/game/objects/items/tanks/watertank.dm
+++ b/code/game/objects/items/tanks/watertank.dm
@@ -325,6 +325,7 @@
 	icon_state = "frozen_smoke_capsule"
 	mouse_opacity = MOUSE_OPACITY_TRANSPARENT
 	pass_flags = PASSTABLE
+	anchored = TRUE
 
 /obj/effect/resin_container/proc/Smoke()
 	var/obj/effect/particle_effect/foam/metal/resin/S = new /obj/effect/particle_effect/foam/metal/resin(get_turf(loc))

--- a/code/modules/atmospherics/gasmixtures/gas_types.dm
+++ b/code/modules/atmospherics/gasmixtures/gas_types.dm
@@ -43,6 +43,7 @@ GLOBAL_LIST_INIT(nonreactive_gases, typecacheof(list(/datum/gas/oxygen, /datum/g
 	var/moles_visible = null
 	var/dangerous = FALSE //currently used by canisters
 	var/fusion_power = 0 //How much the gas accelerates a fusion reaction
+
 /datum/gas/oxygen
 	id = "o2"
 	specific_heat = 20
@@ -129,6 +130,7 @@ GLOBAL_LIST_INIT(nonreactive_gases, typecacheof(list(/datum/gas/oxygen, /datum/g
 /obj/effect/overlay/gas
 	icon = 'icons/effects/tile_effects.dmi'
 	mouse_opacity = MOUSE_OPACITY_TRANSPARENT
+	anchored = TRUE  // should only appear in vis_contents, but to be safe
 	layer = FLY_LAYER
 	appearance_flags = TILE_BOUND
 

--- a/code/modules/mining/lavaland/necropolis_chests.dm
+++ b/code/modules/mining/lavaland/necropolis_chests.dm
@@ -372,6 +372,7 @@
 
 /obj/effect/warp_cube
 	mouse_opacity = MOUSE_OPACITY_TRANSPARENT
+	anchored = TRUE
 
 /obj/effect/warp_cube/ex_act(severity, target)
 	return

--- a/code/modules/ruins/objects_and_mobs/necropolis_gate.dm
+++ b/code/modules/ruins/objects_and_mobs/necropolis_gate.dm
@@ -74,6 +74,7 @@
 	pixel_y = -32
 	mouse_opacity = MOUSE_OPACITY_TRANSPARENT
 	opacity = TRUE
+	anchored = TRUE
 
 /obj/structure/opacity_blocker/singularity_pull()
 	return 0


### PR DESCRIPTION
:cl:
fix: It is no longer possible to pull the mirages images at space transitions, and some other abstract effects.
/:cl:

Fixes #38137. Previous work in #38141. A little code improvement while we're here too.