### PR TITLE
[Ready] Re-adds M-90gl to Nuke Ops uplink

### DIFF
--- a/code/modules/uplink/uplink_items.dm
+++ b/code/modules/uplink/uplink_items.dm
@@ -521,7 +521,7 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 /datum/uplink_item/ammo/carbine
 	name = "5.56mm Toploader Magazine"
 	desc = "An additional 30-round 5.56mm magazine; suitable for use with the M-90gl carbine. \
-			These bullets pack the punch of 1.95mm rounds, but they still offer more power than .45 ammo."
+			These bullets pack less punch than 1.95mm rounds, but they still offer more power than .45 ammo."
 	item = /obj/item/ammo_box/magazine/m556
 	cost = 4
 	include_modes = list(/datum/game_mode/nuclear)

--- a/code/modules/uplink/uplink_items.dm
+++ b/code/modules/uplink/uplink_items.dm
@@ -201,6 +201,15 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 	cost = 10
 	surplus = 40
 	include_modes = list(/datum/game_mode/nuclear)
+	
+/datum/uplink_item/dangerous/carbine
+	name = "M-90gl Carbine"
+	desc = "A fully-loaded, specialized three-round burst carbine that fires 30-round 5.56mm magazines with a togglable \
+			underslung 40mm grenade launcher."
+	item = /obj/item/gun/ballistic/automatic/m90
+	cost = 18
+	surplus = 50
+	include_modes = list(/datum/game_mode/nuclear)
 
 /datum/uplink_item/dangerous/machinegun
 	name = "L6 Squad Automatic Weapon"
@@ -507,6 +516,22 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 	desc = "A duffel bag filled with enough .45 ammo to supply an entire team, at a discounted price."
 	item = /obj/item/storage/backpack/duffelbag/syndie/ammo/smg
 	cost = 20
+	include_modes = list(/datum/game_mode/nuclear)
+	
+/datum/uplink_item/ammo/carbine
+	name = "5.56 Toploader Magazine"
+	desc = "An additional 30-round 5.56 magazine; sutable for use with the M-90gl carbine. \
+			These bullets don't have the punch to knock most targets down, but dish out higher overall damage."
+	item = /obj/item/ammo_box/magazine/m556
+	cost = 5
+	include_modes = list(/datum/game_mode/nuclear)
+	
+/datum/uplink_item/ammo/a40mm
+	name = "40mm Grenade"
+	desc = "A 40mm HE grenade for use with the M-90gl's underbarrel grenade launcher. \
+			Your teammates will ask you to not shoot these down small hallways."
+	item = /obj/item/ammo_casing/a40mm
+	cost = 2
 	include_modes = list(/datum/game_mode/nuclear)
 
 /datum/uplink_item/ammo/machinegun

--- a/code/modules/uplink/uplink_items.dm
+++ b/code/modules/uplink/uplink_items.dm
@@ -204,8 +204,8 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 	
 /datum/uplink_item/dangerous/carbine
 	name = "M-90gl Carbine"
-	desc = "A fully-loaded, specialized three-round burst carbine that fires 30-round 5.56mm magazines with a togglable \
-			underslung 40mm grenade launcher."
+	desc = "A fully-loaded, specialized three-round burst carbine that fires 5.56mm ammunition from a 30 round magazine \
+			with a togglable 40mm under-barrel grenade launcher."
 	item = /obj/item/gun/ballistic/automatic/m90
 	cost = 18
 	surplus = 50
@@ -519,16 +519,16 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 	include_modes = list(/datum/game_mode/nuclear)
 	
 /datum/uplink_item/ammo/carbine
-	name = "5.56 Toploader Magazine"
-	desc = "An additional 30-round 5.56 magazine; sutable for use with the M-90gl carbine. \
-			These bullets don't have the punch to knock most targets down, but dish out higher overall damage."
+	name = "5.56mm Toploader Magazine"
+	desc = "An additional 30-round 5.56mm magazine; suitable for use with the M-90gl carbine. \
+			These bullets pack the punch of 1.95mm rounds, but they still offer more power than .45 ammo."
 	item = /obj/item/ammo_box/magazine/m556
 	cost = 4
 	include_modes = list(/datum/game_mode/nuclear)
 	
 /datum/uplink_item/ammo/a40mm
 	name = "40mm Grenade"
-	desc = "A 40mm HE grenade for use with the M-90gl's underbarrel grenade launcher. \
+	desc = "A 40mm HE grenade for use with the M-90gl's under-barrel grenade launcher. \
 			Your teammates will ask you to not shoot these down small hallways."
 	item = /obj/item/ammo_casing/a40mm
 	cost = 2

--- a/code/modules/uplink/uplink_items.dm
+++ b/code/modules/uplink/uplink_items.dm
@@ -523,7 +523,7 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 	desc = "An additional 30-round 5.56 magazine; sutable for use with the M-90gl carbine. \
 			These bullets don't have the punch to knock most targets down, but dish out higher overall damage."
 	item = /obj/item/ammo_box/magazine/m556
-	cost = 5
+	cost = 4
 	include_modes = list(/datum/game_mode/nuclear)
 	
 /datum/uplink_item/ammo/a40mm


### PR DESCRIPTION
:cl: 
add: The M-90gl is back in the Nuke Ops uplink with rebalanced pricing. 
/:cl:

I thought this weapon was interesting enough to re-add as a Nuke Ops weapon. In the course of making this PR I went back to some of the PRs from when it was removed from the uplink to get a good sense of what was seen as wrong with it at the time. I have done my best to deal with these issues and balance it properly.
In terms of power, the weapon basically fits between the C-20r and the L6 SAW. It's more portable than a SAW, but generally less powerful, and costs just as much to purchase and outfit. The weapon fires half as fast as a SAW and the bullets do less damage, just barely critting an unarmored person with a full burst. Targets with even the relatively weak Security Officer body armor can withstand a burst from it, and people wearing Bulletproof Armor can take multiple bursts before going down. The grenade launcher is strong, but slow to reload, and expensive to use a lot.

For people who remember the old one, this is basically the same thing but significantly more expensive. I also changed the grenade shells to be purchasable individually for 2 TC each instead of buying a box of 4 for 5 TC. There's also no ridiculously cheap bundle this time around, that can stay gone. 