### PR TITLE
[Not ready] storage circuits selfreference fix

### DIFF
--- a/code/modules/integrated_electronics/subtypes/reagents.dm
+++ b/code/modules/integrated_electronics/subtypes/reagents.dm
@@ -16,63 +16,6 @@
 	set_pin_data(IC_OUTPUT, 1, reagents.total_volume)
 	push_data()
 
-/obj/item/integrated_circuit/reagent/smoke
-	name = "smoke generator"
-	desc = "Unlike most electronics, creating smoke is completely intentional."
-	icon_state = "smoke"
-	extended_desc = "This smoke generator creates clouds of smoke on command. It can also hold liquids inside, which will go \
-	into the smoke clouds when activated. The reagents are consumed when the smoke is made."
-	ext_cooldown = 1
-	container_type = OPENCONTAINER
-	volume = 100
-
-	complexity = 20
-	cooldown_per_use = 1 SECONDS
-	inputs = list()
-	outputs = list(
-		"volume used" = IC_PINTYPE_NUMBER,
-		"self reference" = IC_PINTYPE_REF
-		)
-	activators = list(
-		"create smoke" = IC_PINTYPE_PULSE_IN,
-		"on smoked" = IC_PINTYPE_PULSE_OUT,
-		"push ref" = IC_PINTYPE_PULSE_IN
-		)
-	spawn_flags = IC_SPAWN_RESEARCH
-	power_draw_per_use = 20
-	var/smoke_radius = 5
-	var/notified = FALSE
-
-/obj/item/integrated_circuit/reagent/smoke/Initialize()
-	.=..()
-	set_pin_data(IC_OUTPUT, 2, src)
-
-/obj/item/integrated_circuit/reagent/smoke/on_reagent_change(changetype)
-	//reset warning only if we have reagents now
-	if(changetype == ADD_REAGENT)
-		notified = FALSE
-	push_vol()
-
-/obj/item/integrated_circuit/reagent/smoke/do_work(ord)
-	switch(ord)
-		if(1)
-			if(!reagents || (reagents.total_volume < IC_SMOKE_REAGENTS_MINIMUM_UNITS))
-				return
-			var/location = get_turf(src)
-			var/datum/effect_system/smoke_spread/chem/S = new
-			S.attach(location)
-			playsound(location, 'sound/effects/smoke.ogg', 50, 1, -3)
-			if(S)
-				S.set_up(reagents, smoke_radius, location, notified)
-				if(!notified)
-					notified = TRUE
-				S.start()
-			reagents.clear_reagents()
-			activate_pin(2)
-		if(3)
-			set_pin_data(IC_OUTPUT, 2, WEAKREF(src))
-			push_data()
-
 // Hydroponics trays have no reagents holder and handle reagents in their own snowflakey way.
 // This is a dirty hack to make injecting reagents into them work.
 // TODO: refactor that.

--- a/code/modules/integrated_electronics/subtypes/reagents.dm
+++ b/code/modules/integrated_electronics/subtypes/reagents.dm
@@ -334,7 +334,7 @@
 	spawn_flags = IC_SPAWN_DEFAULT|IC_SPAWN_RESEARCH
 
 /obj/item/integrated_circuit/reagent/storage/Initialize()
-		.=..()
+	.=..()
 	set_pin_data(IC_OUTPUT, 2, src)
 
 /obj/item/integrated_circuit/reagent/storage/do_work()

--- a/code/modules/integrated_electronics/subtypes/reagents.dm
+++ b/code/modules/integrated_electronics/subtypes/reagents.dm
@@ -43,8 +43,8 @@
 	var/smoke_radius = 5
 	var/notified = FALSE
 
-/obj/item/integrated_circuit/reagent/smoke/New()
-	..()
+/obj/item/integrated_circuit/reagent/smoke/Initialize()
+	.=..()
 	set_pin_data(IC_OUTPUT, 2, src)
 
 /obj/item/integrated_circuit/reagent/smoke/on_reagent_change(changetype)
@@ -137,8 +137,8 @@
 	var/transfer_amount = 10
 	var/busy = FALSE
 
-/obj/item/integrated_circuit/reagent/injector/New()
-	..()
+/obj/item/integrated_circuit/reagent/injector/Initialize()
+	.=..()
 	set_pin_data(IC_OUTPUT, 2, src)
 
 /obj/item/integrated_circuit/reagent/injector/on_reagent_change(changetype)
@@ -333,8 +333,8 @@
 	activators = list("push ref" = IC_PINTYPE_PULSE_OUT)
 	spawn_flags = IC_SPAWN_DEFAULT|IC_SPAWN_RESEARCH
 
-/obj/item/integrated_circuit/reagent/storage/New()
-	..()
+/obj/item/integrated_circuit/reagent/storage/Initialize()
+		.=..()
 	set_pin_data(IC_OUTPUT, 2, src)
 
 /obj/item/integrated_circuit/reagent/storage/do_work()

--- a/code/modules/integrated_electronics/subtypes/reagents.dm
+++ b/code/modules/integrated_electronics/subtypes/reagents.dm
@@ -43,6 +43,10 @@
 	var/smoke_radius = 5
 	var/notified = FALSE
 
+/obj/item/integrated_circuit/reagent/smoke/New()
+	..()
+	set_pin_data(IC_OUTPUT, 2, src)
+
 /obj/item/integrated_circuit/reagent/smoke/on_reagent_change(changetype)
 	//reset warning only if we have reagents now
 	if(changetype == ADD_REAGENT)
@@ -132,6 +136,10 @@
 	var/direction_mode = SYRINGE_INJECT
 	var/transfer_amount = 10
 	var/busy = FALSE
+
+/obj/item/integrated_circuit/reagent/injector/New()
+	..()
+	set_pin_data(IC_OUTPUT, 2, src)
 
 /obj/item/integrated_circuit/reagent/injector/on_reagent_change(changetype)
 	push_vol()
@@ -325,7 +333,9 @@
 	activators = list("push ref" = IC_PINTYPE_PULSE_OUT)
 	spawn_flags = IC_SPAWN_DEFAULT|IC_SPAWN_RESEARCH
 
-
+/obj/item/integrated_circuit/reagent/storage/New()
+	..()
+	set_pin_data(IC_OUTPUT, 2, src)
 
 /obj/item/integrated_circuit/reagent/storage/do_work()
 	set_pin_data(IC_OUTPUT, 2, WEAKREF(src))
@@ -379,7 +389,6 @@
 	power_draw_per_use = 150
 	complexity = 16
 	spawn_flags = IC_SPAWN_RESEARCH
-
 
 /obj/item/integrated_circuit/reagent/storage/grinder/do_work(ord)
 	switch(ord)


### PR DESCRIPTION
Back then, the self-reference output pin didn't work: it didn't reference the circuit itself from the start and had to be set up to do so. Now, each time a storage circuit is spawned, it automatically references itself, as it was supposed to.

[Changelogs]: # Fixed selfreference in most beaker-like circuits

:cl: Shdorsh
fix: selfreference now is initially set to itself for most circuits, as it was intended to (see: name of the pin)
/:cl:

[why]: # First, because that's what it was supposed to do I believe. Secondly, it makes handling reagent circuitry easier.

Edit: I see this thing isn't as good as it could be so I set it to not ready and will work on raising it to something a little bit more respectable.