### PR TITLE
techweb tweaks

### DIFF
--- a/code/modules/research/techweb/all_nodes.dm
+++ b/code/modules/research/techweb/all_nodes.dm
@@ -224,7 +224,7 @@
 	id = "neural_programming"
 	display_name = "Neural Programming"
 	description = "Study into networks of processing units that mimic our brains."
-	prereq_ids = list("biotech", "datatheory", "mmi")
+	prereq_ids = list("biotech", "datatheory")
 	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = 2500)
 	export_price = 5000
 

--- a/code/modules/research/techweb/all_nodes.dm
+++ b/code/modules/research/techweb/all_nodes.dm
@@ -151,7 +151,7 @@
 	prereq_ids = list("practical_bluespace", "high_efficiency")
 	design_ids = list("bluespace_matter_bin", "femto_mani", "triphasic_scanning", "tele_station", "tele_hub", "quantumpad", "launchpad", "launchpad_console",
 	"teleconsole", "bluespace_crystal", "bluespace_pod", "wormholeprojector")
-	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = 7500)
+	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = 10000)
 	export_price = 5000
 
 /datum/techweb_node/adv_bluespace_bags
@@ -160,7 +160,7 @@
 	description = "Deeper understanding of how bags works"
 	prereq_ids = list("adv_bluespace")
 	design_ids = list("bag_holding")
-	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = 7500)
+	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = 5000)
 	export_price = 5000
 
 /datum/techweb_node/practical_bluespace
@@ -197,7 +197,7 @@
 	display_name = "Advanced Plasma Research"
 	description = "Research on how to fully exploit the power of plasma."
 	prereq_ids = list("basic_plasma")
-	design_ids = list("mech_plasma_cutter", "power_turbine", "power_turbine_console", "power_compressor", "circulator", "teg")
+	design_ids = list("power_turbine", "power_turbine_console", "power_compressor", "circulator", "teg")
 	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = 2500)
 	export_price = 5000
 
@@ -282,7 +282,7 @@
 	design_ids = list("aifixer", "aicore", "safeguard_module", "onehuman_module", "protectstation_module", "quarantine_module", "oxygen_module", "freeform_module",
 	"reset_module", "purge_module", "remove_module", "freeformcore_module", "asimov_module", "paladin_module", "tyrant_module", "corporate_module",
 	"default_module", "borg_ai_control", "mecha_tracking_ai_control", "aiupload", "intellicard")
-	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = 2500)
+	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = 5000)
 	export_price = 5000
 
 /////////////////////////EMP tech/////////////////////////
@@ -688,7 +688,16 @@
 	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = 2500)
 	export_price = 5000
 
-/datum/techweb_node/mech_modules
+/datum/techweb_node/mining_mech_tools
+	id = "mining_mech_tools"
+	display_name = "Advanced Mining Exosuit Equipment"
+	description = "Tools for high efficiency mining"
+	prereq_ids = list("basic_mining", "mech_tools")
+	design_ids = list("mech_plasma_cutter", "mech_diamond_drill")
+	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = 2500)
+	export_price = 5000
+
+/datum/techweb_node/adv_mech_modules
 	id = "adv_mecha_modules"
 	display_name = "Advanced Exosuit Modules"
 	description = "Advanced mech tools"
@@ -820,15 +829,6 @@
 	description = "An advanced piece of mech weaponry"
 	prereq_ids = list("mecha", "ballistic_weapons")
 	design_ids = list("mech_lmg")
-	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = 2500)
-	export_price = 5000
-
-/datum/techweb_node/mech_diamond_drill
-	id = "mech_diamond_drill"
-	display_name =  "Exosuit Diamond Drill"
-	description = "A diamond drill fit for a large exosuit"
-	prereq_ids = list("mecha", "adv_mining")
-	design_ids = list("mech_diamond_drill")
 	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = 2500)
 	export_price = 5000
 

--- a/code/modules/research/techweb/all_nodes.dm
+++ b/code/modules/research/techweb/all_nodes.dm
@@ -37,7 +37,7 @@
 	description = "From slimes to kitchens."
 	prereq_ids = list("biotech")
 	design_ids = list("smartfridge", "gibber", "deepfryer", "monkey_recycler", "processor", "gibber", "microwave", "reagentgrinder", "dish_drive")
-	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = 2500)
+	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = 1000)
 	export_price = 5000
 
 /////////////////////////Advanced Surgery/////////////////////////
@@ -130,7 +130,7 @@
 	display_name = "Advanced Power Manipulation"
 	description = "How to get more zap."
 	prereq_ids = list("engineering")
-	design_ids = list("smes", "super_cell", "hyper_cell", "super_capacitor", "superpacman", "mrspacman", "power_turbine", "power_turbine_console", "power_compressor", "circulator", "teg")
+	design_ids = list("smes", "super_cell", "hyper_cell", "super_capacitor", "superpacman", "mrspacman")
 	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = 2500)
 	export_price = 5000
 
@@ -150,8 +150,17 @@
 	description = "Deeper understanding of how the Bluespace dimension works"
 	prereq_ids = list("practical_bluespace", "high_efficiency")
 	design_ids = list("bluespace_matter_bin", "femto_mani", "triphasic_scanning", "tele_station", "tele_hub", "quantumpad", "launchpad", "launchpad_console",
-	"teleconsole", "bag_holding", "bluespace_crystal", "wormholeprojector", "bluespace_pod")
-	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = 15000)
+	"teleconsole", "bluespace_crystal", "bluespace_pod" "wormholeprojector")
+	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = 7500)
+	export_price = 5000
+
+/datum/techweb_node/adv_bluespace_bags
+	id = "adv_bluespace_bags"
+	display_name = "Advanced Bluespace Storage Research"
+	description = "Deeper understanding of how bags works"
+	prereq_ids = list("adv_bluespace")
+	design_ids = list("bag_holding")
+	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = 7500)
 	export_price = 5000
 
 /datum/techweb_node/practical_bluespace
@@ -188,7 +197,7 @@
 	display_name = "Advanced Plasma Research"
 	description = "Research on how to fully exploit the power of plasma."
 	prereq_ids = list("basic_plasma")
-	design_ids = list("mech_plasma_cutter")
+	design_ids = list("mech_plasma_cutter", "power_turbine", "power_turbine_console", "power_compressor", "circulator", "teg")
 	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = 2500)
 	export_price = 5000
 
@@ -215,16 +224,7 @@
 	id = "neural_programming"
 	display_name = "Neural Programming"
 	description = "Study into networks of processing units that mimic our brains."
-	prereq_ids = list("biotech", "datatheory")
-	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = 2500)
-	export_price = 5000
-
-/datum/techweb_node/mmi
-	id = "mmi"
-	display_name = "Man Machine Interface"
-	description = "A slightly Frankensteinian device that allows human brains to interface natively with software APIs."
-	prereq_ids = list("neural_programming")
-	design_ids = list("mmi")
+	prereq_ids = list("biotech", "datatheory", "mmi")
 	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = 2500)
 	export_price = 5000
 
@@ -232,7 +232,7 @@
 	id = "posibrain"
 	display_name = "Positronic Brain"
 	description = "Applied usage of neural technology allowing for autonomous AI units based on special metallic cubes with conductive and processing circuits."
-	prereq_ids = list("neural_programming", "mmi")
+	prereq_ids = list("neural_programming")
 	design_ids = list("mmi_posi")
 	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = 2500)
 	export_price = 5000
@@ -241,7 +241,7 @@
 	id = "cyborg"
 	display_name = "Cyborg Construction"
 	description = "Sapient robots with preloaded tool modules and programmable laws."
-	prereq_ids = list("mmi", "robotics")
+	prereq_ids = list("neural_programming", "robotics")
 	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = 1000)
 	export_price = 5000
 	design_ids = list("robocontrol", "sflash", "borg_suit", "borg_head", "borg_chest", "borg_r_arm", "borg_l_arm", "borg_r_leg", "borg_l_leg", "borgupload",
@@ -478,7 +478,7 @@
 	id = "janitor"
 	display_name = "Advanced Sanitation Technology"
 	description = "Clean things better, faster, stronger, and harder!"
-	prereq_ids = list("adv_engi")
+	prereq_ids = list("adv_engi", "biotech")
 	design_ids = list("advmop", "buffer", "blutrash", "light_replacer")
 	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = 2500)
 	export_price = 5000
@@ -551,7 +551,7 @@
 	id = "medical_weapons"
 	display_name = "Medical Weaponry"
 	description = "Weapons using medical technology."
-	prereq_ids = list("adv_biotech", "adv_weaponry")
+	prereq_ids = list("adv_biotech", "weaponry")
 	design_ids = list("rapidsyringe", "shotgundartcryostatis")
 	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = 2500)
 	export_price = 5000
@@ -679,30 +679,30 @@
 	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = 2500)
 	export_price = 5000
 
-/datum/techweb_node/adv_mecha_tools
-	id = "adv_mecha_tools"
-	display_name = "Advanced Exosuit Equipment"
-	description = "Tools for high level mech suits"
-	prereq_ids = list("adv_mecha", "mech_tools")
-	design_ids = list("mech_rcd")
-	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = 2500)
-	export_price = 5000
-
 /datum/techweb_node/med_mech_tools
 	id = "med_mech_tools"
 	display_name = "Medical Exosuit Equipment"
 	description = "Tools for high level mech suits"
-	prereq_ids = list("mecha", "adv_biotech", "mech_tools")
+	prereq_ids = list("adv_biotech", "mech_tools")
 	design_ids = list("mech_sleeper", "mech_syringe_gun", "mech_medi_beam")
 	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = 2500)
 	export_price = 5000
 
 /datum/techweb_node/mech_modules
 	id = "adv_mecha_modules"
-	display_name = "Simple Exosuit Modules"
-	description = "An advanced piece of mech weaponry"
-	prereq_ids = list("adv_mecha", "bluespace_power")
-	design_ids = list("mech_energy_relay", "mech_ccw_armor", "mech_proj_armor", "mech_generator_nuclear")
+	display_name = "Advanced Exosuit Modules"
+	description = "Advanced mech tools"
+	prereq_ids = list("mech_tools", "adv_engi")
+	design_ids = list("mech_ccw_armor", "mech_proj_armor", "mech_rcd")
+	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = 2500)
+	export_price = 5000
+	
+/datum/techweb_node/mech_power
+	id = "mech_power"
+	display_name = "Mech Power Modules"
+	description = "Better generators for mechs"
+	prereq_ids = list("mech_tools", "bluespace_power")
+	design_ids = list("mech_energy_relay", "mech_generator_nuclear")
 	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = 2500)
 	export_price = 5000
 

--- a/code/modules/research/techweb/all_nodes.dm
+++ b/code/modules/research/techweb/all_nodes.dm
@@ -682,7 +682,7 @@
 /datum/techweb_node/med_mech_tools
 	id = "med_mech_tools"
 	display_name = "Medical Exosuit Equipment"
-	description = "Tools for high level mech suits"
+	description = "Tools for medical mech suits"
 	prereq_ids = list("adv_biotech", "mech_tools")
 	design_ids = list("mech_sleeper", "mech_syringe_gun", "mech_medi_beam")
 	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = 2500)
@@ -708,7 +708,7 @@
 	
 /datum/techweb_node/mech_power
 	id = "mech_power"
-	display_name = "Mech Power Modules"
+	display_name = "Power Exosuit Modules"
 	description = "Better generators for mechs"
 	prereq_ids = list("mech_tools", "bluespace_power")
 	design_ids = list("mech_energy_relay", "mech_generator_nuclear")

--- a/code/modules/research/techweb/all_nodes.dm
+++ b/code/modules/research/techweb/all_nodes.dm
@@ -150,7 +150,7 @@
 	description = "Deeper understanding of how the Bluespace dimension works"
 	prereq_ids = list("practical_bluespace", "high_efficiency")
 	design_ids = list("bluespace_matter_bin", "femto_mani", "triphasic_scanning", "tele_station", "tele_hub", "quantumpad", "launchpad", "launchpad_console",
-	"teleconsole", "bluespace_crystal", "bluespace_pod" "wormholeprojector")
+	"teleconsole", "bluespace_crystal", "bluespace_pod", "wormholeprojector")
 	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = 7500)
 	export_price = 5000
 


### PR DESCRIPTION
:cl: 
balance: split adv bluespace tech into 2 nodes 
/:cl:

- lowered price of bio processing to 1000 because its useless tech (-1500 points)
- lightened power manipulation, gave some of the parts that make more sense under adv_plasma  
- split boh from tier 4 because whats the point of diving techs and then have all these thing in 1 node?
- removed mmi node because its fucking roundstart shit (-2500 points)
- sanitation tech now requires undestanding of biology
- syringe guns now require normal weaponry tech instead of advanced, it shoots syringes not magics
- changed some mech tools nodes, I always hated how there was a node "basic mech modules" and "simple mech modules" now there is basic -> advanced, power generators and others
