### PR TITLE
Fixes uncrossed being called on the wrong turf's contents

### DIFF
--- a/code/game/atoms_movable.dm
+++ b/code/game/atoms_movable.dm
@@ -167,7 +167,7 @@
 	. = TRUE
 	oldloc.Exited(src, newloc)
 
-	for(var/i in loc)
+	for(var/i in oldloc)
 		if(i == src) // Multi tile objects
 			continue
 		var/atom/movable/thing = i


### PR DESCRIPTION
:cl:
fix: Footprints should no longer spread out of control
/:cl:
Fixes #39146 
Closes #39550