### PR TITLE
Refactor status displays

### DIFF
--- a/_maps/map_files/BoxStation/BoxStation.dmm
+++ b/_maps/map_files/BoxStation/BoxStation.dmm
@@ -7275,7 +7275,7 @@
 /turf/open/floor/wood,
 /area/lawoffice)
 "asa" = (
-/obj/machinery/status_display{
+/obj/machinery/status_display/evac{
 	pixel_x = 32
 	},
 /turf/open/floor/plasteel/red/corner{
@@ -13238,7 +13238,7 @@
 /turf/open/floor/plating,
 /area/chapel/main)
 "aHu" = (
-/obj/machinery/status_display{
+/obj/machinery/status_display/evac{
 	pixel_x = 32
 	},
 /turf/open/floor/plasteel/white/corner{
@@ -15589,7 +15589,7 @@
 /obj/machinery/light/small{
 	dir = 4
 	},
-/obj/machinery/status_display{
+/obj/machinery/status_display/evac{
 	pixel_x = 32
 	},
 /turf/open/floor/plasteel/bar,
@@ -16306,7 +16306,7 @@
 /turf/open/floor/plasteel,
 /area/crew_quarters/locker)
 "aPE" = (
-/obj/machinery/status_display,
+/obj/machinery/status_display/evac,
 /turf/closed/wall,
 /area/crew_quarters/locker)
 "aPF" = (
@@ -16397,7 +16397,7 @@
 /obj/structure/cable{
 	icon_state = "0-8"
 	},
-/obj/machinery/status_display,
+/obj/machinery/status_display/evac,
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/door/poddoor/preopen{
 	id = "bridge blast";
@@ -16429,7 +16429,7 @@
 /obj/structure/cable{
 	icon_state = "0-4"
 	},
-/obj/machinery/status_display,
+/obj/machinery/status_display/evac,
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/door/poddoor/preopen{
 	id = "bridge blast";
@@ -17518,7 +17518,7 @@
 /area/hallway/secondary/exit)
 "aTl" = (
 /obj/machinery/vending/cola/random,
-/obj/machinery/status_display{
+/obj/machinery/status_display/evac{
 	layer = 4;
 	pixel_y = 32
 	},
@@ -17553,7 +17553,7 @@
 /area/hallway/secondary/exit)
 "aTr" = (
 /obj/machinery/door/firedoor,
-/obj/machinery/status_display{
+/obj/machinery/status_display/evac{
 	pixel_x = 32
 	},
 /turf/open/floor/plasteel,
@@ -19568,7 +19568,7 @@
 /turf/closed/wall/r_wall,
 /area/ai_monitored/turret_protected/ai_upload)
 "aYy" = (
-/obj/machinery/ai_status_display,
+/obj/machinery/status_display/ai,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
@@ -20215,7 +20215,7 @@
 /turf/open/floor/plasteel,
 /area/hydroponics)
 "baq" = (
-/obj/machinery/ai_status_display{
+/obj/machinery/status_display/ai{
 	pixel_y = 32
 	},
 /obj/structure/cable{
@@ -20461,7 +20461,7 @@
 /turf/open/floor/plasteel,
 /area/quartermaster/warehouse)
 "baZ" = (
-/obj/machinery/status_display{
+/obj/machinery/status_display/evac{
 	layer = 4;
 	pixel_y = 32
 	},
@@ -20626,7 +20626,7 @@
 /turf/open/floor/wood,
 /area/crew_quarters/heads/captain)
 "bbv" = (
-/obj/machinery/status_display{
+/obj/machinery/status_display/evac{
 	pixel_y = 32
 	},
 /obj/structure/cable{
@@ -21286,7 +21286,7 @@
 	dir = 4
 	},
 /obj/structure/disposalpipe/segment,
-/obj/machinery/status_display{
+/obj/machinery/status_display/evac{
 	pixel_x = -32
 	},
 /turf/open/floor/plasteel/blue/corner{
@@ -22178,7 +22178,7 @@
 /turf/closed/wall/r_wall,
 /area/ai_monitored/turret_protected/ai_upload)
 "bft" = (
-/obj/machinery/ai_status_display,
+/obj/machinery/status_display/ai,
 /turf/closed/wall/r_wall,
 /area/ai_monitored/turret_protected/ai_upload)
 "bfu" = (
@@ -22191,7 +22191,7 @@
 /turf/closed/wall/r_wall,
 /area/ai_monitored/turret_protected/ai_upload)
 "bfw" = (
-/obj/machinery/status_display,
+/obj/machinery/status_display/evac,
 /turf/closed/wall/r_wall,
 /area/ai_monitored/turret_protected/ai_upload)
 "bfx" = (
@@ -24055,7 +24055,7 @@
 /obj/machinery/light{
 	dir = 4
 	},
-/obj/machinery/status_display{
+/obj/machinery/status_display/evac{
 	pixel_x = 32
 	},
 /obj/machinery/aug_manipulator,
@@ -24134,9 +24134,8 @@
 /turf/open/floor/plasteel,
 /area/quartermaster/office)
 "bkx" = (
-/obj/machinery/status_display{
-	pixel_y = 2;
-	supply_display = 1
+/obj/machinery/status_display/supply{
+	pixel_y = 2
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
@@ -24935,7 +24934,7 @@
 	dir = 8
 	},
 /obj/machinery/door/firedoor,
-/obj/machinery/status_display{
+/obj/machinery/status_display/evac{
 	pixel_x = -32
 	},
 /turf/open/floor/plasteel/brown/corner{
@@ -26250,7 +26249,7 @@
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "bpw" = (
-/obj/machinery/status_display,
+/obj/machinery/status_display/evac,
 /turf/closed/wall,
 /area/medical/medbay/central)
 "bpx" = (
@@ -27520,7 +27519,7 @@
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "bsz" = (
-/obj/machinery/status_display{
+/obj/machinery/status_display/evac{
 	pixel_x = -32
 	},
 /turf/open/floor/plasteel/white/side{
@@ -28859,9 +28858,8 @@
 	id = "QMLoad"
 	},
 /obj/machinery/light,
-/obj/machinery/status_display{
-	pixel_y = -30;
-	supply_display = 1
+/obj/machinery/status_display/supply{
+	pixel_y = -30
 	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -29585,7 +29583,7 @@
 /turf/closed/wall,
 /area/engine/gravity_generator)
 "bxI" = (
-/obj/machinery/ai_status_display,
+/obj/machinery/status_display/ai,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 10
 	},
@@ -30916,9 +30914,8 @@
 /obj/item/radio/intercom{
 	pixel_y = -35
 	},
-/obj/machinery/status_display{
-	pixel_x = -32;
-	supply_display = 1
+/obj/machinery/status_display/supply{
+	pixel_x = -32
 	},
 /obj/machinery/computer/security/qm{
 	dir = 4
@@ -31142,7 +31139,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/machinery/status_display{
+/obj/machinery/status_display/evac{
 	pixel_y = -32
 	},
 /turf/open/floor/plasteel,
@@ -31993,7 +31990,7 @@
 	},
 /obj/item/assembly/flash/handheld,
 /obj/item/assembly/flash/handheld,
-/obj/machinery/ai_status_display{
+/obj/machinery/status_display/ai{
 	pixel_x = -32
 	},
 /turf/open/floor/plating,
@@ -33787,7 +33784,7 @@
 /area/medical/sleeper)
 "bIe" = (
 /obj/structure/disposalpipe/segment,
-/obj/machinery/status_display{
+/obj/machinery/status_display/evac{
 	pixel_x = -32
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -40417,7 +40414,7 @@
 /turf/open/floor/plating,
 /area/tcommsat/computer)
 "bZr" = (
-/obj/machinery/status_display,
+/obj/machinery/status_display/evac,
 /turf/closed/wall,
 /area/tcommsat/computer)
 "bZs" = (
@@ -47687,7 +47684,7 @@
 /area/ai_monitored/turret_protected/aisat_interior)
 "cuc" = (
 /obj/structure/rack,
-/obj/machinery/status_display{
+/obj/machinery/status_display/evac{
 	pixel_y = -32
 	},
 /obj/item/storage/box/donkpockets,
@@ -47725,7 +47722,7 @@
 /turf/closed/wall/r_wall,
 /area/ai_monitored/turret_protected/aisat/service)
 "cug" = (
-/obj/machinery/ai_status_display{
+/obj/machinery/status_display/ai{
 	pixel_y = -32
 	},
 /obj/structure/table,
@@ -48204,7 +48201,7 @@
 /turf/closed/wall/r_wall,
 /area/ai_monitored/turret_protected/ai)
 "cvb" = (
-/obj/machinery/ai_status_display,
+/obj/machinery/status_display/ai,
 /turf/closed/wall/r_wall,
 /area/ai_monitored/turret_protected/ai)
 "cvc" = (
@@ -48258,7 +48255,7 @@
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/aisat_interior)
 "cvf" = (
-/obj/machinery/status_display,
+/obj/machinery/status_display/evac,
 /turf/closed/wall/r_wall,
 /area/ai_monitored/turret_protected/ai)
 "cvg" = (
@@ -48778,7 +48775,7 @@
 /obj/machinery/light{
 	dir = 8
 	},
-/obj/machinery/status_display{
+/obj/machinery/status_display/evac{
 	pixel_x = -32
 	},
 /turf/open/floor/circuit,
@@ -48831,7 +48828,7 @@
 /obj/machinery/light{
 	dir = 4
 	},
-/obj/machinery/ai_status_display{
+/obj/machinery/status_display/ai{
 	pixel_x = 32
 	},
 /turf/open/floor/circuit,
@@ -49876,7 +49873,7 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "cBu" = (
-/obj/machinery/ai_status_display{
+/obj/machinery/status_display/ai{
 	pixel_y = 32
 	},
 /obj/effect/landmark/event_spawn,
@@ -50625,11 +50622,11 @@
 /turf/open/floor/engine,
 /area/engine/engineering)
 "cEf" = (
-/obj/machinery/ai_status_display,
+/obj/machinery/status_display/ai,
 /turf/closed/wall/r_wall,
 /area/engine/supermatter)
 "cEg" = (
-/obj/machinery/status_display,
+/obj/machinery/status_display/evac,
 /turf/closed/wall/r_wall,
 /area/engine/supermatter)
 "cEh" = (

--- a/_maps/map_files/Deltastation/DeltaStation2.dmm
+++ b/_maps/map_files/Deltastation/DeltaStation2.dmm
@@ -586,7 +586,7 @@
 /turf/open/space,
 /area/solar/starboard/fore)
 "acV" = (
-/obj/machinery/status_display{
+/obj/machinery/status_display/evac{
 	pixel_x = -32
 	},
 /obj/machinery/light{
@@ -601,7 +601,7 @@
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
 "acW" = (
-/obj/machinery/status_display{
+/obj/machinery/status_display/evac{
 	pixel_x = 32
 	},
 /obj/machinery/light{
@@ -621,7 +621,7 @@
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
 "acX" = (
-/obj/machinery/status_display{
+/obj/machinery/status_display/evac{
 	pixel_x = -32
 	},
 /obj/machinery/light{
@@ -633,7 +633,7 @@
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
 "acY" = (
-/obj/machinery/status_display{
+/obj/machinery/status_display/evac{
 	pixel_x = 32
 	},
 /obj/machinery/light{
@@ -650,7 +650,7 @@
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
 "adb" = (
-/obj/machinery/status_display{
+/obj/machinery/status_display/evac{
 	pixel_x = -32
 	},
 /obj/machinery/light{
@@ -667,7 +667,7 @@
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
 "adc" = (
-/obj/machinery/status_display{
+/obj/machinery/status_display/evac{
 	pixel_x = 32
 	},
 /obj/machinery/light{
@@ -922,7 +922,7 @@
 /turf/open/floor/plasteel/neutral,
 /area/hallway/secondary/entry)
 "aeB" = (
-/obj/machinery/status_display,
+/obj/machinery/status_display/evac,
 /turf/closed/wall,
 /area/construction/mining/aux_base)
 "aeC" = (
@@ -1489,7 +1489,7 @@
 	},
 /area/construction/mining/aux_base)
 "ahO" = (
-/obj/machinery/status_display{
+/obj/machinery/status_display/evac{
 	pixel_x = -32
 	},
 /obj/machinery/light{
@@ -1502,7 +1502,7 @@
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
 "ahP" = (
-/obj/machinery/status_display{
+/obj/machinery/status_display/evac{
 	pixel_x = 32
 	},
 /obj/machinery/light{
@@ -1520,7 +1520,7 @@
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
 "ahR" = (
-/obj/machinery/status_display{
+/obj/machinery/status_display/evac{
 	pixel_x = -32
 	},
 /obj/machinery/light{
@@ -1533,7 +1533,7 @@
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
 "ahS" = (
-/obj/machinery/status_display{
+/obj/machinery/status_display/evac{
 	pixel_x = 32
 	},
 /obj/machinery/light{
@@ -1551,7 +1551,7 @@
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
 "ahW" = (
-/obj/machinery/status_display{
+/obj/machinery/status_display/evac{
 	pixel_x = -32
 	},
 /obj/machinery/light{
@@ -1569,7 +1569,7 @@
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
 "ahX" = (
-/obj/machinery/status_display{
+/obj/machinery/status_display/evac{
 	pixel_x = 32
 	},
 /obj/machinery/light{
@@ -2499,7 +2499,7 @@
 /turf/open/floor/plasteel,
 /area/security/vacantoffice)
 "akC" = (
-/obj/machinery/status_display,
+/obj/machinery/status_display/evac,
 /turf/closed/wall,
 /area/security/vacantoffice)
 "akD" = (
@@ -2840,11 +2840,11 @@
 	},
 /area/security/checkpoint/customs)
 "alx" = (
-/obj/machinery/ai_status_display,
+/obj/machinery/status_display/ai,
 /turf/closed/wall,
 /area/hallway/secondary/entry)
 "aly" = (
-/obj/machinery/status_display,
+/obj/machinery/status_display/evac,
 /turf/closed/wall,
 /area/hallway/secondary/entry)
 "alz" = (
@@ -3108,7 +3108,7 @@
 /turf/open/floor/carpet,
 /area/security/vacantoffice)
 "amh" = (
-/obj/machinery/ai_status_display{
+/obj/machinery/status_display/ai{
 	pixel_x = 32
 	},
 /obj/structure/frame/computer,
@@ -3419,7 +3419,7 @@
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/electronic_marketing_den)
 "amP" = (
-/obj/machinery/status_display{
+/obj/machinery/status_display/evac{
 	pixel_y = 32
 	},
 /obj/machinery/light/small{
@@ -3452,7 +3452,7 @@
 /turf/open/floor/wood,
 /area/crew_quarters/electronic_marketing_den)
 "amU" = (
-/obj/machinery/status_display{
+/obj/machinery/status_display/evac{
 	pixel_y = 32
 	},
 /obj/machinery/light/small{
@@ -3527,7 +3527,7 @@
 /turf/open/floor/carpet,
 /area/security/vacantoffice)
 "ang" = (
-/obj/machinery/status_display{
+/obj/machinery/status_display/evac{
 	pixel_x = 32
 	},
 /obj/structure/frame/computer,
@@ -3545,7 +3545,7 @@
 /obj/machinery/computer/crew{
 	dir = 4
 	},
-/obj/machinery/ai_status_display{
+/obj/machinery/status_display/ai{
 	pixel_x = -32
 	},
 /turf/open/floor/plasteel/blue/side{
@@ -3647,7 +3647,7 @@
 /obj/machinery/computer/prisoner{
 	dir = 8
 	},
-/obj/machinery/status_display{
+/obj/machinery/status_display/evac{
 	pixel_x = 32
 	},
 /obj/machinery/camera{
@@ -4326,7 +4326,7 @@
 /obj/machinery/computer/med_data{
 	dir = 4
 	},
-/obj/machinery/status_display{
+/obj/machinery/status_display/evac{
 	pixel_x = -32
 	},
 /turf/open/floor/plasteel/blue/side{
@@ -4414,7 +4414,7 @@
 /obj/machinery/computer/secure_data{
 	dir = 8
 	},
-/obj/machinery/ai_status_display{
+/obj/machinery/status_display/ai{
 	pixel_x = 32
 	},
 /turf/open/floor/plasteel/red/side{
@@ -4704,7 +4704,7 @@
 /area/crew_quarters/electronic_marketing_den)
 "apY" = (
 /obj/structure/frame/computer,
-/obj/machinery/status_display{
+/obj/machinery/status_display/evac{
 	pixel_x = 32
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -7538,7 +7538,7 @@
 /turf/open/floor/plasteel/neutral,
 /area/janitor)
 "avA" = (
-/obj/machinery/status_display{
+/obj/machinery/status_display/evac{
 	pixel_y = 32
 	},
 /obj/effect/decal/cleanable/dirt,
@@ -7580,7 +7580,7 @@
 /area/janitor)
 "avD" = (
 /obj/structure/table/reinforced,
-/obj/machinery/status_display{
+/obj/machinery/status_display/evac{
 	pixel_y = 32
 	},
 /obj/item/clipboard,
@@ -7835,7 +7835,7 @@
 /turf/open/floor/plasteel,
 /area/engine/atmospherics_engine)
 "awf" = (
-/obj/machinery/ai_status_display,
+/obj/machinery/status_display/ai,
 /turf/closed/wall/r_wall,
 /area/engine/supermatter)
 "awg" = (
@@ -7846,7 +7846,7 @@
 /turf/open/floor/plating,
 /area/engine/supermatter)
 "awi" = (
-/obj/machinery/status_display,
+/obj/machinery/status_display/evac,
 /turf/closed/wall/r_wall,
 /area/engine/supermatter)
 "awj" = (
@@ -8286,10 +8286,7 @@
 /turf/open/floor/plasteel,
 /area/quartermaster/storage)
 "axn" = (
-/obj/machinery/status_display{
-	name = "cargo display";
-	supply_display = 1
-	},
+/obj/machinery/status_display/supply,
 /turf/closed/wall,
 /area/quartermaster/storage)
 "axo" = (
@@ -8609,7 +8606,7 @@
 /turf/open/floor/plasteel/neutral/side,
 /area/crew_quarters/toilet/auxiliary)
 "ayd" = (
-/obj/machinery/status_display{
+/obj/machinery/status_display/evac{
 	pixel_y = -32
 	},
 /turf/open/floor/plasteel/neutral/side,
@@ -10050,7 +10047,7 @@
 /area/hydroponics/garden/abandoned)
 "aBm" = (
 /obj/item/twohanded/required/kirbyplants/random,
-/obj/machinery/status_display{
+/obj/machinery/status_display/evac{
 	pixel_y = 32
 	},
 /obj/effect/turf_decal/delivery,
@@ -11137,7 +11134,7 @@
 /area/hallway/secondary/service)
 "aDF" = (
 /obj/structure/bed,
-/obj/machinery/status_display{
+/obj/machinery/status_display/evac{
 	pixel_y = 32
 	},
 /obj/item/bedsheet/rainbow,
@@ -11701,7 +11698,7 @@
 /area/crew_quarters/bar)
 "aER" = (
 /obj/structure/closet/secure_closet/bar,
-/obj/machinery/status_display{
+/obj/machinery/status_display/evac{
 	pixel_y = 32
 	},
 /obj/machinery/light/small{
@@ -11745,7 +11742,7 @@
 /area/crew_quarters/bar)
 "aEW" = (
 /obj/machinery/vending/boozeomat,
-/obj/machinery/status_display{
+/obj/machinery/status_display/evac{
 	pixel_y = 32
 	},
 /turf/open/floor/plasteel/dark,
@@ -11770,7 +11767,7 @@
 /area/crew_quarters/bar)
 "aEY" = (
 /obj/structure/table/wood,
-/obj/machinery/status_display{
+/obj/machinery/status_display/evac{
 	pixel_y = 32
 	},
 /obj/item/clipboard,
@@ -12088,7 +12085,7 @@
 /area/hydroponics/garden/abandoned)
 "aFM" = (
 /obj/machinery/seed_extractor,
-/obj/machinery/status_display{
+/obj/machinery/status_display/evac{
 	pixel_y = -32
 	},
 /obj/item/reagent_containers/glass/bucket,
@@ -12415,7 +12412,7 @@
 /turf/open/floor/plating,
 /area/quartermaster/sorting)
 "aGu" = (
-/obj/machinery/status_display{
+/obj/machinery/status_display/evac{
 	pixel_y = 32
 	},
 /obj/structure/reagent_dispensers/peppertank{
@@ -12450,7 +12447,7 @@
 	},
 /area/security/checkpoint/supply)
 "aGw" = (
-/obj/machinery/ai_status_display{
+/obj/machinery/status_display/ai{
 	pixel_y = 32
 	},
 /obj/machinery/firealarm{
@@ -12847,7 +12844,7 @@
 /turf/open/floor/plasteel,
 /area/engine/atmospherics_engine)
 "aHa" = (
-/obj/machinery/status_display{
+/obj/machinery/status_display/evac{
 	pixel_y = -32
 	},
 /obj/machinery/light,
@@ -13765,7 +13762,7 @@
 /area/hallway/secondary/service)
 "aIP" = (
 /obj/structure/bed,
-/obj/machinery/status_display{
+/obj/machinery/status_display/evac{
 	pixel_y = 32
 	},
 /obj/item/bedsheet/orange,
@@ -13833,7 +13830,7 @@
 	},
 /area/crew_quarters/bar)
 "aIY" = (
-/obj/machinery/status_display,
+/obj/machinery/status_display/evac,
 /turf/closed/wall,
 /area/crew_quarters/bar)
 "aIZ" = (
@@ -14667,7 +14664,7 @@
 	icon_state = "0-4"
 	},
 /obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/ai_status_display{
+/obj/machinery/status_display/ai{
 	pixel_x = -32
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -14693,7 +14690,7 @@
 	icon_state = "0-8"
 	},
 /obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/status_display{
+/obj/machinery/status_display/evac{
 	pixel_x = 32
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -14727,7 +14724,7 @@
 /turf/closed/wall/r_wall,
 /area/maintenance/disposal/incinerator)
 "aLd" = (
-/obj/machinery/status_display{
+/obj/machinery/status_display/evac{
 	pixel_x = -32
 	},
 /obj/machinery/atmospherics/components/unary/portables_connector/visible,
@@ -14908,7 +14905,7 @@
 	name = "Engineering Power Monitoring Console"
 	},
 /obj/structure/cable/white,
-/obj/machinery/status_display{
+/obj/machinery/status_display/evac{
 	pixel_y = -32
 	},
 /turf/open/floor/plasteel/vault,
@@ -15607,7 +15604,7 @@
 /area/hallway/secondary/service)
 "aNa" = (
 /obj/structure/table/wood,
-/obj/machinery/status_display{
+/obj/machinery/status_display/evac{
 	pixel_x = -32
 	},
 /obj/item/camera_film{
@@ -15656,7 +15653,7 @@
 /obj/structure/window/reinforced{
 	dir = 4
 	},
-/obj/machinery/status_display{
+/obj/machinery/status_display/evac{
 	pixel_y = 32
 	},
 /obj/structure/easel,
@@ -15715,7 +15712,7 @@
 /turf/open/floor/plasteel,
 /area/quartermaster/sorting)
 "aNo" = (
-/obj/machinery/status_display,
+/obj/machinery/status_display/evac,
 /turf/closed/wall,
 /area/quartermaster/sorting)
 "aNp" = (
@@ -16127,7 +16124,7 @@
 	},
 /area/engine/atmos)
 "aOh" = (
-/obj/machinery/status_display{
+/obj/machinery/status_display/evac{
 	pixel_y = 32
 	},
 /obj/machinery/light/small{
@@ -16244,7 +16241,7 @@
 /obj/machinery/newscaster{
 	pixel_y = 32
 	},
-/obj/machinery/status_display{
+/obj/machinery/status_display/evac{
 	pixel_x = -32
 	},
 /turf/open/floor/plasteel/redblue,
@@ -17332,10 +17329,7 @@
 	},
 /area/quartermaster/storage)
 "aQO" = (
-/obj/machinery/status_display{
-	name = "cargo display";
-	supply_display = 1
-	},
+/obj/machinery/status_display/supply,
 /turf/closed/wall,
 /area/quartermaster/qm)
 "aQP" = (
@@ -18318,7 +18312,7 @@
 	dir = 4;
 	pixel_x = -23
 	},
-/obj/machinery/status_display{
+/obj/machinery/status_display/evac{
 	pixel_y = 32
 	},
 /obj/item/reagent_containers/glass/bottle/morphine{
@@ -18956,7 +18950,7 @@
 /area/quartermaster/office)
 "aTT" = (
 /obj/machinery/photocopier,
-/obj/machinery/ai_status_display{
+/obj/machinery/status_display/ai{
 	pixel_y = 32
 	},
 /turf/open/floor/plasteel/brown{
@@ -19200,7 +19194,7 @@
 /turf/open/floor/plasteel/neutral,
 /area/quartermaster/qm)
 "aUs" = (
-/obj/machinery/status_display{
+/obj/machinery/status_display/evac{
 	pixel_x = 32
 	},
 /obj/machinery/camera{
@@ -20111,7 +20105,7 @@
 /obj/machinery/light{
 	dir = 4
 	},
-/obj/machinery/ai_status_display{
+/obj/machinery/status_display/ai{
 	pixel_x = 32
 	},
 /turf/open/floor/plasteel/brown{
@@ -20398,7 +20392,7 @@
 /turf/open/floor/plasteel/neutral,
 /area/engine/atmos)
 "aWG" = (
-/obj/machinery/ai_status_display,
+/obj/machinery/status_display/ai,
 /turf/closed/wall,
 /area/engine/atmos)
 "aWH" = (
@@ -20425,7 +20419,7 @@
 /turf/closed/wall,
 /area/engine/atmos)
 "aWK" = (
-/obj/machinery/status_display,
+/obj/machinery/status_display/evac,
 /turf/closed/wall,
 /area/engine/atmos)
 "aWL" = (
@@ -20912,7 +20906,7 @@
 /area/security/prison)
 "aXM" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/machinery/status_display,
+/obj/machinery/status_display/evac,
 /turf/closed/wall,
 /area/security/prison)
 "aXN" = (
@@ -21344,7 +21338,7 @@
 /turf/closed/wall,
 /area/crew_quarters/kitchen)
 "aYD" = (
-/obj/machinery/status_display,
+/obj/machinery/status_display/evac,
 /turf/closed/wall,
 /area/crew_quarters/kitchen)
 "aYE" = (
@@ -21503,7 +21497,7 @@
 /turf/open/floor/plasteel,
 /area/quartermaster/storage)
 "aYW" = (
-/obj/machinery/ai_status_display{
+/obj/machinery/status_display/ai{
 	pixel_y = -32
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -22452,7 +22446,7 @@
 /turf/open/floor/plasteel,
 /area/quartermaster/miningoffice)
 "baX" = (
-/obj/machinery/status_display,
+/obj/machinery/status_display/evac,
 /turf/closed/wall,
 /area/quartermaster/qm)
 "baY" = (
@@ -23088,7 +23082,7 @@
 /turf/open/floor/plasteel,
 /area/quartermaster/office)
 "bcr" = (
-/obj/machinery/status_display,
+/obj/machinery/status_display/evac,
 /turf/closed/wall,
 /area/quartermaster/office)
 "bcs" = (
@@ -23308,7 +23302,7 @@
 /obj/structure/closet/secure_closet/brig{
 	name = "Prisoner Locker"
 	},
-/obj/machinery/ai_status_display{
+/obj/machinery/status_display/ai{
 	pixel_y = -32
 	},
 /obj/machinery/light/small{
@@ -23329,7 +23323,7 @@
 /obj/structure/closet/secure_closet/brig{
 	name = "Prisoner Locker"
 	},
-/obj/machinery/status_display{
+/obj/machinery/status_display/evac{
 	pixel_y = -32
 	},
 /turf/open/floor/plasteel/vault,
@@ -25869,7 +25863,7 @@
 /obj/machinery/computer/security{
 	dir = 8
 	},
-/obj/machinery/status_display{
+/obj/machinery/status_display/evac{
 	pixel_x = 32
 	},
 /turf/open/floor/plasteel/vault{
@@ -26847,7 +26841,7 @@
 	},
 /area/engine/atmos)
 "bkY" = (
-/obj/machinery/status_display{
+/obj/machinery/status_display/evac{
 	pixel_x = 32
 	},
 /obj/machinery/light/small{
@@ -26887,7 +26881,7 @@
 /area/maintenance/port/fore)
 "bld" = (
 /obj/machinery/hydroponics/constructable,
-/obj/machinery/status_display{
+/obj/machinery/status_display/evac{
 	pixel_x = -32
 	},
 /obj/effect/turf_decal/delivery,
@@ -27019,7 +27013,7 @@
 /area/crew_quarters/kitchen)
 "bls" = (
 /obj/machinery/light,
-/obj/machinery/status_display{
+/obj/machinery/status_display/evac{
 	pixel_y = -32
 	},
 /obj/machinery/vending/dinnerware,
@@ -27511,7 +27505,7 @@
 /turf/open/floor/plasteel/grimy,
 /area/crew_quarters/heads/hos)
 "bmx" = (
-/obj/machinery/ai_status_display{
+/obj/machinery/status_display/ai{
 	pixel_x = 32;
 	pixel_y = 32
 	},
@@ -27563,7 +27557,7 @@
 "bmB" = (
 /obj/structure/bed,
 /obj/item/bedsheet/hos,
-/obj/machinery/status_display{
+/obj/machinery/status_display/evac{
 	pixel_y = 32
 	},
 /obj/machinery/camera{
@@ -27993,7 +27987,7 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/fore)
 "bnx" = (
-/obj/machinery/status_display,
+/obj/machinery/status_display/evac,
 /turf/closed/wall,
 /area/hallway/primary/fore)
 "bny" = (
@@ -28366,7 +28360,7 @@
 /obj/machinery/atmospherics/pipe/manifold/cyan/visible{
 	dir = 8
 	},
-/obj/machinery/status_display{
+/obj/machinery/status_display/evac{
 	pixel_x = -32
 	},
 /turf/open/floor/plating,
@@ -28523,7 +28517,7 @@
 /turf/open/floor/plasteel,
 /area/hydroponics)
 "boD" = (
-/obj/machinery/status_display,
+/obj/machinery/status_display/evac,
 /turf/closed/wall,
 /area/hydroponics)
 "boE" = (
@@ -28803,7 +28797,7 @@
 /area/security/execution/transfer)
 "bpf" = (
 /obj/machinery/computer/shuttle/labor,
-/obj/machinery/status_display{
+/obj/machinery/status_display/evac{
 	pixel_y = 32
 	},
 /turf/open/floor/plasteel/red/side{
@@ -28819,7 +28813,7 @@
 /area/security/execution/transfer)
 "bph" = (
 /obj/machinery/computer/secure_data,
-/obj/machinery/ai_status_display{
+/obj/machinery/status_display/ai{
 	pixel_y = 32
 	},
 /obj/machinery/camera{
@@ -31121,7 +31115,7 @@
 /turf/open/floor/plasteel/grimy,
 /area/crew_quarters/heads/hos)
 "btA" = (
-/obj/machinery/status_display{
+/obj/machinery/status_display/evac{
 	pixel_x = 32;
 	pixel_y = -32
 	},
@@ -31154,7 +31148,7 @@
 /area/crew_quarters/heads/hos)
 "btD" = (
 /obj/machinery/light,
-/obj/machinery/ai_status_display{
+/obj/machinery/status_display/ai{
 	pixel_y = -32
 	},
 /obj/item/radio/intercom{
@@ -31409,7 +31403,7 @@
 /turf/open/floor/plasteel,
 /area/engine/atmos)
 "buf" = (
-/obj/machinery/status_display,
+/obj/machinery/status_display/evac,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/closed/wall/r_wall,
 /area/engine/atmos)
@@ -31516,7 +31510,7 @@
 /turf/open/floor/plating,
 /area/hallway/primary/central)
 "bur" = (
-/obj/machinery/status_display,
+/obj/machinery/status_display/evac,
 /turf/closed/wall,
 /area/hallway/primary/central)
 "bus" = (
@@ -32185,7 +32179,7 @@
 	},
 /area/security/nuke_storage)
 "bvR" = (
-/obj/machinery/ai_status_display{
+/obj/machinery/status_display/ai{
 	pixel_y = 32
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on,
@@ -32295,7 +32289,7 @@
 /area/security/main)
 "bwi" = (
 /obj/machinery/light,
-/obj/machinery/ai_status_display{
+/obj/machinery/status_display/ai{
 	pixel_y = -32
 	},
 /obj/machinery/camera{
@@ -32343,7 +32337,7 @@
 /turf/open/floor/plating,
 /area/crew_quarters/heads/hos)
 "bwn" = (
-/obj/machinery/ai_status_display,
+/obj/machinery/status_display/ai,
 /turf/closed/wall/r_wall,
 /area/ai_monitored/turret_protected/ai)
 "bwo" = (
@@ -32452,7 +32446,7 @@
 	},
 /area/engine/atmos)
 "bwy" = (
-/obj/machinery/status_display,
+/obj/machinery/status_display/evac,
 /turf/closed/wall/r_wall,
 /area/engine/atmos)
 "bwz" = (
@@ -33049,7 +33043,7 @@
 /turf/closed/wall/r_wall,
 /area/engine/storage_shared)
 "bxH" = (
-/obj/machinery/status_display,
+/obj/machinery/status_display/evac,
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
 	dir = 4
 	},
@@ -33289,7 +33283,7 @@
 /area/bridge)
 "byj" = (
 /obj/structure/table/reinforced,
-/obj/machinery/ai_status_display{
+/obj/machinery/status_display/ai{
 	pixel_y = 32
 	},
 /obj/item/restraints/handcuffs,
@@ -33319,7 +33313,7 @@
 /area/bridge)
 "byn" = (
 /obj/structure/table/reinforced,
-/obj/machinery/status_display{
+/obj/machinery/status_display/evac{
 	pixel_y = 32
 	},
 /obj/item/storage/toolbox/mechanical,
@@ -33827,7 +33821,7 @@
 /turf/closed/wall/r_wall,
 /area/engine/break_room)
 "bzt" = (
-/obj/machinery/status_display{
+/obj/machinery/status_display/evac{
 	pixel_x = -32
 	},
 /obj/structure/cable/white{
@@ -34406,7 +34400,7 @@
 	},
 /area/aisat)
 "bAx" = (
-/obj/machinery/status_display,
+/obj/machinery/status_display/evac,
 /turf/closed/wall/r_wall,
 /area/ai_monitored/turret_protected/ai)
 "bAy" = (
@@ -34522,7 +34516,7 @@
 /obj/machinery/light{
 	dir = 1
 	},
-/obj/machinery/status_display{
+/obj/machinery/status_display/evac{
 	pixel_y = 32
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -35070,7 +35064,7 @@
 	},
 /area/security/nuke_storage)
 "bBV" = (
-/obj/machinery/status_display{
+/obj/machinery/status_display/evac{
 	pixel_y = -32
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
@@ -35644,7 +35638,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/item/paper_bin,
 /obj/item/pen,
-/obj/machinery/status_display{
+/obj/machinery/status_display/evac{
 	pixel_y = -32
 	},
 /obj/machinery/requests_console{
@@ -35877,7 +35871,7 @@
 /turf/open/floor/plasteel,
 /area/storage/primary)
 "bDu" = (
-/obj/machinery/status_display,
+/obj/machinery/status_display/evac,
 /turf/closed/wall,
 /area/storage/primary)
 "bDv" = (
@@ -36859,7 +36853,7 @@
 /area/hallway/primary/port)
 "bES" = (
 /obj/item/twohanded/required/kirbyplants/random,
-/obj/machinery/status_display{
+/obj/machinery/status_display/evac{
 	pixel_x = -32
 	},
 /turf/open/floor/plasteel/vault{
@@ -36880,7 +36874,7 @@
 /area/storage/tech)
 "bEV" = (
 /obj/item/twohanded/required/kirbyplants/random,
-/obj/machinery/ai_status_display{
+/obj/machinery/status_display/ai{
 	pixel_x = 32
 	},
 /turf/open/floor/plasteel/vault{
@@ -37496,7 +37490,7 @@
 /turf/open/floor/plasteel,
 /area/engine/storage_shared)
 "bGe" = (
-/obj/machinery/status_display{
+/obj/machinery/status_display/evac{
 	pixel_x = 32;
 	pixel_y = -32
 	},
@@ -37608,7 +37602,7 @@
 /turf/open/floor/plasteel/neutral,
 /area/engine/break_room)
 "bGr" = (
-/obj/machinery/status_display{
+/obj/machinery/status_display/evac{
 	pixel_x = 32;
 	pixel_y = 32
 	},
@@ -37769,7 +37763,7 @@
 /obj/structure/rack,
 /obj/item/airlock_painter,
 /obj/item/toner,
-/obj/machinery/status_display{
+/obj/machinery/status_display/evac{
 	pixel_x = -32
 	},
 /obj/effect/turf_decal/bot,
@@ -38293,7 +38287,7 @@
 /area/engine/gravity_generator)
 "bHP" = (
 /obj/machinery/light,
-/obj/machinery/status_display{
+/obj/machinery/status_display/evac{
 	pixel_y = -32
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -38381,7 +38375,7 @@
 /turf/closed/wall,
 /area/engine/break_room)
 "bHX" = (
-/obj/machinery/status_display,
+/obj/machinery/status_display/evac,
 /turf/closed/wall,
 /area/engine/break_room)
 "bHY" = (
@@ -38767,7 +38761,7 @@
 	},
 /area/bridge)
 "bIN" = (
-/obj/machinery/status_display,
+/obj/machinery/status_display/evac,
 /turf/closed/wall,
 /area/bridge)
 "bIO" = (
@@ -38855,7 +38849,7 @@
 /turf/open/floor/plasteel/grimy,
 /area/bridge)
 "bIT" = (
-/obj/machinery/ai_status_display,
+/obj/machinery/status_display/ai,
 /turf/closed/wall,
 /area/bridge)
 "bIU" = (
@@ -39028,7 +39022,7 @@
 /area/security/detectives_office)
 "bJm" = (
 /obj/machinery/photocopier,
-/obj/machinery/ai_status_display{
+/obj/machinery/status_display/ai{
 	pixel_y = 32
 	},
 /turf/open/floor/plasteel/vault,
@@ -39322,7 +39316,7 @@
 "bJS" = (
 /obj/machinery/cell_charger,
 /obj/structure/table/reinforced,
-/obj/machinery/ai_status_display{
+/obj/machinery/status_display/ai{
 	pixel_y = 32
 	},
 /obj/item/stock_parts/cell/high,
@@ -39619,7 +39613,7 @@
 /turf/open/floor/plasteel/neutral/corner,
 /area/hallway/primary/central)
 "bKy" = (
-/obj/machinery/status_display{
+/obj/machinery/status_display/evac{
 	pixel_x = -32
 	},
 /obj/machinery/newscaster{
@@ -39750,7 +39744,7 @@
 /turf/open/floor/wood,
 /area/crew_quarters/heads/captain)
 "bKQ" = (
-/obj/machinery/ai_status_display{
+/obj/machinery/status_display/ai{
 	pixel_y = 32
 	},
 /turf/open/floor/plasteel/vault{
@@ -39762,7 +39756,7 @@
 /turf/open/floor/plasteel/vault,
 /area/crew_quarters/heads/captain)
 "bKS" = (
-/obj/machinery/status_display{
+/obj/machinery/status_display/evac{
 	pixel_y = 32
 	},
 /turf/open/floor/plasteel/vault{
@@ -40164,7 +40158,7 @@
 	},
 /area/engine/transit_tube)
 "bLH" = (
-/obj/machinery/status_display,
+/obj/machinery/status_display/evac,
 /turf/closed/wall,
 /area/engine/transit_tube)
 "bLI" = (
@@ -40446,7 +40440,7 @@
 /area/hallway/primary/port)
 "bMg" = (
 /obj/item/twohanded/required/kirbyplants/random,
-/obj/machinery/ai_status_display{
+/obj/machinery/status_display/ai{
 	pixel_x = -32
 	},
 /turf/open/floor/plasteel/vault{
@@ -40472,7 +40466,7 @@
 /area/storage/tech)
 "bMj" = (
 /obj/item/twohanded/required/kirbyplants/random,
-/obj/machinery/status_display{
+/obj/machinery/status_display/evac{
 	pixel_x = 32
 	},
 /turf/open/floor/plasteel/vault{
@@ -40490,7 +40484,7 @@
 	pixel_x = 3;
 	pixel_y = -3
 	},
-/obj/machinery/status_display{
+/obj/machinery/status_display/evac{
 	pixel_x = -32
 	},
 /obj/effect/turf_decal/bot,
@@ -41297,7 +41291,7 @@
 /obj/machinery/computer/card/minor/ce{
 	dir = 4
 	},
-/obj/machinery/status_display{
+/obj/machinery/status_display/evac{
 	pixel_x = -32
 	},
 /turf/open/floor/plasteel/vault{
@@ -41411,7 +41405,7 @@
 /turf/open/floor/plasteel/yellow/side,
 /area/engine/break_room)
 "bOd" = (
-/obj/machinery/status_display{
+/obj/machinery/status_display/evac{
 	pixel_y = -32
 	},
 /turf/open/floor/plasteel/yellow/side,
@@ -41651,7 +41645,7 @@
 /area/bridge/meeting_room/council)
 "bOG" = (
 /obj/machinery/announcement_system,
-/obj/machinery/ai_status_display{
+/obj/machinery/status_display/ai{
 	pixel_x = -32
 	},
 /turf/open/floor/plasteel/vault{
@@ -41714,7 +41708,7 @@
 /obj/machinery/computer/telecomms/monitor{
 	dir = 8
 	},
-/obj/machinery/status_display{
+/obj/machinery/status_display/evac{
 	pixel_x = 32
 	},
 /turf/open/floor/plasteel/vault{
@@ -41901,7 +41895,7 @@
 /obj/machinery/light{
 	dir = 4
 	},
-/obj/machinery/status_display{
+/obj/machinery/status_display/evac{
 	pixel_x = 32
 	},
 /turf/open/floor/carpet,
@@ -42069,7 +42063,7 @@
 /turf/closed/wall/r_wall,
 /area/ai_monitored/turret_protected/aisat_interior)
 "bPD" = (
-/obj/machinery/ai_status_display,
+/obj/machinery/status_display/ai,
 /turf/closed/wall/r_wall,
 /area/ai_monitored/turret_protected/aisat_interior)
 "bPE" = (
@@ -42111,7 +42105,7 @@
 /turf/closed/wall/r_wall,
 /area/ai_monitored/turret_protected/aisat_interior)
 "bPI" = (
-/obj/machinery/status_display,
+/obj/machinery/status_display/evac,
 /turf/closed/wall/r_wall,
 /area/ai_monitored/turret_protected/aisat_interior)
 "bPJ" = (
@@ -42988,7 +42982,7 @@
 /obj/machinery/light{
 	dir = 1
 	},
-/obj/machinery/ai_status_display{
+/obj/machinery/status_display/ai{
 	pixel_y = 32
 	},
 /obj/effect/turf_decal/stripes/line{
@@ -43073,7 +43067,7 @@
 /obj/machinery/light{
 	dir = 1
 	},
-/obj/machinery/ai_status_display{
+/obj/machinery/status_display/ai{
 	pixel_y = 32
 	},
 /obj/effect/turf_decal/stripes/line,
@@ -43230,7 +43224,7 @@
 "bSe" = (
 /obj/structure/table/wood,
 /obj/item/flashlight/lamp,
-/obj/machinery/ai_status_display{
+/obj/machinery/status_display/ai{
 	pixel_y = 32
 	},
 /turf/open/floor/plasteel/grimy,
@@ -43245,7 +43239,7 @@
 /area/crew_quarters/heads/chief)
 "bSg" = (
 /obj/structure/dresser,
-/obj/machinery/status_display{
+/obj/machinery/status_display/evac{
 	pixel_y = 32
 	},
 /turf/open/floor/plasteel/grimy,
@@ -43428,7 +43422,7 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "bSx" = (
-/obj/machinery/ai_status_display{
+/obj/machinery/status_display/ai{
 	pixel_x = -32
 	},
 /obj/structure/table/wood,
@@ -44187,7 +44181,7 @@
 /obj/machinery/computer/station_alert{
 	dir = 4
 	},
-/obj/machinery/status_display{
+/obj/machinery/status_display/evac{
 	pixel_x = -32
 	},
 /turf/open/floor/plasteel/vault{
@@ -44762,7 +44756,7 @@
 /area/crew_quarters/heads/captain)
 "bUP" = (
 /obj/structure/table/wood,
-/obj/machinery/status_display{
+/obj/machinery/status_display/evac{
 	pixel_x = 32
 	},
 /obj/item/coin/adamantine{
@@ -45814,7 +45808,7 @@
 /turf/open/floor/plasteel/neutral/corner,
 /area/hallway/primary/central)
 "bWO" = (
-/obj/machinery/ai_status_display,
+/obj/machinery/status_display/ai,
 /turf/closed/wall,
 /area/hallway/primary/central)
 "bWP" = (
@@ -45943,7 +45937,7 @@
 /obj/machinery/computer/communications{
 	dir = 4
 	},
-/obj/machinery/ai_status_display{
+/obj/machinery/status_display/ai{
 	pixel_x = -32
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -46677,7 +46671,7 @@
 	},
 /area/engine/transit_tube)
 "bYp" = (
-/obj/machinery/ai_status_display{
+/obj/machinery/status_display/ai{
 	pixel_y = -32
 	},
 /obj/structure/transit_tube/station/reverse/flipped,
@@ -46846,7 +46840,7 @@
 /obj/machinery/computer/station_alert{
 	dir = 1
 	},
-/obj/machinery/ai_status_display{
+/obj/machinery/status_display/ai{
 	pixel_y = -32
 	},
 /turf/open/floor/plasteel/red/side,
@@ -46879,7 +46873,7 @@
 	pixel_x = 26;
 	pixel_y = -32
 	},
-/obj/machinery/status_display{
+/obj/machinery/status_display/evac{
 	pixel_x = 32
 	},
 /obj/machinery/recharger,
@@ -47584,7 +47578,7 @@
 /area/ai_monitored/turret_protected/aisat_interior)
 "caa" = (
 /obj/machinery/recharge_station,
-/obj/machinery/ai_status_display{
+/obj/machinery/status_display/ai{
 	pixel_y = -32
 	},
 /obj/effect/turf_decal/stripes/line{
@@ -47611,7 +47605,7 @@
 /area/ai_monitored/turret_protected/aisat_interior)
 "cac" = (
 /obj/machinery/recharge_station,
-/obj/machinery/status_display{
+/obj/machinery/status_display/evac{
 	pixel_y = -32
 	},
 /obj/effect/turf_decal/stripes/line{
@@ -47690,7 +47684,7 @@
 "cal" = (
 /obj/structure/table/reinforced,
 /obj/item/paper_bin,
-/obj/machinery/status_display{
+/obj/machinery/status_display/evac{
 	pixel_y = -32
 	},
 /obj/item/pen,
@@ -47721,7 +47715,7 @@
 	pixel_y = 3
 	},
 /obj/item/folder/yellow,
-/obj/machinery/ai_status_display{
+/obj/machinery/status_display/ai{
 	pixel_y = -32
 	},
 /obj/item/aicard,
@@ -47970,7 +47964,7 @@
 /area/crew_quarters/heads/hop)
 "caS" = (
 /obj/machinery/pdapainter,
-/obj/machinery/status_display{
+/obj/machinery/status_display/evac{
 	pixel_x = 32
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -48777,7 +48771,7 @@
 /turf/open/floor/plasteel/neutral,
 /area/hallway/primary/central)
 "ccz" = (
-/obj/machinery/status_display,
+/obj/machinery/status_display/evac,
 /turf/closed/wall/r_wall,
 /area/crew_quarters/heads/hop)
 "ccA" = (
@@ -49226,7 +49220,7 @@
 /turf/closed/wall/r_wall,
 /area/ai_monitored/turret_protected/ai_upload)
 "cdu" = (
-/obj/machinery/ai_status_display,
+/obj/machinery/status_display/ai,
 /turf/closed/wall/r_wall,
 /area/ai_monitored/turret_protected/ai_upload)
 "cdv" = (
@@ -49637,7 +49631,7 @@
 /obj/structure/table/wood,
 /obj/item/paper_bin,
 /obj/item/pen,
-/obj/machinery/status_display{
+/obj/machinery/status_display/evac{
 	pixel_x = 32
 	},
 /turf/open/floor/plasteel/vault{
@@ -49833,7 +49827,7 @@
 /obj/structure/table/wood,
 /obj/item/folder/blue,
 /obj/item/pen/fourcolor,
-/obj/machinery/status_display{
+/obj/machinery/status_display/evac{
 	pixel_x = -32
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -50362,7 +50356,7 @@
 /obj/machinery/light{
 	dir = 8
 	},
-/obj/machinery/status_display{
+/obj/machinery/status_display/evac{
 	pixel_x = -32
 	},
 /obj/effect/turf_decal/stripes/line{
@@ -50791,7 +50785,7 @@
 /area/crew_quarters/heads/captain/private)
 "cgz" = (
 /obj/structure/table,
-/obj/machinery/ai_status_display{
+/obj/machinery/status_display/ai{
 	pixel_x = -32
 	},
 /obj/item/storage/box/donkpockets,
@@ -51401,7 +51395,7 @@
 	pixel_x = -24;
 	pixel_y = -32
 	},
-/obj/machinery/status_display{
+/obj/machinery/status_display/evac{
 	pixel_y = -32
 	},
 /obj/structure/cable/white{
@@ -51772,7 +51766,7 @@
 /area/lawoffice)
 "ciy" = (
 /obj/machinery/photocopier,
-/obj/machinery/status_display{
+/obj/machinery/status_display/evac{
 	pixel_x = 32
 	},
 /obj/machinery/camera{
@@ -51934,7 +51928,7 @@
 /area/security/brig)
 "ciL" = (
 /obj/structure/closet/secure_closet/security/sec,
-/obj/machinery/status_display{
+/obj/machinery/status_display/evac{
 	pixel_y = -32
 	},
 /obj/structure/cable/white{
@@ -51977,7 +51971,7 @@
 /area/security/brig)
 "ciP" = (
 /obj/structure/closet/secure_closet/security/sec,
-/obj/machinery/ai_status_display{
+/obj/machinery/status_display/ai{
 	pixel_y = -32
 	},
 /obj/effect/turf_decal/bot,
@@ -52483,7 +52477,7 @@
 /turf/open/floor/plasteel/neutral,
 /area/security/courtroom)
 "ckd" = (
-/obj/machinery/status_display{
+/obj/machinery/status_display/evac{
 	pixel_x = 32
 	},
 /obj/machinery/camera{
@@ -52602,7 +52596,7 @@
 	},
 /area/ai_monitored/turret_protected/ai_upload)
 "cko" = (
-/obj/machinery/status_display{
+/obj/machinery/status_display/evac{
 	pixel_x = -32;
 	pixel_y = -32
 	},
@@ -52631,7 +52625,7 @@
 /turf/open/floor/circuit/green,
 /area/ai_monitored/turret_protected/ai_upload)
 "cks" = (
-/obj/machinery/status_display{
+/obj/machinery/status_display/evac{
 	pixel_x = 32;
 	pixel_y = -32
 	},
@@ -53604,7 +53598,7 @@
 /turf/open/floor/plasteel/grimy,
 /area/crew_quarters/heads/hop)
 "cmC" = (
-/obj/machinery/ai_status_display{
+/obj/machinery/status_display/ai{
 	pixel_x = 32
 	},
 /obj/item/twohanded/required/kirbyplants/random,
@@ -54199,7 +54193,7 @@
 /turf/closed/wall/r_wall,
 /area/engine/engineering)
 "cnD" = (
-/obj/machinery/status_display,
+/obj/machinery/status_display/evac,
 /turf/closed/wall/r_wall,
 /area/engine/engineering)
 "cnE" = (
@@ -54241,7 +54235,7 @@
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "cnH" = (
-/obj/machinery/status_display,
+/obj/machinery/status_display/evac,
 /turf/closed/wall,
 /area/engine/engineering)
 "cnI" = (
@@ -54546,7 +54540,7 @@
 /area/teleporter)
 "cor" = (
 /obj/machinery/teleport/station,
-/obj/machinery/status_display{
+/obj/machinery/status_display/evac{
 	pixel_x = 32
 	},
 /turf/open/floor/plasteel/vault{
@@ -55263,7 +55257,7 @@
 /area/teleporter)
 "cpV" = (
 /obj/structure/table,
-/obj/machinery/status_display{
+/obj/machinery/status_display/evac{
 	pixel_x = -32
 	},
 /obj/item/paper_bin,
@@ -55659,7 +55653,7 @@
 /area/library)
 "cqU" = (
 /obj/machinery/libraryscanner,
-/obj/machinery/status_display{
+/obj/machinery/status_display/evac{
 	pixel_x = 32
 	},
 /turf/open/floor/plasteel/grimy,
@@ -55867,7 +55861,7 @@
 	},
 /area/crew_quarters/locker)
 "crs" = (
-/obj/machinery/status_display,
+/obj/machinery/status_display/evac,
 /turf/closed/wall,
 /area/crew_quarters/locker)
 "crt" = (
@@ -56572,7 +56566,7 @@
 	dir = 1;
 	name = "Jury"
 	},
-/obj/machinery/ai_status_display{
+/obj/machinery/status_display/ai{
 	pixel_y = -32
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -56599,7 +56593,7 @@
 	dir = 1;
 	name = "Jury"
 	},
-/obj/machinery/status_display{
+/obj/machinery/status_display/evac{
 	pixel_y = -32
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -57789,7 +57783,7 @@
 /turf/open/floor/plasteel/grimy,
 /area/library)
 "cvk" = (
-/obj/machinery/status_display,
+/obj/machinery/status_display/evac,
 /turf/closed/wall,
 /area/library)
 "cvl" = (
@@ -58286,7 +58280,7 @@
 /obj/structure/cable/white{
 	icon_state = "1-2"
 	},
-/obj/machinery/status_display{
+/obj/machinery/status_display/evac{
 	pixel_x = 32
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -58919,7 +58913,7 @@
 /obj/machinery/suit_storage_unit/engine,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/ai_status_display{
+/obj/machinery/status_display/ai{
 	pixel_y = 32
 	},
 /obj/effect/turf_decal/stripes/line{
@@ -58941,7 +58935,7 @@
 /area/engine/storage)
 "cxL" = (
 /obj/machinery/suit_storage_unit/engine,
-/obj/machinery/status_display{
+/obj/machinery/status_display/evac{
 	pixel_y = 32
 	},
 /obj/effect/turf_decal/stripes/line{
@@ -59028,7 +59022,7 @@
 /obj/structure/table/wood,
 /obj/item/clipboard,
 /obj/item/folder,
-/obj/machinery/ai_status_display{
+/obj/machinery/status_display/ai{
 	pixel_x = -32
 	},
 /turf/open/floor/plasteel/dark,
@@ -59344,7 +59338,7 @@
 /obj/machinery/gateway{
 	dir = 1
 	},
-/obj/machinery/status_display{
+/obj/machinery/status_display/evac{
 	pixel_y = 32
 	},
 /obj/effect/decal/cleanable/dirt,
@@ -59523,7 +59517,7 @@
 /turf/open/floor/plasteel/neutral/corner,
 /area/crew_quarters/locker)
 "cyW" = (
-/obj/machinery/status_display{
+/obj/machinery/status_display/evac{
 	pixel_x = 32
 	},
 /obj/structure/closet/wardrobe/mixed,
@@ -59884,7 +59878,7 @@
 /obj/structure/table/wood,
 /obj/item/paper_bin,
 /obj/item/pen,
-/obj/machinery/status_display{
+/obj/machinery/status_display/evac{
 	pixel_y = -32
 	},
 /turf/open/floor/plasteel/vault{
@@ -59907,7 +59901,7 @@
 /obj/structure/table/wood,
 /obj/item/taperecorder,
 /obj/item/camera,
-/obj/machinery/ai_status_display{
+/obj/machinery/status_display/ai{
 	pixel_y = -32
 	},
 /turf/open/floor/plasteel/vault{
@@ -60597,7 +60591,7 @@
 /turf/open/floor/plasteel/grimy,
 /area/bridge/showroom/corporate)
 "cBs" = (
-/obj/machinery/ai_status_display{
+/obj/machinery/status_display/ai{
 	pixel_y = 32
 	},
 /obj/machinery/camera{
@@ -60614,7 +60608,7 @@
 /turf/open/floor/plasteel/vault,
 /area/bridge/showroom/corporate)
 "cBu" = (
-/obj/machinery/status_display{
+/obj/machinery/status_display/evac{
 	pixel_y = 32
 	},
 /turf/open/floor/plasteel/vault{
@@ -61021,7 +61015,7 @@
 /obj/machinery/light{
 	dir = 1
 	},
-/obj/machinery/status_display{
+/obj/machinery/status_display/evac{
 	pixel_y = 32
 	},
 /turf/open/floor/wood,
@@ -61051,7 +61045,7 @@
 	dir = 1
 	},
 /obj/item/bedsheet/red,
-/obj/machinery/status_display{
+/obj/machinery/status_display/evac{
 	pixel_y = 32
 	},
 /turf/open/floor/carpet,
@@ -61275,7 +61269,7 @@
 	pixel_y = 3
 	},
 /obj/item/newspaper,
-/obj/machinery/status_display{
+/obj/machinery/status_display/evac{
 	pixel_x = -32
 	},
 /turf/open/floor/plasteel/vault{
@@ -61803,7 +61797,7 @@
 /obj/structure/table,
 /obj/item/paper_bin,
 /obj/item/pen,
-/obj/machinery/ai_status_display{
+/obj/machinery/status_display/ai{
 	pixel_x = -32
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -61851,7 +61845,7 @@
 /turf/open/floor/plating,
 /area/crew_quarters/fitness/recreation)
 "cDR" = (
-/obj/machinery/status_display,
+/obj/machinery/status_display/evac,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
@@ -61889,7 +61883,7 @@
 /obj/machinery/light{
 	dir = 8
 	},
-/obj/machinery/status_display{
+/obj/machinery/status_display/evac{
 	pixel_x = -32
 	},
 /obj/effect/turf_decal/stripes/line{
@@ -62106,7 +62100,7 @@
 "cEs" = (
 /obj/machinery/light,
 /obj/structure/dresser,
-/obj/machinery/status_display{
+/obj/machinery/status_display/evac{
 	pixel_y = -32
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -62543,7 +62537,7 @@
 	},
 /area/crew_quarters/toilet/restrooms)
 "cFj" = (
-/obj/machinery/status_display{
+/obj/machinery/status_display/evac{
 	pixel_y = -32
 	},
 /obj/structure/cable/white{
@@ -62566,7 +62560,7 @@
 /area/crew_quarters/toilet/restrooms)
 "cFl" = (
 /obj/machinery/light,
-/obj/machinery/status_display{
+/obj/machinery/status_display/evac{
 	pixel_y = -32
 	},
 /obj/structure/cable/white{
@@ -63000,7 +62994,7 @@
 	},
 /area/ai_monitored/storage/eva)
 "cGg" = (
-/obj/machinery/ai_status_display{
+/obj/machinery/status_display/ai{
 	pixel_y = -32
 	},
 /obj/machinery/camera{
@@ -63043,7 +63037,7 @@
 /turf/open/floor/plasteel,
 /area/ai_monitored/storage/eva)
 "cGm" = (
-/obj/machinery/status_display{
+/obj/machinery/status_display/evac{
 	pixel_y = -32
 	},
 /obj/effect/turf_decal/stripes/line{
@@ -63561,7 +63555,7 @@
 /area/engine/storage)
 "cHr" = (
 /obj/structure/reagent_dispensers/watertank,
-/obj/machinery/status_display{
+/obj/machinery/status_display/evac{
 	pixel_y = -32
 	},
 /obj/effect/turf_decal/bot,
@@ -63581,7 +63575,7 @@
 "cHt" = (
 /obj/structure/reagent_dispensers/fueltank,
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/ai_status_display{
+/obj/machinery/status_display/ai{
 	pixel_y = -32
 	},
 /obj/effect/turf_decal/bot,
@@ -64044,7 +64038,7 @@
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/fitness/recreation)
 "cIo" = (
-/obj/machinery/status_display,
+/obj/machinery/status_display/evac,
 /turf/closed/wall,
 /area/crew_quarters/fitness/recreation)
 "cIp" = (
@@ -66669,7 +66663,7 @@
 /turf/open/floor/plasteel,
 /area/science/research)
 "cNs" = (
-/obj/machinery/status_display,
+/obj/machinery/status_display/evac,
 /turf/closed/wall,
 /area/science/research)
 "cNt" = (
@@ -66766,7 +66760,7 @@
 /turf/open/floor/plasteel,
 /area/medical/medbay/central)
 "cNB" = (
-/obj/machinery/status_display,
+/obj/machinery/status_display/evac,
 /turf/closed/wall,
 /area/medical/medbay/central)
 "cNC" = (
@@ -68169,7 +68163,7 @@
 	dir = 8;
 	pixel_x = -24
 	},
-/obj/machinery/status_display{
+/obj/machinery/status_display/evac{
 	pixel_y = 32
 	},
 /obj/structure/extinguisher_cabinet{
@@ -68197,7 +68191,7 @@
 /obj/structure/table/reinforced,
 /obj/item/book/manual/wiki/security_space_law,
 /obj/item/radio,
-/obj/machinery/ai_status_display{
+/obj/machinery/status_display/ai{
 	pixel_y = 32
 	},
 /obj/structure/reagent_dispensers/peppertank{
@@ -68535,7 +68529,7 @@
 /turf/open/floor/plasteel,
 /area/maintenance/department/electrical)
 "cRE" = (
-/obj/machinery/status_display,
+/obj/machinery/status_display/evac,
 /turf/closed/wall,
 /area/maintenance/department/electrical)
 "cRF" = (
@@ -68644,7 +68638,7 @@
 /obj/structure/cable/white{
 	icon_state = "2-8"
 	},
-/obj/machinery/status_display{
+/obj/machinery/status_display/evac{
 	pixel_y = 32
 	},
 /obj/structure/cable/white{
@@ -69078,7 +69072,7 @@
 	},
 /area/medical/medbay/central)
 "cSM" = (
-/obj/machinery/status_display{
+/obj/machinery/status_display/evac{
 	pixel_y = 32
 	},
 /obj/structure/reagent_dispensers/peppertank{
@@ -69121,7 +69115,7 @@
 	},
 /area/security/checkpoint/medical)
 "cSO" = (
-/obj/machinery/ai_status_display{
+/obj/machinery/status_display/ai{
 	pixel_y = 32
 	},
 /obj/machinery/firealarm{
@@ -69365,7 +69359,7 @@
 	},
 /area/maintenance/port)
 "cTm" = (
-/obj/machinery/status_display{
+/obj/machinery/status_display/evac{
 	pixel_x = -32
 	},
 /obj/item/twohanded/required/kirbyplants/random,
@@ -70206,7 +70200,7 @@
 /obj/item/folder,
 /obj/item/pen,
 /obj/machinery/light,
-/obj/machinery/status_display{
+/obj/machinery/status_display/evac{
 	pixel_y = -32
 	},
 /obj/item/paicard,
@@ -70228,7 +70222,7 @@
 /obj/structure/bed,
 /obj/machinery/light,
 /obj/item/bedsheet/brown,
-/obj/machinery/status_display{
+/obj/machinery/status_display/evac{
 	pixel_y = -32
 	},
 /turf/open/floor/carpet,
@@ -70264,7 +70258,7 @@
 	name = "trenchcoat"
 	},
 /obj/item/clothing/suit/toggle/lawyer/black,
-/obj/machinery/status_display{
+/obj/machinery/status_display/evac{
 	pixel_y = -32
 	},
 /obj/item/clothing/head/fedora,
@@ -70289,7 +70283,7 @@
 	dir = 8
 	},
 /obj/item/toy/katana,
-/obj/machinery/ai_status_display{
+/obj/machinery/status_display/ai{
 	pixel_x = -32
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -70339,7 +70333,7 @@
 /turf/open/floor/plating,
 /area/crew_quarters/fitness/recreation)
 "cVj" = (
-/obj/machinery/status_display,
+/obj/machinery/status_display/evac,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
@@ -70905,7 +70899,7 @@
 	},
 /obj/item/storage/box/syringes,
 /obj/item/gun/syringe,
-/obj/machinery/status_display{
+/obj/machinery/status_display/evac{
 	pixel_x = -32
 	},
 /obj/structure/window/reinforced,
@@ -70944,7 +70938,7 @@
 	pixel_x = -3;
 	pixel_y = 2
 	},
-/obj/machinery/status_display{
+/obj/machinery/status_display/evac{
 	pixel_x = 32
 	},
 /obj/machinery/firealarm{
@@ -71335,7 +71329,7 @@
 /obj/machinery/computer/camera_advanced/xenobio{
 	dir = 8
 	},
-/obj/machinery/status_display{
+/obj/machinery/status_display/evac{
 	pixel_x = 32
 	},
 /turf/open/floor/circuit/green,
@@ -71466,7 +71460,7 @@
 /obj/structure/table,
 /obj/item/gps,
 /obj/item/assembly/flash/handheld,
-/obj/machinery/status_display{
+/obj/machinery/status_display/evac{
 	pixel_y = -32
 	},
 /turf/open/floor/plasteel/whitepurple/side,
@@ -71938,7 +71932,7 @@
 "cYE" = (
 /obj/machinery/power/smes,
 /obj/machinery/light/small,
-/obj/machinery/status_display{
+/obj/machinery/status_display/evac{
 	pixel_y = -32
 	},
 /obj/effect/turf_decal/stripes/line{
@@ -71961,7 +71955,7 @@
 "cYH" = (
 /obj/machinery/power/smes,
 /obj/machinery/light/small,
-/obj/machinery/status_display{
+/obj/machinery/status_display/evac{
 	pixel_y = -32
 	},
 /obj/effect/decal/cleanable/dirt,
@@ -73113,7 +73107,7 @@
 	dir = 1
 	},
 /obj/item/twohanded/required/kirbyplants/random,
-/obj/machinery/status_display{
+/obj/machinery/status_display/evac{
 	pixel_y = 32
 	},
 /turf/open/floor/plasteel/whitepurple/corner{
@@ -73260,7 +73254,7 @@
 /turf/open/floor/plasteel,
 /area/medical/chemistry)
 "dbi" = (
-/obj/machinery/ai_status_display,
+/obj/machinery/status_display/ai,
 /turf/closed/wall,
 /area/medical/chemistry)
 "dbj" = (
@@ -73399,7 +73393,7 @@
 /area/medical/medbay/central)
 "dbz" = (
 /obj/machinery/vending/cola/random,
-/obj/machinery/status_display{
+/obj/machinery/status_display/evac{
 	pixel_x = 32
 	},
 /obj/machinery/light{
@@ -74013,7 +74007,7 @@
 /turf/open/floor/plasteel,
 /area/science/lab)
 "dcK" = (
-/obj/machinery/ai_status_display{
+/obj/machinery/status_display/ai{
 	pixel_x = 32
 	},
 /obj/machinery/light{
@@ -74055,7 +74049,7 @@
 	pixel_x = 3;
 	pixel_y = 3
 	},
-/obj/machinery/status_display{
+/obj/machinery/status_display/evac{
 	pixel_x = -32
 	},
 /turf/open/floor/plasteel/whiteyellow/side{
@@ -74534,7 +74528,7 @@
 "ddU" = (
 /obj/structure/filingcabinet/chestdrawer,
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/ai_status_display{
+/obj/machinery/status_display/ai{
 	pixel_y = -32
 	},
 /obj/effect/turf_decal/bot,
@@ -74733,7 +74727,7 @@
 	},
 /area/medical/chemistry)
 "der" = (
-/obj/machinery/status_display,
+/obj/machinery/status_display/evac,
 /turf/closed/wall,
 /area/medical/chemistry)
 "des" = (
@@ -77137,7 +77131,7 @@
 /area/science/explab)
 "djG" = (
 /obj/structure/filingcabinet/chestdrawer,
-/obj/machinery/status_display{
+/obj/machinery/status_display/evac{
 	pixel_y = 32
 	},
 /obj/effect/turf_decal/bot,
@@ -77319,7 +77313,7 @@
 /obj/item/storage/toolbox/mechanical,
 /obj/item/stack/cable_coil/white,
 /obj/item/stack/cable_coil/white,
-/obj/machinery/status_display{
+/obj/machinery/status_display/evac{
 	pixel_y = -32
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -77681,7 +77675,7 @@
 /area/medical/abandoned)
 "dkK" = (
 /obj/structure/table/reinforced,
-/obj/machinery/status_display{
+/obj/machinery/status_display/evac{
 	pixel_y = -32
 	},
 /obj/item/storage/firstaid/regular,
@@ -77702,7 +77696,7 @@
 /area/medical/abandoned)
 "dkM" = (
 /obj/structure/table/reinforced,
-/obj/machinery/status_display{
+/obj/machinery/status_display/evac{
 	pixel_y = -32
 	},
 /obj/item/reagent_containers/blood/random,
@@ -78237,7 +78231,7 @@
 /turf/closed/wall,
 /area/medical/surgery)
 "dmb" = (
-/obj/machinery/status_display,
+/obj/machinery/status_display/evac,
 /turf/closed/wall,
 /area/medical/surgery)
 "dmc" = (
@@ -78720,7 +78714,7 @@
 /obj/structure/window/reinforced{
 	dir = 4
 	},
-/obj/machinery/status_display{
+/obj/machinery/status_display/evac{
 	pixel_x = -32
 	},
 /turf/open/floor/plasteel/vault{
@@ -80439,7 +80433,7 @@
 /area/maintenance/department/medical)
 "dqZ" = (
 /obj/machinery/door/window/eastright,
-/obj/machinery/ai_status_display{
+/obj/machinery/status_display/ai{
 	pixel_x = -32
 	},
 /turf/open/floor/plasteel/vault{
@@ -80767,7 +80761,7 @@
 /turf/closed/wall/r_wall,
 /area/science/explab)
 "drL" = (
-/obj/machinery/status_display,
+/obj/machinery/status_display/evac,
 /turf/closed/wall/r_wall,
 /area/science/explab)
 "drM" = (
@@ -81282,7 +81276,7 @@
 /area/crew_quarters/abandoned_gambling_den)
 "dta" = (
 /obj/structure/table/wood,
-/obj/machinery/status_display{
+/obj/machinery/status_display/evac{
 	pixel_x = 32
 	},
 /obj/item/book/manual/wiki/engineering_hacking,
@@ -81409,7 +81403,7 @@
 /obj/machinery/computer/card/minor/rd{
 	dir = 8
 	},
-/obj/machinery/ai_status_display{
+/obj/machinery/status_display/ai{
 	pixel_x = 32
 	},
 /obj/effect/turf_decal/bot,
@@ -81427,7 +81421,7 @@
 /area/science/research)
 "dtw" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/status_display{
+/obj/machinery/status_display/evac{
 	pixel_x = -32
 	},
 /obj/effect/turf_decal/bot,
@@ -82167,7 +82161,7 @@
 	},
 /area/medical/genetics)
 "dvi" = (
-/obj/machinery/status_display,
+/obj/machinery/status_display/evac,
 /turf/closed/wall/r_wall,
 /area/medical/genetics)
 "dvj" = (
@@ -82749,7 +82743,7 @@
 	dir = 8
 	},
 /obj/machinery/light,
-/obj/machinery/status_display{
+/obj/machinery/status_display/evac{
 	pixel_x = 32
 	},
 /obj/machinery/keycard_auth{
@@ -83858,7 +83852,7 @@
 	dir = 8;
 	pixel_x = -24
 	},
-/obj/machinery/ai_status_display{
+/obj/machinery/status_display/ai{
 	pixel_y = -32
 	},
 /obj/item/clothing/suit/straight_jacket,
@@ -83884,7 +83878,7 @@
 /obj/machinery/computer/crew{
 	dir = 1
 	},
-/obj/machinery/status_display{
+/obj/machinery/status_display/evac{
 	pixel_y = -32
 	},
 /turf/open/floor/plasteel/whiteblue/corner,
@@ -83897,7 +83891,7 @@
 /turf/open/floor/plasteel/vault,
 /area/medical/surgery)
 "dyH" = (
-/obj/machinery/ai_status_display{
+/obj/machinery/status_display/ai{
 	pixel_y = -32
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
@@ -83922,7 +83916,7 @@
 /turf/open/floor/plasteel/vault,
 /area/medical/surgery)
 "dyJ" = (
-/obj/machinery/status_display{
+/obj/machinery/status_display/evac{
 	pixel_y = -32
 	},
 /turf/open/floor/plasteel/vault,
@@ -84088,7 +84082,7 @@
 /area/crew_quarters/abandoned_gambling_den)
 "dze" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/status_display{
+/obj/machinery/status_display/evac{
 	pixel_x = -32
 	},
 /obj/effect/turf_decal/delivery,
@@ -84768,7 +84762,7 @@
 /obj/machinery/light{
 	dir = 8
 	},
-/obj/machinery/ai_status_display{
+/obj/machinery/status_display/ai{
 	pixel_x = -32
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
@@ -84809,7 +84803,7 @@
 	},
 /obj/structure/bed,
 /obj/item/bedsheet/rd,
-/obj/machinery/status_display{
+/obj/machinery/status_display/evac{
 	pixel_x = 32
 	},
 /turf/open/floor/plasteel/whitepurple/side{
@@ -84952,7 +84946,7 @@
 /turf/open/floor/plasteel/whitepurple/corner,
 /area/medical/genetics)
 "dAV" = (
-/obj/machinery/ai_status_display,
+/obj/machinery/status_display/ai,
 /turf/closed/wall/r_wall,
 /area/medical/genetics)
 "dAW" = (
@@ -85820,7 +85814,7 @@
 /obj/machinery/computer/card/minor/cmo{
 	dir = 8
 	},
-/obj/machinery/ai_status_display{
+/obj/machinery/status_display/ai{
 	pixel_x = 32
 	},
 /turf/open/floor/plasteel/neutral/side{
@@ -86103,7 +86097,7 @@
 	pixel_y = 2
 	},
 /obj/structure/table/reinforced,
-/obj/machinery/status_display{
+/obj/machinery/status_display/evac{
 	pixel_x = -32
 	},
 /obj/effect/turf_decal/stripes/corner{
@@ -86524,7 +86518,7 @@
 /area/medical/medbay/central)
 "dEg" = (
 /obj/structure/filingcabinet/chestdrawer,
-/obj/machinery/status_display{
+/obj/machinery/status_display/evac{
 	pixel_x = 32
 	},
 /turf/open/floor/plasteel/cmo,
@@ -87105,7 +87099,7 @@
 "dFB" = (
 /obj/structure/table,
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/status_display{
+/obj/machinery/status_display/evac{
 	pixel_y = 32
 	},
 /obj/item/crowbar,
@@ -87193,7 +87187,7 @@
 	pixel_y = -2
 	},
 /obj/structure/table/reinforced,
-/obj/machinery/status_display{
+/obj/machinery/status_display/evac{
 	pixel_x = -32
 	},
 /obj/effect/turf_decal/stripes/corner,
@@ -88126,7 +88120,7 @@
 /obj/machinery/light{
 	dir = 4
 	},
-/obj/machinery/ai_status_display{
+/obj/machinery/status_display/ai{
 	pixel_x = 32
 	},
 /obj/effect/turf_decal/bot,
@@ -88248,7 +88242,7 @@
 /obj/machinery/light{
 	dir = 8
 	},
-/obj/machinery/ai_status_display{
+/obj/machinery/status_display/ai{
 	pixel_x = -32
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
@@ -88281,7 +88275,7 @@
 /obj/machinery/light{
 	dir = 4
 	},
-/obj/machinery/status_display{
+/obj/machinery/status_display/evac{
 	pixel_x = 32
 	},
 /turf/open/floor/plasteel/cmo,
@@ -88808,7 +88802,7 @@
 "dIR" = (
 /obj/structure/table/optable,
 /obj/effect/decal/cleanable/blood/old,
-/obj/machinery/status_display{
+/obj/machinery/status_display/evac{
 	pixel_y = -32
 	},
 /turf/open/floor/plasteel/whitepurple/corner,
@@ -90124,7 +90118,7 @@
 /obj/machinery/light/small{
 	dir = 8
 	},
-/obj/machinery/status_display{
+/obj/machinery/status_display/evac{
 	pixel_x = -32
 	},
 /turf/open/floor/wood{
@@ -90167,7 +90161,7 @@
 /obj/machinery/light/small{
 	dir = 8
 	},
-/obj/machinery/status_display{
+/obj/machinery/status_display/evac{
 	pixel_x = -32
 	},
 /turf/open/floor/plasteel/grimy,
@@ -91859,7 +91853,7 @@
 /obj/machinery/computer/med_data{
 	dir = 4
 	},
-/obj/machinery/status_display{
+/obj/machinery/status_display/evac{
 	pixel_x = -32
 	},
 /turf/open/floor/plasteel/blue/side{
@@ -92168,7 +92162,7 @@
 "dPQ" = (
 /obj/machinery/vending/cola/random,
 /obj/machinery/light,
-/obj/machinery/status_display{
+/obj/machinery/status_display/evac{
 	pixel_y = -32
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -92556,7 +92550,7 @@
 /obj/machinery/computer/crew{
 	dir = 4
 	},
-/obj/machinery/ai_status_display{
+/obj/machinery/status_display/ai{
 	pixel_x = -32
 	},
 /turf/open/floor/plasteel/blue/side{
@@ -93412,7 +93406,7 @@
 /obj/machinery/light{
 	dir = 4
 	},
-/obj/machinery/status_display{
+/obj/machinery/status_display/evac{
 	pixel_x = 32
 	},
 /turf/open/floor/plasteel/whitegreen/corner{
@@ -93769,7 +93763,7 @@
 /turf/open/floor/plasteel/neutral,
 /area/medical/virology)
 "dTj" = (
-/obj/machinery/ai_status_display{
+/obj/machinery/status_display/ai{
 	pixel_x = 32
 	},
 /turf/open/floor/plasteel/whitegreen/corner,
@@ -94010,7 +94004,7 @@
 /obj/machinery/atmospherics/components/unary/portables_connector/visible{
 	dir = 1
 	},
-/obj/machinery/status_display{
+/obj/machinery/status_display/evac{
 	pixel_y = -32
 	},
 /obj/machinery/portable_atmospherics/canister/air,
@@ -94167,7 +94161,7 @@
 	pixel_y = 3
 	},
 /obj/item/reagent_containers/food/snacks/grown/poppy,
-/obj/machinery/status_display{
+/obj/machinery/status_display/evac{
 	pixel_y = 32
 	},
 /turf/open/floor/plasteel/dark,
@@ -94206,7 +94200,7 @@
 	pixel_y = 3
 	},
 /obj/item/reagent_containers/food/snacks/grown/harebell,
-/obj/machinery/status_display{
+/obj/machinery/status_display/evac{
 	pixel_y = 32
 	},
 /turf/open/floor/plasteel/dark,
@@ -94548,7 +94542,7 @@
 /obj/machinery/light{
 	dir = 1
 	},
-/obj/machinery/status_display{
+/obj/machinery/status_display/evac{
 	pixel_y = 32
 	},
 /obj/item/twohanded/required/kirbyplants/random,
@@ -95833,7 +95827,7 @@
 /turf/open/floor/grass,
 /area/hallway/secondary/exit/departure_lounge)
 "dYF" = (
-/obj/machinery/status_display,
+/obj/machinery/status_display/evac,
 /turf/closed/wall,
 /area/hallway/secondary/exit/departure_lounge)
 "dYG" = (
@@ -95845,7 +95839,7 @@
 /turf/open/floor/grass,
 /area/hallway/secondary/exit/departure_lounge)
 "dYH" = (
-/obj/machinery/ai_status_display,
+/obj/machinery/status_display/ai,
 /turf/closed/wall,
 /area/hallway/secondary/exit/departure_lounge)
 "dYI" = (
@@ -95924,7 +95918,7 @@
 /area/medical/virology)
 "dYT" = (
 /obj/machinery/light,
-/obj/machinery/status_display{
+/obj/machinery/status_display/evac{
 	pixel_y = -32
 	},
 /obj/item/twohanded/required/kirbyplants/random,
@@ -97026,7 +97020,7 @@
 	},
 /area/medical/virology)
 "ebx" = (
-/obj/machinery/status_display,
+/obj/machinery/status_display/evac,
 /turf/closed/wall,
 /area/medical/virology)
 "eby" = (
@@ -97503,7 +97497,7 @@
 /turf/open/floor/plasteel/dark,
 /area/chapel/main)
 "ecA" = (
-/obj/machinery/ai_status_display{
+/obj/machinery/status_display/ai{
 	pixel_y = -32
 	},
 /turf/open/floor/plasteel/grimy,
@@ -97664,7 +97658,7 @@
 	},
 /area/chapel/main)
 "ecT" = (
-/obj/machinery/status_display,
+/obj/machinery/status_display/evac,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/closed/wall,
 /area/chapel/main)
@@ -98297,7 +98291,7 @@
 /turf/open/floor/plating,
 /area/security/checkpoint/escape)
 "eee" = (
-/obj/machinery/status_display,
+/obj/machinery/status_display/evac,
 /turf/closed/wall,
 /area/security/checkpoint/escape)
 "eef" = (
@@ -98500,7 +98494,7 @@
 	dir = 4;
 	pixel_x = 24
 	},
-/obj/machinery/status_display{
+/obj/machinery/status_display/evac{
 	pixel_y = 32
 	},
 /turf/open/floor/plasteel/vault{
@@ -98554,7 +98548,7 @@
 "eeF" = (
 /obj/structure/table/wood,
 /obj/item/storage/fancy/donut_box,
-/obj/machinery/ai_status_display{
+/obj/machinery/status_display/ai{
 	pixel_x = 32
 	},
 /turf/open/floor/carpet,
@@ -99132,7 +99126,7 @@
 	name = "Chapel RC";
 	pixel_y = -32
 	},
-/obj/machinery/status_display{
+/obj/machinery/status_display/evac{
 	pixel_x = 32
 	},
 /obj/machinery/camera{
@@ -99187,7 +99181,7 @@
 /obj/machinery/computer/security{
 	dir = 1
 	},
-/obj/machinery/status_display{
+/obj/machinery/status_display/evac{
 	pixel_y = -32
 	},
 /turf/open/floor/plasteel/red/side{
@@ -100790,7 +100784,7 @@
 /obj/structure/table/reinforced,
 /obj/item/storage/toolbox/electrical,
 /obj/item/wrench/power,
-/obj/machinery/status_display{
+/obj/machinery/status_display/evac{
 	pixel_y = 32
 	},
 /obj/effect/turf_decal/bot,

--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -535,7 +535,7 @@
 	},
 /area/security/prison)
 "abr" = (
-/obj/machinery/status_display{
+/obj/machinery/status_display/evac{
 	pixel_y = 32
 	},
 /turf/open/floor/plasteel/barber{
@@ -2567,7 +2567,7 @@
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/heads/hos)
 "afj" = (
-/obj/machinery/status_display{
+/obj/machinery/status_display/evac{
 	pixel_x = -32;
 	pixel_y = 32
 	},
@@ -2596,7 +2596,7 @@
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/heads/hos)
 "afn" = (
-/obj/machinery/status_display{
+/obj/machinery/status_display/evac{
 	pixel_x = 32;
 	pixel_y = 32
 	},
@@ -11996,9 +11996,8 @@
 /area/quartermaster/miningoffice)
 "azl" = (
 /obj/structure/closet/emcloset,
-/obj/machinery/status_display{
-	pixel_y = 32;
-	supply_display = 1
+/obj/machinery/status_display/supply{
+	pixel_y = 32
 	},
 /turf/open/floor/plasteel/brown{
 	dir = 9
@@ -14031,7 +14030,7 @@
 /obj/machinery/light{
 	dir = 1
 	},
-/obj/machinery/status_display{
+/obj/machinery/status_display/evac{
 	pixel_y = 32
 	},
 /turf/open/floor/plasteel/red/corner{
@@ -16353,9 +16352,8 @@
 	pixel_x = -28;
 	pixel_y = 23
 	},
-/obj/machinery/status_display{
-	pixel_y = 32;
-	supply_display = 1
+/obj/machinery/status_display/supply{
+	pixel_y = 32
 	},
 /obj/machinery/conveyor{
 	dir = 5;
@@ -16776,7 +16774,7 @@
 /obj/structure/chair{
 	name = "Judge"
 	},
-/obj/machinery/status_display{
+/obj/machinery/status_display/evac{
 	pixel_y = 32
 	},
 /obj/machinery/light{
@@ -17951,7 +17949,7 @@
 "aLO" = (
 /obj/machinery/atmospherics/components/unary/portables_connector/visible,
 /obj/machinery/portable_atmospherics/scrubber,
-/obj/machinery/status_display{
+/obj/machinery/status_display/evac{
 	pixel_y = 30
 	},
 /obj/effect/turf_decal/delivery,
@@ -19821,7 +19819,7 @@
 /obj/structure/cable/yellow{
 	icon_state = "0-4"
 	},
-/obj/machinery/status_display{
+/obj/machinery/status_display/evac{
 	pixel_y = 32
 	},
 /obj/machinery/camera{
@@ -19983,9 +19981,8 @@
 /obj/structure/table,
 /obj/item/clipboard,
 /obj/item/stamp/qm,
-/obj/machinery/status_display{
-	pixel_x = 32;
-	supply_display = 1
+/obj/machinery/status_display/supply{
+	pixel_x = 32
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/qm)
@@ -20041,7 +20038,7 @@
 /obj/machinery/light{
 	dir = 8
 	},
-/obj/machinery/ai_status_display{
+/obj/machinery/status_display/ai{
 	pixel_x = -32
 	},
 /obj/machinery/flasher{
@@ -20095,7 +20092,7 @@
 /obj/machinery/light{
 	dir = 4
 	},
-/obj/machinery/status_display{
+/obj/machinery/status_display/evac{
 	pixel_x = 32
 	},
 /obj/machinery/flasher{
@@ -21154,9 +21151,8 @@
 /obj/structure/disposalpipe/trunk{
 	dir = 8
 	},
-/obj/machinery/status_display{
-	pixel_x = 32;
-	supply_display = 1
+/obj/machinery/status_display/supply{
+	pixel_x = 32
 	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -22224,7 +22220,7 @@
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/ai)
 "aVm" = (
-/obj/machinery/status_display{
+/obj/machinery/status_display/evac{
 	pixel_y = 32
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on,
@@ -22254,7 +22250,7 @@
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/ai)
 "aVq" = (
-/obj/machinery/status_display{
+/obj/machinery/status_display/evac{
 	pixel_y = 32
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on,
@@ -22317,7 +22313,7 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 4
 	},
-/obj/machinery/status_display{
+/obj/machinery/status_display/evac{
 	pixel_y = 32
 	},
 /obj/effect/turf_decal/stripes/line{
@@ -22408,9 +22404,7 @@
 	},
 /area/hallway/secondary/entry)
 "aVG" = (
-/obj/machinery/status_display{
-	supply_display = 1
-	},
+/obj/machinery/status_display/supply,
 /turf/closed/wall,
 /area/quartermaster/storage)
 "aVH" = (
@@ -22579,7 +22573,7 @@
 /obj/machinery/light{
 	dir = 1
 	},
-/obj/machinery/status_display{
+/obj/machinery/status_display/evac{
 	pixel_y = 32
 	},
 /turf/open/floor/plasteel/neutral/side{
@@ -22753,7 +22747,7 @@
 	pixel_x = -25;
 	pixel_y = 25
 	},
-/obj/machinery/status_display{
+/obj/machinery/status_display/evac{
 	pixel_y = 32
 	},
 /obj/structure/extinguisher_cabinet{
@@ -22774,7 +22768,7 @@
 /turf/open/floor/plasteel/vault,
 /area/crew_quarters/heads/chief)
 "aWz" = (
-/obj/machinery/ai_status_display{
+/obj/machinery/status_display/ai{
 	pixel_y = 32
 	},
 /obj/machinery/computer/station_alert,
@@ -22838,7 +22832,7 @@
 /turf/open/space,
 /area/space/nearstation)
 "aWL" = (
-/obj/machinery/ai_status_display{
+/obj/machinery/status_display/ai{
 	pixel_x = -32
 	},
 /obj/machinery/light{
@@ -22881,7 +22875,7 @@
 /obj/machinery/light{
 	dir = 4
 	},
-/obj/machinery/ai_status_display{
+/obj/machinery/status_display/ai{
 	pixel_x = 32
 	},
 /turf/open/floor/circuit,
@@ -23302,7 +23296,7 @@
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
 	dir = 2
 	},
-/obj/machinery/ai_status_display{
+/obj/machinery/status_display/ai{
 	pixel_y = 32
 	},
 /obj/effect/turf_decal/stripes/line{
@@ -23586,7 +23580,7 @@
 /area/storage/tech)
 "aYk" = (
 /obj/structure/rack,
-/obj/machinery/ai_status_display{
+/obj/machinery/status_display/ai{
 	pixel_y = 31
 	},
 /obj/effect/spawner/lootdrop/techstorage/medical,
@@ -24741,9 +24735,8 @@
 /area/hallway/primary/port)
 "baA" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on,
-/obj/machinery/status_display{
-	pixel_y = 32;
-	supply_display = 1
+/obj/machinery/status_display/supply{
+	pixel_y = 32
 	},
 /obj/structure/table,
 /obj/item/folder/yellow,
@@ -25451,9 +25444,8 @@
 /area/quartermaster/office)
 "bbS" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on,
-/obj/machinery/status_display{
-	pixel_y = 32;
-	supply_display = 1
+/obj/machinery/status_display/supply{
+	pixel_y = 32
 	},
 /turf/open/floor/plasteel/brown{
 	dir = 1
@@ -25524,7 +25516,7 @@
 /obj/item/radio/intercom{
 	pixel_x = -29
 	},
-/obj/machinery/status_display{
+/obj/machinery/status_display/evac{
 	pixel_x = -32
 	},
 /turf/open/floor/plasteel/neutral/corner{
@@ -25839,7 +25831,7 @@
 /obj/machinery/light{
 	dir = 8
 	},
-/obj/machinery/ai_status_display{
+/obj/machinery/status_display/ai{
 	pixel_x = -32
 	},
 /turf/open/floor/circuit,
@@ -26226,7 +26218,7 @@
 /turf/open/floor/carpet,
 /area/crew_quarters/heads/captain/private)
 "bdI" = (
-/obj/machinery/status_display{
+/obj/machinery/status_display/evac{
 	pixel_y = 32
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -26243,7 +26235,7 @@
 /turf/open/floor/carpet,
 /area/crew_quarters/heads/captain/private)
 "bdK" = (
-/obj/machinery/ai_status_display{
+/obj/machinery/status_display/ai{
 	pixel_y = 32
 	},
 /obj/structure/disposalpipe/segment{
@@ -27571,9 +27563,8 @@
 /turf/open/floor/plasteel,
 /area/quartermaster/sorting)
 "bgL" = (
-/obj/machinery/status_display{
-	pixel_y = 32;
-	supply_display = 1
+/obj/machinery/status_display/supply{
+	pixel_y = 32
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -27847,7 +27838,7 @@
 	},
 /area/bridge)
 "bhk" = (
-/obj/machinery/status_display{
+/obj/machinery/status_display/evac{
 	pixel_y = 32
 	},
 /obj/item/folder/yellow{
@@ -27886,7 +27877,7 @@
 	},
 /area/bridge)
 "bho" = (
-/obj/machinery/ai_status_display{
+/obj/machinery/status_display/ai{
 	pixel_y = 32
 	},
 /obj/item/storage/toolbox/mechanical{
@@ -28370,7 +28361,7 @@
 /obj/structure/chair/office/dark{
 	dir = 8
 	},
-/obj/machinery/ai_status_display{
+/obj/machinery/status_display/ai{
 	pixel_y = -32
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -28404,7 +28395,7 @@
 /obj/structure/chair/office/dark{
 	dir = 4
 	},
-/obj/machinery/status_display{
+/obj/machinery/status_display/evac{
 	pixel_y = -32
 	},
 /turf/open/floor/plasteel/dark,
@@ -29947,7 +29938,7 @@
 /area/ai_monitored/turret_protected/aisat/foyer)
 "blC" = (
 /obj/machinery/teleport/station,
-/obj/machinery/status_display{
+/obj/machinery/status_display/evac{
 	pixel_y = 32
 	},
 /turf/open/floor/plasteel/vault{
@@ -30029,7 +30020,7 @@
 /area/ai_monitored/storage/satellite)
 "blK" = (
 /obj/machinery/recharge_station,
-/obj/machinery/status_display{
+/obj/machinery/status_display/evac{
 	pixel_y = 32
 	},
 /obj/structure/cable/yellow{
@@ -30472,7 +30463,7 @@
 /area/crew_quarters/heads/captain/private)
 "bmJ" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/machinery/status_display{
+/obj/machinery/status_display/evac{
 	pixel_x = -32
 	},
 /obj/structure/disposalpipe/segment,
@@ -31372,7 +31363,7 @@
 /obj/structure/displaycase/captain{
 	pixel_y = 5
 	},
-/obj/machinery/status_display{
+/obj/machinery/status_display/evac{
 	pixel_y = 32
 	},
 /turf/open/floor/wood,
@@ -31408,7 +31399,7 @@
 	name = "Station Intercom (Captain)";
 	pixel_x = 28
 	},
-/obj/machinery/ai_status_display{
+/obj/machinery/status_display/ai{
 	pixel_y = 32
 	},
 /obj/machinery/keycard_auth{
@@ -32371,7 +32362,7 @@
 /turf/open/floor/wood,
 /area/crew_quarters/heads/hop)
 "bqF" = (
-/obj/machinery/status_display{
+/obj/machinery/status_display/evac{
 	pixel_y = 32
 	},
 /turf/open/floor/plasteel/darkblue/corner{
@@ -32867,7 +32858,7 @@
 /obj/structure/window/reinforced{
 	dir = 4
 	},
-/obj/machinery/ai_status_display{
+/obj/machinery/status_display/ai{
 	pixel_y = 32
 	},
 /obj/structure/transit_tube/curved{
@@ -33037,7 +33028,7 @@
 	},
 /area/ai_monitored/turret_protected/aisat/foyer)
 "brX" = (
-/obj/machinery/ai_status_display{
+/obj/machinery/status_display/ai{
 	pixel_y = 32
 	},
 /obj/machinery/porta_turret/ai{
@@ -33120,7 +33111,7 @@
 /turf/open/floor/plasteel/darkblue/corner,
 /area/ai_monitored/turret_protected/aisat_interior)
 "bse" = (
-/obj/machinery/status_display{
+/obj/machinery/status_display/evac{
 	pixel_y = 32
 	},
 /obj/machinery/porta_turret/ai{
@@ -33373,7 +33364,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
-/obj/machinery/status_display{
+/obj/machinery/status_display/evac{
 	pixel_y = -32
 	},
 /turf/open/floor/plasteel/neutral/corner{
@@ -33473,7 +33464,7 @@
 /turf/open/floor/carpet,
 /area/crew_quarters/heads/hop)
 "bsP" = (
-/obj/machinery/status_display{
+/obj/machinery/status_display/evac{
 	pixel_y = 32
 	},
 /obj/structure/bed/dogbed/ian,
@@ -34707,7 +34698,7 @@
 /area/tcommsat/computer)
 "bvz" = (
 /obj/structure/table/wood,
-/obj/machinery/ai_status_display{
+/obj/machinery/status_display/ai{
 	pixel_y = 31
 	},
 /obj/item/flashlight/lamp,
@@ -35124,7 +35115,7 @@
 /area/bridge)
 "bwu" = (
 /obj/machinery/holopad,
-/obj/machinery/status_display{
+/obj/machinery/status_display/evac{
 	pixel_y = 32
 	},
 /obj/machinery/light{
@@ -35140,7 +35131,7 @@
 /obj/machinery/light{
 	dir = 1
 	},
-/obj/machinery/ai_status_display{
+/obj/machinery/status_display/ai{
 	pixel_y = 32
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on,
@@ -35612,7 +35603,7 @@
 	c_tag = "Arrivals - Middle Arm - Far";
 	dir = 1
 	},
-/obj/machinery/status_display{
+/obj/machinery/status_display/evac{
 	pixel_y = -32
 	},
 /obj/effect/turf_decal/stripes/line,
@@ -35750,7 +35741,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
-/obj/machinery/status_display{
+/obj/machinery/status_display/evac{
 	pixel_y = -32
 	},
 /turf/open/floor/plasteel/neutral/side,
@@ -36282,7 +36273,7 @@
 	},
 /area/engine/atmos)
 "byS" = (
-/obj/machinery/status_display{
+/obj/machinery/status_display/evac{
 	pixel_y = 32
 	},
 /obj/machinery/light{
@@ -36731,7 +36722,7 @@
 /turf/open/floor/plasteel,
 /area/hallway/secondary/command)
 "bzN" = (
-/obj/machinery/status_display{
+/obj/machinery/status_display/evac{
 	pixel_y = 32
 	},
 /obj/effect/turf_decal/bot,
@@ -37214,7 +37205,7 @@
 /area/tcommsat/computer)
 "bAW" = (
 /obj/structure/table/wood,
-/obj/machinery/status_display{
+/obj/machinery/status_display/evac{
 	pixel_y = 31
 	},
 /obj/item/book/manual/wiki/tcomms,
@@ -38176,7 +38167,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
-/obj/machinery/status_display{
+/obj/machinery/status_display/evac{
 	pixel_y = 32
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on,
@@ -38231,7 +38222,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
-/obj/machinery/ai_status_display{
+/obj/machinery/status_display/ai{
 	pixel_y = 32
 	},
 /turf/open/floor/plasteel/neutral/corner{
@@ -38299,7 +38290,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
-/obj/machinery/status_display{
+/obj/machinery/status_display/evac{
 	pixel_y = 32
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on,
@@ -38631,7 +38622,7 @@
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
-/obj/machinery/status_display{
+/obj/machinery/status_display/evac{
 	pixel_x = 32
 	},
 /turf/open/floor/plasteel/arrival{
@@ -41336,7 +41327,7 @@
 /obj/machinery/gateway{
 	dir = 1
 	},
-/obj/machinery/status_display{
+/obj/machinery/status_display/evac{
 	pixel_y = 32
 	},
 /obj/effect/turf_decal/bot_white,
@@ -42047,7 +42038,7 @@
 /area/maintenance/central)
 "bLH" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/machinery/status_display{
+/obj/machinery/status_display/evac{
 	pixel_x = -32
 	},
 /obj/machinery/camera{
@@ -45750,7 +45741,7 @@
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 1
 	},
-/obj/machinery/status_display{
+/obj/machinery/status_display/evac{
 	pixel_y = 32
 	},
 /turf/open/floor/plasteel/neutral/corner{
@@ -45805,7 +45796,7 @@
 /obj/machinery/light{
 	dir = 1
 	},
-/obj/machinery/status_display{
+/obj/machinery/status_display/evac{
 	pixel_y = 32
 	},
 /turf/open/floor/plasteel/neutral/corner{
@@ -48806,7 +48797,7 @@
 	pixel_y = 4
 	},
 /obj/item/pen,
-/obj/machinery/status_display{
+/obj/machinery/status_display/evac{
 	pixel_y = 32
 	},
 /obj/machinery/light/small{
@@ -52040,7 +52031,7 @@
 	},
 /area/science/research)
 "chu" = (
-/obj/machinery/ai_status_display{
+/obj/machinery/status_display/ai{
 	pixel_y = 32
 	},
 /obj/structure/chair/stool,
@@ -54720,7 +54711,7 @@
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "cnC" = (
-/obj/machinery/status_display{
+/obj/machinery/status_display/evac{
 	pixel_y = 32
 	},
 /obj/structure/table/glass,
@@ -57582,7 +57573,7 @@
 	},
 /area/crew_quarters/heads/hor)
 "ctc" = (
-/obj/machinery/status_display{
+/obj/machinery/status_display/evac{
 	pixel_y = 32
 	},
 /obj/effect/landmark/xmastree/rdrod,
@@ -57605,7 +57596,7 @@
 /obj/item/storage/secure/safe{
 	pixel_x = 32
 	},
-/obj/machinery/ai_status_display{
+/obj/machinery/status_display/ai{
 	pixel_y = 32
 	},
 /obj/effect/turf_decal/stripes/line{
@@ -60272,7 +60263,7 @@
 "cyO" = (
 /obj/machinery/disposal/bin,
 /obj/structure/disposalpipe/trunk,
-/obj/machinery/status_display{
+/obj/machinery/status_display/evac{
 	pixel_y = 32
 	},
 /turf/open/floor/plasteel/white/side{
@@ -62885,7 +62876,7 @@
 /obj/item/assembly/flash/handheld,
 /obj/item/assembly/flash/handheld,
 /obj/item/assembly/flash/handheld,
-/obj/machinery/ai_status_display{
+/obj/machinery/status_display/ai{
 	pixel_x = 32
 	},
 /obj/effect/turf_decal/delivery,
@@ -67234,7 +67225,7 @@
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit/departure_lounge)
 "cMU" = (
-/obj/machinery/status_display{
+/obj/machinery/status_display/evac{
 	layer = 4
 	},
 /turf/closed/wall,
@@ -67934,7 +67925,7 @@
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit/departure_lounge)
 "cOs" = (
-/obj/machinery/ai_status_display,
+/obj/machinery/status_display/ai,
 /turf/closed/wall,
 /area/hallway/secondary/exit/departure_lounge)
 "cOt" = (
@@ -70304,7 +70295,7 @@
 /obj/machinery/light{
 	dir = 1
 	},
-/obj/machinery/status_display{
+/obj/machinery/status_display/evac{
 	pixel_y = 30
 	},
 /obj/machinery/photocopier{
@@ -72400,7 +72391,7 @@
 /turf/open/floor/plasteel/dark,
 /area/engine/engineering)
 "deD" = (
-/obj/machinery/status_display,
+/obj/machinery/status_display/evac,
 /turf/closed/wall/r_wall,
 /area/engine/supermatter)
 "deI" = (
@@ -73836,7 +73827,7 @@
 /area/maintenance/aft)
 "diD" = (
 /obj/machinery/vending/cigarette,
-/obj/machinery/status_display{
+/obj/machinery/status_display/evac{
 	pixel_y = 32
 	},
 /obj/structure/sign/poster/official/random{

--- a/_maps/map_files/Mining/Lavaland.dmm
+++ b/_maps/map_files/Mining/Lavaland.dmm
@@ -356,7 +356,7 @@
 /turf/open/floor/plasteel,
 /area/mine/laborcamp)
 "bj" = (
-/obj/machinery/status_display{
+/obj/machinery/status_display/evac{
 	pixel_y = 32
 	},
 /turf/open/floor/plasteel,

--- a/_maps/map_files/OmegaStation/OmegaStation.dmm
+++ b/_maps/map_files/OmegaStation/OmegaStation.dmm
@@ -128,7 +128,7 @@
 /area/bridge)
 "aar" = (
 /obj/machinery/computer/crew,
-/obj/machinery/status_display{
+/obj/machinery/status_display/evac{
 	pixel_y = 32
 	},
 /turf/open/floor/plasteel/darkblue/side{
@@ -169,7 +169,7 @@
 /area/bridge)
 "aav" = (
 /obj/machinery/computer/cargo/request,
-/obj/machinery/ai_status_display{
+/obj/machinery/status_display/ai{
 	pixel_y = 32
 	},
 /turf/open/floor/plasteel/darkyellow/side{
@@ -993,7 +993,7 @@
 /turf/open/floor/plasteel/white,
 /area/crew_quarters/heads/captain/private)
 "abY" = (
-/obj/machinery/status_display,
+/obj/machinery/status_display/evac,
 /turf/closed/wall,
 /area/crew_quarters/heads/captain/private)
 "abZ" = (
@@ -1214,7 +1214,7 @@
 /turf/open/floor/wood,
 /area/crew_quarters/heads/hop)
 "acs" = (
-/obj/machinery/status_display,
+/obj/machinery/status_display/evac,
 /turf/closed/wall,
 /area/crew_quarters/heads/hop)
 "act" = (
@@ -1354,7 +1354,7 @@
 /turf/open/floor/wood,
 /area/security/detectives_office)
 "acL" = (
-/obj/machinery/status_display,
+/obj/machinery/status_display/evac,
 /turf/closed/wall,
 /area/security/detectives_office)
 "acM" = (
@@ -1699,10 +1699,7 @@
 /turf/open/floor/plating,
 /area/quartermaster/storage)
 "adp" = (
-/obj/machinery/status_display{
-	name = "cargo display";
-	supply_display = 1
-	},
+/obj/machinery/status_display/supply,
 /turf/closed/wall,
 /area/quartermaster/storage)
 "adq" = (
@@ -1875,7 +1872,7 @@
 	},
 /area/bridge)
 "adO" = (
-/obj/machinery/ai_status_display,
+/obj/machinery/status_display/ai,
 /turf/closed/wall/r_wall,
 /area/ai_monitored/nuke_storage)
 "adP" = (
@@ -2376,10 +2373,8 @@
 	},
 /area/crew_quarters/heads/hop)
 "aeP" = (
-/obj/machinery/status_display{
-	name = "cargo display";
-	pixel_x = -32;
-	supply_display = 1
+/obj/machinery/status_display/supply{
+	pixel_x = -32
 	},
 /obj/effect/turf_decal/loading_area,
 /turf/open/floor/plasteel,
@@ -2751,7 +2746,7 @@
 /obj/machinery/computer/secure_data{
 	dir = 8
 	},
-/obj/machinery/ai_status_display{
+/obj/machinery/status_display/ai{
 	pixel_x = 32
 	},
 /obj/machinery/camera{
@@ -3138,7 +3133,7 @@
 /obj/machinery/computer/card{
 	dir = 8
 	},
-/obj/machinery/status_display{
+/obj/machinery/status_display/evac{
 	pixel_x = 32
 	},
 /obj/structure/sign/nanotrasen{
@@ -3303,7 +3298,7 @@
 /obj/machinery/light{
 	dir = 4
 	},
-/obj/machinery/status_display{
+/obj/machinery/status_display/evac{
 	pixel_x = 32
 	},
 /turf/open/floor/plasteel/grimy,
@@ -3574,7 +3569,7 @@
 /turf/open/floor/plating,
 /area/crew_quarters/heads/hop)
 "ahh" = (
-/obj/machinery/status_display,
+/obj/machinery/status_display/evac,
 /turf/closed/wall/r_wall,
 /area/crew_quarters/heads/hop)
 "ahi" = (
@@ -3734,7 +3729,7 @@
 /turf/open/floor/plasteel/vault/side,
 /area/security/brig)
 "ahx" = (
-/obj/machinery/ai_status_display{
+/obj/machinery/status_display/ai{
 	pixel_y = 32
 	},
 /obj/machinery/light/small{
@@ -3872,7 +3867,7 @@
 /obj/machinery/computer/communications{
 	dir = 1
 	},
-/obj/machinery/status_display{
+/obj/machinery/status_display/evac{
 	pixel_y = -32
 	},
 /obj/machinery/keycard_auth{
@@ -3885,7 +3880,7 @@
 /obj/machinery/computer/card{
 	dir = 1
 	},
-/obj/machinery/ai_status_display{
+/obj/machinery/status_display/ai{
 	pixel_y = -32
 	},
 /turf/open/floor/carpet,
@@ -4446,7 +4441,7 @@
 /obj/machinery/light{
 	dir = 8
 	},
-/obj/machinery/status_display{
+/obj/machinery/status_display/evac{
 	pixel_x = -32
 	},
 /obj/effect/turf_decal/bot,
@@ -7146,7 +7141,7 @@
 /obj/machinery/light{
 	dir = 4
 	},
-/obj/machinery/status_display{
+/obj/machinery/status_display/evac{
 	pixel_x = 32
 	},
 /turf/open/floor/plasteel/vault/side{
@@ -7222,7 +7217,7 @@
 /obj/machinery/light{
 	dir = 8
 	},
-/obj/machinery/status_display{
+/obj/machinery/status_display/evac{
 	pixel_x = -32
 	},
 /turf/open/floor/plasteel/vault{
@@ -8228,7 +8223,7 @@
 	},
 /area/teleporter)
 "apL" = (
-/obj/machinery/status_display{
+/obj/machinery/status_display/evac{
 	pixel_y = -32
 	},
 /obj/effect/turf_decal/stripes/line{
@@ -8250,7 +8245,7 @@
 /turf/open/floor/plasteel,
 /area/teleporter)
 "apN" = (
-/obj/machinery/status_display{
+/obj/machinery/status_display/evac{
 	pixel_y = -32
 	},
 /obj/structure/cable/white{
@@ -8435,7 +8430,7 @@
 	},
 /area/ai_monitored/storage/eva)
 "aqd" = (
-/obj/machinery/status_display{
+/obj/machinery/status_display/evac{
 	pixel_y = -32
 	},
 /obj/structure/cable/white{
@@ -8460,7 +8455,7 @@
 /turf/open/floor/plasteel,
 /area/ai_monitored/storage/eva)
 "aqf" = (
-/obj/machinery/status_display{
+/obj/machinery/status_display/evac{
 	pixel_y = -32
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
@@ -8794,7 +8789,7 @@
 /obj/item/assembly/igniter,
 /obj/item/assembly/igniter,
 /obj/effect/spawner/lootdrop/maintenance,
-/obj/machinery/status_display{
+/obj/machinery/status_display/evac{
 	pixel_y = 32
 	},
 /obj/effect/turf_decal/bot,
@@ -8981,7 +8976,7 @@
 /obj/machinery/computer/security/mining{
 	dir = 8
 	},
-/obj/machinery/status_display{
+/obj/machinery/status_display/evac{
 	pixel_x = 32
 	},
 /obj/machinery/newscaster{
@@ -9073,7 +9068,7 @@
 /obj/machinery/light{
 	dir = 8
 	},
-/obj/machinery/status_display{
+/obj/machinery/status_display/evac{
 	pixel_x = -32
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
@@ -9411,7 +9406,7 @@
 /obj/machinery/light_switch{
 	pixel_y = 24
 	},
-/obj/machinery/status_display{
+/obj/machinery/status_display/evac{
 	pixel_x = -32
 	},
 /obj/machinery/camera{
@@ -9707,7 +9702,7 @@
 /obj/structure/table/reinforced,
 /obj/item/book/manual/wiki/security_space_law,
 /obj/item/taperecorder,
-/obj/machinery/status_display{
+/obj/machinery/status_display/evac{
 	pixel_y = -32
 	},
 /obj/item/flashlight/seclite,
@@ -9727,7 +9722,7 @@
 	pixel_x = -26;
 	pixel_y = -26
 	},
-/obj/machinery/status_display{
+/obj/machinery/status_display/evac{
 	pixel_y = -32
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
@@ -10327,7 +10322,7 @@
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/bar/atrium)
 "aui" = (
-/obj/machinery/status_display,
+/obj/machinery/status_display/evac,
 /turf/closed/wall,
 /area/crew_quarters/bar/atrium)
 "auj" = (
@@ -10384,7 +10379,7 @@
 /area/maintenance/starboard/central)
 "auo" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/machinery/status_display{
+/obj/machinery/status_display/evac{
 	pixel_x = -32
 	},
 /turf/open/floor/plasteel/neutral/corner{
@@ -11134,7 +11129,7 @@
 /area/storage/primary)
 "avZ" = (
 /obj/machinery/vending/tool,
-/obj/machinery/status_display{
+/obj/machinery/status_display/evac{
 	pixel_y = -32
 	},
 /obj/effect/turf_decal/delivery,
@@ -11650,7 +11645,7 @@
 /obj/machinery/light{
 	dir = 1
 	},
-/obj/machinery/ai_status_display{
+/obj/machinery/status_display/ai{
 	pixel_y = 32
 	},
 /obj/item/twohanded/required/kirbyplants{
@@ -11718,7 +11713,7 @@
 /obj/item/weldingtool,
 /obj/item/clothing/head/welding,
 /obj/structure/table/reinforced,
-/obj/machinery/status_display{
+/obj/machinery/status_display/evac{
 	pixel_y = 32
 	},
 /obj/effect/turf_decal/stripes/line{
@@ -11793,7 +11788,7 @@
 	},
 /area/crew_quarters/dorms)
 "axE" = (
-/obj/machinery/status_display{
+/obj/machinery/status_display/evac{
 	pixel_y = 32
 	},
 /obj/effect/turf_decal/bot,
@@ -12325,7 +12320,7 @@
 /obj/structure/table/reinforced,
 /obj/item/restraints/handcuffs,
 /obj/item/assembly/flash/handheld,
-/obj/machinery/status_display{
+/obj/machinery/status_display/evac{
 	pixel_y = 32
 	},
 /obj/structure/cable/white{
@@ -12353,7 +12348,7 @@
 /area/hallway/secondary/exit)
 "ayZ" = (
 /obj/structure/chair,
-/obj/machinery/ai_status_display{
+/obj/machinery/status_display/ai{
 	pixel_y = 32
 	},
 /obj/structure/cable/white{
@@ -13514,7 +13509,7 @@
 /turf/open/floor/plasteel/redyellow,
 /area/crew_quarters/bar/atrium)
 "aCb" = (
-/obj/machinery/status_display,
+/obj/machinery/status_display/evac,
 /turf/closed/wall,
 /area/crew_quarters/kitchen)
 "aCc" = (
@@ -13967,7 +13962,7 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard/central)
 "aDc" = (
-/obj/machinery/status_display,
+/obj/machinery/status_display/evac,
 /turf/closed/wall,
 /area/hallway/primary/starboard/fore)
 "aDd" = (
@@ -14457,7 +14452,7 @@
 /obj/machinery/computer/monitor{
 	name = "Engineering Power Monitoring Console"
 	},
-/obj/machinery/status_display{
+/obj/machinery/status_display/evac{
 	pixel_x = -32
 	},
 /obj/structure/cable/white{
@@ -14635,7 +14630,7 @@
 /obj/item/twohanded/required/kirbyplants{
 	icon_state = "plant-21"
 	},
-/obj/machinery/status_display{
+/obj/machinery/status_display/evac{
 	pixel_y = -32
 	},
 /obj/effect/turf_decal/bot,
@@ -15365,7 +15360,7 @@
 /turf/closed/wall/r_wall,
 /area/engine/engineering)
 "aGj" = (
-/obj/machinery/status_display,
+/obj/machinery/status_display/evac,
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 1
 	},
@@ -16285,7 +16280,7 @@
 /turf/open/floor/plasteel/redyellow,
 /area/crew_quarters/bar/atrium)
 "aHV" = (
-/obj/machinery/status_display,
+/obj/machinery/status_display/evac,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/closed/wall,
 /area/crew_quarters/kitchen)
@@ -16856,7 +16851,7 @@
 	},
 /area/hallway/primary/starboard)
 "aIZ" = (
-/obj/machinery/ai_status_display,
+/obj/machinery/status_display/ai,
 /turf/closed/wall,
 /area/hallway/primary/starboard)
 "aJa" = (
@@ -17722,7 +17717,7 @@
 /obj/machinery/light/small{
 	dir = 8
 	},
-/obj/machinery/status_display{
+/obj/machinery/status_display/evac{
 	pixel_x = -32
 	},
 /obj/effect/turf_decal/bot,
@@ -17970,7 +17965,7 @@
 /turf/open/floor/plasteel,
 /area/engine/gravity_generator)
 "aLE" = (
-/obj/machinery/status_display{
+/obj/machinery/status_display/evac{
 	pixel_y = -32
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
@@ -18088,7 +18083,7 @@
 /turf/open/floor/engine,
 /area/engine/engineering)
 "aLO" = (
-/obj/machinery/ai_status_display,
+/obj/machinery/status_display/ai,
 /turf/closed/wall/r_wall,
 /area/engine/supermatter)
 "aLP" = (
@@ -18127,7 +18122,7 @@
 /turf/closed/wall/r_wall,
 /area/engine/supermatter)
 "aLU" = (
-/obj/machinery/status_display,
+/obj/machinery/status_display/evac,
 /turf/closed/wall/r_wall,
 /area/engine/supermatter)
 "aLV" = (
@@ -18552,7 +18547,7 @@
 /area/engine/engineering)
 "aNc" = (
 /obj/machinery/suit_storage_unit/engine,
-/obj/machinery/status_display{
+/obj/machinery/status_display/evac{
 	pixel_y = -32
 	},
 /obj/item/clothing/glasses/meson/engine,
@@ -18576,7 +18571,7 @@
 /area/engine/engineering)
 "aNe" = (
 /obj/structure/reagent_dispensers/watertank,
-/obj/machinery/status_display{
+/obj/machinery/status_display/evac{
 	pixel_y = -32
 	},
 /obj/effect/turf_decal/stripes/line{
@@ -18851,7 +18846,7 @@
 /area/hallway/secondary/exit)
 "aNH" = (
 /obj/structure/closet/crate,
-/obj/machinery/ai_status_display{
+/obj/machinery/status_display/ai{
 	pixel_y = -32
 	},
 /obj/effect/turf_decal/bot,
@@ -18869,7 +18864,7 @@
 /area/hallway/secondary/exit)
 "aNJ" = (
 /obj/structure/closet/crate,
-/obj/machinery/status_display{
+/obj/machinery/status_display/evac{
 	pixel_y = -32
 	},
 /obj/effect/turf_decal/bot,
@@ -18886,7 +18881,7 @@
 /area/hallway/secondary/exit)
 "aNT" = (
 /obj/machinery/announcement_system,
-/obj/machinery/ai_status_display{
+/obj/machinery/status_display/ai{
 	pixel_x = -32
 	},
 /obj/machinery/firealarm{
@@ -19292,7 +19287,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
-/obj/machinery/status_display{
+/obj/machinery/status_display/evac{
 	pixel_y = 32
 	},
 /obj/structure/cable/white{
@@ -19704,7 +19699,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
-/obj/machinery/status_display{
+/obj/machinery/status_display/evac{
 	pixel_y = 32
 	},
 /obj/structure/cable/white{
@@ -20893,7 +20888,7 @@
 /turf/closed/wall,
 /area/medical/medbay/zone3)
 "aSi" = (
-/obj/machinery/status_display,
+/obj/machinery/status_display/evac,
 /turf/closed/wall,
 /area/medical/medbay/zone3)
 "aSj" = (
@@ -21222,7 +21217,7 @@
 	},
 /obj/structure/cable/white,
 /obj/machinery/light,
-/obj/machinery/status_display{
+/obj/machinery/status_display/evac{
 	pixel_y = -32
 	},
 /obj/effect/turf_decal/bot,
@@ -21832,7 +21827,7 @@
 	},
 /area/medical/medbay/zone3)
 "aUr" = (
-/obj/machinery/status_display,
+/obj/machinery/status_display/evac,
 /turf/closed/wall,
 /area/medical/chemistry)
 "aUs" = (
@@ -22459,7 +22454,7 @@
 /obj/structure/table/wood,
 /obj/item/storage/bag/books,
 /obj/item/taperecorder,
-/obj/machinery/status_display{
+/obj/machinery/status_display/evac{
 	pixel_x = -32
 	},
 /turf/open/floor/plasteel/dark,
@@ -22734,7 +22729,7 @@
 /turf/open/floor/plasteel/vault/side,
 /area/science/lab)
 "aWp" = (
-/obj/machinery/status_display,
+/obj/machinery/status_display/evac,
 /turf/closed/wall,
 /area/science/lab)
 "aWq" = (
@@ -22853,7 +22848,7 @@
 /area/library)
 "aWG" = (
 /obj/machinery/bookbinder,
-/obj/machinery/status_display{
+/obj/machinery/status_display/evac{
 	pixel_x = 32
 	},
 /turf/open/floor/plasteel/vault{
@@ -23161,7 +23156,7 @@
 /obj/machinery/light{
 	dir = 1
 	},
-/obj/machinery/status_display{
+/obj/machinery/status_display/evac{
 	pixel_y = 32
 	},
 /turf/open/floor/plasteel/whiteblue/corner{
@@ -24115,7 +24110,7 @@
 /turf/closed/wall/r_wall,
 /area/science/robotics/lab)
 "aZj" = (
-/obj/machinery/ai_status_display,
+/obj/machinery/status_display/ai,
 /turf/closed/wall/r_wall,
 /area/science/robotics/lab)
 "aZk" = (
@@ -24177,7 +24172,7 @@
 /turf/closed/wall,
 /area/maintenance/port)
 "aZu" = (
-/obj/machinery/status_display{
+/obj/machinery/status_display/evac{
 	pixel_y = -32
 	},
 /obj/machinery/newscaster{
@@ -24205,7 +24200,7 @@
 	},
 /area/library)
 "aZw" = (
-/obj/machinery/ai_status_display{
+/obj/machinery/status_display/ai{
 	pixel_y = -32
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
@@ -25655,7 +25650,7 @@
 /turf/open/floor/plasteel/neutral,
 /area/security/checkpoint)
 "bcp" = (
-/obj/machinery/status_display{
+/obj/machinery/status_display/evac{
 	pixel_x = 32
 	},
 /obj/machinery/computer/card{
@@ -26101,7 +26096,7 @@
 /turf/open/floor/circuit/green,
 /area/science/robotics/mechbay)
 "bdp" = (
-/obj/machinery/status_display,
+/obj/machinery/status_display/evac,
 /turf/closed/wall,
 /area/science/robotics/mechbay)
 "bdq" = (
@@ -26190,7 +26185,7 @@
 /obj/structure/table/reinforced,
 /obj/item/retractor,
 /obj/item/hemostat,
-/obj/machinery/ai_status_display{
+/obj/machinery/status_display/ai{
 	pixel_x = 32
 	},
 /obj/effect/turf_decal/bot,
@@ -26525,7 +26520,7 @@
 /obj/machinery/computer/secure_data{
 	dir = 8
 	},
-/obj/machinery/ai_status_display{
+/obj/machinery/status_display/ai{
 	pixel_x = 32
 	},
 /turf/open/floor/plasteel/red/side{
@@ -26559,7 +26554,7 @@
 /obj/machinery/computer/mech_bay_power_console{
 	dir = 1
 	},
-/obj/machinery/ai_status_display{
+/obj/machinery/status_display/ai{
 	pixel_y = -32
 	},
 /turf/open/floor/circuit/green,
@@ -26654,7 +26649,7 @@
 "beq" = (
 /obj/structure/table/optable,
 /obj/effect/decal/cleanable/blood/old,
-/obj/machinery/status_display{
+/obj/machinery/status_display/evac{
 	pixel_y = -32
 	},
 /turf/open/floor/plasteel/whitepurple/corner,
@@ -27536,7 +27531,7 @@
 /obj/machinery/light/small{
 	dir = 4
 	},
-/obj/machinery/ai_status_display{
+/obj/machinery/status_display/ai{
 	pixel_x = 32
 	},
 /turf/open/floor/plasteel/vault{
@@ -27757,7 +27752,7 @@
 	},
 /area/chapel/main)
 "bgF" = (
-/obj/machinery/status_display,
+/obj/machinery/status_display/evac,
 /turf/closed/wall/rust,
 /area/chapel/main)
 "bgG" = (
@@ -27900,7 +27895,7 @@
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
 "bgT" = (
-/obj/machinery/ai_status_display,
+/obj/machinery/status_display/ai,
 /turf/closed/wall,
 /area/hallway/secondary/entry)
 "bgU" = (
@@ -27908,7 +27903,7 @@
 /turf/open/floor/plating,
 /area/hallway/secondary/entry)
 "bgV" = (
-/obj/machinery/status_display,
+/obj/machinery/status_display/evac,
 /turf/closed/wall,
 /area/hallway/secondary/entry)
 "bgW" = (
@@ -28456,7 +28451,7 @@
 	},
 /area/chapel/main)
 "big" = (
-/obj/machinery/status_display,
+/obj/machinery/status_display/evac,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
@@ -29023,7 +29018,7 @@
 "bjk" = (
 /obj/structure/table/wood,
 /obj/item/storage/fancy/donut_box,
-/obj/machinery/ai_status_display{
+/obj/machinery/status_display/ai{
 	pixel_x = 32
 	},
 /turf/open/floor/plasteel/grimy,
@@ -29256,7 +29251,7 @@
 	name = "Chapel RC";
 	pixel_y = -32
 	},
-/obj/machinery/status_display{
+/obj/machinery/status_display/evac{
 	pixel_x = 32
 	},
 /turf/open/floor/plasteel/grimy,
@@ -29300,7 +29295,7 @@
 /obj/structure/table/reinforced,
 /obj/item/storage/box/monkeycubes,
 /obj/item/storage/box/monkeycubes,
-/obj/machinery/status_display{
+/obj/machinery/status_display/evac{
 	pixel_y = -32
 	},
 /obj/effect/turf_decal/stripes/line{
@@ -29338,7 +29333,7 @@
 /obj/item/reagent_containers/glass/beaker/large,
 /obj/item/reagent_containers/glass/beaker,
 /obj/item/reagent_containers/dropper,
-/obj/machinery/status_display{
+/obj/machinery/status_display/evac{
 	pixel_y = -32
 	},
 /obj/structure/cable/white{
@@ -29377,7 +29372,7 @@
 /turf/open/floor/plasteel,
 /area/science/xenobiology)
 "bjU" = (
-/obj/machinery/status_display{
+/obj/machinery/status_display/evac{
 	pixel_x = -32
 	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
@@ -29389,7 +29384,7 @@
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
 "bjV" = (
-/obj/machinery/status_display{
+/obj/machinery/status_display/evac{
 	pixel_x = 32
 	},
 /obj/machinery/light{
@@ -29524,7 +29519,7 @@
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
 "bkW" = (
-/obj/machinery/status_display{
+/obj/machinery/status_display/evac{
 	pixel_x = -32
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
@@ -29536,7 +29531,7 @@
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
 "bkX" = (
-/obj/machinery/status_display{
+/obj/machinery/status_display/evac{
 	pixel_x = 32
 	},
 /obj/machinery/light{
@@ -30064,7 +30059,7 @@
 /obj/structure/cable/white{
 	icon_state = "4-8"
 	},
-/obj/machinery/status_display{
+/obj/machinery/status_display/evac{
 	pixel_y = -32
 	},
 /turf/open/floor/plasteel/escape,
@@ -30368,7 +30363,7 @@
 /area/tcommsat/server)
 "buN" = (
 /obj/machinery/announcement_system,
-/obj/machinery/ai_status_display{
+/obj/machinery/status_display/ai{
 	pixel_x = 32
 	},
 /turf/open/floor/circuit/telecomms/mainframe,
@@ -30390,7 +30385,7 @@
 /turf/open/floor/circuit/telecomms/mainframe,
 /area/tcommsat/server)
 "buR" = (
-/obj/machinery/status_display{
+/obj/machinery/status_display/evac{
 	pixel_y = -32
 	},
 /obj/effect/turf_decal/stripes/corner{
@@ -31352,7 +31347,7 @@
 	},
 /area/hallway/primary/starboard)
 "fgG" = (
-/obj/machinery/ai_status_display,
+/obj/machinery/status_display/ai,
 /turf/closed/wall,
 /area/crew_quarters/lounge)
 "fjs" = (
@@ -31762,7 +31757,7 @@
 /turf/open/floor/plasteel/neutral,
 /area/hallway/primary/aft)
 "iUq" = (
-/obj/machinery/status_display,
+/obj/machinery/status_display/evac,
 /turf/closed/wall,
 /area/library)
 "iVw" = (
@@ -32717,7 +32712,7 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
 "rzn" = (
-/obj/machinery/status_display,
+/obj/machinery/status_display/evac,
 /turf/closed/wall,
 /area/hallway/primary/starboard)
 "rzq" = (
@@ -32883,10 +32878,7 @@
 /turf/closed/wall/rust,
 /area/quartermaster/storage)
 "swM" = (
-/obj/machinery/status_display{
-	name = "cargo display";
-	supply_display = 1
-	},
+/obj/machinery/status_display/supply,
 /turf/closed/wall/rust,
 /area/quartermaster/storage)
 "swN" = (
@@ -33421,7 +33413,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
-/obj/machinery/status_display{
+/obj/machinery/status_display/evac{
 	pixel_y = 32
 	},
 /turf/open/floor/plasteel,
@@ -33680,7 +33672,7 @@
 /area/maintenance/starboard)
 "sJk" = (
 /obj/machinery/light,
-/obj/machinery/status_display{
+/obj/machinery/status_display/evac{
 	pixel_y = -32
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -34378,7 +34370,7 @@
 /obj/machinery/light{
 	dir = 1
 	},
-/obj/machinery/ai_status_display{
+/obj/machinery/status_display/ai{
 	pixel_y = 32
 	},
 /obj/effect/turf_decal/delivery,
@@ -34448,7 +34440,7 @@
 /obj/machinery/light{
 	dir = 1
 	},
-/obj/machinery/ai_status_display{
+/obj/machinery/status_display/ai{
 	pixel_y = 32
 	},
 /obj/effect/turf_decal/stripes/line{
@@ -34903,7 +34895,7 @@
 /area/ai_monitored/turret_protected/aisat_interior)
 "sNJ" = (
 /obj/machinery/recharge_station,
-/obj/machinery/status_display{
+/obj/machinery/status_display/evac{
 	pixel_y = -32
 	},
 /obj/effect/turf_decal/stripes/line{
@@ -34963,7 +34955,7 @@
 	pixel_y = 4
 	},
 /obj/structure/table,
-/obj/machinery/status_display{
+/obj/machinery/status_display/evac{
 	pixel_y = -32
 	},
 /obj/machinery/light,
@@ -35015,7 +35007,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
-/obj/machinery/ai_status_display{
+/obj/machinery/status_display/ai{
 	pixel_y = 32
 	},
 /turf/open/floor/plasteel/vault/side{
@@ -35427,7 +35419,7 @@
 	},
 /area/engine/atmos)
 "uuU" = (
-/obj/machinery/status_display,
+/obj/machinery/status_display/evac,
 /turf/closed/wall,
 /area/crew_quarters/lounge)
 "uuX" = (

--- a/_maps/map_files/PubbyStation/PubbyStation.dmm
+++ b/_maps/map_files/PubbyStation/PubbyStation.dmm
@@ -138,7 +138,7 @@
 /obj/structure/cable/yellow{
 	icon_state = "0-8"
 	},
-/obj/machinery/ai_status_display{
+/obj/machinery/status_display/ai{
 	pixel_y = 32
 	},
 /turf/open/floor/circuit,
@@ -345,7 +345,7 @@
 	id = "AI";
 	pixel_y = 20
 	},
-/obj/machinery/ai_status_display{
+/obj/machinery/status_display/ai{
 	pixel_y = 37
 	},
 /turf/open/floor/circuit,
@@ -2969,7 +2969,7 @@
 /area/security/main)
 "ajo" = (
 /obj/machinery/vending/coffee,
-/obj/machinery/status_display{
+/obj/machinery/status_display/evac{
 	pixel_y = 32
 	},
 /turf/open/floor/plasteel/red/side{
@@ -3289,7 +3289,7 @@
 "akc" = (
 /obj/structure/table/wood,
 /obj/machinery/recharger,
-/obj/machinery/status_display{
+/obj/machinery/status_display/evac{
 	pixel_y = 32
 	},
 /obj/machinery/light{
@@ -5942,7 +5942,7 @@
 /turf/open/floor/plasteel/dark,
 /area/security/brig)
 "aqD" = (
-/obj/machinery/ai_status_display{
+/obj/machinery/status_display/ai{
 	pixel_y = 32
 	},
 /turf/open/floor/plasteel/dark,
@@ -6353,7 +6353,7 @@
 	},
 /area/bridge)
 "arK" = (
-/obj/machinery/status_display{
+/obj/machinery/status_display/evac{
 	pixel_y = 32
 	},
 /obj/item/folder/yellow{
@@ -6392,7 +6392,7 @@
 	},
 /area/bridge)
 "arO" = (
-/obj/machinery/ai_status_display{
+/obj/machinery/status_display/ai{
 	pixel_y = 32
 	},
 /obj/structure/table/glass,
@@ -8315,7 +8315,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/machinery/status_display{
+/obj/machinery/status_display/evac{
 	pixel_y = 32
 	},
 /turf/open/floor/plasteel/arrival{
@@ -10328,7 +10328,7 @@
 /turf/open/floor/wood,
 /area/crew_quarters/heads/hop)
 "aBF" = (
-/obj/machinery/status_display{
+/obj/machinery/status_display/evac{
 	pixel_y = 32
 	},
 /obj/structure/bed/dogbed/ian,
@@ -12875,7 +12875,7 @@
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 1
 	},
-/obj/machinery/status_display{
+/obj/machinery/status_display/evac{
 	pixel_y = 32
 	},
 /turf/open/floor/plasteel/neutral/corner{
@@ -14436,9 +14436,8 @@
 	id = "packageSort2"
 	},
 /obj/effect/spawner/lootdrop/maintenance,
-/obj/machinery/status_display{
-	pixel_y = 30;
-	supply_display = 1
+/obj/machinery/status_display/supply{
+	pixel_y = 30
 	},
 /turf/open/floor/plating,
 /area/quartermaster/sorting)
@@ -15959,7 +15958,7 @@
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit/departure_lounge)
 "aQt" = (
-/obj/machinery/status_display,
+/obj/machinery/status_display/evac,
 /turf/closed/wall,
 /area/hallway/secondary/exit/departure_lounge)
 "aQu" = (
@@ -17188,9 +17187,8 @@
 /turf/open/floor/plating,
 /area/quartermaster/storage)
 "aTo" = (
-/obj/machinery/status_display{
-	pixel_y = 30;
-	supply_display = 1
+/obj/machinery/status_display/supply{
+	pixel_y = 30
 	},
 /obj/machinery/conveyor{
 	dir = 4;
@@ -18565,11 +18563,10 @@
 /turf/open/floor/plasteel/dark,
 /area/quartermaster/office)
 "aWw" = (
-/obj/machinery/status_display{
+/obj/machinery/status_display/supply{
 	dir = 8;
 	layer = 4;
-	pixel_x = 32;
-	supply_display = 1
+	pixel_x = 32
 	},
 /turf/open/floor/plasteel/brown{
 	dir = 4
@@ -19638,11 +19635,10 @@
 	},
 /area/hallway/primary/central)
 "aZj" = (
-/obj/machinery/status_display{
+/obj/machinery/status_display/supply{
 	dir = 4;
 	layer = 4;
-	pixel_x = -32;
-	supply_display = 1
+	pixel_x = -32
 	},
 /obj/machinery/computer/bounty{
 	dir = 4
@@ -21712,11 +21708,10 @@
 /turf/closed/wall,
 /area/science/robotics/mechbay)
 "beJ" = (
-/obj/machinery/status_display{
+/obj/machinery/status_display/supply{
 	dir = 4;
 	layer = 4;
-	pixel_x = -32;
-	supply_display = 1
+	pixel_x = -32
 	},
 /obj/structure/filingcabinet,
 /turf/open/floor/plasteel/brown{
@@ -22002,7 +21997,7 @@
 /obj/structure/cable{
 	icon_state = "0-2"
 	},
-/obj/machinery/status_display{
+/obj/machinery/status_display/evac{
 	pixel_y = 30
 	},
 /turf/open/floor/plasteel/dark,
@@ -31977,7 +31972,7 @@
 /obj/item/folder/white,
 /obj/item/pen,
 /obj/item/stamp/rd,
-/obj/machinery/status_display{
+/obj/machinery/status_display/evac{
 	pixel_y = -30;
 	supply_display = 0
 	},
@@ -32882,7 +32877,7 @@
 /area/medical/surgery)
 "bHc" = (
 /obj/machinery/computer/med_data,
-/obj/machinery/status_display{
+/obj/machinery/status_display/evac{
 	pixel_y = 32
 	},
 /turf/open/floor/plasteel/freezer,
@@ -43822,7 +43817,7 @@
 /turf/open/space,
 /area/space/nearstation)
 "cmu" = (
-/obj/machinery/status_display{
+/obj/machinery/status_display/evac{
 	pixel_x = -32
 	},
 /obj/structure/table,

--- a/_maps/map_files/PubbyStation/PubbyStation.dmm
+++ b/_maps/map_files/PubbyStation/PubbyStation.dmm
@@ -31973,8 +31973,7 @@
 /obj/item/pen,
 /obj/item/stamp/rd,
 /obj/machinery/status_display/evac{
-	pixel_y = -30;
-	supply_display = 0
+	pixel_y = -30
 	},
 /obj/machinery/camera{
 	c_tag = "Research Director's Office";

--- a/_maps/map_files/debug/runtimestation.dmm
+++ b/_maps/map_files/debug/runtimestation.dmm
@@ -1466,10 +1466,7 @@
 /turf/open/floor/plating,
 /area/hallway/secondary/entry)
 "ey" = (
-/obj/machinery/status_display{
-	name = "cargo display";
-	supply_display = 1
-	},
+/obj/machinery/status_display/supply,
 /turf/closed/wall,
 /area/quartermaster/storage)
 "ez" = (
@@ -1931,10 +1928,7 @@
 /turf/open/floor/plasteel,
 /area/storage/primary)
 "fB" = (
-/obj/machinery/status_display{
-	name = "cargo display";
-	supply_display = 1
-	},
+/obj/machinery/status_display/supply,
 /turf/closed/wall/r_wall,
 /area/quartermaster/storage)
 "fC" = (
@@ -2077,7 +2071,7 @@
 /area/hallway/secondary/exit/departure_lounge)
 "fQ" = (
 /obj/machinery/computer/communications,
-/obj/machinery/status_display{
+/obj/machinery/status_display/evac{
 	pixel_y = 32
 	},
 /turf/open/floor/plasteel,

--- a/_maps/map_files/generic/CentCom.dmm
+++ b/_maps/map_files/generic/CentCom.dmm
@@ -2678,7 +2678,7 @@
 /turf/closed/indestructible/riveted,
 /area/centcom/prison)
 "im" = (
-/obj/machinery/status_display,
+/obj/machinery/status_display/evac,
 /turf/closed/indestructible/riveted,
 /area/centcom/control)
 "in" = (
@@ -2689,7 +2689,7 @@
 /turf/closed/indestructible/riveted,
 /area/centcom/control)
 "ip" = (
-/obj/machinery/ai_status_display,
+/obj/machinery/status_display/ai,
 /turf/closed/indestructible/riveted,
 /area/centcom/control)
 "iq" = (
@@ -2860,10 +2860,7 @@
 /turf/open/floor/plasteel,
 /area/centcom/control)
 "iN" = (
-/obj/machinery/status_display{
-	name = "cargo display";
-	supply_display = 1
-	},
+/obj/machinery/status_display/supply,
 /turf/closed/indestructible/riveted,
 /area/centcom/supply)
 "iO" = (
@@ -3216,7 +3213,7 @@
 /turf/open/floor/plasteel,
 /area/centcom/supply)
 "jE" = (
-/obj/machinery/status_display,
+/obj/machinery/status_display/evac,
 /turf/closed/indestructible/riveted,
 /area/centcom/supply)
 "jF" = (
@@ -4343,7 +4340,7 @@
 /turf/closed/indestructible/riveted,
 /area/centcom/ferry)
 "mF" = (
-/obj/machinery/ai_status_display,
+/obj/machinery/status_display/ai,
 /turf/closed/indestructible/riveted,
 /area/centcom/supply)
 "mG" = (
@@ -4859,11 +4856,11 @@
 /turf/open/floor/plasteel/white,
 /area/centcom/ferry)
 "nT" = (
-/obj/machinery/ai_status_display,
+/obj/machinery/status_display/ai,
 /turf/closed/indestructible/riveted,
 /area/centcom/ferry)
 "nU" = (
-/obj/machinery/status_display,
+/obj/machinery/status_display/evac,
 /turf/closed/indestructible/riveted,
 /area/centcom/ferry)
 "nV" = (
@@ -4962,7 +4959,7 @@
 	},
 /area/centcom/ferry)
 "oh" = (
-/obj/machinery/ai_status_display{
+/obj/machinery/status_display/ai{
 	pixel_y = 32
 	},
 /obj/item/twohanded/required/kirbyplants{
@@ -4979,7 +4976,7 @@
 /turf/open/floor/plasteel/vault,
 /area/centcom/ferry)
 "oj" = (
-/obj/machinery/status_display{
+/obj/machinery/status_display/evac{
 	pixel_y = 32
 	},
 /turf/open/floor/plasteel/vault{
@@ -5461,7 +5458,7 @@
 	dir = 1
 	},
 /obj/machinery/light,
-/obj/machinery/status_display{
+/obj/machinery/status_display/evac{
 	pixel_y = -32
 	},
 /turf/open/floor/plasteel/vault{
@@ -5480,7 +5477,7 @@
 /area/centcom/control)
 "pr" = (
 /obj/structure/bookcase/random,
-/obj/machinery/status_display{
+/obj/machinery/status_display/evac{
 	pixel_y = -32
 	},
 /turf/open/floor/plasteel/vault{
@@ -6472,7 +6469,7 @@
 	},
 /area/centcom/control)
 "rS" = (
-/obj/machinery/status_display,
+/obj/machinery/status_display/evac,
 /turf/closed/indestructible/riveted,
 /area/centcom/evac)
 "rT" = (
@@ -7216,7 +7213,7 @@
 	},
 /area/centcom/control)
 "tR" = (
-/obj/machinery/ai_status_display,
+/obj/machinery/status_display/ai,
 /turf/closed/indestructible/riveted,
 /area/centcom/evac)
 "tS" = (
@@ -10812,7 +10809,7 @@
 	},
 /area/tdome/tdomeobserve)
 "EK" = (
-/obj/machinery/status_display,
+/obj/machinery/status_display/evac,
 /turf/closed/indestructible/riveted,
 /area/tdome/tdomeobserve)
 "EL" = (
@@ -11822,7 +11819,7 @@
 /obj/machinery/light{
 	dir = 1
 	},
-/obj/machinery/ai_status_display{
+/obj/machinery/status_display/ai{
 	pixel_y = 32
 	},
 /turf/open/floor/plasteel/vault{
@@ -12828,11 +12825,11 @@
 /turf/open/floor/grass,
 /area/tdome/tdomeadmin)
 "KC" = (
-/obj/machinery/status_display,
+/obj/machinery/status_display/evac,
 /turf/closed/indestructible/riveted,
 /area/tdome/tdomeadmin)
 "KD" = (
-/obj/machinery/ai_status_display,
+/obj/machinery/status_display/ai,
 /turf/closed/indestructible/riveted,
 /area/tdome/tdomeadmin)
 "KG" = (

--- a/_maps/shuttles/arrival_delta.dmm
+++ b/_maps/shuttles/arrival_delta.dmm
@@ -182,7 +182,7 @@
 	},
 /area/shuttle/arrival)
 "r" = (
-/obj/machinery/status_display{
+/obj/machinery/status_display/evac{
 	pixel_x = -32
 	},
 /obj/item/twohanded/required/kirbyplants{
@@ -200,7 +200,7 @@
 /turf/open/floor/plasteel,
 /area/shuttle/arrival)
 "t" = (
-/obj/machinery/ai_status_display{
+/obj/machinery/status_display/ai{
 	pixel_x = 32
 	},
 /obj/item/twohanded/required/kirbyplants{
@@ -337,7 +337,7 @@
 /turf/open/floor/plasteel,
 /area/shuttle/arrival)
 "N" = (
-/obj/machinery/status_display,
+/obj/machinery/status_display/evac,
 /turf/closed/wall/mineral/titanium,
 /area/shuttle/arrival)
 "O" = (
@@ -353,7 +353,7 @@
 /turf/open/floor/plasteel,
 /area/shuttle/arrival)
 "P" = (
-/obj/machinery/ai_status_display,
+/obj/machinery/status_display/ai,
 /turf/closed/wall/mineral/titanium,
 /area/shuttle/arrival)
 "Q" = (

--- a/_maps/shuttles/emergency_asteroid.dmm
+++ b/_maps/shuttles/emergency_asteroid.dmm
@@ -206,7 +206,7 @@
 /turf/open/floor/mineral/titanium,
 /area/shuttle/escape)
 "aX" = (
-/obj/machinery/ai_status_display,
+/obj/machinery/status_display/ai,
 /turf/closed/wall/mineral/titanium,
 /area/shuttle/escape)
 "aY" = (
@@ -264,7 +264,7 @@
 /turf/open/floor/mineral/titanium,
 /area/shuttle/escape)
 "bi" = (
-/obj/machinery/status_display,
+/obj/machinery/status_display/evac,
 /turf/closed/wall/mineral/titanium,
 /area/shuttle/escape)
 "bj" = (

--- a/_maps/shuttles/emergency_backup.dmm
+++ b/_maps/shuttles/emergency_backup.dmm
@@ -25,7 +25,7 @@
 /turf/open/floor/mineral/plastitanium/red,
 /area/shuttle/escape/backup)
 "q" = (
-/obj/machinery/status_display,
+/obj/machinery/status_display/evac,
 /turf/closed/wall/mineral/titanium,
 /area/shuttle/escape/backup)
 "u" = (

--- a/_maps/shuttles/emergency_bar.dmm
+++ b/_maps/shuttles/emergency_bar.dmm
@@ -134,7 +134,7 @@
 /turf/open/floor/carpet,
 /area/shuttle/escape)
 "aA" = (
-/obj/machinery/status_display,
+/obj/machinery/status_display/evac,
 /turf/closed/wall/mineral/titanium,
 /area/shuttle/escape)
 "aC" = (

--- a/_maps/shuttles/emergency_box.dmm
+++ b/_maps/shuttles/emergency_box.dmm
@@ -109,7 +109,7 @@
 /turf/open/floor/mineral/titanium,
 /area/shuttle/escape)
 "az" = (
-/obj/machinery/status_display,
+/obj/machinery/status_display/evac,
 /turf/closed/wall/mineral/titanium,
 /area/shuttle/escape)
 "aA" = (

--- a/_maps/shuttles/emergency_clown.dmm
+++ b/_maps/shuttles/emergency_clown.dmm
@@ -105,7 +105,7 @@
 /turf/open/floor/bluespace,
 /area/shuttle/escape)
 "at" = (
-/obj/machinery/status_display,
+/obj/machinery/status_display/evac,
 /turf/closed/wall/mineral/titanium,
 /area/shuttle/escape)
 "au" = (

--- a/_maps/shuttles/emergency_cramped.dmm
+++ b/_maps/shuttles/emergency_cramped.dmm
@@ -51,7 +51,7 @@
 /turf/open/floor/plasteel/dark,
 /area/shuttle/escape)
 "j" = (
-/obj/machinery/status_display,
+/obj/machinery/status_display/evac,
 /turf/closed/wall/mineral/titanium,
 /area/shuttle/escape)
 "k" = (

--- a/_maps/shuttles/emergency_delta.dmm
+++ b/_maps/shuttles/emergency_delta.dmm
@@ -178,7 +178,7 @@
 	},
 /area/shuttle/escape)
 "aq" = (
-/obj/machinery/status_display,
+/obj/machinery/status_display/evac,
 /turf/closed/wall/mineral/titanium,
 /area/shuttle/escape)
 "ar" = (
@@ -294,11 +294,11 @@
 	},
 /area/shuttle/escape)
 "aC" = (
-/obj/machinery/ai_status_display,
+/obj/machinery/status_display/ai,
 /turf/closed/wall/mineral/titanium/nodiagonal,
 /area/shuttle/escape)
 "aD" = (
-/obj/machinery/status_display,
+/obj/machinery/status_display/evac,
 /turf/closed/wall/mineral/titanium/nodiagonal,
 /area/shuttle/escape)
 "aE" = (
@@ -715,7 +715,7 @@
 /area/shuttle/escape)
 "bD" = (
 /obj/structure/chair/comfy/shuttle,
-/obj/machinery/status_display{
+/obj/machinery/status_display/evac{
 	pixel_y = 32
 	},
 /obj/effect/turf_decal/bot,
@@ -774,7 +774,7 @@
 /obj/structure/chair/comfy/shuttle{
 	dir = 4
 	},
-/obj/machinery/status_display{
+/obj/machinery/status_display/evac{
 	pixel_x = -32
 	},
 /turf/open/floor/mineral/plastitanium/red/brig,

--- a/_maps/shuttles/emergency_goon.dmm
+++ b/_maps/shuttles/emergency_goon.dmm
@@ -21,7 +21,7 @@
 /turf/closed/wall/mineral/titanium,
 /area/shuttle/escape)
 "f" = (
-/obj/machinery/status_display,
+/obj/machinery/status_display/evac,
 /turf/closed/wall/mineral/titanium,
 /area/shuttle/escape)
 "g" = (

--- a/_maps/shuttles/emergency_imfedupwiththisworld.dmm
+++ b/_maps/shuttles/emergency_imfedupwiththisworld.dmm
@@ -160,7 +160,7 @@
 /turf/open/floor/carpet,
 /area/shuttle/escape)
 "E" = (
-/obj/machinery/status_display,
+/obj/machinery/status_display/evac,
 /turf/closed/wall/mineral/wood,
 /area/shuttle/escape)
 

--- a/_maps/shuttles/emergency_meta.dmm
+++ b/_maps/shuttles/emergency_meta.dmm
@@ -198,7 +198,7 @@
 /turf/open/floor/mineral/titanium/blue,
 /area/shuttle/escape)
 "az" = (
-/obj/machinery/status_display,
+/obj/machinery/status_display/evac,
 /turf/closed/wall/mineral/titanium,
 /area/shuttle/escape)
 "aA" = (
@@ -262,7 +262,7 @@
 /turf/open/floor/mineral/titanium/blue,
 /area/shuttle/escape)
 "aN" = (
-/obj/machinery/status_display{
+/obj/machinery/status_display/evac{
 	dir = 8;
 	pixel_x = 32
 	},

--- a/_maps/shuttles/emergency_mini.dmm
+++ b/_maps/shuttles/emergency_mini.dmm
@@ -174,7 +174,7 @@
 /turf/open/floor/mineral/titanium/blue,
 /area/shuttle/escape)
 "H" = (
-/obj/machinery/status_display,
+/obj/machinery/status_display/evac,
 /turf/closed/wall/mineral/titanium,
 /area/shuttle/escape)
 "I" = (

--- a/_maps/shuttles/emergency_narnar.dmm
+++ b/_maps/shuttles/emergency_narnar.dmm
@@ -98,7 +98,7 @@
 /turf/open/floor/plasteel/cult,
 /area/shuttle/escape)
 "s" = (
-/obj/machinery/status_display,
+/obj/machinery/status_display/evac,
 /turf/closed/wall/mineral/cult,
 /area/shuttle/escape)
 "t" = (

--- a/_maps/shuttles/emergency_omega.dmm
+++ b/_maps/shuttles/emergency_omega.dmm
@@ -40,7 +40,7 @@
 "ag" = (
 /obj/structure/table/reinforced,
 /obj/machinery/recharger,
-/obj/machinery/status_display{
+/obj/machinery/status_display/evac{
 	pixel_y = 32
 	},
 /turf/open/floor/plasteel/vault{
@@ -70,7 +70,7 @@
 /obj/structure/chair/comfy/shuttle{
 	dir = 4
 	},
-/obj/machinery/status_display{
+/obj/machinery/status_display/evac{
 	pixel_x = -32
 	},
 /obj/machinery/light{
@@ -159,7 +159,7 @@
 /obj/machinery/computer/crew{
 	dir = 8
 	},
-/obj/machinery/ai_status_display{
+/obj/machinery/status_display/ai{
 	pixel_x = 32
 	},
 /turf/open/floor/plasteel/vault{
@@ -174,7 +174,7 @@
 /turf/open/floor/mineral/plastitanium/red/brig,
 /area/shuttle/escape)
 "aw" = (
-/obj/machinery/ai_status_display,
+/obj/machinery/status_display/ai,
 /turf/closed/wall/mineral/titanium/nodiagonal,
 /area/shuttle/escape)
 "ax" = (
@@ -243,7 +243,7 @@
 /obj/structure/chair/comfy/shuttle{
 	dir = 4
 	},
-/obj/machinery/status_display{
+/obj/machinery/status_display/evac{
 	pixel_x = -32
 	},
 /obj/effect/turf_decal/bot,
@@ -445,7 +445,7 @@
 /turf/open/floor/plasteel,
 /area/shuttle/escape)
 "aU" = (
-/obj/machinery/status_display,
+/obj/machinery/status_display/evac,
 /turf/closed/wall/mineral/titanium/nodiagonal,
 /area/shuttle/escape)
 "aV" = (
@@ -528,7 +528,7 @@
 /area/shuttle/escape)
 "bd" = (
 /obj/machinery/recharge_station,
-/obj/machinery/status_display{
+/obj/machinery/status_display/evac{
 	pixel_x = -32
 	},
 /obj/effect/decal/cleanable/dirt,
@@ -587,7 +587,7 @@
 	pixel_y = 3
 	},
 /obj/structure/table/reinforced,
-/obj/machinery/status_display{
+/obj/machinery/status_display/evac{
 	pixel_x = 32
 	},
 /obj/machinery/light{

--- a/_maps/shuttles/emergency_raven.dmm
+++ b/_maps/shuttles/emergency_raven.dmm
@@ -6,7 +6,7 @@
 /turf/closed/wall/mineral/plastitanium/interior,
 /area/shuttle/escape)
 "ab" = (
-/obj/machinery/status_display,
+/obj/machinery/status_display/evac,
 /turf/closed/wall/mineral/plastitanium/interior,
 /area/shuttle/escape)
 "ac" = (
@@ -504,7 +504,7 @@
 /turf/open/floor/mineral/plastitanium/red,
 /area/shuttle/escape)
 "bo" = (
-/obj/machinery/status_display,
+/obj/machinery/status_display/evac,
 /turf/closed/wall/mineral/plastitanium,
 /area/shuttle/escape)
 "bp" = (
@@ -994,7 +994,7 @@
 	},
 /area/shuttle/escape)
 "eO" = (
-/obj/machinery/status_display,
+/obj/machinery/status_display/evac,
 /turf/closed/wall/mineral/plastitanium/nodiagonal,
 /area/shuttle/escape)
 "eP" = (

--- a/_maps/shuttles/emergency_russiafightpit.dmm
+++ b/_maps/shuttles/emergency_russiafightpit.dmm
@@ -113,7 +113,7 @@
 /turf/open/floor/mineral/titanium/blue,
 /area/shuttle/escape)
 "as" = (
-/obj/machinery/status_display,
+/obj/machinery/status_display/evac,
 /turf/closed/wall/rust,
 /area/shuttle/escape)
 "at" = (
@@ -443,7 +443,7 @@
 /turf/open/floor/mineral/plastitanium,
 /area/shuttle/escape)
 "bv" = (
-/obj/machinery/status_display,
+/obj/machinery/status_display/evac,
 /turf/closed/wall,
 /area/shuttle/escape)
 "bw" = (

--- a/_maps/shuttles/emergency_scrapheap.dmm
+++ b/_maps/shuttles/emergency_scrapheap.dmm
@@ -318,7 +318,7 @@
 /turf/open/floor/plasteel/bar,
 /area/shuttle/escape)
 "bc" = (
-/obj/machinery/status_display,
+/obj/machinery/status_display/evac,
 /turf/closed/wall/mineral/titanium,
 /area/shuttle/escape)
 "bd" = (

--- a/_maps/shuttles/emergency_supermatter.dmm
+++ b/_maps/shuttles/emergency_supermatter.dmm
@@ -69,7 +69,7 @@
 /turf/open/floor/noslip,
 /area/shuttle/escape)
 "aq" = (
-/obj/machinery/status_display,
+/obj/machinery/status_display/evac,
 /turf/closed/wall/mineral/titanium,
 /area/shuttle/escape)
 "ar" = (

--- a/_maps/shuttles/emergency_wabbajack.dmm
+++ b/_maps/shuttles/emergency_wabbajack.dmm
@@ -175,7 +175,7 @@
 /turf/open/floor/mineral/titanium/white,
 /area/shuttle/escape)
 "aH" = (
-/obj/machinery/status_display,
+/obj/machinery/status_display/evac,
 /turf/closed/wall/mineral/titanium,
 /area/shuttle/escape)
 "aI" = (

--- a/_maps/shuttles/escape_pod_default.dmm
+++ b/_maps/shuttles/escape_pod_default.dmm
@@ -6,7 +6,7 @@
 /obj/structure/chair/comfy/shuttle{
 	dir = 1
 	},
-/obj/machinery/status_display{
+/obj/machinery/status_display/evac{
 	pixel_x = 32
 	},
 /obj/machinery/computer/shuttle/pod{

--- a/_maps/shuttles/escape_pod_large.dmm
+++ b/_maps/shuttles/escape_pod_large.dmm
@@ -45,7 +45,7 @@
 /obj/structure/chair/comfy/shuttle{
 	dir = 4
 	},
-/obj/machinery/status_display{
+/obj/machinery/status_display/evac{
 	pixel_x = -32
 	},
 /turf/open/floor/mineral/titanium/blue,
@@ -60,7 +60,7 @@
 /obj/structure/chair/comfy/shuttle{
 	dir = 8
 	},
-/obj/machinery/status_display{
+/obj/machinery/status_display/evac{
 	pixel_x = 32
 	},
 /turf/open/floor/mineral/titanium/blue,

--- a/_maps/shuttles/infiltrator_basic.dmm
+++ b/_maps/shuttles/infiltrator_basic.dmm
@@ -62,7 +62,7 @@
 /area/shuttle/syndicate/bridge)
 "an" = (
 /obj/structure/table/reinforced,
-/obj/machinery/status_display{
+/obj/machinery/status_display/evac{
 	pixel_x = -32
 	},
 /obj/item/clipboard,
@@ -108,7 +108,7 @@
 /area/shuttle/syndicate/bridge)
 "as" = (
 /obj/structure/table/reinforced,
-/obj/machinery/ai_status_display{
+/obj/machinery/status_display/ai{
 	pixel_x = 32
 	},
 /obj/item/storage/fancy/donut_box,
@@ -123,7 +123,7 @@
 /turf/open/floor/plasteel/vault/side,
 /area/shuttle/syndicate/bridge)
 "au" = (
-/obj/machinery/status_display,
+/obj/machinery/status_display/evac,
 /turf/closed/wall/mineral/plastitanium,
 /area/shuttle/syndicate/bridge)
 "av" = (
@@ -431,7 +431,7 @@
 /turf/closed/wall/mineral/plastitanium,
 /area/shuttle/syndicate/medical)
 "bl" = (
-/obj/machinery/ai_status_display,
+/obj/machinery/status_display/ai,
 /turf/closed/wall/mineral/plastitanium,
 /area/shuttle/syndicate/medical)
 "bm" = (
@@ -444,7 +444,7 @@
 /turf/closed/wall/mineral/plastitanium,
 /area/shuttle/syndicate/armory)
 "bp" = (
-/obj/machinery/status_display,
+/obj/machinery/status_display/evac,
 /turf/closed/wall/mineral/plastitanium,
 /area/shuttle/syndicate/armory)
 "bq" = (

--- a/code/game/machinery/status_display.dm
+++ b/code/game/machinery/status_display.dm
@@ -1,165 +1,58 @@
+// Status display
+// (formerly Countdown timer display)
+
 #define CHARS_PER_LINE 5
 #define FONT_SIZE "5pt"
 #define FONT_COLOR "#09f"
 #define FONT_STYLE "Arial Black"
 #define SCROLL_SPEED 2
 
-// Status display
-// (formerly Countdown timer display)
+#define SD_BLANK 0  // 0 = Blank
+#define SD_EMERGENCY 1  // 1 = Emergency Shuttle timer
+#define SD_MESSAGE 2  // 2 = Arbitrary message(s)
+#define SD_PICTURE 3  // 3 = alert picture
 
-// Use to show shuttle ETA/ETD times
-// Alert status
-// And arbitrary messages set by comms computer
+#define SD_AI_EMOTE 1  // 1 = AI emoticon
+#define SD_AI_BSOD 2  // 2 = Blue screen of death
 
+/// Status display which can show images and scrolling text.
 /obj/machinery/status_display
+	name = "status display"
+	desc = null
 	icon = 'icons/obj/status_display.dmi'
 	icon_state = "frame"
-	name = "status display"
 	density = FALSE
 	use_power = IDLE_POWER_USE
 	idle_power_usage = 10
-	var/mode = 1	// 0 = Blank
-					// 1 = Emergency Shuttle timer
-					// 2 = Arbitrary message(s)
-					// 3 = alert picture
-					// 4 = Supply shuttle timer
-					// 5 = Generic shuttle timer
 
-	var/picture_state	// icon_state of alert picture
+	maptext_height = 26
+	maptext_width = 32
+
 	var/message1 = ""	// message line 1
 	var/message2 = ""	// message line 2
 	var/index1			// display index for scrolling messages or 0 if non-scrolling
 	var/index2
 
-	var/frequency = FREQ_STATUS_DISPLAYS
-	var/supply_display = 0		// true if a supply shuttle display
-	var/shuttle_id				// Id used for "generic shuttle timer" mode
+/// Immediately blank the display.
+/obj/machinery/status_display/proc/remove_display()
+	cut_overlays()
+	if(maptext)
+		maptext = ""
 
-	var/friendc = 0      // track if Friend Computer mode
+/// Immediately change the display to the given picture.
+/obj/machinery/status_display/proc/set_picture(state)
+	remove_display()
+	add_overlay(state)
 
-	maptext_height = 26
-	maptext_width = 32
+/// Immediately change the display to the given two lines.
+/obj/machinery/status_display/proc/update_display(line1, line2)
+	var/new_text = {"<div style="font-size:[FONT_SIZE];color:[FONT_COLOR];font:'[FONT_STYLE]';text-align:center;" valign="top">[line1]<br>[line2]</div>"}
+	if(maptext != new_text)
+		maptext = new_text
 
-	// new display
-	// register for radio system
-
-/obj/machinery/status_display/Initialize()
-	. = ..()
-	GLOB.ai_status_displays.Add(src)
-	SSradio.add_object(src, frequency)
-
-/obj/machinery/status_display/Destroy()
-	SSradio.remove_object(src,frequency)
-	GLOB.ai_status_displays.Remove(src)
-	return ..()
-
-// timed process
-
-/obj/machinery/status_display/process()
-	if(stat & NOPOWER)
-		remove_display()
-		return PROCESS_KILL
-	return update()
-
-/obj/machinery/status_display/emp_act(severity)
-	. = ..()
-	if(stat & (NOPOWER|BROKEN) || . & EMP_PROTECT_SELF)
-		return
-	set_picture("ai_bsod")
-
-// set what is displayed
-
-/obj/machinery/status_display/proc/update()
-	if(friendc && mode!=4) //Makes all status displays except supply shuttle timer display the eye -- Urist
-		set_picture("ai_friend")
-		return PROCESS_KILL
-	if (supply_display)
-		mode = 4
-	switch(mode)
-		if(0)				//blank
-			remove_display()
-			return PROCESS_KILL
-		if(1)				//emergency shuttle timer
-			. = display_shuttle_status()
-		if(2)				//custom messages
-			var/line1
-			var/line2
-			if(!index1)
-				line1 = message1
-			else
-				line1 = copytext(message1+"|"+message1, index1, index1+CHARS_PER_LINE)
-				var/message1_len = length(message1)
-				index1 += SCROLL_SPEED
-				if(index1 > message1_len)
-					index1 -= message1_len
-
-			if(!index2)
-				line2 = message2
-			else
-				line2 = copytext(message2+"|"+message2, index2, index2+CHARS_PER_LINE)
-				var/message2_len = length(message2)
-				index2 += SCROLL_SPEED
-				if(index2 > message2_len)
-					index2 -= message2_len
-			update_display(line1, line2)
-			if (!index1 && !index2)
-				return PROCESS_KILL
-		if(3)
-			return PROCESS_KILL
-		if(4)				// supply shuttle timer
-			var/line1
-			var/line2
-			if(SSshuttle.supply.mode == SHUTTLE_IDLE)
-				if(is_station_level(SSshuttle.supply.z))
-					line1 = "CARGO"
-					line2 = "Docked"
-			else
-				line1 = "CARGO"
-				line2 = SSshuttle.supply.getTimerStr()
-				if(lentext(line2) > CHARS_PER_LINE)
-					line2 = "Error"
-			update_display(line1, line2)
-		if(5)
-			. = display_shuttle_status()
-	if (. != PROCESS_KILL)
-		START_PROCESSING(SSmachines, src)
-
-/obj/machinery/status_display/examine(mob/user)
-	. = ..()
-	switch(mode)
-		if(1,5)  // Emergency or generic shuttle
-			var/obj/docking_port/mobile/shuttle
-			if(mode == 1)
-				shuttle = SSshuttle.emergency
-			else
-				shuttle = SSshuttle.getShuttle(shuttle_id)
-
-			if (!shuttle)
-				to_chat(user, "The display says:<br>\t<xmp>Shuttle?</xmp>")
-			else if (shuttle.timer)
-				to_chat(user, "The display says:<br>\t<xmp>[shuttle.getModeStr()]: [shuttle.getTimerStr()]</xmp>")
-			if (mode == 1 && shuttle)
-				to_chat(user, "Current shuttle: [shuttle.name].")
-		if(4)  // Supply shuttle
-			var/obj/docking_port/mobile/shuttle = SSshuttle.supply
-			var/shuttleMsg = null
-			if (shuttle.mode == SHUTTLE_IDLE)
-				if (is_station_level(shuttle.z))
-					shuttleMsg = "Docked"
-			else
-				shuttleMsg = "[shuttle.getModeStr()]: [shuttle.getTimerStr()]"
-			if (shuttleMsg)
-				to_chat(user, "The display says:<br>\t<xmp>[shuttleMsg]</xmp>")
-		if(2)  // Custom message
-			if (message1 || message2)
-				var/msg = "The display says:"
-				if (message1)
-					msg += "<br>\t<xmp>[message1]</xmp>"
-				if (message2)
-					msg += "<br>\t<xmp>[message2]</xmp>"
-				to_chat(user, msg)
-
-
+/// Prepare the display to marquee the given two lines.
+///
+/// Call with no arguments to disable.
 /obj/machinery/status_display/proc/set_message(m1, m2)
 	if(m1)
 		index1 = (length(m1) > CHARS_PER_LINE)
@@ -175,105 +68,260 @@
 		message2 = ""
 		index2 = 0
 
-/obj/machinery/status_display/proc/set_picture(state)
-	picture_state = state
-	remove_display()
-	add_overlay(picture_state)
-
-/obj/machinery/status_display/proc/update_display(line1, line2)
-	var/new_text = {"<div style="font-size:[FONT_SIZE];color:[FONT_COLOR];font:'[FONT_STYLE]';text-align:center;" valign="top">[line1]<br>[line2]</div>"}
-	if(maptext != new_text)
-		maptext = new_text
-
-/obj/machinery/status_display/proc/remove_display()
-	cut_overlays()
-	if(maptext)
-		maptext = ""
-
-/obj/machinery/status_display/proc/display_shuttle_status()
-	var/obj/docking_port/mobile/shuttle
-
-	if(mode == 1)
-		shuttle = SSshuttle.emergency
-	else
-		shuttle = SSshuttle.getShuttle(shuttle_id)
-
-	if(!shuttle)
-		update_display("shutl?","")
-	else if(shuttle.timer)
-		var/line1 = "-[shuttle.getModeStr()]-"
-		var/line2 = shuttle.getTimerStr()
-
-		if(length(line2) > CHARS_PER_LINE)
-			line2 = "Error!"
-		update_display(line1, line2)
-	else
+// Timed process - performs default marquee action if so needed.
+/obj/machinery/status_display/process()
+	if(stat & NOPOWER)
+		// No power, no processing.
 		remove_display()
 		return PROCESS_KILL
 
+	var/line1 = message1
+	if(index1)
+		line1 = copytext("[message1]|[message1]", index1, index1+CHARS_PER_LINE)
+		var/message1_len = length(message1)
+		index1 += SCROLL_SPEED
+		if(index1 > message1_len)
+			index1 -= message1_len
 
-/obj/machinery/status_display/receive_signal(datum/signal/signal)
-	if(supply_display)
-		mode = 4
-		return
-	switch(signal.data["command"])
-		if("blank")
-			mode = 0
-		if("shuttle")
-			mode = 1
-		if("message")
-			mode = 2
-			set_message(signal.data["msg1"], signal.data["msg2"])
-		if("alert")
-			mode = 3
-			set_picture(signal.data["picture_state"])
-		if("friendcomputer")
-			friendc = !friendc
+	var/line2 = message2
+	if(index2)
+		line2 = copytext("[message2]|[message2]", index2, index2+CHARS_PER_LINE)
+		var/message2_len = length(message2)
+		index2 += SCROLL_SPEED
+		if(index2 > message2_len)
+			index2 -= message2_len
+
+	update_display(line1, line2)
+	if (!index1 && !index2)
+		// No marquee, no processing.
+		return PROCESS_KILL
+
+/// Update the display and, if necessary, re-enable processing.
+/obj/machinery/status_display/proc/update()
+	if (process() != PROCESS_KILL)
+		START_PROCESSING(SSmachines, src)
+
+/obj/machinery/status_display/power_change()
+	. = ..()
 	update()
 
-/obj/machinery/ai_status_display
-	icon = 'icons/obj/status_display.dmi'
-	desc = "A small screen which the AI can use to present itself."
-	icon_state = "frame"
-	name = "\improper AI display"
-	density = FALSE
-
-	var/mode = 0	// 0 = Blank
-					// 1 = AI emoticon
-					// 2 = Blue screen of death
-
-	var/picture_state	// icon_state of ai picture
-
-	var/emotion = "Neutral"
-
-/obj/machinery/ai_status_display/Initialize()
-	. = ..()
-	GLOB.ai_status_displays.Add(src)
-
-/obj/machinery/ai_status_display/Destroy()
-	GLOB.ai_status_displays.Remove(src)
-	. = ..()
-
-/obj/machinery/ai_status_display/attack_ai(mob/living/silicon/ai/user)
-	if(isAI(user))
-		user.ai_statuschange()
-
-/obj/machinery/ai_status_display/emp_act(severity)
+/obj/machinery/status_display/emp_act(severity)
 	. = ..()
 	if(stat & (NOPOWER|BROKEN) || . & EMP_PROTECT_SELF)
 		return
 	set_picture("ai_bsod")
 
-/obj/machinery/ai_status_display/power_change()
+/obj/machinery/status_display/examine(mob/user)
 	. = ..()
+	if (message1 || message2)
+		var/list/msg = list("The display says:")
+		if (message1)
+			msg += "<br>\t<tt>[html_encode(message1)]</tt>"
+		if (message2)
+			msg += "<br>\t<tt>[html_encode(message2)]</tt>"
+		to_chat(user, msg.Join())
+
+// Helper procs for child display types.
+/obj/machinery/status_display/proc/display_shuttle_status(obj/docking_port/mobile/shuttle)
+	if(!shuttle)
+		// the shuttle is missing - no processing
+		update_display("shutl?","")
+		return PROCESS_KILL
+	else if(shuttle.timer)
+		var/line1 = "-[shuttle.getModeStr()]-"
+		var/line2 = shuttle.getTimerStr()
+
+		if(length(line2) > CHARS_PER_LINE)
+			line2 = "error"
+		update_display(line1, line2)
+	else
+		// don't kill processing, the timer might turn back on
+		remove_display()
+
+/obj/machinery/status_display/proc/examine_shuttle(mob/user, obj/docking_port/mobile/shuttle)
+	if (shuttle)
+		var/modestr = shuttle.getModeStr()
+		if (modestr)
+			if (shuttle.timer)
+				modestr = "<br>\t<tt>[modestr]: [shuttle.getTimerStr()]</tt>"
+			else
+				modestr = "<br>\t<tt>[modestr]</tt>"
+		to_chat(user, "The display says:<br>\t<tt>[shuttle.name]</tt>[modestr]")
+	else
+		to_chat(user, "The display says:<br>\t<tt>Shuttle missing!</tt>")
+
+
+/// Evac display which shows shuttle timer or message set by Command.
+/obj/machinery/status_display/evac
+	var/frequency = FREQ_STATUS_DISPLAYS
+	var/mode = SD_EMERGENCY
+	var/friendc = FALSE      // track if Friend Computer mode
+	var/last_picture  // For when Friend Computer mode is undone
+
+/obj/machinery/status_display/evac/Initialize()
+	. = ..()
+	// register for radio system
+	SSradio.add_object(src, frequency)
+
+/obj/machinery/status_display/evac/Destroy()
+	SSradio.remove_object(src,frequency)
+	return ..()
+
+/obj/machinery/status_display/evac/process()
+	if(stat & NOPOWER)
+		// No power, no processing.
+		remove_display()
+		return PROCESS_KILL
+
+	if(friendc) //Makes all status displays except supply shuttle timer display the eye -- Urist
+		set_picture("ai_friend")
+		return PROCESS_KILL
+
+	switch(mode)
+		if(SD_BLANK)
+			remove_display()
+			return PROCESS_KILL
+
+		if(SD_EMERGENCY)
+			return display_shuttle_status(SSshuttle.emergency)
+
+		if(SD_MESSAGE)
+			return ..()
+
+		if(SD_PICTURE)
+			set_picture(last_picture)
+			return PROCESS_KILL
+
+/obj/machinery/status_display/evac/examine(mob/user)
+	. = ..()
+	if(mode == SD_EMERGENCY)
+		examine_shuttle(user, SSshuttle.emergency)
+	else if(!message1 && !message2)
+		to_chat(user, "The display is blank.")
+
+/obj/machinery/status_display/evac/receive_signal(datum/signal/signal)
+	switch(signal.data["command"])
+		if("blank")
+			mode = SD_BLANK
+			set_message(null, null)
+		if("shuttle")
+			mode = SD_EMERGENCY
+			set_message(null, null)
+		if("message")
+			mode = SD_MESSAGE
+			set_message(signal.data["msg1"], signal.data["msg2"])
+		if("alert")
+			mode = SD_PICTURE
+			last_picture = signal.data["picture_state"]
+			set_picture(last_picture)
+		if("friendcomputer")
+			friendc = !friendc
 	update()
 
-/obj/machinery/ai_status_display/proc/update()
-	if(mode==0 || stat & NOPOWER) //Blank
-		cut_overlays()
-		return
 
-	if(mode==1)	// AI emoticon
+/// Supply display which shows the status of the supply shuttle.
+/obj/machinery/status_display/supply
+	name = "supply display"
+
+/obj/machinery/status_display/supply/process()
+	if(stat & NOPOWER)
+		// No power, no processing.
+		remove_display()
+		return PROCESS_KILL
+
+	var/line1
+	var/line2
+	if(!SSshuttle.supply)
+		// Might be missing in our first update on initialize before shuttles
+		// have loaded. Cross our fingers that it will soon return.
+		line1 = "CARGO"
+		line2 = "shutl?"
+	else if(SSshuttle.supply.mode == SHUTTLE_IDLE)
+		if(is_station_level(SSshuttle.supply.z))
+			line1 = "CARGO"
+			line2 = "Docked"
+	else
+		line1 = "CARGO"
+		line2 = SSshuttle.supply.getTimerStr()
+		if(lentext(line2) > CHARS_PER_LINE)
+			line2 = "Error"
+	update_display(line1, line2)
+
+/obj/machinery/status_display/supply/examine(mob/user)
+	. = ..()
+	var/obj/docking_port/mobile/shuttle = SSshuttle.supply
+	var/shuttleMsg = null
+	if (shuttle.mode == SHUTTLE_IDLE)
+		if (is_station_level(shuttle.z))
+			shuttleMsg = "Docked"
+	else
+		shuttleMsg = "[shuttle.getModeStr()]: [shuttle.getTimerStr()]"
+	if (shuttleMsg)
+		to_chat(user, "The display says:<br>\t<tt>[shuttleMsg]</tt>")
+	else
+		to_chat(user, "The display is blank.")
+
+
+/// General-purpose shuttle status display.
+/obj/machinery/status_display/shuttle
+	name = "shuttle display"
+	var/shuttle_id
+
+/obj/machinery/status_display/shuttle/process()
+	if(!shuttle_id || (stat & NOPOWER))
+		// No power, no processing.
+		remove_display()
+		return PROCESS_KILL
+
+	return display_shuttle_status(SSshuttle.getShuttle(shuttle_id))
+
+/obj/machinery/status_display/shuttle/examine(mob/user)
+	. = ..()
+	if(shuttle_id)
+		examine_shuttle(user, SSshuttle.getShuttle(shuttle_id))
+	else
+		to_chat(user, "The display is blank.")
+
+/obj/machinery/status_display/shuttle/vv_edit_var(var_name, var_value)
+	. = ..()
+	if(!.)
+		return
+	switch(var_name)
+		if("shuttle_id")
+			update()
+
+/obj/machinery/status_display/shuttle/proc/connect_to_shuttle(obj/docking_port/mobile/port, obj/docking_port/stationary/dock, idnum, override)
+	if (port && (shuttle_id == initial(shuttle_id) || override))
+		shuttle_id = port.id
+	update()
+
+
+/// Pictograph display which the AI can use to emote.
+/obj/machinery/status_display/ai
+	name = "\improper AI display"
+	desc = "A small screen which the AI can use to present itself."
+
+	var/mode = SD_BLANK
+	var/emotion = "Neutral"
+
+/obj/machinery/status_display/ai/Initialize()
+	. = ..()
+	GLOB.ai_status_displays.Add(src)
+
+/obj/machinery/status_display/ai/Destroy()
+	GLOB.ai_status_displays.Remove(src)
+	. = ..()
+
+/obj/machinery/status_display/ai/attack_ai(mob/living/silicon/ai/user)
+	if(isAI(user))
+		user.ai_statuschange()
+
+/obj/machinery/status_display/ai/process()
+	if(mode == SD_BLANK || (stat & NOPOWER))
+		remove_display()
+		return PROCESS_KILL
+
+	if(mode == SD_AI_EMOTE)
 		switch(emotion)
 			if("Very Happy")
 				set_picture("ai_veryhappy")
@@ -305,18 +353,12 @@
 				set_picture("ai_sal")
 			if("Red Glow")
 				set_picture("ai_hal")
+		return PROCESS_KILL
 
-		return
-
-	if(mode==2)	// BSOD
+	if(mode == SD_AI_BSOD)
 		set_picture("ai_bsod")
-		return
+		return PROCESS_KILL
 
-
-/obj/machinery/ai_status_display/proc/set_picture(state)
-	picture_state = state
-	cut_overlays()
-	add_overlay(picture_state)
 
 #undef CHARS_PER_LINE
 #undef FONT_SIZE

--- a/code/game/objects/objs.dm
+++ b/code/game/objects/objs.dm
@@ -41,7 +41,7 @@
 			var/obj/O = vval
 			if(istype(O) && (O.obj_flags & DANGEROUS_POSSESSION))
 				return FALSE
-	..()
+	return ..()
 
 /obj/Initialize()
 	. = ..()

--- a/code/modules/mob/living/silicon/ai/ai.dm
+++ b/code/modules/mob/living/silicon/ai/ai.dm
@@ -631,7 +631,7 @@
 		return
 	var/list/ai_emotions = list("Very Happy", "Happy", "Neutral", "Unsure", "Confused", "Sad", "BSOD", "Blank", "Problems?", "Awesome", "Facepalm", "Friend Computer", "Dorfy", "Blue Glow", "Red Glow")
 	var/emote = input("Please, select a status!", "AI Status", null, null) in ai_emotions
-	for (var/obj/machinery/ai_status_display/M in GLOB.ai_status_displays) //change status of displays
+	for (var/obj/machinery/status_display/ai/M in GLOB.ai_status_displays) //change status of displays
 		M.emotion = emote
 		M.update()
 	if (emote == "Friend Computer")

--- a/code/modules/mob/living/silicon/ai/ai.dm
+++ b/code/modules/mob/living/silicon/ai/ai.dm
@@ -631,7 +631,8 @@
 		return
 	var/list/ai_emotions = list("Very Happy", "Happy", "Neutral", "Unsure", "Confused", "Sad", "BSOD", "Blank", "Problems?", "Awesome", "Facepalm", "Friend Computer", "Dorfy", "Blue Glow", "Red Glow")
 	var/emote = input("Please, select a status!", "AI Status", null, null) in ai_emotions
-	for (var/obj/machinery/status_display/ai/M in GLOB.ai_status_displays) //change status of displays
+	for (var/each in GLOB.ai_status_displays) //change status of displays
+		var/obj/machinery/status_display/ai/M = each
 		M.emotion = emote
 		M.update()
 	if (emote == "Friend Computer")

--- a/code/modules/mob/living/silicon/ai/death.dm
+++ b/code/modules/mob/living/silicon/ai/death.dm
@@ -26,7 +26,8 @@
 			explosion(src.loc, 3, 6, 12, 15)
 
 	if(src.key)
-		for(var/obj/machinery/status_display/ai/O in GLOB.ai_status_displays) //change status
+		for(var/each in GLOB.ai_status_displays) //change status
+			var/obj/machinery/status_display/ai/O = each
 			O.mode = 2
 			O.update()
 

--- a/code/modules/mob/living/silicon/ai/death.dm
+++ b/code/modules/mob/living/silicon/ai/death.dm
@@ -25,8 +25,8 @@
 		spawn(10)
 			explosion(src.loc, 3, 6, 12, 15)
 
-	for(var/obj/machinery/ai_status_display/O in GLOB.ai_status_displays) //change status
-		if(src.key)
+	if(src.key)
+		for(var/obj/machinery/status_display/ai/O in GLOB.ai_status_displays) //change status
 			O.mode = 2
 			O.update()
 

--- a/code/modules/mob/living/silicon/ai/login.dm
+++ b/code/modules/mob/living/silicon/ai/login.dm
@@ -1,7 +1,8 @@
 /mob/living/silicon/ai/Login()
 	..()
 	if(stat != DEAD)
-		for(var/obj/machinery/status_display/ai/O in GLOB.ai_status_displays) //change status
+		for(var/each in GLOB.ai_status_displays) //change status
+			var/obj/machinery/status_display/ai/O = each
 			O.mode = 1
 			O.emotion = "Neutral"
 			O.update()

--- a/code/modules/mob/living/silicon/ai/login.dm
+++ b/code/modules/mob/living/silicon/ai/login.dm
@@ -1,9 +1,10 @@
 /mob/living/silicon/ai/Login()
 	..()
 	if(stat != DEAD)
-		for(var/obj/machinery/ai_status_display/O in GLOB.ai_status_displays) //change status
+		for(var/obj/machinery/status_display/ai/O in GLOB.ai_status_displays) //change status
 			O.mode = 1
 			O.emotion = "Neutral"
+			O.update()
 	if(multicam_on)
 		end_multicam()
 	view_core()

--- a/code/modules/mob/living/silicon/ai/logout.dm
+++ b/code/modules/mob/living/silicon/ai/logout.dm
@@ -1,6 +1,7 @@
 /mob/living/silicon/ai/Logout()
 	..()
-	for(var/obj/machinery/status_display/ai/O in GLOB.ai_status_displays) //change status
+	for(var/each in GLOB.ai_status_displays) //change status
+		var/obj/machinery/status_display/ai/O = each
 		O.mode = 0
 		O.update()
 	view_core()

--- a/code/modules/mob/living/silicon/ai/logout.dm
+++ b/code/modules/mob/living/silicon/ai/logout.dm
@@ -1,5 +1,6 @@
 /mob/living/silicon/ai/Logout()
 	..()
-	for(var/obj/machinery/ai_status_display/O in GLOB.ai_status_displays) //change status
+	for(var/obj/machinery/status_display/ai/O in GLOB.ai_status_displays) //change status
 		O.mode = 0
+		O.update()
 	view_core()

--- a/code/modules/shuttle/shuttle.dm
+++ b/code/modules/shuttle/shuttle.dm
@@ -311,6 +311,8 @@
 			comp.connect_to_shuttle(src, dock, idnum)
 		for(var/obj/machinery/computer/camera_advanced/shuttle_docker/comp in place)
 			comp.connect_to_shuttle(src, dock, idnum)
+		for(var/obj/machinery/status_display/shuttle/sd in place)
+			sd.connect_to_shuttle(src, dock, idnum)
 
 
 //this is a hook for custom behaviour. Maybe at some point we could add checks to see if engines are intact
@@ -640,7 +642,9 @@
 		return "--:--"
 
 	var/timeleft = timeLeft()
-	if(timeleft > 0)
+	if(timeleft > 1 HOURS)
+		return "--:--"
+	else if(timeleft > 0)
 		return "[add_zero(num2text((timeleft / 60) % 60),2)]:[add_zero(num2text(timeleft % 60), 2)]"
 	else
 		return "00:00"


### PR DESCRIPTION
:cl:
refactor: Status displays have been refactored to be cleaner and more flexible.
fix: The AI dying properly updates its status displays again.
/:cl:

Having `status_display` which bundles normal status display + `if`-based supply shuttle display + arbitrary shuttle display that doesn't actually work alongside `ai_status_display` which is 50% copy-paste from `status_display` is a mess.

Instead, let's have `status_display` hold the common functionality (displaying icons and marquee), and use subtypes:
* `status_display/evac` for the general-purpose station display (emergency shuttle status, comms console messages and icons)
* `status_display/supply` for the supply shuttle display (sports "CARGO" in big letters)
* `status_display/shuttle` for arbitrary shuttle display (acts similar to evac but does not react to comms console)
* `status_display/ai` which the AI may freely manipulate and which BSODs if it dies.

The AI death display seemed to have been broken by #39132. This PR fixes it but is careful not to undo the performance gains of that PR.

Script (#39907) used to update maps:
```
/obj/machinery/status_display{supply_display = 1} : /obj/machinery/status_display/supply{@OLD; supply_display = @SKIP; name = @SKIP}
/obj/machinery/status_display : /obj/machinery/status_display/evac{@OLD}
/obj/machinery/ai_status_display : /obj/machinery/status_display/ai{@OLD}
```
