### PR TITLE
Increases the probability of cultist deconversion effects

### DIFF
--- a/code/modules/reagents/chemistry/reagents/other_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/other_reagents.dm
@@ -218,9 +218,9 @@
 			M.stuttering = 1
 		M.stuttering = min(M.stuttering+4, 10)
 		M.Dizzy(5)
-		if(iscultist(M) && prob(8))
+		if(iscultist(M) && prob(20))
 			M.say(pick("Av'te Nar'sie","Pa'lid Mors","INO INO ORA ANA","SAT ANA!","Daim'niodeis Arc'iai Le'eones","R'ge Na'sie","Diabo us Vo'iscum","Eld' Mon Nobis"))
-			if(prob(20))
+			if(prob(10))
 				M.visible_message("<span class='danger'>[M] starts having a seizure!</span>", "<span class='userdanger'>You have a seizure!</span>")
 				M.Unconscious(120)
 				to_chat(M, "<span class='cultlarge'>[pick("Your blood is your bond - you are nothing without it", "Do not forget your place", \


### PR DESCRIPTION
:cl:
balance: Visible indications of cultist status during deconversion using holy water happen more often.
/:cl:

These effects rarely trigger with the current probability. This should make it more obvious a player is being deconverted, leading to a more confident trust among loyal crew members. This might be relatively more spammy, but I think it's more immersive given that the player is going through what is basically an exorcism.