### PR TITLE
Checks the Emperor Penguin description's privilege

### DIFF
--- a/code/modules/mob/living/simple_animal/friendly/penguin.dm
+++ b/code/modules/mob/living/simple_animal/friendly/penguin.dm
@@ -18,7 +18,7 @@
 /mob/living/simple_animal/pet/penguin/emperor
 	name = "Emperor penguin"
 	real_name = "penguin"
-	desc = "Emperor of all he surveys."
+	desc = "Emperor of all they survey."
 	icon_state = "penguin"
 	icon_living = "penguin"
 	icon_dead = "penguin_dead"


### PR DESCRIPTION
Emperor penguins can rest easier knowing their gender identity won't be assumed.

[Non-meme description]: Fixes grammar to account for female emperor penguins (#39462)