### PR TITLE
Radiation balance tweaks

### DIFF
--- a/code/__DEFINES/radiation.dm
+++ b/code/__DEFINES/radiation.dm
@@ -12,7 +12,7 @@ Ask ninjanomnom if they're around
 #define RAD_MOB_SKIN_PROTECTION ((1/RAD_MOB_COEFFICIENT)+RAD_BACKGROUND_RADIATION)
 
 #define RAD_LOSS_PER_TICK 0.5
-#define RAD_TOX_COEFFICIENT 0.05					// Toxin damage per tick coefficient
+#define RAD_TOX_COEFFICIENT 0.08					// Toxin damage per tick coefficient
 #define RAD_OVERDOSE_REDUCTION 0.000001				// Coefficient to the reduction in applied rads once the thing, usualy mob, has too much radiation
 													// WARNING: This number is highly sensitive to change, graph is first for best results
 #define RAD_BURN_THRESHOLD 1000						// Applied radiation must be over this to burn
@@ -38,12 +38,12 @@ Ask ninjanomnom if they're around
 #define RAD_EXTREME_INSULATION 0.5					// What rad collectors have
 #define RAD_FULL_INSULATION 0						// Unused
 
-// WARNING: The deines below could have disastrous consequences if tweaked incorrectly. See: The great SM purge of Oct.6.2017
+// WARNING: The defines below could have disastrous consequences if tweaked incorrectly. See: The great SM purge of Oct.6.2017
 // contamination_chance = 		(strength-RAD_MINIMUM_CONTAMINATION) * RAD_CONTAMINATION_CHANCE_COEFFICIENT * min(1/(steps*RAD_DISTANCE_COEFFICIENT), 1))
 // contamination_strength = 	(strength-RAD_MINIMUM_CONTAMINATION) * RAD_CONTAMINATION_STR_COEFFICIENT
 #define RAD_MINIMUM_CONTAMINATION 350				// How strong does a radiation wave have to be to contaminate objects
-#define RAD_CONTAMINATION_CHANCE_COEFFICIENT 0.005	// Higher means higher strength scaling contamination chance
-#define RAD_CONTAMINATION_STR_COEFFICIENT 0.3		// Higher means higher strength scaling contamination strength
+#define RAD_CONTAMINATION_CHANCE_COEFFICIENT 0.01	// Higher means higher strength scaling contamination chance
+#define RAD_CONTAMINATION_STR_COEFFICIENT 0.25		// Higher means higher strength scaling contamination strength
 #define RAD_DISTANCE_COEFFICIENT 1					// Lower means further rad spread
 
 #define RAD_HALF_LIFE 90							// The half-life of contaminated objects

--- a/code/datums/components/radioactive.dm
+++ b/code/datums/components/radioactive.dm
@@ -24,8 +24,7 @@
 			RegisterSignal(parent, COMSIG_ITEM_ATTACK, .proc/rad_attack)
 			RegisterSignal(parent, COMSIG_ITEM_ATTACK_OBJ, .proc/rad_attack)
 	else
-		CRASH("Something that wasn't an atom was given /datum/component/radioactive")
-		return
+		return COMPONENT_INCOMPATIBLE
 
 	if(strength > RAD_MINIMUM_CONTAMINATION)
 		SSradiation.warn(src)

--- a/code/game/objects/structures/holosign.dm
+++ b/code/game/objects/structures/holosign.dm
@@ -83,6 +83,10 @@
 	. = ..()
 	air_update_turf(TRUE)
 
+/obj/structure/holosign/barrier/atmos/ComponentInitialize()
+	. = ..()
+	AddComponent(/datum/component/rad_insulation, RAD_LIGHT_INSULATION)
+
 /obj/structure/holosign/barrier/cyborg
 	name = "Energy Field"
 	desc = "A fragile energy field that blocks movement. Excels at blocking lethal projectiles."

--- a/code/game/objects/structures/watercloset.dm
+++ b/code/game/objects/structures/watercloset.dm
@@ -410,7 +410,7 @@
 	if(strength <= RAD_BACKGROUND_RADIATION)
 		qdel(healthy_green_glow)
 		return
-	healthy_green_glow.strength = max(strength-1, 0)
+	healthy_green_glow.strength -= max(0, (healthy_green_glow.strength - (RAD_BACKGROUND_RADIATION * 2)) * 0.2)
 
 /obj/machinery/shower/process()
 	if(on)


### PR DESCRIPTION
:cl: ninjanomnom
balance: Radiation toxin damage has been slightly increased.
balance: Contaminated objects are overall a bit weaker but are easier to create in the first place.
balance: Showers deal with high amounts of contamination much faster but aren't that great at dealing with weakly contaminated objects.
add: Atmos holo-barriers have been given radiation insulation like the engineering ones.
/:cl:
