### PR TITLE
Fix object UIs closing when they should remain visible

### DIFF
--- a/code/_onclick/other_mobs.dm
+++ b/code/_onclick/other_mobs.dm
@@ -56,6 +56,11 @@
 		return FALSE
 	return TRUE
 
+/atom/ui_status(mob/user)
+	. = ..()
+	if(!can_interact(user))
+		. = min(., UI_UPDATE)
+
 /atom/movable/can_interact(mob/user)
 	. = ..()
 	if(!.)

--- a/code/game/machinery/_machinery.dm
+++ b/code/game/machinery/_machinery.dm
@@ -239,11 +239,6 @@ Class Procs:
 		user.set_machine(src)
 	. = ..()
 
-/obj/machinery/ui_status(mob/user)
-	if(can_interact(user))
-		return ..()
-	return UI_CLOSE
-
 /obj/machinery/ui_act(action, params)
 	add_fingerprint(usr)
 	return ..()


### PR DESCRIPTION
:cl:
fix: Machinery UIs no longer close immediately upon going out of interaction range.
/:cl:

Bug introduced in #38939. See previous discussion in #39271.

The intended behavior is that UIs are interactive at 1 tile, update at 2 tiles, and can stay open without updating up to 5 tiles away.