### PR TITLE
[s] Fixes SM-megafauna server crash exploit

### DIFF
--- a/code/modules/mob/living/death.dm
+++ b/code/modules/mob/living/death.dm
@@ -26,14 +26,14 @@
 /mob/living/proc/spread_bodyparts()
 	return
 
-/mob/living/dust(just_ash = FALSE, drop_items = FALSE)
+/mob/living/dust(just_ash, drop_items, force)
 	death(TRUE)
 
 	if(drop_items)
 		unequip_everything()
 
 	if(buckled)
-		buckled.unbuckle_mob(src,force=1)
+		buckled.unbuckle_mob(src, force = TRUE)
 
 	dust_animation()
 	spawn_dust(just_ash)

--- a/code/modules/mob/living/simple_animal/hostile/megafauna/megafauna.dm
+++ b/code/modules/mob/living/simple_animal/hostile/megafauna/megafauna.dm
@@ -68,8 +68,8 @@
 	else
 		..()
 
-/mob/living/simple_animal/hostile/megafauna/dust()
-	if(health > 0)
+/mob/living/simple_animal/hostile/megafauna/dust(just_ash, drop_items, force)
+	if(!force && health > 0)
 		return
 	else
 		..()

--- a/code/modules/power/supermatter/supermatter.dm
+++ b/code/modules/power/supermatter/supermatter.dm
@@ -615,7 +615,7 @@ GLOBAL_DATUM(main_supermatter_engine, /obj/machinery/power/supermatter_crystal)
 			return
 		message_admins("[src] has consumed [key_name_admin(user)] [ADMIN_JMP(src)].")
 		investigate_log("has consumed [key_name(user)].", INVESTIGATE_SUPERMATTER)
-		user.dust()
+		user.dust(force = TRUE)
 		matter_power += 200
 	else if(istype(AM, /obj/singularity))
 		return

--- a/config/admins.txt
+++ b/config/admins.txt
@@ -138,3 +138,4 @@ The Dreamweaver = Game Master
 88Naoki = Game Master
 Naksuasdf = Game Master
 MrDoomBringer = Game Master
+shizcalev = Game Master


### PR DESCRIPTION
You could infinitely touch the SM after being turned into a lesser ash drake via potion, which results in a server crash.

:cl: ShizCalev
tweak: The SM is now even more deadly to "certain mobs"™
/:cl: