### PR TITLE
Tweak Chemical Grenade Assemblies to Show Beakers

### DIFF
--- a/code/game/objects/items/grenades/chem_grenade.dm
+++ b/code/game/objects/items/grenades/chem_grenade.dm
@@ -29,18 +29,21 @@
 	display_timer = (stage == READY && !nadeassembly)	//show/hide the timer based on assembly state
 	..()
 	if(user.can_see_reagents())
-		var/count = 0
 		if(beakers.len)
 			to_chat(user, "<span class='notice'>You scan the grenade and detect the following reagents:</span>")
 			for(var/obj/item/reagent_containers/glass/G in beakers)
-				var/textcount = thtotext(++count)
 				for(var/datum/reagent/R in G.reagents.reagent_list)
-					to_chat(user, "<span class='notice'>[R.volume] units of [R.name] in the [textcount] beaker.</span>")
+					to_chat(user, "<span class='notice'>[R.volume] units of [R.name] in the [G.name].</span>")
 			if(beakers.len == 1)
 				to_chat(user, "<span class='notice'>You detect no second beaker in the grenade.</span>")
 		else
 			to_chat(user, "<span class='notice'>You scan the grenade, but detect nothing.</span>")
-
+	else if(stage != READY && beakers.len)
+		if(beakers.len == 2 && beakers[1].name == beakers[2].name)
+			to_chat(user, "<span class='notice'>You see two [beakers[1].name]s inside the grenade.</span>")
+		else
+			for(var/obj/item/reagent_containers/glass/G in beakers)
+				to_chat(user, "<span class='notice'>You see a [G.name] inside the grenade.</span>")
 
 /obj/item/grenade/chem_grenade/attack_self(mob/user)
 	if(stage == READY && !active)
@@ -48,7 +51,6 @@
 			nadeassembly.attack_self(user)
 		else
 			..()
-
 
 /obj/item/grenade/chem_grenade/attackby(obj/item/I, mob/user, params)
 	if(istype(I, /obj/item/screwdriver))


### PR DESCRIPTION
:cl: bobbahbrown
add: Unsecured grenade assemblies now show the number and type of beakers inside when not wearing science goggles.
tweak: Science goggles now show the type of beakers inside a grenade assembly.
/:cl:

Manipulating grenade assemblies without science goggles was difficult when it was impossible to determine by examination how many beakers were already inside. Improved the science goggle examination to provide information as to what kind of beakers are inside as well.