### PR TITLE
Allows admins to make pneumatic cannons fire nonitems

### DIFF
--- a/code/game/objects/items/pneumaticCannon.dm
+++ b/code/game/objects/items/pneumaticCannon.dm
@@ -165,7 +165,7 @@
 				    		 "<span class='danger'>You fire \the [src]!</span>")
 	add_logs(user, target, "fired at", src)
 	var/turf/T = get_target(target, get_turf(src))
-	playsound(src.loc, 'sound/weapons/sonic_jackhammer.ogg', 50, 1)
+	playsound(src, 'sound/weapons/sonic_jackhammer.ogg', 50, 1)
 	fire_items(T, user)
 	if(pressureSetting >= 3 && iscarbon(user))
 		var/mob/living/carbon/C = user
@@ -227,31 +227,31 @@
 
 /obj/item/pneumatic_cannon/proc/updateTank(obj/item/tank/internals/thetank, removing = 0, mob/living/carbon/human/user)
 	if(removing)
-		if(!src.tank)
+		if(!tank)
 			return
 		to_chat(user, "<span class='notice'>You detach \the [thetank] from \the [src].</span>")
-		src.tank.forceMove(user.drop_location())
+		tank.forceMove(user.drop_location())
 		user.put_in_hands(tank)
-		src.tank = null
+		tank = null
 	if(!removing)
-		if(src.tank)
+		if(tank)
 			to_chat(user, "<span class='warning'>\The [src] already has a tank.</span>")
 			return
 		if(!user.transferItemToLoc(thetank, src))
 			return
 		to_chat(user, "<span class='notice'>You hook \the [thetank] up to \the [src].</span>")
-		src.tank = thetank
-	src.update_icons()
+		tank = thetank
+	update_icons()
 
 /obj/item/pneumatic_cannon/proc/update_icons()
-	src.cut_overlays()
+	cut_overlays()
 	if(!tank)
 		return
 	add_overlay(tank.icon_state)
-	src.update_icon()
+	update_icon()
 
 /obj/item/pneumatic_cannon/proc/fill_with_type(type, amount)
-	if(!ispath(type, /obj/item))
+	if(!ispath(type, /obj) && !ispath(type, /mob))
 		return FALSE
 	var/loaded = 0
 	for(var/i in 1 to amount)

--- a/code/game/objects/items/pneumaticCannon.dm
+++ b/code/game/objects/items/pneumaticCannon.dm
@@ -98,6 +98,8 @@
 		load_item(IW, user)
 
 /obj/item/pneumatic_cannon/proc/can_load_item(obj/item/I, mob/user)
+	if(!istype(I))			//Players can't load non items, this allows for admin varedit inserts.
+		return TRUE
 	if(allowed_typecache && !is_type_in_typecache(I, allowed_typecache))
 		if(user)
 			to_chat(user, "<span class='warning'>[I] won't fit into [src]!</span>")


### PR DESCRIPTION
Why: Allows varediting of the charge type to non items, like meteors and such. This shouldn't be that dangerous, because players can't load in things they can't even pick up (non items).
Also, isitem() is already checked on attackby().
It is still constrained to /objs and /mobs, as I cannot fathom why admins would want to fire something that isn't an /obj or /mob...