### PR TITLE
bike horns and most things that have the squeak component no longer triggers from projectiles flying past them

### DIFF
--- a/code/datums/components/squeak.dm
+++ b/code/datums/components/squeak.dm
@@ -18,7 +18,7 @@
 	RegisterSignal(parent, list(COMSIG_ATOM_ENTERED, COMSIG_ATOM_BLOB_ACT, COMSIG_ATOM_HULK_ATTACK, COMSIG_PARENT_ATTACKBY), .proc/play_squeak)
 	if(ismovableatom(parent))
 		RegisterSignal(parent, list(COMSIG_MOVABLE_BUMP, COMSIG_MOVABLE_IMPACT), .proc/play_squeak)
-		RegisterSignal(parent, COMSIG_MOVABLE_CROSSED, .proc/play_squeak_turf)
+		RegisterSignal(parent, COMSIG_MOVABLE_CROSSED, .proc/play_squeak_crossed)
 		RegisterSignal(parent, COMSIG_MOVABLE_DISPOSING, .proc/disposing_react)
 		if(isitem(parent))
 			RegisterSignal(parent, list(COMSIG_ITEM_ATTACK, COMSIG_ITEM_ATTACK_OBJ, COMSIG_ITEM_HIT_REACT), .proc/play_squeak)
@@ -52,6 +52,15 @@
 	else
 		steps++
 
+/datum/component/squeak/proc/play_squeak_crossed(atom/movable/AM)
+	if(AM.flags_1 & ABSTRACT_1)
+		return
+	if(istype(AM, /obj/item/projectile))
+		var/obj/item/projectile/P = AM
+		if(P.original != parent)
+			return
+	return play_squeak_turf()
+	
 /datum/component/squeak/proc/play_squeak_turf()
 	var/atom/current_parent = parent
 	if(isturf(current_parent.loc))

--- a/code/datums/components/squeak.dm
+++ b/code/datums/components/squeak.dm
@@ -53,8 +53,10 @@
 		steps++
 
 /datum/component/squeak/proc/play_squeak_crossed(atom/movable/AM)
-	if(AM.flags_1 & ABSTRACT_1)
-		return
+	if(isitem(AM))
+		var/obj/item/I = AM
+		if(I.item_flags & ABSTRACT)
+			return
 	if(istype(AM, /obj/item/projectile))
 		var/obj/item/projectile/P = AM
 		if(P.original != parent)

--- a/code/datums/components/squeak.dm
+++ b/code/datums/components/squeak.dm
@@ -57,13 +57,10 @@
 		var/obj/item/I = AM
 		if(I.item_flags & ABSTRACT)
 			return
-	if(istype(AM, /obj/item/projectile))
-		var/obj/item/projectile/P = AM
-		if(P.original != parent)
-			return
-	return play_squeak_turf()
-	
-/datum/component/squeak/proc/play_squeak_turf()
+		else if(istype(AM, /obj/item/projectile))
+			var/obj/item/projectile/P = AM
+			if(P.original != parent)
+				return
 	var/atom/current_parent = parent
 	if(isturf(current_parent.loc))
 		play_squeak()


### PR DESCRIPTION
why: doesn't make sense for these things to trigger from a projectile flying above them.
still happens if you directly target (and hit) them.

fixes #40054 