### PR TITLE
Standardizes cam networks, minor tweaks/fixes

### DIFF
--- a/_maps/map_files/BoxStation/BoxStation.dmm
+++ b/_maps/map_files/BoxStation/BoxStation.dmm
@@ -714,7 +714,7 @@
 /turf/open/floor/carpet,
 /area/crew_quarters/heads/hos)
 "abV" = (
-/obj/machinery/computer/security,
+/obj/machinery/computer/security/hos,
 /turf/open/floor/carpet,
 /area/crew_quarters/heads/hos)
 "abW" = (
@@ -1737,10 +1737,7 @@
 /obj/machinery/light{
 	dir = 1
 	},
-/obj/machinery/computer/security/telescreen{
-	desc = "Used for watching Prison Wing holding areas.";
-	name = "Prison Monitor";
-	network = list("prison");
+/obj/machinery/computer/security/telescreen/prison{
 	pixel_y = 30
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -1776,10 +1773,7 @@
 /turf/open/floor/plasteel,
 /area/security/prison)
 "aen" = (
-/obj/machinery/computer/security/telescreen{
-	desc = "Used for watching Prison Wing holding areas.";
-	name = "Prison Monitor";
-	network = list("prison");
+/obj/machinery/computer/security/telescreen/prison{
 	pixel_y = 30
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -3525,7 +3519,8 @@
 "ail" = (
 /obj/machinery/camera{
 	c_tag = "Brig Interrogation";
-	dir = 8
+	dir = 8;
+	network = list("interrogation")
 	},
 /turf/open/floor/plasteel/dark,
 /area/security/prison)
@@ -4003,10 +3998,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 6
 	},
-/obj/machinery/computer/security{
-	name = "Labor Camp Monitoring";
-	network = list("labor")
-	},
+/obj/machinery/computer/security/labor,
 /turf/open/floor/plasteel,
 /area/security/processing)
 "ajv" = (
@@ -4062,6 +4054,9 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 1
+	},
+/obj/machinery/computer/security/telescreen/interrogation{
+	pixel_y = 30
 	},
 /turf/open/floor/plasteel/red/side{
 	dir = 1
@@ -7926,11 +7921,8 @@
 	pixel_y = 7
 	},
 /obj/item/pen,
-/obj/machinery/computer/security/telescreen{
-	desc = "Used for watching Prison Wing holding areas.";
+/obj/machinery/computer/security/telescreen/prison{
 	dir = 1;
-	name = "Prison Monitor";
-	network = list("prison");
 	pixel_y = -27
 	},
 /turf/open/floor/wood,
@@ -9141,12 +9133,9 @@
 /obj/item/wallframe/camera,
 /obj/item/wallframe/camera,
 /obj/item/assault_pod/mining,
-/obj/machinery/computer/security/telescreen{
-	desc = "Used for the Auxillary Mining Base.";
+/obj/machinery/computer/security/telescreen/auxbase{
 	dir = 8;
-	name = "Auxillary Base Monitor";
-	network = list("auxbase");
-	pixel_x = 28
+	pixel_x = 30
 	},
 /turf/open/floor/plasteel/yellow/side{
 	dir = 4
@@ -12611,7 +12600,7 @@
 /obj/machinery/camera/motion{
 	c_tag = "Vault";
 	dir = 1;
-	network = list("minisat")
+	network = list("vault")
 	},
 /obj/machinery/light,
 /turf/open/floor/plasteel/vault/corner{
@@ -17727,9 +17716,7 @@
 /turf/open/floor/plasteel,
 /area/bridge)
 "aUd" = (
-/obj/machinery/computer/security/mining{
-	network = list("mine","auxbase")
-	},
+/obj/machinery/computer/security/mining,
 /turf/open/floor/plasteel/brown{
 	dir = 6
 	},
@@ -20820,7 +20807,8 @@
 /obj/structure/table,
 /obj/item/aiModule/supplied/quarantine,
 /obj/machinery/camera/motion{
-	dir = 4
+	dir = 4;
+	network = list("aiupload")
 	},
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/ai_upload)
@@ -20838,7 +20826,8 @@
 	pixel_x = 32
 	},
 /obj/machinery/camera/motion{
-	dir = 8
+	dir = 8;
+	network = list("aiupload")
 	},
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/ai_upload)
@@ -23908,6 +23897,7 @@
 "bkb" = (
 /obj/machinery/camera{
 	c_tag = "Medbay Morgue";
+	network = list("ss13", "medbay");
 	dir = 8
 	},
 /obj/machinery/airalarm{
@@ -24434,6 +24424,7 @@
 /obj/structure/table/reinforced,
 /obj/machinery/camera{
 	c_tag = "Medbay Foyer";
+	network = list("ss13", "medbay");
 	dir = 8
 	},
 /obj/machinery/cell_charger,
@@ -25527,10 +25518,7 @@
 /turf/open/floor/plasteel,
 /area/crew_quarters/heads/hop)
 "bnR" = (
-/obj/machinery/computer/security/telescreen{
-	desc = "Used for watching Prison Wing holding areas.";
-	name = "Prison Monitor";
-	network = list("prison");
+/obj/machinery/computer/security/telescreen/vault{
 	pixel_y = 30
 	},
 /obj/machinery/disposal/bin,
@@ -26827,6 +26815,7 @@
 	},
 /obj/machinery/camera{
 	c_tag = "Medbay West";
+	network = list("ss13", "medbay");
 	dir = 2
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -27511,6 +27500,7 @@
 	},
 /obj/machinery/camera{
 	c_tag = "Medbay East";
+	network = list("ss13", "medbay");
 	dir = 8;
 	pixel_y = -22
 	},
@@ -28839,7 +28829,8 @@
 /obj/machinery/camera{
 	c_tag = "Genetics Research";
 	dir = 1;
-	network = list("ss13","rd")
+	network = list("ss13", "medbay");
+	
 	},
 /obj/machinery/firealarm{
 	dir = 1;
@@ -28873,6 +28864,7 @@
 "bvB" = (
 /obj/machinery/camera{
 	c_tag = "Genetics Access";
+	network = list("ss13", "medbay");
 	dir = 8;
 	pixel_y = -22
 	},
@@ -29230,7 +29222,8 @@
 "bww" = (
 /obj/structure/chair,
 /obj/machinery/camera{
-	c_tag = "Surgery Observation"
+	c_tag = "Surgery Observation";
+	network = list("ss13", "medbay")
 	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 4
@@ -29315,6 +29308,7 @@
 /obj/structure/table/glass,
 /obj/machinery/camera{
 	c_tag = "Medbay Cryogenics";
+	network = list("ss13", "medbay");
 	dir = 2
 	},
 /obj/item/reagent_containers/glass/beaker/cryoxadone,
@@ -29333,6 +29327,7 @@
 "bwL" = (
 /obj/machinery/camera{
 	c_tag = "Genetics Cloning";
+	network = list("ss13", "medbay");
 	dir = 4
 	},
 /obj/structure/table,
@@ -29585,13 +29580,8 @@
 /turf/open/floor/plasteel/cafeteria,
 /area/crew_quarters/heads/hor)
 "bxj" = (
-/obj/machinery/computer/security/telescreen{
-	desc = "Used for watching the RD's goons and the AI's satellite from the safety of his office.";
-	name = "Research Monitor";
-	network = list("rd","minisat");
-	pixel_y = 2
-	},
 /obj/structure/table,
+/obj/machinery/computer/security/telescreen/rd,
 /turf/open/floor/plasteel/cafeteria,
 /area/crew_quarters/heads/hor)
 "bxk" = (
@@ -30237,8 +30227,7 @@
 	pixel_x = 27
 	},
 /obj/machinery/computer/security/mining{
-	dir = 8;
-	network = list("mine","auxbase")
+	dir = 8
 	},
 /turf/open/floor/plasteel/red/side{
 	dir = 4
@@ -30581,13 +30570,8 @@
 /area/security/checkpoint/science)
 "bzD" = (
 /obj/structure/table,
-/obj/machinery/computer/security/telescreen{
-	desc = "Used for watching the RD's goons from the safety of your own office.";
-	name = "Research Monitor";
-	network = list("rd");
-	pixel_y = 2
-	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/machinery/computer/security/telescreen/circuitry,
 /turf/open/floor/plasteel/red/side{
 	dir = 1
 	},
@@ -30905,6 +30889,7 @@
 	},
 /obj/machinery/camera{
 	c_tag = "Medbay Treatment Center";
+	network = list("ss13", "medbay");
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -31123,10 +31108,6 @@
 /turf/open/floor/engine,
 /area/science/explab)
 "bAS" = (
-/obj/machinery/computer/security/mining{
-	dir = 4;
-	network = list("mine","auxbase")
-	},
 /obj/machinery/camera{
 	c_tag = "Quartermaster's Office";
 	dir = 4
@@ -31138,6 +31119,9 @@
 /obj/machinery/status_display{
 	pixel_x = -32;
 	supply_display = 1
+	},
+/obj/machinery/computer/security/qm{
+	dir = 4
 	},
 /turf/open/floor/plasteel/brown{
 	dir = 10
@@ -31938,6 +31922,7 @@
 /obj/structure/closet/secure_closet/medical3,
 /obj/machinery/camera{
 	c_tag = "Medbay Storage";
+	network = list("ss13", "medbay");
 	dir = 2
 	},
 /turf/open/floor/plasteel/white,
@@ -32020,6 +32005,7 @@
 	},
 /obj/machinery/camera{
 	c_tag = "Medbay South";
+	network = list("ss13", "medbay");
 	dir = 4
 	},
 /turf/open/floor/plasteel/white,
@@ -32312,6 +32298,7 @@
 	},
 /obj/machinery/camera{
 	c_tag = "Medbay Recovery Room";
+	network = list("ss13", "medbay");
 	dir = 8
 	},
 /obj/machinery/iv_drip,
@@ -32553,6 +32540,7 @@
 	},
 /obj/machinery/camera{
 	c_tag = "Chief Medical Office";
+	network = list("ss13", "medbay");
 	dir = 8;
 	pixel_y = -22
 	},
@@ -32765,13 +32753,11 @@
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
 "bEK" = (
-/obj/machinery/computer/security/mining{
-	network = list("mine","auxbase")
-	},
 /obj/machinery/camera{
 	c_tag = "Mining Dock";
 	dir = 4
 	},
+/obj/machinery/computer/security/mining,
 /turf/open/floor/plasteel,
 /area/quartermaster/miningdock)
 "bEL" = (
@@ -33134,6 +33120,10 @@
 "bFE" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 8
+	},
+/obj/machinery/computer/security/telescreen/cmo{
+	dir = 1;
+	pixel_y = -24
 	},
 /turf/open/floor/plasteel/barber,
 /area/crew_quarters/heads/cmo)
@@ -33847,16 +33837,12 @@
 /turf/open/floor/plasteel,
 /area/science/mixing)
 "bHv" = (
-/obj/machinery/computer/security/telescreen{
-	desc = "Used for watching the test chamber.";
-	dir = 8;
-	layer = 4;
-	name = "Test Chamber Telescreen";
-	network = list("toxins");
-	pixel_x = 30
-	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 5
+	},
+/obj/machinery/computer/security/telescreen/toxins{
+	dir = 4;
+	pixel_x = 30
 	},
 /turf/open/floor/plasteel,
 /area/science/mixing)
@@ -34100,6 +34086,7 @@
 	},
 /obj/machinery/camera{
 	c_tag = "Surgery Operating";
+	network = list("ss13", "medbay");
 	dir = 1;
 	pixel_x = 22
 	},
@@ -34421,7 +34408,8 @@
 	pixel_y = 29
 	},
 /obj/machinery/camera{
-	c_tag = "Virology Break Room"
+	c_tag = "Virology Break Room";
+	network = list("ss13", "medbay")
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 8
@@ -34570,7 +34558,6 @@
 /turf/open/floor/plating/airless,
 /area/science/test_area)
 "bJa" = (
-/obj/item/flashlight/lamp,
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
@@ -35613,20 +35600,12 @@
 	},
 /area/science/test_area)
 "bLr" = (
-/obj/machinery/camera{
-	active_power_usage = 0;
-	c_tag = "Bomb Test Site";
-	desc = "A specially-reinforced camera with a long lasting battery, used to monitor the bomb testing site.";
-	dir = 8;
-	invuln = 1;
-	light = null;
-	name = "Hardened Bomb-Test Camera";
-	network = list("toxins");
-	use_power = 0
-	},
 /obj/item/target/alien/anchored,
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
+	},
+/obj/machinery/camera/preset/toxins{
+	dir = 8
 	},
 /turf/open/floor/plating{
 	luminosity = 2;
@@ -36475,7 +36454,6 @@
 /turf/open/floor/plating/airless,
 /area/science/test_area)
 "bNF" = (
-/obj/item/flashlight/lamp,
 /obj/effect/turf_decal/stripes/line{
 	dir = 2
 	},
@@ -36728,6 +36706,7 @@
 /obj/structure/closet/emcloset,
 /obj/machinery/camera{
 	c_tag = "Virology Airlock";
+	network = list("ss13", "medbay");
 	dir = 2
 	},
 /obj/effect/turf_decal/stripes/line{
@@ -37872,14 +37851,10 @@
 /area/science/misc_lab)
 "bQY" = (
 /obj/structure/table/reinforced,
-/obj/machinery/computer/security/telescreen{
-	desc = "Used for watching the RD's goons from the safety of his office.";
-	dir = 2;
-	name = "Research Monitor";
-	network = list("rd");
-	pixel_y = 28
-	},
 /obj/item/integrated_circuit_printer,
+/obj/machinery/computer/security/telescreen/circuitry{
+	pixel_y = 30
+	},
 /turf/open/floor/plasteel/white,
 /area/science/circuit)
 "bQZ" = (
@@ -37984,13 +37959,9 @@
 /obj/machinery/computer/secure_data{
 	dir = 8
 	},
-/obj/machinery/computer/security/telescreen{
-	desc = "Used for watching the Engine.";
+/obj/machinery/computer/security/telescreen/engine{
 	dir = 8;
-	layer = 4;
-	name = "Engine Monitor";
-	network = list("engine");
-	pixel_x = 30
+	pixel_x = 24
 	},
 /turf/open/floor/plasteel/red/side{
 	dir = 4
@@ -38410,7 +38381,8 @@
 /obj/structure/closet/emcloset,
 /obj/machinery/camera{
 	c_tag = "Telecomms Monitoring";
-	dir = 8
+	dir = 8;
+	network = list("tcomms")
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plasteel,
@@ -38679,7 +38651,8 @@
 	icon_state = "0-8"
 	},
 /obj/machinery/camera{
-	c_tag = "Virology Module"
+	c_tag = "Virology Module";
+	network = list("ss13", "medbay")
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
@@ -41983,7 +41956,8 @@
 "cbl" = (
 /obj/machinery/camera{
 	c_tag = "Telecomms Server Room";
-	dir = 4
+	dir = 4;
+	network = list("tcomms")
 	},
 /turf/open/floor/plasteel/dark/telecomms/mainframe,
 /area/tcommsat/server)
@@ -42325,14 +42299,11 @@
 /area/science/circuit)
 "cbZ" = (
 /obj/structure/table/reinforced,
-/obj/machinery/computer/security/telescreen{
-	desc = "Used for watching the RD's goons from the safety of his office.";
-	dir = 1;
-	name = "Research Monitor";
-	network = list("rd");
-	pixel_y = -28
-	},
 /obj/item/integrated_circuit_printer,
+/obj/machinery/computer/security/telescreen/circuitry{
+	dir = 1;
+	pixel_y = -30
+	},
 /turf/open/floor/plasteel/white,
 /area/science/circuit)
 "cca" = (
@@ -45323,11 +45294,8 @@
 /obj/machinery/computer/station_alert{
 	dir = 4
 	},
-/obj/machinery/computer/security/telescreen{
-	desc = "Used for watching the RD's goons from the safety of your own office.";
+/obj/machinery/computer/security/telescreen/ce{
 	dir = 4;
-	name = "Research Monitor";
-	network = list("rd");
 	pixel_x = -24
 	},
 /turf/open/floor/plasteel/vault,
@@ -48079,15 +48047,12 @@
 /turf/open/space,
 /area/space/nearstation)
 "csq" = (
-/obj/machinery/computer/security/telescreen{
-	desc = "Used for watching the turbine vent.";
-	dir = 1;
-	name = "turbine vent monitor";
-	network = list("turbine");
-	pixel_y = -29
-	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
 	dir = 4
+	},
+/obj/machinery/computer/security/telescreen/turbine{
+	dir = 1;
+	pixel_y = -30
 	},
 /turf/open/floor/plasteel/floorgrime,
 /area/maintenance/disposal/incinerator)
@@ -49444,7 +49409,7 @@
 /obj/machinery/camera/motion{
 	c_tag = "MiniSat Core Hallway";
 	dir = 4;
-	network = list("minisat")
+	network = list("aicore")
 	},
 /obj/machinery/firealarm{
 	dir = 8;
@@ -49822,7 +49787,7 @@
 /obj/machinery/camera/motion{
 	c_tag = "MiniSat AI Chamber North";
 	dir = 1;
-	network = list("minisat")
+	network = list("aicore")
 	},
 /turf/open/floor/circuit,
 /area/ai_monitored/turret_protected/ai)
@@ -50718,7 +50683,7 @@
 /obj/machinery/camera/motion{
 	c_tag = "MiniSat AI Chamber South";
 	dir = 2;
-	network = list("minisat")
+	network = list("aicore")
 	},
 /turf/open/floor/circuit,
 /area/ai_monitored/turret_protected/ai)
@@ -52671,16 +52636,12 @@
 /turf/open/floor/plating,
 /area/engine/engineering)
 "cMC" = (
-/obj/machinery/computer/security/telescreen{
-	desc = "Used for watching the Engine.";
-	dir = 8;
-	layer = 4;
-	name = "Engine Monitor";
-	network = list("engine");
-	pixel_x = 30
-	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 5
+	},
+/obj/machinery/computer/security/telescreen/engine{
+	dir = 8;
+	pixel_x = 30
 	},
 /turf/open/floor/plasteel/vault{
 	dir = 5

--- a/_maps/map_files/Deltastation/DeltaStation2.dmm
+++ b/_maps/map_files/Deltastation/DeltaStation2.dmm
@@ -19220,9 +19220,6 @@
 /turf/open/floor/plasteel/neutral,
 /area/quartermaster/qm)
 "aUs" = (
-/obj/machinery/computer/security/mining{
-	dir = 8
-	},
 /obj/machinery/status_display{
 	pixel_x = 32
 	},
@@ -19230,6 +19227,9 @@
 	c_tag = "Cargo - Quartermaster's Quarters";
 	dir = 8;
 	name = "cargo camera"
+	},
+/obj/machinery/computer/security/qm{
+	dir = 8
 	},
 /turf/open/floor/plasteel/brown{
 	dir = 4
@@ -28840,14 +28840,11 @@
 	},
 /area/security/execution/transfer)
 "bpg" = (
-/obj/machinery/computer/security{
-	name = "Labor Camp Monitoring";
-	network = list("labor")
-	},
 /obj/item/radio/intercom{
 	name = "Station Intercom";
 	pixel_y = 26
 	},
+/obj/machinery/computer/security/labor,
 /turf/open/floor/plasteel/red,
 /area/security/execution/transfer)
 "bph" = (
@@ -30115,11 +30112,11 @@
 /turf/open/floor/plasteel/grimy,
 /area/crew_quarters/heads/hos)
 "brC" = (
-/obj/machinery/computer/security{
-	dir = 1
-	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
+	},
+/obj/machinery/computer/security/hos{
+	dir = 1
 	},
 /turf/open/floor/plasteel/grimy,
 /area/crew_quarters/heads/hos)
@@ -32398,7 +32395,7 @@
 /obj/machinery/camera/motion{
 	c_tag = "AI Chamber - Fore";
 	name = "motion-sensitive ai camera";
-	network = list("ai")
+	network = list("aichamber")
 	},
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plasteel/dark,
@@ -32852,7 +32849,8 @@
 "bxe" = (
 /obj/machinery/camera/motion{
 	c_tag = "Vault";
-	dir = 4
+	dir = 4;
+	network = list("vault")
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
@@ -40846,7 +40844,7 @@
 	c_tag = "Telecomms - Monitoring";
 	dir = 2;
 	name = "telecomms camera";
-	network = list("ss13","tcomm")
+	network = list("ss13","tcomms")
 	},
 /turf/open/floor/plasteel/grimy,
 /area/tcommsat/computer)
@@ -41330,7 +41328,7 @@
 	c_tag = "AI Chamber - Aft";
 	dir = 1;
 	name = "motion-sensitive ai camera";
-	network = list("ai")
+	network = list("aichamber")
 	},
 /turf/open/floor/plasteel/vault,
 /area/ai_monitored/turret_protected/ai)
@@ -45719,12 +45717,8 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
-/obj/machinery/computer/security/telescreen{
-	desc = "Used for watching the AI's satellite.";
-	dir = 4;
-	name = "Research Monitor";
-	network = list("minisat");
-	pixel_y = 2
+/obj/machinery/computer/security/telescreen/minisat{
+	dir = 4
 	},
 /turf/open/floor/plasteel/vault{
 	dir = 8
@@ -45765,12 +45759,8 @@
 /obj/machinery/light{
 	dir = 8
 	},
-/obj/machinery/computer/security/telescreen{
-	desc = "Used for watching the Engine.";
+/obj/machinery/computer/security/telescreen/ce{
 	dir = 4;
-	layer = 4;
-	name = "Engine Monitor";
-	network = list("engine");
 	pixel_x = -30
 	},
 /mob/living/simple_animal/parrot/Poly,
@@ -49044,6 +49034,10 @@
 /obj/item/stack/packageWrap,
 /obj/item/hand_labeler,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/machinery/computer/security/telescreen/vault{
+	dir = 8;
+	pixel_x = 26
+	},
 /turf/open/floor/wood,
 /area/crew_quarters/heads/hop)
 "ccD" = (
@@ -49054,7 +49048,7 @@
 	c_tag = "Telecomms - Chamber Port";
 	dir = 4;
 	name = "telecomms camera";
-	network = list("ss13","tcomm")
+	network = list("ss13","tcomms")
 	},
 /turf/open/floor/plasteel/vault/telecomms{
 	dir = 8
@@ -49498,7 +49492,7 @@
 /obj/machinery/camera/motion{
 	c_tag = "AI - Upload";
 	name = "motion-sensitive ai camera";
-	network = list("minisat")
+	network = list("aiupload")
 	},
 /turf/open/floor/plasteel/vault,
 /area/ai_monitored/turret_protected/ai_upload)
@@ -50941,7 +50935,7 @@
 	c_tag = "Telecomms - Chamber Starboard";
 	dir = 8;
 	name = "telecomms camera";
-	network = list("ss13","tcomm")
+	network = list("ss13","tcomms")
 	},
 /turf/open/floor/plasteel/vault/telecomms{
 	dir = 8
@@ -52597,7 +52591,7 @@
 /obj/machinery/camera/motion{
 	c_tag = "Bridge - Captain's Emergency Escape";
 	dir = 4;
-	name = "command camera"
+	name = "motion-sensitive command camera"
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -54723,7 +54717,7 @@
 	c_tag = "Telecomms - Cooling Room";
 	dir = 8;
 	name = "telecomms camera";
-	network = list("ss13","tcomm")
+	network = list("ss13","tcomms")
 	},
 /obj/effect/turf_decal/delivery,
 /turf/open/floor/plasteel,
@@ -67890,6 +67884,7 @@
 	},
 /obj/machinery/camera{
 	c_tag = "Medbay - Storage";
+	network = list("ss13", "medbay");
 	dir = 4;
 	name = "medbay camera"
 	},
@@ -71808,6 +71803,7 @@
 /obj/machinery/light,
 /obj/machinery/camera{
 	c_tag = "Medbay - Waiting Room";
+	network = list("ss13", "medbay");
 	dir = 1;
 	name = "medbay camera"
 	},
@@ -71947,6 +71943,7 @@
 "cYc" = (
 /obj/machinery/camera{
 	c_tag = "Medbay - Break Room";
+	network = list("ss13", "medbay");
 	dir = 2;
 	name = "medbay camera"
 	},
@@ -72624,6 +72621,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/machinery/camera{
 	c_tag = "Medbay - Fore Port";
+	network = list("ss13", "medbay");
 	dir = 8;
 	name = "medbay camera"
 	},
@@ -72705,6 +72703,7 @@
 /obj/item/stack/medical/ointment,
 /obj/machinery/camera{
 	c_tag = "Medbay - Sleepers";
+	network = list("ss13", "medbay");
 	dir = 2;
 	name = "medbay camera"
 	},
@@ -75473,9 +75472,9 @@
 	},
 /obj/machinery/camera{
 	c_tag = "Medbay - Chemistry";
+	network = list("ss13", "medbay");
 	dir = 8;
-	name = "medbay camera";
-	network = list("ss13","medbay")
+	name = "medbay camera"
 	},
 /turf/open/floor/plasteel/whiteyellow/corner,
 /area/medical/chemistry)
@@ -76304,6 +76303,7 @@
 	},
 /obj/machinery/camera{
 	c_tag = "Medbay - Center";
+	network = list("ss13", "medbay");
 	dir = 2;
 	name = "medbay camera"
 	},
@@ -77694,6 +77694,7 @@
 /obj/machinery/light,
 /obj/machinery/camera{
 	c_tag = "Medbay - Port";
+	network = list("ss13", "medbay");
 	dir = 1;
 	name = "medbay camera"
 	},
@@ -77792,6 +77793,7 @@
 /obj/machinery/light,
 /obj/machinery/camera{
 	c_tag = "Medbay - Starboard";
+	network = list("ss13", "medbay");
 	dir = 1;
 	name = "medbay camera"
 	},
@@ -81242,6 +81244,7 @@
 	},
 /obj/machinery/camera{
 	c_tag = "Medbay - Cloning Lab";
+	network = list("ss13", "medbay");
 	dir = 1;
 	name = "medbay camera"
 	},
@@ -81301,6 +81304,7 @@
 /obj/item/clothing/neck/stethoscope,
 /obj/machinery/camera{
 	c_tag = "Medbay - Cryogenics";
+	network = list("ss13", "medbay");
 	dir = 1;
 	name = "medbay camera"
 	},
@@ -81767,6 +81771,7 @@
 /obj/machinery/iv_drip,
 /obj/machinery/camera{
 	c_tag = "Medbay - Recovery Room";
+	network = list("ss13", "medbay");
 	dir = 8;
 	name = "medbay camera"
 	},
@@ -83163,6 +83168,7 @@
 	},
 /obj/machinery/camera{
 	c_tag = "Medbay - Genetics Lab";
+	network = list("ss13", "medbay");
 	dir = 4;
 	name = "medbay camera"
 	},
@@ -83794,6 +83800,7 @@
 /obj/item/storage/box/disks,
 /obj/machinery/camera{
 	c_tag = "Medbay - Genetics Desk";
+	network = list("ss13", "medbay");
 	dir = 4;
 	name = "medbay camera"
 	},
@@ -84101,6 +84108,7 @@
 	},
 /obj/machinery/camera{
 	c_tag = "Medbay - Surgery";
+	network = list("ss13", "medbay");
 	dir = 1;
 	name = "medbay camera"
 	},
@@ -84695,6 +84703,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/machinery/camera{
 	c_tag = "Medbay - Aft Port";
+	network = list("ss13", "medbay");
 	dir = 8;
 	name = "medbay camera"
 	},
@@ -84753,6 +84762,7 @@
 	},
 /obj/machinery/camera{
 	c_tag = "Medbay - Chief Medical Officer's Office";
+	network = list("ss13", "medbay");
 	dir = 8;
 	name = "medbay camera"
 	},
@@ -85973,8 +85983,9 @@
 /obj/structure/table/glass,
 /obj/item/clipboard,
 /obj/item/toy/figure/cmo,
-/obj/machinery/status_display{
-	pixel_x = -32
+/obj/machinery/computer/security/telescreen/cmo{
+	dir = 4;
+	pixel_x = -30
 	},
 /turf/open/floor/plasteel/neutral/side{
 	dir = 4
@@ -86021,6 +86032,7 @@
 	},
 /obj/machinery/camera{
 	c_tag = "Medbay - Aft Starboard";
+	network = list("ss13", "medbay");
 	dir = 4;
 	name = "medbay camera"
 	},
@@ -88046,15 +88058,11 @@
 /area/science/test_area)
 "dGY" = (
 /obj/structure/table/reinforced,
-/obj/machinery/computer/security/telescreen{
-	desc = "Used for watching the testing site.";
-	dir = 4;
-	layer = 4;
-	name = "Testing Site Telescreen";
-	network = list("toxins")
-	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
+	},
+/obj/machinery/computer/security/telescreen/toxins{
+	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/science/mixing)
@@ -89054,6 +89062,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/camera{
 	c_tag = "Medbay - Morgue";
+	network = list("ss13", "medbay");
 	dir = 1;
 	name = "medbay camera"
 	},
@@ -89165,6 +89174,7 @@
 	},
 /obj/machinery/camera{
 	c_tag = "Medbay - Chief Medical Officer's Quarters";
+	network = list("ss13", "medbay");
 	dir = 1;
 	name = "medbay camera"
 	},
@@ -90362,17 +90372,8 @@
 /obj/item/target,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/camera{
-	active_power_usage = 0;
-	c_tag = "Bomb Test Site";
-	desc = "A specially-reinforced camera with a long lasting battery, used to monitor the bomb testing site.";
-	dir = 4;
-	invuln = 1;
-	light = null;
-	name = "hardened testing camera";
-	network = list("toxins");
-	start_active = 1;
-	use_power = 0
+/obj/machinery/camera/preset/toxins{
+	dir = 4
 	},
 /turf/open/floor/plating/airless,
 /area/science/test_area)
@@ -92465,6 +92466,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/machinery/camera{
 	c_tag = "Virology - Containment Lock";
+	network = list("ss13", "medbay");
 	dir = 8;
 	name = "virology camera"
 	},
@@ -92977,6 +92979,7 @@
 	},
 /obj/machinery/camera{
 	c_tag = "Virology - Break Room";
+	network = list("ss13", "medbay");
 	dir = 8;
 	name = "virology camera"
 	},
@@ -94683,6 +94686,7 @@
 	},
 /obj/machinery/camera{
 	c_tag = "Virology - Lab";
+	network = list("ss13", "medbay");
 	name = "virology camera"
 	},
 /obj/effect/turf_decal/bot,
@@ -94702,6 +94706,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/machinery/camera{
 	c_tag = "Virology - Hallway";
+	network = list("ss13", "medbay");
 	dir = 8;
 	name = "virology camera"
 	},
@@ -96405,6 +96410,7 @@
 	},
 /obj/machinery/camera{
 	c_tag = "Virology - Cells";
+	network = list("ss13", "medbay");
 	dir = 8;
 	name = "virology camera"
 	},

--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -1910,7 +1910,7 @@
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/heads/hos)
 "aev" = (
-/obj/machinery/computer/security,
+/obj/machinery/computer/security/hos,
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/heads/hos)
 "aew" = (
@@ -3554,13 +3554,6 @@
 	},
 /obj/structure/disposalpipe/trunk{
 	dir = 4
-	},
-/obj/machinery/computer/security/telescreen{
-	desc = "Used for watching certain areas.";
-	dir = 1;
-	name = "Head of Security's Monitor";
-	network = list("prison","minisat","tcomm");
-	pixel_y = -30
 	},
 /turf/open/floor/plasteel/vault,
 /area/crew_quarters/heads/hos)
@@ -7852,10 +7845,7 @@
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
 "aqY" = (
-/obj/machinery/computer/security{
-	name = "Labor Camp Monitoring";
-	network = list("labor")
-	},
+/obj/machinery/computer/security/labor,
 /turf/open/floor/plasteel/dark,
 /area/security/brig)
 "aqZ" = (
@@ -8778,12 +8768,8 @@
 /area/security/main)
 "asN" = (
 /obj/structure/chair,
-/obj/machinery/computer/security/telescreen{
-	desc = "Used for watching proceedings in the interrogation room.";
+/obj/machinery/computer/security/telescreen/interrogation{
 	dir = 1;
-	layer = 4;
-	name = "interrogation monitor";
-	network = list("interrogation");
 	pixel_y = -30
 	},
 /turf/open/floor/plasteel/grimy,
@@ -9867,6 +9853,10 @@
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
 	dir = 4
 	},
+/obj/machinery/computer/security/telescreen/interrogation{
+	dir = 8;
+	pixel_x = 30
+	},
 /turf/open/floor/plasteel/red/side{
 	dir = 5
 	},
@@ -10533,7 +10523,7 @@
 /area/security/brig)
 "awz" = (
 /obj/machinery/camera{
-	c_tag = "Interrogation";
+	c_tag = "Interrogation room";
 	dir = 8;
 	network = list("interrogation")
 	},
@@ -13115,6 +13105,7 @@
 "aCg" = (
 /obj/machinery/camera/motion{
 	c_tag = "Vault";
+	network = list("vault");
 	dir = 1
 	},
 /obj/machinery/light,
@@ -14211,8 +14202,7 @@
 /area/quartermaster/warehouse)
 "aEv" = (
 /obj/machinery/computer/security/mining{
-	dir = 4;
-	network = list("mine","auxbase")
+	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/miningoffice)
@@ -17486,7 +17476,7 @@
 /obj/structure/table,
 /obj/machinery/camera/motion{
 	c_tag = "AI Upload Chamber - Fore";
-	network = list("ss13","rd","aiupload")
+	network = list("aiupload")
 	},
 /obj/item/twohanded/required/kirbyplants/photosynthetic{
 	pixel_y = 10
@@ -19642,12 +19632,11 @@
 /turf/closed/wall,
 /area/quartermaster/qm)
 "aQq" = (
-/obj/machinery/computer/security/mining{
-	dir = 4;
-	network = list("mine","auxbase")
-	},
 /obj/machinery/light_switch{
 	pixel_x = -23
+	},
+/obj/machinery/computer/cargo{
+	dir = 4
 	},
 /turf/open/floor/plasteel/brown{
 	dir = 8
@@ -19747,7 +19736,7 @@
 /obj/machinery/camera/motion{
 	c_tag = "AI Upload Chamber - Port";
 	dir = 1;
-	network = list("ss13","rd","aiupload")
+	network = list("aiupload")
 	},
 /turf/open/floor/circuit,
 /area/ai_monitored/turret_protected/ai_upload)
@@ -19770,7 +19759,7 @@
 /obj/machinery/camera/motion{
 	c_tag = "AI Upload Chamber - Starboard";
 	dir = 1;
-	network = list("ss13","rd","aiupload")
+	network = list("aiupload")
 	},
 /turf/open/floor/circuit,
 /area/ai_monitored/turret_protected/ai_upload)
@@ -20268,7 +20257,7 @@
 /turf/open/floor/plasteel,
 /area/quartermaster/storage)
 "aRK" = (
-/obj/machinery/computer/cargo{
+/obj/machinery/computer/security/qm{
 	dir = 4
 	},
 /turf/open/floor/plasteel/brown{
@@ -21603,16 +21592,9 @@
 /obj/machinery/light/small{
 	dir = 4
 	},
-/obj/machinery/computer/security/telescreen{
-	desc = "Used for watching areas on the MiniSat.";
-	dir = 8;
-	name = "MiniSat Monitor";
-	network = list("minisat","tcomm");
-	pixel_x = 29
-	},
 /obj/machinery/camera/motion{
 	c_tag = "AI Upload Foyer";
-	network = list("ss13","rd","aiupload")
+	network = list("aiupload")
 	},
 /obj/machinery/airalarm{
 	pixel_y = 26
@@ -21935,7 +21917,7 @@
 /obj/machinery/camera{
 	c_tag = "AI Chamber - Fore";
 	dir = 2;
-	network = list("rd")
+	network = list("aicore")
 	},
 /obj/structure/showcase/cyborg/old{
 	dir = 2;
@@ -22183,8 +22165,7 @@
 	pixel_x = 27
 	},
 /obj/machinery/computer/security/mining{
-	dir = 8;
-	network = list("mine","auxbase")
+	dir = 8
 	},
 /turf/open/floor/plasteel/red/side{
 	dir = 4
@@ -23419,7 +23400,7 @@
 /obj/machinery/camera{
 	c_tag = "AI Chamber - Port";
 	dir = 4;
-	network = list("rd")
+	network = list("aicore")
 	},
 /obj/structure/showcase/cyborg/old{
 	dir = 4;
@@ -24131,7 +24112,7 @@
 /obj/machinery/camera{
 	c_tag = "AI Chamber - Core";
 	dir = 2;
-	network = list("rd")
+	network = list("aicore")
 	},
 /turf/open/floor/plasteel/vault{
 	dir = 10
@@ -25035,10 +25016,8 @@
 	pixel_y = 10
 	},
 /obj/item/radio/off,
-/obj/machinery/computer/security/telescreen{
+/obj/machinery/computer/security/telescreen/minisat{
 	dir = 4;
-	name = "MiniSat Monitor";
-	network = list("minisat","tcomm");
 	pixel_x = -29
 	},
 /turf/open/floor/plasteel/red/side{
@@ -25096,7 +25075,7 @@
 /obj/machinery/camera{
 	c_tag = "AI Chamber - Starboard";
 	dir = 8;
-	network = list("rd")
+	network = list("aicore")
 	},
 /obj/structure/showcase/cyborg/old{
 	dir = 8;
@@ -26192,10 +26171,8 @@
 /obj/structure/rack,
 /obj/item/storage/secure/briefcase,
 /obj/item/clothing/mask/cigarette/cigar,
-/obj/machinery/computer/security/telescreen{
+/obj/machinery/computer/security/telescreen/ce{
 	dir = 1;
-	name = "MiniSat Monitor";
-	network = list("minisat","tcomm");
 	pixel_y = -30
 	},
 /turf/open/floor/plasteel/vault{
@@ -28117,7 +28094,7 @@
 /obj/machinery/camera{
 	c_tag = "AI Chamber - Aft";
 	dir = 1;
-	network = list("rd")
+	network = list("aicore")
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on,
 /turf/open/floor/plasteel/dark,
@@ -30032,15 +30009,12 @@
 	},
 /obj/item/storage/secure/briefcase,
 /obj/structure/table/wood,
-/obj/machinery/computer/security/telescreen{
-	desc = "Used for watching Prison Wing holding areas.";
-	name = "Prison Monitor";
-	network = list("prison");
-	pixel_y = 30
-	},
 /obj/item/folder/blue,
 /obj/item/storage/secure/briefcase,
 /obj/item/assembly/flash/handheld,
+/obj/machinery/computer/security/telescreen/vault{
+	pixel_y = 30
+	},
 /turf/open/floor/wood,
 /area/crew_quarters/heads/hop)
 "bmq" = (
@@ -32209,10 +32183,8 @@
 /obj/structure/rack,
 /obj/item/aicard,
 /obj/item/radio/off,
-/obj/machinery/computer/security/telescreen{
+/obj/machinery/computer/security/telescreen/minisat{
 	dir = 1;
-	name = "MiniSat Monitor";
-	network = list("minisat","tcomm");
 	pixel_y = -29
 	},
 /turf/open/floor/plasteel/darkblue/side{
@@ -33007,10 +32979,8 @@
 /obj/machinery/porta_turret/ai{
 	dir = 2
 	},
-/obj/machinery/computer/security/telescreen{
+/obj/machinery/computer/security/telescreen/minisat{
 	dir = 8;
-	name = "MiniSat Monitor";
-	network = list("minisat","tcomm");
 	pixel_x = 28
 	},
 /turf/open/floor/plasteel/vault{
@@ -33032,10 +33002,8 @@
 	},
 /obj/machinery/light,
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden,
-/obj/machinery/computer/security/telescreen{
+/obj/machinery/computer/security/telescreen/minisat{
 	dir = 1;
-	name = "MiniSat Monitor";
-	network = list("minisat","tcomm");
 	pixel_y = -29
 	},
 /turf/open/floor/plasteel/dark,
@@ -33797,10 +33765,8 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/item/pen,
-/obj/machinery/computer/security/telescreen{
+/obj/machinery/computer/security/telescreen/minisat{
 	dir = 1;
-	name = "MiniSat Monitor";
-	network = list("minisat","tcomm");
 	pixel_y = -28
 	},
 /turf/open/floor/plasteel/darkblue/corner,
@@ -35514,7 +35480,7 @@
 /obj/machinery/computer/security/telescreen{
 	dir = 8;
 	name = "Telecomms Camera Monitor";
-	network = list("tcomm");
+	network = list("tcomms");
 	pixel_x = 26
 	},
 /obj/machinery/computer/telecomms/monitor{
@@ -36810,10 +36776,8 @@
 /area/crew_quarters/heads/captain/private)
 "bAe" = (
 /obj/machinery/light,
-/obj/machinery/computer/security/telescreen{
+/obj/machinery/computer/security/telescreen/minisat{
 	dir = 1;
-	name = "MiniSat Monitor";
-	network = list("minisat","tcomm");
 	pixel_y = -29
 	},
 /obj/structure/bed/dogbed/renault,
@@ -38521,7 +38485,7 @@
 /obj/machinery/camera{
 	c_tag = "Telecomms - Server Room - Fore-Port";
 	dir = 2;
-	network = list("ss13","tcomm")
+	network = list("ss13","tcomms")
 	},
 /turf/open/floor/circuit/green/telecomms/mainframe,
 /area/tcommsat/server)
@@ -38552,7 +38516,7 @@
 /obj/machinery/camera{
 	c_tag = "Telecomms - Server Room - Fore-Starboard";
 	dir = 2;
-	network = list("ss13","tcomm")
+	network = list("ss13","tcomms")
 	},
 /turf/open/floor/circuit/green/telecomms/mainframe,
 /area/tcommsat/server)
@@ -40871,7 +40835,7 @@
 /obj/machinery/camera{
 	c_tag = "Telecomms - Control Room";
 	dir = 1;
-	network = list("ss13","tcomm")
+	network = list("ss13","tcomms")
 	},
 /obj/structure/table/wood,
 /obj/item/pen,
@@ -42286,7 +42250,7 @@
 /obj/machinery/camera{
 	c_tag = "Telecomms - Server Room - Aft-Port";
 	dir = 4;
-	network = list("ss13","tcomm")
+	network = list("ss13","tcomms")
 	},
 /turf/open/floor/plasteel/dark/telecomms/mainframe,
 /area/tcommsat/server)
@@ -42324,7 +42288,7 @@
 /obj/machinery/camera{
 	c_tag = "Telecomms - Server Room - Aft-Starboard";
 	dir = 8;
-	network = list("ss13","tcomm")
+	network = list("ss13","tcomms")
 	},
 /obj/structure/cable/yellow{
 	icon_state = "0-8"
@@ -43130,7 +43094,7 @@
 /obj/machinery/camera{
 	c_tag = "Telecomms - Server Room - Aft";
 	dir = 1;
-	network = list("ss13","tcomm")
+	network = list("ss13","tcomms")
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/machinery/ntnet_relay,
@@ -57860,13 +57824,8 @@
 /turf/open/floor/plating,
 /area/crew_quarters/heads/hor)
 "csZ" = (
-/obj/machinery/computer/security/telescreen{
-	desc = "Used for watching the RD's goons from the safety of his office.";
-	name = "Research Monitor";
-	network = list("rd");
-	pixel_y = 2
-	},
 /obj/structure/table/reinforced,
+/obj/machinery/computer/security/telescreen/rd,
 /turf/open/floor/plasteel/cafeteria{
 	dir = 5
 	},
@@ -62085,7 +62044,6 @@
 /turf/open/floor/plating/airless,
 /area/science/test_area)
 "cBO" = (
-/obj/item/flashlight/lamp,
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
@@ -62875,21 +62833,12 @@
 /turf/open/floor/plating/airless,
 /area/science/test_area)
 "cDy" = (
-/obj/machinery/camera{
-	active_power_usage = 0;
-	c_tag = "Bomb Test Site";
-	desc = "A specially-reinforced camera with a long lasting battery, used to monitor the bomb testing site. An external light is attached to the top.";
-	dir = 8;
-	invuln = 1;
-	light = null;
-	luminosity = 3;
-	name = "Hardened Bomb-Test Camera";
-	network = list("toxins");
-	use_power = 0
-	},
 /obj/item/target/alien/anchored,
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
+	},
+/obj/machinery/camera/preset/toxins{
+	dir = 8
 	},
 /turf/open/floor/plating/airless{
 	luminosity = 2
@@ -63870,7 +63819,6 @@
 /turf/open/floor/plating/airless,
 /area/science/test_area)
 "cFw" = (
-/obj/item/flashlight/lamp,
 /obj/effect/turf_decal/stripes/line{
 	dir = 2
 	},
@@ -76163,14 +76111,11 @@
 /area/crew_quarters/fitness/recreation)
 "jyv" = (
 /obj/structure/table/reinforced,
-/obj/machinery/computer/security/telescreen{
-	desc = "Used for watching the RD's goons from the safety of your own office.";
-	name = "Research Monitor";
-	network = list("rd");
-	pixel_y = 32
+/obj/item/stock_parts/cell/high,
+/obj/item/stock_parts/cell/high,
+/obj/machinery/computer/security/telescreen/circuitry{
+	pixel_x = 30
 	},
-/obj/item/stock_parts/cell/high,
-/obj/item/stock_parts/cell/high,
 /turf/open/floor/plasteel/white,
 /area/science/circuit)
 "jyQ" = (
@@ -76470,14 +76415,11 @@
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
-/obj/machinery/computer/security/telescreen{
-	desc = "Used for watching the RD's goons from the safety of your own office.";
-	name = "Research Monitor";
-	network = list("rd");
-	pixel_y = 32
+/obj/item/stock_parts/cell/high,
+/obj/item/stock_parts/cell/high,
+/obj/machinery/computer/security/telescreen/circuitry{
+	pixel_y = 30
 	},
-/obj/item/stock_parts/cell/high,
-/obj/item/stock_parts/cell/high,
 /turf/open/floor/plasteel/white,
 /area/science/circuit)
 "ohj" = (

--- a/_maps/map_files/PubbyStation/PubbyStation.dmm
+++ b/_maps/map_files/PubbyStation/PubbyStation.dmm
@@ -2249,9 +2249,7 @@
 	c_tag = "Brig Prison Hallway";
 	network = list("ss13","prison")
 	},
-/obj/machinery/computer/security/telescreen{
-	desc = "Used for watching Prison Wing holding areas.";
-	name = "Prison Monitor";
+/obj/machinery/computer/security/telescreen/prison{
 	network = list("prison");
 	pixel_y = 30
 	},
@@ -4378,7 +4376,7 @@
 /turf/open/floor/carpet,
 /area/crew_quarters/heads/hos)
 "amz" = (
-/obj/machinery/computer/security{
+/obj/machinery/computer/security/hos{
 	dir = 8
 	},
 /turf/open/floor/carpet,
@@ -5072,10 +5070,7 @@
 /turf/open/floor/plating,
 /area/maintenance/department/security/brig)
 "aok" = (
-/obj/machinery/computer/security{
-	name = "Labor Camp Monitoring";
-	network = list("labor")
-	},
+/obj/machinery/computer/security/labor,
 /turf/open/floor/plasteel/dark,
 /area/security/brig)
 "aol" = (
@@ -5936,6 +5931,10 @@
 	},
 /area/security/brig)
 "aqA" = (
+/obj/machinery/computer/security/telescreen/interrogation{
+	dir = 8;
+	pixel_x = 30
+	},
 /turf/open/floor/plasteel/red/side{
 	dir = 5
 	},
@@ -6269,7 +6268,8 @@
 "arz" = (
 /obj/machinery/camera{
 	c_tag = "Brig Interrogation";
-	dir = 8
+	dir = 8;
+	network = list("interrogation")
 	},
 /turf/open/floor/plasteel/dark,
 /area/security/brig)
@@ -7310,6 +7310,7 @@
 "aud" = (
 /obj/machinery/camera/motion{
 	c_tag = "Vault";
+	network = list("vault");
 	dir = 1
 	},
 /obj/machinery/light,
@@ -10280,6 +10281,9 @@
 /turf/open/floor/wood,
 /area/crew_quarters/heads/hop)
 "aBA" = (
+/obj/machinery/computer/security/telescreen/vault{
+	pixel_y = 30
+	},
 /obj/machinery/computer/security/mining,
 /turf/open/floor/wood,
 /area/crew_quarters/heads/hop)
@@ -10783,7 +10787,8 @@
 /obj/item/aiModule/supplied/quarantine,
 /obj/machinery/camera/motion{
 	c_tag = "AI Upload Port";
-	dir = 4
+	dir = 4;
+	network = list("aiupload")
 	},
 /obj/item/aiModule/reset,
 /obj/machinery/flasher{
@@ -10830,7 +10835,8 @@
 /obj/item/aiModule/supplied/freeform,
 /obj/machinery/camera/motion{
 	c_tag = "AI Upload Starboard";
-	dir = 8
+	dir = 8;
+	network = list("aiupload")
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -11261,7 +11267,8 @@
 /obj/machinery/holopad,
 /obj/machinery/camera/motion{
 	c_tag = "AI Upload Center";
-	dir = 1
+	dir = 1;
+	network = list("aiupload")
 	},
 /obj/item/radio/intercom{
 	broadcasting = 1;
@@ -16561,6 +16568,10 @@
 /obj/machinery/light{
 	dir = 4
 	},
+/obj/machinery/computer/security/telescreen/auxbase{
+	dir = 8;
+	pixel_x = 30
+	},
 /turf/open/floor/plasteel,
 /area/construction/mining/aux_base)
 "aRH" = (
@@ -21317,13 +21328,13 @@
 /turf/open/floor/plasteel,
 /area/quartermaster/miningdock)
 "bdM" = (
-/obj/machinery/computer/security/mining{
-	dir = 8
-	},
 /obj/machinery/requests_console{
 	department = "Mining";
 	departmentType = 0;
 	pixel_x = 32
+	},
+/obj/machinery/computer/security/mining{
+	dir = 8
 	},
 /turf/open/floor/plasteel/brown/corner,
 /area/quartermaster/miningdock)
@@ -22046,13 +22057,11 @@
 	},
 /area/quartermaster/qm)
 "bfD" = (
-/obj/machinery/computer/security/mining{
-	dir = 8
-	},
 /obj/item/radio/intercom{
 	name = "Station Intercom (General)";
 	pixel_y = -35
 	},
+/obj/machinery/computer/security/qm,
 /turf/open/floor/plasteel/brown{
 	dir = 6
 	},
@@ -23836,6 +23845,7 @@
 	},
 /obj/machinery/camera{
 	c_tag = "Genetics Cloning Foyer";
+	network = list("ss13","medbay");
 	dir = 2
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on,
@@ -24222,12 +24232,8 @@
 	dir = 1
 	},
 /obj/item/integrated_electronics/debugger,
-/obj/machinery/computer/security/telescreen{
-	desc = "Used for watching the other eggheads from the comfort of the circuitry lab.";
-	dir = 2;
-	name = "RnD Monitor";
-	network = list("rd");
-	pixel_y = 32
+/obj/machinery/computer/security/telescreen/circuitry{
+	pixel_y = 30
 	},
 /turf/open/floor/plasteel/vault{
 	dir = 5
@@ -24248,12 +24254,8 @@
 /obj/machinery/light{
 	dir = 1
 	},
-/obj/machinery/computer/security/telescreen{
-	desc = "Used for watching the other eggheads from the comfort of the circuitry lab.";
-	dir = 2;
-	name = "RnD Monitor";
-	network = list("rd");
-	pixel_y = 32
+/obj/machinery/computer/security/telescreen/circuitry{
+	pixel_y = 30
 	},
 /turf/open/floor/plasteel/vault{
 	dir = 5
@@ -24400,6 +24402,7 @@
 	},
 /obj/machinery/camera{
 	c_tag = "Medbay Security Post";
+	network = list("ss13","medbay");
 	dir = 4
 	},
 /obj/structure/closet/secure_closet/security/med,
@@ -25229,6 +25232,7 @@
 /obj/structure/bed/roller,
 /obj/machinery/camera{
 	c_tag = "Medbay Entrance";
+	network = list("ss13","medbay");
 	dir = 1
 	},
 /turf/open/floor/plasteel/whiteblue/side,
@@ -26119,7 +26123,7 @@
 /obj/machinery/camera{
 	c_tag = "Genetics Monkey Pen Fore";
 	dir = 4;
-	network = list("ss13","rd")
+	network = list("ss13","medbay")
 	},
 /obj/machinery/light/small{
 	dir = 8
@@ -26731,6 +26735,7 @@
 /obj/machinery/dna_scannernew,
 /obj/machinery/camera{
 	c_tag = "Genetics Cloning";
+	network = list("ss13","medbay");
 	dir = 4
 	},
 /obj/machinery/airalarm/unlocked{
@@ -27756,6 +27761,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/machinery/camera{
 	c_tag = "Medbay Port Hallway";
+	network = list("ss13","medbay");
 	dir = 4
 	},
 /obj/machinery/airalarm{
@@ -29665,7 +29671,7 @@
 /obj/machinery/camera{
 	c_tag = "Genetics Monkey Pen Aft";
 	dir = 4;
-	network = list("ss13","rd")
+	network = list("ss13","medbay")
 	},
 /obj/structure/flora/ausbushes/grassybush,
 /obj/machinery/light/small{
@@ -30316,19 +30322,15 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 10
 	},
-/obj/machinery/computer/security/telescreen{
-	desc = "Used for watching surgery.";
-	dir = 8;
-	layer = 4;
-	name = "Surgery Telescreen";
-	network = list("surgery");
-	pixel_x = 30
-	},
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
 /obj/structure/cable{
 	icon_state = "2-8"
+	},
+/obj/machinery/computer/security/telescreen/cmo{
+	dir = 8;
+	pixel_x = 30
 	},
 /turf/open/floor/plasteel/cmo,
 /area/crew_quarters/heads/cmo)
@@ -30687,7 +30689,7 @@
 /obj/machinery/camera{
 	c_tag = "Genetics";
 	dir = 1;
-	network = list("ss13","rd")
+	network = list("ss13","medbay")
 	},
 /turf/open/floor/plasteel/whitepurple/side,
 /area/medical/genetics)
@@ -30743,6 +30745,7 @@
 /obj/structure/closet/emcloset,
 /obj/machinery/camera{
 	c_tag = "Virology Airlock";
+	network = list("ss13","medbay");
 	dir = 2
 	},
 /obj/effect/turf_decal/stripes/line{
@@ -32003,13 +32006,11 @@
 	pixel_x = 4;
 	pixel_y = 6
 	},
-/obj/machinery/computer/security/telescreen{
-	desc = "Used for watching the RD's goons and the AI's satellite from the safety of his office.";
-	name = "Research Monitor";
-	network = list("rd","minisat");
-	pixel_y = -32
-	},
 /obj/structure/table/glass,
+/obj/machinery/computer/security/telescreen/rd{
+	dir = 1;
+	pixel_y = -26
+	},
 /turf/open/floor/plasteel/darkpurple/side,
 /area/crew_quarters/heads/hor)
 "bEV" = (
@@ -33211,6 +33212,7 @@
 "bHY" = (
 /obj/machinery/camera{
 	c_tag = "Virology";
+	network = list("ss13","medbay");
 	dir = 2
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -33269,6 +33271,7 @@
 /obj/machinery/light,
 /obj/machinery/camera{
 	c_tag = "Medbay Equipment Room";
+	network = list("ss13","medbay");
 	dir = 1
 	},
 /turf/open/floor/plasteel/whiteblue/side,
@@ -33335,6 +33338,7 @@
 "bIm" = (
 /obj/machinery/camera{
 	c_tag = "Medbay Recovery Room";
+	network = list("ss13","medbay");
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -38254,6 +38258,9 @@
 	c_tag = "Chief Engineer's Office";
 	dir = 2
 	},
+/obj/machinery/computer/security/telescreen/ce{
+	pixel_y = 30
+	},
 /turf/open/floor/plasteel/yellow/side{
 	dir = 1
 	},
@@ -41890,7 +41897,7 @@
 	dir = 2;
 	layer = 4;
 	name = "Telecomms Telescreen";
-	network = list("tcomm");
+	network = list("tcomms");
 	pixel_y = 28
 	},
 /obj/structure/disposalpipe/segment{
@@ -43104,16 +43111,7 @@
 /turf/open/floor/carpet,
 /area/library/lounge)
 "cjV" = (
-/obj/machinery/camera{
-	active_power_usage = 0;
-	c_tag = "Bomb Testing Asteroid Fore";
-	desc = "A specially-reinforced camera with a long lasting battery, used to monitor the bomb testing site. An external light is attached to the top.";
-	invuln = 1;
-	luminosity = 3;
-	name = "Hardened Bomb-Test Camera";
-	network = list("ss13","rd","toxins");
-	use_power = 0
-	},
+/obj/machinery/camera/preset/toxins,
 /turf/open/floor/plating/asteroid/airless,
 /area/asteroid/nearstation/bomb_site)
 "cjZ" = (
@@ -43865,7 +43863,7 @@
 /obj/machinery/camera/motion{
 	c_tag = "Telecomms External Port";
 	dir = 8;
-	network = list("tcomm")
+	network = list("tcomms")
 	},
 /turf/open/space,
 /area/space/nearstation)
@@ -43927,7 +43925,7 @@
 /obj/machinery/camera/motion{
 	c_tag = "Telecomms External Starboard";
 	dir = 4;
-	network = list("tcomm")
+	network = list("tcomms")
 	},
 /turf/open/space,
 /area/space/nearstation)
@@ -44103,7 +44101,7 @@
 /obj/machinery/camera/motion{
 	c_tag = "Telecomms Server Room";
 	dir = 1;
-	network = list("ss13","tcomm")
+	network = list("tcomms")
 	},
 /turf/open/floor/plasteel/dark/telecomms,
 /area/tcommsat/server)
@@ -44134,7 +44132,7 @@
 /obj/machinery/camera/motion{
 	c_tag = "Telecomms External Port Aft";
 	dir = 2;
-	network = list("tcomm")
+	network = list("tcomms")
 	},
 /turf/open/space,
 /area/space/nearstation)
@@ -44143,7 +44141,7 @@
 /obj/machinery/camera/motion{
 	c_tag = "Telecomms External Starboard Aft";
 	dir = 2;
-	network = list("tcomm")
+	network = list("tcomms")
 	},
 /turf/open/space,
 /area/space/nearstation)
@@ -49216,7 +49214,7 @@
 /obj/machinery/camera{
 	c_tag = "Telecomms External Fore";
 	dir = 1;
-	network = list("SS13","tcomm");
+	network = list("tcomms");
 	start_active = 1
 	},
 /obj/structure/cable/yellow{
@@ -50935,7 +50933,7 @@
 /obj/machinery/camera/motion{
 	c_tag = "Telecomms Monitoring";
 	dir = 2;
-	network = list("ss13","tcomm")
+	network = list("tcomms")
 	},
 /obj/structure/cable{
 	icon_state = "2-8"
@@ -52231,7 +52229,7 @@
 /obj/machinery/camera/motion{
 	c_tag = "Telecomms External Access";
 	dir = 1;
-	network = list("ss13","tcomm")
+	network = list("tcomms")
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 1
@@ -54450,7 +54448,7 @@
 /obj/machinery/camera{
 	c_tag = "Engineering Telecomms Access";
 	dir = 8;
-	network = list("tcomm")
+	network = list("tcomms")
 	},
 /obj/machinery/light{
 	dir = 4

--- a/_maps/shuttles/aux_base_default.dmm
+++ b/_maps/shuttles/aux_base_default.dmm
@@ -78,7 +78,8 @@
 /area/shuttle/auxillary_base)
 "X" = (
 /obj/machinery/camera{
-	dir = 1
+	dir = 1;
+	network = list("auxbase")
 	},
 /obj/structure/mining_shuttle_beacon,
 /turf/open/floor/plating,

--- a/code/game/machinery/camera/camera.dm
+++ b/code/game/machinery/camera/camera.dm
@@ -41,6 +41,16 @@
 
 	var/internal_light = TRUE //Whether it can light up when an AI views it
 
+/obj/machinery/camera/preset/toxins //Bomb test site in space
+	name = "Hardened Bomb-Test Camera"
+	desc = "A specially-reinforced camera with a long lasting battery, used to monitor the bomb testing site. An external light is attached to the top."
+	c_tag = "Bomb Testing Site"
+	network = list("rd","toxins")
+	use_power = NO_POWER_USE //Test site is an unpowered area
+	invuln = TRUE
+	light_range = 10
+	start_active = TRUE
+
 /obj/machinery/camera/Initialize(mapload, obj/structure/camera_assembly/CA)
 	. = ..()
 	for(var/i in network)

--- a/code/game/machinery/camera/motion.dm
+++ b/code/game/machinery/camera/motion.dm
@@ -63,6 +63,7 @@
 	for (var/mob/living/silicon/aiPlayer in GLOB.player_list)
 		if (status)
 			aiPlayer.triggerAlarm("Motion", get_area(src), list(src), src)
+			visible_message("<span class='warning'>A red light flashes on the [src]!</span>")
 	detectTime = -1
 	return TRUE
 

--- a/code/game/machinery/camera/presets.dm
+++ b/code/game/machinery/camera/presets.dm
@@ -2,7 +2,7 @@
 
 // EMP
 /obj/machinery/camera/emp_proof
-	start_active = 1
+	start_active = TRUE
 
 /obj/machinery/camera/emp_proof/Initialize()
 	. = ..()
@@ -11,7 +11,7 @@
 // X-RAY
 
 /obj/machinery/camera/xray
-	start_active = 1
+	start_active = TRUE
 	icon_state = "xraycam" // Thanks to Krutchen for the icons.
 
 /obj/machinery/camera/xray/Initialize()
@@ -20,7 +20,7 @@
 
 // MOTION
 /obj/machinery/camera/motion
-	start_active = 1
+	start_active = TRUE
 	name = "motion-sensitive security camera"
 
 /obj/machinery/camera/motion/Initialize()
@@ -29,7 +29,7 @@
 
 // ALL UPGRADES
 /obj/machinery/camera/all
-	start_active = 1
+	start_active = TRUE
 
 /obj/machinery/camera/all/Initialize()
 	. = ..()

--- a/code/game/machinery/computer/camera.dm
+++ b/code/game/machinery/computer/camera.dm
@@ -152,6 +152,50 @@
 			D["[C.c_tag][(C.status ? null : " (Deactivated)")]"] = C
 	return D
 
+// SECURITY MONITORS
+
+/obj/machinery/computer/security/wooden_tv
+	name = "security camera monitor"
+	desc = "An old TV hooked into the station's camera network."
+	icon_state = "television"
+	icon_keyboard = null
+	icon_screen = "detective_tv"
+	clockwork = TRUE //it'd look weird
+
+/obj/machinery/computer/security/mining
+	name = "outpost camera console"
+	desc = "Used to access the various cameras on the outpost."
+	icon_screen = "mining"
+	icon_keyboard = "mining_key"
+	network = list("mine", "auxbase")
+	circuit = /obj/item/circuitboard/computer/mining
+
+/obj/machinery/computer/security/research
+	name = "research camera console"
+	desc = "Used to access the various cameras in science."
+	network = list("rd")
+	circuit = /obj/item/circuitboard/computer/research
+
+/obj/machinery/computer/security/hos
+	name = "Head of Security's camera console"
+	desc = "A custom security console with added access to the labor camp network."
+	network = list("ss13", "labor")
+	circuit = null
+
+/obj/machinery/computer/security/labor
+	name = "labor camp monitoring"
+	desc = "Used to access the various cameras on the labor camp."
+	network = list("labor")
+	circuit = null
+
+/obj/machinery/computer/security/qm
+	name = "Quartermaster's camera console"
+	desc = "A console with access to the mining, auxillary base and vault camera networks."
+	network = list("mine", "auxbase", "vault")
+	circuit = null
+
+// TELESCREENS
+
 /obj/machinery/computer/security/telescreen
 	name = "\improper Telescreen"
 	desc = "Used for watching an empty arena."
@@ -161,7 +205,6 @@
 	density = FALSE
 	circuit = null
 	clockwork = TRUE //it'd look very weird
-
 	light_power = 0
 
 /obj/machinery/computer/security/telescreen/update_icon()
@@ -176,28 +219,68 @@
 	icon = 'icons/obj/status_display.dmi'
 	icon_state = "entertainment"
 	network = list("thunder")
-	density = FALSE
-	circuit = null
 
-/obj/machinery/computer/security/wooden_tv
-	name = "security camera monitor"
-	desc = "An old TV hooked into the stations camera network."
-	icon_state = "television"
-	icon_keyboard = null
-	icon_screen = "detective_tv"
-	clockwork = TRUE //it'd look weird
+/obj/machinery/computer/security/telescreen/rd
+	name = "Research Director's telescreen"
+	desc = "Used for watching the AI and the RD's goons from the safety of his office."
+	network = list("rd", "aicore", "aiupload", "minisat", "xeno", "test")
 
-
-/obj/machinery/computer/security/mining
-	name = "outpost camera console"
-	desc = "Used to access the various cameras on the outpost."
-	icon_screen = "mining"
-	icon_keyboard = "mining_key"
-	network = list("mine")
-	circuit = /obj/item/circuitboard/computer/mining
-
-/obj/machinery/computer/security/research
-	name = "research camera console"
-	desc = "Used to access the various cameras in science."
+/obj/machinery/computer/security/telescreen/circuitry
+	name = "circuitry telescreen"
+	desc = "Used for watching the other eggheads from the safety of the circuitry lab."
 	network = list("rd")
-	circuit = /obj/item/circuitboard/computer/research
+
+/obj/machinery/computer/security/telescreen/ce
+	name = "Chief Engineer's telescreen"
+	desc = "Used for watching the engine, telecommunications and the minisat."
+	network = list("engine", "singularity", "tcomms", "minisat")
+
+/obj/machinery/computer/security/telescreen/cmo
+	name = "Chief Medical Officer's telescreen"
+	desc = "A telescreen with access to the medbay's camera network."
+	network = list("medbay")
+
+/obj/machinery/computer/security/telescreen/vault
+	name = "Vault monitor"
+	desc = "A telescreen that connects to the vault's camera network."
+	network = list("vault")
+
+/obj/machinery/computer/security/telescreen/toxins
+	name = "Bomb test site monitor"
+	desc = "A telescreen that connects to the bomb test site's camera."
+	network = list("toxin")
+
+/obj/machinery/computer/security/telescreen/engine
+	name = "engine monitor"
+	desc = "A telescreen that connects to the engine's camera network."
+	network = list("engine")
+
+/obj/machinery/computer/security/telescreen/turbine
+	name = "turbine monitor"
+	desc = "A telescreen that connects to the turbine's camera."
+	network = list("turbine")
+
+/obj/machinery/computer/security/telescreen/interrogation
+	name = "interrogation room monitor"
+	desc = "A telescreen that connects to the interrogation room's camera."
+	network = list("interrogation")
+
+/obj/machinery/computer/security/telescreen/prison
+	name = "prison monitor"
+	desc = "A telescreen that connects to the permabrig's camera network."
+	network = list("prison")
+
+/obj/machinery/computer/security/telescreen/auxbase
+	name = "auxillary base monitor"
+	desc = "A telescreen that connects to the auxillary base's camera."
+	network = list("auxbase")
+
+/obj/machinery/computer/security/telescreen/minisat
+	name = "minisat monitor"
+	desc = "A telescreen that connects to the minisat's camera network."
+	network = list("minisat")
+
+/obj/machinery/computer/security/telescreen/aiupload
+	name = "AI upload monitor"
+	desc = "A telescreen that connects to the AI upload's camera network."
+	network = list("aiupload")


### PR DESCRIPTION
:cl: Denton
tweak: Camera networks, monitor screens and telescreens have been standardized.
tweak: Motion-sensitive cameras now show a message when they trigger the alarm.
fix: The Box/Meta auxillary base camera now works.
fix: Bomb test site cameras now emit light, as intended.
fix: Meta: Replaced the RD telescreen in the CE office with the correct one.
/:cl:

Cam networks/telescreens were all over the place - the last time someone updated them was when Genetics was still a part of RnD.

I figured that it makes sense if department heads can access their relevant camnets:
- RD: AI core, AI upload, the minisat and RnD
- CE: The engine, telecomms and minisat
- HoS: Security cameras and gulag
- HoP/QM: the vault/vault+auxbase+mining
- CMO: medbay

Other than that I fixed bomb site+aux base cams and made motion sensitive cams show a warning when they trigger the alarm.