### PR TITLE
Fixes mech equipment being unremovable

### DIFF
--- a/code/game/atoms_movable.dm
+++ b/code/game/atoms_movable.dm
@@ -151,19 +151,11 @@
 	if(!direct)
 		direct = get_dir(src, newloc)
 	setDir(direct)
-	
-	if(!loc.Exit(src))
-		return
-	for(var/i in loc)
-		if(i == src)
-			continue
-		var/atom/movable/thing = i
-		if(!thing.Uncross(src, newloc))
-			if(thing.flags_1 & ON_BORDER_1)
-				Bump(thing)
-			return
 
-	if(!newloc.Enter(src))
+	if(!loc.Exit(src, newloc))
+		return
+
+	if(!newloc.Enter(src, src.loc))
 		return
 
 	// Past this is the point of no return

--- a/code/game/turfs/turf.dm
+++ b/code/game/turfs/turf.dm
@@ -149,7 +149,7 @@
 		firstbump = src
 	else
 		for(var/i in contents)
-			if(i == mover) // Multi tile objects
+			if(i == mover || i == mover.loc) // Multi tile objects and moving out of other objects
 				continue
 			var/atom/movable/thing = i
 			if(thing.Cross(mover))
@@ -160,6 +160,19 @@
 		mover.Bump(firstbump)
 		return FALSE
 	return TRUE
+
+/turf/Exit(atom/movable/mover, atom/newloc)
+	. = ..()
+	if(!.)
+		return FALSE
+	for(var/i in contents)
+		if(i == mover)
+			continue
+		var/atom/movable/thing = i
+		if(!thing.Uncross(mover, newloc))
+			if(thing.flags_1 & ON_BORDER_1)
+				mover.Bump(thing)
+			return FALSE
 
 /turf/Entered(atom/movable/AM)
 	..()


### PR DESCRIPTION
:cl: ninjanomnom
fix: Mech equipment can be detached again. This probably also fixes any other uncaught bugs relating to objects moving out of other objects.
/:cl:

fixes #39137

I moved the `Exit()` functionality to be similar to `Enter()`