### PR TITLE
Replaces most static ingame manuals with wiki versions

### DIFF
--- a/_maps/RandomRuins/LavaRuins/lavaland_biodome_beach.dmm
+++ b/_maps/RandomRuins/LavaRuins/lavaland_biodome_beach.dmm
@@ -163,7 +163,7 @@
 /obj/machinery/light{
 	dir = 1
 	},
-/obj/item/book/manual/barman_recipes,
+/obj/item/book/manual/wiki/barman_recipes,
 /obj/item/book/granter/action/drink_fling,
 /obj/item/reagent_containers/food/drinks/shaker,
 /obj/item/reagent_containers/glass/rag,

--- a/_maps/RandomRuins/LavaRuins/lavaland_surface_golem_ship.dmm
+++ b/_maps/RandomRuins/LavaRuins/lavaland_surface_golem_ship.dmm
@@ -118,7 +118,7 @@
 	pixel_x = 5;
 	pixel_y = 9
 	},
-/obj/item/book/manual/research_and_development{
+/obj/item/book/manual/wiki/research_and_development{
 	name = "Sacred Text of the Liberator";
 	pixel_x = -4;
 	pixel_y = 3

--- a/_maps/RandomRuins/LavaRuins/lavaland_surface_syndicate_base1.dmm
+++ b/_maps/RandomRuins/LavaRuins/lavaland_surface_syndicate_base1.dmm
@@ -3902,7 +3902,7 @@
 	pixel_x = 2;
 	pixel_y = 6
 	},
-/obj/item/book/manual/barman_recipes,
+/obj/item/book/manual/wiki/barman_recipes,
 /obj/item/reagent_containers/food/drinks/shaker,
 /turf/open/floor/wood,
 /area/ruin/unpowered/syndicate_lava_base/bar)

--- a/_maps/RandomRuins/SpaceRuins/spacehotel.dmm
+++ b/_maps/RandomRuins/SpaceRuins/spacehotel.dmm
@@ -1801,7 +1801,7 @@
 /area/ruin/space/has_grav/hotel/bar)
 "fF" = (
 /obj/structure/table,
-/obj/item/book/manual/barman_recipes,
+/obj/item/book/manual/wiki/barman_recipes,
 /obj/item/reagent_containers/food/drinks/shaker,
 /turf/open/floor/plasteel/bar,
 /area/ruin/space/has_grav/hotel/bar)

--- a/_maps/RandomZLevels/beach2.dmm
+++ b/_maps/RandomZLevels/beach2.dmm
@@ -228,7 +228,7 @@
 /area/awaymission/beach)
 "aO" = (
 /obj/structure/table/wood,
-/obj/item/book/manual/barman_recipes,
+/obj/item/book/manual/wiki/barman_recipes,
 /turf/open/floor/wood,
 /area/awaymission/beach)
 "aP" = (

--- a/_maps/RandomZLevels/moonoutpost19.dmm
+++ b/_maps/RandomZLevels/moonoutpost19.dmm
@@ -4454,7 +4454,7 @@
 /area/awaymission/moonoutpost19/arrivals)
 "jc" = (
 /obj/structure/table,
-/obj/item/book/manual/detective,
+/obj/item/book/manual/wiki/detective,
 /turf/open/floor/plasteel/floorgrime{
 	dir = 8;
 	heat_capacity = 1e+006
@@ -4772,7 +4772,7 @@
 /area/awaymission/moonoutpost19/arrivals)
 "jP" = (
 /obj/structure/table,
-/obj/item/book/manual/barman_recipes{
+/obj/item/book/manual/wiki/barman_recipes{
 	pixel_y = 5
 	},
 /obj/item/reagent_containers/food/drinks/shaker,

--- a/_maps/RandomZLevels/undergroundoutpost45.dmm
+++ b/_maps/RandomZLevels/undergroundoutpost45.dmm
@@ -3662,7 +3662,7 @@
 /area/awaymission/undergroundoutpost45/crew_quarters)
 "io" = (
 /obj/structure/table,
-/obj/item/book/manual/barman_recipes,
+/obj/item/book/manual/wiki/barman_recipes,
 /obj/item/reagent_containers/food/drinks/shaker,
 /turf/open/floor/plasteel/bar{
 	heat_capacity = 1e+006

--- a/_maps/RandomZLevels/wildwest.dmm
+++ b/_maps/RandomZLevels/wildwest.dmm
@@ -367,7 +367,7 @@
 /area/awaymission/wildwest/mines)
 "bG" = (
 /obj/structure/table/wood,
-/obj/item/book/manual/barman_recipes,
+/obj/item/book/manual/wiki/barman_recipes,
 /turf/open/floor/wood,
 /area/awaymission/wildwest/mines)
 "bH" = (

--- a/_maps/map_files/BoxStation/BoxStation.dmm
+++ b/_maps/map_files/BoxStation/BoxStation.dmm
@@ -19043,7 +19043,7 @@
 /obj/machinery/computer/security/telescreen/entertainment{
 	pixel_x = 32
 	},
-/obj/item/book/manual/barman_recipes,
+/obj/item/book/manual/wiki/barman_recipes,
 /obj/item/reagent_containers/glass/rag,
 /turf/open/floor/plasteel/bar,
 /area/crew_quarters/bar)
@@ -23391,7 +23391,7 @@
 	req_access_txt = "29"
 	},
 /obj/structure/table,
-/obj/item/book/manual/robotics_cyborgs{
+/obj/item/book/manual/wiki/robotics_cyborgs{
 	pixel_x = 2;
 	pixel_y = 5
 	},
@@ -28761,7 +28761,7 @@
 	pixel_y = 24
 	},
 /obj/structure/table,
-/obj/item/book/manual/medical_cloning{
+/obj/item/book/manual/wiki/medical_cloning{
 	pixel_y = 6
 	},
 /turf/open/floor/plasteel/white,
@@ -29632,7 +29632,7 @@
 "bxq" = (
 /obj/structure/table,
 /obj/item/clipboard,
-/obj/item/book/manual/experimentor,
+/obj/item/book/manual/wiki/experimentor,
 /turf/open/floor/plasteel/white/corner{
 	dir = 4
 	},

--- a/_maps/map_files/Deltastation/DeltaStation2.dmm
+++ b/_maps/map_files/Deltastation/DeltaStation2.dmm
@@ -11743,7 +11743,7 @@
 	pixel_y = 32;
 	receive_ore_updates = 1
 	},
-/obj/item/book/manual/barman_recipes,
+/obj/item/book/manual/wiki/barman_recipes,
 /obj/item/reagent_containers/food/drinks/shaker,
 /obj/item/reagent_containers/glass/rag,
 /turf/open/floor/plasteel/vault{
@@ -52379,7 +52379,6 @@
 	pixel_x = 3;
 	pixel_y = 3
 	},
-/obj/item/book/manual/engineering_particle_accelerator,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/delivery,
 /turf/open/floor/plasteel,
@@ -52394,7 +52393,7 @@
 	pixel_x = 3;
 	pixel_y = 3
 	},
-/obj/item/book/manual/engineering_singularity_safety,
+/obj/item/book/manual/wiki/engineering_singulo_tesla,
 /obj/effect/turf_decal/delivery,
 /turf/open/floor/plasteel,
 /area/engine/engineering)
@@ -78978,7 +78977,7 @@
 	pixel_y = 24
 	},
 /obj/item/folder/white,
-/obj/item/book/manual/medical_cloning,
+/obj/item/book/manual/wiki/medical_cloning,
 /turf/open/floor/plasteel/whiteblue/corner{
 	dir = 4
 	},
@@ -80301,7 +80300,7 @@
 /area/science/explab)
 "dqn" = (
 /obj/structure/table/reinforced,
-/obj/item/book/manual/experimentor,
+/obj/item/book/manual/wiki/experimentor,
 /obj/item/healthanalyzer,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
@@ -82010,7 +82009,7 @@
 /area/science/research/abandoned)
 "duq" = (
 /obj/structure/rack,
-/obj/item/book/manual/robotics_cyborgs,
+/obj/item/book/manual/wiki/robotics_cyborgs,
 /obj/item/storage/belt/utility,
 /obj/item/reagent_containers/glass/beaker/large,
 /obj/effect/decal/cleanable/dirt,
@@ -84542,7 +84541,7 @@
 /area/science/robotics/lab)
 "dzI" = (
 /obj/structure/rack,
-/obj/item/book/manual/robotics_cyborgs,
+/obj/item/book/manual/wiki/robotics_cyborgs,
 /obj/item/storage/belt/utility/full,
 /obj/machinery/light{
 	dir = 1
@@ -87275,7 +87274,7 @@
 	pixel_x = 3;
 	pixel_y = 3
 	},
-/obj/item/book/manual/detective,
+/obj/item/book/manual/wiki/detective,
 /obj/item/camera/detective,
 /turf/open/floor/plasteel/vault{
 	dir = 5

--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -35211,7 +35211,7 @@
 	receive_ore_updates = 1
 	},
 /obj/structure/table,
-/obj/item/book/manual/barman_recipes{
+/obj/item/book/manual/wiki/barman_recipes{
 	pixel_y = 5
 	},
 /obj/item/reagent_containers/food/drinks/shaker,
@@ -54633,7 +54633,7 @@
 "cmU" = (
 /obj/structure/table/reinforced,
 /obj/item/clipboard,
-/obj/item/book/manual/experimentor,
+/obj/item/book/manual/wiki/experimentor,
 /obj/effect/turf_decal/stripes/line{
 	dir = 2
 	},
@@ -61123,7 +61123,7 @@
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/aft)
 "czX" = (
-/obj/item/book/manual/medical_cloning{
+/obj/item/book/manual/wiki/medical_cloning{
 	pixel_y = 6
 	},
 /obj/item/paper,
@@ -62665,7 +62665,7 @@
 	pixel_y = 32
 	},
 /obj/structure/rack,
-/obj/item/book/manual/robotics_cyborgs{
+/obj/item/book/manual/wiki/robotics_cyborgs{
 	pixel_x = 2;
 	pixel_y = 5
 	},

--- a/_maps/map_files/OmegaStation/OmegaStation.dmm
+++ b/_maps/map_files/OmegaStation/OmegaStation.dmm
@@ -11553,7 +11553,7 @@
 /area/crew_quarters/bar/atrium)
 "awZ" = (
 /obj/structure/table/wood,
-/obj/item/book/manual/barman_recipes,
+/obj/item/book/manual/wiki/barman_recipes,
 /obj/item/reagent_containers/food/drinks/shaker,
 /obj/item/reagent_containers/glass/rag,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -20254,7 +20254,7 @@
 	pixel_x = 3;
 	pixel_y = 3
 	},
-/obj/item/book/manual/detective,
+/obj/item/book/manual/wiki/detective,
 /obj/item/camera/detective,
 /turf/open/floor/plasteel/vault{
 	dir = 5
@@ -24559,7 +24559,7 @@
 /area/science/robotics/lab)
 "bad" = (
 /obj/structure/rack,
-/obj/item/book/manual/robotics_cyborgs,
+/obj/item/book/manual/wiki/robotics_cyborgs,
 /obj/item/storage/belt/utility/full,
 /obj/item/circuitboard/mecha/ripley/main,
 /obj/item/circuitboard/mecha/ripley/peripherals,

--- a/_maps/map_files/PubbyStation/PubbyStation.dmm
+++ b/_maps/map_files/PubbyStation/PubbyStation.dmm
@@ -19179,7 +19179,7 @@
 /area/crew_quarters/bar)
 "aYf" = (
 /obj/structure/table/reinforced,
-/obj/item/book/manual/barman_recipes,
+/obj/item/book/manual/wiki/barman_recipes,
 /obj/item/reagent_containers/glass/rag,
 /turf/open/floor/plasteel/darkred/side{
 	dir = 1
@@ -24218,7 +24218,7 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/item/book/manual/experimentor,
+/obj/item/book/manual/wiki/experimentor,
 /turf/open/floor/engine,
 /area/science/explab)
 "blT" = (
@@ -25817,7 +25817,7 @@
 /area/hallway/primary/aft)
 "bqg" = (
 /obj/structure/table,
-/obj/item/book/manual/robotics_cyborgs{
+/obj/item/book/manual/wiki/robotics_cyborgs{
 	pixel_x = 2;
 	pixel_y = 5
 	},
@@ -27354,7 +27354,7 @@
 /area/medical/genetics)
 "btX" = (
 /obj/structure/table,
-/obj/item/book/manual/medical_cloning{
+/obj/item/book/manual/wiki/medical_cloning{
 	pixel_y = 6
 	},
 /obj/structure/disposalpipe/segment,
@@ -28477,7 +28477,7 @@
 /obj/structure/extinguisher_cabinet{
 	pixel_x = -24
 	},
-/obj/item/book/manual/research_and_development,
+/obj/item/book/manual/wiki/research_and_development,
 /obj/item/disk/tech_disk,
 /obj/item/disk/design_disk,
 /turf/open/floor/plasteel/dark,
@@ -40770,15 +40770,11 @@
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "cbg" = (
-/obj/item/book/manual/engineering_singularity_safety{
+/obj/item/book/manual/wiki/engineering_singulo_tesla{
 	pixel_x = 3;
 	pixel_y = 3
 	},
 /obj/item/book/manual/wiki/engineering_guide,
-/obj/item/book/manual/engineering_particle_accelerator{
-	pixel_x = -3;
-	pixel_y = -3
-	},
 /obj/structure/table/glass,
 /turf/open/floor/plasteel,
 /area/engine/engineering)

--- a/_maps/map_files/generic/CentCom.dmm
+++ b/_maps/map_files/generic/CentCom.dmm
@@ -353,7 +353,7 @@
 /area/holodeck/rec_center/lounge)
 "bf" = (
 /obj/structure/table/wood,
-/obj/item/book/manual/barman_recipes,
+/obj/item/book/manual/wiki/barman_recipes,
 /obj/item/clothing/mask/cigarette/pipe,
 /turf/open/floor/holofloor/carpet,
 /area/holodeck/rec_center/lounge)
@@ -12069,7 +12069,7 @@
 /area/tdome/tdomeobserve)
 "Iq" = (
 /obj/structure/table/wood,
-/obj/item/book/manual/barman_recipes,
+/obj/item/book/manual/wiki/barman_recipes,
 /obj/item/reagent_containers/food/drinks/shaker,
 /obj/item/reagent_containers/glass/rag,
 /obj/machinery/newscaster{
@@ -14245,7 +14245,7 @@
 "YJ" = (
 /obj/item/reagent_containers/food/condiment/enzyme,
 /obj/item/reagent_containers/food/drinks/shaker,
-/obj/item/book/manual/barman_recipes,
+/obj/item/book/manual/wiki/barman_recipes,
 /obj/item/book/granter/action/drink_fling,
 /obj/structure/closet/crate,
 /turf/open/floor/plasteel/cafeteria,

--- a/_maps/shuttles/pirate_default.dmm
+++ b/_maps/shuttles/pirate_default.dmm
@@ -1256,7 +1256,7 @@
 /area/shuttle/pirate)
 "cQ" = (
 /obj/structure/table/reinforced,
-/obj/item/book/manual/barman_recipes{
+/obj/item/book/manual/wiki/barman_recipes{
 	pixel_x = -4
 	},
 /obj/effect/decal/cleanable/dirt,

--- a/code/game/objects/items/gift.dm
+++ b/code/game/objects/items/gift.dm
@@ -56,7 +56,7 @@ GLOBAL_LIST_EMPTY(possible_gifts)
 		/obj/item/grown/corncob,
 		/obj/item/poster/random_contraband,
 		/obj/item/poster/random_official,
-		/obj/item/book/manual/barman_recipes,
+		/obj/item/book/manual/wiki/barman_recipes,
 		/obj/item/book/manual/chef_recipes,
 		/obj/item/bikehorn,
 		/obj/item/toy/beach_ball,

--- a/code/game/objects/items/manuals.dm
+++ b/code/game/objects/items/manuals.dm
@@ -4,102 +4,14 @@
 /obj/item/book/manual
 	icon = 'icons/obj/library.dmi'
 	due_date = 0 // Game time in 1/10th seconds
-	unique = 1   // 0 - Normal book, 1 - Should not be treated as normal book, unable to be copied, unable to be modified
-
-/obj/item/book/manual/engineering_particle_accelerator
-	name = "Particle Accelerator User's Guide"
-	icon_state ="bookParticleAccelerator"
-	author = "Engineering Encyclopedia"		  // Whoever wrote the paper or book, can be changed by pen or PC. It is not automatically assigned.
-	title = "Particle Accelerator User's Guide"
-//book contents below
-
-	dat = {"<html>
-				<head>
-				<style>
-				h1 {font-size: 18px; margin: 15px 0px 5px;}
-				h2 {font-size: 15px; margin: 15px 0px 5px;}
-				li {margin: 2px 0px 2px 15px;}
-				ul {list-style: none; margin: 5px; padding: 0px;}
-				ol {margin: 5px; padding: 0px 15px;}
-				</style>
-				</head>
-				<body>
-
-				<h3>Experienced user's guide</h3>
-
-				<h4>Setting up</h4>
-
-				<ol>
-					<li><b>Wrench</b> all pieces to the floor</li>
-					<li>Add <b>wires</b> to all the pieces</li>
-					<li>Close all the panels with your <b>screwdriver</b></li>
-				</ol>
-
-				<h4>Use</h4>
-
-				<ol>
-					<li>Open the control panel</li>
-					<li>Set the speed to 2</li>
-					<li>Start firing at the singularity generator</li>
-					<li><font color='red'><b>When the singularity reaches a large enough size so it starts moving on its own set the speed down to 0, but don't shut it off</b></font></li>
-					<li>Remember to wear a radiation suit when working with this machine... we did tell you that at the start, right?</li>
-				</ol>
-
-				</body>
-				</html>"}
-
-
-/obj/item/book/manual/engineering_singularity_safety
-	name = "Singularity Safety in Special Circumstances"
-	icon_state ="bookEngineeringSingularitySafety"
-	author = "Engineering Encyclopedia"
-	title = "Singularity Safety in Special Circumstances"
-	dat = {"<html>
-				<head>
-				<style>
-				h1 {font-size: 18px; margin: 15px 0px 5px;}
-				h2 {font-size: 15px; margin: 15px 0px 5px;}
-				li {margin: 2px 0px 2px 15px;}
-				ul {list-style: none; margin: 5px; padding: 0px;}
-				ol {margin: 5px; padding: 0px 15px;}
-				</style>
-				</head>
-				<body>
-				<h3>Singularity Safety in Special Circumstances</h3>
-
-				<h4>Power outage</h4>
-
-				A power problem has made the entire station lose power? Could be station-wide wiring problems or syndicate power sinks. In any case follow these steps:
-				<p>
-				<b>Step one:</b> <b><font color='red'>PANIC!</font></b><br>
-				<b>Step two:</b> Get your ass over to engineering! <b>QUICKLY!!!</b><br>
-				<b>Step three:</b> Make sure the SMES is still powering the emitters, if not, setup the generator in secure storage and disconnect the emitters from the SMES.<br>
-				<b>Step four:</b> Next, head over to the APC and swipe it with your <b>ID card</b> - if it doesn't unlock, continue with step 15.<br>
-				<b>Step five:</b> Open the console and disengage the cover lock.<br>
-				<b>Step six:</b> Pry open the APC with a <b>Crowbar.</b><br>
-				<b>Step seven:</b> Take out the empty <b>power cell.</b><br>
-				<b>Step eight:</b> Put in the new, <b>full power cell</b> - if you don't have one, continue with step 15.<br>
-				<b>Step nine:</b> Quickly put on a <b>Radiation suit.</b><br>
-				<b>Step ten:</b> Check if the <b>singularity field generators</b> withstood the down-time - if they didn't, continue with step 15.<br>
-				<b>Step eleven:</b> Since disaster was averted you now have to ensure it doesn't repeat. If it was a powersink which caused it and if the engineering apc is wired to the same powernet, which the powersink is on, you have to remove the piece of wire which links the apc to the powernet. If it wasn't a powersink which caused it, then skip to step 14.<br>
-				<b>Step twelve:</b> Grab your crowbar and pry away the tile closest to the APC.<br>
-				<b>Step thirteen:</b> Use the wirecutters to cut the wire which is conecting the grid to the terminal. <br>
-				<b>Step fourteen:</b> Go to the bar and tell the guys how you saved them all. Stop reading this guide here.<br>
-				<b>Step fifteen:</b> <b>GET THE FUCK OUT OF THERE!!!</b><br>
-				</p>
-
-				<h4>Shields get damaged</h4>
-
-				Step one: <b>GET THE FUCK OUT OF THERE!!! FORGET THE WOMEN AND CHILDREN, SAVE YOURSELF!!!</b><br>
-				</body>
-				</html>
-				"}
+	unique = TRUE   // FALSE - Normal book, TRUE - Should not be treated as normal book, unable to be copied, unable to be modified
 
 /obj/item/book/manual/hydroponics_pod_people
 	name = "The Human Harvest - From seed to market"
 	icon_state ="bookHydroponicsPodPeople"
-	author = "Farmer John"
+	author = "Farmer John" // Whoever wrote the paper or book, can be changed by pen or PC. It is not automatically assigned.
 	title = "The Human Harvest - From seed to market"
+	//book contents below
 	dat = {"<html>
 				<head>
 				<style>
@@ -125,86 +37,10 @@
 				</ol>
 				<p>
 				It really is that easy! Good luck!
-
+	
 				</body>
 				</html>
 				"}
-
-/obj/item/book/manual/medical_cloning
-	name = "Cloning techniques of the 26th century"
-	icon_state ="bookCloning"
-	author = "Medical Journal, volume 3"
-	title = "Cloning techniques of the 26th century"
-	dat = {"<html>
-				<head>
-				<style>
-				h1 {font-size: 18px; margin: 15px 0px 5px;}
-				h2 {font-size: 15px; margin: 15px 0px 5px;}
-				li {margin: 2px 0px 2px 15px;}
-				ul {list-style: none; margin: 5px; padding: 0px;}
-				ol {margin: 5px; padding: 0px 15px;}
-				</style>
-				</head>
-				<body>
-
-				<H3>How to Clone People</H3>
-				So there's fifty dead people lying on the floor, chairs are spinning like no tomorrow and you haven't the foggiest idea of what to do? Not to worry! This guide is intended to teach you how to clone people and how to do it right, in a simple step-by-step process! If at any point of the guide you have a mental meltdown, genetics probably isn't for you and you should get a job-change as soon as possible before you're sued for malpractice.
-
-				<ol>
-					<li><a href='#1'>Acquire body/head/brain</a></li>
-					<li><a href='#2'>Put body/head/brain in cloning machine</a></li>
-					<li><a href='#3'>Scan body/head/brain</a></li>
-					<li><a href='#4'>Clone body/head/brain</a></li>
-					<li><a href='#5'>Get Mannitol, Mutadone, or a clean SE for the clone</a></li>
-					<li><a href='#6'>Put remains in morgue</a></li>
-					<li><a href='#7'>Await cloned body</a></li>
-					<li><a href='#8'>Give the clone Mannitol and Mutadone, or a clean SE</a></li>
-					<li><a href='#9'>Give person clothes back</a></li>
-					<li><a href='#10'>Place clone in cryo</a></li>
-					<li><a href='#11'>Send person on their way</a></li>
-				</ol>
-
-				<a name='1'><H4>Step 1: Acquire a body, head, or brain</H4>
-				This is pretty much vital for the process because without a body, you cannot clone it. Usually, bodies will be brought to you, so you do not need to worry so much about this step. If you already have a body, head, or even a brain, great! Move on to the next step.
-
-				<a name='2'><H4>Step 2: Put the body/head/brain in cloning machine</H4>
-				Grab the body, head, or brain and then put it inside the DNA modifier.
-
-				<a name='3'><H4>Step 3: Scan the body/head/brain</H4>
-				Go onto the computer and scan the body by pressing 'Scan - <Subject Name Here>'. If you're successful, they will be added to the records (note that this can be done at any time, even with living people, so that they can be cloned without a body in the event that they are lying dead on port solars and didn't turn on their suit sensors As an added bonus, they have a health monitoring implant, which'll allow you to check their vitals from their record in the cloning console)! If not, and it says 'Error: Mental interface failure.', then they have left their bodily confines and are one with the spirits. If this happens, just shout at them to get back in their body, click 'Refresh' and try scanning them again. If there's no success, threaten them with gibbing. Still no success? Skip over to Step 7 and don't continue after it, as you have an unresponsive body and it cannot be cloned. If you got 'Error: Unable to locate valid genetic data', you are trying to clone a monkey - start over.
-
-				<a name='4'><H4>Step 4: Clone the body/head/brain</H4>
-				Now that the body has a record, click 'View Records', click the subject's name, and then click 'Clone' to start the cloning process. Congratulations! You're halfway there. Remember not to 'Eject' the cloning pod as this will kill the developing clone and you'll have to start the process again.
-
-				<a name='5'><H4>Step 5: Get Mannitol, Mutadone, or a clean SE for the clone</H4>
-				Cloning is a finicky and unreliable process. Whilst it will most certainly bring someone back from the dead, they can have any number of nasty disabilities given to them during the cloning process! For this reason, you need Mutadone, or a clean, defect-free Structural Enzyme (SE) injection for when they're done. If you're a competent Geneticist, you will already have one ready on your working computer. If, for any reason, you do not, then eject the body from the DNA modifier (NOT THE CLONING POD) and take it next door to the Genetics research room. Put the body in one of those DNA modifiers and then go onto the console. Go into View/Edit/Transfer Buffer, find an open slot and click 'SE' to save it. Then click 'Injector' to get the SEs in syringe form. Put this in your pocket or something for when the body is done. Do note, most Genetic labs have Mannitol and Mutadone pills readily available, provided no-one has stolen them or ate them all. Don't forget most clones will also have severe brain damage as well, to fix this, give them a Mannitol pill or injection.
-
-				<a name='6'><H4>Step 6: Put remains in morgue</H4>
-				Now that the cloning process has been initiated and you hopefully have some Mannitol, Mutadone, and a clean Structural Enzymes, you no longer need the body! Drag it to the morgue and tell the Chef over the radio that they have some fresh meat waiting for them in there, or call the Chaplain so they can prepare an impromptu funeral. To put a body in a morgue bed, simply open the tray, grab the body, put it on the open tray, then close the tray again. Use a pen to label the morgue tray 'CHEF MEAT' or 'CLONED' in order to avoid confusion.
-
-				<a name='7'><H4>Step 7: Await cloned body</H4>
-				Now go back to the lab and wait for your patient to be cloned. This can take atleast three minutes at the least.
-
-				<a name='8'><H4>Step 8: Give the clone Mannitol and Mutadone, or a clean SE</H4>
-				Has your patient been cloned yet? Great! As soon as the clone pops out, administer Mannitol and Mutadone. Then move onto the next step. In the event you have no Mutadone, a clean SE will suffice, but keep in mind this may irradiate the patient, causing more problems!
-
-				<a name='9'><H4>Step 9: Give person their clothes back</H4>
-				Obviously the person will be naked after they have been cloned. Provided you weren't an irresponsible little shit, you should have protected their possessions from thieves and should be able to give them back to the patient. No matter how cruel you are, it's simply against protocol to force your patients to walk outside naked.
-
-				<a name='10'><H4>Step 10: Place clone in cryo</H4>
-				An unfortunate problem with speedcloning technology is that the clone will suffer from severe genetic degradation upon exiting the pod. To rectify this, ensure the nearby cryogenic cells are 1.) at freezing temperatures (normally around 73.15 K), and 2.) filled with cryoxadone, or clonexadone. Once you've assured both conditions are met, place the clone in the cryogenic tube, and turn it on. Remember to set the door to 'Auto' ejection, else the clone will be stuck in cryo until someone releases them. You can also kill two birds with one stone and add Mannitol and Mutadone to the beaker, which'll heal the brain damage, along with removing any genetic defects.
-
-				<a name='11'><H4>Step 11: Send person on their way</H4>
-				Give the patient one last check-over - make sure they don't still have any defects and that they have all their possessions. Ask them how they died, if they know, so that you can report any foul play over the radio. Once you're done, your patient is ready to go back to work! Chances are they do not have Medbay access, so you should let them out of Genetics and the Medbay main entrance.
-
-				<p>If you've gotten this far, congratulations! You have mastered the art of cloning. Now, the real problem is how to resurrect yourself after that traitor had his way with you for cloning his target.
-
-
-
-				</body>
-				</html>
-				"}
-
 
 /obj/item/book/manual/ripley_build_and_repair
 	name = "APLU \"Ripley\" Construction and Operation Manual"
@@ -276,383 +112,8 @@
 				</html>
 
 				<h2>Operation</h2>
-				Coming soon...
+				Please consult the Nanotrasen compendium "Robotics for Dummies".
 			"}
-
-/obj/item/book/manual/experimentor
-	name = "Mentoring your Experiments"
-	icon_state = "rdbook"
-	author = "Dr. H.P. Kritz"
-	title = "Mentoring your Experiments"
-	dat = {"<html>
-		<head>
-		<style>
-		h1 {font-size: 18px; margin: 15px 0px 5px;}
-		h2 {font-size: 15px; margin: 15px 0px 5px;}
-		li {margin: 2px 0px 2px 15px;}
-		ul {list-style: none; margin: 5px; padding: 0px;}
-		ol {margin: 5px; padding: 0px 15px;}
-		</style>
-		</head>
-		<body>
-		<h1>THE E.X.P.E.R.I-MENTOR</h1>
-		The Enhanced Xenobiological Period Extraction (and) Restoration Instructor is a machine designed to discover the secrets behind every item in existence.
-		With advanced technology, it can process 99.95% of items, and discover their uses and secrets.
-		The E.X.P.E.R.I-MENTOR is a Research apparatus that takes items, and through a process of elimination, it allows you to deduce new technological designs from them.
-		Due to the volatile nature of the E.X.P.E.R.I-MENTOR, there is a slight chance for malfunction, potentially causing irreparable damage to you or your environment.
-		However, upgrading the apparatus has proven to decrease the chances of undesirable, potentially life-threatening outcomes.
-		Please note that the E.X.P.E.R.I-MENTOR uses a state-of-the-art random generator, which has a larger entropy than the observable universe,
-		therefore it can generate wildly different results each day, therefore it is highly suggested to re-scan objects of interests frequently (e.g. each shift).
-
-		<h2>BASIC PROCESS</h2>
-		The usage of the E.X.P.E.R.I-MENTOR is quite simple:
-		<ol>
-			<li>Find an item with a technological background</li>
-			<li>Insert the item into the E.X.P.E.R.I-MENTOR</li>
-			<li>Cycle through each processing method of the device.</li>
-			<li>Stand back, even in case of a successful experiment, as the machine might produce undesired behaviour.</li>
-		</ol>
-
-		<h2>ADVANCED USAGE</h2>
-		The E.X.P.E.R.I-MENTOR has a variety of uses, beyond menial research work. The different results can be used to combat localised events, or even to get special items.
-
-		The E.X.P.E.R.I-MENTOR's OBLITERATE function has the added use of transferring the destroyed item's material into a linked lathe.
-
-		The IRRADIATE function can be used to transform items into other items, resulting in potential upgrades (or downgrades).
-
-		Users should remember to always wear appropriate protection when using the machine, because malfunction can occur at any moment!
-
-		<h1>EVENTS</h1>
-		<h2>GLOBAL (happens at any time):</h2>
-			<ol>
-			<li>DETECTION MALFUNCTION - The machine's onboard sensors have malfunctioned, causing it to redefine the item's experiment type.
-			Produces the message: The E.X.P.E.R.I-MENTOR's onboard detection system has malfunctioned!</li>
-
-			<li>IANIZATION - The machine's onboard corgi-filter has malfunctioned, causing it to produce a corgi from.. somewhere.
-			Produces the message: The E.X.P.E.R.I-MENTOR melts the banana, ian-izing the air around it!</li>
-
-			<li>RUNTIME ERROR - The machine's onboard C4T-P processor has encountered a critical error, causing it to produce a cat from.. somewhere.
-			Produces the message: The E.X.P.E.R.I-MENTOR encounters a run-time error!</li>
-
-			<li>B100DG0D.EXE - The machine has encountered an unknown subroutine, which has been injected into its runtime. It upgrades the held item!
-			Produces the message: The E.X.P.E.R.I-MENTOR improves the banana, drawing the life essence of those nearby!</li>
-
-			<li>POWERSINK - The machine's PSU has tripped the charging mechanism! It consumes massive amounts of power!
-			Produces the message: The E.X.P.E.R.I-MENTOR begins to smoke and hiss, shaking violently!</li>
-			</ol>
-		<h2>FAIL:</h2>
-			This event is produced when the item mismatches the selected experiment.
-			Produces a random message similar to: "the Banana rumbles, and shakes, the experiment was a failure!"
-
-		<h2>POKE:</h2>
-			<ol>
-			<li>WILD ARMS - The machine's gryoscopic processors malfunction, causing it to lash out at nearby people with its arms.
-			Produces the message: The E.X.P.E.R.I-MENTOR malfunctions and destroys the banana, lashing its arms out at nearby people!</li>
-
-			<li>MISTYPE - The machine's interface has been garbled, and it switches to OBLITERATE.
-			Produces the message: The E.X.P.E.R.I-MENTOR malfunctions!</li>
-
-			<li>THROW - The machine's spatial recognition device has shifted several meters across the room, causing it to try and repostion the item there.
-			Produces the message: The E.X.P.E.R.I-MENTOR malfunctions, throwing the banana!</li>
-			</ol>
-		<h2>IRRADIATE:</h2>
-			<ol>
-			<li>RADIATION LEAK - The machine's shield has failed, resulting in a toxic radiation leak.
-			Produces the message: The E.X.P.E.R.I-MENTOR malfunctions, melting the banana and leaking radiation!</li>
-
-			<li>RADIATION DUMP - The machine's recycling and containment functions have failed, resulting in a dump of toxic waste around it
-			Produces the message: The E.X.P.E.R.I-MENTOR malfunctions, spewing toxic waste!</li>
-
-			<li>MUTATION - The machine's radio-isotope level meter has malfunctioned, causing it over-irradiate the item, making it transform.
-			Produces the message: The E.X.P.E.R.I-MENTOR malfunctions, transforming the banana!</li>
-			</ol>
-		<h2>GAS:</h2>
-			<ol>
-			<li>TOXIN LEAK - The machine's filtering and vent systems have failed, resulting in a cloud of toxic gas being expelled.
-			Produces the message: The E.X.P.E.R.I-MENTOR destroys the banana, leaking dangerous gas!</li>
-
-			<li>GAS LEAK - The machine's vent systems have failed, resulting in a cloud of harmless, but obscuring gas.
-			Produces the message: The E.X.P.E.R.I-MENTOR malfunctions, spewing harmless gas!</li>
-
-			<li>ELECTROMAGNETIC IONS - The machine's electrolytic scanners have failed, causing a dangerous Electromagnetic reaction.
-			Produces the message: The E.X.P.E.R.I-MENTOR melts the banana, ionizing the air around it!</li>
-			</ol>
-		<h2>HEAT:</h2>
-			<ol>
-			<li>TOASTER - The machine's heating coils have come into contact with the machine's gas storage, causing a large, sudden blast of flame.
-			Produces the message: The E.X.P.E.R.I-MENTOR malfunctions, melting the banana and releasing a burst of flame!</li>
-
-			<li>SAUNA - The machine's vent loop has sprung a leak, resulting in a large amount of superheated air being dumped around it.
-			Produces the message: The E.X.P.E.R.I-MENTOR malfunctions, melting the banana and leaking hot air!</li>
-
-			<li>EMERGENCY VENT - The machine's temperature gauge has malfunctioned, resulting in it attempting to cool the area around it, but instead, dumping a cloud of steam.
-			Produces the message: The E.X.P.E.R.I-MENTOR malfunctions, activating its emergency coolant systems!</li>
-			</ol>
-		<h2>COLD:</h2>
-			<ol>
-			<li>FREEZER - The machine's cooling loop has sprung a leak, resulting in a cloud of super-cooled liquid being blasted into the air.
-			Produces the message: The E.X.P.E.R.I-MENTOR malfunctions, shattering the banana and releasing a dangerous cloud of coolant!</li>
-
-			<li>FRIDGE - The machine's cooling loop has been exposed to the outside air, resulting in a large decrease in temperature.
-			Produces the message: The E.X.P.E.R.I-MENTOR malfunctions, shattering the banana and leaking cold air!</li>
-
-			<li>SNOWSTORM - The machine's cooling loop has come into contact with the heating coils, resulting in a sudden blast of cool air.
-			Produces the message: The E.X.P.E.R.I-MENTOR malfunctions, releasing a flurry of chilly air as the banana pops out!</li>
-			</ol>
-		<h2>OBLITERATE:</h2>
-			<ol>
-			<li>IMPLOSION - The machine's pressure leveller has malfunctioned, causing it to pierce the space-time momentarily, making everything in the area fly towards it.
-			Produces the message: The E.X.P.E.R.I-MENTOR's crusher goes way too many levels too high, crushing right through space-time!</li>
-
-			<li>DISTORTION - The machine's pressure leveller has completely disabled, resulting in a momentary space-time distortion, causing everything to fly around.
-			Produces the message: The E.X.P.E.R.I-MENTOR's crusher goes one level too high, crushing right into space-time!</li>
-			</ol>
-		</body>
-	</html>
-	"}
-
-/obj/item/book/manual/research_and_development
-	name = "Research and Development 101"
-	icon_state = "rdbook"
-	author = "Dr. L. Ight"
-	title = "Research and Development 101"
-	dat = {"<html>
-				<head>
-				<style>
-				h1 {font-size: 18px; margin: 15px 0px 5px;}
-				h2 {font-size: 15px; margin: 15px 0px 5px;}
-				li {margin: 2px 0px 2px 15px;}
-				ul {list-style: none; margin: 5px; padding: 0px;}
-				ol {margin: 5px; padding: 0px 15px;}
-				</style>
-				</head>
-				<body>
-
-				<h1>Science For Dummies</h1>
-				So you want to further SCIENCE? Good man/woman/thing! However, SCIENCE is a complicated process even though it's quite easy. For the most part, it's a three step process:
-				<ol>
-					<li> 1) Deconstruct items in the Destructive Analyzer to advance technology or improve the design.</li>
-					<li> 2) Build unlocked designs in the Protolathe and Circuit Imprinter</li>
-					<li> 3) Repeat!</li>
-				</ol>
-
-				Those are the basic steps to furthing science. What do you do science with, however? Well, you have four major tools: R&D Console, the Destructive Analyzer, the Protolathe, and the Circuit Imprinter.
-
-				<h2>The R&D Console</h2>
-				The R&D console is the cornerstone of any research lab. It is the central system from which the Destructive Analyzer, Protolathe, and Circuit Imprinter (your R&D systems) are controled. More on those systems in their own sections. On its own, the R&D console acts as a database for all your technological gains and new devices you discover. So long as the R&D console remains intact, you'll retain all that SCIENCE you've discovered. Protect it though, because if it gets damaged, you'll lose your data! In addition to this important purpose, the R&D console has a disk menu that lets you transfer data from the database onto disk or from the disk into the database. It also has a settings menu that lets you re-sync with nearby R&D devices (if they've become disconnected), lock the console from the unworthy, upload the data to all other R&D consoles in the network (all R&D consoles are networked by default), connect/disconnect from the network, and purge all data from the database.
-				<b>NOTE:</b> The technology list screen, circuit imprinter, and protolathe menus are accessible by non-scientists. This is intended to allow 'public' systems for the plebians to utilize some new devices.
-
-				<h2>Destructive Analyzer</h2>
-				This is the source of all technology. Whenever you put a handheld object in it, it analyzes it and determines what sort of technological advancements you can discover from it. If the technology of the object is equal or higher then your current knowledge, you can destroy the object to further those sciences. Some devices (notably, some devices made from the protolathe and circuit imprinter) aren't 100% reliable when you first discover them. If these devices break down, you can put them into the Destructive Analyzer and improve their reliability rather then futher science. If their reliability is high enough ,it'll also advance their related technologies.
-
-				<h2>Circuit Imprinter</h2>
-				This machine, along with the Protolathe, is used to actually produce new devices. The Circuit Imprinter takes glass and various chemicals (depends on the design) to produce new circuit boards to build new machines or computers. It can even be used to print AI modules.
-
-				<h2>Protolathe</h2>
-				This machine is an advanced form of the Autolathe that produce non-circuit designs. Unlike the Autolathe, it can use processed metal, glass, solid plasma, silver, gold, and diamonds along with a variety of chemicals to produce devices. The downside is that, again, not all devices you make are 100% reliable when you first discover them.
-
-				<h1>Reliability and You</h1>
-				As it has been stated, many devices when they're first discovered do not have a 100% reliablity when you first discover them. Instead, the reliablity of the device is dependent upon a base reliability value, whatever improvements to the design you've discovered through the Destructive Analyzer, and any advancements you've made with the device's source technologies. To be able to improve the reliability of a device, you have to use the device until it breaks beyond repair. Once that happens, you can analyze it in a Destructive Analyzer. Once the device reachs a certain minimum reliability, you'll gain tech advancements from it.
-
-				<h1>Building a Better Machine</h1>
-				Many machines produces from circuit boards and inserted into a machine frame require a variety of parts to construct. These are parts like capacitors, batteries, matter bins, and so forth. As your knowledge of science improves, more advanced versions are unlocked. If you use these parts when constructing something, its attributes may be improved. For example, if you use an advanced matter bin when constructing an autolathe (rather then a regular one), it'll hold more materials. Experiment around with stock parts of various qualities to see how they affect the end results! Be warned, however: Tier 3 and higher stock parts don't have 100% reliability and their low reliability may affect the reliability of the end machine.
-				</body>
-				</html>
-			"}
-
-
-/obj/item/book/manual/robotics_cyborgs
-	name = "Cyborgs for Dummies"
-	icon_state = "borgbook"
-	author = "XISC"
-	title = "Cyborgs for Dummies"
-	dat = {"<html>
-				<head>
-				<style>
-				h1 {font-size: 21px; margin: 15px 0px 5px;}
-				h2 {font-size: 18px; margin: 15px 0px 5px;}
-        h3 {font-size: 15px; margin: 15px 0px 5px;}
-				li {margin: 2px 0px 2px 15px;}
-				ul {list-style: none; margin: 5px; padding: 0px;}
-				ol {margin: 5px; padding: 0px 15px;}
-				</style>
-				</head>
-				<body>
-
-				<h1>Cyborgs for Dummies</h1>
-
-				<h2>Chapters</h2>
-
-				<ol>
-					<li><a href="#Equipment">Cyborg Related Equipment</a></li>
-					<li><a href="#Modules">Cyborg Modules</a></li>
-					<li><a href="#Construction">Cyborg Construction</a></li>
-					<li><a href="#Deconstruction">Cyborg Deconstruction</a></li>
-					<li><a href="#Maintenance">Cyborg Maintenance</a></li>
-					<li><a href="#Repairs">Cyborg Repairs</a></li>
-					<li><a href="#Emergency">In Case of Emergency</a></li>
-				</ol>
-
-
-				<h2><a name="Equipment">Cyborg Related Equipment</h2>
-
-				<h3>Exosuit Fabricator</h3>
-				The Exosuit Fabricator is the most important piece of equipment related to cyborgs. It allows the construction of the core cyborg parts. Without these machines, cyborgs can not be built. It seems that they may also benefit from advanced research techniques.
-
-				<h3>Cyborg Recharging Station</h3>
-				This useful piece of equipment will suck power out of the power systems to charge a cyborg's power cell back up to full charge.
-
-				<h3>Robotics Control Console</h3>
-				This useful piece of equipment can be used to immobolize or destroy a cyborg. A word of warning: Cyborgs are expensive pieces of equipment, do not destroy them without good reason, or Nanotrasen may see to it that it never happens again.
-
-
-				<h2><a name="Modules">Cyborg Modules</h2>
-				When a cyborg is created it picks out of an array of modules to designate its purpose. There are 6 different cyborg modules.
-
-				<h3>Standard Cyborg</h3>
-				The standard cyborg module is a multi-purpose cyborg. It is equipped with various modules, allowing it to do basic tasks.<br>
-
-				<h3>Engineering Cyborg</h3>
-				The Engineering cyborg module comes equipped with various engineering-related tools to help with engineering-related tasks.<br>
-
-				<h3>Mining Cyborg</h3>
-				The Mining Cyborg module comes equipped with the latest in mining equipment. They are efficient at mining due to no need for oxygen, but their power cells limit their time in the mines.
-
-				<h3>Security Cyborg</h3>
-				The Security Cyborg module is equipped with effective security measures used to apprehend and arrest criminals without harming them a bit.
-
-				<h3>Janitor Cyborg</h3>
-				The Janitor Cyborg module is equipped with various cleaning-facilitating devices.
-
-				<h3>Service Cyborg</h3>
-				The service cyborg module comes ready to serve your human needs. It includes various entertainment and refreshment devices. Occasionally some service cyborgs may have been referred to as "Bros"
-
-				<h2><a name="Construction">Cyborg Construction</h2>
-				Cyborg construction is a rather easy process, requiring a decent amount of metal and a few other supplies.<br>The required materials to make a cyborg are:
-				<ul>
-				  <li>Metal</li>
-				  <li>Two Flashes</li>
-				  <li>One Power Cell (Preferrably rated to 15000w)</li>
-				  <li>Some electrical wires</li>
-				  <li>One Human Brain</li>
-				  <li>One Man-Machine Interface</li>
-				</ul>
-				Once you have acquired the materials, you can start on construction of your cyborg.<br>To construct a cyborg, follow the steps below:
-				<ol>
-				  <li>Start the Exosuit Fabricators constructing all of the cyborg parts</li>
-				  <li>While the parts are being constructed, take your human brain, and place it inside the Man-Machine Interface</li>
-				  <li>Once you have a Robot Head, place your two flashes inside the eye sockets</li>
-				  <li>Once you have your Robot Chest, wire the Robot chest, then insert the power cell</li>
-				  <li>Attach all of the Robot parts to the Robot frame</li>
-				  <li>Insert the Man-Machine Interface (With the Brain inside) Into the Robot Body</li>
-				  <li>Congratulations! You have a new cyborg!</li>
-				</ol>
-
-				<h2><a name="Deconstruction">Cyborg Deconstruction</h2>
-				If you want to deconstruct a cyborg, say to remove its MMI without <a href="#Emergency">blowing the Cyborg to pieces</a>, they come apart very quickly, <b>and</b> very safely, in a few simple steps.
-				<ul>
-				  <li>Crowbar</li>
-				  <li>Wrench</li>
-				  Optional:
-				  <li>Screwdriver</li>
-				  <li>Wirecutters</li>
-				</ul>
-				<ol>
-				  <li>Begin by unlocking the Cyborg's access panel using your ID</li>
-				  <li>Use your crowbar to open the Cyborg's access panel</li>
-				  <li>Using your bare hands, remove the power cell from the Cyborg</li>
-				  <li>Lockdown the Cyborg to disengage safety protocols</li>
-				  <ol>
-				    Option 1: Robotics console
-				    <li>Use the Robotics console in the RD's office</li>
-				    <li>Find the entry for your Cyborg</li>
-				    <li>Press the Lockdown button on the Robotics console</li>
-				  </ol>
-				  <ol>
-				    Option 2: Lockdown wire
-				    <li>Use your screwdriver to expose the Cyborg's wiring</li>
-				    <li>Use your wirecutters to start cutting all of the wires until the lockdown light turns off, cutting all of the wires irregardless of the lockdown light works as well</li>
-				  </ol>
-				  <li>Use your wrench to unfasten the Cyborg's bolts, the Cyborg will then fall apart onto the floor, the MMI will be there as well</li>
-				</ol>
-
-				<h2><a name="Maintenance">Cyborg Maintenance</h2>
-				Occasionally Cyborgs may require maintenance of a couple types, this could include replacing a power cell with a charged one, or possibly maintaining the cyborg's internal wiring.
-
-				<h3>Replacing a Power Cell</h3>
-				Replacing a Power cell is a common type of maintenance for cyborgs. It usually involves replacing the cell with a fully charged one, or upgrading the cell with a larger capacity cell.<br>The steps to replace a cell are follows:
-				<ol>
-				  <li>Unlock the Cyborg's Interface by swiping your ID on it</li>
-				  <li>Open the Cyborg's outer panel using a crowbar</li>
-				  <li>Remove the old power cell</li>
-				  <li>Insert the new power cell</li>
-				  <li>Close the Cyborg's outer panel using a crowbar</li>
-				  <li>Lock the Cyborg's Interface by swiping your ID on it, this will prevent non-qualified personnel from attempting to remove the power cell</li>
-				</ol>
-
-				<h3>Exposing the Internal Wiring</h3>
-				Exposing the internal wiring of a cyborg is fairly easy to do, and is mainly used for cyborg repairs.<br>You can easily expose the internal wiring by following the steps below:
-				<ol>
-				  <li>Follow Steps 1 - 3 of "Replacing a Cyborg's Power Cell"</li>
-				  <li>Open the cyborg's internal wiring panel by using a screwdriver to unsecure the panel</li>
-			  </ol>
-			  To re-seal the cyborg's internal wiring:
-			  <ol>
-			    <li>Use a screwdriver to secure the cyborg's internal panel</li>
-			    <li>Follow steps 4 - 6 of "Replacing a Cyborg's Power Cell" to close up the cyborg</li>
-			  </ol>
-
-			  <h2><a name="Repairs">Cyborg Repairs</h2>
-			  Occasionally a Cyborg may become damaged. This could be in the form of impact damage from a heavy or fast-travelling object, or it could be heat damage from high temperatures, or even lasers or Electromagnetic Pulses (EMPs).
-
-			  <h3>Dents</h3>
-			  If a cyborg becomes damaged due to impact from heavy or fast-moving objects, it will become dented. Sure, a dent may not seem like much, but it can compromise the structural integrity of the cyborg, possibly causing a critical failure.
-			  Dents in a cyborg's frame are rather easy to repair, all you need is to apply a welding tool to the dented area, and the high-tech cyborg frame will repair the dent under the heat of the welder.
-
-        <h3>Excessive Heat Damage</h3>
-        If a cyborg becomes damaged due to excessive heat, it is likely that the internal wires will have been damaged. You must replace those wires to ensure that the cyborg remains functioning properly.<br>To replace the internal wiring follow the steps below:
-        <ol>
-          <li>Unlock the Cyborg's Interface by swiping your ID</li>
-          <li>Open the Cyborg's External Panel using a crowbar</li>
-          <li>Remove the Cyborg's Power Cell</li>
-          <li>Using a screwdriver, expose the internal wiring or the Cyborg</li>
-          <li>Replace the damaged wires inside the cyborg</li>
-          <li>Secure the internal wiring cover using a screwdriver</li>
-          <li>Insert the Cyborg's Power Cell</li>
-          <li>Close the Cyborg's External Panel using a crowbar</li>
-          <li>Lock the Cyborg's Interface by swiping your ID</li>
-        </ol>
-        These repair tasks may seem difficult, but are essential to keep your cyborgs running at peak efficiency.
-
-        <h2><a name="Emergency">In Case of Emergency</h2>
-        In case of emergency, there are a few steps you can take.
-
-        <h3>"Rogue" Cyborgs</h3>
-        If the cyborgs seem to become "rogue", they may have non-standard laws. In this case, use extreme caution.
-        To repair the situation, follow these steps:
-        <ol>
-          <li>Locate the nearest robotics console</li>
-          <li>Determine which cyborgs are "Rogue"</li>
-          <li>Press the lockdown button to immobolize the cyborg</li>
-          <li>Locate the cyborg</li>
-          <li>Expose the cyborg's internal wiring</li>
-          <li>Check to make sure the LawSync and AI Sync lights are lit</li>
-          <li>If they are not lit, pulse the LawSync wire using a multitool to enable the cyborg's Law Sync</li>
-          <li>Proceed to a cyborg upload console. Nanotrasen usually places these in the same location as AI uplaod consoles.</li>
-          <li>Use a "Reset" upload moduleto reset the cyborg's laws</li>
-          <li>Proceed to a Robotics Control console</li>
-          <li>Remove the lockdown on the cyborg</li>
-        </ol>
-
-        <h3>As a last resort</h3>
-        If all else fails in a case of cyborg-related emergency. There may be only one option. Using a Robotics Control console, you may have to remotely detonate the cyborg.
-        <h3>WARNING:</h3> Do not detonate a borg without an explicit reason for doing so. Cyborgs are expensive pieces of Nanotrasen equipment, and you may be punished for detonating them without reason.
-
-        </body>
-		</html>
-		"}
-
-
 
 /obj/item/book/manual/chef_recipes
 	name = "Chef Recipes"
@@ -734,101 +195,6 @@
 				</body>
 				</html>
 			"}
-
-
-/obj/item/book/manual/barman_recipes
-	name = "Barman Recipes"
-	icon_state = "barbook"
-	author = "Sir John Rose"
-	title = "Barman Recipes"
-	dat = {"<html>
-				<head>
-				<style>
-				h1 {font-size: 18px; margin: 15px 0px 5px;}
-				h2 {font-size: 15px; margin: 15px 0px 5px;}
-				li {margin: 2px 0px 2px 15px;}
-				ul {list-style: none; margin: 5px; padding: 0px;}
-				ol {margin: 5px; padding: 0px 15px;}
-				</style>
-				</head>
-				<body>
-
-				<h1>Drinks for dummies</h1>
-				Heres a guide for some basic drinks.
-
-				<h2>Manly Dorf:</h2>
-				Mix ale and beer into a glass.
-
-				<h2>Grog:</h2>
-				Mix rum and water into a glass.
-
-				<h2>Black Russian:</h2>
-				Mix vodka and kahlua into a glass.
-
-				<h2>Irish Cream:</h2>
-				Mix cream and whiskey into a glass.
-
-				<h2>Screwdriver:</h2>
-				Mix vodka and orange juice into a glass.
-
-				<h2>Cafe Latte:</h2>
-				Mix milk and coffee into a glass.
-
-				<h2>Mead:</h2>
-				Mix Enzyme, water and sugar into a glass.
-
-				<h2>Gin Tonic:</h2>
-				Mix gin and tonic into a glass.
-
-				<h2>Classic Martini:</h2>
-				Mix vermouth and gin into a glass.
-
-
-				</body>
-				</html>
-			"}
-
-
-/obj/item/book/manual/detective
-	name = "The Film Noir: Proper Procedures for Investigations"
-	icon_state ="bookDetective"
-	author = "Nanotrasen"
-	title = "The Film Noir: Proper Procedures for Investigations"
-	dat = {"<html>
-			<head>
-			<style>
-			h1 {font-size: 18px; margin: 15px 0px 5px;}
-			h2 {font-size: 15px; margin: 15px 0px 5px;}
-			li {margin: 2px 0px 2px 15px;}
-			ul {list-style: none; margin: 5px; padding: 0px;}
-			ol {margin: 5px; padding: 0px 15px;}
-			</style>
-			</head>
-			<body>
-			<h3>Detective Work</h3>
-
-			Between your bouts of self-narration, and drinking whiskey on the rocks, you might get a case or two to solve.<br>
-			To have the best chance to solve your case, follow these directions:
-			<p>
-			<ol>
-			<li>Go to the crime scene. </li>
-			<li>Take your scanner and scan EVERYTHING (Yes, the doors, the tables, even the dog.) </li>
-			<li>Once you are reasonably certain you have every scrap of evidence you can use, find all possible entry points and scan them, too. </li>
-			<li>Return to your office. </li>
-			<li>Using your forensic scanning computer, scan your Scanner to upload all of your evidence into the database.</li>
-			<li>Browse through the resulting dossiers, looking for the one that either has the most complete set of prints, or the most suspicious items handled. </li>
-			<li>If you have 80% or more of the print (The print is displayed) go to step 10, otherwise continue to step 8.</li>
-			<li>Look for clues from the suit fibres you found on your perp, and go about looking for more evidence with this new information, scanning as you go. </li>
-			<li>Try to get a fingerprint card of your perp, as if used in the computer, the prints will be completed on their dossier.</li>
-			<li>Assuming you have enough of a print to see it, grab the biggest complete piece of the print and search the security records for it. </li>
-			<li>Since you now have both your dossier and the name of the person, print both out as evidence, and get security to nab your baddie.</li>
-			<li>Give yourself a pat on the back and a bottle of the ships finest vodka, you did it!</li>
-			</ol>
-			<p>
-			It really is that easy! Good luck!
-
-			</body>
-			</html>"}
 
 /obj/item/book/manual/nuclear
 	name = "Fission Mailed: Nuclear Sabotage 101"
@@ -925,6 +291,13 @@
 	title = "Engineering Textbook"
 	page_link = "Guide_to_engineering"
 
+/obj/item/book/manual/wiki/engineering_singulo_tesla
+	name = "Singularity and Tesla for Dummies"
+	icon_state ="bookEngineeringSingularitySafety"
+	author = "Engineering Encyclopedia"
+	title = "Singularity and Tesla for Dummies"
+	page_link = "Singularity_and_Tesla_engines"
+
 /obj/item/book/manual/wiki/security_space_law
 	name = "Space Law"
 	desc = "A set of Nanotrasen guidelines for keeping law and order on their space stations."
@@ -957,3 +330,45 @@
 	author = "Engineering Encyclopedia"
 	title = "Hacking"
 	page_link = "Hacking"
+
+/obj/item/book/manual/wiki/detective
+	name = "The Film Noir: Proper Procedures for Investigations"
+	icon_state ="bookDetective"
+	author = "Nanotrasen"
+	title = "The Film Noir: Proper Procedures for Investigations"
+	page_link = "Detective"
+
+/obj/item/book/manual/wiki/barman_recipes
+	name = "Barman Recipes"
+	icon_state = "barbook"
+	author = "Sir John Rose"
+	title = "Barman Recipes"
+	page_link = "Guide_to_food_and_drinks"
+	
+/obj/item/book/manual/wiki/robotics_cyborgs
+	name = "Robotics for Dummies"
+	icon_state = "borgbook"
+	author = "XISC"
+	title = "Robotics for Dummies"
+	page_link = "Guide_to_robotics"
+	
+/obj/item/book/manual/wiki/research_and_development
+	name = "Research and Development 101"
+	icon_state = "rdbook"
+	author = "Dr. L. Ight"
+	title = "Research and Development 101"
+	page_link = "Guide_to_Research_and_Development"
+
+/obj/item/book/manual/wiki/experimentor
+	name = "Mentoring your Experiments"
+	icon_state = "rdbook"
+	author = "Dr. H.P. Kritz"
+	title = "Mentoring your Experiments"
+	page_link = "Experimentor"
+
+/obj/item/book/manual/wiki/medical_cloning
+	name = "Cloning techniques of the 26th century"
+	icon_state ="bookCloning"
+	author = "Medical Journal, volume 3"
+	title = "Cloning techniques of the 26th century"
+	page_link = "Guide_to_genetics#Cloning"

--- a/code/modules/library/lib_items.dm
+++ b/code/modules/library/lib_items.dm
@@ -149,7 +149,7 @@
 
 /obj/structure/bookcase/manuals/medical/Initialize()
 	. = ..()
-	new /obj/item/book/manual/medical_cloning(src)
+	new /obj/item/book/manual/wiki/medical_cloning(src)
 	update_icon()
 
 
@@ -159,11 +159,10 @@
 /obj/structure/bookcase/manuals/engineering/Initialize()
 	. = ..()
 	new /obj/item/book/manual/wiki/engineering_construction(src)
-	new /obj/item/book/manual/engineering_particle_accelerator(src)
 	new /obj/item/book/manual/wiki/engineering_hacking(src)
 	new /obj/item/book/manual/wiki/engineering_guide(src)
-	new /obj/item/book/manual/engineering_singularity_safety(src)
-	new /obj/item/book/manual/robotics_cyborgs(src)
+	new /obj/item/book/manual/wiki/engineering_singulo_tesla(src)
+	new /obj/item/book/manual/wiki/robotics_cyborgs(src)
 	update_icon()
 
 
@@ -172,7 +171,7 @@
 
 /obj/structure/bookcase/manuals/research_and_development/Initialize()
 	. = ..()
-	new /obj/item/book/manual/research_and_development(src)
+	new /obj/item/book/manual/wiki/research_and_development(src)
 	update_icon()
 
 


### PR DESCRIPTION
:cl: Denton
tweak: Most static ingame manuals have been replaced with ones that open relevant wiki articles.
remove: Deleted the "Particle Accelerator User's Guide" manual, since it's included in the Singulo/Tesla one.
/:cl:

Most static ingame manuals are either outdated, incomplete or a combination of both. 
I replaced most with manuals that open relevant wiki articles - this means more recent, more complete contents that can be updated by anyone with a wiki account (instead of having to open a PR every damn time).

I didn't touch the chef/ripley/podman/nuke ones, since they're nicely written and don't really have wiki equivalents.

So far I spawned in all affected manuals and tested them, couldn't find any errors.