### PR TITLE
Unlocks AI Multicamera Mode, now with config.

### DIFF
--- a/code/controllers/configuration/entries/game_options.dm
+++ b/code/controllers/configuration/entries/game_options.dm
@@ -62,6 +62,8 @@
 
 /datum/config_entry/flag/allow_ai	// allow ai job
 
+/datum/config_entry/flag/allow_ai_multicam	// allow ai multicamera mode
+
 /datum/config_entry/flag/disable_human_mood
 
 /datum/config_entry/flag/disable_secborg	// disallow secborg module to be chosen.

--- a/code/modules/mob/living/silicon/ai/ai.dm
+++ b/code/modules/mob/living/silicon/ai/ai.dm
@@ -86,7 +86,6 @@
 	var/datum/action/innate/deploy_last_shell/redeploy_action = new
 	var/chnotify = 0
 
-	var/multicam_allowed = FALSE
 	var/multicam_on = FALSE
 	var/obj/screen/movable/pic_in_pic/ai/master_multicam
 	var/list/multicam_screens = list()

--- a/code/modules/mob/living/silicon/ai/multicam.dm
+++ b/code/modules/mob/living/silicon/ai/multicam.dm
@@ -194,7 +194,7 @@ GLOBAL_DATUM(ai_camera_room_landmark, /obj/effect/landmark/ai_multicam_room)
 //AI procs
 
 /mob/living/silicon/ai/proc/drop_new_multicam(silent = FALSE)
-	if(!multicam_allowed)
+	if(!CONFIG_GET(flag/allow_ai_multicam))
 		if(!silent)
 			to_chat(src, "<span class='warning'>This action is currently disabled. Contact an administrator to enable this feature.</span>")
 		return
@@ -213,7 +213,7 @@ GLOBAL_DATUM(ai_camera_room_landmark, /obj/effect/landmark/ai_multicam_room)
 	return C
 
 /mob/living/silicon/ai/proc/toggle_multicam()
-	if(!multicam_allowed)
+	if(!CONFIG_GET(flag/allow)_ai_multicam))
 		to_chat(src, "<span class='warning'>This action is currently disabled. Contact an administrator to enable this feature.</span>")
 		return
 	if(multicam_on)

--- a/code/modules/mob/living/silicon/ai/multicam.dm
+++ b/code/modules/mob/living/silicon/ai/multicam.dm
@@ -213,7 +213,7 @@ GLOBAL_DATUM(ai_camera_room_landmark, /obj/effect/landmark/ai_multicam_room)
 	return C
 
 /mob/living/silicon/ai/proc/toggle_multicam()
-	if(!CONFIG_GET(flag/allow)_ai_multicam))
+	if(!CONFIG_GET(flag/allow_ai_multicam))
 		to_chat(src, "<span class='warning'>This action is currently disabled. Contact an administrator to enable this feature.</span>")
 		return
 	if(multicam_on)

--- a/config/game_options.txt
+++ b/config/game_options.txt
@@ -258,6 +258,9 @@ EVENTS_MIN_PLAYERS_MUL 1
 ## Allow the AI job to be picked.
 ALLOW_AI
 
+## Allow the AI Multicamera feature to be used by AI players
+ALLOW_AI_MULTICAM
+
 ## Secborg ###
 ## Uncomment to prevent the security cyborg module from being chosen
 #DISABLE_SECBORG


### PR DESCRIPTION
:cl: Potato Masher
tweak: CentCom would like to announce that new station AIs will now support updated surveillance software, allowing units to monitor multiple locations with ease with customizable viewing range, albeit at an overall reduced viewing radius.
config: Cruix's AI Multicamera mode has been finally enabled, with a new config option for enabling and disabling it as well!
/:cl:

If you somehow have missed this feature's addition a while back, check here for details and original discussion: #37695
Earlier attempt that inspired this PR: #40153 

---

>![firefox_2018-09-09_23-52-58](https://user-images.githubusercontent.com/33107541/45275568-81723700-b48b-11e8-9ca5-e36effbb444c.png)

This probably should have been a config in the first place. Oh well.
Return of the AI Multicamera Mode, this time with requested config toggle.

First time messing with config shenanigans, let's see if I'm not retarded.