### PR TITLE
Plasma cutter nerfs to prevent cutterspam vs. stationside antags: lavaland only, others pending

### DIFF
--- a/code/modules/projectiles/guns/energy/special.dm
+++ b/code/modules/projectiles/guns/energy/special.dm
@@ -124,6 +124,7 @@
 	force = 12
 	sharpness = IS_SHARP
 	can_charge = 0
+	pin = /obj/item/firing_pin/mining //Can't use it as weapons on station unless you get an actual weapon pin.
 
 	heat = 3800
 	usesound = list('sound/items/welder.ogg', 'sound/items/welder2.ogg')

--- a/code/modules/projectiles/pins.dm
+++ b/code/modules/projectiles/pins.dm
@@ -213,7 +213,22 @@
 	suit_requirement = /obj/item/clothing/suit/bluetag
 	tagcolor = "blue"
 
+/obj/item/firing_pin/mining
+	name = "mining firing pin"
+	desc = "This is a mining firing pin. It only authorizes firing the weapon in designated mining locations."
+	fail_message = "<span class='warning'>INVALID LOCATION. REQUIRED LOCATION: MINING ZONE.</span>"
+	pin_removeable = TRUE
+
+/obj/item/firing_pin/mining/pin_auth(mob/living/user)
+	if(!istype(user))
+		return FALSE
+	if(is_mining_level(user.z)) //if you're somehow on a different turf z and user z, YOU HAVE BIGGER PROBLEMS BOY
+		return TRUE
+	return FALSE
+
+
 /obj/item/firing_pin/Destroy()
 	if(gun)
 		gun.pin = null
 	return ..()
+

--- a/code/modules/projectiles/projectile/special/plasma.dm
+++ b/code/modules/projectiles/projectile/special/plasma.dm
@@ -2,7 +2,7 @@
 	name = "plasma blast"
 	icon_state = "plasmacutter"
 	damage_type = BRUTE
-	damage = 20
+	damage = 10
 	range = 4
 	dismemberment = 20
 	impact_effect_type = /obj/effect/temp_visual/impact_effect/purple_laser
@@ -32,12 +32,12 @@
 			return -1
 
 /obj/item/projectile/plasma/adv
-	damage = 28
+	damage = 18
 	range = 5
 	mine_range = 5
 
 /obj/item/projectile/plasma/adv/mech
-	damage = 40
+	damage = 30
 	range = 9
 	mine_range = 3
 

--- a/code/modules/projectiles/projectile/special/plasma.dm
+++ b/code/modules/projectiles/projectile/special/plasma.dm
@@ -2,7 +2,7 @@
 	name = "plasma blast"
 	icon_state = "plasmacutter"
 	damage_type = BRUTE
-	damage = 10
+	damage = 20
 	range = 4
 	dismemberment = 20
 	impact_effect_type = /obj/effect/temp_visual/impact_effect/purple_laser
@@ -32,12 +32,12 @@
 			return -1
 
 /obj/item/projectile/plasma/adv
-	damage = 18
+	damage = 28
 	range = 5
 	mine_range = 5
 
 /obj/item/projectile/plasma/adv/mech
-	damage = 30
+	damage = 40
 	range = 9
 	mine_range = 3
 


### PR DESCRIPTION
It's still replaceable normally, but you now need actual firing pin to be able to use plasmacutters as a weapon on station. Does not otherwise nerf plasma cutters, for now.

:cl: Barhandar
balance: Following safety complaints, plasma cutters now come with special mining firing pin that only allows shooting the weapon while on Lavaland.
/:cl:

Because nerfing plasmacutters as weapons globally (see #40324) sucks for miners **and does not even affect the issue of being able to equip everyone with them**, and limiting them to lavaland doesn't while still preventing easy xeno/blob obliteration. They're still very potent weapons on station, if you can snag some good firing pins, but they're no longer unlimited supply, and there are better options to use pins on (for example, beam rifles).