### PR TITLE
Fixes wizard objective equipment.

### DIFF
--- a/code/modules/antagonists/wizard/wizard.dm
+++ b/code/modules/antagonists/wizard/wizard.dm
@@ -16,9 +16,9 @@
 
 /datum/antagonist/wizard/on_gain()
 	register()
+	equip_wizard()
 	if(give_objectives)
 		create_objectives()
-	equip_wizard()
 	if(move_to_lair)
 		send_to_lair()
 	. = ..()


### PR DESCRIPTION
Fixes #39947 

The moment this happens needs to be made explicit not sewn somewhere in objective creation but that's another PR.