### PR TITLE
Removes can_vv_get from some things

### DIFF
--- a/code/controllers/globals.dm
+++ b/code/controllers/globals.dm
@@ -30,11 +30,6 @@ GLOBAL_REAL(GLOB, /datum/controller/global_vars)
 	
 	stat("Globals:", statclick.update("Edit"))
 
-/datum/controller/global_vars/can_vv_get(var_name)
-	if(gvars_datum_protected_varlist[var_name])
-		return FALSE
-	return ..()
-
 /datum/controller/global_vars/vv_edit_var(var_name, var_value)
 	if(gvars_datum_protected_varlist[var_name])
 		return FALSE

--- a/code/modules/admin/admin_ranks.dm
+++ b/code/modules/admin/admin_ranks.dm
@@ -42,9 +42,6 @@ GLOBAL_PROTECT(protected_ranks)
 		return QDEL_HINT_LETMELIVE
 	. = ..()
 
-/datum/admin_rank/can_vv_get(var_name)
-	return FALSE
-
 /datum/admin_rank/vv_edit_var(var_name, var_value)
 	return FALSE
 

--- a/code/modules/admin/holder2.dm
+++ b/code/modules/admin/holder2.dm
@@ -146,9 +146,6 @@ GLOBAL_PROTECT(href_token)
 			return 1 //we have all the rights they have and more
 	return 0
 
-/datum/admins/can_vv_get(var_name, var_value)
-	return FALSE //nice try trialmin
-
 /datum/admins/vv_edit_var(var_name, var_value)
 	return FALSE //nice try trialmin
 

--- a/code/modules/client/client_procs.dm
+++ b/code/modules/client/client_procs.dm
@@ -152,9 +152,6 @@ GLOBAL_LIST_INIT(blacklisted_builds, list(
 GLOBAL_LIST_EMPTY(external_rsc_urls)
 #endif
 
-/client/vv_edit_var(var_name, var_value)
-	return var_name != NAMEOF(src, holder) && ..()
-
 /client/New(TopicData)
 	var/tdata = TopicData //save this for later use
 	chatOutput = new /datum/chatOutput(src)

--- a/code/modules/client/client_procs.dm
+++ b/code/modules/client/client_procs.dm
@@ -152,9 +152,6 @@ GLOBAL_LIST_INIT(blacklisted_builds, list(
 GLOBAL_LIST_EMPTY(external_rsc_urls)
 #endif
 
-/client/can_vv_get(var_name)
-	return var_name != NAMEOF(src, holder) && ..()
-
 /client/vv_edit_var(var_name, var_value)
 	return var_name != NAMEOF(src, holder) && ..()
 


### PR DESCRIPTION
Globals are a leftover from when they stored the db password

holder doesn't need read protection

Closes #39135 
Closes #39134 