### PR TITLE
Tweaks outfit datums

### DIFF
--- a/code/modules/awaymissions/corpse.dm
+++ b/code/modules/awaymissions/corpse.dm
@@ -336,10 +336,10 @@
 
 /obj/effect/mob_spawn/human/miner
 	name = "Shaft Miner"
-	outfit = /datum/outfit/job/miner/asteroid
+	outfit = /datum/outfit/job/miner
 
 /obj/effect/mob_spawn/human/miner/rig
-	outfit = /datum/outfit/job/miner/equipped/asteroid
+	outfit = /datum/outfit/job/miner/equipped/hardsuit
 
 /obj/effect/mob_spawn/human/miner/explorer
 	outfit = /datum/outfit/job/miner/equipped

--- a/code/modules/clothing/outfits/standard.dm
+++ b/code/modules/clothing/outfits/standard.dm
@@ -435,9 +435,4 @@
 	glasses = /obj/item/clothing/glasses/meson/night
 	ears = /obj/item/radio/headset/headset_cent/commander
 	back = /obj/item/storage/backpack/holding
-
-	backpack_contents = list(/obj/item/card/emag=1,\ 
-		/obj/item/flashlight/emp/debug=1,\
-		/obj/item/construction/rcd/combat =1,\
-		/obj/item/gun/magic/wand/resurrection/debug=1,\
-		/obj/item/melee/transforming/energy/axe=1)
+	backpack_contents = list(/obj/item/card/emag=1,	/obj/item/flashlight/emp/debug=1, /obj/item/construction/rcd/combat =1, /obj/item/gun/magic/wand/resurrection/debug=1, /obj/item/melee/transforming/energy/axe=1)

--- a/code/modules/clothing/outfits/standard.dm
+++ b/code/modules/clothing/outfits/standard.dm
@@ -424,6 +424,20 @@
 	mask = /obj/item/clothing/mask/breath
 	suit_store = /obj/item/tank/internals/oxygen
 
+/datum/outfit/debug //Debug objs plus hardsuit
+	name = "Debug outfit"
+	uniform = /obj/item/clothing/under/patriotsuit 
+	suit = /obj/item/clothing/suit/space/hardsuit/syndi/elite
+	suit_store = /obj/item/tank/internals/oxygen
+	belt = /obj/item/storage/belt/utility/chief/full
+	gloves = /obj/item/clothing/gloves/combat
+	id = /obj/item/card/id/ert
+	glasses = /obj/item/clothing/glasses/meson/night
+	ears = /obj/item/radio/headset/headset_cent/commander
+	back = /obj/item/storage/backpack/holding
 
-
-
+	backpack_contents = list(/obj/item/card/emag=1,\ 
+		/obj/item/flashlight/emp/debug=1,\
+		/obj/item/construction/rcd/combat =1,\
+		/obj/item/gun/magic/wand/resurrection/debug=1,\
+		/obj/item/melee/transforming/energy/axe=1)

--- a/code/modules/jobs/job_types/captain.dm
+++ b/code/modules/jobs/job_types/captain.dm
@@ -52,6 +52,13 @@ Captain
 
 	chameleon_extras = list(/obj/item/gun/energy/e_gun, /obj/item/stamp/captain)
 
+/datum/outfit/job/captain/hardsuit
+	name = "Captain (Hardsuit)"
+
+	mask = /obj/item/clothing/mask/gas/sechailer
+	suit = /obj/item/clothing/suit/space/hardsuit/captain
+	suit_store = /obj/item/tank/internals/oxygen
+
 /*
 Head of Personnel
 */

--- a/code/modules/jobs/job_types/cargo_service.dm
+++ b/code/modules/jobs/job_types/cargo_service.dm
@@ -78,7 +78,7 @@ Shaft Miner
 	minimal_access = list(ACCESS_MINING, ACCESS_MINING_STATION, ACCESS_MAILSORTING, ACCESS_MINERAL_STOREROOM)
 
 /datum/outfit/job/miner
-	name = "Shaft Miner (Lavaland)"
+	name = "Shaft Miner"
 	jobtype = /datum/job/mining
 
 	belt = /obj/item/pda/shaftminer
@@ -101,13 +101,8 @@ Shaft Miner
 
 	chameleon_extras = /obj/item/gun/energy/kinetic_accelerator
 
-/datum/outfit/job/miner/asteroid
-	name = "Shaft Miner (Asteroid)"
-	uniform = /obj/item/clothing/under/rank/miner
-	shoes = /obj/item/clothing/shoes/workboots
-
 /datum/outfit/job/miner/equipped
-	name = "Shaft Miner (Lavaland + Equipment)"
+	name = "Shaft Miner (Equipment)"
 	suit = /obj/item/clothing/suit/hooded/explorer
 	mask = /obj/item/clothing/mask/gas/explorer
 	glasses = /obj/item/clothing/glasses/meson
@@ -130,13 +125,9 @@ Shaft Miner
 		S.ToggleHood()
 
 /datum/outfit/job/miner/equipped/asteroid
-	name = "Shaft Miner (Asteroid + Equipment)"
-	uniform = /obj/item/clothing/under/rank/miner
-	shoes = /obj/item/clothing/shoes/workboots
+	name = "Shaft Miner (Equipment + Hardsuit)"
 	suit = /obj/item/clothing/suit/space/hardsuit/mining
 	mask = /obj/item/clothing/mask/breath
-
-
 
 /*
 Bartender

--- a/code/modules/jobs/job_types/cargo_service.dm
+++ b/code/modules/jobs/job_types/cargo_service.dm
@@ -124,7 +124,7 @@ Shaft Miner
 		var/obj/item/clothing/suit/hooded/S = H.wear_suit
 		S.ToggleHood()
 
-/datum/outfit/job/miner/equipped/asteroid
+/datum/outfit/job/miner/equipped/hardsuit
 	name = "Shaft Miner (Equipment + Hardsuit)"
 	suit = /obj/item/clothing/suit/space/hardsuit/mining
 	mask = /obj/item/clothing/mask/breath

--- a/code/modules/jobs/job_types/engineering.dm
+++ b/code/modules/jobs/job_types/engineering.dm
@@ -57,6 +57,7 @@ Chief Engineer
 	suit = /obj/item/clothing/suit/space/hardsuit/engine/elite
 	shoes = /obj/item/clothing/shoes/magboots/advance
 	suit_store = /obj/item/tank/internals/oxygen
+	glasses = /obj/item/clothing/glasses/meson/engine
 	gloves = /obj/item/clothing/gloves/color/yellow
 	head = null
 	internals_slot = SLOT_S_STORE

--- a/code/modules/jobs/job_types/medical.dm
+++ b/code/modules/jobs/job_types/medical.dm
@@ -48,7 +48,7 @@ Chief Medical Officer
 
 	chameleon_extras = list(/obj/item/gun/syringe, /obj/item/stamp/cmo)
 
-/datum/outfit/job/cmo
+/datum/outfit/job/cmo/hardsuit
 	name = "Chief Medical Officer (Hardsuit)"
 
 	mask = /obj/item/clothing/mask/breath

--- a/code/modules/jobs/job_types/medical.dm
+++ b/code/modules/jobs/job_types/medical.dm
@@ -48,6 +48,14 @@ Chief Medical Officer
 
 	chameleon_extras = list(/obj/item/gun/syringe, /obj/item/stamp/cmo)
 
+/datum/outfit/job/cmo
+	name = "Chief Medical Officer (Hardsuit)"
+
+	mask = /obj/item/clothing/mask/breath
+	suit = /obj/item/clothing/suit/space/hardsuit/medical
+	suit_store = /obj/item/tank/internals/oxygen
+	r_pocket = /obj/item/flashlight/pen
+
 /*
 Medical Doctor
 */

--- a/code/modules/jobs/job_types/security.dm
+++ b/code/modules/jobs/job_types/security.dm
@@ -62,6 +62,14 @@ Head of Security
 
 	chameleon_extras = list(/obj/item/gun/energy/e_gun/hos, /obj/item/stamp/hos)
 
+/datum/outfit/job/hos/hardsuit
+	name = "Head of Security (Hardsuit)"
+
+	mask = /obj/item/clothing/mask/gas/sechailer
+	suit = /obj/item/clothing/suit/space/hardsuit/security/hos
+	suit_store = /obj/item/tank/internals/oxygen
+	backpack_contents = list(/obj/item/melee/baton/loaded=1, /obj/item/gun/energy/e_gun=1)
+
 /*
 Warden
 */

--- a/code/modules/vending/wardrobes.dm
+++ b/code/modules/vending/wardrobes.dm
@@ -105,6 +105,7 @@
 					/obj/item/clothing/gloves/fingerless = 3,
 					/obj/item/clothing/head/soft = 3,
 					/obj/item/radio/headset/headset_cargo = 1)
+	premium = list(/obj/item/clothing/under/rank/miner = 3)
 	refill_canister = /obj/item/vending_refill/wardrobe/cargo_wardrobe
 
 /obj/item/vending_refill/wardrobe/cargo_wardrobe

--- a/code/modules/vending/wardrobes.dm
+++ b/code/modules/vending/wardrobes.dm
@@ -105,7 +105,6 @@
 					/obj/item/clothing/gloves/fingerless = 3,
 					/obj/item/clothing/head/soft = 3,
 					/obj/item/radio/headset/headset_cargo = 1)
-	premium = list(/obj/item/clothing/under/rank/miner = 3)
 	refill_canister = /obj/item/vending_refill/wardrobe/cargo_wardrobe
 
 /obj/item/vending_refill/wardrobe/cargo_wardrobe


### PR DESCRIPTION
:cl: Denton
admin: Added hardsuit outfits for the Captain, HoS, and CMO. Removed old Shaft Miner (Asteroid) outfits. Gave Chief Engineer (Hardsuit) engineering scanner goggles. Added debug outfit for testing.
/:cl:

I added hardsuit outfit datums for Cap/HoS/CMO so admins have an easier time dressing up players. I removed Shaft Miner (Asteroid), since the asteroid has been dead for a long time. 
Also added a "debug" outfit so I don't have to spend 2 1/2 seconds spawning equipment when testing.