### PR TITLE
Return of Party button

### DIFF
--- a/code/game/machinery/firealarm.dm
+++ b/code/game/machinery/firealarm.dm
@@ -296,6 +296,7 @@
 /obj/machinery/firealarm/partyalarm
 	name = "\improper PARTY BUTTON"
 	desc = "Cuban Pete is in the house!"
+	var/static/party_overlay
 
 /obj/machinery/firealarm/partyalarm/reset()
 	if (stat & (NOPOWER|BROKEN))
@@ -304,7 +305,7 @@
 	if (!A || !A.party)
 		return
 	A.party = FALSE
-	A.cut_overlay("party")
+	A.cut_overlay(party_overlay)
 
 /obj/machinery/firealarm/partyalarm/alarm()
 	if (stat & (NOPOWER|BROKEN))
@@ -313,7 +314,9 @@
 	if (!A || A.party || A.name == "Space")
 		return
 	A.party = TRUE
-	A.add_overlay("party")
+	if (!party_overlay)
+		party_overlay = iconstate2appearance('icons/turf/areas.dmi', "party")
+	A.add_overlay(party_overlay)
 
 /obj/machinery/firealarm/partyalarm/ui_data(mob/user)
 	. = ..()

--- a/code/game/machinery/firealarm.dm
+++ b/code/game/machinery/firealarm.dm
@@ -285,3 +285,37 @@
 		set_light(l_power = 0.8)
 	else
 		set_light(l_power = 0)
+
+/*
+ * Return of Party button
+ */
+
+/area
+	var/party = FALSE
+
+/obj/machinery/firealarm/partyalarm
+	name = "\improper PARTY BUTTON"
+	desc = "Cuban Pete is in the house!"
+
+/obj/machinery/firealarm/partyalarm/reset()
+	if (stat & (NOPOWER|BROKEN))
+		return
+	var/area/A = get_area(src)
+	if (!A || !A.party)
+		return
+	A.party = FALSE
+	A.cut_overlay("party")
+
+/obj/machinery/firealarm/partyalarm/alarm()
+	if (stat & (NOPOWER|BROKEN))
+		return
+	var/area/A = get_area(src)
+	if (!A || A.party || A.name == "Space")
+		return
+	A.party = TRUE
+	A.add_overlay("party")
+
+/obj/machinery/firealarm/partyalarm/ui_data(mob/user)
+	. = ..()
+	var/area/A = get_area(src)
+	.["alarm"] = A && A.party


### PR DESCRIPTION
:cl:
admin: The party button is back.
/:cl:

Re-adds what #38366 removed.

~~Has some kind of weird interaction with weather icons where the overlay can't be added or cut if weather is active but this object is rare enough and its confluence with weather even rarer so w/e.~~