### PR TITLE
flightsuit speed rebalancing

### DIFF
--- a/code/modules/mob/living/carbon/human/species.dm
+++ b/code/modules/mob/living/carbon/human/species.dm
@@ -1097,13 +1097,11 @@ GLOBAL_LIST_EMPTY(roundstart_races)
 			. -= 2
 		else if(istype(T) && T.allow_thrust(0.01, H))
 			. -= 2
-		else if(flightpack && F.allow_thrust(0.01, src))
-			. -= 2
 
 	if(flightpack && F.boost)
 		. -= F.boost_speed
 	else if(flightpack && F.brake)
-		. += 2
+		. += 1
 
 	if(!ignoreslow && !flightpack && gravity)
 		if(H.wear_suit)


### PR DESCRIPTION
:cl:
experimental: Flightsuits no longer give you innate jetpack speeds in nograv environments
experimental: Flightsuit braking/precision mode no longer slows you as badly
/:cl:
why: using precision mode was basically useless, while having innate jetpack is ridiculous when it already has its own movement processing that would make you faster. jetpacks require fuel for their precision -2 slowdown.
this should cut down on the infinite saxxing.

honestly tempted to just remove it and re-PR it with unique mechanics when pixel movement is out but i'm hoping i can salvage the current version before then

and yes, this is a nerf.