### PR TITLE
Adds reactive hardening nanites, along with an adjust_damage signal

### DIFF
--- a/code/__DEFINES/components.dm
+++ b/code/__DEFINES/components.dm
@@ -126,6 +126,7 @@
 #define COMSIG_MOB_HUD_CREATED "mob_hud_created"				//from base of mob/create_mob_hud(): ()
 
 // /mob/living signals
+#define COMSIG_LIVING_ADJUST_DAMAGE "adjust_damage"				//from base of several damage procs (damage_type, amount)
 #define COMSIG_LIVING_RESIST "living_resist"					//from base of mob/living/resist() (/mob/living)
 #define COMSIG_LIVING_IGNITED "living_ignite"					//from base of mob/living/IgniteMob() (/mob/living)
 #define COMSIG_LIVING_EXTINGUISHED "living_extinguished"		//from base of mob/living/ExtinguishMob() (/mob/living)

--- a/code/datums/components/nanites.dm
+++ b/code/datums/components/nanites.dm
@@ -51,6 +51,7 @@
 		RegisterSignal(parent, COMSIG_ATOM_EMP_ACT, .proc/on_emp)
 		RegisterSignal(parent, COMSIG_MOB_DEATH, .proc/on_death)
 		RegisterSignal(parent, COMSIG_MOB_ALLOWED, .proc/check_access)
+		RegisterSignal(parent, COMSIG_LIVING_ADJUST_DAMAGE, .proc/on_damage)
 		RegisterSignal(parent, COMSIG_LIVING_ELECTROCUTE_ACT, .proc/on_shock)
 		RegisterSignal(parent, COMSIG_LIVING_MINOR_SHOCK, .proc/on_minor_shock)
 		RegisterSignal(parent, COMSIG_MOVABLE_HEAR, .proc/on_hear)
@@ -190,6 +191,11 @@
 		var/datum/nanite_program/NP = X
 		NP.on_minor_shock()
 
+/datum/component/nanites/proc/on_damage(datum/source, damage_type, amount)
+	for(var/X in programs)
+		var/datum/nanite_program/NP = X
+		NP.on_damage(damage_type, amount)		
+		
 /datum/component/nanites/proc/on_death(datum/source, gibbed)
 	for(var/X in programs)
 		var/datum/nanite_program/NP = X

--- a/code/modules/mob/living/carbon/damage_procs.dm
+++ b/code/modules/mob/living/carbon/damage_procs.dm
@@ -101,6 +101,7 @@
 		take_overall_damage(0, 0, amount, updating_health)
 	else
 		heal_overall_damage(0, 0, abs(amount), FALSE, FALSE, updating_health)
+	SEND_SIGNAL(src, COMSIG_LIVING_ADJUST_DAMAGE, STAMINA, amount)
 	return amount
 
 /mob/living/carbon/setStaminaLoss(amount, updating = TRUE, forced = FALSE)
@@ -225,6 +226,7 @@
 	if(!B)
 		return
 	B.adjust_brain_damage(amount, maximum)
+	SEND_SIGNAL(src, COMSIG_LIVING_ADJUST_DAMAGE, BRAIN, amount)
 	if(amount <= 0) //cut this early
 		return
 	var/brainloss = getBrainLoss()

--- a/code/modules/mob/living/damage_procs.dm
+++ b/code/modules/mob/living/damage_procs.dm
@@ -146,6 +146,7 @@
 	if(!forced && (status_flags & GODMODE))
 		return FALSE
 	bruteloss = CLAMP((bruteloss + (amount * CONFIG_GET(number/damage_multiplier))), 0, maxHealth * 2)
+	SEND_SIGNAL(src, COMSIG_LIVING_ADJUST_DAMAGE, BRUTE, amount)
 	if(updating_health)
 		updatehealth()
 	return amount
@@ -157,6 +158,7 @@
 	if(!forced && (status_flags & GODMODE))
 		return FALSE
 	oxyloss = CLAMP((oxyloss + (amount * CONFIG_GET(number/damage_multiplier))), 0, maxHealth * 2)
+	SEND_SIGNAL(src, COMSIG_LIVING_ADJUST_DAMAGE, OXY, amount)
 	if(updating_health)
 		updatehealth()
 	return amount
@@ -176,6 +178,7 @@
 	if(!forced && (status_flags & GODMODE))
 		return FALSE
 	toxloss = CLAMP((toxloss + (amount * CONFIG_GET(number/damage_multiplier))), 0, maxHealth * 2)
+	SEND_SIGNAL(src, COMSIG_LIVING_ADJUST_DAMAGE, TOX, amount)
 	if(updating_health)
 		updatehealth()
 	return amount
@@ -195,6 +198,7 @@
 	if(!forced && (status_flags & GODMODE))
 		return FALSE
 	fireloss = CLAMP((fireloss + (amount * CONFIG_GET(number/damage_multiplier))), 0, maxHealth * 2)
+	SEND_SIGNAL(src, COMSIG_LIVING_ADJUST_DAMAGE, BURN, amount)
 	if(updating_health)
 		updatehealth()
 	return amount
@@ -206,6 +210,7 @@
 	if(!forced && (status_flags & GODMODE))
 		return FALSE
 	cloneloss = CLAMP((cloneloss + (amount * CONFIG_GET(number/damage_multiplier))), 0, maxHealth * 2)
+	SEND_SIGNAL(src, COMSIG_LIVING_ADJUST_DAMAGE, CLONE, amount)
 	if(updating_health)
 		updatehealth()
 	return amount

--- a/code/modules/research/designs/nanite_designs.dm
+++ b/code/modules/research/designs/nanite_designs.dm
@@ -193,6 +193,13 @@
 	id = "refractive_nanites"
 	program_type = /datum/nanite_program/refractive
 	category = list("Augmentation Nanites")
+	
+/datum/design/nanites/reactive_hardening
+	name = "Reactive Hardening"
+	desc = "The nanites form a mesh under the host's skin that reacts to physical damage, becoming extremely durable for a limited time. Can be triggered to activate the effect manually."
+	id = "reactive_hardening_nanites"
+	program_type = /datum/nanite_program/triggered/reactive_hardening
+	category = list("Augmentation Nanites")
 
 /datum/design/nanites/coagulating
 	name = "Rapid Coagulation"

--- a/code/modules/research/nanites/nanite_programs.dm
+++ b/code/modules/research/nanites/nanite_programs.dm
@@ -200,6 +200,9 @@
 
 /datum/nanite_program/proc/on_death()
 	return
+	
+/datum/nanite_program/proc/on_damage(damage_type, amount)
+	return
 
 /datum/nanite_program/proc/on_hear(message, atom/movable/speaker, message_language, raw_message, radio_freq, list/spans, message_mode)
 	return

--- a/code/modules/research/nanites/nanite_programs/buffing.dm
+++ b/code/modules/research/nanites/nanite_programs/buffing.dm
@@ -105,7 +105,7 @@
 	nanomachines()
 	timer_id = addtimer(CALLBACK(src, .proc/son), harden_duration)
 
-/datum/nanite_program/hardening/disable_passive_effect()
+/datum/nanite_program/triggered/reactive_hardening/disable_passive_effect()
 	. = ..()
 	son() //you ran out of nanomachines son
 	

--- a/code/modules/research/nanites/nanite_programs/buffing.dm
+++ b/code/modules/research/nanites/nanite_programs/buffing.dm
@@ -136,10 +136,10 @@
 
 /datum/nanite_program/triggered/reactive_hardening/set_extra_setting(user, setting)
 	if(setting == "Hardening Duration")
-		var/new_duration = input(user, "Choose the duration of the hardening effect in deciseconds.", name, harden_duration) as null|num
+		var/new_duration = input(user, "Choose the duration of the hardening effect in deciseconds. (Max 150)", name, harden_duration) as null|num
 		if(isnull(new_duration))
 			return
-		new_duration = CLAMP(round(new_duration, 1), 20, 6000)
+		new_duration = CLAMP(round(new_duration, 1), 20, 150)
 
 	if(setting == "Damage Threshold")
 		var/new_threshold = input(user, "Choose the amount of damage that will trigger the program. Set to 0 to disable reactive triggering.", name, trigger_threshold) as null|num

--- a/code/modules/research/nanites/nanite_programs/buffing.dm
+++ b/code/modules/research/nanites/nanite_programs/buffing.dm
@@ -43,8 +43,6 @@
 	use_rate = 0.5
 	rogue_types = list(/datum/nanite_program/skin_decay)
 
-//TODO on_hit effect that turns skin grey for a moment
-
 /datum/nanite_program/hardening/enable_passive_effect()
 	. = ..()
 	if(ishuman(host_mob))
@@ -58,7 +56,7 @@
 		var/mob/living/carbon/human/H = host_mob
 		H.physiology.armor.melee -= 50
 		H.physiology.armor.bullet -= 35
-
+	
 /datum/nanite_program/refractive
 	name = "Dermal Refractive Surface"
 	desc = "The nanites form a membrane above the host's skin, reducing the effect of laser and energy impacts."
@@ -78,6 +76,86 @@
 		var/mob/living/carbon/human/H = host_mob
 		H.physiology.armor.laser -= 50
 		H.physiology.armor.energy -= 35
+	
+/datum/nanite_program/triggered/reactive_hardening
+	name = "Reactive Hardening"
+	desc = "The nanites form a mesh under the host's skin that reacts to physical damage, becoming extremely durable for a limited time. Can be triggered to activate the effect manually."
+	use_rate = 0.25
+	trigger_cost = 10
+	trigger_cooldown = 100
+	rogue_types = list(/datum/nanite_program/skin_decay)
+	extra_settings = list("Hardening Duration","Damage Threshold")
+	var/hardened = FALSE
+	var/harden_duration = 50
+	var/trigger_threshold = 10
+	var/timer_id
+	
+/datum/nanite_program/triggered/reactive_hardening/on_damage(damage_type, amount)
+	if(!trigger_threshold)
+		return
+	if(!hardened && (damage_type == BRUTE || damage_type == BURN) && amount >= trigger_threshold)
+		trigger()
+	
+/datum/nanite_program/triggered/reactive_hardening/trigger()
+	if(hardened) //turning it off is free
+		son()
+		return
+	if(!..())
+		return
+	nanomachines()
+	timer_id = addtimer(CALLBACK(src, .proc/son), harden_duration)
+
+/datum/nanite_program/hardening/disable_passive_effect()
+	. = ..()
+	son() //you ran out of nanomachines son
+	
+/datum/nanite_program/triggered/reactive_hardening/proc/nanomachines()
+	if(ishuman(host_mob))
+		var/mob/living/carbon/human/H = host_mob
+		hardened = TRUE
+		H.visible_message("<span class='warning'>[H]'s skin is suddenly covered in metal!</span>", "<span class='notice'>Your skin hardens and becomes metallic as nanites cover it!</span>")
+		H.physiology.brute_mod *= 0.1
+		H.physiology.burn_mod *= 0.1
+		H.add_trait(TRAIT_PIERCEIMMUNE, "reactive_hardening")
+		H.add_trait(TRAIT_NODISMEMBER, "reactive_hardening")
+		use_rate = 7
+
+/datum/nanite_program/triggered/reactive_hardening/proc/son()
+	if(ishuman(host_mob) && hardened)
+		var/mob/living/carbon/human/H = host_mob
+		hardened = FALSE
+		if(timer_id)
+			deltimer(timer_id)
+		timer_id = null
+		H.visible_message("<span class='warning'>The metal covering [H] is reabsorbed into [H.p_their()] skin.</span>", "<span class='notice'>You feel your skin return to normal.</span>")
+		H.physiology.brute_mod /= 0.1
+		H.physiology.burn_mod /= 0.1
+		H.remove_trait(TRAIT_PIERCEIMMUNE, "reactive_hardening")
+		H.remove_trait(TRAIT_NODISMEMBER, "reactive_hardening")
+		use_rate = initial(use_rate)
+
+/datum/nanite_program/triggered/reactive_hardening/set_extra_setting(user, setting)
+	if(setting == "Hardening Duration")
+		var/new_duration = input(user, "Choose the duration of the hardening effect in deciseconds.", name, harden_duration) as null|num
+		if(isnull(new_duration))
+			return
+		new_duration = CLAMP(round(new_duration, 1), 20, 6000)
+
+	if(setting == "Damage Threshold")
+		var/new_threshold = input(user, "Choose the amount of damage that will trigger the program. Set to 0 to disable reactive triggering.", name, trigger_threshold) as null|num
+		if(isnull(new_threshold))
+			return
+		new_threshold = CLAMP(round(new_threshold, 1), 0, 200)
+
+/datum/nanite_program/triggered/reactive_hardening/get_extra_setting(setting)
+	if(setting == "Hardening Duration")
+		return harden_duration
+	if(setting == "Damage Threshold")
+		return trigger_threshold
+
+/datum/nanite_program/triggered/reactive_hardening/copy_extra_settings_to(datum/nanite_program/triggered/reactive_hardening/target)
+	target.harden_duration = harden_duration
+	target.trigger_threshold = trigger_threshold
 
 /datum/nanite_program/coagulating
 	name = "Rapid Coagulation"

--- a/code/modules/research/techweb/all_nodes.dm
+++ b/code/modules/research/techweb/all_nodes.dm
@@ -879,7 +879,7 @@
 	display_name = "Harmonic Nanite Programming"
 	description = "Nanite programs that require seamless integration between nanites and biology."
 	prereq_ids = list("nanite_bio","nanite_smart","nanite_mesh")
-	design_ids = list("fakedeath_nanites","aggressive_nanites","defib_nanites","regenerative_plus_nanites","brainheal_plus_nanites","purging_plus_nanites","adrenaline_nanites")
+	design_ids = list("fakedeath_nanites","reactive_hardening_nanites","aggressive_nanites","defib_nanites","regenerative_plus_nanites","brainheal_plus_nanites","purging_plus_nanites","adrenaline_nanites")
 	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = 4000)
 	export_price = 8000
 

--- a/code/modules/surgery/bodyparts/bodyparts.dm
+++ b/code/modules/surgery/bodyparts/bodyparts.dm
@@ -173,12 +173,18 @@
 
 	brute_dam += brute
 	burn_dam += burn
+	
+	SEND_SIGNAL(owner, COMSIG_LIVING_ADJUST_DAMAGE, BRUTE, brute)
+	SEND_SIGNAL(owner, COMSIG_LIVING_ADJUST_DAMAGE, BURN, burn)
 
 	//We've dealt the physical damages, if there's room lets apply the stamina damage.
 	var/current_damage = get_damage(TRUE)		//This time around, count stamina loss too.
 	var/available_damage = max_damage - current_damage
-	stamina_dam += round(CLAMP(stamina, 0, min(max_stamina_damage - stamina_dam, available_damage)), DAMAGE_PRECISION)
-
+	var/stamina_hit = round(CLAMP(stamina, 0, min(max_stamina_damage - stamina_dam, available_damage)), DAMAGE_PRECISION)
+	stamina_dam += stamina_hit
+	
+	SEND_SIGNAL(owner, COMSIG_LIVING_ADJUST_DAMAGE, STAMINA, stamina_hit)
+	
 	if(owner && updating_health)
 		owner.updatehealth()
 		if(stamina > DAMAGE_PRECISION)
@@ -197,6 +203,10 @@
 
 	if(only_organic && status != BODYPART_ORGANIC) //This makes robolimbs not healable by chems.
 		return
+		
+	SEND_SIGNAL(owner, COMSIG_LIVING_ADJUST_DAMAGE, BRUTE, brute)
+	SEND_SIGNAL(owner, COMSIG_LIVING_ADJUST_DAMAGE, BURN, burn)
+	SEND_SIGNAL(owner, COMSIG_LIVING_ADJUST_DAMAGE, STAMINA, stamina)
 
 	brute_dam	= round(max(brute_dam - brute, 0), DAMAGE_PRECISION)
 	burn_dam	= round(max(burn_dam - burn, 0), DAMAGE_PRECISION)


### PR DESCRIPTION
:cl: XDTM
add: Added the Reactive Hardening nanite program; when triggered, makes the host temporarily incredibly resistant to brute and burn damage, but rapidly drains nanites in the meantime. Automatically triggers when receiving damage above a set threshold.
/:cl:

Finally, the program we were all waiting for! As soon as someone implements increased punch damage i'll put it in as well.
No actual skin color changes until i find a non-snowflake way of doing it.
