### PR TITLE
Fix footprints stacking when blood and oil share a tile

### DIFF
--- a/code/modules/mob/living/carbon/human/human_movement.dm
+++ b/code/modules/mob/living/carbon/human/human_movement.dm
@@ -56,20 +56,19 @@
 				//Bloody footprints
 				var/turf/T = get_turf(src)
 				if(S.bloody_shoes && S.bloody_shoes[S.blood_state])
-					var/obj/effect/decal/cleanable/blood/footprints/oldFP = locate(/obj/effect/decal/cleanable/blood/footprints) in T
-					if(oldFP && oldFP.blood_state == S.blood_state)
-						return
-					else
-						//No oldFP or it's a different kind of blood
-						S.bloody_shoes[S.blood_state] = max(0, S.bloody_shoes[S.blood_state] - BLOOD_LOSS_PER_STEP)
-						if (S.bloody_shoes[S.blood_state] > BLOOD_LOSS_IN_SPREAD)
-							var/obj/effect/decal/cleanable/blood/footprints/FP = new /obj/effect/decal/cleanable/blood/footprints(T)
-							FP.blood_state = S.blood_state
-							FP.entered_dirs |= dir
-							FP.bloodiness = S.bloody_shoes[S.blood_state] - BLOOD_LOSS_IN_SPREAD
-							FP.add_blood_DNA(S.return_blood_DNA())
-							FP.update_icon()
-						update_inv_shoes()
+					for(var/obj/effect/decal/cleanable/blood/footprints/oldFP in T)
+						if (oldFP.blood_state == S.blood_state)
+							return
+					//No oldFP or they're all a different kind of blood
+					S.bloody_shoes[S.blood_state] = max(0, S.bloody_shoes[S.blood_state] - BLOOD_LOSS_PER_STEP)
+					if (S.bloody_shoes[S.blood_state] > BLOOD_LOSS_IN_SPREAD)
+						var/obj/effect/decal/cleanable/blood/footprints/FP = new /obj/effect/decal/cleanable/blood/footprints(T)
+						FP.blood_state = S.blood_state
+						FP.entered_dirs |= dir
+						FP.bloodiness = S.bloody_shoes[S.blood_state] - BLOOD_LOSS_IN_SPREAD
+						FP.add_blood_DNA(S.return_blood_DNA())
+						FP.update_icon()
+					update_inv_shoes()
 				//End bloody footprints
 				S.step_action()
 


### PR DESCRIPTION
:cl:
fix: Blood and oil footprints sharing a tile no longer causes footprint decals to stack.
/:cl:

Fixes #39648.