### PR TITLE
MassInsert now defaults to async.

### DIFF
--- a/code/controllers/subsystem/dbcore.dm
+++ b/code/controllers/subsystem/dbcore.dm
@@ -188,7 +188,7 @@ Delayed insert mode was removed in mysql 7 and only works with MyISAM type table
 	It was included because it is still supported in mariadb.
 	It does not work with duplicate_key and the mysql server ignores it in those cases
 */
-/datum/controller/subsystem/dbcore/proc/MassInsert(table, list/rows, duplicate_key = FALSE, ignore_errors = FALSE, delayed = FALSE, warn = FALSE, async = FALSE)
+/datum/controller/subsystem/dbcore/proc/MassInsert(table, list/rows, duplicate_key = FALSE, ignore_errors = FALSE, delayed = FALSE, warn = FALSE, async = TRUE)
 	if (!table || !rows || !istype(rows))
 		return
 	var/list/columns = list()

--- a/code/modules/admin/admin_ranks.dm
+++ b/code/modules/admin/admin_ranks.dm
@@ -111,7 +111,21 @@ GLOBAL_PROTECT(protected_ranks)
 	var/flag = admin_keyword_to_flag(word)
 	if(flag)
 		return ((rank.rights & flag) == flag) //true only if right has everything in flag
+/proc/sync_ranks_with_db()
+	set waitfor = FALSE
 
+	if(IsAdminAdvancedProcCall())
+		to_chat(usr, "<span class='admin prefix'>Admin rank DB Sync blocked: Advanced ProcCall detected.</span>")
+		return
+
+	var/list/sql_ranks = list()
+	for(var/datum/admin_rank/R in GLOB.admin_ranks)
+		var/sql_rank = sanitizeSQL(R.name)
+		var/sql_flags = sanitizeSQL(R.include_rights)
+		var/sql_exclude_flags = sanitizeSQL(R.exclude_rights)
+		var/sql_can_edit_flags = sanitizeSQL(R.can_edit_rights)
+		sql_ranks += list(list("rank" = "'[sql_rank]'", "flags" = "[sql_flags]", "exclude_flags" = "[sql_exclude_flags]", "can_edit_flags" = "[sql_can_edit_flags]"))
+	SSdbcore.MassInsert(format_table_name("admin_ranks"), sql_ranks, duplicate_key = TRUE)
 //load our rank - > rights associations
 /proc/load_admin_ranks(dbfail, no_update)
 	if(IsAdminAdvancedProcCall())
@@ -139,14 +153,7 @@ GLOBAL_PROTECT(protected_ranks)
 	if(!CONFIG_GET(flag/admin_legacy_system) || dbfail)
 		if(CONFIG_GET(flag/load_legacy_ranks_only))
 			if(!no_update)
-				var/list/sql_ranks = list()
-				for(var/datum/admin_rank/R in GLOB.admin_ranks)
-					var/sql_rank = sanitizeSQL(R.name)
-					var/sql_flags = sanitizeSQL(R.include_rights)
-					var/sql_exclude_flags = sanitizeSQL(R.exclude_rights)
-					var/sql_can_edit_flags = sanitizeSQL(R.can_edit_rights)
-					sql_ranks += list(list("rank" = "'[sql_rank]'", "flags" = "[sql_flags]", "exclude_flags" = "[sql_exclude_flags]", "can_edit_flags" = "[sql_can_edit_flags]"))
-				SSdbcore.MassInsert(format_table_name("admin_ranks"), sql_ranks, duplicate_key = TRUE, blocking = TRUE)
+				sync_ranks_with_db()
 		else
 			var/datum/DBQuery/query_load_admin_ranks = SSdbcore.NewQuery("SELECT rank, flags, exclude_flags, can_edit_flags FROM [format_table_name("admin_ranks")]")
 			if(!query_load_admin_ranks.Execute())


### PR DESCRIPTION
:cl:
fix: synchronizing admin ranks with the database now lags the server less
fix: saving stats now lags the server less
fix: jobexp updating now lags the server less
fix: poll creation now lags the server less.
/:cl: