### PR TITLE
Changes to vendor prices and other tweaks

### DIFF
--- a/code/modules/vending/autodrobe.dm
+++ b/code/modules/vending/autodrobe.dm
@@ -128,8 +128,8 @@
 		           /obj/item/skub = 1,)
 
 	refill_canister = /obj/item/vending_refill/autodrobe
-	default_price = 100
-	extra_price = 200
+	default_price = 50
+	extra_price = 100
 	payment_department = ACCOUNT_SRV
 /obj/machinery/vending/autodrobe/all_access
 	desc = "A vending machine for costumes. This model appears to have no access restrictions."

--- a/code/modules/vending/boozeomat.dm
+++ b/code/modules/vending/boozeomat.dm
@@ -3,42 +3,43 @@
 	desc = "A technological marvel, supposedly able to mix just the mixture you'd like to drink the moment you ask for one."
 	icon_state = "boozeomat"
 	icon_deny = "boozeomat-deny"
-	products = list(/obj/item/reagent_containers/food/drinks/bottle/gin = 5,
-		            /obj/item/reagent_containers/food/drinks/bottle/whiskey = 5,
-					/obj/item/reagent_containers/food/drinks/bottle/tequila = 5,
-					/obj/item/reagent_containers/food/drinks/bottle/vodka = 5,
-					/obj/item/reagent_containers/food/drinks/bottle/vermouth = 5,
-					/obj/item/reagent_containers/food/drinks/bottle/rum = 5,
-					/obj/item/reagent_containers/food/drinks/bottle/wine = 5,
-					/obj/item/reagent_containers/food/drinks/bottle/cognac = 5,
-					/obj/item/reagent_containers/food/drinks/bottle/kahlua = 5,
-					/obj/item/reagent_containers/food/drinks/bottle/hcider = 5,
-					/obj/item/reagent_containers/food/drinks/bottle/absinthe = 5,
-					/obj/item/reagent_containers/food/drinks/bottle/grappa = 5,
-					/obj/item/reagent_containers/food/drinks/bottle/sake = 5,
-					/obj/item/reagent_containers/food/drinks/ale = 6,
+	products = list(/obj/item/reagent_containers/food/drinks/drinkingglass = 30,
+					/obj/item/reagent_containers/food/drinks/drinkingglass/shotglass = 12,
+					/obj/item/reagent_containers/food/drinks/flask = 3,
+					/obj/item/reagent_containers/food/drinks/ice = 10,
 					/obj/item/reagent_containers/food/drinks/bottle/orangejuice = 4,
 					/obj/item/reagent_containers/food/drinks/bottle/tomatojuice = 4,
 					/obj/item/reagent_containers/food/drinks/bottle/limejuice = 4,
-					/obj/item/reagent_containers/food/drinks/bottle/grenadine = 4,
-					/obj/item/reagent_containers/food/drinks/bottle/menthol = 4,
 					/obj/item/reagent_containers/food/drinks/bottle/cream = 4,
 					/obj/item/reagent_containers/food/drinks/soda_cans/tonic = 8,
 					/obj/item/reagent_containers/food/drinks/soda_cans/cola = 8,
 					/obj/item/reagent_containers/food/drinks/soda_cans/sodawater = 15,
-					/obj/item/reagent_containers/food/drinks/drinkingglass = 30,
-					/obj/item/reagent_containers/food/drinks/ice = 10,
-					/obj/item/reagent_containers/food/drinks/drinkingglass/shotglass = 12,
-					/obj/item/reagent_containers/food/drinks/flask = 3,
+					/obj/item/reagent_containers/food/drinks/ale = 6,
 					/obj/item/reagent_containers/food/drinks/beer = 6)
 	contraband = list(/obj/item/reagent_containers/food/drinks/mug/tea = 12,
 					  /obj/item/reagent_containers/food/drinks/bottle/fernet = 5)
+	premium = list(/obj/item/reagent_containers/food/drinks/bottle/gin = 5,
+		           /obj/item/reagent_containers/food/drinks/bottle/whiskey = 5,
+		           /obj/item/reagent_containers/food/drinks/bottle/tequila = 5,
+		           /obj/item/reagent_containers/food/drinks/bottle/vodka = 5,
+		           /obj/item/reagent_containers/food/drinks/bottle/vermouth = 5,
+		           /obj/item/reagent_containers/food/drinks/bottle/rum = 5,
+		           /obj/item/reagent_containers/food/drinks/bottle/wine = 5,
+		           /obj/item/reagent_containers/food/drinks/bottle/cognac = 5,
+		           /obj/item/reagent_containers/food/drinks/bottle/kahlua = 5,
+		           /obj/item/reagent_containers/food/drinks/bottle/hcider = 5,
+		           /obj/item/reagent_containers/food/drinks/bottle/absinthe = 5,
+		           /obj/item/reagent_containers/food/drinks/bottle/grappa = 5,
+		           /obj/item/reagent_containers/food/drinks/bottle/sake = 5,
+		           /obj/item/reagent_containers/food/drinks/bottle/grenadine = 4,
+		           /obj/item/reagent_containers/food/drinks/bottle/menthol = 4)
+
 	product_slogans = "I hope nobody asks me for a bloody cup o' tea...;Alcohol is humanity's friend. Would you abandon a friend?;Quite delighted to serve you!;Is nobody thirsty on this station?"
 	product_ads = "Drink up!;Booze is good for you!;Alcohol is humanity's best friend.;Quite delighted to serve you!;Care for a nice, cold beer?;Nothing cures you like booze!;Have a sip!;Have a drink!;Have a beer!;Beer is good for you!;Only the finest alcohol!;Best quality booze since 2053!;Award-winning wine!;Maximum alcohol!;Man loves beer.;A toast for progress!"
 	req_access = list(ACCESS_BAR)
 	refill_canister = /obj/item/vending_refill/boozeomat
-	default_price = 50
-	extra_price = 100
+	default_price = 10
+	extra_price = 50
 	payment_department = ACCOUNT_SRV
 
 /obj/machinery/vending/boozeomat/all_access

--- a/code/modules/vending/cigarette.dm
+++ b/code/modules/vending/cigarette.dm
@@ -12,15 +12,16 @@
 					/obj/item/storage/box/matches = 10,
 					/obj/item/lighter/greyscale = 4,
 					/obj/item/storage/fancy/rollingpapers = 5)
-	contraband = list(/obj/item/lighter = 3,
-		              /obj/item/clothing/mask/vape = 5)
 	premium = list(/obj/item/storage/fancy/cigarettes/cigpack_robustgold = 3,
 		           /obj/item/storage/fancy/cigarettes/cigars = 1,
 		           /obj/item/storage/fancy/cigarettes/cigars/havana = 1,
-		           /obj/item/storage/fancy/cigarettes/cigars/cohiba = 1)
+		           /obj/item/storage/fancy/cigarettes/cigars/cohiba = 1,
+		           /obj/item/lighter = 3,
+		           /obj/item/clothing/mask/vape = 5)
+
 	refill_canister = /obj/item/vending_refill/cigarette
-	default_price = 10
-	extra_price = 25
+	default_price = 20
+	extra_price = 40
 	payment_department = ACCOUNT_SRV
 
 /obj/machinery/vending/cigarette/syndicate

--- a/code/modules/vending/cigarette.dm
+++ b/code/modules/vending/cigarette.dm
@@ -21,7 +21,7 @@
 
 	refill_canister = /obj/item/vending_refill/cigarette
 	default_price = 20
-	extra_price = 40
+	extra_price = 50
 	payment_department = ACCOUNT_SRV
 
 /obj/machinery/vending/cigarette/syndicate

--- a/code/modules/vending/clothesmate.dm
+++ b/code/modules/vending/clothesmate.dm
@@ -6,10 +6,7 @@
 	icon_deny = "clothes-deny"
 	product_slogans = "Dress for success!;Prepare to look swagalicious!;Look at all this free swag!;Why leave style up to fate? Use the ClothesMate!"
 	vend_reply = "Thank you for using the ClothesMate!"
-	products = list(/obj/item/clothing/head/that = 2,
-		            /obj/item/clothing/head/fedora = 1,
-		            /obj/item/clothing/glasses/monocle = 1,
-		            /obj/item/clothing/suit/jacket = 2,
+	products = list(/obj/item/clothing/suit/jacket = 2,
 		            /obj/item/clothing/suit/jacket/puffer/vest = 2,
 		            /obj/item/clothing/suit/jacket/puffer = 2,
 		            /obj/item/clothing/under/suit_jacket/navy = 1,
@@ -17,7 +14,6 @@
 		            /obj/item/clothing/under/suit_jacket/burgundy = 1,
 		            /obj/item/clothing/under/suit_jacket/charcoal = 1,
 		            /obj/item/clothing/under/suit_jacket/white = 1,
-		            /obj/item/clothing/under/kilt = 1,
 		            /obj/item/clothing/under/overalls = 1,
 		            /obj/item/clothing/under/sl_suit = 1,
 		            /obj/item/clothing/under/pants/jeans = 3,
@@ -55,17 +51,11 @@
 		            /obj/item/clothing/under/skirt/blue = 1,
 		            /obj/item/clothing/under/skirt/red = 1,
 		            /obj/item/clothing/under/skirt/purple = 1,
-		            /obj/item/clothing/under/sundress = 2,
-		            /obj/item/clothing/under/stripeddress = 1,
-		            /obj/item/clothing/under/sailordress = 1,
-		            /obj/item/clothing/under/redeveninggown = 1,
-		            /obj/item/clothing/under/blacktango = 1,
 		            /obj/item/clothing/under/plaid_skirt = 1,
 		            /obj/item/clothing/under/plaid_skirt/blue = 1,
 		            /obj/item/clothing/under/plaid_skirt/purple = 1,
 		            /obj/item/clothing/under/plaid_skirt/green = 1,
 		            /obj/item/clothing/glasses/regular = 1,
-		            /obj/item/clothing/glasses/regular/jamjar = 1,
 		            /obj/item/clothing/head/sombrero = 1,
 		            /obj/item/clothing/suit/poncho = 1,
 		            /obj/item/clothing/suit/ianshirt = 1,
@@ -94,7 +84,7 @@
 		            /obj/item/clothing/head/beanie/stripedblue = 1,
 		            /obj/item/clothing/head/beanie/stripedgreen = 1,
 		            /obj/item/clothing/suit/jacket/letterman_red = 1,
-		            /obj/item/clothing/ears/headphones = 10,
+		            /obj/item/clothing/ears/headphones = 3,
 		            /obj/item/clothing/suit/apron/purple_bartender = 2,
 		            /obj/item/clothing/under/rank/bartender/purple = 2)
 	contraband = list(/obj/item/clothing/under/syndicate/tacticool = 1,
@@ -107,15 +97,25 @@
 		              /obj/item/clothing/suit/vapeshirt = 1,
 		              /obj/item/clothing/under/geisha = 1)
 	premium = list(/obj/item/clothing/under/suit_jacket/checkered = 1,
+		           /obj/item/clothing/glasses/regular/jamjar = 1,
+		           /obj/item/clothing/under/sundress = 2,
+		           /obj/item/clothing/under/stripeddress = 1,
+		           /obj/item/clothing/under/sailordress = 1,
+		           /obj/item/clothing/under/redeveninggown = 1,
+		           /obj/item/clothing/under/blacktango = 1,
+		           /obj/item/clothing/under/kilt = 1,
 		           /obj/item/clothing/head/mailman = 1,
 		           /obj/item/clothing/under/rank/mailman = 1,
 		           /obj/item/clothing/suit/jacket/leather = 1,
 		           /obj/item/clothing/suit/jacket/leather/overcoat = 1,
 		           /obj/item/clothing/under/pants/mustangjeans = 1,
 		           /obj/item/clothing/neck/necklace/dope = 3,
-		           /obj/item/clothing/suit/jacket/letterman_nanotrasen = 1)
+		           /obj/item/clothing/suit/jacket/letterman_nanotrasen = 1,
+		           /obj/item/clothing/head/that = 2,
+		           /obj/item/clothing/head/fedora = 1,
+		           /obj/item/clothing/glasses/monocle = 1)
 	refill_canister = /obj/item/vending_refill/clothing
-	default_price = 50
+	default_price = 25
 	extra_price = 75
 	payment_department = NO_FREEBIES
 /obj/item/vending_refill/clothing

--- a/code/modules/vending/coffee.dm
+++ b/code/modules/vending/coffee.dm
@@ -4,9 +4,9 @@
 	product_ads = "Have a drink!;Drink up!;It's good for you!;Would you like a hot joe?;I'd kill for some coffee!;The best beans in the galaxy.;Only the finest brew for you.;Mmmm. Nothing like a coffee.;I like coffee, don't you?;Coffee helps you work!;Try some tea.;We hope you like the best!;Try our new chocolate!;Admin conspiracies"
 	icon_state = "coffee"
 	icon_vend = "coffee-vend"
-	products = list(/obj/item/reagent_containers/food/drinks/coffee = 25,
-		            /obj/item/reagent_containers/food/drinks/mug/tea = 25,
-		            /obj/item/reagent_containers/food/drinks/mug/coco = 25)
+	products = list(/obj/item/reagent_containers/food/drinks/coffee = 8,
+		            /obj/item/reagent_containers/food/drinks/mug/tea = 8)
+	premium = list(/obj/item/reagent_containers/food/drinks/mug/coco = 4)
 	contraband = list(/obj/item/reagent_containers/food/drinks/ice = 12)
 	refill_canister = /obj/item/vending_refill/coffee
 	default_price = 10

--- a/code/modules/vending/cola.dm
+++ b/code/modules/vending/cola.dm
@@ -19,7 +19,7 @@
 		           /obj/item/reagent_containers/food/drinks/soda_cans/air = 1)
 	refill_canister = /obj/item/vending_refill/cola
 	default_price = 10
-	extra_price = 25
+	extra_price = 30
 	payment_department = ACCOUNT_SRV
 /obj/item/vending_refill/cola
 	machine_name = "Robust Softdrinks"

--- a/code/modules/vending/drinnerware.dm
+++ b/code/modules/vending/drinnerware.dm
@@ -4,20 +4,20 @@
 	product_ads = "Mm, food stuffs!;Food and food accessories.;Get your plates!;You like forks?;I like forks.;Woo, utensils.;You don't really need these..."
 	icon_state = "dinnerware"
 	products = list(/obj/item/storage/bag/tray = 8,
+		            /obj/item/reagent_containers/glass/bowl = 20,
 		            /obj/item/kitchen/fork = 6,
-		            /obj/item/kitchen/knife = 6,
-		            /obj/item/kitchen/rollingpin = 2,
 		            /obj/item/reagent_containers/food/drinks/drinkingglass = 8,
-		            /obj/item/clothing/suit/apron/chef = 2,
 		            /obj/item/reagent_containers/food/condiment/pack/ketchup = 5,
 		            /obj/item/reagent_containers/food/condiment/pack/hotsauce = 5,
 		            /obj/item/reagent_containers/food/condiment/saltshaker = 5,
-		            /obj/item/reagent_containers/food/condiment/peppermill = 5,
-		            /obj/item/reagent_containers/glass/bowl = 20)
-	contraband = list(/obj/item/kitchen/rollingpin = 2,
-		              /obj/item/kitchen/knife/butcher = 2)
+		            /obj/item/reagent_containers/food/condiment/peppermill = 5)
+	contraband = list(/obj/item/kitchen/knife/butcher = 2)
+	premium = list(/obj/item/kitchen/knife = 6,
+		           /obj/item/kitchen/rollingpin = 2,
+		           /obj/item/clothing/suit/apron/chef = 2)
+
 	armor = list("melee" = 100, "bullet" = 100, "laser" = 100, "energy" = 100, "bomb" = 0, "bio" = 0, "rad" = 0, "fire" = 100, "acid" = 50)
 	resistance_flags = FIRE_PROOF
-	default_price = 30
-	extra_price = 50
+	default_price = 20
+	extra_price = 60
 	payment_department = ACCOUNT_SRV

--- a/code/modules/vending/engineering.dm
+++ b/code/modules/vending/engineering.dm
@@ -5,14 +5,7 @@
 	icon_state = "engi"
 	icon_deny = "engi-deny"
 	req_access = list(ACCESS_ENGINE_EQUIP)
-	products = list(/obj/item/clothing/under/rank/chief_engineer = 4,
-		            /obj/item/clothing/under/rank/engineer = 4,
-		            /obj/item/clothing/shoes/sneakers/orange = 4,
-		            /obj/item/clothing/head/hardhat = 4,
-					/obj/item/storage/belt/utility = 4,
-					/obj/item/clothing/glasses/meson/engine = 4,
-					/obj/item/clothing/gloves/color/yellow = 4,
-					/obj/item/screwdriver = 12,
+	products = list(/obj/item/screwdriver = 12,
 					/obj/item/crowbar = 12,
 					/obj/item/wirecutters = 12,
 					/obj/item/multitool = 12,
@@ -20,15 +13,23 @@
 					/obj/item/t_scanner = 12,
 					/obj/item/stock_parts/cell = 8,
 					/obj/item/weldingtool = 8,
-					/obj/item/clothing/head/welding = 8,
 					/obj/item/light/tube = 10,
-					/obj/item/clothing/suit/fire = 4,
 					/obj/item/stock_parts/scanning_module = 5,
 					/obj/item/stock_parts/micro_laser = 5,
 					/obj/item/stock_parts/matter_bin = 5,
 					/obj/item/stock_parts/manipulator = 5)
+	premium = list(/obj/item/clothing/under/rank/chief_engineer = 4,
+		            /obj/item/clothing/under/rank/engineer = 4,
+		            /obj/item/clothing/shoes/sneakers/orange = 4,
+		            /obj/item/clothing/head/hardhat = 4,
+		            /obj/item/clothing/gloves/color/yellow = 4,
+		            /obj/item/storage/belt/utility = 4,
+					/obj/item/clothing/glasses/meson/engine = 4,
+					/obj/item/clothing/suit/fire = 4,
+					/obj/item/clothing/head/welding = 8)
+
 	armor = list("melee" = 100, "bullet" = 100, "laser" = 100, "energy" = 100, "bomb" = 0, "bio" = 0, "rad" = 0, "fire" = 100, "acid" = 50)
 	resistance_flags = FIRE_PROOF
-	default_price = 50
-	extra_price = 60
+	default_price = 25
+	extra_price = 75
 	payment_department = ACCOUNT_ENG

--- a/code/modules/vending/engineering.dm
+++ b/code/modules/vending/engineering.dm
@@ -30,6 +30,6 @@
 
 	armor = list("melee" = 100, "bullet" = 100, "laser" = 100, "energy" = 100, "bomb" = 0, "bio" = 0, "rad" = 0, "fire" = 100, "acid" = 50)
 	resistance_flags = FIRE_PROOF
-	default_price = 25
-	extra_price = 75
+	default_price = 45
+	extra_price = 90
 	payment_department = ACCOUNT_ENG

--- a/code/modules/vending/engivend.dm
+++ b/code/modules/vending/engivend.dm
@@ -20,6 +20,6 @@
 		           /obj/item/clothing/glasses/welding = 3)
 	armor = list("melee" = 100, "bullet" = 100, "laser" = 100, "energy" = 100, "bomb" = 0, "bio" = 0, "rad" = 0, "fire" = 100, "acid" = 50)
 	resistance_flags = FIRE_PROOF
-	default_price = 25
-	extra_price = 75
+	default_price = 45
+	extra_price = 90
 	payment_department = ACCOUNT_ENG

--- a/code/modules/vending/engivend.dm
+++ b/code/modules/vending/engivend.dm
@@ -4,24 +4,22 @@
 	icon_state = "engivend"
 	icon_deny = "engivend-deny"
 	req_access = list(ACCESS_ENGINE_EQUIP)
-	products = list(/obj/item/clothing/glasses/meson/engine = 2,
-					/obj/item/clothing/glasses/welding = 3,
-					/obj/item/multitool = 4,
-					/obj/item/construction/rcd/loaded = 3,
+	products = list(/obj/item/multitool = 4,
 					/obj/item/grenade/chem_grenade/smart_metal_foam = 10,
 					/obj/item/geiger_counter = 5,
 					/obj/item/stock_parts/cell/high = 10,
-          /obj/item/electronics/airlock = 10,
+					/obj/item/electronics/airlock = 10,
 					/obj/item/electronics/apc = 10,
 					/obj/item/electronics/airalarm = 10,
 					/obj/item/electronics/firealarm = 10,
-					/obj/item/electronics/firelock = 10
-					)
+					/obj/item/electronics/firelock = 10)
 	contraband = list(/obj/item/stock_parts/cell/potato = 3)
 	premium = list(/obj/item/storage/belt/utility = 3,
-		           /obj/item/storage/box/smart_metal_foam = 1)
+		           /obj/item/construction/rcd/loaded = 3,
+		           /obj/item/clothing/glasses/meson/engine = 2,
+		           /obj/item/clothing/glasses/welding = 3)
 	armor = list("melee" = 100, "bullet" = 100, "laser" = 100, "energy" = 100, "bomb" = 0, "bio" = 0, "rad" = 0, "fire" = 100, "acid" = 50)
 	resistance_flags = FIRE_PROOF
 	default_price = 25
-	extra_price = 50
+	extra_price = 75
 	payment_department = ACCOUNT_ENG

--- a/code/modules/vending/games.dm
+++ b/code/modules/vending/games.dm
@@ -9,7 +9,7 @@
 		            /obj/item/toy/cards/deck/cas/black = 3)
 	contraband = list(/obj/item/dice/fudge = 9)
 	refill_canister = /obj/item/vending_refill/games
-	default_price = 25
+	default_price = 10
 	extra_price = 50
 	payment_department = ACCOUNT_SRV
 /obj/item/vending_refill/games

--- a/code/modules/vending/medical.dm
+++ b/code/modules/vending/medical.dm
@@ -9,7 +9,6 @@
 					/obj/item/reagent_containers/dropper = 3,
 					/obj/item/healthanalyzer = 4,
 					/obj/item/sensor_device = 2,
-					/obj/item/pinpointer/crew = 2,
 					/obj/item/reagent_containers/medspray/sterilizine = 1,
 					/obj/item/stack/medical/gauze = 8,
 					/obj/item/reagent_containers/pill/patch/styptic = 5,
@@ -30,7 +29,8 @@
 		              /obj/item/reagent_containers/pill/charcoal = 6)
 	premium = list(/obj/item/storage/box/hug/medical = 1,
 		           /obj/item/storage/belt/medical = 3,
-		           /obj/item/wrench/medical = 1)
+		           /obj/item/wrench/medical = 1,
+		           /obj/item/pinpointer/crew = 2)
 	armor = list("melee" = 100, "bullet" = 100, "laser" = 100, "energy" = 100, "bomb" = 0, "bio" = 0, "rad" = 0, "fire" = 100, "acid" = 50)
 	resistance_flags = FIRE_PROOF
 	refill_canister = /obj/item/vending_refill/medical

--- a/code/modules/vending/medical.dm
+++ b/code/modules/vending/medical.dm
@@ -23,12 +23,12 @@
 					/obj/item/reagent_containers/glass/bottle/salglu_solution = 3,
 					/obj/item/reagent_containers/glass/bottle/morphine = 4,
 					/obj/item/reagent_containers/glass/bottle/toxin = 3,
-					/obj/item/reagent_containers/syringe/antiviral = 6)
+					/obj/item/reagent_containers/syringe/antiviral = 6,
+					/obj/item/reagent_containers/hypospray/medipen = 3)
 	contraband = list(/obj/item/reagent_containers/pill/tox = 3,
 		              /obj/item/reagent_containers/pill/morphine = 4,
 		              /obj/item/reagent_containers/pill/charcoal = 6)
 	premium = list(/obj/item/storage/box/hug/medical = 1,
-		           /obj/item/reagent_containers/hypospray/medipen = 3,
 		           /obj/item/storage/belt/medical = 3,
 		           /obj/item/wrench/medical = 1)
 	armor = list("melee" = 100, "bullet" = 100, "laser" = 100, "energy" = 100, "bomb" = 0, "bio" = 0, "rad" = 0, "fire" = 100, "acid" = 50)

--- a/code/modules/vending/robotics.dm
+++ b/code/modules/vending/robotics.dm
@@ -5,20 +5,20 @@
 	icon_state = "robotics"
 	icon_deny = "robotics-deny"
 	req_access = list(ACCESS_ROBOTICS)
-	products = list(/obj/item/clothing/suit/toggle/labcoat = 4,
-		            /obj/item/clothing/under/rank/roboticist = 4,
-		            /obj/item/stack/cable_coil = 4,
+	products = list(/obj/item/stack/cable_coil = 4,
 		            /obj/item/assembly/flash/handheld = 4,
 					/obj/item/stock_parts/cell/high = 12,
 					/obj/item/assembly/prox_sensor = 3,
 					/obj/item/assembly/signaler = 3,
 					/obj/item/healthanalyzer = 3,
-					/obj/item/scalpel = 2,
-					/obj/item/circular_saw = 2,
 					/obj/item/tank/internals/anesthetic = 2,
 					/obj/item/clothing/mask/breath/medical = 5,
 					/obj/item/screwdriver = 5,
 					/obj/item/crowbar = 5)
+	premium = list(/obj/item/clothing/suit/toggle/labcoat = 4,
+		            /obj/item/clothing/under/rank/roboticist = 4,
+		            /obj/item/scalpel = 2,
+					/obj/item/circular_saw = 2)
 	armor = list("melee" = 100, "bullet" = 100, "laser" = 100, "energy" = 100, "bomb" = 0, "bio" = 0, "rad" = 0, "fire" = 100, "acid" = 50)
 	resistance_flags = FIRE_PROOF
 	default_price = 50

--- a/code/modules/vending/snack.dm
+++ b/code/modules/vending/snack.dm
@@ -14,7 +14,7 @@
 	contraband = list(/obj/item/reagent_containers/food/snacks/syndicake = 6)
 	refill_canister = /obj/item/vending_refill/snack
 	var/chef_compartment_access = "28" //ACCESS_KITCHEN
-	default_price = 20
+	default_price = 15
 	extra_price = 30
 	payment_department = ACCOUNT_SRV
 

--- a/code/modules/vending/youtool.dm
+++ b/code/modules/vending/youtool.dm
@@ -14,8 +14,8 @@
 		            /obj/item/flashlight/glowstick = 3,
 		            /obj/item/flashlight/glowstick/red = 3,
 		            /obj/item/flashlight = 5)
-	contraband = list(/obj/item/weldingtool/hugetank = 2)
-	premium = list(/obj/item/clothing/gloves/color/yellow = 2,
+	contraband = list(/obj/item/clothing/gloves/color/fyellow = 2)
+	premium = list(/obj/item/clothing/gloves/color/yellow = 1,
 		           /obj/item/weldingtool/hugetank = 2)
 	armor = list("melee" = 100, "bullet" = 100, "laser" = 100, "energy" = 100, "bomb" = 0, "bio" = 0, "rad" = 0, "fire" = 100, "acid" = 70)
 	resistance_flags = FIRE_PROOF

--- a/code/modules/vending/youtool.dm
+++ b/code/modules/vending/youtool.dm
@@ -14,11 +14,11 @@
 		            /obj/item/flashlight/glowstick = 3,
 		            /obj/item/flashlight/glowstick/red = 3,
 		            /obj/item/flashlight = 5)
-	contraband = list(/obj/item/weldingtool/hugetank = 2,
-		              /obj/item/clothing/gloves/color/fyellow = 2)
-	premium = list(/obj/item/clothing/gloves/color/yellow = 1)
+	contraband = list(/obj/item/weldingtool/hugetank = 2)
+	premium = list(/obj/item/clothing/gloves/color/yellow = 2,
+		           /obj/item/weldingtool/hugetank = 2)
 	armor = list("melee" = 100, "bullet" = 100, "laser" = 100, "energy" = 100, "bomb" = 0, "bio" = 0, "rad" = 0, "fire" = 100, "acid" = 70)
 	resistance_flags = FIRE_PROOF
 	default_price = 25
-	extra_price = 50
+	extra_price = 75
 	payment_department = ACCOUNT_ENG

--- a/code/modules/vending/youtool.dm
+++ b/code/modules/vending/youtool.dm
@@ -19,6 +19,6 @@
 		           /obj/item/weldingtool/hugetank = 2)
 	armor = list("melee" = 100, "bullet" = 100, "laser" = 100, "energy" = 100, "bomb" = 0, "bio" = 0, "rad" = 0, "fire" = 100, "acid" = 70)
 	resistance_flags = FIRE_PROOF
-	default_price = 25
+	default_price = 20
 	extra_price = 75
 	payment_department = ACCOUNT_ENG


### PR DESCRIPTION
:cl: Mickyan
balance: Changed price and availability of several items sold in vending machines
/:cl:

No new items in this PR, split most vending machines into the two price ranges, where applicable the distinction is between equipment and supplies (ie. engi vendor) or otherwise either how useful or how fancy the item is. Even though at first glance it may look like all prices have been decreased, in reality a lot of stuff has been moved to premium and increased in price. The main goal is having better distinction between cheap and expensive items.

Occasionally changed some items from contraband to premium and the available amounts to be more in line with the rest.

Changed the order of the items in the booze-o-mat and sorted them by type (dinnerware -> juices -> sodas -> light booze -> booze)