### PR TITLE
Prevents grabbers from holding circuit assemblies.

### DIFF
--- a/code/modules/integrated_electronics/subtypes/manipulation.dm
+++ b/code/modules/integrated_electronics/subtypes/manipulation.dm
@@ -367,7 +367,7 @@
 	var/atom/movable/acting_object = get_object()
 	var/turf/T = get_turf(acting_object)
 	var/obj/item/AM = get_pin_data_as_type(IC_INPUT, 1, /obj/item)
-	if(AM)
+	if(!QDELETED(AM) && !istype(AM, /obj/item/electronic_assembly))
 		var/mode = get_pin_data(IC_INPUT, 2)
 		if(mode == 1)
 			if(check_target(AM))


### PR DESCRIPTION
⚖️ Prevents grabbers from holding circuit assemblies.

Preventing grabbers from holding other circuits is a simple (one-line) fix that strongly nerfs so-called 'uberthrower' circuits, dropping their damage output drastically. Uberthrower circuits are one of the most famous unintended uses of circuits.

:cl:
tweak: Grabbers can no longer hold circuit assemblies
/:cl:

Fixes #38587
