### PR TITLE
Removes fresh oil from all stations

### DIFF
--- a/_maps/map_files/BoxStation/BoxStation.dmm
+++ b/_maps/map_files/BoxStation/BoxStation.dmm
@@ -11254,7 +11254,7 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
 "aCy" = (
-
+/obj/effect/decal/cleanable/oil,
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
 "aCz" = (
@@ -24120,7 +24120,7 @@
 /turf/open/floor/plating,
 /area/maintenance/disposal)
 "bkC" = (
-
+/obj/effect/decal/cleanable/oil,
 /obj/machinery/light_switch{
 	pixel_x = 25
 	},
@@ -31772,7 +31772,7 @@
 /turf/open/floor/plasteel/barber,
 /area/crew_quarters/heads/cmo)
 "bCX" = (
-
+/obj/effect/decal/cleanable/oil,
 /obj/item/cigbutt,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 4
@@ -36901,7 +36901,7 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
 "bPP" = (
-
+/obj/effect/decal/cleanable/oil,
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
 "bPQ" = (
@@ -36937,7 +36937,7 @@
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
 "bPW" = (
-
+/obj/effect/decal/cleanable/oil,
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
 "bPX" = (
@@ -50766,7 +50766,7 @@
 	id = "engsm";
 	name = "Radiation Chamber Shutters"
 	},
-
+/obj/effect/decal/cleanable/oil,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/stripes/line{
 	dir = 8

--- a/_maps/map_files/BoxStation/BoxStation.dmm
+++ b/_maps/map_files/BoxStation/BoxStation.dmm
@@ -11254,7 +11254,7 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
 "aCy" = (
-/obj/effect/decal/cleanable/oil,
+
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
 "aCz" = (
@@ -24120,7 +24120,7 @@
 /turf/open/floor/plating,
 /area/maintenance/disposal)
 "bkC" = (
-/obj/effect/decal/cleanable/oil,
+
 /obj/machinery/light_switch{
 	pixel_x = 25
 	},
@@ -31772,7 +31772,7 @@
 /turf/open/floor/plasteel/barber,
 /area/crew_quarters/heads/cmo)
 "bCX" = (
-/obj/effect/decal/cleanable/oil,
+
 /obj/item/cigbutt,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 4
@@ -36901,7 +36901,7 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
 "bPP" = (
-/obj/effect/decal/cleanable/oil,
+
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
 "bPQ" = (
@@ -36937,7 +36937,7 @@
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
 "bPW" = (
-/obj/effect/decal/cleanable/oil,
+
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
 "bPX" = (
@@ -50766,7 +50766,7 @@
 	id = "engsm";
 	name = "Radiation Chamber Shutters"
 	},
-/obj/effect/decal/cleanable/oil,
+
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/stripes/line{
 	dir = 8

--- a/_maps/map_files/BoxStation/BoxStation.dmm
+++ b/_maps/map_files/BoxStation/BoxStation.dmm
@@ -11254,7 +11254,6 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
 "aCy" = (
-/obj/effect/decal/cleanable/oil,
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
 "aCz" = (
@@ -24120,7 +24119,6 @@
 /turf/open/floor/plating,
 /area/maintenance/disposal)
 "bkC" = (
-/obj/effect/decal/cleanable/oil,
 /obj/machinery/light_switch{
 	pixel_x = 25
 	},
@@ -31772,7 +31770,6 @@
 /turf/open/floor/plasteel/barber,
 /area/crew_quarters/heads/cmo)
 "bCX" = (
-/obj/effect/decal/cleanable/oil,
 /obj/item/cigbutt,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 4
@@ -36901,7 +36898,6 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
 "bPP" = (
-/obj/effect/decal/cleanable/oil,
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
 "bPQ" = (
@@ -36937,7 +36933,6 @@
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
 "bPW" = (
-/obj/effect/decal/cleanable/oil,
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
 "bPX" = (
@@ -50766,7 +50761,6 @@
 	id = "engsm";
 	name = "Radiation Chamber Shutters"
 	},
-/obj/effect/decal/cleanable/oil,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/stripes/line{
 	dir = 8

--- a/_maps/map_files/Deltastation/DeltaStation2.dmm
+++ b/_maps/map_files/Deltastation/DeltaStation2.dmm
@@ -5066,7 +5066,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
-
+/obj/effect/decal/cleanable/oil,
 /obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel,
 /area/maintenance/disposal)
@@ -6488,7 +6488,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
-
+/obj/effect/decal/cleanable/oil,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
@@ -8964,7 +8964,7 @@
 	id = "engsm";
 	name = "Radiation Chamber Shutters"
 	},
-
+/obj/effect/decal/cleanable/oil,
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
@@ -9727,7 +9727,7 @@
 /turf/open/floor/plasteel/neutral,
 /area/quartermaster/warehouse)
 "aAy" = (
-
+/obj/effect/decal/cleanable/oil,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
@@ -10363,7 +10363,7 @@
 /turf/open/floor/plasteel/neutral,
 /area/quartermaster/storage)
 "aBU" = (
-
+/obj/effect/decal/cleanable/oil,
 /turf/open/floor/plasteel/neutral,
 /area/quartermaster/storage)
 "aBV" = (
@@ -10773,7 +10773,7 @@
 	},
 /area/quartermaster/warehouse)
 "aCR" = (
-
+/obj/effect/decal/cleanable/oil,
 /obj/structure/cable/white{
 	icon_state = "2-8"
 	},
@@ -13555,7 +13555,7 @@
 /obj/structure/cable/white{
 	icon_state = "0-2"
 	},
-
+/obj/effect/decal/cleanable/oil,
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
@@ -14729,7 +14729,7 @@
 	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment,
-
+/obj/effect/decal/cleanable/oil,
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
@@ -19060,7 +19060,7 @@
 /turf/open/floor/plasteel/neutral,
 /area/quartermaster/storage)
 "aUe" = (
-
+/obj/effect/decal/cleanable/oil,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
@@ -20651,7 +20651,7 @@
 /turf/open/floor/plasteel/neutral,
 /area/quartermaster/office)
 "aXk" = (
-
+/obj/effect/decal/cleanable/oil,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
@@ -24394,7 +24394,7 @@
 	},
 /area/quartermaster/miningoffice)
 "bfy" = (
-
+/obj/effect/decal/cleanable/oil,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plasteel/neutral,
 /area/quartermaster/miningoffice)
@@ -25667,7 +25667,7 @@
 /area/quartermaster/miningoffice)
 "bit" = (
 /obj/effect/decal/cleanable/dirt,
-
+/obj/effect/decal/cleanable/oil,
 /obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel,
 /area/quartermaster/miningoffice)
@@ -52766,7 +52766,7 @@
 /turf/open/floor/plating/airless,
 /area/space/nearstation)
 "ckA" = (
-
+/obj/effect/decal/cleanable/oil,
 /obj/machinery/door/poddoor/shutters/preopen{
 	id = "engpa";
 	name = "Engineering Chamber Shutters"
@@ -54745,7 +54745,7 @@
 /turf/open/floor/plasteel/neutral/side,
 /area/maintenance/starboard)
 "coG" = (
-
+/obj/effect/decal/cleanable/oil,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
@@ -56221,7 +56221,7 @@
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "crY" = (
-
+/obj/effect/decal/cleanable/oil,
 /obj/effect/turf_decal/stripes/line{
 	dir = 2
 	},
@@ -56915,7 +56915,7 @@
 /turf/open/floor/plating,
 /area/engine/engineering)
 "ctr" = (
-
+/obj/effect/decal/cleanable/oil,
 /turf/open/floor/plating,
 /area/engine/engineering)
 "cts" = (
@@ -57043,7 +57043,7 @@
 /turf/open/floor/plasteel,
 /area/maintenance/port)
 "ctG" = (
-
+/obj/effect/decal/cleanable/oil,
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plasteel,
 /area/maintenance/port)
@@ -61955,7 +61955,7 @@
 /turf/open/floor/plating/airless,
 /area/engine/engineering)
 "cDU" = (
-
+/obj/effect/decal/cleanable/oil,
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
@@ -68605,7 +68605,7 @@
 /turf/open/floor/plating,
 /area/maintenance/department/electrical)
 "cRI" = (
-
+/obj/effect/decal/cleanable/oil,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
@@ -79787,7 +79787,7 @@
 /turf/open/floor/plating,
 /area/hallway/secondary/construction)
 "dpH" = (
-
+/obj/effect/decal/cleanable/oil,
 /turf/open/floor/plating,
 /area/hallway/secondary/construction)
 "dpI" = (
@@ -82536,7 +82536,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
-
+/obj/effect/decal/cleanable/oil,
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
@@ -83410,7 +83410,7 @@
 /turf/open/floor/plasteel/neutral,
 /area/science/research/abandoned)
 "dxN" = (
-
+/obj/effect/decal/cleanable/oil,
 /obj/effect/turf_decal/delivery,
 /turf/open/floor/plasteel,
 /area/science/research/abandoned)
@@ -85667,7 +85667,7 @@
 /turf/open/floor/plasteel/neutral,
 /area/science/robotics/lab)
 "dCs" = (
-
+/obj/effect/decal/cleanable/oil,
 /obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel,
 /area/science/robotics/lab)
@@ -89598,7 +89598,7 @@
 /turf/open/floor/plating/airless,
 /area/science/test_area)
 "dKy" = (
-
+/obj/effect/decal/cleanable/oil,
 /obj/effect/turf_decal/stripes/corner{
 	dir = 8
 	},
@@ -92055,7 +92055,7 @@
 /area/maintenance/port/aft)
 "dPM" = (
 /obj/effect/decal/cleanable/dirt,
-
+/obj/effect/decal/cleanable/oil,
 /obj/effect/landmark/blobstart,
 /turf/open/floor/plasteel/neutral/side{
 	dir = 1
@@ -98280,7 +98280,7 @@
 	icon_state = "1-2"
 	},
 /obj/effect/decal/cleanable/dirt,
-
+/obj/effect/decal/cleanable/oil,
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plasteel,
 /area/maintenance/port/aft)

--- a/_maps/map_files/Deltastation/DeltaStation2.dmm
+++ b/_maps/map_files/Deltastation/DeltaStation2.dmm
@@ -5066,7 +5066,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/oil,
+
 /obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel,
 /area/maintenance/disposal)
@@ -6488,7 +6488,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/oil,
+
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
@@ -8964,7 +8964,7 @@
 	id = "engsm";
 	name = "Radiation Chamber Shutters"
 	},
-/obj/effect/decal/cleanable/oil,
+
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
@@ -9727,7 +9727,7 @@
 /turf/open/floor/plasteel/neutral,
 /area/quartermaster/warehouse)
 "aAy" = (
-/obj/effect/decal/cleanable/oil,
+
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
@@ -10363,7 +10363,7 @@
 /turf/open/floor/plasteel/neutral,
 /area/quartermaster/storage)
 "aBU" = (
-/obj/effect/decal/cleanable/oil,
+
 /turf/open/floor/plasteel/neutral,
 /area/quartermaster/storage)
 "aBV" = (
@@ -10773,7 +10773,7 @@
 	},
 /area/quartermaster/warehouse)
 "aCR" = (
-/obj/effect/decal/cleanable/oil,
+
 /obj/structure/cable/white{
 	icon_state = "2-8"
 	},
@@ -13555,7 +13555,7 @@
 /obj/structure/cable/white{
 	icon_state = "0-2"
 	},
-/obj/effect/decal/cleanable/oil,
+
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
@@ -14729,7 +14729,7 @@
 	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment,
-/obj/effect/decal/cleanable/oil,
+
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
@@ -19060,7 +19060,7 @@
 /turf/open/floor/plasteel/neutral,
 /area/quartermaster/storage)
 "aUe" = (
-/obj/effect/decal/cleanable/oil,
+
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
@@ -20651,7 +20651,7 @@
 /turf/open/floor/plasteel/neutral,
 /area/quartermaster/office)
 "aXk" = (
-/obj/effect/decal/cleanable/oil,
+
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
@@ -24394,7 +24394,7 @@
 	},
 /area/quartermaster/miningoffice)
 "bfy" = (
-/obj/effect/decal/cleanable/oil,
+
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plasteel/neutral,
 /area/quartermaster/miningoffice)
@@ -25667,7 +25667,7 @@
 /area/quartermaster/miningoffice)
 "bit" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/oil,
+
 /obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel,
 /area/quartermaster/miningoffice)
@@ -52766,7 +52766,7 @@
 /turf/open/floor/plating/airless,
 /area/space/nearstation)
 "ckA" = (
-/obj/effect/decal/cleanable/oil,
+
 /obj/machinery/door/poddoor/shutters/preopen{
 	id = "engpa";
 	name = "Engineering Chamber Shutters"
@@ -54745,7 +54745,7 @@
 /turf/open/floor/plasteel/neutral/side,
 /area/maintenance/starboard)
 "coG" = (
-/obj/effect/decal/cleanable/oil,
+
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
@@ -56221,7 +56221,7 @@
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "crY" = (
-/obj/effect/decal/cleanable/oil,
+
 /obj/effect/turf_decal/stripes/line{
 	dir = 2
 	},
@@ -56915,7 +56915,7 @@
 /turf/open/floor/plating,
 /area/engine/engineering)
 "ctr" = (
-/obj/effect/decal/cleanable/oil,
+
 /turf/open/floor/plating,
 /area/engine/engineering)
 "cts" = (
@@ -57043,7 +57043,7 @@
 /turf/open/floor/plasteel,
 /area/maintenance/port)
 "ctG" = (
-/obj/effect/decal/cleanable/oil,
+
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plasteel,
 /area/maintenance/port)
@@ -61955,7 +61955,7 @@
 /turf/open/floor/plating/airless,
 /area/engine/engineering)
 "cDU" = (
-/obj/effect/decal/cleanable/oil,
+
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
@@ -68605,7 +68605,7 @@
 /turf/open/floor/plating,
 /area/maintenance/department/electrical)
 "cRI" = (
-/obj/effect/decal/cleanable/oil,
+
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
@@ -79787,7 +79787,7 @@
 /turf/open/floor/plating,
 /area/hallway/secondary/construction)
 "dpH" = (
-/obj/effect/decal/cleanable/oil,
+
 /turf/open/floor/plating,
 /area/hallway/secondary/construction)
 "dpI" = (
@@ -82536,7 +82536,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/oil,
+
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
@@ -83410,7 +83410,7 @@
 /turf/open/floor/plasteel/neutral,
 /area/science/research/abandoned)
 "dxN" = (
-/obj/effect/decal/cleanable/oil,
+
 /obj/effect/turf_decal/delivery,
 /turf/open/floor/plasteel,
 /area/science/research/abandoned)
@@ -85667,7 +85667,7 @@
 /turf/open/floor/plasteel/neutral,
 /area/science/robotics/lab)
 "dCs" = (
-/obj/effect/decal/cleanable/oil,
+
 /obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel,
 /area/science/robotics/lab)
@@ -89598,7 +89598,7 @@
 /turf/open/floor/plating/airless,
 /area/science/test_area)
 "dKy" = (
-/obj/effect/decal/cleanable/oil,
+
 /obj/effect/turf_decal/stripes/corner{
 	dir = 8
 	},
@@ -92055,7 +92055,7 @@
 /area/maintenance/port/aft)
 "dPM" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/oil,
+
 /obj/effect/landmark/blobstart,
 /turf/open/floor/plasteel/neutral/side{
 	dir = 1
@@ -98280,7 +98280,7 @@
 	icon_state = "1-2"
 	},
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/oil,
+
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plasteel,
 /area/maintenance/port/aft)

--- a/_maps/map_files/Deltastation/DeltaStation2.dmm
+++ b/_maps/map_files/Deltastation/DeltaStation2.dmm
@@ -5066,7 +5066,6 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/oil,
 /obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel,
 /area/maintenance/disposal)
@@ -6488,7 +6487,6 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/oil,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
@@ -8964,7 +8962,6 @@
 	id = "engsm";
 	name = "Radiation Chamber Shutters"
 	},
-/obj/effect/decal/cleanable/oil,
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
@@ -9727,7 +9724,6 @@
 /turf/open/floor/plasteel/neutral,
 /area/quartermaster/warehouse)
 "aAy" = (
-/obj/effect/decal/cleanable/oil,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
@@ -10363,7 +10359,6 @@
 /turf/open/floor/plasteel/neutral,
 /area/quartermaster/storage)
 "aBU" = (
-/obj/effect/decal/cleanable/oil,
 /turf/open/floor/plasteel/neutral,
 /area/quartermaster/storage)
 "aBV" = (
@@ -10773,7 +10768,6 @@
 	},
 /area/quartermaster/warehouse)
 "aCR" = (
-/obj/effect/decal/cleanable/oil,
 /obj/structure/cable/white{
 	icon_state = "2-8"
 	},
@@ -13555,7 +13549,6 @@
 /obj/structure/cable/white{
 	icon_state = "0-2"
 	},
-/obj/effect/decal/cleanable/oil,
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
@@ -14729,7 +14722,6 @@
 	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment,
-/obj/effect/decal/cleanable/oil,
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
@@ -19060,7 +19052,6 @@
 /turf/open/floor/plasteel/neutral,
 /area/quartermaster/storage)
 "aUe" = (
-/obj/effect/decal/cleanable/oil,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
@@ -20651,7 +20642,6 @@
 /turf/open/floor/plasteel/neutral,
 /area/quartermaster/office)
 "aXk" = (
-/obj/effect/decal/cleanable/oil,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
@@ -24394,7 +24384,6 @@
 	},
 /area/quartermaster/miningoffice)
 "bfy" = (
-/obj/effect/decal/cleanable/oil,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plasteel/neutral,
 /area/quartermaster/miningoffice)
@@ -25667,7 +25656,6 @@
 /area/quartermaster/miningoffice)
 "bit" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/oil,
 /obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel,
 /area/quartermaster/miningoffice)
@@ -52766,7 +52754,6 @@
 /turf/open/floor/plating/airless,
 /area/space/nearstation)
 "ckA" = (
-/obj/effect/decal/cleanable/oil,
 /obj/machinery/door/poddoor/shutters/preopen{
 	id = "engpa";
 	name = "Engineering Chamber Shutters"
@@ -54745,7 +54732,6 @@
 /turf/open/floor/plasteel/neutral/side,
 /area/maintenance/starboard)
 "coG" = (
-/obj/effect/decal/cleanable/oil,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
@@ -56221,7 +56207,6 @@
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "crY" = (
-/obj/effect/decal/cleanable/oil,
 /obj/effect/turf_decal/stripes/line{
 	dir = 2
 	},
@@ -56915,7 +56900,6 @@
 /turf/open/floor/plating,
 /area/engine/engineering)
 "ctr" = (
-/obj/effect/decal/cleanable/oil,
 /turf/open/floor/plating,
 /area/engine/engineering)
 "cts" = (
@@ -57043,7 +57027,6 @@
 /turf/open/floor/plasteel,
 /area/maintenance/port)
 "ctG" = (
-/obj/effect/decal/cleanable/oil,
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plasteel,
 /area/maintenance/port)
@@ -61955,7 +61938,6 @@
 /turf/open/floor/plating/airless,
 /area/engine/engineering)
 "cDU" = (
-/obj/effect/decal/cleanable/oil,
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
@@ -68605,7 +68587,6 @@
 /turf/open/floor/plating,
 /area/maintenance/department/electrical)
 "cRI" = (
-/obj/effect/decal/cleanable/oil,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
@@ -79787,7 +79768,6 @@
 /turf/open/floor/plating,
 /area/hallway/secondary/construction)
 "dpH" = (
-/obj/effect/decal/cleanable/oil,
 /turf/open/floor/plating,
 /area/hallway/secondary/construction)
 "dpI" = (
@@ -82536,7 +82516,6 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/oil,
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
@@ -83410,7 +83389,6 @@
 /turf/open/floor/plasteel/neutral,
 /area/science/research/abandoned)
 "dxN" = (
-/obj/effect/decal/cleanable/oil,
 /obj/effect/turf_decal/delivery,
 /turf/open/floor/plasteel,
 /area/science/research/abandoned)
@@ -85667,7 +85645,6 @@
 /turf/open/floor/plasteel/neutral,
 /area/science/robotics/lab)
 "dCs" = (
-/obj/effect/decal/cleanable/oil,
 /obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel,
 /area/science/robotics/lab)
@@ -89598,7 +89575,6 @@
 /turf/open/floor/plating/airless,
 /area/science/test_area)
 "dKy" = (
-/obj/effect/decal/cleanable/oil,
 /obj/effect/turf_decal/stripes/corner{
 	dir = 8
 	},
@@ -92055,7 +92031,6 @@
 /area/maintenance/port/aft)
 "dPM" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/oil,
 /obj/effect/landmark/blobstart,
 /turf/open/floor/plasteel/neutral/side{
 	dir = 1
@@ -98280,7 +98255,6 @@
 	icon_state = "1-2"
 	},
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/oil,
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plasteel,
 /area/maintenance/port/aft)

--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -6641,7 +6641,7 @@
 /turf/open/floor/plating,
 /area/maintenance/disposal)
 "anZ" = (
-
+/obj/effect/decal/cleanable/oil,
 /obj/machinery/light_switch{
 	pixel_x = 25
 	},
@@ -43389,7 +43389,7 @@
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
-
+/obj/effect/decal/cleanable/oil,
 /turf/open/floor/wood,
 /area/bridge/showroom/corporate)
 "bOz" = (
@@ -64844,7 +64844,7 @@
 /turf/open/floor/plasteel/floorgrime,
 /area/maintenance/aft)
 "cHG" = (
-
+/obj/effect/decal/cleanable/oil,
 /turf/open/floor/plasteel/floorgrime,
 /area/maintenance/aft)
 "cHH" = (

--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -6641,7 +6641,7 @@
 /turf/open/floor/plating,
 /area/maintenance/disposal)
 "anZ" = (
-/obj/effect/decal/cleanable/oil,
+
 /obj/machinery/light_switch{
 	pixel_x = 25
 	},
@@ -43389,7 +43389,7 @@
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
-/obj/effect/decal/cleanable/oil,
+
 /turf/open/floor/wood,
 /area/bridge/showroom/corporate)
 "bOz" = (
@@ -64844,7 +64844,7 @@
 /turf/open/floor/plasteel/floorgrime,
 /area/maintenance/aft)
 "cHG" = (
-/obj/effect/decal/cleanable/oil,
+
 /turf/open/floor/plasteel/floorgrime,
 /area/maintenance/aft)
 "cHH" = (

--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -6641,7 +6641,6 @@
 /turf/open/floor/plating,
 /area/maintenance/disposal)
 "anZ" = (
-/obj/effect/decal/cleanable/oil,
 /obj/machinery/light_switch{
 	pixel_x = 25
 	},
@@ -43389,7 +43388,6 @@
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
-/obj/effect/decal/cleanable/oil,
 /turf/open/floor/wood,
 /area/bridge/showroom/corporate)
 "bOz" = (
@@ -64844,7 +64842,6 @@
 /turf/open/floor/plasteel/floorgrime,
 /area/maintenance/aft)
 "cHG" = (
-/obj/effect/decal/cleanable/oil,
 /turf/open/floor/plasteel/floorgrime,
 /area/maintenance/aft)
 "cHH" = (

--- a/_maps/map_files/OmegaStation/OmegaStation.dmm
+++ b/_maps/map_files/OmegaStation/OmegaStation.dmm
@@ -3241,7 +3241,6 @@
 /turf/closed/wall/r_wall,
 /area/security/brig)
 "agG" = (
-/obj/effect/decal/cleanable/oil,
 /turf/open/floor/plating,
 /area/asteroid/nearstation)
 "agH" = (
@@ -8607,7 +8606,6 @@
 /turf/open/floor/plasteel,
 /area/quartermaster/miningdock)
 "aqv" = (
-/obj/effect/decal/cleanable/oil,
 /obj/structure/closet/crate,
 /obj/item/flashlight,
 /obj/item/flashlight,
@@ -8821,7 +8819,6 @@
 /area/storage/primary)
 "aqW" = (
 /obj/structure/reagent_dispensers/fueltank,
-/obj/effect/decal/cleanable/oil,
 /obj/structure/extinguisher_cabinet{
 	pixel_y = 26
 	},
@@ -9513,7 +9510,6 @@
 /turf/open/floor/plasteel,
 /area/maintenance/starboard)
 "ast" = (
-/obj/effect/decal/cleanable/oil,
 /obj/effect/turf_decal/bot,
 /obj/effect/turf_decal/stripes/line{
 	dir = 6
@@ -10469,7 +10465,6 @@
 /area/maintenance/port/fore)
 "auE" = (
 /obj/machinery/space_heater,
-/obj/effect/decal/cleanable/oil,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
@@ -11675,7 +11670,6 @@
 	pixel_x = 24;
 	pixel_y = 24
 	},
-/obj/effect/decal/cleanable/oil,
 /obj/effect/turf_decal/bot,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel,
@@ -11972,7 +11966,6 @@
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/visible{
 	dir = 8
 	},
-/obj/effect/decal/cleanable/oil,
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/meter/atmos,
 /turf/open/floor/plasteel/vault{
@@ -18968,7 +18961,6 @@
 	id = "engsm";
 	name = "Radiation Chamber Shutters"
 	},
-/obj/effect/decal/cleanable/oil,
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
@@ -24507,7 +24499,6 @@
 /area/science/robotics/mechbay)
 "aZX" = (
 /obj/structure/reagent_dispensers/fueltank,
-/obj/effect/decal/cleanable/oil,
 /obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel/vault/side,
 /area/science/robotics/mechbay)
@@ -25408,7 +25399,6 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
-/obj/effect/decal/cleanable/oil,
 /obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel,
 /area/science/robotics/lab)
@@ -35352,7 +35342,6 @@
 	},
 /area/hallway/primary/starboard)
 "ueC" = (
-/obj/effect/decal/cleanable/oil,
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
@@ -35504,7 +35493,6 @@
 	},
 /area/engine/atmos)
 "uVJ" = (
-/obj/effect/decal/cleanable/oil,
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 8
 	},

--- a/_maps/map_files/OmegaStation/OmegaStation.dmm
+++ b/_maps/map_files/OmegaStation/OmegaStation.dmm
@@ -3241,7 +3241,7 @@
 /turf/closed/wall/r_wall,
 /area/security/brig)
 "agG" = (
-
+/obj/effect/decal/cleanable/oil,
 /turf/open/floor/plating,
 /area/asteroid/nearstation)
 "agH" = (
@@ -8607,7 +8607,7 @@
 /turf/open/floor/plasteel,
 /area/quartermaster/miningdock)
 "aqv" = (
-
+/obj/effect/decal/cleanable/oil,
 /obj/structure/closet/crate,
 /obj/item/flashlight,
 /obj/item/flashlight,
@@ -8821,7 +8821,7 @@
 /area/storage/primary)
 "aqW" = (
 /obj/structure/reagent_dispensers/fueltank,
-
+/obj/effect/decal/cleanable/oil,
 /obj/structure/extinguisher_cabinet{
 	pixel_y = 26
 	},
@@ -9513,7 +9513,7 @@
 /turf/open/floor/plasteel,
 /area/maintenance/starboard)
 "ast" = (
-
+/obj/effect/decal/cleanable/oil,
 /obj/effect/turf_decal/bot,
 /obj/effect/turf_decal/stripes/line{
 	dir = 6
@@ -10469,7 +10469,7 @@
 /area/maintenance/port/fore)
 "auE" = (
 /obj/machinery/space_heater,
-
+/obj/effect/decal/cleanable/oil,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
@@ -11675,7 +11675,7 @@
 	pixel_x = 24;
 	pixel_y = 24
 	},
-
+/obj/effect/decal/cleanable/oil,
 /obj/effect/turf_decal/bot,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel,
@@ -11972,7 +11972,7 @@
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/visible{
 	dir = 8
 	},
-
+/obj/effect/decal/cleanable/oil,
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/meter/atmos,
 /turf/open/floor/plasteel/vault{
@@ -18968,7 +18968,7 @@
 	id = "engsm";
 	name = "Radiation Chamber Shutters"
 	},
-
+/obj/effect/decal/cleanable/oil,
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
@@ -24507,7 +24507,7 @@
 /area/science/robotics/mechbay)
 "aZX" = (
 /obj/structure/reagent_dispensers/fueltank,
-
+/obj/effect/decal/cleanable/oil,
 /obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel/vault/side,
 /area/science/robotics/mechbay)
@@ -25408,7 +25408,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
-
+/obj/effect/decal/cleanable/oil,
 /obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel,
 /area/science/robotics/lab)
@@ -35352,7 +35352,7 @@
 	},
 /area/hallway/primary/starboard)
 "ueC" = (
-
+/obj/effect/decal/cleanable/oil,
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
@@ -35504,7 +35504,7 @@
 	},
 /area/engine/atmos)
 "uVJ" = (
-
+/obj/effect/decal/cleanable/oil,
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 8
 	},

--- a/_maps/map_files/OmegaStation/OmegaStation.dmm
+++ b/_maps/map_files/OmegaStation/OmegaStation.dmm
@@ -3241,7 +3241,7 @@
 /turf/closed/wall/r_wall,
 /area/security/brig)
 "agG" = (
-/obj/effect/decal/cleanable/oil,
+
 /turf/open/floor/plating,
 /area/asteroid/nearstation)
 "agH" = (
@@ -8607,7 +8607,7 @@
 /turf/open/floor/plasteel,
 /area/quartermaster/miningdock)
 "aqv" = (
-/obj/effect/decal/cleanable/oil,
+
 /obj/structure/closet/crate,
 /obj/item/flashlight,
 /obj/item/flashlight,
@@ -8821,7 +8821,7 @@
 /area/storage/primary)
 "aqW" = (
 /obj/structure/reagent_dispensers/fueltank,
-/obj/effect/decal/cleanable/oil,
+
 /obj/structure/extinguisher_cabinet{
 	pixel_y = 26
 	},
@@ -9513,7 +9513,7 @@
 /turf/open/floor/plasteel,
 /area/maintenance/starboard)
 "ast" = (
-/obj/effect/decal/cleanable/oil,
+
 /obj/effect/turf_decal/bot,
 /obj/effect/turf_decal/stripes/line{
 	dir = 6
@@ -10469,7 +10469,7 @@
 /area/maintenance/port/fore)
 "auE" = (
 /obj/machinery/space_heater,
-/obj/effect/decal/cleanable/oil,
+
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
@@ -11675,7 +11675,7 @@
 	pixel_x = 24;
 	pixel_y = 24
 	},
-/obj/effect/decal/cleanable/oil,
+
 /obj/effect/turf_decal/bot,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel,
@@ -11972,7 +11972,7 @@
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/visible{
 	dir = 8
 	},
-/obj/effect/decal/cleanable/oil,
+
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/meter/atmos,
 /turf/open/floor/plasteel/vault{
@@ -18968,7 +18968,7 @@
 	id = "engsm";
 	name = "Radiation Chamber Shutters"
 	},
-/obj/effect/decal/cleanable/oil,
+
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
@@ -24507,7 +24507,7 @@
 /area/science/robotics/mechbay)
 "aZX" = (
 /obj/structure/reagent_dispensers/fueltank,
-/obj/effect/decal/cleanable/oil,
+
 /obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel/vault/side,
 /area/science/robotics/mechbay)
@@ -25408,7 +25408,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
-/obj/effect/decal/cleanable/oil,
+
 /obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel,
 /area/science/robotics/lab)
@@ -35352,7 +35352,7 @@
 	},
 /area/hallway/primary/starboard)
 "ueC" = (
-/obj/effect/decal/cleanable/oil,
+
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
@@ -35504,7 +35504,7 @@
 	},
 /area/engine/atmos)
 "uVJ" = (
-/obj/effect/decal/cleanable/oil,
+
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 8
 	},

--- a/_maps/map_files/PubbyStation/PubbyStation.dmm
+++ b/_maps/map_files/PubbyStation/PubbyStation.dmm
@@ -3331,9 +3331,6 @@
 /turf/open/floor/plating,
 /area/maintenance/department/crew_quarters/dorms)
 "akh" = (
-/obj/effect/decal/cleanable/oil{
-	icon_state = "floor5"
-	},
 /turf/open/floor/plating,
 /area/maintenance/department/crew_quarters/dorms)
 "akj" = (
@@ -4413,9 +4410,6 @@
 	},
 /area/maintenance/department/crew_quarters/dorms)
 "amG" = (
-/obj/effect/decal/cleanable/oil{
-	icon_state = "floor6"
-	},
 /turf/open/floor/wood{
 	icon_state = "wood-broken4"
 	},
@@ -13513,9 +13507,6 @@
 	dir = 6
 	},
 /obj/effect/decal/cleanable/cobweb,
-/obj/effect/decal/cleanable/oil{
-	icon_state = "floor6"
-	},
 /turf/open/floor/plating{
 	icon_state = "panelscorched"
 	},
@@ -13868,14 +13859,12 @@
 	c_tag = "Dormitory Cyborg Recharging Station";
 	dir = 2
 	},
-/obj/effect/decal/cleanable/oil,
 /turf/open/floor/plasteel/freezer,
 /area/crew_quarters/toilet/restrooms)
 "aKk" = (
 /obj/structure/disposalpipe/segment{
 	dir = 6
 	},
-/obj/effect/decal/cleanable/oil,
 /obj/structure/cable{
 	icon_state = "2-4"
 	},
@@ -22427,7 +22416,6 @@
 /turf/open/floor/plasteel,
 /area/science/robotics/mechbay)
 "bgE" = (
-/obj/effect/decal/cleanable/oil,
 /obj/effect/decal/cleanable/robot_debris{
 	icon_state = "gib3"
 	},
@@ -34602,9 +34590,6 @@
 /turf/open/space,
 /area/space/nearstation)
 "bLt" = (
-/obj/effect/decal/cleanable/oil{
-	icon_state = "floor6"
-	},
 /obj/effect/decal/cleanable/robot_debris/old,
 /turf/open/floor/plasteel/dark,
 /area/maintenance/department/engine)
@@ -35061,7 +35046,6 @@
 	},
 /area/maintenance/department/engine)
 "bMD" = (
-/obj/effect/decal/cleanable/oil,
 /turf/open/floor/plasteel/dark,
 /area/maintenance/department/engine)
 "bME" = (
@@ -48398,9 +48382,6 @@
 "gjN" = (
 /obj/item/weldingtool,
 /obj/effect/spawner/lootdrop/maintenance,
-/obj/effect/decal/cleanable/oil{
-	icon_state = "floor6"
-	},
 /turf/open/floor/plating,
 /area/maintenance/department/security/brig)
 "gkR" = (
@@ -50136,7 +50117,6 @@
 /area/storage/primary)
 "lqc" = (
 /obj/item/toy/gun,
-/obj/effect/decal/cleanable/oil,
 /turf/open/floor/plating,
 /area/maintenance/department/security/brig)
 "lqy" = (
@@ -51510,7 +51490,6 @@
 /turf/open/floor/engine,
 /area/science/xenobiology)
 "pdq" = (
-/obj/effect/decal/cleanable/oil,
 /turf/open/floor/plating,
 /area/maintenance/department/security/brig)
 "pdW" = (
@@ -52561,9 +52540,6 @@
 /obj/structure/sign/poster/contraband/random{
 	pixel_x = 32
 	},
-/obj/effect/decal/cleanable/oil{
-	icon_state = "floor6"
-	},
 /turf/open/floor/plasteel/dark,
 /area/maintenance/department/crew_quarters/dorms)
 "sqQ" = (
@@ -53074,9 +53050,6 @@
 /turf/open/floor/carpet,
 /area/maintenance/department/crew_quarters/dorms)
 "uaE" = (
-/obj/effect/decal/cleanable/oil{
-	icon_state = "floor6"
-	},
 /turf/open/floor/plating,
 /area/maintenance/department/security/brig)
 "uaP" = (
@@ -53482,9 +53455,6 @@
 /area/engine/engineering)
 "vlF" = (
 /obj/item/coin/silver,
-/obj/effect/decal/cleanable/oil{
-	icon_state = "floor5"
-	},
 /obj/structure/light_construct/small{
 	dir = 8
 	},

--- a/_maps/map_files/PubbyStation/PubbyStation.dmm
+++ b/_maps/map_files/PubbyStation/PubbyStation.dmm
@@ -13868,14 +13868,14 @@
 	c_tag = "Dormitory Cyborg Recharging Station";
 	dir = 2
 	},
-/obj/effect/decal/cleanable/oil,
+
 /turf/open/floor/plasteel/freezer,
 /area/crew_quarters/toilet/restrooms)
 "aKk" = (
 /obj/structure/disposalpipe/segment{
 	dir = 6
 	},
-/obj/effect/decal/cleanable/oil,
+
 /obj/structure/cable{
 	icon_state = "2-4"
 	},
@@ -22427,7 +22427,7 @@
 /turf/open/floor/plasteel,
 /area/science/robotics/mechbay)
 "bgE" = (
-/obj/effect/decal/cleanable/oil,
+
 /obj/effect/decal/cleanable/robot_debris{
 	icon_state = "gib3"
 	},
@@ -35061,7 +35061,7 @@
 	},
 /area/maintenance/department/engine)
 "bMD" = (
-/obj/effect/decal/cleanable/oil,
+
 /turf/open/floor/plasteel/dark,
 /area/maintenance/department/engine)
 "bME" = (
@@ -50136,7 +50136,7 @@
 /area/storage/primary)
 "lqc" = (
 /obj/item/toy/gun,
-/obj/effect/decal/cleanable/oil,
+
 /turf/open/floor/plating,
 /area/maintenance/department/security/brig)
 "lqy" = (
@@ -51510,7 +51510,7 @@
 /turf/open/floor/engine,
 /area/science/xenobiology)
 "pdq" = (
-/obj/effect/decal/cleanable/oil,
+
 /turf/open/floor/plating,
 /area/maintenance/department/security/brig)
 "pdW" = (

--- a/_maps/map_files/PubbyStation/PubbyStation.dmm
+++ b/_maps/map_files/PubbyStation/PubbyStation.dmm
@@ -13868,14 +13868,14 @@
 	c_tag = "Dormitory Cyborg Recharging Station";
 	dir = 2
 	},
-
+/obj/effect/decal/cleanable/oil,
 /turf/open/floor/plasteel/freezer,
 /area/crew_quarters/toilet/restrooms)
 "aKk" = (
 /obj/structure/disposalpipe/segment{
 	dir = 6
 	},
-
+/obj/effect/decal/cleanable/oil,
 /obj/structure/cable{
 	icon_state = "2-4"
 	},
@@ -22427,7 +22427,7 @@
 /turf/open/floor/plasteel,
 /area/science/robotics/mechbay)
 "bgE" = (
-
+/obj/effect/decal/cleanable/oil,
 /obj/effect/decal/cleanable/robot_debris{
 	icon_state = "gib3"
 	},
@@ -35061,7 +35061,7 @@
 	},
 /area/maintenance/department/engine)
 "bMD" = (
-
+/obj/effect/decal/cleanable/oil,
 /turf/open/floor/plasteel/dark,
 /area/maintenance/department/engine)
 "bME" = (
@@ -50136,7 +50136,7 @@
 /area/storage/primary)
 "lqc" = (
 /obj/item/toy/gun,
-
+/obj/effect/decal/cleanable/oil,
 /turf/open/floor/plating,
 /area/maintenance/department/security/brig)
 "lqy" = (
@@ -51510,7 +51510,7 @@
 /turf/open/floor/engine,
 /area/science/xenobiology)
 "pdq" = (
-
+/obj/effect/decal/cleanable/oil,
 /turf/open/floor/plating,
 /area/maintenance/department/security/brig)
 "pdW" = (

--- a/_maps/map_files/generic/CentCom.dmm
+++ b/_maps/map_files/generic/CentCom.dmm
@@ -6196,7 +6196,6 @@
 "rr" = (
 /obj/structure/reagent_dispensers/fueltank,
 /obj/item/weldingtool/experimental,
-/obj/effect/decal/cleanable/oil,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plasteel,

--- a/_maps/map_files/generic/CentCom.dmm
+++ b/_maps/map_files/generic/CentCom.dmm
@@ -6196,7 +6196,7 @@
 "rr" = (
 /obj/structure/reagent_dispensers/fueltank,
 /obj/item/weldingtool/experimental,
-
+/obj/effect/decal/cleanable/oil,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plasteel,

--- a/_maps/map_files/generic/CentCom.dmm
+++ b/_maps/map_files/generic/CentCom.dmm
@@ -6196,7 +6196,7 @@
 "rr" = (
 /obj/structure/reagent_dispensers/fueltank,
 /obj/item/weldingtool/experimental,
-/obj/effect/decal/cleanable/oil,
+
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plasteel,


### PR DESCRIPTION
[Changelogs]: #

:cl:
del: Nanotrasen sucked all oil from station using oil sucking bots
/:cl:

Spawned oil sucks.
It makes cargo and engineering a footprint mess 10 seconds into the round, and it makes you so used to seeing oil footprints you won't stop to investigate even if you are a detective.
Now, if you see oil footprints somewhere, you know someone is doing bad things. Like the feature was always supposed to be.
