### PR TITLE
Asay logs have ASAY: again

### DIFF
--- a/code/__DEFINES/logging.dm
+++ b/code/__DEFINES/logging.dm
@@ -32,6 +32,7 @@
 #define LOG_OWNERSHIP	(1 << 11)
 #define LOG_GAME		(1 << 12)
 #define LOG_ADMIN_PRIVATE (1 << 13)
+#define LOG_ASAY		(1 << 14)
 
 //Individual logging panel pages
 #define INDIVIDUAL_ATTACK_LOG		(LOG_ATTACK)

--- a/code/game/atoms.dm
+++ b/code/game/atoms.dm
@@ -613,6 +613,8 @@
 			log_admin(log_text)
 		if(LOG_ADMIN_PRIVATE)
 			log_admin_private(log_text)
+		if(LOG_ASAY)
+			log_adminsay(log_text)
 		if(LOG_OWNERSHIP)
 			log_game(log_text)
 		if(LOG_GAME)

--- a/code/modules/admin/verbs/adminsay.dm
+++ b/code/modules/admin/verbs/adminsay.dm
@@ -9,7 +9,7 @@
 	if(!msg)
 		return
 
-	mob.log_talk(msg, LOG_ADMIN_PRIVATE)
+	mob.log_talk(msg, LOG_ASAY)
 
 	msg = keywords_lookup(msg)
 	msg = "<span class='adminsay'><span class='prefix'>ADMIN:</span> <EM>[key_name(usr, 1)]</EM> [ADMIN_FLW(mob)]: <span class='message linkify'>[msg]</span></span>"


### PR DESCRIPTION
:cl: JJRcop
admin: Asay logs show "ADMINPRIVATE: ASAY:" again instead of just "ADMINPRIVATE:"
/:cl:

The log_adminsay proc was orphaned so I adopted it.
