### PR TITLE
Fix stealth box and chameleon projector escaping lockers

### DIFF
--- a/code/datums/action.dm
+++ b/code/datums/action.dm
@@ -502,14 +502,14 @@
 /datum/action/item_action/agent_box/Trigger()
 	if(!..())
 		return FALSE
-	if(!box)
+	if(!QDELETED(box))
 		if(cooldown < world.time - 100)
-			box = new(get_turf(owner))
+			box = new(owner.drop_location())
 			owner.forceMove(box)
 			cooldown = world.time
 			owner.playsound_local(box, 'sound/misc/box_deploy.ogg', 50, TRUE)
 	else
-		owner.forceMove(get_turf(box))
+		owner.forceMove(box.drop_location())
 		owner.playsound_local(box, 'sound/misc/box_deploy.ogg', 50, TRUE)
 		QDEL_NULL(box)
 

--- a/code/game/objects/items/devices/chameleonproj.dm
+++ b/code/game/objects/items/devices/chameleonproj.dm
@@ -77,7 +77,7 @@
 		new /obj/effect/temp_visual/emp/pulse(get_turf(src))
 	else
 		playsound(get_turf(src), 'sound/effects/pop.ogg', 100, 1, -6)
-		var/obj/effect/dummy/chameleon/C = new/obj/effect/dummy/chameleon(get_turf(user))
+		var/obj/effect/dummy/chameleon/C = new/obj/effect/dummy/chameleon(user.drop_location())
 		C.activate(user, saved_appearance, src)
 		to_chat(user, "<span class='notice'>You activate \the [src].</span>")
 		new /obj/effect/temp_visual/emp/pulse(get_turf(src))


### PR DESCRIPTION
:cl:
fix: The stealth box and chameleon projector no longer allow escaping lockers.
fix: Combining the stealth box and chameleon projector should cause less teleportation behavior.
/:cl:

Fixes #39652.
Fixes #39984.
Fixes #40071.