### PR TITLE
Possibly fix wall defibs

### DIFF
--- a/code/game/machinery/defibrillator_mount.dm
+++ b/code/game/machinery/defibrillator_mount.dm
@@ -59,10 +59,10 @@
 	if(!defib)
 		to_chat(user, "<span class='warning'>There's no defibrillator unit loaded!</span>")
 		return
-	if(defib.on)
+	if(defib.paddles.loc != defib)
 		to_chat(user, "<span class='warning'>[defib.paddles.loc == user ? "You are already" : "Someone else is"] holding [defib]'s paddles!</span>")
 		return
-	defib.attack_hand(user)
+	user.put_in_hands(defib.paddles)
 
 /obj/machinery/defibrillator_mount/attackby(obj/item/I, mob/living/user, params)
 	if(istype(I, /obj/item/defibrillator))
@@ -77,6 +77,9 @@
 		playsound(src, 'sound/machines/click.ogg', 50, TRUE)
 		defib = I
 		update_icon()
+		return
+	else if(I == defib.paddles)
+		defib.paddles.snap_back()
 		return
 	var/obj/item/card/id = I.GetID()
 	if(id)


### PR DESCRIPTION
This seems to work in testing but this seemed a bit too easy to work first try. Changes the mounted defibs to use the paddle object on the defib rather than the defib itself.

[Changelogs]: #

:cl:
fix: Fixes issues with mounted defibrilators.
/:cl: