### PR TITLE
Readd asay to admin log

### DIFF
--- a/code/__HELPERS/_logging.dm
+++ b/code/__HELPERS/_logging.dm
@@ -44,6 +44,7 @@
 		WRITE_LOG(GLOB.world_game_log, "ADMINPRIVATE: [text]")
 
 /proc/log_adminsay(text)
+	GLOB.admin_log.Add(text)
 	if (CONFIG_GET(flag/log_adminchat))
 		WRITE_LOG(GLOB.world_game_log, "ADMINPRIVATE: ASAY: [text]")
 


### PR DESCRIPTION
This was it seems inadvertently removed in #36858 by changing the proc to not called call `log_admin_private()`

:cl:
admin: Asay history is once again logged under the admin log secret.
/:cl:

