### PR TITLE
Adds config deprecation system

### DIFF
--- a/code/controllers/configuration/config_entry.dm
+++ b/code/controllers/configuration/config_entry.dm
@@ -10,6 +10,8 @@
 	var/resident_file	//the file which this was loaded from, if any
 	var/modified = FALSE	//set to TRUE if the default has been overridden by a config entry
 
+	var/deprecated_by	//the /datum/config_entry type that supercedes this one
+
 	var/protection = NONE
 	var/abstract_type = /datum/config_entry	//do not instantiate if type matches this
 
@@ -84,6 +86,9 @@
 
 /datum/config_entry/proc/ValidateListEntry(key_name, key_value)
 	return TRUE
+
+/datum/config_entry/proc/DeprecationUpdate(value)
+	return
 
 /datum/config_entry/string
 	config_entry_value = ""

--- a/code/controllers/configuration/configuration.dm
+++ b/code/controllers/configuration/configuration.dm
@@ -3,6 +3,7 @@
 
 	var/directory = "config"
 
+	var/warned_deprecated_configs = FALSE
 	var/hiding_entries_by_type = TRUE	//Set for readability, admins can set this to FALSE if they want to debug it
 	var/list/entries
 	var/list/entries_by_type
@@ -123,11 +124,26 @@
 		if(lockthis)
 			E.protection |= CONFIG_ENTRY_LOCKED
 
+		if(E.deprecated_by)
+			var/datum/config_entry/new_ver = entries_by_type[E.deprecated_by]
+			var/new_value = E.DeprecationUpdate(value)
+			var/good_update = istext(new_value)
+			log_config("Entry [entry] is deprecated and will be removed soon. Migrate to [new_ver.name]![good_update ? " Suggested new value is: [new_value]" : ""]")
+			if(!warned_deprecated_configs)
+				addtimer(CALLBACK(GLOBAL_PROC, /proc/message_admins, "This server is using deprecated configuration settings. Please check the logs and update accordingly."), 0)
+				warned_deprecated_configs = TRUE
+			if(good_update)
+				value = new_value
+				E = new_ver
+			else
+				warning("[new_ver.type] is deprecated but gave no proper return for DeprecationUpdate()")
+			
 		var/validated = E.ValidateAndSet(value)
 		if(!validated)
 			log_config("Failed to validate setting \"[value]\" for [entry]")
-		else if(E.modified && !E.dupes_allowed)
-			log_config("Duplicate setting for [entry] ([value], [E.resident_file]) detected! Using latest.")
+		else 
+			if(E.modified && !E.dupes_allowed)
+				log_config("Duplicate setting for [entry] ([value], [E.resident_file]) detected! Using latest.")
 
 		E.resident_file = filename
 		


### PR DESCRIPTION
:cl:
server: Logs and admin messages will now appear when you are using deprecated config settings and advise on upgrades
/:cl:

A lot of our flags are inverted from sane defaults. I plan on fixing this in the future, this helps with that and any other future config changes we need to make.