### PR TITLE
Fixes a typo with 10mm ammo casings

### DIFF
--- a/code/modules/projectiles/ammunition/ballistic/pistol.dm
+++ b/code/modules/projectiles/ammunition/ballistic/pistol.dm
@@ -1,23 +1,23 @@
 // 10mm (Stechkin)
 
 /obj/item/ammo_casing/c10mm
-	name = ".10mm bullet casing"
+	name = "10mm bullet casing"
 	desc = "A 10mm bullet casing."
 	caliber = "10mm"
 	projectile_type = /obj/item/projectile/bullet/c10mm
 
 /obj/item/ammo_casing/c10mm/ap
-	name = ".10mm armor-piercing bullet casing"
+	name = "10mm armor-piercing bullet casing"
 	desc = "A 10mm armor-piercing bullet casing."
 	projectile_type = /obj/item/projectile/bullet/c10mm_ap
 
 /obj/item/ammo_casing/c10mm/hp
-	name = ".10mm hollow-point bullet casing"
+	name = "10mm hollow-point bullet casing"
 	desc = "A 10mm hollow-point bullet casing."
 	projectile_type = /obj/item/projectile/bullet/c10mm_hp
 
 /obj/item/ammo_casing/c10mm/fire
-	name = ".10mm incendiary bullet casing"
+	name = "10mm incendiary bullet casing"
 	desc = "A 10mm incendiary bullet casing."
 	projectile_type = /obj/item/projectile/bullet/incendiary/c10mm
 


### PR DESCRIPTION
:cl:
spellcheck: Fixed a typo with 10mm ammo casings.
/:cl:

Common mistake, metric measurements vs. caliber.