### PR TITLE
Fixes deltastation maintenance having fresh blood decals

### DIFF
--- a/_maps/map_files/Deltastation/DeltaStation2.dmm
+++ b/_maps/map_files/Deltastation/DeltaStation2.dmm
@@ -68195,10 +68195,10 @@
 /area/maintenance/port)
 "cQd" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/blood/splatter,
 /obj/effect/turf_decal/stripes/line{
 	dir = 6
 	},
+/obj/effect/decal/cleanable/blood/old,
 /turf/open/floor/plasteel,
 /area/maintenance/port)
 "cQe" = (
@@ -93572,7 +93572,7 @@
 /obj/structure/cable/white{
 	icon_state = "1-2"
 	},
-/obj/effect/decal/cleanable/blood/splatter,
+/obj/effect/decal/cleanable/blood/old,
 /turf/open/floor/plasteel/grimy,
 /area/library/abandoned)
 "dSu" = (
@@ -94764,7 +94764,7 @@
 /turf/open/floor/plating,
 /area/library/abandoned)
 "dVJ" = (
-/obj/effect/decal/cleanable/blood/splatter,
+/obj/effect/decal/cleanable/blood/old,
 /turf/open/floor/wood{
 	icon_state = "wood-broken6"
 	},
@@ -97962,10 +97962,10 @@
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
 "edj" = (
-/obj/effect/decal/cleanable/blood/splatter,
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
+/obj/effect/decal/cleanable/blood/old,
 /turf/open/floor/plasteel,
 /area/maintenance/port/aft)
 "edk" = (


### PR DESCRIPTION
:cl: Mickyan
fix: Deltastation: replaced blood decals in maintenance with their dried counterparts
/:cl:

There's are a few spots in delta (south west maintenance) that were using fresh blood decals instead of the dried ones, confusing people into thinking someone got attacked there