### PR TITLE
fixes anomaly cores being flamable

### DIFF
--- a/code/modules/assembly/signaler.dm
+++ b/code/modules/assembly/signaler.dm
@@ -187,6 +187,7 @@ Code:
 	lefthand_file = 'icons/mob/inhands/misc/devices_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/misc/devices_righthand.dmi'
 	var/anomaly_type = /obj/effect/anomaly
+	resistance_flags = FIRE_PROOF
 
 /obj/item/assembly/signaler/anomaly/receive_signal(datum/signal/signal)
 	if(!signal)

--- a/code/modules/assembly/signaler.dm
+++ b/code/modules/assembly/signaler.dm
@@ -186,8 +186,8 @@ Code:
 	item_state = "electronic"
 	lefthand_file = 'icons/mob/inhands/misc/devices_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/misc/devices_righthand.dmi'
-	var/anomaly_type = /obj/effect/anomaly
 	resistance_flags = FIRE_PROOF
+	var/anomaly_type = /obj/effect/anomaly
 
 /obj/item/assembly/signaler/anomaly/receive_signal(datum/signal/signal)
 	if(!signal)


### PR DESCRIPTION


:cl: 
fix: anomaly cores no longer tend to dust
/:cl:

[why]: the pyro anomaly causes loads of fires and hot air and when it gets pinged it burns down before you can pick it up