### PR TITLE
Revert "Remaps the circuit lab to include less roundstart material and items"

### DIFF
--- a/_maps/map_files/BoxStation/BoxStation.dmm
+++ b/_maps/map_files/BoxStation/BoxStation.dmm
@@ -37890,7 +37890,12 @@
 /obj/machinery/light{
 	dir = 1
 	},
-/obj/item/stack/sheet/metal/ten,
+/obj/item/stack/sheet/metal/fifty,
+/turf/open/floor/plasteel/white,
+/area/science/circuit)
+"bRb" = (
+/obj/structure/table/reinforced,
+/obj/machinery/computer/libraryconsole/bookmanagement,
 /turf/open/floor/plasteel/white,
 /area/science/circuit)
 "bRc" = (
@@ -53320,8 +53325,6 @@
 /obj/item/radio/intercom{
 	pixel_x = -30
 	},
-/obj/item/stock_parts/cell/high,
-/obj/item/stock_parts/cell/high,
 /turf/open/floor/plasteel/white,
 /area/science/circuit)
 "eyM" = (
@@ -53360,8 +53363,7 @@
 /turf/closed/wall/r_wall,
 /area/science/mixing)
 "flc" = (
-/obj/structure/table/reinforced,
-/obj/item/storage/fancy/donut_box,
+/obj/machinery/bookbinder,
 /turf/open/floor/plasteel/white,
 /area/science/circuit)
 "fnC" = (
@@ -53473,6 +53475,8 @@
 /obj/machinery/cell_charger{
 	pixel_y = 5
 	},
+/obj/item/stock_parts/cell/super,
+/obj/item/stock_parts/cell/super,
 /turf/open/floor/plasteel/white,
 /area/science/circuit)
 "ijc" = (
@@ -53537,6 +53541,7 @@
 /turf/open/floor/plasteel,
 /area/quartermaster/office)
 "jrE" = (
+/obj/machinery/rnd/production/protolathe/department/science,
 /obj/structure/sign/poster/official/random{
 	pixel_x = 32
 	},
@@ -53828,6 +53833,13 @@
 	},
 /turf/open/floor/plasteel,
 /area/science/circuit)
+"qpv" = (
+/obj/machinery/light{
+	dir = 4
+	},
+/obj/machinery/autolathe,
+/turf/open/floor/plasteel/white,
+/area/science/circuit)
 "quT" = (
 /obj/structure/lattice,
 /obj/structure/grille/broken,
@@ -54031,7 +54043,6 @@
 	dir = 8;
 	pixel_x = -24
 	},
-/obj/item/stock_parts/cell/high,
 /turf/open/floor/plasteel/white,
 /area/science/circuit)
 "vCb" = (
@@ -54046,6 +54057,7 @@
 /obj/machinery/light{
 	dir = 4
 	},
+/obj/machinery/libraryscanner,
 /turf/open/floor/plasteel/white,
 /area/science/circuit)
 "wkN" = (
@@ -54077,7 +54089,9 @@
 "wvX" = (
 /obj/structure/table/reinforced,
 /obj/machinery/light,
-/obj/item/stack/sheet/metal/ten,
+/obj/item/stock_parts/cell/super,
+/obj/item/stock_parts/cell/super,
+/obj/item/stack/sheet/metal/fifty,
 /turf/open/floor/plasteel/white,
 /area/science/circuit)
 "wBd" = (
@@ -103893,16 +103907,16 @@ bMB
 bNA
 cOe
 bSl
-bUq
+bRb
 flc
 vPE
-bXs
+bUq
 bVt
 dfh
 jSO
 jgm
 oUh
-vPE
+qpv
 jrE
 saK
 bSl

--- a/_maps/map_files/Deltastation/DeltaStation2.dmm
+++ b/_maps/map_files/Deltastation/DeltaStation2.dmm
@@ -77160,17 +77160,19 @@
 /area/science/research/abandoned)
 "djp" = (
 /obj/structure/table/reinforced,
-/obj/machinery/cell_charger,
+/obj/item/stack/sheet/glass/fifty,
 /turf/open/floor/plasteel/white/side,
 /area/science/circuit)
 "djq" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/machinery/rnd/production/protolathe/department/science,
 /obj/machinery/light{
 	dir = 1
 	},
 /turf/open/floor/plasteel/white/side,
 /area/science/circuit)
 "djr" = (
+/obj/machinery/autolathe,
 /turf/open/floor/plasteel/white/side,
 /area/science/circuit)
 "djs" = (
@@ -78536,11 +78538,12 @@
 /area/crew_quarters/abandoned_gambling_den)
 "dmr" = (
 /obj/structure/table/reinforced,
+/obj/item/stack/sheet/metal/fifty,
+/obj/item/stock_parts/cell/super,
+/obj/item/stock_parts/cell/super,
 /obj/structure/sign/departments/science{
 	pixel_x = -32
 	},
-/obj/item/stock_parts/cell/high,
-/obj/item/stock_parts/cell/high,
 /turf/open/floor/plasteel/white/side{
 	dir = 4
 	},
@@ -79275,8 +79278,7 @@
 	pixel_x = -26
 	},
 /obj/effect/decal/cleanable/dirt,
-/obj/item/stock_parts/cell/high,
-/obj/item/stock_parts/cell/high,
+/obj/item/stack/sheet/metal/fifty,
 /turf/open/floor/plasteel/white/side{
 	dir = 4
 	},
@@ -80843,6 +80845,8 @@
 	pixel_y = -32
 	},
 /obj/machinery/cell_charger,
+/obj/item/stock_parts/cell/super,
+/obj/item/stock_parts/cell/super,
 /turf/open/floor/plasteel/white/side{
 	dir = 1
 	},
@@ -80876,16 +80880,16 @@
 	},
 /area/science/circuit)
 "drD" = (
+/obj/machinery/vending/assist,
 /turf/open/floor/plasteel/white/side{
 	dir = 1
 	},
 /area/science/circuit)
 "drE" = (
+/obj/machinery/bookbinder,
 /obj/structure/sign/poster/official/build{
 	pixel_y = -32
 	},
-/obj/structure/table/reinforced,
-/obj/item/storage/fancy/donut_box,
 /turf/open/floor/plasteel/white/side{
 	dir = 1
 	},
@@ -80894,11 +80898,11 @@
 /obj/machinery/light_switch{
 	pixel_x = 36
 	},
+/obj/machinery/libraryscanner,
 /obj/machinery/firealarm{
 	dir = 4;
 	pixel_x = 24
 	},
-/obj/machinery/vending/assist,
 /turf/open/floor/plasteel/white/corner{
 	dir = 1
 	},
@@ -99707,7 +99711,7 @@
 "gUH" = (
 /obj/machinery/light,
 /obj/structure/table/reinforced,
-/obj/item/stack/sheet/metal/ten,
+/obj/machinery/computer/libraryconsole/bookmanagement,
 /turf/open/floor/plasteel/white/side{
 	dir = 1
 	},

--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -75954,7 +75954,6 @@
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
-/obj/item/stack/sheet/metal/ten,
 /turf/open/floor/plasteel/white,
 /area/science/circuit)
 "eqG" = (
@@ -76016,6 +76015,10 @@
 /obj/structure/disposalpipe/segment{
 	dir = 10
 	},
+/turf/open/floor/plasteel/white,
+/area/science/circuit)
+"gfh" = (
+/obj/machinery/libraryscanner,
 /turf/open/floor/plasteel/white,
 /area/science/circuit)
 "gnZ" = (
@@ -76099,6 +76102,13 @@
 	},
 /turf/closed/wall/r_wall,
 /area/maintenance/disposal/incinerator)
+"hfJ" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/machinery/autolathe,
+/turf/open/floor/plasteel/white,
+/area/science/circuit)
 "hvt" = (
 /obj/structure/kitchenspike_frame,
 /obj/effect/decal/cleanable/blood/gibs/old,
@@ -76162,6 +76172,9 @@
 /turf/closed/wall/mineral/plastitanium,
 /area/crew_quarters/fitness/recreation)
 "jyv" = (
+/obj/item/stock_parts/cell/super,
+/obj/item/stock_parts/cell/super,
+/obj/item/stack/sheet/metal/fifty,
 /obj/structure/table/reinforced,
 /obj/machinery/computer/security/telescreen{
 	desc = "Used for watching the RD's goons from the safety of your own office.";
@@ -76169,8 +76182,6 @@
 	network = list("rd");
 	pixel_y = 32
 	},
-/obj/item/stock_parts/cell/high,
-/obj/item/stock_parts/cell/high,
 /turf/open/floor/plasteel/white,
 /area/science/circuit)
 "jyQ" = (
@@ -76466,6 +76477,7 @@
 /obj/machinery/light{
 	dir = 1
 	},
+/obj/item/stock_parts/cell/super,
 /obj/structure/table/reinforced,
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
@@ -76476,8 +76488,8 @@
 	network = list("rd");
 	pixel_y = 32
 	},
-/obj/item/stock_parts/cell/high,
-/obj/item/stock_parts/cell/high,
+/obj/item/stock_parts/cell/super,
+/obj/item/stack/sheet/metal/fifty,
 /turf/open/floor/plasteel/white,
 /area/science/circuit)
 "ohj" = (
@@ -76696,6 +76708,11 @@
 /obj/structure/grille,
 /turf/open/floor/plating/airless,
 /area/space/nearstation)
+"sog" = (
+/obj/machinery/libraryscanner,
+/obj/machinery/bookbinder,
+/turf/open/floor/plasteel/white,
+/area/science/circuit)
 "sFv" = (
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
@@ -76737,6 +76754,11 @@
 "sJW" = (
 /turf/closed/wall/mineral/plastitanium,
 /area/engine/break_room)
+"tjH" = (
+/obj/structure/table/reinforced,
+/obj/machinery/computer/libraryconsole/bookmanagement,
+/turf/open/floor/plasteel/white,
+/area/science/circuit)
 "tsx" = (
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
@@ -76835,9 +76857,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
-/obj/item/twohanded/required/kirbyplants{
-	icon_state = "plant-10"
-	},
+/obj/machinery/rnd/production/protolathe/department/science,
 /turf/open/floor/plasteel/white,
 /area/science/circuit)
 "uYk" = (
@@ -113688,7 +113708,7 @@ cuZ
 fFM
 cud
 kxk
-cxO
+tjH
 cxO
 cxO
 dGH
@@ -114975,7 +114995,7 @@ mjJ
 krD
 eqq
 llb
-uTS
+hfJ
 cxO
 cxO
 krD
@@ -115234,7 +115254,7 @@ lsv
 txj
 eEe
 cxO
-cxO
+gfh
 krD
 aaa
 aaa
@@ -115491,7 +115511,7 @@ jyv
 ohj
 nnK
 cxO
-cxO
+sog
 krD
 aaa
 aaa

--- a/_maps/map_files/PubbyStation/PubbyStation.dmm
+++ b/_maps/map_files/PubbyStation/PubbyStation.dmm
@@ -24235,9 +24235,13 @@
 /area/science/explab)
 "blV" = (
 /obj/structure/table/reinforced,
+/obj/item/stack/sheet/metal/fifty{
+	pixel_x = -2;
+	pixel_y = 2
+	},
+/obj/item/stack/sheet/metal/fifty,
 /obj/item/clothing/glasses/science,
 /obj/item/clothing/glasses/science,
-/obj/item/stack/sheet/metal/ten,
 /turf/open/floor/plasteel/vault{
 	dir = 5
 	},
@@ -24641,10 +24645,10 @@
 /obj/machinery/cell_charger{
 	pixel_y = 5
 	},
-/obj/item/stock_parts/cell/high,
-/obj/item/stock_parts/cell/high,
-/obj/item/stock_parts/cell/high,
-/obj/item/stock_parts/cell/high,
+/obj/item/stock_parts/cell/super,
+/obj/item/stock_parts/cell/super,
+/obj/item/stock_parts/cell/super,
+/obj/item/stock_parts/cell/super,
 /turf/open/floor/plasteel/vault{
 	dir = 5
 	},
@@ -24983,9 +24987,7 @@
 /turf/open/floor/engine,
 /area/science/explab)
 "bnZ" = (
-/obj/item/twohanded/required/kirbyplants{
-	icon_state = "plant-10"
-	},
+/obj/machinery/rnd/production/techfab/department/science,
 /turf/open/floor/plasteel/vault{
 	dir = 5
 	},
@@ -48941,6 +48943,12 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/security/brig)
+"hOd" = (
+/obj/machinery/autolathe,
+/turf/open/floor/plasteel/vault{
+	dir = 5
+	},
+/area/science/explab)
 "hOx" = (
 /obj/structure/cable{
 	icon_state = "2-4"
@@ -96225,7 +96233,7 @@ bjx
 bjw
 qDJ
 vmG
-bnZ
+hOd
 pDP
 nBL
 bqs


### PR DESCRIPTION
Reverts tgstation/tgstation#38589

Reasoning: the person creating the pull request either was unable to answer basic questions about the need for the pull request without using buzzwords to aboid actually answering, or was in fact hiding the real reason for the pull request (nerf new science to make people want old science back)

Instead of properly handling feedback and criticism, they went silent and pestered a maintainers for a quick merge. They very clearly haven't replied to the requested questions, choosing instead to opt for a snarky insulting remark like a total douchebag. Source: https://github.com/tgstation/tgstation/pull/38589#issuecomment-398362624

Please don't merge pull requests intended to impact balance negatively without securing an accurate and actually physical reason as to why the pull request is needed. This was a change for shits and giggles that wastes all of our time.