### PR TITLE
Removes the extra headset from the syndicate listening post.

### DIFF
--- a/_maps/RandomRuins/SpaceRuins/listeningstation.dmm
+++ b/_maps/RandomRuins/SpaceRuins/listeningstation.dmm
@@ -275,7 +275,6 @@
 	dir = 8
 	},
 /obj/item/multitool,
-/obj/item/radio/headset/syndicate/alt,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/dark,
 /area/ruin/space/has_grav/listeningstation)


### PR DESCRIPTION
Removed the extra syndicate headset in the syndie listening post ruin, because it was more often than not used by crewmembers who stumbled upon it, jeopardizing the security of the syndie network through no fault of the agents on the station.

The simple animal who spawns 90% of the time does not have an actual headset on him, but the player who can spawn 10% of the time still does, except he's on the traitors' side anyway.

:cl: WJohnston
del: Removed the extra syndie headset from the syndicate listening post space ruin so people stumbling on the ruin won't be able to ruin your channel's security as often.
/:cl:
