### PR TITLE
Adds ore silo examine message, adds it to runtimestation

### DIFF
--- a/_maps/map_files/debug/runtimestation.dmm
+++ b/_maps/map_files/debug/runtimestation.dmm
@@ -39,15 +39,6 @@
 "ak" = (
 /turf/closed/wall/r_wall,
 /area/engine/gravity_generator)
-"al" = (
-/obj/machinery/airalarm/unlocked{
-	pixel_y = 23
-	},
-/obj/structure/closet/secure_closet/atmospherics{
-	locked = 0
-	},
-/turf/open/floor/plating,
-/area/engine/atmos)
 "am" = (
 /obj/machinery/atmospherics/components/unary/tank/air,
 /turf/open/floor/plating,
@@ -257,10 +248,6 @@
 	dir = 4
 	},
 /area/engine/gravity_generator)
-"aM" = (
-/obj/machinery/suit_storage_unit/ce,
-/turf/open/floor/plating,
-/area/engine/atmos)
 "aN" = (
 /obj/machinery/atmospherics/components/unary/portables_connector/visible{
 	dir = 4
@@ -374,12 +361,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/engine/gravity_generator)
-"aZ" = (
-/obj/structure/tank_dispenser{
-	pixel_x = -1
-	},
-/turf/open/floor/plating,
-/area/engine/atmos)
 "ba" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on,
 /turf/open/floor/plating,
@@ -438,24 +419,12 @@
 	dir = 8
 	},
 /area/engine/gravity_generator)
-"bj" = (
-/obj/machinery/power/apc{
-	dir = 8;
-	pixel_x = -24
-	},
-/obj/structure/cable{
-	icon_state = "0-2"
-	},
-/obj/machinery/light,
-/obj/structure/table,
-/obj/item/analyzer,
-/obj/item/wrench,
-/turf/open/floor/plasteel,
-/area/engine/atmos)
 "bk" = (
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	dir = 8
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/structure/cable{
+	icon_state = "1-2"
 	},
+/obj/machinery/door/airlock,
 /turf/open/floor/plating,
 /area/engine/atmos)
 "bl" = (
@@ -469,13 +438,6 @@
 /obj/machinery/atmospherics/components/binary/valve/on{
 	dir = 4
 	},
-/turf/open/floor/plating,
-/area/engine/atmos)
-"bn" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 9
-	},
-/obj/machinery/light,
 /turf/open/floor/plating,
 /area/engine/atmos)
 "bo" = (
@@ -507,16 +469,22 @@
 /turf/open/floor/plasteel,
 /area/engine/gravity_generator)
 "bs" = (
+/obj/machinery/airalarm/unlocked{
+	pixel_y = 23
+	},
+/obj/machinery/rnd/destructive_analyzer,
+/turf/open/floor/plasteel,
+/area/science)
+"bt" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/turf/closed/wall/r_wall,
-/area/hallway/primary/central)
-"bt" = (
-/obj/machinery/door/airlock,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/structure/cable{
+	icon_state = "2-4"
+	},
 /turf/open/floor/plasteel,
-/area/engine/atmos)
+/area/science)
 "bu" = (
 /turf/closed/wall/r_wall,
 /area/bridge)
@@ -543,18 +511,7 @@
 /turf/closed/wall/r_wall,
 /area/science)
 "bB" = (
-/obj/machinery/power/apc{
-	dir = 8;
-	pixel_x = -24
-	},
-/obj/structure/cable,
-/obj/structure/cable{
-	icon_state = "0-2"
-	},
-/obj/machinery/airalarm/unlocked{
-	pixel_y = 23
-	},
-/obj/machinery/autolathe/hacked,
+/obj/machinery/mecha_part_fabricator,
 /turf/open/floor/plasteel,
 /area/science)
 "bC" = (
@@ -564,10 +521,6 @@
 /turf/open/floor/plasteel,
 /area/security/brig)
 "bD" = (
-/obj/machinery/light{
-	dir = 1
-	},
-/obj/machinery/mecha_part_fabricator,
 /turf/open/floor/plasteel,
 /area/science)
 "bE" = (
@@ -729,19 +682,14 @@
 /turf/open/floor/plating,
 /area/hallway/primary/central)
 "ca" = (
-/obj/structure/cable{
-	icon_state = "1-4"
-	},
-/obj/structure/cable{
-	icon_state = "2-4"
-	},
+/obj/machinery/autolathe/hacked,
 /turf/open/floor/plasteel,
 /area/science)
 "cb" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
 /turf/open/floor/plasteel,
 /area/science)
 "cc" = (
@@ -825,15 +773,11 @@
 "cm" = (
 /turf/open/floor/plasteel,
 /area/medical/medbay)
-"cn" = (
-/obj/machinery/door/airlock,
-/turf/open/floor/plating,
-/area/medical/medbay)
 "co" = (
 /obj/machinery/light{
 	dir = 4
 	},
-/obj/structure/closet/syndicate/resources/everything,
+/obj/machinery/ore_silo,
 /turf/open/floor/plasteel,
 /area/science)
 "cp" = (
@@ -1104,9 +1048,7 @@
 /turf/open/floor/plasteel,
 /area/security/brig)
 "dg" = (
-/obj/machinery/airalarm/unlocked{
-	pixel_x = 32
-	},
+/obj/machinery/airalarm/directional/east,
 /turf/open/floor/plasteel,
 /area/security/brig)
 "dh" = (
@@ -2069,11 +2011,7 @@
 "fI" = (
 /obj/machinery/door/airlock,
 /turf/open/floor/plating,
-/area/hallway/secondary/entry)
-"fJ" = (
-/obj/machinery/door/airlock,
-/turf/open/floor/plating,
-/area/hallway/secondary/exit/departure_lounge)
+/area/maintenance/aft)
 "fK" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -2164,6 +2102,9 @@
 /area/hallway/secondary/exit/departure_lounge)
 "fT" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
 /turf/open/floor/plasteel,
 /area/science)
 "fU" = (
@@ -2502,6 +2443,9 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 8
 	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
 /turf/open/floor/plasteel,
 /area/science)
 "hD" = (
@@ -2516,22 +2460,28 @@
 /area/medical/chemistry)
 "jb" = (
 /obj/machinery/door/airlock,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
 /turf/open/floor/plasteel,
 /area/science)
+"jE" = (
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/engine/atmos)
 "jU" = (
 /obj/structure/table,
 /obj/item/melee/transforming/energy/axe,
 /turf/open/floor/plasteel,
 /area/storage/primary)
 "kn" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
 /obj/machinery/light{
 	dir = 1
 	},
 /obj/structure/cable{
-	icon_state = "1-4"
+	icon_state = "2-4"
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
@@ -2545,6 +2495,9 @@
 /obj/machinery/power/apc{
 	dir = 1;
 	pixel_y = 25
+	},
+/obj/structure/cable{
+	icon_state = "0-4"
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
@@ -2568,6 +2521,10 @@
 /obj/item/storage/toolbox/syndicate,
 /turf/open/floor/plasteel,
 /area/storage/primary)
+"ou" = (
+/obj/machinery/airalarm/directional/west,
+/turf/open/floor/plating,
+/area/engine/atmos)
 "oV" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -2592,6 +2549,10 @@
 	},
 /turf/open/floor/plasteel,
 /area/medical/chemistry)
+"qb" = (
+/obj/machinery/door/airlock,
+/turf/open/floor/plating,
+/area/engine/atmos)
 "qn" = (
 /obj/structure/cable{
 	icon_state = "0-2"
@@ -2603,6 +2564,21 @@
 /obj/structure/cable,
 /turf/open/floor/plating/airless,
 /area/space/nearstation)
+"ut" = (
+/obj/structure/closet/secure_closet/atmospherics{
+	locked = 0
+	},
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/engine/atmos)
+"vf" = (
+/turf/open/floor/plasteel,
+/area/space)
+"vm" = (
+/turf/closed/wall/r_wall,
+/area/maintenance/aft)
 "vv" = (
 /obj/machinery/door/airlock,
 /turf/open/floor/plating,
@@ -2634,11 +2610,17 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
+"zo" = (
+/obj/machinery/power/apc/auto_name/south,
+/obj/structure/cable{
+	icon_state = "0-8"
+	},
+/turf/open/floor/plasteel,
+/area/engine/atmos)
 "AP" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
 	dir = 8
 	},
-/obj/machinery/rnd/production/techfab/department,
 /turf/open/floor/plasteel,
 /area/science)
 "Bl" = (
@@ -2669,7 +2651,7 @@
 /turf/open/floor/plasteel,
 /area/medical/chemistry)
 "Ct" = (
-/obj/machinery/rnd/production/circuit_imprinter/department,
+/obj/structure/closet/syndicate/resources/everything,
 /turf/open/floor/plasteel,
 /area/science)
 "CV" = (
@@ -2685,18 +2667,18 @@
 	},
 /turf/open/floor/plasteel/blue/side,
 /area/bridge)
-"If" = (
-/obj/structure/cable{
-	icon_state = "1-2"
+"ES" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
 	},
-/obj/machinery/rnd/destructive_analyzer,
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
 /turf/open/floor/plasteel,
-/area/science)
-"In" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/closed/wall/r_wall,
+/area/hallway/primary/central)
+"If" = (
+/obj/machinery/rnd/production/techfab/department,
+/turf/open/floor/plasteel,
 /area/science)
 "Iy" = (
 /obj/structure/closet/secure_closet/RD{
@@ -2710,12 +2692,30 @@
 	},
 /turf/open/floor/plasteel,
 /area/medical/chemistry)
+"Kx" = (
+/obj/structure/table,
+/obj/item/analyzer,
+/obj/item/wrench,
+/obj/machinery/light,
+/turf/open/floor/plating,
+/area/engine/atmos)
 "Ly" = (
 /obj/machinery/chem_dispenser/chem_synthesizer,
 /turf/open/floor/plasteel/dark,
 /area/medical/chemistry)
+"MY" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/structure/cable{
+	icon_state = "2-4"
+	},
+/turf/open/floor/plasteel,
+/area/engine/atmos)
 "NZ" = (
 /obj/machinery/rnd/production/protolathe/department,
+/turf/open/floor/plasteel,
+/area/science)
+"OU" = (
+/obj/item/disk/tech_disk/debug,
 /turf/open/floor/plasteel,
 /area/science)
 "PI" = (
@@ -2729,6 +2729,10 @@
 /obj/machinery/door/airlock/external/glass,
 /turf/open/floor/plating,
 /area/medical/medbay)
+"Rb" = (
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
+/area/maintenance/aft)
 "RC" = (
 /obj/machinery/power/rtg/advanced,
 /obj/structure/cable{
@@ -2736,17 +2740,13 @@
 	},
 /turf/open/floor/plating/airless,
 /area/space/nearstation)
-"RY" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/item/disk/tech_disk/debug,
-/turf/open/floor/plasteel,
-/area/science)
 "Sj" = (
 /obj/structure/table/optable,
 /turf/open/floor/plasteel/arrival,
 /area/medical/medbay)
+"Tt" = (
+/turf/open/floor/plating,
+/area/maintenance/aft)
 "Ut" = (
 /obj/structure/closet/secure_closet/medical3{
 	locked = 0
@@ -2771,6 +2771,10 @@
 /obj/structure/fans/tiny,
 /turf/open/floor/plasteel,
 /area/engine/engineering)
+"Wh" = (
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
+/area/engine/atmos)
 "WT" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -2787,6 +2791,50 @@
 	},
 /turf/open/floor/plasteel,
 /area/medical/chemistry)
+"Xp" = (
+/obj/machinery/light,
+/obj/structure/tank_dispenser{
+	pixel_x = -1
+	},
+/turf/open/floor/plasteel,
+/area/engine/atmos)
+"XC" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
+/turf/open/floor/plasteel,
+/area/science)
+"XR" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 9
+	},
+/turf/open/floor/plating,
+/area/engine/atmos)
+"XU" = (
+/obj/machinery/atmospherics/components/unary/tank/air,
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/engine/atmos)
+"Yy" = (
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/machinery/rnd/production/circuit_imprinter/department,
+/obj/machinery/power/apc/auto_name/north,
+/obj/structure/cable{
+	icon_state = "0-8"
+	},
+/turf/open/floor/plasteel,
+/area/science)
+"ZD" = (
+/obj/machinery/suit_storage_unit/ce,
+/turf/open/floor/plasteel,
+/area/engine/atmos)
 
 (1,1,1) = {"
 aa
@@ -6021,10 +6069,9 @@ aa
 aa
 aa
 aa
-ad
-dH
 ah
 ah
+qb
 ah
 ah
 ah
@@ -6033,6 +6080,7 @@ ah
 bA
 bA
 bA
+gd
 bA
 bZ
 ft
@@ -6113,19 +6161,19 @@ aa
 aa
 aa
 aa
-ad
-af
 ah
-al
+ut
 aw
-aM
-aZ
-bj
+ou
+aw
+aw
+Kx
+ah
 bs
 bB
 ca
 If
-In
+bA
 kn
 fu
 bO
@@ -6143,8 +6191,8 @@ dy
 dm
 dK
 cN
-af
-ad
+Tt
+vm
 fg
 aa
 aa
@@ -6205,13 +6253,13 @@ aa
 aa
 aa
 aa
-ad
-af
 ah
 am
 ax
 aw
 ba
+jE
+MY
 bk
 bt
 fT
@@ -6235,8 +6283,8 @@ dn
 dn
 dL
 cN
-af
-ad
+Tt
+vm
 fg
 aa
 aa
@@ -6297,20 +6345,20 @@ aa
 aa
 aa
 aa
-ad
-af
 ah
 dS
 ay
 aN
 bb
 bl
+zo
 ah
+Yy
 bD
-cc
+XC
 gY
 jb
-cA
+ES
 bE
 bE
 cQ
@@ -6327,8 +6375,8 @@ dn
 dn
 dL
 cN
-af
-ad
+Tt
+vm
 fg
 aa
 aa
@@ -6389,16 +6437,16 @@ aa
 aa
 aa
 aa
-ad
-af
 ah
 am
 ay
 aO
 bc
 bm
+ZD
 ah
 bF
+OU
 cc
 Ct
 gd
@@ -6419,8 +6467,8 @@ dn
 dn
 dL
 cN
-af
-ad
+Tt
+vm
 fg
 aa
 aa
@@ -6481,22 +6529,22 @@ aa
 aa
 aa
 aa
-ad
-af
 ah
-am
+XU
 az
 aP
 aP
-bn
+XR
+Xp
 ah
 NZ
-RY
+bD
+cc
 co
 bA
 wS
 bE
-bE
+vf
 cN
 dW
 dn
@@ -6511,8 +6559,8 @@ dn
 dn
 dL
 cN
-af
-ad
+Tt
+vm
 fg
 aa
 aa
@@ -6573,11 +6621,11 @@ aa
 aa
 aa
 aa
-ad
-bY
+ah
+Wh
 ah
 ah
-ah
+Wh
 ah
 ah
 ah
@@ -6603,8 +6651,8 @@ dn
 dn
 dL
 cN
-af
-ad
+Tt
+vm
 fg
 aa
 aa
@@ -6695,8 +6743,8 @@ dn
 dn
 dZ
 cN
-af
-bY
+Tt
+Rb
 fg
 aa
 aa
@@ -6787,8 +6835,8 @@ dn
 dn
 dL
 cN
-af
-bY
+Tt
+Rb
 fg
 aa
 aa
@@ -6879,8 +6927,8 @@ dn
 dn
 dL
 cN
-af
-bY
+Tt
+Rb
 fg
 aa
 aa
@@ -6971,8 +7019,8 @@ dn
 dn
 dL
 cN
-af
-bY
+Tt
+Rb
 fg
 aa
 aa
@@ -7063,8 +7111,8 @@ dn
 dn
 dL
 cN
-af
-bY
+Tt
+Rb
 fg
 aa
 aa
@@ -7155,8 +7203,8 @@ dz
 do
 dM
 cN
-af
-bY
+Tt
+Rb
 fg
 aa
 aa
@@ -7247,7 +7295,7 @@ cS
 cS
 cS
 cS
-fJ
+fI
 ga
 ga
 ga
@@ -8515,7 +8563,7 @@ ak
 ak
 by
 by
-cn
+dH
 by
 Qt
 by

--- a/code/modules/mining/machine_silo.dm
+++ b/code/modules/mining/machine_silo.dm
@@ -180,6 +180,10 @@ GLOBAL_LIST_EMPTY(silo_access_logs)
 	updateUsrDialog()
 	flick("silo_active", src)
 
+/obj/machinery/ore_silo/examine(mob/user)
+	..()
+	to_chat(user, "<span class='notice'>[src] can be linked to techfabs, circuit printers and protolathes with a multitool.</span>")
+
 /datum/ore_silo_log
 	var/name  // for VV
 	var/formatted  // for display


### PR DESCRIPTION
I added an examine message to the ore silo: `[src] can be linked to techfabs, circuit printers and protolathes with a multitool.`

Also added it to runtimestation, which required me to expand the area a little.