### PR TITLE
[s] Remove libstdc++6 from .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,10 +24,6 @@ matrix:
     - env:
       - BUILD_TESTING=true
       - BUILD_TOOLS=false
-      addons:
-        apt:
-          packages:
-            - libstdc++6:i386
       cache:
         directories:
           - $HOME/BYOND-${BYOND_MAJOR}.${BYOND_MINOR}
@@ -38,7 +34,6 @@ matrix:
         mariadb: '10.2'
         apt:
           packages:
-            - libstdc++6:i386
             - libssl-dev:i386
             - gcc-multilib
       cache:

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,6 +24,10 @@ matrix:
     - env:
       - BUILD_TESTING=true
       - BUILD_TOOLS=false
+      addons:
+        apt:
+          packages:
+            - libstdc++6:i386
       cache:
         directories:
           - $HOME/BYOND-${BYOND_MAJOR}.${BYOND_MINOR}
@@ -34,8 +38,8 @@ matrix:
         mariadb: '10.2'
         apt:
           packages:
+            - libstdc++6:i386
             - libssl-dev:i386
-            - gcc-multilib
       cache:
         directories:
           - $HOME/BYOND-${BYOND_MAJOR}.${BYOND_MINOR}


### PR DESCRIPTION
I don't remember why this is needed and this is the laziest way to find out