### PR TITLE
Fixes non-detective fedoras spawning with flasks

### DIFF
--- a/code/modules/clothing/head/jobs.dm
+++ b/code/modules/clothing/head/jobs.dm
@@ -64,7 +64,7 @@
 	pocket_storage_component_path = /datum/component/storage/concrete/pockets/small/detective
 	dog_fashion = /datum/dog_fashion/head/detective
 
-/obj/item/clothing/head/fedora/Initialize()
+/obj/item/clothing/head/fedora/det_hat/Initialize()
 	. = ..()
 	new /obj/item/reagent_containers/food/drinks/flask/det(src)
 


### PR DESCRIPTION
:cl: Denton
fix: Regular fedoras no longer spawn containing flasks.
/:cl:

Closes: #39408