### PR TITLE
Changelings only get competitive objectives if there are other changelings.

### DIFF
--- a/code/game/gamemodes/changeling/changeling.dm
+++ b/code/game/gamemodes/changeling/changeling.dm
@@ -73,6 +73,12 @@ GLOBAL_VAR(changeling_team_objective_type) //If this is not null, we hand our th
 		log_game("[key_name(changeling)] has been selected as a changeling")
 		var/datum/antagonist/changeling/new_antag = new()
 		new_antag.team_mode = TRUE
+
+		if(changelings.len >= 2)
+			new_antag.competitive_objectives = TRUE
+		else
+			new_antag.competitive_objectives = FALSE
+
 		changeling.add_antag_datum(new_antag)
 	..()
 

--- a/code/modules/antagonists/changeling/changeling.dm
+++ b/code/modules/antagonists/changeling/changeling.dm
@@ -12,6 +12,7 @@
 	var/you_are_greet = TRUE
 	var/give_objectives = TRUE
 	var/team_mode = FALSE //Should assign team objectives ?
+	var/competitive_objectives = FALSE //Should we assign objectives in competition with others?
 
 	//Changeling Stuff
 
@@ -371,7 +372,8 @@
 		if(!CTO.escape_objective_compatible)
 			escape_objective_possible = FALSE
 			break
-	var/changeling_objective = rand(1,3)
+
+	var/changeling_objective = competitive_objectives ? rand(1,3) : 1
 	switch(changeling_objective)
 		if(1)
 			var/datum/objective/absorb/absorb_objective = new


### PR DESCRIPTION
Closes #38753.

:cl: MacHac
fix: Changelings can no longer be assigned to kill another changeling if they are the only changeling.
/:cl: