### PR TITLE
flash AOE confusion no longer stacks indefinitely

### DIFF
--- a/code/modules/assembly/flash.dm
+++ b/code/modules/assembly/flash.dm
@@ -108,7 +108,8 @@
 		to_chat(M, "<span class='disarm'>[src] emits a blinding light!</span>")
 	if(targeted)
 		if(M.flash_act(1, 1))
-			M.confused += power
+			if(M.confused <= power*2)
+				M.confused += power
 			if(user)
 				terrible_conversion_proc(M, user)
 				visible_message("<span class='disarm'>[user] blinds [M] with the flash!</span>")


### PR DESCRIPTION
instead you can get to a max of 2 times the power of the flash instead

You can still keep someone chain confused with a continous flash but you
can't confuse them for 40 minutes by flashing them a lot in a short
period of time

:cl: oranges
balance: Flash AOE stun no longer stacks confusion indefinitely
/:cl:
