### PR TITLE
Makes magnetic catch cleaner in game

### DIFF
--- a/code/__DEFINES/components.dm
+++ b/code/__DEFINES/components.dm
@@ -102,7 +102,9 @@
 #define COMSIG_MOVABLE_IMPACT_ZONE "item_impact_zone"				//from base of mob/living/hitby(): (mob/living/target, hit_zone)
 #define COMSIG_MOVABLE_BUCKLE "buckle"								//from base of atom/movable/buckle_mob(): (mob, force)
 #define COMSIG_MOVABLE_UNBUCKLE "unbuckle"							//from base of atom/movable/unbuckle_mob(): (mob, force)
-#define COMSIG_MOVABLE_THROW "movable_throw"					//from base of atom/movable/throw_at(): (datum/thrownthing, spin)
+#define COMSIG_MOVABLE_PRE_THROW "movable_pre_throw"			//from base of atom/movable/throw_at(): (list/args)
+	#define COMPONENT_CANCEL_THROW 1
+#define COMSIG_MOVABLE_POST_THROW "movable_post_throw"			//from base of atom/movable/throw_at(): (datum/thrownthing, spin)
 #define COMSIG_MOVABLE_Z_CHANGED "movable_ztransit" 			//from base of atom/movable/onTransitZ(): (old_z, new_z)
 #define COMSIG_MOVABLE_DISPOSING "movable_disposing"			//called when the movable is added to a disposal holder object for disposal movement: (obj/structure/disposalholder/holder, obj/machinery/disposal/source)
 

--- a/code/datums/components/magnetic_catch.dm
+++ b/code/datums/components/magnetic_catch.dm
@@ -1,23 +1,34 @@
 /datum/component/magnetic_catch/Initialize()
 	if(!isatom(parent))
 		return COMPONENT_INCOMPATIBLE
-	if(ismovableatom(parent))
-		RegisterSignal(parent, COMSIG_MOVABLE_UNCROSS, .proc/uncross_react)
-	else
-		RegisterSignal(parent, COMSIG_ATOM_EXIT, .proc/exit_react)
 	RegisterSignal(parent, COMSIG_PARENT_EXAMINE, .proc/examine)
-
-/datum/component/magnetic_catch/proc/uncross_react(atom/movable/thing)
-	if(!thing.throwing || thing.throwing.thrower)
-		return
-	qdel(thing.throwing)
-	return COMPONENT_MOVABLE_BLOCK_UNCROSS
-
-/datum/component/magnetic_catch/proc/exit_react(atom/movable/thing, atom/newloc)
-	if(!thing.throwing || thing.throwing.thrower)
-		return
-	qdel(thing.throwing)
-	return COMPONENT_ATOM_BLOCK_EXIT
+	if(ismovableatom(parent))
+		RegisterSignal(parent, COMSIG_MOVABLE_CROSSED, .proc/crossed_react)
+		RegisterSignal(parent, COMSIG_MOVABLE_UNCROSSED, .proc/uncrossed_react)
+		for(var/i in get_turf(parent))
+			if(i == parent)
+				continue
+			RegisterSignal(i, COMSIG_MOVABLE_PRE_THROW, .proc/throw_react)
+	else
+		RegisterSignal(parent, COMSIG_ATOM_ENTERED, .proc/entered_react)
+		RegisterSignal(parent, COMSIG_ATOM_EXITED, .proc/exited_react)
+		for(var/i in parent)
+			RegisterSignal(i, COMSIG_MOVABLE_PRE_THROW, .proc/throw_react)
 
 /datum/component/magnetic_catch/proc/examine(mob/user)
 	to_chat(user, "It has been installed with inertia dampening to prevent coffee spills.")
+
+/datum/component/magnetic_catch/proc/crossed_react(atom/movable/thing)
+	RegisterSignal(thing, COMSIG_MOVABLE_PRE_THROW, .proc/throw_react, TRUE)
+
+/datum/component/magnetic_catch/proc/uncrossed_react(atom/movable/thing)
+	UnregisterSignal(thing, COMSIG_MOVABLE_PRE_THROW)
+
+/datum/component/magnetic_catch/proc/entered_react(atom/movable/thing, atom/oldloc)
+	RegisterSignal(thing, COMSIG_MOVABLE_PRE_THROW, .proc/throw_react, TRUE)
+
+/datum/component/magnetic_catch/proc/exited_react(atom/movable/thing, atom/newloc)
+	UnregisterSignal(thing, COMSIG_MOVABLE_PRE_THROW)
+
+/datum/component/magnetic_catch/proc/throw_react(list/arguments)
+	return COMPONENT_CANCEL_THROW

--- a/code/datums/components/storage/storage.dm
+++ b/code/datums/components/storage/storage.dm
@@ -94,7 +94,7 @@
 	RegisterSignal(parent, COMSIG_ITEM_ATTACK_SELF, .proc/attack_self)
 	RegisterSignal(parent, COMSIG_ITEM_PICKUP, .proc/signal_on_pickup)
 
-	RegisterSignal(parent, COMSIG_MOVABLE_THROW, .proc/close_all)
+	RegisterSignal(parent, COMSIG_MOVABLE_POST_THROW, .proc/close_all)
 
 	RegisterSignal(parent, COMSIG_CLICK_ALT, .proc/on_alt_click)
 	RegisterSignal(parent, COMSIG_MOUSEDROP_ONTO, .proc/mousedrop_onto)

--- a/code/game/atoms_movable.dm
+++ b/code/game/atoms_movable.dm
@@ -469,6 +469,9 @@
 	if (!target || speed <= 0)
 		return
 
+	if(SEND_SIGNAL(src, COMSIG_MOVABLE_PRE_THROW, args) & COMPONENT_CANCEL_THROW)
+		return
+
 	if (pulledby)
 		pulledby.stop_pulling()
 
@@ -538,7 +541,7 @@
 	if(spin)
 		SpinAnimation(5, 1)
 
-	SEND_SIGNAL(src, COMSIG_MOVABLE_THROW, TT, spin)
+	SEND_SIGNAL(src, COMSIG_MOVABLE_POST_THROW, TT, spin)
 	SSthrowing.processing[src] = TT
 	if (SSthrowing.state == SS_PAUSED && length(SSthrowing.currentrun))
 		SSthrowing.currentrun[src] = TT


### PR DESCRIPTION
:cl: ninjanomnom
fix: Objects on tables that are thrown by shuttle movement should no longer do a silly spin
/:cl:

Utilizes the new signal refactor to cancel throws before they happen.