### PR TITLE
Fixes emote runtimes

### DIFF
--- a/code/datums/brain_damage/split_personality.dm
+++ b/code/datums/brain_damage/split_personality.dm
@@ -142,7 +142,7 @@
 	to_chat(src, "<span class='warning'>You cannot speak, your other self is controlling your body!</span>")
 	return FALSE
 
-/mob/living/split_personality/emote(message)
+/mob/living/split_personality/emote(act, m_type = null, message = null, intentional = FALSE)
 	return
 
 ///////////////BRAINWASHING////////////////////

--- a/code/modules/mob/camera/camera.dm
+++ b/code/modules/mob/camera/camera.dm
@@ -28,5 +28,5 @@
 /mob/camera/forceMove(atom/destination)
 	loc = destination
 
-/mob/camera/emote(act, m_type=1, message = null)
+/mob/camera/emote(act, m_type=1, message = null, intentional = FALSE)
 	return

--- a/code/modules/mob/living/simple_animal/simple_animal.dm
+++ b/code/modules/mob/living/simple_animal/simple_animal.dm
@@ -268,7 +268,7 @@
 		verb_say = pick(speak_emote)
 	. = ..()
 
-/mob/living/simple_animal/emote(act, m_type=1, message = null)
+/mob/living/simple_animal/emote(act, m_type=1, message = null, intentional = FALSE)
 	if(stat)
 		return
 	if(act == "scream")


### PR DESCRIPTION
```
[19:01:07] Runtime in , line : bad arg name 'intentional'
proc name: emote (/mob/living/simple_animal/emote)
usr: Gorilla (305) (gblue) (/mob/living/simple_animal/hostile/gorilla)
usr.loc: The floor (91,151,2) (/turf/open/floor/plasteel)
src: Gorilla (305) (/mob/living/simple_animal/hostile/gorilla)
src.loc: the floor (91,151,2) (/turf/open/floor/plasteel)
call stack:
Gorilla (305) (/mob/living/simple_animal/hostile/gorilla): emote("ooga", null, null)
Gorilla (305) (/mob/living/simple_animal/hostile/gorilla): check emote("*ooga")
Gorilla (305) (/mob/living/simple_animal/hostile/gorilla): say("*ooga", null, /list (/list), 1, null, 0)
```

:cl: Naksu
fix: fixed some missing args in emote procs called with named args, leading to runtimes
/:cl:


