### PR TITLE
Hardsuit helmets protect eyes from pepperspray

### DIFF
--- a/code/modules/reagents/chemistry/reagents/food_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/food_reagents.dm
@@ -283,10 +283,10 @@
 		if(ishuman(victim))
 			var/mob/living/carbon/human/H = victim
 			if( H.head )
-				if ( H.head.flags_cover & MASKCOVERSEYES )
+				if ( H.head.flags_cover & HEADCOVERSEYES )
 					eyes_covered = 1
 					safe_thing = H.head
-				if ( H.head.flags_cover & MASKCOVERSMOUTH )
+				if ( H.head.flags_cover & HEADCOVERSMOUTH )
 					mouth_covered = 1
 					safe_thing = H.head
 			if(H.glasses)


### PR DESCRIPTION
The reaction code for condensed capsaicin wasn't using the correct flag when checking the targets helmet. 

:cl:
fix: Hardsuit helmets now protect the wearer from pepperspray
/:cl:

fixes: #38686 
