### PR TITLE
Drops DF_USE_TAG in core Destroy.

### DIFF
--- a/code/datums/datum.dm
+++ b/code/datums/datum.dm
@@ -20,6 +20,7 @@
 // Return the appropriate QDEL_HINT; in most cases this is QDEL_HINT_QUEUE.
 /datum/proc/Destroy(force=FALSE, ...)
 	tag = null
+	datum_flags &= ~DF_USE_TAG //In case something tries to REF us
 	weak_reference = null	//ensure prompt GCing of weakref.
 
 	var/list/timers = active_timers


### PR DESCRIPTION
Solves stack traces when something tries to ref it afterwards.

I'm not sure this is a cleanest solution. Is trying to get tagged object in delete queue an issue in itself ?