### PR TITLE
Cleans up supermatter related varedits

### DIFF
--- a/_maps/map_files/OmegaStation/OmegaStation.dmm
+++ b/_maps/map_files/OmegaStation/OmegaStation.dmm
@@ -18952,10 +18952,7 @@
 /turf/open/floor/engine,
 /area/engine/engineering)
 "aOa" = (
-/obj/machinery/power/supermatter_crystal/shard/engine{
-	anchored = 1;
-	moveable = 0
-	},
+/obj/machinery/power/supermatter_crystal/shard/engine,
 /turf/open/floor/engine,
 /area/engine/supermatter)
 "aOb" = (

--- a/_maps/shuttles/emergency_supermatter.dmm
+++ b/_maps/shuttles/emergency_supermatter.dmm
@@ -112,7 +112,7 @@
 /turf/open/floor/plating,
 /area/shuttle/escape)
 "aB" = (
-/obj/machinery/power/supermatter_crystal/shard/hugbox,
+/obj/machinery/power/supermatter_crystal/shard/hugbox/fakecrystal,
 /turf/open/floor/plating,
 /area/shuttle/escape)
 "aD" = (

--- a/_maps/shuttles/emergency_supermatter.dmm
+++ b/_maps/shuttles/emergency_supermatter.dmm
@@ -112,14 +112,7 @@
 /turf/open/floor/plating,
 /area/shuttle/escape)
 "aB" = (
-/obj/machinery/power/supermatter_crystal/shard/hugbox{
-	anchored = 1;
-	base_icon_state = "darkmatter";
-	explosion_power = 20;
-	gasefficency = 0.15;
-	icon_state = "darkmatter";
-	name = "anchored supermatter crystal"
-	},
+/obj/machinery/power/supermatter_crystal/shard/hugbox,
 /turf/open/floor/plating,
 /area/shuttle/escape)
 "aD" = (
@@ -210,10 +203,7 @@
 /turf/open/floor/plating/airless,
 /area/shuttle/escape)
 "aV" = (
-/obj/machinery/power/supermatter_crystal/shard/hugbox{
-	anchored = 1;
-	name = "anchored supermatter shard"
-	},
+/obj/machinery/power/supermatter_crystal/shard/hugbox,
 /turf/open/floor/plating/airless,
 /area/shuttle/escape)
 "aW" = (

--- a/code/modules/power/supermatter/supermatter.dm
+++ b/code/modules/power/supermatter/supermatter.dm
@@ -653,7 +653,7 @@ GLOBAL_DATUM(main_supermatter_engine, /obj/machinery/power/supermatter_crystal)
 	name = "anchored supermatter shard"
 	is_main_engine = TRUE
 	anchored = TRUE
-	moveable = FALE
+	moveable = FALSE
 
 // When you wanna make a supermatter shard for the dramatic effect, but
 // don't want it exploding suddenly

--- a/code/modules/power/supermatter/supermatter.dm
+++ b/code/modules/power/supermatter/supermatter.dm
@@ -650,14 +650,24 @@ GLOBAL_DATUM(main_supermatter_engine, /obj/machinery/power/supermatter_crystal)
 	moveable = TRUE
 
 /obj/machinery/power/supermatter_crystal/shard/engine
+	name = "anchored supermatter shard"
 	is_main_engine = TRUE
+	anchored = TRUE
+	moveable = FALE
 
 // When you wanna make a supermatter shard for the dramatic effect, but
 // don't want it exploding suddenly
 /obj/machinery/power/supermatter_crystal/shard/hugbox
+	name = "anchored supermatter shard"
 	takes_damage = FALSE
 	produces_gas = FALSE
 	moveable = FALSE
+	anchored = TRUE
+
+/obj/machinery/power/supermatter_crystal/shard/hugbox/fakecrystal //Hugbox shard with crystal visuals, used in the Supermatter/Hyperfractal shuttle
+	name = "supermatter crystal"
+	base_icon_state = "darkmatter"
+	icon_state = "darkmatter"
 
 /obj/machinery/power/supermatter_crystal/proc/supermatter_pull(turf/center, pull_range = 10)
 	playsound(src.loc, 'sound/weapons/marauder.ogg', 100, 1, extrarange = 7)


### PR DESCRIPTION
I moved the varedits for Omega's/Supermatter shuttle's snowflake SM crystals from their mapfiles to the supermatter's. For some reason, the shuttle's had a bunch of unnecessary things like explosion_power defined.