### PR TITLE
Refactors and improves briefcase launchpad

### DIFF
--- a/code/game/machinery/launch_pad.dm
+++ b/code/game/machinery/launch_pad.dm
@@ -148,14 +148,14 @@
 	idle_power_usage = 0
 	active_power_usage = 0
 	teleport_speed = 20
-	range = 3
+	range = 5
 	stationary = FALSE
 	var/closed = TRUE
-	var/obj/item/briefcase_launchpad/briefcase
+	var/obj/item/storage/briefcase_launchpad/briefcase
 
 /obj/machinery/launchpad/briefcase/Initialize()
 	. = ..()
-	if(istype(loc, /obj/item/briefcase_launchpad))
+	if(istype(loc, /obj/item/storage/briefcase_launchpad))
 		briefcase = loc
 	else
 		log_game("[src] has been spawned without a briefcase.")
@@ -192,7 +192,7 @@
 		return ..()
 
 //Briefcase item that contains the launchpad.
-/obj/item/briefcase_launchpad
+/obj/item/storage/briefcase_launchpad
 	name = "briefcase"
 	desc = "It's made of AUTHENTIC faux-leather and has a price-tag still attached. Its owner must be a real professional."
 	icon = 'icons/obj/storage.dmi'
@@ -209,18 +209,29 @@
 	resistance_flags = FLAMMABLE
 	max_integrity = 150
 	var/obj/machinery/launchpad/briefcase/pad
+	var/folder_path = /obj/item/folder //this is the path of the folder that gets spawned in New()
 
-/obj/item/briefcase_launchpad/Initialize()
+/obj/item/storage/briefcase_launchpad/Initialize()
 	. = ..()
 	pad = new(src)
 
-/obj/item/briefcase_launchpad/Destroy()
+/obj/item/storage/briefcase_launchpad/Destroy()
 	if(!QDELETED(pad))
 		qdel(pad)
 	pad = null
 	return ..()
 
-/obj/item/briefcase_launchpad/attack_self(mob/user)
+/obj/item/storage/briefcase_launchpad/ComponentInitialize()
+	. = ..()
+	GET_COMPONENT(STR, /datum/component/storage)
+	STR.max_w_class = WEIGHT_CLASS_NORMAL
+	STR.max_combined_w_class = 21
+
+/obj/item/storage/briefcase_launchpad/PopulateContents()
+	new /obj/item/pen(src)
+	new /obj/item/launchpad_remote(src)
+
+/obj/item/storage/briefcase_launchpad/attack_self(mob/user)
 	if(!isturf(user.loc)) //no setting up in a locker
 		return
 	add_fingerprint(user)
@@ -230,7 +241,7 @@
 		pad.closed = FALSE
 		user.transferItemToLoc(src, pad, TRUE)
 
-/obj/item/briefcase_launchpad/attackby(obj/item/I, mob/user, params)
+/obj/item/storage/briefcase_launchpad/attackby(obj/item/I, mob/user, params)
 	if(istype(I, /obj/item/launchpad_remote))
 		var/obj/item/launchpad_remote/L = I
 		L.pad = src.pad
@@ -239,14 +250,18 @@
 		return ..()
 
 /obj/item/launchpad_remote
-	name = "\improper Launchpad Control Remote"
-	desc = "Used to teleport objects to and from a portable launchpad."
-	icon = 'icons/obj/telescience.dmi'
-	icon_state = "blpad-remote"
+	name = "folder"
+	desc = "A folder."
+	icon = 'icons/obj/bureaucracy.dmi'
+	icon_state = "folder"
 	w_class = WEIGHT_CLASS_SMALL
-	slot_flags = ITEM_SLOT_BELT
 	var/sending = TRUE
 	var/obj/machinery/launchpad/briefcase/pad
+
+/obj/item/launchpad_remote/attack_self(mob/user)
+	. = ..()
+	ui_interact(user)
+	to_chat(user, "<span class='notice'>The folder projects a display onto your retina.</span>")
 
 /obj/item/launchpad_remote/ui_interact(mob/user, ui_key = "launchpad_remote", datum/tgui/ui = null, force_open = FALSE, datum/tgui/master_ui = null, datum/ui_state/state = GLOB.default_state)
 	ui = SStgui.try_update_ui(user, src, ui_key, ui, force_open)

--- a/code/game/machinery/launch_pad.dm
+++ b/code/game/machinery/launch_pad.dm
@@ -185,6 +185,8 @@
 /obj/machinery/launchpad/briefcase/attackby(obj/item/I, mob/user, params)
 	if(istype(I, /obj/item/launchpad_remote))
 		var/obj/item/launchpad_remote/L = I
+		if(L.pad == src) //do not attempt to link when already linked
+			return ..()
 		L.pad = src
 		to_chat(user, "<span class='notice'>You link [src] to [L].</span>")
 	else
@@ -196,7 +198,7 @@
 
 /obj/item/storage/briefcase/launchpad/Initialize()
 	. = ..()
-	pad = new(null, src)
+	pad = new(null, src) //spawns pad in nullspace to hide it from briefcase contents
 
 /obj/item/storage/briefcase/launchpad/Destroy()
 	if(!QDELETED(pad))
@@ -205,7 +207,7 @@
 
 /obj/item/storage/briefcase/launchpad/PopulateContents()
 	new /obj/item/pen(src)
-	new /obj/item/launchpad_remote(src)
+	new /obj/item/launchpad_remote(src, pad) 
 
 /obj/item/storage/briefcase/launchpad/attack_self(mob/user)
 	if(!isturf(user.loc)) //no setting up in a locker
@@ -218,14 +220,6 @@
 		user.transferItemToLoc(src, pad, TRUE)
 		SEND_SIGNAL(src, COMSIG_TRY_STORAGE_HIDE_ALL)
 
-/obj/item/storage/briefcase/launchpad/attackby(obj/item/I, mob/user, params)
-	if(istype(I, /obj/item/launchpad_remote))
-		var/obj/item/launchpad_remote/L = I
-		L.pad = src.pad
-		to_chat(user, "<span class='notice'>You link [pad] to [L].</span>")
-	else
-		return ..()
-
 /obj/item/launchpad_remote
 	name = "folder"
 	desc = "A folder."
@@ -234,6 +228,10 @@
 	w_class = WEIGHT_CLASS_SMALL
 	var/sending = TRUE
 	var/obj/machinery/launchpad/briefcase/pad
+
+/obj/item/launchpad_remote/Initialize(mapload, pad) //remote spawns linked to the briefcase pad
+	. = ..()
+	src.pad = pad
 
 /obj/item/launchpad_remote/attack_self(mob/user)
 	. = ..()

--- a/code/game/machinery/launch_pad.dm
+++ b/code/game/machinery/launch_pad.dm
@@ -180,7 +180,7 @@
 		usr.visible_message("<span class='notice'>[usr] starts closing [src]...</span>", "<span class='notice'>You start closing [src]...</span>")
 		if(do_after(usr, 30, target = usr))
 			usr.put_in_hands(briefcase)
-			forceMove(briefcase)
+			moveToNullspace() //hides it from suitcase contents
 			closed = TRUE
 
 /obj/machinery/launchpad/briefcase/attackby(obj/item/I, mob/user, params)
@@ -200,7 +200,9 @@
 	pad = new(src)
 
 /obj/item/storage/briefcase/launchpad/Destroy()
-	QDEL_NULL(pad)
+	if(!QDELETED(pad))
+		qdel(pad)
+	pad = null
 	return ..()
 
 /obj/item/storage/briefcase/launchpad/PopulateContents()

--- a/code/game/machinery/launch_pad.dm
+++ b/code/game/machinery/launch_pad.dm
@@ -11,7 +11,7 @@
 	var/stationary = TRUE //to prevent briefcase pad deconstruction and such
 	var/display_name = "Launchpad"
 	var/teleport_speed = 35
-	var/range = 5
+	var/range = 8
 	var/teleporting = FALSE //if it's in the process of teleporting
 	var/power_efficiency = 1
 	var/x_offset = 0
@@ -148,7 +148,7 @@
 	idle_power_usage = 0
 	active_power_usage = 0
 	teleport_speed = 20
-	range = 6
+	range = 8
 	stationary = FALSE
 	var/closed = TRUE
 	var/obj/item/storage/briefcase/launchpad/briefcase
@@ -197,8 +197,8 @@
 	var/obj/machinery/launchpad/briefcase/pad
 
 /obj/item/storage/briefcase/launchpad/Initialize()
-	. = ..()
 	pad = new(null, src) //spawns pad in nullspace to hide it from briefcase contents
+	. = ..()
 
 /obj/item/storage/briefcase/launchpad/Destroy()
 	if(!QDELETED(pad))

--- a/code/game/machinery/launch_pad.dm
+++ b/code/game/machinery/launch_pad.dm
@@ -201,8 +201,7 @@
 
 /obj/item/storage/briefcase/launchpad/Destroy()
 	if(!QDELETED(pad))
-		qdel(pad)
-	pad = null
+		QDEL_NULL(pad)
 	return ..()
 
 /obj/item/storage/briefcase/launchpad/PopulateContents()

--- a/code/game/machinery/launch_pad.dm
+++ b/code/game/machinery/launch_pad.dm
@@ -148,7 +148,7 @@
 	idle_power_usage = 0
 	active_power_usage = 0
 	teleport_speed = 20
-	range = 5
+	range = 6
 	stationary = FALSE
 	var/closed = TRUE
 	var/obj/item/storage/briefcase/launchpad/briefcase
@@ -217,6 +217,7 @@
 		pad.forceMove(get_turf(src))
 		pad.closed = FALSE
 		user.transferItemToLoc(src, pad, TRUE)
+		SEND_SIGNAL(src, COMSIG_TRY_STORAGE_HIDE_ALL)
 
 /obj/item/storage/briefcase/launchpad/attackby(obj/item/I, mob/user, params)
 	if(istype(I, /obj/item/launchpad_remote))

--- a/code/game/machinery/launch_pad.dm
+++ b/code/game/machinery/launch_pad.dm
@@ -11,7 +11,7 @@
 	var/stationary = TRUE //to prevent briefcase pad deconstruction and such
 	var/display_name = "Launchpad"
 	var/teleport_speed = 35
-	var/range = 8
+	var/range = 15
 	var/teleporting = FALSE //if it's in the process of teleporting
 	var/power_efficiency = 1
 	var/x_offset = 0
@@ -219,6 +219,16 @@
 		pad.closed = FALSE
 		user.transferItemToLoc(src, pad, TRUE)
 		SEND_SIGNAL(src, COMSIG_TRY_STORAGE_HIDE_ALL)
+
+/obj/item/storage/briefcase/launchpad/attackby(obj/item/I, mob/user, params)
+	if(istype(I, /obj/item/launchpad_remote))
+		var/obj/item/launchpad_remote/L = I
+		if(L.pad == src.pad) //do not attempt to link when already linked
+			return ..()
+		L.pad = src.pad
+		to_chat(user, "<span class='notice'>You link [pad] to [L].</span>")
+	else
+		return ..()	
 
 /obj/item/launchpad_remote
 	name = "folder"

--- a/code/game/machinery/launch_pad.dm
+++ b/code/game/machinery/launch_pad.dm
@@ -197,7 +197,7 @@
 
 /obj/item/storage/briefcase/launchpad/Initialize()
 	. = ..()
-	pad = new(src)
+	pad = new(null)
 
 /obj/item/storage/briefcase/launchpad/Destroy()
 	if(!QDELETED(pad))

--- a/code/game/machinery/launch_pad.dm
+++ b/code/game/machinery/launch_pad.dm
@@ -153,13 +153,12 @@
 	var/closed = TRUE
 	var/obj/item/storage/briefcase/launchpad/briefcase
 
-/obj/machinery/launchpad/briefcase/Initialize()
-	. = ..()
-	if(istype(loc, /obj/item/storage/briefcase/launchpad))
-		briefcase = loc
-	else
-		log_game("[src] has been spawned without a briefcase.")
-		return INITIALIZE_HINT_QDEL
+/obj/machinery/launchpad/briefcase/Initialize(mapload, briefcase)
+    . = ..()
+    if(!briefcase)
+        log_game("[src] has been spawned without a briefcase.")
+        return INITIALIZE_HINT_QDEL
+    src.briefcase = briefcase
 
 /obj/machinery/launchpad/briefcase/Destroy()
 	QDEL_NULL(briefcase)
@@ -197,7 +196,7 @@
 
 /obj/item/storage/briefcase/launchpad/Initialize()
 	. = ..()
-	pad = new(null)
+	pad = new(null, src)
 
 /obj/item/storage/briefcase/launchpad/Destroy()
 	if(!QDELETED(pad))

--- a/code/game/machinery/launch_pad.dm
+++ b/code/game/machinery/launch_pad.dm
@@ -151,11 +151,11 @@
 	range = 5
 	stationary = FALSE
 	var/closed = TRUE
-	var/obj/item/storage/briefcase_launchpad/briefcase
+	var/obj/item/storage/briefcase/launchpad/briefcase
 
 /obj/machinery/launchpad/briefcase/Initialize()
 	. = ..()
-	if(istype(loc, /obj/item/storage/briefcase_launchpad))
+	if(istype(loc, /obj/item/storage/briefcase/launchpad))
 		briefcase = loc
 	else
 		log_game("[src] has been spawned without a briefcase.")
@@ -192,46 +192,24 @@
 		return ..()
 
 //Briefcase item that contains the launchpad.
-/obj/item/storage/briefcase_launchpad
-	name = "briefcase"
-	desc = "It's made of AUTHENTIC faux-leather and has a price-tag still attached. Its owner must be a real professional."
-	icon = 'icons/obj/storage.dmi'
-	icon_state = "briefcase"
-	lefthand_file = 'icons/mob/inhands/equipment/briefcase_lefthand.dmi'
-	righthand_file = 'icons/mob/inhands/equipment/briefcase_righthand.dmi'
-	flags_1 = CONDUCT_1
-	force = 8
-	hitsound = "swing_hit"
-	throw_speed = 2
-	throw_range = 4
-	w_class = WEIGHT_CLASS_BULKY
-	attack_verb = list("bashed", "battered", "bludgeoned", "thrashed", "whacked")
-	resistance_flags = FLAMMABLE
-	max_integrity = 150
+/obj/item/storage/briefcase/launchpad
 	var/obj/machinery/launchpad/briefcase/pad
-	var/folder_path = /obj/item/folder //this is the path of the folder that gets spawned in New()
 
-/obj/item/storage/briefcase_launchpad/Initialize()
+/obj/item/storage/briefcase/launchpad/Initialize()
 	. = ..()
 	pad = new(src)
 
-/obj/item/storage/briefcase_launchpad/Destroy()
+/obj/item/storage/briefcase/launchpad/Destroy()
 	if(!QDELETED(pad))
 		qdel(pad)
 	pad = null
 	return ..()
 
-/obj/item/storage/briefcase_launchpad/ComponentInitialize()
-	. = ..()
-	GET_COMPONENT(STR, /datum/component/storage)
-	STR.max_w_class = WEIGHT_CLASS_NORMAL
-	STR.max_combined_w_class = 21
-
-/obj/item/storage/briefcase_launchpad/PopulateContents()
+/obj/item/storage/briefcase/launchpad/PopulateContents()
 	new /obj/item/pen(src)
 	new /obj/item/launchpad_remote(src)
 
-/obj/item/storage/briefcase_launchpad/attack_self(mob/user)
+/obj/item/storage/briefcase/launchpad/attack_self(mob/user)
 	if(!isturf(user.loc)) //no setting up in a locker
 		return
 	add_fingerprint(user)
@@ -241,7 +219,7 @@
 		pad.closed = FALSE
 		user.transferItemToLoc(src, pad, TRUE)
 
-/obj/item/storage/briefcase_launchpad/attackby(obj/item/I, mob/user, params)
+/obj/item/storage/briefcase/launchpad/attackby(obj/item/I, mob/user, params)
 	if(istype(I, /obj/item/launchpad_remote))
 		var/obj/item/launchpad_remote/L = I
 		L.pad = src.pad
@@ -261,7 +239,7 @@
 /obj/item/launchpad_remote/attack_self(mob/user)
 	. = ..()
 	ui_interact(user)
-	to_chat(user, "<span class='notice'>The folder projects a display onto your retina.</span>")
+	to_chat(user, "<span class='notice'>[src] projects a display onto your retina.</span>")
 
 /obj/item/launchpad_remote/ui_interact(mob/user, ui_key = "launchpad_remote", datum/tgui/ui = null, force_open = FALSE, datum/tgui/master_ui = null, datum/ui_state/state = GLOB.default_state)
 	ui = SStgui.try_update_ui(user, src, ui_key, ui, force_open)

--- a/code/game/machinery/launch_pad.dm
+++ b/code/game/machinery/launch_pad.dm
@@ -200,9 +200,7 @@
 	pad = new(src)
 
 /obj/item/storage/briefcase/launchpad/Destroy()
-	if(!QDELETED(pad))
-		qdel(pad)
-	pad = null
+	QDEL_NULL(pad)
 	return ..()
 
 /obj/item/storage/briefcase/launchpad/PopulateContents()

--- a/code/modules/uplink/uplink_items.dm
+++ b/code/modules/uplink/uplink_items.dm
@@ -1053,7 +1053,7 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 
 /datum/uplink_item/device_tools/briefcase_launchpad
 	name = "Briefcase Launchpad"
-	desc = "A briefcase containing a launchpad, a device able to teleport items and people to and from targets up to five tiles away from the briefcase. \
+	desc = "A briefcase containing a launchpad, a device able to teleport items and people to and from targets up to six tiles away from the briefcase. \
 			Also includes a remote control, disguised as an ordinary folder. Touch the briefcase with the remote to link it."
 	surplus = 0
 	item = /obj/item/storage/briefcase/launchpad

--- a/code/modules/uplink/uplink_items.dm
+++ b/code/modules/uplink/uplink_items.dm
@@ -1056,7 +1056,7 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 	desc = "A briefcase containing a launchpad, a device able to teleport items and people to and from targets up to five tiles away from the briefcase. \
 			Also includes a remote control, disguised as an ordinary folder. Touch the briefcase with the remote to link it."
 	surplus = 0
-	item = /obj/item/storage/briefcase_launchpad
+	item = /obj/item/storage/briefcase/launchpad
 	cost = 6
 
 /datum/uplink_item/device_tools/magboots

--- a/code/modules/uplink/uplink_items.dm
+++ b/code/modules/uplink/uplink_items.dm
@@ -1053,7 +1053,7 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 
 /datum/uplink_item/device_tools/briefcase_launchpad
 	name = "Briefcase Launchpad"
-	desc = "A briefcase containing a launchpad, a device able to teleport items and people to and from targets up to six tiles away from the briefcase. \
+	desc = "A briefcase containing a launchpad, a device able to teleport items and people to and from targets up to eight tiles away from the briefcase. \
 			Also includes a remote control, disguised as an ordinary folder. Touch the briefcase with the remote to link it."
 	surplus = 0
 	item = /obj/item/storage/briefcase/launchpad

--- a/code/modules/uplink/uplink_items.dm
+++ b/code/modules/uplink/uplink_items.dm
@@ -1053,15 +1053,11 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 
 /datum/uplink_item/device_tools/briefcase_launchpad
 	name = "Briefcase Launchpad"
-	desc = "A briefcase containing a launchpad, a device able to teleport items and people to and from targets up to three tiles away from the briefcase. \
-			Also includes a remote control. Touch the briefcase with the remote to link it."
+	desc = "A briefcase containing a launchpad, a device able to teleport items and people to and from targets up to five tiles away from the briefcase. \
+			Also includes a remote control, disguised as an ordinary folder. Touch the briefcase with the remote to link it."
 	surplus = 0
-	item = /obj/item/briefcase_launchpad
+	item = /obj/item/storage/briefcase_launchpad
 	cost = 6
-
-/datum/uplink_item/device_tools/briefcase_launchpad/purchase(mob/user, datum/component/uplink/U)
-	spawn_item(/obj/item/launchpad_remote, user) //free remote
-	..()
 
 /datum/uplink_item/device_tools/magboots
 	name = "Blood-Red Magboots"


### PR DESCRIPTION
:cl: Denton
tweak: The briefcase launchpad can now hold items while in briefcase mode (just like a regular briefcase). Its remote has been disguised as a folder and now spawns pre-linked inside the briefcase.
balance: Increased the briefcase launchpad's range from 3 to 8 tiles, which is roughly half the screen.
/:cl:

According to statbus, the bluespace launchpad is purchased in less than 2% of rounds on average. It's obvious why - it's slow, loud and extremely noticable with a short range.

I refactored it to storage/briefcase/launchpad (thanks XDTM) and disguised the remote as a folder that spawns inside the briefcase. 
This will make it harder to detect than a briefcase that can't actually hold items and a red remote that screams "hi I'm valid".
On top of that, I increased the teleport range from 3 to 8 (roughly half the screen). It still has the slow and very obvious animation, but can finally be used to retrieve and send items that aren't at the corner of a room.