### PR TITLE
Fixes economy subsys firing before game is running

### DIFF
--- a/code/controllers/subsystem/economy.dm
+++ b/code/controllers/subsystem/economy.dm
@@ -2,6 +2,7 @@ SUBSYSTEM_DEF(economy)
 	name = "Economy"
 	wait = 5 MINUTES
 	init_order = INIT_ORDER_ECONOMY
+	runlevels = RUNLEVEL_GAME
 	var/roundstart_paychecks = 5
 	var/budget_pool = 35000
 	var/list/department_accounts = list(ACCOUNT_CIV = ACCOUNT_CIV_NAME,


### PR DESCRIPTION
```
[02:48:32] Runtime in economy.dm, line 75: Cannot execute null.score().
proc name: boring eng payout (/datum/controller/subsystem/economy/proc/boring_eng_payout)
src: Economy (/datum/controller/subsystem/economy)
call stack:
Economy (/datum/controller/subsystem/economy): boring eng payout()
Economy (/datum/controller/subsystem/economy): fire(0)
Economy (/datum/controller/subsystem/economy): ignite(0)
```
trying to fire before SS.ticker has even finished init. Figure this should probably only run after the game has started @Iamgoofball 