### PR TITLE
Adds "Toggle Flashlight" to PDA Context Menu

### DIFF
--- a/code/game/objects/items/devices/PDA/PDA.dm
+++ b/code/game/objects/items/devices/PDA/PDA.dm
@@ -451,13 +451,7 @@ GLOBAL_LIST_EMPTY(PDAs)
 //MAIN FUNCTIONS===================================
 
 			if("Light")
-				if(fon)
-					fon = FALSE
-					set_light(0)
-				else if(f_lum)
-					fon = TRUE
-					set_light(f_lum)
-				update_icon()
+				toggle_light()
 			if("Medical Scan")
 				if(scanmode == PDA_SCANNER_MEDICAL)
 					scanmode = PDA_SCANNER_NONE
@@ -713,6 +707,12 @@ GLOBAL_LIST_EMPTY(PDAs)
 
 	remove_pen()
 
+/obj/item/pda/verb/verb_toggle_light()
+	set category = "Object"
+	set name = "Toggle Flashlight"
+	
+	toggle_light()
+
 /obj/item/pda/verb/verb_remove_id()
 	set category = "Object"
 	set name = "Eject ID"
@@ -729,6 +729,15 @@ GLOBAL_LIST_EMPTY(PDAs)
 	set src in usr
 
 	remove_pen()
+
+/obj/item/pda/proc/toggle_light()
+	if(fon)
+		fon = FALSE
+		set_light(0)
+	else if(f_lum)
+		fon = TRUE
+		set_light(f_lum)
+	update_icon()
 
 /obj/item/pda/proc/remove_pen()
 


### PR DESCRIPTION
new verb for the PDA that toggles the flashlight, moved the toggle code to a new proc

:cl: Epoc
add: Adds "Toggle Flashlight" to PDA context menu.
/:cl:

why: because i'm tired of having to open the PDA menu at the beginning of every round to turn on the flashlight
