### PR TITLE
Fixes SDQL strings

### DIFF
--- a/code/modules/admin/verbs/SDQL2/SDQL_2.dm
+++ b/code/modules/admin/verbs/SDQL2/SDQL_2.dm
@@ -196,9 +196,10 @@
 
 
 /proc/SDQL_testout(list/query_tree, indent = 0)
+	var/static/whitespace = "&nbsp;&nbsp;&nbsp; "
 	var/spaces = ""
 	for(var/s = 0, s < indent, s++)
-		spaces += "    "
+		spaces += whitespace
 
 	for(var/item in query_tree)
 		if(istype(item, /list))
@@ -212,12 +213,12 @@
 		if(!isnum(item) && query_tree[item])
 
 			if(istype(query_tree[item], /list))
-				to_chat(usr, "[spaces]    (")
+				to_chat(usr, "[spaces][whitespace](")
 				SDQL_testout(query_tree[item], indent + 2)
-				to_chat(usr, "[spaces]    )")
+				to_chat(usr, "[spaces][whitespace])")
 
 			else
-				to_chat(usr, "[spaces]    [query_tree[item]]")
+				to_chat(usr, "[spaces][whitespace][query_tree[item]]")
 
 
 

--- a/code/modules/admin/verbs/SDQL2/SDQL_2_parser.dm
+++ b/code/modules/admin/verbs/SDQL2/SDQL_2_parser.dm
@@ -331,7 +331,7 @@
 //string:	''' <some text> ''' | '"' <some text > '"'
 /datum/SDQL_parser/proc/string(i, list/node)
 	if(copytext(token(i), 1, 2) in list("'", "\""))
-		node += copytext(token(i),2,-1)
+		node += token(i)
 	else
 		parse_error("Expected string but found '[token(i)]'")
 	return i + 1


### PR DESCRIPTION
This is done by partially reverting commit 503a8a3557b135707b2c746e7bb5a6f023a36838 (#13960)
Also fixed EXPLAIN not working well with goonchat

:cl: JJRcop
fix: Fixed some strange string handling in SDQL
/:cl:

This solution was the first one I thought of, but I immediately dismissed it at first. It doesn't appear that there are any problems with this.

Fixes #23710, which was caused by SDQL expecting unescaped " or ' to be included in strings, as according to the SDQL spec
https://github.com/tgstation/tgstation/blob/5ab7990313dec47d5cfb7e0a52040d5bbdd74a7e/code/modules/admin/verbs/SDQL2/SDQL_2.dm#L369-L370

I did some testing to make sure I didn't cause #4943 to resurface (the bug that resulted in #13960), and it looks like we're all clear.

Now it actually matches the spec! (??? it probably doesn't in whole i dunno, but at least the string part does)
https://github.com/tgstation/tgstation/blob/5ab7990313dec47d5cfb7e0a52040d5bbdd74a7e/code/modules/admin/verbs/SDQL2/SDQL_2_parser.dm#L42