### PR TITLE
Partial revert of #40431

### DIFF
--- a/code/modules/projectiles/projectile/special/plasma.dm
+++ b/code/modules/projectiles/projectile/special/plasma.dm
@@ -9,6 +9,13 @@
 	tracer_type = /obj/effect/projectile/tracer/plasma_cutter
 	muzzle_type = /obj/effect/projectile/muzzle/plasma_cutter
 	impact_type = /obj/effect/projectile/impact/plasma_cutter
+	var/pressure_check_scaling = FALSE
+	
+/obj/item/projectile/plasma/Initialize()	
+	. = ..()	
+	if(pressure_check_scaling && !lavaland_equipment_pressure_check(get_turf(src)))	
+		name = "weakened [name]"	
+		damage *= 0.25
 
 /obj/item/projectile/plasma/on_hit(atom/target)
 	. = ..()
@@ -30,10 +37,14 @@
 	damage = 40
 	range = 9
 	mine_range = 3
-
+	dismemberment = 20
+	pressure_check_scaling = TRUE
+	
 /obj/item/projectile/plasma/turret
 	//Between normal and advanced for damage, made a beam so not the turret does not destroy glass
 	name = "plasma beam"
 	damage = 24
 	range = 7
+	dismemberment = 20
 	pass_flags = PASSTABLE | PASSGLASS | PASSGRILLE
+	pressure_check_scaling = TRUE

--- a/code/modules/projectiles/projectile/special/plasma.dm
+++ b/code/modules/projectiles/projectile/special/plasma.dm
@@ -27,13 +27,13 @@
 	mine_range = 5
 
 /obj/item/projectile/plasma/adv/mech
-	damage = 10
+	damage = 40
 	range = 9
 	mine_range = 3
 
 /obj/item/projectile/plasma/turret
 	//Between normal and advanced for damage, made a beam so not the turret does not destroy glass
 	name = "plasma beam"
-	damage = 6
+	damage = 24
 	range = 7
 	pass_flags = PASSTABLE | PASSGLASS | PASSGRILLE


### PR DESCRIPTION
:cl: Sgt. Rootbeer
Balance: Mecha and Aux base turret's plasma cutters have been buffed back to full power.
/:cl:
This is because the intent in #40431 was to nerf the handheld plasma cutters so as to prevent spam against aliens and blobs. Because it is nearly impossible to spam RIPLEYS, and definetly impossible to spam aux base turrets against blobs and xenos the nerf against them was out of scope of the PR, and wholly unnecessary.

Yes, technically now both of them are capable of doing full damage in full presure enviornments, but again, ripleys are weak, and the aux base can't even be used offensively by a player.

If anyone wants to fix this correctly by re-implementing the pressure change only for the mecha and the base, then by all means, go ahead. For now, I'd consider this good.