### PR TITLE
Automatically determine shuttle size and offsets from template

### DIFF
--- a/code/datums/shuttles.dm
+++ b/code/datums/shuttles.dm
@@ -12,6 +12,8 @@
 	var/credit_cost = INFINITY
 	var/can_be_bought = TRUE
 
+	var/port_x_offset
+	var/port_y_offset
 
 /datum/map_template/shuttle/proc/prerequisites_met()
 	return TRUE
@@ -20,6 +22,32 @@
 	shuttle_id = "[port_id]_[suffix]"
 	mappath = "[prefix][shuttle_id].dmm"
 	. = ..()
+
+/datum/map_template/shuttle/preload_size(path, cache)
+	. = ..(path, TRUE) // Done this way because we still want to know if someone actualy wanted to cache the map
+	if(!cached_map)
+		return
+
+	var/key
+	var/list/models = cached_map.grid_models
+	for(key in models)
+		if(findtext(models[key], "[/obj/docking_port/mobile]")) // Yay compile time checks
+			break // This works by assuming there will ever only be one mobile dock in a template at most
+	
+	var/datum/grid_set/gset
+	for(var/i in cached_map.gridSets)
+		gset = i
+		var/ycrd = gset.ycrd
+		for(var/line in gset.gridLines)
+			if(key != line)
+				ycrd--
+				continue
+			port_x_offset = gset.xcrd
+			port_y_offset = ycrd
+			break
+
+	if(!cache)
+		cached_map = null
 
 /datum/map_template/shuttle/load(turf/T, centered, register=TRUE)
 	. = ..()
@@ -35,9 +63,32 @@
 			continue
 		place.baseturfs.Insert(3, /turf/baseturf_skipover/shuttle)
 
-		if(register)
-			for(var/obj/docking_port/mobile/port in place)
+		for(var/obj/docking_port/mobile/port in place)
+			if(register)
 				port.register()
+			if(isnull(port_x_offset))
+				return
+			switch(port.dir) // Yeah this looks a little ugly but mappers had to do this in their head before
+				if(NORTH)
+					port.width = width
+					port.height = height
+					port.dwidth = port_x_offset - 1
+					port.dheight = port_y_offset - 1
+				if(EAST)
+					port.width = height
+					port.height = width
+					port.dwidth = height - port_y_offset
+					port.dheight = port_x_offset - 1
+				if(SOUTH)
+					port.width = width
+					port.height = height
+					port.dwidth = width - port_x_offset
+					port.dheight = height - port_y_offset
+				if(WEST)
+					port.width = height
+					port.height = width
+					port.dwidth = port_y_offset - 1
+					port.dheight = width - port_x_offset
 
 		for(var/obj/structure/closet/closet in place)
 			if(closet.anchorable)


### PR DESCRIPTION
:cl: ninjanomnom
code: Mappers no longer need to manually update the size and offset vars on mobile docks while mapping.
/:cl:

This requires the shuttle be in a template and the template must match the shuttle size.

Need I say more?