### PR TITLE
Gives melee simple animal syndicate 30% dodge and doubled attack rate.

### DIFF
--- a/code/modules/mob/living/simple_animal/hostile/syndicate.dm
+++ b/code/modules/mob/living/simple_animal/hostile/syndicate.dm
@@ -46,7 +46,7 @@
 	check_friendly_fire = 1
 	status_flags = CANPUSH
 	del_on_death = 1
-	dodging = 1
+	dodging = TRUE
 	rapid_melee = 2
 
 ///////////////Melee////////////
@@ -172,7 +172,7 @@
 	casingtype = /obj/item/ammo_casing/c10mm
 	projectilesound = 'sound/weapons/gunshot.ogg'
 	loot = list(/obj/effect/gibspawner/human)
-	dodging = 0
+	dodging = FALSE
 	rapid_melee = 1
 
 /mob/living/simple_animal/hostile/syndicate/ranged/infiltrator //shuttle loan event

--- a/code/modules/mob/living/simple_animal/hostile/syndicate.dm
+++ b/code/modules/mob/living/simple_animal/hostile/syndicate.dm
@@ -1,9 +1,9 @@
 /*
 	CONTENTS
 	LINE 10  - BASE MOB
-	LINE 50  - SWORD AND SHIELD
-	LINE 95  - GUNS
-	LINE 136 - MISC
+	LINE 52  - SWORD AND SHIELD
+	LINE 164 - GUNS
+	LINE 267 - MISC
 */
 
 
@@ -46,6 +46,8 @@
 	check_friendly_fire = 1
 	status_flags = CANPUSH
 	del_on_death = 1
+	dodging = 1
+	rapid_melee = 2
 
 ///////////////Melee////////////
 
@@ -170,6 +172,8 @@
 	casingtype = /obj/item/ammo_casing/c10mm
 	projectilesound = 'sound/weapons/gunshot.ogg'
 	loot = list(/obj/effect/gibspawner/human)
+	dodging = 0
+	rapid_melee = 1
 
 /mob/living/simple_animal/hostile/syndicate/ranged/infiltrator //shuttle loan event
 	projectilesound = 'sound/weapons/gunshot_silenced.ogg'


### PR DESCRIPTION
This ONLY applies to the melee types. Ranged versions remain predictable and slow to hit in melee. This change came around because melee syndies are frankly really weak.

:cl: WJohnston
balance: Syndicate (melee) simple animals will now move less predictably and attack twice as often, hopefully making them quite a bit more dangerous.
/:cl: