### PR TITLE
Gives Inquisition ERT commander a whetstone

### DIFF
--- a/code/game/objects/items/sharpener.dm
+++ b/code/game/objects/items/sharpener.dm
@@ -56,3 +56,8 @@
 	max = 200
 	prefix = "super-sharpened"
 	requires_sharpness = 0
+
+/obj/item/sharpener/inquisition_commander
+	name = "blessed whetstone"
+	increment = 12
+	max = 30

--- a/code/modules/clothing/outfits/ert.dm
+++ b/code/modules/clothing/outfits/ert.dm
@@ -198,7 +198,8 @@
 	suit = /obj/item/clothing/suit/space/hardsuit/ert/paranormal
 	backpack_contents = list(/obj/item/storage/box/engineer=1,
 		/obj/item/clothing/mask/gas/sechailer=1,
-		/obj/item/gun/energy/e_gun=1)
+		/obj/item/gun/energy/e_gun=1,
+		/obj/item/sharpener/inquisition_commander=1)
 
 /datum/outfit/ert/security/inquisitor
 	name = "Inquisition Security"


### PR DESCRIPTION
#38765 reduced the possessed chainsword's force (30->18) to stop Chaplains from abusing it, however it's still used by inquisition ERT commanders. 

This whetstone increases damage by 12, which makes the chainsword as deadly as it used to be.