### PR TITLE
Allows empty borg shells to be disassembled.

### DIFF
--- a/code/game/objects/items/robot/robot_parts.dm
+++ b/code/game/objects/items/robot/robot_parts.dm
@@ -21,7 +21,6 @@
 	var/lawsync = 1
 	var/aisync = 1
 	var/panel_locked = TRUE
-	var/partcheck = 0
 
 /obj/item/robot_suit/New()
 	..()
@@ -79,50 +78,42 @@
 			else
 				to_chat(user, "<span class='warning'>You need one sheet of metal to start building ED-209!</span>")
 				return
-	else if(istype(W, /obj/item/wrench))//Deconstucts empty borg shell. Flashes remain unbroken because they haven't been used yet
-		partcheck = 0
+	else if(istype(W, /obj/item/wrench)) //Deconstucts empty borg shell. Flashes remain unbroken because they haven't been used yet
 		var/turf/T = get_turf(src)
 		src.forceMove(T)
-		if(l_leg)
-			partcheck = 1
-			src.l_leg.forceMove(T)
-			src.l_leg = null
-		if(r_leg)
-			partcheck = 1
-			src.r_leg.forceMove(T)
-			src.r_leg = null
-		if(chest)
-			if (src.chest.cell) //Sanity check.
-				src.chest.cell.forceMove(T)
-				src.chest.cell = null
-			partcheck = 1
-			src.chest.forceMove(T)
-			new /obj/item/stack/cable_coil(T, 1)
-			src.chest.wired = 0
-			src.chest = null
-		if(l_arm)
-			partcheck = 1
-			src.l_arm.forceMove(T)
-			src.l_arm = null
-		if(r_arm)
-			partcheck = 1
-			src.r_arm.forceMove(T)
-			src.r_arm = null
-		if(head)
-			partcheck = 1
-			src.head.forceMove(T)
-			src.head.flash1.forceMove(T)
-			src.head.flash1 = null
-			src.head.flash2.forceMove(T)
-			src.head.flash2 = null
-			src.head = null
-		src.updateicon()
-		if(partcheck > 0)
-			to_chat(user, "<span class='notice'>You disassemble the cyborg shell.</span>")
-			partcheck = 0
-			W.use_tool(src, user, 0, volume=50)//play wrench sound
+		if(l_leg || r_leg || chest || l_arm || r_arm || head)
+			if(W.use_tool(src, user, 5, volume=50))
+				if(l_leg)
+					src.l_leg.forceMove(T)
+					src.l_leg = null
+				if(r_leg)
+					src.r_leg.forceMove(T)
+					src.r_leg = null
+				if(chest)
+					if (src.chest.cell) //Sanity check.
+						src.chest.cell.forceMove(T)
+						src.chest.cell = null
+					src.chest.forceMove(T)
+					new /obj/item/stack/cable_coil(T, 1)
+					src.chest.wired = 0
+					src.chest = null
+				if(l_arm)
+					src.l_arm.forceMove(T)
+					src.l_arm = null
+				if(r_arm)
+					src.r_arm.forceMove(T)
+					src.r_arm = null
+				if(head)
+					src.head.forceMove(T)
+					src.head.flash1.forceMove(T)
+					src.head.flash1 = null
+					src.head.flash2.forceMove(T)
+					src.head.flash2 = null
+					src.head = null
+				to_chat(user, "<span class='notice'>You disassemble the cyborg shell.</span>")
 		else
 			to_chat(user, "<span class='notice'>There is nothing to remove from the endoskeleton.</span>")
+		src.updateicon()
 	else if(istype(W, /obj/item/bodypart/l_leg/robot))
 		if(src.l_leg)
 			return

--- a/code/game/objects/items/robot/robot_parts.dm
+++ b/code/game/objects/items/robot/robot_parts.dm
@@ -114,7 +114,7 @@
 		else
 			to_chat(user, "<span class='notice'>There is nothing to remove from the endoskeleton.</span>")
 		updateicon()
-	else if(istype(W, /obj/item/screwdriver))
+	else if(istype(W, /obj/item/screwdriver)) //Swaps the power cell if you're holding a new one in your other hand.
 		var/turf/T = get_turf(src)
 		if(istype(user.held_items[user.active_hand_index == 1 ? 2 : 1], /obj/item/stock_parts/cell))
 			if (chest.cell) //Sanity check.

--- a/code/game/objects/items/robot/robot_parts.dm
+++ b/code/game/objects/items/robot/robot_parts.dm
@@ -119,7 +119,7 @@
 		if(istype(user.held_items[user.active_hand_index == 1 ? 2 : 1], /obj/item/stock_parts/cell))
 			if (src.chest.cell) //Sanity check.
 				src.chest.cell.forceMove(T)
-				src.chest.cell = user.held_items[user.active_hand_index == 1 ? 2 : 1]
+			src.chest.cell = user.held_items[user.active_hand_index == 1 ? 2 : 1]
 			if(!user.transferItemToLoc(user.held_items[user.active_hand_index == 1 ? 2 : 1], src.chest))
 				src.chest.cell = null
 				return

--- a/code/game/objects/items/robot/robot_parts.dm
+++ b/code/game/objects/items/robot/robot_parts.dm
@@ -62,6 +62,54 @@
 				return 1
 	return 0
 
+/obj/item/robot_suit/wrench_act(mob/living/user, obj/item/I) //Deconstucts empty borg shell. Flashes remain unbroken because they haven't been used yet
+	var/turf/T = get_turf(src)
+	forceMove(T)
+	if(l_leg || r_leg || chest || l_arm || r_arm || head)
+		if(I.use_tool(src, user, 5, volume=50))
+			if(l_leg)
+				l_leg.forceMove(T)
+				l_leg = null
+			if(r_leg)
+				r_leg.forceMove(T)
+				r_leg = null
+			if(chest)
+				if (chest.cell) //Sanity check.
+					chest.cell.forceMove(T)
+					chest.cell = null
+				chest.forceMove(T)
+				new /obj/item/stack/cable_coil(T, 1)
+				chest.wired = 0
+				chest = null
+			if(l_arm)
+				l_arm.forceMove(T)
+				l_arm = null
+			if(r_arm)
+				r_arm.forceMove(T)
+				r_arm = null
+			if(head)
+				head.forceMove(T)
+				head.flash1.forceMove(T)
+				head.flash1 = null
+				head.flash2.forceMove(T)
+				head.flash2 = null
+				head = null
+			to_chat(user, "<span class='notice'>You disassemble the cyborg shell.</span>")
+	else
+		to_chat(user, "<span class='notice'>There is nothing to remove from the endoskeleton.</span>")
+	updateicon()
+
+obj/item/robot_suit/screwdriver_act(mob/living/user, obj/item/I) //Swaps the power cell if you're holding a new one in your other hand.
+	var/turf/T = get_turf(src)
+	if(istype(user.held_items[user.active_hand_index == 1 ? 2 : 1], /obj/item/stock_parts/cell))
+		if (chest.cell) //Sanity check.
+			chest.cell.forceMove(T)
+		chest.cell = user.held_items[user.active_hand_index == 1 ? 2 : 1]
+		if(!user.transferItemToLoc(user.held_items[user.active_hand_index == 1 ? 2 : 1], src.chest))
+			chest.cell = null
+			return
+		to_chat(user, "<span class='notice'>You replace the power cell.</span>")
+
 /obj/item/robot_suit/attackby(obj/item/W, mob/user, params)
 
 	if(istype(W, /obj/item/stack/sheet/metal))
@@ -78,52 +126,6 @@
 			else
 				to_chat(user, "<span class='warning'>You need one sheet of metal to start building ED-209!</span>")
 				return
-	else if(istype(W, /obj/item/wrench)) //Deconstucts empty borg shell. Flashes remain unbroken because they haven't been used yet
-		var/turf/T = get_turf(src)
-		forceMove(T)
-		if(l_leg || r_leg || chest || l_arm || r_arm || head)
-			if(W.use_tool(src, user, 5, volume=50))
-				if(l_leg)
-					l_leg.forceMove(T)
-					l_leg = null
-				if(r_leg)
-					r_leg.forceMove(T)
-					r_leg = null
-				if(chest)
-					if (chest.cell) //Sanity check.
-						chest.cell.forceMove(T)
-						chest.cell = null
-					chest.forceMove(T)
-					new /obj/item/stack/cable_coil(T, 1)
-					chest.wired = 0
-					chest = null
-				if(l_arm)
-					l_arm.forceMove(T)
-					l_arm = null
-				if(r_arm)
-					r_arm.forceMove(T)
-					r_arm = null
-				if(head)
-					head.forceMove(T)
-					head.flash1.forceMove(T)
-					head.flash1 = null
-					head.flash2.forceMove(T)
-					head.flash2 = null
-					head = null
-				to_chat(user, "<span class='notice'>You disassemble the cyborg shell.</span>")
-		else
-			to_chat(user, "<span class='notice'>There is nothing to remove from the endoskeleton.</span>")
-		updateicon()
-	else if(istype(W, /obj/item/screwdriver)) //Swaps the power cell if you're holding a new one in your other hand.
-		var/turf/T = get_turf(src)
-		if(istype(user.held_items[user.active_hand_index == 1 ? 2 : 1], /obj/item/stock_parts/cell))
-			if (chest.cell) //Sanity check.
-				chest.cell.forceMove(T)
-			chest.cell = user.held_items[user.active_hand_index == 1 ? 2 : 1]
-			if(!user.transferItemToLoc(user.held_items[user.active_hand_index == 1 ? 2 : 1], src.chest))
-				chest.cell = null
-				return
-			to_chat(user, "<span class='notice'>You replace the power cell.</span>")
 	else if(istype(W, /obj/item/bodypart/l_leg/robot))
 		if(src.l_leg)
 			return

--- a/code/game/objects/items/robot/robot_parts.dm
+++ b/code/game/objects/items/robot/robot_parts.dm
@@ -80,48 +80,48 @@
 				return
 	else if(istype(W, /obj/item/wrench)) //Deconstucts empty borg shell. Flashes remain unbroken because they haven't been used yet
 		var/turf/T = get_turf(src)
-		src.forceMove(T)
+		forceMove(T)
 		if(l_leg || r_leg || chest || l_arm || r_arm || head)
 			if(W.use_tool(src, user, 5, volume=50))
 				if(l_leg)
-					src.l_leg.forceMove(T)
-					src.l_leg = null
+					l_leg.forceMove(T)
+					l_leg = null
 				if(r_leg)
-					src.r_leg.forceMove(T)
-					src.r_leg = null
+					r_leg.forceMove(T)
+					r_leg = null
 				if(chest)
-					if (src.chest.cell) //Sanity check.
-						src.chest.cell.forceMove(T)
-						src.chest.cell = null
-					src.chest.forceMove(T)
+					if (chest.cell) //Sanity check.
+						chest.cell.forceMove(T)
+						chest.cell = null
+					chest.forceMove(T)
 					new /obj/item/stack/cable_coil(T, 1)
-					src.chest.wired = 0
-					src.chest = null
+					chest.wired = 0
+					chest = null
 				if(l_arm)
-					src.l_arm.forceMove(T)
-					src.l_arm = null
+					l_arm.forceMove(T)
+					l_arm = null
 				if(r_arm)
-					src.r_arm.forceMove(T)
-					src.r_arm = null
+					r_arm.forceMove(T)
+					r_arm = null
 				if(head)
-					src.head.forceMove(T)
-					src.head.flash1.forceMove(T)
-					src.head.flash1 = null
-					src.head.flash2.forceMove(T)
-					src.head.flash2 = null
-					src.head = null
+					head.forceMove(T)
+					head.flash1.forceMove(T)
+					head.flash1 = null
+					head.flash2.forceMove(T)
+					head.flash2 = null
+					head = null
 				to_chat(user, "<span class='notice'>You disassemble the cyborg shell.</span>")
 		else
 			to_chat(user, "<span class='notice'>There is nothing to remove from the endoskeleton.</span>")
-		src.updateicon()
+		updateicon()
 	else if(istype(W, /obj/item/screwdriver))
 		var/turf/T = get_turf(src)
 		if(istype(user.held_items[user.active_hand_index == 1 ? 2 : 1], /obj/item/stock_parts/cell))
-			if (src.chest.cell) //Sanity check.
-				src.chest.cell.forceMove(T)
-			src.chest.cell = user.held_items[user.active_hand_index == 1 ? 2 : 1]
+			if (chest.cell) //Sanity check.
+				chest.cell.forceMove(T)
+			chest.cell = user.held_items[user.active_hand_index == 1 ? 2 : 1]
 			if(!user.transferItemToLoc(user.held_items[user.active_hand_index == 1 ? 2 : 1], src.chest))
-				src.chest.cell = null
+				chest.cell = null
 				return
 			to_chat(user, "<span class='notice'>You replace the power cell.</span>")
 	else if(istype(W, /obj/item/bodypart/l_leg/robot))

--- a/code/game/objects/items/robot/robot_parts.dm
+++ b/code/game/objects/items/robot/robot_parts.dm
@@ -214,6 +214,9 @@
 	else if(istype(W, /obj/item/mmi))
 		var/obj/item/mmi/M = W
 		if(check_completion())
+			if(!chest.cell)
+				to_chat(user, "<span class='warning'>The shell still needs a power cell!</span>")
+				return
 			if(!isturf(loc))
 				to_chat(user, "<span class='warning'>You can't put [M] in, the frame has to be standing on the ground to be perfectly precise!</span>")
 				return

--- a/code/game/objects/items/robot/robot_parts.dm
+++ b/code/game/objects/items/robot/robot_parts.dm
@@ -99,16 +99,21 @@
 		to_chat(user, "<span class='notice'>There is nothing to remove from the endoskeleton.</span>")
 	updateicon()
 
-obj/item/robot_suit/screwdriver_act(mob/living/user, obj/item/I) //Swaps the power cell if you're holding a new one in your other hand.
-	var/turf/T = get_turf(src)
-	if(istype(user.held_items[user.active_hand_index == 1 ? 2 : 1], /obj/item/stock_parts/cell))
-		if (chest.cell) //Sanity check.
-			chest.cell.forceMove(T)
-		chest.cell = user.held_items[user.active_hand_index == 1 ? 2 : 1]
-		if(!user.transferItemToLoc(user.held_items[user.active_hand_index == 1 ? 2 : 1], src.chest))
-			chest.cell = null
-			return
-		to_chat(user, "<span class='notice'>You replace the power cell.</span>")
+/obj/item/robot_suit/screwdriver_act(mob/living/user, obj/item/I) //Swaps the power cell if you're holding a new one in your other hand.
+	var/obj/item/stock_parts/cell/temp_cell = user.is_holding_item_of_type(/obj/item/stock_parts/cell)
+	if(QDELETED(temp_cell))
+		return
+	if(QDELETED(chest.cell))
+		to_chat(user, "<span class='notice'>There doesn't seem to unscrew from [src].</span>")
+		return
+	if(!user.transferItemToLoc(temp_cell, chest))
+		to_chat(user, "<span class='warning'>[temp_cell] is stuck to your hand, you can't put it in [src]!</span>")
+		return
+	if(!user.put_in_hands(chest.cell))
+		chest.cell.forceMove(drop_location())
+	chest.cell = temp_cell
+	to_chat(user, "<span class='notice'>You replace [src]'s power cell.</span>")
+	return TRUE
 
 /obj/item/robot_suit/attackby(obj/item/W, mob/user, params)
 

--- a/code/game/objects/items/robot/robot_parts.dm
+++ b/code/game/objects/items/robot/robot_parts.dm
@@ -99,6 +99,12 @@
 		to_chat(user, "<span class='notice'>There is nothing to remove from the endoskeleton.</span>")
 	updateicon()
 
+/obj/item/robot_suit/proc/put_in_hand_or_drop(mob/living/user, obj/item/I) //normal put_in_hands() drops the item ontop of the player, this drops it at the suit's loc
+	if(!user.put_in_hands(I))
+		I.forceMove(drop_location())
+		return FALSE
+	return TRUE
+
 /obj/item/robot_suit/screwdriver_act(mob/living/user, obj/item/I) //Removes the current power cell, or swaps it if you're holding a new one.
 	if(!chest.cell) //If no cell is in the shell
 		if(!user.is_holding_item_of_type(/obj/item/stock_parts/cell)) //And we're also not holding a cell

--- a/code/game/objects/items/robot/robot_parts.dm
+++ b/code/game/objects/items/robot/robot_parts.dm
@@ -215,7 +215,7 @@
 		var/obj/item/mmi/M = W
 		if(check_completion())
 			if(!chest.cell)
-				to_chat(user, "<span class='warning'>The shell still needs a power cell!</span>")
+				to_chat(user, "<span class='warning'>The endoskeleton still needs a power cell!</span>")
 				return
 			if(!isturf(loc))
 				to_chat(user, "<span class='warning'>You can't put [M] in, the frame has to be standing on the ground to be perfectly precise!</span>")

--- a/code/game/objects/items/robot/robot_parts.dm
+++ b/code/game/objects/items/robot/robot_parts.dm
@@ -114,6 +114,16 @@
 		else
 			to_chat(user, "<span class='notice'>There is nothing to remove from the endoskeleton.</span>")
 		src.updateicon()
+	else if(istype(W, /obj/item/screwdriver))
+		var/turf/T = get_turf(src)
+		if(istype(user.held_items[user.active_hand_index == 1 ? 2 : 1], /obj/item/stock_parts/cell))
+			if (src.chest.cell) //Sanity check.
+				src.chest.cell.forceMove(T)
+				src.chest.cell = user.held_items[user.active_hand_index == 1 ? 2 : 1]
+			if(!user.transferItemToLoc(user.held_items[user.active_hand_index == 1 ? 2 : 1], src.chest))
+				src.chest.cell = null
+				return
+			to_chat(user, "<span class='notice'>You replace the power cell.</span>")
 	else if(istype(W, /obj/item/bodypart/l_leg/robot))
 		if(src.l_leg)
 			return

--- a/code/game/objects/items/robot/robot_parts.dm
+++ b/code/game/objects/items/robot/robot_parts.dm
@@ -101,9 +101,9 @@
 
 /obj/item/robot_suit/screwdriver_act(mob/living/user, obj/item/I) //Swaps the power cell if you're holding a new one in your other hand.
 	var/obj/item/stock_parts/cell/temp_cell = user.is_holding_item_of_type(/obj/item/stock_parts/cell)
-	if(QDELETED(temp_cell))
+	if(!temp_cell)
 		return
-	if(QDELETED(chest.cell))
+	if(!chest.cell)
 		to_chat(user, "<span class='notice'>There doesn't seem to unscrew from [src].</span>")
 		return
 	if(!user.transferItemToLoc(temp_cell, chest))

--- a/code/game/objects/items/robot/robot_parts.dm
+++ b/code/game/objects/items/robot/robot_parts.dm
@@ -21,6 +21,7 @@
 	var/lawsync = 1
 	var/aisync = 1
 	var/panel_locked = TRUE
+	var/partcheck = 0
 
 /obj/item/robot_suit/New()
 	..()
@@ -78,6 +79,50 @@
 			else
 				to_chat(user, "<span class='warning'>You need one sheet of metal to start building ED-209!</span>")
 				return
+	else if(istype(W, /obj/item/wrench))//Deconstucts empty borg shell. Flashes remain unbroken because they haven't been used yet
+		partcheck = 0
+		var/turf/T = get_turf(src)
+		src.forceMove(T)
+		if(l_leg)
+			partcheck = 1
+			src.l_leg.forceMove(T)
+			src.l_leg = null
+		if(r_leg)
+			partcheck = 1
+			src.r_leg.forceMove(T)
+			src.r_leg = null
+		if(chest)
+			if (src.chest.cell) //Sanity check.
+				src.chest.cell.forceMove(T)
+				src.chest.cell = null
+			partcheck = 1
+			src.chest.forceMove(T)
+			new /obj/item/stack/cable_coil(T, 1)
+			src.chest.wired = 0
+			src.chest = null
+		if(l_arm)
+			partcheck = 1
+			src.l_arm.forceMove(T)
+			src.l_arm = null
+		if(r_arm)
+			partcheck = 1
+			src.r_arm.forceMove(T)
+			src.r_arm = null
+		if(head)
+			partcheck = 1
+			src.head.forceMove(T)
+			src.head.flash1.forceMove(T)
+			src.head.flash1 = null
+			src.head.flash2.forceMove(T)
+			src.head.flash2 = null
+			src.head = null
+		src.updateicon()
+		if(partcheck > 0)
+			to_chat(user, "<span class='notice'>You disassemble the cyborg shell.</span>")
+			partcheck = 0
+			W.use_tool(src, user, 0, volume=50)//play wrench sound
+		else
+			to_chat(user, "<span class='notice'>There is nothing to remove from the endoskeleton.</span>")
 	else if(istype(W, /obj/item/bodypart/l_leg/robot))
 		if(src.l_leg)
 			return


### PR DESCRIPTION
:cl: Zxaber
tweak: Empty cyborg shells can now be disassembled with a wrench.
tweak: Using a screwdriver on an empty shell will now remove the cell, or swap it if you're holding a cell in your other hand.
/:cl:

Sometimes you end up with a borg shell sitting around from roundstart, and a better battery next to it waiting. It would be nice to replace the battery _before_ having an MMI to put in.

Besides, a functional borg can be disassembled, so it's weird than the empty shell cannot.

Flashes remain unbroken because the shell hasn't been used yet.

~~Adding the [Ready] tag, as all requested changes have been done.~~