### PR TITLE
Fixes Meta disposals junction

### DIFF
--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -18376,8 +18376,8 @@
 /obj/structure/cable/yellow{
 	icon_state = "2-8"
 	},
-/obj/structure/disposalpipe/sorting/mail/flip{
-	dir = 8;
+/obj/structure/disposalpipe/sorting/mail{
+	dir = 4;
 	sortType = 29
 	},
 /turf/open/floor/plasteel/neutral/corner{


### PR DESCRIPTION
Fixes: #39833

Probably a good speedmerge candidate since right now, disposals get people and items stuck near the lawyer's office/dorms entrance.