### PR TITLE
Prefer non-hidden pipes in gas meter targeting

### DIFF
--- a/code/modules/atmospherics/machinery/other/meter.dm
+++ b/code/modules/atmospherics/machinery/other/meter.dm
@@ -40,11 +40,15 @@
 	return ..()
 
 /obj/machinery/meter/proc/reattach_to_layer()
+	var/obj/machinery/atmospherics/candidate
 	for(var/obj/machinery/atmospherics/pipe/pipe in loc)
 		if(pipe.piping_layer == target_layer)
-			target = pipe
-			setAttachLayer(pipe.piping_layer)
-			break
+			candidate = pipe
+			if(pipe.level == 2)
+				break
+	if(candidate)
+		target = candidate
+		setAttachLayer(candidate.piping_layer)
 
 /obj/machinery/meter/proc/setAttachLayer(var/new_layer)
 	target_layer = new_layer
@@ -140,6 +144,5 @@
 //	why are you yelling?
 /obj/machinery/meter/turf
 
-/obj/machinery/meter/turf/Initialize()
-	. = ..()
+/obj/machinery/meter/turf/reattach_to_layer()
 	target = loc


### PR DESCRIPTION
:cl:
tweak: Gas meters will now prefer to target visible pipes if they share a turf with hidden pipes.
/:cl:

Fixes #39584