### PR TITLE
Fixes non-silicons being able to use machines without being adjacent

### DIFF
--- a/code/game/machinery/_machinery.dm
+++ b/code/game/machinery/_machinery.dm
@@ -227,7 +227,7 @@ Class Procs:
 			return FALSE
 		if(!Adjacent(user))
 			var/mob/living/carbon/H = user
-			if(istype(H) && H.has_dna() && !H.dna.check_mutation(TK))
+			if(!(istype(H) && H.has_dna() && H.dna.check_mutation(TK)))
 				return FALSE
 	return TRUE
 

--- a/code/game/machinery/_machinery.dm
+++ b/code/game/machinery/_machinery.dm
@@ -223,8 +223,8 @@ Class Procs:
 	else if(silicon && !(interaction_flags_machine & INTERACT_MACHINE_ALLOW_SILICON))
 		return FALSE
 	if(!silicon && !Adjacent(user))
-		var/mob/living/carbon/human/H = user
-		if(istype(H) && !H.dna.check_mutation(TK))
+		var/mob/living/carbon/H = user
+		if(istype(H) && H.has_dna() && !H.dna.check_mutation(TK))
 			return FALSE
 	return TRUE
 

--- a/code/game/machinery/_machinery.dm
+++ b/code/game/machinery/_machinery.dm
@@ -222,6 +222,8 @@ Class Procs:
 		return FALSE
 	else if(silicon && !(interaction_flags_machine & INTERACT_MACHINE_ALLOW_SILICON))
 		return FALSE
+	if(!silicon && !Adjacent(user))
+		return FALSE
 	return TRUE
 
 ////////////////////////////////////////////////////////////////////////////////////////////

--- a/code/game/machinery/_machinery.dm
+++ b/code/game/machinery/_machinery.dm
@@ -223,7 +223,9 @@ Class Procs:
 	else if(silicon && !(interaction_flags_machine & INTERACT_MACHINE_ALLOW_SILICON))
 		return FALSE
 	if(!silicon && !Adjacent(user))
-		return FALSE
+		var/mob/living/carbon/H = user
+		if(istype(H) && !H.dna.check_mutation(TK))
+			return FALSE
 	return TRUE
 
 ////////////////////////////////////////////////////////////////////////////////////////////

--- a/code/game/machinery/_machinery.dm
+++ b/code/game/machinery/_machinery.dm
@@ -218,14 +218,16 @@ Class Procs:
 	if(panel_open && !(interaction_flags_machine & INTERACT_MACHINE_OPEN))
 		if(!silicon || !(interaction_flags_machine & INTERACT_MACHINE_OPEN_SILICON))
 			return FALSE
-	if(!silicon && (interaction_flags_machine & INTERACT_MACHINE_REQUIRES_SILICON))
-		return FALSE
-	else if(silicon && !(interaction_flags_machine & INTERACT_MACHINE_ALLOW_SILICON))
-		return FALSE
-	if(!silicon && !Adjacent(user))
-		var/mob/living/carbon/H = user
-		if(istype(H) && H.has_dna() && !H.dna.check_mutation(TK))
+	if(silicon)
+		if(!(interaction_flags_machine & INTERACT_MACHINE_ALLOW_SILICON))
 			return FALSE
+	else if(!silicon)
+		if(interaction_flags_machine & INTERACT_MACHINE_REQUIRES_SILICON)
+			return FALSE
+		if(!Adjacent(user))
+			var/mob/living/carbon/H = user
+			if(istype(H) && H.has_dna() && !H.dna.check_mutation(TK))
+				return FALSE
 	return TRUE
 
 ////////////////////////////////////////////////////////////////////////////////////////////

--- a/code/game/machinery/_machinery.dm
+++ b/code/game/machinery/_machinery.dm
@@ -223,7 +223,7 @@ Class Procs:
 	else if(silicon && !(interaction_flags_machine & INTERACT_MACHINE_ALLOW_SILICON))
 		return FALSE
 	if(!silicon && !Adjacent(user))
-		var/mob/living/carbon/H = user
+		var/mob/living/carbon/human/H = user
 		if(istype(H) && !H.dna.check_mutation(TK))
 			return FALSE
 	return TRUE

--- a/code/game/machinery/_machinery.dm
+++ b/code/game/machinery/_machinery.dm
@@ -218,10 +218,11 @@ Class Procs:
 	if(panel_open && !(interaction_flags_machine & INTERACT_MACHINE_OPEN))
 		if(!silicon || !(interaction_flags_machine & INTERACT_MACHINE_OPEN_SILICON))
 			return FALSE
+
 	if(silicon)
 		if(!(interaction_flags_machine & INTERACT_MACHINE_ALLOW_SILICON))
 			return FALSE
-	else if(!silicon)
+	else
 		if(interaction_flags_machine & INTERACT_MACHINE_REQUIRES_SILICON)
 			return FALSE
 		if(!Adjacent(user))


### PR DESCRIPTION
Checks to see if the user of a machine is both not a silicon and not standing next to it. If they are both the machine will not work.

:cl:
fix: non-silicons can no longer use machines without standing next to them.
/:cl:

fixes: #38916 
fixes: #38959

It wasn't just lathes, most machines were being effected.