### PR TITLE
Fixes exo reactor rads, changes SSU desc

### DIFF
--- a/code/game/machinery/suit_storage_unit.dm
+++ b/code/game/machinery/suit_storage_unit.dm
@@ -1,7 +1,7 @@
 // SUIT STORAGE UNIT /////////////////
 /obj/machinery/suit_storage_unit
 	name = "suit storage unit"
-	desc = "An industrial unit made to hold space suits. It comes with a built-in UV cauterization mechanism. A small warning label advises that organic matter should not be placed into the unit."
+	desc = "An industrial unit made to hold and decontaminate irradiated equipment. It comes with a built-in UV cauterization mechanism. A small warning label advises that organic matter should not be placed into the unit."
 	icon = 'icons/obj/machines/suit_storage.dmi'
 	icon_state = "close"
 	density = TRUE

--- a/code/game/mecha/equipment/tools/other_tools.dm
+++ b/code/game/mecha/equipment/tools/other_tools.dm
@@ -468,7 +468,7 @@
 	fuel_per_cycle_idle = 10
 	fuel_per_cycle_active = 30
 	power_per_cycle = 50
-	var/rad_per_cycle = 3
+	var/rad_per_cycle = 30
 
 /obj/item/mecha_parts/mecha_equipment/generator/nuclear/generator_init()
 	fuel = new /obj/item/stack/sheet/mineral/uranium(src, 0)


### PR DESCRIPTION
:cl: Denton
fix: ExoNuclear mech reactors now noticably irradiate their environment.
spellcheck: Adjusted suit storage unit descriptions to mention that they can decontaminate irradiated equipment.
/:cl:

Nuclear mech reactors were outputting about one tenth of their pre refactor rad amount; now they should properly irradiate their environment again.
I've also noticed that most people don't know that SSUs can hold a variety of items and decontaminate them. Maybe changing the desc helps?