### PR TITLE
Re-removes drooling and brain damage lines from brainloss

### DIFF
--- a/code/modules/mob/living/carbon/human/life.dm
+++ b/code/modules/mob/living/carbon/human/life.dm
@@ -66,13 +66,8 @@
 	else if(eye_blurry)			//blurry eyes heal slowly
 		adjust_blurriness(-1)
 
-	if (getBrainLoss() >= 60 && !incapacitated(TRUE))
+	if (getBrainLoss() >= 60)
 		SEND_SIGNAL(src, COMSIG_ADD_MOOD_EVENT, "brain_damage", /datum/mood_event/brain_damage)
-		if(prob(3))
-			if(prob(25))
-				emote("drool")
-			else
-				say(pick_list_replacements(BRAIN_DAMAGE_FILE, "brain_damage"))
 	else
 		SEND_SIGNAL(src, COMSIG_CLEAR_MOOD_EVENT, "brain_damage")
 


### PR DESCRIPTION
:cl: XDTM
del: Removed the chance of spouting brain damage lines when over 60 brain damage. The dumbness trauma still has them.
/:cl:

These were removed intentionally with traumas to make brain damage different for everyone, instead of being generic IQ reduction. Those effects have been placed in the dumbness trauma. I'm not sure if it was readded with moodlets or by someone else, but it shouldn't be there.