### PR TITLE
Spices up the syndie shuttle loan event

### DIFF
--- a/code/modules/events/shuttle_loan.dm
+++ b/code/modules/events/shuttle_loan.dm
@@ -97,7 +97,6 @@
 
 				shuttle_spawns.Add(/mob/living/simple_animal/hostile/syndicate/melee)
 				shuttle_spawns.Add(/mob/living/simple_animal/hostile/syndicate/melee)
-				shuttle_spawns.Add(/mob/living/simple_animal/hostile/syndicate/ranged)
 				if(prob(75))
 					shuttle_spawns.Add(/mob/living/simple_animal/hostile/syndicate/ranged)
 				if(prob(50))

--- a/code/modules/events/shuttle_loan.dm
+++ b/code/modules/events/shuttle_loan.dm
@@ -95,12 +95,13 @@
 				var/datum/supply_pack/pack = SSshuttle.supply_packs[/datum/supply_pack/emergency/specialops]
 				pack.generate(pick_n_take(empty_shuttle_turfs))
 
-				shuttle_spawns.Add(/mob/living/simple_animal/hostile/syndicate)
-				shuttle_spawns.Add(/mob/living/simple_animal/hostile/syndicate)
+				shuttle_spawns.Add(/mob/living/simple_animal/hostile/syndicate/melee)
+				shuttle_spawns.Add(/mob/living/simple_animal/hostile/syndicate/melee)
+				shuttle_spawns.Add(/mob/living/simple_animal/hostile/syndicate/ranged)
 				if(prob(75))
-					shuttle_spawns.Add(/mob/living/simple_animal/hostile/syndicate)
+					shuttle_spawns.Add(/mob/living/simple_animal/hostile/syndicate/ranged)
 				if(prob(50))
-					shuttle_spawns.Add(/mob/living/simple_animal/hostile/syndicate)
+					shuttle_spawns.Add(/mob/living/simple_animal/hostile/syndicate/melee/space/stormtrooper) //twice the HP of regular melee syndies
 
 			if(RUSKY_PARTY)
 				var/datum/supply_pack/pack = SSshuttle.supply_packs[/datum/supply_pack/service/party]


### PR DESCRIPTION
:cl: Denton
balance: Syndicate shuttle boarding parties have been beefed up considerably.
/:cl:

"Hey Frank, who should we send to infiltrate this space station full of deranged sociopaths?" "How about two to four dudes but we don't give them any weapons?" 🤔 

New crew is two syndies with an esword+eshield. 75% chance for another dude with a pistol as well as a 50% for a melee stormtrooper (really just a spaceproof melee syndie with twice the HP).

Keep in mind that these are still simplemobs, which means they're very easy to cheese if you know what you're doing. It's just no longer a completely risk free specops crate + cargo $$$.