### PR TITLE
Slash SSatmos init time by 93%

### DIFF
--- a/code/controllers/subsystem/air.dm
+++ b/code/controllers/subsystem/air.dm
@@ -288,9 +288,12 @@ SUBSYSTEM_DEF(air)
 	var/list/active_turfs = src.active_turfs
 	var/times_fired = ++src.times_fired
 
+	// Clear active turfs - faster than removing every single turf in the world
+	// one-by-one, and Initalize_Atmos only ever adds `src` back in.
+	active_turfs.Cut()
+
 	for(var/thing in turfs_to_init)
 		var/turf/T = thing
-		active_turfs -= T
 		if (T.blocks_air)
 			continue
 		T.Initalize_Atmos(times_fired)


### PR DESCRIPTION
:cl:
code: Atmospherics now initializes 93% (about 40 seconds) faster.
/:cl:

On BoxStation with default configs, takes SSatmos init from 46.3 seconds to 3.5 seconds.

According to profiling, and confirmed in a test project, `setup_allturfs` spends almost all of its time on the `active_turfs -= T` line, slowly and painfully removing every turf in the world from `active_turfs` one by one. Instead, let's just clear it outright.

No ill effects observed, but someone who knows atmos code better should double-check this.


