### PR TITLE
Emitter gun mounts

### DIFF
--- a/code/datums/wires/emitter.dm
+++ b/code/datums/wires/emitter.dm
@@ -1,13 +1,17 @@
 
 /datum/wires/emitter
-	randomize = 1	//Only one wire don't need blueprints
 	holder_type = /obj/machinery/power/emitter
 
 /datum/wires/emitter/New(atom/holder)
-	wires = list(WIRE_ZAP)
+	wires = list(WIRE_ZAP,WIRE_HACK)
 	..()
 
 /datum/wires/emitter/on_pulse(wire)
 	var/obj/machinery/power/emitter/E = holder
-	E.fire_beam_pulse()
+	switch(wire)
+		if(WIRE_ZAP)
+			E.fire_beam_pulse()
+		if(WIRE_HACK)
+			E.mode = !E.mode
+			E.set_projectile()
 	..()

--- a/code/modules/power/singularity/emitter.dm
+++ b/code/modules/power/singularity/emitter.dm
@@ -307,10 +307,10 @@
 
 /obj/machinery/power/emitter/proc/integrate(obj/item/gun/energy/E,mob/user)
 	if(istype(E, /obj/item/gun/energy))
-		gun = E
 		if(!user.transferItemToLoc(E, src))
 			return
-		gun_properties = E.get_turret_properties()
+		gun = E
+		gun_properties = gun.get_turret_properties()
 		set_projectile()
 		return TRUE
 

--- a/code/modules/power/singularity/emitter.dm
+++ b/code/modules/power/singularity/emitter.dm
@@ -31,15 +31,15 @@
 	var/allow_switch_interact = TRUE
 
 	var/projectile_type = /obj/item/projectile/beam/emitter
-
 	var/projectile_sound = 'sound/weapons/emitter.ogg'
-
 	var/datum/effect_system/spark_spread/sparks
+	var/obj/item/gun/energy/gun
 
 	// The following 3 vars are mostly for the prototype
 	var/manual = FALSE
 	var/charge = 0
 	var/last_projectile_params
+
 
 /obj/machinery/power/emitter/anchored
 	anchored = TRUE
@@ -269,6 +269,8 @@
 	return TRUE
 
 /obj/machinery/power/emitter/crowbar_act(mob/living/user, obj/item/I)
+	if(panel_open && gun)
+		return remove_gun(user)
 	default_deconstruction_crowbar(I)
 	return TRUE
 
@@ -295,8 +297,34 @@
 	else if(is_wire_tool(I) && panel_open)
 		wires.interact(user)
 		return
-
+	else if(panel_open && !gun && istype(I,/obj/item/gun/energy))
+		if(integrate(I,user))
+			return
 	return ..()
+
+/obj/machinery/power/emitter/proc/integrate(obj/item/gun/energy/E,mob/user)
+	if(istype(E, /obj/item/gun/energy))
+		gun = E
+		if(!gun.chambered)
+			return
+		if(!user.transferItemToLoc(E, src))
+			return
+		if(!gun.chambered || !gun.chambered.BB)
+			return
+		var/obj/item/ammo_casing/energy/AM = gun.chambered
+		projectile_type = AM.BB.type
+		projectile_sound = AM.fire_sound
+		return TRUE
+
+/obj/machinery/power/emitter/proc/remove_gun(mob/user)
+	if(!gun)
+		return
+	user.put_in_hands(gun)
+	gun = null
+	playsound(src, 'sound/items/deconstruct.ogg', 50, 1)
+	projectile_type = initial(projectile_type)
+	projectile_sound = initial(projectile_sound)
+	return TRUE
 
 /obj/machinery/power/emitter/emag_act(mob/user)
 	if(obj_flags & EMAGGED)

--- a/code/modules/power/singularity/emitter.dm
+++ b/code/modules/power/singularity/emitter.dm
@@ -33,7 +33,10 @@
 	var/projectile_type = /obj/item/projectile/beam/emitter
 	var/projectile_sound = 'sound/weapons/emitter.ogg'
 	var/datum/effect_system/spark_spread/sparks
+
 	var/obj/item/gun/energy/gun
+	var/list/gun_properties
+	var/mode = 0
 
 	// The following 3 vars are mostly for the prototype
 	var/manual = FALSE
@@ -305,15 +308,10 @@
 /obj/machinery/power/emitter/proc/integrate(obj/item/gun/energy/E,mob/user)
 	if(istype(E, /obj/item/gun/energy))
 		gun = E
-		if(!gun.chambered)
-			return
 		if(!user.transferItemToLoc(E, src))
 			return
-		if(!gun.chambered || !gun.chambered.BB)
-			return
-		var/obj/item/ammo_casing/energy/AM = gun.chambered
-		projectile_type = AM.BB.type
-		projectile_sound = AM.fire_sound
+		gun_properties = E.get_turret_properties()
+		set_projectile()
 		return TRUE
 
 /obj/machinery/power/emitter/proc/remove_gun(mob/user)
@@ -322,9 +320,21 @@
 	user.put_in_hands(gun)
 	gun = null
 	playsound(src, 'sound/items/deconstruct.ogg', 50, 1)
+	gun_properties = list()
+	set_projectile()
+	return TRUE
+
+/obj/machinery/power/emitter/proc/set_projectile()
+	if(LAZYLEN(gun_properties))
+		if(mode || !gun_properties["lethal_projectile"])
+			projectile_type = gun_properties["stun_projectile"]
+			projectile_sound = gun_properties["stun_projectile_sound"]
+		else
+			projectile_type = gun_properties["lethal_projectile"]
+			projectile_sound = gun_properties["lethal_projectile_sound"]
+		return
 	projectile_type = initial(projectile_type)
 	projectile_sound = initial(projectile_sound)
-	return TRUE
 
 /obj/machinery/power/emitter/emag_act(mob/user)
 	if(obj_flags & EMAGGED)

--- a/code/modules/projectiles/projectile/special/wormhole.dm
+++ b/code/modules/projectiles/projectile/special/wormhole.dm
@@ -20,7 +20,8 @@
 	if(casing)
 		gun = casing.gun
 
+
 /obj/item/projectile/beam/wormhole/on_hit(atom/target)
 	if(!gun)
-		qdel(src)
+		return qdel(src)
 	gun.create_portal(src, get_turf(src))

--- a/code/modules/projectiles/projectile/special/wormhole.dm
+++ b/code/modules/projectiles/projectile/special/wormhole.dm
@@ -23,5 +23,6 @@
 
 /obj/item/projectile/beam/wormhole/on_hit(atom/target)
 	if(!gun)
-		return qdel(src)
+		qdel(src)
+		return 
 	gun.create_portal(src, get_turf(src))


### PR DESCRIPTION
Simple PR, allows you to mount energy guns into emitters. You can now insert anything from a taser to an x-ray gun, and have the emitter shoot that round.

:cl: Time-Green
add: You can now mount energy guns into emitters
fix: portal guns no longer runtime when fired by turrets
/:cl:

Turrets already do exactly this, and why not let people do it with emitters
