### PR TITLE
Adds Pulse Multiplexer Circuits

### DIFF
--- a/code/modules/integrated_electronics/subtypes/data_transfer.dm
+++ b/code/modules/integrated_electronics/subtypes/data_transfer.dm
@@ -166,7 +166,7 @@
 	complexity = number_of_pins
 
 	. = ..()
-	desc += " It has [number_of_pins] input pins and [number_of_pins] output pins."
+	desc += " It has [number_of_pins] pulse in pins and [number_of_pins] output pins."
 	extended_desc += " This pulse multiplexer has a range from 1 to [activators.len - 1]."
 
 /obj/item/integrated_circuit/transfer/pulsemultiplexer/do_work(ord)

--- a/code/modules/integrated_electronics/subtypes/data_transfer.dm
+++ b/code/modules/integrated_electronics/subtypes/data_transfer.dm
@@ -144,7 +144,8 @@
 	icon_state = "dmux16"
 	w_class = WEIGHT_CLASS_SMALL
 	number_of_pins = 16
-	/obj/item/integrated_circuit/transfer/pulsemultiplexer
+
+/obj/item/integrated_circuit/transfer/pulsemultiplexer
 	name = "two pulse multiplexer"
 	desc = "Pulse in pins to choose the pin value to be sent."
 	extended_desc = "The input pulses are used to select which of the input pins has its data moved to the output."

--- a/code/modules/integrated_electronics/subtypes/data_transfer.dm
+++ b/code/modules/integrated_electronics/subtypes/data_transfer.dm
@@ -144,6 +144,54 @@
 	icon_state = "dmux16"
 	w_class = WEIGHT_CLASS_SMALL
 	number_of_pins = 16
+	/obj/item/integrated_circuit/transfer/pulsemultiplexer
+	name = "two pulse multiplexer"
+	desc = "Pulse in pins to choose the pin value to be sent."
+	extended_desc = "The input pulses are used to select which of the input pins has its data moved to the output."
+	complexity = 2
+	icon_state = "dmux2"
+	inputs = list()
+	outputs = list("output" = IC_PINTYPE_ANY)
+	activators = list("on selected" = IC_PINTYPE_PULSE_OUT)
+	spawn_flags = IC_SPAWN_DEFAULT|IC_SPAWN_RESEARCH
+	power_draw_per_use = 4
+	var/number_of_pins = 2
+
+/obj/item/integrated_circuit/transfer/pulsemultiplexer/Initialize()
+	for(var/i = 1 to number_of_pins)
+		inputs["input [i]"] = IC_PINTYPE_ANY
+	for(var/i = 1 to number_of_pins)
+		activators["input [i]"] = IC_PINTYPE_PULSE_IN
+	complexity = number_of_pins
+
+	. = ..()
+	desc += " It has [number_of_pins] input pins and [number_of_pins] output pins."
+	extended_desc += " This pulse multiplexer has a range from 1 to [activators.len - 1]."
+
+/obj/item/integrated_circuit/transfer/pulsemultiplexer/do_work(ord)
+	var/input_index = ord - 2
+
+	if(!isnull(input_index) && (input_index >= 0 && input_index < inputs.len))
+		set_pin_data(IC_OUTPUT, 1,get_pin_data(IC_INPUT, input_index + 1))
+		push_data()
+	activate_pin(1)
+
+/obj/item/integrated_circuit/transfer/pulsemultiplexer/medium
+	name = "four pulse multiplexer"
+	icon_state = "dmux4"
+	number_of_pins = 4
+
+/obj/item/integrated_circuit/transfer/pulsemultiplexer/large
+	name = "eight pulse multiplexer"
+	icon_state = "dmux8"
+	w_class = WEIGHT_CLASS_SMALL
+	number_of_pins = 8
+
+/obj/item/integrated_circuit/transfer/pulsemultiplexer/huge
+	name = "sixteen pulse multiplexer"
+	icon_state = "dmux16"
+	w_class = WEIGHT_CLASS_SMALL
+	number_of_pins = 16
 
 /obj/item/integrated_circuit/transfer/wire_node
 	name = "wire node"


### PR DESCRIPTION
:cl:
add: Added pulse multiplexer circuits, to complete the list of data transfers.
/:cl:

[why]: There are multiplexers, demultiplexers, and pulse demultiplexers. I figured pulse demultiplexers would complete the list and prove themselves useful.