### PR TITLE
[READY] Giving circuits possibility to load item while in assembly

### DIFF
--- a/code/modules/integrated_electronics/core/assemblies.dm
+++ b/code/modules/integrated_electronics/core/assemblies.dm
@@ -469,14 +469,14 @@
 		battery = I
 		diag_hud_set_circuitstat() //update diagnostic hud
 		playsound(get_turf(src), 'sound/items/Deconstruct.ogg', 50, 1)
-		to_chat(user, "<span class='notice'>You slot \the [I] inside \the [src]'s power supplier.</span>")
+		to_chat(user, "<span class='notice'>You slot the [I] inside \the [src]'s power supplier.</span>")
 		return TRUE
 	else if(istype(I, /obj/item/integrated_electronics/detailer))
 		var/obj/item/integrated_electronics/detailer/D = I
 		detail_color = D.detail_color
 		update_icon()
 	else
-		if(user.a_intent != "help")
+		if(user.a_intent != INTENT_HELP)
 			return ..()
 		var/list/input_selection = list()
 		//Check all the components asking for an input
@@ -544,7 +544,7 @@
 			if(!check_interactivity(user))
 				return
 			if(selection)
-				choice = input_selection.[selection]
+				choice = input_selection[selection]
 
 	if(choice)
 		choice.ask_for_input(user)

--- a/code/modules/integrated_electronics/core/assemblies.dm
+++ b/code/modules/integrated_electronics/core/assemblies.dm
@@ -520,7 +520,7 @@
 
 	var/list/input_selection = list()
 	//Check all the components asking for an input
-	for(var/obj/item/integrated_circuit/input in assembly_components)
+	for(var/obj/item/integrated_circuit/input/input in assembly_components)
 		if(input.can_be_asked_input)
 			var/i = 0
 			//Check if there is another component with the same name and append a number for identification

--- a/code/modules/integrated_electronics/core/assemblies.dm
+++ b/code/modules/integrated_electronics/core/assemblies.dm
@@ -481,7 +481,7 @@
 		var/list/input_selection = list()
 		//Check all the components asking for an input
 		for(var/obj/item/integrated_circuit/input in assembly_components)
-			if((input.demands_object_input && opened) || (input.demands_object_input && can_input_object_when_closed))
+			if((input.demands_object_input && opened) || (input.demands_object_input && input.can_input_object_when_closed))
 				var/i = 0
 				//Check if there is another component with the same name and append a number for identification
 				for(var/s in input_selection)

--- a/code/modules/integrated_electronics/core/assemblies.dm
+++ b/code/modules/integrated_electronics/core/assemblies.dm
@@ -465,13 +465,11 @@
 			for(var/obj/item/integrated_circuit/input/S in assembly_components)
 				S.attackby_react(I,user,user.a_intent)
 			return ..()
-		var/obj/item/stock_parts/cell = I
-		user.transferItemToLoc(I, contents)
-		cell.forceMove(src)
-		battery = cell
+		I.forceMove(src)
+		battery = I
 		diag_hud_set_circuitstat() //update diagnostic hud
 		playsound(get_turf(src), 'sound/items/Deconstruct.ogg', 50, 1)
-		to_chat(user, "<span class='notice'>You slot \the [cell] inside \the [src]'s power supplier.</span>")
+		to_chat(user, "<span class='notice'>You slot \the [I] inside \the [src]'s power supplier.</span>")
 		return TRUE
 	else if(istype(I, /obj/item/integrated_electronics/detailer))
 		var/obj/item/integrated_electronics/detailer/D = I

--- a/code/modules/integrated_electronics/core/assemblies.dm
+++ b/code/modules/integrated_electronics/core/assemblies.dm
@@ -466,7 +466,7 @@
 				S.attackby_react(I,user,user.a_intent)
 			return ..()
 		var/obj/item/stock_parts/cell = I
-		user.transferItemToLoc(I, loc)
+		user.transferItemToLoc(I, contents)
 		cell.forceMove(src)
 		battery = cell
 		diag_hud_set_circuitstat() //update diagnostic hud

--- a/code/modules/integrated_electronics/core/assemblies.dm
+++ b/code/modules/integrated_electronics/core/assemblies.dm
@@ -510,7 +510,7 @@
 		if(choice)
 			choice.additem(I, user)
 		for(var/obj/item/integrated_circuit/input/S in assembly_components)
-		S.attackby_react(I,user,user.a_intent)
+			S.attackby_react(I,user,user.a_intent)
 		return ..()
 
 

--- a/code/modules/integrated_electronics/core/assemblies.dm
+++ b/code/modules/integrated_electronics/core/assemblies.dm
@@ -539,7 +539,7 @@
 
 	if(input_selection)
 		if(input_selection.len ==1)
-			choice = input_selection[1]
+			choice = input_selection[input_selection[1]]
 		else
 			var/selection = input(user, "What do you want to interact with?", "Interaction") as null|anything in input_selection
 			if(!check_interactivity(user))

--- a/code/modules/integrated_electronics/core/assemblies.dm
+++ b/code/modules/integrated_electronics/core/assemblies.dm
@@ -504,12 +504,14 @@
 		else
 			var/selection = input(user, "Where do you want to insert that item?", "Interaction") as null|anything in input_selection
 			if(!check_interactivity(user))
-				return FALSE
+				return ..()
 			if(selection)
 				choice = input_selection[selection]
 		if(choice)
 			choice.additem(I, user)
-		return TRUE
+		for(var/obj/item/integrated_circuit/input/S in assembly_components)
+		S.attackby_react(I,user,user.a_intent)
+		return ..()
 
 
 /obj/item/electronic_assembly/attack_self(mob/user)

--- a/code/modules/integrated_electronics/core/assemblies.dm
+++ b/code/modules/integrated_electronics/core/assemblies.dm
@@ -478,10 +478,38 @@
 		detail_color = D.detail_color
 		update_icon()
 	else
-		for(var/obj/item/integrated_circuit/input/S in assembly_components)
-			S.attackby_react(I,user,user.a_intent)
-		if(user.a_intent != INTENT_HELP)
+		if(user.a_intent != "help" || !(opened))
 			return ..()
+		var/list/input_selection = list()
+		//Check all the components asking for an input
+		for(var/obj/item/integrated_circuit/input in assembly_components)
+			if(input.demands_object_input)
+				var/i = 0
+				//Check if there is another component with the same name and append a number for identification
+				for(var/s in input_selection)
+					var/obj/item/integrated_circuit/s_circuit = input_selection[s]
+					if(s_circuit.name == input.name && s_circuit.displayed_name == input.displayed_name && s_circuit != input)
+						i++
+				var/disp_name= "[input.displayed_name] \[[input]\]"
+				if(i)
+					disp_name += " ([i+1])"
+				//Associative lists prevent me from needing another list and using a Find proc
+				input_selection[disp_name] = input
+
+		var/obj/item/integrated_circuit/choice
+		if(!input_selection)
+			return ..()
+		if(input_selection.len == 1)
+			choice = input_selection[input_selection[1]]
+		else
+			var/selection = input(user, "Where do you want to insert that item?", "Interaction") as null|anything in input_selection
+			if(!check_interactivity(user))
+				return FALSE
+			if(selection)
+				choice = input_selection[selection]
+		if(choice)
+			choice.additem(I, user)
+		return TRUE
 
 
 /obj/item/electronic_assembly/attack_self(mob/user)
@@ -490,31 +518,34 @@
 	if(opened)
 		interact(user)
 
-	var/list/input_selection = list()
-	var/list/available_inputs = list()
-	for(var/obj/item/integrated_circuit/input/input in assembly_components)
+var/list/input_selection = list()
+	//Check all the components asking for an input
+	for(var/obj/item/integrated_circuit/input in assembly_components)
 		if(input.can_be_asked_input)
-			available_inputs.Add(input)
 			var/i = 0
-			for(var/obj/item/integrated_circuit/s in available_inputs)
-				if(s.name == input.name && s.displayed_name == input.displayed_name && s != input)
+			//Check if there is another component with the same name and append a number for identification
+			for(var/s in input_selection)
+				var/obj/item/integrated_circuit/s_circuit = input_selection[s]
+				if(s_circuit.name == input.name && s_circuit.displayed_name == input.displayed_name && s_circuit != input)
 					i++
 			var/disp_name= "[input.displayed_name] \[[input]\]"
 			if(i)
 				disp_name += " ([i+1])"
-			input_selection.Add(disp_name)
+			//Associative lists prevent me from needing another list and using a Find proc
+			input_selection[disp_name] = input
 
 	var/obj/item/integrated_circuit/input/choice
-	if(available_inputs)
-		if(available_inputs.len ==1)
-			choice = available_inputs[1]
+
+
+	if(input_selection)
+		if(input_selection.len ==1)
+			choice = input_selection[1]
 		else
 			var/selection = input(user, "What do you want to interact with?", "Interaction") as null|anything in input_selection
 			if(!check_interactivity(user))
 				return
 			if(selection)
-				var/index = input_selection.Find(selection)
-				choice = available_inputs[index]
+				choice = input_selection.[selection]
 
 	if(choice)
 		choice.ask_for_input(user)

--- a/code/modules/integrated_electronics/core/assemblies.dm
+++ b/code/modules/integrated_electronics/core/assemblies.dm
@@ -476,12 +476,12 @@
 		detail_color = D.detail_color
 		update_icon()
 	else
-		if(user.a_intent != "help" || !(opened))
+		if(user.a_intent != "help")
 			return ..()
 		var/list/input_selection = list()
 		//Check all the components asking for an input
 		for(var/obj/item/integrated_circuit/input in assembly_components)
-			if(input.demands_object_input)
+			if((input.demands_object_input && opened) || (input.demands_object_input && can_input_object_when_closed))
 				var/i = 0
 				//Check if there is another component with the same name and append a number for identification
 				for(var/s in input_selection)

--- a/code/modules/integrated_electronics/core/assemblies.dm
+++ b/code/modules/integrated_electronics/core/assemblies.dm
@@ -518,7 +518,7 @@
 	if(opened)
 		interact(user)
 
-var/list/input_selection = list()
+	var/list/input_selection = list()
 	//Check all the components asking for an input
 	for(var/obj/item/integrated_circuit/input in assembly_components)
 		if(input.can_be_asked_input)

--- a/code/modules/integrated_electronics/core/assemblies.dm
+++ b/code/modules/integrated_electronics/core/assemblies.dm
@@ -497,18 +497,17 @@
 				input_selection[disp_name] = input
 
 		var/obj/item/integrated_circuit/choice
-		if(!input_selection)
-			return ..()
-		if(input_selection.len == 1)
-			choice = input_selection[input_selection[1]]
-		else
-			var/selection = input(user, "Where do you want to insert that item?", "Interaction") as null|anything in input_selection
-			if(!check_interactivity(user))
-				return ..()
-			if(selection)
-				choice = input_selection[selection]
-		if(choice)
-			choice.additem(I, user)
+		if(input_selection)
+			if(input_selection.len == 1)
+				choice = input_selection[input_selection[1]]
+			else
+				var/selection = input(user, "Where do you want to insert that item?", "Interaction") as null|anything in input_selection
+				if(!check_interactivity(user))
+					return ..()
+				if(selection)
+					choice = input_selection[selection]
+			if(choice)
+				choice.additem(I, user)
 		for(var/obj/item/integrated_circuit/input/S in assembly_components)
 			S.attackby_react(I,user,user.a_intent)
 		return ..()

--- a/code/modules/integrated_electronics/core/integrated_circuit.dm
+++ b/code/modules/integrated_electronics/core/integrated_circuit.dm
@@ -40,8 +40,7 @@ a creative player the means to solve many problems.  Circuits are held inside an
 
 // Can be called via electronic_assembly/attackby()
 /obj/item/integrated_circuit/proc/additem(var/obj/item/I, var/mob/living/user)
-	to_chat(user,"<span class='warning'>The [I.name] doesn't seem to fit in here.</span>")
-	return
+	attackby(I, user)
 
 // This should be used when someone is examining while the case is opened.
 /obj/item/integrated_circuit/proc/internal_examine(mob/user)

--- a/code/modules/integrated_electronics/core/integrated_circuit.dm
+++ b/code/modules/integrated_electronics/core/integrated_circuit.dm
@@ -24,6 +24,8 @@
 	var/category_text = "NO CATEGORY THIS IS A BUG"	// To show up on circuit printer, and perhaps other places.
 	var/removable = TRUE 			// Determines if a circuit is removable from the assembly.
 	var/displayed_name = ""
+	var/demands_object_input = FALSE
+	
 	
 /*
 	Integrated circuits are essentially modular machines.  Each circuit has a specific function, and combining them inside Electronic Assemblies allows
@@ -34,6 +36,11 @@ a creative player the means to solve many problems.  Circuits are held inside an
 	interact(user)
 	external_examine(user)
 	. = ..()
+
+// Can be called via electronic_assembly/attackby()
+/obj/item/integrated_circuit/proc/additem(var/obj/item/I, var/mob/living/user)
+	to_chat(user,"<span class='warning'>The [I.name] doesn't seem to fit in here.</span>")
+	return
 
 // This should be used when someone is examining while the case is opened.
 /obj/item/integrated_circuit/proc/internal_examine(mob/user)

--- a/code/modules/integrated_electronics/core/integrated_circuit.dm
+++ b/code/modules/integrated_electronics/core/integrated_circuit.dm
@@ -25,6 +25,7 @@
 	var/removable = TRUE 			// Determines if a circuit is removable from the assembly.
 	var/displayed_name = ""
 	var/demands_object_input = FALSE
+	var/can_input_object_when_closed = FALSE
 	
 	
 /*

--- a/code/modules/integrated_electronics/subtypes/manipulation.dm
+++ b/code/modules/integrated_electronics/subtypes/manipulation.dm
@@ -33,7 +33,8 @@
 	var/stun_projectile_sound
 	var/lethal_projectile = null	//lethal mode projectile type
 	var/lethal_projectile_sound
-	demands_object_input = TRUE
+
+	demands_object_input = TRUE		// You can put stuff in once the circuit is in assembly,passed down from additem and handled by attackby()
 
 
 
@@ -185,7 +186,7 @@
 	action_flags = IC_ACTION_COMBAT
 	var/obj/item/grenade/attached_grenade
 	var/pre_attached_grenade_type
-	demands_object_input = TRUE
+	demands_object_input = TRUE	// You can put stuff in once the circuit is in assembly,passed down from additem and handled by attackby()
 
 /obj/item/integrated_circuit/manipulation/grenade/Initialize()
 	. = ..()

--- a/code/modules/integrated_electronics/subtypes/manipulation.dm
+++ b/code/modules/integrated_electronics/subtypes/manipulation.dm
@@ -33,6 +33,7 @@
 	var/stun_projectile_sound
 	var/lethal_projectile = null	//lethal mode projectile type
 	var/lethal_projectile_sound
+	demands_object_input = TRUE
 
 
 
@@ -184,6 +185,7 @@
 	action_flags = IC_ACTION_COMBAT
 	var/obj/item/grenade/attached_grenade
 	var/pre_attached_grenade_type
+	demands_object_input = TRUE
 
 /obj/item/integrated_circuit/manipulation/grenade/Initialize()
 	. = ..()


### PR DESCRIPTION
[Changelogs]: #Adds the demand_object_input var and change the attackby() script so certain circuits can get an item while they are in an assembly. Also changed the attack_self proc so it doesn't require 2 lists and a list.Find() proc. It only uses 1 list now and that should do the trick. Also fixed a bug where the battery was inserted in the assembly but rather showed up on the location of the assembly instead of going into its contents.

:cl: Shdorsh
tweak:  Makes it possible to create circuits that can get an item loaded into them while they are in an assembly and the assembly is open.
code:  Optimized electronic assemblies also.
fix:  A bug pertaining putting batteries in assemblies
/:cl:

[why]: # Initiating 2 lists is unneeded, so I optimized it all a little bit. Also, makes it easier to craft circuits.