### PR TITLE
Give crayon a talk_into()

### DIFF
--- a/code/game/objects/items/crayons.dm
+++ b/code/game/objects/items/crayons.dm
@@ -252,7 +252,7 @@
 			paint_mode = PAINT_LARGE_HORIZONTAL
 			text_buffer = ""
 		else
-		paint_mode = PAINT_NORMAL
+			paint_mode = PAINT_NORMAL
 	
 	return NOPASS
 

--- a/code/game/objects/items/crayons.dm
+++ b/code/game/objects/items/crayons.dm
@@ -232,6 +232,30 @@
 			drawtype = "a"
 	update_icon()
 
+/obj/item/toy/crayon/talk_into(mob/M, input, channel, spans, datum/language/language)
+	input = trim(input, MAX_MESSAGE_LEN)
+	var/newtext = crayon_text_strip(input)
+	
+	if(input[1] in (letters|numerals)) // accept the input as a string of letters and numbers to paint.
+		text_buffer = newtext
+		paint_mode = PAINT_NORMAL
+		drawtype = "a"
+	
+	if(input[1] == "#" && can_change_colour && length(newtext) >= 6) // RGB hex color.
+		paint_color = sanitize_hexcolor( copytext(newtext,1,7) , 6 , TRUE, paint_color)
+	
+	if(input[1] == "!") // pick a stencil directly
+		var/stencil = newtext
+		if(stencil in all_drawables + randoms) // graffiti sprites have strictly lowercase, alphanumeric names
+			drawtype = stencil
+		if(stencil in graffiti_large_h)
+			paint_mode = PAINT_LARGE_HORIZONTAL
+			text_buffer = ""
+		else
+		paint_mode = PAINT_NORMAL
+	
+	return NOPASS
+
 /obj/item/toy/crayon/proc/crayon_text_strip(text)
 	var/list/base = string2charlist(lowertext(text))
 	var/list/out = list()


### PR DESCRIPTION
This will allow crayons to be set blindly, without opening a UI panel.

:cl:
rscadd: It is now possible to control a crayon/spraycan by speaking into it rather than using the tgui popup.
/:cl:

Why:
1. for the clown on the run
2. I play in WINE, tgui barely works, and this particular interface hangs and fails completely to render.