### PR TITLE
Restructures Hulk as a job-bannable role.

### DIFF
--- a/code/__DEFINES/role_preferences.dm
+++ b/code/__DEFINES/role_preferences.dm
@@ -33,6 +33,7 @@
 #define ROLE_DRONE                  "drone"
 #define ROLE_DEATHSQUAD             "deathsquad"
 #define ROLE_LAVALAND               "lavaland"
+#define ROLE_HULK                   "hulk"
 
 //Missing assignment means it's not a gamemode specific role, IT'S NOT A BUG OR ERROR.
 //The gamemode specific ones are just so the gamemodes can query whether a player is old enough

--- a/code/datums/mutations/hulk.dm
+++ b/code/datums/mutations/hulk.dm
@@ -11,6 +11,10 @@
 /datum/mutation/human/hulk/on_acquiring(mob/living/carbon/human/owner)
 	if(..())
 		return
+	if(jobban_isbanned(owner, ROLE_HULK))
+		on_losing(owner)
+		to_chat(owner, "<span class='warning'>Your muscles suddenly shrink back to normal. You remember that Nanotrasen has put genetic inhibitors on this sequence due to your misuse of the trait!</span>")
+		return
 	owner.add_trait(TRAIT_STUNIMMUNE, TRAIT_HULK)
 	owner.add_trait(TRAIT_PUSHIMMUNE, TRAIT_HULK)
 	owner.update_body_parts()

--- a/code/datums/mutations/hulk.dm
+++ b/code/datums/mutations/hulk.dm
@@ -13,7 +13,7 @@
 		return
 	if(jobban_isbanned(owner, ROLE_HULK))
 		on_losing(owner)
-		to_chat(owner, "<span class='warning'>Your muscles suddenly shrink back to normal. You remember that Nanotrasen has put genetic inhibitors on this sequence due to your misuse of the trait!</span>")
+		to_chat(owner, "<span class='warning'>Your muscles suddenly shrink back to normal! You feel the gods looking down upon you in shame...</span>")
 		return
 	owner.add_trait(TRAIT_STUNIMMUNE, TRAIT_HULK)
 	owner.add_trait(TRAIT_PUSHIMMUNE, TRAIT_HULK)

--- a/code/modules/admin/DB_ban/functions.dm
+++ b/code/modules/admin/DB_ban/functions.dm
@@ -424,7 +424,7 @@
 		output += "<option value='[j]'>[j]</option>"
 	for(var/j in GLOB.nonhuman_positions)
 		output += "<option value='[j]'>[j]</option>"
-	for(var/j in list(ROLE_TRAITOR, ROLE_CHANGELING, ROLE_OPERATIVE, ROLE_REV, ROLE_CULTIST, ROLE_WIZARD))
+	for(var/j in list(ROLE_TRAITOR, ROLE_CHANGELING, ROLE_OPERATIVE, ROLE_REV, ROLE_CULTIST, ROLE_WIZARD, ROLE_SENTIENCE, ROLE_MIND_TRANSFER, ROLE_HULK))
 		output += "<option value='[j]'>[j]</option>"
 	output += "</select></td></tr></table>"
 	output += "<b>Reason:<br></b><textarea name='dbbanreason' cols='50'></textarea><br>"

--- a/code/modules/admin/topic.dm
+++ b/code/modules/admin/topic.dm
@@ -911,6 +911,12 @@
 		else
 			dat += "<td width='20%'><a href='?src=[REF(src)];[HrefToken()];jobban3=[ROLE_MIND_TRANSFER];jobban4=[REF(M)]'>Mind Transfer Potion</a></td>"
 
+		//Hulk
+		if(jobban_isbanned(M, ROLE_HULK))
+			dat += "<td width='20%'><a href='?src=[REF(src)];[HrefToken()];jobban3=[ROLE_HULK];jobban4=[REF(M)]'><font color=red>Hulk</font></a></td>"
+		else
+			dat += "<td width='20%'><a href='?src=[REF(src)];[HrefToken()];jobban3=[ROLE_HULK];jobban4=[REF(M)]'>Hulk</a></td>"
+		
 		dat += "</tr></table>"
 		usr << browse(dat, "window=jobban2;size=800x450")
 		return
@@ -976,7 +982,7 @@
 			if("convertantags")
 				joblist += list(ROLE_REV, ROLE_CULTIST, ROLE_SERVANT_OF_RATVAR, ROLE_ALIEN)
 			if("otherroles")
-				joblist += list(ROLE_MIND_TRANSFER)
+				joblist += list(ROLE_MIND_TRANSFER, ROLE_HULK)
 			else
 				joblist += href_list["jobban3"]
 


### PR DESCRIPTION
:cl: The Dreamweaver
admin: Gives admins the ability to role-ban a user from utilizing the Hulk trait.
/:cl:
 
This change has already been approved by at least one headmin.

I have gotten further words from headmin that a hulk ban would be given as a full punishment and that those banned do not deserve exceptions during antag rounds: https://imgur.com/a/kweHS0N