### PR TITLE
Maps are now voted on at the end of the round

### DIFF
--- a/code/controllers/configuration/configuration.dm
+++ b/code/controllers/configuration/configuration.dm
@@ -266,8 +266,6 @@
 				currentmap.config_min_users = text2num(data)
 			if ("maxplayers","maxplayer")
 				currentmap.config_max_users = text2num(data)
-			if ("weight","voteweight")
-				currentmap.voteweight = text2num(data)
 			if ("default","defaultmap")
 				defaultmap = currentmap
 			if ("endmap")

--- a/code/controllers/subsystem/mapping.dm
+++ b/code/controllers/subsystem/mapping.dm
@@ -257,61 +257,30 @@ GLOBAL_LIST_EMPTY(the_station_areas)
 		log_world("ERROR: Station areas list failed to generate!")
 
 /datum/controller/subsystem/mapping/proc/maprotate()
-	var/players = GLOB.clients.len
-	var/list/mapvotes = list()
-	//count votes
 	var/amv = CONFIG_GET(flag/allow_map_voting)
 	if(amv)
-		for (var/client/c in GLOB.clients)
-			var/vote = c.prefs.preferred_map
-			if (!vote)
-				if (global.config.defaultmap)
-					mapvotes[global.config.defaultmap.map_name] += 1
-				continue
-			mapvotes[vote] += 1
-	else
-		for(var/M in global.config.maplist)
-			mapvotes[M] = 1
-
-	//filter votes
-	for (var/map in mapvotes)
-		if (!map)
-			mapvotes.Remove(map)
-		if (!(map in global.config.maplist))
-			mapvotes.Remove(map)
-			continue
-		var/datum/map_config/VM = global.config.maplist[map]
-		if (!VM)
-			mapvotes.Remove(map)
-			continue
-		if (VM.voteweight <= 0)
-			mapvotes.Remove(map)
-			continue
-		if (VM.config_min_users > 0 && players < VM.config_min_users)
-			mapvotes.Remove(map)
-			continue
-		if (VM.config_max_users > 0 && players > VM.config_max_users)
-			mapvotes.Remove(map)
-			continue
-
-		if(amv)
-			mapvotes[map] = mapvotes[map]*VM.voteweight
-
-	var/pickedmap = pickweight(mapvotes)
+		//run map vote
+		SSvote.reset(TRUE)
+		SSvote.initiate_vote("maprotate", "[name] subsystem", TRUE)
+		return
+	//random rotate
+	var/pickedmap = pickweight(global.config.maplist)
 	if (!pickedmap)
 		return
 	var/datum/map_config/VM = global.config.maplist[pickedmap]
 	message_admins("Randomly rotating map to [VM.map_name]")
-	. = changemap(VM)
-	if (. && VM.map_name != config.map_name)
-		to_chat(world, "<span class='boldannounce'>Map rotation has chosen [VM.map_name] for next round!</span>")
+	return changemap(VM, VM.map_path != config.map_path || VM.map_file != config.map_file, FALSE)
 
-/datum/controller/subsystem/mapping/proc/changemap(var/datum/map_config/VM)
+/datum/controller/subsystem/mapping/proc/changemap(var/datum/map_config/VM, announce = TRUE, voted = FALSE)
 	if(!VM.MakeNextMap())
 		next_map_config = load_map_config(default_to_box = TRUE)
 		message_admins("Failed to set new map with next_map.json for [VM.map_name]! Using default as backup!")
 		return
 
+	if(announce)
+		var/msg = !voted ? "Map rotation has chosen [VM.map_name] for next round!" : "[VM.map_name] has won the map vote!"
+		to_chat(world, "<span class='boldannounce'>[msg]</span>")
+	
 	next_map_config = VM
 	return TRUE
 

--- a/code/controllers/subsystem/mapping.dm
+++ b/code/controllers/subsystem/mapping.dm
@@ -264,7 +264,7 @@ GLOBAL_LIST_EMPTY(the_station_areas)
 		SSvote.initiate_vote("maprotate", "[name] subsystem", TRUE)
 		return
 	//random rotate
-	var/pickedmap = pickweight(global.config.maplist)
+	var/pickedmap = safepick(global.config.maplist)
 	if (!pickedmap)
 		return
 	var/datum/map_config/VM = global.config.maplist[pickedmap]

--- a/code/controllers/subsystem/vote.dm
+++ b/code/controllers/subsystem/vote.dm
@@ -190,8 +190,6 @@ SUBSYSTEM_DEF(vote)
 						if (VM.config_min_users > 0 && players < VM.config_min_users)
 							continue
 						if (VM.config_max_users > 0 && players > VM.config_max_users)
-							continue	
-						if (VM.voteweight <= 0)
 							continue
 						var/map_name = verbose ? VM.config_filename : VM.map_name
 						if(!verbose && (map_name in choices))

--- a/code/controllers/subsystem/vote.dm
+++ b/code/controllers/subsystem/vote.dm
@@ -181,10 +181,11 @@ SUBSYSTEM_DEF(vote)
 			if("maprotate")
 				var/verbose = FALSE
 				var/players = GLOB.clients.len
+				var/enabled_verbose
 				question = "Next map"
 				map_config_cache = list()
 				do
-					var/enabled_verbose = FALSE
+					enabled_verbose = FALSE
 					for(var/M in global.config.maplist)
 						var/datum/map_config/VM = global.config.maplist[M]
 						if (VM.config_min_users > 0 && players < VM.config_min_users)

--- a/code/datums/map_config.dm
+++ b/code/datums/map_config.dm
@@ -10,7 +10,6 @@
 	// Config from maps.txt
 	var/config_max_users = 0
 	var/config_min_users = 0
-	var/voteweight = 1
 
 	// Config actually from the JSON - should default to Box
 	var/map_name = "Box Station"

--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -45,7 +45,6 @@ GLOBAL_LIST_EMPTY(preferences_datums)
 	var/ghost_hud = 1
 	var/inquisitive_ghost = 1
 	var/allow_midround_antag = 1
-	var/preferred_map = null
 	var/pda_style = MONO
 	var/pda_color = "#808000"
 
@@ -511,24 +510,6 @@ GLOBAL_LIST_EMPTY(preferences_datums)
 
 			dat += "<b>Ambient Occlusion:</b> <a href='?_src_=prefs;preference=ambientocclusion'>[ambientocclusion ? "Enabled" : "Disabled"]</a><br>"
 			dat += "<b>Fit Viewport:</b> <a href='?_src_=prefs;preference=auto_fit_viewport'>[auto_fit_viewport ? "Auto" : "Manual"]</a><br>"
-
-			if (CONFIG_GET(flag/maprotation))
-				var/p_map = preferred_map
-				if (!p_map)
-					p_map = "Default"
-					if (config.defaultmap)
-						p_map += " ([config.defaultmap.map_name])"
-				else
-					if (p_map in config.maplist)
-						var/datum/map_config/VM = config.maplist[p_map]
-						if (!VM)
-							p_map += " (No longer exists)"
-						else
-							p_map = VM.map_name
-					else
-						p_map += " (No longer exists)"
-				if(CONFIG_GET(flag/allow_map_voting))
-					dat += "<b>Preferred Map:</b> <a href='?_src_=prefs;preference=preferred_map;task=input'>[p_map]</a><br>"
 
 			dat += "</td><td width='300px' height='300px' valign='top'>"
 
@@ -1358,22 +1339,6 @@ GLOBAL_LIST_EMPTY(preferences_datums)
 					var/department = input(user, "Choose your prefered security department:", "Security Departments") as null|anything in GLOB.security_depts_prefs
 					if(department)
 						prefered_security_department = department
-
-				if ("preferred_map")
-					var/maplist = list()
-					var/default = "Default"
-					if (config.defaultmap)
-						default += " ([config.defaultmap.map_name])"
-					for (var/M in config.maplist)
-						var/datum/map_config/VM = config.maplist[M]
-						var/friendlyname = "[VM.map_name] "
-						if (VM.voteweight <= 0)
-							friendlyname += " (disabled)"
-						maplist[friendlyname] = VM.map_name
-					maplist[default] = null
-					var/pickedmap = input(user, "Choose your preferred map. This will be used to help weight random map selection.", "Character Preference")  as null|anything in maplist
-					if (pickedmap)
-						preferred_map = maplist[pickedmap]
 
 				if ("clientfps")
 					var/desiredfps = input(user, "Choose your desired fps. (0 = synced with server tick rate (currently:[world.fps]))", "Character Preference", clientfps)  as null|num

--- a/code/modules/client/preferences_savefile.dm
+++ b/code/modules/client/preferences_savefile.dm
@@ -90,7 +90,6 @@ SAVEFILE UPDATING/VERSIONING - 'Simplified', or rather, more coder-friendly ~Car
 	S["ghost_orbit"]		>> ghost_orbit
 	S["ghost_accs"]			>> ghost_accs
 	S["ghost_others"]		>> ghost_others
-	S["preferred_map"]		>> preferred_map
 	S["ignoring"]			>> ignoring
 	S["ghost_hud"]			>> ghost_hud
 	S["inquisitive_ghost"]	>> inquisitive_ghost
@@ -162,7 +161,6 @@ SAVEFILE UPDATING/VERSIONING - 'Simplified', or rather, more coder-friendly ~Car
 	WRITE_FILE(S["ghost_orbit"], ghost_orbit)
 	WRITE_FILE(S["ghost_accs"], ghost_accs)
 	WRITE_FILE(S["ghost_others"], ghost_others)
-	WRITE_FILE(S["preferred_map"], preferred_map)
 	WRITE_FILE(S["ignoring"], ignoring)
 	WRITE_FILE(S["ghost_hud"], ghost_hud)
 	WRITE_FILE(S["inquisitive_ghost"], inquisitive_ghost)

--- a/config/maps.txt
+++ b/config/maps.txt
@@ -9,18 +9,15 @@ Format:
 	minplayers [number] (0 or less disables this requirement)
 	maxplayers [number] (0 or less disables this requirement)
 	default (The last map with this defined will get all votes of players who have not explicitly voted for a map)
-	voteweight [number] (How much to count each player vote as, defaults to 1, setting to 0.5 counts each vote as half a vote, 2 as double, etc, Setting to 0 disables the map but allows players to still pick it)
 	disabled (disables the map)
 endmap
 
 map boxstation
 	default
-	#voteweight 1.5
 endmap
 
 map metastation
 	minplayers 25
-	#voteweight 0.5
 endmap
 
 map pubbystation


### PR DESCRIPTION
:cl:
add: If the map is to rotate and the config is enabled, a vote will be called for which of the available maps to rotate to when it normally would have been selected
del: Removed preference based voting
/:cl:

99% of the time people pick their favorite map the first time they set their prefs and then forget about it. Having them make the decision consciously each time can lead us to find what maps the players actually gravitate to on a daily basis. i.e. Does everyone hate pubby or is it just everyone loves meta?

This just uses a standard SSvote run