### PR TITLE
Activating nanites resets timer

### DIFF
--- a/code/modules/research/nanites/nanite_programs.dm
+++ b/code/modules/research/nanites/nanite_programs.dm
@@ -115,6 +115,7 @@
 
 /datum/nanite_program/proc/activate()
 	activated = TRUE
+	timer_counter = activation_delay
 
 /datum/nanite_program/proc/deactivate()
 	if(passive_enabled)


### PR DESCRIPTION
:cl: XDTM
tweak: Sending an activation code to a nanite program will reset its timer.
fix: Fixed self-deactivating programs being unable to be reactivated afterwards.
/:cl:

Fixes #40379

Timer didn't reset properly, now it does. Plus, now you can extend the duration of your temporary programs if you want to do so.