### PR TITLE
Fix getrev when TGS is present

### DIFF
--- a/code/datums/helper_datums/getrev.dm
+++ b/code/datums/helper_datums/getrev.dm
@@ -7,20 +7,25 @@
 /datum/getrev/New()
 	testmerge = world.TgsTestMerges()
 	log_world("Running /tg/ revision:")
-	var/list/logs = world.file2list(".git/logs/HEAD")
-	if(logs)
-		logs = splittext(logs[logs.len - 1], " ")
-		date = unix2date(text2num(logs[5]))
-		commit = logs[2]
-		log_world("[commit]: [date]")
+	var/datum/tgs_revision_information/revinfo = world.TgsRevision()
+	if(revinfo)
+		commit = revinfo.commit
+		originmastercommit = revinfo.origin_commit
 	else
-		log_world("Unable to read git logs, revision information not available")
-		originmastercommit = commit = "Unknown"
-		date = unix2date(world.timeofday)
-		return
-	logs = world.file2list(".git/logs/refs/remotes/origin/master")
-	if(logs.len)
-		originmastercommit = splittext(logs[logs.len - 1], " ")[2]
+		var/list/logs = world.file2list(".git/logs/HEAD")
+		if(logs)
+			logs = splittext(logs[logs.len - 1], " ")
+			date = unix2date(text2num(logs[5]))
+			commit = logs[2]
+			log_world("[commit]: [date]")
+		else
+			log_world("Unable to read git logs, revision information not available")
+			originmastercommit = commit = "Unknown"
+			date = unix2date(world.timeofday)
+			return
+		logs = world.file2list(".git/logs/refs/remotes/origin/master")
+		if(logs.len)
+			originmastercommit = splittext(logs[logs.len - 1], " ")[2]
 
 	if(testmerge.len)
 		log_world(commit)


### PR DESCRIPTION
TGS4 doesn't copy .git. This fixes the runtime by using the API to get better data