### PR TITLE
Bees only inject the reagent they were mutated with

### DIFF
--- a/code/modules/mob/living/simple_animal/hostile/bees.dm
+++ b/code/modules/mob/living/simple_animal/hostile/bees.dm
@@ -149,6 +149,7 @@
 	if(istype(R))
 		beegent = R
 		name = "[initial(name)] ([R.name])"
+		poison_type = null
 		generate_bee_visuals()
 
 


### PR DESCRIPTION
:cl: Denton
balance: Bees only inject the reagent they were mutated with. Non-mutated bees still inject toxin when stinging someone.
/:cl:

As a `simple_animal/hostile/poison` subtype, bees inject the `toxin` reagent by default. This sticks around when they're mutated with different reagents.

I removed it for the following reasons:
A) It makes random toxin bees (from buzzkill grenades and the holodeck) less random, as you'll always have the 5u toxin damage as a baseline, even if they spawn with useless chems like coffee grounds.
B) It makes all bees lethal, no matter the used reagent. Unless you're a jellyperson, you can forget using any beneficial reagents since there will always be that 5u toxin to deal damage.

Edit:
In case someone is worried about healing bees: About 90% of all injectable healing chems have fairly low overdose thresholds, which prevents bees from becoming medibots.