### PR TITLE
Adds lighting effects to explosions

### DIFF
--- a/code/game/objects/effects/effect_system/effects_explosion.dm
+++ b/code/game/objects/effects/effect_system/effects_explosion.dm
@@ -3,10 +3,21 @@
 	icon_state = "explosion_particle"
 	opacity = 1
 	anchored = TRUE
+	layer = ABOVE_LIGHTING_LAYER
+	plane = ABOVE_LIGHTING_PLANE
+	light_color = LIGHT_COLOR_FIRE
+	light_range = MINIMUM_USEFUL_LIGHT_RANGE
+	light_power = 3
 
 /obj/effect/particle_effect/expl_particles/Initialize()
 	. = ..()
 	QDEL_IN(src, 15)
+
+/obj/effect/particle_effect/expl_particles/singularity_pull()
+	return
+
+/obj/effect/particle_effect/expl_particles/ex_act()
+	return
 
 /datum/effect_system/expl_particles
 	number = 10
@@ -23,15 +34,26 @@
 	name = "fire"
 	icon = 'icons/effects/96x96.dmi'
 	icon_state = "explosion"
-	opacity = 1
+	opacity = TRUE
 	anchored = TRUE
 	mouse_opacity = MOUSE_OPACITY_TRANSPARENT
+	layer = ABOVE_LIGHTING_LAYER
+	plane = ABOVE_LIGHTING_PLANE
+	light_color = LIGHT_COLOR_FIRE
+	light_range = 4
+	light_power = 4
 	pixel_x = -32
 	pixel_y = -32
 
 /obj/effect/explosion/Initialize()
 	. = ..()
 	QDEL_IN(src, 10)
+
+/obj/effect/explosion/singularity_pull()
+	return
+
+/obj/effect/explosion/ex_act()
+	return
 
 /datum/effect_system/explosion
 

--- a/code/game/objects/effects/temporary_visuals/miscellaneous.dm
+++ b/code/game/objects/effects/temporary_visuals/miscellaneous.dm
@@ -301,6 +301,17 @@
 	pixel_x = -32
 	pixel_y = -32
 	duration = 8
+	layer = ABOVE_LIGHTING_LAYER
+	plane = ABOVE_LIGHTING_PLANE
+	light_color = LIGHT_COLOR_FIRE
+	light_range = 3
+	light_power = 4
+
+/obj/effect/temp_visual/explosion/singularity_pull()
+	return
+
+/obj/effect/temp_visual/explosion/ex_act()
+	return
 
 /obj/effect/temp_visual/explosion/fast
 	icon_state = "explosionfast"


### PR DESCRIPTION
:cl: ShizCalev
tweak: Explosions now LIGHT SHIT UP.
fix: Explosion effects will no longer be deleted by other explosions, nor will they be pulled by a singularity.
/:cl:

[why]: 

https://dl.dropboxusercontent.com/s/9mr64v44tnyzavv/2018-09-19_23-50-21.webm

need i say more

also moved the explosion VFX above the lighting layer/plane so they're fullbright.
