### PR TITLE
Increases handheld T-ray scanner range

### DIFF
--- a/code/game/objects/items/devices/scanners.dm
+++ b/code/game/objects/items/devices/scanners.dm
@@ -42,7 +42,7 @@ SLIME SCANNER
 /obj/item/t_scanner/proc/scan()
 	t_ray_scan(loc)
 
-/proc/t_ray_scan(mob/viewer, flick_time = 8, distance = 2)
+/proc/t_ray_scan(mob/viewer, flick_time = 8, distance = 3)
 	if(!ismob(viewer) || !viewer.client)
 		return
 	var/list/t_ray_images = list()


### PR DESCRIPTION
:cl: Denton
tweak: Increased the range of handheld T-ray scanners.
/:cl:

Right now, handheld T-ray scanners barely see any use since they have the same range as T-ray glasses but still take up a pocket/hand slot. Increasing their scan range will hopefully make them a viable alternative.

New T-ray ranges:
Engineering scanner glasses: 1
T-ray glasses: 2
T-ray scanners: 3