### PR TITLE
Refactors exports and pirate loot gathering.

### DIFF
--- a/_maps/shuttles/pirate_default.dmm
+++ b/_maps/shuttles/pirate_default.dmm
@@ -12,22 +12,13 @@
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on,
 /obj/machinery/atmospherics/components/unary/vent_pump/on,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/pod/dark,
 /area/shuttle/pirate)
 "ab" = (
 /obj/structure/table,
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/recharger{
-	pixel_x = 4
-	},
-/obj/item/grenade/smokebomb{
-	pixel_x = -6;
-	pixel_y = 10
-	},
-/obj/item/grenade/smokebomb{
-	pixel_x = -6
-	},
+/obj/machinery/recharger,
 /turf/open/floor/plasteel/darkred/side{
 	dir = 10
 	},
@@ -54,7 +45,6 @@
 /area/shuttle/pirate)
 "ae" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/darkred/corner{
 	dir = 1
 	},
@@ -75,50 +65,15 @@
 	},
 /area/shuttle/pirate)
 "ai" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/table,
-/obj/machinery/microwave{
-	pixel_y = 5
+/obj/machinery/atmospherics/components/unary/vent_pump/on{
+	dir = 1
 	},
-/obj/item/book/manual/wiki/barman_recipes{
-	pixel_x = -8
-	},
-/turf/open/floor/plasteel/bar,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/small,
+/turf/open/floor/pod/dark,
 /area/shuttle/pirate)
 "aj" = (
 /turf/closed/wall/mineral/plastitanium/nodiagonal,
-/area/shuttle/pirate)
-"ak" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/table,
-/obj/item/storage/fancy/cigarettes{
-	pixel_x = 2;
-	pixel_y = 6
-	},
-/obj/item/storage/fancy/cigarettes/cigpack_carp{
-	pixel_x = 10;
-	pixel_y = 6
-	},
-/obj/item/storage/fancy/cigarettes/cigpack_robust{
-	pixel_x = 2
-	},
-/obj/item/storage/fancy/cigarettes/cigpack_midori{
-	pixel_x = 10
-	},
-/obj/item/storage/fancy/cigarettes/cigpack_shadyjims{
-	pixel_x = 2;
-	pixel_y = -6
-	},
-/obj/item/storage/fancy/cigarettes/cigpack_uplift{
-	pixel_x = 10;
-	pixel_y = -6
-	},
-/obj/item/lighter{
-	pixel_x = -14;
-	pixel_y = -6
-	},
-/turf/open/floor/plasteel/bar,
 /area/shuttle/pirate)
 "al" = (
 /obj/machinery/loot_locator,
@@ -158,6 +113,7 @@
 	pixel_x = 24
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/pod/dark,
 /area/shuttle/pirate)
 "ap" = (
@@ -166,92 +122,49 @@
 	},
 /obj/structure/barricade/wooden/crude,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/turf/open/floor/pod/dark,
-/area/shuttle/pirate/vault)
-"aq" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/closet/crate,
-/obj/item/storage/bag/money/vault,
-/obj/item/stack/sheet/mineral/gold{
-	amount = 3;
-	pixel_x = -2;
-	pixel_y = 2
+/turf/open/floor/pod/dark,
+/area/shuttle/pirate)
+"aq" = (
+/obj/structure/chair/stool,
+/obj/machinery/atmospherics/components/unary/vent_pump/on{
+	dir = 4
 	},
-/obj/item/stack/sheet/mineral/silver{
-	amount = 8;
-	pixel_x = 2;
-	pixel_y = -1
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/turf/open/floor/pod/light,
-/area/shuttle/pirate/vault)
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/bar,
+/area/shuttle/pirate)
 "ar" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/rack{
-	dir = 8;
-	layer = 2.9
-	},
-/obj/item/storage/box/lethalshot,
-/obj/item/shield/riot{
-	pixel_x = -3;
-	pixel_y = 3
-	},
-/obj/item/shield/riot,
-/obj/item/gun/ballistic/shotgun/automatic/combat{
-	pixel_x = -2;
-	pixel_y = 2
-	},
-/obj/structure/sign/poster/contraband/revolver{
-	pixel_x = 32
-	},
-/turf/open/floor/pod/light,
-/area/shuttle/pirate/vault)
-"as" = (
-/obj/effect/decal/cleanable/dirt,
 /obj/structure/table,
-/obj/item/gun/energy/laser{
-	pixel_x = -6;
-	pixel_y = 9
-	},
-/obj/item/gun/energy/laser{
-	pixel_x = 3;
-	pixel_y = 9
-	},
-/obj/item/gun/energy/laser{
-	pixel_x = -3;
+/obj/item/storage/fancy/cigarettes{
+	pixel_x = 2;
 	pixel_y = 6
 	},
-/obj/item/gun/energy/laser{
-	pixel_x = 6;
+/obj/item/storage/fancy/cigarettes/cigpack_carp{
+	pixel_x = 10;
 	pixel_y = 6
 	},
-/obj/machinery/recharger,
-/turf/open/floor/pod/light,
-/area/shuttle/pirate/vault)
-"at" = (
-/obj/machinery/light/small,
+/obj/item/storage/fancy/cigarettes/cigpack_robust{
+	pixel_x = 2
+	},
+/obj/item/storage/fancy/cigarettes/cigpack_midori{
+	pixel_x = 10
+	},
+/obj/item/storage/fancy/cigarettes/cigpack_shadyjims{
+	pixel_x = 2;
+	pixel_y = -6
+	},
+/obj/item/storage/fancy/cigarettes/cigpack_uplift{
+	pixel_x = 10;
+	pixel_y = -6
+	},
+/obj/item/lighter{
+	pixel_x = -10;
+	pixel_y = -2
+	},
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/table,
-/obj/item/storage/backpack/duffelbag/syndie/x4{
-	pixel_y = -4
-	},
-/obj/item/melee/transforming/energy/sword/pirate{
-	pixel_x = -1;
-	pixel_y = 10
-	},
-/obj/item/melee/transforming/energy/sword/pirate{
-	pixel_x = 6;
-	pixel_y = 10
-	},
-/obj/item/melee/transforming/energy/sword/pirate{
-	pixel_x = 13;
-	pixel_y = 10
-	},
-/turf/open/floor/pod/light,
-/area/shuttle/pirate/vault)
+/turf/open/floor/plasteel/bar,
+/area/shuttle/pirate)
 "au" = (
 /obj/machinery/door/airlock/hatch{
 	id_tag = "piratebridgebolt";
@@ -268,60 +181,40 @@
 	},
 /obj/structure/barricade/wooden/crude,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/pod/dark,
 /area/shuttle/pirate)
 "aw" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	dir = 8
-	},
-/obj/machinery/vending/wallmed{
-	pixel_x = -28
-	},
-/turf/open/floor/pod/dark,
-/area/shuttle/pirate/vault)
-"ax" = (
-/obj/machinery/light/small{
-	dir = 1
-	},
-/obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/turf/open/floor/pod/dark,
-/area/shuttle/pirate/vault)
-"ay" = (
-/obj/machinery/door/airlock/highsecurity{
-	name = "Armory"
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/turf/open/floor/pod/dark,
-/area/shuttle/pirate/vault)
-"az" = (
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	dir = 1
-	},
-/turf/open/floor/plasteel/vault{
 	dir = 5
 	},
-/area/shuttle/pirate)
-"aA" = (
-/obj/machinery/light/small{
-	dir = 1
-	},
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/obj/machinery/airalarm/all_access{
+/turf/open/floor/plasteel/bar,
+/area/shuttle/pirate)
+"ax" = (
+/obj/machinery/firealarm{
 	pixel_y = 24
 	},
-/turf/open/floor/plasteel/vault{
-	dir = 5
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
 	},
+/turf/open/floor/plasteel/bar,
+/area/shuttle/pirate)
+"ay" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 10
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/vomit/old,
+/turf/open/floor/plasteel/bar,
+/area/shuttle/pirate)
+"az" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/table,
+/obj/machinery/chem_dispenser/drinks{
+	dir = 8
+	},
+/turf/open/floor/plasteel/bar,
 /area/shuttle/pirate)
 "aB" = (
 /obj/machinery/light/small{
@@ -330,7 +223,6 @@
 /obj/machinery/computer/monitor/secret{
 	dir = 8
 	},
-/obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/airalarm/all_access{
 	dir = 1;
@@ -349,14 +241,6 @@
 /area/shuttle/pirate)
 "aD" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/oil,
-/turf/open/floor/plating,
-/area/shuttle/pirate)
-"aE" = (
-/obj/effect/turf_decal/stripes/line,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/space_heater,
 /turf/open/floor/plating,
 /area/shuttle/pirate)
 "aF" = (
@@ -369,18 +253,16 @@
 /turf/open/floor/plating,
 /area/shuttle/pirate)
 "aG" = (
-/obj/effect/turf_decal/stripes/line,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
 /obj/machinery/power/port_gen/pacman{
 	anchored = 1
 	},
 /obj/structure/cable{
 	icon_state = "0-4"
 	},
-/obj/item/wrench{
-	anchored = 1
-	},
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
 /area/shuttle/pirate)
 "aH" = (
@@ -412,25 +294,20 @@
 /turf/open/floor/plating/airless,
 /area/shuttle/pirate)
 "aL" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/bot,
-/obj/machinery/suit_storage_unit/pirate,
-/obj/machinery/light/small{
-	dir = 1
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
+	dir = 4
 	},
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
 /area/shuttle/pirate)
 "aM" = (
+/obj/structure/closet/secure_closet/personal,
+/obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/stripes/line,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/reagent_dispensers/fueltank,
-/obj/machinery/light/small{
-	dir = 8
-	},
-/turf/open/floor/plating,
+/turf/open/floor/wood,
 /area/shuttle/pirate)
 "aN" = (
+/obj/machinery/light/small,
 /obj/machinery/button/door{
 	id = "pirateportexternal";
 	name = "External Bolt Control";
@@ -443,12 +320,10 @@
 	dir = 1
 	},
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/airalarm/all_access{
-	pixel_y = 24
-	},
 /turf/open/floor/plating,
 /area/shuttle/pirate)
 "aO" = (
+/obj/machinery/light/small,
 /obj/machinery/button/door{
 	id = "piratestarboardexternal";
 	name = "External Bolt Control";
@@ -459,30 +334,6 @@
 	},
 /obj/effect/turf_decal/stripes/corner,
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/cable{
-	icon_state = "0-8"
-	},
-/obj/machinery/power/apc{
-	dir = 1;
-	name = "Pirate Corvette APC";
-	pixel_y = 24;
-	req_access = null
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/shuttle/pirate)
-"aP" = (
-/obj/effect/turf_decal/stripes/line,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/components/unary/tank/air{
-	dir = 8
-	},
-/obj/machinery/light/small{
-	dir = 4
-	},
 /turf/open/floor/plating,
 /area/shuttle/pirate)
 "aQ" = (
@@ -505,19 +356,6 @@
 "aS" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/shuttle/pirate)
-"aT" = (
-/obj/effect/turf_decal/stripes/line,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/obj/machinery/meter,
 /turf/open/floor/plating,
 /area/shuttle/pirate)
 "aU" = (
@@ -525,18 +363,13 @@
 /turf/closed/wall/mineral/plastitanium/nodiagonal,
 /area/shuttle/pirate)
 "aV" = (
+/obj/effect/mob_spawn/human/pirate{
+	dir = 1
+	},
 /obj/effect/turf_decal/stripes/line,
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
+/turf/open/floor/plasteel/vault{
+	dir = 5
 	},
-/obj/structure/rack,
-/obj/item/tank/jetpack/carbondioxide{
-	pixel_x = -3;
-	pixel_y = 3
-	},
-/obj/item/tank/jetpack/carbondioxide,
-/turf/open/floor/plating,
 /area/shuttle/pirate)
 "aW" = (
 /obj/machinery/light/small{
@@ -548,7 +381,6 @@
 	y_offset = 7
 	},
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
 /obj/machinery/firealarm{
 	dir = 1;
 	pixel_y = -24
@@ -558,13 +390,13 @@
 	},
 /area/shuttle/pirate)
 "be" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/firealarm{
-	pixel_y = 24
-	},
+/obj/machinery/space_heater,
 /obj/effect/turf_decal/bot,
-/obj/machinery/suit_storage_unit/pirate,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/oil,
 /turf/open/floor/plating,
 /area/shuttle/pirate)
 "bf" = (
@@ -584,37 +416,54 @@
 	},
 /area/shuttle/pirate)
 "bg" = (
-/obj/machinery/door/airlock/hatch{
-	name = "Armory Access"
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/turf/open/floor/plasteel/vault{
-	dir = 5
-	},
-/area/shuttle/pirate)
-"bk" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/effect/decal/cleanable/dirt,
+/obj/structure/table,
+/obj/item/gun/energy/laser{
+	pixel_x = -3;
+	pixel_y = 6
+	},
+/obj/item/gun/energy/laser{
+	pixel_y = 3
+	},
+/obj/machinery/recharger,
+/turf/open/floor/pod/light,
+/area/shuttle/pirate)
+"bk" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
 /obj/machinery/power/smes/engineering{
 	charge = 1e+006
 	},
 /obj/structure/cable,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
 /area/shuttle/pirate)
 "bl" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
+/obj/effect/turf_decal/stripes/line{
+	dir = 6
 	},
-/turf/open/floor/plasteel/bar,
+/obj/machinery/light/small{
+	dir = 1
+	},
+/obj/machinery/airalarm/all_access{
+	pixel_y = 24
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/table,
+/obj/item/gun/energy/laser{
+	pixel_x = -3;
+	pixel_y = 6
+	},
+/obj/item/gun/energy/laser{
+	pixel_y = 3
+	},
+/turf/open/floor/pod/light,
 /area/shuttle/pirate)
 "bm" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/manifold4w/supply/hidden,
-/turf/open/floor/plasteel/bar,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/turf/open/floor/pod/dark,
 /area/shuttle/pirate)
 "bo" = (
 /obj/machinery/light/small{
@@ -626,230 +475,217 @@
 /turf/open/floor/plating,
 /area/shuttle/pirate)
 "br" = (
-/obj/effect/turf_decal/stripes/line,
+/obj/structure/table/wood,
+/obj/item/storage/box/matches,
+/obj/item/reagent_containers/food/drinks/bottle/rum{
+	name = "Captain Pete's Private Reserve Cuban Spaced Rum";
+	pixel_x = -6;
+	pixel_y = 8
+	},
+/obj/item/reagent_containers/food/drinks/drinkingglass/shotglass{
+	pixel_x = 6;
+	pixel_y = 12
+	},
+/obj/item/clothing/mask/cigarette/cigar,
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/reagent_dispensers/watertank,
-/obj/item/reagent_containers/glass/bucket,
-/obj/item/mop,
-/turf/open/floor/plating,
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/wood,
 /area/shuttle/pirate)
 "bt" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/vomit/old,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+/obj/effect/turf_decal/stripes/line{
 	dir = 10
 	},
-/turf/open/floor/plasteel/bar,
-/area/shuttle/pirate)
-"bu" = (
-/obj/structure/closet/secure_closet/personal,
-/obj/machinery/airalarm/all_access{
+/obj/machinery/light/small{
+	dir = 1
+	},
+/obj/machinery/firealarm{
 	pixel_y = 24
 	},
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/components/unary/vent_pump/on,
-/turf/open/floor/plasteel,
+/obj/structure/table,
+/obj/item/melee/transforming/energy/sword/pirate{
+	pixel_x = -1;
+	pixel_y = 6
+	},
+/obj/item/melee/transforming/energy/sword/pirate{
+	pixel_x = 6;
+	pixel_y = 6
+	},
+/obj/item/melee/transforming/energy/sword/pirate{
+	pixel_x = 13;
+	pixel_y = 6
+	},
+/turf/open/floor/pod/light,
+/area/shuttle/pirate)
+"bu" = (
+/obj/machinery/firealarm{
+	pixel_y = 24
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
 /obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel,
 /area/shuttle/pirate)
 "bv" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 9
+	},
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plasteel,
 /area/shuttle/pirate)
 "bw" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
 /obj/machinery/airalarm/all_access{
 	dir = 4;
 	pixel_x = -24
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/turf/open/floor/pod/dark,
-/area/shuttle/pirate/vault)
-"bx" = (
-/obj/machinery/door/airlock{
-	name = "Captain's Quarters"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/turf/open/floor/wood,
-/area/shuttle/pirate)
-"by" = (
-/obj/structure/chair/stool,
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
-	dir = 1
-	},
-/turf/open/floor/plasteel/bar,
-/area/shuttle/pirate)
-"bz" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
+/obj/machinery/light/small{
 	dir = 8
 	},
+/obj/structure/closet/secure_closet/freezer{
+	locked = 0;
+	name = "fridge"
+	},
+/obj/item/storage/box/donkpockets{
+	pixel_x = 2;
+	pixel_y = 3
+	},
+/obj/item/storage/box/donkpockets,
+/obj/item/storage/fancy/donut_box,
+/obj/item/reagent_containers/food/snacks/cookie,
+/obj/item/reagent_containers/food/snacks/cookie{
+	pixel_x = -6;
+	pixel_y = -6
+	},
+/obj/item/reagent_containers/food/snacks/chocolatebar,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/bar,
+/area/shuttle/pirate)
+"bx" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/bar,
+/area/shuttle/pirate)
+"by" = (
+/obj/machinery/atmospherics/pipe/manifold4w/supply/hidden,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/piratepad,
+/turf/open/floor/pod/dark,
 /area/shuttle/pirate)
 "bA" = (
-/obj/machinery/firealarm{
-	dir = 1;
-	pixel_y = -24
-	},
-/obj/machinery/light/small,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
-/turf/open/floor/plasteel/bar,
+/turf/open/floor/pod/dark,
 /area/shuttle/pirate)
 "bB" = (
-/obj/machinery/door/airlock{
-	name = "Crew Quarters"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/turf/open/floor/plasteel/neutral/corner,
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel,
 /area/shuttle/pirate)
 "bC" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	dir = 1
+/obj/machinery/airalarm/all_access{
+	dir = 8;
+	pixel_x = 24
 	},
-/turf/open/floor/plasteel/neutral/corner,
-/area/shuttle/pirate)
-"bD" = (
-/obj/machinery/firealarm{
-	dir = 1;
-	pixel_y = -24
+/obj/machinery/light/small{
+	dir = 4
 	},
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/light/small,
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden,
-/turf/open/floor/plasteel/neutral/corner,
-/area/shuttle/pirate)
-"bE" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
 	dir = 4
 	},
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/neutral/corner,
 /area/shuttle/pirate)
 "bF" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 6
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/table,
+/obj/machinery/microwave{
+	pixel_y = 5
 	},
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = -26
+/obj/item/book/manual/wiki/barman_recipes{
+	pixel_x = -8
 	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/bar,
+/area/shuttle/pirate)
+"bH" = (
+/obj/machinery/vending/boozeomat/all_access,
+/turf/open/floor/plasteel/bar,
+/area/shuttle/pirate)
+"bI" = (
+/obj/machinery/light/small,
+/obj/machinery/computer/piratepad_control{
 	dir = 1
 	},
 /turf/open/floor/pod/dark,
-/area/shuttle/pirate/vault)
-"bH" = (
-/obj/structure/chair/wood/normal,
-/obj/machinery/light/small{
-	dir = 8
-	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
-	dir = 1
-	},
-/turf/open/floor/wood,
-/area/shuttle/pirate)
-"bI" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/turf/open/floor/plasteel/bar,
 /area/shuttle/pirate)
 "bJ" = (
-/obj/machinery/door/airlock{
-	name = "Cabin 1"
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
+	dir = 8
 	},
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/turf/open/floor/plasteel/vault{
-	dir = 5
+/turf/open/floor/plasteel/neutral/side{
+	dir = 6
 	},
 /area/shuttle/pirate)
 "bK" = (
-/obj/machinery/door/airlock{
-	name = "Cabin 2"
-	},
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/turf/open/floor/plasteel/vault{
-	dir = 5
+/obj/structure/sink{
+	pixel_y = 24
 	},
-/area/shuttle/pirate)
-"bL" = (
-/obj/machinery/door/airlock/engineering{
-	name = "Engineering"
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/turf/open/floor/plating,
-/area/shuttle/pirate)
-"bM" = (
-/obj/effect/mob_spawn/human/pirate{
-	dir = 1
-	},
-/obj/machinery/airalarm/all_access{
-	dir = 1;
-	pixel_y = -24
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/light/small{
-	dir = 4
-	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
-	dir = 1
-	},
-/turf/open/floor/plasteel/vault{
-	dir = 5
-	},
-/area/shuttle/pirate)
-"bN" = (
-/obj/effect/mob_spawn/human/pirate{
-	dir = 1
-	},
-/obj/machinery/airalarm/all_access{
-	dir = 1;
-	pixel_y = -24
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/light/small{
+/obj/structure/toilet{
 	dir = 8
 	},
+/obj/machinery/light/small,
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
-	dir = 1
+	dir = 8
 	},
+/turf/open/floor/plasteel/showroomfloor,
+/area/shuttle/pirate)
+"bM" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/machinery/door/airlock{
+	name = "Crew Cabin"
+	},
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/vault{
 	dir = 5
 	},
 /area/shuttle/pirate)
 "bO" = (
+/obj/structure/cable{
+	icon_state = "0-2"
+	},
+/obj/machinery/power/apc{
+	dir = 1;
+	name = "Pirate Corvette APC";
+	pixel_y = 24;
+	req_access = null
+	},
+/obj/structure/reagent_dispensers/watertank,
+/obj/effect/turf_decal/bot,
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plating,
 /area/shuttle/pirate)
 "bP" = (
-/obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
-	dir = 4
+	dir = 1
 	},
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
 /area/shuttle/pirate)
 "bQ" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
 /obj/structure/cable{
-	icon_state = "2-4"
+	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
 /area/shuttle/pirate)
 "bX" = (
-/obj/effect/turf_decal/stripes/line,
-/obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/power/terminal{
 	dir = 4
@@ -870,6 +706,9 @@
 	amount = 10
 	},
 /obj/item/multitool,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
 /turf/open/floor/plating,
 /area/shuttle/pirate)
 "bZ" = (
@@ -922,11 +761,45 @@
 	},
 /turf/closed/wall/mineral/plastitanium,
 /area/shuttle/pirate)
+"dy" = (
+/obj/structure/chair/wood/normal,
+/obj/machinery/atmospherics/components/unary/vent_pump/on{
+	dir = 1
+	},
+/obj/machinery/light/small{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/wood,
+/area/shuttle/pirate)
+"dU" = (
+/obj/machinery/light/small{
+	dir = 8
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on{
+	dir = 1
+	},
+/turf/open/floor/plasteel/vault{
+	dir = 5
+	},
+/area/shuttle/pirate)
 "ek" = (
+/obj/effect/turf_decal/stripes/line,
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/table,
-/obj/machinery/chem_dispenser/drinks,
-/turf/open/floor/plasteel/bar,
+/obj/structure/sign/poster/contraband/revolver{
+	pixel_x = 32
+	},
+/obj/item/storage/backpack/duffelbag/syndie/x4{
+	pixel_y = 8
+	},
+/obj/item/grenade/smokebomb{
+	pixel_x = -5
+	},
+/obj/item/grenade/smokebomb{
+	pixel_x = 5
+	},
+/turf/open/floor/pod/light,
 /area/shuttle/pirate)
 "ep" = (
 /obj/structure/window/reinforced{
@@ -942,27 +815,27 @@
 /area/shuttle/pirate)
 "et" = (
 /obj/structure/grille,
-/turf/open/floor/plating,
+/turf/open/floor/plating/airless,
 /area/shuttle/pirate)
 "eu" = (
 /obj/structure/girder,
 /obj/item/stack/rods{
 	amount = 3
 	},
-/turf/open/floor/plating,
+/turf/open/floor/plating/airless,
 /area/shuttle/pirate)
 "ew" = (
 /obj/structure/girder,
 /obj/item/stack/rods{
 	amount = 5
 	},
-/turf/open/floor/plating,
+/turf/open/floor/plating/airless,
 /area/shuttle/pirate)
 "ex" = (
 /obj/structure/window/reinforced,
 /obj/structure/frame/machine,
 /obj/item/wrench,
-/turf/open/floor/plating,
+/turf/open/floor/plating/airless,
 /area/shuttle/pirate)
 "ey" = (
 /obj/machinery/door/poddoor/shutters/preopen{
@@ -976,7 +849,7 @@
 /obj/structure/window/reinforced,
 /obj/structure/frame/machine,
 /obj/item/stack/cable_coil/cut/red,
-/turf/open/floor/plating,
+/turf/open/floor/plating/airless,
 /area/shuttle/pirate)
 "eA" = (
 /obj/structure/window/reinforced{
@@ -986,64 +859,15 @@
 /obj/structure/frame/computer{
 	anchored = 1
 	},
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/pod/dark,
 /area/shuttle/pirate)
 "eE" = (
-/obj/structure/closet/secure_closet/personal,
-/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 6
+	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel,
-/obj/effect/decal/cleanable/dirt,
-/area/shuttle/pirate)
-"eS" = (
-/obj/structure/closet/secure_closet/personal,
-/turf/open/floor/wood,
-/area/shuttle/pirate)
-"ft" = (
-/obj/machinery/door/airlock{
-	name = "Unisex Restrooms"
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/showroomfloor,
-/area/shuttle/pirate)
-"fw" = (
-/obj/effect/mob_spawn/human/pirate/captain{
-	dir = 8
-	},
-/obj/machinery/airalarm/all_access{
-	pixel_y = 24
-	},
-/turf/open/floor/wood,
-/area/shuttle/pirate)
-"fB" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/toilet{
-	dir = 1
-	},
-/obj/structure/sink{
-	dir = 4;
-	pixel_x = 11;
-	pixel_y = 7
-	},
-/obj/machinery/light/small{
-	dir = 8
-	},
-/turf/open/floor/plasteel/showroomfloor,
-/area/shuttle/pirate)
-"fM" = (
-/obj/structure/table/wood,
-/obj/item/storage/box/matches,
-/obj/item/reagent_containers/food/drinks/bottle/rum{
-	name = "Captain Pete's Private Reserve Cuban Spaced Rum";
-	pixel_x = -6;
-	pixel_y = 8
-	},
-/obj/item/reagent_containers/food/drinks/drinkingglass/shotglass{
-	pixel_x = 6;
-	pixel_y = 12
-	},
-/obj/item/clothing/mask/cigarette/cigar,
-/turf/open/floor/wood,
 /area/shuttle/pirate)
 "fV" = (
 /obj/effect/turf_decal/stripes/line,
@@ -1054,37 +878,75 @@
 /turf/closed/wall/mineral/plastitanium,
 /area/shuttle/pirate)
 "fY" = (
-/obj/machinery/airalarm/all_access{
-	dir = 4;
-	pixel_x = -24
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
+	dir = 1
 	},
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/light/small{
-	dir = 8
-	},
-/obj/structure/closet/secure_closet/freezer{
-	locked = 0;
-	name = "fridge"
-	},
-/obj/item/storage/box/donkpockets{
-	pixel_x = 2;
-	pixel_y = 3
-	},
-/obj/item/storage/box/donkpockets,
-/obj/item/storage/fancy/donut_box,
-/obj/item/reagent_containers/food/snacks/cookie,
-/obj/item/reagent_containers/food/snacks/cookie{
-	pixel_x = -6;
-	pixel_y = -6
-	},
-/obj/item/reagent_containers/food/snacks/chocolatebar,
-/turf/open/floor/plasteel/bar,
+/turf/open/floor/pod/dark,
 /area/shuttle/pirate)
-"gb" = (
+"gY" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
 /obj/effect/decal/cleanable/dirt,
+/turf/open/floor/pod/dark,
+/area/shuttle/pirate)
+"km" = (
+/obj/machinery/atmospherics/components/unary/tank/air,
+/obj/effect/turf_decal/bot,
+/obj/machinery/firealarm{
+	pixel_y = 24
+	},
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/vending/boozeomat/all_access,
-/turf/open/floor/plasteel/bar,
+/turf/open/floor/plating,
+/area/shuttle/pirate)
+"mD" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on,
+/obj/structure/closet/secure_closet/personal,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel,
+/area/shuttle/pirate)
+"mU" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/machinery/door/airlock/engineering{
+	name = "Engineering"
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/pod/dark,
+/area/shuttle/pirate)
+"np" = (
+/obj/structure/reagent_dispensers/fueltank,
+/obj/effect/turf_decal/bot,
+/obj/machinery/airalarm/all_access{
+	pixel_y = 24
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating,
+/area/shuttle/pirate)
+"vB" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 9
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/rack{
+	dir = 8;
+	layer = 2.9
+	},
+/obj/item/storage/box/lethalshot,
+/obj/item/gun/ballistic/shotgun/automatic/combat{
+	pixel_x = -2;
+	pixel_y = 2
+	},
+/turf/open/floor/pod/light,
+/area/shuttle/pirate)
+"wf" = (
+/obj/machinery/door/airlock{
+	name = "Unisex Restrooms"
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/turf/open/floor/plasteel/showroomfloor,
 /area/shuttle/pirate)
 "wR" = (
 /obj/machinery/porta_turret/syndicate/energy{
@@ -1094,10 +956,94 @@
 	mode = 1
 	},
 /turf/closed/wall/mineral/plastitanium,
-/area/shuttle/pirate/vault)
+/area/shuttle/pirate)
+"yi" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/machinery/door/airlock/hatch{
+	name = "Armory Access"
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/pod/dark,
+/area/shuttle/pirate)
+"zw" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/machinery/door/airlock{
+	name = "Captain's Quarters"
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/wood,
+/area/shuttle/pirate)
+"Gk" = (
+/obj/effect/turf_decal/delivery,
+/obj/machinery/suit_storage_unit/pirate,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating,
+/area/shuttle/pirate)
+"JT" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 5
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/closet/crate,
+/obj/item/storage/bag/money/vault,
+/obj/item/stack/sheet/mineral/gold{
+	amount = 3;
+	pixel_x = -2;
+	pixel_y = 2
+	},
+/obj/item/stack/sheet/mineral/silver{
+	amount = 8;
+	pixel_x = 2;
+	pixel_y = -1
+	},
+/turf/open/floor/pod/light,
+/area/shuttle/pirate)
+"NM" = (
+/obj/effect/turf_decal/delivery,
+/obj/machinery/suit_storage_unit/pirate,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating,
+/area/shuttle/pirate)
 "Oe" = (
-/turf/closed/wall/mineral/plastitanium/nodiagonal,
-/area/shuttle/pirate/vault)
+/obj/machinery/atmospherics/pipe/manifold4w/supply/hidden,
+/turf/open/floor/plasteel/bar,
+/area/shuttle/pirate)
+"OD" = (
+/obj/machinery/airalarm/all_access{
+	pixel_y = 24
+	},
+/obj/structure/sign/poster/contraband/random{
+	pixel_x = 32
+	},
+/turf/open/floor/plasteel/vault{
+	dir = 5
+	},
+/area/shuttle/pirate)
+"OL" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/bar,
+/area/shuttle/pirate)
+"RY" = (
+/obj/effect/mob_spawn/human/pirate/captain{
+	dir = 4
+	},
+/obj/machinery/airalarm/all_access{
+	pixel_y = 24
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/sign/poster/contraband/random{
+	pixel_x = -32
+	},
+/turf/open/floor/wood,
+/area/shuttle/pirate)
+"Ur" = (
+/obj/structure/closet/secure_closet/personal,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/neutral/side,
+/area/shuttle/pirate)
 
 (1,1,1) = {"
 af
@@ -1106,11 +1052,11 @@ af
 fW
 aj
 aj
-Oe
-Oe
-Oe
-Oe
-Oe
+aj
+aj
+aj
+aj
+aj
 wR
 af
 af
@@ -1128,8 +1074,8 @@ ap
 aw
 bw
 bF
-as
-Oe
+aj
+aj
 aj
 fW
 af
@@ -1142,12 +1088,12 @@ aj
 aj
 aj
 aj
-Oe
+aj
 ax
 aq
 ar
-at
-Oe
+aj
+RY
 aM
 ep
 aH
@@ -1160,12 +1106,12 @@ af
 af
 af
 af
-Oe
+ey
 ay
 Oe
-Oe
-Oe
-Oe
+OL
+zw
+dy
 br
 ep
 er
@@ -1178,13 +1124,13 @@ af
 af
 af
 af
-ey
+aj
 az
 bx
 bH
-fM
 aj
-aE
+aj
+aj
 aj
 aj
 aR
@@ -1197,11 +1143,11 @@ ey
 ey
 aj
 aj
-aA
 aj
-fw
-eS
+yi
 aj
+aj
+Gk
 fV
 aF
 aI
@@ -1216,10 +1162,10 @@ aC
 aW
 aj
 bg
+gY
+JT
 aj
-aj
-aj
-aj
+km
 aN
 aj
 aj
@@ -1236,7 +1182,7 @@ aj
 bl
 fY
 ai
-aj
+aU
 be
 aD
 aG
@@ -1253,8 +1199,8 @@ am
 au
 bm
 by
-ak
-aU
+bm
+mU
 aL
 bP
 bX
@@ -1270,9 +1216,9 @@ ah
 an
 aj
 bt
-bz
+gY
 bI
-bL
+aj
 bO
 bQ
 bk
@@ -1289,9 +1235,9 @@ aB
 aj
 ek
 bA
+vB
 aj
-aj
-aj
+np
 aO
 aj
 aj
@@ -1305,11 +1251,11 @@ ey
 ey
 aj
 aj
-gb
-bl
-ft
-fB
 aj
+yi
+aj
+aj
+NM
 aS
 bZ
 bo
@@ -1323,12 +1269,12 @@ af
 af
 af
 aj
-aj
+mD
 bB
+Ur
 aj
 aj
 aj
-aT
 aj
 aj
 aR
@@ -1345,7 +1291,7 @@ eE
 bC
 bJ
 bM
-aj
+dU
 aV
 ep
 aH
@@ -1360,11 +1306,11 @@ aj
 aj
 aj
 bu
-bD
 aj
+wf
 aj
-aj
-aP
+OD
+aV
 ep
 er
 af
@@ -1378,9 +1324,9 @@ eA
 ao
 av
 bv
-bE
+aj
 bK
-bN
+aj
 aj
 aj
 fW

--- a/code/__DEFINES/exports.dm
+++ b/code/__DEFINES/exports.dm
@@ -1,0 +1,4 @@
+#define EXPORT_CARGO 1
+#define EXPORT_EMAG 2
+#define EXPORT_CONTRABAND 4
+#define EXPORT_PIRATE 8

--- a/code/game/machinery/computer/communications.dm
+++ b/code/game/machinery/computer/communications.dm
@@ -234,8 +234,9 @@
 					currmsg.answered = answer
 					log_game("[key_name(usr)] answered [currmsg.title] comm message. Answer : [currmsg.answered]")
 					if(currmsg)
-						currmsg.answer_callback.Invoke()
+						currmsg.answer_callback.InvokeAsync()
 				state = STATE_VIEWMESSAGE
+				updateDialog()
 		if("status")
 			state = STATE_STATUSDISPLAY
 		if("securitylevel")
@@ -371,7 +372,7 @@
 					aicurrmsg.answered = answer
 					log_game("[key_name(usr)] answered [aicurrmsg.title] comm message. Answer : [aicurrmsg.answered]")
 					if(aicurrmsg.answer_callback)
-						aicurrmsg.answer_callback.Invoke()
+						aicurrmsg.answer_callback.InvokeAsync()
 				aistate = STATE_VIEWMESSAGE
 		if("ai-status")
 			aistate = STATE_STATUSDISPLAY

--- a/code/game/machinery/computer/communications.dm
+++ b/code/game/machinery/computer/communications.dm
@@ -229,13 +229,13 @@
 			var/answer = text2num(href_list["answer"])
 			if(!currmsg || !answer || currmsg.possible_answers.len < answer)
 				state = STATE_MESSAGELIST
-			currmsg.answered = answer
-			log_game("[key_name(usr)] answered [currmsg.title] comm message. Answer : [currmsg.answered]")
-			if(currmsg)
-				currmsg.answer_callback.Invoke()
-
-			state = STATE_VIEWMESSAGE
-			updateDialog()
+			else
+				if(!currmsg.answered)
+					currmsg.answered = answer
+					log_game("[key_name(usr)] answered [currmsg.title] comm message. Answer : [currmsg.answered]")
+					if(currmsg)
+						currmsg.answer_callback.Invoke()
+				state = STATE_VIEWMESSAGE
 		if("status")
 			state = STATE_STATUSDISPLAY
 		if("securitylevel")
@@ -366,11 +366,13 @@
 			var/answer = text2num(href_list["answer"])
 			if(!aicurrmsg || !answer || aicurrmsg.possible_answers.len < answer)
 				aistate = STATE_MESSAGELIST
-			aicurrmsg.answered = answer
-			log_game("[key_name(usr)] answered [aicurrmsg.title] comm message. Answer : [aicurrmsg.answered]")
-			if(aicurrmsg.answer_callback)
-				aicurrmsg.answer_callback.Invoke()
-			aistate = STATE_VIEWMESSAGE
+			else
+				if(!aicurrmsg.answered)
+					aicurrmsg.answered = answer
+					log_game("[key_name(usr)] answered [aicurrmsg.title] comm message. Answer : [aicurrmsg.answered]")
+					if(aicurrmsg.answer_callback)
+						aicurrmsg.answer_callback.Invoke()
+				aistate = STATE_VIEWMESSAGE
 		if("ai-status")
 			aistate = STATE_STATUSDISPLAY
 		if("ai-announce")

--- a/code/game/machinery/computer/communications.dm
+++ b/code/game/machinery/computer/communications.dm
@@ -235,6 +235,7 @@
 				currmsg.answer_callback.Invoke()
 
 			state = STATE_VIEWMESSAGE
+			updateDialog()
 		if("status")
 			state = STATE_STATUSDISPLAY
 		if("securitylevel")

--- a/code/modules/antagonists/pirate/pirate.dm
+++ b/code/modules/antagonists/pirate/pirate.dm
@@ -45,27 +45,26 @@
 /datum/team/pirate/proc/forge_objectives()
 	var/datum/objective/loot/getbooty = new()
 	getbooty.team = src
-	getbooty.storage_area = locate(/area/shuttle/pirate) in GLOB.sortedAreas
+	for(var/obj/machinery/computer/piratepad_control/P in GLOB.machines)
+		var/area/A = get_area(P)
+		if(istype(A,/area/shuttle/pirate))
+			getbooty.cargo_hold = P
+			break
 	getbooty.update_explanation_text()
-	getbooty.link_cargo_hold()
 	objectives += getbooty
 	for(var/datum/mind/M in members)
 		M.objectives |= objectives
 
 
 /datum/objective/loot
-	var/area/storage_area //Place where we we will look for the loot.
 	var/obj/machinery/computer/piratepad_control/cargo_hold
 	explanation_text = "Acquire valuable loot and store it in designated area."
 	var/target_value = 50000
 
 
-/datum/objective/loot/proc/link_cargo_hold()
-	if(!cargo_hold)
-		cargo_hold = locate() in storage_area.contents
-
 /datum/objective/loot/update_explanation_text()
-	if(storage_area)
+	if(cargo_hold)
+		var/area/storage_area = get_area(cargo_hold)
 		explanation_text = "Acquire loot and store [target_value] of credits worth in [storage_area.name] cargo hold."
 
 /datum/objective/loot/proc/loot_listing()

--- a/code/modules/antagonists/pirate/pirate.dm
+++ b/code/modules/antagonists/pirate/pirate.dm
@@ -46,64 +46,43 @@
 	var/datum/objective/loot/getbooty = new()
 	getbooty.team = src
 	getbooty.storage_area = locate(/area/shuttle/pirate/vault) in GLOB.sortedAreas
-	getbooty.update_initial_value()
 	getbooty.update_explanation_text()
+	getbooty.link_cargo_hold()
 	objectives += getbooty
 	for(var/datum/mind/M in members)
 		M.objectives |= objectives
 
 
-GLOBAL_LIST_INIT(pirate_loot_cache, typecacheof(list(
-	/obj/structure/reagent_dispensers/beerkeg,
-	/mob/living/simple_animal/parrot,
-	/obj/item/stack/sheet/mineral/gold,
-	/obj/item/stack/sheet/mineral/diamond,
-	/obj/item/stack/spacecash,
-	/obj/item/melee/sabre,)))
-
 /datum/objective/loot
 	var/area/storage_area //Place where we we will look for the loot.
+	var/obj/machinery/computer/piratepad_control/cargo_hold
 	explanation_text = "Acquire valuable loot and store it in designated area."
 	var/target_value = 50000
-	var/initial_value = 0 //Things in the vault at spawn time do not count
+
+
+/datum/objective/loot/proc/link_cargo_hold()
+	if(!cargo_hold)
+		cargo_hold = locate() in storage_area.contents
 
 /datum/objective/loot/update_explanation_text()
 	if(storage_area)
-		explanation_text = "Acquire loot and store [target_value] of credits worth in [storage_area.name]."
+		explanation_text = "Acquire loot and store [target_value] of credits worth in [storage_area.name] cargo hold."
 
 /datum/objective/loot/proc/loot_listing()
 	//Lists notable loot.
-	if(!storage_area)
+	if(!cargo_hold || !cargo_hold.total_report)
 		return "Nothing"
-	var/list/loot_table = list()
-	for(var/atom/movable/AM in storage_area.GetAllContents())
-		if(is_type_in_typecache(AM,GLOB.pirate_loot_cache))
-			var/lootname = AM.name
-			var/count = 1
-			if(istype(AM,/obj/item/stack)) //Ugh.
-				var/obj/item/stack/S = AM
-				lootname = S.singular_name
-				count = S.amount
-			if(!loot_table[lootname])
-				loot_table[lootname] = count
-			else
-				loot_table[lootname] += count
+	cargo_hold.total_report.total_value = sortTim(cargo_hold.total_report.total_value, cmp = /proc/cmp_numeric_dsc, associative = TRUE)
+	var/count = 0
 	var/list/loot_texts = list()
-	for(var/key in loot_table)
-		var/amount = loot_table[key]
-		loot_texts += "[amount] [key][amount > 1 ? "s":""]"
+	for(var/datum/export/E in cargo_hold.total_report.total_value)
+		if(++count > 5)
+			break
+		loot_texts += E.total_printout(cargo_hold.total_report,notes = FALSE)
 	return loot_texts.Join(", ")
 
 /datum/objective/loot/proc/get_loot_value()
-	if(!storage_area)
-		return 0
-	var/value = 0
-	for(var/turf/T in storage_area.contents)
-		value += export_item_and_contents(T,TRUE, TRUE, dry_run = TRUE)
-	return value - initial_value
-
-/datum/objective/loot/proc/update_initial_value()
-	initial_value = get_loot_value()
+	return cargo_hold.points
 
 /datum/objective/loot/check_completion()
 	return ..() || get_loot_value() >= target_value

--- a/code/modules/antagonists/pirate/pirate.dm
+++ b/code/modules/antagonists/pirate/pirate.dm
@@ -45,7 +45,7 @@
 /datum/team/pirate/proc/forge_objectives()
 	var/datum/objective/loot/getbooty = new()
 	getbooty.team = src
-	getbooty.storage_area = locate(/area/shuttle/pirate/vault) in GLOB.sortedAreas
+	getbooty.storage_area = locate(/area/shuttle/pirate) in GLOB.sortedAreas
 	getbooty.update_explanation_text()
 	getbooty.link_cargo_hold()
 	objectives += getbooty

--- a/code/modules/cargo/console.dm
+++ b/code/modules/cargo/console.dm
@@ -28,6 +28,13 @@
 	else
 		obj_flags &= ~EMAGGED
 
+/obj/machinery/computer/cargo/proc/get_export_categories()
+	var/cat = EXPORT_CARGO
+	if(contraband)
+		cat |= EXPORT_CONTRABAND
+	if(obj_flags & EMAGGED)
+		cat |= EXPORT_EMAG
+
 /obj/machinery/computer/cargo/emag_act(mob/user)
 	if(obj_flags & EMAGGED)
 		return
@@ -115,11 +122,7 @@
 				say(blockade_warning)
 				return
 			if(SSshuttle.supply.getDockedId() == "supply_home")
-				if (obj_flags & EMAGGED)
-					SSshuttle.supply.obj_flags |= EMAGGED
-				else
-					SSshuttle.supply.obj_flags = (SSshuttle.supply.obj_flags & ~EMAGGED)
-				SSshuttle.supply.contraband = contraband
+				SSshuttle.supply.export_categories = get_export_categories()
 				SSshuttle.moveShuttle("supply", "supply_away", TRUE)
 				say("The supply shuttle is departing.")
 				investigate_log("[key_name(usr)] sent the supply shuttle away.", INVESTIGATE_CARGO)

--- a/code/modules/cargo/export_scanner.dm
+++ b/code/modules/cargo/export_scanner.dm
@@ -31,7 +31,12 @@
 	else
 		// Before you fix it:
 		// yes, checking manifests is a part of intended functionality.
-		var/price = export_item_and_contents(O, cargo_console.contraband, (cargo_console.obj_flags & EMAGGED), dry_run=TRUE)
+		
+		var/datum/export_report/ex = export_item_and_contents(O, cargo_console.get_export_categories(), dry_run=TRUE)
+		var/price = 0
+		for(var/x in ex.total_amount)
+			price += ex.total_value[x]
+
 		if(price)
 			to_chat(user, "<span class='notice'>Scanned [O], value: <b>[price]</b> credits[O.contents.len ? " (contents included)" : ""].</span>")
 		else

--- a/code/modules/cargo/exports.dm
+++ b/code/modules/cargo/exports.dm
@@ -88,7 +88,7 @@ Credit dupes that require a lot of manual work shouldn't be removed, unless they
 
 // Checks the cost. 0 cost items are skipped in export.
 /datum/export/proc/get_cost(obj/O, allowed_categories = NONE, apply_elastic = TRUE)
-	var/amount = get_amount(O, allowed_categories)
+	var/amount = get_amount(O)
 	if(apply_elastic)
 		if(k_elasticity!=0)
 			return round((cost/k_elasticity) * (1 - NUM_E**(-1 * k_elasticity * amount)))	//anti-derivative of the marginal cost function

--- a/code/modules/cargo/exports.dm
+++ b/code/modules/cargo/exports.dm
@@ -127,7 +127,6 @@ Credit dupes that require a lot of manual work shouldn't be removed, unless they
 		return FALSE
 	
 	report.total_value[src] += the_cost
-	//total_cost += the_cost
 	
 	if(istype(O, /datum/export/material))
 		report.total_amount[src] += amount*MINERAL_MATERIAL_AMOUNT

--- a/code/modules/cargo/exports.dm
+++ b/code/modules/cargo/exports.dm
@@ -1,15 +1,7 @@
 /* How it works:
  The shuttle arrives at CentCom dock and calls sell(), which recursively loops through all the shuttle contents that are unanchored.
- The loop only checks contents of storage types, see supply.dm shuttle code.
-
+ 
  Each object in the loop is checked for applies_to() of various export datums, except the invalid ones.
- Objects on shutlle floor are checked only against shuttle_floor = TRUE exports.
-
- If applies_to() returns TRUE, sell_object() is called on object and checks against exports are stopped for this object.
- sell_object() must add object amount and cost to export's total_cost and total_amount.
-
- When all the shuttle objects are looped, export cycle is over. The shuttle calls total_printout() for each valid export.
- If total_printout() returns something, the export datum's total_cost is added to cargo credits, then export_end() is called to reset total_cost and total_amount.
 */
 
 /* The rule in figuring out item export cost:
@@ -26,51 +18,56 @@ Credit dupes that require a lot of manual work shouldn't be removed, unless they
 
  then the player gets the profit from selling his own wasted time.
 */
-/proc/export_item_and_contents(atom/movable/AM, contraband, emagged, dry_run=FALSE)
+
+// Simple holder datum to pass export results around
+/datum/export_report
+	var/list/exported_atoms = list()	//names of atoms sold/deleted by export
+	var/list/total_amount = list()		//export instance => total count of sold objects of its type, only exists if any were sold
+	var/list/total_value = list()		//export instance => total value of sold objects
+
+// external_report works as "transaction" object, pass same one in if you're doing more than one export in single go
+/proc/export_item_and_contents(atom/movable/AM, allowed_categories = EXPORT_CARGO, apply_elastic = TRUE, delete_unsold = TRUE, dry_run=FALSE, datum/export_report/external_report)
 	if(!GLOB.exports_list.len)
 		setupExports()
 
-	var/sold_str = ""
-	var/cost = 0
-
 	var/list/contents = AM.GetAllContents()
+	
+	var/datum/export_report/report = external_report
+	if(!report) //If we don't have any longer transaction going on
+		report = new
 
 	// We go backwards, so it'll be innermost objects sold first
 	for(var/i in reverseRange(contents))
 		var/atom/movable/thing = i
+		var/sold = FALSE
 		for(var/datum/export/E in GLOB.exports_list)
 			if(!E)
 				continue
-			if(E.applies_to(thing, contraband, emagged))
-				if(dry_run)
-					cost += E.get_cost(thing, contraband, emagged)
-				else
-					E.sell_object(thing, contraband, emagged)
-					sold_str += " [thing.name]"
+			if(E.applies_to(thing, allowed_categories, apply_elastic))
+				sold = E.sell_object(thing, report, dry_run, allowed_categories , apply_elastic)
+				report.exported_atoms += " [thing.name]"
 				break
-		if(!dry_run)
+		if(!dry_run && (sold || delete_unsold))
+			if(ismob(thing))
+				thing.investigate_log("deleted through cargo export",INVESTIGATE_CARGO)
 			qdel(thing)
 
-	if(dry_run)
-		return cost
-	else
-		return sold_str
+	return report
 
 /datum/export
 	var/unit_name = ""				// Unit name. Only used in "Received [total_amount] [name]s [message]." message
 	var/message = ""
 	var/cost = 100					// Cost of item, in cargo credits. Must not alow for infinite price dupes, see above.
 	var/k_elasticity = 1/30			//coefficient used in marginal price calculation that roughly corresponds to the inverse of price elasticity, or "quantity elasticity"
-	var/contraband = FALSE			// Export must be unlocked with multitool.
-	var/emagged = FALSE				// Export must be unlocked with emag.
 	var/list/export_types = list()	// Type of the exported object. If none, the export datum is considered base type.
 	var/include_subtypes = TRUE		// Set to FALSE to make the datum apply only to a strict type.
 	var/list/exclude_types = list()	// Types excluded from export
 
-	// Used by print-out
-	var/total_cost = 0
-	var/total_amount = 0
+	//cost includes elasticity, this does not.
 	var/init_cost
+
+	//All these need to be present in export call parameter for this to apply.
+	var/export_category = EXPORT_CARGO
 
 /datum/export/New()
 	..()
@@ -78,7 +75,6 @@ Credit dupes that require a lot of manual work shouldn't be removed, unless they
 	init_cost = cost
 	export_types = typecacheof(export_types)
 	exclude_types = typecacheof(exclude_types)
-
 
 /datum/export/Destroy()
 	SSprocessing.processing -= src
@@ -91,29 +87,30 @@ Credit dupes that require a lot of manual work shouldn't be removed, unless they
 		cost = init_cost
 
 // Checks the cost. 0 cost items are skipped in export.
-/datum/export/proc/get_cost(obj/O, contr = 0, emag = 0)
-	var/amount = get_amount(O, contr, emag)
-	if(k_elasticity!=0)
-		return round((cost/k_elasticity) * (1 - NUM_E**(-1 * k_elasticity * amount)))	//anti-derivative of the marginal cost function
+/datum/export/proc/get_cost(obj/O, allowed_categories = NONE, apply_elastic = TRUE)
+	var/amount = get_amount(O, allowed_categories)
+	if(apply_elastic)
+		if(k_elasticity!=0)
+			return round((cost/k_elasticity) * (1 - NUM_E**(-1 * k_elasticity * amount)))	//anti-derivative of the marginal cost function
+		else
+			return round(cost * amount)	//alternative form derived from L'Hopital to avoid division by 0
 	else
-		return round(cost * amount)	//alternative form derived from L'Hopital to avoid division by 0
+		return round(init_cost * amount)
 
 // Checks the amount of exportable in object. Credits in the bill, sheets in the stack, etc.
 // Usually acts as a multiplier for a cost, so item that has 0 amount will be skipped in export.
-/datum/export/proc/get_amount(obj/O, contr = 0, emag = 0)
+/datum/export/proc/get_amount(obj/O)
 	return 1
 
 // Checks if the item is fit for export datum.
-/datum/export/proc/applies_to(obj/O, contr = 0, emag = 0)
-	if(contraband && !contr)
-		return FALSE
-	if(emagged && !emag)
+/datum/export/proc/applies_to(obj/O, allowed_categories = NONE, apply_elastic = TRUE)
+	if((allowed_categories & export_category) != export_category)
 		return FALSE
 	if(!include_subtypes && !(O.type in export_types))
 		return FALSE
 	if(include_subtypes && (!is_type_in_typecache(O, export_types) || is_type_in_typecache(O, exclude_types)))
 		return FALSE
-	if(!get_cost(O, contr, emag))
+	if(!get_cost(O, allowed_categories , apply_elastic))
 		return FALSE
 	if(O.flags_1 & HOLOGRAM_1)
 		return FALSE
@@ -122,26 +119,39 @@ Credit dupes that require a lot of manual work shouldn't be removed, unless they
 // Called only once, when the object is actually sold by the datum.
 // Adds item's cost and amount to the current export cycle.
 // get_cost, get_amount and applies_to do not neccesary mean a successful sale.
-/datum/export/proc/sell_object(obj/O, contr = 0, emag = 0)
-	var/the_cost = get_cost(O)
+/datum/export/proc/sell_object(obj/O, datum/export_report/report, dry_run = TRUE, allowed_categories = EXPORT_CARGO , apply_elastic = TRUE)
+	var/the_cost = get_cost(O, allowed_categories , apply_elastic)
 	var/amount = get_amount(O)
-	total_cost += the_cost
-	if(istype(O, /datum/export/material))
-		total_amount += amount*MINERAL_MATERIAL_AMOUNT
-	else
-		total_amount += amount
 
-	cost *= NUM_E**(-1*k_elasticity*amount)		//marginal cost modifier
-	SSblackbox.record_feedback("nested tally", "export_sold_cost", 1, list("[O.type]", "[the_cost]"))
+	if(amount <=0 || the_cost <=0)
+		return FALSE
+	
+	report.total_value[src] += the_cost
+	//total_cost += the_cost
+	
+	if(istype(O, /datum/export/material))
+		report.total_amount[src] += amount*MINERAL_MATERIAL_AMOUNT
+	else
+		report.total_amount[src] += amount
+
+	if(!dry_run)
+		if(apply_elastic)
+			cost *= NUM_E**(-1*k_elasticity*amount)		//marginal cost modifier
+		SSblackbox.record_feedback("nested tally", "export_sold_cost", 1, list("[O.type]", "[the_cost]"))
+	return TRUE
 
 // Total printout for the cargo console.
 // Called before the end of current export cycle.
 // It must always return something if the datum adds or removes any credts.
-/datum/export/proc/total_printout(contr = 0, emag = 0)
-	if(!total_cost && !total_amount)
+/datum/export/proc/total_printout(datum/export_report/ex, notes = TRUE)
+	if(!ex.total_amount[src] || !ex.total_value[src])
 		return ""
-	var/msg = "[total_cost] credits: Received [total_amount] "
-	if(total_cost > 0)
+
+	var/total_value = ex.total_value[src]
+	var/total_amount = ex.total_amount[src]
+	
+	var/msg = "[total_value] credits: Received [total_amount] "
+	if(total_value > 0)
 		msg = "+" + msg
 
 	if(unit_name)
@@ -156,11 +166,6 @@ Credit dupes that require a lot of manual work shouldn't be removed, unless they
 
 	msg += "."
 	return msg
-
-// The current export cycle is over now. Reset all the export temporary vars.
-/datum/export/proc/export_end()
-	total_cost = 0
-	total_amount = 0
 
 GLOBAL_LIST_EMPTY(exports_list)
 

--- a/code/modules/cargo/exports/large_objects.dm
+++ b/code/modules/cargo/exports/large_objects.dm
@@ -5,9 +5,9 @@
 	export_types = list(/obj/structure/closet/crate)
 	exclude_types = list(/obj/structure/closet/crate/large, /obj/structure/closet/crate/wooden)
 
-/datum/export/large/crate/total_printout() // That's why a goddamn metal crate costs that much.
+/datum/export/large/crate/total_printout(datum/export_report/ex, notes = TRUE) // That's why a goddamn metal crate costs that much.
 	. = ..()
-	if(.)
+	if(. && notes)
 		. += " Thanks for participating in Nanotrasen Crates Recycling Program."
 
 /datum/export/large/crate/wooden

--- a/code/modules/cargo/exports/seeds.dm
+++ b/code/modules/cargo/exports/seeds.dm
@@ -15,9 +15,10 @@
 	return ..() * S.rarity // That's right, no bonus for potency. Send a crappy sample first to "show improvement" later.
 
 /datum/export/seed/sell_object(obj/O)
-	..()
-	var/obj/item/seeds/S = O
-	discoveredPlants[S.type] = S.potency
+	. = ..()
+	if(.)
+		var/obj/item/seeds/S = O
+		discoveredPlants[S.type] = S.potency
 
 
 /datum/export/seed/potency

--- a/code/modules/cargo/exports/sheets.dm
+++ b/code/modules/cargo/exports/sheets.dm
@@ -16,7 +16,7 @@
 
 /datum/export/stack/skin/human
 	cost = 100
-	contraband = TRUE
+	export_category = EXPORT_CONTRABAND
 	unit_name = "piece"
 	message = "of human skin"
 	export_types = list(/obj/item/stack/sheet/animalhide/human)
@@ -28,13 +28,13 @@
 
 /datum/export/stack/skin/cat
 	cost = 150
-	contraband = TRUE
+	export_category = EXPORT_CONTRABAND
 	unit_name = "cat hide"
 	export_types = list(/obj/item/stack/sheet/animalhide/cat)
 
 /datum/export/stack/skin/corgi
 	cost = 200
-	contraband = TRUE
+	export_category = EXPORT_CONTRABAND
 	unit_name = "corgi hide"
 	export_types = list(/obj/item/stack/sheet/animalhide/corgi)
 

--- a/code/modules/cargo/exports/tools.dm
+++ b/code/modules/cargo/exports/tools.dm
@@ -117,16 +117,16 @@
 	export_types = list(/obj/singularity)
 	include_subtypes = FALSE
 
-/datum/export/singulo/total_printout()
+/datum/export/singulo/total_printout(datum/export_report/ex, notes = TRUE)
 	. = ..()
-	if(.)
+	if(. && notes)
 		. += " ERROR: Invalid object detected."
 
 /datum/export/singulo/tesla //see above
 	unit_name = "energy ball"
 	export_types = list(/obj/singularity/energy_ball)
 
-/datum/export/singulo/tesla/total_printout()
+/datum/export/singulo/tesla/total_printout(datum/export_report/ex, notes = TRUE)
 	. = ..()
-	if(.)
+	if(. && notes)
 		. += " ERROR: Unscheduled energy ball delivery detected."

--- a/code/modules/events/pirates.dm
+++ b/code/modules/events/pirates.dm
@@ -1,5 +1,3 @@
-#define LOOT_LOCATOR_COOLDOWN 150
-
 /datum/round_event_control/pirates
 	name = "Space Pirates"
 	typepath = /datum/round_event/pirates
@@ -26,10 +24,9 @@
 /datum/round_event/pirates/setup()
 	ship_name = pick(strings(PIRATE_NAMES_FILE, "ship_names"))
 
-/datum/round_event/pirates/announce()
+/datum/round_event/pirates/announce(fake)
 	priority_announce("Incoming subspace communication. Secure channel opened at all communication consoles.", "Incoming Message", 'sound/ai/commandreport.ogg')
-
-	if(!control) //Means this is false alarm, todo : explicit checks instead of using announceWhen
+	if(fake)
 		return
 	threat = new
 	payoff = round(SSshuttle.points * 0.80)
@@ -227,43 +224,214 @@
 	mask_type = /obj/item/clothing/mask/breath
 	storage_type = /obj/item/tank/internals/oxygen
 
+
 /obj/machinery/loot_locator
 	name = "Booty Locator"
 	desc = "This sophisticated machine scans the nearby space for items of value."
 	icon = 'icons/obj/machines/research.dmi'
 	icon_state = "tdoppler"
 	density = TRUE
-	var/cooldown = 0
-	var/result_count = 3 //Show X results.
-
-/obj/machinery/proc/display_current_value()
-	var/area/current = get_area(src)
-	var/value = 0
-	for(var/turf/T in current.contents)
-		value += export_item_and_contents(T,TRUE, TRUE, dry_run = TRUE)
-	say("Current vault value : [value] credits.")
+	var/cooldown = 300
+	var/next_use = 0
 
 /obj/machinery/loot_locator/interact(mob/user)
-	if(world.time <= cooldown)
+	if(world.time <= next_use)
 		to_chat(user,"<span class='warning'>[src] is recharging.</span>")
 		return
-	cooldown = world.time + LOOT_LOCATOR_COOLDOWN
-	display_current_value()
-	var/list/results = list()
-	for(var/atom/movable/AM in world)
-		if(is_type_in_typecache(AM,GLOB.pirate_loot_cache))
-			if(is_station_level(AM.z))
-				if(get_area(AM) == get_area(src)) //Should this be variable ?
-					continue
-				results += AM
-		CHECK_TICK
-	if(!results.len)
+	next_use = world.time + cooldown
+	var/atom/movable/AM = find_random_loot()
+	if(!AM)
 		say("No valuables located. Try again later.")
 	else
-		for(var/i in 1 to result_count)
-			if(!results.len)
-				return
-			var/atom/movable/AM = pick_n_take(results)
-			say("Located: [AM.name] at [get_area_name(AM)]")
+		say("Located: [AM.name] at [get_area_name(AM)]")
 
-#undef LOOT_LOCATOR_COOLDOWN
+/obj/machinery/loot_locator/proc/find_random_loot()
+	if(!GLOB.exports_list.len)
+		setupExports()
+	var/list/possible_loot = list()
+	for(var/datum/export/pirate/E in GLOB.exports_list)
+		possible_loot += E
+	var/datum/export/pirate/P
+	var/atom/movable/AM
+	while(!AM && possible_loot.len)
+		P = pick_n_take(possible_loot)
+		AM = P.find_loot()
+	return AM
+
+//Pad & Pad Terminal
+/obj/machinery/piratepad
+	name = "cargo hold pad"
+	icon = 'icons/obj/telescience.dmi'
+	var/idle_state = "lpad-idle-o"
+	var/warmup_state = "lpad-idle"
+	var/sending_state = "lpad-beam"
+	icon_state = "lpad-idle-o"
+
+/obj/machinery/computer/piratepad_control
+	name = "cargo hold control terminal"
+	var/status_report = "Idle"
+	var/obj/machinery/piratepad/pad
+	var/warmup_time = 100
+	var/sending = FALSE
+	var/points = 0
+	var/datum/export_report/total_report
+	var/sending_timer
+
+/obj/machinery/computer/piratepad_control/Initialize()
+	..()
+	return INITIALIZE_HINT_LATELOAD
+
+/obj/machinery/computer/piratepad_control/LateInitialize()
+	. = ..()
+	pad = locate() in range(4,src)
+	//Todo manual linking with multitool or id linking
+
+/obj/machinery/computer/piratepad_control/ui_interact(mob/user)
+	. = ..()
+	var/list/t = list()
+	t += "<div class='statusDisplay'>Cargo Hold Control<br>"
+	t += "Current cargo value : [points]"
+	t += "</div>"
+	if(!pad)
+		t += "<div class='statusDisplay'>No pad located.</div><BR>"
+	else
+		t += "<br>[status_report]<br>"
+		if(!sending)
+			t += "<a href='?src=[REF(src)];recalc=1;'>Recalculate Value</a><a href='?src=[REF(src)];send=1'>Send</a>"
+		else
+			t += "<a href='?src=[REF(src)];stop=1'>Stop sending</a>"
+
+	var/datum/browser/popup = new(user, "piratepad", name, 300, 500)
+	popup.set_content(t.Join())
+	popup.open()
+
+/obj/machinery/computer/piratepad_control/proc/recalc()
+	if(sending)
+		return
+	status_report = "Predicted value:<br>"
+	var/datum/export_report/ex = new
+	for(var/atom/movable/AM in get_turf(pad))
+		if(AM == pad)
+			continue
+		export_item_and_contents(AM, EXPORT_PIRATE | EXPORT_CARGO | EXPORT_CONTRABAND | EXPORT_EMAG, apply_elastic = FALSE, dry_run = TRUE, external_report = ex)
+		
+	for(var/datum/export/E in ex.total_amount)
+		status_report += E.total_printout(ex,notes = FALSE) + "<br>"
+
+/obj/machinery/computer/piratepad_control/proc/send()
+	if(!sending)
+		return
+
+	var/datum/export_report/ex = new
+	
+	for(var/atom/movable/AM in get_turf(pad))
+		if(AM == pad)
+			continue
+		export_item_and_contents(AM, EXPORT_PIRATE | EXPORT_CARGO | EXPORT_CONTRABAND | EXPORT_EMAG, apply_elastic = FALSE, delete_unsold = FALSE, external_report = ex)
+	
+	status_report = "Sold:<br>"
+	var/value = 0
+	for(var/datum/export/E in ex.total_amount)
+		var/export_text = E.total_printout(ex,notes = FALSE) //Don't want nanotrasen messages, makes no sense here.
+		if(!export_text)
+			continue
+
+		status_report += export_text + "<br>"
+		value += ex.total_value[E]
+
+	if(!total_report)
+		total_report = ex
+	else
+		total_report.exported_atoms += ex.exported_atoms
+		for(var/datum/export/E in ex.total_amount)
+			total_report.total_amount[E] += ex.total_amount[E]
+			total_report.total_value[E] += ex.total_value[E]
+
+	points += value
+
+	pad.visible_message("<span class='notice'>[pad] activates!</span>")
+	flick(pad.sending_state,pad)
+	pad.icon_state = pad.idle_state
+	sending = FALSE
+	updateDialog()
+
+/obj/machinery/computer/piratepad_control/proc/start_sending()
+	if(sending)
+		return
+	sending = TRUE
+	status_report = "Sending..."
+	pad.visible_message("<span class='notice'>[pad] starts charging up.</span>")
+	pad.icon_state = pad.warmup_state
+	sending_timer = addtimer(CALLBACK(src,.proc/send),warmup_time, TIMER_STOPPABLE)
+
+/obj/machinery/computer/piratepad_control/proc/stop_sending()
+	if(!sending)
+		return
+	sending = FALSE
+	status_report = "Idle"
+	pad.icon_state = pad.idle_state
+	deltimer(sending_timer)
+
+/obj/machinery/computer/piratepad_control/Topic(href, href_list)
+	if(..())
+		return
+	if(pad)
+		if(href_list["recalc"])
+			recalc()
+		if(href_list["send"])
+			start_sending()
+		if(href_list["stop"])
+			stop_sending()
+		updateDialog()
+	else
+		updateDialog()
+
+/datum/export/pirate
+	export_category = EXPORT_PIRATE
+
+//Attempts to find the thing on station
+/datum/export/pirate/proc/find_loot()
+	return
+
+/datum/export/pirate/ransom
+	cost = 3000
+	unit_name = "hostage"
+	export_types = list(/mob/living/carbon/human)
+
+/datum/export/pirate/ransom/find_loot()
+	var/list/head_minds = SSjob.get_living_heads()
+	var/list/head_mobs = list()
+	for(var/datum/mind/M in head_minds)
+		head_mobs += M.current
+	if(head_mobs.len)
+		return pick(head_mobs)
+
+/datum/export/pirate/ransom/get_cost(atom/movable/AM)
+	var/mob/living/carbon/human/H = AM
+	if(H.stat != CONSCIOUS || !H.mind || !H.mind.assigned_role) //mint condition only
+		return 0
+	else
+		if(H.mind.assigned_role in GLOB.command_positions)
+			return 3000
+		else
+			return 1000
+
+/datum/export/pirate/parrot
+	cost = 2000
+	unit_name = "alive parrot"
+	export_types = list(/mob/living/simple_animal/parrot)
+
+/datum/export/pirate/parrot/find_loot()
+	for(var/mob/living/simple_animal/parrot/P in GLOB.alive_mob_list)
+		var/turf/T = get_turf(P)
+		if(T && is_station_level(T.z))
+			return P
+
+/datum/export/pirate/cash
+	cost = 1
+	unit_name = "bills"
+	export_types = list(/obj/item/stack/spacecash)
+
+/datum/export/pirate/cash/get_amount(obj/O)
+	var/obj/item/stack/spacecash/C = O
+	return ..() * C.amount * C.value

--- a/code/modules/events/pirates.dm
+++ b/code/modules/events/pirates.dm
@@ -262,10 +262,10 @@
 /obj/machinery/piratepad
 	name = "cargo hold pad"
 	icon = 'icons/obj/telescience.dmi'
+	icon_state = "lpad-idle-o"
 	var/idle_state = "lpad-idle-o"
 	var/warmup_state = "lpad-idle"
 	var/sending_state = "lpad-beam"
-	icon_state = "lpad-idle-o"
 	var/cargo_hold_id
 
 /obj/machinery/piratepad/multitool_act(mob/living/user, obj/item/multitool/I)
@@ -297,6 +297,7 @@
 		return TRUE
 
 /obj/machinery/computer/piratepad_control/LateInitialize()
+	. = ..()
 	if(cargo_hold_id)
 		for(var/obj/machinery/piratepad/P in GLOB.machines)
 			if(P.cargo_hold_id == cargo_hold_id)

--- a/code/modules/events/pirates.dm
+++ b/code/modules/events/pirates.dm
@@ -266,6 +266,13 @@
 	var/warmup_state = "lpad-idle"
 	var/sending_state = "lpad-beam"
 	icon_state = "lpad-idle-o"
+	var/cargo_hold_id
+
+/obj/machinery/piratepad/multitool_act(mob/living/user, obj/item/multitool/I)
+	if (istype(I))
+		to_chat(user, "<span class='notice'>You register [src] in [I]s buffer.</span>")
+		I.buffer = src
+		return TRUE
 
 /obj/machinery/computer/piratepad_control
 	name = "cargo hold control terminal"
@@ -276,15 +283,27 @@
 	var/points = 0
 	var/datum/export_report/total_report
 	var/sending_timer
+	var/cargo_hold_id
 
 /obj/machinery/computer/piratepad_control/Initialize()
 	..()
 	return INITIALIZE_HINT_LATELOAD
 
+/obj/machinery/computer/piratepad_control/multitool_act(mob/living/user, obj/item/multitool/I)
+	if (istype(I) && istype(I.buffer,/obj/machinery/piratepad))
+		to_chat(user, "<span class='notice'>You link [src] with [I.buffer] in [I] buffer.</span>")
+		pad = I.buffer
+		updateDialog()
+		return TRUE
+
 /obj/machinery/computer/piratepad_control/LateInitialize()
-	. = ..()
-	pad = locate() in range(4,src)
-	//Todo manual linking with multitool or id linking
+	if(cargo_hold_id)
+		for(var/obj/machinery/piratepad/P in GLOB.machines)
+			if(P.cargo_hold_id == cargo_hold_id)
+				pad = P
+				return
+	else
+		pad = locate() in range(4,src)
 
 /obj/machinery/computer/piratepad_control/ui_interact(mob/user)
 	. = ..()

--- a/code/modules/shuttle/supply.dm
+++ b/code/modules/shuttle/supply.dm
@@ -38,9 +38,9 @@ GLOBAL_LIST_INIT(blacklisted_cargo_types, typecacheof(list(
 	height = 7
 	movement_force = list("KNOCKDOWN" = 0, "THROW" = 0)
 
-	// When TRUE, these vars allow exporting emagged/contraband items, and add some special interactions to existing exports.
-	var/contraband = FALSE
-	var/emagged = FALSE
+
+	//Export categories for this run, this is set by console sending the shuttle.
+	var/export_categories = EXPORT_CARGO
 
 /obj/docking_port/mobile/supply/register()
 	. = ..()
@@ -117,7 +117,8 @@ GLOBAL_LIST_INIT(blacklisted_cargo_types, typecacheof(list(
 
 	var/msg = ""
 	var/matched_bounty = FALSE
-	var/sold_atoms = ""
+
+	var/datum/export_report/ex = new
 
 	for(var/place in shuttle_areas)
 		var/area/shuttle/shuttle_area = place
@@ -127,23 +128,21 @@ GLOBAL_LIST_INIT(blacklisted_cargo_types, typecacheof(list(
 			if(bounty_ship_item_and_contents(AM, dry_run = FALSE))
 				matched_bounty = TRUE
 			if(!AM.anchored || istype(AM, /obj/mecha))
-				sold_atoms += export_item_and_contents(AM, contraband, emagged, dry_run = FALSE)
+				export_item_and_contents(AM, export_categories , dry_run = FALSE, external_report = ex)
 
-	if(sold_atoms)
-		sold_atoms += "."
+	if(ex.exported_atoms)
+		ex.exported_atoms += "." //ugh
 
 	if(matched_bounty)
 		msg += "Bounty items received. An update has been sent to all bounty consoles. "
 
-	for(var/a in GLOB.exports_list)
-		var/datum/export/E = a
-		var/export_text = E.total_printout()
+	for(var/datum/export/E in ex.total_amount)
+		var/export_text = E.total_printout(ex)
 		if(!export_text)
 			continue
 
 		msg += export_text + "\n"
-		SSshuttle.points += E.total_cost
-		E.export_end()
+		SSshuttle.points += ex.total_value[E]
 
 	SSshuttle.centcom_message = msg
-	investigate_log("Shuttle contents sold for [SSshuttle.points - presale_points] credits. Contents: [sold_atoms || "none."] Message: [SSshuttle.centcom_message || "none."]", INVESTIGATE_CARGO)
+	investigate_log("Shuttle contents sold for [SSshuttle.points - presale_points] credits. Contents: [ex.exported_atoms || "none."] Message: [SSshuttle.centcom_message || "none."]", INVESTIGATE_CARGO)

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -40,6 +40,7 @@
 #include "code\__DEFINES\diseases.dm"
 #include "code\__DEFINES\DNA.dm"
 #include "code\__DEFINES\events.dm"
+#include "code\__DEFINES\exports.dm"
 #include "code\__DEFINES\flags.dm"
 #include "code\__DEFINES\food.dm"
 #include "code\__DEFINES\forensics.dm"


### PR DESCRIPTION
Pirates will now use cargo hold terminal and pad to dump their ill-gotten gains. Including hostages.

Refactors exports to be less dependant on cargo state.

Pirate shuttle remapped a bit by @WJohn.