### PR TITLE
Improves disease infection code

### DIFF
--- a/code/datums/diseases/_disease.dm
+++ b/code/datums/diseases/_disease.dm
@@ -42,10 +42,8 @@
 
 //add this disease if the host does not already have too many
 /datum/disease/proc/try_infect(var/mob/living/infectee, make_copy = TRUE)
-	if(infectee.diseases.len < DISEASE_LIMIT)
-		infect(infectee, make_copy)
-		return TRUE
-	return FALSE
+	infect(infectee, make_copy)
+	return TRUE
 
 //add the disease with no checks
 /datum/disease/proc/infect(var/mob/living/infectee, make_copy = TRUE)

--- a/code/datums/diseases/advance/advance.dm
+++ b/code/datums/diseases/advance/advance.dm
@@ -56,13 +56,13 @@
 	return ..()
 
 /datum/disease/advance/try_infect(var/mob/living/infectee, make_copy = TRUE)
-	var/replace_num = infectee.diseases.len + 1 - DISEASE_LIMIT
+	//see if we are more transmittable than enough diseases to replace them
+	//diseases replaced in this way do not confer immunity
+	var/list/L = list()
+	for(var/datum/disease/advance/P in infectee.diseases)
+		L += P
+	var/replace_num = L.len + 1 - DISEASE_LIMIT
 	if(replace_num > 0)
-		//see if we are more transmittable than enough diseases to replace them
-		//diseases replaced in this way do not confer immunity
-		var/list/L = list()
-		for(var/datum/disease/advance/P in infectee.diseases)
-			L += P
 		sortTim(L, /proc/cmp_advdisease_resistance_asc)
 		var/datum/disease/advance/competition = L[replace_num]
 		if(totalTransmittable() > competition.totalResistance())

--- a/code/datums/diseases/advance/advance.dm
+++ b/code/datums/diseases/advance/advance.dm
@@ -58,20 +58,18 @@
 /datum/disease/advance/try_infect(var/mob/living/infectee, make_copy = TRUE)
 	//see if we are more transmittable than enough diseases to replace them
 	//diseases replaced in this way do not confer immunity
-	var/list/L = list()
+	var/list/advance_diseases = list()
 	for(var/datum/disease/advance/P in infectee.diseases)
-		L += P
-	var/replace_num = L.len + 1 - DISEASE_LIMIT
+		advance_diseases += P
+	var/replace_num = advance_diseases.len + 1 - DISEASE_LIMIT //amount of diseases that need to be removed to fit this one
 	if(replace_num > 0)
-		sortTim(L, /proc/cmp_advdisease_resistance_asc)
-		var/datum/disease/advance/competition = L[replace_num]
-		if(totalTransmittable() > competition.totalResistance())
-			for(var/i in 1 to replace_num)
-				var/datum/disease/advance/A = L[replace_num]
-				A.cure(FALSE)
-		else
-			//we are not strong enough to bully our way in
-			return FALSE
+		sortTim(advance_diseases, /proc/cmp_advdisease_resistance_asc)
+		for(var/i in 1 to replace_num)
+			var/datum/disease/advance/competition = advance_diseases[i]
+			if(totalTransmittable() > competition.totalResistance())
+				competition.cure(FALSE)
+			else
+				return FALSE //we are not strong enough to bully our way in
 	infect(infectee, make_copy)
 	return TRUE
 


### PR DESCRIPTION
Basic diseases now properly ignore limits as initially intended, and advance diseases should (in theory) not cause collateral removal when trying to remove existing diseases.

_Might_ fix #38729

I'm not even sure what the old code was supposed to do, apparently it counted ALL diseases to get the amount to replace, but then only tried to replace the same amount of advance diseases, which would overflow the list every time the target has a basic disease. Then it sorted the diseases from weakest to strongest, but then it confronts the strongest instead of the weakest.