### PR TITLE
Readds medium screens

### DIFF
--- a/code/modules/integrated_electronics/subtypes/output.dm
+++ b/code/modules/integrated_electronics/subtypes/output.dm
@@ -34,6 +34,24 @@
 	else
 		stuff_to_display = replacetext("[I.data]", eol , "<br>")
 
+/obj/item/integrated_circuit/output/screen/large
+	name = "large screen"
+	desc = "Takes any data type as an input and displays it to anybody near the device when pulsed. \
+	It can also be examined to see the last thing it displayed."
+	icon_state = "screen_medium"
+	power_draw_per_use = 20
+
+/obj/item/integrated_circuit/output/screen/large/do_work()
+	..()
+	var/list/nearby_things = range(0, get_turf(src))
+	for(var/mob/M in nearby_things)
+		var/obj/O = assembly ? assembly : src
+		to_chat(M, "<span class='notice'>[icon2html(O.icon, world, O.icon_state)] [stuff_to_display]</span>")
+	if(assembly)
+		assembly.investigate_log("displayed \"[html_encode(stuff_to_display)]\" with [type].", INVESTIGATE_CIRCUIT)
+	else
+		investigate_log("displayed \"[html_encode(stuff_to_display)]\" as [type].", INVESTIGATE_CIRCUIT)
+
 /obj/item/integrated_circuit/output/light
 	name = "light"
 	desc = "A basic light which can be toggled on/off when pulsed."

--- a/code/modules/integrated_electronics/subtypes/output.dm
+++ b/code/modules/integrated_electronics/subtypes/output.dm
@@ -43,6 +43,16 @@
 
 /obj/item/integrated_circuit/output/screen/large/do_work()
 	..()
+
+	var/in_hands = FALSE//this whole block just returns if the assembly is neither in a mobs hands or on the ground
+	if(isliving(assembly.loc))
+		in_hands = TRUE
+		var/mob/living/H = assembly.loc
+		if(H.get_active_held_item() != assembly && H.get_inactive_held_item() != assembly)
+			return
+	if(!isturf(assembly.loc) && !in_hands)
+		return
+
 	var/list/nearby_things = range(0, get_turf(src))
 	for(var/mob/M in nearby_things)
 		var/obj/O = assembly ? assembly : src

--- a/code/modules/integrated_electronics/subtypes/output.dm
+++ b/code/modules/integrated_electronics/subtypes/output.dm
@@ -44,13 +44,13 @@
 /obj/item/integrated_circuit/output/screen/large/do_work()
 	..()
 
-	var/in_hands = FALSE//this whole block just returns if the assembly is neither in a mobs hands or on the ground
-	if(isliving(assembly.loc))
+	if(isliving(assembly.loc))//this whole block just returns if the assembly is neither in a mobs hands or on the ground
 		var/mob/living/H = assembly.loc
-		if(H.get_active_held_item() == assembly || H.get_inactive_held_item() == assembly)
-			in_hands = TRUE
-	if(!isturf(assembly.loc) && !in_hands)
-		return
+		if(H.get_active_held_item() != assembly && H.get_inactive_held_item() != assembly)
+			return
+	else
+		if(!isturf(assembly.loc))
+			return
 
 	var/list/nearby_things = range(0, get_turf(src))
 	for(var/mob/M in nearby_things)

--- a/code/modules/integrated_electronics/subtypes/output.dm
+++ b/code/modules/integrated_electronics/subtypes/output.dm
@@ -46,10 +46,9 @@
 
 	var/in_hands = FALSE//this whole block just returns if the assembly is neither in a mobs hands or on the ground
 	if(isliving(assembly.loc))
-		in_hands = TRUE
 		var/mob/living/H = assembly.loc
-		if(H.get_active_held_item() != assembly && H.get_inactive_held_item() != assembly)
-			return
+		if(H.get_active_held_item() == assembly || H.get_inactive_held_item() == assembly)
+			in_hands = TRUE
 	if(!isturf(assembly.loc) && !in_hands)
 		return
 


### PR DESCRIPTION
:cl:
add: Integrated circuit medium screens have been readded. They are now called large screens. They now only work from your hands or on the ground when you're standing on top of them (NOT from pockets, lockers, backpacks, etc).
/:cl:

Why:

Circuits may have deserved many of the nerfs in https://github.com/tgstation/tgstation/pull/39376, but the removal of medium screens was absolutely not one of them. It is one of the only meaningful ways to send feedback to the user, and fills the niche of essentially being a `to_chat()` that the TTS circuit doesn't do (TTS announces to EVERYBODY within a screen's range, medium screens only announce to the user and anybody adjacent).

The main reason for removal was "anti-deaf" circuits. The usefulness of those is only questionably useful at best to begin with, as it is very situational (requires you to have printed and to be carrying the circuit with you and then go deaf and then get into a conversation where the other person is unaware that you are deaf). I don't believe this was even close to enough of a reason to remove one of the only meaningful ways of giving user feedback with circuits.