### PR TITLE
Lets dispensers add 5u to buckets, plastic and meta beakers.

### DIFF
--- a/code/modules/reagents/reagent_containers/glass.dm
+++ b/code/modules/reagents/reagent_containers/glass.dm
@@ -172,7 +172,7 @@
 	materials = list(MAT_GLASS=2500, MAT_PLASTIC=3000)
 	volume = 120
 	amount_per_transfer_from_this = 10
-	possible_transfer_amounts = list(10,15,20,25,30,60,120)
+	possible_transfer_amounts = list(5,10,15,20,25,30,60,120)
 
 /obj/item/reagent_containers/glass/beaker/plastic/update_icon()
 	icon_state = "beakerlarge" // hack to lets us reuse the large beaker reagent fill states
@@ -186,7 +186,7 @@
 	materials = list(MAT_GLASS=2500, MAT_PLASTIC=3000, MAT_GOLD=1000, MAT_TITANIUM=1000)
 	volume = 180
 	amount_per_transfer_from_this = 10
-	possible_transfer_amounts = list(10,15,20,25,30,60,120,180)
+	possible_transfer_amounts = list(5,10,15,20,25,30,60,120,180)
 
 /obj/item/reagent_containers/glass/beaker/noreact
 	name = "cryostasis beaker"
@@ -251,7 +251,7 @@
 	materials = list(MAT_METAL=200)
 	w_class = WEIGHT_CLASS_NORMAL
 	amount_per_transfer_from_this = 20
-	possible_transfer_amounts = list(10,15,20,25,30,50,70)
+	possible_transfer_amounts = list(5,10,15,20,25,30,50,70)
 	volume = 70
 	flags_inv = HIDEHAIR
 	slot_flags = ITEM_SLOT_HEAD


### PR DESCRIPTION
:cl: Skoglol
fix: Dispensers can now add 5u to buckets, plastic beakers and metamaterial beakers, down from 10u.
fix: You can now pour 5u from buckets, plastic beakers and metamaterial beakers, down from 10u.
/:cl:

These three reagent containers could previously not have 5u added to them by machines. This screwed with recipes in chem, and was inconsistent. Pour amounts is pulled from the same list, this will change too.