### PR TITLE
Fixes the span tag closure on the clowncar space lube message

### DIFF
--- a/code/modules/vehicles/cars/clowncar.dm
+++ b/code/modules/vehicles/cars/clowncar.dm
@@ -30,7 +30,7 @@
 /obj/vehicle/sealed/car/clowncar/take_damage(damage_amount, damage_type = BRUTE, damage_flag = 0, sound_effect = 1, attack_dir)
 	. = ..()
 	if(prob(33))
-		visible_message("<span class='danger'>[src] spews out a ton of space lube!/span>/span>")
+		visible_message("<span class='danger'>[src] spews out a ton of space lube!</span>")
 		new /obj/effect/particle_effect/foam(loc) //YEET
 
 /obj/vehicle/sealed/car/clowncar/Bump(atom/movable/M)


### PR DESCRIPTION
It's so it doesn't do this:

![image](https://user-images.githubusercontent.com/701959/44930119-af40d880-ad33-11e8-9628-ed9a30958ade.png)
