### PR TITLE
Reworks tachyon-doppler array

### DIFF
--- a/code/__DEFINES/research.dm
+++ b/code/__DEFINES/research.dm
@@ -71,3 +71,5 @@
 #define TECHWEB_POINT_TYPE_LIST_ASSOCIATIVE_NAMES list(\
 	TECHWEB_POINT_TYPE_GENERIC = "General Research"\
 	)
+
+#define TECHWEB_BOMB_POINTCAP		50000 //Adjust as needed; Stops toxins from nullifying RND progression mechanics. Current Value Cap Radius: 100

--- a/code/__DEFINES/research.dm
+++ b/code/__DEFINES/research.dm
@@ -73,3 +73,5 @@
 	)
 
 #define TECHWEB_BOMB_POINTCAP		50000 //Adjust as needed; Stops toxins from nullifying RND progression mechanics. Current Value Cap Radius: 100
+#define TACHYON_MODE_RESEARCH	"research"
+#define TACHYON_MODE_CREDIT		"credit"

--- a/code/game/machinery/doppler_array.dm
+++ b/code/game/machinery/doppler_array.dm
@@ -1,7 +1,5 @@
 GLOBAL_LIST_EMPTY(doppler_arrays)
 
-#define RESEARCH	"research"
-#define CREDIT	"credit"
 
 /obj/machinery/doppler_array
 	name = "tachyon-doppler array"
@@ -11,7 +9,7 @@ GLOBAL_LIST_EMPTY(doppler_arrays)
 	density = TRUE
 	var/integrated = FALSE
 	var/max_dist = 150
-	var/mode = RESEARCH
+	var/mode = TACHYON_MODE_RESEARCH
 	verb_say = "states coldly"
 
 /obj/machinery/doppler_array/Initialize()
@@ -45,12 +43,12 @@ GLOBAL_LIST_EMPTY(doppler_arrays)
 		I.play_tool_sound(src)
 
 	if(istype(I, /obj/item/multitool))
-		if(mode == RESEARCH)
-			mode = CREDIT
-			to_chat(user, "<span class='nocice'>You set [src] to generate credits.</span>")
+		if(mode == TACHYON_MODE_RESEARCH)
+			mode = TACHYON_MODE_CREDIT
+			to_chat(user, "<span class='notice'>You set [src] to generate credits.</span>")
 		else
-			mode = RESEARCH
-			to_chat(user, "<span class='nocice'>You set [src] to generate research points.</span>")
+			mode = TACHYON_MODE_RESEARCH
+			to_chat(user, "<span class='notice'>You set [src] to generate research points.</span>")
 	else
 		return ..()
 
@@ -133,7 +131,7 @@ GLOBAL_LIST_EMPTY(doppler_arrays)
 		say("Explosion not large enough for research calculations.")
 		return
 
-	if(mode == RESEARCH)
+	if(mode == TACHYON_MODE_RESEARCH)
 		point_gain = round(((log(orig_light)-1)**1.6)*TECHWEB_BOMB_POINTCAP)
 		linked_techweb.logged_theoretical_points += point_gain
 		say("Logged [point_gain] theoretical points from explosion dataset, new total is [linked_techweb.logged_theoretical_points].")
@@ -149,7 +147,7 @@ GLOBAL_LIST_EMPTY(doppler_arrays)
 				point_gain = 1000
 
 			linked_techweb.add_point_type(TECHWEB_POINT_TYPE_DEFAULT, point_gain)
-			say("Gained [point_gain] points from explosion dataset.")
+			say("Gained [point_gain] research points from explosion dataset.")
 
 		else //you've made smaller bombs
 			say("Data already captured. Aborting.")
@@ -169,7 +167,7 @@ GLOBAL_LIST_EMPTY(doppler_arrays)
 			linked_techweb.reward_level++
 			new /obj/effect/particle_effect/sparks(loc)
 			playsound(src, "sparks", 50, 1)
-			say("Nanotransen has sent you a canister of pluxonium for your efforts, the next reard is at 100000 total points.")
+			say("Nanotrasen has sent you a canister of pluxonium for your efforts, the next reward is at 100000 total points.")
 
 	if(linked_techweb.logged_theoretical_points > 1000000)
 		if(linked_techweb.reward_level==2)
@@ -177,7 +175,7 @@ GLOBAL_LIST_EMPTY(doppler_arrays)
 			linked_techweb.reward_level++
 			new /obj/effect/particle_effect/sparks(loc)
 			playsound(src, "sparks", 50, 1)
-			say("Nanotransen has sent you a canister of nitryl for your efforts, the next reard is at 5000000 total points.")
+			say("Nanotrasen has sent you a canister of nitryl for your efforts, the next rweard is at 5000000 total points.")
 
 	if(linked_techweb.logged_theoretical_points > 5000000)
 		if(linked_techweb.reward_level==3)
@@ -185,12 +183,9 @@ GLOBAL_LIST_EMPTY(doppler_arrays)
 			linked_techweb.reward_level++
 			new /obj/effect/particle_effect/sparks(loc)
 			playsound(src, "sparks", 50, 1)
-			say("Nanotransen has sent you a prototype canister for your efforts, this completes our current toxins work cycle.")
+			say("Nanotrasen has sent you a prototype canister for your efforts, this completes our current toxins work cycle.")
 
 
 /obj/machinery/doppler_array/research/science/Initialize()
 	. = ..()
 	linked_techweb = SSresearch.science_tech
-
-#undef RESEARCH
-#undef CREDIT

--- a/code/game/machinery/doppler_array.dm
+++ b/code/game/machinery/doppler_array.dm
@@ -1,5 +1,8 @@
 GLOBAL_LIST_EMPTY(doppler_arrays)
 
+#define RESEARCH	"research"
+#define CREDIT	"credit"
+
 /obj/machinery/doppler_array
 	name = "tachyon-doppler array"
 	desc = "A highly precise directional sensor array which measures the release of quants from decaying tachyons. The doppler shifting of the mirror-image formed by these quants can reveal the size, location and temporal affects of energetic disturbances within a large radius ahead of the array.\n"
@@ -8,6 +11,7 @@ GLOBAL_LIST_EMPTY(doppler_arrays)
 	density = TRUE
 	var/integrated = FALSE
 	var/max_dist = 150
+	var/mode = RESEARCH
 	verb_say = "states coldly"
 
 /obj/machinery/doppler_array/Initialize()
@@ -23,7 +27,7 @@ GLOBAL_LIST_EMPTY(doppler_arrays)
 
 /obj/machinery/doppler_array/examine(mob/user)
 	..()
-	to_chat(user, "<span class='notice'>Its dish is facing to the [dir2text(dir)].</span>")
+	to_chat(user, "<span class='notice'>Its dish is facing to the [dir2text(dir)], the mode is set to [mode].</span>")
 
 /obj/machinery/doppler_array/process()
 	return PROCESS_KILL
@@ -39,6 +43,14 @@ GLOBAL_LIST_EMPTY(doppler_arrays)
 			power_change()
 			to_chat(user, "<span class='notice'>You unfasten [src].</span>")
 		I.play_tool_sound(src)
+
+	if(istype(I, /obj/item/multitool))
+		if(mode == RESEARCH)
+			mode = CREDIT
+			to_chat(user, "<span class='nocice'>You set [src] to generate credits.</span>")
+		else
+			mode = RESEARCH
+			to_chat(user, "<span class='nocice'>You set [src] to generate research points.</span>")
 	else
 		return ..()
 
@@ -111,22 +123,74 @@ GLOBAL_LIST_EMPTY(doppler_arrays)
 		return FALSE
 	if(!istype(linked_techweb))
 		say("Warning: No linked research system!")
-		return 
-	var/adjusted = orig_light - 10
-	if(adjusted <= 0)
+		return
+
+	var/point_gain = 0
+
+	/*****The Point Calculator*****/
+
+	if(orig_light < 10)
 		say("Explosion not large enough for research calculations.")
 		return
-	var/point_gain = techweb_scale_bomb(adjusted) - techweb_scale_bomb(linked_techweb.max_bomb_value)
-	if(point_gain <= 0)
-		say("Explosion not large enough for research calculations.")
-		return
-	linked_techweb.max_bomb_value = adjusted
-	linked_techweb.add_point_type(TECHWEB_POINT_TYPE_DEFAULT, point_gain)
-	say("Gained [point_gain] points from explosion dataset.")
+
+	if(mode == RESEARCH)
+		point_gain = round(((log(orig_light)-1)**1.6)*TECHWEB_BOMB_POINTCAP)
+		linked_techweb.logged_theoretical_points += point_gain
+		say("Logged [point_gain] theoretical points from explosion dataset, new total is [linked_techweb.logged_theoretical_points].")
+
+		if(point_gain > linked_techweb.largest_bomb_value)
+			if(point_gain <= TECHWEB_BOMB_POINTCAP || linked_techweb.largest_bomb_value < TECHWEB_BOMB_POINTCAP)
+				var/old_tech_largest_bomb_value = linked_techweb.largest_bomb_value //held so we can pull old before we do math
+				linked_techweb.largest_bomb_value = point_gain
+				point_gain -= old_tech_largest_bomb_value
+				point_gain = min(point_gain,TECHWEB_BOMB_POINTCAP)
+			else
+				linked_techweb.largest_bomb_value = TECHWEB_BOMB_POINTCAP
+				point_gain = 1000
+
+			linked_techweb.add_point_type(TECHWEB_POINT_TYPE_DEFAULT, point_gain)
+			say("Gained [point_gain] points from explosion dataset.")
+
+		else //you've made smaller bombs
+			say("Data already captured. Aborting.")
+
+	else //Credit production is only capped per bomb
+		point_gain = round(((log(orig_light)-1)**1.6)*TECHWEB_BOMB_POINTCAP)
+		linked_techweb.logged_theoretical_points += point_gain
+		say("Logged [point_gain] theoretical points from explosion dataset, new total is [linked_techweb.logged_theoretical_points].")
+		point_gain = min(point_gain,TECHWEB_BOMB_POINTCAP)
+		SSshuttle.points += point_gain
+		say("Gained [point_gain] credits from explosion dataset.")
+
+	//give the toxins scientists things that directly interest them
+	if(linked_techweb.logged_theoretical_points > 50000)
+		if(linked_techweb.reward_level==1)
+			new /obj/machinery/portable_atmospherics/canister/pluoxium(loc)
+			linked_techweb.reward_level++
+			new /obj/effect/particle_effect/sparks(loc)
+			playsound(src, "sparks", 50, 1)
+			say("Nanotransen has sent you a canister of pluxonium for your efforts, the next reard is at 100000 total points.")
+
+	if(linked_techweb.logged_theoretical_points > 1000000)
+		if(linked_techweb.reward_level==2)
+			new /obj/machinery/portable_atmospherics/canister/nitryl(loc)
+			linked_techweb.reward_level++
+			new /obj/effect/particle_effect/sparks(loc)
+			playsound(src, "sparks", 50, 1)
+			say("Nanotransen has sent you a canister of nitryl for your efforts, the next reard is at 5000000 total points.")
+
+	if(linked_techweb.logged_theoretical_points > 5000000)
+		if(linked_techweb.reward_level==3)
+			new /obj/machinery/portable_atmospherics/canister/proto/default(loc) //useful in toxins and fusion but if the player achieves this they should have already done both
+			linked_techweb.reward_level++
+			new /obj/effect/particle_effect/sparks(loc)
+			playsound(src, "sparks", 50, 1)
+			say("Nanotransen has sent you a prototype canister for your efforts, this completes our current toxins work cycle.")
+
 
 /obj/machinery/doppler_array/research/science/Initialize()
 	. = ..()
 	linked_techweb = SSresearch.science_tech
 
-/proc/techweb_scale_bomb(lightradius)
-	return (lightradius ** 0.5) * 3000
+#undef RESEARCH
+#undef CREDIT

--- a/code/modules/research/techweb/_techweb.dm
+++ b/code/modules/research/techweb/_techweb.dm
@@ -16,7 +16,9 @@
 	var/list/obj/machinery/computer/rdconsole/consoles_accessing = list()
 	var/id = "generic"
 	var/list/research_logs = list()								//IC logs.
-	var/max_bomb_value = 0
+	var/largest_bomb_value = 0									//Logs current research point cap progression for doppler.
+	var/logged_theoretical_points = 0							//Logs cumulative points for doppler.
+	var/reward_level = 1										//Logs current reward tier for doppler.
 	var/organization = "Third-Party"							//Organization name, used for display.
 	var/list/last_bitcoins = list()								//Current per-second production, used for display only.
 	var/list/tiers = list()										//Assoc list, datum = number, 1 is available, 2 is all reqs are 1, so on


### PR DESCRIPTION
:cl: Cobby and Granpawalton
balance: Maximum amount of research points gained from explosions has been capped at 50,000 and recorded explosions passed that can only generate 1,000 at a time.
balance: Techweb toxins equation has been edited (once again)
add: The tachyon-doppler array can now be set to generate credits using a multitool, this is also capped at 50,000 but does not have diminishing returns like research points.
add: The tachyon-doppler array now records your total potential points and rewards you with some goodies based on how high you can get it.
/:cl:

Reason: 10 minute prep is not worth nullifying the entire balancing act of techwebs, which are meant to more/less dripfeed items into an hour-hour thirty round. To prevent a large amount of circulation of bombs on the station from "useless bombs" the credit producing mode was added and the cumulative score was put in place to encourage the ttvs to not be found outside of toxins. There was a mention of giving the bombs to miners but the amount of time arrange a meeting and to meet up with the miner could have mined just as much ore by just using normal mining tools assuming nothing goes wrong in the process of finding them, there is also not a lot of incentive to give away weapons of mass destruction since the scientists will be typically giving the miners upgraded tools in exchange for the ores already. The cumulative rewards themselves will be hard to cause balance issues due to the time gating and are selected in mind to not encourage meta rushes while still peaking the interest of toxins players.  The balance for the cumulative checkpoints is based loosely on (what i consider a typical trit bomb) a 600,000k plasma tank and a 50% oxy 50% trit tank at 30k producing 1.3 million points, this means 1 would be enough to get the nitryl and 4 for the prototype canister. This would be a safe way of introducing two rarely seen objects in the game due to them being rewards for what they would be used to abuse. If anyone has any concern on the numbers or rewards for balance reasons id be glad to adjust them.

Rewards:
50,000 = pluxonium canister
1,000,000 = nitryl canister
5,000,000 = prototype canister

![point gain graph](https://user-images.githubusercontent.com/36310010/45249691-0de4f400-b2ea-11e8-9f4f-5c4f1659e840.png)

closes #40107 