### PR TITLE
Fixes default supplypods exploding their contents

### DIFF
--- a/code/datums/explosion.dm
+++ b/code/datums/explosion.dm
@@ -198,7 +198,8 @@ GLOBAL_LIST_EMPTY(explosions)
 			var/list/items = list()
 			for(var/I in T)
 				var/atom/A = I
-				items += A.GetAllContents()
+				if (A.contents_explosion()) //The atom/contents_explosion() proc returns null if the contents ex_acting has been handled by the atom, and TRUE if it hasn't.
+					items += A.GetAllContents()
 			for(var/O in items)
 				var/atom/A = O
 				if(!QDELETED(A))

--- a/code/game/atoms.dm
+++ b/code/game/atoms.dm
@@ -292,7 +292,7 @@
 	return
 
 /atom/proc/contents_explosion(severity, target)
-	return
+	return TRUE //Return TRUE if the contents_explosion has not been overridden.
 
 /atom/proc/ex_act(severity, target)
 	set waitfor = FALSE

--- a/code/modules/cargo/supplypod.dm
+++ b/code/modules/cargo/supplypod.dm
@@ -92,7 +92,6 @@
 /obj/structure/closet/supplypod/proc/preOpen() //Called before the open() proc. Handles anything that occurs right as the pod lands.
 	var/turf/T = get_turf(src)
 	var/list/B = explosionSize //Mostly because B is more readable than explosionSize :p
-	var/boomTotal = 0 //A counter used to check if the explosion does nothing
 	if (landingSound)
 		playsound(get_turf(src), landingSound, soundVolume, 0, 0)
 	for (var/mob/living/M in T)
@@ -108,10 +107,7 @@
 			M.gib() //After adjusting the fuck outta that brute loss we finish the job with some satisfying gibs
 		M.adjustBruteLoss(damage)
 
-	for (var/i in B)
-		boomTotal += i //Count up all the values of the explosion
-
-	if (boomTotal != 0) //If the explosion list isn't all zeroes, call an explosion
+	if (B[1] || B[2] || B[3] || B[4]) //If the explosion list isn't all zeroes, call an explosion
 		explosion(get_turf(src), B[1], B[2], B[3], flame_range = B[4], silent = effectQuiet, ignorecap = istype(src, /obj/structure/closet/supplypod/centcompod)) //less advanced equipment than bluespace pod, so larger explosion when landing
 	else if (!effectQuiet) //If our explosion list IS all zeroes, we still make a nice explosion sound (unless the effectQuiet var is true)
 		playsound(src, "explosion", landingSound ? 15 : 80, 1)


### PR DESCRIPTION
Fixes #40486

:cl: MrDoomBringer
fix: Supplypods no longer detonate their contents
/:cl:

I did this by adding a return value to the atom/contents_explosion() proc. If the proc is overridden, it should return null. This is then checked in explosion.dm to see if the contents have been properly exploded. If they havent (if contents_explosion() returns true), then explosion.dm handles it manually.

There might be a better way to go about this, if there is please let me know