### PR TITLE
Securitrons cuff and hold detainees instead of chainstunning them

### DIFF
--- a/code/modules/mob/living/simple_animal/bot/bot.dm
+++ b/code/modules/mob/living/simple_animal/bot/bot.dm
@@ -253,7 +253,12 @@
 
 /mob/living/simple_animal/bot/attack_hand(mob/living/carbon/human/H)
 	if(H.a_intent == INTENT_HELP)
+		add_fingerprint(H)
 		interact(H)
+		if(auto_patrol == TRUE && bot_core.allowed(H)) //don't want people without access interrupting Beepsky
+			bot_reset() //HOLD IT!!
+			auto_patrol = FALSE
+			speak("<span class = 'robot'>Patrol stopped to interface with user.</span>", radio_channel)
 	else
 		return ..()
 


### PR DESCRIPTION
alternative to the popular #40471 

[Changelogs]: # (Your PR should contain a detailed changelog of notable changes, titled and categorized appropriately. This includes, new features, sprites, sounds, balance changes, admin tools, map edits, removals, big refactors, config changes, hosting changes and important fixes. An example changelog has been provided below for you to edit. If you need additional help, read https://github.com/tgstation/tgstation/wiki/Changelogs)

:cl: cacogen
balance: Securitrons cuff and hold detainees instead of chainstunning them, giving them a chance to escape by themselves
add: If you have access bots will stop patrolling when you open their window, making it easier to interact with them (don't forget to turn auto patrol back on if desired)
/:cl:

[why]: # (Please add a short description [two lines down] of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.)
