### PR TITLE
Fixes #38875 - Destroyed non-human bodies cloning as humans

### DIFF
--- a/code/datums/dna.dm
+++ b/code/datums/dna.dm
@@ -12,6 +12,7 @@
 	var/list/temporary_mutations = list() //Timers for temporary mutations
 	var/list/previous = list() //For temporary name/ui/ue/blood_type modifications
 	var/mob/living/holder
+	var/delete_species = TRUE //Set to FALSE when a body is scanned by a cloner to fix #38875
 
 /datum/dna/New(mob/living/new_holder)
 	if(istype(new_holder))
@@ -23,7 +24,9 @@
 		if(cholder.dna == src)
 			cholder.dna = null
 	holder = null
-	QDEL_NULL(species)
+
+	if(delete_species)
+		QDEL_NULL(species)
 
 	mutations.Cut()					//This only references mutations, just dereference.
 	temporary_mutations.Cut()		//^

--- a/code/game/machinery/computer/cloning.dm
+++ b/code/game/machinery/computer/cloning.dm
@@ -468,6 +468,7 @@
 		// We store the instance rather than the path, because some
 		// species (abductors, slimepeople) store state in their
 		// species datums
+		dna.delete_species = FALSE
 		R.fields["mrace"] = dna.species
 	else
 		var/datum/species/rando_race = pick(GLOB.roundstart_races)


### PR DESCRIPTION
I really don't like my way of doing this but I don't know if there's something more obvious I'm missing...

[Changelogs]: 

:cl:
fix: Fixes destroyed non-human bodies cloning as humans.
/:cl:
