### PR TITLE
Adds fancy boxes to cardboard crafting & flour sacks + UE designs to biogenerator.

### DIFF
--- a/code/game/objects/items/stacks/sheets/sheet_types.dm
+++ b/code/game/objects/items/stacks/sheets/sheet_types.dm
@@ -277,6 +277,9 @@ GLOBAL_LIST_INIT(cardboard_recipes, list ( \
 	new/datum/stack_recipe("cardborg suit", /obj/item/clothing/suit/cardborg, 3), \
 	new/datum/stack_recipe("cardborg helmet", /obj/item/clothing/head/cardborg), \
 	new/datum/stack_recipe("pizza box", /obj/item/pizzabox), \
+	new/datum/stack_recipe("donut box", /obj/item/storage/fancy/donut_box), \
+	new/datum/stack_recipe("egg box", /obj/item/storage/fancy/egg_box), \
+	new/datum/stack_recipe("candle box" /obj/item/storage/fancy/candle_box), \
 	new/datum/stack_recipe("folder", /obj/item/folder), \
 	new/datum/stack_recipe("large box", /obj/structure/closet/cardboard, 4), \
 	new/datum/stack_recipe("cardboard cutout", /obj/item/cardboard_cutout, 5), \

--- a/code/game/objects/items/stacks/sheets/sheet_types.dm
+++ b/code/game/objects/items/stacks/sheets/sheet_types.dm
@@ -279,7 +279,7 @@ GLOBAL_LIST_INIT(cardboard_recipes, list ( \
 	new/datum/stack_recipe("pizza box", /obj/item/pizzabox), \
 	new/datum/stack_recipe("donut box", /obj/item/storage/fancy/donut_box), \
 	new/datum/stack_recipe("egg box", /obj/item/storage/fancy/egg_box), \
-	new/datum/stack_recipe("candle box" /obj/item/storage/fancy/candle_box), \
+	new/datum/stack_recipe("candle box", /obj/item/storage/fancy/candle_box), \
 	new/datum/stack_recipe("folder", /obj/item/folder), \
 	new/datum/stack_recipe("large box", /obj/structure/closet/cardboard, 4), \
 	new/datum/stack_recipe("cardboard cutout", /obj/item/cardboard_cutout, 5), \

--- a/code/modules/research/designs/biogenerator_designs.dm
+++ b/code/modules/research/designs/biogenerator_designs.dm
@@ -51,6 +51,22 @@
 	make_reagents = list()
 	category = list("initial","Food")
 
+/datum/design/enzyme
+	name = "10u Universal Enzyme"
+	id = "enzyme"
+	build_type = BIOGENERATOR
+	materials = list(MAT_BIOMASS = 30)
+	make_reagents = list("enzyme" = 10)
+	category = list("initial","Food")
+
+/datum/design/flour_sack
+	name = "Flour Sack"
+	id = "flour_sack"
+	build_type = BIOGENERATOR
+	materials = list(MAT_BIOMASS = 150)
+	build_path = /obj/item/reagent_containers/food/condiment/flour
+	category = list("initial","Food")
+
 /datum/design/monkey_cube
 	name = "Monkey Cube"
 	id = "mcube"


### PR DESCRIPTION
:cl: Moon Farmer
add: Both reagent universal enzyme & sacks of flour are now availible for their respective costs from the biogenerator.
add: New crafting recipies for donut boxes, eggboxes & candle boxes have been added to cardboard recipies for the collective benefit of service personnel and the station.
/:cl:

![thanks to idea contributors](https://puu.sh/BvXsN/b134c5a0e5.png)

This PR strives to achieve greater co-operation by a use of biogenerator supplies, firstly the chef directly benefits with added capacity to store more donuts :doughnut: & additional eggs :egg: when availible than their starting equipment from constructable fancy boxes, while also being able to quickly produce quick sacks of wheat & spare universal enzyme with only minor botany input instead of waiting for lengthy emergency imports from cargo.

- The cost of the wheat sacks incentivises botanists who are too busy to grow wheat directly to quickly supply the chef out of other chaff plants, while making it ineffective enough to not rely upon it long-term.

:atom_symbol: **Why couldn't you atomise this? :** In practicality outside the scope of the game it is being conservative of GBP. Also, many of the points of fancy objects revolve around food and their relationship between service, such as the eggs to make the pastry, which then in turn makes the doughnuts to be eaten at a candlelit dinner (_if so inclined_) neatly stored in quantity. :candle: 
