### PR TITLE
Buffs reconstruction surgery

### DIFF
--- a/code/modules/surgery/advanced/reconstruction.dm
+++ b/code/modules/surgery/advanced/reconstruction.dm
@@ -2,12 +2,9 @@
 	name = "Reconstruction"
 	desc = "A surgical procedure that gradually repairs damage done to a body without the assistance of chemicals. Unlike classic medicine, it is effective on corpses."
 	steps = list(/datum/surgery_step/incise,
-				/datum/surgery_step/incise,
 				/datum/surgery_step/retract_skin,
 				/datum/surgery_step/incise,
 				/datum/surgery_step/clamp_bleeders,
-				/datum/surgery_step/incise,
-				/datum/surgery_step/retract_skin,
 				/datum/surgery_step/reconstruct,
 				/datum/surgery_step/close)
 

--- a/code/modules/surgery/advanced/reconstruction.dm
+++ b/code/modules/surgery/advanced/reconstruction.dm
@@ -23,7 +23,7 @@
 
 /datum/surgery_step/reconstruct/success(mob/user, mob/living/carbon/target, target_zone, obj/item/tool, datum/surgery/surgery)
 	user.visible_message("[user] fixes some of [target]'s wounds.", "<span class='notice'>You succeed in fixing some of [target]'s wounds.</span>")
-	target.heal_bodypart_damage(10,10)
+	target.heal_bodypart_damage(30,30)
 	return TRUE
 
 /datum/surgery_step/reconstruct/failure(mob/user, mob/living/carbon/target, target_zone, obj/item/tool, datum/surgery/surgery)


### PR DESCRIPTION
[Changelogs]: # (Your PR should contain a detailed changelog of notable changes, titled and categorized appropriately. This includes, new features, sprites, sounds, balance changes, admin tools, map edits, removals, big refactors, config changes, hosting changes and important fixes. An example changelog has been provided below for you to edit. If you need additional help, read https://github.com/tgstation/tgstation/wiki/Changelogs)

:cl: Frosty Fridge
balance: Reduced steps for reconstruction surgery & increased healing
/:cl:

[why]: # (Please add a short description [two lines down] of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.)

At 8 surgery steps (9 if you include cauterizing), reconstruction is the longest surgery in the game. I don't believe that reconstruction warrants this many steps. This PR removes three steps from the surgery, making it a little faster to perform. 

Previously healed for 10/10 damage, which was absurdly low. Now heals for 30/30.