### PR TITLE
fixes roundstart borgs

### DIFF
--- a/code/modules/jobs/job_types/silicon.dm
+++ b/code/modules/jobs/job_types/silicon.dm
@@ -86,3 +86,4 @@ Cyborg
 
 /datum/job/cyborg/after_spawn(mob/living/silicon/robot/R, mob/M)
 	R.updatename(M.client)
+	R.gender = NEUTER


### PR DESCRIPTION
:cl:
fix: Roundstart cyborgs will now be properly referred to as "it."
/:cl:

Fixes https://github.com/tgstation/tgstation/issues/39902