### PR TITLE
[s] Blacklists parcels & storage items from the deep-frier

### DIFF
--- a/code/modules/food_and_drinks/kitchen_machinery/deep_fryer.dm
+++ b/code/modules/food_and_drinks/kitchen_machinery/deep_fryer.dm
@@ -46,7 +46,8 @@ God bless America.
 		/obj/item/reagent_containers/glass,
 		/obj/item/reagent_containers/syringe,
 		/obj/item/reagent_containers/food/condiment,
-		/obj/item/storage/part_replacer,
+		/obj/item/storage,
+		/obj/item/smallDelivery,
 		/obj/item/his_grace))
 	var/datum/looping_sound/deep_fryer/fry_loop
 


### PR DESCRIPTION
Fixes #34443

Was looking at doing the w_class changes that Oranges suggest, however I realized that even with that there's still the issue of being able to deepfry another item that's blacklisted/wouldn't pass the flag check if you put it inside a container. You can obviously check the contents of that item if they put it in a box of course to make sure it passes, but what if they put that box in a bag? What if that bag is then put in another bag? 

You could potentially have 20 BoH's all inside of one another at one point, which just seems like a headache to have to check the contents and sub-contents of absolutely everything that goes in.

:cl: 
fix: Storage items and parcels can no longer be fried.
/:cl: