### PR TITLE
Revert "[s] Guards client.holder"

### DIFF
--- a/code/modules/client/client_procs.dm
+++ b/code/modules/client/client_procs.dm
@@ -152,11 +152,6 @@ GLOBAL_LIST_INIT(blacklisted_builds, list(
 GLOBAL_LIST_EMPTY(external_rsc_urls)
 #endif
 
-/client/can_vv_get(var_name)
-	return var_name != NAMEOF(src, holder) && ..()
-
-/client/vv_edit_var(var_name, var_value)
-	return var_name != NAMEOF(src, holder) && ..()
 
 /client/New(TopicData)
 	var/tdata = TopicData //save this for later use


### PR DESCRIPTION
vv_edit_var already exists and already guards holder.

And there is 0 legit reason to hide the datum from me.

https://github.com/tgstation/tgstation/blame/803556b92391575392952d995c14a3295c90551b/code/modules/client/client_procs.dm#L738