### PR TITLE
Fixes bad lighting values

### DIFF
--- a/code/game/objects/effects/effect_system/effects_sparks.dm
+++ b/code/game/objects/effects/effect_system/effects_sparks.dm
@@ -20,12 +20,14 @@
 	name = "sparks"
 	icon_state = "sparks"
 	anchored = TRUE
-	light_range = 1
+	light_power = 1.3
+	light_range = MINIMUM_USEFUL_LIGHT_RANGE
+	light_color = LIGHT_COLOR_FIRE
 
 /obj/effect/particle_effect/sparks/Initialize()
 	. = ..()
 	flick("sparks", src) // replay the animation
-	playsound(src.loc, "sparks", 100, 1)
+	playsound(src, "sparks", 100, TRUE)
 	var/turf/T = loc
 	if(isturf(T))
 		T.hotspot_expose(300,5)

--- a/code/modules/antagonists/swarmer/swarmer.dm
+++ b/code/modules/antagonists/swarmer/swarmer.dm
@@ -617,7 +617,7 @@
 	name = "swarmer blockade"
 	desc = "A quickly assembled energy blockade. Will not retain its form if damaged enough, but disabler beams and swarmers pass right through."
 	icon_state = "barricade"
-	light_range = 1
+	light_range = MINIMUM_USEFUL_LIGHT_RANGE
 	max_integrity = 50
 
 /obj/structure/swarmer/blockade/CanPass(atom/movable/O)

--- a/code/modules/mining/lavaland/ash_flora.dm
+++ b/code/modules/mining/lavaland/ash_flora.dm
@@ -109,7 +109,8 @@
 	icon_state = "t_mushroom"
 	name = "numerous mushrooms"
 	desc = "A large number of mushrooms, some of which have long, fleshy stems. They're radiating light!"
-	light_range = 1
+	light_range = 1.5
+	light_power = 2.1
 	harvested_name = "tiny mushrooms"
 	harvested_desc = "A few tiny mushrooms around larger stumps. You can already see them growing back."
 	harvest = /obj/item/reagent_containers/food/snacks/grown/ash_flora/mushroom_stem
@@ -183,7 +184,6 @@
 	desc = "A long mushroom stem. It's slightly glowing."
 	list_reagents = list("tinlux" = 2, "vitamin" = 1, "space_drugs" = 1)
 	icon_state = "mushroom_stem"
-	light_range = 1
 	seed = /obj/item/seeds/lavaland/ember
 	wine_power = 60
 

--- a/code/modules/mob/living/simple_animal/guardian/types/support.dm
+++ b/code/modules/mob/living/simple_animal/guardian/types/support.dm
@@ -92,7 +92,7 @@
 	icon = 'icons/turf/floors.dmi'
 	desc = "A receiving zone for bluespace teleportations."
 	icon_state = "light_on-w"
-	light_range = 1
+	light_range = MINIMUM_USEFUL_LIGHT_RANGE
 	density = FALSE
 	anchored = TRUE
 	layer = ABOVE_OPEN_TURF_LAYER

--- a/code/modules/mob/living/simple_animal/hostile/megafauna/hierophant.dm
+++ b/code/modules/mob/living/simple_animal/hostile/megafauna/hierophant.dm
@@ -455,7 +455,7 @@ Difficulty: Hard
 /obj/effect/temp_visual/hierophant/squares
 	icon_state = "hierophant_squares"
 	duration = 3
-	light_range = 1
+	light_range = MINIMUM_USEFUL_LIGHT_RANGE
 	randomdir = FALSE
 
 /obj/effect/temp_visual/hierophant/squares/Initialize(mapload, new_caster)
@@ -468,7 +468,7 @@ Difficulty: Hard
 	name = "vortex wall"
 	icon = 'icons/turf/walls/hierophant_wall_temp.dmi'
 	icon_state = "wall"
-	light_range = 1
+	light_range = MINIMUM_USEFUL_LIGHT_RANGE
 	duration = 100
 	smooth = SMOOTH_TRUE
 

--- a/code/modules/station_goals/dna_vault.dm
+++ b/code/modules/station_goals/dna_vault.dm
@@ -128,7 +128,10 @@
 	idle_power_usage = 5000
 	pixel_x = -32
 	pixel_y = -64
-	light_range = 1
+	light_range = 3
+	light_power = 1.5
+	light_color = LIGHT_COLOR_CYAN
+
 
 	//High defaults so it's not completed automatically if there's no station goal
 	var/animals_max = 100


### PR DESCRIPTION
Corrected light_range values that were below the minimum (1.4) required to apply a light source to the obj. Also tweaked the lighting values for the DNA vault, lavaland cave-glowshrooms, and sparks so they're a touch more aesthetically pleasing.

🆑 ShizCalev
fix: Lighting effects have been restored and tweaked for a handful of items.
/🆑