### PR TITLE
Fix bad vars in maps spilling over onto unrelated types

### DIFF
--- a/code/modules/mapping/reader.dm
+++ b/code/modules/mapping/reader.dm
@@ -496,12 +496,12 @@ GLOBAL_DATUM_INIT(_preloader, /datum/map_preloader, new)
 		target_path = path
 
 /datum/map_preloader/proc/load(atom/what)
+	GLOB.use_preloader = FALSE
 	for(var/attribute in attributes)
 		var/value = attributes[attribute]
 		if(islist(value))
 			value = deepCopyList(value)
 		what.vars[attribute] = value
-	GLOB.use_preloader = FALSE
 
 /area/template_noop
 	name = "Area Passthrough"


### PR DESCRIPTION
If any var doesn't exist, the `.vars[]=` assignment runtimes and `GLOB.use_preloader = FALSE` is never reached. The "bad var" runtime is then spammed for every single atom until something else populates the preloader.

The only proc called between the two locations is `deepCopyList` which calls only itself and `/list/Copy()`, and there are no `CHECK_TICK`s, so hopefully this should not have any other observable effects.