### PR TITLE
Powernets now tracks load added between power ticks.

### DIFF
--- a/code/game/machinery/syndicatebeacon.dm
+++ b/code/game/machinery/syndicatebeacon.dm
@@ -86,7 +86,7 @@
 	if(!active)
 		return
 
-	if(surplus() > 1500)
+	if(surplus() >= 1500)
 		add_load(1500)
 		if(cooldown <= world.time)
 			cooldown = world.time + 80

--- a/code/game/objects/items/devices/powersink.dm
+++ b/code/game/objects/items/devices/powersink.dm
@@ -122,8 +122,8 @@
 
 		// found a powernet, so drain up to max power from it
 
-		var/drained = min ( drain_rate, PN.avail )
-		PN.load += drained
+		var/drained = min ( drain_rate, attached.newavail() )
+		attached.add_delayedload(drained)
 		power_drained += drained
 
 		// if tried to drain more than available on powernet
@@ -137,6 +137,8 @@
 						power_drained += 50
 						if(A.charging == 2) // If the cell was full
 							A.charging = 1 // It's no longer full
+				if(drained >= drain_rate)
+					break
 
 	if(power_drained > max_power * 0.98)
 		if (!admins_warned)

--- a/code/game/objects/structures/grille.dm
+++ b/code/game/objects/structures/grille.dm
@@ -270,8 +270,8 @@
 				var/obj/structure/cable/C = T.get_cable_node()
 				if(C)
 					playsound(src, 'sound/magic/lightningshock.ogg', 100, 1, extrarange = 5)
-					tesla_zap(src, 3, C.powernet.avail * 0.01, TESLA_MOB_DAMAGE | TESLA_OBJ_DAMAGE | TESLA_MOB_STUN | TESLA_ALLOW_DUPLICATES) //Zap for 1/100 of the amount of power. At a million watts in the grid, it will be as powerful as a tesla revolver shot.
-					C.powernet.load += C.powernet.avail * 0.0375 // you can gain up to 3.5 via the 4x upgrades power is halved by the pole so thats 2x then 1X then .5X for 3.5x the 3 bounces shock.
+					tesla_zap(src, 3, C.newavail() * 0.01, TESLA_MOB_DAMAGE | TESLA_OBJ_DAMAGE | TESLA_MOB_STUN | TESLA_ALLOW_DUPLICATES) //Zap for 1/100 of the amount of power. At a million watts in the grid, it will be as powerful as a tesla revolver shot.
+					C.add_delayedload(C.newavail() * 0.0375) // you can gain up to 3.5 via the 4x upgrades power is halved by the pole so thats 2x then 1X then .5X for 3.5x the 3 bounces shock.
 	return ..()
 
 /obj/structure/grille/get_dumping_location(datum/component/storage/source,mob/user)

--- a/code/modules/ninja/suit/ninjaDrainAct.dm
+++ b/code/modules/ninja/suit/ninjaDrainAct.dm
@@ -169,8 +169,8 @@ They *could* go in their appropriate files, but this is supposed to be modular
 		drain = (round((rand(G.mindrain, G.maxdrain))/2))
 		var/drained = 0
 		if(PN && do_after(H,10, target = src))
-			drained = min(drain, PN.avail)
-			PN.load += drained
+			drained = min(drain, delayed_surplus())
+			add_delayedload(drained)
 			if(drained < drain)//if no power on net, drain apcs
 				for(var/obj/machinery/power/terminal/T in PN.nodes)
 					if(istype(T.master, /obj/machinery/power/apc))

--- a/code/modules/power/apc.dm
+++ b/code/modules/power/apc.dm
@@ -1104,7 +1104,7 @@
 
 /obj/machinery/power/apc/add_load(amount)
 	if(terminal && terminal.powernet)
-		terminal.powernet.load += amount
+		terminal.add_load(amount)
 
 /obj/machinery/power/apc/avail()
 	if(terminal)

--- a/code/modules/power/cable.dm
+++ b/code/modules/power/cable.dm
@@ -199,6 +199,10 @@ By design, d1 is the smallest direction and d2 is the highest
 // Power related
 ///////////////////////////////////////////
 
+// All power generation handled in add_avail()
+// Machines should use add_load(), surplus(), avail()
+// Non-machines should use add_delayedload(), delayed_surplus(), newavail()
+
 /obj/structure/cable/proc/add_avail(amount)
 	if(powernet)
 		powernet.newavail += amount
@@ -216,6 +220,22 @@ By design, d1 is the smallest direction and d2 is the highest
 /obj/structure/cable/proc/avail()
 	if(powernet)
 		return powernet.avail
+	else
+		return 0
+
+/obj/structure/cable/proc/add_delayedload(amount)
+	if(powernet)
+		powernet.delayedload += amount
+
+/obj/structure/cable/proc/delayed_surplus()
+	if(powernet)
+		return powernet.newavail - powernet.delayedload
+	else
+		return 0
+
+/obj/structure/cable/proc/newavail()
+	if(powernet)
+		return powernet.newavail
 	else
 		return 0
 

--- a/code/modules/power/cable.dm
+++ b/code/modules/power/cable.dm
@@ -213,7 +213,7 @@ By design, d1 is the smallest direction and d2 is the highest
 
 /obj/structure/cable/proc/surplus()
 	if(powernet)
-		return powernet.avail-powernet.load
+		return CLAMP(powernet.avail-powernet.load, 0, powernet.avail)
 	else
 		return 0
 
@@ -229,7 +229,7 @@ By design, d1 is the smallest direction and d2 is the highest
 
 /obj/structure/cable/proc/delayed_surplus()
 	if(powernet)
-		return powernet.newavail - powernet.delayedload
+		return CLAMP(powernet.newavail - powernet.delayedload, 0, powernet.newavail)
 	else
 		return 0
 

--- a/code/modules/power/floodlight.dm
+++ b/code/modules/power/floodlight.dm
@@ -52,7 +52,7 @@
 	light_power = 1.75
 
 /obj/machinery/power/floodlight/process()
-	if(surplus() >= active_power_usage)
+	if(avail(active_power_usage))
 		add_load(active_power_usage)
 	else
 		change_setting(1)
@@ -61,7 +61,7 @@
 	if((val < 1) || (val > light_setting_list.len))
 		return
 	active_power_usage = light_setting_list[val]
-	if(surplus() < active_power_usage)
+	if(!avail(active_power_usage))
 		return change_setting(val - 1)
 	setting = val
 	set_light(light_setting_list[val])

--- a/code/modules/power/floodlight.dm
+++ b/code/modules/power/floodlight.dm
@@ -52,7 +52,7 @@
 	light_power = 1.75
 
 /obj/machinery/power/floodlight/process()
-	if(avail(active_power_usage))
+	if(surplus() >= active_power_usage)
 		add_load(active_power_usage)
 	else
 		change_setting(1)
@@ -61,7 +61,7 @@
 	if((val < 1) || (val > light_setting_list.len))
 		return
 	active_power_usage = light_setting_list[val]
-	if(!avail(active_power_usage))
+	if(surplus() < active_power_usage)
 		return change_setting(val - 1)
 	setting = val
 	set_light(light_setting_list[val])

--- a/code/modules/power/power.dm
+++ b/code/modules/power/power.dm
@@ -42,7 +42,7 @@
 
 /obj/machinery/power/proc/surplus()
 	if(powernet)
-		return powernet.avail - powernet.load
+		return CLAMP(powernet.avail-powernet.load, 0, powernet.avail)
 	else
 		return 0
 
@@ -58,7 +58,7 @@
 
 /obj/machinery/power/proc/delayed_surplus()
 	if(powernet)
-		return powernet.newavail - powernet.delayedload
+		return CLAMP(powernet.newavail - powernet.delayedload, 0, powernet.newavail)
 	else
 		return 0
 

--- a/code/modules/power/power.dm
+++ b/code/modules/power/power.dm
@@ -25,6 +25,10 @@
 //////////////////////////////
 
 // common helper procs for all power machines
+// All power generation handled in add_avail()
+// Machines should use add_load(), surplus(), avail()
+// Non-machines should use add_delayedload(), delayed_surplus(), newavail()
+
 /obj/machinery/power/proc/add_avail(amount)
 	if(powernet)
 		powernet.newavail += amount
@@ -45,6 +49,22 @@
 /obj/machinery/power/proc/avail()
 	if(powernet)
 		return powernet.avail
+	else
+		return 0
+
+/obj/machinery/power/proc/add_delayedload(amount)
+	if(powernet)
+		powernet.delayedload += amount
+
+/obj/machinery/power/proc/delayed_surplus()
+	if(powernet)
+		return powernet.newavail - powernet.delayedload
+	else
+		return 0
+
+/obj/machinery/power/proc/newavail()
+	if(powernet)
+		return powernet.newavail
 	else
 		return 0
 
@@ -341,7 +361,7 @@
 		source_area.use_power(drained_energy/GLOB.CELLRATE)
 	else if (istype(power_source, /datum/powernet))
 		var/drained_power = drained_energy/GLOB.CELLRATE //convert from "joules" to "watts"
-		PN.load+=drained_power
+		PN.delayedload += (min(drained_power, max(PN.newavail - PN.delayedload, 0)))
 	else if (istype(power_source, /obj/item/stock_parts/cell))
 		cell.use(drained_energy)
 	return drained_energy

--- a/code/modules/power/powernet.dm
+++ b/code/modules/power/powernet.dm
@@ -13,6 +13,7 @@
 	var/viewavail = 0			// the available power as it appears on the power console (gradually updated)
 	var/viewload = 0			// the load as it appears on the power console (gradually updated)
 	var/netexcess = 0			// excess power on the powernet (typically avail-load)///////
+	var/delayedload = 0			// load applied to powernet between power ticks.
 
 /datum/powernet/New()
 	SSmachines.powernets += src
@@ -88,7 +89,8 @@
 	viewload = round(0.8 * viewload + 0.2 * load)
 
 	// reset the powernet
-	load = 0
+	load = delayedload
+	delayedload = 0
 	avail = newavail
 	newavail = 0
 

--- a/code/modules/power/singularity/emitter.dm
+++ b/code/modules/power/singularity/emitter.dm
@@ -160,7 +160,7 @@
 		update_icon()
 		return
 	if(active == TRUE)
-		if(!active_power_usage || avail(active_power_usage))
+		if(!active_power_usage || surplus() >= active_power_usage)
 			add_load(active_power_usage)
 			if(!powered)
 				powered = TRUE
@@ -189,7 +189,7 @@
 		return FALSE
 	if(state != EMITTER_WELDED)
 		return FALSE
-	if(avail(active_power_usage))
+	if(surplus() >= active_power_usage)
 		add_load(active_power_usage)
 		fire_beam()
 


### PR DESCRIPTION
[Changelogs]: # (Your PR should contain a detailed changelog of notable changes, titled and categorized appropriately. This includes, new features, sprites, sounds, balance changes, admin tools, map edits, removals, big refactors, config changes, hosting changes and important fixes. An example changelog has been provided below for you to edit. If you need additional help, read https://github.com/tgstation/tgstation/wiki/Changelogs)

:cl: Skoglol
fix: Power changes between power ticks are now tracked by the powernets and applied to the next power tick.
fix: Power sinks now apply load before machines. This includes SMES and APC charging.
code: Electric grilles, ninja gloves, apc terminals and power sinks now use helper procs to add load.
code: Power beacons can no longer cause powernet excess to go negative instead of turning off.
code: Shocks can no longer cause powernet excess to go negative.
/:cl:

[why]: # (Please add a short description [two lines down] of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.)

Fixes #36769.
Currently, powernet load is reset at the beginning of the ssmachines tick. This means load applied between ticks is just zeroed out. A new var makes them keep track of it, causing power sinks in particular to be able to do their job as intended. 

The power sink can now be countered (as intended) by adding more power to the powernet, preventing it from draining APC's. Adds some incentive for engineers to work on increasing power output above a basic SME setup. 

Also added some checks where appropriate, and made non-machines use the new helper procs instead of updating powernet vars directly.
