### PR TITLE
[dnm] [s] Completely blocks middle click aimbot

### DIFF
--- a/code/modules/client/client_procs.dm
+++ b/code/modules/client/client_procs.dm
@@ -706,7 +706,10 @@ GLOBAL_LIST_EMPTY(external_rsc_urls)
 		if (clicklimiter[SECOND_COUNT] > scl)
 			to_chat(src, "<span class='danger'>Your previous click was ignored because you've done too many in a second</span>")
 			return
-
+	
+	if (ab)
+		return
+	
 	if (prefs.hotkeys)
 		// If hotkey mode is enabled, then clicking the map will automatically
 		// unfocus the text bar. This removes the red color from the text bar


### PR DESCRIPTION
Why: Blocks the aimbot exploit, as right now it's still very abusable as long as you are careful enough to not trigger the warning by doing more than 3 clicks with it, but often times all you need is one click. There's really no good reason you would need to middleclickdrag things while leftclicking them.