### PR TITLE
Fix the docker build by updating rust

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,9 +14,10 @@ WORKDIR /rust_g
 
 RUN apt-get install -y --no-install-recommends \
     libssl-dev \
-    rustc \
-    cargo \
     pkg-config \
+    curl \
+    gcc-multilib \
+    && curl https://sh.rustup.rs -sSf | sh -s -- -y --default-host i686-unknown-linux-gnu \
     && git init \
     && git remote add origin https://github.com/tgstation/rust-g
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -26,7 +26,7 @@ COPY dependencies.sh .
 RUN /bin/bash -c "source dependencies.sh \
     && git fetch --depth 1 origin \$RUST_G_VERSION" \
     && git checkout FETCH_HEAD \
-    && cargo build --release
+    && ~/.cargo/bin/cargo build --release
 
 FROM build_base as bsql
 


### PR DESCRIPTION
Untested because windows line ending memes

Someone on linux test if possible please

1. Install docker
2. Clone tg, add upstream remote pointing here
```
cd tgstation
git fetch upstream pull/40331/head:pr-40331
git checkout pr-40331
docker build .
```
See if it succeeds