### PR TITLE
Readds the second syndicate fighter to the caravan space ruin.

### DIFF
--- a/_maps/RandomRuins/SpaceRuins/caravanambush.dmm
+++ b/_maps/RandomRuins/SpaceRuins/caravanambush.dmm
@@ -1277,6 +1277,18 @@
 	},
 /turf/open/floor/plating/airless,
 /area/shuttle/caravan/freighter3)
+"xU" = (
+/obj/docking_port/stationary{
+	dir = 1;
+	dwidth = 4;
+	height = 5;
+	id = "caravansyndicate1_ambush";
+	name = "Trade Route";
+	roundstart_template = /datum/map_template/shuttle/ruin/syndicate_fighter_shiv;
+	width = 9
+	},
+/turf/template_noop,
+/area/template_noop)
 "GL" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/door/airlock/external{
@@ -5745,7 +5757,7 @@ aa
 aa
 aa
 aa
-aa
+xU
 aa
 aa
 aa

--- a/_maps/shuttles/ruin_syndicate_fighter_shiv.dmm
+++ b/_maps/shuttles/ruin_syndicate_fighter_shiv.dmm
@@ -93,7 +93,6 @@
 	dir = 4;
 	dwidth = 4;
 	height = 5;
-	id = "caravansyndicate1";
 	ignitionTime = 25;
 	name = "Syndicate Fighter";
 	port_direction = 2;


### PR DESCRIPTION
For real this time! This uses shuttle duplication as instructed by ninjanomnom. Currently this system is a little bit experimental, and as a result the duplicated buttons, camera networks, and APCs are on the same networks and will influence the other pilotable ship, something to be fixed in the future.

Can be seen here: https://i.imgur.com/L8VyF8M.png

:cl: WJohnston
add: Readded the second pilotable syndicate fighter in the caravan space ruin.
/:cl:

----

Fixes #38273