### PR TITLE
Handle shuttle registration from inside the template

### DIFF
--- a/code/datums/shuttles.dm
+++ b/code/datums/shuttles.dm
@@ -21,7 +21,7 @@
 	mappath = "[prefix][shuttle_id].dmm"
 	. = ..()
 
-/datum/map_template/shuttle/load(turf/T, centered)
+/datum/map_template/shuttle/load(turf/T, centered, register=TRUE)
 	. = ..()
 	if(!.)
 		return
@@ -34,6 +34,10 @@
 		if(length(place.baseturfs) < 2) // Some snowflake shuttle shit
 			continue
 		place.baseturfs.Insert(3, /turf/baseturf_skipover/shuttle)
+
+		if(register)
+			for(var/obj/docking_port/mobile/port in place)
+				port.register()
 
 		for(var/obj/structure/closet/closet in place)
 			if(closet.anchorable)

--- a/code/modules/events/pirates.dm
+++ b/code/modules/events/pirates.dm
@@ -81,8 +81,6 @@
 				candidates -= M
 			else
 				notify_ghosts("Space pirates are waking up!", source = spawner, action=NOTIFY_ATTACK, flashwindow = FALSE)
-		for(var/obj/docking_port/mobile/port in A)
-			port.register()
 
 	priority_announce("Unidentified armed ship detected near the station.")
 

--- a/code/modules/shuttle/manipulator.dm
+++ b/code/modules/shuttle/manipulator.dm
@@ -215,8 +215,7 @@
 		D = existing_shuttle.get_docked()
 
 	if(!D)
-		var/m = "No dock found for preview shuttle ([preview_template.name]), aborting."
-		throw EXCEPTION(m)
+		CRASH("No dock found for preview shuttle ([preview_template.name]), aborting.")
 
 	var/result = preview_shuttle.canDock(D)
 	// truthy value means that it cannot dock for some reason
@@ -254,7 +253,7 @@
 	. = FALSE
 	// load shuttle template, centred at shuttle import landmark,
 	var/turf/landmark_turf = get_turf(locate(/obj/effect/landmark/shuttle_import) in GLOB.landmarks_list)
-	S.load(landmark_turf, centered = TRUE)
+	S.load(landmark_turf, centered = TRUE, register = FALSE)
 
 	var/affected = S.get_affected_turfs(landmark_turf, centered=TRUE)
 


### PR DESCRIPTION
:cl: ninjanomnom
fix: Shuttle templates now handle shuttle registration in the load rather than the shuttle manipulator. This means admin loaded shuttle templates no longer need to be manually registered.
/:cl:
