### PR TITLE
Fixes templates causing air runtimes.

### DIFF
--- a/code/modules/mapping/map_template.dm
+++ b/code/modules/mapping/map_template.dm
@@ -76,6 +76,11 @@
 	if(T.y+height > world.maxy)
 		return
 
+	//Remove affected turfs from active air processing.
+	if(SSair.initialized)
+		for(var/turf/AF in get_affected_turfs(T,centered))
+			SSair.remove_from_active(AF)
+
 	var/list/bounds = maploader.load_map(file(mappath), T.x, T.y, T.z, cropMap=TRUE, no_changeturf=(SSatoms.initialized == INITIALIZATION_INSSATOMS), placeOnTop=TRUE)
 	if(!bounds)
 		return


### PR DESCRIPTION
Most common with meteor shuttle clipping into centcom.

While maploading delays activation , if open turfs were processing before load they would still be on the list after changing into closed ones.