### PR TITLE
Adds Gondola meat

### DIFF
--- a/code/datums/diseases/transformation.dm
+++ b/code/datums/diseases/transformation.dm
@@ -274,7 +274,7 @@
 	cures = list("condensedcapsaicin") //beats the hippie crap right out of your system
 	cure_chance = 80
 	stage_prob = 5
-	agent = "Tranquillity"
+	agent = "Tranquility"
 	desc = "Consuming the flesh of a Gondola comes at a terrible price."
 	severity = DISEASE_SEVERITY_BIOHAZARD
 	visibility_flags = 0

--- a/code/datums/diseases/transformation.dm
+++ b/code/datums/diseases/transformation.dm
@@ -267,3 +267,43 @@
 	stage5	= list("<span class='danger'>You have become a morph.</span>")
 	new_form = /mob/living/simple_animal/hostile/morph
 	infectable_biotypes = list(MOB_ORGANIC, MOB_INORGANIC, MOB_UNDEAD) //magic!
+
+/datum/disease/transformation/gondola
+	name = "Gondola Transformation"
+	cure_text = "Liberal ingestion of bath salts."
+	cures = list("bath_salts")
+	cure_chance = 80
+	stage_prob = 5 //reduced to give chemists a realistic chance to produce a cure
+	agent = "Tranquility"
+	desc = "Consuming the flesh of a Gondola comes at a terrible price."
+	severity = DISEASE_SEVERITY_BIOHAZARD
+	visibility_flags = 0
+	stage1	= list("You seem a little lighter in your step.")
+	stage2	= list("You catch yourself smiling for no reason.")
+	stage3	= list("<span class='danger'>A cruel sense of calm overcomes you.</span>", "<span class='danger'>You can't feel your arms!</span>", "<span class='danger'>You let go of the urge to hurt clowns.</span>")
+	stage4	= list("<span class='danger'>You can't feel your arms. It does not bother you anymore.</span>", "<span class='danger'>You forgive the clown for hurting you.</span>")
+	stage5	= list("<span class='danger'>You have become a Gondola.</span>")
+	new_form = /mob/living/simple_animal/pet/gondola
+
+/datum/disease/transformation/gondola/stage_act()
+	..()
+	switch(stage)
+		if(2)
+			if (prob(5))
+				affected_mob.emote("smile")
+			if (prob(20))
+				affected_mob.reagents.add_reagent_list(list("pax" = 5))
+		if(3)
+			if (prob(5))
+				affected_mob.emote("smile")
+			if (prob(20))
+				affected_mob.reagents.add_reagent_list(list("pax" = 5))
+		if(4)
+			if (prob(5))
+				affected_mob.emote("smile")
+			if (prob(20))
+				affected_mob.reagents.add_reagent_list(list("pax" = 5))
+			if (prob(2))
+				to_chat(affected_mob, "<span class='danger'>You let go of what you were holding.</span>")
+				var/obj/item/I = affected_mob.get_active_held_item()
+				affected_mob.dropItemToGround(I)

--- a/code/datums/diseases/transformation.dm
+++ b/code/datums/diseases/transformation.dm
@@ -274,7 +274,7 @@
 	cures = list("bath_salts")
 	cure_chance = 80
 	stage_prob = 5 //reduced to give chemists a realistic chance to produce a cure
-	agent = "Tranquility"
+	agent = "Tranquillity"
 	desc = "Consuming the flesh of a Gondola comes at a terrible price."
 	severity = DISEASE_SEVERITY_BIOHAZARD
 	visibility_flags = 0

--- a/code/datums/diseases/transformation.dm
+++ b/code/datums/diseases/transformation.dm
@@ -270,10 +270,10 @@
 
 /datum/disease/transformation/gondola
 	name = "Gondola Transformation"
-	cure_text = "Liberal ingestion of bath salts."
-	cures = list("bath_salts")
+	cure_text = "Condensed Capsaicin, ingested or injected." //getting pepper sprayed doesn't help
+	cures = list("condensedcapsaicin") //beats the hippie crap right out of your system
 	cure_chance = 80
-	stage_prob = 5 //reduced to give chemists a realistic chance to produce a cure
+	stage_prob = 5
 	agent = "Tranquillity"
 	desc = "Consuming the flesh of a Gondola comes at a terrible price."
 	severity = DISEASE_SEVERITY_BIOHAZARD

--- a/code/modules/food_and_drinks/food/snacks/meat.dm
+++ b/code/modules/food_and_drinks/food/snacks/meat.dm
@@ -257,6 +257,16 @@
 	tastes = list("bacon" = 1)
 	foodtype = MEAT
 
+/obj/item/reagent_containers/food/snacks/meat/slab/gondola
+	name = "gondola meat"
+	desc = "According to legends of old, consuming raw gondola flesh grants one inner peace."
+	list_reagents = list("nutriment" = 3, "tranquility" = 5, "cooking_oil" = 3)
+	tastes = list("meat" = 4, "tranquility" = 1)
+	filling_color = "#9A6750"
+	cooked_type = /obj/item/reagent_containers/food/snacks/meat/steak/gondola
+	slice_path = /obj/item/reagent_containers/food/snacks/meat/rawcutlet/gondola
+	foodtype = RAW | MEAT
+
 ////////////////////////////////////// MEAT STEAKS ///////////////////////////////////////////////////////////
 
 
@@ -303,6 +313,10 @@
 	trash = null
 	tastes = list("meat" = 1, "rock" = 1)
 	foodtype = MEAT
+
+/obj/item/reagent_containers/food/snacks/meat/steak/gondola
+	name = "gondola steak"
+	tastes = list("meat = 1", "tranquility" = 1)
 
 //////////////////////////////// MEAT CUTLETS ///////////////////////////////////////////////////////
 
@@ -361,6 +375,11 @@
 	cooked_type = /obj/item/reagent_containers/food/snacks/meat/cutlet/spider
 	tastes = list("cobwebs" = 1)
 
+/obj/item/reagent_containers/food/snacks/meat/rawcutlet/gondola
+	name = "raw gondola cutlet"
+	cooked_type = /obj/item/reagent_containers/food/snacks/meat/cutlet/gondola
+	tastes = list("meat" = 1, "tranquility" = 1)
+
 //Cooked cutlets
 
 /obj/item/reagent_containers/food/snacks/meat/cutlet
@@ -396,3 +415,7 @@
 /obj/item/reagent_containers/food/snacks/meat/cutlet/spider
 	name = "spider cutlet"
 	tastes = list("cobwebs" = 1)
+
+/obj/item/reagent_containers/food/snacks/meat/cutlet/gondola
+	name = "gondola cutlet"
+	tastes = list("meat" = 1, "tranquility" = 1)

--- a/code/modules/food_and_drinks/food/snacks/meat.dm
+++ b/code/modules/food_and_drinks/food/snacks/meat.dm
@@ -260,8 +260,8 @@
 /obj/item/reagent_containers/food/snacks/meat/slab/gondola
 	name = "gondola meat"
 	desc = "According to legends of old, consuming raw gondola flesh grants one inner peace."
-	list_reagents = list("nutriment" = 3, "tranquility" = 5, "cooking_oil" = 3)
-	tastes = list("meat" = 4, "tranquility" = 1)
+	list_reagents = list("nutriment" = 3, "tranquillity" = 5, "cooking_oil" = 3)
+	tastes = list("meat" = 4, "tranquillity" = 1)
 	filling_color = "#9A6750"
 	cooked_type = /obj/item/reagent_containers/food/snacks/meat/steak/gondola
 	slice_path = /obj/item/reagent_containers/food/snacks/meat/rawcutlet/gondola
@@ -316,7 +316,7 @@
 
 /obj/item/reagent_containers/food/snacks/meat/steak/gondola
 	name = "gondola steak"
-	tastes = list("meat = 1", "tranquility" = 1)
+	tastes = list("meat = 1", "tranquillity" = 1)
 
 //////////////////////////////// MEAT CUTLETS ///////////////////////////////////////////////////////
 
@@ -378,7 +378,7 @@
 /obj/item/reagent_containers/food/snacks/meat/rawcutlet/gondola
 	name = "raw gondola cutlet"
 	cooked_type = /obj/item/reagent_containers/food/snacks/meat/cutlet/gondola
-	tastes = list("meat" = 1, "tranquility" = 1)
+	tastes = list("meat" = 1, "tranquillity" = 1)
 
 //Cooked cutlets
 
@@ -418,4 +418,4 @@
 
 /obj/item/reagent_containers/food/snacks/meat/cutlet/gondola
 	name = "gondola cutlet"
-	tastes = list("meat" = 1, "tranquility" = 1)
+	tastes = list("meat" = 1, "tranquillity" = 1)

--- a/code/modules/food_and_drinks/food/snacks/meat.dm
+++ b/code/modules/food_and_drinks/food/snacks/meat.dm
@@ -260,8 +260,8 @@
 /obj/item/reagent_containers/food/snacks/meat/slab/gondola
 	name = "gondola meat"
 	desc = "According to legends of old, consuming raw gondola flesh grants one inner peace."
-	list_reagents = list("nutriment" = 3, "tranquillity" = 5, "cooking_oil" = 3)
-	tastes = list("meat" = 4, "tranquillity" = 1)
+	list_reagents = list("nutriment" = 3, "tranquility" = 5, "cooking_oil" = 3)
+	tastes = list("meat" = 4, "tranquility" = 1)
 	filling_color = "#9A6750"
 	cooked_type = /obj/item/reagent_containers/food/snacks/meat/steak/gondola
 	slice_path = /obj/item/reagent_containers/food/snacks/meat/rawcutlet/gondola
@@ -316,7 +316,7 @@
 
 /obj/item/reagent_containers/food/snacks/meat/steak/gondola
 	name = "gondola steak"
-	tastes = list("meat = 1", "tranquillity" = 1)
+	tastes = list("meat = 1", "tranquility" = 1)
 
 //////////////////////////////// MEAT CUTLETS ///////////////////////////////////////////////////////
 
@@ -378,7 +378,7 @@
 /obj/item/reagent_containers/food/snacks/meat/rawcutlet/gondola
 	name = "raw gondola cutlet"
 	cooked_type = /obj/item/reagent_containers/food/snacks/meat/cutlet/gondola
-	tastes = list("meat" = 1, "tranquillity" = 1)
+	tastes = list("meat" = 1, "tranquility" = 1)
 
 //Cooked cutlets
 
@@ -418,4 +418,4 @@
 
 /obj/item/reagent_containers/food/snacks/meat/cutlet/gondola
 	name = "gondola cutlet"
-	tastes = list("meat" = 1, "tranquillity" = 1)
+	tastes = list("meat" = 1, "tranquility" = 1)

--- a/code/modules/mob/living/simple_animal/friendly/gondola.dm
+++ b/code/modules/mob/living/simple_animal/friendly/gondola.dm
@@ -17,7 +17,7 @@
 	icon = 'icons/mob/gondolas.dmi'
 	icon_state = "gondola"
 	icon_living = "gondola"
-	loot = list(/obj/effect/decal/cleanable/blood/gibs, /obj/item/stack/sheet/animalhide/gondola = 1)
+	loot = list(/obj/effect/decal/cleanable/blood/gibs, /obj/item/stack/sheet/animalhide/gondola = 1, /obj/item/reagent_containers/food/snacks/meat/slab/gondola = 1)
 	//Gondolas aren't affected by cold.
 	atmos_requirements = list("min_oxy" = 0, "max_oxy" = 0, "min_tox" = 0, "max_tox" = 0, "min_co2" = 0, "max_co2" = 0, "min_n2" = 0, "max_n2" = 0)
 	minbodytemp = 0

--- a/code/modules/reagents/chemistry/reagents/other_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/other_reagents.dm
@@ -1830,14 +1830,14 @@
 		to_chat(M, "You should sit down and take a rest...")
 	..()
 
-/datum/reagent/tranquility
-	name = "Tranquility"
-	id = "tranquility"
+/datum/reagent/tranquillity
+	name = "Tranquillity"
+	id = "tranquillity"
 	description = "A highly mutative liquid of unknown origin."
 	color = "#9A6750" //RGB: 154, 103, 80
 	taste_description = "inner peace"
 	can_synth = FALSE
 
-/datum/reagent/tranquility/reaction_mob(mob/living/L, method=TOUCH, reac_volume, show_message = 1, touch_protection = 0)
+/datum/reagent/tranquillity/reaction_mob(mob/living/L, method=TOUCH, reac_volume, show_message = 1, touch_protection = 0)
 	if(method==PATCH || method==INGEST || method==INJECT || (method == VAPOR && prob(min(reac_volume,100)*(1 - touch_protection))))
 		L.ForceContractDisease(new /datum/disease/transformation/gondola(), FALSE, TRUE)

--- a/code/modules/reagents/chemistry/reagents/other_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/other_reagents.dm
@@ -1829,3 +1829,15 @@
 	if(prob(30))
 		to_chat(M, "You should sit down and take a rest...")
 	..()
+
+/datum/reagent/tranquility
+	name = "Tranquility"
+	id = "tranquility"
+	description = "A highly mutative liquid of unknown origin."
+	color = "#9A6750" //RGB: 154, 103, 80
+	taste_description = "inner peace"
+	can_synth = FALSE
+
+/datum/reagent/tranquility/reaction_mob(mob/living/L, method=TOUCH, reac_volume, show_message = 1, touch_protection = 0)
+	if(method==PATCH || method==INGEST || method==INJECT || (method == VAPOR && prob(min(reac_volume,100)*(1 - touch_protection))))
+		L.ForceContractDisease(new /datum/disease/transformation/gondola(), FALSE, TRUE)

--- a/code/modules/reagents/chemistry/reagents/other_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/other_reagents.dm
@@ -1830,14 +1830,14 @@
 		to_chat(M, "You should sit down and take a rest...")
 	..()
 
-/datum/reagent/tranquillity
-	name = "Tranquillity"
-	id = "tranquillity"
+/datum/reagent/tranquility
+	name = "Tranquility"
+	id = "tranquility"
 	description = "A highly mutative liquid of unknown origin."
 	color = "#9A6750" //RGB: 154, 103, 80
 	taste_description = "inner peace"
 	can_synth = FALSE
 
-/datum/reagent/tranquillity/reaction_mob(mob/living/L, method=TOUCH, reac_volume, show_message = 1, touch_protection = 0)
+/datum/reagent/tranquility/reaction_mob(mob/living/L, method=TOUCH, reac_volume, show_message = 1, touch_protection = 0)
 	if(method==PATCH || method==INGEST || method==INJECT || (method == VAPOR && prob(min(reac_volume,100)*(1 - touch_protection))))
 		L.ForceContractDisease(new /datum/disease/transformation/gondola(), FALSE, TRUE)


### PR DESCRIPTION
:cl: Denton
add: Killing gondolas now lets you harvest meat from them. Eating it raw might be a bad idea.
/:cl:

I've heard of this story where eating mermaid flesh either makes you immortal or gives you a horrible fate, so I thought, why not apply this to our beloved gondolas?

Gondola meat contains a reagent that causes the gondola transformation disease - it will continuously dose the victim with pax until eventually triggering the transformation. The cure? Condensed capsaicin.

I've reduced the default stage_prob (translates to progress speed) and changed the cure to condensed capsaicin, so you can't easily fuck over people with tranquillity smoke grenades.