### PR TITLE
ctf flag stays in bearer's hands

### DIFF
--- a/code/modules/awaymissions/capture_the_flag.dm
+++ b/code/modules/awaymissions/capture_the_flag.dm
@@ -42,8 +42,7 @@
 
 /obj/item/twohanded/ctf/process()
 	if(is_ctf_target(loc)) //don't reset from someone's hands.
-		STOP_PROCESSING(SSobj, src)
-		return
+		return PROCESS_KILL
 	if(world.time > reset_cooldown)
 		forceMove(get_turf(src.reset))
 		for(var/mob/M in GLOB.player_list)

--- a/code/modules/awaymissions/capture_the_flag.dm
+++ b/code/modules/awaymissions/capture_the_flag.dm
@@ -41,6 +41,9 @@
 		reset = new reset_path(get_turf(src))
 
 /obj/item/twohanded/ctf/process()
+	if(is_ctf_target(loc)) //don't reset from someone's hands.
+		STOP_PROCESSING(SSobj, src)
+		return
 	if(world.time > reset_cooldown)
 		forceMove(get_turf(src.reset))
 		for(var/mob/M in GLOB.player_list)


### PR DESCRIPTION
Cancel return-to-base countdown if item process()es in a player's hands. 

We have reports that the capture-the-flag banner (`/obj/item/twohanded/ctf`) has been resetting itself to base when in a player's hands, presumably without score. This change ensures the flag stays in hands even if attack_hand somehow didn't get called in getting it to the human.

Fixes #40288