### PR TITLE
Makes the configured default map work

### DIFF
--- a/code/controllers/subsystem/mapping.dm
+++ b/code/controllers/subsystem/mapping.dm
@@ -49,9 +49,11 @@ SUBSYSTEM_DEF(mapping)
 	if(initialized)
 		return
 	if(config.defaulted)
+		var/old_config = config
 		config = global.config.defaultmap
 		if(!config || config.defaulted)
 			to_chat(world, "<span class='boldannounce'>Unable to load next or default map config, defaulting to Box Station</span>")
+			config = old_config
 	loader = new
 	loadWorld()
 	repopulate_sorted_areas()

--- a/code/controllers/subsystem/mapping.dm
+++ b/code/controllers/subsystem/mapping.dm
@@ -49,7 +49,9 @@ SUBSYSTEM_DEF(mapping)
 	if(initialized)
 		return
 	if(config.defaulted)
-		to_chat(world, "<span class='boldannounce'>Unable to load next map config, defaulting to Box Station</span>")
+		config = global.config.defaultmap
+		if(!config || config.defaulted)
+			to_chat(world, "<span class='boldannounce'>Unable to load next or default map config, defaulting to Box Station</span>")
 	loader = new
 	loadWorld()
 	repopulate_sorted_areas()


### PR DESCRIPTION
:cl: 
fix: Setting "default" in maps.txt now will load that map as the first fallback when a next_map.json is missing
/:cl:

oof