### PR TITLE
Fix circuit printer printing finished TEG machinery

### DIFF
--- a/code/modules/research/designs/machine_designs.dm
+++ b/code/modules/research/designs/machine_designs.dm
@@ -14,7 +14,7 @@
 	name = "Machine Design (Circulator Board)"
 	desc = "The circuit board for a circulator."
 	id = "circulator"
-	build_path = /obj/machinery/atmospherics/components/binary/circulator
+	build_path = /obj/item/circuitboard/machine/circulator
 	category = list ("Engineering Machinery")
 	departmental_flags = DEPARTMENTAL_FLAG_ENGINEERING
 
@@ -22,7 +22,7 @@
 	name = "Machine Design (TEG Board)"
 	desc = "The circuit board for a TEG."
 	id = "teg"
-	build_path = /obj/machinery/power/generator
+	build_path = /obj/item/circuitboard/machine/generator
 	category = list ("Engineering Machinery")
 	departmental_flags = DEPARTMENTAL_FLAG_ENGINEERING
 


### PR DESCRIPTION
:cl:
fix: Printing the TEG and circulator boards no longer prints the completed machinery instead.
/:cl:

Fixes #38841.