### PR TITLE
Makes the hover overlays toggleable

### DIFF
--- a/code/_onclick/hud/screen_objects.dm
+++ b/code/_onclick/hud/screen_objects.dm
@@ -150,7 +150,7 @@
 	cut_overlay(object_overlays)
 	object_overlays.Cut()
 
-	if(hud && user && slot_id)
+	if(hud && user && slot_id && usr.client.prefs.hover_storage)
 		var/obj/item/holding = user.get_active_held_item()
 
 		if(!holding || user.get_item_by_slot(slot_id))

--- a/code/modules/client/preferences_savefile.dm
+++ b/code/modules/client/preferences_savefile.dm
@@ -5,7 +5,7 @@
 //	You do not need to raise this if you are adding new values that have sane defaults.
 //	Only raise this value when changing the meaning/format/name/layout of an existing value
 //	where you would want the updater procs below to run
-#define SAVEFILE_VERSION_MAX	20
+#define SAVEFILE_VERSION_MAX	21
 
 /*
 SAVEFILE UPDATING/VERSIONING - 'Simplified', or rather, more coder-friendly ~Carn
@@ -103,6 +103,7 @@ SAVEFILE UPDATING/VERSIONING - 'Simplified', or rather, more coder-friendly ~Car
 	S["tip_delay"]			>> tip_delay
 	S["pda_style"]			>> pda_style
 	S["pda_color"]			>> pda_color
+	S["hover_storage"]		>> hover_storage
 
 	//try to fix any outdated data if necessary
 	if(needs_update >= 0)
@@ -175,7 +176,8 @@ SAVEFILE UPDATING/VERSIONING - 'Simplified', or rather, more coder-friendly ~Car
 	WRITE_FILE(S["tip_delay"], tip_delay)
 	WRITE_FILE(S["pda_style"], pda_style)
 	WRITE_FILE(S["pda_color"], pda_color)
-
+	WRITE_FILE(S["hover_storage"], hover_storage)
+	
 	return 1
 
 /datum/preferences/proc/load_character(slot)

--- a/code/modules/client/preferences_toggles.dm
+++ b/code/modules/client/preferences_toggles.dm
@@ -339,6 +339,14 @@ GLOBAL_LIST_INIT(ghost_orbits, list(GHOST_ORBIT_CIRCLE,GHOST_ORBIT_TRIANGLE,GHOS
 	prefs.save_preferences()
 	SSblackbox.record_feedback("nested tally", "preferences_verb", 1, list("Toggle Intent Selection", "[prefs.toggles & INTENT_STYLE ? "Enabled" : "Disabled"]")) //If you are copy-pasting this, ensure the 2nd parameter is unique to the new proc!
 
+/client/verb/toggle_hover_storage()
+	set name = "Toggle Hover Storage Overlay"
+	set category = "Preferences"
+	set desc = "Toggle the overlay in your inventory showing if you can equip an item there."
+	prefs.hover_storage = !prefs.hover_storage
+	prefs.save_preferences()
+	to_chat(usr, "<span class='danger'>Overlays showing if you can equip an item [prefs.hover_storage ? "en" : "dis"]abled.</span>")
+	
 /client/verb/toggle_ghost_hud_pref()
 	set name = "Toggle Ghost HUD"
 	set category = "Preferences"


### PR DESCRIPTION
Closes #39819 

:cl: BeeSting12
tweak: Storage overlays that tell you if you can put an item somewhere are now a preference.
/:cl:

See #39819 for why.

Not sure if I did this properly.
