### PR TITLE
Emitters no longer sometimes produce sparks upon firing

### DIFF
--- a/code/modules/power/singularity/emitter.dm
+++ b/code/modules/power/singularity/emitter.dm
@@ -193,8 +193,6 @@
 /obj/machinery/power/emitter/proc/fire_beam(mob/user)
 	var/obj/item/projectile/P = new projectile_type(get_turf(src))
 	playsound(get_turf(src), projectile_sound, 50, TRUE)
-	if(prob(35))
-		sparks.start()
 	P.firer = user ? user : src
 	if(last_projectile_params)
 		P.p_x = last_projectile_params[2]


### PR DESCRIPTION
[Changelogs]: Emitters no longer sometimes produce sparks on firing.

:cl: 
del: Emitters no longer sometimes produce sparks on firing 
/:cl:

[why]: I've noticed a lot that with the fact that sparks heat up the air, it can render the laser room of engineering uninhabitable from the high heat - especially with many/sufficiently upgraded emitters.  I've also noticed this sometimes causing plasma to spontaneously ignite in a few circumstances. 