### PR TITLE
Removes cyborg hypospray reagent toggle pop-up window

### DIFF
--- a/code/modules/reagents/reagent_containers/borghydro.dm
+++ b/code/modules/reagents/reagent_containers/borghydro.dm
@@ -114,12 +114,11 @@ Borg Hypospray
 	log_combat(user, M, "injected", src, "(CHEMICALS: [english_list(injected)])")
 
 /obj/item/reagent_containers/borghypo/attack_self(mob/user)
-	var/chosen_reagent = modes[input(user, "What reagent do you want to dispense?") as null|anything in reagent_ids]
-	if(!chosen_reagent)
-		return
-	mode = chosen_reagent
+	mode++
+	if (mode > modes.len)
+		mode = 1
 	playsound(loc, 'sound/effects/pop.ogg', 50, 0)
-	var/datum/reagent/R = GLOB.chemical_reagents_list[reagent_ids[mode]]
+	var/datum/reagent/R = GLOB.chemical_reagents_list[modes[mode]]
 	to_chat(user, "<span class='notice'>[src] is now dispensing '[R.name]'.</span>")
 	return
 


### PR DESCRIPTION
Replaces the awkward cyborg hypospray switch pop-up window to a simple toggle that'll circle through the reagents on each attack_self()

![image](https://user-images.githubusercontent.com/701959/44305886-04571480-a35a-11e8-9793-740f9aae0df2.png)

