### PR TITLE
Fix Build Your Own Shuttle crashing the server

### DIFF
--- a/_maps/shuttles/emergency_airless.dmm
+++ b/_maps/shuttles/emergency_airless.dmm
@@ -31,7 +31,7 @@
 /turf/open/floor/plating/airless,
 /area/shuttle/escape)
 "g" = (
-/obj/docking_port/mobile/emergency{
+/obj/docking_port/mobile/emergency/shuttle_build{
 	dwidth = 11;
 	height = 18;
 	name = "Shuttle Under Construction";
@@ -39,10 +39,6 @@
 	preferred_direction = 2;
 	width = 30
 	},
-/turf/open/floor/plating/airless,
-/area/shuttle/escape)
-"h" = (
-/obj/effect/shuttle_build,
 /turf/open/floor/plating/airless,
 /area/shuttle/escape)
 
@@ -341,7 +337,7 @@ f
 f
 f
 f
-h
+f
 f
 f
 f

--- a/code/modules/admin/fun_balloon.dm
+++ b/code/modules/admin/fun_balloon.dm
@@ -102,19 +102,6 @@
 	qdel(src)
 
 
-//Shuttle Build
-
-/obj/effect/shuttle_build
-	name = "shuttle_build"
-	desc = "Some assembly required."
-	icon = 'icons/obj/items_and_weapons.dmi'
-	icon_state = "syndballoon"
-	anchored = TRUE
-
-/obj/effect/shuttle_build/New()
-	SSshuttle.emergency.initiate_docking(SSshuttle.getDock("emergency_home"))
-	qdel(src)
-
 //Arena
 
 /obj/effect/forcefield/arena_shuttle

--- a/code/modules/shuttle/emergency.dm
+++ b/code/modules/shuttle/emergency.dm
@@ -571,6 +571,10 @@
 	SSshuttle.emergency = current_emergency
 	SSshuttle.backup_shuttle = src
 
+/obj/docking_port/mobile/emergency/shuttle_build/register()
+	. = ..()
+	initiate_docking(SSshuttle.getDock("emergency_home"))
+
 #undef TIME_LEFT
 #undef ENGINES_START_TIME
 #undef ENGINES_STARTED


### PR DESCRIPTION
:cl:
fix: Ordering the Build Your Own Shuttle kit no longer crashes the server.
/:cl:

Reported by Naksu, Bagil 2018-08-23 round 92900. Ordering the kit spammed runtimes for 2+ minutes and then crashed the server. It didn't crash when I tested locally but definitely did spam 1000+ runtimes.

Basically the shuttle is being docked to the station before it has even finished loading, so both atmos and lighting are in particularly invalid states. Now it docks to the station only after it's fully replaced the original emergency shuttle.

There's still a few runtimes coming from `process_cell`, but I don't know enough about atmos to fix them:

```
(3x) Runtime in LINDA_turf_tile.dm, line 178: undefined variable /turf/closed/wall/var/air
(4x) Runtime in LINDA_turf_tile.dm, line 91: Cannot execute null.archive().
(4x) Runtime in gas_mixture.dm, line 385: Cannot read null.gases
```