### PR TITLE
Removed Comment for Renaming

### DIFF
--- a/config/game_options.txt
+++ b/config/game_options.txt
@@ -14,8 +14,6 @@ REVIVAL_CLONING
 ## amount of time (in hundredths of seconds) for which a brain retains the "spark of life" after the person's death (set to -1 for infinite)
 REVIVAL_BRAIN_LIFE -1
 
-## RENAMING ###
-
 ## OOC DURING ROUND ###
 ## Comment this out if you want OOC to be automatically disabled during the round, it will be enabled during the lobby and after the round end results.
 OOC_DURING_ROUND


### PR DESCRIPTION
Just removed the remnant section that existed for Cyborg renaming to avoid confusion of possible missing config options. The only thing removed was a "section" of the config that no longer had any entries within it.

:cl: Coolguy3289
config: Removed un-needed and un-used RENAME comment from game_options.txt
/:cl:

[why]: Removes any confusion from deprecated rename config entries since these entries no longer exist. 
