### PR TITLE
Makes detect_room type agnostic again

### DIFF
--- a/code/__HELPERS/areas.dm
+++ b/code/__HELPERS/areas.dm
@@ -3,7 +3,8 @@
 // Gets an atmos isolated contained space
 // Returns an associative list of turf|dirs pairs
 // The dirs are connected turfs in the same space
-// break_if_found is a typecache of turf types to return false if found
+// break_if_found is a typecache of turf/area types to return false if found
+// Please keep this proc type agnostic. If you need to restrict it do it elsewhere or add an arg.
 /proc/detect_room(turf/origin, list/break_if_found)
 	if(origin.blocks_air)
 		return list(origin)
@@ -13,9 +14,7 @@
 	var/list/found_turfs = list(origin)
 	while(found_turfs.len)
 		var/turf/sourceT = found_turfs[1]
-		if(break_if_found[sourceT.type])
-			return FALSE
-		if (istype(sourceT.loc, /area/shuttle))
+		if(break_if_found[sourceT.type] || break_if_found[sourceT.loc.type])
 			return FALSE
 		found_turfs.Cut(1, 2)
 		var/dir_flags = checked_turfs[sourceT]
@@ -35,12 +34,16 @@
 			found_turfs += checkT // Since checkT is connected, add it to the list to be processed
 
 /proc/create_area(mob/creator)
-	var/static/blacklisted_turfs = typecacheof(/turf/open/space)
-	var/static/blacklisted_areas = typecacheof(list(
-		/area/space,
+	// Passed into the above proc as list/break_if_found
+	var/static/area_or_turf_fail_types = typecacheof(list(
+		/turf/open/space,
 		/area/shuttle,
 		))
-	var/list/turfs = detect_room(get_turf(creator), blacklisted_turfs)
+	// Ignore these areas and dont let people expand them. They can expand into them though
+	var/static/blacklisted_areas = typecacheof(list(
+		/area/space,
+		))
+	var/list/turfs = detect_room(get_turf(creator), area_or_turf_fail_types)
 	if(!turfs)
 		to_chat(creator, "<span class='warning'>The new area must be completely airtight and not a part of a shuttle.</span>")
 		return
@@ -50,7 +53,7 @@
 	var/list/areas = list("New Area" = /area)
 	for(var/i in 1 to turfs.len)
 		var/area/place = get_area(turfs[i])
-		if(blacklisted_areas[place.type] || istype(place, /area/shuttle))
+		if(blacklisted_areas[place.type])
 			continue
 		if(!place.requires_power || place.noteleport || place.hidden)
 			continue // No expanding powerless rooms etc

--- a/code/__HELPERS/areas.dm
+++ b/code/__HELPERS/areas.dm
@@ -14,8 +14,6 @@
 	var/list/found_turfs = list(origin)
 	while(found_turfs.len)
 		var/turf/sourceT = found_turfs[1]
-		if(break_if_found[sourceT.type] || break_if_found[sourceT.loc.type])
-			return FALSE
 		found_turfs.Cut(1, 2)
 		var/dir_flags = checked_turfs[sourceT]
 		for(var/dir in GLOB.alldirs)
@@ -28,6 +26,8 @@
 			checked_turfs[checkT] |= turn(dir, 180)
 			.[sourceT] |= dir
 			.[checkT] |= turn(dir, 180)
+			if(break_if_found[checkT.type] || break_if_found[checkT.loc.type])
+				return FALSE
 			var/static/list/cardinal_cache = list("[NORTH]"=TRUE, "[EAST]"=TRUE, "[SOUTH]"=TRUE, "[WEST]"=TRUE)
 			if(!cardinal_cache["[dir]"] || checkT.blocks_air || !CANATMOSPASS(sourceT, checkT))
 				continue


### PR DESCRIPTION
`detect_room()` should be able to be used by whatever, it's the player accessible area modification that cares about these restrictions.

This code is an independent proc who don't need no explicit istypes.

Goddamit naksu