### PR TITLE
Allow security to eject from gulag shuttle sheet stacker

### DIFF
--- a/_maps/shuttles/labour_box.dmm
+++ b/_maps/shuttles/labour_box.dmm
@@ -41,7 +41,7 @@
 /turf/open/floor/mineral/plastitanium,
 /area/shuttle/labor)
 "h" = (
-/obj/machinery/mineral/labor_claim_console{
+/obj/machinery/mineral/stacking_unit_console{
 	machinedir = 2;
 	pixel_x = 30;
 	pixel_y = 30

--- a/_maps/shuttles/labour_delta.dmm
+++ b/_maps/shuttles/labour_delta.dmm
@@ -49,7 +49,7 @@
 /turf/open/floor/mineral/plastitanium/brig,
 /area/shuttle/labor)
 "i" = (
-/obj/machinery/mineral/labor_claim_console{
+/obj/machinery/mineral/stacking_unit_console{
 	machinedir = 2;
 	pixel_x = 30;
 	pixel_y = 30


### PR DESCRIPTION
:cl:
fix: The bridge of the gulag shuttle now has a stacking machine console for ejecting sheets.
/:cl:

Fixes #34154. Issue was largely solved by #39118 due to redirecting minerals to the ore silo, but this fixes the weird situation of having a prisoner-facing console in the Security side of the ship.