### PR TITLE
Corrects a stat error in the Nuke Ops uplink

### DIFF
--- a/code/modules/uplink/uplink_items.dm
+++ b/code/modules/uplink/uplink_items.dm
@@ -196,7 +196,7 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 /datum/uplink_item/dangerous/smg
 	name = "C-20r Submachine Gun"
 	desc = "A fully-loaded Scarborough Arms bullpup submachine gun. The C-20r fires .45 rounds with a \
-			20-round magazine and is compatible with suppressors."
+			24-round magazine and is compatible with suppressors."
 	item = /obj/item/gun/ballistic/automatic/c20r
 	cost = 10
 	surplus = 40
@@ -496,7 +496,7 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 
 /datum/uplink_item/ammo/smg
 	name = ".45 SMG Magazine"
-	desc = "An additional 20-round .45 magazine suitable for use with the C-20r submachine gun. \
+	desc = "An additional 24-round .45 magazine suitable for use with the C-20r submachine gun. \
 			These bullets pack a lot of punch that can knock most targets down, but do limited overall damage."
 	item = /obj/item/ammo_box/magazine/smgm45
 	cost = 3


### PR DESCRIPTION
:cl:
spellcheck: The Nuke Op uplink no longer lies about how much ammo a C-20r holds.
/:cl:

When this was buffed 2 years ago the person who did it forgot to update the uplink descriptions, so I've done so. Not sure if a changelog would be required for this as it's an incredibly minor change, but I've added it anyway. Also not sure about using the grammar tag, so please tell me if it's wrong to use it for this sort of thing.