### PR TITLE
Fixes the r4407-era comment on what CELLRATE is

### DIFF
--- a/code/_globalvars/misc.dm
+++ b/code/_globalvars/misc.dm
@@ -10,7 +10,7 @@ GLOBAL_VAR_INIT(TAB, "&nbsp;&nbsp;&nbsp;&nbsp;")
 
 GLOBAL_DATUM_INIT(data_core, /datum/datacore, new)
 
-GLOBAL_VAR_INIT(CELLRATE, 0.002)  // multiplier for watts per tick <> cell storage (eg: .002 means if there is a load of 1000 watts, 20 units will be taken from a cell per second)
+GLOBAL_VAR_INIT(CELLRATE, 0.002)  // conversion ratio between a watt-tick and kilojoule
 GLOBAL_VAR_INIT(CHARGELEVEL, 0.001) // Cap for how fast cells charge, as a percentage-per-tick (.001 means cellcharge is capped to 1% per second)
 
 GLOBAL_LIST_EMPTY(powernets)


### PR DESCRIPTION
So, I've finally figured out what the fuck CELLRATE is. The comment that was there is completely misleading.  I can imagine how this got there: Someone must have decided to put some magic number because they wanted to convert between watt-ticks and kilojoules, and it was 0.002 and it was used in APCs. Someone else was probably like "Hey this needs to be a define" and then proceeded to completely misinterpret what the fuck this means.

There's literally nothing correct about the old comment at all. "watts per tick" is not a real unit and doesn't make sense in any way, since watts are already per unit time. Cell storage... meh. And the example of it meaning 1000 watts -> 20 cell units per second is completely wrong - the tick in this case refers to the "every 2 seconds" tick of the machines subsystem. In other words this is off by a factor of 20, meaning it's 1000 watts -> 1 cell units per second, and ayyy that means that 1 cell unit is a kilojoule. In fact the only other place that links "cell unit" to "kilojoule" is in *research design descriptions*. Which is almost impossible to read in-game because the only way to do so is to put a *design* disk into a RnD computer which is rarely done. In other words, the meaning of this number was completely misinterpreted by whoever wrote this comment.