### PR TITLE
Fixes some slip & fall runtimes

### DIFF
--- a/code/modules/antagonists/cult/cult_items.dm
+++ b/code/modules/antagonists/cult/cult_items.dm
@@ -981,7 +981,7 @@
 					L.Knockdown(60)
 				else
 					L.Knockdown(30)
-				if(D && D.thrower)
+				if(D?.thrower)
 					for(var/mob/living/Next in orange(2, T))
 						if(!Next.density || iscultist(Next))
 							continue

--- a/code/modules/antagonists/cult/cult_items.dm
+++ b/code/modules/antagonists/cult/cult_items.dm
@@ -981,7 +981,7 @@
 					L.Knockdown(60)
 				else
 					L.Knockdown(30)
-				if(D.thrower)
+				if(D && D.thrower)
 					for(var/mob/living/Next in orange(2, T))
 						if(!Next.density || iscultist(Next))
 							continue

--- a/code/modules/food_and_drinks/drinks/drinks.dm
+++ b/code/modules/food_and_drinks/drinks/drinks.dm
@@ -104,7 +104,7 @@
 /obj/item/reagent_containers/food/drinks/throw_impact(atom/target, datum/thrownthing/throwinfo)
 	. = ..()
 	if(!.) //if the bottle wasn't caught
-		smash(target, throwinfo.thrower, TRUE)
+		smash(target, throwinfo ? throwinfo.thrower : null, TRUE)
 
 /obj/item/reagent_containers/food/drinks/proc/smash(atom/target, mob/thrower, ranged = FALSE)
 	if(!isGlass)

--- a/code/modules/food_and_drinks/drinks/drinks.dm
+++ b/code/modules/food_and_drinks/drinks/drinks.dm
@@ -104,7 +104,7 @@
 /obj/item/reagent_containers/food/drinks/throw_impact(atom/target, datum/thrownthing/throwinfo)
 	. = ..()
 	if(!.) //if the bottle wasn't caught
-		smash(target, throwinfo ? throwinfo.thrower : null, TRUE)
+		smash(target, throwinfo?.thrower, TRUE)
 
 /obj/item/reagent_containers/food/drinks/proc/smash(atom/target, mob/thrower, ranged = FALSE)
 	if(!isGlass)

--- a/code/modules/food_and_drinks/drinks/drinks/bottle.dm
+++ b/code/modules/food_and_drinks/drinks/drinks/bottle.dm
@@ -21,7 +21,7 @@
 	if(bartender_check(target) && ranged)
 		return
 	var/obj/item/broken_bottle/B = new (loc)
-	if(!ranged)
+	if(!ranged && thrower)
 		thrower.put_in_hands(B)
 	B.icon_state = icon_state
 


### PR DESCRIPTION
accident() calls throw_impact() directly on the obj without a thrown datum, resulting in a runtime for bottles & cult shields.

:cl: ShizCalev
fix: Fixed bottles not smashing properly when slipping on puddles/lube.
/:cl:
