### PR TITLE
Makes lone nukeops spawn as often as originally intended

### DIFF
--- a/code/modules/antagonists/nukeop/equipment/nuclearbomb.dm
+++ b/code/modules/antagonists/nukeop/equipment/nuclearbomb.dm
@@ -588,7 +588,7 @@ This is here to make the tiles around the station mininuke change when it's arme
 		CRASH("A fake nuke disk tried to call process(). Who the fuck and how the fuck")
 	var/turf/newturf = get_turf(src)
 	if(newturf && lastlocation == newturf)
-		if(last_disk_move < world.time - 5000 && prob((world.time - 5000 - last_disk_move)*0.00001))
+		if(last_disk_move < world.time - 5000 && prob((world.time - 5000 - last_disk_move)*0.0001))
 			var/datum/round_event_control/operative/loneop = locate(/datum/round_event_control/operative) in SSevents.control
 			if(istype(loneop))
 				loneop.weight += 1


### PR DESCRIPTION
So, uh, turns out I'm a complete idiot, and ended up adding way too many zeroes to the modifier that toned down the chance for the lone nukeop event weight increase when I converted the proc to use world.time instead of it's own internal timer. So instead of the event weight being pretty high by the hour mark if the disk stays perfectly still roundstart, the event weight ended up only being either 2 or 1 by the time the hour mark rolls around, as instead of the event weight increase chance at the hour mark being 2% per process() as intended, it ended up being a mere 0.2%. This PR fixes that issue, and should make lone nukeops spawn as often as actually intended. Secure that fuckin disk

:cl: deathride58
tweak: Lone nuclear operatives now spawn as often as originally intended when the disk is immobile. Secure that fuckin' disk.
/:cl:
