### PR TITLE
Fix non-secure windoors not supporting One Required access mode

### DIFF
--- a/code/game/objects/structures/windoor_assembly.dm
+++ b/code/game/objects/structures/windoor_assembly.dm
@@ -293,7 +293,10 @@
 						windoor.setDir(dir)
 						windoor.density = FALSE
 
-						windoor.req_access = electronics.accesses
+						if(electronics.one_access)
+							windoor.req_one_access = electronics.accesses
+						else
+							windoor.req_access = electronics.accesses
 						windoor.electronics = electronics
 						electronics.loc = windoor
 						if(created_name)


### PR DESCRIPTION
:cl:
fix: Non-secure windoors now properly support the "One Required" access mode of airlock electronics.
/:cl:

Fixes #38528.