### PR TITLE
Magicarp now are named after their bolt type

### DIFF
--- a/code/modules/events/wizard/magicarp.dm
+++ b/code/modules/events/wizard/magicarp.dm
@@ -39,9 +39,12 @@
 	var/allowed_projectile_types = list(/obj/item/projectile/magic/change, /obj/item/projectile/magic/animate, /obj/item/projectile/magic/resurrection,
 	/obj/item/projectile/magic/death, /obj/item/projectile/magic/teleport, /obj/item/projectile/magic/door, /obj/item/projectile/magic/aoe/fireball,
 	/obj/item/projectile/magic/spellblade, /obj/item/projectile/magic/arcane_barrage)
+	var/chaos = FALSE
 	
 /mob/living/simple_animal/hostile/carp/ranged/Initialize()
 	projectiletype = pick(allowed_projectile_types)
+	if(!chaos && initial(name) == name)
+		name = "[initial(projectiletype.name)] [name]"
 	. = ..()
 
 /mob/living/simple_animal/hostile/carp/ranged/chaos
@@ -50,7 +53,9 @@
 	color = "#00FFFF"
 	maxHealth = 75
 	health = 75
+	chaos = TRUE
 
 /mob/living/simple_animal/hostile/carp/ranged/chaos/Shoot()
-	projectiletype = pick(allowed_projectile_types)
+	if(chaos)
+		projectiletype = pick(allowed_projectile_types)
 	..()

--- a/code/modules/mob/living/simple_animal/hostile/hostile.dm
+++ b/code/modules/mob/living/simple_animal/hostile/hostile.dm
@@ -14,7 +14,7 @@
 	var/dodge_prob = 30
 	var/sidestep_per_cycle = 1 //How many sidesteps per npcpool cycle when in melee
 
-	var/projectiletype	//set ONLY it and NULLIFY casingtype var, if we have ONLY projectile
+	var/obj/item/projectile/projectiletype	//set ONLY it and NULLIFY casingtype var, if we have ONLY projectile
 	var/projectilesound
 	var/casingtype		//set ONLY it and NULLIFY projectiletype, if we have projectile IN CASING
 	var/move_to_delay = 3 //delay for the automated movement.


### PR DESCRIPTION
> That's a bolt of death magicarp
> 50% magic, 50% carp, 100% horrible.

:cl: coiax
add: Magicarp are now named after the type of magical bolt that they
shoot at people.
/:cl:

Minor buff to Xenobio, as you can now determine a carp's bolt type
without waking it up.

Chaos magicarp are unaffected, and are still called chaos magicarp.