### PR TITLE
Redesigns the pirate event ship

### DIFF
--- a/_maps/shuttles/pirate_default.dmm
+++ b/_maps/shuttles/pirate_default.dmm
@@ -203,6 +203,9 @@
 	pixel_x = -2;
 	pixel_y = 2
 	},
+/obj/structure/sign/poster/contraband/revolver{
+	pixel_x = 32
+	},
 /turf/open/floor/pod/light,
 /area/shuttle/pirate)
 "as" = (
@@ -269,11 +272,11 @@
 /area/shuttle/pirate)
 "aw" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/sign/poster/contraband/revolver{
-	pixel_x = -32
-	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
 	dir = 8
+	},
+/obj/machinery/vending/wallmed{
+	pixel_x = -28
 	},
 /turf/open/floor/pod/dark,
 /area/shuttle/pirate)

--- a/_maps/shuttles/pirate_default.dmm
+++ b/_maps/shuttles/pirate_default.dmm
@@ -1,43 +1,67 @@
 //MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
 "aa" = (
-/turf/template_noop,
-/area/template_noop)
-"ab" = (
-/obj/machinery/door/poddoor/shutters/preopen{
-	id = "piratebridge"
+/obj/structure/chair/comfy/shuttle{
+	dir = 1
 	},
-/obj/structure/grille,
-/obj/structure/window/plastitanium,
-/turf/open/floor/plating,
+/obj/machinery/light/small{
+	dir = 8
+	},
+/obj/machinery/airalarm/all_access{
+	dir = 4;
+	pixel_x = -24
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on,
+/obj/machinery/atmospherics/components/unary/vent_pump/on,
+/turf/open/floor/pod/dark,
+/area/shuttle/pirate)
+"ab" = (
+/obj/structure/table,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/recharger{
+	pixel_x = 4
+	},
+/obj/item/grenade/smokebomb{
+	pixel_x = -6;
+	pixel_y = 10
+	},
+/obj/item/grenade/smokebomb{
+	pixel_x = -6
+	},
+/turf/open/floor/plasteel/darkred/side{
+	dir = 10
+	},
 /area/shuttle/pirate)
 "ac" = (
-/obj/structure/table,
-/obj/machinery/recharger,
+/obj/machinery/computer/shuttle/pirate,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/dark,
+/turf/open/floor/plasteel/darkred/side,
 /area/shuttle/pirate)
 "ad" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/computer/shuttle/pirate,
-/turf/open/floor/plasteel/dark,
-/area/shuttle/pirate)
-"ae" = (
 /obj/structure/table,
 /obj/machinery/button/door{
 	id = "piratebridge";
 	name = "Bridge Shutters Control";
 	pixel_y = -5
 	},
-/obj/effect/decal/cleanable/dirt,
 /obj/item/radio/intercom{
 	pixel_y = 5
 	},
-/turf/open/floor/plasteel/dark,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/darkred/side{
+	dir = 6
+	},
+/area/shuttle/pirate)
+"ae" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/darkred/corner{
+	dir = 1
+	},
 /area/shuttle/pirate)
 "af" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/dark,
-/area/shuttle/pirate)
+/turf/template_noop,
+/area/template_noop)
 "ag" = (
 /obj/structure/chair/comfy/shuttle{
 	dir = 1
@@ -46,730 +70,108 @@
 /area/shuttle/pirate)
 "ah" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/computer/monitor/secret{
-	dir = 8
+/turf/open/floor/plasteel/darkred/corner{
+	dir = 4
 	},
-/turf/open/floor/plasteel/dark,
 /area/shuttle/pirate)
 "ai" = (
-/turf/closed/wall/mineral/plastitanium,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/table,
+/obj/machinery/microwave{
+	pixel_y = 5
+	},
+/obj/item/book/manual/wiki/barman_recipes{
+	pixel_x = -8
+	},
+/turf/open/floor/plasteel/bar,
 /area/shuttle/pirate)
 "aj" = (
 /turf/closed/wall/mineral/plastitanium/nodiagonal,
 /area/shuttle/pirate)
 "ak" = (
-/obj/machinery/light/small,
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/shuttle_scrambler,
-/turf/open/floor/plasteel/dark,
+/obj/structure/table,
+/obj/item/storage/fancy/cigarettes{
+	pixel_x = 2;
+	pixel_y = 6
+	},
+/obj/item/storage/fancy/cigarettes/cigpack_carp{
+	pixel_x = 10;
+	pixel_y = 6
+	},
+/obj/item/storage/fancy/cigarettes/cigpack_robust{
+	pixel_x = 2
+	},
+/obj/item/storage/fancy/cigarettes/cigpack_midori{
+	pixel_x = 10
+	},
+/obj/item/storage/fancy/cigarettes/cigpack_shadyjims{
+	pixel_x = 2;
+	pixel_y = -6
+	},
+/obj/item/storage/fancy/cigarettes/cigpack_uplift{
+	pixel_x = 10;
+	pixel_y = -6
+	},
+/obj/item/lighter{
+	pixel_x = -14;
+	pixel_y = -6
+	},
+/turf/open/floor/plasteel/bar,
 /area/shuttle/pirate)
 "al" = (
-/obj/machinery/airalarm{
-	dir = 1;
-	pixel_y = -24;
-	req_access = null
-	},
-/obj/structure/chair/comfy/shuttle{
-	dir = 8
-	},
+/obj/machinery/loot_locator,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/dark,
+/turf/open/floor/plasteel/darkred/side{
+	dir = 9
+	},
 /area/shuttle/pirate)
 "am" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on,
-/turf/open/floor/plasteel/dark,
+/turf/open/floor/plasteel/vault{
+	dir = 5
+	},
 /area/shuttle/pirate)
 "an" = (
 /obj/structure/chair/comfy/shuttle{
 	dir = 4
 	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/dark,
-/area/shuttle/pirate)
-"ao" = (
-/obj/machinery/light/small,
-/obj/machinery/computer/camera_advanced/shuttle_docker/syndicate/pirate{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
-/area/shuttle/pirate)
-"ap" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/mob_spawn/human/pirate{
-	dir = 4
-	},
-/turf/open/floor/plasteel/dark,
-/area/shuttle/pirate)
-"aq" = (
-/obj/machinery/light/small{
-	dir = 1
-	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on,
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/airalarm{
-	pixel_y = 24;
-	req_access = null
-	},
-/turf/open/floor/plasteel/dark,
-/area/shuttle/pirate)
-"ar" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/mob_spawn/human/pirate/gunner{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
-/area/shuttle/pirate)
-"as" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/machinery/door/airlock/command{
-	name = "Bridge"
-	},
-/turf/open/floor/plasteel/dark,
-/area/shuttle/pirate)
-"at" = (
-/obj/structure/closet/crate/freezer/blood,
-/obj/effect/turf_decal/bot,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/white,
-/area/shuttle/pirate)
-"au" = (
-/obj/machinery/light/small{
-	dir = 1
-	},
-/obj/machinery/airalarm{
-	pixel_y = 24;
-	req_access = null
-	},
-/obj/machinery/sleeper,
-/obj/effect/turf_decal/delivery,
-/turf/open/floor/plasteel/white,
-/area/shuttle/pirate)
-"av" = (
-/obj/machinery/iv_drip,
-/obj/effect/turf_decal/bot,
-/turf/open/floor/plasteel/white,
-/area/shuttle/pirate)
-"aw" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/mob_spawn/human/pirate/captain,
-/turf/open/floor/wood,
-/area/shuttle/pirate)
-"ax" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/door/airlock{
-	name = "Crew Cabin"
-	},
-/turf/open/floor/plasteel/dark,
-/area/shuttle/pirate)
-"ay" = (
-/obj/machinery/light/small{
-	dir = 1
-	},
-/obj/structure/table,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/item/storage/toolbox/emergency,
-/obj/item/extinguisher,
-/turf/open/floor/plasteel/dark,
-/area/shuttle/pirate)
-"az" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/dark,
-/area/shuttle/pirate)
-"aA" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/turf/open/floor/plasteel/dark,
-/area/shuttle/pirate)
-"aB" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/airalarm{
-	pixel_y = 24;
-	req_access = null
-	},
-/turf/open/floor/plasteel/dark,
-/area/shuttle/pirate)
-"aC" = (
-/obj/machinery/light/small{
-	dir = 1
-	},
-/obj/structure/table,
-/obj/effect/decal/cleanable/dirt,
-/obj/item/paper_bin{
-	pixel_x = -1;
-	pixel_y = 6
-	},
-/obj/item/folder,
-/obj/item/pen,
-/turf/open/floor/plasteel/dark,
-/area/shuttle/pirate)
-"aD" = (
-/obj/structure/sign/departments/medbay/alt,
-/turf/closed/wall/mineral/plastitanium/nodiagonal,
-/area/shuttle/pirate)
-"aE" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/white/side{
-	dir = 9
-	},
-/area/shuttle/pirate)
-"aF" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/white/side{
-	dir = 1
-	},
-/area/shuttle/pirate)
-"aG" = (
-/turf/open/floor/plasteel/white/side{
-	dir = 1
-	},
-/area/shuttle/pirate)
-"aH" = (
-/obj/structure/closet/crate/freezer/surplus_limbs,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/white/side{
-	dir = 1
-	},
-/area/shuttle/pirate)
-"aI" = (
-/obj/structure/table,
-/obj/item/clothing/gloves/color/latex,
-/obj/item/surgical_drapes,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/white/side{
-	dir = 5
-	},
-/area/shuttle/pirate)
-"aJ" = (
-/obj/machinery/light/small{
-	brightness = 3;
-	dir = 8
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/airalarm{
-	dir = 4;
-	pixel_x = -24;
-	req_access = null
-	},
-/obj/structure/closet/secure_closet/personal,
-/turf/open/floor/wood,
-/area/shuttle/pirate)
-"aK" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
-	dir = 4
-	},
-/turf/open/floor/wood,
-/area/shuttle/pirate)
-"aL" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/door/airlock{
-	name = "Captain's Quarters"
-	},
-/turf/open/floor/wood,
-/area/shuttle/pirate)
-"aM" = (
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	dir = 1
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/airalarm{
-	pixel_y = 24;
-	req_access = null
-	},
-/turf/open/floor/plasteel/floorgrime,
-/area/shuttle/pirate)
-"aN" = (
-/obj/machinery/atmospherics/pipe/manifold4w/supply/hidden,
-/turf/open/floor/plasteel/floorgrime,
-/area/shuttle/pirate)
-"aO" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel,
-/area/shuttle/pirate)
-"aP" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/door/airlock/command{
-	name = "Bridge"
-	},
-/turf/open/floor/plasteel/dark,
-/area/shuttle/pirate)
-"aQ" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/dark,
-/area/shuttle/pirate)
-"aR" = (
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden,
-/turf/open/floor/plasteel/dark,
-/area/shuttle/pirate)
-"aS" = (
-/obj/machinery/atmospherics/pipe/manifold4w/supply/hidden,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/dark,
-/area/shuttle/pirate)
-"aT" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/turf/open/floor/plasteel/dark,
-/area/shuttle/pirate)
-"aU" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/obj/machinery/door/airlock/command{
-	name = "Bridge"
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/dark,
-/area/shuttle/pirate)
-"aV" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/white/side{
-	dir = 8
-	},
-/area/shuttle/pirate)
-"aW" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/shuttle/pirate)
-"aX" = (
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	dir = 1
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel,
-/area/shuttle/pirate)
-"aY" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
-	dir = 8
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel,
-/area/shuttle/pirate)
-"aZ" = (
-/turf/open/floor/plasteel/white/side{
-	dir = 4
-	},
-/area/shuttle/pirate)
-"ba" = (
-/obj/structure/table,
-/obj/item/circular_saw,
-/obj/item/scalpel{
-	pixel_y = 12
-	},
-/obj/item/cautery{
-	pixel_x = 4
-	},
-/obj/machinery/light/small{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/white,
-/area/shuttle/pirate)
-"bb" = (
-/obj/structure/table/wood,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/item/storage/box/matches,
-/obj/item/clothing/mask/cigarette/cigar,
-/obj/item/reagent_containers/food/drinks/bottle/rum{
-	name = "Captain Pete's Private Reserve Cuban Spaced Rum";
-	pixel_x = -6;
-	pixel_y = 8
-	},
-/turf/open/floor/wood,
-/area/shuttle/pirate)
-"bc" = (
 /obj/machinery/button/door{
-	id = "piratevault";
-	name = "Vault Bolt Control";
+	id = "piratebridgebolt";
+	name = "Bridge Bolt Control";
 	normaldoorcontrol = 1;
-	pixel_x = -8;
 	pixel_y = -24;
 	specialfunctions = 4
 	},
-/obj/machinery/turretid{
-	icon_state = "control_kill";
-	lethal = 1;
-	locked = 0;
-	pixel_x = 4;
-	pixel_y = -24;
-	req_access = null
-	},
+/turf/open/floor/plasteel/darkred/corner,
+/area/shuttle/pirate)
+"ao" = (
 /obj/structure/chair/comfy/shuttle{
-	dir = 8
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/wood,
-/area/shuttle/pirate)
-"bd" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel,
-/area/shuttle/pirate)
-"be" = (
-/obj/machinery/light/small,
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 1
 	},
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/closet/secure_closet/personal,
-/turf/open/floor/plasteel/floorgrime,
-/area/shuttle/pirate)
-"bf" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/closet/secure_closet/personal,
-/turf/open/floor/plasteel/floorgrime,
-/area/shuttle/pirate)
-"bg" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/effect/mapping_helpers/airlock/locked,
-/obj/machinery/door/airlock/vault{
-	id_tag = "piratevault";
-	name = "Vault"
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/pod/dark,
-/area/shuttle/pirate)
-"bh" = (
-/obj/structure/table,
-/obj/item/storage/firstaid/brute{
-	pixel_x = 3;
-	pixel_y = 3
-	},
-/obj/item/storage/firstaid/fire,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/white/side{
-	dir = 10
-	},
-/area/shuttle/pirate)
-"bi" = (
-/obj/machinery/light/small,
-/obj/structure/table,
-/obj/item/storage/box/syringes,
-/obj/item/reagent_containers/glass/beaker{
-	pixel_x = -3;
-	pixel_y = 3
-	},
-/obj/item/reagent_containers/glass/beaker{
-	pixel_x = 3
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/white/side,
-/area/shuttle/pirate)
-"bj" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/turf/open/floor/plasteel/white/side,
-/area/shuttle/pirate)
-"bk" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/white/side,
-/area/shuttle/pirate)
-"bl" = (
-/obj/structure/table/optable,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/white/side{
-	dir = 6
-	},
-/area/shuttle/pirate)
-"bm" = (
-/obj/structure/table,
-/obj/item/retractor,
-/obj/item/hemostat,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/white,
-/area/shuttle/pirate)
-"bn" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/door/airlock{
-	name = "Crew Quarters"
-	},
-/turf/open/floor/plasteel,
-/area/shuttle/pirate)
-"bo" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/pod/dark,
-/area/shuttle/pirate/vault)
-"bp" = (
-/obj/machinery/airalarm{
-	pixel_y = 24;
-	req_access = null
-	},
-/turf/open/floor/pod/dark,
-/area/shuttle/pirate/vault)
-"bq" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/turf/open/floor/pod/dark,
-/area/shuttle/pirate/vault)
-"br" = (
-/obj/structure/extinguisher_cabinet{
-	pixel_y = 28
-	},
-/turf/open/floor/pod/dark,
-/area/shuttle/pirate/vault)
-"bs" = (
-/obj/machinery/door/airlock/medical/glass{
-	name = "Medbay"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/turf/open/floor/plasteel,
-/area/shuttle/pirate)
-"bt" = (
-/obj/structure/sign/warning/vacuum/external{
-	pixel_x = -32
-	},
-/obj/machinery/light/small{
-	dir = 1
-	},
-/obj/machinery/suit_storage_unit/pirate,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating,
-/area/shuttle/pirate)
-"bu" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/floorgrime,
-/area/shuttle/pirate)
-"bv" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/turf/open/floor/plasteel/floorgrime,
-/area/shuttle/pirate)
-"bw" = (
-/obj/structure/rack{
-	dir = 8;
-	layer = 2.9
-	},
-/obj/item/storage/belt/utility,
-/obj/item/radio/off,
-/obj/item/radio/off,
-/turf/open/floor/plasteel,
-/area/shuttle/pirate)
-"bx" = (
-/obj/structure/closet/crate,
-/obj/item/grenade/smokebomb{
-	pixel_x = -4
-	},
-/obj/item/grenade/smokebomb{
-	pixel_x = 2
-	},
-/turf/open/floor/pod/light,
-/area/shuttle/pirate/vault)
-"by" = (
-/obj/structure/rack{
-	dir = 8;
-	layer = 2.9
-	},
-/obj/item/shield/riot{
-	pixel_x = -3;
-	pixel_y = 3
-	},
-/obj/item/shield/riot,
-/turf/open/floor/pod/light,
-/area/shuttle/pirate/vault)
-"bz" = (
-/obj/structure/rack{
-	dir = 8;
-	layer = 2.9
-	},
-/obj/item/gun/energy/laser{
-	pixel_x = -3;
-	pixel_y = 3
-	},
-/obj/item/gun/energy/laser,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/pod/light,
-/area/shuttle/pirate/vault)
-"bA" = (
-/obj/structure/closet/crate,
-/obj/item/storage/bag/money,
-/turf/open/floor/pod/light,
-/area/shuttle/pirate/vault)
-"bB" = (
-/obj/structure/rack{
-	dir = 8;
-	layer = 2.9
-	},
-/obj/item/storage/belt/utility,
-/obj/item/radio/off,
-/obj/item/radio/off,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/floorgrime,
-/area/shuttle/pirate)
-"bC" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/turf/open/floor/plasteel,
-/area/shuttle/pirate)
-"bD" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/space_heater,
-/turf/open/floor/plasteel,
-/area/shuttle/pirate)
-"bE" = (
-/obj/structure/sign/warning/vacuum/external{
-	pixel_x = 32
-	},
-/obj/machinery/light/small{
-	dir = 1
-	},
-/obj/machinery/suit_storage_unit/pirate,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating,
-/area/shuttle/pirate)
-"bF" = (
-/obj/effect/mapping_helpers/airlock/locked,
-/obj/machinery/door/airlock/external{
-	id_tag = "pirateportexternal"
-	},
-/obj/docking_port/mobile/pirate{
-	callTime = 100;
-	dheight = 0;
-	dir = 4;
-	dwidth = 11;
-	height = 21;
-	id = "pirateship";
-	launch_status = 0;
-	movement_force = list("KNOCKDOWN" = 0, "THROW" = 0);
-	name = "Pirate Ship";
-	port_direction = 8;
-	preferred_direction = 1;
-	width = 23
-	},
-/obj/docking_port/stationary{
-	dir = 4;
-	dwidth = 11;
-	height = 21;
-	id = "pirateship_home";
-	name = "Deep Space";
-	width = 23
-	},
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/shuttle/pirate)
-"bG" = (
-/turf/open/floor/plating,
-/area/shuttle/pirate)
-"bH" = (
-/obj/machinery/door/airlock/external,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 8
-	},
-/turf/open/floor/plating,
-/area/shuttle/pirate)
-"bI" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/shuttle/pirate)
-"bJ" = (
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	dir = 4
-	},
-/turf/open/floor/plasteel/floorgrime,
-/area/shuttle/pirate)
-"bK" = (
 /obj/machinery/light/small{
 	dir = 4
 	},
-/obj/machinery/airalarm{
+/obj/machinery/airalarm/all_access{
 	dir = 8;
-	pixel_x = 24;
-	req_access = null;
-	req_access_txt = "152"
+	pixel_x = 24
 	},
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/rack{
-	dir = 8;
-	layer = 2.9
-	},
-/obj/item/storage/toolbox/mechanical,
-/obj/item/multitool,
-/turf/open/floor/plasteel/floorgrime,
+/obj/machinery/atmospherics/components/unary/vent_pump/on,
+/turf/open/floor/pod/dark,
 /area/shuttle/pirate)
-"bL" = (
-/obj/machinery/light/small{
-	brightness = 3;
-	dir = 8
+"ap" = (
+/obj/machinery/door/airlock/hatch{
+	name = "Port Gun Battery"
 	},
-/obj/structure/closet/crate,
-/obj/item/storage/box/lethalshot,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/pod/light,
-/area/shuttle/pirate/vault)
-"bM" = (
+/obj/structure/barricade/wooden/crude,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/pod/dark,
-/area/shuttle/pirate/vault)
-"bN" = (
-/obj/structure/rack{
-	dir = 8;
-	layer = 2.9
-	},
-/obj/item/gun/ballistic/shotgun/automatic/combat{
-	pixel_x = -2;
-	pixel_y = 2
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/pod/light,
-/area/shuttle/pirate/vault)
-"bO" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
-	dir = 1
-	},
-/turf/open/floor/pod/dark,
-/area/shuttle/pirate/vault)
-"bP" = (
-/obj/structure/rack{
-	dir = 8;
-	layer = 2.9
-	},
-/obj/item/gun/energy/laser{
-	pixel_x = -3;
-	pixel_y = 3
-	},
-/obj/item/gun/energy/laser,
-/turf/open/floor/pod/light,
-/area/shuttle/pirate/vault)
-"bQ" = (
+/area/shuttle/pirate)
+"aq" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/closet/crate,
-/obj/machinery/light/small{
-	dir = 4
-	},
+/obj/item/storage/bag/money/vault,
 /obj/item/stack/sheet/mineral/gold{
 	amount = 3;
 	pixel_x = -2;
@@ -780,351 +182,876 @@
 	pixel_x = 2;
 	pixel_y = -1
 	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
 /turf/open/floor/pod/light,
-/area/shuttle/pirate/vault)
-"bR" = (
-/obj/machinery/light/small{
-	brightness = 3;
-	dir = 8
-	},
-/obj/machinery/airalarm{
-	dir = 4;
-	pixel_x = -24;
-	req_access = null
-	},
+/area/shuttle/pirate)
+"ar" = (
+/obj/effect/decal/cleanable/dirt,
 /obj/structure/rack{
 	dir = 8;
 	layer = 2.9
 	},
-/obj/item/weldingtool/largetank,
-/obj/item/storage/toolbox/electrical,
-/obj/item/clothing/head/welding{
-	pixel_x = 4;
-	pixel_y = 4
+/obj/item/storage/box/lethalshot,
+/obj/item/shield/riot{
+	pixel_x = -3;
+	pixel_y = 3
 	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/floorgrime,
+/obj/item/shield/riot,
+/obj/item/gun/ballistic/shotgun/automatic/combat{
+	pixel_x = -2;
+	pixel_y = 2
+	},
+/turf/open/floor/pod/light,
 /area/shuttle/pirate)
-"bS" = (
+"as" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/table,
+/obj/item/gun/energy/laser{
+	pixel_x = -6;
+	pixel_y = 9
+	},
+/obj/item/gun/energy/laser{
+	pixel_x = 3;
+	pixel_y = 9
+	},
+/obj/item/gun/energy/laser{
+	pixel_x = -3;
+	pixel_y = 6
+	},
+/obj/item/gun/energy/laser{
+	pixel_x = 6;
+	pixel_y = 6
+	},
+/obj/machinery/recharger,
+/turf/open/floor/pod/light,
+/area/shuttle/pirate)
+"at" = (
+/obj/machinery/light/small,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/table,
+/obj/item/storage/backpack/duffelbag/syndie/x4{
+	pixel_y = -4
+	},
+/obj/item/melee/transforming/energy/sword/pirate{
+	pixel_x = -1;
+	pixel_y = 10
+	},
+/obj/item/melee/transforming/energy/sword/pirate{
+	pixel_x = 6;
+	pixel_y = 10
+	},
+/obj/item/melee/transforming/energy/sword/pirate{
+	pixel_x = 13;
+	pixel_y = 10
+	},
+/turf/open/floor/pod/light,
+/area/shuttle/pirate)
+"au" = (
+/obj/machinery/door/airlock/hatch{
+	id_tag = "piratebridgebolt";
+	name = "Bridge"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/turf/open/floor/plasteel/vault{
+	dir = 5
+	},
+/area/shuttle/pirate)
+"av" = (
+/obj/machinery/door/airlock/hatch{
+	name = "Starboard Gun Battery"
+	},
+/obj/structure/barricade/wooden/crude,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/turf/open/floor/pod/dark,
+/area/shuttle/pirate)
+"aw" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/sign/poster/contraband/revolver{
+	pixel_x = -32
+	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
 	dir = 8
 	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/floorgrime,
+/turf/open/floor/pod/dark,
 /area/shuttle/pirate)
-"bT" = (
-/obj/effect/turf_decal/stripes/line{
+"ax" = (
+/obj/machinery/light/small{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
+/turf/open/floor/pod/dark,
+/area/shuttle/pirate)
+"ay" = (
+/obj/machinery/door/airlock/highsecurity{
+	name = "Armory"
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/turf/open/floor/pod/dark,
+/area/shuttle/pirate)
+"az" = (
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
+	dir = 1
+	},
+/turf/open/floor/plasteel/vault{
+	dir = 5
+	},
+/area/shuttle/pirate)
+"aA" = (
+/obj/machinery/light/small{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/machinery/airalarm/all_access{
+	pixel_y = 24
+	},
+/turf/open/floor/plasteel/vault{
+	dir = 5
+	},
+/area/shuttle/pirate)
+"aB" = (
+/obj/machinery/light/small{
+	dir = 4
+	},
+/obj/machinery/computer/monitor/secret{
 	dir = 8
 	},
-/turf/open/floor/plasteel/floorgrime,
-/area/shuttle/pirate)
-"bU" = (
-/obj/machinery/door/airlock/external,
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/shuttle/pirate)
-"bV" = (
 /obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/airalarm/all_access{
+	dir = 1;
+	pixel_y = -24
+	},
+/turf/open/floor/plasteel/darkred/side{
+	dir = 10
+	},
+/area/shuttle/pirate)
+"aC" = (
+/obj/machinery/shuttle_scrambler,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/darkred/side{
+	dir = 5
+	},
+/area/shuttle/pirate)
+"aD" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/oil,
 /turf/open/floor/plating,
 /area/shuttle/pirate)
-"bW" = (
+"aE" = (
+/obj/effect/turf_decal/stripes/line,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/space_heater,
+/turf/open/floor/plating,
+/area/shuttle/pirate)
+"aF" = (
+/obj/machinery/door/airlock/external/glass{
+	id_tag = "pirateportexternal"
+	},
 /obj/effect/mapping_helpers/airlock/locked,
-/obj/machinery/door/airlock/external{
-	id_tag = "piratestarboardexternal"
+/obj/effect/mapping_helpers/airlock/cyclelink_helper,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating,
+/area/shuttle/pirate)
+"aG" = (
+/obj/effect/turf_decal/stripes/line,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/power/port_gen/pacman{
+	anchored = 1
+	},
+/obj/structure/cable{
+	icon_state = "0-4"
+	},
+/obj/item/wrench{
+	anchored = 1
+	},
+/turf/open/floor/plating,
+/area/shuttle/pirate)
+"aH" = (
+/obj/structure/shuttle/engine/propulsion/left,
+/turf/open/floor/plating/airless,
+/area/shuttle/pirate)
+"aI" = (
+/obj/machinery/light/small{
+	dir = 8
+	},
+/obj/structure/sign/warning/vacuum/external{
+	pixel_x = -32
 	},
 /obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating,
+/area/shuttle/pirate)
+"aJ" = (
+/obj/machinery/door/airlock/external/glass{
+	id_tag = "pirateportexternal"
+	},
+/obj/effect/mapping_helpers/airlock/locked,
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/shuttle/pirate)
+"aK" = (
+/obj/structure/shuttle/engine/propulsion,
+/turf/open/floor/plating/airless,
+/area/shuttle/pirate)
+"aL" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/bot,
+/obj/machinery/suit_storage_unit/pirate,
+/obj/machinery/light/small{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/shuttle/pirate)
+"aM" = (
+/obj/effect/turf_decal/stripes/line,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/reagent_dispensers/fueltank,
+/obj/machinery/light/small{
 	dir = 8
 	},
 /turf/open/floor/plating,
 /area/shuttle/pirate)
-"bX" = (
-/obj/structure/closet/emcloset/anchored,
+"aN" = (
 /obj/machinery/button/door{
 	id = "pirateportexternal";
 	name = "External Bolt Control";
 	normaldoorcontrol = 1;
-	pixel_x = -24;
+	pixel_x = -4;
+	pixel_y = -24;
 	specialfunctions = 4
 	},
+/obj/effect/turf_decal/stripes/corner{
+	dir = 1
+	},
 /obj/effect/decal/cleanable/dirt,
+/obj/machinery/airalarm/all_access{
+	pixel_y = 24
+	},
 /turf/open/floor/plating,
 /area/shuttle/pirate)
-"bY" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/reagent_dispensers/fueltank,
-/obj/effect/turf_decal/bot,
-/turf/open/floor/plasteel/floorgrime,
-/area/shuttle/pirate)
-"bZ" = (
-/obj/structure/closet/crate,
-/obj/item/tank/jetpack/carbondioxide,
-/obj/item/tank/jetpack/carbondioxide,
-/turf/open/floor/pod/light,
-/area/shuttle/pirate/vault)
-"ca" = (
-/obj/structure/closet/crate,
-/obj/item/coin/gold,
-/obj/item/coin/gold,
-/obj/item/coin/silver,
-/obj/item/coin/silver,
-/obj/item/coin/silver,
-/obj/item/coin/silver,
-/obj/item/coin/silver,
-/obj/item/coin/gold,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/pod/light,
-/area/shuttle/pirate/vault)
-"cb" = (
-/obj/structure/reagent_dispensers/watertank,
-/obj/effect/turf_decal/bot,
-/obj/item/mop,
-/obj/item/reagent_containers/glass/bucket,
-/turf/open/floor/plasteel/floorgrime,
-/area/shuttle/pirate)
-"cc" = (
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/shuttle/pirate)
-"cd" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 10
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/floorgrime,
-/area/shuttle/pirate)
-"ce" = (
-/obj/structure/closet/emcloset/anchored,
+"aO" = (
 /obj/machinery/button/door{
 	id = "piratestarboardexternal";
 	name = "External Bolt Control";
 	normaldoorcontrol = 1;
-	pixel_x = 24;
+	pixel_x = 4;
+	pixel_y = -24;
 	specialfunctions = 4
+	},
+/obj/effect/turf_decal/stripes/corner,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable{
+	icon_state = "0-8"
+	},
+/obj/machinery/power/apc{
+	dir = 1;
+	name = "Pirate Corvette APC";
+	pixel_y = 24;
+	req_access = null
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
 	},
 /turf/open/floor/plating,
 /area/shuttle/pirate)
-"cf" = (
-/obj/structure/table,
-/obj/machinery/chem_dispenser/drinks/beer{
-	dir = 4
+"aP" = (
+/obj/effect/turf_decal/stripes/line,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/components/unary/tank/air{
+	dir = 8
 	},
 /obj/machinery/light/small{
-	brightness = 3;
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/shuttle/pirate)
+"aQ" = (
+/obj/machinery/porta_turret/syndicate/energy{
+	dir = 1;
+	faction = list("pirate");
+	icon_state = "standard_lethal";
+	mode = 1
+	},
+/turf/closed/wall/mineral/plastitanium/nodiagonal,
+/area/shuttle/pirate)
+"aR" = (
+/obj/machinery/porta_turret/syndicate/energy{
+	faction = list("pirate");
+	icon_state = "standard_lethal";
+	mode = 1
+	},
+/turf/closed/wall/mineral/plastitanium,
+/area/shuttle/pirate)
+"aS" = (
+/obj/effect/turf_decal/stripes/line,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/shuttle/pirate)
+"aT" = (
+/obj/effect/turf_decal/stripes/line,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/machinery/meter,
+/turf/open/floor/plating,
+/area/shuttle/pirate)
+"aU" = (
+/obj/structure/sign/departments/engineering,
+/turf/closed/wall/mineral/plastitanium/nodiagonal,
+/area/shuttle/pirate)
+"aV" = (
+/obj/effect/turf_decal/stripes/line,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/structure/rack,
+/obj/item/tank/jetpack/carbondioxide{
+	pixel_x = -3;
+	pixel_y = 3
+	},
+/obj/item/tank/jetpack/carbondioxide,
+/turf/open/floor/plating,
+/area/shuttle/pirate)
+"aW" = (
+/obj/machinery/light/small{
+	dir = 8
+	},
+/obj/machinery/computer/camera_advanced/shuttle_docker/syndicate/pirate{
+	dir = 4;
+	x_offset = -3;
+	y_offset = 7
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/firealarm{
+	dir = 1;
+	pixel_y = -24
+	},
+/turf/open/floor/plasteel/darkred/side{
+	dir = 6
+	},
+/area/shuttle/pirate)
+"be" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/firealarm{
+	pixel_y = 24
+	},
+/obj/effect/turf_decal/bot,
+/obj/machinery/suit_storage_unit/pirate,
+/turf/open/floor/plating,
+/area/shuttle/pirate)
+"bf" = (
+/obj/structure/chair/comfy/shuttle{
 	dir = 8
 	},
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/bar,
+/obj/machinery/turretid{
+	icon_state = "control_kill";
+	lethal = 1;
+	locked = 0;
+	pixel_y = -24;
+	req_access = null
+	},
+/turf/open/floor/plasteel/darkred/corner{
+	dir = 8
+	},
 /area/shuttle/pirate)
-"cg" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/machinery/door/airlock/public/glass{
-	name = "Bar"
+"bg" = (
+/obj/machinery/door/airlock/hatch{
+	name = "Armory Access"
 	},
-/turf/open/floor/plasteel,
-/area/shuttle/pirate)
-"ch" = (
-/obj/structure/table,
-/obj/machinery/door/window/southleft{
-	base_state = "left";
-	dir = 1;
-	icon_state = "left";
-	name = "Explosive Ordinance"
-	},
-/obj/item/grenade/plastic/x4{
-	pixel_x = -5
-	},
-/obj/item/grenade/plastic/x4{
-	pixel_x = 3
-	},
-/obj/item/grenade/plastic/x4{
-	pixel_x = 11
-	},
-/obj/structure/window/reinforced{
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/pod/light,
-/area/shuttle/pirate/vault)
-"ci" = (
-/obj/structure/table,
-/obj/item/melee/transforming/energy/sword/pirate,
-/obj/item/melee/transforming/energy/sword/pirate{
-	pixel_y = 12
+/turf/open/floor/plasteel/vault{
+	dir = 5
 	},
-/obj/item/melee/transforming/energy/sword/pirate{
-	pixel_x = 12;
-	pixel_y = 7
+/area/shuttle/pirate)
+"bk" = (
+/obj/effect/turf_decal/stripes/line,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/power/smes/engineering{
+	charge = 1e+006
+	},
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/shuttle/pirate)
+"bl" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/turf/open/floor/plasteel/bar,
+/area/shuttle/pirate)
+"bm" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/manifold4w/supply/hidden,
+/turf/open/floor/plasteel/bar,
+/area/shuttle/pirate)
+"bo" = (
+/obj/machinery/light/small{
+	dir = 4
+	},
+/obj/structure/sign/warning/vacuum/external{
+	pixel_x = 32
+	},
+/turf/open/floor/plating,
+/area/shuttle/pirate)
+"br" = (
+/obj/effect/turf_decal/stripes/line,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/reagent_dispensers/watertank,
+/obj/item/reagent_containers/glass/bucket,
+/obj/item/mop,
+/turf/open/floor/plating,
+/area/shuttle/pirate)
+"bt" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/vomit/old,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 10
+	},
+/turf/open/floor/plasteel/bar,
+/area/shuttle/pirate)
+"bu" = (
+/obj/structure/closet/secure_closet/personal,
+/obj/machinery/airalarm/all_access{
+	pixel_y = 24
 	},
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/pod/light,
-/area/shuttle/pirate/vault)
-"cj" = (
-/obj/machinery/light/small,
-/obj/effect/turf_decal/stripes/end{
-	dir = 1
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/loot_locator,
-/turf/open/floor/pod/light,
-/area/shuttle/pirate/vault)
-"ck" = (
-/obj/structure/table,
-/obj/machinery/recharger,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/pod/light,
-/area/shuttle/pirate/vault)
-"cl" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/telecomms/relay,
-/turf/open/floor/pod/light,
-/area/shuttle/pirate/vault)
-"cm" = (
-/obj/machinery/door/airlock/atmos{
-	name = "Atmospherics"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/machinery/atmospherics/components/unary/vent_pump/on,
 /turf/open/floor/plasteel/floorgrime,
 /area/shuttle/pirate)
-"cn" = (
+"bv" = (
+/obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/turf/closed/wall/mineral/plastitanium/nodiagonal,
+/turf/open/floor/plasteel,
 /area/shuttle/pirate)
-"co" = (
-/obj/structure/toilet{
-	pixel_y = 20
+"bw" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
 	},
-/obj/structure/sink{
-	dir = 8;
-	pixel_x = -12;
-	pixel_y = 2
+/obj/machinery/airalarm/all_access{
+	dir = 4;
+	pixel_x = -24
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/turf/open/floor/pod/dark,
+/area/shuttle/pirate)
+"bx" = (
+/obj/machinery/door/airlock{
+	name = "Captain's Quarters"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/turf/open/floor/wood,
+/area/shuttle/pirate)
+"by" = (
+/obj/structure/chair/stool,
+/obj/machinery/atmospherics/components/unary/vent_pump/on{
+	dir = 1
+	},
+/turf/open/floor/plasteel/bar,
+/area/shuttle/pirate)
+"bz" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
+	dir = 8
+	},
+/turf/open/floor/plasteel/bar,
+/area/shuttle/pirate)
+"bA" = (
+/obj/machinery/firealarm{
+	dir = 1;
+	pixel_y = -24
 	},
 /obj/machinery/light/small,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/showroomfloor,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/turf/open/floor/plasteel/bar,
 /area/shuttle/pirate)
-"cp" = (
+"bB" = (
+/obj/machinery/door/airlock{
+	name = "Crew Quarters"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/turf/open/floor/plasteel/neutral/corner,
+/area/shuttle/pirate)
+"bC" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
+	dir = 1
+	},
+/turf/open/floor/plasteel/neutral/corner,
+/area/shuttle/pirate)
+"bD" = (
+/obj/machinery/firealarm{
+	dir = 1;
+	pixel_y = -24
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/small,
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden,
+/turf/open/floor/plasteel/neutral/corner,
+/area/shuttle/pirate)
+"bE" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
+	dir = 4
+	},
+/turf/open/floor/plasteel/neutral/corner,
+/area/shuttle/pirate)
+"bF" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 6
+	},
+/obj/machinery/firealarm{
+	dir = 8;
+	pixel_x = -26
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on{
+	dir = 1
+	},
+/turf/open/floor/pod/dark,
+/area/shuttle/pirate)
+"bH" = (
+/obj/structure/chair/wood/normal,
+/obj/machinery/light/small{
+	dir = 8
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on{
+	dir = 1
+	},
+/turf/open/floor/wood,
+/area/shuttle/pirate)
+"bI" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/turf/open/floor/plasteel/bar,
+/area/shuttle/pirate)
+"bJ" = (
+/obj/machinery/door/airlock{
+	name = "Cabin 1"
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/turf/open/floor/plasteel/vault{
+	dir = 5
+	},
+/area/shuttle/pirate)
+"bK" = (
+/obj/machinery/door/airlock{
+	name = "Cabin 2"
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/turf/open/floor/plasteel/vault{
+	dir = 5
+	},
+/area/shuttle/pirate)
+"bL" = (
+/obj/machinery/door/airlock/engineering{
+	name = "Engineering"
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/turf/open/floor/plating,
+/area/shuttle/pirate)
+"bM" = (
+/obj/effect/mob_spawn/human/pirate{
+	dir = 1
+	},
+/obj/machinery/airalarm/all_access{
+	dir = 1;
+	pixel_y = -24
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/small{
+	dir = 4
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on{
+	dir = 1
+	},
+/turf/open/floor/plasteel/vault{
+	dir = 5
+	},
+/area/shuttle/pirate)
+"bN" = (
+/obj/effect/mob_spawn/human/pirate{
+	dir = 1
+	},
+/obj/machinery/airalarm/all_access{
+	dir = 1;
+	pixel_y = -24
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/small{
+	dir = 8
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on{
+	dir = 1
+	},
+/turf/open/floor/plasteel/vault{
+	dir = 5
+	},
+/area/shuttle/pirate)
+"bO" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/turf/open/floor/plating,
+/area/shuttle/pirate)
+"bP" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/components/unary/vent_pump/on{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/shuttle/pirate)
+"bQ" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable{
+	icon_state = "2-4"
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden,
+/turf/open/floor/plating,
+/area/shuttle/pirate)
+"bX" = (
+/obj/effect/turf_decal/stripes/line,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/power/terminal{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "0-8"
+	},
+/obj/structure/rack,
+/obj/item/storage/toolbox/mechanical{
+	pixel_y = 4
+	},
+/obj/item/flashlight{
+	pixel_x = 3;
+	pixel_y = 3
+	},
+/obj/item/storage/box/lights/bulbs,
+/obj/item/stack/sheet/mineral/plasma{
+	amount = 10
+	},
+/obj/item/multitool,
+/turf/open/floor/plating,
+/area/shuttle/pirate)
+"bZ" = (
+/obj/machinery/door/airlock/external/glass{
+	id_tag = "piratestarboardexternal"
+	},
+/obj/effect/mapping_helpers/airlock/locked,
+/obj/effect/mapping_helpers/airlock/cyclelink_helper,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating,
+/area/shuttle/pirate)
+"ce" = (
+/obj/machinery/door/airlock/external/glass{
+	id_tag = "piratestarboardexternal"
+	},
+/obj/effect/mapping_helpers/airlock/locked,
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 1
+	},
+/obj/docking_port/mobile/pirate{
+	callTime = 100;
+	dheight = 0;
+	dir = 1;
+	dwidth = 11;
+	height = 16;
+	id = "pirateship";
+	launch_status = 0;
+	movement_force = list("KNOCKDOWN" = 0, "THROW" = 0);
+	name = "Pirate Ship";
+	port_direction = 2;
+	preferred_direction = 1;
+	width = 17
+	},
+/obj/docking_port/stationary{
+	dir = 1;
+	dwidth = 11;
+	height = 16;
+	id = "pirateship_home";
+	name = "Deep Space";
+	width = 17
+	},
+/turf/open/floor/plating,
+/area/shuttle/pirate)
+"ek" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/table,
+/obj/machinery/chem_dispenser/drinks,
+/turf/open/floor/plasteel/bar,
+/area/shuttle/pirate)
+"ep" = (
+/obj/structure/window/reinforced{
+	dir = 1;
+	pixel_y = 1
+	},
+/obj/structure/shuttle/engine/heater,
+/turf/open/floor/plating/airless,
+/area/shuttle/pirate)
+"er" = (
+/obj/structure/shuttle/engine/propulsion/right,
+/turf/open/floor/plating/airless,
+/area/shuttle/pirate)
+"et" = (
+/obj/structure/grille,
+/turf/open/floor/plating,
+/area/shuttle/pirate)
+"eu" = (
+/obj/structure/girder,
+/obj/item/stack/rods{
+	amount = 3
+	},
+/turf/open/floor/plating,
+/area/shuttle/pirate)
+"ew" = (
+/obj/structure/girder,
+/obj/item/stack/rods{
+	amount = 5
+	},
+/turf/open/floor/plating,
+/area/shuttle/pirate)
+"ex" = (
+/obj/structure/window/reinforced,
+/obj/structure/frame/machine,
+/obj/item/wrench,
+/turf/open/floor/plating,
+/area/shuttle/pirate)
+"ey" = (
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "piratebridge"
+	},
+/obj/structure/grille,
+/obj/structure/window/plastitanium,
+/turf/open/floor/plating,
+/area/shuttle/pirate)
+"ez" = (
+/obj/structure/window/reinforced,
+/obj/structure/frame/machine,
+/obj/item/stack/cable_coil/cut/red,
+/turf/open/floor/plating,
+/area/shuttle/pirate)
+"eA" = (
+/obj/structure/window/reinforced{
+	dir = 1;
+	pixel_y = 1
+	},
+/obj/structure/frame/computer{
+	anchored = 1
+	},
+/turf/open/floor/pod/dark,
+/area/shuttle/pirate)
+"eE" = (
+/obj/structure/closet/secure_closet/personal,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/floorgrime,
+/area/shuttle/pirate)
+"eS" = (
+/obj/structure/closet/secure_closet/personal,
+/turf/open/floor/wood,
+/area/shuttle/pirate)
+"ft" = (
 /obj/machinery/door/airlock{
 	name = "Unisex Restrooms"
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/showroomfloor,
 /area/shuttle/pirate)
-"cq" = (
-/obj/machinery/airalarm{
-	pixel_y = 24;
-	req_access = null
+"fw" = (
+/obj/effect/mob_spawn/human/pirate/captain{
+	dir = 8
 	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/bar,
-/area/shuttle/pirate)
-"cr" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/turf/open/floor/plasteel/bar,
-/area/shuttle/pirate)
-"cs" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/bar,
-/area/shuttle/pirate)
-"ct" = (
-/obj/structure/table,
-/obj/machinery/microwave{
-	pixel_y = 5
+/obj/machinery/airalarm/all_access{
+	pixel_y = 24
 	},
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/bar,
+/turf/open/floor/wood,
 /area/shuttle/pirate)
-"cu" = (
-/obj/machinery/atmospherics/components/unary/tank/nitrogen{
-	dir = 4
+"fB" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/toilet{
+	dir = 1
 	},
-/obj/effect/turf_decal/bot,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel,
-/area/shuttle/pirate)
-"cv" = (
-/obj/machinery/atmospherics/components/binary/pump/on{
+/obj/structure/sink{
 	dir = 4;
-	name = "N2 Out";
-	target_pressure = 4500
+	pixel_x = 11;
+	pixel_y = 7
 	},
-/turf/open/floor/plasteel/floorgrime,
-/area/shuttle/pirate)
-"cw" = (
-/obj/machinery/atmospherics/components/trinary/mixer/airmix/flipped,
-/turf/open/floor/plasteel/floorgrime,
-/area/shuttle/pirate)
-"cx" = (
-/obj/machinery/airalarm{
-	pixel_y = 24;
-	req_access = null
-	},
-/obj/structure/table,
-/obj/item/storage/box/lights/mixed{
-	pixel_x = -4
-	},
-/obj/item/storage/belt/utility{
-	pixel_x = 4
-	},
-/obj/item/analyzer{
-	pixel_x = 3;
-	pixel_y = 2
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/floorgrime,
-/area/shuttle/pirate)
-"cy" = (
-/obj/machinery/portable_atmospherics/pump,
-/obj/structure/window/reinforced{
+/obj/machinery/light/small{
 	dir = 8
 	},
-/obj/effect/turf_decal/delivery,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/showroomfloor,
 /area/shuttle/pirate)
-"cz" = (
-/obj/machinery/portable_atmospherics/scrubber,
-/obj/structure/window/reinforced{
+"fM" = (
+/obj/structure/table/wood,
+/obj/item/storage/box/matches,
+/obj/item/reagent_containers/food/drinks/bottle/rum{
+	name = "Captain Pete's Private Reserve Cuban Spaced Rum";
+	pixel_x = -6;
+	pixel_y = 8
+	},
+/obj/item/reagent_containers/food/drinks/drinkingglass/shotglass{
+	pixel_x = 6;
+	pixel_y = 12
+	},
+/obj/item/clothing/mask/cigarette/cigar,
+/turf/open/floor/wood,
+/area/shuttle/pirate)
+"fV" = (
+/obj/effect/turf_decal/stripes/line,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating,
+/area/shuttle/pirate)
+"fW" = (
+/turf/closed/wall/mineral/plastitanium,
+/area/shuttle/pirate)
+"fY" = (
+/obj/machinery/airalarm/all_access{
+	dir = 4;
+	pixel_x = -24
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/small{
 	dir = 8
 	},
-/obj/effect/turf_decal/delivery,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel,
-/area/shuttle/pirate)
-"cA" = (
-/obj/structure/table/reinforced,
-/obj/item/lighter,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/bar,
-/area/shuttle/pirate)
-"cB" = (
-/obj/structure/chair/stool/bar,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/turf/open/floor/plasteel/bar,
-/area/shuttle/pirate)
-"cC" = (
-/turf/open/floor/plasteel/bar,
-/area/shuttle/pirate)
-"cD" = (
-/obj/structure/closet/crate,
+/obj/structure/closet/secure_closet/freezer{
+	locked = 0;
+	name = "fridge"
+	},
 /obj/item/storage/box/donkpockets{
 	pixel_x = 2;
 	pixel_y = 3
@@ -1137,1190 +1064,318 @@
 	pixel_y = -6
 	},
 /obj/item/reagent_containers/food/snacks/chocolatebar,
-/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/bar,
 /area/shuttle/pirate)
-"cE" = (
-/obj/machinery/computer/turbine_computer{
-	dir = 4;
-	id = "pirateturbine"
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/yellow/side{
-	dir = 9
-	},
-/area/shuttle/pirate)
-"cF" = (
-/obj/structure/chair/stool,
-/obj/machinery/airalarm{
-	pixel_y = 24;
-	req_access = null
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/yellow/side{
-	dir = 1
-	},
-/area/shuttle/pirate)
-"cG" = (
-/obj/machinery/power/smes{
-	capacity = 9e+006;
-	charge = 10000
-	},
-/obj/structure/cable/yellow{
-	icon_state = "0-4"
-	},
-/obj/machinery/light/small{
-	dir = 1
-	},
+"gb" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/yellow/side{
-	dir = 1
-	},
-/area/shuttle/pirate)
-"cH" = (
-/obj/structure/chair/stool,
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
-/obj/structure/cable/yellow{
-	icon_state = "0-8"
-	},
-/obj/machinery/power/apc{
-	dir = 1;
-	name = "Pirate Ship APC";
-	pixel_y = 26;
-	req_access = null
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/yellow/side{
-	dir = 1
-	},
-/area/shuttle/pirate)
-"cI" = (
-/obj/machinery/computer/monitor/secret{
-	dir = 8
-	},
-/obj/structure/cable/yellow{
-	icon_state = "0-8"
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/yellow/side{
-	dir = 5
-	},
-/area/shuttle/pirate)
-"cJ" = (
-/obj/machinery/atmospherics/components/unary/tank/oxygen{
-	dir = 4
-	},
-/obj/effect/turf_decal/bot,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel,
-/area/shuttle/pirate)
-"cK" = (
-/obj/machinery/atmospherics/components/binary/pump/on{
-	dir = 4;
-	name = "O2 Out";
-	target_pressure = 4500
-	},
-/turf/open/floor/plasteel/floorgrime,
-/area/shuttle/pirate)
-"cL" = (
-/obj/machinery/atmospherics/pipe/manifold4w/general{
-	level = 2
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel,
-/area/shuttle/pirate)
-"cM" = (
-/obj/machinery/atmospherics/pipe/simple/general/visible{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/turf/open/floor/plasteel/floorgrime,
-/area/shuttle/pirate)
-"cN" = (
-/obj/machinery/atmospherics/components/binary/pump{
-	dir = 8;
-	name = "Port Out";
-	target_pressure = 4500
-	},
-/turf/open/floor/plasteel/floorgrime,
-/area/shuttle/pirate)
-"cO" = (
-/obj/machinery/atmospherics/components/unary/portables_connector/visible{
-	dir = 8
-	},
-/obj/effect/turf_decal/bot,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel,
-/area/shuttle/pirate)
-"cP" = (
-/obj/structure/table,
-/obj/machinery/chem_dispenser/drinks{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/dirt,
+/obj/machinery/vending/boozeomat/all_access,
 /turf/open/floor/plasteel/bar,
-/area/shuttle/pirate)
-"cQ" = (
-/obj/structure/table/reinforced,
-/obj/item/book/manual/wiki/barman_recipes{
-	pixel_x = -4
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/bar,
-/area/shuttle/pirate)
-"cR" = (
-/obj/structure/chair/stool/bar,
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	dir = 8
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/bar,
-/area/shuttle/pirate)
-"cS" = (
-/obj/structure/sign/departments/engineering{
-	pixel_x = 32
-	},
-/obj/machinery/light/small{
-	dir = 4
-	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
-	dir = 8
-	},
-/turf/open/floor/plasteel/bar,
-/area/shuttle/pirate)
-"cT" = (
-/obj/structure/table,
-/obj/item/clothing/gloves/color/yellow,
-/obj/item/wrench,
-/obj/item/crowbar,
-/obj/item/clothing/glasses/meson/engine,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 6
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/yellow/corner{
-	dir = 1
-	},
-/area/shuttle/pirate)
-"cU" = (
-/obj/machinery/power/terminal{
-	dir = 1
-	},
-/obj/structure/cable{
-	icon_state = "0-2"
-	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	dir = 1
-	},
-/turf/open/floor/plasteel/floorgrime,
-/area/shuttle/pirate)
-"cV" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/turf/open/floor/plasteel/floorgrime,
-/area/shuttle/pirate)
-"cW" = (
-/obj/structure/table,
-/obj/machinery/cell_charger,
-/obj/item/stock_parts/cell/high,
-/obj/item/stack/cable_coil/red{
-	pixel_x = -1;
-	pixel_y = 3
-	},
-/obj/item/stack/cable_coil/red{
-	pixel_x = 2
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/yellow/corner{
-	dir = 4
-	},
-/area/shuttle/pirate)
-"cX" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/turf/closed/wall/mineral/plastitanium/nodiagonal,
-/area/shuttle/pirate)
-"cY" = (
-/obj/structure/sign/departments/engineering{
-	pixel_x = -32
-	},
-/obj/machinery/light/small{
-	brightness = 3;
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/turf/open/floor/plasteel/floorgrime,
-/area/shuttle/pirate)
-"cZ" = (
-/obj/machinery/atmospherics/components/binary/pump{
-	dir = 2;
-	name = "O2 to Incinerator";
-	target_pressure = 4500
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/turf/open/floor/plasteel/floorgrime,
-/area/shuttle/pirate)
-"da" = (
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden,
-/turf/open/floor/plasteel,
-/area/shuttle/pirate)
-"db" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
-	dir = 8
-	},
-/turf/open/floor/plasteel/floorgrime,
-/area/shuttle/pirate)
-"dc" = (
-/obj/structure/extinguisher_cabinet{
-	pixel_x = 25
-	},
-/obj/machinery/light/small{
-	dir = 4
-	},
-/obj/machinery/pipedispenser,
-/turf/open/floor/plasteel/caution{
-	dir = 4
-	},
-/area/shuttle/pirate)
-"dd" = (
-/obj/structure/table/reinforced,
-/obj/effect/decal/cleanable/dirt,
-/obj/item/storage/fancy/cigarettes/cigpack_uplift{
-	pixel_x = 8;
-	pixel_y = -14
-	},
-/obj/item/storage/fancy/cigarettes/cigpack_shadyjims{
-	pixel_x = 1;
-	pixel_y = -14
-	},
-/obj/item/storage/fancy/cigarettes/cigpack_robust{
-	pixel_x = -6;
-	pixel_y = -14
-	},
-/obj/item/storage/fancy/cigarettes/cigpack_midori{
-	pixel_x = 8;
-	pixel_y = -8
-	},
-/obj/item/storage/fancy/cigarettes/cigpack_carp{
-	pixel_x = 1;
-	pixel_y = -8
-	},
-/obj/item/storage/fancy/cigarettes,
-/turf/open/floor/plasteel/bar,
-/area/shuttle/pirate)
-"df" = (
-/obj/structure/chair/stool/bar,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 5
-	},
-/turf/open/floor/plasteel/bar,
-/area/shuttle/pirate)
-"dg" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/turf/open/floor/plasteel/bar,
-/area/shuttle/pirate)
-"dh" = (
-/obj/machinery/door/airlock/engineering{
-	name = "Engineering"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/shuttle/pirate)
-"di" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/sign/warning/nosmoking{
-	pixel_y = 32
-	},
-/turf/open/floor/plasteel,
-/area/shuttle/pirate)
-"dj" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 9
-	},
-/turf/open/floor/plasteel/floorgrime,
-/area/shuttle/pirate)
-"dk" = (
-/turf/open/floor/plasteel,
-/area/shuttle/pirate)
-"dl" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
-	dir = 1
-	},
-/turf/open/floor/plasteel/floorgrime,
-/area/shuttle/pirate)
-"dm" = (
-/obj/machinery/atmospherics/pipe/simple/general/visible{
-	dir = 6
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel,
-/area/shuttle/pirate)
-"dn" = (
-/obj/machinery/atmospherics/pipe/simple/general/visible{
-	dir = 4
-	},
-/turf/open/floor/plasteel/floorgrime,
-/area/shuttle/pirate)
-"do" = (
-/obj/machinery/door/airlock/engineering{
-	name = "Engineering"
-	},
-/obj/machinery/atmospherics/pipe/simple/general/visible{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/shuttle/pirate)
-"dp" = (
-/obj/machinery/atmospherics/pipe/simple/general/visible{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/shuttle/pirate)
-"dq" = (
-/obj/machinery/meter,
-/obj/machinery/atmospherics/pipe/manifold4w/general{
-	level = 2
-	},
-/turf/open/floor/plasteel,
-/area/shuttle/pirate)
-"dr" = (
-/obj/machinery/atmospherics/pipe/simple/general/visible{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/floorgrime,
-/area/shuttle/pirate)
-"ds" = (
-/obj/machinery/atmospherics/components/binary/pump{
-	dir = 8;
-	name = "Plasma to Incinerator";
-	target_pressure = 4500
-	},
-/turf/open/floor/plasteel/floorgrime,
-/area/shuttle/pirate)
-"dt" = (
-/obj/machinery/atmospherics/components/unary/tank/toxins{
-	dir = 8
-	},
-/obj/effect/turf_decal/bot,
-/turf/open/floor/plasteel,
-/area/shuttle/pirate)
-"du" = (
-/obj/machinery/vending/boozeomat{
-	req_access_txt = "0"
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/bar,
-/area/shuttle/pirate)
-"dv" = (
-/obj/machinery/door/window/southleft{
-	base_state = "right";
-	dir = 4;
-	icon_state = "right";
-	name = "Bar"
-	},
-/turf/open/floor/plasteel/bar,
-/area/shuttle/pirate)
-"dw" = (
-/obj/structure/closet/firecloset/full{
-	anchored = 1
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/yellow/side,
-/area/shuttle/pirate)
-"dx" = (
-/obj/effect/turf_decal/stripes/corner,
-/obj/machinery/light/small,
-/turf/open/floor/plasteel/yellow/corner{
-	dir = 8
-	},
-/area/shuttle/pirate)
-"dy" = (
-/obj/machinery/button/door{
-	id = "pirateturbinevent";
-	name = "Turbine Vent Control";
-	pixel_x = -6;
-	pixel_y = -24
-	},
-/obj/effect/turf_decal/stripes/line,
-/obj/machinery/button/door{
-	id = "pirateturbineauxvent";
-	name = "Turbine Auxiliary Vent Control";
-	pixel_x = 6;
-	pixel_y = -24
-	},
-/turf/open/floor/plasteel/floorgrime,
-/area/shuttle/pirate)
-"dz" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/effect/turf_decal/stripes/line,
-/turf/open/floor/plasteel/floorgrime,
-/area/shuttle/pirate)
-"dA" = (
-/obj/machinery/button/ignition{
-	id = "pirateincinerator";
-	pixel_x = -6;
-	pixel_y = -24
-	},
-/obj/effect/turf_decal/stripes/line,
-/obj/machinery/atmospherics/components/binary/pump/on{
-	dir = 2;
-	target_pressure = 4500
-	},
-/obj/machinery/button/door{
-	id = "pirateturbinebolt";
-	name = "Turbine Bolt Control";
-	normaldoorcontrol = 1;
-	pixel_x = 6;
-	pixel_y = -24;
-	specialfunctions = 4
-	},
-/turf/open/floor/plasteel/floorgrime,
-/area/shuttle/pirate)
-"dB" = (
-/obj/effect/turf_decal/stripes/corner{
-	dir = 1
-	},
-/obj/structure/rack{
-	dir = 8;
-	layer = 2.9
-	},
-/obj/item/storage/toolbox/mechanical,
-/obj/item/clothing/head/welding{
-	pixel_x = 4;
-	pixel_y = 4
-	},
-/obj/item/multitool,
-/obj/machinery/light/small,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/yellow/corner,
-/area/shuttle/pirate)
-"dC" = (
-/obj/structure/table,
-/obj/item/stack/sheet/metal{
-	pixel_x = -1
-	},
-/obj/item/stack/sheet/glass{
-	amount = 50;
-	pixel_y = 5
-	},
-/obj/item/stack/sheet/mineral/plastitanium{
-	amount = 30;
-	pixel_x = 3;
-	pixel_y = -2
-	},
-/obj/item/stack/rods/fifty,
-/turf/open/floor/plasteel/yellow/side,
-/area/shuttle/pirate)
-"dD" = (
-/obj/machinery/portable_atmospherics/canister/oxygen,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/caution,
-/area/shuttle/pirate)
-"dE" = (
-/obj/machinery/atmospherics/pipe/simple/general/visible{
-	dir = 5
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/caution,
-/area/shuttle/pirate)
-"dF" = (
-/obj/machinery/atmospherics/pipe/simple/general/visible{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/caution,
-/area/shuttle/pirate)
-"dG" = (
-/obj/machinery/atmospherics/components/binary/pump{
-	dir = 8;
-	name = "Port to Incinerator";
-	target_pressure = 4500
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/caution,
-/area/shuttle/pirate)
-"dH" = (
-/obj/machinery/atmospherics/components/unary/portables_connector/visible{
-	dir = 8
-	},
-/obj/effect/turf_decal/bot,
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/portable_atmospherics/canister,
-/turf/open/floor/plasteel,
-/area/shuttle/pirate)
-"dI" = (
-/obj/structure/shuttle/engine/heater,
-/obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 1
-	},
-/turf/open/floor/plating/airless,
-/area/shuttle/pirate)
-"dJ" = (
-/obj/structure/sign/warning/fire,
-/turf/closed/wall/mineral/plastitanium/nodiagonal,
-/area/shuttle/pirate)
-"dK" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/effect/mapping_helpers/airlock/locked,
-/obj/machinery/door/airlock/public/glass{
-	heat_proof = 1;
-	id_tag = "pirateturbinebolt";
-	name = "Turbine Access"
-	},
-/turf/open/floor/engine,
-/area/shuttle/pirate)
-"dL" = (
-/obj/machinery/atmospherics/pipe/simple/general/visible{
-	dir = 2
-	},
-/turf/closed/wall/mineral/plastitanium/nodiagonal,
-/area/shuttle/pirate)
-"dM" = (
-/obj/structure/shuttle/engine/propulsion/burst,
-/turf/open/floor/plating/airless,
-/area/shuttle/pirate)
-"dN" = (
-/obj/machinery/igniter{
-	id = "pirateincinerator"
-	},
-/turf/open/floor/engine/vacuum,
-/area/shuttle/pirate)
-"dO" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/open/floor/engine/vacuum,
-/area/shuttle/pirate)
-"dP" = (
-/obj/machinery/atmospherics/components/unary/outlet_injector/atmos{
-	dir = 1;
-	id = "inc_in"
-	},
-/obj/structure/sign/warning/vacuum/external{
-	pixel_y = -32
-	},
-/turf/open/floor/engine/vacuum,
-/area/shuttle/pirate)
-"dQ" = (
-/obj/machinery/door/poddoor{
-	id = "pirateturbineauxvent";
-	name = "Turbine Auxiliary Vent"
-	},
-/turf/open/floor/engine/vacuum,
-/area/shuttle/pirate)
-"dR" = (
-/obj/structure/cable,
-/obj/structure/cable{
-	icon_state = "0-2"
-	},
-/obj/machinery/power/compressor{
-	comp_id = "pirateturbine";
-	dir = 1;
-	luminosity = 2
-	},
-/turf/open/floor/engine/vacuum,
-/area/shuttle/pirate)
-"dS" = (
-/obj/structure/cable,
-/obj/machinery/power/turbine{
-	luminosity = 2
-	},
-/turf/open/floor/engine/vacuum,
-/area/shuttle/pirate)
-"dT" = (
-/obj/structure/sign/warning/fire,
-/turf/closed/wall/mineral/plastitanium,
-/area/shuttle/pirate)
-"dU" = (
-/obj/machinery/door/poddoor{
-	id = "pirateturbinevent";
-	name = "Turbine Vent"
-	},
-/turf/open/floor/engine/vacuum,
-/area/shuttle/pirate)
-"dV" = (
-/obj/machinery/porta_turret/syndicate{
-	dir = 1;
-	faction = list("pirate")
-	},
-/turf/closed/wall/mineral/plastitanium/nodiagonal,
 /area/shuttle/pirate)
 
 (1,1,1) = {"
-aa
-aa
-aa
-aa
-aa
-aa
-ai
-aj
-aj
-aj
-aj
-bF
-aj
-dV
+af
+af
+af
+fW
 aj
 aj
 aj
 aj
 aj
-ai
-aa
-aa
-aa
-aa
+aj
+aj
+fW
+af
+af
+af
+af
 "}
 (2,1,1) = {"
+af
+et
+eu
+ex
+eA
 aa
-aa
-aa
-aa
-aa
-ai
+ap
+aw
+bw
+bF
+as
 aj
-aJ
-bb
 aj
-bt
-bG
-bX
-aj
-co
-aj
-cf
-cP
-du
-aj
-ai
-aa
-aa
-aa
+fW
+af
+af
 "}
 (3,1,1) = {"
-aa
-aa
-aa
-aa
-aa
-aj
-aw
-aK
-bc
+aQ
 aj
 aj
-bH
 aj
 aj
-cp
-aj
-cs
-cC
-cs
-dI
-dM
-aa
-aa
-aa
-"}
-(4,1,1) = {"
-aa
-aa
-aa
-aa
-ai
 aj
 aj
-aL
-aj
-aj
-bu
-bI
-bu
-aj
-cq
-cA
-cQ
-dd
-dv
-dI
-dM
-aa
-aa
-aa
-"}
-(5,1,1) = {"
-aa
-aa
-aa
-aa
-aj
-ap
+ax
+aq
+ar
+at
 aj
 aM
-bd
-bn
-bv
-bJ
-bC
-cg
-cr
-cB
-cR
-df
-cC
-dI
-dM
-aa
-aa
-aa
+ep
+aH
+af
+"}
+(4,1,1) = {"
+af
+af
+af
+af
+af
+af
+aj
+ay
+aj
+aj
+aj
+aj
+br
+ep
+er
+af
+"}
+(5,1,1) = {"
+af
+af
+af
+af
+af
+af
+ey
+az
+bx
+bH
+fM
+aj
+aE
+aj
+aj
+aR
 "}
 (6,1,1) = {"
-aa
-aa
-aa
-aa
+af
+af
+af
+ey
+ey
 aj
-aq
-ax
-aN
-be
 aj
-bw
-bK
-bY
+aA
 aj
-cs
-cC
-cS
-dg
-cs
-dI
-dM
-aa
-aa
-aa
+fw
+eS
+aj
+fV
+aF
+aI
+aJ
 "}
 (7,1,1) = {"
-aa
-aa
-aa
-aa
+af
+af
+ey
+ey
+aC
+aW
 aj
-ar
-aj
-aO
-bf
-aj
+bg
 aj
 aj
 aj
 aj
-ct
-cD
-aj
-dh
+aN
 aj
 aj
-ai
-aa
-aa
-aa
+aj
 "}
 (8,1,1) = {"
-aa
-aa
+af
+af
+ey
 ab
-ab
+ae
+bf
+aj
+bl
+fY
+ai
+aj
+be
+aD
+aG
+ep
+aH
+"}
+(9,1,1) = {"
+af
+af
+ey
+ac
+ag
+am
+au
+bm
+by
+ak
+aU
+aL
+bP
+bX
+ep
+aK
+"}
+(10,1,1) = {"
+af
+af
+ey
+ad
+ah
+an
+aj
+bt
+bz
+bI
+bL
+bO
+bQ
+bk
+ep
+er
+"}
+(11,1,1) = {"
+af
+af
+ey
+ey
+al
+aB
+aj
+ek
+bA
+aj
+aj
+aj
+aO
+aj
+aj
+aj
+"}
+(12,1,1) = {"
+af
+af
+af
+ey
+ey
+aj
+aj
+gb
+bl
+ft
+fB
+aj
+aS
+bZ
+bo
+ce
+"}
+(13,1,1) = {"
+af
+af
+af
+af
+af
+af
+aj
+aj
+bB
+aj
+aj
+aj
+aT
+aj
+aj
+aR
+"}
+(14,1,1) = {"
+af
+af
+af
+af
+af
+af
+ey
+eE
+bC
+bJ
+bM
+aj
+aV
+ep
+aH
+af
+"}
+(15,1,1) = {"
+aQ
+aj
+aj
+aj
+aj
+aj
+aj
+bu
+bD
 aj
 aj
 aj
 aP
-aj
-aj
-bx
-bL
-bZ
-aj
-aj
-aj
-aj
-di
-dw
-aj
-aa
-aa
-aa
-aa
-"}
-(9,1,1) = {"
-aa
-ab
-ab
+ep
+er
 af
-ak
-aj
-ay
-aQ
-aj
-bo
-bo
-bM
-bM
-ch
-aj
-cE
-cT
-dj
-dx
-dJ
-aj
-ai
-aa
-aa
-"}
-(10,1,1) = {"
-aa
-ab
-ac
-af
-al
-aj
-az
-aR
-aj
-bp
-by
-bN
-bo
-ci
-aj
-cF
-aW
-dk
-dy
-aj
-dN
-aj
-aj
-dT
-"}
-(11,1,1) = {"
-aa
-ab
-ad
-ag
-am
-as
-aA
-aS
-bg
-bq
-bq
-bO
-bM
-cj
-aj
-cG
-cU
-dl
-dz
-dK
-dO
-dR
-dS
-dU
-"}
-(12,1,1) = {"
-aa
-ab
-ae
-af
-an
-aj
-aB
-aQ
-aj
-br
-bz
-bP
-bo
-ck
-aj
-cH
-cV
-dm
-dA
-dL
-dP
-aj
-aj
-dT
-"}
-(13,1,1) = {"
-aa
-ab
-ab
-ah
-ao
-aj
-aC
-aT
-aj
-bo
-bo
-bo
-bM
-cl
-aj
-cI
-cW
-dn
-dB
-dJ
-dQ
-ai
-aa
-aa
-"}
-(14,1,1) = {"
-aa
-aa
-ab
-ab
-aj
-aj
-aD
-aU
-aj
-aj
-bA
-bQ
-ca
-aj
-aj
-aj
-cX
-dn
-dC
-aj
-aa
-aa
-aa
-aa
-"}
-(15,1,1) = {"
-aa
-aa
-aa
-aa
-aj
-at
-aE
-aV
-bh
-aj
-aj
-aj
-aj
-aj
-cu
-cJ
-cX
-do
-aj
-aj
-ai
-aa
-aa
-aa
 "}
 (16,1,1) = {"
-aa
-aa
-aa
-aa
+af
+et
+ew
+ez
+eA
+ao
+av
+bv
+bE
+bK
+bN
 aj
-au
-aF
-aW
-bi
-aD
-bB
-bR
-cb
 aj
-cv
-cK
-cY
-dp
-dD
-dI
-dM
-aa
-aa
-aa
+fW
+af
+af
 "}
 (17,1,1) = {"
-aa
-aa
-aa
-aa
-aj
-av
-aG
-aX
-bj
-bs
-bC
-bS
-cc
-cm
-cw
-cL
-cZ
-dq
-dE
-dI
-dM
-aa
-aa
-aa
-"}
-(18,1,1) = {"
-aa
-aa
-aa
-aa
-ai
-aj
-aH
-aY
-bk
-aj
-bD
-bT
-cd
-cn
-cx
-cM
-da
-dr
-dF
-dI
-dM
-aa
-aa
-aa
-"}
-(19,1,1) = {"
-aa
-aa
-aa
-aa
-aa
-aj
-aI
-aZ
-bl
-aj
-aj
-bU
-aj
-aj
-cy
-cN
-db
-ds
-dG
-dI
-dM
-aa
-aa
-aa
-"}
-(20,1,1) = {"
-aa
-aa
-aa
-aa
-aa
-ai
-ai
-ba
-bm
-aj
-bE
-bV
-ce
-aj
-cz
-cO
-dc
-dt
-dH
-aj
-ai
-aa
-aa
-aa
-"}
-(21,1,1) = {"
-aa
-aa
-aa
-aa
-aa
-aa
-ai
-aj
-aj
-aj
-aj
-bW
-aj
-dV
+af
+af
+af
+fW
 aj
 aj
 aj
 aj
 aj
-ai
-aa
-aa
-aa
-aa
+aj
+aj
+fW
+af
+af
+af
+af
 "}

--- a/_maps/shuttles/pirate_default.dmm
+++ b/_maps/shuttles/pirate_default.dmm
@@ -167,7 +167,7 @@
 /obj/structure/barricade/wooden/crude,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/pod/dark,
-/area/shuttle/pirate)
+/area/shuttle/pirate/vault)
 "aq" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/closet/crate,
@@ -186,7 +186,7 @@
 	dir = 1
 	},
 /turf/open/floor/pod/light,
-/area/shuttle/pirate)
+/area/shuttle/pirate/vault)
 "ar" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/rack{
@@ -207,7 +207,7 @@
 	pixel_x = 32
 	},
 /turf/open/floor/pod/light,
-/area/shuttle/pirate)
+/area/shuttle/pirate/vault)
 "as" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/table,
@@ -229,7 +229,7 @@
 	},
 /obj/machinery/recharger,
 /turf/open/floor/pod/light,
-/area/shuttle/pirate)
+/area/shuttle/pirate/vault)
 "at" = (
 /obj/machinery/light/small,
 /obj/effect/decal/cleanable/dirt,
@@ -251,7 +251,7 @@
 	pixel_y = 10
 	},
 /turf/open/floor/pod/light,
-/area/shuttle/pirate)
+/area/shuttle/pirate/vault)
 "au" = (
 /obj/machinery/door/airlock/hatch{
 	id_tag = "piratebridgebolt";
@@ -279,7 +279,7 @@
 	pixel_x = -28
 	},
 /turf/open/floor/pod/dark,
-/area/shuttle/pirate)
+/area/shuttle/pirate/vault)
 "ax" = (
 /obj/machinery/light/small{
 	dir = 1
@@ -289,7 +289,7 @@
 	dir = 4
 	},
 /turf/open/floor/pod/dark,
-/area/shuttle/pirate)
+/area/shuttle/pirate/vault)
 "ay" = (
 /obj/machinery/door/airlock/highsecurity{
 	name = "Armory"
@@ -299,7 +299,7 @@
 	dir = 4
 	},
 /turf/open/floor/pod/dark,
-/area/shuttle/pirate)
+/area/shuttle/pirate/vault)
 "az" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
 	dir = 1
@@ -665,7 +665,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/pod/dark,
-/area/shuttle/pirate)
+/area/shuttle/pirate/vault)
 "bx" = (
 /obj/machinery/door/airlock{
 	name = "Captain's Quarters"
@@ -744,7 +744,7 @@
 	dir = 1
 	},
 /turf/open/floor/pod/dark,
-/area/shuttle/pirate)
+/area/shuttle/pirate/vault)
 "bH" = (
 /obj/structure/chair/wood/normal,
 /obj/machinery/light/small{
@@ -912,6 +912,15 @@
 	},
 /turf/open/floor/plating,
 /area/shuttle/pirate)
+"df" = (
+/obj/machinery/porta_turret/syndicate/energy{
+	dir = 4;
+	faction = list("pirate");
+	icon_state = "standard_lethal";
+	mode = 1
+	},
+/turf/closed/wall/mineral/plastitanium,
+/area/shuttle/pirate)
 "ek" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/table,
@@ -1075,6 +1084,18 @@
 /obj/machinery/vending/boozeomat/all_access,
 /turf/open/floor/plasteel/bar,
 /area/shuttle/pirate)
+"wR" = (
+/obj/machinery/porta_turret/syndicate/energy{
+	dir = 8;
+	faction = list("pirate");
+	icon_state = "standard_lethal";
+	mode = 1
+	},
+/turf/closed/wall/mineral/plastitanium,
+/area/shuttle/pirate/vault)
+"Oe" = (
+/turf/closed/wall/mineral/plastitanium/nodiagonal,
+/area/shuttle/pirate/vault)
 
 (1,1,1) = {"
 af
@@ -1083,12 +1104,12 @@ af
 fW
 aj
 aj
-aj
-aj
-aj
-aj
-aj
-fW
+Oe
+Oe
+Oe
+Oe
+Oe
+wR
 af
 af
 af
@@ -1106,7 +1127,7 @@ aw
 bw
 bF
 as
-aj
+Oe
 aj
 fW
 af
@@ -1119,12 +1140,12 @@ aj
 aj
 aj
 aj
-aj
+Oe
 ax
 aq
 ar
 at
-aj
+Oe
 aM
 ep
 aH
@@ -1137,12 +1158,12 @@ af
 af
 af
 af
-aj
+Oe
 ay
-aj
-aj
-aj
-aj
+Oe
+Oe
+Oe
+Oe
 br
 ep
 er
@@ -1376,7 +1397,7 @@ aj
 aj
 aj
 aj
-fW
+df
 af
 af
 af


### PR DESCRIPTION
It was my first ship where I started to delve into shuttle atmos and power and it really, really showed.

...So this one's a lot less shit! 

RIP prolapsed anus fuckin' turbine coming out the back, wasted space, and fucking atmosia(??) room that had no place on a pirate event ship. 

![](https://i.imgur.com/OlyakWc.png)

Armory equipment is unchanged. Turrets are syndicate laser type (on pirate faction). They do less damage, but have the option to stun and there are two that cover the front as well, now, should hopefully feel about the same in terms of protection.

EDIT: Added a med wall vendor to the armory.

:cl: WJohnston
add: Redesigned the pirate event ship to be much prettier and better fitting what it was meant to do.
/:cl: