### PR TITLE
Removes unnecessary double check for volume pump code

### DIFF
--- a/code/modules/atmospherics/machinery/components/binary_devices/volume_pump.dm
+++ b/code/modules/atmospherics/machinery/components/binary_devices/volume_pump.dm
@@ -79,7 +79,7 @@ Thus, the two variables affect pump operation are set in New():
 	if((input_starting_pressure < 0.01) || (output_starting_pressure > 9000))
 		return
 
-	var/transfer_ratio = min(1, transfer_rate/air1.volume)
+	var/transfer_ratio = transfer_rate/air1.volume
 
 	var/datum/gas_mixture/removed = air1.remove_ratio(transfer_ratio)
 


### PR DESCRIPTION
Removes the minimum check of transfer_ratio which is already done in the gas_mixture proc https://github.com/tgstation/tgstation/blob/3a5e22e1caf0b53678b2b0c551beebbcd6cb5c18/code/modules/atmospherics/gasmixtures/gas_mixture.dm#L219

[Changelogs]: # (Your PR should contain a detailed changelog of notable changes, titled and categorized appropriately. This includes, new features, sprites, sounds, balance changes, admin tools, map edits, removals, big refactors, config changes, hosting changes and important fixes. An example changelog has been provided below for you to edit. If you need additional help, read https://github.com/tgstation/tgstation/wiki/Changelogs)

:cl: Nirnael
refactor: Removed an unnecessary volume_pump check
/:cl:

[why]: # (Please add a short description [two lines down] of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.)
