### PR TITLE
Fixes runtime related to items on people taking fire damage after deletion

### DIFF
--- a/code/modules/mob/living/carbon/human/species.dm
+++ b/code/modules/mob/living/carbon/human/species.dm
@@ -1637,7 +1637,7 @@ GLOBAL_LIST_EMPTY(roundstart_races)
 
 		for(var/X in burning_items)
 			var/obj/item/I = X
-			if(!(I.resistance_flags & FIRE_PROOF))
+			if(!(I.resistance_flags & FIRE_PROOF) && !QDELETED(I))
 				I.take_damage(H.fire_stacks, BURN, "fire", 0)
 
 		var/thermal_protection = H.get_thermal_protection()


### PR DESCRIPTION
saw this while testing something else

[16:46:17] Runtime in unsorted.dm,1227: The chief engineer's jumpsuit taking damage after deletion
  proc name: stack trace (/datum/proc/stack_trace)
  src: the chief engineer\'s jumpsuit (/obj/item/clothing/under/rank/chief_engineer)
  src.loc: null
  call stack:
  the chief engineer\'s jumpsuit (/obj/item/clothing/under/rank/chief_engineer): stack trace("The chief engineer\'s jumpsuit...")
  the chief engineer\'s jumpsuit (/obj/item/clothing/under/rank/chief_engineer): take damage(19.9, "fire", "fire", 0, null, 0)
  Human (/datum/species/human): handle fire(Cristopher Moon (/mob/living/carbon/human), 0)
  Cristopher Moon (/mob/living/carbon/human): handle fire()
  Cristopher Moon (/mob/living/carbon/human): Life(2, 101)
  Cristopher Moon (/mob/living/carbon/human): Life(2, 101)
  Cristopher Moon (/mob/living/carbon/human): Life(2, 101)
  Mobs (/datum/controller/subsystem/mobs): fire(0)
  Mobs (/datum/controller/subsystem/mobs): ignite(0)
  Master (/datum/controller/master): RunQueue()
  Master (/datum/controller/master): Loop()
  Master (/datum/controller/master): StartProcessing(0)

simple fix, now it just checks if the item is qdel'd before it lets it take damage