### PR TITLE
Changes cloning countdown timer colour

### DIFF
--- a/code/game/objects/effects/countdown.dm
+++ b/code/game/objects/effects/countdown.dm
@@ -86,7 +86,7 @@
 
 /obj/effect/countdown/clonepod
 	name = "cloning pod countdown"
-	color = "#0C479D"
+	color = "#18d100"
 	text_size = 1
 
 /obj/effect/countdown/clonepod/get_value()


### PR DESCRIPTION
Fixes #39873

The green should be a more visible, high contrast colour at a glance. Didn't go for red as red is usually reserved for Bad Things(TM)