### PR TITLE
Improves supply remote desc

### DIFF
--- a/code/game/objects/items/control_wand.dm
+++ b/code/game/objects/items/control_wand.dm
@@ -84,6 +84,7 @@
 
 /obj/item/door_remote/quartermaster
 	name = "supply door remote"
+	desc = "Remotely controls airlocks. This remote has additional Vault access."
 	icon_state = "gangtool-green"
 	region_access = 6
 


### PR DESCRIPTION
The QM's door remote was lacking a description that hints at vault access.