### PR TITLE
catpeople burn easier because of their fur [100% REALISM PR]

### DIFF
--- a/code/modules/mob/living/carbon/human/species_types/felinid.dm
+++ b/code/modules/mob/living/carbon/human/species_types/felinid.dm
@@ -10,6 +10,9 @@
 	mutantears = /obj/item/organ/ears/cat
 	mutanttail = /obj/item/organ/tail/cat
 
+	burnmod = 1.25
+	heatmod = 1.5
+
 /datum/species/human/felinid/qualifies_for_rank(rank, list/features)
 	return TRUE
 


### PR DESCRIPTION
:cl: basilman
add: catpeople burn easier because of their fur
/:cl:

[why]: # realisms and to make catpeople lifespan shorter so that the ecosstem isnt damaged
### **edit: REMINDER THE PRUSPOE OF THIS PR IS REALISM -ONLY-**