### PR TITLE
Makes hand drills a better ghetto alternative for the surgical drill then regular screwdrivers

### DIFF
--- a/code/modules/surgery/organic_steps.dm
+++ b/code/modules/surgery/organic_steps.dm
@@ -89,7 +89,7 @@
 //drill bone
 /datum/surgery_step/drill
 	name = "drill bone"
-	implements = list(/obj/item/surgicaldrill = 100, /obj/item/pickaxe/drill = 60, /obj/item/mecha_parts/mecha_equipment/drill = 60, TOOL_SCREWDRIVER = 20)
+	implements = list(/obj/item/surgicaldrill = 100, /obj/item/screwdriver/power = 80, /obj/item/pickaxe/drill = 60, /obj/item/mecha_parts/mecha_equipment/drill = 60, TOOL_SCREWDRIVER = 20)
 	time = 30
 
 /datum/surgery_step/drill/preop(mob/user, mob/living/carbon/target, target_zone, obj/item/tool, datum/surgery/surgery)


### PR DESCRIPTION
:cl: barbedwireqtip
tweak: Hand drills are now better ghetto alternatives for surgical drills than standard screwdrivers
/:cl:

why: The hand drill is pretty much a souped-up screwdriver, so it makes sense that it'd be better for surgery than regular screwdrivers.

...not that anyone uses the surgical drill in the first place.