### PR TITLE
Fixes borg names.

### DIFF
--- a/code/__DEFINES/preferences.dm
+++ b/code/__DEFINES/preferences.dm
@@ -67,3 +67,5 @@
 
 //Flags in the players table in the db
 #define DB_FLAG_EXEMPT 1
+
+#define DEFAULT_CYBORG_NAME "Default Cyborg Name"

--- a/code/__HELPERS/unsorted.dm
+++ b/code/__HELPERS/unsorted.dm
@@ -194,8 +194,10 @@ Turf and target are separate in case you want to teleport some distance from a t
 	var/loop = 1
 	var/safety = 0
 
+	var/banned = jobban_isbanned(src, "appearance")
+	
 	while(loop && safety < 5)
-		if(C && C.prefs.custom_names[role] && !safety && (!jobban_isbanned(src, "appearance")))
+		if(C && C.prefs.custom_names[role] && !safety && !banned)
 			newname = C.prefs.custom_names[role]
 		else
 			switch(role)

--- a/code/__HELPERS/unsorted.dm
+++ b/code/__HELPERS/unsorted.dm
@@ -186,7 +186,7 @@ Turf and target are separate in case you want to teleport some distance from a t
 	return 1
 
 //Generalised helper proc for letting mobs rename themselves. Used to be clname() and ainame()
-/mob/proc/rename_self(role, client/C)
+/mob/proc/apply_pref_name(role, client/C)
 	if(!C)
 		C = client
 	var/oldname = real_name

--- a/code/__HELPERS/unsorted.dm
+++ b/code/__HELPERS/unsorted.dm
@@ -195,7 +195,7 @@ Turf and target are separate in case you want to teleport some distance from a t
 	var/safety = 0
 
 	var/banned = jobban_isbanned(src, "appearance")
-	
+
 	while(loop && safety < 5)
 		if(C && C.prefs.custom_names[role] && !safety && !banned)
 			newname = C.prefs.custom_names[role]
@@ -209,10 +209,8 @@ Turf and target are separate in case you want to teleport some distance from a t
 					newname = pick(GLOB.mime_names)
 				if("ai")
 					newname = pick(GLOB.ai_names)
-				if("deity")
-					newname = pick(GLOB.clown_names|GLOB.ai_names|GLOB.mime_names) //pick any old name
 				else
-					return
+					return FALSE
 
 		for(var/mob/living/M in GLOB.player_list)
 			if(M == src)
@@ -226,6 +224,8 @@ Turf and target are separate in case you want to teleport some distance from a t
 
 	if(newname)
 		fully_replace_character_name(oldname,newname)
+		return TRUE
+	return FALSE
 
 
 //Picks a string of symbols to display as the law number for hacked or ion laws

--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -1341,7 +1341,12 @@ GLOBAL_LIST_EMPTY(preferences_datums)
 						to_chat(user, "<font color='red'>Invalid name. Your name should be at least 2 and at most [MAX_NAME_LEN] characters long. It may only contain the characters A-Z, a-z, 0-9, -, ' and .</font>")
 
 				if("cyborg_name")
-					var/new_cyborg_name = reject_bad_name( input(user, "Choose your character's cyborg name:", "Character Preference")  as text|null, 1 )
+					var/raw_name = input(user, "Choose your character's cyborg name (Leave empty to use default naming scheme):", "Character Preference")  as text|null
+					var/new_cyborg_name
+					if(!raw_name)
+						new_cyborg_name = DEFAULT_CYBORG_NAME
+					else
+						new_cyborg_name = reject_bad_name(raw_name,1 )
 					if(new_cyborg_name)
 						custom_names["cyborg"] = new_cyborg_name
 					else

--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -127,7 +127,7 @@ GLOBAL_LIST_EMPTY(preferences_datums)
 	parent = C
 	custom_names["human"] = random_unique_name()
 	custom_names["ai"] = pick(GLOB.ai_names)
-	custom_names["cyborg"] = pick(GLOB.ai_names)
+	custom_names["cyborg"] = DEFAULT_CYBORG_NAME
 	custom_names["clown"] = pick(GLOB.clown_names)
 	custom_names["mime"] = pick(GLOB.mime_names)
 	UI_style = GLOB.available_ui_styles[1]

--- a/code/modules/jobs/job_types/civilian.dm
+++ b/code/modules/jobs/job_types/civilian.dm
@@ -18,7 +18,7 @@ Clown
 	minimal_access = list(ACCESS_THEATRE)
 
 /datum/job/clown/after_spawn(mob/living/carbon/human/H, mob/M)
-	H.rename_self("clown", M.client)
+	H.apply_pref_name("clown", M.client)
 
 /datum/outfit/job/clown
 	name = "Clown"
@@ -81,7 +81,7 @@ Mime
 	minimal_access = list(ACCESS_THEATRE)
 
 /datum/job/mime/after_spawn(mob/living/carbon/human/H, mob/M)
-	H.rename_self("mime", M.client)
+	H.apply_pref_name("mime", M.client)
 
 /datum/outfit/job/mime
 	name = "Mime"

--- a/code/modules/jobs/job_types/job.dm
+++ b/code/modules/jobs/job_types/job.dm
@@ -81,7 +81,7 @@
 	if(CONFIG_GET(flag/enforce_human_authority) && (title in GLOB.command_positions))
 		if(H.dna.species.id != "human")
 			H.set_species(/datum/species/human)
-			H.rename_self("human", H.client)
+			H.apply_pref_name("human", H.client)
 		purrbation_remove(H, silent=TRUE)
 
 	//Equip the rest of the gear

--- a/code/modules/jobs/job_types/silicon.dm
+++ b/code/modules/jobs/job_types/silicon.dm
@@ -34,7 +34,7 @@ AI
 			H.forceMove(lateJoinCore.loc)
 			qdel(lateJoinCore)
 	var/mob/living/silicon/ai/AI = H
-	AI.rename_self("ai", M.client)			//If this runtimes oh well jobcode is fucked.
+	AI.apply_pref_name("ai", M.client)			//If this runtimes oh well jobcode is fucked.
 
 	//we may have been created after our borg
 	if(SSticker.current_state == GAME_STATE_SETTING_UP)
@@ -85,4 +85,4 @@ Cyborg
 	return H.Robotize(FALSE, latejoin)
 
 /datum/job/cyborg/after_spawn(mob/living/silicon/robot/R, mob/M)
-	R.rename_self("cyborg", M.client)
+	R.apply_pref_name("cyborg", M.client)

--- a/code/modules/mob/living/silicon/ai/ai.dm
+++ b/code/modules/mob/living/silicon/ai/ai.dm
@@ -124,7 +124,7 @@
 	job = "AI"
 
 	create_eye()
-	rename_self("ai")
+	apply_pref_name("ai")
 
 	holo_icon = getHologramIcon(icon('icons/mob/ai.dmi',"default"))
 

--- a/code/modules/mob/living/silicon/robot/robot.dm
+++ b/code/modules/mob/living/silicon/robot/robot.dm
@@ -231,9 +231,9 @@
 	var/changed_name = ""
 	if(custom_name)
 		changed_name = custom_name
-	if(changed_name == "" && client)
-		apply_pref_name("cyborg", client)
-		return //built in camera handled in proc
+	if(changed_name == "" && client && client.prefs.custom_names["cyborg"] != DEFAULT_CYBORG_NAME)
+		if(apply_pref_name("cyborg", client))
+			return //built in camera handled in proc
 	if(!changed_name)
 		changed_name = get_standard_name()
 

--- a/code/modules/mob/living/silicon/robot/robot.dm
+++ b/code/modules/mob/living/silicon/robot/robot.dm
@@ -232,7 +232,7 @@
 	if(custom_name)
 		changed_name = custom_name
 	if(changed_name == "" && client)
-		rename_self(src, client)
+		apply_pref_name("cyborg", client)
 		return //built in camera handled in proc
 	if(!changed_name)
 		changed_name = get_standard_name()

--- a/code/modules/mob/transform_procs.dm
+++ b/code/modules/mob/transform_procs.dm
@@ -379,7 +379,7 @@
 	else if(transfer_after)
 		R.key = key
 
-	R.rename_self("cyborg")
+	R.apply_pref_name("cyborg")
 
 	if(R.mmi)
 		R.mmi.name = "Man-Machine Interface: [real_name]"


### PR DESCRIPTION
Fixes #38710

Personally i prefer nameless borg masses but bug is a bug.

Also renamed `rename_self` to `apply_pref_name` the old name wasn't really representative of what it does now.