### PR TITLE
Gives the L6 SAW a small amount of spread

### DIFF
--- a/code/modules/projectiles/guns/ballistic/automatic.dm
+++ b/code/modules/projectiles/guns/ballistic/automatic.dm
@@ -286,6 +286,7 @@
 	can_suppress = FALSE
 	burst_size = 3
 	fire_delay = 1
+	spread = 7
 	pin = /obj/item/firing_pin/implant/pindicate
 
 /obj/item/gun/ballistic/automatic/l6_saw/unrestricted


### PR DESCRIPTION
:cl: 
tweak: The L6 SAW now has a small amount of spread. It is still accurate within visual range, but it's not as effective at longer ranges.
/:cl:

Kor gave me this idea a while back and I finally got around to PRing it. The complaint this is intended to address is that in many cases with the SAW, someone will be instantly critted from a burst fired at a different target entirely from way beyond visual range, like down a long hallway or something of that sort. 7 spread was intentionally chosen as a result of my testing. The weapon is will still always hit all 3 bullets on a target within visual range. I'm not entirely happy with how random it is, but I think this still addresses the complaint pretty well while not affecting the normal use of the gun. 
