### PR TITLE
Tones down hotspot_expose values for sparks

### DIFF
--- a/code/game/objects/effects/effect_system/effects_sparks.dm
+++ b/code/game/objects/effects/effect_system/effects_sparks.dm
@@ -28,20 +28,20 @@
 	playsound(src.loc, "sparks", 100, 1)
 	var/turf/T = loc
 	if(isturf(T))
-		T.hotspot_expose(700,5)
+		T.hotspot_expose(35,5)
 	QDEL_IN(src, 20)
 
 /obj/effect/particle_effect/sparks/Destroy()
 	var/turf/T = loc
 	if(isturf(T))
-		T.hotspot_expose(700,1)
+		T.hotspot_expose(35,1)
 	return ..()
 
 /obj/effect/particle_effect/sparks/Move()
 	..()
 	var/turf/T = loc
 	if(isturf(T))
-		T.hotspot_expose(700,1)
+		T.hotspot_expose(35,1)
 
 /datum/effect_system/spark_spread
 	effect_type = /obj/effect/particle_effect/sparks


### PR DESCRIPTION
:cl: Denton
tweak: Sparks now emit less heat.
/:cl:

Giving cosmetic effects like sparks a noticable impact on gameplay without considering the consequences isn't great. 
Some objs (RPD, emitters) constantly spam sparks, space heaters are extremely ineffective at reducing temps and air alarms can't handle high temperatures short of siphoning/replacing the room's air (making it uninhabitable).
