### PR TITLE
Fixes bounty console build_path

### DIFF
--- a/code/game/objects/items/circuitboards/computer_circuitboards.dm
+++ b/code/game/objects/items/circuitboards/computer_circuitboards.dm
@@ -234,7 +234,7 @@
 
 /obj/item/circuitboard/computer/bounty
 	name = "Nanotrasen Bounty Console (Computer Board)"
-	build_path = /obj/machinery/computer/cargo/request
+	build_path = /obj/machinery/computer/bounty
 
 /obj/item/circuitboard/computer/operating
 	name = "Operating Computer (Computer Board)"


### PR DESCRIPTION
:cl: Denton
fix: Bounty console circuit boards no longer construct into supply request terminals.
/:cl:

Build_path was set to cargo/request for whatever reason