### PR TITLE
Fixes sparks cooling air

### DIFF
--- a/code/game/objects/effects/effect_system/effects_sparks.dm
+++ b/code/game/objects/effects/effect_system/effects_sparks.dm
@@ -28,20 +28,20 @@
 	playsound(src.loc, "sparks", 100, 1)
 	var/turf/T = loc
 	if(isturf(T))
-		T.hotspot_expose(35,5)
+		T.hotspot_expose(300,5)
 	QDEL_IN(src, 20)
 
 /obj/effect/particle_effect/sparks/Destroy()
 	var/turf/T = loc
 	if(isturf(T))
-		T.hotspot_expose(35,1)
+		T.hotspot_expose(300,1)
 	return ..()
 
 /obj/effect/particle_effect/sparks/Move()
 	..()
 	var/turf/T = loc
 	if(isturf(T))
-		T.hotspot_expose(35,1)
+		T.hotspot_expose(300,1)
 
 /datum/effect_system/spark_spread
 	effect_type = /obj/effect/particle_effect/sparks


### PR DESCRIPTION
Turns out I forgot that the game uses Kelvin oops
New temp is 300°K which is roughly 27°C

I'm still in favor of removing hotspot_expose for sparks altogether, but that's out of scope for this PR.

Closes: #39475 