### PR TITLE
Fix and optimize Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,10 @@
-FROM i386/ubuntu:xenial as build
+FROM tgstation/byond:512.1427 as base
+
+FROM base as rustg
 
 WORKDIR /rust_g
 
-RUN apt-get update && apt-get install -y --no-install-recommends \
+RUN apt-get update && apt-get install -y \
     git \
     libssl-dev \
     ca-certificates \
@@ -19,20 +21,51 @@ RUN git fetch --depth 1 origin $RUST_G_VERSION \
     && git checkout FETCH_HEAD \
     && cargo build --release
 
-FROM tgstation/byond:512.1427
-
-EXPOSE 1337
+FROM base as dm_base
 
 WORKDIR /tgstation
 
+FROM dm_base as build
+
 COPY . .
-
-RUN mkdir data && mkdir -p /root/.byond/bin
-
-VOLUME [ "/tgstation/config", "/tgstation/data" ]
 
 RUN DreamMaker -max_errors 0 tgstation.dme
 
-COPY --from=build /rust_g/target/release/librust_g.so /root/.byond/bin/rust_g
+WORKDIR /deploy
+
+RUN mkdir -p \
+    .git/logs \
+    _maps \
+    config \
+    icons/minimaps \
+    sound/chatter \
+    sound/voice/complionator \
+    sound/instruments \
+    strings \
+    && cp /tgstation/tgstation.dmb /tgstation/tgstation.rsc ./ \
+    && cp -r /tgstation/.git/logs/* .git/logs/ \
+    && cp -r /tgstation/_maps/* _maps/ \
+    && cp -r /tgstation/config/* config/ \
+    && cp /tgstation/icons/default_title.dmi icons/ \
+    && cp -r /tgstation/icons/minimaps/* icons/minimaps/ \
+    && cp -r /tgstation/sound/chatter/* sound/chatter/ \
+    && cp -r /tgstation/sound/voice/complionator/* sound/voice/complionator/ \
+    && cp -r /tgstation/sound/instruments/* sound/instruments/ \
+    && cp -r /tgstation/strings/* strings/
+
+FROM dm_base
+
+EXPOSE 1337
+
+RUN apt-get update && apt-get install -y \
+    mariadb-client \
+    libssl1.0.0 \
+    && rm -rf /var/lib/apt/lists/* \
+    && mkdir -p /root/.byond/bin
+
+COPY --from=rustg /rust_g/target/release/librust_g.so /root/.byond/bin/rust_g
+COPY --from=build /deploy ./
+
+VOLUME [ "/tgstation/config", "/tgstation/data" ]
 
 ENTRYPOINT [ "DreamDaemon", "tgstation.dmb", "-port", "1337", "-trusted", "-close", "-verbose" ]

--- a/code/_globalvars/lists/flavor_misc.dm
+++ b/code/_globalvars/lists/flavor_misc.dm
@@ -105,8 +105,6 @@ GLOBAL_LIST_INIT(TAGGERLOCATIONS, list("Disposals",
 	"Robotics", "HoP Office", "Library", "Chapel", "Theatre",
 	"Bar", "Kitchen", "Hydroponics", "Janitor Closet","Genetics"))
 
-GLOBAL_LIST_INIT(guitar_notes, flist("sound/guitar/"))
-
 GLOBAL_LIST_INIT(station_prefixes, world.file2list("strings/station_prefixes.txt") + "")
 
 GLOBAL_LIST_INIT(station_names, world.file2list("strings/station_names.txt" + ""))

--- a/code/controllers/subsystem/tgui.dm
+++ b/code/controllers/subsystem/tgui.dm
@@ -11,7 +11,7 @@ SUBSYSTEM_DEF(tgui)
 	var/basehtml // The HTML base used for all UIs.
 
 /datum/controller/subsystem/tgui/PreInit()
-	basehtml = file2text("tgui/tgui.html")
+	basehtml = file2text('tgui/tgui.html')
 
 /datum/controller/subsystem/tgui/Shutdown()
 	close_all_uis()

--- a/code/modules/atmospherics/gasmixtures/reactions.dm
+++ b/code/modules/atmospherics/gasmixtures/reactions.dm
@@ -302,7 +302,7 @@
 		if (location) //It's going to happen regardless of whether you want it to or not
 			radiation_pulse(location, radiation_power * 2)
 			explosion(location,0,0,10,power_ratio,TRUE,TRUE)//A decent explosion with a huge shockwave. People WILL know you're doing fusion.
-			playsound(location, "sound/effects/supermatter.ogg", FUSION_VOLUME_SUPER, 0)
+			playsound(location, 'sound/effects/supermatter.ogg', FUSION_VOLUME_SUPER, 0)
 
 	else if (power_ratio > FUSION_HIGH_TIER) //power ratio 20-50; High tier. Fuses into one big atom which then turns to tritium instantly. Very dangerous, but super cool.
 		reaction_energy += gases_fused * FUSION_RELEASE_ENERGY_HIGH * (power_ratio / FUSION_ENERGY_DIVISOR_HIGH)
@@ -313,9 +313,9 @@
 			if(prob(power_ratio)) //You really don't want this to happen.
 				radiation_pulse(location, radiation_power)
 				explosion(location,0,0,3,power_ratio * 0.5,TRUE,TRUE)//A tiny explosion with a large shockwave. People will know you're doing fusion.
-				playsound(location, "sound/effects/supermatter.ogg", FUSION_VOLUME_HIGH, 0)
+				playsound(location, 'sound/effects/supermatter.ogg', FUSION_VOLUME_HIGH, 0)
 			else
-				playsound(location, "sound/effects/phasein.ogg", FUSION_VOLUME_HIGH, 0)
+				playsound(location, 'sound/effects/phasein.ogg', FUSION_VOLUME_HIGH, 0)
 
 	else if (power_ratio > FUSION_MID_TIER) //power_ratio 5 to 20; Mediation is overpowered, fusion reaction starts to break down.
 		reaction_energy += gases_fused * FUSION_RELEASE_ENERGY_MID * (power_ratio / FUSION_ENERGY_DIVISOR_MID)
@@ -327,9 +327,9 @@
 		if (location)
 			if(prob(power_ratio * FUSION_MID_TIER_RAD_PROB_FACTOR)) //Still weak, but don't stand next to it unprotected
 				radiation_pulse(location, radiation_power * 0.5)
-				playsound(location, "sound/effects/supermatter.ogg", FUSION_VOLUME_MID, 0)
+				playsound(location, 'sound/effects/supermatter.ogg', FUSION_VOLUME_MID, 0)
 			else
-				playsound(location, "sound/effects/phasein.ogg", FUSION_VOLUME_MID, 0)
+				playsound(location, 'sound/effects/phasein.ogg', FUSION_VOLUME_MID, 0)
 
 	else //power ratio 0 to 5; Gas power is overpowered. Fusion isn't nearly as powerful.
 		reaction_energy += gases_fused * FUSION_RELEASE_ENERGY_LOW * (power_ratio / FUSION_ENERGY_DIVISOR_LOW)
@@ -341,9 +341,9 @@
 		if (location)
 			if(prob(power_ratio * FUSION_LOW_TIER_RAD_PROB_FACTOR)) //Weak, but still something to look out for
 				radiation_pulse(location, radiation_power * 0.25)
-				playsound(location, "sound/effects/supermatter.ogg", FUSION_VOLUME_LOW, 0)
+				playsound(location, 'sound/effects/supermatter.ogg', FUSION_VOLUME_LOW, 0)
 			else
-				playsound(location, "sound/effects/phasein.ogg", FUSION_VOLUME_LOW, 0)
+				playsound(location, 'sound/effects/phasein.ogg', FUSION_VOLUME_LOW, 0)
 
 	if(reaction_energy > 0)
 		var/new_heat_capacity = air.heat_capacity()

--- a/code/modules/mob/living/simple_animal/hostile/gorilla/emotes.dm
+++ b/code/modules/mob/living/simple_animal/hostile/gorilla/emotes.dm
@@ -7,5 +7,5 @@
 	key_third_person = "oogas"
 	message = "oogas."
 	message_param = "oogas at %t."
-	sound = "sound/creatures/gorilla.ogg"
+	sound = 'sound/creatures/gorilla.ogg'
 

--- a/code/modules/mob/living/simple_animal/hostile/gorilla/gorilla.dm
+++ b/code/modules/mob/living/simple_animal/hostile/gorilla/gorilla.dm
@@ -92,7 +92,7 @@
 
 /mob/living/simple_animal/hostile/gorilla/handle_automated_speech(override)
 	if(speak_chance && (override || prob(speak_chance)))
-		playsound(src, "sound/creatures/gorilla.ogg", 200)
+		playsound(src, 'sound/creatures/gorilla.ogg', 200)
 	..()
 
 /mob/living/simple_animal/hostile/gorilla/can_use_guns(obj/item/G)
@@ -103,6 +103,6 @@
 /mob/living/simple_animal/hostile/gorilla/proc/oogaooga()
 	oogas++
 	if(oogas >= rand(2,6))
-		playsound(src, "sound/creatures/gorilla.ogg", 200)
+		playsound(src, 'sound/creatures/gorilla.ogg', 200)
 		oogas = 0
 

--- a/code/modules/projectiles/guns/ballistic.dm
+++ b/code/modules/projectiles/guns/ballistic.dm
@@ -121,7 +121,7 @@
 		user.put_in_hands(magazine)
 		magazine.update_icon()
 		if(magazine.ammo_count())
-			playsound(src, "sound/weapons/gun_magazine_remove_full.ogg", 70, 1)
+			playsound(src, 'sound/weapons/gun_magazine_remove_full.ogg', 70, 1)
 		else
 			playsound(src, "gun_remove_empty_magazine", 70, 1)
 		magazine = null

--- a/code/modules/reagents/chemistry/machinery/chem_dispenser.dm
+++ b/code/modules/reagents/chemistry/machinery/chem_dispenser.dm
@@ -278,7 +278,7 @@
 						var/chemid = reagent[1]
 						visible_message("<span class='warning'>[src] buzzes.</span>", "<span class='italics'>You hear a faint buzz.</span>")
 						to_chat(usr, "<span class ='danger'>[src] cannot find Chemical ID: <b>[chemid]</b>!</span>")
-						playsound(src, "sound/machines/buzz-two.ogg", 50, 1)
+						playsound(src, 'sound/machines/buzz-two.ogg', 50, 1)
 						return
 				if (resmismatch && alert("[src] is not yet capable of replicating this recipe with the precision it needs, do you want to save it anyway?",, "Yes","No") == "No")
 					return

--- a/code/modules/spells/spell_types/spacetime_distortion.dm
+++ b/code/modules/spells/spell_types/spacetime_distortion.dm
@@ -81,7 +81,6 @@
 
 /obj/effect/cross_action/spacetime_dist/Initialize(mapload)
 	. = ..()
-	sound = "sound/guitar/[safepick(GLOB.guitar_notes)]"
 	dir = pick(GLOB.cardinals)
 
 /obj/effect/cross_action/spacetime_dist/proc/walk_link(atom/movable/AM)


### PR DESCRIPTION
Brings down the layer count and overall images size by removing all build time resources (code/icons/sounds/etc...) and switching to an i386 base image

Old layers:
![untitled](https://user-images.githubusercontent.com/8171642/42464257-87781778-8376-11e8-9eee-392709873ca2.png)

New layers:
![untitled](https://user-images.githubusercontent.com/8171642/42464290-9e4700ea-8376-11e8-9cbf-298b69a3e23f.png)

Savings of around ~100MB

Also removes some unnecessary double quote file usages around the codebase and the broken guitar_notes code

Note for downstreams, when porting this make sure to audit and single quote files that should be and also copy files that can't be into the image. 

A regex to find double quote usages is here:
```
"(icons|sound|code|SQL|tools|interface|tgui|goon|cfg|.git|.github)\/.*"
```

I had tried to switch `tgstation/byond` from ubuntu to alpine for another sick 100MB gain, but BYOND wasn't having the glibc memes