### PR TITLE
[READY] Janitor balance and QoL changes

### DIFF
--- a/code/game/objects/effects/decals/cleanable.dm
+++ b/code/game/objects/effects/decals/cleanable.dm
@@ -74,6 +74,8 @@
 		var/mob/living/carbon/human/H = O
 		if(H.shoes && blood_state && bloodiness && !H.has_trait(TRAIT_LIGHT_STEP))
 			var/obj/item/clothing/shoes/S = H.shoes
+			if(!S.can_be_bloody)
+				return
 			var/add_blood = 0
 			if(bloodiness >= BLOOD_GAIN_PER_STEP)
 				add_blood = BLOOD_GAIN_PER_STEP

--- a/code/game/objects/items/clown_items.dm
+++ b/code/game/objects/items/clown_items.dm
@@ -24,37 +24,47 @@
 	throw_speed = 3
 	throw_range = 7
 	grind_results = list("lye" = 10)
-	var/cleanspeed = 50 //slower than mop
+	var/cleanspeed = 35 //slower than mop
 	force_string = "robust... against germs"
+	var/uses = 100
 
 /obj/item/soap/Initialize()
 	. = ..()
 	AddComponent(/datum/component/slippery, 80)
 
 /obj/item/soap/nanotrasen
-	desc = "A Nanotrasen brand bar of soap. Smells of plasma."
+	desc = "A heavy duty bar of Nanotrasen brand soap. Smells of plasma."
+	grind_results = list("plasma" = 10, "lye" = 10)
 	icon_state = "soapnt"
+	cleanspeed = 28 //janitor gets this
+	uses = 300
 
 /obj/item/soap/homemade
 	desc = "A homemade bar of soap. Smells of... well...."
 	icon_state = "soapgibs"
-	cleanspeed = 45 // a little faster to reward chemists for going to the effort
+	cleanspeed = 30 // faster to reward chemists for going to the effort
 
 /obj/item/soap/deluxe
 	desc = "A deluxe Waffle Co. brand bar of soap. Smells of high-class luxury."
 	icon_state = "soapdeluxe"
-	cleanspeed = 40 //same speed as mop because deluxe -- captain gets one of these
+	cleanspeed = 20 //captain gets one of these
 
 /obj/item/soap/syndie
 	desc = "An untrustworthy bar of soap made of strong chemical agents that dissolve blood faster."
 	icon_state = "soapsyndie"
-	cleanspeed = 10 //much faster than mop so it is useful for traitors who want to clean crime scenes
+	cleanspeed = 5 //faster than mop so it is useful for traitors who want to clean crime scenes
 
 /obj/item/soap/suicide_act(mob/user)
 	user.say(";FFFFFFFFFFFFFFFFUUUUUUUDGE!!", forced="soap suicide")
 	user.visible_message("<span class='suicide'>[user] lifts [src] to [user.p_their()] mouth and gnaws on it furiously, producing a thick froth! [user.p_they(TRUE)]'ll never get that BB gun now!</span>")
 	new /obj/effect/particle_effect/foam(loc)
 	return (TOXLOSS)
+
+/obj/item/soap/proc/decreaseUses(mob/user)
+	uses--
+	if(uses <= 0)
+		to_chat(user, "<span class='warning'>The soap runs out!</span>")
+		qdel(src)
 
 /obj/item/soap/afterattack(atom/target, mob/user, proximity)
 	. = ..()
@@ -69,11 +79,14 @@
 		if(do_after(user, src.cleanspeed, target = target))
 			to_chat(user, "<span class='notice'>You scrub \the [target.name] out.</span>")
 			qdel(target)
+			decreaseUses(user)
+
 	else if(ishuman(target) && user.zone_selected == BODY_ZONE_PRECISE_MOUTH)
 		var/mob/living/carbon/human/H = user
 		user.visible_message("<span class='warning'>\the [user] washes \the [target]'s mouth out with [src.name]!</span>", "<span class='notice'>You wash \the [target]'s mouth out with [src.name]!</span>") //washes mouth out with soap sounds better than 'the soap' here
 		H.lip_style = null //removes lipstick
 		H.update_body()
+		decreaseUses(user)
 		return
 	else if(istype(target, /obj/structure/window))
 		user.visible_message("[user] begins to clean \the [target.name] with [src]...", "<span class='notice'>You begin to clean \the [target.name] with [src]...</span>")
@@ -81,15 +94,17 @@
 			to_chat(user, "<span class='notice'>You clean \the [target.name].</span>")
 			target.remove_atom_colour(WASHABLE_COLOUR_PRIORITY)
 			target.set_opacity(initial(target.opacity))
+			decreaseUses(user)
 	else
 		user.visible_message("[user] begins to clean \the [target.name] with [src]...", "<span class='notice'>You begin to clean \the [target.name] with [src]...</span>")
 		if(do_after(user, src.cleanspeed, target = target))
 			to_chat(user, "<span class='notice'>You clean \the [target.name].</span>")
-			var/obj/effect/decal/cleanable/C = locate() in target
-			qdel(C)
+			for(var/obj/effect/decal/cleanable/C in target)
+				qdel(C)
 			target.remove_atom_colour(WASHABLE_COLOUR_PRIORITY)
 			SEND_SIGNAL(target, COMSIG_COMPONENT_CLEAN_ACT, CLEAN_MEDIUM)
 			target.wash_cream()
+			decreaseUses(user)
 	return
 
 

--- a/code/game/objects/items/devices/lightreplacer.dm
+++ b/code/game/objects/items/devices/lightreplacer.dm
@@ -154,6 +154,8 @@
 	Emag()
 
 /obj/item/lightreplacer/attack_self(mob/user)
+	for(var/obj/machinery/light/target in user.loc)
+		ReplaceLight(target, user)
 	to_chat(user, status_string())
 
 /obj/item/lightreplacer/update_icon()

--- a/code/game/objects/items/holosign_creator.dm
+++ b/code/game/objects/items/holosign_creator.dm
@@ -59,6 +59,12 @@
 			qdel(H)
 		to_chat(user, "<span class='notice'>You clear all active holograms.</span>")
 
+/obj/item/holosign_creator/janibarrier
+	name = "custodial holobarrier projector"
+	desc = "A holographic projector that creates hard light wet floor barriers."
+	holosign_type = /obj/structure/holosign/barrier/wetsign
+	creation_time = 20
+	max_signs = 12
 
 /obj/item/holosign_creator/security
 	name = "security holobarrier projector"

--- a/code/game/objects/items/mop.dm
+++ b/code/game/objects/items/mop.dm
@@ -5,8 +5,8 @@
 	icon_state = "mop"
 	lefthand_file = 'icons/mob/inhands/equipment/custodial_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/equipment/custodial_righthand.dmi'
-	force = 3
-	throwforce = 5
+	force = 8
+	throwforce = 10
 	throw_speed = 3
 	throw_range = 7
 	w_class = WEIGHT_CLASS_NORMAL
@@ -14,8 +14,8 @@
 	resistance_flags = FLAMMABLE
 	var/mopping = 0
 	var/mopcount = 0
-	var/mopcap = 5
-	var/mopspeed = 30
+	var/mopcap = 15
+	var/mopspeed = 15
 	force_string = "robust... against germs"
 	var/insertable = TRUE
 
@@ -83,10 +83,10 @@
 	item_state = "mop"
 	lefthand_file = 'icons/mob/inhands/equipment/custodial_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/equipment/custodial_righthand.dmi'
-	force = 6
-	throwforce = 8
+	force = 12
+	throwforce = 14
 	throw_range = 4
-	mopspeed = 20
+	mopspeed = 8
 	var/refill_enabled = TRUE //Self-refill toggle for when a janitor decides to mop with something other than water.
 	var/refill_rate = 1 //Rate per process() tick mop refills itself
 	var/refill_reagent = "water" //Determins what reagent to use for refilling, just in case someone wanted to make a HOLY MOP OF PURGING

--- a/code/game/objects/items/storage/boxes.dm
+++ b/code/game/objects/items/storage/boxes.dm
@@ -591,7 +591,7 @@
 	STR.max_items = 21
 	STR.can_hold = typecacheof(list(/obj/item/light/tube, /obj/item/light/bulb))
 	STR.max_combined_w_class = 21
-	STR.click_gather = TRUE
+	STR.click_gather = FALSE //temp workaround to re-enable filling the light replacer with the box
 
 /obj/item/storage/box/lights/bulbs/PopulateContents()
 	for(var/i in 1 to 21)

--- a/code/game/objects/items/tanks/watertank.dm
+++ b/code/game/objects/items/tanks/watertank.dm
@@ -142,8 +142,8 @@
 
 //Janitor tank
 /obj/item/watertank/janitor
-	name = "backpack water tank"
-	desc = "A janitorial watertank backpack with nozzle to clean dirt and graffiti."
+	name = "backpack cleaner tank"
+	desc = "A janitorial cleaner backpack with nozzle to clean blood and graffiti."
 	icon_state = "waterbackpackjani"
 	item_state = "waterbackpackjani"
 

--- a/code/game/objects/structures/holosign.dm
+++ b/code/game/objects/structures/holosign.dm
@@ -43,7 +43,7 @@
 	icon_state = "holosign"
 
 /obj/structure/holosign/barrier
-	name = "holo barrier"
+	name = "holobarrier"
 	desc = "A short holographic barrier which can only be passed by walking."
 	icon_state = "holosign_sec"
 	pass_flags = LETPASSTHROW
@@ -61,6 +61,12 @@
 		if(allow_walk && C.m_intent == MOVE_INTENT_WALK)
 			return 1
 
+/obj/structure/holosign/barrier/wetsign
+	name = "wet floor holobarrier"
+	desc = "When it says walk it means walk."
+	icon = 'icons/effects/effects.dmi'
+	icon_state = "holosign"
+
 /obj/structure/holosign/barrier/engineering
 	icon_state = "holosign_engi"
 
@@ -69,7 +75,7 @@
 	AddComponent(/datum/component/rad_insulation, RAD_LIGHT_INSULATION)
 
 /obj/structure/holosign/barrier/atmos
-	name = "holo firelock"
+	name = "holofirelock"
 	desc = "A holographic barrier resembling a firelock. Though it does not prevent solid objects from passing through, gas is kept out."
 	icon_state = "holo_firelock"
 	density = FALSE

--- a/code/game/objects/structures/janicart.dm
+++ b/code/game/objects/structures/janicart.dm
@@ -25,7 +25,8 @@
 		to_chat(user, "<span class='warning'>[src] is out of water!</span>")
 		return 0
 	else
-		reagents.trans_to(mop, 5)
+		var/obj/item/mop/M = mop
+		reagents.trans_to(mop, M.mopcap)
 		to_chat(user, "<span class='notice'>You wet [mop] in [src].</span>")
 		playsound(loc, 'sound/effects/slosh.ogg', 25, 1)
 		return 1

--- a/code/modules/clothing/chameleon.dm
+++ b/code/modules/clothing/chameleon.dm
@@ -507,6 +507,7 @@
 	item_color = "black"
 	desc = "A pair of black shoes."
 	clothing_flags = NOSLIP
+	can_be_bloody = FALSE
 
 /obj/item/clothing/shoes/chameleon/noslip/broken/Initialize()
 	. = ..()

--- a/code/modules/clothing/shoes/_shoes.dm
+++ b/code/modules/clothing/shoes/_shoes.dm
@@ -14,6 +14,7 @@
 	var/list/bloody_shoes = list(BLOOD_STATE_HUMAN = 0,BLOOD_STATE_XENO = 0, BLOOD_STATE_OIL = 0, BLOOD_STATE_NOT_BLOODY = 0)
 	var/offset = 0
 	var/equipped_before_drop = FALSE
+	var/can_be_bloody = TRUE
 
 /obj/item/clothing/shoes/ComponentInitialize()
 	. = ..()

--- a/code/modules/clothing/shoes/miscellaneous.dm
+++ b/code/modules/clothing/shoes/miscellaneous.dm
@@ -56,6 +56,7 @@
 	equip_delay_other = 50
 	resistance_flags = NONE
 	armor = list("melee" = 0, "bullet" = 0, "laser" = 0, "energy" = 0, "bomb" = 0, "bio" = 0, "rad" = 0, "fire" = 40, "acid" = 75)
+	can_be_bloody = FALSE
 
 /obj/item/clothing/shoes/galoshes/dry
 	name = "absorbent galoshes"

--- a/code/modules/clothing/suits/bio.dm
+++ b/code/modules/clothing/suits/bio.dm
@@ -60,7 +60,7 @@
 
 /obj/item/clothing/suit/bio_suit/janitor
 	icon_state = "bio_janitor"
-
+	allowed = list(/obj/item/storage/bag/trash)
 
 //Scientist's biosuit, white with a pink-ish hue
 /obj/item/clothing/head/bio_hood/scientist

--- a/code/modules/reagents/chemistry/reagents.dm
+++ b/code/modules/reagents/chemistry/reagents.dm
@@ -29,6 +29,7 @@
 	var/addiction_stage = 0
 	var/overdosed = 0 // You fucked up and this is now triggering its overdose effects, purge that shit quick.
 	var/self_consuming = FALSE
+	var/reagent_weight = 1 //affects how far it travels when sprayed
 
 /datum/reagent/Destroy() // This should only be called by the holder, so it's already handled clearing its references
 	. = ..()

--- a/code/modules/reagents/chemistry/reagents/other_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/other_reagents.dm
@@ -996,6 +996,7 @@
 	description = "A compound used to clean things. Now with 50% more sodium hypochlorite!"
 	color = "#A5F0EE" // rgb: 165, 240, 238
 	taste_description = "sourness"
+	reagent_weight = 0.6 //so it sprays further
 
 /datum/reagent/space_cleaner/reaction_obj(obj/O, reac_volume)
 	if(istype(O, /obj/effect/decal/cleanable))

--- a/code/modules/reagents/reagent_containers/spray.dm
+++ b/code/modules/reagents/reagent_containers/spray.dm
@@ -19,6 +19,7 @@
 	var/stream_range = 1 //the range of tiles the sprayer will reach when in stream mode.
 	var/stream_amount = 10 //the amount of reagents transfered when in stream mode.
 	var/can_fill_from_container = TRUE
+	var/average_reagent_weight = 0 //affects the distance the reagents spray
 	amount_per_transfer_from_this = 5
 	volume = 250
 	possible_transfer_amounts = list(5,10,15,20,25,30,50,100)
@@ -42,7 +43,7 @@
 		return
 
 	if(reagents.total_volume < amount_per_transfer_from_this)
-		to_chat(user, "<span class='warning'>[src] is empty!</span>")
+		to_chat(user, "<span class='warning'>Not enough left!</span>")
 		return
 
 	spray(A)
@@ -142,6 +143,18 @@
 		to_chat(usr, "<span class='notice'>You empty \the [src] onto the floor.</span>")
 		reagents.reaction(usr.loc)
 		src.reagents.clear_reagents()
+
+/obj/item/reagent_containers/spray/on_reagent_change(changetype)
+	var/total_reagent_weight
+	var/amount_of_reagents
+	for (var/datum/reagent/R in reagents.reagent_list)
+		total_reagent_weight = total_reagent_weight + R.reagent_weight
+		amount_of_reagents++
+
+	average_reagent_weight = total_reagent_weight / amount_of_reagents
+	spray_range = CLAMP(round((initial(spray_range) / average_reagent_weight) - ((amount_of_reagents - 1) * 1)), 3, 5) //spray distance between 3 and 5 tiles rounded down; extra reagents lose a tile
+	if(stream_mode == 0)
+		current_range = spray_range
 
 //space cleaner
 /obj/item/reagent_containers/spray/cleaner

--- a/code/modules/research/designs/misc_designs.dm
+++ b/code/modules/research/designs/misc_designs.dm
@@ -294,6 +294,17 @@
 	category = list("Equipment")
 	departmental_flags = DEPARTMENTAL_FLAG_SERVICE
 
+/datum/design/holobarrier_jani
+	name = "Custodial Holobarrier Projector"
+	desc = "A holograpic projector used to project hard light wet floor barriers."
+	id = "holobarrier_jani"
+	build_type = PROTOLATHE
+	materials = list(MAT_METAL = 2000, MAT_GLASS = 1000, MAT_SILVER = 1000)
+	build_path = /obj/structure/holosign/barrier/wetsign
+	category = list("Equipment")
+	departmental_flags = DEPARTMENTAL_FLAG_SERVICE
+
+
 /datum/design/holosignsec
 	name = "Security Holobarrier Projector"
 	desc = "A holographic projector that creates holographic security barriers."
@@ -361,7 +372,7 @@
 	build_path = /obj/item/flashlight/seclite
 	category = list("Equipment")
 	departmental_flags = DEPARTMENTAL_FLAG_SECURITY
-	
+
 /datum/design/detective_scanner
 	name = "Forensic Scanner"
 	desc = "Used to remotely scan objects and biomass for DNA and fingerprints. Can print a report of the findings."
@@ -371,7 +382,7 @@
 	build_path = /obj/item/detective_scanner
 	category = list("Equipment")
 	departmental_flags = DEPARTMENTAL_FLAG_SECURITY
-	
+
 /datum/design/pepperspray
 	name = "Pepper Spray"
 	desc = "Manufactured by UhangInc, used to blind and down an opponent quickly. Printed pepper sprays do not contain reagents."
@@ -381,7 +392,7 @@
 	build_path = /obj/item/reagent_containers/spray/pepper/empty
 	category = list("Equipment")
 	departmental_flags = DEPARTMENTAL_FLAG_SECURITY
-	
+
 /datum/design/bola_energy
 	name = "Energy Bola"
 	desc = "A specialized hard-light bola designed to ensnare fleeing criminals and aid in arrests."
@@ -391,7 +402,7 @@
 	build_path = /obj/item/restraints/legcuffs/bola/energy
 	category = list("Equipment")
 	departmental_flags = DEPARTMENTAL_FLAG_SECURITY
-	
+
 /datum/design/zipties
 	name = "Zipties"
 	desc = "Plastic, disposable zipties that can be used to restrain temporarily but are destroyed after use."
@@ -401,7 +412,7 @@
 	build_path = /obj/item/restraints/handcuffs/cable/zipties
 	category = list("Equipment")
 	departmental_flags = DEPARTMENTAL_FLAG_SECURITY
-	
+
 /datum/design/evidencebag
 	name = "Evidence Bag"
 	desc = "An empty evidence bag."

--- a/code/modules/vending/wardrobes.dm
+++ b/code/modules/vending/wardrobes.dm
@@ -250,7 +250,7 @@
 					/obj/item/caution = 6,
 					/obj/item/holosign_creator = 1,
 					/obj/item/lightreplacer = 1,
-					/obj/item/soap = 1,
+					/obj/item/soap/nanotrasen = 1,
 					/obj/item/storage/bag/trash = 1,
 					/obj/item/clothing/shoes/galoshes = 1,
 					/obj/item/watertank/janitor = 1,


### PR DESCRIPTION
[Changelogs]: # (Your PR should contain a detailed changelog of notable changes, titled and categorized appropriately. This includes, new features, sprites, sounds, balance changes, admin tools, map edits, removals, big refactors, config changes, hosting changes and important fixes. An example changelog has been provided below for you to edit. If you need additional help, read https://github.com/tgstation/tgstation/wiki/Changelogs)

:cl: cacogen
balance: Space cleaner in spray bottles travels 5 tiles instead of 3 (doesn't affect other reagents)
balance: Trash bag fits in exosuit slot of janitor biosuit
balance: All soaps are faster
balance: Soaps now clean all decals on a tile instead of just one
balance: Soap now has limited uses (100 for most, 300 for NT brand which janitor gets)
balance: Mops are considerably faster
balance: Basic mop holds twice the reagents  
balance: Janitorial cart now refills mops completely with one click
balance: Basic and advanced mops are more robust (8 force and 12 force)
balance: Galoshes no longer leave bloody footprints
balance: Chameleon noslips no longer leave bloody footprints
fix: Bulb boxes can be used on light replacers refill them in bulk
balance: Light replacer can be used in-hand to change all bulbs on a tile
add:  Custodial barrier projector which creates solid wet floor signs that force people to walk to pass (available through service protolathe)
/:cl:

[why]: # (Please add a short description [two lines down] of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.)

Janitor's been an exercise in futility for years, and the job is made redundant by janitor cyborgs who can't even keep up with the mess themselves. Spreading blood is instant, but takes a lot longer to clean. The goal here is to make it easier to keep up with the mess and make the controls less finicky while avoiding affecting combat too much (the ~~mop and~~ spray bottle ~~are~~ is a good weapon~~s~~ after all).

To-do:
- [x] make soap buff less extreme
- [x] remove use of integrity var
- [x] rename density vars to be more specific

What else I'd like to add:
- [x] make mops faster
- [x] increase reagents basic mop can hold
- [x] make holosigns force people to walk to pass
- [ ] ~~make mops/cleaner cover more tiles at once?~~

Here is an only slightly autistic and nearly exhaustive table of changes:

| Object                            | Change                          | Old      | New          |
| --------------------------------- | ------------------------------- | -------- | ------------ |
| **Mop**                           | Clean speed                     | 3 sec    | 1.5 sec      |
|                                   | Reagents held                   | 5u       | 15u          |
|                                   | Force                           | 3        | 8            |
|                                   | Throw force                     | 5        | 10           |
| **Advanced mop**                  | Clean speed                     | 2 sec    | 0.8 sec      |
|                                   | Force                           | 6        | 12           |
|                                   | Throw force                     | 8        | 14           |
| **Soap**                          | Clean speed                     | 5 secs   | 3.5 secs     |
|                                   | Uses                            | ∞        | 100          |
|                                   | In janidrobe                    | Yes      | No           |
|                                   | Decals cleaned per use          | 1        | All on tile  |
| **NT soap**                       | Clean speed                     | 5 secs   | 2.8 secs     |
|                                   | Uses                            | ∞        | 300          |
|                                   | In janidrobe                    | No       | Yes          |
|                                   | Decals cleaned per use          | 1        | All on tile  |
| **Homemade soap**                 | Clean speed                     | 4.5 secs | 3 secs       |
|                                   | Uses                            | ∞        | 100          |
|                                   | Decals cleaned per use          | 1        | All on tile  |
| **Deluxe soap**                   | Clean speed                     | 4 secs   | 2 secs       |
|                                   | Uses                            | ∞        | 100          |
|                                   | Decals cleaned per use          | 1        | All on tile  |
| **Syndie soap**                   | Clean speed                     | 1 sec    | 0.5 sec      |
|                                   | Uses                            | ∞        | 100          |
|                                   | Decals cleaned per use          | 1        | All on tile  |
| **Light replacer**                | Use in-hand instead of clicking | No       | Yes          |
|                                   | Use bulb box on to refill       | No       | Yes          |
| **Wet floor barrier projector**   | Exists                          | No       | yuh          |
| **Janitorial cart**               | Units added to mop per click    | 5u       | Mop capacity |
| **Galoshes**                      | Can leave bloody footprints     | Yes      | No           |
| **Chameleon noslips**             | Can leave bloody footprints     | Yes      | No           |
| **Janitor biosuit**               | Trash bag fits in exosuit storage    | No       | Yes          |
| **Space cleaner in spray bottle** | Distance                        | 3 tiles  | 5 tiles      |