### PR TITLE
Makes sand/snowdigging not rely on archaeology feature for the interaction

### DIFF
--- a/code/game/mecha/equipment/tools/mining_tools.dm
+++ b/code/game/mecha/equipment/tools/mining_tools.dm
@@ -79,10 +79,8 @@
 
 /turf/open/floor/plating/asteroid/drill_act(obj/item/mecha_parts/mecha_equipment/drill/drill)
 	for(var/turf/open/floor/plating/asteroid/M in range(1, drill.chassis))
-		if(get_dir(drill.chassis,M)&drill.chassis.dir)
-			for(var/I in GetComponents(/datum/component/archaeology))
-				var/datum/component/archaeology/archy = I
-				archy.gets_dug()
+		if((get_dir(drill.chassis,M)&drill.chassis.dir) && !M.dug)
+			M.getDug()
 	drill.log_message("Drilled through [src]")
 	drill.move_ores()
 

--- a/code/game/turfs/open.dm
+++ b/code/game/turfs/open.dm
@@ -4,7 +4,6 @@
 
 	var/postdig_icon_change = FALSE
 	var/postdig_icon
-	var/list/archdrops
 	var/wet
 
 	var/footstep = null
@@ -13,8 +12,6 @@
 	. = ..()
 	if(wet)
 		AddComponent(/datum/component/wet_floor, wet, INFINITY, 0, INFINITY, TRUE)
-	if(LAZYLEN(archdrops))
-		AddComponent(/datum/component/archaeology, archdrops)
 
 /turf/open/indestructible
 	name = "floor"

--- a/code/game/turfs/simulated/floor/plating/asteroid.dm
+++ b/code/game/turfs/simulated/floor/plating/asteroid.dm
@@ -13,8 +13,9 @@
 	var/environment_type = "asteroid"
 	var/turf_type = /turf/open/floor/plating/asteroid //Because caves do whacky shit to revert to normal
 	var/floor_variance = 20 //probability floor has a different icon state
-	archdrops = list(/obj/item/stack/ore/glass = list(ARCH_PROB = 100,ARCH_MAXDROP = 5))
 	attachment_holes = FALSE
+	var/obj/item/stack/digResult = /obj/item/stack/ore/glass/basalt
+	var/dug
 
 /turf/open/floor/plating/asteroid/Initialize()
 	var/proper_name = name
@@ -22,6 +23,14 @@
 	name = proper_name
 	if(prob(floor_variance))
 		icon_state = "[environment_type][rand(0,12)]"
+
+/turf/open/floor/plating/asteroid/proc/getDug()
+	new digResult(src, 5)
+	if(postdig_icon_change)
+		if(!postdig_icon)
+			icon_plating = "[environment_type]_dug"
+			icon_state = "[environment_type]_dug"
+	dug = TRUE
 
 /turf/open/floor/plating/asteroid/try_replace_tile(obj/item/stack/tile/T, mob/user, params)
 	return
@@ -36,11 +45,26 @@
 	return
 
 /turf/open/floor/plating/asteroid/attackby(obj/item/W, mob/user, params)
-	if(..())
-		return TRUE
-	if(istype(W, /obj/item/storage/bag/ore))
-		for(var/obj/item/stack/ore/O in src)
-			SEND_SIGNAL(W, COMSIG_PARENT_ATTACKBY, O)
+	. = ..()
+	if(!.)
+		if(W.tool_behaviour == TOOL_SHOVEL || W.tool_behaviour == TOOL_MINING)
+			if(dug)
+				to_chat(user, "<span class='notice'>Looks like someone has dug here already.</span>")
+				return TRUE
+
+			if(!isturf(user.loc))
+				return
+
+			to_chat(user, "<span class='notice'>You start digging...</span>")
+
+			if(W.use_tool(src, user, 40, volume=50))
+				to_chat(user, "<span class='notice'>You dig a hole.</span>")
+				getDug()
+				SSblackbox.record_feedback("tally", "pick_used_mining", 1, W.type)
+				return TRUE
+		else if(istype(W, /obj/item/storage/bag/ore))
+			for(var/obj/item/stack/ore/O in src)
+				SEND_SIGNAL(W, COMSIG_PARENT_ATTACKBY, O)
 
 /turf/open/floor/plating/asteroid/singularity_act()
 	if(is_planet_level(z))
@@ -61,8 +85,8 @@
 	icon_state = "basalt"
 	icon_plating = "basalt"
 	environment_type = "basalt"
-	archdrops = list(/obj/item/stack/ore/glass/basalt = list(ARCH_PROB = 100,ARCH_MAXDROP = 5))
 	floor_variance = 15
+	digResult = /obj/item/stack/ore/glass/basalt
 
 /turf/open/floor/plating/asteroid/basalt/lava //lava underneath
 	baseturfs = /turf/open/lava/smooth
@@ -73,9 +97,6 @@
 /turf/open/floor/plating/asteroid/basalt/Initialize()
 	. = ..()
 	set_basalt_light(src)
-	GET_COMPONENT(arch, /datum/component/archaeology)
-	ASSERT(isnull(arch.callback))
-	arch.callback = CALLBACK(src, /atom/proc/set_light, 0)
 
 /proc/set_basalt_light(turf/open/floor/B)
 	switch(B.icon_state)
@@ -276,10 +297,10 @@
 	environment_type = "snow"
 	flags_1 = NONE
 	planetary_atmos = TRUE
-	archdrops = list(/obj/item/stack/sheet/mineral/snow = list(ARCH_PROB = 100, ARCH_MAXDROP = 5))
 	burnt_states = list("snow_dug")
 	bullet_sizzle = TRUE
 	bullet_bounce_sound = null
+	digResult = /obj/item/stack/sheet/mineral/snow
 
 /turf/open/floor/plating/asteroid/snow/burn_tile()
 	if(!burnt)

--- a/code/game/turfs/simulated/floor/plating/asteroid.dm
+++ b/code/game/turfs/simulated/floor/plating/asteroid.dm
@@ -98,6 +98,10 @@
 	. = ..()
 	set_basalt_light(src)
 
+/turf/open/floor/plating/asteroid/getDug()
+	set_light(0)
+	return ..()
+
 /proc/set_basalt_light(turf/open/floor/B)
 	switch(B.icon_state)
 		if("basalt1", "basalt2", "basalt3")

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -321,7 +321,6 @@
 #include "code\datums\brain_damage\split_personality.dm"
 #include "code\datums\components\_component.dm"
 #include "code\datums\components\anti_magic.dm"
-#include "code\datums\components\archaeology.dm"
 #include "code\datums\components\armor_plate.dm"
 #include "code\datums\components\butchering.dm"
 #include "code\datums\components\caltrop.dm"


### PR DESCRIPTION
Simply put, this component with archdrops is responsible for hundreds of thoudsands of total lists being made, along with around 150 thousand callback objects, 50+ thousand components, all so that you can get sand or snow if you click on an asteroid tile. This translates to 50-100 MB of memory depending on how deep space generation shakes out. Yes, really.

:cl: Naksu
del: archaeology component no longer handles sand-digging, it has been disabled until someone works on xenoarch again.
/:cl: