### PR TITLE
Circuits GPS Update

### DIFF
--- a/code/modules/integrated_electronics/subtypes/converters.dm
+++ b/code/modules/integrated_electronics/subtypes/converters.dm
@@ -357,6 +357,7 @@
 /obj/item/integrated_circuit/converter/abs_to_rel_coords
 	name = "abs to rel coordinate converter"
 	desc = "Easily convert absolute coordinates to relative coordinates with this."
+	extended_desc = "Keep in mind that both sets of input coordinates should be absolute."
 	complexity = 1
 	inputs = list(
 		"X1" = IC_PINTYPE_NUMBER,
@@ -381,6 +382,71 @@
 	if(!isnull(x1) && !isnull(y1) && !isnull(x2) && !isnull(y2))
 		set_pin_data(IC_OUTPUT, 1, x1 - x2)
 		set_pin_data(IC_OUTPUT, 2, y1 - y2)
+
+	push_data()
+	activate_pin(2)
+
+/obj/item/integrated_circuit/converter/rel_to_abs_coords
+	name = "rel to abs coordinate converter"
+	desc = "Convert relative coordinates to absolute coordinates with this."
+	extended_desc = "Keep in mind that only one set of input coordinates should be absolute, and the other relative. \
+	The output coordinates will be the absolute form of the input relative coordinates."
+	complexity = 1
+	inputs = list(
+		"X1" = IC_PINTYPE_NUMBER,
+		"Y1" = IC_PINTYPE_NUMBER,
+		"X2" = IC_PINTYPE_NUMBER,
+		"Y2" = IC_PINTYPE_NUMBER
+		)
+	outputs = list(
+		"X" = IC_PINTYPE_NUMBER,
+		"Y" = IC_PINTYPE_NUMBER
+		)
+	activators = list("compute abs coordinates" = IC_PINTYPE_PULSE_IN, "on convert" = IC_PINTYPE_PULSE_OUT)
+	spawn_flags = IC_SPAWN_DEFAULT|IC_SPAWN_RESEARCH
+
+/obj/item/integrated_circuit/converter/abs_to_rel_coords/do_work()
+	var/x1 = get_pin_data(IC_INPUT, 1)
+	var/y1 = get_pin_data(IC_INPUT, 2)
+
+	var/x2 = get_pin_data(IC_INPUT, 3)
+	var/y2 = get_pin_data(IC_INPUT, 4)
+
+	if(!isnull(x1) && !isnull(y1) && !isnull(x2) && !isnull(y2))
+		set_pin_data(IC_OUTPUT, 1, x1 + x2)
+		set_pin_data(IC_OUTPUT, 2, y1 + y2)
+
+	push_data()
+	activate_pin(2)
+
+/obj/item/integrated_circuit/converter/adv_rel_to_abs_coords
+	name = "advanced rel to abs coordinate converter"
+	desc = "Easily convert relative coordinates to absolute coordinates with this."
+	extended_desc = "This circuit only requires a single set of relative inputs to output absolute coordinates."
+	complexity = 2
+	inputs = list(
+		"X" = IC_PINTYPE_NUMBER,
+		"Y" = IC_PINTYPE_NUMBER,
+		)
+	outputs = list(
+		"X" = IC_PINTYPE_NUMBER,
+		"Y" = IC_PINTYPE_NUMBER
+		)
+	activators = list("compute abs coordinates" = IC_PINTYPE_PULSE_IN, "on convert" = IC_PINTYPE_PULSE_OUT)
+	spawn_flags = IC_SPAWN_DEFAULT|IC_SPAWN_RESEARCH
+
+/obj/item/integrated_circuit/converter/abs_to_rel_coords/do_work()
+	var/turf/T = get_turf(src)
+
+	if(!T)
+		return
+
+	var/x1 = get_pin_data(IC_INPUT, 1)
+	var/y1 = get_pin_data(IC_INPUT, 2)
+
+	if(!isnull(x1) && !isnull(y1))
+		set_pin_data(IC_OUTPUT, 1, T.x + x1)
+		set_pin_data(IC_OUTPUT, 2, T.y + y1)
 
 	push_data()
 	activate_pin(2)

--- a/code/modules/integrated_electronics/subtypes/input.dm
+++ b/code/modules/integrated_electronics/subtypes/input.dm
@@ -815,11 +815,11 @@
 /obj/item/integrated_circuit/input/gps
 	name = "global positioning system"
 	desc = "This allows you to easily know the position of a machine containing this device."
-	extended_desc = "The coordinates that the GPS outputs are absolute, not relative."
+	extended_desc = "The coordinates that the GPS outputs are absolute, not relative. The full coords output has the coords separated by commas and is in string format."
 	icon_state = "gps"
 	complexity = 4
 	inputs = list()
-	outputs = list("X"= IC_PINTYPE_NUMBER, "Y" = IC_PINTYPE_NUMBER, "Z" = IC_PINTYPE_NUMBER)
+	outputs = list("X"= IC_PINTYPE_NUMBER, "Y" = IC_PINTYPE_NUMBER, "Z" = IC_PINTYPE_NUMBER, "full coords" = IC_PINTYPE_STRING)
 	activators = list("get coordinates" = IC_PINTYPE_PULSE_IN, "on get coordinates" = IC_PINTYPE_PULSE_OUT)
 	spawn_flags = IC_SPAWN_DEFAULT|IC_SPAWN_RESEARCH
 	power_draw_per_use = 30
@@ -830,13 +830,14 @@
 	set_pin_data(IC_OUTPUT, 1, null)
 	set_pin_data(IC_OUTPUT, 2, null)
 	set_pin_data(IC_OUTPUT, 3, null)
+	set_pin_data(IC_OUTPUT, 4, null)
 	if(!T)
 		return
 
 	set_pin_data(IC_OUTPUT, 1, T.x)
 	set_pin_data(IC_OUTPUT, 2, T.y)
 	set_pin_data(IC_OUTPUT, 3, T.z)
-
+	set_pin_data(IC_OUTPUT, 4, "[T.x],[T.y],[T.z]")
 	push_data()
 	activate_pin(2)
 


### PR DESCRIPTION
:cl:
tweak: The GPS circuit now has a 4th output, placing X,Y,Z all in a string.
add: 2 new converters: Rel to Abs, and Advanced Rel to Abs.
add: Rel to Abs takes a set of relative and a set of absolute coordinates, and converts the relative one to absolute. 1 complexity.
add: Advanced Rel to Abs takes a set of relative coordinates and converts it to absolute without the need for an already known set of absolute coordinates. 2 complexity.
/:cl:

Why:
Handling GPS output when you want to display it as a string is a major pain in the ass, requiring multiple number-to-strings before being able to pass it to a concatenator. Having it already in a string form would be very helpful for specifically this purpose and wouldn't affect any past functionality.

Abs to Rel converters already exist, and the inverse has been requested multiple times, hence the Rel to Abs converter. The advanced version exists because of the nature of converting relative to absolute requiring knowledge of an existing absolute coordinate, which is still mostly just a hassle and isn't really necessary (but if you have the means to avoid it (such as a GPS circuit), you may save a complexity by using the non-advanced version).