### PR TITLE
Makes flashes, & flashbangs flash

### DIFF
--- a/code/__DEFINES/lighting.dm
+++ b/code/__DEFINES/lighting.dm
@@ -28,6 +28,7 @@
 
 //Some defines to generalise colours used in lighting.
 //Important note on colors. Colors can end up significantly different from the basic html picture, especially when saturated
+#define LIGHT_COLOR_WHITE		"#FFFFFF"
 #define LIGHT_COLOR_RED        "#FA8282" //Warm but extremely diluted red. rgb(250, 130, 130)
 #define LIGHT_COLOR_GREEN      "#64C864" //Bright but quickly dissipating neon green. rgb(100, 200, 100)
 #define LIGHT_COLOR_BLUE       "#6496FA" //Cold, diluted blue. rgb(100, 150, 250)
@@ -75,3 +76,7 @@
 #define LIGHTING_VIS_UPDATE 1
 #define LIGHTING_CHECK_UPDATE 2
 #define LIGHTING_FORCE_UPDATE 3
+
+#define FLASH_LIGHT_DURATION 2
+#define FLASH_LIGHT_POWER 3
+#define FLASH_LIGHT_RANGE 3.8

--- a/code/__HELPERS/unsorted.dm
+++ b/code/__HELPERS/unsorted.dm
@@ -1469,7 +1469,7 @@ GLOBAL_DATUM_INIT(dview_mob, /mob/dview, new)
 /proc/get_random_drink()
 	var/list/blocked = list(/obj/item/reagent_containers/food/drinks/soda_cans,
 		/obj/item/reagent_containers/food/drinks/bottle
-		)	
+		)
 	return pick(subtypesof(/obj/item/reagent_containers/food/drinks) - blocked)
 
 //For these two procs refs MUST be ref = TRUE format like typecaches!

--- a/code/game/machinery/flasher.dm
+++ b/code/game/machinery/flasher.dm
@@ -7,6 +7,8 @@
 	icon_state = "mflash1"
 	max_integrity = 250
 	integrity_failure = 100
+	light_color = LIGHT_COLOR_WHITE
+	light_power = FLASH_LIGHT_POWER
 	var/obj/item/assembly/flash/handheld/bulb
 	var/id = null
 	var/range = 2 //this is roughly the size of brig cell
@@ -103,6 +105,7 @@
 
 	playsound(src.loc, 'sound/weapons/flash.ogg', 100, 1)
 	flick("[base_state]_flash", src)
+	flash_lighting_fx(FLASH_LIGHT_RANGE, light_power, light_color)
 	last_flash = world.time
 	use_power(1000)
 

--- a/code/game/objects/effects/misc.dm
+++ b/code/game/objects/effects/misc.dm
@@ -67,22 +67,24 @@
 	name = "active turf marker"
 
 
-/mob/living/proc/mob_light(_color, _range, _power, _duration)
-	var/obj/effect/dummy/moblight/mob_light_obj = new (src, _color, _range, _power, _duration)
-	return mob_light_obj
-
-/obj/effect/dummy/moblight
-	name = "mob lighting fx"
+/obj/effect/dummy/lighting_obj
+	name = "lighting fx obj"
 	desc = "Tell a coder if you're seeing this."
 	icon_state = "nothing"
 	light_color = "#FFFFFF"
 	light_range = MINIMUM_USEFUL_LIGHT_RANGE
+	mouse_opacity = MOUSE_OPACITY_TRANSPARENT
 
-/obj/effect/dummy/moblight/Initialize(mapload, _color, _range, _power, _duration)
+/obj/effect/dummy/lighting_obj/Initialize(mapload, _color, _range, _power, _duration)
 	. = ..()
-	if(!isliving(loc))
-		return INITIALIZE_HINT_QDEL
 	set_light(_range ? _range : light_range, _power ? _power : light_power, _color ? _color : light_color)
 	if(_duration)
 		QDEL_IN(src, _duration)
 
+/obj/effect/dummy/lighting_obj/moblight
+	name = "mob lighting fx"
+
+/obj/effect/dummy/lighting_obj/moblight/Initialize(mapload, _color, _range, _power, _duration)
+	. = ..()
+	if(!ismob(loc))
+		return INITIALIZE_HINT_QDEL

--- a/code/game/objects/items/grenades/flashbang.dm
+++ b/code/game/objects/items/grenades/flashbang.dm
@@ -4,6 +4,7 @@
 	item_state = "flashbang"
 	lefthand_file = 'icons/mob/inhands/equipment/security_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/equipment/security_righthand.dmi'
+	var/flashbang_range = 7 //how many tiles away the mob will be stunned.
 
 /obj/item/grenade/flashbang/prime()
 	update_mob()
@@ -12,8 +13,8 @@
 		return
 	do_sparks(rand(5, 9), FALSE, src)
 	playsound(flashbang_turf, 'sound/weapons/flashbang.ogg', 100, TRUE, 8, 0.9)
-	new /obj/effect/dummy/lighting_obj (flashbang_turf, LIGHT_COLOR_WHITE, (world.view + 2), 4, 2)
-	for(var/mob/living/M in get_hearers_in_view(7, flashbang_turf))
+	new /obj/effect/dummy/lighting_obj (flashbang_turf, LIGHT_COLOR_WHITE, (flashbang_range + 2), 4, 2)
+	for(var/mob/living/M in get_hearers_in_view(flashbang_range, flashbang_turf))
 		bang(get_turf(M), M)
 	qdel(src)
 

--- a/code/game/objects/items/grenades/flashbang.dm
+++ b/code/game/objects/items/grenades/flashbang.dm
@@ -10,6 +10,9 @@
 	var/flashbang_turf = get_turf(src)
 	if(!flashbang_turf)
 		return
+	do_sparks(rand(5, 9), FALSE, src)
+	playsound(flashbang_turf, 'sound/weapons/flashbang.ogg', 100, TRUE, 8, 0.9)
+	new /obj/effect/dummy/lighting_obj (flashbang_turf, LIGHT_COLOR_WHITE, (world.view + 2), 4, 2)
 	for(var/mob/living/M in get_hearers_in_view(7, flashbang_turf))
 		bang(get_turf(M), M)
 	qdel(src)
@@ -18,7 +21,6 @@
 	if(M.stat == DEAD)	//They're dead!
 		return
 	M.show_message("<span class='warning'>BANG</span>", 2)
-	playsound(loc, 'sound/weapons/flashbang.ogg', 100, 1)
 	var/distance = max(0,get_dist(get_turf(src),T))
 
 //Flash

--- a/code/modules/assembly/flash.dm
+++ b/code/modules/assembly/flash.dm
@@ -10,6 +10,8 @@
 	w_class = WEIGHT_CLASS_TINY
 	materials = list(MAT_METAL = 300, MAT_GLASS = 300)
 	crit_fail = FALSE     //Is the flash burnt out?
+	light_color = LIGHT_COLOR_WHITE
+	light_power = FLASH_LIGHT_POWER
 	var/times_used = 0 //Number of times it's been used.
 	var/burnout_resistance = 0
 	var/last_used = 0 //last world.time it was used.
@@ -94,6 +96,7 @@
 		return FALSE
 	last_trigger = world.time
 	playsound(src, 'sound/weapons/flash.ogg', 100, TRUE)
+	flash_lighting_fx(FLASH_LIGHT_RANGE, light_power, light_color)
 	times_used++
 	flash_recharge()
 	update_icon(TRUE)

--- a/code/modules/atmospherics/environmental/LINDA_fire.dm
+++ b/code/modules/atmospherics/environmental/LINDA_fire.dm
@@ -250,7 +250,7 @@
 /obj/effect/hotspot/singularity_pull()
 	return
 
-/obj/effect/dummy/moblight/fire
+/obj/effect/dummy/lighting_obj/moblight/fire
 	name = "fire"
 	light_color = LIGHT_COLOR_FIRE
 	light_range = LIGHT_RANGE_FIRE

--- a/code/modules/lighting/lighting_atom.dm
+++ b/code/modules/lighting/lighting_atom.dm
@@ -105,3 +105,31 @@
 			return TRUE
 
 	return ..()
+
+
+/atom/proc/flash_lighting_fx(_range = FLASH_LIGHT_RANGE, _power = FLASH_LIGHT_POWER, _color = LIGHT_COLOR_WHITE, _duration = FLASH_LIGHT_DURATION, _reset_lighting = TRUE)
+	return
+
+/turf/flash_lighting_fx(_range = FLASH_LIGHT_RANGE, _power = FLASH_LIGHT_POWER, _color = LIGHT_COLOR_WHITE, _duration = FLASH_LIGHT_DURATION, _reset_lighting = TRUE)
+	if(!_duration)
+		stack_trace("Lighting FX obj created on a turf without a duration")
+	new /obj/effect/dummy/lighting_obj (src, _color, _range, _power, _duration)
+
+/obj/flash_lighting_fx(_range = FLASH_LIGHT_RANGE, _power = FLASH_LIGHT_POWER, _color = LIGHT_COLOR_WHITE, _duration = FLASH_LIGHT_DURATION, _reset_lighting = TRUE)
+	var/temp_color
+	var/temp_power
+	var/temp_range
+	if(!_reset_lighting) //incase the obj already has a lighting color that you don't want cleared out after, ie computer monitors.
+		temp_color = light_color
+		temp_power = light_power
+		temp_range = light_range
+	set_light(_range, _power, _color)
+	addtimer(CALLBACK(src, /atom/proc/set_light, _reset_lighting ? initial(light_range) : temp_range, _reset_lighting ? initial(light_power) : temp_power, _reset_lighting ? initial(light_color) : temp_color), _duration, TIMER_OVERRIDE|TIMER_UNIQUE)
+
+/mob/living/flash_lighting_fx(_range = FLASH_LIGHT_RANGE, _power = FLASH_LIGHT_POWER, _color = LIGHT_COLOR_WHITE, _duration = FLASH_LIGHT_DURATION, _reset_lighting = TRUE)
+	mob_light(_color, _range, _power, _duration)
+
+/mob/living/proc/mob_light(_color, _range, _power, _duration)
+	var/obj/effect/dummy/lighting_obj/moblight/mob_light_obj = new (src, _color, _range, _power, _duration)
+	return mob_light_obj
+

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -900,7 +900,7 @@
 		on_fire = 1
 		src.visible_message("<span class='warning'>[src] catches fire!</span>", \
 						"<span class='userdanger'>You're set on fire!</span>")
-		new/obj/effect/dummy/moblight/fire(src)
+		new/obj/effect/dummy/lighting_obj/moblight/fire(src)
 		throw_alert("fire", /obj/screen/alert/fire)
 		update_fire()
 		SEND_SIGNAL(src, COMSIG_LIVING_IGNITED,src)
@@ -911,7 +911,7 @@
 	if(on_fire)
 		on_fire = 0
 		fire_stacks = 0
-		for(var/obj/effect/dummy/moblight/fire/F in src)
+		for(var/obj/effect/dummy/lighting_obj/moblight/fire/F in src)
 			qdel(F)
 		clear_alert("fire")
 		SEND_SIGNAL(src, COMSIG_CLEAR_MOOD_EVENT, "on_fire")

--- a/code/modules/photography/camera/camera.dm
+++ b/code/modules/photography/camera/camera.dm
@@ -9,10 +9,13 @@
 	item_state = "camera"
 	lefthand_file = 'icons/mob/inhands/misc/devices_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/misc/devices_righthand.dmi'
+	light_color = LIGHT_COLOR_WHITE
+	light_power = FLASH_LIGHT_POWER
 	w_class = WEIGHT_CLASS_SMALL
 	flags_1 = CONDUCT_1
 	slot_flags = ITEM_SLOT_NECK
 	materials = list(MAT_METAL = 50, MAT_GLASS = 150)
+	var/flash_enabled = TRUE
 	var/state_on = "camera"
 	var/state_off = "camera_off"
 	var/pictures_max = 10
@@ -43,13 +46,13 @@
 	to_chat(user, "<span class='notice'>Alt-click to change its focusing, allowing you to set how big of an area it will capture.</span>")
 
 /obj/item/camera/AltClick(mob/user)
+	if(!user.canUseTopic(src, BE_CLOSE))
+		return
 	var/desired_x = input(user, "How high do you want the camera to shoot, between [picture_size_x_min] and [picture_size_x_max]?", "Zoom", picture_size_x) as num
 	var/desired_y = input(user, "How wide do you want the camera to shoot, between [picture_size_y_min] and [picture_size_y_max]?", "Zoom", picture_size_y) as num
-	desired_x = min(CLAMP(desired_x, picture_size_x_min, picture_size_x_max), CAMERA_PICTURE_SIZE_HARD_LIMIT)
-	desired_y = min(CLAMP(desired_y, picture_size_y_min, picture_size_y_max), CAMERA_PICTURE_SIZE_HARD_LIMIT)
-	if(user.canUseTopic(src))
-		picture_size_x = desired_x
-		picture_size_y = desired_y
+	picture_size_x = min(CLAMP(desired_x, picture_size_x_min, picture_size_x_max), CAMERA_PICTURE_SIZE_HARD_LIMIT)
+	picture_size_y = min(CLAMP(desired_y, picture_size_y_min, picture_size_y_max), CAMERA_PICTURE_SIZE_HARD_LIMIT)
+
 
 /obj/item/camera/attack(mob/living/carbon/human/M, mob/user)
 	return
@@ -142,6 +145,8 @@
 	qdel(P)
 
 /obj/item/camera/proc/captureimage(atom/target, mob/user, flag, size_x = 1, size_y = 1)
+	if(flash_enabled)
+		flash_lighting_fx(8, light_power, light_color)
 	blending = TRUE
 	var/turf/target_turf = get_turf(target)
 	if(!isturf(target_turf))

--- a/code/modules/photography/camera/silicon_camera.dm
+++ b/code/modules/photography/camera/silicon_camera.dm
@@ -6,6 +6,7 @@
 
 /obj/item/camera/siliconcam/ai_camera
 	name = "AI photo camera"
+	flash_enabled = FALSE
 
 /obj/item/camera/siliconcam/proc/toggle_camera_mode(mob/user)
 	if(in_camera_mode)

--- a/code/modules/reagents/chemistry/recipes/pyrotechnics.dm
+++ b/code/modules/reagents/chemistry/recipes/pyrotechnics.dm
@@ -242,7 +242,11 @@
 		return
 	var/location = get_turf(holder.my_atom)
 	do_sparks(2, TRUE, location)
-	for(var/mob/living/carbon/C in get_hearers_in_view(created_volume/3, location))
+	var/range = created_volume/3
+	if(isatom(holder.my_atom))
+		var/atom/A = holder.my_atom
+		A.flash_lighting_fx(_range = (range + 2), _reset_lighting = FALSE)
+	for(var/mob/living/carbon/C in get_hearers_in_view(range, location))
 		if(C.flash_act())
 			if(get_dist(C, location) < 4)
 				C.Knockdown(60)
@@ -259,7 +263,11 @@
 /datum/chemical_reaction/flash_powder_flash/on_reaction(datum/reagents/holder, created_volume)
 	var/location = get_turf(holder.my_atom)
 	do_sparks(2, TRUE, location)
-	for(var/mob/living/carbon/C in get_hearers_in_view(created_volume/10, location))
+	var/range = created_volume/10
+	if(isatom(holder.my_atom))
+		var/atom/A = holder.my_atom
+		A.flash_lighting_fx(_range = (range + 2), _reset_lighting = FALSE)
+	for(var/mob/living/carbon/C in get_hearers_in_view(range, location))
 		if(C.flash_act())
 			if(get_dist(C, location) < 4)
 				C.Knockdown(60)


### PR DESCRIPTION
:cl: ShizCalev
fix: Flashbangs will now make a sound if nobody is around to see them. (honk)
tweak: Flashbangs now come with sparks and will also light things up around them on detonation!
tweak: Flashes, flashers, flash powder, and cameras also now produce lighting! Woo!
fix: Cameras will no longer give you a prompt when alt-clicking them while not adjacent to them.
/:cl:

[why]: #
because it just makes sense

Flashbangs (ignore the lighting on the sparks, that's from a different fix PR):
https://gfycat.com/NeglectedWeepyAmethystinepython

Flashes / flashers (they can also have their lighting effects vareditted for badminery):
https://gfycat.com/GrayConsiderateBrahmanbull

(Flash powder is essentially the same as a flash, but scales depending on the amount of powder consumed.)

