### PR TITLE
Makes the orbiter component less prone to failure

### DIFF
--- a/code/modules/mob/camera/camera.dm
+++ b/code/modules/mob/camera/camera.dm
@@ -27,7 +27,9 @@
 	return
 
 /mob/camera/forceMove(atom/destination)
+	var/oldloc = loc
 	loc = destination
+	Moved(oldloc, NONE, TRUE)
 
 /mob/camera/emote(act, m_type=1, message = null, intentional = FALSE)
 	return

--- a/code/modules/mob/dead/dead.dm
+++ b/code/modules/mob/dead/dead.dm
@@ -35,7 +35,9 @@ INITIALIZE_IMMEDIATE(/mob/dead)
 	var/turf/new_turf = get_turf(destination)
 	if (old_turf?.z != new_turf?.z)
 		onTransitZ(old_turf?.z, new_turf?.z)
+	var/oldloc = loc
 	loc = destination
+	Moved(oldloc, NONE, TRUE)
 
 /mob/dead/Stat()
 	..()


### PR DESCRIPTION
Missed some qdeling work because components clean themselves up fine if you only have one thing able to orbit. But when you get into an environment with many ghosts orbiting/deorbiting...

This also makes orbiting properly keep track of everything holding it and when they move so that you still properly follow something while it's inside something else.

Dead and camera mobs also didn't call Moved() which this fixes so movements can be kept track of with the signal.

Fixes #40484 