### PR TITLE
Removes Curator's phobia of snakes, because it's retarded

### DIFF
--- a/code/modules/jobs/job_types/civilian.dm
+++ b/code/modules/jobs/job_types/civilian.dm
@@ -154,7 +154,6 @@ Curator
 		return
 
 	H.grant_all_languages(omnitongue=TRUE)
-	H.gain_trauma(/datum/brain_trauma/mild/phobia, TRAUMA_RESILIENCE_SURGERY, "snakes") //why does it have to be snakes...
 /*
 Lawyer
 */


### PR DESCRIPTION
:cl: 
del: removes curator's fear of snakes
/:cl:

Reasons for change:
* Curators are already underplayed and not very useful outside of gimmicks.
* At the moment, when you say "snake" near a Curator, you blind them.  No _seriously_.  If your an antag and your target is the curator, just scream "SNAKE" over and over.  They will be permablinded and not be able to fight back.
* This is especially cancerous when someone on the station is named "Snake".  Better take that headset off and avoid radios or be blind forever!
* I'm coming off a round as Curator and really tilted.

e: removed something I said that wasn't true because I was tilted.  Don't PR when you're angry, kids.