### PR TITLE
Prevents arrivals shuttles from tossing items/players

### DIFF
--- a/code/modules/shuttle/arrivals.dm
+++ b/code/modules/shuttle/arrivals.dm
@@ -10,6 +10,8 @@
 
 	callTime = INFINITY
 	ignitionTime = 50
+	
+	movement_force = list("KNOCKDOWN" = 0, "THROW" = 0)
 
 	var/sound_played
 	var/damaged	//too damaged to undock?

--- a/code/modules/shuttle/arrivals.dm
+++ b/code/modules/shuttle/arrivals.dm
@@ -11,7 +11,7 @@
 	callTime = INFINITY
 	ignitionTime = 50
 	
-	movement_force = list("KNOCKDOWN" = 0, "THROW" = 0)
+	movement_force = list("KNOCKDOWN" = 3, "THROW" = 0)
 
 	var/sound_played
 	var/damaged	//too damaged to undock?


### PR DESCRIPTION
:cl: Denton
tweak: Arrivals shuttles no longer throw objects/players when docking.
/:cl:

Arrivals shuttles aren't designed around item tossing - on docking, loose items get tossed around which can hit latejoin players before they have a reasonable amount of time to react.

This leads to cases where a player joins a round and less than 3 seconds later gets brought down to half health because someone left a crate full of oxygen tanks open.

Looks like this on Delta:
![reeee](https://user-images.githubusercontent.com/32391752/43326717-d2b8c2b8-91b9-11e8-88f8-b47440234ceb.PNG)

Anywho, this PR disables item tossing/knockdown for arrivals shuttles.
