### PR TITLE
Heaters/Freezers can now be moved without deconstructing.

### DIFF
--- a/code/modules/atmospherics/machinery/components/unary_devices/thermomachine.dm
+++ b/code/modules/atmospherics/machinery/components/unary_devices/thermomachine.dm
@@ -98,14 +98,11 @@
 	build_network()
 
 /obj/machinery/atmospherics/components/unary/thermomachine/attackby(obj/item/I, mob/user, params)
-	if(on)
-		return
-
-	if(anchored)
+	if(anchored && !on)
 		if(default_deconstruction_screwdriver(user, icon_state_open, initial(icon_state), I))
 			return
 
-	if(panel_open)
+	if(panel_open && I.tool_behaviour == TOOL_WRENCH)
 		default_unfasten_wrench(user, I, 50)
 		return
 

--- a/code/modules/atmospherics/machinery/components/unary_devices/thermomachine.dm
+++ b/code/modules/atmospherics/machinery/components/unary_devices/thermomachine.dm
@@ -3,9 +3,9 @@
 	desc = "Heats or cools gas in connected pipes."
 	icon = 'icons/obj/atmospherics/components/thermomachine.dmi'
 	icon_state = "freezer"
-	var/icon_state_off = "cold_off"
-	var/icon_state_on = "cold_on"
-	var/icon_state_open = "cold_off"
+	var/icon_state_off = "freezer"
+	var/icon_state_on = "freezer_1"
+	var/icon_state_open = "freezer-o"
 	density = TRUE
 	max_integrity = 300
 	armor = list("melee" = 0, "bullet" = 0, "laser" = 0, "energy" = 100, "bomb" = 0, "bio" = 100, "rad" = 100, "fire" = 80, "acid" = 30)

--- a/code/modules/atmospherics/machinery/components/unary_devices/thermomachine.dm
+++ b/code/modules/atmospherics/machinery/components/unary_devices/thermomachine.dm
@@ -98,17 +98,27 @@
 	build_network()
 
 /obj/machinery/atmospherics/components/unary/thermomachine/attackby(obj/item/I, mob/user, params)
-	if(anchored && !on)
-		if(default_deconstruction_screwdriver(user, icon_state_open, initial(icon_state), I))
+	if(I.tool_behaviour == TOOL_SCREWDRIVER || I.tool_behaviour == TOOL_WRENCH || I.tool_behaviour == TOOL_CROWBAR)
+		if(user.a_intent != INTENT_HARM)
 			return
 
-	if(panel_open && I.tool_behaviour == TOOL_WRENCH)
-		default_unfasten_wrench(user, I, 50)
+	return ..()
+
+/obj/machinery/atmospherics/components/unary/thermomachine/screwdriver_act(mob/living/user, obj/item/I)
+	if(!anchored || on)
 		return
 
-	if(default_deconstruction_crowbar(I)) //Has its own panel_open check.
+	default_deconstruction_screwdriver(user, icon_state_open, initial(icon_state), I)
+
+/obj/machinery/atmospherics/components/unary/thermomachine/wrench_act(mob/living/user, obj/item/I)
+	if(!panel_open)
 		return
-	return ..()
+
+	default_unfasten_wrench(user, I, 50)
+
+/obj/machinery/atmospherics/components/unary/thermomachine/crowbar_act(mob/living/user, obj/item/I)
+	default_deconstruction_crowbar(I)
+
 
 /obj/machinery/atmospherics/components/unary/thermomachine/default_unfasten_wrench(mob/user, obj/item/I, time = 20)
 	var/unanchoring = anchored

--- a/code/modules/atmospherics/machinery/components/unary_devices/thermomachine.dm
+++ b/code/modules/atmospherics/machinery/components/unary_devices/thermomachine.dm
@@ -21,6 +21,7 @@
 /obj/machinery/atmospherics/components/unary/thermomachine/Initialize()
 	. = ..()
 	initialize_directions = dir
+	update_icon()
 
 /obj/machinery/atmospherics/components/unary/thermomachine/on_construction()
 	..(dir,dir)
@@ -87,7 +88,8 @@
 	if(node)
 		node.disconnect(src)
 		nodes[1] = null
-	nullifyPipenet(parents[1])
+	if(parents[1])
+		nullifyPipenet(parents[1])
 
 /obj/machinery/atmospherics/components/unary/thermomachine/proc/reconnect_machine()
 	atmosinit()
@@ -113,6 +115,11 @@
 /obj/machinery/atmospherics/components/unary/thermomachine/wrench_act(mob/living/user, obj/item/I)
 	if(!panel_open)
 		return
+
+	for(var/obj/machinery/atmospherics/M in loc)
+		if(M != src)
+			to_chat(user, "<span class='warning'>There is already a pipe at that location!</span>")
+			return
 
 	default_unfasten_wrench(user, I, 50)
 
@@ -204,10 +211,6 @@
 	min_temperature = 170 //actual minimum temperature is defined by RefreshParts()
 	circuit = /obj/item/circuitboard/machine/thermomachine/freezer
 
-/obj/machinery/atmospherics/components/unary/thermomachine/freezer/on
-	on = TRUE
-	icon_state = "freezer_1"
-
 /obj/machinery/atmospherics/components/unary/thermomachine/freezer/on/Initialize()
 	. = ..()
 	if(target_temperature == initial(target_temperature))
@@ -229,13 +232,15 @@
 	min_temperature = T20C
 	circuit = /obj/item/circuitboard/machine/thermomachine/heater
 
-/obj/machinery/atmospherics/components/unary/thermomachine/heater/on
-	on = TRUE
-	icon_state = "heater_1"
-
 /obj/machinery/atmospherics/components/unary/thermomachine/heater/RefreshParts()
 	..()
 	var/L
 	for(var/obj/item/stock_parts/micro_laser/M in component_parts)
 		L += M.rating
 	max_temperature = T20C + (initial(max_temperature) * L) //573.15K with T1 stock parts
+
+/obj/machinery/atmospherics/components/unary/thermomachine/freezer/on
+	on = TRUE
+
+/obj/machinery/atmospherics/components/unary/thermomachine/heater/on
+	on = TRUE

--- a/code/modules/atmospherics/machinery/components/unary_devices/thermomachine.dm
+++ b/code/modules/atmospherics/machinery/components/unary_devices/thermomachine.dm
@@ -3,6 +3,7 @@
 	desc = "Heats or cools gas in connected pipes."
 	icon = 'icons/obj/atmospherics/components/thermomachine.dmi'
 	icon_state = "freezer"
+	var/icon_state_off = "cold_off"
 	var/icon_state_on = "cold_on"
 	var/icon_state_open = "cold_off"
 	density = TRUE
@@ -21,7 +22,6 @@
 /obj/machinery/atmospherics/components/unary/thermomachine/Initialize()
 	. = ..()
 	initialize_directions = dir
-	update_icon()
 
 /obj/machinery/atmospherics/components/unary/thermomachine/on_construction()
 	..(dir,dir)
@@ -50,7 +50,7 @@
 	else if(on && is_operational())
 		icon_state = icon_state_on
 	else
-		icon_state = initial(icon_state)
+		icon_state = icon_state_off
 
 /obj/machinery/atmospherics/components/unary/thermomachine/update_icon_nopipes()
 	cut_overlays()
@@ -110,7 +110,7 @@
 	if(!anchored || on)
 		return
 
-	default_deconstruction_screwdriver(user, icon_state_open, initial(icon_state), I)
+	default_deconstruction_screwdriver(user, icon_state_open, icon_state_off, I)
 
 /obj/machinery/atmospherics/components/unary/thermomachine/wrench_act(mob/living/user, obj/item/I)
 	if(!panel_open)
@@ -205,6 +205,7 @@
 /obj/machinery/atmospherics/components/unary/thermomachine/freezer
 	name = "freezer"
 	icon_state = "freezer"
+	icon_state_off = "freezer"
 	icon_state_on = "freezer_1"
 	icon_state_open = "freezer-o"
 	max_temperature = T20C
@@ -226,6 +227,7 @@
 /obj/machinery/atmospherics/components/unary/thermomachine/heater
 	name = "heater"
 	icon_state = "heater"
+	icon_state_off = "heater"
 	icon_state_on = "heater_1"
 	icon_state_open = "heater-o"
 	max_temperature = 140 //actual maximum temperature is defined by RefreshParts()
@@ -241,6 +243,8 @@
 
 /obj/machinery/atmospherics/components/unary/thermomachine/freezer/on
 	on = TRUE
+	icon_state = "freezer_1"
 
 /obj/machinery/atmospherics/components/unary/thermomachine/heater/on
 	on = TRUE
+	icon_state = "heater_1"

--- a/code/modules/reagents/chemistry/machinery/chem_heater.dm
+++ b/code/modules/reagents/chemistry/machinery/chem_heater.dm
@@ -50,12 +50,19 @@
 			beaker.reagents.adjust_thermal_energy((target_temperature - beaker.reagents.chem_temp) * heater_coefficient * SPECIFIC_HEAT_DEFAULT * beaker.reagents.total_volume)
 			beaker.reagents.handle_reactions()
 
-/obj/machinery/chem_heater/attackby(obj/item/I, mob/user, params)
-	if(default_deconstruction_screwdriver(user, "mixer0b", "mixer0b", I))
-		return
+/obj/machinery/chem_heater/screwdriver_act(mob/living/user, obj/item/I)
+	default_deconstruction_screwdriver(user, "mixer0b", "mixer0b", I)
 
-	if(default_deconstruction_crowbar(I))
-		return
+/obj/machinery/chem_heater/wrench_act(mob/living/user, obj/item/I)
+	default_unfasten_wrench(user, I)
+
+/obj/machinery/chem_heater/crowbar_act(mob/living/user, obj/item/I)
+	default_deconstruction_crowbar(I)
+
+/obj/machinery/chem_heater/attackby(obj/item/I, mob/user, params)
+	if(I.tool_behaviour == TOOL_SCREWDRIVER || I.tool_behaviour == TOOL_WRENCH || I.tool_behaviour == TOOL_CROWBAR)
+		if(user.a_intent != INTENT_HARM)
+			return
 
 	if(istype(I, /obj/item/reagent_containers) && !(I.item_flags & ABSTRACT) && I.is_open_container())
 		. = 1 //no afterattack


### PR DESCRIPTION
:cl: MacHac
tweak: Atmospherics Freezers/Heaters now behave more like other piping elements.
tweak: Chem heaters can be wrenched/unwrenched from the floor without deconstructing.
/:cl:

Fixes a consistency issue that's been bugging me for some time about atmos freezers and heaters.
### OLD BEHAVIOR:
Using a wrench on a heater with the panel open rotated it.  Heaters and freezers had to be deconstructed, moved to the desired location, and reconstructed on the spot.
### NEW BEHAVIOR:
Using a wrench on a heater with the panel open unanchors it.  When unanchored, the machine can be rotated with alt-click.  The machine can not be operated while unanchored.
### WHY:
Not only was the old behavior different from that of every other atmos machine (pumps, mixers, whatever), but it also had the annoying side effect of making heaters impossible to move without full deconstruction and reconstruction.  
As someone who likes rearranging atmos in his own image, this is the ideal buff that will turn atmospheric technicians into the ultimate powergaming gods of the station, wrapped in the veneer of fixing a slightly annoying consistency issue.