### PR TITLE
Prevents reagents being transferred to a bucket while its worn on a head

### DIFF
--- a/code/modules/reagents/reagent_containers/glass.dm
+++ b/code/modules/reagents/reagent_containers/glass.dm
@@ -290,6 +290,11 @@
 		to_chat(user, "<span class='userdanger'>[src]'s contents spill all over you!</span>")
 		reagents.reaction(user, TOUCH)
 		reagents.clear_reagents()
+		container_type = NONE
+
+/obj/item/reagent_containers/glass/bucket/dropped(mob/user)
+	..()
+	container_type = OPENCONTAINER
 
 /obj/item/reagent_containers/glass/bucket/equip_to_best_slot(var/mob/M)
 	if(reagents.total_volume) //If there is water in a bucket, don't quick equip it to the head

--- a/code/modules/reagents/reagent_containers/glass.dm
+++ b/code/modules/reagents/reagent_containers/glass.dm
@@ -294,8 +294,8 @@
 		container_type = NONE
 
 /obj/item/reagent_containers/glass/bucket/dropped(mob/user)
-	..()
-	container_type = OPENCONTAINER
+	. = ..()
+	container_type = initial(container_type)
 
 /obj/item/reagent_containers/glass/bucket/equip_to_best_slot(var/mob/M)
 	if(reagents.total_volume) //If there is water in a bucket, don't quick equip it to the head

--- a/code/modules/reagents/reagent_containers/glass.dm
+++ b/code/modules/reagents/reagent_containers/glass.dm
@@ -290,11 +290,9 @@
 		to_chat(user, "<span class='userdanger'>[src]'s contents spill all over you!</span>")
 		reagents.reaction(user, TOUCH)
 		reagents.clear_reagents()
-	else if (slot == SLOT_HEAD)
+	if (slot == SLOT_HEAD)
 		container_type = NONE
-	else if(slot == SLOT_L_STORE || slot ==SLOT_R_STORE)
-		container_type = OPENCONTAINER
-
+		
 /obj/item/reagent_containers/glass/bucket/dropped(mob/user)
 	..()
 	container_type = OPENCONTAINER

--- a/code/modules/reagents/reagent_containers/glass.dm
+++ b/code/modules/reagents/reagent_containers/glass.dm
@@ -286,13 +286,13 @@
 
 /obj/item/reagent_containers/glass/bucket/equipped(mob/user, slot)
 	..()
-	if(slot == SLOT_HEAD && reagents.total_volume)
-		to_chat(user, "<span class='userdanger'>[src]'s contents spill all over you!</span>")
-		reagents.reaction(user, TOUCH)
-		reagents.clear_reagents()
 	if (slot == SLOT_HEAD)
+		if(reagents.total_volume)
+			to_chat(user, "<span class='userdanger'>[src]'s contents spill all over you!</span>")
+			reagents.reaction(user, TOUCH)
+			reagents.clear_reagents()
 		container_type = NONE
-		
+
 /obj/item/reagent_containers/glass/bucket/dropped(mob/user)
 	..()
 	container_type = OPENCONTAINER

--- a/code/modules/reagents/reagent_containers/glass.dm
+++ b/code/modules/reagents/reagent_containers/glass.dm
@@ -290,7 +290,10 @@
 		to_chat(user, "<span class='userdanger'>[src]'s contents spill all over you!</span>")
 		reagents.reaction(user, TOUCH)
 		reagents.clear_reagents()
+	else if (slot == SLOT_HEAD)
 		container_type = NONE
+	else if(slot == SLOT_L_STORE || slot ==SLOT_R_STORE)
+		container_type = OPENCONTAINER
 
 /obj/item/reagent_containers/glass/bucket/dropped(mob/user)
 	..()


### PR DESCRIPTION
Stopped the user from pouring reagents into a bucket while worn as a hat. Does so by changing the bucket to not have a container type after pouring its contents on the subject and changes back after its removed

:cl:
fix: Bucket helmets cannot have reagents transferred into them until after they are removed
/:cl:

fixes: #38669 

~~also why is the proc called after removing a piece of equipment called "dropped"? Took me a while to realise what it did. Still no more magic upside down buckets.~~ Misinterpreted it, still useful though.
