### PR TITLE
Fix lava not igniting thrown objects on landing.

### DIFF
--- a/code/game/turfs/simulated/lava.dm
+++ b/code/game/turfs/simulated/lava.dm
@@ -30,12 +30,10 @@
 	initial_gas_mix = "TEMP=2.7"
 
 /turf/open/lava/Entered(atom/movable/AM)
-	if(burn_stuff(AM))
-		START_PROCESSING(SSobj, src)
+	START_PROCESSING(SSobj, src)
 
 /turf/open/lava/hitby(atom/movable/AM)
-	if(burn_stuff(AM))
-		START_PROCESSING(SSobj, src)
+	START_PROCESSING(SSobj, src)
 
 /turf/open/lava/process()
 	if(!burn_stuff())

--- a/code/game/turfs/simulated/lava.dm
+++ b/code/game/turfs/simulated/lava.dm
@@ -30,10 +30,12 @@
 	initial_gas_mix = "TEMP=2.7"
 
 /turf/open/lava/Entered(atom/movable/AM)
-	START_PROCESSING(SSobj, src)
+	if(burn_stuff(AM))
+		START_PROCESSING(SSobj, src)
 
 /turf/open/lava/hitby(atom/movable/AM)
-	START_PROCESSING(SSobj, src)
+	if(burn_stuff(AM))
+		START_PROCESSING(SSobj, src)
 
 /turf/open/lava/process()
 	if(!burn_stuff())
@@ -94,10 +96,10 @@
 		thing_to_check = list(AM)
 	for(var/thing in thing_to_check)
 		if(isobj(thing))
+			. = 1
 			var/obj/O = thing
 			if((O.resistance_flags & (LAVA_PROOF|INDESTRUCTIBLE)) || O.throwing)
 				continue
-			. = 1
 			if((O.resistance_flags & (ON_FIRE)))
 				continue
 			if(!(O.resistance_flags & FLAMMABLE))


### PR DESCRIPTION
Sets the lava turf to process. It'll burn_stuff or not the following tick.

:cl:
fix: Lava turfs will now consistently burn things thrown on them.
/:cl:

Fixes #39066