### PR TITLE
Adds bomb defusal shuttle loan event

### DIFF
--- a/code/game/objects/items/storage/belt.dm
+++ b/code/game/objects/items/storage/belt.dm
@@ -608,11 +608,6 @@
 	icon_state = "fannypack_yellow"
 	item_state = "fannypack_yellow"
 
-/obj/item/storage/belt/fannypack/yellow/bee_terrorist/PopulateContents() //used in the bee terrorist shuttle loan event
-	new /obj/item/grenade/plastic/c4 (src)
-	new /obj/item/reagent_containers/pill/cyanide(src)
-	new /obj/item/grenade/chem_grenade/facid(src)
-
 /obj/item/storage/belt/sabre
 	name = "sabre sheath"
 	desc = "An ornate sheath designed to hold an officer's blade."

--- a/code/modules/events/shuttle_loan.dm
+++ b/code/modules/events/shuttle_loan.dm
@@ -5,6 +5,7 @@
 #define ANTIDOTE_NEEDED 5
 #define PIZZA_DELIVERY 6
 #define ITS_HIP_TO 7
+#define MY_GOD_JC 8
 
 
 /datum/round_event_control/shuttle_loan
@@ -22,7 +23,7 @@
 	var/thanks_msg = "The cargo shuttle should return in five minutes. Have some supply points for your trouble."
 
 /datum/round_event/shuttle_loan/setup()
-	dispatch_type = pick(HIJACK_SYNDIE, RUSKY_PARTY, SPIDER_GIFT, DEPARTMENT_RESUPPLY, ANTIDOTE_NEEDED, PIZZA_DELIVERY, ITS_HIP_TO)
+	dispatch_type = pick(HIJACK_SYNDIE, RUSKY_PARTY, SPIDER_GIFT, DEPARTMENT_RESUPPLY, ANTIDOTE_NEEDED, PIZZA_DELIVERY, ITS_HIP_TO, MY_GOD_JC)
 
 /datum/round_event/shuttle_loan/announce(fake)
 	SSshuttle.shuttle_loan = src
@@ -46,6 +47,10 @@
 		if(ITS_HIP_TO)
 			priority_announce("Cargo: One of our freighters carrying a bee shipment has been attacked by eco-terrorists. Can you clean up the mess for us?", "CentCom Janitorial Division")
 			bonus_points = 20000 //Toxin bees can be unbeelievably lethal
+		if(MY_GOD_JC)
+			priority_announce("Cargo: We have discovered an active Syndicate bomb near our VIP shuttle's fuel lines. If you feel up to the task, we will pay you for defusing it.", "CentCom Security Division")
+			thanks_msg = "Live explosive ordnance incoming via supply shuttle. Evacuating cargo bay is recommended."
+			bonus_points = 45000 //If you mess up, people die and the shuttle gets turned into swiss cheese
 
 /datum/round_event/shuttle_loan/proc/loan_shuttle()
 	priority_announce(thanks_msg, "Cargo shuttle commandeered by CentCom.")
@@ -73,6 +78,8 @@
 			SSshuttle.centcom_message += "Pizza delivery for [station_name()]"
 		if(ITS_HIP_TO)
 			SSshuttle.centcom_message += "Biohazard cleanup incoming."
+		if(MY_GOD_JC)
+			SSshuttle.centcom_message += "Live explosive ordnance incoming. Exercise extreme caution."
 
 /datum/round_event/shuttle_loan/tick()
 	if(dispatched)
@@ -210,6 +217,13 @@
 					var/casing = /obj/item/ammo_casing/spent
 					new casing(pick_n_take(empty_shuttle_turfs))
 
+			if(MY_GOD_JC)
+				shuttle_spawns.Add(/obj/machinery/syndicatebomb/shuttle_loan)
+				if(prob(95))
+					shuttle_spawns.Add(/obj/item/paper/fluff/cargo/bomb)
+				else
+					shuttle_spawns.Add(/obj/item/paper/fluff/cargo/bomb/allyourbase)
+
 		var/false_positive = 0
 		while(shuttle_spawns.len && empty_shuttle_turfs.len)
 			var/turf/T = pick_n_take(empty_shuttle_turfs)
@@ -220,6 +234,31 @@
 			var/spawn_type = pick_n_take(shuttle_spawns)
 			new spawn_type(T)
 
+//items that appear only in shuttle loan events
+
+/obj/item/storage/belt/fannypack/yellow/bee_terrorist/PopulateContents()
+	new /obj/item/grenade/plastic/c4 (src)
+	new /obj/item/reagent_containers/pill/cyanide(src)
+	new /obj/item/grenade/chem_grenade/facid(src)
+
+/obj/item/paper/fluff/bee_objectives
+	name = "Objectives of a Bee Liberation Front Operative"
+	info = "<b>Objective #1</b>. Liberate all bees on the NT transport vessel 2416/B. <b>Success!</b>  <br><b>Objective #2</b>. Escape alive. <b>Failed.</b>"
+
+/obj/machinery/syndicatebomb/shuttle_loan/Initialize()
+	. = ..()
+	setAnchored(TRUE)
+	timer_set = rand(480, 600) //once the supply shuttle docks (after 5 minutes travel time), players have between 3-5 minutes to defuse the bomb
+	activate()
+	update_icon()
+
+/obj/item/paper/fluff/cargo/bomb
+	name = "hastly scribbled note"
+	info = "GOOD LUCK!"
+
+/obj/item/paper/fluff/cargo/bomb/allyourbase
+	info = "Somebody set us up the bomb!"
+
 #undef HIJACK_SYNDIE
 #undef RUSKY_PARTY
 #undef SPIDER_GIFT
@@ -227,3 +266,4 @@
 #undef ANTIDOTE_NEEDED
 #undef PIZZA_DELIVERY
 #undef ITS_HIP_TO
+#undef MY_GOD_JC

--- a/code/modules/mob/living/simple_animal/corpse.dm
+++ b/code/modules/mob/living/simple_animal/corpse.dm
@@ -218,8 +218,4 @@
 	belt = /obj/item/storage/belt/fannypack/yellow/bee_terrorist
 	id = /obj/item/card/id
 	l_pocket = /obj/item/paper/fluff/bee_objectives
-	mask = /obj/item/clothing/mask/rat/bee 
-
-/obj/item/paper/fluff/bee_objectives
-	name = "Objectives of a Bee Liberation Front Operative"
-	info = "<b>Objective #1</b>. Liberate all bees on the NT transport vessel 2416/B. <b>Success!</b>  <br><b>Objective #2</b>. Escape alive. <b>Failed.</b>"
+	mask = /obj/item/clothing/mask/rat/bee

--- a/code/modules/shuttle/supply.dm
+++ b/code/modules/shuttle/supply.dm
@@ -23,7 +23,8 @@ GLOBAL_LIST_INIT(blacklisted_cargo_types, typecacheof(list(
 		/obj/item/projectile/beam/wormhole,
 		/obj/effect/portal,
 		/obj/item/shared_storage,
-		/obj/structure/extraction_point
+		/obj/structure/extraction_point,
+		/obj/machinery/syndicatebomb
 	)))
 
 /obj/docking_port/mobile/supply


### PR DESCRIPTION
:cl: Denton
add: Added a new shuttle loan event where crew can get paid for having an active syndicate bomb delivered to cargo bay.
/:cl:

This is a shuttle loan event where CentCom asks you to defuse an active syndicate bomb.
The good part? It pays a lot of dosh.
The bad part? You have a real chance of dying, blowing up the supply shuttle and tearing a big fukken hole into cargo bay.
Maybe cargo techs will step back for a second and think "is the money really worth that risk"? 

Anywho, I blacklisted syndie bombs from cargo exports (so people can't just send it back to CentCom) and also moved shuttle loan related items into shuttle_loan.dm.