### PR TITLE
Ports particle accelerator attack_hand to ui_interact

### DIFF
--- a/code/modules/power/singularity/particle_accelerator/particle_control.dm
+++ b/code/modules/power/singularity/particle_accelerator/particle_control.dm
@@ -226,10 +226,10 @@
 /obj/machinery/particle_accelerator/control_box/ui_interact(mob/user)
 	. = ..()
 
-	if(construction_state != PA_CONSTRUCTION_COMPLETE)
-		return
 	if(construction_state == PA_CONSTRUCTION_PANEL_OPEN)
 		wires.interact(user)
+		return
+	if(construction_state != PA_CONSTRUCTION_COMPLETE)
 		return
 
 	if((get_dist(src, user) > 1) || (stat & (BROKEN|NOPOWER)))

--- a/code/modules/power/singularity/particle_accelerator/particle_control.dm
+++ b/code/modules/power/singularity/particle_accelerator/particle_control.dm
@@ -12,11 +12,11 @@
 	var/strength_upper_limit = 2
 	var/interface_control = 1
 	var/list/obj/structure/particle_accelerator/connected_parts
-	var/assembled = 0
+	var/assembled = FALSE
 	var/construction_state = PA_CONSTRUCTION_UNSECURED
-	var/active = 0
+	var/active = FALSE
 	var/strength = 0
-	var/powered = 0
+	var/powered = FALSE
 	mouse_opacity = MOUSE_OPACITY_OPAQUE
 
 /obj/machinery/particle_accelerator/control_box/Initialize()
@@ -43,18 +43,18 @@
 /obj/machinery/particle_accelerator/control_box/proc/update_state()
 	if(construction_state < PA_CONSTRUCTION_COMPLETE)
 		use_power = NO_POWER_USE
-		assembled = 0
-		active = 0
+		assembled = FALSE
+		active = FALSE
 		for(var/CP in connected_parts)
 			var/obj/structure/particle_accelerator/part = CP
 			part.strength = null
-			part.powered = 0
+			part.powered = FALSE
 			part.update_icon()
 		connected_parts.Cut()
 		return
 	if(!part_scan())
 		use_power = IDLE_POWER_USE
-		active = 0
+		active = FALSE
 		connected_parts.Cut()
 
 /obj/machinery/particle_accelerator/control_box/update_icon()
@@ -134,7 +134,7 @@
 /obj/machinery/particle_accelerator/control_box/power_change()
 	..()
 	if(stat & NOPOWER)
-		active = 0
+		active = FALSE
 		use_power = NO_POWER_USE
 	else if(!stat && construction_state == PA_CONSTRUCTION_COMPLETE)
 		use_power = IDLE_POWER_USE
@@ -157,48 +157,48 @@
 	var/odir = turn(dir,180)
 	var/turf/T = loc
 
-	assembled = 0
+	assembled = FALSE
 	critical_machine = FALSE
 
 	var/obj/structure/particle_accelerator/fuel_chamber/F = locate() in orange(1,src)
 	if(!F)
-		return 0
+		return FALSE
 
 	setDir(F.dir)
 	connected_parts.Cut()
 
 	T = get_step(T,rdir)
 	if(!check_part(T, /obj/structure/particle_accelerator/fuel_chamber))
-		return 0
+		return FALSE
 	T = get_step(T,odir)
 	if(!check_part(T, /obj/structure/particle_accelerator/end_cap))
-		return 0
+		return FALSE
 	T = get_step(T,dir)
 	T = get_step(T,dir)
 	if(!check_part(T, /obj/structure/particle_accelerator/power_box))
-		return 0
+		return FALSE
 	T = get_step(T,dir)
 	if(!check_part(T, /obj/structure/particle_accelerator/particle_emitter/center))
-		return 0
+		return FALSE
 	T = get_step(T,ldir)
 	if(!check_part(T, /obj/structure/particle_accelerator/particle_emitter/left))
-		return 0
+		return FALSE
 	T = get_step(T,rdir)
 	T = get_step(T,rdir)
 	if(!check_part(T, /obj/structure/particle_accelerator/particle_emitter/right))
-		return 0
+		return FALSE
 
-	assembled = 1
+	assembled = TRUE
 	critical_machine = TRUE	//Only counts if the PA is actually assembled.
-	return 1
+	return TRUE
 
 /obj/machinery/particle_accelerator/control_box/proc/check_part(turf/T, type)
 	var/obj/structure/particle_accelerator/PA = locate(/obj/structure/particle_accelerator) in T
 	if(istype(PA, type) && (PA.construction_state == PA_CONSTRUCTION_COMPLETE))
 		if(PA.connect_master(src))
 			connected_parts.Add(PA)
-			return 1
-	return 0
+			return TRUE
+	return FALSE
 
 
 /obj/machinery/particle_accelerator/control_box/proc/toggle_power()
@@ -211,16 +211,16 @@
 		for(var/CP in connected_parts)
 			var/obj/structure/particle_accelerator/part = CP
 			part.strength = strength
-			part.powered = 1
+			part.powered = TRUE
 			part.update_icon()
 	else
 		use_power = IDLE_POWER_USE
 		for(var/CP in connected_parts)
 			var/obj/structure/particle_accelerator/part = CP
 			part.strength = null
-			part.powered = 0
+			part.powered = FALSE
 			part.update_icon()
-	return 1
+	return TRUE
 
 
 /obj/machinery/particle_accelerator/control_box/ui_interact(mob/user)

--- a/code/modules/power/singularity/particle_accelerator/particle_control.dm
+++ b/code/modules/power/singularity/particle_accelerator/particle_control.dm
@@ -34,14 +34,11 @@
 	QDEL_NULL(wires)
 	return ..()
 
-/obj/machinery/particle_accelerator/control_box/attack_hand(mob/user)
-	. = ..()
-	if(.)
-		return
-	if(construction_state == PA_CONSTRUCTION_COMPLETE)
-		interact(user)
-	else if(construction_state == PA_CONSTRUCTION_PANEL_OPEN)
+/obj/machinery/particle_accelerator/control_box/multitool_act(mob/living/user, obj/item/I)
+	if(construction_state == PA_CONSTRUCTION_PANEL_OPEN)
 		wires.interact(user)
+		return TRUE
+	return ..()
 
 /obj/machinery/particle_accelerator/control_box/proc/update_state()
 	if(construction_state < PA_CONSTRUCTION_COMPLETE)
@@ -228,6 +225,13 @@
 
 /obj/machinery/particle_accelerator/control_box/ui_interact(mob/user)
 	. = ..()
+
+	if(construction_state != PA_CONSTRUCTION_COMPLETE)
+		return
+	if(construction_state == PA_CONSTRUCTION_PANEL_OPEN)
+		wires.interact(user)
+		return
+
 	if((get_dist(src, user) > 1) || (stat & (BROKEN|NOPOWER)))
 		if(!issilicon(user))
 			user.unset_machine()

--- a/code/modules/power/singularity/particle_accelerator/particle_control.dm
+++ b/code/modules/power/singularity/particle_accelerator/particle_control.dm
@@ -35,10 +35,10 @@
 	return ..()
 
 /obj/machinery/particle_accelerator/control_box/multitool_act(mob/living/user, obj/item/I)
+	..()
 	if(construction_state == PA_CONSTRUCTION_PANEL_OPEN)
 		wires.interact(user)
 		return TRUE
-	return ..()
 
 /obj/machinery/particle_accelerator/control_box/proc/update_state()
 	if(construction_state < PA_CONSTRUCTION_COMPLETE)


### PR DESCRIPTION
[Changelogs]: # (Your PR should contain a detailed changelog of notable changes, titled and categorized appropriately. This includes, new features, sprites, sounds, balance changes, admin tools, map edits, removals, big refactors, config changes, hosting changes and important fixes. An example changelog has been provided below for you to edit. If you need additional help, read https://github.com/tgstation/tgstation/wiki/Changelogs)

:cl: YoYoBatty
code: Particle accelerator control box now uses multitool_act and better ui_interact
fix: Particle accelerator wires can be opened by borgs with multitools now.
/:cl:

[why]: # (Please add a short description [two lines down] of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.)

This has been bothering me for a while now.