### PR TITLE
Zombie Organ now does toxin damage!

### DIFF
--- a/code/modules/admin/verbs/randomverbs.dm
+++ b/code/modules/admin/verbs/randomverbs.dm
@@ -1117,7 +1117,7 @@ GLOBAL_LIST_EMPTY(custom_outfits) //Admin created outfits
 		return
 
 	for(var/mob/living/carbon/human/H in GLOB.carbon_list)
-		new /obj/item/organ/zombie_infection(H)
+		new /obj/item/organ/zombie_infection/nodamage(H)
 
 	message_admins("[key_name_admin(usr)] added a latent zombie infection to all humans.")
 	log_admin("[key_name(usr)] added a latent zombie infection to all humans.")
@@ -1134,7 +1134,7 @@ GLOBAL_LIST_EMPTY(custom_outfits) //Admin created outfits
 	if(confirm != "Yes")
 		return
 
-	for(var/obj/item/organ/zombie_infection/I in GLOB.zombie_infection_list)
+	for(var/obj/item/organ/zombie_infection/nodamage/I in GLOB.zombie_infection_list)
 		qdel(I)
 
 	message_admins("[key_name_admin(usr)] cured all zombies.")

--- a/code/modules/reagents/chemistry/reagents/other_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/other_reagents.dm
@@ -1665,7 +1665,7 @@
 /datum/reagent/romerol/reaction_mob(mob/living/carbon/human/H, method=TOUCH, reac_volume)
 	// Silently add the zombie infection organ to be activated upon death
 	if(!H.getorganslot(ORGAN_SLOT_ZOMBIE))
-		var/obj/item/organ/zombie_infection/ZI = new()
+		var/obj/item/organ/zombie_infection/nodamage/ZI = new()
 		ZI.Insert(H)
 	..()
 

--- a/code/modules/zombie/organs.dm
+++ b/code/modules/zombie/organs.dm
@@ -46,8 +46,8 @@
 		Remove(owner)
 	if (!iszombie(owner) && owner.stat != DEAD)
 		owner.adjustToxLoss(1)
-	if (prob(10))
-		to_chat(owner, "<span class='danger'>You feel sick...</span>")
+		if (prob(10))
+			to_chat(owner, "<span class='danger'>You feel sick...</span>")
 	if(timer_id)
 		return
 	if(owner.suiciding)

--- a/code/modules/zombie/organs.dm
+++ b/code/modules/zombie/organs.dm
@@ -4,6 +4,7 @@
 	zone = BODY_ZONE_HEAD
 	slot = ORGAN_SLOT_ZOMBIE
 	icon_state = "blacktumor"
+	var/causes_damage = TRUE
 	var/datum/species/old_species = /datum/species/human
 	var/living_transformation_time = 30
 	var/converts_living = FALSE
@@ -44,7 +45,7 @@
 		return
 	if(!(src in owner.internal_organs))
 		Remove(owner)
-	if (!iszombie(owner) && owner.stat != DEAD)
+	if (causes_damage && !iszombie(owner) && owner.stat != DEAD)
 		owner.adjustToxLoss(1)
 		if (prob(10))
 			to_chat(owner, "<span class='danger'>You feel sick...</span>")
@@ -69,7 +70,7 @@
 
 	if(!converts_living && owner.stat != DEAD)
 		return
-	
+
 	if(!iszombie(owner))
 		old_species = owner.dna.species.type
 		owner.set_species(/datum/species/zombie/infectious)
@@ -80,7 +81,7 @@
 	owner.setToxLoss(0, 0)
 	owner.setOxyLoss(0, 0)
 	owner.heal_overall_damage(INFINITY, INFINITY, INFINITY, FALSE, FALSE, TRUE)
-	
+
 	if(!owner.revive())
 		return
 
@@ -90,3 +91,6 @@
 	owner.do_jitter_animation(living_transformation_time)
 	owner.Stun(living_transformation_time)
 	to_chat(owner, "<span class='alertalien'>You are now a zombie!</span>")
+
+/obj/item/organ/zombie_infection/nodamage
+	causes_damage = FALSE

--- a/code/modules/zombie/organs.dm
+++ b/code/modules/zombie/organs.dm
@@ -47,7 +47,7 @@
 	if (!iszombie(owner) && owner.stat != DEAD)
 		owner.adjustToxLoss(1)
 	if (prob(10))
-		to_chat(owner, "<span class='danger'>You feel sick.</span>")
+		to_chat(owner, "<span class='danger'>You feel sick...</span>")
 	if(timer_id)
 		return
 	if(owner.suiciding)

--- a/code/modules/zombie/organs.dm
+++ b/code/modules/zombie/organs.dm
@@ -44,7 +44,10 @@
 		return
 	if(!(src in owner.internal_organs))
 		Remove(owner)
-
+	if (!iszombie(owner) && owner.stat != DEAD)
+		owner.adjustToxLoss(1)
+	if (prob(10))
+		to_chat(owner, "<span class='danger'>You feel sick.</span>")
 	if(timer_id)
 		return
 	if(owner.suiciding)


### PR DESCRIPTION
🆑 fluffe9911 and with a ton of help from Macelarius
add: Zombie organs not created by romerol now do toxin damage
🆑
Reason I did this is cause right now theirs really not much of a reason to remove the zombie organ from a living person this now adds a time limit to that by making the zombie organ slowly kill whoever has this can be delayed by using charcoal or antitox but you must remove the organ (or turn into a zombie) for the tox damage to really go away
