### PR TITLE
Allows images sent by PDA to be closed

### DIFF
--- a/code/game/machinery/telecomms/machines/message_server.dm
+++ b/code/game/machinery/telecomms/machines/message_server.dm
@@ -144,7 +144,7 @@
 		M << browse("<html><head><title>PDA Photo</title></head>" \
 		+ "<body style='overflow:hidden;margin:0;text-align:center'>" \
 		+ "<img src='pda_photo.png' width='192' style='-ms-interpolation-mode:nearest-neighbor' />" \
-		+ "</body></html>", "window=pdaphoto;size=[picture.psize_x]x[picture.psize_y]")
+		+ "</body></html>", "window=pdaphoto;size=[picture.psize_x]x[picture.psize_y];can-close=true")
 		onclose(M, "pdaphoto")
 
 /datum/data_rc_msg


### PR DESCRIPTION
Allows PDA sent image windows to be closed

:cl:
fix: "Allows image windows sent by PDA to be closed"
/:cl:

Fixes issue #39702 
