### PR TITLE
Makes law upload consoles require RD access

### DIFF
--- a/code/game/machinery/computer/law.dm
+++ b/code/game/machinery/computer/law.dm
@@ -3,11 +3,15 @@
 /obj/machinery/computer/upload
 	var/mob/living/silicon/current = null //The target of future law uploads
 	icon_screen = "command"
+	req_access = list(ACCESS_RD)
 
 /obj/machinery/computer/upload/attackby(obj/item/O, mob/user, params)
 	if(istype(O, /obj/item/aiModule))
 		var/obj/item/aiModule/M = O
 		if(src.stat & (NOPOWER|BROKEN|MAINT))
+			return
+		if(!src.allowed(usr) && !M.bypass_access_check)
+			to_chat(usr, "<span class='danger'>Access Denied.</span>")
 			return
 		if(!current)
 			to_chat(user, "<span class='caution'>You haven't selected anything to transmit laws to!</span>")

--- a/code/game/objects/items/AI_modules.dm
+++ b/code/game/objects/items/AI_modules.dm
@@ -22,6 +22,7 @@ AI MODULES
 	throw_range = 7
 	var/list/laws = list()
 	var/bypass_law_amt_check = 0
+	var/bypass_access_check = FALSE
 	materials = list(MAT_GOLD=50)
 
 /obj/item/aiModule/examine(var/mob/user as mob)
@@ -461,6 +462,7 @@ AI MODULES
 /obj/item/aiModule/core/full/overthrow
 	name = "'Overthrow' Hacked AI Module"
 	law_id = "overthrow"
+	bypass_access_check = TRUE
 
 /obj/item/aiModule/core/full/overthrow/install(datum/ai_laws/law_datum, mob/user)
 	if(!user || !law_datum || !law_datum.owner)
@@ -497,6 +499,7 @@ AI MODULES
 	name = "Hacked AI Module"
 	desc = "An AI Module for hacking additional laws to an AI."
 	laws = list("")
+	bypass_access_check = TRUE
 
 /obj/item/aiModule/syndicate/attack_self(mob/user)
 	var/targName = stripped_input(user, "Please enter a new law for the AI.", "Freeform Law Entry", laws[1])


### PR DESCRIPTION
:cl:
tweak: Law upload consoles now require RD access. Hacked law boards can bypass it.
/:cl:

[why]: 
being able to subvert every single silicon on the station with the total effort of a few clicks on rnd console and no cost at all is dumb
investing 9 TC in hacked law board when you can achieve almost the same result with whatever variation of purge/freeform/onehuman you like also is dumb