### PR TITLE
Adds dance machine, drink dispensers, flavor to beach bum ruin

### DIFF
--- a/_maps/RandomRuins/LavaRuins/lavaland_biodome_beach.dmm
+++ b/_maps/RandomRuins/LavaRuins/lavaland_biodome_beach.dmm
@@ -10,6 +10,7 @@
 /obj/structure/table,
 /obj/item/storage/toolbox/mechanical,
 /obj/item/stack/cable_coil,
+/obj/item/storage/box/lights/mixed,
 /turf/open/floor/plating,
 /area/ruin/powered/beach)
 "af" = (
@@ -18,6 +19,9 @@
 /obj/machinery/light/small{
 	dir = 1
 	},
+/obj/item/clothing/glasses/sunglasses/big,
+/obj/item/clothing/glasses/sunglasses/big,
+/obj/item/clothing/glasses/sunglasses/big,
 /turf/open/floor/plating,
 /area/ruin/powered/beach)
 "ag" = (
@@ -94,11 +98,15 @@
 /turf/open/floor/plating,
 /area/ruin/powered/beach)
 "av" = (
-/obj/machinery/door/airlock/hatch,
+/obj/machinery/door/airlock/sandstone{
+	name = "Lavatory"
+	},
 /turf/open/floor/plating,
 /area/ruin/powered/beach)
 "aw" = (
-/obj/machinery/door/airlock/sandstone,
+/obj/machinery/door/airlock/sandstone{
+	name = "Bar Storage"
+	},
 /turf/open/floor/wood,
 /area/ruin/powered/beach)
 "ax" = (
@@ -106,8 +114,10 @@
 /turf/closed/wall/mineral/sandstone,
 /area/ruin/powered/beach)
 "ay" = (
-/obj/machinery/door/airlock/hatch,
 /obj/effect/turf_decal/sand,
+/obj/machinery/door/airlock/sandstone{
+	name = "Restroom"
+	},
 /turf/open/floor/plating,
 /area/ruin/powered/beach)
 "az" = (
@@ -130,13 +140,10 @@
 /area/ruin/powered/beach)
 "aD" = (
 /obj/structure/table,
-/obj/item/storage/box/drinkingglasses,
-/obj/item/storage/box/drinkingglasses,
-/obj/item/reagent_containers/food/drinks/shaker,
-/obj/item/storage/box/beakers,
 /obj/machinery/light{
 	dir = 1
 	},
+/obj/machinery/chem_dispenser/drinks,
 /turf/open/floor/wood,
 /area/ruin/powered/beach)
 "aE" = (
@@ -151,18 +158,15 @@
 	},
 /turf/open/floor/wood,
 /area/ruin/powered/beach)
-"aG" = (
-/obj/structure/table,
-/obj/item/book/manual/barman_recipes,
-/obj/item/reagent_containers/glass/rag,
-/turf/open/floor/wood,
-/area/ruin/powered/beach)
 "aH" = (
 /obj/structure/table,
-/obj/item/storage/box/donkpockets,
 /obj/machinery/light{
 	dir = 1
 	},
+/obj/item/book/manual/barman_recipes,
+/obj/item/book/granter/action/drink_fling,
+/obj/item/reagent_containers/food/drinks/shaker,
+/obj/item/reagent_containers/glass/rag,
 /turf/open/floor/wood,
 /area/ruin/powered/beach)
 "aI" = (
@@ -185,7 +189,7 @@
 /area/ruin/powered/beach)
 "aL" = (
 /obj/effect/mob_spawn/human/bartender/alive{
-	name = "beach bum sleeper"
+	name = "bartender sleeper"
 	},
 /turf/open/floor/wood,
 /area/ruin/powered/beach)
@@ -259,7 +263,9 @@
 /turf/open/floor/plating/beach/sand,
 /area/ruin/powered/beach)
 "bc" = (
-/obj/machinery/door/airlock/sandstone,
+/obj/machinery/door/airlock/sandstone{
+	name = "Bar Access"
+	},
 /obj/effect/turf_decal/sand,
 /turf/open/floor/wood,
 /area/ruin/powered/beach)
@@ -279,21 +285,8 @@
 /obj/structure/sign/barsign,
 /turf/closed/wall/mineral/sandstone,
 /area/ruin/powered/beach)
-"bj" = (
-/obj/structure/chair/wood/normal{
-	dir = 4
-	},
-/turf/open/floor/plasteel/asteroid,
-/area/ruin/powered/beach)
-"bk" = (
-/obj/structure/table/wood,
-/obj/item/reagent_containers/food/snacks/pastatomato,
-/turf/open/floor/plasteel/asteroid,
-/area/ruin/powered/beach)
 "bl" = (
-/obj/structure/chair/wood/normal{
-	dir = 8
-	},
+/obj/effect/turf_decal/caution,
 /turf/open/floor/plasteel/asteroid,
 /area/ruin/powered/beach)
 "bx" = (
@@ -353,7 +346,8 @@
 	id = /obj/item/card/id;
 	id_access = "Medical Doctor";
 	id_job = "Lifeguard";
-	mob_gender = "female"
+	mob_gender = "female";
+	name = "lifeguard sleeper"
 	},
 /turf/open/floor/wood,
 /area/ruin/powered/beach)
@@ -466,8 +460,23 @@
 /turf/open/floor/pod/dark,
 /area/ruin/powered/beach)
 "dw" = (
-/obj/machinery/door/airlock/sandstone,
+/obj/machinery/door/airlock/sandstone{
+	name = "Beach Access"
+	},
 /turf/open/floor/pod/dark,
+/area/ruin/powered/beach)
+"gg" = (
+/obj/structure/table,
+/obj/item/storage/box/drinkingglasses,
+/obj/item/storage/box/drinkingglasses,
+/obj/item/storage/box/beakers,
+/obj/item/storage/box/donkpockets,
+/turf/open/floor/plating,
+/area/ruin/powered/beach)
+"hY" = (
+/obj/structure/table,
+/obj/machinery/chem_dispenser/drinks/beer,
+/turf/open/floor/wood,
 /area/ruin/powered/beach)
 "iw" = (
 /obj/machinery/light/small{
@@ -496,8 +505,16 @@
 /obj/effect/spawner/structure/window,
 /turf/open/floor/plating,
 /area/ruin/powered/beach)
+"oK" = (
+/obj/effect/turf_decal/caution{
+	dir = 1
+	},
+/turf/open/floor/plasteel/asteroid,
+/area/ruin/powered/beach)
 "pI" = (
-/obj/machinery/door/airlock/hatch,
+/obj/machinery/door/airlock/hatch{
+	name = "Lava Beach Club"
+	},
 /obj/structure/fans/tiny,
 /turf/open/floor/pod/dark,
 /area/ruin/powered/beach)
@@ -514,6 +531,16 @@
 	},
 /turf/open/floor/pod/dark,
 /area/ruin/powered/beach)
+"sy" = (
+/obj/effect/turf_decal/caution{
+	dir = 4
+	},
+/turf/open/floor/plasteel/asteroid,
+/area/ruin/powered/beach)
+"sO" = (
+/obj/machinery/jukebox/disco,
+/turf/open/floor/light/colour_cycle,
+/area/ruin/powered/beach)
 "vl" = (
 /obj/structure/closet/athletic_mixed,
 /turf/open/floor/pod/dark,
@@ -521,15 +548,27 @@
 "wY" = (
 /turf/open/floor/pod/light,
 /area/ruin/powered/beach)
+"yp" = (
+/obj/item/reagent_containers/spray/spraytan,
+/turf/open/floor/plasteel/asteroid,
+/area/ruin/powered/beach)
 "zw" = (
 /obj/structure/closet/athletic_mixed,
 /obj/effect/turf_decal/sand,
 /turf/open/floor/pod/dark,
 /area/ruin/powered/beach)
 "Ec" = (
-/obj/machinery/door/airlock/sandstone,
+/obj/machinery/door/airlock/sandstone{
+	name = "Beach Access"
+	},
 /obj/effect/turf_decal/sand,
 /turf/open/floor/pod/dark,
+/area/ruin/powered/beach)
+"Ga" = (
+/obj/effect/turf_decal/caution{
+	dir = 8
+	},
+/turf/open/floor/plasteel/asteroid,
 /area/ruin/powered/beach)
 "Gc" = (
 /obj/effect/turf_decal/sand,
@@ -854,7 +893,7 @@ aa
 aa
 bW
 ae
-as
+gg
 bW
 aB
 aK
@@ -863,7 +902,7 @@ aK
 aK
 aK
 aK
-aK
+yp
 aA
 ar
 ar
@@ -894,7 +933,7 @@ aj
 aB
 aK
 aK
-bj
+aK
 aK
 aA
 ar
@@ -925,8 +964,8 @@ aC
 aP
 aW
 aK
+Ga
 aK
-bk
 aK
 aA
 ar
@@ -956,8 +995,8 @@ aD
 aC
 aQ
 aW
-aK
-aK
+oK
+sO
 bl
 aK
 aA
@@ -984,12 +1023,12 @@ bW
 ai
 at
 ax
-aE
+hY
 aL
 aP
 aW
 aK
-aK
+sy
 aK
 aK
 aA
@@ -1048,7 +1087,7 @@ bW
 ak
 au
 aj
-aG
+aE
 aC
 aj
 aj
@@ -1307,7 +1346,7 @@ ap
 ar
 ar
 aU
-ar
+bE
 ar
 ar
 bz
@@ -1371,7 +1410,7 @@ ap
 ar
 ar
 aq
-ar
+aV
 be
 ar
 ch

--- a/_maps/RandomRuins/LavaRuins/lavaland_biodome_beach.dmm
+++ b/_maps/RandomRuins/LavaRuins/lavaland_biodome_beach.dmm
@@ -538,7 +538,7 @@
 /turf/open/floor/plasteel/asteroid,
 /area/ruin/powered/beach)
 "sO" = (
-/obj/machinery/jukebox/disco,
+/obj/machinery/jukebox/disco/indestructible,
 /turf/open/floor/light/colour_cycle,
 /area/ruin/powered/beach)
 "vl" = (

--- a/_maps/RandomRuins/LavaRuins/lavaland_biodome_beach.dmm
+++ b/_maps/RandomRuins/LavaRuins/lavaland_biodome_beach.dmm
@@ -188,9 +188,7 @@
 /turf/open/floor/plasteel/asteroid,
 /area/ruin/powered/beach)
 "aL" = (
-/obj/effect/mob_spawn/human/bartender/alive{
-	name = "bartender sleeper"
-	},
+/obj/effect/mob_spawn/human/bartender/alive,
 /turf/open/floor/wood,
 /area/ruin/powered/beach)
 "aM" = (
@@ -232,11 +230,7 @@
 /turf/open/floor/plating/beach/sand,
 /area/ruin/powered/beach)
 "aV" = (
-/obj/effect/mob_spawn/human/beach/alive{
-	flavour_text = "<span class='big bold'>You're, like, totally a dudebro, bruh.</span><b> Ch'yea. You came here, like, on spring break, hopin' to pick up some bangin' hot chicks, y'knaw?</b>";
-	l_pocket = /obj/item/reagent_containers/food/snacks/pizzaslice/dank;
-	uniform = /obj/item/clothing/under/pants/youngfolksjeans
-	},
+/obj/effect/mob_spawn/human/beach/alive,
 /turf/open/floor/plating/beach/sand,
 /area/ruin/powered/beach)
 "aW" = (
@@ -341,14 +335,7 @@
 /obj/structure/window/reinforced{
 	dir = 4
 	},
-/obj/effect/mob_spawn/human/beach/alive{
-	flavour_text = "<span class='big bold'>You're a spunky lifeguard!</span><b> It's up to you to make sure nobody drowns or gets eaten by sharks and stuff.</b>";
-	id = /obj/item/card/id;
-	id_access = "Medical Doctor";
-	id_job = "Lifeguard";
-	mob_gender = "female";
-	name = "lifeguard sleeper"
-	},
+/obj/effect/mob_spawn/human/beach/alive/lifeguard,
 /turf/open/floor/wood,
 /area/ruin/powered/beach)
 "bJ" = (

--- a/_maps/RandomRuins/LavaRuins/lavaland_biodome_beach.dmm
+++ b/_maps/RandomRuins/LavaRuins/lavaland_biodome_beach.dmm
@@ -29,7 +29,7 @@
 /turf/open/floor/plating,
 /area/ruin/powered/beach)
 "ah" = (
-/obj/machinery/power/smes,
+/obj/effect/mob_spawn/human/bartender/alive,
 /turf/open/floor/plating,
 /area/ruin/powered/beach)
 "ai" = (
@@ -187,16 +187,12 @@
 "aK" = (
 /turf/open/floor/plasteel/asteroid,
 /area/ruin/powered/beach)
-"aL" = (
-/obj/effect/mob_spawn/human/bartender/alive,
-/turf/open/floor/wood,
-/area/ruin/powered/beach)
 "aM" = (
 /obj/structure/reagent_dispensers/beerkeg,
 /turf/open/floor/wood,
 /area/ruin/powered/beach)
 "aN" = (
-/obj/machinery/vending/cigarette,
+/obj/machinery/vending/cigarette/beach,
 /turf/open/floor/plasteel/asteroid,
 /area/ruin/powered/beach)
 "aO" = (
@@ -498,6 +494,13 @@
 	},
 /turf/open/floor/plasteel/asteroid,
 /area/ruin/powered/beach)
+"pg" = (
+/obj/effect/turf_decal/sand,
+/obj/machinery/shower{
+	dir = 4
+	},
+/turf/open/floor/pod/light,
+/area/ruin/powered/beach)
 "pI" = (
 /obj/machinery/door/airlock/hatch{
 	name = "Lava Beach Club"
@@ -517,6 +520,12 @@
 	dir = 4
 	},
 /turf/open/floor/pod/dark,
+/area/ruin/powered/beach)
+"qT" = (
+/obj/machinery/shower{
+	dir = 8
+	},
+/turf/open/floor/pod/light,
 /area/ruin/powered/beach)
 "sy" = (
 /obj/effect/turf_decal/caution{
@@ -544,6 +553,13 @@
 /obj/effect/turf_decal/sand,
 /turf/open/floor/pod/dark,
 /area/ruin/powered/beach)
+"Bl" = (
+/obj/effect/turf_decal/sand,
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/open/floor/plating/beach/sand,
+/area/ruin/powered/beach)
 "Ec" = (
 /obj/machinery/door/airlock/sandstone{
 	name = "Beach Access"
@@ -567,6 +583,13 @@
 /obj/item/clothing/shoes/sandal,
 /obj/effect/turf_decal/sand,
 /turf/open/floor/pod/dark,
+/area/ruin/powered/beach)
+"QS" = (
+/obj/effect/turf_decal/sand,
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/open/floor/plating/beach/sand,
 /area/ruin/powered/beach)
 "TP" = (
 /obj/machinery/light{
@@ -636,7 +659,7 @@ bW
 vl
 iw
 wY
-Gc
+pg
 wY
 Xp
 cR
@@ -731,9 +754,9 @@ ar
 cg
 ar
 ar
+Bl
 aA
-aA
-aA
+Bl
 ar
 ar
 cg
@@ -1011,7 +1034,7 @@ ai
 at
 ax
 hY
-aL
+aC
 aP
 aW
 aK
@@ -1403,9 +1426,9 @@ ar
 ch
 ar
 ar
+QS
 aA
-aA
-aA
+QS
 ar
 ar
 cs
@@ -1500,7 +1523,7 @@ bW
 HC
 qa
 wY
-wY
+qT
 Gc
 pU
 cR

--- a/code/game/objects/items/cigs_lighters.dm
+++ b/code/game/objects/items/cigs_lighters.dm
@@ -321,6 +321,12 @@ CIGARETTE PACKETS ARE IN FANCY.DM
 	list_reagents = list("nicotine" = 15, "mushroomhallucinogen" = 35)
 	starts_lit = TRUE
 
+/obj/item/clothing/mask/cigarette/rollie/cannabis
+	list_reagents = list("space_drugs" = 15, "lipolicide" = 35)
+
+/obj/item/clothing/mask/cigarette/rollie/mindbreaker
+	list_reagents = list("mindbreaker" = 35, "lipolicide" = 15)	
+
 /obj/item/cigbutt/roach
 	name = "roach"
 	desc = "A manky old roach, or for non-stoners, a used rollup."
@@ -385,7 +391,7 @@ CIGARETTE PACKETS ARE IN FANCY.DM
 /////////////////
 /obj/item/clothing/mask/cigarette/pipe
 	name = "smoking pipe"
-	desc = "A pipe, for smoking. Probably made of meershaum or something."
+	desc = "A pipe, for smoking. Probably made of meerschaum or something."
 	icon_state = "pipeoff"
 	item_state = "pipeoff"
 	icon_on = "pipeon"  //Note - these are in masks.dmi

--- a/code/game/objects/items/storage/fancy.dm
+++ b/code/game/objects/items/storage/fancy.dm
@@ -253,6 +253,18 @@
 	icon_state = "slime"
 	spawn_type = /obj/item/clothing/mask/cigarette/xeno
 
+/obj/item/storage/fancy/cigarettes/cigpack_cannabis
+	name = "\improper Freak Brothers' Special packet"
+	desc = "A label on the packaging reads, \"Endorsed by Phineas, Freddy and Franklin.\""
+	icon_state = "midori"
+	spawn_type = /obj/item/clothing/mask/cigarette/rollie/cannabis
+
+/obj/item/storage/fancy/cigarettes/cigpack_mindbreaker
+	name = "\improper Leary's Delight packet"
+	desc = "Banned in over 36 galaxies."
+	icon_state = "shadyjim"
+	spawn_type = /obj/item/clothing/mask/cigarette/rollie/mindbreaker
+
 /obj/item/storage/fancy/rollingpapers
 	name = "rolling paper pack"
 	desc = "A pack of Nanotrasen brand rolling papers."

--- a/code/modules/awaymissions/corpse.dm
+++ b/code/modules/awaymissions/corpse.dm
@@ -361,7 +361,7 @@
 	name = "bartender sleeper"
 	icon = 'icons/obj/machines/sleeper.dmi'
 	icon_state = "sleeper"
-	flavour_text = "<span class='big bold'>You are a space bartender!</span>"
+	flavour_text = "<span class='big bold'>You are a space bartender!</span><b> Time to mix drinks and change lives.</b>"
 	assignedrole = "Space Bartender"
 	id_job = "Bartender"
 

--- a/code/modules/awaymissions/corpse.dm
+++ b/code/modules/awaymissions/corpse.dm
@@ -363,6 +363,7 @@
 	icon_state = "sleeper"
 	flavour_text = "<span class='big bold'>You are a space bartender!</span>"
 	assignedrole = "Space Bartender"
+	id_job = "Bartender"
 
 /datum/outfit/spacebartender
 	name = "Space Bartender"
@@ -372,7 +373,6 @@
 	suit = /obj/item/clothing/suit/armor/vest
 	glasses = /obj/item/clothing/glasses/sunglasses/reagent
 	id = /obj/item/card/id
-
 
 /obj/effect/mob_spawn/human/beach
 	outfit = /datum/outfit/beachbum
@@ -385,14 +385,23 @@
 	name = "beach bum sleeper"
 	icon = 'icons/obj/machines/sleeper.dmi'
 	icon_state = "sleeper"
-	flavour_text = "<span class='big bold'>You are a beach bum!</span>"
+	flavour_text = "<span class='big bold'>You're, like, totally a dudebro, bruh.</span><b> Ch'yea. You came here, like, on spring break, hopin' to pick up some bangin' hot chicks, y'knaw?</b>"
 	assignedrole = "Beach Bum"
 
+/obj/effect/mob_spawn/human/beach/alive/lifeguard
+	flavour_text = "<span class='big bold'>You're a spunky lifeguard!</span><b> It's up to you to make sure nobody drowns or gets eaten by sharks and stuff.</b>"
+	mob_gender = "female"
+	name = "lifeguard sleeper"
+	id_job = "Lifeguard"
+	uniform = /obj/item/clothing/under/shorts/red
+	
 /datum/outfit/beachbum
 	name = "Beach Bum"
 	glasses = /obj/item/clothing/glasses/sunglasses
-	uniform = /obj/item/clothing/under/shorts/red
 	r_pocket = /obj/item/storage/wallet/random
+	l_pocket = /obj/item/reagent_containers/food/snacks/pizzaslice/dank;
+	uniform = /obj/item/clothing/under/pants/youngfolksjeans
+	id = /obj/item/card/id
 
 /datum/outfit/beachbum/post_equip(mob/living/carbon/human/H, visualsOnly = FALSE)
 	..()

--- a/code/modules/awaymissions/corpse.dm
+++ b/code/modules/awaymissions/corpse.dm
@@ -361,7 +361,7 @@
 	name = "bartender sleeper"
 	icon = 'icons/obj/machines/sleeper.dmi'
 	icon_state = "sleeper"
-	flavour_text = "<span class='big bold'>You are a space bartender!</span><b> Time to mix drinks and change lives.</b>"
+	flavour_text = "<span class='big bold'>You are a space bartender!</span><b> Time to mix drinks and change lives. Smoking space drugs makes it easier to understand your patrons' odd dialect.</b>"
 	assignedrole = "Space Bartender"
 	id_job = "Bartender"
 

--- a/code/modules/vending/cigarette.dm
+++ b/code/modules/vending/cigarette.dm
@@ -20,6 +20,24 @@
 		           /obj/item/storage/fancy/cigarettes/cigars/cohiba = 1)
 	refill_canister = /obj/item/vending_refill/cigarette
 
+/obj/machinery/vending/cigarette/beach //Used in the lavaland_biodome_beach.dmm ruin
+	name = "\improper ShadyCigs Ultra"
+	desc = "Now with extra premium products!"
+	product_ads = "Probably not bad for you!;Dope will get you through times of no money better than money will get you through times of no dope!;It's good for you!"
+	product_slogans = "Turn on, tune in, drop out!;Better living through chemistry!;Toke!;Don't forget to keep a smile on your lips and a song in your heart!"
+	products = list(/obj/item/storage/fancy/cigarettes = 5,
+					/obj/item/storage/fancy/cigarettes/cigpack_uplift = 3,
+					/obj/item/storage/fancy/cigarettes/cigpack_robust = 3,
+					/obj/item/storage/fancy/cigarettes/cigpack_carp = 3,
+					/obj/item/storage/fancy/cigarettes/cigpack_midori = 3,
+					/obj/item/storage/fancy/cigarettes/cigpack_cannabis = 5,
+					/obj/item/storage/box/matches = 10,
+					/obj/item/lighter/greyscale = 4,
+					/obj/item/storage/fancy/rollingpapers = 5)
+	premium = list(/obj/item/storage/fancy/cigarettes/cigpack_mindbreaker = 5,
+					/obj/item/clothing/mask/vape = 5,
+					/obj/item/lighter = 3)
+
 /obj/item/vending_refill/cigarette
 	machine_name = "ShadyCigs Deluxe"
 	icon_state = "refill_smoke"


### PR DESCRIPTION
:cl: Denton
tweak: NanoTours is proud to announce that the Lavaland beach club has been outfitted with a dance machine, state of the art bar equipment and more.
/:cl:

The beach bum ruin was lacking in content other than "overdose on spraytan and suicide" or the classic "run off to lavaland and die".

I added booze/soda dispensers so people can mix drinks, a dance machine to well, dance, as well as aesthetic sunglasses because you're on a beach. Other than that I gave airlocks proper names and moved some items into the bar backroom.

Also a second beach bum spawner because there is now enough content to let an additional player live out the fantasy of being a fit, outgoing person.