### PR TITLE
Bank Cards now only display messages to the owner if carried

### DIFF
--- a/code/__HELPERS/game.dm
+++ b/code/__HELPERS/game.dm
@@ -498,12 +498,11 @@
 //Recursively checks if an item is inside a given type, even through layers of storage. Returns the atom if it finds it.
 /proc/recursive_loc_check(atom/movable/target, type)
 	var/atom/A = target
-	while(TRUE)
+	while(!istype(A.loc, type))
 		if(!A.loc)
 			return
-		if(istype(A.loc, type))
-			return A.loc
 		A = A.loc
+	return A
 
 /proc/AnnounceArrival(var/mob/living/carbon/human/character, var/rank)
 	if(!SSticker.IsRoundInProgress() || QDELETED(character))

--- a/code/__HELPERS/game.dm
+++ b/code/__HELPERS/game.dm
@@ -499,11 +499,11 @@
 /proc/recursive_loc_check(atom/movable/target, type)
 	var/atom/A = target
 	while(TRUE)
-		if(!loc)
+		if(!A.loc)
 			return
 		if(istype(A.loc, type))
 			return A.loc
-		A = loc
+		A = A.loc
 
 /proc/AnnounceArrival(var/mob/living/carbon/human/character, var/rank)
 	if(!SSticker.IsRoundInProgress() || QDELETED(character))

--- a/code/__HELPERS/game.dm
+++ b/code/__HELPERS/game.dm
@@ -494,6 +494,16 @@
 	if(!C || (!C.prefs.windowflashing && !ignorepref))
 		return
 	winset(C, "mainwindow", "flash=5")
+	
+//Recursively checks if an item is inside a given type, even through layers of storage. Returns the atom if it finds it.
+/proc/recursive_loc_check(atom/movable/target, type)
+	var/atom/A = target
+	while(TRUE)
+		if(!loc)
+			return
+		if(istype(A.loc, type))
+			return A.loc
+		A = loc
 
 /proc/AnnounceArrival(var/mob/living/carbon/human/character, var/rank)
 	if(!SSticker.IsRoundInProgress() || QDELETED(character))

--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -405,16 +405,6 @@ GLOBAL_VAR_INIT(rpg_loot_items, FALSE)
 		return 0
 
 	return M.can_equip(src, slot, disable_warning, bypass_equip_delay_self)
-	
-//Recursively checks if an item is inside a mob, even through layers of storage. Returns the mob if it finds one.
-/obj/item/proc/is_in_mob()
-	var/atom/A = src
-	while(TRUE)
-		if(!loc || isturf(loc))
-			return
-		if(ismob(A.loc))
-			return A.loc
-		A = loc
 
 /obj/item/verb/verb_pickup()
 	set src in oview(1)

--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -405,6 +405,16 @@ GLOBAL_VAR_INIT(rpg_loot_items, FALSE)
 		return 0
 
 	return M.can_equip(src, slot, disable_warning, bypass_equip_delay_self)
+	
+//Recursively checks if an item is inside a mob, even through layers of storage. Returns the mob if it finds one.
+/obj/item/proc/is_in_mob()
+	var/atom/A = src
+	while(TRUE)
+		if(!loc || isturf(loc))
+			return
+		if(ismob(A.loc))
+			return A.loc
+		A = loc
 
 /obj/item/verb/verb_pickup()
 	set src in oview(1)

--- a/code/modules/economy/account.dm
+++ b/code/modules/economy/account.dm
@@ -54,12 +54,16 @@
 	bank_card_talk("ERROR: Payday aborted, unable to contact departmental account.")
 	return FALSE
 
-/datum/bank_account/proc/bank_card_talk(fuck)
-	if(!fuck || !bank_cards.len)
+/datum/bank_account/proc/bank_card_talk(message)
+	if(!message || !bank_cards.len)
 		return
 	for(var/obj/A in bank_cards)
-		for(var/mob/M in hearers(1,get_turf(A)))
-			to_chat(M, fuck)
+		if(ismob(A.loc))
+			var/mob/card_holder = A.loc
+			to_chat(card_holder, message)
+		else if(isturf(A.loc))
+			for(var/mob/M in hearers(1,get_turf(A)))
+				to_chat(M, message)
 
 /datum/bank_account/department
 	account_holder = "Guild Credit Agency"

--- a/code/modules/economy/account.dm
+++ b/code/modules/economy/account.dm
@@ -68,7 +68,7 @@
 				playsound(get_turf(card_holder), 'sound/machines/twobeep.ogg', 50, 1)
 				A.audible_message("[icon2html(A, hearers(A))] *[message]*", null, 1)
 		else
-			for(var/mob/M in A.loc.contents) //If inside a container with other mobs (e.g. locker)
+			for(var/mob/M in A.loc) //If inside a container with other mobs (e.g. locker)
 				M.playsound_local(get_turf(M), 'sound/machines/twobeep.ogg', 50, 1)
 				if(M.can_hear())
 					to_chat(M, "[icon2html(A, M)] *[message]*")

--- a/code/modules/economy/account.dm
+++ b/code/modules/economy/account.dm
@@ -58,12 +58,20 @@
 	if(!message || !bank_cards.len)
 		return
 	for(var/obj/A in bank_cards)
-		if(ismob(A.loc))
-			var/mob/card_holder = A.loc
-			to_chat(card_holder, message)
-		else if(isturf(A.loc))
+		var/mob/card_holder = recursive_loc_check(A, /mob)
+		if(card_holder) //If on a mob
+			card_holder.playsound_local(get_turf(card_holder), 'sound/machines/twobeep.ogg', 50, 1)
+			if(card_holder.can_hear())
+				to_chat(card_holder, "[icon2html(A, card_holder)] *[message]*")
+		else if(isturf(A.loc)) //If on the ground
 			for(var/mob/M in hearers(1,get_turf(A)))
-				to_chat(M, message)
+				playsound(get_turf(card_holder), 'sound/machines/twobeep.ogg', 50, 1)
+				A.audible_message("[icon2html(A, hearers(A))] *[message]*", null, 1)
+		else
+			for(var/mob/M in loc.contents) //If inside a container with other mobs (e.g. locker)
+				M.playsound_local(get_turf(M), 'sound/machines/twobeep.ogg', 50, 1)
+				if(M.can_hear())
+					to_chat(M, "[icon2html(A, M)] *[message]*")
 
 /datum/bank_account/department
 	account_holder = "Guild Credit Agency"

--- a/code/modules/economy/account.dm
+++ b/code/modules/economy/account.dm
@@ -68,7 +68,7 @@
 				playsound(get_turf(card_holder), 'sound/machines/twobeep.ogg', 50, 1)
 				A.audible_message("[icon2html(A, hearers(A))] *[message]*", null, 1)
 		else
-			for(var/mob/M in loc.contents) //If inside a container with other mobs (e.g. locker)
+			for(var/mob/M in A.loc.contents) //If inside a container with other mobs (e.g. locker)
 				M.playsound_local(get_turf(M), 'sound/machines/twobeep.ogg', 50, 1)
 				if(M.can_hear())
 					to_chat(M, "[icon2html(A, M)] *[message]*")


### PR DESCRIPTION
:cl: XDTM
fix: ID Cards now only display payday messages to the owner if they're being carried. Cards on the ground will still display them to nearby mobs.
/:cl:

Fixes #40439