### PR TITLE
Adds pixel offsets to directional APC/air alarm subtypes

### DIFF
--- a/code/modules/atmospherics/machinery/airalarm.dm
+++ b/code/modules/atmospherics/machinery/airalarm.dm
@@ -155,6 +155,22 @@
 /obj/machinery/airalarm/syndicate //general syndicate access
 	req_access = list(ACCESS_SYNDICATE)
 
+/obj/machinery/airalarm/directional/north //Pixel offsets get overwritten on New()
+	dir = SOUTH
+	pixel_y = 24
+
+/obj/machinery/airalarm/directional/south
+	dir = NORTH
+	pixel_y = -24
+
+/obj/machinery/airalarm/directional/east
+	dir = WEST
+	pixel_x = 24
+
+/obj/machinery/airalarm/directional/west
+	dir = EAST
+	pixel_x = -24
+
 //all air alarms in area are connected via magic
 /area
 	var/list/air_vent_names = list()

--- a/code/modules/power/apc.dm
+++ b/code/modules/power/apc.dm
@@ -120,17 +120,21 @@
 /obj/machinery/power/apc/auto_name
 	auto_name = TRUE
 	
-/obj/machinery/power/apc/auto_name/north
+/obj/machinery/power/apc/auto_name/north //Pixel offsets get overwritten on New()
 	dir = NORTH
+	pixel_y = 23
 	
 /obj/machinery/power/apc/auto_name/south
 	dir = SOUTH
+	pixel_y = -23
 
 /obj/machinery/power/apc/auto_name/east
 	dir = EAST
+	pixel_x = 24
 	
 /obj/machinery/power/apc/auto_name/west
 	dir = WEST
+	pixel_x = -25
 
 /obj/machinery/power/apc/get_cell()
 	return cell


### PR DESCRIPTION
This PR adds air alarm subtypes with preset dir/pixel offset values and adds pixel offsets to autoname APCs.

While air alarm/APC pixel offsets get overwritten according to their dir on New(), they still float in the middle of the room while you're working in the map editor. Very annoying if you don't have another APC to copy and have to set the pixel offset manually, just to move it out of the way.