### PR TITLE
Adds the forcefield projector to the engineering protolathe

### DIFF
--- a/code/game/objects/items/devices/forcefieldprojector.dm
+++ b/code/game/objects/items/devices/forcefieldprojector.dm
@@ -1,4 +1,4 @@
-/obj/item/forcefield
+/obj/item/forcefield_projector
 	name = "forcefield projector"
 	desc = "An experimental device that can create several forcefields at a distance."
 	icon = 'icons/obj/device.dmi'
@@ -16,7 +16,7 @@
 	var/list/current_fields
 	var/field_distance_limit = 7
 
-/obj/item/forcefield/afterattack(atom/target, mob/user, proximity_flag)
+/obj/item/forcefield_projector/afterattack(atom/target, mob/user, proximity_flag)
 	. = ..()
 	if(!check_allowed_items(target, 1))
 		return
@@ -41,27 +41,27 @@
 	current_fields += F
 	user.changeNext_move(CLICK_CD_MELEE)
 
-/obj/item/forcefield/attack_self(mob/user)
+/obj/item/forcefield_projector/attack_self(mob/user)
 	if(LAZYLEN(current_fields))
 		to_chat(user, "<span class='notice'>You deactivate [src], disabling all active forcefields.</span>")
 		for(var/obj/structure/projected_forcefield/F in current_fields)
 			qdel(F)
 
-/obj/item/forcefield/examine(mob/user)
+/obj/item/forcefield_projector/examine(mob/user)
 	..()
 	var/percent_charge = round((shield_integrity/max_shield_integrity)*100)
 	to_chat(user, "<span class='notice'>It is currently sustaining [LAZYLEN(current_fields)]/[max_fields] fields, and it's [percent_charge]% charged.</span>")
 
-/obj/item/forcefield/Initialize(mapload)
+/obj/item/forcefield_projector/Initialize(mapload)
 	..()
 	current_fields = list()
 	START_PROCESSING(SSobj, src)
 
-/obj/item/forcefield/Destroy()
+/obj/item/forcefield_projector/Destroy()
 	STOP_PROCESSING(SSobj, src)
 	return ..()
 
-/obj/item/forcefield/process()
+/obj/item/forcefield_projector/process()
 	if(!LAZYLEN(current_fields))
 		shield_integrity = min(shield_integrity + 4, max_shield_integrity)
 	else

--- a/code/game/objects/items/devices/forcefieldprojector.dm
+++ b/code/game/objects/items/devices/forcefieldprojector.dm
@@ -82,9 +82,9 @@
 	resistance_flags = INDESTRUCTIBLE
 	CanAtmosPass = ATMOS_PASS_DENSITY
 	armor = list("melee" = 0, "bullet" = 25, "laser" = 50, "energy" = 50, "bomb" = 25, "bio" = 100, "rad" = 100, "fire" = 100, "acid" = 100)
-	var/obj/item/forcefield/generator
+	var/obj/item/forcefield_projector/generator
 
-/obj/structure/projected_forcefield/Initialize(mapload, obj/item/forcefield/origin)
+/obj/structure/projected_forcefield/Initialize(mapload, obj/item/forcefield_projector/origin)
 	. = ..()
 	generator = origin
 

--- a/code/modules/research/designs/misc_designs.dm
+++ b/code/modules/research/designs/misc_designs.dm
@@ -157,6 +157,16 @@
 	category = list("Equipment")
 	departmental_flags = DEPARTMENTAL_FLAG_ENGINEERING
 
+/datum/design/forcefield_projector
+	name = "Forcefield Projector"
+	desc = "A device which can project temporary forcefields to seal off an area."
+	id = "forcefield_projector"
+	build_type = PROTOLATHE
+	materials = list(MAT_METAL = 2500, MAT_GLASS = 1000)
+	build_path = /obj/item/forcefield_projector
+	category = list("Equipment")
+	departmental_flags = DEPARTMENTAL_FLAG_ENGINEERING
+
 /datum/design/sci_goggles
 	name = "Science Goggles"
 	desc = "Goggles fitted with a portable analyzer capable of determining the research worth of an item or components of a machine."

--- a/code/modules/research/techweb/all_nodes.dm
+++ b/code/modules/research/techweb/all_nodes.dm
@@ -134,7 +134,7 @@
 	display_name = "Advanced Engineering"
 	description = "Pushing the boundaries of physics, one chainsaw-fist at a time."
 	prereq_ids = list("engineering", "emp_basic")
-	design_ids = list("engine_goggles", "magboots", "weldingmask")
+	design_ids = list("engine_goggles", "magboots", "forcefield_projector", "weldingmask")
 	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = 2500)
 	export_price = 5000
 


### PR DESCRIPTION
:cl: XDTM
add: The forcefield projector is now available ingame in the engineering protolathe. It can project up to 3 forcefields which act as transparent walls, and share a pool of health which is recharged over time. The projector must remain within 7 tiles of the forcefields to keep them active.
/:cl:

This was added a while ago for robustin's engineering gbp thing, and never got added. Might as well put it in the techweb bin.
