### PR TITLE
Fix PROCESS_KILL for SSobj and generally

### DIFF
--- a/code/controllers/subsystem/processing/obj.dm
+++ b/code/controllers/subsystem/processing/obj.dm
@@ -1,29 +1,5 @@
-SUBSYSTEM_DEF(obj)
+PROCESSING_SUBSYSTEM_DEF(obj)
 	name = "Objects"
 	priority = FIRE_PRIORITY_OBJ
 	flags = SS_NO_INIT
-
-	var/list/processing = list()
-	var/list/currentrun = list()
-
-/datum/controller/subsystem/obj/stat_entry()
-	..("P:[processing.len]")
-
-/datum/controller/subsystem/obj/fire(resumed = 0)
-	if (!resumed)
-		src.currentrun = processing.Copy()
-	//cache for sanic speed (lists are references anyways)
-	var/list/currentrun = src.currentrun
-
-	while(currentrun.len)
-		var/datum/thing = currentrun[currentrun.len]
-		currentrun.len--
-		if(thing)
-			thing.process(wait)
-		else
-			SSobj.processing -= thing
-		if (MC_TICK_CHECK)
-			return
-
-/datum/controller/subsystem/obj/Recover()
-	processing = SSobj.processing
+	wait = 20

--- a/code/controllers/subsystem/processing/processing.dm
+++ b/code/controllers/subsystem/processing/processing.dm
@@ -22,12 +22,14 @@ SUBSYSTEM_DEF(processing)
 	while(current_run.len)
 		var/datum/thing = current_run[current_run.len]
 		current_run.len--
-		if(QDELETED(thing) || thing.process(wait) == PROCESS_KILL)
+		if(QDELETED(thing))
 			processing -= thing
+		if(thing.process(wait) == PROCESS_KILL)
+			// fully stop so that a future START_PROCESSING will work
+			STOP_PROCESSING(src, thing)
 		if (MC_TICK_CHECK)
 			return
 
 /datum/proc/process()
 	set waitfor = 0
-	STOP_PROCESSING(SSobj, src)
-	return 0
+	return PROCESS_KILL

--- a/code/controllers/subsystem/processing/processing.dm
+++ b/code/controllers/subsystem/processing/processing.dm
@@ -24,7 +24,7 @@ SUBSYSTEM_DEF(processing)
 		current_run.len--
 		if(QDELETED(thing))
 			processing -= thing
-		if(thing.process(wait) == PROCESS_KILL)
+		else if(thing.process(wait) == PROCESS_KILL)
 			// fully stop so that a future START_PROCESSING will work
 			STOP_PROCESSING(src, thing)
 		if (MC_TICK_CHECK)


### PR DESCRIPTION
* Makes SSobj a processing subsystem so that it will obey `PROCESS_KILL`.
* Changes default `process()` to return `PROCESS_KILL` rather than unsubscribing from `SSobj`.
* Unset `DF_ISPROCESSING` if `PROCESS_KILL` is returned, so that the object may process again.

Fixes #39320.