### PR TITLE
Stamina rework electric boogaloo - Limb specific regen instead of mob combined regen, chest/head only limbs that count for full stun, other limbs get individually disabled.

### DIFF
--- a/code/__DEFINES/mobs.dm
+++ b/code/__DEFINES/mobs.dm
@@ -255,3 +255,6 @@
 // AI Toggles
 #define AI_CAMERA_LUMINOSITY	5
 #define AI_VOX // Comment out if you don't want VOX to be enabled and have players download the voice sounds.
+
+// /obj/item/bodypart on_mob_life() retval flag
+#define BODYPART_LIFE_UPDATE_HEALTH (1<<0)

--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -508,13 +508,23 @@
 		var/obj/item/bodypart/BP = X
 		total_brute	+= (BP.brute_dam * BP.body_damage_coeff)
 		total_burn	+= (BP.burn_dam * BP.body_damage_coeff)
-		total_stamina += (BP.stamina_dam * BP.body_damage_coeff)
+		total_stamina += (BP.stamina_dam * BP.stam_damage_coeff)
 	health = maxHealth - getOxyLoss() - getToxLoss() - getCloneLoss() - total_burn - total_brute
 	staminaloss = total_stamina
 	update_stat()
 	if(((maxHealth - total_burn) < HEALTH_THRESHOLD_DEAD) && stat == DEAD )
 		become_husk("burn")
 	med_hud_set_health()
+
+/mob/living/carbon/update_stamina()
+	var/stam = getStaminaLoss()
+	if(stam)
+		var/total_health = (health - stam)
+		if(total_health <= crit_threshold && !stat)
+			if(!IsKnockdown())
+				to_chat(src, "<span class='notice'>You're too exhausted to keep going...</span>")
+			Knockdown(70)
+			update_health_hud()
 
 /mob/living/carbon/update_sight()
 	if(!client)

--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -509,8 +509,8 @@
 		total_brute	+= (BP.brute_dam * BP.body_damage_coeff)
 		total_burn	+= (BP.burn_dam * BP.body_damage_coeff)
 		total_stamina += (BP.stamina_dam * BP.stam_damage_coeff)
-	health = maxHealth - getOxyLoss() - getToxLoss() - getCloneLoss() - total_burn - total_brute
-	staminaloss = total_stamina
+	health = round(maxHealth - getOxyLoss() - getToxLoss() - getCloneLoss() - total_burn - total_brute, DAMAGE_PRECISION)
+	staminaloss = round(total_stamina, DAMAGE_PRECISION)
 	update_stat()
 	if(((maxHealth - total_burn) < HEALTH_THRESHOLD_DEAD) && stat == DEAD )
 		become_husk("burn")
@@ -518,7 +518,7 @@
 
 /mob/living/carbon/update_stamina()
 	var/stam = getStaminaLoss()
-	if(stam)
+	if(stam > DAMAGE_PRECISION)
 		var/total_health = (health - stam)
 		if(total_health <= crit_threshold && !stat)
 			if(!IsKnockdown())

--- a/code/modules/mob/living/carbon/damage_procs.dm
+++ b/code/modules/mob/living/carbon/damage_procs.dm
@@ -92,7 +92,7 @@
 	. = 0
 	for(var/X in bodyparts)
 		var/obj/item/bodypart/BP = X
-		. += BP.stamina_dam * BP.stam_damage_coeff
+		. += round(BP.stamina_dam * BP.stam_damage_coeff, DAMAGE_PRECISION)
 
 /mob/living/carbon/adjustStaminaLoss(amount, updating_health = TRUE, forced = FALSE)
 	if(!forced && (status_flags & GODMODE))

--- a/code/modules/mob/living/carbon/damage_procs.dm
+++ b/code/modules/mob/living/carbon/damage_procs.dm
@@ -92,7 +92,7 @@
 	. = 0
 	for(var/X in bodyparts)
 		var/obj/item/bodypart/BP = X
-		. += BP.stamina_dam
+		. += BP.stamina_dam * BP.stam_damage_coeff
 
 /mob/living/carbon/adjustStaminaLoss(amount, updating_health = TRUE, forced = FALSE)
 	if(!forced && (status_flags & GODMODE))

--- a/code/modules/mob/living/carbon/life.dm
+++ b/code/modules/mob/living/carbon/life.dm
@@ -14,6 +14,15 @@
 	if(..()) //not dead
 		handle_blood()
 
+	var/bprv
+	if(stat != DEAD)
+		bprv = handle_bodyparts()
+
+	if(stat != DEAD)
+		if(bprv & BODYPART_LIFE_UPDATE_HEALTH)
+			updatehealth()
+			update_stamina()
+
 	if(stat != DEAD)
 		handle_brain_damage()
 
@@ -243,6 +252,12 @@
 /mob/living/carbon/proc/handle_blood()
 	return
 
+/mob/living/carbon/proc/handle_bodyparts()
+	for(var/I in bodyparts)
+		var/obj/item/bodypart/BP = I
+		if(BP.needs_processing)
+			. |= BP.on_life()
+
 /mob/living/carbon/proc/handle_organs()
 	for(var/V in internal_organs)
 		var/obj/item/organ/O = V
@@ -352,8 +367,6 @@ GLOBAL_LIST_INIT(ballmer_windows_me_msg, list("Yo man, what if, we like, uh, put
 //this updates all special effects: stun, sleeping, knockdown, druggy, stuttering, etc..
 /mob/living/carbon/handle_status_effects()
 	..()
-	if(getStaminaLoss())
-		adjustStaminaLoss(-3)
 
 	var/restingpwr = 1 + 4 * resting
 

--- a/code/modules/mob/living/carbon/life.dm
+++ b/code/modules/mob/living/carbon/life.dm
@@ -15,8 +15,7 @@
 		handle_blood()
 
 	if(stat != DEAD)
-		var/bprv = NONE
-		bprv |= handle_bodyparts()
+		var/bprv = handle_bodyparts()
 		if(bprv & BODYPART_LIFE_UPDATE_HEALTH)
 			updatehealth()
 			update_stamina()

--- a/code/modules/mob/living/carbon/life.dm
+++ b/code/modules/mob/living/carbon/life.dm
@@ -14,11 +14,9 @@
 	if(..()) //not dead
 		handle_blood()
 
-	var/bprv
 	if(stat != DEAD)
-		bprv = handle_bodyparts()
-
-	if(stat != DEAD)
+		var/bprv = NONE
+		bprv |= handle_bodyparts()
 		if(bprv & BODYPART_LIFE_UPDATE_HEALTH)
 			updatehealth()
 			update_stamina()

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -803,15 +803,6 @@
 /mob/living/proc/update_stamina()
 	return
 
-/mob/living/carbon/update_stamina()
-	var/stam = getStaminaLoss()
-	if(stam)
-		var/total_health = (health - stam)
-		if(total_health <= crit_threshold && !stat && !IsKnockdown())
-			to_chat(src, "<span class='notice'>You're too exhausted to keep going...</span>")
-			Knockdown(100)
-			update_health_hud()
-
 /mob/living/carbon/alien/update_stamina()
 	return
 

--- a/code/modules/surgery/bodyparts/bodyparts.dm
+++ b/code/modules/surgery/bodyparts/bodyparts.dm
@@ -10,6 +10,7 @@
 	var/mob/living/carbon/owner = null
 	var/mob/living/carbon/original_owner = null
 	var/status = BODYPART_ORGANIC
+	var/needs_processing = FALSE
 
 	var/body_zone //BODY_ZONE_CHEST, BODY_ZONE_L_ARM, etc , used for def_zone
 	var/aux_zone // used for hands
@@ -22,12 +23,15 @@
 
 	var/disabled = FALSE //If TRUE, limb is as good as missing
 	var/body_damage_coeff = 1 //Multiplier of the limb's damage that gets applied to the mob
+	var/stam_damage_coeff = 0
 	var/brutestate = 0
 	var/burnstate = 0
 	var/brute_dam = 0
 	var/burn_dam = 0
 	var/stamina_dam = 0
+	var/max_stamina_damage = 0
 	var/max_damage = 0
+	var/stam_heal_tick = 3		//per Life().
 
 	var/brute_reduction = 0 //Subtracted to brute damage taken
 	var/burn_reduction = 0	//Subtracted to burn damage taken
@@ -121,6 +125,20 @@
 	for(var/obj/item/I in src)
 		I.forceMove(T)
 
+/obj/item/bodypart/proc/consider_processing()
+	if(stamina_dam)
+		. = TRUE
+	//else if.. else if.. so on.
+	else
+		. = FALSE
+	needs_processing = .
+
+//Return TRUE to get whatever mob this is in to update health.
+/obj/item/bodypart/proc/on_life()
+	if(stamina_dam)					//DO NOT update health here, it'll be done in the carbon's life.
+		if(heal_damage(brute = 0, burn = 0, stamina = stam_heal_tick, only_robotic = FALSE, only_organic = FALSE, updating_health = FALSE))
+			. |= BODYPART_LIFE_UPDATE_HEALTH
+
 //Applies brute and burn damage to the organ. Returns 1 if the damage-icon states changed at all.
 //Damage will not exceed max_damage using this proc
 //Cannot apply negative damage
@@ -159,12 +177,13 @@
 	//We've dealt the physical damages, if there's room lets apply the stamina damage.
 	var/current_damage = get_damage(TRUE)		//This time around, count stamina loss too.
 	var/available_damage = max_damage - current_damage
-	stamina_dam += CLAMP(stamina, 0, available_damage)
+	stamina_dam += CLAMP(stamina, 0, min(max_stamina_damage - stamina_dam, available_damage))
 
 	if(owner && updating_health)
 		owner.updatehealth()
 		if(stamina)
 			owner.update_stamina()
+	consider_processing()
 	check_disabled()
 	return update_bodypart_damage_state()
 
@@ -184,17 +203,16 @@
 	stamina_dam = round(max(stamina_dam - stamina, 0), DAMAGE_PRECISION)
 	if(owner && updating_health)
 		owner.updatehealth()
+	consider_processing()
 	check_disabled()
 	return update_bodypart_damage_state()
 
-
-//Returns total damage...kinda pointless really
+//Returns total damage.
 /obj/item/bodypart/proc/get_damage(include_stamina = FALSE)
 	var/total = brute_dam + burn_dam
 	if(include_stamina)
 		total += stamina_dam
 	return total
-
 
 //Checks disabled status thresholds
 /obj/item/bodypart/proc/check_disabled()
@@ -223,8 +241,6 @@
 		burnstate = tburn
 		return TRUE
 	return FALSE
-
-
 
 //Change organ status
 /obj/item/bodypart/proc/change_bodypart_status(new_limb_status, heal_limb, change_icon_to_default)
@@ -414,6 +430,8 @@
 	body_part = CHEST
 	px_x = 0
 	px_y = 0
+	stam_damage_coeff = 1
+	max_stamina_damage = 100
 	var/obj/item/cavity_item
 
 /obj/item/bodypart/chest/Destroy()
@@ -460,7 +478,8 @@
 	icon_state = "default_human_l_arm"
 	attack_verb = list("slapped", "punched")
 	max_damage = 50
-	body_zone =BODY_ZONE_L_ARM
+	max_stamina_damage = 50
+	body_zone = BODY_ZONE_L_ARM
 	body_part = ARM_LEFT
 	aux_zone = BODY_ZONE_PRECISE_L_HAND
 	aux_layer = HANDS_PART_LAYER
@@ -468,6 +487,7 @@
 	held_index = 1
 	px_x = -6
 	px_y = 0
+	stam_heal_tick = 2
 
 /obj/item/bodypart/l_arm/set_disabled(new_disabled = TRUE)
 	..()
@@ -517,6 +537,8 @@
 	held_index = 2
 	px_x = 6
 	px_y = 0
+	stam_heal_tick = 2
+	max_stamina_damage = 50
 
 /obj/item/bodypart/r_arm/set_disabled(new_disabled = TRUE)
 	..()
@@ -563,6 +585,8 @@
 	body_damage_coeff = 0.75
 	px_x = -2
 	px_y = 12
+	stam_heal_tick = 2
+	max_stamina_damage = 50
 
 /obj/item/bodypart/l_leg/set_disabled(new_disabled = TRUE)
 	..()
@@ -608,6 +632,8 @@
 	body_damage_coeff = 0.75
 	px_x = 2
 	px_y = 12
+	max_stamina_damage = 50
+	stam_heal_tick = 2
 
 /obj/item/bodypart/r_leg/set_disabled(new_disabled = TRUE)
 	..()

--- a/code/modules/surgery/bodyparts/bodyparts.dm
+++ b/code/modules/surgery/bodyparts/bodyparts.dm
@@ -66,9 +66,9 @@
 
 /obj/item/bodypart/examine(mob/user)
 	..()
-	if(brute_dam > 0)
+	if(brute_dam > DAMAGE_PRECISION)
 		to_chat(user, "<span class='warning'>This limb has [brute_dam > 30 ? "severe" : "minor"] bruising.</span>")
-	if(burn_dam > 0)
+	if(burn_dam > DAMAGE_PRECISION)
 		to_chat(user, "<span class='warning'>This limb has [burn_dam > 30 ? "severe" : "minor"] burns.</span>")
 
 /obj/item/bodypart/blob_act()
@@ -135,7 +135,7 @@
 
 //Return TRUE to get whatever mob this is in to update health.
 /obj/item/bodypart/proc/on_life()
-	if(stamina_dam)					//DO NOT update health here, it'll be done in the carbon's life.
+	if(stamina_dam > DAMAGE_PRECISION)					//DO NOT update health here, it'll be done in the carbon's life.
 		if(heal_damage(brute = 0, burn = 0, stamina = stam_heal_tick, only_robotic = FALSE, only_organic = FALSE, updating_health = FALSE))
 			. |= BODYPART_LIFE_UPDATE_HEALTH
 
@@ -177,11 +177,11 @@
 	//We've dealt the physical damages, if there's room lets apply the stamina damage.
 	var/current_damage = get_damage(TRUE)		//This time around, count stamina loss too.
 	var/available_damage = max_damage - current_damage
-	stamina_dam += CLAMP(stamina, 0, min(max_stamina_damage - stamina_dam, available_damage))
+	stamina_dam += round(CLAMP(stamina, 0, min(max_stamina_damage - stamina_dam, available_damage)), DAMAGE_PRECISION)
 
 	if(owner && updating_health)
 		owner.updatehealth()
-		if(stamina)
+		if(stamina > DAMAGE_PRECISION)
 			owner.update_stamina()
 	consider_processing()
 	check_disabled()

--- a/code/modules/surgery/bodyparts/bodyparts.dm
+++ b/code/modules/surgery/bodyparts/bodyparts.dm
@@ -126,7 +126,7 @@
 		I.forceMove(T)
 
 /obj/item/bodypart/proc/consider_processing()
-	if(stamina_dam)
+	if(stamina_dam > DAMAGE_PRECISION)
 		. = TRUE
 	//else if.. else if.. so on.
 	else

--- a/code/modules/surgery/bodyparts/head.dm
+++ b/code/modules/surgery/bodyparts/head.dm
@@ -11,6 +11,8 @@
 	throw_range = 2 //No head bowling
 	px_x = 0
 	px_y = -8
+	stam_damage_coeff = 1
+	max_stamina_damage = 100
 
 	var/mob/living/brain/brainmob = null //The current occupant.
 	var/obj/item/organ/brain/brain = null //The brain organ


### PR DESCRIPTION
THING TO TAKE NOTE OF: The maximum of 100 stamina cap was REMOVED somehow, and I'm assuming it's my fuckup. 
So, instead of fixing the above, I went and reworked how stam dam is healed on carbons entirely.
Instead of the entire mob healing 3 per tick, and just slapping the hardcap back on, chest/head heals 3 per tick, and other limbs 2 per tick, and chest/head now has 100 stamina hardcap.

To stun someone, you MUST do a combined 100 stamina damage to their chest or head.

Why: I believe this will lead to interesting gameplay than putting on the hardcap again when we already have limb specific stamina damage. Now, to keep all of someone's limbs stamcritted, you'll have to put in more stamina damage to the person for each limb disabled. With this in place, if you just stun someone by taking out their chest via stam damage, they'll still heal 3 per tick like before, but if you take the out by downing chest + head, now their total regen is 6 per tick. 

Values up to negotation.

:cl:
experimental: Stamina damage has been reworked. Instead of healing 3 stamina per tick for the entire mob for carbon mobs, head/chest heals 3 stamina per tick, other limbs 2.
experimental: To fully stun someone, you must do a combined 100 stamina damage to their chest and head. Individually limbs can be disabled, but it will not fully stun the person like before.
experimental: Stuns from stamina damage are now more consistent. After being stamcritted, you'll always be stunned for a 7 seconds afterwards, down from the previous, where it stunned you for 10 but only if you weren't stunned already.
/:cl: