### PR TITLE
tweaks borg ion thrusters  to not be noob bait

### DIFF
--- a/code/modules/mob/living/silicon/robot/robot.dm
+++ b/code/modules/mob/living/silicon/robot/robot.dm
@@ -285,12 +285,12 @@
 	if(!ionpulse_on)
 		return
 
-	if(cell.charge <= 50)
+	if(cell.charge <= 10)
 		toggle_ionpulse()
 		return
 
-	cell.charge -= 50 // 500 steps on a default cell.
-	return 1
+	cell.charge -= 10
+	return TRUE
 
 /mob/living/silicon/robot/proc/toggle_ionpulse()
 	if(!ionpulse)


### PR DESCRIPTION
:cl:
balance: Cyborg ion thrusters consume 1/5 of their previous power.
/:cl:

shooting bullets as syndiborg is 100 times cheaper than using the thrusters
