### PR TITLE
Allow admin ghosts to use .p and .d say prefixes

### DIFF
--- a/code/modules/mob/dead/observer/say.dm
+++ b/code/modules/mob/dead/observer/say.dm
@@ -1,7 +1,18 @@
 /mob/dead/observer/say(message)
 	message = trim(copytext(sanitize(message), 1, MAX_MESSAGE_LEN))
-
 	if (!message)
+		return
+
+	var/message_mode = get_message_mode(message)
+	if(client && (message_mode == "admin" || message_mode == "deadmin"))
+		message = copytext(message, 3)
+		if(findtext(message, " ", 1, 2))
+			message = copytext(message, 2)
+
+		if(message_mode == "admin")
+			client.cmd_admin_say(message)
+		else if(message_mode == "deadmin")
+			client.dsay(message)
 		return
 
 	log_talk(src,"Ghost/[src.key] : [message]", LOGSAY)

--- a/code/modules/mob/living/say.dm
+++ b/code/modules/mob/living/say.dm
@@ -307,16 +307,6 @@ GLOBAL_LIST_INIT(department_radio_keys, list(
 
 	return 1
 
-/mob/living/proc/get_message_mode(message)
-	var/key = copytext(message, 1, 2)
-	if(key == "#")
-		return MODE_WHISPER
-	else if(key == ";")
-		return MODE_HEADSET
-	else if(length(message) > 2 && (key in GLOB.department_radio_prefixes))
-		var/key_symbol = lowertext(copytext(message, 2, 3))
-		return GLOB.department_radio_keys[key_symbol]
-
 /mob/living/proc/get_key(message)
 	var/key = copytext(message, 1, 2)
 	if(key in GLOB.department_radio_prefixes)

--- a/code/modules/mob/say.dm
+++ b/code/modules/mob/say.dm
@@ -83,3 +83,13 @@
 
 /mob/proc/lingcheck()
 	return LINGHIVE_NONE
+
+/mob/proc/get_message_mode(message)
+	var/key = copytext(message, 1, 2)
+	if(key == "#")
+		return MODE_WHISPER
+	else if(key == ";")
+		return MODE_HEADSET
+	else if(length(message) > 2 && (key in GLOB.department_radio_prefixes))
+		var/key_symbol = lowertext(copytext(message, 2, 3))
+		return GLOB.department_radio_keys[key_symbol]


### PR DESCRIPTION
:cl:
admin: It is now possible to use the ".p" (Asay) and ".d" (Dsay) prefixes while an admin ghost.
/:cl:

Fixes #33735.