### PR TITLE
Cere shuttle no longer flies backwards

### DIFF
--- a/_maps/shuttles/emergency_cere.dmm
+++ b/_maps/shuttles/emergency_cere.dmm
@@ -549,8 +549,6 @@
 	dwidth = 15;
 	height = 20;
 	name = "Cere emergency shuttle";
-	port_direction = 4;
-	preferred_direction = 2;
 	width = 42
 	},
 /turf/open/floor/plating,


### PR DESCRIPTION
:cl: Denton
fix: Cere Station's escape shuttle has had its turbo encabulator replaced and should no longer fly through hyperspace backwards.
/:cl:

Closes: #38914