### PR TITLE
Makes hits from multitools sound as painful as they are.

### DIFF
--- a/code/game/objects/items/devices/multitool.dm
+++ b/code/game/objects/items/devices/multitool.dm
@@ -25,7 +25,6 @@
 	throw_speed = 3
 	materials = list(MAT_METAL=50, MAT_GLASS=20)
 	var/obj/machinery/buffer // simple machine buffer for device linkage
-	hitsound = 'sound/weapons/tap.ogg'
 	toolspeed = 1
 	tool_behaviour = TOOL_MULTITOOL
 	usesound = 'sound/weapons/empty.ogg'


### PR DESCRIPTION
:cl:
tweak: Removed tap.ogg from multitool so getting hit by one sounds as painful as it really is.
/:cl:

Noticed hitting someone with a multitool sounded deceptively harmless, only realizing I was doing damage when I was explicitly told. This should prevent future confusion.