### PR TITLE
Fixes uncalibrated teleporters not turning humans into flies

### DIFF
--- a/code/datums/helper_datums/teleport.dm
+++ b/code/datums/helper_datums/teleport.dm
@@ -60,6 +60,8 @@
 		var/mob/M = teleatom
 		M.cancel_camera()
 
+	return TRUE
+
 /proc/tele_play_specials(atom/movable/teleatom, atom/location, datum/effect_system/effect, sound)
 	if (location && !isobserver(teleatom))
 		if (sound)


### PR DESCRIPTION
:cl:
fix: Uncalibrated teleporters can turn humans into flies again
/:cl:

This line got cut off accidentally here
https://github.com/tgstation/tgstation/commit/6e021b54b23fc232159b23f6cf1ba7479bbb267c#diff-02f4a56bc3009ce6e875da92a07e78c8L125

Return value is used here
https://github.com/tgstation/tgstation/blob/dc9fe22c58050ac6f4a9621fba09760dc7f9381c/code/game/machinery/teleporter.dm#L69