### PR TITLE
Admin spawnable version of the Death Ripley that actually inflicts damage and can rip arms off

### DIFF
--- a/code/game/mecha/equipment/tools/work_tools.dm
+++ b/code/game/mecha/equipment/tools/work_tools.dm
@@ -78,6 +78,15 @@
 	name = "\improper KILL CLAMP"
 	desc = "They won't know what clamped them!"
 	energy_drain = 0
+	var/real_clamp = FALSE
+	dam_force = 0
+
+/obj/item/mecha_parts/mecha_equipment/hydraulic_clamp/kill/proper
+	name = "\proper KILL CLAMP"
+	desc = "They won't know what clamped them! This time for real!"
+	energy_drain = 10
+	dam_force = 20
+	real_clamp = TRUE
 
 /obj/item/mecha_parts/mecha_equipment/hydraulic_clamp/kill/action(atom/target)
 	if(!action_checks(target))
@@ -108,30 +117,38 @@
 		if(M.stat == DEAD)
 			return
 		if(chassis.occupant.a_intent == INTENT_HARM)
-			M.take_overall_damage(dam_force)
-			if(!M)
-				return
-			M.adjustOxyLoss(round(dam_force/2))
-			M.updatehealth()
-			target.visible_message("<span class='danger'>[chassis] destroys [target] in an unholy fury.</span>", \
-								"<span class='userdanger'>[chassis] destroys [target] in an unholy fury.</span>")
-			add_logs(chassis.occupant, M, "attacked", "[name]", "(INTENT: [uppertext(chassis.occupant.a_intent)]) (DAMTYE: [uppertext(damtype)])")
+			if(real_clamp)
+				M.take_overall_damage(dam_force)
+				if(!M)
+					return
+				M.adjustOxyLoss(round(dam_force/2))
+				M.updatehealth()
+				target.visible_message("<span class='danger'>[chassis] destroys [target] in an unholy fury.</span>", \
+									"<span class='userdanger'>[chassis] destroys [target] in an unholy fury.</span>")
+				add_logs(chassis.occupant, M, "attacked", "[name]", "(INTENT: [uppertext(chassis.occupant.a_intent)]) (DAMTYE: [uppertext(damtype)])")
+			else
+				target.visible_message("<span class='danger'>[chassis] destroys [target] in an unholy fury.</span>", \
+									"<span class='userdanger'>[chassis] destroys [target] in an unholy fury.</span>")
 		else if(chassis.occupant.a_intent == INTENT_DISARM)
-			var/mob/living/carbon/C = target
-			var/play_sound = FALSE
-			var/obj/item/bodypart/affected = C.get_bodypart(BODY_ZONE_L_ARM)
-			if(affected != null)
-				affected.dismember(damtype)
-				play_sound = TRUE
-			affected = C.get_bodypart(BODY_ZONE_R_ARM)
-			if(affected != null)
-				affected.dismember(damtype)
-				play_sound = TRUE
-			if(play_sound)
-				playsound(get_turf(src), get_dismember_sound(), 80, 1)
+			if(real_clamp)
+				var/mob/living/carbon/C = target
+				var/play_sound = FALSE
+				var/obj/item/bodypart/affected = C.get_bodypart(BODY_ZONE_L_ARM)
+				if(affected != null)
+					affected.dismember(damtype)
+					play_sound = TRUE
+				affected = C.get_bodypart(BODY_ZONE_R_ARM)
+				if(affected != null)
+					affected.dismember(damtype)
+					play_sound = TRUE
+				if(play_sound)
+					playsound(get_turf(src), get_dismember_sound(), 80, 1)
+					target.visible_message("<span class='danger'>[chassis] rips [target]'s arms off.</span>", \
+								   "<span class='userdanger'>[chassis] rips [target]'s arms off.</span>")
+					add_logs(chassis.occupant, M, "attacked", "[name]", "(INTENT: [uppertext(chassis.occupant.a_intent)]) (DAMTYE: [uppertext(damtype)])")
+			else
 				target.visible_message("<span class='danger'>[chassis] rips [target]'s arms off.</span>", \
 								   "<span class='userdanger'>[chassis] rips [target]'s arms off.</span>")
-			add_logs(chassis.occupant, M, "attacked", "[name]", "(INTENT: [uppertext(chassis.occupant.a_intent)]) (DAMTYE: [uppertext(damtype)])")
 		else
 			step_away(M,chassis)
 			target.visible_message("[chassis] tosses [target] like a piece of paper.")

--- a/code/game/mecha/equipment/tools/work_tools.dm
+++ b/code/game/mecha/equipment/tools/work_tools.dm
@@ -78,8 +78,8 @@
 	name = "\improper KILL CLAMP"
 	desc = "They won't know what clamped them!"
 	energy_drain = 0
-	var/real_clamp = FALSE
 	dam_force = 0
+	var/real_clamp = FALSE
 
 /obj/item/mecha_parts/mecha_equipment/hydraulic_clamp/kill/real
 	desc = "They won't know what clamped them! This time for real!"
@@ -144,7 +144,7 @@
 					play_sound = TRUE
 					limbs_gone = "[limbs_gone], [affected]"
 				if(play_sound)
-					playsound(get_turf(src), get_dismember_sound(), 80, TRUE)
+					playsound(src, get_dismember_sound(), 80, TRUE)
 					target.visible_message("<span class='danger'>[chassis] rips [target]'s arms off.</span>", \
 								   "<span class='userdanger'>[chassis] rips [target]'s arms off.</span>")
 					add_logs(chassis.occupant, M, "dismembered of[limbs_gone],", "[name]", "(INTENT: [uppertext(chassis.occupant.a_intent)]) (DAMTYE: [uppertext(damtype)])")

--- a/code/game/mecha/equipment/tools/work_tools.dm
+++ b/code/game/mecha/equipment/tools/work_tools.dm
@@ -81,8 +81,7 @@
 	var/real_clamp = FALSE
 	dam_force = 0
 
-/obj/item/mecha_parts/mecha_equipment/hydraulic_clamp/kill/proper
-	name = "\proper KILL CLAMP"
+/obj/item/mecha_parts/mecha_equipment/hydraulic_clamp/kill/real
 	desc = "They won't know what clamped them! This time for real!"
 	energy_drain = 10
 	dam_force = 20
@@ -133,19 +132,22 @@
 			if(real_clamp)
 				var/mob/living/carbon/C = target
 				var/play_sound = FALSE
+				var/limbs_gone = ""
 				var/obj/item/bodypart/affected = C.get_bodypart(BODY_ZONE_L_ARM)
 				if(affected != null)
 					affected.dismember(damtype)
 					play_sound = TRUE
+					limbs_gone = ", [affected]"
 				affected = C.get_bodypart(BODY_ZONE_R_ARM)
 				if(affected != null)
 					affected.dismember(damtype)
 					play_sound = TRUE
+					limbs_gone = "[limbs_gone], [affected]"
 				if(play_sound)
-					playsound(get_turf(src), get_dismember_sound(), 80, 1)
+					playsound(get_turf(src), get_dismember_sound(), 80, TRUE)
 					target.visible_message("<span class='danger'>[chassis] rips [target]'s arms off.</span>", \
 								   "<span class='userdanger'>[chassis] rips [target]'s arms off.</span>")
-					add_logs(chassis.occupant, M, "attacked", "[name]", "(INTENT: [uppertext(chassis.occupant.a_intent)]) (DAMTYE: [uppertext(damtype)])")
+					add_logs(chassis.occupant, M, "dismembered of[limbs_gone],", "[name]", "(INTENT: [uppertext(chassis.occupant.a_intent)]) (DAMTYE: [uppertext(damtype)])")
 			else
 				target.visible_message("<span class='danger'>[chassis] rips [target]'s arms off.</span>", \
 								   "<span class='userdanger'>[chassis] rips [target]'s arms off.</span>")

--- a/code/game/mecha/equipment/tools/work_tools.dm
+++ b/code/game/mecha/equipment/tools/work_tools.dm
@@ -115,11 +115,16 @@
 			M.updatehealth()
 			target.visible_message("<span class='danger'>[chassis] destroys [target] in an unholy fury.</span>", \
 								"<span class='userdanger'>[chassis] destroys [target] in an unholy fury.</span>")
-
 			add_logs(chassis.occupant, M, "attacked", "[name]", "(INTENT: [uppertext(chassis.occupant.a_intent)]) (DAMTYE: [uppertext(damtype)])")
 		else if(chassis.occupant.a_intent == INTENT_DISARM)
+			var/mob/living/carbon/C = target
+			var/obj/item/bodypart/affected = C.get_bodypart(BODY_ZONE_L_ARM)
+			affected.dismember(damtype)
+			affected = C.get_bodypart(BODY_ZONE_R_ARM)
+			affected.dismember(damtype)
+			playsound(get_turf(src), get_dismember_sound(), 80, 1)
 			target.visible_message("<span class='danger'>[chassis] rips [target]'s arms off.</span>", \
-								"<span class='userdanger'>[chassis] rips [target]'s arms off.</span>")
+								   "<span class='userdanger'>[chassis] rips [target]'s arms off.</span>")
 		else
 			step_away(M,chassis)
 			target.visible_message("[chassis] tosses [target] like a piece of paper.")

--- a/code/game/mecha/equipment/tools/work_tools.dm
+++ b/code/game/mecha/equipment/tools/work_tools.dm
@@ -115,6 +115,7 @@
 			M.updatehealth()
 			target.visible_message("<span class='danger'>[chassis] destroys [target] in an unholy fury.</span>", \
 								"<span class='userdanger'>[chassis] destroys [target] in an unholy fury.</span>")
+
 			add_logs(chassis.occupant, M, "attacked", "[name]", "(INTENT: [uppertext(chassis.occupant.a_intent)]) (DAMTYE: [uppertext(damtype)])")
 		else if(chassis.occupant.a_intent == INTENT_DISARM)
 			target.visible_message("<span class='danger'>[chassis] rips [target]'s arms off.</span>", \

--- a/code/game/mecha/equipment/tools/work_tools.dm
+++ b/code/game/mecha/equipment/tools/work_tools.dm
@@ -117,7 +117,7 @@
 								"<span class='userdanger'>[chassis] destroys [target] in an unholy fury.</span>")
 
 			add_logs(chassis.occupant, M, "attacked", "[name]", "(INTENT: [uppertext(chassis.occupant.a_intent)]) (DAMTYE: [uppertext(damtype)])")
-		if(chassis.occupant.a_intent == INTENT_DISARM)
+		else if(chassis.occupant.a_intent == INTENT_DISARM)
 			target.visible_message("<span class='danger'>[chassis] rips [target]'s arms off.</span>", \
 								"<span class='userdanger'>[chassis] rips [target]'s arms off.</span>")
 		else

--- a/code/game/mecha/equipment/tools/work_tools.dm
+++ b/code/game/mecha/equipment/tools/work_tools.dm
@@ -118,13 +118,20 @@
 			add_logs(chassis.occupant, M, "attacked", "[name]", "(INTENT: [uppertext(chassis.occupant.a_intent)]) (DAMTYE: [uppertext(damtype)])")
 		else if(chassis.occupant.a_intent == INTENT_DISARM)
 			var/mob/living/carbon/C = target
+			var/play_sound = FALSE
 			var/obj/item/bodypart/affected = C.get_bodypart(BODY_ZONE_L_ARM)
-			affected.dismember(damtype)
+			if(affected != null)
+				affected.dismember(damtype)
+				play_sound = TRUE
 			affected = C.get_bodypart(BODY_ZONE_R_ARM)
-			affected.dismember(damtype)
-			playsound(get_turf(src), get_dismember_sound(), 80, 1)
-			target.visible_message("<span class='danger'>[chassis] rips [target]'s arms off.</span>", \
+			if(affected != null)
+				affected.dismember(damtype)
+				play_sound = TRUE
+			if(play_sound)
+				playsound(get_turf(src), get_dismember_sound(), 80, 1)
+				target.visible_message("<span class='danger'>[chassis] rips [target]'s arms off.</span>", \
 								   "<span class='userdanger'>[chassis] rips [target]'s arms off.</span>")
+			add_logs(chassis.occupant, M, "attacked", "[name]", "(INTENT: [uppertext(chassis.occupant.a_intent)]) (DAMTYE: [uppertext(damtype)])")
 		else
 			step_away(M,chassis)
 			target.visible_message("[chassis] tosses [target] like a piece of paper.")

--- a/code/game/mecha/equipment/tools/work_tools.dm
+++ b/code/game/mecha/equipment/tools/work_tools.dm
@@ -108,8 +108,15 @@
 		if(M.stat == DEAD)
 			return
 		if(chassis.occupant.a_intent == INTENT_HARM)
+			M.take_overall_damage(dam_force)
+			if(!M)
+				return
+			M.adjustOxyLoss(round(dam_force/2))
+			M.updatehealth()
 			target.visible_message("<span class='danger'>[chassis] destroys [target] in an unholy fury.</span>", \
 								"<span class='userdanger'>[chassis] destroys [target] in an unholy fury.</span>")
+
+			add_logs(chassis.occupant, M, "attacked", "[name]", "(INTENT: [uppertext(chassis.occupant.a_intent)]) (DAMTYE: [uppertext(damtype)])")
 		if(chassis.occupant.a_intent == INTENT_DISARM)
 			target.visible_message("<span class='danger'>[chassis] rips [target]'s arms off.</span>", \
 								"<span class='userdanger'>[chassis] rips [target]'s arms off.</span>")

--- a/code/game/mecha/equipment/tools/work_tools.dm
+++ b/code/game/mecha/equipment/tools/work_tools.dm
@@ -115,7 +115,6 @@
 			M.updatehealth()
 			target.visible_message("<span class='danger'>[chassis] destroys [target] in an unholy fury.</span>", \
 								"<span class='userdanger'>[chassis] destroys [target] in an unholy fury.</span>")
-
 			add_logs(chassis.occupant, M, "attacked", "[name]", "(INTENT: [uppertext(chassis.occupant.a_intent)]) (DAMTYE: [uppertext(damtype)])")
 		else if(chassis.occupant.a_intent == INTENT_DISARM)
 			target.visible_message("<span class='danger'>[chassis] rips [target]'s arms off.</span>", \

--- a/code/game/mecha/working/ripley.dm
+++ b/code/game/mecha/working/ripley.dm
@@ -88,16 +88,15 @@
 	var/obj/item/mecha_parts/mecha_equipment/ME = new /obj/item/mecha_parts/mecha_equipment/hydraulic_clamp/kill
 	ME.attach(src)
 
-/obj/mecha/working/ripley/deathripley/proper
+/obj/mecha/working/ripley/deathripley/real
 	desc = "OH SHIT IT'S THE DEATHSQUAD WE'RE ALL GONNA DIE. FOR REAL"
-	name = "\proper DEATH-RIPLEY"
 
-/obj/mecha/working/ripley/deathripley/proper/Initialize()
+/obj/mecha/working/ripley/deathripley/real/Initialize()
 	. = ..()
 	for(var/obj/item/mecha_parts/mecha_equipment/E in equipment)
 		E.detach()
 		qdel(E)
-	var/obj/item/mecha_parts/mecha_equipment/ME = new /obj/item/mecha_parts/mecha_equipment/hydraulic_clamp/kill/proper
+	var/obj/item/mecha_parts/mecha_equipment/ME = new /obj/item/mecha_parts/mecha_equipment/hydraulic_clamp/kill/real
 	ME.attach(src)
 
 /obj/mecha/working/ripley/mining

--- a/code/game/mecha/working/ripley.dm
+++ b/code/game/mecha/working/ripley.dm
@@ -88,6 +88,18 @@
 	var/obj/item/mecha_parts/mecha_equipment/ME = new /obj/item/mecha_parts/mecha_equipment/hydraulic_clamp/kill
 	ME.attach(src)
 
+/obj/mecha/working/ripley/deathripley/proper
+	desc = "OH SHIT IT'S THE DEATHSQUAD WE'RE ALL GONNA DIE. FOR REAL"
+	name = "\proper DEATH-RIPLEY"
+
+/obj/mecha/working/ripley/deathripley/proper/Initialize()
+	. = ..()
+	for(var/obj/item/mecha_parts/mecha_equipment/E in equipment)
+		E.detach()
+		qdel(E)
+	var/obj/item/mecha_parts/mecha_equipment/ME = new /obj/item/mecha_parts/mecha_equipment/hydraulic_clamp/kill/proper
+	ME.attach(src)
+
 /obj/mecha/working/ripley/mining
 	desc = "An old, dusty mining Ripley."
 	name = "\improper APLU \"Miner\""

--- a/code/game/mecha/working/ripley.dm
+++ b/code/game/mecha/working/ripley.dm
@@ -96,6 +96,7 @@
 	for(var/obj/item/mecha_parts/mecha_equipment/E in equipment)
 		E.detach()
 		qdel(E)
+	equipment.Cut()
 	var/obj/item/mecha_parts/mecha_equipment/ME = new /obj/item/mecha_parts/mecha_equipment/hydraulic_clamp/kill/real
 	ME.attach(src)
 


### PR DESCRIPTION

:cl: 
add: Admin spawnable Death Ripley that comes with a version of the Death Clamp that actually inflicts damage and rips arms off.
/:cl:

The Death Ripley uses a KILL CLAMP rather than the normal clamp and overrides its action, though doesn't actually inflict any damage on the target. This fix simply inflicts that damage.

~~On disarm intent the KILL CLAMP is supposed to rip off the targets arms. As of writing this I'm not sure how to do this. I've been looking through trying to find how to do this, but any hints on where to look would be appreciated.~~
figured it out.

