### PR TITLE
Ops have an intelligence potion instead of PDA bombs

### DIFF
--- a/_maps/map_files/generic/CentCom.dmm
+++ b/_maps/map_files/generic/CentCom.dmm
@@ -6520,6 +6520,9 @@
 "sg" = (
 /obj/structure/table/wood,
 /obj/item/pizzabox,
+/obj/item/slimepotion/slime/sentience/nuclear{
+	pixel_y = 10
+	},
 /turf/open/floor/plasteel/bar{
 	dir = 2
 	},

--- a/code/game/objects/structures/crates_lockers/closets/syndicate.dm
+++ b/code/game/objects/structures/crates_lockers/closets/syndicate.dm
@@ -25,7 +25,6 @@
 	new /obj/item/storage/box/flashbangs(src)
 	new /obj/item/storage/box/teargas(src)
 	new /obj/item/storage/backpack/duffelbag/syndie/med(src)
-	new /obj/item/pda/syndicate(src)
 
 /obj/structure/closet/syndicate/resources
 	desc = "An old, dusty locker."


### PR DESCRIPTION
:cl: coiax
del: Nuclear operatives no longer are issued a free PDA with a
Detomatix cartridge.
add: Instead, they are given a syndicate intelligence potion, which may
be used on any simple animal in the vicinity.
/:cl:

![image](https://user-images.githubusercontent.com/609465/44687775-00a64a80-aa4a-11e8-90d3-29964596e397.png)

PDA bombs are a new player trap. Everyone at this point associates PDA
bombs with nuke ops, because no one really uses them as a regular
traitor since they're not cost effective.

With this PR, ops (most of the time) gain a talking unlimited
jetpack that can be injected with explosives. Detomatix catridges can
still be bought.

Although the ops are losing 6 TC of equipment, and gaining only 4 TC, I
think this is far more suited to their aims and plans.