### PR TITLE
removes unused icon helper

### DIFF
--- a/code/__HELPERS/icons.dm
+++ b/code/__HELPERS/icons.dm
@@ -931,15 +931,6 @@ world
 	flat_icon.AddAlphaMask(alpha_mask)//Finally, let's mix in a distortion effect.
 	return flat_icon
 
-//For photo camera.
-/proc/build_composite_icon(atom/A)
-	var/icon/composite = icon(A.icon, A.icon_state, A.dir, 1)
-	for(var/O in A.overlays)
-		var/image/I = O
-		composite.Blend(icon(I.icon, I.icon_state, I.dir, 1), ICON_OVERLAY)
-	return composite
-
-
 //What the mob looks like as animated static
 //By vg's ComicIronic
 /proc/getStaticIcon(icon/A, safety = TRUE)


### PR DESCRIPTION
deprecated by getflaticon
not used anywhere
won't even work on anything with a direction if there's only a south state in its icon