### PR TITLE
Fixes porta_turret and decal shuttle rotations

### DIFF
--- a/code/__DEFINES/components.dm
+++ b/code/__DEFINES/components.dm
@@ -60,7 +60,6 @@
 #define COMSIG_ATOM_RCD_ACT "atom_rcd_act"						//from base of atom/rcd_act(): (/mob, /obj/item/construction/rcd, passed_mode)
 #define COMSIG_ATOM_SING_PULL "atom_sing_pull"					//from base of atom/singularity_pull(): (S, current_size)
 #define COMSIG_ATOM_SET_LIGHT "atom_set_light"					//from base of atom/set_light(): (l_range, l_power, l_color)
-#define COMSIG_ATOM_ROTATE "atom_rotate"						//from base of atom/shuttleRotate(): (rotation, params)
 #define COMSIG_ATOM_DIR_CHANGE "atom_dir_change"				//from base of atom/setDir(): (old_dir, new_dir)
 #define COMSIG_ATOM_CONTENTS_DEL "atom_contents_del"			//from base of atom/handle_atom_del(): (atom/deleted)
 #define COMSIG_ATOM_HAS_GRAVITY "atom_has_gravity"				//from base of atom/has_gravity(): (turf/location, list/forced_gravities)

--- a/code/datums/components/README.md
+++ b/code/datums/components/README.md
@@ -115,6 +115,12 @@ Stands have a lot of procs which mimic mob procs. Rather than inserting hooks fo
     * Clears `parent` and removes the component from it's component list
 1. `/datum/component/proc/_JoinParent` (private, final)
     * Tries to add the component to it's `parent`s `datum_components` list
+1. `/datum/component/proc/RegisterWithParent` (abstract, no-sleep)
+    * Used to register the signals that should be on the `parent` object
+    * Use this if you plan on the component transfering between parents
+1. `/datum/component/proc/UnregisterFromParent` (abstract, no-sleep)
+    * Counterpart to `RegisterWithParent()`
+    * Used to unregister the signals that should only be on the `parent` object
 1. `/datum/component/proc/RegisterSignal(datum/target, signal(string/list of strings), proc_ref(type), override(boolean))` (protected, final)
     * If signal is a list it will be as if RegisterSignal was called for each of the entries with the same following arguments
     * Makes a component listen for the specified `signal` on it's `parent` datum.

--- a/code/datums/components/_component.dm
+++ b/code/datums/components/_component.dm
@@ -47,6 +47,12 @@
 		else	//only component of this type, no list
 			dc[I] = src
 
+	RegisterWithParent()
+
+// If you want/expect to be moving the component around between parents, use this to register on the parent for signals
+/datum/component/proc/RegisterWithParent()
+	return
+
 /datum/component/proc/Initialize(...)
 	return
 
@@ -77,6 +83,11 @@
 			dc -= I
 	if(!dc.len)
 		P.datum_components = null
+
+	UnregisterFromParent()
+
+/datum/component/proc/UnregisterFromParent()
+	return
 
 /datum/component/proc/RegisterSignal(datum/target, sig_type_or_types, proc_or_callback, override = FALSE)
 	if(QDELETED(src) || QDELETED(target))

--- a/code/datums/components/decal.dm
+++ b/code/datums/components/decal.dm
@@ -5,19 +5,27 @@
 	var/description
 	var/mutable_appearance/pic
 
+	var/first_dir // This only stores the dir arg from init
+
 /datum/component/decal/Initialize(_icon, _icon_state, _dir, _cleanable=CLEAN_GOD, _color, _layer=TURF_LAYER, _description)
 	if(!isatom(parent) || !generate_appearance(_icon, _icon_state, _dir, _layer, _color))
 		return COMPONENT_INCOMPATIBLE
+	first_dir = _dir
 	description = _description
 	cleanable = _cleanable
-
-	if(_dir) // If no dir is assigned at start then it follows the atom's dir
-		RegisterSignal(parent, COMSIG_ATOM_DIR_CHANGE, .proc/rotate_react)
-	if(_cleanable)
-		RegisterSignal(parent, COMSIG_COMPONENT_CLEAN_ACT, .proc/clean_react)
-	if(_description)
-		RegisterSignal(parent, COMSIG_PARENT_EXAMINE, .proc/examine)
+	
 	apply()
+
+/datum/component/decal/RegisterWithParent()
+	if(first_dir)
+		RegisterSignal(parent, COMSIG_ATOM_DIR_CHANGE, .proc/rotate_react)
+	if(cleanable)
+		RegisterSignal(parent, COMSIG_COMPONENT_CLEAN_ACT, .proc/clean_react)
+	if(description)
+		RegisterSignal(parent, COMSIG_PARENT_EXAMINE, .proc/examine)
+
+/datum/component/decal/UnregisterFromParent()
+	UnregisterSignal(parent, list(COMSIG_ATOM_DIR_CHANGE, COMSIG_COMPONENT_CLEAN_ACT, COMSIG_PARENT_EXAMINE))
 
 /datum/component/decal/Destroy()
 	remove()

--- a/code/game/machinery/porta_turret/portable_turret.dm
+++ b/code/game/machinery/porta_turret/portable_turret.dm
@@ -551,10 +551,6 @@
 	A.fire()
 	return A
 
-/obj/machinery/porta_turret/shuttleRotate(rotation)
-	if(wall_turret_direction)
-		wall_turret_direction = turn(wall_turret_direction,rotation)
-
 /obj/machinery/porta_turret/proc/setState(on, mode)
 	if(controllock)
 		return

--- a/code/modules/shuttle/shuttle_rotate.dm
+++ b/code/modules/shuttle/shuttle_rotate.dm
@@ -25,8 +25,6 @@ If ever any of these procs are useful for non-shuttles, rename it to proc/rotate
 			pixel_x = oldPY
 			pixel_y = (oldPX*(-1))
 
-	SEND_SIGNAL(src, COMSIG_ATOM_ROTATE, rotation, params)
-
 /************************************Turf rotate procs************************************/
 
 /turf/closed/mineral/shuttleRotate(rotation, params)
@@ -111,3 +109,8 @@ If ever any of these procs are useful for non-shuttles, rename it to proc/rotate
 	if(cyclelinkeddir)
 		cyclelinkeddir = angle2dir(rotation+dir2angle(cyclelinkeddir))
 		cyclelinkairlock()
+
+/obj/machinery/porta_turret/shuttleRotate(rotation, params)
+	. = ..()
+	if(wall_turret_direction && (params & ROTATE_DIR))
+		wall_turret_direction = turn(wall_turret_direction,rotation)


### PR DESCRIPTION
:cl: ninjanomnom
fix: Porta turret rotation on shuttles visually would not turn, this has been dealt with.
fix: Decals weren't rotating properly after the recent signal refactor, a couple new procs for dealing with the signals on the parent object have been added to deal with this.
/:cl:

An unused signal in shuttle rotation also got removed as you should just be using the setDir signal.