### PR TITLE
Fixes bee terrorist outfit datum

### DIFF
--- a/code/modules/mob/living/simple_animal/corpse.dm
+++ b/code/modules/mob/living/simple_animal/corpse.dm
@@ -209,6 +209,7 @@
 	outfit = /datum/outfit/bee_terrorist
 	
 /datum/outfit/bee_terrorist
+	name = "BLF Operative"
 	uniform = /obj/item/clothing/under/color/yellow
 	suit = /obj/item/clothing/suit/hooded/bee_costume
 	shoes = /obj/item/clothing/shoes/sneakers/yellow


### PR DESCRIPTION
BLF outfit datum had no name, which lead to the "Naked" outfit selecting this one instead.

Fixes: #39149
