### PR TITLE
Fixes lacking hands giving erroneous feedback in a few situations

### DIFF
--- a/code/datums/action.dm
+++ b/code/datums/action.dm
@@ -487,7 +487,10 @@
 		owner.put_in_hands(I)
 		I.attack_self(owner)
 	else
-		to_chat(owner, "<span class='cultitalic'>Your hands are full!</span>")
+		if (user.get_num_arms() <= 0)
+			to_chat(user, "<span class='warning'>You dont have any usable hands!</span>")
+		else
+			to_chat(user, "<span class='warning'>Your hands are full!</span>")
 
 /datum/action/item_action/agent_box
 	name = "Deploy Box"

--- a/code/datums/action.dm
+++ b/code/datums/action.dm
@@ -487,10 +487,10 @@
 		owner.put_in_hands(I)
 		I.attack_self(owner)
 	else
-		if (user.get_num_arms() <= 0)
-			to_chat(user, "<span class='warning'>You dont have any usable hands!</span>")
+		if (owner.get_num_arms() <= 0)
+			to_chat(owner, "<span class='warning'>You dont have any usable hands!</span>")
 		else
-			to_chat(user, "<span class='warning'>Your hands are full!</span>")
+			to_chat(owner, "<span class='warning'>Your hands are full!</span>")
 
 /datum/action/item_action/agent_box
 	name = "Deploy Box"

--- a/code/modules/mob/living/silicon/robot/robot.dm
+++ b/code/modules/mob/living/silicon/robot/robot.dm
@@ -1163,10 +1163,10 @@
 			M.visible_message("<span class='boldwarning'>Unfortunately, [M] just can't seem to hold onto [src]!</span>")
 			return
 	if(iscarbon(M) && (!riding_datum.equip_buckle_inhands(M, 1)))
-		if (user.get_num_arms() <= 0)
-			M.visible_message("<span class='boldwarning'>[M] can't climb onto [src] because [user.p_they()] don't have any usable arms!</span>")
+		if (M.get_num_arms() <= 0)
+			M.visible_message("<span class='boldwarning'>[M] can't climb onto [src] because [M.p_they()] don't have any usable arms!</span>")
 		else
-			M.visible_message("<span class='boldwarning'>[M] can't climb onto [src] because [user.p_their()] hands are full!</span>")
+			M.visible_message("<span class='boldwarning'>[M] can't climb onto [src] because [M.p_their()] hands are full!</span>")
 		return
 	. = ..(M, force, check_loc)
 

--- a/code/modules/mob/living/silicon/robot/robot.dm
+++ b/code/modules/mob/living/silicon/robot/robot.dm
@@ -1163,7 +1163,7 @@
 			M.visible_message("<span class='boldwarning'>Unfortunately, [M] just can't seem to hold onto [src]!</span>")
 			return
 	if(iscarbon(M) && (!riding_datum.equip_buckle_inhands(M, 1)))
-		M.visible_message("<span class='boldwarning'>[M] can't climb onto [src] because [M.p_their()] hands are full!</span>")
+		M.visible_message("<span class='boldwarning'>[M] can't climb onto [src]!</span>")
 		return
 	. = ..(M, force, check_loc)
 

--- a/code/modules/mob/living/silicon/robot/robot.dm
+++ b/code/modules/mob/living/silicon/robot/robot.dm
@@ -1163,7 +1163,10 @@
 			M.visible_message("<span class='boldwarning'>Unfortunately, [M] just can't seem to hold onto [src]!</span>")
 			return
 	if(iscarbon(M) && (!riding_datum.equip_buckle_inhands(M, 1)))
-		M.visible_message("<span class='boldwarning'>[M] can't climb onto [src]!</span>")
+		if (user.get_num_arms() <= 0)
+			M.visible_message("<span class='boldwarning'>[M] can't climb onto [src] because [user.p_they()] don't have any usable arms!</span>")
+		else
+			M.visible_message("<span class='boldwarning'>[M] can't climb onto [src] because [user.p_their()] hands are full!</span>")
 		return
 	. = ..(M, force, check_loc)
 

--- a/code/modules/spells/spell_types/touch_attacks.dm
+++ b/code/modules/spells/spell_types/touch_attacks.dm
@@ -41,7 +41,10 @@
 	attached_hand.attached_spell = src
 	if(!user.put_in_hands(attached_hand))
 		remove_hand(TRUE)
-		to_chat(user, "<span class='warning'>Your hands are full!</span>")
+		if (user.get_num_arms() <= 0)
+			to_chat(user, "<span class='warning'>You dont have any usable hands!</span>")
+		else
+			to_chat(user, "<span class='warning'>Your hands are full!</span>")
 		return FALSE
 	to_chat(user, "<span class='notice'>You channel the power of the spell to your hand.</span>")
 	return TRUE


### PR DESCRIPTION
Fixes #40546

:cl: MrDoomBringer
:fix: Lacking hands will no tell you that "your hands are full" in a few situations
/:cl:

If you got your arms chopped off and tried to buckle to a borg/summon a spell, etc. you would get feedback that "your hands are full". This fixes that

maybe i should make a proc to give feedback to user, like
`mob/proc/tellUserWhyTheyCantUseTheirHands()`