### PR TITLE
Fix Shuttle Manipulator admin verb

### DIFF
--- a/code/modules/shuttle/manipulator.dm
+++ b/code/modules/shuttle/manipulator.dm
@@ -40,6 +40,10 @@
 	add_overlay(hologram_projection)
 	add_overlay(hologram_ship)
 
+/obj/machinery/shuttle_manipulator/can_interact(mob/user)
+	// Only admins can use this, but they can use it from anywhere
+	return user.client && check_rights_for(user.client, R_ADMIN)
+
 /obj/machinery/shuttle_manipulator/ui_interact(mob/user, ui_key = "main", datum/tgui/ui = null, force_open = FALSE, datum/tgui/master_ui = null, datum/ui_state/state = GLOB.admin_state)
 	ui = SStgui.try_update_ui(user, src, ui_key, ui, force_open)
 	if(!ui)


### PR DESCRIPTION
:cl:
fix: The Shuttle Manipulator admin verb works once more.
/:cl:

Fixes #39103.

Also makes it so non-admins (namely ERT members) can't use the shuttle manipulator.