### PR TITLE
Fix alien screwdrivers not appearing on toolbelts

### DIFF
--- a/code/game/objects/items/tools/screwdriver.dm
+++ b/code/game/objects/items/tools/screwdriver.dm
@@ -101,6 +101,9 @@
 	toolspeed = 0.1
 	random_color = FALSE
 
+/obj/item/screwdriver/abductor/get_belt_overlay()
+	return mutable_appearance('icons/obj/clothing/belt_overlays.dmi', "screwdriver_nuke")
+
 /obj/item/screwdriver/power
 	name = "hand drill"
 	desc = "A simple powered hand drill. It's fitted with a screw bit."


### PR DESCRIPTION
Fixes  #40090

:cl:
fix: toolbelts will now show alien screwdrivers on the item sprite
/:cl:

There was no icon in belt_overlays.dmi for `"screwdriver_a"`. I'm using `"screwdriver_nuke"` since they're basically all-black.