### PR TITLE
Dulls the possessed Chainsword's blade

### DIFF
--- a/code/game/objects/items/holy_weapons.dm
+++ b/code/game/objects/items/holy_weapons.dm
@@ -449,7 +449,6 @@
 	name = "possessed chainsaw sword"
 	desc = "Suffer not a heretic to live."
 	slot_flags = ITEM_SLOT_BELT
-	force = 18
 	attack_verb = list("sawed", "torn", "cut", "chopped", "diced")
 	hitsound = 'sound/weapons/chainsawhit.ogg'
 

--- a/code/game/objects/items/holy_weapons.dm
+++ b/code/game/objects/items/holy_weapons.dm
@@ -449,7 +449,7 @@
 	name = "possessed chainsaw sword"
 	desc = "Suffer not a heretic to live."
 	slot_flags = ITEM_SLOT_BELT
-	force = 30
+	force = 18
 	attack_verb = list("sawed", "torn", "cut", "chopped", "diced")
 	hitsound = 'sound/weapons/chainsawhit.ogg'
 


### PR DESCRIPTION
[Changelogs]: The possessed chainsaw blade is no longer equivalent to a double e-sword in damage, because I promised to fix this ages ago and finally remembered to actually do it. I'm 95% sure this is an oversight because who in their right-mind would approve giving the chappy a force 30 weapon that fits in a belt slot?

:cl: 
balance: The possessed chainsword no longer makes e-swords look pathetic
/:cl:

[why]: I think it should be self-evident as to why giving the chaplain a 30 force weapon at roundstart is a bad idea. 