### PR TITLE
Makes synths not metabolize reagents

### DIFF
--- a/code/modules/mob/living/carbon/human/species_types/synths.dm
+++ b/code/modules/mob/living/carbon/human/species_types/synths.dm
@@ -33,9 +33,8 @@
 	if(chem.id == "synthflesh")
 		chem.reaction_mob(H, TOUCH, 2 ,0) //heal a little
 		H.reagents.remove_reagent(chem.id, REAGENTS_METABOLISM)
-		return 1
-	else
-		return ..()
+	..()
+	return 1
 
 
 /datum/species/synth/proc/assume_disguise(datum/species/S, mob/living/carbon/human/H)

--- a/code/modules/mob/living/carbon/human/species_types/synths.dm
+++ b/code/modules/mob/living/carbon/human/species_types/synths.dm
@@ -34,7 +34,7 @@
 		chem.reaction_mob(H, TOUCH, 2 ,0) //heal a little
 		H.reagents.remove_reagent(chem.id, REAGENTS_METABOLISM)
 	..()
-	return 1
+	return TRUE
 
 
 /datum/species/synth/proc/assume_disguise(datum/species/S, mob/living/carbon/human/H)


### PR DESCRIPTION
According to the wiki, they aren't supposed to metabolize chems

:cl: McDonald072
fix: Synths don't process chemicals anymore.
/:cl:
