### PR TITLE
Improve supermatter Consume logging

### DIFF
--- a/code/modules/power/supermatter/supermatter.dm
+++ b/code/modules/power/supermatter/supermatter.dm
@@ -623,7 +623,11 @@ GLOBAL_DATUM(main_supermatter_engine, /obj/machinery/power/supermatter_crystal)
 		return
 	else if(isobj(AM))
 		if(!iseffect(AM))
-			investigate_log("has consumed [AM].", INVESTIGATE_SUPERMATTER)
+			var/suspicion = ""
+			if(AM.fingerprintslast)
+				suspicion = "last touched by [AM.fingerprintslast]"
+				message_admins("[src] has consumed [AM], [suspicion] [ADMIN_JMP(src)].")
+			investigate_log("has consumed [AM] - [suspicion].", INVESTIGATE_SUPERMATTER)
 		qdel(AM)
 	if(!iseffect(AM))
 		matter_power += 200


### PR DESCRIPTION
Log fingerprintslast (ckey) when an object smacks into a supermatter crystal.

:cl:
admin: Supermatter more likely to log fingerprintslast when it consumes any object.
/:cl:

Fixes #40013