### PR TITLE
SMES can no longer output to nowhere.

### DIFF
--- a/code/modules/power/power.dm
+++ b/code/modules/power/power.dm
@@ -28,6 +28,7 @@
 /obj/machinery/power/proc/add_avail(amount)
 	if(powernet)
 		powernet.newavail += amount
+		return TRUE
 	else
 		return FALSE
 

--- a/code/modules/power/power.dm
+++ b/code/modules/power/power.dm
@@ -28,6 +28,8 @@
 /obj/machinery/power/proc/add_avail(amount)
 	if(powernet)
 		powernet.newavail += amount
+	else
+		return 0
 
 /obj/machinery/power/proc/add_load(amount)
 	if(powernet)

--- a/code/modules/power/power.dm
+++ b/code/modules/power/power.dm
@@ -29,7 +29,7 @@
 	if(powernet)
 		powernet.newavail += amount
 	else
-		return 0
+		return FALSE
 
 /obj/machinery/power/proc/add_load(amount)
 	if(powernet)
@@ -54,13 +54,13 @@
 // defaults to power_channel
 /obj/machinery/proc/powered(var/chan = -1) // defaults to power_channel
 	if(!loc)
-		return 0
+		return FALSE
 	if(!use_power)
-		return 1
+		return TRUE
 
 	var/area/A = get_area(src)		// make sure it's in an area
 	if(!A)
-		return 0					// if not, then not powered
+		return FALSE					// if not, then not powered
 	if(chan == -1)
 		chan = power_channel
 	return A.powered(chan)	// return power status of the area
@@ -97,21 +97,21 @@
 /obj/machinery/power/proc/connect_to_network()
 	var/turf/T = src.loc
 	if(!T || !istype(T))
-		return 0
+		return FALSE
 
 	var/obj/structure/cable/C = T.get_cable_node() //check if we have a node cable on the machine turf, the first found is picked
 	if(!C || !C.powernet)
-		return 0
+		return FALSE
 
 	C.powernet.add_machine(src)
-	return 1
+	return TRUE
 
 // remove and disconnect the machine from its current powernet
 /obj/machinery/power/proc/disconnect_from_network()
 	if(!powernet)
-		return 0
+		return FALSE
 	powernet.remove_machine(src)
-	return 1
+	return TRUE
 
 // attach a wire to a power machine - leads from the turf you are standing on
 //almost never called, overwritten by all power machines but terminal and generator

--- a/code/modules/power/smes.dm
+++ b/code/modules/power/smes.dm
@@ -24,14 +24,14 @@
 	var/capacity = 5e6 // maximum charge
 	var/charge = 0 // actual charge
 
-	var/input_attempt = 1 // 1 = attempting to charge, 0 = not attempting to charge
-	var/inputting = 1 // 1 = actually inputting, 0 = not inputting
+	var/input_attempt = TRUE // TRUE = attempting to charge, FALSE = not attempting to charge
+	var/inputting = TRUE // TRUE = actually inputting, FALSE = not inputting
 	var/input_level = 50000 // amount of power the SMES attempts to charge by
 	var/input_level_max = 200000 // cap on input_level
 	var/input_available = 0 // amount of charge available from input last tick
 
-	var/output_attempt = 1 // 1 = attempting to output, 0 = not attempting to output
-	var/outputting = 1 // 1 = actually outputting, 0 = not outputting
+	var/output_attempt = TRUE // TRUE = attempting to output, FALSE = not attempting to output
+	var/outputting = TRUE // TRUE = actually outputting, FALSE = not outputting
 	var/output_level = 50000 // amount of power the SMES attempts to output
 	var/output_level_max = 200000 // cap on output_level
 	var/output_used = 0 // amount of power actually outputted. may be less than output_level if the powernet returns excess power
@@ -249,13 +249,13 @@
 				terminal.add_load(load) // add the load to the terminal side network
 
 			else					// if not enough capcity
-				inputting = 0		// stop inputting
+				inputting = FALSE		// stop inputting
 
 		else
 			if(input_attempt && input_available > 0)
-				inputting = 1
+				inputting = TRUE
 	else
-		inputting = 0
+		inputting = FALSE
 
 	//outputting
 	if(output_attempt)
@@ -265,17 +265,17 @@
 			if (add_avail(output_used))				// add output to powernet if it exists (smes side)
 				charge -= output_used*SMESRATE		// reduce the storage (may be recovered in /restore() if excessive)
 			else
-				outputting = 0
+				outputting = FALSE
 
 			if(output_used < 0.0001)		// either from no charge or set to 0
-				outputting = 0
+				outputting = FALSE
 				investigate_log("lost power and turned <font color='red'>off</font>", INVESTIGATE_SINGULO)
 		else if(output_attempt && charge > output_level && output_level > 0)
-			outputting = 1
+			outputting = TRUE
 		else
 			output_used = 0
 	else
-		outputting = 0
+		outputting = FALSE
 
 	// only update icon if state changed
 	if(last_disp != chargedisplay() || last_chrg != inputting || last_onln != outputting)

--- a/code/modules/power/smes.dm
+++ b/code/modules/power/smes.dm
@@ -264,6 +264,7 @@
 
 			if (add_avail(output_used))				// add output to powernet if it exists (smes side)
 				charge -= output_used*SMESRATE		// reduce the storage (may be recovered in /restore() if excessive)
+			else
 				outputting = 0
 
 			if(output_used < 0.0001)		// either from no charge or set to 0

--- a/code/modules/power/smes.dm
+++ b/code/modules/power/smes.dm
@@ -246,7 +246,7 @@
 
 				charge += load * SMESRATE	// increase the charge
 
-				add_load(load)		// add the load to the terminal side network
+				terminal.add_load(load) // add the load to the terminal side network
 
 			else					// if not enough capcity
 				inputting = 0		// stop inputting
@@ -262,9 +262,9 @@
 		if(outputting)
 			output_used = min( charge/SMESRATE, output_level)		//limit output to that stored
 
-			charge -= output_used*SMESRATE		// reduce the storage (may be recovered in /restore() if excessive)
-
-			add_avail(output_used)				// add output to powernet (smes side)
+			if (add_avail(output_used))				// add output to powernet if it exists (smes side)
+				charge -= output_used*SMESRATE		// reduce the storage (may be recovered in /restore() if excessive)
+				outputting = 0
 
 			if(output_used < 0.0001)		// either from no charge or set to 0
 				outputting = 0
@@ -311,10 +311,6 @@
 		update_icon()
 	return
 
-
-/obj/machinery/power/smes/add_load(amount)
-	if(terminal && terminal.powernet)
-		terminal.powernet.load += amount
 
 /obj/machinery/power/smes/ui_interact(mob/user, ui_key = "main", datum/tgui/ui = null, force_open = FALSE, \
 										datum/tgui/master_ui = null, datum/ui_state/state = GLOB.default_state)


### PR DESCRIPTION
:cl: Skoglol
fix: SMES will no longer output if not connected to a powernet.
/:cl:

Makes SMES check if they are connected to a powernet before outputting. Also removes a duplicate proc used in input.