### PR TITLE
Fixes the cig reagent bug, removes pointless and buggy RNG

### DIFF
--- a/code/game/objects/items/cigs_lighters.dm
+++ b/code/game/objects/items/cigs_lighters.dm
@@ -205,9 +205,8 @@ CIGARETTE PACKETS ARE IN FANCY.DM
 		if(iscarbon(loc))
 			var/mob/living/carbon/C = loc
 			if (src == C.wear_mask) // if it's in the human/monkey mouth, transfer reagents to the mob
-				if(prob(15)) // so it's not an instarape in case of acid
-					var/fraction = min(REAGENTS_METABOLISM/reagents.total_volume, 1)
-					reagents.reaction(C, INGEST, fraction)
+				var/fraction = min(REAGENTS_METABOLISM/reagents.total_volume, 1)
+				reagents.reaction(C, INGEST, fraction)
 				if(!reagents.trans_to(C, REAGENTS_METABOLISM))
 					reagents.remove_any(REAGENTS_METABOLISM)
 				return

--- a/code/modules/reagents/chemistry/holder.dm
+++ b/code/modules/reagents/chemistry/holder.dm
@@ -551,8 +551,6 @@
 		WARNING("[my_atom] attempted to add a reagent called '[reagent]' which doesn't exist. ([usr])")
 		return FALSE
 	
-	if(isliving(my_atom))
-		R.on_mob_add(my_atom) //Must occur befor it could posibly run on_mob_delete 
  	update_total()
 	var/cached_total = total_volume
 	if(cached_total + amount > maximum_volume)
@@ -596,7 +594,9 @@
 	if(data)
 		R.data = data
 		R.on_new(data)
-
+	
+	if(isliving(my_atom))
+		R.on_mob_add(my_atom) //Must occur befor it could posibly run on_mob_delete 
 	update_total()
 	if(my_atom)
 		my_atom.on_reagent_change(ADD_REAGENT)

--- a/code/modules/reagents/chemistry/holder.dm
+++ b/code/modules/reagents/chemistry/holder.dm
@@ -550,7 +550,9 @@
 	if(!D)
 		WARNING("[my_atom] attempted to add a reagent called '[reagent]' which doesn't exist. ([usr])")
 		return FALSE
-
+	
+	if(isliving(my_atom))
+		R.on_mob_add(my_atom) //Must occur befor it could posibly run on_mob_delete 
  	update_total()
 	var/cached_total = total_volume
 	if(cached_total + amount > maximum_volume)
@@ -600,8 +602,6 @@
 		my_atom.on_reagent_change(ADD_REAGENT)
 	if(!no_react)
 		handle_reactions()
-	if(isliving(my_atom))
-		R.on_mob_add(my_atom)
 	return TRUE
 
 /datum/reagents/proc/add_reagent_list(list/list_reagents, list/data=null) // Like add_reagent but you can enter a list. Format it like this: list("toxin" = 10, "beer" = 15)


### PR DESCRIPTION
:cl:
fix: Cigarettes now always transfer a valid amount of reagents.
fix:  Reagent order of operations is no longer completely insane
/:cl:
Fixes:#36152

The balance in the note is no longer a concern, a 50/50 sacid and facid dipped cig took almost a minute to knockout and damage stopped when it was removed. It allowed a severe bug in the chem system.

I'm not closing that issue report because in theory the underlying bug is still present and any future ways to apply chems may still have it.
