### PR TITLE
Fix repairing Cyborg headlamp even when its panel is closed

### DIFF
--- a/code/modules/mob/living/silicon/robot/robot.dm
+++ b/code/modules/mob/living/silicon/robot/robot.dm
@@ -529,7 +529,7 @@
 	else if(istype(W, /obj/item/flashlight))
 		if(!opened)
 			to_chat(user, "<span class='warning'>You need to open the panel to repair the headlamp!</span>")
-		if(lamp_cooldown <= world.time)
+		else if(lamp_cooldown <= world.time)
 			to_chat(user, "<span class='warning'>The headlamp is already functional!</span>")
 		else
 			if(!user.temporarilyRemoveItemFromInventory(W))


### PR DESCRIPTION
:cl:
fix: It is no longer possible to repair cyborg headlamps even when their panel is closed.
/:cl:

Fixes #38546. Mostly.