### PR TITLE
Hovering over storage slots with an item in your hand will show you first if you can put the item in

### DIFF
--- a/code/_onclick/hud/screen_objects.dm
+++ b/code/_onclick/hud/screen_objects.dm
@@ -128,7 +128,7 @@
 
 /obj/screen/inventory/MouseEntered()
 	..()
-	update_overlays()
+	add_overlays()
 
 /obj/screen/inventory/MouseExited()
 	..()
@@ -144,7 +144,7 @@
 		else
 			icon_state = icon_empty
 
-/obj/screen/inventory/proc/update_overlays()
+/obj/screen/inventory/proc/add_overlays()
 	var/mob/user = hud.mymob
 
 	cut_overlay(object_overlays)

--- a/code/_onclick/hud/screen_objects.dm
+++ b/code/_onclick/hud/screen_objects.dm
@@ -166,11 +166,12 @@
 				return // Don't show preview if there's a regular item
 			
 			can_equip = storage.can_be_inserted(holding, TRUE, user)
+		else
+			can_equip = user.can_equip(holding, slot_id, disable_warning = TRUE)
 		
 		var/image/item_overlay = image(holding)
 		item_overlay.alpha = 191
 		object_overlays += item_overlay
-		can_equip = user.can_equip(holding, slot_id, disable_warning = TRUE)
 		
 		if(!can_equip)
 			var/image/nope_overlay = image('icons/mob/screen_gen.dmi', "x")

--- a/code/_onclick/hud/screen_objects.dm
+++ b/code/_onclick/hud/screen_objects.dm
@@ -153,27 +153,14 @@
 	if(hud && user && slot_id)
 		var/obj/item/holding = user.get_active_held_item()
 
-		if(!holding)
+		if(!holding || user.get_item_by_slot(slot_id))
 			return
 
-		var/obj/item/item_in_slot = user.get_item_by_slot(slot_id)
-		var/can_equip
-
-		if(item_in_slot)
-			GET_COMPONENT_FROM(storage, /datum/component/storage, item_in_slot)
-
-			if(!storage)
-				return // Don't show preview if there's a regular item
-			
-			can_equip = storage.can_be_inserted(holding, TRUE, user)
-		else
-			can_equip = user.can_equip(holding, slot_id, disable_warning = TRUE)
-		
 		var/image/item_overlay = image(holding)
 		item_overlay.alpha = 191
 		object_overlays += item_overlay
 		
-		if(!can_equip)
+		if(!user.can_equip(holding, slot_id, disable_warning = TRUE))
 			var/image/nope_overlay = image('icons/mob/screen_gen.dmi', "x")
 			nope_overlay.alpha = 128
 			nope_overlay.layer = item_overlay.layer + 1

--- a/code/datums/components/storage/storage.dm
+++ b/code/datums/components/storage/storage.dm
@@ -552,7 +552,7 @@
 	if(real_location == I.loc)
 		return FALSE //Means the item is already in the storage item
 	if(locked)
-		if(M)
+		if(M && !stop_messages)
 			host.add_fingerprint(M)
 			to_chat(M, "<span class='warning'>[host] seems to be locked!</span>")
 		return FALSE


### PR DESCRIPTION
[Changelogs]: #

:cl:
add: Hovering over storage slots with an item in your hand will show you first if you can put the item in.
/:cl:

[why]: # Quality of life. Sometimes I forget whether or not I can put an item in my suit storage/pockets. Note this doesn't trigger for hands.

(You can't see it but my mouse is hovering over the inventory slots)

![2018-08-11_20-33-12](https://user-images.githubusercontent.com/35135081/43999779-ff1f3fe8-9dc7-11e8-871c-74e14ab4f9f9.gif)