### PR TITLE
Various mapfixes

### DIFF
--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -31687,6 +31687,7 @@
 	},
 /area/security/checkpoint/customs)
 "bpu" = (
+/obj/structure/lattice,
 /turf/closed/wall/r_wall,
 /area/space/nearstation)
 "bpv" = (
@@ -76677,6 +76678,11 @@
 	dir = 8
 	},
 /area/science/circuit)
+"svg" = (
+/obj/structure/lattice,
+/obj/structure/girder/reinforced,
+/turf/open/space/basic,
+/area/space/nearstation)
 "szA" = (
 /turf/open/floor/plasteel/whitepurple/side{
 	dir = 8
@@ -123684,10 +123690,10 @@ anT
 anT
 anT
 anT
+aqB
 anT
-aaf
-aaa
-aaa
+fwb
+fwb
 aaf
 aaa
 aaa
@@ -123933,13 +123939,13 @@ bpu
 bpu
 bpu
 bpu
+svg
 bpu
 bpu
 bpu
 bpu
-bpu
-bpu
-aaa
+svg
+lMJ
 aaa
 aaa
 aaf
@@ -124196,9 +124202,9 @@ anT
 anT
 anT
 aqB
-aaf
-aaf
-aaf
+anT
+anT
+anT
 aaf
 aaa
 aaf

--- a/_maps/map_files/OmegaStation/OmegaStation.dmm
+++ b/_maps/map_files/OmegaStation/OmegaStation.dmm
@@ -13303,7 +13303,7 @@
 	name = "Atmospherics Lockdown Control";
 	pixel_x = 24;
 	pixel_y = -24;
-	req_access_txt = "25"
+	req_access_txt = "24"
 	},
 /turf/open/floor/plasteel/caution,
 /area/engine/atmos)

--- a/_maps/map_files/PubbyStation/PubbyStation.dmm
+++ b/_maps/map_files/PubbyStation/PubbyStation.dmm
@@ -15193,6 +15193,14 @@
 /obj/structure/disposalpipe/trunk{
 	dir = 4
 	},
+/obj/machinery/door/window/westleft,
+/obj/structure/window/reinforced,
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/structure/window/reinforced{
+	dir = 4
+	},
 /turf/open/floor/plating,
 /area/maintenance/disposal)
 "aNY" = (
@@ -15610,10 +15618,6 @@
 /turf/open/floor/plating,
 /area/maintenance/department/cargo)
 "aPg" = (
-/obj/machinery/conveyor{
-	dir = 8;
-	id = "garbage"
-	},
 /obj/structure/disposaloutlet{
 	dir = 4
 	},
@@ -15627,11 +15631,8 @@
 /area/maintenance/disposal)
 "aPh" = (
 /obj/machinery/conveyor{
-	dir = 8;
+	dir = 4;
 	id = "garbage"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 10
 	},
 /turf/open/floor/plating,
 /area/maintenance/disposal)
@@ -15952,7 +15953,7 @@
 	dir = 8
 	},
 /obj/machinery/conveyor{
-	dir = 2;
+	dir = 1;
 	id = "garbage"
 	},
 /turf/open/floor/plating,
@@ -16997,8 +16998,7 @@
 	},
 /area/maintenance/department/crew_quarters/bar)
 "aSN" = (
-/obj/item/assembly/mousetrap,
-/obj/item/storage/box/mousetraps,
+/obj/structure/reagent_dispensers/beerkeg,
 /turf/open/floor/wood{
 	icon_state = "wood-broken6"
 	},
@@ -17016,6 +17016,8 @@
 "aSQ" = (
 /obj/effect/landmark/xeno_spawn,
 /obj/item/storage/box/beanbag,
+/obj/item/assembly/mousetrap,
+/obj/item/storage/box/mousetraps,
 /turf/open/floor/wood,
 /area/crew_quarters/bar)
 "aSR" = (
@@ -17550,10 +17552,6 @@
 	dir = 8
 	},
 /area/maintenance/department/crew_quarters/bar)
-"aUc" = (
-/obj/structure/reagent_dispensers/beerkeg,
-/turf/open/floor/wood,
-/area/crew_quarters/bar)
 "aUd" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -32192,6 +32190,14 @@
 	dir = 5
 	},
 /area/science/mixing)
+"bFq" = (
+/obj/machinery/door/airlock/maintenance{
+	req_access_txt = "12"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/plating,
+/area/maintenance/department/engine)
 "bFr" = (
 /turf/open/floor/plasteel/purple/side{
 	dir = 1
@@ -45855,11 +45861,11 @@
 /turf/open/floor/plasteel/dark,
 /area/chapel/main/monastery)
 "cvf" = (
+/obj/machinery/recycler,
 /obj/machinery/conveyor{
-	dir = 8;
+	dir = 4;
 	id = "garbage"
 	},
-/obj/machinery/recycler,
 /turf/open/floor/plating,
 /area/maintenance/disposal)
 "cvg" = (
@@ -47515,7 +47521,7 @@
 /area/hallway/secondary/exit/departure_lounge)
 "dqY" = (
 /obj/machinery/conveyor{
-	dir = 4;
+	dir = 8;
 	id = "garbage"
 	},
 /turf/open/floor/plating,
@@ -51955,9 +51961,10 @@
 "qEN" = (
 /obj/machinery/rnd/production/techfab/department/service,
 /obj/structure/window/reinforced{
-	dir = 8
+	dir = 8;
+	pixel_x = -4
 	},
-/turf/closed/wall,
+/turf/open/floor/plasteel/dark,
 /area/crew_quarters/bar)
 "qFu" = (
 /obj/machinery/power/port_gen/pacman,
@@ -52151,7 +52158,7 @@
 /area/medical/sleeper)
 "rax" = (
 /obj/machinery/conveyor{
-	dir = 2;
+	dir = 1;
 	id = "garbage"
 	},
 /turf/open/floor/plating,
@@ -84710,7 +84717,7 @@ aPE
 aQS
 aRQ
 aSN
-aUc
+aPE
 aPE
 aWd
 aXb
@@ -87057,7 +87064,7 @@ tTl
 dgg
 phJ
 phJ
-xje
+bFq
 bAk
 bIt
 bJB

--- a/code/modules/reagents/chemistry/machinery/chem_dispenser.dm
+++ b/code/modules/reagents/chemistry/machinery/chem_dispenser.dm
@@ -534,6 +534,8 @@
 /obj/machinery/chem_dispenser/mutagensaltpeter
 	name = "botanical chemical dispenser"
 	desc = "Creates and dispenses chemicals useful for botany."
+	flags_1 = NODECONSTRUCT_1
+
 	dispensable_reagents = list(
 		"mutagen",
 		"saltpetre",
@@ -548,6 +550,18 @@
 		"ammonia",
 		"ash",
 		"diethylamine")
+	
+/obj/machinery/chem_dispenser/mutagensaltpeter/Initialize()
+	. = ..()
+	component_parts = list()
+	component_parts += new /obj/item/circuitboard/machine/chem_dispenser(null)
+	component_parts += new /obj/item/stock_parts/matter_bin/bluespace(null)
+	component_parts += new /obj/item/stock_parts/matter_bin/bluespace(null)
+	component_parts += new /obj/item/stock_parts/capacitor/quadratic(null)
+	component_parts += new /obj/item/stock_parts/manipulator/femto(null)
+	component_parts += new /obj/item/stack/sheet/glass(null)
+	component_parts += new /obj/item/stock_parts/cell/bluespace(null)
+	RefreshParts()
 
 /obj/machinery/chem_dispenser/fullupgrade //fully ugpraded stock parts, emagged
 	desc = "Creates and dispenses chemicals. This model has had its safeties shorted out."


### PR DESCRIPTION
:cl: Denton
fix: Omegastation's Atmospherics lockdown button now has the proper access reqs.
fix: Pubbystation's disposals conveyor belts now face the correct direction.
fix: Pubby's service techfab is no longer stuck inside a wall.
fix: Pubby's disposal loop is no longer broken.
tweak: The Lavaland seed vault chem dispenser now has upgraded stock parts.
tweak: Metastation: Extended protective grilles to partially cover the Supermatter cooling loop.
/:cl:
Fixes: #36972 #37034 #39380 #39453 #39482 

put the GBP in the bag and nobody gets hurt

- Omega atmos lockdown button no longer has bar access reqs
- Pubby disposals conveyors now have the correct dirs
- Pubby's service techfab is no longer inside a wall
- Pubby's disposals loop is no longer cut off near the RD office
- Lavaland seed vault chem dispenser now initializes with upgraded parts (since those planty bastards are stuck in there and can't even upgrade/charge it etc)
- Meta's SME cooling loop now has grilles that partially cover it. Nothing that will stop a meteorite, but probably the odd space dust