### PR TITLE
Adds syndicate balloon mood modifier for antagonists

### DIFF
--- a/code/datums/mood_events/generic_positive_events.dm
+++ b/code/datums/mood_events/generic_positive_events.dm
@@ -52,6 +52,11 @@
 	mood_change = 12
 	hidden = TRUE
 
+/datum/mood_event/badass_antag
+	description = "I'm a fucking badass and everyone around me knows it. Just look at them; they're all fucking shaking at the mere thought of me around."
+	mood_change = 15
+	hidden = TRUE
+
 /datum/mood_event/revolution
 	description = "<span class='nicegreen'>VIVA LA REVOLUTION!</span>\n"
 	mood_change = 3

--- a/code/game/objects/items/toys.dm
+++ b/code/game/objects/items/toys.dm
@@ -122,25 +122,23 @@
 	lefthand_file = 'icons/mob/inhands/antag/balloons_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/antag/balloons_righthand.dmi'
 	w_class = WEIGHT_CLASS_BULKY
-	var/mob/equipped_mob
 
 /obj/item/toy/syndicateballoon/pickup(mob/user)
 	. = ..()
 	if(user && user.mind && user.mind.has_antag_datum(/datum/antagonist, TRUE))
 		SEND_SIGNAL(user, COMSIG_ADD_MOOD_EVENT, "badass_antag", /datum/mood_event/badass_antag)
-		equipped_mob = user
 
 /obj/item/toy/syndicateballoon/dropped(mob/user)
+	if(user)
+		SEND_SIGNAL(user, COMSIG_CLEAR_MOOD_EVENT, "badass_antag", /datum/mood_event/badass_antag)
 	. = ..()
-	if(equipped_mob)
-		SEND_SIGNAL(equipped_mob, COMSIG_CLEAR_MOOD_EVENT, "badass_antag", /datum/mood_event/badass_antag)
-		equipped_mob = null
+
 
 /obj/item/toy/syndicateballoon/Destroy()
+	if(ismob(loc))
+		var/mob/M = loc
+		SEND_SIGNAL(M, COMSIG_CLEAR_MOOD_EVENT, "badass_antag", /datum/mood_event/badass_antag)
 	. = ..()
-	if(equipped_mob)
-		SEND_SIGNAL(equipped_mob, COMSIG_CLEAR_MOOD_EVENT, "badass_antag", /datum/mood_event/badass_antag)
-		equipped_mob = null
 
 
 /*

--- a/code/game/objects/items/toys.dm
+++ b/code/game/objects/items/toys.dm
@@ -122,6 +122,26 @@
 	lefthand_file = 'icons/mob/inhands/antag/balloons_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/antag/balloons_righthand.dmi'
 	w_class = WEIGHT_CLASS_BULKY
+	var/mob/equipped_mob
+
+/obj/item/toy/syndicateballoon/pickup(mob/user)
+	. = ..()
+	if(user && user.mind && user.mind.has_antag_datum(/datum/antagonist, TRUE))
+		SEND_SIGNAL(user, COMSIG_ADD_MOOD_EVENT, "badass_antag", /datum/mood_event/badass_antag)
+		equipped_mob = user
+
+/obj/item/toy/syndicateballoon/dropped(mob/user)
+	. = ..()
+	if(equipped_mob)
+		SEND_SIGNAL(equipped_mob, COMSIG_CLEAR_MOOD_EVENT, "badass_antag", /datum/mood_event/badass_antag)
+		equipped_mob = null
+
+/obj/item/toy/syndicateballoon/Destroy()
+	. = ..()
+	if(equipped_mob)
+		SEND_SIGNAL(equipped_mob, COMSIG_CLEAR_MOOD_EVENT, "badass_antag", /datum/mood_event/badass_antag)
+		equipped_mob = null
+
 
 /*
  * Fake singularity


### PR DESCRIPTION
You won't just look badass, you'll **FEEL** badass.

reasoning: holding the balloon attracts tons of attention, and most players will assume you're a traitor and will watch you like a fucking hawk and jump you the second you give them a reason. Might as well give a little more incentive to show off just how much you don't give a fuck.

:cl: ShizCalev
add: An antagonist holding a syndicate balloon will now receive a positive mood modifier.
/:cl:

