### PR TITLE
Adds binoculars to the Detective's locker

### DIFF
--- a/code/game/objects/structures/crates_lockers/closets/secure/security.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/security.dm
@@ -193,6 +193,7 @@
 	new /obj/item/clothing/suit/armor/vest/det_suit(src)
 	new /obj/item/storage/belt/holster/full(src)
 	new /obj/item/pinpointer/crew(src)
+	new /obj/item/twohanded/binoculars(src)
 
 /obj/structure/closet/secure_closet/injection
 	name = "lethal injections"


### PR DESCRIPTION
:cl: barbedwireqtip
tweak: added binoculars to the detective's locker
/:cl:

Why: Figured you should be able to obtain these in-game since they're a pretty nifty feature and it makes the most sense to give them to the detective so he can ~~spy on people~~ "investigate" better.