### PR TITLE
Destructive analyzers can now destroy anything again, even if it has no materials

### DIFF
--- a/code/modules/research/destructive_analyzer.dm
+++ b/code/modules/research/destructive_analyzer.dm
@@ -126,7 +126,12 @@ Note: Must be placed within 3 tiles of the R&D Console
 		var/list/point_value = techweb_item_point_check(loaded_item)
 		if(linked_console.stored_research.deconstructed_items[loaded_item.type])
 			point_value = list()
-		var/choice = input("Are you sure you want to destroy [loaded_item] for [length(point_value) ? "[json_encode(point_value)] points" : "material reclamation"]?") in list("Proceed", "Cancel")
+		var/user_mode_string = ""
+		if(length(point_value))
+			user_mode_string = " for [json_encode(point_value)] points"
+		else if(loaded_item.materials.len)
+			user_mode_string = " for material reclamation"
+		var/choice = input("Are you sure you want to destroy [loaded_item][user_mode_string]?") in list("Proceed", "Cancel")
 		if(choice == "Cancel")
 			return FALSE
 		if(QDELETED(loaded_item) || QDELETED(linked_console) || !user.Adjacent(linked_console) || QDELETED(src))

--- a/code/modules/research/rdconsole.dm
+++ b/code/modules/research/rdconsole.dm
@@ -594,9 +594,9 @@ Nothing else in the console has ID requirements.
 				l += "This item is worth: <BR>[techweb_point_display_generic(point_values)]!"
 			l += "</div>[RDSCREEN_NOBREAK]"
 
-		var/list/materials = linked_destroy.loaded_item.materials
-		if (materials.len)
-			l += "<div class='statusDisplay'><A href='?src=[REF(src)];deconstruct=[RESEARCH_MATERIAL_RECLAMATION_ID]'>Material Reclamation</A>"
+		if(!(linked_destroy.loaded_item.resistance_flags & INDESTRUCTIBLE))
+			var/list/materials = linked_destroy.loaded_item.materials
+			l += "<div class='statusDisplay'><A href='?src=[REF(src)];deconstruct=[RESEARCH_MATERIAL_RECLAMATION_ID]'>[materials.len? "Material Reclamation" : "Destroy Item"]</A>"
 			for (var/M in materials)
 				l += "* [CallMaterialName(M)] x [materials[M]]"
 			l += "</div>[RDSCREEN_NOBREAK]"


### PR DESCRIPTION
before techwebs they could do this and it's inconsistent for them to not be able to destroy things that have no material value anymore.
:cl:
rscadd: R&D deconstructors can now destroy things regardless of if there's a point value or material 
/:cl: