### PR TITLE
Makes tear in the fabric of reality inaccessible until a boh bomb is detonated

### DIFF
--- a/code/__DEFINES/turf_flags.dm
+++ b/code/__DEFINES/turf_flags.dm
@@ -1,4 +1,5 @@
 #define CHANGETURF_DEFER_CHANGE		1
-#define CHANGETURF_IGNORE_AIR		2
+#define CHANGETURF_IGNORE_AIR		2 // This flag prevents changeturf from gathering air from nearby turfs to fill the new turf with an approximation of local air
 #define CHANGETURF_FORCEOP			4
 #define CHANGETURF_SKIP				8 // A flag for PlaceOnTop to just instance the new turf instead of calling ChangeTurf. Used for uninitialized turfs NOTHING ELSE
+#define CHANGETURF_INHERIT_AIR 16 // Inherit air from previous turf. Implies CHANGETURF_IGNORE_AIR

--- a/code/datums/components/storage/concrete/bag_of_holding.dm
+++ b/code/datums/components/storage/concrete/bag_of_holding.dm
@@ -22,6 +22,8 @@
 					M.visible_message("<span class='danger'>The bluespace collapse crushes the air towards it, pulling [M] towards the ground...</span>")
 					M.Knockdown(5, TRUE, TRUE)		//Overrides stun absorbs.
 			T.TerraformTurf(/turf/open/chasm/magic, /turf/open/chasm/magic)
+		for (var/obj/structure/ladder/unbreakable/binary/ladder in GLOB.ladders)
+			ladder.ActivateAlmonds()
 		message_admins("[ADMIN_LOOKUPFLW(user)] detonated a bag of holding at [ADMIN_VERBOSEJMP(loccheck)].")
 		log_game("[key_name(user)] detonated a bag of holding at [AREACOORD(loccheck)].")
 		qdel(A)

--- a/code/game/machinery/navbeacon.dm
+++ b/code/game/machinery/navbeacon.dm
@@ -45,8 +45,9 @@
 /obj/machinery/navbeacon/onTransitZ(old_z, new_z)
 	if (GLOB.navbeacons["[old_z]"])
 		GLOB.navbeacons["[old_z]"] -= src
+	if (GLOB.navbeacons["[new_z]"])
+		GLOB.navbeacons["[new_z]"] += src
 	..()
-	qdel(src) // Should probably commit sudoku since moving these across Z-levels makes no sense
 
 // set the transponder codes assoc list from codes_txt
 /obj/machinery/navbeacon/proc/set_codes()

--- a/code/game/machinery/navbeacon.dm
+++ b/code/game/machinery/navbeacon.dm
@@ -37,9 +37,16 @@
 		GLOB.deliverybeacontags += location
 
 /obj/machinery/navbeacon/Destroy()
-	GLOB.navbeacons["[z]"] -= src //Remove from beacon list, if in one.
+	if (GLOB.navbeacons["[z]"])
+		GLOB.navbeacons["[z]"] -= src //Remove from beacon list, if in one.
 	GLOB.deliverybeacons -= src
 	return ..()
+
+/obj/machinery/navbeacon/onTransitZ(old_z, new_z)
+	if (GLOB.navbeacons["[old_z]"])
+		GLOB.navbeacons["[old_z]"] -= src
+	..()
+	qdel(src) // Should probably commit sudoku since moving these across Z-levels makes no sense
 
 // set the transponder codes assoc list from codes_txt
 /obj/machinery/navbeacon/proc/set_codes()

--- a/code/game/objects/structures/ladders.dm
+++ b/code/game/objects/structures/ladders.dm
@@ -204,30 +204,27 @@
 		active = TRUE
 
 /obj/structure/ladder/unbreakable/binary/proc/getTargetTurf()
-	return safepick(get_area_turfs(area_to_place))
-
-/obj/structure/ladder/unbreakable/binary/space
-	id = "space_binary"
-	area_to_place = /area/space
-
-/obj/structure/ladder/unbreakable/binary/space/getTargetTurf()
-	var/list/L = get_area_turfs(area_to_place)
-	while (L.len && !.)
-		var/I = rand(1, L.len)
-		var/turf/T = L[I]
-		if (is_centcom_level(T.z)) // These ladders don't lead to centcom.
-			L.Cut(I,I+1)
+	var/list/turfList = get_area_turfs(area_to_place)
+	while (turfList.len && !.)
+		var/i = rand(1, turfList.len)
+		var/turf/potentialTurf = turfList[i]
+		if (is_centcom_level(potentialTurf.z)) // These ladders don't lead to centcom.
+			turfList.Cut(i,i+1)
 			continue
-		if(!T.density)			// Or inside dense turfs.
+		if(!istype(potentialTurf, /turf/open/lava) && !potentialTurf.density)			// Or inside dense turfs or lava
 			var/clear = TRUE
-			for(var/obj/O in T) // Let's not place these on dense objects either. Might be funny though.
+			for(var/obj/O in potentialTurf) // Let's not place these on dense objects either. Might be funny though.
 				if(O.density)
 					clear = FALSE
 					break
 			if(clear)
-				. = T
+				. = potentialTurf
 		if (!.)
-			L.Cut(I,I+1)
+			turfList.Cut(i,i+1)
+
+/obj/structure/ladder/unbreakable/binary/space
+	id = "space_binary"
+	area_to_place = /area/space
 
 /obj/structure/ladder/unbreakable/binary/unlinked //Crew gets to complete one
 	id = "unlinked_binary"

--- a/code/game/turfs/change_turf.dm
+++ b/code/game/turfs/change_turf.dm
@@ -114,6 +114,24 @@ GLOBAL_LIST_INIT(blacklisted_automated_baseturfs, typecacheof(list(
 
 	return W
 
+/turf/open/ChangeTurf(path, list/new_baseturfs, flags)
+	if (flags & CHANGETURF_INHERIT_AIR)
+		SSair.remove_from_active(src)
+		var/stashed_air = air
+		air = null // so that it doesn't get deleted
+		. = ..()
+		if (!. || . == src) // changeturf failed or didn't do anything
+			air = stashed_air
+			return
+		if(istype(., /turf/open))
+			var/turf/open/newTurf = .
+			if (!istype(newTurf.air, /datum/gas_mixture/immutable))
+				QDEL_NULL(newTurf.air)
+				newTurf.air = stashed_air
+			SSair.add_to_active(newTurf)
+	else
+		return ..()
+
 // Take off the top layer turf and replace it with the next baseturf down
 /turf/proc/ScrapeAway(amount=1, flags)
 	if(!amount)
@@ -251,7 +269,7 @@ GLOBAL_LIST_INIT(blacklisted_automated_baseturfs, typecacheof(list(
 /turf/open/AfterChange(flags)
 	..()
 	RemoveLattice()
-	if(!(flags & CHANGETURF_IGNORE_AIR))
+	if(!(flags & (CHANGETURF_IGNORE_AIR | CHANGETURF_INHERIT_AIR)))
 		Assimilate_Air()
 
 //////Assimilate Air//////

--- a/code/game/turfs/change_turf.dm
+++ b/code/game/turfs/change_turf.dm
@@ -115,7 +115,7 @@ GLOBAL_LIST_INIT(blacklisted_automated_baseturfs, typecacheof(list(
 	return W
 
 /turf/open/ChangeTurf(path, list/new_baseturfs, flags)
-	if (flags & CHANGETURF_INHERIT_AIR)
+	if ((flags & CHANGETURF_INHERIT_AIR) && ispath(path, /turf/open))
 		SSair.remove_from_active(src)
 		var/stashed_air = air
 		air = null // so that it doesn't get deleted
@@ -123,12 +123,11 @@ GLOBAL_LIST_INIT(blacklisted_automated_baseturfs, typecacheof(list(
 		if (!. || . == src) // changeturf failed or didn't do anything
 			air = stashed_air
 			return
-		if(istype(., /turf/open))
-			var/turf/open/newTurf = .
-			if (!istype(newTurf.air, /datum/gas_mixture/immutable))
-				QDEL_NULL(newTurf.air)
-				newTurf.air = stashed_air
-			SSair.add_to_active(newTurf)
+		var/turf/open/newTurf = .
+		if (!istype(newTurf.air, /datum/gas_mixture/immutable/space))
+			QDEL_NULL(newTurf.air)
+			newTurf.air = stashed_air
+		SSair.add_to_active(newTurf)
 	else
 		return ..()
 


### PR DESCRIPTION
Fixes #38839

:cl: Naksu
tweak: The ladders in the tear in the fabric of reality no longer spawn their endpoints when the area is loaded, but only when the tear is made accessible via a BoH bomb.
tweak: CentCom is no longer accessible via the space ladder in the tear.
tweak: The lavaland endpoint can no longer spawn completely surrounded by lava, unless it spawns on an island 
code: ChangeTurf can now conditionally inherit the air of the turf it is replacing, via the CHANGETURF_INHERIT_AIR flag.
fix: when ladder endpoints are created, the binary turfs that are created inherit the air of the turfs they are replacing. This means the lavaland ladder endpoint will have the lavaland airmix, instead of a vacuum.
code: navigation beacons are now properly deregistered from their Z-level list and re-registered on the correct one if moved across Z-levels by an effect such as teleportation or a BoH-induced chasm.
/:cl:

CHANGETURF_INHERIT_AIR will not inherit if the new turf would have an immutable space mixture, this prevents turf changes into spess from creating freaky non-vacuum space