### PR TITLE
Fixes storage component's COMSIG_TRY_STORAGE_TAKE_TYPE, and therefore, fixes bio bags not working for reproductive extracts.

### DIFF
--- a/code/datums/components/storage/storage.dm
+++ b/code/datums/components/storage/storage.dm
@@ -656,8 +656,8 @@
 			if(!user || !user.CanReach(destination) || !user.CanReach(parent))
 				return FALSE
 	var/list/taking = typecache_filter_list(contents(), typecacheof(type))
-	if(length(taking) > amount)
-		taking.Cut(amount)
+	if(taking.len > amount)
+		taking.len = amount
 	if(inserted)			//duplicated code for performance, don't bother checking retval/checking for list every item.
 		for(var/i in taking)
 			if(remove_from_storage(i, destination))


### PR DESCRIPTION
>Take 1

>Length of cubes is above 1

>Cut(1)

>Wait that just cut the entire list to nothing

Now the signal should work properly instead of not working whenever there's more of a thing than the requested amount.