### PR TITLE
Fix some erroneous reagent typepaths

### DIFF
--- a/code/modules/reagents/chemistry/reagents/alcohol_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/alcohol_reagents.dm
@@ -1697,7 +1697,7 @@ All effects don't start immediately, but rather get worse over time; the rate is
 	glass_name = "glass of fernet cola"
 	glass_desc = "A sawed-off cola bottle filled with Fernet Cola. Nothing better after eating like a lardass."
 
-/datum/reagent/consumable/ethanol/fernetcola/on_mob_life(mob/living/carbon/M)
+/datum/reagent/consumable/ethanol/fernet_cola/on_mob_life(mob/living/carbon/M)
 	if(M.nutrition <= NUTRITION_LEVEL_STARVING)
 		M.adjustToxLoss(0.5*REM, 0)
 	M.nutrition = max(M.nutrition - 3, 0)

--- a/code/modules/reagents/chemistry/reagents/drug_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/drug_reagents.dm
@@ -132,7 +132,7 @@
 	..()
 	. = 1
 
-/datum/reagent/krokodil/addiction_act_stage2(mob/living/M)
+/datum/reagent/drug/krokodil/addiction_act_stage2(mob/living/M)
 	if(prob(25))
 		to_chat(M, "<span class='danger'>Your skin feels loose...</span>")
 	..()


### PR DESCRIPTION
:cl:
fix: Fernet Cola's effect has been restored.
fix: Krokodil's addition stage two warning message has been restored.
/:cl: