### PR TITLE
Easier admin varedits for movespeed

### DIFF
--- a/code/modules/mob/mob_defines.dm
+++ b/code/modules/mob/mob_defines.dm
@@ -42,6 +42,7 @@
 	//MOVEMENT SPEED
 	var/list/movespeed_modification				//Lazy list, see mob_movespeed.dm
 	var/cached_multiplicative_slowdown
+	var/admin_movespeed = 0
 	/////////////////
 
 	var/name_archive //For admin things like possession

--- a/code/modules/mob/mob_movespeed.dm
+++ b/code/modules/mob/mob_movespeed.dm
@@ -31,7 +31,7 @@
 
 /mob/vv_edit_var(var_name, var_value)
 	. = ..()
-	if(. && (var_name == NAMEOF(src, admin_movespeed))
+	if(. && (var_name == NAMEOF(src, admin_movespeed)))
 		if(isnum(var_value))
 			add_movespeed_modifier(MOVESPEED_ID_ADMIN_VAREDIT, TRUE, 100, override = TRUE, multiplicative_slowdown = var_value)
 		else		//nonsensical value

--- a/code/modules/mob/mob_movespeed.dm
+++ b/code/modules/mob/mob_movespeed.dm
@@ -30,14 +30,12 @@
 	return TRUE
 
 /mob/vv_edit_var(var_name, var_value)
-	var/slowdown_edit = (var_name == NAMEOF(src, cached_multiplicative_slowdown))
-	var/diff
-	if(slowdown_edit && isnum(cached_multiplicative_slowdown) && isnum(var_value))
-		remove_movespeed_modifier(MOVESPEED_ID_ADMIN_VAREDIT)
-		diff = var_value - cached_multiplicative_slowdown
 	. = ..()
-	if(. && slowdown_edit && isnum(diff))
-		add_movespeed_modifier(MOVESPEED_ID_ADMIN_VAREDIT, TRUE, 100, override = TRUE, multiplicative_slowdown = diff)
+	if(. && (var_name == NAMEOF(src, admin_movespeed))
+		if(isnum(var_value))
+			add_movespeed_modifier(MOVESPEED_ID_ADMIN_VAREDIT, TRUE, 100, override = TRUE, multiplicative_slowdown = var_value)
+		else		//nonsensical value
+			remove_movespeed_modifier(MOVESPEED_ID_ADMIN_VAREDIT)
 
 /mob/proc/has_movespeed_modifier(id)
 	return LAZYACCESS(movespeed_modification, id)


### PR DESCRIPTION
admin_movespeed variable added.
If this is edited:
If the new value is a number, it is added to movespeed modifications on the mob, overwriting the previous if it exists.
If the new value is ANYTHING else or 0, the admin movespeed modifier is removed.