### PR TITLE
Bloodcult Stun Spell Tweaks

### DIFF
--- a/code/__DEFINES/lighting.dm
+++ b/code/__DEFINES/lighting.dm
@@ -1,6 +1,8 @@
 //Bay lighting engine shit, not in /code/modules/lighting because BYOND is being shit about it
 #define LIGHTING_INTERVAL       5 // frequency, in 1/10ths of a second, of the lighting process
 
+#define MINIMUM_USEFUL_LIGHT_RANGE 1.4
+
 #define LIGHTING_FALLOFF        1 // type of falloff to use for lighting; 1 for circular, 2 for square
 #define LIGHTING_LAMBERTIAN     0 // use lambertian shading for light sources
 #define LIGHTING_HEIGHT         1 // height off the ground of light sources on the pseudo-z-axis, you should probably leave this alone

--- a/code/__DEFINES/lighting.dm
+++ b/code/__DEFINES/lighting.dm
@@ -41,6 +41,9 @@
 #define LIGHT_COLOR_PURPLE     "#952CF4" //Light Purple. rgb(149, 44, 244)
 #define LIGHT_COLOR_LAVENDER   "#9B51FF" //Less-saturated light purple. rgb(155, 81, 255)
 
+#define LIGHT_COLOR_HOLY_MAGIC	"#FFF743" //slightly desaturated bright yellow.
+#define LIGHT_COLOR_BLOOD_MAGIC	"#D00000" //deep crimson
+
 //These ones aren't a direct colour like the ones above, because nothing would fit
 #define LIGHT_COLOR_FIRE       "#FAA019" //Warm orange color, leaning strongly towards yellow. rgb(250, 160, 25)
 #define LIGHT_COLOR_LAVA       "#C48A18" //Very warm yellow, leaning slightly towards orange. rgb(196, 138, 24)

--- a/code/game/objects/effects/misc.dm
+++ b/code/game/objects/effects/misc.dm
@@ -66,3 +66,23 @@
 /obj/effect/abstract/marker/at
 	name = "active turf marker"
 
+
+/mob/living/proc/mob_light(_color, _range, _power, _duration)
+	var/obj/effect/dummy/moblight/mob_light_obj = new (src, _color, _range, _power, _duration)
+	return mob_light_obj
+
+/obj/effect/dummy/moblight
+	name = "mob lighting fx"
+	desc = "Tell a coder if you're seeing this."
+	icon_state = "nothing"
+	light_color = "#FFFFFF"
+	light_range = MINIMUM_USEFUL_LIGHT_RANGE
+
+/obj/effect/dummy/moblight/Initialize(mapload, _color, _range, _power, _duration)
+	. = ..()
+	if(!isliving(loc))
+		return INITIALIZE_HINT_QDEL
+	set_light(_range ? _range : light_range, _power ? _power : light_power, _color ? _color : light_color)
+	if(_duration)
+		QDEL_IN(src, _duration)
+

--- a/code/modules/antagonists/cult/blood_magic.dm
+++ b/code/modules/antagonists/cult/blood_magic.dm
@@ -400,7 +400,7 @@
 
 //Stun
 /obj/item/melee/blood_magic/stun
-	name = "Stunning Aura "
+	name = "Stunning Aura"
 	color = RUNE_COLOR_RED
 	invocation = "Fuu ma'jin!"
 
@@ -412,12 +412,29 @@
 		return
 	if(iscultist(user))
 		user.visible_message("<span class='warning'>[user] holds up [user.p_their()] hand, which explodes in a flash of red light!</span>", \
-							 "<span class='cultitalic'>You stun [L] with the spell!</span>")
-		var/obj/item/nullrod/N = locate() in L
-		if(N)
-			target.visible_message("<span class='warning'>[L]'s holy weapon absorbs the light!</span>", \
-								   "<span class='userdanger'>Your holy weapon absorbs the blinding light!</span>")
+							"<span class='cultitalic'>You attempt to stun [L] with the spell!</span>")
+
+		var/obj/effect/dummy/fire/cult_magic/cult_light = new(user)
+		addtimer(CALLBACK(GLOBAL_PROC, .proc/qdel, cult_light), 2)
+
+		var/anti_magic_source = L.anti_magic_check()
+		if(anti_magic_source)
+
+			var/obj/effect/dummy/fire/holy_magic/holy_light = new(L)
+			addtimer(CALLBACK(GLOBAL_PROC, .proc/qdel, holy_light), 85)
+			var/mutable_appearance/forbearance = mutable_appearance('icons/effects/genetics.dmi', "servitude", -MUTATIONS_LAYER)
+			L.add_overlay(forbearance)
+			addtimer(CALLBACK(L, /atom/proc/cut_overlay, forbearance), 85)
+
+			if(istype(anti_magic_source, /obj/item))
+				var/obj/item/ams_object = anti_magic_source
+				target.visible_message("<span class='warning'>[L] starts to glow in a halo of light!</span>", \
+									   "<span class='userdanger'>Your [ams_object.name] begins to glow, emitting a blanket of holy light which surrounds you and protects you from the flash of light!</span>")
+			else
+				target.visible_message("<span class='warning'>[L] starts to glow in a halo of light!</span>", \
+									   "<span class='userdanger'>A feeling of warmth washes over you, rays of holy light surround your body and protect you from the flash of light!</span>")
 		else
+			to_chat(user, "<span class='cultitalic'>In an brilliant flash of red, [L] falls to the ground!</span>")
 			L.Knockdown(160)
 			L.flash_act(1,1)
 			if(issilicon(target))

--- a/code/modules/antagonists/cult/blood_magic.dm
+++ b/code/modules/antagonists/cult/blood_magic.dm
@@ -414,17 +414,15 @@
 		user.visible_message("<span class='warning'>[user] holds up [user.p_their()] hand, which explodes in a flash of red light!</span>", \
 							"<span class='cultitalic'>You attempt to stun [L] with the spell!</span>")
 
-		var/obj/effect/dummy/fire/cult_magic/cult_light = new(user)
-		addtimer(CALLBACK(GLOBAL_PROC, .proc/qdel, cult_light), 2)
+		user.mob_light(_color = LIGHT_COLOR_BLOOD_MAGIC, _range = 3, _duration = 2)
 
 		var/anti_magic_source = L.anti_magic_check()
 		if(anti_magic_source)
 
-			var/obj/effect/dummy/fire/holy_magic/holy_light = new(L)
-			addtimer(CALLBACK(GLOBAL_PROC, .proc/qdel, holy_light), 85)
+			L.mob_light(_color = LIGHT_COLOR_HOLY_MAGIC, _range = 2, _duration = 100)
 			var/mutable_appearance/forbearance = mutable_appearance('icons/effects/genetics.dmi', "servitude", -MUTATIONS_LAYER)
 			L.add_overlay(forbearance)
-			addtimer(CALLBACK(L, /atom/proc/cut_overlay, forbearance), 85)
+			addtimer(CALLBACK(L, /atom/proc/cut_overlay, forbearance), 100)
 
 			if(istype(anti_magic_source, /obj/item))
 				var/obj/item/ams_object = anti_magic_source

--- a/code/modules/atmospherics/environmental/LINDA_fire.dm
+++ b/code/modules/atmospherics/environmental/LINDA_fire.dm
@@ -250,24 +250,9 @@
 /obj/effect/hotspot/singularity_pull()
 	return
 
-/obj/effect/dummy/fire
+/obj/effect/dummy/moblight/fire
 	name = "fire"
-	desc = "OWWWWWW. IT BURNS. Tell a coder if you're seeing this."
-	icon_state = "nothing"
 	light_color = LIGHT_COLOR_FIRE
 	light_range = LIGHT_RANGE_FIRE
-
-/obj/effect/dummy/fire/Initialize()
-	. = ..()
-	if(!isliving(loc))
-		return INITIALIZE_HINT_QDEL
-
-/obj/effect/dummy/fire/cult_magic
-	name = "crimson glow"
-	light_color = LIGHT_COLOR_BLOOD_MAGIC
-
-/obj/effect/dummy/fire/holy_magic
-	name = "holy glow"
-	light_color = LIGHT_COLOR_HOLY_MAGIC
 
 #undef INSUFFICIENT

--- a/code/modules/atmospherics/environmental/LINDA_fire.dm
+++ b/code/modules/atmospherics/environmental/LINDA_fire.dm
@@ -42,7 +42,7 @@
 		active_hotspot.just_spawned = (current_cycle < SSair.times_fired)
 			//remove just_spawned protection if no longer processing this cell
 		SSair.add_to_active(src, 0)
-	else	
+	else
 		var/datum/gas_mixture/heating = air_contents.remove_ratio(exposed_volume/air_contents.volume)
 		heating.temperature = exposed_temperature
 		heating.react()
@@ -261,4 +261,13 @@
 	. = ..()
 	if(!isliving(loc))
 		return INITIALIZE_HINT_QDEL
+
+/obj/effect/dummy/fire/cult_magic
+	name = "crimson glow"
+	light_color = LIGHT_COLOR_BLOOD_MAGIC
+
+/obj/effect/dummy/fire/holy_magic
+	name = "holy glow"
+	light_color = LIGHT_COLOR_HOLY_MAGIC
+
 #undef INSUFFICIENT

--- a/code/modules/lighting/lighting_atom.dm
+++ b/code/modules/lighting/lighting_atom.dm
@@ -1,4 +1,3 @@
-#define MINIMUM_USEFUL_LIGHT_RANGE 1.4
 
 /atom
 	var/light_power = 1 // Intensity of the light.

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -900,7 +900,7 @@
 		on_fire = 1
 		src.visible_message("<span class='warning'>[src] catches fire!</span>", \
 						"<span class='userdanger'>You're set on fire!</span>")
-		new/obj/effect/dummy/fire(src)
+		new/obj/effect/dummy/moblight/fire(src)
 		throw_alert("fire", /obj/screen/alert/fire)
 		update_fire()
 		SEND_SIGNAL(src, COMSIG_LIVING_IGNITED,src)
@@ -911,7 +911,7 @@
 	if(on_fire)
 		on_fire = 0
 		fire_stacks = 0
-		for(var/obj/effect/dummy/fire/F in src)
+		for(var/obj/effect/dummy/moblight/fire/F in src)
 			qdel(F)
 		clear_alert("fire")
 		SEND_SIGNAL(src, COMSIG_CLEAR_MOOD_EVENT, "on_fire")


### PR DESCRIPTION
Updated to use anti_magic_check instead of a nullrod check.

Corrected the stun message showing if the target is immune to the effect.

Added some visual effects (an actual red flash), and a "holy bubble" around the target if they're immune to the effect.

https://i.imgur.com/wd77s8w.gifv

Closes #40285

:cl: ShizCalev
fix: Blood cultists using a stun spell now emit a flash of red light when.... they emit a flash of red light!
fix: Blood cult stun spells now properly check for any holy items on the target mob.
tweak: Targets immune to blood cult stun spells will now glow with holy light for a short duration after.
/:cl: