### PR TITLE
Comfy computer lighting and a vis_contents overlay system foundation

### DIFF
--- a/code/__DEFINES/subsystems.dm
+++ b/code/__DEFINES/subsystems.dm
@@ -51,36 +51,37 @@
 // Subsystems shutdown in the reverse of the order they initialize in
 // The numbers just define the ordering, they are meaningless otherwise.
 
-#define INIT_ORDER_GARBAGE 19
-#define INIT_ORDER_DBCORE 18
-#define INIT_ORDER_BLACKBOX 17
-#define INIT_ORDER_SERVER_MAINT 16
-#define INIT_ORDER_INPUT 15
-#define INIT_ORDER_RESEARCH 14
-#define INIT_ORDER_EVENTS 13
-#define INIT_ORDER_JOBS 12
-#define INIT_ORDER_QUIRKS 11
-#define INIT_ORDER_TICKER 10
-#define INIT_ORDER_MAPPING 9
-#define INIT_ORDER_NETWORKS 8
-#define INIT_ORDER_ATOMS 7
-#define INIT_ORDER_LANGUAGE 6
-#define INIT_ORDER_MACHINES 5
-#define INIT_ORDER_CIRCUIT 4
-#define INIT_ORDER_TIMER 1
-#define INIT_ORDER_DEFAULT 0
-#define INIT_ORDER_AIR -1
-#define INIT_ORDER_MINIMAP -3
-#define INIT_ORDER_ASSETS -4
-#define INIT_ORDER_ICON_SMOOTHING -5
-#define INIT_ORDER_OVERLAY -6
-#define INIT_ORDER_XKEYSCORE -10
-#define INIT_ORDER_STICKY_BAN -10
-#define INIT_ORDER_LIGHTING -20
-#define INIT_ORDER_SHUTTLE -21
-#define INIT_ORDER_SQUEAK -40
-#define INIT_ORDER_PATH -50
-#define INIT_ORDER_PERSISTENCE -100
+#define INIT_ORDER_GARBAGE			19
+#define INIT_ORDER_DBCORE			18
+#define INIT_ORDER_BLACKBOX			17
+#define INIT_ORDER_SERVER_MAINT		16
+#define INIT_ORDER_INPUT			15
+#define INIT_ORDER_VIS				14
+#define INIT_ORDER_RESEARCH			13
+#define INIT_ORDER_EVENTS			12
+#define INIT_ORDER_JOBS				11
+#define INIT_ORDER_QUIRKS			10
+#define INIT_ORDER_TICKER			9
+#define INIT_ORDER_MAPPING			8
+#define INIT_ORDER_NETWORKS			7
+#define INIT_ORDER_ATOMS			6
+#define INIT_ORDER_LANGUAGE			5
+#define INIT_ORDER_MACHINES			4
+#define INIT_ORDER_CIRCUIT			3
+#define INIT_ORDER_TIMER			1
+#define INIT_ORDER_DEFAULT			0
+#define INIT_ORDER_AIR				-1
+#define INIT_ORDER_MINIMAP			-3
+#define INIT_ORDER_ASSETS			-4
+#define INIT_ORDER_ICON_SMOOTHING	-5
+#define INIT_ORDER_OVERLAY			-6
+#define INIT_ORDER_XKEYSCORE		-10
+#define INIT_ORDER_STICKY_BAN		-10
+#define INIT_ORDER_LIGHTING			-20
+#define INIT_ORDER_SHUTTLE			-21
+#define INIT_ORDER_SQUEAK			-40
+#define INIT_ORDER_PATH				-50
+#define INIT_ORDER_PERSISTENCE		-100
 
 // Subsystem fire priority, from lowest to highest priority
 // If the subsystem isn't listed here it's either DEFAULT or PROCESS (if it's a processing subsystem child)
@@ -89,6 +90,7 @@
 #define FIRE_PRIORITY_IDLE_NPC		10
 #define FIRE_PRIORITY_SERVER_MAINT	10
 #define FIRE_PRIORITY_RESEARCH		10
+#define FIRE_PRIORITY_VIS			10
 #define FIRE_PRIORITY_GARBAGE		15
 #define FIRE_PRIORITY_WET_FLOORS	20
 #define FIRE_PRIORITY_AIR			20

--- a/code/controllers/subsystem/vis_overlays.dm
+++ b/code/controllers/subsystem/vis_overlays.dm
@@ -1,0 +1,75 @@
+SUBSYSTEM_DEF(vis_overlays)
+	name = "Vis contents overlays"
+	wait = 1 MINUTES
+	priority = FIRE_PRIORITY_VIS
+	init_order = INIT_ORDER_VIS
+
+	var/list/vis_overlay_cache
+	var/list/currentrun
+	var/datum/callback/rotate_cb
+
+/datum/controller/subsystem/vis_overlays/Initialize()
+	vis_overlay_cache = list()
+	rotate_cb = CALLBACK(src, .proc/rotate_vis_overlay)
+	return ..()
+
+/datum/controller/subsystem/vis_overlays/fire(resumed = FALSE)
+	if(!resumed)
+		currentrun = vis_overlay_cache.Copy()
+	var/list/current_run = currentrun
+
+	while(current_run.len)
+		var/key = current_run[current_run.len]
+		var/obj/effect/overlay/vis/overlay = current_run[key]
+		current_run.len--
+		if(!overlay.unused && !length(overlay.vis_locs))
+			overlay.unused = world.time
+		else if(overlay.unused && overlay.unused + overlay.cache_expiration < world.time)
+			vis_overlay_cache -= key
+			qdel(overlay)
+		if(MC_TICK_CHECK)
+			return
+
+//the "thing" var can be anything with vis_contents which includes images
+/datum/controller/subsystem/vis_overlays/proc/add_vis_overlay(atom/movable/thing, icon, iconstate, layer, plane, dir, alpha=255)
+	. = "[icon]|[iconstate]|[layer]|[plane]|[dir]|[alpha]"
+	var/obj/effect/overlay/vis/overlay = vis_overlay_cache[.]
+	if(!overlay)
+		overlay = new
+		overlay.icon = icon
+		overlay.icon_state = iconstate
+		overlay.layer = layer
+		overlay.plane = plane
+		overlay.dir = dir
+		overlay.alpha = alpha
+		vis_overlay_cache[.] = overlay
+	else
+		overlay.unused = 0
+	thing.vis_contents += overlay
+
+	if(!isatom(thing)) // Automatic rotation is not supported on non atoms
+		return
+
+	if(!thing.managed_vis_overlays)
+		thing.managed_vis_overlays = list(overlay)
+		RegisterSignal(thing, COMSIG_ATOM_DIR_CHANGE, rotate_cb)
+	else
+		thing.managed_vis_overlays += overlay
+
+/datum/controller/subsystem/vis_overlays/proc/remove_vis_overlay(atom/movable/thing, list/overlays)
+	thing.vis_contents -= overlays
+	if(!isatom(thing))
+		return
+	thing.managed_vis_overlays -= overlays
+	if(!length(thing.managed_vis_overlays))
+		thing.managed_vis_overlays = null
+		UnregisterSignal(thing, COMSIG_ATOM_DIR_CHANGE)
+
+/datum/controller/subsystem/vis_overlays/proc/rotate_vis_overlay(atom/thing, old_dir, new_dir)
+	var/rotation = dir2angle(old_dir) - dir2angle(new_dir)
+	var/list/overlays_to_remove = list()
+	for(var/i in thing.managed_vis_overlays)
+		var/obj/effect/overlay/vis/overlay = i
+		add_vis_overlay(thing, overlay.icon, overlay.icon_state, overlay.layer, overlay.plane, turn(overlay.dir, rotation))
+		overlays_to_remove += overlay
+	remove_vis_overlay(thing, overlays_to_remove)

--- a/code/game/atoms.dm
+++ b/code/game/atoms.dm
@@ -24,6 +24,8 @@
 	var/list/remove_overlays // a very temporary list of overlays to remove
 	var/list/add_overlays // a very temporary list of overlays to add
 
+	var/list/managed_vis_overlays //vis overlays managed by SSvis_overlays to automaticaly turn them like other overlays
+
 	var/datum/proximity_monitor/proximity_monitor
 	var/buckle_message_cooldown = 0
 	var/fingerprintslast

--- a/code/game/machinery/computer/_computer.dm
+++ b/code/game/machinery/computer/_computer.dm
@@ -9,7 +9,7 @@
 	max_integrity = 200
 	integrity_failure = 100
 	armor = list("melee" = 0, "bullet" = 0, "laser" = 0, "energy" = 0, "bomb" = 0, "bio" = 0, "rad" = 0, "fire" = 40, "acid" = 20)
-	var/brightness_on = 2
+	var/brightness_on = 1
 	var/icon_keyboard = "generic_key"
 	var/icon_screen = "generic"
 	var/clockwork = FALSE
@@ -49,14 +49,19 @@
 
 /obj/machinery/computer/update_icon()
 	cut_overlays()
+	SSvis_overlays.remove_vis_overlay(src, managed_vis_overlays)
 	if(stat & NOPOWER)
 		add_overlay("[icon_keyboard]_off")
 		return
 	add_overlay(icon_keyboard)
+
+	// This whole block lets screens ignore lighting and be visible even in the darkest room
+	// We can't do this for many things that emit light unfortunately because it layers over things that would be on top of it
+	var/overlay_state = icon_screen
 	if(stat & BROKEN)
-		add_overlay("[icon_state]_broken")
-	else
-		add_overlay(icon_screen)
+		overlay_state = "[icon_state]_broken"
+	SSvis_overlays.add_vis_overlay(src, icon, overlay_state, layer, plane, dir)
+	SSvis_overlays.add_vis_overlay(src, icon, overlay_state, ABOVE_LIGHTING_LAYER, ABOVE_LIGHTING_PLANE, dir, alpha=128)
 
 /obj/machinery/computer/power_change()
 	..()

--- a/code/game/objects/effects/overlays.dm
+++ b/code/game/objects/effects/overlays.dm
@@ -45,3 +45,9 @@
 	icon = 'icons/effects/effects.dmi'
 	icon_state = "shieldsparkles"
 	anchored = TRUE
+
+/obj/effect/overlay/vis
+	mouse_opacity = MOUSE_OPACITY_TRANSPARENT
+	anchored = TRUE
+	var/unused = 0 //When detected to be unused it gets set to world.time, after a while it gets removed
+	var/cache_expiration = 2 MINUTES // overlays which go unused for 2 minutes get cleaned up

--- a/code/modules/power/apc.dm
+++ b/code/modules/power/apc.dm
@@ -300,19 +300,17 @@
 			icon_state = "apc0"
 
 	if(!(update_state & UPSTATE_ALLGOOD))
-		cut_overlays()
+		SSvis_overlays.remove_vis_overlay(src, managed_vis_overlays)
 
 	if(update & 2)
-		cut_overlays()
+		SSvis_overlays.remove_vis_overlay(src, managed_vis_overlays)
 		if(!(stat & (BROKEN|MAINT)) && update_state & UPSTATE_ALLGOOD)
-			var/list/O = list(
-				"apcox-[locked]",
-				"apco3-[charging]")
+			SSvis_overlays.add_vis_overlay(src, icon, "apcox-[locked]", ABOVE_LIGHTING_LAYER, ABOVE_LIGHTING_PLANE, dir)
+			SSvis_overlays.add_vis_overlay(src, icon, "apco3-[charging]", ABOVE_LIGHTING_LAYER, ABOVE_LIGHTING_PLANE, dir)
 			if(operating)
-				O += "apco0-[equipment]"
-				O += "apco1-[lighting]"
-				O += "apco2-[environ]"
-			add_overlay(O)
+				SSvis_overlays.add_vis_overlay(src, icon, "apco0-[equipment]", ABOVE_LIGHTING_LAYER, ABOVE_LIGHTING_PLANE, dir)
+				SSvis_overlays.add_vis_overlay(src, icon, "apco1-[lighting]", ABOVE_LIGHTING_LAYER, ABOVE_LIGHTING_PLANE, dir)
+				SSvis_overlays.add_vis_overlay(src, icon, "apco2-[environ]", ABOVE_LIGHTING_LAYER, ABOVE_LIGHTING_PLANE, dir)
 
 	// And now, separately for cleanness, the lighting changing
 	if(update_state & UPSTATE_ALLGOOD)

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -257,6 +257,7 @@
 #include "code\controllers\subsystem\timer.dm"
 #include "code\controllers\subsystem\title.dm"
 #include "code\controllers\subsystem\traumas.dm"
+#include "code\controllers\subsystem\vis_overlays.dm"
 #include "code\controllers\subsystem\vote.dm"
 #include "code\controllers\subsystem\weather.dm"
 #include "code\controllers\subsystem\processing\circuit.dm"


### PR DESCRIPTION
:cl:
add: Computers are now visible even in the darkest of rooms. Comfy!
tweak: Because computers are now far easier to find in dark rooms their base light output has been reduced.
/:cl:

Not fully satisfied with this system but it gets the framework in place. The cache expiration may be unnecessary but it prevents the cached overlays list from just always growing.

Using this system I made some screens ignore the lighting so they are always visible. There are serious limitations to our ability to do this (they get layered on top of things that should be on top of them) but with computer screens and apcs at least they shouldn't be an issue.

Before
![image](https://user-images.githubusercontent.com/1234602/44734754-a0022680-aab8-11e8-9084-7d1de91d908c.png)
After
![image](https://user-images.githubusercontent.com/1234602/44734767-aa242500-aab8-11e8-8052-21ac04702db1.png)

Yeah these don't *have* to be vis_contents overlays but I want to throw more of these in so we can get some good data on them compared to regular overlays. Things which change a lot between overlays should benefit with vis_contents over regular overlays.