### PR TITLE
Remaps the circuit lab to include less roundstart material and items

### DIFF
--- a/_maps/map_files/BoxStation/BoxStation.dmm
+++ b/_maps/map_files/BoxStation/BoxStation.dmm
@@ -37890,12 +37890,7 @@
 /obj/machinery/light{
 	dir = 1
 	},
-/obj/item/stack/sheet/metal/fifty,
-/turf/open/floor/plasteel/white,
-/area/science/circuit)
-"bRb" = (
-/obj/structure/table/reinforced,
-/obj/machinery/computer/libraryconsole/bookmanagement,
+/obj/item/stack/sheet/metal/ten,
 /turf/open/floor/plasteel/white,
 /area/science/circuit)
 "bRc" = (
@@ -53325,6 +53320,8 @@
 /obj/item/radio/intercom{
 	pixel_x = -30
 	},
+/obj/item/stock_parts/cell/high,
+/obj/item/stock_parts/cell/high,
 /turf/open/floor/plasteel/white,
 /area/science/circuit)
 "eyM" = (
@@ -53363,7 +53360,8 @@
 /turf/closed/wall/r_wall,
 /area/science/mixing)
 "flc" = (
-/obj/machinery/bookbinder,
+/obj/structure/table/reinforced,
+/obj/item/storage/fancy/donut_box,
 /turf/open/floor/plasteel/white,
 /area/science/circuit)
 "fnC" = (
@@ -53475,8 +53473,6 @@
 /obj/machinery/cell_charger{
 	pixel_y = 5
 	},
-/obj/item/stock_parts/cell/super,
-/obj/item/stock_parts/cell/super,
 /turf/open/floor/plasteel/white,
 /area/science/circuit)
 "ijc" = (
@@ -53541,7 +53537,6 @@
 /turf/open/floor/plasteel,
 /area/quartermaster/office)
 "jrE" = (
-/obj/machinery/rnd/production/protolathe/department/science,
 /obj/structure/sign/poster/official/random{
 	pixel_x = 32
 	},
@@ -53833,13 +53828,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/science/circuit)
-"qpv" = (
-/obj/machinery/light{
-	dir = 4
-	},
-/obj/machinery/autolathe,
-/turf/open/floor/plasteel/white,
-/area/science/circuit)
 "quT" = (
 /obj/structure/lattice,
 /obj/structure/grille/broken,
@@ -54043,6 +54031,7 @@
 	dir = 8;
 	pixel_x = -24
 	},
+/obj/item/stock_parts/cell/high,
 /turf/open/floor/plasteel/white,
 /area/science/circuit)
 "vCb" = (
@@ -54057,7 +54046,6 @@
 /obj/machinery/light{
 	dir = 4
 	},
-/obj/machinery/libraryscanner,
 /turf/open/floor/plasteel/white,
 /area/science/circuit)
 "wkN" = (
@@ -54089,9 +54077,7 @@
 "wvX" = (
 /obj/structure/table/reinforced,
 /obj/machinery/light,
-/obj/item/stock_parts/cell/super,
-/obj/item/stock_parts/cell/super,
-/obj/item/stack/sheet/metal/fifty,
+/obj/item/stack/sheet/metal/ten,
 /turf/open/floor/plasteel/white,
 /area/science/circuit)
 "wBd" = (
@@ -103907,16 +103893,16 @@ bMB
 bNA
 cOe
 bSl
-bRb
+bUq
 flc
 vPE
-bUq
+bXs
 bVt
 dfh
 jSO
 jgm
 oUh
-qpv
+vPE
 jrE
 saK
 bSl

--- a/_maps/map_files/Deltastation/DeltaStation2.dmm
+++ b/_maps/map_files/Deltastation/DeltaStation2.dmm
@@ -77164,19 +77164,17 @@
 /area/science/research/abandoned)
 "djp" = (
 /obj/structure/table/reinforced,
-/obj/item/stack/sheet/glass/fifty,
+/obj/machinery/cell_charger,
 /turf/open/floor/plasteel/white/side,
 /area/science/circuit)
 "djq" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/machinery/rnd/production/protolathe/department/science,
 /obj/machinery/light{
 	dir = 1
 	},
 /turf/open/floor/plasteel/white/side,
 /area/science/circuit)
 "djr" = (
-/obj/machinery/autolathe,
 /turf/open/floor/plasteel/white/side,
 /area/science/circuit)
 "djs" = (
@@ -78542,12 +78540,11 @@
 /area/crew_quarters/abandoned_gambling_den)
 "dmr" = (
 /obj/structure/table/reinforced,
-/obj/item/stack/sheet/metal/fifty,
-/obj/item/stock_parts/cell/super,
-/obj/item/stock_parts/cell/super,
 /obj/structure/sign/departments/science{
 	pixel_x = -32
 	},
+/obj/item/stock_parts/cell/high,
+/obj/item/stock_parts/cell/high,
 /turf/open/floor/plasteel/white/side{
 	dir = 4
 	},
@@ -79282,7 +79279,8 @@
 	pixel_x = -26
 	},
 /obj/effect/decal/cleanable/dirt,
-/obj/item/stack/sheet/metal/fifty,
+/obj/item/stock_parts/cell/high,
+/obj/item/stock_parts/cell/high,
 /turf/open/floor/plasteel/white/side{
 	dir = 4
 	},
@@ -80849,8 +80847,6 @@
 	pixel_y = -32
 	},
 /obj/machinery/cell_charger,
-/obj/item/stock_parts/cell/super,
-/obj/item/stock_parts/cell/super,
 /turf/open/floor/plasteel/white/side{
 	dir = 1
 	},
@@ -80884,16 +80880,16 @@
 	},
 /area/science/circuit)
 "drD" = (
-/obj/machinery/vending/assist,
 /turf/open/floor/plasteel/white/side{
 	dir = 1
 	},
 /area/science/circuit)
 "drE" = (
-/obj/machinery/bookbinder,
 /obj/structure/sign/poster/official/build{
 	pixel_y = -32
 	},
+/obj/structure/table/reinforced,
+/obj/item/storage/fancy/donut_box,
 /turf/open/floor/plasteel/white/side{
 	dir = 1
 	},
@@ -80902,11 +80898,11 @@
 /obj/machinery/light_switch{
 	pixel_x = 36
 	},
-/obj/machinery/libraryscanner,
 /obj/machinery/firealarm{
 	dir = 4;
 	pixel_x = 24
 	},
+/obj/machinery/vending/assist,
 /turf/open/floor/plasteel/white/corner{
 	dir = 1
 	},
@@ -99717,7 +99713,7 @@
 "gUH" = (
 /obj/machinery/light,
 /obj/structure/table/reinforced,
-/obj/machinery/computer/libraryconsole/bookmanagement,
+/obj/item/stack/sheet/metal/ten,
 /turf/open/floor/plasteel/white/side{
 	dir = 1
 	},

--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -75956,6 +75956,7 @@
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
+/obj/item/stack/sheet/metal/ten,
 /turf/open/floor/plasteel/white,
 /area/science/circuit)
 "eqG" = (
@@ -76017,10 +76018,6 @@
 /obj/structure/disposalpipe/segment{
 	dir = 10
 	},
-/turf/open/floor/plasteel/white,
-/area/science/circuit)
-"gfh" = (
-/obj/machinery/libraryscanner,
 /turf/open/floor/plasteel/white,
 /area/science/circuit)
 "gnZ" = (
@@ -76104,13 +76101,6 @@
 	},
 /turf/closed/wall/r_wall,
 /area/maintenance/disposal/incinerator)
-"hfJ" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/obj/machinery/autolathe,
-/turf/open/floor/plasteel/white,
-/area/science/circuit)
 "hvt" = (
 /obj/structure/kitchenspike_frame,
 /obj/effect/decal/cleanable/blood/gibs/old,
@@ -76174,9 +76164,6 @@
 /turf/closed/wall/mineral/plastitanium,
 /area/crew_quarters/fitness/recreation)
 "jyv" = (
-/obj/item/stock_parts/cell/super,
-/obj/item/stock_parts/cell/super,
-/obj/item/stack/sheet/metal/fifty,
 /obj/structure/table/reinforced,
 /obj/machinery/computer/security/telescreen{
 	desc = "Used for watching the RD's goons from the safety of your own office.";
@@ -76184,6 +76171,8 @@
 	network = list("rd");
 	pixel_y = 32
 	},
+/obj/item/stock_parts/cell/high,
+/obj/item/stock_parts/cell/high,
 /turf/open/floor/plasteel/white,
 /area/science/circuit)
 "jyQ" = (
@@ -76479,7 +76468,6 @@
 /obj/machinery/light{
 	dir = 1
 	},
-/obj/item/stock_parts/cell/super,
 /obj/structure/table/reinforced,
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
@@ -76490,8 +76478,8 @@
 	network = list("rd");
 	pixel_y = 32
 	},
-/obj/item/stock_parts/cell/super,
-/obj/item/stack/sheet/metal/fifty,
+/obj/item/stock_parts/cell/high,
+/obj/item/stock_parts/cell/high,
 /turf/open/floor/plasteel/white,
 /area/science/circuit)
 "ohj" = (
@@ -76710,11 +76698,6 @@
 /obj/structure/grille,
 /turf/open/floor/plating/airless,
 /area/space/nearstation)
-"sog" = (
-/obj/machinery/libraryscanner,
-/obj/machinery/bookbinder,
-/turf/open/floor/plasteel/white,
-/area/science/circuit)
 "sFv" = (
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
@@ -76756,11 +76739,6 @@
 "sJW" = (
 /turf/closed/wall/mineral/plastitanium,
 /area/engine/break_room)
-"tjH" = (
-/obj/structure/table/reinforced,
-/obj/machinery/computer/libraryconsole/bookmanagement,
-/turf/open/floor/plasteel/white,
-/area/science/circuit)
 "tsx" = (
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
@@ -76859,7 +76837,9 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
-/obj/machinery/rnd/production/protolathe/department/science,
+/obj/item/twohanded/required/kirbyplants{
+	icon_state = "plant-10"
+	},
 /turf/open/floor/plasteel/white,
 /area/science/circuit)
 "uYk" = (
@@ -113710,7 +113690,7 @@ cuZ
 fFM
 cud
 kxk
-tjH
+cxO
 cxO
 cxO
 dGH
@@ -114997,7 +114977,7 @@ mjJ
 krD
 eqq
 llb
-hfJ
+uTS
 cxO
 cxO
 krD
@@ -115256,7 +115236,7 @@ lsv
 txj
 eEe
 cxO
-gfh
+cxO
 krD
 aaa
 aaa
@@ -115513,7 +115493,7 @@ jyv
 ohj
 nnK
 cxO
-sog
+cxO
 krD
 aaa
 aaa

--- a/_maps/map_files/PubbyStation/PubbyStation.dmm
+++ b/_maps/map_files/PubbyStation/PubbyStation.dmm
@@ -24235,13 +24235,9 @@
 /area/science/explab)
 "blV" = (
 /obj/structure/table/reinforced,
-/obj/item/stack/sheet/metal/fifty{
-	pixel_x = -2;
-	pixel_y = 2
-	},
-/obj/item/stack/sheet/metal/fifty,
 /obj/item/clothing/glasses/science,
 /obj/item/clothing/glasses/science,
+/obj/item/stack/sheet/metal/ten,
 /turf/open/floor/plasteel/vault{
 	dir = 5
 	},
@@ -24645,10 +24641,10 @@
 /obj/machinery/cell_charger{
 	pixel_y = 5
 	},
-/obj/item/stock_parts/cell/super,
-/obj/item/stock_parts/cell/super,
-/obj/item/stock_parts/cell/super,
-/obj/item/stock_parts/cell/super,
+/obj/item/stock_parts/cell/high,
+/obj/item/stock_parts/cell/high,
+/obj/item/stock_parts/cell/high,
+/obj/item/stock_parts/cell/high,
 /turf/open/floor/plasteel/vault{
 	dir = 5
 	},
@@ -24987,7 +24983,9 @@
 /turf/open/floor/engine,
 /area/science/explab)
 "bnZ" = (
-/obj/machinery/rnd/production/techfab/department/science,
+/obj/item/twohanded/required/kirbyplants{
+	icon_state = "plant-10"
+	},
 /turf/open/floor/plasteel/vault{
 	dir = 5
 	},
@@ -48943,12 +48941,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/security/brig)
-"hOd" = (
-/obj/machinery/autolathe,
-/turf/open/floor/plasteel/vault{
-	dir = 5
-	},
-/area/science/explab)
 "hOx" = (
 /obj/structure/cable{
 	icon_state = "2-4"
@@ -96233,7 +96225,7 @@ bjx
 bjw
 qDJ
 vmG
-hOd
+bnZ
 pDP
 nBL
 bqs


### PR DESCRIPTION
[Changelogs]: # (Your PR should contain a detailed changelog of notable changes, titled and categorized appropriately. This includes, new features, sprites, sounds, balance changes, admin tools, map edits, removals, big refactors, config changes, hosting changes and important fixes. An example changelog has been provided below for you to edit. If you need additional help, read https://github.com/tgstation/tgstation/wiki/Changelogs)

:cl: Dax Dupont
balance: Circuit lab no longer starts with super batteries, they have been replaced with high batteries.
balance: Circuit labs now start with 20 sheets of metal instead of 50/100. Plenty of materials on the station you can gather.
balance: Circuit labs no longer have their own protolathe and autolathe. Science has their own lathes already. 
tweak: There's no more entire library worth of equipment, they can go publish the books like the rest of the station, in the library. At least give the librarians something other to do than screaming about lizard porn on the radio.
/:cl:

The insane powercreep that is circuit labs must be killed. 
They have their own protolathe, 50 stacks of metal, better batteries than robotics and even a fucking entire library.

Not anymore, this brings some much needed balance changes to circuit labs as advised by at least one maintainer.
