### PR TITLE
Blacklists machine frames from tesla zaps

### DIFF
--- a/code/modules/power/tesla/energy_ball.dm
+++ b/code/modules/power/tesla/energy_ball.dm
@@ -193,7 +193,8 @@
 										/obj/machinery/gateway,
 										/obj/structure/lattice,
 										/obj/structure/grille,
-										/obj/machinery/the_singularitygen/tesla))
+										/obj/machinery/the_singularitygen/tesla,
+										/obj/structure/frame/machine))
 
 	for(var/A in typecache_filter_multi_list_exclusion(oview(source, zap_range+2), things_to_shock, blacklisted_tesla_types))
 		if(!(tesla_flags & TESLA_ALLOW_DUPLICATES) && LAZYACCESS(shocked_targets, A))


### PR DESCRIPTION
:cl: Denton
tweak: Machine frames no longer explode when struck by tesla arcs.
/:cl:

Right now, players can't construct anything around a running tesla engine - machine frames are unwrenched when built and will explode before you're able to wrench them down. Even grounding rods don't help reliably.

Blacklisting them from tesla arcs allows players to build new tesla coils/grounding rods instead of having them explode in their face almost instantly.