### PR TITLE
Fix escape pod 1 not reaching the recovery ship

### DIFF
--- a/code/modules/shuttle/shuttle.dm
+++ b/code/modules/shuttle/shuttle.dm
@@ -299,11 +299,7 @@
 // Called after the shuttle is loaded from template
 /obj/docking_port/mobile/proc/linkup(datum/map_template/shuttle/template, obj/docking_port/stationary/dock)
 	var/list/static/shuttle_id = list()
-	var/idnum
-	if(!shuttle_id[template])
-		shuttle_id[template] = idnum = 1
-	else
-		idnum = shuttle_id[template]++
+	var/idnum = ++shuttle_id[template]
 	if(idnum > 1)
 		if(id == initial(id))
 			id = "[id][idnum]"


### PR DESCRIPTION
:cl:
fix: Escape Pod 1 now reaches the CentCom recovery ship again.
/:cl:

First shuttle hits the first branch, sets entry to 1 and takes id 1. Second shuttle sees entry, reads 1, uses it, and then increments it. Thusly, two pod ones.