### PR TITLE
Removes cargo bounties that request irreplaceable items

### DIFF
--- a/code/modules/cargo/bounties/assistant.dm
+++ b/code/modules/cargo/bounties/assistant.dm
@@ -155,19 +155,6 @@
 	required_count = 5
 	wanted_types = list(/obj/structure/chair/comfy)
 
-/datum/bounty/item/assistant/revolver
-	name = "Revolver"
-	description = "Captain Johann of station 12 has challenged Captain Vic of station 11 to a duel. He's asked for help securing an appropriate revolver to use."
-	reward = 2000
-	wanted_types = list(/obj/item/gun/ballistic/revolver)
-	exclude_types = list(/obj/item/gun/ballistic/revolver/doublebarrel, /obj/item/gun/ballistic/revolver/grenadelauncher)
-
-/datum/bounty/item/assistant/hand_tele
-	name = "Hand Tele"
-	description = "Central Command has come up with a genius idea: Why not teleport cargo rather than ship it? Send over a hand tele, receive payment, then wait 6-8 years while they deliberate."
-	reward = 2000
-	wanted_types = list(/obj/item/hand_tele)
-
 /datum/bounty/item/assistant/geranium
 	name = "Geraniums"
 	description = "Commander Zot has the hots for Commander Zena. Send a shipment of geraniums - her favorite flower - and he'll happily reward you."

--- a/code/modules/cargo/bounties/security.dm
+++ b/code/modules/cargo/bounties/security.dm
@@ -1,15 +1,3 @@
-/datum/bounty/item/security/securitybelt
-	name = "Security Belt"
-	description = "CentCom is having difficulties with their security belts. Ship one from the station to receive compensation."
-	reward = 800
-	wanted_types = list(/obj/item/storage/belt/security)
-
-/datum/bounty/item/security/sechuds
-	name = "Security HUDSunglasses"
-	description = "CentCom screwed up and ordered the wrong type of security sunglasses. They request the station ship some of theirs."
-	reward = 800
-	wanted_types = list(/obj/item/clothing/glasses/hud/security/sunglasses)
-
 /datum/bounty/item/security/riotshotgun
 	name = "Riot Shotguns"
 	description = "Hooligans have boarded CentCom! Ship riot shotguns quick, or things are going to get dirty."

--- a/code/modules/cargo/bounties/security.dm
+++ b/code/modules/cargo/bounties/security.dm
@@ -1,9 +1,3 @@
-/datum/bounty/item/security/headset
-	name = "Security Headset"
-	description = "Nanotrasen wants to ensure that their encryption is working correctly. Ship them a security headset so that they can check."
-	reward = 800
-	wanted_types = list(/obj/item/radio/headset/headset_sec, /obj/item/radio/headset/heads/hos)
-
 /datum/bounty/item/security/securitybelt
 	name = "Security Belt"
 	description = "CentCom is having difficulties with their security belts. Ship one from the station to receive compensation."
@@ -23,40 +17,9 @@
 	required_count = 2
 	wanted_types = list(/obj/item/gun/ballistic/shotgun/riot)
 
-/datum/bounty/item/security/pinpointer
-	name = "Nuclear Pinpointer"
-	description = "There's a teeny-tiny itty-bitty chance CentCom may have lost a nuke disk. Can the station spare a pinpointer to help out?"
-	reward = 1500
-	wanted_types = list(/obj/item/pinpointer/nuke)
-
-/datum/bounty/item/security/captains_spare
-	name = "Captain's Spare"
-	description = "Captain Bart of Station 12 has forgotten his ID! Ship him your station's spare, would you?"
-	reward = 1500
-	wanted_types = list(/obj/item/card/id/captains_spare)
-
-/datum/bounty/item/security/hardsuit
-	name = "Security Hardsuit"
-	description = "Space pirates are heading towards CentCom! Quick! Ship a security hardsuit to aid the fight!"
-	reward = 2000
-	wanted_types = list(/obj/item/clothing/suit/space/hardsuit/security)
-
-/datum/bounty/item/security/krav_maga
-	name = "Krav Maga Gloves"
-	description = "Chef Howerwitz of CentCom is trying to take a kung-fu Pizza out of the oven, but his mitts aren't up to the task. Ship them a pair of Krav Maga gloves to do the job right."
-	reward = 2000
-	wanted_types = list(/obj/item/clothing/gloves/krav_maga)
-
 /datum/bounty/item/security/recharger
 	name = "Rechargers"
 	description = "Nanotrasen military academy is conducting marksmanship exercises. They request that rechargers be shipped."
 	reward = 2000
 	required_count = 3
 	wanted_types = list(/obj/machinery/recharger)
-
-/datum/bounty/item/security/sabre
-	name = "Officer's Sabre"
-	description = "A 3-hour LARP session will be held at CentCom in the upcoming months. A shipped officer's sabre would make a good prop."
-	reward = 2500
-	wanted_types = list(/obj/item/melee/sabre)
-


### PR DESCRIPTION
:cl: Denton
balance: Cargo bounties that request irreplaceable items have been removed.
/:cl:

@Kagus put the reason in words better than I could:

>Do we really even want these bounties? They're kinda the odd ones out due to being completely irreplaceable items, meaning that if they get lost/destroyed/sold they are permanently gone from the station until a new round. 
>
>It ends up with either an empty bounty listing just sitting there and taking up space forever or some cognitively impaired cargo tech feverishly trying to break in because "I MUST MONEY" and they honestly have no idea what the actual value of the item even is.
>
>And to those who say "conflict breeds gameplay", I have never seen the SS13 community fail to make their own conflicts at every opportunity.