### PR TITLE
Various atmos code cleanups and performance boosts

### DIFF
--- a/code/__DEFINES/atmospherics.dm
+++ b/code/__DEFINES/atmospherics.dm
@@ -256,11 +256,9 @@
 		out_var += cached_gases[total_moles_id][MOLES];\
 	}
 
-#define ASSERT_GAS(gas_id, gas_mixture) if (!gas_mixture.gases[gas_id]) { ADD_GAS(gas_id, gas_mixture.gases) };
+#define ASSERT_GAS(gas_id, cached_gases) if (!cached_gases[gas_id]) { ADD_GAS(gas_id, cached_gases) };
 
-#define RETURN_GAS_MOLES(gas_id, gas_mixture) (gas_mixture.gases[gas_id] ? gas_mixture.gases[gas_id][MOLES] : 0)
-
-#define RETURN_GAS_MOLES_CACHE(gas_id, gases) (gases[gas_id] ? gases[gas_id][MOLES] : 0) //used in cases where a cached gas list is used instead for performance reasons
+#define RETURN_GAS_MOLES(gas_id, cached_gases) (cached_gases[gas_id] ? cached_gases[gas_id][MOLES] : 0) 
 
 GLOBAL_LIST_INIT(pipe_paint_colors, list(
 		"amethyst" = rgb(130,43,255), //supplymain

--- a/code/__DEFINES/atmospherics.dm
+++ b/code/__DEFINES/atmospherics.dm
@@ -70,6 +70,10 @@
 #define REACTING		1
 #define STOP_REACTIONS 	2
 
+//Minimum values for reactions
+#define MINIMUM_HEAT_CAPACITY	0.0003
+#define MINIMUM_MOLE_COUNT		0.01
+
 // Pressure limits.
 #define HAZARD_HIGH_PRESSURE				550		//This determins at what pressure the ultra-high pressure red icon is displayed. (This one is set as a constant)
 #define WARNING_HIGH_PRESSURE				325		//This determins when the orange pressure icon is displayed (it is 0.7 * HAZARD_HIGH_PRESSURE)
@@ -88,7 +92,6 @@
 
 #define BODYTEMP_HEAT_DAMAGE_LIMIT			(BODYTEMP_NORMAL + 50) // The limit the human body can take before it starts taking damage from heat.
 #define BODYTEMP_COLD_DAMAGE_LIMIT			(BODYTEMP_NORMAL - 50) // The limit the human body can take before it starts taking damage from coldness.
-
 
 #define SPACE_HELM_MIN_TEMP_PROTECT			2.0		//what min_cold_protection_temperature is set to for space-helmet quality headwear. MUST NOT BE 0.
 #define SPACE_HELM_MAX_TEMP_PROTECT			1500	//Thermal insulation works both ways /Malkevin
@@ -242,10 +245,22 @@
 //HELPERS
 #define THERMAL_ENERGY(gas) (gas.temperature * gas.heat_capacity())
 
+#define QUANTIZE(variable)		(round(variable,0.0000001))/*I feel the need to document what happens here. Basically this is used to catch most rounding errors, however it's previous value made it so that
+															once gases got hot enough, most procedures wouldnt occur due to the fact that the mole counts would get rounded away. Thus, we lowered it a few orders of magnititude */
 #define ADD_GAS(gas_id, out_list)\
 	var/list/tmp_gaslist = GLOB.gaslist_cache[gas_id]; out_list[gas_id] = tmp_gaslist.Copy();
 
+#define TOTAL_MOLES(cached_gases, out_var)\
+	out_var = 0;\
+	for(var/total_moles_id in cached_gases){\
+		out_var += cached_gases[total_moles_id][MOLES];\
+	}
+
 #define ASSERT_GAS(gas_id, gas_mixture) if (!gas_mixture.gases[gas_id]) { ADD_GAS(gas_id, gas_mixture.gases) };
+
+#define RETURN_GAS_MOLES(gas_id, gas_mixture) (gas_mixture.gases[gas_id] ? gas_mixture.gases[gas_id][MOLES] : 0)
+
+#define RETURN_GAS_MOLES_CACHE(gas_id, gases) (gases[gas_id] ? gases[gas_id][MOLES] : 0) //used in cases where a cached gas list is used instead for performance reasons
 
 GLOBAL_LIST_INIT(pipe_paint_colors, list(
 		"amethyst" = rgb(130,43,255), //supplymain

--- a/code/game/objects/effects/spawners/bombspawner.dm
+++ b/code/game/objects/effects/spawners/bombspawner.dm
@@ -19,11 +19,11 @@
 	var/obj/item/tank/internals/plasma/PT = new(V)
 	var/obj/item/tank/internals/oxygen/OT = new(V)
 
-	PT.air_contents.assert_gas(/datum/gas/plasma)
+	PT.air_contents.add_gas(/datum/gas/plasma)
 	PT.air_contents.gases[/datum/gas/plasma][MOLES] = pressure_p*PT.volume/(R_IDEAL_GAS_EQUATION*CELSIUS_TO_KELVIN(temp_p))
 	PT.air_contents.temperature = CELSIUS_TO_KELVIN(temp_p)
 
-	OT.air_contents.assert_gas(/datum/gas/oxygen)
+	OT.air_contents.add_gas(/datum/gas/oxygen)
 	OT.air_contents.gases[/datum/gas/oxygen][MOLES] = pressure_o*OT.volume/(R_IDEAL_GAS_EQUATION*CELSIUS_TO_KELVIN(temp_o))
 	OT.air_contents.temperature = CELSIUS_TO_KELVIN(temp_o)
 

--- a/code/game/objects/items/tanks/jetpack.dm
+++ b/code/game/objects/items/tanks/jetpack.dm
@@ -17,7 +17,7 @@
 /obj/item/tank/jetpack/New()
 	..()
 	if(gas_type)
-		air_contents.assert_gas(gas_type)
+		air_contents.add_gas(gas_type)
 		air_contents.gases[gas_type][MOLES] = (6 * ONE_ATMOSPHERE) * volume / (R_IDEAL_GAS_EQUATION * T20C)
 
 	ion_trail = new

--- a/code/game/objects/items/tanks/tank_types.dm
+++ b/code/game/objects/items/tanks/tank_types.dm
@@ -21,7 +21,7 @@
 
 /obj/item/tank/internals/oxygen/New()
 	..()
-	air_contents.assert_gas(/datum/gas/oxygen)
+	air_contents.add_gas(/datum/gas/oxygen)
 	air_contents.gases[/datum/gas/oxygen][MOLES] = (6*ONE_ATMOSPHERE)*volume/(R_IDEAL_GAS_EQUATION*T20C)
 	return
 
@@ -49,7 +49,7 @@
 
 /obj/item/tank/internals/anesthetic/New()
 	..()
-	air_contents.assert_gases(/datum/gas/oxygen, /datum/gas/nitrous_oxide)
+	air_contents.add_gases(/datum/gas/oxygen, /datum/gas/nitrous_oxide)
 	air_contents.gases[/datum/gas/oxygen][MOLES] = (3*ONE_ATMOSPHERE)*volume/(R_IDEAL_GAS_EQUATION*T20C) * O2STANDARD
 	air_contents.gases[/datum/gas/nitrous_oxide][MOLES] = (3*ONE_ATMOSPHERE)*volume/(R_IDEAL_GAS_EQUATION*T20C) * N2STANDARD
 	return
@@ -67,7 +67,7 @@
 
 /obj/item/tank/internals/air/New()
 	..()
-	air_contents.assert_gases(/datum/gas/oxygen, /datum/gas/nitrogen)
+	air_contents.add_gases(/datum/gas/oxygen, /datum/gas/nitrogen)
 	air_contents.gases[/datum/gas/oxygen][MOLES] = (6*ONE_ATMOSPHERE)*volume/(R_IDEAL_GAS_EQUATION*T20C) * O2STANDARD
 	air_contents.gases[/datum/gas/nitrogen][MOLES] = (6*ONE_ATMOSPHERE)*volume/(R_IDEAL_GAS_EQUATION*T20C) * N2STANDARD
 	return
@@ -87,7 +87,7 @@
 
 /obj/item/tank/internals/plasma/New()
 	..()
-	air_contents.assert_gas(/datum/gas/plasma)
+	air_contents.add_gas(/datum/gas/plasma)
 	air_contents.gases[/datum/gas/plasma][MOLES] = (3*ONE_ATMOSPHERE)*volume/(R_IDEAL_GAS_EQUATION*T20C)
 	return
 
@@ -124,7 +124,7 @@
 
 /obj/item/tank/internals/plasmaman/New()
 	..()
-	air_contents.assert_gas(/datum/gas/plasma)
+	air_contents.add_gas(/datum/gas/plasma)
 	air_contents.gases[/datum/gas/plasma][MOLES] = (3*ONE_ATMOSPHERE)*volume/(R_IDEAL_GAS_EQUATION*T20C)
 	return
 
@@ -166,7 +166,7 @@
 
 /obj/item/tank/internals/emergency_oxygen/New()
 	..()
-	air_contents.assert_gas(/datum/gas/oxygen)
+	air_contents.add_gas(/datum/gas/oxygen)
 	air_contents.gases[/datum/gas/oxygen][MOLES] = (3*ONE_ATMOSPHERE)*volume/(R_IDEAL_GAS_EQUATION*T20C)
 	return
 

--- a/code/game/turfs/change_turf.dm
+++ b/code/game/turfs/change_turf.dm
@@ -271,7 +271,7 @@ GLOBAL_LIST_INIT(blacklisted_automated_baseturfs, typecacheof(list(
 			continue
 		var/list/S_gases = S.air.gases
 		for(var/id in S_gases)
-			ASSERT_GAS(id, total)
+			ASSERT_GAS(id, total_gases)
 			total_gases[id][MOLES] += S_gases[id][MOLES]
 		total.temperature += S.air.temperature
 

--- a/code/game/turfs/open.dm
+++ b/code/game/turfs/open.dm
@@ -257,10 +257,11 @@
 
 /turf/open/rad_act(pulse_strength)
 	. = ..()
-	if (air.gases[/datum/gas/carbon_dioxide] && air.gases[/datum/gas/oxygen])
-		pulse_strength = min(pulse_strength,air.gases[/datum/gas/carbon_dioxide][MOLES]*1000,air.gases[/datum/gas/oxygen][MOLES]*2000) //Ensures matter is conserved properly
-		air.gases[/datum/gas/carbon_dioxide][MOLES]=max(air.gases[/datum/gas/carbon_dioxide][MOLES]-(pulse_strength/1000),0)
-		air.gases[/datum/gas/oxygen][MOLES]=max(air.gases[/datum/gas/oxygen][MOLES]-(pulse_strength/2000),0)
-		air.assert_gas(/datum/gas/pluoxium)
-		air.gases[/datum/gas/pluoxium][MOLES]+=(pulse_strength/4000)
+	var/cached_gases = air.gases
+	if (cached_gases[/datum/gas/carbon_dioxide] && cached_gases[/datum/gas/oxygen])
+		pulse_strength = min(pulse_strength,cached_gases[/datum/gas/carbon_dioxide][MOLES]*1000,cached_gases[/datum/gas/oxygen][MOLES]*2000) //Ensures matter is conserved properly
+		cached_gases[/datum/gas/carbon_dioxide][MOLES]=max(cached_gases[/datum/gas/carbon_dioxide][MOLES]-(pulse_strength/1000),0)
+		cached_gases[/datum/gas/oxygen][MOLES]=max(cached_gases[/datum/gas/oxygen][MOLES]-(pulse_strength/2000),0)
+		ASSERT_GAS(/datum/gas/pluoxium, cached_gases)
+		cached_gases[/datum/gas/pluoxium][MOLES]+=(pulse_strength/4000)
 		air.garbage_collect()

--- a/code/modules/atmospherics/environmental/LINDA_fire.dm
+++ b/code/modules/atmospherics/environmental/LINDA_fire.dm
@@ -16,9 +16,11 @@
 	if(!air_contents)
 		return FALSE
 
-	var/oxygen = RETURN_GAS_MOLES(/datum/gas/oxygen, air_contents)
-	var/plasma = RETURN_GAS_MOLES(/datum/gas/plasma, air_contents)
-	var/tritium = RETURN_GAS_MOLES(/datum/gas/tritium, air_contents)
+	var/cached_gases = air_contents.gases
+
+	var/oxygen = RETURN_GAS_MOLES(/datum/gas/oxygen, cached_gases)
+	var/plasma = RETURN_GAS_MOLES(/datum/gas/plasma, cached_gases)
+	var/tritium = RETURN_GAS_MOLES(/datum/gas/tritium, cached_gases)
 	if(active_hotspot)
 		if(soh)
 			if(SUFFICIENT_HYDROCARBONS && SUFFICIENT_OXYGEN)
@@ -47,7 +49,6 @@
 	else	
 		var/datum/gas_mixture/heating = air_contents.remove_ratio(exposed_volume/air_contents.volume)
 		heating.temperature = exposed_temperature
-		heating.react()
 		assume_air(heating)
 	return igniting
 

--- a/code/modules/atmospherics/gasmixtures/gas_mixture.dm
+++ b/code/modules/atmospherics/gasmixtures/gas_mixture.dm
@@ -177,7 +177,7 @@ GLOBAL_LIST_INIT(gaslist_cache, init_gaslist_cache())
 	var/list/giver_gases = giver.gases
 	//gas transfer
 	for(var/giver_id in giver_gases)
-		ASSERT_GAS(giver_id, gases)
+		ASSERT_GAS(giver_id, cached_gases)
 		cached_gases[giver_id][MOLES] += giver_gases[giver_id][MOLES]
 
 	return 1

--- a/code/modules/atmospherics/gasmixtures/gas_mixture.dm
+++ b/code/modules/atmospherics/gasmixtures/gas_mixture.dm
@@ -38,12 +38,13 @@ GLOBAL_LIST_INIT(gaslist_cache, init_gaslist_cache())
 	//assert_gas(gas_id) - used to guarantee that the gas list for this id exists in gas_mixture.gases.
 	//Must be used before adding to a gas. May be used before reading from a gas.
 /datum/gas_mixture/proc/assert_gas(gas_id)
-	ASSERT_GAS(gas_id, src)
+	ASSERT_GAS(gas_id, gases)
 
 	//assert_gases(args) - shorthand for calling ASSERT_GAS() once for each gas type.
 /datum/gas_mixture/proc/assert_gases()
+	var/cached_gases = gases
 	for(var/id in args)
-		ASSERT_GAS(id, src)
+		ASSERT_GAS(id, cached_gases)
 
 	//add_gas(gas_id) - similar to assert_gas(), but does not check for an existing
 		//gas list for this id. This can clobber existing gases.
@@ -372,8 +373,8 @@ GLOBAL_LIST_INIT(gaslist_cache, init_gaslist_cache())
 	var/list/cached_gases = gases
 
 	for(var/id in cached_gases | sample_gases) // compare gases from either mixture
-		var/gas_moles = RETURN_GAS_MOLES_CACHE(id, cached_gases)
-		var/sample_moles = RETURN_GAS_MOLES_CACHE(id, sample_gases)
+		var/gas_moles = RETURN_GAS_MOLESE(id, cached_gases)
+		var/sample_moles = RETURN_GAS_MOLES(id, sample_gases)
 		var/delta = abs(gas_moles - sample_moles)
 		if(delta > MINIMUM_MOLES_DELTA_TO_MOVE && \
 			delta > gas_moles * MINIMUM_AIR_RATIO_TO_MOVE)

--- a/code/modules/atmospherics/gasmixtures/gas_mixture.dm
+++ b/code/modules/atmospherics/gasmixtures/gas_mixture.dm
@@ -177,7 +177,7 @@ GLOBAL_LIST_INIT(gaslist_cache, init_gaslist_cache())
 	var/list/giver_gases = giver.gases
 	//gas transfer
 	for(var/giver_id in giver_gases)
-		ASSERT_GAS(giver_id, src)
+		ASSERT_GAS(giver_id, gases)
 		cached_gases[giver_id][MOLES] += giver_gases[giver_id][MOLES]
 
 	return 1
@@ -239,7 +239,7 @@ GLOBAL_LIST_INIT(gaslist_cache, init_gaslist_cache())
 
 	temperature = sample.temperature
 	for(var/id in sample_gases)
-		ASSERT_GAS(id,src)
+		ASSERT_GAS(id, cached_gases)
 		cached_gases[id][MOLES] = sample_gases[id][MOLES]
 
 	//remove all gases not in the sample
@@ -298,7 +298,7 @@ GLOBAL_LIST_INIT(gaslist_cache, init_gaslist_cache())
 	for(var/id in sharer_gases - cached_gases) // create gases not in our cache
 		ADD_GAS(id, gases)
 	for(var/id in cached_gases) // transfer gases
-		ASSERT_GAS(id, sharer)
+		ASSERT_GAS(id, sharer_gases)
 
 		var/gas = cached_gases[id]
 		var/sharergas = sharer_gases[id]

--- a/code/modules/atmospherics/gasmixtures/gas_mixture.dm
+++ b/code/modules/atmospherics/gasmixtures/gas_mixture.dm
@@ -373,7 +373,7 @@ GLOBAL_LIST_INIT(gaslist_cache, init_gaslist_cache())
 	var/list/cached_gases = gases
 
 	for(var/id in cached_gases | sample_gases) // compare gases from either mixture
-		var/gas_moles = RETURN_GAS_MOLESE(id, cached_gases)
+		var/gas_moles = RETURN_GAS_MOLES(id, cached_gases)
 		var/sample_moles = RETURN_GAS_MOLES(id, sample_gases)
 		var/delta = abs(gas_moles - sample_moles)
 		if(delta > MINIMUM_MOLES_DELTA_TO_MOVE && \

--- a/code/modules/atmospherics/gasmixtures/immutable_mixtures.dm
+++ b/code/modules/atmospherics/gasmixtures/immutable_mixtures.dm
@@ -23,9 +23,6 @@
 	. = ..(sharer, 0)
 	garbage_collect()
 
-/datum/gas_mixture/immutable/after_share()
-	garbage_collect()
-
 /datum/gas_mixture/immutable/react()
 	return 0 //we're immutable.
 

--- a/code/modules/atmospherics/gasmixtures/reactions.dm
+++ b/code/modules/atmospherics/gasmixtures/reactions.dm
@@ -152,7 +152,7 @@
 		if(location && prob(10) && burned_fuel > TRITIUM_MINIMUM_RADIATION_ENERGY) //woah there let's not crash the server
 			radiation_pulse(location, energy_released/TRITIUM_BURN_RADIOACTIVITY_FACTOR)
 
-		ASSERT_GAS(/datum/gas/water_vapor, air) //oxygen+more-or-less hydrogen=H2O
+		ASSERT_GAS(/datum/gas/water_vapor, cached_gases) //oxygen+more-or-less hydrogen=H2O
 		cached_gases[/datum/gas/water_vapor][MOLES] += burned_fuel/TRITIUM_BURN_OXY_FACTOR
 
 		cached_results["fire"] += burned_fuel
@@ -222,10 +222,10 @@
 			cached_gases[/datum/gas/plasma][MOLES] = QUANTIZE(cached_gases[/datum/gas/plasma][MOLES] - plasma_burn_rate)
 			cached_gases[/datum/gas/oxygen][MOLES] = QUANTIZE(cached_gases[/datum/gas/oxygen][MOLES] - (plasma_burn_rate * oxygen_burn_rate))
 			if (super_saturation)
-				ASSERT_GAS(/datum/gas/tritium,air)
+				ASSERT_GAS(/datum/gas/tritium,cached_gases)
 				cached_gases[/datum/gas/tritium][MOLES] += plasma_burn_rate
 			else
-				ASSERT_GAS(/datum/gas/carbon_dioxide,air)
+				ASSERT_GAS(/datum/gas/carbon_dioxide,cached_gases)
 				cached_gases[/datum/gas/carbon_dioxide][MOLES] += plasma_burn_rate
 
 			energy_released += FIRE_PLASMA_ENERGY_RELEASED * (plasma_burn_rate)
@@ -371,7 +371,7 @@
 	var/old_heat_capacity = air.heat_capacity()
 	var/heat_efficency = min(temperature/(FIRE_MINIMUM_TEMPERATURE_TO_EXIST*100),cached_gases[/datum/gas/oxygen][MOLES],cached_gases[/datum/gas/nitrogen][MOLES])
 	var/energy_used = heat_efficency*NITRYL_FORMATION_ENERGY
-	ASSERT_GAS(/datum/gas/nitryl,air)
+	ASSERT_GAS(/datum/gas/nitryl,cached_gases)
 	if ((cached_gases[/datum/gas/oxygen][MOLES] - heat_efficency < 0 )|| (cached_gases[/datum/gas/nitrogen][MOLES] - heat_efficency < 0)) //Shouldn't produce gas from nothing.
 		return NO_REACTION
 	cached_gases[/datum/gas/oxygen][MOLES] -= heat_efficency
@@ -406,7 +406,7 @@
 	var/energy_released = 2*reaction_efficency*FIRE_CARBON_ENERGY_RELEASED
 	if ((cached_gases[/datum/gas/tritium][MOLES] - reaction_efficency < 0 )|| (cached_gases[/datum/gas/plasma][MOLES] - (2*reaction_efficency) < 0)) //Shouldn't produce gas from nothing.
 		return NO_REACTION
-	ASSERT_GAS(/datum/gas/bz,air)
+	ASSERT_GAS(/datum/gas/bz,cached_gases)
 	cached_gases[/datum/gas/bz][MOLES] += reaction_efficency
 	cached_gases[/datum/gas/tritium][MOLES] -= reaction_efficency
 	cached_gases[/datum/gas/plasma][MOLES]  -= 2*reaction_efficency
@@ -437,7 +437,7 @@
 	var/heat_scale = min(air.temperature/STIMULUM_HEAT_SCALE,cached_gases[/datum/gas/tritium][MOLES],cached_gases[/datum/gas/plasma][MOLES],cached_gases[/datum/gas/nitryl][MOLES])
 	var/stim_energy_change = heat_scale + STIMULUM_FIRST_RISE*(heat_scale**2) - STIMULUM_FIRST_DROP*(heat_scale**3) + STIMULUM_SECOND_RISE*(heat_scale**4) - STIMULUM_ABSOLUTE_DROP*(heat_scale**5)
 
-	ASSERT_GAS(/datum/gas/stimulum,air)
+	ASSERT_GAS(/datum/gas/stimulum,cached_gases)
 	if ((cached_gases[/datum/gas/tritium][MOLES] - heat_scale < 0 )|| (cached_gases[/datum/gas/plasma][MOLES] - heat_scale < 0) || (cached_gases[/datum/gas/nitryl][MOLES] - heat_scale < 0)) //Shouldn't produce gas from nothing.
 		return NO_REACTION
 	cached_gases[/datum/gas/stimulum][MOLES]+= heat_scale/10

--- a/code/modules/atmospherics/machinery/components/unary_devices/tank.dm
+++ b/code/modules/atmospherics/machinery/components/unary_devices/tank.dm
@@ -17,7 +17,7 @@
 	air_contents.volume = volume
 	air_contents.temperature = T20C
 	if(gas_type)
-		air_contents.assert_gas(gas_type)
+		air_contents.add_gas(gas_type)
 		air_contents.gases[gas_type][MOLES] = AIR_CONTENTS
 		name = "[name] ([air_contents.gases[gas_type][GAS_META][META_GAS_NAME]])"
 
@@ -44,6 +44,6 @@
 /obj/machinery/atmospherics/components/unary/tank/air/New()
 	..()
 	var/datum/gas_mixture/air_contents = airs[1]
-	air_contents.assert_gases(/datum/gas/oxygen, /datum/gas/nitrogen)
+	air_contents.add_gases(/datum/gas/oxygen, /datum/gas/nitrogen)
 	air_contents.gases[/datum/gas/oxygen][MOLES] = AIR_CONTENTS * 0.2
 	air_contents.gases[/datum/gas/nitrogen][MOLES] = AIR_CONTENTS * 0.8

--- a/code/modules/atmospherics/machinery/other/miner.dm
+++ b/code/modules/atmospherics/machinery/other/miner.dm
@@ -131,7 +131,7 @@
 	if(!isopenturf(O))
 		return FALSE
 	var/datum/gas_mixture/merger = new
-	merger.assert_gas(spawn_id)
+	merger.add_gas(spawn_id)
 	merger.gases[spawn_id][MOLES] = (spawn_mol)
 	merger.temperature = spawn_temp
 	O.assume_air(merger)


### PR DESCRIPTION
- adds RETURN_GAS_MOLES for ease of use
- ASSERT_GAS now uses cached gas lists woohoo this increases performance a presumably measurable amount but I am too lazy (right now) to measure it
- moves some errant defines in gas_mixture.dm to their proper place in __DEFINES\atmospherics.dm
- cleans up hotspot_expose() a hell of a lot with defines (in preparation for touching it later)
at some point im just going to go through and change every instance of the code that still refers to plasma as "toxins" or "tox"
- removes useless react() call in hotspot_expose(). the subsystems already handle that, you dont need to do it manually---especially not after failing a check for high temperatures and for plasma/tritium. in fact after some theorycrafting i realized that this react call being here can result in an exploit where you can bypass hypernoblium's oppression threshold on turfs up to a certain point because it's called on only a slice (remove_ratio) of the original air contents and then assimilated into the air contents
- removes the /datum/gas_mixture proc after_share() because it did literally nothing, was only ever called in one place, and was only referenced like four times. now we have a nanosecond more cpu time to spare since share() doesn't call it
- tank, jetpacks, atmos miners and bomb spawners New() now uses add_gas instead of assert_gas because its faster

[why]: # lots of atmos code is a mess and this is just the tip of the iceberg
untested right now but that'll change obviously