### PR TITLE
Fixes players being unable to construct on the same tile as a directional window

### DIFF
--- a/code/game/objects/items/stacks/stack.dm
+++ b/code/game/objects/items/stacks/stack.dm
@@ -249,9 +249,7 @@
 			if(istype(AM,/obj/structure/window))
 				var/obj/structure/window/W = AM
 				var/obj/structure/window/O = new R.result_type
-				if(istype(O,/obj/structure/window) && O.fulltile)
-					//Do nuthin and move on
-				else if(!W.fulltile)
+				if(!W.fulltile && !(istype(O,/obj/structure/window) && O.fulltile))
 					continue
 			if(AM.density)
 				to_chat(usr, "<span class='warning'>Theres a [AM.name] here. You cant make a [R.title] here!</span>")

--- a/code/game/objects/items/stacks/stack.dm
+++ b/code/game/objects/items/stacks/stack.dm
@@ -231,12 +231,11 @@
 			to_chat(usr, "<span class='warning'>You haven't got enough [src] to build \the [R.title]!</span>")
 		return FALSE
 	var/turf/T = get_turf(usr)
-	var/obj/structure/window/M = new R.result_type
-	if(R.window_checks && !valid_window_location(T, M.fulltile ? FULLTILE_WINDOW_DIR : usr.dir))
-		qdel(M)
+
+	var/obj/D = R.result_type
+	if(R.window_checks && !valid_window_location(T, initial(D.dir) == FULLTILE_WINDOW_DIR ? FULLTILE_WINDOW_DIR : usr.dir))
 		to_chat(usr, "<span class='warning'>The [R.title] won't fit here!</span>")
 		return FALSE
-	qdel(M)
 	if(R.one_per_turf && (locate(R.result_type) in T))
 		to_chat(usr, "<span class='warning'>There is another [R.title] here!</span>")
 		return FALSE

--- a/code/game/objects/items/stacks/stack.dm
+++ b/code/game/objects/items/stacks/stack.dm
@@ -246,8 +246,10 @@
 				continue
 			if(istype(AM,/obj/structure/table))
 				continue
-			if(istype(AM,/obj/structure/window) && !istype(AM,/obj/structure/window/fulltile))
-				continue
+			if(istype(AM,/obj/structure/window))
+				var/obj/structure/window/W = AM
+				if(!W.fulltile)
+					continue
 			if(AM.density)
 				to_chat(usr, "<span class='warning'>Theres a [AM.name] here. You cant make a [R.title] here!</span>")
 				return FALSE

--- a/code/game/objects/items/stacks/stack.dm
+++ b/code/game/objects/items/stacks/stack.dm
@@ -231,9 +231,12 @@
 			to_chat(usr, "<span class='warning'>You haven't got enough [src] to build \the [R.title]!</span>")
 		return FALSE
 	var/turf/T = get_turf(usr)
-	if(R.window_checks && !valid_window_location(T, usr.dir))
+	var/obj/structure/window/M = new R.result_type
+	if(R.window_checks && !valid_window_location(T, M.fulltile? FULLTILE_WINDOW_DIR : usr.dir))
+		qdel(M)
 		to_chat(usr, "<span class='warning'>The [R.title] won't fit here!</span>")
 		return FALSE
+	qdel(M)
 	if(R.one_per_turf && (locate(R.result_type) in T))
 		to_chat(usr, "<span class='warning'>There is another [R.title] here!</span>")
 		return FALSE
@@ -248,8 +251,7 @@
 				continue
 			if(istype(AM,/obj/structure/window))
 				var/obj/structure/window/W = AM
-				var/obj/structure/window/O = new R.result_type
-				if(!W.fulltile && !(istype(O,/obj/structure/window) && O.fulltile))
+				if(!W.fulltile)
 					continue
 			if(AM.density)
 				to_chat(usr, "<span class='warning'>Theres a [AM.name] here. You cant make a [R.title] here!</span>")

--- a/code/game/objects/items/stacks/stack.dm
+++ b/code/game/objects/items/stacks/stack.dm
@@ -246,6 +246,8 @@
 				continue
 			if(istype(AM,/obj/structure/table))
 				continue
+			if(istype(AM,/obj/structure/window) && !istype(AM,/obj/structure/window/fulltile))
+				continue
 			if(AM.density)
 				to_chat(usr, "<span class='warning'>Theres a [AM.name] here. You cant make a [R.title] here!</span>")
 				return FALSE

--- a/code/game/objects/items/stacks/stack.dm
+++ b/code/game/objects/items/stacks/stack.dm
@@ -248,7 +248,10 @@
 				continue
 			if(istype(AM,/obj/structure/window))
 				var/obj/structure/window/W = AM
-				if(!W.fulltile)
+				var/obj/structure/window/O = new R.result_type
+				if(istype(O,/obj/structure/window) && O.fulltile)
+					//Do nuthin and move on
+				else if(!W.fulltile)
 					continue
 			if(AM.density)
 				to_chat(usr, "<span class='warning'>Theres a [AM.name] here. You cant make a [R.title] here!</span>")

--- a/code/game/objects/items/stacks/stack.dm
+++ b/code/game/objects/items/stacks/stack.dm
@@ -232,7 +232,7 @@
 		return FALSE
 	var/turf/T = get_turf(usr)
 	var/obj/structure/window/M = new R.result_type
-	if(R.window_checks && !valid_window_location(T, M.fulltile? FULLTILE_WINDOW_DIR : usr.dir))
+	if(R.window_checks && !valid_window_location(T, M.fulltile ? FULLTILE_WINDOW_DIR : usr.dir))
 		qdel(M)
 		to_chat(usr, "<span class='warning'>The [R.title] won't fit here!</span>")
 		return FALSE


### PR DESCRIPTION
:cl:
fix: players can construct while standing on top of a directional window. (machine frames, computer frames, etc)
/:cl:

fixes: #39078 

Users could drag stuff onto the same tile as a directional window and anchor it down, but couldn't build them while standing on the tile. This adds directional windows to the list of objects that construction is allowed on top of.
