### PR TITLE
Fix timer bug

### DIFF
--- a/code/controllers/subsystem/timer.dm
+++ b/code/controllers/subsystem/timer.dm
@@ -1,5 +1,5 @@
 #define BUCKET_LEN (world.fps*1*60) //how many ticks should we keep in the bucket. (1 minutes worth)
-#define BUCKET_POS(timer) ((round((timer.timeToRun - SStimer.head_offset) / world.tick_lag) % BUCKET_LEN) + 1)
+#define BUCKET_POS(timer) ((round((timer.timeToRun - SStimer.head_offset) / world.tick_lag) % BUCKET_LEN)||BUCKET_LEN)
 #define TIMER_MAX (world.time + TICKS2DS(min(BUCKET_LEN-(SStimer.practical_offset-DS2TICKS(world.time - SStimer.head_offset))-1, BUCKET_LEN-1)))
 #define TIMER_ID_MAX (2**24) //max float with integer precision
 


### PR DESCRIPTION
@carbonhell

This was creating an off by one error that would lead timers to get inserted in the wrong position of the bucket, creating a 0.5 delay as well as causing wrap around timers to get inserted into the currently being processed bucket and ran up to 600ds early.

If this happened after the server got 590ds behind on running timers, soundloop datums with a wait of 10ds would insert themselves into the currently being processed bucket thinking it was already cleared, run, then insert themselves into that same bucket, forever and ever.