### PR TITLE
[WIP]Adds shared Engineering storage to more maps, fixes access reqs

### DIFF
--- a/_maps/map_files/BoxStation/BoxStation.dmm
+++ b/_maps/map_files/BoxStation/BoxStation.dmm
@@ -32317,12 +32317,6 @@
 	},
 /turf/open/floor/plating,
 /area/medical/medbay/central)
-"bDG" = (
-/obj/machinery/door/firedoor,
-/turf/open/floor/plasteel/yellow/corner{
-	dir = 2
-	},
-/area/hallway/primary/aft)
 "bDH" = (
 /obj/structure/closet/l3closet/janitor,
 /obj/machinery/airalarm{
@@ -33979,11 +33973,6 @@
 /obj/machinery/light/small,
 /turf/open/floor/plating,
 /area/storage/tech)
-"bHP" = (
-/turf/open/floor/plasteel/yellow/corner{
-	dir = 2
-	},
-/area/hallway/primary/aft)
 "bHQ" = (
 /obj/machinery/vending/assist,
 /turf/open/floor/plating,
@@ -36911,23 +36900,14 @@
 /turf/open/floor/plating,
 /area/security/detectives_office)
 "bOO" = (
-/obj/machinery/power/apc{
-	dir = 8;
-	name = "Engineering Security APC";
-	areastring = "/area/security/checkpoint/engineering";
-	pixel_x = -24
+/obj/structure/closet/secure_closet/engineering_electrical,
+/obj/machinery/airalarm{
+	pixel_y = 26
 	},
-/obj/structure/cable{
-	icon_state = "0-2"
-	},
-/obj/machinery/newscaster{
-	pixel_y = 32
-	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on,
-/turf/open/floor/plasteel/red/side{
+/turf/open/floor/plasteel/yellow/side{
 	dir = 9
 	},
-/area/security/checkpoint/engineering)
+/area/engine/storage_shared)
 "bOP" = (
 /obj/structure/table/glass,
 /obj/structure/reagent_dispensers/virusfood{
@@ -37506,30 +37486,14 @@
 /turf/open/floor/plasteel,
 /area/tcommsat/computer)
 "bQe" = (
-/obj/item/screwdriver{
-	pixel_y = 10
+/obj/machinery/light/small{
+	dir = 8;
+	light_color = "#fff4bc"
 	},
-/obj/machinery/button/door{
-	desc = "A remote control-switch for the engineering security doors.";
-	id = "Engineering";
-	name = "Engineering Lockdown";
-	pixel_x = -24;
-	pixel_y = -6;
-	req_access_txt = "10"
-	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/item/radio/off,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/machinery/light_switch{
-	pixel_x = -27;
-	pixel_y = 4
-	},
-/turf/open/floor/plasteel/red/side{
+/turf/open/floor/plasteel/yellow/side{
 	dir = 8
 	},
-/area/security/checkpoint/engineering)
+/area/engine/storage_shared)
 "bQf" = (
 /turf/open/floor/plasteel/caution{
 	dir = 5
@@ -37606,23 +37570,11 @@
 /turf/open/floor/plasteel,
 /area/engine/atmos)
 "bQq" = (
-/obj/machinery/camera{
-	c_tag = "Security Post - Engineering";
-	dir = 8
-	},
-/obj/item/radio/intercom{
-	dir = 4;
-	name = "Station Intercom (General)";
-	pixel_x = 27
-	},
-/obj/machinery/light{
+/obj/machinery/rnd/production/circuit_imprinter,
+/turf/open/floor/plasteel/yellow/side{
 	dir = 4
 	},
-/obj/machinery/vending/wardrobe/sec_wardrobe,
-/turf/open/floor/plasteel/red/side{
-	dir = 4
-	},
-/area/security/checkpoint/engineering)
+/area/engine/storage_shared)
 "bQr" = (
 /obj/structure/closet/crate,
 /turf/open/floor/plasteel,
@@ -37793,12 +37745,12 @@
 /turf/open/floor/plating,
 /area/tcommsat/computer)
 "bQQ" = (
-/obj/machinery/door/firedoor,
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel,
-/area/hallway/primary/aft)
+/area/engine/break_room)
 "bQR" = (
 /obj/structure/table,
 /obj/structure/window/reinforced{
@@ -37906,12 +37858,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
-"bRi" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/engine/break_room)
 "bRj" = (
 /obj/structure/cable{
 	icon_state = "2-4"
@@ -37919,19 +37865,22 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
 /turf/open/floor/plasteel,
 /area/engine/break_room)
 "bRk" = (
 /obj/structure/cable{
-	icon_state = "1-8"
+	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 9
+	dir = 4
 	},
-/turf/open/floor/plasteel/red/side{
+/turf/open/floor/plasteel/yellow/side{
 	dir = 8
 	},
-/area/security/checkpoint/engineering)
+/area/engine/storage_shared)
 "bRl" = (
 /obj/structure/light_construct{
 	dir = 8
@@ -37939,18 +37888,19 @@
 /turf/open/floor/plating,
 /area/construction)
 "bRm" = (
-/obj/machinery/door/airlock/security/glass{
-	name = "Security Office";
-	req_access_txt = "63"
-	},
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
+/obj/machinery/door/airlock/engineering/glass{
+	name = "Shared Engineering Storage";
+	req_access_txt = "32"
+	},
+/obj/machinery/door/firedoor,
 /turf/open/floor/plasteel,
-/area/security/checkpoint/engineering)
+/area/engine/storage_shared)
 "bRn" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
@@ -37958,17 +37908,13 @@
 /turf/closed/wall,
 /area/construction)
 "bRo" = (
-/obj/machinery/computer/secure_data{
+/obj/machinery/computer/rdconsole/production{
 	dir = 8
 	},
-/obj/machinery/computer/security/telescreen/engine{
-	dir = 8;
-	pixel_x = 24
-	},
-/turf/open/floor/plasteel/red/side{
+/turf/open/floor/plasteel/yellow/side{
 	dir = 4
 	},
-/area/security/checkpoint/engineering)
+/area/engine/storage_shared)
 "bRp" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -38192,11 +38138,14 @@
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
 "bRS" = (
-/obj/structure/chair/office/dark,
-/obj/effect/landmark/start/depsec/engineering,
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on,
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 9
+	},
 /turf/open/floor/plasteel,
-/area/security/checkpoint/engineering)
+/area/engine/storage_shared)
 "bRT" = (
 /obj/structure/disposalpipe/trunk{
 	dir = 4
@@ -38409,11 +38358,15 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
-	dir = 8
+/obj/structure/disposalpipe/sorting/mail/flip{
+	dir = 2;
+	sortType = 5
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
 	},
 /turf/open/floor/plasteel,
-/area/hallway/primary/aft)
+/area/engine/break_room)
 "bSx" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
@@ -38575,15 +38528,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
-"bSR" = (
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	dir = 1
-	},
-/turf/open/floor/plasteel/caution/corner{
-	dir = 8
-	},
-/area/hallway/primary/aft)
 "bSS" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/virology{
@@ -38750,28 +38694,29 @@
 /area/engine/break_room)
 "bTh" = (
 /obj/machinery/holopad,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/structure/disposalpipe/segment{
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
+	dir = 4
+	},
 /turf/open/floor/plasteel,
 /area/engine/break_room)
 "bTi" = (
-/obj/structure/table,
-/obj/machinery/recharger{
-	pixel_y = 4
-	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
-/turf/open/floor/plasteel/red/side{
-	dir = 10
+/turf/open/floor/plasteel/yellow/side{
+	dir = 8
 	},
-/area/security/checkpoint/engineering)
+/area/engine/storage_shared)
 "bTj" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
 /turf/open/floor/plating,
-/area/security/checkpoint/engineering)
+/area/engine/storage_shared)
 "bTk" = (
 /obj/machinery/atmospherics/components/binary/valve,
 /turf/open/floor/engine,
@@ -38941,28 +38886,17 @@
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
 "bTG" = (
-/obj/structure/table,
-/obj/item/paper_bin{
-	pixel_x = 1;
-	pixel_y = 9
-	},
-/obj/item/pen,
-/obj/structure/reagent_dispensers/peppertank{
-	pixel_x = 30
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+/obj/machinery/rnd/production/protolathe/department/engineering,
+/turf/open/floor/plasteel/yellow/side{
 	dir = 4
 	},
-/turf/open/floor/plasteel/red/side{
-	dir = 6
-	},
-/area/security/checkpoint/engineering)
+/area/engine/storage_shared)
 "bTH" = (
-/obj/structure/table,
-/obj/item/book/manual/wiki/security_space_law,
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden,
-/turf/open/floor/plasteel/red/side,
-/area/security/checkpoint/engineering)
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/engine/storage_shared)
 "bTI" = (
 /obj/machinery/holopad,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -39202,15 +39136,9 @@
 /turf/open/floor/plasteel,
 /area/science/misc_lab)
 "bUl" = (
-/obj/structure/disposalpipe/sorting/mail/flip{
-	dir = 2;
-	sortType = 5
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/turf/open/floor/plasteel/caution/corner{
-	dir = 8
-	},
-/area/hallway/primary/aft)
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
+/area/security/checkpoint/engineering)
 "bUm" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -39507,65 +39435,50 @@
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden,
 /turf/open/floor/plasteel,
 /area/tcommsat/computer)
-"bVc" = (
-/obj/structure/disposalpipe/segment{
-	dir = 6
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/turf/open/floor/plasteel/yellow/side{
-	dir = 1
-	},
-/area/hallway/primary/aft)
 "bVd" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/turf/open/floor/plasteel/yellow/side{
 	dir = 9
 	},
-/area/hallway/primary/aft)
+/turf/open/floor/plasteel/yellow/side{
+	dir = 8
+	},
+/area/engine/break_room)
 "bVe" = (
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/aft)
-"bVf" = (
-/obj/structure/disposalpipe/segment{
+/obj/structure/disposalpipe/segment,
+/obj/structure/table,
+/obj/item/book/manual/wiki/security_space_law,
+/turf/open/floor/plasteel/red/side{
 	dir = 9
 	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden,
-/turf/open/floor/plasteel/yellow/corner{
-	dir = 1
-	},
-/area/hallway/primary/aft)
+/area/security/checkpoint/engineering)
 "bVg" = (
-/obj/item/radio/intercom{
-	broadcasting = 0;
-	name = "Station Intercom (General)";
-	pixel_y = 20
+/obj/structure/table,
+/obj/machinery/recharger{
+	pixel_y = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
+/obj/machinery/computer/security/telescreen/engine{
+	dir = 8;
+	pixel_x = 24
 	},
-/turf/open/floor/plasteel/yellow/side{
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/turf/open/floor/plasteel/red/side{
 	dir = 5
 	},
-/area/hallway/primary/aft)
+/area/security/checkpoint/engineering)
 "bVh" = (
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
+/obj/structure/table,
+/obj/item/paper_bin{
+	pixel_x = 1;
+	pixel_y = 9
 	},
-/turf/open/floor/plasteel/yellow/corner{
-	dir = 4
+/obj/item/pen,
+/turf/open/floor/plasteel/red/side{
+	dir = 1
 	},
-/area/hallway/primary/aft)
+/area/security/checkpoint/engineering)
 "bVi" = (
 /obj/structure/sign/warning/electricshock,
 /turf/closed/wall,
@@ -39589,15 +39502,6 @@
 	},
 /turf/open/floor/plasteel/floorgrime,
 /area/science/misc_lab)
-"bVm" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/engine/break_room)
 "bVn" = (
 /obj/machinery/atmospherics/pipe/manifold/general/visible{
 	dir = 4
@@ -39605,32 +39509,9 @@
 /obj/machinery/meter,
 /turf/open/floor/plasteel/floorgrime,
 /area/science/misc_lab)
-"bVo" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/engine/break_room)
-"bVp" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/turf/open/floor/plasteel,
-/area/engine/break_room)
 "bVq" = (
-/obj/machinery/atmospherics/pipe/manifold4w/supply/hidden,
-/turf/open/floor/plasteel,
-/area/engine/break_room)
-"bVr" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on,
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plasteel,
 /area/engine/break_room)
 "bVs" = (
@@ -39902,12 +39783,6 @@
 	dir = 4
 	},
 /area/medical/virology)
-"bWh" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 10
-	},
-/turf/open/floor/plasteel,
-/area/engine/break_room)
 "bWi" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/effect/spawner/structure/window,
@@ -40088,15 +39963,17 @@
 /turf/open/floor/plating,
 /area/tcommsat/computer)
 "bWJ" = (
-/obj/structure/disposalpipe/segment,
 /obj/structure/cable{
 	icon_state = "2-4"
 	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 1
 	},
+/obj/structure/disposalpipe/segment{
+	dir = 6
+	},
 /turf/open/floor/plasteel,
-/area/hallway/primary/aft)
+/area/engine/break_room)
 "bWK" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
@@ -40104,7 +39981,7 @@
 /turf/open/floor/plasteel/yellow/side{
 	dir = 8
 	},
-/area/hallway/primary/aft)
+/area/engine/break_room)
 "bWL" = (
 /obj/machinery/airalarm{
 	dir = 4;
@@ -40158,7 +40035,7 @@
 /area/engine/atmos)
 "bWQ" = (
 /turf/closed/wall/r_wall,
-/area/security/checkpoint/engineering)
+/area/engine/storage_shared)
 "bWR" = (
 /obj/item/radio/intercom{
 	freerange = 0;
@@ -40350,10 +40227,6 @@
 /turf/open/floor/plasteel/floorgrime,
 /area/science/misc_lab)
 "bXk" = (
-/obj/machinery/navbeacon{
-	codes_txt = "patrol;next_patrol=AIE";
-	location = "AftH"
-	},
 /obj/structure/cable{
 	icon_state = "1-8"
 	},
@@ -40363,8 +40236,16 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/aft)
+/obj/structure/disposalpipe/segment{
+	dir = 9
+	},
+/obj/machinery/computer/secure_data{
+	dir = 4
+	},
+/turf/open/floor/plasteel/red/side{
+	dir = 8
+	},
+/area/security/checkpoint/engineering)
 "bXl" = (
 /obj/structure/table,
 /obj/item/paper_bin{
@@ -40382,8 +40263,12 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/aft)
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
+/area/security/checkpoint/engineering)
 "bXn" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -40391,46 +40276,57 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
-/turf/open/floor/plasteel/yellow/side{
-	dir = 4
+/obj/effect/landmark/event_spawn,
+/obj/machinery/atmospherics/components/unary/vent_pump/on{
+	dir = 1
 	},
-/area/hallway/primary/aft)
+/turf/open/floor/plasteel,
+/area/security/checkpoint/engineering)
 "bXo" = (
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 1
 	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/aft)
-"bXp" = (
-/obj/structure/cable{
-	icon_state = "1-8"
+/obj/structure/chair/office/dark{
+	dir = 8
 	},
+/obj/effect/landmark/start/depsec/engineering,
+/obj/structure/cable{
+	icon_state = "2-4"
+	},
+/turf/open/floor/plasteel,
+/area/security/checkpoint/engineering)
+"bXp" = (
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
+/obj/machinery/door/airlock/security/glass{
+	name = "Security Office";
+	req_access_txt = "63"
+	},
+/obj/machinery/door/firedoor,
 /turf/open/floor/plasteel,
-/area/engine/break_room)
+/area/security/checkpoint/engineering)
 "bXq" = (
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/engineering/glass{
-	name = "Engineering";
-	req_access_txt = "32"
-	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
-/turf/open/floor/plasteel,
-/area/engine/break_room)
+/obj/machinery/light_switch{
+	pixel_x = 6;
+	pixel_y = 24
+	},
+/turf/open/floor/plasteel/red/side{
+	dir = 4
+	},
+/area/security/checkpoint/engineering)
 "bXr" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -40525,6 +40421,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel,
 /area/engine/break_room)
 "bXJ" = (
@@ -40556,31 +40453,30 @@
 /turf/open/floor/plasteel,
 /area/engine/atmos)
 "bXN" = (
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	dir = 4
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 10
 	},
 /turf/open/floor/plasteel,
 /area/engine/break_room)
 "bXO" = (
-/obj/structure/filingcabinet,
-/obj/machinery/airalarm{
-	pixel_y = 23
-	},
-/turf/open/floor/plasteel/red/side{
+/obj/item/twohanded/required/kirbyplants/random,
+/turf/open/floor/plasteel/yellow/side{
 	dir = 5
 	},
-/area/security/checkpoint/engineering)
+/area/engine/storage_shared)
 "bXP" = (
-/obj/machinery/requests_console{
-	department = "Security";
-	departmentType = 5;
-	pixel_y = 30
+/obj/structure/closet/secure_closet/engineering_welding,
+/obj/machinery/power/apc/auto_name/north{
+	pixel_y = 26
 	},
-/obj/structure/closet/secure_closet/security/engine,
-/turf/open/floor/plasteel/red/side{
+/obj/structure/cable{
+	icon_state = "0-2";
+	pixel_y = 1
+	},
+/turf/open/floor/plasteel/yellow/side{
 	dir = 1
 	},
-/area/security/checkpoint/engineering)
+/area/engine/storage_shared)
 "bXQ" = (
 /obj/structure/fireaxecabinet{
 	pixel_x = -32
@@ -40780,13 +40676,13 @@
 	},
 /area/science/misc_lab)
 "bYn" = (
-/obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel/yellow/side,
-/area/hallway/primary/aft)
+/area/engine/break_room)
 "bYo" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 8
@@ -40803,11 +40699,19 @@
 /turf/open/floor/plasteel/yellow/side{
 	dir = 10
 	},
-/area/hallway/primary/aft)
+/area/engine/break_room)
 "bYq" = (
 /obj/machinery/light,
-/turf/open/floor/plasteel/yellow/side,
-/area/hallway/primary/aft)
+/obj/structure/filingcabinet,
+/obj/machinery/requests_console{
+	department = "Security";
+	departmentType = 5;
+	pixel_y = -30
+	},
+/turf/open/floor/plasteel/red/side{
+	dir = 10
+	},
+/area/security/checkpoint/engineering)
 "bYr" = (
 /obj/machinery/door/airlock/maintenance{
 	req_access_txt = "12"
@@ -40886,70 +40790,68 @@
 	dir = 10
 	},
 /area/tcommsat/computer)
-"bYE" = (
-/turf/open/floor/plasteel/yellow/side,
-/area/hallway/primary/aft)
 "bYF" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plasteel,
 /area/tcommsat/computer)
 "bYG" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
+/obj/structure/closet/secure_closet/security/engine,
+/obj/machinery/airalarm{
+	dir = 1;
+	pixel_y = -22
 	},
-/turf/open/floor/plasteel/yellow/side{
-	dir = 6
-	},
-/area/hallway/primary/aft)
+/turf/open/floor/plasteel/red/side,
+/area/security/checkpoint/engineering)
 "bYH" = (
 /turf/closed/wall,
 /area/engine/break_room)
-"bYI" = (
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = 24
-	},
-/turf/open/floor/plasteel/yellow/corner{
-	dir = 2
-	},
-/area/hallway/primary/aft)
 "bYJ" = (
+/obj/machinery/power/apc{
+	dir = 8;
+	name = "Engineering Foyer APC";
+	areastring = "/area/engine/break_room";
+	pixel_x = -24
+	},
+/obj/structure/cable{
+	icon_state = "0-4"
+	},
 /turf/open/floor/plasteel/caution{
 	dir = 9
 	},
 /area/engine/break_room)
 "bYK" = (
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
 /turf/open/floor/plasteel/caution{
 	dir = 5
 	},
 /area/engine/break_room)
 "bYL" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
 /turf/open/floor/plasteel/caution{
 	dir = 1
 	},
 /area/engine/break_room)
 "bYM" = (
-/obj/machinery/airalarm{
-	dir = 1;
-	pixel_y = -22
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 5
-	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 1
 	},
-/turf/open/floor/plasteel/yellow/side,
-/area/hallway/primary/aft)
+/obj/item/screwdriver{
+	pixel_y = 10
+	},
+/obj/item/radio/off,
+/obj/machinery/power/apc/auto_name/south{
+	pixel_y = -26
+	},
+/obj/structure/cable,
+/turf/open/floor/plasteel/red/side,
+/area/security/checkpoint/engineering)
 "bYN" = (
 /turf/closed/wall,
 /area/security/checkpoint/engineering)
-"bYO" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/engine/break_room)
 "bYP" = (
 /obj/effect/landmark/event_spawn,
 /turf/closed/wall,
@@ -41048,17 +40950,26 @@
 /turf/open/floor/plasteel,
 /area/science/misc_lab)
 "bZe" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
+/obj/machinery/vending/wardrobe/sec_wardrobe,
+/obj/structure/reagent_dispensers/peppertank{
+	pixel_x = 30
 	},
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating,
-/area/engine/break_room)
+/obj/item/radio/intercom{
+	dir = 4;
+	name = "Station Intercom (General)";
+	pixel_y = -26
+	},
+/turf/open/floor/plasteel/red/side{
+	dir = 6
+	},
+/area/security/checkpoint/engineering)
 "bZg" = (
-/obj/structure/disposalpipe/segment{
-	dir = 10
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
+	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/structure/table,
+/obj/machinery/cell_charger,
 /turf/open/floor/plasteel,
 /area/engine/break_room)
 "bZh" = (
@@ -41149,6 +41060,9 @@
 /area/tcommsat/computer)
 "bZt" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
 /turf/open/floor/plasteel,
 /area/engine/break_room)
 "bZu" = (
@@ -41159,6 +41073,9 @@
 /obj/structure/noticeboard{
 	dir = 1;
 	pixel_y = -27
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/engine/break_room)
@@ -41176,36 +41093,20 @@
 /obj/structure/closet/firecloset,
 /turf/open/floor/plasteel,
 /area/engine/break_room)
-"bZx" = (
-/obj/machinery/door/firedoor,
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/plasteel/caution/corner{
-	dir = 8
-	},
-/area/hallway/primary/aft)
 "bZy" = (
 /turf/open/floor/plasteel,
 /area/engine/break_room)
 "bZz" = (
-/obj/structure/table,
-/obj/machinery/cell_charger,
-/obj/machinery/light_switch{
-	pixel_x = -23
-	},
-/obj/machinery/light{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/engine/break_room)
-"bZA" = (
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	dir = 8
+/obj/machinery/camera{
+	c_tag = "Engineering Foyer";
+	dir = 2;
+	network = list("ss13","monastery")
 	},
 /turf/open/floor/plasteel,
 /area/engine/break_room)
 "bZB" = (
 /obj/machinery/door/airlock/maintenance{
-	req_access_txt = "12"
+	req_access_txt = "10"
 	},
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -41544,21 +41445,18 @@
 	},
 /turf/closed/wall,
 /area/maintenance/port/aft)
-"cas" = (
-/obj/machinery/door/airlock/maintenance{
-	req_access_txt = "12"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/maintenance/port/aft)
 "cat" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 5
+/obj/machinery/airalarm{
+	dir = 4;
+	pixel_x = -22
 	},
-/turf/open/floor/plating,
-/area/maintenance/port/aft)
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
+	dir = 8
+	},
+/turf/open/floor/plasteel/yellow/side{
+	dir = 8
+	},
+/area/engine/break_room)
 "cau" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -41578,11 +41476,14 @@
 	},
 /area/hallway/primary/aft)
 "caw" = (
-/obj/structure/table,
-/obj/item/clothing/glasses/meson,
-/obj/machinery/airalarm{
-	dir = 4;
-	pixel_x = -22
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/sign/poster/official/random{
+	pixel_y = -32
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/engine/break_room)
@@ -41621,7 +41522,7 @@
 "caA" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
-/area/security/checkpoint/engineering)
+/area/engine/storage_shared)
 "caC" = (
 /obj/structure/disposalpipe/segment{
 	dir = 9
@@ -41639,7 +41540,7 @@
 	dir = 4
 	},
 /turf/closed/wall/r_wall,
-/area/security/checkpoint/engineering)
+/area/engine/storage_shared)
 "caE" = (
 /obj/machinery/requests_console{
 	department = "Atmospherics";
@@ -41989,9 +41890,7 @@
 /turf/open/floor/plating,
 /area/tcommsat/computer)
 "cbp" = (
-/obj/structure/closet/secure_closet/engineering_chief{
-	req_access_txt = "0"
-	},
+/obj/structure/closet/secure_closet/engineering_chief,
 /obj/machinery/power/apc/highcap/five_k{
 	dir = 4;
 	name = "CE Office APC";
@@ -42021,44 +41920,27 @@
 	},
 /area/crew_quarters/heads/chief)
 "cbr" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/aft)
+/obj/structure/disposalpipe/segment,
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
+/area/security/checkpoint/engineering)
 "cbs" = (
 /obj/structure/sign/warning/securearea,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/closed/wall,
 /area/engine/engineering)
 "cbt" = (
-/obj/structure/disposalpipe/segment{
-	dir = 10
-	},
 /obj/machinery/camera{
 	c_tag = "Aft Primary Hallway 1";
 	dir = 8;
 	pixel_y = -22
 	},
-/turf/open/floor/plasteel/yellow/corner{
-	dir = 2
-	},
-/area/hallway/primary/aft)
-"cbu" = (
-/obj/machinery/power/apc{
-	dir = 8;
-	name = "Engineering Foyer APC";
-	areastring = "/area/engine/break_room";
-	pixel_x = -24
-	},
-/obj/structure/cable{
-	icon_state = "0-2"
-	},
-/turf/open/floor/plasteel,
-/area/engine/break_room)
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
+/area/security/checkpoint/engineering)
 "cbv" = (
 /obj/machinery/door/airlock/maintenance/abandoned{
 	name = "Research Delivery access";
@@ -42843,7 +42725,9 @@
 /area/maintenance/starboard/aft)
 "cdt" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/yellow/side{
+	dir = 9
+	},
 /area/engine/break_room)
 "cdu" = (
 /obj/structure/closet/emcloset,
@@ -43625,7 +43509,8 @@
 /obj/machinery/button/door{
 	id = "ceprivacy";
 	name = "Privacy Shutters Control";
-	pixel_y = 26
+	pixel_y = 26;
+	req_access_txt = "56"
 	},
 /obj/machinery/holopad,
 /obj/machinery/light{
@@ -50088,6 +49973,12 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plasteel,
 /area/engine/engineering)
+"cyO" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 6
+	},
+/turf/open/floor/plasteel,
+/area/engine/break_room)
 "cyT" = (
 /obj/docking_port/stationary{
 	dir = 8;
@@ -50911,9 +50802,12 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
 "cBI" = (
-/obj/effect/landmark/event_spawn,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on,
 /turf/open/floor/plasteel,
-/area/security/checkpoint/engineering)
+/area/engine/storage_shared)
 "cBJ" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
 	dir = 9
@@ -53316,6 +53210,15 @@
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/miningdock)
+"fam" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/engine/break_room)
 "fcG" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 5
@@ -53431,6 +53334,17 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/port)
+"hdC" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/turf/open/floor/plating,
+/area/security/checkpoint/engineering)
+"hId" = (
+/obj/machinery/newscaster{
+	pixel_y = 32
+	},
+/turf/open/floor/plasteel,
+/area/engine/break_room)
 "hRa" = (
 /obj/structure/table/reinforced,
 /obj/machinery/light{
@@ -53464,6 +53378,28 @@
 	},
 /turf/open/floor/plating,
 /area/hallway/secondary/entry)
+"iHb" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/door/airlock/engineering/glass{
+	name = "Engineering";
+	req_access_txt = "32"
+	},
+/obj/structure/disposalpipe/segment,
+/obj/machinery/door/firedoor,
+/turf/open/floor/plasteel,
+/area/engine/break_room)
+"iMI" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/navbeacon{
+	codes_txt = "patrol;next_patrol=AIE";
+	location = "AftH"
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/aft)
 "iNn" = (
 /obj/machinery/camera{
 	c_tag = "Kitchen Cold Room"
@@ -53472,6 +53408,11 @@
 /obj/structure/reagent_dispensers/cooking_oil,
 /turf/open/floor/plasteel/showroomfloor,
 /area/crew_quarters/kitchen)
+"iQj" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/plasteel,
+/area/engine/break_room)
 "jbf" = (
 /obj/structure/cable{
 	icon_state = "0-2"
@@ -53502,6 +53443,13 @@
 /obj/machinery/rnd/production/techfab/department/cargo,
 /turf/open/floor/plasteel,
 /area/quartermaster/office)
+"jrr" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/machinery/door/airlock/maintenance{
+	req_access_txt = "10"
+	},
+/turf/open/floor/plating,
+/area/maintenance/port/aft)
 "jrE" = (
 /obj/structure/sign/poster/official/random{
 	pixel_x = 32
@@ -53570,6 +53518,14 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
+"kax" = (
+/obj/machinery/firealarm{
+	dir = 2;
+	pixel_y = 24
+	},
+/obj/machinery/holopad,
+/turf/open/floor/plasteel,
+/area/engine/break_room)
 "khb" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 10
@@ -53607,12 +53563,23 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
+"kuN" = (
+/turf/closed/wall,
+/area/engine/storage_shared)
 "kzT" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 6
 	},
 /turf/closed/wall/r_wall,
 /area/science/mixing)
+"kAB" = (
+/obj/structure/disposalpipe/segment{
+	dir = 5
+	},
+/turf/open/floor/plasteel/caution/corner{
+	dir = 8
+	},
+/area/hallway/primary/aft)
 "kOw" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plasteel/white,
@@ -53643,6 +53610,12 @@
 /obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel,
 /area/quartermaster/miningdock)
+"lmw" = (
+/obj/machinery/vending/tool,
+/turf/open/floor/plasteel/yellow/side{
+	dir = 10
+	},
+/area/engine/storage_shared)
 "lAB" = (
 /obj/structure/sign/nanotrasen,
 /turf/closed/wall,
@@ -53663,6 +53636,15 @@
 /obj/effect/spawner/structure/window,
 /turf/open/floor/plating,
 /area/science/circuit)
+"lUr" = (
+/obj/machinery/light{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/turf/open/floor/plasteel/yellow/side{
+	dir = 8
+	},
+/area/engine/break_room)
 "mdr" = (
 /obj/machinery/nuclearbomb/beer,
 /turf/open/floor/plating,
@@ -53798,11 +53780,26 @@
 	},
 /turf/open/floor/plasteel,
 /area/science/circuit)
+"qfk" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/engine/break_room)
 "quT" = (
 /obj/structure/lattice,
 /obj/structure/grille/broken,
 /turf/open/space/basic,
 /area/space/nearstation)
+"qLg" = (
+/obj/item/twohanded/required/kirbyplants/random,
+/turf/open/floor/plasteel/yellow/side{
+	dir = 6
+	},
+/area/engine/storage_shared)
 "rcD" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
@@ -53813,11 +53810,27 @@
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden,
 /turf/open/floor/plasteel/floorgrime,
 /area/maintenance/disposal/incinerator)
+"rmO" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/structure/table,
+/obj/item/clothing/glasses/meson/engine,
+/turf/open/floor/plasteel,
+/area/engine/break_room)
 "rmX" = (
 /obj/structure/table,
 /obj/item/reagent_containers/food/drinks/beer,
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
+"rBq" = (
+/obj/machinery/vending/engivend,
+/turf/open/floor/plasteel,
+/area/engine/storage_shared)
 "rKP" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
 	dir = 1
@@ -53964,6 +53977,15 @@
 	},
 /turf/closed/wall/r_wall,
 /area/maintenance/disposal/incinerator)
+"uRY" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 10
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/aft)
 "uVS" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -54004,6 +54026,10 @@
 /obj/item/stock_parts/cell/high,
 /turf/open/floor/plasteel/white,
 /area/science/circuit)
+"vzW" = (
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
+/area/engine/break_room)
 "vCb" = (
 /obj/machinery/rnd/production/techfab/department/service,
 /turf/open/floor/plasteel/hydrofloor,
@@ -82283,10 +82309,10 @@ bUD
 bVM
 bVM
 bVM
-bVM
-bVM
+jrr
+cdt
 cat
-bCq
+lUr
 bVd
 bWK
 bYp
@@ -82541,10 +82567,10 @@ bCq
 bCq
 bCq
 bCq
-bCq
-cas
-bCq
-bVc
+hId
+cer
+bZy
+bZy
 bWJ
 bYn
 bZB
@@ -82796,14 +82822,14 @@ bTJ
 bSA
 bSA
 bWL
-bSA
-bSA
-bZx
-bSR
+kAB
+vzW
+bZy
+cer
 bUl
-bVf
+bUl
 bXm
-bYE
+bYN
 bCq
 bHE
 ccw
@@ -83052,9 +83078,9 @@ cBH
 bMG
 bLZ
 bLZ
-bLZ
-bLZ
-bLZ
+iMI
+uRY
+iHb
 bQQ
 bSw
 cbr
@@ -83311,9 +83337,9 @@ bQg
 bQg
 bQg
 bQg
-bYI
-bDG
-bHP
+vzW
+bZy
+fam
 cbt
 bVh
 bXo
@@ -83569,9 +83595,9 @@ bUE
 bWM
 bXJ
 bYH
-bYH
-bYH
-bYH
+kax
+qfk
+hdC
 bVg
 bXn
 bYG
@@ -83828,8 +83854,8 @@ bXK
 bYH
 bZz
 caw
-bYH
-bVo
+bYN
+bYN
 bXq
 bZe
 cfb
@@ -84083,12 +84109,12 @@ bVN
 bWN
 bLK
 bYJ
-bRi
 bZy
-cbu
-bVm
+fam
+bVK
+bYN
 bXp
-bYO
+bYN
 cfc
 cgO
 ccj
@@ -84340,9 +84366,9 @@ bVQ
 bWN
 bXM
 bYL
-cew
+cyO
 bTh
-cdt
+iQj
 bVq
 bXI
 bZg
@@ -84600,9 +84626,9 @@ bYK
 bRj
 bTg
 bUm
-bVp
-bXH
 bUm
+bXH
+rmO
 bZC
 cbp
 cck
@@ -84853,11 +84879,11 @@ bTP
 bRA
 bWQ
 bWQ
-bYN
+kuN
 bRm
 bTj
 caA
-cer
+caA
 ccs
 bZu
 cfb
@@ -85113,8 +85139,8 @@ bOO
 bQe
 bRk
 bTi
+lmw
 caA
-bVr
 bXN
 bZt
 bZE
@@ -85370,10 +85396,10 @@ bXP
 cBI
 bRS
 bTH
+rBq
 caA
-bWh
-cdt
-bZA
+bZy
+cew
 cfh
 cfM
 cco
@@ -85627,8 +85653,8 @@ bXO
 bQq
 bRo
 bTG
+qLg
 caA
-bVK
 bYb
 bZw
 cap
@@ -85885,7 +85911,7 @@ bWQ
 bWQ
 caD
 bWQ
-ccw
+bWQ
 ccw
 cey
 ccw

--- a/_maps/map_files/Deltastation/DeltaStation2.dmm
+++ b/_maps/map_files/Deltastation/DeltaStation2.dmm
@@ -172,6 +172,10 @@
 /obj/structure/lattice/catwalk,
 /turf/open/space,
 /area/space/nearstation)
+"abl" = (
+/obj/structure/lattice,
+/turf/open/space/basic,
+/area/space/nearstation)
 "abp" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/light/small{
@@ -20429,7 +20433,7 @@
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/atmos/glass{
 	name = "Atmospherics Storage";
-	req_one_access_txt = "24;10"
+	req_access_txt = "24"
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -24653,7 +24657,7 @@
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/atmos/glass{
 	name = "Atmospherics Storage";
-	req_one_access_txt = "24;10"
+	req_access_txt = "24"
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -33074,26 +33078,26 @@
 	dir = 5
 	},
 /turf/closed/wall/r_wall,
-/area/engine/break_room)
+/area/engine/storage_shared)
 "bxG" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
 /turf/closed/wall/r_wall,
-/area/engine/break_room)
+/area/engine/storage_shared)
 "bxH" = (
 /obj/machinery/status_display,
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
 	dir = 4
 	},
 /turf/closed/wall/r_wall,
-/area/engine/break_room)
+/area/engine/storage_shared)
 "bxI" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 5
 	},
 /turf/closed/wall/r_wall,
-/area/engine/break_room)
+/area/engine/storage_shared)
 "bxJ" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 4
@@ -33770,68 +33774,28 @@
 "bzg" = (
 /turf/closed/wall,
 /area/engine/break_room)
-"bzh" = (
-/obj/structure/table/reinforced,
-/obj/machinery/light/small{
-	dir = 1
-	},
-/obj/item/stack/sheet/metal{
-	amount = 30
-	},
-/obj/item/stack/sheet/glass{
-	amount = 30
-	},
-/obj/item/crowbar/red,
-/obj/item/wrench,
-/obj/structure/sign/warning/nosmoking{
-	pixel_y = 32
-	},
-/obj/effect/turf_decal/bot,
-/turf/open/floor/plasteel,
-/area/engine/break_room)
 "bzi" = (
 /obj/structure/table/reinforced,
-/obj/item/storage/toolbox/electrical,
-/obj/item/wrench/power,
-/obj/machinery/status_display{
-	pixel_y = 32
-	},
-/obj/effect/turf_decal/bot,
-/turf/open/floor/plasteel,
-/area/engine/break_room)
+/turf/open/floor/plasteel/neutral/corner,
+/area/engine/storage_shared)
 "bzj" = (
-/obj/structure/cable/white{
-	icon_state = "0-2"
-	},
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating,
-/area/engine/break_room)
+/obj/machinery/computer/rdconsole/production,
+/obj/effect/turf_decal/bot,
+/turf/open/floor/plasteel/neutral/side,
+/area/engine/storage_shared)
 "bzk" = (
-/obj/structure/table/reinforced,
-/obj/item/stack/rods/fifty,
-/obj/item/stack/sheet/rglass{
-	amount = 30;
-	pixel_x = 2;
-	pixel_y = -2
-	},
-/obj/item/stack/cable_coil/white,
+/obj/machinery/rnd/production/protolathe/department/engineering,
 /obj/effect/turf_decal/bot,
-/turf/open/floor/plasteel,
-/area/engine/break_room)
+/turf/open/floor/plasteel/neutral/side,
+/area/engine/storage_shared)
 "bzl" = (
-/obj/structure/table/reinforced,
-/obj/machinery/light/small{
-	dir = 1
-	},
-/obj/item/stack/sheet/plasteel/fifty,
-/obj/item/crowbar/power,
-/obj/structure/sign/nanotrasen{
-	pixel_x = 32
-	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/machinery/rnd/production/circuit_imprinter,
 /obj/effect/turf_decal/bot,
-/turf/open/floor/plasteel,
-/area/engine/break_room)
+/turf/open/floor/plasteel/neutral/corner{
+	dir = 8
+	},
+/area/engine/storage_shared)
 "bzm" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/structure/bonfire,
@@ -34609,43 +34573,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/gravity_generator)
-"bAL" = (
-/obj/machinery/power/apc/highcap/five_k{
-	dir = 1;
-	name = "Gravity Generator APC";
-	areastring = "/area/engine/gravity_generator";
-	pixel_y = 24
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/obj/structure/cable{
-	icon_state = "0-2"
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/engine/gravity_generator)
-"bAM" = (
-/obj/machinery/power/terminal{
-	dir = 4
-	},
-/obj/item/radio/intercom{
-	name = "Station Intercom";
-	pixel_y = 26
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 10
-	},
-/obj/structure/cable/white{
-	icon_state = "0-2"
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 5
-	},
-/turf/open/floor/plasteel,
-/area/engine/gravity_generator)
 "bAN" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/cobweb/cobweb2,
@@ -34685,33 +34612,28 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/gravity_generator)
-"bAQ" = (
-/obj/structure/extinguisher_cabinet{
-	pixel_x = -26
-	},
-/obj/effect/turf_decal/delivery,
-/turf/open/floor/plasteel,
-/area/engine/break_room)
 "bAR" = (
 /obj/effect/turf_decal/delivery,
 /turf/open/floor/plasteel,
 /area/engine/break_room)
 "bAS" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on,
+/turf/open/floor/plasteel/neutral,
+/area/engine/storage_shared)
+"bAT" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/machinery/power/apc/auto_name/east{
+	pixel_x = 26
+	},
 /obj/structure/cable/white{
 	icon_state = "0-2"
 	},
-/obj/structure/cable/white,
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating,
-/area/engine/break_room)
-"bAT" = (
-/obj/machinery/newscaster{
-	pixel_x = 32
+/obj/effect/turf_decal/bot,
+/turf/open/floor/plasteel/neutral/side{
+	dir = 8;
+	heat_capacity = 1e+006
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/effect/turf_decal/delivery,
-/turf/open/floor/plasteel,
-/area/engine/break_room)
+/area/engine/storage_shared)
 "bAU" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/closed/wall,
@@ -35468,31 +35390,35 @@
 /turf/open/floor/plating,
 /area/engine/gravity_generator)
 "bCB" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/airalarm{
+	pixel_y = 23
+	},
+/obj/machinery/camera{
+	c_tag = "Engineering - Gravity Generator Foyer";
+	dir = 4;
+	name = "engineering camera"
+	},
 /obj/effect/turf_decal/stripes/line{
-	dir = 8
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/engine/gravity_generator)
-"bCC" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
-	dir = 4
-	},
-/obj/structure/cable{
-	icon_state = "1-4"
-	},
-/turf/open/floor/plasteel/neutral,
-/area/engine/gravity_generator)
 "bCD" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden,
-/obj/structure/cable{
-	icon_state = "4-8"
+/obj/machinery/light/small{
+	dir = 1
 	},
-/obj/structure/cable/white{
-	icon_state = "1-2"
+/obj/structure/extinguisher_cabinet{
+	pixel_x = 26
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
 	},
 /obj/effect/turf_decal/stripes/line{
-	dir = 4
+	dir = 5
 	},
 /turf/open/floor/plasteel,
 /area/engine/gravity_generator)
@@ -35515,23 +35441,28 @@
 /turf/closed/wall/r_wall,
 /area/engine/gravity_generator)
 "bCG" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/airalarm{
-	pixel_y = 23
+/obj/machinery/door/firedoor,
+/obj/machinery/door/airlock/command/glass{
+	name = "Power Tools Storage";
+	req_access_txt = "19"
+	},
+/obj/structure/cable/white{
+	icon_state = "2-4"
+	},
+/obj/structure/cable/white{
+	icon_state = "2-8"
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 2
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
 	dir = 1
 	},
-/obj/machinery/camera{
-	c_tag = "Engineering - Gravity Generator Foyer";
-	dir = 4;
-	name = "engineering camera"
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 9
-	},
 /turf/open/floor/plasteel,
-/area/engine/gravity_generator)
+/area/engine/storage_shared)
 "bCH" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -35540,105 +35471,75 @@
 /turf/open/floor/plasteel,
 /area/engine/gravity_generator)
 "bCI" = (
-/obj/structure/closet/radiation,
-/obj/machinery/light/small{
-	dir = 1
+/obj/machinery/door/firedoor,
+/obj/machinery/door/airlock/command/glass{
+	name = "Power Tools Storage";
+	req_access_txt = "19"
 	},
-/obj/structure/extinguisher_cabinet{
-	pixel_x = 26
+/obj/structure/cable/white{
+	icon_state = "2-4"
+	},
+/obj/structure/cable/white{
+	icon_state = "2-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
 /obj/effect/turf_decal/stripes/line{
-	dir = 5
+	dir = 2
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
 	},
 /turf/open/floor/plasteel,
-/area/engine/gravity_generator)
+/area/engine/storage_shared)
 "bCJ" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/turf/closed/wall,
-/area/engine/break_room)
-"bCK" = (
 /obj/structure/cable/white{
-	icon_state = "0-4"
+	icon_state = "0-8"
 	},
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
 /turf/open/floor/plating,
-/area/engine/break_room)
+/area/engine/storage_shared)
 "bCL" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/command/glass{
-	name = "Power Tools Storage";
-	req_access_txt = "19"
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
 	},
-/obj/structure/cable/white{
-	icon_state = "2-4"
+/obj/structure/table/reinforced,
+/obj/machinery/airalarm{
+	dir = 4;
+	pixel_x = -22
 	},
-/obj/structure/cable/white{
-	icon_state = "2-8"
+/obj/machinery/light/small{
+	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	dir = 1
+/turf/open/floor/plasteel/neutral/side{
+	dir = 4
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 2
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/engine/break_room)
+/area/engine/storage_shared)
 "bCM" = (
-/obj/structure/cable/white{
-	icon_state = "0-4"
-	},
-/obj/structure/cable/white{
-	icon_state = "0-8"
-	},
-/obj/structure/cable/white,
-/obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/engine/break_room)
-"bCN" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/command/glass{
-	name = "Power Tools Storage";
-	req_access_txt = "19"
-	},
-/obj/structure/cable/white{
-	icon_state = "2-4"
-	},
-/obj/structure/cable/white{
-	icon_state = "2-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 2
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/engine/break_room)
-"bCO" = (
-/obj/structure/cable/white{
-	icon_state = "0-8"
-	},
-/obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden,
-/turf/open/floor/plating,
-/area/engine/break_room)
+/turf/open/floor/plasteel/neutral,
+/area/engine/storage_shared)
+"bCN" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/turf/open/floor/plasteel/neutral,
+/area/engine/storage_shared)
+"bCO" = (
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden,
+/obj/structure/cable/white{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plasteel/neutral/side{
+	dir = 8;
+	heat_capacity = 1e+006
+	},
+/area/engine/storage_shared)
 "bCP" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -36764,15 +36665,20 @@
 /area/engine/gravity_generator)
 "bEv" = (
 /obj/structure/cable/white{
-	icon_state = "2-4"
+	icon_state = "1-8"
+	},
+/obj/structure/cable/white{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
 	},
 /obj/structure/cable/white{
 	icon_state = "2-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/effect/turf_decal/delivery,
 /turf/open/floor/plasteel,
-/area/engine/gravity_generator)
+/area/engine/storage_shared)
 "bEw" = (
 /obj/machinery/holopad,
 /obj/effect/decal/cleanable/dirt,
@@ -36794,106 +36700,15 @@
 /turf/open/floor/plasteel,
 /area/engine/gravity_generator)
 "bEy" = (
-/obj/machinery/door/firedoor,
 /obj/structure/cable/white{
 	icon_state = "4-8"
 	},
-/obj/machinery/door/airlock/highsecurity{
-	name = "Gravity Generator Foyer";
-	req_access_txt = "10"
-	},
-/obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 4
-	},
 /turf/open/floor/plasteel,
-/area/engine/break_room)
+/area/engine/storage_shared)
 "bEz" = (
-/obj/structure/cable/white{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/obj/effect/turf_decal/stripes/end{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/engine/break_room)
-"bEA" = (
-/obj/structure/cable/white{
-	icon_state = "1-8"
-	},
-/obj/structure/cable/white{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 2
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/engine/break_room)
-"bEB" = (
-/obj/structure/cable/white{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 2
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/engine/break_room)
-"bEC" = (
-/obj/structure/cable/white{
-	icon_state = "1-8"
-	},
-/obj/structure/cable/white{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	dir = 1
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 2
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/engine/break_room)
-"bED" = (
-/obj/structure/cable/white{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/obj/effect/turf_decal/stripes/end{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/engine/break_room)
-"bEE" = (
 /obj/machinery/door/firedoor,
 /obj/structure/cable/white{
 	icon_state = "4-8"
@@ -36916,7 +36731,40 @@
 	dir = 8
 	},
 /turf/open/floor/plasteel,
-/area/engine/break_room)
+/area/engine/storage_shared)
+"bEC" = (
+/obj/structure/cable/white{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden,
+/turf/open/floor/plasteel/neutral,
+/area/engine/storage_shared)
+"bED" = (
+/obj/structure/cable/white{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/structure/cable/white{
+	icon_state = "1-4"
+	},
+/turf/open/floor/plasteel/neutral/side{
+	dir = 8;
+	heat_capacity = 1e+006
+	},
+/area/engine/storage_shared)
+"bEE" = (
+/obj/structure/cable/white{
+	icon_state = "4-8"
+	},
+/obj/machinery/door/firedoor,
+/obj/machinery/door/airlock/engineering/glass{
+	name = "Shared Engineering Storage";
+	req_one_access_txt = "32;19"
+	},
+/turf/open/floor/plasteel,
+/area/engine/storage_shared)
 "bEF" = (
 /obj/structure/cable/white{
 	icon_state = "4-8"
@@ -37635,24 +37483,22 @@
 	},
 /area/engine/gravity_generator)
 "bFY" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/engine/gravity_generator)
 "bFZ" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
+/obj/effect/turf_decal/delivery,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
-/turf/open/floor/plasteel/neutral,
+/turf/open/floor/plasteel,
 /area/engine/gravity_generator)
 "bGa" = (
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	dir = 1
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 9
 	},
 /turf/open/floor/plasteel,
 /area/engine/gravity_generator)
@@ -37676,49 +37522,19 @@
 /obj/structure/cable/white{
 	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/effect/turf_decal/stripes/line{
-	dir = 10
-	},
 /turf/open/floor/plasteel,
-/area/engine/gravity_generator)
+/area/engine/storage_shared)
 "bGe" = (
 /obj/machinery/status_display{
 	pixel_x = 32;
 	pixel_y = -32
 	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	dir = 1
-	},
-/obj/effect/turf_decal/delivery,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plasteel,
-/area/engine/gravity_generator)
+/area/engine/storage_shared)
 "bGf" = (
-/obj/structure/closet/radiation,
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 9
-	},
-/obj/machinery/light/small,
-/obj/effect/turf_decal/stripes/line{
-	dir = 6
-	},
-/turf/open/floor/plasteel,
-/area/engine/gravity_generator)
-"bGg" = (
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = -24
-	},
-/obj/item/twohanded/required/kirbyplants/random,
-/obj/effect/turf_decal/delivery,
-/turf/open/floor/plasteel,
-/area/engine/break_room)
-"bGh" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 1
 	},
 /obj/machinery/camera{
@@ -37726,31 +37542,47 @@
 	dir = 1;
 	name = "engineering camera"
 	},
-/turf/open/floor/plasteel/caution,
-/area/engine/break_room)
-"bGi" = (
 /obj/machinery/light,
-/turf/open/floor/plasteel/caution,
-/area/engine/break_room)
+/turf/open/floor/plasteel,
+/area/engine/storage_shared)
+"bGh" = (
+/obj/structure/closet/secure_closet/engineering_electrical,
+/obj/effect/turf_decal/bot,
+/obj/machinery/light_switch{
+	pixel_x = -22
+	},
+/turf/open/floor/plasteel/neutral/corner{
+	dir = 4
+	},
+/area/engine/storage_shared)
+"bGi" = (
+/obj/machinery/vending/engivend,
+/obj/effect/turf_decal/bot,
+/turf/open/floor/plasteel/neutral/side{
+	dir = 1;
+	heat_capacity = 1e+006
+	},
+/area/engine/storage_shared)
 "bGj" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
+/obj/machinery/vending/tool,
+/obj/effect/turf_decal/bot,
+/turf/open/floor/plasteel/neutral/side{
+	dir = 1;
+	heat_capacity = 1e+006
+	},
+/area/engine/storage_shared)
+"bGk" = (
+/obj/structure/closet/secure_closet/engineering_welding,
+/obj/machinery/camera{
+	c_tag = "Engineering - Shared Storage";
+	dir = 1;
+	name = "engineering camera"
+	},
+/obj/effect/turf_decal/bot,
+/turf/open/floor/plasteel/neutral/corner{
 	dir = 1
 	},
-/turf/open/floor/plasteel/caution,
-/area/engine/break_room)
-"bGk" = (
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = 24
-	},
-/obj/machinery/airalarm{
-	dir = 1;
-	pixel_y = -22
-	},
-/obj/item/twohanded/required/kirbyplants/random,
-/obj/effect/turf_decal/delivery,
-/turf/open/floor/plasteel,
-/area/engine/break_room)
+/area/engine/storage_shared)
 "bGl" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -38510,26 +38342,17 @@
 /area/engine/gravity_generator)
 "bHQ" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/airalarm{
-	dir = 1;
-	pixel_y = -22
+/obj/effect/turf_decal/stripes/line{
+	dir = 2
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/obj/effect/turf_decal/stripes/line,
+/obj/machinery/light/small,
 /turf/open/floor/plasteel,
 /area/engine/gravity_generator)
 "bHR" = (
-/obj/machinery/newscaster{
-	pixel_y = -32
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 9
-	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 6
 	},
+/obj/structure/closet/radiation,
 /turf/open/floor/plasteel,
 /area/engine/gravity_generator)
 "bHS" = (
@@ -38547,37 +38370,36 @@
 /turf/open/floor/plasteel,
 /area/engine/gravity_generator)
 "bHT" = (
+/obj/machinery/door/poddoor/preopen{
+	id = "transitlock";
+	name = "Transit Tube Lockdown Door"
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 2
+	},
 /obj/structure/cable/white{
 	icon_state = "1-2"
 	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/turf/open/floor/plasteel/caution,
+/area/engine/storage_shared)
+"bHU" = (
 /obj/machinery/door/poddoor/preopen{
 	id = "transitlock";
 	name = "Transit Tube Lockdown Door"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/effect/turf_decal/stripes/line{
-	dir = 2
 	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
-/turf/open/floor/plasteel,
-/area/engine/gravity_generator)
-"bHU" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/door/poddoor/preopen{
-	id = "transitlock";
-	name = "Transit Tube Lockdown Door"
+/obj/effect/turf_decal/stripes/line{
+	dir = 2
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/effect/turf_decal/stripes/line{
-	dir = 2
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/engine/gravity_generator)
+/turf/open/floor/plasteel/caution,
+/area/engine/storage_shared)
 "bHV" = (
 /turf/closed/wall/r_wall,
 /area/crew_quarters/heads/chief)
@@ -40406,7 +40228,7 @@
 	id = "transitlock";
 	name = "Transit Tube Lockdown Control";
 	pixel_y = 26;
-	req_access_txt = "39; 19"
+	req_access_txt = "19"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plasteel/vault{
@@ -40422,7 +40244,7 @@
 	id = "atmoslock";
 	name = "Atmospherics Lockdown Control";
 	pixel_x = -26;
-	req_access_txt = "25"
+	req_access_txt = "24"
 	},
 /turf/open/floor/plasteel/vault{
 	dir = 5
@@ -41493,6 +41315,8 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 9
 	},
+/obj/machinery/holopad,
+/obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel/vault{
 	dir = 5
 	},
@@ -43393,7 +43217,7 @@
 	name = "Transit Tube Lockdown Control";
 	pixel_x = -38;
 	pixel_y = -8;
-	req_access_txt = "39; 19"
+	req_access_txt = "19"
 	},
 /obj/machinery/modular_computer/console/preset/engineering{
 	dir = 4
@@ -51625,11 +51449,9 @@
 	},
 /area/engine/engineering)
 "chD" = (
-/obj/machinery/vending/engivend,
 /obj/structure/cable/white{
 	icon_state = "1-4"
 	},
-/obj/effect/turf_decal/delivery,
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "chE" = (
@@ -52419,8 +52241,6 @@
 /turf/open/floor/plasteel/neutral,
 /area/engine/engineering)
 "cjo" = (
-/obj/machinery/vending/tool,
-/obj/effect/turf_decal/delivery,
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "cjp" = (
@@ -53622,11 +53442,6 @@
 /area/engine/engineering)
 "clZ" = (
 /obj/structure/closet/radiation,
-/obj/effect/turf_decal/bot,
-/turf/open/floor/plasteel,
-/area/engine/engineering)
-"cma" = (
-/obj/structure/closet/secure_closet/engineering_welding,
 /obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel,
 /area/engine/engineering)
@@ -59151,12 +58966,10 @@
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "cxG" = (
-/obj/structure/closet/secure_closet/engineering_electrical,
 /obj/machinery/light_switch{
 	pixel_x = -26;
 	pixel_y = 26
 	},
-/obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "cxH" = (
@@ -60614,36 +60427,10 @@
 	},
 /turf/open/floor/plating,
 /area/engine/engineering)
-"cAL" = (
-/obj/machinery/rnd/production/protolathe/department/engineering,
-/obj/effect/turf_decal/stripes/line{
-	dir = 9
-	},
-/turf/open/floor/plasteel/caution{
-	dir = 1
-	},
-/area/engine/engineering)
 "cAM" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/landmark/start/station_engineer,
-/obj/effect/turf_decal/loading_area,
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/turf/open/floor/plasteel/caution{
-	dir = 1
-	},
-/area/engine/engineering)
-"cAN" = (
-/obj/machinery/computer/rdconsole/production{
-	dir = 8
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 5
-	},
-/turf/open/floor/plasteel/caution{
-	dir = 1
-	},
+/turf/open/floor/plasteel/neutral,
 /area/engine/engineering)
 "cAO" = (
 /obj/structure/cable/white{
@@ -61447,16 +61234,6 @@
 	dir = 1
 	},
 /turf/open/floor/plating,
-/area/engine/engineering)
-"cCs" = (
-/obj/structure/table/reinforced,
-/obj/item/stack/packageWrap,
-/obj/item/hand_labeler,
-/obj/effect/turf_decal/delivery,
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/turf/open/floor/plasteel/caution,
 /area/engine/engineering)
 "cCt" = (
 /turf/open/floor/plasteel/yellow/side{
@@ -63793,6 +63570,9 @@
 /area/engine/engineering)
 "cHj" = (
 /obj/effect/turf_decal/stripes/line,
+/obj/structure/table/reinforced,
+/obj/item/stack/packageWrap,
+/obj/item/hand_labeler,
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "cHk" = (
@@ -99494,13 +99274,6 @@
 "ehv" = (
 /turf/open/floor/plasteel/caution,
 /area/engine/engineering)
-"ehw" = (
-/obj/machinery/rnd/production/circuit_imprinter,
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/turf/open/floor/plasteel/caution,
-/area/engine/engineering)
 "ehy" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 2
@@ -99585,6 +99358,10 @@
 	},
 /turf/open/floor/plasteel/whitepurple/side,
 /area/science/misc_lab)
+"eDi" = (
+/obj/effect/turf_decal/delivery,
+/turf/open/floor/plasteel,
+/area/engine/storage_shared)
 "eJc" = (
 /obj/machinery/atmospherics/pipe/simple/general/visible,
 /turf/closed/wall/r_wall,
@@ -99639,6 +99416,22 @@
 	dir = 5
 	},
 /area/science/mixing)
+"fpa" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/structure/cable/white{
+	icon_state = "1-2"
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/engine/gravity_generator)
 "fpQ" = (
 /obj/machinery/door/airlock/research/glass/incinerator/toxmix_interior,
 /obj/effect/mapping_helpers/airlock/locked,
@@ -99680,12 +99473,46 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/closed/wall/r_wall,
 /area/science/circuit)
+"gwC" = (
+/obj/structure/lattice,
+/turf/closed/wall/r_wall,
+/area/engine/gravity_generator)
+"gDB" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/airalarm{
+	dir = 1;
+	pixel_y = -22
+	},
+/obj/effect/turf_decal/stripes/line,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 9
+	},
+/turf/open/floor/plasteel,
+/area/engine/gravity_generator)
 "gKr" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 1
 	},
 /turf/open/floor/circuit/green,
 /area/science/research/abandoned)
+"gMU" = (
+/obj/machinery/power/apc/highcap/five_k{
+	dir = 1;
+	name = "Gravity Generator APC";
+	areastring = "/area/engine/gravity_generator";
+	pixel_y = 24
+	},
+/obj/structure/cable{
+	icon_state = "0-2"
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 10
+	},
+/turf/open/floor/plasteel,
+/area/engine/gravity_generator)
 "gNw" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/structure/table/glass,
@@ -99734,6 +99561,18 @@
 	},
 /turf/open/floor/plasteel,
 /area/maintenance/department/electrical)
+"gYi" = (
+/obj/structure/cable/white{
+	icon_state = "1-8"
+	},
+/obj/structure/cable/white{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/engine/storage_shared)
 "hdH" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/conveyor{
@@ -99751,6 +99590,16 @@
 	dir = 10
 	},
 /area/science/circuit)
+"hlu" = (
+/obj/structure/table/reinforced,
+/obj/item/storage/toolbox/electrical,
+/obj/item/wrench/power,
+/obj/machinery/status_display{
+	pixel_y = 32
+	},
+/obj/effect/turf_decal/bot,
+/turf/open/floor/plasteel,
+/area/engine/storage_shared)
 "hrP" = (
 /obj/structure/cable/white{
 	icon_state = "1-2"
@@ -99811,6 +99660,13 @@
 	dir = 9
 	},
 /area/science/circuit)
+"hUS" = (
+/obj/effect/turf_decal/delivery,
+/obj/structure/cable/white{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plasteel,
+/area/engine/gravity_generator)
 "iaF" = (
 /obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel,
@@ -99841,6 +99697,16 @@
 	dir = 5
 	},
 /area/science/mixing)
+"iZj" = (
+/obj/structure/cable/white{
+	icon_state = "0-4"
+	},
+/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/engine/storage_shared)
 "jdO" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
@@ -99881,6 +99747,13 @@
 /obj/item/integrated_circuit_printer,
 /turf/open/floor/plasteel/white/side,
 /area/science/circuit)
+"joq" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
+/area/engine/storage_shared)
 "jqM" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/stripes/line{
@@ -99953,6 +99826,14 @@
 	},
 /turf/open/floor/plating,
 /area/quartermaster/storage)
+"kqB" = (
+/obj/structure/cable/white{
+	icon_state = "0-2"
+	},
+/obj/structure/cable/white,
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
+/area/engine/storage_shared)
 "kvf" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -99987,6 +99868,18 @@
 	dir = 4
 	},
 /area/science/mixing)
+"kMr" = (
+/turf/closed/wall,
+/area/engine/storage_shared)
+"kST" = (
+/obj/structure/cable/white{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/turf/open/floor/plasteel/neutral,
+/area/engine/storage_shared)
 "lak" = (
 /turf/open/floor/plasteel/white/side{
 	dir = 10
@@ -100057,6 +99950,20 @@
 	dir = 6
 	},
 /area/science/circuit)
+"lRn" = (
+/obj/structure/cable/white{
+	icon_state = "0-4"
+	},
+/obj/structure/cable/white{
+	icon_state = "0-8"
+	},
+/obj/structure/cable/white,
+/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/engine/storage_shared)
 "lTo" = (
 /obj/docking_port/stationary{
 	area_type = /area/construction/mining/aux_base;
@@ -100098,6 +100005,13 @@
 	dir = 5
 	},
 /area/science/mixing)
+"mso" = (
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden,
+/turf/open/floor/plasteel/neutral,
+/area/engine/gravity_generator)
 "mvm" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable/white{
@@ -100109,6 +100023,25 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/circuit/green,
 /area/science/research/abandoned)
+"mOO" = (
+/obj/structure/table/reinforced,
+/obj/machinery/light/small{
+	dir = 1
+	},
+/obj/item/stack/sheet/metal{
+	amount = 30
+	},
+/obj/item/stack/sheet/glass{
+	amount = 30
+	},
+/obj/item/crowbar/red,
+/obj/item/wrench,
+/obj/structure/sign/warning/nosmoking{
+	pixel_y = 32
+	},
+/obj/effect/turf_decal/bot,
+/turf/open/floor/plasteel,
+/area/engine/storage_shared)
 "mQE" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
@@ -100120,6 +100053,30 @@
 	dir = 8
 	},
 /area/science/research)
+"mTs" = (
+/obj/machinery/door/firedoor,
+/obj/structure/cable/white{
+	icon_state = "4-8"
+	},
+/obj/machinery/door/airlock/highsecurity{
+	name = "Gravity Generator Foyer";
+	req_access_txt = "10"
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/engine/storage_shared)
 "mWZ" = (
 /obj/machinery/atmospherics/components/binary/pump,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -100131,10 +100088,33 @@
 	},
 /turf/open/floor/engine,
 /area/science/mixing)
+"nry" = (
+/obj/structure/cable/white{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/turf/open/floor/plasteel/neutral/side{
+	dir = 4
+	},
+/area/engine/storage_shared)
 "nSh" = (
 /obj/machinery/atmospherics/pipe/simple/general/hidden,
 /turf/closed/wall/r_wall,
 /area/maintenance/disposal/incinerator)
+"ood" = (
+/obj/structure/table/reinforced,
+/obj/item/stack/rods/fifty,
+/obj/item/stack/sheet/rglass{
+	amount = 30;
+	pixel_x = 2;
+	pixel_y = -2
+	},
+/obj/item/stack/cable_coil/white,
+/obj/effect/turf_decal/bot,
+/turf/open/floor/plasteel,
+/area/engine/storage_shared)
 "oIl" = (
 /obj/machinery/atmospherics/components/unary/portables_connector/visible{
 	dir = 1
@@ -100234,6 +100214,17 @@
 	},
 /turf/open/floor/plating,
 /area/science/research/abandoned)
+"pKo" = (
+/obj/structure/table/reinforced,
+/obj/item/reagent_containers/food/drinks/soda_cans/thirteenloko,
+/obj/machinery/firealarm{
+	dir = 8;
+	pixel_x = -24
+	},
+/turf/open/floor/plasteel/neutral/side{
+	dir = 4
+	},
+/area/engine/storage_shared)
 "pQm" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable/white{
@@ -100250,6 +100241,13 @@
 	dir = 9
 	},
 /area/science/circuit)
+"qne" = (
+/obj/structure/extinguisher_cabinet{
+	pixel_x = -26
+	},
+/obj/effect/turf_decal/delivery,
+/turf/open/floor/plasteel,
+/area/engine/storage_shared)
 "qnx" = (
 /obj/machinery/atmospherics/components/unary/outlet_injector/atmos/toxins_mixing_input,
 /turf/open/floor/engine/vacuum,
@@ -100272,6 +100270,25 @@
 	dir = 6
 	},
 /area/science/circuit)
+"rMx" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/engine/gravity_generator)
+"rOG" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/engine/gravity_generator)
 "rUD" = (
 /obj/machinery/meter,
 /obj/machinery/atmospherics/pipe/manifold/general/visible{
@@ -100291,14 +100308,58 @@
 "saw" = (
 /turf/closed/wall,
 /area/science/circuit)
+"saR" = (
+/obj/machinery/power/terminal{
+	dir = 4
+	},
+/obj/item/radio/intercom{
+	name = "Station Intercom";
+	pixel_y = 26
+	},
+/obj/structure/cable/white{
+	icon_state = "0-2"
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 5
+	},
+/turf/open/floor/plasteel,
+/area/engine/gravity_generator)
 "sfo" = (
 /obj/effect/decal/remains/xeno,
 /turf/open/floor/engine/vacuum,
 /area/science/mixing)
+"shp" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 10
+	},
+/obj/structure/closet/radiation,
+/turf/open/floor/plasteel,
+/area/engine/gravity_generator)
+"som" = (
+/obj/structure/cable/white{
+	icon_state = "0-2"
+	},
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
+/area/engine/storage_shared)
 "svv" = (
 /obj/machinery/door/poddoor/incinerator_toxmix,
 /turf/open/floor/engine/vacuum,
 /area/science/mixing)
+"sGg" = (
+/obj/structure/cable/white{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/turf/open/floor/plasteel,
+/area/engine/storage_shared)
+"thj" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on,
+/turf/open/floor/plasteel/neutral,
+/area/engine/storage_shared)
 "tmi" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -100311,6 +100372,14 @@
 	dir = 4
 	},
 /area/crew_quarters/fitness/recreation)
+"txT" = (
+/obj/item/twohanded/required/kirbyplants/random,
+/obj/effect/turf_decal/delivery,
+/obj/machinery/light_switch{
+	pixel_x = 22
+	},
+/turf/open/floor/plasteel,
+/area/engine/storage_shared)
 "tCh" = (
 /turf/closed/wall,
 /area/science/misc_lab)
@@ -100347,6 +100416,12 @@
 	},
 /turf/open/floor/plasteel/whitepurple/side,
 /area/science/misc_lab)
+"uKL" = (
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
+	dir = 1
+	},
+/turf/open/floor/plasteel/neutral,
+/area/engine/gravity_generator)
 "uNP" = (
 /obj/machinery/atmospherics/pipe/simple/general/visible,
 /obj/effect/turf_decal/stripes/line{
@@ -100356,6 +100431,19 @@
 	dir = 5
 	},
 /area/science/mixing)
+"uUc" = (
+/obj/structure/table/reinforced,
+/obj/machinery/light/small{
+	dir = 1
+	},
+/obj/item/stack/sheet/plasteel/fifty,
+/obj/item/crowbar/power,
+/obj/structure/sign/nanotrasen{
+	pixel_x = 32
+	},
+/obj/effect/turf_decal/bot,
+/turf/open/floor/plasteel,
+/area/engine/storage_shared)
 "uYS" = (
 /obj/machinery/door/airlock/atmos/glass/critical{
 	heat_proof = 1;
@@ -100367,6 +100455,15 @@
 	},
 /turf/open/floor/engine,
 /area/engine/supermatter)
+"vcX" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/engine/gravity_generator)
 "vqd" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/bodycontainer/morgue{
@@ -100384,6 +100481,25 @@
 	dir = 4
 	},
 /area/science/mixing)
+"vDy" = (
+/obj/machinery/newscaster{
+	pixel_y = -32
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 6
+	},
+/turf/open/floor/plasteel,
+/area/engine/gravity_generator)
+"vET" = (
+/obj/machinery/firealarm{
+	dir = 8;
+	pixel_x = -24
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/engine/storage_shared)
 "wei" = (
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plasteel,
@@ -100402,6 +100518,9 @@
 	},
 /turf/open/floor/plasteel/whitepurple/corner,
 /area/science/misc_lab)
+"wTx" = (
+/turf/closed/wall/r_wall,
+/area/engine/storage_shared)
 "xaf" = (
 /obj/machinery/door/airlock/public/glass{
 	name = "Holodeck Access"
@@ -100484,13 +100603,45 @@
 /obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel,
 /area/science/research)
+"xPj" = (
+/obj/structure/cable/white{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/engine/storage_shared)
 "xXn" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/siphon/atmos/toxins_mixing_output,
 /turf/open/floor/engine/vacuum,
 /area/science/mixing)
+"xYW" = (
+/obj/machinery/door/poddoor/preopen{
+	id = "transitlock";
+	name = "Transit Tube Lockdown Door"
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 2
+	},
+/turf/open/floor/plasteel/caution,
+/area/engine/storage_shared)
 "xZM" = (
 /obj/structure/fans/tiny/invisible,
 /turf/open/space/basic,
+/area/space)
+"yeD" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/turf/closed/wall,
+/area/engine/storage_shared)
+"yeJ" = (
+/obj/structure/lattice,
+/turf/open/space,
 /area/space)
 "yiv" = (
 /obj/effect/decal/cleanable/dirt,
@@ -116557,14 +116708,14 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
+aad
 ajr
-aaa
+ajr
 ajr
 aad
+ajr
+ajr
+ajr
 aad
 aad
 aad
@@ -116815,13 +116966,13 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-ajr
 aad
-ajr
 aaa
+aad
+aaa
+aad
+aaa
+aad
 aaa
 aaa
 aad
@@ -117071,14 +117222,14 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
 ajr
-aaa
+ajr
 aad
-aaa
+ajr
+ajr
+ajr
+ajr
+aad
 aaa
 aaa
 aad
@@ -117328,13 +117479,13 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
 ajr
 aad
-ajr
+aad
+aad
+aad
+aad
+aad
 aad
 aad
 aad
@@ -117585,15 +117736,15 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
+ajr
 aad
-aaa
-aad
-aaa
-aaa
+bxC
+bxC
+bxC
+bxC
+bxC
+bxC
+bxC
 aaa
 aad
 aaa
@@ -117842,15 +117993,15 @@ aaa
 aaa
 ajr
 ajr
-aad
-ajr
-ajr
 ajr
 aad
-ajr
-ajr
-ajr
-aad
+bxC
+bAH
+bAH
+bEn
+bAH
+bAH
+gwC
 ajr
 aad
 aad
@@ -118099,15 +118250,15 @@ aaa
 aaa
 ajr
 aaa
-aaa
 aad
-aaa
 aad
-aaa
-aad
-aaa
-aad
-aaa
+bxC
+bAH
+bCw
+bCx
+bCy
+bAH
+bxC
 aad
 aaa
 aaa
@@ -118357,14 +118508,14 @@ aaa
 ajr
 aad
 ajr
-ajr
 aad
-ajr
-ajr
-ajr
-ajr
-aad
-ajr
+bxC
+bAH
+bCx
+bEo
+bFW
+bAH
+bxC
 ajr
 ajr
 aad
@@ -118615,13 +118766,13 @@ ajr
 aaa
 ajr
 aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
+bxC
+bAH
+bCy
+bCx
+bCw
+bAH
+gwC
 aad
 ajr
 aaa
@@ -118873,11 +119024,11 @@ aaa
 ajr
 aad
 bxC
-bxC
-bxC
-bxC
-bxC
-bxC
+bAI
+bCz
+bAH
+bFX
+bHN
 bxC
 aad
 aad
@@ -119127,14 +119278,14 @@ aaa
 aaa
 ajr
 aad
-ajr
+aaa
 aad
 bxC
-bAH
-bAH
-bEn
-bAH
-bAH
+bAJ
+bCA
+bEp
+bCA
+bHO
 bxC
 aad
 ajr
@@ -119387,11 +119538,11 @@ aaa
 aad
 aad
 bxC
-bAH
-bCw
-bCx
-bCy
-bAH
+bAK
+vcX
+bEq
+rMx
+bHP
 bxC
 aad
 ajr
@@ -119641,14 +119792,14 @@ aaa
 aaa
 ajr
 aad
-ajr
+aad
 aad
 bxC
-bAH
-bCx
-bEo
-bFW
-bAH
+gMU
+mso
+bEr
+uKL
+gDB
 bxC
 aad
 aad
@@ -119898,14 +120049,14 @@ aaa
 aaa
 aad
 aaa
-ajr
+aad
 aad
 bxC
-bAH
-bCy
-bCx
-bCw
-bAH
+saR
+fpa
+bEs
+rOG
+vDy
 bxC
 aad
 ajr
@@ -120155,14 +120306,14 @@ ajr
 aad
 ajr
 aad
-ajr
+aad
 aad
 bxC
-bAI
-bCz
-bAH
-bFX
-bHN
+bAN
+bCE
+bEt
+bGb
+bHS
 bxC
 aad
 aad
@@ -120412,14 +120563,14 @@ aad
 aaa
 aad
 aaa
-aaa
-aad
+yeJ
 bxC
-bAJ
-bCA
-bEp
-bCA
-bHO
+bxC
+bxC
+bCF
+bEu
+bGc
+bxC
 bxC
 aad
 bNH
@@ -120669,14 +120820,14 @@ ajr
 ajr
 ajr
 ajr
-aad
-aad
+abj
 bxC
-bAK
+bzd
+bAO
 bCB
-bEq
+hUS
 bFY
-bHP
+shp
 bxC
 aad
 bNF
@@ -120926,12 +121077,12 @@ aad
 aaa
 aad
 aad
-aad
-aad
-bxC
-bAL
-bCC
-bEr
+abj
+bxD
+bze
+bAP
+bCH
+bEw
 bFZ
 bHQ
 bxC
@@ -121183,12 +121334,12 @@ aRF
 aRF
 aRF
 aRF
-aad
-aad
+abj
 bxC
-bAM
+bzf
+bAO
 bCD
-bEs
+bEx
 bGa
 bHR
 bxC
@@ -121440,15 +121591,15 @@ bpO
 brT
 bpO
 aRF
-aad
-aad
-bxC
-bAN
-bCE
-bEt
-bGb
-bHS
-bxC
+abl
+wTx
+kMr
+kMr
+yeD
+mTs
+kMr
+wTx
+bLF
 bLH
 bNK
 bPM
@@ -121697,15 +121848,15 @@ bpO
 bpO
 btK
 aRF
-aad
-bxC
-bxC
-bxC
-bCF
-bEu
-bGc
-bxC
-bxC
+abl
+wTx
+mOO
+qne
+iZj
+sGg
+vET
+xYW
+bLF
 bLI
 bNL
 bPN
@@ -121954,10 +122105,10 @@ bpP
 brU
 btL
 aRF
-abj
-bxC
-bzd
-bAO
+abl
+wTx
+hlu
+eDi
 bCG
 bEv
 bGd
@@ -122211,12 +122362,12 @@ aZQ
 aUY
 aWw
 aRF
-abj
-bxD
-bze
-bAP
-bCH
-bEw
+abl
+wTx
+som
+kqB
+lRn
+xPj
 bGe
 bHU
 bJP
@@ -122468,12 +122619,12 @@ aZR
 aRE
 aWx
 aRE
-abj
-bxC
-bzf
-bAO
+abl
+wTx
+ood
+eDi
 bCI
-bEx
+gYi
 bGf
 bHV
 bHV
@@ -122726,12 +122877,12 @@ aMB
 aWy
 aMG
 aMG
-bxE
-bzg
-bzg
+wTx
+uUc
+eDi
 bCJ
 bEy
-bzg
+txT
 bHV
 bJQ
 bLL
@@ -122983,12 +123134,12 @@ brV
 btM
 buY
 bwr
-bxE
-bzh
-bAQ
-bCK
+wTx
+wTx
+wTx
+bxG
 bEz
-bGg
+wTx
 bHV
 bJR
 bLM
@@ -123240,11 +123391,11 @@ brW
 btN
 buZ
 bws
-bxE
+wTx
 bzi
-bAR
+pKo
 bCL
-bEA
+nry
 bGh
 bHV
 bJS
@@ -123501,7 +123652,7 @@ bxF
 bzj
 bAS
 bCM
-bEB
+kST
 bGi
 bHV
 bJT
@@ -123756,7 +123907,7 @@ bva
 bwu
 bxG
 bzk
-bAR
+thj
 bCN
 bEC
 bGj
@@ -124269,11 +124420,11 @@ btR
 bvc
 bww
 bxI
-bzg
-bzg
-bCJ
+kMr
+kMr
+joq
 bEE
-bzg
+kMr
 bHV
 bJW
 bLQ
@@ -124814,8 +124965,8 @@ cuT
 cnE
 clX
 czt
-cAL
-cCs
+cjn
+ehv
 cDX
 cFP
 cHj
@@ -125328,8 +125479,8 @@ car
 car
 cxF
 cjn
-cAN
-ehw
+cjn
+ehv
 cDZ
 cdN
 cHl
@@ -125575,7 +125726,7 @@ cfF
 chy
 cjk
 ckE
-cma
+cjo
 cnG
 cpe
 cqx

--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -24863,7 +24863,7 @@
 	name = "Transit Tube Lockdown";
 	pixel_x = -24;
 	pixel_y = -5;
-	req_access_txt = "24"
+	req_access_txt = "19"
 	},
 /obj/machinery/button/door{
 	desc = "A remote control-switch for secure storage.";
@@ -26150,7 +26150,8 @@
 /obj/machinery/button/door{
 	id = "ceprivacy";
 	name = "Privacy Shutters Control";
-	pixel_y = -26
+	pixel_y = -26;
+	req_access_txt = "56"
 	},
 /turf/open/floor/plasteel/vault{
 	dir = 5
@@ -26165,9 +26166,7 @@
 	},
 /area/crew_quarters/heads/chief)
 "bek" = (
-/obj/structure/closet/secure_closet/engineering_chief{
-	req_access_txt = "0"
-	},
+/obj/structure/closet/secure_closet/engineering_chief,
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
@@ -26211,14 +26210,14 @@
 	name = "Engineering Lockdown";
 	pixel_x = -24;
 	pixel_y = -6;
-	req_access_txt = "1"
+	req_one_access_txt = "1;10"
 	},
 /obj/machinery/button/door{
 	id = "atmos";
 	name = "Atmospherics Lockdown";
 	pixel_x = -24;
 	pixel_y = 5;
-	req_access_txt = "1"
+	req_one_access_txt = "1;24"
 	},
 /obj/structure/cable/yellow{
 	icon_state = "2-4"
@@ -26257,8 +26256,12 @@
 /obj/machinery/light/small{
 	dir = 8
 	},
+/obj/structure/cable/yellow,
+/obj/machinery/power/apc/auto_name/west{
+	pixel_x = -26
+	},
 /turf/open/floor/plasteel,
-/area/engine/break_room)
+/area/engine/storage_shared)
 "beq" = (
 /obj/structure/sign/warning/vacuum/external,
 /turf/closed/wall/r_wall,
@@ -29547,6 +29550,9 @@
 /obj/structure/cable/yellow{
 	icon_state = "1-8"
 	},
+/obj/structure/cable/yellow{
+	icon_state = "2-8"
+	},
 /turf/open/floor/plasteel,
 /area/engine/break_room)
 "bll" = (
@@ -30293,6 +30299,9 @@
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
+	},
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel,
 /area/engine/break_room)
@@ -31327,19 +31336,22 @@
 /area/hallway/primary/starboard)
 "bpg" = (
 /obj/machinery/vending/cigarette,
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
 /turf/open/floor/plasteel,
 /area/engine/break_room)
 "bph" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
-/area/engine/break_room)
+/area/engine/storage_shared)
 "bpi" = (
 /obj/effect/turf_decal/stripes/corner{
 	dir = 1
 	},
 /turf/closed/wall,
-/area/engine/break_room)
+/area/engine/storage_shared)
 "bpj" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/structure/table,
@@ -32557,7 +32569,7 @@
 "brE" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plasteel,
-/area/engine/break_room)
+/area/engine/storage_shared)
 "brI" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
@@ -34204,7 +34216,7 @@
 /obj/structure/closet/secure_closet/engineering_electrical,
 /obj/effect/turf_decal/delivery,
 /turf/open/floor/plasteel,
-/area/engine/break_room)
+/area/engine/storage_shared)
 "bvf" = (
 /obj/item/radio/intercom{
 	broadcasting = 0;
@@ -34253,7 +34265,7 @@
 	dir = 1
 	},
 /turf/open/floor/plasteel,
-/area/engine/break_room)
+/area/engine/storage_shared)
 "bvh" = (
 /obj/machinery/computer/rdconsole/production{
 	dir = 1
@@ -34262,14 +34274,14 @@
 	dir = 1
 	},
 /turf/open/floor/plasteel,
-/area/engine/break_room)
+/area/engine/storage_shared)
 "bvi" = (
 /obj/machinery/rnd/production/protolathe/department/engineering,
 /obj/effect/turf_decal/bot{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
-/area/engine/break_room)
+/area/engine/storage_shared)
 "bvk" = (
 /obj/machinery/door/poddoor/preopen{
 	id = "atmos";
@@ -75900,7 +75912,7 @@
 	dir = 1
 	},
 /turf/open/floor/plasteel,
-/area/engine/break_room)
+/area/engine/storage_shared)
 "hvt" = (
 /obj/structure/kitchenspike_frame,
 /obj/effect/decal/cleanable/blood/gibs/old,
@@ -75942,6 +75954,9 @@
 /obj/machinery/door/firedoor,
 /turf/open/floor/plasteel,
 /area/science/circuit)
+"irL" = (
+/turf/open/floor/plasteel,
+/area/engine/storage_shared)
 "izu" = (
 /obj/machinery/autolathe{
 	name = "public autolathe"
@@ -75964,7 +75979,7 @@
 	dir = 1
 	},
 /turf/open/floor/plasteel,
-/area/engine/break_room)
+/area/engine/storage_shared)
 "iLj" = (
 /obj/structure/table,
 /turf/open/floor/plating,
@@ -75980,7 +75995,7 @@
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plating,
-/area/engine/break_room)
+/area/engine/storage_shared)
 "jrE" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 10
@@ -75990,6 +76005,10 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/break_room)
+"jsd" = (
+/obj/effect/landmark/event_spawn,
+/turf/open/floor/plasteel,
+/area/engine/storage_shared)
 "jwW" = (
 /turf/closed/wall/mineral/plastitanium,
 /area/crew_quarters/fitness/recreation)
@@ -76213,7 +76232,14 @@
 	dir = 1
 	},
 /turf/open/floor/plasteel,
-/area/engine/break_room)
+/area/engine/storage_shared)
+"mEN" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plating,
+/area/engine/storage_shared)
 "mWg" = (
 /obj/structure/girder,
 /obj/structure/grille,
@@ -76336,20 +76362,20 @@
 /area/hydroponics)
 "owR" = (
 /turf/closed/wall,
-/area/engine/break_room)
+/area/engine/storage_shared)
 "oJW" = (
 /obj/structure/sign/poster/random{
 	pixel_y = 32
 	},
 /obj/machinery/camera{
-	c_tag = "Engineering - Foyer - Storage";
+	c_tag = "Engineering - Foyer - Shared Storage";
 	dir = 8
 	},
 /obj/machinery/light/small{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
-/area/engine/break_room)
+/area/engine/storage_shared)
 "oLW" = (
 /obj/structure/table/reinforced,
 /obj/structure/cable/yellow{
@@ -76476,7 +76502,7 @@
 "qdT" = (
 /obj/item/twohanded/required/kirbyplants/random,
 /turf/open/floor/plasteel,
-/area/engine/break_room)
+/area/engine/storage_shared)
 "qhe" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -76568,13 +76594,17 @@
 /obj/machinery/vending/snack/random,
 /turf/open/floor/plasteel,
 /area/science/mixing)
+"rUK" = (
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
+/area/engine/storage_shared)
 "sao" = (
 /obj/machinery/vending/tool,
 /obj/effect/turf_decal/bot{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
-/area/engine/break_room)
+/area/engine/storage_shared)
 "sdi" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 10
@@ -76687,16 +76717,24 @@
 /obj/machinery/vending/assist,
 /turf/open/floor/plasteel,
 /area/science/mixing)
+"uyH" = (
+/obj/item/twohanded/required/kirbyplants/random,
+/obj/machinery/airalarm{
+	dir = 8;
+	pixel_x = 24
+	},
+/turf/open/floor/plasteel,
+/area/engine/storage_shared)
 "uEH" = (
 /obj/machinery/door/airlock/engineering/glass{
-	name = "Engineering Storage";
+	name = "Shared Engineering Storage";
 	req_one_access_txt = "32;19"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/effect/turf_decal/delivery,
 /obj/machinery/door/firedoor,
 /turf/open/floor/plating,
-/area/engine/break_room)
+/area/engine/storage_shared)
 "uGW" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -76779,7 +76817,7 @@
 /obj/structure/closet/secure_closet/engineering_welding,
 /obj/effect/turf_decal/delivery,
 /turf/open/floor/plasteel,
-/area/engine/break_room)
+/area/engine/storage_shared)
 "vLD" = (
 /obj/structure/lattice,
 /turf/open/space/basic,
@@ -116893,7 +116931,7 @@ bjF
 blk
 bmZ
 bpg
-bie
+mEN
 bep
 vzO
 bxd
@@ -117150,8 +117188,8 @@ bjG
 bll
 bna
 kCw
-bie
-bjL
+rUK
+irL
 bve
 bxd
 byS
@@ -117665,7 +117703,7 @@ bln
 bnc
 bph
 iHl
-bln
+jsd
 bvg
 bxd
 byU
@@ -117922,7 +117960,7 @@ ecs
 rxn
 bpi
 sao
-bjL
+irL
 bvh
 bxd
 byV
@@ -118437,7 +118475,7 @@ bne
 owR
 owR
 oJW
-qdT
+uyH
 bxc
 byW
 bAG

--- a/_maps/map_files/PubbyStation/PubbyStation.dmm
+++ b/_maps/map_files/PubbyStation/PubbyStation.dmm
@@ -32905,14 +32905,6 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/closed/wall,
 /area/medical/surgery)
-"bHf" = (
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	dir = 8
-	},
-/turf/open/floor/plasteel/yellow/corner{
-	dir = 8
-	},
-/area/hallway/primary/aft)
 "bHg" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -33901,6 +33893,11 @@
 /obj/structure/sign/departments/engineering{
 	pixel_y = -32
 	},
+/obj/machinery/camera{
+	c_tag = "Aft Primary Hallway Portable Atmospherics";
+	dir = 1;
+	start_active = 1
+	},
 /turf/open/floor/plasteel/green/side,
 /area/hallway/primary/aft)
 "bJE" = (
@@ -34346,7 +34343,7 @@
 /obj/machinery/light{
 	dir = 4
 	},
-/turf/open/floor/plasteel/yellow/corner,
+/turf/open/floor/plasteel,
 /area/hallway/primary/aft)
 "bKM" = (
 /obj/effect/spawner/structure/window,
@@ -34759,43 +34756,74 @@
 	},
 /area/medical/surgery)
 "bLR" = (
-/obj/machinery/vending/cigarette,
-/turf/open/floor/plasteel/yellow/corner{
-	dir = 1
+/obj/structure/filingcabinet/security,
+/obj/machinery/atmospherics/components/unary/vent_pump/on{
+	dir = 8
 	},
-/area/hallway/primary/aft)
-"bLS" = (
-/obj/machinery/vending/cola,
-/turf/open/floor/plasteel/yellow/corner{
-	dir = 1
+/obj/machinery/power/apc/auto_name/north{
+	pixel_y = 26
 	},
-/area/hallway/primary/aft)
-"bLT" = (
-/obj/item/twohanded/required/kirbyplants{
-	icon_state = "applebush"
+/obj/structure/cable{
+	icon_state = "0-2";
+	pixel_y = 1
 	},
-/obj/machinery/airalarm{
-	pixel_y = 22
+/obj/machinery/camera{
+	c_tag = "Engineering Security Post";
+	dir = 2;
+	start_active = 1
 	},
-/turf/open/floor/plasteel/yellow/corner{
-	dir = 1
-	},
-/area/hallway/primary/aft)
-"bLU" = (
-/obj/machinery/atmospherics/components/unary/portables_connector/visible{
-	dir = 4
-	},
-/obj/machinery/portable_atmospherics/scrubber,
-/turf/open/floor/plasteel/escape{
+/turf/open/floor/plasteel/red/side{
 	dir = 9
 	},
-/area/hallway/primary/aft)
-"bLV" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
-	dir = 10
+/area/security/checkpoint/engineering)
+"bLS" = (
+/obj/structure/table,
+/obj/machinery/recharger{
+	pixel_y = 4
 	},
-/turf/closed/wall/r_wall,
-/area/engine/atmos)
+/obj/machinery/atmospherics/pipe/simple/cyan/hidden,
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/machinery/requests_console{
+	department = "Security";
+	departmentType = 5;
+	pixel_y = 32
+	},
+/turf/open/floor/plasteel/red/side{
+	dir = 1
+	},
+/area/security/checkpoint/engineering)
+"bLT" = (
+/obj/structure/table,
+/obj/item/book/manual/wiki/security_space_law,
+/obj/structure/reagent_dispensers/peppertank{
+	pixel_y = 32
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/turf/open/floor/plasteel/red/side{
+	dir = 1
+	},
+/area/security/checkpoint/engineering)
+"bLU" = (
+/obj/machinery/computer/security{
+	icon_state = "computer";
+	dir = 8
+	},
+/obj/machinery/airalarm{
+	pixel_y = 24
+	},
+/obj/item/radio/intercom{
+	dir = 8;
+	freerange = 1;
+	name = "Station Intercom (Telecomms)";
+	pixel_x = 28;
+	pixel_y = 24
+	},
+/turf/open/floor/plasteel/red/side{
+	dir = 5
+	},
+/area/security/checkpoint/engineering)
 "bLW" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
@@ -35153,47 +35181,54 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
 "bMT" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
+	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
 "bMU" = (
-/obj/machinery/camera{
-	c_tag = "Aft Primary Hallway Atmospherics";
-	dir = 2;
-	start_active = 1
+/obj/machinery/door/airlock/security/glass{
+	name = "Engineering Security Post";
+	req_access_txt = "63"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
-/obj/item/radio/intercom{
-	dir = 8;
-	freerange = 1;
-	name = "Station Intercom (Telecomms)";
-	pixel_y = 26
+/obj/structure/cable{
+	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel,
-/area/hallway/primary/aft)
+/area/security/checkpoint/engineering)
 "bMV" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 10
+/obj/structure/cable{
+	icon_state = "1-8"
 	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/aft)
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
+	dir = 8
+	},
+/turf/open/floor/plasteel/red/side{
+	dir = 8
+	},
+/area/security/checkpoint/engineering)
 "bMW" = (
-/obj/machinery/atmospherics/components/unary/portables_connector/visible{
+/obj/machinery/computer/secure_data{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
-/obj/machinery/portable_atmospherics/scrubber,
-/turf/open/floor/plasteel/escape{
-	dir = 10
+/turf/open/floor/plasteel/red/side{
+	dir = 4
 	},
-/area/hallway/primary/aft)
+/area/security/checkpoint/engineering)
 "bMX" = (
 /obj/machinery/meter,
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/visible,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
 /turf/closed/wall/r_wall,
 /area/engine/atmos)
 "bMY" = (
@@ -35598,25 +35633,28 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
 "bOd" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
-	dir = 1
+/obj/machinery/vending/wardrobe/sec_wardrobe,
+/turf/open/floor/plasteel/red/side{
+	dir = 10
 	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/aft)
+/area/security/checkpoint/engineering)
 "bOe" = (
-/obj/machinery/atmospherics/components/unary/portables_connector/visible{
+/obj/machinery/computer/station_alert{
+	icon_state = "computer";
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/cyan/hidden{
 	dir = 4
 	},
-/obj/machinery/portable_atmospherics/pump,
-/turf/open/floor/plasteel/arrival{
-	dir = 9
+/turf/open/floor/plasteel/red/side{
+	dir = 6
 	},
-/area/hallway/primary/aft)
+/area/security/checkpoint/engineering)
 "bOf" = (
-/obj/machinery/atmospherics/pipe/manifold/cyan/visible{
-	dir = 1
-	},
 /obj/machinery/meter,
+/obj/machinery/atmospherics/pipe/simple/cyan/visible{
+	dir = 4
+	},
 /turf/closed/wall/r_wall,
 /area/engine/atmos)
 "bOg" = (
@@ -35852,21 +35890,6 @@
 /obj/structure/chair/stool,
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
-"bOM" = (
-/obj/machinery/atmospherics/components/unary/portables_connector/visible{
-	dir = 4
-	},
-/obj/machinery/portable_atmospherics/pump,
-/turf/open/floor/plasteel/arrival{
-	dir = 10
-	},
-/area/hallway/primary/aft)
-"bON" = (
-/obj/machinery/atmospherics/pipe/simple/cyan/visible{
-	dir = 9
-	},
-/turf/closed/wall/r_wall,
-/area/engine/atmos)
 "bOO" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 4
@@ -36184,23 +36207,24 @@
 "bPJ" = (
 /obj/structure/table,
 /obj/item/reagent_containers/food/drinks/soda_cans/lemon_lime,
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/yellow/corner,
 /area/hallway/primary/aft)
 "bPK" = (
 /obj/structure/table,
 /obj/item/clothing/gloves/color/fyellow,
 /obj/item/wrench,
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/yellow/corner,
 /area/hallway/primary/aft)
 "bPL" = (
 /obj/structure/table,
 /obj/item/storage/toolbox/mechanical,
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/yellow/corner,
 /area/hallway/primary/aft)
 "bPM" = (
 /obj/machinery/light{
 	dir = 4
 	},
+/obj/structure/chair/stool,
 /turf/open/floor/plasteel/yellow/corner,
 /area/hallway/primary/aft)
 "bPN" = (
@@ -37125,8 +37149,9 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	dir = 4
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden,
+/obj/structure/sign/poster/official/random{
+	pixel_y = -32
 	},
 /turf/open/floor/plasteel/yellow/corner{
 	dir = 8
@@ -37139,7 +37164,10 @@
 /obj/structure/cable{
 	icon_state = "1-4"
 	},
-/turf/open/floor/plasteel,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/turf/open/floor/plasteel/yellow/corner,
 /area/hallway/primary/aft)
 "bRX" = (
 /obj/structure/cable{
@@ -37147,18 +37175,12 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
-"bRY" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/aft)
 "bRZ" = (
 /obj/structure/cable{
 	icon_state = "2-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 10
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
@@ -37454,38 +37476,13 @@
 /turf/open/floor/plasteel/dark,
 /area/storage/tech)
 "bSL" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 5
-	},
-/turf/open/floor/plasteel/yellow/corner,
-/area/hallway/primary/aft)
-"bSM" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/turf/open/floor/plasteel/yellow/corner,
-/area/hallway/primary/aft)
-"bSN" = (
-/obj/machinery/camera{
-	c_tag = "Aft Primary Hallway Engineering";
-	dir = 1;
-	start_active = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/obj/structure/sign/departments/engineering{
-	pixel_y = -32
-	},
-/turf/open/floor/plasteel/yellow/corner,
-/area/hallway/primary/aft)
+/turf/closed/wall,
+/area/engine/storage_shared)
 "bSO" = (
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 10
-	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plasteel/yellow/corner,
 /area/hallway/primary/aft)
 "bSP" = (
@@ -38028,32 +38025,27 @@
 /turf/closed/wall/r_wall,
 /area/storage/tech)
 "bUi" = (
-/obj/structure/table,
-/obj/item/book/manual/wiki/security_space_law,
-/obj/machinery/camera{
-	c_tag = "Engineering Security Post";
+/obj/machinery/rnd/production/circuit_imprinter,
+/obj/item/radio/intercom{
+	name = "Station Intercom (General)";
+	pixel_x = -27
+	},
+/turf/open/floor/plasteel/yellow/side{
+	dir = 8
+	},
+/area/engine/storage_shared)
+"bUj" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on,
+/turf/open/floor/plasteel,
+/area/engine/storage_shared)
+"bUk" = (
+/turf/open/floor/plasteel/yellow/side{
 	dir = 4
 	},
-/obj/machinery/airalarm{
-	dir = 4;
-	pixel_x = -23
-	},
-/turf/open/floor/plasteel/red/side{
-	dir = 9
-	},
-/area/security/checkpoint/engineering)
-"bUj" = (
-/obj/machinery/computer/secure_data,
-/turf/open/floor/plasteel/red/side{
-	dir = 1
-	},
-/area/security/checkpoint/engineering)
-"bUk" = (
-/obj/machinery/computer/secure_data,
-/turf/open/floor/plasteel/red/side{
-	dir = 5
-	},
-/area/security/checkpoint/engineering)
+/area/engine/storage_shared)
 "bUl" = (
 /obj/machinery/light{
 	dir = 1
@@ -38354,36 +38346,25 @@
 /turf/closed/wall/r_wall,
 /area/engine/engine_smes)
 "bUV" = (
-/obj/structure/table,
-/obj/item/pen,
-/obj/machinery/light{
-	dir = 8
-	},
-/obj/machinery/requests_console{
-	department = "Security";
-	departmentType = 5;
-	pixel_x = -32
-	},
-/obj/item/paper_bin{
-	layer = 2.9
-	},
-/turf/open/floor/plasteel/red/side{
-	dir = 8
-	},
-/area/security/checkpoint/engineering)
-"bUW" = (
-/obj/structure/chair/office/dark{
-	dir = 1
-	},
-/obj/structure/cable{
-	icon_state = "2-4"
-	},
-/obj/effect/landmark/start/depsec/engineering,
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
+/obj/machinery/computer/rdconsole/production{
 	dir = 4
 	},
+/obj/machinery/light/small{
+	dir = 8
+	},
+/turf/open/floor/plasteel/yellow/side{
+	dir = 8
+	},
+/area/engine/storage_shared)
+"bUW" = (
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 5
+	},
 /turf/open/floor/plasteel,
-/area/security/checkpoint/engineering)
+/area/engine/storage_shared)
 "bUX" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -38391,23 +38372,23 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
-/turf/open/floor/plasteel/red/side{
+/turf/open/floor/plasteel/yellow/side{
 	dir = 4
 	},
-/area/security/checkpoint/engineering)
+/area/engine/storage_shared)
 "bUY" = (
-/obj/machinery/door/airlock/security/glass{
-	name = "Engineering Security Post";
-	req_access_txt = "63"
-	},
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
-/turf/open/floor/plasteel/red,
-/area/security/checkpoint/engineering)
+/obj/machinery/door/airlock/engineering{
+	name = "Shared Engineering Storage";
+	req_one_access_txt = "10;24"
+	},
+/turf/open/floor/plasteel,
+/area/engine/storage_shared)
 "bUZ" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -38743,41 +38724,28 @@
 	},
 /area/engine/engine_smes)
 "bVO" = (
-/obj/structure/table,
-/obj/machinery/recharger{
-	pixel_y = 4
+/obj/machinery/rnd/production/protolathe/department/engineering,
+/obj/structure/sign/poster/random{
+	pixel_x = -32
 	},
-/obj/machinery/power/apc{
-	dir = 8;
-	name = "Engineering Security APC";
-	areastring = "/area/security/checkpoint/engineering";
-	pixel_x = -24
-	},
-/obj/structure/cable{
-	icon_state = "0-4"
-	},
-/turf/open/floor/plasteel/red/side{
+/turf/open/floor/plasteel/yellow/side{
 	dir = 8
 	},
-/area/security/checkpoint/engineering)
+/area/engine/storage_shared)
 "bVP" = (
-/obj/structure/cable{
-	icon_state = "1-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 6
+/obj/machinery/atmospherics/components/unary/vent_pump/on{
+	dir = 4
 	},
 /turf/open/floor/plasteel,
-/area/security/checkpoint/engineering)
+/area/engine/storage_shared)
 "bVQ" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
-/obj/structure/closet/wardrobe/red,
-/turf/open/floor/plasteel/red/side{
+/turf/open/floor/plasteel/yellow/side{
 	dir = 4
 	},
-/area/security/checkpoint/engineering)
+/area/engine/storage_shared)
 "bVR" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -39065,36 +39033,24 @@
 	},
 /area/engine/engine_smes)
 "bWA" = (
-/obj/structure/filingcabinet,
-/obj/machinery/computer/security/telescreen{
-	desc = "Used for watching the engine containment area.";
-	dir = 4;
-	name = "Engine Monitor";
-	network = list("engine");
-	pixel_x = -32
-	},
-/turf/open/floor/plasteel/red/side{
+/obj/item/twohanded/required/kirbyplants/random,
+/turf/open/floor/plasteel/yellow/side{
 	dir = 10
 	},
-/area/security/checkpoint/engineering)
+/area/engine/storage_shared)
 "bWB" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
-	dir = 1
-	},
-/turf/open/floor/plasteel/red/side,
-/area/security/checkpoint/engineering)
+/obj/machinery/vending/engivend,
+/turf/open/floor/plasteel/yellow/side,
+/area/engine/storage_shared)
 "bWC" = (
-/obj/structure/reagent_dispensers/peppertank{
-	pixel_x = 32
-	},
-/obj/structure/closet/secure_closet/security/engine,
-/turf/open/floor/plasteel/red/side{
+/obj/machinery/vending/tool,
+/turf/open/floor/plasteel/yellow/side{
 	dir = 6
 	},
-/area/security/checkpoint/engineering)
+/area/engine/storage_shared)
 "bWD" = (
 /turf/closed/wall/r_wall,
-/area/security/checkpoint/engineering)
+/area/engine/storage_shared)
 "bWE" = (
 /obj/machinery/door/poddoor/preopen{
 	id = "Engineering";
@@ -39609,11 +39565,6 @@
 /turf/open/floor/plating,
 /area/engine/engine_smes)
 "bYj" = (
-/obj/machinery/vending/engivend,
-/turf/open/floor/plasteel/dark,
-/area/engine/engineering)
-"bYk" = (
-/obj/machinery/vending/tool,
 /turf/open/floor/plasteel/dark,
 /area/engine/engineering)
 "bYl" = (
@@ -40709,6 +40660,13 @@
 	dir = 8
 	},
 /area/chapel/main/monastery)
+"caY" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/structure/sign/poster/official/random{
+	pixel_x = 32
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/aft)
 "caZ" = (
 /obj/structure/table,
 /obj/item/wirecutters,
@@ -40817,10 +40775,10 @@
 /obj/machinery/light{
 	dir = 8
 	},
-/obj/structure/closet/secure_closet/engineering_welding,
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
+/obj/structure/closet/radiation,
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "cbm" = (
@@ -41050,7 +41008,6 @@
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "ccc" = (
-/obj/structure/closet/radiation,
 /obj/structure/extinguisher_cabinet{
 	pixel_x = 27
 	},
@@ -41096,7 +41053,6 @@
 /turf/open/floor/plating,
 /area/engine/engineering)
 "cch" = (
-/obj/structure/closet/secure_closet/engineering_electrical,
 /obj/structure/extinguisher_cabinet{
 	pixel_x = -27
 	},
@@ -41600,12 +41556,6 @@
 	icon_state = "1-8"
 	},
 /turf/open/floor/plasteel/yellow/side,
-/area/engine/engineering)
-"ceb" = (
-/obj/machinery/computer/rdconsole/production{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
 /area/engine/engineering)
 "cec" = (
 /obj/effect/spawner/structure/window/reinforced,
@@ -44853,7 +44803,11 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
-/turf/open/floor/plasteel/green/side,
+/obj/machinery/atmospherics/components/unary/portables_connector/visible,
+/obj/machinery/portable_atmospherics/pump,
+/turf/open/floor/plasteel/arrival{
+	dir = 9
+	},
 /area/hallway/primary/aft)
 "cqD" = (
 /obj/effect/turf_decal/stripes/line,
@@ -47168,14 +47122,6 @@
 /obj/machinery/rnd/production/protolathe/department/cargo,
 /turf/open/floor/plasteel,
 /area/quartermaster/storage)
-"cCU" = (
-/obj/machinery/rnd/production/circuit_imprinter,
-/turf/open/floor/plasteel,
-/area/engine/engineering)
-"cCV" = (
-/obj/machinery/rnd/production/protolathe/department/engineering,
-/turf/open/floor/plasteel,
-/area/engine/engineering)
 "cCW" = (
 /obj/machinery/vending/games,
 /turf/open/floor/plasteel/dark,
@@ -47369,6 +47315,15 @@
 /obj/structure/barricade/wooden,
 /turf/open/floor/plating,
 /area/maintenance/department/security/brig)
+"deK" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/turf/open/floor/plasteel/yellow/corner,
+/area/hallway/primary/aft)
 "dgg" = (
 /obj/structure/disposalpipe/segment{
 	dir = 6
@@ -47417,6 +47372,23 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/science/xenobiology)
+"djt" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/machinery/camera{
+	c_tag = "Aft Primary Hallway Engineering";
+	dir = 1;
+	start_active = 1
+	},
+/obj/structure/sign/departments/engineering{
+	pixel_y = -32
+	},
+/turf/open/floor/plasteel/yellow/corner,
+/area/hallway/primary/aft)
 "dkR" = (
 /obj/effect/turf_decal/box/corners{
 	dir = 4
@@ -47880,6 +47852,11 @@
 	},
 /turf/open/floor/plasteel,
 /area/construction/mining/aux_base)
+"eDI" = (
+/obj/machinery/atmospherics/pipe/simple/cyan/hidden,
+/obj/effect/landmark/start/depsec/engineering,
+/turf/open/floor/plasteel,
+/area/security/checkpoint/engineering)
 "eEp" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 4
@@ -48057,6 +48034,16 @@
 	},
 /turf/open/floor/plasteel/yellow/side,
 /area/construction/mining/aux_base)
+"ffS" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/machinery/atmospherics/components/unary/portables_connector/visible,
+/obj/machinery/portable_atmospherics/scrubber,
+/turf/open/floor/plasteel/escape{
+	dir = 9
+	},
+/area/hallway/primary/aft)
 "fhM" = (
 /obj/item/storage/secure/safe{
 	pixel_x = -22
@@ -48070,6 +48057,13 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel/grimy,
 /area/security/detectives_office)
+"fhZ" = (
+/obj/structure/closet/secure_closet/security/science,
+/obj/machinery/atmospherics/pipe/simple/cyan/hidden{
+	dir = 5
+	},
+/turf/open/floor/plasteel/red/side,
+/area/security/checkpoint/engineering)
 "fjs" = (
 /obj/machinery/light{
 	dir = 8
@@ -48236,6 +48230,15 @@
 	dir = 5
 	},
 /area/science/mixing)
+"fEv" = (
+/obj/structure/chair/stool,
+/obj/machinery/camera{
+	c_tag = "Aft Primary Hallway Atmospherics";
+	dir = 2;
+	start_active = 1
+	},
+/turf/open/floor/plasteel/yellow/corner,
+/area/hallway/primary/aft)
 "fFv" = (
 /obj/structure/lattice,
 /turf/open/space/basic,
@@ -48307,6 +48310,13 @@
 /obj/structure/bookcase/random/religion,
 /turf/open/floor/plasteel/dark,
 /area/library/lounge)
+"gak" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/engine/storage_shared)
 "gam" = (
 /obj/machinery/door/airlock/medical/glass{
 	name = "Service Door";
@@ -48804,6 +48814,12 @@
 	dir = 4
 	},
 /area/hallway/primary/central)
+"hqO" = (
+/obj/machinery/atmospherics/pipe/manifold/cyan/hidden{
+	dir = 4
+	},
+/turf/closed/wall,
+/area/security/checkpoint/engineering)
 "hvW" = (
 /obj/machinery/door/poddoor/preopen{
 	id = "xenobio4";
@@ -48907,6 +48923,12 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/security/brig)
+"hKF" = (
+/obj/machinery/atmospherics/pipe/simple/cyan/hidden{
+	dir = 4
+	},
+/turf/open/floor/plasteel/red/side,
+/area/security/checkpoint/engineering)
 "hOx" = (
 /obj/structure/cable{
 	icon_state = "2-4"
@@ -49307,6 +49329,12 @@
 	},
 /turf/open/floor/plating,
 /area/security/execution/transfer)
+"iSb" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 9
+	},
+/turf/closed/wall,
+/area/security/checkpoint/engineering)
 "iSz" = (
 /obj/structure/cable{
 	icon_state = "2-8"
@@ -49687,6 +49715,18 @@
 	},
 /turf/closed/wall/r_wall,
 /area/science/mixing)
+"kfr" = (
+/obj/structure/closet/secure_closet/engineering_electrical,
+/obj/machinery/power/apc/auto_name/north{
+	pixel_y = 26
+	},
+/obj/structure/cable{
+	icon_state = "0-2"
+	},
+/turf/open/floor/plasteel/yellow/side{
+	dir = 1
+	},
+/area/engine/storage_shared)
 "kfM" = (
 /obj/structure/closet,
 /obj/machinery/light/small{
@@ -49822,6 +49862,12 @@
 	dir = 1
 	},
 /area/engine/engineering)
+"kzK" = (
+/obj/machinery/atmospherics/pipe/simple/cyan/hidden{
+	dir = 5
+	},
+/turf/closed/wall,
+/area/security/checkpoint/engineering)
 "kAa" = (
 /obj/structure/chair{
 	dir = 8
@@ -49838,6 +49884,15 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
+"kCC" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/aft)
 "kDf" = (
 /obj/machinery/light/small{
 	dir = 2
@@ -50091,6 +50146,12 @@
 /obj/machinery/atmospherics/pipe/simple/general/hidden,
 /turf/open/floor/plating,
 /area/maintenance/department/cargo)
+"lkj" = (
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
+	dir = 8
+	},
+/turf/closed/wall,
+/area/security/checkpoint/engineering)
 "lms" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 9
@@ -50363,6 +50424,17 @@
 /obj/effect/turf_decal/stripes/corner,
 /turf/open/floor/plating/airless,
 /area/engine/engineering)
+"mgS" = (
+/obj/structure/sign/poster/official/random{
+	pixel_x = -32
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
+	dir = 8
+	},
+/turf/open/floor/plasteel/yellow/corner{
+	dir = 8
+	},
+/area/hallway/primary/aft)
 "mhl" = (
 /obj/machinery/power/emitter,
 /obj/machinery/light{
@@ -50370,6 +50442,12 @@
 	},
 /turf/open/floor/plating,
 /area/engine/engineering)
+"mll" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 5
+	},
+/turf/open/floor/plasteel,
+/area/security/checkpoint/engineering)
 "mlr" = (
 /obj/structure/lattice,
 /obj/structure/disposalpipe/junction{
@@ -50514,7 +50592,7 @@
 	name = "engineering security door"
 	},
 /turf/open/floor/plating,
-/area/security/checkpoint/engineering)
+/area/engine/storage_shared)
 "mDW" = (
 /obj/machinery/power/smes{
 	charge = 5e+006
@@ -50656,6 +50734,10 @@
 /obj/structure/lattice,
 /turf/open/space,
 /area/space/nearstation)
+"ngh" = (
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
+/area/engine/storage_shared)
 "ngp" = (
 /obj/item/chair/stool,
 /turf/open/floor/carpet,
@@ -51331,6 +51413,12 @@
 	},
 /turf/open/floor/plating,
 /area/quartermaster/miningdock)
+"oRB" = (
+/obj/item/twohanded/required/kirbyplants/random,
+/turf/open/floor/plasteel/yellow/side{
+	dir = 9
+	},
+/area/engine/storage_shared)
 "oRX" = (
 /obj/structure/closet,
 /turf/open/floor/plating,
@@ -51583,6 +51671,15 @@
 /obj/machinery/shieldwallgen/xenobiologyaccess,
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
+"pCj" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/aft)
 "pDP" = (
 /obj/machinery/vending/assist,
 /turf/open/floor/plasteel/vault{
@@ -53180,6 +53277,15 @@
 /obj/machinery/field/generator,
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
+"uxD" = (
+/obj/structure/closet/secure_closet/engineering_welding,
+/obj/machinery/airalarm{
+	pixel_y = 22
+	},
+/turf/open/floor/plasteel/yellow/side{
+	dir = 5
+	},
+/area/engine/storage_shared)
 "uzn" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden,
 /obj/structure/cable{
@@ -53210,6 +53316,13 @@
 	},
 /turf/open/floor/engine,
 /area/science/explab)
+"uBb" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/aft)
 "uCS" = (
 /obj/machinery/door/poddoor/shutters{
 	id = "aux_base_shutters";
@@ -54416,6 +54529,12 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/cargo)
+"yiT" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/aft)
 "ymb" = (
 /obj/machinery/camera{
 	c_tag = "Engineering Telecomms Access";
@@ -86705,8 +86824,8 @@ jCv
 bOK
 bEN
 bKI
-bEN
-bHf
+mgS
+bBm
 bOa
 bOK
 bPG
@@ -86714,7 +86833,7 @@ bQB
 bBm
 bRV
 bSL
-bTC
+oRB
 bUi
 bUV
 bVO
@@ -86962,22 +87081,22 @@ bAk
 bIt
 bJB
 bKJ
-bJB
 bMS
+pCj
 bOb
 bJB
 bPH
 bQC
 bJB
 bRW
-bSM
-bTC
+bSL
+kfr
 bUj
 bUW
 bVP
 bWB
 mCe
-bYk
+bYl
 bYQ
 bZA
 cam
@@ -87219,22 +87338,22 @@ bAl
 bIu
 bJC
 bKK
-bCC
+uBb
 bMT
 bOc
-bmD
+caY
 bPI
 bmD
 bRn
-bRX
-bSM
-bTC
+deK
+bSL
+uxD
 bUk
 bUX
 bVQ
 bWC
 mCe
-bYl
+bYj
 bYO
 bZC
 hYm
@@ -87475,20 +87594,20 @@ jSA
 bHg
 bIv
 bJD
-bBo
-bBo
-bMU
-bmC
-bOL
-bPJ
-bOL
-bRo
-bRX
-bSN
 bTD
-bTC
-bUY
 bVR
+bMU
+bTC
+bTD
+fEv
+bmC
+bRo
+djt
+bSL
+bSL
+ngh
+bUY
+gak
 bWD
 bWD
 bTE
@@ -87732,16 +87851,16 @@ bBp
 bvD
 bIv
 cqz
-bKM
+kzK
 bLR
 bMV
 bOd
+bTC
+bPJ
 bOL
-bPK
-bOL
-bRp
-bRY
-bSM
+bRo
+kCC
+bQD
 pps
 bUl
 bUZ
@@ -87989,12 +88108,12 @@ bBp
 bHh
 bIv
 cqz
-bBo
+hqO
 bLS
-bmC
-bmC
-bOL
-bPL
+eDI
+fhZ
+bTC
+bPK
 bOL
 bRo
 bRZ
@@ -88245,16 +88364,16 @@ bES
 bBp
 bHi
 bIv
-cqz
-bBo
+ffS
+lkj
 bLT
-bmC
-bmC
-bmC
-bmC
-bmC
-bRo
-bmC
+mll
+hKF
+bTC
+bPL
+bOL
+bRp
+yiT
 bQD
 pps
 bUn
@@ -88502,12 +88621,12 @@ bET
 bBp
 bHj
 bIx
-cqz
-bKM
+ffS
+iSb
 bLU
 bMW
 bOe
-bOM
+bTD
 bPM
 bQD
 bRq
@@ -88522,9 +88641,9 @@ bXk
 bTE
 bZc
 bZJ
-cCU
-cCV
-ceb
+cam
+cam
+cam
 jPo
 ory
 bXk
@@ -88761,10 +88880,10 @@ bHk
 bIv
 bJE
 bJN
-bLV
+bJN
 bMX
 bOf
-bON
+bJN
 bJN
 bQE
 bRr

--- a/code/game/area/Space_Station_13_areas.dm
+++ b/code/game/area/Space_Station_13_areas.dm
@@ -589,6 +589,10 @@ NOTE: there are two lists of areas in the end of this file: centcom and station 
 	name = "Engineering Storage"
 	icon_state = "engi_storage"
 
+/area/engine/storage_shared
+	name = "Shared Engineering Storage"
+	icon_state = "engi_storage"
+
 /area/engine/transit_tube
 	name = "Transit Tube"
 	icon_state = "transit_tube"


### PR DESCRIPTION
:cl: Denton
add: Shared engineering storage rooms have been added to Box, Delta and Pubbystation.
fix: Fixed the access requirements of lockdown buttons in the CE office. On some maps, these were set to the wrong department.
fix: Fixed Box and Metastation's CE locker having no access requirements.
fix: Deltastation: Fixed engineers having access to atmospheric technicians' storage room.
/:cl:

This is a continuation of #39144, where both engineers and atmos techs gain access to a shared storage room. To fit the rooms, I had to change parts of each map:
* Box: The engineering department has been made larger and now includes part of the former XXX hallway. Balance wise, this makes the telecomms airlock harder to reach.
* Delta: Power tool storage and the gravity generator have been moved to the west; shared storage is now where power tool storage used to be.
* Pubby: The storage room is now where the security post used to be. Sec post has been moved north.

Apart from storage rooms:
* Lockdown button reqs in CE offices were often either wrong or broken. I've set them to the following: Atmos/engi lockdown requires atmos/engi access. Transit tube lockdown requires head of staff access. Secure storage shutters require power storage access.
* Box and Meta CE lockers had their access reqs set to "0". I reverted it to reqular CE access.
* On Delta, engineers had access to the atmos tech only storage room (atmos equipment+hardsuit, fire axe). I changed it to atmos tech only, as on all other maps.

Screenshots:

![engi-box](https://user-images.githubusercontent.com/32391752/42811991-8d76cf2e-89bc-11e8-8866-09e90f270c10.PNG)

![engi-delta](https://user-images.githubusercontent.com/32391752/42811996-90ec9530-89bc-11e8-866a-4d625cf9a4af.PNG)

![engi-pubby](https://user-images.githubusercontent.com/32391752/42812017-9412a7ea-89bc-11e8-9717-19ea3fe1d694.PNG)


