### PR TITLE
Replaces names in plasmaman.txt

### DIFF
--- a/strings/names/plasmaman.txt
+++ b/strings/names/plasmaman.txt
@@ -60,13 +60,16 @@ Meitnerium
 Mendelevium
 Mercury
 Molybdenum
+Moscovium
 Neodymium
 Neon
 Neptunium
 Nickel
+Nihonium
 Niobium
 Nitrogen
 Nobelium
+Oganesson
 Osmium
 Oxygen
 Palladium
@@ -98,6 +101,7 @@ Sulfur
 Tantalum
 Technetium
 Tellurium
+Tennessine
 Terbium
 Thallium
 Thorium
@@ -105,10 +109,6 @@ Thulium
 Tin
 Titanium
 Tungsten
-Ununoctium
-Ununpentium
-Ununseptium
-Ununtrium
 Uranium
 Vanadium
 Xenon


### PR DESCRIPTION
This PR affects plasmaman random names. It replaces the names _Ununoctium_, _Ununpentium_, _Ununseptium_ and _Ununtrium_ with _Oganesson_, _Moscovium_, _Tennessine_ and _Nihonium_.

The removed names were placeholders for elements that were given real names in 2016. These names were [approved](https://iupac.org/iupac-announces-the-names-of-the-elements-113-115-117-and-118/) on 28 November, one week after #21675 (which added plasmaman.txt).