### PR TITLE
[READY]fixing fuel cell

### DIFF
--- a/code/modules/integrated_electronics/passive/power.dm
+++ b/code/modules/integrated_electronics/passive/power.dm
@@ -93,7 +93,7 @@
 	container_type = OPENCONTAINER
 	complexity = 4
 	inputs = list()
-	outputs = list("volume used" = IC_PINTYPE_NUMBER, "self reference" = IC_PINTYPE_REF)
+	outputs = list("volume used" = IC_PINTYPE_NUMBER, "self reference" = IC_PINTYPE_SELFREF)
 	activators = list("push ref" = IC_PINTYPE_PULSE_IN)
 	spawn_flags = IC_SPAWN_DEFAULT|IC_SPAWN_RESEARCH
 	var/volume = 60


### PR DESCRIPTION
forgot this one here in the selfref PR

[Changelogs]: # Makes fuel cells use the selfref pins from #40129. I kinda forgot to change this one too

:cl: Shdorsh
fix: Fuel cell circuits are now using the right pin
/:cl:

[why]: # Part of the QOL PRs.