### PR TITLE
Removes grab-buckle shortcuts from power machinery

### DIFF
--- a/code/modules/power/rtg.dm
+++ b/code/modules/power/rtg.dm
@@ -43,12 +43,6 @@
 		return
 	return ..()
 
-//ATTACK HAND IGNORING PARENT RETURN VALUE
-/obj/machinery/power/rtg/attack_hand(mob/user)
-	if(user.a_intent == INTENT_GRAB && user_buckle_mob(user.pulling, user, check_loc = 0))
-		return
-	. = ..()
-
 /obj/machinery/power/rtg/advanced
 	desc = "An advanced RTG capable of moderating isotope decay, increasing power output but reducing lifetime. It uses plasma-fueled radiation collectors to increase output even further."
 	power_gen = 1250 // 2500 on T1, 10000 on T4.

--- a/code/modules/power/singularity/generator.dm
+++ b/code/modules/power/singularity/generator.dm
@@ -17,12 +17,6 @@
 	var/energy = 0
 	var/creation_type = /obj/singularity
 
-//ATTACK HAND IGNORING PARENT RETURN VALUE
-/obj/machinery/the_singularitygen/attack_hand(mob/user)
-	if(user.a_intent == INTENT_GRAB && user_buckle_mob(user.pulling, user, check_loc = 0))
-		return
-	. = ..()
-
 /obj/machinery/the_singularitygen/attackby(obj/item/W, mob/user, params)
 	if(istype(W, /obj/item/wrench))
 		default_unfasten_wrench(user, W, 0)

--- a/code/modules/power/tesla/coil.dm
+++ b/code/modules/power/tesla/coil.dm
@@ -68,11 +68,6 @@
 
 	return ..()
 
-//ATTACK HAND IGNORING PARENT RETURN VALUE
-/obj/machinery/power/tesla_coil/attack_hand(mob/user)
-	if(user.a_intent == INTENT_GRAB && user_buckle_mob(user.pulling, user, check_loc = 0))
-		return ..()
-
 /obj/machinery/power/tesla_coil/tesla_act(power, tesla_flags, shocked_targets)
 	if(anchored && !panel_open)
 		obj_flags |= BEING_SHOCKED
@@ -173,12 +168,6 @@
 		return
 
 	return ..()
-
-//ATTACK HAND IGNORING PARENT RETURN VALUE
-/obj/machinery/power/grounding_rod/attack_hand(mob/user)
-	if(user.a_intent == INTENT_GRAB && user_buckle_mob(user.pulling, user, check_loc = 0))
-		return
-	. = ..()
 
 /obj/machinery/power/grounding_rod/tesla_act(var/power)
 	if(anchored && !panel_open)


### PR DESCRIPTION
These are just causing issues, and absolutely undiscoverable given nothing else uses this interaction format. You can still buckle fine with drag&drop.