### PR TITLE
Removes slippery component from turf/open/water

### DIFF
--- a/code/game/turfs/simulated/water.dm
+++ b/code/game/turfs/simulated/water.dm
@@ -11,6 +11,3 @@
 	bullet_sizzle = TRUE
 	bullet_bounce_sound = null //needs a splashing sound one day.
 
-/turf/open/water/Initialize()
-	. = ..()
-	MakeSlippery(TURF_WET_WATER, INFINITY, 0, INFINITY, TRUE)


### PR DESCRIPTION
:cl: 
del: Removed slippery component from water turf
/:cl:

![image](https://user-images.githubusercontent.com/31262308/43306657-e236b47c-9149-11e8-8abb-7d1cc9d80de0.png)

[why]: # yeah this is a little bit of a problem when trying to make things look good. Obviously, this could use a complete rework to make it like waist high or whatever but I don't have enough time since the charity event is next week. 

The event will be using water a lot so this is a problem.