### PR TITLE
Remove base types from get_random_drink()

### DIFF
--- a/code/__HELPERS/unsorted.dm
+++ b/code/__HELPERS/unsorted.dm
@@ -1459,6 +1459,7 @@ GLOBAL_DATUM_INIT(dview_mob, /mob/dview, new)
 		/obj/item/reagent_containers/food/snacks/soup,
 		/obj/item/reagent_containers/food/snacks/grown,
 		/obj/item/reagent_containers/food/snacks/grown/mushroom,
+		/obj/item/reagent_containers/food/snacks/grown/nettle, // base type
 		/obj/item/reagent_containers/food/snacks/deepfryholder
 		)
 	blocked |= typesof(/obj/item/reagent_containers/food/snacks/customizable)
@@ -1467,8 +1468,7 @@ GLOBAL_DATUM_INIT(dview_mob, /mob/dview, new)
 
 /proc/get_random_drink()
 	var/list/blocked = list(/obj/item/reagent_containers/food/drinks/soda_cans,
-	/obj/item/reagent_containers/food/drinks/bottle,
-	/obj/item/reagent_containers/food/snacks/grown/nettle // base type
+	/obj/item/reagent_containers/food/drinks/bottle
 	)	
 	return pick(subtypesof(/obj/item/reagent_containers/food/drinks) - blocked)
 

--- a/code/__HELPERS/unsorted.dm
+++ b/code/__HELPERS/unsorted.dm
@@ -1466,7 +1466,11 @@ GLOBAL_DATUM_INIT(dview_mob, /mob/dview, new)
 	return pick(typesof(/obj/item/reagent_containers/food/snacks) - blocked)
 
 /proc/get_random_drink()
-	return pick(subtypesof(/obj/item/reagent_containers/food/drinks))
+	var/list/blocked = list(/obj/item/reagent_containers/food/drinks/soda_cans,
+	/obj/item/reagent_containers/food/drinks/bottle,
+	/obj/item/reagent_containers/food/snacks/grown/nettle // base type
+	)	
+	return pick(subtypesof(/obj/item/reagent_containers/food/drinks) - blocked)
 
 //For these two procs refs MUST be ref = TRUE format like typecaches!
 /proc/weakref_filter_list(list/things, list/refs)

--- a/code/__HELPERS/unsorted.dm
+++ b/code/__HELPERS/unsorted.dm
@@ -1468,8 +1468,8 @@ GLOBAL_DATUM_INIT(dview_mob, /mob/dview, new)
 
 /proc/get_random_drink()
 	var/list/blocked = list(/obj/item/reagent_containers/food/drinks/soda_cans,
-	/obj/item/reagent_containers/food/drinks/bottle
-	)	
+		/obj/item/reagent_containers/food/drinks/bottle
+		)	
 	return pick(subtypesof(/obj/item/reagent_containers/food/drinks) - blocked)
 
 //For these two procs refs MUST be ref = TRUE format like typecaches!


### PR DESCRIPTION
:cl: 
fix: remove base types not meant to spawn from get_random_drink and from the silver-slime spawnlist.
/:cl:

[why]: 
Fixes #39974 

The nettle typepath change of #39763 seems to be a bit inconsistent regarding nettle vs subtypes nettle/basic and nettle/death .