### PR TITLE
Makes social anxiety less miserable

### DIFF
--- a/code/datums/traits/negative.dm
+++ b/code/datums/traits/negative.dm
@@ -12,7 +12,7 @@
 	var/mob/living/carbon/human/H = quirk_holder
 	if(NOBLOOD in H.dna.species.species_traits) //can't lose blood if your species doesn't have any
 		return
-	else 
+	else
 		quirk_holder.blood_volume -= 0.275
 
 
@@ -260,7 +260,7 @@
 
 /datum/quirk/social_anxiety/on_process()
 	var/nearby_people = 0
-	for(var/mob/living/carbon/human/H in view(5, quirk_holder))
+	for(var/mob/living/carbon/human/H in oview(3, quirk_holder))
 		if(H.client)
 			nearby_people++
 	var/mob/living/carbon/human/H = quirk_holder


### PR DESCRIPTION
:cl: Mickyan
balance: Social anxiety trigger range decreased. Stay out of my personal space!
fix: Social anxiety no longer triggers while nobody is around but you
/:cl:

Shorter range should make social anxiety usually trigger when it matters: while you're in the same area and talking with someone, rather than just because someone walked past on the other side of the screen. 
It's still pretty miserable, just a little less so.