### PR TITLE
Ends lavaland syndicate booze prohibition

### DIFF
--- a/_maps/RandomRuins/LavaRuins/lavaland_surface_syndicate_base1.dmm
+++ b/_maps/RandomRuins/LavaRuins/lavaland_surface_syndicate_base1.dmm
@@ -4055,7 +4055,7 @@
 /area/ruin/unpowered/syndicate_lava_base/bar)
 "lD" = (
 /obj/machinery/vending/boozeomat{
-	req_access_txt = "0"
+	req_access_txt = "150"
 	},
 /turf/closed/wall/mineral/plastitanium/nodiagonal,
 /area/ruin/unpowered/syndicate_lava_base/bar)


### PR DESCRIPTION
Fixes #39329

:cl: 
fix: Syndicate personnel operating in Lavaland rejoice as prohibition is repealed
/:cl:

[why]: Because I want to drown my sorrows without taking the extra step of hacking a boozemat to do so
