### PR TITLE
potency gene disks now clarify what the % means on examine

### DIFF
--- a/code/modules/hydroponics/gene_modder.dm
+++ b/code/modules/hydroponics/gene_modder.dm
@@ -427,7 +427,7 @@
 
 /obj/item/disk/plantgene/proc/update_name()
 	if(gene)
-		name = "[gene.get_name()] (Plant Data Disk)"
+		name = "[gene.get_name()] (plant data disk)"
 	else
 		name = "plant data disk"
 
@@ -437,4 +437,6 @@
 
 /obj/item/disk/plantgene/examine(mob/user)
 	..()
+	if(gene && (istype(gene, /datum/plant_gene/core/potency)))
+		to_chat(user,"<span class='notice'>Percent is relative to potency, not maximum volume of the plant.</span>")
 	to_chat(user, "The write-protect tab is set to [src.read_only ? "protected" : "unprotected"].")


### PR DESCRIPTION
:cl:
spellcheck: Plant disks with potency genes clarify the percent is for potency scaling and not relative to max volume on examine.
/:cl:

Fixes #38601 

I CL'd it just to subtly inform people that's what the percent means so we don't get more issues about it.