### PR TITLE
Rebalance of L6 SAW ammo choices

### DIFF
--- a/code/modules/projectiles/projectile/bullets/lmg.dm
+++ b/code/modules/projectiles/projectile/bullets/lmg.dm
@@ -40,5 +40,5 @@
 
 /obj/item/projectile/bullet/incendiary/mm195x129
 	name = "1.95x129mm incendiary bullet"
-	damage = 15
+	damage = 20
 	fire_stacks = 3

--- a/code/modules/uplink/uplink_items.dm
+++ b/code/modules/uplink/uplink_items.dm
@@ -531,6 +531,7 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 	desc = "A 50-round magazine of 1.95x129mm ammunition for use in the L6 SAW; equipped with special properties \
 			to puncture even the most durable armor."
 	item = /obj/item/ammo_box/magazine/mm195x129/ap
+	cost = 8
 
 /datum/uplink_item/ammo/machinegun/incen
 	name = "1.95x129mm (Incendiary) Box Magazine"

--- a/code/modules/uplink/uplink_items.dm
+++ b/code/modules/uplink/uplink_items.dm
@@ -531,7 +531,7 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 	desc = "A 50-round magazine of 1.95x129mm ammunition for use in the L6 SAW; equipped with special properties \
 			to puncture even the most durable armor."
 	item = /obj/item/ammo_box/magazine/mm195x129/ap
-	cost = 8
+	cost = 9
 
 /datum/uplink_item/ammo/machinegun/incen
 	name = "1.95x129mm (Incendiary) Box Magazine"


### PR DESCRIPTION
:cl:
balance: L6 SAW AP ammo now costs 9 TC per magazine, up from 6.
balance: L6 SAW incendiary ammo now deals 20 damage per shot, up from 15.
/:cl:

The intent of this change is to make ammo choice with the L6 SAW meaningful. It is not meant to dramatically affect the balance of the SAW as a whole, but rather make all ammo types worth considering as opposed to there being one clear winner.
Using ball ammo as a baseline for what the SAW's expected power is, here is a short overview:

- Incendiary ammo is seriously weak, it takes 2 full bursts with all shots hitting AND 1 shot from another burst or damage from the firestacks to down a completely unarmored target. If anyone has an extinguisher (or if you're fighting in space, very common for ops) this ammo goes from being really niche to worse than a C-20r.
- Hollow point ammo is very powerful against unarmored targets, but pretty much useless versus even normal Security Officer body armor. Considering your regular target (the Captain) and the people who protect them both wear body armor as standard, it's a pretty weird choice. You can manually aim for limbs to dish out some damage, but it's very unreliable.
- AP ammo has zero downsides, and is WAY better against targets wearing body armor compared to ball ammo. For the exact same price, AP is objectively better. The loss of 5 damage is completely irrelevant, as it will still crit through any body armor in the game in 3 hits.

Hollow point ammo was weird enough that I've just left it alone. I don't think adjusting the price or the damage or the armor pen of this ammo would help. Incendiary ammo has gone from 15 damage to 20, which lets it crit if you land 5 shots on an un-armored target. I think it could probably receive some other buff, but I don't want to make it cancer, and what I've done is a big help in turns of killing quickly. AP ammo has gone from 6 TC to 9 TC. The rationale behind this change is that I don't want to seriously affect the maximum killing power of the SAW, but I want to give players a reason to choose types of ammo besides AP. The exact value that I change it to here could be tweaked, but I figured I'd get some feedback first. 

The SAW is a weapon that generates a lot of salt and I've been very careful to avoid making this PR feel like an "i ded plz nerf" PR. Would very much appreciate input on the changes, and what I've intentionally chosen to leave unchanged.