### PR TITLE
Players can Ctrl+Shift click APCs to toggle night shift lighting

### DIFF
--- a/code/_onclick/ai.dm
+++ b/code/_onclick/ai.dm
@@ -174,6 +174,10 @@
 		toggle_breaker()
 		add_fingerprint(usr)
 
+/obj/machinery/power/apc/AICtrlShiftClick() // toggles night shift lighting
+	if(can_use(usr, 1))
+		toggle_nightshift_lights()
+
 /* AI Turrets */
 /obj/machinery/turretid/AIAltClick() //toggles lethal on turrets
 	if(ailock)

--- a/code/modules/power/apc.dm
+++ b/code/modules/power/apc.dm
@@ -265,8 +265,8 @@
 	if(integration_cog && is_servant_of_ratvar(user))
 		to_chat(user, "<span class='brass'>There is an integration cog installed!</span>")
 	
-	to_chat(user, "<span class='notice'>Alt+Click [src] to toggle the cover lock.</span>")
-	to_chat(user, "<span class='notice'>Ctrl+Click [src] to toggle night shift lighting.</span>")
+	to_chat(user, "<span class='notice'>Alt-Click [src] to toggle the cover lock.</span>")
+	to_chat(user, "<span class='notice'>Ctrl+Shift-Click [src] to toggle night shift lighting.</span>")
 
 // update the APC icon to show the three base states
 // also add overlays for indicator lights

--- a/code/modules/power/apc.dm
+++ b/code/modules/power/apc.dm
@@ -737,7 +737,7 @@
 	else if(stat & (BROKEN|MAINT))
 		to_chat(user, "<span class='warning'>Nothing happens!</span>")
 	else
-		if(last_nightshift_switch > world.time - 100) //to prevent spamming
+		if(last_nightshift_switch > world.time - 600) //~60 seconds between each toggle to prevent spamming
 			to_chat(usr, "<span class='warning'>[src]'s night lighting circuit breaker is still cycling!</span>")
 			return
 		last_nightshift_switch = world.time

--- a/code/modules/power/apc.dm
+++ b/code/modules/power/apc.dm
@@ -737,6 +737,10 @@
 	else if(stat & (BROKEN|MAINT))
 		to_chat(user, "<span class='warning'>Nothing happens!</span>")
 	else
+		if(last_nightshift_switch > world.time - 100) //to prevent spamming
+			to_chat(usr, "<span class='warning'>[src]'s night lighting circuit breaker is still cycling!</span>")
+			return
+		last_nightshift_switch = world.time
 		set_nightshift(!nightshift_lights)
 		to_chat(user, "<span class='notice'>You [ nightshift_lights ? "enable" : "disable"] night shift lighting.</span>")
 


### PR DESCRIPTION
:cl: Denton
tweak: Players can now ctrl+shift click APCs to toggle night shift lighting.
fix: The 10 second anti spam cooldown of night shift lighting now works properly and has been increased to 60 seconds.
/:cl:

Closes: #39897

I've heard from plenty of players that toggling night lighting is frustrating, as they need to have access/hack the APC and then go through an interface to toggle what's essentially a light switch.
This PR lets them do it by ctrl+shift-clicking APCs - no access check, since it just toggles cosmetic lighting.