### PR TITLE
Allows AI read access to smartfridges

### DIFF
--- a/code/modules/food_and_drinks/kitchen_machinery/smartfridge.dm
+++ b/code/modules/food_and_drinks/kitchen_machinery/smartfridge.dm
@@ -170,6 +170,7 @@
 			var/desired = 0
 
 			if(!allow_ai_retrieve && isAI(usr))
+				to_chat(usr, "<span class='warning'>[src] does not seem to be configured to respect your authority!</span>")
 				return
 
 			if (params["amount"])

--- a/code/modules/food_and_drinks/kitchen_machinery/smartfridge.dm
+++ b/code/modules/food_and_drinks/kitchen_machinery/smartfridge.dm
@@ -15,6 +15,7 @@
 	var/max_n_of_items = 1500
 	var/icon_on = "smartfridge"
 	var/icon_off = "smartfridge-off"
+	var/allow_ai_retrieve = FALSE
 	var/list/initial_contents
 
 /obj/machinery/smartfridge/Initialize()
@@ -131,9 +132,6 @@
 			O.forceMove(src)
 			return TRUE
 
-/obj/machinery/smartfridge/attack_ai(mob/user)
-	return FALSE
-
 /obj/machinery/smartfridge/ui_interact(mob/user, ui_key = "main", datum/tgui/ui = null, force_open = FALSE, datum/tgui/master_ui = null, datum/ui_state/state = GLOB.default_state)
 	ui = SStgui.try_update_ui(user, src, ui_key, ui, force_open)
 	if(!ui)
@@ -170,6 +168,9 @@
 	switch(action)
 		if("Release")
 			var/desired = 0
+
+			if(!allow_ai_retrieve && isAI(usr))
+				return
 
 			if (params["amount"])
 				desired = text2num(params["amount"])


### PR DESCRIPTION
Ehhhhhh why not. Give the AI some more fun. Can argue about giving them access to dump stuff out in some other PR.
:cl:
rscadd: AIs can now interact with smartfridges by default, but by default they will not be able to retrieve items.
/:cl: