### PR TITLE
Fix gulag shuttle moving instantly

### DIFF
--- a/code/modules/mining/laborcamp/laborstacker.dm
+++ b/code/modules/mining/laborcamp/laborstacker.dm
@@ -92,11 +92,11 @@
 			if(!alone_in_area(get_area(src), usr))
 				to_chat(usr, "<span class='warning'>Prisoners are only allowed to be released while alone.</span>")
 			else
-				switch(SSshuttle.moveShuttle("laborcamp","laborcamp_home"))
+				switch(SSshuttle.moveShuttle("laborcamp", "laborcamp_home", TRUE))
 					if(1)
-						to_chat(usr, "<span class='notice'>Shuttle not found</span>")
+						to_chat(usr, "<span class='notice'>Shuttle not found.</span>")
 					if(2)
-						to_chat(usr, "<span class='notice'>Shuttle already at station</span>")
+						to_chat(usr, "<span class='notice'>Shuttle already at station.</span>")
 					if(3)
 						to_chat(usr, "<span class='notice'>No permission to dock could be granted.</span>")
 					else


### PR DESCRIPTION
:cl:
fix: The gulag shuttle no longer moves instantly when returned via the claim console.
/:cl:

Fixes #38464.