### PR TITLE
Some tiny optimizations to atmos and chatcode

### DIFF
--- a/code/modules/atmospherics/environmental/LINDA_turf_tile.dm
+++ b/code/modules/atmospherics/environmental/LINDA_turf_tile.dm
@@ -102,7 +102,7 @@
 		for(var/overlay in atmos_overlay_types-new_overlay_types) //doesn't remove overlays that would only be added
 			vis_contents -= overlay
 
-	if (new_overlay_types.len)
+	if (length(new_overlay_types))
 		if (atmos_overlay_types)
 			vis_contents += new_overlay_types - atmos_overlay_types //don't add overlays that already exist
 		else
@@ -112,15 +112,25 @@
 	src.atmos_overlay_types = new_overlay_types
 
 /turf/open/proc/tile_graphic()
-	. = new /list
+	var/static/list/nonoverlaying_gases = typecache_of_gases_with_no_overlays()
 	if(air)
+		. = new /list
 		var/list/gases = air.gases
 		for(var/id in gases)
+			if (nonoverlaying_gases[id])
+				continue
 			var/gas = gases[id]
 			var/gas_meta = gas[GAS_META]
 			var/gas_overlay = gas_meta[META_GAS_OVERLAY]
 			if(gas_overlay && gas[MOLES] > gas_meta[META_GAS_MOLES_VISIBLE])
 				. += gas_overlay
+
+/proc/typecache_of_gases_with_no_overlays()
+	. = list()
+	for (var/gastype in subtypesof(/datum/gas))
+		var/datum/gas/gasvar = gastype
+		if (!initial(gasvar.gas_overlay))
+			.[gastype] = TRUE
 
 /////////////////////////////SIMULATION///////////////////////////////////
 

--- a/code/modules/atmospherics/gasmixtures/gas_mixture.dm
+++ b/code/modules/atmospherics/gasmixtures/gas_mixture.dm
@@ -285,8 +285,6 @@ GLOBAL_LIST_INIT(gaslist_cache, init_gaslist_cache())
 	return 1
 
 /datum/gas_mixture/share(datum/gas_mixture/sharer, atmos_adjacent_turfs = 4)
-	if(!sharer)
-		return 0
 
 	var/list/cached_gases = gases
 	var/list/sharer_gases = sharer.gases
@@ -322,7 +320,7 @@ GLOBAL_LIST_INIT(gaslist_cache, init_gaslist_cache())
 			if(delta > 0)
 				heat_capacity_self_to_sharer += gas_heat_capacity
 			else
-				heat_capacity_sharer_to_self -= gas_heat_capacity //subtract here instead of adding the absolute value because we know that delta is negative. saves a proc call.
+				heat_capacity_sharer_to_self -= gas_heat_capacity //subtract here instead of adding the absolute value because we know that delta is negative.
 
 		gas[MOLES]			-= delta
 		sharergas[MOLES]	+= delta
@@ -348,8 +346,7 @@ GLOBAL_LIST_INIT(gaslist_cache, init_gaslist_cache())
 				if(abs(new_sharer_heat_capacity/old_sharer_heat_capacity - 1) < 0.1) // <10% change in sharer heat capacity
 					temperature_share(sharer, OPEN_HEAT_TRANSFER_COEFFICIENT)
 
-	var/list/unique_gases = cached_gases ^ sharer_gases
-	if(unique_gases.len) //if all gases were present in both mixtures, we know that no gases are 0
+	if(length(cached_gases ^ sharer_gases)) //if all gases were present in both mixtures, we know that no gases are 0
 		garbage_collect(cached_gases - sharer_gases) //any gases the sharer had, we are guaranteed to have. gases that it didn't have we are not.
 		sharer.garbage_collect(sharer_gases - cached_gases) //the reverse is equally true
 	sharer.after_share(src, atmos_adjacent_turfs)
@@ -358,8 +355,7 @@ GLOBAL_LIST_INIT(gaslist_cache, init_gaslist_cache())
 		TOTAL_MOLES(cached_gases,our_moles)
 		var/their_moles
 		TOTAL_MOLES(sharer_gases,their_moles)
-		var/delta_pressure = temperature_archived*(our_moles + moved_moles) - sharer.temperature_archived*(their_moles - moved_moles)
-		return delta_pressure * R_IDEAL_GAS_EQUATION / volume
+		return (temperature_archived*(our_moles + moved_moles) - sharer.temperature_archived*(their_moles - moved_moles)) * R_IDEAL_GAS_EQUATION / volume
 
 /datum/gas_mixture/after_share(datum/gas_mixture/sharer, atmos_adjacent_turfs = 4)
 	return

--- a/code/modules/goonchat/browserOutput.dm
+++ b/code/modules/goonchat/browserOutput.dm
@@ -206,7 +206,18 @@ GLOBAL_DATUM_INIT(iconCache, /savefile, new("data/iconCache.sav")) //Cache of ic
 
 	for(var/I in targets)
 		//Grab us a client if possible
-		var/client/C = istype(I, /client) ? I : grab_client(I)
+		var/client/C
+		if (ismob(I))
+			var/mob/M = I
+			if(M.client)
+				C = M.client
+		else if(istype(I, /client))
+			C = I
+		else if(istype(I, /datum/mind))
+			var/datum/mind/M = I
+			if(M.current && M.current.client)
+				C = M.current.client
+			
 
 		if (!C)
 			continue
@@ -224,15 +235,3 @@ GLOBAL_DATUM_INIT(iconCache, /savefile, new("data/iconCache.sav")) //Cache of ic
 
 		// url_encode it TWICE, this way any UTF-8 characters are able to be decoded by the Javascript.
 		C << output(url_encode(url_encode(message)), "browseroutput:output")
-
-/proc/grab_client(target)
-	if(ismob(target))
-		var/mob/M = target
-		if(M.client)
-			return M.client
-	else if(istype(target, /datum/mind))
-		var/datum/mind/M = target
-		if(M.current && M.current.client)
-			return M.current.client
-	else if(istype(target, /client))
-		return target

--- a/code/modules/goonchat/browserOutput.dm
+++ b/code/modules/goonchat/browserOutput.dm
@@ -206,7 +206,7 @@ GLOBAL_DATUM_INIT(iconCache, /savefile, new("data/iconCache.sav")) //Cache of ic
 
 	for(var/I in targets)
 		//Grab us a client if possible
-		var/client/C = grab_client(I)
+		var/client/C = istype(I, /client) ? I : grab_client(I)
 
 		if (!C)
 			continue
@@ -226,9 +226,7 @@ GLOBAL_DATUM_INIT(iconCache, /savefile, new("data/iconCache.sav")) //Cache of ic
 		C << output(url_encode(url_encode(message)), "browseroutput:output")
 
 /proc/grab_client(target)
-	if(istype(target, /client))
-		return target
-	else if(ismob(target))
+	if(ismob(target))
 		var/mob/M = target
 		if(M.client)
 			return M.client
@@ -236,3 +234,5 @@ GLOBAL_DATUM_INIT(iconCache, /savefile, new("data/iconCache.sav")) //Cache of ic
 		var/datum/mind/M = target
 		if(M.current && M.current.client)
 			return M.current.client
+	else if(istype(target, /client))
+		return target


### PR DESCRIPTION
These are cherrypicked from my working branches and are (apart from the safe chat-opt) pretty much tested to death.

There's another micro-opt that can be done to share (removal of `var/temperature_delta`), but this introduces a change in functionality as it is used on line 353.




| Proc Name                                           | Self CPU | Total CPU | Real Time | Calls |
|-----------------------------------------------------|----------|-----------|-----------|-------|
 | /turf/open/proc/oldtile_graphic | 0.149 | 0.149 | 0.153 | 62493 |
 | /turf/open/proc/newtile_graphic   | 0.125  | 0.125  | 0.129  | 62281  |
 |/datum/gas_mixture/proc/oldshare   | 0.552    |     0.557    |     0.559     |    45670 |
 |/datum/gas_mixture/proc/newshare  | 0.504         |0.508     |    0.512     |    45582 |

:cl: Naksu
code: Sped up atmos very slightly
/:cl:
