### PR TITLE
Changes power sink drain rate and max power before exploding.

### DIFF
--- a/code/game/objects/items/devices/powersink.dm
+++ b/code/game/objects/items/devices/powersink.dm
@@ -14,9 +14,9 @@
 	throw_speed = 1
 	throw_range = 2
 	materials = list(MAT_METAL=750)
-	var/drain_rate = 1600000	// amount of power to drain per tick
+	var/drain_rate = 2000000	// amount of power to drain per tick
 	var/power_drained = 0 		// has drained this much power
-	var/max_power = 1e10		// maximum power that can be drained before exploding
+	var/max_power = 6e8		// maximum power that can be drained before exploding
 	var/mode = 0		// 0 = off, 1=clamped (off), 2=operating
 	var/admins_warned = FALSE // stop spam, only warn the admins once that we are about to boom
 


### PR DESCRIPTION
[Changelogs]: # (Your PR should contain a detailed changelog of notable changes, titled and categorized appropriately. This includes, new features, sprites, sounds, balance changes, admin tools, map edits, removals, big refactors, config changes, hosting changes and important fixes. An example changelog has been provided below for you to edit. If you need additional help, read https://github.com/tgstation/tgstation/wiki/Changelogs)

:cl: Skoglol
fix: Power sinks now explode within a reasonable amount of time.
/:cl:

[why]: # (Please add a short description [two lines down] of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.)

With the current max power and drain rate:
10 000 000 000 / 1 600 000 / 30 (power ticks in a minute) = 208,33 minutes of max drain to reach max power.

With the proposed change:
600 000 000 / 2 000 000 / 30 = 10 minutes of max drain to reach max power.

Drain rate increased slightly to avoid unupgraded roundstart SMES (with solars) almost negating a power sink. 7 fully powered unupgraded SMES will supply a little over 75% of the new max power in about 11 minutes. If you wanna fully counter (and inevitably blow) a sink, you gotta work at least a little bit more than just connecting solars. 

Hopefully, this change should cause the average power sink to blow up in between 10-20 minutes. I would like some feedback on the numbers though, as they may need tweaking.