### PR TITLE
Fixes flipped TEG mode

### DIFF
--- a/code/modules/atmospherics/machinery/components/binary_devices/circulator.dm
+++ b/code/modules/atmospherics/machinery/components/binary_devices/circulator.dm
@@ -1,7 +1,7 @@
 //node2, air2, network2 correspond to input
 //node1, air1, network1 correspond to output
-#define CIRCULATOR_COLD 0
-#define CIRCULATOR_HOT 1
+#define CIRCULATOR_HOT 0
+#define CIRCULATOR_COLD 1
 
 /obj/machinery/atmospherics/components/binary/circulator
 	name = "circulator/heat exchanger"


### PR DESCRIPTION
All instances of mode assumes that cold is 1 and hot is 0, but they're defined the other way arong. I caused this, so no GBP for mee

fixes: #38842 
