### PR TITLE
Fixes nanite chambers not working under windows

### DIFF
--- a/code/modules/research/nanites/nanite_chamber.dm
+++ b/code/modules/research/nanites/nanite_chamber.dm
@@ -4,6 +4,7 @@
 	circuit = /obj/item/circuitboard/machine/nanite_chamber
 	icon = 'icons/obj/machines/nanite_chamber.dmi'
 	icon_state = "nanite_chamber"
+	layer = ABOVE_WINDOW_LAYER
 	use_power = IDLE_POWER_USE
 	anchored = TRUE
 	density = TRUE

--- a/code/modules/research/nanites/public_chamber.dm
+++ b/code/modules/research/nanites/public_chamber.dm
@@ -4,6 +4,7 @@
 	circuit = /obj/item/circuitboard/machine/public_nanite_chamber
 	icon = 'icons/obj/machines/nanite_chamber.dmi'
 	icon_state = "nanite_chamber"
+	layer = ABOVE_WINDOW_LAYER
 	use_power = IDLE_POWER_USE
 	anchored = TRUE
 	density = TRUE


### PR DESCRIPTION
:cl: XDTM
fix: Fixed nanite chambers not being interactable if placed under a window.
/:cl:

Same method that cryotubes apparently use, aka layering above windows. Another possible fix would be fixing the get_turf_pixel proc, which i'm not sure how to do without risking breaking something.

Fixes #40108 
Fixes #40138 
