### PR TITLE
Fixes bubblegum comments

### DIFF
--- a/code/modules/mob/living/simple_animal/hostile/megafauna/bubblegum.dm
+++ b/code/modules/mob/living/simple_animal/hostile/megafauna/bubblegum.dm
@@ -14,7 +14,7 @@ Whenever it isn't chasing something down, it will sink into nearby blood pools (
 To make this possible, it sprays streams of blood at random.
 From these blood pools Bubblegum may summon slaughterlings - weak, low-damage minions designed to impede the target's progress.
 
-When Bubblegum dies, it leaves behind a chest that can contain three things:
+When Bubblegum dies, it leaves behind a H.E.C.K. suit+helmet as well as a chest that can contain three things:
  1. A spellblade that can slice off limbs at range
  2. A bottle that, when activated, drives everyone nearby into a frenzy
  3. A contract that marks for death the chosen target


### PR DESCRIPTION
From
`When Bubblegum dies, it leaves behind a chest that can contain three things:`
to
`When Bubblegum dies, it leaves behind a H.E.C.K. suit+helmet as well as a chest that can contain three things:`