### PR TITLE
Adjusts wood golem color to match their respective material.

### DIFF
--- a/code/modules/mob/living/carbon/human/species_types/golems.dm
+++ b/code/modules/mob/living/carbon/human/species_types/golems.dm
@@ -262,7 +262,7 @@
 /datum/species/golem/wood
 	name = "Wood Golem"
 	id = "wood golem"
-	fixed_mut_color = "B78B67"
+	fixed_mut_color = "9E704B"
 	meat = /obj/item/stack/sheet/mineral/wood
 	//Can burn and take damage from heat
 	inherent_traits = list(TRAIT_NOBREATH, TRAIT_RESISTCOLD,TRAIT_RESISTHIGHPRESSURE,TRAIT_RESISTLOWPRESSURE,TRAIT_NOGUNS,TRAIT_RADIMMUNE,TRAIT_PIERCEIMMUNE,TRAIT_NODISMEMBER)

--- a/code/modules/mob/living/carbon/human/species_types/golems.dm
+++ b/code/modules/mob/living/carbon/human/species_types/golems.dm
@@ -262,7 +262,7 @@
 /datum/species/golem/wood
 	name = "Wood Golem"
 	id = "wood golem"
-	fixed_mut_color = "49311c"
+	fixed_mut_color = "B78B67"
 	meat = /obj/item/stack/sheet/mineral/wood
 	//Can burn and take damage from heat
 	inherent_traits = list(TRAIT_NOBREATH, TRAIT_RESISTCOLD,TRAIT_RESISTHIGHPRESSURE,TRAIT_RESISTLOWPRESSURE,TRAIT_NOGUNS,TRAIT_RADIMMUNE,TRAIT_PIERCEIMMUNE,TRAIT_NODISMEMBER)


### PR DESCRIPTION
:cl: Potato Masher
tweak: The color of Wooden golems should be more in line with the color of the wood used to make it.
/:cl:

This has always bothered me, but wood golems have always been a super dark brown that almost no other wood object has. On top of that, the wood planks used to make them are a much lighter color.
Mostly just a consistency change.

Before:
![wood_golem](https://user-images.githubusercontent.com/33107541/44849829-5b49cd00-ac29-11e8-8893-08c4ed18cb0d.png)

After:
![dreamseeker_2018-08-30_07-44-07](https://user-images.githubusercontent.com/33107541/44849842-63097180-ac29-11e8-97d2-7bc68cc349e5.png)
