### PR TITLE
[Ready]Adds hypnosis and the hypnotic stupor brain trauma

### DIFF
--- a/code/datums/brain_damage/hypnosis.dm
+++ b/code/datums/brain_damage/hypnosis.dm
@@ -40,7 +40,7 @@
 			if(1)
 				to_chat(owner, "<i>...[lowertext(hypnotic_phrase)]...</i>")
 			if(2)
-				new /datum/hallucination/chat(owner, TRUE, FALSE, hypnotic_phrase)
+				new /datum/hallucination/chat(owner, TRUE, FALSE, "<span class='hypnophrase'>[hypnotic_phrase]</span>")
 				
 /datum/brain_trauma/hypnosis/on_hear(message, speaker, message_language, raw_message, radio_freq)			
 	message = replacetext(message, hypnotic_phrase, "<span class='hypnophrase'>[hypnotic_phrase]</span>")

--- a/code/datums/brain_damage/hypnosis.dm
+++ b/code/datums/brain_damage/hypnosis.dm
@@ -5,25 +5,25 @@
 	gain_text = ""
 	lose_text = ""
 	resilience = TRAUMA_RESILIENCE_SURGERY
-	
+
 	var/hypnotic_phrase = ""
-	
+
 /datum/brain_trauma/hypnosis/New(phrase)
-	hypnotic_phrase = phrase
 	if(!phrase)
 		qdel(src)
-	..()	
-	
+	hypnotic_phrase = phrase
+	..()
+
 /datum/brain_trauma/hypnosis/on_gain()
 	message_admins("[ADMIN_LOOKUPFLW(owner)] was hypnotized with the phrase '[hypnotic_phrase]'.")
 	log_game("[key_name(owner)] was hypnotized with the phrase '[hypnotic_phrase]'.")
-	to_chat(owner, "<span class='big'>[hypnotic_phrase]</span>")
+	to_chat(owner, "<span class='reallybig hypnophrase'>[hypnotic_phrase]</span>")
 	to_chat(owner, "<span class='notice'>[pick("You feel your thoughts focusing on this phrase... you can't seem to get it out of your head.",\
 												"Your head hurts, but this is all you can think of. It must be vitally important.",\
 												"You feel a part of your mind repeating this over and over. You need to follow these words.",\
 												"Something about this sounds... right, for some reason. You feel like you should follow these words.",\
 												"These words keep echoing in your mind. You find yourself completely fascinated by them.")]</span>")
-	to_chat(owner, "<span class='danger'>You've been hypnotized by this sentence. You must follow these words. If it isn't a clear order, you can freely interpret how to do so,\
+	to_chat(owner, "<span class='boldwarning'>You've been hypnotized by this sentence. You must follow these words. If it isn't a clear order, you can freely interpret how to do so,\
 										as long as you act like the words are your highest priority.</span>")
 	..()
 
@@ -32,16 +32,17 @@
 	log_game("[key_name(owner)] is no longer hypnotized with the phrase '[hypnotic_phrase]'.")
 	to_chat(owner, "<span class='userdanger'>You suddenly snap out of your hypnosis. The phrase '[hypnotic_phrase]' no longer feels important to you.</span>")
 	..()
-	
+
 /datum/brain_trauma/hypnosis/on_life()
 	..()
-	if(prob(4))
+	if(prob(2))
 		switch(rand(1,2))
 			if(1)
 				to_chat(owner, "<i>...[lowertext(hypnotic_phrase)]...</i>")
 			if(2)
 				new /datum/hallucination/chat(owner, TRUE, FALSE, "<span class='hypnophrase'>[hypnotic_phrase]</span>")
-				
-/datum/brain_trauma/hypnosis/on_hear(message, speaker, message_language, raw_message, radio_freq)			
-	message = replacetext(message, hypnotic_phrase, "<span class='hypnophrase'>[hypnotic_phrase]</span>")
+
+/datum/brain_trauma/hypnosis/on_hear(message, speaker, message_language, raw_message, radio_freq)
+	var/regex/target_phrase = new("(\\b[hypnotic_phrase]\\b)","ig")
+	message = target_phrase.Replace(message, "<span class='hypnophrase'>$1</span>")
 	return message

--- a/code/datums/brain_damage/hypnosis.dm
+++ b/code/datums/brain_damage/hypnosis.dm
@@ -41,3 +41,7 @@
 				to_chat(owner, "<i>...[lowertext(hypnotic_phrase)]...</i>")
 			if(2)
 				new /datum/hallucination/chat(owner, TRUE, FALSE, hypnotic_phrase)
+				
+/datum/brain_trauma/hypnosis/on_hear(message, speaker, message_language, raw_message, radio_freq)			
+	message = replacetext(message, hypnotic_phrase, "<span class='hypnophrase'>[hypnotic_phrase]</span>")
+	return message

--- a/code/datums/brain_damage/hypnosis.dm
+++ b/code/datums/brain_damage/hypnosis.dm
@@ -1,0 +1,43 @@
+/datum/brain_trauma/hypnosis
+	name = "Hypnosis"
+	desc = "Patient's unconscious is completely enthralled by a word or sentence, focusing their thoughts and actions on it."
+	scan_desc = "looping thought pattern"
+	gain_text = ""
+	lose_text = ""
+	resilience = TRAUMA_RESILIENCE_SURGERY
+	
+	var/hypnotic_phrase = ""
+	
+/datum/brain_trauma/hypnosis/New(phrase)
+	hypnotic_phrase = phrase
+	if(!phrase)
+		qdel(src)
+	..()	
+	
+/datum/brain_trauma/hypnosis/on_gain()
+	message_admins("[ADMIN_LOOKUPFLW(owner)] was hypnotized with the phrase '[hypnotic_phrase]'.")
+	log_game("[key_name(owner)] was hypnotized with the phrase '[hypnotic_phrase]'.")
+	to_chat(owner, "<span class='big'>[hypnotic_phrase]</span>")
+	to_chat(owner, "<span class='notice'>[pick("You feel your thoughts focusing on this phrase... you can't seem to get it out of your head.",\
+												"Your head hurts, but this is all you can think of. It must be vitally important.",\
+												"You feel a part of your mind repeating this over and over. You need to follow these words.",\
+												"Something about this sounds... right, for some reason. You feel like you should follow these words.",\
+												"These words keep echoing in your mind. You find yourself completely fascinated by them.")]</span>")
+	to_chat(owner, "<span class='danger'>You've been hypnotized by this sentence. You must follow these words. If it isn't a clear order, you can freely interpret how to do so,\
+										as long as you act like the words are your highest priority.</span>")
+	..()
+
+/datum/brain_trauma/hypnosis/on_lose()
+	message_admins("[ADMIN_LOOKUPFLW(owner)] is no longer hypnotized with the phrase '[hypnotic_phrase]'.")
+	log_game("[key_name(owner)] is no longer hypnotized with the phrase '[hypnotic_phrase]'.")
+	to_chat(owner, "<span class='userdanger'>You suddenly snap out of your hypnosis. The phrase '[hypnotic_phrase]' no longer feels important to you.</span>")
+	..()
+	
+/datum/brain_trauma/hypnosis/on_life()
+	..()
+	if(prob(4))
+		switch(rand(1,2))
+			if(1)
+				to_chat(owner, "<i>...[lowertext(hypnotic_phrase)]...</i>")
+			if(2)
+				new /datum/hallucination/chat(owner, TRUE, FALSE, hypnotic_phrase)

--- a/code/datums/brain_damage/severe.dm
+++ b/code/datums/brain_damage/severe.dm
@@ -208,7 +208,7 @@
 /datum/brain_trauma/severe/hypnotic_stupor
 	name = "Hypnotic Stupor"
 	desc = "Patient is prone to episodes of extreme stupor that leaves them extremely suggestible."
-	scan_desc = "oniric feedback loop"
+	scan_desc = "oneiric feedback loop"
 	gain_text = "<span class='warning'>You feel somewhat dazed.</span>"
 	lose_text = "<span class='notice'>You feel like a fog was lifted from your mind.</span>"
 	var/active_stupor = FALSE
@@ -233,6 +233,7 @@
 	if(stupor_timer)
 		deltimer(stupor_timer)
 	owner.dizziness = 300
+	owner.add_trait(TRAIT_MUTE, "hypnotic_stupor") //Too dazed to speak (or warn people around you)
 	stupor_timer = addtimer(CALLBACK(src, .proc/clear_stupor, TRUE), rand(100, 300), TIMER_STOPPABLE)
 	
 /datum/brain_trauma/severe/hypnotic_stupor/proc/clear_stupor(timeout = FALSE)
@@ -240,6 +241,7 @@
 		to_chat(owner, "<span class='notice'>The weird feeling passes.</span>")
 	active_stupor = FALSE
 	owner.dizziness = 0
+	owner.remove_trait(TRAIT_MUTE, "hypnotic_stupor")
 	if(stupor_timer)
 		deltimer(stupor_timer)
 		

--- a/code/datums/brain_damage/severe.dm
+++ b/code/datums/brain_damage/severe.dm
@@ -214,11 +214,10 @@
 
 /datum/brain_trauma/severe/hypnotic_stupor/on_lose() //hypnosis must be cleared separately, but brain surgery should get rid of both anyway
 	..()
-	if(active_stupor)
-		owner.remove_status_effect(/datum/status_effect/trance)
+	owner.remove_status_effect(/datum/status_effect/trance)
 	
 /datum/brain_trauma/severe/hypnotic_stupor/on_life()
 	..()
-	if(!active_stupor && prob(1))
+	if(prob(1) && !owner.has_status_effect(/datum/status_effect/trance))
 		owner.apply_status_effect(/datum/status_effect/trance, rand(100,300), FALSE)
 	

--- a/code/datums/brain_damage/severe.dm
+++ b/code/datums/brain_damage/severe.dm
@@ -211,54 +211,14 @@
 	scan_desc = "oneiric feedback loop"
 	gain_text = "<span class='warning'>You feel somewhat dazed.</span>"
 	lose_text = "<span class='notice'>You feel like a fog was lifted from your mind.</span>"
-	var/active_stupor = FALSE
-	var/stupor_timer
-	var/datum/brain_trauma/hypnosis/current_hypnosis
 
-/datum/brain_trauma/severe/hypnotic_stupor/on_lose()
+/datum/brain_trauma/severe/hypnotic_stupor/on_lose() //hypnosis must be cleared separately, but brain surgery should get rid of both anyway
 	..()
 	if(active_stupor)
-		clear_stupor(TRUE)
-	if(current_hypnosis)
-		QDEL_NULL(current_hypnosis)
+		owner.remove_status_effect(/datum/status_effect/trance)
 	
 /datum/brain_trauma/severe/hypnotic_stupor/on_life()
 	..()
 	if(!active_stupor && prob(1))
-		start_stupor()
-
-/datum/brain_trauma/severe/hypnotic_stupor/proc/start_stupor()
-	to_chat(owner, "<span class='warning'>[pick("You feel your thoughts slow down...", "You suddenly feel extremely dizzy...", "You feel like you're in the middle of a dream...")]</span>")
-	active_stupor = TRUE
-	if(stupor_timer)
-		deltimer(stupor_timer)
-	owner.dizziness = 300
-	owner.add_trait(TRAIT_MUTE, "hypnotic_stupor") //Too dazed to speak (or warn people around you)
-	stupor_timer = addtimer(CALLBACK(src, .proc/clear_stupor, TRUE), rand(100, 300), TIMER_STOPPABLE)
-	
-/datum/brain_trauma/severe/hypnotic_stupor/proc/clear_stupor(timeout = FALSE)
-	if(timeout)
-		to_chat(owner, "<span class='notice'>The weird feeling passes.</span>")
-	active_stupor = FALSE
-	owner.dizziness = 0
-	owner.remove_trait(TRAIT_MUTE, "hypnotic_stupor")
-	if(stupor_timer)
-		deltimer(stupor_timer)
-		
-/datum/brain_trauma/severe/hypnotic_stupor/on_hear(message, speaker, message_language, raw_message, radio_freq)
-	. = message
-	if(!active_stupor || !owner.can_hear()) //words can't hypnotize you if you can't hear them *taps head*
-		return
-	if(speaker == owner) //No self hypnosis!
-		return
-	addtimer(CALLBACK(src, .proc/hypnotize, raw_message), 10) //to react AFTER the chat message	
-	
-/datum/brain_trauma/severe/hypnotic_stupor/proc/hypnotize(phrase)
-	clear_stupor()
-	if(current_hypnosis)
-		QDEL_NULL(current_hypnosis)
-	current_hypnosis = new
-	owner.gain_trauma(current_hypnosis, TRAUMA_RESILIENCE_ABSOLUTE, phrase)
-	owner.Unconscious(60) //Take some time to think about it
-	
+		owner.apply_status_effect(/datum/status_effect/trance, rand(100,300), FALSE)
 	

--- a/code/datums/status_effects/debuffs.dm
+++ b/code/datums/status_effects/debuffs.dm
@@ -567,5 +567,5 @@
 		return
 	var/mob/living/carbon/C = owner
 	C.cure_trauma_type(/datum/brain_trauma/hypnosis, TRAUMA_RESILIENCE_SURGERY) //clear previous hypnosis
-	C.gain_trauma(current_hypnosis, TRAUMA_RESILIENCE_SURGERY, raw_message)
+	C.gain_trauma(/datum/brain_trauma/hypnosis, TRAUMA_RESILIENCE_SURGERY, raw_message)
 	C.Unconscious(60, TRUE, TRUE) //Take some time to think about it

--- a/code/datums/status_effects/debuffs.dm
+++ b/code/datums/status_effects/debuffs.dm
@@ -571,5 +571,5 @@
 	var/mob/living/carbon/C = owner
 	C.cure_trauma_type(/datum/brain_trauma/hypnosis, TRAUMA_RESILIENCE_SURGERY) //clear previous hypnosis
 	addtimer(CALLBACK(C, /mob/living/carbon.proc/gain_trauma, /datum/brain_trauma/hypnosis, TRAUMA_RESILIENCE_SURGERY, raw_message), 10)
-	addtimer(CALLBACK(C, /mob/living.proc/Unconscious, 60, TRUE, TRUE), 15) //Take some time to think about it
+	addtimer(CALLBACK(C, /mob/living.proc/Stun, 60, TRUE, TRUE), 15) //Take some time to think about it
 	qdel(src)

--- a/code/datums/status_effects/debuffs.dm
+++ b/code/datums/status_effects/debuffs.dm
@@ -525,7 +525,7 @@
 	owner.remove_trait(TRAIT_PACIFISM, "gonbolaPacify")
 	owner.remove_trait(TRAIT_MUTE, "gonbolaMute")
 	owner.remove_trait(TRAIT_JOLLY, "gonbolaJolly")
-	
+
 /datum/status_effect/trance
 	id = "trance"
 	status_type = STATUS_EFFECT_UNIQUE
@@ -537,23 +537,22 @@
 /datum/status_effect/trance/tick()
 	if(stun)
 		owner.Stun(60, TRUE, TRUE)
-	
+	owner.dizziness = 20
+
 /datum/status_effect/trance/on_apply()
 	if(!iscarbon(owner))
 		return FALSE
 	RegisterSignal(owner, COMSIG_MOVABLE_HEAR, .proc/hypnotize)
 	owner.add_trait(TRAIT_MUTE, "trance")
-	owner.dizziness = 300
 	owner.visible_message("[stun ? "<span class='warning'>[owner] stands still as [owner.p_their()] eyes seem to focus on a distant point.</span>" : ""]", \
 	"<span class='warning'>[pick("You feel your thoughts slow down...", "You suddenly feel extremely dizzy...", "You feel like you're in the middle of a dream...","You feel incredibly relaxed...")]</span>")
-	return TRUE	
-	
+	return TRUE
+
 /datum/status_effect/trance/on_creation(mob/living/new_owner, _duration, _stun = TRUE)
+	duration = _duration
+	stun = _stun
 	. = ..()
-	if(.)
-		duration = _duration
-		stun = _stun
-	
+
 /datum/status_effect/trance/on_remove()
 	UnregisterSignal(owner, COMSIG_MOVABLE_HEAR)
 	owner.remove_trait(TRAIT_MUTE, "trance")
@@ -567,5 +566,6 @@
 		return
 	var/mob/living/carbon/C = owner
 	C.cure_trauma_type(/datum/brain_trauma/hypnosis, TRAUMA_RESILIENCE_SURGERY) //clear previous hypnosis
-	C.gain_trauma(/datum/brain_trauma/hypnosis, TRAUMA_RESILIENCE_SURGERY, raw_message)
-	C.Unconscious(60, TRUE, TRUE) //Take some time to think about it
+	addtimer(CALLBACK(C, /mob/living/carbon.proc/gain_trauma, /datum/brain_trauma/hypnosis, TRAUMA_RESILIENCE_SURGERY, raw_message), 10)
+	addtimer(CALLBACK(C, /mob/living.proc/Unconscious, 60, TRUE, TRUE), 15) //Take some time to think about it
+	qdel(src)

--- a/code/datums/status_effects/debuffs.dm
+++ b/code/datums/status_effects/debuffs.dm
@@ -566,7 +566,6 @@
 	if(speaker == owner)
 		return
 	var/mob/living/carbon/C = owner
-	for(var/X in C.get_traumas_type(/datum/brain_trauma/hypnosis, TRAUMA_RESILIENCE_SURGERY)) //clear existing hypnosis
-		qdel(X)
-	owner.gain_trauma(current_hypnosis, TRAUMA_RESILIENCE_SURGERY, raw_message)
-	owner.Unconscious(60, TRUE, TRUE) //Take some time to think about it
+	C.cure_trauma_type(/datum/brain_trauma/hypnosis, TRAUMA_RESILIENCE_SURGERY) //clear previous hypnosis
+	C.gain_trauma(current_hypnosis, TRAUMA_RESILIENCE_SURGERY, raw_message)
+	C.Unconscious(60, TRUE, TRUE) //Take some time to think about it

--- a/code/datums/status_effects/debuffs.dm
+++ b/code/datums/status_effects/debuffs.dm
@@ -544,6 +544,8 @@
 		return FALSE
 	RegisterSignal(owner, COMSIG_MOVABLE_HEAR, .proc/hypnotize)
 	owner.add_trait(TRAIT_MUTE, "trance")
+	if(!owner.has_quirk(/datum/quirk/monochromatic))
+		owner.add_client_colour(/datum/client_colour/monochrome)
 	owner.visible_message("[stun ? "<span class='warning'>[owner] stands still as [owner.p_their()] eyes seem to focus on a distant point.</span>" : ""]", \
 	"<span class='warning'>[pick("You feel your thoughts slow down...", "You suddenly feel extremely dizzy...", "You feel like you're in the middle of a dream...","You feel incredibly relaxed...")]</span>")
 	return TRUE
@@ -557,6 +559,8 @@
 	UnregisterSignal(owner, COMSIG_MOVABLE_HEAR)
 	owner.remove_trait(TRAIT_MUTE, "trance")
 	owner.dizziness = 0
+	if(!owner.has_quirk(/datum/quirk/monochromatic))
+		owner.remove_client_colour(/datum/client_colour/monochrome)
 	to_chat(owner, "<span class='warning'>You snap out of your trance!</span>")
 
 /datum/status_effect/trance/proc/hypnotize(datum/source, message, atom/movable/speaker, message_language, raw_message, radio_freq, list/spans, message_mode)

--- a/code/datums/status_effects/debuffs.dm
+++ b/code/datums/status_effects/debuffs.dm
@@ -544,7 +544,7 @@
 	RegisterSignal(owner, COMSIG_MOVABLE_HEAR, .proc/hypnotize)
 	owner.add_trait(TRAIT_MUTE, "trance")
 	owner.dizziness = 300
-	owner.visible_message([stun ? "<span class='warning'>[owner] stands still as [owner.p_their()] eyes seem to focus on a distant point.</span>" : ""], \
+	owner.visible_message("[stun ? "<span class='warning'>[owner] stands still as [owner.p_their()] eyes seem to focus on a distant point.</span>" : ""]", \
 	"<span class='warning'>[pick("You feel your thoughts slow down...", "You suddenly feel extremely dizzy...", "You feel like you're in the middle of a dream...","You feel incredibly relaxed...")]</span>")
 	return TRUE	
 	

--- a/code/modules/goonchat/browserassets/css/browserOutput.css
+++ b/code/modules/goonchat/browserassets/css/browserOutput.css
@@ -393,6 +393,13 @@ h1.alert, h2.alert		{color: #000000;}
 .redtext				{color: #FF0000;	font-size: 24px;}
 .clown					{color: #FF69Bf;	font-size: 24px; font-family: "Comic Sans MS", cursive, sans-serif; font-weight: bold;}
 .his_grace				{color: #15D512;	font-family: "Courier New", cursive, sans-serif; font-style: italic;}
+.hypnophrase			{color: #0d0d0d;	font-weight: bold; animation: hypnocolor 1500ms infinite;}
+@keyframes hypnocolor {
+    0% { color: #0d0d0d; }
+    25% { color: #410194; }
+    50% { color: #7f17d8; }
+		75% { color: #410194; }
+}
 
 .icon 					{height: 1em;	width: auto;}
 

--- a/code/modules/mob/living/carbon/say.dm
+++ b/code/modules/mob/living/carbon/say.dm
@@ -39,10 +39,8 @@
 	else
 		. = initial(dt.flags) & TONGUELESS_SPEECH
 
-/mob/living/carbon/Hear(message, atom/movable/speaker, datum/language/message_language, raw_message, radio_freq, list/spans, message_mode)
-	. = ..()
-	if(!client)
-		return
+/mob/living/carbon/hear_intercept(message, atom/movable/speaker, datum/language/message_language, raw_message, radio_freq, list/spans, message_mode)
 	for(var/T in get_traumas())
 		var/datum/brain_trauma/trauma = T
 		message = trauma.on_hear(message, speaker, message_language, raw_message, radio_freq)
+	return message

--- a/code/modules/mob/living/say.dm
+++ b/code/modules/mob/living/say.dm
@@ -228,7 +228,11 @@ GLOBAL_LIST_INIT(department_radio_keys, list(
 
 	// Recompose message for AI hrefs, language incomprehension.
 	message = compose_message(speaker, message_language, raw_message, radio_freq, spans, message_mode)
+	message = hear_intercept(message, speaker, message_language, raw_message, radio_freq, spans, message_mode)
 	show_message(message, 2, deaf_message, deaf_type)
+	return message
+
+/mob/living/proc/hear_intercept(message, atom/movable/speaker, datum/language/message_language, raw_message, radio_freq, list/spans, message_mode)
 	return message
 
 /mob/living/send_speech(message, message_range = 6, obj/source = src, bubble_type = bubble_icon, list/spans, datum/language/message_language=null, message_mode)

--- a/interface/stylesheet.dm
+++ b/interface/stylesheet.dm
@@ -153,7 +153,13 @@ h1.alert, h2.alert		{color: #000000;}
 .redtext				{color: #FF0000;	font-size: 3;}
 .clown					{color: #FF69Bf;	font-size: 3; font-family: "Comic Sans MS", cursive, sans-serif; font-weight: bold;}
 .his_grace				{color: #15D512;	font-family: "Courier New", cursive, sans-serif; font-style: italic;}
-.hypnophrase			{color: #47175b;	font-weight: bold; text-decoration: underline;}
+.hypnophrase			{color: #3bb5d3;	font-weight: bold; animation: hypnocolor 1500ms infinite;}
+@keyframes hypnocolor {
+    0% { color: #0d0d0d; }
+    25% { color: #410194; }
+    50% { color: #7f17d8; }
+	75% { color: #410194; }
+}
 
 .icon 					{height: 1em;	width: auto;}
 

--- a/interface/stylesheet.dm
+++ b/interface/stylesheet.dm
@@ -153,6 +153,7 @@ h1.alert, h2.alert		{color: #000000;}
 .redtext				{color: #FF0000;	font-size: 3;}
 .clown					{color: #FF69Bf;	font-size: 3; font-family: "Comic Sans MS", cursive, sans-serif; font-weight: bold;}
 .his_grace				{color: #15D512;	font-family: "Courier New", cursive, sans-serif; font-style: italic;}
+.hypnophrase			{color: #47175b;	font-weight: bold; text-decoration: underline;}
 
 .icon 					{height: 1em;	width: auto;}
 

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -315,6 +315,7 @@
 #include "code\datums\actions\beam_rifle.dm"
 #include "code\datums\actions\ninja.dm"
 #include "code\datums\brain_damage\brain_trauma.dm"
+#include "code\datums\brain_damage\hypnosis.dm"
 #include "code\datums\brain_damage\imaginary_friend.dm"
 #include "code\datums\brain_damage\mild.dm"
 #include "code\datums\brain_damage\phobia.dm"


### PR DESCRIPTION
:cl: XDTM
add: Added a new severe brain trauma: hypnotic stupor. Victims of hypnotic stupor occasionally fall into a trance, and upon hearing a sentence they'll focus on it to the point of obsession, until it is replaced by a new hypnosis or the trauma is cured.
/:cl:

Adds the potential for some fancy rp gameplay. The idea is that they should take a passing message way too seriously, while leaving room for interpretation to the player. Hearing an isolated "greytide" over the radio might prompt a player to take up arms against the rampaging greyshirts, another might interpret it as having to _become_ the greytide. Someone who realizes what's up might use this to give clear orders to the victim, although they'll only last until the following trance.

I plan on adding more methods to inflict hypnosis with the same trance->"focus on a sentence" mechanics, perhaps as a traitor/CMO pendulum item, or as a wizard/cult spell.
