### PR TITLE
.38 no longer insta stuns

### DIFF
--- a/code/modules/projectiles/projectile/bullets/revolver.dm
+++ b/code/modules/projectiles/projectile/bullets/revolver.dm
@@ -15,7 +15,6 @@
 /obj/item/projectile/bullet/c38
 	name = ".38 bullet"
 	damage = 15
-	knockdown = 60
 	stamina = 50
 
 // .357 (Syndie Revolver)

--- a/code/modules/projectiles/projectile/bullets/revolver.dm
+++ b/code/modules/projectiles/projectile/bullets/revolver.dm
@@ -14,8 +14,7 @@
 
 /obj/item/projectile/bullet/c38
 	name = ".38 bullet"
-	damage = 15
-	stamina = 50
+	damage = 25
 
 // .357 (Syndie Revolver)
 


### PR DESCRIPTION
:cl:
balance: .38 no longer insta stuns, it still deals 25 brute
/:cl:
>inb4 limited ammo 

yeah its not like the seclathe prints the ammo and every detective and their mother have at least 7 speedloarders in their bag
>inb4 det nerf 

yeah det isnt supposed to be the elite officer which dies to a stun pod and then traitor LB kills everyone with a .38
>inb4 i ded

not an argument yet i didnt die from .38 
>inb4 useless now

1 shot slows down 2 shots and he is down 3 shots stuns an armored target maybe i should also lower the stamina dmg
