### PR TITLE
Fix git not ignoring _maps/backup folders

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -201,5 +201,5 @@ tools/MapAtmosFixer/MapAtmosFixer/bin/*
 .atom-build.json
 
 #extra map stuff
-_maps/backup/
-_maps/templates.dm
+/_maps/**/backup/
+/_maps/templates.dm


### PR DESCRIPTION
`backup/` in `_maps/.gitignore` is not the same as `_maps/backup/` in `.gitignore` (#39028)