### PR TITLE
[On hold]Adds research-boosting and credit-giving nanite programs

### DIFF
--- a/code/controllers/subsystem/processing/nanites.dm
+++ b/code/controllers/subsystem/processing/nanites.dm
@@ -6,6 +6,7 @@ PROCESSING_SUBSYSTEM_DEF(nanites)
 	var/list/datum/nanite_cloud_backup/cloud_backups = list()
 	var/list/mob/living/nanite_monitored_mobs = list()
 	var/list/datum/nanite_program/relay/nanite_relays = list()
+	var/neural_network_count = 0
 
 /datum/controller/subsystem/processing/nanites/proc/check_hardware(datum/nanite_cloud_backup/backup)
 	if(QDELETED(backup.storage) || (backup.storage.stat & (NOPOWER|BROKEN)))

--- a/code/modules/research/designs/nanite_designs.dm
+++ b/code/modules/research/designs/nanite_designs.dm
@@ -38,6 +38,13 @@
 	id = "researchplus_nanites"
 	program_type = /datum/nanite_program/triggered/researchplus
 	category = list("Utility Nanites")
+	
+/datum/design/nanites/bitcoin
+	name = "Cryptocurrency Processing"
+	desc = "The nanites automatically mine cryptocurrency, automatically transferring the resulting credits to the station's account."
+	id = "cash_nanites"
+	program_type = /datum/nanite_program/bitcoin
+	category = list("Utility Nanites")
 
 /datum/design/nanites/monitoring
 	name = "Monitoring"

--- a/code/modules/research/designs/nanite_designs.dm
+++ b/code/modules/research/designs/nanite_designs.dm
@@ -25,6 +25,13 @@
 	program_type = /datum/nanite_program/viral
 	category = list("Utility Nanites")
 
+/datum/design/nanites/research
+	name = "Parallel Computing"
+	desc = "The nanites aid the research servers by performing a portion of its calculations, increasing research point generation."
+	id = "research_nanites"
+	program_type = /datum/nanite_program/research
+	category = list("Utility Nanites")
+
 /datum/design/nanites/monitoring
 	name = "Monitoring"
 	desc = "The nanites monitor the host's vitals and location, sending them to the suit sensor network."

--- a/code/modules/research/designs/nanite_designs.dm
+++ b/code/modules/research/designs/nanite_designs.dm
@@ -26,10 +26,17 @@
 	category = list("Utility Nanites")
 
 /datum/design/nanites/research
-	name = "Parallel Computing"
+	name = "Distributed Computing"
 	desc = "The nanites aid the research servers by performing a portion of its calculations, increasing research point generation."
 	id = "research_nanites"
 	program_type = /datum/nanite_program/research
+	category = list("Utility Nanites")
+	
+/datum/design/nanites/researchplus
+	name = "Neural Network"
+	desc = "The nanites link the host's brains together forming a neural research network, that becomes more efficient with the amount of total hosts. Can be overloaded to increase research output."
+	id = "researchplus_nanites"
+	program_type = /datum/nanite_program/triggered/researchplus
 	category = list("Utility Nanites")
 
 /datum/design/nanites/monitoring

--- a/code/modules/research/nanites/nanite_programs/utility.dm
+++ b/code/modules/research/nanites/nanite_programs/utility.dm
@@ -250,9 +250,10 @@
 	if(!iscarbon(host_mob))
 		return
 	var/mob/living/carbon/C = host_mob
-	var/points = round(SSnanites.neural_network_count / 15, 1)
+	var/points = round(SSnanites.neural_network_count / 15, 0.1)
 	if(overclock)
-		C.adjustBrainLoss(1, TRUE)
+		if(prob(50))
+			C.adjustBrainLoss(1, TRUE)
 		points *= 2.5
 	if(!C.client) //less brainpower
 		points *= 0.25
@@ -264,8 +265,10 @@
 	overclock = !overclock
 	if(overclock)
 		use_rate = 1.25
+		to_chat(host_mob, "<span class='warning'>You feel like your brain is starting to overheat...</span>")
 	else
 		use_rate = initial(use_rate)
+		to_chat(host_mob, "<span class='warning'>The feeling of overheating in your brain rapidly fades away.</span>")
 
 /datum/nanite_program/triggered/access
 	name = "Subdermal ID"

--- a/code/modules/research/nanites/nanite_programs/utility.dm
+++ b/code/modules/research/nanites/nanite_programs/utility.dm
@@ -199,13 +199,59 @@
 	host_mob.nutrition -= 0.5
 
 /datum/nanite_program/research
-	name = "Parallel Computing"
+	name = "Distributed Computing"
 	desc = "The nanites aid the research servers by performing a portion of its calculations, increasing research point generation."
 	use_rate = 0.2
 	rogue_types = list(/datum/nanite_program/toxic)
 
 /datum/nanite_program/research/active_effect()
-	SSresearch.science_tech.add_point_list(list(TECHWEB_POINT_TYPE_GENERIC = 1))
+	if(!iscarbon(host_mob))
+		return
+	var/points = 1
+	if(!host_mob.client) //less brainpower
+		points *= 0.25
+	SSresearch.science_tech.add_point_list(list(TECHWEB_POINT_TYPE_GENERIC = points))
+	
+/datum/nanite_program/triggered/researchplus
+	name = "Neural Network"
+	desc = "The nanites link the host's brains together forming a neural research network, that becomes more efficient with the amount of total hosts. \
+			Can be overclocked (by triggering) to increase research output at the cost of increased nanite consumption and rapid brain decay from the host."
+	use_rate = 0.4
+	rogue_types = list(/datum/nanite_program/brain_decay)
+	var/overclock = FALSE
+
+/datum/nanite_program/triggered/researchplus/enable_passive_effect()
+	. = ..()
+	if(!iscarbon(host_mob))
+		return
+	SSnanites.neural_network_count++
+
+/datum/nanite_program/triggered/researchplus/disable_passive_effect()
+	. = ..()
+	if(!iscarbon(host_mob))
+		return
+	SSnanites.neural_network_count--
+	
+/datum/nanite_program/triggered/researchplus/active_effect()
+	if(!iscarbon(host_mob))
+		return
+	var/mob/living/carbon/C = host_mob
+	var/points = round(SSnanites.neural_network_count / 15, 1)
+	if(overclock)
+		C.adjustBrainLoss(1, TRUE)
+		points *= 2.5
+	if(!C.client) //less brainpower
+		points *= 0.25
+	SSresearch.science_tech.add_point_list(list(TECHWEB_POINT_TYPE_GENERIC = points))
+	
+/datum/nanite_program/triggered/researchplus/trigger()
+	if(!..())
+		return
+	overclock = !overclock
+	if(overclock)
+		use_rate = 1.25
+	else
+		use_rate = initial(use_rate)
 
 /datum/nanite_program/triggered/access
 	name = "Subdermal ID"

--- a/code/modules/research/nanites/nanite_programs/utility.dm
+++ b/code/modules/research/nanites/nanite_programs/utility.dm
@@ -198,6 +198,15 @@
 /datum/nanite_program/metabolic_synthesis/active_effect()
 	host_mob.nutrition -= 0.5
 
+/datum/nanite_program/research
+	name = "Parallel Computing"
+	desc = "The nanites aid the research servers by performing a portion of its calculations, increasing research point generation."
+	use_rate = 0.2
+	rogue_types = list(/datum/nanite_program/toxic)
+
+/datum/nanite_program/research/active_effect()
+	SSresearch.science_tech.add_point_list(list(TECHWEB_POINT_TYPE_GENERIC = 1))
+
 /datum/nanite_program/triggered/access
 	name = "Subdermal ID"
 	desc = "The nanites store the host's ID access rights in a subdermal magnetic strip. Updates when triggered, copying the host's current access."

--- a/code/modules/research/nanites/nanite_programs/utility.dm
+++ b/code/modules/research/nanites/nanite_programs/utility.dm
@@ -212,6 +212,20 @@
 		points *= 0.25
 	SSresearch.science_tech.add_point_list(list(TECHWEB_POINT_TYPE_GENERIC = points))
 	
+/datum/nanite_program/bitcoin
+	name = "Cryptocurrency Processing"
+	desc = "The nanites automatically mine cryptocurrency, automatically transferring the resulting credits to the station's account."
+	use_rate = 0.3
+	rogue_types = list(/datum/nanite_program/toxic)
+
+/datum/nanite_program/bitcoin/active_effect()
+	if(!iscarbon(host_mob))
+		return
+	var/points = 4 // 240/min
+	if(!host_mob.client)
+		points *= 0.25
+	SSshuttle.points += points
+	
 /datum/nanite_program/triggered/researchplus
 	name = "Neural Network"
 	desc = "The nanites link the host's brains together forming a neural research network, that becomes more efficient with the amount of total hosts. \

--- a/code/modules/research/techweb/all_nodes.dm
+++ b/code/modules/research/techweb/all_nodes.dm
@@ -879,7 +879,7 @@
 	display_name = "Harmonic Nanite Programming"
 	description = "Nanite programs that require seamless integration between nanites and biology."
 	prereq_ids = list("nanite_bio","nanite_smart","nanite_mesh")
-	design_ids = list("fakedeath_nanites","aggressive_nanites","defib_nanites","regenerative_plus_nanites","brainheal_plus_nanites","purging_plus_nanites","adrenaline_nanites")
+	design_ids = list("fakedeath_nanites","researchplus_nanites","aggressive_nanites","defib_nanites","regenerative_plus_nanites","brainheal_plus_nanites","purging_plus_nanites","adrenaline_nanites")
 	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = 4000)
 	export_price = 8000
 

--- a/code/modules/research/techweb/all_nodes.dm
+++ b/code/modules/research/techweb/all_nodes.dm
@@ -833,7 +833,7 @@
 	display_name = "Smart Nanite Programming"
 	description = "Nanite programs that require nanites to perform complex actions, act independently, roam or seek targets."
 	prereq_ids = list("nanite_base","adv_robotics")
-	design_ids = list("purging_nanites", "research_nanites", "metabolic_nanites", "stealth_nanites", "memleak_nanites","sensor_voice_nanites", "voice_nanites")
+	design_ids = list("purging_nanites", "research_nanites", "cash_nanites", "metabolic_nanites", "stealth_nanites", "memleak_nanites","sensor_voice_nanites", "voice_nanites")
 	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = 2000)
 	export_price = 4000
 

--- a/code/modules/research/techweb/all_nodes.dm
+++ b/code/modules/research/techweb/all_nodes.dm
@@ -833,7 +833,7 @@
 	display_name = "Smart Nanite Programming"
 	description = "Nanite programs that require nanites to perform complex actions, act independently, roam or seek targets."
 	prereq_ids = list("nanite_base","adv_robotics")
-	design_ids = list("purging_nanites", "metabolic_nanites", "stealth_nanites", "memleak_nanites","sensor_voice_nanites", "voice_nanites")
+	design_ids = list("purging_nanites", "research_nanites", "metabolic_nanites", "stealth_nanites", "memleak_nanites","sensor_voice_nanites", "voice_nanites")
 	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = 2000)
 	export_price = 4000
 


### PR DESCRIPTION
:cl: XDTM
add: Added the Distributed Computing nanite program, which slowly adds research points over time. 
add: Added the Neural Network nanite program, which adds research points over time as well, but scales in efficiency for each mob that is currently running the program. Can be triggered to overclock it, increasing the point output but dealing brain damage as well as increasing the nanite decay rate.
add: Added the Cryptocurrency Processor program, which adds credits to the station while running.
add: All of these programs only work on complex mobs (humans, monkeys, xenomorphs) and only have 25% efficiency on NPC mobs.
/:cl:

Goals:
- Give science an incentive to spread nanites as much as possible.
- Give non-science a small incentive to get nanites (more points = more chance of getting that research you need).
- Soften the blow when someone rushes nanites, since they can generate points earlier.
