### PR TITLE
Fixes maploader for areas.

### DIFF
--- a/code/modules/mapping/reader.dm
+++ b/code/modules/mapping/reader.dm
@@ -305,9 +305,9 @@
 	//The next part of the code assumes there's ALWAYS an /area AND a /turf on a given tile
 	//first instance the /area and remove it from the members list
 	index = members.len
-	if(members[index] != /area/template_noop)
-		GLOB._preloader.setup(members_attributes[index])//preloader for assigning  set variables on atom creation
+	if(members[index] != /area/template_noop)		
 		var/atype = members[index]
+		GLOB._preloader.setup(members_attributes[index], atype)//preloader for assigning  set variables on atom creation
 		var/atom/instance = areaCache[atype]
 		if (!instance)
 			instance = GLOB.areas_by_type[atype]


### PR DESCRIPTION
Wasn't setting type to load into before.
Technically this still doesn't mirror inbuilt loader 1:1 because different mapedits should create separate instances but let's leave that for now.

This was resulting in for example loaded areas with dynamic lighting to 0 to not initialize properly.