### PR TITLE
Allows Non-Holy created Holy Water 

### DIFF
--- a/code/modules/reagents/chemistry/recipes/others.dm
+++ b/code/modules/reagents/chemistry/recipes/others.dm
@@ -592,3 +592,10 @@
 	id = "pax"
 	results = list("pax" = 3)
 	required_reagents  = list("mindbreaker" = 1, "synaptizine" = 1, "water" = 1)
+	
+	
+/datum/chemical_reaction/holywater
+	name = "Holy Water"
+	id = "holywater"
+	results = list("holywater" = 3)
+	required_reagents = list("water" = 1, "mercury" = 1, "wine" = 1)


### PR DESCRIPTION
Currently to acquire Holy Water to make Strange Reagent for your non cloneable species "Plasmaman" you require Holy Water. But to get it requires a Chaplain if they aren't off validhunting or sacrificing monkies to their Pray verb, or hope to God Cargo actually orders your holy materials crate.

🆑 
add: You can now make Holy Water; required for Strange Reagent, with Mercury, Water, and Wine. Finally Plasmaman and others will no longer stay dead forever.
/🆑
