### PR TITLE
Massively lowers the alpha of the phantom screen object for equipping

### DIFF
--- a/code/_onclick/hud/screen_objects.dm
+++ b/code/_onclick/hud/screen_objects.dm
@@ -157,7 +157,7 @@
 			return
 
 		var/image/item_overlay = image(holding)
-		item_overlay.alpha = 191
+		item_overlay.alpha = 92
 		object_overlays += item_overlay
 		
 		if(!user.can_equip(holding, slot_id, disable_warning = TRUE))


### PR DESCRIPTION
Should fix some of the confusion

closes #39819