### PR TITLE
Light Step quirk stops you from leaving footprints

### DIFF
--- a/code/datums/traits/good.dm
+++ b/code/datums/traits/good.dm
@@ -61,7 +61,7 @@
 
 /datum/quirk/light_step
 	name = "Light Step"
-	desc = "You walk with a gentle step, making stepping on sharp objects quieter and less painful."
+	desc = "You walk with a gentle step; stepping on sharp objects is quieter, less painful and you won't leave footprints behind you."
 	value = 1
 	mob_trait = TRAIT_LIGHT_STEP
 	gain_text = "<span class='notice'>You walk with a little more litheness.</span>"

--- a/code/game/objects/effects/decals/cleanable.dm
+++ b/code/game/objects/effects/decals/cleanable.dm
@@ -72,7 +72,7 @@
 	..()
 	if(ishuman(O))
 		var/mob/living/carbon/human/H = O
-		if(H.shoes && blood_state && bloodiness)
+		if(H.shoes && blood_state && bloodiness && !H.has_trait(TRAIT_LIGHT_STEP))
 			var/obj/item/clothing/shoes/S = H.shoes
 			var/add_blood = 0
 			if(bloodiness >= BLOOD_GAIN_PER_STEP)


### PR DESCRIPTION
:cl: Mickyan
balance: Light Step quirk now stops you from leaving footprints
/:cl:

Light Step always seemed rather pointless in practice, this would make it a little bit more desirable for those that intend on sneaking about while still being a fairly minor advantage. 
Also a bit of extra utility for clumsy janitors!

(and remember if for some reason you really want to avoid leaving footprints, even without the quirk you can simply take off your shoes)