### PR TITLE
Allows beheading in hard crit

### DIFF
--- a/code/modules/surgery/bodyparts/head.dm
+++ b/code/modules/surgery/bodyparts/head.dm
@@ -32,7 +32,7 @@
 	var/lip_color = "white"
 
 /obj/item/bodypart/head/can_dismember(obj/item/I)
-	if(!(owner.stat == DEAD))
+	if(!((owner.stat == DEAD) || (owner.stat == UNCONSCIOUS)))
 		return FALSE
 	return ..()
 

--- a/code/modules/surgery/bodyparts/head.dm
+++ b/code/modules/surgery/bodyparts/head.dm
@@ -32,7 +32,7 @@
 	var/lip_color = "white"
 
 /obj/item/bodypart/head/can_dismember(obj/item/I)
-	if(!((owner.stat == DEAD) || (owner.stat == UNCONSCIOUS)))
+	if(!((owner.stat == DEAD) || owner.InFullCritical()))
 		return FALSE
 	return ..()
 


### PR DESCRIPTION
:cl: XDTM
fix: Beheading now works while in hard crit, so it can be used against zombies.
/:cl:

If you're in hard crit it won't make much difference if you get beheaded a little earlier, and it's necessary to make zombies vulnerable to head loss. Memento Mori users are still immune since they're limited to soft crit.

Fixes #39254