### PR TITLE
Pubby: Replaces medical/cargo protolathes with techfabs

### DIFF
--- a/_maps/map_files/PubbyStation/PubbyStation.dmm
+++ b/_maps/map_files/PubbyStation/PubbyStation.dmm
@@ -31727,7 +31727,7 @@
 /obj/structure/extinguisher_cabinet{
 	pixel_x = -26
 	},
-/obj/machinery/rnd/production/protolathe/department/medical,
+/obj/machinery/rnd/production/techfab/department/medical,
 /turf/open/floor/plasteel/whiteblue/side{
 	dir = 1
 	},
@@ -47179,7 +47179,7 @@
 /turf/open/floor/plasteel/dark,
 /area/security/main)
 "cCT" = (
-/obj/machinery/rnd/production/protolathe/department/cargo,
+/obj/machinery/rnd/production/techfab/department/cargo,
 /turf/open/floor/plasteel,
 /area/quartermaster/storage)
 "cCU" = (


### PR DESCRIPTION
:cl: Denton
fix: Pubbystation: Medbay and Cargo now have a techfab instead of protolathe.
/:cl:

Pubby medbay/cargo had a protolathe intead of techfab, which prevented them from printing circuits.
