### PR TITLE
Fixes runtimes when using supplypod smite on ghosts and fixes supplypod-smite hotspot effects.

### DIFF
--- a/code/game/objects/structures/crates_lockers/closets/secure/supplypod.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/supplypod.dm
@@ -104,7 +104,7 @@
 	light_range = 2
 	var/obj/effect/temp_visual/fallingPod
 
-/obj/effect/DPtarget/Initialize(mapload, var/SO, var/podID, var/target)
+/obj/effect/DPtarget/Initialize(mapload, var/SO, var/podID)
 	. = ..()
 	var/delayTime = 17			//We're forcefully adminspawned, make it faster
 	switch(podID)
@@ -132,6 +132,8 @@
 	else if(podID == POD_CENTCOM)
 		new /obj/structure/closet/supplypod/bluespacepod/centcompod(drop_location(), SO)//CentCom supplypods dont create explosions; instead they directly deal 40 fire damage to people on the turf
 		var/turf/T = get_turf(src)
+		playsound(T, "explosion", 80, 1)
+		new /obj/effect/hotspot(T)
 		T.hotspot_expose(700, 50, 1)//same as fireball
 		for(var/mob/living/M in T.contents)
 			M.adjustFireLoss(40)

--- a/code/game/objects/structures/crates_lockers/closets/secure/supplypod.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/supplypod.dm
@@ -32,7 +32,7 @@
 	desc = "A Nanotrasen Bluespace drop pod, this one has been marked with Central Command's designations. Teleports back to Centcom after delivery."
 	icon_state = "centcompod"
 
-/obj/structure/closet/supplypod/Initialize(mapload, var/SO)
+/obj/structure/closet/supplypod/Initialize(mapload, SO)
 	. = ..()
 	if(istype(SO, /datum/supply_order))
 		SupplyOrder = SO//uses Supply Order passed from expressconsole into BDPtarget
@@ -84,7 +84,7 @@
 	randomdir = FALSE
 	icon_state = "supplypod_falling"
 
-/obj/effect/temp_visual/DPfall/Initialize(var/dropLocation, var/podID)
+/obj/effect/temp_visual/DPfall/Initialize(dropLocation, podID)
 	if (podID == POD_STANDARD)
 		icon_state = "supplypod_falling"
 		name = "Supply Drop Pod"
@@ -104,7 +104,7 @@
 	light_range = 2
 	var/obj/effect/temp_visual/fallingPod
 
-/obj/effect/DPtarget/Initialize(mapload, var/SO, var/podID)
+/obj/effect/DPtarget/Initialize(mapload, SO, podID)
 	. = ..()
 	var/delayTime = 17			//We're forcefully adminspawned, make it faster
 	switch(podID)
@@ -117,12 +117,12 @@
 
 	addtimer(CALLBACK(src, .proc/beginLaunch, SO, podID), delayTime)//standard pods take 3 seconds to come in, bluespace pods take 1.5
 
-/obj/effect/DPtarget/proc/beginLaunch(var/SO, var/podID)
+/obj/effect/DPtarget/proc/beginLaunch(SO, podID)
 	fallingPod = new /obj/effect/temp_visual/DPfall(drop_location(), podID)
 	animate(fallingPod, pixel_z = 0, time = 3, easing = LINEAR_EASING)//make and animate a falling pod
 	addtimer(CALLBACK(src, .proc/endLaunch, SO, podID), 3, TIMER_CLIENT_TIME)//fall 0.3seconds
 
-/obj/effect/DPtarget/proc/endLaunch(var/SO, var/podID)
+/obj/effect/DPtarget/proc/endLaunch(SO, podID)
 	if(podID == POD_STANDARD)
 		new /obj/structure/closet/supplypod(drop_location(), SO)//pod is created
 		explosion(src,0,0,2, flame_range = 3) //less advanced equipment than bluespace pod, so larger explosion when landing
@@ -132,7 +132,7 @@
 	else if(podID == POD_CENTCOM)
 		new /obj/structure/closet/supplypod/bluespacepod/centcompod(drop_location(), SO)//CentCom supplypods dont create explosions; instead they directly deal 40 fire damage to people on the turf
 		var/turf/T = get_turf(src)
-		playsound(T, "explosion", 80, 1)
+		playsound(src, "explosion", 80, 1)
 		new /obj/effect/hotspot(T)
 		T.hotspot_expose(700, 50, 1)//same as fireball
 		for(var/mob/living/M in T.contents)

--- a/code/modules/admin/verbs/randomverbs.dm
+++ b/code/modules/admin/verbs/randomverbs.dm
@@ -1356,7 +1356,7 @@ GLOBAL_LIST_EMPTY(custom_outfits) //Admin created outfits
 					alert("ERROR: Incorrect / improper path given.")
 					return
 			//send the pod
-			if(istype(target, /mob/living/carbon))
+			if(iscarbon(target))
 				target.Stun(10)//takes 0.53 seconds for CentCom pod to land
 			new /obj/effect/DPtarget(get_turf(target), delivery, POD_CENTCOM)
 

--- a/code/modules/admin/verbs/randomverbs.dm
+++ b/code/modules/admin/verbs/randomverbs.dm
@@ -1356,8 +1356,9 @@ GLOBAL_LIST_EMPTY(custom_outfits) //Admin created outfits
 					alert("ERROR: Incorrect / improper path given.")
 					return
 			//send the pod
-			target.Stun(10)//takes 0.53 seconds for CentCom pod to land
-			new /obj/effect/DPtarget(get_turf(target), delivery, POD_CENTCOM, target)
+			if(!isobserver(target))
+				target.Stun(10)//takes 0.53 seconds for CentCom pod to land
+			new /obj/effect/DPtarget(get_turf(target), delivery, POD_CENTCOM)
 
 	var/msg = "[key_name_admin(usr)] punished [key_name_admin(target)] with [punishment]."
 	message_admins(msg)

--- a/code/modules/admin/verbs/randomverbs.dm
+++ b/code/modules/admin/verbs/randomverbs.dm
@@ -1356,7 +1356,7 @@ GLOBAL_LIST_EMPTY(custom_outfits) //Admin created outfits
 					alert("ERROR: Incorrect / improper path given.")
 					return
 			//send the pod
-			if(!isobserver(target))
+			if(istype(target,mob/living/carbon))
 				target.Stun(10)//takes 0.53 seconds for CentCom pod to land
 			new /obj/effect/DPtarget(get_turf(target), delivery, POD_CENTCOM)
 

--- a/code/modules/admin/verbs/randomverbs.dm
+++ b/code/modules/admin/verbs/randomverbs.dm
@@ -1356,7 +1356,7 @@ GLOBAL_LIST_EMPTY(custom_outfits) //Admin created outfits
 					alert("ERROR: Incorrect / improper path given.")
 					return
 			//send the pod
-			if(istype(target,mob/living/carbon))
+			if(istype(target, /mob/living/carbon))
 				target.Stun(10)//takes 0.53 seconds for CentCom pod to land
 			new /obj/effect/DPtarget(get_turf(target), delivery, POD_CENTCOM)
 


### PR DESCRIPTION
SupplyPod smites weren't creating a hotspot and explosion sound when called on living mobs, and when called on ghosts they wouldn't happen at all. Closes #38626 @Arianya 

:cl: MrDoomBringer
fix: SupplyPod smites work properly once again.
/:cl:

I have a suspicion that this was caused by ~#38374~ an act of god or some shit  , but I'm not certain. Works now though! 
