### PR TITLE
Allow setting a per-z-level baseturf

### DIFF
--- a/code/__DEFINES/maps.dm
+++ b/code/__DEFINES/maps.dm
@@ -59,6 +59,9 @@ require only minor tweaks.
     // CROSSLINKED - mixed in with the cross-linked space pool
     #define CROSSLINKED "Cross"
 
+// string - type path of the z-level's baseturf (defaults to space)
+#define ZTRAIT_BASETURF "Baseturf"
+
 // default trait definitions, used by SSmapping
 #define ZTRAITS_CENTCOM list(ZTRAIT_CENTCOM = TRUE)
 #define ZTRAITS_STATION list(ZTRAIT_LINKAGE = CROSSLINKED, ZTRAIT_STATION = TRUE)

--- a/code/game/turfs/baseturf_skipover.dm
+++ b/code/game/turfs/baseturf_skipover.dm
@@ -11,3 +11,8 @@
 /turf/baseturf_skipover/shuttle
 	name = "Shuttle baseturf skipover"
 	desc = "Acts as the bottom of the shuttle, if this isn't here the shuttle floor is broken through."
+
+/turf/baseturf_bottom
+	name = "Z-level baseturf placeholder"
+	desc = "Marker for z-level baseturf, usually resolves to space."
+	baseturfs = /turf/baseturf_bottom

--- a/code/game/turfs/change_turf.dm
+++ b/code/game/turfs/change_turf.dm
@@ -1,6 +1,7 @@
 // This is a list of turf types we dont want to assign to baseturfs unless through initialization or explicitly
 GLOBAL_LIST_INIT(blacklisted_automated_baseturfs, typecacheof(list(
 	/turf/open/space,
+	/turf/baseturf_bottom,
 	)))
 
 /turf/proc/empty(turf_type=/turf/open/space, baseturf_type, list/ignore_typecache, flags)
@@ -220,7 +221,7 @@ GLOBAL_LIST_INIT(blacklisted_automated_baseturfs, typecacheof(list(
 			newT.assemble_baseturfs(initial(fake_turf_type.baseturfs)) // The baseturfs list is created like roundstart
 			if(!length(newT.baseturfs))
 				newT.baseturfs = list(baseturfs)
-			newT.baseturfs -= newT.baseturfs & GLOB.blacklisted_automated_baseturfs
+			newT.baseturfs -= GLOB.blacklisted_automated_baseturfs
 			newT.baseturfs.Insert(1, old_baseturfs) // The old baseturfs are put underneath
 			return newT
 		if(!length(baseturfs))

--- a/code/game/turfs/change_turf.dm
+++ b/code/game/turfs/change_turf.dm
@@ -58,6 +58,13 @@ GLOBAL_LIST_INIT(blacklisted_automated_baseturfs, typecacheof(list(
 /turf/proc/ChangeTurf(path, list/new_baseturfs, flags)
 	if(!path)
 		return
+	if(path == /turf/baseturf_bottom)
+		path = SSmapping.level_trait(z, ZTRAIT_BASETURF) || /turf/open/space
+		if (!ispath(path))
+			path = text2path(path)
+			if (!ispath(path))
+				warning("Z-level [z] has invalid baseturf '[SSmapping.level_trait(z, ZTRAIT_BASETURF)]'")
+				path = /turf/open/space
 	if(path == /turf/open/space/basic)
 		// basic doesn't initialize and this will cause issues
 		// no warning though because this can happen naturaly as a result of it being built on top of

--- a/code/game/turfs/change_turf.dm
+++ b/code/game/turfs/change_turf.dm
@@ -57,19 +57,21 @@ GLOBAL_LIST_INIT(blacklisted_automated_baseturfs, typecacheof(list(
 // Creates a new turf
 // new_baseturfs can be either a single type or list of types, formated the same as baseturfs. see turf.dm
 /turf/proc/ChangeTurf(path, list/new_baseturfs, flags)
-	if(!path)
-		return
-	if(path == /turf/baseturf_bottom)
-		path = SSmapping.level_trait(z, ZTRAIT_BASETURF) || /turf/open/space
-		if (!ispath(path))
-			path = text2path(path)
+	switch(path)
+		if(null)
+			return
+		if(/turf/baseturf_bottom)
+			path = SSmapping.level_trait(z, ZTRAIT_BASETURF) || /turf/open/space
 			if (!ispath(path))
-				warning("Z-level [z] has invalid baseturf '[SSmapping.level_trait(z, ZTRAIT_BASETURF)]'")
-				path = /turf/open/space
-	if(path == /turf/open/space/basic)
-		// basic doesn't initialize and this will cause issues
-		// no warning though because this can happen naturaly as a result of it being built on top of
-		path = /turf/open/space
+				path = text2path(path)
+				if (!ispath(path))
+					warning("Z-level [z] has invalid baseturf '[SSmapping.level_trait(z, ZTRAIT_BASETURF)]'")
+					path = /turf/open/space
+		if(/turf/open/space/basic)
+			// basic doesn't initialize and this will cause issues
+			// no warning though because this can happen naturaly as a result of it being built on top of
+			path = /turf/open/space
+
 	if(!GLOB.use_preloader && path == type && !(flags & CHANGETURF_FORCEOP)) // Don't no-op if the map loader requires it to be reconstructed
 		return src
 	if(flags & CHANGETURF_SKIP)

--- a/code/game/turfs/simulated/floor/plating.dm
+++ b/code/game/turfs/simulated/floor/plating.dm
@@ -11,7 +11,7 @@
 	name = "plating"
 	icon_state = "plating"
 	intact = FALSE
-	baseturfs = /turf/open/space
+	baseturfs = /turf/baseturf_bottom
 	footstep = FOOTSTEP_PLATING
 
 	var/attachment_holes = TRUE

--- a/code/game/turfs/turf.dm
+++ b/code/game/turfs/turf.dm
@@ -9,7 +9,7 @@
 	// A list will be created in initialization that figures out the baseturf's baseturf etc.
 	// In the case of a list it is sorted from bottom layer to top.
 	// This shouldn't be modified directly, use the helper procs.
-	var/list/baseturfs = /turf/open/space
+	var/list/baseturfs = /turf/baseturf_bottom
 
 	var/temperature = T20C
 	var/to_be_destroyed = 0 //Used for fire, if a melting temperature was reached, it will be destroyed


### PR DESCRIPTION
:cl:
code: It is now possible to set a different most-base-turf per z-level.
/:cl:

To do:
* [x] make sure this interacts in a sane way with shuttles
* deferred: ~~use this on lavaland instead of per-area baseturf helpers~~

r+ @ninjanomnom 