### PR TITLE
Adds tinyfan to gondola asteroid entrance

### DIFF
--- a/_maps/RandomRuins/SpaceRuins/gondolaasteroid.dmm
+++ b/_maps/RandomRuins/SpaceRuins/gondolaasteroid.dmm
@@ -82,6 +82,10 @@
 /obj/effect/mapping_helpers/airlock/cyclelink_helper,
 /turf/open/floor/plating/asteroid/airless,
 /area/ruin/space/has_grav)
+"w" = (
+/obj/structure/fans/tiny/invisible,
+/turf/open/floor/plating/asteroid/airless,
+/area/ruin/space/has_grav)
 "T" = (
 /obj/machinery/door/airlock/survival_pod/glass{
 	dir = 4
@@ -792,7 +796,7 @@ c
 c
 c
 u
-c
+w
 T
 "}
 (20,1,1) = {"


### PR DESCRIPTION
The area depressurizes a bit every time the airlocks are opened and has no air supply - I added an invisible tiny fan to stop that from happening.