### PR TITLE
Fixes catpeople not being able to laugh

### DIFF
--- a/code/modules/mob/living/emote.dm
+++ b/code/modules/mob/living/emote.dm
@@ -209,9 +209,9 @@
 
 /datum/emote/living/laugh/run_emote(mob/user, params)
 	. = ..()
-	if(. && ishuman(user))
+	if(. && iscarbon(user))
 		var/mob/living/carbon/human/H = user
-		if(H.dna.species.id == "human" && (!H.mind || !H.mind.miming))
+		if((H.dna.species.id == "human" || H.dna.species.id == "felinid") && (!H.mind || !H.mind.miming))
 			if(user.gender == FEMALE)
 				playsound(H, 'sound/voice/human/womanlaugh.ogg', 50, 1)
 			else


### PR DESCRIPTION
:cl: Nervere
tweak: Catpeople can now laugh again!
/:cl:

[why]: Catpeople couldn't laugh because the laughing sound was restricted to humans only. The refactor for catpeople into a different species had the unintended effect of restricting catpeople from being able to do an audible laugh.