### PR TITLE
Moves the Stealth Implant from Cybernetic Implants to Normal Implants

### DIFF
--- a/code/modules/uplink/uplink_items.dm
+++ b/code/modules/uplink/uplink_items.dm
@@ -1293,6 +1293,12 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 	cost = 4
 	restricted = TRUE
 
+/datum/uplink_item/implants/stealthimplant
+	name = "Stealth Implant"
+	desc = "This one-of-a-kind implant will make you almost invisible if you play your cards right."
+	item = /obj/item/implanter/stealth
+	cost = 8
+
 // Cybernetics
 /datum/uplink_item/cyber_implants
 	category = "Cybernetic Implants"

--- a/code/modules/uplink/uplink_items.dm
+++ b/code/modules/uplink/uplink_items.dm
@@ -1336,12 +1336,6 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 	cost = 40
 	cant_discount = TRUE
 
-/datum/uplink_item/cyber_implants/stealthimplant
-	name = "Stealth Implant"
-	desc = "This one-of-a-kind implant will make you almost invisible if you play your cards right."
-	item = /obj/item/implanter/stealth
-	cost = 8
-
 // Role-specific items
 /datum/uplink_item/role_restricted
 	category = "Role-Restricted"


### PR DESCRIPTION
Going by this exchange on the forums, it would seem that bman intended this to be available to all traitors, and that it being put under cybernetic implants was a mistake from not testing the implant out properly.
https://tgstation13.org/phpBB/viewtopic.php?f=10&t=18951#p431202

I've corrected this mistake.
:cl: Iamgoofball
tweak: The Stealth Implant was mistakenly made nuclear operatives only due to a misunderstanding of the code. This has been fixed.
/:cl: