### PR TITLE
Block default interact when opening an unlocked uplink

### DIFF
--- a/code/__DEFINES/components.dm
+++ b/code/__DEFINES/components.dm
@@ -103,6 +103,7 @@
 // /obj/item signals
 #define COMSIG_ITEM_ATTACK "item_attack"						//from base of obj/item/attack(): (/mob/living/target, /mob/living/user)
 #define COMSIG_ITEM_ATTACK_SELF "item_attack_self"				//from base of obj/item/attack_self(): (/mob)
+	#define COMPONENT_NO_INTERACT 1
 #define COMSIG_ITEM_ATTACK_OBJ "item_attack_obj"				//from base of obj/item/attack_obj(): (/obj, /mob)
 	#define COMPONENT_NO_ATTACK_OBJ 1
 #define COMSIG_ITEM_PRE_ATTACK "item_pre_attack"				//from base of obj/item/pre_attack(): (atom/target, mob/user, params)

--- a/code/_onclick/item_attack.dm
+++ b/code/_onclick/item_attack.dm
@@ -17,7 +17,8 @@
 
 // Called when the item is in the active hand, and clicked; alternately, there is an 'activate held object' verb or you can hit pagedown.
 /obj/item/proc/attack_self(mob/user)
-	SEND_SIGNAL(src, COMSIG_ITEM_ATTACK_SELF, user)
+	if(SEND_SIGNAL(src, COMSIG_ITEM_ATTACK_SELF, user) & COMPONENT_NO_INTERACT)
+		return
 	interact(user)
 
 /obj/item/proc/pre_attack(atom/A, mob/living/user, params) //do stuff before attackby!

--- a/code/game/gamemodes/clown_ops/clown_ops.dm
+++ b/code/game/gamemodes/clown_ops/clown_ops.dm
@@ -48,7 +48,7 @@
 		/obj/item/reagent_containers/spray/waterflower/lube)
 	implants = list(/obj/item/implant/sad_trombone)
 
-	uplink_type = /obj/item/radio/uplink/clownop
+	uplink_type = /obj/item/uplink/clownop
 
 /datum/outfit/syndicate/clownop/no_crystals
 	tc = 0

--- a/code/game/gamemodes/nuclear/nuclear.dm
+++ b/code/game/gamemodes/nuclear/nuclear.dm
@@ -134,7 +134,7 @@
 
 	var/tc = 25
 	var/command_radio = FALSE
-	var/uplink_type = /obj/item/radio/uplink/nuclear
+	var/uplink_type = /obj/item/uplink/nuclear
 
 
 /datum/outfit/syndicate/leader
@@ -154,7 +154,7 @@
 		R.command = TRUE
 
 	if(tc)
-		var/obj/item/radio/uplink/U = new uplink_type(H, H.key, tc)
+		var/obj/item/U = new uplink_type(H, H.key, tc)
 		H.equip_to_slot_or_del(U, SLOT_IN_BACKPACK)
 
 	var/obj/item/implant/weapons_auth/W = new/obj/item/implant/weapons_auth(H)

--- a/code/game/objects/items/devices/PDA/PDA.dm
+++ b/code/game/objects/items/devices/PDA/PDA.dm
@@ -171,12 +171,12 @@ GLOBAL_LIST_EMPTY(PDAs)
 		return attack_self(M)
 	return ..()
 
-/obj/item/pda/attack_self(mob/user)
+/obj/item/pda/interact(mob/user)
 	if(!user.IsAdvancedToolUser())
 		to_chat(user, "<span class='warning'>You don't have the dexterity to do this!</span>")
 		return
 
-	. = ..()
+	..()
 
 	var/datum/asset/spritesheet/assets = get_asset_datum(/datum/asset/spritesheet/simple/pda)
 	assets.send(user)

--- a/code/game/objects/items/devices/radio/radio.dm
+++ b/code/game/objects/items/devices/radio/radio.dm
@@ -100,12 +100,11 @@
 	AddComponent(/datum/component/empprotection, EMP_PROTECT_WIRES)
 
 /obj/item/radio/interact(mob/user)
-	if (..())
-		return
 	if(unscrewed && !isAI(user))
 		wires.interact(user)
+		add_fingerprint(user)
 	else
-		ui_interact(user)
+		..()
 
 /obj/item/radio/ui_interact(mob/user, ui_key = "main", datum/tgui/ui = null, force_open = FALSE, \
 										datum/tgui/master_ui = null, datum/ui_state/state = GLOB.inventory_state)

--- a/code/modules/antagonists/nukeop/equipment/nuclear_challenge.dm
+++ b/code/modules/antagonists/nukeop/equipment/nuclear_challenge.dm
@@ -16,7 +16,7 @@ GLOBAL_LIST_EMPTY(jam_on_wardec)
 			Such a brazen move will attract the attention of powerful benefactors within the Syndicate, who will supply your team with a massive amount of bonus telecrystals.  \
 			Must be used within five minutes, or your benefactors will lose interest."
 	var/declaring_war = FALSE
-	var/uplink_type = /obj/item/radio/uplink/nuclear
+	var/uplink_type = /obj/item/uplink/nuclear
 
 /obj/item/nuclear_challenge/attack_self(mob/living/user)
 	if(!check_allowed(user))
@@ -88,7 +88,7 @@ GLOBAL_LIST_EMPTY(jam_on_wardec)
 	return TRUE
 
 /obj/item/nuclear_challenge/clownops
-	uplink_type = /obj/item/radio/uplink/clownop
+	uplink_type = /obj/item/uplink/clownop
 
 #undef CHALLENGE_TELECRYSTALS
 #undef CHALLENGE_TIME_LIMIT

--- a/code/modules/awaymissions/mission_code/snowdin.dm
+++ b/code/modules/awaymissions/mission_code/snowdin.dm
@@ -530,7 +530,7 @@
 				/obj/item/gun/ballistic/automatic/c20r/unrestricted = 16,
 				/obj/item/gun/magic/wand/resurrection/inert = 15,
 				/obj/item/gun/magic/wand/resurrection = 10,
-				/obj/item/radio/uplink/old = 2,
+				/obj/item/uplink/old = 2,
 				/obj/item/book/granter/spell/charge = 12,
 				/obj/item/grenade/clusterbuster/spawner_manhacks = 15,
 				/obj/item/book/granter/spell/fireball = 10,

--- a/code/modules/clothing/outfits/vr.dm
+++ b/code/modules/clothing/outfits/vr.dm
@@ -27,7 +27,7 @@
 
 /datum/outfit/vr/syndicate/post_equip(mob/living/carbon/human/H)
 	. = ..()
-	var/obj/item/radio/uplink/U = new /obj/item/radio/uplink/nuclear_restricted(H, H.key, 80)
+	var/obj/item/uplink/U = new /obj/item/uplink/nuclear_restricted(H, H.key, 80)
 	H.equip_to_slot_or_del(U, SLOT_IN_BACKPACK)
 	var/obj/item/implant/weapons_auth/W = new/obj/item/implant/weapons_auth(H)
 	W.implant(H)

--- a/code/modules/mob/living/simple_animal/friendly/drone/extra_drone_types.dm
+++ b/code/modules/mob/living/simple_animal/friendly/drone/extra_drone_types.dm
@@ -26,7 +26,7 @@
 	"1. Interfere.\n"+\
 	"2. Kill.\n"+\
 	"3. Destroy."
-	default_storage = /obj/item/radio/uplink
+	default_storage = /obj/item/uplink
 	default_hatmask = /obj/item/clothing/head/helmet/space/hardsuit/syndi
 	hacked = TRUE
 	flavortext = null
@@ -43,7 +43,7 @@
 /mob/living/simple_animal/drone/syndrone/badass
 	name = "Badass Syndrone"
 	default_hatmask = /obj/item/clothing/head/helmet/space/hardsuit/syndi/elite
-	default_storage = /obj/item/radio/uplink/nuclear
+	default_storage = /obj/item/uplink/nuclear
 
 /mob/living/simple_animal/drone/syndrone/badass/Initialize()
 	. = ..()

--- a/code/modules/uplink/uplink.dm
+++ b/code/modules/uplink/uplink.dm
@@ -92,6 +92,8 @@ GLOBAL_LIST_EMPTY(uplinks)
 	active = TRUE
 	if(user)
 		ui_interact(user)
+	// an unlocked uplink blocks also opening the PDA or headset menu
+	return COMPONENT_NO_INTERACT
 
 /datum/component/uplink/ui_interact(mob/user, ui_key = "main", datum/tgui/ui = null, force_open = FALSE, \
 									datum/tgui/master_ui = null, datum/ui_state/state = GLOB.inventory_state)

--- a/code/modules/uplink/uplink_devices.dm
+++ b/code/modules/uplink/uplink_devices.dm
@@ -1,42 +1,60 @@
-
 // A collection of pre-set uplinks, for admin spawns.
-/obj/item/radio/uplink/Initialize(mapload, _owner, _tc_amount = 20)
-	. = ..()
+
+// Radio-like uplink; not an actual radio because this uplink is most commonly
+// used for nuke ops, for whom opening the radio GUI and the uplink GUI
+// simultaneously is an annoying distraction.
+/obj/item/uplink
+	name = "station bounced radio"
+	icon = 'icons/obj/radio.dmi'
 	icon_state = "radio"
+	item_state = "walkietalkie"
+	desc = "A basic handheld radio that communicates with local telecommunication networks."
 	lefthand_file = 'icons/mob/inhands/misc/devices_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/misc/devices_righthand.dmi'
-	AddComponent(/datum/component/uplink, _owner, FALSE, TRUE, null, _tc_amount)
+	dog_fashion = /datum/dog_fashion/back
 
-/obj/item/radio/uplink/nuclear/Initialize()
+	flags_1 = CONDUCT_1
+	slot_flags = ITEM_SLOT_BELT
+	throw_speed = 3
+	throw_range = 7
+	w_class = WEIGHT_CLASS_SMALL
+
+/obj/item/uplink/Initialize(mapload, owner, tc_amount = 20)
+	. = ..()
+	AddComponent(/datum/component/uplink, owner, FALSE, TRUE, null, tc_amount)
+
+/obj/item/uplink/nuclear/Initialize()
 	. = ..()
 	GET_COMPONENT(hidden_uplink, /datum/component/uplink)
 	hidden_uplink.set_gamemode(/datum/game_mode/nuclear)
 
-/obj/item/radio/uplink/nuclear_restricted/Initialize()
+/obj/item/uplink/nuclear_restricted/Initialize()
 	. = ..()
 	GET_COMPONENT(hidden_uplink, /datum/component/uplink)
 	hidden_uplink.allow_restricted = FALSE
 	hidden_uplink.set_gamemode(/datum/game_mode/nuclear)
 
-/obj/item/radio/uplink/clownop/Initialize()
+/obj/item/uplink/clownop/Initialize()
 	. = ..()
 	GET_COMPONENT(hidden_uplink, /datum/component/uplink)
 	hidden_uplink.set_gamemode(/datum/game_mode/nuclear/clown_ops)
 
-/obj/item/multitool/uplink/Initialize(mapload, _owner, _tc_amount = 20)
-	. = ..()
-	AddComponent(/datum/component/uplink, _owner, FALSE, TRUE, null, _tc_amount)
-
-/obj/item/pen/uplink/Initialize(mapload, _owner, _tc_amount = 20)
-	. = ..()
-	AddComponent(/datum/component/uplink)
-	traitor_unlock_degrees = 360
-
-/obj/item/radio/uplink/old
+/obj/item/uplink/old
 	name = "dusty radio"
 	desc = "A dusty looking radio."
 
-/obj/item/radio/uplink/old/Initialize(mapload, _owner, _tc_amount = 10)
+/obj/item/uplink/old/Initialize(mapload, owner, tc_amount = 10)
 	. = ..()
 	GET_COMPONENT(hidden_uplink, /datum/component/uplink)
 	hidden_uplink.name = "dusty radio"
+
+// Multitool uplink
+/obj/item/multitool/uplink/Initialize(mapload, owner, tc_amount = 20)
+	. = ..()
+	AddComponent(/datum/component/uplink, owner, FALSE, TRUE, null, tc_amount)
+
+// Pen uplink
+/obj/item/pen/uplink/Initialize(mapload, owner, tc_amount = 20)
+	. = ..()
+	AddComponent(/datum/component/uplink, owner, TRUE, FALSE, null, tc_amount)
+	traitor_unlock_degrees = 360


### PR DESCRIPTION
:cl:
tweak: PDAs and radios with unlocked uplinks no longer open their normal interface in addition to the uplink when activated.
tweak: Nuclear operative uplinks are no longer also radios.
/:cl:

Fixes #33261.