### PR TITLE
Moves main R&D console to the Bridge on MetaStation

### DIFF
--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -29167,7 +29167,9 @@
 	dir = 4;
 	pixel_x = -23
 	},
-/obj/machinery/modular_computer/console/preset/command,
+/obj/machinery/modular_computer/console/preset/research{
+	name = "research console"
+	},
 /turf/open/floor/plasteel/darkblue/side{
 	dir = 9
 	},
@@ -29177,7 +29179,7 @@
 	name = "Station Intercom (General)";
 	pixel_y = 29
 	},
-/obj/machinery/modular_computer/console/preset/engineering,
+/obj/machinery/computer/rdconsole,
 /turf/open/floor/plasteel/darkblue/side{
 	dir = 1
 	},
@@ -53134,10 +53136,10 @@
 	},
 /area/medical/chemistry)
 "cjX" = (
-/obj/machinery/computer/rdconsole/core{
+/obj/effect/turf_decal/stripes/line,
+/obj/machinery/computer/rdconsole/production{
 	dir = 4
 	},
-/obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plasteel,
 /area/science/lab)
 "cjY" = (
@@ -54445,10 +54447,10 @@
 /turf/open/floor/plasteel,
 /area/science/explab)
 "cmT" = (
-/obj/machinery/computer/rdconsole/experiment,
 /obj/effect/turf_decal/stripes/line{
 	dir = 2
 	},
+/obj/machinery/computer/rdconsole/production,
 /turf/open/floor/plasteel,
 /area/science/explab)
 "cmU" = (
@@ -63938,9 +63940,6 @@
 	},
 /area/hallway/primary/aft)
 "cGa" = (
-/obj/machinery/computer/rdconsole/robotics{
-	dir = 4
-	},
 /obj/machinery/requests_console{
 	department = "Robotics";
 	departmentType = 2;
@@ -63949,6 +63948,9 @@
 	receive_ore_updates = 1
 	},
 /obj/effect/turf_decal/bot,
+/obj/machinery/computer/rdconsole/production{
+	dir = 4
+	},
 /turf/open/floor/plasteel,
 /area/science/robotics/lab)
 "cGb" = (


### PR DESCRIPTION
![rdconsole](https://user-images.githubusercontent.com/37943475/43427942-d3beba2e-9429-11e8-93cb-b950853b15fc.png)
:cl:
balance: MetaStation: Replaced Bridge modular consoles with research variant and R&D console. Changed all other R&D consoles to the production variant.
/:cl:

Another step in decentralizing R&D. Command console was useless as its program was id console which already exists on the bridge. Engineering console had supermatter info, which research console can download. Research console has ai restorer which makes more sense to be beside an R&D console. https://tgstation13.org/phpBB/viewtopic.php?f=10&t=17586#p410342 Heads can potentially see when another head is spending points. I did consider redoing the Bridge but decided on the simplest way of bringing the change so there's no repercussions for undoing it. Alarm console or power monitor console can be replaced with engineering console to keep functionality. The production variants can be reconstructed into normal consoles but fixing that is for another PR.