### PR TITLE
Un-Nerfs the clown car TC cost.

### DIFF
--- a/code/modules/uplink/uplink_items.dm
+++ b/code/modules/uplink/uplink_items.dm
@@ -1480,7 +1480,7 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 			someone saves them or they manage to crawl out. Be sure not to ram into any walls or vending machines, as the springloaded seats \
 			are very sensetive. Now with our included lube defense mechanism which will protect you against any angry shitcurity!"
 	item = /obj/vehicle/sealed/car/clowncar
-	cost = 20
+	cost = 15
 	restricted_roles = list("Clown")
 
 // Pointless


### PR DESCRIPTION
:cl: GuyonBroadway
balance: The traitor clown car costs 15 tc again
/:cl:

[why] There were lots of arguments as to why the clown car should remain at 15tc as detailed in https://github.com/tgstation/tgstation/pull/40222 but to rattle a few off here goes.

Its significantly less lethal than other items that are cheaper than 20tc.

Its extended functionality makes it into more of a "go all in" item and was priced such that you could only get said emag if either was discounted. Making the car 20tc requires you to roll discount on the car itself and a high discount as that making the chances of it happening VERY low.

Its comparable in strength to a laughter demon, except it can't hide in blood, doesn't come with noclip mode, isn't as durable, can't heal by consuming bodies and everyone comes out alive when it hits a wall. Laughter demons cost 1 spell point which is about 4tc at most.