### PR TITLE
Fixes a bug with Branca Menta and moves Fernet to contraband

### DIFF
--- a/code/modules/reagents/chemistry/machinery/chem_dispenser.dm
+++ b/code/modules/reagents/chemistry/machinery/chem_dispenser.dm
@@ -467,14 +467,14 @@
 		"creme_de_menthe",
 		"creme_de_cacao",
 		"triple_sec",
-		"sake",
-		"fernet"
+		"sake"
 	)
 	emagged_reagents = list(
 		"ethanol",
 		"iron",
 		"minttoxin",
-		"atomicbomb"
+		"atomicbomb",
+		"fernet"
 	)
 
 

--- a/code/modules/reagents/chemistry/reagents/alcohol_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/alcohol_reagents.dm
@@ -1739,10 +1739,6 @@ All effects don't start immediately, but rather get worse over time; the rate is
 
 /datum/reagent/consumable/ethanol/branca_menta/on_mob_life(mob/living/M)
 	M.adjust_bodytemperature(-20 * TEMPERATURE_DAMAGE_COEFFICIENT, T0C)
-	if(M.nutrition <= NUTRITION_LEVEL_STARVING)
-		M.adjustToxLoss(1*REM, 0)
-	M.nutrition = max(M.nutrition - 5, 0)
-	M.overeatduration = 0
 	return ..()
 
 /datum/reagent/consumable/ethanol/branca_menta/on_mob_add(mob/living/M)

--- a/code/modules/reagents/reagent_containers/borghydro.dm
+++ b/code/modules/reagents/reagent_containers/borghydro.dm
@@ -180,7 +180,7 @@ Borg Shaker
 	recharge_time = 3
 	accepts_reagent_upgrades = FALSE
 
-	reagent_ids = list("beer", "orangejuice", "grenadine", "limejuice", "tomatojuice", "cola", "tonic", "sodawater", "ice", "cream", "whiskey", "vodka", "rum", "gin", "tequila", "vermouth", "wine", "kahlua", "cognac", "ale", "fernet", "milk", "coffee", "banana", "lemonjuice")
+	reagent_ids = list("beer", "orangejuice", "grenadine", "limejuice", "tomatojuice", "cola", "tonic", "sodawater", "ice", "cream", "whiskey", "vodka", "rum", "gin", "tequila", "vermouth", "wine", "kahlua", "cognac", "ale", "milk", "coffee", "banana", "lemonjuice")
 
 /obj/item/reagent_containers/borghypo/borgshaker/attack(mob/M, mob/user)
 	return //Can't inject stuff with a shaker, can we? //not with that attitude
@@ -235,7 +235,7 @@ Borg Shaker
 	recharge_time = 3
 	accepts_reagent_upgrades = FALSE
 
-	reagent_ids = list("fakebeer")
+	reagent_ids = list("fakebeer", "fernet")
 
 /obj/item/reagent_containers/borghypo/peace
 	name = "Peace Hypospray"

--- a/code/modules/vending/boozeomat.dm
+++ b/code/modules/vending/boozeomat.dm
@@ -16,7 +16,6 @@
 					/obj/item/reagent_containers/food/drinks/bottle/absinthe = 5,
 					/obj/item/reagent_containers/food/drinks/bottle/grappa = 5,
 					/obj/item/reagent_containers/food/drinks/bottle/sake = 5,
-					/obj/item/reagent_containers/food/drinks/bottle/fernet = 5,
 					/obj/item/reagent_containers/food/drinks/ale = 6,
 					/obj/item/reagent_containers/food/drinks/bottle/orangejuice = 4,
 					/obj/item/reagent_containers/food/drinks/bottle/tomatojuice = 4,
@@ -32,7 +31,8 @@
 					/obj/item/reagent_containers/food/drinks/drinkingglass/shotglass = 12,
 					/obj/item/reagent_containers/food/drinks/flask = 3,
 					/obj/item/reagent_containers/food/drinks/beer = 6)
-	contraband = list(/obj/item/reagent_containers/food/drinks/mug/tea = 12)
+	contraband = list(/obj/item/reagent_containers/food/drinks/mug/tea = 12,
+					  /obj/item/reagent_containers/food/drinks/bottle/fernet = 5)
 	product_slogans = "I hope nobody asks me for a bloody cup o' tea...;Alcohol is humanity's friend. Would you abandon a friend?;Quite delighted to serve you!;Is nobody thirsty on this station?"
 	product_ads = "Drink up!;Booze is good for you!;Alcohol is humanity's best friend.;Quite delighted to serve you!;Care for a nice, cold beer?;Nothing cures you like booze!;Have a sip!;Have a drink!;Have a beer!;Beer is good for you!;Only the finest alcohol!;Best quality booze since 2053!;Award-winning wine!;Maximum alcohol!;Man loves beer.;A toast for progress!"
 	req_access = list(ACCESS_BAR)
@@ -55,11 +55,11 @@
 	req_access = null
 
 /obj/machinery/vending/boozeomat/pubby_captain //Captain's quarters on Pubbystation
-	products = list(/obj/item/reagent_containers/food/drinks/bottle/rum = 1, 
-					/obj/item/reagent_containers/food/drinks/bottle/wine = 1, 
-					/obj/item/reagent_containers/food/drinks/ale = 1, 
-					/obj/item/reagent_containers/food/drinks/drinkingglass = 6, 
-					/obj/item/reagent_containers/food/drinks/ice = 1, 
+	products = list(/obj/item/reagent_containers/food/drinks/bottle/rum = 1,
+					/obj/item/reagent_containers/food/drinks/bottle/wine = 1,
+					/obj/item/reagent_containers/food/drinks/ale = 1,
+					/obj/item/reagent_containers/food/drinks/drinkingglass = 6,
+					/obj/item/reagent_containers/food/drinks/ice = 1,
 					/obj/item/reagent_containers/food/drinks/drinkingglass/shotglass = 4);
 	req_access = list(ACCESS_CAPTAIN)
 


### PR DESCRIPTION
:cl: Mickyan
fix: Branca Menta won't make you starve and then kill you
tweak: Fernet has been moved to contraband
/:cl:

Closes #38565
See issue above for more detailed discussion & context.

Branca Menta was not supposed to lower satiety according to the original creator

A single glass of Fernet is enough to starve you(tested at about 350 nutriment, 400 being the roundstart max) and then kill you through toxloss, making it the deadliest drink the bartender has with the exception of Bacchus Blessing. 
The original PR was misleading and gave the impression that this was meant to be a weaker, no risk alternative to lipolicide while it's the opposite.
This is ridiculous, makes no sense and has no business being in the bartender's standard selection where it can easily be mistaken for a regular drink by anyone who didn't read the code for it. 
If a bartender wants to risk poisoning people they may do so willfully by going the extra mile for it.