### PR TITLE
motion sensitive cameras no longer sound the alarm if EMPed

### DIFF
--- a/code/game/machinery/camera/motion.dm
+++ b/code/game/machinery/camera/motion.dm
@@ -10,6 +10,8 @@
 	if(!isMotion())
 		. = PROCESS_KILL
 		return
+	if(stat & EMPED)
+		return
 	if (detectTime > 0)
 		var/elapsed = world.time - detectTime
 		if (elapsed > alarm_delay)


### PR DESCRIPTION
:cl: 
fix: Cameras that are EMPed no longer sound an alarm
/:cl:

[why]: # closes #38674 unless you'd rather an EMP trigger an alarm?