### PR TITLE
Fix the power flow control console

### DIFF
--- a/code/game/machinery/computer/apc_control.dm
+++ b/code/game/machinery/computer/apc_control.dm
@@ -28,6 +28,7 @@
 				playsound(active_apc, 'sound/machines/terminal_alert.ogg', 50, 0)
 			active_apc.locked = TRUE
 			active_apc.update_icon()
+			active_apc.remote_control = null
 			active_apc = null
 
 /obj/machinery/computer/apc_control/attack_ai(mob/user)
@@ -121,10 +122,12 @@
 			playsound(active_apc, 'sound/machines/terminal_alert.ogg', 50, 0)
 			active_apc.locked = TRUE
 			active_apc.update_icon()
+			active_apc.remote_control = null
 			active_apc = null
 		to_chat(usr, "<span class='robot notice'>[icon2html(src, usr)] Connected to APC in [get_area_name(APC.area, TRUE)]. Interface request sent.</span>")
 		log_activity("remotely accessed APC in [get_area_name(APC.area, TRUE)]")
-		APC.ui_interact(usr, state = GLOB.not_incapacitated_state)
+		APC.remote_control = src
+		APC.ui_interact(usr)
 		playsound(src, 'sound/machines/terminal_prompt_confirm.ogg', 50, 0)
 		message_admins("[ADMIN_LOOKUPFLW(usr)] remotely accessed [APC] from [src] at [AREACOORD(src)].")
 		log_game("[key_name(usr)] remotely accessed [APC] from [src] at [AREACOORD(src)].")

--- a/code/modules/power/apc.dm
+++ b/code/modules/power/apc.dm
@@ -101,10 +101,11 @@
 	var/update_state = -1
 	var/update_overlay = -1
 	var/icon_update_needed = FALSE
+	var/obj/machinery/computer/apc_control/remote_control = null
 
 /obj/machinery/power/apc/unlocked
 	locked = FALSE
-	
+
 /obj/machinery/power/apc/syndicate //general syndicate access
 	req_access = list(ACCESS_SYNDICATE)
 
@@ -116,14 +117,14 @@
 
 /obj/machinery/power/apc/highcap/fifteen_k
 	cell_type = /obj/item/stock_parts/cell/high/plus
-	
+
 /obj/machinery/power/apc/auto_name
 	auto_name = TRUE
-	
+
 /obj/machinery/power/apc/auto_name/north //Pixel offsets get overwritten on New()
 	dir = NORTH
 	pixel_y = 23
-	
+
 /obj/machinery/power/apc/auto_name/south
 	dir = SOUTH
 	pixel_y = -23
@@ -131,7 +132,7 @@
 /obj/machinery/power/apc/auto_name/east
 	dir = EAST
 	pixel_x = 24
-	
+
 /obj/machinery/power/apc/auto_name/west
 	dir = WEST
 	pixel_x = -25
@@ -881,6 +882,16 @@
 				to_chat(user, "<span class='danger'>\The [src] has eee disabled!</span>")
 			return FALSE
 	return TRUE
+
+/obj/machinery/power/apc/can_interact(mob/user)
+	. = ..()
+	if (!. && !QDELETED(remote_control))
+		. = remote_control.can_interact(user)
+
+/obj/machinery/power/apc/ui_status(mob/user)
+	. = ..()
+	if (!QDELETED(remote_control) && user == remote_control.operator)
+		. = UI_INTERACTIVE
 
 /obj/machinery/power/apc/ui_act(action, params)
 	if(..() || !can_use(usr, 1) || (locked && !usr.has_unlimited_silicon_privilege && !failure_timer && !(integration_cog && (is_servant_of_ratvar(usr)))))


### PR DESCRIPTION
:cl:
fix: The power flow control console once again allows actually modifying APCs.
/:cl:

Fixes #39449. The console can now *actually* only control one APC at a time, rather than allowing continued access to every APC opened as it did before #38939.