### PR TITLE
Stops engine heaters from passing atmos

### DIFF
--- a/code/game/shuttle_engines.dm
+++ b/code/game/shuttle_engines.dm
@@ -88,6 +88,7 @@
 	icon_state = "heater"
 	desc = "Directs energy into compressed particles in order to power engines."
 	engine_power = 0 // todo make these into 2x1 parts
+	CanAtmosPass = ATMOS_PASS_NO
 
 /obj/structure/shuttle/engine/platform
 	name = "engine platform"


### PR DESCRIPTION
:cl: Denton
tweak: Engine heaters no longer let gases pass through them.
/:cl:

It's pretty unintuitive that engine heaters let gases pass, since they're big, neigh indestructible structures. On top of that they're only covered by a single directional R-window on most shuttles.

I've noticed that if you break it, pretty much all players have no clue what is depressurizing the shuttle. Even smart foam can't plug the leak.

![heaters](https://user-images.githubusercontent.com/32391752/42123745-6c35f8b6-7c57-11e8-934e-b66fb8f7f562.PNG)