### PR TITLE
Improves wizard spell descs, booleans

### DIFF
--- a/code/modules/spells/spell.dm
+++ b/code/modules/spells/spell.dm
@@ -109,12 +109,12 @@ GLOBAL_LIST_INIT(spells, typesof(/obj/effect/proc_holder/spell)) //needed for th
 	var/holder_var_type = "bruteloss" //only used if charge_type equals to "holder_var"
 	var/holder_var_amount = 20 //same. The amount adjusted with the mob's var when the spell is used
 
-	var/clothes_req = 1 //see if it requires clothes
-	var/cult_req = 0 //SPECIAL SNOWFLAKE clothes required for cult only spells
-	var/human_req = 0 //spell can only be cast by humans
-	var/nonabstract_req = 0 //spell can only be cast by mobs that are physical entities
-	var/stat_allowed = 0 //see if it requires being conscious/alive, need to set to 1 for ghostpells
-	var/phase_allowed = 0 // If true, the spell can be cast while phased, eg. blood crawling, ethereal jaunting
+	var/clothes_req = TRUE //see if it requires clothes
+	var/cult_req = FALSE //SPECIAL SNOWFLAKE clothes required for cult only spells
+	var/human_req = FALSE //spell can only be cast by humans
+	var/nonabstract_req = FALSE //spell can only be cast by mobs that are physical entities
+	var/stat_allowed = FALSE //see if it requires being conscious/alive, need to set to 1 for ghostpells
+	var/phase_allowed = FALSE // If true, the spell can be cast while phased, eg. blood crawling, ethereal jaunting
 	var/invocation = "HURP DURP" //what is uttered when the wizard casts the spell
 	var/invocation_emote_self = null
 	var/invocation_type = "none" //can be none, whisper, emote and shout
@@ -124,7 +124,7 @@ GLOBAL_LIST_INIT(spells, typesof(/obj/effect/proc_holder/spell)) //needed for th
 	var/spell_level = 0 //if a spell can be taken multiple times, this raises
 	var/level_max = 4 //The max possible level_max is 4
 	var/cooldown_min = 0 //This defines what spell quickened four times has as a cooldown. Make sure to set this for every spell
-	var/player_lock = 1 //If it can be used by simple mobs
+	var/player_lock = TRUE //If it can be used by simple mobs
 
 	var/overlay = 0
 	var/overlay_icon = 'icons/obj/wizard.dmi'
@@ -136,7 +136,7 @@ GLOBAL_LIST_INIT(spells, typesof(/obj/effect/proc_holder/spell)) //needed for th
 	var/smoke_spread = 0 //1 - harmless, 2 - harmful
 	var/smoke_amt = 0 //cropped at 10
 
-	var/centcom_cancast = 1 //Whether or not the spell should be allowed on z2
+	var/centcom_cancast = TRUE //Whether or not the spell should be allowed on z2
 
 	action_icon = 'icons/mob/actions/actions_spells.dmi'
 	action_icon_state = "spell_default"
@@ -518,8 +518,8 @@ GLOBAL_LIST_INIT(spells, typesof(/obj/effect/proc_holder/spell)) //needed for th
 /obj/effect/proc_holder/spell/self/basic_heal //This spell exists mainly for debugging purposes, and also to show how casting works
 	name = "Lesser Heal"
 	desc = "Heals a small amount of brute and burn damage."
-	human_req = 1
-	clothes_req = 0
+	human_req = TRUE
+	clothes_req = FALSE
 	charge_max = 100
 	cooldown_min = 50
 	invocation = "Victus sano!"

--- a/code/modules/spells/spell_types/aimed.dm
+++ b/code/modules/spells/spell_types/aimed.dm
@@ -90,10 +90,10 @@
 
 /obj/effect/proc_holder/spell/aimed/lightningbolt
 	name = "Lightning Bolt"
-	desc = "Fire a high powered lightning bolt at your foes!"
+	desc = "Fire a lightning bolt at your foes! It will jump between targets, but can't knock them down."
 	school = "evocation"
 	charge_max = 200
-	clothes_req = 1
+	clothes_req = TRUE
 	invocation = "UN'LTD P'WAH"
 	invocation_type = "shout"
 	cooldown_min = 30
@@ -108,10 +108,10 @@
 
 /obj/effect/proc_holder/spell/aimed/fireball
 	name = "Fireball"
-	desc = "This spell fires a fireball at a target and does not require wizard garb."
+	desc = "This spell fires an explosive fireball at a target."
 	school = "evocation"
 	charge_max = 60
-	clothes_req = 0
+	clothes_req = FALSE
 	invocation = "ONI SOMA"
 	invocation_type = "shout"
 	range = 20
@@ -126,10 +126,10 @@
 
 /obj/effect/proc_holder/spell/aimed/spell_cards
 	name = "Spell Cards"
-	desc = "Blazing hot rapid-fire homing cards. Banish your foes with its mystical power!"
+	desc = "Blazing hot rapid-fire homing cards. Send your foes to the shadow realm with their mystical power!"
 	school = "evocation"
 	charge_max = 50
-	clothes_req = 0
+	clothes_req = FALSE
 	invocation = "Sigi'lu M'Fan 'Tasia"
 	invocation_type = "shout"
 	range = 40
@@ -143,7 +143,7 @@
 	var/projectile_initial_spread_amount = 30
 	var/projectile_location_spread_amount = 12
 	var/datum/component/lockon_aiming/lockon_component
-	ranged_clickcd_override = 1
+	ranged_clickcd_override = TRUE
 
 /obj/effect/proc_holder/spell/aimed/spell_cards/on_activation(mob/M)
 	QDEL_NULL(lockon_component)

--- a/code/modules/spells/spell_types/area_teleport.dm
+++ b/code/modules/spells/spell_types/area_teleport.dm
@@ -1,10 +1,10 @@
 /obj/effect/proc_holder/spell/targeted/area_teleport
 	name = "Area teleport"
 	desc = "This spell teleports you to a type of area of your selection."
-	nonabstract_req = 1
+	nonabstract_req = TRUE
 
-	var/randomise_selection = 0 //if it lets the usr choose the teleport loc or picks it from the list
-	var/invocation_area = 1 //if the invocation appends the selected area
+	var/randomise_selection = FALSE //if it lets the usr choose the teleport loc or picks it from the list
+	var/invocation_area = TRUE //if the invocation appends the selected area
 	var/sound1 = 'sound/weapons/zapbang.ogg'
 	var/sound2 = 'sound/weapons/zapbang.ogg'
 
@@ -38,10 +38,10 @@
 		var/list/L = list()
 		for(var/turf/T in get_area_turfs(thearea.type))
 			if(!T.density)
-				var/clear = 1
+				var/clear = TRUE
 				for(var/obj/O in T)
 					if(O.density)
-						clear = 0
+						clear = FALSE
 						break
 				if(clear)
 					L+=T
@@ -55,12 +55,12 @@
 
 		var/list/tempL = L
 		var/attempt = null
-		var/success = 0
+		var/success = FALSE
 		while(tempL.len)
 			attempt = pick(tempL)
 			target.Move(attempt)
 			if(get_turf(target) == attempt)
-				success = 1
+				success = TRUE
 				break
 			else
 				tempL.Remove(attempt)

--- a/code/modules/spells/spell_types/barnyard.dm
+++ b/code/modules/spells/spell_types/barnyard.dm
@@ -5,8 +5,8 @@
 	charge_type = "recharge"
 	charge_max	= 150
 	charge_counter = 0
-	clothes_req = 0
-	stat_allowed = 0
+	clothes_req = FALSE
+	stat_allowed = FALSE
 	invocation = "KN'A FTAGHU, PUCK 'BTHNK!"
 	invocation_type = "shout"
 	range = 7

--- a/code/modules/spells/spell_types/bloodcrawl.dm
+++ b/code/modules/spells/spell_types/bloodcrawl.dm
@@ -2,9 +2,9 @@
 	name = "Blood Crawl"
 	desc = "Use pools of blood to phase out of existence."
 	charge_max = 0
-	clothes_req = 0
+	clothes_req = FALSE
 	//If you couldn't cast this while phased, you'd have a problem
-	phase_allowed = 1
+	phase_allowed = TRUE
 	selection_type = "range"
 	range = 1
 	cooldown_min = 0
@@ -12,7 +12,7 @@
 	action_icon = 'icons/mob/actions/actions_minor_antag.dmi'
 	action_icon_state = "bloodcrawl"
 	action_background_icon_state = "bg_demon"
-	var/phased = 0
+	var/phased = FALSE
 
 /obj/effect/proc_holder/spell/bloodcrawl/choose_targets(mob/user = usr)
 	for(var/obj/effect/decal/cleanable/target in range(range, get_turf(user)))
@@ -26,10 +26,10 @@
 	if(istype(user))
 		if(phased)
 			if(user.phasein(target))
-				phased = 0
+				phased = FALSE
 		else
 			if(user.phaseout(target))
-				phased = 1
+				phased = TRUE
 		start_recharge()
 		return
 	revert_cast()

--- a/code/modules/spells/spell_types/charge.dm
+++ b/code/modules/spells/spell_types/charge.dm
@@ -4,12 +4,12 @@
 
 	school = "transmutation"
 	charge_max = 600
-	clothes_req = 0
+	clothes_req = FALSE
 	invocation = "DIRI CEL"
 	invocation_type = "whisper"
 	range = -1
 	cooldown_min = 400 //50 deciseconds reduction per rank
-	include_user = 1
+	include_user = TRUE
 
 
 /obj/effect/proc_holder/spell/targeted/charge/cast(list/targets,mob/user = usr)
@@ -29,7 +29,7 @@
 				to_chat(M, "<span class='notice'>You feel raw magic flowing through you. It feels good!</span>")
 			else
 				to_chat(M, "<span class='notice'>You feel very strange for a moment, but then it passes.</span>")
-				burnt_out = 1
+				burnt_out = TRUE
 			charged_item = M
 			break
 		for(var/obj/item in hand_items)

--- a/code/modules/spells/spell_types/conjure.dm
+++ b/code/modules/spells/spell_types/conjure.dm
@@ -7,8 +7,8 @@
 
 	var/summon_lifespan = 0 // 0=permanent, any other time in deciseconds
 	var/summon_amt = 1 //amount of objects summoned
-	var/summon_ignore_density = FALSE //if set to 1, adds dense tiles to possible spawn places
-	var/summon_ignore_prev_spawn_points = 0 //if set to 1, each new object is summoned on a new spawn point
+	var/summon_ignore_density = FALSE //if set to TRUE, adds dense tiles to possible spawn places
+	var/summon_ignore_prev_spawn_points = TRUE //if set to TRUE, each new object is summoned on a new spawn point
 
 	var/list/newVars = list() //vars of the summoned objects will be replaced with those where they meet
 	//should have format of list("emagged" = 1,"name" = "Wizard's Justicebot"), for example
@@ -72,9 +72,9 @@
 	name = "Summon weapon"
 	desc = "A generic spell that should not exist.  This summons an instance of a specific type of item, or if one already exists, un-summons it.  Summons into hand if possible."
 	invocation_type = "none"
-	include_user = 1
+	include_user = TRUE
 	range = -1
-	clothes_req = 0
+	clothes_req = FALSE
 	var/obj/item/item
 	var/item_type = /obj/item/banhammer
 	school = "conjuration"

--- a/code/modules/spells/spell_types/construct_spells.dm
+++ b/code/modules/spells/spell_types/construct_spells.dm
@@ -7,7 +7,7 @@
 	action_background_icon_state = "bg_demon"
 
 /obj/effect/proc_holder/spell/aoe_turf/conjure/construct/lesser/cult
-	cult_req = 1
+	clothes_req = TRUE
 	charge_max = 2500
 
 
@@ -17,7 +17,7 @@
 
 	school = "transmutation"
 	charge_max = 50
-	clothes_req = 0
+	clothes_req = FALSE
 	invocation = "none"
 	invocation_type = "none"
 	range = 2
@@ -37,7 +37,7 @@
 
 	school = "conjuration"
 	charge_max = 20
-	clothes_req = 0
+	clothes_req = FALSE
 	invocation = "none"
 	invocation_type = "none"
 	range = 0
@@ -53,7 +53,7 @@
 
 	school = "conjuration"
 	charge_max = 100
-	clothes_req = 0
+	clothes_req = FALSE
 	invocation = "none"
 	invocation_type = "none"
 	range = 0
@@ -70,7 +70,7 @@
 
 	school = "conjuration"
 	charge_max = 300
-	clothes_req = 0
+	clothes_req = FALSE
 	invocation = "none"
 	invocation_type = "none"
 	range = 0
@@ -83,7 +83,7 @@
 
 	school = "conjuration"
 	charge_max = 2400
-	clothes_req = 0
+	clothes_req = FALSE
 	invocation = "none"
 	invocation_type = "none"
 	range = 0
@@ -94,7 +94,7 @@
 	summon_type = list(/obj/item/soulstone)
 
 /obj/effect/proc_holder/spell/aoe_turf/conjure/soulstone/cult
-	cult_req = 1
+	clothes_req = TRUE
 	charge_max = 3600
 
 /obj/effect/proc_holder/spell/aoe_turf/conjure/soulstone/noncult
@@ -121,11 +121,11 @@
 
 	school = "transmutation"
 	charge_max = 250
-	clothes_req = 0
+	clothes_req = FALSE
 	invocation = "none"
 	invocation_type = "none"
 	range = -1
-	include_user = 1
+	include_user = TRUE
 	jaunt_duration = 50 //in deciseconds
 	action_icon = 'icons/mob/actions/actions_cult.dmi'
 	action_icon_state = "phaseshift"
@@ -143,7 +143,7 @@
 
 	school = "evocation"
 	charge_max = 400
-	clothes_req = 0
+	clothes_req = FALSE
 	invocation = "none"
 	invocation_type = "none"
 	proj_lifespan = 10
@@ -158,11 +158,11 @@
 
 	school = "conjuration"
 	charge_max = 200
-	clothes_req = 0
+	clothes_req = FALSE
 	invocation = "none"
 	invocation_type = "none"
 	range = -1
-	include_user = 1
+	include_user = TRUE
 	cooldown_min = 20 //25 deciseconds reduction per rank
 
 	smoke_spread = 3

--- a/code/modules/spells/spell_types/devil.dm
+++ b/code/modules/spells/spell_types/devil.dm
@@ -2,9 +2,9 @@
 	name = "Summon Pitchfork"
 	desc = "A devil's weapon of choice.  Use this to summon/unsummon your pitchfork."
 	invocation_type = "none"
-	include_user = 1
+	include_user = TRUE
 	range = -1
-	clothes_req = 0
+	clothes_req = FALSE
 	item_type = /obj/item/twohanded/pitchfork/demonic
 
 	school = "conjuration"
@@ -35,9 +35,9 @@
 	desc = "Skip making a contract by hand, just do it by magic."
 	invocation_type = "whisper"
 	invocation = "Just sign on the dotted line."
-	include_user = 0
+	include_user = FALSE
 	range = 5
-	clothes_req = 0
+	clothes_req = FALSE
 
 	school = "conjuration"
 	charge_max = 150
@@ -79,7 +79,7 @@
 
 	school = "evocation"
 	charge_max = 80
-	clothes_req = 0
+	clothes_req = FALSE
 	invocation = "Your very soul will catch fire!"
 	invocation_type = "shout"
 	range = 2
@@ -92,15 +92,15 @@
 	name = "Infernal Jaunt"
 	desc = "Use hellfire to phase out of existence."
 	charge_max = 200
-	clothes_req = 0
+	clothes_req = FALSE
 	selection_type = "range"
 	range = -1
 	cooldown_min = 0
 	overlay = null
-	include_user = 1
+	include_user = TRUE
 	action_icon_state = "jaunt"
 	action_background_icon_state = "bg_demon"
-	phase_allowed = 1
+	phase_allowed = TRUE
 
 /obj/effect/proc_holder/spell/targeted/infernal_jaunt/cast(list/targets, mob/living/user = usr)
 	if(istype(user))
@@ -149,7 +149,7 @@
 	ExtinguishMob()
 	forceMove(holder)
 	holder = holder
-	notransform = 0
+	notransform = FALSE
 	fakefireextinguish()
 
 /mob/living/proc/infernalphasein()
@@ -167,17 +167,17 @@
 	name = "Sin Touch"
 	desc = "Subtly encourage someone to sin."
 	charge_max = 1800
-	clothes_req = 0
+	clothes_req = FALSE
 	selection_type = "range"
 	range = 2
 	cooldown_min = 0
 	overlay = null
-	include_user = 0
+	include_user = FALSE
 	action_icon = 'icons/mob/actions/actions_cult.dmi'
 	action_icon_state = "sintouch"
 	action_background_icon_state = "bg_demon"
-	phase_allowed = 0
-	random_target = 1
+	phase_allowed = FALSE
+	random_target = TRUE
 	random_target_priority = TARGET_RANDOM
 	max_targets = 3
 	invocation = "TASTE SIN AND INDULGE!!"
@@ -204,9 +204,9 @@
 /obj/effect/proc_holder/spell/targeted/summon_dancefloor
 	name = "Summon Dancefloor"
 	desc = "When what a Devil really needs is funk."
-	include_user = 1
+	include_user = TRUE
 	range = -1
-	clothes_req = 0
+	clothes_req = FALSE
 
 	school = "conjuration"
 	charge_max = 10

--- a/code/modules/spells/spell_types/devil_boons.dm
+++ b/code/modules/spells/spell_types/devil_boons.dm
@@ -2,9 +2,9 @@
 	name = "Summon wealth"
 	desc = "The reward for selling your soul."
 	invocation_type = "none"
-	include_user = 1
+	include_user = TRUE
 	range = -1
-	clothes_req = 0
+	clothes_req = FALSE
 	school = "conjuration"
 	charge_max = 100
 	cooldown_min = 10
@@ -30,9 +30,9 @@
 	name = "Distant vision"
 	desc = "The reward for selling your soul."
 	invocation_type = "none"
-	include_user = 1
+	include_user = TRUE
 	range = -1
-	clothes_req = 0
+	clothes_req = FALSE
 	charge_max = 50
 	cooldown_min = 10
 	action_icon = 'icons/mob/actions/actions_silicon.dmi'
@@ -49,9 +49,9 @@
 	name = "Summon Friend"
 	desc = "The reward for selling your soul."
 	invocation_type = "none"
-	include_user = 1
+	include_user = TRUE
 	range = -1
-	clothes_req = 0
+	clothes_req = FALSE
 	charge_max = 50
 	cooldown_min = 10
 	action_icon = 'icons/mob/actions/actions_spells.dmi'

--- a/code/modules/spells/spell_types/ethereal_jaunt.dm
+++ b/code/modules/spells/spell_types/ethereal_jaunt.dm
@@ -1,16 +1,16 @@
 /obj/effect/proc_holder/spell/targeted/ethereal_jaunt
 	name = "Ethereal Jaunt"
-	desc = "This spell creates your ethereal form, temporarily making you invisible and able to pass through walls."
+	desc = "This spell turns your form ethereal, temporarily making you invisible and able to pass through walls."
 
 	school = "transmutation"
 	charge_max = 300
-	clothes_req = 1
+	clothes_req = TRUE
 	invocation = "none"
 	invocation_type = "none"
 	range = -1
 	cooldown_min = 100 //50 deciseconds reduction per rank
-	include_user = 1
-	nonabstract_req = 1
+	include_user = TRUE
+	nonabstract_req = TRUE
 	var/jaunt_duration = 50 //in deciseconds
 	var/jaunt_in_time = 5
 	var/jaunt_in_type = /obj/effect/temp_visual/wizard
@@ -66,7 +66,7 @@
 	name = "water"
 	icon = 'icons/effects/effects.dmi'
 	icon_state = "nothing"
-	var/reappearing = 0
+	var/reappearing = FALSE
 	var/movedelay = 0
 	var/movespeed = 2
 	density = FALSE

--- a/code/modules/spells/spell_types/forcewall.dm
+++ b/code/modules/spells/spell_types/forcewall.dm
@@ -1,15 +1,15 @@
 /obj/effect/proc_holder/spell/targeted/forcewall
 	name = "Forcewall"
-	desc = "Create a magical barrier that only you can pass through. Does not require wizard garb."
+	desc = "Create a magical barrier that only you can pass through."
 	school = "transmutation"
 	charge_max = 100
-	clothes_req = 0
+	clothes_req = FALSE
 	invocation = "TARCOL MINTI ZHERI"
 	invocation_type = "shout"
 	sound = 'sound/magic/forcewall.ogg'
 	action_icon_state = "shield"
 	range = -1
-	include_user = 1
+	include_user = TRUE
 	cooldown_min = 50 //12 deciseconds reduction per rank
 	var/wall_type = /obj/effect/forcefield/wizard
 

--- a/code/modules/spells/spell_types/infinite_guns.dm
+++ b/code/modules/spells/spell_types/infinite_guns.dm
@@ -1,13 +1,13 @@
 /obj/effect/proc_holder/spell/targeted/infinite_guns
 	name = "Lesser Summon Guns"
-	desc = "Why reload when you have infinite guns? Summons an unending stream of bolt action rifles. Requires both hands free to use. Learning this spell makes you unable to learn Arcane Barrage."
+	desc = "Why reload when you have infinite guns? Summons an unending stream of bolt action rifles that deal little damage, but will knock targets down. Requires both hands free to use. Learning this spell makes you unable to learn Arcane Barrage."
 	invocation_type = "none"
-	include_user = 1
+	include_user = TRUE
 	range = -1
 
 	school = "conjuration"
 	charge_max = 750
-	clothes_req = 1
+	clothes_req = TRUE
 	cooldown_min = 10 //Gun wizard
 	action_icon_state = "bolt_action"
 	var/summon_path = /obj/item/gun/ballistic/shotgun/boltaction/enchanted
@@ -22,6 +22,6 @@
 
 /obj/effect/proc_holder/spell/targeted/infinite_guns/arcane_barrage
 	name = "Arcane Barrage"
-	desc = "Fire a torrent of arcane energy at your foes with this (powerful) spell. Requires both hands free to use. Learning this spell makes you unable to learn Lesser Summon Gun."
+	desc = "Fire a torrent of arcane energy at your foes with this (powerful) spell. Deals much more damage than Lesser Summon Guns, but won't knock targets down. Requires both hands free to use. Learning this spell makes you unable to learn Lesser Summon Gun."
 	action_icon_state = "arcane_barrage"
 	summon_path = /obj/item/gun/ballistic/shotgun/boltaction/enchanted/arcane_barrage

--- a/code/modules/spells/spell_types/knock.dm
+++ b/code/modules/spells/spell_types/knock.dm
@@ -1,10 +1,10 @@
 /obj/effect/proc_holder/spell/aoe_turf/knock
 	name = "Knock"
-	desc = "This spell opens nearby doors and does not require wizard garb."
+	desc = "This spell opens nearby doors and closets."
 
 	school = "transmutation"
 	charge_max = 100
-	clothes_req = 0
+	clothes_req = FALSE
 	invocation = "AULIE OXIN FIERA"
 	invocation_type = "whisper"
 	range = 3

--- a/code/modules/spells/spell_types/lichdom.dm
+++ b/code/modules/spells/spell_types/lichdom.dm
@@ -8,14 +8,14 @@
 	becoming a lich destroys all internal organs except the brain."
 	school = "necromancy"
 	charge_max = 10
-	clothes_req = 0
-	centcom_cancast = 0
+	clothes_req = FALSE
+	centcom_cancast = FALSE
 	invocation = "NECREM IMORTIUM!"
 	invocation_type = "shout"
 	range = -1
 	level_max = 0 //cannot be improved
 	cooldown_min = 10
-	include_user = 1
+	include_user = TRUE
 
 	action_icon = 'icons/mob/actions/actions_spells.dmi'
 	action_icon_state = "skeleton"

--- a/code/modules/spells/spell_types/lightning.dm
+++ b/code/modules/spells/spell_types/lightning.dm
@@ -1,16 +1,16 @@
 /obj/effect/proc_holder/spell/targeted/tesla
 	name = "Tesla Blast"
-	desc = "Blast lightning at your foes!"
+	desc = "Charge up a tesla arc and release it at a random nearby target! The arc jumps between targets and can knock them out."
 	charge_type = "recharge"
 	charge_max	= 300
-	clothes_req = 1
+	clothes_req = TRUE
 	invocation = "UN'LTD P'WAH!"
 	invocation_type = "shout"
 	range = 7
 	cooldown_min = 30
 	selection_type = "view"
-	random_target = 1
-	var/ready = 0
+	random_target = TRUE
+	var/ready = FALSE
 	var/static/mutable_appearance/halo
 	var/sound/Snd // so far only way i can think of to stop a sound, thank MSO for the idea.
 
@@ -19,10 +19,10 @@
 /obj/effect/proc_holder/spell/targeted/tesla/Click()
 	if(!ready && cast_check())
 		StartChargeup()
-	return 1
+	return TRUE
 
 /obj/effect/proc_holder/spell/targeted/tesla/proc/StartChargeup(mob/user = usr)
-	ready = 1
+	ready = TRUE
 	to_chat(user, "<span class='notice'>You start gathering the power.</span>")
 	Snd = new/sound('sound/magic/lightning_chargeup.ogg',channel = 7)
 	halo = halo || mutable_appearance('icons/effects/effects.dmi', "electricity", EFFECTS_LAYER)
@@ -37,7 +37,7 @@
 		revert_cast(user, 0)
 
 /obj/effect/proc_holder/spell/targeted/tesla/proc/Reset(mob/user = usr)
-	ready = 0
+	ready = FALSE
 	user.cut_overlay(halo)
 
 /obj/effect/proc_holder/spell/targeted/tesla/revert_cast(mob/user = usr, message = 1)
@@ -47,7 +47,7 @@
 	..()
 
 /obj/effect/proc_holder/spell/targeted/tesla/cast(list/targets, mob/user = usr)
-	ready = 0
+	ready = FALSE
 	var/mob/living/carbon/target = targets[1]
 	Snd=sound(null, repeat = 0, wait = 1, channel = Snd.channel) //byond, why you suck?
 	playsound(get_turf(user),Snd,50,0)// Sorry MrPerson, but the other ways just didn't do it the way i needed to work, this is the only way.

--- a/code/modules/spells/spell_types/lightning.dm
+++ b/code/modules/spells/spell_types/lightning.dm
@@ -1,6 +1,6 @@
 /obj/effect/proc_holder/spell/targeted/tesla
 	name = "Tesla Blast"
-	desc = "Charge up a tesla arc and release it at a random nearby target! The arc jumps between targets and can knock them out."
+	desc = "Charge up a tesla arc and release it at a random nearby target! You can move freely while it charges. The arc jumps between targets and can knock them down."
 	charge_type = "recharge"
 	charge_max	= 300
 	clothes_req = TRUE

--- a/code/modules/spells/spell_types/mime.dm
+++ b/code/modules/spells/spell_types/mime.dm
@@ -8,10 +8,10 @@
 	invocation_emote_self = "<span class='notice'>You form a wall in front of yourself.</span>"
 	summon_lifespan = 300
 	charge_max = 300
-	clothes_req = 0
+	clothes_req = FALSE
 	range = 0
 	cast_sound = null
-	human_req = 1
+	human_req = TRUE
 
 	action_icon_state = "mime"
 	action_background_icon_state = "bg_mime"
@@ -32,11 +32,11 @@
 	desc = "Make or break a vow of silence."
 	school = "mime"
 	panel = "Mime"
-	clothes_req = 0
-	human_req = 1
+	clothes_req = FALSE
+	human_req = TRUE
 	charge_max = 3000
 	range = -1
-	include_user = 1
+	include_user = TRUE
 
 	action_icon_state = "mime"
 	action_background_icon_state = "bg_mime"
@@ -75,9 +75,9 @@
 	invocation_emote_self = "<span class='notice'>You form a blockade in front of yourself.</span>"
 	charge_max = 600
 	sound =  null
-	clothes_req = 0
+	clothes_req = FALSE
 	range = -1
-	include_user = 1
+	include_user = TRUE
 
 	action_icon_state = "mime"
 	action_background_icon_state = "bg_mime"
@@ -98,7 +98,7 @@
 	school = "mime"
 	panel = "Mime"
 	charge_max = 300
-	clothes_req = 0
+	clothes_req = FALSE
 	invocation_type = "emote"
 	invocation_emote_self = "<span class='dangers'>You fire your finger gun!</span>"
 	range = 20

--- a/code/modules/spells/spell_types/mind_transfer.dm
+++ b/code/modules/spells/spell_types/mind_transfer.dm
@@ -4,7 +4,7 @@
 
 	school = "transmutation"
 	charge_max = 600
-	clothes_req = 0
+	clothes_req = FALSE
 	invocation = "GIN'YU CAPAN"
 	invocation_type = "whisper"
 	range = 1

--- a/code/modules/spells/spell_types/projectile.dm
+++ b/code/modules/spells/spell_types/projectile.dm
@@ -9,7 +9,7 @@
 	var/proj_icon_state = "spell"
 	var/proj_name = "a spell projectile"
 
-	var/proj_trail = 0 //if it leaves a trail
+	var/proj_trail = FALSE //if it leaves a trail
 	var/proj_trail_lifespan = 0 //deciseconds
 	var/proj_trail_icon = 'icons/obj/wizard.dmi'
 	var/proj_trail_icon_state = "trail"
@@ -17,10 +17,10 @@
 
 	var/proj_type = "/obj/effect/proc_holder/spell/targeted" //IMPORTANT use only subtypes of this
 
-	var/proj_lingering = 0 //if it lingers or disappears upon hitting an obstacle
-	var/proj_homing = 1 //if it follows the target
-	var/proj_insubstantial = 0 //if it can pass through dense objects or not
-	var/proj_trigger_range = 0 //the range from target at which the projectile triggers cast(target)
+	var/proj_lingering = FALSE //if it lingers or disappears upon hitting an obstacle
+	var/proj_homing = TRUE //if it follows the target
+	var/proj_insubstantial = FALSE //if it can pass through dense objects or not
+	var/proj_trigger_range = FALSE //the range from target at which the projectile triggers cast(target)
 
 	var/proj_lifespan = 15 //in deciseconds * proj_step_delay
 	var/proj_step_delay = 1 //lower = faster

--- a/code/modules/spells/spell_types/rod_form.dm
+++ b/code/modules/spells/spell_types/rod_form.dm
@@ -1,12 +1,12 @@
 /obj/effect/proc_holder/spell/targeted/rod_form
 	name = "Rod Form"
 	desc = "Take on the form of an immovable rod, destroying all in your path."
-	clothes_req = 1
-	human_req = 0
+	clothes_req = TRUE
+	human_req = FALSE
 	charge_max = 250
 	cooldown_min = 100
 	range = -1
-	include_user = 1
+	include_user = TRUE
 	invocation = "CLANG!"
 	invocation_type = "shout"
 	action_icon_state = "immrod"
@@ -20,7 +20,7 @@
 		W.damage_bonus += spell_level * 20 //You do more damage when you upgrade the spell
 		W.start_turf = start
 		M.forceMove(W)
-		M.notransform = 1
+		M.notransform = TRUE
 		M.status_flags |= GODMODE
 
 //Wizard Version of the Immovable Rod
@@ -40,7 +40,7 @@
 /obj/effect/immovablerod/wizard/Destroy()
 	if(wizard)
 		wizard.status_flags &= ~GODMODE
-		wizard.notransform = 0
+		wizard.notransform = FALSE
 		wizard.forceMove(get_turf(src))
 	return ..()
 

--- a/code/modules/spells/spell_types/rod_form.dm
+++ b/code/modules/spells/spell_types/rod_form.dm
@@ -1,6 +1,6 @@
 /obj/effect/proc_holder/spell/targeted/rod_form
 	name = "Rod Form"
-	desc = "Take on the form of an immovable rod, destroying all in your path."
+	desc = "Take on the form of an immovable rod, destroying all in your path. Purchasing this spell multiple times will also increase the rod's damage and travel range."
 	clothes_req = TRUE
 	human_req = FALSE
 	charge_max = 250

--- a/code/modules/spells/spell_types/santa.dm
+++ b/code/modules/spells/spell_types/santa.dm
@@ -4,7 +4,7 @@
 	desc = "This spell lets you reach into S-space and retrieve presents! Yay!"
 	school = "santa"
 	charge_max = 600
-	clothes_req = 0
+	clothes_req = FALSE
 	invocation = "HO HO HO"
 	invocation_type = "shout"
 	range = 3

--- a/code/modules/spells/spell_types/shadow_walk.dm
+++ b/code/modules/spells/spell_types/shadow_walk.dm
@@ -2,11 +2,11 @@
 	name = "Shadow Walk"
 	desc = "Grants unlimited movement in darkness."
 	charge_max = 0
-	clothes_req = 0
-	phase_allowed = 1
+	clothes_req = FALSE
+	phase_allowed = TRUE
 	selection_type = "range"
 	range = -1
-	include_user = 1
+	include_user = TRUE
 	cooldown_min = 0
 	overlay = null
 	action_icon = 'icons/mob/actions/actions_minor_antag.dmi'
@@ -38,7 +38,7 @@
 	name = "darkness"
 	icon = 'icons/effects/effects.dmi'
 	icon_state = "nothing"
-	var/canmove = 1
+	var/canmove = TRUE
 	var/mob/living/jaunter
 	density = FALSE
 	anchored = TRUE

--- a/code/modules/spells/spell_types/shapeshift.dm
+++ b/code/modules/spells/spell_types/shapeshift.dm
@@ -1,12 +1,12 @@
 /obj/effect/proc_holder/spell/targeted/shapeshift
 	name = "Shapechange"
 	desc = "Take on the shape of another for a time to use their natural abilities. Once you've made your choice it cannot be changed."
-	clothes_req = 0
-	human_req = 0
+	clothes_req = FALSE
+	human_req = FALSE
 	charge_max = 200
 	cooldown_min = 50
 	range = -1
-	include_user = 1
+	include_user = TRUE
 	invocation = "RAC'WA NO!"
 	invocation_type = "shout"
 	action_icon_state = "shapeshift"
@@ -60,8 +60,8 @@
 	var/mob/living/shape = new shapeshift_type(caster.loc)
 	H = new(shape,src,caster)
 
-	clothes_req = 0
-	human_req = 0
+	clothes_req = FALSE
+	human_req = FALSE
 
 /obj/effect/proc_holder/spell/targeted/shapeshift/proc/Restore(mob/living/shape)
 	var/obj/shapeshift_holder/H = locate() in shape

--- a/code/modules/spells/spell_types/spacetime_distortion.dm
+++ b/code/modules/spells/spell_types/spacetime_distortion.dm
@@ -1,6 +1,6 @@
 /obj/effect/proc_holder/spell/spacetime_dist
 	name = "Spacetime Distortion"
-	desc = "Entangle the strings of spacetime to deny easy movement around you. The strings vibrate..."
+	desc = "Entangle the strings of space-time to deny easy movement in an area around you. The strings vibrate..."
 	charge_max = 300
 	var/duration = 150
 	range = 7

--- a/code/modules/spells/spell_types/spacetime_distortion.dm
+++ b/code/modules/spells/spell_types/spacetime_distortion.dm
@@ -1,6 +1,6 @@
 /obj/effect/proc_holder/spell/spacetime_dist
 	name = "Spacetime Distortion"
-	desc = "Entangle the strings of space-time to deny easy movement in an area around you. The strings vibrate..."
+	desc = "Entangle the strings of space-time in an area around you, randomizing the layout and making proper movement impossible. The strings vibrate..."
 	charge_max = 300
 	var/duration = 150
 	range = 7

--- a/code/modules/spells/spell_types/summonitem.dm
+++ b/code/modules/spells/spell_types/summonitem.dm
@@ -3,13 +3,13 @@
 	desc = "This spell can be used to recall a previously marked item to your hand from anywhere in the universe."
 	school = "transmutation"
 	charge_max = 100
-	clothes_req = 0
+	clothes_req = FALSE
 	invocation = "GAR YOK"
 	invocation_type = "whisper"
 	range = -1
 	level_max = 0 //cannot be improved
 	cooldown_min = 100
-	include_user = 1
+	include_user = TRUE
 
 	var/obj/marked_item
 

--- a/code/modules/spells/spell_types/the_traps.dm
+++ b/code/modules/spells/spell_types/the_traps.dm
@@ -1,11 +1,11 @@
 /obj/effect/proc_holder/spell/aoe_turf/conjure/the_traps
 	name = "The Traps!"
-	desc = "Summon a number of traps to confuse and knockdown your enemies, and possibly you."
+	desc = "Summon a number of traps around you. They will damage and enrage any enemies that step on them."
 
 	charge_max = 250
 	cooldown_min = 50
 
-	clothes_req = 1
+	clothes_req = TRUE
 	invocation = "CAVERE INSIDIAS"
 	invocation_type = "shout"
 	range = 3

--- a/code/modules/spells/spell_types/touch_attacks.dm
+++ b/code/modules/spells/spell_types/touch_attacks.dm
@@ -2,7 +2,7 @@
 	var/hand_path = /obj/item/melee/touch_attack
 	var/obj/item/melee/touch_attack/attached_hand = null
 	invocation_type = "none" //you scream on connecting, not summoning
-	include_user = 1
+	include_user = TRUE
 	range = -1
 
 /obj/effect/proc_holder/spell/targeted/touch/proc/remove_hand(recharge = FALSE)
@@ -54,7 +54,7 @@
 
 	school = "evocation"
 	charge_max = 600
-	clothes_req = 1
+	clothes_req = TRUE
 	cooldown_min = 200 //100 deciseconds reduction per rank
 
 	action_icon_state = "gib"
@@ -66,7 +66,7 @@
 
 	school = "transmutation"
 	charge_max = 600
-	clothes_req = 1
+	clothes_req = TRUE
 	cooldown_min = 200 //100 deciseconds reduction per rank
 
 	action_icon_state = "statue"

--- a/code/modules/spells/spell_types/turf_teleport.dm
+++ b/code/modules/spells/spell_types/turf_teleport.dm
@@ -1,13 +1,13 @@
 /obj/effect/proc_holder/spell/targeted/turf_teleport
 	name = "Turf Teleport"
 	desc = "This spell teleports the target to the turf in range."
-	nonabstract_req = 1
+	nonabstract_req = TRUE
 
 	var/inner_tele_radius = 1
 	var/outer_tele_radius = 2
 
-	var/include_space = 0 //whether it includes space tiles in possible teleport locations
-	var/include_dense = 0 //whether it includes dense tiles in possible teleport locations
+	var/include_space = FALSE //whether it includes space tiles in possible teleport locations
+	var/include_dense = FALSE //whether it includes dense tiles in possible teleport locations
 	var/sound1 = 'sound/weapons/zapbang.ogg'
 	var/sound2 = 'sound/weapons/zapbang.ogg'
 

--- a/code/modules/spells/spell_types/voice_of_god.dm
+++ b/code/modules/spells/spell_types/voice_of_god.dm
@@ -4,7 +4,7 @@
 	charge_max = 1200 //variable
 	cooldown_min = 0
 	level_max = 1
-	clothes_req = 0
+	clothes_req = FALSE
 	action_icon = 'icons/mob/actions/actions_items.dmi'
 	action_icon_state = "voice_of_god"
 	var/command

--- a/code/modules/spells/spell_types/wizard.dm
+++ b/code/modules/spells/spell_types/wizard.dm
@@ -4,7 +4,7 @@
 
 	school = "evocation"
 	charge_max = 200
-	clothes_req = 1
+	clothes_req = TRUE
 	invocation = "FORTI GY AMA"
 	invocation_type = "shout"
 	range = 7
@@ -20,7 +20,7 @@
 	proj_lifespan = 20
 	proj_step_delay = 5
 
-	proj_trail = 1
+	proj_trail = TRUE
 	proj_trail_lifespan = 5
 	proj_trail_icon_state = "magicmd"
 
@@ -37,11 +37,11 @@
 
 	school = "transmutation"
 	charge_max = 400
-	clothes_req = 1
+	clothes_req = TRUE
 	invocation = "BIRUZ BENNAR"
 	invocation_type = "shout"
 	range = -1
-	include_user = 1
+	include_user = TRUE
 
 	mutations = list(LASEREYES, HULK)
 	duration = 300
@@ -53,15 +53,15 @@
 
 /obj/effect/proc_holder/spell/targeted/smoke
 	name = "Smoke"
-	desc = "This spell spawns a cloud of choking smoke at your location and does not require wizard garb."
+	desc = "This spell spawns a cloud of choking smoke at your location."
 
 	school = "conjuration"
 	charge_max = 120
-	clothes_req = 0
+	clothes_req = FALSE
 	invocation = "none"
 	invocation_type = "none"
 	range = -1
-	include_user = 1
+	include_user = TRUE
 	cooldown_min = 20 //25 deciseconds reduction per rank
 
 	smoke_spread = 2
@@ -76,11 +76,11 @@
 
 	school = "conjuration"
 	charge_max = 360
-	clothes_req = 0
+	clothes_req = FALSE
 	invocation = "none"
 	invocation_type = "none"
 	range = -1
-	include_user = 1
+	include_user = TRUE
 
 	smoke_spread = 1
 	smoke_amt = 2
@@ -91,11 +91,11 @@
 	name = "Disable Tech"
 	desc = "This spell disables all weapons, cameras and most other technology in range."
 	charge_max = 400
-	clothes_req = 1
+	clothes_req = TRUE
 	invocation = "NEC CANTIO"
 	invocation_type = "shout"
 	range = -1
-	include_user = 1
+	include_user = TRUE
 	cooldown_min = 200 //50 deciseconds reduction per rank
 
 	emp_heavy = 6
@@ -108,11 +108,11 @@
 
 	school = "abjuration"
 	charge_max = 20
-	clothes_req = 1
+	clothes_req = TRUE
 	invocation = "none"
 	invocation_type = "none"
 	range = -1
-	include_user = 1
+	include_user = TRUE
 	cooldown_min = 5 //4 deciseconds reduction per rank
 
 
@@ -130,20 +130,20 @@
 	name = "quickstep"
 
 	charge_max = 100
-	clothes_req = 0
-	cult_req = 1
+	clothes_req = FALSE
+	clothes_req = TRUE
 
 /obj/effect/proc_holder/spell/targeted/area_teleport/teleport
 	name = "Teleport"
-	desc = "This spell teleports you to a type of area of your selection."
+	desc = "This spell teleports you to an area of your selection."
 
 	school = "abjuration"
 	charge_max = 600
-	clothes_req = 1
+	clothes_req = TRUE
 	invocation = "SCYAR NILA"
 	invocation_type = "shout"
 	range = -1
-	include_user = 1
+	include_user = TRUE
 	cooldown_min = 200 //100 deciseconds reduction per rank
 
 	smoke_spread = 1
@@ -155,7 +155,7 @@
 	name = "Stop Time"
 	desc = "This spell stops time for everyone except for you, allowing you to move freely while your enemies and even projectiles are frozen."
 	charge_max = 500
-	clothes_req = 1
+	clothes_req = TRUE
 	invocation = "TOKI WO TOMARE"
 	invocation_type = "shout"
 	range = 0
@@ -171,7 +171,7 @@
 
 	school = "conjuration"
 	charge_max = 1200
-	clothes_req = 1
+	clothes_req = TRUE
 	invocation = "NOUK FHUNMM SACP RISSKA"
 	invocation_type = "shout"
 	range = 1
@@ -186,7 +186,7 @@
 
 	school = "conjuration"
 	charge_max = 600
-	clothes_req = 0
+	clothes_req = FALSE
 	invocation = "none"
 	invocation_type = "none"
 	range = 0
@@ -203,7 +203,7 @@
 
 	school = "conjuration"
 	charge_max = 1200
-	clothes_req = 0
+	clothes_req = FALSE
 	invocation = "IA IA"
 	invocation_type = "shout"
 	summon_amt = 10
@@ -214,11 +214,11 @@
 
 /obj/effect/proc_holder/spell/targeted/trigger/blind
 	name = "Blind"
-	desc = "This spell temporarily blinds a single person and does not require wizard garb."
+	desc = "This spell temporarily blinds a single target."
 
 	school = "transmutation"
 	charge_max = 300
-	clothes_req = 0
+	clothes_req = FALSE
 	invocation = "STI KALY"
 	invocation_type = "whisper"
 	message = "<span class='notice'>Your eyes cry out in pain!</span>"
@@ -230,7 +230,7 @@
 
 /obj/effect/proc_holder/spell/aoe_turf/conjure/creature/cult
 	name = "Summon Creatures (DANGEROUS)"
-	cult_req = 1
+	clothes_req = TRUE
 	charge_max = 5000
 	summon_amt = 2
 
@@ -249,7 +249,7 @@
 	name = "Repulse"
 	desc = "This spell throws everything around the user away."
 	charge_max = 400
-	clothes_req = 1
+	clothes_req = TRUE
 	invocation = "GITTAH WEIGH"
 	invocation_type = "shout"
 	range = 5
@@ -302,7 +302,7 @@
 	desc = "Throw back attackers with a sweep of your tail."
 	sound = 'sound/magic/tail_swing.ogg'
 	charge_max = 150
-	clothes_req = 0
+	clothes_req = FALSE
 	range = 2
 	cooldown_min = 150
 	invocation_type = "none"
@@ -323,12 +323,12 @@
 	name = "Sacred Flame"
 	desc = "Makes everyone around you more flammable, and lights yourself on fire."
 	charge_max = 60
-	clothes_req = 0
+	clothes_req = FALSE
 	invocation = "FI'RAN DADISKO"
 	invocation_type = "shout"
 	max_targets = 0
 	range = 6
-	include_user = 1
+	include_user = TRUE
 	selection_type = "view"
 	action_icon_state = "sacredflame"
 	sound = 'sound/magic/fireball.ogg'
@@ -346,7 +346,7 @@
 /obj/effect/proc_holder/spell/targeted/conjure_item/spellpacket
 	name = "Thrown Lightning"
 	desc = "Forged from eldrich energies, a packet of pure power, known as a spell packet will appear in your hand, that when thrown will stun the target."
-	clothes_req = 1
+	clothes_req = TRUE
 	item_type = /obj/item/spellpacket/lightningbolt
 	charge_max = 10
 
@@ -357,7 +357,7 @@
 
 /obj/item/spellpacket/lightningbolt
 	name = "\improper Lightning bolt Spell Packet"
-	desc = "Some birdseed wrapped in cloth that somehow crackles with electricity."
+	desc = "Some birdseed wrapped in cloth that crackles with electricity."
 	icon = 'icons/obj/toy.dmi'
 	icon_state = "snappop"
 	w_class = WEIGHT_CLASS_TINY
@@ -370,7 +370,7 @@
 				M.electrocute_act(80, src, illusion = 1)
 		qdel(src)
 
-/obj/item/spellpacket/lightningbolt/throw_at(atom/target, range, speed, mob/thrower, spin=1, diagonals_first = 0, datum/callback/callback)
+/obj/item/spellpacket/lightningbolt/throw_at(atom/target, range, speed, mob/thrower, spin=TRUE, diagonals_first = FALSE, datum/callback/callback)
 	. = ..()
 	if(ishuman(thrower))
 		var/mob/living/carbon/human/H = thrower

--- a/code/modules/spells/spell_types/wizard.dm
+++ b/code/modules/spells/spell_types/wizard.dm
@@ -370,7 +370,7 @@
 				M.electrocute_act(80, src, illusion = 1)
 		qdel(src)
 
-/obj/item/spellpacket/lightningbolt/throw_at(atom/target, range, speed, mob/thrower, spin=TRUE, diagonals_first = FALSE, datum/callback/callback)
+/obj/item/spellpacket/lightningbolt/throw_at(atom/target, range, speed, mob/thrower, spin=TRUE, diagonals_first = FALSE, datum/callback/callback, force = INFINITY)
 	. = ..()
 	if(ishuman(thrower))
 		var/mob/living/carbon/human/H = thrower


### PR DESCRIPTION
:cl: Denton
spellcheck: Changed a few wizard spell descriptions to better explain what they do.
/:cl:

I changed a few wizard spell descriptions, so the person rolling wizard for the first time in half a year has an idea of what the spells actually do.
Some had "Does not require wizard garb." at the end of their desc, which is pointless since `clothes_req = FALSE` does the same.

Also, replaced a bunch of 0/1 with booleans.