### PR TITLE
Fixes cult pylons destroying plating and cult floors deconstructing into rods

### DIFF
--- a/code/game/turfs/simulated/floor/reinf_floor.dm
+++ b/code/game/turfs/simulated/floor/reinf_floor.dm
@@ -36,7 +36,8 @@
 	if(I.use_tool(src, user, 30, volume=80))
 		if(!istype(src, /turf/open/floor/engine))
 			return TRUE
-		new /obj/item/stack/rods(src, 2)
+		if(floor_tile)
+			new floor_tile(src, 2)
 		ScrapeAway()
 	return TRUE
 

--- a/code/modules/antagonists/cult/cult_structures.dm
+++ b/code/modules/antagonists/cult/cult_structures.dm
@@ -221,7 +221,10 @@
 
 		var/turf/T = safepick(validturfs)
 		if(T)
-			T.ChangeTurf(/turf/open/floor/engine/cult)
+			if(istype(T, /turf/open/floor/plating))
+				T.PlaceOnTop(/turf/open/floor/engine/cult)
+			else
+				T.ChangeTurf(/turf/open/floor/engine/cult)
 		else
 			var/turf/open/floor/engine/cult/F = safepick(cultturfs)
 			if(F)


### PR DESCRIPTION
:cl:
fix: Cult floors will not deconstruct to space
fix: Cult floors do not spawn rods when deconstructed
/:cl:
Fixes #39619
#36092 was supposed to make cult floors not deconstruct into metal to prevent metal farming with pylons, but forgot to update the deconstruction code.
