### PR TITLE
Adds a nul lcheck to camera_get_icon

### DIFF
--- a/code/modules/photography/camera/camera_image_capturing.dm
+++ b/code/modules/photography/camera/camera_image_capturing.dm
@@ -73,7 +73,8 @@
 			xo += AM.step_x
 			yo += AM.step_y
 		var/icon/img = getFlatIcon(A)
-		res.Blend(img, blendMode2iconMode(A.blend_mode), xo, yo)
+		if(img)
+			res.Blend(img, blendMode2iconMode(A.blend_mode), xo, yo)
 		CHECK_TICK
 
 	if(!silent)


### PR DESCRIPTION
Right so apparently some atoms don't have icons and wasn't accounted for
and no I am not causing the crashes.
I think.