### PR TITLE
Augmentation uses replace_limb instead of manually doing the same

### DIFF
--- a/code/modules/surgery/limb_augmentation.dm
+++ b/code/modules/surgery/limb_augmentation.dm
@@ -57,8 +57,7 @@
 			tool.cut_overlays()
 			tool = tool.contents[1]
 		if(istype(tool) && user.temporarilyRemoveItemFromInventory(tool))
-			L.drop_limb(TRUE) //The limb is augmented, not directly replaced, so keep the internal organs
-			tool.attach_limb(target)
+			tool.replace_limb(target)
 		user.visible_message("[user] successfully augments [target]'s [parse_zone(target_zone)]!", "<span class='notice'>You successfully augment [target]'s [parse_zone(target_zone)].</span>")
 		add_logs(user, target, "augmented", addition="by giving him new [parse_zone(target_zone)] INTENT: [uppertext(user.a_intent)]")
 	else


### PR DESCRIPTION
Fixes #39485

I can't believe i never noticed that there's a perfect proc for this surgery

I also can't believe that it was there all along but the surgery still used to varedit the robotic status into the limb