### PR TITLE
Pickup animation now tweens to the correct spot if you move

### DIFF
--- a/code/game/atoms_movable.dm
+++ b/code/game/atoms_movable.dm
@@ -779,27 +779,16 @@
 	return TRUE
 
 
-/obj/item/proc/do_pickup_animation(turf/target)
+/obj/item/proc/do_pickup_animation(atom/target)
 	set waitfor = FALSE
 	var/image/I = image(icon = src, loc = loc, layer = layer + 0.1)
 	I.plane = GAME_PLANE
 	I.transform *= 0.75
 	I.appearance_flags = APPEARANCE_UI_IGNORE_ALPHA
-	var/direction = get_dir(src, target)
+	var/turf/T = get_turf(src)
+	var/direction
 	var/to_x = 0
 	var/to_y = 0
-	if(direction & NORTH)
-		to_y = 32
-	else if(direction & SOUTH)
-		to_y = -32
-
-	if(direction & EAST)
-		to_x = 32
-	else if(direction & WEST)
-		to_x = -32
-
-	if(!direction)
-		to_y = 16
 
 	flick_overlay(I, GLOB.clients, 6)
 	var/matrix/M = new
@@ -809,6 +798,18 @@
 	sleep(1)
 	animate(I, transform = matrix(), time = 1)
 	sleep(1)
+	if(!QDELETED(T) && !QDELETED(target))
+		direction = get_dir(T, target)
+	if(direction & NORTH)
+		to_y = 32
+	else if(direction & SOUTH)
+		to_y = -32
+	if(direction & EAST)
+		to_x = 32
+	else if(direction & WEST)
+		to_x = -32
+	if(!direction)
+		to_y = 16
 	animate(I, alpha = 175, pixel_x = to_x, pixel_y = to_y, time = 3, easing = CUBIC_EASING)
 	sleep(1)
 	animate(I, alpha = 0, time = 1)


### PR DESCRIPTION
:cl:
tweak: The item pick up animation tweens to the correct spot if you move
/:cl:

![a](https://user-images.githubusercontent.com/5211576/42969485-529046d8-8b74-11e8-9260-228e319de76c.gif)

See also Iamgoofball/-tg-station#16