### PR TITLE
Fixes performance issues with hitscans and portals

### DIFF
--- a/code/game/objects/effects/portals.dm
+++ b/code/game/objects/effects/portals.dm
@@ -27,6 +27,7 @@
 	var/turf/open/atmos_destination	//Atmos link destination
 	var/allow_anchored = FALSE
 	var/innate_accuracy_penalty = 0
+	var/last_effect = 0
 
 /obj/effect/portal/anom
 	name = "wormhole"
@@ -154,7 +155,12 @@
 		return
 	if(ismegafauna(M))
 		message_admins("[M] has used a portal at [ADMIN_VERBOSEJMP(src)] made by [usr].")
-	if(do_teleport(M, real_target, innate_accuracy_penalty))
+	var/no_effect = FALSE
+	if(last_effect == world.time)
+		no_effect = TRUE
+	else
+		last_effect = world.time
+	if(do_teleport(M, real_target, innate_accuracy_penalty, no_effects = no_effect))
 		if(istype(M, /obj/item/projectile))
 			var/obj/item/projectile/P = M
 			P.ignore_source_check = TRUE

--- a/code/game/objects/effects/temporary_visuals/projectiles/projectile_effects.dm
+++ b/code/game/objects/effects/temporary_visuals/projectiles/projectile_effects.dm
@@ -51,6 +51,10 @@
 		pixel_x += round((sin(angle_override)+16*sin(angle_override)*2), 1)
 		pixel_y += round((cos(angle_override)+16*cos(angle_override)*2), 1)
 
-/obj/effect/projectile_lighting/Initialize(mapload, color, range, intensity)
+/obj/effect/projectile_lighting
+	var/owner
+
+/obj/effect/projectile_lighting/Initialize(mapload, color, range, intensity, owner_key)
 	. = ..()
 	set_light(range, intensity, color)
+	owner = owner_key

--- a/code/game/objects/effects/temporary_visuals/projectiles/tracer.dm
+++ b/code/game/objects/effects/temporary_visuals/projectiles/tracer.dm
@@ -1,4 +1,4 @@
-/proc/generate_tracer_between_points(datum/point/starting, datum/point/ending, beam_type, color, qdel_in = 5, light_range = 2, light_color_override, light_intensity = 1)		//Do not pass z-crossing points as that will not be properly (and likely will never be properly until it's absolutely needed) supported!
+/proc/generate_tracer_between_points(datum/point/starting, datum/point/ending, beam_type, color, qdel_in = 5, light_range = 2, light_color_override, light_intensity = 1, instance_key)		//Do not pass z-crossing points as that will not be properly (and likely will never be properly until it's absolutely needed) supported!
 	if(!istype(starting) || !istype(ending) || !ispath(beam_type))
 		return
 	var/datum/point/midpoint = point_midpoint_points(starting, ending)
@@ -9,9 +9,13 @@
 	. = PB
 	if(light_range > 0 && light_intensity > 0)
 		var/list/turf/line = getline(starting.return_turf(), ending.return_turf())
-		for(var/i in line)
-			var/turf/T = i
-			QDEL_IN(new /obj/effect/projectile_lighting(T, light_color_override, light_range, light_intensity), qdel_in > 0? qdel_in : 5)
+		tracing_line:
+			for(var/i in line)
+				var/turf/T = i
+				for(var/obj/effect/projectile_lighting/PL in T)
+					if(PL.owner == instance_key)
+						continue tracing_line
+				QDEL_IN(new /obj/effect/projectile_lighting(T, light_color_override, light_range, light_intensity, instance_key), qdel_in > 0? qdel_in : 5)
 		line = null
 	if(qdel_in)
 		QDEL_IN(PB, qdel_in)

--- a/code/modules/projectiles/projectile.dm
+++ b/code/modules/projectiles/projectile.dm
@@ -590,8 +590,9 @@
 	if(!length(beam_segments))
 		return
 	if(tracer_type)
+		var/tempref = REF(src)
 		for(var/datum/point/p in beam_segments)
-			generate_tracer_between_points(p, beam_segments[p], tracer_type, color, duration, hitscan_light_range, hitscan_light_color_override, hitscan_light_intensity)
+			generate_tracer_between_points(p, beam_segments[p], tracer_type, color, duration, hitscan_light_range, hitscan_light_color_override, hitscan_light_intensity, tempref)
 	if(muzzle_type && duration > 0)
 		var/datum/point/p = beam_segments[1]
 		var/atom/movable/thing = new muzzle_type


### PR DESCRIPTION
Portals can only spark once per tick now, and hitscan tracers don't make multiple lighting objects on one turf from one projectile.