### PR TITLE
Fix orbit-causing verbs breaking sounds for ghosts that jump between z-levels as a result of an orbit update

### DIFF
--- a/code/modules/orbit/orbit.dm
+++ b/code/modules/orbit/orbit.dm
@@ -55,7 +55,12 @@
 	if (!targetloc || (!lock && orbiter.loc != lastloc && orbiter.loc != targetloc))
 		orbiter.stop_orbit()
 		return
-	orbiter.forceMove(targetloc)
+	var/turf/old_turf = get_turf(orbiter)
+	var/turf/new_turf = get_turf(targetloc)
+	if (old_turf?.z != new_turf?.z)
+		orbiter.onTransitZ(old_turf?.z, new_turf?.z)
+	// DO NOT PORT TO FORCEMOVE - MEMECODE WILL KILL MC
+	orbiter.loc = targetloc
 	orbiter.update_parallax_contents()
 	orbiter.update_light()
 	lastloc = orbiter.loc

--- a/code/modules/orbit/orbit.dm
+++ b/code/modules/orbit/orbit.dm
@@ -55,7 +55,7 @@
 	if (!targetloc || (!lock && orbiter.loc != lastloc && orbiter.loc != targetloc))
 		orbiter.stop_orbit()
 		return
-	orbiter.loc = targetloc
+	orbiter.forceMove(targetloc)
 	orbiter.update_parallax_contents()
 	orbiter.update_light()
 	lastloc = orbiter.loc


### PR DESCRIPTION
:cl: Naksu
fix: ghosts will no longer lose their hearing from jumping between z-levels via orbiting
/:cl:
