### PR TITLE
Makes gas sensors fireproof, fixes unneeded resis flags on airlock sensors

### DIFF
--- a/code/game/machinery/airlock_control.dm
+++ b/code/game/machinery/airlock_control.dm
@@ -88,7 +88,7 @@
 	icon = 'icons/obj/airlock_machines.dmi'
 	icon_state = "airlock_sensor_off"
 	name = "airlock sensor"
-	resistance_flags = INDESTRUCTIBLE | LAVA_PROOF | FIRE_PROOF | UNACIDABLE | ACID_PROOF
+	resistance_flags = FIRE_PROOF
 
 	power_channel = ENVIRON
 

--- a/code/game/machinery/computer/atmos_control.dm
+++ b/code/game/machinery/computer/atmos_control.dm
@@ -6,6 +6,7 @@
 	name = "gas sensor"
 	icon = 'icons/obj/stationobjs.dmi'
 	icon_state = "gsensor1"
+	resistance_flags = FIRE_PROOF
 
 	var/on = TRUE
 

--- a/code/game/objects/structures/signs/signs_warning.dm
+++ b/code/game/objects/structures/signs/signs_warning.dm
@@ -45,11 +45,13 @@
 	name = "\improper DANGER: FIRE"
 	desc = "A warning sign which reads 'DANGER: FIRE'."
 	icon_state = "fire"
+	resistance_flags = FIRE_PROOF
 
 /obj/structure/sign/warning/nosmoking
 	name = "\improper NO SMOKING"
 	desc = "A warning sign which reads 'NO SMOKING'."
 	icon_state = "nosmoking2"
+	resistance_flags = FLAMMABLE
 
 /obj/structure/sign/warning/nosmoking/circle
 	icon_state = "nosmoking"

--- a/code/modules/reagents/chemistry/reagents/other_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/other_reagents.dm
@@ -972,7 +972,7 @@
 /datum/reagent/fuel
 	name = "Welding fuel"
 	id = "welding_fuel"
-	description = "Required for welders. Flamable."
+	description = "Required for welders. Flammable."
 	color = "#660000" // rgb: 102, 0, 0
 	taste_description = "gross metal"
 	glass_icon_state = "dr_gibb_glass"
@@ -1245,7 +1245,7 @@
 	L.remove_trait(TRAIT_SLEEPIMMUNE, id)
 	..()
 
-/datum/reagent/stimulum/on_mob_life(mob/living/carbon/M) 
+/datum/reagent/stimulum/on_mob_life(mob/living/carbon/M)
 	M.adjustStaminaLoss(-2*REM, 0)
 	current_cycle++
 	holder.remove_reagent(id, 0.99)		//Gives time for the next tick of life().


### PR DESCRIPTION
Fixes #40227

:cl: ShizCalev
fix: Gas sensors in the incinerator chamber will no longer catch on fire.
fix: Airlock sensors are no longer completely immune to damage
tweak: No smoking signs are now flammable, fire warning signs are now fireproofed
/:cl: