### PR TITLE
Prevent admins from giving mobs an invalid maxHealth

### DIFF
--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -1139,6 +1139,8 @@
 		if("eye_blurry")
 			set_blurriness(var_value)
 		if("maxHealth")
+			if (var_value <= 0)
+				return FALSE
 			updatehealth()
 		if("resize")
 			update_transform()

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -1115,6 +1115,9 @@
 
 /mob/living/vv_edit_var(var_name, var_value)
 	switch(var_name)
+		if ("maxHealth")
+			if (!isnum(var_value) || var_value <= 0)
+				return FALSE
 		if("stat")
 			if((stat == DEAD) && (var_value < DEAD))//Bringing the dead back to life
 				GLOB.dead_mob_list -= src
@@ -1139,8 +1142,6 @@
 		if("eye_blurry")
 			set_blurriness(var_value)
 		if("maxHealth")
-			if (!isnum(var_value) || var_value <= 0)
-				return FALSE
 			updatehealth()
 		if("resize")
 			update_transform()

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -1139,7 +1139,7 @@
 		if("eye_blurry")
 			set_blurriness(var_value)
 		if("maxHealth")
-			if (var_value <= 0)
+			if (!isnum(var_value) || var_value <= 0)
 				return FALSE
 			updatehealth()
 		if("resize")


### PR DESCRIPTION
:cl: Naksu
admin: maxHealth is now guarded against invalid values when varediting
/:cl:

Giving it a non-numeric or zero value leads to a shitton of runtimes