### PR TITLE
Adds zombies to Box's whiteship

### DIFF
--- a/_maps/shuttles/whiteship_box.dmm
+++ b/_maps/shuttles/whiteship_box.dmm
@@ -440,6 +440,15 @@
 /obj/structure/cable{
 	icon_state = "1-8"
 	},
+/mob/living/simple_animal/hostile/zombie{
+	desc = "This undead fiend looks to be badly decomposed.";
+	environment_smash = 0;
+	health = 60;
+	melee_damage_lower = 11;
+	melee_damage_upper = 11;
+	name = "Rotting Carcass";
+	zombiejob = "Assistant"
+	},
 /turf/open/floor/plasteel/white/corner{
 	dir = 1
 	},
@@ -545,6 +554,14 @@
 	icon_state = "1-2"
 	},
 /obj/effect/decal/cleanable/blood/old,
+/mob/living/simple_animal/hostile/zombie{
+	desc = "This undead fiend looks to be badly decomposed.";
+	environment_smash = 0;
+	health = 60;
+	melee_damage_lower = 11;
+	melee_damage_upper = 11;
+	name = "Rotting Carcass"
+	},
 /turf/open/floor/plasteel/floorgrime,
 /area/shuttle/abandoned/crew)
 "aQ" = (
@@ -1263,6 +1280,14 @@
 	dir = 6
 	},
 /obj/effect/decal/cleanable/blood/old,
+/mob/living/simple_animal/hostile/zombie{
+	desc = "This undead fiend looks to be badly decomposed.";
+	environment_smash = 0;
+	health = 60;
+	melee_damage_lower = 11;
+	melee_damage_upper = 11;
+	name = "Rotting Carcass"
+	},
 /turf/open/floor/plasteel/floorgrime,
 /area/shuttle/abandoned/medbay)
 "bT" = (
@@ -2208,6 +2233,15 @@
 	icon_state = "4-8"
 	},
 /obj/effect/decal/cleanable/blood/gibs/old,
+/mob/living/simple_animal/hostile/zombie{
+	desc = "This undead fiend looks to be badly decomposed.";
+	environment_smash = 0;
+	health = 60;
+	melee_damage_lower = 11;
+	melee_damage_upper = 11;
+	name = "Rotting Carcass";
+	zombiejob = "Assistant"
+	},
 /turf/open/floor/plasteel,
 /area/shuttle/abandoned/medbay)
 "dc" = (

--- a/code/datums/shuttles.dm
+++ b/code/datums/shuttles.dm
@@ -346,7 +346,7 @@
 
 /datum/map_template/shuttle/whiteship/delta
 	suffix = "delta"
-	name = "NT Luxury Frigate"
+	name = "NT Frigate"
 
 /datum/map_template/shuttle/whiteship/pod
 	suffix = "whiteship_pod"


### PR DESCRIPTION
These were planned from the beginning as in #39351 

These, like in the other ships, are pretty weak (meta still has the strongest monsters, but it's also the most well stocked ship). These zombies have no infection chance, 60 hp instead of 100, and do 11 damage instead of 21 (could be raised to 15, if you guys want). And like the other ships there are 4 monsters on it.

:cl: WJohn
add: Added zombies to boxstation's abandoned ship.
/:cl: