### PR TITLE
Reverts "Hovering over storage slots with an item in your hand will show you first if you can put the item in

### DIFF
--- a/code/_onclick/hud/screen_objects.dm
+++ b/code/_onclick/hud/screen_objects.dm
@@ -102,7 +102,6 @@
 	var/slot_id	// The indentifier for the slot. It has nothing to do with ID cards.
 	var/icon_empty // Icon when empty. For now used only by humans.
 	var/icon_full  // Icon when contains an item. For now used only by humans.
-	var/list/object_overlays = list()
 	layer = HUD_LAYER
 	plane = HUD_PLANE
 
@@ -126,14 +125,6 @@
 		usr.update_inv_hands()
 	return 1
 
-/obj/screen/inventory/MouseEntered()
-	..()
-	add_overlays()
-
-/obj/screen/inventory/MouseExited()
-	..()
-	cut_overlay(object_overlays)
-
 /obj/screen/inventory/update_icon()
 	if(!icon_empty)
 		icon_empty = icon_state
@@ -143,30 +134,6 @@
 			icon_state = icon_full
 		else
 			icon_state = icon_empty
-
-/obj/screen/inventory/proc/add_overlays()
-	var/mob/user = hud.mymob
-
-	cut_overlay(object_overlays)
-	object_overlays.Cut()
-
-	if(hud && user && slot_id)
-		var/obj/item/holding = user.get_active_held_item()
-
-		if(!holding || user.get_item_by_slot(slot_id))
-			return
-
-		var/image/item_overlay = image(holding)
-		item_overlay.alpha = 191
-		object_overlays += item_overlay
-		
-		if(!user.can_equip(holding, slot_id, disable_warning = TRUE))
-			var/image/nope_overlay = image('icons/mob/screen_gen.dmi', "x")
-			nope_overlay.alpha = 128
-			nope_overlay.layer = item_overlay.layer + 1
-			object_overlays += nope_overlay
-
-		add_overlay(object_overlays)
 
 /obj/screen/inventory/hand
 	var/mutable_appearance/handcuff_overlay

--- a/code/datums/components/storage/storage.dm
+++ b/code/datums/components/storage/storage.dm
@@ -552,7 +552,7 @@
 	if(real_location == I.loc)
 		return FALSE //Means the item is already in the storage item
 	if(locked)
-		if(M && !stop_messages)
+		if(M)
 			host.add_fingerprint(M)
 			to_chat(M, "<span class='warning'>[host] seems to be locked!</span>")
 		return FALSE


### PR DESCRIPTION
:cl: BeeSting12
del: Hovering over storage slots no longer gives an overlay.
/:cl:

Why:
1. There's so much of a delay, it's not useful.
2. The system only benefits new players in the first couple hours of the game. Extra feedback is good, but this is unnecessary and completely useless to anyone who's played the game more than a few hours.
3. Everything this system can do is already done by clicking to put the object in the wrong spot and then getting the "you are unable to equip this" message. 