### PR TITLE
Enables async queries on everything not in the startup/shutdown flow

### DIFF
--- a/code/__HELPERS/roundend.dm
+++ b/code/__HELPERS/roundend.dm
@@ -523,7 +523,7 @@
 	else if(load_admins(TRUE)) //returns true if there was a database failure and the backup was loaded from
 		return
 	var/datum/DBQuery/query_admin_rank_update = SSdbcore.NewQuery("UPDATE [format_table_name("player")] p INNER JOIN [format_table_name("admin")] a ON p.ckey = a.ckey SET p.lastadminrank = a.rank")
-	query_admin_rank_update.Execute()
+	query_admin_rank_update.Execute(async = TRUE)
 	qdel(query_admin_rank_update)
 
 	//json format backup file generation stored per server

--- a/code/controllers/subsystem/blackbox.dm
+++ b/code/controllers/subsystem/blackbox.dm
@@ -45,7 +45,7 @@ SUBSYSTEM_DEF(blackbox)
 			playercount += 1
 	var/admincount = GLOB.admins.len
 	var/datum/DBQuery/query_record_playercount = SSdbcore.NewQuery("INSERT INTO [format_table_name("legacy_population")] (playercount, admincount, time, server_ip, server_port, round_id) VALUES ([playercount], [admincount], '[SQLtime()]', INET_ATON(IF('[world.internet_address]' LIKE '', '0', '[world.internet_address]')), '[world.port]', '[GLOB.round_id]')")
-	query_record_playercount.Execute()
+	query_record_playercount.Execute(async = TRUE)
 	qdel(query_record_playercount)
 
 /datum/controller/subsystem/blackbox/Recover()
@@ -331,5 +331,5 @@ Versioning
 	map = sanitizeSQL(map)
 	var/datum/DBQuery/query_report_death = SSdbcore.NewQuery("INSERT INTO [format_table_name("death")] (pod, x_coord, y_coord, z_coord, mapname, server_ip, server_port, round_id, tod, job, special, name, byondkey, laname, lakey, bruteloss, fireloss, brainloss, oxyloss, toxloss, cloneloss, staminaloss, last_words, suicide) VALUES ('[sqlpod]', '[x_coord]', '[y_coord]', '[z_coord]', '[map]', INET_ATON(IF('[world.internet_address]' LIKE '', '0', '[world.internet_address]')), '[world.port]', [GLOB.round_id], '[SQLtime()]', '[sqljob]', '[sqlspecial]', '[sqlname]', '[sqlkey]', '[laname]', '[lakey]', [sqlbrute], [sqlfire], [sqlbrain], [sqloxy], [sqltox], [sqlclone], [sqlstamina], '[last_words]', [suicide])")
 	if(query_report_death)
-		query_report_death.Execute()
+		query_report_death.Execute(async = TRUE)
 		qdel(query_report_death)

--- a/code/controllers/subsystem/dbcore.dm
+++ b/code/controllers/subsystem/dbcore.dm
@@ -133,7 +133,7 @@ SUBSYSTEM_DEF(dbcore)
 	if(!Connect())
 		return
 	var/datum/DBQuery/query_round_start = SSdbcore.NewQuery("UPDATE [format_table_name("round")] SET start_datetime = Now() WHERE id = [GLOB.round_id]")
-	query_round_start.Execute()
+	query_round_start.Execute(async = TRUE)
 	qdel(query_round_start)
 
 /datum/controller/subsystem/dbcore/proc/SetRoundEnd()
@@ -141,7 +141,7 @@ SUBSYSTEM_DEF(dbcore)
 		return
 	var/sql_station_name = sanitizeSQL(station_name())
 	var/datum/DBQuery/query_round_end = SSdbcore.NewQuery("UPDATE [format_table_name("round")] SET end_datetime = Now(), game_mode_result = '[sanitizeSQL(SSticker.mode_result)]', station_name = '[sql_station_name]' WHERE id = [GLOB.round_id]")
-	query_round_end.Execute()
+	query_round_end.Execute(async = TRUE)
 	qdel(query_round_end)
 
 /datum/controller/subsystem/dbcore/proc/Disconnect()

--- a/code/controllers/subsystem/mapping.dm
+++ b/code/controllers/subsystem/mapping.dm
@@ -223,7 +223,7 @@ SUBSYSTEM_DEF(mapping)
 
 	if(SSdbcore.Connect())
 		var/datum/DBQuery/query_round_map_name = SSdbcore.NewQuery("UPDATE [format_table_name("round")] SET map_name = '[config.map_name]' WHERE id = [GLOB.round_id]")
-		query_round_map_name.Execute()
+		query_round_map_name.Execute(async = TRUE)
 		qdel(query_round_map_name)
 
 #ifndef LOWMEMORYMODE

--- a/code/game/gamemodes/game_mode.dm
+++ b/code/game/gamemodes/game_mode.dm
@@ -83,6 +83,10 @@
 		report = !CONFIG_GET(flag/no_intercept_report)
 	addtimer(CALLBACK(GLOBAL_PROC, .proc/display_roundstart_logout_report), ROUNDSTART_LOGOUT_REPORT_TIME)
 
+	if(report)
+		addtimer(CALLBACK(src, .proc/send_intercept, 0), rand(waittime_l, waittime_h))
+	generate_station_goals()
+
 	if(SSdbcore.Connect())
 		var/sql
 		if(SSticker.mode)
@@ -93,11 +97,9 @@
 			sql += "commit_hash = '[GLOB.revdata.originmastercommit]'"
 		if(sql)
 			var/datum/DBQuery/query_round_game_mode = SSdbcore.NewQuery("UPDATE [format_table_name("round")] SET [sql] WHERE id = [GLOB.round_id]")
-			query_round_game_mode.Execute()
+			query_round_game_mode.Execute(async = TRUE)
 			qdel(query_round_game_mode)
-	if(report)
-		addtimer(CALLBACK(src, .proc/send_intercept, 0), rand(waittime_l, waittime_h))
-	generate_station_goals()
+
 	gamemode_ready = TRUE
 	return 1
 

--- a/code/modules/admin/IsBanned.dm
+++ b/code/modules/admin/IsBanned.dm
@@ -79,7 +79,7 @@
 			cidquery = " OR computerid = '[computer_id]' "
 
 		var/datum/DBQuery/query_ban_check = SSdbcore.NewQuery("SELECT ckey, a_ckey, reason, expiration_time, duration, bantime, bantype, id, round_id FROM [format_table_name("ban")] WHERE (ckey = '[ckeytext]' [ipquery] [cidquery]) AND (bantype = 'PERMABAN' OR bantype = 'ADMIN_PERMABAN' OR ((bantype = 'TEMPBAN' OR bantype = 'ADMIN_TEMPBAN') AND expiration_time > Now())) AND isnull(unbanned)")
-		if(!query_ban_check.Execute())
+		if(!query_ban_check.Execute(async = TRUE))
 			qdel(query_ban_check)
 			return
 		while(query_ban_check.NextRow())

--- a/code/modules/admin/ipintel.dm
+++ b/code/modules/admin/ipintel.dm
@@ -50,7 +50,7 @@
 							date + INTERVAL [CONFIG_GET(number/ipintel_save_bad)] HOUR > NOW()
 					))
 				"})
-			if(!query_get_ip_intel.Execute())
+			if(!query_get_ip_intel.Execute(async = TRUE))
 				qdel(query_get_ip_intel)
 				return
 			if (query_get_ip_intel.NextRow())
@@ -68,7 +68,7 @@
 		SSipintel.cache[ip] = res
 		if(SSdbcore.Connect())
 			var/datum/DBQuery/query_add_ip_intel = SSdbcore.NewQuery("INSERT INTO [format_table_name("ipintel")] (ip, intel) VALUES (INET_ATON('[ip]'), [res.intel]) ON DUPLICATE KEY UPDATE intel = VALUES(intel), date = NOW()")
-			query_add_ip_intel.Execute()
+			query_add_ip_intel.Execute(async = TRUE)
 			qdel(query_add_ip_intel)
 
 

--- a/code/modules/admin/sql_message_system.dm
+++ b/code/modules/admin/sql_message_system.dm
@@ -409,7 +409,7 @@
 		notetext = note.group[2]
 		var/admin_ckey = note.group[3]
 		var/datum/DBQuery/query_convert_time = SSdbcore.NewQuery("SELECT ADDTIME(STR_TO_DATE('[timestamp]','%d-%b-%Y'), '0')")
-		if(!query_convert_time.Execute())
+		if(!query_convert_time.Execute(async = TRUE))
 			qdel(query_convert_time)
 			return
 		if(query_convert_time.NextRow())

--- a/code/modules/jobs/job_exp.dm
+++ b/code/modules/jobs/job_exp.dm
@@ -155,7 +155,7 @@ GLOBAL_PROTECT(exp_to_update)
 	if(!SSdbcore.Connect())
 		return -1
 	var/datum/DBQuery/exp_read = SSdbcore.NewQuery("SELECT job, minutes FROM [format_table_name("role_time")] WHERE ckey = '[sanitizeSQL(ckey)]'")
-	if(!exp_read.Execute())
+	if(!exp_read.Execute(async = TRUE))
 		qdel(exp_read)
 		return -1
 	var/list/play_records = list()
@@ -189,7 +189,7 @@ GLOBAL_PROTECT(exp_to_update)
 
 	var/datum/DBQuery/flag_update = SSdbcore.NewQuery("UPDATE [format_table_name("player")] SET flags = '[prefs.db_flags]' WHERE ckey='[sanitizeSQL(ckey)]'")
 
-	if(!flag_update.Execute())
+	if(!flag_update.Execute(async = TRUE))
 		qdel(flag_update)
 		return -1
 	qdel(flag_update)
@@ -269,7 +269,7 @@ GLOBAL_PROTECT(exp_to_update)
 
 	var/datum/DBQuery/flags_read = SSdbcore.NewQuery("SELECT flags FROM [format_table_name("player")] WHERE ckey='[ckey]'")
 
-	if(!flags_read.Execute())
+	if(!flags_read.Execute(async = TRUE))
 		qdel(flags_read)
 		return FALSE
 

--- a/code/modules/library/lib_machines.dm
+++ b/code/modules/library/lib_machines.dm
@@ -50,7 +50,7 @@
 				dat += "<tr><td>AUTHOR</td><td>TITLE</td><td>CATEGORY</td><td>SS<sup>13</sup>BN</td></tr>"
 
 				var/datum/DBQuery/query_library_list_books = SSdbcore.NewQuery(SQLquery)
-				if(!query_library_list_books.Execute())
+				if(!query_library_list_books.Execute(async = TRUE))
 					dat += "<font color=red><b>ERROR</b>: Unable to retrieve book listings. Please contact your system administrator for assistance.</font><BR>"
 				else
 					while(query_library_list_books.NextRow())
@@ -140,7 +140,7 @@ GLOBAL_LIST(cachedbooks) // List of our cached book datums
 		return
 	GLOB.cachedbooks = list()
 	var/datum/DBQuery/query_library_cache = SSdbcore.NewQuery("SELECT id, author, title, category FROM [format_table_name("library")] WHERE isnull(deleted)")
-	if(!query_library_cache.Execute())
+	if(!query_library_cache.Execute(async = TRUE))
 		qdel(query_library_cache)
 		return
 	while(query_library_cache.NextRow())
@@ -424,7 +424,7 @@ GLOBAL_LIST(cachedbooks) // List of our cached book datums
 						var/sqlcategory = sanitizeSQL(upload_category)
 						var/msg = "[key_name(usr)] has uploaded the book titled [scanner.cache.name], [length(scanner.cache.dat)] signs"
 						var/datum/DBQuery/query_library_upload = SSdbcore.NewQuery("INSERT INTO [format_table_name("library")] (author, title, content, category, ckey, datetime, round_id_created) VALUES ('[sqlauthor]', '[sqltitle]', '[sqlcontent]', '[sqlcategory]', '[usr.ckey]', Now(), '[GLOB.round_id]')")
-						if(!query_library_upload.Execute())
+						if(!query_library_upload.Execute(async = TRUE))
 							qdel(query_library_upload)
 							alert("Database error encountered uploading to Archive")
 							return
@@ -462,7 +462,7 @@ GLOBAL_LIST(cachedbooks) // List of our cached book datums
 		else
 			cooldown = world.time + PRINTER_COOLDOWN
 			var/datum/DBQuery/query_library_print = SSdbcore.NewQuery("SELECT * FROM [format_table_name("library")] WHERE id=[sqlid] AND isnull(deleted)")
-			if(!query_library_print.Execute())
+			if(!query_library_print.Execute(async = TRUE))
 				qdel(query_library_print)
 				say("PRINTER ERROR! Failed to print document (0x0000000F)")
 				return

--- a/code/modules/library/random_books.dm
+++ b/code/modules/library/random_books.dm
@@ -51,7 +51,7 @@
 		category = null
 	var/c = category? " AND category='[sanitizeSQL(category)]'" :""
 	var/datum/DBQuery/query_get_random_books = SSdbcore.NewQuery("SELECT * FROM [format_table_name("library")] WHERE isnull(deleted)[c] GROUP BY title ORDER BY rand() LIMIT [amount];") // isdeleted copyright (c) not me
-	if(query_get_random_books.Execute())
+	if(query_get_random_books.Execute(async = TRUE))
 		while(query_get_random_books.NextRow())
 			var/obj/item/book/B = new(location)
 			. += B

--- a/code/modules/mob/dead/new_player/new_player.dm
+++ b/code/modules/mob/dead/new_player/new_player.dm
@@ -55,7 +55,7 @@
 				isadmin = 1
 			var/datum/DBQuery/query_get_new_polls = SSdbcore.NewQuery("SELECT id FROM [format_table_name("poll_question")] WHERE [(isadmin ? "" : "adminonly = false AND")] Now() BETWEEN starttime AND endtime AND id NOT IN (SELECT pollid FROM [format_table_name("poll_vote")] WHERE ckey = \"[ckey]\") AND id NOT IN (SELECT pollid FROM [format_table_name("poll_textreply")] WHERE ckey = \"[ckey]\")")
 			var/rs = REF(src)
-			if(query_get_new_polls.Execute())
+			if(query_get_new_polls.Execute(async = TRUE))
 				var/newpoll = 0
 				if(query_get_new_polls.NextRow())
 					newpoll = 1

--- a/code/modules/shuttle/emergency.dm
+++ b/code/modules/shuttle/emergency.dm
@@ -268,7 +268,7 @@
 	if(!SSdbcore.Connect())
 		return
 	var/datum/DBQuery/query_round_shuttle_name = SSdbcore.NewQuery("UPDATE [format_table_name("round")] SET shuttle_name = '[name]' WHERE id = [GLOB.round_id]")
-	query_round_shuttle_name.Execute()
+	query_round_shuttle_name.Execute(async = TRUE)
 	qdel(query_round_shuttle_name)
 
 /obj/docking_port/mobile/emergency/check()


### PR DESCRIPTION
To be paired with #38323 

:cl:
fix: SQL queries will (usually) no longer hang the server
/:cl:

Everything except stuff in the /world/New() and /world/Reboot() control paths. #38363 already did preparations for this. These queries will sleep while running