### PR TITLE
Makes the inventory helper overlay less impactful

### DIFF
--- a/code/_onclick/hud/screen_objects.dm
+++ b/code/_onclick/hud/screen_objects.dm
@@ -133,6 +133,7 @@
 /obj/screen/inventory/MouseExited()
 	..()
 	cut_overlay(object_overlays)
+	object_overlays.Cut()
 
 /obj/screen/inventory/update_icon()
 	if(!icon_empty)
@@ -147,9 +148,6 @@
 /obj/screen/inventory/proc/add_overlays()
 	var/mob/user = hud.mymob
 
-	cut_overlay(object_overlays)
-	object_overlays.Cut()
-
 	if(hud && user && slot_id)
 		var/obj/item/holding = user.get_active_held_item()
 
@@ -157,15 +155,14 @@
 			return
 
 		var/image/item_overlay = image(holding)
-		item_overlay.alpha = 191
-		object_overlays += item_overlay
+		item_overlay.alpha = 92
 		
 		if(!user.can_equip(holding, slot_id, disable_warning = TRUE))
-			var/image/nope_overlay = image('icons/mob/screen_gen.dmi', "x")
-			nope_overlay.alpha = 128
-			nope_overlay.layer = item_overlay.layer + 1
-			object_overlays += nope_overlay
+			item_overlay.color = "#FF0000"
+		else
+			item_overlay.color = "#00ff00"
 
+		object_overlays += item_overlay
 		add_overlay(object_overlays)
 
 /obj/screen/inventory/hand


### PR DESCRIPTION
Reduces alpha and has a traffic light system for the items

-> red ghost when the item can't be placed
-> green ghost when it can
-> full solid colour item, object is in the inventory

This is so you can differentiate the ghost view from the actual object entering the
slot, which was sticky's primary complaint

Incorporates and therefore closes #39821

I moved the cut of overlays only to mouse out, since if that somehow isn't called we have bigger problems than overlays doubling up. INB4 this causes server crashes.

Side bonus it removes one image operation, it's worth investigating a cache for this as well I would say, a simple rotating buffer list of the last x many images.

Tested and ready to go

:cl: oranges
tweak: Inventory overlay now uses a traffic light to indicate if the item can be placed in there
/:cl: