### PR TITLE
Rebalances AI console/module costs

### DIFF
--- a/code/modules/research/designs/AI_module_designs.dm
+++ b/code/modules/research/designs/AI_module_designs.dm
@@ -14,7 +14,7 @@
 	name = "Module Design (Safeguard)"
 	desc = "Allows for the construction of a Safeguard AI Module."
 	id = "safeguard_module"
-	materials = list(MAT_GLASS = 1000, MAT_GOLD = 100)
+	materials = list(MAT_GLASS = 1000, MAT_GOLD = 2000)
 	build_path = /obj/item/aiModule/supplied/safeguard
 	category = list("AI Modules")
 	departmental_flags = DEPARTMENTAL_FLAG_SCIENCE
@@ -23,7 +23,7 @@
 	name = "Module Design (OneHuman)"
 	desc = "Allows for the construction of a OneHuman AI Module."
 	id = "onehuman_module"
-	materials = list(MAT_GLASS = 1000, MAT_DIAMOND = 100)
+	materials = list(MAT_GLASS = 1000, MAT_DIAMOND = 6000)
 	build_path = /obj/item/aiModule/zeroth/oneHuman
 	category = list("AI Modules")
 	departmental_flags = DEPARTMENTAL_FLAG_SCIENCE
@@ -32,7 +32,7 @@
 	name = "Module Design (ProtectStation)"
 	desc = "Allows for the construction of a ProtectStation AI Module."
 	id = "protectstation_module"
-	materials = list(MAT_GLASS = 1000, MAT_GOLD = 100)
+	materials = list(MAT_GLASS = 1000, MAT_GOLD = 2000)
 	build_path = /obj/item/aiModule/supplied/protectStation
 	category = list("AI Modules")
 	departmental_flags = DEPARTMENTAL_FLAG_SCIENCE
@@ -41,7 +41,7 @@
 	name = "Module Design (Quarantine)"
 	desc = "Allows for the construction of a Quarantine AI Module."
 	id = "quarantine_module"
-	materials = list(MAT_GLASS = 1000, MAT_GOLD = 100)
+	materials = list(MAT_GLASS = 1000, MAT_GOLD = 2000)
 	build_path = /obj/item/aiModule/supplied/quarantine
 	category = list("AI Modules")
 	departmental_flags = DEPARTMENTAL_FLAG_SCIENCE
@@ -50,7 +50,7 @@
 	name = "Module Design (OxygenIsToxicToHumans)"
 	desc = "Allows for the construction of a Safeguard AI Module."
 	id = "oxygen_module"
-	materials = list(MAT_GLASS = 1000, MAT_GOLD = 100)
+	materials = list(MAT_GLASS = 1000, MAT_GOLD = 2000)
 	build_path = /obj/item/aiModule/supplied/oxygen
 	category = list("AI Modules")
 	departmental_flags = DEPARTMENTAL_FLAG_SCIENCE
@@ -59,7 +59,7 @@
 	name = "Module Design (Freeform)"
 	desc = "Allows for the construction of a Freeform AI Module."
 	id = "freeform_module"
-	materials = list(MAT_GLASS = 1000, MAT_GOLD = 100)
+	materials = list(MAT_GLASS = 1000, MAT_GOLD = 10000)//Custom inputs should be more expensive to get
 	build_path = /obj/item/aiModule/supplied/freeform
 	category = list("AI Modules")
 	departmental_flags = DEPARTMENTAL_FLAG_SCIENCE
@@ -68,7 +68,7 @@
 	name = "Module Design (Reset)"
 	desc = "Allows for the construction of a Reset AI Module."
 	id = "reset_module"
-	materials = list(MAT_GLASS = 1000, MAT_GOLD = 100)
+	materials = list(MAT_GLASS = 1000, MAT_GOLD = 2000)
 	build_path = /obj/item/aiModule/reset
 	category = list("AI Modules")
 	departmental_flags = DEPARTMENTAL_FLAG_SCIENCE
@@ -77,7 +77,7 @@
 	name = "Module Design (Purge)"
 	desc = "Allows for the construction of a Purge AI Module."
 	id = "purge_module"
-	materials = list(MAT_GLASS = 1000, MAT_DIAMOND = 100)
+	materials = list(MAT_GLASS = 1000, MAT_DIAMOND = 2000)
 	build_path = /obj/item/aiModule/reset/purge
 	category = list("AI Modules")
 	departmental_flags = DEPARTMENTAL_FLAG_SCIENCE
@@ -86,7 +86,7 @@
 	name = "Module Design (Law Removal)"
 	desc = "Allows for the construction of a Law Removal AI Core Module."
 	id = "remove_module"
-	materials = list(MAT_GLASS = 1000, MAT_DIAMOND = 100)
+	materials = list(MAT_GLASS = 1000, MAT_DIAMOND = 2000)
 	build_path = /obj/item/aiModule/remove
 	category = list("AI Modules")
 	departmental_flags = DEPARTMENTAL_FLAG_SCIENCE
@@ -95,7 +95,7 @@
 	name = "AI Core Module (Freeform)"
 	desc = "Allows for the construction of a Freeform AI Core Module."
 	id = "freeformcore_module"
-	materials = list(MAT_GLASS = 1000, MAT_DIAMOND = 100)
+	materials = list(MAT_GLASS = 1000, MAT_DIAMOND = 10000)//Ditto
 	build_path = /obj/item/aiModule/core/freeformcore
 	category = list("AI Modules")
 	departmental_flags = DEPARTMENTAL_FLAG_SCIENCE
@@ -104,7 +104,7 @@
 	name = "Core Module Design (Asimov)"
 	desc = "Allows for the construction of an Asimov AI Core Module."
 	id = "asimov_module"
-	materials = list(MAT_GLASS = 1000, MAT_DIAMOND = 100)
+	materials = list(MAT_GLASS = 1000, MAT_DIAMOND = 2000)
 	build_path = /obj/item/aiModule/core/full/asimov
 	category = list("AI Modules")
 	departmental_flags = DEPARTMENTAL_FLAG_SCIENCE
@@ -114,7 +114,7 @@
 	desc = "Allows for the construction of a P.A.L.A.D.I.N. AI Core Module."
 	id = "paladin_module"
 	build_type = IMPRINTER
-	materials = list(MAT_GLASS = 1000, MAT_DIAMOND = 100)
+	materials = list(MAT_GLASS = 1000, MAT_DIAMOND = 2000)
 	build_path = /obj/item/aiModule/core/full/paladin
 	category = list("AI Modules")
 	departmental_flags = DEPARTMENTAL_FLAG_SCIENCE
@@ -123,7 +123,7 @@
 	name = "Core Module Design (T.Y.R.A.N.T.)"
 	desc = "Allows for the construction of a T.Y.R.A.N.T. AI Module."
 	id = "tyrant_module"
-	materials = list(MAT_GLASS = 1000, MAT_DIAMOND = 100)
+	materials = list(MAT_GLASS = 1000, MAT_DIAMOND = 2000)
 	build_path = /obj/item/aiModule/core/full/tyrant
 	category = list("AI Modules")
 	departmental_flags = DEPARTMENTAL_FLAG_SCIENCE
@@ -132,7 +132,7 @@
 	name = "Core Module Design (Corporate)"
 	desc = "Allows for the construction of a Corporate AI Core Module."
 	id = "corporate_module"
-	materials = list(MAT_GLASS = 1000, MAT_DIAMOND = 100)
+	materials = list(MAT_GLASS = 1000, MAT_DIAMOND = 2000)
 	build_path = /obj/item/aiModule/core/full/corp
 	category = list("AI Modules")
 	departmental_flags = DEPARTMENTAL_FLAG_SCIENCE
@@ -141,7 +141,7 @@
 	name = "Core Module Design (Default)"
 	desc = "Allows for the construction of a Default AI Core Module."
 	id = "default_module"
-	materials = list(MAT_GLASS = 1000, MAT_DIAMOND = 100)
+	materials = list(MAT_GLASS = 1000, MAT_DIAMOND = 2000)
 	build_path = /obj/item/aiModule/core/full/custom
 	category = list("AI Modules")
 	departmental_flags = DEPARTMENTAL_FLAG_SCIENCE

--- a/code/modules/research/designs/comp_board_designs.dm
+++ b/code/modules/research/designs/comp_board_designs.dm
@@ -50,6 +50,7 @@
 	name = "Computer Design (AI Upload)"
 	desc = "Allows for the construction of circuit boards used to build an AI Upload Console."
 	id = "aiupload"
+	materials = list(MAT_GLASS = 1000, MAT_GOLD = 2000)
 	build_path = /obj/item/circuitboard/computer/aiupload
 	category = list("Computer Boards")
 	departmental_flags = DEPARTMENTAL_FLAG_SCIENCE
@@ -58,6 +59,7 @@
 	name = "Computer Design (Cyborg Upload)"
 	desc = "Allows for the construction of circuit boards used to build a Cyborg Upload Console."
 	id = "borgupload"
+	materials = list(MAT_GLASS = 1000, MAT_GOLD = 2000)
 	build_path = /obj/item/circuitboard/computer/borgupload
 	category = list("Computer Boards")
 	departmental_flags = DEPARTMENTAL_FLAG_SCIENCE

--- a/code/modules/research/designs/machine_designs.dm
+++ b/code/modules/research/designs/machine_designs.dm
@@ -398,7 +398,7 @@
 	name = "Machine Design (Weapon Recharger Board)"
 	desc = "The circuit board for a Weapon Recharger."
 	id = "recharger"
-	materials = list(MAT_GLASS = 1000, MAT_GOLD = 100)
+	materials = list(MAT_GLASS = 1000, MAT_GOLD = 2000)
 	build_path = /obj/item/circuitboard/machine/recharger
 	category = list("Misc. Machinery")
 	departmental_flags = DEPARTMENTAL_FLAG_ALL


### PR DESCRIPTION
[Changelogs]: AI/Cyborg Uploads now require a bar of gold to construct. AI Modules now require significantly more material in their construction, especially the freeform and OneHuman boards. Weapon recharger boards have their cost raised to keep parity with the new price icnrease.

:cl: 
balance: Upload boards and AI modules, in addition to Weapon Recharger boards, are now more expensive to manufacture
/:cl:

[why]: To be perfectly frank this has been something that's needed addressing for a while now, it's become too easy to subvert the AI with printed boards to the point that you have zero reason to ever try and break into the Upload or even steal the boards from the secure tech storage. 
In addition, why would you ever buy the Hacked Law module when you can just wait 20 minutes until mining comes back with even one diamond. This doesn't totally eliminate the triviality but it's not *as* trivial. 
