### PR TITLE
Fix banlist runtime not creating notes for server bans

### DIFF
--- a/code/modules/admin/NewBan.dm
+++ b/code/modules/admin/NewBan.dm
@@ -101,7 +101,8 @@ GLOBAL_PROTECT(Banlist)
 
 
 /proc/AddBan(key, computerid, reason, bannedby, temp, minutes, address)
-
+	if(!CONFIG_GET(flag/ban_legacy_system))
+		return
 	var/bantimestamp
 	var/ban_ckey = ckey(key)
 	if (temp)
@@ -124,10 +125,6 @@ GLOBAL_PROTECT(Banlist)
 		WRITE_FILE(GLOB.Banlist["roundid"], GLOB.round_id)
 		if (temp)
 			WRITE_FILE(GLOB.Banlist["minutes"], bantimestamp)
-		if(!temp)
-			create_message("note", key, bannedby, "Permanently banned - [reason]", null, null, 0, 0, null, 0, 0)
-		else
-			create_message("note", key, bannedby, "Banned for [minutes] minutes - [reason]", null, null, 0, 0, null, 0, 0)
 	return 1
 
 /proc/RemoveBan(foldername)

--- a/code/modules/admin/topic.dm
+++ b/code/modules/admin/topic.dm
@@ -1276,6 +1276,7 @@
 					to_chat(usr, "<span class='danger'>Failed to apply ban.</span>")
 					return
 				AddBan(M.ckey, M.computer_id, reason, usr.ckey, 1, mins)
+				create_message("note", ckey(M.ckey), usr.ckey, "Banned for [mins] minutes - [reason]", null, null, 0, 0, null, 0, 0)
 				ban_unban_log_save("[key_name(usr)] has banned [key_name(M)]. - Reason: [reason] - This will be removed in [mins] minutes.")
 				to_chat(M, "<span class='boldannounce'><BIG>You have been banned by [usr.client.key].\nReason: [reason]</BIG></span>")
 				to_chat(M, "<span class='danger'>This is a temporary ban, it will be removed in [mins] minutes. The round ID is [GLOB.round_id].</span>")
@@ -1302,6 +1303,7 @@
 						AddBan(M.ckey, M.computer_id, reason, usr.ckey, 0, 0, M.lastKnownIP)
 					if("No")
 						AddBan(M.ckey, M.computer_id, reason, usr.ckey, 0, 0)
+				create_message("note", ckey(M.ckey), usr.ckey, "Permanently banned - [reason]", null, null, 0, 0, null, 0, 0)
 				to_chat(M, "<span class='boldannounce'><BIG>You have been banned by [usr.client.key].\nReason: [reason]</BIG></span>")
 				to_chat(M, "<span class='danger'>This is a permanent ban. The round ID is [GLOB.round_id].</span>")
 				var/bran = CONFIG_GET(string/banappeals)


### PR DESCRIPTION
Since the banlist file is no longer created when legacy ban is off `AddBan` would runtime trying to append access the file and the call to create a note for server bans is hidden after that because aaaaaaah.
Jobbans are fine though.

This does mean that when sql banning is enabled a fallback legacy ban is no longer created as well, but the alternative is just runtiming so....