### PR TITLE
Fixed cyborgs not getting their names at round start 

### DIFF
--- a/code/__HELPERS/unsorted.dm
+++ b/code/__HELPERS/unsorted.dm
@@ -195,7 +195,7 @@ Turf and target are separate in case you want to teleport some distance from a t
 	var/safety = 0
 
 	while(loop && safety < 5)
-		if(C && C.prefs.custom_names[role] && !safety)
+		if(C && C.prefs.custom_names[role] && !safety && (!jobban_isbanned(src, "appearance")))
 			newname = C.prefs.custom_names[role]
 		else
 			switch(role)

--- a/code/controllers/configuration/entries/game_options.dm
+++ b/code/controllers/configuration/entries/game_options.dm
@@ -170,8 +170,6 @@
 	config_entry_value = -1
 	min_val = -1
 
-/datum/config_entry/flag/rename_cyborg
-
 /datum/config_entry/flag/ooc_during_round
 
 /datum/config_entry/flag/emojis

--- a/code/controllers/subsystem/job.dm
+++ b/code/controllers/subsystem/job.dm
@@ -442,7 +442,7 @@ SUBSYSTEM_DEF(job)
 			to_chat(M, "<FONT color='blue'><B>As this station was initially staffed with a [CONFIG_GET(flag/jobs_have_minimal_access) ? "full crew, only your job's necessities" : "skeleton crew, additional access may"] have been added to your ID card.</B></font>")
 
 	if(job && H)
-		job.after_spawn(H, M, joined_late)
+		job.after_spawn(H, M, joined_late) // note:this happens before the mob has a key!
 
 	return H
 

--- a/code/controllers/subsystem/job.dm
+++ b/code/controllers/subsystem/job.dm
@@ -442,7 +442,7 @@ SUBSYSTEM_DEF(job)
 			to_chat(M, "<FONT color='blue'><B>As this station was initially staffed with a [CONFIG_GET(flag/jobs_have_minimal_access) ? "full crew, only your job's necessities" : "skeleton crew, additional access may"] have been added to your ID card.</B></font>")
 
 	if(job && H)
-		job.after_spawn(H, M, joined_late) // note:this happens before the mob has a key!
+		job.after_spawn(H, M, joined_late) // note: this happens before the mob has a key! M will always have a client, H might not.
 
 	return H
 

--- a/code/modules/jobs/job_types/silicon.dm
+++ b/code/modules/jobs/job_types/silicon.dm
@@ -85,5 +85,4 @@ Cyborg
 	return H.Robotize(FALSE, latejoin)
 
 /datum/job/cyborg/after_spawn(mob/living/silicon/robot/R, mob/M)
-	if(CONFIG_GET(flag/rename_cyborg))	//name can't be set in robot/New without the client
 		R.rename_self("cyborg", M.client)

--- a/code/modules/jobs/job_types/silicon.dm
+++ b/code/modules/jobs/job_types/silicon.dm
@@ -85,4 +85,4 @@ Cyborg
 	return H.Robotize(FALSE, latejoin)
 
 /datum/job/cyborg/after_spawn(mob/living/silicon/robot/R, mob/M)
-		R.rename_self("cyborg", M.client)
+	R.rename_self("cyborg", M.client)

--- a/code/modules/mob/living/silicon/robot/robot.dm
+++ b/code/modules/mob/living/silicon/robot/robot.dm
@@ -228,7 +228,8 @@
 	if(custom_name)
 		changed_name = custom_name
 	if(changed_name == "" && client)
-		changed_name = client.prefs.custom_names["cyborg"]
+		rename_self(src, client)
+		return //built in camera handled in proc
 	if(!changed_name)
 		changed_name = get_standard_name()
 

--- a/code/modules/mob/transform_procs.dm
+++ b/code/modules/mob/transform_procs.dm
@@ -379,8 +379,7 @@
 	else if(transfer_after)
 		R.key = key
 
-	if (CONFIG_GET(flag/rename_cyborg))
-		R.rename_self("cyborg")
+	R.rename_self("cyborg")
 
 	if(R.mmi)
 		R.mmi.name = "Man-Machine Interface: [real_name]"

--- a/config/game_options.txt
+++ b/config/game_options.txt
@@ -16,9 +16,6 @@ REVIVAL_BRAIN_LIFE -1
 
 ## RENAMING ###
 
-## Uncomment to allow cyborgs to rename themselves at roundstart.  Has no effect on roboticists renaming cyborgs the normal way.
-#RENAME_CYBORG
-
 ## OOC DURING ROUND ###
 ## Comment this out if you want OOC to be automatically disabled during the round, it will be enabled during the lobby and after the round end results.
 OOC_DURING_ROUND


### PR DESCRIPTION
Also, fixed cyborgs and A.Is being able to get around appearance bans

[Changelogs]: # 
:cl: 
fix: Fixed cyborgs not getting their names at round start
fix: Fixed cyborgs and A.I.s being able to bypass appearance bans
/:cl:

[why]: # fixes #38281 also I realized they can get around appearance bans this way. Added a check for that. This was an absolute pain to look over since I didn't know when the minds were transferred to mobs so I left a friendly note for anyone who attempts to read this behemoth of code without any help. We don't set that config on our side so I don't think it's much use to anyone.
