### PR TITLE
Fixes plasma cutters not using charge when used as welder, and adds flashing

### DIFF
--- a/code/modules/projectiles/guns/energy/special.dm
+++ b/code/modules/projectiles/guns/energy/special.dm
@@ -168,7 +168,9 @@
 	if(!cell)
 		to_chat(user, "<span class='warning'>[src] does not have a cell, and cannot be used!</span>")
 		return FALSE
-	// Amount cannot be used if drain is made continuous, e.g. amount = 5, charge_weld = 25,
+	// Amount cannot be used if drain is made continuous, e.g. amount = 5, charge_weld = 25
+	// Then it'll drain 125 at first and 25 periodically, but fail if charge dips below 125 even though it still can finish action
+	// Alternately it'll need to drain amount*charge_weld every period, which is either obscene or makes it free for other uses
 	if(amount ? cell.charge < charge_weld * amount : cell.charge < charge_weld)
 		to_chat(user, "<span class='warning'>You need more charge to complete this task!</span>")
 		return FALSE
@@ -176,7 +178,7 @@
 	return TRUE
 
 /obj/item/gun/energy/plasmacutter/use(amount)
-	return cell.use(amount ? amount * charge_weld : charge_weld)
+	return (cell && cell.use(amount ? amount * charge_weld : charge_weld))
 
 // This only gets called by use_tool(delay > 0)
 // It's also supposed to not get overridden in the first place.

--- a/code/modules/projectiles/guns/energy/special.dm
+++ b/code/modules/projectiles/guns/energy/special.dm
@@ -166,6 +166,9 @@
 
 //This is called every tick of delay by tool_check_callback
 /obj/item/gun/energy/plasmacutter/tool_use_check(mob/living/user, amount)
+	if(!cell)
+		to_chat(user, "<span class='warning'>[src] does not have a cell, and cannot be used!</span>")
+		return FALSE
 	if(cell.charge < charge_weld)
 		to_chat(user, "<span class='warning'>You need more charge to complete this task!</span>")
 		return FALSE

--- a/code/modules/projectiles/guns/energy/special.dm
+++ b/code/modules/projectiles/guns/energy/special.dm
@@ -37,7 +37,7 @@
 /obj/item/gun/energy/decloner/update_icon()
 	..()
 	var/obj/item/ammo_casing/energy/shot = ammo_type[select]
-	if(cell.charge > shot.e_cost)
+	if(!QDELETED(cell) && (cell.charge > shot.e_cost))
 		add_overlay("decloner_spin")
 
 /obj/item/gun/energy/floragun

--- a/code/modules/projectiles/guns/energy/special.dm
+++ b/code/modules/projectiles/guns/energy/special.dm
@@ -191,6 +191,12 @@
 		else
 			progress_flash_divisor--
 
+/obj/item/gun/energy/plasmacutter/use_tool(atom/target, mob/living/user, delay, amount=1, volume=0, datum/callback/extra_checks)
+	if(amount)
+		. = ..()
+	else
+		. = ..(amount=1)
+
 
 /obj/item/gun/energy/plasmacutter/update_icon()
 	return

--- a/code/modules/projectiles/guns/energy/special.dm
+++ b/code/modules/projectiles/guns/energy/special.dm
@@ -178,7 +178,7 @@
 	return TRUE
 
 /obj/item/gun/energy/plasmacutter/use(amount)
-	return !QDELETED(cell) ? cell.use(amount ? amount * charge_weld : charge_weld)) : FALSE
+	return (!QDELETED(cell) && cell.use(amount ? amount * charge_weld : charge_weld))
 
 // This only gets called by use_tool(delay > 0)
 // It's also supposed to not get overridden in the first place.

--- a/code/modules/projectiles/guns/energy/special.dm
+++ b/code/modules/projectiles/guns/energy/special.dm
@@ -165,7 +165,7 @@
 // Can we weld? Plasma cutter does not use charge continuously.
 // Amount cannot be defaulted to 1: most of the code specifies 0 in the call.
 /obj/item/gun/energy/plasmacutter/tool_use_check(mob/living/user, amount)
-	if(!cell)
+	if(QDELETED(cell))
 		to_chat(user, "<span class='warning'>[src] does not have a cell, and cannot be used!</span>")
 		return FALSE
 	// Amount cannot be used if drain is made continuous, e.g. amount = 5, charge_weld = 25
@@ -178,7 +178,7 @@
 	return TRUE
 
 /obj/item/gun/energy/plasmacutter/use(amount)
-	return (cell && cell.use(amount ? amount * charge_weld : charge_weld))
+	return !QDELETED(cell) ? cell.use(amount ? amount * charge_weld : charge_weld)) : FALSE
 
 // This only gets called by use_tool(delay > 0)
 // It's also supposed to not get overridden in the first place.

--- a/code/modules/projectiles/guns/energy/special.dm
+++ b/code/modules/projectiles/guns/energy/special.dm
@@ -113,6 +113,7 @@
 	ammo_type = list(/obj/item/ammo_casing/energy/bolt/large)
 	pin = null
 
+
 /obj/item/gun/energy/plasmacutter
 	name = "plasma cutter"
 	desc = "A mining tool capable of expelling concentrated plasma bursts. You could use it to cut limbs off xenos! Or, you know, mine stuff."
@@ -129,6 +130,8 @@
 	usesound = list('sound/items/welder.ogg', 'sound/items/welder2.ogg')
 	tool_behaviour = TOOL_WELDER
 	toolspeed = 0.7 //plasmacutters can be used as welders, and are faster than standard welders
+	var/progress_flash_divisor = 10  //copypasta is best pasta
+	var/light_intensity = 0
 
 /obj/item/gun/energy/plasmacutter/Initialize()
 	. = ..()
@@ -152,16 +155,12 @@
 		..()
 
 // Tool procs, in case plasma cutter is used as welder
+
 /obj/item/gun/energy/plasmacutter/tool_use_check(mob/living/user, amount)
 	if(!QDELETED(cell) && (cell.charge >= amount * 100))
 		return TRUE
 
-	to_chat(user, "<span class='warning'>You need more charge to complete this task!</span>")
-	return FALSE
-
 /obj/item/gun/energy/plasmacutter/use(amount)
-	return cell.use(amount * 100)
-
 /obj/item/gun/energy/plasmacutter/update_icon()
 	return
 


### PR DESCRIPTION
Resolves first (and consequently fourth) issue from #40409.

:cl: Barhandar
balance: Plasma cutters now flash you (same intensity as experimental welder) when used for welding.
fix: Plasma cutters also use charge to weld. 25 per most things like vents or walls, more for specials like airlock shielding.
/:cl:


