### PR TITLE
bumps beam rifle tracers above lighting plane

### DIFF
--- a/code/game/objects/effects/temporary_visuals/projectiles/tracer.dm
+++ b/code/game/objects/effects/temporary_visuals/projectiles/tracer.dm
@@ -61,6 +61,8 @@
 
 /obj/effect/projectile/tracer/tracer/aiming
 	icon_state = "pixelbeam_greyscale"
+	layer = ABOVE_LIGHTING_LAYER
+	plane = ABOVE_LIGHTING_PLANE
 
 /obj/effect/projectile/tracer/wormhole
 	icon_state = "wormhole_g"


### PR DESCRIPTION
these things already don't have projectile lighting so this makes them visible in the dark.