### PR TITLE
[s]Fixed being able to create nearly infinite amount of materials from autolathes

### DIFF
--- a/code/game/machinery/autolathe.dm
+++ b/code/game/machinery/autolathe.dm
@@ -154,7 +154,7 @@
 
 			var/multiplier = text2num(href_list["multiplier"])
 			var/is_stack = ispath(being_built.build_path, /obj/item/stack)
-			multiplier = CLAMP(multiplier,1,10)
+			multiplier = CLAMP(multiplier,1,30)
 
 			/////////////////
 

--- a/code/game/machinery/autolathe.dm
+++ b/code/game/machinery/autolathe.dm
@@ -154,7 +154,7 @@
 
 			var/multiplier = text2num(href_list["multiplier"])
 			var/is_stack = ispath(being_built.build_path, /obj/item/stack)
-			multiplier = CLAMP(multiplier,1,30)
+			multiplier = CLAMP(multiplier,1,50)
 
 			/////////////////
 

--- a/code/game/machinery/autolathe.dm
+++ b/code/game/machinery/autolathe.dm
@@ -154,6 +154,7 @@
 
 			var/multiplier = text2num(href_list["multiplier"])
 			var/is_stack = ispath(being_built.build_path, /obj/item/stack)
+			multiplier = CLAMP(multiplier,1,10)
 
 			/////////////////
 


### PR DESCRIPTION
[Changelogs]: # Essentially, you were able to edit the multiplier via an href exploit that allowed for you to create nearly infinite materials from autolathes
![image](https://user-images.githubusercontent.com/31262308/41633230-cfc310b6-740b-11e8-94c0-3d80efb3c5bb.png)


:cl: 
fix: added a clamp so you can't set a negative multiplier to create materials and create more than 50 items.
/:cl:

[why]: # People were able to crash downstream servers with this so this would be a temporary fix until the href vulnerability is sorted out. I'm not too keen on hrefs personally but this should fix the gamebreaking part of the exploit for now (since you shouldn't be making less than 1 item nor more than 50 items)