### PR TITLE
adds chameleon belt to chameleon kits

### DIFF
--- a/code/game/objects/items/storage/uplink_kits.dm
+++ b/code/game/objects/items/storage/uplink_kits.dm
@@ -273,6 +273,7 @@
 	new /obj/item/clothing/suit/chameleon(src)
 	new /obj/item/clothing/gloves/chameleon(src)
 	new /obj/item/clothing/shoes/chameleon(src)
+	new /obj/item/storage/belt/chameleon(src)
 	new /obj/item/clothing/glasses/chameleon(src)
 	new /obj/item/clothing/head/chameleon(src)
 	new /obj/item/clothing/mask/chameleon(src)


### PR DESCRIPTION
for the full STEALTH experience

:cl: improvedname
tweak:chameleon kits now include chameleon belts
/:cl:

[why]: # (Please add a short description [two lines down] of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.) full chameleon experience
