### PR TITLE
This Kills The Tactical Bored Shuttle Call: Bored Call Blocker and Dynamic Shuttle Refueling

### DIFF
--- a/code/controllers/configuration/entries/game_options.dm
+++ b/code/controllers/configuration/entries/game_options.dm
@@ -134,7 +134,7 @@
 	min_val = 0
 	max_val = 1
 
-/datum/config_entry/number/shuttle_refuel_delay
+/datum/config_entry/number/shuttle_refuel_min_delay // The minimum shuttle refuel time at 50% or more dead crewmembers
 	config_entry_value = 12000
 	min_val = 0
 

--- a/code/controllers/subsystem/shuttle.dm
+++ b/code/controllers/subsystem/shuttle.dm
@@ -331,7 +331,8 @@ SUBSYSTEM_DEF(shuttle)
 			break
 		var/area/A = get_area(thing)
 		if(A && !A.blob_allowed)
-
+			callShuttle = 0
+			break
 	if(callShuttle)
 		if(EMERGENCY_IDLE_OR_RECALLED)
 			emergency.request(null, set_coefficient = 2.5)

--- a/code/game/objects/items/circuitboards/computer_circuitboards.dm
+++ b/code/game/objects/items/circuitboards/computer_circuitboards.dm
@@ -47,6 +47,19 @@
 	build_path = /obj/machinery/computer/communications
 	var/lastTimeUsed = 0
 
+/obj/item/circuitboard/computer/communications/Initialize(mapload)
+	. = ..()
+	GLOB.shuttle_caller_list += src
+
+/obj/item/circuitboard/computer/communications/obj_break()
+	SSshuttle.autoEvac()
+	. = ..()
+
+/obj/item/circuitboard/computer/communications/Destroy(mapload)
+	GLOB.shuttle_caller_list -= src
+	SSshuttle.autoEvac()
+	..()
+
 /obj/item/circuitboard/computer/card
 	name = "ID Console (Computer Board)"
 	build_path = /obj/machinery/computer/card

--- a/code/modules/antagonists/nukeop/equipment/nuclear_challenge.dm
+++ b/code/modules/antagonists/nukeop/equipment/nuclear_challenge.dm
@@ -1,7 +1,7 @@
 #define CHALLENGE_TELECRYSTALS 280
 #define CHALLENGE_TIME_LIMIT 3000
 #define CHALLENGE_MIN_PLAYERS 50
-#define CHALLENGE_SHUTTLE_DELAY 15000 // 25 minutes, so the ops have at least 5 minutes before the shuttle is callable.
+#define CHALLENGE_SHUTTLE_DELAY 15000 // force sets the refuel delay minimum to 25 minutes, giving the operatives a minimum of 5 minutes and a maximum of 25 minutes to work provided they keep casualties down
 
 GLOBAL_LIST_EMPTY(jam_on_wardec)
 
@@ -62,7 +62,7 @@ GLOBAL_LIST_EMPTY(jam_on_wardec)
 		D.jammed = TRUE
 
 	new uplink_type(get_turf(user), user.key, CHALLENGE_TELECRYSTALS)
-	CONFIG_SET(number/shuttle_refuel_delay, max(CONFIG_GET(number/shuttle_refuel_delay), CHALLENGE_SHUTTLE_DELAY))
+	CONFIG_SET(number/shuttle_refuel_min_delay, max(CONFIG_GET(number/shuttle_refuel_min_delay), CHALLENGE_SHUTTLE_DELAY))
 	SSblackbox.record_feedback("amount", "nuclear_challenge_mode", 1)
 
 	qdel(src)

--- a/code/modules/research/machinery/departmental_protolathe.dm
+++ b/code/modules/research/machinery/departmental_protolathe.dm
@@ -6,12 +6,30 @@
 	circuit = /obj/item/circuitboard/machine/protolathe/department
 	requires_console = FALSE
 	consoleless_interface = TRUE
+	var/emergency_shuttle_call = FALSE
+
+/obj/machinery/rnd/production/protolathe/department/Initialize(mapload)
+	. = ..()
+	if(emergency_shuttle_call)
+		GLOB.shuttle_caller_list += src
+
+/obj/machinery/rnd/production/protolathe/department/obj_break()
+	if(emergency_shuttle_call)
+		SSshuttle.autoEvac()
+	. = ..()
+
+/obj/machinery/rnd/production/protolathe/department/Destroy(mapload)
+	if(emergency_shuttle_call)
+		GLOB.shuttle_caller_list -= src
+		SSshuttle.autoEvac()
+	..()
 
 /obj/machinery/rnd/production/protolathe/department/engineering
 	name = "department protolathe (Engineering)"
 	allowed_department_flags = DEPARTMENTAL_FLAG_ALL|DEPARTMENTAL_FLAG_ENGINEERING
 	department_tag = "Engineering"
 	circuit = /obj/item/circuitboard/machine/protolathe/department/engineering
+	emergency_shuttle_call = TRUE
 
 /obj/machinery/rnd/production/protolathe/department/service
 	name = "department protolathe (Service)"
@@ -42,3 +60,4 @@
 	allowed_department_flags = DEPARTMENTAL_FLAG_ALL|DEPARTMENTAL_FLAG_SECURITY
 	department_tag = "Security"
 	circuit = /obj/item/circuitboard/machine/protolathe/department/security
+	emergency_shuttle_call = TRUE

--- a/config/game_options.txt
+++ b/config/game_options.txt
@@ -189,8 +189,8 @@ MIDROUND_ANTAG WIZARD
 
 
 
-## The amount of time it takes for the emergency shuttle to be called, from round start.
-SHUTTLE_REFUEL_DELAY 12000
+## The minimum shuttle refuel time at 50% or more dead crewmembers.
+SHUTTLE_REFUEL_MIN_DELAY 12000
 
 ## Variables calculate how number of antagonists will scale to population.
 ## Used as (Antagonists = Population / Coeff)


### PR DESCRIPTION
:cl: Iamgoofball and Ninjanomnom
add: The shuttle refuel timer is now based on amount of dead crewmembers.
experimental: It scales from 40 minutes down to 20 minutes the more crewmembers are dead, with the earlier crew deaths counting for more compared to later deaths. Suicides/ghosts do not count towards this number.
add: The shuttle will refuse to be called if less than 10% of the crew is dead(as long as there's at least 10 crewmembers, otherwise it just requires at least 1 person be dead). Don't call unless you need to.
fix: The shuttle evac checker is now more brutal, and will check to make there really is no way to produce a replacement communications console. No more "laser the two consoles and go home free", you'll need to actually make sure there's no way to call.
/:cl:

Goodbye "im bored" shuttle calls! Better learn to stick with your station or call the shuttle only when there's an actual emergency.

"muh war ops"
Don't worry, the system is compatible. They're guaranteed their five minutes of safety on the call delay, but might get more if there's less casualties.