### PR TITLE
[s] Fixes ore redemption exploit

### DIFF
--- a/code/modules/mining/machine_redemption.dm
+++ b/code/modules/mining/machine_redemption.dm
@@ -53,7 +53,7 @@
 	if (!mat_container)
 		return
 		
-	if(istype(O, /obj/item/stack/ore/bluespace_crystal/refined))
+	if(O.refined_type == null)
 		return
 
 	ore_buffer -= O

--- a/code/modules/mining/machine_redemption.dm
+++ b/code/modules/mining/machine_redemption.dm
@@ -52,6 +52,9 @@
 	var/datum/component/material_container/mat_container = materials.mat_container
 	if (!mat_container)
 		return
+		
+	if(istype(O, /obj/item/stack/ore/bluespace_crystal/refined))
+		return
 
 	ore_buffer -= O
 
@@ -179,6 +182,11 @@
 		if(user.transferItemToLoc(W, src))
 			inserted_disk = W
 			return TRUE
+			
+	if(istype(W, /obj/item/stack/ore/bluespace_crystal/refined))
+		to_chat(user, "<span class='notice'>[W] has already been refined!</span>")
+		return
+		
 	return ..()
 
 /obj/machinery/mineral/ore_redemption/multitool_act(mob/living/user, obj/item/multitool/I)

--- a/code/modules/mining/machine_redemption.dm
+++ b/code/modules/mining/machine_redemption.dm
@@ -183,9 +183,10 @@
 			inserted_disk = W
 			return TRUE
 			
-	if(istype(W, /obj/item/stack/ore/bluespace_crystal/refined))
-		to_chat(user, "<span class='notice'>[W] has already been refined!</span>")
-		return
+	if(istype(W, /obj/item/stack/ore))
+		if(W.refined_type == null)
+			to_chat(user, "<span class='notice'>[W] has already been refined!</span>")
+			return
 		
 	return ..()
 

--- a/code/modules/mining/machine_redemption.dm
+++ b/code/modules/mining/machine_redemption.dm
@@ -183,12 +183,11 @@
 			inserted_disk = W
 			return TRUE
 			
-	if(istype(W, /obj/item/stack/ore))
-		var/obj/item/stack/ore/O = W
-		if(istype(O))
-			if(O.refined_type == null)
-				to_chat(user, "<span class='notice'>[O] has already been refined!</span>")
-				return
+	var/obj/item/stack/ore/O = W
+	if(istype(O))
+		if(O.refined_type == null)
+			to_chat(user, "<span class='notice'>[O] has already been refined!</span>")
+			return
 		
 	return ..()
 

--- a/code/modules/mining/machine_redemption.dm
+++ b/code/modules/mining/machine_redemption.dm
@@ -184,9 +184,11 @@
 			return TRUE
 			
 	if(istype(W, /obj/item/stack/ore))
-		if(W.refined_type == null)
-			to_chat(user, "<span class='notice'>[W] has already been refined!</span>")
-			return
+		var/obj/item/stack/ore/O = W
+		if(istype(O))
+			if(O.refined_type == null)
+				to_chat(user, "<span class='notice'>[O] has already been refined!</span>")
+				return
 		
 	return ..()
 


### PR DESCRIPTION
Since the crystal is already refined, it would make sense for the refinery to reject it. 

fixes #35057