### PR TITLE
Fixes synthflesh desc, allows VAPOR application

### DIFF
--- a/code/modules/reagents/chemistry/reagents/medicine_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/medicine_reagents.dm
@@ -374,7 +374,7 @@
 /datum/reagent/medicine/synthflesh
 	name = "Synthflesh"
 	id = "synthflesh"
-	description = "Has a 100% chance of instantly healing brute and burn damage. One unit of the chemical will heal one point of damage. Touch application only."
+	description = "Has a 100% chance of instantly healing brute and burn damage. One unit of the chemical will heal one point of damage. Can be applied by patch, smoke and splashing."
 	reagent_state = LIQUID
 	color = "#FFEBEB"
 

--- a/code/modules/reagents/chemistry/reagents/medicine_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/medicine_reagents.dm
@@ -374,7 +374,7 @@
 /datum/reagent/medicine/synthflesh
 	name = "Synthflesh"
 	id = "synthflesh"
-	description = "Has a 100% chance of instantly healing brute and burn damage. One unit of the chemical will heal one point of damage. Can be applied by patch, smoke and splashing."
+	description = "Has a 100% chance of instantly healing brute and burn damage. One unit of the chemical will heal one point of damage. Topical application only."
 	reagent_state = LIQUID
 	color = "#FFEBEB"
 
@@ -382,7 +382,7 @@
 	if(iscarbon(M))
 		if (M.stat == DEAD)
 			show_message = 0
-		if(method in list(PATCH, TOUCH))
+		if(method in list(PATCH, TOUCH, VAPOR))
 			M.adjustBruteLoss(-1.25 * reac_volume)
 			M.adjustFireLoss(-1.25 * reac_volume)
 			if(show_message)


### PR DESCRIPTION
:cl:
tweak: Synthflesh can be applied by VAPOR, which includes spray bottles and foam.
/:cl:

I replaced the desc part "Touch application only." with "Topical application only."
Also, allowed synthflesh to be applied by VAPOR so we no longer have the situation where medical sprays work, but spray bottles don't. 

Application types are a bit confusing in general, if you consider that cleaner spray bottles are VAPOR, medical spray bottles are PATCH and smoke is TOUCH 🤔 