### PR TITLE
Dirty Var Cleanup

### DIFF
--- a/_maps/RandomRuins/SpaceRuins/abandonedzoo.dmm
+++ b/_maps/RandomRuins/SpaceRuins/abandonedzoo.dmm
@@ -144,9 +144,7 @@
 /obj/machinery/light{
 	dir = 8
 	},
-/turf/open/floor/plasteel{
-	icon_state = "dark"
-	},
+/turf/open/floor/plasteel/dark/side,
 /area/ruin/space/has_grav/abandonedzoo)
 "ay" = (
 /obj/effect/turf_decal/tile/green{
@@ -171,9 +169,7 @@
 /obj/machinery/light{
 	dir = 4
 	},
-/turf/open/floor/plasteel{
-	icon_state = "dark"
-	},
+/turf/open/floor/plasteel/dark/side,
 /area/ruin/space/has_grav/abandonedzoo)
 "aA" = (
 /obj/structure/flora/ausbushes/ywflowers,
@@ -196,9 +192,7 @@
 	name = "Bio Containment";
 	req_one_access_txt = "47"
 	},
-/turf/open/floor/plasteel{
-	icon_state = "dark"
-	},
+/turf/open/floor/plasteel/dark/side,
 /area/ruin/space/has_grav/abandonedzoo)
 "aE" = (
 /obj/machinery/shieldwallgen{
@@ -232,9 +226,7 @@
 	icon_state = "4-8"
 	},
 /obj/item/gun/energy/floragun,
-/turf/open/floor/plasteel{
-	icon_state = "dark"
-	},
+/turf/open/floor/plasteel/dark/side,
 /area/ruin/space/has_grav/abandonedzoo)
 "aH" = (
 /obj/structure/cable{
@@ -261,9 +253,7 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/turf/open/floor/plasteel{
-	icon_state = "dark"
-	},
+/turf/open/floor/plasteel/dark/side,
 /area/ruin/space/has_grav/abandonedzoo)
 "aJ" = (
 /obj/machinery/shieldwallgen{
@@ -289,9 +279,7 @@
 /turf/template_noop,
 /area/space/nearstation)
 "aL" = (
-/turf/open/floor/plasteel{
-	icon_state = "dark"
-	},
+/turf/open/floor/plasteel/dark/side,
 /area/ruin/space/has_grav/abandonedzoo)
 "aM" = (
 /obj/structure/cable{
@@ -302,9 +290,7 @@
 "aN" = (
 /obj/structure/table/reinforced,
 /obj/item/folder,
-/turf/open/floor/plasteel{
-	icon_state = "dark"
-	},
+/turf/open/floor/plasteel/dark/side,
 /area/ruin/space/has_grav/abandonedzoo)
 "aO" = (
 /obj/structure/chair/office/light{
@@ -326,9 +312,7 @@
 /obj/structure/table/reinforced,
 /obj/item/reagent_containers/glass/bottle/random_virus,
 /obj/item/reagent_containers/dropper,
-/turf/open/floor/plasteel{
-	icon_state = "dark"
-	},
+/turf/open/floor/plasteel/dark/side,
 /area/ruin/space/has_grav/abandonedzoo)
 "aQ" = (
 /obj/structure/window/reinforced{
@@ -340,9 +324,7 @@
 /obj/machinery/light/small{
 	dir = 4
 	},
-/turf/open/floor/plasteel{
-	icon_state = "dark"
-	},
+/turf/open/floor/plasteel/dark/side,
 /area/ruin/space/has_grav/abandonedzoo)
 "aS" = (
 /obj/machinery/power/apc/unlocked{
@@ -359,9 +341,7 @@
 /obj/structure/rack,
 /obj/item/melee/baton/cattleprod,
 /obj/effect/spawner/lootdrop/maintenance,
-/turf/open/floor/plasteel{
-	icon_state = "dark"
-	},
+/turf/open/floor/plasteel/dark/side,
 /area/ruin/space/has_grav/abandonedzoo)
 "aT" = (
 /obj/structure/cable{
@@ -373,9 +353,7 @@
 /obj/structure/rack,
 /obj/item/clothing/suit/space/hardsuit/medical,
 /obj/item/tank/internals/emergency_oxygen/double,
-/turf/open/floor/plasteel{
-	icon_state = "dark"
-	},
+/turf/open/floor/plasteel/dark/side,
 /area/ruin/space/has_grav/abandonedzoo)
 "aU" = (
 /obj/structure/rack,
@@ -384,22 +362,16 @@
 /obj/machinery/light{
 	dir = 1
 	},
-/turf/open/floor/plasteel{
-	icon_state = "dark"
-	},
+/turf/open/floor/plasteel/dark/side,
 /area/ruin/space/has_grav/abandonedzoo)
 "aV" = (
 /obj/machinery/smartfridge/chemistry,
-/turf/open/floor/plasteel{
-	icon_state = "dark"
-	},
+/turf/open/floor/plasteel/dark/side,
 /area/ruin/space/has_grav/abandonedzoo)
 "aW" = (
 /obj/structure/table/reinforced,
 /obj/item/gun/syringe,
-/turf/open/floor/plasteel{
-	icon_state = "dark"
-	},
+/turf/open/floor/plasteel/dark/side,
 /area/ruin/space/has_grav/abandonedzoo)
 "aX" = (
 /obj/structure/table/reinforced,
@@ -417,34 +389,26 @@
 /obj/machinery/light{
 	dir = 1
 	},
-/turf/open/floor/plasteel{
-	icon_state = "dark"
-	},
+/turf/open/floor/plasteel/dark/side,
 /area/ruin/space/has_grav/abandonedzoo)
 "aY" = (
 /obj/structure/table/reinforced,
 /obj/item/gun/energy/temperature{
 	pin = /obj/item/firing_pin
 	},
-/turf/open/floor/plasteel{
-	icon_state = "dark"
-	},
+/turf/open/floor/plasteel/dark/side,
 /area/ruin/space/has_grav/abandonedzoo)
 "aZ" = (
 /obj/structure/table/reinforced,
 /obj/item/cultivator,
 /obj/item/shovel,
-/turf/open/floor/plasteel{
-	icon_state = "dark"
-	},
+/turf/open/floor/plasteel/dark/side,
 /area/ruin/space/has_grav/abandonedzoo)
 "ba" = (
 /obj/machinery/light/small{
 	dir = 8
 	},
-/turf/open/floor/plasteel{
-	icon_state = "dark"
-	},
+/turf/open/floor/plasteel/dark/side,
 /area/ruin/space/has_grav/abandonedzoo)
 "bb" = (
 /obj/machinery/door/airlock/hatch{
@@ -497,9 +461,7 @@
 /area/ruin/space/has_grav/abandonedzoo)
 "be" = (
 /obj/structure/reagent_dispensers/fueltank,
-/turf/open/floor/plasteel{
-	icon_state = "dark"
-	},
+/turf/open/floor/plasteel/dark/side,
 /area/ruin/space/has_grav/abandonedzoo)
 "bf" = (
 /obj/machinery/power/smes/magical{
@@ -510,31 +472,23 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/turf/open/floor/plasteel{
-	icon_state = "dark"
-	},
+/turf/open/floor/plasteel/dark/side,
 /area/ruin/space/has_grav/abandonedzoo)
 "bg" = (
 /obj/structure/reagent_dispensers/watertank,
 /obj/machinery/light,
-/turf/open/floor/plasteel{
-	icon_state = "dark"
-	},
+/turf/open/floor/plasteel/dark/side,
 /area/ruin/space/has_grav/abandonedzoo)
 "bh" = (
 /obj/machinery/disposal/bin,
 /obj/structure/disposalpipe/trunk,
-/turf/open/floor/plasteel{
-	icon_state = "dark"
-	},
+/turf/open/floor/plasteel/dark/side,
 /area/ruin/space/has_grav/abandonedzoo)
 "bi" = (
 /obj/structure/table/reinforced,
 /obj/item/reagent_containers/hypospray/medipen/stimpack,
 /obj/item/reagent_containers/glass/bottle/mutagen,
-/turf/open/floor/plasteel{
-	icon_state = "dark"
-	},
+/turf/open/floor/plasteel/dark/side,
 /area/ruin/space/has_grav/abandonedzoo)
 "bj" = (
 /obj/structure/table/reinforced,
@@ -546,37 +500,27 @@
 /obj/item/cautery,
 /obj/item/circular_saw,
 /obj/machinery/light,
-/turf/open/floor/plasteel{
-	icon_state = "dark"
-	},
+/turf/open/floor/plasteel/dark/side,
 /area/ruin/space/has_grav/abandonedzoo)
 "bk" = (
 /obj/structure/table/optable,
-/turf/open/floor/plasteel{
-	icon_state = "dark"
-	},
+/turf/open/floor/plasteel/dark/side,
 /area/ruin/space/has_grav/abandonedzoo)
 "bl" = (
 /obj/machinery/computer/operating{
 	dir = 8
 	},
-/turf/open/floor/plasteel{
-	icon_state = "dark"
-	},
+/turf/open/floor/plasteel/dark/side,
 /area/ruin/space/has_grav/abandonedzoo)
 "bm" = (
 /obj/structure/closet/wardrobe/science_white,
 /obj/structure/disposalpipe/segment,
-/turf/open/floor/plasteel{
-	icon_state = "dark"
-	},
+/turf/open/floor/plasteel/dark/side,
 /area/ruin/space/has_grav/abandonedzoo)
 "bn" = (
 /obj/structure/table/reinforced,
 /obj/item/reagent_containers/food/snacks/carrotfries,
-/turf/open/floor/plasteel{
-	icon_state = "dark"
-	},
+/turf/open/floor/plasteel/dark/side,
 /area/ruin/space/has_grav/abandonedzoo)
 "bo" = (
 /obj/machinery/shieldwallgen{
@@ -600,9 +544,7 @@
 /obj/structure/bed,
 /obj/item/bedsheet/green,
 /obj/structure/disposalpipe/segment,
-/turf/open/floor/plasteel{
-	icon_state = "dark"
-	},
+/turf/open/floor/plasteel/dark/side,
 /area/ruin/space/has_grav/abandonedzoo)
 "bq" = (
 /obj/item/stack/cable_coil/cut/red,
@@ -619,9 +561,7 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/turf/open/floor/plasteel{
-	icon_state = "dark"
-	},
+/turf/open/floor/plasteel/dark/side,
 /area/ruin/space/has_grav/abandonedzoo)
 "bs" = (
 /obj/structure/cable{
@@ -675,16 +615,12 @@
 /obj/machinery/light{
 	dir = 8
 	},
-/turf/open/floor/plasteel{
-	icon_state = "dark"
-	},
+/turf/open/floor/plasteel/dark/side,
 /area/ruin/space/has_grav/abandonedzoo)
 "bA" = (
 /obj/structure/table/reinforced,
 /obj/machinery/reagentgrinder,
-/turf/open/floor/plasteel{
-	icon_state = "dark"
-	},
+/turf/open/floor/plasteel/dark/side,
 /area/ruin/space/has_grav/abandonedzoo)
 "bB" = (
 /obj/structure/alien/weeds,

--- a/_maps/RandomRuins/SpaceRuins/crashedship.dmm
+++ b/_maps/RandomRuins/SpaceRuins/crashedship.dmm
@@ -342,7 +342,7 @@
 /turf/open/floor/plating/airless,
 /area/awaymission/BMPship/Fore)
 "bu" = (
-/turf/open/floor/plasteel{
+/turf/open/floor/wood{
 	icon_state = "wood-broken"
 	},
 /area/awaymission/BMPship/Fore)

--- a/_maps/RandomRuins/SpaceRuins/derelict6.dmm
+++ b/_maps/RandomRuins/SpaceRuins/derelict6.dmm
@@ -69,10 +69,8 @@
 /turf/open/floor/plating/airless,
 /area/ruin/unpowered)
 "an" = (
-/obj/machinery/light{
-	dir = 8;
-	icon_state = "tube-broken";
-	status = 2
+/obj/machinery/light/broken{
+	dir = 8
 	},
 /turf/open/floor/plasteel/airless,
 /area/ruin/unpowered)
@@ -154,10 +152,7 @@
 	},
 /area/ruin/unpowered)
 "aC" = (
-/obj/machinery/light{
-	icon_state = "tube-broken";
-	status = 2
-	},
+/obj/machinery/light/broken,
 /turf/open/floor/plasteel/airless,
 /area/ruin/unpowered)
 "aD" = (
@@ -212,10 +207,8 @@
 /area/ruin/unpowered)
 "aK" = (
 /obj/structure/closet/secure_closet/freezer/fridge,
-/obj/machinery/light{
-	dir = 1;
-	icon_state = "tube-broken";
-	status = 2
+/obj/machinery/light/broken{
+	dir = 1
 	},
 /turf/open/floor/plasteel/airless/cafeteria,
 /area/ruin/unpowered)
@@ -247,10 +240,8 @@
 /turf/open/floor/plasteel/airless,
 /area/ruin/unpowered)
 "aP" = (
-/obj/machinery/light{
-	dir = 1;
-	icon_state = "tube-broken";
-	status = 2
+/obj/machinery/light/broken{
+	dir = 1
 	},
 /turf/open/floor/plating/airless{
 	icon_state = "platingdmg3"
@@ -344,10 +335,8 @@
 	},
 /area/ruin/unpowered)
 "bh" = (
-/obj/machinery/light{
-	dir = 8;
-	icon_state = "tube-broken";
-	status = 2
+/obj/machinery/light/broken{
+	dir = 8
 	},
 /obj/structure/table_frame,
 /turf/open/floor/plasteel/airless/cafeteria,
@@ -467,7 +456,6 @@
 "bC" = (
 /obj/structure/lattice,
 /obj/structure/fluff/broken_flooring{
-	icon_state = "corner";
 	dir = 1
 	},
 /turf/template_noop,
@@ -482,7 +470,6 @@
 "bE" = (
 /obj/structure/lattice,
 /obj/structure/fluff/broken_flooring{
-	icon_state = "corner";
 	dir = 8
 	},
 /turf/template_noop,

--- a/_maps/RandomRuins/SpaceRuins/spacehotel.dmm
+++ b/_maps/RandomRuins/SpaceRuins/spacehotel.dmm
@@ -125,7 +125,6 @@
 /area/ruin/space/has_grav/hotel/guestroom/room_3)
 "ay" = (
 /obj/structure/window{
-	icon_state = "window";
 	dir = 8
 	},
 /obj/structure/toilet,
@@ -166,7 +165,6 @@
 /area/ruin/space/has_grav/hotel/guestroom/room_4)
 "aG" = (
 /obj/structure/window{
-	icon_state = "window";
 	dir = 8
 	},
 /obj/structure/toilet,
@@ -207,7 +205,6 @@
 /area/ruin/space/has_grav/hotel/guestroom/room_5)
 "aO" = (
 /obj/structure/window{
-	icon_state = "window";
 	dir = 8
 	},
 /obj/structure/toilet,
@@ -248,7 +245,6 @@
 /area/ruin/space/has_grav/hotel/guestroom/room_6)
 "aW" = (
 /obj/structure/window{
-	icon_state = "window";
 	dir = 8
 	},
 /obj/structure/toilet,
@@ -287,7 +283,6 @@
 /area/ruin/unpowered/no_grav)
 "be" = (
 /obj/structure/window{
-	icon_state = "window";
 	dir = 8
 	},
 /turf/open/floor/plasteel/showroomfloor,
@@ -319,7 +314,6 @@
 /area/ruin/space/has_grav/hotel/guestroom/room_3)
 "bk" = (
 /obj/structure/window{
-	icon_state = "window";
 	dir = 8
 	},
 /turf/open/floor/plasteel/showroomfloor,
@@ -351,7 +345,6 @@
 /area/ruin/space/has_grav/hotel/guestroom/room_4)
 "bq" = (
 /obj/structure/window{
-	icon_state = "window";
 	dir = 8
 	},
 /turf/open/floor/plasteel/showroomfloor,
@@ -383,7 +376,6 @@
 /area/ruin/space/has_grav/hotel/guestroom/room_5)
 "bw" = (
 /obj/structure/window{
-	icon_state = "window";
 	dir = 8
 	},
 /turf/open/floor/plasteel/showroomfloor,
@@ -1059,7 +1051,6 @@
 /area/ruin/space/has_grav/hotel/guestroom/room_2)
 "dl" = (
 /obj/structure/window{
-	icon_state = "window";
 	dir = 8
 	},
 /obj/structure/toilet,
@@ -1121,7 +1112,6 @@
 /area/ruin/space/has_grav/hotel/guestroom/room_1)
 "dt" = (
 /obj/structure/window{
-	icon_state = "window";
 	dir = 8
 	},
 /obj/structure/toilet,
@@ -1218,7 +1208,6 @@
 /area/ruin/space/has_grav/hotel/guestroom/room_2)
 "dI" = (
 /obj/structure/window{
-	icon_state = "window";
 	dir = 8
 	},
 /turf/open/floor/plasteel/showroomfloor,
@@ -1250,7 +1239,6 @@
 /area/ruin/space/has_grav/hotel/guestroom/room_1)
 "dP" = (
 /obj/structure/window{
-	icon_state = "window";
 	dir = 8
 	},
 /turf/open/floor/plasteel/showroomfloor,
@@ -4269,7 +4257,6 @@
 /area/ruin/space/has_grav/hotel/security)
 "lG" = (
 /obj/structure/window{
-	icon_state = "window";
 	dir = 1
 	},
 /obj/machinery/light{
@@ -4293,7 +4280,6 @@
 /obj/item/clothing/shoes/sandal,
 /obj/item/clothing/shoes/sandal,
 /obj/structure/window{
-	icon_state = "window";
 	dir = 1
 	},
 /turf/open/floor/plasteel/showroomfloor,

--- a/_maps/RandomZLevels/Cabin.dmm
+++ b/_maps/RandomZLevels/Cabin.dmm
@@ -205,7 +205,6 @@
 /area/awaymission/cabin)
 "aJ" = (
 /obj/machinery/shower{
-	icon_state = "shower";
 	dir = 8
 	},
 /obj/machinery/door/window/northright,
@@ -213,7 +212,6 @@
 /area/awaymission/cabin)
 "aK" = (
 /obj/machinery/shower{
-	icon_state = "shower";
 	dir = 4
 	},
 /obj/machinery/door/window/northleft,
@@ -466,12 +464,10 @@
 /area/awaymission/cabin)
 "bI" = (
 /obj/machinery/shower{
-	icon_state = "shower";
 	dir = 4
 	},
 /obj/machinery/door/window/eastright,
 /obj/structure/window{
-	icon_state = "window";
 	dir = 1
 	},
 /turf/open/floor/plasteel/freezer,

--- a/_maps/RandomZLevels/VR/snowdin_VR.dmm
+++ b/_maps/RandomZLevels/VR/snowdin_VR.dmm
@@ -2405,7 +2405,6 @@
 /area/awaymission/snowdin/post/dorm)
 "fw" = (
 /obj/machinery/sleeper{
-	icon_state = "sleeper";
 	dir = 4
 	},
 /obj/effect/turf_decal/tile/blue{
@@ -6230,9 +6229,7 @@
 /obj/effect/turf_decal/tile/yellow{
 	dir = 8
 	},
-/turf/open/floor/plasteel{
-	icon_state = "yellow"
-	},
+/turf/open/floor/plasteel,
 /area/awaymission/snowdin/post/engineering)
 "np" = (
 /obj/structure/cable/yellow{
@@ -6476,9 +6473,7 @@
 /obj/effect/turf_decal/tile/yellow{
 	dir = 8
 	},
-/turf/open/floor/plasteel{
-	icon_state = "yellow"
-	},
+/turf/open/floor/plasteel,
 /area/awaymission/snowdin/post/engineering)
 "nR" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
@@ -7106,9 +7101,7 @@
 /obj/effect/turf_decal/tile/red{
 	dir = 8
 	},
-/turf/open/floor/plasteel{
-	icon_state = "redcorner"
-	},
+/turf/open/floor/plasteel,
 /area/awaymission/snowdin/post/secpost)
 "pn" = (
 /turf/open/floor/plating,
@@ -7742,9 +7735,7 @@
 /obj/effect/turf_decal/tile/yellow{
 	dir = 8
 	},
-/turf/open/floor/plasteel{
-	icon_state = "yellow"
-	},
+/turf/open/floor/plasteel,
 /area/awaymission/snowdin/post/engineering)
 "qS" = (
 /obj/machinery/button/door{
@@ -9892,9 +9883,8 @@
 /turf/open/floor/plating/asteroid/snow,
 /area/awaymission/snowdin/cave)
 "wy" = (
-/obj/structure/bonfire{
-	burning = 1;
-	icon_state = "bonfire_warm"
+/obj/structure/bonfire/prelit{
+	burn_icon = "bonfire_warm"
 	},
 /obj/effect/light_emitter{
 	light_color = "#FAA019";
@@ -11532,9 +11522,8 @@
 /turf/open/floor/plating/snowed/smoothed,
 /area/awaymission/snowdin/post/minipost)
 "AI" = (
-/obj/structure/bonfire{
-	burning = 1;
-	icon_state = "bonfire_warm"
+/obj/structure/bonfire/prelit{
+	burn_icon = "bonfire_warm"
 	},
 /obj/effect/light_emitter{
 	light_color = "#FAA019";
@@ -14474,7 +14463,6 @@
 /area/awaymission/snowdin/post/mining_main/mechbay)
 "In" = (
 /obj/mecha/working/ripley/mining{
-	icon_state = "ripley";
 	dir = 1
 	},
 /obj/effect/turf_decal/bot,

--- a/_maps/RandomZLevels/beach.dmm
+++ b/_maps/RandomZLevels/beach.dmm
@@ -112,7 +112,6 @@
 /area/awaymission/beach)
 "av" = (
 /obj/machinery/shower{
-	icon_state = "shower";
 	dir = 1
 	},
 /obj/effect/decal/cleanable/dirt,
@@ -124,7 +123,6 @@
 /area/awaymission/beach)
 "ax" = (
 /obj/machinery/shower{
-	icon_state = "shower";
 	dir = 1
 	},
 /turf/open/floor/plasteel/white,

--- a/_maps/RandomZLevels/caves.dmm
+++ b/_maps/RandomZLevels/caves.dmm
@@ -1394,7 +1394,6 @@
 /area/awaymission/caves/BMP_asteroid)
 "ek" = (
 /obj/structure/window{
-	icon_state = "window";
 	dir = 8
 	},
 /mob/living/simple_animal/hostile/mining_drone,
@@ -1440,7 +1439,6 @@
 /area/awaymission/caves/BMP_asteroid)
 "es" = (
 /obj/structure/window{
-	icon_state = "window";
 	dir = 8
 	},
 /obj/structure/window,

--- a/_maps/RandomZLevels/challenge.dmm
+++ b/_maps/RandomZLevels/challenge.dmm
@@ -36,8 +36,7 @@
 /area/awaymission/challenge/start)
 "ai" = (
 /obj/item/flashlight{
-	icon_state = "flashlight-on";
-	on = 1
+	icon_state = "flashlight-on"
 	},
 /turf/open/floor/plasteel/airless,
 /area/awaymission/challenge/start)

--- a/_maps/RandomZLevels/moonoutpost19.dmm
+++ b/_maps/RandomZLevels/moonoutpost19.dmm
@@ -18,11 +18,8 @@
 /area/awaymission/moonoutpost19/hive)
 "ag" = (
 /obj/structure/alien/weeds,
-/obj/structure/alien/weeds{
-	desc = "A large mottled egg.";
-	obj_integrity = 100;
-	icon_state = "egg_hatched";
-	name = "egg"
+/obj/structure/alien/egg/burst{
+	desc = "A large mottled egg."
 	},
 /turf/open/floor/plating/asteroid{
 	initial_gas_mix = "co2=48.7;n2=13.2;o2=32.4;TEMP=251";
@@ -241,11 +238,8 @@
 /area/awaymission/moonoutpost19/syndicate)
 "aJ" = (
 /obj/structure/alien/weeds,
-/obj/structure/alien/weeds{
-	desc = "A large mottled egg.";
-	obj_integrity = 100;
-	icon_state = "egg_hatched";
-	name = "egg"
+/obj/structure/alien/egg/burst{
+	desc = "A large mottled egg."
 	},
 /obj/effect/decal/cleanable/blood/gibs,
 /turf/open/floor/plating/asteroid{
@@ -255,11 +249,8 @@
 /area/awaymission/moonoutpost19/hive)
 "aK" = (
 /obj/structure/alien/weeds,
-/obj/structure/alien/weeds{
-	desc = "A large mottled egg.";
-	obj_integrity = 100;
-	icon_state = "egg_hatched";
-	name = "egg"
+/obj/structure/alien/egg/burst{
+	desc = "A large mottled egg."
 	},
 /obj/effect/decal/cleanable/blood,
 /turf/open/floor/plating/asteroid{
@@ -1084,11 +1075,8 @@
 	},
 /area/awaymission/moonoutpost19/syndicate)
 "ch" = (
-/obj/machinery/light/small{
-	active_power_usage = 0;
-	dir = 4;
-	icon_state = "bulb-broken";
-	status = 2
+/obj/machinery/light/small/broken{
+	dir = 4
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/tile/red,
@@ -1529,11 +1517,8 @@
 	req_access = null;
 	req_access_txt = "150"
 	},
-/obj/machinery/light{
-	active_power_usage = 0;
-	dir = 4;
-	icon_state = "tube-broken";
-	status = 2
+/obj/machinery/light/broken{
+	dir = 4
 	},
 /obj/effect/turf_decal/tile/red,
 /obj/effect/turf_decal/tile/red{
@@ -1813,11 +1798,7 @@
 	},
 /area/awaymission/moonoutpost19/syndicate)
 "dr" = (
-/obj/structure/closet/secure_closet{
-	desc = "It's a secure locker for personnel. The first card swiped gains control.";
-	icon_state = "cabinet";
-	locked = 1;
-	name = "personal closet";
+/obj/structure/closet/secure_closet/personal/cabinet{
 	req_access_txt = "150"
 	},
 /obj/item/ammo_box/magazine/m10mm{
@@ -1841,11 +1822,8 @@
 	},
 /area/awaymission/moonoutpost19/syndicate)
 "dt" = (
-/obj/structure/closet/secure_closet{
-	desc = "It's a secure locker for personnel. The first card swiped gains control.";
-	icon_state = "cabinet";
+/obj/structure/closet/secure_closet/personal/cabinet{
 	locked = 0;
-	name = "personal closet";
 	req_access_txt = "150"
 	},
 /obj/item/stack/spacecash/c50,
@@ -1883,11 +1861,8 @@
 /obj/structure/tank_dispenser/oxygen{
 	oxygentanks = 9
 	},
-/obj/machinery/light/small{
-	active_power_usage = 0;
-	dir = 1;
-	icon_state = "bulb-broken";
-	status = 2
+/obj/machinery/light/small/broken{
+	dir = 1
 	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 9
@@ -2005,8 +1980,7 @@
 /area/awaymission/moonoutpost19/main)
 "dH" = (
 /obj/item/flashlight/lantern{
-	icon_state = "lantern-on";
-	on = 1
+	icon_state = "lantern-on"
 	},
 /obj/effect/decal/cleanable/blood/splatter,
 /turf/open/floor/plating/asteroid{
@@ -2258,18 +2232,12 @@
 /turf/open/floor/engine,
 /area/awaymission/moonoutpost19/research)
 "eo" = (
-/obj/machinery/light{
-	active_power_usage = 0;
-	dir = 1;
-	icon_state = "tube-broken";
-	status = 2
+/obj/machinery/light/broken{
+	dir = 1
 	},
 /obj/structure/alien/weeds,
-/obj/structure/alien/weeds{
-	desc = "A large mottled egg.";
-	obj_integrity = 100;
-	icon_state = "egg_hatched";
-	name = "egg"
+/obj/structure/alien/egg/burst{
+	desc = "A large mottled egg."
 	},
 /obj/machinery/camera{
 	c_tag = "Xenobiology Containment North";
@@ -2310,11 +2278,8 @@
 	},
 /area/awaymission/moonoutpost19/research)
 "ev" = (
-/obj/machinery/light/small{
-	active_power_usage = 0;
-	dir = 4;
-	icon_state = "bulb-broken";
-	status = 2
+/obj/machinery/light/small/broken{
+	dir = 4
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel{
@@ -2377,11 +2342,8 @@
 /area/awaymission/moonoutpost19/research)
 "eH" = (
 /obj/structure/alien/weeds,
-/obj/structure/alien/weeds{
-	desc = "A large mottled egg.";
-	obj_integrity = 100;
-	icon_state = "egg_hatched";
-	name = "egg"
+/obj/structure/alien/egg/burst{
+	desc = "A large mottled egg."
 	},
 /turf/open/floor/engine,
 /area/awaymission/moonoutpost19/research)
@@ -2405,11 +2367,8 @@
 	},
 /area/awaymission/moonoutpost19/research)
 "eM" = (
-/obj/machinery/light/small{
-	active_power_usage = 0;
-	dir = 8;
-	icon_state = "bulb-broken";
-	status = 2
+/obj/machinery/light/small/broken{
+	dir = 8
 	},
 /obj/machinery/camera{
 	c_tag = "Xenobiology";
@@ -2631,11 +2590,8 @@
 "fg" = (
 /obj/structure/table,
 /obj/item/stack/sheet/mineral/plasma,
-/obj/machinery/light/small{
-	active_power_usage = 0;
-	dir = 1;
-	icon_state = "bulb-broken";
-	status = 2
+/obj/machinery/light/small/broken{
+	dir = 1
 	},
 /obj/machinery/airalarm/unlocked{
 	pixel_y = 23;
@@ -2946,11 +2902,8 @@
 /turf/open/floor/engine,
 /area/awaymission/moonoutpost19/research)
 "fK" = (
-/obj/machinery/light{
-	active_power_usage = 0;
-	dir = 4;
-	icon_state = "tube-broken";
-	status = 2
+/obj/machinery/light/broken{
+	dir = 4
 	},
 /obj/structure/alien/weeds,
 /obj/machinery/camera{
@@ -3481,22 +3434,16 @@
 "gI" = (
 /obj/structure/table,
 /obj/item/surgical_drapes,
-/obj/machinery/light/small{
-	active_power_usage = 0;
-	dir = 4;
-	icon_state = "bulb-broken";
-	status = 2
+/obj/machinery/light/small/broken{
+	dir = 4
 	},
 /obj/structure/alien/weeds,
 /turf/open/floor/plasteel/white,
 /area/awaymission/moonoutpost19/research)
 "gJ" = (
 /obj/structure/filingcabinet/filingcabinet,
-/obj/machinery/light/small{
-	active_power_usage = 0;
-	dir = 8;
-	icon_state = "bulb-broken";
-	status = 2
+/obj/machinery/light/small/broken{
+	dir = 8
 	},
 /obj/item/paper/fluff/awaymissions/moonoutpost19/research/larva_social,
 /obj/item/paper/fluff/awaymissions/moonoutpost19/research/xeno_queen,
@@ -3608,11 +3555,8 @@
 	},
 /area/awaymission/moonoutpost19/research)
 "gS" = (
-/obj/machinery/light{
-	active_power_usage = 0;
-	dir = 4;
-	icon_state = "tube-broken";
-	status = 2
+/obj/machinery/light/broken{
+	dir = 4
 	},
 /obj/machinery/airalarm/unlocked{
 	dir = 8;
@@ -3703,11 +3647,8 @@
 /turf/open/floor/engine,
 /area/awaymission/moonoutpost19/research)
 "hb" = (
-/obj/machinery/light{
-	active_power_usage = 0;
-	dir = 2;
-	icon_state = "tube-broken";
-	status = 2
+/obj/machinery/light/broken{
+	dir = 2
 	},
 /obj/structure/alien/weeds,
 /obj/machinery/camera{
@@ -3828,11 +3769,8 @@
 /obj/item/clothing/gloves/color/latex,
 /obj/item/trash/chips,
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/light/small{
-	active_power_usage = 0;
-	dir = 1;
-	icon_state = "bulb-broken";
-	status = 2
+/obj/machinery/light/small/broken{
+	dir = 1
 	},
 /turf/open/floor/plasteel/white/side{
 	dir = 2;
@@ -3887,11 +3825,8 @@
 /area/awaymission/moonoutpost19/research)
 "hs" = (
 /obj/structure/filingcabinet/chestdrawer,
-/obj/machinery/light/small{
-	active_power_usage = 0;
-	dir = 1;
-	icon_state = "bulb-broken";
-	status = 2
+/obj/machinery/light/small/broken{
+	dir = 1
 	},
 /obj/machinery/airalarm/unlocked{
 	pixel_y = 23;
@@ -4018,11 +3953,8 @@
 	dir = 1;
 	pixel_y = -32
 	},
-/obj/machinery/light/small{
-	active_power_usage = 0;
-	dir = 2;
-	icon_state = "bulb-broken";
-	status = 2
+/obj/machinery/light/small/broken{
+	dir = 2
 	},
 /obj/item/paper/fluff/awaymissions/moonoutpost19/research/evacuation,
 /obj/machinery/camera{
@@ -4294,11 +4226,8 @@
 /area/awaymission/moonoutpost19/research)
 "ig" = (
 /obj/structure/closet/l3closet,
-/obj/machinery/light/small{
-	active_power_usage = 0;
-	dir = 2;
-	icon_state = "bulb-broken";
-	status = 2
+/obj/machinery/light/small/broken{
+	dir = 2
 	},
 /turf/open/floor/plasteel/white/side{
 	dir = 1;
@@ -4446,7 +4375,6 @@
 	},
 /obj/machinery/shower{
 	dir = 4;
-	icon_state = "shower";
 	name = "emergency shower"
 	},
 /obj/effect/turf_decal/stripes/line{
@@ -4572,11 +4500,8 @@
 /obj/machinery/computer/security/telescreen/entertainment{
 	pixel_y = -32
 	},
-/obj/machinery/light/small{
-	active_power_usage = 0;
-	dir = 2;
-	icon_state = "bulb-broken";
-	status = 2
+/obj/machinery/light/small/broken{
+	dir = 2
 	},
 /obj/machinery/camera{
 	c_tag = "Research Director's Office";
@@ -5704,11 +5629,8 @@
 	},
 /area/awaymission/moonoutpost19/arrivals)
 "kU" = (
-/obj/structure/closet/secure_closet{
-	desc = "It's a secure locker for personnel. The first card swiped gains control.";
-	icon_state = "cabinet";
+/obj/structure/closet/secure_closet/personal/cabinet{
 	locked = 0;
-	name = "personal closet";
 	req_access_txt = "201"
 	},
 /obj/item/clothing/under/suit_jacket/navy,
@@ -6230,7 +6152,6 @@
 /obj/machinery/portable_atmospherics/canister/air,
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/window{
-	icon_state = "window";
 	dir = 1
 	},
 /turf/open/floor/plating{
@@ -6645,11 +6566,8 @@
 	},
 /area/awaymission/moonoutpost19/arrivals)
 "nb" = (
-/obj/structure/closet/secure_closet{
-	desc = "It's a secure locker for personnel. The first card swiped gains control.";
-	icon_state = "cabinet";
+/obj/structure/closet/secure_closet/personal/cabinet{
 	locked = 0;
-	name = "personal closet";
 	req_access_txt = "201"
 	},
 /obj/item/clothing/under/assistantformal,
@@ -7058,11 +6976,8 @@
 	},
 /area/awaymission/moonoutpost19/arrivals)
 "nT" = (
-/obj/structure/closet/secure_closet{
-	desc = "It's a secure locker for personnel. The first card swiped gains control.";
-	icon_state = "cabinet";
+/obj/structure/closet/secure_closet/personal/cabinet{
 	locked = 0;
-	name = "personal closet";
 	req_access_txt = "201"
 	},
 /obj/item/clothing/under/suit_jacket/burgundy,

--- a/_maps/RandomZLevels/research.dmm
+++ b/_maps/RandomZLevels/research.dmm
@@ -4030,7 +4030,7 @@
 	read_only = 1
 	},
 /obj/item/disk/data{
-	desc = "A specialized data disk for holding critical genetic backup data. Without proper passwords, information will turn up blank on most DNA machines. This one has the initials 'C.P' marked on the front. ";
+	desc = "A specialized data disk for holding critical genetic backup data. Without proper passwords, information will turn up blank on most DNA machines. This one has the initials 'C.P' marked on the front.";
 	name = "encrypted genetic data disk";
 	read_only = 1
 	},
@@ -4549,7 +4549,6 @@
 /area/awaymission/research/interior/bathroom)
 "iN" = (
 /obj/machinery/shower{
-	icon_state = "shower";
 	dir = 8
 	},
 /turf/open/floor/plasteel/freezer,

--- a/_maps/RandomZLevels/snowdin.dmm
+++ b/_maps/RandomZLevels/snowdin.dmm
@@ -2405,7 +2405,6 @@
 /area/awaymission/snowdin/post/dorm)
 "fw" = (
 /obj/machinery/sleeper{
-	icon_state = "sleeper";
 	dir = 4
 	},
 /obj/effect/turf_decal/tile/blue{
@@ -6275,9 +6274,7 @@
 /obj/effect/turf_decal/tile/yellow{
 	dir = 8
 	},
-/turf/open/floor/plasteel{
-	icon_state = "yellow"
-	},
+/turf/open/floor/plasteel,
 /area/awaymission/snowdin/post/engineering)
 "np" = (
 /obj/structure/cable/yellow{
@@ -6521,9 +6518,7 @@
 /obj/effect/turf_decal/tile/yellow{
 	dir = 8
 	},
-/turf/open/floor/plasteel{
-	icon_state = "yellow"
-	},
+/turf/open/floor/plasteel,
 /area/awaymission/snowdin/post/engineering)
 "nR" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
@@ -7151,9 +7146,7 @@
 /obj/effect/turf_decal/tile/red{
 	dir = 8
 	},
-/turf/open/floor/plasteel{
-	icon_state = "redcorner"
-	},
+/turf/open/floor/plasteel,
 /area/awaymission/snowdin/post/secpost)
 "pn" = (
 /turf/open/floor/plating,
@@ -7792,9 +7785,7 @@
 /obj/effect/turf_decal/tile/yellow{
 	dir = 8
 	},
-/turf/open/floor/plasteel{
-	icon_state = "yellow"
-	},
+/turf/open/floor/plasteel,
 /area/awaymission/snowdin/post/engineering)
 "qS" = (
 /obj/machinery/button/door{
@@ -9956,9 +9947,8 @@
 /turf/open/floor/plating/asteroid/snow,
 /area/awaymission/snowdin/cave)
 "wy" = (
-/obj/structure/bonfire{
-	burning = 1;
-	icon_state = "bonfire_warm"
+/obj/structure/bonfire/prelit{
+	burn_icon = "bonfire_warm"
 	},
 /obj/effect/light_emitter{
 	light_color = "#FAA019";
@@ -11600,9 +11590,8 @@
 /turf/open/floor/plating/snowed/smoothed,
 /area/awaymission/snowdin/post/minipost)
 "AI" = (
-/obj/structure/bonfire{
-	burning = 1;
-	icon_state = "bonfire_warm"
+/obj/structure/bonfire/prelit{
+	burn_icon = "bonfire_warm"
 	},
 /obj/effect/light_emitter{
 	light_color = "#FAA019";
@@ -12902,7 +12891,6 @@
 /area/awaymission/snowdin/cave)
 "DU" = (
 /obj/structure/shuttle/engine/heater{
-	icon_state = "heater";
 	dir = 4
 	},
 /obj/effect/turf_decal/stripes/line{
@@ -14580,7 +14568,6 @@
 /area/awaymission/snowdin/post/mining_main/mechbay)
 "In" = (
 /obj/mecha/working/ripley/mining{
-	icon_state = "ripley";
 	dir = 1
 	},
 /obj/effect/turf_decal/bot,

--- a/_maps/RandomZLevels/spacebattle.dmm
+++ b/_maps/RandomZLevels/spacebattle.dmm
@@ -856,7 +856,6 @@
 /area/awaymission/spacebattle/cruiser)
 "dN" = (
 /obj/machinery/mech_bay_recharge_port{
-	icon_state = "recharge_port";
 	dir = 2
 	},
 /turf/open/floor/mineral/plastitanium/red,
@@ -2169,7 +2168,6 @@
 /area/awaymission/spacebattle/syndicate7)
 "hV" = (
 /obj/machinery/shower{
-	icon_state = "shower";
 	dir = 4
 	},
 /obj/item/bikehorn/rubberducky,
@@ -2180,7 +2178,6 @@
 /area/awaymission/spacebattle/cruiser)
 "hX" = (
 /obj/machinery/shower{
-	icon_state = "shower";
 	dir = 8
 	},
 /turf/open/floor/plasteel/freezer,
@@ -2209,14 +2206,12 @@
 /area/awaymission/spacebattle/cruiser)
 "if" = (
 /obj/machinery/shower{
-	icon_state = "shower";
 	dir = 4
 	},
 /turf/open/floor/plasteel/freezer,
 /area/awaymission/spacebattle/cruiser)
 "ig" = (
 /obj/machinery/shower{
-	icon_state = "shower";
 	dir = 8
 	},
 /obj/item/soap,
@@ -2790,7 +2785,6 @@
 /area/awaymission/spacebattle/cruiser)
 "ks" = (
 /obj/machinery/mech_bay_recharge_port{
-	icon_state = "recharge_port";
 	dir = 2
 	},
 /turf/open/floor/plating,
@@ -2868,7 +2862,6 @@
 /area/awaymission/spacebattle/cruiser)
 "kH" = (
 /obj/machinery/mech_bay_recharge_port{
-	icon_state = "recharge_port";
 	dir = 1
 	},
 /turf/open/floor/plating,

--- a/_maps/RandomZLevels/undergroundoutpost45.dmm
+++ b/_maps/RandomZLevels/undergroundoutpost45.dmm
@@ -34,11 +34,8 @@
 	},
 /area/awaymission/undergroundoutpost45/central)
 "ak" = (
-/obj/machinery/light/small{
-	active_power_usage = 0;
-	dir = 8;
-	icon_state = "bulb-broken";
-	status = 2
+/obj/machinery/light/small/broken{
+	dir = 8
 	},
 /turf/open/floor/plating{
 	heat_capacity = 1e+006;
@@ -66,11 +63,8 @@
 	},
 /area/awaymission/undergroundoutpost45/central)
 "ap" = (
-/obj/machinery/light/small{
-	active_power_usage = 0;
-	dir = 4;
-	icon_state = "bulb-broken";
-	status = 2
+/obj/machinery/light/small/broken{
+	dir = 4
 	},
 /turf/open/floor/plasteel{
 	dir = 8;
@@ -302,11 +296,8 @@
 /area/awaymission/undergroundoutpost45/central)
 "aU" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/structure/closet/secure_closet{
-	desc = "It's a secure locker for personnel. The first card swiped gains control.";
-	icon_state = "cabinet";
+/obj/structure/closet/secure_closet/personal/cabinet{
 	locked = 0;
-	name = "personal closet";
 	req_access_txt = "201"
 	},
 /obj/item/clothing/under/pj/blue,
@@ -352,11 +343,8 @@
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
 	dir = 8
 	},
-/obj/structure/closet/secure_closet{
-	desc = "It's a secure locker for personnel. The first card swiped gains control.";
-	icon_state = "cabinet";
+/obj/structure/closet/secure_closet/personal/cabinet{
 	locked = 0;
-	name = "personal closet";
 	req_access_txt = "201"
 	},
 /obj/item/clothing/under/suit_jacket/female,
@@ -1257,7 +1245,6 @@
 	},
 /obj/machinery/portable_atmospherics/scrubber,
 /obj/structure/window{
-	icon_state = "window";
 	dir = 8
 	},
 /turf/open/floor/plating{
@@ -1279,7 +1266,6 @@
 	},
 /obj/structure/reagent_dispensers/fueltank,
 /obj/structure/window{
-	icon_state = "window";
 	dir = 4
 	},
 /turf/open/floor/plating{
@@ -2133,11 +2119,8 @@
 /area/awaymission/undergroundoutpost45/caves)
 "ev" = (
 /obj/item/clothing/under/pj/red,
-/obj/structure/closet/secure_closet{
-	desc = "It's a secure locker for personnel. The first card swiped gains control.";
-	icon_state = "cabinet";
+/obj/structure/closet/secure_closet/personal/cabinet{
 	locked = 0;
-	name = "personal closet";
 	req_access_txt = "201"
 	},
 /turf/open/floor/carpet{
@@ -5261,11 +5244,8 @@
 /area/awaymission/undergroundoutpost45/gateway)
 "km" = (
 /obj/item/clothing/under/suit_jacket/navy,
-/obj/structure/closet/secure_closet{
-	desc = "It's a secure locker for personnel. The first card swiped gains control.";
-	icon_state = "cabinet";
+/obj/structure/closet/secure_closet/personal/cabinet{
 	locked = 0;
-	name = "personal closet";
 	req_access_txt = "201"
 	},
 /turf/open/floor/carpet{
@@ -6469,7 +6449,6 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/machinery/portable_atmospherics/scrubber,
 /obj/structure/window{
-	icon_state = "window";
 	dir = 4
 	},
 /obj/effect/decal/cleanable/dirt,
@@ -6653,10 +6632,8 @@
 /obj/item/clothing/suit/hazardvest,
 /obj/item/clothing/mask/gas,
 /obj/item/clothing/glasses/meson,
-/obj/structure/closet/secure_closet{
-	icon_state = "eng_secure";
+/obj/structure/closet/secure_closet/engineering_personal{
 	locked = 0;
-	name = "engineer's locker";
 	req_access_txt = "201"
 	},
 /obj/effect/turf_decal/tile/yellow{
@@ -9696,11 +9673,8 @@
 	},
 /area/awaymission/undergroundoutpost45/engineering)
 "rs" = (
-/obj/structure/closet/secure_closet{
-	desc = "It's a secure locker for personnel. The first card swiped gains control.";
-	icon_state = "cabinet";
+/obj/structure/closet/secure_closet/personal/cabinet{
 	locked = 0;
-	name = "personal closet";
 	req_access_txt = "201"
 	},
 /obj/item/clothing/under/pj/red,
@@ -10243,11 +10217,8 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 4
 	},
-/obj/structure/closet/secure_closet{
-	desc = "It's a secure locker for personnel. The first card swiped gains control.";
-	icon_state = "cabinet";
+/obj/structure/closet/secure_closet/personal/cabinet{
 	locked = 0;
-	name = "personal closet";
 	req_access_txt = "201"
 	},
 /turf/open/floor/carpet{
@@ -13601,7 +13572,6 @@
 /area/awaymission/undergroundoutpost45/mining)
 "xS" = (
 /obj/machinery/mech_bay_recharge_port{
-	icon_state = "recharge_port";
 	dir = 8
 	},
 /obj/structure/cable{

--- a/_maps/RandomZLevels/wildwest.dmm
+++ b/_maps/RandomZLevels/wildwest.dmm
@@ -312,16 +312,12 @@
 /turf/closed/wall/mineral/sandstone,
 /area/awaymission/wildwest/mines)
 "bv" = (
-/obj/structure/window/reinforced{
-	icon_state = "fwindow"
-	},
+/obj/structure/window/reinforced/tinted/frosted,
 /turf/open/space,
 /area/space/nearstation)
 "bw" = (
 /obj/structure/lattice,
-/obj/structure/window/reinforced{
-	icon_state = "fwindow"
-	},
+/obj/structure/window/reinforced/tinted/frosted,
 /turf/open/space,
 /area/space/nearstation)
 "bx" = (
@@ -420,8 +416,7 @@
 /area/awaymission/wildwest/mines)
 "bO" = (
 /obj/structure/lattice,
-/obj/structure/window/reinforced{
-	icon_state = "fwindow";
+/obj/structure/window/reinforced/tinted/frosted{
 	dir = 4
 	},
 /turf/open/space,
@@ -430,13 +425,10 @@
 /turf/closed/wall/mineral/sandstone,
 /area/awaymission/wildwest/gov)
 "bQ" = (
-/obj/structure/window/reinforced{
-	icon_state = "fwindow";
+/obj/structure/window/reinforced/tinted/frosted{
 	dir = 1
 	},
-/obj/structure/window/reinforced{
-	icon_state = "fwindow"
-	},
+/obj/structure/window/reinforced/tinted/frosted,
 /obj/effect/spawner/structure/window/hollow/reinforced/directional{
 	dir = 8
 	},
@@ -445,29 +437,22 @@
 	},
 /area/awaymission/wildwest/gov)
 "bR" = (
-/obj/structure/window/reinforced{
-	icon_state = "fwindow";
+/obj/structure/window/reinforced/tinted/frosted{
 	dir = 1
 	},
-/obj/structure/window/reinforced{
-	icon_state = "fwindow"
-	},
+/obj/structure/window/reinforced/tinted/frosted,
 /obj/structure/grille,
 /turf/open/floor/plating/ironsand{
 	icon_state = "ironsand1"
 	},
 /area/awaymission/wildwest/gov)
 "bS" = (
-/obj/structure/window/reinforced{
-	icon_state = "fwindow";
+/obj/structure/window/reinforced/tinted/frosted{
 	dir = 1
 	},
-/obj/structure/window/reinforced{
-	icon_state = "fwindow"
-	},
+/obj/structure/window/reinforced/tinted/frosted,
 /obj/structure/grille,
-/obj/structure/window/reinforced{
-	icon_state = "fwindow";
+/obj/structure/window/reinforced/tinted/frosted{
 	dir = 4
 	},
 /turf/open/floor/plating/ironsand{
@@ -475,8 +460,7 @@
 	},
 /area/awaymission/wildwest/gov)
 "bT" = (
-/obj/structure/window/reinforced{
-	icon_state = "fwindow";
+/obj/structure/window/reinforced/tinted/frosted{
 	dir = 8
 	},
 /turf/open/space,
@@ -498,24 +482,20 @@
 	},
 /area/awaymission/wildwest/mines)
 "bW" = (
-/obj/structure/window/reinforced{
-	icon_state = "fwindow";
+/obj/structure/window/reinforced/tinted/frosted{
 	dir = 4
 	},
 /turf/open/space,
 /area/space/nearstation)
 "bX" = (
-/obj/structure/window/reinforced{
-	icon_state = "fwindow";
+/obj/structure/window/reinforced/tinted/frosted{
 	dir = 8
 	},
-/obj/structure/window/reinforced{
-	icon_state = "fwindow";
+/obj/structure/window/reinforced/tinted/frosted{
 	dir = 4
 	},
 /obj/structure/grille,
-/obj/structure/window/reinforced{
-	icon_state = "fwindow";
+/obj/structure/window/reinforced/tinted/frosted{
 	dir = 1
 	},
 /turf/open/floor/plating/ironsand{
@@ -533,12 +513,10 @@
 	},
 /area/awaymission/wildwest/gov)
 "ca" = (
-/obj/structure/window/reinforced{
-	icon_state = "fwindow";
+/obj/structure/window/reinforced/tinted/frosted{
 	dir = 4
 	},
-/obj/structure/window/reinforced{
-	icon_state = "fwindow";
+/obj/structure/window/reinforced/tinted/frosted{
 	dir = 8
 	},
 /obj/effect/spawner/structure/window/hollow/reinforced/directional{
@@ -561,12 +539,10 @@
 	},
 /area/awaymission/wildwest/mines)
 "ce" = (
-/obj/structure/window/reinforced{
-	icon_state = "fwindow";
+/obj/structure/window/reinforced/tinted/frosted{
 	dir = 8
 	},
-/obj/structure/window/reinforced{
-	icon_state = "fwindow";
+/obj/structure/window/reinforced/tinted/frosted{
 	dir = 4
 	},
 /obj/structure/grille,
@@ -575,12 +551,10 @@
 	},
 /area/awaymission/wildwest/gov)
 "cf" = (
-/obj/structure/window/reinforced{
-	icon_state = "fwindow";
+/obj/structure/window/reinforced/tinted/frosted{
 	dir = 4
 	},
-/obj/structure/window/reinforced{
-	icon_state = "fwindow";
+/obj/structure/window/reinforced/tinted/frosted{
 	dir = 8
 	},
 /obj/structure/grille,
@@ -603,9 +577,7 @@
 	},
 /area/awaymission/wildwest/mines)
 "ci" = (
-/obj/structure/mineral_door/wood{
-	icon_state = "wood"
-	},
+/obj/structure/mineral_door/wood,
 /turf/open/floor/wood,
 /area/awaymission/wildwest/mines)
 "cj" = (
@@ -621,8 +593,8 @@
 /turf/open/floor/wood,
 /area/awaymission/wildwest/mines)
 "cm" = (
-/obj/structure/bookcase{
-	icon_state = "book-5"
+/obj/structure/bookcase/random{
+	book_count = 5
 	},
 /turf/open/floor/wood,
 /area/awaymission/wildwest/gov)
@@ -660,8 +632,7 @@
 /area/awaymission/wildwest/gov)
 "ct" = (
 /obj/structure/lattice,
-/obj/structure/window/reinforced{
-	icon_state = "fwindow";
+/obj/structure/window/reinforced/tinted/frosted{
 	dir = 8
 	},
 /turf/open/space,
@@ -738,8 +709,8 @@
 	},
 /area/awaymission/wildwest/gov)
 "cI" = (
-/obj/structure/bookcase{
-	icon_state = "book-5"
+/obj/structure/bookcase/random{
+	book_count = 5
 	},
 /turf/open/floor/wood,
 /area/awaymission/wildwest/mines)
@@ -767,9 +738,7 @@
 /turf/open/floor/wood,
 /area/awaymission/wildwest/gov)
 "cO" = (
-/obj/structure/mineral_door/wood{
-	icon_state = "wood"
-	},
+/obj/structure/mineral_door/wood,
 /turf/open/floor/wood,
 /area/awaymission/wildwest/gov)
 "cP" = (
@@ -777,18 +746,14 @@
 /turf/open/floor/carpet,
 /area/awaymission/wildwest/gov)
 "cQ" = (
-/obj/structure/window/reinforced{
-	icon_state = "fwindow";
+/obj/structure/window/reinforced/tinted/frosted{
 	dir = 8
 	},
-/obj/structure/window/reinforced{
-	icon_state = "fwindow";
+/obj/structure/window/reinforced/tinted/frosted{
 	dir = 4
 	},
 /obj/structure/grille,
-/obj/structure/window/reinforced{
-	icon_state = "fwindow"
-	},
+/obj/structure/window/reinforced/tinted/frosted,
 /turf/open/floor/plating/ironsand{
 	icon_state = "ironsand1"
 	},
@@ -800,18 +765,14 @@
 /turf/open/floor/wood,
 /area/awaymission/wildwest/gov)
 "cS" = (
-/obj/structure/window/reinforced{
-	icon_state = "fwindow";
+/obj/structure/window/reinforced/tinted/frosted{
 	dir = 4
 	},
-/obj/structure/window/reinforced{
-	icon_state = "fwindow";
+/obj/structure/window/reinforced/tinted/frosted{
 	dir = 8
 	},
 /obj/structure/grille,
-/obj/structure/window/reinforced{
-	icon_state = "fwindow"
-	},
+/obj/structure/window/reinforced/tinted/frosted,
 /turf/open/floor/plating/ironsand{
 	icon_state = "ironsand1"
 	},
@@ -871,12 +832,10 @@
 /turf/open/floor/wood,
 /area/awaymission/wildwest/mines)
 "dc" = (
-/obj/structure/window/reinforced{
-	icon_state = "fwindow";
+/obj/structure/window/reinforced/tinted/frosted{
 	dir = 8
 	},
-/obj/structure/window/reinforced{
-	icon_state = "fwindow";
+/obj/structure/window/reinforced/tinted/frosted{
 	dir = 4
 	},
 /obj/effect/spawner/structure/window/hollow/reinforced/directional{
@@ -908,17 +867,14 @@
 	},
 /area/awaymission/wildwest/gov)
 "dg" = (
-/obj/structure/window/reinforced{
-	icon_state = "fwindow";
+/obj/structure/window/reinforced/tinted/frosted{
 	dir = 4
 	},
-/obj/structure/window/reinforced{
-	icon_state = "fwindow";
+/obj/structure/window/reinforced/tinted/frosted{
 	dir = 8
 	},
 /obj/structure/grille,
-/obj/structure/window/reinforced{
-	icon_state = "fwindow";
+/obj/structure/window/reinforced/tinted/frosted{
 	dir = 1
 	},
 /turf/open/floor/plating/ironsand{
@@ -946,17 +902,13 @@
 /turf/open/floor/carpet,
 /area/awaymission/wildwest/mines)
 "dm" = (
-/obj/structure/mineral_door/wood{
-	icon_state = "wood"
-	},
+/obj/structure/mineral_door/wood,
 /turf/open/floor/plating/ironsand{
 	icon_state = "ironsand1"
 	},
 /area/awaymission/wildwest/mines)
 "dn" = (
-/obj/structure/mineral_door/wood{
-	icon_state = "wood"
-	},
+/obj/structure/mineral_door/wood,
 /obj/effect/decal/cleanable/blood/tracks,
 /turf/open/floor/plating/ironsand{
 	icon_state = "ironsand1"
@@ -1048,9 +1000,7 @@
 	},
 /area/awaymission/wildwest/gov)
 "dD" = (
-/obj/structure/mineral_door/wood{
-	icon_state = "wood"
-	},
+/obj/structure/mineral_door/wood,
 /turf/open/floor/plating/ironsand{
 	icon_state = "ironsand1"
 	},
@@ -1121,16 +1071,12 @@
 /turf/closed/wall/mineral/sandstone,
 /area/awaymission/wildwest/mines)
 "dR" = (
-/obj/structure/window/reinforced{
-	icon_state = "fwindow"
-	},
-/obj/structure/window/reinforced{
-	icon_state = "fwindow";
+/obj/structure/window/reinforced/tinted/frosted,
+/obj/structure/window/reinforced/tinted/frosted{
 	dir = 1
 	},
 /obj/structure/grille,
-/obj/structure/window/reinforced{
-	icon_state = "fwindow";
+/obj/structure/window/reinforced/tinted/frosted{
 	dir = 8
 	},
 /turf/open/floor/plating/ironsand{
@@ -1138,11 +1084,8 @@
 	},
 /area/awaymission/wildwest/gov)
 "dS" = (
-/obj/structure/window/reinforced{
-	icon_state = "fwindow"
-	},
-/obj/structure/window/reinforced{
-	icon_state = "fwindow";
+/obj/structure/window/reinforced/tinted/frosted,
+/obj/structure/window/reinforced/tinted/frosted{
 	dir = 1
 	},
 /obj/structure/grille,
@@ -1151,16 +1094,12 @@
 	},
 /area/awaymission/wildwest/gov)
 "dT" = (
-/obj/structure/window/reinforced{
-	icon_state = "fwindow"
-	},
-/obj/structure/window/reinforced{
-	icon_state = "fwindow";
+/obj/structure/window/reinforced/tinted/frosted,
+/obj/structure/window/reinforced/tinted/frosted{
 	dir = 1
 	},
 /obj/structure/grille,
-/obj/structure/window/reinforced{
-	icon_state = "fwindow";
+/obj/structure/window/reinforced/tinted/frosted{
 	dir = 4
 	},
 /turf/open/floor/plating/ironsand{
@@ -1176,7 +1115,6 @@
 /area/awaymission/wildwest/gov)
 "dV" = (
 /obj/machinery/shower{
-	icon_state = "shower";
 	dir = 4
 	},
 /turf/open/floor/plasteel/cafeteria{
@@ -1185,7 +1123,6 @@
 /area/awaymission/wildwest/mines)
 "dW" = (
 /obj/machinery/shower{
-	icon_state = "shower";
 	dir = 8
 	},
 /turf/open/floor/plasteel/cafeteria{
@@ -1225,23 +1162,20 @@
 /turf/open/floor/carpet,
 /area/awaymission/wildwest/mines)
 "ed" = (
-/obj/structure/window/reinforced{
-	icon_state = "fwindow";
+/obj/structure/window/reinforced/tinted/frosted{
 	dir = 1
 	},
 /turf/open/space,
 /area/space/nearstation)
 "ee" = (
 /obj/structure/lattice,
-/obj/structure/window/reinforced{
-	icon_state = "fwindow";
+/obj/structure/window/reinforced/tinted/frosted{
 	dir = 1
 	},
 /turf/open/space,
 /area/space/nearstation)
 "ef" = (
-/obj/structure/window/reinforced{
-	icon_state = "fwindow";
+/obj/structure/window/reinforced/tinted/frosted{
 	dir = 1
 	},
 /obj/structure/window/reinforced{
@@ -1250,8 +1184,7 @@
 /turf/open/space,
 /area/space/nearstation)
 "eg" = (
-/obj/structure/window/reinforced{
-	icon_state = "fwindow";
+/obj/structure/window/reinforced/tinted/frosted{
 	dir = 8
 	},
 /turf/open/floor/plating/ironsand{
@@ -1267,12 +1200,10 @@
 	},
 /area/awaymission/wildwest/gov)
 "ei" = (
-/obj/structure/window/reinforced{
-	icon_state = "fwindow";
+/obj/structure/window/reinforced/tinted/frosted{
 	dir = 1
 	},
-/obj/structure/window/reinforced{
-	icon_state = "fwindow";
+/obj/structure/window/reinforced/tinted/frosted{
 	dir = 8
 	},
 /turf/open/space,
@@ -1311,8 +1242,7 @@
 /turf/open/floor/wood,
 /area/awaymission/wildwest/mines)
 "er" = (
-/obj/structure/window/reinforced{
-	icon_state = "fwindow";
+/obj/structure/window/reinforced/tinted/frosted{
 	dir = 8
 	},
 /turf/open/floor/plating/ironsand{
@@ -1344,8 +1274,7 @@
 /turf/open/floor/carpet,
 /area/awaymission/wildwest/mines)
 "ex" = (
-/obj/structure/window/reinforced{
-	icon_state = "fwindow";
+/obj/structure/window/reinforced/tinted/frosted{
 	dir = 8
 	},
 /turf/open/floor/plating/ironsand{
@@ -1433,8 +1362,7 @@
 /turf/closed/wall/mineral/sandstone,
 /area/awaymission/wildwest/mines)
 "eN" = (
-/obj/structure/window/reinforced{
-	icon_state = "fwindow";
+/obj/structure/window/reinforced/tinted/frosted{
 	dir = 8
 	},
 /turf/open/floor/plating/ironsand{
@@ -1443,12 +1371,10 @@
 /area/awaymission/wildwest/gov)
 "eO" = (
 /obj/structure/window/reinforced,
-/obj/structure/window/reinforced{
-	icon_state = "fwindow";
+/obj/structure/window/reinforced/tinted/frosted{
 	dir = 8
 	},
-/obj/structure/window/reinforced{
-	icon_state = "fwindow";
+/obj/structure/window/reinforced/tinted/frosted{
 	dir = 1
 	},
 /obj/structure/grille,
@@ -1456,36 +1382,28 @@
 /area/awaymission/wildwest/refine)
 "eP" = (
 /obj/structure/window/reinforced,
-/obj/structure/window/reinforced{
-	icon_state = "fwindow";
+/obj/structure/window/reinforced/tinted/frosted{
 	dir = 1
 	},
 /obj/structure/grille,
 /turf/open/floor/plasteel,
 /area/awaymission/wildwest/refine)
 "eQ" = (
-/obj/structure/window/reinforced{
-	icon_state = "fwindow";
+/obj/structure/window/reinforced/tinted/frosted{
 	dir = 1
 	},
-/obj/structure/window/reinforced{
-	icon_state = "fwindow"
-	},
+/obj/structure/window/reinforced/tinted/frosted,
 /obj/structure/grille,
 /turf/open/floor/plasteel,
 /area/awaymission/wildwest/refine)
 "eR" = (
-/obj/structure/window/reinforced{
-	icon_state = "fwindow";
+/obj/structure/window/reinforced/tinted/frosted{
 	dir = 4
 	},
-/obj/structure/window/reinforced{
-	icon_state = "fwindow";
+/obj/structure/window/reinforced/tinted/frosted{
 	dir = 1
 	},
-/obj/structure/window/reinforced{
-	icon_state = "fwindow"
-	},
+/obj/structure/window/reinforced/tinted/frosted,
 /obj/structure/grille,
 /turf/open/floor/plasteel,
 /area/awaymission/wildwest/refine)
@@ -1620,12 +1538,10 @@
 /turf/open/floor/plasteel/cafeteria,
 /area/awaymission/wildwest/mines)
 "fj" = (
-/obj/structure/window/reinforced{
-	icon_state = "fwindow";
+/obj/structure/window/reinforced/tinted/frosted{
 	dir = 4
 	},
-/obj/structure/window/reinforced{
-	icon_state = "fwindow";
+/obj/structure/window/reinforced/tinted/frosted{
 	dir = 1
 	},
 /obj/structure/grille,
@@ -1656,12 +1572,10 @@
 /turf/open/floor/plasteel/cafeteria,
 /area/awaymission/wildwest/mines)
 "fo" = (
-/obj/structure/window/reinforced{
-	icon_state = "fwindow";
+/obj/structure/window/reinforced/tinted/frosted{
 	dir = 8
 	},
-/obj/structure/window/reinforced{
-	icon_state = "fwindow";
+/obj/structure/window/reinforced/tinted/frosted{
 	dir = 4
 	},
 /obj/structure/grille,
@@ -1735,28 +1649,21 @@
 /obj/structure/window/reinforced{
 	dir = 4
 	},
-/obj/structure/window/reinforced{
-	icon_state = "fwindow"
-	},
+/obj/structure/window/reinforced/tinted/frosted,
 /turf/open/space,
 /area/space/nearstation)
 "fz" = (
-/obj/structure/window/reinforced{
-	icon_state = "fwindow";
+/obj/structure/window/reinforced/tinted/frosted{
 	dir = 8
 	},
-/obj/structure/window/reinforced{
-	icon_state = "fwindow"
-	},
+/obj/structure/window/reinforced/tinted/frosted,
 /turf/open/space,
 /area/space/nearstation)
 "fA" = (
-/obj/structure/window/reinforced{
-	icon_state = "fwindow";
+/obj/structure/window/reinforced/tinted/frosted{
 	dir = 8
 	},
-/obj/structure/window/reinforced{
-	icon_state = "fwindow";
+/obj/structure/window/reinforced/tinted/frosted{
 	dir = 4
 	},
 /obj/effect/spawner/structure/window/hollow/reinforced/directional,
@@ -1821,19 +1728,16 @@
 /turf/open/floor/plasteel/cafeteria,
 /area/awaymission/wildwest/mines)
 "fJ" = (
-/obj/structure/window/reinforced{
-	icon_state = "fwindow";
+/obj/structure/window/reinforced/tinted/frosted{
 	dir = 1
 	},
-/obj/structure/window/reinforced{
-	icon_state = "fwindow";
+/obj/structure/window/reinforced/tinted/frosted{
 	dir = 8
 	},
 /turf/open/floor/grass,
 /area/awaymission/wildwest/gov)
 "fK" = (
-/obj/structure/window/reinforced{
-	icon_state = "fwindow";
+/obj/structure/window/reinforced/tinted/frosted{
 	dir = 1
 	},
 /turf/open/floor/grass,
@@ -1845,15 +1749,13 @@
 /obj/structure/window/reinforced{
 	dir = 4
 	},
-/obj/structure/window/reinforced{
-	icon_state = "fwindow";
+/obj/structure/window/reinforced/tinted/frosted{
 	dir = 1
 	},
 /turf/open/floor/grass,
 /area/awaymission/wildwest/gov)
 "fN" = (
-/obj/structure/window/reinforced{
-	icon_state = "fwindow";
+/obj/structure/window/reinforced/tinted/frosted{
 	dir = 8
 	},
 /obj/structure/lattice,
@@ -1899,8 +1801,7 @@
 /turf/open/floor/plasteel/cafeteria,
 /area/awaymission/wildwest/mines)
 "fU" = (
-/obj/structure/window/reinforced{
-	icon_state = "fwindow";
+/obj/structure/window/reinforced/tinted/frosted{
 	dir = 8
 	},
 /turf/open/floor/grass,
@@ -1916,17 +1817,14 @@
 /turf/open/floor/grass,
 /area/awaymission/wildwest/gov)
 "fX" = (
-/obj/structure/window/reinforced{
-	icon_state = "fwindow";
+/obj/structure/window/reinforced/tinted/frosted{
 	dir = 8
 	},
-/obj/structure/window/reinforced{
-	icon_state = "fwindow";
+/obj/structure/window/reinforced/tinted/frosted{
 	dir = 4
 	},
 /obj/structure/grille,
-/obj/structure/window/reinforced{
-	icon_state = "fwindow";
+/obj/structure/window/reinforced/tinted/frosted{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -1941,23 +1839,18 @@
 /turf/open/floor/wood,
 /area/awaymission/wildwest/mines)
 "ga" = (
-/obj/structure/window/reinforced{
-	icon_state = "fwindow"
-	},
+/obj/structure/window/reinforced/tinted/frosted,
 /turf/open/floor/grass,
 /area/awaymission/wildwest/gov)
 "gb" = (
 /obj/structure/window/reinforced{
 	dir = 4
 	},
-/obj/structure/window/reinforced{
-	icon_state = "fwindow"
-	},
+/obj/structure/window/reinforced/tinted/frosted,
 /turf/open/floor/grass,
 /area/awaymission/wildwest/gov)
 "gc" = (
-/obj/structure/window/reinforced{
-	icon_state = "fwindow";
+/obj/structure/window/reinforced/tinted/frosted{
 	dir = 8
 	},
 /turf/open/floor/plasteel/airless,
@@ -2082,24 +1975,20 @@
 /area/awaymission/wildwest/gov)
 "gz" = (
 /obj/structure/window/reinforced,
-/obj/structure/window/reinforced{
-	icon_state = "fwindow";
+/obj/structure/window/reinforced/tinted/frosted{
 	dir = 1
 	},
 /obj/structure/grille,
-/obj/structure/window/reinforced{
-	icon_state = "fwindow";
+/obj/structure/window/reinforced/tinted/frosted{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
 /area/awaymission/wildwest/refine)
 "gA" = (
-/obj/structure/window/reinforced{
-	icon_state = "fwindow";
+/obj/structure/window/reinforced/tinted/frosted{
 	dir = 8
 	},
-/obj/structure/window/reinforced{
-	icon_state = "fwindow";
+/obj/structure/window/reinforced/tinted/frosted{
 	dir = 1
 	},
 /obj/structure/grille,
@@ -2107,33 +1996,28 @@
 /area/awaymission/wildwest/refine)
 "gB" = (
 /obj/structure/window/reinforced,
-/obj/structure/window/reinforced{
-	icon_state = "fwindow";
+/obj/structure/window/reinforced/tinted/frosted{
 	dir = 1
 	},
 /obj/structure/grille,
-/obj/structure/window/reinforced{
-	icon_state = "fwindow";
+/obj/structure/window/reinforced/tinted/frosted{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/awaymission/wildwest/refine)
 "gC" = (
 /obj/structure/window/reinforced,
-/obj/structure/window/reinforced{
-	icon_state = "fwindow";
+/obj/structure/window/reinforced/tinted/frosted{
 	dir = 1
 	},
-/obj/structure/window/reinforced{
-	icon_state = "fwindow";
+/obj/structure/window/reinforced/tinted/frosted{
 	dir = 4
 	},
 /obj/structure/grille,
 /turf/open/floor/plasteel,
 /area/awaymission/wildwest/refine)
 "gD" = (
-/obj/structure/window/reinforced{
-	icon_state = "fwindow";
+/obj/structure/window/reinforced/tinted/frosted{
 	dir = 8
 	},
 /obj/structure/window/reinforced,
@@ -2152,12 +2036,10 @@
 /area/awaymission/wildwest/gov)
 "gG" = (
 /obj/structure/window/reinforced,
-/obj/structure/window/reinforced{
-	icon_state = "fwindow";
+/obj/structure/window/reinforced/tinted/frosted{
 	dir = 4
 	},
-/obj/structure/window/reinforced{
-	icon_state = "fwindow";
+/obj/structure/window/reinforced/tinted/frosted{
 	dir = 8
 	},
 /obj/structure/grille,
@@ -2205,9 +2087,7 @@
 /obj/effect/spawner/structure/window/hollow/reinforced/end{
 	dir = 1
 	},
-/obj/structure/window/reinforced{
-	icon_state = "fwindow"
-	},
+/obj/structure/window/reinforced/tinted/frosted,
 /turf/open/floor/mineral/titanium/yellow,
 /area/awaymission/wildwest/refine)
 "gY" = (

--- a/_maps/map_files/BoxStation/BoxStation.dmm
+++ b/_maps/map_files/BoxStation/BoxStation.dmm
@@ -12467,7 +12467,6 @@
 	icon_state = "1-8"
 	},
 /obj/structure/window{
-	icon_state = "window";
 	dir = 4
 	},
 /obj/structure/window,
@@ -17552,9 +17551,7 @@
 	req_access_txt = "25"
 	},
 /obj/structure/disposalpipe/segment,
-/turf/open/floor/plasteel{
-	icon_state = "wood"
-	},
+/turf/open/floor/wood,
 /area/crew_quarters/bar)
 "aOP" = (
 /obj/effect/landmark/blobstart,
@@ -17762,10 +17759,7 @@
 /area/hallway/secondary/entry)
 "aPw" = (
 /obj/machinery/disposal/bin,
-/obj/structure/sign/warning/securearea{
-	desc = "Under the painting a plaque reads: 'While the meat grinder may not have spared you, fear not. Not one part of you has gone to waste... You were delicious.'";
-	icon_state = "monkey_painting";
-	name = "Mr. Deempisi portrait";
+/obj/structure/sign/plaques/deempisi{
 	pixel_x = -28;
 	pixel_y = -4
 	},
@@ -20409,7 +20403,6 @@
 "aWj" = (
 /obj/structure/grille,
 /obj/structure/window{
-	icon_state = "window";
 	dir = 8
 	},
 /obj/structure/window,
@@ -20425,7 +20418,6 @@
 "aWl" = (
 /obj/structure/grille,
 /obj/structure/window{
-	icon_state = "window";
 	dir = 1
 	},
 /turf/open/floor/plating,
@@ -21569,7 +21561,6 @@
 /obj/structure/table,
 /obj/item/razor,
 /obj/structure/window{
-	icon_state = "window";
 	dir = 1
 	},
 /obj/effect/turf_decal/tile/blue{
@@ -21664,7 +21655,6 @@
 	pixel_x = -2
 	},
 /obj/structure/window{
-	icon_state = "window";
 	dir = 1
 	},
 /obj/effect/turf_decal/tile/blue{
@@ -25221,7 +25211,6 @@
 	dir = 4
 	},
 /obj/structure/window{
-	icon_state = "window";
 	dir = 1
 	},
 /obj/structure/window,
@@ -25233,7 +25222,6 @@
 	dir = 4
 	},
 /obj/structure/window{
-	icon_state = "window";
 	dir = 8
 	},
 /turf/open/floor/plating,
@@ -25550,7 +25538,6 @@
 /area/quartermaster/office)
 "biG" = (
 /obj/machinery/mech_bay_recharge_port{
-	icon_state = "recharge_port";
 	dir = 2
 	},
 /obj/structure/cable{
@@ -50095,7 +50082,6 @@
 "crb" = (
 /obj/machinery/atmospherics/components/binary/pump{
 	dir = 2;
-	icon_state = "pump_map";
 	name = "Gas to Chamber"
 	},
 /obj/effect/decal/cleanable/dirt,
@@ -54320,7 +54306,6 @@
 	},
 /obj/machinery/atmospherics/components/binary/pump{
 	dir = 2;
-	icon_state = "pump_map";
 	name = "Cooling Loop Bypass"
 	},
 /turf/open/floor/engine,
@@ -54962,7 +54947,6 @@
 /area/science/robotics/lab)
 "cHL" = (
 /obj/machinery/mech_bay_recharge_port{
-	icon_state = "recharge_port";
 	dir = 2
 	},
 /obj/structure/cable{
@@ -57563,7 +57547,6 @@
 "wHy" = (
 /obj/machinery/atmospherics/components/trinary/mixer{
 	dir = 1;
-	icon_state = "mixer_off";
 	name = "plasma mixer"
 	},
 /turf/open/floor/plasteel,

--- a/_maps/map_files/Deltastation/DeltaStation2.dmm
+++ b/_maps/map_files/Deltastation/DeltaStation2.dmm
@@ -9255,15 +9255,9 @@
 	pixel_y = 3
 	},
 /obj/item/storage/box/mousetraps,
-/obj/item/restraints/legcuffs/beartrap{
-	icon_state = "beartrap0"
-	},
-/obj/item/restraints/legcuffs/beartrap{
-	icon_state = "beartrap0"
-	},
-/obj/item/restraints/legcuffs/beartrap{
-	icon_state = "beartrap0"
-	},
+/obj/item/restraints/legcuffs/beartrap,
+/obj/item/restraints/legcuffs/beartrap,
+/obj/item/restraints/legcuffs/beartrap,
 /obj/effect/decal/cleanable/cobweb,
 /obj/effect/turf_decal/bot,
 /obj/effect/turf_decal/tile/neutral{
@@ -9614,7 +9608,6 @@
 "awd" = (
 /obj/machinery/atmospherics/components/binary/pump{
 	dir = 1;
-	icon_state = "pump_map";
 	name = "Gas to Loop"
 	},
 /obj/effect/turf_decal/tile/neutral{
@@ -11013,7 +11006,6 @@
 	},
 /obj/machinery/atmospherics/components/binary/pump{
 	dir = 1;
-	icon_state = "pump_map";
 	name = "Thermo to Gas"
 	},
 /turf/open/floor/plasteel,
@@ -12327,7 +12319,6 @@
 "aBb" = (
 /obj/machinery/atmospherics/components/binary/pump{
 	dir = 8;
-	icon_state = "pump_map";
 	name = "Atmos to Gas"
 	},
 /obj/effect/turf_decal/stripes/line{
@@ -12984,7 +12975,6 @@
 "aCn" = (
 /obj/machinery/atmospherics/components/binary/pump{
 	dir = 1;
-	icon_state = "pump_map";
 	name = "Gas to Chamber"
 	},
 /turf/open/floor/engine,
@@ -18994,7 +18984,6 @@
 "aMy" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/components/trinary/filter/flipped{
-	icon_state = "filter_off_f";
 	dir = 8
 	},
 /obj/effect/turf_decal/tile/yellow{
@@ -19707,7 +19696,6 @@
 /area/maintenance/disposal/incinerator)
 "aNP" = (
 /obj/machinery/power/turbine{
-	icon_state = "turbine";
 	dir = 8;
 	luminosity = 2
 	},
@@ -21164,7 +21152,6 @@
 "aPZ" = (
 /obj/structure/table/wood,
 /obj/item/toy/cards/deck/syndicate{
-	icon_state = "deck_syndicate_full";
 	pixel_y = 6
 	},
 /turf/open/floor/plasteel/grimy,
@@ -56012,7 +55999,6 @@
 "bRQ" = (
 /obj/structure/lattice,
 /obj/structure/transit_tube/curved/flipped{
-	icon_state = "curved1";
 	dir = 4
 	},
 /turf/open/space,
@@ -56025,7 +56011,6 @@
 "bRS" = (
 /obj/structure/lattice,
 /obj/structure/transit_tube/curved{
-	icon_state = "curved0";
 	dir = 8
 	},
 /turf/open/space,
@@ -57230,7 +57215,6 @@
 "bTJ" = (
 /obj/structure/lattice,
 /obj/structure/transit_tube/diagonal{
-	icon_state = "diagonal";
 	dir = 4
 	},
 /turf/open/space,
@@ -58929,7 +58913,6 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden,
 /obj/structure/transit_tube/station{
-	icon_state = "closed_station0";
 	dir = 8
 	},
 /obj/effect/turf_decal/tile/neutral{
@@ -58967,7 +58950,6 @@
 	dir = 4
 	},
 /obj/structure/transit_tube/junction{
-	icon_state = "junction0";
 	dir = 4
 	},
 /turf/open/space,
@@ -58997,7 +58979,6 @@
 	dir = 4
 	},
 /obj/structure/transit_tube/curved{
-	icon_state = "curved0";
 	dir = 8
 	},
 /turf/open/space,
@@ -60654,7 +60635,6 @@
 	dir = 4
 	},
 /obj/structure/transit_tube/curved/flipped{
-	icon_state = "curved1";
 	dir = 1
 	},
 /obj/effect/turf_decal/tile/neutral{
@@ -60679,7 +60659,6 @@
 	dir = 8
 	},
 /obj/structure/transit_tube/curved{
-	icon_state = "curved0";
 	dir = 4
 	},
 /obj/structure/sign/warning/securearea{
@@ -62063,7 +62042,6 @@
 "cap" = (
 /obj/structure/lattice,
 /obj/structure/transit_tube/curved{
-	icon_state = "curved0";
 	dir = 4
 	},
 /turf/open/space,
@@ -62071,7 +62049,6 @@
 "caq" = (
 /obj/structure/lattice,
 /obj/structure/transit_tube/curved/flipped{
-	icon_state = "curved1";
 	dir = 8
 	},
 /turf/open/space,
@@ -78368,8 +78345,7 @@
 /area/crew_quarters/toilet/restrooms)
 "cBJ" = (
 /obj/machinery/shower{
-	dir = 8;
-	icon_state = "shower"
+	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -80522,8 +80498,7 @@
 /area/crew_quarters/toilet/restrooms)
 "cFd" = (
 /obj/machinery/shower{
-	dir = 8;
-	icon_state = "shower"
+	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
@@ -88427,7 +88402,6 @@
 	req_access_txt = "5"
 	},
 /obj/effect/mapping_helpers/airlock/unres{
-	icon_state = "airlock_unres_helper";
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -89605,7 +89579,6 @@
 	req_access_txt = "5"
 	},
 /obj/effect/mapping_helpers/airlock/unres{
-	icon_state = "airlock_unres_helper";
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -101774,7 +101747,6 @@
 /area/science/robotics/mechbay)
 "dpb" = (
 /obj/machinery/mech_bay_recharge_port{
-	icon_state = "recharge_port";
 	dir = 8
 	},
 /obj/effect/turf_decal/stripes/line{
@@ -101987,7 +101959,6 @@
 	req_access_txt = "5"
 	},
 /obj/effect/mapping_helpers/airlock/unres{
-	icon_state = "airlock_unres_helper";
 	dir = 8
 	},
 /obj/structure/cable/white{
@@ -102234,7 +102205,6 @@
 "dpP" = (
 /obj/structure/table/wood/poker,
 /obj/item/toy/cards/deck/syndicate{
-	icon_state = "deck_syndicate_full";
 	pixel_y = 6
 	},
 /turf/open/floor/plasteel/grimy,
@@ -103072,7 +103042,6 @@
 	req_access_txt = "5"
 	},
 /obj/effect/mapping_helpers/airlock/unres{
-	icon_state = "airlock_unres_helper";
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -105013,7 +104982,6 @@
 /area/science/robotics/mechbay)
 "duY" = (
 /obj/machinery/mech_bay_recharge_port{
-	icon_state = "recharge_port";
 	dir = 8
 	},
 /obj/effect/turf_decal/stripes/line{
@@ -108216,7 +108184,6 @@
 /area/science/research/abandoned)
 "dAr" = (
 /obj/machinery/mech_bay_recharge_port{
-	icon_state = "recharge_port";
 	dir = 1
 	},
 /obj/effect/decal/cleanable/dirt,

--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -12030,7 +12030,7 @@
 	dir = 4
 	},
 /mob/living/simple_animal/bot/secbot/beepsky{
-	desc = "It's Officer Beepsky! Powered by a potato and a shot of whiskey, and with a sturdier reinforced chassis, too. ";
+	desc = "It's Officer Beepsky! Powered by a potato and a shot of whiskey, and with a sturdier reinforced chassis, too.";
 	health = 45;
 	maxHealth = 45;
 	name = "Officer Beepsky"
@@ -38134,9 +38134,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/structure/disposalpipe/segment,
-/turf/open/floor/plasteel{
-	icon_state = "wood"
-	},
+/turf/open/floor/wood,
 /area/crew_quarters/bar)
 "buP" = (
 /obj/machinery/computer/slot_machine{
@@ -39188,10 +39186,7 @@
 /turf/open/floor/plasteel,
 /area/crew_quarters/bar)
 "bwQ" = (
-/obj/structure/sign/warning/securearea{
-	desc = "Under the painting a plaque reads: 'While the meat grinder may not have spared you, fear not. Not one part of you has gone to waste... You were delicious.'";
-	icon_state = "monkey_painting";
-	name = "Mr. Deempisi portrait";
+/obj/structure/sign/plaques/deempisi{
 	pixel_y = 28
 	},
 /obj/structure/disposalpipe/trunk{
@@ -66183,7 +66178,6 @@
 	dir = 4
 	},
 /obj/effect/mapping_helpers/airlock/unres{
-	icon_state = "airlock_unres_helper";
 	dir = 4
 	},
 /obj/effect/turf_decal/tile/blue{
@@ -73711,7 +73705,7 @@
 "cMa" = (
 /obj/structure/table/wood,
 /obj/item/book/granter/spell/smoke/lesser{
-	name = "mysterious old book of "
+	name = "mysterious old book of cloud-chasing"
 	},
 /obj/item/reagent_containers/food/drinks/bottle/holywater{
 	name = "flask of holy water";

--- a/_maps/map_files/Mining/Lavaland.dmm
+++ b/_maps/map_files/Mining/Lavaland.dmm
@@ -3708,7 +3708,6 @@
 /area/mine/production)
 "rP" = (
 /obj/machinery/atmospherics/pipe/layer_manifold{
-	icon_state = "manifoldlayer";
 	dir = 4
 	},
 /obj/structure/cable{

--- a/_maps/map_files/PubbyStation/PubbyStation.dmm
+++ b/_maps/map_files/PubbyStation/PubbyStation.dmm
@@ -3507,9 +3507,8 @@
 "akb" = (
 /obj/machinery/disposal/bin,
 /obj/structure/disposalpipe/trunk,
-/obj/structure/sign/plaques/atmos{
+/obj/structure/sign/plaques/kiddie{
 	desc = "An embossed piece of paper from the University of Nanotrasen at Portpoint.";
-	icon_state = "kiddieplaque";
 	name = "\improper 'Diploma' frame";
 	pixel_y = 32
 	},
@@ -4739,7 +4738,6 @@
 /area/crew_quarters/heads/hos)
 "amA" = (
 /obj/structure/transit_tube/curved/flipped{
-	icon_state = "curved1";
 	dir = 4
 	},
 /obj/structure/lattice/catwalk,
@@ -4757,7 +4755,6 @@
 /area/space/nearstation)
 "amD" = (
 /obj/structure/transit_tube/curved/flipped{
-	icon_state = "curved1";
 	dir = 8
 	},
 /obj/structure/lattice/catwalk,
@@ -6935,7 +6932,6 @@
 	},
 /obj/effect/turf_decal/stripes/line,
 /obj/structure/transit_tube/curved/flipped{
-	icon_state = "curved1";
 	dir = 8
 	},
 /turf/open/floor/plating,
@@ -8662,10 +8658,7 @@
 /obj/machinery/light/small{
 	dir = 1
 	},
-/obj/structure/sign/warning/securearea{
-	desc = "Under the painting a plaque reads: 'While the meat grinder may not have spared you, fear not. Not one part of you has gone to waste... You were delicious.'";
-	icon_state = "monkey_painting";
-	name = "Mr. Deempisi portrait";
+/obj/structure/sign/plaques/deempisi{
 	pixel_y = 28
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
@@ -10121,10 +10114,7 @@
 /obj/machinery/light/small{
 	dir = 1
 	},
-/obj/structure/sign/warning/securearea{
-	desc = "Under the painting a plaque reads: 'While the meat grinder may not have spared you, fear not. Not one part of you has gone to waste... You were delicious.'";
-	icon_state = "monkey_painting";
-	name = "Mr. Deempisi portrait";
+/obj/structure/sign/plaques/deempisi{
 	pixel_y = 28
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
@@ -11581,10 +11571,7 @@
 /obj/machinery/light/small{
 	dir = 1
 	},
-/obj/structure/sign/warning/securearea{
-	desc = "Under the painting a plaque reads: 'While the meat grinder may not have spared you, fear not. Not one part of you has gone to waste... You were delicious.'";
-	icon_state = "monkey_painting";
-	name = "Mr. Deempisi portrait";
+/obj/structure/sign/plaques/deempisi{
 	pixel_y = 28
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
@@ -12301,7 +12288,6 @@
 /area/crew_quarters/dorms)
 "aDk" = (
 /turf/open/floor/plasteel/white/corner{
-	icon_state = "whitecorner";
 	dir = 8
 	},
 /area/crew_quarters/dorms)
@@ -15267,7 +15253,6 @@
 	icon_state = "plant-04"
 	},
 /turf/open/floor/plasteel/white/corner{
-	icon_state = "whitecorner";
 	dir = 4
 	},
 /area/hallway/primary/central)
@@ -20508,10 +20493,7 @@
 /area/hallway/secondary/exit/departure_lounge)
 "aWM" = (
 /obj/machinery/washing_machine,
-/obj/structure/sign/warning/securearea{
-	desc = "Under the painting a plaque reads: 'While the meat grinder may not have spared you, fear not. Not one part of you has gone to waste... You were delicious.'";
-	icon_state = "monkey_painting";
-	name = "Mr. Deempisi portrait";
+/obj/structure/sign/plaques/deempisi{
 	pixel_y = 28
 	},
 /obj/effect/turf_decal/tile/neutral{
@@ -29379,7 +29361,6 @@
 	req_one_access_txt = "5;9"
 	},
 /obj/effect/mapping_helpers/airlock/unres{
-	icon_state = "airlock_unres_helper";
 	dir = 8
 	},
 /obj/structure/cable{
@@ -32895,9 +32876,7 @@
 /obj/effect/turf_decal/tile/purple{
 	dir = 8
 	},
-/turf/open/floor/plasteel{
-	icon_state = "purple"
-	},
+/turf/open/floor/plasteel,
 /area/hallway/primary/aft)
 "byK" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -33868,7 +33847,6 @@
 /area/science/xenobiology)
 "bAI" = (
 /obj/structure/transit_tube/curved/flipped{
-	icon_state = "curved1";
 	dir = 4
 	},
 /turf/open/space/basic,
@@ -36152,9 +36130,7 @@
 /obj/effect/turf_decal/tile/purple{
 	dir = 8
 	},
-/turf/open/floor/plasteel/dark{
-	icon_state = "darkpurple"
-	},
+/turf/open/floor/plasteel/dark,
 /area/crew_quarters/heads/hor)
 "bES" = (
 /obj/item/aicard,
@@ -37184,7 +37160,6 @@
 /area/medical/virology)
 "bGV" = (
 /obj/machinery/shower{
-	icon_state = "shower";
 	dir = 4
 	},
 /obj/item/radio/intercom{
@@ -38814,7 +38789,6 @@
 /area/maintenance/department/engine)
 "bKm" = (
 /obj/structure/light_construct{
-	icon_state = "tube-construct-stage1";
 	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
@@ -40266,7 +40240,6 @@
 /area/chapel/dock)
 "bNx" = (
 /obj/structure/transit_tube/station/reverse{
-	icon_state = "closed_terminus0";
 	dir = 1
 	},
 /turf/open/floor/plating,
@@ -41283,8 +41256,7 @@
 /area/chapel/asteroid/monastery)
 "bQe" = (
 /obj/item/flashlight/lantern{
-	icon_state = "lantern-on";
-	on = 1
+	icon_state = "lantern-on"
 	},
 /turf/open/floor/plating/asteroid,
 /area/chapel/asteroid/monastery)
@@ -46439,7 +46411,6 @@
 	pixel_y = -6
 	},
 /obj/machinery/atmospherics/components/trinary/filter/flipped{
-	icon_state = "filter_off_f";
 	dir = 4
 	},
 /obj/effect/turf_decal/tile/yellow,
@@ -46737,8 +46708,7 @@
 /area/chapel/main/monastery)
 "ccL" = (
 /obj/item/flashlight/lantern{
-	icon_state = "lantern-on";
-	on = 1
+	icon_state = "lantern-on"
 	},
 /obj/effect/turf_decal/sand,
 /turf/open/floor/plasteel,
@@ -48004,10 +47974,7 @@
 /area/chapel/main/monastery)
 "cgM" = (
 /obj/structure/dresser,
-/obj/structure/sign/warning/securearea{
-	desc = "Under the painting a plaque reads: 'While the meat grinder may not have spared you, fear not. Not one part of you has gone to waste... You were delicious.'";
-	icon_state = "monkey_painting";
-	name = "Mr. Deempisi portrait";
+/obj/structure/sign/plaques/deempisi{
 	pixel_y = 28
 	},
 /turf/open/floor/plasteel/grimy,
@@ -49092,8 +49059,7 @@
 /area/library)
 "clj" = (
 /obj/item/flashlight/lantern{
-	icon_state = "lantern-on";
-	on = 1
+	icon_state = "lantern-on"
 	},
 /turf/open/floor/plating/asteroid/airless,
 /area/asteroid/nearstation/bomb_site)
@@ -52846,7 +52812,6 @@
 "czC" = (
 /obj/structure/table/wood/fancy,
 /obj/item/flashlight/lantern{
-	on = 1;
 	icon_state = "lantern-on";
 	pixel_y = 8
 	},
@@ -55897,10 +55862,7 @@
 /turf/open/floor/plasteel/white,
 /area/medical/sleeper)
 "jsD" = (
-/obj/structure/sign/warning/securearea{
-	desc = "Under the painting a plaque reads: 'While the meat grinder may not have spared you, fear not. Not one part of you has gone to waste... You were delicious.'";
-	icon_state = "monkey_painting";
-	name = "Mr. Deempisi portrait";
+/obj/structure/sign/plaques/deempisi{
 	pixel_y = 28
 	},
 /obj/item/twohanded/required/kirbyplants{
@@ -59431,10 +59393,7 @@
 /area/maintenance/department/security/brig)
 "syQ" = (
 /obj/machinery/vending/games,
-/obj/structure/sign/warning/securearea{
-	desc = "Under the painting a plaque reads: 'While the meat grinder may not have spared you, fear not. Not one part of you has gone to waste... You were delicious.'";
-	icon_state = "monkey_painting";
-	name = "Mr. Deempisi portrait";
+/obj/structure/sign/plaques/deempisi{
 	pixel_y = 28
 	},
 /turf/open/floor/plating{
@@ -61364,9 +61323,8 @@
 /area/science/mixing)
 "xJy" = (
 /obj/structure/chair/comfy/black,
-/obj/structure/sign/plaques/atmos{
+/obj/structure/sign/plaques/kiddie{
 	desc = "An embossed piece of paper from the Third University of Harvard.";
-	icon_state = "kiddieplaque";
 	name = "\improper 'Diploma' frame";
 	pixel_y = 32
 	},

--- a/_maps/map_files/generic/CentCom.dmm
+++ b/_maps/map_files/generic/CentCom.dmm
@@ -8592,7 +8592,6 @@
 	pixel_y = -2
 	},
 /obj/item/toy/cards/deck/syndicate{
-	icon_state = "deck_syndicate_full";
 	pixel_x = -6;
 	pixel_y = 6
 	},

--- a/_maps/shuttles/emergency_bar.dmm
+++ b/_maps/shuttles/emergency_bar.dmm
@@ -178,8 +178,7 @@
 /area/shuttle/escape)
 "aF" = (
 /obj/structure/piano{
-	icon_state = "piano";
-	name = "space piano"
+	icon_state = "piano"
 	},
 /turf/open/floor/plasteel/grimy,
 /area/shuttle/escape)

--- a/_maps/shuttles/emergency_delta.dmm
+++ b/_maps/shuttles/emergency_delta.dmm
@@ -437,7 +437,6 @@
 "aJ" = (
 /obj/machinery/shower{
 	dir = 8;
-	icon_state = "shower";
 	name = "emergency shower"
 	},
 /obj/effect/turf_decal/tile/blue,

--- a/_maps/shuttles/emergency_luxury.dmm
+++ b/_maps/shuttles/emergency_luxury.dmm
@@ -7,7 +7,7 @@
 /area/shuttle/escape/luxury)
 "ac" = (
 /obj/machinery/door/airlock/external,
-/turf/open/floor/plating{
+/turf/open/floor/wood{
 	icon_state = "wood-broken2"
 	},
 /area/shuttle/escape/luxury)
@@ -33,22 +33,20 @@
 /turf/open/floor/mineral/gold,
 /area/shuttle/escape/luxury)
 "af" = (
-/turf/open/floor/plating{
+/turf/open/floor/wood{
 	icon_state = "wood-broken3"
 	},
 /area/shuttle/escape/luxury)
 "ag" = (
-/turf/open/floor/plating{
-	icon_state = "wood"
-	},
+/turf/open/floor/wood,
 /area/shuttle/escape/luxury)
 "ah" = (
-/turf/open/floor/plating{
+/turf/open/floor/wood{
 	icon_state = "wood-broken"
 	},
 /area/shuttle/escape/luxury)
 "ai" = (
-/turf/open/floor/plating{
+/turf/open/floor/wood{
 	icon_state = "wood-broken5"
 	},
 /area/shuttle/escape/luxury)
@@ -68,19 +66,19 @@
 /turf/open/floor/mineral/gold,
 /area/shuttle/escape/luxury)
 "am" = (
-/turf/open/floor/plating{
+/turf/open/floor/wood{
 	icon_state = "wood-broken7"
 	},
 /area/shuttle/escape/luxury)
 "an" = (
 /obj/machinery/light/small,
-/turf/open/floor/plating{
+/turf/open/floor/wood{
 	icon_state = "wood-broken2"
 	},
 /area/shuttle/escape/luxury)
 "ao" = (
 /obj/machinery/light/small,
-/turf/open/floor/plating{
+/turf/open/floor/wood{
 	icon_state = "wood-broken6"
 	},
 /area/shuttle/escape/luxury)

--- a/_maps/shuttles/emergency_omega.dmm
+++ b/_maps/shuttles/emergency_omega.dmm
@@ -699,7 +699,6 @@
 "bh" = (
 /obj/machinery/shower{
 	dir = 4;
-	icon_state = "shower";
 	name = "emergency shower"
 	},
 /obj/effect/turf_decal/tile/blue{

--- a/_maps/shuttles/emergency_raven.dmm
+++ b/_maps/shuttles/emergency_raven.dmm
@@ -290,7 +290,6 @@
 "aH" = (
 /obj/machinery/shower{
 	dir = 4;
-	icon_state = "shower";
 	name = "emergency shower"
 	},
 /obj/effect/turf_decal/tile/purple{

--- a/_maps/shuttles/infiltrator_basic.dmm
+++ b/_maps/shuttles/infiltrator_basic.dmm
@@ -505,11 +505,8 @@
 /turf/open/floor/plasteel/dark,
 /area/shuttle/syndicate/airlock)
 "bd" = (
-/obj/structure/sign/warning/securearea{
-	desc = "A warning sign which reads 'EXTERNAL AIRLOCK'";
-	icon_state = "space";
-	layer = 4;
-	name = "EXTERNAL AIRLOCK"
+/obj/structure/sign/warning/vacuum/external{
+	layer = 4
 	},
 /turf/closed/wall/mineral/plastitanium,
 /area/shuttle/syndicate/airlock)

--- a/_maps/shuttles/whiteship_cere.dmm
+++ b/_maps/shuttles/whiteship_cere.dmm
@@ -35,7 +35,6 @@
 /area/shuttle/abandoned)
 "ae" = (
 /obj/machinery/mech_bay_recharge_port{
-	icon_state = "recharge_port";
 	dir = 2
 	},
 /obj/effect/decal/cleanable/dirt{

--- a/_maps/templates/medium_shuttle2.dmm
+++ b/_maps/templates/medium_shuttle2.dmm
@@ -93,7 +93,6 @@
 /area/ruin/powered/shuttle/medium_2)
 "t" = (
 /obj/machinery/sleeper{
-	icon_state = "sleeper";
 	dir = 1
 	},
 /obj/effect/turf_decal/tile/blue{

--- a/_maps/templates/medium_shuttle4.dmm
+++ b/_maps/templates/medium_shuttle4.dmm
@@ -49,7 +49,6 @@
 /area/ruin/powered/shuttle/medium_4)
 "l" = (
 /obj/structure/chair/old{
-	icon_state = "chairold";
 	dir = 1
 	},
 /turf/open/floor/oldshuttle,

--- a/_maps/templates/shelter_2.dmm
+++ b/_maps/templates/shelter_2.dmm
@@ -64,7 +64,6 @@
 "n" = (
 /obj/structure/window/reinforced/survival_pod{
 	dir = 8;
-	icon_state = "pwindow";
 	layer = 3
 	},
 /obj/machinery/door/window/survival_pod{
@@ -81,7 +80,6 @@
 	name = "lusty xenomorph maid"
 	},
 /obj/structure/window/reinforced/survival_pod{
-	icon_state = "pwindow";
 	dir = 1
 	},
 /turf/open/floor/carpet/black,
@@ -101,8 +99,7 @@
 /area/survivalpod)
 "r" = (
 /obj/structure/window/reinforced/survival_pod{
-	dir = 8;
-	icon_state = "pwindow"
+	dir = 8
 	},
 /turf/open/floor/carpet/black,
 /area/survivalpod)
@@ -127,7 +124,6 @@
 	pixel_y = -2
 	},
 /obj/structure/window/reinforced/survival_pod{
-	icon_state = "pwindow";
 	dir = 1
 	},
 /obj/structure/table/wood/fancy/black{
@@ -144,7 +140,6 @@
 /area/survivalpod)
 "v" = (
 /obj/structure/window/reinforced/survival_pod{
-	icon_state = "pwindow";
 	dir = 1
 	},
 /obj/structure/displaycase{
@@ -159,8 +154,7 @@
 "w" = (
 /obj/structure/window/reinforced/survival_pod{
 	density = 0;
-	dir = 9;
-	icon_state = "pwindow"
+	dir = 9
 	},
 /turf/open/floor/carpet/black,
 /area/survivalpod)

--- a/code/game/objects/items/devices/flashlight.dm
+++ b/code/game/objects/items/devices/flashlight.dm
@@ -17,6 +17,8 @@
 
 /obj/item/flashlight/Initialize()
 	. = ..()
+	if(icon_state == "[initial(icon_state)]-on")
+		on = TRUE
 	update_brightness()
 
 /obj/item/flashlight/proc/update_brightness(mob/user = null)

--- a/code/game/objects/items/toys.dm
+++ b/code/game/objects/items/toys.dm
@@ -944,6 +944,7 @@
 /obj/item/toy/cards/deck/syndicate
 	name = "suspicious looking deck of cards"
 	desc = "A deck of space-grade playing cards. They seem unusually rigid."
+	icon_state = "deck_syndicate_full"
 	deckstyle = "syndicate"
 	card_hitsound = 'sound/weapons/bladeslice.ogg'
 	card_force = 5

--- a/code/game/objects/structures/musician.dm
+++ b/code/game/objects/structures/musician.dm
@@ -335,7 +335,7 @@
 	..()
 	song = new("piano", src)
 
-	if(prob(50))
+	if(prob(50) && icon_state == initial(icon_state))
 		name = "space minimoog"
 		desc = "This is a minimoog, like a space piano, but more spacey!"
 		icon_state = "minimoog"

--- a/code/game/objects/structures/signs/signs_plaques.dm
+++ b/code/game/objects/structures/signs/signs_plaques.dm
@@ -41,3 +41,8 @@
 /obj/structure/sign/plaques/kiddie/perfect_drone
 	name = "\improper 'Perfect Drone' sign"
 	desc = "A guide to the drone shell dispenser, detailing the constructive and destructive applications of modern repair drones, as well as the development of the incorruptible cyborg servants of tomorrow, available today."
+
+/obj/structure/sign/plaques/deempisi
+	name = "Mr. Deempisi portrait"
+	desc = "Under the painting a plaque reads: 'While the meat grinder may not have spared you, fear not. Not one part of you has gone to waste... You were delicious.'"
+	icon_state = "monkey_painting"

--- a/code/modules/holodeck/turfs.dm
+++ b/code/modules/holodeck/turfs.dm
@@ -119,6 +119,10 @@
 	if(intact)
 		queue_smooth(src)
 
+/turf/open/floor/holofloor/wood
+	icon_state = "wood"
+	tiled_dirt = FALSE
+
 /turf/open/floor/holofloor/snow
 	gender = PLURAL
 	name = "snow"

--- a/code/modules/hydroponics/grown/towercap.dm
+++ b/code/modules/hydroponics/grown/towercap.dm
@@ -110,11 +110,16 @@
 	anchored = TRUE
 	buckle_lying = 0
 	var/burning = 0
+	var/burn_icon = "bonfire_on_fire" //for a softer more burning embers icon, use "bonfire_warm"
 	var/grill = FALSE
 	var/fire_stack_strength = 5
 
 /obj/structure/bonfire/dense
 	density = TRUE
+
+/obj/structure/bonfire/prelit/Initialize()
+	. = ..()
+	StartBurning()
 
 /obj/structure/bonfire/CanPass(atom/movable/mover, turf/target)
 	if(istype(mover) && (mover.pass_flags & PASSTABLE))
@@ -183,13 +188,13 @@
 		if(O.air)
 			var/loc_gases = O.air.gases
 			if(loc_gases[/datum/gas/oxygen][MOLES] > 13)
-				return 1
-	return 0
+				return TRUE
+	return FALSE
 
 /obj/structure/bonfire/proc/StartBurning()
 	if(!burning && CheckOxygen())
-		icon_state = "bonfire_on_fire"
-		burning = 1
+		icon_state = burn_icon
+		burning = TRUE
 		set_light(6)
 		Burn()
 		START_PROCESSING(SSobj, src)


### PR DESCRIPTION
:cl: ShizCalev
fix: Fixed vareditted bonfires not properly igniting at round start.
fix: Fixed vareditted pianos switching to minimoogs at round start.
fix: Fixed some vareddited flashlights not turning on properly at round start.
fix: Fixed all missing floor icons
fix: Fixed bookcases at the Wild West away mission not being properly populated.
/:cl:

Fixes #40469
Fixes #40307
Fixes missing icon in DM for syndie playing cards
Added support to change the burning icon of bonfires (right now there's the normal on_fire and warm states, warm being more of a burning embers sort of deal.)