### PR TITLE
Fix mood component signal registering

### DIFF
--- a/code/datums/components/mood.dm
+++ b/code/datums/components/mood.dm
@@ -12,8 +12,8 @@
 		return COMPONENT_INCOMPATIBLE
 	START_PROCESSING(SSmood, src)
 	owner = parent
-	RegisterSignal(COMSIG_ADD_MOOD_EVENT, .proc/add_event)
-	RegisterSignal(COMSIG_CLEAR_MOOD_EVENT, .proc/clear_event)
+	RegisterSignal(parent, COMSIG_ADD_MOOD_EVENT, .proc/add_event)
+	RegisterSignal(parent, COMSIG_CLEAR_MOOD_EVENT, .proc/clear_event)
 
 /datum/component/mood/Destroy()
 	STOP_PROCESSING(SSmood, src)


### PR DESCRIPTION
Yeah uh, strings can't host components and these flat out just runtime at roundstart, leading to moods being flat out broken.

:cl: Naksu
code: fixed mood component
/:cl:
