### PR TITLE
Add UI to circuit printers

### DIFF
--- a/code/modules/integrated_electronics/core/printer.dm
+++ b/code/modules/integrated_electronics/core/printer.dm
@@ -109,6 +109,9 @@
 	interact(user)
 
 /obj/item/integrated_circuit_printer/interact(mob/user)
+	if(!(in_range(src, user) || issilicon(user)))
+		return
+
 	if(isnull(current_category))
 		current_category = SScircuit.circuit_fabricator_recipe_list[1]
 
@@ -116,9 +119,6 @@
 
 	//Preparing the browser
 	var/datum/browser/popup = new(user, "printernew", "Integrated Circuit Printer", 800, 630) // Set up the popup browser window
-	if(!(in_range(src, user) || issilicon(user)))
-		popup.close()
-		return
 
 	var/HTML = "<center><h2>Integrated Circuit Printer</h2></center><br>"
 	if(debug)

--- a/code/modules/integrated_electronics/core/printer.dm
+++ b/code/modules/integrated_electronics/core/printer.dm
@@ -170,8 +170,6 @@
 		else
 			HTML += "<s>\[[initial(O.name)]\]</s>: [initial(O.desc)]<br>"
 
-	user << browse(HTML, "window=integrated_printer;size=600x500;border=1;can_resize=1;can_close=1;can_minimize=1")
-
 	popup.set_content(HTML)
 	popup.open()
 

--- a/code/modules/integrated_electronics/core/printer.dm
+++ b/code/modules/integrated_electronics/core/printer.dm
@@ -38,6 +38,7 @@
 /obj/item/integrated_circuit_printer/proc/print_program(mob/user)
 	if(!cloning)
 		return
+
 	visible_message("<span class='notice'>[src] has finished printing its assembly!</span>")
 	playsound(src, 'sound/items/poster_being_created.ogg', 50, TRUE)
 	var/obj/item/electronic_assembly/assembly = SScircuit.load_electronic_assembly(get_turf(src), program)
@@ -113,6 +114,12 @@
 
 	var/datum/component/material_container/materials = GetComponent(/datum/component/material_container)
 
+	//Preparing the browser
+	var/datum/browser/popup = new(user, "printernew", "Integrated Circuit Printer", 800, 630) // Set up the popup browser window
+	if(!(in_range(src, user) || issilicon(user)))
+		popup.close()
+		return
+
 	var/HTML = "<center><h2>Integrated Circuit Printer</h2></center><br>"
 	if(debug)
 		HTML += "<center><h3>DEBUG PRINTER -- Infinite materials. Cloning available.</h3></center>"
@@ -164,6 +171,9 @@
 			HTML += "<s>\[[initial(O.name)]\]</s>: [initial(O.desc)]<br>"
 
 	user << browse(HTML, "window=integrated_printer;size=600x500;border=1;can_resize=1;can_close=1;can_minimize=1")
+
+	popup.set_content(HTML)
+	popup.open()
 
 /obj/item/integrated_circuit_printer/Topic(href, href_list)
 	if(!check_interactivity(usr))


### PR DESCRIPTION
The ugly white with text looks kinda ugly, so let's add some css to it and make it borderline bearable for eyes.

:cl:
tweak: added UI to the circuit printer. That's all
/:cl:

Because the interface is kinda hard to look at as it is now and it can be confusing to get into circuitry that way.