### PR TITLE
Fix double-wide shuttle airlocks losing their cycle-link

### DIFF
--- a/code/modules/shuttle/on_move.dm
+++ b/code/modules/shuttle/on_move.dm
@@ -183,10 +183,12 @@ All ShuttleMove procs go here
 
 /obj/machinery/door/airlock/afterShuttleMove(turf/oldT, list/movement_force, shuttle_dir, shuttle_preferred_direction, move_dir, rotation)
 	. = ..()
+	var/current_area = get_area(src)
 	for(var/obj/machinery/door/airlock/A in orange(1, src))  // does not include src
-		// Cycle linking is only disabled if we are actually adjacent to another airlock
-		shuttledocked = TRUE
-		A.shuttledocked = TRUE
+		if(get_area(A) != current_area)  // does not include double-wide airlocks unless actually docked
+			// Cycle linking is only disabled if we are actually adjacent to another airlock
+			shuttledocked = TRUE
+			A.shuttledocked = TRUE
 
 /obj/machinery/camera/beforeShuttleMove(turf/newT, rotation, move_mode, obj/docking_port/mobile/moving_dock)
 	. = ..()

--- a/code/modules/shuttle/shuttle_rotate.dm
+++ b/code/modules/shuttle/shuttle_rotate.dm
@@ -106,9 +106,11 @@ If ever any of these procs are useful for non-shuttles, rename it to proc/rotate
 
 /obj/machinery/door/airlock/shuttleRotate(rotation, params)
 	. = ..()
-	if(cyclelinkeddir)
+	if(cyclelinkeddir && (params & ROTATE_DIR))
 		cyclelinkeddir = angle2dir(rotation+dir2angle(cyclelinkeddir))
-		cyclelinkairlock()
+		// If we update the linked airlock here, the partner airlock might
+		// not be present yet, so don't do that. Just assume we're still
+		// partnered with the same airlock as before.
 
 /obj/machinery/porta_turret/shuttleRotate(rotation, params)
 	. = ..()


### PR DESCRIPTION
:cl:
fix: Double-wide shuttle airlocks now cycle link properly, rather than always thinking they are docked.
/:cl:

Also fixes a pointless and annoying "WARNING: can't find the cycle-linked airlock" every time a shuttle with cycle-linked airlocks moves.