### PR TITLE
Improves cargo shuttle/firefighting foam descs

### DIFF
--- a/code/modules/cargo/console.dm
+++ b/code/modules/cargo/console.dm
@@ -5,9 +5,9 @@
 	circuit = /obj/item/circuitboard/computer/cargo
 	var/requestonly = FALSE
 	var/contraband = FALSE
-	var/safety_warning = "For safety reasons the automated supply shuttle \
-		cannot transport live organisms, classified nuclear weaponry or \
-		homing beacons."
+	var/safety_warning = "For safety reasons, the automated supply shuttle \
+		cannot transport live organisms, human remains, classified nuclear weaponry \
+		or homing beacons."
 	var/blockade_warning = "Bluespace instability detected. Shuttle movement impossible."
 
 	light_color = "#E2853D"//orange
@@ -121,7 +121,7 @@
 					SSshuttle.supply.obj_flags = (SSshuttle.supply.obj_flags & ~EMAGGED)
 				SSshuttle.supply.contraband = contraband
 				SSshuttle.moveShuttle("supply", "supply_away", TRUE)
-				say("The supply shuttle has departed.")
+				say("The supply shuttle is departing.")
 				investigate_log("[key_name(usr)] sent the supply shuttle away.", INVESTIGATE_CARGO)
 			else
 				investigate_log("[key_name(usr)] called the supply shuttle.", INVESTIGATE_CARGO)

--- a/code/modules/cargo/packs.dm
+++ b/code/modules/cargo/packs.dm
@@ -993,7 +993,7 @@
 
 /datum/supply_pack/materials/foamtank
 	name = "Foam Tank Crate"
-	desc = "Contains plasmamen's bane."
+	desc = "Contains a tank of firefighting foam. Also known as \"plasmaman's bane\"."
 	cost = 1500
 	contains = list(/obj/structure/reagent_dispensers/foamtank)
 	crate_name = "foam tank crate"

--- a/code/modules/cargo/packs.dm
+++ b/code/modules/cargo/packs.dm
@@ -992,7 +992,7 @@
 	crate_type = /obj/structure/closet/crate/large
 
 /datum/supply_pack/materials/foamtank
-	name = "Foam Tank Crate"
+	name = "Firefighting Foam Tank Crate"
 	desc = "Contains a tank of firefighting foam. Also known as \"plasmaman's bane\"."
 	cost = 1500
 	contains = list(/obj/structure/reagent_dispensers/foamtank)

--- a/code/modules/reagents/reagent_dispenser.dm
+++ b/code/modules/reagents/reagent_dispenser.dm
@@ -52,8 +52,8 @@
 	tank_volume = 100000
 
 /obj/structure/reagent_dispensers/foamtank
-	name = "firefoam tank"
-	desc = "A tank full of foaming things."
+	name = "firefighting foam tank"
+	desc = "A tank full of firefighting foam."
 	icon_state = "foam"
 	reagent_id = "firefighting_foam"
 	tank_volume = 500


### PR DESCRIPTION
:cl: Denton
spellcheck: Improved supply shuttle messages and firefighting foam descs.
/:cl:

"The supply shuttle has departed." is a bit misleading since you have a 5s timer before it actually leaves. "live organisms" doesn't cut it either since you can't ship out human corpses. 
Firefighting foam descs have also been improved.