### PR TITLE
Fixes attaching accessories to chests

### DIFF
--- a/code/modules/clothing/under/_under.dm
+++ b/code/modules/clothing/under/_under.dm
@@ -90,6 +90,9 @@
 				to_chat(user, "<span class='warning'>[src] already has an accessory.</span>")
 			return
 		else
+
+			if(!A.can_attach_accessory(src, user)) //Make sure the suit has a place to put the accessory.
+				return
 			if(user && !user.temporarilyRemoveItemFromInventory(I))
 				return
 			if(!A.attach(src, user))

--- a/code/modules/clothing/under/accessories.dm
+++ b/code/modules/clothing/under/accessories.dm
@@ -10,6 +10,13 @@
 	var/above_suit = FALSE
 	var/minimize_when_attached = TRUE // TRUE if shown as a small icon in corner, FALSE if overlayed
 	var/datum/component/storage/detached_pockets
+	var/attachment_slot = CHEST
+
+/obj/item/clothing/accessory/proc/can_attach_accessory(obj/item/clothing/U, mob/user)
+	if(!attachment_slot || (U && U.body_parts_covered & attachment_slot))
+		return TRUE
+	if(user)
+		to_chat(user, "<span class='warning'>There doesn't seem to be anywhere to put [src]...</span>")
 
 /obj/item/clothing/accessory/proc/attach(obj/item/clothing/under/U, user)
 	GET_COMPONENT(storage, /datum/component/storage)
@@ -85,6 +92,7 @@
 	item_state = "waistcoat"
 	item_color = "waistcoat"
 	minimize_when_attached = FALSE
+	attachment_slot = null
 
 /obj/item/clothing/accessory/maidapron
 	name = "maid apron"
@@ -93,6 +101,7 @@
 	item_state = "maidapron"
 	item_color = "maidapron"
 	minimize_when_attached = FALSE
+	attachment_slot = null
 
 //////////
 //Medals//
@@ -139,7 +148,7 @@
 							SSblackbox.record_feedback("associative", "commendation", 1, list("commender" = "[user.real_name]", "commendee" = "[M.real_name]", "medal" = "[src]", "reason" = input))
 							GLOB.commendations += "[user.real_name] awarded <b>[M.real_name]</b> the <span class='medaltext'>[name]</span>! \n- [input]"
 							commended = TRUE
-							desc += "<br>The inscription reads: [input] - [user.real_name]" 
+							desc += "<br>The inscription reads: [input] - [user.real_name]"
 							log_game("<b>[key_name(M)]</b> was given the following commendation by <b>[key_name(user)]</b>: [input]")
 							message_admins("<b>[key_name(M)]</b> was given the following commendation by <b>[key_name(user)]</b>: [input]")
 
@@ -230,6 +239,7 @@
 	desc = "An fancy red armband!"
 	icon_state = "redband"
 	item_color = "redband"
+	attachment_slot = null
 
 /obj/item/clothing/accessory/armband/deputy
 	name = "security deputy armband"
@@ -280,7 +290,7 @@
 	desc = "Fills you with the conviction of JUSTICE. Lawyers tend to want to show it to everyone they meet."
 	icon_state = "lawyerbadge"
 	item_color = "lawyerbadge"
-	
+
 /obj/item/clothing/accessory/lawyers_badge/attack_self(mob/user)
 	if(prob(1))
 		user.say("The testimony contradicts the evidence!", forced = "attorney's badge")
@@ -327,6 +337,7 @@
 	icon_state = "talisman"
 	item_color = "talisman"
 	armor = list("melee" = 5, "bullet" = 5, "laser" = 5, "energy" = 5, "bomb" = 20, "bio" = 20, "rad" = 5, "fire" = 0, "acid" = 25)
+	attachment_slot = null
 
 /obj/item/clothing/accessory/skullcodpiece
 	name = "skull codpiece"
@@ -335,3 +346,4 @@
 	item_color = "skull"
 	above_suit = TRUE
 	armor = list("melee" = 5, "bullet" = 5, "laser" = 5, "energy" = 5, "bomb" = 20, "bio" = 20, "rad" = 5, "fire" = 0, "acid" = 25)
+	attachment_slot = GROIN


### PR DESCRIPTION
:cl: ShizCalev
fix: You can no longer put a pocket protector in your shirt pocket if you're only wearing a pair of pants. This also applies to pinning medals on your chest (owww.)
/:cl:
