### PR TITLE
Fix bunch of runtimes involving transformation diseases, and also a way to avoid job bans

### DIFF
--- a/code/datums/diseases/transformation.dm
+++ b/code/datums/diseases/transformation.dm
@@ -86,6 +86,9 @@
 	else
 		to_chat(new_mob, "Your mob has been claimed by death! Appeal your job ban if you want to avoid this in the future!")
 		new_mob.death()
+		if (!QDELETED(new_mob))
+			new_mob.ghostize(can_reenter_corpse = FALSE)
+			new_mob.key = null
 
 /datum/disease/transformation/jungle_fever
 	name = "Jungle Fever"

--- a/code/modules/mob/living/carbon/human/life.dm
+++ b/code/modules/mob/living/carbon/human/life.dm
@@ -23,7 +23,12 @@
 	if (notransform)
 		return
 
-	if(..()) //not dead
+	. = ..()
+
+	if (QDELETED(src))
+		return 0
+
+	if(.) //not dead
 		handle_active_genes()
 
 	if(stat != DEAD)

--- a/code/modules/mob/living/carbon/life.dm
+++ b/code/modules/mob/living/carbon/life.dm
@@ -11,7 +11,12 @@
 	if(stat != DEAD) //Reagent processing needs to come before breathing, to prevent edge cases.
 		handle_organs()
 
-	if(..()) //not dead
+	. = ..()
+
+	if (QDELETED(src))
+		return
+
+	if(.) //not dead
 		handle_blood()
 
 	if(stat != DEAD)

--- a/code/modules/mob/living/life.dm
+++ b/code/modules/mob/living/life.dm
@@ -43,7 +43,10 @@
 		//Breathing, if applicable
 		handle_breathing(times_fired)
 
-	handle_diseases() // DEAD check is in the proc itself; we want it to spread even if the mob is dead, but to handle its disease-y properties only if you're not.
+	handle_diseases()// DEAD check is in the proc itself; we want it to spread even if the mob is dead, but to handle its disease-y properties only if you're not.
+
+	if (QDELETED(src)) // diseases can qdel the mob via transformations
+		return
 
 	if(stat != DEAD)
 		//Random events (vomiting etc)


### PR DESCRIPTION
Transformation diseases checked for jobban by path, paths are not valid bantypes

:cl: Naksu
fix: Transformation diseases now properly check for job bans where applicable
code: Fixed a bunch of runtimes that result from transforming into a nonhuman from a human, or a noncarbon from a carbon.
/:cl:

