### PR TITLE
Adds nanite circuit boards to tech storage

### DIFF
--- a/code/game/objects/effects/spawners/lootdrop.dm
+++ b/code/game/objects/effects/spawners/lootdrop.dm
@@ -240,16 +240,20 @@
 
 /obj/effect/spawner/lootdrop/techstorage/rnd
 	name = "RnD circuit board spawner"
-	lootcount = 8
+	lootcount = 12
 	loot = list(
 				/obj/item/circuitboard/computer/aifixer,
 				/obj/item/circuitboard/machine/rdserver,
-				/obj/item/circuitboard/computer/pandemic,
 				/obj/item/circuitboard/machine/mechfab,
 				/obj/item/circuitboard/machine/circuit_imprinter/department,
 				/obj/item/circuitboard/computer/teleporter,
 				/obj/item/circuitboard/machine/destructive_analyzer,
-				/obj/item/circuitboard/computer/rdconsole
+				/obj/item/circuitboard/computer/rdconsole,
+				/obj/item/circuitboard/computer/nanite_chamber_control,
+				/obj/item/circuitboard/computer/nanite_cloud_controller,
+				/obj/item/circuitboard/machine/nanite_chamber,
+				/obj/item/circuitboard/machine/nanite_programmer,
+				/obj/item/circuitboard/machine/nanite_program_hub
 				)
 
 /obj/effect/spawner/lootdrop/techstorage/security
@@ -287,7 +291,7 @@
 
 /obj/effect/spawner/lootdrop/techstorage/medical
 	name = "medical circuit board spawner"
-	lootcount = 8
+	lootcount = 9
 	loot = list(
 				/obj/item/circuitboard/computer/cloning,
 				/obj/item/circuitboard/machine/clonepod,
@@ -296,7 +300,8 @@
 				/obj/item/circuitboard/computer/med_data,
 				/obj/item/circuitboard/machine/smoke_machine,
 				/obj/item/circuitboard/machine/chem_master,
-				/obj/item/circuitboard/machine/clonescanner
+				/obj/item/circuitboard/machine/clonescanner,
+				/obj/item/circuitboard/computer/pandemic
 				)
 
 /obj/effect/spawner/lootdrop/techstorage/AI


### PR DESCRIPTION
:cl: Denton
tweak: Added nanite circuit boards to tech storage.
/:cl:

Nanite boards are (iirc) the only ones missing from tech storage. I also moved the PANDEMIC board from the RnD pile to the medical pile.