### PR TITLE
fixes roundstart atmos from lavaland_surface_ufo_crash.dmm

### DIFF
--- a/_maps/RandomRuins/LavaRuins/lavaland_surface_ufo_crash.dmm
+++ b/_maps/RandomRuins/LavaRuins/lavaland_surface_ufo_crash.dmm
@@ -16,12 +16,12 @@
 	team_number = 100
 	},
 /turf/open/floor/plating/abductor{
-	initial_gas_mix = "o2=16;n2=23;TEMP=300"
+	initial_gas_mix = "o2=14;n2=23;TEMP=300"
 	},
 /area/ruin/unpowered)
 "k" = (
 /turf/open/floor/plating/abductor{
-	initial_gas_mix = "o2=16;n2=23;TEMP=300"
+	initial_gas_mix = "o2=14;n2=23;TEMP=300"
 	},
 /area/ruin/unpowered)
 "l" = (
@@ -29,59 +29,59 @@
 	team_number = 100
 	},
 /turf/open/floor/plating/abductor{
-	initial_gas_mix = "o2=16;n2=23;TEMP=300"
+	initial_gas_mix = "o2=14;n2=23;TEMP=300"
 	},
 /area/ruin/unpowered)
 "o" = (
 /obj/item/hemostat/alien,
 /turf/open/floor/plating/abductor{
-	initial_gas_mix = "o2=16;n2=23;TEMP=300"
+	initial_gas_mix = "o2=14;n2=23;TEMP=300"
 	},
 /area/ruin/unpowered)
 "p" = (
 /obj/effect/mob_spawn/human/abductor,
 /turf/open/floor/plating/abductor{
-	initial_gas_mix = "o2=16;n2=23;TEMP=300"
+	initial_gas_mix = "o2=14;n2=23;TEMP=300"
 	},
 /area/ruin/unpowered)
 "q" = (
 /obj/structure/closet/abductor,
 /turf/open/floor/plating/abductor{
-	initial_gas_mix = "o2=16;n2=23;TEMP=300"
+	initial_gas_mix = "o2=14;n2=23;TEMP=300"
 	},
 /area/ruin/unpowered)
 "s" = (
 /obj/structure/table/optable/abductor,
 /obj/item/cautery/alien,
 /turf/open/floor/plating/abductor{
-	initial_gas_mix = "o2=16;n2=23;TEMP=300"
+	initial_gas_mix = "o2=14;n2=23;TEMP=300"
 	},
 /area/ruin/unpowered)
 "t" = (
 /obj/structure/table/abductor,
 /obj/item/storage/box/alienhandcuffs,
 /turf/open/floor/plating/abductor{
-	initial_gas_mix = "o2=16;n2=23;TEMP=300"
+	initial_gas_mix = "o2=14;n2=23;TEMP=300"
 	},
 /area/ruin/unpowered)
 "v" = (
 /obj/item/scalpel/alien,
 /obj/item/surgical_drapes,
 /turf/open/floor/plating/abductor{
-	initial_gas_mix = "o2=16;n2=23;TEMP=300"
+	initial_gas_mix = "o2=14;n2=23;TEMP=300"
 	},
 /area/ruin/unpowered)
 "w" = (
 /obj/item/retractor/alien,
 /obj/item/paper/guides/antag/abductor,
 /turf/open/floor/plating/abductor{
-	initial_gas_mix = "o2=16;n2=23;TEMP=300"
+	initial_gas_mix = "o2=14;n2=23;TEMP=300"
 	},
 /area/ruin/unpowered)
 "y" = (
 /obj/machinery/abductor/gland_dispenser,
 /turf/open/floor/plating/abductor{
-	initial_gas_mix = "o2=16;n2=23;TEMP=300"
+	initial_gas_mix = "o2=14;n2=23;TEMP=300"
 	},
 /area/ruin/unpowered)
 "z" = (
@@ -89,13 +89,13 @@
 /obj/item/surgicaldrill/alien,
 /obj/item/circular_saw/alien,
 /turf/open/floor/plating/abductor{
-	initial_gas_mix = "o2=16;n2=23;TEMP=300"
+	initial_gas_mix = "o2=14;n2=23;TEMP=300"
 	},
 /area/ruin/unpowered)
 "A" = (
 /obj/structure/bed/abductor,
 /turf/open/floor/plating/abductor{
-	initial_gas_mix = "o2=16;n2=23;TEMP=300"
+	initial_gas_mix = "o2=14;n2=23;TEMP=300"
 	},
 /area/ruin/unpowered)
 


### PR DESCRIPTION
:cl: Granpawalton
fix: fixed some round start atmospherics differences on lavaland caused by the ufo crash ruin
/:cl:

[why]: it was set to 16 moles O2 when it should be 14 moles like the rest of lavaland, this lowers load time by .1 to .5 seconds when loading lavaland with this ruin on it.
