### PR TITLE
Fix backpack water tank behavior, related fixes

### DIFF
--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -290,13 +290,13 @@ GLOBAL_VAR_INIT(rpg_loot_items, FALSE)
 	if(throwing)
 		throwing.finalize(FALSE)
 	if(loc == user)
-		if(!allow_attack_hand_drop(user) || !user.dropItemToGround(src))
+		if(!allow_attack_hand_drop(user) || !user.temporarilyRemoveItemFromInventory(src))
 			return
 
 	pickup(user)
 	add_fingerprint(user)
 	if(!user.put_in_active_hand(src))
-		dropped(user)
+		user.dropItemToGround(src)
 
 /obj/item/proc/allow_attack_hand_drop(mob/user)
 	return TRUE
@@ -312,13 +312,13 @@ GLOBAL_VAR_INIT(rpg_loot_items, FALSE)
 	if(throwing)
 		throwing.finalize(FALSE)
 	if(loc == user)
-		if(!user.dropItemToGround(src))
+		if(!user.temporarilyRemoveItemFromInventory(src))
 			return
 
 	pickup(user)
 	add_fingerprint(user)
 	if(!user.put_in_active_hand(src))
-		dropped(user)
+		user.dropItemToGround(src)
 
 /obj/item/attack_alien(mob/user)
 	var/mob/living/carbon/alien/A = user

--- a/code/game/objects/items/extinguisher.dm
+++ b/code/game/objects/items/extinguisher.dm
@@ -42,8 +42,8 @@
 	sprite_name = "miniFE"
 	dog_fashion = null
 
-/obj/item/extinguisher/New()
-	..()
+/obj/item/extinguisher/Initialize()
+	. = ..()
 	create_reagents(max_water)
 	reagents.add_reagent(chem, max_water)
 

--- a/code/game/objects/items/tanks/watertank.dm
+++ b/code/game/objects/items/tanks/watertank.dm
@@ -14,45 +14,44 @@
 	resistance_flags = FIRE_PROOF
 
 	var/obj/item/noz
-	var/on = FALSE
 	var/volume = 500
 
-/obj/item/watertank/New()
-	..()
+/obj/item/watertank/Initialize()
+	. = ..()
 	create_reagents(volume)
 	noz = make_noz()
 
-/obj/item/watertank/ui_action_click()
-	toggle_mister()
+/obj/item/watertank/ui_action_click(mob/user)
+	toggle_mister(user)
 
 /obj/item/watertank/item_action_slot_check(slot, mob/user)
 	if(slot == user.getBackSlot())
 		return 1
 
-/obj/item/watertank/verb/toggle_mister()
-	set name = "Toggle Mister"
-	set category = "Object"
-	if (usr.get_item_by_slot(usr.getBackSlot()) != src)
-		to_chat(usr, "<span class='warning'>The watertank must be worn properly to use!</span>")
+/obj/item/watertank/proc/toggle_mister(mob/living/user)
+	if(!istype(user))
 		return
-	if(usr.incapacitated())
+	if(user.get_item_by_slot(user.getBackSlot()) != src)
+		to_chat(user, "<span class='warning'>The watertank must be worn properly to use!</span>")
 		return
-	on = !on
+	if(user.incapacitated())
+		return
 
-	var/mob/living/carbon/human/user = usr
-	if(on)
-		if(noz == null)
-			noz = make_noz()
-
+	if(QDELETED(noz))
+		noz = make_noz()
+	if(noz in src)
 		//Detach the nozzle into the user's hands
 		if(!user.put_in_hands(noz))
-			on = FALSE
 			to_chat(user, "<span class='warning'>You need a free hand to hold the mister!</span>")
 			return
 	else
 		//Remove from their hands and put back "into" the tank
 		remove_noz()
-	return
+
+/obj/item/watertank/verb/toggle_mister_verb()
+	set name = "Toggle Mister"
+	set category = "Object"
+	toggle_mister(usr)
 
 /obj/item/watertank/proc/make_noz()
 	return new /obj/item/reagent_containers/spray/mister(src)
@@ -66,19 +65,17 @@
 	if(ismob(noz.loc))
 		var/mob/M = noz.loc
 		M.temporarilyRemoveItemFromInventory(noz, TRUE)
-	return
+	noz.forceMove(src)
 
 /obj/item/watertank/Destroy()
-	if (on)
-		qdel(noz)
+	QDEL_NULL(noz)
 	return ..()
 
 /obj/item/watertank/attack_hand(mob/user)
-	. = ..()
-	if(.)
-		return
-	if(loc == user)
-		ui_action_click()
+	if (user.get_item_by_slot(user.getBackSlot()) == src)
+		toggle_mister(user)
+	else
+		return ..()
 
 /obj/item/watertank/MouseDrop(obj/over_object)
 	var/mob/M = loc
@@ -114,40 +111,28 @@
 	amount_per_transfer_from_this = 50
 	possible_transfer_amounts = list(25,50,100)
 	volume = 500
-	item_flags = NOBLUDGEON
+	item_flags = NOBLUDGEON | ABSTRACT  // don't put in storage
 	container_type = OPENCONTAINER
 	slot_flags = 0
 
 	var/obj/item/watertank/tank
 
-/obj/item/reagent_containers/spray/mister/New(parent_tank)
-	..()
-	if(check_tank_exists(parent_tank, src))
-		tank = parent_tank
-		reagents = tank.reagents	//This mister is really just a proxy for the tank's reagents
-		forceMove(tank)
-	return
-
-/obj/item/reagent_containers/spray/mister/dropped(mob/user)
-	..()
-	to_chat(user, "<span class='notice'>The mister snaps back onto the watertank.</span>")
-	tank.on = 0
-	forceMove(tank)
+/obj/item/reagent_containers/spray/mister/Initialize()
+	. = ..()
+	tank = loc
+	if(!istype(tank))
+		return INITIALIZE_HINT_QDEL
+	reagents = tank.reagents	//This mister is really just a proxy for the tank's reagents
 
 /obj/item/reagent_containers/spray/mister/attack_self()
 	return
 
-/proc/check_tank_exists(parent_tank, mob/living/carbon/human/M, obj/O)
-	if (!parent_tank || !istype(parent_tank, /obj/item/watertank))	//To avoid weird issues from admin spawns
-		qdel(O)
-		return 0
-	else
-		return 1
-
-/obj/item/reagent_containers/spray/mister/Move()
+/obj/item/reagent_containers/spray/mister/doMove(atom/destination)
+	if(destination && (destination != tank.loc || !ismob(destination)))
+		if (loc != tank)
+			to_chat(tank.loc, "<span class='notice'>The mister snaps back onto the watertank.</span>")
+		destination = tank
 	..()
-	if(loc != tank.loc)
-		forceMove(tank.loc)
 
 /obj/item/reagent_containers/spray/mister/afterattack(obj/target, mob/user, proximity)
 	if(target.loc == loc) //Safety check so you don't fill your mister with mutagen or something and then blast yourself in the face with it
@@ -161,8 +146,8 @@
 	icon_state = "waterbackpackjani"
 	item_state = "waterbackpackjani"
 
-/obj/item/watertank/janitor/New()
-	..()
+/obj/item/watertank/janitor/Initialize()
+	. = ..()
 	reagents.add_reagent("cleaner", 500)
 
 /obj/item/reagent_containers/spray/mister/janitor
@@ -197,8 +182,8 @@
 	volume = 200
 	slowdown = 0
 
-/obj/item/watertank/atmos/New()
-	..()
+/obj/item/watertank/atmos/Initialize()
+	. = ..()
 	reagents.add_reagent("water", 200)
 
 /obj/item/watertank/atmos/make_noz()
@@ -226,25 +211,27 @@
 	precision = 1
 	cooling_power = 5
 	w_class = WEIGHT_CLASS_HUGE
+	item_flags = ABSTRACT  // don't put in storage
 	var/obj/item/watertank/tank
 	var/nozzle_mode = 0
 	var/metal_synthesis_cooldown = 0
 	var/resin_cooldown = 0
 
-/obj/item/extinguisher/mini/nozzle/New(parent_tank)
-	..()
-	if(check_tank_exists(parent_tank, src))
-		tank = parent_tank
-		reagents = tank.reagents
-		max_water = tank.volume
-		forceMove(tank)
+/obj/item/extinguisher/mini/nozzle/Initialize()
+	. = ..()
+	tank = loc
+	if (!istype(tank))
+		return INITIALIZE_HINT_QDEL
+	reagents = tank.reagents
+	max_water = tank.volume
 
 
-/obj/item/extinguisher/mini/nozzle/Move()
+/obj/item/extinguisher/mini/nozzle/doMove(atom/destination)
+	if(destination && (destination != tank.loc || !ismob(destination)))
+		if(loc != tank)
+			to_chat(tank.loc, "<span class='notice'>The nozzle snaps back onto the tank!</span>")
+		destination = tank
 	..()
-	if(loc != tank.loc)
-		forceMove(tank)
-	return
 
 /obj/item/extinguisher/mini/nozzle/attack_self(mob/user)
 	switch(nozzle_mode)
@@ -264,12 +251,6 @@
 			to_chat(user, "Swapped to water extinguisher")
 			return
 	return
-
-/obj/item/extinguisher/mini/nozzle/dropped(mob/user)
-	..()
-	to_chat(user, "<span class='notice'>The nozzle snaps back onto the tank!</span>")
-	tank.on = 0
-	forceMove(tank)
 
 /obj/item/extinguisher/mini/nozzle/afterattack(atom/target, mob/user)
 	if(nozzle_mode == EXTINGUISHER)
@@ -453,8 +434,8 @@
 	volume = 2000
 	slowdown = 0
 
-/obj/item/watertank/op/New()
-	..()
+/obj/item/watertank/op/Initialize()
+	. = ..()
 	reagents.add_reagent("mutagen",350)
 	reagents.add_reagent("napalm",125)
 	reagents.add_reagent("welding_fuel",125)


### PR DESCRIPTION
:cl:
fix: Backpack water tanks now work properly when wielded by drones.
fix: Backpack water tank nozzles can no longer be placed inside bags of holding and chem dispensers.
fix: Moving items between your hands no longer causes them to cross the floor (squeaking, lava burning).
/:cl:

Fixes #28074.

The nozzles are now `ABSTRACT` to prevent placing them in storage items and chem dispensers, and have a more robust prevention against accidentally ending up in an invalid state.

Tweaks item `attack_hand` in order to get the right behavior with snapping the nozzle back when dropped. Fixes #25860. The new behavior is probably the right behavior but I'm not certain it won't have side effects with some item somewhere.

Ports backpack water tanks and fire extinguishers to `Initialize`.