### PR TITLE
Prison food tastes gross now.

### DIFF
--- a/code/modules/food_and_drinks/drinks/drinks.dm
+++ b/code/modules/food_and_drinks/drinks/drinks.dm
@@ -207,6 +207,11 @@
 	spillable = TRUE
 	isGlass = FALSE
 
+/obj/item/reagent_containers/food/drinks/ice/prison
+	name = "dirty ice cup"
+	desc = "Either this machine actually vends lemon, chocolate, and cherry snow cones, or this isn't just ice."
+	list_reagents  = list("ice" = 25, "liquidgibs" = 5)
+
 /obj/item/reagent_containers/food/drinks/mug/ // parent type is literally just so empty mug sprites are a thing
 	name = "mug"
 	desc = "A drink served in a classy mug."

--- a/code/modules/food_and_drinks/drinks/drinks.dm
+++ b/code/modules/food_and_drinks/drinks/drinks.dm
@@ -209,7 +209,7 @@
 
 /obj/item/reagent_containers/food/drinks/ice/prison
 	name = "dirty ice cup"
-	desc = "Either this machine actually vends lemon, chocolate, and cherry snow cones, or this isn't just ice."
+	desc = "Either Nanotrasen's water supply is contaminated, or this machine actually vends lemon, chocolate, and cherry snow cones."
 	list_reagents  = list("ice" = 25, "liquidgibs" = 5)
 
 /obj/item/reagent_containers/food/drinks/mug/ // parent type is literally just so empty mug sprites are a thing

--- a/code/modules/food_and_drinks/food/snacks_meat.dm
+++ b/code/modules/food_and_drinks/food/snacks_meat.dm
@@ -65,6 +65,12 @@
 	tastes = list("tofu" = 1)
 	foodtype = VEGETABLES
 
+/obj/item/reagent_container/food/snacks/tofu/prison
+	name = "soggy tofu"
+	desc = "You refuse to eat this strange bean curd."
+	tastes = list("sour, rotten water" = 1)
+	foodtype = GROSS
+
 /obj/item/reagent_containers/food/snacks/spiderleg
 	name = "spider leg"
 	desc = "A still twitching leg of a giant spider... you don't really want to eat this, do you?"

--- a/code/modules/food_and_drinks/food/snacks_meat.dm
+++ b/code/modules/food_and_drinks/food/snacks_meat.dm
@@ -65,7 +65,7 @@
 	tastes = list("tofu" = 1)
 	foodtype = VEGETABLES
 
-/obj/item/reagent_container/food/snacks/tofu/prison
+/obj/item/reagent_containers/food/snacks/tofu/prison
 	name = "soggy tofu"
 	desc = "You refuse to eat this strange bean curd."
 	tastes = list("sour, rotten water" = 1)

--- a/code/modules/food_and_drinks/food/snacks_other.dm
+++ b/code/modules/food_and_drinks/food/snacks_other.dm
@@ -39,6 +39,14 @@
 	tastes = list("candy corn" = 1)
 	foodtype = JUNKFOOD | SUGAR
 
+/obj/item/reagent_containers/food/snacks/candy_corn/prison
+	name = "desiccated candy corn"
+	desc = "If this candy corn were any harder Security would confiscate it for being a potential shiv."
+	force = 1 // the description isn't lying
+	throwforce = 1 // if someone manages to bust out of jail with candy corn god bless them
+	tastes = list("bitter wax" = 1)
+	foodtype = GROSS
+
 /obj/item/reagent_containers/food/snacks/chocolatebar
 	name = "chocolate bar"
 	desc = "Such, sweet, fattening food."

--- a/code/modules/vending/sustenance.dm
+++ b/code/modules/vending/sustenance.dm
@@ -4,9 +4,9 @@
 	product_slogans = "Enjoy your meal.;Enough calories to support strenuous labor."
 	product_ads = "Sufficiently healthy.;Efficiently produced tofu!;Mmm! So good!;Have a meal.;You need food to live!;Have some more candy corn!;Try our new ice cups!"
 	icon_state = "sustenance"
-	products = list(/obj/item/reagent_containers/food/snacks/tofu = 24,
-					/obj/item/reagent_containers/food/drinks/ice = 12,
-					/obj/item/reagent_containers/food/snacks/candy_corn = 6)
+	products = list(/obj/item/reagent_containers/food/snacks/tofu/prison = 24,
+					/obj/item/reagent_containers/food/drinks/ice/prison = 12,
+					/obj/item/reagent_containers/food/snacks/candy_corn/prison = 6)
 	contraband = list(/obj/item/kitchen/knife = 6,
 					  /obj/item/reagent_containers/food/drinks/coffee = 12,
 					  /obj/item/tank/internals/emergency_oxygen = 6,


### PR DESCRIPTION
:cl: bandit
tweak: Due to cost-cutting measures throughout the company, Nanotrasen has changed the recipes for food supplied to sustenance vendors in all station brigs. Nanotrasen prides itself in its quality standards and is sure crew members will notice no difference in taste!
/:cl:

>get thrown into perma
>eat some food out of the sustenance vendor explicitly stated to contain gross food
>"I love this taste!"

This just creates subtypes of food for sustenance vendors, with the GROSS attribute, so if you are a species that likes gross food (flypeople for instance) you will also like prison food.