### PR TITLE
Fire extinguishers no longer spray when put away with safety off

### DIFF
--- a/code/game/objects/structures/extinguisher.dm
+++ b/code/game/objects/structures/extinguisher.dm
@@ -59,6 +59,7 @@
 			stored_extinguisher = I
 			to_chat(user, "<span class='notice'>You place [I] in [src].</span>")
 			update_icon()
+			return TRUE
 		else
 			toggle_cabinet(user)
 	else if(user.a_intent != INTENT_HARM)


### PR DESCRIPTION
yet another in a long line of pointless QoL changes

:cl: Epoc
tweak: Putting an extinguisher into a cabinet with the safety off will no longer cause it to spray first
/:cl:

because it's annoying as hell, let me know if I did this wrong
