### PR TITLE
Fix constructed directional windows leaking atmos, wrap setting of the anchored var on objects

### DIFF
--- a/code/__DEFINES/components.dm
+++ b/code/__DEFINES/components.dm
@@ -113,7 +113,7 @@
 
 // /obj signals
 #define COMSIG_OBJ_DECONSTRUCT "obj_deconstruct"				//from base of obj/deconstruct(): (disassembled)
-#define COMSIG_OBJ_SETANCHORED "obj_setanchored" //called in /obj/structure/setAnchored(): (value)
+#define COMSIG_OBJ_SETANCHORED "obj_setanchored"				//called in /obj/structure/setAnchored(): (value)
 
 // /obj/item signals
 #define COMSIG_ITEM_ATTACK "item_attack"						//from base of obj/item/attack(): (/mob/living/target, /mob/living/user)

--- a/code/__DEFINES/components.dm
+++ b/code/__DEFINES/components.dm
@@ -152,6 +152,9 @@
 // /obj/item/pen signals
 #define COMSIG_PEN_ROTATED "pen_rotated"						//called after rotation in /obj/item/pen/attack_self(): (rotation, mob/living/carbon/user)
 
+// /obj/structure signals
+#define COMSIG_STRUCTURE_SETANCHORED "struct_setanchorted" //called in /obj/structure/setAnchored(): (value)
+
 // /mob/living/carbon/human signals
 #define COMSIG_HUMAN_MELEE_UNARMED_ATTACK "human_melee_unarmed_attack"			//from mob/living/carbon/human/UnarmedAttack(): (atom/target)
 #define COMSIG_HUMAN_MELEE_UNARMED_ATTACKBY "human_melee_unarmed_attackby"		//from mob/living/carbon/human/UnarmedAttack(): (mob/living/carbon/human/attacker)

--- a/code/__DEFINES/components.dm
+++ b/code/__DEFINES/components.dm
@@ -113,6 +113,7 @@
 
 // /obj signals
 #define COMSIG_OBJ_DECONSTRUCT "obj_deconstruct"				//from base of obj/deconstruct(): (disassembled)
+#define COMSIG_OBJ_SETANCHORED "obj_setanchored" //called in /obj/structure/setAnchored(): (value)
 
 // /obj/item signals
 #define COMSIG_ITEM_ATTACK "item_attack"						//from base of obj/item/attack(): (/mob/living/target, /mob/living/user)
@@ -152,8 +153,6 @@
 // /obj/item/pen signals
 #define COMSIG_PEN_ROTATED "pen_rotated"						//called after rotation in /obj/item/pen/attack_self(): (rotation, mob/living/carbon/user)
 
-// /obj/structure signals
-#define COMSIG_STRUCTURE_SETANCHORED "struct_setanchorted" //called in /obj/structure/setAnchored(): (value)
 
 // /mob/living/carbon/human signals
 #define COMSIG_HUMAN_MELEE_UNARMED_ATTACK "human_melee_unarmed_attack"			//from mob/living/carbon/human/UnarmedAttack(): (atom/target)

--- a/code/game/machinery/_machinery.dm
+++ b/code/game/machinery/_machinery.dm
@@ -311,7 +311,7 @@ Class Procs:
 /obj/machinery/proc/spawn_frame(disassembled)
 	var/obj/structure/frame/machine/M = new /obj/structure/frame/machine(loc)
 	. = M
-	M.anchored = anchored
+	M.setAnchored(anchored)
 	if(!disassembled)
 		M.obj_integrity = M.max_integrity * 0.5 //the frame is already half broken
 	transfer_fingerprints_to(M)
@@ -372,7 +372,7 @@ Class Procs:
 		//as long as we're the same anchored state and we're either on a floor or are anchored, toggle our anchored state
 		if(I.use_tool(src, user, time, extra_checks = CALLBACK(src, .proc/unfasten_wrench_check, prev_anchored, user)))
 			to_chat(user, "<span class='notice'>You [anchored ? "un" : ""]secure [src].</span>")
-			anchored = !anchored
+			setAnchored(!anchored)
 			playsound(src, 'sound/items/deconstruct.ogg', 50, 1)
 			return SUCCESSFUL_UNFASTEN
 		return FAILED_UNFASTEN

--- a/code/game/machinery/camera/camera_assembly.dm
+++ b/code/game/machinery/camera/camera_assembly.dm
@@ -42,7 +42,7 @@
 			if(istype(W, /obj/item/weldingtool))
 				if(weld(W, user))
 					to_chat(user, "<span class='notice'>You weld the assembly securely into place.</span>")
-					anchored = TRUE
+					setAnchored(TRUE)
 					state = 2
 				return
 		if(2)
@@ -62,7 +62,7 @@
 				if(weld(W, user))
 					to_chat(user, "<span class='notice'>You unweld the assembly from its place.</span>")
 					state = 1
-					anchored = TRUE
+					setAnchored(TRUE)
 				return
 
 	// Upgrades!

--- a/code/game/machinery/computer/_computer.dm
+++ b/code/game/machinery/computer/_computer.dm
@@ -111,7 +111,7 @@
 			var/obj/structure/frame/computer/A = new /obj/structure/frame/computer(src.loc)
 			A.dir = dir
 			A.circuit = circuit
-			A.anchored = TRUE
+			A.setAnchored(TRUE)
 			if(stat & BROKEN)
 				if(user)
 					to_chat(user, "<span class='notice'>The broken glass falls out.</span>")

--- a/code/game/machinery/computer/buildandrepair.dm
+++ b/code/game/machinery/computer/buildandrepair.dm
@@ -11,7 +11,7 @@
 				to_chat(user, "<span class='notice'>You start wrenching the frame into place...</span>")
 				if(P.use_tool(src, user, 20, volume=50))
 					to_chat(user, "<span class='notice'>You wrench the frame into place.</span>")
-					anchored = TRUE
+					setAnchored(TRUE)
 					state = 1
 				return
 			if(istype(P, /obj/item/weldingtool))
@@ -30,7 +30,7 @@
 				to_chat(user, "<span class='notice'>You start to unfasten the frame...</span>")
 				if(P.use_tool(src, user, 20, volume=50))
 					to_chat(user, "<span class='notice'>You unfasten the frame.</span>")
-					anchored = FALSE
+					setAnchored(FALSE)
 					state = 0
 				return
 			if(istype(P, /obj/item/circuitboard/computer) && !circuit)

--- a/code/game/machinery/constructable_frame.dm
+++ b/code/game/machinery/constructable_frame.dm
@@ -106,7 +106,7 @@
 				if(P.use_tool(src, user, 40, volume=75))
 					if(state == 1)
 						to_chat(user, "<span class='notice'>You [anchored ? "un" : ""]secure [name].</span>")
-						anchored = !anchored
+						setAnchored(!anchored)
 				return
 
 		if(2)
@@ -114,7 +114,7 @@
 				to_chat(user, "<span class='notice'>You start [anchored ? "un" : ""]securing [name]...</span>")
 				if(P.use_tool(src, user, 40, volume=75))
 					to_chat(user, "<span class='notice'>You [anchored ? "un" : ""]secure [name].</span>")
-					anchored = !anchored
+					setAnchored(!anchored)
 				return
 
 			if(istype(P, /obj/item/circuitboard/machine))
@@ -169,7 +169,7 @@
 				to_chat(user, "<span class='notice'>You start [anchored ? "un" : ""]securing [name]...</span>")
 				if(P.use_tool(src, user, 40, volume=75))
 					to_chat(user, "<span class='notice'>You [anchored ? "un" : ""]secure [name].</span>")
-					anchored = !anchored
+					setAnchored(!anchored)
 				return
 
 			if(istype(P, /obj/item/screwdriver))
@@ -181,7 +181,7 @@
 				if(component_check)
 					P.play_tool_sound(src)
 					var/obj/machinery/new_machine = new circuit.build_path(loc, 1)
-					new_machine.anchored = anchored
+					new_machine.setAnchored(anchored)
 					new_machine.on_construction()
 					for(var/obj/O in new_machine.component_parts)
 						qdel(O)

--- a/code/game/machinery/dance_machine.dm
+++ b/code/game/machinery/dance_machine.dm
@@ -66,10 +66,10 @@
 		if(istype(O, /obj/item/wrench))
 			if(!anchored && !isinspace())
 				to_chat(user,"<span class='notice'>You secure [src] to the floor.</span>")
-				anchored = TRUE
+				setAnchored(TRUE)
 			else if(anchored)
 				to_chat(user,"<span class='notice'>You unsecure and disconnect [src].</span>")
-				anchored = FALSE
+				setAnchored(FALSE)
 			playsound(src, 'sound/items/deconstruct.ogg', 50, 1)
 			return
 	return ..()

--- a/code/game/machinery/doors/airlock.dm
+++ b/code/game/machinery/doors/airlock.dm
@@ -1321,7 +1321,7 @@
 			A = new /obj/structure/door_assembly(loc)
 			//If you come across a null assemblytype, it will produce the default assembly instead of disintegrating.
 		A.heat_proof_finished = src.heat_proof //tracks whether there's rglass in
-		A.anchored = TRUE
+		A.setAnchored(TRUE)
 		A.glass = src.glass
 		A.state = AIRLOCK_ASSEMBLY_NEEDS_ELECTRONICS
 		A.created_name = name

--- a/code/game/machinery/doors/windowdoor.dm
+++ b/code/game/machinery/doors/windowdoor.dm
@@ -246,7 +246,7 @@
 							if("rightsecure")
 								WA.facing = "r"
 								WA.secure = TRUE
-						WA.anchored = TRUE
+						WA.setAnchored(TRUE)
 						WA.state= "02"
 						WA.setDir(src.dir)
 						WA.ini_dir = src.dir

--- a/code/game/machinery/flasher.dm
+++ b/code/game/machinery/flasher.dm
@@ -167,13 +167,13 @@
 		if (!anchored && !isinspace())
 			to_chat(user, "<span class='notice'>[src] is now secured.</span>")
 			add_overlay("[base_state]-s")
-			anchored = TRUE
+			setAnchored(TRUE)
 			power_change()
 			proximity_monitor.SetRange(range)
 		else
 			to_chat(user, "<span class='notice'>[src] can now be moved.</span>")
 			cut_overlays()
-			anchored = FALSE
+			setAnchored(FALSE)
 			power_change()
 			proximity_monitor.SetRange(0)
 

--- a/code/game/machinery/hologram.dm
+++ b/code/game/machinery/hologram.dm
@@ -393,7 +393,7 @@ Possible to do for anyone motivated enough:
 		Hologram.copy_known_languages_from(user,replace = TRUE)
 		Hologram.mouse_opacity = MOUSE_OPACITY_TRANSPARENT//So you can't click on it.
 		Hologram.layer = FLY_LAYER//Above all the other objects/mobs. Or the vast majority of them.
-		Hologram.anchored = TRUE//So space wind cannot drag it.
+		Hologram.setAnchored(TRUE)//So space wind cannot drag it.
 		Hologram.name = "[user.name] (Hologram)"//If someone decides to right click.
 		Hologram.set_light(2)	//hologram lighting
 		move_hologram()
@@ -551,7 +551,7 @@ For the other part of the code, check silicon say.dm. Particularly robot talk.*/
 	holder.selected_default_language = record.language
 	Hologram.mouse_opacity = MOUSE_OPACITY_TRANSPARENT//So you can't click on it.
 	Hologram.layer = FLY_LAYER//Above all the other objects/mobs. Or the vast majority of them.
-	Hologram.anchored = TRUE//So space wind cannot drag it.
+	Hologram.setAnchored(TRUE)//So space wind cannot drag it.
 	Hologram.name = "[record.caller_name] (Hologram)"//If someone decides to right click.
 	Hologram.set_light(2)	//hologram lighting
 	visible_message("<span class='notice'>A holographic image of [record.caller_name] flickers to life before your eyes!</span>")

--- a/code/game/machinery/porta_turret/portable_turret.dm
+++ b/code/game/machinery/porta_turret/portable_turret.dm
@@ -261,7 +261,7 @@
 
 		//This code handles moving the turret around. After all, it's a portable turret!
 		if(!anchored && !isinspace())
-			anchored = TRUE
+			setAnchored(TRUE)
 			invisibility = INVISIBILITY_MAXIMUM
 			update_icon()
 			to_chat(user, "<span class='notice'>You secure the exterior bolts on the turret.</span>")
@@ -269,7 +269,7 @@
 				cover = new /obj/machinery/porta_turret_cover(loc) //create a new turret. While this is handled in process(), this is to workaround a bug where the turret becomes invisible for a split second
 				cover.parent_turret = src //make the cover's parent src
 		else if(anchored)
-			anchored = FALSE
+			setAnchored(FALSE)
 			to_chat(user, "<span class='notice'>You unsecure the exterior bolts on the turret.</span>")
 			power_change()
 			invisibility = 0

--- a/code/game/machinery/porta_turret/portable_turret_construct.dm
+++ b/code/game/machinery/porta_turret/portable_turret_construct.dm
@@ -26,7 +26,7 @@
 			if(istype(I, /obj/item/wrench) && !anchored)
 				I.play_tool_sound(src, 100)
 				to_chat(user, "<span class='notice'>You secure the external bolts.</span>")
-				anchored = TRUE
+				setAnchored(TRUE)
 				build_step = PTURRET_BOLTED
 				return
 
@@ -51,7 +51,7 @@
 			else if(istype(I, /obj/item/wrench))
 				I.play_tool_sound(src, 75)
 				to_chat(user, "<span class='notice'>You unfasten the external bolts.</span>")
-				anchored = FALSE
+				setAnchored(FALSE)
 				build_step = PTURRET_UNSECURED
 				return
 

--- a/code/game/machinery/porta_turret/portable_turret_cover.dm
+++ b/code/game/machinery/porta_turret/portable_turret_cover.dm
@@ -45,12 +45,12 @@
 			return
 
 		if(!parent_turret.anchored)
-			parent_turret.anchored = TRUE
+			parent_turret.setAnchored(TRUE)
 			to_chat(user, "<span class='notice'>You secure the exterior bolts on the turret.</span>")
 			parent_turret.invisibility = 0
 			parent_turret.update_icon()
 		else
-			parent_turret.anchored = FALSE
+			parent_turret.setAnchored(FALSE)
 			to_chat(user, "<span class='notice'>You unsecure the exterior bolts on the turret.</span>")
 			parent_turret.invisibility = INVISIBILITY_MAXIMUM
 			parent_turret.update_icon()

--- a/code/game/machinery/recharger.dm
+++ b/code/game/machinery/recharger.dm
@@ -25,7 +25,7 @@
 		if(charging)
 			to_chat(user, "<span class='notice'>Remove the charging item first!</span>")
 			return
-		anchored = !anchored
+		setAnchored(!anchored)
 		power_change()
 		to_chat(user, "<span class='notice'>You [anchored ? "attached" : "detached"] [src].</span>")
 		G.play_tool_sound(src)

--- a/code/game/machinery/shieldgen.dm
+++ b/code/game/machinery/shieldgen.dm
@@ -178,14 +178,14 @@
 		if(!anchored && !isinspace())
 			W.play_tool_sound(src, 100)
 			to_chat(user, "<span class='notice'>You secure \the [src] to the floor!</span>")
-			anchored = TRUE
+			setAnchored(TRUE)
 		else if(anchored)
 			W.play_tool_sound(src, 100)
 			to_chat(user, "<span class='notice'>You unsecure \the [src] from the floor!</span>")
 			if(active)
 				to_chat(user, "<span class='notice'>\The [src] shuts off!</span>")
 				shields_down()
-			anchored = FALSE
+			setAnchored(FALSE)
 
 	else if(W.GetID())
 		if(allowed(user) && !(obj_flags & EMAGGED))

--- a/code/game/machinery/syndicatebeacon.dm
+++ b/code/game/machinery/syndicatebeacon.dm
@@ -62,7 +62,7 @@
 			return
 
 		if(anchored)
-			anchored = FALSE
+			setAnchored(FALSE)
 			to_chat(user, "<span class='notice'>You unscrew the beacon from the floor.</span>")
 			disconnect_from_network()
 			return
@@ -70,7 +70,7 @@
 			if(!connect_to_network())
 				to_chat(user, "<span class='warning'>This device must be placed over an exposed, powered cable node!</span>")
 				return
-			anchored = TRUE
+			setAnchored(TRUE)
 			to_chat(user, "<span class='notice'>You screw the beacon to the floor and attach the cable.</span>")
 			return
 	else

--- a/code/game/machinery/syndicatebomb.dm
+++ b/code/game/machinery/syndicatebomb.dm
@@ -119,14 +119,14 @@
 			else
 				to_chat(user, "<span class='notice'>You firmly wrench the bomb to the floor.</span>")
 				I.play_tool_sound(src)
-				anchored = TRUE
+				setAnchored(TRUE)
 				if(active)
 					to_chat(user, "<span class='notice'>The bolts lock in place.</span>")
 		else
 			if(!active)
 				to_chat(user, "<span class='notice'>You wrench the bomb from the floor.</span>")
 				I.play_tool_sound(src)
-				anchored = FALSE
+				setAnchored(FALSE)
 			else
 				to_chat(user, "<span class='warning'>The bolts are locked down!</span>")
 

--- a/code/game/objects/objs.dm
+++ b/code/game/objects/objs.dm
@@ -31,6 +31,9 @@
 
 /obj/vv_edit_var(vname, vval)
 	switch(vname)
+		if("anchored")
+			setAnchored(vval)
+			return TRUE
 		if("obj_flags")
 			if ((obj_flags & DANGEROUS_POSSESSION) && !(vval & DANGEROUS_POSSESSION))
 				return FALSE
@@ -70,6 +73,10 @@
 		STOP_PROCESSING(SSobj, src) // TODO: Have a processing bitflag to reduce on unnecessary loops through the processing lists
 	SStgui.close_uis(src)
 	. = ..()
+
+/obj/proc/setAnchored(anchorvalue)
+	SEND_SIGNAL(src, COMSIG_OBJ_SETANCHORED, anchorvalue)
+	anchored = anchorvalue
 
 /obj/throw_at(atom/target, range, speed, mob/thrower, spin=1, diagonals_first = 0, datum/callback/callback)
 	..()

--- a/code/game/objects/structures.dm
+++ b/code/game/objects/structures.dm
@@ -108,3 +108,13 @@
 		if(0 to 25)
 			if(!broken)
 				return  "<span class='warning'>It's falling apart!</span>"
+
+/obj/structure/proc/setAnchored(anchorvalue)
+	anchored = anchorvalue
+
+/obj/structure/vv_edit_var(var_name, var_value)
+	switch(var_name)
+		if("anchored")
+			setAnchored(var_value)
+			return TRUE
+	return ..()

--- a/code/game/objects/structures.dm
+++ b/code/game/objects/structures.dm
@@ -110,6 +110,7 @@
 				return  "<span class='warning'>It's falling apart!</span>"
 
 /obj/structure/proc/setAnchored(anchorvalue)
+	SEND_SIGNAL(src, COMSIG_STRUCTURE_SETANCHORED, anchorvalue)
 	anchored = anchorvalue
 
 /obj/structure/vv_edit_var(var_name, var_value)

--- a/code/game/objects/structures.dm
+++ b/code/game/objects/structures.dm
@@ -108,14 +108,3 @@
 		if(0 to 25)
 			if(!broken)
 				return  "<span class='warning'>It's falling apart!</span>"
-
-/obj/structure/proc/setAnchored(anchorvalue)
-	SEND_SIGNAL(src, COMSIG_STRUCTURE_SETANCHORED, anchorvalue)
-	anchored = anchorvalue
-
-/obj/structure/vv_edit_var(var_name, var_value)
-	switch(var_name)
-		if("anchored")
-			setAnchored(var_value)
-			return TRUE
-	return ..()

--- a/code/game/objects/structures/crates_lockers/closets.dm
+++ b/code/game/objects/structures/crates_lockers/closets.dm
@@ -254,7 +254,7 @@
 	else if(istype(W, /obj/item/wrench) && anchorable)
 		if(isinspace() && !anchored)
 			return
-		anchored = !anchored
+		setAnchored(!anchored)
 		W.play_tool_sound(src, 75)
 		user.visible_message("<span class='notice'>[user] [anchored ? "anchored" : "unanchored"] \the [src] [anchored ? "to" : "from"] the ground.</span>", \
 						"<span class='notice'>You [anchored ? "anchored" : "unanchored"] \the [src] [anchored ? "to" : "from"] the ground.</span>", \

--- a/code/game/objects/structures/door_assembly.dm
+++ b/code/game/objects/structures/door_assembly.dm
@@ -106,7 +106,7 @@
 						return
 					to_chat(user, "<span class='notice'>You secure the airlock assembly.</span>")
 					name = "secured airlock assembly"
-					anchored = TRUE
+					setAnchored(TRUE)
 			else
 				to_chat(user, "There is another door here!")
 
@@ -119,7 +119,7 @@
 					return
 				to_chat(user, "<span class='notice'>You unsecure the airlock assembly.</span>")
 				name = "airlock assembly"
-				anchored = FALSE
+				setAnchored(FALSE)
 
 	else if(istype(W, /obj/item/stack/cable_coil) && state == AIRLOCK_ASSEMBLY_NEEDS_WIRES && anchored )
 		if(!W.tool_start_check(user, amount=1))
@@ -281,7 +281,7 @@
 	target.heat_proof_finished = source.heat_proof_finished
 	target.created_name = source.created_name
 	target.state = source.state
-	target.anchored = source.anchored
+	target.setAnchored(source.anchored)
 	if(previous)
 		target.previous_assembly = source.type
 	if(electronics)

--- a/code/game/objects/structures/dresser.dm
+++ b/code/game/objects/structures/dresser.dm
@@ -11,7 +11,7 @@
 		to_chat(user, "<span class='notice'>You begin to [anchored ? "unwrench" : "wrench"] [src].</span>")
 		if(I.use_tool(src, user, 20, volume=50))
 			to_chat(user, "<span class='notice'>You successfully [anchored ? "unwrench" : "wrench"] [src].</span>")
-			anchored = !anchored
+			setAnchored(!anchored)
 	else
 		return ..()
 

--- a/code/game/objects/structures/grille.dm
+++ b/code/game/objects/structures/grille.dm
@@ -68,7 +68,7 @@
 				return FALSE
 			to_chat(user, "<span class='notice'>You construct the window.</span>")
 			var/obj/structure/window/WD = new the_rcd.window_type(drop_location())
-			WD.anchored = TRUE
+			WD.setAnchored(TRUE)
 			return TRUE
 	return FALSE
 
@@ -145,7 +145,7 @@
 	else if((istype(W, /obj/item/screwdriver)) && (isturf(loc) || anchored))
 		if(!shock(user, 90))
 			W.play_tool_sound(src, 100)
-			anchored = !anchored
+			setAnchored(!anchored)
 			user.visible_message("<span class='notice'>[user] [anchored ? "fastens" : "unfastens"] [src].</span>", \
 								 "<span class='notice'>You [anchored ? "fasten [src] to" : "unfasten [src] from"] the floor.</span>")
 			return
@@ -194,7 +194,7 @@
 					WD = new/obj/structure/window/fulltile(drop_location()) //normal window
 				WD.setDir(dir_to_set)
 				WD.ini_dir = dir_to_set
-				WD.anchored = FALSE
+				WD.setAnchored(FALSE)
 				WD.state = 0
 				ST.use(2)
 				to_chat(user, "<span class='notice'>You place [WD] on [src].</span>")

--- a/code/game/objects/structures/plasticflaps.dm
+++ b/code/game/objects/structures/plasticflaps.dm
@@ -25,7 +25,7 @@
 	var/uraction = anchored ? "unscrew [src] from " : "screw [src] to"
 	user.visible_message("<span class='warning'>[user] [action] the floor.</span>", "<span class='notice'>You start to [uraction] the floor...</span>", "You hear rustling noises.")
 	if(W.use_tool(src, user, 100, volume=100, extra_checks = CALLBACK(src, .proc/check_anchored_state, anchored)))
-		anchored = !anchored
+		setAnchored(!anchored)
 		to_chat(user, "<span class='notice'> You [anchored ? "unscrew" : "screw"] [src] from the floor.</span>")
 		return TRUE
 	else

--- a/code/game/objects/structures/reflector.dm
+++ b/code/game/objects/structures/reflector.dm
@@ -117,7 +117,7 @@
 								"<span class='notice'>You start to weld [src] to the floor...</span>",
 								"<span class='italics'>You hear welding.</span>")
 			if (W.use_tool(src, user, 20, volume=50))
-				anchored = TRUE
+				setAnchored(TRUE)
 				to_chat(user, "<span class='notice'>You weld [src] to the floor.</span>")
 		else
 			if(!W.tool_start_check(user, amount=0))
@@ -127,7 +127,7 @@
 								"<span class='notice'>You start to cut [src] free from the floor...</span>",
 								"<span class='italics'>You hear welding.</span>")
 			if (W.use_tool(src, user, 20, volume=50))
-				anchored = FALSE
+				setAnchored(FALSE)
 				to_chat(user, "<span class='notice'>You cut [src] free from the floor.</span>")
 
 	//Finishing the frame

--- a/code/game/objects/structures/windoor_assembly.dm
+++ b/code/game/objects/structures/windoor_assembly.dm
@@ -121,7 +121,7 @@
 							to_chat(user, "<span class='warning'>There is already a windoor in that location!</span>")
 							return
 					to_chat(user, "<span class='notice'>You secure the windoor assembly.</span>")
-					anchored = TRUE
+					setAnchored(TRUE)
 					if(secure)
 						name = "secure anchored windoor assembly"
 					else
@@ -136,7 +136,7 @@
 					if(!anchored)
 						return
 					to_chat(user, "<span class='notice'>You unsecure the windoor assembly.</span>")
-					anchored = FALSE
+					setAnchored(FALSE)
 					if(secure)
 						name = "secure windoor assembly"
 					else

--- a/code/game/objects/structures/window.dm
+++ b/code/game/objects/structures/window.dm
@@ -462,13 +462,6 @@
 /obj/structure/window/plasma/reinforced/unanchored
 	anchored = FALSE
 
-/obj/structure/window/plasma/reinforced/unanchored/CanAtmosPass(turf/T)
-	if(!anchored || !density)
-		warning("canAtmosPass: anchored is [anchored], density is [density], returning TRUE")
-		return TRUE
-	warning("canAtmosPass: FULLTILE_WINDOW_DIR is [FULLTILE_WINDOW_DIR], dir is [dir], first term is [(FULLTILE_WINDOW_DIR == dir)], get_dir is [get_dir(loc, T)], second term is [(dir == get_dir(loc, T))]")
-	return !(FULLTILE_WINDOW_DIR == dir || dir == get_dir(loc, T))
-
 /obj/structure/window/reinforced/tinted
 	name = "tinted window"
 	icon_state = "twindow"

--- a/code/game/objects/structures/window.dm
+++ b/code/game/objects/structures/window.dm
@@ -207,15 +207,12 @@
 				else if(state == WINDOW_OUT_OF_FRAME)
 					to_chat(user, "<span class='notice'>You begin to [anchored ? "unscrew the frame from":"screw the frame to"] the floor...</span>")
 					if(I.use_tool(src, user, decon_speed, extra_checks = CALLBACK(src, .proc/check_state_and_anchored, state, anchored)))
-						anchored = !anchored
-						update_nearby_icons()
+						setAnchored(!anchored)
 						to_chat(user, "<span class='notice'>You [anchored ? "fasten the frame to":"unfasten the frame from"] the floor.</span>")
 			else //if we're not reinforced, we don't need to check or update state
 				to_chat(user, "<span class='notice'>You begin to [anchored ? "unscrew the window from":"screw the window to"] the floor...</span>")
 				if(I.use_tool(src, user, decon_speed, extra_checks = CALLBACK(src, .proc/check_anchored, anchored)))
-					anchored = !anchored
-					air_update_turf(TRUE)
-					update_nearby_icons()
+					setAnchored(!anchored)
 					to_chat(user, "<span class='notice'>You [anchored ? "fasten the window to":"unfasten the window from"] the floor.</span>")
 			return
 
@@ -239,6 +236,11 @@
 				qdel(src)
 			return
 	return ..()
+
+/obj/structure/window/setAnchored(anchorvalue)
+	..()
+	air_update_turf(TRUE)
+	update_nearby_icons()
 
 /obj/structure/window/proc/check_state(checked_state)
 	if(state == checked_state)
@@ -459,6 +461,13 @@
 
 /obj/structure/window/plasma/reinforced/unanchored
 	anchored = FALSE
+
+/obj/structure/window/plasma/reinforced/unanchored/CanAtmosPass(turf/T)
+	if(!anchored || !density)
+		warning("canAtmosPass: anchored is [anchored], density is [density], returning TRUE")
+		return TRUE
+	warning("canAtmosPass: FULLTILE_WINDOW_DIR is [FULLTILE_WINDOW_DIR], dir is [dir], first term is [(FULLTILE_WINDOW_DIR == dir)], get_dir is [get_dir(loc, T)], second term is [(dir == get_dir(loc, T))]")
+	return !(FULLTILE_WINDOW_DIR == dir || dir == get_dir(loc, T))
 
 /obj/structure/window/reinforced/tinted
 	name = "tinted window"


### PR DESCRIPTION
:cl: Naksu
fix: constructed directional windows no longer leak atmos across them
code: setting the value of anchored for objects should be done via the setAnchored proc to properly handle things like atmos updates in one place
/:cl:

before:
![image](https://user-images.githubusercontent.com/20017308/42332119-e2c3af2e-807f-11e8-9011-b37e99fc697c.png)
after:
![image](https://user-images.githubusercontent.com/20017308/42332134-eb2e298c-807f-11e8-9658-5123521b3068.png)
