### PR TITLE
Fixed jumping to faraway cameras as the AI clearing static from your screen

### DIFF
--- a/code/modules/mob/living/silicon/ai/freelook/cameranet.dm
+++ b/code/modules/mob/living/silicon/ai/freelook/cameranet.dm
@@ -91,7 +91,7 @@ GLOBAL_DATUM_INIT(cameranet, /datum/cameranet, new)
 
 		for(var/chunk in remove)
 			var/datum/camerachunk/c = chunk
-			c.remove(eye)
+			c.remove(eye, FALSE)
 
 		for(var/chunk in add)
 			var/datum/camerachunk/c = chunk

--- a/code/modules/mob/living/silicon/ai/freelook/chunk.dm
+++ b/code/modules/mob/living/silicon/ai/freelook/chunk.dm
@@ -26,10 +26,10 @@
 
 // Remove an AI eye from the chunk, then update if changed.
 
-/datum/camerachunk/proc/remove(mob/camera/aiEye/eye)
+/datum/camerachunk/proc/remove(mob/camera/aiEye/eye, remove_static_with_last_chunk = TRUE)
 	eye.visibleCameraChunks -= src
 	seenby -= eye
-	if(!eye.visibleCameraChunks.len)
+	if(remove_static_with_last_chunk && !eye.visibleCameraChunks.len)
 		var/client/client = eye.GetViewerClient()
 		if(client)
 			switch(eye.use_static)


### PR DESCRIPTION
Static was being cleared on camera jump but not re-added until you moved the eye again.

:cl: Cruix
fix: AI eyes will now see static immediately after jumping between cameras.
/:cl:

