### PR TITLE
Modifies the adminhelp system to allow for servers to send a reminder message about policy when opening the dialouge

### DIFF
--- a/code/modules/admin/verbs/adminhelp.dm
+++ b/code/modules/admin/verbs/adminhelp.dm
@@ -487,7 +487,7 @@ GLOBAL_DATUM_INIT(ahelp_tickets, /datum/admin_help_tickets, new)
 	if(GLOB.say_disabled)	//This is here to try to identify lag problems
 		to_chat(usr, "<span class='danger'>Speech is currently admin-disabled.</span>")
 		return
-	to_chat(usr, "<span class='notice'>Please keep rule 10 in mind, losing is part of the game. your character will frequently die, sometimes without even a possibility of avoiding it. No matter how good or prepared you are, sometimes you just lose. Adminhelp is not intended to be a 'I got outrobusted button' it's intended for genuine issues that require admin assistance.</span>")
+	to_chat(usr, config.policies["adminhelpnotification"])
 
 	//handle muting and automuting
 	if(prefs.muted & MUTE_ADMINHELP)

--- a/code/modules/admin/verbs/adminhelp.dm
+++ b/code/modules/admin/verbs/adminhelp.dm
@@ -487,6 +487,7 @@ GLOBAL_DATUM_INIT(ahelp_tickets, /datum/admin_help_tickets, new)
 	if(GLOB.say_disabled)	//This is here to try to identify lag problems
 		to_chat(usr, "<span class='danger'>Speech is currently admin-disabled.</span>")
 		return
+	usr << "<span class='notice'>Please keep rule 10 in mind, losing is part of the game. your character will frequently die, sometimes without even a possibility of avoiding it. No matter how good or prepared you are, sometimes you just lose. Adminhelp is not intended to be a 'I got outrobusted button' it's intended for genuine issues that require admin assistance.</span>"
 
 	//handle muting and automuting
 	if(prefs.muted & MUTE_ADMINHELP)

--- a/code/modules/admin/verbs/adminhelp.dm
+++ b/code/modules/admin/verbs/adminhelp.dm
@@ -487,7 +487,7 @@ GLOBAL_DATUM_INIT(ahelp_tickets, /datum/admin_help_tickets, new)
 	if(GLOB.say_disabled)	//This is here to try to identify lag problems
 		to_chat(usr, "<span class='danger'>Speech is currently admin-disabled.</span>")
 		return
-	usr << "<span class='notice'>Please keep rule 10 in mind, losing is part of the game. your character will frequently die, sometimes without even a possibility of avoiding it. No matter how good or prepared you are, sometimes you just lose. Adminhelp is not intended to be a 'I got outrobusted button' it's intended for genuine issues that require admin assistance.</span>"
+	to_chat(usr, "<span class='notice'>Please keep rule 10 in mind, losing is part of the game. your character will frequently die, sometimes without even a possibility of avoiding it. No matter how good or prepared you are, sometimes you just lose. Adminhelp is not intended to be a 'I got outrobusted button' it's intended for genuine issues that require admin assistance.</span>")
 
 	//handle muting and automuting
 	if(prefs.muted & MUTE_ADMINHELP)

--- a/config/policies.txt
+++ b/config/policies.txt
@@ -3,3 +3,5 @@
 
 # When a mob is polymorphed
 POLYMORPH <span class='danger'>Note that you are allowed to act as an antagonist while transformed into a hostile mob, unless you volunteered for or sought out transformation.</span>
+# When a player opens adminhelp
+ADMINHELPNOTIFICATION <span class='notice'>Please keep rule 10 in mind, losing is part of the game. your character will frequently die, sometimes without even a possibility of avoiding it. No matter how good or prepared you are, sometimes you just lose. Adminhelp is not intended to be a 'I got outrobusted button' it's intended for genuine issues that require admin assistance.</span>


### PR DESCRIPTION
:tada: 
[Changelogs]:

:cl: F-OS
admin: Adminhelp now contains a warning message so players know it's not a "I got outrobusted send help" button, this is alterable with config changes.
/:cl:

[why]:

Based on what i've heard, there is a genuine issue of adminhelp becoming the go to for minor issues that should be resolved IC, and this has a chilling effect on roleplay because players live in fear of the bwoink, i'm suggesting this as a small solution to that problem. 


Original pr idea credited to kor in #21535 