### PR TITLE
boards now show their required components on examine

### DIFF
--- a/code/game/objects/items/circuitboards/circuitboard.dm
+++ b/code/game/objects/items/circuitboards/circuitboard.dm
@@ -64,4 +64,4 @@ micro-manipulator, console screen, beaker, Microlaser, matter bin, power cells.
 			if(!ispath(A))
 				continue
 			nice_list += list("[req_components[A]] [initial(A.name)]")
-		to_chat(user,"<span class='notice'>Required components: [english_list(nice_list)]</span>")
+		to_chat(user,"<span class='notice'>Required components: [english_list(nice_list)].</span>")

--- a/code/game/objects/items/circuitboards/circuitboard.dm
+++ b/code/game/objects/items/circuitboards/circuitboard.dm
@@ -54,3 +54,19 @@ micro-manipulator, console screen, beaker, Microlaser, matter bin, power cells.
 				M.component_parts += new comp_path(null)
 
 	M.RefreshParts()
+
+/obj/item/circuitboard/machine/examine(mob/user)
+	..()
+	if(LAZYLEN(req_components))
+		var/dat = "Required components: "
+		var/first = TRUE
+		for(var/B in req_components)
+			var/atom/A = B
+			if(!ispath(A))
+				continue
+			if(!first)
+				dat += ", "
+			else
+				first = FALSE
+			dat += "[req_components[A]] [initial(A.name)]"
+		to_chat(user,"<span class='notice'>[dat]</span>")

--- a/code/game/objects/items/circuitboards/circuitboard.dm
+++ b/code/game/objects/items/circuitboards/circuitboard.dm
@@ -58,15 +58,10 @@ micro-manipulator, console screen, beaker, Microlaser, matter bin, power cells.
 /obj/item/circuitboard/machine/examine(mob/user)
 	..()
 	if(LAZYLEN(req_components))
-		var/dat = "Required components: "
-		var/first = TRUE
+		var/list/nice_list = list()
 		for(var/B in req_components)
 			var/atom/A = B
 			if(!ispath(A))
 				continue
-			if(!first)
-				dat += ", "
-			else
-				first = FALSE
-			dat += "[req_components[A]] [initial(A.name)]"
-		to_chat(user,"<span class='notice'>[dat]</span>")
+			nice_list += list("[req_components[A]] [initial(A.name)]")
+		to_chat(user,"<span class='notice'>Required components: [english_list(nice_list)]</span>")


### PR DESCRIPTION
 That's Quantum Pad (Machine Board)
It is a small item.
Required components: 1 bluespace crystal, 1 capacitor, 1 micro-manipulator and 1 cable coil.

:cl: Time-Green
add: Circuit Boards now tell you the components required to build them on examine
/:cl:

Why: QoL, so you don't have to look it up or build the machine first and go back for parts
