### PR TITLE
Pubby: Fixes auxbase cams, department signs, fire alarms etc

### DIFF
--- a/_maps/map_files/PubbyStation/PubbyStation.dmm
+++ b/_maps/map_files/PubbyStation/PubbyStation.dmm
@@ -13625,8 +13625,8 @@
 	pixel_x = 32;
 	pixel_y = -40
 	},
-/obj/structure/sign/directions/evac{
-	dir = 1;
+/obj/structure/sign/directions/command{
+	dir = 4;
 	pixel_x = 32;
 	pixel_y = -32
 	},
@@ -15679,14 +15679,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit/departure_lounge)
-"aPw" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/structure/sign/directions/evac{
-	dir = 1;
-	pixel_x = 32
-	},
-/turf/open/floor/plasteel/neutral/corner,
-/area/hallway/primary/central)
 "aPx" = (
 /obj/machinery/light/small{
 	dir = 1
@@ -17593,6 +17585,20 @@
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
 	dir = 8
 	},
+/obj/structure/sign/directions/supply{
+	dir = 4;
+	pixel_x = -32;
+	pixel_y = -8
+	},
+/obj/structure/sign/directions/command{
+	dir = 1;
+	pixel_x = -32;
+	pixel_y = 8
+	},
+/obj/structure/sign/directions/security{
+	dir = 1;
+	pixel_x = -32
+	},
 /turf/open/floor/plasteel/brown/corner{
 	dir = 1
 	},
@@ -17767,21 +17773,6 @@
 /area/solar/starboard)
 "aUG" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden,
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/turf/open/floor/plasteel/escape{
-	dir = 1
-	},
-/area/hallway/secondary/exit/departure_lounge)
-"aUH" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/obj/structure/sign/directions/evac{
-	dir = 1;
-	pixel_y = 32
-	},
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
@@ -18130,6 +18121,17 @@
 /obj/machinery/light{
 	dir = 8
 	},
+/obj/structure/sign/directions/engineering{
+	pixel_x = -32;
+	pixel_y = -8
+	},
+/obj/structure/sign/directions/science{
+	pixel_x = -32
+	},
+/obj/structure/sign/directions/medical{
+	pixel_x = -32;
+	pixel_y = 8
+	},
 /turf/open/floor/plasteel/brown/corner{
 	dir = 1
 	},
@@ -18327,6 +18329,20 @@
 "aVR" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
 	dir = 4
+	},
+/obj/structure/sign/directions/evac{
+	dir = 1;
+	pixel_x = 32;
+	pixel_y = -8
+	},
+/obj/structure/sign/directions/security{
+	dir = 1;
+	pixel_x = 32;
+	pixel_y = 8
+	},
+/obj/structure/sign/directions/command{
+	dir = 1;
+	pixel_x = 32
 	},
 /turf/open/floor/plasteel/neutral/corner,
 /area/hallway/primary/central)
@@ -21859,10 +21875,6 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
-/obj/structure/sign/directions/evac{
-	dir = 8;
-	pixel_y = -32
-	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "bfg" = (
@@ -22195,17 +22207,18 @@
 /area/crew_quarters/lounge)
 "bge" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/structure/sign/directions/security{
-	dir = 1;
-	pixel_x = 32;
-	pixel_y = 40
-	},
-/obj/structure/sign/directions/science{
+/obj/structure/sign/directions/engineering{
 	dir = 4;
 	pixel_x = 32;
 	pixel_y = 32
 	},
-/obj/structure/sign/directions/engineering{
+/obj/structure/sign/directions/science{
+	dir = 4;
+	pixel_x = 32;
+	pixel_y = 40
+	},
+/obj/structure/sign/directions/medical{
+	dir = 4;
 	pixel_x = 32;
 	pixel_y = 24
 	},
@@ -22384,11 +22397,6 @@
 /area/hallway/primary/central)
 "bgA" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/structure/sign/directions/evac{
-	dir = 1;
-	pixel_x = -32;
-	pixel_y = 40
-	},
 /obj/structure/sign/directions/medical{
 	dir = 8;
 	pixel_x = -32;
@@ -22397,6 +22405,11 @@
 /obj/structure/sign/directions/engineering{
 	pixel_x = -32;
 	pixel_y = 24
+	},
+/obj/structure/sign/directions/supply{
+	dir = 1;
+	pixel_x = -32;
+	pixel_y = 40
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
@@ -22603,12 +22616,16 @@
 	},
 /obj/structure/sign/directions/engineering{
 	pixel_x = 32;
-	pixel_y = 28
+	pixel_y = 24
 	},
-/obj/structure/sign/directions/evac{
-	dir = 1;
+/obj/structure/sign/directions/science{
 	pixel_x = 32;
-	pixel_y = 38
+	pixel_y = 32
+	},
+/obj/structure/sign/directions/supply{
+	dir = 4;
+	pixel_x = 32;
+	pixel_y = 40
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
@@ -25315,12 +25332,12 @@
 	id = "robotics";
 	name = "Shutters Control Button";
 	pixel_x = -26;
-	pixel_y = 4;
+	pixel_y = 8;
 	req_access_txt = "29"
 	},
 /obj/machinery/light_switch{
 	pixel_x = -25;
-	pixel_y = -6
+	pixel_y = -8
 	},
 /turf/open/floor/plasteel/dark,
 /area/science/robotics/lab)
@@ -26929,9 +26946,9 @@
 /obj/machinery/chem_dispenser{
 	layer = 2.7
 	},
-/obj/item/radio/intercom{
-	name = "Station Intercom (General)";
-	pixel_x = 29
+/obj/machinery/firealarm{
+	dir = 4;
+	pixel_x = 28
 	},
 /turf/open/floor/plasteel/whiteyellow/side{
 	dir = 4
@@ -38283,8 +38300,9 @@
 /area/crew_quarters/heads/chief)
 "bUL" = (
 /obj/machinery/computer/station_alert,
-/obj/machinery/computer/security/telescreen/entertainment{
-	pixel_y = 32
+/obj/machinery/firealarm{
+	dir = 1;
+	pixel_y = 29
 	},
 /turf/open/floor/plasteel/yellow/side{
 	dir = 1
@@ -38292,6 +38310,9 @@
 /area/crew_quarters/heads/chief)
 "bUM" = (
 /obj/machinery/computer/card/minor/ce,
+/obj/machinery/computer/security/telescreen/entertainment{
+	pixel_y = 32
+	},
 /turf/open/floor/plasteel/yellow/side{
 	dir = 5
 	},
@@ -46331,13 +46352,6 @@
 /obj/item/flashlight/lantern,
 /turf/open/floor/plasteel/dark,
 /area/chapel/main/monastery)
-"cwP" = (
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = 28
-	},
-/turf/closed/wall,
-/area/medical/chemistry)
 "cwR" = (
 /obj/structure/window/reinforced{
 	dir = 8;
@@ -48094,6 +48108,14 @@
 	},
 /turf/open/floor/plasteel,
 /area/science/explab)
+"flk" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/structure/sign/directions/evac{
+	dir = 8;
+	pixel_x = -32
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
 "fmh" = (
 /turf/open/floor/wood,
 /area/maintenance/department/engine)
@@ -49311,6 +49333,20 @@
 	},
 /turf/open/floor/plating,
 /area/security/execution/transfer)
+"iQH" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plasteel/escape{
+	dir = 1
+	},
+/area/hallway/secondary/exit/departure_lounge)
 "iSz" = (
 /obj/structure/cable{
 	icon_state = "2-8"
@@ -49751,6 +49787,28 @@
 	dir = 4
 	},
 /area/hallway/secondary/exit/departure_lounge)
+"klP" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/structure/sign/directions/science{
+	dir = 4;
+	pixel_x = 32;
+	pixel_y = 40
+	},
+/obj/structure/sign/directions/engineering{
+	dir = 4;
+	pixel_x = 32;
+	pixel_y = 32
+	},
+/obj/structure/sign/directions/supply{
+	dir = 4;
+	pixel_x = 32;
+	pixel_y = 24
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
 "klV" = (
 /obj/item/clothing/under/rank/clown/sexy,
 /turf/open/floor/plasteel/dark,
@@ -49771,6 +49829,15 @@
 	},
 /turf/open/floor/plating/airless,
 /area/engine/engineering)
+"knx" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/structure/sign/directions/engineering{
+	pixel_x = 32
+	},
+/turf/open/floor/plasteel/green/side{
+	dir = 4
+	},
+/area/hallway/primary/aft)
 "kpK" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 5
@@ -50213,6 +50280,21 @@
 /obj/item/wrench,
 /turf/open/floor/plating,
 /area/maintenance/department/science)
+"lKG" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/structure/sign/directions/medical{
+	pixel_x = 32;
+	pixel_y = -8
+	},
+/obj/structure/sign/directions/science{
+	pixel_x = 32
+	},
+/obj/structure/sign/directions/engineering{
+	pixel_x = 32;
+	pixel_y = 8
+	},
+/turf/open/floor/plasteel/neutral/corner,
+/area/hallway/primary/central)
 "lKL" = (
 /obj/machinery/door/airlock/abandoned{
 	name = "Starboard Emergency Storage";
@@ -50498,6 +50580,11 @@
 	dir = 1;
 	pixel_x = 32
 	},
+/obj/structure/sign/directions/security{
+	dir = 8;
+	pixel_x = 32;
+	pixel_y = 8
+	},
 /turf/open/floor/plasteel/vault,
 /area/bridge)
 "mzl" = (
@@ -50639,15 +50726,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
-"nfi" = (
-/obj/structure/sign/directions/evac{
-	dir = 1;
-	pixel_y = 32
-	},
-/turf/open/floor/plasteel/escape{
-	dir = 1
-	},
-/area/hallway/secondary/exit/departure_lounge)
 "nfz" = (
 /obj/structure/disposalpipe/segment{
 	dir = 9
@@ -50893,6 +50971,14 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
+"nMf" = (
+/obj/machinery/door/firedoor,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/structure/sign/directions/evac{
+	pixel_x = -32
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
 "nMG" = (
 /obj/structure/cable{
 	icon_state = "2-4"
@@ -51681,6 +51767,10 @@
 /area/medical/virology)
 "pSc" = (
 /obj/machinery/chem_heater,
+/obj/item/radio/intercom{
+	name = "Station Intercom (General)";
+	pixel_x = 29
+	},
 /turf/open/floor/plasteel/whiteyellow/side{
 	dir = 5
 	},
@@ -52923,9 +53013,9 @@
 "tHk" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/structure/sign/directions/evac{
-	pixel_x = 32;
-	pixel_y = 3
+/obj/structure/sign/directions/security{
+	dir = 1;
+	pixel_x = 32
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
@@ -53266,6 +53356,24 @@
 /obj/effect/turf_decal/plaque,
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
+"uPN" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/structure/sign/directions/evac{
+	dir = 8;
+	pixel_x = -32;
+	pixel_y = 8
+	},
+/obj/structure/sign/directions/security{
+	dir = 1;
+	pixel_x = -32
+	},
+/obj/structure/sign/directions/command{
+	dir = 1;
+	pixel_x = -32;
+	pixel_y = -8
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
 "uQR" = (
 /obj/item/ammo_casing/shotgun/beanbag,
 /turf/open/floor/plating,
@@ -54099,6 +54207,13 @@
 /obj/structure/cable,
 /turf/open/floor/plasteel/dark,
 /area/library)
+"xjb" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/structure/sign/directions/evac{
+	pixel_x = -32
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
 "xjc" = (
 /obj/structure/cable{
 	icon_state = "2-8"
@@ -75620,7 +75735,7 @@ aIH
 jTh
 aSu
 aiu
-nfi
+aML
 aJE
 aWF
 aXF
@@ -76134,7 +76249,7 @@ oEA
 scp
 oEA
 oEA
-dpa
+iQH
 dTV
 aWF
 kAa
@@ -77419,7 +77534,7 @@ aQx
 aRG
 qWM
 oEA
-aUH
+mal
 dTV
 aWF
 aXI
@@ -78177,11 +78292,11 @@ aDu
 aEs
 aFr
 aGb
-aGU
+nMf
 aHE
 aAL
 aAL
-aAL
+xjb
 aAL
 aMR
 aAL
@@ -78197,11 +78312,11 @@ aGU
 aAL
 aZL
 aAL
-aAL
+uPN
 aAL
 aAL
 bfg
-aAL
+flk
 aAL
 bhJ
 bif
@@ -78699,14 +78814,14 @@ aKI
 aLv
 aMT
 aKI
-aPw
+aKI
 aQC
 aKI
 aKI
 aTP
 aUM
 aVR
-aKI
+lKG
 aXL
 aYL
 aZN
@@ -82571,7 +82686,7 @@ bdo
 ben
 bfo
 bfo
-aJZ
+klP
 aAL
 bin
 bja
@@ -83663,7 +83778,7 @@ fFv
 fFv
 fFv
 fFv
-bTE
+bXk
 aaa
 aaa
 aaa
@@ -83920,7 +84035,7 @@ fFv
 qbp
 fFv
 fFv
-bTE
+bXk
 aaa
 aaa
 aaa
@@ -84177,7 +84292,7 @@ cBR
 uVW
 lRY
 ckr
-bTE
+bXk
 aaa
 aaa
 aaa
@@ -84434,7 +84549,7 @@ cjs
 cfV
 cfV
 cfV
-bTE
+bXk
 abI
 aaa
 aaa
@@ -84691,7 +84806,7 @@ uaP
 ciG
 cfV
 cfV
-bTE
+bXk
 abI
 abI
 aaa
@@ -84948,7 +85063,7 @@ uoq
 uRk
 ciG
 cfV
-bTE
+bXk
 abI
 aaa
 aaa
@@ -85205,7 +85320,7 @@ fyO
 uoq
 hQC
 mpd
-bTE
+bXk
 abI
 aaa
 aaa
@@ -85462,7 +85577,7 @@ fyO
 fyO
 hQC
 mpd
-bTE
+bXk
 abI
 aaa
 aaa
@@ -85719,7 +85834,7 @@ mpd
 mpd
 hQC
 sYp
-bTE
+bXk
 abI
 aaa
 aaa
@@ -85976,7 +86091,7 @@ fyO
 fyO
 hQC
 mpd
-bTE
+bXk
 aaa
 aaa
 aaa
@@ -86233,7 +86348,7 @@ fyO
 uoq
 hQC
 mpd
-bTE
+bXk
 aaa
 aaa
 aaa
@@ -86437,7 +86552,7 @@ bmA
 bjd
 bpY
 bpY
-cwP
+bpY
 pSc
 gGA
 bwW
@@ -86490,7 +86605,7 @@ fyO
 dZj
 ciI
 cfV
-bTE
+bXk
 aaa
 aaa
 aaa
@@ -86747,7 +86862,7 @@ cZt
 ciI
 cfV
 cfV
-bTE
+bXk
 abI
 aaa
 aaa
@@ -87004,7 +87119,7 @@ cjt
 cfV
 cfV
 cfV
-bTE
+bXk
 abI
 abI
 abI
@@ -87261,7 +87376,7 @@ woh
 liR
 phg
 cks
-bTE
+bXk
 abI
 aaa
 abI
@@ -87518,7 +87633,7 @@ fFv
 kWQ
 fFv
 fFv
-bTE
+bXk
 abI
 aaa
 aaa
@@ -87775,7 +87890,7 @@ fFv
 fFv
 fFv
 fFv
-bTE
+bXk
 abI
 abI
 abI
@@ -90032,7 +90147,7 @@ bks
 blD
 bko
 bko
-bko
+knx
 bqf
 bko
 bsV

--- a/_maps/map_files/PubbyStation/PubbyStation.dmm
+++ b/_maps/map_files/PubbyStation/PubbyStation.dmm
@@ -26348,7 +26348,7 @@
 	name = "Shutters Control";
 	pixel_x = 26;
 	pixel_y = 4;
-	req_access_txt = "5; 33"
+	req_one_access_txt = "5;33"
 	},
 /turf/open/floor/plasteel/whiteyellow/side{
 	dir = 5

--- a/_maps/shuttles/aux_base_small.dmm
+++ b/_maps/shuttles/aux_base_small.dmm
@@ -35,7 +35,8 @@
 /area/shuttle/auxillary_base)
 "h" = (
 /obj/machinery/camera{
-	dir = 1
+	dir = 1;
+	network = list("auxbase")
 	},
 /obj/structure/mining_shuttle_beacon,
 /turf/open/floor/plating,


### PR DESCRIPTION
:cl: Denton
tweak: Pubbystation: Added missing fire alarm, moved existing fire alarms to easier to reach positions. Replaced most department signs.
fix: Pubbystation: The auxillary base telescreen now works again.
tweak: Pubbystation: The southern engine room wall has been replaced with r-walls to make it harder to sabotage engine containment. 
/:cl:

- Replaced most department signs to make departments easier to find. Bridge/cargo now have them as well.
- Fixed the aux base camera network.
- Added missing fire alarm to CE office, moved other fire alarms that had awkward positioning (ie chemistry).
- Replaced the southern singulo containment wall with r-walls. It is way too easy for traitors to take down a single wall and snip emitter wires; this will make it a little more challenging.
- Fixed the req_access for chemistry shutters.