### PR TITLE
[READY] Luxury shuttle charges bank cards

### DIFF
--- a/code/modules/mob/living/carbon/human/human_helpers.dm
+++ b/code/modules/mob/living/carbon/human/human_helpers.dm
@@ -147,3 +147,13 @@
 			return FALSE
 
 	return .
+
+/mob/living/carbon/human/proc/get_bank_account()
+	var/datum/bank_account/account
+	var/obj/item/card/id/I = get_idcard()
+
+	if(I && I.registered_account)
+		account = I.registered_account
+		return account
+
+	return FALSE


### PR DESCRIPTION
:cl: cacogen
add: Luxury shuttle now attempts to charge humans' bank accounts in addition to taking held and dragged money
add: Luxury shuttle now attempts to return change to humans' bank accounts
add: You can now pay for the luxury shuttle in instalments (mostly useful for handless mobs)
tweak: Luxury shuttle ticket booth messages are now spoken, so you can spend loudly
/:cl:

### Other changes:
- Gives the ticket booth a unique name and description
- Gives humans a proc to return their bank account datum, or false if they don't have one

[why]: # (Please add a short description [two lines down] of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.)
### Why:

1. Allows handless mobs to pay with denominations smaller than 500 credits
3. Ticket booth talks because it's better.

### What else I'd like to add:

- [x] Gets money straight from ID
- [ ] ~~Change proc?~~


This originally gave tickets that could be stolen from other players but Goof's economy pull means most people will have the money to board now.