### PR TITLE
Skip GC prequeue for 4 most common, guaranteed-to-GC datum types

### DIFF
--- a/code/controllers/subsystem/throwing.dm
+++ b/code/controllers/subsystem/throwing.dm
@@ -68,7 +68,8 @@ SUBSYSTEM_DEF(throwing)
 	target = null
 	thrower = null
 	callback = null
-	return ..()
+	..()
+	return QDEL_HINT_IWILLGC
 
 /datum/thrownthing/proc/tick()
 	var/atom/movable/AM = thrownthing
@@ -116,7 +117,7 @@ SUBSYSTEM_DEF(throwing)
 			return
 
 		dist_travelled++
-		
+
 		if (dist_travelled > MAX_THROWING_DIST)
 			finalize()
 			return

--- a/code/datums/callback.dm
+++ b/code/datums/callback.dm
@@ -59,6 +59,10 @@
 	if(usr)
 		user = WEAKREF(usr)
 
+/datum/callback/Destroy()
+	..()
+	return QDEL_HINT_IWILLGC
+
 /world/proc/ImmediateInvokeAsync(thingtocall, proctocall, ...)
 	set waitfor = FALSE
 
@@ -177,4 +181,3 @@
 	while(CS.pendingcount)
 		sleep(resolution*world.tick_lag)
 	return CS.finished
-

--- a/code/datums/components/forensics.dm
+++ b/code/datums/components/forensics.dm
@@ -5,6 +5,10 @@
 	var/list/blood_DNA			//assoc dna = bloodtype
 	var/list/fibers				//assoc print = print
 
+/datum/component/forensics/Destroy()
+	..()
+	return QDEL_HINT_IWILLGC
+
 /datum/component/forensics/InheritComponent(datum/component/forensics/F, original)		//Use of | and |= being different here is INTENTIONAL.
 	fingerprints = fingerprints | F.fingerprints
 	hiddenprints = hiddenprints | F.hiddenprints

--- a/code/modules/lighting/lighting_source.dm
+++ b/code/modules/lighting/lighting_source.dm
@@ -60,7 +60,8 @@
 	if (needs_update)
 		GLOB.lighting_update_lights -= src
 
-	. = ..()
+	..()
+	return QDEL_HINT_IWILLGC
 
 // Yes this doesn't align correctly on anything other than 4 width tabs.
 // If you want it to go switch everybody to elastic tab stops.


### PR DESCRIPTION
These four never seem to have any issues GCing normally, so there is no specific need to keep a reference around in prequeue to delay that. If the OOM crash bug is merely caused by the garbage subsystem generically being unable to keep up and letting these disposable datums pile up, this will also help with that leading to less crashes.