### PR TITLE
Make shuttle getStatusText more useful

### DIFF
--- a/code/modules/shuttle/shuttle.dm
+++ b/code/modules/shuttle/shuttle.dm
@@ -664,14 +664,19 @@
 
 /obj/docking_port/mobile/proc/getStatusText()
 	var/obj/docking_port/stationary/dockedAt = get_docked()
-	. = (dockedAt && dockedAt.name) ? dockedAt.name : "unknown"
+
 	if(istype(dockedAt, /obj/docking_port/stationary/transit))
-		var/obj/docking_port/stationary/dst
-		if(mode == SHUTTLE_RECALL)
-			dst = previous
+		if (timeLeft() > 1 HOURS)
+			return "hyperspace"
 		else
-			dst = destination
-		. += " towards [dst ? dst.name : "unknown location"] ([timeLeft(600)] minutes)"
+			var/obj/docking_port/stationary/dst
+			if(mode == SHUTTLE_RECALL)
+				dst = previous
+			else
+				dst = destination
+			. = "transit towards [dst?.name || "unknown location"] ([getTimerStr()])"
+	else
+		return dockedAt?.name || "unknown"
 
 
 /obj/docking_port/mobile/proc/getDbgStatusText()


### PR DESCRIPTION
:cl:
tweak: The status messages shown by shuttle consoles are now more useful.
/:cl:

Something along the lines of:

>transit towards mining outpost (00:43)

Instead of:

>Transit for mining/Mining Shuttle to mining outpost (0 minutes)

More accurate time, doesn't dump the shuttle ID (supposed to be internal) and name (already onscreen).