### PR TITLE
Fixes plastic reaction creating 10 sheets for all reagent amounts

### DIFF
--- a/code/modules/reagents/chemistry/recipes/others.dm
+++ b/code/modules/reagents/chemistry/recipes/others.dm
@@ -584,7 +584,7 @@
 
 /datum/chemical_reaction/plastic_polymers/on_reaction(datum/reagents/holder, created_volume)
 	var/location = get_turf(holder.my_atom)
-	for(var/i in 1 to 10)
+	for(var/i in 1 to created_volume)
 		new /obj/item/stack/sheet/plastic(location)
 
 /datum/chemical_reaction/pax


### PR DESCRIPTION
[Changelogs]: # (Your PR should contain a detailed changelog of notable changes, titled and categorized appropriately. This includes, new features, sprites, sounds, balance changes, admin tools, map edits, removals, big refactors, config changes, hosting changes and important fixes. An example changelog has been provided below for you to edit. If you need additional help, read https://github.com/tgstation/tgstation/wiki/Changelogs)

:cl: Frosty Fridge
fix: Plastic creation reaction now properly scales with the amount of reagents; 10u = 1 sheet.
/:cl:

[why]: # (Please add a short description [two lines down] of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.)

Fixes #38292