### PR TITLE
Cyborgs now drop radio keys on detonation/destruction

### DIFF
--- a/code/modules/mob/living/silicon/robot/robot.dm
+++ b/code/modules/mob/living/silicon/robot/robot.dm
@@ -162,7 +162,7 @@
 
 //If there's an MMI in the robot, have it ejected when the mob goes away. --NEO
 /mob/living/silicon/robot/Destroy()
-	var/turf/T = drop_location()//To hopefully prevent run time errors.
+	var/atom/T = drop_location()//To hopefully prevent run time errors.
 	if(mmi && mind)//Safety for when a cyborg gets dust()ed. Or there is no MMI inside.
 		if(T)
 			mmi.forceMove(T)

--- a/code/modules/mob/living/silicon/robot/robot.dm
+++ b/code/modules/mob/living/silicon/robot/robot.dm
@@ -162,7 +162,7 @@
 
 //If there's an MMI in the robot, have it ejected when the mob goes away. --NEO
 /mob/living/silicon/robot/Destroy()
-	var/turf/T = get_turf(loc)//To hopefully prevent run time errors.
+	var/turf/T = drop_location()//To hopefully prevent run time errors.
 	if(mmi && mind)//Safety for when a cyborg gets dust()ed. Or there is no MMI inside.
 		if(T)
 			mmi.forceMove(T)

--- a/code/modules/mob/living/silicon/robot/robot.dm
+++ b/code/modules/mob/living/silicon/robot/robot.dm
@@ -180,6 +180,9 @@
 		mmi = null
 	if(connected_ai)
 		connected_ai.connected_robots -= src
+	if(istype(radio) && istype(radio.keyslot))
+		radio.keyslot.forceMove(T)
+		radio.keyslot = null
 	if(shell)
 		GLOB.available_ai_shells -= src
 	qdel(wires)

--- a/code/modules/mob/living/silicon/robot/robot.dm
+++ b/code/modules/mob/living/silicon/robot/robot.dm
@@ -162,8 +162,8 @@
 
 //If there's an MMI in the robot, have it ejected when the mob goes away. --NEO
 /mob/living/silicon/robot/Destroy()
+	var/turf/T = get_turf(loc)//To hopefully prevent run time errors.
 	if(mmi && mind)//Safety for when a cyborg gets dust()ed. Or there is no MMI inside.
-		var/turf/T = get_turf(loc)//To hopefully prevent run time errors.
 		if(T)
 			mmi.forceMove(T)
 		if(mmi.brainmob)
@@ -180,11 +180,12 @@
 		mmi = null
 	if(connected_ai)
 		connected_ai.connected_robots -= src
-	if(istype(radio) && istype(radio.keyslot))
-		radio.keyslot.forceMove(T)
-		radio.keyslot = null
 	if(shell)
 		GLOB.available_ai_shells -= src
+	else
+		if(T && istype(radio) && istype(radio.keyslot))
+			radio.keyslot.forceMove(T)
+			radio.keyslot = null
 	qdel(wires)
 	qdel(module)
 	qdel(eye_lights)


### PR DESCRIPTION
Why: Radio keys as of now are not replaceable, and being able to retrieve them from destroyed cyborgs would be a useful thing.
:cl:
rscadd: Cyborgs now drop keys on deconstruction/detonation
/:cl: