### PR TITLE
Adds buzzkill grenade to nuke ops uplink

### DIFF
--- a/code/game/objects/items/grenades/spawnergrenade.dm
+++ b/code/game/objects/items/grenades/spawnergrenade.dm
@@ -34,3 +34,10 @@
 /obj/item/grenade/spawnergrenade/syndiesoap
 	name = "Mister Scrubby"
 	spawner_type = /obj/item/soap/syndie
+
+/obj/item/grenade/spawnergrenade/buzzkill
+	name = "Buzzkill grenade"
+	desc = "The label reads: \"WARNING: DEVICE WILL RELEASE LIVE SPECIMENS UPON ACTIVATION. SEAL SUIT BEFORE USE.\" It is warm to the touch and vibrates faintly."
+	icon_state = "holy_grenade"
+	spawner_type = /mob/living/simple_animal/hostile/poison/bees/toxin
+	deliveryamt = 10

--- a/code/game/objects/items/storage/uplink_kits.dm
+++ b/code/game/objects/items/storage/uplink_kits.dm
@@ -339,3 +339,11 @@
 	new /obj/item/stamp/chameleon/broken(src)
 	new /obj/item/pda/chameleon/broken(src)
 	// No chameleon laser, they can't randomise for //REASONS//
+
+/obj/item/storage/box/syndie_kit/bee_grenades
+	name = "buzzkill grenade box"
+	desc = "A sleek, sturdy box with a buzzing noise coming from the inside. Uh oh."
+
+/obj/item/storage/box/syndie_kit/bee_grenades/PopulateContents()
+	for(var/i in 1 to 3)
+		new /obj/item/grenade/spawnergrenade/buzzkill(src)

--- a/code/modules/uplink/uplink_items.dm
+++ b/code/modules/uplink/uplink_items.dm
@@ -395,6 +395,15 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 	player_minimum = 25
 	restricted = TRUE
 
+/datum/uplink_item/dangerous/buzzkill
+	name = "Buzzkill Grenade"
+	desc = "A grenade that releases a swarm of bees upon activation. These bees indiscriminately attack friend and foe \
+			with random toxins, courtesy of the BLF and Tiger Cooperative."
+	item = /obj/item/grenade/spawnergrenade/buzzkill
+	cost = 5
+	surplus = 35
+	include_modes = list(/datum/game_mode/nuclear, /datum/game_mode/nuclear/clown_ops)
+
 // Ammunition
 /datum/uplink_item/ammo
 	category = "Ammunition"

--- a/code/modules/uplink/uplink_items.dm
+++ b/code/modules/uplink/uplink_items.dm
@@ -396,10 +396,10 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 	restricted = TRUE
 
 /datum/uplink_item/dangerous/buzzkill
-	name = "Buzzkill Grenade"
-	desc = "A grenade that releases a swarm of bees upon activation. These bees indiscriminately attack friend and foe \
-			with random toxins, courtesy of the BLF and Tiger Cooperative."
-	item = /obj/item/grenade/spawnergrenade/buzzkill
+	name = "Buzzkill Grenade Box"
+	desc = "A box with three grenades that release a swarm of angry bees upon activation. These bees indiscriminately attack friend or foe \
+			with random toxins. Courtesy of the BLF and Tiger Cooperative."
+	item = /obj/item/storage/box/syndie_kit/bee_grenades
 	cost = 5
 	surplus = 35
 	include_modes = list(/datum/game_mode/nuclear, /datum/game_mode/nuclear/clown_ops)


### PR DESCRIPTION
:cl: Denton
add: Nuclear Operatives can now purchase Buzzkill grenades for 5TC per box of three. Those release a swarm of angry bees with random toxins.
/:cl:

I thought that nuke ops can use more terror weapons like the manhack nade - this one spawns ten random toxin bees on activation.

TC cost and surplus chance are the same as the manhack delivery nade, but could probably be adjusted since bees can't attack players who wear thick clothing and are lacking the limb cutting/FoF detection of manhacks. Also you sometimes just get bees with coffee grounds and tea leaf toxin.

Edit: Replaced a single 5TC grenade with a box of three nades for 5TC.