### PR TITLE
Thrower circuits can no longer throw the assembly it's in

### DIFF
--- a/code/modules/integrated_electronics/subtypes/manipulation.dm
+++ b/code/modules/integrated_electronics/subtypes/manipulation.dm
@@ -491,6 +491,8 @@
 	power_draw_per_use = 50
 
 /obj/item/integrated_circuit/manipulation/thrower/do_work()
+	if(A == assembly)
+		return
 	var/max_w_class = assembly.w_class
 	var/target_x_rel = round(get_pin_data(IC_INPUT, 1))
 	var/target_y_rel = round(get_pin_data(IC_INPUT, 2))


### PR DESCRIPTION
@optimumtact I'm hoping this will be a lighter-handed solution but only time will tell if this works.