### PR TITLE
Fix link to rust-g repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ where the admin rank must be properly capitalised.
 This codebase also depends on a native library called rust-g. A precompiled
 Windows DLL is included in this repository, but Linux users will need to build
 and install it themselves. Directions can be found at the [rust-g
-repo](https://github.com/tgstation13/rust-g).
+repo](https://github.com/tgstation/rust-g).
 
 Finally, to start the server, run Dream Daemon and enter the path to your
 compiled tgstation.dmb file. Make sure to set the port to the one you


### PR DESCRIPTION
There was an erroneous github URL since merging #36858 (adding rust-g)