### PR TITLE
Chem dispenser window now slightly wider, no longer shuffles buttons.

### DIFF
--- a/code/modules/reagents/chemistry/machinery/chem_dispenser.dm
+++ b/code/modules/reagents/chemistry/machinery/chem_dispenser.dm
@@ -139,7 +139,7 @@
 											datum/tgui/master_ui = null, datum/ui_state/state = GLOB.default_state)
 	ui = SStgui.try_update_ui(user, src, ui_key, ui, force_open)
 	if(!ui)
-		ui = new(user, src, ui_key, "chem_dispenser", name, 550, 550, master_ui, state)
+		ui = new(user, src, ui_key, "chem_dispenser", name, 565, 550, master_ui, state)
 		if(user.hallucinating())
 			ui.set_autoupdate(FALSE) //to not ruin the immersion by constantly changing the fake chemicals
 		ui.open()


### PR DESCRIPTION
:cl: Skoglol
fix: Chem dispenser window width increased slightly, no longer shuffles buttons when scroll bar appears. 
/:cl:

If you add five chemicals to a beaker in a standard chem dispenser, the scrollbar appears. With the previous width there was not enough space for the scroll bar, and the fourth column of chems merged with the other three columns. 