### PR TITLE
Shuttle throwing applies to all objects as opposed to just mobs

### DIFF
--- a/code/__DEFINES/components.dm
+++ b/code/__DEFINES/components.dm
@@ -34,6 +34,8 @@
 	//End positions
 	#define COMPONENT_EXNAME_CHANGED 1
 #define COMSIG_ATOM_ENTERED "atom_entered"                      //from base of atom/Entered(): (atom/movable/entering, /atom)
+#define COMSIG_ATOM_EXIT "atom_exit"							//from base of atom/Exit(): (/atom/movable/exiting, /atom/newloc)
+	#define COMPONENT_ATOM_BLOCK_EXIT 1
 #define COMSIG_ATOM_EXITED "atom_exited"						//from base of atom/Exited(): (atom/movable/exiting, atom/newloc)
 #define COMSIG_ATOM_EX_ACT "atom_ex_act"						//from base of atom/ex_act(): (severity, target)
 #define COMSIG_ATOM_EMP_ACT "atom_emp_act"						//from base of atom/emp_act(): (severity)
@@ -80,6 +82,8 @@
 // /atom/movable signals
 #define COMSIG_MOVABLE_MOVED "movable_moved"					//from base of atom/movable/Moved(): (/atom, dir)
 #define COMSIG_MOVABLE_CROSSED "movable_crossed"                //from base of atom/movable/Crossed(): (/atom/movable)
+#define COMSIG_MOVABLE_UNCROSS "movable_uncross"				//from base of atom/movable/Uncross(): (/atom/movable)
+	#define COMPONENT_MOVABLE_BLOCK_UNCROSS 1
 #define COMSIG_MOVABLE_UNCROSSED "movable_uncrossed"            //from base of atom/movable/Uncrossed(): (/atom/movable)
 #define COMSIG_MOVABLE_COLLIDE "movable_collide"				//from base of atom/movable/Collide(): (/atom)
 #define COMSIG_MOVABLE_IMPACT "movable_impact"					//from base of atom/movable/throw_impact(): (/atom/hit_atom, /datum/thrownthing/throwingdatum)

--- a/code/datums/components/magnetic_catch.dm
+++ b/code/datums/components/magnetic_catch.dm
@@ -8,13 +8,13 @@
 	RegisterSignal(COMSIG_PARENT_EXAMINE, .proc/examine)
 
 /datum/component/magnetic_catch/proc/uncross_react(atom/movable/thing)
-	if(!thing.throwing)
+	if(!thing.throwing || thing.throwing.thrower)
 		return
 	qdel(thing.throwing)
 	return COMPONENT_MOVABLE_BLOCK_UNCROSS
 
 /datum/component/magnetic_catch/proc/exit_react(atom/movable/thing, atom/newloc)
-	if(!thing.throwing)
+	if(!thing.throwing || thing.throwing.thrower)
 		return
 	qdel(thing.throwing)
 	return COMPONENT_ATOM_BLOCK_EXIT

--- a/code/datums/components/magnetic_catch.dm
+++ b/code/datums/components/magnetic_catch.dm
@@ -1,0 +1,23 @@
+/datum/component/magnetic_catch/Initialize()
+	if(!isatom(parent))
+		return COMPONENT_INCOMPATIBLE
+	if(ismovableatom(parent))
+		RegisterSignal(COMSIG_MOVABLE_UNCROSS, .proc/uncross_react)
+	else
+		RegisterSignal(COMSIG_ATOM_EXIT, .proc/exit_react)
+	RegisterSignal(COMSIG_PARENT_EXAMINE, .proc/examine)
+
+/datum/component/magnetic_catch/proc/uncross_react(atom/movable/thing)
+	if(!thing.throwing)
+		return
+	qdel(thing.throwing)
+	return COMPONENT_MOVABLE_BLOCK_UNCROSS
+
+/datum/component/magnetic_catch/proc/exit_react(atom/movable/thing, atom/newloc)
+	if(!thing.throwing)
+		return
+	qdel(thing.throwing)
+	return COMPONENT_ATOM_BLOCK_EXIT
+
+/datum/component/magnetic_catch/proc/examine(mob/user)
+	to_chat(user, "It has been installed with inertia dampening to prevent coffee spills.")

--- a/code/datums/shuttles.dm
+++ b/code/datums/shuttles.dm
@@ -42,6 +42,9 @@
 		for(var/obj/structure/table/table in place)
 			table.AddComponent(/datum/component/magnetic_catch)
 
+		for(var/obj/structure/rack/rack in place)
+			rack.AddComponent(/datum/component/magnetic_catch)
+
 //Whatever special stuff you want
 /datum/map_template/shuttle/proc/on_bought()
 	return

--- a/code/datums/shuttles.dm
+++ b/code/datums/shuttles.dm
@@ -34,6 +34,13 @@
 		if(length(place.baseturfs) < 2) // Some snowflake shuttle shit
 			continue
 		place.baseturfs.Insert(3, /turf/baseturf_skipover/shuttle)
+		
+		for(var/obj/structure/closet/closet in place)
+			if(closet.anchorable)
+				closet.anchored = TRUE
+
+		for(var/obj/structure/table/table in place)
+			table.AddComponent(/datum/component/magnetic_catch)
 
 //Whatever special stuff you want
 /datum/map_template/shuttle/proc/on_bought()

--- a/code/game/atoms.dm
+++ b/code/game/atoms.dm
@@ -532,6 +532,11 @@
 /atom/Entered(atom/movable/AM, atom/oldLoc)
 	SEND_SIGNAL(src, COMSIG_ATOM_ENTERED, AM, oldLoc)
 
+/atom/Exit(atom/movable/AM, atom/newLoc)
+	. = ..()
+	if(SEND_SIGNAL(src, COMSIG_ATOM_EXIT, AM, newLoc) & COMPONENT_ATOM_BLOCK_EXIT)
+		return FALSE
+
 /atom/Exited(atom/movable/AM, atom/newLoc)
 	SEND_SIGNAL(src, COMSIG_ATOM_EXITED, AM, newLoc)
 

--- a/code/game/atoms_movable.dm
+++ b/code/game/atoms_movable.dm
@@ -279,6 +279,11 @@
 /atom/movable/Crossed(atom/movable/AM, oldloc)
 	SEND_SIGNAL(src, COMSIG_MOVABLE_CROSSED, AM)
 
+/atom/movable/Uncross(atom/movable/AM)
+	. = ..()
+	if(SEND_SIGNAL(src, COMSIG_MOVABLE_UNCROSS, AM) & COMPONENT_MOVABLE_BLOCK_UNCROSS)
+		return FALSE
+
 /atom/movable/Uncrossed(atom/movable/AM)
 	SEND_SIGNAL(src, COMSIG_MOVABLE_UNCROSSED, AM)
 

--- a/code/modules/shuttle/docking.dm
+++ b/code/modules/shuttle/docking.dm
@@ -99,13 +99,7 @@
 
 	return DOCKING_SUCCESS
 
-/obj/docking_port/mobile/proc/preflight_check(
-	list/old_turfs,
-	list/new_turfs,
-	list/areas_to_move,
-	rotation,
-	)
-
+/obj/docking_port/mobile/proc/preflight_check(list/old_turfs, list/new_turfs, list/areas_to_move, rotation)
 	for(var/i in 1 to old_turfs.len)
 		CHECK_TICK
 		var/turf/oldT = old_turfs[i]
@@ -134,16 +128,7 @@
 
 		old_turfs[oldT] = move_mode
 
-/obj/docking_port/mobile/proc/takeoff(
-	list/old_turfs,
-	list/new_turfs,
-	list/moved_atoms,
-	rotation,
-	movement_direction,
-	old_dock,
-	area/underlying_old_area,
-	)
-
+/obj/docking_port/mobile/proc/takeoff(list/old_turfs, list/new_turfs, list/moved_atoms, rotation, movement_direction, old_dock, area/underlying_old_area)
 	for(var/i in 1 to old_turfs.len)
 		var/turf/oldT = old_turfs[i]
 		var/turf/newT = new_turfs[i]
@@ -163,17 +148,7 @@
 			var/area/shuttle_area = oldT.loc
 			shuttle_area.onShuttleMove(oldT, newT, underlying_old_area)										//areas
 
-/obj/docking_port/mobile/proc/cleanup_runway(
-	obj/docking_port/stationary/new_dock,
-	list/old_turfs,
-	list/new_turfs,
-	list/areas_to_move,
-	list/moved_atoms,
-	rotation,
-	movement_direction,
-	area/underlying_old_area,
-	)
-
+/obj/docking_port/mobile/proc/cleanup_runway(obj/docking_port/stationary/new_dock, list/old_turfs, list/new_turfs, list/areas_to_move, list/moved_atoms, rotation, movement_direction, area/underlying_old_area)
 	underlying_old_area.afterShuttleMove()
 
 	// Parallax handling
@@ -202,14 +177,28 @@
 		var/turf/oldT = moved_atoms[moved_object]
 		moved_object.afterShuttleMove(oldT, movement_force, dir, preferred_direction, movement_direction, rotation)//atoms
 
+	// lateShuttleMove (There had better be a really good reason for additional stages beyond this)
+
+	underlying_old_area.lateShuttleMove()
+
+	for(var/i in 1 to areas_to_move.len)
+		CHECK_TICK
+		var/area/internal_area = areas_to_move[i]
+		internal_area.lateShuttleMove()
+
 	for(var/i in 1 to old_turfs.len)
 		CHECK_TICK
-		// Objects can block air so either turf or content changes means an air update is needed
 		if(!(old_turfs[old_turfs[i]] & MOVE_CONTENTS | MOVE_TURF))
 			continue
 		var/turf/oldT = old_turfs[i]
 		var/turf/newT = new_turfs[i]
-		oldT.blocks_air = initial(oldT.blocks_air)
-		oldT.air_update_turf(TRUE)
-		newT.blocks_air = initial(newT.blocks_air)
-		newT.air_update_turf(TRUE)
+		newT.lateShuttleMove(oldT)
+
+	for(var/i in 1 to moved_atoms.len)
+		CHECK_TICK
+		var/atom/movable/moved_object = moved_atoms[i]
+		if(QDELETED(moved_object))
+			continue
+		var/turf/oldT = moved_atoms[moved_object]
+		moved_object.lateShuttleMove(oldT, movement_force, movement_direction)
+

--- a/code/modules/shuttle/manipulator.dm
+++ b/code/modules/shuttle/manipulator.dm
@@ -224,7 +224,11 @@
 	if(existing_shuttle)
 		existing_shuttle.jumpToNullSpace()
 
+	var/list/force_memory = preview_shuttle.movement_force
+	preview_shuttle.movement_force = list("KNOCKDOWN" = 0, "THROW" = 0)
 	preview_shuttle.initiate_docking(D)
+	preview_shuttle.movement_force = force_memory
+	
 	. = preview_shuttle
 
 	// Shuttle state involves a mode and a timer based on world.time, so

--- a/code/modules/shuttle/on_move.dm
+++ b/code/modules/shuttle/on_move.dm
@@ -78,6 +78,14 @@ All ShuttleMove procs go here
 
 	return TRUE
 
+/turf/proc/lateShuttleMove(turf/oldT)
+	blocks_air = initial(blocks_air)
+	air_update_turf(TRUE)
+	oldT.blocks_air = initial(oldT.blocks_air)
+	oldT.air_update_turf(TRUE)
+	return
+
+
 /////////////////////////////////////////////////////////////////////////////////////
 
 // Called on every atom in shuttle turf contents before anything has been moved
@@ -91,9 +99,8 @@ All ShuttleMove procs go here
 	if(newT == oldT) // In case of in place shuttle rotation shenanigans.
 		return
 
-	if(locs && locs.len > 1) // This is for multi tile objects
-		if(loc != oldT)
-			return
+	if(loc != oldT) // This is for multi tile objects
+		return
 
 	loc = newT
 
@@ -111,11 +118,21 @@ All ShuttleMove procs go here
 	if(rotation)
 		shuttleRotate(rotation)
 
-
-
 	update_parallax_contents()
 
 	return TRUE
+
+/atom/movable/proc/lateShuttleMove(turf/oldT, list/movement_force, move_dir)
+	if(!movement_force || anchored)
+		return
+	var/throw_force = movement_force["THROW"]
+	if(!throw_force)
+		return
+	var/turf/target = get_edge_target_turf(src, move_dir)
+	var/range = throw_force * 10
+	range = CEILING(rand(range-(range*0.1), range+(range*0.1)), 10)/10
+	var/speed = range/5
+	throw_at(target, range, speed)
 
 /////////////////////////////////////////////////////////////////////////////////////
 
@@ -148,6 +165,9 @@ All ShuttleMove procs go here
 /area/proc/afterShuttleMove(new_parallax_dir)
 	parallax_movedir = new_parallax_dir
 	return TRUE
+
+/area/proc/lateShuttleMove()
+	return
 
 /************************************Turf move procs************************************/
 
@@ -288,17 +308,16 @@ All ShuttleMove procs go here
 			shake_force *= 0.25
 		shake_camera(src, shake_force, 1)
 
-/mob/living/afterShuttleMove(turf/oldT, list/movement_force, shuttle_dir, shuttle_preferred_direction, move_dir, rotation)
+/mob/living/lateShuttleMove(turf/oldT, list/movement_force, move_dir)
+	if(buckled)
+		return
+	
 	. = ..()
-	if(movement_force && !buckled)
-		if(movement_force["THROW"])
-			var/throw_dir = move_dir
-			var/turf/target = get_edge_target_turf(src, throw_dir)
-			var/range = movement_force["THROW"]
-			var/speed = range/5
-			src.throw_at(target, range, speed)
-		if(movement_force["KNOCKDOWN"])
-			Knockdown(movement_force["KNOCKDOWN"])
+
+	var/knockdown = movement_force["KNOCKDOWN"]
+	if(knockdown)
+		Knockdown(knockdown)
+
 
 /mob/living/simple_animal/hostile/megafauna/onShuttleMove(turf/newT, turf/oldT, list/movement_force, move_dir, obj/docking_port/stationary/old_dock, obj/docking_port/mobile/moving_dock)
 	. = ..()

--- a/code/modules/shuttle/on_move.dm
+++ b/code/modules/shuttle/on_move.dm
@@ -83,7 +83,6 @@ All ShuttleMove procs go here
 	air_update_turf(TRUE)
 	oldT.blocks_air = initial(oldT.blocks_air)
 	oldT.air_update_turf(TRUE)
-	return
 
 
 /////////////////////////////////////////////////////////////////////////////////////

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -327,6 +327,7 @@
 #include "code\datums\components\jousting.dm"
 #include "code\datums\components\knockoff.dm"
 #include "code\datums\components\lockon_aiming.dm"
+#include "code\datums\components\magnetic_catch.dm"
 #include "code\datums\components\material_container.dm"
 #include "code\datums\components\mirage_border.dm"
 #include "code\datums\components\mood.dm"


### PR DESCRIPTION
:cl: ninjanomnom
tweak: Shuttle throwing also applies to loose objects on shuttles now.
tweak: Closets on shuttles start anchored.
tweak: The throw distance of shuttle throws is marginally random, potentialy 10% further or shorter
add: Tables and racks on shuttles have been installed with inertia dampeners.
fix: Some very thin barriers didn't stop mobs from being thrown by the shuttle under certain circumstances, this has been fixed.
/:cl:

fixes #34997

This is primarily a pr to make shuttle movement throw everything inside the shuttle rather than just mobs. As a side effect of the changes required for that, some minor cleanup and changes have been made in the throwing system and shuttle docking.

![image](https://puu.sh/AEKNG/281571b57f.gif)
