### PR TITLE
Added the pheromone receptor power to changelings.

### DIFF
--- a/code/modules/antagonists/changeling/powers/pheromone_receptors.dm
+++ b/code/modules/antagonists/changeling/powers/pheromone_receptors.dm
@@ -1,0 +1,57 @@
+#define CHANGELING_PHEROMONE_MIN_DISTANCE 10 //More generous than the agent pinpointer because you don't know who you're looking for.
+#define CHANGELING_PHEROMONE_MAX_DISTANCE 25 //They can smell your fear a mile away.  Well, 50 meters.
+#define CHANGELING_PHEROMONE_PING_TIME 20 //2s update time.
+
+
+/obj/effect/proc_holder/changeling/pheromone_receptors
+	name = "Pheromone Receptors"
+	desc = "We attune our senses to track other changelings by scent.  The closer they are, the easier we can find them."
+	helptext = "We will know the general direction of nearby changelings, with closer scents being stronger.  Our chemical generation is slowed while this is active."
+	chemical_cost = 0 //Reduces regain rate while active.
+	dna_cost = 2
+	var/receptors_active = FALSE
+
+/obj/effect/proc_holder/changeling/pheromone_receptors/sting_action(mob/living/carbon/user)
+	var/datum/antagonist/changeling/changeling = user.mind.has_antag_datum(/datum/antagonist/changeling)
+	if(!receptors_active)
+		to_chat(user, "<span class='warning'>We search for the scent of any nearby changelings.</span>")
+		changeling.chem_recharge_slowdown += 0.5
+		user.apply_status_effect(/datum/status_effect/agent_pinpointer/changeling)
+	else
+		to_chat(user, "<span class='notice'>We stop searching for now.</span>")
+		changeling.chem_recharge_slowdown -= 0.5
+		user.remove_status_effect(/datum/status_effect/agent_pinpointer/changeling)
+
+	receptors_active = !receptors_active
+
+//Modified IA pinpointer - Points to the NEAREST changeling, but will only get you within a few tiles of the target.
+//You'll still have to rely on intuition and observation to make the identification.  Lings can 'hide' in public places.
+/datum/status_effect/agent_pinpointer/changeling
+	alert_type = /obj/screen/alert/status_effect/agent_pinpointer/changeling
+	minimum_range = CHANGELING_PHEROMONE_MIN_DISTANCE
+	tick_interval = CHANGELING_PHEROMONE_PING_TIME
+	range_fuzz_factor = 0
+
+/datum/status_effect/agent_pinpointer/changeling/scan_for_target()
+	var/turf/my_loc = get_turf(owner)
+
+	var/list/mob/living/carbon/changelings = list()
+
+	for(var/mob/living/carbon/C in GLOB.alive_mob_list)
+		if(C != owner && C.mind)
+			var/datum/antagonist/changeling/antag_datum = C.mind.has_antag_datum(/datum/antagonist/changeling)
+			if(istype(antag_datum))
+				var/their_loc = get_turf(C)
+				var/distance = get_dist_euclidian(my_loc, their_loc)
+				if (distance < CHANGELING_PHEROMONE_MAX_DISTANCE)
+					changelings[C] = (CHANGELING_PHEROMONE_MAX_DISTANCE ** 2) - (distance ** 2)
+
+	if(changelings.len)
+		scan_target = pickweight(changelings) //Point at a 'random' changeling, biasing heavily towards closer ones.
+	else
+		scan_target = null
+
+
+/obj/screen/alert/status_effect/agent_pinpointer/changeling
+	name = "Pheromone Scent"
+	desc = "The nose always knows."

--- a/code/modules/antagonists/traitor/IAA/internal_affairs.dm
+++ b/code/modules/antagonists/traitor/IAA/internal_affairs.dm
@@ -44,6 +44,7 @@
 	tick_interval = PINPOINTER_PING_TIME
 	alert_type = /obj/screen/alert/status_effect/agent_pinpointer
 	var/minimum_range = PINPOINTER_MINIMUM_RANGE
+	var/range_fuzz_factor = PINPOINTER_EXTRA_RANDOM_RANGE
 	var/mob/scan_target = null
 
 /obj/screen/alert/status_effect/agent_pinpointer
@@ -61,7 +62,7 @@
 	if(here.z != there.z)
 		linked_alert.icon_state = "pinonnull"
 		return
-	if(get_dist_euclidian(here,there)<=minimum_range + rand(0, PINPOINTER_EXTRA_RANDOM_RANGE))
+	if(get_dist_euclidian(here,there)<=minimum_range + rand(0, range_fuzz_factor))
 		linked_alert.icon_state = "pinondirect"
 	else
 		linked_alert.setDir(get_dir(here, there))
@@ -228,7 +229,7 @@
 
 /datum/antagonist/traitor/internal_affairs/forge_traitor_objectives()
 	forge_iaa_objectives()
-	
+
 	var/objtype = traitor_kind == TRAITOR_HUMAN ? /datum/objective/escape : /datum/objective/survive
 	var/datum/objective/escape_objective = new objtype
 	escape_objective.owner = owner

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -1144,6 +1144,7 @@
 #include "code\modules\antagonists\changeling\powers\mimic_voice.dm"
 #include "code\modules\antagonists\changeling\powers\mutations.dm"
 #include "code\modules\antagonists\changeling\powers\panacea.dm"
+#include "code\modules\antagonists\changeling\powers\pheromone_receptors.dm"
 #include "code\modules\antagonists\changeling\powers\regenerate.dm"
 #include "code\modules\antagonists\changeling\powers\revive.dm"
 #include "code\modules\antagonists\changeling\powers\shriek.dm"


### PR DESCRIPTION
:cl: MacHac
add: Changelings can now take the Pheromone Receptors ability to hunt down other changelings.
/:cl:

Changelings' 'Absorb another ling' objectives have been astoundingly difficult for a while now because lings haven't historically had any good way to identify each other.  By the time a ling gets called on the radio, every bored validhunter on the station is already dragging it to the cremator while beating it, making the old yoink'n'succ borderline suicidal.  Short of some sucker announcing his name and position over lingchat (a mistake most people only make once), changelings assigned to absorb other lings are nearly always SOL.

With this in mind, I've created 'pheromone receptors', a new changeling power.  By tracking the unique but normally undetectable scent of other changelings, a hunter can track fellow lings and find their general location.  Similar to the target pinpointer that all IA agents get, receptors help to locate other changelings, with a few important caveats:
 - They have a maximum range of 25 tiles.  They will not give any indication of changelings outside this radius.
 - They have a minimum range of 10 tiles.  The pinpointer will not display a direction for closer targets.
 - The pinpointer does not show its current target.  It may switch randomly between targets at similar distances.
 - The pinpointer slows down chemical regeneration while active, similar to the 'mimic voice' ability.
 - The power has to be purchased for 2 points.

This power is not intended as a replacement for player skill in identifying changelings; rather, it's a supplement.  Hunting lings can easily identify lone and out-of-place people as their targets.  This encourages hunted changelings to stay mobile and in public, where it will be more difficult to confirm their identity.  Well-hidden changelings might in turn be able to detect someone who's looking for them; This allows them to either slip away or arrange a confrontation.

Hopefully, with a way to accomplish this objective that's not random-ass luck, changelings might be able to start greentexting regularly again.

*No they won't, team objectives still exist.