### PR TITLE
improves emote and suicide restraint checks

### DIFF
--- a/code/datums/emotes.dm
+++ b/code/datums/emotes.dm
@@ -102,12 +102,25 @@
 		return FALSE
 	if(status_check && !is_type_in_typecache(user, mob_type_ignore_stat_typecache))
 		if(user.stat > stat_allowed)
-			if(intentional)
-				to_chat(user, "<span class='notice'>You cannot [key] while unconscious.</span>")
+			if(!intentional)
+				return FALSE
+			switch(user.stat)
+				if(SOFT_CRIT)
+					to_chat(user, "<span class='notice'>You cannot [key] while in a critical condition.</span>")
+				if(UNCONSCIOUS)
+					to_chat(user, "<span class='notice'>You cannot [key] while unconscious.</span>")
+				if(DEAD)
+					to_chat(user, "<span class='notice'>You cannot [key] while dead.</span>")
 			return FALSE
-		if(restraint_check && (user.restrained() || user.buckled))
-			if(intentional)
-				to_chat(user, "<span class='notice'>You cannot [key] while restrained.</span>")
+		if(restraint_check && (user.IsStun() || user.IsKnockdown()))
+			if(!intentional)
+				return FALSE
+			to_chat(user, "<span class='notice'>You cannot [key] while stunned.</span>")
+			return FALSE
+		if(restraint_check && user.restrained())
+			if(!intentional)
+				return FALSE
+			to_chat(user, "<span class='notice'>You cannot [key] while restrained.</span>")
 			return FALSE
 
 	if(isliving(user))

--- a/code/modules/client/verbs/suicide.dm
+++ b/code/modules/client/verbs/suicide.dm
@@ -205,18 +205,24 @@
 	log_game("[key_name(src)] (job: [src.job ? "[src.job]" : "None"]) committed suicide at [AREACOORD(src)].")
 
 /mob/living/proc/canSuicide()
-	if(stat == CONSCIOUS)
-		return TRUE
-	else if(stat == DEAD)
-		to_chat(src, "You're already dead!")
-	else if(stat == UNCONSCIOUS)
-		to_chat(src, "You need to be conscious to suicide!")
+	switch(stat)
+		if(CONSCIOUS)
+			return TRUE
+		if(SOFT_CRIT)
+			to_chat(src, "You can't commit suicide while in a critical condition!")
+		if(UNCONSCIOUS)
+			to_chat(src, "You need to be conscious to commit suicide!")
+		if(DEAD)
+			to_chat(src, "You're already dead!")
 	return
 
 /mob/living/carbon/canSuicide()
 	if(!..())
 		return
-	if(!canmove || restrained())	//just while I finish up the new 'fun' suiciding verb. This is to prevent metagaming via suicide
-		to_chat(src, "You can't commit suicide whilst restrained! ((You can type Ghost instead however.))")
+	if(IsStun() || IsKnockdown())	//just while I finish up the new 'fun' suiciding verb. This is to prevent metagaming via suicide
+		to_chat(src, "You can't commit suicide while stunned! ((You can type Ghost instead however.))")
+		return
+	if(restrained())
+		to_chat(src, "You can't commit suicide while restrained! ((You can type Ghost instead however.))")
 		return
 	return TRUE


### PR DESCRIPTION
:cl:
fix: You can now use certain emotes and the suicide verb while buckled, but not while stunned.
/:cl:

this will allow using emotes, with the restraint check, and the suicide verb while riding vehicles or sitting in chairs (you're not actually restrained), but unable to use them while stunned (you're technically restrained) e.g. clap, salute
improved to_chat messages so there's always feedback and they make sense in all circumstances