### PR TITLE
Fix runtime on navigation computer first use

### DIFF
--- a/code/modules/shuttle/navigation_computer.dm
+++ b/code/modules/shuttle/navigation_computer.dm
@@ -57,9 +57,8 @@
 		shuttle_port = null
 		return
 
-	eyeobj = new /mob/camera/aiEye/remote/shuttle_docker()
+	eyeobj = new /mob/camera/aiEye/remote/shuttle_docker(null, src)
 	var/mob/camera/aiEye/remote/shuttle_docker/the_eye = eyeobj
-	the_eye.origin = src
 	the_eye.setDir(shuttle_port.dir)
 	var/turf/origin = locate(shuttle_port.x + x_offset, shuttle_port.y + y_offset, shuttle_port.z)
 	for(var/V in shuttle_port.shuttle_areas)
@@ -73,7 +72,7 @@
 			I.loc = locate(origin.x + x_off, origin.y + y_off, origin.z) //we have to set this after creating the image because it might be null, and images created in nullspace are immutable.
 			I.layer = ABOVE_NORMAL_TURF_LAYER
 			I.plane = 0
-			I.mouse_opacity = 0
+			I.mouse_opacity = MOUSE_OPACITY_TRANSPARENT
 			the_eye.placement_images[I] = list(x_off, y_off)
 
 /obj/machinery/computer/camera_advanced/shuttle_docker/give_eye_control(mob/user)
@@ -250,6 +249,7 @@
 /obj/machinery/computer/camera_advanced/shuttle_docker/proc/connect_to_shuttle(obj/docking_port/mobile/port, obj/docking_port/stationary/dock, idnum, override=FALSE)
 	if(port && (shuttleId == initial(shuttleId) || override))
 		shuttleId = port.id
+		shuttlePortId = "[port.id]_custom"
 	if(dock)
 		jumpto_ports += dock.id
 
@@ -258,6 +258,10 @@
 	use_static = USE_STATIC_NONE
 	var/list/placement_images = list()
 	var/list/placed_images = list()
+
+/mob/camera/aiEye/remote/shuttle_docker/Initialize(mapload, obj/machinery/computer/camera_advanced/origin)
+	src.origin = origin
+	return ..()
 
 /mob/camera/aiEye/remote/shuttle_docker/setLoc(T)
 	..()


### PR DESCRIPTION
`new()` calls `Initialize` calls `CreateEye` which reads `origin` which isn't set until after `new()` returns.

```
[12:18:31] Runtime in navigation_computer.dm, line 265: Cannot execute null.checkLandingSpot().
proc name: setLoc (/mob/camera/aiEye/remote/shuttle_docker/setLoc)
usr: *no key*/(Inactive Camera Eye)
src: Inactive Camera Eye (/mob/camera/aiEye/remote/shuttle_docker)
src.loc: null
call stack:
Inactive Camera Eye (/mob/camera/aiEye/remote/shuttle_docker): setLoc(null, 1)
Inactive Camera Eye (/mob/camera/aiEye/remote/shuttle_docker): Initialize(0)
Atoms (/datum/controller/subsystem/atoms): InitAtom(Inactive Camera Eye (/mob/camera/aiEye/remote/shuttle_docker), /list (/list))
Inactive Camera Eye (/mob/camera/aiEye/remote/shuttle_docker): New(0)
White Ship Navigation Computer (/obj/machinery/computer/camera_advanced/shuttle_docker/whiteship): CreateEye()
White Ship Navigation Computer (/obj/machinery/computer/camera_advanced/shuttle_docker/whiteship): attack hand(Joe Bine (/mob/living/carbon/human))
White Ship Navigation Computer (/obj/machinery/computer/camera_advanced/shuttle_docker/whiteship): attack hand(Joe Bine (/mob/living/carbon/human))
Joe Bine (/mob/living/carbon/human): UnarmedAttack(White Ship Navigation Computer (/obj/machinery/computer/camera_advanced/shuttle_docker/whiteship), 1)
Joe Bine (/mob/living/carbon/human): ClickOn(White Ship Navigation Computer (/obj/machinery/computer/camera_advanced/shuttle_docker/whiteship), "icon-x=14;icon-y=19;left=1;scr...")
White Ship Navigation Computer (/obj/machinery/computer/camera_advanced/shuttle_docker/whiteship): Click(the floor (97,107,2) (/turf/open/floor/plasteel/darkblue/side), "mapwindow.map", "icon-x=14;icon-y=19;left=1;scr...")
SpaceManiac (/client): Click(White Ship Navigation Computer (/obj/machinery/computer/camera_advanced/shuttle_docker/whiteship), the floor (97,107,2) (/turf/open/floor/plasteel/darkblue/side), "mapwindow.map", "icon-x=14;icon-y=19;left=1;scr...")
```