### PR TITLE
Fixes alarms not being cleared on camera destruction

### DIFF
--- a/code/game/machinery/camera/camera.dm
+++ b/code/game/machinery/camera/camera.dm
@@ -83,6 +83,7 @@
 		if(bug.current == src)
 			bug.current = null
 		bug = null
+	cancelCameraAlarm()
 	return ..()
 
 /obj/machinery/camera/emp_act(severity)

--- a/code/game/machinery/camera/motion.dm
+++ b/code/game/machinery/camera/motion.dm
@@ -42,6 +42,7 @@
 	localMotionTargets = null
 	if(istype(A))
 		A.motioncameras -= src
+	cancelAlarm()
 	return ..()
 
 /obj/machinery/camera/proc/lostTargetRef(datum/weakref/R)


### PR DESCRIPTION
:cl: ShizCalev
fix: Destroying a camera will now clear it's alarm.
/:cl:

Fixes #39354
