### PR TITLE
Adds APC to Delta hydroponics

### DIFF
--- a/_maps/map_files/Deltastation/DeltaStation2.dmm
+++ b/_maps/map_files/Deltastation/DeltaStation2.dmm
@@ -30788,6 +30788,7 @@
 /obj/effect/turf_decal/tile/green{
 	dir = 8
 	},
+/obj/machinery/power/apc/auto_name/south,
 /turf/open/floor/plasteel,
 /area/hydroponics)
 "beS" = (


### PR DESCRIPTION
:cl: Denton
fix: Deltastation's hydroponics department now has an APC and no longer draws its power from the twilight zone.
/:cl:

Closes: #40450