### PR TITLE
Fixed the icon state of two floor tiles in puppy science

### DIFF
--- a/_maps/map_files/PubbyStation/PubbyStation.dmm
+++ b/_maps/map_files/PubbyStation/PubbyStation.dmm
@@ -32881,7 +32881,7 @@
 	dir = 8
 	},
 /turf/open/floor/plasteel{
-	icon_state = "purple"
+	icon_state = "floor"
 	},
 /area/hallway/primary/aft)
 "byK" = (
@@ -36146,7 +36146,7 @@
 	dir = 8
 	},
 /turf/open/floor/plasteel/dark{
-	icon_state = "darkpurple"
+	icon_state = "darkfull"
 	},
 /area/crew_quarters/heads/hor)
 "bES" = (


### PR DESCRIPTION
Fixes #40307

:cl: EchoZed
fix: The icon state of the two floor tiles were incorrect. Changed them to match the state of their surrounding tiles.
/:cl:

First PR, hopefully I did everything right.