### PR TITLE
[s] Fixes ID console exploit

### DIFF
--- a/code/game/machinery/computer/card.dm
+++ b/code/game/machinery/computer/card.dm
@@ -348,6 +348,12 @@ GLOBAL_VAR_INIT(time_last_changed_position, 0)
 /obj/machinery/computer/card/Topic(href, href_list)
 	if(..())
 		return
+
+	if(!usr.canUseTopic(src, !issilicon(usr)) || !is_operational())
+		usr.unset_machine()
+		usr << browse(null, "window=id_com")
+		return
+
 	usr.set_machine(src)
 	switch(href_list["choice"])
 		if ("modify")
@@ -532,11 +538,12 @@ GLOBAL_VAR_INIT(time_last_changed_position, 0)
 	updateUsrDialog()
 
 /obj/machinery/computer/card/AltClick(mob/user)
-	if(user.canUseTopic(src))
-		if(scan)
-			eject_id_scan(user)
-		if(modify)
-			eject_id_modify(user)
+	if(!user.canUseTopic(src, !issilicon(user)) || !is_operational())
+		return
+	if(scan)
+		eject_id_scan(user)
+	if(modify)
+		eject_id_modify(user)
 
 /obj/machinery/computer/card/proc/eject_id_scan(mob/user)
 	if(scan)

--- a/code/game/objects/items/devices/PDA/cart.dm
+++ b/code/game/objects/items/devices/PDA/cart.dm
@@ -549,7 +549,7 @@ Code:
 /obj/item/cartridge/Topic(href, href_list)
 	..()
 
-	if (!usr.canmove || usr.stat || usr.restrained() || !in_range(loc, usr))
+	if(!usr.canUseTopic(src, !issilicon(usr)))
 		usr.unset_machine()
 		usr << browse(null, "window=pda")
 		return


### PR DESCRIPTION
ID consoles didn't have a canUseTopic check, so you could control the computer, eject IDs, ect ect from anywhere if you left the window open.

Also cleaned up a similar line in pda/cart