### PR TITLE
/mob/dead no longer has a throwforce

### DIFF
--- a/code/modules/mob/dead/dead.dm
+++ b/code/modules/mob/dead/dead.dm
@@ -4,6 +4,7 @@ INITIALIZE_IMMEDIATE(/mob/dead)
 
 /mob/dead
 	sight = SEE_TURFS | SEE_MOBS | SEE_OBJS | SEE_SELF
+	throwforce = 0
 
 /mob/dead/Initialize()
 	if(flags_1 & INITIALIZED_1)


### PR DESCRIPTION
fixes #39846

closes #39849 (@Iamgoofball)

This pr is the same as goofs only without the sass.