### PR TITLE
Adds five new cargo packs

### DIFF
--- a/code/game/objects/items/stacks/tiles/tile_types.dm
+++ b/code/game/objects/items/stacks/tiles/tile_types.dm
@@ -100,6 +100,9 @@
 	turf_type = /turf/open/floor/carpet
 	resistance_flags = FLAMMABLE
 
+/obj/item/stack/tile/carpet/fifty
+	amount = 50
+
 /obj/item/stack/tile/carpet/black
 	name = "black carpet"
 	icon_state = "tile-carpet-black"

--- a/code/modules/cargo/packs.dm
+++ b/code/modules/cargo/packs.dm
@@ -1052,6 +1052,15 @@
 					/obj/item/storage/firstaid/o2)
 	crate_name = "oxygen deprivation kit crate"
 
+/datum/supply_pack/medical/surgery
+	name = "Surgical Supplies Crate"
+	desc = "Do you want to perform surgery, but don't have one of those fancy shmancy degrees? Just get started with this crate containing a medical duffelbag, Sterilizine spray and collapsible roller bed."
+	cost = 3000
+	contains = list(/obj/item/storage/backpack/duffelbag/med/surgery,
+					/obj/item/reagent_containers/medspray/sterilizine,
+					/obj/item/roller)
+	crate_name = "surgical supplies crate"
+
 /datum/supply_pack/medical/firstaidtoxins
 	name = "Toxin Treatment Kit Crate"
 	desc = "Contains three first aid kits focused on healing damage dealt by heavy toxins."
@@ -1072,7 +1081,8 @@
 					/obj/item/reagent_containers/blood/BPlus,
 					/obj/item/reagent_containers/blood/BMinus,
 					/obj/item/reagent_containers/blood/OPlus,
-					/obj/item/reagent_containers/blood/OMinus)
+					/obj/item/reagent_containers/blood/OMinus,
+					/obj/item/reagent_containers/blood/lizard)
 	crate_name = "blood freezer"
 	crate_type = /obj/structure/closet/crate/freezer
 
@@ -1181,6 +1191,16 @@
 	crate_name = "\improper APLU Ripley circuit crate"
 	crate_type = /obj/structure/closet/crate/secure/science
 
+/datum/supply_pack/science/circuitry
+	name = "Circuitry Starter Pack Crate"
+	desc = "Journey into the mysterious world of Circuitry with this starter pack. Contains a circuit printer, analyzer, debugger and wirer. Power cells not included."
+	cost = 1000
+	contains = list(/obj/item/integrated_electronics/analyzer,
+					/obj/item/integrated_circuit_printer,
+					/obj/item/integrated_electronics/debugger,
+					/obj/item/integrated_electronics/wirer)
+	crate_name = "circuitry starter pack crate"
+
 /datum/supply_pack/science/plasma
 	name = "Plasma Assembly Crate"
 	desc = "Everything you need to burn something to the ground, this contains three plasma assembly sets. Each set contains a plasma tank, igniter, proximity sensor, and timer! Warranty void if exposed to high temperatures. Requires Toxins access to open."
@@ -1257,6 +1277,18 @@
 /datum/supply_pack/service
 	group = "Service"
 
+/datum/supply_pack/service/cargo_supples
+	name = "Cargo Supplies Crate"
+	desc = "Sold everything that wasn't bolted down? You can get right back to work with this crate containing stamps, an export scanner, destination tagger, hand labeler and some package wrapping."
+	cost = 1000
+	contains = list(/obj/item/stamp,
+					/obj/item/stamp/denied,
+					/obj/item/export_scanner,
+					/obj/item/destTagger,
+					/obj/item/hand_labeler,
+					/obj/item/stack/packageWrap)
+	crate_name = "cargo supplies crate"
+
 /datum/supply_pack/service/noslipfloor
 	name = "High-traction Floor Tiles"
 	desc = "Make slipping a thing of the past with thirty industrial-grade anti-slip floortiles!"
@@ -1331,6 +1363,16 @@
 					/obj/item/flashlight/glowstick/yellow,
 					/obj/item/flashlight/glowstick/pink)
 	crate_name = "party equipment crate"
+
+/datum/supply_pack/service/carpet
+	name = "Premium Carpet Crate"
+	desc = "Plasteel floor tiles getting on your nerves? These stacks of extra soft carpet will tie any room together."
+	cost = 2000
+	contains = list(/obj/item/stack/tile/carpet/fifty,
+					/obj/item/stack/tile/carpet/fifty,
+					/obj/item/stack/tile/carpet/black/fifty,
+					/obj/item/stack/tile/carpet/black/fifty)
+	crate_name = "premium carpet crate"
 
 /datum/supply_pack/service/lightbulbs
 	name = "Replacement Lights"
@@ -1753,7 +1795,8 @@
 					/obj/item/storage/fancy/cigarettes/cigpack_syndicate,
 					/obj/item/storage/fancy/cigarettes/cigpack_shadyjims,
 					/obj/item/clothing/mask/gas/syndicate,
-					/obj/item/clothing/neck/necklace/dope)
+					/obj/item/clothing/neck/necklace/dope,
+					/obj/item/vending_refill/donksoft)
 	crate_name = "crate"
 
 /datum/supply_pack/costumes_toys/foamforce
@@ -1950,14 +1993,14 @@
 	crate_name = "autodrobe supply crate"
 
 /datum/supply_pack/costumes_toys/wardrobes/cargo
-	name = "Cargo Department Supply Crate"
+	name = "Cargo Wardrobe Supply Crate"
 	desc = "This crate contains a refill for the CargoDrobe."
 	cost = 750
 	contains = list(/obj/item/vending_refill/wardrobe/cargo_wardrobe)
 	crate_name = "cargo department supply crate"
 
 /datum/supply_pack/costumes_toys/wardrobes/engineering
-	name = "Engineering Department Wardrobe Supply Crate"
+	name = "Engineering Wardrobe Supply Crate"
 	desc = "This crate contains refills for the EngiDrobe and AtmosDrobe."
 	cost = 1500
 	contains = list(/obj/item/vending_refill/wardrobe/engi_wardrobe,
@@ -1983,7 +2026,7 @@
 	crate_name = "hydrobe supply crate"
 
 /datum/supply_pack/costumes_toys/wardrobes/medical
-	name = "Medical Department Wardrobe Supply Crate"
+	name = "Medical Wardrobe Supply Crate"
 	desc = "This crate contains refills for the MediDrobe, ChemDrobe, GeneDrobe, and ViroDrobe."
 	cost = 3000
 	contains = list(/obj/item/vending_refill/wardrobe/medi_wardrobe,
@@ -1993,7 +2036,7 @@
 	crate_name = "medical department wardrobe supply crate"
 
 /datum/supply_pack/costumes_toys/wardrobes/science
-	name = "Science Department Wardrobe Supply Crate"
+	name = "Science Wardrobe Supply Crate"
 	desc = "This crate contains refills for the SciDrobe and RoboDrobe."
 	cost = 1500
 	contains = list(/obj/item/vending_refill/wardrobe/robo_wardrobe,
@@ -2001,7 +2044,7 @@
 	crate_name = "science department wardrobe supply crate"
 
 /datum/supply_pack/costumes_toys/wardrobes/security
-	name = "Security Department Supply Crate"
+	name = "Security Wardrobe Supply Crate"
 	desc = "This crate contains refills for the SecDrobe and LawDrobe."
 	cost = 1500
 	contains = list(/obj/item/vending_refill/wardrobe/sec_wardrobe,

--- a/code/modules/cargo/packs.dm
+++ b/code/modules/cargo/packs.dm
@@ -1367,7 +1367,7 @@
 /datum/supply_pack/service/carpet
 	name = "Premium Carpet Crate"
 	desc = "Plasteel floor tiles getting on your nerves? These stacks of extra soft carpet will tie any room together."
-	cost = 2000
+	cost = 1000
 	contains = list(/obj/item/stack/tile/carpet/fifty,
 					/obj/item/stack/tile/carpet/fifty,
 					/obj/item/stack/tile/carpet/black/fifty,

--- a/code/modules/cargo/packs.dm
+++ b/code/modules/cargo/packs.dm
@@ -2146,7 +2146,7 @@
 /datum/supply_pack/misc/wrapping_paper
 	name = "Festive Wrapping Paper Crate"
 	desc = "Want to mail your loved ones gift-wrapped chocolates, stuffed animals, the Clown's severed head? You can do all that, with this crate full of wrapping paper."
-	cost = 700
+	cost = 1000
 	contains = list(/obj/item/stack/wrapping_paper)
 	crate_type = /obj/structure/closet/crate/wooden
 	crate_name = "festive wrapping paper crate"

--- a/code/modules/cargo/packs.dm
+++ b/code/modules/cargo/packs.dm
@@ -2141,6 +2141,16 @@
 	cost = 700
 	contains = list(/obj/item/storage/box/fountainpens)
 	crate_type = /obj/structure/closet/crate/wooden
+	crate_name = "calligraphy crate"
+
+/datum/supply_pack/misc/wrapping_paper
+	name = "Festive Wrapping Paper Crate"
+	desc = "Want to mail your loved ones gift-wrapped chocolates, stuffed animals, the Clown's severed head? You can do all that, with this crate full of wrapping paper."
+	cost = 700
+	contains = list(/obj/item/stack/wrapping_paper)
+	crate_type = /obj/structure/closet/crate/wooden
+	crate_name = "festive wrapping paper crate"
+
 
 /datum/supply_pack/misc/funeral
 	name = "Funeral Supply crate"


### PR DESCRIPTION
:cl: Denton
add: Added five new cargo packs: cargo supplies, circuitry starter pack, premium carpet, surgical supplies and wrapping paper.
tweak: Added one bag of L type blood to the blood pack crate. Added a chance for contraband crates to contain DonkSoft refill packs.
/:cl:

Four new cargo packs:
- Surgical Supplies Crate: 3000 bucks, contains a medical duffelbag, Sterilizine spray and roller bed. All of these are either printable or obtainable from medbay; this crate is for when medbay gets bombed yet again.
- Circuitry Starter Pack: 1000 bucks, contains a circuit printer, analyzer, debugger and wirer.
- Cargo Supplies: 1000 bucks, contains stamps, an export scanner, destination tagger, hand labeler and package wrapping.
- Premium Carpet: 1000 bucks, contains two stacks of regular and black carpet each.
- Wrapping Paper: 700 bucks, contains a sheet of festive wrapping paper.

Other than that, added an L type bloodbag to blood pack crates (looks like an oversight) and donksoft vendor refills to possible contraband crate contents. 