### PR TITLE
Enables hitscan on wormhole beams

### DIFF
--- a/code/modules/projectiles/projectile/special/wormhole.dm
+++ b/code/modules/projectiles/projectile/special/wormhole.dm
@@ -9,6 +9,7 @@
 	tracer_type = /obj/effect/projectile/tracer/wormhole
 	impact_type = /obj/effect/projectile/impact/wormhole
 	muzzle_type = /obj/effect/projectile/muzzle/wormhole
+	hitscan = TRUE
 
 /obj/item/projectile/beam/wormhole/orange
 	name = "orange bluespace beam"


### PR DESCRIPTION
Why: They no longer do anything to mobs, so I feel this would be a fair buff to them in trade. Could also add delay if it gets spammy.