### PR TITLE
Fixes moth space move

### DIFF
--- a/code/modules/mob/living/carbon/human/human_movement.dm
+++ b/code/modules/mob/living/carbon/human/human_movement.dm
@@ -67,6 +67,6 @@
 				S.step_action()
 
 /mob/living/carbon/human/Process_Spacemove(movement_dir = 0) //Temporary laziness thing. Will change to handles by species reee.
-	if(..())
-		return 1
-	return dna.species.space_move(src)
+	if(dna.species.space_move(src))
+		return TRUE
+	return ..()

--- a/code/modules/mob/living/carbon/human/species_types/humans.dm
+++ b/code/modules/mob/living/carbon/human/species_types/humans.dm
@@ -23,11 +23,6 @@
 		H.endTailWag()
 	. = ..()
 
-/datum/species/human/space_move(mob/living/carbon/human/H)
-	var/obj/item/flightpack/F = H.get_flightpack()
-	if(istype(F) && (F.flight) && F.allow_thrust(0.01, src))
-		return TRUE
-
 /datum/species/human/on_species_gain(mob/living/carbon/human/H, datum/species/old_species)
 	if(H.dna.features["ears"] == "Cat")
 		mutantears = /obj/item/organ/ears/cat


### PR DESCRIPTION
:cl: Nichlas0010
fix: Mothpeople no longer push objects to move in 0-grav, if they can fly
/:cl:

see: https://github.com/yogstation13/Yogstation-TG/issues/1451

The human species check is unnecessary, as flightpack is checked here: https://github.com/yogstation13/Yogstation-TG/blob/cb434847ae9b14bd6f3bcae801a6cad5566b45c7/code/modules/mob/living/carbon/carbon_movement.dm#L37
