### PR TITLE
Fix item fortification scrolls stacking

### DIFF
--- a/code/modules/events/wizard/rpgloot.dm
+++ b/code/modules/events/wizard/rpgloot.dm
@@ -39,7 +39,7 @@
 
 	var/datum/rpg_loot/rpg_loot_datum = target.rpg_loot
 	if(!istype(rpg_loot_datum))
-		rpg_loot_datum = new /datum/rpg_loot(target)
+		target.rpg_loot = rpg_loot_datum = new /datum/rpg_loot(target)
 
 	var/quality = rpg_loot_datum.quality
 


### PR DESCRIPTION
:cl:
fix: Item fortification scrolls no longer add multiple prefixes when applied to the same item.
/:cl:

Fixes #38530.