### PR TITLE
Fixes grenade launchers reporting incorrect live rounds

### DIFF
--- a/code/modules/projectiles/boxes_magazines/_box_magazine.dm
+++ b/code/modules/projectiles/boxes_magazines/_box_magazine.dm
@@ -124,8 +124,15 @@
 		materials[material] = material_amount
 
 //Behavior for magazines
-/obj/item/ammo_box/magazine/proc/ammo_count()
-	return stored_ammo.len
+/obj/item/ammo_box/magazine/proc/ammo_count(countempties = TRUE)
+	if(countempties)
+		return stored_ammo.len
+
+	var/boolets = 0
+	for(var/obj/item/ammo_casing/bullet in stored_ammo)
+		if(bullet && bullet.BB)
+			boolets++
+	return boolets
 
 /obj/item/ammo_box/magazine/proc/empty_magazine()
 	var/turf_mag = get_turf(src)

--- a/code/modules/projectiles/boxes_magazines/external/shotgun.dm
+++ b/code/modules/projectiles/boxes_magazines/external/shotgun.dm
@@ -8,7 +8,7 @@
 
 /obj/item/ammo_box/magazine/m12g/update_icon()
 	..()
-	icon_state = "[initial(icon_state)]-[CEILING(ammo_count(0)/8, 1)*8]"
+	icon_state = "[initial(icon_state)]-[CEILING(ammo_count(FALSE)/8, 1)*8]"
 
 /obj/item/ammo_box/magazine/m12g/stun
 	name = "shotgun magazine (12g taser slugs)"

--- a/code/modules/projectiles/boxes_magazines/internal/_cylinder.dm
+++ b/code/modules/projectiles/boxes_magazines/internal/_cylinder.dm
@@ -4,14 +4,6 @@
 	caliber = "357"
 	max_ammo = 7
 
-/obj/item/ammo_box/magazine/internal/cylinder/ammo_count(countempties = 1)
-	var/boolets = 0
-	for(var/obj/item/ammo_casing/bullet in stored_ammo)
-		if(bullet && (bullet.BB || countempties))
-			boolets++
-
-	return boolets
-
 /obj/item/ammo_box/magazine/internal/cylinder/get_round(keep = 0)
 	rotate()
 

--- a/code/modules/projectiles/boxes_magazines/internal/shotgun.dm
+++ b/code/modules/projectiles/boxes_magazines/internal/shotgun.dm
@@ -5,16 +5,6 @@
 	max_ammo = 4
 	multiload = 0
 
-/obj/item/ammo_box/magazine/internal/shot/ammo_count(countempties = 1)
-	if (!countempties)
-		var/boolets = 0
-		for(var/obj/item/ammo_casing/bullet in stored_ammo)
-			if(bullet.BB)
-				boolets++
-		return boolets
-	else
-		return ..()
-
 /obj/item/ammo_box/magazine/internal/shot/tube
 	name = "dual feed shotgun internal tube"
 	ammo_type = /obj/item/ammo_casing/shotgun/rubbershot

--- a/code/modules/projectiles/guns/ballistic.dm
+++ b/code/modules/projectiles/guns/ballistic.dm
@@ -46,7 +46,7 @@
 		chambered.forceMove(src)
 
 /obj/item/gun/ballistic/can_shoot()
-	if(!magazine || !magazine.ammo_count(0))
+	if(!magazine || !magazine.ammo_count(FALSE))
 		return 0
 	return 1
 
@@ -142,7 +142,7 @@
 	..()
 	to_chat(user, "It has [get_ammo()] round\s remaining.")
 
-/obj/item/gun/ballistic/proc/get_ammo(countchambered = 1)
+/obj/item/gun/ballistic/proc/get_ammo(countchambered = TRUE)
 	var/boolets = 0 //mature var names for mature people
 	if (chambered && countchambered)
 		boolets++

--- a/code/modules/projectiles/guns/ballistic/launchers.dm
+++ b/code/modules/projectiles/guns/ballistic/launchers.dm
@@ -95,4 +95,4 @@
 
 /obj/item/gun/ballistic/automatic/atlauncher/update_icon()
 	..()
-	icon_state = "rocketlauncher[magazine ? "-[get_ammo(1)]" : ""]"
+	icon_state = "rocketlauncher[magazine ? "-[get_ammo(TRUE)]" : ""]"

--- a/code/modules/projectiles/guns/ballistic/revolver.dm
+++ b/code/modules/projectiles/guns/ballistic/revolver.dm
@@ -70,9 +70,9 @@
 		chamber_round(0)
 
 /obj/item/gun/ballistic/revolver/can_shoot()
-	return get_ammo(0,0)
+	return get_ammo(FALSE, FALSE)
 
-/obj/item/gun/ballistic/revolver/get_ammo(countchambered = 0, countempties = 1)
+/obj/item/gun/ballistic/revolver/get_ammo(countchambered = FALSE, countempties = TRUE)
 	var/boolets = 0 //mature var names for mature people
 	if (chambered && countchambered)
 		boolets++
@@ -82,7 +82,8 @@
 
 /obj/item/gun/ballistic/revolver/examine(mob/user)
 	..()
-	to_chat(user, "[get_ammo(0,0)] of those are live rounds.")
+	var/live_ammo = get_ammo(FALSE, FALSE)
+	to_chat(user, "[live_ammo ? live_ammo : "None"] of those are live rounds.")
 
 /obj/item/gun/ballistic/revolver/detective
 	name = "\improper .38 Mars Special"


### PR DESCRIPTION
Fixes #26046
Also cleaned up some duplicate procs by rolling it into the parent one.

:cl: ShizCalev
fix: Grenade launchers will no longer report an incorrect number of live rounds.
/:cl: