### PR TITLE
Fixed camera consoles not adding static to the client's view when activated

### DIFF
--- a/code/game/machinery/computer/camera_advanced.dm
+++ b/code/game/machinery/computer/camera_advanced.dm
@@ -174,9 +174,9 @@
 			C.images -= user_image
 
 /mob/camera/aiEye/remote/Destroy()
-	eye_user = null
 	origin = null
-	return ..()
+	. = ..()
+	eye_user = null
 
 /mob/camera/aiEye/remote/GetViewerClient()
 	if(eye_user)

--- a/code/game/machinery/computer/camera_advanced.dm
+++ b/code/game/machinery/computer/camera_advanced.dm
@@ -54,6 +54,9 @@
 		var/datum/action/A = V
 		A.Remove(user)
 	actions.Cut()
+	for(var/V in eyeobj.visibleCameraChunks)
+		var/datum/camerachunk/C = V
+		C.remove(eyeobj)
 	if(user.client)
 		user.reset_perspective(null)
 		eyeobj.RemoveImages()


### PR DESCRIPTION
Fixes #38905

:cl:
fix: Advaced camera consoles now properly show camera static in the area that the eye starts
/:cl: