### PR TITLE
Fixes Deltastation CMO/Morgue disposals

### DIFF
--- a/_maps/map_files/Deltastation/DeltaStation2.dmm
+++ b/_maps/map_files/Deltastation/DeltaStation2.dmm
@@ -108689,6 +108689,9 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/bot,
+/obj/structure/disposalpipe/trunk{
+	dir = 8
+	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/heads/cmo)
 "dBj" = (
@@ -113459,6 +113462,9 @@
 /area/hallway/primary/aft)
 "dIU" = (
 /obj/machinery/disposal/bin,
+/obj/structure/disposalpipe/trunk{
+	dir = 1
+	},
 /turf/open/floor/plating,
 /area/medical/morgue)
 "dIV" = (


### PR DESCRIPTION
:cl: Denton
fix: The CMO office and morgue disposal bins on Deltastation are now connected to the disposal loop.
/:cl:

Those two bins never had any trunks to connect them to the disposal loop.