### PR TITLE
Handheld IDs are valid for authentication

### DIFF
--- a/code/game/machinery/_machinery.dm
+++ b/code/game/machinery/_machinery.dm
@@ -240,7 +240,7 @@ Class Procs:
 	if(occupant && !state_open)
 		if(ishuman(occupant))
 			var/mob/living/carbon/human/H = occupant
-			var/obj/item/card/id/I = H.get_idcard()
+			var/obj/item/card/id/I = H.get_idcard(TRUE)
 			if(I)
 				var/datum/bank_account/insurance = I.registered_account
 				if(!insurance)

--- a/code/game/machinery/computer/apc_control.dm
+++ b/code/game/machinery/computer/apc_control.dm
@@ -93,9 +93,7 @@
 	if(!usr || !usr.canUseTopic(src) || stat || QDELETED(src))
 		return
 	if(href_list["authenticate"])
-		var/obj/item/card/id/ID = usr.get_active_held_item()
-		if(!istype(ID))
-			ID = usr.get_idcard()
+		var/obj/item/card/id/ID = usr.get_idcard(TRUE)
 		if(ID && istype(ID))
 			if(check_access(ID))
 				authenticated = TRUE

--- a/code/game/machinery/computer/cloning.dm
+++ b/code/game/machinery/computer/cloning.dm
@@ -439,7 +439,7 @@
 	if(ishuman(mob_occupant))
 		var/mob/living/carbon/C = mob_occupant
 		dna = C.has_dna()
-		var/obj/item/card/id/I = C.get_idcard()
+		var/obj/item/card/id/I = C.get_idcard(TRUE)
 		if(I)
 			has_bank_account = I.registered_account
 	if(isbrain(mob_occupant))

--- a/code/game/machinery/computer/communications.dm
+++ b/code/game/machinery/computer/communications.dm
@@ -71,9 +71,7 @@
 		if("login")
 			var/mob/M = usr
 
-			var/obj/item/card/id/I = M.get_active_held_item()
-			if(!istype(I))
-				I = M.get_idcard()
+			var/obj/item/card/id/I = M.get_idcard(TRUE)
 
 			if(I && istype(I))
 				if(check_access(I))

--- a/code/modules/cargo/console.dm
+++ b/code/modules/cargo/console.dm
@@ -161,7 +161,7 @@
 			if(ishuman(usr))
 				var/mob/living/carbon/human/H = usr
 				name = H.get_authentification_name()
-				rank = H.get_assignment()
+				rank = H.get_assignment(hand_first = TRUE)
 			else if(issilicon(usr))
 				name = usr.real_name
 				rank = "Silicon"

--- a/code/modules/cargo/expressconsole.dm
+++ b/code/modules/cargo/expressconsole.dm
@@ -157,7 +157,7 @@
 			if(ishuman(usr))
 				var/mob/living/carbon/human/H = usr
 				name = H.get_authentification_name()
-				rank = H.get_assignment()
+				rank = H.get_assignment(hand_first = TRUE)
 			else if(issilicon(usr))
 				name = usr.real_name
 				rank = "Silicon"

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -566,7 +566,7 @@
 		return threatcount
 
 	//Check for ID
-	var/obj/item/card/id/idcard = get_idcard()
+	var/obj/item/card/id/idcard = get_idcard(FALSE)
 	if( (judgement_criteria & JUDGE_IDCHECK) && !idcard && name=="Unknown")
 		threatcount += 4
 

--- a/code/modules/mob/living/carbon/human/human_helpers.dm
+++ b/code/modules/mob/living/carbon/human/human_helpers.dm
@@ -85,17 +85,27 @@
 		. = if_no_id	//to prevent null-names making the mob unclickable
 	return
 
-//Gets ID card object. If hand_first is false the one in the id slot is prioritized.
+//Gets ID card from a human. If hand_first is false the one in the id slot is prioritized, otherwise inventory slots go first.
 /mob/living/carbon/human/get_idcard(hand_first = TRUE)
+	//Check hands
 	var/obj/item/I = get_active_held_item()
-	if(I.GetID())
+	if(!I)
+		I = get_inactive_held_item()
+	if(I && I.GetID())
 		if(hand_first)
 			return I.GetID()
 		else
 			. = I.GetID()
-	if(wear_id)
+			
+	//Check inventory slots		
+	if(wear_id && wear_id.GetID())
 		return wear_id.GetID()
-
+	else if(belt && belt.GetID())
+		return belt.GetID()
+	else if(l_store && l_store.GetID())
+		return l_store.GetID()
+	else if(r_store && r_store.GetID())
+		return r_store.GetID()
 
 /mob/living/carbon/human/IsAdvancedToolUser()
 	if(has_trait(TRAIT_MONKEYLIKE))

--- a/code/modules/mob/living/carbon/human/human_helpers.dm
+++ b/code/modules/mob/living/carbon/human/human_helpers.dm
@@ -11,8 +11,8 @@
 
 //gets assignment from ID or ID inside PDA or PDA itself
 //Useful when player do something with computers
-/mob/living/carbon/human/proc/get_assignment(if_no_id = "No id", if_no_job = "No job")
-	var/obj/item/card/id/id = get_idcard()
+/mob/living/carbon/human/proc/get_assignment(if_no_id = "No id", if_no_job = "No job", hand_first = TRUE)
+	var/obj/item/card/id/id = get_idcard(hand_first)
 	if(id)
 		. = id.assignment
 	else
@@ -27,7 +27,7 @@
 //gets name from ID or ID inside PDA or PDA itself
 //Useful when player do something with computers
 /mob/living/carbon/human/proc/get_authentification_name(if_no_id = "Unknown")
-	var/obj/item/card/id/id = get_idcard()
+	var/obj/item/card/id/id = get_idcard(FALSE)
 	if(id)
 		return id.registered_name
 	var/obj/item/pda/pda = wear_id
@@ -85,8 +85,14 @@
 		. = if_no_id	//to prevent null-names making the mob unclickable
 	return
 
-//gets ID card object from special clothes slot or null.
-/mob/living/carbon/human/get_idcard()
+//Gets ID card object. If hand_first is false the one in the id slot is prioritized.
+/mob/living/carbon/human/get_idcard(hand_first = TRUE)
+	var/obj/item/I = get_active_held_item()
+	if(I.GetID())
+		if(hand_first)
+			return I.GetID()
+		else
+			. = I.GetID()
 	if(wear_id)
 		return wear_id.GetID()
 

--- a/code/modules/mob/living/carbon/human/human_helpers.dm
+++ b/code/modules/mob/living/carbon/human/human_helpers.dm
@@ -107,19 +107,19 @@
 	if(wear_id)
 		id_card = wear_id.GetID()
 		if(id_card)
-			return wear_id.GetID()
+			return id_card
 	else if(belt)
 		id_card = belt.GetID()
 		if(id_card)
-			return belt.GetID()
+			return id_card
 	else if(l_store)
 		id_card = l_store.GetID()
 		if(id_card)
-			return l_store.GetID()
+			return id_card
 	else if(r_store)
 		id_card = r_store.GetID()
 		if(id_card)
-			return r_store.GetID()
+			return id_card
 
 /mob/living/carbon/human/IsAdvancedToolUser()
 	if(has_trait(TRAIT_MONKEYLIKE))

--- a/code/modules/mob/living/carbon/human/human_helpers.dm
+++ b/code/modules/mob/living/carbon/human/human_helpers.dm
@@ -112,14 +112,6 @@
 		id_card = belt.GetID()
 		if(id_card)
 			return id_card
-	else if(l_store)
-		id_card = l_store.GetID()
-		if(id_card)
-			return id_card
-	else if(r_store)
-		id_card = r_store.GetID()
-		if(id_card)
-			return id_card
 
 /mob/living/carbon/human/IsAdvancedToolUser()
 	if(has_trait(TRAIT_MONKEYLIKE))

--- a/code/modules/mob/living/carbon/human/human_helpers.dm
+++ b/code/modules/mob/living/carbon/human/human_helpers.dm
@@ -88,24 +88,38 @@
 //Gets ID card from a human. If hand_first is false the one in the id slot is prioritized, otherwise inventory slots go first.
 /mob/living/carbon/human/get_idcard(hand_first = TRUE)
 	//Check hands
-	var/obj/item/I = get_active_held_item()
-	if(!I)
-		I = get_inactive_held_item()
-	if(I && I.GetID())
+	var/obj/item/card/id/id_card
+	var/obj/item/held_item
+	held_item = get_active_held_item()
+	if(I) //Check active hand
+		id_card = held_item.GetID()
+	if(!id_card) //If there is no id, check the other hand
+		held_item = get_inactive_held_item()
+		id_card = held_item.GetID()
+		
+	if(id_card)
 		if(hand_first)
-			return I.GetID()
+			return id_card
 		else
-			. = I.GetID()
+			. = id_card
 			
 	//Check inventory slots		
-	if(wear_id && wear_id.GetID())
-		return wear_id.GetID()
-	else if(belt && belt.GetID())
-		return belt.GetID()
-	else if(l_store && l_store.GetID())
-		return l_store.GetID()
-	else if(r_store && r_store.GetID())
-		return r_store.GetID()
+	if(wear_id)
+		id_card = wear_id.GetID()
+		if(id_card)
+			return wear_id.GetID()
+	else if(belt)
+		id_card = belt.GetID()
+		if(id_card)
+			return belt.GetID()
+	else if(l_store)
+		id_card = l_store.GetID()
+		if(id_card)
+			return l_store.GetID()
+	else if(r_store)
+		id_card = r_store.GetID()
+		if(id_card)
+			return r_store.GetID()
 
 /mob/living/carbon/human/IsAdvancedToolUser()
 	if(has_trait(TRAIT_MONKEYLIKE))

--- a/code/modules/mob/living/carbon/human/human_helpers.dm
+++ b/code/modules/mob/living/carbon/human/human_helpers.dm
@@ -91,7 +91,7 @@
 	var/obj/item/card/id/id_card
 	var/obj/item/held_item
 	held_item = get_active_held_item()
-	if(I) //Check active hand
+	if(held_item) //Check active hand
 		id_card = held_item.GetID()
 	if(!id_card) //If there is no id, check the other hand
 		held_item = get_inactive_held_item()

--- a/code/modules/mob/living/simple_animal/simple_animal.dm
+++ b/code/modules/mob/living/simple_animal/simple_animal.dm
@@ -463,7 +463,7 @@
 			return
 	sync_lighting_plane_alpha()
 
-/mob/living/simple_animal/get_idcard()
+/mob/living/simple_animal/get_idcard(hand_first)
 	return access_card
 
 /mob/living/simple_animal/OpenCraftingMenu()

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -884,7 +884,7 @@
 /mob/proc/can_hold_items()
 	return FALSE
 
-/mob/proc/get_idcard()
+/mob/proc/get_idcard(hand_first)
 	return
 
 

--- a/code/modules/modular_computers/file_system/program.dm
+++ b/code/modules/modular_computers/file_system/program.dm
@@ -97,23 +97,15 @@
 			card_slot = computer.all_components[MC_CARD]
 			D = card_slot.GetID()
 		var/mob/living/carbon/human/h = user
-		var/obj/item/card/id/I = h.get_idcard()
-		var/obj/item/card/id/C = h.get_active_held_item()
-		if(C)
-			C = C.GetID()
-		if(!(C && istype(C)))
-			C = null
+		var/obj/item/card/id/I = h.get_idcard(TRUE)
 
-		if(!I && !C && !D)
+		if(!I && !D)
 			if(loud)
 				to_chat(user, "<span class='danger'>\The [computer] flashes an \"RFID Error - Unable to scan ID\" warning.</span>")
 			return 0
 
 		if(I)
 			if(access_to_check in I.GetAccess())
-				return 1
-		else if(C)
-			if(access_to_check in C.GetAccess())
 				return 1
 		else if(D)
 			if(access_to_check in D.GetAccess())

--- a/code/modules/modular_computers/file_system/programs/card.dm
+++ b/code/modules/modular_computers/file_system/programs/card.dm
@@ -117,7 +117,7 @@
 	else
 		if(ishuman(user))
 			var/mob/living/carbon/human/h = user
-			user_id_card = h.get_idcard()
+			user_id_card = h.get_idcard(TRUE)
 
 	switch(action)
 		if("PRG_switchm")

--- a/code/modules/shuttle/emergency.dm
+++ b/code/modules/shuttle/emergency.dm
@@ -57,7 +57,7 @@
 	var/mob/user = usr
 	. = FALSE
 
-	var/obj/item/card/id/ID = user.get_idcard()
+	var/obj/item/card/id/ID = user.get_idcard(TRUE)
 
 	if(!ID)
 		to_chat(user, "<span class='warning'>You don't have an ID.</span>")
@@ -93,7 +93,7 @@
 			minor_announce("Early launch authorization revoked, [remaining] authorizations needed")
 
 /obj/machinery/computer/emergency_shuttle/proc/authorize(mob/user, source)
-	var/obj/item/card/id/ID = user.get_idcard()
+	var/obj/item/card/id/ID = user.get_idcard(TRUE)
 
 	if(ID in authorized)
 		return FALSE

--- a/code/modules/shuttle/special.dm
+++ b/code/modules/shuttle/special.dm
@@ -199,7 +199,7 @@
 		if(H.mind && H.mind.assigned_role == "Bartender")
 			return TRUE
 
-	var/obj/item/card/id/ID = user.get_idcard()
+	var/obj/item/card/id/ID = user.get_idcard(FALSE)
 	if(ID && (ACCESS_CENT_BAR in ID.access))
 		return TRUE
 

--- a/code/modules/vending/_vending.dm
+++ b/code/modules/vending/_vending.dm
@@ -305,7 +305,7 @@ IF YOU MODIFY THE PRODUCTS LIST OF A MACHINE, MAKE SURE TO UPDATE ITS RESUPPLY C
 	var/obj/item/card/id/C
 	if(ishuman(user))
 		H = user
-		C = H.get_idcard()
+		C = H.get_idcard(TRUE)
 
 	if(!C)
 		dat += "<font color = 'red'><h3>No ID Card detected!</h3></font>"
@@ -376,7 +376,7 @@ IF YOU MODIFY THE PRODUCTS LIST OF A MACHINE, MAKE SURE TO UPDATE ITS RESUPPLY C
 		vend_ready = 0
 		if(ishuman(usr) && onstation)
 			var/mob/living/carbon/human/H = usr
-			var/obj/item/card/id/C = H.get_idcard()
+			var/obj/item/card/id/C = H.get_idcard(TRUE)
 
 			if(!C)
 				say("No card found.")
@@ -441,7 +441,7 @@ IF YOU MODIFY THE PRODUCTS LIST OF A MACHINE, MAKE SURE TO UPDATE ITS RESUPPLY C
 			return
 		if(onstation && ishuman(usr))
 			var/mob/living/carbon/human/H = usr
-			var/obj/item/card/id/C = H.get_idcard()
+			var/obj/item/card/id/C = H.get_idcard(TRUE)
 
 			if(!C)
 				say("No card found.")


### PR DESCRIPTION
:cl: XDTM
tweak: Holding an ID in your hands uses it instead of your worn ID for authentication purposes.
tweak: If you don't have an ID in your id slot, the belt slot will be checked as well.
/:cl:

Fixes #40437

Makes sense if you want to use a specific access card without playing pocket tetris. The get_idcard has an argument for prioritizing worn id over held id, for stuff like identification.
