### PR TITLE
[NEED NUMBER TWEAKING?] Surgeries now give techweb points on completion.

### DIFF
--- a/code/modules/mob/living/brain/brain_item.dm
+++ b/code/modules/mob/living/brain/brain_item.dm
@@ -281,5 +281,8 @@
 
 /obj/item/organ/brain/proc/cure_all_traumas(resilience = TRAUMA_RESILIENCE_BASIC)
 	var/list/traumas = get_traumas_type(resilience = resilience)
+	var/count_traumas_cured = 0
 	for(var/X in traumas)
+		count_traumas++
 		qdel(X)
+	return count_traumas_cured

--- a/code/modules/mob/living/brain/brain_item.dm
+++ b/code/modules/mob/living/brain/brain_item.dm
@@ -283,6 +283,6 @@
 	var/list/traumas = get_traumas_type(resilience = resilience)
 	var/count_traumas_cured = 0
 	for(var/X in traumas)
-		count_traumas++
+		count_traumas_cured++
 		qdel(X)
 	return count_traumas_cured

--- a/code/modules/surgery/advanced/bioware/bioware_surgery.dm
+++ b/code/modules/surgery/advanced/bioware/bioware_surgery.dm
@@ -1,6 +1,7 @@
 /datum/surgery/advanced/bioware
 	name = "enhancement surgery"
 	var/bioware_target = BIOWARE_GENERIC
+	research_completion_bonus = 3000
 
 /datum/surgery/advanced/bioware/can_start(mob/user, mob/living/carbon/human/target)
 	if(!..())

--- a/code/modules/surgery/advanced/brainwashing.dm
+++ b/code/modules/surgery/advanced/brainwashing.dm
@@ -2,6 +2,7 @@
 	name = "Brainwashing Surgery Disk"
 	desc = "The disk provides instructions on how to impress an order on a brain, making it the primary objective of the patient."
 	surgeries = list(/datum/surgery/advanced/brainwashing)
+	research_completion_bonus = 3000 //implying you wouldn't watch rnd console to see if someone is doing this surgery
 
 /datum/surgery/advanced/brainwashing
 	name = "Brainwashing"

--- a/code/modules/surgery/advanced/brainwashing.dm
+++ b/code/modules/surgery/advanced/brainwashing.dm
@@ -2,7 +2,6 @@
 	name = "Brainwashing Surgery Disk"
 	desc = "The disk provides instructions on how to impress an order on a brain, making it the primary objective of the patient."
 	surgeries = list(/datum/surgery/advanced/brainwashing)
-	research_completion_bonus = 3000 //implying you wouldn't watch rnd console to see if someone is doing this surgery
 
 /datum/surgery/advanced/brainwashing
 	name = "Brainwashing"
@@ -17,6 +16,7 @@
 
 	species = list(/mob/living/carbon/human)
 	possible_locs = list(BODY_ZONE_HEAD)
+	research_completion_bonus = 3000 //implying you wouldn't watch rnd console to see if someone is doing this surgery
 
 /datum/surgery/advanced/brainwashing/can_start(mob/user, mob/living/carbon/target)
 	if(!..())

--- a/code/modules/surgery/advanced/lobotomy.dm
+++ b/code/modules/surgery/advanced/lobotomy.dm
@@ -37,7 +37,8 @@
 
 /datum/surgery_step/lobotomize/success(mob/user, mob/living/carbon/target, target_zone, obj/item/tool, datum/surgery/surgery)
 	user.visible_message("[user] successfully lobotomizes [target]!", "<span class='notice'>You succeed in lobotomizing [target].</span>")
-	target.cure_all_traumas(TRAUMA_RESILIENCE_LOBOTOMY)
+	var/trauma_count = target.cure_all_traumas(TRAUMA_RESILIENCE_LOBOTOMY)
+	surgery.research_completion_bonus += 750 // REMOVE ALL THE TRAUMAS!!!
 	if(target.mind && target.mind.has_antag_datum(/datum/antagonist/brainwashed))
 		target.mind.remove_antag_datum(/datum/antagonist/brainwashed)
 	switch(rand(1,4))//Now let's see what hopefully-not-important part of the brain we cut off

--- a/code/modules/surgery/advanced/lobotomy.dm
+++ b/code/modules/surgery/advanced/lobotomy.dm
@@ -38,7 +38,7 @@
 /datum/surgery_step/lobotomize/success(mob/user, mob/living/carbon/target, target_zone, obj/item/tool, datum/surgery/surgery)
 	user.visible_message("[user] successfully lobotomizes [target]!", "<span class='notice'>You succeed in lobotomizing [target].</span>")
 	var/trauma_count = target.cure_all_traumas(TRAUMA_RESILIENCE_LOBOTOMY)
-	surgery.research_completion_bonus += 750 // REMOVE ALL THE TRAUMAS!!!
+	surgery.research_completion_bonus = 750*trauma_count // REMOVE ALL THE TRAUMAS!!!
 	if(target.mind && target.mind.has_antag_datum(/datum/antagonist/brainwashed))
 		target.mind.remove_antag_datum(/datum/antagonist/brainwashed)
 	switch(rand(1,4))//Now let's see what hopefully-not-important part of the brain we cut off

--- a/code/modules/surgery/advanced/necrotic_revival.dm
+++ b/code/modules/surgery/advanced/necrotic_revival.dm
@@ -9,6 +9,7 @@
 				/datum/surgery_step/close)
 
 	possible_locs = list(BODY_ZONE_HEAD)
+	research_completion_bonus = 7500 // quite a bargain...
 
 /datum/surgery/advanced/necrotic_revival/can_start(mob/user, mob/living/carbon/target)
 	. = ..()

--- a/code/modules/surgery/advanced/pacification.dm
+++ b/code/modules/surgery/advanced/pacification.dm
@@ -11,6 +11,7 @@
 	species = list(/mob/living/carbon/human, /mob/living/carbon/monkey)
 	possible_locs = list(BODY_ZONE_HEAD)
 	requires_bodypart_type = 0
+	research_completion_bonus = 3000 // you make someone VERY MAD doing this!
 
 /datum/surgery/advanced/pacify/can_start(mob/user, mob/living/carbon/target)
 	. = ..()

--- a/code/modules/surgery/advanced/reconstruction.dm
+++ b/code/modules/surgery/advanced/reconstruction.dm
@@ -14,6 +14,7 @@
 	species = list(/mob/living/carbon/human, /mob/living/carbon/monkey)
 	possible_locs = list(BODY_ZONE_CHEST)
 	requires_bodypart_type = 0
+	research_completion_bonus = 2500
 
 /datum/surgery_step/reconstruct
 	name = "repair body"

--- a/code/modules/surgery/advanced/revival.dm
+++ b/code/modules/surgery/advanced/revival.dm
@@ -12,6 +12,7 @@
 	species = list(/mob/living/carbon/human, /mob/living/carbon/monkey)
 	possible_locs = list(BODY_ZONE_HEAD)
 	requires_bodypart_type = 0
+	research_completion_bonus = 5000
 
 /datum/surgery/advanced/revival/can_start(mob/user, mob/living/carbon/target)
 	if(!..())

--- a/code/modules/surgery/advanced/viral_bonding.dm
+++ b/code/modules/surgery/advanced/viral_bonding.dm
@@ -10,6 +10,7 @@
 
 	species = list(/mob/living/carbon/human, /mob/living/carbon/monkey)
 	possible_locs = list(BODY_ZONE_CHEST)
+	research_completion_bonus = 3000
 
 /datum/surgery/advanced/viral_bonding/can_start(mob/user, mob/living/carbon/target)
 	if(!..())

--- a/code/modules/surgery/amputation.dm
+++ b/code/modules/surgery/amputation.dm
@@ -5,6 +5,7 @@
 	species = list(/mob/living/carbon/human, /mob/living/carbon/monkey)
 	possible_locs = list(BODY_ZONE_R_ARM, BODY_ZONE_L_ARM, BODY_ZONE_L_LEG, BODY_ZONE_R_LEG, BODY_ZONE_HEAD)
 	requires_bodypart_type = 0
+	research_completion_bonus = 500 // pity points because just clicking with harm on a saw is faster.
 
 
 /datum/surgery_step/sever_limb
@@ -22,4 +23,4 @@
 		var/obj/item/bodypart/target_limb = surgery.operated_bodypart
 		target_limb.drop_limb()
 
-	return 1
+	return TRUE

--- a/code/modules/surgery/brain_surgery.dm
+++ b/code/modules/surgery/brain_surgery.dm
@@ -30,8 +30,12 @@
 	user.visible_message("[user] successfully fixes [target]'s brain!", "<span class='notice'>You succeed in fixing [target]'s brain.</span>")
 	if(target.mind && target.mind.has_antag_datum(/datum/antagonist/brainwashed))
 		target.mind.remove_antag_datum(/datum/antagonist/brainwashed)
+		research_completion_bonus += 1000
 	target.adjustBrainLoss(-60)
-	target.cure_all_traumas(TRAUMA_RESILIENCE_SURGERY)
+	var/traumas_cured = target.cure_all_traumas(TRAUMA_RESILIENCE_SURGERY)
+		if(traumas_cured)
+			surgery.research_completion_bonus += 500
+
 	return TRUE
 
 /datum/surgery_step/fix_brain/failure(mob/user, mob/living/carbon/target, target_zone, obj/item/tool, datum/surgery/surgery)

--- a/code/modules/surgery/brain_surgery.dm
+++ b/code/modules/surgery/brain_surgery.dm
@@ -30,11 +30,11 @@
 	user.visible_message("[user] successfully fixes [target]'s brain!", "<span class='notice'>You succeed in fixing [target]'s brain.</span>")
 	if(target.mind && target.mind.has_antag_datum(/datum/antagonist/brainwashed))
 		target.mind.remove_antag_datum(/datum/antagonist/brainwashed)
-		research_completion_bonus += 1000
+		surgery.research_completion_bonus += 1000
 	target.adjustBrainLoss(-60)
 	var/traumas_cured = target.cure_all_traumas(TRAUMA_RESILIENCE_SURGERY)
-		if(traumas_cured)
-			surgery.research_completion_bonus += 500
+	if(traumas_cured)
+		surgery.research_completion_bonus = 500 * traumas_cured
 
 	return TRUE
 

--- a/code/modules/surgery/cavity_implant.dm
+++ b/code/modules/surgery/cavity_implant.dm
@@ -3,13 +3,14 @@
 	steps = list(/datum/surgery_step/incise, /datum/surgery_step/clamp_bleeders, /datum/surgery_step/retract_skin, /datum/surgery_step/incise, /datum/surgery_step/handle_cavity, /datum/surgery_step/close)
 	species = list(/mob/living/carbon/human, /mob/living/carbon/monkey)
 	possible_locs = list(BODY_ZONE_CHEST)
+	research_completion_bonus = 100 // taking stuff in and out, while funny, is not cool bro!
 
 
 //handle cavity
 /datum/surgery_step/handle_cavity
 	name = "implant item"
-	accept_hand = 1
-	accept_any_item = 1
+	accept_hand = TRUE
+	accept_any_item = TRUE
 	time = 32
 	var/obj/item/IC = null
 
@@ -31,22 +32,22 @@
 	if(tool)
 		if(IC || tool.w_class > WEIGHT_CLASS_NORMAL || (tool.item_flags & NODROP) || istype(tool, /obj/item/organ))
 			to_chat(user, "<span class='warning'>You can't seem to fit [tool] in [target]'s [target_zone]!</span>")
-			return 0
+			return FALSE
 		var/obj/item/electronic_assembly/EA = tool
 		if(istype(EA) && EA.combat_circuits && tool.w_class > WEIGHT_CLASS_SMALL)
 			to_chat(user, "<span class='warning'>[tool] is too dangerous to put in [target]'s [target_zone]! Maybe if it was smaller...</span>")
-			return 0
+			return FALSE
 		else
 			user.visible_message("[user] stuffs [tool] into [target]'s [target_zone]!", "<span class='notice'>You stuff [tool] into [target]'s [target_zone].</span>")
 			user.transferItemToLoc(tool, target, TRUE)
 			CH.cavity_item = tool
-			return 1
+			return TRUE
 	else
 		if(IC)
 			user.visible_message("[user] pulls [IC] out of [target]'s [target_zone]!", "<span class='notice'>You pull [IC] out of [target]'s [target_zone].</span>")
 			user.put_in_hands(IC)
 			CH.cavity_item = null
-			return 1
+			return TRUE
 		else
 			to_chat(user, "<span class='warning'>You don't find anything in [target]'s [target_zone].</span>")
-			return 0
+			return FALSE

--- a/code/modules/surgery/core_removal.dm
+++ b/code/modules/surgery/core_removal.dm
@@ -6,8 +6,8 @@
 
 /datum/surgery/core_removal/can_start(mob/user, mob/living/target)
 	if(target.stat == DEAD)
-		return 1
-	return 0
+		return TRUE
+	return FALSE
 
 //extract brain
 /datum/surgery_step/extract_core
@@ -22,15 +22,16 @@
 	var/mob/living/simple_animal/slime/slime = target
 	if(slime.cores > 0)
 		slime.cores--
+		surgery.research_completion_bonus += 100
 		user.visible_message("[user] successfully extracts a core from [target]!", "<span class='notice'>You successfully extract a core from [target]. [slime.cores] core\s remaining.</span>")
 
 		new slime.coretype(slime.loc)
 
 		if(slime.cores <= 0)
 			slime.icon_state = "[slime.colour] baby slime dead-nocore"
-			return 1
+			return TRUE
 		else
-			return 0
+			return FALSE
 	else
 		to_chat(user, "<span class='warning'>There aren't any cores left in [target]!</span>")
-		return 1
+		return TRUE

--- a/code/modules/surgery/dental_implant.dm
+++ b/code/modules/surgery/dental_implant.dm
@@ -2,6 +2,7 @@
 	name = "dental implant"
 	steps = list(/datum/surgery_step/drill, /datum/surgery_step/insert_pill)
 	possible_locs = list(BODY_ZONE_PRECISE_MOUTH)
+	research_completion_bonus = 100
 
 /datum/surgery_step/insert_pill
 	name = "insert pill"
@@ -13,7 +14,7 @@
 
 /datum/surgery_step/insert_pill/success(mob/user, mob/living/carbon/target, target_zone, var/obj/item/reagent_containers/pill/tool, datum/surgery/surgery)
 	if(!istype(tool))
-		return 0
+		return FALSE
 
 	user.transferItemToLoc(tool, target, TRUE)
 
@@ -23,18 +24,18 @@
 	P.Grant(target)	//The pill never actually goes in an inventory slot, so the owner doesn't inherit actions from it
 
 	user.visible_message("[user] wedges \the [tool] into [target]'s [parse_zone(target_zone)]!", "<span class='notice'>You wedge [tool] into [target]'s [parse_zone(target_zone)].</span>")
-	return 1
+	return TRUE
 
 /datum/action/item_action/hands_free/activate_pill
 	name = "Activate Pill"
 
 /datum/action/item_action/hands_free/activate_pill/Trigger()
 	if(!..())
-		return 0
+		return FALSE
 	to_chat(owner, "<span class='caution'>You grit your teeth and burst the implanted [target.name]!</span>")
 	log_combat(owner, null, "swallowed an implanted pill", target)
 	if(target.reagents.total_volume)
 		target.reagents.reaction(owner, INGEST)
 		target.reagents.trans_to(owner, target.reagents.total_volume)
 	qdel(target)
-	return 1
+	return TRUE

--- a/code/modules/surgery/eye_surgery.dm
+++ b/code/modules/surgery/eye_surgery.dm
@@ -23,6 +23,8 @@
 
 /datum/surgery_step/fix_eyes/success(mob/user, mob/living/carbon/target, target_zone, obj/item/tool, datum/surgery/surgery)
 	user.visible_message("[user] successfully fixes [target]'s eyes!", "<span class='notice'>You succeed in fixing [target]'s eyes.</span>")
+	if(target.eyes.eye_damage)
+		surgery.research_completion_bonus = min(target.eyes.eye_damage * 25, 30*25)  // more eye damage = more $$, max 30 damage [725 pts] which means you're blind
 	target.cure_blind(list(EYE_DAMAGE))
 	target.set_blindness(0)
 	target.cure_nearsighted(list(EYE_DAMAGE))

--- a/code/modules/surgery/eye_surgery.dm
+++ b/code/modules/surgery/eye_surgery.dm
@@ -23,8 +23,9 @@
 
 /datum/surgery_step/fix_eyes/success(mob/user, mob/living/carbon/target, target_zone, obj/item/tool, datum/surgery/surgery)
 	user.visible_message("[user] successfully fixes [target]'s eyes!", "<span class='notice'>You succeed in fixing [target]'s eyes.</span>")
-	if(target.eyes.eye_damage)
-		surgery.research_completion_bonus = min(target.eyes.eye_damage * 25, 30*25)  // more eye damage = more $$, max 30 damage [725 pts] which means you're blind
+	var/obj/item/organ/eyes/the_eyes = target.getorganslot(ORGAN_SLOT_EYES)
+	if(the_eyes.eye_damage)
+		surgery.research_completion_bonus = min(the_eyes.eye_damage * 25, 30*25)  // more eye damage = more $$, max 30 damage [725 pts] which means you're blind
 	target.cure_blind(list(EYE_DAMAGE))
 	target.set_blindness(0)
 	target.cure_nearsighted(list(EYE_DAMAGE))

--- a/code/modules/surgery/implant_removal.dm
+++ b/code/modules/surgery/implant_removal.dm
@@ -23,6 +23,7 @@
 
 /datum/surgery_step/extract_implant/success(mob/user, mob/living/carbon/target, target_zone, obj/item/tool, datum/surgery/surgery)
 	if(I)
+		surgery.research_completion_bonus = 100 // farmers gtfo
 		user.visible_message("[user] successfully removes [I] from [target]'s [target_zone]!", "<span class='notice'>You successfully remove [I] from [target]'s [target_zone].</span>")
 		I.removed(target)
 

--- a/code/modules/surgery/limb_augmentation.dm
+++ b/code/modules/surgery/limb_augmentation.dm
@@ -46,6 +46,7 @@
 	species = list(/mob/living/carbon/human)
 	possible_locs = list(BODY_ZONE_R_ARM,BODY_ZONE_L_ARM,BODY_ZONE_R_LEG,BODY_ZONE_L_LEG,BODY_ZONE_CHEST,BODY_ZONE_HEAD)
 	requires_real_bodypart = TRUE
+	research_completion_bonus = 1000 // DO AUGMENTS!
 
 //SURGERY STEP SUCCESSES
 

--- a/code/modules/surgery/lipoplasty.dm
+++ b/code/modules/surgery/lipoplasty.dm
@@ -2,6 +2,7 @@
 	name = "lipoplasty"
 	steps = list(/datum/surgery_step/incise, /datum/surgery_step/clamp_bleeders, /datum/surgery_step/cut_fat, /datum/surgery_step/remove_fat, /datum/surgery_step/close)
 	possible_locs = list(BODY_ZONE_CHEST)
+	research_completion_bonus = 500 // biggest... winner?
 
 /datum/surgery/lipoplasty/can_start(mob/user, mob/living/carbon/target)
 	if(target.has_trait(TRAIT_FAT))

--- a/code/modules/surgery/organ_manipulation.dm
+++ b/code/modules/surgery/organ_manipulation.dm
@@ -147,4 +147,4 @@
 		else
 			user.visible_message("[user] can't seem to extract anything from [target]'s [parse_zone(target_zone)]!",
 				"<span class='notice'>You can't extract anything from [target]'s [parse_zone(target_zone)]!</span>")
-	return 0
+	return FALSE

--- a/code/modules/surgery/plastic_surgery.dm
+++ b/code/modules/surgery/plastic_surgery.dm
@@ -2,6 +2,7 @@
 	name = "plastic surgery"
 	steps = list(/datum/surgery_step/incise, /datum/surgery_step/retract_skin, /datum/surgery_step/reshape_face, /datum/surgery_step/close)
 	possible_locs = list(BODY_ZONE_HEAD)
+	research_completion_bonus = 500 // rip snowflake
 
 //reshape_face
 /datum/surgery_step/reshape_face

--- a/code/modules/surgery/prosthetic_replacement.dm
+++ b/code/modules/surgery/prosthetic_replacement.dm
@@ -5,6 +5,7 @@
 	possible_locs = list(BODY_ZONE_R_ARM, BODY_ZONE_L_ARM, BODY_ZONE_L_LEG, BODY_ZONE_R_LEG, BODY_ZONE_HEAD)
 	requires_bodypart = FALSE //need a missing limb
 	requires_bodypart_type = 0
+	research_completion_bonus = 750 // REPLACE BODY PARTS
 
 /datum/surgery/prosthetic_replacement/can_start(mob/user, mob/living/carbon/target)
 	if(!iscarbon(target))

--- a/code/modules/surgery/remove_embedded_object.dm
+++ b/code/modules/surgery/remove_embedded_object.dm
@@ -2,6 +2,7 @@
 	name = "removal of embedded objects"
 	steps = list(/datum/surgery_step/incise, /datum/surgery_step/clamp_bleeders, /datum/surgery_step/retract_skin, /datum/surgery_step/remove_object)
 	possible_locs = list(BODY_ZONE_R_ARM,BODY_ZONE_L_ARM,BODY_ZONE_R_LEG,BODY_ZONE_L_LEG,BODY_ZONE_CHEST,BODY_ZONE_HEAD)
+	research_completion_bonus = 500 // pity points for not clicking help intent
 
 
 /datum/surgery_step/remove_object

--- a/code/modules/surgery/surgery.dm
+++ b/code/modules/surgery/surgery.dm
@@ -15,6 +15,7 @@
 	var/requires_bodypart = TRUE							//Surgery available only when a bodypart is present, or only when it is missing.
 	var/success_multiplier = 0								//Step success propability multiplier
 	var/requires_real_bodypart = 0							//Some surgeries don't work on limbs that don't really exist
+	var/research_completion_bonus = 0 //upon completion, you will get X amount of points for SCIENCE!
 
 /datum/surgery/New(surgery_target, surgery_location, surgery_bodypart)
 	..()
@@ -66,6 +67,8 @@
 
 /datum/surgery/proc/complete()
 	SSblackbox.record_feedback("tally", "surgeries_completed", 1, type)
+	if(research_completion_bonus && target.client) //anti-farm check
+		SSresearch.science_tech.add_point_list(list(TECHWEB_POINT_TYPE_GENERIC = research_completion_bonus))
 	qdel(src)
 
 /datum/surgery/proc/get_propability_multiplier()
@@ -93,7 +96,7 @@
 		var/datum/species/abductor/S = H.dna.species
 		if(S.scientist)
 			return TRUE
-	
+
 	if(iscyborg(user))
 		var/mob/living/silicon/robot/R = user
 		var/obj/item/surgical_processor/SP = locate() in R.module.modules
@@ -101,7 +104,7 @@
 			return FALSE
 		if(type in SP.advanced_surgeries)
 			return TRUE
-	
+
 	var/turf/T = get_turf(target)
 	var/obj/structure/table/optable/table = locate(/obj/structure/table/optable, T)
 	if(!table || !table.computer)


### PR DESCRIPTION
:cl: XDTM (hijacked by Cobby)
add: Surgeries now give points on completion. A list SHOULD be on the wiki
/:cl:

closes #40158
Purpose: to give medbay a way to contribute to the cooperative progression system.

**I do not know how I'd display this information ingame, and I need review on the numbers. I've put disks ones high and farmable ones super low then tried to make the others relative to that.**

Surgery | Point Amount
-- | --
Bioware Surgeries | 3000
Brainwashing | 3000
Lobotomy | 750 per trauma
Necrotic | 7500
Pacification | 3000
Reconstruction | 2500
Revival | 5000
Viral Bond | 3000
Amput | 500
Brain Surgery | 500 per trauma
Cavity | 100
Core Removal | 100 per extract
Dental | 100
Eye Surgery | 25*eye damage, capped at 725
Implant Removal | 100
Augment | 1000
Lipo | 500
Plastic Surgery | 500
Prosthetics | 750
Remove Embed | 500


