### PR TITLE
Adding circuits text file in .dme

### DIFF
--- a/tgstation.dme
+++ b/tgstation.dme
@@ -1679,6 +1679,7 @@
 #include "code\modules\integrated_electronics\subtypes\power.dm"
 #include "code\modules\integrated_electronics\subtypes\reagents.dm"
 #include "code\modules\integrated_electronics\subtypes\smart.dm"
+#include "code\modules\integrated_electronics\subtypes\text.dm"
 #include "code\modules\integrated_electronics\subtypes\time.dm"
 #include "code\modules\integrated_electronics\subtypes\trig.dm"
 #include "code\modules\jobs\access.dm"


### PR DESCRIPTION
Adds some of the stuff I did last PR, namely the replacetext circuit, since I forgot to add the new file to the .dme file.

[Changelogs]: # Added a new text category for circuits with more to come.

:cl: Shdorsh
fix: The previously-added find-replace circuit now actually exists.
/:cl:

[why]: # Because I have a tendency to forget about adding new files to the .dme.