### PR TITLE
Disables knockdown/throw on supply shuttle docking

### DIFF
--- a/code/modules/shuttle/supply.dm
+++ b/code/modules/shuttle/supply.dm
@@ -35,6 +35,7 @@ GLOBAL_LIST_INIT(blacklisted_cargo_types, typecacheof(list(
 	width = 12
 	dwidth = 5
 	height = 7
+	movement_force = list("KNOCKDOWN" = 0, "THROW" = 0)
 
 	// When TRUE, these vars allow exporting emagged/contraband items, and add some special interactions to existing exports.
 	var/contraband = FALSE


### PR DESCRIPTION
:cl: Denton
fix: Supply shuttles will no longer spill containers on docking.
/:cl:

#38513 throws shuttle contents, which causes loose bottles to get thrown and spill their contents - like the virus culture bottles that appear during the virus shuttle loan event.
This PR disables knockdown/item throwing when the supply shuttle docks.