### PR TITLE
Var menu has a dropdown for granting martial arts.

### DIFF
--- a/code/datums/datumvars.dm
+++ b/code/datums/datumvars.dm
@@ -1007,8 +1007,13 @@
 				to_chat(usr, "This can only be done to instances of type /mob/living/carbon")
 				return
 
-			var/list/arts = subtypesof(/datum/martial_art)
-			var/result = input(usr, "Choose the martial art to teach","JUDO CHOP") as null|anything in arts
+			var/list/artpaths = subtypesof(/datum/martial_art)
+			var/list/artnames = list()
+			for(var/i in artpaths)
+				var/datum/martial_art/M = i
+				artnames[initial(M.name)] = M
+
+			var/result = input(usr, "Choose the martial art to teach","JUDO CHOP") as null|anything in artnames
 			if(!usr)
 				return
 			if(QDELETED(C))
@@ -1016,8 +1021,9 @@
 				return
 
 			if(result)
-				var/datum/martial_art/M = new result
-				M.teach(C)
+				var/chosenart = artnames[result]
+				var/datum/martial_art/MA = new chosenart
+				MA.teach(C)
 
 		else if(href_list["givetrauma"])
 			if(!check_rights(NONE))

--- a/code/datums/datumvars.dm
+++ b/code/datums/datumvars.dm
@@ -1002,7 +1002,7 @@
 			if(!check_rights(NONE))
 				return
 
-			var/mob/living/carbon/C = locate(href_list["givemartialart"]) in GLOB.mob_list
+			var/mob/living/carbon/C = locate(href_list["givemartialart"]) in GLOB.carbon_list
 			if(!istype(C))
 				to_chat(usr, "This can only be done to instances of type /mob/living/carbon")
 				return

--- a/code/datums/datumvars.dm
+++ b/code/datums/datumvars.dm
@@ -998,6 +998,27 @@
 			manipulate_organs(C)
 			href_list["datumrefresh"] = href_list["editorgans"]
 
+		else if(href_list["givemartialart"])
+			if(!check_rights(NONE))
+				return
+
+			var/mob/living/carbon/C = locate(href_list["givemartialart"]) in GLOB.mob_list
+			if(!istype(C))
+				to_chat(usr, "This can only be done to instances of type /mob/living/carbon")
+				return
+
+			var/list/arts = subtypesof(/datum/martial_art)
+			var/result = input(usr, "Choose the martial art to teach","JUDO CHOP") as null|anything in arts
+			if(!usr)
+				return
+			if(QDELETED(C))
+				to_chat(usr, "Mob doesn't exist anymore")
+				return
+
+			if(result)
+				var/datum/martial_art/M = new result
+				M.teach(C)
+
 		else if(href_list["givetrauma"])
 			if(!check_rights(NONE))
 				return

--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -864,6 +864,7 @@
 	.["Modify bodypart"] = "?_src_=vars;[HrefToken()];editbodypart=[REF(src)]"
 	.["Modify organs"] = "?_src_=vars;[HrefToken()];editorgans=[REF(src)]"
 	.["Hallucinate"] = "?_src_=vars;[HrefToken()];hallucinate=[REF(src)]"
+	.["Give martial art"] = "?src=vars;[HrefToken()];givemartialart=[REF(src)]"
 	.["Give brain trauma"] = "?_src_=vars;[HrefToken()];givetrauma=[REF(src)]"
 	.["Cure brain traumas"] = "?_src_=vars;[HrefToken()];curetraumas=[REF(src)]"
 

--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -864,7 +864,7 @@
 	.["Modify bodypart"] = "?_src_=vars;[HrefToken()];editbodypart=[REF(src)]"
 	.["Modify organs"] = "?_src_=vars;[HrefToken()];editorgans=[REF(src)]"
 	.["Hallucinate"] = "?_src_=vars;[HrefToken()];hallucinate=[REF(src)]"
-	.["Give martial art"] = "?src=vars;[HrefToken()];givemartialart=[REF(src)]"
+	.["Give martial arts"] = "?_src_=vars;[HrefToken()];givemartialart=[REF(src)]"
 	.["Give brain trauma"] = "?_src_=vars;[HrefToken()];givetrauma=[REF(src)]"
 	.["Cure brain traumas"] = "?_src_=vars;[HrefToken()];curetraumas=[REF(src)]"
 


### PR DESCRIPTION
I was making a ninjutsu martial art, and I got really pissed that I have to make specific snowflake items whenever I want to test a martial art, so I coded a quick fix for that in the dropdown. Then, I realized that admins have to find these same dumb snowflake art granters and so I decided to quickly make a new branch and pr this.

:cl:
admin: admins, you can now find martial art granting buttons in your VV dropdown.
/:cl:

Why: Way better way of doing martial art TC trades, hopefully saves some time for our admins. Maybe helpful in setting up events.
