### PR TITLE
Legacy defined ranks and admins now synced to db

### DIFF
--- a/code/__HELPERS/roundend.dm
+++ b/code/__HELPERS/roundend.dm
@@ -529,9 +529,6 @@
 		return
 	else if(load_admins(TRUE)) //returns true if there was a database failure and the backup was loaded from
 		return
-	var/datum/DBQuery/query_admin_rank_update = SSdbcore.NewQuery("UPDATE [format_table_name("player")] p INNER JOIN [format_table_name("admin")] a ON p.ckey = a.ckey SET p.lastadminrank = a.rank")
-	query_admin_rank_update.Execute()
-	qdel(query_admin_rank_update)
 	sync_ranks_with_db()
 	var/list/sql_admins = list()
 	for(var/datum/admins/A in GLOB.protected_admins)
@@ -539,6 +536,9 @@
 		var/sql_rank = sanitizeSQL(A.rank.name)
 		sql_admins = list(list("ckey" = "'[sql_ckey]'", "rank" = "'[sql_rank]'"))
 	SSdbcore.MassInsert(format_table_name("admin"), sql_admins, duplicate_key = TRUE)
+	var/datum/DBQuery/query_admin_rank_update = SSdbcore.NewQuery("UPDATE [format_table_name("player")] p INNER JOIN [format_table_name("admin")] a ON p.ckey = a.ckey SET p.lastadminrank = a.rank")
+	query_admin_rank_update.Execute()
+	qdel(query_admin_rank_update)
 
 	//json format backup file generation stored per server
 	var/json_file = file("data/admins_backup.json")

--- a/code/__HELPERS/roundend.dm
+++ b/code/__HELPERS/roundend.dm
@@ -522,6 +522,9 @@
 	return objective_parts.Join("<br>")
 
 /datum/controller/subsystem/ticker/proc/save_admin_data()
+	if(IsAdminAdvancedProcCall())
+		to_chat(usr, "<span class='admin prefix'>Admin rank DB Sync blocked: Advanced ProcCall detected.</span>")
+		return
 	if(CONFIG_GET(flag/admin_legacy_system)) //we're already using legacy system so there's nothing to save
 		return
 	else if(load_admins(TRUE)) //returns true if there was a database failure and the backup was loaded from
@@ -529,6 +532,13 @@
 	var/datum/DBQuery/query_admin_rank_update = SSdbcore.NewQuery("UPDATE [format_table_name("player")] p INNER JOIN [format_table_name("admin")] a ON p.ckey = a.ckey SET p.lastadminrank = a.rank")
 	query_admin_rank_update.Execute()
 	qdel(query_admin_rank_update)
+	sync_ranks_with_db()
+	var/list/sql_admins = list()
+	for(var/datum/admins/A in GLOB.protected_admins)
+		var/sql_ckey = sanitizeSQL(A.owner.ckey)
+		var/sql_rank = sanitizeSQL(A.rank.name)
+		sql_admins = list(list("ckey" = "'[sql_ckey]'", "rank" = "'[sql_rank]'"))
+	SSdbcore.MassInsert(format_table_name("admin"), sql_admins, duplicate_key = TRUE)
 
 	//json format backup file generation stored per server
 	var/json_file = file("data/admins_backup.json")
@@ -559,14 +569,15 @@
 			flags += "can_edit_flags"
 		if(!flags.len)
 			continue
+		var/sql_rank = sanitizeSQL(R.name)
 		var/flags_to_check = flags.Join(" != [R_EVERYTHING] AND ") + " != [R_EVERYTHING]"
-		var/datum/DBQuery/query_check_everything_ranks = SSdbcore.NewQuery("SELECT flags, exclude_flags, can_edit_flags FROM [format_table_name("admin_ranks")] WHERE rank = '[R.name]' AND ([flags_to_check])")
+		var/datum/DBQuery/query_check_everything_ranks = SSdbcore.NewQuery("SELECT flags, exclude_flags, can_edit_flags FROM [format_table_name("admin_ranks")] WHERE rank = '[sql_rank]' AND ([flags_to_check])")
 		if(!query_check_everything_ranks.Execute())
 			qdel(query_check_everything_ranks)
 			return
 		if(query_check_everything_ranks.NextRow()) //no row is returned if the rank already has the correct flag value
 			var/flags_to_update = flags.Join(" = [R_EVERYTHING], ") + " = [R_EVERYTHING]"
-			var/datum/DBQuery/query_update_everything_ranks = SSdbcore.NewQuery("UPDATE [format_table_name("admin_ranks")] SET [flags_to_update] WHERE rank = '[R.name]'")
+			var/datum/DBQuery/query_update_everything_ranks = SSdbcore.NewQuery("UPDATE [format_table_name("admin_ranks")] SET [flags_to_update] WHERE rank = '[sql_rank]'")
 			if(!query_update_everything_ranks.Execute())
 				qdel(query_update_everything_ranks)
 				return

--- a/code/modules/admin/admin_ranks.dm
+++ b/code/modules/admin/admin_ranks.dm
@@ -108,6 +108,7 @@ GLOBAL_PROTECT(protected_ranks)
 	var/flag = admin_keyword_to_flag(word)
 	if(flag)
 		return ((rank.rights & flag) == flag) //true only if right has everything in flag
+
 /proc/sync_ranks_with_db()
 	set waitfor = FALSE
 
@@ -116,13 +117,14 @@ GLOBAL_PROTECT(protected_ranks)
 		return
 
 	var/list/sql_ranks = list()
-	for(var/datum/admin_rank/R in GLOB.admin_ranks)
+	for(var/datum/admin_rank/R in GLOB.protected_ranks)
 		var/sql_rank = sanitizeSQL(R.name)
 		var/sql_flags = sanitizeSQL(R.include_rights)
 		var/sql_exclude_flags = sanitizeSQL(R.exclude_rights)
 		var/sql_can_edit_flags = sanitizeSQL(R.can_edit_rights)
 		sql_ranks += list(list("rank" = "'[sql_rank]'", "flags" = "[sql_flags]", "exclude_flags" = "[sql_exclude_flags]", "can_edit_flags" = "[sql_can_edit_flags]"))
 	SSdbcore.MassInsert(format_table_name("admin_ranks"), sql_ranks, duplicate_key = TRUE)
+
 //load our rank - > rights associations
 /proc/load_admin_ranks(dbfail, no_update)
 	if(IsAdminAdvancedProcCall())


### PR DESCRIPTION
Since it's possible for a ckey or rank to exist only on the txts or to have a ckey with a rank different in the txt to the db. This matters for i.e. rank-based filtering since it'd see only the rank an admin held before they were added to `admins.txt`. Removals from the txt are not handled.

Also fixed an unsanitized value in `update_everything_flag_in_db()`