### PR TITLE
Adds a new shuttle loan event, tweaks others

### DIFF
--- a/code/game/objects/items/storage/belt.dm
+++ b/code/game/objects/items/storage/belt.dm
@@ -608,6 +608,11 @@
 	icon_state = "fannypack_yellow"
 	item_state = "fannypack_yellow"
 
+/obj/item/storage/belt/fannypack/yellow/bee_terrorist/PopulateContents() //used in the bee terrorist shuttle loan event
+	new /obj/item/grenade/plastic/c4 (src)
+	new /obj/item/reagent_containers/pill/cyanide(src)
+	new /obj/item/grenade/chem_grenade/facid(src)
+
 /obj/item/storage/belt/sabre
 	name = "sabre sheath"
 	desc = "An ornate sheath designed to hold an officer's blade."

--- a/code/modules/events/shuttle_loan.dm
+++ b/code/modules/events/shuttle_loan.dm
@@ -4,6 +4,7 @@
 #define DEPARTMENT_RESUPPLY 4
 #define ANTIDOTE_NEEDED 5
 #define PIZZA_DELIVERY 6
+#define ITS_HIP_TO 7
 
 
 /datum/round_event_control/shuttle_loan
@@ -21,7 +22,7 @@
 	var/thanks_msg = "The cargo shuttle should return in five minutes. Have some supply points for your trouble."
 
 /datum/round_event/shuttle_loan/setup()
-	dispatch_type = pick(HIJACK_SYNDIE, RUSKY_PARTY, SPIDER_GIFT, DEPARTMENT_RESUPPLY, ANTIDOTE_NEEDED, PIZZA_DELIVERY)
+	dispatch_type = pick(HIJACK_SYNDIE, RUSKY_PARTY, SPIDER_GIFT, DEPARTMENT_RESUPPLY, ANTIDOTE_NEEDED, PIZZA_DELIVERY, ITS_HIP_TO)
 
 /datum/round_event/shuttle_loan/announce(fake)
 	SSshuttle.shuttle_loan = src
@@ -38,8 +39,13 @@
 			bonus_points = 0
 		if(ANTIDOTE_NEEDED)
 			priority_announce("Cargo: Your station has been chosen for an epidemiological research project. Send us your cargo shuttle to receive your research samples.", "CentCom Research Initiatives")
-		if (PIZZA_DELIVERY)
-			priority_announce("Cargo: It looks like a neighbouring station accidentally delivered their pizza to you instead", "CentCom Spacepizza Division")
+		if(PIZZA_DELIVERY)
+			priority_announce("Cargo: It looks like a neighbouring station accidentally delivered their pizza to you instead.", "CentCom Spacepizza Division")
+			thanks_msg = "The cargo shuttle should return in 5 minutes."
+			bonus_points = 0
+		if(ITS_HIP_TO)
+			priority_announce("Cargo: One of our freighters carrying a bee shipment has been attacked by eco-terrorists. Can you clean up the mess for us?", "CentCom Janitorial Division")
+			bonus_points = 20000 //Toxin bees can be unbeelievably lethal
 
 /datum/round_event/shuttle_loan/proc/loan_shuttle()
 	priority_announce(thanks_msg, "Cargo shuttle commandeered by CentCom.")
@@ -65,6 +71,8 @@
 			SSshuttle.centcom_message += "Virus samples incoming."
 		if(PIZZA_DELIVERY)
 			SSshuttle.centcom_message += "Pizza delivery for [station_name()]"
+		if(ITS_HIP_TO)
+			SSshuttle.centcom_message += "Biohazard cleanup incoming."
 
 /datum/round_event/shuttle_loan/tick()
 	if(dispatched)
@@ -95,12 +103,12 @@
 				var/datum/supply_pack/pack = SSshuttle.supply_packs[/datum/supply_pack/emergency/specialops]
 				pack.generate(pick_n_take(empty_shuttle_turfs))
 
-				shuttle_spawns.Add(/mob/living/simple_animal/hostile/syndicate)
-				shuttle_spawns.Add(/mob/living/simple_animal/hostile/syndicate)
+				shuttle_spawns.Add(/mob/living/simple_animal/hostile/syndicate/ranged/infiltrator)
+				shuttle_spawns.Add(/mob/living/simple_animal/hostile/syndicate/ranged/infiltrator)
 				if(prob(75))
-					shuttle_spawns.Add(/mob/living/simple_animal/hostile/syndicate)
+					shuttle_spawns.Add(/mob/living/simple_animal/hostile/syndicate/ranged/infiltrator)
 				if(prob(50))
-					shuttle_spawns.Add(/mob/living/simple_animal/hostile/syndicate)
+					shuttle_spawns.Add(/mob/living/simple_animal/hostile/syndicate/ranged/infiltrator)
 
 			if(RUSKY_PARTY)
 				var/datum/supply_pack/pack = SSshuttle.supply_packs[/datum/supply_pack/service/party]
@@ -171,14 +179,42 @@
 					new decal(pick_n_take(empty_shuttle_turfs))
 			if(PIZZA_DELIVERY)
 				shuttle_spawns.Add(/obj/item/pizzabox/margherita)
-				shuttle_spawns.Add(/obj/item/pizzabox/margherita)
+				shuttle_spawns.Add(/obj/item/pizzabox/mushroom)
 				shuttle_spawns.Add(/obj/item/pizzabox/meat)
-				shuttle_spawns.Add(/obj/item/pizzabox/meat)
+				shuttle_spawns.Add(/obj/item/pizzabox/pineapple)
 				shuttle_spawns.Add(/obj/item/pizzabox/vegetable)
 				if(prob(10))
 					shuttle_spawns.Add(/obj/item/pizzabox/bomb)
 				else
 					shuttle_spawns.Add(/obj/item/pizzabox/margherita)
+			
+			if(ITS_HIP_TO)
+				var/datum/supply_pack/pack = SSshuttle.supply_packs[/datum/supply_pack/organic/hydroponics/beekeeping_fullkit]
+				pack.generate(pick_n_take(empty_shuttle_turfs))
+				
+				shuttle_spawns.Add(/obj/effect/mob_spawn/human/corpse/bee_terrorist)
+				shuttle_spawns.Add(/obj/effect/mob_spawn/human/corpse/cargo_tech)
+				shuttle_spawns.Add(/obj/effect/mob_spawn/human/corpse/cargo_tech)
+				shuttle_spawns.Add(/obj/effect/mob_spawn/human/corpse/nanotrasensoldier)
+				shuttle_spawns.Add(/obj/item/gun/ballistic/automatic/pistol/no_mag)
+				shuttle_spawns.Add(/obj/item/gun/ballistic/automatic/pistol/m1911/no_mag)
+				shuttle_spawns.Add(/obj/item/honey_frame)
+				shuttle_spawns.Add(/obj/item/honey_frame)
+				shuttle_spawns.Add(/obj/item/honey_frame)
+				shuttle_spawns.Add(/obj/structure/beebox/unwrenched)
+				shuttle_spawns.Add(/obj/item/queen_bee/bought)
+				shuttle_spawns.Add(/obj/structure/closet/crate/hydroponics)
+			
+				for(var/i in 1 to 8)
+					shuttle_spawns.Add(/mob/living/simple_animal/hostile/poison/bees/toxin)
+
+				for(var/i in 1 to 5)
+					var/decal = pick(/obj/effect/decal/cleanable/blood, /obj/effect/decal/cleanable/insectguts)
+					new decal(pick_n_take(empty_shuttle_turfs))
+
+				for(var/i in 1 to 10)
+					var/casing = /obj/item/ammo_casing/spent
+					new casing(pick_n_take(empty_shuttle_turfs))
 
 		var/false_positive = 0
 		while(shuttle_spawns.len && empty_shuttle_turfs.len)
@@ -196,3 +232,4 @@
 #undef DEPARTMENT_RESUPPLY
 #undef ANTIDOTE_NEEDED
 #undef PIZZA_DELIVERY
+#undef ITS_HIP_TO

--- a/code/modules/mob/living/simple_animal/corpse.dm
+++ b/code/modules/mob/living/simple_animal/corpse.dm
@@ -27,7 +27,6 @@
 	back = /obj/item/storage/backpack
 	id = /obj/item/card/id/syndicate
 
-
 /obj/effect/mob_spawn/human/corpse/syndicatecommando
 	name = "Syndicate Commando"
 	id_job = "Operative"
@@ -204,3 +203,22 @@
 	back = /obj/item/storage/backpack/satchel/med
 	id = /obj/item/card/id
 	glasses = /obj/item/clothing/glasses/hud/health
+
+/obj/effect/mob_spawn/human/corpse/bee_terrorist
+	name = "BLF Operative"
+	outfit = /datum/outfit/bee_terrorist
+	
+/datum/outfit/bee_terrorist
+	uniform = /obj/item/clothing/under/color/yellow
+	suit = /obj/item/clothing/suit/hooded/bee_costume
+	shoes = /obj/item/clothing/shoes/sneakers/yellow
+	gloves = /obj/item/clothing/gloves/color/yellow
+	ears = /obj/item/radio/headset
+	belt = /obj/item/storage/belt/fannypack/yellow/bee_terrorist
+	id = /obj/item/card/id
+	l_pocket = /obj/item/paper/fluff/bee_objectives
+	mask = /obj/item/clothing/mask/rat/bee 
+
+/obj/item/paper/fluff/bee_objectives
+	name = "Objectives of a Bee Liberation Front Operative"
+	info = "<b>Objective #1</b>. Liberate all bees on the NT transport vessel 2416/B. <b>Success!</b>  <br><b>Objective #2</b>. Escape alive. <b>Failed.</b>"

--- a/code/modules/mob/living/simple_animal/hostile/syndicate.dm
+++ b/code/modules/mob/living/simple_animal/hostile/syndicate.dm
@@ -118,8 +118,13 @@
 	projectilesound = 'sound/weapons/gunshot_smg.ogg'
 	loot = list(/obj/effect/gibspawner/human)
 
-/mob/living/simple_animal/hostile/syndicate/ranged/pilot
+/mob/living/simple_animal/hostile/syndicate/ranged/pilot //caravan ambush ruin
 	name = "Syndicate Salvage Pilot"	
+	loot = list(/obj/effect/mob_spawn/human/corpse/syndicatesoldier)
+
+/mob/living/simple_animal/hostile/syndicate/ranged/infiltrator //shuttle loan event
+	rapid = FALSE
+	projectilesound = 'sound/weapons/gunshot_silenced.ogg'
 	loot = list(/obj/effect/mob_spawn/human/corpse/syndicatesoldier)
 
 /mob/living/simple_animal/hostile/syndicate/ranged/space
@@ -142,7 +147,7 @@
 	name = "Syndicate Stormtrooper"
 	maxHealth = 200
 	health = 200
-	casingtype = /obj/item/ammo_casing/shotgun/buckshot
+	casingtype = /obj/item/ammo_casing/shotgun/buckshot //buckshot (up to 72.5 brute) fired in a three-round burst
 	projectilesound = 'sound/weapons/gunshot.ogg'
 	loot = list(/obj/effect/gibspawner/human)
 

--- a/code/modules/projectiles/ammunition/_ammunition.dm
+++ b/code/modules/projectiles/ammunition/_ammunition.dm
@@ -21,6 +21,9 @@
 	var/heavy_metal = TRUE
 	var/harmful = TRUE //pacifism check for boolet, set to FALSE if bullet is non-lethal
 
+/obj/item/ammo_casing/spent
+	name = "spent bullet casing"
+	BB = null
 
 /obj/item/ammo_casing/Initialize()
 	. = ..()
@@ -34,7 +37,7 @@
 /obj/item/ammo_casing/update_icon()
 	..()
 	icon_state = "[initial(icon_state)][BB ? "-live" : ""]"
-	desc = "[initial(desc)][BB ? "" : " This one is spent"]"
+	desc = "[initial(desc)][BB ? "" : " This one is spent."]"
 
 //proc to magically refill a casing with a new projectile
 /obj/item/ammo_casing/proc/newshot() //For energy weapons, syringe gun, shotgun shells and wands (!).

--- a/code/modules/projectiles/guns/ballistic/pistol.dm
+++ b/code/modules/projectiles/guns/ballistic/pistol.dm
@@ -9,6 +9,9 @@
 	fire_delay = 0
 	actions_types = list()
 
+/obj/item/gun/ballistic/automatic/pistol/no_mag
+	spawnwithmagazine = FALSE
+
 /obj/item/gun/ballistic/automatic/pistol/update_icon()
 	..()
 	icon_state = "[initial(icon_state)][chambered ? "" : "-e"][suppressed ? "-suppressed" : ""]"
@@ -25,6 +28,9 @@
 	w_class = WEIGHT_CLASS_NORMAL
 	mag_type = /obj/item/ammo_box/magazine/m45
 	can_suppress = FALSE
+
+/obj/item/gun/ballistic/automatic/pistol/m1911/no_mag
+	spawnwithmagazine = FALSE
 
 /obj/item/gun/ballistic/automatic/pistol/deagle
 	name = "\improper Desert Eagle"


### PR DESCRIPTION
:cl: Denton
add: A new shuttle loan event has been added. Hope you like bees!
tweak: The pizza delivery shuttle loan event now has some of each flavor and no longer pays the station for accepting it.
balance: Syndicate shuttle infiltrators now carry suppressed pistols.
spellcheck: Added a missing period to spent bullet casing and pizza shutte loan text.
/:cl:

I added a new shuttle loan event, where NT asks you to clean up the mess after one of their freighters got hit by eco-terrorists:

![yeet01](https://user-images.githubusercontent.com/32391752/42417728-7759241c-8291-11e8-9685-a274039ebf80.PNG)

![beeeees](https://user-images.githubusercontent.com/32391752/42431447-bcc16636-8345-11e8-81be-27238ef915c8.PNG)

This pays more than regular events since you'll have to deal with a swarm of god damn toxin bees.

Other changes:
- The pizza shuttle loan event contains one of each box type and no longer pays cargo. Getting paid to receive free pizza is a bit odd.
- Mobs in the syndie infiltrator shuttle loan event fire .45 bullets at a very slow rate. Right now they're melee simplemobs without any weapons - really underwhelming considering you get to keep their armor, combat gloves and the specops crate.