### PR TITLE
Fixes MMIs in borgs dying to ash storms.

### DIFF
--- a/code/datums/weather/weather.dm
+++ b/code/datums/weather/weather.dm
@@ -105,6 +105,10 @@
 	update_areas()
 
 /datum/weather/proc/can_weather_act(mob/living/L) //Can this weather impact a mob?
+	if(ishuman(L))
+		var/mob/living/carbon/human/H = L
+		if(H.get_thermal_protection() >= FIRE_IMMUNITY_SUIT_MAX_TEMP_PROTECT)
+			return FALSE
 	var/turf/mob_turf = get_turf(L)
 	if(mob_turf && !(mob_turf.z in impacted_z_levels))
 		return

--- a/code/datums/weather/weather.dm
+++ b/code/datums/weather/weather.dm
@@ -105,10 +105,6 @@
 	update_areas()
 
 /datum/weather/proc/can_weather_act(mob/living/L) //Can this weather impact a mob?
-	if(ishuman(L))
-		var/mob/living/carbon/human/H = L
-		if(H.get_thermal_protection() >= FIRE_IMMUNITY_SUIT_MAX_TEMP_PROTECT)
-			return FALSE
 	var/turf/mob_turf = get_turf(L)
 	if(mob_turf && !(mob_turf.z in impacted_z_levels))
 		return

--- a/code/datums/weather/weather_types/ash_storm.dm
+++ b/code/datums/weather/weather_types/ash_storm.dm
@@ -75,20 +75,14 @@
 	sound_wi.stop()
 
 /datum/weather/ash_storm/proc/is_ash_immune(atom/L)
-	while (L && !isturf(L))
-		if(ismecha(L)) //Mechs are immune
-			return TRUE
-		if(ishuman(L)) //Are you immune?
-			var/mob/living/carbon/human/H = L
-			var/thermal_protection = H.get_thermal_protection()
-			if(thermal_protection >= FIRE_IMMUNITY_SUIT_MAX_TEMP_PROTECT)
-				return TRUE
-		if(isliving(L))// if we're a non immune mob inside an immune mob we have to reconsider if that mob is immune to protect ourselves
-			var/mob/living/the_mob = L
-			if("ash" in the_mob.weather_immunities)
-				return TRUE
-		L = L.loc //Check parent items immunities (recurses up to the turf)
-	return FALSE //RIP you
+    while(L && !isturf(L))
+        if(isliving(L))
+            if(!can_weather_act(L)) //you're immune to ash-storms, harry!
+                return TRUE
+        if(ismecha(L))
+            return TRUE
+        L = L.loc // Pushing_Upwards.wav
+    return FALSE
 
 /datum/weather/ash_storm/weather_act(mob/living/L)
 	if(is_ash_immune(L))

--- a/code/datums/weather/weather_types/ash_storm.dm
+++ b/code/datums/weather/weather_types/ash_storm.dm
@@ -75,14 +75,20 @@
 	sound_wi.stop()
 
 /datum/weather/ash_storm/proc/is_ash_immune(atom/L)
-    while(L && !isturf(L))
-        if(isliving(L))
-            if(!can_weather_act(L)) //you're immune to ash-storms, harry!
-                return TRUE
-        if(ismecha(L))
-            return TRUE
-        L = L.loc // Pushing_Upwards.wav
-    return FALSE
+	while (L && !isturf(L))
+		if(ismecha(L)) //Mechs are immune
+			return TRUE
+		if(ishuman(L)) //Are you immune?
+			var/mob/living/carbon/human/H = L
+			var/thermal_protection = H.get_thermal_protection()
+			if(thermal_protection >= FIRE_IMMUNITY_SUIT_MAX_TEMP_PROTECT)
+				return TRUE
+		if(isliving(L))// if we're a non immune mob inside an immune mob we have to reconsider if that mob is immune to protect ourselves
+			var/mob/living/the_mob = L
+			if("ash" in the_mob.weather_immunities)
+				return TRUE
+		L = L.loc //Check parent items immunities (recurses up to the turf)
+	return FALSE //RIP you
 
 /datum/weather/ash_storm/weather_act(mob/living/L)
 	if(is_ash_immune(L))

--- a/code/datums/weather/weather_types/ash_storm.dm
+++ b/code/datums/weather/weather_types/ash_storm.dm
@@ -76,7 +76,7 @@
 
 /datum/weather/ash_storm/proc/is_ash_immune(atom/L)
 	while (L && !isturf(L))
-		if(ismecha(L)) //Mechs are immune
+		if(ismecha(L) || istype(L, /mob/living/brain)) //Mechs and brains are immune
 			return TRUE
 		if(ishuman(L)) //Are you immune?
 			var/mob/living/carbon/human/H = L

--- a/code/datums/weather/weather_types/ash_storm.dm
+++ b/code/datums/weather/weather_types/ash_storm.dm
@@ -76,14 +76,18 @@
 
 /datum/weather/ash_storm/proc/is_ash_immune(atom/L)
 	while (L && !isturf(L))
-		if(ismecha(L) || istype(L, /mob/living/brain)) //Mechs and brains are immune
+		if(ismecha(L)) //Mechs are immune
 			return TRUE
 		if(ishuman(L)) //Are you immune?
 			var/mob/living/carbon/human/H = L
 			var/thermal_protection = H.get_thermal_protection()
 			if(thermal_protection >= FIRE_IMMUNITY_SUIT_MAX_TEMP_PROTECT)
 				return TRUE
-		L = L.loc //Matryoshka check
+		if(isliving(L))// if we're a non immune mob inside an immune mob we have to reconsider if that mob is immune to protect ourselves
+			var/mob/living/the_mob = L
+			if("ash" in the_mob.weather_immunities)
+				return TRUE
+		L = L.loc //Check parent items immunities (recurses up to the turf)
 	return FALSE //RIP you
 
 /datum/weather/ash_storm/weather_act(mob/living/L)


### PR DESCRIPTION
Fixes #38713 
Credit is basically Oranges.

:cl: Zxaber
fix: MMI units inside cyborgs are no longer affected by ash storms.
/:cl:

Borgs are supposed to be ash-proof, and they are. Their (organic) MMIs, however, are not, and take burn damage while the borg is in a storm. This does not result is issues until the MMI is removed from the borg, at which point it's basically dead sans being able to talk for about thirty seconds. You cannot place the brain into a new shell at any time until you clone it. 

This fixes that. Thanks to Oranges, normal unborged MMIs (and brains) are still affected by storms. If and when I can figure out the better way to fix this (remaking weather immunity), I'll change it later, but this at least fixes the bug in the meantime.