### PR TITLE
Fixex the staff of the locker sometimes gibbing or deleting people

### DIFF
--- a/code/modules/projectiles/projectile/magic.dm
+++ b/code/modules/projectiles/projectile/magic.dm
@@ -345,9 +345,10 @@
 	flag = "magic"
 	var/weld = TRUE
 	var/created = FALSE //prevents creation of more then one locker if it has multiple hits
+	var/locker_suck = TRUE
 
 /obj/item/projectile/magic/locker/prehit(atom/A)
-	if(ismob(A))
+	if(ismob(A) && locker_suck)
 		var/mob/M = A
 		if(M.anti_magic_check())
 			M.visible_message("<span class='warning'>[src] vanishes on contact with [A]!</span>")
@@ -372,6 +373,7 @@
 	return ..()
 
 /obj/item/projectile/magic/locker/Destroy()
+	locker_suck = FALSE
 	for(var/atom/movable/AM in contents)
 		AM.forceMove(get_turf(src))
 	. = ..()
@@ -410,11 +412,6 @@
 			unmagify()
 		else
 			addtimer(CALLBACK(src, .proc/decay), 15 SECONDS)
-
-/obj/structure/closet/decay/contents_explosion(severity, target)
-	for(var/atom/A in contents)
-		A.ex_act(severity/2, target) //Difference is it does half the damage to contents from explosion, to make fireball not completely instakill
-		CHECK_TICK
 
 /obj/structure/closet/decay/proc/unmagify()
 	icon_state = weakened_icon


### PR DESCRIPTION
Halfing severity on locker damage was a horrible mistake, since thats not how that works
Deletion would drop everyone off, but then immidiatly recapture them and delete themselves
Fixes https://github.com/tgstation/tgstation/issues/40292

:cl: Time-Green
fix: staff of the locker no longer gibs or deletes people
/:cl:
Its a web edit, but its a really easy fix
No GBP
EDIT: I meant PRB, not GBP. Apparently someone lied to me about Good Boi Points
