### PR TITLE
Changes consoles on the old box white ship ruin into "broken computers"

### DIFF
--- a/_maps/RandomRuins/SpaceRuins/whiteshipruin_box.dmm
+++ b/_maps/RandomRuins/SpaceRuins/whiteshipruin_box.dmm
@@ -124,8 +124,9 @@
 /turf/open/floor/mineral/titanium,
 /area/ruin/space/has_grav/whiteship/box)
 "ax" = (
-/obj/machinery/computer/camera_advanced/shuttle_docker/whiteship/ruin{
-	view_range = 18
+/obj/machinery/computer{
+	desc = "A computer long since rendered non-functional due to lack of maintenance. Spitting out error messages.";
+	name = "Broken Computer"
 	},
 /turf/open/floor/mineral/titanium,
 /area/ruin/space/has_grav/whiteship/box)
@@ -207,8 +208,10 @@
 /turf/open/floor/mineral/titanium,
 /area/ruin/space/has_grav/whiteship/box)
 "aM" = (
-/obj/machinery/computer/shuttle/white_ship/ruin{
-	dir = 8
+/obj/machinery/computer{
+	desc = "A computer long since rendered non-functional due to lack of maintenance. Spitting out error messages.";
+	dir = 8;
+	name = "Broken Computer"
 	},
 /turf/open/floor/mineral/titanium,
 /area/ruin/space/has_grav/whiteship/box)
@@ -263,7 +266,8 @@
 /area/ruin/space/has_grav/whiteship/box)
 "aW" = (
 /obj/structure/frame/computer{
-	anchored = 1
+	anchored = 1;
+	dir = 1
 	},
 /obj/structure/light_construct,
 /turf/open/floor/mineral/titanium,
@@ -282,7 +286,8 @@
 /area/ruin/space/has_grav/whiteship/box)
 "aZ" = (
 /obj/structure/frame/computer{
-	anchored = 1
+	anchored = 1;
+	dir = 8
 	},
 /turf/open/floor/mineral/titanium,
 /area/ruin/space/has_grav/whiteship/box)


### PR DESCRIPTION
We get a lot of issue reports and admin PMs telling us that the ship doesn't work when it was never supposed to fly. Then why have two consoles that give the illusion it does, saying "shuttle: missing" like it's bugged?

This removes that ambiguity by turning them into the same green broken computers as on the ancient station space ruin.

:cl: WJohnston
tweak: Abandoned box ship space ruin consoles have been turned into something more obviously broken so people stop complaining the ship doesn't work when it's not meant to anyway.
/:cl:
