### PR TITLE
Emergency shuttle fix and tweaks

### DIFF
--- a/_maps/shuttles/emergency_asteroid.dmm
+++ b/_maps/shuttles/emergency_asteroid.dmm
@@ -402,6 +402,7 @@
 /obj/item/retractor,
 /obj/item/hemostat,
 /obj/item/scalpel,
+/obj/item/surgicaldrill,
 /turf/open/floor/mineral/titanium/white,
 /area/shuttle/escape)
 "bG" = (

--- a/_maps/shuttles/emergency_bar.dmm
+++ b/_maps/shuttles/emergency_bar.dmm
@@ -305,11 +305,11 @@
 /turf/open/floor/plasteel,
 /area/shuttle/escape)
 "aU" = (
-/mob/living/simple_animal/hostile/alien/maid/barmaid,
 /obj/effect/turf_decal/tile/bar,
 /obj/effect/turf_decal/tile/bar{
 	dir = 1
 	},
+/mob/living/simple_animal/hostile/alien/maid/barmaid,
 /turf/open/floor/plasteel,
 /area/shuttle/escape)
 "aW" = (
@@ -320,11 +320,11 @@
 /obj/machinery/light{
 	dir = 4
 	},
-/mob/living/simple_animal/drone/snowflake/bardrone,
 /obj/effect/turf_decal/tile/bar,
 /obj/effect/turf_decal/tile/bar{
 	dir = 1
 	},
+/mob/living/simple_animal/drone/snowflake/bardrone,
 /turf/open/floor/plasteel,
 /area/shuttle/escape)
 "aY" = (
@@ -472,6 +472,8 @@
 /obj/item/hemostat,
 /obj/item/retractor,
 /obj/item/scalpel,
+/obj/item/surgicaldrill,
+/obj/item/cautery,
 /turf/open/floor/mineral/titanium,
 /area/shuttle/escape)
 "bC" = (

--- a/_maps/shuttles/emergency_cere.dmm
+++ b/_maps/shuttles/emergency_cere.dmm
@@ -500,47 +500,12 @@
 /obj/structure/reagent_dispensers/peppertank{
 	pixel_x = -32
 	},
-/turf/open/floor/mineral/plastitanium/red/brig{
-	dir = 9;
-	floor_tile = /obj/item/stack/tile/plasteel;
-	icon_state = "darkred"
-	},
+/turf/open/floor/mineral/plastitanium/red/brig,
 /area/shuttle/escape)
 "aV" = (
 /obj/structure/table,
 /obj/item/book/manual/wiki/security_space_law,
-/turf/open/floor/mineral/plastitanium/red/brig{
-	icon_state = "darkred";
-	dir = 1;
-	floor_tile = /obj/item/stack/tile/plasteel
-	},
-/area/shuttle/escape)
-"aW" = (
-/obj/structure/chair/comfy/shuttle,
-/obj/machinery/light{
-	dir = 1
-	},
-/turf/open/floor/mineral/plastitanium/red/brig{
-	icon_state = "darkred";
-	dir = 1;
-	floor_tile = /obj/item/stack/tile/plasteel
-	},
-/area/shuttle/escape)
-"aX" = (
-/obj/structure/chair/comfy/shuttle,
-/turf/open/floor/mineral/plastitanium/red/brig{
-	icon_state = "darkred";
-	dir = 1;
-	floor_tile = /obj/item/stack/tile/plasteel
-	},
-/area/shuttle/escape)
-"aY" = (
-/obj/structure/chair/comfy/shuttle,
-/turf/open/floor/mineral/plastitanium/red/brig{
-	icon_state = "darkred";
-	dir = 5;
-	floor_tile = /obj/item/stack/tile/plasteel
-	},
+/turf/open/floor/mineral/plastitanium/red/brig,
 /area/shuttle/escape)
 "aZ" = (
 /obj/effect/turf_decal/tile/neutral{
@@ -560,7 +525,6 @@
 /area/shuttle/escape)
 "bb" = (
 /obj/machinery/mech_bay_recharge_port{
-	icon_state = "recharge_port";
 	dir = 2
 	},
 /turf/open/floor/plasteel,
@@ -596,25 +560,7 @@
 	},
 /obj/structure/table,
 /obj/machinery/recharger,
-/turf/open/floor/mineral/plastitanium/red/brig{
-	dir = 8;
-	floor_tile = /obj/item/stack/tile/plasteel;
-	icon_state = "darkred"
-	},
-/area/shuttle/escape)
-"bh" = (
-/turf/open/floor/mineral/plastitanium/red/brig{
-	icon_state = "darkred";
-	dir = 1;
-	floor_tile = /obj/item/stack/tile/plasteel
-	},
-/area/shuttle/escape)
-"bi" = (
-/turf/open/floor/mineral/plastitanium/red/brig{
-	dir = 4;
-	floor_tile = /obj/item/stack/tile/plasteel;
-	icon_state = "darkred"
-	},
+/turf/open/floor/mineral/plastitanium/red/brig,
 /area/shuttle/escape)
 "bj" = (
 /turf/open/floor/mech_bay_recharge_floor,
@@ -625,26 +571,12 @@
 	},
 /turf/open/floor/mineral/plastitanium/red/brig,
 /area/shuttle/escape)
-"bl" = (
-/turf/open/floor/mineral/plastitanium/red/brig{
-	dir = 8;
-	floor_tile = /obj/item/stack/tile/plasteel;
-	icon_state = "darkred"
-	},
-/area/shuttle/escape)
-"bm" = (
-/turf/open/floor/mineral/plastitanium/red/brig{
-	icon_state = "darkredfull"
-	},
-/area/shuttle/escape)
 "bn" = (
 /obj/machinery/door/airlock/security/glass{
 	name = "Emergency Shuttle Brig";
 	req_access_txt = "2"
 	},
-/turf/open/floor/mineral/plastitanium/red/brig{
-	icon_state = "darkredfull"
-	},
+/turf/open/floor/mineral/plastitanium/red/brig,
 /area/shuttle/escape)
 "bo" = (
 /obj/machinery/computer/mech_bay_power_console,
@@ -666,16 +598,7 @@
 	name = "Emergency Shuttle Brig";
 	req_access_txt = "2"
 	},
-/turf/open/floor/mineral/plastitanium/red/brig{
-	icon_state = "darkredfull"
-	},
-/area/shuttle/escape)
-"br" = (
-/turf/open/floor/mineral/plastitanium/red/brig{
-	icon_state = "darkred";
-	dir = 2;
-	floor_tile = /obj/item/stack/tile/plasteel
-	},
+/turf/open/floor/mineral/plastitanium/red/brig,
 /area/shuttle/escape)
 "bs" = (
 /obj/effect/turf_decal/stripes/line{
@@ -727,41 +650,13 @@
 /obj/structure/chair/comfy/shuttle{
 	dir = 1
 	},
-/turf/open/floor/mineral/plastitanium/red/brig{
-	icon_state = "darkred";
-	dir = 10;
-	floor_tile = /obj/item/stack/tile/plasteel
-	},
-/area/shuttle/escape)
-"bx" = (
-/obj/structure/chair/comfy/shuttle{
-	dir = 1
-	},
-/turf/open/floor/mineral/plastitanium/red/brig{
-	icon_state = "darkred";
-	dir = 2;
-	floor_tile = /obj/item/stack/tile/plasteel
-	},
+/turf/open/floor/mineral/plastitanium/red/brig,
 /area/shuttle/escape)
 "by" = (
 /obj/structure/table,
 /obj/item/storage/box/teargas,
 /obj/item/storage/box/zipties,
-/turf/open/floor/mineral/plastitanium/red/brig{
-	icon_state = "darkred";
-	dir = 2;
-	floor_tile = /obj/item/stack/tile/plasteel
-	},
-/area/shuttle/escape)
-"bz" = (
-/obj/structure/chair/comfy/shuttle{
-	dir = 1
-	},
-/turf/open/floor/mineral/plastitanium/red/brig{
-	dir = 6;
-	floor_tile = /obj/item/stack/tile/plasteel;
-	icon_state = "darkred"
-	},
+/turf/open/floor/mineral/plastitanium/red/brig,
 /area/shuttle/escape)
 "bA" = (
 /obj/machinery/door/airlock/shuttle{
@@ -1117,9 +1012,6 @@
 /turf/open/floor/plasteel,
 /area/shuttle/escape)
 "ch" = (
-/mob/living/simple_animal/bot/medbot{
-	name = "Speedy* Recovery"
-	},
 /obj/effect/turf_decal/tile/blue{
 	dir = 1
 	},
@@ -1128,6 +1020,9 @@
 	},
 /obj/effect/turf_decal/tile/blue{
 	dir = 8
+	},
+/mob/living/simple_animal/bot/medbot{
+	name = "Speedy* Recovery"
 	},
 /turf/open/floor/plasteel/white,
 /area/shuttle/escape)
@@ -2085,8 +1980,8 @@ aM
 ab
 aU
 bg
-bl
-bl
+be
+be
 bw
 ab
 bG
@@ -2128,10 +2023,10 @@ aI
 aN
 ab
 aV
-bh
-bl
-br
-bx
+be
+be
+be
+bw
 ac
 bH
 bR
@@ -2171,10 +2066,10 @@ aA
 aC
 aC
 ab
-aW
-bh
-bm
-br
+aT
+be
+be
+be
 by
 ac
 bI
@@ -2215,11 +2110,11 @@ aB
 aC
 aC
 ab
-aX
-bh
-bi
-br
-bx
+aS
+be
+be
+be
+bw
 ac
 bJ
 bR
@@ -2259,11 +2154,11 @@ aC
 aC
 aC
 ab
-aY
-bi
-bi
-bi
-bz
+aS
+be
+be
+be
+bw
 ab
 bK
 bR

--- a/_maps/shuttles/emergency_clown.dmm
+++ b/_maps/shuttles/emergency_clown.dmm
@@ -15,7 +15,7 @@
 "ae" = (
 /obj/structure/table,
 /obj/item/storage/firstaid/fire,
-/turf/open/floor/noslip,
+/turf/open/floor/mineral/bananium,
 /area/shuttle/escape)
 "af" = (
 /obj/structure/chair/comfy/shuttle{
@@ -34,13 +34,13 @@
 	pixel_y = 3
 	},
 /obj/item/crowbar,
-/turf/open/floor/noslip,
+/turf/open/floor/mineral/bananium,
 /area/shuttle/escape)
 "ai" = (
 /obj/machinery/computer/atmos_alert{
 	dir = 4
 	},
-/turf/open/floor/noslip,
+/turf/open/floor/mineral/bananium,
 /area/shuttle/escape)
 "aj" = (
 /obj/structure/chair/comfy/shuttle{
@@ -62,13 +62,13 @@
 /obj/machinery/computer/security{
 	dir = 8
 	},
-/turf/open/floor/noslip,
+/turf/open/floor/mineral/bananium,
 /area/shuttle/escape)
 "an" = (
 /obj/machinery/computer/crew{
 	dir = 4
 	},
-/turf/open/floor/noslip,
+/turf/open/floor/mineral/bananium,
 /area/shuttle/escape)
 "ao" = (
 /obj/structure/chair/comfy/shuttle{
@@ -96,10 +96,10 @@
 /obj/machinery/computer/communications{
 	dir = 8
 	},
-/turf/open/floor/noslip,
+/turf/open/floor/mineral/bananium,
 /area/shuttle/escape)
 "as" = (
-/obj/machinery/door/airlock/public/glass{
+/obj/machinery/door/airlock/bananium/glass{
 	name = "Emergency Shuttle Premium Lounge"
 	},
 /turf/open/floor/bluespace,
@@ -115,15 +115,7 @@
 /obj/machinery/light{
 	dir = 1
 	},
-/turf/open/floor/noslip,
-/area/shuttle/escape)
-"aw" = (
-/turf/open/floor/noslip,
-/area/shuttle/escape)
-"ax" = (
-/obj/structure/closet/emcloset,
-/obj/item/toy/sword,
-/turf/open/floor/noslip,
+/turf/open/floor/mineral/bananium,
 /area/shuttle/escape)
 "ay" = (
 /obj/structure/table,
@@ -133,7 +125,7 @@
 	pixel_y = 3
 	},
 /obj/item/crowbar,
-/turf/open/floor/noslip,
+/turf/open/floor/mineral/bananium,
 /area/shuttle/escape)
 "az" = (
 /obj/item/greentext/quiet{
@@ -142,31 +134,25 @@
 /turf/open/floor/mineral/plastitanium/red/brig,
 /area/shuttle/escape)
 "aA" = (
-/obj/machinery/door/airlock/public/glass{
+/obj/machinery/door/airlock/bananium/glass{
 	name = "Emergency Shuttle Greentext"
 	},
 /turf/open/floor/bluespace,
 /area/shuttle/escape)
-"aB" = (
-/obj/machinery/light/small{
-	dir = 4
-	},
-/turf/open/floor/noslip,
-/area/shuttle/escape)
 "aC" = (
 /obj/structure/chair/comfy/shuttle,
-/turf/open/floor/noslip,
+/turf/open/floor/mineral/bananium,
 /area/shuttle/escape)
 "aD" = (
 /obj/structure/chair/comfy/shuttle{
 	dir = 4
 	},
-/turf/open/floor/noslip,
+/turf/open/floor/mineral/bananium,
 /area/shuttle/escape)
 "aE" = (
 /obj/structure/table,
 /obj/item/multitool/ai_detect,
-/turf/open/floor/noslip,
+/turf/open/floor/mineral/bananium,
 /area/shuttle/escape)
 "aF" = (
 /turf/closed/wall/mineral/titanium/nodiagonal,
@@ -177,15 +163,15 @@
 /obj/machinery/light{
 	dir = 8
 	},
-/turf/open/floor/noslip,
+/turf/open/floor/mineral/bananium,
 /area/shuttle/escape)
 "aH" = (
 /obj/structure/table,
 /obj/item/toy/sword,
-/turf/open/floor/noslip,
+/turf/open/floor/mineral/bananium,
 /area/shuttle/escape)
 "aI" = (
-/obj/machinery/door/airlock/titanium{
+/obj/machinery/door/airlock/bananium{
 	name = "Emergency Shuttle Airlock"
 	},
 /obj/docking_port/mobile/emergency{
@@ -221,7 +207,7 @@
 "aM" = (
 /obj/structure/bed,
 /obj/item/bedsheet/random,
-/turf/open/floor/noslip,
+/turf/open/floor/mineral/bananium,
 /area/shuttle/escape)
 "aN" = (
 /obj/structure/window/reinforced{
@@ -229,7 +215,7 @@
 	},
 /obj/structure/bed,
 /obj/item/bedsheet/random,
-/turf/open/floor/noslip,
+/turf/open/floor/mineral/bananium,
 /area/shuttle/escape)
 "aO" = (
 /obj/structure/window/reinforced{
@@ -237,7 +223,7 @@
 	},
 /obj/structure/bed,
 /obj/item/bedsheet/random,
-/turf/open/floor/noslip,
+/turf/open/floor/mineral/bananium,
 /area/shuttle/escape)
 "aP" = (
 /obj/structure/bed,
@@ -245,10 +231,10 @@
 /obj/structure/window/reinforced{
 	dir = 8
 	},
-/turf/open/floor/noslip,
+/turf/open/floor/mineral/bananium,
 /area/shuttle/escape)
 "aQ" = (
-/obj/machinery/door/airlock/titanium{
+/obj/machinery/door/airlock/bananium{
 	name = "Emergency Shuttle Airlock"
 	},
 /turf/open/floor/plating,
@@ -266,13 +252,13 @@
 /turf/open/floor/bluespace,
 /area/shuttle/escape)
 "aT" = (
-/obj/machinery/door/airlock/titanium{
+/obj/machinery/door/airlock/bananium{
 	name = "Emergency Shuttle Cargo"
 	},
 /turf/open/floor/bluespace,
 /area/shuttle/escape)
 "aU" = (
-/obj/machinery/door/airlock/public/glass{
+/obj/machinery/door/airlock/bananium/glass{
 	name = "Emergency Shuttle Infirmary"
 	},
 /turf/open/floor/bluespace,
@@ -290,7 +276,7 @@
 /obj/machinery/sleeper{
 	dir = 8
 	},
-/turf/open/floor/noslip,
+/turf/open/floor/mineral/bananium,
 /area/shuttle/escape)
 "aY" = (
 /obj/machinery/light/small{
@@ -304,13 +290,6 @@
 	dir = 4
 	},
 /turf/open/floor/mineral/bananium,
-/area/shuttle/escape)
-"ba" = (
-/obj/machinery/light/small{
-	brightness = 3;
-	dir = 8
-	},
-/turf/open/floor/noslip,
 /area/shuttle/escape)
 "bb" = (
 /obj/structure/table,
@@ -326,7 +305,7 @@
 /obj/machinery/light/small{
 	dir = 4
 	},
-/turf/open/floor/noslip,
+/turf/open/floor/mineral/bananium,
 /area/shuttle/escape)
 "bc" = (
 /obj/structure/closet/crate/trashcart{
@@ -358,6 +337,11 @@
 "bg" = (
 /obj/structure/shuttle/engine/propulsion,
 /turf/open/floor/plating/airless,
+/area/shuttle/escape)
+"Zf" = (
+/obj/structure/closet/emcloset,
+/obj/item/toy/sword,
+/turf/open/floor/mineral/bananium,
 /area/shuttle/escape)
 
 (1,1,1) = {"
@@ -522,9 +506,9 @@ aN
 aN
 ak
 ac
-ax
-ba
-ax
+Zf
+aY
+Zf
 bf
 bg
 "}
@@ -534,7 +518,7 @@ ah
 al
 al
 at
-aw
+aV
 ak
 aE
 aH
@@ -546,9 +530,9 @@ aO
 aO
 ak
 aU
-aw
-aw
-aw
+aV
+aV
+aV
 bf
 bg
 "}
@@ -558,7 +542,7 @@ ad
 am
 ar
 ab
-ax
+Zf
 ak
 ak
 ak
@@ -570,9 +554,9 @@ ak
 ak
 ak
 ac
-aw
-aw
-aw
+aV
+aV
+aV
 bf
 bg
 "}
@@ -583,9 +567,9 @@ ab
 ab
 ab
 ay
-aB
-aw
-aw
+aZ
+aV
+aV
 aL
 aM
 aM

--- a/_maps/shuttles/emergency_delta.dmm
+++ b/_maps/shuttles/emergency_delta.dmm
@@ -176,6 +176,8 @@
 /obj/effect/turf_decal/tile/blue{
 	dir = 8
 	},
+/obj/item/surgicaldrill,
+/obj/item/cautery,
 /turf/open/floor/plasteel/white,
 /area/shuttle/escape)
 "an" = (

--- a/_maps/shuttles/emergency_imfedupwiththisworld.dmm
+++ b/_maps/shuttles/emergency_imfedupwiththisworld.dmm
@@ -55,7 +55,9 @@
 /obj/machinery/light{
 	dir = 4
 	},
-/obj/machinery/vending/boozeomat,
+/obj/machinery/vending/boozeomat{
+	req_access = null
+	},
 /obj/effect/turf_decal/tile/bar,
 /obj/effect/turf_decal/tile/bar{
 	dir = 1

--- a/_maps/shuttles/emergency_meta.dmm
+++ b/_maps/shuttles/emergency_meta.dmm
@@ -593,6 +593,8 @@
 	name = "Station Intercom (General)";
 	pixel_x = -27
 	},
+/obj/item/surgicaldrill,
+/obj/item/cautery,
 /turf/open/floor/mineral/titanium,
 /area/shuttle/escape)
 "bI" = (

--- a/_maps/shuttles/emergency_omega.dmm
+++ b/_maps/shuttles/emergency_omega.dmm
@@ -805,6 +805,8 @@
 /obj/effect/turf_decal/tile/blue{
 	dir = 8
 	},
+/obj/item/cautery,
+/obj/item/surgicaldrill,
 /turf/open/floor/plasteel/white,
 /area/shuttle/escape)
 "bo" = (

--- a/_maps/shuttles/emergency_raven.dmm
+++ b/_maps/shuttles/emergency_raven.dmm
@@ -238,6 +238,8 @@
 /obj/effect/turf_decal/tile/purple{
 	dir = 8
 	},
+/obj/item/surgicaldrill,
+/obj/item/cautery,
 /turf/open/floor/plasteel/dark,
 /area/shuttle/escape)
 "aC" = (
@@ -670,16 +672,16 @@
 /turf/closed/wall/mineral/plastitanium,
 /area/shuttle/escape)
 "bp" = (
-/mob/living/simple_animal/bot/medbot{
-	name = "\improper emergency medibot";
-	pixel_x = -3;
-	pixel_y = 2
-	},
 /obj/effect/turf_decal/tile/purple{
 	dir = 1
 	},
 /obj/effect/turf_decal/tile/purple{
 	dir = 8
+	},
+/mob/living/simple_animal/bot/medbot{
+	name = "\improper emergency medibot";
+	pixel_x = -3;
+	pixel_y = 2
 	},
 /turf/open/floor/plasteel/dark,
 /area/shuttle/escape)

--- a/_maps/shuttles/emergency_supermatter.dmm
+++ b/_maps/shuttles/emergency_supermatter.dmm
@@ -68,10 +68,6 @@
 	},
 /turf/open/floor/noslip,
 /area/shuttle/escape)
-"aq" = (
-/obj/machinery/status_display/evac,
-/turf/closed/wall/mineral/titanium,
-/area/shuttle/escape)
 "ar" = (
 /obj/structure/chair/comfy/shuttle{
 	dir = 8
@@ -313,6 +309,36 @@
 	},
 /turf/open/floor/plating,
 /area/shuttle/escape)
+"hD" = (
+/obj/structure/lattice/catwalk,
+/turf/open/space,
+/area/shuttle/escape)
+"pb" = (
+/obj/structure/closet/radiation{
+	anchored = 1
+	},
+/obj/item/clothing/glasses/meson/engine,
+/obj/machinery/status_display/evac{
+	pixel_x = 32
+	},
+/turf/open/floor/mineral/titanium/yellow,
+/area/shuttle/escape)
+"Bi" = (
+/obj/structure/closet/radiation{
+	anchored = 1
+	},
+/obj/item/clothing/glasses/meson/engine,
+/obj/machinery/status_display/evac{
+	pixel_x = -32
+	},
+/turf/open/floor/mineral/titanium/yellow,
+/area/shuttle/escape)
+"UA" = (
+/obj/machinery/status_display/evac{
+	pixel_y = -32
+	},
+/turf/open/floor/mineral/titanium/yellow,
+/area/shuttle/escape)
 
 (1,1,1) = {"
 aa
@@ -343,13 +369,13 @@ ae
 ae
 ad
 ac
-aq
+ae
 ad
 ax
 ai
 aD
-ai
-aq
+UA
+ae
 aa
 aa
 aN
@@ -357,7 +383,7 @@ aM
 aR
 aU
 aX
-at
+aM
 ba
 bc
 be
@@ -367,7 +393,7 @@ ac
 ag
 ag
 bi
-ag
+Bi
 ag
 ag
 ai
@@ -376,12 +402,12 @@ ai
 ad
 aa
 aa
-at
+aM
 aa
 aS
 aV
 aY
-at
+aM
 ba
 bc
 be
@@ -400,13 +426,13 @@ ar
 aI
 aw
 aa
-at
+aM
 aa
 aT
 aW
 aZ
 aa
-aM
+hD
 aa
 aa
 "}
@@ -423,11 +449,11 @@ as
 as
 bk
 ad
-at
+aM
 aO
 aa
 aa
-aM
+hD
 aa
 aa
 aR
@@ -449,11 +475,11 @@ at
 aL
 aM
 aM
-aM
-aM
-aM
-aM
-aM
+hD
+hD
+hD
+hD
+hD
 bb
 bd
 aY
@@ -471,11 +497,11 @@ au
 au
 bl
 ad
-at
+aM
 aP
 aa
 aa
-aM
+hD
 aa
 aa
 aT
@@ -496,13 +522,13 @@ av
 aI
 aw
 aa
-at
+aM
 aa
 aR
 aU
 aX
 aa
-aM
+hD
 aa
 aa
 "}
@@ -511,7 +537,7 @@ ac
 ag
 ag
 bj
-ag
+pb
 ag
 ag
 ai
@@ -520,12 +546,12 @@ ai
 ad
 aa
 aa
-at
+aM
 aa
 aS
 aV
 aY
-at
+aM
 ba
 bc
 be
@@ -535,13 +561,13 @@ ae
 ae
 ad
 ac
-aq
+ae
 ad
 ax
 ai
 aE
-ai
-aq
+UA
+ae
 aa
 aa
 aQ
@@ -549,7 +575,7 @@ aM
 aT
 aW
 aZ
-at
+aM
 ba
 bc
 be


### PR DESCRIPTION
:cl: Denton
fix: Fixed the Cere emergency shuttle brig floor.
tweak: Removed access restrictions on the Hi Daniel shuttle's booze-o-mat.
tweak: Added missing surgical drills and cauteries to emergency shuttles.
tweak: Replaced boring high traction floors in the SnapPop!(tm) shuttle with exciting bananium floors.
/:cl:

Closes: #40155

Nothing exciting, except for the SnapPop! shuttle. Giving a clown shuttle high-traction floors that prevent water slips is absolute madness. I replaced them with bananium floors; the airlocks with bananium airlocks too.
I replaced some of the outer plating in the Gigashuttle with lattice to break up the boring floor plating look:

![yeetttt](https://user-images.githubusercontent.com/32391752/45240243-3c61cf80-b2e8-11e8-8b94-5fadae14f8fa.PNG)

![p o p](https://user-images.githubusercontent.com/32391752/45240836-54d2e980-b2ea-11e8-9db0-4acd5fe4b7c6.PNG)

