### PR TITLE
Fixes mech construction messages

### DIFF
--- a/code/game/mecha/mecha_construction_paths.dm
+++ b/code/game/mecha/mecha_construction_paths.dm
@@ -198,7 +198,7 @@
 				user.visible_message("[user] removes the wiring from [parent].", "<span class='notice'>You remove the wiring from [parent].</span>")
 		if(5)
 			if(diff==FORWARD)
-				user.visible_message("[user] installs the central control module into [parent].", "<span class='notice'>You install the central computer mainboard into [parent].</span>")
+				user.visible_message("[user] installs the [I.name] into [parent].", "<span class='notice'>You install the [I.name] into [parent].</span>")
 			else
 				user.visible_message("[user] disconnects the wiring of [parent].", "<span class='notice'>You disconnect the wiring of [parent].</span>")
 		if(6)
@@ -208,7 +208,7 @@
 				user.visible_message("[user] removes the central control module from [parent].", "<span class='notice'>You remove the central computer mainboard from [parent].</span>")
 		if(7)
 			if(diff==FORWARD)
-				user.visible_message("[user] installs the peripherals control module into [parent].", "<span class='notice'>You install the peripherals control module into [parent].</span>")
+				user.visible_message("[user] installs the [I.name] into [parent].", "<span class='notice'>You install the [I.name] into [parent].</span>")
 			else
 				user.visible_message("[user] unfastens the mainboard.", "<span class='notice'>You unfasten the mainboard.</span>")
 		if(8)
@@ -218,7 +218,7 @@
 				user.visible_message("[user] removes the peripherals control module from [parent].", "<span class='notice'>You remove the peripherals control module from [parent].</span>")
 		if(9)
 			if(diff==FORWARD)
-				user.visible_message("[user] installs the power cell into [parent].", "<span class='notice'>You install the power cell into [parent].</span>")
+				user.visible_message("[user] installs the [I.name] into [parent].", "<span class='notice'>You install the [I.name] into [parent].</span>")
 			else
 				user.visible_message("[user] unfastens the peripherals control module.", "<span class='notice'>You unfasten the peripherals control module.</span>")
 		if(10)
@@ -464,7 +464,7 @@
 				user.visible_message("[user] removes the wiring from [parent].", "<span class='notice'>You remove the wiring from [parent].</span>")
 		if(5)
 			if(diff==FORWARD)
-				user.visible_message("[user] installs the central control module into [parent].", "<span class='notice'>You install the central computer mainboard into [parent].</span>")
+				user.visible_message("[user] installs the [I.name] into [parent].", "<span class='notice'>You install the [I.name] into [parent].</span>")
 			else
 				user.visible_message("[user] disconnects the wiring of [parent].", "<span class='notice'>You disconnect the wiring of [parent].</span>")
 		if(6)
@@ -474,7 +474,7 @@
 				user.visible_message("[user] removes the central control module from [parent].", "<span class='notice'>You remove the central computer mainboard from [parent].</span>")
 		if(7)
 			if(diff==FORWARD)
-				user.visible_message("[user] installs the peripherals control module into [parent].", "<span class='notice'>You install the peripherals control module into [parent].</span>")
+				user.visible_message("[user] installs the [I.name] into [parent].", "<span class='notice'>You install the [I.name] into [parent].</span>")
 			else
 				user.visible_message("[user] unfastens the mainboard.", "<span class='notice'>You unfasten the mainboard.</span>")
 		if(8)
@@ -484,7 +484,7 @@
 				user.visible_message("[user] removes the peripherals control module from [parent].", "<span class='notice'>You remove the peripherals control module from [parent].</span>")
 		if(9)
 			if(diff==FORWARD)
-				user.visible_message("[user] installs the weapon control module into [parent].", "<span class='notice'>You install the weapon control module into [parent].</span>")
+				user.visible_message("[user] installs the [I.name] into [parent].", "<span class='notice'>You install the [I.name] into [parent].</span>")
 			else
 				user.visible_message("[user] unfastens the peripherals control module.", "<span class='notice'>You unfasten the peripherals control module.</span>")
 		if(10)
@@ -494,7 +494,7 @@
 				user.visible_message("[user] removes the weapon control module from [parent].", "<span class='notice'>You remove the weapon control module from [parent].</span>")
 		if(11)
 			if(diff==FORWARD)
-				user.visible_message("[user] installs the scanner module into [parent].", "<span class='notice'>You install scanner module into [parent].</span>")
+				user.visible_message("[user] installs the [I.name] to [parent].", "<span class='notice'>You install the [I.name] to [parent].</span>")
 			else
 				user.visible_message("[user] unfastens the weapon control module.", "<span class='notice'>You unfasten the weapon control module.</span>")
 		if(12)
@@ -504,7 +504,7 @@
 				user.visible_message("[user] removes the scanner module from [parent].", "<span class='notice'>You remove the scanner module from [parent].</span>")
 		if(13)
 			if(diff==FORWARD)
-				user.visible_message("[user] installs the capacitor into [parent].", "<span class='notice'>You install capacitor into [parent].</span>")
+				user.visible_message("[user] installs the [I.name] to [parent].", "<span class='notice'>You install the [I.name] to [parent].</span>")
 			else
 				user.visible_message("[user] unfastens the scanner module.", "<span class='notice'>You unfasten the scanner module.</span>")
 		if(14)
@@ -514,7 +514,7 @@
 				user.visible_message("[user] removes the capacitor from [parent].", "<span class='notice'>You remove the capacitor from [parent].</span>")
 		if(15)
 			if(diff==FORWARD)
-				user.visible_message("[user] installs the power cell into [parent].", "<span class='notice'>You install the power cell into [parent].</span>")
+				user.visible_message("[user] installs the [I.name] into [parent].", "<span class='notice'>You install the [I.name] into [parent].</span>")
 			else
 				user.visible_message("[user] unfastens the capacitor.", "<span class='notice'>You unfasten the capacitor.</span>")
 		if(16)
@@ -539,7 +539,7 @@
 				user.visible_message("[user] unfastens the internal armor layer.", "<span class='notice'>You unfasten the internal armor layer.</span>")
 		if(20)
 			if(diff==FORWARD)
-				user.visible_message("[user] installs Gygax Armor Plates to [parent].", "<span class='notice'>You install Gygax Armor Plates to [parent].</span>")
+				user.visible_message("[user] installs [I.name] to [parent].", "<span class='notice'>You install [I.name] to [parent].</span>")
 			else
 				user.visible_message("[user] cuts the internal armor layer from [parent].", "<span class='notice'>You cut the internal armor layer from [parent].</span>")
 		if(21)
@@ -720,7 +720,7 @@
 				user.visible_message("[user] removes the wiring from [parent].", "<span class='notice'>You remove the wiring from [parent].</span>")
 		if(5)
 			if(diff==FORWARD)
-				user.visible_message("[user] installs the central control module into [parent].", "<span class='notice'>You install the central computer mainboard into [parent].</span>")
+				user.visible_message("[user] installs the [I.name] into [parent].", "<span class='notice'>You install the [I.name] into [parent].</span>")
 			else
 				user.visible_message("[user] disconnects the wiring of [parent].", "<span class='notice'>You disconnect the wiring of [parent].</span>")
 		if(6)
@@ -730,7 +730,7 @@
 				user.visible_message("[user] removes the central control module from [parent].", "<span class='notice'>You remove the central computer mainboard from [parent].</span>")
 		if(7)
 			if(diff==FORWARD)
-				user.visible_message("[user] installs the peripherals control module into [parent].", "<span class='notice'>You install the peripherals control module into [parent].</span>")
+				user.visible_message("[user] installs the [I.name]into [parent].", "<span class='notice'>You install the [I.name]into [parent].</span>")
 			else
 				user.visible_message("[user] unfastens the mainboard.", "<span class='notice'>You unfasten the mainboard.</span>")
 		if(8)
@@ -740,7 +740,7 @@
 				user.visible_message("[user] removes the peripherals control module from [parent].", "<span class='notice'>You remove the peripherals control module from [parent].</span>")
 		if(9)
 			if(diff==FORWARD)
-				user.visible_message("[user] installs the power cell into [parent].", "<span class='notice'>You install the power cell into [parent].</span>")
+				user.visible_message("[user] installs the [I.name] into [parent].", "<span class='notice'>You install the [I.name] into [parent].</span>")
 			else
 				user.visible_message("[user] unfastens the peripherals control module.", "<span class='notice'>You unfasten the peripherals control module.</span>")
 		if(10)
@@ -890,17 +890,17 @@
 	//TODO: better messages.
 	switch(index)
 		if(2)
-			user.visible_message("[user] installs the central control module into [parent].", "<span class='notice'>You install the central control module into [parent].</span>")
+			user.visible_message("[user] installs the [I.name] into [parent].", "<span class='notice'>You install the [I.name] into [parent].</span>")
 		if(4)
-			user.visible_message("[user] installs the peripherals control module into [parent].", "<span class='notice'>You install the peripherals control module into [parent].</span>")
+			user.visible_message("[user] installs the [I.name] into [parent].", "<span class='notice'>You install the [I.name] into [parent].</span>")
 		if(6)
-			user.visible_message("[user] installs the weapon control module into [parent].", "<span class='notice'>You install the weapon control module into [parent].</span>")
+			user.visible_message("[user] installs the [I.name] into [parent].", "<span class='notice'>You install the [I.name] into [parent].</span>")
 		if(8)
-			user.visible_message("[user] installs the power cell into [parent].", "<span class='notice'>You install the power cell into [parent].</span>")
+			user.visible_message("[user] installs the [I.name] into [parent].", "<span class='notice'>You install the [I.name] into [parent].</span>")
 		if(10)
-			user.visible_message("[user] puts clown wig and mask on [parent].", "<span class='notice'>You put clown wig and mask on [parent].</span>")
+			user.visible_message("[user] puts [I.name] on [parent].", "<span class='notice'>You put [I.name] on [parent].</span>")
 		if(12)
-			user.visible_message("[user] puts clown boots on [parent].", "<span class='notice'>You put clown boots on [parent].</span>")
+			user.visible_message("[user] puts [I.name] on [parent].", "<span class='notice'>You put [I.name] on [parent].</span>")
 	return TRUE
 
 /datum/component/construction/unordered/mecha_chassis/durand
@@ -1107,7 +1107,7 @@
 				user.visible_message("[user] removes the wiring from [parent].", "<span class='notice'>You remove the wiring from [parent].</span>")
 		if(5)
 			if(diff==FORWARD)
-				user.visible_message("[user] installs the central control module into [parent].", "<span class='notice'>You install the central computer mainboard into [parent].</span>")
+				user.visible_message("[user] installs the [I.name] into [parent].", "<span class='notice'>You install the [I.name] into [parent].</span>")
 			else
 				user.visible_message("[user] disconnects the wiring of [parent].", "<span class='notice'>You disconnect the wiring of [parent].</span>")
 		if(6)
@@ -1117,7 +1117,7 @@
 				user.visible_message("[user] removes the central control module from [parent].", "<span class='notice'>You remove the central computer mainboard from [parent].</span>")
 		if(7)
 			if(diff==FORWARD)
-				user.visible_message("[user] installs the peripherals control module into [parent].", "<span class='notice'>You install the peripherals control module into [parent].</span>")
+				user.visible_message("[user] installs the [I.name] into [parent].", "<span class='notice'>You install the [I.name] into [parent].</span>")
 			else
 				user.visible_message("[user] unfastens the mainboard.", "<span class='notice'>You unfasten the mainboard.</span>")
 		if(8)
@@ -1127,7 +1127,7 @@
 				user.visible_message("[user] removes the peripherals control module from [parent].", "<span class='notice'>You remove the peripherals control module from [parent].</span>")
 		if(9)
 			if(diff==FORWARD)
-				user.visible_message("[user] installs the weapon control module into [parent].", "<span class='notice'>You install the weapon control module into [parent].</span>")
+				user.visible_message("[user] installs the [I.name] into [parent].", "<span class='notice'>You install the [I.name] into [parent].</span>")
 			else
 				user.visible_message("[user] unfastens the peripherals control module.", "<span class='notice'>You unfasten the peripherals control module.</span>")
 		if(10)
@@ -1137,7 +1137,7 @@
 				user.visible_message("[user] removes the weapon control module from [parent].", "<span class='notice'>You remove the weapon control module from [parent].</span>")
 		if(11)
 			if(diff==FORWARD)
-				user.visible_message("[user] installs scanner module to [parent].", "<span class='notice'>You install scanner module into [parent].</span>")
+				user.visible_message("[user] installs [I.name] to [parent].", "<span class='notice'>You install [I.name] to [parent].</span>")
 			else
 				user.visible_message("[user] unfastens the weapon control module.", "<span class='notice'>You unfasten the weapon control module.</span>")
 		if(12)
@@ -1147,7 +1147,7 @@
 				user.visible_message("[user] removes the scanner module from [parent].", "<span class='notice'>You remove the scanner module from [parent].</span>")
 		if(13)
 			if(diff==FORWARD)
-				user.visible_message("[user] installs the capacitor to [parent].", "<span class='notice'>You install capacitor to [parent].</span>")
+				user.visible_message("[user] installs the [I.name] to [parent].", "<span class='notice'>You install the [I.name] to [parent].</span>")
 			else
 				user.visible_message("[user] unfastens the scanner module.", "<span class='notice'>You unfasten the scanner module.</span>")
 		if(14)
@@ -1157,7 +1157,7 @@
 				user.visible_message("[user] removes the capacitor from [parent].", "<span class='notice'>You remove the capacitor from [parent].</span>")
 		if(15)
 			if(diff==FORWARD)
-				user.visible_message("[user] installs the power cell into [parent].", "<span class='notice'>You install the power cell into [parent].</span>")
+				user.visible_message("[user] installs the [I.name] into [parent].", "<span class='notice'>You install the [I.name] into [parent].</span>")
 			else
 				user.visible_message("[user] unfastens the capacitor.", "<span class='notice'>You unfasten the capacitor.</span>")
 		if(16)
@@ -1182,7 +1182,7 @@
 				user.visible_message("[user] unfastens the internal armor layer.", "<span class='notice'>You unfasten the internal armor layer.</span>")
 		if(20)
 			if(diff==FORWARD)
-				user.visible_message("[user] installs Durand Armor Plates to [parent].", "<span class='notice'>You install Durand Armor Plates to [parent].</span>")
+				user.visible_message("[user] installs [I.name] to [parent].", "<span class='notice'>You install [I.name] to [parent].</span>")
 			else
 				user.visible_message("[user] cuts the internal armor layer from [parent].", "<span class='notice'>You cut the internal armor layer from [parent].</span>")
 		if(21)
@@ -1443,7 +1443,7 @@
 				user.visible_message("[user] removes the wiring from [parent].", "<span class='notice'>You remove the wiring from [parent].</span>")
 		if(5)
 			if(diff==FORWARD)
-				user.visible_message("[user] installs the central control module into [parent].", "<span class='notice'>You install the central computer mainboard into [parent].</span>")
+				user.visible_message("[user] installs the [I.name] into [parent].", "<span class='notice'>You install the [I.name] into [parent].</span>")
 			else
 				user.visible_message("[user] disconnects the wiring of [parent].", "<span class='notice'>You disconnect the wiring of [parent].</span>")
 		if(6)
@@ -1453,7 +1453,7 @@
 				user.visible_message("[user] removes the central control module from [parent].", "<span class='notice'>You remove the central computer mainboard from [parent].</span>")
 		if(7)
 			if(diff==FORWARD)
-				user.visible_message("[user] installs the peripherals control module into [parent].", "<span class='notice'>You install the peripherals control module into [parent].</span>")
+				user.visible_message("[user] installs the [I.name] into [parent].", "<span class='notice'>You install the [I.name] into [parent].</span>")
 			else
 				user.visible_message("[user] unfastens the mainboard.", "<span class='notice'>You unfasten the mainboard.</span>")
 		if(8)
@@ -1463,7 +1463,7 @@
 				user.visible_message("[user] removes the peripherals control module from [parent].", "<span class='notice'>You remove the peripherals control module from [parent].</span>")
 		if(9)
 			if(diff==FORWARD)
-				user.visible_message("[user] installs the weapon control module into [parent].", "<span class='notice'>You install the weapon control module into [parent].</span>")
+				user.visible_message("[user] installs the [I.name] into [parent].", "<span class='notice'>You install the [I.name] into [parent].</span>")
 			else
 				user.visible_message("[user] unfastens the peripherals control module.", "<span class='notice'>You unfasten the peripherals control module.</span>")
 		if(10)
@@ -1473,7 +1473,7 @@
 				user.visible_message("[user] removes the weapon control module from [parent].", "<span class='notice'>You remove the weapon control module from [parent].</span>")
 		if(11)
 			if(diff==FORWARD)
-				user.visible_message("[user] installs the scanner module to [parent].", "<span class='notice'>You install the scanner module into [parent].</span>")
+				user.visible_message("[user] installs the [I.name] to [parent].", "<span class='notice'>You install the [I.name] to [parent].</span>")
 			else
 				user.visible_message("[user] unfastens the weapon control module.", "<span class='notice'>You unfasten the weapon control module.</span>")
 		if(12)
@@ -1483,17 +1483,17 @@
 				user.visible_message("[user] removes the scanner module from [parent].", "<span class='notice'>You remove the scanner module from [parent].</span>")
 		if(13)
 			if(diff==FORWARD)
-				user.visible_message("[user] installs the capacitor to [parent].", "<span class='notice'>You install capacitor into [parent].</span>")
+				user.visible_message("[user] installs [I.name] to [parent].", "<span class='notice'>You install the [I.name] to [parent].</span>")
 			else
 				user.visible_message("[user] unfastens the scanner module.", "<span class='notice'>You unfasten the scanner module.</span>")
 		if(14)
 			if(diff==FORWARD)
-				user.visible_message("[user] secures the capacitor.", "<span class='notice'>You secure the capacitor.</span>")
+				user.visible_message("[user] secures the [I.name].", "<span class='notice'>You secure the [I.name].</span>")
 			else
 				user.visible_message("[user] removes the capacitor from [parent].", "<span class='notice'>You remove the capacitor from [parent].</span>")
 		if(15)
 			if(diff==FORWARD)
-				user.visible_message("[user] installs the bluespace crystal.", "<span class='notice'>You install the bluespace crystal.</span>")
+				user.visible_message("[user] installs the [I.name].", "<span class='notice'>You install the [I.name].</span>")
 			else
 				user.visible_message("[user] unsecures the capacitor from [parent].", "<span class='notice'>You unsecure the capacitor from [parent].</span>")
 		if(16)
@@ -1508,7 +1508,7 @@
 				user.visible_message("[user] disconnects the bluespace crystal from [parent].", "<span class='notice'>You disconnect the bluespace crystal from [parent].</span>")
 		if(18)
 			if(diff==FORWARD)
-				user.visible_message("[user] installs the power cell into [parent].", "<span class='notice'>You install the power cell into [parent].</span>")
+				user.visible_message("[user] installs the [I.name] into [parent].", "<span class='notice'>You install the [I.name] into [parent].</span>")
 			else
 				user.visible_message("[user] disengages the bluespace crystal.", "<span class='notice'>You disengage the bluespace crystal.</span>")
 		if(19)
@@ -1533,7 +1533,7 @@
 				user.visible_message("[user] unfastens the phase armor layer.", "<span class='notice'>You unfasten the phase armor layer.</span>")
 		if(23)
 			if(diff==FORWARD)
-				user.visible_message("[user] installs Phazon Armor Plates to [parent].", "<span class='notice'>You install Phazon Armor Plates to [parent].</span>")
+				user.visible_message("[user] installs [I.name] to [parent].", "<span class='notice'>You install [I.name] to [parent].</span>")
 			else
 				user.visible_message("[user] cuts phase armor layer from [parent].", "<span class='notice'>You cut the phase armor layer from [parent].</span>")
 		if(24)
@@ -1712,7 +1712,7 @@
 				user.visible_message("[user] removes the wiring from [parent].", "<span class='notice'>You remove the wiring from [parent].</span>")
 		if(5)
 			if(diff==FORWARD)
-				user.visible_message("[user] installs the central control module into [parent].", "<span class='notice'>You install the central computer mainboard into [parent].</span>")
+				user.visible_message("[user] installs the [I.name] into [parent].", "<span class='notice'>You install the [I.name] into [parent].</span>")
 			else
 				user.visible_message("[user] disconnects the wiring of [parent].", "<span class='notice'>You disconnect the wiring of [parent].</span>")
 		if(6)
@@ -1722,7 +1722,7 @@
 				user.visible_message("[user] removes the central control module from [parent].", "<span class='notice'>You remove the central computer mainboard from [parent].</span>")
 		if(7)
 			if(diff==FORWARD)
-				user.visible_message("[user] installs the peripherals control module into [parent].", "<span class='notice'>You install the peripherals control module into [parent].</span>")
+				user.visible_message("[user] installs the [I.name] into [parent].", "<span class='notice'>You install the [I.name] into [parent].</span>")
 			else
 				user.visible_message("[user] unfastens the mainboard.", "<span class='notice'>You unfasten the mainboard.</span>")
 		if(8)
@@ -1732,7 +1732,7 @@
 				user.visible_message("[user] removes the peripherals control module from [parent].", "<span class='notice'>You remove the peripherals control module from [parent].</span>")
 		if(9)
 			if(diff==FORWARD)
-				user.visible_message("[user] installs the power cell into [parent].", "<span class='notice'>You install the power cell into [parent].</span>")
+				user.visible_message("[user] installs the [I.name] into [parent].", "<span class='notice'>You install the [I.name] into [parent].</span>")
 			else
 				user.visible_message("[user] unfastens the peripherals control module.", "<span class='notice'>You unfasten the peripherals control module.</span>")
 		if(10)

--- a/code/game/mecha/mecha_construction_paths.dm
+++ b/code/game/mecha/mecha_construction_paths.dm
@@ -1011,7 +1011,7 @@
 			"key" = /obj/item/stock_parts/capacitor,
 			"action" = ITEM_MOVE_INSIDE,
 			"back_key" = TOOL_SCREWDRIVER,
-			"desc" = Scanner module is secured."
+			"desc" = "Scanner module is secured."
 		),
 
 		//14

--- a/code/game/mecha/mecha_construction_paths.dm
+++ b/code/game/mecha/mecha_construction_paths.dm
@@ -198,7 +198,7 @@
 				user.visible_message("[user] removes the wiring from [parent].", "<span class='notice'>You remove the wiring from [parent].</span>")
 		if(5)
 			if(diff==FORWARD)
-				user.visible_message("[user] installs the [I.name] into [parent].", "<span class='notice'>You install the [I.name] into [parent].</span>")
+				user.visible_message("[user] installs the [I] into [parent].", "<span class='notice'>You install the [I] into [parent].</span>")
 			else
 				user.visible_message("[user] disconnects the wiring of [parent].", "<span class='notice'>You disconnect the wiring of [parent].</span>")
 		if(6)
@@ -208,7 +208,7 @@
 				user.visible_message("[user] removes the central control module from [parent].", "<span class='notice'>You remove the central computer mainboard from [parent].</span>")
 		if(7)
 			if(diff==FORWARD)
-				user.visible_message("[user] installs the [I.name] into [parent].", "<span class='notice'>You install the [I.name] into [parent].</span>")
+				user.visible_message("[user] installs the [I] into [parent].", "<span class='notice'>You install the [I] into [parent].</span>")
 			else
 				user.visible_message("[user] unfastens the mainboard.", "<span class='notice'>You unfasten the mainboard.</span>")
 		if(8)
@@ -218,7 +218,7 @@
 				user.visible_message("[user] removes the peripherals control module from [parent].", "<span class='notice'>You remove the peripherals control module from [parent].</span>")
 		if(9)
 			if(diff==FORWARD)
-				user.visible_message("[user] installs the [I.name] into [parent].", "<span class='notice'>You install the [I.name] into [parent].</span>")
+				user.visible_message("[user] installs the [I] into [parent].", "<span class='notice'>You install the [I] into [parent].</span>")
 			else
 				user.visible_message("[user] unfastens the peripherals control module.", "<span class='notice'>You unfasten the peripherals control module.</span>")
 		if(10)
@@ -464,7 +464,7 @@
 				user.visible_message("[user] removes the wiring from [parent].", "<span class='notice'>You remove the wiring from [parent].</span>")
 		if(5)
 			if(diff==FORWARD)
-				user.visible_message("[user] installs the [I.name] into [parent].", "<span class='notice'>You install the [I.name] into [parent].</span>")
+				user.visible_message("[user] installs the [I] into [parent].", "<span class='notice'>You install the [I] into [parent].</span>")
 			else
 				user.visible_message("[user] disconnects the wiring of [parent].", "<span class='notice'>You disconnect the wiring of [parent].</span>")
 		if(6)
@@ -474,7 +474,7 @@
 				user.visible_message("[user] removes the central control module from [parent].", "<span class='notice'>You remove the central computer mainboard from [parent].</span>")
 		if(7)
 			if(diff==FORWARD)
-				user.visible_message("[user] installs the [I.name] into [parent].", "<span class='notice'>You install the [I.name] into [parent].</span>")
+				user.visible_message("[user] installs the [I] into [parent].", "<span class='notice'>You install the [I] into [parent].</span>")
 			else
 				user.visible_message("[user] unfastens the mainboard.", "<span class='notice'>You unfasten the mainboard.</span>")
 		if(8)
@@ -484,7 +484,7 @@
 				user.visible_message("[user] removes the peripherals control module from [parent].", "<span class='notice'>You remove the peripherals control module from [parent].</span>")
 		if(9)
 			if(diff==FORWARD)
-				user.visible_message("[user] installs the [I.name] into [parent].", "<span class='notice'>You install the [I.name] into [parent].</span>")
+				user.visible_message("[user] installs the [I] into [parent].", "<span class='notice'>You install the [I] into [parent].</span>")
 			else
 				user.visible_message("[user] unfastens the peripherals control module.", "<span class='notice'>You unfasten the peripherals control module.</span>")
 		if(10)
@@ -494,7 +494,7 @@
 				user.visible_message("[user] removes the weapon control module from [parent].", "<span class='notice'>You remove the weapon control module from [parent].</span>")
 		if(11)
 			if(diff==FORWARD)
-				user.visible_message("[user] installs the [I.name] to [parent].", "<span class='notice'>You install the [I.name] to [parent].</span>")
+				user.visible_message("[user] installs the [I] to [parent].", "<span class='notice'>You install the [I] to [parent].</span>")
 			else
 				user.visible_message("[user] unfastens the weapon control module.", "<span class='notice'>You unfasten the weapon control module.</span>")
 		if(12)
@@ -504,7 +504,7 @@
 				user.visible_message("[user] removes the scanner module from [parent].", "<span class='notice'>You remove the scanner module from [parent].</span>")
 		if(13)
 			if(diff==FORWARD)
-				user.visible_message("[user] installs the [I.name] to [parent].", "<span class='notice'>You install the [I.name] to [parent].</span>")
+				user.visible_message("[user] installs the [I] to [parent].", "<span class='notice'>You install the [I] to [parent].</span>")
 			else
 				user.visible_message("[user] unfastens the scanner module.", "<span class='notice'>You unfasten the scanner module.</span>")
 		if(14)
@@ -514,7 +514,7 @@
 				user.visible_message("[user] removes the capacitor from [parent].", "<span class='notice'>You remove the capacitor from [parent].</span>")
 		if(15)
 			if(diff==FORWARD)
-				user.visible_message("[user] installs the [I.name] into [parent].", "<span class='notice'>You install the [I.name] into [parent].</span>")
+				user.visible_message("[user] installs the [I] into [parent].", "<span class='notice'>You install the [I] into [parent].</span>")
 			else
 				user.visible_message("[user] unfastens the capacitor.", "<span class='notice'>You unfasten the capacitor.</span>")
 		if(16)
@@ -539,7 +539,7 @@
 				user.visible_message("[user] unfastens the internal armor layer.", "<span class='notice'>You unfasten the internal armor layer.</span>")
 		if(20)
 			if(diff==FORWARD)
-				user.visible_message("[user] installs [I.name] to [parent].", "<span class='notice'>You install [I.name] to [parent].</span>")
+				user.visible_message("[user] installs [I] to [parent].", "<span class='notice'>You install [I] to [parent].</span>")
 			else
 				user.visible_message("[user] cuts the internal armor layer from [parent].", "<span class='notice'>You cut the internal armor layer from [parent].</span>")
 		if(21)
@@ -720,7 +720,7 @@
 				user.visible_message("[user] removes the wiring from [parent].", "<span class='notice'>You remove the wiring from [parent].</span>")
 		if(5)
 			if(diff==FORWARD)
-				user.visible_message("[user] installs the [I.name] into [parent].", "<span class='notice'>You install the [I.name] into [parent].</span>")
+				user.visible_message("[user] installs the [I] into [parent].", "<span class='notice'>You install the [I] into [parent].</span>")
 			else
 				user.visible_message("[user] disconnects the wiring of [parent].", "<span class='notice'>You disconnect the wiring of [parent].</span>")
 		if(6)
@@ -730,7 +730,7 @@
 				user.visible_message("[user] removes the central control module from [parent].", "<span class='notice'>You remove the central computer mainboard from [parent].</span>")
 		if(7)
 			if(diff==FORWARD)
-				user.visible_message("[user] installs the [I.name]into [parent].", "<span class='notice'>You install the [I.name]into [parent].</span>")
+				user.visible_message("[user] installs the [I]into [parent].", "<span class='notice'>You install the [I]into [parent].</span>")
 			else
 				user.visible_message("[user] unfastens the mainboard.", "<span class='notice'>You unfasten the mainboard.</span>")
 		if(8)
@@ -740,7 +740,7 @@
 				user.visible_message("[user] removes the peripherals control module from [parent].", "<span class='notice'>You remove the peripherals control module from [parent].</span>")
 		if(9)
 			if(diff==FORWARD)
-				user.visible_message("[user] installs the [I.name] into [parent].", "<span class='notice'>You install the [I.name] into [parent].</span>")
+				user.visible_message("[user] installs the [I] into [parent].", "<span class='notice'>You install the [I] into [parent].</span>")
 			else
 				user.visible_message("[user] unfastens the peripherals control module.", "<span class='notice'>You unfasten the peripherals control module.</span>")
 		if(10)
@@ -890,17 +890,17 @@
 	//TODO: better messages.
 	switch(index)
 		if(2)
-			user.visible_message("[user] installs the [I.name] into [parent].", "<span class='notice'>You install the [I.name] into [parent].</span>")
+			user.visible_message("[user] installs the [I] into [parent].", "<span class='notice'>You install the [I] into [parent].</span>")
 		if(4)
-			user.visible_message("[user] installs the [I.name] into [parent].", "<span class='notice'>You install the [I.name] into [parent].</span>")
+			user.visible_message("[user] installs the [I] into [parent].", "<span class='notice'>You install the [I] into [parent].</span>")
 		if(6)
-			user.visible_message("[user] installs the [I.name] into [parent].", "<span class='notice'>You install the [I.name] into [parent].</span>")
+			user.visible_message("[user] installs the [I] into [parent].", "<span class='notice'>You install the [I] into [parent].</span>")
 		if(8)
-			user.visible_message("[user] installs the [I.name] into [parent].", "<span class='notice'>You install the [I.name] into [parent].</span>")
+			user.visible_message("[user] installs the [I] into [parent].", "<span class='notice'>You install the [I] into [parent].</span>")
 		if(10)
-			user.visible_message("[user] puts [I.name] on [parent].", "<span class='notice'>You put [I.name] on [parent].</span>")
+			user.visible_message("[user] puts [I] on [parent].", "<span class='notice'>You put [I] on [parent].</span>")
 		if(12)
-			user.visible_message("[user] puts [I.name] on [parent].", "<span class='notice'>You put [I.name] on [parent].</span>")
+			user.visible_message("[user] puts [I] on [parent].", "<span class='notice'>You put [I] on [parent].</span>")
 	return TRUE
 
 /datum/component/construction/unordered/mecha_chassis/durand
@@ -1107,7 +1107,7 @@
 				user.visible_message("[user] removes the wiring from [parent].", "<span class='notice'>You remove the wiring from [parent].</span>")
 		if(5)
 			if(diff==FORWARD)
-				user.visible_message("[user] installs the [I.name] into [parent].", "<span class='notice'>You install the [I.name] into [parent].</span>")
+				user.visible_message("[user] installs the [I] into [parent].", "<span class='notice'>You install the [I] into [parent].</span>")
 			else
 				user.visible_message("[user] disconnects the wiring of [parent].", "<span class='notice'>You disconnect the wiring of [parent].</span>")
 		if(6)
@@ -1117,7 +1117,7 @@
 				user.visible_message("[user] removes the central control module from [parent].", "<span class='notice'>You remove the central computer mainboard from [parent].</span>")
 		if(7)
 			if(diff==FORWARD)
-				user.visible_message("[user] installs the [I.name] into [parent].", "<span class='notice'>You install the [I.name] into [parent].</span>")
+				user.visible_message("[user] installs the [I] into [parent].", "<span class='notice'>You install the [I] into [parent].</span>")
 			else
 				user.visible_message("[user] unfastens the mainboard.", "<span class='notice'>You unfasten the mainboard.</span>")
 		if(8)
@@ -1127,7 +1127,7 @@
 				user.visible_message("[user] removes the peripherals control module from [parent].", "<span class='notice'>You remove the peripherals control module from [parent].</span>")
 		if(9)
 			if(diff==FORWARD)
-				user.visible_message("[user] installs the [I.name] into [parent].", "<span class='notice'>You install the [I.name] into [parent].</span>")
+				user.visible_message("[user] installs the [I] into [parent].", "<span class='notice'>You install the [I] into [parent].</span>")
 			else
 				user.visible_message("[user] unfastens the peripherals control module.", "<span class='notice'>You unfasten the peripherals control module.</span>")
 		if(10)
@@ -1137,7 +1137,7 @@
 				user.visible_message("[user] removes the weapon control module from [parent].", "<span class='notice'>You remove the weapon control module from [parent].</span>")
 		if(11)
 			if(diff==FORWARD)
-				user.visible_message("[user] installs [I.name] to [parent].", "<span class='notice'>You install [I.name] to [parent].</span>")
+				user.visible_message("[user] installs [I] to [parent].", "<span class='notice'>You install [I] to [parent].</span>")
 			else
 				user.visible_message("[user] unfastens the weapon control module.", "<span class='notice'>You unfasten the weapon control module.</span>")
 		if(12)
@@ -1147,7 +1147,7 @@
 				user.visible_message("[user] removes the scanner module from [parent].", "<span class='notice'>You remove the scanner module from [parent].</span>")
 		if(13)
 			if(diff==FORWARD)
-				user.visible_message("[user] installs the [I.name] to [parent].", "<span class='notice'>You install the [I.name] to [parent].</span>")
+				user.visible_message("[user] installs the [I] to [parent].", "<span class='notice'>You install the [I] to [parent].</span>")
 			else
 				user.visible_message("[user] unfastens the scanner module.", "<span class='notice'>You unfasten the scanner module.</span>")
 		if(14)
@@ -1157,7 +1157,7 @@
 				user.visible_message("[user] removes the capacitor from [parent].", "<span class='notice'>You remove the capacitor from [parent].</span>")
 		if(15)
 			if(diff==FORWARD)
-				user.visible_message("[user] installs the [I.name] into [parent].", "<span class='notice'>You install the [I.name] into [parent].</span>")
+				user.visible_message("[user] installs the [I] into [parent].", "<span class='notice'>You install the [I] into [parent].</span>")
 			else
 				user.visible_message("[user] unfastens the capacitor.", "<span class='notice'>You unfasten the capacitor.</span>")
 		if(16)
@@ -1182,7 +1182,7 @@
 				user.visible_message("[user] unfastens the internal armor layer.", "<span class='notice'>You unfasten the internal armor layer.</span>")
 		if(20)
 			if(diff==FORWARD)
-				user.visible_message("[user] installs [I.name] to [parent].", "<span class='notice'>You install [I.name] to [parent].</span>")
+				user.visible_message("[user] installs [I] to [parent].", "<span class='notice'>You install [I] to [parent].</span>")
 			else
 				user.visible_message("[user] cuts the internal armor layer from [parent].", "<span class='notice'>You cut the internal armor layer from [parent].</span>")
 		if(21)
@@ -1443,7 +1443,7 @@
 				user.visible_message("[user] removes the wiring from [parent].", "<span class='notice'>You remove the wiring from [parent].</span>")
 		if(5)
 			if(diff==FORWARD)
-				user.visible_message("[user] installs the [I.name] into [parent].", "<span class='notice'>You install the [I.name] into [parent].</span>")
+				user.visible_message("[user] installs the [I] into [parent].", "<span class='notice'>You install the [I] into [parent].</span>")
 			else
 				user.visible_message("[user] disconnects the wiring of [parent].", "<span class='notice'>You disconnect the wiring of [parent].</span>")
 		if(6)
@@ -1453,7 +1453,7 @@
 				user.visible_message("[user] removes the central control module from [parent].", "<span class='notice'>You remove the central computer mainboard from [parent].</span>")
 		if(7)
 			if(diff==FORWARD)
-				user.visible_message("[user] installs the [I.name] into [parent].", "<span class='notice'>You install the [I.name] into [parent].</span>")
+				user.visible_message("[user] installs the [I] into [parent].", "<span class='notice'>You install the [I] into [parent].</span>")
 			else
 				user.visible_message("[user] unfastens the mainboard.", "<span class='notice'>You unfasten the mainboard.</span>")
 		if(8)
@@ -1463,7 +1463,7 @@
 				user.visible_message("[user] removes the peripherals control module from [parent].", "<span class='notice'>You remove the peripherals control module from [parent].</span>")
 		if(9)
 			if(diff==FORWARD)
-				user.visible_message("[user] installs the [I.name] into [parent].", "<span class='notice'>You install the [I.name] into [parent].</span>")
+				user.visible_message("[user] installs the [I] into [parent].", "<span class='notice'>You install the [I] into [parent].</span>")
 			else
 				user.visible_message("[user] unfastens the peripherals control module.", "<span class='notice'>You unfasten the peripherals control module.</span>")
 		if(10)
@@ -1473,7 +1473,7 @@
 				user.visible_message("[user] removes the weapon control module from [parent].", "<span class='notice'>You remove the weapon control module from [parent].</span>")
 		if(11)
 			if(diff==FORWARD)
-				user.visible_message("[user] installs the [I.name] to [parent].", "<span class='notice'>You install the [I.name] to [parent].</span>")
+				user.visible_message("[user] installs the [I] to [parent].", "<span class='notice'>You install the [I] to [parent].</span>")
 			else
 				user.visible_message("[user] unfastens the weapon control module.", "<span class='notice'>You unfasten the weapon control module.</span>")
 		if(12)
@@ -1483,17 +1483,17 @@
 				user.visible_message("[user] removes the scanner module from [parent].", "<span class='notice'>You remove the scanner module from [parent].</span>")
 		if(13)
 			if(diff==FORWARD)
-				user.visible_message("[user] installs [I.name] to [parent].", "<span class='notice'>You install the [I.name] to [parent].</span>")
+				user.visible_message("[user] installs [I] to [parent].", "<span class='notice'>You install the [I] to [parent].</span>")
 			else
 				user.visible_message("[user] unfastens the scanner module.", "<span class='notice'>You unfasten the scanner module.</span>")
 		if(14)
 			if(diff==FORWARD)
-				user.visible_message("[user] secures the [I.name].", "<span class='notice'>You secure the [I.name].</span>")
+				user.visible_message("[user] secures the [I].", "<span class='notice'>You secure the [I].</span>")
 			else
 				user.visible_message("[user] removes the capacitor from [parent].", "<span class='notice'>You remove the capacitor from [parent].</span>")
 		if(15)
 			if(diff==FORWARD)
-				user.visible_message("[user] installs the [I.name].", "<span class='notice'>You install the [I.name].</span>")
+				user.visible_message("[user] installs the [I].", "<span class='notice'>You install the [I].</span>")
 			else
 				user.visible_message("[user] unsecures the capacitor from [parent].", "<span class='notice'>You unsecure the capacitor from [parent].</span>")
 		if(16)
@@ -1508,7 +1508,7 @@
 				user.visible_message("[user] disconnects the bluespace crystal from [parent].", "<span class='notice'>You disconnect the bluespace crystal from [parent].</span>")
 		if(18)
 			if(diff==FORWARD)
-				user.visible_message("[user] installs the [I.name] into [parent].", "<span class='notice'>You install the [I.name] into [parent].</span>")
+				user.visible_message("[user] installs the [I] into [parent].", "<span class='notice'>You install the [I] into [parent].</span>")
 			else
 				user.visible_message("[user] disengages the bluespace crystal.", "<span class='notice'>You disengage the bluespace crystal.</span>")
 		if(19)
@@ -1533,7 +1533,7 @@
 				user.visible_message("[user] unfastens the phase armor layer.", "<span class='notice'>You unfasten the phase armor layer.</span>")
 		if(23)
 			if(diff==FORWARD)
-				user.visible_message("[user] installs [I.name] to [parent].", "<span class='notice'>You install [I.name] to [parent].</span>")
+				user.visible_message("[user] installs [I] to [parent].", "<span class='notice'>You install [I] to [parent].</span>")
 			else
 				user.visible_message("[user] cuts phase armor layer from [parent].", "<span class='notice'>You cut the phase armor layer from [parent].</span>")
 		if(24)
@@ -1712,7 +1712,7 @@
 				user.visible_message("[user] removes the wiring from [parent].", "<span class='notice'>You remove the wiring from [parent].</span>")
 		if(5)
 			if(diff==FORWARD)
-				user.visible_message("[user] installs the [I.name] into [parent].", "<span class='notice'>You install the [I.name] into [parent].</span>")
+				user.visible_message("[user] installs the [I] into [parent].", "<span class='notice'>You install the [I] into [parent].</span>")
 			else
 				user.visible_message("[user] disconnects the wiring of [parent].", "<span class='notice'>You disconnect the wiring of [parent].</span>")
 		if(6)
@@ -1722,7 +1722,7 @@
 				user.visible_message("[user] removes the central control module from [parent].", "<span class='notice'>You remove the central computer mainboard from [parent].</span>")
 		if(7)
 			if(diff==FORWARD)
-				user.visible_message("[user] installs the [I.name] into [parent].", "<span class='notice'>You install the [I.name] into [parent].</span>")
+				user.visible_message("[user] installs the [I] into [parent].", "<span class='notice'>You install the [I] into [parent].</span>")
 			else
 				user.visible_message("[user] unfastens the mainboard.", "<span class='notice'>You unfasten the mainboard.</span>")
 		if(8)
@@ -1732,7 +1732,7 @@
 				user.visible_message("[user] removes the peripherals control module from [parent].", "<span class='notice'>You remove the peripherals control module from [parent].</span>")
 		if(9)
 			if(diff==FORWARD)
-				user.visible_message("[user] installs the [I.name] into [parent].", "<span class='notice'>You install the [I.name] into [parent].</span>")
+				user.visible_message("[user] installs the [I] into [parent].", "<span class='notice'>You install the [I] into [parent].</span>")
 			else
 				user.visible_message("[user] unfastens the peripherals control module.", "<span class='notice'>You unfasten the peripherals control module.</span>")
 		if(10)

--- a/code/game/mecha/mecha_construction_paths.dm
+++ b/code/game/mecha/mecha_construction_paths.dm
@@ -358,7 +358,7 @@
 		list(
 			"key" = TOOL_SCREWDRIVER,
 			"back_key" = TOOL_CROWBAR,
-			"desc" = "Advanced scanner module is installed."
+			"desc" = "Scanner module is installed."
 		),
 
 		//13
@@ -366,14 +366,14 @@
 			"key" = /obj/item/stock_parts/capacitor,
 			"action" = ITEM_MOVE_INSIDE,
 			"back_key" = TOOL_SCREWDRIVER,
-			"desc" = "Advanced scanner module is secured."
+			"desc" = "Scanner module is secured."
 		),
 
 		//14
 		list(
 			"key" = TOOL_SCREWDRIVER,
 			"back_key" = TOOL_CROWBAR,
-			"desc" = "Advanced capacitor is installed."
+			"desc" = "Capacitor is installed."
 		),
 
 		//15
@@ -381,7 +381,7 @@
 			"key" = /obj/item/stock_parts/cell,
 			"action" = ITEM_MOVE_INSIDE,
 			"back_key" = TOOL_SCREWDRIVER,
-			"desc" = "Advanced capacitor is secured."
+			"desc" = "Capacitor is secured."
 		),
 
 		//16
@@ -494,19 +494,19 @@
 				user.visible_message("[user] removes the weapon control module from [parent].", "<span class='notice'>You remove the weapon control module from [parent].</span>")
 		if(11)
 			if(diff==FORWARD)
-				user.visible_message("[user] installs scanner module to [parent].", "<span class='notice'>You install scanner module to [parent].</span>")
+				user.visible_message("[user] installs the scanner module into [parent].", "<span class='notice'>You install scanner module into [parent].</span>")
 			else
 				user.visible_message("[user] unfastens the weapon control module.", "<span class='notice'>You unfasten the weapon control module.</span>")
 		if(12)
 			if(diff==FORWARD)
-				user.visible_message("[user] secures the advanced scanner module.", "<span class='notice'>You secure the scanner module.</span>")
+				user.visible_message("[user] secures the scanner module.", "<span class='notice'>You secure the scanner module.</span>")
 			else
-				user.visible_message("[user] removes the advanced scanner module from [parent].", "<span class='notice'>You remove the scanner module from [parent].</span>")
+				user.visible_message("[user] removes the scanner module from [parent].", "<span class='notice'>You remove the scanner module from [parent].</span>")
 		if(13)
 			if(diff==FORWARD)
-				user.visible_message("[user] installs capacitor to [parent].", "<span class='notice'>You install capacitor to [parent].</span>")
+				user.visible_message("[user] installs the capacitor into [parent].", "<span class='notice'>You install capacitor into [parent].</span>")
 			else
-				user.visible_message("[user] unfastens the  scanner module.", "<span class='notice'>You unfasten the scanner module.</span>")
+				user.visible_message("[user] unfastens the scanner module.", "<span class='notice'>You unfasten the scanner module.</span>")
 		if(14)
 			if(diff==FORWARD)
 				user.visible_message("[user] secures the capacitor.", "<span class='notice'>You secure the capacitor.</span>")
@@ -1003,7 +1003,7 @@
 		list(
 			"key" = TOOL_SCREWDRIVER,
 			"back_key" = TOOL_CROWBAR,
-			"desc" = "Phasic scanner module is installed."
+			"desc" = "Scanner module is installed."
 		),
 
 		//13
@@ -1011,14 +1011,14 @@
 			"key" = /obj/item/stock_parts/capacitor,
 			"action" = ITEM_MOVE_INSIDE,
 			"back_key" = TOOL_SCREWDRIVER,
-			"desc" = "Phasic scanner module is secured."
+			"desc" = Scanner module is secured."
 		),
 
 		//14
 		list(
 			"key" = TOOL_SCREWDRIVER,
 			"back_key" = TOOL_CROWBAR,
-			"desc" = "Super capacitor is installed."
+			"desc" = "Capacitor is installed."
 		),
 
 		//15
@@ -1026,7 +1026,7 @@
 			"key" = /obj/item/stock_parts/cell,
 			"action" = ITEM_MOVE_INSIDE,
 			"back_key" = TOOL_SCREWDRIVER,
-			"desc" = "Super capacitor is secured."
+			"desc" = "Capacitor is secured."
 		),
 
 		//16
@@ -1137,7 +1137,7 @@
 				user.visible_message("[user] removes the weapon control module from [parent].", "<span class='notice'>You remove the weapon control module from [parent].</span>")
 		if(11)
 			if(diff==FORWARD)
-				user.visible_message("[user] installs scanner module to [parent].", "<span class='notice'>You install phasic scanner module to [parent].</span>")
+				user.visible_message("[user] installs scanner module to [parent].", "<span class='notice'>You install scanner module into [parent].</span>")
 			else
 				user.visible_message("[user] unfastens the weapon control module.", "<span class='notice'>You unfasten the weapon control module.</span>")
 		if(12)
@@ -1147,14 +1147,14 @@
 				user.visible_message("[user] removes the scanner module from [parent].", "<span class='notice'>You remove the scanner module from [parent].</span>")
 		if(13)
 			if(diff==FORWARD)
-				user.visible_message("[user] installs capacitor to [parent].", "<span class='notice'>You install capacitor to [parent].</span>")
+				user.visible_message("[user] installs the capacitor to [parent].", "<span class='notice'>You install capacitor to [parent].</span>")
 			else
 				user.visible_message("[user] unfastens the scanner module.", "<span class='notice'>You unfasten the scanner module.</span>")
 		if(14)
 			if(diff==FORWARD)
 				user.visible_message("[user] secures the capacitor.", "<span class='notice'>You secure the capacitor.</span>")
 			else
-				user.visible_message("[user] removes the super capacitor from [parent].", "<span class='notice'>You remove the capacitor from [parent].</span>")
+				user.visible_message("[user] removes the capacitor from [parent].", "<span class='notice'>You remove the capacitor from [parent].</span>")
 		if(15)
 			if(diff==FORWARD)
 				user.visible_message("[user] installs the power cell into [parent].", "<span class='notice'>You install the power cell into [parent].</span>")
@@ -1299,7 +1299,7 @@
 		list(
 			"key" = TOOL_SCREWDRIVER,
 			"back_key" = TOOL_CROWBAR,
-			"desc" = "Phasic scanner module is installed."
+			"desc" = "Scanner module is installed."
 		),
 
 		//13
@@ -1307,14 +1307,14 @@
 			"key" = /obj/item/stock_parts/capacitor,
 			"action" = ITEM_MOVE_INSIDE,
 			"back_key" = TOOL_SCREWDRIVER,
-			"desc" = "Phasic scanner module is secured."
+			"desc" = "Scanner module is secured."
 		),
 
 		//14
 		list(
 			"key" = TOOL_SCREWDRIVER,
 			"back_key" = TOOL_CROWBAR,
-			"desc" = "Super capacitor is installed."
+			"desc" = "Capacitor is installed."
 		),
 
 		//15
@@ -1322,7 +1322,7 @@
 			"key" = /obj/item/stack/ore/bluespace_crystal,
 			"amount" = 1,
 			"back_key" = TOOL_SCREWDRIVER,
-			"desc" = "Super capacitor is secured."
+			"desc" = "Capacitor is secured."
 		),
 
 		//16
@@ -1473,29 +1473,29 @@
 				user.visible_message("[user] removes the weapon control module from [parent].", "<span class='notice'>You remove the weapon control module from [parent].</span>")
 		if(11)
 			if(diff==FORWARD)
-				user.visible_message("[user] installs phasic scanner module to [parent].", "<span class='notice'>You install scanner module to [parent].</span>")
+				user.visible_message("[user] installs the scanner module to [parent].", "<span class='notice'>You install the scanner module into [parent].</span>")
 			else
 				user.visible_message("[user] unfastens the weapon control module.", "<span class='notice'>You unfasten the weapon control module.</span>")
 		if(12)
 			if(diff==FORWARD)
-				user.visible_message("[user] secures the phasic scanner module.", "<span class='notice'>You secure the scanner module.</span>")
+				user.visible_message("[user] secures the scanner module.", "<span class='notice'>You secure the scanner module.</span>")
 			else
-				user.visible_message("[user] removes the phasic scanner module from [parent].", "<span class='notice'>You remove the scanner module from [parent].</span>")
+				user.visible_message("[user] removes the scanner module from [parent].", "<span class='notice'>You remove the scanner module from [parent].</span>")
 		if(13)
 			if(diff==FORWARD)
-				user.visible_message("[user] installs super capacitor to [parent].", "<span class='notice'>You install capacitor to [parent].</span>")
+				user.visible_message("[user] installs the capacitor to [parent].", "<span class='notice'>You install capacitor into [parent].</span>")
 			else
-				user.visible_message("[user] unfastens the phasic scanner module.", "<span class='notice'>You unfasten the scanner module.</span>")
+				user.visible_message("[user] unfastens the scanner module.", "<span class='notice'>You unfasten the scanner module.</span>")
 		if(14)
 			if(diff==FORWARD)
-				user.visible_message("[user] secures the super capacitor.", "<span class='notice'>You secure the capacitor.</span>")
+				user.visible_message("[user] secures the capacitor.", "<span class='notice'>You secure the capacitor.</span>")
 			else
-				user.visible_message("[user] removes the super capacitor from [parent].", "<span class='notice'>You remove the capacitor from [parent].</span>")
+				user.visible_message("[user] removes the capacitor from [parent].", "<span class='notice'>You remove the capacitor from [parent].</span>")
 		if(15)
 			if(diff==FORWARD)
 				user.visible_message("[user] installs the bluespace crystal.", "<span class='notice'>You install the bluespace crystal.</span>")
 			else
-				user.visible_message("[user] unsecures the super capacitor from [parent].", "<span class='notice'>You unsecure the capacitor from [parent].</span>")
+				user.visible_message("[user] unsecures the capacitor from [parent].", "<span class='notice'>You unsecure the capacitor from [parent].</span>")
 		if(16)
 			if(diff==FORWARD)
 				user.visible_message("[user] connects the bluespace crystal.", "<span class='notice'>You connect the bluespace crystal.</span>")

--- a/code/game/mecha/mecha_construction_paths.dm
+++ b/code/game/mecha/mecha_construction_paths.dm
@@ -198,7 +198,7 @@
 				user.visible_message("[user] removes the wiring from [parent].", "<span class='notice'>You remove the wiring from [parent].</span>")
 		if(5)
 			if(diff==FORWARD)
-				user.visible_message("[user] installs the [I] into [parent].", "<span class='notice'>You install the [I] into [parent].</span>")
+				user.visible_message("[user] installs [I] into [parent].", "<span class='notice'>You install [I] into [parent].</span>")
 			else
 				user.visible_message("[user] disconnects the wiring of [parent].", "<span class='notice'>You disconnect the wiring of [parent].</span>")
 		if(6)
@@ -208,7 +208,7 @@
 				user.visible_message("[user] removes the central control module from [parent].", "<span class='notice'>You remove the central computer mainboard from [parent].</span>")
 		if(7)
 			if(diff==FORWARD)
-				user.visible_message("[user] installs the [I] into [parent].", "<span class='notice'>You install the [I] into [parent].</span>")
+				user.visible_message("[user] installs [I] into [parent].", "<span class='notice'>You install [I] into [parent].</span>")
 			else
 				user.visible_message("[user] unfastens the mainboard.", "<span class='notice'>You unfasten the mainboard.</span>")
 		if(8)
@@ -218,7 +218,7 @@
 				user.visible_message("[user] removes the peripherals control module from [parent].", "<span class='notice'>You remove the peripherals control module from [parent].</span>")
 		if(9)
 			if(diff==FORWARD)
-				user.visible_message("[user] installs the [I] into [parent].", "<span class='notice'>You install the [I] into [parent].</span>")
+				user.visible_message("[user] installs [I] into [parent].", "<span class='notice'>You install [I] into [parent].</span>")
 			else
 				user.visible_message("[user] unfastens the peripherals control module.", "<span class='notice'>You unfasten the peripherals control module.</span>")
 		if(10)
@@ -464,7 +464,7 @@
 				user.visible_message("[user] removes the wiring from [parent].", "<span class='notice'>You remove the wiring from [parent].</span>")
 		if(5)
 			if(diff==FORWARD)
-				user.visible_message("[user] installs the [I] into [parent].", "<span class='notice'>You install the [I] into [parent].</span>")
+				user.visible_message("[user] installs [I] into [parent].", "<span class='notice'>You install [I] into [parent].</span>")
 			else
 				user.visible_message("[user] disconnects the wiring of [parent].", "<span class='notice'>You disconnect the wiring of [parent].</span>")
 		if(6)
@@ -474,7 +474,7 @@
 				user.visible_message("[user] removes the central control module from [parent].", "<span class='notice'>You remove the central computer mainboard from [parent].</span>")
 		if(7)
 			if(diff==FORWARD)
-				user.visible_message("[user] installs the [I] into [parent].", "<span class='notice'>You install the [I] into [parent].</span>")
+				user.visible_message("[user] installs [I] into [parent].", "<span class='notice'>You install [I] into [parent].</span>")
 			else
 				user.visible_message("[user] unfastens the mainboard.", "<span class='notice'>You unfasten the mainboard.</span>")
 		if(8)
@@ -484,7 +484,7 @@
 				user.visible_message("[user] removes the peripherals control module from [parent].", "<span class='notice'>You remove the peripherals control module from [parent].</span>")
 		if(9)
 			if(diff==FORWARD)
-				user.visible_message("[user] installs the [I] into [parent].", "<span class='notice'>You install the [I] into [parent].</span>")
+				user.visible_message("[user] installs [I] into [parent].", "<span class='notice'>You install [I] into [parent].</span>")
 			else
 				user.visible_message("[user] unfastens the peripherals control module.", "<span class='notice'>You unfasten the peripherals control module.</span>")
 		if(10)
@@ -494,7 +494,7 @@
 				user.visible_message("[user] removes the weapon control module from [parent].", "<span class='notice'>You remove the weapon control module from [parent].</span>")
 		if(11)
 			if(diff==FORWARD)
-				user.visible_message("[user] installs the [I] to [parent].", "<span class='notice'>You install the [I] to [parent].</span>")
+				user.visible_message("[user] installs [I] to [parent].", "<span class='notice'>You install [I] to [parent].</span>")
 			else
 				user.visible_message("[user] unfastens the weapon control module.", "<span class='notice'>You unfasten the weapon control module.</span>")
 		if(12)
@@ -504,7 +504,7 @@
 				user.visible_message("[user] removes the scanner module from [parent].", "<span class='notice'>You remove the scanner module from [parent].</span>")
 		if(13)
 			if(diff==FORWARD)
-				user.visible_message("[user] installs the [I] to [parent].", "<span class='notice'>You install the [I] to [parent].</span>")
+				user.visible_message("[user] installs [I] to [parent].", "<span class='notice'>You install [I] to [parent].</span>")
 			else
 				user.visible_message("[user] unfastens the scanner module.", "<span class='notice'>You unfasten the scanner module.</span>")
 		if(14)
@@ -514,7 +514,7 @@
 				user.visible_message("[user] removes the capacitor from [parent].", "<span class='notice'>You remove the capacitor from [parent].</span>")
 		if(15)
 			if(diff==FORWARD)
-				user.visible_message("[user] installs the [I] into [parent].", "<span class='notice'>You install the [I] into [parent].</span>")
+				user.visible_message("[user] installs [I] into [parent].", "<span class='notice'>You install [I] into [parent].</span>")
 			else
 				user.visible_message("[user] unfastens the capacitor.", "<span class='notice'>You unfasten the capacitor.</span>")
 		if(16)
@@ -720,7 +720,7 @@
 				user.visible_message("[user] removes the wiring from [parent].", "<span class='notice'>You remove the wiring from [parent].</span>")
 		if(5)
 			if(diff==FORWARD)
-				user.visible_message("[user] installs the [I] into [parent].", "<span class='notice'>You install the [I] into [parent].</span>")
+				user.visible_message("[user] installs [I] into [parent].", "<span class='notice'>You install [I] into [parent].</span>")
 			else
 				user.visible_message("[user] disconnects the wiring of [parent].", "<span class='notice'>You disconnect the wiring of [parent].</span>")
 		if(6)
@@ -730,7 +730,7 @@
 				user.visible_message("[user] removes the central control module from [parent].", "<span class='notice'>You remove the central computer mainboard from [parent].</span>")
 		if(7)
 			if(diff==FORWARD)
-				user.visible_message("[user] installs the [I]into [parent].", "<span class='notice'>You install the [I]into [parent].</span>")
+				user.visible_message("[user] installs [I]into [parent].", "<span class='notice'>You install [I]into [parent].</span>")
 			else
 				user.visible_message("[user] unfastens the mainboard.", "<span class='notice'>You unfasten the mainboard.</span>")
 		if(8)
@@ -740,7 +740,7 @@
 				user.visible_message("[user] removes the peripherals control module from [parent].", "<span class='notice'>You remove the peripherals control module from [parent].</span>")
 		if(9)
 			if(diff==FORWARD)
-				user.visible_message("[user] installs the [I] into [parent].", "<span class='notice'>You install the [I] into [parent].</span>")
+				user.visible_message("[user] installs [I] into [parent].", "<span class='notice'>You install [I] into [parent].</span>")
 			else
 				user.visible_message("[user] unfastens the peripherals control module.", "<span class='notice'>You unfasten the peripherals control module.</span>")
 		if(10)
@@ -890,13 +890,13 @@
 	//TODO: better messages.
 	switch(index)
 		if(2)
-			user.visible_message("[user] installs the [I] into [parent].", "<span class='notice'>You install the [I] into [parent].</span>")
+			user.visible_message("[user] installs [I] into [parent].", "<span class='notice'>You install [I] into [parent].</span>")
 		if(4)
-			user.visible_message("[user] installs the [I] into [parent].", "<span class='notice'>You install the [I] into [parent].</span>")
+			user.visible_message("[user] installs [I] into [parent].", "<span class='notice'>You install [I] into [parent].</span>")
 		if(6)
-			user.visible_message("[user] installs the [I] into [parent].", "<span class='notice'>You install the [I] into [parent].</span>")
+			user.visible_message("[user] installs [I] into [parent].", "<span class='notice'>You install [I] into [parent].</span>")
 		if(8)
-			user.visible_message("[user] installs the [I] into [parent].", "<span class='notice'>You install the [I] into [parent].</span>")
+			user.visible_message("[user] installs [I] into [parent].", "<span class='notice'>You install [I] into [parent].</span>")
 		if(10)
 			user.visible_message("[user] puts [I] on [parent].", "<span class='notice'>You put [I] on [parent].</span>")
 		if(12)
@@ -1107,7 +1107,7 @@
 				user.visible_message("[user] removes the wiring from [parent].", "<span class='notice'>You remove the wiring from [parent].</span>")
 		if(5)
 			if(diff==FORWARD)
-				user.visible_message("[user] installs the [I] into [parent].", "<span class='notice'>You install the [I] into [parent].</span>")
+				user.visible_message("[user] installs [I] into [parent].", "<span class='notice'>You install [I] into [parent].</span>")
 			else
 				user.visible_message("[user] disconnects the wiring of [parent].", "<span class='notice'>You disconnect the wiring of [parent].</span>")
 		if(6)
@@ -1117,7 +1117,7 @@
 				user.visible_message("[user] removes the central control module from [parent].", "<span class='notice'>You remove the central computer mainboard from [parent].</span>")
 		if(7)
 			if(diff==FORWARD)
-				user.visible_message("[user] installs the [I] into [parent].", "<span class='notice'>You install the [I] into [parent].</span>")
+				user.visible_message("[user] installs [I] into [parent].", "<span class='notice'>You install [I] into [parent].</span>")
 			else
 				user.visible_message("[user] unfastens the mainboard.", "<span class='notice'>You unfasten the mainboard.</span>")
 		if(8)
@@ -1127,7 +1127,7 @@
 				user.visible_message("[user] removes the peripherals control module from [parent].", "<span class='notice'>You remove the peripherals control module from [parent].</span>")
 		if(9)
 			if(diff==FORWARD)
-				user.visible_message("[user] installs the [I] into [parent].", "<span class='notice'>You install the [I] into [parent].</span>")
+				user.visible_message("[user] installs [I] into [parent].", "<span class='notice'>You install [I] into [parent].</span>")
 			else
 				user.visible_message("[user] unfastens the peripherals control module.", "<span class='notice'>You unfasten the peripherals control module.</span>")
 		if(10)
@@ -1147,7 +1147,7 @@
 				user.visible_message("[user] removes the scanner module from [parent].", "<span class='notice'>You remove the scanner module from [parent].</span>")
 		if(13)
 			if(diff==FORWARD)
-				user.visible_message("[user] installs the [I] to [parent].", "<span class='notice'>You install the [I] to [parent].</span>")
+				user.visible_message("[user] installs [I] to [parent].", "<span class='notice'>You install [I] to [parent].</span>")
 			else
 				user.visible_message("[user] unfastens the scanner module.", "<span class='notice'>You unfasten the scanner module.</span>")
 		if(14)
@@ -1157,7 +1157,7 @@
 				user.visible_message("[user] removes the capacitor from [parent].", "<span class='notice'>You remove the capacitor from [parent].</span>")
 		if(15)
 			if(diff==FORWARD)
-				user.visible_message("[user] installs the [I] into [parent].", "<span class='notice'>You install the [I] into [parent].</span>")
+				user.visible_message("[user] installs [I] into [parent].", "<span class='notice'>You install [I] into [parent].</span>")
 			else
 				user.visible_message("[user] unfastens the capacitor.", "<span class='notice'>You unfasten the capacitor.</span>")
 		if(16)
@@ -1443,7 +1443,7 @@
 				user.visible_message("[user] removes the wiring from [parent].", "<span class='notice'>You remove the wiring from [parent].</span>")
 		if(5)
 			if(diff==FORWARD)
-				user.visible_message("[user] installs the [I] into [parent].", "<span class='notice'>You install the [I] into [parent].</span>")
+				user.visible_message("[user] installs [I] into [parent].", "<span class='notice'>You install [I] into [parent].</span>")
 			else
 				user.visible_message("[user] disconnects the wiring of [parent].", "<span class='notice'>You disconnect the wiring of [parent].</span>")
 		if(6)
@@ -1453,7 +1453,7 @@
 				user.visible_message("[user] removes the central control module from [parent].", "<span class='notice'>You remove the central computer mainboard from [parent].</span>")
 		if(7)
 			if(diff==FORWARD)
-				user.visible_message("[user] installs the [I] into [parent].", "<span class='notice'>You install the [I] into [parent].</span>")
+				user.visible_message("[user] installs [I] into [parent].", "<span class='notice'>You install [I] into [parent].</span>")
 			else
 				user.visible_message("[user] unfastens the mainboard.", "<span class='notice'>You unfasten the mainboard.</span>")
 		if(8)
@@ -1463,7 +1463,7 @@
 				user.visible_message("[user] removes the peripherals control module from [parent].", "<span class='notice'>You remove the peripherals control module from [parent].</span>")
 		if(9)
 			if(diff==FORWARD)
-				user.visible_message("[user] installs the [I] into [parent].", "<span class='notice'>You install the [I] into [parent].</span>")
+				user.visible_message("[user] installs [I] into [parent].", "<span class='notice'>You install [I] into [parent].</span>")
 			else
 				user.visible_message("[user] unfastens the peripherals control module.", "<span class='notice'>You unfasten the peripherals control module.</span>")
 		if(10)
@@ -1473,7 +1473,7 @@
 				user.visible_message("[user] removes the weapon control module from [parent].", "<span class='notice'>You remove the weapon control module from [parent].</span>")
 		if(11)
 			if(diff==FORWARD)
-				user.visible_message("[user] installs the [I] to [parent].", "<span class='notice'>You install the [I] to [parent].</span>")
+				user.visible_message("[user] installs [I] to [parent].", "<span class='notice'>You install [I] to [parent].</span>")
 			else
 				user.visible_message("[user] unfastens the weapon control module.", "<span class='notice'>You unfasten the weapon control module.</span>")
 		if(12)
@@ -1483,17 +1483,17 @@
 				user.visible_message("[user] removes the scanner module from [parent].", "<span class='notice'>You remove the scanner module from [parent].</span>")
 		if(13)
 			if(diff==FORWARD)
-				user.visible_message("[user] installs [I] to [parent].", "<span class='notice'>You install the [I] to [parent].</span>")
+				user.visible_message("[user] installs [I] to [parent].", "<span class='notice'>You install [I] to [parent].</span>")
 			else
 				user.visible_message("[user] unfastens the scanner module.", "<span class='notice'>You unfasten the scanner module.</span>")
 		if(14)
 			if(diff==FORWARD)
-				user.visible_message("[user] secures the [I].", "<span class='notice'>You secure the [I].</span>")
+				user.visible_message("[user] secures [I].", "<span class='notice'>You secure [I].</span>")
 			else
 				user.visible_message("[user] removes the capacitor from [parent].", "<span class='notice'>You remove the capacitor from [parent].</span>")
 		if(15)
 			if(diff==FORWARD)
-				user.visible_message("[user] installs the [I].", "<span class='notice'>You install the [I].</span>")
+				user.visible_message("[user] installs [I].", "<span class='notice'>You install [I].</span>")
 			else
 				user.visible_message("[user] unsecures the capacitor from [parent].", "<span class='notice'>You unsecure the capacitor from [parent].</span>")
 		if(16)
@@ -1508,7 +1508,7 @@
 				user.visible_message("[user] disconnects the bluespace crystal from [parent].", "<span class='notice'>You disconnect the bluespace crystal from [parent].</span>")
 		if(18)
 			if(diff==FORWARD)
-				user.visible_message("[user] installs the [I] into [parent].", "<span class='notice'>You install the [I] into [parent].</span>")
+				user.visible_message("[user] installs [I] into [parent].", "<span class='notice'>You install [I] into [parent].</span>")
 			else
 				user.visible_message("[user] disengages the bluespace crystal.", "<span class='notice'>You disengage the bluespace crystal.</span>")
 		if(19)
@@ -1712,7 +1712,7 @@
 				user.visible_message("[user] removes the wiring from [parent].", "<span class='notice'>You remove the wiring from [parent].</span>")
 		if(5)
 			if(diff==FORWARD)
-				user.visible_message("[user] installs the [I] into [parent].", "<span class='notice'>You install the [I] into [parent].</span>")
+				user.visible_message("[user] installs [I] into [parent].", "<span class='notice'>You install [I] into [parent].</span>")
 			else
 				user.visible_message("[user] disconnects the wiring of [parent].", "<span class='notice'>You disconnect the wiring of [parent].</span>")
 		if(6)
@@ -1722,7 +1722,7 @@
 				user.visible_message("[user] removes the central control module from [parent].", "<span class='notice'>You remove the central computer mainboard from [parent].</span>")
 		if(7)
 			if(diff==FORWARD)
-				user.visible_message("[user] installs the [I] into [parent].", "<span class='notice'>You install the [I] into [parent].</span>")
+				user.visible_message("[user] installs [I] into [parent].", "<span class='notice'>You install [I] into [parent].</span>")
 			else
 				user.visible_message("[user] unfastens the mainboard.", "<span class='notice'>You unfasten the mainboard.</span>")
 		if(8)
@@ -1732,7 +1732,7 @@
 				user.visible_message("[user] removes the peripherals control module from [parent].", "<span class='notice'>You remove the peripherals control module from [parent].</span>")
 		if(9)
 			if(diff==FORWARD)
-				user.visible_message("[user] installs the [I] into [parent].", "<span class='notice'>You install the [I] into [parent].</span>")
+				user.visible_message("[user] installs [I] into [parent].", "<span class='notice'>You install [I] into [parent].</span>")
 			else
 				user.visible_message("[user] unfastens the peripherals control module.", "<span class='notice'>You unfasten the peripherals control module.</span>")
 		if(10)


### PR DESCRIPTION
:cl: Denton
spellcheck: Mech construction messages no longer incorrectly mention high-tier stock parts.
/:cl:

Many mech construction messages mention T3/T4 stock parts, which is flat out wrong. You can use any tier of stock part; the higher, the more EMP resistance/less power consumption.