### PR TITLE
Pirate buffs via changes to pirate_default.dmm

### DIFF
--- a/_maps/shuttles/pirate_default.dmm
+++ b/_maps/shuttles/pirate_default.dmm
@@ -394,6 +394,11 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/item/storage/box/matches,
 /obj/item/clothing/mask/cigarette/cigar,
+/obj/item/reagent_containers/food/drinks/bottle/rum{
+	name = "Captain Pete's Private Reserve Cuban Spaced Rum";
+	pixel_x = -6;
+	pixel_y = 8
+	},
 /turf/open/floor/wood,
 /area/shuttle/pirate)
 "bc" = (
@@ -734,8 +739,15 @@
 	dir = 8;
 	layer = 2.9
 	},
-/obj/item/gun/ballistic/shotgun/automatic/combat,
+/obj/item/gun/ballistic/shotgun/automatic/combat{
+	pixel_x = -2;
+	pixel_y = 2
+	},
 /obj/effect/decal/cleanable/dirt,
+/obj/item/gun/ballistic/automatic/l6_saw/unrestricted{
+	pixel_x = 2;
+	pixel_y = -2
+	},
 /turf/open/floor/pod/light,
 /area/shuttle/pirate/vault)
 "bO" = (
@@ -855,7 +867,8 @@
 /area/shuttle/pirate)
 "bZ" = (
 /obj/structure/closet/crate,
-/obj/effect/decal/cleanable/dirt,
+/obj/item/tank/jetpack/carbondioxide,
+/obj/item/tank/jetpack/carbondioxide,
 /turf/open/floor/pod/light,
 /area/shuttle/pirate/vault)
 "ca" = (
@@ -947,6 +960,15 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
+/obj/item/grenade/plastic/x4{
+	pixel_x = 11
+	},
+/obj/item/grenade/plastic/x4{
+	pixel_x = 11
+	},
+/obj/item/grenade/plastic/x4{
+	pixel_x = 11
+	},
 /turf/open/floor/pod/light,
 /area/shuttle/pirate/vault)
 "ci" = (
@@ -1768,6 +1790,14 @@
 	},
 /turf/closed/wall/mineral/plastitanium/nodiagonal,
 /area/shuttle/pirate)
+"Ny" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/portable_atmospherics/canister/carbon_dioxide,
+/turf/open/floor/plasteel/floorgrime,
+/area/shuttle/pirate)
 
 (1,1,1) = {"
 aa
@@ -1860,7 +1890,7 @@ aj
 aj
 bu
 bI
-bu
+Ny
 aj
 cq
 cA

--- a/_maps/shuttles/pirate_default.dmm
+++ b/_maps/shuttles/pirate_default.dmm
@@ -744,10 +744,6 @@
 	pixel_y = 2
 	},
 /obj/effect/decal/cleanable/dirt,
-/obj/item/gun/ballistic/automatic/l6_saw/unrestricted{
-	pixel_x = 2;
-	pixel_y = -2
-	},
 /turf/open/floor/pod/light,
 /area/shuttle/pirate/vault)
 "bO" = (
@@ -960,15 +956,6 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
-/obj/item/grenade/plastic/x4{
-	pixel_x = 11
-	},
-/obj/item/grenade/plastic/x4{
-	pixel_x = 11
-	},
-/obj/item/grenade/plastic/x4{
-	pixel_x = 11
-	},
 /turf/open/floor/pod/light,
 /area/shuttle/pirate/vault)
 "ci" = (
@@ -1790,14 +1777,6 @@
 	},
 /turf/closed/wall/mineral/plastitanium/nodiagonal,
 /area/shuttle/pirate)
-"Ny" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/portable_atmospherics/canister/carbon_dioxide,
-/turf/open/floor/plasteel/floorgrime,
-/area/shuttle/pirate)
 
 (1,1,1) = {"
 aa
@@ -1890,7 +1869,7 @@ aj
 aj
 bu
 bI
-Ny
+bu
 aj
 cq
 cA


### PR DESCRIPTION
:cl:
balance:  Adds 2 carbon dioxide jetpacks to the pirate ship. Also gives the captain a renamed bottle of rum in his room.
/:cl:

[why]: # Pirates almost never suceed, and they need jetpacks to do their job remotely effectively. They also lack any access, so additional explosives are needed.