### PR TITLE
Adds recreational beer nukes to more maps

### DIFF
--- a/_maps/map_files/BoxStation/BoxStation.dmm
+++ b/_maps/map_files/BoxStation/BoxStation.dmm
@@ -53663,6 +53663,10 @@
 /obj/effect/spawner/structure/window,
 /turf/open/floor/plating,
 /area/science/circuit)
+"mdr" = (
+/obj/machinery/nuclearbomb/beer,
+/turf/open/floor/plating,
+/area/maintenance/starboard/fore)
 "mjr" = (
 /obj/machinery/vending/wardrobe/bar_wardrobe,
 /turf/open/floor/wood,
@@ -98154,7 +98158,7 @@ anf
 anf
 apE
 anf
-anf
+mdr
 aCE
 aDZ
 aFu

--- a/_maps/map_files/Deltastation/DeltaStation2.dmm
+++ b/_maps/map_files/Deltastation/DeltaStation2.dmm
@@ -57043,6 +57043,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
+/obj/machinery/nuclearbomb/beer,
 /turf/open/floor/plating,
 /area/maintenance/starboard)
 "cti" = (

--- a/_maps/map_files/PubbyStation/PubbyStation.dmm
+++ b/_maps/map_files/PubbyStation/PubbyStation.dmm
@@ -53232,6 +53232,7 @@
 /obj/machinery/power/terminal{
 	dir = 1
 	},
+/obj/machinery/nuclearbomb/beer,
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
 "uLF" = (


### PR DESCRIPTION
:cl: Denton
add: Box/Delta/Pubbystation: Nuclear explosive-shaped beerkegs have been added to maintenance areas.
/:cl:

The beer nuke functionality added in #38084 is amazing, it's a shame that it's only available on Meta. This PR adds them to maint areas of Box, Delta and Pubby.