### PR TITLE
Health sensor's detect death mode triggers on -100 health, not -90

### DIFF
--- a/code/modules/assembly/health.dm
+++ b/code/modules/assembly/health.dm
@@ -8,7 +8,7 @@
 
 	var/scanning = FALSE
 	var/health_scan
-	var/alarm_health = 0
+	var/alarm_health = HEALTH_THRESHOLD_CRIT
 
 /obj/item/assembly/health/examine(mob/user)
 	..()
@@ -31,11 +31,11 @@
 	return secured
 
 /obj/item/assembly/health/multitool_act(mob/living/user, obj/item/I)
-	if(alarm_health == 0)
-		alarm_health = -100
+	if(alarm_health == HEALTH_THRESHOLD_CRIT)
+		alarm_health = HEALTH_THRESHOLD_DEAD
 		to_chat(user, "<span class='notice'>You toggle [src] to \"detect death\" mode.</span>")
 	else
-		alarm_health = 0
+		alarm_health = HEALTH_THRESHOLD_CRIT
 		to_chat(user, "<span class='notice'>You toggle [src] to \"detect critical state\" mode.</span>")
 	return TRUE
 

--- a/code/modules/assembly/health.dm
+++ b/code/modules/assembly/health.dm
@@ -32,7 +32,7 @@
 
 /obj/item/assembly/health/multitool_act(mob/living/user, obj/item/I)
 	if(alarm_health == 0)
-		alarm_health = -90
+		alarm_health = -100
 		to_chat(user, "<span class='notice'>You toggle [src] to \"detect death\" mode.</span>")
 	else
 		alarm_health = 0


### PR DESCRIPTION
:cl: 
tweak: Health sensor's 'detect death' mode now triggers on death rather than extreme unwellness.
/:cl:

[why]: Being able to detect the bearer's death allows for the use of mechanisms such as a replica pod harvester and behaves as the mode name would suggest, rather than detecting being very unwell as currently.