### PR TITLE
Unintentional emotes no longer complain while restrained or unconscious

### DIFF
--- a/code/datums/emotes.dm
+++ b/code/datums/emotes.dm
@@ -29,9 +29,9 @@
 	mob_type_blacklist_typecache = typecacheof(mob_type_blacklist_typecache)
 	mob_type_ignore_stat_typecache = typecacheof(mob_type_ignore_stat_typecache)
 
-/datum/emote/proc/run_emote(mob/user, params, type_override)
+/datum/emote/proc/run_emote(mob/user, params, type_override, intentional = FALSE)
 	. = TRUE
-	if(!can_run_emote(user))
+	if(!can_run_emote(user, TRUE, intentional))
 		return FALSE
 	var/msg = select_message_type(user)
 	if(params && message_param)
@@ -94,7 +94,7 @@
 /datum/emote/proc/select_param(mob/user, params)
 	return replacetext(message_param, "%t", params)
 
-/datum/emote/proc/can_run_emote(mob/user, status_check = TRUE)
+/datum/emote/proc/can_run_emote(mob/user, status_check = TRUE, intentional = FALSE)
 	. = TRUE
 	if(!is_type_in_typecache(user, mob_type_allowed_typecache))
 		return FALSE
@@ -102,10 +102,12 @@
 		return FALSE
 	if(status_check && !is_type_in_typecache(user, mob_type_ignore_stat_typecache))
 		if(user.stat > stat_allowed)
-			to_chat(user, "<span class='notice'>You cannot [key] while unconscious.</span>")
+			if(intentional)
+				to_chat(user, "<span class='notice'>You cannot [key] while unconscious.</span>")
 			return FALSE
 		if(restraint_check && (user.restrained() || user.buckled))
-			to_chat(user, "<span class='notice'>You cannot [key] while restrained.</span>")
+			if(intentional)
+				to_chat(user, "<span class='notice'>You cannot [key] while restrained.</span>")
 			return FALSE
 
 	if(isliving(user))

--- a/code/modules/mob/emote.dm
+++ b/code/modules/mob/emote.dm
@@ -1,5 +1,5 @@
 //The code execution of the emote datum is located at code/datums/emotes.dm
-/mob/proc/emote(act, m_type = null, message = null)
+/mob/proc/emote(act, m_type = null, message = null, intentional = FALSE)
 	act = lowertext(act)
 	var/param = message
 	var/custom_param = findchar(act, " ")
@@ -12,7 +12,7 @@
 	if(!E)
 		to_chat(src, "<span class='notice'>Unusable emote '[act]'. Say *help for a list.</span>")
 		return
-	E.run_emote(src, param, m_type)
+	E.run_emote(src, param, m_type, intentional)
 
 /datum/emote/flip
 	key = "flip"

--- a/code/modules/mob/say.dm
+++ b/code/modules/mob/say.dm
@@ -30,7 +30,7 @@
 
 	message = trim(copytext(sanitize(message), 1, MAX_MESSAGE_LEN))
 
-	usr.emote("me",1,message)
+	usr.emote("me",1,message,TRUE)
 
 /mob/proc/say_dead(var/message)
 	var/name = real_name
@@ -81,7 +81,7 @@
 
 /mob/proc/check_emote(message)
 	if(copytext(message, 1, 2) == "*")
-		emote(copytext(message, 2))
+		emote(copytext(message, 2), intentional = TRUE)
 		return 1
 
 /mob/proc/hivecheck()


### PR DESCRIPTION
:cl: XDTM
fix: Automatic emotes no longer spam you saying that you can't perform them while unconscious.
/:cl:

Fixes #34451
Fixes #32617