### PR TITLE
Makes the signal redirect component a bit more transfer proof

### DIFF
--- a/code/datums/components/signal_redirect.dm
+++ b/code/datums/components/signal_redirect.dm
@@ -4,13 +4,20 @@
 /datum/component/redirect
 	dupe_mode = COMPONENT_DUPE_ALLOWED
 	var/list/signals
+	var/datum/callback/turfchangeCB
 
 /datum/component/redirect/Initialize(list/_signals, flags=NONE)
 	//It's not our job to verify the right signals are registered here, just do it.
 	if(!LAZYLEN(_signals))
 		return COMPONENT_INCOMPATIBLE
 	if(flags & REDIRECT_TRANSFER_WITH_TURF && isturf(parent))
-		RegisterSignal(parent, COMSIG_TURF_CHANGE, .proc/turf_change)
+		// If they also want to listen to the turf change then we need to set it up so both callbacks run
+		if(_signals[COMSIG_TURF_CHANGE])
+			turfchangeCB = _signals[COMSIG_TURF_CHANGE]
+			if(!istype(turfchangeCB))
+				. = COMPONENT_INCOMPATIBLE
+				CRASH("Redirect components must be given instanced callbacks, not proc paths.")
+		_signals[COMSIG_TURF_CHANGE] = CALLBACK(src, .proc/turf_change)
 	
 	signals = _signals
 
@@ -23,3 +30,4 @@
 
 /datum/component/redirect/proc/turf_change(path, new_baseturfs, flags, list/transfers)
 	transfers += src
+	return turfchangeCB?.InvokeAsync(arglist(args))


### PR DESCRIPTION
The turf change signal needed to get moved properly in transfer. 
It also needed to have code to deal with the creator wanting to listen to the turf change signal.
