### PR TITLE
Puts toasters on tables

### DIFF
--- a/_maps/RandomRuins/LavaRuins/lavaland_surface_seed_vault.dmm
+++ b/_maps/RandomRuins/LavaRuins/lavaland_surface_seed_vault.dmm
@@ -21,11 +21,17 @@
 /turf/open/floor/plasteel/freezer,
 /area/ruin/powered/seedvault)
 "f" = (
-/obj/machinery/plantgenes/seedvault,
+/obj/machinery/plantgenes/seedvault{
+	pixel_y = 6
+	},
+/obj/structure/table/wood,
 /turf/open/floor/plasteel/freezer,
 /area/ruin/powered/seedvault)
 "g" = (
 /obj/structure/table/wood,
+/obj/machinery/smartfridge/disks{
+	pixel_y = 2
+	},
 /turf/open/floor/plasteel/freezer,
 /area/ruin/powered/seedvault)
 "h" = (

--- a/_maps/map_files/BoxStation/BoxStation.dmm
+++ b/_maps/map_files/BoxStation/BoxStation.dmm
@@ -14504,7 +14504,10 @@
 /obj/machinery/light/small{
 	dir = 1
 	},
-/obj/machinery/plantgenes,
+/obj/machinery/plantgenes{
+	pixel_y = 6
+	},
+/obj/structure/table,
 /turf/open/floor/plasteel/hydrofloor,
 /area/hydroponics)
 "aKM" = (
@@ -23897,7 +23900,7 @@
 "bkb" = (
 /obj/machinery/camera{
 	c_tag = "Medbay Morgue";
-	network = list("ss13", "medbay");
+	network = list("ss13","medbay");
 	dir = 8
 	},
 /obj/machinery/airalarm{
@@ -24424,7 +24427,7 @@
 /obj/structure/table/reinforced,
 /obj/machinery/camera{
 	c_tag = "Medbay Foyer";
-	network = list("ss13", "medbay");
+	network = list("ss13","medbay");
 	dir = 8
 	},
 /obj/machinery/cell_charger,
@@ -26815,7 +26818,7 @@
 	},
 /obj/machinery/camera{
 	c_tag = "Medbay West";
-	network = list("ss13", "medbay");
+	network = list("ss13","medbay");
 	dir = 2
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -27500,7 +27503,7 @@
 	},
 /obj/machinery/camera{
 	c_tag = "Medbay East";
-	network = list("ss13", "medbay");
+	network = list("ss13","medbay");
 	dir = 8;
 	pixel_y = -22
 	},
@@ -28829,8 +28832,7 @@
 /obj/machinery/camera{
 	c_tag = "Genetics Research";
 	dir = 1;
-	network = list("ss13", "medbay");
-	
+	network = list("ss13","medbay")
 	},
 /obj/machinery/firealarm{
 	dir = 1;
@@ -28864,7 +28866,7 @@
 "bvB" = (
 /obj/machinery/camera{
 	c_tag = "Genetics Access";
-	network = list("ss13", "medbay");
+	network = list("ss13","medbay");
 	dir = 8;
 	pixel_y = -22
 	},
@@ -29223,7 +29225,7 @@
 /obj/structure/chair,
 /obj/machinery/camera{
 	c_tag = "Surgery Observation";
-	network = list("ss13", "medbay")
+	network = list("ss13","medbay")
 	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 4
@@ -29308,7 +29310,7 @@
 /obj/structure/table/glass,
 /obj/machinery/camera{
 	c_tag = "Medbay Cryogenics";
-	network = list("ss13", "medbay");
+	network = list("ss13","medbay");
 	dir = 2
 	},
 /obj/item/reagent_containers/glass/beaker/cryoxadone,
@@ -29327,7 +29329,7 @@
 "bwL" = (
 /obj/machinery/camera{
 	c_tag = "Genetics Cloning";
-	network = list("ss13", "medbay");
+	network = list("ss13","medbay");
 	dir = 4
 	},
 /obj/structure/table,
@@ -30889,7 +30891,7 @@
 	},
 /obj/machinery/camera{
 	c_tag = "Medbay Treatment Center";
-	network = list("ss13", "medbay");
+	network = list("ss13","medbay");
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -31922,7 +31924,7 @@
 /obj/structure/closet/secure_closet/medical3,
 /obj/machinery/camera{
 	c_tag = "Medbay Storage";
-	network = list("ss13", "medbay");
+	network = list("ss13","medbay");
 	dir = 2
 	},
 /turf/open/floor/plasteel/white,
@@ -32005,7 +32007,7 @@
 	},
 /obj/machinery/camera{
 	c_tag = "Medbay South";
-	network = list("ss13", "medbay");
+	network = list("ss13","medbay");
 	dir = 4
 	},
 /turf/open/floor/plasteel/white,
@@ -32298,7 +32300,7 @@
 	},
 /obj/machinery/camera{
 	c_tag = "Medbay Recovery Room";
-	network = list("ss13", "medbay");
+	network = list("ss13","medbay");
 	dir = 8
 	},
 /obj/machinery/iv_drip,
@@ -32540,7 +32542,7 @@
 	},
 /obj/machinery/camera{
 	c_tag = "Chief Medical Office";
-	network = list("ss13", "medbay");
+	network = list("ss13","medbay");
 	dir = 8;
 	pixel_y = -22
 	},
@@ -34086,7 +34088,7 @@
 	},
 /obj/machinery/camera{
 	c_tag = "Surgery Operating";
-	network = list("ss13", "medbay");
+	network = list("ss13","medbay");
 	dir = 1;
 	pixel_x = 22
 	},
@@ -34409,7 +34411,7 @@
 	},
 /obj/machinery/camera{
 	c_tag = "Virology Break Room";
-	network = list("ss13", "medbay")
+	network = list("ss13","medbay")
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 8
@@ -36706,7 +36708,7 @@
 /obj/structure/closet/emcloset,
 /obj/machinery/camera{
 	c_tag = "Virology Airlock";
-	network = list("ss13", "medbay");
+	network = list("ss13","medbay");
 	dir = 2
 	},
 /obj/effect/turf_decal/stripes/line{
@@ -38652,7 +38654,7 @@
 	},
 /obj/machinery/camera{
 	c_tag = "Virology Module";
-	network = list("ss13", "medbay")
+	network = list("ss13","medbay")
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
@@ -53343,7 +53345,10 @@
 /turf/open/floor/plasteel/dark,
 /area/engine/engineering)
 "fGf" = (
-/obj/machinery/smartfridge/disks,
+/obj/machinery/smartfridge/disks{
+	pixel_y = 2
+	},
+/obj/structure/table,
 /turf/open/floor/plasteel/hydrofloor,
 /area/hydroponics)
 "fKl" = (

--- a/_maps/map_files/Deltastation/DeltaStation2.dmm
+++ b/_maps/map_files/Deltastation/DeltaStation2.dmm
@@ -27901,13 +27901,16 @@
 	pixel_x = 26;
 	pixel_y = 8
 	},
-/obj/machinery/plantgenes,
+/obj/machinery/plantgenes{
+	pixel_y = 6
+	},
 /obj/machinery/camera{
 	c_tag = "Hydroponics";
 	dir = 8;
 	name = "service camera"
 	},
 /obj/effect/turf_decal/delivery,
+/obj/structure/table,
 /turf/open/floor/plasteel,
 /area/hydroponics)
 "bnn" = (
@@ -28548,7 +28551,10 @@
 /turf/open/floor/plasteel,
 /area/hydroponics)
 "boC" = (
-/obj/machinery/smartfridge/disks,
+/obj/machinery/smartfridge/disks{
+	pixel_y = 2
+	},
+/obj/structure/table,
 /turf/open/floor/plasteel,
 /area/hydroponics)
 "boD" = (
@@ -67884,7 +67890,7 @@
 	},
 /obj/machinery/camera{
 	c_tag = "Medbay - Storage";
-	network = list("ss13", "medbay");
+	network = list("ss13","medbay");
 	dir = 4;
 	name = "medbay camera"
 	},
@@ -71803,7 +71809,7 @@
 /obj/machinery/light,
 /obj/machinery/camera{
 	c_tag = "Medbay - Waiting Room";
-	network = list("ss13", "medbay");
+	network = list("ss13","medbay");
 	dir = 1;
 	name = "medbay camera"
 	},
@@ -71943,7 +71949,7 @@
 "cYc" = (
 /obj/machinery/camera{
 	c_tag = "Medbay - Break Room";
-	network = list("ss13", "medbay");
+	network = list("ss13","medbay");
 	dir = 2;
 	name = "medbay camera"
 	},
@@ -72621,7 +72627,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/machinery/camera{
 	c_tag = "Medbay - Fore Port";
-	network = list("ss13", "medbay");
+	network = list("ss13","medbay");
 	dir = 8;
 	name = "medbay camera"
 	},
@@ -72703,7 +72709,7 @@
 /obj/item/stack/medical/ointment,
 /obj/machinery/camera{
 	c_tag = "Medbay - Sleepers";
-	network = list("ss13", "medbay");
+	network = list("ss13","medbay");
 	dir = 2;
 	name = "medbay camera"
 	},
@@ -75472,7 +75478,7 @@
 	},
 /obj/machinery/camera{
 	c_tag = "Medbay - Chemistry";
-	network = list("ss13", "medbay");
+	network = list("ss13","medbay");
 	dir = 8;
 	name = "medbay camera"
 	},
@@ -76303,7 +76309,7 @@
 	},
 /obj/machinery/camera{
 	c_tag = "Medbay - Center";
-	network = list("ss13", "medbay");
+	network = list("ss13","medbay");
 	dir = 2;
 	name = "medbay camera"
 	},
@@ -77694,7 +77700,7 @@
 /obj/machinery/light,
 /obj/machinery/camera{
 	c_tag = "Medbay - Port";
-	network = list("ss13", "medbay");
+	network = list("ss13","medbay");
 	dir = 1;
 	name = "medbay camera"
 	},
@@ -77793,7 +77799,7 @@
 /obj/machinery/light,
 /obj/machinery/camera{
 	c_tag = "Medbay - Starboard";
-	network = list("ss13", "medbay");
+	network = list("ss13","medbay");
 	dir = 1;
 	name = "medbay camera"
 	},
@@ -81244,7 +81250,7 @@
 	},
 /obj/machinery/camera{
 	c_tag = "Medbay - Cloning Lab";
-	network = list("ss13", "medbay");
+	network = list("ss13","medbay");
 	dir = 1;
 	name = "medbay camera"
 	},
@@ -81304,7 +81310,7 @@
 /obj/item/clothing/neck/stethoscope,
 /obj/machinery/camera{
 	c_tag = "Medbay - Cryogenics";
-	network = list("ss13", "medbay");
+	network = list("ss13","medbay");
 	dir = 1;
 	name = "medbay camera"
 	},
@@ -81771,7 +81777,7 @@
 /obj/machinery/iv_drip,
 /obj/machinery/camera{
 	c_tag = "Medbay - Recovery Room";
-	network = list("ss13", "medbay");
+	network = list("ss13","medbay");
 	dir = 8;
 	name = "medbay camera"
 	},
@@ -83168,7 +83174,7 @@
 	},
 /obj/machinery/camera{
 	c_tag = "Medbay - Genetics Lab";
-	network = list("ss13", "medbay");
+	network = list("ss13","medbay");
 	dir = 4;
 	name = "medbay camera"
 	},
@@ -83800,7 +83806,7 @@
 /obj/item/storage/box/disks,
 /obj/machinery/camera{
 	c_tag = "Medbay - Genetics Desk";
-	network = list("ss13", "medbay");
+	network = list("ss13","medbay");
 	dir = 4;
 	name = "medbay camera"
 	},
@@ -84108,7 +84114,7 @@
 	},
 /obj/machinery/camera{
 	c_tag = "Medbay - Surgery";
-	network = list("ss13", "medbay");
+	network = list("ss13","medbay");
 	dir = 1;
 	name = "medbay camera"
 	},
@@ -84703,7 +84709,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/machinery/camera{
 	c_tag = "Medbay - Aft Port";
-	network = list("ss13", "medbay");
+	network = list("ss13","medbay");
 	dir = 8;
 	name = "medbay camera"
 	},
@@ -84762,7 +84768,7 @@
 	},
 /obj/machinery/camera{
 	c_tag = "Medbay - Chief Medical Officer's Office";
-	network = list("ss13", "medbay");
+	network = list("ss13","medbay");
 	dir = 8;
 	name = "medbay camera"
 	},
@@ -86032,7 +86038,7 @@
 	},
 /obj/machinery/camera{
 	c_tag = "Medbay - Aft Starboard";
-	network = list("ss13", "medbay");
+	network = list("ss13","medbay");
 	dir = 4;
 	name = "medbay camera"
 	},
@@ -89062,7 +89068,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/camera{
 	c_tag = "Medbay - Morgue";
-	network = list("ss13", "medbay");
+	network = list("ss13","medbay");
 	dir = 1;
 	name = "medbay camera"
 	},
@@ -89174,7 +89180,7 @@
 	},
 /obj/machinery/camera{
 	c_tag = "Medbay - Chief Medical Officer's Quarters";
-	network = list("ss13", "medbay");
+	network = list("ss13","medbay");
 	dir = 1;
 	name = "medbay camera"
 	},
@@ -92466,7 +92472,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/machinery/camera{
 	c_tag = "Virology - Containment Lock";
-	network = list("ss13", "medbay");
+	network = list("ss13","medbay");
 	dir = 8;
 	name = "virology camera"
 	},
@@ -92979,7 +92985,7 @@
 	},
 /obj/machinery/camera{
 	c_tag = "Virology - Break Room";
-	network = list("ss13", "medbay");
+	network = list("ss13","medbay");
 	dir = 8;
 	name = "virology camera"
 	},
@@ -94686,7 +94692,7 @@
 	},
 /obj/machinery/camera{
 	c_tag = "Virology - Lab";
-	network = list("ss13", "medbay");
+	network = list("ss13","medbay");
 	name = "virology camera"
 	},
 /obj/effect/turf_decal/bot,
@@ -94706,7 +94712,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/machinery/camera{
 	c_tag = "Virology - Hallway";
-	network = list("ss13", "medbay");
+	network = list("ss13","medbay");
 	dir = 8;
 	name = "virology camera"
 	},
@@ -96410,7 +96416,7 @@
 	},
 /obj/machinery/camera{
 	c_tag = "Virology - Cells";
-	network = list("ss13", "medbay");
+	network = list("ss13","medbay");
 	dir = 8;
 	name = "virology camera"
 	},

--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -49814,7 +49814,10 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
-/obj/machinery/smartfridge/disks,
+/obj/machinery/smartfridge/disks{
+	pixel_y = 2
+	},
+/obj/structure/table,
 /turf/open/floor/plasteel,
 /area/hydroponics)
 "ccA" = (
@@ -71360,10 +71363,13 @@
 /turf/open/floor/circuit/killroom,
 /area/science/xenobiology)
 "dbE" = (
-/obj/machinery/plantgenes,
+/obj/machinery/plantgenes{
+	pixel_y = 6
+	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
+/obj/structure/table,
 /turf/open/floor/plasteel,
 /area/hydroponics)
 "dbF" = (

--- a/_maps/map_files/OmegaStation/OmegaStation.dmm
+++ b/_maps/map_files/OmegaStation/OmegaStation.dmm
@@ -30957,7 +30957,10 @@
 /area/maintenance/disposal/incinerator)
 "coR" = (
 /obj/effect/turf_decal/bot,
-/obj/machinery/smartfridge/disks,
+/obj/machinery/smartfridge/disks{
+	pixel_y = 2
+	},
+/obj/structure/table/glass,
 /turf/open/floor/plasteel/neutral,
 /area/hydroponics)
 "csX" = (
@@ -35409,8 +35412,11 @@
 	},
 /area/hallway/primary/starboard)
 "uuj" = (
-/obj/machinery/plantgenes,
+/obj/machinery/plantgenes{
+	pixel_y = 6
+	},
 /obj/effect/turf_decal/bot,
+/obj/structure/table/glass,
 /turf/open/floor/plasteel/neutral,
 /area/hydroponics)
 "uuJ" = (

--- a/_maps/map_files/PubbyStation/PubbyStation.dmm
+++ b/_maps/map_files/PubbyStation/PubbyStation.dmm
@@ -19103,7 +19103,10 @@
 	},
 /area/hydroponics)
 "aXW" = (
-/obj/machinery/plantgenes,
+/obj/machinery/plantgenes{
+	pixel_y = 6
+	},
+/obj/structure/table,
 /turf/open/floor/plasteel/green/corner{
 	dir = 4
 	},
@@ -49904,7 +49907,10 @@
 	},
 /area/hallway/primary/central)
 "kEW" = (
-/obj/machinery/smartfridge/disks,
+/obj/machinery/smartfridge/disks{
+	pixel_y = 2
+	},
+/obj/structure/table,
 /turf/open/floor/plasteel,
 /area/hydroponics)
 "kFm" = (


### PR DESCRIPTION
:cl: Denton
tweak: To comply with space OSHA regulations, all toasters (disk compartmentalizers) have been put on tables.
add: Added a disk compartmentalizer to the seed vault Lavaland ruin.
/:cl:

IMO they look much better on tables than on the ground. The seed vault podpeople now get a free toaster as well.

Also, I accidentally put a lot of spaces in medbay camera nets and this PR corrects them.