### PR TITLE
[READY] fixing atmos analyzer circuit

### DIFF
--- a/code/modules/integrated_electronics/subtypes/input.dm
+++ b/code/modules/integrated_electronics/subtypes/input.dm
@@ -1150,10 +1150,9 @@
 	for(var/i=1 to 6)
 		set_pin_data(IC_OUTPUT, i, null)
 	var/atom/target = get_pin_data_as_type(IC_INPUT, 1, /atom)
-	var/atom/movable/acting_object = get_object()
 	if(!target)
-		target = acting_object.loc
-	if(!target.Adjacent(acting_object))
+		target = get_turf(src)
+	if( get_dist(get_turf(target),get_turf(src)) > 1 )
 		activate_pin(3)
 		return
 


### PR DESCRIPTION
Didn't check tanks etc. that were in backpack, other hand, or for new PRs, in the same circuit.

[Changelogs]: # Now checks stuff inside its own assembly, in hand etc.

:cl: Shdorsh
fix: atmos analyzer circuit not analyzing certain stuff
/:cl:

[why]: # Needed for debugging certain stuff, especially new circuits for hippie and also for utility.

Tested and working, besides.