### PR TITLE
Achievement quirks

### DIFF
--- a/code/__DEFINES/is_helpers.dm
+++ b/code/__DEFINES/is_helpers.dm
@@ -10,6 +10,8 @@
 
 #define isweakref(D) (istype(D, /datum/weakref))
 
+#define isdatum(D) (istype(D, /datum))
+
 //Turfs
 //#define isturf(A) (istype(A, /turf)) This is actually a byond built-in. Added here for completeness sake.
 

--- a/code/__DEFINES/traits.dm
+++ b/code/__DEFINES/traits.dm
@@ -64,6 +64,8 @@
 #define TRAIT_PROSOPAGNOSIA		"prosopagnosia"
 #define	TRAIT_DRUNK_HEALING		"drunk_healing"
 
+#define TRAIT_DEATH             "death"
+
 // common trait sources
 #define TRAIT_GENERIC "generic"
 #define EYE_DAMAGE "eye_damage"
@@ -85,3 +87,7 @@
 #define STASIS_MUTE "stasis"
 #define GENETICS_SPELL "genetics_spell"
 #define EYES_COVERED "eyes_covered"
+
+// bitflags for unlockable traits, should be fine with 24 slots
+#define UNLOCK_DEATH 1
+

--- a/code/datums/traits/_quirk.dm
+++ b/code/datums/traits/_quirk.dm
@@ -11,6 +11,7 @@
 	var/mood_quirk = FALSE //if true, this quirk affects mood and is unavailable if moodlets are disabled
 	var/mob_trait //if applicable, apply and remove this mob trait
 	var/mob/living/quirk_holder
+	var/unlock    //bitflag for the flag needed for the quirk to be unlocked
 
 /datum/quirk/New(mob/living/quirk_mob, spawn_effects)
 	..()
@@ -93,6 +94,58 @@
 	for(var/V in roundstart_quirks)
 		var/datum/quirk/T = V
 		T.transfer_mob(to_mob)
+
+/client/proc/grant_quirk(_quirk, cause, silent = FALSE)
+	if(!_quirk)
+		return
+	var/BF
+	var/datum/quirk/Q = null
+	if(isdatum(_quirk))
+		Q = _quirk
+	else
+		for(var/V in SSquirks.quirks)
+			Q = SSquirks.quirks[V]
+			if(Q.unlock == _quirk)
+				BF = _quirk //Could also just Q.unlock, either is fine
+				break
+		if(!Q)
+			CRASH("Unlock quirk bitflag not recognized in client/proc/grant_quirk")
+			return
+
+	if(!prefs || prefs.unlocked_quirks & BF)
+		return
+	prefs.unlocked_quirks += BF
+//	if(!silent)
+//		to_chat(usr,"<font color=#d800ff'><b>You were granted [Q.name][cause ?  ", due to [cause]." : "."] You are now able to select \
+		this quirk at roundstart.")
+//	log_admin("[ckey] was granted [Q.name][cause ?  "by [cause]." : "."]")
+
+/client/proc/take_quirk(_quirk, reason) //should be admin only, so excuse the weird returns
+	if(!_quirk)
+		return "param1= the quirks unlock bitflag or quirkdatum as integer or ref, param2=reason to take away their loved ones"
+	if(!reason)
+		return "at least give a reason to take away their life's achievements you butt"
+	var/datum/quirk/Q = null
+	var/BF
+	if(isdatum(_quirk))
+		Q = _quirk
+	else
+		for(var/V in SSquirks.quirks)
+			Q = SSquirks.quirks[V]
+			if(Q.unlock == _quirk)
+				BF = _quirk
+				break
+		if(!Q)
+			CRASH("Unlock-quirk bitflag, [_quirk], not recognized in client/proc/take_quirk. Leave a mans' quirk alone!")
+			return ":("
+	if(prefs.unlocked_quirks & BF)
+		prefs.unlocked_quirks -= BF
+		to_chat(usr,"<span class='warning'>The quirk [Q.name] was taken away from you. Reason: [reason].")
+		return "Succes! You fucking monster."
+	else
+		return "You can't take what they don't have."
+
+
 
 /*
 

--- a/code/datums/traits/_quirk.dm
+++ b/code/datums/traits/_quirk.dm
@@ -105,7 +105,7 @@
 	else
 		for(var/V in SSquirks.quirks)
 			Q = SSquirks.quirks[V]
-			if(Q.unlock == _quirk)
+			if(initial(Q.unlock) == _quirk)
 				BF = _quirk //Could also just Q.unlock, either is fine
 				break
 		if(!Q)
@@ -115,10 +115,10 @@
 	if(!prefs || prefs.unlocked_quirks & BF)
 		return
 	prefs.unlocked_quirks += BF
-//	if(!silent)
-//		to_chat(usr,"<font color=#d800ff'><b>You were granted [Q.name][cause ?  ", due to [cause]." : "."] You are now able to select \
+	if(!silent)
+		to_chat(usr,"<font color=#d800ff'><b>You were granted [initial(Q.name)][cause ?  ", due to [cause]." : "."] You are now able to select \
 		this quirk at roundstart.")
-//	log_admin("[ckey] was granted [Q.name][cause ?  "by [cause]." : "."]")
+	log_admin("[ckey] was granted [initial(Q.name)][cause ?  "by [cause]." : "."]")
 
 /client/proc/take_quirk(_quirk, reason) //should be admin only, so excuse the weird returns
 	if(!_quirk)
@@ -132,7 +132,7 @@
 	else
 		for(var/V in SSquirks.quirks)
 			Q = SSquirks.quirks[V]
-			if(Q.unlock == _quirk)
+			if(initial(Q.unlock) == _quirk)
 				BF = _quirk
 				break
 		if(!Q)
@@ -140,7 +140,8 @@
 			return ":("
 	if(prefs.unlocked_quirks & BF)
 		prefs.unlocked_quirks -= BF
-		to_chat(usr,"<span class='warning'>The quirk [Q.name] was taken away from you. Reason: [reason].")
+		to_chat(usr,"<span class='warning'>The quirk [initial(Q.name)] was taken away from you. Reason: [reason].")
+		log_admin("[ckey]'s [initial(Q.name)] was taken away. Reason: [reason]" )
 		return "Succes! You fucking monster."
 	else
 		return "You can't take what they don't have."

--- a/code/datums/traits/unlock.dm
+++ b/code/datums/traits/unlock.dm
@@ -1,0 +1,15 @@
+/datum/quirk/death
+	name = "Instant-Death"
+	desc = "Tired of suiciding every round? Then this quirk is just for you! It kills you! And you'll never come back!"
+	value = -2 //worth it
+	mob_trait = TRAIT_DEATH
+	unlock = UNLOCK_DEATH
+	gain_text = "<span class='notice'>Mr. Stark, I don't feel so good...</span>"
+	lose_text = "<span class='notice'>Not like it matters anymore.</span>"
+	medical_record_text = "Patient suffers from spontanious, uncurable, death."
+
+/datum/quirk/death/on_spawn()
+	if(!isliving(quirk_holder))
+		return
+	var/mob/living/L = quirk_holder
+	addtimer(CALLBACK(L, .proc/death), 100)

--- a/code/datums/traits/unlock.dm
+++ b/code/datums/traits/unlock.dm
@@ -1,3 +1,12 @@
+/*Same as normal quirks, but requires a special event to be unlocked. Still costs or takes points. Shouldn't be too powerful, just unique to a spe-
+ific event.
+
+To add: Change the unlock variable to something like UNLOCK_ASS, and then add that define to /DEFINES/traits.dm
+		Then call client.grant_quirk(UNLOCK_ASS,"you being an ass") on the mob. The first parameter can also just be the quirk datum
+
+
+Please remove the example quirk (instant death) when adding an unlockable quirk, or don't.
+*/
 /datum/quirk/death
 	name = "Instant-Death"
 	desc = "Tired of suiciding every round? Then this quirk is just for you! It kills you! And you'll never come back!"
@@ -12,4 +21,5 @@
 	if(!isliving(quirk_holder))
 		return
 	var/mob/living/L = quirk_holder
-	addtimer(CALLBACK(L, .proc/death), 100)
+	addtimer(CALLBACK(L, /mob/proc/death), 100)
+	L.hellbound = TRUE

--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -902,6 +902,7 @@ GLOBAL_LIST_EMPTY(preferences_datums)
 			for(var/_V in all_quirks)
 				if(_V == quirk_name)
 					has_quirk = TRUE
+			to_chat(world,"0-[V]")
 			if(initial(T.mood_quirk) && CONFIG_GET(flag/disable_human_mood))
 				lock_reason = "Mood is disabled."
 				quirk_conflict = TRUE
@@ -911,8 +912,9 @@ GLOBAL_LIST_EMPTY(preferences_datums)
 					has_quirk = FALSE
 				else
 					quirk_cost *= -1 //invert it back, since we'd be regaining this amount
-			if(T.unlock)
-				if(!(T.unlock & unlocked_quirks))
+			if(initial(T.unlock))
+				to_chat(world,"1-[initial(T.unlock)]-[unlocked_quirks]")
+				if(!(unlocked_quirks & initial(T.unlock)))
 					break
 			if(quirk_cost > 0)
 				quirk_cost = "+[quirk_cost]"
@@ -922,7 +924,7 @@ GLOBAL_LIST_EMPTY(preferences_datums)
 			if(quirk_conflict)
 				dat += "<font color='[font_color]'>[quirk_name]</font> - [initial(T.desc)] \
 				<font color='red'><b>LOCKED: [lock_reason]</b></font><br>"
-			if(T.unlock)
+			if(initial(T.unlock))
 				font_color = "#d800ff"
 			else
 				if(has_quirk)

--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -902,7 +902,6 @@ GLOBAL_LIST_EMPTY(preferences_datums)
 			for(var/_V in all_quirks)
 				if(_V == quirk_name)
 					has_quirk = TRUE
-			to_chat(world,"0-[V]")
 			if(initial(T.mood_quirk) && CONFIG_GET(flag/disable_human_mood))
 				lock_reason = "Mood is disabled."
 				quirk_conflict = TRUE

--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -82,6 +82,7 @@ GLOBAL_LIST_EMPTY(preferences_datums)
 	var/list/neutral_quirks = list()
 	var/list/all_quirks = list()
 	var/list/character_quirks = list()
+	var/unlocked_quirks = 0 //bitfield
 
 		//Jobs, uses bitflags
 	var/job_civilian_high = 0
@@ -910,6 +911,9 @@ GLOBAL_LIST_EMPTY(preferences_datums)
 					has_quirk = FALSE
 				else
 					quirk_cost *= -1 //invert it back, since we'd be regaining this amount
+			if(T.unlock)
+				if(!(T.unlock & unlocked_quirks))
+					break
 			if(quirk_cost > 0)
 				quirk_cost = "+[quirk_cost]"
 			var/font_color = "#AAAAFF"
@@ -918,6 +922,8 @@ GLOBAL_LIST_EMPTY(preferences_datums)
 			if(quirk_conflict)
 				dat += "<font color='[font_color]'>[quirk_name]</font> - [initial(T.desc)] \
 				<font color='red'><b>LOCKED: [lock_reason]</b></font><br>"
+			if(T.unlock)
+				font_color = "#d800ff"
 			else
 				if(has_quirk)
 					dat += "<b><font color='[font_color]'>[quirk_name]</font></b> - [initial(T.desc)] \

--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -913,9 +913,7 @@ GLOBAL_LIST_EMPTY(preferences_datums)
 				else
 					quirk_cost *= -1 //invert it back, since we'd be regaining this amount
 			if(initial(T.unlock))
-				to_chat(world,"1-[initial(T.unlock)]-[unlocked_quirks]")
 				if(!(unlocked_quirks & initial(T.unlock)))
-					to_chat(world,"2")
 					break
 			if(quirk_cost > 0)
 				quirk_cost = "+[quirk_cost]"

--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -915,24 +915,24 @@ GLOBAL_LIST_EMPTY(preferences_datums)
 			if(initial(T.unlock))
 				to_chat(world,"1-[initial(T.unlock)]-[unlocked_quirks]")
 				if(!(unlocked_quirks & initial(T.unlock)))
+					to_chat(world,"2")
 					break
 			if(quirk_cost > 0)
 				quirk_cost = "+[quirk_cost]"
 			var/font_color = "#AAAAFF"
 			if(initial(T.value) != 0)
 				font_color = initial(T.value) > 0 ? "#AAFFAA" : "#FFAAAA"
+			if(initial(T.unlock))
+				font_color = "#d800ff"
 			if(quirk_conflict)
 				dat += "<font color='[font_color]'>[quirk_name]</font> - [initial(T.desc)] \
 				<font color='red'><b>LOCKED: [lock_reason]</b></font><br>"
-			if(initial(T.unlock))
-				font_color = "#d800ff"
+			if(has_quirk)
+				dat += "<b><font color='[font_color]'>[quirk_name]</font></b> - [initial(T.desc)] \
+				<a href='?_src_=prefs;preference=trait;task=update;trait=[quirk_name]'>[has_quirk ? "Lose" : "Take"] ([quirk_cost] pts.)</a><br>"
 			else
-				if(has_quirk)
-					dat += "<b><font color='[font_color]'>[quirk_name]</font></b> - [initial(T.desc)] \
-					<a href='?_src_=prefs;preference=trait;task=update;trait=[quirk_name]'>[has_quirk ? "Lose" : "Take"] ([quirk_cost] pts.)</a><br>"
-				else
-					dat += "<font color='[font_color]'>[quirk_name]</font> - [initial(T.desc)] \
-					<a href='?_src_=prefs;preference=trait;task=update;trait=[quirk_name]'>[has_quirk ? "Lose" : "Take"] ([quirk_cost] pts.)</a><br>"
+				dat += "<font color='[font_color]'>[quirk_name]</font> - [initial(T.desc)] \
+				<a href='?_src_=prefs;preference=trait;task=update;trait=[quirk_name]'>[has_quirk ? "Lose" : "Take"] ([quirk_cost] pts.)</a><br>"
 		dat += "<br><center><a href='?_src_=prefs;preference=trait;task=reset'>Reset Traits</a></center>"
 
 	user << browse(null, "window=preferences")

--- a/code/modules/client/preferences_savefile.dm
+++ b/code/modules/client/preferences_savefile.dm
@@ -132,6 +132,7 @@ SAVEFILE UPDATING/VERSIONING - 'Simplified', or rather, more coder-friendly ~Car
 	be_special		= SANITIZE_LIST(be_special)
 	pda_style		= sanitize_inlist(pda_style, GLOB.pda_styles, initial(pda_style))
 	pda_color		= sanitize_hexcolor(pda_color, 6, 1, initial(pda_color))
+	unlocked_quirks	= sanitize_integer(unlocked_quirks, 0, 16777215, 0)
 
 	return 1
 
@@ -176,6 +177,7 @@ SAVEFILE UPDATING/VERSIONING - 'Simplified', or rather, more coder-friendly ~Car
 	WRITE_FILE(S["tip_delay"], tip_delay)
 	WRITE_FILE(S["pda_style"], pda_style)
 	WRITE_FILE(S["pda_color"], pda_color)
+	WRITE_FILE(S["unlocked_quirks"], unlocked_quirks)
 
 	return 1
 

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -450,6 +450,7 @@
 #include "code\datums\traits\good.dm"
 #include "code\datums\traits\negative.dm"
 #include "code\datums\traits\neutral.dm"
+#include "code\datums\traits\unlock.dm"
 #include "code\datums\weather\weather.dm"
 #include "code\datums\weather\weather_types\acid_rain.dm"
 #include "code\datums\weather\weather_types\ash_storm.dm"


### PR DESCRIPTION
Adds a framework for achievement locked quirks. You do something, and boom you can now select a new quirk! Quirks still cost or give points, and they should generally not give an actual advantage, rather just some fun stuff related to what they did.

:cl: Time-Green
feature: Added a framework for achievement locked quirks
/:cl:
There's an example/test quirk, called instant death. Next person that makes something should probably remove that, if they beat me to it. Until then, it's there as an example.

The functions used to give and take quirks are: grant_quirk(bitflag or ref,"because you suck"), take_quirk(bitflag or ref,"i am an asshole")
Take quirk generally shouldn't ever be used, because taking quirks is fucking brutal.

If you want to give someone the death quirk, call grant_quirk(UNLOCK_DEATH,"kill yourself") on their client.

I've got some plans for this myselfs, but it will be a while from now