### PR TITLE
[s] Tweak sight flags on advanced camera consoles

### DIFF
--- a/code/game/machinery/computer/camera_advanced.dm
+++ b/code/game/machinery/computer/camera_advanced.dm
@@ -159,7 +159,7 @@
 
 /mob/camera/aiEye/remote/update_remote_sight(mob/living/user)
 	user.see_invisible = SEE_INVISIBLE_LIVING //can't see ghosts through cameras
-	user.sight = 0
+	user.sight = SEE_TURFS | SEE_BLACKNESS
 	user.see_in_dark = 2
 	return 1
 


### PR DESCRIPTION
Fixes #38746.

SEE_TURFS means that turfs are visible through walls, including the camera static on them.

SEE_BLACKNESS means that blackness covers up turfs where there is no camera static above the blackness layer.

Combined, blackness covers turfs which are on the other side of walls but would be visible if the eye crossed the wall, and static covers turfs which cannot be seen at all.

This may make it possible to detect out-of-vision walls which are in range of some turf which is in vision, but I don't know a solution to that other than simply allowing advanced camera consoles to see through walls like the AI does.