### PR TITLE
Give multiple copies of shuttles their own area instances

### DIFF
--- a/code/__HELPERS/unsorted.dm
+++ b/code/__HELPERS/unsorted.dm
@@ -577,14 +577,9 @@ Turf and target are separate in case you want to teleport some distance from a t
 //Takes: Area type as a text string from a variable.
 //Returns: Instance for the area in the world.
 /proc/get_area_instance_from_text(areatext)
-	var/areainstance = null
 	if(istext(areatext))
 		areatext = text2path(areatext)
-	for(var/V in GLOB.sortedAreas)
-		var/area/A = V
-		if(A.type == areatext)
-			areainstance = V
-	return areainstance
+	return GLOB.areas_by_type[areatext]
 
 //Takes: Area type as text string or as typepath OR an instance of the area.
 //Returns: A list of all areas of that type in the world.

--- a/code/_globalvars/lists/mapping.dm
+++ b/code/_globalvars/lists/mapping.dm
@@ -34,5 +34,7 @@ GLOBAL_LIST_EMPTY(vr_spawnpoints)
 
 	//used by jump-to-area etc. Updated by area/updateName()
 GLOBAL_LIST_EMPTY(sortedAreas)
+/// An association from typepath to area instance. Only includes areas with `unique` set.
+GLOBAL_LIST_EMPTY(areas_by_type)
 
 GLOBAL_LIST_EMPTY(all_abstract_markers)

--- a/code/controllers/subsystem/job.dm
+++ b/code/controllers/subsystem/job.dm
@@ -559,7 +559,7 @@ SUBSYSTEM_DEF(job)
 		SendToAtom(M, pick(latejoin_trackers), buckle)
 	else
 		//bad mojo
-		var/area/shuttle/arrival/A = locate() in GLOB.sortedAreas
+		var/area/shuttle/arrival/A = GLOB.areas_by_type[/area/shuttle/arrival]
 		if(A)
 			//first check if we can find a chair
 			var/obj/structure/chair/C = locate() in A

--- a/code/game/area/areas.dm
+++ b/code/game/area/areas.dm
@@ -46,6 +46,8 @@
 	var/noteleport = FALSE			//Are you forbidden from teleporting to the area? (centcom, mobs, wizard, hand teleporter)
 	var/hidden = FALSE 			//Hides area from player Teleport function.
 	var/safe = FALSE 				//Is the area teleport-safe: no space / radiation / aggresive mobs / other dangers
+	/// If false, loading multiple maps with this area type will create multiple instances.
+	var/unique = TRUE
 
 	var/no_air = null
 
@@ -82,6 +84,12 @@ GLOBAL_LIST_EMPTY(teleportlocs)
 
 // ===
 
+/area/New()
+	// This interacts with the map loader, so it needs to be set immediately
+	// rather than waiting for atoms to initialize.
+	if (unique)
+		GLOB.areas_by_type[type] = src
+	return ..()
 
 /area/Initialize()
 	icon_state = ""
@@ -135,6 +143,8 @@ GLOBAL_LIST_EMPTY(teleportlocs)
 	power_change()		// all machines set to current power level, also updates icon
 
 /area/Destroy()
+	if(GLOB.areas_by_type[type] == src)
+		GLOB.areas_by_type[type] = null
 	STOP_PROCESSING(SSobj, src)
 	return ..()
 

--- a/code/game/area/areas/shuttles.dm
+++ b/code/game/area/areas/shuttles.dm
@@ -10,6 +10,8 @@
 	always_unpowered = FALSE
 	valid_territory = FALSE
 	icon_state = "shuttle"
+	// Loading the same shuttle map at a different time will produce distinct area instances.
+	unique = FALSE
 
 /area/shuttle/Initialize()
 	if(!canSmoothWithAreas)
@@ -103,6 +105,7 @@
 
 /area/shuttle/arrival
 	name = "Arrival Shuttle"
+	unique = TRUE  // SSjob refers to this area for latejoiners
 
 /area/shuttle/pod_1
 	name = "Escape Pod One"

--- a/code/game/gamemodes/objective.dm
+++ b/code/game/gamemodes/objective.dm
@@ -539,7 +539,7 @@ GLOBAL_LIST_EMPTY(possible_items_special)
 
 /datum/objective/capture/check_completion()//Basically runs through all the mobs in the area to determine how much they are worth.
 	var/captured_amount = 0
-	var/area/centcom/holding/A = locate() in GLOB.sortedAreas
+	var/area/centcom/holding/A = GLOB.areas_by_type[/area/centcom/holding]
 	for(var/mob/living/carbon/human/M in A)//Humans.
 		if(M.stat == DEAD)//Dead folks are worth less.
 			captured_amount+=0.5

--- a/code/modules/antagonists/wizard/equipment/spellbook.dm
+++ b/code/modules/antagonists/wizard/equipment/spellbook.dm
@@ -76,7 +76,7 @@
 	return 0
 
 /datum/spellbook_entry/proc/Refund(mob/living/carbon/human/user,obj/item/spellbook/book) //return point value or -1 for failure
-	var/area/wizard_station/A = locate() in GLOB.sortedAreas
+	var/area/wizard_station/A = GLOB.areas_by_type[/area/wizard_station]
 	if(!(user in A.contents))
 		to_chat(user, "<span class='warning'>You can only refund spells at the wizard lair</span>")
 		return -1

--- a/code/modules/cargo/expressconsole.dm
+++ b/code/modules/cargo/expressconsole.dm
@@ -167,7 +167,7 @@
 						LZ = get_turf(beacon)
 						beacon.update_status(SP_LAUNCH)
 					else if (!usingBeacon)//find a suitable supplypod landing zone in cargobay
-						landingzone = locate(/area/quartermaster/storage) in GLOB.sortedAreas
+						landingzone = GLOB.areas_by_type[/area/quartermaster/storage]
 						if (!landingzone)
 							WARNING("[src] couldnt find a Quartermaster/Storage (aka cargobay) area on the station, and as such it has set the supplypod landingzone to the area it resides in.")
 							landingzone = get_area(src)
@@ -185,7 +185,7 @@
 						update_icon()
 			else
 				if(SO.pack.cost * (0.72*MAX_EMAG_ROCKETS) <= SSshuttle.points) // bulk discount :^)
-					landingzone = locate(pick(GLOB.the_station_areas)) in GLOB.sortedAreas //override default landing zone
+					landingzone = GLOB.areas_by_type[pick(GLOB.the_station_areas)]  //override default landing zone
 					for(var/turf/open/floor/T in landingzone.contents)
 						if(is_blocked_turf(T))
 							continue

--- a/code/modules/holodeck/computer.dm
+++ b/code/modules/holodeck/computer.dm
@@ -177,7 +177,7 @@
 
 /obj/machinery/computer/holodeck/proc/generate_program_list()
 	for(var/typekey in subtypesof(program_type))
-		var/area/holodeck/A = locate(typekey) in GLOB.sortedAreas
+		var/area/holodeck/A = GLOB.areas_by_type[typekey]
 		if(!A || !A.contents.len)
 			continue
 		var/list/info_this = list()

--- a/code/modules/shuttle/docking.dm
+++ b/code/modules/shuttle/docking.dm
@@ -32,12 +32,7 @@
 
 	// The underlying old area is the area assumed to be under the shuttle's starting location
 	// If it no longer/has never existed it will be created
-	var/area/underlying_old_area
-	for(var/i in GLOB.sortedAreas) // Locate grabs subtypes and we want a particular type
-		var/area/place = i
-		if(place.type == underlying_area_type)
-			underlying_old_area = place
-			break
+	var/area/underlying_old_area = GLOB.areas_by_type[underlying_area_type]
 	if(!underlying_old_area)
 		underlying_old_area = new underlying_area_type(null)
 

--- a/code/modules/shuttle/shuttle.dm
+++ b/code/modules/shuttle/shuttle.dm
@@ -435,12 +435,7 @@
 
 	var/list/old_turfs = return_ordered_turfs(x, y, z, dir)
 
-	var/area/underlying_area
-	for(var/i in GLOB.sortedAreas)
-		var/area/place = i
-		if(place.type == underlying_area_type)
-			underlying_area = place
-			break
+	var/area/underlying_area = GLOB.areas_by_type[underlying_area_type]
 	if(!underlying_area)
 		underlying_area = new underlying_area_type(null)
 


### PR DESCRIPTION
:cl:
code: Multiple copies of a shuttle each get their own area instances (affects APCs and air alarms).
/:cl:

Replaces various `locate(typepath) in GLOB.sortedAreas` and for loops to the same effect with `GLOB.areas_by_type[typepath]`. Shuttle areas are excluded from this mapping (except the arrivals shuttle, which remains included), which is what gives them fresh instances each time a shuttle is loaded.

Pirates not touched in order to avoid conflicts with #39749.

Fun crossover between the "remove locate()" and "enhance shuttles" warpaths.