### PR TITLE
Formula change to techwebs bomb scaling, usual tier 2 tritium rush nerfed to ~100k points from ~200k

### DIFF
--- a/code/game/machinery/doppler_array.dm
+++ b/code/game/machinery/doppler_array.dm
@@ -129,4 +129,4 @@ GLOBAL_LIST_EMPTY(doppler_arrays)
 	linked_techweb = SSresearch.science_tech
 
 /proc/techweb_scale_bomb(lightradius)
-	return (lightradius ** 0.5) * 3000
+	return lightradius^1.36

--- a/code/game/machinery/doppler_array.dm
+++ b/code/game/machinery/doppler_array.dm
@@ -129,4 +129,4 @@ GLOBAL_LIST_EMPTY(doppler_arrays)
 	linked_techweb = SSresearch.science_tech
 
 /proc/techweb_scale_bomb(lightradius)
-	return lightradius^1.36
+	return lightradius ** 1.36


### PR DESCRIPTION
:clap:
Why: Being able to finish all of science within 20 minutes was apparently bad.