### PR TITLE
Fix Meta and Delta escape pod rooms having no air

### DIFF
--- a/_maps/map_files/Deltastation/DeltaStation2.dmm
+++ b/_maps/map_files/Deltastation/DeltaStation2.dmm
@@ -204,6 +204,7 @@
 	roundstart_template = /datum/map_template/shuttle/escape_pod/default;
 	width = 3
 	},
+/obj/structure/fans/tiny/invisible,
 /turf/open/space/basic,
 /area/space)
 "abv" = (
@@ -22725,6 +22726,7 @@
 	roundstart_template = /datum/map_template/shuttle/escape_pod/default;
 	width = 3
 	},
+/obj/structure/fans/tiny/invisible,
 /turf/open/space/basic,
 /area/space)
 "bbz" = (
@@ -100478,6 +100480,10 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/siphon/atmos/toxins_mixing_output,
 /turf/open/floor/engine/vacuum,
 /area/science/mixing)
+"xZM" = (
+/obj/structure/fans/tiny/invisible,
+/turf/open/space/basic,
+/area/space)
 "yiv" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/vault{
@@ -136773,7 +136779,7 @@ aaa
 aaa
 aaa
 aaa
-aaa
+xZM
 abE
 aaO
 aca
@@ -137287,7 +137293,7 @@ aaa
 aaa
 aaa
 aaa
-aaa
+xZM
 abG
 aaO
 acc
@@ -141399,7 +141405,7 @@ aaa
 aaa
 aaa
 aaa
-aaa
+xZM
 abE
 aaO
 aca
@@ -141913,7 +141919,7 @@ aaa
 aaa
 aaa
 aaa
-aaa
+xZM
 abG
 aaO
 acc
@@ -158676,9 +158682,9 @@ aaa
 ajr
 aad
 aKV
-aaa
+xZM
 bbv
-aaa
+xZM
 aKV
 aad
 aad

--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -466,6 +466,7 @@
 	roundstart_template = /datum/map_template/shuttle/escape_pod/default;
 	width = 3
 	},
+/obj/structure/fans/tiny/invisible,
 /turf/open/space/basic,
 /area/space)
 "abv" = (
@@ -1518,6 +1519,7 @@
 	roundstart_template = /datum/map_template/shuttle/escape_pod/default;
 	width = 3
 	},
+/obj/structure/fans/tiny/invisible,
 /turf/open/space/basic,
 /area/space)
 "adG" = (
@@ -76936,6 +76938,10 @@
 "wOE" = (
 /turf/open/floor/plating,
 /area/maintenance/aft)
+"wOY" = (
+/obj/structure/fans/tiny/invisible,
+/turf/open/space/basic,
+/area/space)
 "wPk" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -86399,7 +86405,7 @@ aaa
 aaa
 aaa
 aaa
-aaa
+wOY
 aSH
 aUb
 aVt
@@ -86913,7 +86919,7 @@ aaa
 aaa
 aaa
 aaa
-aaa
+wOY
 aSI
 aRA
 aVv
@@ -102035,7 +102041,7 @@ aaa
 aaa
 aaa
 aaa
-aaa
+wOY
 abL
 acf
 acy
@@ -102549,7 +102555,7 @@ aaa
 aaa
 aaa
 aaa
-aaa
+wOY
 abN
 ach
 aax
@@ -114633,9 +114639,9 @@ aaa
 aaf
 aaa
 acP
-aaa
+wOY
 adF
-aaa
+wOY
 acP
 afB
 agz
@@ -120332,9 +120338,9 @@ dgp
 cXI
 cYj
 atm
-aaa
+wOY
 adF
-aaa
+wOY
 bhT
 bpv
 brL


### PR DESCRIPTION
:cl:
fix: The escape pod hallways on MetaStation and DeltaStation now have air again.
/:cl:

Fixes #37614. The invisible tiny fans block air during its initialization. Because they are anchored, the shuttle simply `qdel`s them when it arrives.