### PR TITLE
Removes the shuttle timid var

### DIFF
--- a/_maps/map_files/generic/CentCom.dmm
+++ b/_maps/map_files/generic/CentCom.dmm
@@ -12622,13 +12622,6 @@
 	dir = 5
 	},
 /area/tdome/tdomeadmin)
-"JV" = (
-/turf/closed/wall/mineral/titanium,
-/area/shuttle/escape/backup)
-"JW" = (
-/obj/machinery/status_display,
-/turf/closed/wall/mineral/titanium,
-/area/shuttle/escape/backup)
 "JX" = (
 /obj/machinery/door/firedoor,
 /obj/effect/turf_decal/stripes/line{
@@ -12669,18 +12662,6 @@
 	dir = 8
 	},
 /area/tdome/tdomeadmin)
-"Kd" = (
-/turf/open/floor/mineral/titanium,
-/area/shuttle/escape/backup)
-"Ke" = (
-/turf/open/floor/mineral/plastitanium,
-/area/shuttle/escape/backup)
-"Kf" = (
-/obj/machinery/computer/emergency_shuttle{
-	dir = 8
-	},
-/turf/open/floor/mineral/titanium,
-/area/shuttle/escape/backup)
 "Kg" = (
 /turf/closed/indestructible/fakedoor{
 	name = "Thunderdome Admin"
@@ -12709,29 +12690,17 @@
 /turf/open/floor/plasteel,
 /area/tdome/tdomeadmin)
 "Kk" = (
-/obj/machinery/door/airlock/titanium,
 /obj/docking_port/stationary{
 	dir = 4;
 	dwidth = 2;
 	height = 8;
 	id = "backup_away";
 	name = "Backup Shuttle Dock";
+	roundstart_template = /datum/map_template/shuttle/emergency/backup;
 	width = 8
 	},
-/obj/docking_port/mobile/emergency/backup,
-/turf/open/floor/plating,
-/area/shuttle/escape/backup)
-"Kl" = (
-/obj/structure/chair/office/light{
-	dir = 4
-	},
-/turf/open/floor/mineral/titanium,
-/area/shuttle/escape/backup)
-"Km" = (
-/obj/structure/table/wood,
-/obj/item/paper/fluff/stations/centcom/broken_evac,
-/turf/open/floor/mineral/titanium,
-/area/shuttle/escape/backup)
+/turf/open/space/basic,
+/area/space)
 "Kn" = (
 /obj/structure/bookcase/random,
 /turf/open/floor/plasteel/vault{
@@ -12863,11 +12832,6 @@
 	dir = 8
 	},
 /area/tdome/tdomeadmin)
-"Kz" = (
-/obj/structure/table/wood,
-/obj/item/book/manual/random,
-/turf/open/floor/mineral/titanium,
-/area/shuttle/escape/backup)
 "KA" = (
 /obj/structure/flora/ausbushes/lavendergrass,
 /obj/structure/flora/ausbushes/sparsegrass,
@@ -12894,18 +12858,6 @@
 /obj/machinery/ai_status_display,
 /turf/closed/indestructible/riveted,
 /area/tdome/tdomeadmin)
-"KE" = (
-/obj/machinery/light{
-	dir = 8
-	},
-/turf/open/floor/mineral/titanium,
-/area/shuttle/escape/backup)
-"KF" = (
-/obj/machinery/light{
-	dir = 4
-	},
-/turf/open/floor/mineral/titanium,
-/area/shuttle/escape/backup)
 "KG" = (
 /obj/structure/flora/ausbushes/lavendergrass,
 /obj/structure/flora/ausbushes/sparsegrass,
@@ -63652,14 +63604,14 @@ aa
 aa
 aa
 aa
-JV
-JV
+aa
+aa
 Kk
-JV
-JV
-JV
-JV
-JV
+aa
+aa
+aa
+aa
+aa
 aa
 aa
 aa
@@ -63909,14 +63861,14 @@ aa
 aa
 aa
 aa
-JW
-Kd
-Kd
-Kd
-KE
-Kd
-Kd
-JW
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
 aa
 aa
 aa
@@ -64166,14 +64118,14 @@ aa
 aa
 aa
 aa
-JV
-Kd
-Kd
-Kd
-Kd
-Kd
-Kd
-JV
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
 aa
 aa
 aa
@@ -64423,14 +64375,14 @@ aa
 aa
 aa
 aa
-JV
-Ke
-Ke
-Ke
-Ke
-Kd
-Ke
-JV
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
 aa
 aa
 aa
@@ -64680,14 +64632,14 @@ aa
 aa
 aa
 aa
-JV
-Ke
-Ke
-Ke
-Ke
-Kd
-Ke
-JV
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
 aa
 aa
 aa
@@ -64937,14 +64889,14 @@ aa
 aa
 aa
 aa
-JV
-Kd
-Kl
-Kd
-Kd
-Kd
-Kd
-JV
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
 aa
 aa
 aa
@@ -65194,14 +65146,14 @@ aa
 aa
 aa
 aa
-JW
-Kf
-Km
-Kz
-KF
-Kd
-Kd
-JW
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
 aa
 aa
 aa
@@ -65451,14 +65403,14 @@ aa
 aa
 aa
 aa
-JV
-JV
-JV
-JV
-JV
-JV
-JV
-JV
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
 aa
 aa
 aa

--- a/_maps/shuttles/assault_pod_default.dmm
+++ b/_maps/shuttles/assault_pod_default.dmm
@@ -23,8 +23,7 @@
 	dwidth = 3;
 	name = "steel rain";
 	port_direction = 4;
-	preferred_direction = 4;
-	timid = 1
+	preferred_direction = 4
 	},
 /turf/open/floor/plating,
 /area/shuttle/assault_pod)

--- a/_maps/shuttles/aux_base_default.dmm
+++ b/_maps/shuttles/aux_base_default.dmm
@@ -56,8 +56,7 @@
 	dir = 2;
 	dwidth = 4;
 	height = 9;
-	width = 9;
-	timid = 1
+	width = 9
 	},
 /obj/machinery/bluespace_beacon,
 /obj/machinery/computer/auxillary_base,

--- a/_maps/shuttles/aux_base_small.dmm
+++ b/_maps/shuttles/aux_base_small.dmm
@@ -53,8 +53,7 @@
 	dir = 2;
 	dwidth = 4;
 	height = 9;
-	width = 9;
-	timid = 1
+	width = 9
 	},
 /obj/machinery/bluespace_beacon,
 /obj/machinery/computer/auxillary_base,

--- a/_maps/shuttles/emergency_backup.dmm
+++ b/_maps/shuttles/emergency_backup.dmm
@@ -1,0 +1,134 @@
+//MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
+"a" = (
+/obj/machinery/computer/emergency_shuttle{
+	dir = 8
+	},
+/turf/open/floor/mineral/titanium,
+/area/shuttle/escape/backup)
+"c" = (
+/obj/machinery/door/airlock/titanium,
+/obj/docking_port/mobile/emergency/backup,
+/turf/open/floor/plating,
+/area/shuttle/escape/backup)
+"f" = (
+/obj/structure/table/wood,
+/obj/item/book/manual/random,
+/turf/open/floor/mineral/titanium,
+/area/shuttle/escape/backup)
+"g" = (
+/turf/open/floor/mineral/titanium,
+/area/shuttle/escape/backup)
+"m" = (
+/turf/closed/wall/mineral/titanium,
+/area/shuttle/escape/backup)
+"p" = (
+/turf/open/floor/mineral/plastitanium,
+/area/shuttle/escape/backup)
+"q" = (
+/obj/machinery/status_display,
+/turf/closed/wall/mineral/titanium,
+/area/shuttle/escape/backup)
+"u" = (
+/obj/structure/chair/office/light{
+	dir = 4
+	},
+/turf/open/floor/mineral/titanium,
+/area/shuttle/escape/backup)
+"x" = (
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/open/floor/mineral/titanium,
+/area/shuttle/escape/backup)
+"F" = (
+/obj/structure/table/wood,
+/obj/item/paper/fluff/stations/centcom/broken_evac,
+/turf/open/floor/mineral/titanium,
+/area/shuttle/escape/backup)
+"P" = (
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/open/floor/mineral/titanium,
+/area/shuttle/escape/backup)
+
+(1,1,1) = {"
+m
+m
+c
+m
+m
+m
+m
+m
+"}
+(2,1,1) = {"
+q
+g
+g
+g
+x
+g
+g
+q
+"}
+(3,1,1) = {"
+m
+g
+g
+g
+g
+g
+g
+m
+"}
+(4,1,1) = {"
+m
+p
+p
+p
+p
+g
+p
+m
+"}
+(5,1,1) = {"
+m
+p
+p
+p
+p
+g
+p
+m
+"}
+(6,1,1) = {"
+m
+g
+u
+g
+g
+g
+g
+m
+"}
+(7,1,1) = {"
+q
+a
+F
+f
+P
+g
+g
+q
+"}
+(8,1,1) = {"
+m
+m
+m
+m
+m
+m
+m
+m
+"}

--- a/_maps/shuttles/escape_pod_default.dmm
+++ b/_maps/shuttles/escape_pod_default.dmm
@@ -20,7 +20,6 @@
 	},
 /obj/docking_port/mobile/pod{
 	port_direction = 2;
-	timid = 1;
 	dwidth = 1;
 	width = 3;
 	height = 4

--- a/_maps/shuttles/escape_pod_large.dmm
+++ b/_maps/shuttles/escape_pod_large.dmm
@@ -74,7 +74,6 @@
 	height = 6;
 	launch_status = 0;
 	port_direction = 2;
-	timid = 1;
 	width = 5
 	},
 /turf/open/floor/mineral/titanium/blue,

--- a/_maps/shuttles/pirate_default.dmm
+++ b/_maps/shuttles/pirate_default.dmm
@@ -660,7 +660,6 @@
 	name = "Pirate Ship";
 	port_direction = 8;
 	preferred_direction = 1;
-	timid = 0;
 	width = 23
 	},
 /obj/docking_port/stationary{

--- a/_maps/shuttles/ruin_caravan_victim.dmm
+++ b/_maps/shuttles/ruin_caravan_victim.dmm
@@ -901,7 +901,6 @@
 	name = "Small Freighter";
 	port_direction = 8;
 	preferred_direction = 4;
-	timid = 1;
 	width = 21
 	},
 /turf/open/floor/plating,

--- a/_maps/shuttles/ruin_pirate_cutter.dmm
+++ b/_maps/shuttles/ruin_pirate_cutter.dmm
@@ -707,7 +707,6 @@
 	name = "Pirate Cutter";
 	port_direction = 8;
 	preferred_direction = 4;
-	timid = 1;
 	width = 22
 	},
 /turf/open/floor/plating,

--- a/_maps/shuttles/ruin_syndicate_dropship.dmm
+++ b/_maps/shuttles/ruin_syndicate_dropship.dmm
@@ -69,7 +69,6 @@
 	name = "Syndicate Drop Ship";
 	port_direction = 8;
 	preferred_direction = 4;
-	timid = 1;
 	width = 15
 	},
 /obj/effect/mapping_helpers/airlock/cyclelink_helper,

--- a/_maps/shuttles/ruin_syndicate_fighter_shiv.dmm
+++ b/_maps/shuttles/ruin_syndicate_fighter_shiv.dmm
@@ -98,7 +98,6 @@
 	name = "Syndicate Fighter";
 	port_direction = 2;
 	preferred_direction = 4;
-	timid = 1;
 	width = 9
 	},
 /turf/open/floor/plating,

--- a/_maps/shuttles/snowdin_excavation.dmm
+++ b/_maps/shuttles/snowdin_excavation.dmm
@@ -8,7 +8,6 @@
 	height = 6;
 	id = "snowdin_excavation";
 	name = "excavation elevator";
-	timid = 1;
 	width = 6
 	},
 /turf/open/floor/plating,

--- a/_maps/shuttles/snowdin_mining.dmm
+++ b/_maps/shuttles/snowdin_mining.dmm
@@ -9,7 +9,6 @@
 	height = 5;
 	id = "snowdin_mining";
 	name = "mining elevator";
-	timid = 1;
 	width = 5
 	},
 /turf/open/floor/plating,

--- a/code/datums/shuttles.dm
+++ b/code/datums/shuttles.dm
@@ -110,6 +110,11 @@
 
 // Shuttles start here:
 
+/datum/map_template/shuttle/emergency/backup
+	suffix = "backup"
+	name = "Backup Shuttle"
+	can_be_bought = FALSE
+
 /datum/map_template/shuttle/emergency/airless
 	suffix = "airless"
 	name = "Build your own shuttle kit"

--- a/code/modules/events/pirates.dm
+++ b/code/modules/events/pirates.dm
@@ -81,6 +81,8 @@
 				candidates -= M
 			else
 				notify_ghosts("Space pirates are waking up!", source = spawner, action=NOTIFY_ATTACK, flashwindow = FALSE)
+		for(var/obj/docking_port/mobile/port in A)
+			port.register()
 
 	priority_announce("Unidentified armed ship detected near the station.")
 

--- a/code/modules/mining/aux_base.dm
+++ b/code/modules/mining/aux_base.dm
@@ -239,7 +239,6 @@ interface with the mining shuttle at the landing site if a mobile beacon is also
 /obj/docking_port/mobile/auxillary_base
 	name = "auxillary base"
 	id = "colony_drop"
-	timid = FALSE
 	//Reminder to map-makers to set these values equal to the size of your base.
 	dheight = 4
 	dwidth = 4

--- a/code/modules/shuttle/assault_pod.dm
+++ b/code/modules/shuttle/assault_pod.dm
@@ -1,7 +1,6 @@
 /obj/docking_port/mobile/assault_pod
 	name = "assault pod"
 	id = "steel_rain"
-	timid = FALSE
 	dwidth = 3
 	width = 7
 	height = 7

--- a/code/modules/shuttle/elevator.dm
+++ b/code/modules/shuttle/elevator.dm
@@ -1,7 +1,6 @@
 /obj/docking_port/mobile/elevator
 	name = "elevator"
 	id = "elevator"
-	timid = FALSE
 	dwidth = 3
 	width = 7
 	height = 7

--- a/code/modules/shuttle/emergency.dm
+++ b/code/modules/shuttle/emergency.dm
@@ -273,7 +273,7 @@
 					if(prevent)
 						return FALSE
 
-	
+
 	return has_people && hijacker_present
 
 /obj/docking_port/mobile/emergency/proc/ShuttleDBStuff()
@@ -422,7 +422,6 @@
 /obj/docking_port/mobile/pod
 	name = "escape pod"
 	id = "pod"
-	timid = FALSE
 	dwidth = 1
 	width = 3
 	height = 4

--- a/code/modules/shuttle/manipulator.dm
+++ b/code/modules/shuttle/manipulator.dm
@@ -233,7 +233,7 @@
 	preview_shuttle.movement_force = list("KNOCKDOWN" = 0, "THROW" = 0)
 	preview_shuttle.initiate_docking(D)
 	preview_shuttle.movement_force = force_memory
-	
+
 	. = preview_shuttle
 
 	// Shuttle state involves a mode and a timer based on world.time, so
@@ -267,18 +267,10 @@
 	for(var/T in affected)
 		for(var/obj/docking_port/P in T)
 			if(istype(P, /obj/docking_port/mobile))
-				var/obj/docking_port/mobile/M = P
 				found++
 				if(found > 1)
 					qdel(P, force=TRUE)
 					log_world("Map warning: Shuttle Template [S.mappath] has multiple mobile docking ports.")
-				else if(!M.timid)
-					// The shuttle template we loaded isn't "timid" which means
-					// it's already registered with the shuttles subsystem.
-					// This is a bad thing.
-					stack_trace("Template [S] is non-timid! Unloading.")
-					M.jumpToNullSpace()
-					return
 				else
 					preview_shuttle = P
 			if(istype(P, /obj/docking_port/stationary))

--- a/code/modules/shuttle/shuttle.dm
+++ b/code/modules/shuttle/shuttle.dm
@@ -253,11 +253,6 @@
 
 	var/list/movement_force = list("KNOCKDOWN" = 3, "THROW" = 2)
 
-	// A timid shuttle will not register itself with the shuttle subsystem
-	// All shuttle templates MUST be timid, imports will fail if they're not
-	// Shuttle defined already on the map MUST NOT be timid, or they won't work
-	var/timid = TRUE
-
 	var/list/ripples = list()
 	var/engine_coeff = 1 //current engine coeff
 	var/current_engines = 0 //current engine power
@@ -280,8 +275,6 @@
 
 /obj/docking_port/mobile/Initialize(mapload)
 	. = ..()
-	if(!timid)
-		register()
 
 	if(!id)
 		id = "[SSshuttle.mobile.len]"


### PR DESCRIPTION
Now that shuttles are all loaded via template we no longer have a need for the timid var on shuttles.

Well not all shuttles, it seems I forgot to template the backup shuttle so it wouldn't have been working until now. This got fixed here as well.