### PR TITLE
Makes the caravan ambush ruin harder to cheese

### DIFF
--- a/_maps/RandomRuins/SpaceRuins/caravanambush.dmm
+++ b/_maps/RandomRuins/SpaceRuins/caravanambush.dmm
@@ -33,9 +33,7 @@
 /area/template_noop)
 "ah" = (
 /obj/structure/lattice/catwalk,
-/mob/living/simple_animal/hostile/pirate/space{
-	environment_smash = 0
-	},
+/mob/living/simple_animal/hostile/pirate/space/ranged,
 /turf/template_noop,
 /area/template_noop)
 "ai" = (
@@ -176,7 +174,7 @@
 /area/shuttle/caravan/freighter3)
 "aP" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on,
-/mob/living/simple_animal/hostile/pirate/space{
+/mob/living/simple_animal/hostile/pirate/space/ranged{
 	environment_smash = 0
 	},
 /turf/open/floor/plasteel/airless/floorgrime,
@@ -404,6 +402,8 @@
 /area/shuttle/caravan/freighter3)
 "gt" = (
 /obj/effect/turf_decal/bot_white,
+/obj/structure/closet/crate/secure/weapon,
+/obj/item/gun/ballistic/revolver/grenadelauncher/unrestricted,
 /turf/open/floor/plasteel/airless/dark,
 /area/shuttle/caravan/freighter3)
 "gv" = (
@@ -471,7 +471,7 @@
 /turf/open/floor/plating/airless,
 /area/shuttle/caravan/freighter3)
 "gT" = (
-/mob/living/simple_animal/hostile/syndicate/melee/space{
+/mob/living/simple_animal/hostile/syndicate/ranged/space{
 	environment_smash = 0;
 	name = "Syndicate Salvage Worker"
 	},
@@ -612,6 +612,10 @@
 /obj/effect/turf_decal/box/white/corners{
 	dir = 1
 	},
+/mob/living/simple_animal/hostile/syndicate/ranged/space/stormtrooper{
+	environment_smash = 0;
+	name = "Syndicate Salvage Leader"
+	},
 /turf/open/floor/plasteel/airless/dark,
 /area/shuttle/caravan/freighter3)
 "hz" = (
@@ -625,10 +629,6 @@
 	},
 /area/shuttle/caravan/freighter3)
 "hB" = (
-/mob/living/simple_animal/hostile/syndicate/ranged/space/stormtrooper{
-	environment_smash = 0;
-	name = "Syndicate Salvage Leader"
-	},
 /turf/open/floor/plasteel/airless{
 	icon_state = "damaged2"
 	},
@@ -895,7 +895,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
-/mob/living/simple_animal/hostile/syndicate/melee/space{
+/mob/living/simple_animal/hostile/syndicate/ranged/space{
 	environment_smash = 0;
 	name = "Syndicate Salvage Worker"
 	},

--- a/_maps/RandomRuins/SpaceRuins/caravanambush.dmm
+++ b/_maps/RandomRuins/SpaceRuins/caravanambush.dmm
@@ -33,7 +33,9 @@
 /area/template_noop)
 "ah" = (
 /obj/structure/lattice/catwalk,
-/mob/living/simple_animal/hostile/pirate/space/ranged,
+/mob/living/simple_animal/hostile/pirate/space/ranged{
+	environment_smash = 0
+	},
 /turf/template_noop,
 /area/template_noop)
 "ai" = (

--- a/_maps/shuttles/ruin_pirate_cutter.dmm
+++ b/_maps/shuttles/ruin_pirate_cutter.dmm
@@ -80,7 +80,9 @@
 /turf/open/floor/plasteel/red/side,
 /area/shuttle/caravan/pirate)
 "hh" = (
-/mob/living/simple_animal/hostile/pirate,
+/mob/living/simple_animal/hostile/pirate{
+	environment_smash = 0
+	},
 /turf/open/floor/plasteel,
 /area/shuttle/caravan/pirate)
 "hI" = (
@@ -398,7 +400,9 @@
 /turf/open/floor/plasteel/dark,
 /area/shuttle/caravan/pirate)
 "tM" = (
-/mob/living/simple_animal/hostile/pirate/ranged,
+/mob/living/simple_animal/hostile/pirate/ranged{
+	environment_smash = 0
+	},
 /turf/open/floor/plasteel/floorgrime,
 /area/shuttle/caravan/pirate)
 "ul" = (

--- a/_maps/shuttles/ruin_pirate_cutter.dmm
+++ b/_maps/shuttles/ruin_pirate_cutter.dmm
@@ -43,6 +43,13 @@
 	dir = 5
 	},
 /area/shuttle/caravan/pirate)
+"eL" = (
+/obj/machinery/porta_turret/syndicate/pod{
+	dir = 10;
+	faction = list("pirate")
+	},
+/turf/closed/wall/mineral/plastitanium,
+/area/shuttle/caravan/pirate)
 "fh" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
 	dir = 4
@@ -390,6 +397,10 @@
 /obj/item/reagent_containers/food/drinks/bottle/rum,
 /turf/open/floor/plasteel/dark,
 /area/shuttle/caravan/pirate)
+"tM" = (
+/mob/living/simple_animal/hostile/pirate/ranged,
+/turf/open/floor/plasteel/floorgrime,
+/area/shuttle/caravan/pirate)
 "ul" = (
 /obj/structure/table,
 /obj/item/retractor,
@@ -448,8 +459,6 @@
 /obj/machinery/light/small{
 	dir = 8
 	},
-/obj/structure/closet/crate/secure/weapon,
-/obj/item/gun/ballistic/revolver/grenadelauncher/unrestricted,
 /turf/open/floor/plasteel/red/side{
 	dir = 8
 	},
@@ -853,6 +862,13 @@
 /obj/item/melee/classic_baton,
 /turf/open/floor/plasteel/darkred/corner,
 /area/shuttle/caravan/pirate)
+"Yj" = (
+/obj/machinery/porta_turret/syndicate/pod{
+	dir = 9;
+	faction = list("pirate")
+	},
+/turf/closed/wall/mineral/plastitanium,
+/area/shuttle/caravan/pirate)
 "Yo" = (
 /obj/structure/table,
 /obj/item/storage/box/lethalshot,
@@ -913,7 +929,7 @@ Jv
 "}
 (3,1,1) = {"
 Jv
-oL
+Yj
 af
 qX
 yt
@@ -923,7 +939,7 @@ RK
 FM
 jh
 af
-oL
+eL
 Jv
 "}
 (4,1,1) = {"
@@ -980,7 +996,7 @@ su
 Ag
 af
 jo
-su
+tM
 sr
 af
 af

--- a/_maps/shuttles/ruin_syndicate_dropship.dmm
+++ b/_maps/shuttles/ruin_syndicate_dropship.dmm
@@ -319,10 +319,7 @@
 /obj/structure/chair/office/dark{
 	dir = 4
 	},
-/mob/living/simple_animal/hostile/syndicate{
-	environment_smash = 0;
-	name = "Syndicate Salvage Pilot"
-	},
+/mob/living/simple_animal/hostile/syndicate/ranged/pilot,
 /turf/open/floor/plasteel/dark,
 /area/shuttle/caravan/syndicate3)
 "Ij" = (

--- a/_maps/shuttles/ruin_syndicate_dropship.dmm
+++ b/_maps/shuttles/ruin_syndicate_dropship.dmm
@@ -319,7 +319,9 @@
 /obj/structure/chair/office/dark{
 	dir = 4
 	},
-/mob/living/simple_animal/hostile/syndicate/ranged/pilot,
+/mob/living/simple_animal/hostile/syndicate/ranged/pilot{
+	environment_smash = 0
+	},
 /turf/open/floor/plasteel/dark,
 /area/shuttle/caravan/syndicate3)
 "Ij" = (

--- a/_maps/shuttles/ruin_syndicate_fighter.dmm
+++ b/_maps/shuttles/ruin_syndicate_fighter.dmm
@@ -18,7 +18,9 @@
 /obj/structure/cable/yellow{
 	icon_state = "0-2"
 	},
-/mob/living/simple_animal/hostile/syndicate/ranged/pilot,
+/mob/living/simple_animal/hostile/syndicate/ranged/pilot{
+	environment_smash = 0
+	},
 /turf/open/floor/mineral/plastitanium,
 /area/shuttle/caravan/syndicate1)
 "fh" = (

--- a/_maps/shuttles/ruin_syndicate_fighter.dmm
+++ b/_maps/shuttles/ruin_syndicate_fighter.dmm
@@ -18,10 +18,7 @@
 /obj/structure/cable/yellow{
 	icon_state = "0-2"
 	},
-/mob/living/simple_animal/hostile/syndicate{
-	environment_smash = 0;
-	name = "Syndicate Salvage Pilot"
-	},
+/mob/living/simple_animal/hostile/syndicate/ranged/pilot,
 /turf/open/floor/mineral/plastitanium,
 /area/shuttle/caravan/syndicate1)
 "fh" = (

--- a/code/modules/mob/living/simple_animal/hostile/syndicate.dm
+++ b/code/modules/mob/living/simple_animal/hostile/syndicate.dm
@@ -118,6 +118,10 @@
 	projectilesound = 'sound/weapons/gunshot_smg.ogg'
 	loot = list(/obj/effect/gibspawner/human)
 
+/mob/living/simple_animal/hostile/syndicate/ranged/pilot
+	name = "Syndicate Salvage Pilot"	
+	loot = list(/obj/effect/mob_spawn/human/corpse/syndicatesoldier)
+
 /mob/living/simple_animal/hostile/syndicate/ranged/space
 	icon_state = "syndicaterangedspace"
 	icon_living = "syndicaterangedspace"


### PR DESCRIPTION
:cl: Denton
balance: Pirates and Syndicate salvage workers have been beefed up around the caravan ambush ruin.
/:cl:

Caravan ambush is probably my favorite ruin, but way too easy to cheese. 
While you can still cheese it by abusing simplemob AI, I've tried to make it harder so you can't just zip through while half asleep.

I didn't remove any of the loot; here is what I changed:

- Added turrets to the pirate cutter's blind spot. You could stand diagonally from the airlock, unbolt it and walk inside without getting hit once.
- Moved the grenade launcher from pirate cutter to the eastern freighter. It's easily the strongest weapon in this ruin and could use something stronger than a single melee mob guarding it.
- Replaced "outdoors" melee simplemobs with ranged ones. If you're at this ruin, you'll have a jetpack. Having a jetpack lets you fly circles around melee mobs without getting hit once.
- Gave guns to syndicate pilots. Right now, you can just open the airlock and watch them suffocate while they helplessly float towards you.
- Added one extra pirate gunner to the pirate cutter.