### PR TITLE
Fixes the active timer count getting out of sync when buckets reset while spent timers were awaiting qdeletion

### DIFF
--- a/code/controllers/subsystem/timer.dm
+++ b/code/controllers/subsystem/timer.dm
@@ -198,6 +198,9 @@ SUBSYSTEM_DEF(timer)
 	bucket_count -= length(spent)
 
 	for (var/spent_timer in spent)
+		if (QDELETED(spent_timer))
+			bucket_count++
+			continue
 		qdel(spent_timer)
 
 	spent.len = 0


### PR DESCRIPTION
This is why it would go into the negatives when the timer bug happened.