### PR TITLE
Skip the map merger on merge commits

### DIFF
--- a/tools/mapmerge2/precommit.py
+++ b/tools/mapmerge2/precommit.py
@@ -9,6 +9,13 @@ def main(repo):
         print("You need to resolve merge conflicts first.")
         return 1
 
+    try:
+        repo.lookup_reference('MERGE_HEAD')
+        print("Not running mapmerge for merge commit.")
+        return 0
+    except KeyError:
+        pass
+
     changed = 0
     for path, status in repo.status().items():
         if path.endswith(".dmm") and (status & (pygit2.GIT_STATUS_INDEX_MODIFIED | pygit2.GIT_STATUS_INDEX_NEW)):


### PR DESCRIPTION
Been meaning to do this for a while. Should cut down on complaints about mapmerge editing maps that people didn't actually edit.

Yes, despite the confusing terminology, this does make sense to do.