### PR TITLE
Delta: Nanite lab, tweaks/fixes

### DIFF
--- a/_maps/map_files/BoxStation/BoxStation.dmm
+++ b/_maps/map_files/BoxStation/BoxStation.dmm
@@ -40056,7 +40056,6 @@
 /area/science/misc_lab)
 "bYl" = (
 /obj/structure/chair/office/light{
-	icon_state = "officechair_white";
 	dir = 4
 	},
 /obj/effect/landmark/start/scientist,

--- a/_maps/map_files/Deltastation/DeltaStation2.dmm
+++ b/_maps/map_files/Deltastation/DeltaStation2.dmm
@@ -72967,7 +72967,6 @@
 /area/science/xenobiology)
 "daE" = (
 /obj/structure/chair/office/light{
-	icon_state = "officechair_white";
 	dir = 4
 	},
 /obj/effect/turf_decal/stripes/line{
@@ -76508,7 +76507,6 @@
 /area/science/lab)
 "dil" = (
 /obj/structure/chair/office/light{
-	icon_state = "officechair_white";
 	dir = 4
 	},
 /turf/open/floor/plasteel/whitepurple/corner,
@@ -81882,7 +81880,6 @@
 /area/science/nanite)
 "duD" = (
 /obj/structure/chair/office/light{
-	icon_state = "officechair_white";
 	dir = 4
 	},
 /turf/open/floor/plasteel/vault{
@@ -84840,7 +84837,6 @@
 /area/science/robotics/lab)
 "dAO" = (
 /obj/structure/chair/office/light{
-	icon_state = "officechair_white";
 	dir = 4
 	},
 /obj/effect/landmark/start/roboticist,

--- a/_maps/map_files/Deltastation/DeltaStation2.dmm
+++ b/_maps/map_files/Deltastation/DeltaStation2.dmm
@@ -15956,7 +15956,6 @@
 /area/maintenance/disposal/incinerator)
 "aNQ" = (
 /obj/machinery/power/compressor{
-	icon_state = "compressor";
 	dir = 4;
 	luminosity = 2;
 	comp_id = "incineratorturbine"
@@ -35464,6 +35463,7 @@
 /obj/machinery/light/small{
 	dir = 8
 	},
+/obj/item/clothing/gloves/color/yellow,
 /turf/open/floor/plasteel/neutral/side{
 	dir = 4
 	},
@@ -54915,8 +54915,9 @@
 /area/engine/engineering)
 "cpg" = (
 /obj/structure/table/reinforced,
-/obj/item/airlock_painter,
 /obj/effect/turf_decal/delivery,
+/obj/item/clothing/gloves/color/yellow,
+/obj/item/airlock_painter,
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "cph" = (
@@ -72015,9 +72016,7 @@
 /obj/machinery/holopad,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/effect/turf_decal/bot,
-/obj/structure/disposalpipe/segment{
-	dir = 5
-	},
+/obj/structure/disposalpipe/junction/flip,
 /turf/open/floor/plasteel,
 /area/science/xenobiology)
 "cYO" = (
@@ -72143,28 +72142,20 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 10
 	},
-/obj/structure/disposalpipe/junction{
-	dir = 4
+/obj/structure/disposalpipe/segment{
+	dir = 10
 	},
 /turf/open/floor/plasteel/purple,
 /area/science/xenobiology)
 "cYZ" = (
 /obj/machinery/holopad,
 /obj/effect/turf_decal/bot,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /turf/open/floor/plasteel,
 /area/science/xenobiology)
 "cZa" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
-/obj/structure/disposalpipe/trunk{
-	dir = 8
-	},
-/obj/machinery/disposal/bin,
-/obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel,
 /area/science/xenobiology)
 "cZb" = (
@@ -72864,12 +72855,18 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 9
 	},
+/obj/structure/disposalpipe/segment{
+	dir = 5
+	},
 /turf/open/floor/plasteel/neutral,
 /area/science/xenobiology)
 "dau" = (
-/obj/item/twohanded/required/kirbyplants/random,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/effect/turf_decal/bot,
+/obj/structure/disposalpipe/trunk{
+	dir = 8
+	},
+/obj/machinery/disposal/bin,
 /turf/open/floor/plasteel,
 /area/science/xenobiology)
 "dav" = (
@@ -76365,13 +76362,13 @@
 /turf/open/floor/plating,
 /area/science/research/abandoned)
 "dhT" = (
-/obj/machinery/door/airlock/maintenance_hatch{
-	name = "Maintenance Hatch";
-	req_access_txt = "12"
-	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/structure/cable/white{
 	icon_state = "1-2"
+	},
+/obj/machinery/door/airlock/maintenance_hatch{
+	name = "Maintenance Hatch";
+	req_one_access_txt = "12;47"
 	},
 /turf/open/floor/plasteel,
 /area/science/misc_lab)
@@ -77073,93 +77070,78 @@
 /turf/closed/wall/r_wall,
 /area/science/explab)
 "djB" = (
-/obj/structure/table/reinforced,
 /obj/item/storage/toolbox/mechanical,
 /obj/item/flashlight,
 /obj/effect/turf_decal/bot,
 /obj/structure/sign/poster/official/science{
 	pixel_x = -32
 	},
-/turf/open/floor/plasteel,
+/obj/structure/rack,
+/turf/open/floor/plasteel/vault,
 /area/science/explab)
 "djC" = (
-/obj/machinery/atmospherics/components/unary/portables_connector/visible,
-/obj/effect/turf_decal/stripes/line{
-	dir = 10
-	},
-/turf/open/floor/plasteel,
-/area/science/explab)
-"djD" = (
-/obj/machinery/atmospherics/components/unary/portables_connector/visible,
-/obj/machinery/light{
-	dir = 1
-	},
-/obj/structure/sign/warning/nosmoking{
-	pixel_y = 32
-	},
-/obj/effect/turf_decal/stripes/line,
-/turf/open/floor/plasteel,
-/area/science/explab)
-"djE" = (
-/obj/machinery/atmospherics/components/unary/portables_connector/visible,
-/obj/effect/turf_decal/stripes/line{
-	dir = 6
-	},
-/obj/machinery/airalarm{
-	pixel_y = 23
-	},
-/turf/open/floor/plasteel,
-/area/science/explab)
-"djF" = (
-/obj/structure/cable/white{
-	icon_state = "0-2"
-	},
-/obj/machinery/power/apc{
-	dir = 1;
-	name = "Experimentation Lab APC";
-	areastring = "/area/science/explab";
-	pixel_y = 24
-	},
 /obj/machinery/camera{
 	c_tag = "Science - Experimentation Lab";
 	dir = 2;
 	name = "science camera";
 	network = list("ss13","rd")
 	},
-/obj/effect/turf_decal/delivery,
-/turf/open/floor/plasteel,
-/area/science/explab)
-"djG" = (
-/obj/structure/filingcabinet/chestdrawer,
-/obj/machinery/status_display/evac{
-	pixel_y = 32
+/obj/effect/turf_decal/bot,
+/obj/machinery/airalarm{
+	pixel_y = 23
 	},
-/obj/effect/turf_decal/bot,
-/turf/open/floor/plasteel,
+/obj/structure/closet/radiation,
+/turf/open/floor/plasteel/vault,
 /area/science/explab)
-"djH" = (
-/obj/structure/closet/l3closet/scientist,
-/obj/effect/turf_decal/bot,
-/turf/open/floor/plasteel,
-/area/science/explab)
-"djI" = (
-/obj/structure/closet/bombcloset,
+"djD" = (
 /obj/machinery/light{
 	dir = 1
 	},
+/obj/structure/sign/warning/nosmoking{
+	pixel_y = 32
+	},
 /obj/effect/turf_decal/bot,
-/turf/open/floor/plasteel,
+/obj/structure/closet/bombcloset/white,
+/turf/open/floor/plasteel/vault,
 /area/science/explab)
+"djE" = (
+/obj/item/crowbar,
+/obj/item/wrench,
+/obj/item/clothing/mask/gas,
+/obj/structure/rack,
+/turf/open/floor/plasteel/vault,
+/area/science/explab)
+"djF" = (
+/turf/closed/wall/r_wall,
+/area/science/nanite)
+"djG" = (
+/obj/machinery/computer/nanite_cloud_controller,
+/obj/effect/turf_decal/bot,
+/turf/open/floor/plasteel/vault,
+/area/science/nanite)
+"djH" = (
+/obj/machinery/nanite_programmer,
+/obj/effect/turf_decal/bot,
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/turf/open/floor/plasteel/vault,
+/area/science/nanite)
+"djI" = (
+/obj/machinery/computer/nanite_chamber_control,
+/obj/effect/turf_decal/bot,
+/obj/structure/sign/poster/random{
+	pixel_y = 32
+	},
+/turf/open/floor/plasteel/vault,
+/area/science/nanite)
 "djJ" = (
-/obj/structure/table/reinforced,
-/obj/item/clothing/suit/radiation,
-/obj/item/clothing/head/radiation,
-/obj/effect/turf_decal/bot,
-/turf/open/floor/plasteel,
-/area/science/explab)
+/obj/machinery/nanite_chamber,
+/turf/open/floor/plasteel/vault,
+/area/science/nanite)
 "djK" = (
 /turf/closed/wall,
-/area/science/explab)
+/area/science/nanite)
 "djL" = (
 /obj/machinery/airalarm{
 	dir = 4;
@@ -77933,73 +77915,59 @@
 	},
 /area/science/misc_lab)
 "dlo" = (
-/obj/structure/table/reinforced,
 /obj/machinery/newscaster{
 	pixel_x = -32
 	},
-/obj/item/crowbar,
-/obj/item/wrench,
-/obj/item/clothing/mask/gas,
+/obj/structure/table/reinforced,
 /obj/effect/turf_decal/bot,
-/turf/open/floor/plasteel,
+/obj/item/clothing/gloves/color/latex,
+/obj/item/clothing/glasses/science,
+/obj/item/clothing/glasses/science,
+/turf/open/floor/plasteel/vault,
 /area/science/explab)
 "dlp" = (
-/obj/machinery/atmospherics/pipe/simple/general/visible{
-	dir = 5
-	},
-/turf/open/floor/plasteel/whitepurple/corner{
-	dir = 1
-	},
-/area/science/explab)
-"dlq" = (
-/obj/machinery/atmospherics/components/trinary/filter{
-	dir = 8
-	},
-/turf/open/floor/plasteel/whitepurple/corner{
-	dir = 1
-	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on,
+/turf/open/floor/plasteel/vault,
 /area/science/explab)
 "dlr" = (
-/obj/machinery/atmospherics/pipe/simple/general/visible{
-	dir = 9
+/obj/structure/table/reinforced,
+/obj/item/taperecorder,
+/obj/item/folder/white,
+/obj/effect/turf_decal/bot,
+/obj/item/stack/sheet/mineral/plasma{
+	amount = 5
 	},
-/turf/open/floor/plasteel/whitepurple/corner{
-	dir = 1
-	},
-/area/science/explab)
-"dls" = (
-/obj/structure/cable/white{
-	icon_state = "1-2"
-	},
-/turf/open/floor/plasteel/whitepurple/side{
-	dir = 1
-	},
+/turf/open/floor/plasteel/vault,
 /area/science/explab)
 "dlt" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on,
-/turf/open/floor/plasteel/whitepurple/corner{
-	dir = 4
-	},
-/area/science/explab)
-"dlu" = (
-/turf/open/floor/plasteel/whitepurple/corner{
-	dir = 4
-	},
-/area/science/explab)
-"dlv" = (
-/obj/structure/table/reinforced,
-/obj/item/stack/cable_coil/white{
-	pixel_x = 3;
-	pixel_y = 3
-	},
-/obj/item/stack/cable_coil/white,
-/obj/item/geiger_counter,
 /obj/effect/turf_decal/bot,
-/obj/structure/sign/poster/official/cleanliness{
-	pixel_x = 32
+/obj/machinery/power/apc/auto_name/west,
+/obj/structure/cable/white{
+	icon_state = "0-4"
 	},
-/turf/open/floor/plasteel,
-/area/science/explab)
+/turf/open/floor/plasteel/vault,
+/area/science/nanite)
+"dlu" = (
+/obj/structure/cable/white{
+	icon_state = "2-8"
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 9
+	},
+/turf/open/floor/plasteel/vault,
+/area/science/nanite)
+"dlv" = (
+/obj/effect/turf_decal/loading_area{
+	dir = 1
+	},
+/obj/machinery/light{
+	dir = 4
+	},
+/obj/machinery/light_switch{
+	pixel_x = 26
+	},
+/turf/open/floor/plasteel/vault,
+/area/science/nanite)
 "dlw" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -78416,66 +78384,55 @@
 /turf/open/floor/plasteel,
 /area/science/misc_lab)
 "dmB" = (
-/obj/item/twohanded/required/kirbyplants/random,
-/obj/effect/turf_decal/bot,
 /obj/machinery/light_switch{
 	pixel_x = -26
 	},
-/turf/open/floor/plasteel,
+/obj/structure/table/reinforced,
+/obj/effect/turf_decal/bot,
+/obj/item/stack/medical/gauze,
+/obj/item/stack/medical/bruise_pack,
+/obj/item/stack/medical/ointment,
+/turf/open/floor/plasteel/vault,
 /area/science/explab)
 "dmC" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on,
-/turf/open/floor/plasteel/whitepurple/side{
-	dir = 8
-	},
-/area/science/explab)
-"dmD" = (
-/turf/open/floor/plasteel/neutral,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/turf/open/floor/plasteel/vault,
 /area/science/explab)
 "dmE" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/neutral,
-/area/science/explab)
-"dmF" = (
-/obj/structure/cable/white{
-	icon_state = "1-2"
-	},
-/obj/effect/landmark/event_spawn,
-/turf/open/floor/plasteel/neutral,
-/area/science/explab)
-"dmG" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/turf/open/floor/plasteel/neutral,
-/area/science/explab)
-"dmH" = (
-/obj/machinery/holopad,
-/obj/effect/turf_decal/bot,
-/turf/open/floor/plasteel,
-/area/science/explab)
-"dmI" = (
-/turf/open/floor/plasteel/whitepurple/side{
-	dir = 4
-	},
-/area/science/explab)
-"dmJ" = (
+/obj/item/twohanded/required/kirbyplants/random,
+/obj/machinery/atmospherics/components/unary/vent_pump/on,
 /obj/machinery/firealarm{
 	dir = 4;
 	pixel_x = 24
 	},
-/obj/effect/turf_decal/bot,
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/vault,
 /area/science/explab)
-"dmK" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
-	dir = 4
-	},
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = -24
-	},
+"dmF" = (
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
+/area/science/nanite)
+"dmG" = (
+/obj/machinery/nanite_program_hub,
 /obj/effect/turf_decal/bot,
-/turf/open/floor/plasteel,
-/area/science/research)
+/turf/open/floor/plasteel/vault,
+/area/science/nanite)
+"dmH" = (
+/obj/structure/cable/white{
+	icon_state = "1-2"
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/turf/open/floor/plasteel/vault,
+/area/science/nanite)
+"dmI" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on,
+/turf/open/floor/plasteel/vault,
+/area/science/nanite)
+"dmJ" = (
+/obj/item/twohanded/required/kirbyplants/random,
+/turf/open/floor/plasteel/vault,
+/area/science/nanite)
 "dmL" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 4
@@ -78513,6 +78470,10 @@
 	network = list("ss13","rd")
 	},
 /obj/effect/turf_decal/bot,
+/obj/machinery/firealarm{
+	dir = 4;
+	pixel_x = 24
+	},
 /turf/open/floor/plasteel,
 /area/science/research)
 "dmS" = (
@@ -79184,7 +79145,7 @@
 /area/science/misc_lab)
 "dos" = (
 /obj/machinery/door/airlock/research{
-	name = "Circuitry Lab";
+	name = "Experimentation Lab";
 	req_access_txt = "47"
 	},
 /obj/structure/disposalpipe/segment{
@@ -79203,135 +79164,132 @@
 /obj/structure/cable/white{
 	icon_state = "4-8"
 	},
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 4
+	},
 /turf/open/floor/plasteel,
 /area/science/misc_lab)
 "dot" = (
-/obj/structure/cable/white{
-	icon_state = "4-8"
-	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
-/obj/effect/turf_decal/delivery,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/turf/open/floor/plasteel,
+/obj/structure/cable/white{
+	icon_state = "2-8"
+	},
+/obj/structure/cable/white{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plasteel/vault,
 /area/science/explab)
 "dou" = (
-/obj/structure/cable/white{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/turf/open/floor/plasteel/whitepurple/corner{
-	dir = 8
-	},
-/area/science/explab)
-"dov" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/structure/cable/white{
 	icon_state = "4-8"
 	},
+/turf/open/floor/plasteel/vault,
+/area/science/explab)
+"dov" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/structure/chair/office/light,
+/obj/structure/cable/white{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plasteel/vault,
+/area/science/explab)
+"dow" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold4w/supply/hidden,
+/obj/structure/cable/white{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plasteel/vault,
+/area/science/explab)
+"dox" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/machinery/door/airlock/research{
+	name = "Experimentation Lab";
+	req_access_txt = "47"
+	},
+/obj/machinery/door/firedoor,
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 8
+	},
+/obj/structure/cable/white{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plasteel/vault,
+/area/science/nanite)
+"doy" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/structure/cable/white{
+	icon_state = "4-8"
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel/vault,
+/area/science/nanite)
+"doz" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/structure/cable/white{
+	icon_state = "1-8"
+	},
+/obj/effect/turf_decal/stripes/corner{
+	dir = 4
+	},
+/turf/open/floor/plasteel/vault,
+/area/science/nanite)
+"doA" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden,
+/turf/open/floor/plasteel/vault,
+/area/science/nanite)
+"doB" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
 /obj/structure/disposalpipe/junction{
 	dir = 4
 	},
-/turf/open/floor/plasteel/whitepurple/corner{
-	dir = 8
-	},
-/area/science/explab)
-"dow" = (
-/obj/structure/cable/white{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/plasteel/whitepurple/corner{
-	dir = 8
-	},
-/area/science/explab)
-"dox" = (
-/obj/structure/table/reinforced,
-/obj/structure/cable/white{
-	icon_state = "1-8"
-	},
-/obj/item/stack/sheet/mineral/plasma{
-	amount = 5
-	},
-/obj/item/taperecorder,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 9
-	},
-/turf/open/floor/plasteel,
-/area/science/explab)
-"doy" = (
-/obj/structure/chair/office/light,
-/obj/effect/landmark/start/scientist,
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/science/explab)
-"doz" = (
-/obj/structure/table/reinforced,
-/obj/item/clipboard,
-/obj/item/folder/white,
-/obj/item/pen,
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	dir = 1
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 5
-	},
-/turf/open/floor/plasteel,
-/area/science/explab)
-"doA" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/plasteel/whitepurple/corner,
-/area/science/explab)
-"doB" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/effect/turf_decal/delivery,
-/turf/open/floor/plasteel,
-/area/science/explab)
+/turf/open/floor/plasteel/vault,
+/area/science/nanite)
 "doC" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/research{
-	name = "Experimentation Lab";
+	name = "Nanite Lab";
 	req_access_txt = "47"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -79347,7 +79305,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel,
-/area/science/explab)
+/area/science/nanite)
 "doD" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -80061,110 +80019,121 @@
 /turf/closed/wall/r_wall,
 /area/science/explab)
 "dqj" = (
-/obj/structure/table,
-/obj/item/stack/medical/gauze,
-/obj/item/stack/medical/bruise_pack,
-/obj/item/stack/medical/ointment,
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	dir = 1
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
 	},
+/obj/structure/table/reinforced,
+/obj/item/book/manual/wiki/experimentor,
+/obj/item/healthanalyzer,
+/obj/machinery/light_switch{
+	pixel_x = -26
+	},
+/obj/machinery/power/apc/auto_name/west,
+/obj/structure/cable/white,
 /obj/effect/turf_decal/bot,
-/turf/open/floor/plasteel,
+/obj/effect/turf_decal/stripes/line{
+	dir = 9
+	},
+/turf/open/floor/plasteel/vault,
 /area/science/explab)
 "dqk" = (
-/obj/effect/turf_decal/delivery,
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden,
-/turf/open/floor/plasteel,
+/obj/machinery/atmospherics/pipe/manifold4w/scrubbers/hidden,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel/vault,
 /area/science/explab)
 "dql" = (
 /obj/machinery/light,
-/obj/machinery/disposal/bin,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/effect/turf_decal/bot,
+/obj/machinery/computer/rdconsole/experiment{
+	dir = 1
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel/vault,
+/area/science/explab)
+"dqm" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/structure/table/reinforced,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/item/paper_bin,
+/obj/item/pen,
+/obj/effect/turf_decal/bot,
+/obj/effect/turf_decal/stripes/line{
+	dir = 5
+	},
+/obj/machinery/button/door{
+	id = "experimentor";
+	name = "Experimentor Door Control";
+	pixel_x = 24;
+	req_access_txt = "47"
+	},
+/turf/open/floor/plasteel/vault,
+/area/science/explab)
+"dqn" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
+/area/science/nanite)
+"dqo" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/structure/table/reinforced,
+/obj/item/nanite_scanner{
+	pixel_x = -4;
+	pixel_y = -4
+	},
+/obj/item/nanite_scanner{
+	pixel_x = 4;
+	pixel_y = -4
+	},
+/obj/item/nanite_remote{
+	pixel_x = -4;
+	pixel_y = 4
+	},
+/obj/item/nanite_remote{
+	pixel_x = 4;
+	pixel_y = 4
+	},
+/obj/machinery/firealarm{
+	dir = 8;
+	pixel_x = -24
+	},
+/obj/effect/turf_decal/bot,
+/turf/open/floor/plasteel/vault,
+/area/science/nanite)
+"dqp" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/turf/open/floor/plasteel/vault,
+/area/science/nanite)
+"dqq" = (
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
+	dir = 1
+	},
+/turf/open/floor/plasteel/vault,
+/area/science/nanite)
+"dqr" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
 /obj/structure/disposalpipe/trunk{
 	dir = 1
 	},
-/obj/effect/turf_decal/bot,
-/turf/open/floor/plasteel,
-/area/science/explab)
-"dqm" = (
-/obj/structure/table/reinforced,
-/obj/item/clothing/gloves/color/white,
-/obj/item/clothing/gloves/color/white,
-/obj/item/clothing/glasses/science,
-/obj/item/clothing/glasses/science,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 9
-	},
-/turf/open/floor/plasteel,
-/area/science/explab)
-"dqn" = (
-/obj/structure/table/reinforced,
-/obj/item/book/manual/wiki/experimentor,
-/obj/item/healthanalyzer,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/obj/effect/turf_decal/stripes/corner{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/science/explab)
-"dqo" = (
-/obj/machinery/computer/rdconsole/experiment{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/obj/effect/turf_decal/bot,
-/turf/open/floor/plasteel,
-/area/science/explab)
-"dqp" = (
-/obj/structure/table/reinforced,
-/obj/item/stack/packageWrap,
-/obj/item/hand_labeler,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/effect/turf_decal/stripes/corner{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/science/explab)
-"dqq" = (
-/obj/structure/table/reinforced,
-/obj/machinery/light,
-/obj/item/paper_bin,
-/obj/item/pen,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 5
-	},
-/turf/open/floor/plasteel,
-/area/science/explab)
-"dqr" = (
-/obj/item/twohanded/required/kirbyplants/random,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/obj/effect/turf_decal/bot,
-/turf/open/floor/plasteel,
-/area/science/explab)
-"dqs" = (
-/obj/structure/sign/warning/securearea,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/turf/closed/wall,
-/area/science/explab)
+/obj/machinery/disposal/bin,
+/turf/open/floor/plasteel/vault,
+/area/science/nanite)
 "dqt" = (
 /obj/machinery/light/small,
 /obj/structure/closet/firecloset,
@@ -80736,49 +80705,77 @@
 /turf/open/floor/plating,
 /area/maintenance/port)
 "drI" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/turf/closed/wall/r_wall,
-/area/science/explab)
-"drJ" = (
-/obj/machinery/door/firedoor/heavy,
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/button/door{
-	id = "experimentor";
-	name = "Experimentor Door Control";
-	pixel_x = -26;
-	req_access_txt = "47"
-	},
+/obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/door/poddoor/preopen{
 	id = "experimentor";
 	name = "Test Chamber Blast door"
 	},
-/turf/open/floor/plasteel/vault{
-	dir = 8
+/turf/open/floor/engine,
+/area/science/explab)
+"drJ" = (
+/obj/machinery/door/firedoor/heavy,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/door/poddoor/preopen{
+	id = "experimentor";
+	name = "Test Chamber Blast door"
 	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/effect/turf_decal/delivery,
+/turf/open/floor/engine,
 /area/science/explab)
 "drK" = (
 /obj/structure/sign/warning/securearea,
-/turf/closed/wall/r_wall,
+/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/door/poddoor/preopen{
+	id = "experimentor";
+	name = "Test Chamber Blast door"
+	},
+/turf/open/floor/engine,
 /area/science/explab)
 "drL" = (
-/obj/machinery/status_display/evac,
-/turf/closed/wall/r_wall,
+/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/door/poddoor/preopen{
+	id = "experimentor";
+	name = "Test Chamber Blast door"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/turf/open/floor/engine,
 /area/science/explab)
 "drM" = (
-/obj/machinery/door/firedoor/heavy,
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating,
-/area/science/explab)
+/obj/structure/table/reinforced,
+/obj/item/storage/box/disks_nanite{
+	pixel_x = 4;
+	pixel_y = -4
+	},
+/obj/item/storage/box/disks_nanite{
+	pixel_x = -4;
+	pixel_y = 4
+	},
+/obj/machinery/camera{
+	c_tag = "Research Division - Nanite Lab";
+	dir = 4;
+	name = "science camera";
+	network = list("ss13","rd")
+	},
+/obj/item/radio/intercom{
+	pixel_x = -26
+	},
+/obj/effect/turf_decal/bot,
+/turf/open/floor/plasteel/vault,
+/area/science/nanite)
 "drN" = (
-/obj/machinery/door/firedoor/heavy,
-/obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/turf/open/floor/plating,
-/area/science/explab)
+/turf/open/floor/plasteel/vault,
+/area/science/nanite)
 "drO" = (
-/obj/structure/sign/nanotrasen,
-/turf/closed/wall/r_wall,
-/area/science/explab)
+/obj/effect/turf_decal/loading_area,
+/obj/machinery/light{
+	dir = 4
+	},
+/obj/machinery/status_display/evac{
+	pixel_x = 32
+	},
+/turf/open/floor/plasteel/vault,
+/area/science/nanite)
 "drP" = (
 /turf/closed/wall/r_wall,
 /area/science/mixing)
@@ -81287,21 +81284,20 @@
 /turf/closed/wall,
 /area/science/misc_lab)
 "dte" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/turf/open/floor/plasteel/vault,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
+	dir = 4
+	},
+/turf/open/floor/engine,
 /area/science/explab)
 "dtf" = (
 /turf/open/floor/plasteel/vault,
 /area/science/explab)
 "dtg" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
 /turf/open/floor/plasteel/vault,
-/area/science/explab)
-"dth" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/vault,
-/area/science/explab)
+/area/science/nanite)
 "dti" = (
 /obj/structure/closet/bombcloset,
 /obj/machinery/firealarm{
@@ -81858,66 +81854,53 @@
 	},
 /area/maintenance/port)
 "duw" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 5
-	},
-/turf/open/floor/plasteel/vault{
-	dir = 5
-	},
+/turf/open/floor/engine,
 /area/science/explab)
 "dux" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
-	dir = 8
-	},
-/turf/open/floor/plasteel/vault{
-	dir = 5
-	},
+/obj/effect/turf_decal/bot_white,
+/obj/machinery/rnd/experimentor,
+/turf/open/floor/engine,
 /area/science/explab)
 "duy" = (
-/mob/living/simple_animal/pet/dog/pug{
-	name = "Swanson"
-	},
-/turf/open/floor/plasteel/vault{
-	dir = 5
-	},
+/obj/effect/turf_decal/bot_white,
+/turf/open/floor/engine,
 /area/science/explab)
 "duz" = (
-/obj/effect/turf_decal/bot_white,
+/obj/effect/turf_decal/bot,
+/obj/machinery/airalarm/directional/west,
 /turf/open/floor/plasteel/vault{
 	dir = 8
 	},
-/area/science/explab)
-"duA" = (
-/obj/machinery/rnd/experimentor,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/bot_white,
-/turf/open/floor/plasteel/vault{
-	dir = 8
-	},
-/area/science/explab)
+/area/science/nanite)
 "duC" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 5
-	},
-/turf/open/floor/plasteel/vault{
-	dir = 5
-	},
-/area/science/explab)
-"duD" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
+/obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
-/obj/effect/landmark/xeno_spawn,
 /turf/open/floor/plasteel/vault{
 	dir = 5
 	},
-/area/science/explab)
+/area/science/nanite)
+"duD" = (
+/obj/structure/chair/office/light{
+	icon_state = "officechair_white";
+	dir = 4
+	},
+/turf/open/floor/plasteel/vault{
+	dir = 5
+	},
+/area/science/nanite)
 "duE" = (
-/obj/effect/decal/cleanable/dirt,
+/obj/machinery/computer/nanite_chamber_control{
+	dir = 8
+	},
+/obj/effect/turf_decal/bot,
+/obj/structure/sign/poster/random{
+	pixel_x = 32
+	},
 /turf/open/floor/plasteel/vault{
 	dir = 5
 	},
-/area/science/explab)
+/area/science/nanite)
 "duF" = (
 /obj/machinery/airalarm{
 	dir = 4;
@@ -82653,27 +82636,18 @@
 	},
 /area/maintenance/port)
 "dwd" = (
-/turf/open/floor/plasteel/vault{
-	dir = 5
-	},
-/area/science/explab)
-"dwe" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/light,
-/turf/open/floor/plasteel/vault{
-	dir = 5
-	},
-/area/science/explab)
-"dwf" = (
 /obj/machinery/camera{
 	c_tag = "Science - Experimentor";
 	dir = 1;
 	name = "science camera";
 	network = list("ss13","rd")
 	},
-/turf/open/floor/plasteel/vault{
-	dir = 5
-	},
+/turf/open/floor/engine,
+/area/science/explab)
+"dwe" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light,
+/turf/open/floor/engine,
 /area/science/explab)
 "dwg" = (
 /obj/machinery/camera{
@@ -84147,10 +84121,6 @@
 	dir = 4
 	},
 /obj/structure/barricade/wooden,
-/obj/machinery/door/airlock/maintenance_hatch{
-	name = "Maintenance Hatch";
-	req_access_txt = "12"
-	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
@@ -84159,6 +84129,10 @@
 	},
 /obj/structure/cable/white{
 	icon_state = "4-8"
+	},
+/obj/machinery/door/airlock/maintenance_hatch{
+	name = "Maintenance Hatch";
+	req_one_access_txt = "12;47"
 	},
 /turf/open/floor/plasteel,
 /area/science/research/abandoned)
@@ -87150,10 +87124,6 @@
 /obj/structure/cable/white{
 	icon_state = "1-2"
 	},
-/obj/machinery/door/airlock/maintenance_hatch{
-	name = "Maintenance Hatch";
-	req_access_txt = "12"
-	},
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -87164,6 +87134,10 @@
 	dir = 1
 	},
 /obj/effect/mapping_helpers/airlock/cyclelink_helper,
+/obj/machinery/door/airlock/maintenance_hatch{
+	name = "Maintenance Hatch";
+	req_one_access_txt = "12;47"
+	},
 /turf/open/floor/plasteel,
 /area/maintenance/port)
 "dFH" = (
@@ -99446,6 +99420,17 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/library)
+"eny" = (
+/obj/machinery/door/airlock/maintenance_hatch{
+	name = "Maintenance Hatch";
+	req_one_access_txt = "12;47"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/structure/cable/white{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plasteel,
+/area/science/misc_lab)
 "exE" = (
 /obj/machinery/air_sensor/atmos/toxins_mixing_tank,
 /turf/open/floor/engine/vacuum,
@@ -99590,6 +99575,14 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/closed/wall/r_wall,
 /area/science/circuit)
+"gFZ" = (
+/obj/machinery/nanite_program_hub,
+/obj/effect/turf_decal/bot,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel/vault,
+/area/science/nanite)
 "gKr" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 1
@@ -99690,10 +99683,6 @@
 /obj/structure/cable/white{
 	icon_state = "1-2"
 	},
-/obj/machinery/door/airlock/maintenance_hatch{
-	name = "Maintenance Hatch";
-	req_access_txt = "12"
-	},
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/effect/turf_decal/stripes/line{
@@ -99704,6 +99693,10 @@
 	},
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 1
+	},
+/obj/machinery/door/airlock/maintenance_hatch{
+	name = "Maintenance Hatch";
+	req_one_access_txt = "12;47"
 	},
 /turf/open/floor/plasteel,
 /area/maintenance/port/aft)
@@ -99741,6 +99734,12 @@
 /obj/machinery/atmospherics/pipe/manifold/general/visible,
 /turf/open/space,
 /area/space/nearstation)
+"hFX" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on{
+	dir = 1
+	},
+/turf/open/floor/engine,
+/area/science/explab)
 "hGT" = (
 /obj/machinery/door/firedoor,
 /obj/structure/cable/white{
@@ -99813,6 +99812,12 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/gravity_generator)
+"imL" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
+	dir = 1
+	},
+/turf/open/floor/plasteel/vault,
+/area/science/nanite)
 "ixL" = (
 /obj/structure/sign/warning/vacuum{
 	pixel_x = 32
@@ -99920,6 +99925,12 @@
 	dir = 5
 	},
 /area/science/mixing)
+"jAD" = (
+/mob/living/simple_animal/pet/dog/pug{
+	name = "Swanson"
+	},
+/turf/open/floor/engine,
+/area/science/explab)
 "jBE" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/neutral,
@@ -100244,6 +100255,10 @@
 	},
 /turf/open/floor/engine,
 /area/science/mixing)
+"ncP" = (
+/obj/effect/landmark/xeno_spawn,
+/turf/open/floor/engine,
+/area/science/explab)
 "nyB" = (
 /obj/structure/lattice,
 /turf/closed/wall/r_wall,
@@ -100291,6 +100306,10 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/gravity_generator)
+"oyx" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/turf/open/floor/engine,
+/area/science/explab)
 "oIl" = (
 /obj/machinery/atmospherics/components/unary/portables_connector/visible{
 	dir = 1
@@ -100442,6 +100461,17 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/storage_shared)
+"qdJ" = (
+/obj/machinery/nanite_programmer,
+/obj/effect/turf_decal/bot,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/plasteel/vault{
+	dir = 5
+	},
+/area/science/nanite)
 "qhc" = (
 /obj/structure/table/reinforced,
 /obj/item/integrated_electronics/analyzer,
@@ -100476,6 +100506,20 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/gravity_generator)
+"qUc" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/turf/open/floor/plasteel/vault{
+	dir = 5
+	},
+/area/science/nanite)
+"qVd" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 9
+	},
+/turf/open/floor/engine,
+/area/science/explab)
 "qWg" = (
 /obj/structure/table/reinforced,
 /obj/machinery/light/small{
@@ -100762,10 +100806,30 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel/whitegreen/side,
 /area/medical/medbay/central)
+"vJu" = (
+/obj/machinery/door/airlock/maintenance_hatch{
+	name = "Nanite Lab Maintenance";
+	req_access_txt = "47"
+	},
+/turf/open/floor/plating,
+/area/maintenance/port)
 "wei" = (
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plasteel,
 /area/science/circuit)
+"wjF" = (
+/obj/structure/chair/office/light{
+	dir = 1;
+	pixel_y = 3
+	},
+/turf/open/floor/plasteel/vault,
+/area/science/nanite)
+"wpB" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/turf/closed/wall/r_wall,
+/area/science/nanite)
 "wAA" = (
 /obj/structure/sign/nanotrasen,
 /turf/closed/wall/r_wall,
@@ -100802,6 +100866,14 @@
 	},
 /turf/open/floor/plating/airless,
 /area/maintenance/port)
+"wTa" = (
+/obj/machinery/computer/nanite_cloud_controller,
+/obj/effect/turf_decal/bot,
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/plasteel/vault{
+	dir = 5
+	},
+/area/science/nanite)
 "xaf" = (
 /obj/machinery/door/airlock/public/glass{
 	name = "Holodeck Access"
@@ -129106,7 +129178,7 @@ faI
 dor
 dqh
 wBO
-dhT
+eny
 duv
 dwc
 drH
@@ -129877,7 +129949,7 @@ dmC
 dou
 dqk
 drJ
-dtf
+qVd
 dux
 dwe
 djA
@@ -130129,14 +130201,14 @@ cNd
 cNd
 cMY
 djD
-dlq
-dmD
+dtf
+dtf
 dov
 dql
 drK
-dtf
+jAD
 duy
-dwd
+ncP
 djA
 dzp
 cLy
@@ -130391,9 +130463,9 @@ dmE
 dow
 dqm
 drL
-dtf
-duz
-dwd
+oyx
+oyx
+hFX
 djA
 dzq
 cLt
@@ -130643,15 +130715,15 @@ cNd
 cNd
 cMY
 djF
-dls
-dmF
+djF
+djF
 dox
-dqn
-drM
-dtf
-duA
-dwf
-djA
+wpB
+djF
+djF
+djF
+djF
+djF
 cJS
 cLu
 caE
@@ -130905,10 +130977,10 @@ dmG
 doy
 dqo
 drM
-dtf
+gFZ
 duz
-dwd
-djA
+wTa
+djF
 dzp
 cLs
 caE
@@ -131164,8 +131236,8 @@ dqp
 drN
 dtg
 duC
-dwd
-djA
+duC
+vJu
 cJT
 cLy
 dBY
@@ -131414,15 +131486,15 @@ cON
 dgt
 cMY
 djI
-dlu
+wjF
 dmI
 doA
 dqq
-drL
-dth
+imL
+drN
 duD
-dwe
-djA
+qUc
+djF
 dzr
 dAv
 cqL
@@ -131676,10 +131748,10 @@ dmJ
 doB
 dqr
 drO
-dth
+djJ
 duE
-dwd
-djA
+qdJ
+djF
 dzs
 cRP
 dBZ
@@ -131929,14 +132001,14 @@ cMY
 dhU
 djK
 djK
-djK
+dmF
 doC
-dqs
-drP
-drP
-drP
-drP
-drP
+dqn
+djF
+djF
+djF
+djF
+djF
 drP
 drP
 drP
@@ -132186,7 +132258,7 @@ dgu
 dhV
 djL
 dfp
-dmK
+dcz
 doD
 dqt
 drQ

--- a/_maps/map_files/PubbyStation/PubbyStation.dmm
+++ b/_maps/map_files/PubbyStation/PubbyStation.dmm
@@ -51823,7 +51823,6 @@
 /area/maintenance/department/engine)
 "qar" = (
 /obj/structure/chair/office/light{
-	icon_state = "officechair_white";
 	dir = 4
 	},
 /turf/open/floor/plasteel/white,
@@ -53159,7 +53158,6 @@
 /area/science/xenobiology)
 "ugC" = (
 /obj/structure/chair/office/light{
-	icon_state = "officechair_white";
 	dir = 4
 	},
 /obj/structure/disposalpipe/segment,

--- a/_maps/shuttles/emergency_cere.dmm
+++ b/_maps/shuttles/emergency_cere.dmm
@@ -100,7 +100,6 @@
 /area/shuttle/escape)
 "at" = (
 /obj/structure/chair/office/light{
-	icon_state = "officechair_white";
 	dir = 1
 	},
 /turf/open/floor/plasteel/dark,


### PR DESCRIPTION
:cl: Denton
tweak: Added a nanite lab to Deltastation! It's at the old EXPERIMENTOR lab.
tweak: Delta: Moved the Xenobiology disposals bin to be less obstructive. Added two sets of insulated gloves to Engineering.
fix: Delta: Fixed scientists not having maintenance access near the circuitry lab and toxins launch chamber.
/:cl:

I downsized Delta's EXPERIMENTOR lab and used the free space to add a nanite lab - two workspaces since Delta is for highpop.

Other than that, I added two sets of insulated gloves to Engineering; people were complaining that engineers are running out of gloves when the department is fully staffed. 
The Xenobio disposals bin is now in a less obstructive area and scientists have access to the maint doors near circuitry/toxins launch site.

![nanites son](https://user-images.githubusercontent.com/32391752/44949037-961a5380-ae29-11e8-807d-f77326fc30eb.PNG)
closes #40089