### PR TITLE
Portable flashers will only count sucessful flashes towards burnout probability

### DIFF
--- a/code/game/machinery/flasher.dm
+++ b/code/game/machinery/flasher.dm
@@ -100,19 +100,23 @@
 	if(!bulb.flash_recharge(30)) //Bulb can burn out if it's used too often too fast
 		power_change()
 		return
-	bulb.times_used ++
 
 	playsound(src.loc, 'sound/weapons/flash.ogg', 100, 1)
 	flick("[base_state]_flash", src)
 	last_flash = world.time
 	use_power(1000)
 
+	var/flashed = FALSE
 	for (var/mob/living/L in viewers(src, null))
 		if (get_dist(src, L) > range)
 			continue
 
 		if(L.flash_act(affect_silicon = 1))
 			L.Knockdown(strength)
+			flashed = TRUE
+
+	if(flashed)
+		bulb.times_used++
 
 	return 1
 


### PR DESCRIPTION
:cl:
balance: Portable flashers won't burnout from failed flashes.
/:cl:

Might be probability on failure instead if this is too useful, but right now they're just waste of space and time.