### PR TITLE
makes /datum/gas_mixture/turf/heat_capacity() 20% faster with the power of copypasta

### DIFF
--- a/code/modules/atmospherics/gasmixtures/gas_mixture.dm
+++ b/code/modules/atmospherics/gasmixtures/gas_mixture.dm
@@ -81,8 +81,12 @@ GLOBAL_LIST_INIT(gaslist_cache, init_gaslist_cache())
 		var/gas_data = cached_gases[id]
 		. += gas_data[data] * gas_data[GAS_META][META_GAS_SPECIFIC_HEAT]
 
-/datum/gas_mixture/turf/heat_capacity()
-	. = ..()
+/datum/gas_mixture/turf/heat_capacity(data = MOLES) // Same as above except vacuums return HEAT_CAPACITY_VACUUM
+	var/list/cached_gases = gases
+	. = 0
+	for(var/id in cached_gases)
+		var/gas_data = cached_gases[id]
+		. += gas_data[data] * gas_data[GAS_META][META_GAS_SPECIFIC_HEAT]
 	if(!.)
 		. += HEAT_CAPACITY_VACUUM //we want vacuums in turfs to have the same heat capacity as space
 


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/20017308/45922622-eab96780-bed9-11e8-863b-ba3c9898b580.png)

The significant comparison here is turf/new_heat_capacity total vs. turf/old_heat_capacity total. The other proc is there just to make . = ..() work