### PR TITLE
[Ready] Atmos trinary devices improvement

### DIFF
--- a/code/modules/atmospherics/machinery/components/trinary_devices/filter.dm
+++ b/code/modules/atmospherics/machinery/components/trinary_devices/filter.dm
@@ -124,7 +124,7 @@
 
 	//Early return
 	var/datum/gas_mixture/air1 = airs[1]
-	if(!air1)
+	if(!air1 || air1.temperature <= 0)
 		return
 
 	var/datum/gas_mixture/air2 = airs[2]

--- a/code/modules/atmospherics/machinery/components/trinary_devices/filter.dm
+++ b/code/modules/atmospherics/machinery/components/trinary_devices/filter.dm
@@ -122,7 +122,11 @@
 	if(!on || !(nodes[1] && nodes[2] && nodes[3]) || !is_operational())
 		return
 
+	//Early return
 	var/datum/gas_mixture/air1 = airs[1]
+	if(!air1.temperature)
+		return
+
 	var/datum/gas_mixture/air2 = airs[2]
 	var/datum/gas_mixture/air3 = airs[3]
 
@@ -132,43 +136,40 @@
 		//No need to transfer if target is already full!
 		return
 
-	//Calculate necessary moles to transfer using PV=nRT
-
-	var/pressure_delta = target_pressure - output_starting_pressure
-	var/transfer_moles
-
-	if(air1.temperature > 0)
-		transfer_moles = pressure_delta*air3.volume/(air1.temperature * R_IDEAL_GAS_EQUATION)
+	//Calculate necessary moles to transfer using PV=nRT, no need to create a new var that will be used only once (delta)
+	var/transfer_moles = (target_pressure - output_starting_pressure)*air3.volume/(air1.temperature * R_IDEAL_GAS_EQUATION)
 
 	//Actually transfer the gas
 
-	if(transfer_moles > 0)
-		var/datum/gas_mixture/removed = air1.remove(transfer_moles)
+	if(!transfer_moles)
+		return
 
-		if(!removed)
-			return
+	var/datum/gas_mixture/removed = air1.remove(transfer_moles)
 
-		var/filtering = TRUE
-		if(!ispath(filter_type))
-			if(filter_type)
-				filter_type = gas_id2path(filter_type) //support for mappers so they don't need to type out paths
-			else
-				filtering = FALSE
+	if(!removed)
+		return
 
-		if(filtering && removed.gases[filter_type])
-			var/datum/gas_mixture/filtered_out = new
+	var/filtering = TRUE
+	if(!ispath(filter_type))
+		if(filter_type)
+			filter_type = gas_id2path(filter_type) //support for mappers so they don't need to type out paths
+		else
+			filtering = FALSE
 
-			filtered_out.temperature = removed.temperature
-			filtered_out.add_gas(filter_type)
-			filtered_out.gases[filter_type][MOLES] = removed.gases[filter_type][MOLES]
+	if(filtering && removed.gases[filter_type])
+		var/datum/gas_mixture/filtered_out = new
 
-			removed.gases[filter_type][MOLES] = 0
-			removed.garbage_collect()
+		filtered_out.temperature = removed.temperature
+		filtered_out.add_gas(filter_type)
+		filtered_out.gases[filter_type][MOLES] = removed.gases[filter_type][MOLES]
 
-			var/datum/gas_mixture/target = (air2.return_pressure() < target_pressure ? air2 : air1) //if there's no room for the filtered gas; just leave it in air1
-			target.merge(filtered_out)
+		removed.gases[filter_type][MOLES] = 0
+		removed.garbage_collect()
 
-		air3.merge(removed)
+		var/datum/gas_mixture/target = (air2.return_pressure() < target_pressure ? air2 : air1) //if there's no room for the filtered gas; just leave it in air1
+		target.merge(filtered_out)
+
+	air3.merge(removed)
 
 	update_parents()
 

--- a/code/modules/atmospherics/machinery/components/trinary_devices/filter.dm
+++ b/code/modules/atmospherics/machinery/components/trinary_devices/filter.dm
@@ -124,7 +124,7 @@
 
 	//Early return
 	var/datum/gas_mixture/air1 = airs[1]
-	if(!air1.temperature)
+	if(air1.temperature <= 0)
 		return
 
 	var/datum/gas_mixture/air2 = airs[2]
@@ -141,7 +141,7 @@
 
 	//Actually transfer the gas
 
-	if(!transfer_moles)
+	if(transfer_moles <= 0)
 		return
 
 	var/datum/gas_mixture/removed = air1.remove(transfer_moles)

--- a/code/modules/atmospherics/machinery/components/trinary_devices/filter.dm
+++ b/code/modules/atmospherics/machinery/components/trinary_devices/filter.dm
@@ -124,6 +124,8 @@
 
 	//Early return
 	var/datum/gas_mixture/air1 = airs[1]
+	if(!air1)
+		return
 	if(air1.temperature <= 0)
 		return
 

--- a/code/modules/atmospherics/machinery/components/trinary_devices/filter.dm
+++ b/code/modules/atmospherics/machinery/components/trinary_devices/filter.dm
@@ -126,8 +126,6 @@
 	var/datum/gas_mixture/air1 = airs[1]
 	if(!air1)
 		return
-	if(air1.temperature <= 0)
-		return
 
 	var/datum/gas_mixture/air2 = airs[2]
 	var/datum/gas_mixture/air3 = airs[3]

--- a/code/modules/atmospherics/machinery/components/trinary_devices/mixer.dm
+++ b/code/modules/atmospherics/machinery/components/trinary_devices/mixer.dm
@@ -96,6 +96,10 @@
 	//Get those gases, mah boiiii
 	var/datum/gas_mixture/air1 = airs[1]
 	var/datum/gas_mixture/air2 = airs[2]
+
+	if(!air1 || !air2 || air1.temperature <= 0 || air2.temperature <= 0)
+		return
+
 	var/datum/gas_mixture/air3 = airs[3]
 
 	var/output_starting_pressure = air3.return_pressure()

--- a/code/modules/atmospherics/machinery/components/trinary_devices/mixer.dm
+++ b/code/modules/atmospherics/machinery/components/trinary_devices/mixer.dm
@@ -93,9 +93,15 @@
 	if(!on || !(nodes[1] && nodes[2] && nodes[3]) && !is_operational())
 		return
 
+	//Get those gases, mah boiiii
 	var/datum/gas_mixture/air1 = airs[1]
 	var/datum/gas_mixture/air2 = airs[2]
 	var/datum/gas_mixture/air3 = airs[3]
+
+	//No temperature or below 0: do not transfer, should normally never hit this.
+	//Might want to check this for below TCMB instead.
+	if(!air1.temperature || !air2.temperature)
+		return
 
 	var/output_starting_pressure = air3.return_pressure()
 
@@ -105,40 +111,32 @@
 
 	//Calculate necessary moles to transfer using PV=nRT
 
-	var/pressure_delta = target_pressure - output_starting_pressure
-	var/transfer_moles1 = 0
-	var/transfer_moles2 = 0
+	var/general_transfer = (target_pressure - output_starting_pressure) * air3.volume / R_IDEAL_GAS_EQUATION
 
-	if(air1.temperature > 0)
-		transfer_moles1 = (node1_concentration * pressure_delta) * air3.volume / (air1.temperature * R_IDEAL_GAS_EQUATION)
+	var/transfer_moles1 = node1_concentration * general_transfer / air1.temperature
 
-	if(air2.temperature > 0)
-		transfer_moles2 = (node2_concentration * pressure_delta) * air3.volume / (air2.temperature * R_IDEAL_GAS_EQUATION)
+	var/transfer_moles2 = node2_concentration * general_transfer / air2.temperature
+
+	if((transfer_moles2 <= 0) || (transfer_moles1 <= 0))
+		return
+
 
 	var/air1_moles = air1.total_moles()
 	var/air2_moles = air2.total_moles()
 
 	if((air1_moles < transfer_moles1) || (air2_moles < transfer_moles2))
 		var/ratio = 0
-		if((transfer_moles1 > 0 ) && (transfer_moles2 > 0))
-			ratio = min(air1_moles / transfer_moles1, air2_moles / transfer_moles2)
-		if((transfer_moles2 == 0 ) && ( transfer_moles1 > 0))
-			ratio = air1_moles / transfer_moles1
-		if((transfer_moles1 == 0 ) && ( transfer_moles2 > 0))
-			ratio = air2_moles / transfer_moles2
-
+		ratio = min(air1_moles / transfer_moles1, air2_moles / transfer_moles2)
 		transfer_moles1 *= ratio
 		transfer_moles2 *= ratio
 
 	//Actually transfer the gas
 
-	if(transfer_moles1 > 0)
-		var/datum/gas_mixture/removed1 = air1.remove(transfer_moles1)
-		air3.merge(removed1)
+	var/datum/gas_mixture/removed1 = air1.remove(transfer_moles1)
+	air3.merge(removed1)
 
-	if(transfer_moles2 > 0)
-		var/datum/gas_mixture/removed2 = air2.remove(transfer_moles2)
-		air3.merge(removed2)
+	var/datum/gas_mixture/removed2 = air2.remove(transfer_moles2)
+	air3.merge(removed2)
 
 	if(transfer_moles1)
 		var/datum/pipeline/parent1 = parents[1]

--- a/code/modules/atmospherics/machinery/components/trinary_devices/mixer.dm
+++ b/code/modules/atmospherics/machinery/components/trinary_devices/mixer.dm
@@ -96,12 +96,13 @@
 	//Get those gases, mah boiiii
 	var/datum/gas_mixture/air1 = airs[1]
 	var/datum/gas_mixture/air2 = airs[2]
-	var/datum/gas_mixture/air3 = airs[3]
 
 	//No temperature or below 0: do not transfer, should normally never hit this.
 	//Might want to check this for below TCMB instead.
-	if(!air1.temperature || !air2.temperature)
+	if(air1.temperature <= 0 || air2.temperature <= 0)
 		return
+
+	var/datum/gas_mixture/air3 = airs[3]
 
 	var/output_starting_pressure = air3.return_pressure()
 
@@ -148,8 +149,6 @@
 
 	var/datum/pipeline/parent3 = parents[3]
 	parent3.update = TRUE
-
-	return
 
 /obj/machinery/atmospherics/components/trinary/mixer/ui_interact(mob/user, ui_key = "main", datum/tgui/ui = null, force_open = FALSE, \
 																	datum/tgui/master_ui = null, datum/ui_state/state = GLOB.default_state)

--- a/code/modules/atmospherics/machinery/components/trinary_devices/mixer.dm
+++ b/code/modules/atmospherics/machinery/components/trinary_devices/mixer.dm
@@ -96,12 +96,6 @@
 	//Get those gases, mah boiiii
 	var/datum/gas_mixture/air1 = airs[1]
 	var/datum/gas_mixture/air2 = airs[2]
-
-	//No temperature or below 0: do not transfer, should normally never hit this.
-	//Might want to check this for below TCMB instead.
-	if(air1.temperature <= 0 || air2.temperature <= 0)
-		return
-
 	var/datum/gas_mixture/air3 = airs[3]
 
 	var/output_starting_pressure = air3.return_pressure()


### PR DESCRIPTION
[Changelogs]: # Made slight improvements in the code of trinary devices: Mixers and filters. They should run slightly faster and mixers shouldn't just disregard gas percentages entirely when one input was sucked dry, messing up everything. You might not see any compactness gained in code, since I tend to place comments everywhere. Also, ran both of them on private server, works accurately.
:cl: Shdorsh
tweak: Mixers are now more accurate
code: Improved mixer and filter code
/:cl:

[why]: # Whatever might make it run more smoothly. Please test it out and see if the procs run faster. I know the station isn't shock-full of these, but that doesn't mean we can neglect them either.
