### PR TITLE
Fixed Remove IV Container verb showing every nearby mob

### DIFF
--- a/code/game/machinery/iv_drip.dm
+++ b/code/game/machinery/iv_drip.dm
@@ -167,7 +167,7 @@
 	else
 		toggle_mode()
 
-/obj/machinery/iv_drip/verb/eject_beaker(mob/user)
+/obj/machinery/iv_drip/verb/eject_beaker()
 	set category = "Object"
 	set name = "Remove IV Container"
 	set src in view(1)


### PR DESCRIPTION
This has been an issue [since this feature was made](https://github.com/tgstation/tgstation/commit/0645d461686aa805381497fd2c39291cc5674eb1#diff-0844c285d1dc014d121d8d0b30a77ba0R153).

[Changelogs]:

:cl:
fix: Fixed the "Remove IV Container" verb on IV drips from showing every nearby mob
/:cl: