### PR TITLE
Increase gas_mixture/react() performance by around 10%

### DIFF
--- a/code/modules/atmospherics/gasmixtures/gas_mixture.dm
+++ b/code/modules/atmospherics/gasmixtures/gas_mixture.dm
@@ -427,14 +427,14 @@ GLOBAL_LIST_INIT(gaslist_cache, init_gaslist_cache())
 		for(var/r in SSair.gas_reactions)
 			var/datum/gas_reaction/reaction = r
 
-			var/list/min_reqs = reaction.min_requirements.Copy()
+			var/list/min_reqs = reaction.min_requirements
 			if((min_reqs["TEMP"] && temp < min_reqs["TEMP"]) \
 			|| (min_reqs["ENER"] && ener < min_reqs["ENER"]))
 				continue
-			min_reqs -= "TEMP"
-			min_reqs -= "ENER"
 
 			for(var/id in min_reqs)
+				if (id == "TEMP" || id == "ENER")
+					continue
 				if(!cached_gases[id] || cached_gases[id][MOLES] < min_reqs[id])
 					continue reaction_loop
 			//at this point, all minimum requirements for the reaction are satisfied.


### PR DESCRIPTION
This is cherrypicked from a WIP branch since that needs more work and might not materialize


:cl: Naksu
code: gas reactions no longer copy a list needlessly
/:cl:


![image](https://user-images.githubusercontent.com/20017308/43165549-d3691dbc-8f9c-11e8-95b3-4376ea8a6a56.png)
