### PR TITLE
Fix runtimes when energy guns are deleted

### DIFF
--- a/code/modules/projectiles/guns/energy.dm
+++ b/code/modules/projectiles/guns/energy.dm
@@ -130,6 +130,8 @@
 	return
 
 /obj/item/gun/energy/update_icon(force_update)
+	if(QDELETED(src))
+		return
 	..()
 	if(!automatic_charge_overlays)
 		return


### PR DESCRIPTION
`Destroy` qdels contents which calls `handle_atom_del` which calls `update_icon` which can't find `cell` since it was just `QDEL_NULL`ed.

```
[15:01:57] Runtime in energy.dm,136: Cannot read null.charge
  proc name: update icon (/obj/item/gun/energy/update_icon)
  usr: Joe Bine (spacemaniac) (/mob/living/carbon/human)
  usr.loc: The floor (56,54,2) (/turf/open/floor/plasteel)
  src: the taser gun (/obj/item/gun/energy/taser)
  src.loc: the floor (56,55,2) (/turf/open/floor/plasteel)
  call stack:
  the taser gun (/obj/item/gun/energy/taser): update icon(null)
  the taser gun (/obj/item/gun/energy/taser): handle atom del(the energy weapon lens (/obj/item/ammo_casing/energy/electrode))
  the energy weapon lens (/obj/item/ammo_casing/energy/electrode): Destroy(0)
  the energy weapon lens (/obj/item/ammo_casing/energy/electrode): Destroy(0)
  the energy weapon lens (/obj/item/ammo_casing/energy/electrode): Destroy(0)
  the energy weapon lens (/obj/item/ammo_casing/energy/electrode): Destroy(0)
  the energy weapon lens (/obj/item/ammo_casing/energy/electrode): Destroy(0)
  qdel(the energy weapon lens (/obj/item/ammo_casing/energy/electrode), 0)
  the taser gun (/obj/item/gun/energy/taser): Destroy(0)
  the taser gun (/obj/item/gun/energy/taser): Destroy(0)
  the taser gun (/obj/item/gun/energy/taser): Destroy(0)
  the taser gun (/obj/item/gun/energy/taser): Destroy(0)
  the taser gun (/obj/item/gun/energy/taser): Destroy(0)
  the taser gun (/obj/item/gun/energy/taser): Destroy(0)
  qdel(the taser gun (/obj/item/gun/energy/taser), 0)
  SpaceManiac (/client): admin delete(the taser gun (/obj/item/gun/energy/taser))
  SpaceManiac (/client): Delete(the taser gun (/obj/item/gun/energy/taser))
```