### PR TITLE
Bump Node version to 8, tidy tgui build scripts

### DIFF
--- a/dependencies.sh
+++ b/dependencies.sh
@@ -16,4 +16,4 @@ export RUST_G_VERSION=0.4.0
 export BSQL_VERSION=v1.4.0.0
 
 #node version
-export NODE_VERSION=4
+export NODE_VERSION=8

--- a/tgui/build_assets.bat
+++ b/tgui/build_assets.bat
@@ -2,5 +2,5 @@
 echo node.js and all dependencies must be installed for this script to work.
 echo If this script fails try installing dependencies again.
 REM Build minified assets
-cmd /c gulp --min
+node node_modules/gulp/bin/gulp.js --min
 pause

--- a/tgui/install_dependencies.bat
+++ b/tgui/install_dependencies.bat
@@ -3,14 +3,6 @@ echo node.js 5.3.0 or newer must be installed for this script to work.
 echo If this script fails, try closing editors and running it again first.
 echo Any warnings about optional dependencies can be safely ignored.
 pause
-REM Install npm-cache
-cmd /c npm install npm-cache -g
-REM Install Gulp
-cmd /c npm install gulp-cli -g
-REM Install tgui dependencies
-cmd /c npm-cache install npm
-REM Flatten dependency tree
-cmd /c npm dedupe
-REM Clean dependency tree
-cmd /c npm prune
+REM Install dependencies
+npm install
 pause

--- a/tgui/install_dependencies.bat
+++ b/tgui/install_dependencies.bat
@@ -4,5 +4,5 @@ echo If this script fails, try closing editors and running it again first.
 echo Any warnings about optional dependencies can be safely ignored.
 pause
 REM Install dependencies
-npm install
+npm ci
 pause

--- a/tools/travis/build_tools.sh
+++ b/tools/travis/build_tools.sh
@@ -6,7 +6,7 @@ set -e
 if [ "$BUILD_TOOLS" = true ];
 then
     md5sum -c - <<< "49bc6b1b9ed56c83cceb6674bd97cb34 *html/changelogs/example.yml";
-    (cd tgui && source ~/.nvm/nvm.sh && npm install && node node_modules/gulp/bin/gulp.js --min)
+    (cd tgui && source ~/.nvm/nvm.sh && npm ci && node node_modules/gulp/bin/gulp.js --min)
     phpenv global 5.6
     php -l tools/WebhookProcessor/github_webhook_processor.php;
     php -l tools/TGUICompiler.php;

--- a/tools/travis/build_tools.sh
+++ b/tools/travis/build_tools.sh
@@ -6,7 +6,7 @@ set -e
 if [ "$BUILD_TOOLS" = true ];
 then
     md5sum -c - <<< "49bc6b1b9ed56c83cceb6674bd97cb34 *html/changelogs/example.yml";
-    cd tgui && source ~/.nvm/nvm.sh && gulp && cd ..;
+    (cd tgui && source ~/.nvm/nvm.sh && npm install && node node_modules/gulp/bin/gulp.js --min)
     phpenv global 5.6
     php -l tools/WebhookProcessor/github_webhook_processor.php;
     php -l tools/TGUICompiler.php;

--- a/tools/travis/install_build_tools.sh
+++ b/tools/travis/install_build_tools.sh
@@ -5,7 +5,6 @@ source dependencies.sh
 
 if [ "$BUILD_TOOLS" = true ]; then
       rm -rf ~/.nvm && git clone https://github.com/creationix/nvm.git ~/.nvm && (cd ~/.nvm && git checkout `git describe --abbrev=0 --tags`) && source ~/.nvm/nvm.sh && nvm install $NODE_VERSION
-      npm install -g gulp-cli
       pip3 install --user PyYaml -q
       pip3 install --user beautifulsoup4 -q
 fi;


### PR DESCRIPTION
Node 4 was [end-of-lifed in April](https://github.com/nodejs/Release#release-schedule). Node 8 is the current LTS.

`tgui` depends on `stylus:0.54.5` depends on `debug:*`, meaning "any version", including newer breaking ones. NPM 2, associated with Node 4, *does not obey `package-lock.json` at all* (the feature was added in NPM 5.0), meaning downstreams who *don't* have our known-good Travis caches will catch [versions of `debug`](https://www.npmjs.com/package/debug) (released 4 days ago as of this writing) using features Node 4 doesn't support, and fail CI.

The batch files do a bunch of unnecessary stuff, I've pared it down to only the two commands which I actually use.

Here's hoping this one passes Travis.
* Previous: node v4.9.1, npm v2.15.11
* Current: node v8.12.0, npm v6.4.1