### PR TITLE
Fix overcharging energy guns crashing the server

### DIFF
--- a/code/modules/projectiles/guns/energy.dm
+++ b/code/modules/projectiles/guns/energy.dm
@@ -135,7 +135,7 @@
 	..()
 	if(!automatic_charge_overlays)
 		return
-	var/ratio = CEILING((cell.charge / cell.maxcharge) * charge_sections, 1)
+	var/ratio = CEILING(CLAMP(cell.charge / cell.maxcharge, 0, 1) * charge_sections, 1)
 	if(ratio == old_ratio && !force_update)
 		return
 	old_ratio = ratio


### PR DESCRIPTION
:cl:
fix: Overcharging energy guns no longer crashes the server.
/:cl:

Fixes #39878.