### PR TITLE
Fixes disabled limb examine

### DIFF
--- a/code/modules/mob/living/carbon/human/examine.dm
+++ b/code/modules/mob/living/carbon/human/examine.dm
@@ -144,8 +144,13 @@
 
 	for(var/X in disabled)
 		var/obj/item/bodypart/BP = X
-		var/more_brute = BP.brute_dam >= BP.burn_dam
-		msg += "<B>[capitalize(t_his)] [BP.name] is [more_brute ? "broken and mangled" : "burnt and blistered"]!</B>\n"
+		var/damage_text
+		if(!(BP.get_damage(include_stamina = FALSE) >= BP.max_damage)) //Stamina is disabling the limb
+			damage_text = "limp and lifeless"
+		else
+			var/more_brute = BP.brute_dam >= BP.burn_dam
+			damage_text = more_brute ? "broken and mangled" : "burnt and blistered"
+		msg += "<B>[capitalize(t_his)] [BP.name] is [damage_text]!</B>\n"
 
 	//stores missing limbs
 	var/l_limbs_missing = 0


### PR DESCRIPTION
:cl: XDTM
fix: Limbs disabled by stamina damage no longer appear as broken and mangled.
/:cl:

Fixes #39199

Now i kinda want to replace broken and mangled with something with alliteration, to keep the theme going. Maybe broken and battered?
