### PR TITLE
Adds tcomms to runtimestation

### DIFF
--- a/_maps/map_files/debug/runtimestation.dmm
+++ b/_maps/map_files/debug/runtimestation.dmm
@@ -417,6 +417,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
+/obj/machinery/announcement_system,
 /turf/open/floor/plasteel,
 /area/engine/gravity_generator)
 "bh" = (
@@ -487,6 +488,9 @@
 	dir = 10
 	},
 /obj/machinery/light,
+/obj/machinery/telecomms/allinone{
+	network = "tcommsat"
+	},
 /turf/open/floor/plasteel,
 /area/engine/gravity_generator)
 "br" = (


### PR DESCRIPTION
:cl: Denton
tweak: Added all-in-one tcomms machinery and an automated announcement system.
/:cl:

Having tcomms is neccessary in some cases and damaged shuttles throw runtimes if no announcement system is present.
