### PR TITLE
Replace z_is_planet with a Z trait

### DIFF
--- a/code/__DEFINES/maps.dm
+++ b/code/__DEFINES/maps.dm
@@ -37,6 +37,8 @@ require only minor tweaks.
 #define ZTRAIT_AWAY "Away Mission"
 #define ZTRAIT_SPACE_RUINS "Space Ruins"
 #define ZTRAIT_LAVA_RUINS "Lava Ruins"
+// prevents certain turfs from being stripped by a singularity
+#define ZTRAIT_PLANET "Planet"
 
 // number - bombcap is multiplied by this before being applied to bombs
 #define ZTRAIT_BOMBCAP_MULTIPLIER "Bombcap Multiplier"

--- a/code/__HELPERS/level_traits.dm
+++ b/code/__HELPERS/level_traits.dm
@@ -14,4 +14,4 @@
 #define is_away_level(z) SSmapping.level_trait(z, ZTRAIT_AWAY)
 
 // If true, the singularity cannot strip away asteroid turf on this Z
-#define is_planet_level(z) (GLOB.z_is_planet["z"])
+#define is_planet_level(z) SSmapping.level_trait(z, ZTRAIT_PLANET)

--- a/code/modules/mapping/mapping_helpers.dm
+++ b/code/modules/mapping/mapping_helpers.dm
@@ -145,17 +145,15 @@ INITIALIZE_IMMEDIATE(/obj/effect/mapping_helpers/no_lava)
 	var/turf/T = get_turf(src)
 	T.flags_1 |= NO_LAVA_GEN_1
 
-//Contains the list of planetary z-levels defined by the planet_z helper.
-GLOBAL_LIST_EMPTY(z_is_planet)
-
-/obj/effect/mapping_helpers/planet_z //adds the map it is on to the z_is_planet list
+/// Adds the map it is on to the z_is_planet list
+/obj/effect/mapping_helpers/planet_z
 	name = "planet z helper"
 	layer = POINT_LAYER
 
 /obj/effect/mapping_helpers/planet_z/Initialize()
 	. = ..()
-	var/turf/T = get_turf(src)
-	GLOB.z_is_planet["[T.z]"] = TRUE
+	var/datum/space_level/S = SSmapping.get_level(z)
+	S.traits[ZTRAIT_PLANET] = TRUE
 
 
 //This helper applies components to things on the map directly.


### PR DESCRIPTION
Should have been done long ago.

The mapping helper needs to stay for now because away missions can't specify Z traits yet.