### PR TITLE
Fixes chest and head augmentation

### DIFF
--- a/code/modules/surgery/bodyparts/dismemberment.dm
+++ b/code/modules/surgery/bodyparts/dismemberment.dm
@@ -159,7 +159,8 @@
 	..()
 
 /obj/item/bodypart/chest/drop_limb(special)
-	return
+	if(special)
+		..()
 
 /obj/item/bodypart/r_arm/drop_limb(special)
 	var/mob/living/carbon/C = owner

--- a/code/modules/surgery/limb_augmentation.dm
+++ b/code/modules/surgery/limb_augmentation.dm
@@ -57,7 +57,7 @@
 			tool.cut_overlays()
 			tool = tool.contents[1]
 		if(istype(tool) && user.temporarilyRemoveItemFromInventory(tool))
-			tool.replace_limb(target)
+			tool.replace_limb(target, TRUE)
 		user.visible_message("[user] successfully augments [target]'s [parse_zone(target_zone)]!", "<span class='notice'>You successfully augment [target]'s [parse_zone(target_zone)].</span>")
 		log_combat(user, target, "augmented", addition="by giving him new [parse_zone(target_zone)] INTENT: [uppertext(user.a_intent)]")
 	else


### PR DESCRIPTION
:cl: XDTM
fix: Fixed chest and head augmentation not working properly.
/:cl:

Fixes #39858

Roboticists can no longer get away with just pretending to replace heads.
They also can no longer infinitely stack chests on people, which i have severe trouble imagining.

Shoutout to @Arkvold for the excellent bug report
