### PR TITLE
Fixed minor inefficiency in gift code.

### DIFF
--- a/code/game/objects/items/gift.dm
+++ b/code/game/objects/items/gift.dm
@@ -97,7 +97,7 @@ GLOBAL_LIST_EMPTY(possible_gifts)
 			var/obj/item/I = V
 			if((!initial(I.icon_state)) || (!initial(I.item_state)) || (initial(I.item_flags) & ABSTRACT))
 				gift_types_list -= V
-				GLOB.possible_gifts = gift_types_list
+		GLOB.possible_gifts = gift_types_list
 	var/gift_type = pick(GLOB.possible_gifts)
 
 	return gift_type


### PR DESCRIPTION
:cl: The Dreamweaver
code: Refactored gift code to fix a minor inefficiency.
/:cl:

Gift code was writing to a global var every iteration of a very long for loop when it only needed to do it at the end of the loop. Probably very minor impact difference, but figured I'd fix it when I noticed it.
