### PR TITLE
Fixes hardsuits not covering eyes/mouth

### DIFF
--- a/code/modules/clothing/spacesuits/hardsuit.dm
+++ b/code/modules/clothing/spacesuits/hardsuit.dm
@@ -6,6 +6,7 @@
 	item_state = "eng_helm"
 	max_integrity = 300
 	armor = list("melee" = 10, "bullet" = 5, "laser" = 10, "energy" = 5, "bomb" = 10, "bio" = 100, "rad" = 75, "fire" = 50, "acid" = 75)
+	flags_cover = HEADCOVERSEYES | HEADCOVERSMOUTH
 	var/basestate = "hardsuit"
 	var/brightness_on = 4 //luminosity when on
 	var/on = FALSE

--- a/code/modules/reagents/chemistry/reagents/food_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/food_reagents.dm
@@ -280,13 +280,13 @@
 				safe_thing = victim.wear_mask
 
 		//only humans can have helmets and glasses
-		if(ishuman(victim))
+		if(!ismonkey(victim))
 			var/mob/living/carbon/human/H = victim
 			if( H.head )
-				if ( H.head.flags_cover & MASKCOVERSEYES )
+				if ( H.head.flags_cover & HEADCOVERSEYES )
 					eyes_covered = 1
 					safe_thing = H.head
-				if ( H.head.flags_cover & MASKCOVERSMOUTH )
+				if ( H.head.flags_cover & HEADCOVERSMOUTH )
 					mouth_covered = 1
 					safe_thing = H.head
 			if(H.glasses)


### PR DESCRIPTION

[Changelogs]: # Pepperspray was affecting people that had headwear that covered their entire head. Also, helmets weren't using the correct flags since they cover both the mouth and eyes.

:cl: 
fix: fixed hardsuits flags and pepperspray
/:cl:

[why]: Fixes #38686
