### PR TITLE
Fix being unable to export mechs

### DIFF
--- a/code/modules/shuttle/supply.dm
+++ b/code/modules/shuttle/supply.dm
@@ -124,7 +124,7 @@ GLOBAL_LIST_INIT(blacklisted_cargo_types, typecacheof(list(
 				continue
 			if(bounty_ship_item_and_contents(AM, dry_run = FALSE))
 				matched_bounty = TRUE
-			if(!AM.anchored)
+			if(!AM.anchored || istype(AM, /obj/mecha))
 				sold_atoms += export_item_and_contents(AM, contraband, emagged, dry_run = FALSE)
 
 	if(sold_atoms)


### PR DESCRIPTION
:cl:
fix: It is once again possible for Cargo to export mechs.
/:cl:

Fixes #37775.
Broken by #29049.