### PR TITLE
Adds missing content to anime phobia

### DIFF
--- a/code/controllers/subsystem/traumas.dm
+++ b/code/controllers/subsystem/traumas.dm
@@ -51,7 +51,8 @@ SUBSYSTEM_DEF(traumas)
 					   "conspiracies" = typecacheof(list(/mob/living/simple_animal/bot/secbot, /mob/living/simple_animal/bot/ed209, /mob/living/simple_animal/drone,
 					   /mob/living/simple_animal/pet/penguin)),
 					   "birds" = typecacheof(list(/mob/living/simple_animal/parrot, /mob/living/simple_animal/chick, /mob/living/simple_animal/chicken,
-					   /mob/living/simple_animal/pet/penguin))
+					   /mob/living/simple_animal/pet/penguin)),
+					   "anime" = typecacheof(list(/mob/living/simple_animal/hostile/guardian))
 					   )
 
 	phobia_objs = list("snakes" = typecacheof(list(/obj/item/rod_of_asclepius)),

--- a/code/controllers/subsystem/traumas.dm
+++ b/code/controllers/subsystem/traumas.dm
@@ -138,8 +138,10 @@ SUBSYSTEM_DEF(traumas)
 						/obj/item/clothing/under/griffin, /obj/item/clothing/shoes/griffin, /obj/item/clothing/head/griffin,
 						/obj/item/clothing/head/helmet/space/freedom, /obj/item/clothing/suit/space/freedom)),
 						
-					   "anime" = typecacheof(list(/obj/item/clothing/under/schoolgirl, /obj/item/katana, /obj/item/reagent_containers/food/snacks/sashimi,
-					   /obj/item/reagent_containers/food/drinks/bottle/sake, /obj/item/throwing_star))
+					   "anime" = typecacheof(list(/obj/item/clothing/under/schoolgirl, /obj/item/katana, /obj/item/reagent_containers/food/snacks/sashimi, /obj/item/reagent_containers/food/snacks/chawanmushi,
+					   /obj/item/reagent_containers/food/drinks/bottle/sake, /obj/item/throwing_star, /obj/item/clothing/head/kitty/genuine, /obj/item/clothing/suit/space/space_ninja,
+					   /obj/item/clothing/mask/gas/space_ninja, /obj/item/clothing/shoes/space_ninja, /obj/item/clothing/gloves/space_ninja, /obj/item/twohanded/vibro_weapon,
+					   /obj/item/nullrod/scythe/vibro, /obj/item/energy_katana, /obj/item/toy/katana, /obj/item/nullrod/claymore/katana, /obj/structure/window/paperframe, /obj/structure/mineral_door/paperframe))
 						)
 						
 	phobia_turfs = list("space" = typecacheof(list(/turf/open/space, /turf/open/floor/holofloor/space, /turf/open/floor/fakespace)),
@@ -150,13 +152,14 @@ SUBSYSTEM_DEF(traumas)
 						"falling" = typecacheof(list(/turf/open/chasm, /turf/open/floor/fakepit))
 						)
 
-	phobia_species = list("lizards"   = typecacheof(list(/datum/species/lizard)),
+	phobia_species = list("lizards" = typecacheof(list(/datum/species/lizard)),
 						  "skeletons" = typecacheof(list(/datum/species/skeleton, /datum/species/plasmaman)),
 						  "conspiracies" = typecacheof(list(/datum/species/abductor, /datum/species/lizard, /datum/species/synth)),
-						  "robots"   = typecacheof(list(/datum/species/android)),
+						  "robots" = typecacheof(list(/datum/species/android)),
 						  "the supernatural" = typecacheof(list(/datum/species/golem/clockwork, /datum/species/golem/runic)),
 						  "aliens" = typecacheof(list(/datum/species/abductor, /datum/species/jelly, /datum/species/pod,
-						  /datum/species/shadow))
+						  /datum/species/shadow)),
+						  "anime" = typecacheof(list(/datum/species/human/felinid))
 						 )				 
 
 	return ..()

--- a/strings/phobia.json
+++ b/strings/phobia.json
@@ -270,6 +270,17 @@
 		"catgirl",
 		"catgirls",
 		"ninja",
-		"uguu"
+		"uguu",
+		"waifu",
+		"husbando",
+		"best girl",
+		"worst girl",
+		"subs",
+		"dubs",
+		"season two when",
+		"cosplay",
+		"nya",
+		"nyaa",
+		"neet"
 	]
 }

--- a/strings/phobia.json
+++ b/strings/phobia.json
@@ -282,6 +282,7 @@
 		"nya",
 		"nyaa",
 		"neet",
-		"ora"
+		"ora",
+		"~"
 	]
 }

--- a/strings/phobia.json
+++ b/strings/phobia.json
@@ -281,6 +281,7 @@
 		"cosplay",
 		"nya",
 		"nyaa",
-		"neet"
+		"neet",
+		"ora"
 	]
 }


### PR DESCRIPTION
:cl: Denton
tweak: Anime is even more horrifying than previously discovered!
/:cl:

Anime phobia was missing some items:
- All flavors of katanas, high frequency blades and other cutting utensils used by cyborg ninjas
- Space ninja gear
- Paper frame windows and doors
- Chawanmushi
- Those tacky wearable cat ears

Also, felinids as phobia_species and a few phobia_words.