### PR TITLE
Fix Reebe not loading when clockcult is set

### DIFF
--- a/code/controllers/subsystem/mapping.dm
+++ b/code/controllers/subsystem/mapping.dm
@@ -94,7 +94,6 @@ SUBSYSTEM_DEF(mapping)
 	// Set up Z-level transitions.
 	setup_map_transitions()
 	generate_station_area_list()
-	QDEL_NULL(loader)
 	initialize_reserved_level()
 	..()
 


### PR DESCRIPTION
Fixes #38979

```
[2018-07-08 02:11:24.221] runtime error: Cannot execute null.load map().
[2018-07-08 02:11:24.221] proc name: LoadGroup (/datum/controller/subsystem/mapping/proc/LoadGroup)
[2018-07-08 02:11:24.221]   source file: mapping.dm,182
[2018-07-08 02:11:24.221]   usr: null
[2018-07-08 02:11:24.221]   src: Mapping (/datum/controller/subsystem/mapping)
[2018-07-08 02:11:24.221]   call stack:
[2018-07-08 02:11:24.221] Mapping (/datum/controller/subsystem/mapping): LoadGroup(/list (/list), "Reebe", "map_files/generic", /list (/list), null, /list (/list), 1)
[2018-07-08 02:11:24.221] clockwork cult (/datum/game_mode/clockwork_cult): pre setup()
[2018-07-08 02:11:24.221] Ticker (/datum/controller/subsystem/ticker): setup()
[2018-07-08 02:11:24.221] Ticker (/datum/controller/subsystem/ticker): fire(0)
[2018-07-08 02:11:24.221] Ticker (/datum/controller/subsystem/ticker): ignite(0)
[2018-07-08 02:11:24.221] Master (/datum/controller/master): RunQueue()
[2018-07-08 02:11:24.221] Master (/datum/controller/master): Loop()
[2018-07-08 02:11:24.221] Master (/datum/controller/master): StartProcessing(0)
```