### PR TITLE
Removes fake nuclear disks from null-crates.

### DIFF
--- a/code/modules/uplink/uplink_items.dm
+++ b/code/modules/uplink/uplink_items.dm
@@ -914,6 +914,7 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 	item = /obj/item/disk/nuclear/fake
 	cost = 1
 	surplus = 1
+	surplus_nullcrates = 0
 
 //Space Suits and Hardsuits
 /datum/uplink_item/suits


### PR DESCRIPTION
:cl: Administrative Moonman
tweak: Fake nuclear disks no longer appear in null-crates, but can appear in surplus traitor crates with the regularity they had before.
/:cl:

**Why?:** Besides from being a soft target to flex GBP on, the station_loving aspect of fake nuclear disks makes properly approving the null crate they are within with cargo impossible to achieve due to the disk wandering off whenever they re-manifest on station due to the way cargo manually transports its boxes between z levels by shuttle, causing a lot of bother when you cannot confidently be sure whether the manifest is correct or not.

As the old addage goes, "don't fix what ain't broke". Im sure nobody will miss the disk since it only spawned with a 1% chance of regularity anyway as a not critically prioritised surplus item, without applying a over the top exemption rule to just be transported by cargo.

Fixes  #39609 
