### PR TITLE
Adds more wiki books/manuals

### DIFF
--- a/_maps/map_files/BoxStation/BoxStation.dmm
+++ b/_maps/map_files/BoxStation/BoxStation.dmm
@@ -17644,6 +17644,10 @@
 "aTO" = (
 /obj/structure/table,
 /obj/item/book/manual/chef_recipes,
+/obj/item/book/manual/wiki/cooking_to_serve_man{
+	pixel_x = -4;
+	pixel_y = 4
+	},
 /turf/open/floor/plasteel/cafeteria,
 /area/crew_quarters/kitchen)
 "aTP" = (
@@ -25625,6 +25629,11 @@
 /area/medical/medbay/central)
 "bod" = (
 /obj/structure/table,
+/obj/item/book/manual/wiki/grenades,
+/obj/item/book/manual/wiki/chemistry{
+	pixel_x = -4;
+	pixel_y = 4
+	},
 /obj/item/folder/white,
 /obj/item/pen,
 /turf/open/floor/plasteel/white,
@@ -30451,6 +30460,7 @@
 /area/quartermaster/qm)
 "bzS" = (
 /obj/structure/table,
+/obj/item/book/manual/wiki/surgery,
 /obj/item/cautery{
 	pixel_x = 4
 	},
@@ -33816,10 +33826,11 @@
 "bIj" = (
 /obj/structure/table,
 /obj/machinery/light,
+/obj/item/book/manual/wiki/medicine,
+/obj/item/clothing/glasses/hud/health,
+/obj/item/clothing/glasses/hud/health,
+/obj/item/clothing/glasses/hud/health,
 /obj/item/reagent_containers/spray/cleaner,
-/obj/item/clothing/glasses/hud/health,
-/obj/item/clothing/glasses/hud/health,
-/obj/item/clothing/glasses/hud/health,
 /turf/open/floor/plasteel/white,
 /area/medical/sleeper)
 "bIk" = (
@@ -37895,6 +37906,7 @@
 	pixel_x = 2;
 	pixel_y = 2
 	},
+/obj/item/book/manual/wiki/atmospherics,
 /turf/open/floor/plasteel,
 /area/engine/atmos)
 "bSH" = (
@@ -42222,6 +42234,7 @@
 /area/tcommsat/server)
 "cee" = (
 /obj/structure/table,
+/obj/item/book/manual/wiki/tcomms,
 /obj/item/radio/off,
 /turf/open/floor/plasteel/yellow/side{
 	dir = 10
@@ -52837,6 +52850,7 @@
 /area/maintenance/starboard/aft)
 "kwK" = (
 /obj/structure/table/reinforced,
+/obj/item/book/manual/wiki/toxins,
 /turf/open/floor/plasteel/white,
 /area/science/mixing)
 "kxC" = (
@@ -53568,6 +53582,7 @@
 /area/engine/engineering)
 "ueT" = (
 /obj/structure/table/reinforced,
+/obj/item/book/manual/wiki/circuitry,
 /turf/open/floor/plasteel/white,
 /area/science/circuit)
 "uhH" = (

--- a/_maps/map_files/Deltastation/DeltaStation2.dmm
+++ b/_maps/map_files/Deltastation/DeltaStation2.dmm
@@ -16846,13 +16846,14 @@
 	dir = 8
 	},
 /obj/structure/table/reinforced,
-/obj/item/electronics/airalarm,
-/obj/item/electronics/airalarm,
-/obj/item/electronics/firealarm,
-/obj/item/electronics/firealarm,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 6
 	},
+/obj/item/book/manual/wiki/atmospherics{
+	pixel_x = 4;
+	pixel_y = -4
+	},
+/obj/item/book/manual/wiki/atmospherics,
 /turf/open/floor/plasteel/caution{
 	dir = 9
 	},
@@ -25419,6 +25420,7 @@
 "bhR" = (
 /obj/structure/table/reinforced,
 /obj/effect/turf_decal/bot,
+/obj/item/book/manual/wiki/cooking_to_serve_man,
 /turf/open/floor/plasteel,
 /area/crew_quarters/kitchen)
 "bhS" = (
@@ -40706,6 +40708,7 @@
 	name = "Station Intercom";
 	pixel_y = 26
 	},
+/obj/item/book/manual/wiki/tcomms,
 /obj/item/radio{
 	pixel_y = 5
 	},
@@ -55251,11 +55254,12 @@
 	pixel_x = 26
 	},
 /obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/delivery,
+/obj/item/book/manual/wiki/tcomms,
 /obj/item/wrench,
 /obj/item/screwdriver{
 	pixel_y = 5
 	},
-/obj/effect/turf_decal/delivery,
 /turf/open/floor/plasteel,
 /area/tcommsat/server)
 "cpN" = (
@@ -72482,15 +72486,16 @@
 /area/medical/medbay/central)
 "cZH" = (
 /obj/structure/table/glass,
-/obj/item/stack/medical/gauze,
-/obj/item/stack/medical/bruise_pack,
-/obj/item/stack/medical/ointment,
 /obj/machinery/camera{
 	c_tag = "Medbay - Sleepers";
 	network = list("ss13","medbay");
 	dir = 2;
 	name = "medbay camera"
 	},
+/obj/item/book/manual/wiki/medicine,
+/obj/item/stack/medical/gauze,
+/obj/item/stack/medical/bruise_pack,
+/obj/item/stack/medical/ointment,
 /turf/open/floor/plasteel/whiteblue/corner{
 	dir = 1
 	},
@@ -73179,8 +73184,19 @@
 /area/medical/chemistry)
 "dbc" = (
 /obj/structure/table/glass,
-/obj/item/clipboard,
-/obj/item/toy/figure/chemist,
+/obj/item/book/manual/wiki/chemistry{
+	pixel_x = -4;
+	pixel_y = 4
+	},
+/obj/item/book/manual/wiki/grenades,
+/obj/item/clipboard{
+	pixel_x = 4;
+	pixel_y = -4
+	},
+/obj/item/toy/figure/chemist{
+	pixel_x = 4;
+	pixel_y = -4
+	},
 /turf/open/floor/plasteel/whiteyellow/corner{
 	dir = 1
 	},
@@ -81084,14 +81100,15 @@
 /area/medical/medbay/central)
 "dsG" = (
 /obj/structure/table/glass,
-/obj/item/wrench/medical,
-/obj/item/clothing/neck/stethoscope,
 /obj/machinery/camera{
 	c_tag = "Medbay - Cryogenics";
 	network = list("ss13","medbay");
 	dir = 1;
 	name = "medbay camera"
 	},
+/obj/item/book/manual/wiki/medicine,
+/obj/item/clothing/neck/stethoscope,
+/obj/item/wrench/medical,
 /turf/open/floor/plasteel/whiteblue,
 /area/medical/medbay/central)
 "dsH" = (
@@ -81181,12 +81198,13 @@
 /turf/open/floor/plasteel/whiteblue,
 /area/medical/surgery)
 "dsQ" = (
-/obj/item/scalpel,
-/obj/item/cautery,
 /obj/structure/table/reinforced,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
+/obj/item/book/manual/wiki/surgery,
+/obj/item/scalpel,
+/obj/item/cautery,
 /turf/open/floor/plasteel/whiteblue/side{
 	dir = 9
 	},
@@ -87920,9 +87938,13 @@
 /area/science/mixing)
 "dHh" = (
 /obj/structure/table/reinforced,
-/obj/item/storage/firstaid/toxin,
 /obj/effect/turf_decal/stripes/line{
 	dir = 6
+	},
+/obj/item/book/manual/wiki/toxins,
+/obj/item/storage/firstaid/toxin{
+	pixel_x = -4;
+	pixel_y = 4
 	},
 /turf/open/floor/plasteel,
 /area/science/mixing)
@@ -100070,6 +100092,13 @@
 	},
 /turf/closed/wall,
 /area/engine/storage_shared)
+"nDZ" = (
+/obj/structure/table/reinforced,
+/obj/item/book/manual/wiki/circuitry,
+/turf/open/floor/plasteel/white/side{
+	dir = 4
+	},
+/area/science/circuit)
 "nOg" = (
 /obj/structure/lattice,
 /turf/open/space,
@@ -125486,7 +125515,7 @@ djn
 dle
 dmr
 dog
-dle
+nDZ
 drz
 dhR
 dul

--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -37208,10 +37208,10 @@
 /area/tcommsat/computer)
 "bAW" = (
 /obj/structure/table/wood,
-/obj/item/folder/blue,
 /obj/machinery/status_display{
 	pixel_y = 31
 	},
+/obj/item/book/manual/wiki/tcomms,
 /obj/item/folder/blue,
 /obj/item/pen,
 /turf/open/floor/plasteel/grimy,
@@ -37820,13 +37820,14 @@
 /area/engine/atmos)
 "bCn" = (
 /obj/structure/table,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/item/book/manual/wiki/atmospherics,
 /obj/item/storage/belt/utility,
 /obj/item/t_scanner,
 /obj/item/t_scanner,
 /obj/item/t_scanner,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
 /turf/open/floor/plasteel/caution{
 	dir = 8
 	},
@@ -43561,6 +43562,7 @@
 "bOU" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/structure/table,
+/obj/item/book/manual/wiki/cooking_to_serve_man,
 /turf/open/floor/plasteel/cafeteria{
 	dir = 5
 	},
@@ -51226,15 +51228,6 @@
 /area/medical/sleeper)
 "cfJ" = (
 /obj/structure/table,
-/obj/item/folder/white{
-	pixel_x = 4;
-	pixel_y = -3
-	},
-/obj/item/folder/white{
-	pixel_x = 4;
-	pixel_y = -3
-	},
-/obj/item/pen,
 /obj/machinery/power/apc{
 	dir = 1;
 	name = "Sleeper Room APC";
@@ -51244,7 +51237,13 @@
 /obj/structure/cable/yellow{
 	icon_state = "0-2"
 	},
+/obj/item/book/manual/wiki/medicine,
 /obj/item/clothing/neck/stethoscope,
+/obj/item/folder/white{
+	pixel_x = 4;
+	pixel_y = -3
+	},
+/obj/item/pen,
 /turf/open/floor/plasteel/vault,
 /area/medical/sleeper)
 "cfK" = (
@@ -54624,6 +54623,7 @@
 /area/medical/surgery)
 "cnq" = (
 /obj/structure/table,
+/obj/item/book/manual/wiki/surgery,
 /obj/item/retractor,
 /turf/open/floor/plasteel,
 /area/medical/surgery)
@@ -54834,19 +54834,12 @@
 	},
 /area/crew_quarters/heads/cmo)
 "cnH" = (
-/obj/item/clothing/glasses/science{
-	pixel_x = 2;
-	pixel_y = 4
-	},
-/obj/item/clothing/glasses/science,
 /obj/item/radio/intercom{
 	dir = 8;
 	name = "Station Intercom (General)";
 	pixel_x = -28
 	},
 /obj/structure/table/glass,
-/obj/item/stack/cable_coil,
-/obj/item/stack/cable_coil,
 /obj/machinery/camera{
 	c_tag = "Chemistry";
 	dir = 4;
@@ -54855,6 +54848,15 @@
 /obj/machinery/light{
 	dir = 8
 	},
+/obj/item/book/manual/wiki/chemistry{
+	pixel_x = -4;
+	pixel_y = 4
+	},
+/obj/item/book/manual/wiki/grenades,
+/obj/item/stack/cable_coil,
+/obj/item/stack/cable_coil,
+/obj/item/clothing/glasses/science,
+/obj/item/clothing/glasses/science,
 /turf/open/floor/plasteel/whiteyellow/side{
 	dir = 10
 	},
@@ -62580,13 +62582,14 @@
 /area/science/mixing)
 "cDp" = (
 /obj/structure/table,
+/obj/effect/turf_decal/stripes/corner{
+	dir = 4
+	},
+/obj/item/book/manual/wiki/toxins,
 /obj/item/clothing/glasses/science,
 /obj/item/clothing/glasses/science,
 /obj/item/multitool{
 	pixel_x = 3
-	},
-/obj/effect/turf_decal/stripes/corner{
-	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/science/mixing)
@@ -76384,10 +76387,11 @@
 /area/engine/storage_shared)
 "oLW" = (
 /obj/structure/table/reinforced,
-/obj/item/integrated_electronics/debugger,
 /obj/structure/sign/poster/random{
 	pixel_y = 32
 	},
+/obj/item/book/manual/wiki/circuitry,
+/obj/item/integrated_electronics/debugger,
 /turf/open/floor/plasteel/purple/side,
 /area/science/circuit)
 "oRL" = (

--- a/_maps/map_files/PubbyStation/PubbyStation.dmm
+++ b/_maps/map_files/PubbyStation/PubbyStation.dmm
@@ -20796,10 +20796,11 @@
 /area/crew_quarters/kitchen)
 "bcg" = (
 /obj/structure/table,
-/obj/item/kitchen/rollingpin,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
+/obj/item/book/manual/wiki/cooking_to_serve_man,
+/obj/item/kitchen/rollingpin,
 /turf/open/floor/plasteel/cafeteria,
 /area/crew_quarters/kitchen)
 "bch" = (
@@ -24249,10 +24250,11 @@
 /obj/machinery/light{
 	dir = 1
 	},
-/obj/item/integrated_electronics/debugger,
 /obj/machinery/computer/security/telescreen/circuitry{
 	pixel_y = 30
 	},
+/obj/item/book/manual/wiki/circuitry,
+/obj/item/integrated_electronics/debugger,
 /turf/open/floor/plasteel/vault{
 	dir = 5
 	},
@@ -26931,6 +26933,7 @@
 "bsL" = (
 /obj/item/storage/box/beakers,
 /obj/structure/table/glass,
+/obj/item/stack/cable_coil/random,
 /turf/open/floor/plasteel/white,
 /area/medical/chemistry)
 "bsM" = (
@@ -29916,8 +29919,11 @@
 	dir = 1;
 	pixel_y = -22
 	},
-/obj/item/stack/cable_coil/random,
 /obj/item/book/manual/wiki/chemistry,
+/obj/item/book/manual/wiki/grenades{
+	pixel_x = -4;
+	pixel_y = 4
+	},
 /turf/open/floor/plasteel/whiteyellow/side,
 /area/medical/chemistry)
 "bAh" = (
@@ -30776,10 +30782,11 @@
 /area/medical/virology)
 "bCi" = (
 /obj/structure/table/glass,
-/obj/item/stack/medical/gauze,
 /obj/structure/extinguisher_cabinet{
 	pixel_x = -24
 	},
+/obj/item/book/manual/wiki/medicine,
+/obj/item/stack/medical/gauze,
 /turf/open/floor/plasteel/blue,
 /area/medical/sleeper)
 "bCj" = (
@@ -32150,11 +32157,12 @@
 /area/science/mixing)
 "bFk" = (
 /obj/structure/table/reinforced,
+/obj/item/book/manual/wiki/toxins,
+/obj/item/analyzer,
 /obj/item/wrench,
 /obj/item/screwdriver{
 	pixel_y = 10
 	},
-/obj/item/analyzer,
 /turf/open/floor/plasteel/white,
 /area/science/mixing)
 "bFl" = (
@@ -35157,6 +35165,7 @@
 /area/medical/surgery)
 "bMR" = (
 /obj/structure/table,
+/obj/item/book/manual/wiki/surgery,
 /obj/item/retractor,
 /turf/open/floor/plasteel/whiteblue,
 /area/medical/surgery)
@@ -35940,9 +35949,10 @@
 /area/engine/atmos)
 "bOV" = (
 /obj/structure/table,
+/obj/item/book/manual/wiki/atmospherics,
 /obj/item/clothing/head/welding{
-	pixel_x = -3;
-	pixel_y = 7
+	pixel_x = -5;
+	pixel_y = 3
 	},
 /obj/item/clothing/head/welding{
 	pixel_x = -5;
@@ -43859,6 +43869,7 @@
 	pixel_x = -32
 	},
 /obj/structure/table,
+/obj/item/book/manual/wiki/tcomms,
 /obj/item/paper_bin{
 	pixel_x = -2;
 	pixel_y = 5

--- a/code/game/objects/items/manuals.dm
+++ b/code/game/objects/items/manuals.dm
@@ -372,3 +372,60 @@
 	author = "Medical Journal, volume 3"
 	title = "Cloning techniques of the 26th century"
 	page_link = "Guide_to_genetics#Cloning"
+
+/obj/item/book/manual/wiki/cooking_to_serve_man
+	name = "To Serve Man"
+	desc = "It's a cookbook!"
+	icon_state ="cooked_book"
+	author = "the Kanamitan Empire"
+	title = "To Serve Man"
+	page_link = "Guide_to_food_and_drinks"
+
+/obj/item/book/manual/wiki/circuitry
+	name = "Circuitry for Dummies"
+	icon_state = "book1"
+	author = "Dr. Hans Asperger"
+	title = "Circuitry for Dummies"
+	page_link = "Guide_to_circuits"
+
+/obj/item/book/manual/wiki/tcomms
+	name = "Subspace Telecommunications And You"
+	icon_state = "book3"
+	author = "Engineering Encyclopedia"
+	title = "Subspace Telecommunications And You"
+	page_link = "Guide_to_Telecommunications"
+
+/obj/item/book/manual/wiki/atmospherics
+	name = "The Atmosian Chronicles"
+	icon_state = "book5"
+	author = "the City-state of Atmosia"
+	title = "The Atmosian Chronicles"
+	page_link = "Guide_to_Atmospherics"
+	
+/obj/item/book/manual/wiki/medicine
+	name = "Medical Space Compendium, Volume 638"
+	icon_state = "book8"
+	author = "Medical Journal"
+	title = "Medical Space Compendium, Volume 638"
+	page_link = "Guide_to_medicine"
+
+/obj/item/book/manual/wiki/surgery
+	name = "Brain Surgery for Dummies"
+	icon_state = "book4"
+	author = "Dr. F. Fran"
+	title = "Brain Surgery for Dummies"
+	page_link = "Surgery"
+
+/obj/item/book/manual/wiki/grenades
+	name = "DIY Chemical Grenades"
+	icon_state = "book2"
+	author = "W. Powell"
+	title = "DIY Chemical Grenades"
+	page_link = "Grenade"
+
+/obj/item/book/manual/wiki/toxins
+	name = "Toxins or: How I Learned to Stop Worrying and Love the Maxcap"
+	icon_state = "book6"
+	author = "Cuban Pete"
+	title = "Toxins or: How I Learned to Stop Worrying and Love the Maxcap"
+	page_link = "Guide_to_toxins"

--- a/code/game/objects/items/manuals.dm
+++ b/code/game/objects/items/manuals.dm
@@ -339,10 +339,10 @@
 	page_link = "Detective"
 
 /obj/item/book/manual/wiki/barman_recipes
-	name = "Barman Recipes"
+	name = "Barman Recipes: Mixing Drinks and Changing Lives"
 	icon_state = "barbook"
 	author = "Sir John Rose"
-	title = "Barman Recipes"
+	title = "Barman Recipes: Mixing Drinks and Changing Lives"
 	page_link = "Guide_to_food_and_drinks"
 	
 /obj/item/book/manual/wiki/robotics_cyborgs
@@ -396,10 +396,10 @@
 	page_link = "Guide_to_Telecommunications"
 
 /obj/item/book/manual/wiki/atmospherics
-	name = "The Atmosian Chronicles"
+	name = "Lexica Atmosia"
 	icon_state = "book5"
 	author = "the City-state of Atmosia"
-	title = "The Atmosian Chronicles"
+	title = "Lexica Atmosia"
 	page_link = "Guide_to_Atmospherics"
 	
 /obj/item/book/manual/wiki/medicine
@@ -429,3 +429,24 @@
 	author = "Cuban Pete"
 	title = "Toxins or: How I Learned to Stop Worrying and Love the Maxcap"
 	page_link = "Guide_to_toxins"
+
+/obj/item/book/manual/wiki/toxins/suicide_act(mob/user)
+	var/mob/living/carbon/human/H = user
+	user.visible_message("<span class='suicide'>[user] starts dancing to the Rhumba Beat! It looks like [user.p_theyre()] trying to commit suicide!</span>")
+	playsound(loc, 'sound/effects/spray.ogg', 10, 1, -3)
+	if (!QDELETED(H))
+		H.emote("spin")
+		sleep(20)
+		for(var/obj/item/W in H)
+			H.dropItemToGround(W)
+			if(prob(50))
+				step(W, pick(GLOB.alldirs))
+		H.add_trait(TRAIT_DISFIGURED, TRAIT_GENERIC)
+		H.bleed_rate = 5
+		H.gib_animation()
+		sleep(3)
+		H.adjustBruteLoss(1000) //to make the body super-bloody
+		H.spawn_gibs()
+		H.spill_organs()
+		H.spread_bodyparts()
+	return (BRUTELOSS)


### PR DESCRIPTION
:cl: Denton
spellcheck: Added more ingame manuals that access wiki pages.
/:cl:

I added /wiki manuals for the following:
- Tcomms
- Atmos
- Circuitry
- Toxins
- Medicine/Medbay
- Surgery
- DIY grenades
- Food

Should give new players an easier time since they won't have to tab out to a browser and search the wiki.