### PR TITLE
Janitors cleaning the floor now generates 50 techweb points per tile cleaned that has anything to clean

### DIFF
--- a/code/game/objects/items/mop.dm
+++ b/code/game/objects/items/mop.dm
@@ -34,7 +34,7 @@
 			if(is_cleanable(O))
 				cleaned = TRUE
 				qdel(O)
-	if(cleaned)
+	if(cleaned && user && user.mind && user.mind.assigned_role == "Janitor")
 		SSresearch.station_tech.add_points_all(CLEAN_TILE_REWARD)
 		to_chat(user, "<span class='notice'>Your [src] flashes a message that it has gained useful information from eradicating the mess on the floor. Good work.</span>")
 	reagents.reaction(A, TOUCH, 10)	//Needed for proper floor wetting.

--- a/code/game/objects/items/mop.dm
+++ b/code/game/objects/items/mop.dm
@@ -37,9 +37,9 @@
 				qdel(O)
 	if(cleaned && user && user.mind && user.mind.assigned_role == "Janitor")
 		stored_points += CLEAN_TILE_REWARD
-		to_chat(user, "<span class='notice'>Your [src] flashes a message that it has gained useful information from eradicating the mess on the floor. Good work.</span>")
 	reagents.reaction(A, TOUCH, 10)	//Needed for proper floor wetting.
 	reagents.remove_any(1)			//reaction() doesn't use up the reagents
+	return cleaned
 
 /obj/item/mop/pre_attack(atom/target, mob/user, params)
 	if(istype(target, /obj/machinery/computer/rdconsole))
@@ -69,8 +69,8 @@
 		user.visible_message("[user] begins to clean \the [T] with [src].", "<span class='notice'>You begin to clean \the [T] with [src]...</span>")
 
 		if(do_after(user, src.mopspeed, target = T))
-			to_chat(user, "<span class='notice'>You finish mopping.</span>")
-			clean(T, user)
+			var/got_points = clean(T, user)
+			to_chat(user, "<span class='notice'>You finish mopping.[got_points?" [src] flashes that it has gathered and stored useful research data from your efforts.":""]</span>")
 
 
 /obj/effect/attackby(obj/item/I, mob/user, params)

--- a/code/game/objects/items/mop.dm
+++ b/code/game/objects/items/mop.dm
@@ -1,3 +1,5 @@
+#define CLEAN_TILE_REWARD 50
+
 /obj/item/mop
 	desc = "The world of janitalia wouldn't be complete without a mop."
 	name = "mop"
@@ -25,11 +27,15 @@
 
 
 /obj/item/mop/proc/clean(turf/A)
+	var/cleaned = FALSE
 	if(reagents.has_reagent("water", 1) || reagents.has_reagent("holywater", 1) || reagents.has_reagent("vodka", 1) || reagents.has_reagent("cleaner", 1))
 		SEND_SIGNAL(A, COMSIG_COMPONENT_CLEAN_ACT, CLEAN_MEDIUM)
 		for(var/obj/effect/O in A)
 			if(is_cleanable(O))
+				cleaned = TRUE
 				qdel(O)
+	if(cleaned)
+		SSresearch.station_tech.add_points_all(CLEAN_TILE_REWARD)
 	reagents.reaction(A, TOUCH, 10)	//Needed for proper floor wetting.
 	reagents.remove_any(1)			//reaction() doesn't use up the reagents
 
@@ -119,3 +125,5 @@
 
 /obj/item/mop/advanced/cyborg
 	insertable = FALSE
+
+#undef CLEAN_TILE_REWARD

--- a/code/game/objects/items/mop.dm
+++ b/code/game/objects/items/mop.dm
@@ -18,6 +18,7 @@
 	var/mopcount = 0
 	var/mopcap = 5
 	var/mopspeed = 30
+	var/stored_points = 0
 	force_string = "robust... against germs"
 	var/insertable = TRUE
 
@@ -35,10 +36,20 @@
 				cleaned = TRUE
 				qdel(O)
 	if(cleaned && user && user.mind && user.mind.assigned_role == "Janitor")
-		SSresearch.station_tech.add_points_all(CLEAN_TILE_REWARD)
+		stored_points += CLEAN_TILE_REWARD
 		to_chat(user, "<span class='notice'>Your [src] flashes a message that it has gained useful information from eradicating the mess on the floor. Good work.</span>")
 	reagents.reaction(A, TOUCH, 10)	//Needed for proper floor wetting.
 	reagents.remove_any(1)			//reaction() doesn't use up the reagents
+
+/obj/item/mop/pre_attack(atom/target, mob/user, params)
+	if(istype(target, /obj/machinery/computer/rdconsole))
+		var/obj/machinery/computer/rdconsole/RDC = target
+		if(stored_points)
+			RDC.stored_research.add_point_type(TECHWEB_POINT_TYPE_DEFAULT, stored_points)
+			to_chat(user, "<span class='boldnotice'>You upload [stored_points] points to [RDC]'s research storage.</span>")
+			stored_points = 0
+	else
+		return ..()
 
 /obj/item/mop/afterattack(atom/A, mob/user, proximity)
 	if(!proximity)

--- a/code/game/objects/items/mop.dm
+++ b/code/game/objects/items/mop.dm
@@ -26,7 +26,7 @@
 	create_reagents(mopcap)
 
 
-/obj/item/mop/proc/clean(turf/A)
+/obj/item/mop/proc/clean(turf/A, mob/user)
 	var/cleaned = FALSE
 	if(reagents.has_reagent("water", 1) || reagents.has_reagent("holywater", 1) || reagents.has_reagent("vodka", 1) || reagents.has_reagent("cleaner", 1))
 		SEND_SIGNAL(A, COMSIG_COMPONENT_CLEAN_ACT, CLEAN_MEDIUM)
@@ -36,9 +36,9 @@
 				qdel(O)
 	if(cleaned)
 		SSresearch.station_tech.add_points_all(CLEAN_TILE_REWARD)
+		to_chat(user, "<span class='notice'>Your [src] flashes a message that it has gained useful information from eradicating the mess on the floor. Good work.</span>")
 	reagents.reaction(A, TOUCH, 10)	//Needed for proper floor wetting.
 	reagents.remove_any(1)			//reaction() doesn't use up the reagents
-
 
 /obj/item/mop/afterattack(atom/A, mob/user, proximity)
 	if(!proximity)
@@ -58,7 +58,7 @@
 
 		if(do_after(user, src.mopspeed, target = T))
 			to_chat(user, "<span class='notice'>You finish mopping.</span>")
-			clean(T)
+			clean(T, user)
 
 
 /obj/effect/attackby(obj/item/I, mob/user, params)

--- a/code/game/objects/items/mop.dm
+++ b/code/game/objects/items/mop.dm
@@ -46,7 +46,8 @@
 		var/obj/machinery/computer/rdconsole/RDC = target
 		if(stored_points)
 			RDC.stored_research.add_point_type(TECHWEB_POINT_TYPE_DEFAULT, stored_points)
-			to_chat(user, "<span class='boldnotice'>You upload [stored_points] points to [RDC]'s research storage.</span>")
+			user.visible_message("<span class='notice'>[user] passes [src] over [RDC], wirelessly transmitting its stored information \
+			into [RDC].</span>", "<span class='boldnotice'>You upload [stored_points] points to [RDC]'s research storage.</span>")
 			stored_points = 0
 	else
 		return ..()


### PR DESCRIPTION
Now you have a better reason to be making yourself a horrible, slippery nuisance! 
:cl:
rscadd: Mops now have adaptive sensors on them that can generate research points when cleaning up messes! Unfortunately, this only works if the user is a trained and skilled janitor, and not some random with a mop...
experimental: Mops store the points generated. They can be uploaded to the station's research databanks by using them on a R&D console.
/:cl: