### PR TITLE
Skateboards have adjustable speed, can fit in backpacks

### DIFF
--- a/code/game/objects/items/weaponry.dm
+++ b/code/game/objects/items/weaponry.dm
@@ -476,7 +476,7 @@ for further reading, please see: https://github.com/tgstation/tgstation/pull/301
 	item_state = "skateboard"
 	force = 12
 	throwforce = 4
-	w_class = WEIGHT_CLASS_HUGE
+	w_class = WEIGHT_CLASS_NORMAL
 	attack_verb = list("smacked", "whacked", "slammed", "smashed")
 
 /obj/item/melee/skateboard/attack_self(mob/user)

--- a/code/modules/vehicles/scooter.dm
+++ b/code/modules/vehicles/scooter.dm
@@ -41,7 +41,7 @@
 
 /obj/vehicle/ridden/scooter/skateboard
 	name = "skateboard"
-	desc = "An unfinished scooter which can only barely be called a skateboard. It's still rideable, but probably unsafe. Looks like you'll need to add a few rods to make handlebars.Alt-click to adjust speed."
+	desc = "An unfinished scooter which can only barely be called a skateboard. It's still rideable, but probably unsafe. Looks like you'll need to add a few rods to make handlebars. Alt-click to adjust speed."
 	icon_state = "skateboard"
 	density = FALSE
 	var/adjusted_speed = FALSE

--- a/code/modules/vehicles/scooter.dm
+++ b/code/modules/vehicles/scooter.dm
@@ -41,7 +41,7 @@
 
 /obj/vehicle/ridden/scooter/skateboard
 	name = "skateboard"
-	desc = "An unfinished scooter which can only barely be called a skateboard. It's still rideable, but probably unsafe. Looks like you'll need to add a few rods to make handlebars."
+	desc = "An unfinished scooter which can only barely be called a skateboard. It's still rideable, but probably unsafe. Looks like you'll need to add a few rods to make handlebars.Alt-click to adjust speed."
 	icon_state = "skateboard"
 	density = FALSE
 	var/adjusted_speed = FALSE

--- a/code/modules/vehicles/scooter.dm
+++ b/code/modules/vehicles/scooter.dm
@@ -44,11 +44,12 @@
 	desc = "An unfinished scooter which can only barely be called a skateboard. It's still rideable, but probably unsafe. Looks like you'll need to add a few rods to make handlebars."
 	icon_state = "skateboard"
 	density = FALSE
+	var/adjusted_speed = FALSE
 
 /obj/vehicle/ridden/scooter/skateboard/Initialize()
 	. = ..()
 	var/datum/component/riding/D = LoadComponent(/datum/component/riding)
-	D.vehicle_move_delay = 0
+	D.vehicle_move_delay = 1
 	D.set_vehicle_dir_layer(SOUTH, ABOVE_MOB_LAYER)
 	D.set_vehicle_dir_layer(NORTH, OBJ_LAYER)
 	D.set_vehicle_dir_layer(EAST, OBJ_LAYER)
@@ -91,6 +92,17 @@
 		var/obj/item/melee/skateboard/board = new /obj/item/melee/skateboard()
 		M.put_in_hands(board)
 		qdel(src)
+
+/obj/vehicle/ridden/scooter/skateboard/AltClick(mob/user)
+	var/datum/component/riding/R = src.GetComponent(/datum/component/riding)
+	if (!adjusted_speed)
+		R.vehicle_move_delay = 0
+		to_chat(user, "<span class='notice'>You adjust the wheels on [src] to make it go faster.</span>")
+		adjusted_speed = TRUE
+	else
+		R.vehicle_move_delay = 1
+		to_chat(user, "<span class='notice'>You adjust the wheels on [src] to make it go slower.</span>")
+		adjusted_speed = FALSE
 
 //CONSTRUCTION
 /obj/item/scooter_frame


### PR DESCRIPTION
:cl: Mickyan
balance: Skateboards can fit in backpacks
tweak: Skateboards are slower by default, speed can be adjusted by alt-clicking
/:cl:

Skateboards are fun but without even considering the bumping hazards they're almost impossible to use on station just because of how unreasonably fast they are. 
They're so fast, they couldn't be any faster. Literally! They have no move delay, making them as fast as a vehicle can possibly be.
But if you think you can handle it, you can simply adjust it back to sanic speed. Crashing penalties are unaffected.

I see no reason why they shouldn't fit in backpacks, maybe they used to be strong weapons a while ago but nowadays you can find stronger stuff just laying around that fit in backpacks just fine. 
Plenty of items bigger than a skateboard that already fit in backpacks, too. (i.e. instruments)