### PR TITLE
Should fix vanishing chems (Issue #39045)

### DIFF
--- a/code/modules/reagents/chemistry/holder.dm
+++ b/code/modules/reagents/chemistry/holder.dm
@@ -551,7 +551,7 @@
 		WARNING("[my_atom] attempted to add a reagent called '[reagent]' which doesn't exist. ([usr])")
 		return FALSE
 	
- 	update_total()
+	update_total()
 	var/cached_total = total_volume
 	if(cached_total + amount > maximum_volume)
 		amount = (maximum_volume - cached_total) //Doesnt fit in. Make it disappear. Shouldnt happen. Will happen.


### PR DESCRIPTION
:cl:
fix: Chemicals should no longer vanish for some reactions.
/:cl:

fixes #39045
Removes a sneaky space from line 554 of holder.dm, which seems to have been causing this.
