### PR TITLE
auto_name and  directional APC's

### DIFF
--- a/code/modules/power/apc.dm
+++ b/code/modules/power/apc.dm
@@ -116,6 +116,25 @@
 
 /obj/machinery/power/apc/highcap/fifteen_k
 	cell_type = /obj/item/stock_parts/cell/high/plus
+	
+/obj/machinery/power/apc/auto_name
+	auto_name = 1
+	
+/obj/machinery/power/apc/auto_name/directional/north
+	dir = 1
+	pixel_y = 24
+
+/obj/machinery/power/apc/auto_name/directional/south
+	dir = 2
+	pixel_y = -23
+
+/obj/machinery/power/apc/auto_name/directional/east
+	dir = 4
+	pixel_x = 24
+	
+/obj/machinery/power/apc/auto_name/directional/west
+	dir = 8
+	pixel_y = -25
 
 /obj/machinery/power/apc/get_cell()
 	return cell

--- a/code/modules/power/apc.dm
+++ b/code/modules/power/apc.dm
@@ -134,7 +134,7 @@
 	
 /obj/machinery/power/apc/auto_name/directional/west
 	dir = 8
-	pixel_y = -25
+	pixel_x = -25
 
 /obj/machinery/power/apc/get_cell()
 	return cell

--- a/code/modules/power/apc.dm
+++ b/code/modules/power/apc.dm
@@ -120,21 +120,17 @@
 /obj/machinery/power/apc/auto_name
 	auto_name = 1
 	
-/obj/machinery/power/apc/auto_name/directional/north
+/obj/machinery/power/apc/auto_name/north
 	dir = 1
-	pixel_y = 24
 
-/obj/machinery/power/apc/auto_name/directional/south
+/obj/machinery/power/apc/auto_name/south
 	dir = 2
-	pixel_y = -23
 
-/obj/machinery/power/apc/auto_name/directional/east
+/obj/machinery/power/apc/auto_name/east
 	dir = 4
-	pixel_x = 24
 	
-/obj/machinery/power/apc/auto_name/directional/west
+/obj/machinery/power/apc/auto_name/west
 	dir = 8
-	pixel_x = -25
 
 /obj/machinery/power/apc/get_cell()
 	return cell

--- a/code/modules/power/apc.dm
+++ b/code/modules/power/apc.dm
@@ -118,19 +118,19 @@
 	cell_type = /obj/item/stock_parts/cell/high/plus
 	
 /obj/machinery/power/apc/auto_name
-	auto_name = 1
+	auto_name = TRUE
 	
 /obj/machinery/power/apc/auto_name/north
-	dir = 1
-
+	dir = NORTH
+	
 /obj/machinery/power/apc/auto_name/south
-	dir = 2
+	dir = SOUTH
 
 /obj/machinery/power/apc/auto_name/east
-	dir = 4
+	dir = EAST
 	
 /obj/machinery/power/apc/auto_name/west
-	dir = 8
+	dir = WEST
 
 /obj/machinery/power/apc/get_cell()
 	return cell


### PR DESCRIPTION
:cl:
add: autoname APC
add: directional autoname APC's
/:cl:

[why]: 

adds auto name apc's and directional apc's for easier map making.
similar to autoname cameras
