### PR TITLE
Fixes atmos_spawn_air causing invalid temperatures

### DIFF
--- a/code/modules/atmospherics/environmental/LINDA_system.dm
+++ b/code/modules/atmospherics/environmental/LINDA_system.dm
@@ -120,4 +120,5 @@
 	G.parse_gas_string(text)
 
 	air.merge(G)
+	archive()
 	SSair.add_to_active(src, 0)


### PR DESCRIPTION
The issue is mismatch between archived and current temperature when sharing with something adjacent that goes first. The alternative fix here is to force excited group handling because i feel this might be the cause here but i'll have to investigate first.