### PR TITLE
Fixes vending machines not updating their interface on use

### DIFF
--- a/code/modules/vending/_vending.dm
+++ b/code/modules/vending/_vending.dm
@@ -319,7 +319,7 @@ IF YOU MODIFY THE PRODUCTS LIST OF A MACHINE, MAKE SURE TO UPDATE ITS RESUPPLY C
 			return
 	return ..()
 
-/obj/machinery/vending/interact(mob/user)
+/obj/machinery/vending/ui_interact(mob/user)
 	var/dat = ""
 
 	dat += "<h3>Select an item</h3>"
@@ -466,10 +466,6 @@ IF YOU MODIFY THE PRODUCTS LIST OF A MACHINE, MAKE SURE TO UPDATE ITS RESUPPLY C
 		new R.product_path(get_turf(src))
 		SSblackbox.record_feedback("nested tally", "vending_machine_usage", 1, list("[type]", "[R.product_path]"))
 		vend_ready = 1
-		return
-
-		updateUsrDialog()
-		return
 
 	else if(href_list["togglevoice"] && panel_open)
 		shut_up = !shut_up


### PR DESCRIPTION
They were using the wrong call that updateUsrDialog() uses plus some strange return calls