### PR TITLE
Luxury shuttle ticket booth now counts dragged money

### DIFF
--- a/code/modules/shuttle/special.dm
+++ b/code/modules/shuttle/special.dm
@@ -246,6 +246,17 @@
 		if(total_cash >= threshold)
 			break
 
+	if(AM.pulling)
+		if(istype(AM.pulling, /obj/item/coin))
+			var/obj/item/coin/C = AM.pulling
+			total_cash += C.value
+			counted_money += C
+
+		else if(istype(AM.pulling, /obj/item/stack/spacecash))
+			var/obj/item/stack/spacecash/S = AM.pulling
+			total_cash += S.value * S.amount
+			counted_money += S
+
 	if(total_cash >= threshold)
 		for(var/obj/I in counted_money)
 			qdel(I)


### PR DESCRIPTION
[Changelogs]: # (Your PR should contain a detailed changelog of notable changes, titled and categorized appropriately. This includes, new features, sprites, sounds, balance changes, admin tools, map edits, removals, big refactors, config changes, hosting changes and important fixes. An example changelog has been provided below for you to edit. If you need additional help, read https://github.com/tgstation/tgstation/wiki/Changelogs)

:cl: cacogen
add: The luxury shuttle now accepts dragged money. Useful for mobs without hands.
/:cl:

[why]: # (Please add a short description [two lines down] of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.)

Gondola tried to board, couldn't, I stole his money so I could board myself.
