### PR TITLE
Adds organ harvester examine desc

### DIFF
--- a/code/game/machinery/harvester.dm
+++ b/code/game/machinery/harvester.dm
@@ -169,3 +169,10 @@
 /obj/machinery/harvester/relaymove(mob/user)
 	if (!state_open)
 		container_resist(user)
+
+/obj/machinery/harvester/examine(mob/user)
+	..()
+	if(state_open)
+		to_chat(user, "<span class='notice'>[src] must be closed before harvesting.</span>")
+	else
+		to_chat(user, "<span class='notice'>Alt-click [src] to start harvesting.</span>")


### PR DESCRIPTION
:cl: Denton
spellcheck: Added examine descriptions to the organ harvester.
/:cl:

Organ harvester was lacking examine descs, new players might not know that it's started with alt+click.