### PR TITLE
Port fire axe and extinguisher cabinets to Initialize

### DIFF
--- a/code/game/objects/structures/extinguisher.dm
+++ b/code/game/objects/structures/extinguisher.dm
@@ -8,22 +8,22 @@
 	max_integrity = 200
 	integrity_failure = 50
 	var/obj/item/extinguisher/stored_extinguisher
-	var/opened = 0
+	var/opened = FALSE
 
-/obj/structure/extinguisher_cabinet/examine(mob/user)
-	..()
-	to_chat(user, "<span class='notice'>Alt-click to [opened ? "close":"open"] it.</span>")
-
-/obj/structure/extinguisher_cabinet/New(loc, ndir, building)
-	..()
+/obj/structure/extinguisher_cabinet/Initialize(mapload, ndir, building)
+	. = ..()
 	if(building)
 		setDir(ndir)
 		pixel_x = (dir & 3)? 0 : (dir == 4 ? -27 : 27)
 		pixel_y = (dir & 3)? (dir ==1 ? -30 : 30) : 0
-		opened = 1
+		opened = TRUE
 		icon_state = "extinguisher_empty"
 	else
 		stored_extinguisher = new /obj/item/extinguisher(src)
+
+/obj/structure/extinguisher_cabinet/examine(mob/user)
+	..()
+	to_chat(user, "<span class='notice'>Alt-click to [opened ? "close":"open"] it.</span>")
 
 /obj/structure/extinguisher_cabinet/Destroy()
 	if(stored_extinguisher)

--- a/code/game/objects/structures/fireaxe.dm
+++ b/code/game/objects/structures/fireaxe.dm
@@ -1,19 +1,20 @@
 /obj/structure/fireaxecabinet
 	name = "fire axe cabinet"
 	desc = "There is a small label that reads \"For Emergency use only\" along with details for safe use of the axe. As if."
-	var/obj/item/twohanded/fireaxe/fireaxe = new/obj/item/twohanded/fireaxe
 	icon = 'icons/obj/wallmounts.dmi'
 	icon_state = "fireaxe"
 	anchored = TRUE
 	density = FALSE
 	armor = list("melee" = 50, "bullet" = 20, "laser" = 0, "energy" = 100, "bomb" = 10, "bio" = 100, "rad" = 100, "fire" = 90, "acid" = 50)
-	var/locked = TRUE
-	var/open = FALSE
 	max_integrity = 150
 	integrity_failure = 50
+	var/locked = TRUE
+	var/open = FALSE
+	var/obj/item/twohanded/fireaxe/fireaxe
 
 /obj/structure/fireaxecabinet/Initialize()
 	. = ..()
+	fireaxe = new
 	update_icon()
 
 /obj/structure/fireaxecabinet/Destroy()


### PR DESCRIPTION
:cl:
fix: Fire extinguishers on the emergency shuttle are no longer unclickable once removed from their cabinets.
/:cl:

Fixes #38597. See that ticket for a discussion of the cause.