### PR TITLE
Adds confessional intercoms to Delta/Pubby, cleans up dvars and wrong freqs/settings

### DIFF
--- a/_maps/map_files/BoxStation/BoxStation.dmm
+++ b/_maps/map_files/BoxStation/BoxStation.dmm
@@ -4159,8 +4159,7 @@
 "ajO" = (
 /obj/structure/table/wood,
 /obj/item/radio/intercom{
-	dir = 8;
-	
+	dir = 8
 	},
 /turf/open/floor/plasteel/neutral/side{
 	dir = 1

--- a/_maps/map_files/BoxStation/BoxStation.dmm
+++ b/_maps/map_files/BoxStation/BoxStation.dmm
@@ -15667,7 +15667,7 @@
 "aNX" = (
 /obj/item/radio/intercom{
 	broadcasting = 1;
-	frequency = 1480;
+	frequency = 1481;
 	name = "Confessional Intercom";
 	pixel_x = 25
 	},
@@ -16575,7 +16575,7 @@
 "aQz" = (
 /obj/item/radio/intercom{
 	broadcasting = 1;
-	frequency = 1480;
+	frequency = 1481;
 	name = "Confessional Intercom";
 	pixel_x = 25
 	},

--- a/_maps/map_files/BoxStation/BoxStation.dmm
+++ b/_maps/map_files/BoxStation/BoxStation.dmm
@@ -698,7 +698,6 @@
 	},
 /obj/item/radio/intercom{
 	dir = 4;
-	name = "Station Intercom (General)";
 	pixel_x = -31
 	},
 /obj/structure/table/wood,
@@ -2172,9 +2171,6 @@
 /area/security/main)
 "afd" = (
 /obj/item/radio/intercom{
-	freerange = 0;
-	frequency = 1459;
-	name = "Station Intercom (General)";
 	pixel_x = 29
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -2339,7 +2335,6 @@
 "afB" = (
 /obj/item/radio/intercom{
 	dir = 4;
-	name = "Station Intercom (General)";
 	pixel_x = 27
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -3053,9 +3048,6 @@
 /area/security/brig)
 "ahs" = (
 /obj/item/radio/intercom{
-	freerange = 0;
-	frequency = 1459;
-	name = "Station Intercom (General)";
 	pixel_y = 24
 	},
 /obj/structure/table/glass,
@@ -3581,7 +3573,6 @@
 /area/security/main)
 "ait" = (
 /obj/item/radio/intercom{
-	name = "Station Intercom (General)";
 	pixel_y = -29
 	},
 /obj/machinery/computer/security{
@@ -3920,9 +3911,6 @@
 /area/security/courtroom)
 "ajj" = (
 /obj/item/radio/intercom{
-	broadcasting = 0;
-	listening = 1;
-	name = "Station Intercom (General)";
 	pixel_y = 20
 	},
 /obj/machinery/camera{
@@ -4171,10 +4159,8 @@
 "ajO" = (
 /obj/structure/table/wood,
 /obj/item/radio/intercom{
-	broadcasting = 0;
 	dir = 8;
-	listening = 1;
-	name = "Station Intercom (Court)"
+	
 	},
 /turf/open/floor/plasteel/neutral/side{
 	dir = 1
@@ -6007,7 +5993,6 @@
 /area/hallway/primary/fore)
 "aoA" = (
 /obj/item/radio/intercom{
-	name = "Station Intercom (General)";
 	pixel_y = -29
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -8593,9 +8578,6 @@
 	},
 /obj/item/multitool,
 /obj/item/radio/intercom{
-	freerange = 0;
-	frequency = 1459;
-	name = "Station Intercom (General)";
 	pixel_x = 29
 	},
 /turf/open/floor/plasteel/floorgrime,
@@ -9975,7 +9957,6 @@
 	dir = 5
 	},
 /obj/item/radio/intercom{
-	name = "Station Intercom (General)";
 	pixel_y = -29
 	},
 /turf/open/floor/plasteel/neutral/side{
@@ -10104,7 +10085,6 @@
 /area/hallway/secondary/entry)
 "azC" = (
 /obj/item/radio/intercom{
-	name = "Station Intercom (General)";
 	pixel_y = -29
 	},
 /obj/effect/turf_decal/stripes/line,
@@ -10320,7 +10300,6 @@
 /area/crew_quarters/dorms)
 "aAg" = (
 /obj/item/radio/intercom{
-	name = "Station Intercom (General)";
 	pixel_y = -29
 	},
 /turf/open/floor/plasteel/neutral/side,
@@ -11479,8 +11458,6 @@
 	dir = 1
 	},
 /obj/item/radio/intercom{
-	broadcasting = 0;
-	name = "Station Intercom (General)";
 	pixel_y = 20
 	},
 /turf/open/floor/plasteel/red/side{
@@ -11568,8 +11545,6 @@
 /obj/item/assembly/signaler,
 /obj/item/assembly/signaler,
 /obj/item/radio/intercom{
-	broadcasting = 0;
-	name = "Station Intercom (General)";
 	pixel_y = 20
 	},
 /obj/item/multitool,
@@ -12578,9 +12553,6 @@
 /area/gateway)
 "aFX" = (
 /obj/item/radio/intercom{
-	freerange = 0;
-	frequency = 1459;
-	name = "Station Intercom (General)";
 	pixel_x = -30
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -13802,9 +13774,6 @@
 /obj/structure/table/glass,
 /obj/item/plant_analyzer,
 /obj/item/radio/intercom{
-	freerange = 0;
-	frequency = 1459;
-	name = "Station Intercom (General)";
 	pixel_x = 29
 	},
 /obj/machinery/light_switch{
@@ -16175,7 +16144,6 @@
 	},
 /obj/item/radio/intercom{
 	dir = 8;
-	name = "Station Intercom (General)";
 	pixel_x = -28
 	},
 /turf/open/floor/plasteel/red/side{
@@ -16209,8 +16177,6 @@
 /area/hallway/secondary/entry)
 "aPv" = (
 /obj/item/radio/intercom{
-	broadcasting = 0;
-	name = "Station Intercom (General)";
 	pixel_y = 20
 	},
 /obj/effect/turf_decal/stripes/line{
@@ -17135,7 +17101,6 @@
 "aSh" = (
 /obj/structure/closet/wardrobe/mixed,
 /obj/item/radio/intercom{
-	name = "Station Intercom (General)";
 	pixel_x = -27
 	},
 /turf/open/floor/plasteel,
@@ -19481,7 +19446,6 @@
 /area/bridge)
 "aYr" = (
 /obj/item/radio/intercom{
-	name = "Station Intercom (General)";
 	pixel_y = -29
 	},
 /turf/open/floor/plasteel/blue/side,
@@ -20321,7 +20285,6 @@
 /area/bridge/meeting_room)
 "baJ" = (
 /obj/item/radio/intercom{
-	name = "Station Intercom (General)";
 	pixel_y = -29
 	},
 /turf/open/floor/wood,
@@ -21870,7 +21833,6 @@
 /area/hallway/secondary/entry)
 "beN" = (
 /obj/item/radio/intercom{
-	name = "Station Intercom (General)";
 	pixel_y = -29
 	},
 /obj/structure/chair{
@@ -22306,7 +22268,6 @@
 /area/hallway/primary/starboard)
 "bfY" = (
 /obj/item/radio/intercom{
-	name = "Station Intercom (General)";
 	pixel_y = -29
 	},
 /turf/open/floor/plasteel/purple/side{
@@ -23135,9 +23096,6 @@
 	dir = 8
 	},
 /obj/item/radio/intercom{
-	freerange = 0;
-	frequency = 1459;
-	name = "Station Intercom (General)";
 	pixel_x = 29
 	},
 /turf/open/floor/plasteel/white,
@@ -23659,9 +23617,6 @@
 /obj/structure/table,
 /obj/machinery/cell_charger,
 /obj/item/radio/intercom{
-	broadcasting = 0;
-	listening = 1;
-	name = "Station Intercom (General)";
 	pixel_y = 20
 	},
 /turf/open/floor/plasteel,
@@ -23700,9 +23655,6 @@
 "bju" = (
 /obj/machinery/photocopier,
 /obj/item/radio/intercom{
-	broadcasting = 0;
-	listening = 1;
-	name = "Station Intercom (General)";
 	pixel_y = 20
 	},
 /turf/open/floor/plasteel,
@@ -24393,7 +24345,6 @@
 /obj/item/clothing/glasses/science,
 /obj/item/radio/intercom{
 	dir = 8;
-	name = "Station Intercom (General)";
 	pixel_x = -28
 	},
 /turf/open/floor/plasteel/white,
@@ -24642,9 +24593,6 @@
 /obj/item/healthanalyzer,
 /obj/item/healthanalyzer,
 /obj/item/radio/intercom{
-	freerange = 0;
-	frequency = 1459;
-	name = "Station Intercom (General)";
 	pixel_x = 29
 	},
 /turf/open/floor/plasteel,
@@ -25084,7 +25032,6 @@
 "bmJ" = (
 /obj/item/radio/intercom{
 	broadcasting = 1;
-	freerange = 0;
 	frequency = 1485;
 	listening = 0;
 	name = "Station Intercom (Medbay)";
@@ -26660,7 +26607,6 @@
 	},
 /obj/item/pen/blue,
 /obj/item/radio/intercom{
-	name = "Station Intercom (General)";
 	pixel_y = -35
 	},
 /turf/open/floor/plasteel,
@@ -27360,9 +27306,6 @@
 /area/teleporter)
 "bsl" = (
 /obj/item/radio/intercom{
-	broadcasting = 0;
-	listening = 1;
-	name = "Station Intercom (General)";
 	pixel_y = 20
 	},
 /obj/structure/closet/crate,
@@ -27410,10 +27353,8 @@
 	dir = 4
 	},
 /obj/item/radio/intercom{
-	broadcasting = 0;
 	freerange = 0;
 	frequency = 1485;
-	listening = 1;
 	name = "Station Intercom (Medbay)";
 	pixel_y = -30
 	},
@@ -27441,10 +27382,7 @@
 /area/medical/medbay/central)
 "bst" = (
 /obj/item/radio/intercom{
-	broadcasting = 0;
-	freerange = 0;
 	frequency = 1485;
-	listening = 1;
 	name = "Station Intercom (Medbay)";
 	pixel_x = 30
 	},
@@ -28059,7 +27997,6 @@
 "bub" = (
 /obj/machinery/light,
 /obj/item/radio/intercom{
-	name = "Station Intercom (General)";
 	pixel_y = -35
 	},
 /obj/effect/turf_decal/loading_area{
@@ -28964,7 +28901,6 @@
 "bwi" = (
 /obj/item/radio/intercom{
 	dir = 8;
-	name = "Station Intercom (General)";
 	pixel_x = -28
 	},
 /obj/structure/closet/secure_closet/hop,
@@ -30011,7 +29947,6 @@
 "byM" = (
 /obj/item/radio/intercom{
 	dir = 4;
-	name = "Station Intercom (General)";
 	pixel_x = 27
 	},
 /obj/machinery/computer/security/mining{
@@ -30254,7 +30189,6 @@
 /area/medical/genetics)
 "bzr" = (
 /obj/item/radio/intercom{
-	name = "Station Intercom (General)";
 	pixel_y = -29
 	},
 /obj/machinery/vending/wardrobe/gene_wardrobe,
@@ -30894,7 +30828,6 @@
 	dir = 4
 	},
 /obj/item/radio/intercom{
-	name = "Station Intercom (General)";
 	pixel_y = -35
 	},
 /obj/machinery/status_display{
@@ -31450,7 +31383,6 @@
 	network = list("ss13","rd")
 	},
 /obj/item/radio/intercom{
-	name = "Station Intercom (General)";
 	pixel_y = -29
 	},
 /turf/open/floor/plasteel/cafeteria,
@@ -31765,10 +31697,7 @@
 /area/medical/sleeper)
 "bCU" = (
 /obj/item/radio/intercom{
-	broadcasting = 0;
-	freerange = 0;
 	frequency = 1485;
-	listening = 1;
 	name = "Station Intercom (Medbay)";
 	pixel_x = -30
 	},
@@ -33546,7 +33475,6 @@
 	},
 /obj/item/radio/intercom{
 	dir = 4;
-	name = "Station Intercom (General)";
 	pixel_x = 27
 	},
 /obj/effect/turf_decal/stripes/line{
@@ -36048,7 +35976,6 @@
 "bNH" = (
 /obj/structure/table/reinforced,
 /obj/item/radio/intercom{
-	name = "Station Intercom (General)";
 	pixel_y = -26
 	},
 /obj/item/paper_bin{
@@ -36099,9 +36026,6 @@
 	dir = 6
 	},
 /obj/item/radio/intercom{
-	freerange = 0;
-	frequency = 1459;
-	name = "Station Intercom (General)";
 	pixel_x = -30
 	},
 /turf/open/floor/plasteel,
@@ -36859,7 +36783,6 @@
 "bPG" = (
 /obj/machinery/chem_master,
 /obj/item/radio/intercom{
-	name = "Station Intercom (General)";
 	pixel_y = -29
 	},
 /obj/machinery/light,
@@ -37120,7 +37043,6 @@
 	},
 /obj/item/radio/intercom{
 	dir = 4;
-	name = "Station Intercom (General)";
 	pixel_x = 27
 	},
 /obj/machinery/light{
@@ -38889,8 +38811,6 @@
 /area/hallway/primary/aft)
 "bVg" = (
 /obj/item/radio/intercom{
-	broadcasting = 0;
-	name = "Station Intercom (General)";
 	pixel_y = 20
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -39476,9 +39396,6 @@
 /area/security/checkpoint/engineering)
 "bWR" = (
 /obj/item/radio/intercom{
-	freerange = 0;
-	frequency = 1459;
-	name = "Station Intercom (General)";
 	pixel_x = -30
 	},
 /turf/open/floor/plasteel,
@@ -44120,7 +44037,6 @@
 	},
 /obj/item/radio/intercom{
 	dir = 4;
-	name = "Station Intercom (General)";
 	pixel_x = 27
 	},
 /obj/structure/cable{
@@ -44772,7 +44688,6 @@
 /area/maintenance/disposal/incinerator)
 "clg" = (
 /obj/item/radio/intercom{
-	name = "Station Intercom (General)";
 	pixel_y = -29
 	},
 /obj/structure/table,
@@ -46284,7 +46199,6 @@
 "cpT" = (
 /obj/structure/table,
 /obj/item/radio/intercom{
-	name = "Station Intercom (General)";
 	pixel_y = -35
 	},
 /obj/item/stock_parts/cell/high/plus,
@@ -47300,7 +47214,6 @@
 /area/ai_monitored/turret_protected/aisat_interior)
 "cth" = (
 /obj/item/radio/intercom{
-	name = "Station Intercom (General)";
 	pixel_y = -29
 	},
 /obj/machinery/light/small,
@@ -47623,7 +47536,6 @@
 /area/ai_monitored/turret_protected/aisat_interior)
 "cub" = (
 /obj/item/radio/intercom{
-	name = "Station Intercom (General)";
 	pixel_y = -29
 	},
 /obj/machinery/light/small,
@@ -47850,7 +47762,6 @@
 	dir = 4
 	},
 /obj/item/radio/intercom{
-	name = "Station Intercom (General)";
 	pixel_x = 28
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
@@ -47931,7 +47842,6 @@
 	dir = 8
 	},
 /obj/item/radio/intercom{
-	name = "Station Intercom (General)";
 	pixel_x = -28
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -48310,16 +48220,13 @@
 	pixel_y = 28
 	},
 /obj/item/radio/intercom{
-	broadcasting = 0;
 	freerange = 1;
-	listening = 1;
 	name = "Common Channel";
 	pixel_x = -27;
 	pixel_y = 5
 	},
 /obj/item/radio/intercom{
 	anyai = 1;
-	broadcasting = 0;
 	freerange = 1;
 	frequency = 1447;
 	name = "Private Channel";
@@ -48349,16 +48256,13 @@
 	pixel_y = 28
 	},
 /obj/item/radio/intercom{
-	broadcasting = 0;
 	freerange = 1;
-	listening = 1;
 	name = "Common Channel";
 	pixel_x = 27;
 	pixel_y = 5
 	},
 /obj/item/radio/intercom{
 	anyai = 1;
-	broadcasting = 0;
 	freerange = 1;
 	frequency = 1447;
 	name = "Private Channel";
@@ -49616,9 +49520,7 @@
 "cAS" = (
 /obj/effect/landmark/start/ai,
 /obj/item/radio/intercom{
-	broadcasting = 0;
 	freerange = 1;
-	listening = 1;
 	name = "Common Channel";
 	pixel_x = -27;
 	pixel_y = -9
@@ -49632,7 +49534,6 @@
 	},
 /obj/item/radio/intercom{
 	anyai = 1;
-	broadcasting = 0;
 	freerange = 1;
 	frequency = 1447;
 	name = "Private Channel";
@@ -49950,7 +49851,6 @@
 /area/engine/atmos)
 "cBK" = (
 /obj/item/radio/intercom{
-	name = "Station Intercom (General)";
 	pixel_y = -35
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
@@ -51999,8 +51899,6 @@
 "cSM" = (
 /obj/machinery/computer/station_alert,
 /obj/item/radio/intercom{
-	broadcasting = 0;
-	name = "Station Intercom (General)";
 	pixel_y = 20
 	},
 /turf/open/floor/plasteel/vault,
@@ -52490,9 +52388,6 @@
 	},
 /obj/structure/table/reinforced,
 /obj/item/radio/intercom{
-	freerange = 0;
-	frequency = 1459;
-	name = "Station Intercom (General)";
 	pixel_x = 29
 	},
 /turf/open/floor/plasteel/white,
@@ -53329,9 +53224,7 @@
 	pixel_y = -3
 	},
 /obj/item/radio/intercom{
-	freerange = 0;
 	frequency = 1485;
-	listening = 1;
 	name = "Station Intercom (Medbay)";
 	pixel_x = 30
 	},

--- a/_maps/map_files/Deltastation/DeltaStation2.dmm
+++ b/_maps/map_files/Deltastation/DeltaStation2.dmm
@@ -98105,6 +98105,12 @@
 /obj/machinery/newscaster{
 	pixel_y = -32
 	},
+/obj/item/radio/intercom{
+	broadcasting = 1;
+	frequency = 1480;
+	name = "Confessional Intercom";
+	pixel_x = -26
+	},
 /turf/open/floor/plasteel/vault{
 	dir = 5
 	},
@@ -98116,6 +98122,12 @@
 /obj/machinery/light/small,
 /obj/machinery/newscaster{
 	pixel_y = 32
+	},
+/obj/item/radio/intercom{
+	broadcasting = 1;
+	frequency = 1480;
+	name = "Confessional Intercom";
+	pixel_y = -26
 	},
 /turf/open/floor/plasteel/vault{
 	dir = 5

--- a/_maps/map_files/Deltastation/DeltaStation2.dmm
+++ b/_maps/map_files/Deltastation/DeltaStation2.dmm
@@ -424,7 +424,6 @@
 /area/maintenance/solars/starboard/fore)
 "acv" = (
 /obj/item/radio/intercom{
-	name = "Station Intercom";
 	pixel_y = 26
 	},
 /obj/machinery/camera{
@@ -957,7 +956,6 @@
 /obj/item/stock_parts/cell/high,
 /obj/effect/decal/cleanable/dirt,
 /obj/item/radio/intercom{
-	name = "Station Intercom";
 	pixel_y = 26
 	},
 /turf/open/floor/plasteel/yellow/side{
@@ -2040,7 +2038,6 @@
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on,
 /obj/item/radio/intercom{
-	name = "Station Intercom";
 	pixel_y = 26
 	},
 /turf/open/floor/plasteel/arrival{
@@ -2137,7 +2134,6 @@
 	dir = 4
 	},
 /obj/item/radio/intercom{
-	name = "Station Intercom";
 	pixel_y = 26
 	},
 /turf/open/floor/plasteel/arrival{
@@ -3951,7 +3947,6 @@
 	dir = 8
 	},
 /obj/item/radio/intercom{
-	name = "Station Intercom";
 	pixel_x = -26
 	},
 /obj/machinery/camera{
@@ -4074,7 +4069,6 @@
 	dir = 4
 	},
 /obj/item/radio/intercom{
-	name = "Station Intercom";
 	pixel_x = 26
 	},
 /turf/open/floor/plasteel/red,
@@ -5626,7 +5620,6 @@
 "arP" = (
 /obj/machinery/vending/snack/random,
 /obj/item/radio/intercom{
-	name = "Station Intercom";
 	pixel_y = 26
 	},
 /obj/effect/turf_decal/bot,
@@ -7354,7 +7347,6 @@
 "ave" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/item/radio/intercom{
-	name = "Station Intercom";
 	pixel_y = -26
 	},
 /obj/effect/turf_decal/stripes/line,
@@ -8108,7 +8100,6 @@
 "awN" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/item/radio/intercom{
-	name = "Station Intercom";
 	pixel_y = 26
 	},
 /turf/open/floor/plasteel/neutral/side{
@@ -8253,7 +8244,6 @@
 /obj/structure/table/reinforced,
 /obj/item/storage/box/lights/mixed,
 /obj/item/radio/intercom{
-	name = "Station Intercom";
 	pixel_y = 26
 	},
 /turf/open/floor/plasteel/brown{
@@ -9141,7 +9131,6 @@
 /obj/item/mop,
 /obj/item/mop,
 /obj/item/radio/intercom{
-	name = "Station Intercom";
 	pixel_y = -26
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -11672,7 +11661,6 @@
 /obj/structure/table/wood,
 /obj/structure/reagent_dispensers/beerkeg,
 /obj/item/radio/intercom{
-	name = "Station Intercom";
 	pixel_y = 26
 	},
 /turf/open/floor/plasteel/vault{
@@ -11799,7 +11787,6 @@
 	},
 /obj/item/storage/fancy/cigarettes/cigars/havana,
 /obj/item/radio/intercom{
-	name = "Station Intercom";
 	pixel_y = 26
 	},
 /turf/open/floor/plasteel/vault{
@@ -11961,7 +11948,6 @@
 /area/engine/atmospherics_engine)
 "aFv" = (
 /obj/item/radio/intercom{
-	name = "Station Intercom";
 	pixel_x = -28;
 	pixel_y = -28
 	},
@@ -12457,7 +12443,6 @@
 	dir = 1
 	},
 /obj/item/radio/intercom{
-	name = "Station Intercom";
 	pixel_y = 26
 	},
 /turf/open/floor/plasteel/red/side{
@@ -12709,7 +12694,6 @@
 /area/security/prison)
 "aGM" = (
 /obj/item/radio/intercom{
-	name = "Station Intercom";
 	pixel_y = 26
 	},
 /obj/effect/decal/cleanable/dirt,
@@ -14518,7 +14502,6 @@
 "aKB" = (
 /obj/structure/chair/stool/bar,
 /obj/item/radio/intercom{
-	name = "Station Intercom";
 	pixel_x = 26
 	},
 /turf/open/floor/plasteel/redyellow,
@@ -14954,7 +14937,6 @@
 	icon_state = "0-8"
 	},
 /obj/item/radio/intercom{
-	name = "Station Intercom";
 	pixel_y = -24
 	},
 /turf/open/floor/plasteel/vault,
@@ -15706,7 +15688,6 @@
 "aNk" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/item/radio/intercom{
-	name = "Station Intercom";
 	pixel_x = 26
 	},
 /turf/open/floor/plasteel/neutral/corner{
@@ -15782,7 +15763,6 @@
 	},
 /obj/structure/disposalpipe/segment,
 /obj/item/radio/intercom{
-	name = "Station Intercom";
 	pixel_x = -26
 	},
 /obj/effect/turf_decal/stripes/corner{
@@ -16114,7 +16094,6 @@
 /area/engine/atmos)
 "aOd" = (
 /obj/item/radio/intercom{
-	name = "Station Intercom";
 	pixel_y = 26
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
@@ -16313,7 +16292,6 @@
 	pixel_y = 5
 	},
 /obj/item/radio/intercom{
-	name = "Station Intercom";
 	pixel_y = 26
 	},
 /obj/item/toy/figure/clown,
@@ -18224,7 +18202,6 @@
 	},
 /obj/item/radio/intercom{
 	dir = 8;
-	name = "Station Intercom (General)";
 	pixel_x = 28
 	},
 /turf/open/floor/plasteel/brown{
@@ -20239,7 +20216,6 @@
 	},
 /obj/item/flashlight/lamp,
 /obj/item/radio/intercom{
-	name = "Station Intercom";
 	pixel_x = -26
 	},
 /turf/open/floor/plasteel/darkred/side{
@@ -20612,7 +20588,6 @@
 /area/crew_quarters/bar/atrium)
 "aXb" = (
 /obj/item/radio/intercom{
-	name = "Station Intercom";
 	pixel_x = -26;
 	pixel_y = -26
 	},
@@ -20873,7 +20848,6 @@
 	dir = 4
 	},
 /obj/item/radio/intercom{
-	name = "Station Intercom";
 	pixel_x = -26
 	},
 /obj/effect/turf_decal/stripes/line{
@@ -22249,7 +22223,6 @@
 /area/hydroponics)
 "baw" = (
 /obj/item/radio/intercom{
-	name = "Station Intercom";
 	pixel_x = -26
 	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
@@ -22411,7 +22384,6 @@
 	},
 /obj/item/radio/intercom{
 	dir = 8;
-	name = "Station Intercom (General)";
 	pixel_x = 28
 	},
 /obj/machinery/computer/bounty{
@@ -22618,7 +22590,6 @@
 "bbl" = (
 /obj/machinery/light,
 /obj/item/radio/intercom{
-	name = "Station Intercom";
 	pixel_y = -26
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -22923,7 +22894,6 @@
 /obj/item/clothing/suit/apron,
 /obj/effect/turf_decal/bot,
 /obj/item/radio/intercom{
-	name = "Station Intercom";
 	pixel_y = 26
 	},
 /turf/open/floor/plasteel,
@@ -23134,7 +23104,6 @@
 	dir = 8
 	},
 /obj/item/radio/intercom{
-	name = "Station Intercom";
 	pixel_x = -26
 	},
 /turf/open/floor/plasteel/brown{
@@ -23797,7 +23766,6 @@
 	dir = 8
 	},
 /obj/item/radio/intercom{
-	name = "Station Intercom";
 	pixel_x = -26
 	},
 /turf/open/floor/plasteel/brown{
@@ -24005,7 +23973,6 @@
 /area/security/prison)
 "bes" = (
 /obj/item/radio/intercom{
-	name = "Station Intercom";
 	pixel_y = 26
 	},
 /obj/effect/decal/cleanable/dirt,
@@ -24267,7 +24234,6 @@
 	pixel_y = -22
 	},
 /obj/item/radio/intercom{
-	name = "Station Intercom";
 	pixel_x = -26;
 	pixel_y = -26
 	},
@@ -25330,7 +25296,6 @@
 "bhC" = (
 /obj/structure/table/glass,
 /obj/item/radio/intercom{
-	name = "Station Intercom";
 	pixel_y = 26
 	},
 /obj/item/storage/box/beakers{
@@ -25393,7 +25358,6 @@
 	dir = 1
 	},
 /obj/item/radio/intercom{
-	name = "Station Intercom";
 	pixel_y = 26
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -25434,7 +25398,6 @@
 /area/crew_quarters/kitchen)
 "bhO" = (
 /obj/item/radio/intercom{
-	name = "Station Intercom";
 	pixel_y = 26
 	},
 /turf/open/floor/plasteel/white,
@@ -25889,7 +25852,6 @@
 	dir = 4
 	},
 /obj/item/radio/intercom{
-	name = "Station Intercom";
 	pixel_x = 26;
 	pixel_y = 26
 	},
@@ -27351,7 +27313,6 @@
 /obj/machinery/light,
 /obj/item/radio/intercom{
 	dir = 8;
-	name = "Station Intercom (General)";
 	pixel_y = -26
 	},
 /obj/item/storage/backpack/satchel/explorer,
@@ -27414,7 +27375,6 @@
 "bmf" = (
 /obj/structure/bed/roller,
 /obj/item/radio/intercom{
-	name = "Station Intercom";
 	pixel_y = -26
 	},
 /turf/open/floor/plasteel/whitered/side,
@@ -27551,7 +27511,6 @@
 	pixel_y = 32
 	},
 /obj/item/radio/intercom{
-	name = "Station Intercom";
 	pixel_x = 26;
 	pixel_y = 58
 	},
@@ -28505,7 +28464,6 @@
 	dir = 4
 	},
 /obj/item/radio/intercom{
-	name = "Station Intercom";
 	pixel_x = 28
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
@@ -28849,7 +28807,6 @@
 /area/security/execution/transfer)
 "bpg" = (
 /obj/item/radio/intercom{
-	name = "Station Intercom";
 	pixel_y = 26
 	},
 /obj/machinery/computer/security/labor,
@@ -30725,7 +30682,6 @@
 	dir = 4
 	},
 /obj/item/radio/intercom{
-	name = "Station Intercom";
 	pixel_y = -26
 	},
 /obj/machinery/camera{
@@ -31197,7 +31153,6 @@
 	pixel_y = -32
 	},
 /obj/item/radio/intercom{
-	name = "Station Intercom";
 	pixel_x = 26;
 	pixel_y = -26
 	},
@@ -32481,7 +32436,6 @@
 /area/engine/atmos)
 "bwx" = (
 /obj/item/radio/intercom{
-	name = "Station Intercom";
 	pixel_x = 26
 	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/visible{
@@ -32692,7 +32646,6 @@
 "bwO" = (
 /obj/machinery/hydroponics/constructable,
 /obj/item/radio/intercom{
-	name = "Station Intercom";
 	pixel_y = -26
 	},
 /obj/effect/turf_decal/delivery,
@@ -34114,7 +34067,6 @@
 	},
 /obj/structure/disposalpipe/segment,
 /obj/item/radio/intercom{
-	name = "Station Intercom";
 	pixel_x = 26
 	},
 /obj/machinery/camera{
@@ -34413,10 +34365,7 @@
 	},
 /obj/item/radio/intercom{
 	anyai = 1;
-	broadcasting = 0;
-	freerange = 1;
-	frequency = 1424;
-	listening = 1;
+	frequency = 1423;
 	name = "Interrogation Intercom";
 	pixel_y = -58
 	},
@@ -35002,7 +34951,6 @@
 /area/bridge)
 "bBG" = (
 /obj/item/radio/intercom{
-	name = "Station Intercom";
 	pixel_x = -26;
 	pixel_y = 26
 	},
@@ -35045,7 +34993,6 @@
 /area/bridge)
 "bBL" = (
 /obj/item/radio/intercom{
-	name = "Station Intercom";
 	pixel_x = 26;
 	pixel_y = 26
 	},
@@ -35180,7 +35127,6 @@
 /area/security/execution/transfer)
 "bCc" = (
 /obj/item/radio/intercom{
-	name = "Station Intercom";
 	pixel_x = 26
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -35218,7 +35164,6 @@
 /area/security/brig)
 "bCg" = (
 /obj/item/radio/intercom{
-	name = "Station Intercom";
 	pixel_y = -26
 	},
 /obj/structure/extinguisher_cabinet{
@@ -35260,8 +35205,7 @@
 /obj/item/radio/intercom{
 	anyai = 1;
 	broadcasting = 1;
-	freerange = 1;
-	frequency = 1424;
+	frequency = 1423;
 	listening = 0;
 	name = "Interrogation Intercom";
 	pixel_y = -24
@@ -35686,7 +35630,6 @@
 /obj/item/folder/yellow,
 /obj/item/pen,
 /obj/item/radio/intercom{
-	name = "Station Intercom";
 	pixel_y = -26
 	},
 /turf/open/floor/plasteel/caution,
@@ -36439,15 +36382,12 @@
 	pixel_y = 22
 	},
 /obj/item/radio/intercom{
-	broadcasting = 0;
 	freerange = 1;
-	listening = 1;
 	name = "Common Channel";
 	pixel_x = -27
 	},
 /obj/item/radio/intercom{
 	anyai = 1;
-	broadcasting = 0;
 	freerange = 1;
 	frequency = 1447;
 	name = "Private Channel";
@@ -36553,15 +36493,12 @@
 	pixel_y = 22
 	},
 /obj/item/radio/intercom{
-	broadcasting = 0;
 	freerange = 1;
-	listening = 1;
 	name = "Common Channel";
 	pixel_x = 27
 	},
 /obj/item/radio/intercom{
 	anyai = 1;
-	broadcasting = 0;
 	freerange = 1;
 	frequency = 1447;
 	name = "Private Channel";
@@ -37413,7 +37350,6 @@
 /area/security/warden)
 "bFQ" = (
 /obj/item/radio/intercom{
-	name = "Station Intercom";
 	pixel_y = 26
 	},
 /obj/effect/turf_decal/stripes/line{
@@ -37437,9 +37373,7 @@
 /area/ai_monitored/turret_protected/ai)
 "bFT" = (
 /obj/item/radio/intercom{
-	broadcasting = 0;
 	freerange = 1;
-	listening = 1;
 	name = "Common Channel";
 	pixel_x = -27;
 	pixel_y = -7
@@ -37453,7 +37387,6 @@
 	},
 /obj/item/radio/intercom{
 	anyai = 1;
-	broadcasting = 0;
 	freerange = 1;
 	frequency = 1447;
 	name = "Private Channel";
@@ -37821,7 +37754,6 @@
 /obj/item/stock_parts/matter_bin,
 /obj/item/stock_parts/micro_laser,
 /obj/item/radio/intercom{
-	name = "Station Intercom";
 	pixel_x = 26
 	},
 /turf/open/floor/plasteel/vault{
@@ -38896,7 +38828,6 @@
 	pixel_y = -26
 	},
 /obj/item/radio/intercom{
-	name = "Station Intercom";
 	pixel_x = 26;
 	pixel_y = -26
 	},
@@ -39646,7 +39577,6 @@
 "bKs" = (
 /obj/machinery/vending/tool,
 /obj/item/radio/intercom{
-	name = "Station Intercom";
 	pixel_x = -26
 	},
 /obj/effect/turf_decal/delivery,
@@ -39852,7 +39782,6 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/structure/disposalpipe/segment,
 /obj/item/radio/intercom{
-	name = "Station Intercom";
 	pixel_x = 26
 	},
 /turf/open/floor/plasteel/neutral/corner{
@@ -40673,7 +40602,6 @@
 "bMy" = (
 /obj/structure/table/wood,
 /obj/item/radio/intercom{
-	name = "Station Intercom";
 	pixel_y = 26
 	},
 /obj/item/folder/blue,
@@ -40737,7 +40665,6 @@
 "bME" = (
 /obj/structure/table/wood,
 /obj/item/radio/intercom{
-	name = "Station Intercom";
 	pixel_y = 26
 	},
 /obj/item/book/manual/wiki/tcomms,
@@ -41070,7 +40997,6 @@
 	pixel_y = -3
 	},
 /obj/item/radio/intercom{
-	name = "Station Intercom";
 	pixel_x = 26
 	},
 /obj/item/clothing/mask/gas/sechailer,
@@ -41103,7 +41029,6 @@
 	},
 /obj/structure/table/reinforced,
 /obj/item/radio/intercom{
-	name = "Station Intercom";
 	pixel_y = 26
 	},
 /turf/open/floor/plasteel/vault{
@@ -41429,7 +41354,6 @@
 /area/engine/break_room)
 "bNW" = (
 /obj/item/radio/intercom{
-	name = "Station Intercom";
 	pixel_y = -26
 	},
 /turf/open/floor/plasteel/yellow/side{
@@ -41896,7 +41820,6 @@
 /area/storage/tools)
 "bPb" = (
 /obj/item/radio/intercom{
-	name = "Station Intercom";
 	pixel_x = 26
 	},
 /obj/effect/decal/cleanable/dirt,
@@ -43519,7 +43442,6 @@
 	pixel_y = -26
 	},
 /obj/item/radio/intercom{
-	name = "Station Intercom";
 	pixel_y = -26
 	},
 /obj/structure/bookcase/random,
@@ -44508,7 +44430,6 @@
 	pixel_y = 32
 	},
 /obj/item/radio/intercom{
-	name = "Station Intercom";
 	pixel_x = 26
 	},
 /obj/machinery/camera{
@@ -45296,7 +45217,6 @@
 	req_access_txt = "16"
 	},
 /obj/item/radio/intercom{
-	name = "Station Intercom";
 	pixel_y = 26
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -45916,7 +45836,6 @@
 	pixel_y = 7
 	},
 /obj/item/radio/intercom{
-	name = "Station Intercom";
 	pixel_y = 26
 	},
 /obj/machinery/button/door{
@@ -48809,7 +48728,6 @@
 	pixel_x = -32
 	},
 /obj/item/radio/intercom{
-	name = "Station Intercom";
 	pixel_y = 26
 	},
 /turf/open/floor/plasteel/dark,
@@ -48838,7 +48756,6 @@
 	dir = 8
 	},
 /obj/item/radio/intercom{
-	name = "Station Intercom";
 	pixel_x = -26
 	},
 /turf/open/floor/plasteel/neutral/corner{
@@ -48985,7 +48902,6 @@
 /obj/item/pinpointer/nuke,
 /obj/item/disk/nuclear,
 /obj/item/radio/intercom{
-	name = "Station Intercom";
 	pixel_x = -26
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -49234,7 +49150,6 @@
 /area/security/brig)
 "cdp" = (
 /obj/item/radio/intercom{
-	name = "Station Intercom";
 	pixel_x = 26;
 	pixel_y = -7
 	},
@@ -50305,7 +50220,6 @@
 /area/security/brig)
 "cfn" = (
 /obj/item/radio/intercom{
-	name = "Station Intercom";
 	pixel_y = 26
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -50587,7 +50501,6 @@
 	pixel_x = 32
 	},
 /obj/item/radio/intercom{
-	name = "Station Intercom";
 	pixel_x = 26;
 	pixel_y = -26
 	},
@@ -50922,9 +50835,7 @@
 /area/security/courtroom)
 "cgE" = (
 /obj/structure/table/wood,
-/obj/item/radio/intercom{
-	name = "Station Intercom"
-	},
+/obj/item/radio/intercom,
 /turf/open/floor/plasteel/neutral/side{
 	dir = 1
 	},
@@ -51614,7 +51525,6 @@
 "chW" = (
 /obj/structure/chair/comfy/brown,
 /obj/item/radio/intercom{
-	name = "Station Intercom";
 	pixel_y = 26
 	},
 /turf/open/floor/wood,
@@ -52548,7 +52458,6 @@
 "ckb" = (
 /obj/structure/table/wood,
 /obj/item/radio/intercom{
-	name = "Station Intercom";
 	pixel_y = -32
 	},
 /obj/item/folder/yellow{
@@ -52584,7 +52493,6 @@
 /obj/structure/table/wood,
 /obj/item/flashlight/lamp,
 /obj/item/radio/intercom{
-	name = "Station Intercom";
 	pixel_x = -26
 	},
 /turf/open/floor/wood,
@@ -52682,7 +52590,6 @@
 /obj/structure/table/reinforced,
 /obj/item/aiModule/reset,
 /obj/item/radio/intercom{
-	name = "Station Intercom";
 	pixel_x = -26
 	},
 /turf/open/floor/plasteel/vault{
@@ -53876,9 +53783,7 @@
 /area/security/courtroom)
 "cmU" = (
 /obj/structure/table/wood,
-/obj/item/radio/intercom{
-	name = "Station Intercom"
-	},
+/obj/item/radio/intercom,
 /turf/open/floor/plasteel/neutral/side,
 /area/security/courtroom)
 "cmV" = (
@@ -54325,7 +54230,6 @@
 	dir = 8
 	},
 /obj/item/radio/intercom{
-	name = "Station Intercom";
 	pixel_x = -26
 	},
 /obj/effect/turf_decal/bot,
@@ -54494,7 +54398,6 @@
 "cod" = (
 /obj/structure/table/wood,
 /obj/item/radio/intercom{
-	name = "Station Intercom";
 	pixel_x = 26
 	},
 /obj/item/clipboard,
@@ -54658,7 +54561,6 @@
 "cot" = (
 /obj/item/twohanded/required/kirbyplants/random,
 /obj/item/radio/intercom{
-	name = "Station Intercom";
 	pixel_x = -26
 	},
 /obj/effect/decal/cleanable/dirt,
@@ -55074,7 +54976,6 @@
 /obj/structure/tank_dispenser,
 /obj/effect/decal/cleanable/dirt,
 /obj/item/radio/intercom{
-	name = "Station Intercom";
 	pixel_y = 26
 	},
 /obj/effect/decal/cleanable/dirt,
@@ -55170,7 +55071,6 @@
 "cpA" = (
 /obj/structure/table/wood,
 /obj/item/radio/intercom{
-	name = "Station Intercom";
 	pixel_x = -26
 	},
 /obj/item/flashlight/lamp/green,
@@ -55923,9 +55823,7 @@
 /area/security/courtroom)
 "crm" = (
 /obj/structure/table/wood,
-/obj/item/radio/intercom{
-	name = "Station Intercom"
-	},
+/obj/item/radio/intercom,
 /turf/open/floor/plasteel/vault,
 /area/security/courtroom)
 "crn" = (
@@ -56535,7 +56433,6 @@
 	dir = 1
 	},
 /obj/item/radio/intercom{
-	name = "Station Intercom";
 	pixel_y = 26
 	},
 /turf/open/floor/plasteel/neutral/corner{
@@ -57130,7 +57027,6 @@
 	pixel_x = 24
 	},
 /obj/item/radio/intercom{
-	name = "Station Intercom";
 	pixel_y = -26
 	},
 /turf/open/floor/plasteel/grimy,
@@ -59032,7 +58928,6 @@
 	dir = 1
 	},
 /obj/item/radio/intercom{
-	name = "Station Intercom";
 	pixel_y = 26
 	},
 /obj/machinery/suit_storage_unit/engine,
@@ -59999,7 +59894,6 @@
 	pixel_x = 3
 	},
 /obj/item/radio/intercom{
-	name = "Station Intercom";
 	pixel_y = -26
 	},
 /turf/open/floor/plasteel/dark,
@@ -60790,7 +60684,6 @@
 	dir = 4
 	},
 /obj/item/radio/intercom{
-	name = "Station Intercom";
 	pixel_x = 26
 	},
 /obj/effect/decal/cleanable/dirt,
@@ -60845,7 +60738,6 @@
 "cBG" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/item/radio/intercom{
-	name = "Station Intercom";
 	pixel_x = -26
 	},
 /turf/open/floor/plasteel/neutral/corner{
@@ -61134,7 +61026,6 @@
 /obj/item/clothing/suit/jacket/letterman_nanotrasen,
 /obj/item/clothing/suit/toggle/lawyer,
 /obj/item/radio/intercom{
-	name = "Station Intercom";
 	pixel_x = 26;
 	pixel_y = 26
 	},
@@ -61169,7 +61060,6 @@
 	},
 /obj/item/clothing/suit/toggle/lawyer/purple,
 /obj/item/radio/intercom{
-	name = "Station Intercom";
 	pixel_x = 26;
 	pixel_y = 26
 	},
@@ -62199,7 +62089,6 @@
 "cEr" = (
 /obj/item/twohanded/required/kirbyplants/random,
 /obj/item/radio/intercom{
-	name = "Station Intercom";
 	pixel_y = -26
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -63121,7 +63010,6 @@
 /area/ai_monitored/storage/eva)
 "cGh" = (
 /obj/item/radio/intercom{
-	name = "Station Intercom";
 	pixel_y = -26
 	},
 /obj/item/twohanded/required/kirbyplants/random,
@@ -63259,7 +63147,6 @@
 	name = "replica officer's beret"
 	},
 /obj/item/radio/intercom{
-	name = "Station Intercom";
 	pixel_x = 26
 	},
 /turf/open/floor/plasteel/grimy,
@@ -64244,7 +64131,6 @@
 	dir = 4
 	},
 /obj/item/radio/intercom{
-	name = "Station Intercom";
 	pixel_y = 26
 	},
 /turf/open/floor/plasteel/neutral/corner{
@@ -66940,7 +66826,6 @@
 "cNN" = (
 /obj/structure/closet/secure_closet/medical3,
 /obj/item/radio/intercom{
-	name = "Station Intercom";
 	pixel_y = 26
 	},
 /turf/open/floor/plasteel/neutral/side,
@@ -67699,7 +67584,6 @@
 /obj/item/storage/firstaid/regular,
 /obj/item/radio/intercom{
 	dir = 8;
-	name = "Station Intercom (General)";
 	pixel_x = 28
 	},
 /turf/open/floor/plasteel/whiteblue/corner{
@@ -67939,7 +67823,6 @@
 "cPR" = (
 /obj/structure/dresser,
 /obj/item/radio/intercom{
-	name = "Station Intercom";
 	pixel_x = 26;
 	pixel_y = 26
 	},
@@ -67965,7 +67848,6 @@
 "cPT" = (
 /obj/item/twohanded/required/kirbyplants/random,
 /obj/item/radio/intercom{
-	name = "Station Intercom";
 	pixel_x = 26;
 	pixel_y = 26
 	},
@@ -67998,7 +67880,6 @@
 /obj/structure/table/wood,
 /obj/item/flashlight/lamp,
 /obj/item/radio/intercom{
-	name = "Station Intercom";
 	pixel_x = 26;
 	pixel_y = 26
 	},
@@ -68301,7 +68182,6 @@
 	dir = 1
 	},
 /obj/item/radio/intercom{
-	name = "Station Intercom";
 	pixel_y = 26
 	},
 /turf/open/floor/plasteel/red/side{
@@ -68793,7 +68673,6 @@
 	dir = 1
 	},
 /obj/item/radio/intercom{
-	name = "Station Intercom";
 	pixel_x = 26
 	},
 /obj/item/paper_bin,
@@ -69230,7 +69109,6 @@
 	dir = 1
 	},
 /obj/item/radio/intercom{
-	name = "Station Intercom";
 	pixel_y = 26
 	},
 /turf/open/floor/plasteel/red/side{
@@ -69279,7 +69157,6 @@
 	},
 /obj/item/storage/box/beakers,
 /obj/item/radio/intercom{
-	name = "Station Intercom";
 	pixel_y = 26
 	},
 /turf/open/floor/plasteel/whiteblue/side{
@@ -69772,7 +69649,6 @@
 	},
 /obj/item/storage/box/syringes,
 /obj/item/radio/intercom{
-	name = "Station Intercom";
 	pixel_y = 32
 	},
 /obj/item/extinguisher/mini,
@@ -70648,7 +70524,6 @@
 	req_access_txt = "55"
 	},
 /obj/item/radio/intercom{
-	name = "Station Intercom";
 	pixel_y = 5
 	},
 /obj/effect/turf_decal/bot,
@@ -74225,7 +74100,6 @@
 	dir = 4
 	},
 /obj/item/radio/intercom{
-	name = "Station Intercom";
 	pixel_x = -26
 	},
 /turf/open/floor/plasteel/whiteblue/side{
@@ -74690,7 +74564,6 @@
 /area/security/checkpoint/science/research)
 "ddY" = (
 /obj/item/radio/intercom{
-	name = "Station Intercom";
 	pixel_y = -32
 	},
 /obj/structure/closet/emcloset,
@@ -74755,7 +74628,6 @@
 /obj/item/stock_parts/manipulator,
 /obj/item/stock_parts/manipulator,
 /obj/item/radio/intercom{
-	name = "Station Intercom";
 	pixel_x = -26
 	},
 /obj/effect/turf_decal/stripes/line{
@@ -75859,7 +75731,6 @@
 	dir = 4
 	},
 /obj/item/radio/intercom{
-	name = "Station Intercom";
 	pixel_y = 26
 	},
 /obj/machinery/camera{
@@ -77575,7 +77446,6 @@
 	dir = 4
 	},
 /obj/item/radio/intercom{
-	name = "Station Intercom";
 	pixel_x = -6;
 	pixel_y = -26
 	},
@@ -78721,7 +78591,6 @@
 	pixel_x = -23
 	},
 /obj/item/radio/intercom{
-	name = "Station Intercom";
 	pixel_y = 26
 	},
 /obj/effect/turf_decal/bot,
@@ -79212,7 +79081,6 @@
 "dog" = (
 /obj/structure/table/reinforced,
 /obj/item/radio/intercom{
-	name = "Station Intercom";
 	pixel_x = -26
 	},
 /obj/effect/decal/cleanable/dirt,
@@ -81136,7 +81004,6 @@
 	dir = 4
 	},
 /obj/item/radio/intercom{
-	name = "Station Intercom";
 	pixel_x = -26
 	},
 /turf/open/floor/plasteel/vault{
@@ -81572,7 +81439,6 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/structure/disposalpipe/segment,
 /obj/item/radio/intercom{
-	name = "Station Intercom";
 	pixel_x = 26
 	},
 /turf/open/floor/plasteel/neutral/corner,
@@ -82302,7 +82168,6 @@
 "dvj" = (
 /obj/structure/table/reinforced,
 /obj/item/radio/intercom{
-	name = "Station Intercom";
 	pixel_y = 26
 	},
 /obj/item/clothing/gloves/color/latex,
@@ -82441,7 +82306,6 @@
 /obj/item/folder/blue,
 /obj/item/clothing/glasses/hud/health,
 /obj/item/radio/intercom{
-	name = "Station Intercom";
 	pixel_y = 26
 	},
 /turf/open/floor/plasteel/neutral/side{
@@ -82848,7 +82712,6 @@
 	pixel_y = -32
 	},
 /obj/item/radio/intercom{
-	name = "Station Intercom";
 	pixel_x = -26;
 	pixel_y = -26
 	},
@@ -83409,7 +83272,6 @@
 	dir = 4
 	},
 /obj/item/radio/intercom{
-	name = "Station Intercom";
 	pixel_x = 26
 	},
 /turf/open/floor/plasteel/whiteblue/corner,
@@ -84009,7 +83871,6 @@
 	dir = 1
 	},
 /obj/item/radio/intercom{
-	name = "Station Intercom";
 	pixel_y = -26
 	},
 /turf/open/floor/plasteel/whiteblue/side,
@@ -84714,7 +84575,6 @@
 /area/crew_quarters/heads/cmo)
 "dAg" = (
 /obj/item/radio/intercom{
-	name = "Station Intercom";
 	pixel_x = 26
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -84771,7 +84631,6 @@
 	icon_state = "2-4"
 	},
 /obj/item/radio/intercom{
-	name = "Station Intercom";
 	pixel_y = 26
 	},
 /obj/effect/turf_decal/stripes/line{
@@ -85079,7 +84938,6 @@
 /area/medical/genetics)
 "dAT" = (
 /obj/item/radio/intercom{
-	name = "Station Intercom";
 	pixel_y = -26
 	},
 /turf/open/floor/plasteel/whitepurple/corner,
@@ -85674,7 +85532,6 @@
 "dCa" = (
 /obj/structure/table/reinforced,
 /obj/item/radio/intercom{
-	name = "Station Intercom";
 	pixel_y = -32
 	},
 /obj/item/assembly/igniter{
@@ -85760,7 +85617,6 @@
 	pixel_y = -32
 	},
 /obj/item/radio/intercom{
-	name = "Station Intercom";
 	pixel_x = 26
 	},
 /turf/open/floor/plasteel/whitepurple/corner,
@@ -86330,7 +86186,6 @@
 	dir = 8
 	},
 /obj/item/radio/intercom{
-	name = "Station Intercom";
 	pixel_x = -26
 	},
 /turf/open/floor/plasteel/whitepurple/corner{
@@ -86653,7 +86508,6 @@
 "dEe" = (
 /obj/item/twohanded/required/kirbyplants/random,
 /obj/item/radio/intercom{
-	name = "Station Intercom";
 	pixel_y = -26
 	},
 /obj/machinery/light,
@@ -86825,7 +86679,6 @@
 /area/science/storage)
 "dEy" = (
 /obj/item/radio/intercom{
-	name = "Station Intercom";
 	pixel_y = 26
 	},
 /obj/machinery/portable_atmospherics/canister/nitrogen,
@@ -87230,7 +87083,6 @@
 	dir = 8
 	},
 /obj/item/radio/intercom{
-	name = "Station Intercom";
 	pixel_x = -26;
 	pixel_y = 32
 	},
@@ -88895,7 +88747,6 @@
 /obj/item/stock_parts/cell/high,
 /obj/machinery/cell_charger,
 /obj/item/radio/intercom{
-	name = "Station Intercom";
 	pixel_y = -26
 	},
 /obj/effect/turf_decal/bot,
@@ -89114,7 +88965,6 @@
 /area/crew_quarters/heads/cmo)
 "dJj" = (
 /obj/item/radio/intercom{
-	name = "Station Intercom";
 	pixel_y = -26
 	},
 /obj/machinery/camera{
@@ -89479,7 +89329,6 @@
 /obj/machinery/disposal/bin,
 /obj/effect/decal/cleanable/dirt,
 /obj/item/radio/intercom{
-	name = "Station Intercom";
 	pixel_y = -32
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -90560,7 +90409,6 @@
 "dMe" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/item/radio/intercom{
-	name = "Station Intercom";
 	pixel_y = 26
 	},
 /turf/open/floor/plasteel/neutral/side{
@@ -91752,7 +91600,6 @@
 	dir = 8
 	},
 /obj/item/radio/intercom{
-	name = "Station Intercom";
 	pixel_y = 26
 	},
 /turf/open/floor/plasteel/blue/side{
@@ -92520,7 +92367,6 @@
 	},
 /obj/item/paper_bin,
 /obj/item/radio/intercom{
-	name = "Station Intercom";
 	pixel_y = 26
 	},
 /obj/machinery/computer/security/telescreen/entertainment{
@@ -93055,7 +92901,6 @@
 	pixel_y = 1
 	},
 /obj/item/radio/intercom{
-	name = "Station Intercom";
 	pixel_y = 26
 	},
 /obj/machinery/computer/security/telescreen/entertainment{
@@ -94338,7 +94183,6 @@
 "dUq" = (
 /obj/item/twohanded/required/kirbyplants/random,
 /obj/item/radio/intercom{
-	name = "Station Intercom";
 	pixel_y = 26
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -94717,7 +94561,6 @@
 "dVz" = (
 /obj/structure/closet/crate/freezer/blood,
 /obj/item/radio/intercom{
-	name = "Station Intercom";
 	pixel_y = 26
 	},
 /obj/machinery/camera{
@@ -94737,7 +94580,6 @@
 /area/medical/virology)
 "dVC" = (
 /obj/item/radio/intercom{
-	name = "Station Intercom";
 	pixel_x = 26
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -94827,7 +94669,6 @@
 /obj/item/wrench,
 /obj/item/crowbar,
 /obj/item/radio/intercom{
-	name = "Station Intercom";
 	pixel_x = -26
 	},
 /obj/item/clothing/under/burial,
@@ -95810,7 +95651,6 @@
 /obj/item/stack/packageWrap,
 /obj/item/hand_labeler,
 /obj/item/radio/intercom{
-	name = "Station Intercom";
 	pixel_x = 26
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -96785,7 +96625,6 @@
 /area/chapel/office)
 "eav" = (
 /obj/item/radio/intercom{
-	name = "Station Intercom";
 	pixel_x = 26
 	},
 /obj/structure/cable/white{
@@ -96920,7 +96759,6 @@
 /area/medical/virology)
 "eaR" = (
 /obj/item/radio/intercom{
-	name = "Station Intercom";
 	pixel_y = 26
 	},
 /obj/effect/turf_decal/stripes/line{
@@ -98359,7 +98197,6 @@
 /area/maintenance/port/aft)
 "edS" = (
 /obj/item/radio/intercom{
-	name = "Station Intercom";
 	pixel_x = -26
 	},
 /turf/open/floor/plasteel/dark,
@@ -98601,7 +98438,6 @@
 /obj/structure/table/wood,
 /obj/item/flashlight/lamp,
 /obj/item/radio/intercom{
-	name = "Station Intercom";
 	pixel_x = -26
 	},
 /obj/machinery/airalarm{
@@ -99550,7 +99386,6 @@
 /area/hallway/secondary/entry)
 "ehG" = (
 /obj/item/radio/intercom{
-	name = "Station Intercom";
 	pixel_x = -26
 	},
 /obj/effect/turf_decal/stripes/box,
@@ -99935,7 +99770,6 @@
 	dir = 4
 	},
 /obj/item/radio/intercom{
-	name = "Station Intercom";
 	pixel_y = 26
 	},
 /obj/structure/cable/white{

--- a/_maps/map_files/Deltastation/DeltaStation2.dmm
+++ b/_maps/map_files/Deltastation/DeltaStation2.dmm
@@ -98107,7 +98107,7 @@
 	},
 /obj/item/radio/intercom{
 	broadcasting = 1;
-	frequency = 1480;
+	frequency = 1481;
 	name = "Confessional Intercom";
 	pixel_x = -26
 	},
@@ -98125,7 +98125,7 @@
 	},
 /obj/item/radio/intercom{
 	broadcasting = 1;
-	frequency = 1480;
+	frequency = 1481;
 	name = "Confessional Intercom";
 	pixel_y = -26
 	},

--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -67701,7 +67701,7 @@
 "cNz" = (
 /obj/item/radio/intercom{
 	broadcasting = 1;
-	frequency = 1480;
+	frequency = 1481;
 	name = "Confessional Intercom";
 	pixel_x = -25
 	},
@@ -68256,7 +68256,7 @@
 "cOL" = (
 /obj/item/radio/intercom{
 	broadcasting = 1;
-	frequency = 1480;
+	frequency = 1481;
 	name = "Confessional Intercom";
 	pixel_x = 25
 	},

--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -1649,9 +1649,6 @@
 /area/maintenance/starboard)
 "adJ" = (
 /obj/item/radio/intercom{
-	freerange = 0;
-	frequency = 1459;
-	name = "Station Intercom (General)";
 	pixel_x = -28
 	},
 /obj/structure/table,
@@ -2500,9 +2497,6 @@
 	pixel_x = -22
 	},
 /obj/item/radio/intercom{
-	freerange = 0;
-	frequency = 1459;
-	name = "Station Intercom (General)";
 	pixel_x = -29;
 	pixel_y = 23
 	},
@@ -2778,9 +2772,6 @@
 	dir = 4
 	},
 /obj/item/radio/intercom{
-	freerange = 0;
-	frequency = 1459;
-	name = "Station Intercom (General)";
 	pixel_y = -30
 	},
 /turf/open/floor/plasteel/red/corner{
@@ -2873,9 +2864,6 @@
 /area/ai_monitored/security/armory)
 "afZ" = (
 /obj/item/radio/intercom{
-	freerange = 0;
-	frequency = 1459;
-	name = "Station Intercom (General)";
 	pixel_y = 24
 	},
 /obj/structure/rack,
@@ -3510,9 +3498,6 @@
 	dir = 4
 	},
 /obj/item/radio/intercom{
-	freerange = 0;
-	frequency = 1459;
-	name = "Station Intercom (General)";
 	pixel_x = 29
 	},
 /turf/open/floor/plating,
@@ -4894,9 +4879,6 @@
 "aku" = (
 /obj/structure/table,
 /obj/item/radio/intercom{
-	freerange = 0;
-	frequency = 1459;
-	name = "Station Intercom (General)";
 	pixel_y = 26
 	},
 /obj/machinery/light/small{
@@ -5081,9 +5063,6 @@
 	dir = 1
 	},
 /obj/item/radio/intercom{
-	freerange = 0;
-	frequency = 1459;
-	name = "Station Intercom (General)";
 	pixel_y = 26
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -5368,9 +5347,6 @@
 	dir = 1
 	},
 /obj/item/radio/intercom{
-	freerange = 0;
-	frequency = 1459;
-	name = "Station Intercom (General)";
 	pixel_y = -28
 	},
 /obj/machinery/light/small,
@@ -7737,9 +7713,6 @@
 "aqk" = (
 /obj/machinery/vending/coffee,
 /obj/item/radio/intercom{
-	freerange = 0;
-	frequency = 1459;
-	name = "Station Intercom (General)";
 	pixel_y = -28
 	},
 /turf/open/floor/plasteel/vault,
@@ -7888,9 +7861,6 @@
 	dir = 4
 	},
 /obj/item/radio/intercom{
-	freerange = 0;
-	frequency = 1459;
-	name = "Station Intercom (General)";
 	pixel_x = 29
 	},
 /turf/open/floor/plating,
@@ -8828,7 +8798,6 @@
 	},
 /obj/item/radio/intercom{
 	dir = 4;
-	name = "Station Intercom (General)";
 	pixel_x = 29;
 	pixel_y = -28
 	},
@@ -9020,10 +8989,7 @@
 /obj/structure/table/wood,
 /obj/item/radio/intercom{
 	anyai = 1;
-	broadcasting = 0;
-	freerange = 1;
-	frequency = 1424;
-	listening = 1;
+	frequency = 1423;
 	name = "Interrogation Intercom";
 	pixel_y = -31
 	},
@@ -10068,9 +10034,6 @@
 /area/security/brig)
 "avd" = (
 /obj/item/radio/intercom{
-	freerange = 0;
-	frequency = 1459;
-	name = "Station Intercom (General)";
 	pixel_y = 26
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -11255,8 +11218,7 @@
 /obj/item/radio/intercom{
 	anyai = 1;
 	broadcasting = 1;
-	freerange = 1;
-	frequency = 1424;
+	frequency = 1423;
 	listening = 0;
 	name = "Interrogation Intercom";
 	pixel_y = -24
@@ -11953,7 +11915,6 @@
 	},
 /obj/item/radio/intercom{
 	dir = 4;
-	name = "Station Intercom (General)";
 	pixel_x = 27
 	},
 /obj/effect/turf_decal/stripes/line{
@@ -12419,9 +12380,6 @@
 	dir = 1
 	},
 /obj/item/radio/intercom{
-	freerange = 0;
-	frequency = 1459;
-	name = "Station Intercom (General)";
 	pixel_y = 28
 	},
 /obj/item/clothing/accessory/waistcoat,
@@ -12563,9 +12521,6 @@
 /area/engine/engineering)
 "aAr" = (
 /obj/item/radio/intercom{
-	freerange = 0;
-	frequency = 1459;
-	name = "Station Intercom (General)";
 	pixel_y = 21
 	},
 /obj/machinery/camera{
@@ -13280,7 +13235,6 @@
 "aBX" = (
 /obj/item/radio/intercom{
 	dir = 4;
-	name = "Station Intercom (General)";
 	pixel_x = 27
 	},
 /obj/machinery/camera{
@@ -13697,7 +13651,6 @@
 "aCN" = (
 /obj/structure/reagent_dispensers/fueltank,
 /obj/item/radio/intercom{
-	name = "Station Intercom (General)";
 	pixel_x = -30
 	},
 /obj/effect/turf_decal/bot{
@@ -14075,9 +14028,6 @@
 	dir = 8
 	},
 /obj/item/radio/intercom{
-	freerange = 0;
-	frequency = 1459;
-	name = "Station Intercom (General)";
 	pixel_x = 29;
 	pixel_y = -2
 	},
@@ -14121,9 +14071,6 @@
 "aDL" = (
 /obj/machinery/light/small,
 /obj/item/radio/intercom{
-	freerange = 0;
-	frequency = 1459;
-	name = "Station Intercom (General)";
 	pixel_y = -26
 	},
 /obj/structure/cable/yellow{
@@ -15376,9 +15323,6 @@
 	dir = 4
 	},
 /obj/item/radio/intercom{
-	freerange = 0;
-	frequency = 1459;
-	name = "Station Intercom (General)";
 	pixel_y = -26
 	},
 /turf/open/floor/plasteel/red/corner{
@@ -16290,7 +16234,6 @@
 "aIh" = (
 /obj/item/radio/intercom{
 	dir = 4;
-	name = "Station Intercom (General)";
 	pixel_x = -28;
 	pixel_y = 23
 	},
@@ -16525,9 +16468,6 @@
 	dir = 2
 	},
 /obj/item/radio/intercom{
-	freerange = 0;
-	frequency = 1459;
-	name = "Station Intercom (General)";
 	pixel_y = -26
 	},
 /obj/machinery/camera{
@@ -16704,9 +16644,6 @@
 /area/security/courtroom)
 "aIN" = (
 /obj/item/radio/intercom{
-	broadcasting = 0;
-	listening = 1;
-	name = "Station Intercom (General)";
 	pixel_y = 20
 	},
 /turf/open/floor/plasteel,
@@ -17225,7 +17162,6 @@
 	},
 /obj/item/radio/intercom{
 	dir = 8;
-	name = "Station Intercom (General)";
 	pixel_x = -28
 	},
 /turf/open/floor/wood,
@@ -17909,9 +17845,6 @@
 /obj/machinery/atmospherics/components/unary/portables_connector/visible,
 /obj/machinery/portable_atmospherics/scrubber,
 /obj/item/radio/intercom{
-	freerange = 0;
-	frequency = 1459;
-	name = "Station Intercom (General)";
 	pixel_y = 26
 	},
 /obj/machinery/light/small{
@@ -18254,9 +18187,6 @@
 "aMJ" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/item/radio/intercom{
-	freerange = 0;
-	frequency = 1459;
-	name = "Station Intercom (General)";
 	pixel_x = -29
 	},
 /turf/open/floor/plasteel/red/corner{
@@ -19275,9 +19205,6 @@
 	dir = 1
 	},
 /obj/item/radio/intercom{
-	freerange = 0;
-	frequency = 1459;
-	name = "Station Intercom (General)";
 	pixel_y = 21
 	},
 /turf/open/floor/engine,
@@ -19725,9 +19652,6 @@
 /area/hydroponics/garden)
 "aPR" = (
 /obj/item/radio/intercom{
-	freerange = 0;
-	frequency = 1459;
-	name = "Station Intercom (General)";
 	pixel_x = 29
 	},
 /obj/structure/window/reinforced{
@@ -19982,7 +19906,6 @@
 /obj/structure/table,
 /obj/item/radio/intercom{
 	dir = 4;
-	name = "Station Intercom (General)";
 	pixel_x = 27
 	},
 /obj/item/clothing/gloves/color/yellow,
@@ -20538,7 +20461,6 @@
 	},
 /obj/item/radio/intercom{
 	dir = 4;
-	name = "Station Intercom (General)";
 	pixel_x = 27
 	},
 /obj/structure/table,
@@ -20567,9 +20489,6 @@
 	dir = 1
 	},
 /obj/item/radio/intercom{
-	broadcasting = 0;
-	listening = 1;
-	name = "Station Intercom (General)";
 	pixel_y = -28
 	},
 /turf/open/floor/plasteel/brown{
@@ -21255,9 +21174,6 @@
 /area/security/courtroom)
 "aTm" = (
 /obj/item/radio/intercom{
-	freerange = 0;
-	frequency = 1459;
-	name = "Station Intercom (General)";
 	pixel_y = -26
 	},
 /turf/open/floor/plasteel/dark,
@@ -21352,9 +21268,6 @@
 	dir = 4
 	},
 /obj/item/radio/intercom{
-	freerange = 0;
-	frequency = 1459;
-	name = "Station Intercom (General)";
 	pixel_y = -26
 	},
 /obj/machinery/camera{
@@ -22248,9 +22161,6 @@
 /area/hallway/secondary/entry)
 "aVv" = (
 /obj/item/radio/intercom{
-	freerange = 0;
-	frequency = 1459;
-	name = "Station Intercom (General)";
 	pixel_y = 21
 	},
 /obj/structure/chair,
@@ -22446,7 +22356,6 @@
 "aVQ" = (
 /obj/item/radio/intercom{
 	dir = 4;
-	name = "Station Intercom (General)";
 	pixel_x = 27
 	},
 /obj/machinery/computer/security/mining{
@@ -22614,9 +22523,6 @@
 	icon_state = "plant-16"
 	},
 /obj/item/radio/intercom{
-	freerange = 0;
-	frequency = 1459;
-	name = "Station Intercom (General)";
 	pixel_y = 21
 	},
 /turf/open/floor/plasteel/neutral/side{
@@ -23247,9 +23153,6 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/item/radio/intercom{
-	freerange = 0;
-	frequency = 1459;
-	name = "Station Intercom (General)";
 	pixel_y = 21
 	},
 /obj/effect/turf_decal/stripes/line{
@@ -23584,9 +23487,6 @@
 /obj/item/assembly/flash/handheld,
 /obj/item/assembly/flash/handheld,
 /obj/item/radio/intercom{
-	freerange = 0;
-	frequency = 1459;
-	name = "Station Intercom (General)";
 	pixel_y = 28
 	},
 /turf/open/floor/plasteel/dark,
@@ -23599,9 +23499,6 @@
 /area/storage/tech)
 "aYo" = (
 /obj/item/radio/intercom{
-	freerange = 0;
-	frequency = 1459;
-	name = "Station Intercom (General)";
 	pixel_x = -29
 	},
 /turf/open/floor/plasteel/vault{
@@ -23661,9 +23558,6 @@
 /area/engine/engineering)
 "aYt" = (
 /obj/item/radio/intercom{
-	freerange = 0;
-	frequency = 1459;
-	name = "Station Intercom (General)";
 	pixel_x = 29
 	},
 /obj/effect/turf_decal/delivery,
@@ -24291,7 +24185,6 @@
 /obj/structure/table,
 /obj/item/radio/intercom{
 	dir = 4;
-	name = "Station Intercom (General)";
 	pixel_y = 29
 	},
 /obj/machinery/recharger{
@@ -24333,15 +24226,12 @@
 	pixel_y = 22
 	},
 /obj/item/radio/intercom{
-	broadcasting = 0;
 	freerange = 1;
-	listening = 1;
 	name = "Common Channel";
 	pixel_x = -27
 	},
 /obj/item/radio/intercom{
 	anyai = 1;
-	broadcasting = 0;
 	freerange = 1;
 	frequency = 1447;
 	name = "Private Channel";
@@ -24435,15 +24325,12 @@
 	pixel_y = 22
 	},
 /obj/item/radio/intercom{
-	broadcasting = 0;
 	freerange = 1;
-	listening = 1;
 	name = "Common Channel";
 	pixel_x = 27
 	},
 /obj/item/radio/intercom{
 	anyai = 1;
-	broadcasting = 0;
 	freerange = 1;
 	frequency = 1447;
 	name = "Private Channel";
@@ -24561,9 +24448,6 @@
 /area/maintenance/port/fore)
 "bal" = (
 /obj/item/radio/intercom{
-	broadcasting = 0;
-	listening = 1;
-	name = "Station Intercom (General)";
 	pixel_y = -28
 	},
 /obj/structure/cable/yellow{
@@ -25008,9 +24892,6 @@
 	dir = 1
 	},
 /obj/item/radio/intercom{
-	freerange = 0;
-	frequency = 1459;
-	name = "Station Intercom (General)";
 	pixel_x = -27;
 	pixel_y = -29
 	},
@@ -25072,9 +24953,6 @@
 "bbf" = (
 /obj/structure/closet/toolcloset,
 /obj/item/radio/intercom{
-	freerange = 0;
-	frequency = 1459;
-	name = "Station Intercom (General)";
 	pixel_y = 28
 	},
 /turf/open/floor/plasteel/yellow/side{
@@ -25125,9 +25003,6 @@
 	dir = 8
 	},
 /obj/item/radio/intercom{
-	freerange = 0;
-	frequency = 1459;
-	name = "Station Intercom (General)";
 	pixel_x = 29
 	},
 /obj/machinery/light/small{
@@ -25521,9 +25396,6 @@
 "bcb" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/item/radio/intercom{
-	freerange = 0;
-	frequency = 1459;
-	name = "Station Intercom (General)";
 	pixel_x = -29
 	},
 /obj/machinery/status_display{
@@ -25910,8 +25782,6 @@
 /area/security/checkpoint/customs)
 "bcZ" = (
 /obj/item/radio/intercom{
-	broadcasting = 0;
-	name = "Station Intercom (General)";
 	pixel_y = 20
 	},
 /obj/machinery/computer/security,
@@ -26218,7 +26088,6 @@
 	pixel_y = 5
 	},
 /obj/item/radio/intercom{
-	name = "Station Intercom (General)";
 	pixel_x = -27
 	},
 /obj/machinery/computer/security/telescreen/entertainment{
@@ -26429,9 +26298,6 @@
 	dir = 1
 	},
 /obj/item/radio/intercom{
-	freerange = 0;
-	frequency = 1459;
-	name = "Station Intercom (General)";
 	pixel_y = -28
 	},
 /turf/open/floor/plasteel/vault{
@@ -28273,9 +28139,6 @@
 /area/engine/break_room)
 "bia" = (
 /obj/item/radio/intercom{
-	freerange = 0;
-	frequency = 1459;
-	name = "Station Intercom (General)";
 	pixel_y = 21
 	},
 /obj/structure/disposalpipe/segment{
@@ -28636,7 +28499,6 @@
 	},
 /obj/machinery/light/small,
 /obj/item/radio/intercom{
-	name = "Station Intercom (General)";
 	pixel_y = -28
 	},
 /obj/vehicle/ridden/janicart,
@@ -29152,9 +29014,6 @@
 	dir = 4
 	},
 /obj/item/radio/intercom{
-	freerange = 0;
-	frequency = 1459;
-	name = "Station Intercom (General)";
 	pixel_y = 21
 	},
 /obj/machinery/light{
@@ -29248,9 +29107,6 @@
 "bkk" = (
 /obj/structure/filingcabinet/filingcabinet,
 /obj/item/radio/intercom{
-	broadcasting = 0;
-	listening = 1;
-	name = "Station Intercom (General)";
 	pixel_y = -28
 	},
 /obj/machinery/camera{
@@ -29367,9 +29223,6 @@
 	pixel_x = 28
 	},
 /obj/item/radio/intercom{
-	freerange = 0;
-	frequency = 1459;
-	name = "Station Intercom (General)";
 	pixel_y = -28
 	},
 /turf/open/floor/plasteel/brown{
@@ -29441,9 +29294,6 @@
 /obj/structure/table,
 /obj/item/toner,
 /obj/item/radio/intercom{
-	freerange = 0;
-	frequency = 1459;
-	name = "Station Intercom (General)";
 	pixel_x = 30
 	},
 /turf/open/floor/plasteel/brown{
@@ -29491,7 +29341,6 @@
 /area/bridge)
 "bkD" = (
 /obj/item/radio/intercom{
-	name = "Station Intercom (General)";
 	pixel_y = 29
 	},
 /obj/machinery/modular_computer/console/preset/engineering,
@@ -29707,7 +29556,6 @@
 	dir = 4
 	},
 /obj/item/radio/intercom{
-	name = "Station Intercom (General)";
 	pixel_y = -29
 	},
 /obj/machinery/light,
@@ -31163,9 +31011,6 @@
 	dir = 4
 	},
 /obj/item/radio/intercom{
-	freerange = 0;
-	frequency = 1459;
-	name = "Station Intercom (General)";
 	pixel_y = 21
 	},
 /turf/open/floor/plasteel/neutral/corner{
@@ -31442,7 +31287,6 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/item/radio/intercom{
 	dir = 8;
-	name = "Station Intercom (General)";
 	pixel_x = -28
 	},
 /obj/machinery/camera{
@@ -32382,9 +32226,6 @@
 	req_access_txt = "57"
 	},
 /obj/item/radio/intercom{
-	freerange = 0;
-	frequency = 1459;
-	name = "Station Intercom (General)";
 	pixel_y = 21
 	},
 /turf/open/floor/wood,
@@ -32480,9 +32321,6 @@
 /area/bridge)
 "bqP" = (
 /obj/item/radio/intercom{
-	freerange = 0;
-	frequency = 1459;
-	name = "Station Intercom (General)";
 	pixel_y = -29
 	},
 /obj/structure/rack,
@@ -32690,9 +32528,6 @@
 	dir = 4
 	},
 /obj/item/radio/intercom{
-	freerange = 0;
-	frequency = 1459;
-	name = "Station Intercom (General)";
 	pixel_y = -30
 	},
 /turf/open/floor/wood,
@@ -33055,7 +32890,6 @@
 "brW" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden,
 /obj/item/radio/intercom{
-	name = "Station Intercom (General)";
 	pixel_y = -28
 	},
 /turf/open/floor/plasteel/darkblue/corner{
@@ -33184,7 +33018,6 @@
 "bsh" = (
 /obj/structure/table,
 /obj/item/radio/intercom{
-	name = "Station Intercom (General)";
 	pixel_y = -28
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -33318,9 +33151,6 @@
 /area/hallway/primary/port)
 "bsw" = (
 /obj/item/radio/intercom{
-	broadcasting = 0;
-	listening = 1;
-	name = "Station Intercom (General)";
 	pixel_y = -28
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -33679,7 +33509,6 @@
 /obj/item/hand_tele,
 /obj/structure/window/reinforced,
 /obj/item/radio/intercom{
-	name = "Station Intercom (General)";
 	pixel_x = 27
 	},
 /turf/open/floor/wood,
@@ -33896,9 +33725,6 @@
 /area/engine/break_room)
 "btE" = (
 /obj/item/radio/intercom{
-	freerange = 0;
-	frequency = 1459;
-	name = "Station Intercom (General)";
 	pixel_y = -28
 	},
 /obj/structure/chair/office/dark{
@@ -34320,7 +34146,6 @@
 	icon_state = "1-2"
 	},
 /obj/item/radio/intercom{
-	name = "Station Intercom (General)";
 	pixel_x = -26
 	},
 /turf/open/floor/plasteel/darkblue/corner,
@@ -34526,9 +34351,7 @@
 /area/engine/storage_shared)
 "bvf" = (
 /obj/item/radio/intercom{
-	broadcasting = 0;
 	freerange = 1;
-	listening = 1;
 	name = "Common Channel";
 	pixel_x = -27;
 	pixel_y = -7
@@ -34542,7 +34365,6 @@
 	},
 /obj/item/radio/intercom{
 	anyai = 1;
-	broadcasting = 0;
 	freerange = 1;
 	frequency = 1447;
 	name = "Private Channel";
@@ -35156,7 +34978,6 @@
 	pixel_y = 3
 	},
 /obj/item/radio/intercom{
-	name = "Station Intercom (General)";
 	pixel_y = 28
 	},
 /turf/open/floor/plasteel/dark,
@@ -35443,9 +35264,6 @@
 /area/crew_quarters/bar)
 "bwU" = (
 /obj/item/radio/intercom{
-	freerange = 0;
-	frequency = 1459;
-	name = "Station Intercom (General)";
 	pixel_y = 21
 	},
 /obj/structure/cable/yellow{
@@ -35752,9 +35570,6 @@
 	dir = 4
 	},
 /obj/item/radio/intercom{
-	freerange = 0;
-	frequency = 1459;
-	name = "Station Intercom (General)";
 	pixel_y = -25
 	},
 /turf/open/floor/plasteel/arrival{
@@ -35995,7 +35810,6 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/item/radio/intercom{
-	name = "Station Intercom (General)";
 	pixel_x = -26
 	},
 /turf/open/floor/plasteel/darkblue/corner,
@@ -36310,9 +36124,6 @@
 /area/hallway/primary/starboard)
 "byR" = (
 /obj/item/radio/intercom{
-	freerange = 0;
-	frequency = 1459;
-	name = "Station Intercom (General)";
 	pixel_x = -30
 	},
 /obj/item/crowbar/red,
@@ -36768,9 +36579,6 @@
 /area/hallway/secondary/command)
 "bzM" = (
 /obj/item/radio/intercom{
-	freerange = 0;
-	frequency = 1459;
-	name = "Station Intercom (General)";
 	pixel_y = 21
 	},
 /obj/structure/sign/warning/electricshock{
@@ -36788,9 +36596,6 @@
 /area/hallway/secondary/command)
 "bzO" = (
 /obj/item/radio/intercom{
-	freerange = 0;
-	frequency = 1459;
-	name = "Station Intercom (General)";
 	pixel_y = 21
 	},
 /obj/effect/turf_decal/bot,
@@ -36941,7 +36746,6 @@
 /area/crew_quarters/heads/captain/private)
 "bAf" = (
 /obj/item/radio/intercom{
-	name = "Station Intercom (General)";
 	pixel_y = -26
 	},
 /turf/open/floor/carpet,
@@ -38214,9 +38018,6 @@
 	dir = 4
 	},
 /obj/item/radio/intercom{
-	freerange = 0;
-	frequency = 1459;
-	name = "Station Intercom (General)";
 	pixel_y = 21
 	},
 /turf/open/floor/plasteel/neutral/corner{
@@ -38336,9 +38137,6 @@
 	dir = 4
 	},
 /obj/item/radio/intercom{
-	freerange = 0;
-	frequency = 1459;
-	name = "Station Intercom (General)";
 	pixel_y = 21
 	},
 /obj/machinery/camera{
@@ -39794,8 +39592,7 @@
 /area/library)
 "bGv" = (
 /obj/item/radio/intercom{
-	dir = 4;
-	name = "Station Intercom (General)"
+	dir = 4
 	},
 /turf/closed/wall,
 /area/library)
@@ -40687,9 +40484,6 @@
 /area/crew_quarters/bar)
 "bIu" = (
 /obj/item/radio/intercom{
-	freerange = 0;
-	frequency = 1459;
-	name = "Station Intercom (General)";
 	pixel_y = -28
 	},
 /turf/open/floor/plasteel/bar,
@@ -41069,9 +40863,6 @@
 	dir = 4
 	},
 /obj/item/radio/intercom{
-	freerange = 0;
-	frequency = 1459;
-	name = "Station Intercom (General)";
 	pixel_x = -29
 	},
 /turf/open/floor/wood,
@@ -42309,9 +42100,6 @@
 "bMe" = (
 /obj/structure/reagent_dispensers/fueltank,
 /obj/item/radio/intercom{
-	freerange = 0;
-	frequency = 1459;
-	name = "Station Intercom (General)";
 	pixel_y = -26
 	},
 /obj/machinery/camera{
@@ -42470,9 +42258,6 @@
 	dir = 4
 	},
 /obj/item/radio/intercom{
-	freerange = 0;
-	frequency = 1459;
-	name = "Station Intercom (General)";
 	pixel_y = -25
 	},
 /obj/effect/turf_decal/stripes/line,
@@ -42809,9 +42594,6 @@
 	dir = 1
 	},
 /obj/item/radio/intercom{
-	freerange = 0;
-	frequency = 1459;
-	name = "Station Intercom (General)";
 	pixel_y = 21
 	},
 /turf/open/floor/wood,
@@ -42919,7 +42701,6 @@
 	dir = 4
 	},
 /obj/item/radio/intercom{
-	name = "Station Intercom (General)";
 	pixel_x = 29
 	},
 /obj/effect/turf_decal/bot{
@@ -42967,7 +42748,6 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/item/radio/intercom{
 	dir = 8;
-	name = "Station Intercom (General)";
 	pixel_x = -28
 	},
 /turf/open/floor/plasteel/neutral/corner{
@@ -44582,7 +44362,6 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/item/radio/intercom{
 	dir = 4;
-	name = "Station Intercom (General)";
 	pixel_x = 27
 	},
 /turf/open/floor/plasteel/neutral/corner{
@@ -45010,7 +44789,6 @@
 	dir = 4
 	},
 /obj/item/radio/intercom{
-	name = "Station Intercom (General)";
 	pixel_y = -29
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -45296,7 +45074,6 @@
 /obj/structure/disposalpipe/trunk,
 /obj/item/radio/intercom{
 	dir = 4;
-	name = "Station Intercom (General)";
 	pixel_x = 27
 	},
 /turf/open/floor/wood,
@@ -45807,9 +45584,6 @@
 	dir = 4
 	},
 /obj/item/radio/intercom{
-	freerange = 0;
-	frequency = 1459;
-	name = "Station Intercom (General)";
 	pixel_y = 21
 	},
 /obj/effect/turf_decal/stripes/corner{
@@ -45934,9 +45708,6 @@
 	dir = 4
 	},
 /obj/item/radio/intercom{
-	freerange = 0;
-	frequency = 1459;
-	name = "Station Intercom (General)";
 	pixel_y = 21
 	},
 /turf/open/floor/plasteel/neutral/corner{
@@ -46234,9 +46005,6 @@
 /area/engine/atmos)
 "bUC" = (
 /obj/item/radio/intercom{
-	freerange = 0;
-	frequency = 1459;
-	name = "Station Intercom (General)";
 	pixel_y = 28
 	},
 /obj/machinery/pipedispenser/disposal/transit_tube,
@@ -46831,7 +46599,6 @@
 	},
 /obj/item/radio/intercom{
 	dir = 4;
-	name = "Station Intercom (General)";
 	pixel_x = 27
 	},
 /turf/open/floor/plating,
@@ -47935,7 +47702,6 @@
 /obj/item/radio/off,
 /obj/item/radio/off,
 /obj/item/radio/intercom{
-	name = "Station Intercom (General)";
 	pixel_x = 27
 	},
 /turf/open/floor/plasteel/vault{
@@ -48151,7 +47917,6 @@
 /obj/item/clothing/neck/stethoscope,
 /obj/item/radio/intercom{
 	broadcasting = 1;
-	freerange = 0;
 	frequency = 1485;
 	listening = 0;
 	name = "Station Intercom (Medbay)";
@@ -48474,9 +48239,6 @@
 	dir = 5
 	},
 /obj/item/radio/intercom{
-	freerange = 0;
-	frequency = 1459;
-	name = "Station Intercom (General)";
 	pixel_x = -30
 	},
 /turf/open/floor/plasteel/caution{
@@ -49618,7 +49380,6 @@
 	pixel_y = -29
 	},
 /obj/item/radio/intercom{
-	name = "Station Intercom (General)";
 	pixel_x = -27;
 	pixel_y = -10
 	},
@@ -49811,7 +49572,6 @@
 	},
 /obj/structure/table/wood,
 /obj/item/radio/intercom{
-	name = "Station Intercom (General)";
 	pixel_y = -29
 	},
 /turf/open/floor/wood,
@@ -49865,7 +49625,6 @@
 "ccu" = (
 /obj/machinery/hydroponics/constructable,
 /obj/item/radio/intercom{
-	name = "Station Intercom (General)";
 	pixel_y = -29
 	},
 /obj/effect/turf_decal/stripes/line{
@@ -50825,8 +50584,6 @@
 "ceF" = (
 /obj/structure/bed/roller,
 /obj/item/radio/intercom{
-	broadcasting = 0;
-	freerange = 0;
 	frequency = 1485;
 	listening = 1;
 	name = "Station Intercom (Medbay)";
@@ -50927,9 +50684,6 @@
 /area/science/research)
 "ceS" = (
 /obj/item/radio/intercom{
-	freerange = 0;
-	frequency = 1459;
-	name = "Station Intercom (General)";
 	pixel_y = -30
 	},
 /obj/item/twohanded/required/kirbyplants{
@@ -50982,7 +50736,6 @@
 "ceX" = (
 /obj/item/radio/intercom{
 	dir = 4;
-	name = "Station Intercom (General)";
 	pixel_x = 27
 	},
 /obj/machinery/light{
@@ -52209,7 +51962,6 @@
 /obj/structure/reagent_dispensers/fueltank,
 /obj/item/storage/toolbox/emergency,
 /obj/item/radio/intercom{
-	name = "Station Intercom (General)";
 	pixel_y = -29
 	},
 /turf/open/floor/plasteel/floorgrime,
@@ -52995,7 +52747,6 @@
 /obj/structure/bed/roller,
 /obj/item/radio/intercom{
 	broadcasting = 1;
-	freerange = 0;
 	frequency = 1485;
 	listening = 0;
 	name = "Station Intercom (Medbay)";
@@ -53383,9 +53134,6 @@
 "ckq" = (
 /obj/machinery/vending/coffee,
 /obj/item/radio/intercom{
-	freerange = 0;
-	frequency = 1459;
-	name = "Station Intercom (General)";
 	pixel_x = 29
 	},
 /turf/open/floor/plasteel/white/side{
@@ -53713,7 +53461,6 @@
 "clm" = (
 /obj/item/radio/intercom{
 	broadcasting = 1;
-	freerange = 0;
 	frequency = 1485;
 	listening = 0;
 	name = "Station Intercom (Medbay)";
@@ -53932,7 +53679,6 @@
 	},
 /obj/item/radio/intercom{
 	dir = 8;
-	name = "Station Intercom (General)";
 	pixel_y = -28
 	},
 /obj/effect/turf_decal/stripes/line{
@@ -54334,7 +54080,6 @@
 "cmF" = (
 /obj/item/radio/intercom{
 	dir = 8;
-	name = "Station Intercom (General)";
 	pixel_x = -28
 	},
 /obj/machinery/light{
@@ -54695,7 +54440,6 @@
 /obj/structure/table/reinforced,
 /obj/item/radio/intercom{
 	broadcasting = 1;
-	freerange = 0;
 	frequency = 1485;
 	listening = 0;
 	name = "Station Intercom (Medbay)";
@@ -54883,7 +54627,6 @@
 "cnH" = (
 /obj/item/radio/intercom{
 	dir = 8;
-	name = "Station Intercom (General)";
 	pixel_x = -28
 	},
 /obj/structure/table/glass,
@@ -55126,9 +54869,6 @@
 /area/science/research)
 "cog" = (
 /obj/item/radio/intercom{
-	broadcasting = 0;
-	listening = 1;
-	name = "Station Intercom (General)";
 	pixel_y = 20
 	},
 /turf/open/floor/plasteel/whitepurple/corner{
@@ -56566,7 +56306,6 @@
 	dir = 4
 	},
 /obj/item/radio/intercom{
-	name = "Station Intercom (General)";
 	pixel_y = -29
 	},
 /obj/machinery/camera{
@@ -56775,7 +56514,6 @@
 	},
 /obj/item/radio/intercom{
 	broadcasting = 1;
-	freerange = 0;
 	frequency = 1485;
 	listening = 0;
 	name = "Station Intercom (Medbay)";
@@ -56910,9 +56648,6 @@
 "crF" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/item/radio/intercom{
-	freerange = 0;
-	frequency = 1459;
-	name = "Station Intercom (General)";
 	pixel_x = -29
 	},
 /turf/open/floor/plasteel/yellow/corner{
@@ -57199,7 +56934,6 @@
 "csn" = (
 /obj/item/radio/intercom{
 	broadcasting = 1;
-	freerange = 0;
 	frequency = 1485;
 	listening = 0;
 	name = "Station Intercom (Medbay)";
@@ -57398,7 +57132,6 @@
 	},
 /obj/item/radio/intercom{
 	dir = 1;
-	name = "Station Intercom (General)";
 	pixel_y = -29
 	},
 /obj/machinery/computer/card/minor/cmo{
@@ -58300,9 +58033,6 @@
 	},
 /obj/item/storage/box/bodybags,
 /obj/item/radio/intercom{
-	freerange = 0;
-	frequency = 1459;
-	name = "Station Intercom (General)";
 	pixel_x = -29
 	},
 /obj/structure/table/glass,
@@ -58792,9 +58522,6 @@
 	pixel_y = 2
 	},
 /obj/item/radio/intercom{
-	freerange = 0;
-	frequency = 1459;
-	name = "Station Intercom (General)";
 	pixel_x = 29
 	},
 /obj/structure/window/reinforced,
@@ -59077,9 +58804,6 @@
 "cvY" = (
 /obj/machinery/portable_atmospherics/canister/toxins,
 /obj/item/radio/intercom{
-	freerange = 0;
-	frequency = 1459;
-	name = "Station Intercom (General)";
 	pixel_x = 29
 	},
 /obj/effect/turf_decal/delivery,
@@ -59338,9 +59062,6 @@
 	pixel_y = 2
 	},
 /obj/item/radio/intercom{
-	freerange = 0;
-	frequency = 1459;
-	name = "Station Intercom (General)";
 	pixel_x = -29
 	},
 /obj/machinery/camera{
@@ -59404,9 +59125,6 @@
 "cwJ" = (
 /obj/machinery/computer/mech_bay_power_console,
 /obj/item/radio/intercom{
-	broadcasting = 0;
-	listening = 1;
-	name = "Station Intercom (General)";
 	pixel_y = 20
 	},
 /obj/structure/cable/yellow{
@@ -59537,7 +59255,6 @@
 	pixel_x = 24
 	},
 /obj/item/radio/intercom{
-	name = "Station Intercom (General)";
 	pixel_y = -29
 	},
 /turf/open/floor/plasteel/cafeteria{
@@ -59884,9 +59601,6 @@
 /area/science/nanite)
 "cxJ" = (
 /obj/item/radio/intercom{
-	freerange = 0;
-	frequency = 1459;
-	name = "Station Intercom (General)";
 	pixel_x = 29
 	},
 /obj/structure/sink{
@@ -60538,9 +60252,6 @@
 "czf" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/item/radio/intercom{
-	freerange = 0;
-	frequency = 1459;
-	name = "Station Intercom (General)";
 	pixel_x = -26
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -60615,9 +60326,6 @@
 	pixel_y = 4
 	},
 /obj/item/radio/intercom{
-	freerange = 0;
-	frequency = 1459;
-	name = "Station Intercom (General)";
 	pixel_x = -29
 	},
 /obj/machinery/camera{
@@ -61377,7 +61085,6 @@
 /obj/structure/chair/stool,
 /obj/item/radio/intercom{
 	broadcasting = 1;
-	freerange = 0;
 	frequency = 1485;
 	listening = 0;
 	name = "Station Intercom (Medbay)";
@@ -61449,7 +61156,6 @@
 /obj/structure/disposalpipe/segment,
 /obj/item/radio/intercom{
 	broadcasting = 1;
-	freerange = 0;
 	frequency = 1485;
 	listening = 0;
 	name = "Station Intercom (Medbay)";
@@ -61919,9 +61625,6 @@
 "cCm" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/item/radio/intercom{
-	freerange = 0;
-	frequency = 1459;
-	name = "Station Intercom (General)";
 	pixel_x = 29
 	},
 /turf/open/floor/plasteel/purple/corner{
@@ -62043,9 +61746,6 @@
 "cCx" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/item/radio/intercom{
-	broadcasting = 0;
-	listening = 1;
-	name = "Station Intercom (General)";
 	pixel_y = -28
 	},
 /obj/structure/tank_dispenser,
@@ -62313,9 +62013,6 @@
 /obj/item/storage/box/bodybags,
 /obj/item/pen,
 /obj/item/radio/intercom{
-	freerange = 0;
-	frequency = 1459;
-	name = "Station Intercom (General)";
 	pixel_x = 29
 	},
 /turf/open/floor/plasteel/dark,
@@ -62360,9 +62057,6 @@
 	dir = 2
 	},
 /obj/item/radio/intercom{
-	broadcasting = 0;
-	listening = 1;
-	name = "Station Intercom (General)";
 	pixel_y = 20
 	},
 /obj/machinery/light/small{
@@ -63738,9 +63432,6 @@
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/item/radio/intercom{
-	freerange = 0;
-	frequency = 1459;
-	name = "Station Intercom (General)";
 	pixel_x = 29
 	},
 /turf/open/floor/plasteel/whitegreen/side{
@@ -65434,9 +65125,6 @@
 	dir = 9
 	},
 /obj/item/radio/intercom{
-	freerange = 0;
-	frequency = 1459;
-	name = "Station Intercom (General)";
 	pixel_x = 29
 	},
 /obj/machinery/light{
@@ -65787,9 +65475,6 @@
 /obj/item/retractor,
 /obj/item/hemostat,
 /obj/item/radio/intercom{
-	freerange = 0;
-	frequency = 1459;
-	name = "Station Intercom (General)";
 	pixel_x = -29
 	},
 /turf/open/floor/plasteel/white/corner{
@@ -65904,9 +65589,6 @@
 /area/science/server)
 "cJS" = (
 /obj/item/radio/intercom{
-	broadcasting = 0;
-	listening = 1;
-	name = "Station Intercom (General)";
 	pixel_y = -28
 	},
 /obj/machinery/computer/rdservercontrol{
@@ -66085,9 +65767,6 @@
 /area/medical/virology)
 "cKm" = (
 /obj/item/radio/intercom{
-	freerange = 0;
-	frequency = 1459;
-	name = "Station Intercom (General)";
 	pixel_x = 29
 	},
 /obj/structure/table/glass,
@@ -67205,7 +66884,6 @@
 	},
 /obj/item/radio/intercom{
 	dir = 4;
-	name = "Station Intercom (General)";
 	pixel_x = -27
 	},
 /turf/open/floor/plasteel/dark,
@@ -68167,9 +67845,6 @@
 	pixel_x = 4
 	},
 /obj/item/radio/intercom{
-	broadcasting = 0;
-	listening = 1;
-	name = "Station Intercom (General)";
 	pixel_y = -32
 	},
 /turf/open/floor/plasteel/red/side{
@@ -68769,9 +68444,6 @@
 	dir = 4
 	},
 /obj/item/radio/intercom{
-	freerange = 0;
-	frequency = 1459;
-	name = "Station Intercom (General)";
 	pixel_x = 29
 	},
 /obj/item/twohanded/required/kirbyplants{
@@ -68844,9 +68516,6 @@
 /area/chapel/main)
 "cQc" = (
 /obj/item/radio/intercom{
-	freerange = 0;
-	frequency = 1459;
-	name = "Station Intercom (General)";
 	pixel_y = 21
 	},
 /obj/machinery/light/small{
@@ -69035,9 +68704,6 @@
 	dir = 4
 	},
 /obj/item/radio/intercom{
-	broadcasting = 0;
-	listening = 1;
-	name = "Station Intercom (General)";
 	pixel_y = 22
 	},
 /obj/effect/turf_decal/bot{
@@ -69172,9 +68838,6 @@
 /area/science/xenobiology)
 "cQS" = (
 /obj/item/radio/intercom{
-	freerange = 0;
-	frequency = 1459;
-	name = "Station Intercom (General)";
 	pixel_x = 29
 	},
 /obj/machinery/door/poddoor/preopen{
@@ -70509,7 +70172,6 @@
 	},
 /obj/item/radio/intercom{
 	dir = 4;
-	name = "Station Intercom (General)";
 	pixel_x = 27
 	},
 /turf/open/floor/wood,
@@ -70519,9 +70181,6 @@
 	dir = 8
 	},
 /obj/item/radio/intercom{
-	freerange = 1;
-	frequency = 1459;
-	name = "Station Intercom (General)";
 	pixel_x = -30
 	},
 /turf/open/floor/plasteel/neutral/corner{
@@ -70772,9 +70431,6 @@
 /area/science/xenobiology)
 "cZc" = (
 /obj/item/radio/intercom{
-	freerange = 0;
-	frequency = 1459;
-	name = "Station Intercom (General)";
 	pixel_x = 29
 	},
 /turf/open/floor/plasteel/chapel,
@@ -71484,9 +71140,6 @@
 	dir = 4
 	},
 /obj/item/radio/intercom{
-	freerange = 0;
-	frequency = 1459;
-	name = "Station Intercom (General)";
 	pixel_x = -29
 	},
 /obj/effect/turf_decal/stripes/line{
@@ -71819,7 +71472,6 @@
 "dcM" = (
 /obj/machinery/chem_master,
 /obj/item/radio/intercom{
-	name = "Station Intercom (General)";
 	pixel_y = -29
 	},
 /turf/open/floor/plasteel/whitepurple/side,
@@ -72087,7 +71739,6 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/general/visible,
 /obj/item/radio/intercom{
-	name = "Station Intercom (General)";
 	pixel_y = -29
 	},
 /obj/structure/cable/yellow{
@@ -72471,9 +72122,6 @@
 /area/engine/engineering)
 "deq" = (
 /obj/item/radio/intercom{
-	freerange = 0;
-	frequency = 1459;
-	name = "Station Intercom (General)";
 	pixel_y = 21
 	},
 /turf/open/floor/plasteel/dark,
@@ -73574,9 +73222,6 @@
 /area/storage/primary)
 "dhM" = (
 /obj/item/radio/intercom{
-	freerange = 0;
-	frequency = 1459;
-	name = "Station Intercom (General)";
 	pixel_y = 21
 	},
 /obj/structure/sign/poster/official/random{
@@ -73783,9 +73428,6 @@
 /obj/item/instrument/violin,
 /obj/structure/table/wood,
 /obj/item/radio/intercom{
-	freerange = 0;
-	frequency = 1459;
-	name = "Station Intercom (General)";
 	pixel_x = 29
 	},
 /obj/structure/sign/poster/random{
@@ -77000,7 +76642,6 @@
 /obj/item/camera,
 /obj/structure/table/wood,
 /obj/item/radio/intercom{
-	name = "Station Intercom (General)";
 	pixel_y = -29
 	},
 /turf/open/floor/engine/cult,

--- a/_maps/map_files/PubbyStation/PubbyStation.dmm
+++ b/_maps/map_files/PubbyStation/PubbyStation.dmm
@@ -53682,6 +53682,18 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plating,
 /area/maintenance/department/security/brig)
+"vFZ" = (
+/obj/structure/chair/wood/normal{
+	dir = 1
+	},
+/obj/item/radio/intercom{
+	broadcasting = 1;
+	frequency = 1480;
+	name = "Confessional Intercom";
+	pixel_x = 26
+	},
+/turf/open/floor/plasteel/dark,
+/area/chapel/main/monastery)
 "vGg" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 9
@@ -53834,6 +53846,16 @@
 /mob/living/simple_animal/hostile/retaliate/poison/snake,
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
+"whH" = (
+/obj/structure/chair/wood/normal,
+/obj/item/radio/intercom{
+	broadcasting = 1;
+	frequency = 1480;
+	name = "Confessional Intercom";
+	pixel_x = -26
+	},
+/turf/open/floor/plasteel/dark,
+/area/chapel/main/monastery)
 "wig" = (
 /obj/machinery/vending/cigarette,
 /turf/open/floor/plating{
@@ -70196,9 +70218,9 @@ bOw
 bOw
 bUC
 bWV
-cdC
+whH
 caT
-cbK
+vFZ
 bWV
 cds
 csO

--- a/_maps/map_files/PubbyStation/PubbyStation.dmm
+++ b/_maps/map_files/PubbyStation/PubbyStation.dmm
@@ -109,7 +109,6 @@
 /obj/effect/landmark/start/ai/secondary,
 /obj/item/radio/intercom{
 	anyai = 1;
-	broadcasting = 0;
 	freerange = 1;
 	frequency = 1447;
 	name = "Private Channel";
@@ -157,7 +156,6 @@
 /obj/effect/landmark/start/ai/secondary,
 /obj/item/radio/intercom{
 	anyai = 1;
-	broadcasting = 0;
 	freerange = 1;
 	frequency = 1447;
 	name = "Private Channel";
@@ -280,9 +278,7 @@
 "acy" = (
 /obj/effect/landmark/start/ai,
 /obj/item/radio/intercom{
-	broadcasting = 0;
 	freerange = 1;
-	listening = 1;
 	name = "Common Channel";
 	pixel_x = -27;
 	pixel_y = -9
@@ -296,7 +292,6 @@
 	},
 /obj/item/radio/intercom{
 	anyai = 1;
-	broadcasting = 0;
 	freerange = 1;
 	frequency = 1447;
 	name = "Private Channel";
@@ -1653,7 +1648,6 @@
 /area/ai_monitored/turret_protected/aisat_interior)
 "agg" = (
 /obj/item/radio/intercom{
-	name = "Station Intercom (General)";
 	pixel_y = -28
 	},
 /turf/open/floor/plasteel/darkblue/side{
@@ -2067,9 +2061,6 @@
 /area/security/execution/transfer)
 "ahl" = (
 /obj/item/radio/intercom{
-	freerange = 0;
-	frequency = 1459;
-	name = "Station Intercom (General)";
 	pixel_x = 28
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -3445,7 +3436,6 @@
 /obj/machinery/washing_machine,
 /obj/item/radio/intercom{
 	dir = 4;
-	name = "Station Intercom (General)";
 	pixel_x = -31
 	},
 /turf/open/floor/plating,
@@ -3493,7 +3483,6 @@
 "akx" = (
 /obj/structure/bodycontainer/crematorium,
 /obj/item/radio/intercom{
-	name = "Station Intercom (General)";
 	pixel_x = -27
 	},
 /turf/open/floor/plasteel/dark,
@@ -3550,9 +3539,6 @@
 /area/security/brig)
 "akD" = (
 /obj/item/radio/intercom{
-	freerange = 0;
-	frequency = 1459;
-	name = "Station Intercom (General)";
 	pixel_y = 24
 	},
 /obj/structure/table/glass,
@@ -4240,7 +4226,6 @@
 	},
 /obj/item/radio/intercom{
 	dir = 4;
-	name = "Station Intercom (General)";
 	pixel_x = -31
 	},
 /turf/open/floor/plasteel/red/side{
@@ -4564,7 +4549,6 @@
 	},
 /obj/item/radio/intercom{
 	dir = 4;
-	name = "Station Intercom (General)";
 	pixel_y = 24
 	},
 /turf/open/floor/plasteel/showroomfloor,
@@ -4957,7 +4941,6 @@
 	},
 /obj/item/radio/intercom{
 	dir = 4;
-	name = "Station Intercom (General)";
 	pixel_y = -27
 	},
 /turf/open/floor/plasteel/darkred/side{
@@ -5889,7 +5872,6 @@
 	dir = 1
 	},
 /obj/item/radio/intercom{
-	name = "Station Intercom (General)";
 	pixel_y = 29
 	},
 /turf/open/floor/plasteel/red/side{
@@ -7338,9 +7320,6 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/item/radio/intercom{
-	freerange = 0;
-	frequency = 1459;
-	name = "Station Intercom (General)";
 	pixel_x = -30
 	},
 /turf/open/floor/plasteel,
@@ -8031,7 +8010,6 @@
 	dir = 4
 	},
 /obj/item/radio/intercom{
-	name = "Station Intercom (General)";
 	pixel_y = -28
 	},
 /turf/open/floor/plasteel/vault,
@@ -8892,7 +8870,6 @@
 "axU" = (
 /obj/machinery/computer/card,
 /obj/item/radio/intercom{
-	name = "Station Intercom (General)";
 	pixel_y = 26
 	},
 /turf/open/floor/carpet,
@@ -9372,7 +9349,6 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden,
 /obj/item/radio/intercom{
-	name = "Station Intercom (General)";
 	pixel_y = -28
 	},
 /turf/open/floor/plasteel/dark,
@@ -9468,7 +9444,6 @@
 	dir = 4
 	},
 /obj/item/radio/intercom{
-	name = "Station Intercom (General)";
 	pixel_y = -28
 	},
 /turf/open/floor/plasteel/dark,
@@ -10493,7 +10468,6 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/item/radio/intercom{
-	name = "Station Intercom (General)";
 	pixel_x = 28
 	},
 /turf/open/floor/plasteel,
@@ -10648,7 +10622,6 @@
 /obj/machinery/cell_charger,
 /obj/item/stock_parts/cell/high/plus,
 /obj/item/radio/intercom{
-	name = "Station Intercom (General)";
 	pixel_y = 26
 	},
 /obj/item/screwdriver{
@@ -11038,7 +11011,6 @@
 	dir = 4
 	},
 /obj/item/radio/intercom{
-	name = "Station Intercom (General)";
 	pixel_y = -26
 	},
 /turf/open/floor/plasteel,
@@ -11826,7 +11798,6 @@
 	pixel_y = 4
 	},
 /obj/item/radio/intercom{
-	name = "Station Intercom (General)";
 	pixel_x = 27
 	},
 /obj/item/paper_bin{
@@ -11841,7 +11812,6 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/item/radio/intercom{
-	name = "Station Intercom (General)";
 	pixel_x = -27
 	},
 /turf/open/floor/plasteel,
@@ -14415,7 +14385,6 @@
 "aMf" = (
 /obj/machinery/computer/secure_data,
 /obj/item/radio/intercom{
-	name = "Station Intercom (General)";
 	pixel_y = 26
 	},
 /turf/open/floor/plasteel/red/side{
@@ -14802,7 +14771,6 @@
 	dir = 1
 	},
 /obj/item/radio/intercom{
-	name = "Station Intercom (General)";
 	pixel_y = -28
 	},
 /turf/open/floor/plasteel/cafeteria,
@@ -14895,7 +14863,6 @@
 	},
 /obj/item/clothing/shoes/magboots,
 /obj/item/radio/intercom{
-	name = "Station Intercom (General)";
 	pixel_x = -27
 	},
 /obj/effect/turf_decal/stripes/line{
@@ -14944,7 +14911,6 @@
 /obj/structure/closet/crate,
 /obj/item/melee/flyswatter,
 /obj/item/radio/intercom{
-	name = "Station Intercom (General)";
 	pixel_x = -27
 	},
 /obj/effect/turf_decal/stripes/line,
@@ -15639,7 +15605,6 @@
 	dir = 4
 	},
 /obj/item/radio/intercom{
-	name = "Station Intercom (General)";
 	pixel_x = 27
 	},
 /obj/machinery/camera{
@@ -18047,7 +18012,6 @@
 	req_access_txt = "25"
 	},
 /obj/item/radio/intercom{
-	name = "Station Intercom (General)";
 	pixel_y = 26
 	},
 /turf/open/floor/plasteel/dark,
@@ -18452,7 +18416,6 @@
 	icon_state = "2-8"
 	},
 /obj/item/radio/intercom{
-	name = "Station Intercom (General)";
 	pixel_y = 26
 	},
 /turf/open/floor/plasteel/dark,
@@ -18519,7 +18482,6 @@
 	dir = 4
 	},
 /obj/item/radio/intercom{
-	name = "Station Intercom (General)";
 	pixel_y = 26
 	},
 /turf/open/floor/plasteel/redblue,
@@ -18666,7 +18628,6 @@
 	dir = 1
 	},
 /obj/item/radio/intercom{
-	name = "Station Intercom (General)";
 	pixel_y = 26
 	},
 /obj/machinery/light/small{
@@ -19108,7 +19069,6 @@
 "aXX" = (
 /obj/machinery/hydroponics/constructable,
 /obj/item/radio/intercom{
-	name = "Station Intercom (General)";
 	pixel_y = 26
 	},
 /turf/open/floor/plasteel/green/side{
@@ -19430,7 +19390,6 @@
 "aYK" = (
 /obj/structure/closet/secure_closet/security,
 /obj/item/radio/intercom{
-	name = "Station Intercom (General)";
 	pixel_y = 26
 	},
 /turf/open/floor/plasteel/red/side{
@@ -19496,7 +19455,6 @@
 "aYU" = (
 /obj/machinery/processor,
 /obj/item/radio/intercom{
-	name = "Station Intercom (General)";
 	pixel_y = 26
 	},
 /turf/open/floor/plasteel/cafeteria,
@@ -19785,7 +19743,6 @@
 	dir = 4
 	},
 /obj/item/radio/intercom{
-	name = "Station Intercom (General)";
 	pixel_y = 26
 	},
 /turf/open/floor/plasteel/arrival{
@@ -20039,7 +19996,6 @@
 "bao" = (
 /obj/machinery/computer/slot_machine,
 /obj/item/radio/intercom{
-	name = "Station Intercom (General)";
 	pixel_y = 26
 	},
 /turf/open/floor/carpet{
@@ -20077,7 +20033,6 @@
 /obj/structure/table,
 /obj/item/pen,
 /obj/item/radio/intercom{
-	name = "Station Intercom (General)";
 	pixel_y = -26
 	},
 /obj/item/paper_bin{
@@ -20182,7 +20137,6 @@
 	dir = 4
 	},
 /obj/item/radio/intercom{
-	name = "Station Intercom (General)";
 	pixel_y = -26
 	},
 /turf/open/floor/plasteel,
@@ -22052,7 +22006,6 @@
 /area/quartermaster/qm)
 "bfD" = (
 /obj/item/radio/intercom{
-	name = "Station Intercom (General)";
 	pixel_y = -35
 	},
 /obj/machinery/computer/security/qm{
@@ -22224,7 +22177,6 @@
 	name = "Throne of Custodia"
 	},
 /obj/item/radio/intercom{
-	name = "Station Intercom (General)";
 	pixel_y = 26
 	},
 /turf/open/floor/plasteel/purple/corner{
@@ -23558,7 +23510,6 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/item/radio/intercom{
-	name = "Station Intercom (General)";
 	pixel_y = 26
 	},
 /turf/open/floor/plasteel/red/side{
@@ -25193,10 +25144,7 @@
 	pixel_x = -32
 	},
 /obj/item/radio/intercom{
-	broadcasting = 0;
-	freerange = 0;
 	frequency = 1485;
-	listening = 1;
 	name = "Station Intercom (Medbay)";
 	pixel_y = 26
 	},
@@ -25516,10 +25464,7 @@
 "bpy" = (
 /obj/machinery/clonepod,
 /obj/item/radio/intercom{
-	broadcasting = 0;
-	freerange = 0;
 	frequency = 1485;
-	listening = 1;
 	name = "Station Intercom (Medbay)";
 	pixel_x = -30
 	},
@@ -25820,7 +25765,6 @@
 /obj/item/storage/belt/utility,
 /obj/item/reagent_containers/glass/beaker/large,
 /obj/item/radio/intercom{
-	name = "Station Intercom (General)";
 	pixel_x = -27
 	},
 /obj/item/radio/headset/headset_sci{
@@ -26851,10 +26795,7 @@
 /obj/machinery/portable_atmospherics/canister/oxygen,
 /obj/machinery/atmospherics/components/unary/portables_connector/visible,
 /obj/item/radio/intercom{
-	broadcasting = 0;
-	freerange = 0;
 	frequency = 1485;
-	listening = 1;
 	name = "Station Intercom (Medbay)";
 	pixel_x = 28
 	},
@@ -30566,7 +30507,6 @@
 /area/science/mixing)
 "bBP" = (
 /obj/item/radio/intercom{
-	name = "Station Intercom (General)";
 	pixel_y = 26
 	},
 /obj/machinery/portable_atmospherics/canister,
@@ -30652,7 +30592,6 @@
 /obj/structure/table,
 /obj/item/pen,
 /obj/item/radio/intercom{
-	name = "Station Intercom (General)";
 	pixel_x = -27
 	},
 /obj/item/paper_bin{
@@ -31945,7 +31884,6 @@
 	dir = 4
 	},
 /obj/item/radio/intercom{
-	name = "Station Intercom (General)";
 	pixel_y = -26
 	},
 /obj/machinery/light_switch{
@@ -32826,10 +32764,7 @@
 	dir = 4
 	},
 /obj/item/radio/intercom{
-	broadcasting = 0;
-	freerange = 0;
 	frequency = 1485;
-	listening = 1;
 	name = "Station Intercom (Medbay)";
 	pixel_x = -28
 	},
@@ -33253,10 +33188,7 @@
 "bIb" = (
 /obj/machinery/atmospherics/pipe/simple/cyan/hidden,
 /obj/item/radio/intercom{
-	broadcasting = 0;
-	freerange = 0;
 	frequency = 1485;
-	listening = 1;
 	name = "Station Intercom (Medbay)";
 	pixel_x = 28
 	},
@@ -33355,10 +33287,7 @@
 	dir = 4
 	},
 /obj/item/radio/intercom{
-	broadcasting = 0;
-	freerange = 0;
 	frequency = 1485;
-	listening = 1;
 	name = "Station Intercom (Medbay)";
 	pixel_x = 28
 	},
@@ -34436,7 +34365,6 @@
 	dir = 4
 	},
 /obj/item/radio/intercom{
-	name = "Station Intercom (General)";
 	pixel_y = 26
 	},
 /obj/structure/cable{
@@ -35381,7 +35309,6 @@
 	dir = 1
 	},
 /obj/item/radio/intercom{
-	name = "Station Intercom (General)";
 	pixel_x = 27
 	},
 /obj/machinery/light/small,
@@ -36745,7 +36672,6 @@
 	dir = 4
 	},
 /obj/item/radio/intercom{
-	name = "Station Intercom (General)";
 	pixel_y = 26
 	},
 /obj/effect/turf_decal/stripes/line{
@@ -37903,7 +37829,6 @@
 	dir = 4
 	},
 /obj/item/radio/intercom{
-	name = "Station Intercom (General)";
 	pixel_x = 30;
 	pixel_y = 26
 	},
@@ -38100,7 +38025,6 @@
 	dir = 6
 	},
 /obj/item/radio/intercom{
-	name = "Station Intercom (General)";
 	pixel_y = 24
 	},
 /obj/effect/turf_decal/stripes/line{
@@ -40010,7 +39934,6 @@
 	dir = 4
 	},
 /obj/item/radio/intercom{
-	name = "Station Intercom (General)";
 	pixel_y = 26
 	},
 /turf/open/floor/plasteel/yellow/side{
@@ -40182,7 +40105,6 @@
 	dir = 1
 	},
 /obj/item/radio/intercom{
-	name = "Station Intercom (General)";
 	pixel_y = 26
 	},
 /obj/item/storage/belt/utility,
@@ -42590,7 +42512,6 @@
 	},
 /obj/effect/decal/cleanable/cobweb,
 /obj/item/radio/intercom{
-	name = "Station Intercom (General)";
 	pixel_y = 26
 	},
 /turf/open/floor/plasteel/hydrofloor,
@@ -43065,7 +42986,6 @@
 	icon_state = "plant-22"
 	},
 /obj/item/radio/intercom{
-	name = "Station Intercom (General)";
 	pixel_y = 26
 	},
 /turf/open/floor/plasteel/dark,
@@ -44152,7 +44072,6 @@
 	dir = 2
 	},
 /obj/item/radio/intercom{
-	name = "Station Intercom (General)";
 	pixel_y = 29
 	},
 /obj/effect/turf_decal/delivery,
@@ -45185,7 +45104,6 @@
 /area/chapel/main/monastery)
 "csn" = (
 /obj/item/radio/intercom{
-	name = "Station Intercom (General)";
 	pixel_y = 26
 	},
 /obj/machinery/requests_console{
@@ -48453,7 +48371,6 @@
 /area/maintenance/department/crew_quarters/dorms)
 "gnq" = (
 /obj/item/radio/intercom{
-	name = "Station Intercom (General)";
 	pixel_x = -27
 	},
 /obj/effect/turf_decal/stripes/corner{
@@ -48575,7 +48492,6 @@
 /obj/structure/window/reinforced,
 /obj/structure/table/glass,
 /obj/item/radio/intercom{
-	name = "Station Intercom (General)";
 	pixel_x = -28;
 	pixel_y = 3
 	},
@@ -49147,7 +49063,6 @@
 	light_color = "#e8eaff"
 	},
 /obj/item/radio/intercom{
-	name = "Station Intercom (General)";
 	pixel_y = -28
 	},
 /turf/open/floor/plasteel/white,
@@ -50346,7 +50261,6 @@
 /area/maintenance/department/science)
 "lWH" = (
 /obj/item/radio/intercom{
-	name = "Station Intercom (General)";
 	pixel_x = -28
 	},
 /obj/structure/rack,
@@ -50966,7 +50880,6 @@
 	dir = 4
 	},
 /obj/item/radio/intercom{
-	name = "Station Intercom (General)";
 	pixel_y = 26
 	},
 /obj/machinery/camera/motion{
@@ -51758,7 +51671,6 @@
 "pSc" = (
 /obj/machinery/chem_heater,
 /obj/item/radio/intercom{
-	name = "Station Intercom (General)";
 	pixel_x = 29
 	},
 /turf/open/floor/plasteel/whiteyellow/side{
@@ -54156,7 +54068,6 @@
 /obj/item/folder/red,
 /obj/item/clothing/glasses/sunglasses,
 /obj/item/radio/intercom{
-	name = "Station Intercom (General)";
 	pixel_x = 27
 	},
 /obj/machinery/camera{
@@ -54301,7 +54212,6 @@
 /area/maintenance/department/engine)
 "xjK" = (
 /obj/item/radio/intercom{
-	name = "Station Intercom (General)";
 	pixel_x = -27
 	},
 /obj/structure/rack,

--- a/_maps/map_files/PubbyStation/PubbyStation.dmm
+++ b/_maps/map_files/PubbyStation/PubbyStation.dmm
@@ -53688,7 +53688,7 @@
 	},
 /obj/item/radio/intercom{
 	broadcasting = 1;
-	frequency = 1480;
+	frequency = 1481;
 	name = "Confessional Intercom";
 	pixel_x = 26
 	},
@@ -53850,7 +53850,7 @@
 /obj/structure/chair/wood/normal,
 /obj/item/radio/intercom{
 	broadcasting = 1;
-	frequency = 1480;
+	frequency = 1481;
 	name = "Confessional Intercom";
 	pixel_x = -26
 	},

--- a/code/game/objects/items/devices/radio/intercom.dm
+++ b/code/game/objects/items/devices/radio/intercom.dm
@@ -1,5 +1,5 @@
 /obj/item/radio/intercom
-	name = "station intercom"
+	name = "Station Intercom (General)"
 	desc = "Talk through this."
 	icon_state = "intercom"
 	anchored = TRUE

--- a/code/game/objects/items/devices/radio/intercom.dm
+++ b/code/game/objects/items/devices/radio/intercom.dm
@@ -1,5 +1,5 @@
 /obj/item/radio/intercom
-	name = "Station Intercom (General)"
+	name = "station intercom"
 	desc = "Talk through this."
 	icon_state = "intercom"
 	anchored = TRUE


### PR DESCRIPTION
:cl: Denton
tweak: Added private intercoms to the confession booths of the Deltastation+Pubbystation chapels.
fix: Fixed invalid radio frequencies on interrogation chamber/confession booth intercoms.
/:cl:

Delta/Pubby were missing intercoms inside the confession booth, I added them to both.